### PR TITLE
feat(parser): improve offline cpp macros and stackage error handling

### DIFF
--- a/components/haskell-parser/app/hackage-tester/Main.hs
+++ b/components/haskell-parser/app/hackage-tester/Main.hs
@@ -23,7 +23,14 @@ import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, r
 import Distribution.Pretty (prettyShow)
 import GHC.Conc (getNumProcessors)
 import qualified GhcOracle
-import HackageSupport (FileInfo (..), diagToText, downloadPackage, findTargetFilesFromCabal, resolveIncludeBestEffort)
+import HackageSupport
+  ( FileInfo (..),
+    diagToText,
+    downloadPackage,
+    findTargetFilesFromCabal,
+    readTextFileLenient,
+    resolveIncludeBestEffort,
+  )
 import HackageTester.CLI (Options (..), parseOptionsIO)
 import HackageTester.Model (FileResult (..), Outcome (..), Summary (..), failureLabel, shouldFailSummary, summarizeResults)
 import Network.HTTP.Client (HttpException, Manager, Request (responseTimeout), httpLbs, newManager, parseRequest, responseBody, responseTimeoutMicro)
@@ -158,7 +165,7 @@ mapConcurrentlyBounded jobs action items = do
 processFile :: Options -> FilePath -> FileInfo -> IO FileResult
 processFile opts packageRoot info = do
   let file = fileInfoPath info
-  source <- TIO.readFile file
+  source <- readTextFileLenient file
   preprocessed <- preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (resolveIncludeBestEffort packageRoot file) source
   let source' = resultOutput preprocessed
       cppErrs = [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error]

--- a/components/haskell-parser/app/stackage-progress/Main.hs
+++ b/components/haskell-parser/app/stackage-progress/Main.hs
@@ -12,10 +12,17 @@ import Data.List (isPrefixOf, nub)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
 import GHC.Conc (getNumProcessors)
 import qualified GhcOracle
-import HackageSupport (FileInfo (..), diagToText, downloadPackageQuietWithNetwork, findTargetFilesFromCabal, prefixCppErrors, resolveIncludeBestEffort)
+import HackageSupport
+  ( FileInfo (..),
+    diagToText,
+    downloadPackageQuietWithNetwork,
+    findTargetFilesFromCabal,
+    prefixCppErrors,
+    readTextFileLenient,
+    resolveIncludeBestEffort,
+  )
 import HseExtensions (fromExtensionNames)
 import qualified Language.Haskell.Exts as HSE
 import qualified Parser
@@ -107,7 +114,21 @@ main = do
     Just path -> do
       home <- getHomeDirectory
       let sanitize = T.unpack . T.replace (T.pack home) "$HOME" . T.pack
-          ghcErrors = take (optGhcErrorsLimit opts) [(pkgName (package r), sanitize e) | r <- results, Just e <- [packageGhcError r]]
+          ghcFailureMessage r =
+            case packageGhcError r of
+              Just err -> sanitize err
+              Nothing ->
+                let reason = trim (packageReason r)
+                 in if null reason
+                      then "GHC check failed without diagnostic details"
+                      else "No direct GHC diagnostic; package failed before/around GHC check: " ++ sanitize reason
+          ghcErrors =
+            take
+              (optGhcErrorsLimit opts)
+              [ (formatPackage (package r), ghcFailureMessage r)
+              | r <- results,
+                not (packageGhcOk r)
+              ]
       writeFile path $ unlines ["=== " ++ pkg ++ " ===\n" ++ err ++ "\n" | (pkg, err) <- ghcErrors]
       putStrLn $ "GHC errors written to " ++ path
 
@@ -270,7 +291,9 @@ parseConstraint entry
         Nothing ->
           let ws = words entry
            in case ws of
-                [name, "installed"] -> Just (PackageSpec name "installed")
+                -- Snapshot constraints like "base installed" refer to compiler-provided
+                -- packages and do not map to downloadable Hackage tarballs.
+                [_, "installed"] -> Nothing
                 _ -> Nothing
 
 breakOn :: String -> String -> Maybe (String, String)
