### PR TITLE
feat(parser): trim shared minimizer logs and add hackage ghc-only mode

### DIFF
--- a/components/haskell-parser/app/hackage-tester/Main.hs
+++ b/components/haskell-parser/app/hackage-tester/Main.hs
@@ -79,7 +79,7 @@ runTesterWithVersion opts version = do
       putStrLn ("Found " ++ show (length files) ++ " Haskell source files")
 
       jobs <- maybe getNumProcessors pure (optJobs opts)
-      results <- processFiles jobs srcDir files
+      results <- processFiles opts jobs srcDir files
 
       unless (optJson opts) (printFailureDetails results)
 
@@ -111,13 +111,13 @@ fetchCabalFile manager request = do
   response <- httpLbs request' manager
   pure (responseBody response)
 
-processFiles :: Int -> FilePath -> [FileInfo] -> IO [FileResult]
-processFiles jobs packageRoot files = do
+processFiles :: Options -> Int -> FilePath -> [FileInfo] -> IO [FileResult]
+processFiles opts jobs packageRoot files = do
   counter <- newMVar 0
   showProgress <- hIsTerminalDevice stdout
   let total = length files
       worker info = do
-        result <- processFile packageRoot info
+        result <- processFile opts packageRoot info
         when showProgress (printProgress counter total)
         pure result
 
@@ -155,8 +155,8 @@ mapConcurrentlyBounded jobs action items = do
           modifyMVar_ results (\acc -> pure ((idx, value) : acc))
           workerLoop queue results
 
-processFile :: FilePath -> FileInfo -> IO FileResult
-processFile packageRoot info = do
+processFile :: Options -> FilePath -> FileInfo -> IO FileResult
+processFile opts packageRoot info = do
   let file = fileInfoPath info
   source <- TIO.readFile file
   preprocessed <- preprocessForParserIfEnabled (fileInfoExtensions info) file (resolveIncludeBestEffort packageRoot file) source
@@ -174,8 +174,8 @@ processFile packageRoot info = do
             outcomeDetail = Just err
           }
     Right () ->
-      case validateParserDetailed source' of
-        Nothing ->
+      if optOnlyGhcErrors opts
+        then
           pure
             FileResult
               { filePath = file,
@@ -183,24 +183,33 @@ processFile packageRoot info = do
                 cppDiagnostics = cppErrs,
                 outcomeDetail = Nothing
               }
-        Just err ->
-          case validationErrorKind err of
-            ValidationParseError ->
-              pure
-                FileResult
-                  { filePath = file,
-                    outcome = OutcomeParseError,
-                    cppDiagnostics = cppErrs,
-                    outcomeDetail = Just (T.pack (validationErrorMessage err))
-                  }
-            ValidationRoundtripError ->
-              pure
-                FileResult
-                  { filePath = file,
-                    outcome = OutcomeRoundtripFail,
-                    cppDiagnostics = cppErrs,
-                    outcomeDetail = Just (T.pack (validationErrorMessage err))
-                  }
+        else case validateParserDetailed source' of
+          Nothing ->
+            pure
+              FileResult
+                { filePath = file,
+                  outcome = OutcomeSuccess,
+                  cppDiagnostics = cppErrs,
+                  outcomeDetail = Nothing
+                }
+          Just err ->
+            case validationErrorKind err of
+              ValidationParseError ->
+                pure
+                  FileResult
+                    { filePath = file,
+                      outcome = OutcomeParseError,
+                      cppDiagnostics = cppErrs,
+                      outcomeDetail = Just (T.pack (validationErrorMessage err))
+                    }
+              ValidationRoundtripError ->
+                pure
+                  FileResult
+                    { filePath = file,
+                      outcome = OutcomeRoundtripFail,
+                      cppDiagnostics = cppErrs,
+                      outcomeDetail = Just (T.pack (validationErrorMessage err))
+                    }
 
 printFailureDetails :: [FileResult] -> IO ()
 printFailureDetails results = do

