### PR TITLE
fix(parser): preserve logical spans with physical offsets

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -28,6 +28,7 @@ library
       base >=4.16 && <5
     , text >=1.2
     , containers
+    , bytestring
     , deepseq
     , megaparsec
     , prettyprinter

--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -35,18 +35,21 @@ import Aihc.Parser.Internal.Module (moduleParser)
 import Aihc.Parser.Lex
   ( LexToken (..),
     TokenOrigin (..),
-    lexModuleTokensWithExtensions,
-    lexTokensWithExtensions,
+    lexModuleTokensWithSourceNameAndExtensions,
+    lexTokensWithSourceNameAndExtensions,
     readModuleHeaderExtensions,
   )
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax (Expr, Extension (..), ExtensionSetting (..), Module, Pattern, SourceSpan (..), Type)
 import Aihc.Parser.Types
+import Data.ByteString qualified as BS
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Word (Word8)
 import Prettyprinter (Doc, colon, defaultLayoutOptions, layoutPretty, pretty, vcat)
 import Prettyprinter.Render.String (renderString)
 import Text.Megaparsec (runParser)
@@ -91,7 +94,7 @@ defaultConfig =
 -- "error"
 parseExpr :: ParserConfig -> Text -> ParseResult Expr
 parseExpr cfg input =
-  let toks = lexTokensWithExtensions (parserExtensions cfg) input
+  let toks = lexTokensWithSourceNameAndExtensions (parserSourceName cfg) (parserExtensions cfg) input
    in case runParser (exprParser <* eofTok) (parserSourceName cfg) (mkTokStreamWithExtensions toks (parserExtensions cfg)) of
         Left bundle -> ParseErr bundle
         Right expr -> ParseOk expr
@@ -105,7 +108,7 @@ parseExpr cfg input =
 -- ParseOk (PCon "Just" [PVar "x"])
 parsePattern :: ParserConfig -> Text -> ParseResult Pattern
 parsePattern cfg input =
-  let toks = lexTokensWithExtensions (parserExtensions cfg) input
+  let toks = lexTokensWithSourceNameAndExtensions (parserSourceName cfg) (parserExtensions cfg) input
    in case runParser (patternParser <* eofTok) (parserSourceName cfg) (mkTokStreamWithExtensions toks (parserExtensions cfg)) of
         Left bundle -> ParseErr bundle
         Right pat -> ParseOk pat
@@ -119,7 +122,7 @@ parsePattern cfg input =
 -- ParseOk (TApp (TCon "Maybe") (TVar "a"))
 parseType :: ParserConfig -> Text -> ParseResult Type
 parseType cfg input =
-  let toks = lexTokensWithExtensions (parserExtensions cfg) input
+  let toks = lexTokensWithSourceNameAndExtensions (parserSourceName cfg) (parserExtensions cfg) input
    in case runParser (typeParser <* eofTok) (parserSourceName cfg) (mkTokStreamWithExtensions toks (parserExtensions cfg)) of
         Left bundle -> ParseErr bundle
         Right ty -> ParseOk ty
@@ -135,7 +138,7 @@ parseType cfg input =
 -- Nothing
 parseModule :: ParserConfig -> Text -> ParseResult Module
 parseModule cfg input =
-  let toks = lexModuleTokensWithExtensions effectiveExtensions input
+  let toks = lexModuleTokensWithSourceNameAndExtensions (parserSourceName cfg) effectiveExtensions input
    in case runParser (moduleParser <* eofTok) (parserSourceName cfg) (mkTokStreamWithExtensions toks effectiveExtensions) of
         Left bundle -> ParseErr bundle
         Right modu -> ParseOk modu
