### PR TITLE
feat(parser): improve import/export list parsing for symbols and wildcards

### DIFF
--- a/components/aihc-parser/src/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Parser/Internal/Decl.hs
@@ -62,7 +62,7 @@ exportModuleParser = do
 exportNameParser :: TokParser (SourceSpan -> ExportSpec)
 exportNameParser = do
   namespace <- MP.optional exportImportNamespaceParser
-  name <- identifierTextParser
+  name <- identifierTextParser <|> parens operatorTextParser
   members <- MP.optional exportMembersParser
   pure $ \span' ->
     case members of
@@ -76,12 +76,18 @@ exportMembersParser :: TokParser (Maybe [Text])
 exportMembersParser =
   parens $
     (expectedTok TkReservedDotDot >> pure Nothing)
-      <|> (Just <$> (identifierTextParser `MP.sepEndBy` expectedTok TkSpecialComma))
+      <|> (Just <$> (memberNameParser `MP.sepEndBy` expectedTok TkSpecialComma))
+  where
+    memberNameParser = identifierTextParser <|> parens operatorTextParser
 
+-- | Checks if a name refers to a type/class (as opposed to a variable/function).
+-- In Haskell:
+-- - Identifiers starting with uppercase letters are type constructors/classes
+-- - Symbolic operators starting with ':' are constructor operators (type-level)
 isTypeName :: Text -> Bool
 isTypeName txt =
   case T.uncons txt of
-    Just (c, _) -> isUpper c
+    Just (c, _) -> isUpper c || c == ':'
     Nothing -> False
 
 importDeclParser :: TokParser ImportDecl
@@ -135,18 +141,20 @@ importItemParser :: TokParser ImportItem
 importItemParser = withSpan $ do
   namespace <- MP.optional exportImportNamespaceParser
   itemName <- identifierTextParser <|> parens importOperatorParser
-  case namespace of
-    Nothing ->
-      pure (\span' -> ImportItemVar span' Nothing itemName)
-    Just ns -> do
-      members <- MP.optional exportMembersParser
-      pure $ \span' ->
-        case members of
-          Just Nothing -> ImportItemAll span' (Just ns) itemName
-          Just (Just names) -> ImportItemWith span' (Just ns) itemName names
-          Nothing
-            | ns == "type" || isTypeName itemName -> ImportItemAbs span' (Just ns) itemName
-            | otherwise -> ImportItemVar span' (Just ns) itemName
+  -- When there's no explicit namespace, we still need to try parsing members
+  -- for type constructors and type classes (uppercase names or parenthesized operators)
+  let shouldTryMembers = case namespace of
+        Just _ -> True
+        Nothing -> isTypeName itemName
+  members <- if shouldTryMembers then MP.optional exportMembersParser else pure Nothing
+  let effectiveNamespace = namespace
+  pure $ \span' ->
+    case members of
+      Just Nothing -> ImportItemAll span' effectiveNamespace itemName
+      Just (Just names) -> ImportItemWith span' effectiveNamespace itemName names
+      Nothing
+        | effectiveNamespace == Just "type" || isTypeName itemName -> ImportItemAbs span' effectiveNamespace itemName
+        | otherwise -> ImportItemVar span' effectiveNamespace itemName
 
 importOperatorParser :: TokParser Text
 importOperatorParser = operatorTextParser

--- a/components/aihc-parser/src/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Parser/Pretty.hs
@@ -73,10 +73,10 @@ prettyExportSpec spec =
   case spec of
     ExportModule _ modName -> "module" <+> pretty modName
     ExportVar _ namespace name -> prettyNamespacePrefix namespace <> prettyBinderName name
-    ExportAbs _ namespace name -> prettyNamespacePrefix namespace <> pretty name
-    ExportAll _ namespace name -> prettyNamespacePrefix namespace <> pretty name <> "(..)"
+    ExportAbs _ namespace name -> prettyNamespacePrefix namespace <> prettyConstructorName name
+    ExportAll _ namespace name -> prettyNamespacePrefix namespace <> prettyConstructorName name <> "(..)"
     ExportWith _ namespace name members ->
-      prettyNamespacePrefix namespace <> pretty name <> parens (hsep (punctuate comma (map prettyBinderName members)))
+      prettyNamespacePrefix namespace <> prettyConstructorName name <> parens (hsep (punctuate comma (map prettyBinderName members)))
 
 prettyImportDecl :: ImportDecl -> Doc ann
 prettyImportDecl decl =
@@ -114,10 +114,10 @@ prettyImportItem :: ImportItem -> Doc ann
 prettyImportItem item =
   case item of
     ImportItemVar _ namespace name -> prettyNamespacePrefix namespace <> prettyBinderName name
-    ImportItemAbs _ namespace name -> prettyNamespacePrefix namespace <> pretty name
-    ImportItemAll _ namespace name -> prettyNamespacePrefix namespace <> pretty name <> "(..)"
+    ImportItemAbs _ namespace name -> prettyNamespacePrefix namespace <> prettyConstructorName name
+    ImportItemAll _ namespace name -> prettyNamespacePrefix namespace <> prettyConstructorName name <> "(..)"
     ImportItemWith _ namespace name members ->
