### PR TITLE
fix(ci): set write permissions after copying from Nix store

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,6 +32,7 @@ jobs:
           echo "=== Building Haddock documentation ==="
           nix build .#docs --print-out-paths
           cp -rL result docs-output
+          chmod -R u+w docs-output
 
           echo "=== Building coverage report ==="
           nix build .#coverage --print-out-paths


### PR DESCRIPTION
## Summary

Fix docs deployment failure by setting write permissions on copied files.

## Problem

Files copied from the Nix store retain read-only permissions, causing the subsequent `cp` command to fail when trying to create the `coverage` subdirectory:

```
cp: cannot create directory 'docs-output/coverage': Permission denied
```

## Solution

Add `chmod -R u+w docs-output` after copying the docs to make the directory writable.