### PR TITLE
Add statix, hlint, and ormolu checks to flake check

### DIFF
--- a/components/haskell-name-resolution/app/name-resolution-progress/Main.hs
+++ b/components/haskell-name-resolution/app/name-resolution-progress/Main.hs
@@ -2,11 +2,11 @@
 
 module Main (main) where
 
-import Data.Char (isSpace)
 import Data.Bifunctor (first)
-import qualified Data.Map.Strict as M
+import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified GHC.Data.EnumSet as EnumSet
@@ -21,41 +21,42 @@ import GHC.Types.Name.Reader (rdrNameOcc)
 import GHC.Types.SourceText (IntegralLit (..))
 import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
 import GHC.Utils.Error (emptyDiagOpts)
-import Parser.Canonical
 import Parser (defaultConfig, parseModule)
+import Parser.Canonical
 import Parser.Types (ParseResult (..))
 import Resolver (defaultResolveConfig, resolveModule)
 import Resolver.Ast
-import Resolver.Types (DiagnosticCode (..), NameClass (..), diagCode, diagnostics, preludeMode, resolved, ResolveConfig (..), PreludeMode (..))
+import Resolver.Types (DiagnosticCode (..), NameClass (..), PreludeMode (..), ResolveConfig (..), diagCode, diagnostics, preludeMode, resolved)
 import System.Directory (doesFileExist)
 import System.Environment (getArgs)
 import System.Exit (exitFailure, exitSuccess)
 import System.FilePath ((</>))
 
 data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
+
 data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail deriving (Eq, Show)
 
 data CaseMeta = CaseMeta
