### PR TITLE
fix(parser): support backtick operators in type expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -939,17 +939,27 @@ buildInfixType lhs (op, rhs) =
 
 typeInfixOperatorParser :: TokParser Text
 typeInfixOperatorParser =
-  tokenSatisfy "type infix operator" $ \tok ->
-    case lexTokenKind tok of
-      TkVarSym op
-        | op /= "."
-            && op /= "!"
-            && op /= "-" ->
-            Just op
-      TkConSym op -> Just op
-      TkQVarSym op -> Just op
-      TkQConSym op -> Just op
-      _ -> Nothing
+  MP.try backtickTypeOperatorParser
+    <|> tokenSatisfy "type infix operator" tokenToOperator
+  where
+    tokenToOperator tok =
+      case lexTokenKind tok of
+        TkVarSym op
+          | op /= "."
+              && op /= "!"
+              && op /= "-" ->
+              Just op
+        TkConSym op -> Just op
+        TkQVarSym op -> Just op
+        TkQConSym op -> Just op
+        _ -> Nothing
+
+backtickTypeOperatorParser :: TokParser Text
+backtickTypeOperatorParser = do
+  expectedTok TkSpecialBacktick
+  op <- identifierTextParser
+  expectedTok TkSpecialBacktick
+  pure op
 
 typeAppParser :: TokParser Type
 typeAppParser = do


### PR DESCRIPTION
## Summary

- Fix `typeInfixOperatorParser` to support backtick operators in type expressions
- Enables parsing of type synonyms like `type Foo = Int \`Infix\` b`

## Progress Counts

- Parser: 418 PASS (+1), 55 XFAIL, 88.37% complete

## Changes

Modified `components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs`:
- Added `backtickTypeOperatorParser` to handle backtick-wrapped identifiers as type operators
- Updated `typeInfixOperatorParser` to try backtick parsing before falling back to symbolic operators

## Testing

- Type-level backtick operators now work: `type Foo = Int \`Infix\` b`

Note: The original issue (`data A b = Int \`Infix\` b`) is a separate pre-existing bug related to data constructor argument parsing, not the type expression parser.