### PR TITLE
fix(parser): support backticked constructor identifiers in infix data/newtype decls

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -787,12 +787,20 @@ constructorNameParser = constructorIdentifierParser
 
 constructorOperatorParser :: TokParser Text
 constructorOperatorParser =
-  tokenSatisfy "constructor operator" $ \tok ->
-    case lexTokenKind tok of
-      TkConSym op -> Just op
-      TkQConSym op -> Just op
-      TkReservedColon -> Just ":"
-      _ -> Nothing
+  symbolicConstructorOperatorParser <|> backtickConstructorIdentifierParser
+  where
+    symbolicConstructorOperatorParser =
+      tokenSatisfy "constructor operator" $ \tok ->
+        case lexTokenKind tok of
+          TkConSym op -> Just op
+          TkQConSym op -> Just op
+          TkReservedColon -> Just ":"
+          _ -> Nothing
+    backtickConstructorIdentifierParser = do
+      expectedTok TkSpecialBacktick
+      op <- constructorIdentifierParser
+      expectedTok TkSpecialBacktick
+      pure op
 
 unsupportedDeclParser :: String -> TokParser Decl
 unsupportedDeclParser = fail

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -150,7 +150,7 @@ prettyDeclLines decl =
       [ hsep
           ( [prettyFixityAssoc assoc]
               <> maybe [] (pure . pretty . show) prec
-              <> map prettyOperatorName ops
+              <> map prettyInfixOp ops
           )
       ]
     DeclTypeSyn _ synDecl ->
@@ -324,7 +324,7 @@ prettyPattern pat =
     PTuple _ elems -> parens (hsep (punctuate comma (map prettyPattern elems)))
     PList _ elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
     PCon _ con args -> hsep (pretty con : map prettyPatternAtom args)
-    PInfix _ lhs op rhs -> prettyPatternAtom lhs <+> pretty op <+> prettyPatternAtom rhs
+    PInfix _ lhs op rhs -> prettyPatternAtom lhs <+> prettyInfixOp op <+> prettyPatternAtom rhs
     PView _ viewExpr inner -> parens (prettyExprPrec 0 viewExpr <+> "->" <+> prettyPattern inner)
     PAs _ name inner -> pretty name <+> "@" <+> prettyPatternAtom inner
     PStrict _ inner -> "!" <> prettyUnaryPattern inner
@@ -467,7 +467,7 @@ prettyDataCon ctor =
     InfixCon _ forallVars constraints lhs op rhs ->
       hsep
         ( dataConQualifierPrefix forallVars constraints
-            <> [prettyBangTypeAtom lhs, pretty op, prettyBangTypeAtom rhs]
+            <> [prettyBangTypeAtom lhs, prettyInfixOp op, prettyBangTypeAtom rhs]
         )
     RecordCon _ forallVars constraints name fields ->
       hsep (dataConQualifierPrefix forallVars constraints <> [prettyConstructorName name])
@@ -580,7 +580,7 @@ prettyClassItem item =
       hsep
         ( [prettyFixityAssoc assoc]
             <> maybe [] (pure . pretty . show) prec
-            <> map prettyOperatorName ops
+            <> map prettyInfixOp ops
         )
     ClassItemDefault _ valueDecl ->
       case prettyValueDeclLines valueDecl of
@@ -630,7 +630,7 @@ prettyInstanceItem item =
       hsep
         ( [prettyFixityAssoc assoc]
             <> maybe [] (pure . pretty . show) prec
-            <> map prettyOperatorName ops
+            <> map prettyInfixOp ops
         )
 
 prettyFixityAssoc :: FixityAssoc -> Doc ann
@@ -683,10 +683,10 @@ prettyForeignEntity spec =
     ForeignEntityAddress (Just name) -> Just (quoted ("&" <> name))
     ForeignEntityNamed name -> Just (quoted name)
 
-prettyOperatorName :: Text -> Doc ann
-prettyOperatorName name
-  | isOperatorToken name = pretty name
-  | otherwise = parens (pretty name)
+prettyInfixOp :: Text -> Doc ann
+prettyInfixOp op
+  | isOperatorToken op = pretty op
+  | otherwise = "`" <> pretty op <> "`"
 
 prettyFunctionBinder :: Text -> Doc ann
 prettyFunctionBinder name
@@ -695,11 +695,6 @@ prettyFunctionBinder name
 
 prettyBinderName :: Text -> Doc ann
 prettyBinderName = prettyFunctionBinder
-
-prettyExprOperator :: Text -> Doc ann
-prettyExprOperator op
-  | isOperatorToken op = pretty op
-  | otherwise = "`" <> pretty op <> "`"
 
 prettyConstructorName :: Text -> Doc ann
 prettyConstructorName name
@@ -839,10 +834,10 @@ prettyExprPrec prec expr =
       parenthesize
         (prec > 0)
         ("\\" <> "case" <+> "{" <+> hsep (punctuate semi (map prettyCaseAlt alts)) <+> "}")
-    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprInfixLhs lhs <+> prettyExprOperator op <+> prettyExprInfixRhs rhs)
+    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprInfixLhs lhs <+> prettyInfixOp op <+> prettyExprInfixRhs rhs)
     ENegate _ inner -> parenthesize (prec > 2) (prettyNegate inner)
-    ESectionL _ lhs op -> parens (prettyExprPrec 3 lhs <+> prettyExprOperator op)
-    ESectionR _ op rhs -> parens (prettyExprOperator op <+> prettyExprPrec 0 rhs)
+    ESectionL _ lhs op -> parens (prettyExprPrec 3 lhs <+> prettyInfixOp op)
+    ESectionR _ op rhs -> parens (prettyInfixOp op <+> prettyExprPrec 0 rhs)
     ELetDecls _ decls body ->
       parenthesize
         (prec > 0)

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/infix-con.hs
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/declarations/infix-con.hs
@@ -1,0 +1,1 @@
+data A a b = a `Infix` b

--- a/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/haskell2010/manifest.tsv
@@ -305,3 +305,4 @@ decls-operator-funlhs-infix-application	declarations	declarations/operator-funlh
 decls-instance-method-guards	declarations	declarations/instance-method-guards.hs	xfail	parser does not support guards in instance method definitions
 types-newtype-record-function-type	types	types/newtype-record-function-type.hs	xfail	parser does not support function types in newtype record field declarations
 types-tuple-type-constructor-prefix	types	types/tuple-type-constructor-prefix.hs	xfail	parser does not support prefix tuple type constructor syntax like (,) a b
+decls-data-infix-backtick	declarations	declarations/infix-con.hs	pass	parser now supports backtick infix data constructors


### PR DESCRIPTION
# Description

This PR fixes a parse error where Haskell's infix data constructors with backticks failed to parse.
It also ensures that the pretty-printer correctly outputs backticks for infix constructor identifiers, ensuring a correct round-trip.

Changes:
- Updated `constructorOperatorParser` in `Aihc.Parser.Internal.Decl` to support backticked constructor identifiers.
- Unified infix operator printing in `Aihc.Parser.Pretty` and ensured backticks are used for identifiers.
- Added a new `haskell2010` test case: `decls-data-infix-backtick`.

# Progress Changes

-   Haskell 2010 Parser Progress: 417 PASS -> 418 PASS (+1)