### PR TITLE
fix: use lexModuleTokensWithExtensions in aihc-lexer

### DIFF
--- a/components/aihc-parser/app/aihc-lexer/Main.hs
+++ b/components/aihc-parser/app/aihc-lexer/Main.hs
@@ -2,7 +2,7 @@
 
 module Main (main) where
 
-import Aihc.Parser.Lex (lexTokensWithExtensions)
+import Aihc.Parser.Lex (lexModuleTokensWithExtensions)
 import Aihc.Parser.Shorthand (Shorthand (..))
 import Aihc.Parser.Syntax (Extension, ExtensionSetting (..), parseExtensionSettingName)
 import qualified Data.Text as T
@@ -18,7 +18,7 @@ main :: IO ()
 main = do
   opts <- execParser optionsParser
   input <- maybe TIO.getContents TIO.readFile (optInputFile opts)
-  let tokens = lexTokensWithExtensions (optExtensions opts) input
+  let tokens = lexModuleTokensWithExtensions (optExtensions opts) input
   mapM_ (print . shorthand) tokens
 
 optionsParser :: ParserInfo Options

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/char-literal.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/char-literal.yaml
@@ -1,4 +1,6 @@
 input: "'x'"
 output: |
+  TkSpecialLBrace
   TkChar 'x'
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/identifier.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/identifier.yaml
@@ -1,4 +1,6 @@
 input: "foo"
 output: |
+  TkSpecialLBrace
   TkVarId "foo"
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/multiple-tokens.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/multiple-tokens.yaml
@@ -1,6 +1,8 @@
 input: "foo + bar"
 output: |
+  TkSpecialLBrace
   TkVarId "foo"
   TkVarSym "+"
   TkVarId "bar"
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/negative-no-extension.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/negative-no-extension.yaml
@@ -1,5 +1,7 @@
 input: "-10"
 output: |
+  TkSpecialLBrace
   TkVarSym "-"
   TkInteger 10
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/simple-integer.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/simple-integer.yaml
@@ -1,4 +1,6 @@
 input: "42"
 output: |
+  TkSpecialLBrace
   TkInteger 42
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/string-literal.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/core/string-literal.yaml
@@ -1,4 +1,6 @@
-input: '"hello world"'
+input: "\"hello world\""
 output: |
+  TkSpecialLBrace
   TkString "hello world"
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/extensions/negative-literals.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/extensions/negative-literals.yaml
@@ -1,6 +1,7 @@
-args:
-  - "-XNegativeLiterals"
 input: "-10"
+args: ["-XNegativeLiterals"]
 output: |
+  TkSpecialLBrace
   TkInteger -10
+  TkSpecialRBrace
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/cli/lexer/extensions/numeric-underscores.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/cli/lexer/extensions/numeric-underscores.yaml
@@ -1,6 +1,7 @@
-args:
-  - "-XNumericUnderscores"
 input: "1_000_000"
+args: ["-XNumericUnderscores"]
 output: |
+  TkSpecialLBrace
   TkInteger 1000000
+  TkSpecialRBrace
 status: pass


### PR DESCRIPTION
This PR updates `aihc-lexer` to use `lexModuleTokensWithExtensions` instead of `lexTokensWithExtensions`. This ensures that top-level module layout (such as virtual braces and semicolons) is correctly handled when lexing Haskell source code.

Changes:
- Modified `components/aihc-parser/app/aihc-lexer/Main.hs` to use `lexModuleTokensWithExtensions`.
- Updated CLI lexer tests to reflect the inclusion of virtual braces:
  - `core/char-literal.yaml`
  - `core/identifier.yaml`
  - `core/multiple-tokens.yaml`
  - `core/negative-no-extension.yaml`
  - `core/simple-integer.yaml`
  - `core/string-literal.yaml`
  - `extensions/negative-literals.yaml`
  - `extensions/numeric-underscores.yaml`

Progress counts: No changes.
- PASS: 471
- XFAIL: 95
- TOTAL: 566
- COMPLETE: 83.21%