@@ -325,10 +348,10 @@ runPackageOrThrow opts spec = do
           pure
             PackageResult
               { package = spec,
-                packageOursOk = False,
-                packageHseOk = False,
-                packageGhcOk = False,
-                packageReason = "no target source files",
+                packageOursOk = True,
+                packageHseOk = True,
+                packageGhcOk = True,
+                packageReason = "",
                 packageGhcError = Nothing
               }
         else do
@@ -377,7 +400,7 @@ data FileResult = FileResult
 checkFile :: Options -> FilePath -> FileInfo -> IO FileResult
 checkFile opts packageRoot info = do
   let file = fileInfoPath info
-  source <- TIO.readFile file
+  source <- readTextFileLenient file
   preprocessed <- preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (resolveIncludeBestEffort packageRoot file) source
   let source' = resultOutput preprocessed
       cppErrors = [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error]

--- a/components/haskell-parser/common/CppSupport.hs
+++ b/components/haskell-parser/common/CppSupport.hs
@@ -12,21 +12,26 @@ where
 
 import Cpp
   ( Config (..),
-    IncludeRequest,
+    IncludeKind (..),
+    IncludeRequest (..),
     Result (..),
     Step (..),
     defaultConfig,
+    includeFrom,
+    includeKind,
+    includePath,
     preprocess,
   )
-import Data.Char (toLower)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit, toLower)
 import Data.Functor.Identity (Identity (..), runIdentity)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Parser as P
 import Parser.Ast (Extension (CPP), ExtensionSetting (..), parseExtensionSettingName)
-import System.FilePath (takeExtension)
+import System.FilePath (takeDirectory, takeExtension, (</>))
 
 preprocessForParser :: (Monad m) => FilePath -> (IncludeRequest -> m (Maybe Text)) -> Text -> m Result
 preprocessForParser inputFile resolveInclude source =
@@ -34,12 +39,14 @@ preprocessForParser inputFile resolveInclude source =
 
 preprocessForParserWithCppOptions :: (Monad m) => [String] -> FilePath -> (IncludeRequest -> m (Maybe Text)) -> Text -> m Result
 preprocessForParserWithCppOptions cppOptions inputFile resolveInclude source = do
+  minVersionMacros <- discoverMinVersionMacros inputFile resolveInclude source
+  let injected = injectSyntheticCppMacros cppOptions minVersionMacros source
   let cfg =
         defaultConfig
           { configInputFile = inputFile,
             configMacros = cppMacrosFromOptions cppOptions
           }
-  result <- drive (preprocess cfg source)
+  result <- drive (preprocess cfg injected)
   pure result {resultOutput = stripLinePragmas (resultOutput result)}
   where
     drive (Done result) = pure result
@@ -114,7 +121,10 @@ cppMacrosFromOptions cppOptions =
 builtinCppMacros :: M.Map Text Text
 builtinCppMacros =
   M.fromList
