### PR TITLE
fix(parser): pass cabal default-extensions to parser in hackage-tester and stackage-progress

### DIFF
--- a/components/aihc-parser/app/hackage-tester/Main.hs
+++ b/components/aihc-parser/app/hackage-tester/Main.hs
@@ -35,7 +35,7 @@ import HackageTester.CLI (Options (..), parseOptionsIO)
 import HackageTester.Model (FileResult (..), Outcome (..), Summary (..), failureLabel, shouldFailSummary, summarizeResults)
 import Network.HTTP.Client (HttpException, Manager, Request (responseTimeout), httpLbs, newManager, parseRequest, responseBody, responseTimeoutMicro)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
-import ParserValidation (ValidationError (..), ValidationErrorKind (..), validateParserDetailedWithExtensions)
+import ParserValidation (ValidationError (..), ValidationErrorKind (..), validateParserDetailedWithExtensionNames)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hFlush, hIsTerminalDevice, hPutStrLn, stderr, stdout)
 
@@ -190,7 +190,7 @@ processFile opts packageRoot info = do
                 cppDiagnostics = cppErrs,
                 outcomeDetail = Nothing
               }
-        else case validateParserDetailedWithExtensions (GhcOracle.extensionNamesToGhcExtensions (fileInfoExtensions info) (fileInfoLanguage info)) source' of
+        else case validateParserDetailedWithExtensionNames (fileInfoExtensions info) (fileInfoLanguage info) source' of
           Nothing ->
             pure
               FileResult

--- a/components/aihc-parser/app/stackage-progress/Main.hs
+++ b/components/aihc-parser/app/stackage-progress/Main.hs
@@ -18,7 +18,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Conc (getNumProcessors)
-import qualified GHC.LanguageExtensions.Type as GHC
 import qualified GhcOracle
 import HackageSupport
   ( FileInfo (..),
@@ -31,7 +30,7 @@ import HackageSupport
   )
 import HseExtensions (fromExtensionNames)
 import qualified Language.Haskell.Exts as HSE
