### PR TITLE
Fix stale parser progress counters in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The from-scratch parser lives in `components/haskell-parser`.
 
 Current Haskell2010 progress:
-- `77/194` syntax cases implemented (`61.34%` complete)
+- `119/194` syntax cases implemented (`61.34%` complete)
 - status breakdown: `PASS=77`, `XFAIL=75`, `XPASS=42`, `FAIL=0`
 
 Recompute progress with:

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -18,7 +18,7 @@ Runtime outcomes are reported as:
 - `FAIL`: regression or invalid case/manifest (for example oracle rejects a `pass` case)
 
 Current progress baseline:
-- `77/194` implemented (`61.34%` complete)
+- `119/194` implemented (`61.34%` complete)
 - `PASS=77`, `XFAIL=75`, `XPASS=42`, `FAIL=0`
 
 ## Commands


### PR DESCRIPTION
## Summary
- update parser progress counters in README.md and components/haskell-parser/README.md
- align implemented-case numerator with the current progress output (PASS + XPASS = 119/194)

## Validation
- nix run .#parser-progress (passes; reports PASS=77, XPASS=42, COMPLETE=61.34%)
- nix flake check (fails in existing parser test checks unrelated to this docs-only change)
