### PR TITLE
refactor(parser): unify AST Name types with NameSpace enum

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Ast.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Ast.hs
@@ -40,7 +40,8 @@ module Aihc.Parser.Ast
     Literal (..),
     Match (..),
     Module (..),
-    WarningText (..),
+    Name (..),
+    NameSpace (..),
     NewtypeDecl (..),
     OperatorName,
     Pattern (..),
@@ -52,16 +53,19 @@ module Aihc.Parser.Ast
     TyVarBinder (..),
     TypeSynDecl (..),
     ValueDecl (..),
-    declValueBinderNames,
+    WarningText (..),
     allKnownExtensions,
+    declValueBinderNames,
     extensionName,
     extensionSettingName,
     gadtBodyResultType,
     mergeSourceSpans,
+    nameToText,
     noSourceSpan,
     parseExtensionName,
     parseExtensionSettingName,
     sourceSpanEnd,
+    textToName,
     valueDeclBinderName,
   )
 where
@@ -313,6 +317,54 @@ type BinderName = Text
 
 type OperatorName = Text
 
+-- | The namespace of a name, following GHC's naming conventions.
+data NameSpace
+  = -- | Variables (lowercase identifiers and operators in value positions)
+    VarName
+  | -- | Data constructors (uppercase identifiers and operators starting with :)
+    DataName
+  | -- | Type variables (lowercase identifiers in type positions)
+    TvName
+  | -- | Type constructors and classes (uppercase identifiers in type positions)
+    TcClsName
+  deriving (Data, Eq, Ord, Show, Generic, NFData)
+
+-- | A name with optional module qualification and namespace.
+-- Used for all identifiers: variables, constructors, type variables, type constructors.
+data Name = Name
+  { nameModule :: Maybe Text,
+    nameSpace :: NameSpace,
+    nameIdent :: Text
+  }
+  deriving (Data, Eq, Ord, Generic, NFData)
+
+instance Show Name where
+  show (Name mMod _ns ident) =
+    case mMod of
+      Nothing -> show ident
+      Just modName -> show modName <> "." <> show ident
+
+-- | Convert a Name back to text (without namespace information).
+nameToText :: Name -> Text
+nameToText (Name mMod _ns ident) =
+  case mMod of
+    Nothing -> ident
+    Just modName -> modName <> T.pack "." <> ident
+
+-- | Convert a raw text identifier to a Name.
+-- Handles qualified identifiers like @M.x@ and @M.+@.
+-- Uses VarName namespace by default (caller should adjust if needed).
+textToName :: Text -> Name
+textToName txt =
+  case T.breakOnEnd (T.pack ".") txt of
+    (prefix, name)
+      | T.null prefix -> Name Nothing VarName name
+      | otherwise ->
+          let modName = T.dropEnd 1 prefix
+           in if T.null modName
+                then Name Nothing VarName txt
+                else Name (Just modName) VarName name
+
 data WarningText
   = DeprText SourceSpan Text
   | WarnText SourceSpan Text
@@ -487,21 +539,21 @@ instance HasSourceSpan Literal where
       LitString span' _ _ -> span'
 
 data Pattern
-  = PVar SourceSpan Text
+  = PVar SourceSpan Name
   | PWildcard SourceSpan
   | PLit SourceSpan Literal
   | PQuasiQuote SourceSpan Text Text
   | PTuple SourceSpan [Pattern]
   | PList SourceSpan [Pattern]
-  | PCon SourceSpan Text [Pattern]
-  | PInfix SourceSpan Pattern Text Pattern
+  | PCon SourceSpan Name [Pattern]
+  | PInfix SourceSpan Pattern Name Pattern
   | PView SourceSpan Expr Pattern
-  | PAs SourceSpan Text Pattern
+  | PAs SourceSpan Name Pattern
   | PStrict SourceSpan Pattern
   | PIrrefutable SourceSpan Pattern
   | PNegLit SourceSpan Literal
   | PParen SourceSpan Pattern
-  | PRecord SourceSpan Text [(Text, Pattern)]
+  | PRecord SourceSpan Name [(Name, Pattern)]
   deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan Pattern where
@@ -524,11 +576,11 @@ instance HasSourceSpan Pattern where
       PRecord span' _ _ -> span'
 
 data Type
-  = TVar SourceSpan Text
-  | TCon SourceSpan Text
+  = TVar SourceSpan Name
+  | TCon SourceSpan Name
   | TStar SourceSpan
   | TQuasiQuote SourceSpan Text Text
-  | TForall SourceSpan [Text] Type
+  | TForall SourceSpan [Name] Type
   | TApp SourceSpan Type Type
   | TFun SourceSpan Type Type
   | TTuple SourceSpan [Type]
@@ -554,7 +606,7 @@ instance HasSourceSpan Type where
 
 data Constraint = Constraint
   { constraintSpan :: SourceSpan,
-    constraintClass :: Text,
+    constraintClass :: Name,
     constraintArgs :: [Type],
     constraintParen :: Bool
   }
@@ -781,7 +833,7 @@ data ForeignSafety
   deriving (Data, Eq, Show, Generic, NFData)
 
 data Expr
-  = EVar SourceSpan Text
+  = EVar SourceSpan Name
   | EInt SourceSpan Integer Text
   | EIntBase SourceSpan Integer Text
   | EFloat SourceSpan Double Text
@@ -791,17 +843,17 @@ data Expr
   | EIf SourceSpan Expr Expr Expr
   | ELambdaPats SourceSpan [Pattern] Expr
   | ELambdaCase SourceSpan [CaseAlt]
-  | EInfix SourceSpan Expr Text Expr
+  | EInfix SourceSpan Expr Name Expr
   | ENegate SourceSpan Expr
-  | ESectionL SourceSpan Expr Text
-  | ESectionR SourceSpan Text Expr
+  | ESectionL SourceSpan Expr Name
+  | ESectionR SourceSpan Name Expr
   | ELetDecls SourceSpan [Decl] Expr
   | ECase SourceSpan Expr [CaseAlt]
   | EDo SourceSpan [DoStmt]
   | EListComp SourceSpan Expr [CompStmt]
   | EListCompParallel SourceSpan Expr [[CompStmt]]
   | EArithSeq SourceSpan ArithSeq
-  | ERecordCon SourceSpan Text [(Text, Expr)]
+  | ERecordCon SourceSpan Name [(Text, Expr)]
   | ERecordUpd SourceSpan Expr [(Text, Expr)]
   | ETypeSig SourceSpan Expr Type
   | EParen SourceSpan Expr
@@ -910,7 +962,7 @@ valueDeclBinderName vdecl =
     FunctionBind _ name _ -> Just name
     PatternBind _ pat _ ->
       case pat of
-        PVar _ name -> Just name
+        PVar _ name -> Just (nameIdent name)
         _ -> Nothing
 
 declValueBinderNames :: Decl -> [Text]

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -234,10 +234,11 @@ constraintParserWith :: TokParser Type -> TokParser Constraint
 constraintParserWith typeAtomParser = withSpan $ do
   className <- constructorIdentifierParser
   args <- MP.many typeAtomParser
