### PR TITLE
Add parser-fuzz flag for printing generated modules

### DIFF
--- a/components/haskell-parser/app/parser-fuzz/Main.hs
+++ b/components/haskell-parser/app/parser-fuzz/Main.hs
@@ -17,7 +17,8 @@ data Options = Options
     optMaxTests :: Int,
     optSize :: Int,
     optMaxShrinkPasses :: Int,
-    optOutput :: Maybe FilePath
+    optOutput :: Maybe FilePath,
+    optPrintGeneratedModules :: Bool
   }
 
 data SearchResult = SearchResult
@@ -111,19 +112,24 @@ optionsParser =
               <> OA.help "Write minimized source to PATH"
           )
       )
+    <*> OA.switch
+      ( OA.long "print-generated-modules"
+          <> OA.help "Print each generated module before testing it"
+      )
 
 runWithOptions :: Options -> IO ()
 runWithOptions opts = do
   seed <- resolveSeed (optSeed opts)
-  case findFirstFailure opts seed of
+  found <- findFirstFailure opts seed
+  case found of
     Nothing -> do
       putStrLn ("Seed: " <> show seed)
       putStrLn ("Tests tried: " <> show (optMaxTests opts))
       putStrLn "No failing module found."
-    Just found -> do
-      let (minimized, shrinksAccepted) = shrinkCandidate opts (srCandidate found)
+    Just result -> do
+      let (minimized, shrinksAccepted) = shrinkCandidate opts (srCandidate result)
       putStrLn ("Seed: " <> show seed)
-      putStrLn ("Tests tried: " <> show (srTestsTried found))
+      putStrLn ("Tests tried: " <> show (srTestsTried result))
       putStrLn ("Shrink passes accepted: " <> show shrinksAccepted)
       putStrLn "Minimized source:"
       putStrLn "---8<---"
@@ -139,19 +145,30 @@ resolveSeed :: Maybe Int -> IO Int
 resolveSeed (Just seed) = pure seed
 resolveSeed Nothing = randomIO
 
-findFirstFailure :: Options -> Int -> Maybe SearchResult
+findFirstFailure :: Options -> Int -> IO (Maybe SearchResult)
 findFirstFailure opts seed = go 1 (qcGenStream seed)
   where
-    go :: Int -> [QCGen] -> Maybe SearchResult
-    go _ [] = Nothing
+    go :: Int -> [QCGen] -> IO (Maybe SearchResult)
+    go _ [] = pure Nothing
     go idx (g : gs)
-      | idx > optMaxTests opts = Nothing
+      | idx > optMaxTests opts = pure Nothing
       | otherwise =
           let generated = unGen (arbitrary :: Gen GenModule) g (optSize opts)
               candidate = materializeCandidate generated
-           in if oursFails (candSource candidate)
-                then Just (SearchResult idx candidate)
-                else go (idx + 1) gs
+           in do
+                printGeneratedModule opts idx candidate
+                if oursFails (candSource candidate)
+                  then pure (Just (SearchResult idx candidate))
+                  else go (idx + 1) gs
+
+printGeneratedModule :: Options -> Int -> Candidate -> IO ()
+printGeneratedModule opts idx candidate
+  | not (optPrintGeneratedModules opts) = pure ()
+  | otherwise = do
+      putStrLn ("Generated module #" <> show idx <> ":")
+      putStrLn "---8<---"
+      putStrLn (candSource candidate)
+      putStrLn "--->8---"
 
 materializeCandidate :: GenModule -> Candidate
 materializeCandidate (GenModule modu0) =


### PR DESCRIPTION
## Summary
- add `--print-generated-modules` to `parser-fuzz`
- print each generated module to stdout before it is tested when the flag is enabled
- keep default behavior unchanged when the flag is not passed

## Validation
- `nix run .#parser-fuzz -- --help`
- `nix flake check`

## Progress Counts
No progress count changes from this PR.

- Parser (`nix run .#parser-progress`): PASS 169 / XFAIL 74 / XPASS 0 / FAIL 0 / TOTAL 243 / COMPLETE 69.54% (delta: 0)
- Extensions (`nix run .#parser-extension-progress`): SUPPORTED 8 / IN_PROGRESS 14 / PLANNED 37 / TOTAL 59 (delta: 0)
- CPP (`nix run .#cpp-progress`): PASS 9 / XFAIL 5 / XPASS 0 / FAIL 0 / TOTAL 14 / COMPLETE 64.28% (delta: 0)
- Name-resolution (`nix run .#name-resolution-progress`): PASS 10 / XFAIL 2 / XPASS 0 / FAIL 0 / TOTAL 12 / COMPLETE 83.33% (delta: 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command-line flag to print generated test modules during execution for better visibility into testing process.
  * Added ability to save minimized failing test cases to an output file for further analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->