### PR TITLE
Remove simplified Expr constructors

### DIFF
--- a/components/haskell-name-resolution/src/Resolver.hs
+++ b/components/haskell-name-resolution/src/Resolver.hs
@@ -137,18 +137,6 @@ resolveExpr cfg expr st =
           (x', st2) = resolveExpr cfg x st1
        in (RApp f' x', st2)
     EParen inner -> resolveExpr cfg inner st
-    EWhere body binds ->
-      let (binds', st1) =
-            foldl'
-              ( \(acc, stAcc) (_, bindExpr) ->
-                  let (resolvedBind, stNext) = resolveExpr cfg bindExpr stAcc
-                   in (acc <> [resolvedBind], stNext)
-              )
-              ([], st)
-              binds
-          (body', st2) = resolveExpr cfg body st1
-          combined = foldl' RApp body' binds'
-       in (combined, st2)
     EWhereDecls body _decls ->
       resolveExpr cfg body st
     EVar name ->

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -753,9 +753,7 @@ parseRhsExpr cfg rhs0 =
           ParseOk expr -> Right expr
           ParseErr _ -> Left "expression"
       decls <- parseLocalDecls cfg whereTxt
-      case localDeclsToSimpleBindings decls of
-        Just binds -> Right (EWhere bodyExpr binds)
-        Nothing -> Right (EWhereDecls bodyExpr decls)
+      Right (EWhereDecls bodyExpr decls)
 
 parseLocalDecls :: ParserConfig -> Text -> Either Text [Decl]
 parseLocalDecls cfg txt =
@@ -1152,15 +1150,7 @@ parseLambdaExpr txt = do
     else do
       pats <- traverse parsePatternText paramTokens
       body <- parseExprCore bodyTxt
-      pure $
-        case traverse simpleVarName pats of
-          Right names -> ELambda names body
-          Left _ -> ELambdaPats pats body
-  where
-    simpleVarName pat =
-      case pat of
-        PVar name -> Right name
-        _ -> Left ()
+      pure (ELambdaPats pats body)
 
 parseLetExpr :: Text -> Either Text Expr
 parseLetExpr txt = do
@@ -1168,9 +1158,7 @@ parseLetExpr txt = do
   (bindsTxt, bodyTxt) <- splitTopLevelOnce "in" rest
   decls <- parseLocalDecls defaultConfig bindsTxt
   body <- parseExprCore bodyTxt
-  case localDeclsToSimpleBindings decls of
-    Just binds -> Right (ELet binds body)
-    Nothing -> Right (ELetDecls decls body)
+  Right (ELetDecls decls body)
 
 parseCaseExpr :: Text -> Either Text Expr
 parseCaseExpr txt = do

--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -285,13 +285,11 @@ data Expr
   | EChar Char
   | EString Text
   | EIf Expr Expr Expr
-  | ELambda [Text] Expr
   | ELambdaPats [Pattern] Expr
   | EInfix Expr Text Expr
   | ENegate Expr
   | ESectionL Expr Text
   | ESectionR Text Expr
-  | ELet [(Text, Expr)] Expr
   | ELetDecls [Decl] Expr
   | ECase Expr [CaseAlt]
   | EDo [DoStmt]
@@ -301,7 +299,6 @@ data Expr
   | ERecordUpd Expr [(Text, Expr)]
   | ETypeSig Expr Type
   | EParen Expr
-  | EWhere Expr [(Text, Expr)]
   | EWhereDecls Expr [Decl]
   | EList [Expr]
   | ETuple [Expr]

--- a/components/haskell-parser/src/Parser/Pretty.hs
+++ b/components/haskell-parser/src/Parser/Pretty.hs
@@ -504,22 +504,12 @@ prettyExprPrec prec expr =
       parenthesize
         (prec > 0)
         ("if" <+> prettyExprPrec 0 cond <+> "then" <+> prettyExprPrec 0 yes <+> "else" <+> prettyExprPrec 0 no)
-    ELambda params body ->
-      parenthesize (prec > 0) ("\\" <> hsep (map pretty params) <+> "->" <+> prettyExprPrec 0 body)
     ELambdaPats pats body ->
       parenthesize (prec > 0) ("\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyExprPrec 0 body)
     EInfix lhs op rhs -> parenthesize (prec > 1) (prettyExprPrec 1 lhs <+> prettyExprOperator op <+> prettyExprPrec 1 rhs)
     ENegate inner -> parenthesize (prec > 2) ("-" <> prettyExprPrec 3 inner)
     ESectionL lhs op -> parens (prettyExprPrec 0 lhs <+> prettyExprOperator op)
     ESectionR op rhs -> parens (prettyExprOperator op <+> prettyExprPrec 0 rhs)
-    ELet bindings body ->
-      parenthesize
-        (prec > 0)
-        ( "let"
-            <+> hsep (punctuate semi (map prettyBinding bindings))
-            <+> "in"
-            <+> prettyExprPrec 0 body
-        )
     ELetDecls decls body ->
       parenthesize
         (prec > 0)
@@ -553,10 +543,6 @@ prettyExprPrec prec expr =
       prettyExprPrec 3 base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
     ETypeSig inner ty -> parenthesize (prec > 1) (prettyExprPrec 1 inner <+> "::" <+> prettyType ty)
     EParen inner -> parens (prettyExprPrec 0 inner)
-    EWhere body binds ->
-      parenthesize
-        (prec > 0)
-        (prettyExprPrec 0 body <+> "where" <+> braces (hsep (punctuate semi (map prettyBinding binds))))
     EWhereDecls body decls ->
       parenthesize
         (prec > 0)

--- a/components/haskell-parser/test/Spec.hs
+++ b/components/haskell-parser/test/Spec.hs
@@ -251,9 +251,7 @@ stripExprParens expr =
     ESectionL l op -> ESectionL (stripExprParens l) op
     ESectionR op r -> ESectionR op (stripExprParens r)
     EIf c t f -> EIf (stripExprParens c) (stripExprParens t) (stripExprParens f)
-    ELambda ps b -> ELambda ps (stripExprParens b)
     ELambdaPats ps b -> ELambdaPats ps (stripExprParens b)
-    ELet binds body -> ELet [(n, stripExprParens v) | (n, v) <- binds] (stripExprParens body)
     ELetDecls decls body -> ELetDecls (map stripDeclParens decls) (stripExprParens body)
     ECase scrut alts ->
       ECase
@@ -291,7 +289,6 @@ stripExprParens expr =
     ERecordCon n fields -> ERecordCon n [(f, stripExprParens v) | (f, v) <- fields]
     ERecordUpd base fields -> ERecordUpd (stripExprParens base) [(f, stripExprParens v) | (f, v) <- fields]
     ETypeSig inner ty -> ETypeSig (stripExprParens inner) ty
-    EWhere body binds -> EWhere (stripExprParens body) [(n, stripExprParens v) | (n, v) <- binds]
     EWhereDecls body decls -> EWhereDecls (stripExprParens body) (map stripDeclParens decls)
     EList xs -> EList (map stripExprParens xs)
     ETuple xs -> ETuple (map stripExprParens xs)


### PR DESCRIPTION
## Summary
- remove `ELambda`, `ELet`, and `EWhere` from `Expr`
- always construct generalized variants in the parser (`ELambdaPats`, `ELetDecls`, `EWhereDecls`)
- drop pretty-printer and test branches for removed constructors
- remove resolver handling for removed `EWhere` constructor

## Validation
- `nix flake check`