-      prettyNamespacePrefix namespace <> pretty name <> parens (hsep (punctuate comma (map prettyBinderName members)))
+      prettyNamespacePrefix namespace <> prettyConstructorName name <> parens (hsep (punctuate comma (map prettyBinderName members)))
 
 prettyNamespacePrefix :: Maybe Text -> Doc ann
 prettyNamespacePrefix namespace =

--- a/components/aihc-parser/test/Test/Fixtures/PatternSynonyms/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/PatternSynonyms/manifest.tsv
@@ -11,7 +11,7 @@ pattern-synonyms-complete-pragma	declarations	pattern-synonyms-complete-pragma.h
 pattern-synonyms-inline-pragmas	declarations	pattern-synonyms-inline-pragmas.hs	xfail	parser support pending
 pattern-synonyms-export-pattern-keyword	modules	pattern-synonyms-export-pattern-keyword.hs	xfail	parser support pending
 pattern-synonyms-import-pattern-keyword	modules	pattern-synonyms-import-pattern-keyword.hs	xfail	parser support pending
-pattern-synonyms-import-export-bundled	modules	pattern-synonyms-import-export-bundled.hs	xfail	parser support pending
+pattern-synonyms-import-export-bundled	modules	pattern-synonyms-import-export-bundled.hs	pass	parser now supports type constructor explicit member imports/exports
 pattern-synonyms-export-data-keyword	modules	pattern-synonyms-export-data-keyword.hs	xfail	parser support pending
 pattern-synonyms-import-data-keyword	modules	pattern-synonyms-import-data-keyword.hs	xfail	parser support pending
 pattern-synonyms-import-export-bundled-data	modules	pattern-synonyms-import-export-bundled-data.hs	xfail	parser support pending

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -27,15 +27,17 @@ modules-s5-export-qtycon-abstract	modules	modules/s5-export-qtycon-abstract.hs	p
 modules-s5-export-qtycon-all	modules	modules/s5-export-qtycon-all.hs	pass	parser now supports section 5 wildcard type constructor export entries
 modules-s5-export-qtycon-cnames	modules	modules/s5-export-qtycon-cnames.hs	pass	parser now supports section 5 explicit constructor member export entries
 modules-s5-export-qvar	modules	modules/s5-export-qvar.hs	pass	parser now supports section 5 variable export entries
+modules-s5-export-qvar-operator	modules	modules/s5-export-qvar-operator.hs	pass	parser now supports section 5 parenthesized operator export entries
+modules-export-var-operator	modules	modules/export-var-operator.hs	pass	parser now supports parenthesized operator export entries
 modules-s5-import-as-explicit-list	modules	modules/s5-import-as-explicit-list.hs	pass	parser now supports section 5 import aliases with explicit lists
 modules-s5-import-as-hiding	modules	modules/s5-import-as-hiding.hs	pass	parser now supports section 5 import aliases with hiding lists
 modules-s5-import-as	modules	modules/s5-import-as.hs	pass	parser now supports section 5 import aliases
 modules-s5-import-empty-list	modules	modules/s5-import-empty-list.hs	pass	parser now supports empty section 5 import lists
-modules-s5-import-explicit-tycls-all	modules	modules/s5-import-explicit-tycls-all.hs	xfail	section 5 module variation unsupported
-modules-s5-import-explicit-tycls-methods	modules	modules/s5-import-explicit-tycls-methods.hs	xfail	section 5 module variation unsupported
+modules-s5-import-explicit-tycls-all	modules	modules/s5-import-explicit-tycls-all.hs	pass	parser now supports section 5 explicit class imports with wildcard
+modules-s5-import-explicit-tycls-methods	modules	modules/s5-import-explicit-tycls-methods.hs	pass	parser now supports section 5 explicit class method imports
 modules-s5-import-explicit-tycls	modules	modules/s5-import-explicit-tycls.hs	pass	parser now supports section 5 explicit class imports
-modules-s5-import-explicit-tycon-all	modules	modules/s5-import-explicit-tycon-all.hs	xfail	section 5 module variation unsupported
-modules-s5-import-explicit-tycon-cnames	modules	modules/s5-import-explicit-tycon-cnames.hs	xfail	section 5 module variation unsupported
+modules-s5-import-explicit-tycon-all	modules	modules/s5-import-explicit-tycon-all.hs	pass	parser now supports section 5 explicit type constructor imports with wildcard
+modules-s5-import-explicit-tycon-cnames	modules	modules/s5-import-explicit-tycon-cnames.hs	pass	parser now supports section 5 explicit type constructor imports with constructor names
 modules-s5-import-explicit-tycon	modules	modules/s5-import-explicit-tycon.hs	pass	parser now supports section 5 explicit type constructor imports
 modules-s5-import-explicit-var	modules	modules/s5-import-explicit-var.hs	pass	parser now supports section 5 explicit variable imports
 modules-s5-import-hiding-empty	modules	modules/s5-import-hiding-empty.hs	pass	parser now supports section 5 empty hiding import lists
