### PR TITLE
Implement parsing for data deriving clauses

### DIFF
--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -200,6 +200,7 @@ dataDeclParser = withSpan $ do
       TkIdentifier ident -> Just ident
       _ -> Nothing
   constructors <- MP.optional (operatorLikeTok "=" *> dataConDeclParser `MP.sepBy1` operatorLikeTok "|")
+  derivingClause <- MP.optional derivingClauseParser
   pure $ \span' ->
     DeclData
       span'
@@ -209,8 +210,21 @@ dataDeclParser = withSpan $ do
           dataDeclName = typeName,
           dataDeclParams = typeParams,
           dataDeclConstructors = fromMaybe [] constructors,
-          dataDeclDeriving = Nothing
+          dataDeclDeriving = derivingClause
         }
+
+derivingClauseParser :: TokParser DerivingClause
+derivingClauseParser = do
+  identifierExact "deriving"
+  classes <- parenClasses <|> singleClass
+  pure (DerivingClause classes)
+  where
+    singleClass = (: []) <$> identifierTextParser
+    parenClasses = do
+      symbolLikeTok "("
+      classes <- identifierTextParser `MP.sepBy` symbolLikeTok ","
+      symbolLikeTok ")"
+      pure classes
 
 dataConDeclParser :: TokParser DataConDecl
 dataConDeclParser = withSpan $ do

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -96,8 +96,8 @@ decls-data-record-empty	declarations	declarations/data-record-empty.hs	pass
 decls-data-record-fields	declarations	declarations/data-record-fields.hs	xfail	roundtrip mismatch against oracle AST
 decls-data-record-grouped-fields	declarations	declarations/data-record-grouped-fields.hs	xfail	roundtrip mismatch against oracle AST
 decls-data-record-strict-field	declarations	declarations/data-record-strict-field.hs	xfail	roundtrip mismatch against oracle AST
-decls-data-deriving-single	declarations	declarations/data-deriving-single.hs	xfail	parser intentionally disabled
-decls-data-deriving-empty	declarations	declarations/data-deriving-empty.hs	xfail	parser intentionally disabled
+decls-data-deriving-single	declarations	declarations/data-deriving-single.hs	pass	parser now supports data deriving clauses
+decls-data-deriving-empty	declarations	declarations/data-deriving-empty.hs	pass	parser now supports empty data deriving clauses
 decls-data-abstract	declarations	declarations/data-abstract.hs	pass
 decls-newtype	declarations	declarations/newtype.hs	pass	parser now supports simple newtype declarations
 decls-type-synonym	declarations	declarations/type-synonym.hs	pass	parser now supports type synonym declarations
@@ -116,7 +116,7 @@ decls-class-cdecl-fixity	declarations	declarations/class-cdecl-fixity.hs	xfail	p
 decls-instance	declarations	declarations/instance.hs	xfail	parser intentionally disabled
 decls-fixity	declarations	declarations/fixity.hs	xfail	parser intentionally disabled
 decls-default	declarations	declarations/default.hs	xfail	default declarations unsupported
-decls-deriving	declarations	declarations/deriving.hs	xfail	parser intentionally disabled
+decls-deriving	declarations	declarations/deriving.hs	pass	parser now supports parenthesized data deriving clauses
 
 expr-if-then-else	expressions	expressions/if-then-else.hs	pass	parser now handles this if-then-else form
 expr-case-of	expressions	expressions/case-of.hs	pass	parser now supports simple case-of expressions


### PR DESCRIPTION
## Summary
- Implement parsing of `deriving` clauses for `data` declarations.
- Support all Haskell2010 forms covered by fixtures: `deriving Eq`, `deriving (Eq, Show)`, and `deriving ()`.
- Promote now-passing Haskell2010 fixture cases from `xfail` to `pass`:
  - `decls-data-deriving-single`
  - `decls-data-deriving-empty`
  - `decls-deriving`

## Testing
- `nix run .#parser-progress`
- `nix flake check`

## Progress Counts
- Haskell2010 manifest expectations:
  - Before: `pass=154`, `xfail=86`
  - After: `pass=157`, `xfail=83`
  - Delta: `pass +3`, `xfail -3`
- Current `parser-progress` output:
  - `PASS 157`, `XFAIL 83`, `XPASS 0`, `FAIL 0`, `TOTAL 240`, `COMPLETE 65.41%`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Haskell deriving clauses in data declarations, enabling the parser to properly handle both single and multiple class derivations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->