### PR TITLE
refactor: remove CPP usage and conditional compilation

### DIFF
--- a/components/haskell-parser/app/hackage-tester/Main.hs
+++ b/components/haskell-parser/app/hackage-tester/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where

--- a/components/haskell-parser/app/stackage-progress/Main.hs
+++ b/components/haskell-parser/app/stackage-progress/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where

--- a/components/haskell-parser/common/GhcOracle.hs
+++ b/components/haskell-parser/common/GhcOracle.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module GhcOracle
@@ -53,7 +52,6 @@ oracleModuleAstFingerprintWithExtensionsAt sourceTag exts input = do
   pure (pragmaFingerprint <> T.pack (showSDocUnsafe (ppr parsed)))
 
 parseWithGhcWithExtensions :: String -> [Extension] -> Text -> Either Text ([Text], HsModule GhcPs)
-#if __GLASGOW_HASKELL__ >= 910
 parseWithGhcWithExtensions sourceTag extraExts input =
   let parseExts = EnumSet.fromList (nub (ForeignFunctionInterface : extraExts)) :: EnumSet.EnumSet Extension
       opts = mkParserOpts parseExts emptyDiagOpts False False False False
@@ -66,20 +64,6 @@ parseWithGhcWithExtensions sourceTag extraExts input =
         PFailed st ->
           let rendered = showSDocUnsafe (pprMessages NoDiagnosticOpts (getPsErrorMessages st))
            in Left (T.pack rendered)
-#else
-parseWithGhcWithExtensions sourceTag extraExts input =
-  let parseExts = EnumSet.fromList (nub (ForeignFunctionInterface : extraExts)) :: EnumSet.EnumSet Extension
-      opts = mkParserOpts parseExts emptyDiagOpts [] False False False False
-      languagePragmas = extractLanguagePragmas input
-      sanitizedInput = stripLanguagePragmaLines input
-      buffer = stringToStringBuffer (T.unpack sanitizedInput)
-      start = mkRealSrcLoc (mkFastString sourceTag) 1 1
-   in case unP parseModule (initParserState opts buffer start) of
-        POk _ modu -> Right (languagePragmas, unLoc modu)
-        PFailed st ->
-          let rendered = showSDocUnsafe (pprMessages NoDiagnosticOpts (getPsErrorMessages st))
-           in Left (T.pack rendered)
-#endif
 
 extractLanguagePragmas :: Text -> [Text]
 extractLanguagePragmas =


### PR DESCRIPTION
Removed LANGUAGE CPP and conditional compilation blocks across the codebase as we are using Nix to pin dependencies.

- Removed `{-# LANGUAGE CPP #-}` from `hackage-tester`, `stackage-progress`, and `GhcOracle.hs`.
- Removed GHC version-specific conditional compilation in `GhcOracle.hs`, defaulting to GHC 9.10+ compatible code (consistent with the project's current GHC 9.6.7+ environment and Nix pinning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed C preprocessor (CPP) support and conditional compilation logic across multiple components.
  * Updated minimum GHC version requirement to >= 910 for all compiler-related functionality.
  * Simplified the overall build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->