### PR TITLE
fix(lexer): distinguish --X operators from line comments

### DIFF
--- a/components/aihc-parser/src/Parser/Lexer.hs
+++ b/components/aihc-parser/src/Parser/Lexer.hs
@@ -343,7 +343,8 @@ consumeTrivia st
         c : _
           | c == ' ' || c == '\t' || c == '\r' -> Just (consumeWhile (\x -> x == ' ' || x == '\t' || x == '\r') st)
           | c == '\n' -> Just (advanceChars "\n" st)
-        '-' : '-' : _ -> Just (consumeLineComment st)
+        '-' : '-' : rest
+          | isLineComment rest -> Just (consumeLineComment st)
         '{' : '-' : '#' : _ ->
           case tryConsumeControlPragma st of
             Just (Nothing, st') -> Just st'
@@ -1495,6 +1496,19 @@ isIdentTail c = isAlphaNum c || c == '_' || c == '\''
 
 isSymbolicOpChar :: Char -> Bool
 isSymbolicOpChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String)
+
+-- | Check if the remainder after '--' should start a line comment.
+-- Per Haskell Report: '--' starts a comment only if the entire symbol sequence
+-- consists solely of dashes, or is not followed by any symbol character.
+-- E.g., '-- foo' is a comment, '---' is a comment, but '-->' is an operator.
+isLineComment :: String -> Bool
+isLineComment rest =
+  case rest of
+    [] -> True -- Just '--' followed by nothing or whitespace
+    c : _
+      | c == '-' -> isLineComment (dropWhile (== '-') rest) -- More dashes, keep checking
+      | isSymbolicOpChar c -> False -- Non-dash symbol char means it's an operator
+      | otherwise -> True -- Non-symbol char means comment
 
 isIdentTailOrStart :: Char -> Bool
 isIdentTailOrStart c = isAlphaNum c || c == '_' || c == '\''

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/arrow-operator-in-expr.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/arrow-operator-in-expr.yaml
@@ -5,5 +5,4 @@ tokens:
   - 'TkVarId "x"'
   - 'TkVarSym "-->"'
   - 'TkVarId "y"'
-status: xfail
-reason: "lexer incorrectly treats --> as line comment; per Haskell report, --> is a legal operator"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-dollar-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-dollar-operator.yaml
@@ -2,5 +2,4 @@ extensions: []
 input: "--$"
 tokens:
   - 'TkVarSym "--$"'
-status: xfail
-reason: "lexer incorrectly treats --$ as line comment; per Haskell report, --$ is a legal operator"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-gt-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-gt-operator.yaml
@@ -2,5 +2,4 @@ extensions: []
 input: "-->"
 tokens:
   - 'TkVarSym "-->"'
-status: xfail
-reason: "lexer incorrectly treats --> as line comment; per Haskell report, --> is a legal operator"
+status: pass


### PR DESCRIPTION
## Summary

- Fixed lexer to correctly distinguish operators starting with `--` (like `-->`, `--$`) from line comments
- Per Haskell Report Section 2.3: `--` starts a comment only when followed by more dashes or non-symbol characters
- Added `isLineComment` helper function to implement this check

## Progress

Lexer: 29 PASS, 12 XFAIL (was 26 PASS, 15 XFAIL)