### PR TITLE
fix(parser): support do/if/case/let/lambda as infix operands

### DIFF
--- a/components/aihc-parser/src/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Parser/Internal/Expr.hs
@@ -100,9 +100,22 @@ doExprStmtParser = withSpan $ do
 
 infixExprParserExcept :: [Text] -> TokParser Expr
 infixExprParserExcept forbidden = do
-  lhs <- MP.try negateExprParser <|> appExprParser
-  rest <- MP.many ((,) <$> infixOperatorParserExcept forbidden <*> appExprParser)
+  lhs <- MP.try negateExprParser <|> lexpParser
+  rest <- MP.many ((,) <$> infixOperatorParserExcept forbidden <*> lexpParser)
   pure (foldl buildInfix lhs rest)
+
+-- | Parse an lexp (left-expression) - includes do, if, case, let, lambda, and fexp.
+-- This is used on both sides of infix operators per the Haskell Report grammar.
+lexpParser :: TokParser Expr
+lexpParser = do
+  tok <- lookAhead anySingle
+  case lexTokenKind tok of
+    TkKeywordDo -> doExprParser
+    TkKeywordIf -> ifExprParser
+    TkKeywordCase -> caseExprParser
+    TkKeywordLet -> letExprParser
+    TkReservedBackslash -> lambdaExprParser
+    _ -> appExprParser
 
 buildInfix :: Expr -> (Text, Expr) -> Expr
 buildInfix lhs (op, rhs) =

--- a/components/aihc-parser/src/Parser/Lexer.hs
+++ b/components/aihc-parser/src/Parser/Lexer.hs
@@ -174,6 +174,8 @@ data LayoutContext
   = LayoutExplicit
   | LayoutImplicit !Int
   | LayoutImplicitLet !Int
