### PR TITLE
fix(parser): support default signatures in class declarations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -38,6 +38,7 @@ where
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..))
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), TokStream (..), mkFoundToken)
+import Control.Monad (guard)
 import Data.Char (isUpper)
 import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
@@ -319,14 +320,23 @@ constraintParserWith typeAtomParser =
   MP.try parenthesizedConstraintParser <|> bareConstraintParser
   where
     bareConstraintParser = withSpan $ do
-      className <- identifierTextParser
-      args <- MP.many typeAtomParser
+      (className, args) <- MP.try infixConstraintParser <|> prefixConstraintParser
       pure $ \span' ->
         Constraint
           { constraintSpan = span',
             constraintClass = className,
             constraintArgs = args
           }
+    prefixConstraintParser = do
+      className <- identifierTextParser
+      args <- MP.many typeAtomParser
+      pure (className, args)
+    infixConstraintParser = do
+      lhs <- typeAtomParser
+      op <- operatorTextParser
+      guard (op == "~")
+      rhs <- typeAtomParser
+      pure (op, [lhs, rhs])
     parenthesizedConstraintParser = withSpan $ do
       constraint <- parens (constraintParserWith typeAtomParser)
       pure (`CParen` constraint)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -662,6 +662,7 @@ classDeclItemParser =
     <|> MP.try classTypeFamilyDeclParser
     <|> MP.try classDataFamilyDeclParser
     <|> MP.try classDefaultTypeInstParser
+    <|> MP.try classDefaultSigItemParser
     <|> MP.try classTypeSigItemParser
     <|> classDefaultItemParser
 
@@ -671,6 +672,14 @@ classTypeSigItemParser = withSpan $ do
   expectedTok TkReservedDoubleColon
   ty <- typeParser
   pure (\span' -> ClassItemTypeSig span' names ty)
+
+classDefaultSigItemParser :: TokParser ClassDeclItem
+classDefaultSigItemParser = withSpan $ do
+  keywordTok TkKeywordDefault
+  name <- binderNameParser
+  expectedTok TkReservedDoubleColon
+  ty <- typeParser
+  pure (\span' -> ClassItemDefaultSig span' name ty)
 
 classFixityItemParser :: TokParser ClassDeclItem
 classFixityItemParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -346,6 +346,9 @@ prettyContext constraints =
 prettyConstraint :: Constraint -> Doc ann
 prettyConstraint constraint =
   case constraint of
+    Constraint _ cls [lhs, rhs]
+      | cls == "~" ->
+          prettyTypeIn CtxTypeAtom lhs <+> pretty cls <+> prettyTypeIn CtxTypeAtom rhs
     Constraint _ cls args ->
       hsep (pretty cls : map (prettyTypeIn CtxTypeAtom) args)
     CParen _ inner ->
@@ -672,6 +675,7 @@ prettyClassItem :: ClassDeclItem -> Doc ann
 prettyClassItem item =
   case item of
     ClassItemTypeSig _ names ty -> hsep [hsep (punctuate comma (map prettyBinderName names)), "::", prettyType ty]
+    ClassItemDefaultSig _ name ty -> hsep ["default", prettyBinderName name, "::", prettyType ty]
     ClassItemFixity _ assoc prec ops ->
       hsep
         ( [prettyFixityAssoc assoc]

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -320,6 +320,7 @@ docClassDeclItem :: ClassDeclItem -> Doc ann
 docClassDeclItem item =
   case item of
     ClassItemTypeSig _ names ty -> "ClassItemTypeSig" <+> braces (hsep (punctuate comma [field "names" (docTextList names), field "type" (docType ty)]))
+    ClassItemDefaultSig _ name ty -> "ClassItemDefaultSig" <+> braces (hsep (punctuate comma [field "name" (docText name), field "type" (docType ty)]))
     ClassItemFixity _ assoc mPrec ops -> "ClassItemFixity" <+> braces (hsep (punctuate comma ([field "assoc" (docFixityAssoc assoc)] <> optionalField "prec" pretty mPrec <> [field "ops" (docTextList ops)])))
     ClassItemDefault _ vdecl -> "ClassItemDefault" <+> parens (docValueDecl vdecl)
     ClassItemTypeFamilyDecl _ tf -> "ClassItemTypeFamilyDecl" <+> parens (docTypeFamilyDecl tf)

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1065,6 +1065,7 @@ instance HasSourceSpan FunctionalDependency where
 
 data ClassDeclItem
   = ClassItemTypeSig SourceSpan [BinderName] Type
+  | ClassItemDefaultSig SourceSpan BinderName Type
   | ClassItemFixity SourceSpan FixityAssoc (Maybe Int) [OperatorName]
   | ClassItemDefault SourceSpan ValueDecl
   | ClassItemTypeFamilyDecl SourceSpan TypeFamilyDecl
@@ -1076,6 +1077,7 @@ instance HasSourceSpan ClassDeclItem where
   getSourceSpan classDeclItem =
     case classDeclItem of
       ClassItemTypeSig span' _ _ -> span'
+      ClassItemDefaultSig span' _ _ -> span'
       ClassItemFixity span' _ _ _ -> span'
       ClassItemDefault span' _ -> span'
       ClassItemTypeFamilyDecl span' _ -> span'

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DefaultSignatures/basic.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DefaultSignatures/basic.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail basic default signature -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DefaultSignatures #-}
 module Basic where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DefaultSignatures/context.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DefaultSignatures/context.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail default signature with context -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DefaultSignatures #-}
 module Context where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DefaultSignatures/equality.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DefaultSignatures/equality.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DefaultSignatures #-}
+module Equality where
+
+class Inj a where
+  inj :: a -> a
+  default inj :: (p ~ a) => p -> a
+  inj = \x -> x


### PR DESCRIPTION
## Summary
- add parser support for `default name :: type` inside class declarations
- add a minimal oracle regression for the `default inj :: (p ~ a) => p -> a` failure
- mark the existing `DefaultSignatures` oracle fixtures as passing

## Testing
- `cabal test aihc-parser:spec`
- `nix flake check`

## Progress
- Parser progress: `PASS 544 -> 547` (`+3`), `XFAIL 62 -> 60` (`-2`), `TOTAL 606 -> 607` (`+1`), completion `89.76% -> 90.11%` (`+0.35pp`)
- Extension progress: `SUPPORTED 48 -> 49`, `IN_PROGRESS 23 -> 22`
- `DefaultSignatures`: `PASS 0 -> 3`, `XFAIL 2 -> 0` (`In Progress -> Supported`)

## CodeRabbit
- `coderabbit review --prompt-only` did not return findings locally after setup, so this PR proceeds per repo guidance.
