### PR TITLE
fix(parser-fuzz): normalize warning pragmas before exactPrint

### DIFF
--- a/components/aihc-parser/app/parser-fuzz/ParserFuzz/Arbitrary.hs
+++ b/components/aihc-parser/app/parser-fuzz/ParserFuzz/Arbitrary.hs
@@ -127,8 +127,10 @@ normalizeCandidateSource context source0 =
                 <> source0
             )
         HSE.ParseOk modu1 ->
-          let source1 = HSE.exactPrint modu1 []
-           in case HSE.parseFileContentsWithMode mode source1 of
+          case exactPrintParseable context mode modu1 of
+            Left msg -> Left msg
+            Right source1 ->
+              case HSE.parseFileContentsWithMode mode source1 of
                 HSE.ParseFailed loc err ->
                   Left
                     ( context
@@ -140,11 +142,53 @@ normalizeCandidateSource context source0 =
                         <> source1
                     )
                 HSE.ParseOk modu2 ->
-                  Right
-                    Candidate
-                      { candAst = modu2,
-                        candSource = HSE.exactPrint modu2 []
-                      }
+                  case exactPrintParseable context mode modu2 of
+                    Left msg -> Left msg
+                    Right source2 ->
+                      Right
+                        Candidate
+                          { candAst = modu2,
+                            candSource = source2
+                          }
+
+exactPrintParseable :: String -> HSE.ParseMode -> HSE.Module HSE.SrcSpanInfo -> Either String String
+exactPrintParseable context mode modu =
+  let sourceRaw = HSE.exactPrint modu []
+   in case HSE.parseFileContentsWithMode mode sourceRaw of
+        HSE.ParseOk _ -> Right sourceRaw
+        HSE.ParseFailed _ _ ->
+          let sourceNormalized = HSE.exactPrint (normalizeModuleWarningPragmas modu) []
+           in case HSE.parseFileContentsWithMode mode sourceNormalized of
+                HSE.ParseOk _ -> Right sourceNormalized
+                HSE.ParseFailed loc err ->
+                  Left
+                    ( context
+                        <> ": internal bug: normalized exactPrint failed to parse at "
+                        <> show loc
+                        <> " with error: "
+                        <> err
+                        <> "\nsource:\n"
+                        <> sourceNormalized
+                    )
+
+normalizeModuleWarningPragmas :: HSE.Module HSE.SrcSpanInfo -> HSE.Module HSE.SrcSpanInfo
+normalizeModuleWarningPragmas modu =
+  case modu of
+    HSE.Module loc (Just (HSE.ModuleHead hLoc modName warning exports)) pragmas imports decls ->
+      HSE.Module loc (Just (HSE.ModuleHead hLoc modName (fmap normalizeWarningText warning) exports)) pragmas imports decls
+    _ -> modu
+
+normalizeWarningText :: HSE.WarningText HSE.SrcSpanInfo -> HSE.WarningText HSE.SrcSpanInfo
+normalizeWarningText warning =
+  case warning of
+    HSE.DeprText loc msg -> HSE.DeprText loc (quoteWarningMessage msg)
+    HSE.WarnText loc msg -> HSE.WarnText loc (quoteWarningMessage msg)
+
+quoteWarningMessage :: String -> String
+quoteWarningMessage msg =
+  case reads msg :: [(String, String)] of
+    [(decoded, "")] | show decoded == msg -> msg
+    _ -> show msg
 
 shrinkGeneratedModule :: HSE.Module HSE.SrcSpanInfo -> [HSE.Module HSE.SrcSpanInfo]
 shrinkGeneratedModule modu =

--- a/docs/haskell-src-exts-warning-deprecated-exactprint.md
+++ b/docs/haskell-src-exts-warning-deprecated-exactprint.md
@@ -1,0 +1,29 @@
+# `haskell-src-exts` `exactPrint` bug for module `WARNING`/`DEPRECATED` pragmas
+
+## Summary
+
+With `haskell-src-exts-1.23.1`, `exactPrint` can emit invalid Haskell for module-header warning pragmas.
+
+Given input like:
+
+```haskell
+module M {-# DEPRECATED "!801X.6!   " #-} where
+```
+
+`parse -> exactPrint` may produce:
+
+```haskell
+module M {-# DEPRECATED !801X.6!      #-} where
+```
+
+The quotes are dropped, and reparsing fails at `!`.
+
+The same behavior is observed for `{-# WARNING ... #-}` in module headers.
+
+## Impact in this repo
+
+`parser-fuzz` normalizes candidates via `parse -> exactPrint -> parse`. The bug can trigger an internal failure during shrink/normalization even when the original generated source was valid.
+
+## Workaround used here
+
+Before `exactPrint`, `parser-fuzz` now normalizes module-header warning/deprecation message nodes to quoted string literals when needed, and verifies the emitted source reparses. This keeps fuzz normalization robust while preserving the normal `exactPrint` path when it already produces parseable output.


### PR DESCRIPTION
## Summary
- fix parser-fuzz candidate normalization to guard `exactPrint` output and recover from the `haskell-src-exts` module-header `WARNING`/`DEPRECATED` quote-loss bug
- normalize module warning/deprecation nodes only when raw `exactPrint` output is not parseable
- document the upstream `haskell-src-exts` behavior and local workaround in `docs/haskell-src-exts-warning-deprecated-exactprint.md`

## Validation
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)
- `nix run .#parser-fuzz -- --seed 8461706622512592822 --max-tests 30`

## Progress Counts
- No parser/extension/cpp progress-count changes in this PR.