### PR TITLE
ci: commit only markdown in generated reports workflow

### DIFF
--- a/.github/workflows/generated-reports-update.yml
+++ b/.github/workflows/generated-reports-update.yml
@@ -48,6 +48,12 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore(reports): update generated reports"
+          add-paths: |
+            README.md
+            docs/haskell-parser-extension-support.md
+            components/haskell-parser/README.md
+            components/haskell-cpp/README.md
+            components/haskell-name-resolution/README.md
           branch: "automation/generated-reports-update"
           title: "chore(reports): update generated reports"
           body: |


### PR DESCRIPTION
## Summary
- restrict the generated-reports automation PR commit to explicit markdown outputs via `add-paths`
- prevent cache artifacts (for example `.cache/**`) from being staged into automation PRs

## Testing
- `nix flake check`

## Progress Counts
- parser progress count: no change
- parser extension progress count: no change
- cpp progress count: no change
- name-resolution progress count: no change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request generation to track README-related file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->