### PR TITLE
Add Haskell2010 Chapter 8 FFI coverage fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 The from-scratch parser lives in `components/haskell-parser`.
 
 Current Haskell2010 progress:
-- `9/171` syntax cases implemented (`5.26%` complete)
-- status breakdown: `PASS=9`, `XFAIL=162`, `XPASS=0`, `FAIL=0`
+- `9/194` syntax cases implemented (`4.63%` complete)
+- status breakdown: `PASS=9`, `XFAIL=185`, `XPASS=0`, `FAIL=0`
 
 Recompute progress with:
 

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -18,8 +18,8 @@ Runtime outcomes are reported as:
 - `FAIL`: regression or invalid case/manifest (for example oracle rejects a `pass` case)
 
 Current progress baseline:
-- `9/171` implemented (`5.26%` complete)
-- `PASS=9`, `XFAIL=162`, `XPASS=0`, `FAIL=0`
+- `9/194` implemented (`4.63%` complete)
+- `PASS=9`, `XFAIL=185`, `XPASS=0`, `FAIL=0`
 
 ## Commands
 

--- a/components/haskell-parser/app/h2010-progress/Main.hs
+++ b/components/haskell-parser/app/h2010-progress/Main.hs
@@ -11,7 +11,7 @@ import qualified GHC.Data.EnumSet as EnumSet
 import GHC.Data.FastString (mkFastString)
 import GHC.Data.StringBuffer (stringToStringBuffer)
 import GHC.Hs (HsModule, GhcPs)
-import GHC.LanguageExtensions.Type (Extension)
+import GHC.LanguageExtensions.Type (Extension (ForeignFunctionInterface))
 import qualified GHC.Parser as GHCParser
 import qualified GHC.Parser.Lexer as Lexer
 import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
@@ -133,7 +133,8 @@ oracleParsesModule input =
 
 parseWithGhc :: Text -> Either String (HsModule GhcPs)
 parseWithGhc input =
-  let opts = Lexer.mkParserOpts (EnumSet.empty :: EnumSet.EnumSet Extension) emptyDiagOpts False False False False
+  let exts = EnumSet.fromList [ForeignFunctionInterface] :: EnumSet.EnumSet Extension
+      opts = Lexer.mkParserOpts exts emptyDiagOpts False False False False
       buffer = stringToStringBuffer (T.unpack input)
       start = mkRealSrcLoc (mkFastString "<h2010-progress>") 1 1
    in case Lexer.unP GHCParser.parseModule (Lexer.initParserState opts buffer start) of

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-export-ccall-named.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-export-ccall-named.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ExportCcallNamed where
+addInt :: Int -> Int -> Int
+addInt a b = a + b
+foreign export ccall "addInt" addInt :: Int -> Int -> Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-export-ccall-omitted-entity.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-export-ccall-omitted-entity.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ExportCcallOmittedEntity where
+addOne :: Int -> Int
+addOne n = n + 1
+foreign export ccall addOne :: Int -> Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-export-stdcall-named.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-export-stdcall-named.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ExportStdcallNamed where
+mulInt :: Int -> Int -> Int
+mulInt a b = a * b
+foreign export stdcall "mulInt" mulInt :: Int -> Int -> Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-address-header-cid.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-address-header-cid.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportAddressHeaderCid where
+foreign import ccall "errno.h &errno" errnoPtr :: Ptr Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-address-only.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-address-only.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportAddressOnly where
+foreign import ccall "&" errnoPtr :: Ptr Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ccall-basic.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ccall-basic.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportCcallBasic where
+foreign import ccall "puts" c_puts :: String -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ccall-safe.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ccall-safe.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportCcallSafe where
+foreign import ccall safe "puts" c_puts_safe :: String -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ccall-unsafe.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ccall-unsafe.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportCcallUnsafe where
+foreign import ccall unsafe "puts" c_puts_unsafe :: String -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-dynamic.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-dynamic.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportDynamic where
+foreign import ccall "dynamic" mkFun :: Ptr (Int -> IO Int) -> (Int -> IO Int)

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-arrow.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-arrow.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportFtypeArrow where
+foreign import ccall "plus1" plus1 :: Int -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-frtype-only.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-frtype-only.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportFtypeFrtypeOnly where
+foreign import ccall "get_errno" getErrno :: Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-multi-arg.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-multi-arg.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportFtypeMultiArg where
+foreign import ccall "plus" plus :: Int -> Int -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-result-unit.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-ftype-result-unit.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportFtypeResultUnit where
+foreign import ccall "tick" tick :: IO ()

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-impent-omitted.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-impent-omitted.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportImpentOmitted where
+foreign import ccall c_atoi :: String -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-dynamic-name.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-dynamic-name.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportStaticDynamicName where
+foreign import ccall "static dynamic" dynamicFn :: IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-header-cid.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-header-cid.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportStaticHeaderCid where
+foreign import ccall "static math.h sin" c_sin :: Double -> Double

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-header-default-cid.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-header-default-cid.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportStaticHeaderDefaultCid where
+foreign import ccall "static math.h" c_cos :: Double -> Double

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-wrapper-name.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-static-wrapper-name.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportStaticWrapperName where
+foreign import ccall "static wrapper" wrapperFn :: IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-stdcall-basic.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-stdcall-basic.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportStdcallBasic where
+foreign import stdcall "puts" s_puts :: String -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-wrapper.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-import-wrapper.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8ImportWrapper where
+foreign import ccall "wrapper" wrapFun :: (Int -> IO Int) -> IO (Ptr (Int -> IO Int))

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-lexical-identifiers.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-lexical-identifiers.hs
@@ -1,0 +1,4 @@
+module FfiS8LexicalIdentifiers where
+ccall = 1
+stdcall = 2
+foreignName = ccall + stdcall

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-mixed-import-export.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-mixed-import-export.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8MixedImportExport where
+foreign import ccall "atoi" c_atoi :: String -> IO Int
+inc :: Int -> Int
+inc n = n + 1
+foreign export ccall "inc" inc :: Int -> Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-multiple-foreign-decls.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/ffi/s8-multiple-foreign-decls.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module FfiS8MultipleForeignDecls where
+foreign import ccall unsafe "plus1" plus1 :: Int -> IO Int
+foreign import ccall safe "plus2" plus2 :: Int -> IO Int
+foreign import ccall "plus3" plus3 :: Int -> IO Int

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -40,6 +40,30 @@ modules-s5-module-empty-exports	modules	modules/s5-module-empty-exports.hs	xfail
 modules-s5-module-explicit-no-exports	modules	modules/s5-module-explicit-no-exports.hs	pass	
 modules-s5-module-exports-trailing-comma	modules	modules/s5-module-exports-trailing-comma.hs	xfail	section 5 module variation unsupported
 
