### PR TITLE
test(lexer): add golden tests for comment edge cases

### DIFF
--- a/components/haskell-parser/common/LexerGolden.hs
+++ b/components/haskell-parser/common/LexerGolden.hs
@@ -34,7 +34,6 @@ import Text.Read (readMaybe)
 
 data ExpectedStatus
   = StatusPass
-  | StatusFail
   | StatusXPass
   | StatusXFail
   deriving (Eq, Show)
@@ -120,11 +119,9 @@ parseYamlFixture path value =
 evaluateLexerCase :: LexerCase -> (Outcome, String)
 evaluateLexerCase meta =
   let expectedKinds = caseTokens meta
-      actual = lexTokensWithExtensions (caseExtensions meta) (caseInput meta)
-      actualKinds = fmap (map lexTokenKind) actual
-      lexOk = either (const False) (const True) actual
-      tokenMatch = actualKinds == Right expectedKinds
-      lexFail = either (const True) (const False) actual
+      actualTokens = lexTokensWithExtensions (caseExtensions meta) (caseInput meta)
+      actualKinds = map lexTokenKind actualTokens
+      tokenMatch = actualKinds == expectedKinds
    in case caseStatus meta of
         StatusPass
           | tokenMatch -> (OutcomePass, "")
@@ -133,15 +130,12 @@ evaluateLexerCase meta =
                 "expected successful lex with matching token kinds"
                   <> detailsSuffix actualKinds expectedKinds
               )
-        StatusFail
-          | lexFail -> (OutcomePass, "")
-          | otherwise -> (OutcomeFail, "expected lex failure but lexing succeeded")
         StatusXFail
-          | lexFail -> (OutcomeXFail, "")
-          | otherwise -> (OutcomeFail, "expected xfail (known failing bug), but lexing succeeded")
+          | tokenMatch -> (OutcomeFail, "expected xfail (known failing bug), but tokens now match")
+          | otherwise -> (OutcomeXFail, "")
         StatusXPass
-          | lexOk && tokenMatch -> (OutcomeXPass, "known bug still passes unexpectedly")
-          | otherwise -> (OutcomeFail, "expected xpass (known passing bug), but case no longer matches xpass expectation")
+          | tokenMatch -> (OutcomeXPass, "known bug still passes unexpectedly")
+          | otherwise -> (OutcomeFail, "expected xpass (known passing bug), but tokens no longer match")
 
 progressSummary :: [(LexerCase, Outcome, String)] -> (Int, Int, Int, Int)
 progressSummary outcomes =
@@ -153,14 +147,11 @@ progressSummary outcomes =
   where
     count wanted = length [() | (_, out, _) <- outcomes, out == wanted]
 
-detailsSuffix :: Either String [LexTokenKind] -> [LexTokenKind] -> String
+detailsSuffix :: [LexTokenKind] -> [LexTokenKind] -> String
 detailsSuffix actual expected =
-  case actual of
-    Left err -> " (lexer error: " <> err <> ")"
-    Right actualKinds ->
-      if actualKinds == expected
-        then ""
-        else " (expected=" <> show expected <> ", actual=" <> show actualKinds <> ")"
+  if actual == expected
+    then ""
+    else " (expected=" <> show expected <> ", actual=" <> show actual <> ")"
 
 listFixtureFiles :: FilePath -> IO [FilePath]
 listFixtureFiles dir = do
@@ -195,7 +186,6 @@ parseStatus :: FilePath -> Text -> Either String ExpectedStatus
 parseStatus path raw =
   case map toLower (trim (T.unpack raw)) of
     "pass" -> Right StatusPass
-    "fail" -> Right StatusFail
     "xpass" -> Right StatusXPass
     "xfail" -> Right StatusXFail
     _ -> Left ("Invalid [status] in " <> path <> ": " <> T.unpack raw)

--- a/components/haskell-parser/src/Parser.hs
+++ b/components/haskell-parser/src/Parser.hs
@@ -99,10 +99,8 @@ defaultConfig =
 
 parseExpr :: ParserConfig -> Text -> ParseResult Expr
 parseExpr cfg input =
