### PR TITLE
refactor(nix): remove repo-root checks from nix app wrappers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,15 +36,16 @@
           stackageProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "stackage-progress";
           nameResolutionProgressExe =
             pkgs.lib.getExe' hsPkgs.aihc-name-resolution "name-resolution-progress";
-          mkApp = name: text: {
+          mkAppWithInputs = name: runtimeInputs: text: {
             type = "app";
             program = "${pkgs.writeShellApplication {
               inherit name;
-              runtimeInputs = [ pkgs.bash pkgs.cabal-install pkgs.ghc ];
+              inherit runtimeInputs;
               inherit text;
             }}/bin/${name}";
             meta.description = "aihc app: ${name}";
           };
+          mkApp = name: text: mkAppWithInputs name [ pkgs.bash pkgs.cabal-install pkgs.ghc ] text;
           mkReportsApp = name: text: {
             type = "app";
             program = "${pkgs.writeShellApplication {
@@ -82,7 +83,6 @@
 
           hackage-tester = mkApp "hackage-tester" ''
             set -euo pipefail
-            cabal update 2>/dev/null || true
             ${hackageTesterExe} "$@"
           '';
 
@@ -111,14 +111,24 @@
             cabal test --test-show-details=direct
           '';
 
-          cpp-progress = mkApp "cpp-progress" ''
+          cpp-progress = mkAppWithInputs "cpp-progress" [
+            pkgs.bash
+            pkgs.cabal-install
+            pkgs.ghc
+            pkgs.haskellPackages.cpphs
+          ] ''
             set -euo pipefail
-            CPPHS_BIN='${pkgs.lib.getExe pkgs.haskellPackages.cpphs}' ${cppProgressExe}
+            ${cppProgressExe}
           '';
 
-          cpp-progress-strict = mkApp "cpp-progress-strict" ''
+          cpp-progress-strict = mkAppWithInputs "cpp-progress-strict" [
+            pkgs.bash
+            pkgs.cabal-install
+            pkgs.ghc
+            pkgs.haskellPackages.cpphs
+          ] ''
             set -euo pipefail
-            CPPHS_BIN='${pkgs.lib.getExe pkgs.haskellPackages.cpphs}' ${cppProgressExe} --strict
+            ${cppProgressExe} --strict
           '';
 
           name-resolution-test = mkApp "name-resolution-test" ''
@@ -224,7 +234,7 @@
             nativeBuildInputs = [ hsPkgs.aihc-cpp pkgs.haskellPackages.cpphs ];
           } ''
             cd "$src/components/haskell-cpp"
-            CPPHS_BIN='${pkgs.lib.getExe pkgs.haskellPackages.cpphs}' cpp-progress --strict
+            cpp-progress --strict
             touch "$out"
           '';
           nameResolutionProgressStrict = pkgs.runCommand "aihc-name-resolution-progress-strict" {


### PR DESCRIPTION
## Summary
- remove repository-root guard snippets from nix app wrappers that directly execute nix-built binaries
- drop redundant `cd components/*` transitions for those wrappers
- keep cabal test and report script wrappers unchanged

## Validation
- `nix flake check`

## Progress Counts
- `parser-progress`: PASS 212, XFAIL 149, XPASS 0, FAIL 0, TOTAL 361, COMPLETE 58.72%
- `parser-extension-progress`: SUPPORTED 10, IN_PROGRESS 21, PLANNED 29, TOTAL 60
- `cpp-progress`: PASS 9, XFAIL 5, XPASS 0, FAIL 0, TOTAL 14, COMPLETE 64.28%
- `name-resolution-progress`: PASS 10, XFAIL 2, XPASS 0, FAIL 0, TOTAL 12, COMPLETE 83.33%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can now declare explicit runtime dependencies per app, enabling more flexible and explicit runtime input control.

* **Refactor**
  * Simplified app definitions by removing directory-switching and repository-root guard logic. Apps now run directly without prior path validation, and hard-coded runtime inputs were replaced by the new per-app runtime-dependency mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->