### PR TITLE
fix(parser): support strict fields on complex GADT types

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -11,7 +11,7 @@ where
 import Aihc.Lexer (LexTokenKind (..), lexTokenKind)
 import Aihc.Parser.Ast
 import Aihc.Parser.Internal.Common
-import Aihc.Parser.Internal.Expr (equationRhsParser, exprParser, patternParser, simplePatternParser, typeAtomParser, typeParser)
+import Aihc.Parser.Internal.Expr (equationRhsParser, exprParser, patternParser, simplePatternParser, typeAppParser, typeAtomParser, typeParser)
 import Control.Monad (when)
 import Data.Char (isAsciiLower, isUpper)
 import Data.Maybe (fromMaybe)
@@ -595,20 +595,41 @@ gadtRecordBodyParser = do
   expectedTok TkReservedRightArrow
   GadtRecordBody fields <$> gadtResultTypeParser
 
--- | Parse prefix-style GADT body: @Type1 -> Type2 -> ... -> ResultType@
--- The result type is the final type in a chain of arrows
+-- | Parse prefix-style GADT body: @!Type1 -> Type2 -> ... -> ResultType@
+-- Each argument can have an optional strictness annotation (!).
+-- The result type is the final type in a chain of arrows.
 gadtPrefixBodyParser :: TokParser GadtBody
-gadtPrefixBodyParser = typeToGadtPrefixBody <$> typeParser
+gadtPrefixBodyParser = do
+  -- Parse the first component (could be an argument with bang or the result type)
+  firstBang <- gadtBangTypeParser
+  -- Try to parse more arguments after ->
+  moreArgs <- MP.many $ do
+    expectedTok TkReservedRightArrow
+    gadtBangTypeParser
+  -- The last component is the result type, everything before it are arguments
+  case moreArgs of
+    [] ->
+      -- No arrows - this is just a result type
+      pure (GadtPrefixBody [] (bangType firstBang))
+    _ ->
+      -- Multiple components - last is result, rest are args
+      let allBangs = firstBang : moreArgs
+          args = init allBangs
+          result = last allBangs
+       in pure (GadtPrefixBody args (bangType result))
 
--- | Convert a function type into GADT prefix body
--- Splits @a -> b -> c@ into args @[a, b]@ and result @c@
-typeToGadtPrefixBody :: Type -> GadtBody
-typeToGadtPrefixBody = collectArgs []
-  where
-    collectArgs acc (TFun _ argTy resultTy) =
-      let bangArg = BangType (getSourceSpan argTy) False argTy
-       in collectArgs (acc ++ [bangArg]) resultTy
-    collectArgs acc resultTy = GadtPrefixBody acc resultTy
+-- | Parse a potentially strict type for GADT prefix body: @!Type@ or @Type@
+-- This handles strictness annotations on both simple and complex (parenthesized) types.
+gadtBangTypeParser :: TokParser BangType
+gadtBangTypeParser = withSpan $ do
+  strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+  ty <- typeAppParser
+  pure $ \span' ->
+    BangType
+      { bangSpan = span',
+        bangStrict = strict,
+        bangType = ty
+      }
 
 -- | Parse the result type of a GADT constructor
 -- This is a simple type application like @T a b@

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -7,6 +7,7 @@ module Aihc.Parser.Internal.Expr
     appPatternParser,
     patternParser,
     typeParser,
+    typeAppParser,
     typeAtomParser,
   )
 where

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -531,10 +531,15 @@ dataConQualifierPrefix forallVars constraints = forallPrefix forallVars <> conte
     forallPrefix [] = []
     forallPrefix binders = ["forall", hsep (map pretty binders) <> "."]
 
+-- | Pretty print a BangType in GADT prefix body context.
+-- For strict types (!Type), we use prettyTypeAtom to ensure the type is atomic
+-- (e.g., !Int or !(Term a), not !Term a which would be parsed as (!Term) a).
+-- For non-strict types, we use parenthesizeTypeFunLeft since only function types,
+-- foralls, and contexts need parentheses before -> in GADT syntax.
 prettyBangType :: BangType -> Doc ann
 prettyBangType bt
   | bangStrict bt = "!" <> prettyTypeAtom (bangType bt)
-  | otherwise = prettyTypeAtom (bangType bt)
+  | otherwise = parenthesizeTypeFunLeft (bangType bt)
 
 prettyRecordFieldBangType :: BangType -> Doc ann
 prettyRecordFieldBangType bt

--- a/components/aihc-parser/test/Test/Fixtures/GADTSyntax/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/GADTSyntax/manifest.tsv
@@ -3,7 +3,7 @@ gadt-newtype	declarations	gadt-newtype.hs	pass
 gadt-existential	declarations	gadt-existential.hs	pass
 gadt-context	declarations	gadt-context.hs	pass
 gadt-multi-con	declarations	gadt-multi-con.hs	pass
-gadt-strict	declarations	gadt-strict.hs	xfail	strict fields on complex types not yet supported
+gadt-strict	declarations	gadt-strict.hs	pass
 gadt-deriving	declarations	gadt-deriving.hs	pass
 gadt-record	declarations	gadt-record.hs	pass
 gadt-infix	declarations	gadt-infix.hs	pass

--- a/components/aihc-parser/test/Test/Fixtures/GADTs/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/GADTs/manifest.tsv
@@ -1,3 +1,3 @@
 gadts-basic	declarations	gadts-basic.hs	pass
 gadts-record	declarations	gadts-record.hs	pass
-gadts-pattern-match	expressions	gadts-pattern-match.hs	xfail	parser support pending
+gadts-pattern-match	expressions	gadts-pattern-match.hs	pass


### PR DESCRIPTION
## Summary

- Rewrite `gadtPrefixBodyParser` to parse strictness annotations directly using `TkPrefixBang` token, properly capturing `!(Term a)` syntax
- Fix `prettyBangType` to use `parenthesizeTypeFunLeft` for non-strict types instead of `prettyTypeAtom`, avoiding unnecessary parentheses around type applications like `Term Bool`
- Export `typeAppParser` from `Aihc.Parser.Internal.Expr` for GADT parsing
- Update test manifests: `gadt-strict` and `gadts-pattern-match` now pass

## Extension Progress

GADTs and GADTSyntax extensions are now fully **Supported**:

- SUPPORTED: 26 → 28 (+2)
- IN_PROGRESS: 10 → 8 (-2)