### PR TITLE
test(parser): generate Expr directly in round-trip properties

### DIFF
--- a/components/haskell-parser/test/Test/Properties/ExprModuleRoundTrip.hs
+++ b/components/haskell-parser/test/Test/Properties/ExprModuleRoundTrip.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Properties.ExprModuleRoundTrip
   ( prop_exprPrettyRoundTrip,
     prop_modulePrettyRoundTrip,
-    GenExpr,
-    GenModule,
   )
 where
 
@@ -20,29 +19,25 @@ import Test.QuickCheck
 span0 :: SourceSpan
 span0 = noSourceSpan
 
-prop_exprPrettyRoundTrip :: GenExpr -> Property
-prop_exprPrettyRoundTrip generated =
-  let expr = toExpr generated
-      source = prettyExpr expr
-   in counterexample (T.unpack source) $
-        case parseExpr defaultConfig source of
-          ParseOk reparsed ->
-            case fromExpr reparsed of
-              Nothing ->
-                counterexample ("reparsed expression not in generated subset: " <> show reparsed) False
-              Just reparsedGenerated ->
-                counterexample ("reparsed mismatch: " <> show reparsedGenerated) (generated == reparsedGenerated)
-          ParseErr err ->
-            counterexample ("parse failed: " <> errorBundlePretty err) False
+prop_exprPrettyRoundTrip :: Expr -> Property
+prop_exprPrettyRoundTrip expr =
+  let source = prettyExpr expr
+      expected = normalizeExpr expr
+   in checkCoverage $
+        exprCoverage expr $
+          counterexample (T.unpack source) $
+            case parseExpr defaultConfig source of
+              ParseErr err ->
+                counterexample (errorBundlePretty err) False
+              ParseOk parsed ->
+                let actual = normalizeExpr parsed
+                 in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
-fromExpr :: Expr -> Maybe GenExpr
-fromExpr expr =
-  case expr of
-    EParen _ inner -> fromExpr inner
-    EVar _ name -> Just (GVar name)
-    EInt _ value _ -> Just (GInt value)
-    EApp _ fn arg -> GApp <$> fromExpr fn <*> fromExpr arg
-    _ -> Nothing
+exprCoverage :: Expr -> Property -> Property
+exprCoverage expr =
+  cover 20 (hasVarExpr expr) "contains variable"
+    . cover 20 (hasIntExpr expr) "contains integer"
+    . cover 20 (hasAppExpr expr) "contains application"
 
 prop_modulePrettyRoundTrip :: GenModule -> Property
 prop_modulePrettyRoundTrip generated =
@@ -58,14 +53,16 @@ prop_modulePrettyRoundTrip generated =
 moduleOnlyUsesSupportedExprs :: GenModule -> Bool
 moduleOnlyUsesSupportedExprs (GenModule decls) = all (isModuleSupportedExpr . snd) decls
 
-isModuleSupportedExpr :: GenExpr -> Bool
-isModuleSupportedExpr generated =
-  case generated of
-    GVar _ -> True
-    GInt _ -> True
-    GApp fn arg -> isModuleSupportedExpr fn && isModuleSupportedExpr arg
+isModuleSupportedExpr :: Expr -> Bool
+isModuleSupportedExpr expr =
+  case expr of
+    EVar _ _ -> True
+    EInt {} -> True
+    EApp _ fn arg -> isModuleSupportedExpr fn && isModuleSupportedExpr arg
+    EParen _ inner -> isModuleSupportedExpr inner
+    _ -> False
 
-newtype GenModule = GenModule {unGenModule :: [(Text, GenExpr)]}
+newtype GenModule = GenModule {unGenModule :: [(Text, Expr)]}
   deriving (Show)
 
 instance Arbitrary GenModule where
@@ -75,36 +72,66 @@ instance Arbitrary GenModule where
     exprs <- vectorOf n (genExpr 4)
     pure (GenModule (zip names exprs))
 
-data GenExpr
-  = GVar Text
-  | GInt Integer
-  | GApp GenExpr GenExpr
-  deriving (Eq, Show)
-
-instance Arbitrary GenExpr where
+instance Arbitrary Expr where
   arbitrary = sized (genExpr . min 5)
