### PR TITLE
fix(ci): prevent HPC tix file corruption in coverage tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,19 @@
               preCheck = (old.preCheck or "") + ''
                 export AIHC_LEXER_EXE="$PWD/dist/build/aihc-lexer/aihc-lexer"
                 export AIHC_PARSER_EXE="$PWD/dist/build/aihc-parser/aihc-parser"
+                # Create wrapper scripts that disable HPC for spawned executables
+                # This prevents .tix file corruption when test-spawned executables
+                # try to write to the same coverage file as the test runner
+                mkdir -p "$PWD/hpc-wrappers"
+                for exe in aihc-lexer aihc-parser; do
+                  cat > "$PWD/hpc-wrappers/$exe" << EOF
+                #!/bin/sh
+                HPCTIXFILE=/dev/null exec "$PWD/dist/build/$exe/$exe" "\$@"
+                EOF
+                  chmod +x "$PWD/hpc-wrappers/$exe"
+                done
+                export AIHC_LEXER_EXE="$PWD/hpc-wrappers/aihc-lexer"
+                export AIHC_PARSER_EXE="$PWD/hpc-wrappers/aihc-parser"
               '';
               postInstall = (old.postInstall or "") + ''
                 # Export HPC coverage data


### PR DESCRIPTION
## Summary
- Fix HPC `.tix` file corruption when running coverage builds

## Problem
After PR #290 was merged, the coverage workflow still fails because tests spawn
CLI executables (`aihc-lexer`, `aihc-parser`) that are also instrumented with HPC.
Both the test runner and the spawned executables try to write to the same `.tix`
file, causing corruption:

```
Hpc failure: parse error when reading .tix file
(perhaps remove /build/aihc-parser/dist/hpc/vanilla/tix/spec.tix file?)
```

## Solution
Create wrapper scripts that set `HPCTIXFILE=/dev/null` for spawned executables,
so only the test runner contributes to coverage data. The spawned CLI tools
will still run correctly, but their coverage won't be tracked (which is fine
since we care about testing the library code, not the CLI wrapper).