-    [ ("__GLASGOW_HASKELL__", "910")
+    [ ("__GLASGOW_HASKELL__", "906"),
+      ("__GLASGOW_HASKELL_FULL_VERSION__", "\"9.6.7\""),
+      ("__GLASGOW_HASKELL_PATCHLEVEL1__", "7"),
+      ("__GLASGOW_HASKELL_PATCHLEVEL2__", "0")
     ]
 
 data CppMacroOption
@@ -172,3 +182,126 @@ unliterateIfNeeded inputFile source
       | T.strip line == "\\end{code}" = "" : unlitLatex False rest
       | inCode = line : unlitLatex inCode rest
       | otherwise = "" : unlitLatex inCode rest
+
+discoverMinVersionMacros :: (Monad m) => FilePath -> (IncludeRequest -> m (Maybe Text)) -> Text -> m (S.Set Text)
+discoverMinVersionMacros inputFile resolveInclude =
+  go S.empty S.empty inputFile
+  where
+    go seenFiles seenMacros filePath txt
+      | filePath `S.member` seenFiles = pure seenMacros
+      | otherwise = do
+          let seenFiles' = S.insert filePath seenFiles
+              found = extractMinVersionMacroNames txt
+              includeReqs = extractIncludeRequests filePath txt
+              seenMacros' = S.union seenMacros found
+          foldl
+            (\acc req -> acc >>= \curr -> collectInclude seenFiles' curr req)
+            (pure seenMacros')
+            includeReqs
+
+    collectInclude seenFiles seenMacros req = do
+      content <- resolveInclude req
+      case content of
+        Nothing -> pure seenMacros
+        Just includeText ->
+          let includeFilePath =
+                case includeKind req of
+                  IncludeLocal -> takeDirectory (includeFrom req) </> includePath req
+                  IncludeSystem -> includePath req
+           in go seenFiles seenMacros includeFilePath includeText
+
+injectSyntheticCppMacros :: [String] -> S.Set Text -> Text -> Text
+injectSyntheticCppMacros cppOptions minVersionMacroNames source =
+  let existingFromOptions = cppDefinedOrUndefinedFromOptions cppOptions
+      reservedCompilerMinVersionNames = S.fromList ["MIN_VERSION_ghc", "MIN_VERSION_GLASGOW_HASKELL"]
+      shouldDefine name = not (name `S.member` existingFromOptions)
+      compilerMacroLines =
+        [ "#define MIN_VERSION_ghc(major1,major2,minor) 1"
+        | shouldDefine "MIN_VERSION_ghc"
+        ]
+          ++ [ "#define MIN_VERSION_GLASGOW_HASKELL(ma,mi,pl1,pl2) 1"
+             | shouldDefine "MIN_VERSION_GLASGOW_HASKELL"
+             ]
+      dynamicLines =
+        [ "#define " <> name <> "(major1,major2,minor) 1"
+        | name <- S.toAscList minVersionMacroNames,
+          not (name `S.member` reservedCompilerMinVersionNames),
+          shouldDefine name
+        ]
+      header =
+        if null (compilerMacroLines ++ dynamicLines)
+          then ""
+          else T.unlines (compilerMacroLines ++ dynamicLines)
+   in if T.null header then source else header <> source
+
+cppDefinedOrUndefinedFromOptions :: [String] -> S.Set Text
+cppDefinedOrUndefinedFromOptions =
+  foldl addName S.empty . mapMaybe parseCppMacroOption
+  where
+    addName acc option =
+      case option of
+        CppDefine name _ -> S.insert name acc
+        CppUndef name -> S.insert name acc
+
+extractMinVersionMacroNames :: Text -> S.Set Text
+extractMinVersionMacroNames = go S.empty
+  where
+    prefix = "MIN_VERSION_"
+    go acc txt =
+      case T.breakOn prefix txt of
+        (_, "") -> acc
+        (_, rest) ->
+          let candidateWithPrefix = T.takeWhile isMinVersionIdentChar rest
+              suffix = T.drop (T.length candidateWithPrefix) rest
+              acc' =
+                if T.length candidateWithPrefix > T.length prefix
+                  && case T.uncons suffix of
+                    Just ('(', _) -> True
+                    _ -> False
+                  then S.insert candidateWithPrefix acc
+                  else acc
+              nextTxt =
+                if T.null rest
+                  then ""
+                  else T.drop 1 rest
+           in go acc' nextTxt
+
+    isMinVersionIdentChar c = c == '_' || isAsciiAlphaNum c
+    isAsciiAlphaNum c = isAsciiLower c || isAsciiUpper c || isDigit c
+
+extractIncludeRequests :: FilePath -> Text -> [IncludeRequest]
+extractIncludeRequests filePath =
+  mapMaybe parseIncludeLine . T.lines
+  where
+    parseIncludeLine raw =
+      let line = T.stripStart raw
+       in case T.stripPrefix "#include" line of
+            Nothing -> Nothing
+            Just rest ->
+              let stripped = T.stripStart rest
+               in case T.uncons stripped of
+                    Just ('"', t1) ->
+                      let (path, t2) = T.breakOn "\"" t1
+                       in if T.null path || T.null t2
+                            then Nothing
+                            else
+                              Just
+                                IncludeRequest
+                                  { includePath = T.unpack path,
+                                    includeKind = IncludeLocal,
+                                    includeFrom = filePath,
+                                    includeLine = 1
+                                  }
+                    Just ('<', t1) ->
+                      let (path, t2) = T.breakOn ">" t1
+                       in if T.null path || T.null t2
+                            then Nothing
+                            else
+                              Just
+                                IncludeRequest
+                                  { includePath = T.unpack path,
+                                    includeKind = IncludeSystem,
+                                    includeFrom = filePath,
+                                    includeLine = 1
+                                  }
+                    _ -> Nothing

--- a/components/haskell-parser/common/HackageSupport.hs
+++ b/components/haskell-parser/common/HackageSupport.hs
@@ -6,6 +6,7 @@ module HackageSupport
     downloadPackageQuietWithNetwork,
     findTargetFilesFromCabal,
     FileInfo (..),
+    readTextFileLenient,
     resolveIncludeBestEffort,
     diagToText,
     prefixCppErrors,
@@ -15,12 +16,14 @@ where
 import Control.Monad (forM, when)
 import Cpp (Diagnostic (..), IncludeKind (..), IncludeRequest (..), Severity (..))
 import qualified Data.ByteString as BS
-import Data.List (isPrefixOf, isSuffixOf, nub)
+import Data.Char (toLower)
+import Data.List (isPrefixOf, isSuffixOf, nub, sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Version as DV
 import Distribution.Compiler (CompilerFlavor (..))
 import Distribution.ModuleName (ModuleName, toFilePath)
@@ -71,7 +74,7 @@ import System.Directory
     removeFile,
     renameDirectory,
   )
-import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, takeDirectory, (<.>), (</>))
+import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, takeDirectory, takeFileName, (<.>), (</>))
 import System.Info (compilerName, compilerVersion)
 import System.Process (callCommand)
 
@@ -148,11 +151,7 @@ findTargetFilesFromCabal extractedRoot = do
           ( userError
               ("No .cabal file found under extracted package root: " ++ extractedRoot)
           )
-      _ ->
-        ioError
-          ( userError
-              ("Multiple .cabal files found under extracted package root: " ++ show cabalFiles)
-          )
+      files -> pure (chooseBestCabalFile extractedRoot files)
   cabalBytes <- BS.readFile cabalFile
   let (_, parseResult) = runParseResult (parseGenericPackageDescription cabalBytes)
   gpd <-
@@ -314,12 +313,52 @@ existingPaths candidates = do
 dedupeExistingFiles :: [FilePath] -> IO [FilePath]
 dedupeExistingFiles files = fmap nub (existingPaths files)
 
+chooseBestCabalFile :: FilePath -> [FilePath] -> FilePath
+chooseBestCabalFile extractedRoot files =
+  case sortOn rank files of
+    best : _ -> best
+    [] -> error ("chooseBestCabalFile: no .cabal files found under " ++ extractedRoot)
+  where
+    rank file =
+      let rel = splitDirectories (makeRelative extractedRoot file)
+          dirParts = case reverse rel of
+            _fileName : restRev -> reverse restRev
+            [] -> []
+          lowerDirParts = map (map toLower) dirParts
+          isLikelyFixtureDir = any (`elem` fixtureDirNames) lowerDirParts
+       in ( if isLikelyFixtureDir then (1 :: Int) else 0,
+            length rel,
+            length dirParts,
+            scoreByFileName (map toLower (takeFileName file)),
+            file
+          )
+
+    scoreByFileName fileNameLower
+      | "test-" `isPrefixOf` fileNameLower = 1 :: Int
+      | "example-" `isPrefixOf` fileNameLower = 1
+      | otherwise = 0
+
+    fixtureDirNames =
+      [ "test",
+        "tests",
+        "testing",
+        "example",
+        "examples",
+        "benchmark",
+        "benchmarks"
+      ]
+
+readTextFileLenient :: FilePath -> IO Text
+readTextFileLenient filePath = do
+  bytes <- BS.readFile filePath
+  pure (decodeUtf8With lenientDecode bytes)
+
 resolveIncludeBestEffort :: FilePath -> FilePath -> IncludeRequest -> IO (Maybe Text)
 resolveIncludeBestEffort packageRoot currentFile req = do
   firstExisting <- firstExistingPath (includeCandidates packageRoot currentFile req)
   case firstExisting of
     Nothing -> pure Nothing
-    Just includeFile -> Just <$> TIO.readFile includeFile
+    Just includeFile -> Just <$> readTextFileLenient includeFile
 
 includeCandidates :: FilePath -> FilePath -> IncludeRequest -> [FilePath]
 includeCandidates packageRoot currentFile req =

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -6,10 +6,13 @@ module Test.HackageTester.Suite
 where
 
 import Control.Exception (bracket)
+import Cpp (IncludeKind (..), IncludeRequest (..), Result (..))
+import CppSupport (preprocessForParserIfEnabled)
+import qualified Data.ByteString as BS
 import Data.List (isSuffixOf)
 import qualified Data.Text as T
 import GhcOracle (oracleDetailedParsesModuleWithNamesAt)
-import HackageSupport (fileInfoPath, findTargetFilesFromCabal)
+import HackageSupport (fileInfoPath, findTargetFilesFromCabal, resolveIncludeBestEffort)
 import HackageTester.CLI (Options (..), parseOptionsPure)
 import HackageTester.Model (FileResult (..), Outcome (..), Summary (..), shouldFailSummary, summarizeResults)
 import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
@@ -46,7 +49,20 @@ hackageTesterTests =
         ],
       testGroup
         "package-selection"
