### PR TITLE
fix(ci): remove broken hpc-coveralls dependency from coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,47 +23,21 @@ jobs:
           r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           nix-cache-private-key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
 
-      - name: Build and test with coverage
+      - name: Build coverage report
         run: |
-          nix develop .#coverage --command bash << 'COVERAGE_SCRIPT'
-            set -euo pipefail
+          echo "=== Building coverage report with Nix ==="
+          nix build .#coverage --print-out-paths
 
-            echo "=== Building aihc-parser with coverage ==="
-            cd components/aihc-parser
-            cabal configure --enable-tests --enable-coverage
-            cabal build
-            cabal test --test-show-details=direct || true
-            cd ../..
-
-            echo "=== Building aihc-cpp with coverage ==="
-            cd components/aihc-cpp
-            cabal configure --enable-tests --enable-coverage
-            cabal build
-            cabal test --test-show-details=direct || true
-            cd ../..
-
-            echo "=== Coverage data generated ==="
-          COVERAGE_SCRIPT
-
-      - name: Upload coverage to Coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Display coverage summary
         run: |
-          nix develop .#coverage --command bash << 'UPLOAD_SCRIPT'
-            set -euo pipefail
-
-            # Check if repo token is set
-            if [ -z "${COVERALLS_REPO_TOKEN:-}" ]; then
-              echo "Warning: COVERALLS_REPO_TOKEN not set, skipping upload"
-              exit 0
-            fi
-
-            echo "=== Uploading aihc-parser coverage to Coveralls ==="
-            cd components/aihc-parser
-            hpc-coveralls spec \
-              --repo-token="$COVERALLS_REPO_TOKEN" \
-              --exclude-dir=test \
-              --exclude-dir=app \
-              --exclude-dir=common || echo "Parser coverage upload completed (or skipped)"
-            cd ../..
-          UPLOAD_SCRIPT
+          coverage_path=$(nix build .#coverage --print-out-paths)
+          echo "=== Coverage Report Location ==="
+          echo "$coverage_path"
+          echo ""
+          echo "=== Coverage Report Contents ==="
+          ls -la "$coverage_path/"
+          echo ""
+          if [ -f "$coverage_path/README.txt" ]; then
+            echo "=== Coverage Summary ==="
+            cat "$coverage_path/README.txt"
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -474,61 +474,6 @@
               fi
             '';
 
-          # Upload coverage to coveralls.io using hpc-coveralls
-          upload-coverage = mkAppWithInputs "upload-coverage" [
-            pkgs.bash
-            pkgs.git
-            pkgs.curl
-          ] ''
-            set -euo pipefail
-
-            test -d components/aihc-parser || {
-              echo "Run this app from the repository root." >&2
-              exit 1
-            }
-
-            # Check for repo token
-            if [ -z "''${COVERALLS_REPO_TOKEN:-}" ]; then
-              echo "Error: COVERALLS_REPO_TOKEN environment variable is not set" >&2
-              exit 1
-            fi
-
-            echo "=== Uploading coverage to Coveralls.io ==="
-            echo "Note: This app requires hpc-coveralls to be installed separately."
-            echo "In CI, use: nix develop .#coverage --command hpc-coveralls ..."
-
-            # hpc-coveralls expects to find .tix files in dist/hpc/tix/<test-suite-name>/
-            # and .mix files in dist/hpc/mix/<package-name>/
-            # We need to run this from within the cabal project
-
-            # Upload parser coverage
-            if [ -d "components/aihc-parser" ]; then
-              echo "Uploading aihc-parser coverage..."
-              cd components/aihc-parser
-              hpc-coveralls spec \
-                --repo-token="$COVERALLS_REPO_TOKEN" \
-                --exclude-dir=test \
-                --exclude-dir=app \
-                --exclude-dir=common \
-                "$@" || echo "Warning: parser coverage upload failed"
-              cd ../..
-            fi
-
-            # Upload cpp coverage
-            if [ -d "components/aihc-cpp" ]; then
-              echo "Uploading aihc-cpp coverage..."
-              cd components/aihc-cpp
-              hpc-coveralls spec \
-                --repo-token="$COVERALLS_REPO_TOKEN" \
-                --exclude-dir=test \
-                --exclude-dir=app \
-                "$@" || echo "Warning: cpp coverage upload failed"
-              cd ../..
-            fi
-
-            echo "=== Coverage upload complete ==="
-          '';
-
           default = mkApp "default" ''
             set -euo pipefail
             test -d components/aihc-parser || {
@@ -722,8 +667,6 @@
       devShells = forAllSystems (pkgs:
         let
           hsPkgs = mkHsPkgs pkgs;
-          # Allow broken packages for hpc-coveralls
-          hpcCoveralls = pkgs.haskell.lib.unmarkBroken pkgs.haskellPackages.hpc-coveralls;
         in {
           default = pkgs.mkShell {
             buildInputs = [
@@ -738,26 +681,6 @@
               echo "aihc development shell"
               echo "  - GHC with project dependencies"
               echo "  - cabal-install"
-            '';
-          };
-
-          # Shell specifically for coverage builds
-          coverage = pkgs.mkShell {
-            buildInputs = [
-              # GHC with all project dependencies for building with coverage
-              (hsPkgs.ghcWithPackages (p: [
-                p.aihc-parser
-                p.aihc-cpp
-              ]))
-              pkgs.cabal-install
-              # Coverage tools - unmark broken to allow hpc-coveralls
-              hpcCoveralls
-            ];
-            shellHook = ''
-              echo "aihc coverage shell"
-              echo "  - GHC with project dependencies"
-              echo "  - cabal-install"
-              echo "  - hpc-coveralls"
             '';
           };
         });


### PR DESCRIPTION
## Summary
- Remove broken `hpc-coveralls` dependency that caused coverage workflow failures
- Update coverage workflow to use pure Nix-based coverage builds (`nix build .#coverage`)
- Remove obsolete `coverage` devShell and `upload-coverage` app

## Problem
The coverage workflow was failing on every push to main because `hpc-coveralls` (last updated 2017) has severely outdated dependency bounds incompatible with GHC 9.10.3:

```
Encountered missing or private dependencies:
    aeson >=0.7.1 && <1.4,
    bytestring >=0.10 && <0.11,
    containers >=0.5 && <0.6,
    hpc >=0.6 && <0.7,
    retry >=0.5 && <0.8,
    transformers >=0.4.1 && <0.6
```

## Solution
The flake already has a working `mkCoverageReport` function that builds tests with HPC coverage enabled via Nix derivations. This PR:
1. Removes the broken `hpc-coveralls` dependency from `flake.nix`
2. Updates the workflow to use `nix build .#coverage` instead of a cabal-based approach
3. Removes the Coveralls upload step (can be re-added with a working tool later)

## Testing
- `nix flake check --no-build` passes
- `actionlint` passes on the workflow file