### PR TITLE
Update maintainer and author fields

### DIFF
--- a/components/haskell-cpp/aihc-cpp.cabal
+++ b/components/haskell-cpp/aihc-cpp.cabal
@@ -4,8 +4,8 @@ version:            0.1.0.0
 build-type:         Simple
 license:            Unlicense
 license-file:       LICENSE
-author:             aihc
-maintainer:         aihc@example.com
+author:             David Himmelstrup
+maintainer:         lemmih@gmail.com
 category:           Compilers
 synopsis:           Pure Haskell C preprocessor for aihc
 

--- a/components/haskell-name-resolution/aihc-name-resolution.cabal
+++ b/components/haskell-name-resolution/aihc-name-resolution.cabal
@@ -4,8 +4,8 @@ version:            0.1.0.0
 build-type:         Simple
 license:            Unlicense
 license-file:       LICENSE
-author:             aihc
-maintainer:         aihc@example.com
+author:             David Himmelstrup
+maintainer:         lemmih@gmail.com
 category:           Compilers
 synopsis:           Name resolution component for aihc
 

--- a/components/haskell-parser/aihc-parser.cabal
+++ b/components/haskell-parser/aihc-parser.cabal
@@ -4,8 +4,8 @@ version:            0.1.0.0
 build-type:         Simple
 license:            MIT
 license-file:       LICENSE
-author:             aihc
-maintainer:         aihc@example.com
+author:             David Himmelstrup
+maintainer:         lemmih@gmail.com
 category:           Compilers
 synopsis:           From-scratch Haskell parser with differential tests
 


### PR DESCRIPTION
Replaced dummy maintainer aihc@example.com with lemmih@gmail.com and set author fields to 'David Himmelstrup' in the cabal files.