### PR TITLE
feat(parser): implement DerivingVia language extension

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -385,6 +385,7 @@ standaloneDerivingDeclParser :: TokParser Decl
 standaloneDerivingDeclParser = withSpan $ do
   keywordTok TkKeywordDeriving
   strategy <- MP.optional derivingStrategyParser
+  viaTy <- MP.optional (MP.try derivingViaTypeParser)
   keywordTok TkKeywordInstance
   context <- MP.optional (MP.try (declContextParser <* expectedTok TkReservedDoubleArrow))
   className <- constructorIdentifierParser
@@ -397,7 +398,8 @@ standaloneDerivingDeclParser = withSpan $ do
           standaloneDerivingStrategy = strategy,
           standaloneDerivingContext = fromMaybe [] context,
           standaloneDerivingClassName = className,
-          standaloneDerivingTypes = instanceTypes
+          standaloneDerivingTypes = instanceTypes,
+          standaloneDerivingViaType = viaTy
         }
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]
@@ -700,10 +702,16 @@ derivingClauseParser = do
   keywordTok TkKeywordDeriving
   strategy <- MP.optional derivingStrategyParser
   classes <- parenClasses <|> singleClass
-  pure (DerivingClause strategy classes)
+  viaTy <- MP.optional derivingViaTypeParser
+  pure (DerivingClause strategy classes viaTy)
   where
     singleClass = (: []) <$> constraintParserWith typeAtomParser
     parenClasses = parens $ constraintParserWith typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma
+
+derivingViaTypeParser :: TokParser Type
+derivingViaTypeParser = do
+  varIdTok "via"
+  typeParser
 
 derivingStrategyParser :: TokParser DerivingStrategy
 derivingStrategyParser =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -486,8 +486,8 @@ derivingParts :: [DerivingClause] -> [Doc ann]
 derivingParts = concatMap derivingPart
 
 derivingPart :: DerivingClause -> [Doc ann]
-derivingPart (DerivingClause strategy classes) =
-  ["deriving"] <> strategyPart strategy <> classesPart classes
+derivingPart (DerivingClause strategy classes viaTy) =
+  ["deriving"] <> strategyPart strategy <> classesPart classes <> viaPart viaTy
   where
     strategyPart Nothing = []
     strategyPart (Just DerivingStock) = ["stock"]
@@ -499,6 +499,9 @@ derivingPart (DerivingClause strategy classes) =
       | Just DerivingStock <- strategy = [parens (prettyConstraint single)]
       | otherwise = [prettyConstraint single]
     classesPart _ = [parens (hsep (punctuate comma (map prettyConstraint classes)))]
+
+    viaPart Nothing = []
+    viaPart (Just ty) = ["via", prettyType ty]
 
 prettyDeclHead :: [Constraint] -> Text -> [TyVarBinder] -> Doc ann
 prettyDeclHead constraints name params =
@@ -682,6 +685,7 @@ prettyStandaloneDeriving decl =
   hsep
     ( ["deriving"]
         <> maybe [] (\s -> [prettyDerivingStrategy s]) (standaloneDerivingStrategy decl)
+        <> maybe [] (\ty -> ["via", prettyType ty]) (standaloneDerivingViaType decl)
         <> ["instance"]
         <> contextPrefix (standaloneDerivingContext decl)
         <> [pretty (standaloneDerivingClassName decl)]

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -283,6 +283,7 @@ docDerivingClause dc =
     fields =
       optionalField "strategy" docDerivingStrategy (derivingStrategy dc)
         <> listField "classes" docConstraint (derivingClasses dc)
+        <> optionalField "viaType" docType (derivingViaType dc)
 
 docDerivingStrategy :: DerivingStrategy -> Doc ann
 docDerivingStrategy ds =
@@ -343,6 +344,7 @@ docStandaloneDerivingDecl sd =
         <> optionalField "strategy" docDerivingStrategy (standaloneDerivingStrategy sd)
         <> listField "context" docConstraint (standaloneDerivingContext sd)
         <> [field "types" (brackets (hsep (punctuate comma (map docType (standaloneDerivingTypes sd)))))]
+        <> optionalField "viaType" docType (standaloneDerivingViaType sd)
 
 docForeignDecl :: ForeignDecl -> Doc ann
 docForeignDecl fd =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -922,7 +922,8 @@ instance HasSourceSpan FieldDecl where
 
 data DerivingClause = DerivingClause
   { derivingStrategy :: Maybe DerivingStrategy,
-    derivingClasses :: [Constraint]
+    derivingClasses :: [Constraint],
+    derivingViaType :: Maybe Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -937,7 +938,8 @@ data StandaloneDerivingDecl = StandaloneDerivingDecl
     standaloneDerivingStrategy :: Maybe DerivingStrategy,
     standaloneDerivingContext :: [Constraint],
     standaloneDerivingClassName :: Text,
-    standaloneDerivingTypes :: [Type]
+    standaloneDerivingTypes :: [Type],
+    standaloneDerivingViaType :: Maybe Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/multiple-classes.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/multiple-classes.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail deriving multiple classes via -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DerivingVia #-}
 module MultipleClasses where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/standalone.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/standalone.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail standalone deriving via -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StandaloneDeriving #-}
 module Standalone where


### PR DESCRIPTION
## Summary

- Implement the `DerivingVia` language extension in aihc-parser, enabling parsing of `deriving via Type` syntax in both regular deriving clauses and standalone deriving declarations.
- Update AST types (`DerivingClause`, `StandaloneDerivingDecl`), parser, pretty-printer, and shorthand golden output to support the new `via Type` clause.
- Promote two previously xfail test cases (`multiple-classes`, `standalone`) to pass, increasing oracle completion count.

## Test Results

All 4 DerivingVia test cases now pass:
- `basic.hs`: `deriving Show via Int`
- `complex-via.hs`: `deriving Eq via (Maybe a)`
- `multiple-classes.hs`: `deriving (Eq, Ord) via Int`
- `standalone.hs`: `deriving via Int instance Show MyInt`

Full suite: `nix flake check` passes with no regressions.