### PR TITLE
Add name-resolution progress tracking, READMEs, and flake apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ Recompute progress with:
 ```bash
 nix run .#parser-progress
 ```
+
+## Name-Resolution Progress
+
+The name-resolution component lives in `components/haskell-name-resolution`.
+
+Current progress:
+- `8/12` capability cases implemented (`66.66%` complete)
+- status breakdown: `PASS=8`, `XFAIL=4`, `XPASS=0`, `FAIL=0`
+
+Recompute progress with:
+
+```bash
+nix run .#name-resolution-progress
+```

--- a/components/haskell-name-resolution/README.md
+++ b/components/haskell-name-resolution/README.md
@@ -1,0 +1,42 @@
+# Haskell Name Resolution
+
+This component resolves names over the parser AST and reports diagnostics such as unbound variables and duplicate top-level bindings.
+
+## Progress Tracking
+
+Coverage is tracked with a manifest-driven capability corpus:
+- `test/Test/Fixtures/progress/manifest.tsv`
+
+Each case is marked as:
+- `pass`: expected to match oracle resolution facts
+- `xfail`: known unsupported behavior (tracked gap)
+
+Runtime outcomes:
+- `PASS`: expected `pass`, facts match oracle
+- `XFAIL`: expected `xfail`, still unresolved
+- `XPASS`: expected `xfail`, now matches oracle (ready to promote in manifest)
+- `FAIL`: regression (expected pass not matching) or oracle/fixture failure
+
+Current baseline:
+- `8/12` implemented (`66.66%` complete)
+- `PASS=8`, `XFAIL=4`, `XPASS=0`, `FAIL=0`
+
+## Commands
+
+Run all name-resolution tests:
+
+```bash
+nix run .#name-resolution-test
+```
+
+Run progress summary:
+
+```bash
+nix run .#name-resolution-progress
+```
+
+Strict mode (non-zero on `FAIL` or `XPASS`):
+
+```bash
+nix run .#name-resolution-progress-strict
+```

--- a/components/haskell-name-resolution/aihc-name-resolution.cabal
+++ b/components/haskell-name-resolution/aihc-name-resolution.cabal
@@ -30,6 +30,7 @@ test-suite spec
   other-modules:
       Test.Oracle
     , Test.Oracle.Resolve
+    , Test.Progress
     , Test.ResolveFacts
     , Test.Resolver
   build-depends:
@@ -42,6 +43,21 @@ test-suite spec
     , filepath
     , tasty
     , tasty-hunit
+    , ghc-lib-parser
+  ghc-options:        -Wall
+  default-language: Haskell2010
+
+executable name-resolution-progress
+  hs-source-dirs:   app/name-resolution-progress
+  main-is:          Main.hs
+  build-depends:
+      base >=4.16 && <5
+    , aihc-name-resolution
+    , aihc-parser
+    , text
+    , containers
+    , directory
+    , filepath
     , ghc-lib-parser
   ghc-options:        -Wall
   default-language: Haskell2010

