### PR TITLE
ci: run nix flake check on push and PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Determinate Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
       - name: Configure Cloudflare R2 cache
-        uses: lemmih/nix-s3-cache-action@main
+        uses: lemmih/nix-s3-cache-action@29264f2f7ee0569b80a4c91ef27734c92ac69026 # v1.0.2
         with:
           s3-endpoint: ${{ vars.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
           bucket: nix-cache


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run `nix flake check` on pushes to `main` and on pull requests
- install Determinate Nix with `DeterminateSystems/nix-installer-action`
- configure `lemmih/nix-s3-cache-action` for the Cloudflare R2 bucket `nix-cache` using the provided access key ID and `R2_SECRET_ACCESS_KEY`

## Cache configuration
- endpoint: `R2_ACCOUNT_ID.r2.cloudflarestorage.com` (from repository variable `R2_ACCOUNT_ID`)
- public key: `nix-cache:2eICaC37vEBexPk98J0dRt5FzSX7f6hx0vRl9tPaUuM=`
- private key secret: `NIX_CACHE_PRIVATE_KEY`

## Validation
- Ran `nix flake check` before and after the change.
- Both runs fail due to a pre-existing hlint failure in `components/haskell-parser/src/Parser/Pretty.hs:546` (unrelated to this workflow-only change).
