### PR TITLE
feat(reports): add line-counts to generate-reports and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@
 
 | Name | Progress |
 | --- | --- |
-| Parser Stackage | <!-- AUTO-GENERATED: START parser-stackage-progress --> `661/3390` (`19.50%`) <!-- AUTO-GENERATED: END parser-stackage-progress --> |
-| Parser Tests | <!-- AUTO-GENERATED: START parser-progress --> `354/462` (`76.62%`) <!-- AUTO-GENERATED: END parser-progress --> |
-| Lexer Tests | <!-- AUTO-GENERATED: START lexer-progress --> `29/41` (`70.73%`) <!-- AUTO-GENERATED: END lexer-progress --> |
+| Parser Stackage | <!-- AUTO-GENERATED: START parser-stackage-progress --> `895/3390` (`26.40%`) <!-- AUTO-GENERATED: END parser-stackage-progress --> |
+| Parser Tests | <!-- AUTO-GENERATED: START parser-progress --> `401/488` (`82.17%`) <!-- AUTO-GENERATED: END parser-progress --> |
+| Lexer Tests | <!-- AUTO-GENERATED: START lexer-progress --> `59/60` (`98.33%`) <!-- AUTO-GENERATED: END lexer-progress --> |
 | CPP preprocessor | <!-- AUTO-GENERATED: START cpp-progress --> `37/37` (`100.00%`) <!-- AUTO-GENERATED: END cpp-progress --> |
+
+<!-- AUTO-GENERATED: START line-counts -->
+| Component                      |       Code |      Tests |      Total |
+| :------------------------------ | ----------: | ----------: | ----------: |
+| aihc-cpp                       |        589 |        512 |       1101 |
+| aihc-parser                    |       5859 |      11365 |      17224 |
+| **Total**                      |       6448 |      11877 |      18325 |
+<!-- AUTO-GENERATED: END line-counts -->
 
 ## Ways to contribute
 

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -19,7 +19,7 @@ Runtime outcomes are reported as:
 
 Current progress baseline:
 <!-- AUTO-GENERATED: START haskell2010-progress -->
-- `354/416` implemented (`85.09%` complete)
+- `401/451` implemented (`88.91%` complete)
 <!-- AUTO-GENERATED: END haskell2010-progress -->
 
 ## Extension Coverage Tracking
@@ -33,9 +33,9 @@ Each extension can provide a manifest at:
 Current extension baseline:
 <!-- AUTO-GENERATED: START extension-progress -->
 - Total tracked extensions: `138`
-- Supported: `23`
-- In Progress: `11`
-- Planned: `104`
+- Supported: `26`
+- In Progress: `9`
+- Planned: `103`
 <!-- AUTO-GENERATED: END extension-progress -->
 
 Generated report:

--- a/docs/haskell-parser-extension-support.md
+++ b/docs/haskell-parser-extension-support.md
@@ -3,9 +3,9 @@
 ## Summary
 
 - Total Extensions: 138
-- Supported: 23
-- In Progress: 11
-- Planned: 104
+- Supported: 26
+- In Progress: 9
+- Planned: 103
 
 ## Extension Status
 
@@ -36,7 +36,7 @@
 | DerivingStrategies | Supported | 5/5 | DerivingStrategies |
 | DerivingVia | Planned | - | DerivingVia |
 | DisambiguateRecordFields | Planned | - | DisambiguateRecordFields |
-| DoAndIfThenElse | Supported | 3/3 | DoAndIfThenElse |
+| DoAndIfThenElse | Supported | 7/7 | DoAndIfThenElse |
 | DuplicateRecordFields | Planned | - | DuplicateRecordFields |
 | EmptyCase | Supported | 4/4 | EmptyCase |
 | EmptyDataDecls | Supported | 5/5 | EmptyDataDecls |
@@ -83,7 +83,7 @@
 | MultiParamTypeClasses | Supported | 5/5 | MultiParamTypeClasses |
 | MultiWayIf | Planned | - | MultiWayIf |
 | NamedDefaults | Planned | - | NamedDefaults |
-| NamedFieldPuns | In Progress | 0/5 | NamedFieldPuns |
+| NamedFieldPuns | Supported | 5/5 | NamedFieldPuns |
 | NamedWildCards | Supported | 4/4 | NamedWildCards |
 | NegativeLiterals | Planned | - | NegativeLiterals |
 | NondecreasingIndentation | Planned | - | NondecreasingIndentation |
@@ -119,7 +119,7 @@
 | RoleAnnotations | In Progress | 0/4 | RoleAnnotations |
 | Safe | Planned | - | Safe |
 | ScopedTypeVariables | Planned | - | ScopedTypeVariables |
-| StandaloneDeriving | In Progress | 0/4 | StandaloneDeriving |
+| StandaloneDeriving | Supported | 12/12 | StandaloneDeriving |
 | StandaloneKindSignatures | Supported | 5/5 | StandaloneKindSignatures |
 | StarIsType | Planned | - | StarIsType |
 | StaticPointers | Planned | - | StaticPointers |
