### PR TITLE
Disable automatic Copilot code review in main ruleset

### DIFF
--- a/.github/rulesets/main-pr-squash-only.json
+++ b/.github/rulesets/main-pr-squash-only.json
@@ -14,7 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "automatic_copilot_code_review_enabled": true,
+        "automatic_copilot_code_review_enabled": false,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,


### PR DESCRIPTION
## Summary
- set `automatic_copilot_code_review_enabled` to `false` in `.github/rulesets/main-pr-squash-only.json`
- applied the updated main branch ruleset via `gh api` to repository ruleset `Protect main (PR + squash only)`

## Validation
- confirmed the updated live ruleset no longer contains a `copilot_code_review` rule


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic code review automation for the main branch. This configuration change does not affect pull request merge requirements or other branch protection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->