### PR TITLE
feat(lexer): implement whitespace-sensitive ! and ~ parsing (GHC proposal 0229)

### DIFF
--- a/components/aihc-parser/src/Aihc/Lexer.hs
+++ b/components/aihc-parser/src/Aihc/Lexer.hs
@@ -114,8 +114,8 @@ data LexTokenKind
   | TkReservedLeftArrow -- <-
   | TkReservedRightArrow -- ->
   | TkReservedAt -- @
-  | TkReservedTilde -- ~
-  | TkReservedDoubleArrow -- =>
+  | -- Note: ~ is NOT reserved; it uses whitespace-sensitive lexing (GHC proposal 0229)
+    TkReservedDoubleArrow -- =>
   | -- Identifiers (per Haskell Report Section 2.4)
     TkVarId Text -- variable identifier (starts lowercase/_)
   | TkConId Text -- constructor identifier (starts uppercase)
@@ -145,6 +145,9 @@ data LexTokenKind
   | -- LexicalNegation support
     TkMinusOperator -- minus operator when LexicalNegation enabled (before prefix detection)
   | TkPrefixMinus -- prefix minus (tight, no space) for LexicalNegation
+  | -- Whitespace-sensitive operator support (GHC proposal 0229)
+    TkPrefixBang -- prefix bang (!x) for bang patterns
+  | TkPrefixTilde -- prefix tilde (~x) for irrefutable patterns
   | -- Pragmas
     TkPragmaLanguage [ExtensionSetting]
   | TkPragmaWarning Text
@@ -400,6 +403,7 @@ nextToken st =
         lexSymbol,
         lexIdentifier,
         lexNegativeLiteralOrMinus,
+        lexBangOrTildeOperator, -- must come before lexOperator
         lexOperator
       ]
 
@@ -865,6 +869,75 @@ canStartNegatedAtom rest =
       | c == '[' -> True -- list/TH brackets
       | c == '\\' -> True -- lambda
       | c == '-' -> True -- nested negation
+      | otherwise -> False
+
+-- | Whitespace-sensitive lexing for ! and ~ operators (GHC proposal 0229).
+--
+-- Per the proposal, these operators are classified based on surrounding whitespace:
+--   - Prefix occurrence: whitespace before, no whitespace after → bang/lazy pattern
+--   - Otherwise (loose infix, tight infix, suffix) → regular operator
+--
+-- Examples:
+--   a ! b   -- loose infix (operator)
+--   a!b     -- tight infix (operator)
+--   a !b    -- prefix (bang pattern)
+--   a! b    -- suffix (operator)
+lexBangOrTildeOperator :: LexerState -> Maybe (LexToken, LexerState)
+lexBangOrTildeOperator st =
+  case lexerInput st of
+    '!' : rest -> lexPrefixSensitiveOp st '!' "!" TkPrefixBang rest
+    '~' : rest -> lexPrefixSensitiveOp st '~' "~" TkPrefixTilde rest
+    _ -> Nothing
+
+-- | Lex a whitespace-sensitive prefix operator.
+-- Returns TkPrefixBang/TkPrefixTilde if in prefix position, otherwise Nothing
+-- to let lexOperator handle it as a regular VarSym.
+--
+-- Per GHC proposal 0229, prefix position is determined by:
+--   - Whitespace before the operator, OR
+--   - Previous token is an opening bracket/punctuation that allows tight prefix
+-- AND no whitespace after (next char can start a pattern atom).
+lexPrefixSensitiveOp :: LexerState -> Char -> String -> LexTokenKind -> String -> Maybe (LexToken, LexerState)
+lexPrefixSensitiveOp st opChar opStr prefixKind rest
+  -- Only handle single-character ! or ~ (not part of multi-char operator like !=)
+  | isMultiCharOp rest = Nothing
+  -- Prefix position: (whitespace before OR opening token before) AND next char can start a pattern atom
+  | isPrefixPosition && canStartPrefixPatternAtom rest =
+      let st' = advanceChars opStr st
+       in Just (mkToken st st' (T.singleton opChar) prefixKind, st')
+  -- Otherwise, let lexOperator handle it as a regular operator
+  | otherwise = Nothing
+  where
+    -- Check if rest starts with another symbolic operator char (making this a multi-char op)
+    isMultiCharOp (c : _) = isSymbolicOpChar c
+    isMultiCharOp [] = False
+    -- Prefix position is allowed when:
+    -- - There is no previous token (start of input)
+    -- - There was whitespace/trivia before the operator
+    -- - The previous token is an opening bracket or punctuation that allows tight prefix
+    isPrefixPosition =
+      case lexerPrevTokenKind st of
+        Nothing -> True -- start of input
+        Just prevKind
+          | lexerHadTrivia st -> True -- had whitespace before
+          | otherwise -> prevTokenAllowsTightPrefix prevKind -- opening bracket, etc.
+
+-- | Check if the given input could start a pattern atom (for prefix ! and ~).
+-- This is similar to canStartNegatedAtom but tailored for patterns.
+canStartPrefixPatternAtom :: String -> Bool
+canStartPrefixPatternAtom rest =
+  case rest of
+    [] -> False
+    c : _
+      | isIdentStart c -> True -- identifier (variable or constructor)
+      | isDigit c -> True -- numeric literal
+      | c == '\'' -> True -- char literal
+      | c == '"' -> True -- string literal
+      | c == '(' -> True -- parenthesized pattern or tuple
+      | c == '[' -> True -- list pattern
+      | c == '_' -> True -- wildcard
+      | c == '!' -> True -- nested bang pattern
+      | c == '~' -> True -- nested lazy pattern
       | otherwise -> False
 
 lexOperator :: LexerState -> Maybe (LexToken, LexerState)