-  case lexTokensWithExtensions (parserExtensions cfg) input of
-    Left err -> ParseErr (lexerErrorBundle (parserSourceName cfg) err)
-    Right toks ->
-      case runParser (exprParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
+  let toks = lexTokensWithExtensions (parserExtensions cfg) input
+   in case runParser (exprParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
         Left bundle -> ParseErr bundle
         Right expr -> ParseOk expr
 
@@ -111,10 +109,8 @@ parseExprFromTokens = parseFromTokens exprParser
 
 parsePattern :: ParserConfig -> Text -> ParseResult Pattern
 parsePattern cfg input =
-  case lexTokensWithExtensions (parserExtensions cfg) input of
-    Left err -> ParseErr (lexerErrorBundle (parserSourceName cfg) err)
-    Right toks ->
-      case runParser (patternParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
+  let toks = lexTokensWithExtensions (parserExtensions cfg) input
+   in case runParser (patternParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
         Left bundle -> ParseErr bundle
         Right pat -> ParseOk pat
 
@@ -123,10 +119,8 @@ parsePatternFromTokens = parseFromTokens patternParser
 
 parseType :: ParserConfig -> Text -> ParseResult Type
 parseType cfg input =
-  case lexTokensWithExtensions (parserExtensions cfg) input of
-    Left err -> ParseErr (lexerErrorBundle (parserSourceName cfg) err)
-    Right toks ->
-      case runParser (typeParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
+  let toks = lexTokensWithExtensions (parserExtensions cfg) input
+   in case runParser (typeParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
         Left bundle -> ParseErr bundle
         Right ty -> ParseOk ty
 
@@ -135,10 +129,8 @@ parseTypeFromTokens = parseFromTokens typeParser
 
 parseModule :: ParserConfig -> Text -> ParseResult Module
 parseModule cfg input =
-  case lexModuleTokensWithExtensions effectiveExtensions input of
-    Left err -> ParseErr (lexerErrorBundle (parserSourceName cfg) err)
-    Right toks ->
-      case runParser (moduleParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
+  let toks = lexModuleTokensWithExtensions effectiveExtensions input
+   in case runParser (moduleParser <* MP.eof) (parserSourceName cfg) (TokStream toks) of
         Left bundle -> ParseErr bundle
         Right modu -> ParseOk modu
   where

--- a/components/haskell-parser/src/Parser/Lexer.hs
+++ b/components/haskell-parser/src/Parser/Lexer.hs
@@ -193,18 +193,18 @@ lexModuleTokensFromChunks = lexChunksWithExtensions True
 -- | Lex source text using explicit lexer extensions.
 --
 -- This runs raw tokenization, extension rewrites, and implicit-layout insertion.
--- Module-top layout is /not/ enabled here. The result currently cannot fail:
--- malformed lexemes become 'TkError' tokens in the token stream.
-lexTokensWithExtensions :: [Extension] -> Text -> Either String [LexToken]
-lexTokensWithExtensions exts input = Right (lexTokensFromChunksWithExtensions exts [input])
+-- Module-top layout is /not/ enabled here. Malformed lexemes become 'TkError'
+-- tokens in the token stream.
+lexTokensWithExtensions :: [Extension] -> Text -> [LexToken]
+lexTokensWithExtensions exts input = lexTokensFromChunksWithExtensions exts [input]
 
 -- | Lex module source text using explicit lexer extensions.
 --
 -- Like 'lexTokensWithExtensions', but also enables top-level module-body layout:
 -- when the source omits explicit braces, virtual layout tokens are inserted
 -- after @module ... where@ (or from the first non-pragma token in module-less files).
-lexModuleTokensWithExtensions :: [Extension] -> Text -> Either String [LexToken]
-lexModuleTokensWithExtensions exts input = Right (lexModuleTokensFromChunks exts [input])
+lexModuleTokensWithExtensions :: [Extension] -> Text -> [LexToken]
+lexModuleTokensWithExtensions exts input = lexModuleTokensFromChunks exts [input]
 
 -- | Internal chunked lexer entrypoint for non-module inputs.
 --

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/arrow-operator-in-expr.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/arrow-operator-in-expr.yaml
@@ -1,0 +1,9 @@
+extensions: []
+input: |
+  x --> y
+tokens:
+  - 'TkIdentifier "x"'
+  - 'TkOperator "-->"'
+  - 'TkIdentifier "y"'
+status: xfail
+reason: "lexer incorrectly treats --> as line comment; per Haskell report, --> is a legal operator"

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/comment-between-identifiers.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/comment-between-identifiers.yaml
@@ -1,0 +1,8 @@
+extensions: []
+input: |
+  x -- comment
+  y
+tokens:
+  - 'TkIdentifier "x"'
+  - 'TkIdentifier "y"'
+status: pass

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/dash-dash-dollar-operator.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/dash-dash-dollar-operator.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "--$"
+tokens:
+  - 'TkOperator "--$"'
+status: xfail
+reason: "lexer incorrectly treats --$ as line comment; per Haskell report, --$ is a legal operator"

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/dash-dash-foo-comment.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/dash-dash-foo-comment.yaml
@@ -1,0 +1,4 @@
+extensions: []
+input: "--foo"
+tokens: []
+status: pass

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/dash-dash-gt-operator.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/dash-dash-gt-operator.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "-->"
+tokens:
+  - 'TkOperator "-->"'
+status: xfail
+reason: "lexer incorrectly treats --> as line comment; per Haskell report, --> is a legal operator"

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/pipe-dash-dash-operator.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/pipe-dash-dash-operator.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: "|--"
+tokens:
+  - 'TkOperator "|--"'
+status: pass

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/quadruple-dash-comment.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/quadruple-dash-comment.yaml
@@ -1,0 +1,4 @@
+extensions: []
+input: "----"
+tokens: []
+status: pass

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/simple-line-comment.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/simple-line-comment.yaml
@@ -1,0 +1,4 @@
+extensions: []
+input: "-- simple comment"
+tokens: []
+status: pass

--- a/components/haskell-parser/test/Test/Fixtures/lexer/comments/triple-dash-comment.yaml
+++ b/components/haskell-parser/test/Test/Fixtures/lexer/comments/triple-dash-comment.yaml
@@ -1,0 +1,4 @@
+extensions: []
+input: "---"
+tokens: []
+status: pass


### PR DESCRIPTION
## Summary

- Add 9 lexer golden tests for line comment edge cases per Haskell 2010 report
- Refactor LexerGolden to support xfail for token mismatch (not just lexer failure)
- Simplify `lexTokensWithExtensions` and `lexModuleTokensWithExtensions` to return `[LexToken]` instead of `Either String [LexToken]` since lexing never fails

## Test Coverage

| Test | Expected Behavior | Status |
|------|-------------------|--------|
| `-->` | Operator (legal lexeme) | xfail |
| `--$` | Operator (legal lexeme) | xfail |
| `\|--` | Operator | pass |
| `--foo` | Comment (non-symbol after --) | pass |
| `-- comment` | Comment | pass |
| `---` | Comment | pass |
| `----` | Comment | pass |
| `x --> y` | Expr with --> operator | xfail |
| `x -- comment\ny` | Comment between identifiers | pass |

## Progress

```
PASS      12
XFAIL     3
XPASS     0
FAIL      0
```

The 3 xfail cases document known lexer bugs where `-->` and `--$` are incorrectly treated as comments instead of operators per the Haskell 2010 report.