+  let baseName = textToName className
   pure $ \span' ->
     Constraint
       { constraintSpan = span',
-        constraintClass = className,
+        constraintClass = baseName {nameSpace = TcClsName},
         constraintArgs = args,
         constraintParen = False
       }

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -121,7 +121,7 @@ lexpParser = do
 
 buildInfix :: Expr -> (Text, Expr) -> Expr
 buildInfix lhs (op, rhs) =
-  EInfix (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)) lhs op rhs
+  EInfix (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)) lhs (textToName op) rhs
 
 infixOperatorParserExcept :: [Text] -> TokParser Text
 infixOperatorParserExcept forbidden =
@@ -211,8 +211,8 @@ atomOrRecordExprParser = do
         Just fields -> do
           let result = case e of
                 EVar span' name
-                  | isConLikeName name ->
-                      ERecordCon (mergeSourceSpans span' (fieldsEndSpan fields)) name (map normalizeField fields)
+                  | isConName name ->
+                      ERecordCon (mergeSourceSpans span' (fieldsEndSpan fields)) (nameToDataName name) (map normalizeField fields)
                 _ ->
                   ERecordUpd (mergeSourceSpans (getSourceSpan e) (fieldsEndSpan fields)) e (map normalizeField fields)
           -- Recursively check for more record braces (chained updates)
@@ -227,7 +227,19 @@ atomOrRecordExprParser = do
     normalizeField (fieldName, mExpr, sp) =
       case mExpr of
         Just expr' -> (fieldName, expr')
-        Nothing -> (fieldName, EVar sp fieldName) -- NamedFieldPuns: field name becomes variable
+        Nothing -> (fieldName, EVar sp (textToName fieldName)) -- NamedFieldPuns: field name becomes variable
+
+-- | Check if a Name represents a constructor (uppercase or qualified uppercase)
+isConName :: Name -> Bool
+isConName (Name _ ns ident) =
+  case ns of
+    DataName -> True
+    TcClsName -> True
+    _ -> isConLikeName ident
+
+-- | Convert a Name to a DataName (for record constructors)
+nameToDataName :: Name -> Name
+nameToDataName (Name mMod _ ident) = Name mMod DataName ident
 
 -- | Parse record braces: { field = value, field2 = value2, ... }
 -- Supports both explicit assignment (field = value) and puns (field)
@@ -318,7 +330,7 @@ parenOperatorExprParser = withSpan $ do
       -- Note: ~ is now lexed as TkVarSym "~" so TkVarSym case handles it
       _ -> Nothing
   expectedTok TkSpecialRParen
-  pure (`EVar` op)
+  pure (`EVar` textToName op)
 
 patternParser :: TokParser Pattern
 patternParser = asPatternParser
@@ -330,7 +342,7 @@ asPatternParser =
         name <- identifierTextParser
         expectedTok TkReservedAt
         inner <- patternAtomParser
-        pure (\span' -> PAs span' name inner)
+        pure (\span' -> PAs span' (Name Nothing VarName name) inner)
     )
     <|> infixPatternParser
 
@@ -342,7 +354,10 @@ infixPatternParser = do
 
 buildInfixPattern :: Pattern -> (Text, Pattern) -> Pattern
 buildInfixPattern lhs (op, rhs) =
-  PInfix (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)) lhs op rhs
+  -- Constructor operators (starting with ':') use DataName namespace
+  let opName = textToName op
+      ns = if T.isPrefixOf ":" (nameIdent opName) then DataName else VarName
+   in PInfix (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)) lhs (opName {nameSpace = ns}) rhs
 
 conOperatorParser :: TokParser Text
 conOperatorParser =
@@ -368,7 +383,7 @@ buildPatternApp lhs rhs =
   case lhs of
     PCon lSpan name args -> PCon (mergeSourceSpans lSpan (getSourceSpan rhs)) name (args <> [rhs])
     PVar lSpan name
-      | isConLikeName name -> PCon (mergeSourceSpans lSpan (getSourceSpan rhs)) name [rhs]
+      | isConLikeName (nameIdent name) -> PCon (mergeSourceSpans lSpan (getSourceSpan rhs)) (name {nameSpace = DataName}) [rhs]
     _ -> lhs
 
 patternAtomParser :: TokParser Pattern
@@ -592,13 +607,13 @@ parenExprParser = withSpan $ do
       op <- infixOperatorParserExcept []
       rhs <- exprParser
       expectedTok TkSpecialRParen
