### PR TITLE
fix(parser): preserve infix RHS precedence in pretty-printer

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -380,6 +380,8 @@ prettyPatternAtomAfterAt :: Pattern -> Doc ann
 prettyPatternAtomAfterAt pat =
   case pat of
     PNegLit {} -> parens (prettyPattern pat)
+    PStrict {} -> parens (prettyPattern pat)
+    PIrrefutable {} -> parens (prettyPattern pat)
     _ -> prettyPatternAtom pat
 
 prettyUnaryPattern :: Pattern -> Doc ann
@@ -719,15 +721,18 @@ prettyConstructorName name
 -- EWhereDecls needs parentheses because "where" binds looser than infix operators.
 -- ENegate needs parentheses because negate can only appear at the start of
 -- an infix expression, not as the RHS of an operator.
--- Other greedy expressions (do, case, \case, if, lambda, let) are safe as RHS
--- because the parser correctly identifies them and they don't capture following operators.
-prettyExprInfixRhs :: Expr -> Doc ann
-prettyExprInfixRhs expr =
+-- Open-ended expressions (if, lambda, let, and infix expressions with open-ended
+-- RHS) need parentheses when this infix node can be followed by another operator;
+-- otherwise they can capture that trailing operator into their bodies.
+-- Brace-terminated expressions (do, case, \case) are safe on the RHS.
+prettyExprInfixRhs :: Bool -> Expr -> Doc ann
+prettyExprInfixRhs protectOpenEnded expr =
   case expr of
     EInfix {} -> parens (prettyExprPrec 0 expr)
     ETypeSig {} -> parens (prettyExprPrec 0 expr)
     ENegate {} -> parens (prettyExprPrec 0 expr)
     EWhereDecls {} -> parens (prettyExprPrec 0 expr)
+    _ | protectOpenEnded && isOpenEnded expr -> parens (prettyExprPrec 0 expr)
     -- Other greedy expressions are safe at prec 0 as RHS of infix
     _ | isGreedyExpr expr -> prettyExprPrec 0 expr
     _ -> prettyExprPrec 1 expr
@@ -846,7 +851,10 @@ prettyExprPrec prec expr =
       parenthesize
         (prec > 0)
         ("\\" <> "case" <+> "{" <+> hsep (punctuate semi (map prettyCaseAlt alts)) <+> "}")
-    EInfix _ lhs op rhs -> parenthesize (prec > 1) (prettyExprInfixLhs lhs <+> prettyInfixOp op <+> prettyExprInfixRhs rhs)
+    EInfix _ lhs op rhs ->
+      parenthesize
+        (prec > 1)
+        (prettyExprInfixLhs lhs <+> prettyInfixOp op <+> prettyExprInfixRhs (prec == 1) rhs)
     ENegate _ inner -> parenthesize (prec > 2) (prettyNegate inner)
     ESectionL _ lhs op -> parens (prettyExprPrec 3 lhs <+> prettyInfixOp op)
     ESectionR _ op rhs -> parens (prettyInfixOp op <+> prettyExprPrec 0 rhs)

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -412,9 +412,12 @@ normalizeUnaryInner pat =
 
 -- | Normalize the inner pattern of an as-pattern.
 -- The pretty-printer adds parens around negative literals after @ for safety (a@-0 is invalid),
--- so we strip PParen around PNegLit to get the canonical form.
+-- and around strict/irrefutable patterns to avoid lexing @!/@~ as symbolic operators,
+-- so we strip those parens to get the canonical form.
 normalizeAsInner :: Pattern -> Pattern
 normalizeAsInner pat =
   case normalizePattern pat of
     PParen _ inner@(PNegLit {}) -> inner
+    PParen _ inner@(PStrict {}) -> inner
+    PParen _ inner@(PIrrefutable {}) -> inner
     other -> other


### PR DESCRIPTION
## Summary
- Fix expression pretty-printing for infix RHS by parenthesizing open-ended RHS forms (`if`/`let`/lambda and infix chains ending in them) only when needed to prevent trailing operators from being captured on reparse.
- Keep valid Haskell2010 infix-RHS forms unparenthesized where safe, and preserve round-trip behavior for the reported QuickCheck replay.
- Fix as-pattern pretty-printing for strict/irrefutable inner patterns (`@!`/`@~`) by forcing parentheses, and normalize these in the pattern round-trip property.

## Progress Counts
- Parser progress: unchanged (no fixture/manifest changes in this PR).
- Current parser progress (`nix run .#parser-progress`): PASS 428, XFAIL 58, XPASS 0, FAIL 0, COMPLETE 88.06%.

## Validation
- `nix flake check`
- `nix develop -c sh -c 'cabal clean && cabal test spec --test-options="--quickcheck-replay=\"(SMGen 3860117720610008708 2764966532515840083,2)\" -p \"/generated module AST pretty-printer round-trip/\"" && cabal test spec --test-options="--quickcheck-replay=\"(SMGen 7640967780234657508 465146527136968997,28)\" -p \"/generated pattern AST pretty-printer round-trip/\"" && cabal test spec --test-options="-p \"/expr-s3-if-infix-rhs/\"" && cabal test spec --test-options="-p \"/expr-s3-let-infix-rhs/\"" && cabal test spec --test-options="-p \"/expr-s3-lambda-infix-rhs/\"" && cabal test spec --test-options="-p \"/decls-infix-funlhs-lambda/\""'`
- `coderabbit review --prompt-only` (no findings)