@@ -1731,6 +1804,6 @@ reservedOpTokenKind txt = case txt of
   "<-" -> Just TkReservedLeftArrow
   "->" -> Just TkReservedRightArrow
   "@" -> Just TkReservedAt
-  "~" -> Just TkReservedTilde
+  -- Note: ~ is NOT reserved; it uses whitespace-sensitive lexing (GHC proposal 0229)
   "=>" -> Just TkReservedDoubleArrow
   _ -> Nothing

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -82,8 +82,9 @@ renderTokenKind tk = case tk of
   TkReservedLeftArrow -> "operator '<-'"
   TkReservedRightArrow -> "operator '->'"
   TkReservedAt -> "operator '@'"
-  TkReservedTilde -> "operator '~'"
   TkReservedDoubleArrow -> "operator '=>'"
+  TkPrefixBang -> "bang pattern '!'"
+  TkPrefixTilde -> "irrefutable pattern '~'"
   TkVarSym op -> "operator '" <> show op <> "'"
   TkConSym op -> "operator '" <> show op <> "'"
   _ -> show tk
@@ -149,7 +150,9 @@ operatorTextParser =
 -- Per Haskell Report section 4.4.3, funlhs uses 'varop' which is:
 --   varop → varsym | ` varid `
 -- This excludes constructor operators (consym) and qualified operators.
--- Note: We exclude "!" because it's used for strict patterns (BangPatterns)
+-- Note: Whitespace-sensitive lexing (GHC proposal 0229) now distinguishes
+-- TkVarSym "!" (infix operator) from TkPrefixBang (bang pattern), so we
+-- can accept all VarSym operators here.
 infixOperatorNameParser :: TokParser Text
 infixOperatorNameParser =
   symbolicOperatorParser <|> backtickIdentifierParser
@@ -157,7 +160,7 @@ infixOperatorNameParser =
     symbolicOperatorParser =
       tokenSatisfy "variable operator" $ \tok ->
         case lexTokenKind tok of
-          TkVarSym op | op /= "!" -> Just op
+          TkVarSym op -> Just op
           _ -> Nothing
     backtickIdentifierParser = do
       expectedTok TkSpecialBacktick

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -637,7 +637,7 @@ derivingKeywordParser =
 
 bangTypeParser :: TokParser BangType
 bangTypeParser = withSpan $ do
-  strict <- MP.option False (expectedTok (TkVarSym "!") >> pure True)
+  strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   ty <- typeAtomParser
   pure $ \span' ->
     BangType
@@ -648,7 +648,7 @@ bangTypeParser = withSpan $ do
 
 recordFieldBangTypeParser :: TokParser BangType
 recordFieldBangTypeParser = withSpan $ do
-  strict <- MP.option False (expectedTok (TkVarSym "!") >> pure True)
+  strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   ty <- constructorFieldTypeParser
   pure $ \span' ->
     BangType

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -313,8 +313,8 @@ parenOperatorExprParser = withSpan $ do
       TkReservedLeftArrow -> Just "<-"
       TkReservedRightArrow -> Just "->"
       TkReservedDoubleArrow -> Just "=>"
-      TkReservedTilde -> Just "~"
       TkReservedDotDot -> Just ".."
+      -- Note: ~ is now lexed as TkVarSym "~" so TkVarSym case handles it
       _ -> Nothing
   expectedTok TkSpecialRParen
   pure (`EVar` op)
@@ -384,13 +384,13 @@ patternAtomParser =
 
 strictPatternParser :: TokParser Pattern
 strictPatternParser = withSpan $ do
-  expectedTok (TkVarSym "!")
+  expectedTok TkPrefixBang
   inner <- patternAtomParser
   pure (`PStrict` inner)
 
 irrefutablePatternParser :: TokParser Pattern
 irrefutablePatternParser = withSpan $ do
-  expectedTok TkReservedTilde
+  expectedTok TkPrefixTilde
   inner <- patternAtomParser
   pure (`PIrrefutable` inner)
 
@@ -980,7 +980,7 @@ typeParenOperatorParser = withSpan $ do
       TkQConSym sym -> Just sym
       -- Handle reserved operators that can be used as type constructors
       TkReservedRightArrow -> Just "->"
-      TkReservedTilde -> Just "~"
+      -- Note: ~ is now lexed as TkVarSym "~" so TkVarSym case handles it
       _ -> Nothing
   expectedTok TkSpecialRParen
   pure (`TCon` op)

