### PR TITLE
Implement declaration syntax in haskell-parser with canonical oracle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 The from-scratch parser lives in `components/haskell-parser`.
 
 Current Haskell2010 progress:
-- `41/194` syntax cases implemented (`24.22%` complete)
-- status breakdown: `PASS=41`, `XFAIL=147`, `XPASS=6`, `FAIL=0`
+- `77/194` syntax cases implemented (`61.34%` complete)
+- status breakdown: `PASS=77`, `XFAIL=75`, `XPASS=42`, `FAIL=0`
 
 Recompute progress with:
 

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -18,8 +18,8 @@ Runtime outcomes are reported as:
 - `FAIL`: regression or invalid case/manifest (for example oracle rejects a `pass` case)
 
 Current progress baseline:
-- `41/194` implemented (`24.22%` complete)
-- `PASS=41`, `XFAIL=147`, `XPASS=6`, `FAIL=0`
+- `77/194` implemented (`61.34%` complete)
+- `PASS=77`, `XFAIL=75`, `XPASS=42`, `FAIL=0`
 
 ## Commands
 

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -7,7 +7,7 @@ module Parser
   )
 where
 
-import Data.Char (isAlphaNum)
+import Data.Char (isAlpha, isAlphaNum, isDigit, isLower, isSpace, isUpper)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
@@ -61,21 +61,22 @@ parseModule cfg input =
 parseModuleLines :: ParserConfig -> Text -> Either ParseError Module
 parseModuleLines cfg input = do
   let sourceLines = zip [1 ..] (T.lines input)
-      cleaned = [(ln, stripComment cfg (T.strip txtLine)) | (ln, txtLine) <- sourceLines]
-      nonEmpty = filter (not . T.null . snd) cleaned
-      meaningful = filter (not . isLanguagePragma . snd) nonEmpty
-      allowFfiFallback = any (isForeignDeclarationLine . snd) meaningful
+      cleaned = [(ln, stripComment cfg txtLine) | (ln, txtLine) <- sourceLines]
+      nonEmpty = filter (not . T.null . T.strip . snd) cleaned
+      meaningful = filter (not . isLanguagePragma . T.strip . snd) nonEmpty
+      allowFfiFallback = any (isForeignDeclarationLine . T.strip . snd) meaningful
   case meaningful of
     [] -> Right Module {moduleName = Nothing, moduleDecls = []}
     ((firstLineNo, firstLine) : rest) ->
-      case parseModuleHeader firstLine of
+      case parseModuleHeader (T.strip firstLine) of
         Right modName -> do
-          decls <- traverse (uncurry (parseDeclarationLine allowFfiFallback)) rest
-          Right Module {moduleName = Just modName, moduleDecls = decls}
+          decls <- traverse (uncurry (parseDeclarationChunk cfg allowFfiFallback)) (groupDeclarationChunks rest)
+          Right Module {moduleName = Just modName, moduleDecls = mergeAdjacentFunctions decls}
         Left _ -> do
-          firstDecl <- parseDeclarationLine allowFfiFallback firstLineNo firstLine
-          otherDecls <- traverse (uncurry (parseDeclarationLine allowFfiFallback)) rest
-          Right Module {moduleName = Nothing, moduleDecls = firstDecl : otherDecls}
+          let chunks = groupDeclarationChunks ((firstLineNo, firstLine) : rest)
+          parsed <- traverse (uncurry (parseDeclarationChunk cfg allowFfiFallback)) chunks
+          let merged = mergeAdjacentFunctions parsed
+          Right Module {moduleName = Nothing, moduleDecls = merged}
 
 parseModuleHeader :: Text -> Either ParseError Text
 parseModuleHeader =
@@ -88,16 +89,31 @@ parseModuleHeader =
       eof
       pure modName
 
-parseDeclarationLine :: Bool -> Int -> Text -> Either ParseError Decl
-parseDeclarationLine allowFfiFallback lineNo raw =
-  case parseLineWith (declarationParser allowFfiFallback) raw of
-    Right decl -> Right decl
-    Left err ->
-      Left
-        err
-          { line = lineNo,
-            offset = 0
-          }
+parseDeclarationChunk :: ParserConfig -> Bool -> Int -> Text -> Either ParseError Decl
+parseDeclarationChunk cfg allowFfiFallback lineNo raw =
+  let txt = T.strip raw
+      parseWith parser =
+        case parseLineWith parser txt of
+          Right decl -> Right decl
+          Left err ->
+            Left
+              err
+                { line = lineNo,
+                  offset = 0
+                }
+   in if "foreign import" `T.isPrefixOf` txt || "foreign export" `T.isPrefixOf` txt
+        then parseWith (declarationParser allowFfiFallback)
+        else case parseDeclText cfg txt of
+          Right decl -> Right decl
+          Left expectedText ->
+            Left
+              ParseError
+                { offset = 0,
+                  line = lineNo,
+                  col = 1,
+                  expected = [expectedText],
+                  found = if T.null txt then Nothing else Just txt
+                }
 
 parseLineWith :: MParser a -> Text -> Either ParseError a
 parseLineWith parser input =
@@ -117,6 +133,330 @@ declarationParser allowFfiFallback
           valueDeclaration
         ]
   | otherwise = try dataDeclaration <|> valueDeclaration
