### PR TITLE
Run name-resolution tests in flake checks

### DIFF
--- a/components/haskell-name-resolution/app/name-resolution-progress/Main.hs
+++ b/components/haskell-name-resolution/app/name-resolution-progress/Main.hs
@@ -302,7 +302,7 @@ toCanonicalDecl locatedDecl =
                     _ -> Left "unsupported guarded rhs"
                 _ -> Left "unsupported function rhs"
               pure
-                CanonicalDecl
+                CanonicalValueDecl
                   { canonicalDeclName = T.pack (occNameString (rdrNameOcc name))
                   , canonicalDeclExpr = expr
                   }

--- a/components/haskell-name-resolution/test/Test/Oracle.hs
+++ b/components/haskell-name-resolution/test/Test/Oracle.hs
@@ -86,7 +86,7 @@ toCanonicalDecl locatedDecl =
                 _ -> Left "unsupported function rhs"
             _ -> Left "unsupported function rhs"
           pure
-            CanonicalDecl
+            CanonicalValueDecl
               { canonicalDeclName = T.pack (occNameString (rdrNameOcc name))
               , canonicalDeclExpr = expr
               }

--- a/flake.nix
+++ b/flake.nix
@@ -107,9 +107,17 @@
                 final.callCabal2nix "aihc-name-resolution" ./components/haskell-name-resolution { };
             };
           };
+          parserTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgs.aihc-parser);
+          nameResolutionTests =
+            pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgs.aihc-name-resolution);
         in {
-          parser-tests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgs.aihc-parser);
-          name-resolution-tests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgs.aihc-name-resolution);
+          parser-tests = parserTests;
+          name-resolution-tests = nameResolutionTests;
+          all-tests =
+            pkgs.linkFarm "aihc-all-tests" [
+              { name = "parser-tests"; path = parserTests; }
+              { name = "name-resolution-tests"; path = nameResolutionTests; }
+            ];
         });
     };
 }


### PR DESCRIPTION
## Summary
- make `nix flake check` explicitly aggregate both component test derivations via `checks.all-tests`
- keep `checks.parser-tests` and `checks.name-resolution-tests` as first-class checks
- fix two resolver oracle/canonicalization constructor uses (`CanonicalDecl` -> `CanonicalValueDecl`) so name-resolution checks compile and run under flake checks

## Why
`nix flake check` should run parser and name-resolution test checks together. This PR ensures that and keeps a single aggregate check that depends on both.

## Validation
```bash
nix flake check
```

Result on this branch: success (with both parser and name-resolution checks evaluated and built).