-        [ testCase "skips files from non-buildable components by default flags" test_skipsNonBuildableComponents
+        [ testCase "skips files from non-buildable components by default flags" test_skipsNonBuildableComponents,
+          testCase "prefers top-level cabal when multiple cabal files exist" test_prefersTopLevelCabalWhenMultipleExist
+        ],
+      testGroup
+        "cpp-macros"
+        [ testCase "MIN_VERSION_base branch is taken" test_cppMinVersionBaseTrue,
+          testCase "MIN_VERSION_ghc branch is taken" test_cppMinVersionGhcTrue,
+          testCase "negated MIN_VERSION_ghc branch is not taken" test_cppNegatedMinVersionGhcFalse,
+          testCase "MIN_VERSION_GLASGOW_HASKELL branch is taken" test_cppMinVersionGlasgowHaskellTrue,
+          testCase "unknown MIN_VERSION package in include branch is taken" test_cppUnknownMinVersionFromIncludeTrue
+        ],
+      testGroup
+        "io"
+        [ testCase "include resolution decodes invalid utf8 leniently" test_resolveIncludeLenientDecode
         ]
     ]
 
@@ -230,6 +246,133 @@ test_skipsNonBuildableComponents =
     assertBool "expected Main.hs to be selected" (any ("src/Main.hs" `isSuffixOf`) selected)
     assertBool "expected README.lhs from disabled component to be skipped" (not (any ("README.lhs" `isSuffixOf`) selected))
 