--- a/components/aihc-parser/src/Aihc/Parser/PrettyAST.hs
+++ b/components/aihc-parser/src/Aihc/Parser/PrettyAST.hs
@@ -528,7 +528,6 @@ docTokenKind kind =
     TkReservedLeftArrow -> "TkReservedLeftArrow"
     TkReservedRightArrow -> "TkReservedRightArrow"
     TkReservedAt -> "TkReservedAt"
-    TkReservedTilde -> "TkReservedTilde"
     TkReservedDoubleArrow -> "TkReservedDoubleArrow"
     TkVarId name -> "TkVarId" <+> docText name
     TkConId name -> "TkConId" <+> docText name
@@ -554,6 +553,8 @@ docTokenKind kind =
     TkSpecialRBrace -> "TkSpecialRBrace"
     TkMinusOperator -> "TkMinusOperator"
     TkPrefixMinus -> "TkPrefixMinus"
+    TkPrefixBang -> "TkPrefixBang"
+    TkPrefixTilde -> "TkPrefixTilde"
     TkPragmaLanguage settings -> "TkPragmaLanguage" <+> brackets (hsep (punctuate comma (map docExtensionSetting settings)))
     TkPragmaWarning msg -> "TkPragmaWarning" <+> docText msg
     TkPragmaDeprecated msg -> "TkPragmaDeprecated" <+> docText msg

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/infix-funlhs-tilde.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/infix-funlhs-tilde.hs
@@ -1,0 +1,2 @@
+module InfixFunlhsTilde where
+x ~ y = ()

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/mixed-infix-prefix-bang.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/mixed-infix-prefix-bang.hs
@@ -1,0 +1,3 @@
+module MixedInfixPrefixBang where
+a ! b = a + b
+f !x = x

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -140,7 +140,9 @@ decls-infix-funlhs-instance	declarations	declarations/infix-funlhs-instance.hs	p
 decls-infix-funlhs-local	declarations	declarations/infix-funlhs-local.hs	pass	parser now supports infix definitions in where clauses
 decls-infix-funlhs-let	declarations	declarations/infix-funlhs-let.hs	pass	parser now supports infix definitions in let expressions
 decls-infix-funlhs-class	declarations	declarations/infix-funlhs-class.hs	pass	parser now supports infix definitions in class declarations
-decls-infix-funlhs-bang	declarations	declarations/infix-funlhs-bang.hs	xfail	requires whitespace-sensitive lexing (GHC 9.0+ proposal 0229)
+decls-infix-funlhs-bang	declarations	declarations/infix-funlhs-bang.hs	pass	whitespace-sensitive lexing (GHC proposal 0229)
+decls-infix-funlhs-tilde	declarations	declarations/infix-funlhs-tilde.hs	pass	whitespace-sensitive ~ as infix operator (GHC proposal 0229)
+decls-mixed-infix-prefix-bang	declarations	declarations/mixed-infix-prefix-bang.hs	pass	mixed infix operator and prefix bang pattern forms
 
 expr-if-then-else	expressions	expressions/if-then-else.hs	pass	parser now handles this if-then-else form
 expr-case-of	expressions	expressions/case-of.hs	pass	parser now supports simple case-of expressions


### PR DESCRIPTION
## Summary

Implement whitespace-sensitive operator parsing for `!` and `~` following [GHC proposal 0229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst). This allows distinguishing between:

| Example | Classification | Meaning |
|---------|----------------|---------|
| `x ! y = ()` | loose infix | infix function definition using `(!)` |
| `x !y = ()` | prefix | prefix function with bang pattern on `y` |
| `x ~ y = ()` | loose infix | infix function definition using `(~)` |
| `x ~y = ()` | prefix | prefix function with lazy/irrefutable pattern on `y` |

## Changes

### Lexer (`Aihc/Lexer.hs`)
- Add `TkPrefixBang` and `TkPrefixTilde` token kinds for prefix occurrences
- Remove `TkReservedTilde` since `~` is no longer a reserved operator
- Add `lexBangOrTildeOperator` for whitespace-sensitive lexing
- Add `lexPrefixSensitiveOp` and `canStartPrefixPatternAtom` helper functions

### Parser
- Update `strictPatternParser` to use `TkPrefixBang` instead of `TkVarSym "!"`
- Update `irrefutablePatternParser` to use `TkPrefixTilde` instead of `TkReservedTilde`
- Remove `!` exclusion from `infixOperatorNameParser` (now handled at lexer level)
- Update `bangTypeParser` to use `TkPrefixBang`

### Tests
- Add `infix-funlhs-tilde.hs` - tests `x ~ y = ()` as infix operator definition
- Add `mixed-infix-prefix-bang.hs` - tests both infix `!` and prefix bang in same module
- Change `decls-infix-funlhs-bang` from `xfail` to `pass`

## Progress

```
PASS      397 (+3)
XFAIL     50 (-1)
COMPLETE  88.81%
```