### PR TITLE
test(cpp): add xfail fixture for guarded function macros

### DIFF
--- a/components/haskell-cpp/test/Test/Fixtures/progress/function-macro-guard-patterns.hs
+++ b/components/haskell-cpp/test/Test/Fixtures/progress/function-macro-guard-patterns.hs
@@ -1,0 +1,8 @@
+#define GUARD(WORD) (size - 1) <= fromIntegral (maxBound :: WORD)
+#define PUTSUM(WORD) GUARD(WORD) = putSum (0 :: WORD) (fromIntegral size)
+#define GETSUM(WORD) GUARD(WORD) = (get :: Get WORD) >>= checkGetSum (fromIntegral size)
+
+instance ( PutSum        a, PutSum        b
+         , SumSize       a, SumSize       b) => GSerializePut (a :+: b) where
+    gPut | PUTSUM(Word8) | PUTSUM(Word16) | PUTSUM(Word32) | PUTSUM(Word64)
+         | otherwise = sizeError "encode" size

--- a/components/haskell-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/haskell-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -21,6 +21,7 @@ if-defined-bare	conditionals	if-defined-bare.hs	pass
 nested-if-blocks	conditionals	nested-if-blocks.hs	pass
 predefined-line-file	macro	predefined-line-file.hs	pass
 function-macro-basic	macro	function-macro-basic.hs	xfail	function-like macros are not implemented
+function-macro-guard-patterns	macro	function-macro-guard-patterns.hs	xfail	function-like macros are not implemented
 line-directive-file-and-number	diagnostics	line-directive-file-and-number.hs	pass
 line-directive-number-only	diagnostics	line-directive-number-only.hs	pass
 language-pragma-closing-line	lexing	language-pragma-closing-line.hs	pass


### PR DESCRIPTION
## Summary
- Add a new cpp progress fixture with guarded function-like macros in pattern guards to cover a currently unsupported macro-expansion shape.
- Mark the case as `xfail` in the cpp progress manifest with reason `function-like macros are not implemented`.
- Keep behavior expectations explicit while preventing regressions when this syntax starts passing.

## Progress counts
- Before: PASS 28, XFAIL 2, XPASS 0, FAIL 0, TOTAL 30, COMPLETE 93.33%
- After:  PASS 28, XFAIL 3, XPASS 0, FAIL 0, TOTAL 31, COMPLETE 90.32%

## Validation
- `nix run .#cpp-progress`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of serialization for complex data types with enhanced size validation and encoding guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->