+test_prefersTopLevelCabalWhenMultipleExist :: Assertion
+test_prefersTopLevelCabalWhenMultipleExist =
+  withTempDir "hackage-tester" $ \root -> do
+    let rootCabal = root </> "demo.cabal"
+        nestedDir = root </> "testdata"
+        nestedCabal = nestedDir </> "fixture.cabal"
+        srcDir = root </> "src"
+        mainFile = srcDir </> "Main.hs"
+
+    createDirectory nestedDir
+    createDirectory srcDir
+    writeFile mainFile "module Main where\nmain :: IO ()\nmain = pure ()\n"
+    writeFile rootCabal sampleCabal
+    writeFile nestedCabal nestedFixtureCabal
+
+    files <- findTargetFilesFromCabal root
+    let selected = map fileInfoPath files
+    assertBool "expected Main.hs from top-level package to be selected" (any ("src/Main.hs" `isSuffixOf`) selected)
+
+test_resolveIncludeLenientDecode :: Assertion
+test_resolveIncludeLenientDecode =
+  withTempDir "hackage-tester" $ \root -> do
+    let srcDir = root </> "src"
+        incDir = root </> "include"
+        current = srcDir </> "Main.hs"
+        includeFile = incDir </> "bad.inc"
+    createDirectory srcDir
+    createDirectory incDir
+    writeFile current "module Main where\n"
+    BS.writeFile includeFile (BS.pack [65, 10, 255, 66, 10]) -- A\n<invalid>B\n
+    mText <-
+      resolveIncludeBestEffort
+        root
+        current
+        IncludeRequest
+          { includePath = "bad.inc",
+            includeKind = IncludeSystem,
+            includeFrom = current,
+            includeLine = 1
+          }
+    case mText of
+      Nothing -> assertBool "expected include text to resolve" False
+      Just txt ->
+        assertBool "expected replacement character in decoded text" ("\xFFFD" `T.isInfixOf` txt)
+
+test_cppMinVersionBaseTrue :: Assertion
+test_cppMinVersionBaseTrue = do
+  out <- preprocessWithIncludes "A.hs" mempty source
+  assertBool "expected true branch for MIN_VERSION_base" ("hit\n" `T.isInfixOf` out)
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE CPP #-}",
+          "#if MIN_VERSION_base(4,12,0)",
+          "hit",
+          "#else",
+          "miss",
+          "#endif"
+        ]
+
+test_cppMinVersionGhcTrue :: Assertion
+test_cppMinVersionGhcTrue = do
+  out <- preprocessWithIncludes "A.hs" mempty source
+  assertBool "expected true branch for MIN_VERSION_ghc" ("hit\n" `T.isInfixOf` out)
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE CPP #-}",
+          "#if MIN_VERSION_ghc(8,6,0)",
+          "hit",
+          "#else",
+          "miss",
+          "#endif"
+        ]
+
+test_cppNegatedMinVersionGhcFalse :: Assertion
+test_cppNegatedMinVersionGhcFalse = do
+  out <- preprocessWithIncludes "A.hs" mempty source
+  assertBool "expected negated branch to be false for MIN_VERSION_ghc" ("miss\n" `T.isInfixOf` out)
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE CPP #-}",
+          "#if !MIN_VERSION_ghc(8,8,0)",
+          "hit",
+          "#else",
+          "miss",
+          "#endif"
+        ]
+
+test_cppMinVersionGlasgowHaskellTrue :: Assertion
+test_cppMinVersionGlasgowHaskellTrue = do
+  out <- preprocessWithIncludes "A.hs" mempty source
+  assertBool "expected true branch for MIN_VERSION_GLASGOW_HASKELL" ("hit\n" `T.isInfixOf` out)
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE CPP #-}",
+          "#if MIN_VERSION_GLASGOW_HASKELL(8,6,1,0)",
+          "hit",
+          "#else",
+          "miss",
+          "#endif"
+        ]
+
+test_cppUnknownMinVersionFromIncludeTrue :: Assertion
+test_cppUnknownMinVersionFromIncludeTrue = do
+  out <- preprocessWithIncludes "A.hs" includes source
+  assertBool "expected true branch for unknown MIN_VERSION in include" ("hit\n" `T.isInfixOf` out)
+  where
+    source =
+      T.unlines
+        [ "{-# LANGUAGE CPP #-}",
+          "#include \"defs.h\""
+        ]
+    includes =
+      [ ("defs.h", T.unlines ["#if MIN_VERSION_custompkg(1,2,3)", "hit", "#else", "miss", "#endif"])
+      ]
+
+preprocessWithIncludes :: FilePath -> [(FilePath, T.Text)] -> T.Text -> IO T.Text
+preprocessWithIncludes inputFile includeFiles source = do
+  Result {resultOutput = out} <-
+    preprocessForParserIfEnabled [] [] inputFile resolve source
+  pure out
+  where
+    resolve req = pure (lookup (includePath req) includeFiles)
+
 sampleCabal :: String
 sampleCabal =
   unlines