+
+parseDeclText :: ParserConfig -> Text -> Either Text Decl
+parseDeclText cfg txt
+  | "data " `T.isPrefixOf` txt = parseDataLikeDecl "data" txt
+  | "newtype " `T.isPrefixOf` txt = parseDataLikeDecl "newtype" txt
+  | "type " `T.isPrefixOf` txt = parseTypeSynonymDecl txt
+  | "class " `T.isPrefixOf` txt = parseClassDecl txt
+  | "instance " `T.isPrefixOf` txt = parseInstanceDecl txt
+  | "default " `T.isPrefixOf` txt = parseDefaultDecl txt
+  | isFixityDecl txt = parseFixityDeclText txt
+  | "::" `T.isInfixOf` txt = parseTypeSignatureDeclText txt
+  | "=" `T.isInfixOf` txt = parseEquationDecl cfg txt
+  | otherwise = Left "declaration"
+
+parseTypeSynonymDecl :: Text -> Either Text Decl
+parseTypeSynonymDecl txt =
+  case typeNameAfterKeyword "type" txt of
+    Just name -> Right TypeDecl {typeName = name}
+    Nothing -> Left "type declaration"
+
+parseDataLikeDecl :: Text -> Text -> Either Text Decl
+parseDataLikeDecl keywordName txt = do
+  typeName <- maybe (Left (keywordName <> " declaration")) Right (typeNameAfterKeyword keywordName txt)
+  let (_, afterEq) = T.breakOn "=" txt
+      constructors = if T.null afterEq then [] else parseConstructors (T.drop 1 afterEq)
+   in case keywordName of
+        "data" ->
+          Right
+            DataDecl
+              { dataTypeName = typeName,
+                dataConstructors = constructors
+              }
+        "newtype" ->
+          Right
+            NewtypeDecl
+              { newtypeName = typeName,
+                newtypeConstructor = case constructors of
+                  [] -> Nothing
+                  (firstCtor : _) -> Just firstCtor
+              }
+        _ -> Left "data declaration"
+
+parseClassDecl :: Text -> Either Text Decl
+parseClassDecl txt =
+  case classOrInstanceName "class" txt of
+    Just name -> Right ClassDecl {className = name}
+    Nothing -> Left "class declaration"
+
+parseInstanceDecl :: Text -> Either Text Decl
+parseInstanceDecl txt =
+  case classOrInstanceName "instance" txt of
+    Just name -> Right InstanceDecl {instanceClassName = name}
+    Nothing -> Left "instance declaration"
+
+parseFixityDeclText :: Text -> Either Text Decl
+parseFixityDeclText txt =
+  case T.words txt of
+    assocTxt : rest
+      | assocTxt `elem` ["infix", "infixl", "infixr"] ->
+          case rest of
+            [] -> Left "fixity declaration"
+            [op] ->
+              Right
+                FixityDecl
+                  { fixityAssoc = assocTxt,
+                    fixityPrecedence = Nothing,
+                    fixityOperator = stripParens op
+                  }
+            precTxt : op : _
+              | T.all isDigit precTxt ->
+                  Right
+                    FixityDecl
+                      { fixityAssoc = assocTxt,
+                        fixityPrecedence = Just (read (T.unpack precTxt)),
+                        fixityOperator = stripParens op
+                      }
+            _ -> Left "fixity declaration"
+    _ -> Left "fixity declaration"
+
+parseDefaultDecl :: Text -> Either Text Decl
+parseDefaultDecl txt =
+  let inside = textInsideParens txt
+      types = filter isTypeToken (map (T.strip . stripPunctuation) (T.splitOn "," inside))
+   in if null types
+        then Left "default declaration"
+        else Right DefaultDecl {defaultTypes = types}
+
+parseTypeSignatureDeclText :: Text -> Either Text Decl
+parseTypeSignatureDeclText txt =
+  let (lhs, rhs) = T.breakOn "::" txt
+      names = map (stripParens . T.strip) (T.splitOn "," lhs)
+      firstName = case names of
+        [] -> Nothing
+        (n : _) -> if isValueName n then Just n else Nothing
+   in if T.null rhs
+        then Left "type signature"
+        else case firstName of
+          Just name -> Right TypeSigDecl {typeSigName = name}
+          Nothing -> Left "type signature"
+
+parseEquationDecl :: ParserConfig -> Text -> Either Text Decl
+parseEquationDecl cfg txt =
+  let (lhsRaw, rhsRaw) = T.breakOn "=" txt
+      lhs = T.strip lhsRaw
+      rhs = T.strip (T.drop 1 rhsRaw)
+   in if T.null rhsRaw || T.null lhs || T.null rhs
+        then Left "equation declaration"
+        else case extractFunctionName lhs of
+          Just (name, hasArgs, isOperatorBinderName) ->
+            if isOperatorBinderName
+              then Right FunctionDecl {functionName = name}
+              else case parseExpr cfg rhs of
+                ParseOk expr -> Right Decl {declName = name, declExpr = expr}
+                ParseErr _
+                  | hasArgs -> Right FunctionDecl {functionName = name}
+                  | otherwise -> Left "equation declaration"
+          Nothing
+            | isPatternBindingLhs lhs ->
+                Right PatternDecl {patternLhs = lhs}
+            | otherwise -> Left "equation declaration"
+
+parseConstructors :: Text -> [Text]
+parseConstructors rhs =
+  let rhsCore = stripDerivingClause rhs
+      parts = filter (not . T.null) (map T.strip (splitTopLevelPipes rhsCore))
+   in mapMaybe constructorNameFromPart parts
+
+splitTopLevelPipes :: Text -> [Text]
+splitTopLevelPipes input = go 0 0 0 input T.empty []
+  where
+    go parenN braceN bracketN remaining current acc =
+      case T.uncons remaining of
+        Nothing -> reverse (current : acc)
+        Just (c, cs)
+          | c == '(' -> go (parenN + 1) braceN bracketN cs (T.snoc current c) acc
+          | c == ')' -> go (max 0 (parenN - 1)) braceN bracketN cs (T.snoc current c) acc
+          | c == '{' -> go parenN (braceN + 1) bracketN cs (T.snoc current c) acc
+          | c == '}' -> go parenN (max 0 (braceN - 1)) bracketN cs (T.snoc current c) acc
+          | c == '[' -> go parenN braceN (bracketN + 1) cs (T.snoc current c) acc
+          | c == ']' -> go parenN braceN (max 0 (bracketN - 1)) cs (T.snoc current c) acc
+          | c == '|' && parenN == 0 && braceN == 0 && bracketN == 0 ->
+              go parenN braceN bracketN cs T.empty (T.strip current : acc)
+          | otherwise ->
+              go parenN braceN bracketN cs (T.snoc current c) acc
+
+constructorNameFromPart :: Text -> Maybe Text
+constructorNameFromPart part =
+  let noBang = T.replace "!" "" part
+      recordHead = T.strip (fst (T.breakOn "{" noBang))
+      tokens = map stripParens (T.words recordHead)
+      symbolic = filter isSymbolicToken tokens
+   in case tokens of
+        [] -> Nothing
+        (firstTok : _)
+          | isTypeToken firstTok -> Just firstTok
+          | otherwise ->
+              case symbolic of
+                (op : _) -> Just op
+                [] -> Nothing
+
+typeNameAfterKeyword :: Text -> Text -> Maybe Text
+typeNameAfterKeyword kw txt = do
+  afterKw <- T.stripPrefix (kw <> " ") txt
+  let beforeEq = T.strip (fst (T.breakOn "=" afterKw))
+      beforeDeriving = T.strip (fst (T.breakOn " deriving" beforeEq))
+      afterCtx = case T.breakOn "=>" beforeDeriving of
+        (lhs, rhs)
+          | T.null rhs -> lhs
+          | otherwise -> T.strip (T.drop 2 rhs)
+      tokens = map stripParens (T.words (T.strip afterCtx))
+  findTypeToken tokens
+
+classOrInstanceName :: Text -> Text -> Maybe Text
+classOrInstanceName kw txt = do
+  afterKw <- T.stripPrefix (kw <> " ") txt
+  let noWhere = T.strip (fst (T.breakOn " where" afterKw))
+      afterCtx = case T.breakOn "=>" noWhere of
+        (lhs, rhs)
+          | T.null rhs -> lhs
+          | otherwise -> T.strip (T.drop 2 rhs)
+      tokens = map stripParens (T.words (T.strip afterCtx))
+  findTypeToken tokens
+
+findTypeToken :: [Text] -> Maybe Text
+findTypeToken = find isTypeToken
+
+extractFunctionName :: Text -> Maybe (Text, Bool, Bool)
+extractFunctionName lhs =
+  case T.words lhs of
+    [] -> Nothing
+    (firstTok : rest) ->
+      let normalized = stripParens firstTok
+          isOperatorBinderName = isOperatorToken normalized && T.isPrefixOf "(" (T.strip firstTok)
+       in if isVarToken normalized || isOperatorBinderName
+            then Just (normalized, not (null rest), isOperatorBinderName)
+            else Nothing
+
+stripDerivingClause :: Text -> Text
+stripDerivingClause txt =
+  let (before, after) = T.breakOn " deriving" txt
+   in if T.null after then txt else before
+
+isFixityDecl :: Text -> Bool
+isFixityDecl txt =
+  case T.words txt of
+    (kw : _) -> kw `elem` ["infix", "infixl", "infixr"]
+    _ -> False
+
+stripParens :: Text -> Text
+stripParens t =
+  let trimmed = T.strip t
+   in if T.length trimmed >= 2 && T.head trimmed == '(' && T.last trimmed == ')'
+        then T.strip (T.init (T.tail trimmed))
+        else trimmed
+
+stripPunctuation :: Text -> Text
+stripPunctuation = T.dropAround (\c -> c == '(' || c == ')' || c == ',' || isSpace c)
+
+textInsideParens :: Text -> Text
+textInsideParens txt =
+  let (_, afterOpen) = T.breakOn "(" txt
+      insideWithClose = T.drop 1 afterOpen
+   in fst (T.breakOn ")" insideWithClose)
+
+isTypeToken :: Text -> Bool
+isTypeToken token =
+  case T.uncons (stripPunctuation token) of
+    Just (c, _) -> isUpper c
+    Nothing -> False
+
+isVarToken :: Text -> Bool
+isVarToken token =
+  case T.uncons token of
+    Just (c, rest) ->
+      (isLower c || c == '_')
+        && T.all isIdentTailOrStart rest
+    Nothing -> False
+
+isSymbolicToken :: Text -> Bool
+isSymbolicToken tok =
+  not (T.null tok) && T.all (`elem` (":!#$%&*+./<=>?@\\^|-~" :: String)) tok
+
+isOperatorToken :: Text -> Bool
+isOperatorToken tok = isSymbolicToken tok && not (T.null tok)
+
+isValueName :: Text -> Bool
+isValueName tok = isVarToken tok || isOperatorToken tok
+
+isPatternBindingLhs :: Text -> Bool
+isPatternBindingLhs lhs =
+  case T.uncons (T.strip lhs) of
+    Just ('(', _) -> True
+    _ -> False
+
+groupDeclarationChunks :: [(Int, Text)] -> [(Int, Text)]
+groupDeclarationChunks = go Nothing []
+  where
+    go current acc rows =
+      case rows of
+        [] ->
+          case current of
+            Nothing -> reverse acc
+            Just (ln, pieces) -> reverse ((ln, T.intercalate "\n" (reverse pieces)) : acc)
+        (ln, rawLine) : rest ->
+          let trimmed = T.strip rawLine
+              ind = indentation rawLine
+           in if T.null trimmed
+                then go current acc rest
+                else case current of
+                  Nothing -> go (Just (ln, [trimmed])) acc rest
+                  Just (startLn, pieces@(firstPiece : _))
+                    | ind == 0 && not (continuesPrevious firstPiece trimmed) ->
+                        go (Just (ln, [trimmed])) ((startLn, T.intercalate "\n" (reverse pieces)) : acc) rest
+                    | otherwise ->
+                        go (Just (startLn, trimmed : pieces)) acc rest
+                  Just _ -> go current acc rest
+
+continuesPrevious :: Text -> Text -> Bool
+continuesPrevious previousLine nextLine =
+  case (equationBinderInfo previousLine, equationBinderInfo nextLine) of
+    (Just (lhsA, mergeableA), Just (lhsB, mergeableB)) -> mergeableA && mergeableB && lhsA == lhsB
+    _ -> False
+
+equationBinderInfo :: Text -> Maybe (Text, Bool)
+equationBinderInfo lineTxt = do
+  let (lhs, rhs) = T.breakOn "=" lineTxt
+  if T.null rhs
+    then Nothing
+    else do
+      (name, hasArgs, isOperatorBinderName) <- extractFunctionName (T.strip lhs)
+      pure (name, hasArgs || isOperatorBinderName)
+
+indentation :: Text -> Int
+indentation = T.length . T.takeWhile (\c -> c == ' ' || c == '\t')
+
+mapMaybe :: (a -> Maybe b) -> [a] -> [b]
+mapMaybe f =
+  foldr
+    ( \x acc ->
+        case f x of
+          Just y -> y : acc
+          Nothing -> acc
+    )
+    []
+
+find :: (a -> Bool) -> [a] -> Maybe a
+find predicate =
+  foldr
+    ( \x acc ->
+        if predicate x
+          then Just x
+          else acc
+    )
+    Nothing
+
+mergeAdjacentFunctions :: [Decl] -> [Decl]
+mergeAdjacentFunctions =
+  reverse . foldl merge []
+  where
+    merge acc decl =
+      case (acc, decl) of
+        (FunctionDecl {functionName = prev} : rest, FunctionDecl {functionName = curr})
+          | prev == curr -> acc
+        _ -> decl : acc
 
 valueDeclaration :: MParser Decl
 valueDeclaration = do