-  shrink expr =
-    case expr of
-      GVar name -> [GVar shrunk | shrunk <- shrinkIdent name]
-      GInt value -> [GInt shrunk | shrunk <- shrinkIntegral value]
-      GApp fn arg -> [fn, arg] <> [GApp fn' arg | fn' <- shrink fn] <> [GApp fn arg' | arg' <- shrink arg]
+  shrink = shrinkExpr
 
-genExpr :: Int -> Gen GenExpr
+shrinkExpr :: Expr -> [Expr]
+shrinkExpr expr =
+  case expr of
+    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkIdent name]
+    EInt _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
+    EApp _ fn arg ->
+      [fn, arg]
+        <> [EApp span0 fn' arg | fn' <- shrinkExpr fn]
+        <> [EApp span0 fn arg' | arg' <- shrinkExpr arg]
+    EParen _ inner -> inner : [EParen span0 inner' | inner' <- shrinkExpr inner]
+    _ -> []
+
+genExpr :: Int -> Gen Expr
 genExpr depth
-  | depth <= 0 = oneof [GVar <$> genIdent, GInt <$> chooseInteger (0, 999)]
+  | depth <= 0 = oneof [EVar span0 <$> genIdent, mkIntExpr <$> chooseInteger (0, 999)]
   | otherwise =
       frequency
-        [ (3, GVar <$> genIdent),
-          (3, GInt <$> chooseInteger (0, 999)),
-          (4, GApp <$> genExpr (depth - 1) <*> genExpr (depth - 1))
+        [ (3, EVar span0 <$> genIdent),
+          (3, mkIntExpr <$> chooseInteger (0, 999)),
+          (4, EApp span0 <$> genExpr (depth - 1) <*> genExpr (depth - 1))
         ]
 
-toExpr :: GenExpr -> Expr
-toExpr generated =
-  case generated of
-    GVar name -> EVar span0 name
-    GInt value -> EInt span0 value (T.pack (show value))
-    GApp fn arg -> EApp span0 (toExpr fn) (toExpr arg)
+mkIntExpr :: Integer -> Expr
+mkIntExpr value = EInt span0 value (T.pack (show value))
+
+hasVarExpr :: Expr -> Bool
+hasVarExpr expr =
+  case expr of
+    EVar _ _ -> True
+    EApp _ fn arg -> hasVarExpr fn || hasVarExpr arg
+    EParen _ inner -> hasVarExpr inner
+    _ -> False
+
+hasIntExpr :: Expr -> Bool
+hasIntExpr expr =
+  case expr of
+    EInt {} -> True
+    EApp _ fn arg -> hasIntExpr fn || hasIntExpr arg
+    EParen _ inner -> hasIntExpr inner
+    _ -> False
+
+hasAppExpr :: Expr -> Bool
+hasAppExpr expr =
+  case expr of
+    EApp {} -> True
+    EParen _ inner -> hasAppExpr inner
+    _ -> False
+
+normalizeExpr :: Expr -> Expr
+normalizeExpr expr =
+  case expr of
+    EVar _ name -> EVar span0 name
+    EInt _ value _ -> mkIntExpr value
+    EApp _ fn arg -> EApp span0 (normalizeExpr fn) (normalizeExpr arg)
+    EParen _ inner -> normalizeExpr inner
+    _ -> expr
 
 toModule :: GenModule -> Module
 toModule (GenModule decls) =
@@ -124,7 +151,7 @@ toModule (GenModule decls) =
                 [ Match
                     { matchSpan = span0,
                       matchPats = [],
-                      matchRhs = UnguardedRhs span0 (toExpr expr)
+                      matchRhs = UnguardedRhs span0 expr
                     }
                 ]
             )


### PR DESCRIPTION
Closes #231.

## Summary

- remove the `GenExpr` adapter AST from parser QuickCheck properties
- move the expression generator/shrinker into `Test.Properties.ExprModuleRoundTrip` to match the new property-module structure
- generate supported parser `Expr` values directly and compare normalized expression ASTs after pretty/parse round-trips

## Testing

- `nix flake check`
- `coderabbit review --prompt-only` was rate-limited after local checks passed, so no updated review output was available

## Progress counts

- Parser progress: PASS 276, XFAIL 113, FAIL 0, XPASS 0, COMPLETE 70.95%
