### PR TITLE
fix(parser): honor CPP-defined LANGUAGE pragmas in oracle

### DIFF
--- a/components/haskell-parser/common/GhcOracle.hs
+++ b/components/haskell-parser/common/GhcOracle.hs
@@ -73,14 +73,21 @@ parseWithGhcWithExtensions :: String -> [GHC.Extension] -> Text -> Either Text (
 parseWithGhcWithExtensions sourceTag extraExts input =
   let baseExts = nub extraExts
    in do
-        languagePragmas <- extractLanguagePragmas sourceTag baseExts input
-        let parseExts =
+        initialLanguagePragmas <- extractLanguagePragmas sourceTag baseExts input
+        let initialParseExts =
               applyImpliedExtensions
-                (List.foldl' applyExtensionSetting (EnumSet.fromList baseExts :: EnumSet.EnumSet GHC.Extension) languagePragmas)
+                (List.foldl' applyExtensionSetting (EnumSet.fromList baseExts :: EnumSet.EnumSet GHC.Extension) initialLanguagePragmas)
             inputForParse =
-              if EnumSet.member GHC.Cpp parseExts
+              if EnumSet.member GHC.Cpp initialParseExts
                 then resultOutput (preprocessForParserWithoutIncludes sourceTag input)
                 else input
+            languagePragmas =
+              if EnumSet.member GHC.Cpp initialParseExts
+                then nub (initialLanguagePragmas <> moduleHeaderExtensionSettings inputForParse)
+                else initialLanguagePragmas
+            parseExts =
+              applyImpliedExtensions
+                (List.foldl' applyExtensionSetting (EnumSet.fromList baseExts :: EnumSet.EnumSet GHC.Extension) languagePragmas)
             opts = mkParserOpts parseExts emptyDiagOpts False False False True
             buffer = stringToStringBuffer (T.unpack inputForParse)
             start = mkRealSrcLoc (mkFastString sourceTag) 1 1

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -32,7 +32,8 @@ hackageTesterTests =
         "oracle"
         [ testCase "accepts No-prefixed LANGUAGE pragmas" test_oracleAcceptsNoPrefixedLanguagePragma,
           testCase "applies implied extensions" test_oracleAppliesImpliedExtensions,
-          testCase "uses Haskell2010 language defaults" test_oracleUsesHaskell2010Defaults
+          testCase "uses Haskell2010 language defaults" test_oracleUsesHaskell2010Defaults,
+          testCase "handles CPP-defined LANGUAGE pragmas" test_oracleHandlesCppDefinedLanguagePragmas
         ]
     ]
 
@@ -124,6 +125,25 @@ test_oracleUsesHaskell2010Defaults =
       T.unlines
         [ "module A where",
           "data R = R { field :: Int }"
+        ]
+
+test_oracleHandlesCppDefinedLanguagePragmas :: Assertion
+test_oracleHandlesCppDefinedLanguagePragmas =
+  case oracleDetailedParsesModuleWithNamesAt "hackage-tester" [] Nothing source of
+    Left err ->
+      assertBool
+        ("expected oracle to honor CPP-defined LANGUAGE pragmas, got: " <> T.unpack err)
+        False
+    Right () -> pure ()
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE CPP #-}",
+          "#if 1",
+          "{-# LANGUAGE LambdaCase #-}",
+          "#endif",
+          "module Test where",
+          "x = \\case _ -> ()"
         ]
 
 assertLeftContaining :: String -> Either String a -> Assertion


### PR DESCRIPTION
## Summary
- Recompute active LANGUAGE pragmas after preprocessing when `CPP` is enabled, so GHC oracle parsing sees extension pragmas revealed by CPP conditionals in module headers.
- Add a hackage-tester oracle unit test covering a `LambdaCase` pragma gated behind `#if`/`#endif`, validating that CPP-defined extension pragmas are honored.
- Validation: `nix flake check` passes, `coderabbit review --prompt-only` reports no findings.

## Progress
- Parser progress: PASS 269 / XFAIL 117 / XPASS 0 / FAIL 0 / TOTAL 386 / COMPLETE 69.68%
- Parser extension progress: SUPPORTED 17 / IN_PROGRESS 16 / PLANNED 105 / TOTAL 138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parser handling of CPP-defined LANGUAGE pragmas with improved extension derivation.

* **Tests**
  * Added test case for CPP-defined LANGUAGE pragma scenarios to ensure proper oracle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->