### PR TITLE
Fix data-record-empty fixture

### DIFF
--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -171,7 +171,11 @@ dataConDeclParser = withSpan $ do
     case lexTokenKind tok of
       TkIdentifier ident -> Just ident
       _ -> Nothing
-  pure $ \span' -> PrefixCon span' name []
+  mRecordFields <- MP.optional (symbolLikeTok "{" *> symbolLikeTok "}")
+  pure $ \span' ->
+    case mRecordFields of
+      Just () -> RecordCon span' name []
+      Nothing -> PrefixCon span' name []
 
 valueDeclParser :: TokParser Decl
 valueDeclParser = withSpan $ do

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -92,7 +92,7 @@ decls-data-prefix-strict	declarations	declarations/data-prefix-strict.hs	xfail	p
 decls-data-infix	declarations	declarations/data-infix.hs	xfail	parser intentionally disabled
 decls-data-infix-strict-left	declarations	declarations/data-infix-strict-left.hs	xfail	parser intentionally disabled
 decls-data-infix-strict-right	declarations	declarations/data-infix-strict-right.hs	xfail	parser intentionally disabled
-decls-data-record-empty	declarations	declarations/data-record-empty.hs	xfail	roundtrip mismatch against oracle AST
+decls-data-record-empty	declarations	declarations/data-record-empty.hs	pass	
 decls-data-record-fields	declarations	declarations/data-record-fields.hs	xfail	roundtrip mismatch against oracle AST
 decls-data-record-grouped-fields	declarations	declarations/data-record-grouped-fields.hs	xfail	roundtrip mismatch against oracle AST
 decls-data-record-strict-field	declarations	declarations/data-record-strict-field.hs	xfail	roundtrip mismatch against oracle AST


### PR DESCRIPTION
## Summary
- Parse empty record-style data constructors (`Ctor {}`) as `RecordCon` in `dataConDeclParser`.
- Mark `decls-data-record-empty` as `pass` in the Haskell2010 fixture manifest.

## Progress Counts
### Parser (`nix run .#parser-progress`)
- Before: PASS 141, XFAIL 99, XPASS 0, FAIL 0, TOTAL 240, COMPLETE 58.75%
- After:  PASS 142, XFAIL 98, XPASS 0, FAIL 0, TOTAL 240, COMPLETE 59.16%

### Extension (`nix run .#parser-extension-progress`)
- Before: SUPPORTED 1, IN_PROGRESS 4, PLANNED 53, TOTAL 58
- After:  SUPPORTED 1, IN_PROGRESS 4, PLANNED 53, TOTAL 58

### CPP (`nix run .#cpp-progress`)
- Before: PASS 9, XFAIL 5, XPASS 0, FAIL 0, TOTAL 14, COMPLETE 64.28%
- After:  PASS 9, XFAIL 5, XPASS 0, FAIL 0, TOTAL 14, COMPLETE 64.28%

### Name Resolution (`nix run .#name-resolution-progress`)
- Before: PASS 9, XFAIL 3, XPASS 0, FAIL 0, TOTAL 12, COMPLETE 75.0%
- After:  PASS 9, XFAIL 3, XPASS 0, FAIL 0, TOTAL 12, COMPLETE 75.0%

## Validation
- `nix flake check`
