### PR TITLE
test(parser): add more ImplicitParams oracle test cases

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/complicated-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/complicated-type.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST xfail complicated type signature with implicit params -}
+{-# LANGUAGE ImplicitParams #-}
+module ComplicatedType where
+
+sort :: (?cmp :: a -> a -> Bool) => [a] -> [a]
+sort [] = []
+sort (x:xs) = insert x (sort xs)
+  where
+    insert y [] = [y]
+    insert y (z:zs) = if ?cmp y z then y : z : zs else z : insert y zs

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/gadts.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/gadts.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail GADTs with implicit params -}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+module GADTsImplicitParams where
+
+data T where
+  MkT :: (?f :: Int) => T

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/infix-operators.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/infix-operators.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail infix operators with implicit params -}
+{-# LANGUAGE ImplicitParams #-}
+module InfixOperators where
+
+f t = let { ?x = t; ?y = ?x + 1 } in ?x + ?y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/let-bindings.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/let-bindings.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail let-bindings with implicit params -}
+{-# LANGUAGE ImplicitParams #-}
+module LetBindings where
+
+f t = let { ?x = t; ?y = ?x + (1::Int) } in ?x + ?y


### PR DESCRIPTION
## Summary

Add comprehensive xfail test cases for ImplicitParams extension to improve test coverage:

- Complicated type signatures with implicit params (sort function with custom comparison)
- Let-bindings with implicit params and type annotations
- GADTs with implicit parameter constraints
- Infix operators mixed with implicit params

All tests are marked as `xfail` since ImplicitParams is not yet supported by the parser.