### PR TITLE
Enable automatic Copilot review requests in ruleset

### DIFF
--- a/.github/rulesets/main-pr-squash-only.json
+++ b/.github/rulesets/main-pr-squash-only.json
@@ -14,6 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
+        "automatic_copilot_code_review_enabled": true,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,


### PR DESCRIPTION
## Summary
- enable automatic Copilot code review requests in the main branch ruleset

## Changes
- set `automatic_copilot_code_review_enabled` to `true` in `.github/rulesets/main-pr-squash-only.json`

## Verification
- validated JSON syntax with `python3 -m json.tool`