@@ -251,6 +394,18 @@ sampleCabal =
       "executable cli",
       "  main-is: Main.hs",
       "  hs-source-dirs: src",
+      "  build-depends: base",
+      "  default-language: Haskell2010"
+    ]
+
+nestedFixtureCabal :: String
+nestedFixtureCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: fixture",
+      "version: 0.1.0.0",
+      "executable fixture",
+      "  main-is: Fixture.hs",
       "  build-depends: base",
       "  default-language: Haskell2010"
     ]


### PR DESCRIPTION
## Summary

This PR improves parser pipeline robustness for offline/stackage workflows and CPP-heavy packages by:

- Emulating GHC/Cabal-style CPP macros in offline mode:
  - Adds pinned GHC identity macros (`__GLASGOW_HASKELL__=906`, full version, patchlevels)
  - Forces `MIN_VERSION_*` checks to evaluate true for parser preprocessing
  - Auto-discovers `MIN_VERSION_<pkg>(...)` usages in source and includes and synthesizes fallback function-like macros
  - Preserves explicit `-D/-U` macro overrides
- Improving package selection and IO resilience:
  - Picks a best top-level `.cabal` file when packages contain multiple cabal files (instead of failing immediately)
  - Uses lenient UTF-8 decoding for source/include reads to avoid hard failures on invalid bytes
