### PR TITLE
fix: update stackage progress parsing in generate-reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 | Name | Progress |
 | --- | --- |
-| Parser Tests | <!-- AUTO-GENERATED: START parser-progress --> `254/458` (`55.46%`) <!-- AUTO-GENERATED: END parser-progress --> |
-| Lexer Tests | <!-- AUTO-GENERATED: START lexer-progress --> `3/4` (`75.00%`) <!-- AUTO-GENERATED: END lexer-progress --> |
-| Parser Stackage | <!-- AUTO-GENERATED: START parser-stackage-progress --> `888/3427` (`25.91%`) <!-- AUTO-GENERATED: END parser-stackage-progress --> |
-| CPP preprocessor | <!-- AUTO-GENERATED: START cpp-progress --> `19/28` (`67.85%`) <!-- AUTO-GENERATED: END cpp-progress --> |
+| Parser Tests | <!-- AUTO-GENERATED: START parser-progress --> `289/453` (`63.80%`) <!-- AUTO-GENERATED: END parser-progress --> |
+| Lexer Tests | <!-- AUTO-GENERATED: START lexer-progress --> `6/6` (`100.00%`) <!-- AUTO-GENERATED: END lexer-progress --> |
+| Parser Stackage | <!-- AUTO-GENERATED: START parser-stackage-progress --> `230/3390` (`6.78%`) <!-- AUTO-GENERATED: END parser-stackage-progress --> |
+| CPP preprocessor | <!-- AUTO-GENERATED: START cpp-progress --> `37/37` (`100.00%`) <!-- AUTO-GENERATED: END cpp-progress --> |
 | Name resolution | <!-- AUTO-GENERATED: START name-resolution-progress --> `10/12` (`83.33%`) <!-- AUTO-GENERATED: END name-resolution-progress --> |

--- a/components/haskell-cpp/README.md
+++ b/components/haskell-cpp/README.md
@@ -15,7 +15,7 @@ Coverage is tracked with a manifest-driven corpus under:
 
 Current baseline:
 <!-- AUTO-GENERATED: START cpp-progress -->
-- `19/28` implemented (`67.85%` complete)
+- `37/37` implemented (`100.00%` complete)
 <!-- AUTO-GENERATED: END cpp-progress -->
 
 ## Commands

--- a/components/haskell-parser/README.md
+++ b/components/haskell-parser/README.md
@@ -19,7 +19,7 @@ Runtime outcomes are reported as:
 
 Current progress baseline:
 <!-- AUTO-GENERATED: START haskell2010-progress -->
-- `254/386` implemented (`65.80%` complete)
+- `289/394` implemented (`73.35%` complete)
 <!-- AUTO-GENERATED: END haskell2010-progress -->
 
 ## Extension Coverage Tracking
@@ -33,9 +33,9 @@ Each extension can provide a manifest at:
 Current extension baseline:
 <!-- AUTO-GENERATED: START extension-progress -->
 - Total tracked extensions: `138`
-- Supported: `15`
-- In Progress: `18`
-- Planned: `105`
+- Supported: `19`
+- In Progress: `15`
+- Planned: `104`
 <!-- AUTO-GENERATED: END extension-progress -->
 
 Generated report:

--- a/docs/haskell-parser-extension-support.md
+++ b/docs/haskell-parser-extension-support.md
@@ -3,9 +3,9 @@
 ## Summary
 
 - Total Extensions: 138
-- Supported: 15
-- In Progress: 18
-- Planned: 105
+- Supported: 19
+- In Progress: 15
+- Planned: 104
 
 ## Extension Status
 
@@ -41,15 +41,15 @@
 | EmptyCase | Supported | 4/4 | EmptyCase |
 | EmptyDataDecls | In Progress | 4/5 | EmptyDataDecls |
 | EmptyDataDeriving | Planned | - | EmptyDataDeriving |
-| ExistentialQuantification | In Progress | 0/4 | ExistentialQuantification |
+| ExistentialQuantification | Supported | 4/4 | ExistentialQuantification |
 | ExplicitForAll | Supported | 5/5 | ExplicitForAll |
 | ExplicitLevelImports | Supported | 4/4 | ExplicitLevelImports |
-| ExplicitNamespaces | In Progress | 0/3 | ExplicitNamespaces |
+| ExplicitNamespaces | Supported | 3/3 | ExplicitNamespaces |
 | ExtendedDefaultRules | Planned | - | ExtendedDefaultRules |
 | ExtendedLiterals | Planned | - | ExtendedLiterals |
 | FieldSelectors | Planned | - | FieldSelectors |
 | FlexibleContexts | Planned | - | FlexibleContexts |
-| FlexibleInstances | Planned | - | FlexibleInstances |
+| FlexibleInstances | Supported | 3/3 | FlexibleInstances |
 | ForeignFunctionInterface | Planned | - | ForeignFunctionInterface |
 | FunctionalDependencies | In Progress | 0/5 | FunctionalDependencies |
 | GADTs | In Progress | 0/3 | GADTs |
@@ -67,7 +67,7 @@
 | ImportQualifiedPost | Supported | 3/3 | ImportQualifiedPost |
 | ImpredicativeTypes | Planned | - | ImpredicativeTypes |
 | IncoherentInstances | Planned | - | IncoherentInstances |
-| InstanceSigs | In Progress | 3/5 | InstanceSigs |
+| InstanceSigs | Supported | 5/5 | InstanceSigs |
 | InterruptibleFFI | Planned | - | InterruptibleFFI |
 | KindSignatures | In Progress | 0/5 | KindSignatures |
 | LambdaCase | In Progress | 3/5 | LambdaCase |
@@ -108,7 +108,7 @@
 | QualifiedDo | Planned | - | QualifiedDo |
 | QualifiedStrings | Planned | - | QualifiedStrings |
 | QuantifiedConstraints | Planned | - | QuantifiedConstraints |
-| QuasiQuotes | In Progress | 0/3 | QuasiQuotes |
+| QuasiQuotes | In Progress | 2/3 | QuasiQuotes |
 | Rank2Types | Planned | - | Rank2Types |
 | RankNTypes | Planned | - | RankNTypes |
 | RebindableSyntax | Planned | - | RebindableSyntax |
@@ -148,5 +148,5 @@
 | UnliftedFFITypes | Planned | - | UnliftedFFITypes |
 | UnliftedNewtypes | Planned | - | UnliftedNewtypes |
 | Unsafe | Planned | - | Unsafe |
-| ViewPatterns | In Progress | 0/3 | ViewPatterns |
+| ViewPatterns | In Progress | 2/3 | ViewPatterns |
 

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -148,10 +148,11 @@ parse_stackage_progress() {
 	local infile="$1"
 	tr '\r' '\n' <"$infile" | awk '
     {
-      if ($1 ~ /^[0-9]+\/[0-9]+$/) {
-        split($1, parts, "/")
-        implemented = parts[1] + 0
-        total = parts[2] + 0
+      for (i=1; i<=NF; i++) {
+        if ($i == "/" && $(i-2) == "AIHC:") {
+          implemented = $(i-1) + 0
+          total = $(i+1) + 0
+        }
       }
     }
     END {


### PR DESCRIPTION
## Summary
- Fixed a bug in `scripts/update-generated-content.sh` where `stackage-progress` output was not correctly parsed due to a format change (added spaces around the slash).
- Updated progress counts in `README.md` and component documentation.

## Details
The `stackage-progress` tool outputs:
```
  AIHC: 230 / 3390 (6%)
```
The previous `awk` script expected `X/Y` without spaces. The updated script now correctly handles the spaces and filters for the `AIHC:` line.