--- a/components/haskell-name-resolution/app/name-resolution-progress/Main.hs
+++ b/components/haskell-name-resolution/app/name-resolution-progress/Main.hs
@@ -1,0 +1,324 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Data.Char (isSpace)
+import Data.Bifunctor (first)
+import qualified Data.Map.Strict as M
+import Data.List (dropWhileEnd)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+import qualified GHC.Data.EnumSet as EnumSet
+import GHC.Data.FastString (mkFastString)
+import GHC.Data.StringBuffer (stringToStringBuffer)
+import GHC.Hs
+import GHC.LanguageExtensions.Type (Extension)
+import qualified GHC.Parser as GHCParser
+import qualified GHC.Parser.Lexer as Lexer
+import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Types.Name.Reader (rdrNameOcc)
+import GHC.Types.SourceText (IntegralLit (..))
+import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
+import GHC.Utils.Error (emptyDiagOpts)
+import Parser.Canonical
+import Parser (defaultConfig, parseModule)
+import Parser.Types (ParseResult (..))
+import Resolver (defaultResolveConfig, resolveModule)
+import Resolver.Ast
+import Resolver.Types (DiagnosticCode (..), NameClass (..), diagCode, diagnostics, preludeMode, resolved, ResolveConfig (..), PreludeMode (..))
+import System.Directory (doesFileExist)
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+import System.FilePath ((</>))
+
+data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
+data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail deriving (Eq, Show)
+
+data CaseMeta = CaseMeta
+  { caseId :: !String
+  , caseCategory :: !String
+  , casePath :: !FilePath
+  , caseExpected :: !Expected
+  , _caseReason :: !String
+  }
+  deriving (Eq, Show)
+
+data VarFact = VarFact
+  { vfName :: T.Text
+  , vfBinding :: Maybe T.Text
+  , vfClass :: NameClass
+  }
+  deriving (Eq, Show)
+
+data ResolveFacts = ResolveFacts
+  { rfModuleName :: Maybe T.Text
+  , rfDeclNames :: [T.Text]
+  , rfVars :: [VarFact]
+  , rfDiagnosticCodes :: [DiagnosticCode]
+  }
+  deriving (Eq, Show)
+
+fixtureRoot :: FilePath
+fixtureRoot = "test/Test/Fixtures/progress"
+
+manifestPath :: FilePath
+manifestPath = fixtureRoot </> "manifest.tsv"
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let strict = "--strict" `elem` args
+  cases <- loadManifest
+  outcomes <- mapM evaluateCase cases
+  let passN = count OutcomePass outcomes
+      xfailN = count OutcomeXFail outcomes
+      xpassN = count OutcomeXPass outcomes
+      failN = count OutcomeFail outcomes
+      totalN = passN + xfailN + xpassN + failN
+      completion = pct (passN + xpassN) totalN
+  putStrLn "Haskell name-resolution progress"
+  putStrLn "==============================="
+  putStrLn ("PASS      " <> show passN)
+  putStrLn ("XFAIL     " <> show xfailN)
+  putStrLn ("XPASS     " <> show xpassN)
+  putStrLn ("FAIL      " <> show failN)
+  putStrLn ("TOTAL     " <> show totalN)
+  putStrLn ("COMPLETE  " <> show completion <> "%")
+
+  mapM_ printFail [(m, d) | (m, OutcomeFail, d) <- outcomes]
+  mapM_ printXPass [(m, d) | (m, OutcomeXPass, d) <- outcomes]
+
+  if failN == 0 && (not strict || xpassN == 0)
+    then exitSuccess
+    else exitFailure
+
+count :: Outcome -> [(CaseMeta, Outcome, String)] -> Int
+count wanted = length . filter (\(_, o, _) -> o == wanted)
+
+printFail :: (CaseMeta, String) -> IO ()
+printFail (meta, details) =
+  putStrLn ("FAIL " <> caseId meta <> " [" <> caseCategory meta <> "] " <> details)
+
+printXPass :: (CaseMeta, String) -> IO ()
+printXPass (meta, details) =
+  putStrLn ("XPASS " <> caseId meta <> " [" <> caseCategory meta <> "] " <> details)
+
+pct :: Int -> Int -> Double
+pct done totalN
+  | totalN <= 0 = 0.0
+  | otherwise = fromIntegral (done * 10000 `div` totalN) / 100.0
+
+evaluateCase :: CaseMeta -> IO (CaseMeta, Outcome, String)
+evaluateCase meta = do
+  source <- TIO.readFile (fixtureRoot </> casePath meta)
+  case oracleResolveFacts defaultResolveConfig source of
+    Left oracleErr -> pure (meta, OutcomeFail, "oracle failed: " <> T.unpack oracleErr)
+    Right oracleFacts ->
+      let ours = resolveFacts source
+          (outcome, details) = classify (caseExpected meta) ours oracleFacts
+       in pure (meta, outcome, details)
+
+classify :: Expected -> Either String ResolveFacts -> ResolveFacts -> (Outcome, String)
+classify expected ours oracleFacts =
+  case expected of
+    ExpectPass ->
+      case ours of
+        Left err -> (OutcomeFail, "expected pass but parser/resolver failed: " <> err)
+        Right oursFacts
+          | oursFacts == oracleFacts -> (OutcomePass, "")
+          | otherwise -> (OutcomeFail, "facts differ from oracle")
+    ExpectXFail ->
+      case ours of
+        Left _ -> (OutcomeXFail, "")
+        Right oursFacts
+          | oursFacts == oracleFacts -> (OutcomeXPass, "expected xfail but now matches oracle")
+          | otherwise -> (OutcomeXFail, "")
+
+resolveFacts :: T.Text -> Either String ResolveFacts
+resolveFacts input =
+  case parseModule defaultConfig input of
+    ParseErr err -> Left (show err)
+    ParseOk modu ->
+      let rr = resolveModule defaultResolveConfig modu
+          resolvedMod = resolved rr
+          decls = resolvedDecls resolvedMod
+          vars = concatMap (collectExpr . resolvedDeclExpr) decls
+       in Right
+            ResolveFacts
+              { rfModuleName = resolvedModuleName resolvedMod
+              , rfDeclNames = map resolvedDeclName decls
+              , rfVars = vars
+              , rfDiagnosticCodes = map diagCode (diagnostics rr)
+              }
+  where
+    collectExpr expr =
+      case expr of
+        RInt _ -> []
+        RApp f x -> collectExpr f <> collectExpr x
+        RVar name ->
+          [ VarFact
+              { vfName = rnText name
+              , vfBinding = fmap (const (rnText name)) (rnId name)
+              , vfClass = rnClass name
+              }
+          ]
+
+loadManifest :: IO [CaseMeta]
+loadManifest = do
+  raw <- TIO.readFile manifestPath
+  let rows = filter (not . T.null) (map stripComment (T.lines raw))
+  mapM parseRow rows
+
+stripComment :: T.Text -> T.Text
+stripComment line = T.strip (fst (T.breakOn "#" line))
+
+parseRow :: T.Text -> IO CaseMeta
+parseRow row =
+  case T.splitOn "\t" row of
+    [cid, cat, pathTxt, expectedTxt] -> parseRowWithReason cid cat pathTxt expectedTxt ""
+    [cid, cat, pathTxt, expectedTxt, reasonTxt] -> parseRowWithReason cid cat pathTxt expectedTxt reasonTxt
+    _ -> fail ("Invalid manifest row (expected 4 or 5 columns): " <> T.unpack row)
+
+parseRowWithReason :: T.Text -> T.Text -> T.Text -> T.Text -> T.Text -> IO CaseMeta
+parseRowWithReason cid cat pathTxt expectedTxt reasonTxt = do
+  let path = T.unpack pathTxt
+  exists <- doesFileExist (fixtureRoot </> path)
+  if not exists
+    then fail ("Manifest references missing case file: " <> path)
+    else do
+      expected <-
+        case expectedTxt of
+          "pass" -> pure ExpectPass
+          "xfail" -> pure ExpectXFail
+          _ -> fail ("Unknown expected value: " <> T.unpack expectedTxt)
+      let reason = trim (T.unpack reasonTxt)
+      case expected of
+        ExpectXFail | null reason -> fail ("xfail case requires reason: " <> T.unpack cid)
+        _ -> pure ()
+      pure
+        CaseMeta
+          { caseId = T.unpack cid
+          , caseCategory = T.unpack cat
+          , casePath = path
+          , caseExpected = expected
+          , _caseReason = reason
+          }
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace
+
+oracleResolveFacts :: ResolveConfig -> T.Text -> Either T.Text ResolveFacts
+oracleResolveFacts cfg source = do
+  canon <- oracleCanonicalModule source
+  pure (resolveCanonical cfg canon)
+
+resolveCanonical :: ResolveConfig -> CanonicalModule -> ResolveFacts
+resolveCanonical cfg modu =
+  let (declMap, dupDiags) = gatherDecls (canonicalDecls modu)
+      (varFacts, unboundDiags) = foldMap (resolveDeclExpr declMap) (canonicalDecls modu)
+   in ResolveFacts
+        { rfModuleName = canonicalModuleName modu
+        , rfDeclNames = map canonicalDeclName (canonicalDecls modu)
+        , rfVars = varFacts
+        , rfDiagnosticCodes = dupDiags <> unboundDiags
+        }
+  where
+    resolveDeclExpr declMap decl = resolveExpr declMap (canonicalDeclExpr decl)
+
+    resolveExpr declMap expr =
+      case expr of
+        CInt _ -> ([], [])
+        CApp f x ->
+          let (fFacts, fDiags) = resolveExpr declMap f
+              (xFacts, xDiags) = resolveExpr declMap x
+           in (fFacts <> xFacts, fDiags <> xDiags)
+        CVar name ->
+          case M.lookup name declMap of
+            Just _ ->
+              ([VarFact {vfName = name, vfBinding = Just name, vfClass = TopLevelBinder}], [])
+            Nothing ->
+              if isPreludeName cfg name
+                then ([VarFact {vfName = name, vfBinding = Just name, vfClass = PreludeBinder}], [])
+                else ([VarFact {vfName = name, vfBinding = Nothing, vfClass = Unresolved}], [EUnboundVariable])
+
+gatherDecls :: [CanonicalDecl] -> (M.Map T.Text (), [DiagnosticCode])
+gatherDecls = foldl step (M.empty, [])
+  where
+    step (seen, diags) decl =
+      let name = canonicalDeclName decl
+       in case M.lookup name seen of
+            Just _ -> (seen, diags <> [EDuplicateBinding])
+            Nothing -> (M.insert name () seen, diags)
+
+isPreludeName :: ResolveConfig -> T.Text -> Bool
+isPreludeName cfg name =
+  case preludeMode cfg of
+    ImplicitPreludeOff -> False
+    ImplicitPreludeOn -> name `elem` preludeNames
+
+preludeNames :: [T.Text]
+preludeNames = ["return", ">>=", ">>", "fail", "fromInteger", "ifThenElse"]
+
+oracleCanonicalModule :: T.Text -> Either T.Text CanonicalModule
+oracleCanonicalModule input = do
+  parsed <- parseWithGhc input
+  first T.pack (toCanonicalModule parsed)
+
+parseWithGhc :: T.Text -> Either T.Text (HsModule GhcPs)
+parseWithGhc input =
+  let opts = Lexer.mkParserOpts (EnumSet.empty :: EnumSet.EnumSet Extension) emptyDiagOpts False False False False
+      buffer = stringToStringBuffer (T.unpack input)
+      start = mkRealSrcLoc (mkFastString "<name-resolution-progress-oracle>") 1 1
+   in case Lexer.unP GHCParser.parseModule (Lexer.initParserState opts buffer start) of
+        Lexer.POk _ modu -> Right (unLoc modu)
+        Lexer.PFailed _ -> Left "oracle parse failed"
+
+toCanonicalModule :: HsModule GhcPs -> Either String CanonicalModule
+toCanonicalModule modu = do
+  decls <- traverse toCanonicalDecl (hsmodDecls modu)
+  pure
+    CanonicalModule
+      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu)
+      , canonicalDecls = decls
+      }
+
+toCanonicalDecl :: LHsDecl GhcPs -> Either String CanonicalDecl
+toCanonicalDecl locatedDecl =
+  let decl = unLoc locatedDecl
+   in case decl of
+        ValD _ bind ->
+          case bind of
+            FunBind {fun_id = locatedName, fun_matches = MG {mg_alts = locatedMatches}} -> do
+              let name = unLoc locatedName
+                  matches = unLoc locatedMatches
+              match <- case matches of
+                [singleMatch] -> Right (unLoc singleMatch)
+                _ -> Left "unsupported multiple matches"
+              expr <- case m_grhss match of
+                GRHSs _ (grhs :| []) _ ->
+                  case unLoc grhs of
+                    GRHS _ [] body -> toCanonicalExpr (unLoc body)
+                    _ -> Left "unsupported guarded rhs"
+                _ -> Left "unsupported function rhs"
+              pure
+                CanonicalDecl
+                  { canonicalDeclName = T.pack (occNameString (rdrNameOcc name))
+                  , canonicalDeclExpr = expr
+                  }
+            _ -> Left "unsupported value binding"
+        _ -> Left "unsupported declaration kind"
+
+toCanonicalExpr :: HsExpr GhcPs -> Either String CanonicalExpr
+toCanonicalExpr expr =
+  case expr of
+    HsVar _ locatedName ->
+      let name = unLoc locatedName
+       in Right (CVar (T.pack (occNameString (rdrNameOcc name))))
+    HsPar _ inner -> toCanonicalExpr (unLoc inner)
+    HsApp _ f x -> CApp <$> toCanonicalExpr (unLoc f) <*> toCanonicalExpr (unLoc x)
+    HsOverLit _ lit ->
+      case ol_val lit of
+        HsIntegral (IL _ _ value) -> Right (CInt value)
+        _ -> Left "unsupported literal"
+    _ -> Left "unsupported expression"

