### PR TITLE
fix(parser): require CPP extension before preprocessing

### DIFF
--- a/components/haskell-parser/common/CppSupport.hs
+++ b/components/haskell-parser/common/CppSupport.hs
@@ -59,7 +59,8 @@ preprocessForParserWithoutIncludes inputFile source =
 preprocessForParserIfEnabled :: (Monad m) => [String] -> [String] -> FilePath -> (IncludeRequest -> m (Maybe Text)) -> Text -> m Result
 preprocessForParserIfEnabled globalExtensionNames cppOptions inputFile resolveInclude source =
   let normalizedSource = normalizeSourceForParser inputFile source
-   in if cppEnabledInSourceWithGlobals globalExtensionNames normalizedSource || hasCppOptionMacros cppOptions
+      shouldPreprocess = cppEnabledInSourceWithGlobals globalExtensionNames normalizedSource
+   in if shouldPreprocess
         then preprocessForParserWithCppOptions cppOptions inputFile resolveInclude normalizedSource
         else pure Result {resultOutput = normalizedSource, resultDiagnostics = []}
 
@@ -80,13 +81,6 @@ cppEnabledInSourceWithGlobals globalExtensionNames source =
 
 settingsFromExtensionNames :: [String] -> [ExtensionSetting]
 settingsFromExtensionNames = mapMaybe (parseExtensionSettingName . T.pack)
-
-hasCppOptionMacros :: [String] -> Bool
-hasCppOptionMacros = any isCppMacroOption
-  where
-    isCppMacroOption opt =
-      case T.strip (stripWrappingQuotes (T.pack opt)) of
-        x -> "-D" `T.isPrefixOf` x || "-U" `T.isPrefixOf` x
 
 cppEnabledInSettings :: [ExtensionSetting] -> Bool
 cppEnabledInSettings = foldl apply False

--- a/components/haskell-parser/test/Test/HackageTester/Suite.hs
+++ b/components/haskell-parser/test/Test/HackageTester/Suite.hs
@@ -58,7 +58,8 @@ hackageTesterTests =
           testCase "MIN_VERSION_ghc branch is taken" test_cppMinVersionGhcTrue,
           testCase "negated MIN_VERSION_ghc branch is not taken" test_cppNegatedMinVersionGhcFalse,
           testCase "MIN_VERSION_GLASGOW_HASKELL branch is taken" test_cppMinVersionGlasgowHaskellTrue,
-          testCase "unknown MIN_VERSION package in include branch is taken" test_cppUnknownMinVersionFromIncludeTrue
+          testCase "unknown MIN_VERSION package in include branch is taken" test_cppUnknownMinVersionFromIncludeTrue,
+          testCase "cpp-options macros do not enable preprocessing without CPP extension" test_cppOptionsWithoutCppExtensionDoNotPreprocess
         ],
       testGroup
         "io"
@@ -364,6 +365,22 @@ test_cppUnknownMinVersionFromIncludeTrue = do
     includes =
       [ ("defs.h", T.unlines ["#if MIN_VERSION_custompkg(1,2,3)", "hit", "#else", "miss", "#endif"])
       ]
+
+test_cppOptionsWithoutCppExtensionDoNotPreprocess :: Assertion
+test_cppOptionsWithoutCppExtensionDoNotPreprocess = do
+  Result {resultOutput = out} <-
+    preprocessForParserIfEnabled [] ["-DTEST=1"] "A.hs" (\_ -> pure Nothing) source
+  assertEqual "expected source to remain unchanged when CPP extension is not enabled" source out
+  where
+    source =
+      T.unlines
+        [ "module A where",
+          "#if TEST",
+          "x = 1",
+          "#else",
+          "x = 2",
+          "#endif"
+        ]
 
 preprocessWithIncludes :: FilePath -> [(FilePath, T.Text)] -> T.Text -> IO T.Text
 preprocessWithIncludes inputFile includeFiles source = do


### PR DESCRIPTION
## Summary
- Change `preprocessForParserIfEnabled` to run CPP only when the `CPP` extension is enabled (from module pragmas or Cabal extensions).
- Stop enabling preprocessing from `cpp-options` alone.
- Add a regression test that proves `cpp-options` does not trigger preprocessing when `CPP` is not enabled.

## Why
- Fixes false failures on sources like `xmonad-contrib` that contain operators such as `*//*` and were being mangled when preprocessed unnecessarily.
- Aligns behavior with explicit language-extension gating.

## Testing
- `nix run .#parser-test`
- `nix flake check`
- `nix run .#hackage-tester -- --only-ghc-errors xmonad-contrib`
- `coderabbit review --prompt-only` (No findings)

## Progress counts
- `stackage-progress --sanity-check --offline --jobs 8`
- `main`: `AIHC 1045/3390`, `HSE 2528/3390`, `GHC 3382/3390`
- this branch: `AIHC 1045/3390`, `HSE 2527/3390`, `GHC 3381/3390`
- package-level delta vs `main`:
  - fixed: `xmonad-contrib-0.18.1` (no longer a GHC parse failure)
  - newly failing (justified): `gtk2hs-buildtools-0.13.12.0`, `rzk-0.7.7` (both use `#...` directives without CPP enabled via extension; e.g. `rzk` has `-cpp` in `OPTIONS` pragma, which we currently do not support)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preprocessing behavior so that C++ macro options no longer inadvertently trigger preprocessing unless the CPP extension is explicitly enabled.

* **Tests**
  * Added test case validating that preprocessing remains disabled without the CPP extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->