-import ParserValidation (ValidationError (..), ValidationErrorKind (..), validateParserDetailedWithExtensions)
+import ParserValidation (ValidationError (..), ValidationErrorKind (..), validateParserDetailedWithExtensionNames)
 import StackageProgress.Summary
   ( FailedPackage (..),
     PackageResult (..),
@@ -526,8 +525,7 @@ needsFullPackageScan opts =
 checkFile :: Options -> FilePath -> FileInfo -> IO FileResult
 checkFile opts packageRoot info = do
   let file = fileInfoPath info
-      ghcExts = GhcOracle.extensionNamesToGhcExtensions (fileInfoExtensions info) (fileInfoLanguage info)
-      parserExts = mapMaybe GhcOracle.fromGhcExtension ghcExts
+      parserExts = GhcOracle.extensionNamesToParserExtensions (fileInfoExtensions info)
       parserConfig = Aihc.Parser.defaultConfig {Aihc.Parser.parserExtensions = parserExts}
   source <- readTextFileLenient file
   preprocessed <- preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (resolveIncludeBestEffort packageRoot file) source
@@ -547,7 +545,7 @@ checkFile opts packageRoot info = do
     ParseOk parsed -> do
       roundtripRes <-
         if CheckRoundtripGhc `elem` optChecks opts
-          then pure (checkRoundtrip ghcExts file cppErrorMsg source')
+          then pure (checkRoundtrip (fileInfoExtensions info) (fileInfoLanguage info) file cppErrorMsg source')
           else pure (Right ())
       case roundtripRes of
         Left err -> pure (Left err)
@@ -595,9 +593,9 @@ needsParsedModule :: [Check] -> Bool
 needsParsedModule checks =
   CheckRoundtripGhc `elem` checks || CheckSourceSpan `elem` checks
 
-checkRoundtrip :: [GHC.Extension] -> FilePath -> Maybe Text -> Text -> Either String ()
-checkRoundtrip exts file cppErrorMsg source' =
-  case validateParserDetailedWithExtensions exts source' of
+checkRoundtrip :: [String] -> Maybe String -> FilePath -> Maybe Text -> Text -> Either String ()
+checkRoundtrip extNames langName file cppErrorMsg source' =
+  case validateParserDetailedWithExtensionNames extNames langName source' of
     Nothing -> Right ()
     Just err ->
       case validationErrorKind err of

--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -16,6 +16,7 @@ module GhcOracle
     toGhcExtension,
     fromGhcExtension,
     extensionNamesToGhcExtensions,
+    extensionNamesToParserExtensions,
   )
 where
 
@@ -269,6 +270,19 @@ extensionNamesToGhcExtensions extNames langName =
   let extSettings = mapMaybe (Ast.parseExtensionSettingName . T.pack) extNames
       langExts = maybe [] languageExtensions langName
    in EnumSet.toList (List.foldl' applyExtensionSetting (EnumSet.fromList langExts) extSettings)
+
+-- | Convert a list of extension names (from cabal files) directly to AIHC parser extensions.
+-- This extracts enabled extensions from ExtensionSettings, applying enable/disable semantics.
+extensionNamesToParserExtensions :: [String] -> [Ast.Extension]
+extensionNamesToParserExtensions extNames =
+  let extSettings = mapMaybe (Ast.parseExtensionSettingName . T.pack) extNames
+   in applyExtensionSettings extSettings []
+  where
+    applyExtensionSettings [] acc = acc
+    applyExtensionSettings (setting : rest) acc =
+      case setting of
+        Ast.EnableExtension ext -> applyExtensionSettings rest (ext : filter (/= ext) acc)
+        Ast.DisableExtension ext -> applyExtensionSettings rest (filter (/= ext) acc)
 
 languageExtensions :: String -> [GHC.Extension]
 languageExtensions lang =

--- a/components/aihc-parser/common/ParserValidation.hs
+++ b/components/aihc-parser/common/ParserValidation.hs
@@ -7,6 +7,7 @@ module ParserValidation
     validateParserWithExtensions,
     validateParserDetailed,
     validateParserDetailedWithExtensions,
+    validateParserDetailedWithExtensionNames,
   )
 where
 
@@ -40,6 +41,7 @@ validateParserWithExtensions exts = fmap validationErrorMessage . validateParser
 validateParserDetailed :: Text -> Maybe ValidationError
 validateParserDetailed = validateParserDetailedWithExtensions []
 
+-- | Validate parser with GHC extensions.
 validateParserDetailedWithExtensions :: [Extension] -> Text -> Maybe ValidationError
 validateParserDetailedWithExtensions exts source =
   case validateParserDetailedCore exts source of
@@ -50,6 +52,12 @@ validateParserDetailedWithExtensions exts source =
           { validationErrorMessage =
               validationErrorMessage err <> optionalShrunkDiagnostic exts source
           }
+
+-- | Validate parser with extension names (as strings) and optional language.
+-- This is a convenience function for use with cabal file metadata.
+validateParserDetailedWithExtensionNames :: [String] -> Maybe String -> Text -> Maybe ValidationError
+validateParserDetailedWithExtensionNames extNames langName =
+  validateParserDetailedWithExtensions (GhcOracle.extensionNamesToGhcExtensions extNames langName)
 
 validateParserDetailedCore :: [Extension] -> Text -> Maybe ValidationError
 validateParserDetailedCore exts source =


### PR DESCRIPTION
## Summary

- Fix hackage-tester and stackage-progress to pass cabal `default-extensions` to the AIHC parser
- Add `extensionNamesToGhcExtensions` helper function to `GhcOracle` for converting extension names to GHC extensions

## Problem

The hackage-tester and stackage-progress tools were correctly extracting `default-extensions` from cabal files (via `HackageSupport.hs`), but they weren't passing these extensions to the AIHC parser. The extensions were only being passed to:
- CPP preprocessor
- GHC oracle

This caused packages like `natural-induction` (which requires `UnicodeSyntax` via `default-extensions`) to fail parsing.

**Before:**
```
% nix run .#hackage-tester -- natural-induction
Testing package: natural-induction
Parse errors:    1
Success rate:    0%
```

**After:**
```
% nix run .#hackage-tester -- natural-induction
Testing package: natural-induction
Parse errors:    0
Success rate:    100%
```

## Changes

1. **`GhcOracle.hs`**: Added and exported `extensionNamesToGhcExtensions :: [String] -> Maybe String -> [GHC.Extension]` helper function

2. **`hackage-tester/Main.hs`**: Pass extensions to `validateParserDetailedWithExtensions`

3. **`stackage-progress/Main.hs`**: 
   - Create `ParserConfig` with converted extensions
   - Pass extensions to `checkRoundtrip` for roundtrip validation