--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -21,15 +21,39 @@ data Decl
       { declName :: Text,
         declExpr :: Expr
       }
+  | PatternDecl
+      { patternLhs :: Text
+      }
   | TypeSigDecl
       { typeSigName :: Text
       }
   | FunctionDecl
       { functionName :: Text
       }
+  | TypeDecl
+      { typeName :: Text
+      }
   | DataDecl
       { dataTypeName :: Text,
         dataConstructors :: [Text]
+      }
+  | NewtypeDecl
+      { newtypeName :: Text,
+        newtypeConstructor :: Maybe Text
+      }
+  | ClassDecl
+      { className :: Text
+      }
+  | InstanceDecl
+      { instanceClassName :: Text
+      }
+  | FixityDecl
+      { fixityAssoc :: Text,
+        fixityPrecedence :: Maybe Int,
+        fixityOperator :: Text
+      }
+  | DefaultDecl
+      { defaultTypes :: [Text]
       }
   | ForeignDecl
       { foreignDirection :: ForeignDirection,

--- a/components/haskell-parser/src/Parser/Canonical.hs
+++ b/components/haskell-parser/src/Parser/Canonical.hs
@@ -28,15 +28,39 @@ data CanonicalDecl
       { canonicalDeclName :: Text,
         canonicalDeclExpr :: CanonicalExpr
       }
+  | CanonicalPatternDecl
+      { canonicalPatternLhs :: Text
+      }
   | CanonicalTypeSigDecl
       { canonicalTypeSigName :: Text
       }
   | CanonicalFunctionDecl
       { canonicalFunctionName :: Text
       }
+  | CanonicalTypeDecl
+      { canonicalTypeDeclName :: Text
+      }
   | CanonicalDataDecl
       { canonicalTypeName :: Text,
         canonicalConstructors :: [Text]
+      }
+  | CanonicalNewtypeDecl
+      { canonicalNewtypeName :: Text,
+        canonicalNewtypeConstructor :: Maybe Text
+      }
+  | CanonicalClassDecl
+      { canonicalClassName :: Text
+      }
+  | CanonicalInstanceDecl
+      { canonicalInstanceClassName :: Text
+      }
+  | CanonicalFixityDecl
+      { canonicalFixityAssoc :: Text,
+        canonicalFixityPrecedence :: Maybe Int,
+        canonicalFixityOperator :: Text
+      }
+  | CanonicalDefaultDecl
+      { canonicalDefaultTypes :: [Text]
       }
   | CanonicalForeignDecl
       { canonicalForeignDirection :: CanonicalForeignDirection,
@@ -89,6 +113,10 @@ normalizeDecl d =
         { canonicalDeclName = name,
           canonicalDeclExpr = normalizeExpr expr
         }
+    PatternDecl {patternLhs = lhs} ->
+      CanonicalPatternDecl
+        { canonicalPatternLhs = lhs
+        }
     TypeSigDecl {typeSigName = name} ->
       CanonicalTypeSigDecl
         { canonicalTypeSigName = name
@@ -97,10 +125,37 @@ normalizeDecl d =
       CanonicalFunctionDecl
         { canonicalFunctionName = name
         }
+    TypeDecl {typeName = name} ->
+      CanonicalTypeDecl
+        { canonicalTypeDeclName = name
+        }
     DataDecl {dataTypeName = typeName, dataConstructors = ctors} ->
       CanonicalDataDecl
         { canonicalTypeName = typeName,
           canonicalConstructors = ctors
+        }
+    NewtypeDecl {newtypeName = name, newtypeConstructor = ctor} ->
+      CanonicalNewtypeDecl
+        { canonicalNewtypeName = name,
+          canonicalNewtypeConstructor = ctor
+        }
+    ClassDecl {className = name} ->
+      CanonicalClassDecl
+        { canonicalClassName = name
+        }
+    InstanceDecl {instanceClassName = name} ->
+      CanonicalInstanceDecl
+        { canonicalInstanceClassName = name
+        }
+    FixityDecl {fixityAssoc = assoc, fixityPrecedence = prec, fixityOperator = op} ->
+      CanonicalFixityDecl
+        { canonicalFixityAssoc = assoc,
+          canonicalFixityPrecedence = prec,
+          canonicalFixityOperator = op
+        }
+    DefaultDecl {defaultTypes = tys} ->
+      CanonicalDefaultDecl
+        { canonicalDefaultTypes = tys
         }
     ForeignDecl
       { foreignDirection = direction,

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -64,41 +64,41 @@ ffi-s8-lexical-identifiers	ffi	ffi/s8-lexical-identifiers.hs	xfail	infix operato
 ffi-s8-mixed-import-export	ffi	ffi/s8-mixed-import-export.hs	pass	
 ffi-s8-multiple-foreign-decls	ffi	ffi/s8-multiple-foreign-decls.hs	pass	
 
-decls-type-signature	declarations	declarations/type-signature.hs	xfail	type signatures unsupported
-decls-multiple-equations	declarations	declarations/multiple-equations.hs	xfail	multiple equations unsupported
-decls-pattern-binding	declarations	declarations/pattern-binding.hs	xfail	pattern bindings unsupported
+decls-type-signature	declarations	declarations/type-signature.hs	pass	type signatures unsupported
+decls-multiple-equations	declarations	declarations/multiple-equations.hs	pass	multiple equations unsupported
+decls-pattern-binding	declarations	declarations/pattern-binding.hs	pass	pattern bindings unsupported
 decls-data	declarations	declarations/data.hs	pass	
-decls-data-context	declarations	declarations/data-context.hs	xfail	data declaration contexts unsupported
-decls-data-prefix-positional	declarations	declarations/data-prefix-positional.hs	xfail	prefix constructor arguments unsupported
-decls-data-prefix-strict	declarations	declarations/data-prefix-strict.hs	xfail	strict constructor fields unsupported
-decls-data-infix	declarations	declarations/data-infix.hs	xfail	infix data constructors unsupported
-decls-data-infix-strict-left	declarations	declarations/data-infix-strict-left.hs	xfail	strict infix constructor fields unsupported
-decls-data-infix-strict-right	declarations	declarations/data-infix-strict-right.hs	xfail	strict infix constructor fields unsupported
-decls-data-record-empty	declarations	declarations/data-record-empty.hs	xfail	record constructor syntax unsupported
-decls-data-record-fields	declarations	declarations/data-record-fields.hs	xfail	record constructor syntax unsupported
-decls-data-record-grouped-fields	declarations	declarations/data-record-grouped-fields.hs	xfail	record field grouping unsupported
-decls-data-record-strict-field	declarations	declarations/data-record-strict-field.hs	xfail	strict record fields unsupported
-decls-data-deriving-single	declarations	declarations/data-deriving-single.hs	xfail	single-class deriving syntax unsupported
-decls-data-deriving-empty	declarations	declarations/data-deriving-empty.hs	xfail	empty deriving list syntax unsupported
-decls-data-abstract	declarations	declarations/data-abstract.hs	xfail	abstract data declarations unsupported
-decls-newtype	declarations	declarations/newtype.hs	xfail	newtype declarations unsupported
-decls-type-synonym	declarations	declarations/type-synonym.hs	xfail	type synonym declarations unsupported
-decls-class	declarations	declarations/class.hs	xfail	class declarations unsupported
-decls-class-minimal	declarations	declarations/class-minimal.hs	xfail	class declarations without where unsupported
-decls-class-where-empty	declarations	declarations/class-where-empty.hs	xfail	class declarations with empty cdecls unsupported
-decls-class-super-simple	declarations	declarations/class-super-simple.hs	xfail	class superclass contexts unsupported
-decls-class-super-paren-empty	declarations	declarations/class-super-paren-empty.hs	xfail	parenthesized superclass contexts unsupported
-decls-class-super-paren-single	declarations	declarations/class-super-paren-single.hs	xfail	parenthesized superclass contexts unsupported
-decls-class-super-paren-multiple	declarations	declarations/class-super-paren-multiple.hs	xfail	multiple superclass constraints unsupported
-decls-class-cdecl-signature	declarations	declarations/class-cdecl-signature.hs	xfail	class method signatures unsupported
-decls-class-cdecl-signature-context	declarations	declarations/class-cdecl-signature-context.hs	xfail	class method signatures with contexts unsupported
-decls-class-cdecl-default-var	declarations	declarations/class-cdecl-default-var.hs	xfail	default class methods unsupported
-decls-class-cdecl-default-funlhs	declarations	declarations/class-cdecl-default-funlhs.hs	xfail	default class methods unsupported
-decls-class-cdecl-fixity	declarations	declarations/class-cdecl-fixity.hs	xfail	fixity declarations in class bodies unsupported
-decls-instance	declarations	declarations/instance.hs	xfail	instance declarations unsupported
-decls-fixity	declarations	declarations/fixity.hs	xfail	fixity declarations unsupported
-decls-default	declarations	declarations/default.hs	xfail	default declarations unsupported
-decls-deriving	declarations	declarations/deriving.hs	xfail	deriving declarations unsupported
+decls-data-context	declarations	declarations/data-context.hs	pass	data declaration contexts unsupported
+decls-data-prefix-positional	declarations	declarations/data-prefix-positional.hs	pass	prefix constructor arguments unsupported
+decls-data-prefix-strict	declarations	declarations/data-prefix-strict.hs	pass	strict constructor fields unsupported
+decls-data-infix	declarations	declarations/data-infix.hs	pass	infix data constructors unsupported
+decls-data-infix-strict-left	declarations	declarations/data-infix-strict-left.hs	pass	strict infix constructor fields unsupported
+decls-data-infix-strict-right	declarations	declarations/data-infix-strict-right.hs	pass	strict infix constructor fields unsupported
+decls-data-record-empty	declarations	declarations/data-record-empty.hs	pass	record constructor syntax unsupported
+decls-data-record-fields	declarations	declarations/data-record-fields.hs	pass	record constructor syntax unsupported
+decls-data-record-grouped-fields	declarations	declarations/data-record-grouped-fields.hs	pass	record field grouping unsupported
+decls-data-record-strict-field	declarations	declarations/data-record-strict-field.hs	pass	strict record fields unsupported
+decls-data-deriving-single	declarations	declarations/data-deriving-single.hs	pass	single-class deriving syntax unsupported
+decls-data-deriving-empty	declarations	declarations/data-deriving-empty.hs	pass	empty deriving list syntax unsupported
+decls-data-abstract	declarations	declarations/data-abstract.hs	pass	abstract data declarations unsupported
+decls-newtype	declarations	declarations/newtype.hs	pass	newtype declarations unsupported
+decls-type-synonym	declarations	declarations/type-synonym.hs	pass	type synonym declarations unsupported
+decls-class	declarations	declarations/class.hs	pass	class declarations unsupported
+decls-class-minimal	declarations	declarations/class-minimal.hs	pass	class declarations without where unsupported
+decls-class-where-empty	declarations	declarations/class-where-empty.hs	pass	class declarations with empty cdecls unsupported
+decls-class-super-simple	declarations	declarations/class-super-simple.hs	pass	class superclass contexts unsupported
+decls-class-super-paren-empty	declarations	declarations/class-super-paren-empty.hs	pass	parenthesized superclass contexts unsupported
+decls-class-super-paren-single	declarations	declarations/class-super-paren-single.hs	pass	parenthesized superclass contexts unsupported
+decls-class-super-paren-multiple	declarations	declarations/class-super-paren-multiple.hs	pass	multiple superclass constraints unsupported
+decls-class-cdecl-signature	declarations	declarations/class-cdecl-signature.hs	pass	class method signatures unsupported
+decls-class-cdecl-signature-context	declarations	declarations/class-cdecl-signature-context.hs	pass	class method signatures with contexts unsupported
+decls-class-cdecl-default-var	declarations	declarations/class-cdecl-default-var.hs	pass	default class methods unsupported
+decls-class-cdecl-default-funlhs	declarations	declarations/class-cdecl-default-funlhs.hs	pass	default class methods unsupported
+decls-class-cdecl-fixity	declarations	declarations/class-cdecl-fixity.hs	pass	fixity declarations in class bodies unsupported
+decls-instance	declarations	declarations/instance.hs	pass	instance declarations unsupported
+decls-fixity	declarations	declarations/fixity.hs	pass	fixity declarations unsupported
+decls-default	declarations	declarations/default.hs	pass	default declarations unsupported
+decls-deriving	declarations	declarations/deriving.hs	pass	deriving declarations unsupported
 
 expr-if-then-else	expressions	expressions/if-then-else.hs	xfail	if expressions unsupported
 expr-case-of	expressions	expressions/case-of.hs	xfail	case expressions unsupported
@@ -190,8 +190,8 @@ pat-as-pattern	patterns	patterns/as-pattern.hs	xfail	as-patterns unsupported
 pat-irrefutable	patterns	patterns/irrefutable.hs	xfail	irrefutable patterns unsupported
 pat-guards	patterns	patterns/guards.hs	xfail	guards unsupported
 
-types-context	types	types/context.hs	xfail	type contexts unsupported
-types-tuple-list	types	types/tuple-list-types.hs	xfail	complex type signatures unsupported
+types-context	types	types/context.hs	pass	type contexts unsupported
+types-tuple-list	types	types/tuple-list-types.hs	pass	complex type signatures unsupported
 types-newtype-record	types	types/newtype-record.hs	xfail	record syntax unsupported
 
 layout-let	layout	layout/let-layout.hs	xfail	layout-sensitive let unsupported

--- a/components/haskell-parser/test/Test/Oracle.hs
+++ b/components/haskell-parser/test/Test/Oracle.hs
@@ -7,8 +7,9 @@ module Test.Oracle
 where
 
 import Data.Bifunctor (first)
+import Data.Char (isDigit, isUpper)
 import Data.Foldable (toList)
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified GHC.Data.EnumSet as EnumSet
@@ -36,9 +37,9 @@ import GHC.Types.ForeignCall
 import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Types.Name.Reader (RdrName, rdrNameOcc)
 import GHC.Types.SourceText (IntegralLit (..))
-import GHC.Types.SrcLoc (mkRealSrcLoc, unLoc)
+import GHC.Types.SrcLoc (GenLocated, mkRealSrcLoc, unLoc)
 import GHC.Utils.Error (emptyDiagOpts, pprMessages)
-import GHC.Utils.Outputable (ppr, showSDocUnsafe)
+import GHC.Utils.Outputable (Outputable, ppr, showSDocUnsafe)
 import Parser.Canonical
 import Text.Read (readMaybe)
 
@@ -79,6 +80,9 @@ toCanonicalDecls locatedDecl =
   case unLoc locatedDecl of
     ValD _ bind -> (: []) <$> toCanonicalValueDecl bind
     SigD _ sig -> toCanonicalSigDecls sig
+    TyClD _ tyClDecl -> (: []) <$> toCanonicalTyClDecl tyClDecl
+    InstD _ instDecl -> (: []) <$> toCanonicalInstanceDecl instDecl
+    DefD _ defDecl -> (: []) <$> toCanonicalDefaultDecl defDecl
     ForD _ foreignDecl -> (: []) <$> toCanonicalForeignDecl foreignDecl
     _ -> Left "unsupported declaration kind"
 
@@ -104,6 +108,11 @@ toCanonicalValueDecl bind =
                 CanonicalFunctionDecl
                   { canonicalFunctionName = name
                   }
+    PatBind {pat_lhs = locatedPat} ->
+      Right
+        CanonicalPatternDecl
+          { canonicalPatternLhs = normalizeSpaceText (renderLocated locatedPat)
+          }
     _ -> Left "unsupported value binding"
   where
     toSimpleBody match =
@@ -130,7 +139,73 @@ toCanonicalSigDecls sig =
             }
         | locatedName <- locatedNames
         ]
+    FixSig _ (FixitySig _ locatedNames fixity) ->
+      let assoc = fixityAssocText fixity
+          precedence = fixityPrecedenceValue fixity
+       in pure
+            [ CanonicalFixityDecl
+                { canonicalFixityAssoc = assoc,
+                  canonicalFixityPrecedence = precedence,
+                  canonicalFixityOperator = occNameText (unLoc locatedName)
+                }
+            | locatedName <- locatedNames
+            ]
     _ -> Left "unsupported signature declaration"
+
+toCanonicalTyClDecl :: TyClDecl GhcPs -> Either String CanonicalDecl
+toCanonicalTyClDecl tyClDecl =
+  case tyClDecl of
+    SynDecl {tcdLName = locatedName} ->
+      Right
+        CanonicalTypeDecl
+          { canonicalTypeDeclName = occNameText (unLoc locatedName)
+          }
+    DataDecl {tcdLName = locatedName, tcdDataDefn = dataDefn} ->
+      let typeName = occNameText (unLoc locatedName)
+          renderedDecl = renderPrinted dataDefn
+          constructors = constructorsFromRendered renderedDecl
+       in if "newtype " `T.isPrefixOf` T.strip renderedDecl
+            then
+              Right
+                CanonicalNewtypeDecl
+                  { canonicalNewtypeName = typeName,
+                    canonicalNewtypeConstructor =
+                      case constructors of
+                        [] -> Nothing
+                        (ctor : _) -> Just ctor
+                  }
+            else
+              Right
+                CanonicalDataDecl
+                  { canonicalTypeName = typeName,
+                    canonicalConstructors = constructors
+                  }
+    ClassDecl {tcdLName = locatedName} ->
+      Right
+        CanonicalClassDecl
+          { canonicalClassName = occNameText (unLoc locatedName)
+          }
+    _ -> Left "unsupported type/class declaration"
+
+toCanonicalInstanceDecl :: InstDecl GhcPs -> Either String CanonicalDecl
+toCanonicalInstanceDecl instDecl =
+  case instDecl of
+    ClsInstD _ clsInst ->
+      let rendered = renderPrinted clsInst
+       in Right
+            CanonicalInstanceDecl
+              { canonicalInstanceClassName = classNameFromRendered rendered
+              }
+    _ -> Left "unsupported instance declaration"
+
+toCanonicalDefaultDecl :: DefaultDecl GhcPs -> Either String CanonicalDecl
+toCanonicalDefaultDecl defDecl =
+  case defDecl of
+    DefaultDecl _ _ tys ->
+      Right
+        CanonicalDefaultDecl
+          { canonicalDefaultTypes = map (normalizeTypeToken . renderLocated) (toList tys)
+          }
 
 toCanonicalForeignDecl :: ForeignDecl GhcPs -> Either String CanonicalDecl
 toCanonicalForeignDecl foreignDecl =
@@ -205,6 +280,87 @@ classifyImportEntity mHeader importSpec =
 
 occNameText :: RdrName -> Text
 occNameText = T.pack . occNameString . rdrNameOcc
+
+constructorsFromRendered :: Text -> [Text]
+constructorsFromRendered rendered =
+  let (_, afterEq) = T.breakOn "=" rendered
+      rhs = if T.null afterEq then "" else T.drop 1 afterEq
+      rhsCore = T.strip (fst (T.breakOn " deriving" rhs))
+      parts = filter (not . T.null) (map (T.strip . fst . T.breakOn "{") (T.splitOn "|" rhsCore))
+   in mapMaybe constructorName parts
+
+constructorName :: Text -> Maybe Text
+constructorName part =
+  let tokens = map normalizeTypeToken (T.words (T.replace "!" "" part))
+      symbolic = filter isSymbolicToken tokens
+   in case tokens of
+        [] -> Nothing
+        (firstToken : _)
+          | isClassToken firstToken -> Just firstToken
+          | otherwise ->
+              case symbolic of
+                (op : _) -> Just op
+                [] -> Nothing
+
+fixityAssocText :: Fixity -> Text
+fixityAssocText fixity =
+  case T.words (renderPrinted fixity) of
+    (assoc : _)
+      | assoc `elem` ["infix", "infixl", "infixr"] -> assoc
+    _ -> "infix"
+
+fixityPrecedenceValue :: Fixity -> Maybe Int
+fixityPrecedenceValue fixity =
+  case T.words (renderPrinted fixity) of
+    (_ : prec : _) | T.all isDigit prec -> Just (read (T.unpack prec))
+    _ -> Nothing
+
+classNameFromRendered :: Text -> Text
+classNameFromRendered rendered =
+  let withoutInstance = T.strip (fromMaybe rendered (T.stripPrefix "instance" (T.strip rendered)))
+      noWhere = T.strip (fst (T.breakOn " where" withoutInstance))
+      noContext =
+        case T.breakOn "=>" noWhere of
+          (lhs, rhs)
+            | T.null rhs -> lhs
+            | otherwise -> T.strip (T.drop 2 rhs)
+      tokens = map normalizeTypeToken (T.words noContext)
+   in case filter isClassToken tokens of
+        (name : _) -> name
+        [] -> "Instance"
+
+isClassToken :: Text -> Bool
+isClassToken token =
+  case T.uncons token of
+    Just (c, _) -> isUpper c
+    Nothing -> False
+
+normalizeTypeToken :: Text -> Text
+normalizeTypeToken =
+  T.dropAround (\c -> c == '(' || c == ')' || c == ',' || c == ' ')
+
+isSymbolicToken :: Text -> Bool
+isSymbolicToken tok =
+  not (T.null tok) && T.all (`elem` (":!#$%&*+./<=>?@\\^|-~" :: String)) tok
+
+normalizeSpaceText :: Text -> Text
+normalizeSpaceText = T.unwords . T.words
+
+renderLocated :: (Outputable a) => GenLocated l a -> Text
+renderLocated = renderPrinted . unLoc
+
+renderPrinted :: (Outputable a) => a -> Text
+renderPrinted = T.pack . showSDocUnsafe . ppr
+
+mapMaybe :: (a -> Maybe b) -> [a] -> [b]
+mapMaybe f =
+  foldr
+    ( \x acc ->
+        case f x of
+          Just y -> y : acc
+          Nothing -> acc
+    )
+    []
 
 toCanonicalExpr :: HsExpr GhcPs -> Either String CanonicalExpr
 toCanonicalExpr expr =


### PR DESCRIPTION
## Summary
- implement declaration parsing coverage in `components/haskell-parser/src/Parser.hs` for type signatures, multiple equations, pattern bindings, `type`, `data`/`newtype` forms, `class`, `instance`, `fixity`, and `default`
- extend parser and canonical AST declaration variants in `Parser.Ast` and `Parser.Canonical`
- update GHC oracle canonicalization in `components/haskell-parser/test/Test/Oracle.hs` so declaration normalization aligns with parser output
- promote implemented Haskell2010 declaration fixtures (and supported type fixtures) in `manifest.tsv`
- refresh parser progress stats in repo READMEs

## Validation
- `nix run .#parser-test`
- `nix run .#name-resolution-test`
- `nix flake check`
