### PR TITLE
docs(agents): add gotchas for CI merge checks and golden drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@
 - CI checks the PR merge commit (`pull/<n>/merge`), not only the branch HEAD. If local passes but CI fails, merge or rebase `origin/main` locally and rerun `nix flake check`.
 - Golden AST strings are sensitive to upstream AST/shorthand changes (for example, `Match` now printing `headForm = Prefix`), so new fixtures must match current `main` formatting.
 - `nix run .#parser-test` in local shell may fail on CLI executable discovery (`aihc-parser`/`aihc-lexer` not in `PATH`) even when derivation-based `nix flake check` is green.
+- `nix flake check` builds from tracked Git sources. If a manifest references a newly created fixture file, run `git add <file>` before `nix flake check` or the suite may fail with "Manifest references missing case file".
+- In parser oracle suites, `pass` means both oracle acceptance and AST roundtrip-fingerprint equality. A case can parse successfully and still fail as `roundtrip mismatch against oracle AST`.
+- `xfail` rows in fixture `manifest.tsv` files require a reason column (5th TSV field).
 
 ## Testing (TDD)
 
@@ -49,12 +52,6 @@ aihc is developed test-first. Run the full suite with `nix flake check`. When wo
   - Oracle compliance tests:
     - Manifest: `components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv`.
     - Oracle is `cpphs`; outputs are compared against `cpphs` behavior.
-
-## Gotchas
-
-- `nix flake check` builds from tracked Git sources. If a manifest references a newly created fixture file, run `git add <file>` before `nix flake check` or the suite may fail with "Manifest references missing case file".
-- In parser oracle suites, `pass` means both oracle acceptance and AST roundtrip-fingerprint equality. A case can parse successfully and still fail as `roundtrip mismatch against oracle AST`.
-- `xfail` rows in fixture `manifest.tsv` files require a reason column (5th TSV field).
 
 ## Pre-PR Review
 


### PR DESCRIPTION
## Summary
- add a new `## Gotchas` section to `AGENTS.md`
- document that CI validates the PR merge commit (`pull/<n>/merge`) and may differ from branch-head-only local checks
- document golden AST snapshot drift risk when shorthand/AST formatting changes on `main`
- document local `nix run .#parser-test` CLI executable discovery failures vs green derivation-based `nix flake check`

## Testing
- not run (documentation-only change)
