### PR TITLE
test(parser): move round-trip generators to bare syntax

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -59,9 +59,10 @@ test-suite spec
     , Test.ErrorMessages.Suite
     , Test.Oracle.Suite
     , Test.ExtensionMapping.Suite
-    , Test.HackageTester.Suite
-    , Test.Lexer.Suite
-    , Test.Properties.ExprHelpers
+     , Test.HackageTester.Suite
+     , Test.Lexer.Suite
+     , Test.Properties.BareSyntax
+     , Test.Properties.ExprHelpers
     , Test.Properties.ExprRoundTrip
     , Test.Properties.ModuleRoundTrip
     , Test.Properties.Identifiers
@@ -130,10 +131,11 @@ executable parser-quickcheck-batch
   other-modules:
       CppSupport
     , ParserQuickCheck.CLI
-    , ParserQuickCheck.Registry
-    , ParserQuickCheck.Runner
-    , ParserQuickCheck.Types
-    , Test.Properties.ExprHelpers
+     , ParserQuickCheck.Registry
+     , ParserQuickCheck.Runner
+     , ParserQuickCheck.Types
+     , Test.Properties.BareSyntax
+     , Test.Properties.ExprHelpers
     , Test.Properties.ExprRoundTrip
     , Test.Properties.ModuleRoundTrip
     , Test.Properties.Identifiers

