### PR TITLE
fix(parser): preserve raw LANGUAGE pragma text

### DIFF
--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -45,7 +45,7 @@ moduleParser = withSpan $ do
     Module
       { moduleSpan = span',
         moduleName = mName,
-        moduleLanguagePragmas = concat languagePragmas,
+        moduleLanguagePragmas = languagePragmas,
         moduleWarningText = mWarning,
         moduleExports = mExports,
         moduleImports = imports,

--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -289,7 +289,7 @@ data WarningText
 data Module = Module
   { moduleSpan :: SourceSpan,
     moduleName :: Maybe Text,
-    moduleLanguagePragmas :: [ExtensionSetting],
+    moduleLanguagePragmas :: [(Text, [ExtensionSetting])],
     moduleWarningText :: Maybe WarningText,
     moduleExports :: Maybe [ExportSpec],
     moduleImports :: [ImportDecl],

--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -16,15 +16,15 @@ import qualified Data.Text as T
 import Parser.Ast
 import Parser.Internal.Common
 import Parser.Internal.Expr (equationRhsParser, exprParser, simplePatternParser, typeAtomParser, typeParser)
-import Parser.Lexer (LexTokenKind (..), lexTokenKind)
+import Parser.Lexer (LexToken (..), LexTokenKind (..))
 import Text.Megaparsec ((<|>))
 import qualified Text.Megaparsec as MP
 
-languagePragmaParser :: TokParser [ExtensionSetting]
+languagePragmaParser :: TokParser (Text, [ExtensionSetting])
 languagePragmaParser =
   tokenSatisfy $ \tok ->
     case lexTokenKind tok of
-      TkPragmaLanguage names -> Just names
+      TkPragmaLanguage names -> Just (lexTokenText tok, names)
       _ -> Nothing
 
 moduleHeaderParser :: TokParser (Text, Maybe WarningText, Maybe [ExportSpec])

--- a/components/haskell-parser/src/Parser/Lexer.hs
+++ b/components/haskell-parser/src/Parser/Lexer.hs
@@ -520,14 +520,49 @@ lexTokenParser =
 -- canonical comma-separated representation.
 languagePragmaToken :: LParser (Text, LexTokenKind)
 languagePragmaToken = do
-  _ <- C.string "{-#"
-  _ <- many C.spaceChar
-  _ <- C.string "LANGUAGE"
-  _ <- many C.spaceChar
-  body <- manyTillText "#-}"
+  (raw, body) <- MP.match $ do
+    _ <- C.string "{-#"
+    _ <- many C.spaceChar
+    _ <- C.string "LANGUAGE"
+    manyTillTextPragma "#-}"
   let names = parseLanguagePragmaNames (T.pack body)
-      raw = "{-# LANGUAGE " <> T.intercalate ", " (map extensionSettingName names) <> " #-}"
   pure (raw, TkPragmaLanguage names)
+
+-- | Consume characters until @end@ text marker (excluding terminator from result).
+--
+-- This version handles nested block comments specifically for pragmas,
+-- which GHC supports.
+manyTillTextPragma :: Text -> LParser String
+manyTillTextPragma end = go []
+  where
+    go acc =
+      (try (C.string end) >> pure (reverse acc))
+        <|> do
+          ch <- anySingle
+          case ch of
+            '{' -> do
+              mHash <- MP.optional (C.char '#')
+              case mHash of
+                Just _ -> go ('#' : '{' : acc)
+                Nothing -> do
+                  mDash <- MP.optional (C.char '-')
+                  case mDash of
+                    Just _ -> do
+                      innerBody <- skipNestedBlockCommentBodyPragma 1
+                      go (reverse innerBody ++ "-{" ++ acc)
+                    Nothing -> go ('{' : acc)
+            _ -> go (ch : acc)
+
+-- | Skip the remaining body of a nested block comment and return it.
+skipNestedBlockCommentBodyPragma :: Int -> LParser String
+skipNestedBlockCommentBodyPragma depth
+  | depth <= 0 = pure ""
+  | otherwise = do
+      res <-
+        try (C.string "{-" >> (("{-" ++) <$> skipNestedBlockCommentBodyPragma (depth + 1)))
+          <|> try (C.string "-}" >> (("-}" ++) <$> skipNestedBlockCommentBodyPragma (depth - 1)))
+          <|> ((\c -> [c]) <$> anySingle >>= \c -> (c ++) <$> skipNestedBlockCommentBodyPragma depth)
+      pure res
 
 -- | Parse extension names from the body of a LANGUAGE pragma.
 parseLanguagePragmaNames :: Text -> [ExtensionSetting]

--- a/components/haskell-parser/src/Parser/Pretty.hs
+++ b/components/haskell-parser/src/Parser/Pretty.hs
@@ -37,7 +37,7 @@ prettyModule modu =
   where
     pragmaLines =
       map
-        (\ext -> "{-# LANGUAGE" <+> pretty (extensionSettingName ext) <+> "#-}")
+        (\(raw, _exts) -> pretty raw)
         (moduleLanguagePragmas modu)
     headerLines =
       case moduleName modu of


### PR DESCRIPTION
## Summary
- Fixes `hackage-tester` failure for `attoparsec-uri` caused by incorrect `LANGUAGE` pragma normalization.
- Updated the lexer to capture the exact raw text of `LANGUAGE` pragmas using `MP.match`.
- Added support for nested comments within pragmas, matching GHC behavior.
- Refactored the AST and parser to store and pretty-print the original pragma text instead of a normalized version.
- Ensures multiline and complex pragma formatting is preserved for the GHC oracle.

## Verification
- `nix run .#hackage-tester -- attoparsec-uri` now passes (previously failed with `GHC-68686`).