### PR TITLE
test(parser): reject standalone underscore identifiers

### DIFF
--- a/components/haskell-parser/test/Spec.hs
+++ b/components/haskell-parser/test/Spec.hs
@@ -17,7 +17,7 @@ import Test.Properties.ExprModuleRoundTrip
   ( prop_exprPrettyRoundTrip,
     prop_modulePrettyRoundTrip,
   )
-import Test.Properties.Identifiers (isValidGeneratedIdent)
+import Test.Properties.Identifiers (isValidGeneratedIdent, shrinkIdent)
 import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
 import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
 import Test.StackageProgress.Summary (stackageProgressSummaryTests)
@@ -65,7 +65,9 @@ buildTests = do
             testCase "applies COLUMN pragmas to subsequent tokens" test_columnPragmaUpdatesSpan,
             testCase "applies COLUMN pragmas in the middle of a line" test_inlineColumnPragmaUpdatesSpan,
             testCase "can lex lazily from chunks" test_lexerChunkLaziness,
-            testCase "generated identifiers reject reserved keyword as" test_generatedIdentifiersRejectReservedAs
+            testCase "generated identifiers reject reserved keyword as" test_generatedIdentifiersRejectReservedAs,
+            testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
+            testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore
           ],
         testGroup
           "properties"
@@ -320,3 +322,13 @@ test_generatedIdentifiersRejectReservedAs :: Assertion
 test_generatedIdentifiersRejectReservedAs =
   assertBool "reserved keyword 'as' must not be treated as a valid generated identifier" $
     not (isValidGeneratedIdent "as")
+
+test_generatedIdentifiersRejectStandaloneUnderscore :: Assertion
+test_generatedIdentifiersRejectStandaloneUnderscore =
+  assertBool "standalone underscore must not be treated as a valid generated identifier" $
+    not (isValidGeneratedIdent "_")
+
+test_shrunkIdentifiersRejectStandaloneUnderscore :: Assertion
+test_shrunkIdentifiersRejectStandaloneUnderscore =
+  assertBool "standalone underscore must not be produced by shrinking" $
+    "_" `notElem` shrinkIdent "__"

--- a/components/haskell-parser/test/Test/Properties/Identifiers.hs
+++ b/components/haskell-parser/test/Test/Properties/Identifiers.hs
@@ -18,9 +18,9 @@ genIdent = do
   restLen <- chooseInt (0, 8)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
   let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate
-    then genIdent
-    else pure candidate
+  if isValidGeneratedIdent candidate
+    then pure candidate
+    else genIdent
 
 shrinkIdent :: Text -> [Text]
 shrinkIdent name =
@@ -34,7 +34,8 @@ isValidGeneratedIdent :: Text -> Bool
 isValidGeneratedIdent ident =
   case T.uncons ident of
     Just (first, rest) ->
-      (first `elem` (['a' .. 'z'] <> ['_']))
+      ident /= "_"
+        && (first `elem` (['a' .. 'z'] <> ['_']))
         && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
         && not (isReservedIdentifier ident)
     Nothing -> False


### PR DESCRIPTION
## Summary

- prevent generated parser-test identifiers from using the standalone underscore `_`, which pattern pretty-printing cannot round-trip because it reparses as `PWildcard`
- add deterministic regression tests covering identifier validation and shrinking for `_`

## Validation

- `nix run .#parser-quickcheck-batch -- --max-success 10000 --seed 1445609133 --property 'generated pattern AST pretty-printer round-trip'`
- `nix run .#parser-quickcheck-batch -- --max-success 2000 --seed 2145213443 --property 'generated pattern AST pretty-printer round-trip'`
- `nix flake check`

## Progress Counts

- Parser: no change
- PASS 291
- XFAIL 104
- XPASS 0
- FAIL 0
- COMPLETE 73.67%

## CodeRabbit

- `coderabbit review --prompt-only` returned prompts only for unrelated untracked local files (`failed.txt`, `IDEAS.md`), which are excluded from this commit and need no change for issue #250.

Fixes #250
