### PR TITLE
refactor(parser): remove CheckSourceSpan from stackage-progress

### DIFF
--- a/components/aihc-parser/app/stackage-progress/Main.hs
+++ b/components/aihc-parser/app/stackage-progress/Main.hs
@@ -6,7 +6,6 @@ module Main (main) where
 import Aihc.Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
 import Aihc.Parser (ParseResult (..))
 import qualified Aihc.Parser
-import Aihc.Parser.Ast
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception (IOException, SomeException, displayException, try)
 import Control.Monad (when)
@@ -62,7 +61,6 @@ import System.Process (readProcess)
 data Check
   = CheckParse
   | CheckRoundtripGhc
-  | CheckSourceSpan
   | CheckHse
   | CheckGhc
   deriving (Eq, Show)
@@ -179,7 +177,7 @@ main = do
 usage :: String
 usage =
   unlines
-    [ "Usage: cabal run stackage-progress -- [--snapshot lts-24.33] [--checks parse,roundtrip-ghc,source-span] [--jobs N] [--offline] [--prompt] [--prompt-seed N] [--print-succeeded] [--print-failed-table] [--sanity-check]",
+    [ "Usage: cabal run stackage-progress -- [--snapshot lts-24.33] [--checks parse,roundtrip-ghc] [--jobs N] [--offline] [--prompt] [--prompt-seed N] [--print-succeeded] [--print-failed-table] [--sanity-check]",
       "",
       "Defaults:",
       "  --snapshot lts-24.33",
@@ -259,7 +257,6 @@ parseCheck raw =
   case trim raw of
     "parse" -> Right CheckParse
     "roundtrip-ghc" -> Right CheckRoundtripGhc
-    "source-span" -> Right CheckSourceSpan
     other -> Left ("Unknown check: " ++ other)
 
 splitComma :: String -> [String]
@@ -542,17 +539,14 @@ checkFile opts packageRoot info = do
       if CheckParse `elem` optChecks opts || needsParsedModule (optChecks opts)
         then pure (Left (T.unpack (prefixCppErrors cppErrorMsg ("parse failed in " <> T.pack file <> ":\n" <> T.pack (Aihc.Parser.errorBundlePretty err)))))
         else pure (Right ())
-    ParseOk parsed -> do
+    ParseOk _parsed -> do
       roundtripRes <-
         if CheckRoundtripGhc `elem` optChecks opts
           then pure (checkRoundtrip (fileInfoExtensions info) (fileInfoLanguage info) file cppErrorMsg source')
           else pure (Right ())
       case roundtripRes of
         Left err -> pure (Left err)
-        Right () ->
-          if CheckSourceSpan `elem` optChecks opts
-            then pure (checkSourceSpans file source' parsed)
-            else pure (Right ())
+        Right () -> pure (Right ())
 
   hseOk <-
     if CheckHse `elem` optChecks opts
@@ -591,7 +585,7 @@ hseParseMode =
 
 needsParsedModule :: [Check] -> Bool
 needsParsedModule checks =
-  CheckRoundtripGhc `elem` checks || CheckSourceSpan `elem` checks
+  CheckRoundtripGhc `elem` checks
 
 checkRoundtrip :: [String] -> Maybe String -> FilePath -> Maybe Text -> Text -> Either String ()
 checkRoundtrip extNames langName file cppErrorMsg source' =
@@ -603,516 +597,6 @@ checkRoundtrip extNames langName file cppErrorMsg source' =
           Left (T.unpack (prefixCppErrors cppErrorMsg ("parse failed in " <> T.pack file <> ": " <> T.pack (validationErrorMessage err))))
         ValidationRoundtripError ->
           Left (T.unpack (prefixCppErrors cppErrorMsg ("roundtrip mismatch in " <> T.pack file <> ": " <> T.pack (validationErrorMessage err))))
-
-checkSourceSpans :: FilePath -> Text -> Module -> Either String ()
-checkSourceSpans file source modu =
-  let exprs = [expr | expr <- collectModuleExprs modu, hasRealSourceSpan (exprSpan expr)]
-   in case firstLeft (map (validateExprSpan source) exprs) of
-        Nothing -> Right ()
-        Just err -> Left (file ++ ": " ++ err)
-
-validateExprSpan :: Text -> Expr -> Either String ()
-validateExprSpan source expr = do
-  snippet <- extractSpanText source (exprSpan expr)
-  case Aihc.Parser.parseExpr Aihc.Parser.defaultConfig snippet of
-    ParseErr err -> Left ("source-span parse failed for span " ++ show (exprSpan expr) ++ ":\n" ++ Aihc.Parser.errorBundlePretty err)
-    ParseOk reparsed ->
-      if stripExpr reparsed == stripExpr expr
-        then Right ()
-        else Left ("source-span mismatch at " ++ show (exprSpan expr))
-
-firstLeft :: [Either a b] -> Maybe a
-firstLeft [] = Nothing
-firstLeft (x : xs) =
-  case x of
-    Left err -> Just err
-    Right _ -> firstLeft xs
-
-hasRealSourceSpan :: SourceSpan -> Bool
-hasRealSourceSpan span' =
-  case span' of
-    SourceSpan {} -> True
-    NoSourceSpan -> False
-
-extractSpanText :: Text -> SourceSpan -> Either String Text
-extractSpanText input span' =
-  case span' of
-    NoSourceSpan -> Left "missing source span"
-    SourceSpan sLine sCol eLine eCol
-      | sLine <= 0 || sCol <= 0 || eLine <= 0 || eCol <= 0 -> Left "invalid non-positive span coordinates"
-      | (eLine, eCol) < (sLine, sCol) -> Left "invalid reversed span"
-      | otherwise ->
-          let ls = T.splitOn "\n" input
-           in if sLine > length ls || eLine > length ls
-                then Left "span exceeds input line count"
-                else
-                  let lineAt n = ls !! (n - 1)
-                      startLine = lineAt sLine
-                      endLine = lineAt eLine
-                   in if sLine == eLine
-                        then
-                          let startIx = sCol - 1
-                              len = eCol - sCol
-                           in if startIx < 0 || len < 0 || startIx + len > T.length startLine
-                                then Left "single-line span exceeds line bounds"
-                                else Right (T.take len (T.drop startIx startLine))
-                        else
-                          let startIx = sCol - 1
-                              endIx = eCol - 1
-                              firstPart = T.drop startIx startLine
-                              middleParts = [lineAt n | n <- [sLine + 1 .. eLine - 1]]
-                              lastPart = T.take endIx endLine
-                           in if startIx < 0 || endIx < 0 || startIx > T.length startLine || endIx > T.length endLine
-                                then Left "multi-line span exceeds line bounds"
-                                else Right (T.intercalate "\n" (firstPart : middleParts <> [lastPart]))
-
-exprSpan :: Expr -> SourceSpan
-exprSpan expr =
-  case expr of
-    EVar span' _ -> span'
-    EInt span' _ _ -> span'
-    EIntBase span' _ _ -> span'
-    EFloat span' _ _ -> span'
-    EChar span' _ _ -> span'
-    EString span' _ _ -> span'
-    EQuasiQuote span' _ _ -> span'
-    EIf span' _ _ _ -> span'
-    ELambdaPats span' _ _ -> span'
-    ELambdaCase span' _ -> span'
-    EInfix span' _ _ _ -> span'
-    ENegate span' _ -> span'
-    ESectionL span' _ _ -> span'
-    ESectionR span' _ _ -> span'
-    ELetDecls span' _ _ -> span'
-    ECase span' _ _ -> span'
-    EDo span' _ -> span'
-    EListComp span' _ _ -> span'
-    EListCompParallel span' _ _ -> span'
-    EArithSeq span' _ -> span'
-    ERecordCon span' _ _ -> span'
-    ERecordUpd span' _ _ -> span'
-    ETypeSig span' _ _ -> span'
-    EParen span' _ -> span'
-    EWhereDecls span' _ _ -> span'
-    EList span' _ -> span'
-    ETuple span' _ -> span'
-    ETupleSection span' _ -> span'
-    ETupleCon span' _ -> span'
-    ETypeApp span' _ _ -> span'
-    EApp span' _ _ -> span'
-
-collectModuleExprs :: Module -> [Expr]
-collectModuleExprs modu = concatMap collectDeclExprs (moduleDecls modu)
-
-collectDeclExprs :: Decl -> [Expr]
-collectDeclExprs decl =
-  case decl of
-    DeclValue _ valueDecl -> collectValueDeclExprs valueDecl
-    DeclClass _ classDecl -> concatMap collectClassDeclItemExprs (classDeclItems classDecl)
-    DeclInstance _ instDecl -> concatMap collectInstanceDeclItemExprs (instanceDeclItems instDecl)
-    _ -> []
-
-collectClassDeclItemExprs :: ClassDeclItem -> [Expr]
-collectClassDeclItemExprs item =
-  case item of
-    ClassItemDefault _ valueDecl -> collectValueDeclExprs valueDecl
-    _ -> []
-
-collectInstanceDeclItemExprs :: InstanceDeclItem -> [Expr]
-collectInstanceDeclItemExprs item =
-  case item of
-    InstanceItemBind _ valueDecl -> collectValueDeclExprs valueDecl
-    _ -> []
-
-collectValueDeclExprs :: ValueDecl -> [Expr]
-collectValueDeclExprs valueDecl =
-  case valueDecl of
-    FunctionBind _ _ matches -> concatMap collectMatchExprs matches
-    PatternBind _ pat rhs -> collectPatternExprs pat <> collectRhsExprs rhs
-
-collectMatchExprs :: Match -> [Expr]
-collectMatchExprs match =
-  concatMap collectPatternExprs (matchPats match)
-    <> collectRhsExprs (matchRhs match)
-
-collectRhsExprs :: Rhs -> [Expr]
-collectRhsExprs rhs =
-  case rhs of
-    UnguardedRhs _ expr -> collectExprTree expr
-    GuardedRhss _ guarded -> concatMap collectGuardedRhsExprs guarded
-
-collectGuardedRhsExprs :: GuardedRhs -> [Expr]
-collectGuardedRhsExprs guarded =
-  concatMap collectGuardQualifierExprs (guardedRhsGuards guarded)
-    <> collectExprTree (guardedRhsBody guarded)
-
-collectGuardQualifierExprs :: GuardQualifier -> [Expr]
-collectGuardQualifierExprs qualifier =
-  case qualifier of
-    GuardExpr _ expr -> collectExprTree expr
-    GuardPat _ pat expr -> collectPatternExprs pat <> collectExprTree expr
-    GuardLet _ decls -> concatMap collectDeclExprs decls
-
-collectPatternExprs :: Pattern -> [Expr]
-collectPatternExprs pat =
-  case pat of
-    PView _ viewExpr inner -> collectExprTree viewExpr <> collectPatternExprs inner
-    PCon _ _ pats -> concatMap collectPatternExprs pats
-    PInfix _ left _ right -> collectPatternExprs left <> collectPatternExprs right
-    PAs _ _ inner -> collectPatternExprs inner
-    PStrict _ inner -> collectPatternExprs inner
-    PIrrefutable _ inner -> collectPatternExprs inner
-    PParen _ inner -> collectPatternExprs inner
-    PRecord _ _ fields -> concatMap (collectPatternExprs . snd) fields
-    PTuple _ pats -> concatMap collectPatternExprs pats
-    PList _ pats -> concatMap collectPatternExprs pats
-    _ -> []
-
-collectExprTree :: Expr -> [Expr]
-collectExprTree expr =
-  expr
-    : case expr of
-      EIf _ c t e -> collectExprTree c <> collectExprTree t <> collectExprTree e
-      ELambdaPats _ pats body -> concatMap collectPatternExprs pats <> collectExprTree body
-      ELambdaCase _ alts -> concatMap collectCaseAltExprs alts
-      EInfix _ l _ r -> collectExprTree l <> collectExprTree r
-      ENegate _ e -> collectExprTree e
-      ESectionL _ e _ -> collectExprTree e
-      ESectionR _ _ e -> collectExprTree e
-      ELetDecls _ decls body -> concatMap collectDeclExprs decls <> collectExprTree body
-      ECase _ scrutinee alts -> collectExprTree scrutinee <> concatMap collectCaseAltExprs alts
-      EDo _ stmts -> concatMap collectDoStmtExprs stmts
-      EListComp _ body stmts -> collectExprTree body <> concatMap collectCompStmtExprs stmts
-      EListCompParallel _ body stmtGroups ->
-        collectExprTree body <> concatMap (concatMap collectCompStmtExprs) stmtGroups
-      EArithSeq _ seqExpr -> collectArithSeqExprs seqExpr
-      ERecordCon _ _ fields -> concatMap (collectExprTree . snd) fields
-      ERecordUpd _ base fields -> collectExprTree base <> concatMap (collectExprTree . snd) fields
-      ETypeSig _ e _ -> collectExprTree e
-      EParen _ e -> collectExprTree e
-      EWhereDecls _ e decls -> collectExprTree e <> concatMap collectDeclExprs decls
-      EList _ es -> concatMap collectExprTree es
-      ETuple _ es -> concatMap collectExprTree es
-      ETypeApp _ e _ -> collectExprTree e
-      EApp _ f x -> collectExprTree f <> collectExprTree x
-      _ -> []
-
-collectCaseAltExprs :: CaseAlt -> [Expr]
-collectCaseAltExprs alt =
-  collectPatternExprs (caseAltPattern alt)
-    <> collectRhsExprs (caseAltRhs alt)
-
-collectDoStmtExprs :: DoStmt -> [Expr]
-collectDoStmtExprs stmt =
-  case stmt of
-    DoBind _ pat expr -> collectPatternExprs pat <> collectExprTree expr
-    DoLet _ binds -> concatMap (collectExprTree . snd) binds
-    DoLetDecls _ decls -> concatMap collectDeclExprs decls
-    DoExpr _ expr -> collectExprTree expr
-
-collectCompStmtExprs :: CompStmt -> [Expr]
-collectCompStmtExprs stmt =
-  case stmt of
-    CompGen _ pat expr -> collectPatternExprs pat <> collectExprTree expr
-    CompGuard _ expr -> collectExprTree expr
-    CompLet _ binds -> concatMap (collectExprTree . snd) binds
-    CompLetDecls _ decls -> concatMap collectDeclExprs decls
-
-collectArithSeqExprs :: ArithSeq -> [Expr]
-collectArithSeqExprs seqExpr =
-  case seqExpr of
-    ArithSeqFrom _ a -> collectExprTree a
-    ArithSeqFromThen _ a b -> collectExprTree a <> collectExprTree b
-    ArithSeqFromTo _ a b -> collectExprTree a <> collectExprTree b
-    ArithSeqFromThenTo _ a b c -> collectExprTree a <> collectExprTree b <> collectExprTree c
-
-stripExpr :: Expr -> Expr
-stripExpr expr =
-  case expr of
-    EVar _ t -> EVar noSourceSpan t
-    EInt _ n repr -> EInt noSourceSpan n repr
-    EIntBase _ n txt -> EIntBase noSourceSpan n txt
-    EFloat _ d repr -> EFloat noSourceSpan d repr
-    EChar _ c repr -> EChar noSourceSpan c repr
-    EString _ s repr -> EString noSourceSpan s repr
-    EQuasiQuote _ q body -> EQuasiQuote noSourceSpan q body
-    EIf _ a b c -> EIf noSourceSpan (stripExpr a) (stripExpr b) (stripExpr c)
-    ELambdaPats _ pats e -> ELambdaPats noSourceSpan (map stripPattern pats) (stripExpr e)
-    ELambdaCase _ alts -> ELambdaCase noSourceSpan (map stripCaseAlt alts)
-    EInfix _ a op b -> EInfix noSourceSpan (stripExpr a) op (stripExpr b)
-    ENegate _ e -> ENegate noSourceSpan (stripExpr e)
-    ESectionL _ e op -> ESectionL noSourceSpan (stripExpr e) op
-    ESectionR _ op e -> ESectionR noSourceSpan op (stripExpr e)
-    ELetDecls _ decls e -> ELetDecls noSourceSpan (map stripDecl decls) (stripExpr e)
-    ECase _ e alts -> ECase noSourceSpan (stripExpr e) (map stripCaseAlt alts)
-    EDo _ stmts -> EDo noSourceSpan (map stripDoStmt stmts)
-    EListComp _ e stmts -> EListComp noSourceSpan (stripExpr e) (map stripCompStmt stmts)
-    EListCompParallel _ e groups -> EListCompParallel noSourceSpan (stripExpr e) (map (map stripCompStmt) groups)
-    EArithSeq _ a -> EArithSeq noSourceSpan (stripArithSeq a)
-    ERecordCon _ name fields -> ERecordCon noSourceSpan name [(field, stripExpr val) | (field, val) <- fields]
-    ERecordUpd _ base fields -> ERecordUpd noSourceSpan (stripExpr base) [(field, stripExpr val) | (field, val) <- fields]
-    ETypeSig _ e t -> ETypeSig noSourceSpan (stripExpr e) (stripType t)
-    EParen _ e -> EParen noSourceSpan (stripExpr e)
-    EWhereDecls _ e decls -> EWhereDecls noSourceSpan (stripExpr e) (map stripDecl decls)
-    EList _ es -> EList noSourceSpan (map stripExpr es)
-    ETuple _ es -> ETuple noSourceSpan (map stripExpr es)
-    ETupleSection _ es -> ETupleSection noSourceSpan (map (fmap stripExpr) es)
-    ETupleCon _ n -> ETupleCon noSourceSpan n
-    ETypeApp _ e t -> ETypeApp noSourceSpan (stripExpr e) (stripType t)
-    EApp _ f x -> EApp noSourceSpan (stripExpr f) (stripExpr x)
-
-stripDecl :: Decl -> Decl
-stripDecl decl =
-  case decl of
-    DeclValue _ value -> DeclValue noSourceSpan (stripValueDecl value)
-    DeclTypeSig _ names t -> DeclTypeSig noSourceSpan names (stripType t)
-    DeclStandaloneKindSig _ name kind -> DeclStandaloneKindSig noSourceSpan name (stripType kind)
-    DeclFixity _ assoc prec ops -> DeclFixity noSourceSpan assoc prec ops
-    DeclTypeSyn _ syn -> DeclTypeSyn noSourceSpan (stripTypeSynDecl syn)
-    DeclData _ dat -> DeclData noSourceSpan (stripDataDecl dat)
-    DeclNewtype _ nt -> DeclNewtype noSourceSpan (stripNewtypeDecl nt)
-    DeclClass _ cls -> DeclClass noSourceSpan (stripClassDecl cls)
-    DeclInstance _ inst -> DeclInstance noSourceSpan (stripInstanceDecl inst)
-    DeclStandaloneDeriving _ sd -> DeclStandaloneDeriving noSourceSpan (stripStandaloneDerivingDecl sd)
-    DeclDefault _ tys -> DeclDefault noSourceSpan (map stripType tys)
-    DeclForeign _ foreignDecl -> DeclForeign noSourceSpan (stripForeignDecl foreignDecl)
-
-stripValueDecl :: ValueDecl -> ValueDecl
-stripValueDecl valueDecl =
-  case valueDecl of
-    FunctionBind _ name matches -> FunctionBind noSourceSpan name (map stripMatch matches)
-    PatternBind _ pat rhs -> PatternBind noSourceSpan (stripPattern pat) (stripRhs rhs)
-
-stripMatch :: Match -> Match
-stripMatch match =
-  Match
-    { matchSpan = noSourceSpan,
-      matchPats = map stripPattern (matchPats match),
-      matchRhs = stripRhs (matchRhs match)
-    }
-
-stripRhs :: Rhs -> Rhs
-stripRhs rhs =
-  case rhs of
-    UnguardedRhs _ expr -> UnguardedRhs noSourceSpan (stripExpr expr)
-    GuardedRhss _ guarded -> GuardedRhss noSourceSpan (map stripGuardedRhs guarded)
-
-stripGuardedRhs :: GuardedRhs -> GuardedRhs
-stripGuardedRhs guarded =
-  GuardedRhs
-    { guardedRhsSpan = noSourceSpan,
-      guardedRhsGuards = map stripGuardQualifier (guardedRhsGuards guarded),
-      guardedRhsBody = stripExpr (guardedRhsBody guarded)
-    }
-
-stripGuardQualifier :: GuardQualifier -> GuardQualifier
-stripGuardQualifier qualifier =
-  case qualifier of
-    GuardExpr _ expr -> GuardExpr noSourceSpan (stripExpr expr)
-    GuardPat _ pat expr -> GuardPat noSourceSpan (stripPattern pat) (stripExpr expr)
-    GuardLet _ decls -> GuardLet noSourceSpan (map stripDecl decls)
-
-stripPattern :: Pattern -> Pattern
-stripPattern pat =
-  case pat of
-    PVar _ n -> PVar noSourceSpan n
-    PWildcard _ -> PWildcard noSourceSpan
-    PLit _ lit -> PLit noSourceSpan (stripLiteral lit)
-    PQuasiQuote _ q body -> PQuasiQuote noSourceSpan q body
-    PTuple _ pats -> PTuple noSourceSpan (map stripPattern pats)
-    PList _ pats -> PList noSourceSpan (map stripPattern pats)
-    PCon _ name pats -> PCon noSourceSpan name (map stripPattern pats)
-    PInfix _ a op b -> PInfix noSourceSpan (stripPattern a) op (stripPattern b)
-    PView _ expr inner -> PView noSourceSpan (stripExpr expr) (stripPattern inner)
-    PAs _ n inner -> PAs noSourceSpan n (stripPattern inner)
-    PStrict _ inner -> PStrict noSourceSpan (stripPattern inner)
-    PIrrefutable _ inner -> PIrrefutable noSourceSpan (stripPattern inner)
-    PNegLit _ lit -> PNegLit noSourceSpan (stripLiteral lit)
-    PParen _ inner -> PParen noSourceSpan (stripPattern inner)
-    PRecord _ name fields -> PRecord noSourceSpan name [(field, stripPattern value) | (field, value) <- fields]
-
-stripLiteral :: Literal -> Literal
-stripLiteral lit =
-  case lit of
-    LitInt _ i repr -> LitInt noSourceSpan i repr
-    LitIntBase _ i txt -> LitIntBase noSourceSpan i txt
-    LitFloat _ d repr -> LitFloat noSourceSpan d repr
-    LitChar _ c repr -> LitChar noSourceSpan c repr
-    LitString _ s repr -> LitString noSourceSpan s repr
-
-stripType :: Type -> Type
-stripType ty =
-  case ty of
-    TVar _ n -> TVar noSourceSpan n
-    TCon _ n -> TCon noSourceSpan n
-    TStar _ -> TStar noSourceSpan
-    TQuasiQuote _ q body -> TQuasiQuote noSourceSpan q body
-    TForall _ binders inner -> TForall noSourceSpan binders (stripType inner)
-    TApp _ a b -> TApp noSourceSpan (stripType a) (stripType b)
-    TFun _ a b -> TFun noSourceSpan (stripType a) (stripType b)
-    TTuple _ tys -> TTuple noSourceSpan (map stripType tys)
-    TList _ t -> TList noSourceSpan (stripType t)
-    TParen _ t -> TParen noSourceSpan (stripType t)
-    TContext _ constraints t -> TContext noSourceSpan (map stripConstraint constraints) (stripType t)
-
-stripConstraint :: Constraint -> Constraint
-stripConstraint c =
-  Constraint
-    { constraintSpan = noSourceSpan,
-      constraintClass = constraintClass c,
-      constraintArgs = map stripType (constraintArgs c),
-      constraintParen = constraintParen c
-    }
-
-stripTypeSynDecl :: TypeSynDecl -> TypeSynDecl
-stripTypeSynDecl d =
-  TypeSynDecl
-    { typeSynSpan = noSourceSpan,
-      typeSynName = typeSynName d,
-      typeSynParams = map stripTyVarBinder (typeSynParams d),
-      typeSynBody = stripType (typeSynBody d)
-    }
-
-stripDataDecl :: DataDecl -> DataDecl
-stripDataDecl d =
-  DataDecl
-    { dataDeclSpan = noSourceSpan,
-      dataDeclContext = map stripConstraint (dataDeclContext d),
-      dataDeclName = dataDeclName d,
-      dataDeclParams = map stripTyVarBinder (dataDeclParams d),
-      dataDeclConstructors = map stripDataConDecl (dataDeclConstructors d),
-      dataDeclDeriving = dataDeclDeriving d
-    }
-
-stripNewtypeDecl :: NewtypeDecl -> NewtypeDecl
-stripNewtypeDecl d =
-  NewtypeDecl
-    { newtypeDeclSpan = noSourceSpan,
-      newtypeDeclContext = map stripConstraint (newtypeDeclContext d),
-      newtypeDeclName = newtypeDeclName d,
-      newtypeDeclParams = map stripTyVarBinder (newtypeDeclParams d),
-      newtypeDeclConstructor = fmap stripDataConDecl (newtypeDeclConstructor d),
-      newtypeDeclDeriving = newtypeDeclDeriving d
-    }
-
-stripTyVarBinder :: TyVarBinder -> TyVarBinder
-stripTyVarBinder b =
-  TyVarBinder
-    { tyVarBinderSpan = noSourceSpan,
-      tyVarBinderName = tyVarBinderName b,
-      tyVarBinderKind = fmap stripType (tyVarBinderKind b)
-    }
-
-stripDataConDecl :: DataConDecl -> DataConDecl
-stripDataConDecl con =
-  case con of
-    PrefixCon _ forallVars context name args -> PrefixCon noSourceSpan forallVars (map stripConstraint context) name (map stripBangType args)
-    InfixCon _ forallVars context left op right -> InfixCon noSourceSpan forallVars (map stripConstraint context) (stripBangType left) op (stripBangType right)
-    RecordCon _ forallVars context name fields -> RecordCon noSourceSpan forallVars (map stripConstraint context) name (map stripFieldDecl fields)
-
-stripBangType :: BangType -> BangType
-stripBangType b =
-  BangType
-    { bangSpan = noSourceSpan,
-      bangStrict = bangStrict b,
-      bangType = stripType (bangType b)
-    }
-
-stripFieldDecl :: FieldDecl -> FieldDecl
-stripFieldDecl f =
-  FieldDecl
-    { fieldSpan = noSourceSpan,
-      fieldNames = fieldNames f,
-      fieldType = stripBangType (fieldType f)
-    }
-
-stripClassDecl :: ClassDecl -> ClassDecl
-stripClassDecl d =
-  ClassDecl
-    { classDeclSpan = noSourceSpan,
-      classDeclContext = map stripConstraint (classDeclContext d),
-      classDeclName = classDeclName d,
-      classDeclParams = map stripTyVarBinder (classDeclParams d),
-      classDeclItems = map stripClassDeclItem (classDeclItems d)
-    }
-
-stripClassDeclItem :: ClassDeclItem -> ClassDeclItem
-stripClassDeclItem item =
-  case item of
-    ClassItemTypeSig _ names t -> ClassItemTypeSig noSourceSpan names (stripType t)
-    ClassItemFixity _ assoc prec ops -> ClassItemFixity noSourceSpan assoc prec ops
-    ClassItemDefault _ value -> ClassItemDefault noSourceSpan (stripValueDecl value)
-
-stripInstanceDecl :: InstanceDecl -> InstanceDecl
-stripInstanceDecl d =
-  InstanceDecl
-    { instanceDeclSpan = noSourceSpan,
-      instanceDeclContext = map stripConstraint (instanceDeclContext d),
-      instanceDeclClassName = instanceDeclClassName d,
-      instanceDeclTypes = map stripType (instanceDeclTypes d),
-      instanceDeclItems = map stripInstanceDeclItem (instanceDeclItems d)
-    }
-
-stripStandaloneDerivingDecl :: StandaloneDerivingDecl -> StandaloneDerivingDecl
-stripStandaloneDerivingDecl d =
-  StandaloneDerivingDecl
-    { standaloneDerivingSpan = noSourceSpan,
-      standaloneDerivingStrategy = standaloneDerivingStrategy d,
-      standaloneDerivingContext = map stripConstraint (standaloneDerivingContext d),
-      standaloneDerivingClassName = standaloneDerivingClassName d,
-      standaloneDerivingTypes = map stripType (standaloneDerivingTypes d)
-    }
-
-stripInstanceDeclItem :: InstanceDeclItem -> InstanceDeclItem
-stripInstanceDeclItem item =
-  case item of
-    InstanceItemBind _ value -> InstanceItemBind noSourceSpan (stripValueDecl value)
-    InstanceItemTypeSig _ names t -> InstanceItemTypeSig noSourceSpan names (stripType t)
-    InstanceItemFixity _ assoc prec ops -> InstanceItemFixity noSourceSpan assoc prec ops
-
-stripForeignDecl :: ForeignDecl -> ForeignDecl
-stripForeignDecl d =
-  ForeignDecl
-    { foreignDeclSpan = noSourceSpan,
-      foreignDirection = foreignDirection d,
-      foreignCallConv = foreignCallConv d,
-      foreignSafety = foreignSafety d,
-      foreignEntity = foreignEntity d,
-      foreignName = foreignName d,
-      foreignType = stripType (foreignType d)
-    }
-
-stripCaseAlt :: CaseAlt -> CaseAlt
-stripCaseAlt alt =
-  CaseAlt
-    { caseAltSpan = noSourceSpan,
-      caseAltPattern = stripPattern (caseAltPattern alt),
-      caseAltRhs = stripRhs (caseAltRhs alt)
-    }
-
-stripDoStmt :: DoStmt -> DoStmt
-stripDoStmt stmt =
-  case stmt of
-    DoBind _ pat expr -> DoBind noSourceSpan (stripPattern pat) (stripExpr expr)
-    DoLet _ binds -> DoLet noSourceSpan [(name, stripExpr e) | (name, e) <- binds]
-    DoLetDecls _ decls -> DoLetDecls noSourceSpan (map stripDecl decls)
-    DoExpr _ expr -> DoExpr noSourceSpan (stripExpr expr)
-
-stripCompStmt :: CompStmt -> CompStmt
-stripCompStmt stmt =
-  case stmt of
-    CompGen _ pat expr -> CompGen noSourceSpan (stripPattern pat) (stripExpr expr)
-    CompGuard _ expr -> CompGuard noSourceSpan (stripExpr expr)
-    CompLet _ binds -> CompLet noSourceSpan [(name, stripExpr e) | (name, e) <- binds]
-    CompLetDecls _ decls -> CompLetDecls noSourceSpan (map stripDecl decls)
-
-stripArithSeq :: ArithSeq -> ArithSeq
-stripArithSeq seqExpr =
-  case seqExpr of
-    ArithSeqFrom _ a -> ArithSeqFrom noSourceSpan (stripExpr a)
-    ArithSeqFromThen _ a b -> ArithSeqFromThen noSourceSpan (stripExpr a) (stripExpr b)
-    ArithSeqFromTo _ a b -> ArithSeqFromTo noSourceSpan (stripExpr a) (stripExpr b)
-    ArithSeqFromThenTo _ a b c -> ArithSeqFromThenTo noSourceSpan (stripExpr a) (stripExpr b) (stripExpr c)
 
 foldConcurrentlyChunksWithProgress :: Int -> (a -> IO PackageResult) -> [a] -> Int -> Bool -> SummaryOptions -> Bool -> IO (RunSummary, [PromptCandidate])
 foldConcurrentlyChunksWithProgress n action items total showProgress opts collectPromptCandidates =


### PR DESCRIPTION
## Summary
- Remove the `CheckSourceSpan` validation step from stackage-progress as it is no longer needed
- Remove `source-span` CLI option
- Remove ~520 lines of dead code (AST traversal, span extraction, expression stripping functions)
- Remove unused `Aihc.Parser.Ast` import