--- a/components/haskell-name-resolution/test/Spec.hs
+++ b/components/haskell-name-resolution/test/Spec.hs
@@ -1,7 +1,11 @@
 module Main (main) where
 
+import Test.Progress (progressTests)
 import Test.Resolver (resolverTests)
-import Test.Tasty (defaultMain)
+import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
-main = resolverTests >>= defaultMain
+main = do
+  resolver <- resolverTests
+  progress <- progressTests
+  defaultMain (testGroup "aihc-name-resolution" [resolver, progress])

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/backward-reference.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/backward-reference.hs
@@ -1,0 +1,3 @@
+module M where
+id = x
+x = 1

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/duplicate-binding.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/duplicate-binding.hs
@@ -1,0 +1,3 @@
+module M where
+x = 1
+x = 2

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/forward-reference.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/forward-reference.hs
@@ -1,0 +1,4 @@
+module M where
+start = middle
+middle = end
+end = 1

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/module-comments.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/module-comments.hs
@@ -1,0 +1,3 @@
+module M where
+-- comment
+x = 1

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/nested-application.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/nested-application.hs
@@ -1,0 +1,5 @@
+module M where
+x = f (g h)
+f = g
+g = h
+h = 1

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/prelude-reference.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/prelude-reference.hs
@@ -1,0 +1,2 @@
+module M where
+x = return

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/shadow-prelude.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/shadow-prelude.hs
@@ -1,0 +1,3 @@
+module M where
+return = 1
+x = return

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/core/unbound-variable.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/core/unbound-variable.hs
@@ -1,0 +1,2 @@
+module M where
+x = missing

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/manifest.tsv
@@ -1,0 +1,12 @@
+core-backward-reference	core	core/backward-reference.hs	pass	
+core-forward-reference	core	core/forward-reference.hs	pass	
+core-unbound-variable	core	core/unbound-variable.hs	pass	
+core-duplicate-binding	core	core/duplicate-binding.hs	pass	
+core-nested-application	core	core/nested-application.hs	pass	
+core-prelude-reference	core	core/prelude-reference.hs	pass	
+core-shadow-prelude	core	core/shadow-prelude.hs	pass	
+core-module-comments	core	core/module-comments.hs	pass	
+modules-import-qualified	modules	modules/import-qualified.hs	xfail	imports unsupported by parser
+modules-import-hiding	modules	modules/import-hiding.hs	xfail	imports unsupported by parser
+modules-export-list	modules	modules/export-list.hs	xfail	export lists unsupported by parser
+modules-import-as	modules	modules/import-as.hs	xfail	imports unsupported by parser

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/export-list.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/export-list.hs
@@ -1,0 +1,2 @@
+module E (x) where
+x = 1

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/import-as.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/import-as.hs
@@ -1,0 +1,3 @@
+module IA where
+import Data.Maybe as M
+x = M.fromMaybe

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/import-hiding.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/import-hiding.hs
@@ -1,0 +1,3 @@
+module IH where
+import Data.List hiding (map)
+x = map

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/import-qualified.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/import-qualified.hs
@@ -1,0 +1,3 @@
+module IQ where
+import qualified Data.List as L
+x = L.length []

