### PR TITLE
fix(nix): hide passing tests so failures are visible in truncated output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,8 +105,15 @@
                      export AIHC_LEXER_EXE="$PWD/dist/build/aihc-lexer/aihc-lexer"
                      export AIHC_PARSER_EXE="$PWD/dist/build/aihc-parser/aihc-parser"
                    '';
+                   # Hide passing tests so failures are visible in Nix's truncated output
+                   testFlags = (old.testFlags or []) ++ ["--hide-successes"];
                  });
-               aihc-cpp = final.callCabal2nix "aihc-cpp" (cppSrc pkgs) { };
+               aihc-cpp = pkgs.haskell.lib.overrideCabal
+                 (final.callCabal2nix "aihc-cpp" (cppSrc pkgs) { })
+                 (old: {
+                   # Hide passing tests so failures are visible in Nix's truncated output
+                   testFlags = (old.testFlags or []) ++ ["--hide-successes"];
+                 });
              };
            };
         # Haskell packages with Haddock enabled for documentation generation
@@ -152,6 +159,8 @@
             # Enable coverage and export HPC artifacts
             enableCoverageWithExport = drv: pkgs.haskell.lib.overrideCabal drv (old: {
               configureFlags = (old.configureFlags or []) ++ ["--enable-coverage"];
+              # Hide passing tests so failures are visible in Nix's truncated output
+              testFlags = (old.testFlags or []) ++ ["--hide-successes"];
               postInstall = (old.postInstall or "") + ''
                 # Export HPC coverage data
                 if [ -d dist/hpc ]; then
@@ -163,6 +172,8 @@
             # Set up CLI executable environment for tests (same as mkHsPkgsWithTests) + export HPC
             enableCoverageWithTests = drv: pkgs.haskell.lib.overrideCabal drv (old: {
               configureFlags = (old.configureFlags or []) ++ ["--enable-coverage"];
+              # Hide passing tests so failures are visible in Nix's truncated output
+              testFlags = (old.testFlags or []) ++ ["--hide-successes"];
               preCheck = (old.preCheck or "") + ''
                 export AIHC_LEXER_EXE="$PWD/dist/build/aihc-lexer/aihc-lexer"
                 export AIHC_PARSER_EXE="$PWD/dist/build/aihc-parser/aihc-parser"


### PR DESCRIPTION
## Summary

- Add `--hide-successes` flag to Tasty test runs in Nix builds
- Applies to both regular test builds and coverage builds

## Problem

When tests fail in `nix flake check`, Nix only shows the last 25 lines of output. With 750+ tests, this often shows only passing tests while the actual failures are truncated away:

```
> 2 out of 752 tests failed (1.65s)
> Test suite spec: FAIL
```

## Solution

Pass `--hide-successes` to Tasty so only failures appear in the output, making it much easier to diagnose test failures from Nix's truncated logs.