@@ -143,7 +143,7 @@
 | UnboxedTuples | Planned | - | UnboxedTuples |
 | UndecidableInstances | Planned | - | UndecidableInstances |
 | UndecidableSuperClasses | Planned | - | UndecidableSuperClasses |
-| UnicodeSyntax | Planned | - | UnicodeSyntax |
+| UnicodeSyntax | Supported | 6/6 | UnicodeSyntax |
 | UnliftedDatatypes | Planned | - | UnliftedDatatypes |
 | UnliftedFFITypes | Planned | - | UnliftedFFITypes |
 | UnliftedNewtypes | Planned | - | UnliftedNewtypes |

--- a/flake.nix
+++ b/flake.nix
@@ -313,6 +313,9 @@ WRAPPER
               [ -d "$comp_path" ] || continue
               comp=$(basename "$comp_path")
 
+              # Skip aihc-name-resolution (empty stub)
+              [ "$comp" = "aihc-name-resolution" ] && continue
+
               comp_all_lines=$(tokei "$comp_path" --output json | jq '.Total.code // 0')
               test_lines=0
               if [ -d "$comp_path/test" ]; then

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -43,6 +43,7 @@ extension_markdown_cmd="${PARSER_EXTENSION_PROGRESS_CMD:-nix run .#parser-extens
 extension_progress_cmd="${PARSER_EXTENSION_PROGRESS_TEXT_CMD:-nix run .#parser-extension-progress}"
 cpp_cmd="${CPP_PROGRESS_CMD:-nix run .#cpp-progress}"
 stackage_cmd="${PARSER_STACKAGE_PROGRESS_CMD:-nix run .#stackage-progress -- --snapshot lts-24.33 --checks parse}"
+line_counts_cmd="${LINE_COUNTS_CMD:-nix run .#line-counts}"
 
 tmpdir="$(mktemp -d)"
 cleanup() {
@@ -56,6 +57,7 @@ extension_out="$tmpdir/extension-progress.md"
 extension_progress_out="$tmpdir/extension-progress.txt"
 cpp_out="$tmpdir/cpp-progress.txt"
 stackage_out="$tmpdir/stackage-progress.txt"
+line_counts_out="$tmpdir/line-counts.txt"
 
 run_cmd "$parser_cmd" >"$parser_out"
 run_cmd "$lexer_cmd" >"$lexer_out"
@@ -63,6 +65,7 @@ run_cmd "$extension_markdown_cmd" | sed -n '/^# Haskell Parser Extension Support
 run_cmd "$extension_progress_cmd" >"$extension_progress_out"
 run_cmd "$cpp_cmd" >"$cpp_out"
 run_cmd "$stackage_cmd" >"$stackage_out" || true
+run_cmd "$line_counts_cmd" >"$line_counts_out"
 
 parse_progress() {
 	local infile="$1"
@@ -351,6 +354,7 @@ replace_marker_inline README.md "parser-progress" "$tmpdir/readme-root-parser.tx
 replace_marker_inline README.md "lexer-progress" "$tmpdir/readme-root-lexer.txt"
 replace_marker_inline README.md "parser-stackage-progress" "$tmpdir/readme-root-stackage.txt"
 replace_marker_inline README.md "cpp-progress" "$tmpdir/readme-root-cpp.txt"
+replace_marker_block README.md "line-counts" "$line_counts_out"
 replace_marker_block components/aihc-parser/README.md "haskell2010-progress" "$tmpdir/readme-parser-h2010.txt"
 replace_marker_block components/aihc-parser/README.md "extension-progress" "$tmpdir/readme-parser-extension.txt"
 replace_marker_block components/aihc-cpp/README.md "cpp-progress" "$tmpdir/readme-cpp.txt"


### PR DESCRIPTION
## Summary
- Integrate line-counts into the generate-reports nix job
- Add auto-generated line-counts table to README.md Component Progress section
- Exclude aihc-name-resolution from line-counts (empty stub)

## Changes
- **flake.nix**: Skip `aihc-name-resolution` in line-counts app (empty component)
- **scripts/update-generated-content.sh**: Add `line-counts` command integration and `replace_marker_block` call for README
- **README.md**: Add line-counts table in Component Progress section with auto-generated markers

## Line Counts Table
The new table shows code vs test line counts per component:

| Component                      |       Code |      Tests |      Total |
| :----------------------------- | ---------: | ---------: | ---------: |
| aihc-cpp                       |        589 |        512 |       1101 |
| aihc-parser                    |       5859 |      11365 |      17224 |
| **Total**                      |       6448 |      11877 |      18325 |

## Testing
- `nix flake check` passes
- `nix run .#generate-reports` successfully updates README with line-counts
- `nix run .#line-counts` correctly excludes aihc-name-resolution