### PR TITLE
ci: add cabal-test-all nix check for full test parity

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1089,6 +1089,12 @@
         pkgs.runCommand "aihc-cabal-test-all" {
           src = cabalProjectSrc pkgs;
           nativeBuildInputs = [ghcEnv pkgs.cabal-install];
+          # Ensure UTF-8 locale on Linux (nix sandbox defaults to C locale
+          # which cannot decode Unicode test fixtures).
+          LANG = "C.UTF-8";
+          LOCALE_ARCHIVE =
+            pkgs.lib.optionalString pkgs.stdenv.isLinux
+            "${pkgs.glibcLocales}/lib/locale/locale-archive";
         } ''
           # Copy source to a writable location (nix store sources are read-only)
           cp -r "$src" ./build


### PR DESCRIPTION
## Summary

- Add a `cabal-test-all` check to `nix flake check` that runs `cabal test all` inside a nix derivation, ensuring nix exercises exactly the same test matrix as a local `cabal test all` invocation
- Add `cabalProjectSrc` source filter for the full multi-package cabal project
- Include all test dependencies (tasty, QuickCheck, haskell-src-exts, cpphs, etc.) in the GHC environment so cabal can resolve them offline

This guards against divergence between the per-package `callCabal2nix` checks and the multi-package cabal project. If a new test suite or package is added to `cabal.project` but not wired into the individual nix checks, this catch-all check will fail.

## Progress counts

No changes to progress counts.