### PR TITLE
fix(parser): support abstract data declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The from-scratch parser lives in `components/haskell-parser`.
 
 Current Haskell2010 progress:
 <!-- AUTO-GENERATED: START parser-progress -->
-- `12/239` syntax cases implemented (`5.02%` complete)
+- `13/239` syntax cases implemented (`5.43%` complete)
 <!-- AUTO-GENERATED: END parser-progress -->
 
 ## Haskell Parser Extension Support Progress

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -19,7 +19,7 @@ Runtime outcomes are reported as:
 
 Current progress baseline:
 <!-- AUTO-GENERATED: START haskell2010-progress -->
-- `12/239` implemented (`5.02%` complete)
+- `13/239` implemented (`5.43%` complete)
 <!-- AUTO-GENERATED: END haskell2010-progress -->
 
 ## Extension Coverage Tracking

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -10,7 +10,7 @@ where
 
 import Data.Text (Text)
 import Data.Void (Void)
-import Parser.Ast (Decl (..), Expr (..), Match (..), Module (..), Rhs (..), SourceSpan (..), ValueDecl (..))
+import Parser.Ast (DataDecl (..), Decl (..), Expr (..), Match (..), Module (..), Rhs (..), SourceSpan (..), ValueDecl (..))
 import Parser.Lexer (LexToken (..), LexTokenKind (..), lexTokens)
 import Parser.Types
 import Text.Megaparsec (Parsec, anySingle, lookAhead, runParser, (<|>))
@@ -47,7 +47,33 @@ moduleHeaderParser = do
   pure name
 
 declParser :: TokParser Decl
-declParser = withSpan $ do
+declParser = dataDeclParser <|> valueDeclParser
+
+dataDeclParser :: TokParser Decl
+dataDeclParser = withSpan $ do
+  keywordTok TkKeywordData
+  typeName <- tokenSatisfy $ \tok ->
+    case lexTokenKind tok of
+      TkIdentifier ident -> Just ident
+      _ -> Nothing
+  typeParams <- MP.many $ tokenSatisfy $ \tok ->
+    case lexTokenKind tok of
+      TkIdentifier ident -> Just ident
+      _ -> Nothing
+  pure $ \span' ->
+    DeclData
+      span'
+      DataDecl
+        { dataDeclSpan = span',
+          dataDeclContext = [],
+          dataDeclName = typeName,
+          dataDeclParams = typeParams,
+          dataDeclConstructors = [],
+          dataDeclDeriving = Nothing
+        }
+
+valueDeclParser :: TokParser Decl
+valueDeclParser = withSpan $ do
   name <- tokenSatisfy $ \tok ->
     case lexTokenKind tok of
       TkIdentifier ident -> Just ident

--- a/components/haskell-parser/src/Parser/Lexer.hs
+++ b/components/haskell-parser/src/Parser/Lexer.hs
@@ -34,6 +34,7 @@ import Text.Megaparsec.Pos (unPos)
 data LexTokenKind
   = TkKeywordModule
   | TkKeywordWhere
+  | TkKeywordData
   | TkKeywordImport
   | TkKeywordQualified
   | TkKeywordAs
@@ -258,6 +259,7 @@ keywordTokenKind :: Text -> Maybe LexTokenKind
 keywordTokenKind txt = case txt of
   "module" -> Just TkKeywordModule
   "where" -> Just TkKeywordWhere
+  "data" -> Just TkKeywordData
   "import" -> Just TkKeywordImport
   "qualified" -> Just TkKeywordQualified
   "as" -> Just TkKeywordAs

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -98,7 +98,7 @@ decls-data-record-grouped-fields	declarations	declarations/data-record-grouped-f
 decls-data-record-strict-field	declarations	declarations/data-record-strict-field.hs	xfail	parser intentionally disabled
 decls-data-deriving-single	declarations	declarations/data-deriving-single.hs	xfail	parser intentionally disabled
 decls-data-deriving-empty	declarations	declarations/data-deriving-empty.hs	xfail	parser intentionally disabled
-decls-data-abstract	declarations	declarations/data-abstract.hs	xfail	parser intentionally disabled
+decls-data-abstract	declarations	declarations/data-abstract.hs	pass
 decls-newtype	declarations	declarations/newtype.hs	xfail	parser intentionally disabled
 decls-type-synonym	declarations	declarations/type-synonym.hs	xfail	parser intentionally disabled
 decls-class	declarations	declarations/class.hs	xfail	parser intentionally disabled


### PR DESCRIPTION
## Summary
- add `data` keyword tokenization in the parser lexer
- parse abstract `data` declarations (`data T a`) into `DeclData` in `Parser`
- mark `decls-data-abstract` as passing and refresh generated progress blocks so flake checks stay green

## Test plan
- [x] `nix run .#parser-test`
- [x] `nix run .#generate-reports`
- [x] `nix flake check`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing Haskell data declarations alongside existing value declaration parsing.

* **Documentation**
  * Updated progress tracking: parser now implements 13 of 239 syntax cases (5.43% complete), up from the previous 5.02%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->