--- a/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/type-signature.hs
+++ b/components/haskell-name-resolution/test/Test/Fixtures/progress/modules/type-signature.hs
@@ -1,0 +1,3 @@
+module S where
+x :: Int
+x = 1

--- a/components/haskell-name-resolution/test/Test/Progress.hs
+++ b/components/haskell-name-resolution/test/Test/Progress.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Progress
+  ( progressTests
+  ) where
+
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+import Parser (defaultConfig, parseModule)
+import Parser.Types (ParseResult (..))
+import Resolver (defaultResolveConfig, resolveModule)
+import Resolver.Ast
+import Resolver.Types (diagCode, diagnostics, resolved)
+import System.Directory (doesFileExist)
+import System.FilePath ((</>))
+import Test.Oracle.Resolve (oracleResolveFacts)
+import Test.ResolveFacts (ResolveFacts (..), VarFact (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+
+data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
+
+data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail deriving (Eq, Show)
+
+data CaseMeta = CaseMeta
+  { caseId :: !String
+  , caseCategory :: !String
+  , casePath :: !FilePath
+  , caseExpected :: !Expected
+  , caseReason :: !String
+  }
+  deriving (Eq, Show)
+
+fixtureRoot :: FilePath
+fixtureRoot = "test/Test/Fixtures/progress"
+
+manifestPath :: FilePath
+manifestPath = fixtureRoot </> "manifest.tsv"
+
+progressTests :: IO TestTree
+progressTests = do
+  cases <- loadManifest
+  individual <- mapM caseTest cases
+  summary <- summaryTest cases
+  pure (testGroup "resolver-progress" (individual <> [summary]))
+
+caseTest :: CaseMeta -> IO TestTree
+caseTest meta = do
+  source <- TIO.readFile (fixtureRoot </> casePath meta)
+  pure $ testCase (caseId meta) (assertOutcome meta source)
+
+assertOutcome :: CaseMeta -> T.Text -> Assertion
+assertOutcome meta source = do
+  (outcome, details) <- evaluateCaseText meta source
+  case outcome of
+    OutcomeFail ->
+      assertFailure
+        ( "resolver progress regression in "
+            <> caseId meta
+            <> " ["
+            <> caseCategory meta
+            <> "]: "
+            <> details
+        )
+    _ -> pure ()
+
+summaryTest :: [CaseMeta] -> IO TestTree
+summaryTest cases = do
+  outcomes <- mapM evaluateCase cases
+  pure $ testCase "summary" (assertNoFailures outcomes)
+
+assertNoFailures :: [(CaseMeta, Outcome, String)] -> Assertion
+assertNoFailures outcomes = do
+  let failN = length [() | (_, OutcomeFail, _) <- outcomes]
+  if failN > 0
+    then assertFailure ("resolver progress summary contains " <> show failN <> " failure(s)")
+    else pure ()
+
+evaluateCase :: CaseMeta -> IO (CaseMeta, Outcome, String)
+evaluateCase meta = do
+  source <- TIO.readFile (fixtureRoot </> casePath meta)
+  (outcome, details) <- evaluateCaseText meta source
+  pure (meta, outcome, details)
+
+evaluateCaseText :: CaseMeta -> T.Text -> IO (Outcome, String)
+evaluateCaseText meta source =
+  case oracleResolveFacts defaultResolveConfig source of
+    Left oracleErr -> pure (OutcomeFail, "oracle failed: " <> T.unpack oracleErr)
+    Right oracleFacts -> do
+      let oursFacts = resolveFacts source
+      pure $ classify (caseExpected meta) oursFacts oracleFacts
+
+classify :: Expected -> Either String ResolveFacts -> ResolveFacts -> (Outcome, String)
+classify expected oursEither oracleFacts =
+  case expected of
+    ExpectPass ->
+      case oursEither of
+        Left err -> (OutcomeFail, "expected pass but parser/resolver failed: " <> err)
+        Right oursFacts
+          | oursFacts == oracleFacts -> (OutcomePass, "")
+          | otherwise ->
+              ( OutcomeFail
+              , "facts differ from oracle"
+              )
+    ExpectXFail ->
+      case oursEither of
+        Left _ -> (OutcomeXFail, "")
+        Right oursFacts
+          | oursFacts == oracleFacts -> (OutcomeXPass, "expected xfail but now matches oracle")
+          | otherwise -> (OutcomeXFail, "")
+
+resolveFacts :: T.Text -> Either String ResolveFacts
+resolveFacts input =
+  case parseModule defaultConfig input of
+    ParseErr err -> Left (show err)
+    ParseOk modu ->
+      let rr = resolveModule defaultResolveConfig modu
+          resolvedMod = resolved rr
+          decls = resolvedDecls resolvedMod
+          vars = concatMap collectVars decls
+       in Right
+            ResolveFacts
+              { rfModuleName = resolvedModuleName resolvedMod
+              , rfDeclNames = map resolvedDeclName decls
+              , rfVars = vars
+              , rfDiagnosticCodes = map diagCode (diagnostics rr)
+              }
+  where
+    collectVars decl = collectExpr (resolvedDeclExpr decl)
+    collectExpr expr =
+      case expr of
+        RInt _ -> []
+        RApp f x -> collectExpr f <> collectExpr x
+        RVar name ->
+          [ VarFact
+              { vfName = rnText name
+              , vfBinding = fmap (const (rnText name)) (rnId name)
+              , vfClass = rnClass name
+              }
+          ]
+
+loadManifest :: IO [CaseMeta]
+loadManifest = do
+  raw <- TIO.readFile manifestPath
+  let rows = filter (not . T.null) (map stripComment (T.lines raw))
+  mapM parseRow rows
+
+stripComment :: T.Text -> T.Text
+stripComment line =
+  let core = fst (T.breakOn "#" line)
+   in T.strip core
+
+parseRow :: T.Text -> IO CaseMeta
+parseRow row =
+  case T.splitOn "\t" row of
+    [cid, cat, pathTxt, expectedTxt] -> parseRowWithReason cid cat pathTxt expectedTxt ""
+    [cid, cat, pathTxt, expectedTxt, reasonTxt] -> parseRowWithReason cid cat pathTxt expectedTxt reasonTxt
+    _ -> fail ("Invalid manifest row (expected 4 or 5 tab-separated columns): " <> T.unpack row)
+
+parseRowWithReason :: T.Text -> T.Text -> T.Text -> T.Text -> T.Text -> IO CaseMeta
+parseRowWithReason cid cat pathTxt expectedTxt reasonTxt = do
+  let path = T.unpack pathTxt
+  exists <- doesFileExist (fixtureRoot </> path)
+  if not exists
+    then fail ("Manifest references missing case file: " <> path)
+    else do
+      expected <-
+        case expectedTxt of
+          "pass" -> pure ExpectPass
+          "xfail" -> pure ExpectXFail
+          _ -> fail ("Unknown expected value in manifest: " <> T.unpack expectedTxt)
+      let reason = trim (T.unpack reasonTxt)
+      case expected of
+        ExpectXFail | null reason -> fail ("xfail case requires reason: " <> T.unpack cid)
+        _ -> pure ()
+      pure
+        CaseMeta
+          { caseId = T.unpack cid
+          , caseCategory = T.unpack cat
+          , casePath = path
+          , caseExpected = expected
+          , caseReason = reason
+          }
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,36 @@
             cabal run h2010-progress -- --strict
           '';
 
+          name-resolution-test = mkApp "name-resolution-test" ''
+            set -euo pipefail
+            test -d components/haskell-name-resolution || {
+              echo "Run this app from the repository root." >&2
+              exit 1
+            }
+            cd components/haskell-name-resolution
+            cabal test --test-show-details=direct
+          '';
+
+          name-resolution-progress = mkApp "name-resolution-progress" ''
+            set -euo pipefail
+            test -d components/haskell-name-resolution || {
+              echo "Run this app from the repository root." >&2
+              exit 1
+            }
+            cd components/haskell-name-resolution
+            cabal run name-resolution-progress
+          '';
+
+          name-resolution-progress-strict = mkApp "name-resolution-progress-strict" ''
+            set -euo pipefail
+            test -d components/haskell-name-resolution || {
+              echo "Run this app from the repository root." >&2
+              exit 1
+            }
+            cd components/haskell-name-resolution
+            cabal run name-resolution-progress -- --strict
+          '';
+
           default = mkApp "default" ''
             set -euo pipefail
             test -d components/haskell-parser || {


### PR DESCRIPTION
## Summary
- add manifest-driven progress tracking for `components/haskell-name-resolution`
- add resolver progress fixtures and `pass`/`xfail` classification via `test/Test/Fixtures/progress/manifest.tsv`
- add `resolver-progress` test group integrated into the component test suite
- add `name-resolution-progress` executable for PASS/XFAIL/XPASS/FAIL/TOTAL/COMPLETE summary
- add top-level README section for name-resolution progress
- add detailed `components/haskell-name-resolution/README.md`
- add top-level flake apps for name-resolution test/progress commands

## Current name-resolution baseline
- PASS: 8
- XFAIL: 4
- XPASS: 0
- FAIL: 0
- TOTAL: 12
- COMPLETE: 66.66%

## Nix apps
```bash
nix run .#name-resolution-test
nix run .#name-resolution-progress
nix run .#name-resolution-progress-strict
```

## Validation
```bash
nix run .#name-resolution-test
nix run .#name-resolution-progress
nix run .#name-resolution-progress-strict
```
