### PR TITLE
feat(parser): add record expression and NamedFieldPuns support

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -186,10 +186,71 @@ stringExprParser = withSpan $ do
 
 appExprParser :: TokParser Expr
 appExprParser = withSpan $ do
-  first <- atomExprParser
-  rest <- MP.many atomExprParser
+  first <- atomOrRecordExprParser
+  rest <- MP.many atomOrRecordExprParser
   pure $ \span' ->
     foldl (EApp span') first rest
+
+-- | Parse an atom, optionally followed by one or more record construction/update syntax.
+-- This handles cases like:
+--   - Foo { x = 1 }  -- record construction
+--   - expr { x = 1 } -- record update
+--   - r { a = 1 } { b = 2 } -- chained record update
+atomOrRecordExprParser :: TokParser Expr
+atomOrRecordExprParser = do
+  base <- atomExprParser
+  applyRecordSuffixes base
+  where
+    applyRecordSuffixes :: Expr -> TokParser Expr
+    applyRecordSuffixes e = do
+      mRecordFields <- MP.optional recordBracesParser
+      case mRecordFields of
+        Nothing -> pure e
+        Just fields -> do
+          let result = case e of
+                EVar span' name
+                  | isConLikeName name ->
+                      ERecordCon (mergeSourceSpans span' (fieldsEndSpan fields)) name (map normalizeField fields)
+                _ ->
+                  ERecordUpd (mergeSourceSpans (getSourceSpan e) (fieldsEndSpan fields)) e (map normalizeField fields)
+          -- Recursively check for more record braces (chained updates)
+          applyRecordSuffixes result
+
+    -- Get the end span from the last field (or the opening brace position)
+    fieldsEndSpan :: [(Text, Maybe Expr, SourceSpan)] -> SourceSpan
+    fieldsEndSpan [] = NoSourceSpan
+    fieldsEndSpan fs = case last fs of (_, _, sp) -> sp
+    -- Normalize field: if no expression given (pun), use field name as expression
+    normalizeField :: (Text, Maybe Expr, SourceSpan) -> (Text, Expr)
+    normalizeField (fieldName, mExpr, sp) =
+      case mExpr of
+        Just expr' -> (fieldName, expr')
+        Nothing -> (fieldName, EVar sp fieldName) -- NamedFieldPuns: field name becomes variable
+
+-- | Parse record braces: { field = value, field2 = value2, ... }
+-- Supports both explicit assignment (field = value) and puns (field)
+recordBracesParser :: TokParser [(Text, Maybe Expr, SourceSpan)]
+recordBracesParser = do
+  expectedTok TkSpecialLBrace
+  mClose <- MP.optional (expectedTok TkSpecialRBrace)
+  case mClose of
+    Just () -> pure []
+    Nothing -> do
+      fields <- recordFieldBindingParser `MP.sepEndBy` expectedTok TkSpecialComma
+      expectedTok TkSpecialRBrace
+      pure fields
+
+-- | Parse a single record field binding: either "field = expr" or just "field" (pun)
+recordFieldBindingParser :: TokParser (Text, Maybe Expr, SourceSpan)
+recordFieldBindingParser = do
+  startPos <- MP.getSourcePos
+  fieldName <- tokenSatisfy "field name" $ \tok ->
+    case lexTokenKind tok of
+      TkVarId name -> Just name
+      _ -> Nothing
+  mAssign <- MP.optional (expectedTok TkReservedEquals *> exprParser)
+  endPos <- MP.getSourcePos
+  pure (fieldName, mAssign, sourceSpanFromPositions startPos endPos)
 
 atomExprParser :: TokParser Expr
 atomExprParser =
@@ -734,10 +795,18 @@ recordPatternParser = withSpan $ do
 
 recordFieldPatternParser :: TokParser (Text, Pattern)
 recordFieldPatternParser = do
+  startPos <- MP.getSourcePos
   field <- identifierTextParser
-  expectedTok TkReservedEquals
-  pat <- patternParser
-  pure (field, pat)
+  mEq <- MP.optional (expectedTok TkReservedEquals)
+  endPos <- MP.getSourcePos
+  case mEq of
+    Just () -> do
+      pat <- patternParser
+      pure (field, pat)
+    Nothing -> do
+      -- NamedFieldPuns: just "field" means "field = field"
+      let span' = sourceSpanFromPositions startPos endPos
+      pure (field, PVar span' field)
 
 listPatternParser :: TokParser Pattern
 listPatternParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -316,11 +316,18 @@ prettyPattern pat =
           ( hsep
               ( punctuate
                   comma
-                  [ pretty fieldName <+> "=" <+> prettyPattern fieldPat
-                  | (fieldName, fieldPat) <- fields
-                  ]
+                  [prettyPatternFieldBinding fieldName fieldPat | (fieldName, fieldPat) <- fields]
               )
           )
+
+-- | Pretty print a pattern field binding.
+-- Supports NamedFieldPuns: if pattern is a variable with the same name as the field,
+-- print just the field name (punned form).
+prettyPatternFieldBinding :: Text -> Pattern -> Doc ann
+prettyPatternFieldBinding fieldName fieldPat =
+  case fieldPat of
+    PVar _ varName | varName == fieldName -> pretty fieldName -- NamedFieldPuns: punned form
+    _ -> pretty fieldName <+> "=" <+> prettyPattern fieldPat
 
 prettyPatternAtom :: Pattern -> Doc ann
 prettyPatternAtom pat =
@@ -715,8 +722,14 @@ prettyExprPrec prec expr =
         )
     ETupleCon _ arity -> parens (pretty (T.replicate (max 1 (arity - 1)) ","))
 
+-- | Pretty print a record field binding.
+-- Supports NamedFieldPuns: if value is a variable with the same name as the field,
+-- print just the field name (punned form).
 prettyBinding :: (Text, Expr) -> Doc ann
-prettyBinding (name, value) = pretty name <+> "=" <+> prettyExprPrec 0 value
+prettyBinding (name, value) =
+  case value of
+    EVar _ varName | varName == name -> pretty name -- NamedFieldPuns: punned form
+    _ -> pretty name <+> "=" <+> prettyExprPrec 0 value
 
 prettyCaseAlt :: CaseAlt -> Doc ann
 prettyCaseAlt (CaseAlt _ pat rhs) =

--- a/components/aihc-parser/test/Test/Fixtures/NamedFieldPuns/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/NamedFieldPuns/manifest.tsv
@@ -1,5 +1,5 @@
-named-puns-construct	expressions	named-puns-construct.hs	xfail	parser support pending
-named-puns-pattern	expressions	named-puns-pattern.hs	xfail	parser support pending
-named-puns-case	expressions	named-puns-case.hs	xfail	parser support pending
-named-puns-let	expressions	named-puns-let.hs	xfail	parser support pending
-named-puns-mixed	expressions	named-puns-mixed.hs	xfail	parser support pending
+named-puns-construct	expressions	named-puns-construct.hs	pass	parser now supports NamedFieldPuns in record construction expressions
+named-puns-pattern	expressions	named-puns-pattern.hs	pass	parser now supports NamedFieldPuns in record patterns
+named-puns-case	expressions	named-puns-case.hs	pass	parser now supports NamedFieldPuns in case pattern matching
+named-puns-let	expressions	named-puns-let.hs	pass	parser now supports NamedFieldPuns in let bindings
+named-puns-mixed	expressions	named-puns-mixed.hs	pass	parser now supports mixed NamedFieldPuns and explicit field bindings

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/record-construction-trailing-comma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/record-construction-trailing-comma.hs
@@ -1,0 +1,3 @@
+module ExprS315RecordConstructionTrailingComma where
+data R = R { a :: Int, b :: Int }
+x = R { a = 1, b = 2, }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/record-update-chained.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/record-update-chained.hs
@@ -1,0 +1,3 @@
+module ExprS315RecordUpdateChained where
+data R = R { a :: Int, b :: Int }
+x r = r { a = 1 } { b = 2 }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/record-update-paren-base.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/expressions/record-update-paren-base.hs
@@ -1,0 +1,3 @@
+module ExprS315RecordUpdateParenBase where
+data R = R { a :: Int }
+x r = (f r) { a = 1 }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -206,10 +206,13 @@ expr-s3-case-infix-rhs	expressions	expressions/case-infix-rhs.hs	pass	parser sup
 expr-s3-let-infix-rhs	expressions	expressions/let-infix-rhs.hs	pass	parser supports let as right operand of infix expression
 expr-s3-lambda-infix-rhs	expressions	expressions/lambda-infix-rhs.hs	pass	parser supports lambda as right operand of infix expression
 expr-s3-record-field-selection	expressions	expressions/record-field-selection.hs	pass
-expr-s3-record-construction-empty	expressions	expressions/record-construction-empty.hs	xfail	parser intentionally disabled
-expr-s3-record-construction-fields	expressions	expressions/record-construction-fields.hs	xfail	parser intentionally disabled
-expr-s3-record-update-single	expressions	expressions/record-update-single.hs	xfail	parser intentionally disabled
-expr-s3-record-update-multiple	expressions	expressions/record-update-multiple.hs	xfail	parser intentionally disabled
+expr-s3-record-construction-empty	expressions	expressions/record-construction-empty.hs	pass	parser now supports empty record construction expressions
+expr-s3-record-construction-fields	expressions	expressions/record-construction-fields.hs	pass	parser now supports record construction expressions with fields
+expr-s3-record-construction-trailing-comma	expressions	expressions/record-construction-trailing-comma.hs	xfail	GHC does not accept trailing comma in record expressions
+expr-s3-record-update-single	expressions	expressions/record-update-single.hs	pass	parser now supports record update expressions
+expr-s3-record-update-multiple	expressions	expressions/record-update-multiple.hs	pass	parser now supports record update expressions with multiple fields
+expr-s3-record-update-chained	expressions	expressions/record-update-chained.hs	pass	parser now supports chained record updates
+expr-s3-record-update-paren-base	expressions	expressions/record-update-paren-base.hs	pass	parser now supports record update on parenthesized expressions
 expr-s3-expr-type-signature-basic	expressions	expressions/expr-type-signature-basic.hs	pass	parser now supports expression type signatures
 expr-s3-expr-type-signature-context	expressions	expressions/expr-type-signature-context.hs	pass	parser now supports expression type signatures with context
 expr-s3-pattern-infix-constructor	expressions	expressions/pattern-infix-constructor.hs	pass	parser now supports infix constructor patterns in case alternatives


### PR DESCRIPTION
## Summary

- Add parsing support for record construction (`ERecordCon`) and record update (`ERecordUpd`) expressions
- Support chained record updates like `r { a = 1 } { b = 2 }`
- Support NamedFieldPuns extension in both expression and pattern contexts
- Update pretty printer to emit punned form when field = variable for correct roundtrip

## Test Progress

### Haskell2010 (expressions):
- `record-construction-empty`: xfail → **pass**
- `record-construction-fields`: xfail → **pass**
- `record-update-single`: xfail → **pass**
- `record-update-multiple`: xfail → **pass**
- `record-update-chained`: **new test** (pass)
- `record-update-paren-base`: **new test** (pass)
- `record-construction-trailing-comma`: **new test** (xfail - GHC rejects trailing comma)

### NamedFieldPuns:
- `named-puns-construct`: xfail → **pass**
- `named-puns-pattern`: xfail → **pass**
- `named-puns-case`: xfail → **pass**
- `named-puns-let`: xfail → **pass**
- `named-puns-mixed`: xfail → **pass**

## Parser Progress

- Haskell2010: 365/419 tests passing (87.11%)
- Extensions: NamedFieldPuns now fully supported (5/5 tests passing)

## Fixed Package

- `reddit-scrape-0.0.1` now parses successfully