### PR TITLE
feat: add line-counts Nix app command

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,39 @@
             meta.description = "aihc app: ${name}";
           };
         in {
+          line-counts = mkAppWithInputs "line-counts" [ pkgs.tokei pkgs.jq pkgs.bash ] ''
+            set -euo pipefail
+
+            # Output header
+            printf "| %-30s | %10s | %10s | %10s |\n" "Component" "Code" "Tests" "Total"
+            printf "| :%-30s | %10s: | %10s: | %10s: |\n" "------------------------------" "----------" "----------" "----------"
+
+            total_code=0
+            total_tests=0
+
+            for comp_path in components/*; do
+              [ -d "$comp_path" ] || continue
+              comp=$(basename "$comp_path")
+
+              comp_all_lines=$(tokei "$comp_path" --output json | jq '[.[] | .code] | add // 0')
+              test_lines=0
+              if [ -d "$comp_path/test" ]; then
+                test_lines=$(tokei "$comp_path/test" --output json | jq '[.[] | .code] | add // 0')
+              fi
+              code_lines=$((comp_all_lines - test_lines))
+              if [ $code_lines -lt 0 ]; then code_lines=0; fi
+
+              comp_total=$comp_all_lines
+              printf "| %-30s | %10d | %10d | %10d |\n" "$comp" "$code_lines" "$test_lines" "$comp_total"
+
+              total_code=$((total_code + code_lines))
+              total_tests=$((total_tests + test_lines))
+            done
+
+            total_all=$((total_code + total_tests))
+            printf "| %-30s | %10d | %10d | %10d |\n" "**Total**" "$total_code" "$total_tests" "$total_all"
+          '';
+
           parser-test = mkApp "parser-test" ''
             set -euo pipefail
             test -d components/haskell-parser || {


### PR DESCRIPTION
## Summary
Adds a new Nix app command `line-counts` that computes how many lines of code there are for each component (and in total), split into code and tests. The output is a markdown table.

## Line Counts Table
| Component                      |       Code |      Tests |      Total |
| :------------------------------ | ----------: | ----------: | ----------: |
| haskell-cpp                    |       1147 |        882 |       2029 |
| haskell-name-resolution        |       1213 |       2002 |       3215 |
| haskell-parser                 |      16755 |       5626 |      22381 |
| **Total**                      |      19115 |       8510 |      27625 |

## Progress Counts
| Suite           |      PASS |     XFAIL |     XPASS |      FAIL |     TOTAL |
| :-------------- | --------: | --------: | --------: | --------: | --------: |
| Parser          |       270 |       119 |         0 |         0 |       389 |
| CPP             |        37 |         0 |         0 |         0 |        37 |
| Name Resolution |        10 |         2 |         0 |         0 |        12 |

**Haskell Parser Extensions:** 17 Supported, 16 In Progress, 105 Planned (138 Total)

## Test plan
Run `nix run .#line-counts` to verify the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a line-counts utility that analyzes and displays code and test line counts across components, providing per-component breakdowns and overall totals for your codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->