### PR TITLE
fix(parser): reject dash-only generated operators

### DIFF
--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -15,6 +15,7 @@ import Test.H2010.Suite (h2010Tests)
 import Test.HackageTester.Suite (hackageTesterTests)
 import Test.Lexer.Suite (lexerTests)
 import Test.Parser.Suite (parserGoldenTests)
+import Test.Properties.ExprHelpers (genOperator, isValidGeneratedOperator)
 import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip)
 import Test.Properties.Identifiers (isValidGeneratedIdent, shrinkIdent)
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip)
@@ -73,7 +74,8 @@ buildTests = do
             testCase "parser config sets source name in parse errors" test_parserConfigSetsSourceName,
             testCase "generated identifiers reject reserved keyword as" test_generatedIdentifiersRejectReservedAs,
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
-            testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore
+            testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
+            QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters
           ],
         adjustOption (const tenMinutes) $
           testGroup
@@ -357,3 +359,9 @@ test_shrunkIdentifiersRejectStandaloneUnderscore :: Assertion
 test_shrunkIdentifiersRejectStandaloneUnderscore =
   assertBool "standalone underscore must not be produced by shrinking" $
     "_" `notElem` shrinkIdent "__"
+
+prop_generatedOperatorsRejectDashOnlyCommentStarters :: QC.Property
+prop_generatedOperatorsRejectDashOnlyCommentStarters =
+  QC.forAll (QC.vectorOf 2000 genOperator) $ \ops ->
+    let invalid = filter (not . isValidGeneratedOperator) ops
+     in QC.counterexample ("invalid generated operators: " <> show invalid) (null invalid)

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -4,6 +4,8 @@
 -- used by both ExprRoundTrip and ModuleRoundTrip tests.
 module Test.Properties.ExprHelpers
   ( genExpr,
+    genOperator,
+    isValidGeneratedOperator,
     mkIntExpr,
     shrinkExpr,
     normalizeExpr,
@@ -97,10 +99,16 @@ genCustomOperator = do
   -- Excluding ':' since that's for constructor operators
   chars <- vectorOf len (elements "!#$%&*+./<=>?\\^|-~")
   let candidate = T.pack chars
-  -- Avoid reserved operators and comment starters
-  if candidate `elem` ["..", "::", "=", "\\", "|", "<-", "->", "~", "=>", "--"]
-    then genCustomOperator
-    else pure candidate
+  -- Avoid reserved operators and symbols that lex as comments.
+  if isValidGeneratedOperator candidate
+    then pure candidate
+    else genCustomOperator
+
+isValidGeneratedOperator :: Text -> Bool
+isValidGeneratedOperator candidate =
+  let reserved = candidate `elem` ["..", "::", "=", "\\", "|", "<-", "->", "~", "=>", "--"]
+      dashOnly = T.length candidate >= 2 && T.all (== '-') candidate
+   in not reserved && not dashOnly
 
 -- | Generate a data constructor name
 genConName :: Gen Text


### PR DESCRIPTION
## Summary
- prevent QuickCheck expression/module generators from producing dash-only operators like `---` that lex as line comments
- add `isValidGeneratedOperator` and use it in custom operator generation
- add regression property test to ensure generated operators never include dash-only comment starters

## Root Cause
The generator accepted dash-only symbolic operators of length >= 2. Values like `---` pretty-print in sections (for example `(--- I {})`) but lex as a comment start, causing round-trip parse failures.

## Validation
- `nix flake check`
- `nix run .#parser-quickcheck-batch -- --max-success 400 --property "generated module AST pretty-printer round-trip"`
- `nix run .#parser-quickcheck-batch -- --max-success 200 --property "generated expr AST pretty-printer round-trip"`

## Pre-PR Review
- `coderabbit review --prompt-only` was attempted but skipped due rate limiting (`Rate limit exceeded, please try after 6 minutes and 48 seconds`).

## Progress Counts
Current counts:
- Parser progress: PASS 451, XFAIL 94, XPASS 0, FAIL 0, TOTAL 545, COMPLETE 82.75%
- Parser extension support: SUPPORTED 33, IN_PROGRESS 26, PLANNED 79, TOTAL 138
- CPP progress: PASS 37, XFAIL 0, XPASS 0, FAIL 0, TOTAL 37, COMPLETE 100.0%

Change in counts from this PR:
- Parser progress: no change
- Parser extension support: no change
- CPP progress: no change