### PR TITLE
fix(parser-fuzz): omit long minimizer output

### DIFF
--- a/components/haskell-parser/app/parser-fuzz/ParserFuzz/Testing.hs
+++ b/components/haskell-parser/app/parser-fuzz/ParserFuzz/Testing.hs
@@ -22,14 +22,19 @@ runWithOptions opts = do
       putStrLn "No failing module found."
     Just result -> do
       let (minimized, shrinksAccepted) = shrinkCandidate opts (srCandidate result)
+          minimizedSource = candSource minimized
       putStrLn ("Seed: " <> show seed)
       putStrLn ("Tests tried: " <> show (srTestsTried result))
       putStrLn ("Shrink passes accepted: " <> show shrinksAccepted)
-      putStrLn "Minimized source:"
-      putStrLn "---8<---"
-      putStrLn (candSource minimized)
-      putStrLn "--->8---"
-      case validateParser (T.pack (candSource minimized)) of
+      if lineCount minimizedSource <= 5
+        then do
+          putStrLn "Minimized source:"
+          putStrLn "---8<---"
+          putStrLn minimizedSource
+          putStrLn "--->8---"
+        else
+          putStrLn "Minimized source omitted (>5 lines)."
+      case validateParser (T.pack minimizedSource) of
         Nothing -> pure ()
         Just err -> do
           putStrLn "Validation failure:"
@@ -37,7 +42,7 @@ runWithOptions opts = do
       case optOutput opts of
         Nothing -> pure ()
         Just path -> do
-          writeFile path (candSource minimized)
+          writeFile path minimizedSource
           putStrLn ("Wrote minimized source to " <> path)
 
 resolveSeed :: Maybe Int -> IO Int
@@ -106,3 +111,6 @@ oursFails source =
   case validateParser (T.pack source) of
     Nothing -> False
     Just _ -> True
+
+lineCount :: String -> Int
+lineCount = length . lines


### PR DESCRIPTION
## Summary
- omit printing the minimizer output in `parser-fuzz` when the minimized source is longer than 5 lines
- keep validation and optional `--output` file behavior unchanged by reusing the same `minimizedSource` value
- print an explicit message (`Minimized source omitted (>5 lines).`) when output is suppressed

## Testing
- `nix flake check` (pass)

## Progress Counts (main -> this PR)
- Parser progress: PASS 254, XFAIL 132, XPASS 0, FAIL 0, TOTAL 386, COMPLETE 65.8% -> unchanged
- Parser extension progress: SUPPORTED 15, IN_PROGRESS 18, PLANNED 105, TOTAL 138 -> unchanged
- CPP progress: PASS 22, XFAIL 3, XPASS 0, FAIL 0, TOTAL 25, COMPLETE 88.0% -> unchanged
- Name-resolution progress: PASS 10, XFAIL 2, XPASS 0, FAIL 0, TOTAL 12, COMPLETE 83.33% -> unchanged

## Pre-PR Review
- `coderabbit review --prompt-only` could not run due service rate limiting:
  - `Rate limit exceeded, please try after 9 minutes and 37 seconds`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the parser fuzzing tool's output management capabilities. Test output now intelligently handles minimized source code display by conditionally omitting representations that exceed 5 lines in length, reducing overall verbosity while preserving detailed test information. Related file handling and processing have been updated for consistency with the new display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->