@@ -261,10 +263,10 @@ hashable-xxh3-cpp-include	corpus	corpus/hashable/hashable-xxh3-cpp-include.hs	pa
 hashable-generic-instances-kind-arrow	corpus	corpus/hashable/hashable-generic-instances-kind-arrow.hs	pass	from hashable/src/Data/Hashable/Generic/Instances.hs; parser now accepts multiline LANGUAGE pragma lists
 hashable-mix-cpp-if	corpus	corpus/hashable/hashable-mix-cpp-if.hs	pass	from hashable/src/Data/Hashable/Mix.hs; parser now accepts this preprocessed case
 hashable-ffi-capi-calling-convention	corpus	corpus/hashable/hashable-ffi-capi-calling-convention.hs	xfail	from hashable/src/Data/Hashable/FFI.hs; parser does not support capi calling convention (CApiFFI)
-hashable-class-package-imports	corpus	corpus/hashable/hashable-class-package-imports.hs	xfail	from hashable/src/Data/Hashable/Class.hs; parser rejects package-qualified imports
+hashable-class-package-imports	corpus	corpus/hashable/hashable-class-package-imports.hs	pass	from hashable/src/Data/Hashable/Class.hs; parser now supports package-qualified imports with type constructor wildcards
 hashable-lowlevel-cpp-ifdef	corpus	corpus/hashable/hashable-lowlevel-cpp-ifdef.hs	pass	from hashable/src/Data/Hashable/LowLevel.hs; parser now accepts this preprocessed case
 hashable-properties-unboxed-tuples	corpus	corpus/hashable/hashable-properties-unboxed-tuples.hs	xfail	from hashable/tests/Properties.hs; parser rejects unboxed tuple syntax
 hashable-regress-cpp-have-mmap	corpus	corpus/hashable/hashable-regress-cpp-have-mmap.hs	pass	from hashable/tests/Regress.hs; covered by parser-test CPP preprocessing
 hashable-xxhash-tests-numeric-underscores	corpus	corpus/hashable/hashable-xxhash-tests-numeric-underscores.hs	pass	from hashable/tests/xxhash-tests.hs; parser now accepts NumericUnderscores literals
-modules-import-operator	modules	modules/import-operator.hs	xfail	parser supports parenthesized operators in import lists
+modules-import-operator	modules	modules/import-operator.hs	pass	parser now supports parenthesized type operators with wildcard in import lists
 vinyl-loeb-rloeb-section	corpus	corpus/vinyl-loeb-rloeb-section.hs	pass	from vinyl-loeb; parser now supports parenthesized right sections like (($ go) ...)

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/modules/export-var-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/modules/export-var-operator.hs
@@ -1,0 +1,2 @@
+module Test ((</$>)) where
+(</$>) = undefined

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/modules/s5-export-qvar-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/modules/s5-export-qvar-operator.hs
@@ -1,0 +1,2 @@
+module S5ExportQVarOperator ((</$>)) where
+(</$>) = const


### PR DESCRIPTION
## Summary

- Add support for parenthesized operators in export lists (e.g., `module M ((</$>)) where`)
- Add support for constructor wildcard `(..)` in import lists without explicit `type` namespace (e.g., `import Data.Maybe (Maybe(..))`)
- Recognize constructor operators (starting with `:`) as type-level names for member parsing
- Fix pretty printer to properly parenthesize operators in import/export specs
- Add support for parenthesized operators in import/export member lists

## Parser Progress

- Before: 337 PASS (83.0%)
- After: 345 PASS (84.76%)
- Improvement: +8 tests, +1.76%

## Test Cases Fixed

The following test cases now pass:
- `modules-s5-import-explicit-tycls-all` - `import Prelude (Ord(..))`
- `modules-s5-import-explicit-tycls-methods` - `import Prelude (Ord(compare))`
- `modules-s5-import-explicit-tycon-all` - `import Data.Maybe (Maybe(..))`
- `modules-s5-import-explicit-tycon-cnames` - `import Data.Maybe (Maybe(Nothing, Just))`
- `modules-import-operator` - `import Data.Type.Equality ((:~~:)(..))`
- `hashable-class-package-imports` - package-qualified imports with type constructor wildcards
- `pattern-synonyms-import-export-bundled` - pattern synonyms bundled imports/exports
- `modules-s5-export-qvar-operator` - new test for `module M ((</$>)) where`

## Changes

### Parser (`Parser/Internal/Decl.hs`)
1. Export names can now be parenthesized operators
2. Import/export member lists can now contain parenthesized operators
3. `isTypeName` now recognizes constructor operators (starting with `:`) as type-level
4. Import items without explicit `type` namespace now try to parse members for type constructors

### Pretty Printer (`Parser/Pretty.hs`)
1. Use `prettyConstructorName` instead of `pretty` for type constructors in import/export specs
2. This ensures operators like `:~~:` are properly parenthesized in output