@@ -251,27 +254,56 @@ renderErrorBlocks mSource bundle =
 -- """
 renderSourceReference :: String -> Text -> SourceSpan -> Doc ann
 renderSourceReference origin source srcSpan =
-  let (lineNo, colNo, endCol) = case srcSpan of
-        SourceSpan sourceLine col _ endC -> (sourceLine, col, endC)
-        NoSourceSpan -> (1, 1, 1)
+  let (renderedOrigin, lineNo, colNo, endCol, srcLine) = case srcSpan of
+        SourceSpan {sourceSpanSourceName, sourceSpanStartLine, sourceSpanStartCol, sourceSpanEndCol, sourceSpanStartOffset} ->
+          ( sourceSpanSourceName,
+            sourceSpanStartLine,
+            sourceSpanStartCol,
+            sourceSpanEndCol,
+            extractSourceLineByOffset source sourceSpanStartOffset
+          )
+        NoSourceSpan -> (origin, 1, 1, 1, "")
       lineNoText = show lineNo
-      sourceLines = T.lines source
-      lineIdx = lineNo - 1
-      srcLine =
-        if lineIdx < 0 || lineIdx >= length sourceLines
-          then ""
-          else T.unpack (sourceLines !! lineIdx)
       markerPrefix = replicate (length lineNoText) ' ' ++ " | "
       markerStart = max 0 (colNo - 1)
       markerLen = max 1 (endCol - colNo)
       marker = replicate markerStart ' ' ++ replicate markerLen '^'
       header =
-        pretty origin <> colon <> pretty lineNo <> colon <> pretty colNo <> colon
+        pretty renderedOrigin <> colon <> pretty lineNo <> colon <> pretty colNo <> colon
    in vcat
         [ header,
           pretty (lineNoText ++ " | " ++ srcLine),
           pretty (markerPrefix ++ marker)
         ]
+
+extractSourceLineByOffset :: Text -> Int -> String
+extractSourceLineByOffset source offset =
+  let bytes = TE.encodeUtf8 source
+      len = BS.length bytes
+      anchor = max 0 (min len offset)
+      lineStart = scanBackward bytes anchor
+      lineEnd = scanForward bytes anchor
+   in T.unpack (TE.decodeUtf8 (BS.take (lineEnd - lineStart) (BS.drop lineStart bytes)))
+
+scanBackward :: BS.ByteString -> Int -> Int
+scanBackward bytes = go
+  where
+    go idx
+      | idx <= 0 = 0
+      | isLineBreak (BS.index bytes (idx - 1)) = idx
+      | otherwise = go (idx - 1)
+
+scanForward :: BS.ByteString -> Int -> Int
+scanForward bytes = go
+  where
+    len = BS.length bytes
+    go idx
+      | idx >= len = len
+      | isLineBreak (BS.index bytes idx) = idx
+      | otherwise = go (idx + 1)
+
+isLineBreak :: Word8 -> Bool
+isLineBreak w = w == 10 || w == 13
 
 renderErrorBlock :: FilePath -> Maybe Text -> MPE.ParseError TokStream ParserErrorComponent -> Doc ann
 renderErrorBlock sourceName mSource err =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -276,10 +276,13 @@ withSpan parser = do
 sourceSpanFromPositions :: SourcePos -> SourcePos -> SourceSpan
 sourceSpanFromPositions start end =
   SourceSpan
-    { sourceSpanStartLine = MP.unPos (sourceLine start),
+    { sourceSpanSourceName = sourceName start,
+      sourceSpanStartLine = MP.unPos (sourceLine start),
       sourceSpanStartCol = MP.unPos (sourceColumn start),
       sourceSpanEndLine = MP.unPos (sourceLine end),
-      sourceSpanEndCol = MP.unPos (sourceColumn end)
+      sourceSpanEndCol = MP.unPos (sourceColumn end),
+      sourceSpanStartOffset = 0,
+      sourceSpanEndOffset = 0
     }
 
 parens :: TokParser a -> TokParser a

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -689,8 +689,10 @@ parenExprParser = withSpan $ do
 
     tokensAdjacent first second =
       case (lexTokenSpan first, lexTokenSpan second) of
-        (SourceSpan _ _ firstEndLine firstEndCol, SourceSpan secondStartLine secondStartCol _ _) ->
-          firstEndLine == secondStartLine && firstEndCol == secondStartCol
+        ( SourceSpan {sourceSpanEndLine = firstEndLine, sourceSpanEndCol = firstEndCol},
+          SourceSpan {sourceSpanStartLine = secondStartLine, sourceSpanStartCol = secondStartCol}
+          ) ->
+            firstEndLine == secondStartLine && firstEndCol == secondStartCol
         _ -> False
 
     parseSection closeTok = do

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -63,6 +63,8 @@ module Aihc.Parser.Lex
     lexModuleTokensFromChunks,
     lexTokensWithExtensions,
     lexModuleTokensWithExtensions,
+    lexTokensWithSourceNameAndExtensions,
+    lexModuleTokensWithSourceNameAndExtensions,
     lexTokens,
     lexModuleTokens,
   )
@@ -70,7 +72,7 @@ where
 
 import Aihc.Parser.Syntax
 import Control.DeepSeq (NFData)
-import Data.Char (GeneralCategory (..), digitToInt, generalCategory, isAlphaNum, isAsciiLower, isAsciiUpper, isDigit, isHexDigit, isOctDigit, isSpace)
+import Data.Char (GeneralCategory (..), digitToInt, generalCategory, isAlphaNum, isAsciiLower, isAsciiUpper, isDigit, isHexDigit, isOctDigit, isSpace, ord)
 import Data.List qualified as List
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
@@ -199,8 +201,10 @@ data LexToken = LexToken
 
 data LexerState = LexerState
   { lexerInput :: String,
+    lexerLogicalSourceName :: !FilePath,
     lexerLine :: !Int,
     lexerCol :: !Int,
+    lexerByteOffset :: !Int,
     lexerAtLineStart :: !Bool,
     lexerPending :: [LexToken],
     lexerExtensions :: [Extension],
@@ -254,7 +258,8 @@ data LayoutState = LayoutState
 
 data DirectiveUpdate = DirectiveUpdate
   { directiveLine :: !(Maybe Int),
-    directiveCol :: !(Maybe Int)
+    directiveCol :: !(Maybe Int),
+    directiveSourceName :: !(Maybe FilePath)
   }
   deriving (Eq, Show)
 
@@ -264,17 +269,14 @@ data DirectiveUpdate = DirectiveUpdate
 -- tokens. Lexing errors are preserved as 'TkError' tokens instead of causing
 -- lexing to fail.
 lexTokens :: Text -> [LexToken]
-lexTokens = lexTokensFromChunks . (: [])
+lexTokens = lexTokensWithSourceNameAndExtensions "<input>" []
 
 -- | Convenience lexer entrypoint for full modules: no explicit extension list.
 --
 -- Leading header pragmas are scanned first so module-enabled extensions can be
 -- applied before token rewrites and top-level layout insertion.
 lexModuleTokens :: Text -> [LexToken]
-lexModuleTokens input =
-  lexModuleTokensFromChunks
-    (enabledExtensionsFromSettings (readModuleHeaderExtensionsFromChunks [input]))
-    [input]
+lexModuleTokens = lexModuleTokensWithSourceNameAndExtensions "<input>" []
 
 -- | Lex an expression/declaration stream from one or more input chunks.
 --
@@ -288,7 +290,7 @@ lexTokensFromChunks = lexTokensFromChunksWithExtensions []
 -- This variant enables module-body layout insertion in addition to the normal
 -- token scan and extension rewrites.
 lexModuleTokensFromChunks :: [Extension] -> [Text] -> [LexToken]
-lexModuleTokensFromChunks = lexChunksWithExtensions True
+lexModuleTokensFromChunks = lexChunksWithExtensions True "<input>"
 
 -- | Lex source text using explicit lexer extensions.
 --
@@ -296,7 +298,7 @@ lexModuleTokensFromChunks = lexChunksWithExtensions True
 -- Module-top layout is /not/ enabled here. Malformed lexemes become 'TkError'
 -- tokens in the token stream.
 lexTokensWithExtensions :: [Extension] -> Text -> [LexToken]
-lexTokensWithExtensions exts input = lexTokensFromChunksWithExtensions exts [input]
+lexTokensWithExtensions = lexTokensWithSourceNameAndExtensions "<input>"
 
 -- | Lex module source text using explicit lexer extensions.
 --
@@ -304,28 +306,41 @@ lexTokensWithExtensions exts input = lexTokensFromChunksWithExtensions exts [inp
 -- when the source omits explicit braces, virtual layout tokens are inserted
 -- after @module ... where@ (or from the first non-pragma token in module-less files).
 lexModuleTokensWithExtensions :: [Extension] -> Text -> [LexToken]
-lexModuleTokensWithExtensions exts input = lexModuleTokensFromChunks exts [input]
+lexModuleTokensWithExtensions = lexModuleTokensWithSourceNameAndExtensions "<input>"
+
+lexTokensWithSourceNameAndExtensions :: FilePath -> [Extension] -> Text -> [LexToken]
+lexTokensWithSourceNameAndExtensions sourceName exts input =
+  lexChunksWithExtensions False sourceName exts [input]
+
+lexModuleTokensWithSourceNameAndExtensions :: FilePath -> [Extension] -> Text -> [LexToken]
+lexModuleTokensWithSourceNameAndExtensions sourceName baseExts input =
+  lexChunksWithExtensions True sourceName effectiveExts [input]
+  where
+    headerExts = enabledExtensionsFromSettings (readModuleHeaderExtensionsFromChunks [input])
+    effectiveExts = baseExts <> [ext | ext <- headerExts, ext `notElem` baseExts]
 
 -- | Internal chunked lexer entrypoint for non-module inputs.
 --
 -- This exists so callers can stream input through the same scanner while still
 -- selecting extension-driven token rewrites.
 lexTokensFromChunksWithExtensions :: [Extension] -> [Text] -> [LexToken]
-lexTokensFromChunksWithExtensions = lexChunksWithExtensions False
+lexTokensFromChunksWithExtensions = lexChunksWithExtensions False "<input>"
 
 -- | Run the full lexer pipeline over chunked input.
 --
 -- The scanner operates over the concatenated chunk stream with inline extension
 -- handling, then the resulting token stream is passed through the layout insertion step.
-lexChunksWithExtensions :: Bool -> [Extension] -> [Text] -> [LexToken]
-lexChunksWithExtensions enableModuleLayout exts chunks =
+lexChunksWithExtensions :: Bool -> FilePath -> [Extension] -> [Text] -> [LexToken]
+lexChunksWithExtensions enableModuleLayout sourceName exts chunks =
   applyLayoutTokens enableModuleLayout (scanTokens initialLexerState)
   where
     initialLexerState =
       LexerState
         { lexerInput = concatMap T.unpack chunks,
+          lexerLogicalSourceName = sourceName,
           lexerLine = 1,
           lexerCol = 1,
+          lexerByteOffset = 0,
           lexerAtLineStart = True,
           lexerPending = [],
           lexerExtensions = exts,
@@ -446,10 +461,13 @@ scanTokens st0 =
                   -- Emit explicit EOF token with span at current position
                   let eofSpan =
                         SourceSpan
-                          { sourceSpanStartLine = lexerLine st,
+                          { sourceSpanSourceName = lexerLogicalSourceName st,
+                            sourceSpanStartLine = lexerLine st,
                             sourceSpanStartCol = lexerCol st,
                             sourceSpanEndLine = lexerLine st,
-                            sourceSpanEndCol = lexerCol st
+                            sourceSpanEndCol = lexerCol st,
+                            sourceSpanStartOffset = lexerByteOffset st,
+                            sourceSpanEndOffset = lexerByteOffset st
                           }
                       eofToken =
                         LexToken
@@ -927,13 +945,13 @@ isBOL st tok =
 tokenStartLine :: LexToken -> Int
 tokenStartLine tok =
   case lexTokenSpan tok of
-    SourceSpan line _ _ _ -> line
+    SourceSpan {sourceSpanStartLine = line} -> line
     NoSourceSpan -> 1
 
 tokenStartCol :: LexToken -> Int
 tokenStartCol tok =
   case lexTokenSpan tok of
-    SourceSpan _ col _ _ -> col
+    SourceSpan {sourceSpanStartCol = col} -> col
     NoSourceSpan -> 1
 
 virtualSymbolToken :: Text -> SourceSpan -> LexToken
@@ -1115,8 +1133,16 @@ negateToken stBefore numTok =
 
     -- Extend span to start at the '-' position
     extendSpanLeft sp = case sp of
-      SourceSpan _ _ endLine endCol ->
-        SourceSpan (lexerLine stBefore) (lexerCol stBefore) endLine endCol
+      SourceSpan {sourceSpanSourceName, sourceSpanEndLine = endLine, sourceSpanEndCol = endCol, sourceSpanEndOffset} ->
+        SourceSpan
+          { sourceSpanSourceName = sourceSpanSourceName,
+            sourceSpanStartLine = lexerLine stBefore,
+            sourceSpanStartCol = lexerCol stBefore,
+            sourceSpanEndLine = endLine,
+            sourceSpanEndCol = endCol,
+            sourceSpanStartOffset = lexerByteOffset stBefore,
+            sourceSpanEndOffset = sourceSpanEndOffset
+          }
       NoSourceSpan -> NoSourceSpan
 
 -- | Emit TkPrefixMinus or TkMinusOperator based on LexicalNegation rules.
@@ -1783,10 +1809,11 @@ applyDirectiveAdvance consumed update st =
         case reverse consumed of
           '\n' : _ -> True
           _ -> False
-   in st
-        { lexerInput = drop (length consumed) (lexerInput st),
-          lexerLine = maybe (lexerLine st) (max 1) (directiveLine update),
-          lexerCol = maybe (lexerCol st) (max 1) (directiveCol update),
+      st' = advanceChars consumed st
+   in st'
+        { lexerLogicalSourceName = fromMaybe (lexerLogicalSourceName st') (directiveSourceName update),
+          lexerLine = maybe (lexerLine st') (max 1) (directiveLine update),
+          lexerCol = maybe (lexerCol st') (max 1) (directiveCol update),
           lexerAtLineStart = hasTrailingNewline || (Just 1 == directiveCol update)
         }
 
@@ -1997,10 +2024,16 @@ parseHashLineDirective raw =
         if "line" `List.isPrefixOf` trimmed
           then dropWhile isSpace (drop 4 trimmed)
           else trimmed
-      (digits, _) = span isDigit trimmed'
+      (digits, rest) = span isDigit trimmed'
    in if null digits
         then Nothing
-        else Just DirectiveUpdate {directiveLine = Just (read digits), directiveCol = Just 1}
+        else
+          Just
+            DirectiveUpdate
+              { directiveLine = Just (read digits),
+                directiveCol = Just 1,
+                directiveSourceName = parseDirectiveSourceName rest
+              }
 
 parseControlPragma :: String -> Maybe (String, Either Text DirectiveUpdate)
 parseControlPragma input
@@ -2011,7 +2044,12 @@ parseControlPragma input
               | all isDigit lineNo ->
                   Just
                     ( fullPragmaConsumed "LINE" body,
-                      Right DirectiveUpdate {directiveLine = Just (read lineNo), directiveCol = Just 1}
+                      Right
+                        DirectiveUpdate
+                          { directiveLine = Just (read lineNo),
+                            directiveCol = Just 1,
+                            directiveSourceName = parseDirectiveSourceName (dropWhile isSpace (drop (length lineNo) body))
+                          }
                     )
             _ -> Just (fullPragmaConsumed "LINE" body, Left "malformed LINE pragma")
   | Just body <- stripPragma "COLUMN" input =
@@ -2021,7 +2059,7 @@ parseControlPragma input
               | all isDigit colNo ->
                   Just
                     ( fullPragmaConsumed "COLUMN" body,
-                      Right DirectiveUpdate {directiveLine = Nothing, directiveCol = Just (read colNo)}
+                      Right DirectiveUpdate {directiveLine = Nothing, directiveCol = Just (read colNo), directiveSourceName = Nothing}
                     )
             _ -> Just (fullPragmaConsumed "COLUMN" body, Left "malformed COLUMN pragma")
   | otherwise = Nothing
@@ -2041,10 +2079,13 @@ mkToken start end tokTxt kind =
 mkSpan :: LexerState -> LexerState -> SourceSpan
 mkSpan start end =
   SourceSpan
-    { sourceSpanStartLine = lexerLine start,
+    { sourceSpanSourceName = lexerLogicalSourceName start,
+      sourceSpanStartLine = lexerLine start,
       sourceSpanStartCol = lexerCol start,
       sourceSpanEndLine = lexerLine end,
-      sourceSpanEndCol = lexerCol end
+      sourceSpanEndCol = lexerCol end,
+      sourceSpanStartOffset = lexerByteOffset start,
+      sourceSpanEndOffset = lexerByteOffset end
     }
 
 advanceChars :: String -> LexerState -> LexerState
@@ -2057,14 +2098,35 @@ advanceChars chars st = foldl advanceOne st chars
             { lexerInput = drop 1 (lexerInput acc),
               lexerLine = lexerLine acc + 1,
               lexerCol = 1,
+              lexerByteOffset = lexerByteOffset acc + 1,
               lexerAtLineStart = True
             }
         _ ->
           acc
             { lexerInput = drop 1 (lexerInput acc),
               lexerCol = lexerCol acc + 1,
+              lexerByteOffset = lexerByteOffset acc + utf8CharWidth ch,
               lexerAtLineStart = False
             }
+
+utf8CharWidth :: Char -> Int
+utf8CharWidth ch =
+  case ord ch of
+    code
+      | code <= 0x7F -> 1
+      | code <= 0x7FF -> 2
+      | code <= 0xFFFF -> 3
+      | otherwise -> 4
+
+parseDirectiveSourceName :: String -> Maybe FilePath
+parseDirectiveSourceName rest =
+  case dropWhile isSpace rest of
+    '"' : more ->
+      let (name, trailing) = span (/= '"') more
+       in case trailing of
+            '"' : _ -> Just name
+            _ -> Nothing
+    _ -> Nothing
 
 consumeWhile :: (Char -> Bool) -> LexerState -> LexerState
 consumeWhile f st = advanceChars (takeWhile f (lexerInput st)) st

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -484,12 +484,27 @@ languageEditionExtensions edition =
 data SourceSpan
   = NoSourceSpan
   | SourceSpan
-      { sourceSpanStartLine :: !Int,
+      { sourceSpanSourceName :: !FilePath,
+        sourceSpanStartLine :: !Int,
         sourceSpanStartCol :: !Int,
         sourceSpanEndLine :: !Int,
-        sourceSpanEndCol :: !Int
+        sourceSpanEndCol :: !Int,
+        sourceSpanStartOffset :: !Int,
+        sourceSpanEndOffset :: !Int
       }
-  deriving (Data, Eq, Ord, Show, Generic, NFData)
+  deriving (Data, Eq, Ord, Generic, NFData)
+
+instance Show SourceSpan where
+  show NoSourceSpan = "NoSourceSpan"
+  show SourceSpan {sourceSpanStartLine, sourceSpanStartCol, sourceSpanEndLine, sourceSpanEndCol} =
+    "SourceSpan "
+      ++ show sourceSpanStartLine
+      ++ " "
+      ++ show sourceSpanStartCol
+      ++ " "
+      ++ show sourceSpanEndLine
+      ++ " "
+      ++ show sourceSpanEndCol
 
 noSourceSpan :: SourceSpan
 noSourceSpan = NoSourceSpan
@@ -500,7 +515,10 @@ class HasSourceSpan a where
 mergeSourceSpans :: SourceSpan -> SourceSpan -> SourceSpan
 mergeSourceSpans left right =
   case (left, right) of
-    (SourceSpan l1 c1 _ _, SourceSpan _ _ l2 c2) -> SourceSpan l1 c1 l2 c2
+    ( SourceSpan name l1 c1 _ _ startOffset _,
+      SourceSpan _ _ _ l2 c2 _ endOffset
+      ) ->
+        SourceSpan name l1 c1 l2 c2 startOffset endOffset
     (NoSourceSpan, span') -> span'
     (span', NoSourceSpan) -> span'
 

--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -142,13 +142,15 @@ instance TraversableStream TokStream where
 sourcePosFromStartSpan :: FilePath -> SourceSpan -> SourcePos
 sourcePosFromStartSpan file span' =
   case span' of
-    SourceSpan line col _ _ -> SourcePos file (mkPos (max 1 line)) (mkPos (max 1 col))
+    SourceSpan {sourceSpanSourceName, sourceSpanStartLine = line, sourceSpanStartCol = col} ->
+      SourcePos sourceSpanSourceName (mkPos (max 1 line)) (mkPos (max 1 col))
     NoSourceSpan -> SourcePos file (mkPos 1) (mkPos 1)
 
 sourcePosFromEndSpan :: FilePath -> SourceSpan -> SourcePos
 sourcePosFromEndSpan file span' =
   case span' of
-    SourceSpan _ _ line col -> SourcePos file (mkPos (max 1 line)) (mkPos (max 1 col))
+    SourceSpan {sourceSpanSourceName, sourceSpanEndLine = line, sourceSpanEndCol = col} ->
+      SourcePos sourceSpanSourceName (mkPos (max 1 line)) (mkPos (max 1 col))
     NoSourceSpan -> SourcePos file (mkPos 1) (mkPos 1)
 
 data ParserConfig = ParserConfig

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
@@ -302,38 +303,56 @@ test_unterminatedBlockCommentProducesErrorToken =
 test_hashLineDirectiveUpdatesSpan :: Assertion
 test_hashLineDirectiveUpdatesSpan =
   case lexTokens "#line 42\nx" of
-    [LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = SourceSpan 42 1 42 2}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    [LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = span'}, LexToken {lexTokenKind = TkEOF}] ->
+      assertSourceSpan "<input>" 42 1 42 2 9 10 span'
     other -> assertFailure ("expected identifier at line 42, got: " <> show other)
 
 test_gccHashLineDirectiveUpdatesSpan :: Assertion
 test_gccHashLineDirectiveUpdatesSpan =
   case lexTokens "# 42 \"generated.h\"\nx" of
-    [LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = SourceSpan 42 1 42 2}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    [LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = span'}, LexToken {lexTokenKind = TkEOF}] ->
+      assertSourceSpan "generated.h" 42 1 42 2 19 20 span'
     other -> assertFailure ("expected identifier at line 42 from gcc-style directive, got: " <> show other)
 
 test_linePragmaUpdatesSpan :: Assertion
 test_linePragmaUpdatesSpan =
   case lexTokens "{-# LINE 17 #-}\nx" of
-    [LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = SourceSpan 17 1 17 2}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    [LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = span'}, LexToken {lexTokenKind = TkEOF}] ->
+      assertSourceSpan "<input>" 17 1 17 2 16 17 span'
     other -> assertFailure ("expected identifier at line 17, got: " <> show other)
 
 test_columnPragmaUpdatesSpan :: Assertion
 test_columnPragmaUpdatesSpan =
   case lexTokens "x\n{-# COLUMN 7 #-}y" of
     [ LexToken {lexTokenKind = TkVarId "x"},
-      LexToken {lexTokenKind = TkVarId "y", lexTokenSpan = SourceSpan 2 7 2 8},
+      LexToken {lexTokenKind = TkVarId "y", lexTokenSpan = span'},
       LexToken {lexTokenKind = TkEOF}
-      ] -> pure ()
+      ] -> assertSourceSpan "<input>" 2 7 2 8 18 19 span'
     other -> assertFailure ("expected second identifier at column 7, got: " <> show other)
 
 test_inlineColumnPragmaUpdatesSpan :: Assertion
 test_inlineColumnPragmaUpdatesSpan =
   case lexTokens "x{-# COLUMN 7 #-}y" of
-    [ LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = SourceSpan 1 1 1 2},
-      LexToken {lexTokenKind = TkVarId "y", lexTokenSpan = SourceSpan 1 7 1 8},
+    [ LexToken {lexTokenKind = TkVarId "x", lexTokenSpan = xSpan},
+      LexToken {lexTokenKind = TkVarId "y", lexTokenSpan = ySpan},
       LexToken {lexTokenKind = TkEOF}
-      ] -> pure ()
+      ] -> do
+        assertSourceSpan "<input>" 1 1 1 2 0 1 xSpan
+        assertSourceSpan "<input>" 1 7 1 8 17 18 ySpan
     other -> assertFailure ("expected inline COLUMN pragma to update same-line column, got: " <> show other)
+
+assertSourceSpan :: FilePath -> Int -> Int -> Int -> Int -> Int -> Int -> SourceSpan -> Assertion
+assertSourceSpan expectedName expectedStartLine expectedStartCol expectedEndLine expectedEndCol expectedStartOffset expectedEndOffset span' =
+  case span' of
+    SourceSpan {sourceSpanSourceName, sourceSpanStartLine, sourceSpanStartCol, sourceSpanEndLine, sourceSpanEndCol, sourceSpanStartOffset, sourceSpanEndOffset} -> do
+      assertEqual "source name" expectedName sourceSpanSourceName
+      assertEqual "start line" expectedStartLine sourceSpanStartLine
+      assertEqual "start col" expectedStartCol sourceSpanStartCol
+      assertEqual "end line" expectedEndLine sourceSpanEndLine
+      assertEqual "end col" expectedEndCol sourceSpanEndCol
+      assertEqual "start offset" expectedStartOffset sourceSpanStartOffset
+      assertEqual "end offset" expectedEndOffset sourceSpanEndOffset
+    NoSourceSpan -> assertFailure "expected SourceSpan, got NoSourceSpan"
 
 test_lexerChunkLaziness :: Assertion
 test_lexerChunkLaziness =

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/hash-line-missing-rhs.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/hash-line-missing-rhs.yaml
@@ -1,0 +1,13 @@
+src: |
+  # 20 "source"
+  x =
+ghc: |
+  source:21:1: error: [GHC-58481]
+      parse error (possibly incorrect indentation or mismatched brackets)
+aihc: |
+  source:20:3:
+  20 | x =
+     |   ^
+  unexpected end of input
+  expecting expression
+  context: while parsing equation right-hand side

--- a/components/aihc-parser/test/Test/Properties/NoExceptions.hs
+++ b/components/aihc-parser/test/Test/Properties/NoExceptions.hs
@@ -227,6 +227,7 @@ genSourceSpan =
   oneof
     [ pure NoSourceSpan,
       do
+        sourceName <- elements ["<input>", "source", "generated.h"]
         startLine <- chooseInt (1, 200)
         startCol <- chooseInt (1, 200)
         endLine <- chooseInt (startLine, startLine + 5)
@@ -234,13 +235,24 @@ genSourceSpan =
           if endLine == startLine
             then chooseInt (startCol, startCol + 10)
             else chooseInt (1, 200)
-        pure (SourceSpan startLine startCol endLine endCol)
+        startOffset <- chooseInt (0, 4000)
+        endOffset <- chooseInt (startOffset, startOffset + 200)
+        pure (SourceSpan sourceName startLine startCol endLine endCol startOffset endOffset)
     ]
 
 shrinkSourceSpan :: SourceSpan -> [SourceSpan]
 shrinkSourceSpan span' =
   case span' of
     NoSourceSpan -> []
-    SourceSpan sl sc el ec ->
+    SourceSpan sourceName sl sc el ec startOffset endOffset ->
       [NoSourceSpan]
-        <> [SourceSpan sl' sc' el' ec' | (sl', sc', el', ec') <- shrink (sl, sc, el, ec), sl' >= 1, sc' >= 1, el' >= sl', ec' >= 1, el' > sl' || ec' >= sc']
+        <> [ SourceSpan sourceName sl' sc' el' ec' startOffset' endOffset'
+           | (sl', sc', el', ec', startOffset', endOffset') <- shrink (sl, sc, el, ec, startOffset, endOffset),
+             sl' >= 1,
+             sc' >= 1,
+             el' >= sl',
+             ec' >= 1,
+             el' > sl' || ec' >= sc',
+             startOffset' >= 0,
+             endOffset' >= startOffset'
+           ]


### PR DESCRIPTION
## Summary
- preserve directive-adjusted logical source names/line numbers while storing physical UTF-8 byte offsets in `SourceSpan`
- render parser error snippets from physical offsets so `#line` / gcc-style include remapping still shows the correct source line
- add a golden error-message case for `# 20 "source"` and extend lexer tests/property generators for the new span fields

## Verification
- `cabal test aihc-parser:spec`
- `cabal run exe:hackage-tester -v0 -- filepath-bytestring`
- `nix flake check`

## Progress
- parser error fixtures: 15 pass / 0 fail / 100.00% completion

## Notes
- The `filepath-bytestring` repro now reports the remapped logical path in `../Internal.hs` while showing the correct physical snippet from the including file.
- `coderabbit review --prompt-only` was attempted after local checks passed, but CodeRabbit returned a rate-limit error (`try after 23 minutes and 30 seconds`), so no review prompt was generated.