### PR TITLE
fix(parser): accept constraint kind superclass heads

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -319,7 +319,7 @@ constraintParserWith typeAtomParser =
   MP.try parenthesizedConstraintParser <|> bareConstraintParser
   where
     bareConstraintParser = withSpan $ do
-      className <- constructorIdentifierParser
+      className <- identifierTextParser
       args <- MP.many typeAtomParser
       pure $ \span' ->
         Constraint

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1167,4 +1167,5 @@ prettySplice :: Doc ann -> Expr -> Doc ann
 prettySplice prefix body =
   case body of
     EParen _ inner -> prefix <> parens (prettyExprPrec 0 inner)
-    _ -> prefix <> prettyExprPrec 11 body
+    EVar {} -> prefix <> prettyExprPrec 11 body
+    _ -> prefix <> parens (prettyExprPrec 0 body)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultiParamTypeClasses/lawful-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultiParamTypeClasses/lawful-instance.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail lawful instance with constraints -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE MultiParamTypeClasses   #-}
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE ConstraintKinds         #-}


### PR DESCRIPTION
## Summary
- allow lowercase constraint heads in declaration contexts so `ConstraintKinds` superclasses like `class c t => Lawful c t` parse successfully
- preserve typed Template Haskell splice roundtrips by parenthesizing non-variable splice bodies during pretty-printing
- parser progress: PASS 520, XFAIL 86, XPASS 0, FAIL 0, COMPLETE 85.8%

## Validation
- `cabal test spec` in `components/aihc-parser`
- `cabal test parser-quickcheck-tests` in `components/aihc-parser`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)