-      pure (\span' -> EParen span' (ESectionR span' op rhs))
+      pure (\span' -> EParen span' (ESectionR span' (textToName op) rhs))
 
     parseSectionL = do
       lhs <- appExprParser
       op <- infixOperatorParserExcept []
       expectedTok TkSpecialRParen
-      pure (\span' -> EParen span' (ESectionL span' lhs op))
+      pure (\span' -> EParen span' (ESectionL span' lhs (textToName op)))
 
     parseTupleSectionExpr = do
       -- Try to parse as tuple section first (e.g., "(,1)" or "(1,)")
@@ -789,8 +804,8 @@ bareVarOrConPatternParser = withSpan $ do
   name <- identifierTextParser
   pure $ \span' ->
     if isConLikeName name
-      then PCon span' name []
-      else PVar span' name
+      then PCon span' (Name Nothing DataName name) []
+      else PVar span' (Name Nothing VarName name)
 
 recordPatternParser :: TokParser Pattern
 recordPatternParser = withSpan $ do
@@ -798,13 +813,13 @@ recordPatternParser = withSpan $ do
   expectedTok TkSpecialLBrace
   mClose <- MP.optional (expectedTok TkSpecialRBrace)
   case mClose of
-    Just () -> pure (\span' -> PRecord span' con [])
+    Just () -> pure (\span' -> PRecord span' (Name Nothing DataName con) [])
     Nothing -> do
       fields <- recordFieldPatternParser `MP.sepEndBy` expectedTok TkSpecialComma
       expectedTok TkSpecialRBrace
-      pure (\span' -> PRecord span' con fields)
+      pure (\span' -> PRecord span' (Name Nothing DataName con) fields)
 
-recordFieldPatternParser :: TokParser (Text, Pattern)
+recordFieldPatternParser :: TokParser (Name, Pattern)
 recordFieldPatternParser = do
   startPos <- MP.getSourcePos
   field <- identifierTextParser
@@ -813,11 +828,11 @@ recordFieldPatternParser = do
   case mEq of
     Just () -> do
       pat <- patternParser
-      pure (field, pat)
+      pure (Name Nothing VarName field, pat)
     Nothing -> do
       -- NamedFieldPuns: just "field" means "field = field"
       let span' = sourceSpanFromPositions startPos endPos
-      pure (field, PVar span' field)
+      pure (Name Nothing VarName field, PVar span' (Name Nothing VarName field))
 
 listPatternParser :: TokParser Pattern
 listPatternParser = withSpan $ do
@@ -865,7 +880,7 @@ isPatternAppHead :: Pattern -> Bool
 isPatternAppHead pat =
   case pat of
     PCon {} -> True
-    PVar _ name -> isConLikeName name
+    PVar _ name -> isConLikeName (nameIdent name)
     _ -> False
 
 compGuardStmtParser :: TokParser CompStmt
@@ -876,7 +891,7 @@ compGuardStmtParser = withSpan $ do
 varExprParser :: TokParser Expr
 varExprParser = withSpan $ do
   name <- identifierTextParser
-  pure (`EVar` name)
+  pure (`EVar` textToName name)
 
 simplePatternParser :: TokParser Pattern
 simplePatternParser =
@@ -885,7 +900,7 @@ simplePatternParser =
         name <- identifierTextParser
         expectedTok TkReservedAt
         inner <- patternAtomParser
-        pure (\span' -> PAs span' name inner)
+        pure (\span' -> PAs span' (Name Nothing VarName name) inner)
     )
     <|> patternAtomParser
 
@@ -898,7 +913,7 @@ forallTypeParser = withSpan $ do
   binders <- MP.some identifierTextParser
   expectedTok (TkVarSym ".")
   inner <- MP.try contextTypeParser <|> typeFunParser
-  pure (\span' -> TForall span' binders inner)
+  pure (\span' -> TForall span' (map (Name Nothing TvName) binders) inner)
 
 contextTypeParser :: TokParser Type
 contextTypeParser = do
@@ -934,7 +949,7 @@ typeInfixParser = do
 buildInfixType :: Type -> (Text, Type) -> Type
 buildInfixType lhs (op, rhs) =
   let span' = mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)
-      opType = TCon span' op
+      opType = TCon span' (Name Nothing TcClsName op)
    in TApp span' (TApp span' opType lhs) rhs
 
 typeInfixOperatorParser :: TokParser Text
@@ -984,7 +999,7 @@ typeParenOperatorParser = withSpan $ do
       -- Note: ~ is now lexed as TkVarSym "~" so TkVarSym case handles it
       _ -> Nothing
   expectedTok TkSpecialRParen
-  pure (`TCon` op)
+  pure (`TCon` Name Nothing TcClsName op)
 
 typeQuasiQuoteParser :: TokParser Type
 typeQuasiQuoteParser =
@@ -998,8 +1013,8 @@ typeIdentifierParser = withSpan $ do
   name <- identifierTextParser
   pure $ \span' ->
     case T.uncons name of
-      Just (c, _) | isLower c || c == '_' -> TVar span' name
-      _ -> TCon span' name
+      Just (c, _) | isLower c || c == '_' -> TVar span' (Name Nothing TvName name)
+      _ -> TCon span' (Name Nothing TcClsName name)
 
 typeStarParser :: TokParser Type
 typeStarParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -221,14 +221,14 @@ prettyType ty =
   case ty of
     TVar _ name -> pretty name
     TCon _ name
-      | isSymbolicTypeOperator name -> parens (pretty name)
+      | isNameOperator name -> parens (pretty name)
       | otherwise -> pretty name
     TStar _ -> "*"
     TQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
     TForall _ binders inner ->
       "forall" <+> hsep (map pretty binders) <> "." <+> prettyType inner
     TApp _ (TApp _ (TCon _ op) lhs) rhs
-      | isSymbolicTypeOperator op && op /= "->" ->
+      | isNameOperator op && nameToText op /= "->" ->
           parens (prettyType lhs <+> pretty op <+> prettyType rhs)
     TApp _ f x -> parenthesizeTypeApp f <+> parenthesizeTypeArg x
     TFun _ a b -> parenthesizeTypeFunLeft a <+> "->" <+> prettyType b
@@ -261,7 +261,7 @@ parenthesizeTypeArg :: Type -> Doc ann
 parenthesizeTypeArg ty =
   case ty of
     TApp _ (TApp _ (TCon _ op) _) _
-      | isSymbolicTypeOperator op && op /= "->" -> prettyType ty
+      | isNameOperator op && nameToText op /= "->" -> prettyType ty
     TQuasiQuote {} -> prettyType ty
     TApp {} -> parens (prettyType ty)
     TForall {} -> parens (prettyType ty)
@@ -278,7 +278,7 @@ prettyContext constraints =
 prettyConstraint :: Constraint -> Doc ann
 prettyConstraint constraint =
   let base =
-        if constraintClass constraint == "()" && null (constraintArgs constraint)
+        if nameToText (constraintClass constraint) == "()" && null (constraintArgs constraint)
           then "()"
           else hsep (pretty (constraintClass constraint) : map prettyTypeAtom (constraintArgs constraint))
    in if constraintParen constraint
@@ -297,16 +297,10 @@ prettyTypeAtom ty =
     TParen _ _ -> prettyType ty
     _ -> parens (prettyType ty)
 
-isSymbolicTypeOperator :: Text -> Bool
-isSymbolicTypeOperator op =
-  case T.uncons op of
-    Nothing -> False
-    Just _ -> T.all (`elem` (":!#$%&*+./<=>?\\^|-~" :: String)) op
-
 isInfixTypeApp :: Type -> Bool
 isInfixTypeApp ty =
   case ty of
-    TApp _ (TApp _ (TCon _ op) _) _ -> isSymbolicTypeOperator op && op /= "->"
+    TApp _ (TApp _ (TCon _ op) _) _ -> isNameOperator op && nameToText op /= "->"
     _ -> False
 
 prettyPattern :: Pattern -> Doc ann
@@ -318,7 +312,7 @@ prettyPattern pat =
     PQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
     PTuple _ elems -> parens (hsep (punctuate comma (map prettyPattern elems)))
     PList _ elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
-    PCon _ con args -> hsep (pretty con : map prettyPatternAtom args)
+    PCon _ con args -> hsep (prettyConName con : map prettyPatternAtom args)
     PInfix _ lhs op rhs -> prettyPatternAtom lhs <+> pretty op <+> prettyPatternAtom rhs
     PView _ viewExpr inner -> parens (prettyExprPrec 0 viewExpr <+> "->" <+> prettyPattern inner)
     PAs _ name inner -> pretty name <+> "@" <+> prettyPatternAtom inner
@@ -339,10 +333,10 @@ prettyPattern pat =
 -- | Pretty print a pattern field binding.
 -- Supports NamedFieldPuns: if pattern is a variable with the same name as the field,
 -- print just the field name (punned form).
-prettyPatternFieldBinding :: Text -> Pattern -> Doc ann
+prettyPatternFieldBinding :: Name -> Pattern -> Doc ann
 prettyPatternFieldBinding fieldName fieldPat =
   case fieldPat of
-    PVar _ varName | varName == fieldName -> pretty fieldName -- NamedFieldPuns: punned form
+    PVar _ varName | nameIdent varName == nameIdent fieldName -> pretty fieldName -- NamedFieldPuns: punned form
     _ -> pretty fieldName <+> "=" <+> prettyPattern fieldPat
 
 prettyPatternAtom :: Pattern -> Doc ann
@@ -691,11 +685,6 @@ prettyFunctionBinder name
 prettyBinderName :: Text -> Doc ann
 prettyBinderName = prettyFunctionBinder
 
-prettyExprOperator :: Text -> Doc ann
-prettyExprOperator op
-  | isOperatorToken op = pretty op
-  | otherwise = "`" <> pretty op <> "`"
-
 prettyConstructorName :: Text -> Doc ann
 prettyConstructorName name
   | isOperatorToken name = parens (pretty name)
@@ -722,7 +711,7 @@ prettyExprPrec prec expr =
     ETypeApp _ fn ty ->
       parenthesize (prec > 2) (prettyExprPrec 2 fn <+> "@" <> prettyTypeAtom ty)
     EVar _ name
-      | isOperatorToken name -> parens (pretty name)
+      | isNameOperator name -> parens (pretty name)
       | otherwise -> pretty name
     EInt _ _ repr -> pretty repr
     EIntBase _ _ repr -> pretty repr
@@ -740,10 +729,10 @@ prettyExprPrec prec expr =
       parenthesize
         (prec > 0)
         ("\\" <> "case" <+> braces (hsep (punctuate semi (map prettyCaseAlt alts))))
-    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprPrec 1 lhs <+> prettyExprOperator op <+> prettyExprInfixRhs rhs)
+    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprPrec 1 lhs <+> prettyNameOperator op <+> prettyExprInfixRhs rhs)
     ENegate _ inner -> parenthesize (prec > 2) ("-" <> prettyExprPrec 3 inner)
-    ESectionL _ lhs op -> parens (prettyExprPrec 0 lhs <+> prettyExprOperator op)
-    ESectionR _ op rhs -> parens (prettyExprOperator op <+> prettyExprPrec 0 rhs)
+    ESectionL _ lhs op -> parens (prettyExprPrec 0 lhs <+> prettyNameOperator op)
+    ESectionR _ op rhs -> parens (prettyNameOperator op <+> prettyExprPrec 0 rhs)
     ELetDecls _ decls body ->
       parenthesize
         (prec > 0)
@@ -821,7 +810,7 @@ prettyExprPrec prec expr =
 prettyBinding :: (Text, Expr) -> Doc ann
 prettyBinding (name, value) =
   case value of
-    EVar _ varName | varName == name -> pretty name -- NamedFieldPuns: punned form
+    EVar _ varName | nameToText varName == name -> pretty name -- NamedFieldPuns: punned form
     _ -> pretty name <+> "=" <+> prettyExprPrec 0 value
 
 prettyCaseAlt :: CaseAlt -> Doc ann
@@ -890,3 +879,25 @@ prettyQuasiQuote quoter body = "[" <> pretty quoter <> "|" <> pretty body <> "|]
 isOperatorToken :: Text -> Bool
 isOperatorToken tok =
   not (T.null tok) && T.all (`elem` (":!#$%&*+./<=>?\\^|-~" :: String)) tok
+
+-- Pretty instances for Name types
+
+instance Pretty Name where
+  pretty name = pretty (nameToText name)
+
+-- | Check if a Name is an operator (symbolic)
+isNameOperator :: Name -> Bool
+isNameOperator (Name _ _ ident) = isOperatorToken ident
+
+-- | Pretty print a Name used in prefix position (like a constructor).
+-- Parenthesizes symbolic names.
+prettyConName :: Name -> Doc ann
+prettyConName name
+  | isNameOperator name = parens (pretty name)
+  | otherwise = pretty name
+
+-- | Pretty print a Name used as an operator in infix position
+prettyNameOperator :: Name -> Doc ann
+prettyNameOperator name
+  | isNameOperator name = pretty name
+  | otherwise = "`" <> pretty name <> "`"

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -377,11 +377,11 @@ docFixityAssoc fa =
 docType :: Type -> Doc ann
 docType ty =
   case ty of
-    TVar _ name -> "TVar" <+> docText name
-    TCon _ name -> "TCon" <+> docText name
+    TVar _ name -> "TVar" <+> docName name
+    TCon _ name -> "TCon" <+> docName name
     TStar _ -> "TStar"
     TQuasiQuote _ quoter body -> "TQuasiQuote" <+> docText quoter <+> docText body
-    TForall _ binders inner -> "TForall" <+> brackets (hsep (punctuate comma (map docText binders))) <+> parens (docType inner)
+    TForall _ binders inner -> "TForall" <+> brackets (hsep (punctuate comma (map docName binders))) <+> parens (docType inner)
     TApp _ f x -> "TApp" <+> parens (docType f) <+> parens (docType x)
     TFun _ a b -> "TFun" <+> parens (docType a) <+> parens (docType b)
     TTuple _ elems -> "TTuple" <+> brackets (hsep (punctuate comma (map docType elems)))
@@ -394,7 +394,7 @@ docConstraint c =
   "Constraint" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "class" (docText (constraintClass c))]
+      [field "class" (docName (constraintClass c))]
         <> listField "args" docType (constraintArgs c)
         <> boolField "paren" (constraintParen c)
 
@@ -411,21 +411,21 @@ docTyVarBinder tvb =
 docPattern :: Pattern -> Doc ann
 docPattern pat =
   case pat of
-    PVar _ name -> "PVar" <+> docText name
+    PVar _ name -> "PVar" <+> docName name
     PWildcard _ -> "PWildcard"
     PLit _ lit -> "PLit" <+> parens (docLiteral lit)
     PQuasiQuote _ quoter body -> "PQuasiQuote" <+> docText quoter <+> docText body
     PTuple _ elems -> "PTuple" <+> brackets (hsep (punctuate comma (map docPattern elems)))
     PList _ elems -> "PList" <+> brackets (hsep (punctuate comma (map docPattern elems)))
-    PCon _ name args -> "PCon" <+> docText name <+> brackets (hsep (punctuate comma (map docPattern args)))
-    PInfix _ lhs op rhs -> "PInfix" <+> parens (docPattern lhs) <+> docText op <+> parens (docPattern rhs)
+    PCon _ name args -> "PCon" <+> docName name <+> brackets (hsep (punctuate comma (map docPattern args)))
+    PInfix _ lhs op rhs -> "PInfix" <+> parens (docPattern lhs) <+> docName op <+> parens (docPattern rhs)
     PView _ expr inner -> "PView" <+> parens (docExpr expr) <+> parens (docPattern inner)
-    PAs _ name inner -> "PAs" <+> docText name <+> parens (docPattern inner)
+    PAs _ name inner -> "PAs" <+> docName name <+> parens (docPattern inner)
     PStrict _ inner -> "PStrict" <+> parens (docPattern inner)
     PIrrefutable _ inner -> "PIrrefutable" <+> parens (docPattern inner)
     PNegLit _ lit -> "PNegLit" <+> parens (docLiteral lit)
     PParen _ inner -> "PParen" <+> parens (docPattern inner)
-    PRecord _ name fields' -> "PRecord" <+> docText name <+> braces (hsep (punctuate comma [docText fn <+> "=" <+> docPattern fp | (fn, fp) <- fields']))
+    PRecord _ name fields' -> "PRecord" <+> docName name <+> braces (hsep (punctuate comma [docName fn <+> "=" <+> docPattern fp | (fn, fp) <- fields']))
 
 docLiteral :: Literal -> Doc ann
 docLiteral lit =
