### PR TITLE
Implement PackageImports

### DIFF
--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -83,6 +83,7 @@ data ExportSpec
 
 data ImportDecl = ImportDecl
   { importDeclSpan :: SourceSpan,
+    importDeclPackage :: Maybe Text,
     importDeclQualified :: Bool,
     importDeclQualifiedPost :: Bool,
     importDeclModule :: Text,

--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -85,6 +85,7 @@ importDeclParser = withSpan $ do
   keywordTok TkKeywordImport
   preQualified <-
     MP.option False (keywordTok TkKeywordQualified >> pure True)
+  importedPackage <- MP.optional packageNameParser
   importedModule <- moduleNameParser
   postQualified <-
     MP.option False (keywordTok TkKeywordQualified >> pure True)
@@ -96,12 +97,20 @@ importDeclParser = withSpan $ do
   pure $ \span' ->
     ImportDecl
       { importDeclSpan = span',
+        importDeclPackage = importedPackage,
         importDeclQualified = isQualified,
         importDeclQualifiedPost = postQualified,
         importDeclModule = importedModule,
         importDeclAs = importAlias,
         importDeclSpec = importSpec
       }
+
+packageNameParser :: TokParser Text
+packageNameParser =
+  tokenSatisfy $ \tok ->
+    case lexTokenKind tok of
+      TkString txt -> Just txt
+      _ -> Nothing
 
 importSpecParser :: TokParser ImportSpec
 importSpecParser = withSpan $ do

--- a/components/haskell-parser/src/Parser/Pretty.hs
+++ b/components/haskell-parser/src/Parser/Pretty.hs
@@ -6,7 +6,7 @@ module Parser.Pretty
   )
 where
 
-import Data.Maybe (catMaybes, isJust)
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Parser.Ast
@@ -69,15 +69,19 @@ prettyImportDecl :: ImportDecl -> Doc ann
 prettyImportDecl decl =
   let renderPostQualified =
         importDeclQualifiedPost decl
-          && (isJust (importDeclAs decl) || isJust (importDeclSpec decl))
+          && importDeclQualified decl
    in hsep
         ( ["import"]
             <> ["qualified" | importDeclQualified decl && not renderPostQualified]
+            <> maybe [] (\pkg -> [prettyQuotedText pkg]) (importDeclPackage decl)
             <> [pretty (importDeclModule decl)]
             <> ["qualified" | importDeclQualified decl && renderPostQualified]
             <> maybe [] (\alias -> ["as", pretty alias]) (importDeclAs decl)
             <> maybe [] (\spec -> [prettyImportSpec spec]) (importDeclSpec decl)
         )
+
+prettyQuotedText :: Text -> Doc ann
+prettyQuotedText txt = "\"" <> pretty txt <> "\""
 
 prettyImportSpec :: ImportSpec -> Doc ann
 prettyImportSpec spec =

--- a/components/haskell-parser/test/Test/Fixtures/PackageImports/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/PackageImports/manifest.tsv
@@ -1,3 +1,3 @@
-package-imports-basic	modules	package-imports-basic.hs	xfail	parser support pending
-package-imports-qualified	modules	package-imports-qualified.hs	xfail	parser support pending
-package-imports-qualified-post	modules	package-imports-qualified-post.hs	xfail	parser support pending
+package-imports-basic	modules	package-imports-basic.hs	pass
+package-imports-qualified	modules	package-imports-qualified.hs	pass
+package-imports-qualified-post	modules	package-imports-qualified-post.hs	pass

--- a/components/haskell-parser/test/Test/Fixtures/extensions.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/extensions.tsv
@@ -1,5 +1,6 @@
 # extension	fixture_dir	notes
 ParallelListComp	ParallelListComp	Parallel list comprehensions
+PackageImports	PackageImports	Package-qualified imports
 QuasiQuotes	QuasiQuotes	Quasi quotes
 TypeApplications	TypeApplications	Type applications
 ViewPatterns	ViewPatterns	View patterns


### PR DESCRIPTION
## Summary
- implement parser support for `PackageImports` by accepting optional package qualifiers (`import "pkg" Module`)
- add `importDeclPackage :: Maybe Text` to the parser AST
- support package-qualified imports in pretty-printing, including `qualified` post-position for package imports
- mark `PackageImports` extension fixtures as passing and register the extension in `extensions.tsv`

## Validation
- `nix flake check` (pass)
- `nix run .#parser-extension-progress` (pass)
- `nix run .#parser-progress` (pass)
- `nix run .#cpp-progress` (pass)
- `nix run .#name-resolution-progress` (pass)

## Progress Counts
- Parser (`nix run .#parser-progress`): `154/240` (`64.16%`) [PASS=154 XFAIL=86 XPASS=0 FAIL=0]
- Extensions (`nix run .#parser-extension-progress`):
  - Before: `SUPPORTED=1`, `IN_PROGRESS=12`, `PLANNED=45`, `TOTAL=58`
  - After: `SUPPORTED=2`, `IN_PROGRESS=12`, `PLANNED=45`, `TOTAL=59`
  - `PackageImports`: `PASS=3 XFAIL=0 XPASS=0 FAIL=0` (`Supported`)
- CPP (`nix run .#cpp-progress`): `9/14` (`64.28%`) [PASS=9 XFAIL=5 XPASS=0 FAIL=0]
- Name-resolution (`nix run .#name-resolution-progress`): `10/12` (`83.33%`) [PASS=10 XFAIL=2 XPASS=0 FAIL=0]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Extended Haskell parser to support package-qualified import declarations, enabling recognition and proper rendering of optional package specifications in import statements. This improves compatibility with modern Haskell syntax conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->