### PR TITLE
fix(parser): support No-prefixed LANGUAGE pragmas in GHC oracle

### DIFF
--- a/components/haskell-parser/common/GhcOracle.hs
+++ b/components/haskell-parser/common/GhcOracle.hs
@@ -60,8 +60,8 @@ parseWithGhcWithExtensions :: String -> [Extension] -> Text -> Either Text ([Tex
 parseWithGhcWithExtensions sourceTag extraExts input =
   let baseExts = nub extraExts
       languagePragmas = extractLanguagePragmas sourceTag baseExts input
-      pragmaExts = mapMaybe (parseExtension . T.unpack) languagePragmas
-      parseExts = EnumSet.fromList (nub (baseExts <> pragmaExts)) :: EnumSet.EnumSet Extension
+      pragmaSettings = mapMaybe (parseExtensionSetting . T.unpack) languagePragmas
+      parseExts = foldl' applyExtensionSetting (EnumSet.fromList baseExts :: EnumSet.EnumSet Extension) pragmaSettings
       opts = mkParserOpts parseExts emptyDiagOpts False False False False
       buffer = stringToStringBuffer (T.unpack input)
       start = mkRealSrcLoc (mkFastString sourceTag) 1 1
@@ -85,7 +85,13 @@ extractLanguagePragmas sourceTag baseExts input =
       (_warns, rawOptions) = getOptions baseOpts supportedLanguagePragmas buffer sourceTag
    in mapMaybe optionToLanguagePragma rawOptions
   where
-    supportedLanguagePragmas = "CPP" : map show ([minBound .. maxBound] :: [Extension])
+    supportedLanguagePragmas =
+      "CPP" : concatMap (includeNegative . show) ([minBound .. maxBound] :: [Extension])
+
+    includeNegative extName =
+      case extName of
+        "Cpp" -> [extName, "NoCPP", "NoCpp"]
+        _ -> [extName, "No" <> extName]
 
     optionToLanguagePragma locatedOpt =
       let opt = T.pack (unLoc locatedOpt)
@@ -107,15 +113,34 @@ oracleDetailedParsesModuleWithNames = oracleDetailedParsesModuleWithNamesAt "ora
 
 oracleDetailedParsesModuleWithNamesAt :: String -> [String] -> Maybe String -> Text -> Either Text ()
 oracleDetailedParsesModuleWithNamesAt sourceTag extNames langName input =
-  let exts = mapMaybe parseExtension extNames
+  let extSettings = mapMaybe parseExtensionSetting extNames
       langExts = maybe [] languageExtensions langName
-      allExts = nub (exts <> langExts)
+      allExts = EnumSet.toList (foldl' applyExtensionSetting (EnumSet.fromList langExts) extSettings)
    in case parseWithGhcWithExtensions sourceTag allExts input of
         Left err ->
           let extList = T.pack (show extNames)
               langInfo = maybe "" (\l -> " Language: " <> T.pack l) langName
            in Left (err <> "\n(Extensions: " <> extList <> langInfo <> ")")
         Right _ -> Right ()
+
+data ExtensionSetting
+  = Enable Extension
+  | Disable Extension
+
+applyExtensionSetting :: EnumSet.EnumSet Extension -> ExtensionSetting -> EnumSet.EnumSet Extension
+applyExtensionSetting exts setting =
+  case setting of
+    Enable ext -> EnumSet.insert ext exts
+    Disable ext -> EnumSet.delete ext exts
+
+parseExtensionSetting :: String -> Maybe ExtensionSetting
+parseExtensionSetting name =
+  case stripNoPrefix name of
+    Just enabledName -> Disable <$> parseExtension enabledName
+    Nothing -> Enable <$> parseExtension name
+  where
+    stripNoPrefix ('N' : 'o' : rest) | not (null rest) = Just rest
+    stripNoPrefix _ = Nothing
 
 parseExtension :: String -> Maybe Extension
 parseExtension name =

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -5,6 +5,8 @@ module Test.HackageTester.Suite
   )
 where
 
+import qualified Data.Text as T
+import GhcOracle (oracleDetailedParsesModuleWithNamesAt)
 import HackageTester.CLI (Options (..), parseOptionsPure)
 import HackageTester.Model (FileResult (..), Outcome (..), Summary (..), shouldFailSummary, summarizeResults)
 import Test.Tasty (TestTree, testGroup)
@@ -25,6 +27,10 @@ hackageTesterTests =
         "summary"
         [ testCase "counts outcomes correctly" test_summaryCountsOutcomes,
           testCase "fails when no files were processed" test_zeroFilesFails
+        ],
+      testGroup
+        "oracle"
+        [ testCase "accepts No-prefixed LANGUAGE pragmas" test_oracleAcceptsNoPrefixedLanguagePragma
         ]
     ]
 
@@ -69,6 +75,22 @@ test_summaryCountsOutcomes = do
 test_zeroFilesFails :: Assertion
 test_zeroFilesFails =
   assertBool "expected empty run to fail" (shouldFailSummary (summarizeResults []))
+
+test_oracleAcceptsNoPrefixedLanguagePragma :: Assertion
+test_oracleAcceptsNoPrefixedLanguagePragma =
+  case oracleDetailedParsesModuleWithNamesAt "hackage-tester" [] Nothing source of
+    Left err ->
+      assertBool
+        ("expected NoMonomorphismRestriction pragma to be accepted, got: " <> T.unpack err)
+        False
+    Right () -> pure ()
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE NoMonomorphismRestriction #-}",
+          "module A where",
+          "x = 1"
+        ]
 
 assertLeftContaining :: String -> Either String a -> Assertion
 assertLeftContaining needle result =


### PR DESCRIPTION
## Summary
- accept `No`-prefixed LANGUAGE pragmas in `GhcOracle` pragma extraction (`supportedLanguagePragmas` now includes negative forms)
- apply pragma extension settings with enable/disable semantics (`NoX` removes `X`, `X` enables it)
- add hackage-tester oracle regression test for `{-# LANGUAGE NoMonomorphismRestriction #-}`
- include `NoCPP` handling so canonical casing is accepted

## Validation
- `nix flake check`
- `nix run .#hackage-tester -- ace` (verifies the previous `Unsupported extension: NoMonomorphismRestriction` crash is gone; command now reaches parser/roundtrip outcomes)

## Progress Counts
No progress-count changes in this PR (no fixture/progress-manifest updates).

Current snapshots:
- Parser: PASS 243, XFAIL 137, XPASS 0, FAIL 0, TOTAL 380, COMPLETE 63.94%
- Parser extensions: SUPPORTED 13, IN_PROGRESS 19, PLANNED 29, TOTAL 61
- CPP: PASS 19, XFAIL 9, XPASS 0, FAIL 0, TOTAL 28, COMPLETE 67.85%
- Name-resolution: PASS 10, XFAIL 2, XPASS 0, FAIL 0, TOTAL 12, COMPLETE 83.33%

## CodeRabbit
- `coderabbit review --prompt-only` was attempted after checks.
- Skipped due to service rate limit: "Rate limit exceeded, please try after 20 minutes and 42 seconds".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The Haskell parser now supports negated language pragmas (e.g., `NoMonomorphismRestriction`, `NoCPP`), enabling users to explicitly disable specific language extensions in addition to enabling them.

* **Tests**
  * Added test coverage verifying support for negated language pragmas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->