### PR TITLE
docs(aihc-cpp): improve haddock documentation with doctest examples

### DIFF
--- a/components/aihc-cpp/aihc-cpp.cabal
+++ b/components/aihc-cpp/aihc-cpp.cabal
@@ -11,7 +11,7 @@ synopsis:           Pure Haskell C preprocessor for aihc
 
 library
   exposed-modules:
-      Cpp
+      Aihc.Cpp
   hs-source-dirs:   src
   build-depends:
       base >=4.16 && <5

--- a/components/aihc-cpp/src/Aihc/Cpp.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
--- Module      : Cpp
+-- Module      : Aihc.Cpp
 -- Description : Pure Haskell C preprocessor for Haskell source files
 -- License     : Unlicense
 --
@@ -13,7 +13,7 @@
 -- The main entry point is 'preprocess', which takes a 'Config' and
 -- source text, returning a 'Step' that either completes with a 'Result'
 -- or requests an include file to be resolved.
-module Cpp
+module Aihc.Cpp
   ( -- * Preprocessing
     preprocess,
 

--- a/components/aihc-cpp/test/Spec.hs
+++ b/components/aihc-cpp/test/Spec.hs
@@ -2,7 +2,7 @@
 
 module Main (main) where
 
-import Cpp (Config (..), Result (..), Step (..), defaultConfig, preprocess)
+import Aihc.Cpp (Config (..), Result (..), Step (..), defaultConfig, preprocess)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Test.Progress (CaseMeta (..), Outcome (..), evaluateCase, loadManifest)

--- a/components/aihc-cpp/test/Test/Progress.hs
+++ b/components/aihc-cpp/test/Test/Progress.hs
@@ -9,8 +9,8 @@ module Test.Progress
   )
 where
 
+import Aihc.Cpp (Config (..), Diagnostic (..), IncludeRequest (..), Result (..), Severity (..), Step (..), defaultConfig, preprocess)
 import qualified Control.Exception as E
-import Cpp (Config (..), Diagnostic (..), IncludeRequest (..), Result (..), Severity (..), Step (..), defaultConfig, preprocess)
 import Data.Char (isDigit, isSpace)
 import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)

--- a/components/aihc-parser/app/hackage-tester/Main.hs
+++ b/components/aihc-parser/app/hackage-tester/Main.hs
@@ -2,12 +2,12 @@
 
 module Main (main) where
 
+import Aihc.Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
 import Control.Concurrent (newChan, readChan, writeChan)
 import Control.Concurrent.Async (async, wait)
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, readMVar)
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (unless, when)
-import Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
 import CppSupport (preprocessForParserIfEnabled)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS

--- a/components/aihc-parser/app/parser-progress/Main.hs
+++ b/components/aihc-parser/app/parser-progress/Main.hs
@@ -2,8 +2,8 @@
 
 module Main (main) where
 
+import Aihc.Cpp (resultOutput)
 import Control.Monad (filterM)
-import Cpp (resultOutput)
 import CppSupport (preprocessForParserWithoutIncludes)
 import Data.Text (Text)
 import qualified Data.Text.IO as TIO

--- a/components/aihc-parser/app/stackage-progress/Main.hs
+++ b/components/aihc-parser/app/stackage-progress/Main.hs
@@ -3,10 +3,10 @@
 
 module Main (main) where
 
+import Aihc.Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception (IOException, SomeException, displayException, try)
 import Control.Monad (when)
-import Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
 import CppSupport (preprocessForParserIfEnabled)
 import Data.Char (isAlphaNum, isSpace)
 import Data.List (isPrefixOf, nub, sortBy)

--- a/components/aihc-parser/common/CppSupport.hs
+++ b/components/aihc-parser/common/CppSupport.hs
@@ -10,7 +10,7 @@ module CppSupport
   )
 where
 
-import Cpp
+import Aihc.Cpp
   ( Config (..),
     IncludeKind (..),
     IncludeRequest (..),

--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -18,8 +18,8 @@ module GhcOracle
   )
 where
 
+import Aihc.Cpp (resultOutput)
 import Control.Exception (catch, displayException, evaluate)
