### PR TITLE
test(oracle): add 7 new parser failure test cases

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/list-promoted-kind.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/list-promoted-kind.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail list promoted kind -}
+{-# LANGUAGE DataKinds #-}
+module ListPromotedKind where
+
+import Data.Proxy
+fn :: Proxy (() ': '[])
+fn = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultiParamTypeClasses/lawful-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultiParamTypeClasses/lawful-instance.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail lawful instance with constraints -}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE ConstraintKinds         #-}
+{-# LANGUAGE UndecidableSuperclasses #-}
+module LawfulInstance where
+
+class c t => Lawful c t

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RecordWildCards/do-binding.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RecordWildCards/do-binding.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail record wildcard in do binding -}
+{-# LANGUAGE RecordWildCards #-}
+module DoBinding where
+
+x = do
+  Loc {..} <- location
+  pure ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RecordWildCards/function-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RecordWildCards/function-pattern.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail record wildcard in function pattern -}
+{-# LANGUAGE RecordWildCards #-}
+module FunctionPattern where
+
+data Record = Record { a :: Int, b :: Double }
+fn Record{..} = ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/existential-forall.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/existential-forall.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail existential with forall in type -}
+module ExistentialForall where
+
+toJSON ((f :: f a) :=> (g :: g a)) = ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/reserved-as.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/reserved-as.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail reserved keyword as identifier -}
+module ReservedKeywordAs where
+
+reserved :: as
+reserved = undefined
+
+arg as = as

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/patterns/nested-record.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/patterns/nested-record.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail pattern with nested record wildcard -}
+module PatternNestedRecord where
+
+delete (HKey k@(HKey' f _)) (HSet xs count) = ()


### PR DESCRIPTION
## Summary
Add 7 new oracle test cases for known parser failures covering:
- RecordWildCards in do bindings and function patterns
- DataKinds with promoted list types
- Reserved keywords used as identifiers
- Existential types with forall in patterns
- Nested record patterns
- MultiParamTypeClasses with constraint kinds

These are all expected to fail (`xfail`), documenting known parser limitations.