--- a/components/aihc-parser/test/Test/Properties/BareSyntax.hs
+++ b/components/aihc-parser/test/Test/Properties/BareSyntax.hs
@@ -1,0 +1,788 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Test.Properties.BareSyntax
+  ( Module (..),
+    ModuleHead (..),
+    WarningText (..),
+    ExportSpec (..),
+    ImportDecl (..),
+    ImportSpec (..),
+    ImportItem (..),
+    Decl (..),
+    ValueDecl (..),
+    Match (..),
+    Rhs (..),
+    GuardedRhs (..),
+    GuardQualifier (..),
+    Literal (..),
+    Pattern (..),
+    Type (..),
+    Constraint (..),
+    Expr (..),
+    TypeLiteral (..),
+    TypePromotion (..),
+    TupleFlavor (..),
+    MatchHeadForm (..),
+    ImportLevel (..),
+    CaseAlt (..),
+    DoStmt (..),
+    CompStmt (..),
+    ArithSeq (..),
+    moduleName,
+    moduleWarningText,
+    moduleExports,
+    toSyntaxModule,
+    toSyntaxExpr,
+    toSyntaxPattern,
+    toSyntaxType,
+    eraseModule,
+    eraseExpr,
+    erasePattern,
+    eraseType,
+  )
+where
+
+import Aihc.Parser.Syntax
+  ( ExtensionSetting,
+    ImportLevel (..),
+    MatchHeadForm (..),
+    TupleFlavor (..),
+    TypeLiteral (..),
+    TypePromotion (..),
+  )
+import qualified Aihc.Parser.Syntax as Syntax
+import Control.DeepSeq (NFData)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+data WarningText
+  = DeprText Text
+  | WarnText Text
+  deriving (Eq, Show, Generic, NFData)
+
+data Module = Module
+  { moduleHead :: Maybe ModuleHead,
+    moduleLanguagePragmas :: [ExtensionSetting],
+    moduleImports :: [ImportDecl],
+    moduleDecls :: [Decl]
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data ModuleHead = ModuleHead
+  { moduleHeadName :: Text,
+    moduleHeadWarningText :: Maybe WarningText,
+    moduleHeadExports :: Maybe [ExportSpec]
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+moduleName :: Module -> Maybe Text
+moduleName modu = moduleHeadName <$> moduleHead modu
+
+moduleWarningText :: Module -> Maybe WarningText
+moduleWarningText modu = moduleHeadWarningText =<< moduleHead modu
+
+moduleExports :: Module -> Maybe [ExportSpec]
+moduleExports modu = moduleHeadExports =<< moduleHead modu
+
+data ExportSpec
+  = ExportModule Text
+  | ExportVar (Maybe Text) Text
+  | ExportAbs (Maybe Text) Text
+  | ExportAll (Maybe Text) Text
+  | ExportWith (Maybe Text) Text [Text]
+  deriving (Eq, Show, Generic, NFData)
+
+data ImportDecl = ImportDecl
+  { importDeclLevel :: Maybe ImportLevel,
+    importDeclPackage :: Maybe Text,
+    importDeclQualified :: Bool,
+    importDeclQualifiedPost :: Bool,
+    importDeclModule :: Text,
+    importDeclAs :: Maybe Text,
+    importDeclSpec :: Maybe ImportSpec
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data ImportSpec = ImportSpec
+  { importSpecHiding :: Bool,
+    importSpecItems :: [ImportItem]
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data ImportItem
+  = ImportItemVar (Maybe Text) Text
+  | ImportItemAbs (Maybe Text) Text
+  | ImportItemAll (Maybe Text) Text
+  | ImportItemWith (Maybe Text) Text [Text]
+  deriving (Eq, Show, Generic, NFData)
+
+data Decl
+  = DeclValue ValueDecl
+  | DeclTypeSig [Text] Type
+  deriving (Eq, Show, Generic, NFData)
+
+data ValueDecl
+  = FunctionBind Text [Match]
+  | PatternBind Pattern Rhs
+  deriving (Eq, Show, Generic, NFData)
+
+data Match = Match
+  { matchHeadForm :: MatchHeadForm,
+    matchPats :: [Pattern],
+    matchRhs :: Rhs
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data Rhs
+  = UnguardedRhs Expr
+  | GuardedRhss [GuardedRhs]
+  deriving (Eq, Show, Generic, NFData)
+
+data GuardedRhs = GuardedRhs
+  { guardedRhsGuards :: [GuardQualifier],
+    guardedRhsBody :: Expr
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data GuardQualifier
+  = GuardExpr Expr
+  | GuardPat Pattern Expr
+  | GuardLet [Decl]
+  deriving (Eq, Show, Generic, NFData)
+
+data Literal
+  = LitInt Integer Text
+  | LitIntHash Integer Text
+  | LitIntBase Integer Text
+  | LitIntBaseHash Integer Text
+  | LitFloat Double Text
+  | LitFloatHash Double Text
+  | LitChar Char Text
+  | LitCharHash Char Text
+  | LitString Text Text
+  | LitStringHash Text Text
+  deriving (Eq, Show, Generic, NFData)
+
+data Pattern
+  = PVar Text
+  | PWildcard
+  | PLit Literal
+  | PQuasiQuote Text Text
+  | PTuple TupleFlavor [Pattern]
+  | PUnboxedSum Int Int Pattern
+  | PList [Pattern]
+  | PCon Text [Pattern]
+  | PInfix Pattern Text Pattern
+  | PView Expr Pattern
+  | PAs Text Pattern
+  | PStrict Pattern
+  | PIrrefutable Pattern
+  | PNegLit Literal
+  | PParen Pattern
+  | PRecord Text [(Text, Pattern)] Bool
+  | PTypeSig Pattern Type
+  | PSplice Expr
+  deriving (Eq, Show, Generic, NFData)
+
+data Type
+  = TVar Text
+  | TCon Text TypePromotion
+  | TTypeLit TypeLiteral
+  | TStar
+  | TQuasiQuote Text Text
+  | TForall [Text] Type
+  | TApp Type Type
+  | TFun Type Type
+  | TTuple TupleFlavor TypePromotion [Type]
+  | TUnboxedSum [Type]
+  | TList TypePromotion Type
+  | TParen Type
+  | TContext [Constraint] Type
+  | TSplice Expr
+  deriving (Eq, Show, Generic, NFData)
+
+data Constraint
+  = Constraint
+      { constraintClass :: Text,
+        constraintArgs :: [Type]
+      }
+  | CParen
+      { constraintInner :: Constraint
+      }
+  deriving (Eq, Show, Generic, NFData)
+
+data Expr
+  = EVar Text
+  | EInt Integer Text
+  | EIntHash Integer Text
+  | EIntBase Integer Text
+  | EIntBaseHash Integer Text
+  | EFloat Double Text
+  | EFloatHash Double Text
+  | EChar Char Text
+  | ECharHash Char Text
+  | EString Text Text
+  | EStringHash Text Text
+  | EQuasiQuote Text Text
+  | EIf Expr Expr Expr
+  | EMultiWayIf [GuardedRhs]
+  | ELambdaPats [Pattern] Expr
+  | ELambdaCase [CaseAlt]
+  | EInfix Expr Text Expr
+  | ENegate Expr
+  | ESectionL Expr Text
+  | ESectionR Text Expr
+  | ELetDecls [Decl] Expr
+  | ECase Expr [CaseAlt]
+  | EDo [DoStmt]
+  | EListComp Expr [CompStmt]
+  | EListCompParallel Expr [[CompStmt]]
+  | EArithSeq ArithSeq
+  | ERecordCon Text [(Text, Expr)] Bool
+  | ERecordUpd Expr [(Text, Expr)]
+  | ETypeSig Expr Type
+  | EParen Expr
+  | EWhereDecls Expr [Decl]
+  | EList [Expr]
+  | ETuple TupleFlavor [Expr]
+  | ETupleSection TupleFlavor [Maybe Expr]
+  | ETupleCon TupleFlavor Int
+  | EUnboxedSum Int Int Expr
+  | ETypeApp Expr Type
+  | EApp Expr Expr
+  | ETHExpQuote Expr
+  | ETHTypedQuote Expr
+  | ETHDeclQuote [Decl]
+  | ETHTypeQuote Type
+  | ETHPatQuote Pattern
+  | ETHNameQuote Text
+  | ETHTypeNameQuote Text
+  | ETHSplice Expr
+  | ETHTypedSplice Expr
+  deriving (Eq, Show, Generic, NFData)
+
+data CaseAlt = CaseAlt
+  { caseAltPattern :: Pattern,
+    caseAltRhs :: Rhs
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data DoStmt
+  = DoBind Pattern Expr
+  | DoLet [(Text, Expr)]
+  | DoLetDecls [Decl]
+  | DoExpr Expr
+  deriving (Eq, Show, Generic, NFData)
+
+data CompStmt
+  = CompGen Pattern Expr
+  | CompGuard Expr
+  | CompLet [(Text, Expr)]
+  | CompLetDecls [Decl]
+  deriving (Eq, Show, Generic, NFData)
+
+data ArithSeq
+  = ArithSeqFrom Expr
+  | ArithSeqFromThen Expr Expr
+  | ArithSeqFromTo Expr Expr
+  | ArithSeqFromThenTo Expr Expr Expr
+  deriving (Eq, Show, Generic, NFData)
+
+span0 :: Syntax.SourceSpan
+span0 = Syntax.noSourceSpan
+
+toSyntaxWarningText :: WarningText -> Syntax.WarningText
+toSyntaxWarningText warningText =
+  case warningText of
+    DeprText msg -> Syntax.DeprText span0 msg
+    WarnText msg -> Syntax.WarnText span0 msg
+
+toSyntaxModuleHead :: ModuleHead -> Syntax.ModuleHead
+toSyntaxModuleHead head' =
+  Syntax.ModuleHead
+    { Syntax.moduleHeadSpan = span0,
+      Syntax.moduleHeadName = moduleHeadName head',
+      Syntax.moduleHeadWarningText = toSyntaxWarningText <$> moduleHeadWarningText head',
+      Syntax.moduleHeadExports = fmap (map toSyntaxExportSpec) (moduleHeadExports head')
+    }
+
+toSyntaxModule :: Module -> Syntax.Module
+toSyntaxModule modu =
+  Syntax.Module
+    { Syntax.moduleSpan = span0,
+      Syntax.moduleHead = toSyntaxModuleHead <$> moduleHead modu,
+      Syntax.moduleLanguagePragmas = moduleLanguagePragmas modu,
+      Syntax.moduleImports = map toSyntaxImportDecl (moduleImports modu),
+      Syntax.moduleDecls = map toSyntaxDecl (moduleDecls modu)
+    }
+
+toSyntaxExportSpec :: ExportSpec -> Syntax.ExportSpec
+toSyntaxExportSpec spec =
+  case spec of
+    ExportModule modName -> Syntax.ExportModule span0 modName
+    ExportVar namespace name -> Syntax.ExportVar span0 namespace name
+    ExportAbs namespace name -> Syntax.ExportAbs span0 namespace name
+    ExportAll namespace name -> Syntax.ExportAll span0 namespace name
+    ExportWith namespace name members -> Syntax.ExportWith span0 namespace name members
+
+toSyntaxImportDecl :: ImportDecl -> Syntax.ImportDecl
+toSyntaxImportDecl decl =
+  Syntax.ImportDecl
+    { Syntax.importDeclSpan = span0,
+      Syntax.importDeclLevel = importDeclLevel decl,
+      Syntax.importDeclPackage = importDeclPackage decl,
+      Syntax.importDeclQualified = importDeclQualified decl,
+      Syntax.importDeclQualifiedPost = importDeclQualifiedPost decl,
+      Syntax.importDeclModule = importDeclModule decl,
+      Syntax.importDeclAs = importDeclAs decl,
+      Syntax.importDeclSpec = toSyntaxImportSpec <$> importDeclSpec decl
+    }
+
+toSyntaxImportSpec :: ImportSpec -> Syntax.ImportSpec
+toSyntaxImportSpec spec =
+  Syntax.ImportSpec
+    { Syntax.importSpecSpan = span0,
+      Syntax.importSpecHiding = importSpecHiding spec,
+      Syntax.importSpecItems = map toSyntaxImportItem (importSpecItems spec)
+    }
+
+toSyntaxImportItem :: ImportItem -> Syntax.ImportItem
+toSyntaxImportItem item =
+  case item of
+    ImportItemVar namespace name -> Syntax.ImportItemVar span0 namespace name
+    ImportItemAbs namespace name -> Syntax.ImportItemAbs span0 namespace name
+    ImportItemAll namespace name -> Syntax.ImportItemAll span0 namespace name
+    ImportItemWith namespace name members -> Syntax.ImportItemWith span0 namespace name members
+
+toSyntaxDecl :: Decl -> Syntax.Decl
+toSyntaxDecl decl =
+  case decl of
+    DeclValue valueDecl -> Syntax.DeclValue span0 (toSyntaxValueDecl valueDecl)
+    DeclTypeSig names ty -> Syntax.DeclTypeSig span0 names (toSyntaxType ty)
+
+toSyntaxValueDecl :: ValueDecl -> Syntax.ValueDecl
+toSyntaxValueDecl valueDecl =
+  case valueDecl of
+    FunctionBind name matches -> Syntax.FunctionBind span0 name (map toSyntaxMatch matches)
+    PatternBind pat rhs -> Syntax.PatternBind span0 (toSyntaxPattern pat) (toSyntaxRhs rhs)
+
+toSyntaxMatch :: Match -> Syntax.Match
+toSyntaxMatch match =
+  Syntax.Match
+    { Syntax.matchSpan = span0,
+      Syntax.matchHeadForm = matchHeadForm match,
+      Syntax.matchPats = map toSyntaxPattern (matchPats match),
+      Syntax.matchRhs = toSyntaxRhs (matchRhs match)
+    }
+
+toSyntaxRhs :: Rhs -> Syntax.Rhs
+toSyntaxRhs rhs =
+  case rhs of
+    UnguardedRhs expr -> Syntax.UnguardedRhs span0 (toSyntaxExpr expr)
+    GuardedRhss rhss -> Syntax.GuardedRhss span0 (map toSyntaxGuardedRhs rhss)
+
+toSyntaxGuardedRhs :: GuardedRhs -> Syntax.GuardedRhs
+toSyntaxGuardedRhs grhs =
+  Syntax.GuardedRhs
+    { Syntax.guardedRhsSpan = span0,
+      Syntax.guardedRhsGuards = map toSyntaxGuardQualifier (guardedRhsGuards grhs),
+      Syntax.guardedRhsBody = toSyntaxExpr (guardedRhsBody grhs)
+    }
+
+toSyntaxGuardQualifier :: GuardQualifier -> Syntax.GuardQualifier
+toSyntaxGuardQualifier qualifier =
+  case qualifier of
+    GuardExpr expr -> Syntax.GuardExpr span0 (toSyntaxExpr expr)
+    GuardPat pat expr -> Syntax.GuardPat span0 (toSyntaxPattern pat) (toSyntaxExpr expr)
+    GuardLet decls -> Syntax.GuardLet span0 (map toSyntaxDecl decls)
+
+toSyntaxLiteral :: Literal -> Syntax.Literal
+toSyntaxLiteral lit =
+  case lit of
+    LitInt value repr -> Syntax.LitInt span0 value repr
+    LitIntHash value repr -> Syntax.LitIntHash span0 value repr
+    LitIntBase value repr -> Syntax.LitIntBase span0 value repr
+    LitIntBaseHash value repr -> Syntax.LitIntBaseHash span0 value repr
+    LitFloat value repr -> Syntax.LitFloat span0 value repr
+    LitFloatHash value repr -> Syntax.LitFloatHash span0 value repr
+    LitChar value repr -> Syntax.LitChar span0 value repr
+    LitCharHash value repr -> Syntax.LitCharHash span0 value repr
+    LitString value repr -> Syntax.LitString span0 value repr
+    LitStringHash value repr -> Syntax.LitStringHash span0 value repr
+
+toSyntaxPattern :: Pattern -> Syntax.Pattern
+toSyntaxPattern pat =
+  case pat of
+    PVar name -> Syntax.PVar span0 name
+    PWildcard -> Syntax.PWildcard span0
+    PLit lit -> Syntax.PLit span0 (toSyntaxLiteral lit)
+    PQuasiQuote quoter body -> Syntax.PQuasiQuote span0 quoter body
+    PTuple tupleFlavor elems -> Syntax.PTuple span0 tupleFlavor (map toSyntaxPattern elems)
+    PUnboxedSum altIdx arity inner -> Syntax.PUnboxedSum span0 altIdx arity (toSyntaxPattern inner)
+    PList elems -> Syntax.PList span0 (map toSyntaxPattern elems)
+    PCon con args -> Syntax.PCon span0 con (map toSyntaxPattern args)
+    PInfix lhs op rhs -> Syntax.PInfix span0 (toSyntaxPattern lhs) op (toSyntaxPattern rhs)
+    PView expr inner -> Syntax.PView span0 (toSyntaxExpr expr) (toSyntaxPattern inner)
+    PAs name inner -> Syntax.PAs span0 name (toSyntaxPattern inner)
+    PStrict inner -> Syntax.PStrict span0 (toSyntaxPattern inner)
+    PIrrefutable inner -> Syntax.PIrrefutable span0 (toSyntaxPattern inner)
+    PNegLit lit -> Syntax.PNegLit span0 (toSyntaxLiteral lit)
+    PParen inner -> Syntax.PParen span0 (toSyntaxPattern inner)
+    PRecord con fields rwc -> Syntax.PRecord span0 con [(name, toSyntaxPattern fieldPat) | (name, fieldPat) <- fields] rwc
+    PTypeSig inner ty -> Syntax.PTypeSig span0 (toSyntaxPattern inner) (toSyntaxType ty)
+    PSplice body -> Syntax.PSplice span0 (toSyntaxExpr body)
+
+toSyntaxType :: Type -> Syntax.Type
+toSyntaxType ty =
+  case ty of
+    TVar name -> Syntax.TVar span0 name
+    TCon name promoted -> Syntax.TCon span0 name promoted
+    TTypeLit lit -> Syntax.TTypeLit span0 lit
+    TStar -> Syntax.TStar span0
+    TQuasiQuote quoter body -> Syntax.TQuasiQuote span0 quoter body
+    TForall binders inner -> Syntax.TForall span0 binders (toSyntaxType inner)
+    TApp fn arg -> Syntax.TApp span0 (toSyntaxType fn) (toSyntaxType arg)
+    TFun lhs rhs -> Syntax.TFun span0 (toSyntaxType lhs) (toSyntaxType rhs)
+    TTuple tupleFlavor promoted elems -> Syntax.TTuple span0 tupleFlavor promoted (map toSyntaxType elems)
+    TUnboxedSum elems -> Syntax.TUnboxedSum span0 (map toSyntaxType elems)
+    TList promoted inner -> Syntax.TList span0 promoted (toSyntaxType inner)
+    TParen inner -> Syntax.TParen span0 (toSyntaxType inner)
+    TContext constraints inner -> Syntax.TContext span0 (map toSyntaxConstraint constraints) (toSyntaxType inner)
+    TSplice body -> Syntax.TSplice span0 (toSyntaxExpr body)
+
+toSyntaxConstraint :: Constraint -> Syntax.Constraint
+toSyntaxConstraint constraint =
+  case constraint of
+    Constraint cls args ->
+      Syntax.Constraint
+        { Syntax.constraintSpan = span0,
+          Syntax.constraintClass = cls,
+          Syntax.constraintArgs = map toSyntaxType args
+        }
+    CParen inner -> Syntax.CParen span0 (toSyntaxConstraint inner)
+
+toSyntaxExpr :: Expr -> Syntax.Expr
+toSyntaxExpr expr =
+  case expr of
+    EVar name -> Syntax.EVar span0 name
+    EInt value repr -> Syntax.EInt span0 value repr
+    EIntHash value repr -> Syntax.EIntHash span0 value repr
+    EIntBase value repr -> Syntax.EIntBase span0 value repr
+    EIntBaseHash value repr -> Syntax.EIntBaseHash span0 value repr
+    EFloat value repr -> Syntax.EFloat span0 value repr
+    EFloatHash value repr -> Syntax.EFloatHash span0 value repr
+    EChar value repr -> Syntax.EChar span0 value repr
+    ECharHash value repr -> Syntax.ECharHash span0 value repr
+    EString value repr -> Syntax.EString span0 value repr
+    EStringHash value repr -> Syntax.EStringHash span0 value repr
+    EQuasiQuote quoter body -> Syntax.EQuasiQuote span0 quoter body
+    EIf cond yes no -> Syntax.EIf span0 (toSyntaxExpr cond) (toSyntaxExpr yes) (toSyntaxExpr no)
+    EMultiWayIf rhss -> Syntax.EMultiWayIf span0 (map toSyntaxGuardedRhs rhss)
+    ELambdaPats pats body -> Syntax.ELambdaPats span0 (map toSyntaxPattern pats) (toSyntaxExpr body)
+    ELambdaCase alts -> Syntax.ELambdaCase span0 (map toSyntaxCaseAlt alts)
+    EInfix lhs op rhs -> Syntax.EInfix span0 (toSyntaxExpr lhs) op (toSyntaxExpr rhs)
+    ENegate inner -> Syntax.ENegate span0 (toSyntaxExpr inner)
+    ESectionL inner op -> Syntax.ESectionL span0 (toSyntaxExpr inner) op
+    ESectionR op inner -> Syntax.ESectionR span0 op (toSyntaxExpr inner)
+    ELetDecls decls body -> Syntax.ELetDecls span0 (map toSyntaxDecl decls) (toSyntaxExpr body)
+    ECase scrutinee alts -> Syntax.ECase span0 (toSyntaxExpr scrutinee) (map toSyntaxCaseAlt alts)
+    EDo stmts -> Syntax.EDo span0 (map toSyntaxDoStmt stmts)
+    EListComp body stmts -> Syntax.EListComp span0 (toSyntaxExpr body) (map toSyntaxCompStmt stmts)
+    EListCompParallel body stmtss -> Syntax.EListCompParallel span0 (toSyntaxExpr body) (map (map toSyntaxCompStmt) stmtss)
+    EArithSeq seq' -> Syntax.EArithSeq span0 (toSyntaxArithSeq seq')
+    ERecordCon con fields rwc -> Syntax.ERecordCon span0 con [(name, toSyntaxExpr fieldExpr) | (name, fieldExpr) <- fields] rwc
+    ERecordUpd target fields -> Syntax.ERecordUpd span0 (toSyntaxExpr target) [(name, toSyntaxExpr fieldExpr) | (name, fieldExpr) <- fields]
+    ETypeSig inner ty -> Syntax.ETypeSig span0 (toSyntaxExpr inner) (toSyntaxType ty)
+    EParen inner -> Syntax.EParen span0 (toSyntaxExpr inner)
+    EWhereDecls body decls -> Syntax.EWhereDecls span0 (toSyntaxExpr body) (map toSyntaxDecl decls)
+    EList elems -> Syntax.EList span0 (map toSyntaxExpr elems)
+    ETuple tupleFlavor elems -> Syntax.ETuple span0 tupleFlavor (map toSyntaxExpr elems)
+    ETupleSection tupleFlavor elems -> Syntax.ETupleSection span0 tupleFlavor (map (fmap toSyntaxExpr) elems)
+    ETupleCon tupleFlavor n -> Syntax.ETupleCon span0 tupleFlavor n
+    EUnboxedSum altIdx arity inner -> Syntax.EUnboxedSum span0 altIdx arity (toSyntaxExpr inner)
+    ETypeApp inner ty -> Syntax.ETypeApp span0 (toSyntaxExpr inner) (toSyntaxType ty)
+    EApp fn arg -> Syntax.EApp span0 (toSyntaxExpr fn) (toSyntaxExpr arg)
+    ETHExpQuote body -> Syntax.ETHExpQuote span0 (toSyntaxExpr body)
+    ETHTypedQuote body -> Syntax.ETHTypedQuote span0 (toSyntaxExpr body)
+    ETHDeclQuote decls -> Syntax.ETHDeclQuote span0 (map toSyntaxDecl decls)
+    ETHTypeQuote ty -> Syntax.ETHTypeQuote span0 (toSyntaxType ty)
+    ETHPatQuote pat -> Syntax.ETHPatQuote span0 (toSyntaxPattern pat)
+    ETHNameQuote name -> Syntax.ETHNameQuote span0 name
+    ETHTypeNameQuote name -> Syntax.ETHTypeNameQuote span0 name
+    ETHSplice body -> Syntax.ETHSplice span0 (toSyntaxExpr body)
+    ETHTypedSplice body -> Syntax.ETHTypedSplice span0 (toSyntaxExpr body)
+
+toSyntaxCaseAlt :: CaseAlt -> Syntax.CaseAlt
+toSyntaxCaseAlt alt =
+  Syntax.CaseAlt
+    { Syntax.caseAltSpan = span0,
+      Syntax.caseAltPattern = toSyntaxPattern (caseAltPattern alt),
+      Syntax.caseAltRhs = toSyntaxRhs (caseAltRhs alt)
+    }
+
+toSyntaxDoStmt :: DoStmt -> Syntax.DoStmt
+toSyntaxDoStmt stmt =
+  case stmt of
+    DoBind pat expr -> Syntax.DoBind span0 (toSyntaxPattern pat) (toSyntaxExpr expr)
+    DoLet bindings -> Syntax.DoLet span0 [(name, toSyntaxExpr expr) | (name, expr) <- bindings]
+    DoLetDecls decls -> Syntax.DoLetDecls span0 (map toSyntaxDecl decls)
+    DoExpr expr -> Syntax.DoExpr span0 (toSyntaxExpr expr)
+
+toSyntaxCompStmt :: CompStmt -> Syntax.CompStmt
+toSyntaxCompStmt stmt =
+  case stmt of
+    CompGen pat expr -> Syntax.CompGen span0 (toSyntaxPattern pat) (toSyntaxExpr expr)
+    CompGuard expr -> Syntax.CompGuard span0 (toSyntaxExpr expr)
+    CompLet bindings -> Syntax.CompLet span0 [(name, toSyntaxExpr expr) | (name, expr) <- bindings]
+    CompLetDecls decls -> Syntax.CompLetDecls span0 (map toSyntaxDecl decls)
+
+toSyntaxArithSeq :: ArithSeq -> Syntax.ArithSeq
+toSyntaxArithSeq seq' =
+  case seq' of
+    ArithSeqFrom from -> Syntax.ArithSeqFrom span0 (toSyntaxExpr from)
+    ArithSeqFromThen from thenE -> Syntax.ArithSeqFromThen span0 (toSyntaxExpr from) (toSyntaxExpr thenE)
+    ArithSeqFromTo from to -> Syntax.ArithSeqFromTo span0 (toSyntaxExpr from) (toSyntaxExpr to)
+    ArithSeqFromThenTo from thenE to -> Syntax.ArithSeqFromThenTo span0 (toSyntaxExpr from) (toSyntaxExpr thenE) (toSyntaxExpr to)
+
+eraseWarningText :: Syntax.WarningText -> WarningText
+eraseWarningText warningText =
+  case warningText of
+    Syntax.DeprText _ msg -> DeprText msg
+    Syntax.WarnText _ msg -> WarnText msg
+
+eraseModule :: Syntax.Module -> Module
+eraseModule modu =
+  Module
+    { moduleHead = eraseModuleHead <$> Syntax.moduleHead modu,
+      moduleLanguagePragmas = Syntax.moduleLanguagePragmas modu,
+      moduleImports = map eraseImportDecl (Syntax.moduleImports modu),
+      moduleDecls = map eraseDecl (Syntax.moduleDecls modu)
+    }
+
+eraseModuleHead :: Syntax.ModuleHead -> ModuleHead
+eraseModuleHead head' =
+  ModuleHead
+    { moduleHeadName = Syntax.moduleHeadName head',
+      moduleHeadWarningText = eraseWarningText <$> Syntax.moduleHeadWarningText head',
+      moduleHeadExports = fmap (map eraseExportSpec) (Syntax.moduleHeadExports head')
+    }
+
+eraseExportSpec :: Syntax.ExportSpec -> ExportSpec
+eraseExportSpec spec =
+  case spec of
+    Syntax.ExportModule _ modName -> ExportModule modName
+    Syntax.ExportVar _ namespace name -> ExportVar namespace name
+    Syntax.ExportAbs _ namespace name -> ExportAbs namespace name
+    Syntax.ExportAll _ namespace name -> ExportAll namespace name
+    Syntax.ExportWith _ namespace name members -> ExportWith namespace name members
+
+eraseImportDecl :: Syntax.ImportDecl -> ImportDecl
+eraseImportDecl decl =
+  ImportDecl
+    { importDeclLevel = Syntax.importDeclLevel decl,
+      importDeclPackage = Syntax.importDeclPackage decl,
+      importDeclQualified = Syntax.importDeclQualified decl,
+      importDeclQualifiedPost = Syntax.importDeclQualifiedPost decl,
+      importDeclModule = Syntax.importDeclModule decl,
+      importDeclAs = Syntax.importDeclAs decl,
+      importDeclSpec = eraseImportSpec <$> Syntax.importDeclSpec decl
+    }
+
+eraseImportSpec :: Syntax.ImportSpec -> ImportSpec
+eraseImportSpec spec =
+  ImportSpec
+    { importSpecHiding = Syntax.importSpecHiding spec,
+      importSpecItems = map eraseImportItem (Syntax.importSpecItems spec)
+    }
+
+eraseImportItem :: Syntax.ImportItem -> ImportItem
+eraseImportItem item =
+  case item of
+    Syntax.ImportItemVar _ namespace name -> ImportItemVar namespace name
+    Syntax.ImportItemAbs _ namespace name -> ImportItemAbs namespace name
+    Syntax.ImportItemAll _ namespace name -> ImportItemAll namespace name
+    Syntax.ImportItemWith _ namespace name members -> ImportItemWith namespace name members
+
+eraseDecl :: Syntax.Decl -> Decl
+eraseDecl decl =
+  case decl of
+    Syntax.DeclValue _ valueDecl -> DeclValue (eraseValueDecl valueDecl)
+    Syntax.DeclTypeSig _ names ty -> DeclTypeSig names (eraseType ty)
+    _ -> error "eraseDecl: unsupported declaration outside generated subset"
+
+eraseValueDecl :: Syntax.ValueDecl -> ValueDecl
+eraseValueDecl valueDecl =
+  case valueDecl of
+    Syntax.FunctionBind _ name matches -> FunctionBind name (map eraseMatch matches)
+    Syntax.PatternBind _ pat rhs -> PatternBind (erasePattern pat) (eraseRhs rhs)
+
+eraseMatch :: Syntax.Match -> Match
+eraseMatch match =
+  Match
+    { matchHeadForm = Syntax.matchHeadForm match,
+      matchPats = map erasePattern (Syntax.matchPats match),
+      matchRhs = eraseRhs (Syntax.matchRhs match)
+    }
+
+eraseRhs :: Syntax.Rhs -> Rhs
+eraseRhs rhs =
+  case rhs of
+    Syntax.UnguardedRhs _ expr -> UnguardedRhs (eraseExpr expr)
+    Syntax.GuardedRhss _ rhss -> GuardedRhss (map eraseGuardedRhs rhss)
+
+eraseGuardedRhs :: Syntax.GuardedRhs -> GuardedRhs
+eraseGuardedRhs grhs =
+  GuardedRhs
+    { guardedRhsGuards = map eraseGuardQualifier (Syntax.guardedRhsGuards grhs),
+      guardedRhsBody = eraseExpr (Syntax.guardedRhsBody grhs)
+    }
+
+eraseGuardQualifier :: Syntax.GuardQualifier -> GuardQualifier
+eraseGuardQualifier qualifier =
+  case qualifier of
+    Syntax.GuardExpr _ expr -> GuardExpr (eraseExpr expr)
+    Syntax.GuardPat _ pat expr -> GuardPat (erasePattern pat) (eraseExpr expr)
+    Syntax.GuardLet _ decls -> GuardLet (map eraseDecl decls)
+
+eraseLiteral :: Syntax.Literal -> Literal
+eraseLiteral lit =
+  case lit of
+    Syntax.LitInt _ value repr -> LitInt value repr
+    Syntax.LitIntHash _ value repr -> LitIntHash value repr
+    Syntax.LitIntBase _ value repr -> LitIntBase value repr
+    Syntax.LitIntBaseHash _ value repr -> LitIntBaseHash value repr
+    Syntax.LitFloat _ value repr -> LitFloat value repr
+    Syntax.LitFloatHash _ value repr -> LitFloatHash value repr
+    Syntax.LitChar _ value repr -> LitChar value repr
+    Syntax.LitCharHash _ value repr -> LitCharHash value repr
+    Syntax.LitString _ value repr -> LitString value repr
+    Syntax.LitStringHash _ value repr -> LitStringHash value repr
+
+erasePattern :: Syntax.Pattern -> Pattern
+erasePattern pat =
+  case pat of
+    Syntax.PVar _ name -> PVar name
+    Syntax.PWildcard _ -> PWildcard
+    Syntax.PLit _ lit -> PLit (eraseLiteral lit)
+    Syntax.PQuasiQuote _ quoter body -> PQuasiQuote quoter body
+    Syntax.PTuple _ tupleFlavor elems -> PTuple tupleFlavor (map erasePattern elems)
+    Syntax.PUnboxedSum _ altIdx arity inner -> PUnboxedSum altIdx arity (erasePattern inner)
+    Syntax.PList _ elems -> PList (map erasePattern elems)
+    Syntax.PCon _ con args -> PCon con (map erasePattern args)
+    Syntax.PInfix _ lhs op rhs -> PInfix (erasePattern lhs) op (erasePattern rhs)
+    Syntax.PView _ expr inner -> PView (eraseExpr expr) (erasePattern inner)
+    Syntax.PAs _ name inner -> PAs name (erasePattern inner)
+    Syntax.PStrict _ inner -> PStrict (erasePattern inner)
+    Syntax.PIrrefutable _ inner -> PIrrefutable (erasePattern inner)
+    Syntax.PNegLit _ lit -> PNegLit (eraseLiteral lit)
+    Syntax.PParen _ inner -> PParen (erasePattern inner)
+    Syntax.PRecord _ con fields rwc -> PRecord con [(name, erasePattern fieldPat) | (name, fieldPat) <- fields] rwc
+    Syntax.PTypeSig _ inner ty -> PTypeSig (erasePattern inner) (eraseType ty)
+    Syntax.PSplice _ body -> PSplice (eraseExpr body)
+
+eraseType :: Syntax.Type -> Type
+eraseType ty =
+  case ty of
+    Syntax.TVar _ name -> TVar name
+    Syntax.TCon _ name promoted -> TCon name promoted
+    Syntax.TTypeLit _ lit -> TTypeLit lit
+    Syntax.TStar _ -> TStar
+    Syntax.TQuasiQuote _ quoter body -> TQuasiQuote quoter body
+    Syntax.TForall _ binders inner -> TForall binders (eraseType inner)
+    Syntax.TApp _ fn arg -> TApp (eraseType fn) (eraseType arg)
+    Syntax.TFun _ lhs rhs -> TFun (eraseType lhs) (eraseType rhs)
+    Syntax.TTuple _ tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map eraseType elems)
+    Syntax.TUnboxedSum _ elems -> TUnboxedSum (map eraseType elems)
+    Syntax.TList _ promoted inner -> TList promoted (eraseType inner)
+    Syntax.TParen _ inner -> TParen (eraseType inner)
+    Syntax.TContext _ constraints inner -> TContext (map eraseConstraint constraints) (eraseType inner)
+    Syntax.TSplice _ body -> TSplice (eraseExpr body)
+
+eraseConstraint :: Syntax.Constraint -> Constraint
+eraseConstraint constraint =
+  case constraint of
+    Syntax.Constraint _ cls args -> Constraint cls (map eraseType args)
+    Syntax.CParen _ inner -> CParen (eraseConstraint inner)
+
+eraseExpr :: Syntax.Expr -> Expr
+eraseExpr expr =
+  case expr of
+    Syntax.EVar _ name -> EVar name
+    Syntax.EInt _ value repr -> EInt value repr
+    Syntax.EIntHash _ value repr -> EIntHash value repr
+    Syntax.EIntBase _ value repr -> EIntBase value repr
+    Syntax.EIntBaseHash _ value repr -> EIntBaseHash value repr
+    Syntax.EFloat _ value repr -> EFloat value repr
+    Syntax.EFloatHash _ value repr -> EFloatHash value repr
+    Syntax.EChar _ value repr -> EChar value repr
+    Syntax.ECharHash _ value repr -> ECharHash value repr
+    Syntax.EString _ value repr -> EString value repr
+    Syntax.EStringHash _ value repr -> EStringHash value repr
+    Syntax.EQuasiQuote _ quoter body -> EQuasiQuote quoter body
+    Syntax.EIf _ cond yes no -> EIf (eraseExpr cond) (eraseExpr yes) (eraseExpr no)
+    Syntax.EMultiWayIf _ rhss -> EMultiWayIf (map eraseGuardedRhs rhss)
+    Syntax.ELambdaPats _ pats body -> ELambdaPats (map erasePattern pats) (eraseExpr body)
+    Syntax.ELambdaCase _ alts -> ELambdaCase (map eraseCaseAlt alts)
+    Syntax.EInfix _ lhs op rhs -> EInfix (eraseExpr lhs) op (eraseExpr rhs)
+    Syntax.ENegate _ inner -> ENegate (eraseExpr inner)
+    Syntax.ESectionL _ inner op -> ESectionL (eraseExpr inner) op
+    Syntax.ESectionR _ op inner -> ESectionR op (eraseExpr inner)
+    Syntax.ELetDecls _ decls body -> ELetDecls (map eraseDecl decls) (eraseExpr body)
+    Syntax.ECase _ scrutinee alts -> ECase (eraseExpr scrutinee) (map eraseCaseAlt alts)
+    Syntax.EDo _ stmts -> EDo (map eraseDoStmt stmts)
+    Syntax.EListComp _ body stmts -> EListComp (eraseExpr body) (map eraseCompStmt stmts)
+    Syntax.EListCompParallel _ body stmtss -> EListCompParallel (eraseExpr body) (map (map eraseCompStmt) stmtss)
+    Syntax.EArithSeq _ seq' -> EArithSeq (eraseArithSeq seq')
+    Syntax.ERecordCon _ con fields rwc -> ERecordCon con [(name, eraseExpr fieldExpr) | (name, fieldExpr) <- fields] rwc
+    Syntax.ERecordUpd _ target fields -> ERecordUpd (eraseExpr target) [(name, eraseExpr fieldExpr) | (name, fieldExpr) <- fields]
+    Syntax.ETypeSig _ inner ty -> ETypeSig (eraseExpr inner) (eraseType ty)
+    Syntax.EParen _ inner -> EParen (eraseExpr inner)
+    Syntax.EWhereDecls _ body decls -> EWhereDecls (eraseExpr body) (map eraseDecl decls)
+    Syntax.EList _ elems -> EList (map eraseExpr elems)
+    Syntax.ETuple _ tupleFlavor elems -> ETuple tupleFlavor (map eraseExpr elems)
+    Syntax.ETupleSection _ tupleFlavor elems -> ETupleSection tupleFlavor (map (fmap eraseExpr) elems)
+    Syntax.ETupleCon _ tupleFlavor n -> ETupleCon tupleFlavor n
+    Syntax.EUnboxedSum _ altIdx arity inner -> EUnboxedSum altIdx arity (eraseExpr inner)
+    Syntax.ETypeApp _ inner ty -> ETypeApp (eraseExpr inner) (eraseType ty)
+    Syntax.EApp _ fn arg -> EApp (eraseExpr fn) (eraseExpr arg)
+    Syntax.ETHExpQuote _ body -> ETHExpQuote (eraseExpr body)
+    Syntax.ETHTypedQuote _ body -> ETHTypedQuote (eraseExpr body)
+    Syntax.ETHDeclQuote _ decls -> ETHDeclQuote (map eraseDecl decls)
+    Syntax.ETHTypeQuote _ ty -> ETHTypeQuote (eraseType ty)
+    Syntax.ETHPatQuote _ pat -> ETHPatQuote (erasePattern pat)
+    Syntax.ETHNameQuote _ name -> ETHNameQuote name
+    Syntax.ETHTypeNameQuote _ name -> ETHTypeNameQuote name
+    Syntax.ETHSplice _ body -> ETHSplice (eraseExpr body)
+    Syntax.ETHTypedSplice _ body -> ETHTypedSplice (eraseExpr body)
+
+eraseCaseAlt :: Syntax.CaseAlt -> CaseAlt
+eraseCaseAlt alt =
+  CaseAlt
+    { caseAltPattern = erasePattern (Syntax.caseAltPattern alt),
+      caseAltRhs = eraseRhs (Syntax.caseAltRhs alt)
+    }
+
+eraseDoStmt :: Syntax.DoStmt -> DoStmt
+eraseDoStmt stmt =
+  case stmt of
+    Syntax.DoBind _ pat expr -> DoBind (erasePattern pat) (eraseExpr expr)
+    Syntax.DoLet _ bindings -> DoLet [(name, eraseExpr expr) | (name, expr) <- bindings]
+    Syntax.DoLetDecls _ decls -> DoLetDecls (map eraseDecl decls)
+    Syntax.DoExpr _ expr -> DoExpr (eraseExpr expr)
+
+eraseCompStmt :: Syntax.CompStmt -> CompStmt
+eraseCompStmt stmt =
+  case stmt of
+    Syntax.CompGen _ pat expr -> CompGen (erasePattern pat) (eraseExpr expr)
+    Syntax.CompGuard _ expr -> CompGuard (eraseExpr expr)
+    Syntax.CompLet _ bindings -> CompLet [(name, eraseExpr expr) | (name, expr) <- bindings]
+    Syntax.CompLetDecls _ decls -> CompLetDecls (map eraseDecl decls)
+
+eraseArithSeq :: Syntax.ArithSeq -> ArithSeq
+eraseArithSeq seq' =
+  case seq' of
+    Syntax.ArithSeqFrom _ from -> ArithSeqFrom (eraseExpr from)
+    Syntax.ArithSeqFromThen _ from thenE -> ArithSeqFromThen (eraseExpr from) (eraseExpr thenE)
+    Syntax.ArithSeqFromTo _ from to -> ArithSeqFromTo (eraseExpr from) (eraseExpr to)
+    Syntax.ArithSeqFromThenTo _ from thenE to -> ArithSeqFromThenTo (eraseExpr from) (eraseExpr thenE) (eraseExpr to)

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -14,15 +14,15 @@ module Test.Properties.ExprHelpers
 where
 
 import Aihc.Parser.Lex (isReservedIdentifier)
-import Aihc.Parser.Syntax
 import Data.Text (Text)
 import qualified Data.Text as T
+import Test.Properties.BareSyntax
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
 
 -- | Canonical empty source span for normalization.
-span0 :: SourceSpan
-span0 = noSourceSpan
+span0 :: ()
+span0 = ()
 
 -- | Generate a random expression. Uses QuickCheck's size parameter
 -- to control recursion depth.
@@ -39,40 +39,40 @@ genExprSized n
         [ -- Leaf expressions
           genExprLeaf,
           -- Recursive expressions (reduce size for subexpressions)
-          EApp span0 <$> genExprSized half <*> genExprSized half,
-          EInfix span0 <$> genExprSized half <*> genOperator <*> genExprSized half,
-          ENegate span0 <$> genExprSized (n - 1),
-          ESectionL span0 <$> genExprSized (n - 1) <*> genOperator,
-          ESectionR span0 <$> genOperator <*> genExprSized (n - 1),
-          EIf span0 <$> genExprSized third <*> genExprSized third <*> genExprSized third,
-          ECase span0 <$> genExprSized half <*> genCaseAlts half,
-          ELambdaPats span0 <$> genPatterns half <*> genExprSized half,
-          ELambdaCase span0 <$> genCaseAlts (n - 1),
-          ELetDecls span0 <$> genValueDecls half <*> genExprSized half,
-          EWhereDecls span0 <$> genExprSized half <*> genValueDecls half,
-          EDo span0 <$> genDoStmts (n - 1),
-          EListComp span0 <$> genExprSized half <*> genCompStmts half,
-          EListCompParallel span0 <$> genExprSized half <*> genParallelCompStmts half,
-          EList span0 <$> genListElems (n - 1),
-          ETuple span0 Boxed <$> genTupleElems (n - 1),
-          ETuple span0 Unboxed <$> genUnboxedTupleElems (n - 1),
-          ETupleSection span0 Boxed <$> genTupleSectionElems (n - 1),
+          EApp <$> genExprSized half <*> genExprSized half,
+          EInfix <$> genExprSized half <*> genOperator <*> genExprSized half,
+          ENegate <$> genNegateOperand (n - 1),
+          ESectionL <$> genExprSized (n - 1) <*> genOperator,
+          ESectionR <$> genOperator <*> genExprSized (n - 1),
+          EIf <$> genExprSized third <*> genExprSized third <*> genExprSized third,
+          ECase <$> genExprSized half <*> genCaseAlts half,
+          ELambdaPats <$> genPatterns half <*> genExprSized half,
+          ELambdaCase <$> genCaseAlts (n - 1),
+          ELetDecls <$> genValueDecls half <*> genExprSized half,
+          EWhereDecls <$> genExprSized half <*> genValueDecls half,
+          EDo <$> genDoStmts (n - 1),
+          EListComp <$> genExprSized half <*> genCompStmts half,
+          EListCompParallel <$> genExprSized half <*> genParallelCompStmts half,
+          EList <$> genListElems (n - 1),
+          ETuple Boxed <$> genTupleElems (n - 1),
+          ETuple Unboxed <$> genUnboxedTupleElems (n - 1),
+          ETupleSection Boxed <$> genTupleSectionElems (n - 1),
           genUnboxedSumExpr (n - 1),
-          EArithSeq span0 <$> genArithSeq (n - 1),
-          ERecordCon span0 <$> genConName <*> genRecordFields (n - 1) <*> pure False,
-          ERecordUpd span0 <$> genExprSized half <*> genRecordFields half,
-          ETypeSig span0 <$> genExprSized half <*> genType half,
-          EParen span0 <$> genExprSized (n - 1),
+          EArithSeq <$> genArithSeq (n - 1),
+          ERecordCon <$> genConName <*> genRecordFields (n - 1) <*> pure False,
+          ERecordUpd <$> genExprSized half <*> genRecordFields half,
+          ETypeSig <$> genExprSized half <*> genType half,
+          EParen <$> genExprSized (n - 1),
           -- Template Haskell splices and quotes
-          ETHSplice span0 <$> genSpliceBody (n - 1),
-          ETHTypedSplice span0 <$> genTypedSpliceBody (n - 1),
-          ETHExpQuote span0 <$> genExprSized (n - 1),
-          ETHTypedQuote span0 <$> genExprSized (n - 1),
-          ETHDeclQuote span0 <$> genValueDecls (n - 1),
-          ETHPatQuote span0 <$> genSimplePattern,
-          ETHTypeQuote span0 <$> genType (n - 1),
-          ETHNameQuote span0 <$> genNameQuoteIdent,
-          ETHTypeNameQuote span0 <$> genConName
+          ETHSplice <$> genSpliceBody (n - 1),
+          ETHTypedSplice <$> genTypedSpliceBody (n - 1),
+          ETHExpQuote <$> genExprSized (n - 1),
+          ETHTypedQuote <$> genExprSized (n - 1),
+          ETHDeclQuote <$> genValueDecls (n - 1),
+          ETHPatQuote <$> genSimplePattern,
+          ETHTypeQuote <$> genType (n - 1),
+          ETHNameQuote <$> genNameQuoteIdent,
+          ETHTypeNameQuote <$> genConName
         ]
   where
     half = n `div` 2
@@ -82,18 +82,27 @@ genExprSized n
 genExprLeaf :: Gen Expr
 genExprLeaf =
   oneof
-    [ EVar span0 <$> genIdent,
+    [ EVar <$> genIdent,
       mkIntExpr <$> chooseInteger (0, 999),
       mkHexExpr <$> chooseInteger (0, 255),
       mkFloatExpr <$> genTenths,
       mkCharExpr <$> genCharValue,
       mkStringExpr <$> genStringValue,
       -- Note: EQuasiQuote requires QuasiQuotes extension, skip for now
-      pure (EList span0 []),
-      pure (ETuple span0 Boxed []),
-      pure (ETuple span0 Unboxed []),
-      ETupleCon span0 Boxed <$> chooseInt (2, 5),
-      ETupleCon span0 Unboxed <$> chooseInt (2, 5)
+      pure (EList []),
+      pure (ETuple Boxed []),
+      pure (ETuple Unboxed []),
+      ETupleCon Boxed <$> chooseInt (2, 5),
+      ETupleCon Unboxed <$> chooseInt (2, 5)
+    ]
+
+-- | Generate an operand that the current pretty-printer can render
+-- unambiguously after a leading minus.
+genNegateOperand :: Int -> Gen Expr
+genNegateOperand n =
+  oneof
+    [ genExprLeaf,
+      EParen <$> genExprSized (max 0 n)
     ]
 
 -- | Generate the body of a TH splice: either a bare variable or a parenthesized expression.
@@ -101,24 +110,24 @@ genExprLeaf =
 genSpliceBody :: Int -> Gen Expr
 genSpliceBody n =
   oneof
-    [ EVar span0 <$> genIdent,
-      EParen span0 <$> genExprSized (max 0 (n - 1))
+    [ EVar <$> genIdent,
+      EParen <$> genExprSized (max 0 (n - 1))
     ]
 
 -- | Generate the body of a TH typed splice: always parenthesized.
 -- Typed splices require parentheses: $$(expr) is valid, $$expr is invalid.
 genTypedSpliceBody :: Int -> Gen Expr
 genTypedSpliceBody n =
-  EParen span0 <$> genExprSized (max 0 (n - 1))
+  EParen <$> genExprSized (max 0 (n - 1))
 
 -- | Generate a simple pattern for TH pattern quotes [p| pat |].
 -- Only generates patterns that don't require additional extensions.
 genSimplePattern :: Gen Pattern
 genSimplePattern =
   oneof
-    [ PVar span0 <$> genIdent,
-      pure (PWildcard span0),
-      PCon span0 <$> genConName <*> pure []
+    [ PVar <$> genIdent,
+      pure PWildcard,
+      PCon <$> genConName <*> pure []
     ]
 
 -- | Generate an identifier safe for TH name quotes ('name).
@@ -182,8 +191,8 @@ genPattern n
   | otherwise =
       oneof
         [ genPatternLeaf,
-          PTuple span0 Boxed <$> genPatternTupleElems half,
-          PList span0 <$> genPatternListElems half
+          PTuple Boxed <$> genPatternTupleElems half,
+          PList <$> genPatternListElems half
         ]
   where
     half = n `div` 2
@@ -192,8 +201,8 @@ genPattern n
 genPatternLeaf :: Gen Pattern
 genPatternLeaf =
   oneof
-    [ PVar span0 <$> genIdent,
-      pure (PWildcard span0)
+    [ PVar <$> genIdent,
+      pure PWildcard
     ]
 
 genPatternTupleElems :: Int -> Gen [Pattern]
@@ -222,9 +231,8 @@ genCaseAlt n = do
   expr <- genExprSized half
   pure $
     CaseAlt
-      { caseAltSpan = span0,
-        caseAltPattern = pat,
-        caseAltRhs = UnguardedRhs span0 expr
+      { caseAltPattern = pat,
+        caseAltRhs = UnguardedRhs expr
       }
   where
     half = n `div` 2
@@ -239,15 +247,12 @@ genValueDecls n = do
   exprs <- vectorOf count (genExprSized (n `div` count))
   pure
     [ DeclValue
-        span0
         ( FunctionBind
-            span0
             name
             [ Match
-                { matchSpan = span0,
-                  matchHeadForm = MatchHeadPrefix,
+                { matchHeadForm = MatchHeadPrefix,
                   matchPats = [],
-                  matchRhs = UnguardedRhs span0 expr
+                  matchRhs = UnguardedRhs expr
                 }
             ]
         )
@@ -262,14 +267,14 @@ genDoStmts n = do
   stmts <- vectorOf (count - 1) (genDoStmt perStmt)
   -- Last statement must be DoExpr
   lastExpr <- genExprSized perStmt
-  pure (stmts <> [DoExpr span0 lastExpr])
+  pure (stmts <> [DoExpr lastExpr])
 
 genDoStmt :: Int -> Gen DoStmt
 genDoStmt n =
   oneof
-    [ DoBind span0 <$> genPattern half <*> genExprSized half,
-      DoLetDecls span0 <$> genValueDecls (n - 1),
-      DoExpr span0 <$> genExprSized (n - 1)
+    [ DoBind <$> genPattern half <*> genExprSized half,
+      DoLetDecls <$> genValueDecls (n - 1),
+      DoExpr <$> genExprSized (n - 1)
     ]
   where
     half = n `div` 2
@@ -283,8 +288,8 @@ genCompStmts n = do
 genCompStmt :: Int -> Gen CompStmt
 genCompStmt n =
   oneof
-    [ CompGen span0 <$> genPattern half <*> genExprSized half,
-      CompGuard span0 <$> genExprSized (n - 1)
+    [ CompGen <$> genPattern half <*> genExprSized half,
+      CompGuard <$> genExprSized (n - 1)
     ]
   where
     half = n `div` 2
@@ -323,7 +328,7 @@ genUnboxedSumExpr n = do
   arity <- chooseInt (2, 4)
   altIdx <- chooseInt (0, arity - 1)
   inner <- genExprSized n
-  pure (EUnboxedSum span0 altIdx arity inner)
+  pure (EUnboxedSum altIdx arity inner)
 
 -- | Generate tuple section elements
 genTupleSectionElems :: Int -> Gen [Maybe Expr]
@@ -348,10 +353,10 @@ genMaybeExpr n =
 genArithSeq :: Int -> Gen ArithSeq
 genArithSeq n =
   oneof
-    [ ArithSeqFrom span0 <$> genExprSized n,
-      ArithSeqFromThen span0 <$> genExprSized half <*> genExprSized half,
-      ArithSeqFromTo span0 <$> genExprSized half <*> genExprSized half,
-      ArithSeqFromThenTo span0 <$> genExprSized third <*> genExprSized third <*> genExprSized third
+    [ ArithSeqFrom <$> genExprSized n,
+      ArithSeqFromThen <$> genExprSized half <*> genExprSized half,
+      ArithSeqFromTo <$> genExprSized half <*> genExprSized half,
+      ArithSeqFromThenTo <$> genExprSized third <*> genExprSized third <*> genExprSized third
     ]
   where
     half = n `div` 2
@@ -382,11 +387,11 @@ genType n
   | otherwise =
       oneof
         [ genTypeLeaf,
-          TApp span0 <$> genType half <*> genType half,
-          TFun span0 <$> genType half <*> genType half,
-          TList span0 Unpromoted <$> genType (n - 1),
-          TTuple span0 Boxed Unpromoted <$> genTypeTupleElems (n - 1),
-          TParen span0 <$> genType (n - 1)
+          TApp <$> genType half <*> genType half,
+          TFun <$> genType half <*> genType half,
+          TList Unpromoted <$> genType (n - 1),
+          TTuple Boxed Unpromoted <$> genTypeTupleElems (n - 1),
+          TParen <$> genType (n - 1)
         ]
   where
     half = n `div` 2
@@ -395,8 +400,8 @@ genType n
 genTypeLeaf :: Gen Type
 genTypeLeaf =
   oneof
-    [ TVar span0 <$> genTypeVarName,
-      (\name -> TCon span0 name Unpromoted) <$> genConName
+    [ TVar <$> genTypeVarName,
+      (`TCon` Unpromoted) <$> genConName
     ]
 
 genTypeTupleElems :: Int -> Gen [Type]
@@ -420,16 +425,16 @@ genTypeVarName = do
 
 -- | Literal expression generators
 mkHexExpr :: Integer -> Expr
-mkHexExpr value = EIntBase span0 value ("0x" <> T.pack (showHex value))
+mkHexExpr value = EIntBase value ("0x" <> T.pack (showHex value))
 
 mkFloatExpr :: Double -> Expr
-mkFloatExpr value = EFloat span0 value (T.pack (show value))
+mkFloatExpr value = EFloat value (T.pack (show value))
 
 mkCharExpr :: Char -> Expr
-mkCharExpr value = EChar span0 value (T.pack (show value))
+mkCharExpr value = EChar value (T.pack (show value))
 
 mkStringExpr :: Text -> Expr
-mkStringExpr value = EString span0 value (T.pack (show (T.unpack value)))
+mkStringExpr value = EString value (T.pack (show (T.unpack value)))
 
 genTenths :: Gen Double
 genTenths = do
@@ -459,101 +464,101 @@ renderIntBaseHash value
 
 -- | Create an integer expression with canonical representation.
 mkIntExpr :: Integer -> Expr
-mkIntExpr value = EInt span0 value (T.pack (show value))
+mkIntExpr value = EInt value (T.pack (show value))
 
 -- | Shrink an expression for QuickCheck counterexample minimization.
 shrinkExpr :: Expr -> [Expr]
 shrinkExpr expr =
   case expr of
-    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkIdent name]
-    EInt _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
-    EIntHash _ value _ -> [EIntHash span0 shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkIntegral value]
-    EIntBase _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
-    EIntBaseHash _ value _ -> [EIntBaseHash span0 shrunk (renderIntBaseHash shrunk) | shrunk <- shrinkIntegral value]
-    EFloat _ value _ -> [mkFloatExpr shrunk | shrunk <- shrinkFloat value]
-    EFloatHash _ value _ -> [EFloatHash span0 shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkFloat value]
+    EVar name -> [EVar shrunk | shrunk <- shrinkIdent name]
+    EInt value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
+    EIntHash value _ -> [EIntHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkIntegral value]
+    EIntBase value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
+    EIntBaseHash value _ -> [EIntBaseHash shrunk (renderIntBaseHash shrunk) | shrunk <- shrinkIntegral value]
+    EFloat value _ -> [mkFloatExpr shrunk | shrunk <- shrinkFloat value]
+    EFloatHash value _ -> [EFloatHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkFloat value]
     EChar {} -> []
     ECharHash {} -> []
-    EString _ value _ -> [mkStringExpr (T.pack shrunk) | shrunk <- shrink (T.unpack value)]
-    EStringHash _ value _ -> [EStringHash span0 (T.pack shrunk) (T.pack (show shrunk) <> "#") | shrunk <- shrink (T.unpack value)]
-    EQuasiQuote _ quoter body ->
-      [EQuasiQuote span0 quoter (T.pack shrunk) | shrunk <- shrink (T.unpack body)]
-    EApp _ fn arg ->
+    EString value _ -> [mkStringExpr (T.pack shrunk) | shrunk <- shrink (T.unpack value)]
+    EStringHash value _ -> [EStringHash (T.pack shrunk) (T.pack (show shrunk) <> "#") | shrunk <- shrink (T.unpack value)]
+    EQuasiQuote quoter body ->
+      [EQuasiQuote quoter (T.pack shrunk) | shrunk <- shrink (T.unpack body)]
+    EApp fn arg ->
       [fn, arg]
-        <> [EApp span0 fn' arg | fn' <- shrinkExpr fn]
-        <> [EApp span0 fn arg' | arg' <- shrinkExpr arg]
-    EInfix _ lhs op rhs ->
+        <> [EApp fn' arg | fn' <- shrinkExpr fn]
+        <> [EApp fn arg' | arg' <- shrinkExpr arg]
+    EInfix lhs op rhs ->
       [lhs, rhs]
-        <> [EInfix span0 lhs' op rhs | lhs' <- shrinkExpr lhs]
-        <> [EInfix span0 lhs op rhs' | rhs' <- shrinkExpr rhs]
-    ENegate _ inner -> inner : [ENegate span0 inner' | inner' <- shrinkExpr inner]
-    ESectionL _ inner op -> inner : [ESectionL span0 inner' op | inner' <- shrinkExpr inner]
-    ESectionR _ op inner -> inner : [ESectionR span0 op inner' | inner' <- shrinkExpr inner]
-    EIf _ cond thenE elseE ->
+        <> [EInfix lhs' op rhs | lhs' <- shrinkExpr lhs]
+        <> [EInfix lhs op rhs' | rhs' <- shrinkExpr rhs]
+    ENegate inner -> inner : [ENegate inner' | inner' <- shrinkExpr inner]
+    ESectionL inner op -> inner : [ESectionL inner' op | inner' <- shrinkExpr inner]
+    ESectionR op inner -> inner : [ESectionR op inner' | inner' <- shrinkExpr inner]
+    EIf cond thenE elseE ->
       [thenE, elseE]
-        <> [EIf span0 cond' thenE elseE | cond' <- shrinkExpr cond]
-        <> [EIf span0 cond thenE' elseE | thenE' <- shrinkExpr thenE]
-        <> [EIf span0 cond thenE elseE' | elseE' <- shrinkExpr elseE]
-    EMultiWayIf _ rhss ->
-      [EMultiWayIf span0 rhss' | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
-    ECase _ scrutinee alts ->
+        <> [EIf cond' thenE elseE | cond' <- shrinkExpr cond]
+        <> [EIf cond thenE' elseE | thenE' <- shrinkExpr thenE]
+        <> [EIf cond thenE elseE' | elseE' <- shrinkExpr elseE]
+    EMultiWayIf rhss ->
+      [EMultiWayIf rhss' | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
+    ECase scrutinee alts ->
       scrutinee
-        : [ECase span0 scrutinee' alts | scrutinee' <- shrinkExpr scrutinee]
-          <> [ECase span0 scrutinee alts' | alts' <- shrinkCaseAlts alts, not (null alts')]
-    ELambdaPats _ pats body ->
-      body : [ELambdaPats span0 pats body' | body' <- shrinkExpr body]
-    ELambdaCase _ alts ->
-      [ELambdaCase span0 alts' | alts' <- shrinkCaseAlts alts, not (null alts')]
-    ELetDecls _ decls body ->
+        : [ECase scrutinee' alts | scrutinee' <- shrinkExpr scrutinee]
+          <> [ECase scrutinee alts' | alts' <- shrinkCaseAlts alts, not (null alts')]
+    ELambdaPats pats body ->
+      body : [ELambdaPats pats body' | body' <- shrinkExpr body]
+    ELambdaCase alts ->
+      [ELambdaCase alts' | alts' <- shrinkCaseAlts alts, not (null alts')]
+    ELetDecls decls body ->
       body
-        : [ELetDecls span0 decls body' | body' <- shrinkExpr body]
-          <> [ELetDecls span0 decls' body | decls' <- shrinkDecls decls, not (null decls')]
-    EWhereDecls _ body decls ->
+        : [ELetDecls decls body' | body' <- shrinkExpr body]
+          <> [ELetDecls decls' body | decls' <- shrinkDecls decls, not (null decls')]
+    EWhereDecls body decls ->
       body
-        : [EWhereDecls span0 body' decls | body' <- shrinkExpr body]
-          <> [EWhereDecls span0 body decls' | decls' <- shrinkDecls decls, not (null decls')]
-    EDo _ stmts ->
-      [EDo span0 stmts' | stmts' <- shrinkDoStmts stmts, not (null stmts')]
-    EListComp _ body stmts ->
+        : [EWhereDecls body' decls | body' <- shrinkExpr body]
+          <> [EWhereDecls body decls' | decls' <- shrinkDecls decls, not (null decls')]
+    EDo stmts ->
+      [EDo stmts' | stmts' <- shrinkDoStmts stmts, not (null stmts')]
+    EListComp body stmts ->
       body
-        : [EListComp span0 body' stmts | body' <- shrinkExpr body]
-          <> [EListComp span0 body stmts' | stmts' <- shrinkCompStmts stmts, not (null stmts')]
-    EListCompParallel _ body stmtss ->
+        : [EListComp body' stmts | body' <- shrinkExpr body]
+          <> [EListComp body stmts' | stmts' <- shrinkCompStmts stmts, not (null stmts')]
+    EListCompParallel body stmtss ->
       body
-        : [EListCompParallel span0 body' stmtss | body' <- shrinkExpr body]
+        : [EListCompParallel body' stmtss | body' <- shrinkExpr body]
           -- Each branch needs at least one statement, so filter out empty branches
-          <> [EListCompParallel span0 body stmtss' | stmtss' <- shrinkParallelCompStmts stmtss, length stmtss' >= 2]
-    EList _ elems ->
-      [EList span0 elems' | elems' <- shrinkList shrinkExpr elems]
-    ETuple _ tupleFlavor elems ->
-      [ETuple span0 tupleFlavor elems' | elems' <- shrinkTupleElems shrinkExpr elems]
-    ETupleSection _ tupleFlavor elems ->
-      [ETupleSection span0 tupleFlavor elems' | elems' <- shrinkTupleSectionElems elems]
-    ETupleCon _ tupleFlavor n -> [ETupleCon span0 tupleFlavor n' | n' <- shrink n, n' >= 2]
-    EArithSeq _ seq' ->
-      [EArithSeq span0 seq'' | seq'' <- shrinkArithSeq seq']
-    ERecordCon _ con fields _ ->
-      [ERecordCon span0 con fields' False | fields' <- shrinkRecordFields fields]
-    ERecordUpd _ target fields ->
+          <> [EListCompParallel body stmtss' | stmtss' <- shrinkParallelCompStmts stmtss, length stmtss' >= 2]
+    EList elems ->
+      [EList elems' | elems' <- shrinkList shrinkExpr elems]
+    ETuple tupleFlavor elems ->
+      [ETuple tupleFlavor elems' | elems' <- shrinkTupleElems shrinkExpr elems]
+    ETupleSection tupleFlavor elems ->
+      [ETupleSection tupleFlavor elems' | elems' <- shrinkTupleSectionElems elems]
+    ETupleCon tupleFlavor n -> [ETupleCon tupleFlavor n' | n' <- shrink n, n' >= 2]
+    EArithSeq seq' ->
+      [EArithSeq seq'' | seq'' <- shrinkArithSeq seq']
+    ERecordCon con fields _ ->
+      [ERecordCon con fields' False | fields' <- shrinkRecordFields fields]
+    ERecordUpd target fields ->
       target
-        : [ERecordUpd span0 target' fields | target' <- shrinkExpr target]
-          <> [ERecordUpd span0 target fields' | fields' <- shrinkRecordFields fields]
-    ETypeSig _ inner _ ->
-      inner : [ETypeSig span0 inner' (TCon span0 "T" Unpromoted) | inner' <- shrinkExpr inner]
-    ETypeApp _ inner _ ->
-      inner : [ETypeApp span0 inner' (TCon span0 "T" Unpromoted) | inner' <- shrinkExpr inner]
-    EUnboxedSum _ altIdx arity inner ->
-      [EUnboxedSum span0 altIdx arity inner' | inner' <- shrinkExpr inner]
-    EParen _ inner -> inner : [EParen span0 inner' | inner' <- shrinkExpr inner]
-    ETHExpQuote _ body -> body : [ETHExpQuote span0 body' | body' <- shrinkExpr body]
-    ETHTypedQuote _ body -> body : [ETHTypedQuote span0 body' | body' <- shrinkExpr body]
+        : [ERecordUpd target' fields | target' <- shrinkExpr target]
+          <> [ERecordUpd target fields' | fields' <- shrinkRecordFields fields]
+    ETypeSig inner _ ->
+      inner : [ETypeSig inner' (TCon "T" Unpromoted) | inner' <- shrinkExpr inner]
+    ETypeApp inner _ ->
+      inner : [ETypeApp inner' (TCon "T" Unpromoted) | inner' <- shrinkExpr inner]
+    EUnboxedSum altIdx arity inner ->
+      [EUnboxedSum altIdx arity inner' | inner' <- shrinkExpr inner]
+    EParen inner -> inner : [EParen inner' | inner' <- shrinkExpr inner]
+    ETHExpQuote body -> body : [ETHExpQuote body' | body' <- shrinkExpr body]
+    ETHTypedQuote body -> body : [ETHTypedQuote body' | body' <- shrinkExpr body]
     ETHDeclQuote {} -> []
     ETHTypeQuote {} -> []
     ETHPatQuote {} -> []
     ETHNameQuote {} -> []
     ETHTypeNameQuote {} -> []
-    ETHSplice _ body -> body : [ETHSplice span0 body' | body' <- shrinkExpr body]
-    ETHTypedSplice _ body -> body : [ETHTypedSplice span0 body' | body' <- shrinkExpr body]
+    ETHSplice body -> body : [ETHSplice body' | body' <- shrinkExpr body]
+    ETHTypedSplice body -> body : [ETHTypedSplice body' | body' <- shrinkExpr body]
 
 shrinkFloat :: Double -> [Double]
 shrinkFloat value =
@@ -565,8 +570,8 @@ shrinkCaseAlts = shrinkList shrinkCaseAlt
 shrinkCaseAlt :: CaseAlt -> [CaseAlt]
 shrinkCaseAlt alt =
   case caseAltRhs alt of
-    UnguardedRhs _ expr ->
-      [alt {caseAltRhs = UnguardedRhs span0 expr'} | expr' <- shrinkExpr expr]
+    UnguardedRhs expr ->
+      [alt {caseAltRhs = UnguardedRhs expr'} | expr' <- shrinkExpr expr]
     _ -> []
 
 shrinkGuardedRhs :: GuardedRhs -> [GuardedRhs]
@@ -579,15 +584,13 @@ shrinkDecls = shrinkList shrinkDecl
 shrinkDecl :: Decl -> [Decl]
 shrinkDecl decl =
   case decl of
-    DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr)) ->
-      [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr')) | expr' <- shrinkExpr expr]
-    DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr}]) ->
+    DeclValue (PatternBind pat (UnguardedRhs expr)) ->
+      [DeclValue (PatternBind pat (UnguardedRhs expr')) | expr' <- shrinkExpr expr]
+    DeclValue (FunctionBind name [match@Match {matchRhs = UnguardedRhs expr}]) ->
       [ DeclValue
-          span0
           ( FunctionBind
-              span0
               name
-              [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr'}]
+              [match {matchRhs = UnguardedRhs expr'}]
           )
       | expr' <- shrinkExpr expr
       ]
@@ -602,10 +605,10 @@ shrinkDoStmts stmts =
 shrinkDoStmt :: DoStmt -> [DoStmt]
 shrinkDoStmt stmt =
   case stmt of
-    DoBind _ pat expr -> [DoBind span0 pat expr' | expr' <- shrinkExpr expr]
-    DoLet _ bindings -> [DoLet span0 bindings' | bindings' <- shrinkList shrinkBinding bindings, not (null bindings')]
-    DoLetDecls _ decls -> [DoLetDecls span0 decls' | decls' <- shrinkDecls decls, not (null decls')]
-    DoExpr _ expr -> [DoExpr span0 expr' | expr' <- shrinkExpr expr]
+    DoBind pat expr -> [DoBind pat expr' | expr' <- shrinkExpr expr]
+    DoLet bindings -> [DoLet bindings' | bindings' <- shrinkList shrinkBinding bindings, not (null bindings')]
+    DoLetDecls decls -> [DoLetDecls decls' | decls' <- shrinkDecls decls, not (null decls')]
+    DoExpr expr -> [DoExpr expr' | expr' <- shrinkExpr expr]
 
 shrinkBinding :: (Text, Expr) -> [(Text, Expr)]
 shrinkBinding (name, expr) = [(name, expr') | expr' <- shrinkExpr expr]
@@ -625,10 +628,10 @@ shrinkParallelCompStmts =
 shrinkCompStmt :: CompStmt -> [CompStmt]
 shrinkCompStmt stmt =
   case stmt of
-    CompGen _ pat expr -> [CompGen span0 pat expr' | expr' <- shrinkExpr expr]
-    CompGuard _ expr -> [CompGuard span0 expr' | expr' <- shrinkExpr expr]
-    CompLet _ bindings -> [CompLet span0 bindings' | bindings' <- shrinkList shrinkBinding bindings, not (null bindings')]
-    CompLetDecls _ decls -> [CompLetDecls span0 decls' | decls' <- shrinkDecls decls, not (null decls')]
+    CompGen pat expr -> [CompGen pat expr' | expr' <- shrinkExpr expr]
+    CompGuard expr -> [CompGuard expr' | expr' <- shrinkExpr expr]
+    CompLet bindings -> [CompLet bindings' | bindings' <- shrinkList shrinkBinding bindings, not (null bindings')]
+    CompLetDecls decls -> [CompLetDecls decls' | decls' <- shrinkDecls decls, not (null decls')]
 
 shrinkTupleElems :: (a -> [a]) -> [a] -> [[a]]
 shrinkTupleElems shrinkElem elems =
@@ -654,21 +657,21 @@ shrinkMaybeExpr mExpr =
 shrinkArithSeq :: ArithSeq -> [ArithSeq]
 shrinkArithSeq seq' =
   case seq' of
-    ArithSeqFrom _ from ->
-      [ArithSeqFrom span0 from' | from' <- shrinkExpr from]
-    ArithSeqFromThen _ from thenE ->
-      ArithSeqFrom span0 from
-        : [ArithSeqFromThen span0 from' thenE | from' <- shrinkExpr from]
-          <> [ArithSeqFromThen span0 from thenE' | thenE' <- shrinkExpr thenE]
-    ArithSeqFromTo _ from to ->
-      ArithSeqFrom span0 from
-        : [ArithSeqFromTo span0 from' to | from' <- shrinkExpr from]
-          <> [ArithSeqFromTo span0 from to' | to' <- shrinkExpr to]
-    ArithSeqFromThenTo _ from thenE to ->
-      ArithSeqFromTo span0 from to
-        : [ArithSeqFromThenTo span0 from' thenE to | from' <- shrinkExpr from]
-          <> [ArithSeqFromThenTo span0 from thenE' to | thenE' <- shrinkExpr thenE]
-          <> [ArithSeqFromThenTo span0 from thenE to' | to' <- shrinkExpr to]
+    ArithSeqFrom from ->
+      [ArithSeqFrom from' | from' <- shrinkExpr from]
+    ArithSeqFromThen from thenE ->
+      ArithSeqFrom from
+        : [ArithSeqFromThen from' thenE | from' <- shrinkExpr from]
+          <> [ArithSeqFromThen from thenE' | thenE' <- shrinkExpr thenE]
+    ArithSeqFromTo from to ->
+      ArithSeqFrom from
+        : [ArithSeqFromTo from' to | from' <- shrinkExpr from]
+          <> [ArithSeqFromTo from to' | to' <- shrinkExpr to]
+    ArithSeqFromThenTo from thenE to ->
+      ArithSeqFromTo from to
+        : [ArithSeqFromThenTo from' thenE to | from' <- shrinkExpr from]
+          <> [ArithSeqFromThenTo from thenE' to | thenE' <- shrinkExpr thenE]
+          <> [ArithSeqFromThenTo from thenE to' | to' <- shrinkExpr to]
 
 shrinkRecordFields :: [(Text, Expr)] -> [[(Text, Expr)]]
 shrinkRecordFields = shrinkList shrinkRecordField
@@ -681,141 +684,137 @@ shrinkRecordField (name, expr) = [(name, expr') | expr' <- shrinkExpr expr]
 normalizeExpr :: Expr -> Expr
 normalizeExpr expr =
   case expr of
-    EVar _ name -> EVar span0 name
-    EInt _ value _ -> mkIntExpr value
-    EIntHash _ value repr -> EIntHash span0 value repr
-    EIntBase _ value repr -> EIntBase span0 value repr
-    EIntBaseHash _ value repr -> EIntBaseHash span0 value repr
-    EFloat _ value repr -> EFloat span0 value repr
-    EFloatHash _ value repr -> EFloatHash span0 value repr
-    EChar _ value repr -> EChar span0 value repr
-    ECharHash _ value repr -> ECharHash span0 value repr
-    EString _ value repr -> EString span0 value repr
-    EStringHash _ value repr -> EStringHash span0 value repr
-    EQuasiQuote _ quoter body -> EQuasiQuote span0 quoter body
-    EApp _ fn arg -> EApp span0 (normalizeExpr fn) (normalizeExpr arg)
-    EInfix _ lhs op rhs -> EInfix span0 (normalizeExpr lhs) op (normalizeExpr rhs)
-    ENegate _ inner -> ENegate span0 (normalizeExpr inner)
-    ESectionL _ inner op -> ESectionL span0 (normalizeExpr inner) op
-    ESectionR _ op inner -> ESectionR span0 op (normalizeExpr inner)
-    EIf _ cond thenE elseE -> EIf span0 (normalizeExpr cond) (normalizeExpr thenE) (normalizeExpr elseE)
-    EMultiWayIf _ rhss -> EMultiWayIf span0 (map normalizeGuardedRhs rhss)
-    ECase _ scrutinee alts -> ECase span0 (normalizeExpr scrutinee) (map normalizeCaseAlt alts)
-    ELambdaPats _ pats body -> ELambdaPats span0 (map normalizePattern pats) (normalizeExpr body)
-    ELambdaCase _ alts -> ELambdaCase span0 (map normalizeCaseAlt alts)
-    ELetDecls _ decls body -> ELetDecls span0 (map normalizeDecl decls) (normalizeExpr body)
-    EWhereDecls _ body decls -> EWhereDecls span0 (normalizeExpr body) (map normalizeDecl decls)
-    EDo _ stmts -> EDo span0 (map normalizeDoStmt stmts)
-    EListComp _ body stmts -> EListComp span0 (normalizeExpr body) (map normalizeCompStmt stmts)
-    EListCompParallel _ body stmtss -> EListCompParallel span0 (normalizeExpr body) (map (map normalizeCompStmt) stmtss)
-    EList _ elems -> EList span0 (map normalizeExpr elems)
-    ETuple _ tupleFlavor elems -> ETuple span0 tupleFlavor (map normalizeExpr elems)
+    EVar name -> EVar name
+    EInt value _ -> mkIntExpr value
+    EIntHash value repr -> EIntHash value repr
+    EIntBase value repr -> EIntBase value repr
+    EIntBaseHash value repr -> EIntBaseHash value repr
+    EFloat value repr -> EFloat value repr
+    EFloatHash value repr -> EFloatHash value repr
+    EChar value repr -> EChar value repr
+    ECharHash value repr -> ECharHash value repr
+    EString value repr -> EString value repr
+    EStringHash value repr -> EStringHash value repr
+    EQuasiQuote quoter body -> EQuasiQuote quoter body
+    EApp fn arg -> EApp (normalizeExpr fn) (normalizeExpr arg)
+    EInfix lhs op rhs -> EInfix (normalizeExpr lhs) op (normalizeExpr rhs)
+    ENegate inner -> ENegate (normalizeExpr inner)
+    ESectionL inner op -> ESectionL (normalizeExpr inner) op
+    ESectionR op inner -> ESectionR op (normalizeExpr inner)
+    EIf cond thenE elseE -> EIf (normalizeExpr cond) (normalizeExpr thenE) (normalizeExpr elseE)
+    EMultiWayIf rhss -> EMultiWayIf (map normalizeGuardedRhs rhss)
+    ECase scrutinee alts -> ECase (normalizeExpr scrutinee) (map normalizeCaseAlt alts)
+    ELambdaPats pats body -> ELambdaPats (map normalizePattern pats) (normalizeExpr body)
+    ELambdaCase alts -> ELambdaCase (map normalizeCaseAlt alts)
+    ELetDecls decls body -> ELetDecls (map normalizeDecl decls) (normalizeExpr body)
+    EWhereDecls body decls -> EWhereDecls (normalizeExpr body) (map normalizeDecl decls)
+    EDo stmts -> EDo (map normalizeDoStmt stmts)
+    EListComp body stmts -> EListComp (normalizeExpr body) (map normalizeCompStmt stmts)
+    EListCompParallel body stmtss -> EListCompParallel (normalizeExpr body) (map (map normalizeCompStmt) stmtss)
+    EList elems -> EList (map normalizeExpr elems)
+    ETuple tupleFlavor elems -> ETuple tupleFlavor (map normalizeExpr elems)
     -- When a tuple section has all holes, it becomes a tuple constructor
-    ETupleSection _ tupleFlavor elems
-      | all (== Nothing) elems -> ETupleSection span0 tupleFlavor elems
-      | otherwise -> ETupleSection span0 tupleFlavor (map (fmap normalizeExpr) elems)
+    ETupleSection tupleFlavor elems
+      | all (== Nothing) elems -> ETupleSection tupleFlavor elems
+      | otherwise -> ETupleSection tupleFlavor (map (fmap normalizeExpr) elems)
     -- A tuple constructor is equivalent to a tuple section with all holes
-    ETupleCon _ tupleFlavor n -> ETupleSection span0 tupleFlavor (replicate n Nothing)
-    EArithSeq _ seq' -> EArithSeq span0 (normalizeArithSeq seq')
-    ERecordCon _ con fields rwc -> ERecordCon span0 con [(name, normalizeExpr e) | (name, e) <- fields] rwc
-    ERecordUpd _ target fields -> ERecordUpd span0 (normalizeExpr target) [(name, normalizeExpr e) | (name, e) <- fields]
-    ETypeSig _ inner ty -> ETypeSig span0 (normalizeExpr inner) (normalizeType ty)
-    ETypeApp _ inner ty -> ETypeApp span0 (normalizeExpr inner) (normalizeType ty)
-    EUnboxedSum _ altIdx arity inner -> EUnboxedSum span0 altIdx arity (normalizeExpr inner)
-    EParen _ inner -> normalizeExpr inner
-    ETHExpQuote _ body -> ETHExpQuote span0 (normalizeExpr body)
-    ETHTypedQuote _ body -> ETHTypedQuote span0 (normalizeExpr body)
-    ETHDeclQuote _ decls -> ETHDeclQuote span0 (map normalizeDecl decls)
-    ETHTypeQuote _ ty -> ETHTypeQuote span0 (normalizeType ty)
-    ETHPatQuote _ pat -> ETHPatQuote span0 (normalizePattern pat)
-    ETHNameQuote _ name -> ETHNameQuote span0 name
-    ETHTypeNameQuote _ name -> ETHTypeNameQuote span0 name
-    ETHSplice _ body -> ETHSplice span0 (normalizeExpr body)
-    ETHTypedSplice _ body -> ETHTypedSplice span0 (normalizeExpr body)
+    ETupleCon tupleFlavor n -> ETupleSection tupleFlavor (replicate n Nothing)
+    EArithSeq seq' -> EArithSeq (normalizeArithSeq seq')
+    ERecordCon con fields rwc -> ERecordCon con [(name, normalizeExpr e) | (name, e) <- fields] rwc
+    ERecordUpd target fields -> ERecordUpd (normalizeExpr target) [(name, normalizeExpr e) | (name, e) <- fields]
+    ETypeSig inner ty -> ETypeSig (normalizeExpr inner) (normalizeType ty)
+    ETypeApp inner ty -> ETypeApp (normalizeExpr inner) (normalizeType ty)
+    EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (normalizeExpr inner)
+    EParen inner -> normalizeExpr inner
+    ETHExpQuote body -> ETHExpQuote (normalizeExpr body)
+    ETHTypedQuote body -> ETHTypedQuote (normalizeExpr body)
+    ETHDeclQuote decls -> ETHDeclQuote (map normalizeDecl decls)
+    ETHTypeQuote ty -> ETHTypeQuote (normalizeType ty)
+    ETHPatQuote pat -> ETHPatQuote (normalizePattern pat)
+    ETHNameQuote name -> ETHNameQuote name
+    ETHTypeNameQuote name -> ETHTypeNameQuote name
+    ETHSplice body -> ETHSplice (normalizeExpr body)
+    ETHTypedSplice body -> ETHTypedSplice (normalizeExpr body)
 
 normalizeCaseAlt :: CaseAlt -> CaseAlt
 normalizeCaseAlt alt =
   CaseAlt
-    { caseAltSpan = span0,
-      caseAltPattern = normalizePattern (caseAltPattern alt),
+    { caseAltPattern = normalizePattern (caseAltPattern alt),
       caseAltRhs = normalizeRhs (caseAltRhs alt)
     }
 
 normalizeRhs :: Rhs -> Rhs
 normalizeRhs rhs =
   case rhs of
-    UnguardedRhs _ body -> UnguardedRhs span0 (normalizeExpr body)
-    GuardedRhss _ guards -> GuardedRhss span0 (map normalizeGuardedRhs guards)
+    UnguardedRhs body -> UnguardedRhs (normalizeExpr body)
+    GuardedRhss guards -> GuardedRhss (map normalizeGuardedRhs guards)
 
 normalizeGuardedRhs :: GuardedRhs -> GuardedRhs
 normalizeGuardedRhs grhs =
   GuardedRhs
-    { guardedRhsSpan = span0,
-      guardedRhsGuards = map normalizeGuardQualifier (guardedRhsGuards grhs),
+    { guardedRhsGuards = map normalizeGuardQualifier (guardedRhsGuards grhs),
       guardedRhsBody = normalizeExpr (guardedRhsBody grhs)
     }
 
 normalizeGuardQualifier :: GuardQualifier -> GuardQualifier
 normalizeGuardQualifier qual =
   case qual of
-    GuardExpr _ e -> GuardExpr span0 (normalizeExpr e)
-    GuardPat _ pat e -> GuardPat span0 (normalizePattern pat) (normalizeExpr e)
-    GuardLet _ decls -> GuardLet span0 (map normalizeDecl decls)
+    GuardExpr e -> GuardExpr (normalizeExpr e)
+    GuardPat pat e -> GuardPat (normalizePattern pat) (normalizeExpr e)
+    GuardLet decls -> GuardLet (map normalizeDecl decls)
 
 normalizePattern :: Pattern -> Pattern
 normalizePattern pat =
   case pat of
-    PVar _ name -> PVar span0 name
-    PWildcard _ -> PWildcard span0
-    PLit _ lit -> PLit span0 (normalizeLiteral lit)
-    PQuasiQuote _ quoter body -> PQuasiQuote span0 quoter body
-    PTuple _ tupleFlavor elems -> PTuple span0 tupleFlavor (map normalizePattern elems)
-    PList _ elems -> PList span0 (map normalizePattern elems)
-    PCon _ con args -> PCon span0 con (map normalizePattern args)
-    PInfix _ lhs op rhs -> PInfix span0 (normalizePattern lhs) op (normalizePattern rhs)
-    PView _ e inner -> PView span0 (normalizeExpr e) (normalizePattern inner)
-    PAs _ name inner -> PAs span0 name (normalizePattern inner)
-    PStrict _ inner -> PStrict span0 (normalizePattern inner)
-    PIrrefutable _ inner -> PIrrefutable span0 (normalizePattern inner)
-    PNegLit _ lit -> PNegLit span0 (normalizeLiteral lit)
-    PParen _ inner -> PParen span0 (normalizePattern inner)
-    PUnboxedSum _ altIdx arity inner -> PUnboxedSum span0 altIdx arity (normalizePattern inner)
-    PRecord _ con fields rwc -> PRecord span0 con [(name, normalizePattern p) | (name, p) <- fields] rwc
-    PTypeSig _ inner ty -> PTypeSig span0 (normalizePattern inner) (normalizeType ty)
-    PSplice _ body -> PSplice span0 (normalizeExpr body)
+    PVar name -> PVar name
+    PWildcard -> PWildcard
+    PLit lit -> PLit (normalizeLiteral lit)
+    PQuasiQuote quoter body -> PQuasiQuote quoter body
+    PTuple tupleFlavor elems -> PTuple tupleFlavor (map normalizePattern elems)
+    PList elems -> PList (map normalizePattern elems)
+    PCon con args -> PCon con (map normalizePattern args)
+    PInfix lhs op rhs -> PInfix (normalizePattern lhs) op (normalizePattern rhs)
+    PView e inner -> PView (normalizeExpr e) (normalizePattern inner)
+    PAs name inner -> PAs name (normalizePattern inner)
+    PStrict inner -> PStrict (normalizePattern inner)
+    PIrrefutable inner -> PIrrefutable (normalizePattern inner)
+    PNegLit lit -> PNegLit (normalizeLiteral lit)
+    PParen inner -> PParen (normalizePattern inner)
+    PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (normalizePattern inner)
+    PRecord con fields rwc -> PRecord con [(name, normalizePattern p) | (name, p) <- fields] rwc
+    PTypeSig inner ty -> PTypeSig (normalizePattern inner) (normalizeType ty)
+    PSplice body -> PSplice (normalizeExpr body)
 
 normalizeLiteral :: Literal -> Literal
 normalizeLiteral lit =
   case lit of
-    LitInt _ value repr -> LitInt span0 value repr
-    LitIntHash _ value repr -> LitIntHash span0 value repr
-    LitIntBase _ value repr -> LitIntBase span0 value repr
-    LitIntBaseHash _ value repr -> LitIntBaseHash span0 value repr
-    LitFloat _ value repr -> LitFloat span0 value repr
-    LitFloatHash _ value repr -> LitFloatHash span0 value repr
-    LitChar _ value repr -> LitChar span0 value repr
-    LitCharHash _ value repr -> LitCharHash span0 value repr
-    LitString _ value repr -> LitString span0 value repr
-    LitStringHash _ value repr -> LitStringHash span0 value repr
+    LitInt value repr -> LitInt value repr
+    LitIntHash value repr -> LitIntHash value repr
+    LitIntBase value repr -> LitIntBase value repr
+    LitIntBaseHash value repr -> LitIntBaseHash value repr
+    LitFloat value repr -> LitFloat value repr
+    LitFloatHash value repr -> LitFloatHash value repr
+    LitChar value repr -> LitChar value repr
+    LitCharHash value repr -> LitCharHash value repr
+    LitString value repr -> LitString value repr
+    LitStringHash value repr -> LitStringHash value repr
 
 normalizeDecl :: Decl -> Decl
 normalizeDecl decl =
   case decl of
-    DeclValue _ vdecl -> DeclValue span0 (normalizeValueDecl vdecl)
-    DeclTypeSig _ names ty -> DeclTypeSig span0 names (normalizeType ty)
-    _ -> decl
+    DeclValue vdecl -> DeclValue (normalizeValueDecl vdecl)
+    DeclTypeSig names ty -> DeclTypeSig names (normalizeType ty)
 
 normalizeValueDecl :: ValueDecl -> ValueDecl
 normalizeValueDecl vdecl =
   case vdecl of
-    PatternBind _ pat rhs -> PatternBind span0 (normalizePattern pat) (normalizeRhs rhs)
-    FunctionBind _ name matches -> FunctionBind span0 name (map normalizeMatch matches)
+    PatternBind pat rhs -> PatternBind (normalizePattern pat) (normalizeRhs rhs)
+    FunctionBind name matches -> FunctionBind name (map normalizeMatch matches)
 
 normalizeMatch :: Match -> Match
 normalizeMatch m =
   Match
-    { matchSpan = span0,
-      matchHeadForm = matchHeadForm m,
+    { matchHeadForm = matchHeadForm m,
       matchPats = map normalizePattern (matchPats m),
       matchRhs = normalizeRhs (matchRhs m)
     }
@@ -823,54 +822,53 @@ normalizeMatch m =
 normalizeDoStmt :: DoStmt -> DoStmt
 normalizeDoStmt stmt =
   case stmt of
-    DoBind _ pat e -> DoBind span0 (normalizePattern pat) (normalizeExpr e)
-    DoLet _ bindings -> DoLet span0 [(name, normalizeExpr e) | (name, e) <- bindings]
-    DoLetDecls _ decls -> DoLetDecls span0 (map normalizeDecl decls)
-    DoExpr _ e -> DoExpr span0 (normalizeExpr e)
+    DoBind pat e -> DoBind (normalizePattern pat) (normalizeExpr e)
+    DoLet bindings -> DoLet [(name, normalizeExpr e) | (name, e) <- bindings]
+    DoLetDecls decls -> DoLetDecls (map normalizeDecl decls)
+    DoExpr e -> DoExpr (normalizeExpr e)
 
 normalizeCompStmt :: CompStmt -> CompStmt
 normalizeCompStmt stmt =
   case stmt of
-    CompGen _ pat e -> CompGen span0 (normalizePattern pat) (normalizeExpr e)
-    CompGuard _ e -> CompGuard span0 (normalizeExpr e)
-    CompLet _ bindings -> CompLet span0 [(name, normalizeExpr e) | (name, e) <- bindings]
-    CompLetDecls _ decls -> CompLetDecls span0 (map normalizeDecl decls)
+    CompGen pat e -> CompGen (normalizePattern pat) (normalizeExpr e)
+    CompGuard e -> CompGuard (normalizeExpr e)
+    CompLet bindings -> CompLet [(name, normalizeExpr e) | (name, e) <- bindings]
+    CompLetDecls decls -> CompLetDecls (map normalizeDecl decls)
 
 normalizeArithSeq :: ArithSeq -> ArithSeq
 normalizeArithSeq seq' =
   case seq' of
-    ArithSeqFrom _ from -> ArithSeqFrom span0 (normalizeExpr from)
-    ArithSeqFromThen _ from thenE -> ArithSeqFromThen span0 (normalizeExpr from) (normalizeExpr thenE)
-    ArithSeqFromTo _ from to -> ArithSeqFromTo span0 (normalizeExpr from) (normalizeExpr to)
-    ArithSeqFromThenTo _ from thenE to -> ArithSeqFromThenTo span0 (normalizeExpr from) (normalizeExpr thenE) (normalizeExpr to)
+    ArithSeqFrom from -> ArithSeqFrom (normalizeExpr from)
+    ArithSeqFromThen from thenE -> ArithSeqFromThen (normalizeExpr from) (normalizeExpr thenE)
+    ArithSeqFromTo from to -> ArithSeqFromTo (normalizeExpr from) (normalizeExpr to)
+    ArithSeqFromThenTo from thenE to -> ArithSeqFromThenTo (normalizeExpr from) (normalizeExpr thenE) (normalizeExpr to)
 
 normalizeType :: Type -> Type
 normalizeType ty =
   case ty of
-    TVar _ name -> TVar span0 name
-    TCon _ name promoted -> TCon span0 name promoted
-    TTypeLit _ lit -> TTypeLit span0 lit
-    TStar _ -> TStar span0
-    TQuasiQuote _ quoter body -> TQuasiQuote span0 quoter body
-    TForall _ binders inner -> TForall span0 binders (normalizeType inner)
-    TApp _ fn arg -> TApp span0 (normalizeType fn) (normalizeType arg)
-    TFun _ lhs rhs -> TFun span0 (normalizeType lhs) (normalizeType rhs)
-    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map normalizeType elems)
-    TList _ promoted inner -> TList span0 promoted (normalizeType inner)
+    TVar name -> TVar name
+    TCon name promoted -> TCon name promoted
+    TTypeLit lit -> TTypeLit lit
+    TStar -> TStar
+    TQuasiQuote quoter body -> TQuasiQuote quoter body
+    TForall binders inner -> TForall binders (normalizeType inner)
+    TApp fn arg -> TApp (normalizeType fn) (normalizeType arg)
+    TFun lhs rhs -> TFun (normalizeType lhs) (normalizeType rhs)
+    TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
+    TList promoted inner -> TList promoted (normalizeType inner)
     -- Remove redundant parentheses from types
-    TParen _ inner -> normalizeType inner
-    TUnboxedSum _ elems -> TUnboxedSum span0 (map normalizeType elems)
-    TContext _ constraints inner -> TContext span0 (map normalizeConstraint constraints) (normalizeType inner)
-    TSplice _ body -> TSplice span0 (normalizeExpr body)
+    TParen inner -> normalizeType inner
+    TUnboxedSum elems -> TUnboxedSum (map normalizeType elems)
+    TContext constraints inner -> TContext (map normalizeConstraint constraints) (normalizeType inner)
+    TSplice body -> TSplice (normalizeExpr body)
 
 normalizeConstraint :: Constraint -> Constraint
 normalizeConstraint c =
   case c of
-    Constraint _ cls args ->
+    Constraint cls args ->
       Constraint
-        { constraintSpan = span0,
-          constraintClass = cls,
+        { constraintClass = cls,
           constraintArgs = map normalizeType args
         }
-    CParen _ inner ->
-      CParen span0 (normalizeConstraint inner)
+    CParen inner ->
+      CParen (normalizeConstraint inner)

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -7,10 +7,11 @@ module Test.Properties.ExprRoundTrip
 where
 
 import Aihc.Parser
-import Aihc.Parser.Syntax
+import Aihc.Parser.Syntax (Extension (TemplateHaskell, UnboxedSums, UnboxedTuples))
 import qualified Data.Text as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
+import Test.Properties.BareSyntax (Expr, eraseExpr, toSyntaxExpr)
 import Test.Properties.ExprHelpers (genExpr, normalizeExpr, shrinkExpr)
 import Test.QuickCheck
 
@@ -22,7 +23,7 @@ exprConfig =
 
 prop_exprPrettyRoundTrip :: Expr -> Property
 prop_exprPrettyRoundTrip expr =
-  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty (toSyntaxExpr expr)))
       expected = normalizeExpr expr
    in withMaxSuccess 1000 $
         counterexample (T.unpack source) $
@@ -30,7 +31,7 @@ prop_exprPrettyRoundTrip expr =
             ParseErr err ->
               counterexample (errorBundlePretty (Just source) err) False
             ParseOk parsed ->
-              let actual = normalizeExpr parsed
+              let actual = normalizeExpr (eraseExpr parsed)
                in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
 instance Arbitrary Expr where

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -7,13 +7,14 @@ module Test.Properties.ModuleRoundTrip
 where
 
 import Aihc.Parser
-import Aihc.Parser.Syntax
+import Aihc.Parser.Syntax (Extension (TemplateHaskell, UnboxedSums, UnboxedTuples))
 import Data.List (nub)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
-import Test.Properties.ExprHelpers (genExpr, normalizeExpr, shrinkExpr, span0)
+import Test.Properties.BareSyntax
+import Test.Properties.ExprHelpers (genExpr, normalizeExpr, shrinkExpr)
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
 
@@ -25,12 +26,12 @@ moduleConfig =
 
 prop_modulePrettyRoundTrip :: Module -> Property
 prop_modulePrettyRoundTrip modu =
-  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty modu))
+  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty (toSyntaxModule modu)))
    in counterexample (T.unpack source) $
         case parseModule moduleConfig source of
           ParseOk reparsed ->
             let expected = normalizeModule modu
-                actual = normalizeModule reparsed
+                actual = normalizeModule (eraseModule reparsed)
              in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
           ParseErr err ->
             counterexample (errorBundlePretty (Just source) err) False
@@ -38,7 +39,6 @@ prop_modulePrettyRoundTrip modu =
 instance Arbitrary Module where
   arbitrary = do
     n <- chooseInt (1, 6)
-    -- Generate unique names by generating more than needed and deduplicating
     candidateNames <- vectorOf (n * 2) genIdent
     let names = take n (nub candidateNames)
     exprs <- vectorOf (length names) (resize 4 genExpr)
@@ -47,24 +47,16 @@ instance Arbitrary Module where
     decls <- mapM genFunctionDecl (zip names exprs)
     pure $
       Module
-        { moduleSpan = span0,
-          moduleHead = mHead,
+        { moduleHead = mHead,
           moduleLanguagePragmas = [],
           moduleImports = imports,
           moduleDecls = decls
         }
 
   shrink modu =
-    [ modu {moduleDecls = shrunk}
-    | shrunk <- shrinkList shrinkDecl (moduleDecls modu),
-      not (null shrunk)
-    ]
-      <> [ modu {moduleImports = shrunk}
-         | shrunk <- shrinkList shrinkImportDecl (moduleImports modu)
-         ]
-      <> [ modu {moduleHead = shrunk}
-         | shrunk <- shrinkMaybeModuleHead (moduleHead modu)
-         ]
+    [modu {moduleDecls = shrunk} | shrunk <- shrinkList shrinkDecl (moduleDecls modu), not (null shrunk)]
+      <> [modu {moduleImports = shrunk} | shrunk <- shrinkList shrinkImportDecl (moduleImports modu)]
+      <> [modu {moduleHead = shrunk} | shrunk <- shrinkMaybeModuleHead (moduleHead modu)]
 
 genFunctionDecl :: (Text, Expr) -> Gen Decl
 genFunctionDecl (name, expr) = do
@@ -75,41 +67,33 @@ genFunctionDecl (name, expr) = do
       rhs <- genIdent
       pure $
         DeclValue
-          span0
           ( FunctionBind
-              span0
               name
               [ Match
-                  { matchSpan = span0,
-                    matchHeadForm = MatchHeadInfix,
-                    matchPats = [PVar span0 lhs, PVar span0 rhs],
-                    matchRhs = UnguardedRhs span0 expr
+                  { matchHeadForm = MatchHeadInfix,
+                    matchPats = [PVar lhs, PVar rhs],
+                    matchRhs = UnguardedRhs expr
                   }
               ]
           )
     else
       pure $
         DeclValue
-          span0
           ( FunctionBind
-              span0
               name
               [ Match
-                  { matchSpan = span0,
-                    matchHeadForm = MatchHeadPrefix,
+                  { matchHeadForm = MatchHeadPrefix,
                     matchPats = [],
-                    matchRhs = UnguardedRhs span0 expr
+                    matchRhs = UnguardedRhs expr
                   }
               ]
           )
 
--- | Generate an optional module head.
--- Most modules have explicit headers, but implicit modules (Nothing) are also valid.
 genMaybeModuleHead :: Gen (Maybe ModuleHead)
 genMaybeModuleHead =
   frequency
-    [ (9, Just <$> genModuleHead), -- 90% explicit module header
-      (1, pure Nothing) -- 10% implicit module (no module declaration)
+    [ (9, Just <$> genModuleHead),
+      (1, pure Nothing)
     ]
 
 genModuleHead :: Gen ModuleHead
@@ -118,13 +102,11 @@ genModuleHead = do
   exports <- genMaybeExportSpecs
   pure $
     ModuleHead
-      { moduleHeadSpan = span0,
-        moduleHeadName = name,
+      { moduleHeadName = name,
         moduleHeadWarningText = Nothing,
         moduleHeadExports = exports
       }
 
--- | Shrink an optional module head.
 shrinkMaybeModuleHead :: Maybe ModuleHead -> [Maybe ModuleHead]
 shrinkMaybeModuleHead mHead =
   case mHead of
@@ -163,47 +145,43 @@ genExportSpecs = do
 shrinkDecl :: Decl -> [Decl]
 shrinkDecl decl =
   case decl of
-    DeclValue _ (FunctionBind _ name [match]) ->
+    DeclValue (FunctionBind name [match]) ->
       case matchRhs match of
-        UnguardedRhs _ expr ->
-          [ DeclValue span0 (FunctionBind span0 name' [match {matchRhs = UnguardedRhs span0 expr}])
-          | name' <- shrinkIdent name
-          ]
-            <> [ DeclValue span0 (FunctionBind span0 name [match {matchRhs = UnguardedRhs span0 expr'}])
-               | expr' <- shrinkExpr expr
-               ]
+        UnguardedRhs expr ->
+          [DeclValue (FunctionBind name' [match {matchRhs = UnguardedRhs expr}]) | name' <- shrinkIdent name]
+            <> [DeclValue (FunctionBind name [match {matchRhs = UnguardedRhs expr'}]) | expr' <- shrinkExpr expr]
         _ -> []
     _ -> []
 
 instance Arbitrary ExportSpec where
   arbitrary =
     oneof
-      [ ExportModule span0 <$> genModuleName,
-        ExportVar span0 Nothing <$> genIdent,
-        ExportAbs span0 <$> genTypeNamespace <*> genTypeName,
-        ExportAll span0 <$> genTypeNamespace <*> genTypeName,
-        ExportWith span0 <$> genTypeNamespace <*> genTypeName <*> genExportMembers
+      [ ExportModule <$> genModuleName,
+        ExportVar Nothing <$> genIdent,
+        ExportAbs <$> genTypeNamespace <*> genTypeName,
+        ExportAll <$> genTypeNamespace <*> genTypeName,
+        ExportWith <$> genTypeNamespace <*> genTypeName <*> genExportMembers
       ]
 
   shrink spec =
     case spec of
-      ExportModule _ modName ->
-        [ExportModule span0 shrunk | shrunk <- shrinkModuleName modName]
-      ExportVar _ namespace name ->
-        [ExportVar span0 namespace shrunk | shrunk <- shrinkIdent name]
-      ExportAbs _ namespace name ->
-        [ExportAbs span0 namespace shrunk | shrunk <- shrinkTypeName name]
-      ExportAll _ namespace name ->
-        [ExportAbs span0 namespace name]
-          <> [ExportAll span0 namespace shrunk | shrunk <- shrinkTypeName name]
-      ExportWith _ namespace name members ->
-        [ExportAbs span0 namespace name | not (null members)]
-          <> [ExportWith span0 namespace shrunk members | shrunk <- shrinkTypeName name]
-          <> [ExportWith span0 namespace name shrunk | shrunk <- shrinkList shrinkIdent members, not (null shrunk)]
+      ExportModule modName ->
+        [ExportModule shrunk | shrunk <- shrinkModuleName modName]
+      ExportVar namespace name ->
+        [ExportVar namespace shrunk | shrunk <- shrinkIdent name]
+      ExportAbs namespace name ->
+        [ExportAbs namespace shrunk | shrunk <- shrinkTypeName name]
+      ExportAll namespace name ->
+        [ExportAbs namespace name]
+          <> [ExportAll namespace shrunk | shrunk <- shrinkTypeName name]
+      ExportWith namespace name members ->
+        [ExportAbs namespace name | not (null members)]
+          <> [ExportWith namespace shrunk members | shrunk <- shrinkTypeName name]
+          <> [ExportWith namespace name shrunk | shrunk <- shrinkList shrinkIdent members, not (null shrunk)]
 
 instance Arbitrary ImportSpec where
   arbitrary =
-    ImportSpec span0
+    ImportSpec
       <$> arbitrary
       <*> genImportItems
 
@@ -214,25 +192,25 @@ instance Arbitrary ImportSpec where
 instance Arbitrary ImportItem where
   arbitrary =
     oneof
-      [ ImportItemVar span0 Nothing <$> genIdent,
-        ImportItemAbs span0 <$> genTypeNamespace <*> genTypeName,
-        ImportItemAll span0 <$> genTypeNamespace <*> genTypeName,
-        ImportItemWith span0 <$> genTypeNamespace <*> genTypeName <*> genExportMembers
+      [ ImportItemVar Nothing <$> genIdent,
+        ImportItemAbs <$> genTypeNamespace <*> genTypeName,
+        ImportItemAll <$> genTypeNamespace <*> genTypeName,
+        ImportItemWith <$> genTypeNamespace <*> genTypeName <*> genExportMembers
       ]
 
   shrink item =
     case item of
-      ImportItemVar _ namespace name ->
-        [ImportItemVar span0 namespace shrunk | shrunk <- shrinkIdent name]
-      ImportItemAbs _ namespace name ->
-        [ImportItemAbs span0 namespace shrunk | shrunk <- shrinkTypeName name]
-      ImportItemAll _ namespace name ->
-        [ImportItemAbs span0 namespace name]
-          <> [ImportItemAll span0 namespace shrunk | shrunk <- shrinkTypeName name]
-      ImportItemWith _ namespace name members ->
-        [ImportItemAbs span0 namespace name | not (null members)]
-          <> [ImportItemWith span0 namespace shrunk members | shrunk <- shrinkTypeName name]
-          <> [ImportItemWith span0 namespace name shrunk | shrunk <- shrinkList shrinkIdent members, not (null shrunk)]
+      ImportItemVar namespace name ->
+        [ImportItemVar namespace shrunk | shrunk <- shrinkIdent name]
+      ImportItemAbs namespace name ->
+        [ImportItemAbs namespace shrunk | shrunk <- shrinkTypeName name]
+      ImportItemAll namespace name ->
+        [ImportItemAbs namespace name]
+          <> [ImportItemAll namespace shrunk | shrunk <- shrinkTypeName name]
+      ImportItemWith namespace name members ->
+        [ImportItemAbs namespace name | not (null members)]
+          <> [ImportItemWith namespace shrunk members | shrunk <- shrinkTypeName name]
+          <> [ImportItemWith namespace name shrunk | shrunk <- shrinkList shrinkIdent members, not (null shrunk)]
 
 instance Arbitrary ImportDecl where
   arbitrary = do
@@ -240,8 +218,7 @@ instance Arbitrary ImportDecl where
     spec <- genMaybeImportSpec
     pure $
       ImportDecl
-        { importDeclSpan = span0,
-          importDeclLevel = Nothing,
+        { importDeclLevel = Nothing,
           importDeclPackage = Nothing,
           importDeclQualified = False,
           importDeclQualifiedPost = False,
@@ -251,12 +228,8 @@ instance Arbitrary ImportDecl where
         }
 
   shrink decl =
-    [ decl {importDeclModule = shrunk}
-    | shrunk <- shrinkModuleName (importDeclModule decl)
-    ]
-      <> [ decl {importDeclSpec = shrunk}
-         | shrunk <- shrinkMaybeImportSpec (importDeclSpec decl)
-         ]
+    [decl {importDeclModule = shrunk} | shrunk <- shrinkModuleName (importDeclModule decl)]
+      <> [decl {importDeclSpec = shrunk} | shrunk <- shrinkMaybeImportSpec (importDeclSpec decl)]
 
 genImportDecls :: Gen [ImportDecl]
 genImportDecls = do
@@ -324,8 +297,7 @@ genTypeNamespace =
 
 genMemberName :: Gen Text
 genMemberName =
-  oneof
-    [genIdent, genTypeName]
+  oneof [genIdent, genTypeName]
 
 genImportItems :: Gen [ImportItem]
 genImportItems = do
@@ -345,12 +317,10 @@ shrinkMaybeImportSpec mSpec =
     Nothing -> []
     Just spec -> Nothing : [Just shrunk | shrunk <- shrink spec]
 
--- Module normalization
 normalizeModule :: Module -> Module
 normalizeModule modu =
   Module
-    { moduleSpan = span0,
-      moduleHead = fmap normalizeModuleHead (moduleHead modu),
+    { moduleHead = fmap normalizeModuleHead (moduleHead modu),
       moduleLanguagePragmas = [],
       moduleImports = map normalizeImportDecl (moduleImports modu),
       moduleDecls = map normalizeDecl (moduleDecls modu)
@@ -359,8 +329,7 @@ normalizeModule modu =
 normalizeModuleHead :: ModuleHead -> ModuleHead
 normalizeModuleHead head' =
   ModuleHead
-    { moduleHeadSpan = span0,
-      moduleHeadName = moduleHeadName head',
+    { moduleHeadName = moduleHeadName head',
       moduleHeadWarningText = Nothing,
       moduleHeadExports = fmap (map normalizeExportSpec) (moduleHeadExports head')
     }
@@ -368,17 +337,16 @@ normalizeModuleHead head' =
 normalizeExportSpec :: ExportSpec -> ExportSpec
 normalizeExportSpec spec =
   case spec of
-    ExportModule _ modName -> ExportModule span0 modName
-    ExportVar _ namespace name -> ExportVar span0 namespace name
-    ExportAbs _ namespace name -> ExportAbs span0 namespace name
-    ExportAll _ namespace name -> ExportAll span0 namespace name
-    ExportWith _ namespace name members -> ExportWith span0 namespace name members
+    ExportModule modName -> ExportModule modName
+    ExportVar namespace name -> ExportVar namespace name
+    ExportAbs namespace name -> ExportAbs namespace name
+    ExportAll namespace name -> ExportAll namespace name
+    ExportWith namespace name members -> ExportWith namespace name members
 
 normalizeImportDecl :: ImportDecl -> ImportDecl
 normalizeImportDecl decl =
   ImportDecl
-    { importDeclSpan = span0,
-      importDeclLevel = importDeclLevel decl,
+    { importDeclLevel = importDeclLevel decl,
       importDeclPackage = importDeclPackage decl,
       importDeclQualified = importDeclQualified decl,
       importDeclQualifiedPost = importDeclQualifiedPost decl,
@@ -390,36 +358,34 @@ normalizeImportDecl decl =
 normalizeImportSpec :: ImportSpec -> ImportSpec
 normalizeImportSpec spec =
   ImportSpec
-    { importSpecSpan = span0,
-      importSpecHiding = importSpecHiding spec,
+    { importSpecHiding = importSpecHiding spec,
       importSpecItems = map normalizeImportItem (importSpecItems spec)
     }
 
 normalizeImportItem :: ImportItem -> ImportItem
 normalizeImportItem item =
   case item of
-    ImportItemVar _ namespace name -> ImportItemVar span0 namespace name
-    ImportItemAbs _ namespace name -> ImportItemAbs span0 namespace name
-    ImportItemAll _ namespace name -> ImportItemAll span0 namespace name
-    ImportItemWith _ namespace name members -> ImportItemWith span0 namespace name members
+    ImportItemVar namespace name -> ImportItemVar namespace name
+    ImportItemAbs namespace name -> ImportItemAbs namespace name
+    ImportItemAll namespace name -> ImportItemAll namespace name
+    ImportItemWith namespace name members -> ImportItemWith namespace name members
 
 normalizeDecl :: Decl -> Decl
 normalizeDecl decl =
   case decl of
-    DeclValue _ valueDecl -> DeclValue span0 (normalizeValueDecl valueDecl)
-    _ -> decl
+    DeclValue valueDecl -> DeclValue (normalizeValueDecl valueDecl)
+    DeclTypeSig names ty -> DeclTypeSig names ty
 
 normalizeValueDecl :: ValueDecl -> ValueDecl
 normalizeValueDecl valueDecl =
   case valueDecl of
-    PatternBind _ pat rhs -> PatternBind span0 pat (normalizeRhs rhs)
-    FunctionBind _ name matches -> FunctionBind span0 name (map normalizeMatch matches)
+    PatternBind pat rhs -> PatternBind pat (normalizeRhs rhs)
+    FunctionBind name matches -> FunctionBind name (map normalizeMatch matches)
 
 normalizeMatch :: Match -> Match
 normalizeMatch match =
   Match
-    { matchSpan = span0,
-      matchHeadForm = matchHeadForm match,
+    { matchHeadForm = matchHeadForm match,
       matchPats = map normalizeMatchPattern (matchPats match),
       matchRhs = normalizeRhs (matchRhs match)
     }
@@ -427,11 +393,11 @@ normalizeMatch match =
 normalizeMatchPattern :: Pattern -> Pattern
 normalizeMatchPattern pat =
   case pat of
-    PVar _ name -> PVar span0 name
+    PVar name -> PVar name
     _ -> pat
 
 normalizeRhs :: Rhs -> Rhs
 normalizeRhs rhs =
   case rhs of
-    UnguardedRhs _ expr -> UnguardedRhs span0 (normalizeExpr expr)
-    GuardedRhss _ guards -> GuardedRhss span0 guards
+    UnguardedRhs expr -> UnguardedRhs (normalizeExpr expr)
+    GuardedRhss guards -> GuardedRhss guards

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -7,19 +7,15 @@ where
 
 import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, errorBundlePretty, parsePattern)
 import Aihc.Parser.Lex (isReservedIdentifier)
-import Aihc.Parser.Syntax
-import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
-import qualified Data.Set as Set
+import Aihc.Parser.Syntax (Extension (TemplateHaskell, UnboxedSums, UnboxedTuples))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
+import Test.Properties.BareSyntax
 import Test.Properties.ExprHelpers (normalizeExpr)
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
-
-span0 :: SourceSpan
-span0 = noSourceSpan
 
 newtype GenPattern = GenPattern {unGenPattern :: Pattern}
   deriving (Show)
@@ -32,51 +28,15 @@ patternConfig =
 
 prop_patternPrettyRoundTrip :: GenPattern -> Property
 prop_patternPrettyRoundTrip (GenPattern pat) =
-  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty pat))
+  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty (toSyntaxPattern pat)))
       expected = normalizePattern pat
-   in checkCoverage $
-        applyCoverage (patternCtorCoverage pat) $
-          counterexample (T.unpack source) $
-            case parsePattern patternConfig source of
-              ParseErr err ->
-                counterexample (errorBundlePretty (Just source) err) False
-              ParseOk parsed ->
-                let actual = normalizePattern parsed
-                 in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
-
-patternCtorCoverage :: Pattern -> [Property -> Property]
-patternCtorCoverage pat =
-  let allCtors = map showConstr (dataTypeConstrs (dataTypeOf (undefined :: Pattern)))
-      -- Exclude constructors that cannot be round-tripped through the parser yet
-      coverableCtors = allCtors
-      seenCtors = patternCtorNames pat
-   in [cover 1 (ctor `Set.member` seenCtors) ctor | ctor <- coverableCtors]
-
-applyCoverage :: [Property -> Property] -> Property -> Property
-applyCoverage wrappers prop = foldr (\wrap acc -> wrap acc) prop wrappers
-
-patternCtorNames :: Pattern -> Set.Set String
-patternCtorNames pat =
-  let here = Set.singleton (showConstr (toConstr pat))
-   in case pat of
-        PVar {} -> here
-        PWildcard {} -> here
-        PLit {} -> here
-        PQuasiQuote {} -> here
-        PTuple _ _ elems -> here <> mconcat (map patternCtorNames elems)
-        PList _ elems -> here <> mconcat (map patternCtorNames elems)
-        PCon _ _ args -> here <> mconcat (map patternCtorNames args)
-        PInfix _ lhs _ rhs -> here <> patternCtorNames lhs <> patternCtorNames rhs
-        PView _ _ inner -> here <> patternCtorNames inner
-        PAs _ _ inner -> here <> patternCtorNames inner
-        PStrict _ inner -> here <> patternCtorNames inner
-        PIrrefutable _ inner -> here <> patternCtorNames inner
-        PNegLit {} -> here
-        PParen _ inner -> here <> patternCtorNames inner
-        PUnboxedSum _ _ _ inner -> here <> patternCtorNames inner
-        PRecord _ _ fields _ -> here <> mconcat [patternCtorNames fieldPat | (_, fieldPat) <- fields]
-        PTypeSig _ inner _ -> here <> patternCtorNames inner
-        PSplice {} -> here
+   in counterexample (T.unpack source) $
+        case parsePattern patternConfig source of
+          ParseErr err ->
+            counterexample (errorBundlePretty (Just source) err) False
+          ParseOk parsed ->
+            let actual = normalizePattern (erasePattern parsed)
+             in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
 instance Arbitrary GenPattern where
   arbitrary = GenPattern <$> sized (genPattern . min 3)
@@ -85,52 +45,52 @@ instance Arbitrary GenPattern where
 shrinkPattern :: Pattern -> [Pattern]
 shrinkPattern pat =
   case pat of
-    PVar _ name ->
-      [PVar span0 shrunk | shrunk <- shrinkIdent name]
-    PWildcard _ -> []
-    PLit _ lit ->
-      [PLit span0 shrunk | shrunk <- shrinkLiteral lit]
-    PQuasiQuote _ quoter body ->
-      [PQuasiQuote span0 q body | q <- shrinkQuoterName quoter]
-        <> [PQuasiQuote span0 quoter b | b <- map T.pack (shrink (T.unpack body))]
-    PTuple _ tupleFlavor elems ->
+    PVar name ->
+      [PVar shrunk | shrunk <- shrinkIdent name]
+    PWildcard -> []
+    PLit lit ->
+      [PLit shrunk | shrunk <- shrinkLiteral lit]
+    PQuasiQuote quoter body ->
+      [PQuasiQuote q body | q <- shrinkQuoterName quoter]
+        <> [PQuasiQuote quoter b | b <- map T.pack (shrink (T.unpack body))]
+    PTuple tupleFlavor elems ->
       shrinkTupleElems tupleFlavor elems
-    PList _ elems ->
-      [PList span0 elems' | elems' <- shrinkList shrinkPattern elems]
-    PCon _ con args ->
-      [PCon span0 con [] | not (null args)]
-        <> [PCon span0 con args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
-    PInfix _ lhs op rhs ->
+    PList elems ->
+      [PList elems' | elems' <- shrinkList shrinkPattern elems]
+    PCon con args ->
+      [PCon con [] | not (null args)]
+        <> [PCon con args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
+    PInfix lhs op rhs ->
       [canonicalPatternAtom lhs, canonicalPatternAtom rhs]
-        <> [PInfix span0 (canonicalPatternAtom lhs') op (canonicalPatternAtom rhs) | lhs' <- shrinkPattern lhs]
-        <> [PInfix span0 (canonicalPatternAtom lhs) op (canonicalPatternAtom rhs') | rhs' <- shrinkPattern rhs]
-    PView _ expr inner ->
+        <> [PInfix (canonicalPatternAtom lhs') op (canonicalPatternAtom rhs) | lhs' <- shrinkPattern lhs]
+        <> [PInfix (canonicalPatternAtom lhs) op (canonicalPatternAtom rhs') | rhs' <- shrinkPattern rhs]
+    PView expr inner ->
       [inner]
-        <> [PView span0 expr' inner | expr' <- shrinkViewExpr expr]
-        <> [PView span0 expr inner' | inner' <- shrinkPattern inner]
-    PAs _ name inner ->
+        <> [PView expr' inner | expr' <- shrinkViewExpr expr]
+        <> [PView expr inner' | inner' <- shrinkPattern inner]
+    PAs name inner ->
       [canonicalPatternAtom inner]
-        <> [PAs span0 name' (canonicalPatternAtom inner) | name' <- shrinkIdent name]
-        <> [PAs span0 name (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
-    PStrict _ inner ->
+        <> [PAs name' (canonicalPatternAtom inner) | name' <- shrinkIdent name]
+        <> [PAs name (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
+    PStrict inner ->
       [canonicalPatternAtom inner]
-        <> [PStrict span0 (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
-    PIrrefutable _ inner ->
+        <> [PStrict (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
+    PIrrefutable inner ->
       [canonicalPatternAtom inner]
-        <> [PIrrefutable span0 (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
-    PNegLit _ lit ->
-      [PLit span0 lit]
-        <> [PNegLit span0 shrunk | shrunk <- shrinkNumericLiteral lit]
-    PParen _ inner ->
-      [inner] <> [PParen span0 inner' | inner' <- shrinkPattern inner]
-    PUnboxedSum _ altIdx arity inner ->
-      [PUnboxedSum span0 altIdx arity inner' | inner' <- shrinkPattern inner]
-    PRecord _ con fields _ ->
-      [PRecord span0 con [] False | not (null fields)]
-        <> [PRecord span0 con fields' False | fields' <- shrinkList shrinkField fields]
-    PTypeSig _ inner ty ->
+        <> [PIrrefutable (canonicalPatternAtom inner') | inner' <- shrinkPattern inner]
+    PNegLit lit ->
+      [PLit lit]
+        <> [PNegLit shrunk | shrunk <- shrinkNumericLiteral lit]
+    PParen inner ->
+      [inner] <> [PParen inner' | inner' <- shrinkPattern inner]
+    PUnboxedSum altIdx arity inner ->
+      [PUnboxedSum altIdx arity inner' | inner' <- shrinkPattern inner]
+    PRecord con fields _ ->
+      [PRecord con [] False | not (null fields)]
+        <> [PRecord con fields' False | fields' <- shrinkList shrinkField fields]
+    PTypeSig inner ty ->
       [inner]
-        <> [PTypeSig span0 inner' ty | inner' <- shrinkPattern inner]
+        <> [PTypeSig inner' ty | inner' <- shrinkPattern inner]
     PSplice {} ->
       []
 
@@ -139,9 +99,9 @@ shrinkTupleElems tupleFlavor elems =
   [ candidate
   | shrunk <- shrinkList shrinkPattern elems,
     candidate <- case shrunk of
-      [] -> [PTuple span0 tupleFlavor []]
+      [] -> [PTuple tupleFlavor []]
       [_] -> []
-      _ -> [PTuple span0 tupleFlavor shrunk]
+      _ -> [PTuple tupleFlavor shrunk]
   ]
 
 shrinkField :: (Text, Pattern) -> [(Text, Pattern)]
@@ -151,16 +111,16 @@ shrinkField (fieldName, fieldPat) =
 shrinkLiteral :: Literal -> [Literal]
 shrinkLiteral lit =
   case lit of
-    LitInt _ value _ -> [mkIntLiteral shrunk | shrunk <- shrinkIntegral value]
-    LitIntHash _ value _ -> [LitIntHash span0 shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkIntegral value]
-    LitIntBase _ value _ -> [mkHexLiteral shrunk | shrunk <- shrinkIntegral value, shrunk >= 0]
-    LitIntBaseHash _ value _ -> [LitIntBaseHash span0 shrunk ("0x" <> T.pack (showHex shrunk) <> "#") | shrunk <- shrinkIntegral value, shrunk >= 0]
-    LitFloat _ value _ -> [mkFloatLiteral shrunk | shrunk <- shrinkFloat value, shrunk >= 0]
-    LitFloatHash _ value _ -> [LitFloatHash span0 shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkFloat value, shrunk >= 0]
-    LitChar _ c _ -> [mkCharLiteral shrunk | shrunk <- shrink c]
-    LitCharHash _ c _ -> [LitCharHash span0 shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrink c]
-    LitString _ txt _ -> [mkStringLiteral (T.pack shrunk) | shrunk <- shrink (T.unpack txt)]
-    LitStringHash _ txt _ -> [LitStringHash span0 (T.pack shrunk) (T.pack (show shrunk) <> "#") | shrunk <- shrink (T.unpack txt)]
+    LitInt value _ -> [mkIntLiteral shrunk | shrunk <- shrinkIntegral value]
+    LitIntHash value _ -> [LitIntHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkIntegral value]
+    LitIntBase value _ -> [mkHexLiteral shrunk | shrunk <- shrinkIntegral value, shrunk >= 0]
+    LitIntBaseHash value _ -> [LitIntBaseHash shrunk ("0x" <> T.pack (showHex shrunk) <> "#") | shrunk <- shrinkIntegral value, shrunk >= 0]
+    LitFloat value _ -> [mkFloatLiteral shrunk | shrunk <- shrinkFloat value, shrunk >= 0]
+    LitFloatHash value _ -> [LitFloatHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkFloat value, shrunk >= 0]
+    LitChar c _ -> [mkCharLiteral shrunk | shrunk <- shrink c]
+    LitCharHash c _ -> [LitCharHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrink c]
+    LitString txt _ -> [mkStringLiteral (T.pack shrunk) | shrunk <- shrink (T.unpack txt)]
+    LitStringHash txt _ -> [LitStringHash (T.pack shrunk) (T.pack (show shrunk) <> "#") | shrunk <- shrink (T.unpack txt)]
 
 shrinkNumericLiteral :: Literal -> [Literal]
 shrinkNumericLiteral lit =
@@ -188,38 +148,38 @@ genPattern :: Int -> Gen Pattern
 genPattern depth
   | depth <= 0 =
       oneof
-        [ PVar span0 <$> genIdent,
-          pure (PWildcard span0),
-          PLit span0 <$> genLiteral,
-          PQuasiQuote span0 <$> genQuoterName <*> genQuasiBody,
-          PTuple span0 Boxed <$> elements [[], [PVar span0 "x", PWildcard span0]],
-          PTuple span0 Unboxed <$> elements [[], [PVar span0 "x", PWildcard span0]],
-          pure (PList span0 []),
-          PCon span0 <$> genPatternConName <*> pure [],
-          PNegLit span0 <$> genNumericLiteral,
+        [ PVar <$> genIdent,
+          pure PWildcard,
+          PLit <$> genLiteral,
+          PQuasiQuote <$> genQuoterName <*> genQuasiBody,
+          PTuple Boxed <$> elements [[], [PVar "x", PWildcard]],
+          PTuple Unboxed <$> elements [[], [PVar "x", PWildcard]],
+          pure (PList []),
+          PCon <$> genPatternConName <*> pure [],
+          PNegLit <$> genNumericLiteral,
           genUnboxedSumPattern 0
         ]
   | otherwise =
       frequency
-        [ (3, PVar span0 <$> genIdent),
-          (2, pure (PWildcard span0)),
-          (3, PLit span0 <$> genLiteral),
-          (2, PQuasiQuote span0 <$> genQuoterName <*> genQuasiBody),
-          (2, PTuple span0 Boxed <$> genTupleElems (depth - 1)),
-          (1, PTuple span0 Unboxed <$> genTupleElems (depth - 1)),
-          (2, PList span0 <$> genListElems (depth - 1)),
+        [ (3, PVar <$> genIdent),
+          (2, pure PWildcard),
+          (3, PLit <$> genLiteral),
+          (2, PQuasiQuote <$> genQuoterName <*> genQuasiBody),
+          (2, PTuple Boxed <$> genTupleElems (depth - 1)),
+          (1, PTuple Unboxed <$> genTupleElems (depth - 1)),
+          (2, PList <$> genListElems (depth - 1)),
           (3, genPatternCon depth),
           (2, genPatternInfix depth),
-          (2, PView span0 <$> genViewExpr <*> genPattern (depth - 1)),
-          (2, PAs span0 <$> genIdent <*> (canonicalPatternAtom <$> genPattern (depth - 1))),
-          (2, PStrict span0 . canonicalPatternAtom <$> genPattern (depth - 1)),
-          (2, PIrrefutable span0 . canonicalPatternAtom <$> genPattern (depth - 1)),
-          (2, PNegLit span0 <$> genNumericLiteral),
-          (2, PParen span0 <$> genPattern (depth - 1)),
-          (2, PRecord span0 <$> genPatternConName <*> genRecordFields (depth - 1) <*> pure False),
+          (2, PView <$> genViewExpr <*> genPattern (depth - 1)),
+          (2, PAs <$> genIdent <*> (canonicalPatternAtom <$> genPattern (depth - 1))),
+          (2, PStrict . canonicalPatternAtom <$> genPattern (depth - 1)),
+          (2, PIrrefutable . canonicalPatternAtom <$> genPattern (depth - 1)),
+          (2, PNegLit <$> genNumericLiteral),
+          (2, PParen <$> genPattern (depth - 1)),
+          (2, PRecord <$> genPatternConName <*> genRecordFields (depth - 1) <*> pure False),
           (2, genPatternTypeSig depth),
           (1, genUnboxedSumPattern (depth - 1)),
-          (2, PSplice span0 <$> genPatSpliceBody)
+          (2, PSplice <$> genPatSpliceBody)
         ]
 
 genPatternCon :: Int -> Gen Pattern
@@ -227,19 +187,18 @@ genPatternCon depth = do
   con <- genPatternConName
   argCount <- chooseInt (0, 3)
   args <- vectorOf argCount (canonicalPatternAtom <$> genPattern (depth - 1))
-  pure (PCon span0 con args)
+  pure (PCon con args)
 
 genPatternTypeSig :: Int -> Gen Pattern
 genPatternTypeSig depth = do
   inner <- genPattern (depth - 1)
-  PParen span0 . PTypeSig span0 inner <$> genPatternType
+  PParen . PTypeSig inner <$> genPatternType
 
--- | Generate a simple type for use in pattern type signatures.
 genPatternType :: Gen Type
 genPatternType =
   oneof
-    [ TVar span0 <$> genIdent,
-      (\name -> TCon span0 name Unpromoted) <$> genPatternConName
+    [ TVar <$> genIdent,
+      (`TCon` Unpromoted) <$> genPatternConName
     ]
 
 genPatternInfix :: Int -> Gen Pattern
@@ -247,7 +206,7 @@ genPatternInfix depth = do
   lhs <- canonicalPatternAtom <$> genPattern (depth - 1)
   op <- genConOperator
   rhs <- canonicalPatternAtom <$> genPattern (depth - 1)
-  pure (PInfix span0 lhs op rhs)
+  pure (PInfix lhs op rhs)
 
 genTupleElems :: Int -> Gen [Pattern]
 genTupleElems depth = do
@@ -263,7 +222,7 @@ genUnboxedSumPattern depth = do
   arity <- chooseInt (2, 4)
   altIdx <- chooseInt (0, arity - 1)
   inner <- genPattern depth
-  pure (PUnboxedSum span0 altIdx arity inner)
+  pure (PUnboxedSum altIdx arity inner)
 
 genListElems :: Int -> Gen [Pattern]
 genListElems depth = do
@@ -312,25 +271,24 @@ genStringValue = do
 genViewExpr :: Gen Expr
 genViewExpr =
   oneof
-    [ EVar span0 <$> genIdent,
+    [ EVar <$> genIdent,
       mkIntExpr <$> chooseInteger (0, 999),
-      EParen span0 . EVar span0 <$> genIdent
+      EParen . EVar <$> genIdent
     ]
 
--- | Generate the body of a TH pattern splice: either a bare variable or a parenthesized expression.
 genPatSpliceBody :: Gen Expr
 genPatSpliceBody =
   oneof
-    [ EVar span0 <$> genIdent,
-      EParen span0 . EVar span0 <$> genIdent
+    [ EVar <$> genIdent,
+      EParen . EVar <$> genIdent
     ]
 
 shrinkViewExpr :: Expr -> [Expr]
 shrinkViewExpr expr =
   case expr of
-    EVar _ name -> [EVar span0 shrunk | shrunk <- shrinkIdent name]
-    EInt _ value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
-    EParen _ inner -> inner : [EParen span0 inner' | inner' <- shrinkViewExpr inner]
+    EVar name -> [EVar shrunk | shrunk <- shrinkIdent name]
+    EInt value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
+    EParen inner -> inner : [EParen inner' | inner' <- shrinkViewExpr inner]
     _ -> []
 
 genPatternConName :: Gen Text
@@ -346,7 +304,6 @@ genConOperator = do
   restLen <- chooseInt (0, 3)
   rest <- vectorOf restLen (elements ":!#$%&*+./<=>?\\^|-~")
   let op = T.pack (first : rest)
-  -- :: is not a valid constructor operator in patterns (it's a type signature)
   if op == "::" then genConOperator else pure op
 
 genFieldName :: Gen Text
@@ -375,7 +332,6 @@ isValidQuoterName name =
     Just (first, rest) ->
       (first `elem` (['a' .. 'z'] <> ['_']))
         && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'.")) rest
-        -- Exclude names that clash with TH quote brackets when TemplateHaskell is enabled
         && name `notElem` ["e", "t", "d", "p"]
     Nothing -> False
 
@@ -389,7 +345,7 @@ canonicalPatternAtom :: Pattern -> Pattern
 canonicalPatternAtom pat =
   if isPatternAtom pat
     then pat
-    else PParen span0 pat
+    else PParen pat
 
 isPatternAtom :: Pattern -> Bool
 isPatternAtom pat =
@@ -409,22 +365,22 @@ isPatternAtom pat =
     _ -> False
 
 mkIntLiteral :: Integer -> Literal
-mkIntLiteral value = LitInt span0 value (T.pack (show value))
+mkIntLiteral value = LitInt value (T.pack (show value))
 
 mkHexLiteral :: Integer -> Literal
-mkHexLiteral value = LitIntBase span0 value ("0x" <> T.pack (showHex value))
+mkHexLiteral value = LitIntBase value ("0x" <> T.pack (showHex value))
 
 mkFloatLiteral :: Double -> Literal
-mkFloatLiteral value = LitFloat span0 value (T.pack (show value))
+mkFloatLiteral value = LitFloat value (T.pack (show value))
 
 mkCharLiteral :: Char -> Literal
-mkCharLiteral value = LitChar span0 value (T.pack (show value))
+mkCharLiteral value = LitChar value (T.pack (show value))
 
 mkStringLiteral :: Text -> Literal
-mkStringLiteral value = LitString span0 value (T.pack (show (T.unpack value)))
+mkStringLiteral value = LitString value (T.pack (show (T.unpack value)))
 
 mkIntExpr :: Integer -> Expr
-mkIntExpr value = EInt span0 value (T.pack (show value))
+mkIntExpr value = EInt value (T.pack (show value))
 
 showHex :: Integer -> String
 showHex value
@@ -436,82 +392,77 @@ showHex value
 normalizePattern :: Pattern -> Pattern
 normalizePattern pat =
   case pat of
-    PVar _ name -> PVar span0 name
-    PWildcard _ -> PWildcard span0
-    PLit _ lit -> PLit span0 (normalizeLiteral lit)
-    PQuasiQuote _ quoter body -> PQuasiQuote span0 quoter body
-    PTuple _ tupleFlavor elems -> PTuple span0 tupleFlavor (map normalizePattern elems)
-    PList _ elems -> PList span0 (map normalizePattern elems)
-    PCon _ con args -> PCon span0 con (map normalizePattern args)
-    PInfix _ lhs op rhs -> PInfix span0 (normalizePattern lhs) op (normalizePattern rhs)
-    PView _ expr inner -> PView span0 (normalizeViewExpr expr) (normalizePattern inner)
-    PAs _ name inner -> PAs span0 name (normalizeAsInner inner)
-    PStrict _ inner -> PStrict span0 (normalizeUnaryInner inner)
-    PIrrefutable _ inner -> PIrrefutable span0 (normalizeUnaryInner inner)
-    PNegLit _ lit -> PNegLit span0 (normalizeLiteral lit)
-    PParen _ inner -> PParen span0 (normalizePattern inner)
-    PUnboxedSum _ altIdx arity inner -> PUnboxedSum span0 altIdx arity (normalizePattern inner)
-    PRecord _ con fields rwc -> PRecord span0 con [(fieldName, normalizePattern fieldPat) | (fieldName, fieldPat) <- fields] rwc
-    PTypeSig _ inner ty -> PTypeSig span0 (normalizePattern inner) (normalizeTypeSpan ty)
-    PSplice _ body -> PSplice span0 (normalizeExpr body)
+    PVar name -> PVar name
+    PWildcard -> PWildcard
+    PLit lit -> PLit (normalizeLiteral lit)
+    PQuasiQuote quoter body -> PQuasiQuote quoter body
+    PTuple tupleFlavor elems -> PTuple tupleFlavor (map normalizePattern elems)
+    PList elems -> PList (map normalizePattern elems)
+    PCon con args -> PCon con (map normalizePattern args)
+    PInfix lhs op rhs -> PInfix (normalizePattern lhs) op (normalizePattern rhs)
+    PView expr inner -> PView (normalizeViewExpr expr) (normalizePattern inner)
+    PAs name inner -> PAs name (normalizeAsInner inner)
+    PStrict inner -> PStrict (normalizeUnaryInner inner)
+    PIrrefutable inner -> PIrrefutable (normalizeUnaryInner inner)
+    PNegLit lit -> PNegLit (normalizeLiteral lit)
+    PParen inner -> PParen (normalizePattern inner)
+    PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (normalizePattern inner)
+    PRecord con fields rwc -> PRecord con [(fieldName, normalizePattern fieldPat) | (fieldName, fieldPat) <- fields] rwc
+    PTypeSig inner ty -> PTypeSig (normalizePattern inner) (normalizeTypeSpan ty)
+    PSplice body -> PSplice (normalizeExpr body)
 
--- | Normalize source spans in a type (reset to noSourceSpan).
 normalizeTypeSpan :: Type -> Type
 normalizeTypeSpan ty =
   case ty of
-    TVar _ name -> TVar span0 name
-    TCon _ name promoted -> TCon span0 name promoted
-    TTypeLit _ lit -> TTypeLit span0 lit
-    TStar _ -> TStar span0
-    TQuasiQuote _ quoter body -> TQuasiQuote span0 quoter body
-    TForall _ binders inner -> TForall span0 binders (normalizeTypeSpan inner)
-    TApp _ lhs rhs -> TApp span0 (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
-    TFun _ lhs rhs -> TFun span0 (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
-    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map normalizeTypeSpan elems)
-    TList _ promoted inner -> TList span0 promoted (normalizeTypeSpan inner)
-    TParen _ inner -> TParen span0 (normalizeTypeSpan inner)
-    TContext _ constraints inner -> TContext span0 constraints (normalizeTypeSpan inner)
-    TUnboxedSum _ elems -> TUnboxedSum span0 (map normalizeTypeSpan elems)
-    TSplice _ body -> TSplice span0 (normalizeExpr body)
+    TVar name -> TVar name
+    TCon name promoted -> TCon name promoted
+    TTypeLit lit -> TTypeLit lit
+    TStar -> TStar
+    TQuasiQuote quoter body -> TQuasiQuote quoter body
+    TForall binders inner -> TForall binders (normalizeTypeSpan inner)
+    TApp lhs rhs -> TApp (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
+    TFun lhs rhs -> TFun (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
+    TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeTypeSpan elems)
+    TList promoted inner -> TList promoted (normalizeTypeSpan inner)
+    TParen inner -> TParen (normalizeTypeSpan inner)
+    TContext constraints inner -> TContext constraints (normalizeTypeSpan inner)
+    TUnboxedSum elems -> TUnboxedSum (map normalizeTypeSpan elems)
+    TSplice body -> TSplice (normalizeExpr body)
 
 normalizeLiteral :: Literal -> Literal
 normalizeLiteral lit =
   case lit of
-    LitInt _ value repr -> LitInt span0 value repr
-    LitIntHash _ value repr -> LitIntHash span0 value repr
-    LitIntBase _ value repr -> LitIntBase span0 value repr
-    LitIntBaseHash _ value repr -> LitIntBaseHash span0 value repr
-    LitFloat _ value repr -> LitFloat span0 value repr
-    LitFloatHash _ value repr -> LitFloatHash span0 value repr
-    LitChar _ value repr -> LitChar span0 value repr
-    LitCharHash _ value repr -> LitCharHash span0 value repr
-    LitString _ value repr -> LitString span0 value repr
-    LitStringHash _ value repr -> LitStringHash span0 value repr
+    LitInt value repr -> LitInt value repr
+    LitIntHash value repr -> LitIntHash value repr
+    LitIntBase value repr -> LitIntBase value repr
+    LitIntBaseHash value repr -> LitIntBaseHash value repr
+    LitFloat value repr -> LitFloat value repr
+    LitFloatHash value repr -> LitFloatHash value repr
+    LitChar value repr -> LitChar value repr
+    LitCharHash value repr -> LitCharHash value repr
+    LitString value repr -> LitString value repr
+    LitStringHash value repr -> LitStringHash value repr
 
 normalizeViewExpr :: Expr -> Expr
 normalizeViewExpr expr =
   case expr of
-    EVar _ name -> EVar span0 name
-    EInt _ value repr -> EInt span0 value repr
-    EParen _ inner -> EParen span0 (normalizeViewExpr inner)
+    EVar name -> EVar name
+    EInt value repr -> EInt value repr
+    EParen inner -> EParen (normalizeViewExpr inner)
     _ -> expr
 
 normalizeUnaryInner :: Pattern -> Pattern
 normalizeUnaryInner pat =
   case normalizePattern pat of
-    PParen _ inner@(PNegLit {}) -> inner
-    PParen _ inner@(PStrict {}) -> inner
-    PParen _ inner@(PIrrefutable {}) -> inner
+    PParen inner@(PNegLit {}) -> inner
+    PParen inner@(PStrict {}) -> inner
+    PParen inner@(PIrrefutable {}) -> inner
     other -> other
 
--- | Normalize the inner pattern of an as-pattern.
--- The pretty-printer adds parens around negative literals after @ for safety (a@-0 is invalid),
--- and around strict/irrefutable patterns to avoid lexing @!/@~ as symbolic operators,
--- so we strip those parens to get the canonical form.
 normalizeAsInner :: Pattern -> Pattern
 normalizeAsInner pat =
   case normalizePattern pat of
-    PParen _ inner@(PNegLit {}) -> inner
-    PParen _ inner@(PStrict {}) -> inner
-    PParen _ inner@(PIrrefutable {}) -> inner
+    PParen inner@(PNegLit {}) -> inner
+    PParen inner@(PStrict {}) -> inner
+    PParen inner@(PIrrefutable {}) -> inner
     other -> other

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -8,19 +8,15 @@ where
 
 import Aihc.Parser
 import Aihc.Parser.Lex (isReservedIdentifier)
-import Aihc.Parser.Syntax
-import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
-import qualified Data.Set as Set
+import Aihc.Parser.Syntax (Extension (TemplateHaskell, UnboxedSums, UnboxedTuples))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
+import Test.Properties.BareSyntax
 import Test.Properties.ExprHelpers (normalizeExpr)
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
-
-span0 :: SourceSpan
-span0 = noSourceSpan
 
 typeConfig :: ParserConfig
 typeConfig =
@@ -30,54 +26,15 @@ typeConfig =
 
 prop_typePrettyRoundTrip :: Type -> Property
 prop_typePrettyRoundTrip ty =
-  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty ty))
+  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty (toSyntaxType ty)))
       expected = normalizeType ty
-   in checkCoverage $
-        applyCoverage (typeCtorCoverage ty) $
-          counterexample (T.unpack source) $
-            case parseType typeConfig source of
-              ParseErr err ->
-                counterexample (errorBundlePretty (Just source) err) False
-              ParseOk parsed ->
-                let actual = normalizeType parsed
-                 in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
-
-typeCtorCoverage :: Type -> [Property -> Property]
-typeCtorCoverage ty =
-  let allCtors = map showConstr (dataTypeConstrs (dataTypeOf (undefined :: Type)))
-      -- Exclude constructors that cannot be round-tripped through the parser yet
-      coverableCtors = allCtors
-      seenCtors = typeCtorNames ty
-   in [cover 1 (ctor `Set.member` seenCtors) ctor | ctor <- coverableCtors]
-
-applyCoverage :: [Property -> Property] -> Property -> Property
-applyCoverage wrappers prop = foldr (\wrap acc -> wrap acc) prop wrappers
-
-typeCtorNames :: Type -> Set.Set String
-typeCtorNames ty =
-  let here = Set.singleton (showConstr (toConstr ty))
-   in case ty of
-        TVar {} -> here
-        TCon {} -> here
-        TTypeLit {} -> here
-        TStar {} -> here
-        TQuasiQuote {} -> here
-        TForall _ _ inner -> here <> typeCtorNames inner
-        TApp _ f x -> here <> typeCtorNames f <> typeCtorNames x
-        TFun _ a b -> here <> typeCtorNames a <> typeCtorNames b
-        TTuple _ _ _ elems -> here <> mconcat (map typeCtorNames elems)
-        TList _ _ inner -> here <> typeCtorNames inner
-        TParen _ inner -> here <> typeCtorNames inner
-        TUnboxedSum _ elems -> here <> mconcat (map typeCtorNames elems)
-        TContext _ constraints inner ->
-          here <> mconcat (map constraintTypeCtorNames constraints) <> typeCtorNames inner
-        TSplice {} -> here
-
-constraintTypeCtorNames :: Constraint -> Set.Set String
-constraintTypeCtorNames constraint =
-  case constraint of
-    Constraint _ _ args -> mconcat (map typeCtorNames args)
-    CParen _ inner -> constraintTypeCtorNames inner
+   in counterexample (T.unpack source) $
+        case parseType typeConfig source of
+          ParseErr err ->
+            counterexample (errorBundlePretty (Just source) err) False
+          ParseOk parsed ->
+            let actual = normalizeType (eraseType parsed)
+             in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
 instance Arbitrary Type where
   arbitrary = sized (genType . min 6)
@@ -86,48 +43,48 @@ instance Arbitrary Type where
 shrinkType :: Type -> [Type]
 shrinkType ty =
   case ty of
-    TVar _ name ->
-      [TVar span0 shrunk | shrunk <- shrinkIdent name]
-    TCon _ name promoted ->
-      [TCon span0 shrunk promoted | shrunk <- shrinkTypeConName name]
+    TVar name ->
+      [TVar shrunk | shrunk <- shrinkIdent name]
+    TCon name promoted ->
+      [TCon shrunk promoted | shrunk <- shrinkTypeConName name]
     TTypeLit {} ->
       []
-    TStar _ ->
+    TStar ->
       []
-    TQuasiQuote _ quoter body ->
-      [TQuasiQuote span0 q body | q <- shrinkIdent quoter]
-        <> [TQuasiQuote span0 quoter b | b <- map T.pack (shrink (T.unpack body))]
-    TForall _ binders inner ->
+    TQuasiQuote quoter body ->
+      [TQuasiQuote q body | q <- shrinkIdent quoter]
+        <> [TQuasiQuote quoter b | b <- map T.pack (shrink (T.unpack body))]
+    TForall binders inner ->
       [canonicalForallInner inner]
-        <> [TForall span0 binders' (canonicalForallInner inner) | binders' <- shrinkTypeBinders binders]
-        <> [TForall span0 binders (canonicalForallInner inner') | inner' <- shrinkType inner]
-    TApp _ fn arg ->
+        <> [TForall binders' (canonicalForallInner inner) | binders' <- shrinkTypeBinders binders]
+        <> [TForall binders (canonicalForallInner inner') | inner' <- shrinkType inner]
+    TApp fn arg ->
       [canonicalAppHead fn, canonicalAppArg arg]
-        <> [TApp span0 (canonicalAppHead fn') (canonicalAppArg arg) | fn' <- shrinkType fn]
-        <> [TApp span0 (canonicalAppHead fn) (canonicalAppArg arg') | arg' <- shrinkType arg]
-    TFun _ lhs rhs ->
+        <> [TApp (canonicalAppHead fn') (canonicalAppArg arg) | fn' <- shrinkType fn]
+        <> [TApp (canonicalAppHead fn) (canonicalAppArg arg') | arg' <- shrinkType arg]
+    TFun lhs rhs ->
       [canonicalFunLeft lhs, rhs]
-        <> [TFun span0 (canonicalFunLeft lhs') rhs | lhs' <- shrinkType lhs]
-        <> [TFun span0 (canonicalFunLeft lhs) rhs' | rhs' <- shrinkType rhs]
-    TTuple _ tupleFlavor _ elems ->
+        <> [TFun (canonicalFunLeft lhs') rhs | lhs' <- shrinkType lhs]
+        <> [TFun (canonicalFunLeft lhs) rhs' | rhs' <- shrinkType rhs]
+    TTuple tupleFlavor _ elems ->
       shrinkTupleElems tupleFlavor elems
-    TList _ _ inner ->
-      [inner] <> [TList span0 Unpromoted inner' | inner' <- shrinkType inner]
-    TParen _ inner ->
-      [inner] <> [TParen span0 inner' | inner' <- shrinkType inner]
-    TUnboxedSum _ elems ->
-      [TUnboxedSum span0 elems' | elems' <- shrinkList shrinkType elems, length elems' >= 2]
-    TContext _ constraints inner ->
+    TList _ inner ->
+      [inner] <> [TList Unpromoted inner' | inner' <- shrinkType inner]
+    TParen inner ->
+      [inner] <> [TParen inner' | inner' <- shrinkType inner]
+    TUnboxedSum elems ->
+      [TUnboxedSum elems' | elems' <- shrinkList shrinkType elems, length elems' >= 2]
+    TContext constraints inner ->
       [inner]
-        <> [TContext span0 constraints' inner | constraints' <- shrinkConstraints constraints]
-        <> [TContext span0 constraints inner' | inner' <- shrinkType inner]
+        <> [TContext constraints' inner | constraints' <- shrinkConstraints constraints]
+        <> [TContext constraints inner' | inner' <- shrinkType inner]
     TSplice {} ->
       []
 
 canonicalForallInner :: Type -> Type
 canonicalForallInner ty =
   case ty of
-    TForall {} -> TParen span0 ty
+    TForall {} -> TParen ty
     _ -> ty
 
 shrinkTypeBinders :: [Text] -> [[Text]]
@@ -157,9 +114,9 @@ shrinkTupleElems tupleFlavor elems =
   [ candidate
   | shrunk <- shrinkList shrinkType elems,
     candidate <- case shrunk of
-      [] -> [TTuple span0 tupleFlavor Unpromoted []]
+      [] -> [TTuple tupleFlavor Unpromoted []]
       [_] -> []
-      _ -> [TTuple span0 tupleFlavor Unpromoted shrunk]
+      _ -> [TTuple tupleFlavor Unpromoted shrunk]
   ]
 
 shrinkConstraints :: [Constraint] -> [[Constraint]]
@@ -168,69 +125,65 @@ shrinkConstraints = shrinkList shrinkConstraint
 shrinkConstraint :: Constraint -> [Constraint]
 shrinkConstraint constraint =
   case constraint of
-    Constraint _ cls args ->
-      [ Constraint
-          { constraintSpan = span0,
-            constraintClass = cls,
-            constraintArgs = shrunk
-          }
+    Constraint cls args ->
+      [ Constraint cls shrunk
       | shrunk <- shrinkList shrinkType args
       ]
-    CParen _ inner ->
-      inner : [CParen span0 shrunk | shrunk <- shrinkConstraint inner]
+    CParen inner ->
+      inner : [CParen shrunk | shrunk <- shrinkConstraint inner]
 
 genType :: Int -> Gen Type
 genType depth
   | depth <= 0 =
       oneof
-        [ TVar span0 <$> genTypeVarName,
-          (\name -> TCon span0 name Unpromoted) <$> genTypeConName,
-          TTypeLit span0 <$> genTypeLiteral,
-          pure (TStar span0),
-          TQuasiQuote span0 <$> genQuoterName <*> genQuasiBody,
-          TTuple span0 Boxed Unpromoted <$> elements [[], [TVar span0 "a", TCon span0 "B" Unpromoted]],
-          TTuple span0 Unboxed Unpromoted <$> elements [[], [TVar span0 "a", TCon span0 "B" Unpromoted]],
-          TList span0 Unpromoted <$> genTypeAtom 0,
-          TParen span0 <$> genTypeAtom 0,
-          TUnboxedSum span0 <$> genUnboxedSumElems 0
+        [ TVar <$> genTypeVarName,
+          (`TCon` Unpromoted) <$> genTypeConName,
+          TTypeLit <$> genTypeLiteral,
+          pure TStar,
+          TQuasiQuote <$> genQuoterName <*> genQuasiBody,
+          TTuple Boxed Unpromoted <$> elements [[], [TVar "a", TCon "B" Unpromoted]],
+          TTuple Unboxed Unpromoted <$> elements [[], [TVar "a", TCon "B" Unpromoted]],
+          TList Unpromoted <$> genTypeAtom 0,
+          TParen <$> genTypeAtom 0,
+          TUnboxedSum <$> genUnboxedSumElems 0
         ]
   | otherwise =
       frequency
-        [ (3, TVar span0 <$> genTypeVarName),
-          (3, (\name -> TCon span0 name Unpromoted) <$> genTypeConName),
-          (1, TTypeLit span0 <$> genTypeLiteral),
-          (1, pure (TStar span0)),
-          (2, TQuasiQuote span0 <$> genQuoterName <*> genQuasiBody),
-          (2, TForall span0 <$> genTypeBinders <*> genForallInner (depth - 1)),
+        [ (3, TVar <$> genTypeVarName),
+          (3, (`TCon` Unpromoted) <$> genTypeConName),
+          (1, TTypeLit <$> genTypeLiteral),
+          (1, pure TStar),
+          (2, TQuasiQuote <$> genQuoterName <*> genQuasiBody),
+          (2, TForall <$> genTypeBinders <*> genForallInner (depth - 1)),
           (4, genTypeApp depth),
           (4, genTypeFun depth),
-          (3, TTuple span0 Boxed Unpromoted <$> genTypeTupleElems (depth - 1)),
-          (2, TTuple span0 Unboxed Unpromoted <$> genTypeTupleElems (depth - 1)),
-          (2, TUnboxedSum span0 <$> genUnboxedSumElems (depth - 1)),
-          (3, TList span0 Unpromoted <$> genType (depth - 1)),
-          (3, TParen span0 <$> genType (depth - 1)),
-          (3, TContext span0 <$> genConstraints (depth - 1) <*> genContextInner (depth - 1)),
-          (2, TSplice span0 <$> genTypeSpliceBody)
+          (3, TTuple Boxed Unpromoted <$> genTypeTupleElems (depth - 1)),
+          (2, TTuple Unboxed Unpromoted <$> genTypeTupleElems (depth - 1)),
+          (2, TUnboxedSum <$> genUnboxedSumElems (depth - 1)),
+          (3, TList Unpromoted <$> genType (depth - 1)),
+          (3, TParen <$> genType (depth - 1)),
+          (3, TContext <$> genConstraints (depth - 1) <*> genContextInner (depth - 1)),
+          (2, TSplice <$> genTypeSpliceBody)
         ]
 
 genTypeApp :: Int -> Gen Type
 genTypeApp depth = do
   fn <- genType (depth - 1)
   arg <- genType (depth - 1)
-  pure (TApp span0 (canonicalAppHead fn) (canonicalAppArg arg))
+  pure (TApp (canonicalAppHead fn) (canonicalAppArg arg))
 
 genTypeFun :: Int -> Gen Type
 genTypeFun depth = do
   lhs <- genType (depth - 1)
   rhs <- genType (depth - 1)
-  pure (TFun span0 (canonicalFunLeft lhs) rhs)
+  pure (TFun (canonicalFunLeft lhs) rhs)
 
 genForallInner :: Int -> Gen Type
 genForallInner depth = do
   inner <- genType depth
   pure $
     case inner of
-      TForall {} -> TParen span0 inner
+      TForall {} -> TParen inner
       _ -> inner
 
 genContextInner :: Int -> Gen Type
@@ -238,15 +191,14 @@ genContextInner depth = do
   inner <- genType depth
   pure $
     case inner of
-      TContext {} -> TParen span0 inner
+      TContext {} -> TParen inner
       _ -> inner
 
--- | Generate the body of a TH type splice: either a bare variable or a parenthesized expression.
 genTypeSpliceBody :: Gen Expr
 genTypeSpliceBody =
   oneof
-    [ EVar span0 <$> genIdent,
-      EParen span0 . EVar span0 <$> genIdent
+    [ EVar <$> genIdent,
+      EParen . EVar <$> genIdent
     ]
 
 genTypeTupleElems :: Int -> Gen [Type]
@@ -266,16 +218,16 @@ genUnboxedSumElems depth = do
 genTypeAtom :: Int -> Gen Type
 genTypeAtom depth =
   oneof
-    [ TVar span0 <$> genTypeVarName,
-      (\name -> TCon span0 name Unpromoted) <$> genTypeConName,
-      TTypeLit span0 <$> genTypeLiteral,
-      pure (TStar span0),
-      TQuasiQuote span0 <$> genQuoterName <*> genQuasiBody,
-      TTuple span0 Boxed Unpromoted <$> genTypeTupleElems depth,
-      TTuple span0 Unboxed Unpromoted <$> genTypeTupleElems depth,
-      TUnboxedSum span0 <$> genUnboxedSumElems depth,
-      TList span0 Unpromoted <$> genType depth,
-      TParen span0 <$> genType depth
+    [ TVar <$> genTypeVarName,
+      (`TCon` Unpromoted) <$> genTypeConName,
+      TTypeLit <$> genTypeLiteral,
+      pure TStar,
+      TQuasiQuote <$> genQuoterName <*> genQuasiBody,
+      TTuple Boxed Unpromoted <$> genTypeTupleElems depth,
+      TTuple Unboxed Unpromoted <$> genTypeTupleElems depth,
+      TUnboxedSum <$> genUnboxedSumElems depth,
+      TList Unpromoted <$> genType depth,
+      TParen <$> genType depth
     ]
 
 genConstraints :: Int -> Gen [Constraint]
@@ -288,12 +240,7 @@ genConstraint depth = do
   cls <- genTypeConName
   argCount <- chooseInt (0, 2)
   args <- vectorOf argCount (genConstraintArg depth)
-  pure $
-    Constraint
-      { constraintSpan = span0,
-        constraintClass = cls,
-        constraintArgs = args
-      }
+  pure (Constraint cls args)
 
 genConstraintArg :: Int -> Gen Type
 genConstraintArg depth = do
@@ -303,26 +250,26 @@ genConstraintArg depth = do
 canonicalFunLeft :: Type -> Type
 canonicalFunLeft ty =
   case ty of
-    TForall {} -> TParen span0 ty
-    TFun {} -> TParen span0 ty
-    TContext {} -> TParen span0 ty
+    TForall {} -> TParen ty
+    TFun {} -> TParen ty
+    TContext {} -> TParen ty
     _ -> ty
 
 canonicalAppHead :: Type -> Type
 canonicalAppHead ty =
   case ty of
-    TForall {} -> TParen span0 ty
-    TFun {} -> TParen span0 ty
-    TContext {} -> TParen span0 ty
+    TForall {} -> TParen ty
+    TFun {} -> TParen ty
+    TContext {} -> TParen ty
     _ -> ty
 
 canonicalAppArg :: Type -> Type
 canonicalAppArg ty =
   case ty of
-    TApp {} -> TParen span0 ty
-    TForall {} -> TParen span0 ty
-    TFun {} -> TParen span0 ty
-    TContext {} -> TParen span0 ty
+    TApp {} -> TParen ty
+    TForall {} -> TParen ty
+    TFun {} -> TParen ty
+    TContext {} -> TParen ty
     _ -> ty
 
 canonicalConstraintArg :: Type -> Type
@@ -337,7 +284,7 @@ canonicalConstraintArg ty =
     TTuple {} -> ty
     TUnboxedSum {} -> ty
     TParen {} -> ty
-    _ -> TParen span0 ty
+    _ -> TParen ty
 
 genTypeBinders :: Gen [Text]
 genTypeBinders = do
@@ -367,7 +314,6 @@ genQuoterName = do
   restLen <- chooseInt (0, 4)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
   let candidate = T.pack (first : rest)
-  -- Exclude names that clash with TH quote brackets when TemplateHaskell is enabled
   if candidate `elem` ["e", "t", "d", "p"]
     then genQuoterName
     else pure candidate
@@ -404,29 +350,23 @@ genTypeLiteralChar = elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "
 normalizeType :: Type -> Type
 normalizeType ty =
   case ty of
-    TVar _ name -> TVar span0 name
-    TCon _ name promoted -> TCon span0 name promoted
-    TTypeLit _ lit -> TTypeLit span0 lit
-    TStar _ -> TStar span0
-    TQuasiQuote _ quoter body -> TQuasiQuote span0 quoter body
-    TForall _ binders inner -> TForall span0 binders (normalizeType inner)
-    TApp _ f x -> TApp span0 (normalizeType f) (normalizeType x)
-    TFun _ a b -> TFun span0 (normalizeType a) (normalizeType b)
-    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map normalizeType elems)
-    TList _ promoted inner -> TList span0 promoted (normalizeType inner)
-    TParen _ inner -> TParen span0 (normalizeType inner)
-    TUnboxedSum _ elems -> TUnboxedSum span0 (map normalizeType elems)
-    TContext _ constraints inner -> TContext span0 (map normalizeConstraint constraints) (normalizeType inner)
-    TSplice _ body -> TSplice span0 (normalizeExpr body)
+    TVar name -> TVar name
+    TCon name promoted -> TCon name promoted
+    TTypeLit lit -> TTypeLit lit
+    TStar -> TStar
+    TQuasiQuote quoter body -> TQuasiQuote quoter body
+    TForall binders inner -> TForall binders (normalizeType inner)
+    TApp f x -> TApp (normalizeType f) (normalizeType x)
+    TFun a b -> TFun (normalizeType a) (normalizeType b)
+    TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
+    TList promoted inner -> TList promoted (normalizeType inner)
+    TParen inner -> TParen (normalizeType inner)
+    TUnboxedSum elems -> TUnboxedSum (map normalizeType elems)
+    TContext constraints inner -> TContext (map normalizeConstraint constraints) (normalizeType inner)
+    TSplice body -> TSplice (normalizeExpr body)
 
 normalizeConstraint :: Constraint -> Constraint
 normalizeConstraint constraint =
   case constraint of
-    Constraint _ cls args ->
-      Constraint
-        { constraintSpan = span0,
-          constraintClass = cls,
-          constraintArgs = map normalizeType args
-        }
-    CParen _ inner ->
-      CParen span0 (normalizeConstraint inner)
+    Constraint cls args -> Constraint cls (map normalizeType args)
+    CParen inner -> CParen (normalizeConstraint inner)


### PR DESCRIPTION
## Summary
- add a test-only unannotated BareSyntax AST for parser property generators, with conversions to and from the production syntax tree
- migrate expression, pattern, type, and module round-trip properties to generate bare AST values and compare parser output after erasing spans
- keep the production parser AST unchanged for now while unblocking issue #418 with a smaller reviewable slice

## Verification
- cabal build aihc-parser:test:spec
- cabal test aihc-parser:test:spec
- nix flake check
- coderabbit review --prompt-only (no findings)

## Progress
- parser progress: PASS 520 / XFAIL 86 / FAIL 0 / TOTAL 606 (85.8% complete)
- extension progress: SUPPORTED 45 / IN_PROGRESS 26 / TOTAL 71

## Remaining Work
- annotate the production parser AST with source spans instead of the current hardcoded representation
- thread the annotated AST through parser internals, pretty-printing, and shorthand utilities
- decide whether the eventual production AST should use a phase-indexed/extensible annotation design or a simpler direct annotation parameter