### PR TITLE
Add support for basic data declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The from-scratch parser lives in `components/haskell-parser`.
 
 Current Haskell2010 progress:
 <!-- AUTO-GENERATED: START parser-progress -->
-- `26/240` syntax cases implemented (`10.83%` complete)
+- `28/240` syntax cases implemented (`11.66%` complete)
 <!-- AUTO-GENERATED: END parser-progress -->
 
 ## Haskell Parser Extension Support Progress

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -19,7 +19,7 @@ Runtime outcomes are reported as:
 
 Current progress baseline:
 <!-- AUTO-GENERATED: START haskell2010-progress -->
-- `26/240` implemented (`10.83%` complete)
+- `28/240` implemented (`11.66%` complete)
 <!-- AUTO-GENERATED: END haskell2010-progress -->
 
 ## Extension Coverage Tracking

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -8,9 +8,10 @@ module Parser
   )
 where
 
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Void (Void)
-import Parser.Ast (DataDecl (..), Decl (..), Expr (..), ImportDecl (..), Match (..), Module (..), Rhs (..), SourceSpan (..), ValueDecl (..))
+import Parser.Ast (DataConDecl (..), DataDecl (..), Decl (..), Expr (..), ImportDecl (..), Match (..), Module (..), Rhs (..), SourceSpan (..), ValueDecl (..))
 import Parser.Lexer (LexToken (..), LexTokenKind (..), lexTokens)
 import Parser.Types
 import Text.Megaparsec (Parsec, anySingle, lookAhead, runParser, (<|>))
@@ -71,6 +72,7 @@ dataDeclParser = withSpan $ do
     case lexTokenKind tok of
       TkIdentifier ident -> Just ident
       _ -> Nothing
+  constructors <- MP.optional (operatorLikeTok "=" *> dataConDeclParser `MP.sepBy1` operatorLikeTok "|")
   pure $ \span' ->
     DeclData
       span'
@@ -79,9 +81,17 @@ dataDeclParser = withSpan $ do
           dataDeclContext = [],
           dataDeclName = typeName,
           dataDeclParams = typeParams,
-          dataDeclConstructors = [],
+          dataDeclConstructors = fromMaybe [] constructors,
           dataDeclDeriving = Nothing
         }
+
+dataConDeclParser :: TokParser DataConDecl
+dataConDeclParser = withSpan $ do
+  name <- tokenSatisfy $ \tok ->
+    case lexTokenKind tok of
+      TkIdentifier ident -> Just ident
+      _ -> Nothing
+  pure $ \span' -> PrefixCon span' name []
 
 valueDeclParser :: TokParser Decl
 valueDeclParser = withSpan $ do

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -85,7 +85,7 @@ ffi-s8-multiple-foreign-decls	ffi	ffi/s8-multiple-foreign-decls.hs	xfail	parser 
 decls-type-signature	declarations	declarations/type-signature.hs	xfail	parser intentionally disabled
 decls-multiple-equations	declarations	declarations/multiple-equations.hs	xfail	parser intentionally disabled
 decls-pattern-binding	declarations	declarations/pattern-binding.hs	xfail	parser intentionally disabled
-decls-data	declarations	declarations/data.hs	xfail	parser intentionally disabled
+decls-data	declarations	declarations/data.hs	pass
 decls-data-context	declarations	declarations/data-context.hs	xfail	parser intentionally disabled
 decls-data-prefix-positional	declarations	declarations/data-prefix-positional.hs	xfail	parser intentionally disabled
 decls-data-prefix-strict	declarations	declarations/data-prefix-strict.hs	xfail	parser intentionally disabled
@@ -135,7 +135,7 @@ expr-s3-atoms-qvar	expressions	expressions/atoms-qvar.hs	pass	parser now handles
 expr-s3-atoms-gcon-unit	expressions	expressions/atoms-gcon-unit.hs	xfail	parser intentionally disabled
 expr-s3-atoms-gcon-listcon	expressions	expressions/atoms-gcon-listcon.hs	pass	parser supports list constructor expression
 expr-s3-atoms-gcon-tuplecon	expressions	expressions/atoms-gcon-tuplecon.hs	xfail	parser intentionally disabled
-expr-s3-atoms-qcon	expressions	expressions/atoms-qcon.hs	xfail	parser intentionally disabled
+expr-s3-atoms-qcon	expressions	expressions/atoms-qcon.hs	pass
 expr-s3-atoms-literal-int	expressions	expressions/atoms-literal-int.hs	pass	parser now handles integer literal atom case
 expr-s3-atoms-literal-float	expressions	expressions/atoms-literal-float.hs	pass	parser now handles floating literal atom case
 expr-s3-atoms-literal-char	expressions	expressions/atoms-literal-char.hs	pass	parser now handles char literal atom case


### PR DESCRIPTION
## Summary
- parse constructor lists in `data` declarations (e.g. `data Color = Red | Blue`)
- keep abstract `data` declarations supported (`data T a`)
- mark `decls-data` and `expr-s3-atoms-qcon` as passing in the Haskell2010 manifest
- refresh auto-generated progress blocks in READMEs

## Testing
- `nix flake check`