+  | -- | Marker for ( or [ to scope implicit layout closures
+    LayoutDelimiter
   deriving (Eq, Show)
 
 data PendingLayout
@@ -640,6 +642,16 @@ closeBeforeToken st tok =
       | layoutDelimiterDepth st == 0 ->
           let (inserted, contexts') = closeLeadingImplicitLets (lexTokenSpan tok) (layoutContexts st)
            in (inserted, st {layoutContexts = contexts'})
+    -- Close implicit layout contexts before closing delimiters (parse-error rule)
+    TkSpecialRParen ->
+      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
+       in (inserted, st {layoutContexts = contexts'})
+    TkSpecialRBracket ->
+      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
+       in (inserted, st {layoutContexts = contexts'})
+    TkSpecialRBrace ->
+      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
+       in (inserted, st {layoutContexts = contexts'})
     _ -> ([], st)
 
 bolLayout :: LayoutState -> LexToken -> ([LexToken], LayoutState)
@@ -694,6 +706,17 @@ closeLeadingImplicitLets anchor = go []
         LayoutImplicitLet _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
         _ -> (reverse acc, contexts)
 
+-- | Close all implicit layout contexts up to (but not including) the first explicit context.
+-- Used to implement the Haskell Report's "parse-error" rule for closing delimiters.
+closeAllImplicitBeforeDelimiter :: SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
+closeAllImplicitBeforeDelimiter anchor = go []
+  where
+    go acc contexts =
+      case contexts of
+        LayoutImplicit _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
+        LayoutImplicitLet _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
+        _ -> (reverse acc, contexts)
+
 stepTokenContext :: LayoutState -> LexToken -> LayoutState
 stepTokenContext st tok =
   case lexTokenKind tok of
@@ -705,13 +728,37 @@ stepTokenContext st tok =
       | otherwise -> st
     TkKeywordLet -> st {layoutPendingLayout = Just PendingLayoutLet}
     TkKeywordWhere -> st {layoutPendingLayout = Just PendingLayoutGeneric}
-    TkSpecialLParen -> st {layoutDelimiterDepth = layoutDelimiterDepth st + 1}
-    TkSpecialLBracket -> st {layoutDelimiterDepth = layoutDelimiterDepth st + 1}
-    TkSpecialRParen -> st {layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1)}
-    TkSpecialRBracket -> st {layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1)}
+    TkSpecialLParen ->
+      st
+        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
+          layoutContexts = LayoutDelimiter : layoutContexts st
+        }
+    TkSpecialLBracket ->
+      st
+        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
+          layoutContexts = LayoutDelimiter : layoutContexts st
+        }
+    TkSpecialRParen ->
+      st
+        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
+          layoutContexts = popToDelimiter (layoutContexts st)
+        }
+    TkSpecialRBracket ->
+      st
+        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
+          layoutContexts = popToDelimiter (layoutContexts st)
+        }
     TkSpecialLBrace -> st {layoutContexts = LayoutExplicit : layoutContexts st}
     TkSpecialRBrace -> st {layoutContexts = popOneContext (layoutContexts st)}
     _ -> st
+
+-- | Pop the layout context stack up to and including the nearest LayoutDelimiter.
+popToDelimiter :: [LayoutContext] -> [LayoutContext]
+popToDelimiter contexts =
+  case contexts of
+    LayoutDelimiter : rest -> rest
+    _ : rest -> popToDelimiter rest
+    [] -> []
 
 popOneContext :: [LayoutContext] -> [LayoutContext]
 popOneContext contexts =
@@ -735,6 +782,7 @@ isImplicitLayoutContext ctx =
     LayoutImplicit _ -> True
     LayoutImplicitLet _ -> True
     LayoutExplicit -> False
+    LayoutDelimiter -> False
 
 isBOL :: LayoutState -> LexToken -> Bool
 isBOL st tok =

--- a/components/aihc-parser/src/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Parser/Pretty.hs
@@ -601,6 +601,19 @@ prettyConstructorName name
   | isOperatorToken name = parens (pretty name)
   | otherwise = pretty name
 
+-- | Print an expression used as the RHS of an infix operator.
+-- Self-delimiting expressions (do, if, case, let, lambda) don't need parentheses.
+prettyExprInfixRhs :: Expr -> Doc ann
+prettyExprInfixRhs expr =
+  case expr of
+    EDo {} -> prettyExprPrec 0 expr
+    EIf {} -> prettyExprPrec 0 expr
+    ECase {} -> prettyExprPrec 0 expr
+    ELetDecls {} -> prettyExprPrec 0 expr
+    ELambdaPats {} -> prettyExprPrec 0 expr
+    ELambdaCase {} -> prettyExprPrec 0 expr
+    _ -> prettyExprPrec 1 expr
+
 prettyExprPrec :: Int -> Expr -> Doc ann
 prettyExprPrec prec expr =
   case expr of
@@ -627,7 +640,7 @@ prettyExprPrec prec expr =
       parenthesize
         (prec > 0)
         ("\\" <> "case" <+> braces (hsep (punctuate semi (map prettyCaseAlt alts))))
-    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprPrec 1 lhs <+> prettyExprOperator op <+> prettyExprPrec 1 rhs)
+    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprPrec 1 lhs <+> prettyExprOperator op <+> prettyExprInfixRhs rhs)
     ENegate _ inner -> parenthesize (prec > 2) ("-" <> prettyExprPrec 3 inner)
     ESectionL _ lhs op -> parens (prettyExprPrec 0 lhs <+> prettyExprOperator op)
     ESectionR _ op rhs -> parens (prettyExprOperator op <+> prettyExprPrec 0 rhs)

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/case-infix-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/case-infix-rhs.hs
@@ -1,0 +1,2 @@
+module X where
+x = a + case b of { c -> d }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-as-argument.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-as-argument.hs
@@ -1,0 +1,2 @@
+module X where
+x = f (do a;b)

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-in-list.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-in-list.hs
@@ -1,0 +1,2 @@
+module X where
+x = [do a;b]

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-in-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-in-parens.hs
@@ -1,0 +1,2 @@
+module X where
+x = (do a;b)

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-infix-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/do-infix-rhs.hs
@@ -1,0 +1,2 @@
+module X where
+x = y <$ do a;b

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/if-infix-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/if-infix-rhs.hs
@@ -1,0 +1,2 @@
+module X where
+x = a + if b then c else d

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/lambda-infix-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/lambda-infix-rhs.hs
@@ -1,0 +1,2 @@
+module X where
+x = a + \y -> y

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/let-infix-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/let-infix-rhs.hs
@@ -1,0 +1,2 @@
+module X where
+x = a + let y = z in y

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -195,6 +195,14 @@ expr-s3-do-bind-stmt	expressions	expressions/do-bind-stmt.hs	pass	parser now sup
 expr-s3-do-let-stmt	expressions	expressions/do-let-stmt.hs	pass	parser now supports do-notation let statements
 expr-s3-do-let-function-binding-nested	expressions	expressions/do-let-function-binding-nested.hs	pass	parser supports nested do with plain let function bindings
 expr-s3-do-sequence-stmts	expressions	expressions/do-sequence-stmts.hs	pass	parser now supports do statement sequencing
+expr-s3-do-infix-rhs	expressions	expressions/do-infix-rhs.hs	pass	parser supports do as right operand of infix expression
+expr-s3-do-in-parens	expressions	expressions/do-in-parens.hs	pass	parser supports do inside parentheses with layout
+expr-s3-do-in-list	expressions	expressions/do-in-list.hs	pass	parser supports do inside list brackets with layout
+expr-s3-do-as-argument	expressions	expressions/do-as-argument.hs	pass	parser supports do as function argument with layout
+expr-s3-if-infix-rhs	expressions	expressions/if-infix-rhs.hs	pass	parser supports if as right operand of infix expression
+expr-s3-case-infix-rhs	expressions	expressions/case-infix-rhs.hs	pass	parser supports case as right operand of infix expression
+expr-s3-let-infix-rhs	expressions	expressions/let-infix-rhs.hs	pass	parser supports let as right operand of infix expression
+expr-s3-lambda-infix-rhs	expressions	expressions/lambda-infix-rhs.hs	pass	parser supports lambda as right operand of infix expression
 expr-s3-record-field-selection	expressions	expressions/record-field-selection.hs	pass
 expr-s3-record-construction-empty	expressions	expressions/record-construction-empty.hs	xfail	parser intentionally disabled
 expr-s3-record-construction-fields	expressions	expressions/record-construction-fields.hs	xfail	parser intentionally disabled


### PR DESCRIPTION
## Summary

- Fix parsing of expressions like `x = y <$ do a;b` where a layout-based do block appears as the right operand of an infix operator
- Add `LayoutDelimiter` context marker to properly scope implicit layout closures within parentheses and brackets
- Implement `lexpParser` to handle left-expressions (do, if, case, let, lambda) per the Haskell Report grammar
- Fix pretty-printer to avoid unnecessary parentheses around self-delimiting expressions in infix RHS positions

## Test Coverage

Added 8 new test cases:
- `do-infix-rhs`: `x = y <$ do a;b`
- `do-in-parens`: `x = (do a;b)`
- `do-in-list`: `x = [do a;b]`
- `do-as-argument`: `x = f (do a;b)`
- `if-infix-rhs`: `x = a + if b then c else d`
- `case-infix-rhs`: `x = a + case b of { c -> d }`
- `let-infix-rhs`: `x = a + let y = z in y`
- `lambda-infix-rhs`: `x = a + \y -> y`

## Progress Counts

Parser progress: PASS=345, XFAIL=69, COMPLETE=83.33% (unchanged)