### PR TITLE
fix: allow empty braced instance items

### DIFF
--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -249,7 +249,7 @@ instanceItemsBracedParser :: TokParser [InstanceDeclItem]
 instanceItemsBracedParser = do
   symbolLikeTok "{"
   _ <- MP.many (symbolLikeTok ";")
-  items <- instanceDeclItemParser `MP.sepBy1` symbolLikeTok ";"
+  items <- instanceDeclItemParser `MP.sepBy` symbolLikeTok ";"
   _ <- MP.many (symbolLikeTok ";")
   symbolLikeTok "}"
   pure items

--- a/components/haskell-parser/test/Test/Fixtures/FlexibleInstances/flexible-instance-with-braces.hs
+++ b/components/haskell-parser/test/Test/Fixtures/FlexibleInstances/flexible-instance-with-braces.hs
@@ -1,0 +1,2 @@
+{-# LANGUAGE FlexibleInstances #-}
+instance Validity Scientific where {}

--- a/components/haskell-parser/test/Test/Fixtures/FlexibleInstances/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/FlexibleInstances/manifest.tsv
@@ -1,3 +1,4 @@
 flexible-instance-empty-no-where	FlexibleInstances	flexible-instance-empty-no-where.hs	pass	parser supports empty flexible instances without where clause
 flexible-instance-empty-where	FlexibleInstances	flexible-instance-empty-where.hs	pass	parser supports empty flexible instances with where clause
 instance-unit	FlexibleInstances	instance-unit.hs	pass	parser supports FlexibleInstances with kind signatures
+flexible-instance-with-braces	FlexibleInstances	flexible-instance-with-braces.hs	pass	parser supports flexible instances with explicit braces


### PR DESCRIPTION
## Summary
- Fix `instance` declaration parser to allow empty braced item lists.
- Add regression test case in `FlexibleInstances` suite.
- Update `FlexibleInstances` progress count (+1 PASS).