### PR TITLE
feat(parser): implement FunctionalDependencies class-head parsing

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -288,6 +288,7 @@ classDeclParser = withSpan $ do
   context <- MP.optional (MP.try (declContextParser <* expectedTok TkReservedDoubleArrow))
   className <- constructorIdentifierParser
   classParams <- MP.some typeParamParser
+  classFundeps <- MP.option [] (MP.try classFundepsParser)
   items <- MP.option [] classWhereClauseParser
   pure $ \span' ->
     DeclClass
@@ -297,8 +298,26 @@ classDeclParser = withSpan $ do
           classDeclContext = context,
           classDeclName = className,
           classDeclParams = classParams,
+          classDeclFundeps = classFundeps,
           classDeclItems = items
         }
+
+classFundepsParser :: TokParser [FunctionalDependency]
+classFundepsParser = do
+  expectedTok TkReservedPipe
+  classFundepParser `MP.sepBy1` expectedTok TkSpecialComma
+
+classFundepParser :: TokParser FunctionalDependency
+classFundepParser = withSpan $ do
+  determinedBy <- MP.many lowerIdentifierParser
+  expectedTok TkReservedRightArrow
+  determines <- MP.many lowerIdentifierParser
+  pure $ \span' ->
+    FunctionalDependency
+      { functionalDependencySpan = span',
+        functionalDependencyDeterminers = determinedBy,
+        functionalDependencyDetermined = determines
+      }
 
 classWhereClauseParser :: TokParser [ClassDeclItem]
 classWhereClauseParser = whereClauseItemsParser classItemsBracedParser classItemsPlainParser

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -613,10 +613,25 @@ prettyClassDecl decl =
               <> maybeContextPrefix (classDeclContext decl)
               <> [pretty (classDeclName decl)]
               <> map prettyTyVarBinder (classDeclParams decl)
+              <> prettyClassFundeps (classDeclFundeps decl)
           )
    in case classDeclItems decl of
         [] -> headDoc
         items -> headDoc <+> "where" <+> braces (hsep (punctuate semi (map prettyClassItem items)))
+
+prettyClassFundeps :: [FunctionalDependency] -> [Doc ann]
+prettyClassFundeps deps =
+  case deps of
+    [] -> []
+    _ -> ["|", hsep (punctuate comma (map prettyFunctionalDependency deps))]
+
+prettyFunctionalDependency :: FunctionalDependency -> Doc ann
+prettyFunctionalDependency dep =
+  hsep
+    [ hsep (map pretty (functionalDependencyDeterminers dep)),
+      "->",
+      hsep (map pretty (functionalDependencyDetermined dep))
+    ]
 
 maybeContextPrefix :: Maybe [Constraint] -> [Doc ann]
 maybeContextPrefix maybeConstraints =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -299,7 +299,16 @@ docClassDecl cd =
       [field "name" (docText (classDeclName cd))]
         <> optionalField "context" (brackets . hsep . punctuate comma . map docConstraint) (classDeclContext cd)
         <> listField "params" docTyVarBinder (classDeclParams cd)
+        <> listField "fundeps" docFunctionalDependency (classDeclFundeps cd)
         <> listField "items" docClassDeclItem (classDeclItems cd)
+
+docFunctionalDependency :: FunctionalDependency -> Doc ann
+docFunctionalDependency dep =
+  "FunctionalDependency" <+> braces (hsep (punctuate comma fields))
+  where
+    fields =
+      listField "determiners" docText (functionalDependencyDeterminers dep)
+        <> listField "determined" docText (functionalDependencyDetermined dep)
 
 docClassDeclItem :: ClassDeclItem -> Doc ann
 docClassDeclItem item =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -17,6 +17,7 @@ module Aihc.Parser.Syntax
     ClassDeclItem (..),
     CompStmt (..),
     Constraint (..),
+    FunctionalDependency (..),
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
@@ -740,12 +741,23 @@ data ClassDecl = ClassDecl
     classDeclContext :: Maybe [Constraint],
     classDeclName :: Text,
     classDeclParams :: [TyVarBinder],
+    classDeclFundeps :: [FunctionalDependency],
     classDeclItems :: [ClassDeclItem]
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan ClassDecl where
   getSourceSpan = classDeclSpan
+
+data FunctionalDependency = FunctionalDependency
+  { functionalDependencySpan :: SourceSpan,
+    functionalDependencyDeterminers :: [Text],
+    functionalDependencyDetermined :: [Text]
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
+instance HasSourceSpan FunctionalDependency where
+  getSourceSpan = functionalDependencySpan
 
 data ClassDeclItem
   = ClassItemTypeSig SourceSpan [BinderName] Type

--- a/components/aihc-parser/test/Test/Fixtures/FunctionalDependencies/fundep-empty-left.hs
+++ b/components/aihc-parser/test/Test/Fixtures/FunctionalDependencies/fundep-empty-left.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module FunctionalDependenciesEmptyLeft where
+
+class KeepRight a b | -> b where
+  keepRight :: a -> b

--- a/components/aihc-parser/test/Test/Fixtures/FunctionalDependencies/fundep-empty-right.hs
+++ b/components/aihc-parser/test/Test/Fixtures/FunctionalDependencies/fundep-empty-right.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module FunctionalDependenciesEmptyRight where
+
+class KeepLeft a b | a -> where
+  keepLeft :: a -> b -> a

--- a/components/aihc-parser/test/Test/Fixtures/FunctionalDependencies/manifest.tsv
+++ b/components/aihc-parser/test/Test/Fixtures/FunctionalDependencies/manifest.tsv
@@ -1,5 +1,7 @@
-fundep-single	declarations	fundep-single.hs	xfail	parser support pending
-fundep-bidirectional	declarations	fundep-bidirectional.hs	xfail	parser support pending
-fundep-multi-left	declarations	fundep-multi-left.hs	xfail	parser support pending
-fundep-class-instance	declarations	fundep-class-instance.hs	xfail	parser support pending
-fundep-with-context	declarations	fundep-with-context.hs	xfail	parser support pending
+fundep-single	declarations	fundep-single.hs	pass
+fundep-bidirectional	declarations	fundep-bidirectional.hs	pass
+fundep-multi-left	declarations	fundep-multi-left.hs	pass
+fundep-class-instance	declarations	fundep-class-instance.hs	pass
+fundep-with-context	declarations	fundep-with-context.hs	pass
+fundep-empty-right	declarations	fundep-empty-right.hs	pass
+fundep-empty-left	declarations	fundep-empty-left.hs	pass


### PR DESCRIPTION
## Summary
- implement parser support for class-head functional dependencies (`| ... -> ...`) in class declarations
- add AST support via `FunctionalDependency` and `classDeclFundeps`
- update pretty-printer and shorthand rendering to preserve/emit functional dependencies
- mark existing FunctionalDependencies fixtures as `pass` and add corner-case fixtures for empty-side fundeps

## Progress Counts
`nix run .#parser-extension-progress --`
- Supported: **33 -> 34**
- In Progress: **26 -> 25**
- Planned: **79 -> 79**
- FunctionalDependencies: **PASS 0 / XFAIL 5 / XPASS 0 / FAIL 0 -> PASS 7 / XFAIL 0 / XPASS 0 / FAIL 0**

## Validation
- `nix run .#parser-extension-progress -- | rg '^FunctionalDependencies\\b'`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)