### PR TITLE
fix(parser): respect header boundary and Haskell98 default language

### DIFF
--- a/components/haskell-parser/common/HackageSupport.hs
+++ b/components/haskell-parser/common/HackageSupport.hs
@@ -210,7 +210,7 @@ extractLanguage :: BuildInfo -> Maybe String
 extractLanguage bi =
   case defaultLanguage bi of
     Just lang -> Just (prettyShow lang)
-    Nothing -> Just "Haskell2010"
+    Nothing -> Just "Haskell98"
 
 collectCondTreeData :: CondTree v c a -> [a]
 collectCondTreeData tree =

--- a/components/haskell-parser/src/Parser/Lexer.hs
+++ b/components/haskell-parser/src/Parser/Lexer.hs
@@ -146,20 +146,24 @@ lexModuleTokens input =
 -- and stops at the first non-pragma token.
 readModuleHeaderExtensions :: Text -> [ExtensionSetting]
 readModuleHeaderExtensions input =
-  case runParser (triviaConsumer *> many (lexTokenParser <* triviaConsumer) <* eof) "<module-header>" input of
-    Right toks ->
-      concatMap languageSettings (takeWhile isHeaderPragma toks)
+  case runParser parser "<module-header>" input of
+    Right settings -> settings
     Left _ -> []
   where
-    isHeaderPragma tok =
-      case lexTokenKind tok of
-        TkPragmaLanguage _ -> True
-        TkPragmaWarning _ -> True
-        TkPragmaDeprecated _ -> True
-        _ -> False
+    parser = triviaConsumer *> gather []
 
-    languageSettings tok =
-      case lexTokenKind tok of
+    gather acc =
+      do
+        next <- MP.optional (try headerPragmaSettings)
+        case next of
+          Nothing -> pure (reverse acc)
+          Just settings -> do
+            triviaConsumer
+            gather (reverse settings <> acc)
+
+    headerPragmaSettings = do
+      tok <- lexWithSpan (try languagePragmaToken <|> try pragmaWarningToken <|> try pragmaDeprecatedToken)
+      pure $ case lexTokenKind tok of
         TkPragmaLanguage names -> names
         _ -> []
 

--- a/components/haskell-parser/test/Spec.hs
+++ b/components/haskell-parser/test/Spec.hs
@@ -42,7 +42,8 @@ buildTests = do
           [ testCase "module parses declaration list" test_moduleParsesDecls,
             testCase "reads header LANGUAGE pragmas" test_readsHeaderLanguagePragmas,
             testCase "ignores unknown header pragmas" test_ignoresUnknownHeaderPragmas,
-            testCase "ignores LANGUAGE pragmas inside comments" test_ignoresLanguagePragmasInsideComments
+            testCase "ignores LANGUAGE pragmas inside comments" test_ignoresLanguagePragmasInsideComments,
+            testCase "stops header scan at first module token" test_stopsHeaderScanAtFirstModuleToken
           ],
         testGroup
           "properties"
@@ -98,6 +99,17 @@ test_ignoresLanguagePragmasInsideComments = do
       exts = readModuleHeaderExtensions source
       expected = [EnableExtension CPP]
   assertEqual "ignores LANGUAGE pragmas in comments" expected exts
+
+test_stopsHeaderScanAtFirstModuleToken :: Assertion
+test_stopsHeaderScanAtFirstModuleToken = do
+  let source =
+        T.unlines
+          [ "module M where",
+            "{-# LANGUAGE CPP #-}",
+            "x = 1"
+          ]
+      exts = readModuleHeaderExtensions source
+  assertEqual "stops before body pragmas" [] exts
 
 prop_exprPrettyRoundTrip :: GenExpr -> Property
 prop_exprPrettyRoundTrip generated =

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -34,6 +34,7 @@ hackageTesterTests =
           testCase "accepts LANGUAGE Haskell2010 pragmas" test_oracleAcceptsHaskell2010LanguagePragma,
           testCase "applies implied extensions" test_oracleAppliesImpliedExtensions,
           testCase "uses Haskell2010 language defaults" test_oracleUsesHaskell2010Defaults,
+          testCase "uses Haskell98 fallback defaults" test_oracleUsesHaskell98FallbackDefaults,
           testCase "handles CPP-defined LANGUAGE pragmas" test_oracleHandlesCppDefinedLanguagePragmas
         ]
     ]
@@ -142,6 +143,24 @@ test_oracleUsesHaskell2010Defaults =
       T.unlines
         [ "module A where",
           "data R = R { field :: Int }"
+        ]
+
+test_oracleUsesHaskell98FallbackDefaults :: Assertion
+test_oracleUsesHaskell98FallbackDefaults =
+  case oracleDetailedParsesModuleWithNamesAt "hackage-tester" [] (Just "Haskell98") source of
+    Left err ->
+      assertBool
+        ("expected Haskell98 fallback defaults to allow nondecreasing indentation, got: " <> T.unpack err)
+        False
+    Right () -> pure ()
+  where
+    source =
+      T.unlines
+        [ "module A where",
+          "foo bs = do",
+          "  let fn offset x = id $ \\(a, b) -> do",
+          "      pure (offset + b)",
+          "  pure bs"
         ]
 
 test_oracleHandlesCppDefinedLanguagePragmas :: Assertion


### PR DESCRIPTION
## Summary
- stop `readModuleHeaderExtensions` at the first non-pragma module token so `LANGUAGE` pragmas inside the module body no longer leak into global extension detection.
- use `Haskell98` as the fallback `default-language` when a cabal component omits `default-language`, matching historical Cabal behavior and fixing the `zeromq4-haskell` sanity-check parse mismatch.
- add regression tests for both behaviors in parser/header scanning and oracle language-default handling.

## Validation
- `nix run .#hackage-tester -- bytestring-trie --version 0.2.7.6 --jobs 1 --only-ghc-errors`
- `nix run .#hackage-tester -- zeromq4-haskell --version 0.8.0 --jobs 1 --only-ghc-errors`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)

## Progress Impact
- this change fixes false-negative sanity-check outcomes in `stackage-progress` where extension/language reporting was incorrect:
  - `bytestring-trie`: removes incorrect `(Extensions: [] Language: Haskell2010)` diagnostics by correctly honoring header-only pragma scope and allowing CPP-enabled parsing.
  - `zeromq4-haskell`: removes incorrect Haskell2010 fallback, aligning with GHC parsing behavior for packages without explicit `default-language`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Haskell language version from Haskell2010 to Haskell98 when language is not explicitly specified.

* **Refactor**
  * Enhanced header pragma parsing logic with improved trivia handling and parser combinator-based accumulation.

* **Tests**
  * Added comprehensive test coverage for header scanning behavior and Haskell98 default language handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->