@@ -441,7 +441,7 @@ docLiteral lit =
 docExpr :: Expr -> Doc ann
 docExpr expr =
   case expr of
-    EVar _ name -> "EVar" <+> docText name
+    EVar _ name -> "EVar" <+> docName name
     EInt _ n _ -> "EInt" <+> pretty n
     EIntBase _ n repr -> "EIntBase" <+> pretty n <+> docText repr
     EFloat _ n _ -> "EFloat" <+> pretty n
@@ -451,17 +451,17 @@ docExpr expr =
     EIf _ cond yes no -> "EIf" <+> parens (docExpr cond) <+> parens (docExpr yes) <+> parens (docExpr no)
     ELambdaPats _ pats body -> "ELambdaPats" <+> brackets (hsep (punctuate comma (map docPattern pats))) <+> parens (docExpr body)
     ELambdaCase _ alts -> "ELambdaCase" <+> brackets (hsep (punctuate comma (map docCaseAlt alts)))
-    EInfix _ lhs op rhs -> "EInfix" <+> parens (docExpr lhs) <+> docText op <+> parens (docExpr rhs)
+    EInfix _ lhs op rhs -> "EInfix" <+> parens (docExpr lhs) <+> docName op <+> parens (docExpr rhs)
     ENegate _ inner -> "ENegate" <+> parens (docExpr inner)