-import Cpp (resultOutput)
 import CppSupport (moduleHeaderExtensionSettings, preprocessForParserWithoutIncludes)
 import Data.Bifunctor (first)
 import Data.List (nub)

--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -13,8 +13,8 @@ module HackageSupport
   )
 where
 
+import Aihc.Cpp (Diagnostic (..), IncludeKind (..), IncludeRequest (..), Severity (..))
 import Control.Monad (forM, when)
-import Cpp (Diagnostic (..), IncludeKind (..), IncludeRequest (..), Severity (..))
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.List (isPrefixOf, isSuffixOf, nub, sortOn)

--- a/components/aihc-parser/test/Test/Extensions/Suite.hs
+++ b/components/aihc-parser/test/Test/Extensions/Suite.hs
@@ -5,8 +5,8 @@ module Test.Extensions.Suite
   )
 where
 
+import Aihc.Cpp (resultOutput)
 import Control.Monad (when)
-import Cpp (resultOutput)
 import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
 import Data.Maybe (isNothing)
 import Data.Text (Text)

--- a/components/aihc-parser/test/Test/H2010/Suite.hs
+++ b/components/aihc-parser/test/Test/H2010/Suite.hs
@@ -5,8 +5,8 @@ module Test.H2010.Suite
   )
 where
 
+import Aihc.Cpp (resultOutput)
 import Control.Monad (when)
-import Cpp (resultOutput)
 import CppSupport (preprocessForParserWithoutIncludes)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)

--- a/components/aihc-parser/test/Test/HackageTester/Suite.hs
+++ b/components/aihc-parser/test/Test/HackageTester/Suite.hs
@@ -5,8 +5,8 @@ module Test.HackageTester.Suite
   )
 where
 
+import Aihc.Cpp (IncludeKind (..), IncludeRequest (..), Result (..))
 import Control.Exception (bracket)
-import Cpp (IncludeKind (..), IncludeRequest (..), Result (..))
 import CppSupport (preprocessForParserIfEnabled)
 import qualified Data.ByteString as BS
 import Data.List (isSuffixOf)

--- a/flake.nix
+++ b/flake.nix
@@ -507,9 +507,8 @@
             ];
           } ''
             cd "$src/components/aihc-cpp"
-            # Run doctest on the Cpp module
-            # We need to tell doctest where to find the package database
-            doctest -isrc src/Cpp.hs
+            # Run doctest on the Aihc.Cpp module
+            doctest -isrc src/Aihc/Cpp.hs
             touch "$out"
           '';
         in {


### PR DESCRIPTION
## Summary

- Move `preprocess` to top of export list as the primary API entry point
- Add comprehensive Haddock documentation with doctest examples for all exported types
- Remove `configDateTime` field from `Config`; use `configMacros` for `__DATE__`/`__TIME__`
- Add doctest check to CI via `flake.nix`

## Details

### API Improvements

The `preprocess` function is now prominently at the top of the export list with extensive documentation including:
- Macro expansion examples (object-like and function-like macros)
- Conditional compilation examples (`#if`, `#ifdef`, `#else`, `#endif`)
- Include handling with `NeedInclude` step continuation
- Diagnostics (`#warning`, `#error`) examples

### Breaking Change: `configDateTime` removed

The `configDateTime :: !(Text, Text)` field has been removed from `Config`. Users should now use `configMacros` to set `__DATE__` and `__TIME__`:

```haskell
-- Before:
cfg = defaultConfig { configDateTime = ("Mar 15 2026", "12:00:00") }

-- After:
cfg = defaultConfig { configMacros = M.fromList [("__DATE__", "\"Mar 15 2026\""), ("__TIME__", "\"12:00:00\"")] }
```

Note: The macro values must include the quotation marks since they are string literals.

The `defaultConfig` now includes `__DATE__` and `__TIME__` set to the Unix epoch, so users who don't need specific date/time values don't need to change anything.

### Testing

- All existing tests pass
- Added doctest check to verify documentation examples are correct
- 20 doctest examples covering all major functionality