### PR TITLE
fix(parser): accept variable operators in import lists

### DIFF
--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -138,7 +138,7 @@ importSpecParser = withSpan $ do
 importItemParser :: TokParser ImportItem
 importItemParser = withSpan $ do
   namespace <- MP.optional exportImportNamespaceParser
-  itemName <- identifierTextParser <|> parens constructorOperatorParser
+  itemName <- identifierTextParser <|> parens importOperatorParser
   case namespace of
     Nothing ->
       pure (\span' -> ImportItemVar span' Nothing itemName)
@@ -151,6 +151,13 @@ importItemParser = withSpan $ do
           Nothing
             | ns == "type" || isTypeName itemName -> ImportItemAbs span' (Just ns) itemName
             | otherwise -> ImportItemVar span' (Just ns) itemName
+
+importOperatorParser :: TokParser Text
+importOperatorParser =
+  tokenSatisfy $ \tok ->
+    case lexTokenKind tok of
+      TkOperator op -> Just op
+      _ -> Nothing
 
 exportImportNamespaceParser :: TokParser Text
 exportImportNamespaceParser =

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -10,6 +10,7 @@ modules-import-hiding	modules	modules/import-hiding.hs	pass	parser now supports 
 modules-multi-imports	modules	modules/multi-imports.hs	pass	parser supports multiple plain imports
 modules-import-only	modules	modules/import-only.hs	pass	parser supports modules with imports and no declarations
 modules-import-as	modules	modules/import-as.hs	pass	parser now supports import aliases
+modules-import-var-operator	modules	modules/import-var-operator.hs	pass	parser now supports parenthesized variable operators in import lists
 modules-multiline-definition	modules	modules/multiline-definition.hs	pass	parser now handles multiline module headers
 modules-multiline-definition-module-split	modules	modules/multiline-definition-module-split.hs	pass	parser now handles multiline module headers
 modules-multiline-definition-where-split	modules	modules/multiline-definition-where-split.hs	pass	parser now handles multiline module headers

--- a/components/haskell-parser/test/Test/Fixtures/haskell2010/modules/import-var-operator.hs
+++ b/components/haskell-parser/test/Test/Fixtures/haskell2010/modules/import-var-operator.hs
@@ -1,0 +1,1 @@
+import           Control.Applicative       ((<$>))


### PR DESCRIPTION
## Summary
- Fix parser import item handling to accept parenthesized variable operators in import lists (e.g. `((<$>))`).
- Add a new Haskell2010 oracle fixture for this case: `modules/import-var-operator.hs`.
- Register the fixture in `haskell2010/manifest.tsv` as `pass`.

## Motivation
`nix run .#hackage-tester -- optparse-text` failed on:

```haskell
import           Control.Applicative       ((<$>))
```

The parser only allowed parenthesized constructor operators (`:`-prefixed) in import lists, rejecting variable operators.

## Validation
- `nix flake check`
- `nix run .#hackage-tester -- optparse-text`
- `coderabbit review --prompt-only` (no findings)

## Progress Counts
`nix run .#parser-progress`

- Before:
  - PASS: 291
  - XFAIL: 104
  - XPASS: 0
  - FAIL: 0
  - TOTAL: 395
  - COMPLETE: 73.67%
- After:
  - PASS: 292
  - XFAIL: 104
  - XPASS: 0
  - FAIL: 0
  - TOTAL: 396
  - COMPLETE: 73.73%
- Delta:
  - PASS: +1
  - TOTAL: +1
  - COMPLETE: +0.06pp