### PR TITLE
fix(parser): support standalone kind signatures in declarations

### DIFF
--- a/components/haskell-parser/app/stackage-progress/Main.hs
+++ b/components/haskell-parser/app/stackage-progress/Main.hs
@@ -833,6 +833,7 @@ stripDecl decl =
   case decl of
     DeclValue _ value -> DeclValue noSourceSpan (stripValueDecl value)
     DeclTypeSig _ names t -> DeclTypeSig noSourceSpan names (stripType t)
+    DeclStandaloneKindSig _ name kind -> DeclStandaloneKindSig noSourceSpan name (stripType kind)
     DeclFixity _ assoc prec ops -> DeclFixity noSourceSpan assoc prec ops
     DeclTypeSyn _ syn -> DeclTypeSyn noSourceSpan (stripTypeSynDecl syn)
     DeclData _ dat -> DeclData noSourceSpan (stripDataDecl dat)

--- a/components/haskell-parser/common/ParserGolden.hs
+++ b/components/haskell-parser/common/ParserGolden.hs
@@ -311,6 +311,7 @@ renderDecl decl =
   case decl of
     DeclValue _ valueDecl -> "DeclValue " <> par (renderValueDecl valueDecl)
     DeclTypeSig _ names ty -> "DeclTypeSig " <> show names <> " " <> par (renderType ty)
+    DeclStandaloneKindSig _ name kind -> "DeclStandaloneKindSig " <> show name <> " " <> par (renderType kind)
     DeclFixity _ assoc prec ops -> "DeclFixity " <> show assoc <> " " <> show prec <> " " <> show ops
     DeclTypeSyn _ syn -> "DeclTypeSyn " <> par (renderTypeSynDecl syn)
     DeclData _ dat -> "DeclData " <> par (renderDataDecl dat)

--- a/components/haskell-parser/src/Parser/Ast.hs
+++ b/components/haskell-parser/src/Parser/Ast.hs
@@ -345,6 +345,7 @@ data ImportItem
 data Decl
   = DeclValue SourceSpan ValueDecl
   | DeclTypeSig SourceSpan [BinderName] Type
+  | DeclStandaloneKindSig SourceSpan BinderName Type
   | DeclFixity SourceSpan FixityAssoc (Maybe Int) [OperatorName]
   | DeclTypeSyn SourceSpan TypeSynDecl
   | DeclData SourceSpan DataDecl

--- a/components/haskell-parser/src/Parser/Internal/Decl.hs
+++ b/components/haskell-parser/src/Parser/Internal/Decl.hs
@@ -166,12 +166,26 @@ exportImportNamespaceParser =
 declParser :: TokParser Decl
 declParser =
   MP.try foreignDeclParser
+    <|> MP.try standaloneKindSigDeclParser
     <|> MP.try typeSigDeclParser
     <|> MP.try newtypeDeclParser
     <|> MP.try dataDeclParser
     <|> MP.try classDeclParser
     <|> MP.try instanceDeclParser
     <|> valueDeclParser
+
+standaloneKindSigDeclParser :: TokParser Decl
+standaloneKindSigDeclParser = withSpan $ do
+  identifierExact "type"
+  typeName <-
+    tokenSatisfy $ \tok ->
+      case lexTokenKind tok of
+        TkIdentifier ident
+          | isTypeName ident -> Just ident
+        _ -> Nothing
+  operatorLikeTok "::"
+  kind <- typeParser
+  pure (\span' -> DeclStandaloneKindSig span' typeName kind)
 
 typeSigDeclParser :: TokParser Decl
 typeSigDeclParser = withSpan $ do

--- a/components/haskell-parser/src/Parser/Internal/Expr.hs
+++ b/components/haskell-parser/src/Parser/Internal/Expr.hs
@@ -749,6 +749,7 @@ declSourceSpan decl =
   case decl of
     DeclValue span' _ -> span'
     DeclTypeSig span' _ _ -> span'
+    DeclStandaloneKindSig span' _ _ -> span'
     DeclFixity span' _ _ _ -> span'
     DeclTypeSyn span' _ -> span'
     DeclData span' _ -> span'

--- a/components/haskell-parser/src/Parser/Pretty.hs
+++ b/components/haskell-parser/src/Parser/Pretty.hs
@@ -130,6 +130,7 @@ prettyDeclLines decl =
   case decl of
     DeclValue _ valueDecl -> prettyValueDeclLines valueDecl
     DeclTypeSig _ names ty -> [hsep [hsep (punctuate comma (map prettyBinderName names)), "::", prettyType ty]]
+    DeclStandaloneKindSig _ name kind -> [hsep ["type", prettyConstructorName name, "::", prettyType kind]]
     DeclFixity _ assoc prec ops ->
       [ hsep
           ( [prettyFixityAssoc assoc]

--- a/components/haskell-parser/test/Test/Fixtures/StandaloneKindSignatures/manifest.tsv
+++ b/components/haskell-parser/test/Test/Fixtures/StandaloneKindSignatures/manifest.tsv
@@ -1,4 +1,5 @@
-standalone-kind-data	declarations	standalone-kind-data.hs	xfail	parser support pending
-standalone-kind-class	declarations	standalone-kind-class.hs	xfail	parser support pending
-standalone-kind-type-synonym	declarations	standalone-kind-type-synonym.hs	xfail	parser support pending
-standalone-kind-higher-order	declarations	standalone-kind-higher-order.hs	xfail	parser support pending
+standalone-kind-data	declarations	standalone-kind-data.hs	pass
+standalone-kind-class	declarations	standalone-kind-class.hs	pass
+standalone-kind-type-synonym	declarations	standalone-kind-type-synonym.hs	pass
+standalone-kind-higher-order	declarations	standalone-kind-higher-order.hs	pass
+standalone-kind-nullary	declarations	standalone-kind-nullary.hs	pass

--- a/components/haskell-parser/test/Test/Fixtures/StandaloneKindSignatures/standalone-kind-nullary.hs
+++ b/components/haskell-parser/test/Test/Fixtures/StandaloneKindSignatures/standalone-kind-nullary.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+
+module StandaloneKindNullary where
+
+import Data.Kind (Type)
+
+type Range :: Type
+data Range = Range


### PR DESCRIPTION
## Summary
- Parse top-level standalone kind signatures (for example `type Range :: Type`) as declarations so modules no longer fail on StandaloneKindSignatures syntax.
- Add AST/pretty/golden/stackage-strip handling for `DeclStandaloneKindSig` to keep parser tooling and roundtrip paths consistent.
- Promote `StandaloneKindSignatures` extension oracle fixtures from `xfail` to `pass` and add a nullary fixture matching the hackage regression shape.

## Progress Counts
- Extension support totals changed from `SUPPORTED=20, IN_PROGRESS=14, PLANNED=104` to `SUPPORTED=21, IN_PROGRESS=13, PLANNED=104`.
- `StandaloneKindSignatures` changed from `PASS=0, XFAIL=4, XPASS=0, FAIL=0` to `PASS=5, XFAIL=0, XPASS=0, FAIL=0`.

## Validation
- `nix run .#hackage-tester -- simple-media-timestamp`
- `nix run .#parser-extension-progress`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)