+ffi-s8-export-ccall-named	ffi	ffi/s8-export-ccall-named.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-export-ccall-omitted-entity	ffi	ffi/s8-export-ccall-omitted-entity.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-export-stdcall-named	ffi	ffi/s8-export-stdcall-named.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-address-header-cid	ffi	ffi/s8-import-address-header-cid.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-address-only	ffi	ffi/s8-import-address-only.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ccall-basic	ffi	ffi/s8-import-ccall-basic.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ccall-safe	ffi	ffi/s8-import-ccall-safe.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ccall-unsafe	ffi	ffi/s8-import-ccall-unsafe.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-dynamic	ffi	ffi/s8-import-dynamic.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ftype-arrow	ffi	ffi/s8-import-ftype-arrow.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ftype-frtype-only	ffi	ffi/s8-import-ftype-frtype-only.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ftype-multi-arg	ffi	ffi/s8-import-ftype-multi-arg.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-ftype-result-unit	ffi	ffi/s8-import-ftype-result-unit.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-impent-omitted	ffi	ffi/s8-import-impent-omitted.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-static-dynamic-name	ffi	ffi/s8-import-static-dynamic-name.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-static-header-cid	ffi	ffi/s8-import-static-header-cid.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-static-header-default-cid	ffi	ffi/s8-import-static-header-default-cid.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-static-wrapper-name	ffi	ffi/s8-import-static-wrapper-name.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-stdcall-basic	ffi	ffi/s8-import-stdcall-basic.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-import-wrapper	ffi	ffi/s8-import-wrapper.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-lexical-identifiers	ffi	ffi/s8-lexical-identifiers.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-mixed-import-export	ffi	ffi/s8-mixed-import-export.hs	xfail	section 8 FFI variation unsupported
+ffi-s8-multiple-foreign-decls	ffi	ffi/s8-multiple-foreign-decls.hs	xfail	section 8 FFI variation unsupported
+
 decls-type-signature	declarations	declarations/type-signature.hs	xfail	type signatures unsupported
 decls-multiple-equations	declarations	declarations/multiple-equations.hs	xfail	multiple equations unsupported
 decls-pattern-binding	declarations	declarations/pattern-binding.hs	xfail	pattern bindings unsupported

--- a/components/haskell-parser/test/Test/H2010/Suite.hs
+++ b/components/haskell-parser/test/Test/H2010/Suite.hs
@@ -13,7 +13,7 @@ import qualified GHC.Data.EnumSet as EnumSet
 import GHC.Data.FastString (mkFastString)
 import GHC.Data.StringBuffer (stringToStringBuffer)
 import GHC.Hs (GhcPs, HsModule)
-import GHC.LanguageExtensions.Type (Extension)
+import GHC.LanguageExtensions.Type (Extension (ForeignFunctionInterface))
 import qualified GHC.Parser as GHCParser
 import qualified GHC.Parser.Lexer as Lexer
 import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
@@ -149,7 +149,8 @@ oracleParsesModule input =
 
 parseWithGhc :: Text -> Either String (HsModule GhcPs)
 parseWithGhc input =
-  let opts = Lexer.mkParserOpts (EnumSet.empty :: EnumSet.EnumSet Extension) emptyDiagOpts False False False False
+  let exts = EnumSet.fromList [ForeignFunctionInterface] :: EnumSet.EnumSet Extension
+      opts = Lexer.mkParserOpts exts emptyDiagOpts False False False False
       buffer = stringToStringBuffer (T.unpack input)
       start = mkRealSrcLoc (mkFastString "<h2010-oracle>") 1 1
    in case Lexer.unP GHCParser.parseModule (Lexer.initParserState opts buffer start) of


### PR DESCRIPTION
## Summary
- add Haskell2010 Chapter 8 (FFI) syntax coverage fixtures under `components/haskell-parser/test/Test/Fixtures/haskell2010/ffi`
- extend `components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv` with `ffi-s8-*` cases covering:
  - foreign import/export declarations
  - `ccall`/`stdcall` calling conventions accepted by the oracle parser setup
  - `safe`/`unsafe` import safety variants
  - `impent` forms including omitted string, static/header names, address (`&`), `dynamic`, and `wrapper`
  - representative `ftype` forms (`frtype`, arrow, multi-arg, `IO ()`)
- enable `ForeignFunctionInterface` in oracle parsing for H2010 suite/progress so section 8 fixtures are oracle-valid
- update parser progress stats in root `README.md` and `components/haskell-parser/README.md`

## Validation
- `nix run .#parser-progress` => `PASS=9`, `XFAIL=185`, `XPASS=0`, `FAIL=0`, `TOTAL=194`
- `nix flake check`