-    ESectionL _ lhs op -> "ESectionL" <+> parens (docExpr lhs) <+> docText op
-    ESectionR _ op rhs -> "ESectionR" <+> docText op <+> parens (docExpr rhs)
+    ESectionL _ lhs op -> "ESectionL" <+> parens (docExpr lhs) <+> docName op
+    ESectionR _ op rhs -> "ESectionR" <+> docName op <+> parens (docExpr rhs)
     ELetDecls _ decls body -> "ELetDecls" <+> brackets (hsep (punctuate comma (map docDecl decls))) <+> parens (docExpr body)
     ECase _ scrutinee alts -> "ECase" <+> parens (docExpr scrutinee) <+> brackets (hsep (punctuate comma (map docCaseAlt alts)))
     EDo _ stmts -> "EDo" <+> brackets (hsep (punctuate comma (map docDoStmt stmts)))
     EListComp _ body quals -> "EListComp" <+> parens (docExpr body) <+> brackets (hsep (punctuate comma (map docCompStmt quals)))
     EListCompParallel _ body qualGroups -> "EListCompParallel" <+> parens (docExpr body) <+> brackets (hsep (punctuate "|" [brackets (hsep (punctuate comma (map docCompStmt qs))) | qs <- qualGroups]))
     EArithSeq _ seqInfo -> "EArithSeq" <+> parens (docArithSeq seqInfo)
-    ERecordCon _ name fields' -> "ERecordCon" <+> docText name <+> braces (hsep (punctuate comma [docText fn <+> "=" <+> docExpr fv | (fn, fv) <- fields']))
+    ERecordCon _ name fields' -> "ERecordCon" <+> docName name <+> braces (hsep (punctuate comma [docText fn <+> "=" <+> docExpr fv | (fn, fv) <- fields']))
     ERecordUpd _ base fields' -> "ERecordUpd" <+> parens (docExpr base) <+> braces (hsep (punctuate comma [docText fn <+> "=" <+> docExpr fv | (fn, fv) <- fields']))
     ETypeSig _ inner ty -> "ETypeSig" <+> parens (docExpr inner) <+> parens (docType ty)
     EParen _ inner -> "EParen" <+> parens (docExpr inner)
@@ -607,3 +607,7 @@ docText t = dquotes (pretty t)
 
 docTextList :: [Text] -> Doc ann
 docTextList ts = brackets (hsep (punctuate comma (map docText ts)))
+
+-- Helper function for Name type
+docName :: Name -> Doc ann
+docName name = dquotes (pretty (nameToText name))

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -94,9 +94,10 @@ test_moduleParsesDecls =
       assertFailure ("expected module parse success, got parse error: " <> errorBundlePretty err)
     ParseOk modu ->
       case moduleDecls modu of
-        [ DeclValue _ (FunctionBind _ "x" [Match {matchPats = [], matchRhs = UnguardedRhs _ (EIf _ (EVar _ "y") (EVar _ "z") (EVar _ "w"))}])
-          ] ->
-            pure ()
+        [ DeclValue _ (FunctionBind _ "x" [Match {matchPats = [], matchRhs = UnguardedRhs _ (EIf _ (EVar _ nameY) (EVar _ nameZ) (EVar _ nameW))}])
+          ]
+            | nameToText nameY == "y" && nameToText nameZ == "z" && nameToText nameW == "w" ->
+                pure ()
         other ->
           assertFailure ("unexpected parsed declarations: " <> show other)
 

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -15,7 +15,16 @@ import Aihc.Lexer (isReservedIdentifier)
 import Aihc.Parser.Ast
 import Data.Text (Text)
 import qualified Data.Text as T
-import Test.Properties.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Identifiers
+  ( genConName,
+    genIdent,
+    genName,
+    genNameOp,
+    genTypeConName,
+    genTypeVarName,
+    genVarName,
+    shrinkName,
+  )
 import Test.QuickCheck
 
 -- | Canonical empty source span for normalization.
@@ -38,10 +47,10 @@ genExprSized n
           genExprLeaf,
           -- Recursive expressions (reduce size for subexpressions)
           EApp span0 <$> genExprSized half <*> genExprSized half,
-          EInfix span0 <$> genExprSized half <*> genOperator <*> genExprSized half,
+          EInfix span0 <$> genExprSized half <*> genNameOp <*> genExprSized half,
           ENegate span0 <$> genExprSized (n - 1),
-          ESectionL span0 <$> genExprSized (n - 1) <*> genOperator,
-          ESectionR span0 <$> genOperator <*> genExprSized (n - 1),
+          ESectionL span0 <$> genExprSized (n - 1) <*> genNameOp,
+          ESectionR span0 <$> genNameOp <*> genExprSized (n - 1),
           EIf span0 <$> genExprSized third <*> genExprSized third <*> genExprSized third,
           ECase span0 <$> genExprSized half <*> genCaseAlts half,
           ELambdaPats span0 <$> genPatterns half <*> genExprSized half,
@@ -68,7 +77,7 @@ genExprSized n
 genExprLeaf :: Gen Expr
 genExprLeaf =
   oneof
-    [ EVar span0 <$> genIdent,
+    [ EVar span0 <$> genName,
       mkIntExpr <$> chooseInteger (0, 999),
       mkHexExpr <$> chooseInteger (0, 255),
       mkFloatExpr <$> genTenths,
@@ -79,36 +88,6 @@ genExprLeaf =
       pure (ETuple span0 []),
       ETupleCon span0 <$> chooseInt (2, 5)
     ]
-
--- | Generate an operator symbol
-genOperator :: Gen Text
-genOperator =
-  oneof
-    [ elements ["+", "-", "*", "/", "<", ">", "<=", ">=", "==", "/=", "&&", "||", "++", ">>", ">>=", "."],
-      genCustomOperator
-    ]
-
--- | Generate a custom operator
--- Only uses valid operator characters (matching isOperatorToken in Pretty.hs)
-genCustomOperator :: Gen Text
-genCustomOperator = do
-  len <- chooseInt (1, 3)
-  -- Note: matches ":!#$%&*+./<=>?\\^|-~" from Pretty.hs isOperatorToken
-  -- Excluding ':' since that's for constructor operators
-  chars <- vectorOf len (elements "!#$%&*+./<=>?\\^|-~")
-  let candidate = T.pack chars
-  -- Avoid reserved operators and comment starters
-  if candidate `elem` ["..", "::", "=", "\\", "|", "<-", "->", "~", "=>", "--"]
-    then genCustomOperator
-    else pure candidate
-
--- | Generate a data constructor name
-genConName :: Gen Text
-genConName = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  pure (T.pack (first : rest))
 
 -- | Generate simple patterns for lambdas
 genPatterns :: Int -> Gen [Pattern]
@@ -133,7 +112,7 @@ genPattern n
 genPatternLeaf :: Gen Pattern
 genPatternLeaf =
   oneof
-    [ PVar span0 <$> genIdent,
+    [ PVar span0 <$> genVarName,
       pure (PWildcard span0)
     ]
 
@@ -322,7 +301,7 @@ genTypeLeaf :: Gen Type
 genTypeLeaf =
   oneof
     [ TVar span0 <$> genTypeVarName,
-      TCon span0 <$> genConName
+      TCon span0 <$> genTypeConName
     ]
 
 genTypeTupleElems :: Int -> Gen [Type]
@@ -333,16 +312,6 @@ genTypeTupleElems n = do
     else do
       count <- chooseInt (2, 3)
       vectorOf count (genType (n `div` count))
-
-genTypeVarName :: Gen Text
-genTypeVarName = do
-  first <- elements ['a' .. 'z']
-  restLen <- chooseInt (0, 3)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['0' .. '9']))
-  let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate
-    then genTypeVarName
-    else pure candidate
 
 -- | Literal expression generators
 mkHexExpr :: Integer -> Expr
