### PR TITLE
fix(parser): accept LANGUAGE language-version pragmas in GHC oracle

### DIFF
--- a/components/haskell-parser/common/GhcOracle.hs
+++ b/components/haskell-parser/common/GhcOracle.hs
@@ -159,6 +159,10 @@ applyImpliedExtensions = go
 supportedLanguagePragmas :: [String]
 supportedLanguagePragmas =
   [ "CPP",
+    "Haskell98",
+    "Haskell2010",
+    "GHC2021",
+    "GHC2024",
     "Safe",
     "Trustworthy",
     "Unsafe",

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -31,6 +31,7 @@ hackageTesterTests =
       testGroup
         "oracle"
         [ testCase "accepts No-prefixed LANGUAGE pragmas" test_oracleAcceptsNoPrefixedLanguagePragma,
+          testCase "accepts LANGUAGE Haskell2010 pragmas" test_oracleAcceptsHaskell2010LanguagePragma,
           testCase "applies implied extensions" test_oracleAppliesImpliedExtensions,
           testCase "uses Haskell2010 language defaults" test_oracleUsesHaskell2010Defaults,
           testCase "handles CPP-defined LANGUAGE pragmas" test_oracleHandlesCppDefinedLanguagePragmas
@@ -91,6 +92,22 @@ test_oracleAcceptsNoPrefixedLanguagePragma =
     source =
       T.unlines
         [ "{-# LANGUAGE NoMonomorphismRestriction #-}",
+          "module A where",
+          "x = 1"
+        ]
+
+test_oracleAcceptsHaskell2010LanguagePragma :: Assertion
+test_oracleAcceptsHaskell2010LanguagePragma =
+  case oracleDetailedParsesModuleWithNamesAt "hackage-tester" [] Nothing source of
+    Left err ->
+      assertBool
+        ("expected Haskell2010 language pragma to be accepted, got: " <> T.unpack err)
+        False
+    Right () -> pure ()
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE Haskell2010 #-}",
           "module A where",
           "x = 1"
         ]


### PR DESCRIPTION
## Summary
- Fix GHC oracle option parsing to recognize language-version pragmas (`Haskell98`, `Haskell2010`, `GHC2021`, `GHC2024`) instead of treating them as unsupported extensions.
- Add a regression test that verifies `{-# LANGUAGE Haskell2010 #-}` is accepted by `oracleDetailedParsesModuleWithNamesAt`.
- This unblocks oracle testing for `yi-core` where `Yi/PersistentState.hs` sets `{-# LANGUAGE Haskell2010 #-}`.

## Validation
- `nix run .#hackage-tester -- --only-ghc-errors yi-core`
- `nix flake check`

## Progress Counts
- Parser progress: `PASS 269`, `XFAIL 117`, `XPASS 0`, `FAIL 0`, `TOTAL 386`, `COMPLETE 69.68%`
- Parser extension progress: `SUPPORTED 17`, `IN_PROGRESS 16`, `PLANNED 105`, `TOTAL 138`
- CPP progress: `PASS 28`, `XFAIL 4`, `XPASS 0`, `FAIL 0`, `TOTAL 32`, `COMPLETE 87.5%`
- Name-resolution progress: `PASS 10`, `XFAIL 2`, `XPASS 0`, `FAIL 0`, `TOTAL 12`, `COMPLETE 83.33%`

## Pre-PR Review
- `coderabbit review --prompt-only` could not be completed due to service rate limiting ("Rate limit exceeded, please try after 23 minutes and 58 seconds").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended language pragma support to include Haskell98, Haskell2010, GHC2021, and GHC2024 for improved parser compatibility.

* **Tests**
  * Added test coverage for Haskell2010 pragma recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->