### PR TITLE
test: add PartialTypeSignatures xfail tests

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/just1.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/just1.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in return type -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module Just1 where
+
+just1 :: _ Int
+just1 = Just 1

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/just2.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/just2.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in type application -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module Just2 where
+
+just2 :: Maybe _
+just2 = Just False

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/let-binding.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/let-binding.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail wildcard in let binding -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module LetBinding where
+
+x = let y :: _; y = False in y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/list1.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/list1.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in list type -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module List1 where
+
+list :: _ Int
+list = [1]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/list2.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/list2.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in list element type -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module List2 where
+
+list :: [_]
+list = [1]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/multi-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/multi-constraint.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in multi-constraint -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module MultiConstraint where
+
+x :: (Enum a, _) => a -> String
+x = show

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/pattern-wildcard.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/pattern-wildcard.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in pattern -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module PatternWildcard where
+
+foo :: _
+foo (x :: _) = (x :: _)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/qualified-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PartialTypeSignatures/qualified-constraint.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail wildcard in qualified constraint -}
+{-# LANGUAGE PartialTypeSignatures #-}
+module QualifiedConstraint where
+
+x :: _ => a -> String
+x = show

--- a/components/aihc-parser/test/Test/Fixtures/oracle/StandaloneDeriving/partial-type-sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/StandaloneDeriving/partial-type-sig.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail wildcard in deriving instance -}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+module PartialTypeSigDeriving where
+
+data Foo a = Foo a
+
+deriving instance _ => Eq (Foo a)


### PR DESCRIPTION
Add 9 xfail test cases for PartialTypeSignatures support:

- Wildcards in return types (`_ Int`)
- Wildcards in type applications (`Maybe _`)
- Wildcards in list types (`_ Int` and `[_]`)
- Wildcards in qualified constraints (`_ =>`)
- Wildcards in multi-constraint tuples (`(Enum a, _)`)
- Wildcards in let bindings
- Wildcards in pattern signatures
- Wildcards in standalone deriving instances

These are marked as xfail to track expected parse failures until parser support is implemented.