@@ -386,7 +355,7 @@ mkIntExpr value = EInt span0 value (T.pack (show value))
 shrinkExpr :: Expr -> [Expr]
 shrinkExpr expr =
   case expr of
-    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkIdent name]
+    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkName name]
     EInt _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
     EIntBase _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
     EFloat _ value _ -> [mkFloatExpr shrunk | shrunk <- shrinkFloat value]
@@ -453,9 +422,9 @@ shrinkExpr expr =
         : [ERecordUpd span0 target' fields | target' <- shrinkExpr target]
           <> [ERecordUpd span0 target fields' | fields' <- shrinkRecordFields fields]
     ETypeSig _ inner _ ->
-      inner : [ETypeSig span0 inner' (TCon span0 "T") | inner' <- shrinkExpr inner]
+      inner : [ETypeSig span0 inner' (TCon span0 (Name Nothing TcClsName "T")) | inner' <- shrinkExpr inner]
     ETypeApp _ inner _ ->
-      inner : [ETypeApp span0 inner' (TCon span0 "T") | inner' <- shrinkExpr inner]
+      inner : [ETypeApp span0 inner' (TCon span0 (Name Nothing TcClsName "T")) | inner' <- shrinkExpr inner]
     EParen _ inner -> inner : [EParen span0 inner' | inner' <- shrinkExpr inner]
 
 shrinkFloat :: Double -> [Double]

--- a/components/aihc-parser/test/Test/Properties/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Identifiers.hs
@@ -2,16 +2,30 @@
 
 module Test.Properties.Identifiers
   ( genIdent,
+    genConIdent,
+    genOperatorText,
+    genName,
+    genNameOp,
+    genVarName,
+    genDataName,
+    genConName,
+    genTvName,
+    genTcClsName,
+    genTypeVarName,
+    genTypeConName,
     shrinkIdent,
+    shrinkName,
     isValidGeneratedIdent,
   )
 where
 
 import Aihc.Lexer (isReservedIdentifier)
+import Aihc.Parser.Ast (Name (..), NameSpace (..))
 import Data.Text (Text)
 import qualified Data.Text as T
-import Test.QuickCheck (Gen, chooseInt, elements, shrink, vectorOf)
+import Test.QuickCheck (Gen, chooseInt, elements, oneof, shrink, vectorOf)
 
+-- | Generate a lowercase identifier text
 genIdent :: Gen Text
 genIdent = do
   first <- elements (['a' .. 'z'] <> ['_'])
@@ -22,12 +36,83 @@ genIdent = do
     then pure candidate
     else genIdent
 
