### PR TITLE
docs(readme): add workflow status shields for docs and reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Documentation](https://img.shields.io/github/actions/workflow/status/ai-haskell-compiler/aihc/deploy-docs.yml?label=docs)](https://ai-haskell-compiler.github.io/aihc/)
+[![Generated Reports](https://img.shields.io/github/actions/workflow/status/ai-haskell-compiler/aihc/generated-reports-update.yml?label=reports)](https://github.com/ai-haskell-compiler/aihc/actions/workflows/generated-reports-update.yml)
+
 # AI-written Haskell Compiler (aihc)
 
 ## Docs


### PR DESCRIPTION
## Summary

- Adds a Documentation shield that shows the status of the Deploy Documentation workflow and links to the Haddock docs at https://ai-haskell-compiler.github.io/aihc/
- Adds a Generated Reports shield that shows the status of the Generated Reports Update workflow and links to its workflow page