### PR TITLE
Update .gitignore for worktrees and Nix artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+worktrees/
+
+# Nix / direnv artifacts
+result
+result-*
+.direnv/
+.devenv/


### PR DESCRIPTION
## Summary
- ignore local `worktrees/` directory
- ignore common Nix/direnv artifacts

## Changes
- add `worktrees/`
- add `result` and `result-*`
- add `.direnv/` and `.devenv/`