+-- | Generate an uppercase constructor identifier text
+genConIdent :: Gen Text
+genConIdent = do
+  first <- elements ['A' .. 'Z']
+  restLen <- chooseInt (0, 5)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
+  pure (T.pack (first : rest))
+
+-- | Generate an operator symbol text
+genOperatorText :: Gen Text
+genOperatorText = oneof [genSimpleOperator, genCustomOperator]
+  where
+    genSimpleOperator = elements ["+", "-", "*", "/", "++", ">>", ">>=", "<>", ".", "$"]
+    genCustomOperator = do
+      len <- chooseInt (1, 3)
+      -- Excluding ':' since that's for constructor operators
+      chars <- vectorOf len (elements "!#$%&*+./<=>?\\^|-~")
+      let candidate = T.pack chars
+      -- Avoid reserved operators and comment starters
+      if candidate `elem` ["..", "::", "=", "\\", "|", "<-", "->", "~", "=>", "--"]
+        then genCustomOperator
+        else pure candidate
+
+-- | Generate a Name (unqualified variable or symbol)
+genName :: Gen Name
+genName = oneof [genVarName, genOpName]
+
+-- | Generate a VarName (variable namespace)
+genVarName :: Gen Name
+genVarName = Name Nothing VarName <$> genIdent
+
+-- | Generate a DataName (data constructor namespace)
+genDataName :: Gen Name
+genDataName = Name Nothing DataName <$> genConIdent
+
+-- | Generate a TvName (type variable namespace)
+genTvName :: Gen Name
+genTvName = Name Nothing TvName <$> genIdent
+
+-- | Generate a TcClsName (type constructor/class namespace)
+genTcClsName :: Gen Name
+genTcClsName = Name Nothing TcClsName <$> genConIdent
+
+-- | Generate a Name with operator (VarName namespace)
+genOpName :: Gen Name
+genOpName = Name Nothing VarName <$> genOperatorText
+
+-- | Alias for genOpName (used in expression tests)
+genNameOp :: Gen Name
+genNameOp = genOpName
+
+-- | Alias for genDataName (used in expression tests for constructor patterns)
+genConName :: Gen Name
+genConName = genDataName
+
+-- | Generate a type variable Name (TvName namespace) - alias for type contexts
+genTypeVarName :: Gen Name
+genTypeVarName = genTvName
+
+-- | Generate a type constructor Name (TcClsName namespace) - alias for type contexts
+genTypeConName :: Gen Name
+genTypeConName = genTcClsName
+
 shrinkIdent :: Text -> [Text]
 shrinkIdent name =
   [ candidate
   | candidate <- map T.pack (shrink (T.unpack name)),
     not (T.null candidate),
     isValidGeneratedIdent candidate
+  ]
+
+-- | Shrink a Name
+shrinkName :: Name -> [Name]
+shrinkName (Name mMod ns ident) =
+  [ Name mMod ns ident'
+  | ident' <- shrinkIdent ident,
+    not (T.null ident')
   ]
 
 isValidGeneratedIdent :: Text -> Bool

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -14,7 +14,12 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
-import Test.Properties.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Identifiers
+  ( genDataName,
+    genName,
+    genVarName,
+    shrinkName,
+  )
 import Test.QuickCheck
 
 span0 :: SourceSpan
@@ -74,7 +79,7 @@ shrinkPattern :: Pattern -> [Pattern]
 shrinkPattern pat =
   case pat of
     PVar _ name ->
-      [PVar span0 shrunk | shrunk <- shrinkIdent name]
+      [PVar span0 shrunk | shrunk <- shrinkName name]
     PWildcard _ -> []
     PLit _ lit ->
       [PLit span0 shrunk | shrunk <- shrinkLiteral lit]
@@ -86,8 +91,14 @@ shrinkPattern pat =
     PList _ elems ->
       [PList span0 elems' | elems' <- shrinkList shrinkPattern elems]
     PCon _ con args ->
-      [PCon span0 con [] | not (null args)]
-        <> [PCon span0 con args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
+      -- Only shrink to zero args if constructor is alphanumeric
+      -- (operator constructors need at least one argument)
+      [PCon span0 con [] | not (null args), not (isSymbolName con)]
+        <> [ PCon span0 con args'
+           | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args,
+             -- Ensure symbol constructors keep at least one argument
+             not (isSymbolName con) || not (null args')
+           ]
     PInfix _ lhs op rhs ->
       [canonicalPatternAtom lhs, canonicalPatternAtom rhs]
         <> [PInfix span0 (canonicalPatternAtom lhs') op (canonicalPatternAtom rhs) | lhs' <- shrinkPattern lhs]
@@ -98,7 +109,7 @@ shrinkPattern pat =
         <> [PView span0 expr inner' | inner' <- shrinkPattern inner]
     PAs _ name inner ->
       [canonicalPatternAtom inner]
-        <> [PAs span0 name' (canonicalPatternAtom inner) | name' <- shrinkIdent name]
+        <> [PAs span0 name' (canonicalPatternAtom inner) | name' <- shrinkName name]
         <> [PAs span0 name (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
     PStrict _ inner ->
       [canonicalPatternAtom inner]
@@ -125,9 +136,10 @@ shrinkTupleElems elems =
       _ -> [PTuple span0 shrunk]
   ]
 
-shrinkField :: (Text, Pattern) -> [(Text, Pattern)]
+shrinkField :: (Name, Pattern) -> [(Name, Pattern)]
 shrinkField (fieldName, fieldPat) =
   [(fieldName, shrunk) | shrunk <- shrinkPattern fieldPat]
+    <> [(shrunk, fieldPat) | shrunk <- shrinkName fieldName]
 
 shrinkLiteral :: Literal -> [Literal]
 shrinkLiteral lit =
@@ -161,18 +173,20 @@ genPattern :: Int -> Gen Pattern
 genPattern depth
   | depth <= 0 =
       oneof
-        [ PVar span0 <$> genIdent,
+        [ PVar span0 <$> genVarName,
           pure (PWildcard span0),
           PLit span0 <$> genLiteral,
           PQuasiQuote span0 <$> genQuoterName <*> genQuasiBody,
-          PTuple span0 <$> elements [[], [PVar span0 "x", PWildcard span0]],
+          PTuple span0 <$> elements [[], [PVar span0 (Name Nothing VarName "x"), PWildcard span0]],
           pure (PList span0 []),
-          PCon span0 <$> genPatternConName <*> pure [],
+          -- Use only alphanumeric constructor names for nullary patterns
+          -- (operator constructors like (:+) need arguments)
+          PCon span0 <$> genAlphaConName <*> pure [],
           PNegLit span0 <$> genNumericLiteral
         ]
   | otherwise =
       frequency
-        [ (3, PVar span0 <$> genIdent),
+        [ (3, PVar span0 <$> genVarName),
           (2, pure (PWildcard span0)),
           (3, PLit span0 <$> genLiteral),
           (2, PQuasiQuote span0 <$> genQuoterName <*> genQuasiBody),
@@ -181,25 +195,28 @@ genPattern depth
           (3, genPatternCon depth),
           (2, genPatternInfix depth),
           (2, PView span0 <$> genViewExpr <*> genPattern (depth - 1)),
-          (2, PAs span0 <$> genIdent <*> (canonicalPatternAtom <$> genPattern (depth - 1))),
+          (2, PAs span0 <$> genVarName <*> (canonicalPatternAtom <$> genPattern (depth - 1))),
           (2, PStrict span0 . canonicalPatternAtom <$> genPattern (depth - 1)),
           (2, PIrrefutable span0 . canonicalPatternAtom <$> genPattern (depth - 1)),
           (2, PNegLit span0 <$> genNumericLiteral),
           (2, PParen span0 <$> genPattern (depth - 1)),
-          (2, PRecord span0 <$> genPatternConName <*> genRecordFields (depth - 1))
+          (2, PRecord span0 <$> genRecordConName <*> genRecordFields (depth - 1))
         ]
 
 genPatternCon :: Int -> Gen Pattern
 genPatternCon depth = do
-  con <- genPatternConName
   argCount <- chooseInt (0, 3)
+  -- Always use alphanumeric constructor names for PCon patterns
+  -- because the parser doesn't support prefix constructor operators like (:&&) a
+  -- (constructor operators should use PInfix instead)
+  con <- genAlphaConName
   args <- vectorOf argCount (canonicalPatternAtom <$> genPattern (depth - 1))
   pure (PCon span0 con args)
 
 genPatternInfix :: Int -> Gen Pattern
 genPatternInfix depth = do
   lhs <- canonicalPatternAtom <$> genPattern (depth - 1)
-  op <- genConOperator
+  op <- genConOpName
   rhs <- canonicalPatternAtom <$> genPattern (depth - 1)
   pure (PInfix span0 lhs op rhs)
 
@@ -217,10 +234,10 @@ genListElems depth = do
   n <- chooseInt (0, 4)
   vectorOf n (genPattern depth)
 
-genRecordFields :: Int -> Gen [(Text, Pattern)]
+genRecordFields :: Int -> Gen [(Name, Pattern)]
 genRecordFields depth = do
   n <- chooseInt (0, 3)
-  names <- vectorOf n genFieldName
+  names <- vectorOf n genFieldVarName
   pats <- vectorOf n (genPattern depth)
   pure (zip names pats)
 
@@ -259,42 +276,59 @@ genStringValue = do
 genViewExpr :: Gen Expr
 genViewExpr =
   oneof
-    [ EVar span0 <$> genIdent,
+    [ EVar span0 <$> genName,
       mkIntExpr <$> chooseInteger (0, 999),
-      EParen span0 . EVar span0 <$> genIdent
+      EParen span0 . EVar span0 <$> genName
     ]
 
 shrinkViewExpr :: Expr -> [Expr]
 shrinkViewExpr expr =
   case expr of
-    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkIdent name]
+    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkName name]
     EInt _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
     EParen _ inner -> inner : [EParen span0 inner' | inner' <- shrinkViewExpr inner]
     _ -> []
 
-genPatternConName :: Gen Text
-genPatternConName = do
+-- | Generate an alphanumeric constructor name (no operators)
+genAlphaConName :: Gen Name
+genAlphaConName = do
   first <- elements ['A' .. 'Z']
   restLen <- chooseInt (0, 5)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  pure (T.pack (first : rest))
+  pure (Name Nothing DataName (T.pack (first : rest)))
 
-genConOperator :: Gen Text
-genConOperator = do
-  first <- elements ":"
-  restLen <- chooseInt (0, 3)
-  rest <- vectorOf restLen (elements ":!#$%&*+./<=>?\\^|-~")
-  pure (T.pack (first : rest))
+-- | Generate a constructor operator Name (starts with :)
+-- We require at least one character after the initial ':' to avoid
+-- generating bare ':' which is the built-in cons operator with specific arity.
+-- Exclude: backslash (lambda), minus (prefix negate), dot (composition), slash (comment issues)
+genConOpName :: Gen Name
+genConOpName = do
+  -- Require at least one more character to avoid bare ':'
+  restLen <- chooseInt (1, 3)
+  rest <- vectorOf restLen (elements ":!#$%&*+<=>?^|~")
+  pure (Name Nothing DataName (T.pack (':' : rest)))
 
-genFieldName :: Gen Text
-genFieldName = do
+-- | Check if a Name is a symbolic operator
+isSymbolName :: Name -> Bool
+isSymbolName (Name _ _ ident) =
+  case T.uncons ident of
+    Just (c, _) -> c `notElem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['_'])
+    Nothing -> False
+
+-- | Generate a Name for record patterns
+genRecordConName :: Gen Name
+genRecordConName = genDataName
+
+-- | Generate a Name for record field names
+genFieldVarName :: Gen Name
+genFieldVarName = do
   first <- elements (['a' .. 'z'] <> ['_'])
   restLen <- chooseInt (0, 5)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
   let candidate = T.pack (first : rest)
   if isReservedIdentifier candidate
-    then genFieldName
-    else pure candidate
+    then genFieldVarName
+    else pure (Name Nothing VarName candidate)
 
 genQuoterName :: Gen Text
 genQuoterName = do

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -6,7 +6,6 @@ module Test.Properties.TypeRoundTrip
   )
 where
 
-import Aihc.Lexer (isReservedIdentifier)
 import Aihc.Parser
 import Aihc.Parser.Ast
 import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
@@ -15,7 +14,12 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
-import Test.Properties.Identifiers (shrinkIdent)
+import Test.Properties.Identifiers
+  ( genTcClsName,
+    genTvName,
+    shrinkIdent,
+    shrinkName,
+  )
 import Test.QuickCheck
 
 span0 :: SourceSpan
@@ -72,9 +76,9 @@ shrinkType :: Type -> [Type]
 shrinkType ty =
   case ty of
     TVar _ name ->
-      [TVar span0 shrunk | shrunk <- shrinkIdent name]
+      [TVar span0 shrunk | shrunk <- shrinkName name]
     TCon _ name ->
-      [TCon span0 shrunk | shrunk <- shrinkTypeConName name]
+      [TCon span0 shrunk | shrunk <- shrinkName name]
     TStar _ ->
       []
     TQuasiQuote _ quoter body ->
@@ -109,27 +113,12 @@ canonicalForallInner ty =
     TForall {} -> TParen span0 ty
     _ -> ty
 
-shrinkTypeBinders :: [Text] -> [[Text]]
+shrinkTypeBinders :: [Name] -> [[Name]]
 shrinkTypeBinders binders =
   [ shrunk
-  | shrunk <- shrinkList shrinkIdent binders,
+  | shrunk <- shrinkList shrinkName binders,
     not (null shrunk)
   ]
-
-shrinkTypeConName :: Text -> [Text]
-shrinkTypeConName name =
-  [ candidate
-  | candidate <- map T.pack (shrink (T.unpack name)),
-    isValidTypeConName candidate
-  ]
-
-isValidTypeConName :: Text -> Bool
-isValidTypeConName ident =
-  case T.uncons ident of
-    Just (first, rest) ->
-      (first `elem` ['A' .. 'Z'])
-        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
-    Nothing -> False
 
 shrinkTupleElems :: [Type] -> [Type]
 shrinkTupleElems elems =
@@ -154,18 +143,18 @@ genType :: Int -> Gen Type
 genType depth
   | depth <= 0 =
       oneof
-        [ TVar span0 <$> genTypeVarName,
-          TCon span0 <$> genTypeConName,
+        [ TVar span0 <$> genTvName,
+          TCon span0 <$> genTcClsName,
           pure (TStar span0),
           TQuasiQuote span0 <$> genQuoterName <*> genQuasiBody,
-          TTuple span0 <$> elements [[], [TVar span0 "a", TCon span0 "B"]],
+          TTuple span0 <$> elements [[], [TVar span0 (Name Nothing TvName "a"), TCon span0 (Name Nothing TcClsName "B")]],
           TList span0 <$> genTypeAtom 0,
           TParen span0 <$> genTypeAtom 0
         ]
   | otherwise =
       frequency
-        [ (3, TVar span0 <$> genTypeVarName),
-          (3, TCon span0 <$> genTypeConName),
+        [ (3, TVar span0 <$> genTvName),
+          (3, TCon span0 <$> genTcClsName),
           (1, pure (TStar span0)),
           (2, TQuasiQuote span0 <$> genQuoterName <*> genQuasiBody),
           (2, TForall span0 <$> genTypeBinders <*> genForallInner (depth - 1)),
@@ -217,8 +206,8 @@ genTypeTupleElems depth = do
 genTypeAtom :: Int -> Gen Type
 genTypeAtom depth =
   oneof
-    [ TVar span0 <$> genTypeVarName,
-      TCon span0 <$> genTypeConName,
+    [ TVar span0 <$> genTvName,
+      TCon span0 <$> genTcClsName,
       pure (TStar span0),
       TQuasiQuote span0 <$> genQuoterName <*> genQuasiBody,
       TTuple span0 <$> genTypeTupleElems depth,
@@ -233,7 +222,7 @@ genConstraints depth = do
 
 genConstraint :: Int -> Gen Constraint
 genConstraint depth = do
-  cls <- genTypeConName
+  cls <- genTcClsName
   argCount <- chooseInt (0, 2)
   args <- vectorOf argCount (genConstraintArg depth)
   pure $
@@ -286,27 +275,10 @@ canonicalConstraintArg ty =
     TParen {} -> ty
     _ -> TParen span0 ty
 
-genTypeBinders :: Gen [Text]
+genTypeBinders :: Gen [Name]
 genTypeBinders = do
   n <- chooseInt (1, 3)
-  vectorOf n genTypeVarName
-
-genTypeVarName :: Gen Text
-genTypeVarName = do
-  first <- elements (['a' .. 'z'] <> ['_'])
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate
-    then genTypeVarName
-    else pure candidate
-
-genTypeConName :: Gen Text
-genTypeConName = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  pure (T.pack (first : rest))
+  vectorOf n genTvName
 
 genQuoterName :: Gen Text
 genQuoterName = do


### PR DESCRIPTION
## Summary

- Replace multiple name types with a single unified `Name` type
- The `Name` type contains: module qualification, namespace enum, and identifier text
- Namespace enum follows GHC's approach (VarName, DataName, TvName, TcClsName)
- All tests pass (`nix flake check`)

## Design

The new unified `Name` type:
```haskell
data NameSpace = VarName | DataName | TvName | TcClsName

data Name = Name
  { nameModule :: Maybe Text,
    nameSpace :: NameSpace,
    nameIdent :: Text
  }
```

Namespaces:
- `VarName`: term-level variables and operators
- `DataName`: data constructors (including operators starting with `:`)
- `TvName`: type variables
- `TcClsName`: type constructors and classes (shared namespace, as in GHC)

## Changes

- Updated AST types (`Expr`, `Pattern`, `Type`, `Constraint`) to use unified `Name`
- Fixed parser to assign correct namespaces to names
- Updated pretty printer for `Name` type
- Updated all test generators and shrinkers

## Progress

No changes to parser pass rates (this is a refactoring change).