- Improving stackage reporting behavior:
  - `--ghc-errors-file` now includes all `packageGhcOk == False` packages (not only those with direct GHC diagnostics)
  - Filters out `installed` snapshot constraints from stackage targets
  - Treats packages with no target source files as success (as requested)

## Progress Counts

### Stackage sanity-check (offline, jobs=8)

Before these changes:
- AIHC: `946 / 3427` (`27%`)
- HSE: `2413 / 3427` (`70%`)
- GHC: `3249 / 3427` (`94%`)
- `ghc_errors.txt` entries (with expanded reporting): `178`

After these changes:
- AIHC: `1045 / 3390` (`30%`)
- HSE: `2528 / 3390` (`74%`)
- GHC: `3382 / 3390` (`99%`)
- `ghc_errors.txt` entries: `8` (all real parse/lexical diagnostics)

Notes:
- Denominator changed from `3427` to `3390` because `installed` packages are now filtered out.

### Other progress checks run
- CPP progress: `37/37` (`100.0%`)
- Parser progress: `269/386` (`69.68%`)

## Validation

- `nix flake check`
- `nix run .#parser-test`
- `nix run .#cpp-progress`
- `nix run .#parser-progress`
- `nix run .#stackage-progress -- --sanity-check --offline --jobs 8 --ghc-errors-file ghc_errors.txt --ghc-errors-limit 5000`

## Pre-PR review

Ran:
- `coderabbit review --prompt-only`

Findings handling:
- Fixed: `chooseBestCabalFile` empty-list fallback now raises explicit error rather than returning a directory path.
- Intentionally kept: "no target source files as success" behavior, per explicit request in this thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Enhanced C++ preprocessor macro discovery and dynamic injection for complex conditional compilation scenarios
* Lenient file reading for improved resilience when processing malformed or corrupted text files

**Bug Fixes**
* Graceful handling when target source files are not found
* Improved cabal file selection when multiple candidates exist in a directory
* More robust error messaging for compiler failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->