### PR TITLE
fix(lexer): correctly lex qualified operators like Prelude.+

### DIFF
--- a/components/aihc-parser/src/Aihc/Lexer.hs
+++ b/components/aihc-parser/src/Aihc/Lexer.hs
@@ -772,20 +772,40 @@ lexIdentifier st =
       | isIdentStart c ->
           let (seg, rest0) = span isIdentTail rest
               firstChunk = c : seg
-              (consumed, isQualified) = gatherQualified firstChunk rest0
-              ident = T.pack consumed
-              kind = classifyIdentifier c isQualified ident
-              st' = advanceChars consumed st
-           in Just (mkToken st st' ident kind, st')
+              (consumed, rest1, isQualified) = gatherQualified firstChunk rest0
+           in -- Check if we have a qualified operator (e.g., Prelude.+)
+              case (isQualified || isAsciiUpper c, rest1) of
+                (True, '.' : opChar : opRest)
+                  | isSymbolicOpCharNotDot opChar ->
+                      -- This is a qualified operator like Prelude.+ or A.B.C.:++
+                      let (opChars, _) = span isSymbolicOpChar (opChar : opRest)
+                          fullOp = consumed <> "." <> opChars
+                          opTxt = T.pack fullOp
+                          kind =
+                            if opChar == ':'
+                              then TkQConSym opTxt
+                              else TkQVarSym opTxt
+                          st' = advanceChars fullOp st
+                       in Just (mkToken st st' opTxt kind, st')
+                _ ->
+                  -- Regular identifier
+                  let ident = T.pack consumed
+                      kind = classifyIdentifier c isQualified ident
+                      st' = advanceChars consumed st
+                   in Just (mkToken st st' ident kind, st')
     _ -> Nothing
   where
+    -- Returns (consumed, remaining, isQualified)
     gatherQualified acc chars =
       case chars of
         '.' : c' : more
           | isIdentStart c' ->
               let (seg, rest) = span isIdentTail more
                in gatherQualified (acc <> "." <> [c'] <> seg) rest
-        _ -> (acc, '.' `elem` acc)
+        _ -> (acc, chars, '.' `elem` acc)
+
+    -- Check for symbol char that is not '.' to avoid consuming module path dots
+    isSymbolicOpCharNotDot c = isSymbolicOpChar c && c /= '.'
 
     classifyIdentifier firstChar isQualified ident
       | isQualified =

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-conop-infix.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-conop-infix.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  x Data.List.:++ y
+ast: EInfix (EVar "x") "Data.List.:++" (EVar "y")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-deep.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-deep.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  (A.B.C.+)
+ast: EVar "A.B.C.+"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-infix.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-infix.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  x Prelude.+ y
+ast: EInfix (EVar "x") "Prelude.+" (EVar "y")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-paren.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-paren.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  (Prelude.+)
+ast: EVar "Prelude.+"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-section-left.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-section-left.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  (x Prelude.+)
+ast: EParen (ESectionL (EVar "x") "Prelude.+")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-section-right.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-op-section-right.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  (Prelude.+ x)
+ast: EParen (ESectionR "Prelude.+" (EVar "x"))
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/qualified-consym.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/qualified-consym.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: "Data.List.:++"
+tokens:
+  - 'TkQConSym "Data.List.:++"'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/qualified-varsym-deep.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/qualified-varsym-deep.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: "A.B.C.++"
+tokens:
+  - 'TkQVarSym "A.B.C.++"'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/qualified-varsym.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/qualified-varsym.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: "Prelude.+"
+tokens:
+  - 'TkQVarSym "Prelude.+"'
+status: pass


### PR DESCRIPTION
## Summary

- Fix lexer to correctly lex qualified operators (e.g., `Prelude.+`, `Data.List.:++`)
- Previously lexed as separate tokens: `TkConId "Prelude"` + `TkVarSym ".+"`
- Now correctly lexed as single token: `TkQVarSym "Prelude.+"` or `TkQConSym "Data.List.:++"`

## Test Plan

Added comprehensive golden tests:
- Lexer tests: qualified varsym, qualified consym, deep qualified operators
- Parser tests: qualified operators in parentheses, sections (left/right), and infix positions

All tests pass via `nix flake check`.

## Progress Counts (Unchanged)

- Parser: 89.01% (405/455, 50 XFAIL)
- Extensions: In progress (varies by extension)
- CPP: 100.0% (37/37)