### PR TITLE
fix(parser): suppress TTY-only progress output on non-terminal stdout

### DIFF
--- a/components/haskell-parser/app/hackage-tester/Main.hs
+++ b/components/haskell-parser/app/hackage-tester/Main.hs
@@ -30,7 +30,7 @@ import Network.HTTP.Client (HttpException, Manager, Request (responseTimeout), h
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import ParserValidation (ValidationError (..), ValidationErrorKind (..), validateParserDetailed)
 import System.Exit (exitFailure, exitSuccess)
-import System.IO (hFlush, hPutStrLn, stderr, stdout)
+import System.IO (hFlush, hIsTerminalDevice, hPutStrLn, stderr, stdout)
 
 data RunInfo = RunInfo
   { runPackageName :: String,
@@ -114,14 +114,15 @@ fetchCabalFile manager request = do
 processFiles :: Int -> FilePath -> [FileInfo] -> IO [FileResult]
 processFiles jobs packageRoot files = do
   counter <- newMVar 0
+  showProgress <- hIsTerminalDevice stdout
   let total = length files
       worker info = do
         result <- processFile packageRoot info
-        printProgress counter total
+        when showProgress (printProgress counter total)
         pure result
 
   results <- mapConcurrentlyBounded jobs worker files
-  putStrLn ""
+  when showProgress (putStrLn "")
   pure results
 
 printProgress :: MVar Int -> Int -> IO ()

--- a/components/haskell-parser/app/stackage-progress/Main.hs
+++ b/components/haskell-parser/app/stackage-progress/Main.hs
@@ -26,7 +26,7 @@ import System.Directory (XdgDirectory (XdgCache), createDirectoryIfMissing, does
 import System.Environment (getArgs)
 import System.Exit (exitFailure, exitSuccess)
 import System.FilePath ((</>))
-import System.IO (hFlush, hPutStrLn, stderr, stdout)
+import System.IO (hFlush, hIsTerminalDevice, hPutStrLn, stderr, stdout)
 import System.Process (readProcess)
 
 data Check
@@ -84,12 +84,13 @@ main = do
 
   let total = length packages
   jobs <- maybe getNumProcessors pure (optJobs opts)
-  putProgressLine (ProgressState 0 0 total)
-  results <- mapConcurrentlyChunksWithProgress jobs (runPackage opts) packages total
+  showProgress <- hIsTerminalDevice stdout
+  when showProgress (putProgressLine (ProgressState 0 0 total))
+  results <- mapConcurrentlyChunksWithProgress jobs (runPackage opts) packages total showProgress
   let successOursN = length [() | result <- results, packageOursOk result]
       successHseN = length [() | result <- results, packageHseOk result]
       successGhcN = length [() | result <- results, packageGhcOk result]
-  putStrLn ""
+  when showProgress (putStrLn "")
 
   when (optPrintSucceeded opts) $ do
     mapM_ putStrLn [formatPackage (package result) | result <- results, packageOursOk result]
@@ -942,8 +943,8 @@ stripArithSeq seqExpr =
     ArithSeqFromTo _ a b -> ArithSeqFromTo noSourceSpan (stripExpr a) (stripExpr b)
     ArithSeqFromThenTo _ a b c -> ArithSeqFromThenTo noSourceSpan (stripExpr a) (stripExpr b) (stripExpr c)
 
-mapConcurrentlyChunksWithProgress :: Int -> (a -> IO PackageResult) -> [a] -> Int -> IO [PackageResult]
-mapConcurrentlyChunksWithProgress n action items total =
+mapConcurrentlyChunksWithProgress :: Int -> (a -> IO PackageResult) -> [a] -> Int -> Bool -> IO [PackageResult]
+mapConcurrentlyChunksWithProgress n action items total showProgress =
   go 0 0 [] (chunksOf chunkSize items)
   where
     chunkSize = if n <= 0 then 1 else n
@@ -952,7 +953,7 @@ mapConcurrentlyChunksWithProgress n action items total =
       batch <- mapConcurrently action chunk
       let done' = done + length batch
           success' = success + length [() | result <- batch, packageOursOk result]
-      putProgressLine (ProgressState done' success' total)
+      when showProgress (putProgressLine (ProgressState done' success' total))
       go done' success' (batch : acc) rest
 
 chunksOf :: Int -> [a] -> [[a]]


### PR DESCRIPTION
## Summary
- Gate live `\r` progress updates in `hackage-tester` behind `hIsTerminalDevice stdout`, so progress lines are only emitted for terminal output.
- Apply the same TTY guard in `stackage-progress`, including both the initial status line and per-batch progress updates.
- Preserve existing progress behavior for interactive runs while avoiding carriage-return noise in redirected/piped output.

## Validation
- `nix flake check`
- `nix run .#parser-progress`
- `nix run .#parser-extension-progress`
- `nix run .#cpp-progress`
- `nix run .#name-resolution-progress`
- `coderabbit review --prompt-only` (no findings)

## Progress Counts
- Parser progress: `PASS 254`, `XFAIL 132`, `XPASS 0`, `FAIL 0`, `TOTAL 386`, `COMPLETE 65.8%`
- Parser extension progress: `SUPPORTED 15`, `IN_PROGRESS 18`, `PLANNED 105`, `TOTAL 138`
- CPP progress: `PASS 22`, `XFAIL 3`, `XPASS 0`, `FAIL 0`, `TOTAL 25`, `COMPLETE 88.0%`
- Name-resolution progress: `PASS 10`, `XFAIL 2`, `XPASS 0`, `FAIL 0`, `TOTAL 12`, `COMPLETE 83.33%`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress output now displays only when printing to a terminal, eliminating unnecessary messages when output is redirected or piped to other commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->