--- a/components/haskell-parser/common/HackageTester/CLI.hs
+++ b/components/haskell-parser/common/HackageTester/CLI.hs
@@ -11,7 +11,8 @@ data Options = Options
   { optPackage :: String,
     optVersion :: Maybe String,
     optJobs :: Maybe Int,
-    optJson :: Bool
+    optJson :: Bool,
+    optOnlyGhcErrors :: Bool
   }
   deriving (Eq, Show)
 
@@ -62,6 +63,10 @@ optionsParser =
     <*> OA.switch
       ( OA.long "json"
           <> OA.help "Print final summary as JSON"
+      )
+    <*> OA.switch
+      ( OA.long "only-ghc-errors"
+          <> OA.help "Ignore parser/roundtrip errors and report only GHC parse failures"
       )
 
 positiveIntReader :: OA.ReadM Int

--- a/components/haskell-parser/common/ParserValidation.hs
+++ b/components/haskell-parser/common/ParserValidation.hs
@@ -178,13 +178,12 @@ optionalShrunkDiagnostic exts source =
       if T.strip shrunk == T.strip source
         then ""
         else
-          unlines
-            [ "",
-              "HSE minimized reproducer:",
-              "---8<---",
-              T.unpack shrunk,
-              "--->8---"
-            ]
+          let shrunkLineCount = length (T.lines shrunk)
+              bodyLines =
+                if shrunkLineCount <= 5
+                  then ["---8<---", T.unpack shrunk, "--->8---"]
+                  else ["HSE minimized reproducer omitted (>5 lines)."]
+           in unlines (["", "HSE minimized reproducer:"] <> bodyLines)
 
 stillFails :: [Extension] -> Text -> Bool
 stillFails exts source =

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -38,15 +38,15 @@ test_cliParsesPackage :: Assertion
 test_cliParsesPackage =
   assertEqual
     "expected defaults with required package"
-    (Right (Options "transformers" Nothing Nothing False))
+    (Right (Options "transformers" Nothing Nothing False False))
     (parseOptionsPure ["transformers"])
 
 test_cliParsesOptionalFlags :: Assertion
 test_cliParsesOptionalFlags =
   assertEqual
     "expected all optional flags to parse"
-    (Right (Options "text" (Just "2.0.2") (Just 4) True))
-    (parseOptionsPure ["text", "--version", "2.0.2", "--jobs", "4", "--json"])
+    (Right (Options "text" (Just "2.0.2") (Just 4) True True))
+    (parseOptionsPure ["text", "--version", "2.0.2", "--jobs", "4", "--json", "--only-ghc-errors"])
 
 test_cliRejectsMissingPackage :: Assertion
 test_cliRejectsMissingPackage =


### PR DESCRIPTION
## Summary
- Trimmed shared HSE minimizer diagnostics in `ParserValidation` so all consumers now avoid dumping large minimized modules in logs.
  - If the minimized reproducer is 5 lines or fewer, it is printed in full.
  - If it is more than 5 lines, the message now reports it as omitted.
- Added `--only-ghc-errors` to `hackage-tester`.
  - In this mode, parser parse/roundtrip validation failures are ignored.
  - Output and failure accounting only report GHC parse failures.
- Updated `hackage-tester` CLI tests for the new option/defaults.

## Progress Counts
Current counts on this branch:
- Parser progress: `PASS 254 / XFAIL 132 / XPASS 0 / FAIL 0 / TOTAL 386 / COMPLETE 65.8%`
- Parser extension progress: `SUPPORTED 15 / IN_PROGRESS 18 / PLANNED 105 / TOTAL 138`
- CPP progress: `PASS 22 / XFAIL 3 / XPASS 0 / FAIL 0 / TOTAL 25 / COMPLETE 88.0%`
- Name-resolution progress: `PASS 10 / XFAIL 2 / XPASS 0 / FAIL 0 / TOTAL 12 / COMPLETE 83.33%`

## Validation
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--only-ghc-errors` command-line flag to focus output on compiler errors only

* **Improvements**
  * Diagnostic messages for large code reproducers are now condensed for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->