### PR TITLE
fix(lexer): close implicit layouts before then/else in then-do/else-do

### DIFF
--- a/components/aihc-parser/src/Aihc/Lexer.hs
+++ b/components/aihc-parser/src/Aihc/Lexer.hs
@@ -179,6 +179,9 @@ data LayoutContext
   = LayoutExplicit
   | LayoutImplicit !Int
   | LayoutImplicitLet !Int
+  | -- | Implicit layout opened after 'then do' or 'else do'.
+    -- This variant allows 'then' and 'else' to close it at the same indent level.
+    LayoutImplicitAfterThenElse !Int
   | -- | Marker for ( or [ to scope implicit layout closures
     LayoutDelimiter
   deriving (Eq, Show)
@@ -186,6 +189,9 @@ data LayoutContext
 data PendingLayout
   = PendingLayoutGeneric
   | PendingLayoutLet
+  | -- | Pending layout from 'do' after 'then' or 'else'.
+    -- The resulting layout can be closed by 'then'/'else' at the same indent.
+    PendingLayoutAfterThenElse
   deriving (Eq, Show)
 
 data ModuleLayoutMode
@@ -476,6 +482,7 @@ openPendingLayout st tok =
                 case pending of
                   PendingLayoutGeneric -> LayoutImplicit col
                   PendingLayoutLet -> LayoutImplicitLet col
+                  PendingLayoutAfterThenElse -> LayoutImplicitAfterThenElse col
            in if col <= parentIndent
                 then ([openTok, closeTok], st {layoutPendingLayout = Nothing}, False)
                 else
@@ -506,6 +513,16 @@ closeBeforeToken st tok =
        in (inserted, st {layoutContexts = contexts'})
     TkSpecialRBrace ->
       let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
+       in (inserted, st {layoutContexts = contexts'})
+    -- Close implicit layout contexts before 'then' and 'else' keywords (parse-error rule)
+    -- These keywords cannot appear inside a do block, so we close contexts at >= their column.
+    TkKeywordThen ->
+      let col = tokenStartCol tok
+          (inserted, contexts') = closeForDedentInclusive col (lexTokenSpan tok) (layoutContexts st)
+       in (inserted, st {layoutContexts = contexts'})
+    TkKeywordElse ->
+      let col = tokenStartCol tok
+          (inserted, contexts') = closeForDedentInclusive col (lexTokenSpan tok) (layoutContexts st)
        in (inserted, st {layoutContexts = contexts'})
     _ -> ([], st)
 
@@ -547,6 +564,24 @@ closeForDedent col anchor = go []
         LayoutImplicitLet indent : rest
           | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
           | otherwise -> (reverse acc, contexts)
+        LayoutImplicitAfterThenElse indent : rest
+          | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
+          | otherwise -> (reverse acc, contexts)
+        _ -> (reverse acc, contexts)
+
+-- | Close layout contexts opened after 'then do' or 'else do' when encountering
+-- 'then' or 'else' at the same or lesser indent. This handles the parse-error rule
+-- for these specific cases where the keyword cannot be part of the do block.
+-- Only closes LayoutImplicitAfterThenElse contexts, not regular LayoutImplicit.
+-- Recursively closes all such contexts where col <= indent.
+closeForDedentInclusive :: Int -> SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
+closeForDedentInclusive col anchor = go []
+  where
+    go acc contexts =
+      case contexts of
+        LayoutImplicitAfterThenElse indent : rest
+          | col <= indent -> go (virtualSymbolToken "}" anchor : acc) rest
+          | otherwise -> (reverse acc, contexts)
         _ -> (reverse acc, contexts)
 
 closeAllImplicit :: [LayoutContext] -> SourceSpan -> [LexToken]
@@ -570,12 +605,17 @@ closeAllImplicitBeforeDelimiter anchor = go []
       case contexts of
         LayoutImplicit _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
         LayoutImplicitLet _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
+        LayoutImplicitAfterThenElse _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
         _ -> (reverse acc, contexts)
 
 stepTokenContext :: LayoutState -> LexToken -> LayoutState
 stepTokenContext st tok =
   case lexTokenKind tok of
-    TkKeywordDo -> st {layoutPendingLayout = Just PendingLayoutGeneric}
+    TkKeywordDo
+      | layoutPrevTokenKind st == Just TkKeywordThen
+          || layoutPrevTokenKind st == Just TkKeywordElse ->
+          st {layoutPendingLayout = Just PendingLayoutAfterThenElse}
+      | otherwise -> st {layoutPendingLayout = Just PendingLayoutGeneric}
     TkKeywordOf -> st {layoutPendingLayout = Just PendingLayoutGeneric}
     TkKeywordCase
       | layoutPrevTokenKind st == Just TkReservedBackslash ->
@@ -629,6 +669,7 @@ currentLayoutIndentMaybe contexts =
   case contexts of
     LayoutImplicit indent : _ -> Just indent
     LayoutImplicitLet indent : _ -> Just indent
+    LayoutImplicitAfterThenElse indent : _ -> Just indent
     _ -> Nothing
 
 isImplicitLayoutContext :: LayoutContext -> Bool
@@ -636,6 +677,7 @@ isImplicitLayoutContext ctx =
   case ctx of
     LayoutImplicit _ -> True
     LayoutImplicitLet _ -> True
+    LayoutImplicitAfterThenElse _ -> True
     LayoutExplicit -> False
     LayoutDelimiter -> False
 

--- a/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-at-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-at-layout.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: then and else at column of parent do with no inner do.
+-- This should NOT close the outer do layout.
+module DoAndIfThenElseThenElseAtLayout where
+
+atLayout :: Bool -> IO ()
+atLayout cond = do
+  if cond
+  then putStrLn "true"
+  else putStrLn "false"
+  putStrLn "done"

--- a/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-nested-if.hs
+++ b/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-nested-if.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: nested if-then-else inside 'then do' and 'else do'.
+-- Multiple levels of nesting should work correctly.
+module DoAndIfThenElseNestedIf where
+
+nestedIf :: Bool -> Bool -> IO ()
+nestedIf a b = do
+  if a
+    then do
+    if b
+      then do
+      putStrLn "a and b"
+      else do
+      putStrLn "a and not b"
+    else do
+    putStrLn "not a"

--- a/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-then-do-multi-stmt.hs
+++ b/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-then-do-multi-stmt.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: 'then do' and 'else do' where inner do has multiple statements.
+-- The 'else' at column 5 should close the inner do at column 5.
+module DoAndIfThenElseThenDoMultiStmt where
+
+multiStmt :: IO ()
+multiStmt = do
+  if True
+    then do
+    putStrLn "a"
+    putStrLn "b"
+    else do
+    putStrLn "c"
+    putStrLn "d"

--- a/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-then-do-single-stmt.hs
+++ b/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/do-and-if-then-else-then-do-single-stmt.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: 'then do' and 'else do' with single statements at same indent as 'else'.
+-- This tests the parse-error rule for closing implicit layouts before 'else'.
+module DoAndIfThenElseThenDoSingleStmt where
+
+getCachedJSONQuery :: IO ()
+getCachedJSONQuery = do
+  if True
+    then do
+    error "err"
+    else do
+    error "blah"

--- a/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/DoAndIfThenElse/manifest.tsv
@@ -1,3 +1,7 @@
 do-and-if-then-else-basic	layout	do-and-if-then-else-basic.hs	pass
 do-and-if-then-else-nested-do	layout	do-and-if-then-else-nested-do.hs	pass
 do-and-if-then-else-following-stmt	layout	do-and-if-then-else-following-stmt.hs	pass
+do-and-if-then-else-then-do-single-stmt	layout	do-and-if-then-else-then-do-single-stmt.hs	pass
+do-and-if-then-else-then-do-multi-stmt	layout	do-and-if-then-else-then-do-multi-stmt.hs	pass
+do-and-if-then-else-nested-if	layout	do-and-if-then-else-nested-if.hs	pass
+do-and-if-then-else-at-layout	layout	do-and-if-then-else-at-layout.hs	pass


### PR DESCRIPTION
## Summary
- Fix parsing of `then do` and `else do` patterns where the inner do block has statements at the same indent as the following `else`/`then`
- Introduces a new `LayoutImplicitAfterThenElse` context type to track layouts that should be closed by `then`/`else` at the same indent level
- Implements the parse-error rule for this specific case without affecting normal `if-then-else` handling

## Test Cases Added
- `do-and-if-then-else-then-do-single-stmt.hs` - The original failing case
- `do-and-if-then-else-then-do-multi-stmt.hs` - Multiple statements in inner do
- `do-and-if-then-else-nested-if.hs` - Deeply nested if-then-else with then-do
- `do-and-if-then-else-at-layout.hs` - Verifies normal DoAndIfThenElse still works

## Progress
- Parser: PASS 398 (+6), TOTAL 449, 88.64% complete
- DoAndIfThenElse extension: PASS=7 (+4)