-  { caseId :: !String
-  , caseCategory :: !String
-  , casePath :: !FilePath
-  , caseExpected :: !Expected
-  , _caseReason :: !String
+  { caseId :: !String,
+    caseCategory :: !String,
+    casePath :: !FilePath,
+    caseExpected :: !Expected,
+    _caseReason :: !String
   }
   deriving (Eq, Show)
 
 data VarFact = VarFact
-  { vfName :: T.Text
-  , vfBinding :: Maybe T.Text
-  , vfClass :: NameClass
+  { vfName :: T.Text,
+    vfBinding :: Maybe T.Text,
+    vfClass :: NameClass
   }
   deriving (Eq, Show)
 
 data ResolveFacts = ResolveFacts
-  { rfModuleName :: Maybe T.Text
-  , rfDeclNames :: [T.Text]
-  , rfVars :: [VarFact]
-  , rfDiagnosticCodes :: [DiagnosticCode]
+  { rfModuleName :: Maybe T.Text,
+    rfDeclNames :: [T.Text],
+    rfVars :: [VarFact],
+    rfDiagnosticCodes :: [DiagnosticCode]
   }
   deriving (Eq, Show)
 
@@ -146,10 +147,10 @@ resolveFacts input =
           vars = concatMap (collectExpr . resolvedDeclExpr) decls
        in Right
             ResolveFacts
-              { rfModuleName = resolvedModuleName resolvedMod
-              , rfDeclNames = map resolvedDeclName decls
-              , rfVars = vars
-              , rfDiagnosticCodes = map diagCode (diagnostics rr)
+              { rfModuleName = resolvedModuleName resolvedMod,
+                rfDeclNames = map resolvedDeclName decls,
+                rfVars = vars,
+                rfDiagnosticCodes = map diagCode (diagnostics rr)
               }
   where
     collectExpr expr =
@@ -158,9 +159,9 @@ resolveFacts input =
         RApp f x -> collectExpr f <> collectExpr x
         RVar name ->
           [ VarFact
-              { vfName = rnText name
-              , vfBinding = fmap (const (rnText name)) (rnId name)
-              , vfClass = rnClass name
+              { vfName = rnText name,
+                vfBinding = fmap (const (rnText name)) (rnId name),
+                vfClass = rnClass name
               }
           ]
 
@@ -198,11 +199,11 @@ parseRowWithReason cid cat pathTxt expectedTxt reasonTxt = do
         _ -> pure ()
       pure
         CaseMeta
-          { caseId = T.unpack cid
-          , caseCategory = T.unpack cat
-          , casePath = path
-          , caseExpected = expected
-          , _caseReason = reason
+          { caseId = T.unpack cid,
+            caseCategory = T.unpack cat,
+            casePath = path,
+            caseExpected = expected,
+            _caseReason = reason
           }
 
 trim :: String -> String
@@ -218,10 +219,10 @@ resolveCanonical cfg modu =
   let (declMap, dupDiags) = gatherDecls (canonicalDecls modu)
       (varFacts, unboundDiags) = foldMap (resolveDeclExpr declMap) (canonicalDecls modu)
    in ResolveFacts
-        { rfModuleName = canonicalModuleName modu
-        , rfDeclNames = map canonicalDeclName (canonicalDecls modu)
-        , rfVars = varFacts
-        , rfDiagnosticCodes = dupDiags <> unboundDiags
+        { rfModuleName = canonicalModuleName modu,
+          rfDeclNames = map canonicalDeclName (canonicalDecls modu),
+          rfVars = varFacts,
+          rfDiagnosticCodes = dupDiags <> unboundDiags
         }
   where
     resolveDeclExpr declMap decl = resolveExpr declMap (canonicalDeclExpr decl)
@@ -279,8 +280,8 @@ toCanonicalModule modu = do
   decls <- traverse toCanonicalDecl (hsmodDecls modu)
   pure
     CanonicalModule
-      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu)
-      , canonicalDecls = decls
+      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu),
+        canonicalDecls = decls
       }
 
 toCanonicalDecl :: LHsDecl GhcPs -> Either String CanonicalDecl
@@ -303,8 +304,8 @@ toCanonicalDecl locatedDecl =
                 _ -> Left "unsupported function rhs"
               pure
                 CanonicalValueDecl
-                  { canonicalDeclName = T.pack (occNameString (rdrNameOcc name))
-                  , canonicalDeclExpr = expr
+                  { canonicalDeclName = T.pack (occNameString (rdrNameOcc name)),
+                    canonicalDeclExpr = expr
                   }
             _ -> Left "unsupported value binding"
         _ -> Left "unsupported declaration kind"

--- a/components/haskell-name-resolution/src/Resolver.hs
+++ b/components/haskell-name-resolution/src/Resolver.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Resolver
-  ( defaultResolveConfig
-  , resolveModule
-  ) where
+  ( defaultResolveConfig,
+    resolveModule,
+  )
+where
 
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -15,19 +16,19 @@ import Resolver.Types
 defaultResolveConfig :: ResolveConfig
 defaultResolveConfig =
   ResolveConfig
-    { preludeMode = ImplicitPreludeOn
-    , enabledExtensions = S.empty
+    { preludeMode = ImplicitPreludeOn,
+      enabledExtensions = S.empty
     }
 
 data BindingInfo = BindingInfo
-  { bindingId :: !NameId
-  , bindingClass :: !NameClass
+  { bindingId :: !NameId,
+    bindingClass :: !NameClass
   }
 
 data ResolveState = ResolveState
-  { nextId :: !Int
-  , env :: !(M.Map Text BindingInfo)
-  , diags :: [Diagnostic]
+  { nextId :: !Int,
+    env :: !(M.Map Text BindingInfo),
+    diags :: [Diagnostic]
   }
 
 resolveModule :: ResolveConfig -> Module -> ResolveResult ResolvedModule
@@ -36,17 +37,17 @@ resolveModule cfg modu =
    in ResolveResult
         { resolved =
             ResolvedModule
-              { resolvedModuleName = moduleName modu
-              , resolvedDecls = reverse declsRev
-              }
-        , diagnostics = reverse (diags finalState)
+              { resolvedModuleName = moduleName modu,
+                resolvedDecls = reverse declsRev
+              },
+          diagnostics = reverse (diags finalState)
         }
   where
     emptyState =
       ResolveState
-        { nextId = 0
-        , env = preludeEnv (preludeMode cfg)
-        , diags = []
+        { nextId = 0,
+          env = preludeEnv (preludeMode cfg),
+          diags = []
         }
 
 resolveDecls :: ResolveConfig -> [Decl] -> ResolveState -> ([ResolvedDecl], ResolveState)
@@ -59,9 +60,9 @@ resolveDecls cfg decls st0 =
           (expr', st') = resolveExpr cfg' (declExpr decl) st
           outDecl =
             ResolvedDecl
-              { resolvedDeclName = declName decl
-              , resolvedDeclId = thisId
-              , resolvedDeclExpr = expr'
+              { resolvedDeclName = declName decl,
+                resolvedDeclId = thisId,
+                resolvedDeclExpr = expr'
               }
        in (outDecl : acc, st')
 
@@ -76,10 +77,10 @@ assignTopLevelBinders decls st0 = foldl' step (st0, M.empty) decls
             Just _ ->
               let dupDiag =
                     Diagnostic
-                      { diagCode = EDuplicateBinding
-                      , diagSeverity = Error
-                      , diagMessage = "duplicate top-level binding: " <> name
-                      , diagSpan = NoSpan
+                      { diagCode = EDuplicateBinding,
+                        diagSeverity = Error,
+                        diagMessage = "duplicate top-level binding: " <> name,
+                        diagSpan = NoSpan
                       }
                in (stWithId {diags = dupDiag : diags stWithId}, ids)
             Nothing ->
@@ -99,22 +100,22 @@ resolveExpr cfg expr st =
         Just info ->
           ( RVar
               ResolvedName
-                { rnText = name
-                , rnId = Just (bindingId info)
-                , rnClass = bindingClass info
-                }
-          , st
+                { rnText = name,
+                  rnId = Just (bindingId info),
+                  rnClass = bindingClass info
+                },
+            st
           )
         Nothing ->
           let diag =
                 Diagnostic
-                  { diagCode = EUnboundVariable
-                  , diagSeverity = Error
-                  , diagMessage = "unbound variable: " <> name
-                  , diagSpan = NoSpan
+                  { diagCode = EUnboundVariable,
+                    diagSeverity = Error,
+                    diagMessage = "unbound variable: " <> name,
+                    diagSpan = NoSpan
                   }
-           in ( RVar ResolvedName {rnText = name, rnId = Nothing, rnClass = Unresolved}
-              , st {diags = diag : diags st}
+           in ( RVar ResolvedName {rnText = name, rnId = Nothing, rnClass = Unresolved},
+                st {diags = diag : diags st}
               )
 
 preludeEnv :: PreludeMode -> M.Map Text BindingInfo

--- a/components/haskell-name-resolution/src/Resolver/Ast.hs
+++ b/components/haskell-name-resolution/src/Resolver/Ast.hs
@@ -1,30 +1,31 @@
 module Resolver.Ast
-  ( ResolvedDecl (..)
-  , ResolvedExpr (..)
-  , ResolvedModule (..)
-  , ResolvedName (..)
-  ) where
+  ( ResolvedDecl (..),
+    ResolvedExpr (..),
+    ResolvedModule (..),
+    ResolvedName (..),
+  )
+where
 
 import Data.Text (Text)
 import Resolver.Types
 
 data ResolvedModule = ResolvedModule
-  { resolvedModuleName :: Maybe Text
-  , resolvedDecls :: [ResolvedDecl]
+  { resolvedModuleName :: Maybe Text,
+    resolvedDecls :: [ResolvedDecl]
   }
   deriving (Eq, Show)
 
 data ResolvedDecl = ResolvedDecl
-  { resolvedDeclName :: Text
-  , resolvedDeclId :: NameId
-  , resolvedDeclExpr :: ResolvedExpr
+  { resolvedDeclName :: Text,
+    resolvedDeclId :: NameId,
+    resolvedDeclExpr :: ResolvedExpr
   }
   deriving (Eq, Show)
 
 data ResolvedName = ResolvedName
-  { rnText :: Text
-  , rnId :: Maybe NameId
-  , rnClass :: NameClass
+  { rnText :: Text,
+    rnId :: Maybe NameId,
+    rnClass :: NameClass
   }
   deriving (Eq, Show)
 

--- a/components/haskell-name-resolution/src/Resolver/Types.hs
+++ b/components/haskell-name-resolution/src/Resolver/Types.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE DeriveFunctor #-}
 
 module Resolver.Types
-  ( Diagnostic (..)
-  , DiagnosticCode (..)
-  , DiagnosticSeverity (..)
-  , ExtensionTag (..)
-  , NameClass (..)
-  , NameId (..)
-  , PreludeMode (..)
-  , ResolveConfig (..)
-  , ResolveResult (..)
-  , Span (..)
-  ) where
+  ( Diagnostic (..),
+    DiagnosticCode (..),
+    DiagnosticSeverity (..),
+    ExtensionTag (..),
+    NameClass (..),
+    NameId (..),
+    PreludeMode (..),
+    ResolveConfig (..),
+    ResolveResult (..),
+    Span (..),
+  )
+where
 
 import Data.Set (Set)
 import Data.Text (Text)
@@ -42,18 +43,18 @@ data DiagnosticCode
 data Span
   = NoSpan
   | Span
-      { startLine :: !Int
-      , startCol :: !Int
-      , endLine :: !Int
-      , endCol :: !Int
+      { startLine :: !Int,
+        startCol :: !Int,
+        endLine :: !Int,
+        endCol :: !Int
       }
   deriving (Eq, Ord, Show)
 
 data Diagnostic = Diagnostic
-  { diagCode :: !DiagnosticCode
-  , diagSeverity :: !DiagnosticSeverity
-  , diagMessage :: !Text
-  , diagSpan :: !Span
+  { diagCode :: !DiagnosticCode,
+    diagSeverity :: !DiagnosticSeverity,
+    diagMessage :: !Text,
+    diagSpan :: !Span
   }
   deriving (Eq, Show)
 
@@ -68,13 +69,13 @@ data PreludeMode
   deriving (Eq, Ord, Show)
 
 data ResolveConfig = ResolveConfig
-  { preludeMode :: !PreludeMode
-  , enabledExtensions :: !(Set ExtensionTag)
+  { preludeMode :: !PreludeMode,
+    enabledExtensions :: !(Set ExtensionTag)
   }
   deriving (Eq, Show)
 
 data ResolveResult a = ResolveResult
-  { resolved :: a
-  , diagnostics :: [Diagnostic]
+  { resolved :: a,
+    diagnostics :: [Diagnostic]
   }
   deriving (Eq, Show, Functor)

--- a/components/haskell-name-resolution/test/Test/Oracle.hs
+++ b/components/haskell-name-resolution/test/Test/Oracle.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Oracle
-  ( oracleCanonicalModule
-  , oracleParsesModule
-  ) where
+  ( oracleCanonicalModule,
+    oracleParsesModule,
+  )
+where
 
 import Data.Bifunctor (first)
 import Data.Foldable (toList)
@@ -16,19 +17,18 @@ import GHC.Hs
 import GHC.LanguageExtensions.Type (Extension)
 import GHC.Parser (parseModule)
 import GHC.Parser.Lexer
-  ( ParseResult (..)
-  , getPsErrorMessages
-  , initParserState
-  , mkParserOpts
-  , unP
+  ( ParseResult (..),
+    getPsErrorMessages,
+    initParserState,
+    mkParserOpts,
+    unP,
   )
+import GHC.Types.Error (NoDiagnosticOpts (NoDiagnosticOpts))
 import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Types.Name.Reader (rdrNameOcc)
-import GHC.Types.Error (NoDiagnosticOpts (NoDiagnosticOpts))
 import GHC.Types.SourceText (IntegralLit (..))
 import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
-import GHC.Utils.Error (pprMessages)
-import GHC.Utils.Error (emptyDiagOpts)
+import GHC.Utils.Error (emptyDiagOpts, pprMessages)
 import GHC.Utils.Outputable (showSDocUnsafe)
 import Parser.Canonical
 
@@ -59,39 +59,38 @@ toCanonicalModule modu = do
   decls <- traverse toCanonicalDecl (hsmodDecls modu)
   pure
     CanonicalModule
-      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu)
-      , canonicalDecls = decls
+      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu),
+        canonicalDecls = decls
       }
 
 toCanonicalDecl :: LHsDecl GhcPs -> Either String CanonicalDecl
 toCanonicalDecl locatedDecl =
   let decl = unLoc locatedDecl
-   in
-  case decl of
-    ValD _ bind ->
-      case bind of
-        FunBind {fun_id = locatedName, fun_matches = MG {mg_alts = locatedMatches}} -> do
-          let name = unLoc locatedName
-              matches = unLoc locatedMatches
-          match <- case matches of
-            [singleMatch] -> Right (unLoc singleMatch)
-            _ -> Left "unsupported multiple matches"
-          expr <- case m_grhss match of
-            GRHSs _ grhss _ ->
-              case toList grhss of
-                [grhs] ->
-                  case unLoc grhs of
-                    GRHS _ [] body -> toCanonicalExpr (unLoc body)
-                    _ -> Left "unsupported guarded rhs"
+   in case decl of
+        ValD _ bind ->
+          case bind of
+            FunBind {fun_id = locatedName, fun_matches = MG {mg_alts = locatedMatches}} -> do
+              let name = unLoc locatedName
+                  matches = unLoc locatedMatches
+              match <- case matches of
+                [singleMatch] -> Right (unLoc singleMatch)
+                _ -> Left "unsupported multiple matches"
+              expr <- case m_grhss match of
+                GRHSs _ grhss _ ->
+                  case toList grhss of
+                    [grhs] ->
+                      case unLoc grhs of
+                        GRHS _ [] body -> toCanonicalExpr (unLoc body)
+                        _ -> Left "unsupported guarded rhs"
+                    _ -> Left "unsupported function rhs"
                 _ -> Left "unsupported function rhs"
-            _ -> Left "unsupported function rhs"
-          pure
-            CanonicalValueDecl
-              { canonicalDeclName = T.pack (occNameString (rdrNameOcc name))
-              , canonicalDeclExpr = expr
-              }
-        _ -> Left "unsupported value binding"
-    _ -> Left "unsupported declaration kind"
+              pure
+                CanonicalValueDecl
+                  { canonicalDeclName = T.pack (occNameString (rdrNameOcc name)),
+                    canonicalDeclExpr = expr
+                  }
+            _ -> Left "unsupported value binding"
+        _ -> Left "unsupported declaration kind"
 
 toCanonicalExpr :: HsExpr GhcPs -> Either String CanonicalExpr
 toCanonicalExpr expr =

--- a/components/haskell-name-resolution/test/Test/Oracle/Resolve.hs
+++ b/components/haskell-name-resolution/test/Test/Oracle/Resolve.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Oracle.Resolve
-  ( oracleResolveFacts
-  ) where
+  ( oracleResolveFacts,
+  )
+where
 
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -21,10 +22,10 @@ resolveCanonical cfg modu =
   let (declMap, dupDiags) = gatherDecls (canonicalDecls modu)
       (varFacts, unboundDiags) = foldMap (resolveDeclExpr declMap) (canonicalDecls modu)
    in ResolveFacts
-        { rfModuleName = canonicalModuleName modu
-        , rfDeclNames = map canonicalDeclName (canonicalDecls modu)
-        , rfVars = varFacts
-        , rfDiagnosticCodes = dupDiags <> unboundDiags
+        { rfModuleName = canonicalModuleName modu,
+          rfDeclNames = map canonicalDeclName (canonicalDecls modu),
+          rfVars = varFacts,
+          rfDiagnosticCodes = dupDiags <> unboundDiags
         }
   where
     resolveDeclExpr declMap decl = resolveExpr declMap (canonicalDeclExpr decl)

--- a/components/haskell-name-resolution/test/Test/Progress.hs
+++ b/components/haskell-name-resolution/test/Test/Progress.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Progress
-  ( progressTests
-  ) where
+  ( progressTests,
+  )
+where
 
+import Control.Monad (when)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import qualified Data.Text as T
@@ -25,11 +27,11 @@ data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
 data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail deriving (Eq, Show)
 
 data CaseMeta = CaseMeta
-  { caseId :: !String
-  , caseCategory :: !String
-  , casePath :: !FilePath
-  , caseExpected :: !Expected
-  , caseReason :: !String
+  { caseId :: !String,
+    caseCategory :: !String,
+    casePath :: !FilePath,
+    caseExpected :: !Expected,
+    caseReason :: !String
   }
   deriving (Eq, Show)
 
@@ -74,9 +76,8 @@ summaryTest cases = do
 assertNoFailures :: [(CaseMeta, Outcome, String)] -> Assertion
 assertNoFailures outcomes = do
   let failN = length [() | (_, OutcomeFail, _) <- outcomes]
-  if failN > 0
-    then assertFailure ("resolver progress summary contains " <> show failN <> " failure(s)")
-    else pure ()
+  when (failN > 0) $
+    assertFailure ("resolver progress summary contains " <> show failN <> " failure(s)")
 
 evaluateCase :: CaseMeta -> IO (CaseMeta, Outcome, String)
 evaluateCase meta = do
@@ -101,8 +102,8 @@ classify expected oursEither oracleFacts =
         Right oursFacts
           | oursFacts == oracleFacts -> (OutcomePass, "")
           | otherwise ->
-              ( OutcomeFail
-              , "facts differ from oracle"
+              ( OutcomeFail,
+                "facts differ from oracle"
               )
     ExpectXFail ->
       case oursEither of
@@ -122,10 +123,10 @@ resolveFacts input =
           vars = concatMap collectVars decls
        in Right
             ResolveFacts
-              { rfModuleName = resolvedModuleName resolvedMod
-              , rfDeclNames = map resolvedDeclName decls
-              , rfVars = vars
-              , rfDiagnosticCodes = map diagCode (diagnostics rr)
+              { rfModuleName = resolvedModuleName resolvedMod,
+                rfDeclNames = map resolvedDeclName decls,
+                rfVars = vars,
+                rfDiagnosticCodes = map diagCode (diagnostics rr)
               }
   where
     collectVars decl = collectExpr (resolvedDeclExpr decl)
@@ -135,9 +136,9 @@ resolveFacts input =
         RApp f x -> collectExpr f <> collectExpr x
         RVar name ->
           [ VarFact
-              { vfName = rnText name
-              , vfBinding = fmap (const (rnText name)) (rnId name)
-              , vfClass = rnClass name
+              { vfName = rnText name,
+                vfBinding = fmap (const (rnText name)) (rnId name),
+                vfClass = rnClass name
               }
           ]
 
@@ -177,11 +178,11 @@ parseRowWithReason cid cat pathTxt expectedTxt reasonTxt = do
         _ -> pure ()
       pure
         CaseMeta
-          { caseId = T.unpack cid
-          , caseCategory = T.unpack cat
-          , casePath = path
-          , caseExpected = expected
-          , caseReason = reason
+          { caseId = T.unpack cid,
+            caseCategory = T.unpack cat,
+            casePath = path,
+            caseExpected = expected,
+            caseReason = reason
           }
 
 trim :: String -> String

--- a/components/haskell-name-resolution/test/Test/ResolveFacts.hs
+++ b/components/haskell-name-resolution/test/Test/ResolveFacts.hs
@@ -1,22 +1,23 @@
 module Test.ResolveFacts
-  ( ResolveFacts (..)
-  , VarFact (..)
-  ) where
+  ( ResolveFacts (..),
+    VarFact (..),
+  )
+where
 
 import Data.Text (Text)
 import Resolver.Types
 
 data VarFact = VarFact
-  { vfName :: Text
-  , vfBinding :: Maybe Text
-  , vfClass :: NameClass
+  { vfName :: Text,
+    vfBinding :: Maybe Text,
+    vfClass :: NameClass
   }
   deriving (Eq, Show)
 
 data ResolveFacts = ResolveFacts
-  { rfModuleName :: Maybe Text
-  , rfDeclNames :: [Text]
-  , rfVars :: [VarFact]
-  , rfDiagnosticCodes :: [DiagnosticCode]
+  { rfModuleName :: Maybe Text,
+    rfDeclNames :: [Text],
+    rfVars :: [VarFact],
+    rfDiagnosticCodes :: [DiagnosticCode]
   }
   deriving (Eq, Show)

--- a/components/haskell-name-resolution/test/Test/Resolver.hs
+++ b/components/haskell-name-resolution/test/Test/Resolver.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Resolver
-  ( resolverTests
-  ) where
+  ( resolverTests,
+  )
+where
 
 import Control.Monad (forM)
 import Data.List (isSuffixOf, sort)
@@ -29,23 +30,23 @@ resolverTests = do
       "resolver"
       [ testGroup
           "unit"
-          [ testCase "resolves top-level references" case_resolvesTopLevel
-          , testCase "reports unbound variables" case_unboundVariable
-          , testCase "reports duplicate top-level bindings" case_duplicateBinding
-          , testCase "respects implicit prelude config" case_preludeToggle
-          , testCase "deterministic output for same module" case_deterministic
-          ]
-      , testGroup
+          [ testCase "resolves top-level references" case_resolvesTopLevel,
+            testCase "reports unbound variables" case_unboundVariable,
+            testCase "reports duplicate top-level bindings" case_duplicateBinding,
+            testCase "respects implicit prelude config" case_preludeToggle,
+            testCase "deterministic output for same module" case_deterministic
+          ],
+        testGroup
           "progress-matrix"
-          [ testGroup "node-var" [testCase "top-level lookup" case_resolvesTopLevel]
-          , testGroup "node-int" [testCase "integer literal" case_intLiteral]
-          , testGroup "node-app" [testCase "application traversal" case_applicationTraversal]
-          , testGroup "scope-shadowing" [testCase "prelude shadowed by top-level binder" case_shadowPreludeByTopLevel]
-          , testGroup "scope-ordering" [testCase "forward reference to later binder" case_forwardReference]
-          , testGroup "scope-errors" [testCase "duplicate and unbound diagnostics" case_duplicateAndUnbound]
-          , testGroup "extension-haskell2010-core" [testCase "minimal module" case_haskell2010Core]
-          ]
-      , testGroup "differential-fixtures" [scenarios]
+          [ testGroup "node-var" [testCase "top-level lookup" case_resolvesTopLevel],
+            testGroup "node-int" [testCase "integer literal" case_intLiteral],
+            testGroup "node-app" [testCase "application traversal" case_applicationTraversal],
+            testGroup "scope-shadowing" [testCase "prelude shadowed by top-level binder" case_shadowPreludeByTopLevel],
+            testGroup "scope-ordering" [testCase "forward reference to later binder" case_forwardReference],
+            testGroup "scope-errors" [testCase "duplicate and unbound diagnostics" case_duplicateAndUnbound],
+            testGroup "extension-haskell2010-core" [testCase "minimal module" case_haskell2010Core]
+          ],
+        testGroup "differential-fixtures" [scenarios]
       ]
 
 case_resolvesTopLevel :: Assertion
@@ -90,11 +91,11 @@ case_intLiteral = do
 case_applicationTraversal :: Assertion
 case_applicationTraversal = do
   res <- resolveFactsFromSource defaultResolveConfig "module M where\nx = f a\nf = a\n"
-  rfVars res @?=
-    [ VarFact {vfName = "f", vfBinding = Just "f", vfClass = TopLevelBinder}
-    , VarFact {vfName = "a", vfBinding = Nothing, vfClass = Unresolved}
-    , VarFact {vfName = "a", vfBinding = Nothing, vfClass = Unresolved}
-    ]
+  rfVars res
+    @?= [ VarFact {vfName = "f", vfBinding = Just "f", vfClass = TopLevelBinder},
+          VarFact {vfName = "a", vfBinding = Nothing, vfClass = Unresolved},
+          VarFact {vfName = "a", vfBinding = Nothing, vfClass = Unresolved}
+        ]
   rfDiagnosticCodes res @?= [EUnboundVariable, EUnboundVariable]
 
 case_haskell2010Core :: Assertion
@@ -111,10 +112,10 @@ case_shadowPreludeByTopLevel = do
 case_forwardReference :: Assertion
 case_forwardReference = do
   res <- resolveFactsFromSource defaultResolveConfig "module M where\nstart = middle\nmiddle = end\nend = 1\n"
-  rfVars res @?=
-    [ VarFact {vfName = "middle", vfBinding = Just "middle", vfClass = TopLevelBinder}
-    , VarFact {vfName = "end", vfBinding = Just "end", vfClass = TopLevelBinder}
-    ]
+  rfVars res
+    @?= [ VarFact {vfName = "middle", vfBinding = Just "middle", vfClass = TopLevelBinder},
+          VarFact {vfName = "end", vfBinding = Just "end", vfClass = TopLevelBinder}
+        ]
   rfDiagnosticCodes res @?= []
 
 case_duplicateAndUnbound :: Assertion
@@ -158,10 +159,10 @@ toFacts rr =
       vars = concatMap (collectVars declById . resolvedDeclExpr) decls
       codes = map diagCode (diagnostics rr)
    in ResolveFacts
-        { rfModuleName = resolvedModuleName modu
-        , rfDeclNames = map resolvedDeclName decls
-        , rfVars = vars
-        , rfDiagnosticCodes = codes
+        { rfModuleName = resolvedModuleName modu,
+          rfDeclNames = map resolvedDeclName decls,
+          rfVars = vars,
+          rfDiagnosticCodes = codes
         }
 
 collectVars :: M.Map NameId Text -> ResolvedExpr -> [VarFact]
@@ -171,15 +172,15 @@ collectVars declById expr =
     RApp f x -> collectVars declById f <> collectVars declById x
     RVar name ->
       [ VarFact
-          { vfName = rnText name
-          , vfBinding =
+          { vfName = rnText name,
+            vfBinding =
               case rnClass name of
                 TopLevelBinder -> rnId name >>= (`M.lookup` declById)
                 PreludeBinder -> Just (rnText name)
                 LocalBinder -> Just (rnText name)
                 ImportedBinder -> Just (rnText name)
-                Unresolved -> Nothing
-          , vfClass = rnClass name
+                Unresolved -> Nothing,
+            vfClass = rnClass name
           }
       ]
 

--- a/components/haskell-parser/app/h2010-progress/Main.hs
+++ b/components/haskell-parser/app/h2010-progress/Main.hs
@@ -10,7 +10,7 @@ import qualified Data.Text.IO as TIO
 import qualified GHC.Data.EnumSet as EnumSet
 import GHC.Data.FastString (mkFastString)
 import GHC.Data.StringBuffer (stringToStringBuffer)
-import GHC.Hs (HsModule, GhcPs)
+import GHC.Hs (GhcPs, HsModule)
 import GHC.LanguageExtensions.Type (Extension (ForeignFunctionInterface))
 import qualified GHC.Parser as GHCParser
 import qualified GHC.Parser.Lexer as Lexer
@@ -24,14 +24,15 @@ import System.Exit (exitFailure, exitSuccess)
 import System.FilePath ((</>))
 
 data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
+
 data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail deriving (Eq, Show)
 
 data CaseMeta = CaseMeta
-  { caseId :: !String
-  , caseCategory :: !String
-  , casePath :: !FilePath
-  , caseExpected :: !Expected
-  , caseReason :: !String
+  { caseId :: !String,
+    caseCategory :: !String,
+    casePath :: !FilePath,
+    caseExpected :: !Expected,
+    caseReason :: !String
   }
   deriving (Eq, Show)
 
@@ -163,28 +164,28 @@ parseRow row =
 
 parseRowWithReason :: Text -> Text -> Text -> Text -> Text -> IO CaseMeta
 parseRowWithReason cid cat pathTxt expectedTxt reasonTxt = do
-      let path = T.unpack pathTxt
-      exists <- doesFileExist (fixtureRoot </> path)
-      if not exists
-        then fail ("Manifest references missing case file: " <> path)
-        else do
-          expected <-
-            case expectedTxt of
-              "pass" -> pure ExpectPass
-              "xfail" -> pure ExpectXFail
-              _ -> fail ("Unknown expected value in manifest: " <> T.unpack expectedTxt)
-          let reason = trim (T.unpack reasonTxt)
-          case expected of
-            ExpectXFail | null reason -> fail ("xfail case requires a reason: " <> T.unpack cid)
-            _ -> pure ()
-          pure
-            CaseMeta
-              { caseId = T.unpack cid
-              , caseCategory = T.unpack cat
-              , casePath = path
-              , caseExpected = expected
-              , caseReason = reason
-              }
+  let path = T.unpack pathTxt
+  exists <- doesFileExist (fixtureRoot </> path)
+  if not exists
+    then fail ("Manifest references missing case file: " <> path)
+    else do
+      expected <-
+        case expectedTxt of
+          "pass" -> pure ExpectPass
+          "xfail" -> pure ExpectXFail
+          _ -> fail ("Unknown expected value in manifest: " <> T.unpack expectedTxt)
+      let reason = trim (T.unpack reasonTxt)
+      case expected of
+        ExpectXFail | null reason -> fail ("xfail case requires a reason: " <> T.unpack cid)
+        _ -> pure ()
+      pure
+        CaseMeta
+          { caseId = T.unpack cid,
+            caseCategory = T.unpack cat,
+            casePath = path,
+            caseExpected = expected,
+            caseReason = reason
+          }
 
 trim :: String -> String
 trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Parser
-  ( parseExpr
-  , parseModule
-  , defaultConfig
-  ) where
+  ( parseExpr,
+    parseModule,
+    defaultConfig,
+  )
+where
 
 import Data.Char (isAlphaNum)
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -16,18 +17,18 @@ import Data.Void (Void)
 import Parser.Ast
 import Parser.Types
 import Text.Megaparsec
-  ( Parsec
-  , choice
-  , errorOffset
-  , eof
-  , many
-  , notFollowedBy
-  , parse
-  , runParser
-  , sepBy1
-  , some
-  , try
-  , (<|>)
+  ( Parsec,
+    choice,
+    eof,
+    errorOffset,
+    many,
+    notFollowedBy,
+    parse,
+    runParser,
+    sepBy1,
+    some,
+    try,
+    (<|>),
   )
 import qualified Text.Megaparsec as MP
 import qualified Text.Megaparsec.Char as C
@@ -63,11 +64,11 @@ parseModuleLines cfg input = do
     ((firstLineNo, firstLine) : rest) ->
       case parseModuleHeader firstLine of
         Right modName -> do
-          decls <- traverse (\(lineNo, lineText) -> parseDeclarationLine lineNo lineText) rest
+          decls <- traverse (uncurry parseDeclarationLine) rest
           Right Module {moduleName = Just modName, moduleDecls = decls}
         Left _ -> do
           firstDecl <- parseDeclarationLine firstLineNo firstLine
-          otherDecls <- traverse (\(lineNo, lineText) -> parseDeclarationLine lineNo lineText) rest
+          otherDecls <- traverse (uncurry parseDeclarationLine) rest
           Right Module {moduleName = Nothing, moduleDecls = firstDecl : otherDecls}
 
 parseModuleHeader :: Text -> Either ParseError Text
@@ -88,8 +89,8 @@ parseDeclarationLine lineNo raw =
     Left err ->
       Left
         err
-          { line = lineNo
-          , offset = 0
+          { line = lineNo,
+            offset = 0
           }
 
 parseLineWith :: MParser a -> Text -> Either ParseError a
@@ -214,14 +215,14 @@ bundleToError input bundle =
           foundTok = tokenAt input off
           expectedItems = toExpectations firstErr
        in ParseError
-            { offset = off
-            , line = ln
-            , col = cl
-            , expected =
+            { offset = off,
+              line = ln,
+              col = cl,
+              expected =
                 if null expectedItems
                   then ["valid syntax"]
-                  else expectedItems
-            , found = foundTok
+                  else expectedItems,
+              found = foundTok
             }
 
 toExpectations :: MP.ParseError Text Void -> [Text]

--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -1,24 +1,26 @@
 module Parser.Ast
-  ( Decl (..)
-  , Expr (..)
-  , Module (..)
-  ) where
+  ( Decl (..),
+    Expr (..),
+    Module (..),
+  )
+where
 
 import Data.Text (Text)
 
 data Module = Module
-  { moduleName :: Maybe Text
-  , moduleDecls :: [Decl]
+  { moduleName :: Maybe Text,
+    moduleDecls :: [Decl]
   }
   deriving (Eq, Show)
 
-data Decl = Decl
-  { declName :: Text
-  , declExpr :: Expr
-  }
+data Decl
+  = Decl
+      { declName :: Text,
+        declExpr :: Expr
+      }
   | DataDecl
-      { dataTypeName :: Text
-      , dataConstructors :: [Text]
+      { dataTypeName :: Text,
+        dataConstructors :: [Text]
       }
   deriving (Eq, Show)
 

--- a/components/haskell-parser/src/Parser/Canonical.hs
+++ b/components/haskell-parser/src/Parser/Canonical.hs
@@ -1,29 +1,30 @@
 module Parser.Canonical
-  ( CanonicalDecl (..)
-  , CanonicalExpr (..)
-  , CanonicalModule (..)
-  , normalizeDecl
-  , normalizeExpr
-  , normalizeModule
-  ) where
+  ( CanonicalDecl (..),
+    CanonicalExpr (..),
+    CanonicalModule (..),
+    normalizeDecl,
+    normalizeExpr,
+    normalizeModule,
+  )
+where
 
 import Data.Text (Text)
 import Parser.Ast
 
 data CanonicalModule = CanonicalModule
-  { canonicalModuleName :: Maybe Text
-  , canonicalDecls :: [CanonicalDecl]
+  { canonicalModuleName :: Maybe Text,
+    canonicalDecls :: [CanonicalDecl]
   }
   deriving (Eq, Show)
 
 data CanonicalDecl
   = CanonicalValueDecl
-      { canonicalDeclName :: Text
-      , canonicalDeclExpr :: CanonicalExpr
+      { canonicalDeclName :: Text,
+        canonicalDeclExpr :: CanonicalExpr
       }
   | CanonicalDataDecl
-      { canonicalTypeName :: Text
-      , canonicalConstructors :: [Text]
+      { canonicalTypeName :: Text,
+        canonicalConstructors :: [Text]
       }
   deriving (Eq, Show)
 
@@ -36,8 +37,8 @@ data CanonicalExpr
 normalizeModule :: Module -> CanonicalModule
 normalizeModule m =
   CanonicalModule
-    { canonicalModuleName = moduleName m
-    , canonicalDecls = fmap normalizeDecl (moduleDecls m)
+    { canonicalModuleName = moduleName m,
+      canonicalDecls = fmap normalizeDecl (moduleDecls m)
     }
 
 normalizeDecl :: Decl -> CanonicalDecl
@@ -45,13 +46,13 @@ normalizeDecl d =
   case d of
     Decl {declName = name, declExpr = expr} ->
       CanonicalValueDecl
-        { canonicalDeclName = name
-        , canonicalDeclExpr = normalizeExpr expr
+        { canonicalDeclName = name,
+          canonicalDeclExpr = normalizeExpr expr
         }
     DataDecl {dataTypeName = typeName, dataConstructors = ctors} ->
       CanonicalDataDecl
-        { canonicalTypeName = typeName
-        , canonicalConstructors = ctors
+        { canonicalTypeName = typeName,
+          canonicalConstructors = ctors
         }
 
 normalizeExpr :: Expr -> CanonicalExpr

--- a/components/haskell-parser/src/Parser/Types.hs
+++ b/components/haskell-parser/src/Parser/Types.hs
@@ -1,26 +1,27 @@
 module Parser.Types
-  ( CoverageSlice (..)
-  , Expectation
-  , ParseError (..)
-  , ParseResult (..)
-  , ParserConfig (..)
-  ) where
+  ( CoverageSlice (..),
+    Expectation,
+    ParseError (..),
+    ParseResult (..),
+    ParserConfig (..),
+  )
+where
 
 import Data.Text (Text)
 
 type Expectation = Text
 
-data ParserConfig = ParserConfig
+newtype ParserConfig = ParserConfig
   { allowLineComments :: Bool
   }
   deriving (Eq, Show)
 
 data ParseError = ParseError
-  { offset :: !Int
-  , line :: !Int
-  , col :: !Int
-  , expected :: ![Expectation]
-  , found :: !(Maybe Text)
+  { offset :: !Int,
+    line :: !Int,
+    col :: !Int,
+    expected :: ![Expectation],
+    found :: !(Maybe Text)
   }
   deriving (Eq, Show)
 

--- a/components/haskell-parser/test/Spec.hs
+++ b/components/haskell-parser/test/Spec.hs
@@ -12,12 +12,12 @@ import Parser.Canonical
 import Parser.Types (ParseResult (..))
 import System.Directory (listDirectory)
 import System.FilePath ((</>))
+import Test.H2010.Suite (h2010Tests)
+import Test.Oracle
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.HUnit
 import qualified Test.Tasty.QuickCheck as QC
-import Test.H2010.Suite (h2010Tests)
-import Test.Oracle
 
 main :: IO ()
 main = buildTests >>= defaultMain
@@ -34,10 +34,10 @@ buildTests = do
   pure $
     testGroup
       "aihc-parser"
-      [ testGroup "golden" [exprOk, exprErr, moduleOk, moduleErr]
-      , testGroup "differential-fixtures" [diffModule, regressions]
-      , testGroup "properties" [QC.testProperty "generated modules agree with ghc oracle" prop_moduleAgreement]
-      , h2010
+      [ testGroup "golden" [exprOk, exprErr, moduleOk, moduleErr],
+        testGroup "differential-fixtures" [diffModule, regressions],
+        testGroup "properties" [QC.testProperty "generated modules agree with ghc oracle" prop_moduleAgreement],
+        h2010
       ]
 
 goldenGroup :: FilePath -> (Text -> Assertion) -> IO TestTree
@@ -121,28 +121,28 @@ genIdent = do
 
 reservedWords :: [Text]
 reservedWords =
-  [ "_"
-  , "case"
-  , "class"
-  , "data"
-  , "default"
-  , "deriving"
-  , "do"
-  , "else"
-  , "if"
-  , "import"
-  , "in"
-  , "infix"
-  , "infixl"
-  , "infixr"
-  , "instance"
-  , "let"
-  , "module"
-  , "newtype"
-  , "of"
-  , "then"
-  , "type"
-  , "where"
+  [ "_",
+    "case",
+    "class",
+    "data",
+    "default",
+    "deriving",
+    "do",
+    "else",
+    "if",
+    "import",
+    "in",
+    "infix",
+    "infixl",
+    "infixr",
+    "instance",
+    "let",
+    "module",
+    "newtype",
+    "of",
+    "then",
+    "type",
+    "where"
   ]
 
 data GenExpr
@@ -156,9 +156,9 @@ genExpr depth
   | depth <= 0 = oneof [GVar <$> genIdent, GInt <$> chooseInteger (0, 999)]
   | otherwise =
       frequency
-        [ (3, GVar <$> genIdent)
-        , (3, GInt <$> chooseInteger (0, 999))
-        , (4, GApp <$> genExpr (depth - 1) <*> genExpr (depth - 1))
+        [ (3, GVar <$> genIdent),
+          (3, GInt <$> chooseInteger (0, 999)),
+          (4, GApp <$> genExpr (depth - 1) <*> genExpr (depth - 1))
         ]
 
 renderModule :: GenModule -> Text

--- a/components/haskell-parser/test/Test/H2010/Suite.hs
+++ b/components/haskell-parser/test/Test/H2010/Suite.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.H2010.Suite
-  ( h2010Tests
-  ) where
+  ( h2010Tests,
+  )
+where
 
+import Control.Monad (when)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import Data.Text (Text)
@@ -30,11 +32,11 @@ data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
 data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail deriving (Eq, Show)
 
 data CaseMeta = CaseMeta
-  { caseId :: !String
-  , caseCategory :: !String
-  , casePath :: !FilePath
-  , caseExpected :: !Expected
-  , caseReason :: !String
+  { caseId :: !String,
+    caseCategory :: !String,
+    casePath :: !FilePath,
+    caseExpected :: !Expected,
+    caseReason :: !String
   }
   deriving (Eq, Show)
 
@@ -64,23 +66,21 @@ mkSummaryTest cases = do
       let (passN, xfailN, xpassN, failN) = foldr countOutcome (0, 0, 0, 0) outcomes
           totalN = passN + xfailN + xpassN + failN
           completion = pct (passN + xpassN) totalN
-      if failN > 0
-        then
-          assertFailure
-            ( "Haskell2010 regressions found. "
-                <> "pass="
-                <> show passN
-                <> " xfail="
-                <> show xfailN
-                <> " xpass="
-                <> show xpassN
-                <> " fail="
-                <> show failN
-                <> " completion="
-                <> show completion
-                <> "%"
-            )
-        else pure ()
+      when (failN > 0) $
+        assertFailure
+          ( "Haskell2010 regressions found. "
+              <> "pass="
+              <> show passN
+              <> " xfail="
+              <> show xfailN
+              <> " xpass="
+              <> show xpassN
+              <> " fail="
+              <> show failN
+              <> " completion="
+              <> show completion
+              <> "%"
+          )
 
 countOutcome :: Outcome -> (Int, Int, Int, Int) -> (Int, Int, Int, Int)
 countOutcome outcome (passN, xfailN, xpassN, failN) =
@@ -179,28 +179,28 @@ parseRow row =
 
 parseRowWithReason :: Text -> Text -> Text -> Text -> Text -> IO CaseMeta
 parseRowWithReason cid cat pathTxt expectedTxt reasonTxt = do
-      let path = T.unpack pathTxt
-      exists <- doesFileExist (fixtureRoot </> path)
-      if not exists
-        then fail ("Manifest references missing case file: " <> path)
-        else do
-          expected <-
-            case expectedTxt of
-              "pass" -> pure ExpectPass
-              "xfail" -> pure ExpectXFail
-              _ -> fail ("Unknown expected value in manifest: " <> T.unpack expectedTxt)
-          let reason = trim (T.unpack reasonTxt)
-          case expected of
-            ExpectXFail | null reason -> fail ("xfail case requires a reason: " <> T.unpack cid)
-            _ -> pure ()
-          pure
-            CaseMeta
-              { caseId = T.unpack cid
-              , caseCategory = T.unpack cat
-              , casePath = path
-              , caseExpected = expected
-              , caseReason = reason
-              }
+  let path = T.unpack pathTxt
+  exists <- doesFileExist (fixtureRoot </> path)
+  if not exists
+    then fail ("Manifest references missing case file: " <> path)
+    else do
+      expected <-
+        case expectedTxt of
+          "pass" -> pure ExpectPass
+          "xfail" -> pure ExpectXFail
+          _ -> fail ("Unknown expected value in manifest: " <> T.unpack expectedTxt)
+      let reason = trim (T.unpack reasonTxt)
+      case expected of
+        ExpectXFail | null reason -> fail ("xfail case requires a reason: " <> T.unpack cid)
+        _ -> pure ()
+      pure
+        CaseMeta
+          { caseId = T.unpack cid,
+            caseCategory = T.unpack cat,
+            casePath = path,
+            caseExpected = expected,
+            caseReason = reason
+          }
 
 trim :: String -> String
 trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/components/haskell-parser/test/Test/Oracle.hs
+++ b/components/haskell-parser/test/Test/Oracle.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Oracle
-  ( oracleCanonicalModule
-  , oracleParsesModule
-  ) where
+  ( oracleCanonicalModule,
+    oracleParsesModule,
+  )
+where
 
 import Data.Bifunctor (first)
 import Data.Foldable (toList)
@@ -16,19 +17,18 @@ import GHC.Hs
 import GHC.LanguageExtensions.Type (Extension)
 import GHC.Parser (parseModule)
 import GHC.Parser.Lexer
-  ( ParseResult (..)
-  , getPsErrorMessages
-  , initParserState
-  , mkParserOpts
-  , unP
+  ( ParseResult (..),
+    getPsErrorMessages,
+    initParserState,
+    mkParserOpts,
+    unP,
   )
+import GHC.Types.Error (NoDiagnosticOpts (NoDiagnosticOpts))
 import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Types.Name.Reader (rdrNameOcc)
-import GHC.Types.Error (NoDiagnosticOpts (NoDiagnosticOpts))
 import GHC.Types.SourceText (IntegralLit (..))
 import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
-import GHC.Utils.Error (pprMessages)
-import GHC.Utils.Error (emptyDiagOpts)
+import GHC.Utils.Error (emptyDiagOpts, pprMessages)
 import GHC.Utils.Outputable (showSDocUnsafe)
 import Parser.Canonical
 
@@ -59,39 +59,38 @@ toCanonicalModule modu = do
   decls <- traverse toCanonicalDecl (hsmodDecls modu)
   pure
     CanonicalModule
-      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu)
-      , canonicalDecls = decls
+      { canonicalModuleName = fmap (T.pack . moduleNameString . unLoc) (hsmodName modu),
+        canonicalDecls = decls
       }
 
 toCanonicalDecl :: LHsDecl GhcPs -> Either String CanonicalDecl
 toCanonicalDecl locatedDecl =
   let decl = unLoc locatedDecl
-   in
-  case decl of
-    ValD _ bind ->
-      case bind of
-        FunBind {fun_id = locatedName, fun_matches = MG {mg_alts = locatedMatches}} -> do
-          let name = unLoc locatedName
-              matches = unLoc locatedMatches
-          match <- case matches of
-            [singleMatch] -> Right (unLoc singleMatch)
-            _ -> Left "unsupported multiple matches"
-          expr <- case m_grhss match of
-            GRHSs _ grhss _ ->
-              case toList grhss of
-                [grhs] ->
-                  case unLoc grhs of
-                    GRHS _ [] body -> toCanonicalExpr (unLoc body)
-                    _ -> Left "unsupported guarded rhs"
+   in case decl of
+        ValD _ bind ->
+          case bind of
+            FunBind {fun_id = locatedName, fun_matches = MG {mg_alts = locatedMatches}} -> do
+              let name = unLoc locatedName
+                  matches = unLoc locatedMatches
+              match <- case matches of
+                [singleMatch] -> Right (unLoc singleMatch)
+                _ -> Left "unsupported multiple matches"
+              expr <- case m_grhss match of
+                GRHSs _ grhss _ ->
+                  case toList grhss of
+                    [grhs] ->
+                      case unLoc grhs of
+                        GRHS _ [] body -> toCanonicalExpr (unLoc body)
+                        _ -> Left "unsupported guarded rhs"
+                    _ -> Left "unsupported function rhs"
                 _ -> Left "unsupported function rhs"
-            _ -> Left "unsupported function rhs"
-          pure
-            CanonicalValueDecl
-              { canonicalDeclName = T.pack (occNameString (rdrNameOcc name))
-              , canonicalDeclExpr = expr
-              }
-        _ -> Left "unsupported value binding"
-    _ -> Left "unsupported declaration kind"
+              pure
+                CanonicalValueDecl
+                  { canonicalDeclName = T.pack (occNameString (rdrNameOcc name)),
+                    canonicalDeclExpr = expr
+                  }
+            _ -> Left "unsupported value binding"
+        _ -> Left "unsupported declaration kind"
 
 toCanonicalExpr :: HsExpr GhcPs -> Either String CanonicalExpr
 toCanonicalExpr expr =

--- a/flake.nix
+++ b/flake.nix
@@ -110,13 +110,45 @@
           parserTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgs.aihc-parser);
           nameResolutionTests =
             pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgs.aihc-name-resolution);
+          nixLint = pkgs.runCommand "aihc-nix-lint" {
+            src = ./.;
+            nativeBuildInputs = [ pkgs.statix ];
+          } ''
+            cd "$src"
+            statix check flake.nix
+            touch "$out"
+          '';
+          haskellLint = pkgs.runCommand "aihc-haskell-lint" {
+            src = ./.;
+            nativeBuildInputs = [ pkgs.haskellPackages.hlint ];
+          } ''
+            cd "$src"
+            find components -type f -name '*.hs' ! -path '*/test/Test/Fixtures/*' -print0 \
+              | xargs -0 -r hlint
+            touch "$out"
+          '';
+          haskellFormat = pkgs.runCommand "aihc-haskell-format" {
+            src = ./.;
+            nativeBuildInputs = [ pkgs.haskellPackages.ormolu ];
+          } ''
+            cd "$src"
+            find components -type f -name '*.hs' ! -path '*/test/Test/Fixtures/*' -print0 \
+              | xargs -0 -r ormolu --mode check
+            touch "$out"
+          '';
         in {
           parser-tests = parserTests;
           name-resolution-tests = nameResolutionTests;
+          nix-lint = nixLint;
+          haskell-lint = haskellLint;
+          haskell-format = haskellFormat;
           all-tests =
             pkgs.linkFarm "aihc-all-tests" [
               { name = "parser-tests"; path = parserTests; }
               { name = "name-resolution-tests"; path = nameResolutionTests; }
+              { name = "nix-lint"; path = nixLint; }
+              { name = "haskell-lint"; path = haskellLint; }
+              { name = "haskell-format"; path = haskellFormat; }
             ];
         });
     };


### PR DESCRIPTION
## Summary

This PR adds linting/format validation to `nix flake check`:

- `statix` for Nix files
- `hlint` for Haskell files
- `ormolu --mode check` for Haskell formatting

The new checks are exposed as:

- `checks.<system>.nix-lint`
- `checks.<system>.haskell-lint`
- `checks.<system>.haskell-format`

and included in `checks.<system>.all-tests`.

## Notes

- Haskell fixture files under `test/Test/Fixtures` are excluded from `hlint`/`ormolu` checks because many are intentionally parser test inputs, not normal module code.
- Non-fixture Haskell files were formatted with `ormolu`, and minor `hlint` suggestions were applied.

## Verification

- `nix flake check`
- `nix run .#parser-progress`
- `nix run .#name-resolution-progress`
