### PR TITLE
Implement ParallelListComp support in haskell parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Extension support tracking for `components/haskell-parser` is reported in:
 
 Current extension baseline:
 - Total tracked extensions: `33`
-- Supported: `0`
-- In Progress: `1`
+- Supported: `1`
+- In Progress: `0`
 - Planned: `32`
 
 Recompute extension status with:

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -31,8 +31,8 @@ Each extension can provide a manifest at:
 
 Current extension baseline:
 - Total tracked extensions: `33`
-- Supported: `0`
-- In Progress: `1`
+- Supported: `1`
+- In Progress: `0`
 - Planned: `32`
 
 Generated report:

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -1246,12 +1246,20 @@ parseListExpr txt = do
     else case splitTopLevelMaybe "|" inner of
       Just (bodyTxt, qualsTxt) -> do
         body <- parseExprCore bodyTxt
-        qualifiers <- traverse parseCompStmtText (splitTopLevel ',' qualsTxt)
-        Right (EListComp span0 body qualifiers)
+        let groups = splitTopLevel '|' qualsTxt
+        qualifierGroups <- traverse parseCompStmtGroup groups
+        case qualifierGroups of
+          [qualifiers] -> Right (EListComp span0 body qualifiers)
+          _ -> Right (EListCompParallel span0 body qualifierGroups)
       Nothing ->
         case splitTopLevelMaybe ".." inner of
           Just _ -> parseArithSeq inner
           Nothing -> EList span0 <$> traverse parseExprCore (splitTopLevel ',' inner)
+
+parseCompStmtGroup :: Text -> Either Text [CompStmt]
+parseCompStmtGroup groupTxt
+  | T.null (T.strip groupTxt) = Left "expression"
+  | otherwise = traverse parseCompStmtText (splitTopLevel ',' groupTxt)
 
 parseCompStmtText :: Text -> Either Text CompStmt
 parseCompStmtText txt

--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -323,6 +323,7 @@ data Expr
   | ECase SourceSpan Expr [CaseAlt]
   | EDo SourceSpan [DoStmt]
   | EListComp SourceSpan Expr [CompStmt]
+  | EListCompParallel SourceSpan Expr [[CompStmt]]
   | EArithSeq SourceSpan ArithSeq
   | ERecordCon SourceSpan Text [(Text, Expr)]
   | ERecordUpd SourceSpan Expr [(Text, Expr)]

--- a/components/haskell-parser/src/Parser/Pretty.hs
+++ b/components/haskell-parser/src/Parser/Pretty.hs
@@ -536,6 +536,16 @@ prettyExprPrec prec expr =
             <+> "|"
             <+> hsep (punctuate comma (map prettyCompStmt quals))
         )
+    EListCompParallel _ body qualifierGroups ->
+      brackets
+        ( prettyExprPrec 0 body
+            <+> "|"
+            <+> hsep
+              ( punctuate
+                  "|"
+                  (map (\quals -> hsep (punctuate comma (map prettyCompStmt quals))) qualifierGroups)
+              )
+        )
     EArithSeq _ seqInfo -> prettyArithSeq seqInfo
     ERecordCon _ name fields ->
       pretty name <+> braces (hsep (punctuate comma (map prettyBinding fields)))

--- a/components/haskell-parser/test/Spec.hs
+++ b/components/haskell-parser/test/Spec.hs
@@ -292,6 +292,19 @@ stripExprParens expr =
             CompLetDecls s' decls -> CompLetDecls s' (map stripDeclParens decls)
         | q <- quals
         ]
+    EListCompParallel s body qualifierGroups ->
+      EListCompParallel
+        s
+        (stripExprParens body)
+        [ [ case q of
+              CompGen s' p e -> CompGen s' p (stripExprParens e)
+              CompGuard s' e -> CompGuard s' (stripExprParens e)
+              CompLet s' binds -> CompLet s' [(n, stripExprParens v) | (n, v) <- binds]
+              CompLetDecls s' decls -> CompLetDecls s' (map stripDeclParens decls)
+          | q <- quals
+          ]
+        | quals <- qualifierGroups
+        ]
     EArithSeq s seqInfo ->
       EArithSeq
         s

--- a/components/haskell-parser/test/Test/Fixtures/ParallelListComp/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/ParallelListComp/manifest.tsv
@@ -1,1 +1,1 @@
-parallel-list-comp-basic	expressions	parallel-list-comp-basic.hs	xfail	parallel list qualifiers unsupported
+parallel-list-comp-basic	expressions	parallel-list-comp-basic.hs	pass

--- a/docs/haskell-parser-extension-support.md
+++ b/docs/haskell-parser-extension-support.md
@@ -5,15 +5,15 @@
 ## Summary
 
 - Total Extensions: 33
-- Supported: 0
-- In Progress: 1
+- Supported: 1
+- In Progress: 0
 - Planned: 32
 
 ## Extension Status
 
 | Extension | Status | Tests Passing | Notes |
 |-----------|--------|---------------|-------|
-| ParallelListComp | In Progress | 0/1 | Parallel list comprehensions |
+| ParallelListComp | Supported | 1/1 | Parallel list comprehensions |
 | TransformListComp | Planned | - | TransformListComp (then clauses in list comprehensions) |
 | ViewPatterns | Planned | - | View patterns |
 | PatternSynonyms | Planned | - | Pattern synonyms |


### PR DESCRIPTION
## Summary
- add `EListCompParallel` to represent parallel list-comprehension qualifier groups
- update list-comprehension parsing to emit `EListComp` for single groups and `EListCompParallel` for `|`-separated parallel groups
- reject empty parallel qualifier groups during parse
- add pretty-printer and test normalization support for the new AST node
- promote `ParallelListComp` fixture to `pass` and refresh extension progress docs/readme baselines

## Validation
- `nix run .#parser-test`
- `nix run .#parser-extension-progress`
- `nix run .#parser-extension-progress-strict`
- `nix flake check` *(fails on existing unrelated haskell-format issue in `components/haskell-parser/app/hackage-tester/Main.hs` import order)*