### PR TITLE
Expand Haskell2010 class declaration syntax fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 The from-scratch parser lives in `components/haskell-parser`.
 
 Current Haskell2010 progress:
-- `5/57` syntax cases implemented (`8.77%` complete)
-- status breakdown: `PASS=5`, `XFAIL=52`, `XPASS=0`, `FAIL=0`
+- `5/68` syntax cases implemented (`7.35%` complete)
+- status breakdown: `PASS=5`, `XFAIL=63`, `XPASS=0`, `FAIL=0`
 
 Recompute progress with:
 

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -18,8 +18,8 @@ Runtime outcomes are reported as:
 - `FAIL`: regression or invalid case/manifest (for example oracle rejects a `pass` case)
 
 Current progress baseline:
-- `5/57` implemented (`8.77%` complete)
-- `PASS=5`, `XFAIL=52`, `XPASS=0`, `FAIL=0`
+- `5/68` implemented (`7.35%` complete)
+- `PASS=5`, `XFAIL=63`, `XPASS=0`, `FAIL=0`
 
 ## Commands
 

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-default-funlhs.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-default-funlhs.hs
@@ -1,0 +1,2 @@
+module D34 where
+class C a where { op :: a -> a; op x = x }

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-default-var.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-default-var.hs
@@ -1,0 +1,2 @@
+module D33 where
+class C a where { op :: a -> a; op = id }

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-fixity.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-fixity.hs
@@ -1,0 +1,2 @@
+module D35 where
+class C a where { (<+>) :: a -> a -> a; infixl 6 <+> }

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-signature-context.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-signature-context.hs
@@ -1,0 +1,2 @@
+module D32 where
+class C a where { op :: Num b => a -> b -> a }

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-signature.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-cdecl-signature.hs
@@ -1,0 +1,2 @@
+module D31 where
+class C a where { op :: a -> a }

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-minimal.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-minimal.hs
@@ -1,0 +1,2 @@
+module D25 where
+class C a

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-paren-empty.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-paren-empty.hs
@@ -1,0 +1,2 @@
+module D28 where
+class () => C a

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-paren-multiple.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-paren-multiple.hs
@@ -1,0 +1,2 @@
+module D30 where
+class (Eq a, Show a) => C a

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-paren-single.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-paren-single.hs
@@ -1,0 +1,2 @@
+module D29 where
+class (Eq a) => C a

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-simple.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-super-simple.hs
@@ -1,0 +1,2 @@
+module D27 where
+class Eq a => C a

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-where-empty.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/declarations/class-where-empty.hs
@@ -1,0 +1,2 @@
+module D26 where
+class C a where {}

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -28,6 +28,17 @@ decls-data-abstract	declarations	declarations/data-abstract.hs	xfail	abstract da
 decls-newtype	declarations	declarations/newtype.hs	xfail	newtype declarations unsupported
 decls-type-synonym	declarations	declarations/type-synonym.hs	xfail	type synonym declarations unsupported
 decls-class	declarations	declarations/class.hs	xfail	class declarations unsupported
+decls-class-minimal	declarations	declarations/class-minimal.hs	xfail	class declarations without where unsupported
+decls-class-where-empty	declarations	declarations/class-where-empty.hs	xfail	class declarations with empty cdecls unsupported
+decls-class-super-simple	declarations	declarations/class-super-simple.hs	xfail	class superclass contexts unsupported
+decls-class-super-paren-empty	declarations	declarations/class-super-paren-empty.hs	xfail	parenthesized superclass contexts unsupported
+decls-class-super-paren-single	declarations	declarations/class-super-paren-single.hs	xfail	parenthesized superclass contexts unsupported
+decls-class-super-paren-multiple	declarations	declarations/class-super-paren-multiple.hs	xfail	multiple superclass constraints unsupported
+decls-class-cdecl-signature	declarations	declarations/class-cdecl-signature.hs	xfail	class method signatures unsupported
+decls-class-cdecl-signature-context	declarations	declarations/class-cdecl-signature-context.hs	xfail	class method signatures with contexts unsupported
+decls-class-cdecl-default-var	declarations	declarations/class-cdecl-default-var.hs	xfail	default class methods unsupported
+decls-class-cdecl-default-funlhs	declarations	declarations/class-cdecl-default-funlhs.hs	xfail	default class methods unsupported
+decls-class-cdecl-fixity	declarations	declarations/class-cdecl-fixity.hs	xfail	fixity declarations in class bodies unsupported
 decls-instance	declarations	declarations/instance.hs	xfail	instance declarations unsupported
 decls-fixity	declarations	declarations/fixity.hs	xfail	fixity declarations unsupported
 decls-default	declarations	declarations/default.hs	xfail	default declarations unsupported


### PR DESCRIPTION
## Summary
- add one Haskell2010 fixture per class-declaration syntax variation from section 4.3.1
- cover optional superclass context forms (none, simpleclass, parenthesized empty/single/multiple)
- cover optional class body forms (no where, empty where {})
- cover cdecl variants in class bodies: method signatures, contextual signatures, default method bindings (var and funlhs), and fixity declarations
- register all new fixtures in manifest.tsv as xfail (oracle-accepted but parser not yet implemented)
- update parser progress stats in top-level and parser READMEs

## Validation
- nix run .#parser-progress -> PASS=5, XFAIL=63, XPASS=0, FAIL=0, TOTAL=68, COMPLETE=7.35%
- nix run .#parser-test (passes)
- nix flake check (passes)
