### PR TITLE
fix(parser): add parentheses for lambdas in type signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -809,6 +809,7 @@ prettyTypeSigBody expr =
   case expr of
     ENegate {} -> parens (prettyExprPrec 0 expr)
     ETypeSig {} -> parens (prettyExprPrec 0 expr)
+    ELambdaPats {} -> parens (prettyExprPrec 0 expr)
     _ -> prettyExprPrec 1 expr
 
 prettyExprPrec :: Int -> Expr -> Doc ann


### PR DESCRIPTION
## Summary

- Fix pretty-printer to add parentheses around lambda expressions in type signatures
- This resolves round-trip parsing failures where `\x -> 0 :: T` was incorrectly parsed as `\x -> (0 :: T)` instead of `(\x -> 0) :: T`

## Testing

- Verified with quickcheck round-trip test: `nix run .#parser-test -- --quickcheck-replay="(SMGen 10248049724168453772 2270284217933980567,56)" -p "/generated expr AST pretty-printer round-trip/"`