### PR TITLE
test: add oracle tests for 6 parser failure cases

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/DataKinds/datakinds-numeric-type-literal.hs
+++ b/components/aihc-parser/test/Test/Fixtures/DataKinds/datakinds-numeric-type-literal.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+module M where
+import Data.Proxy
+_1 :: Proxy 1
+_1 = Proxy

--- a/components/aihc-parser/test/Test/Fixtures/DataKinds/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/DataKinds/manifest.tsv
@@ -1,0 +1,1 @@
+datakinds-numeric-type-literal	types	datakinds-numeric-type-literal.hs	xfail	parser does not support numeric type-level literals with DataKinds

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/data-record-function-type-simple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/data-record-function-type-simple.hs
@@ -1,0 +1,2 @@
+module M where
+data X = X { f :: Int -> Int }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/data-record-function-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/data-record-function-type.hs
@@ -1,0 +1,5 @@
+module M where
+data Target a = Target {
+    lTarget  :: a -> Double
+  , glTarget :: Maybe (a -> a)
+  }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/instance-method-guards.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/instance-method-guards.hs
@@ -1,0 +1,5 @@
+module M where
+class Class a where
+  fn :: a -> ()
+instance Class X where
+  fn a | True = ()

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/instance-tuple-type-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/instance-tuple-type-constructor.hs
@@ -1,0 +1,5 @@
+module M where
+class Extractable f where
+  runSingleton :: f a -> a
+instance Extractable ((,,) w s) where
+  runSingleton (_,_,x) = x

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/operator-funlhs-infix-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/operator-funlhs-infix-application.hs
@@ -1,0 +1,2 @@
+module M where
+(g . h) x = g (h x)

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -297,3 +297,11 @@ hashable-regress-cpp-have-mmap	corpus	corpus/hashable/hashable-regress-cpp-have-
 hashable-xxhash-tests-numeric-underscores	corpus	corpus/hashable/hashable-xxhash-tests-numeric-underscores.hs	pass	from hashable/tests/xxhash-tests.hs; parser now accepts NumericUnderscores literals
 modules-import-operator	modules	modules/import-operator.hs	pass	parser now supports parenthesized type operators with wildcard in import lists
 vinyl-loeb-rloeb-section	corpus	corpus/vinyl-loeb-rloeb-section.hs	pass	from vinyl-loeb; parser now supports parenthesized right sections like (($ go) ...)
+
+decls-instance-tuple-type-constructor	declarations	declarations/instance-tuple-type-constructor.hs	xfail	parser does not support tuple type constructors like ((,,) w s) in instance heads
+decls-data-record-function-type	declarations	declarations/data-record-function-type.hs	xfail	parser does not support function types in record field declarations
+decls-data-record-function-type-simple	declarations	declarations/data-record-function-type-simple.hs	xfail	parser does not support function types in record field declarations (minimal repro)
+decls-operator-funlhs-infix-application	declarations	declarations/operator-funlhs-infix-application.hs	xfail	parser does not support infix operator application in function LHS like (g . h) x = ...
+decls-instance-method-guards	declarations	declarations/instance-method-guards.hs	xfail	parser does not support guards in instance method definitions
+types-newtype-record-function-type	types	types/newtype-record-function-type.hs	xfail	parser does not support function types in newtype record field declarations
+types-tuple-type-constructor-prefix	types	types/tuple-type-constructor-prefix.hs	xfail	parser does not support prefix tuple type constructor syntax like (,) a b

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/types/newtype-record-function-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/types/newtype-record-function-type.hs
@@ -1,0 +1,2 @@
+module M where
+newtype IOMcn a b = IOMcn { getIOMcn :: a -> IO b }

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/types/tuple-type-constructor-prefix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/types/tuple-type-constructor-prefix.hs
@@ -1,0 +1,3 @@
+module M where
+f :: (,) a b -> Int
+f = undefined


### PR DESCRIPTION
## Summary

Adds oracle compliance tests documenting valid Haskell code that currently fails to parse with aihc-parser.

## Test Cases Added

| Issue | Snippet | Minimized Root Cause |
|-------|---------|---------------------|
| Tuple type constructor in instance | `instance C ((,,) w s)` | Prefix tuple type syntax `(,) a b` unsupported |
| Newtype record with function type | `newtype X = X { f :: a -> IO b }` | Function types in record fields unsupported |
| Operator funlhs infix application | `(g . h) x = g (h x)` | Infix operator application in function LHS |
| Data record with function type | `data X = X { f :: a -> b }` | Same as newtype - `Int -> Int` in records |
| DataKinds numeric literal | `Proxy 1` | Numeric type-level literals unsupported |
| Instance method guards | `fn a \| True = ()` in instance | Guards in instance method definitions |

## Investigation Summary

- **Tuple type constructor**: Parser doesn't support prefix tuple type syntax like `(,) a b` or `(,,) w s`
- **Function types in records**: Parser fails when record field types contain `->` (workaround: parenthesize as `(Int -> Int)`)
- **Operator funlhs**: Parser supports `(.) f g x = ...` but not `(f . g) x = ...` form
- **Instance guards**: Guards work in top-level definitions but not instance method definitions
- **DataKinds**: Numeric type-level literals require DataKinds extension support

## Progress

| Metric | Count |
|--------|-------|
| PASS | 417 |
| XFAIL | 55 (+7) |
| XPASS | 0 |
| FAIL | 0 |
| **Complete** | 88.34% |