### PR TITLE
Add AGENTS.md guidance for tooling and checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+- `gh` and `nix` are available for agents.
+- Other tools (for example `ghc` and `pandoc`) are not directly available, but can be run via `nix`.
+- Run tests with `nix flake check`.
+- `README.md` files include progress stats and must be kept up to date when working on PRs.


### PR DESCRIPTION
## Summary
- add a concise `AGENTS.md` at repo root
- document that `gh` and `nix` are directly available
- note that tools like `ghc` and `pandoc` should be invoked via `nix`
- document test command: `nix flake check`
- require keeping `README.md` progress stats up to date in PRs
