### PR TITLE
fix(parser): support implicit TH declaration splices

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -180,6 +180,19 @@ exportImportNamespaceParser =
 declParser :: TokParser Decl
 declParser = do
   tok <- lookAhead anySingle
+  thFullEnabled <- isExtensionEnabled TemplateHaskell
+  let valueOrSpliceParser =
+        if thFullEnabled
+          then MP.try valueDeclParser <|> implicitSpliceDeclParser
+          else valueDeclParser
+      patternOrSpliceParser =
+        if thFullEnabled
+          then MP.try patternBindDeclParser <|> implicitSpliceDeclParser
+          else MP.try patternBindDeclParser
+      typeSigOrValueOrSpliceParser =
+        MP.try typeSigDeclParser <|> valueOrSpliceParser
+      typeSigOrPatternOrValueOrSpliceParser =
+        MP.try typeSigDeclParser <|> patternOrSpliceParser <|> valueOrSpliceParser
   case lexTokenKind tok of
     TkKeywordData ->
       MP.try dataFamilyDeclParser
@@ -204,17 +217,17 @@ declParser = do
     TkVarId ident ->
       case ident of
         "pattern" -> unsupportedDeclParser "pattern synonym declarations are not implemented yet"
-        _ -> MP.try typeSigDeclParser <|> valueDeclParser
+        _ -> typeSigOrValueOrSpliceParser
     TkConId ident ->
       case ident of
         "pattern" -> unsupportedDeclParser "pattern synonym declarations are not implemented yet"
-        _ -> MP.try typeSigDeclParser <|> valueDeclParser
-    TkSpecialLParen -> MP.try typeSigDeclParser <|> MP.try patternBindDeclParser <|> valueDeclParser
-    TkSpecialLBracket -> patternBindDeclParser
-    TkPrefixTilde -> patternBindDeclParser
-    TkKeywordUnderscore -> patternBindDeclParser
+        _ -> typeSigOrValueOrSpliceParser
+    TkSpecialLParen -> typeSigOrPatternOrValueOrSpliceParser
+    TkSpecialLBracket -> patternOrSpliceParser
+    TkPrefixTilde -> patternOrSpliceParser
+    TkKeywordUnderscore -> patternOrSpliceParser
     TkTHSplice -> spliceDeclParser
-    _ -> MP.try typeSigDeclParser <|> valueDeclParser
+    _ -> typeSigOrValueOrSpliceParser
 
 -- | Parse a top-level Template Haskell declaration splice: $expr or $(expr)
 spliceDeclParser :: TokParser Decl
@@ -230,6 +243,14 @@ spliceDeclParser = withSpan $ do
     bareSpliceBody = withSpan $ do
       name <- identifierTextParser
       pure (`EVar` name)
+
+-- | Parse an implicit top-level Template Haskell declaration splice: @expr@.
+-- GHC accepts bare declaration splices under TemplateHaskell and also pretty-prints
+-- them as explicit @$...@ splices, so we parse the expression body directly here.
+implicitSpliceDeclParser :: TokParser Decl
+implicitSpliceDeclParser = withSpan $ do
+  body <- exprParser
+  pure (`DeclSplice` body)
 
 standaloneKindSigDeclParser :: TokParser Decl
 standaloneKindSigDeclParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -116,6 +116,13 @@ prettyImportLevel level =
     ImportLevelQuote -> "quote"
     ImportLevelSplice -> "splice"
 
+prettyDeclSplice :: Expr -> Doc ann
+prettyDeclSplice body =
+  case body of
+    EVar {} -> prettySplice "$" body
+    EParen {} -> prettySplice "$" body
+    _ -> prettyExprPrec 0 body
+
 prettyQuotedText :: Text -> Doc ann
 prettyQuotedText txt = "\"" <> pretty txt <> "\""
 
@@ -170,7 +177,7 @@ prettyDeclLines decl =
     DeclStandaloneDeriving _ derivingDecl -> [prettyStandaloneDeriving derivingDecl]
     DeclDefault _ tys -> ["default" <+> parens (hsep (punctuate comma (map prettyType tys)))]
     DeclForeign _ foreignDecl -> [prettyForeignDecl foreignDecl]
-    DeclSplice _ body -> [prettySplice "$" body]
+    DeclSplice _ body -> [prettyDeclSplice body]
     DeclTypeFamilyDecl _ tf -> [prettyTypeFamilyDecl tf]
     DeclDataFamilyDecl _ df -> [prettyDataFamilyDecl df]
     DeclTypeFamilyInst _ tfi -> [prettyTopTypeFamilyInst tfi]

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/template-haskell-implicit-decl-splice.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/template-haskell-implicit-decl-splice.yaml
@@ -1,0 +1,8 @@
+extensions: [TemplateHaskell]
+input: |
+  {-# LANGUAGE TemplateHaskell #-}
+  module TH_Implicit_Decl_Splice where
+
+  return []
+ast: Module {name = "TH_Implicit_Decl_Splice", languagePragmas = [EnableExtension TemplateHaskell], decls = [DeclSplice (EApp (EVar "return") (EList []))]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_implicit_splice_decl.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_implicit_splice_decl.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+module TH_Implicit_Splice_Decl where
+
+return []


### PR DESCRIPTION
## Summary

- accept implicit top-level Template Haskell declaration splices when `TemplateHaskell` is enabled
- preserve roundtripping by rendering implicit application splices in bare form while keeping explicit `$decl` and `$(...)` forms explicit
- add golden and oracle regression coverage for implicit declaration splices

## Root Cause

The parser only recognized explicit top-level declaration splices (`$decl` / `$(...)`). Packages like `hourglass-orphans` use the implicit Template Haskell declaration splice form (`deriveJSON defaultOptions Month`), so AIHC treated those lines as ordinary declarations and failed or produced invalid roundtrips.

## Impact

- fixes `hourglass-orphans-0.1.0.0` in `hackage-tester`
- adds regression coverage for the minimal failing construct

## Progress

- Parser progress: PASS 544 -> 545
- Parser progress: FAIL 0 -> 0
- Parser progress: TOTAL 606 -> 607
- Parser progress: COMPLETE 89.76% -> 89.78%

## Validation

- `cabal test aihc-parser:spec`
- `cabal run exe:hackage-tester -v0 -- hourglass-orphans`
- `nix flake check`
- `coderabbit review --prompt-only` skipped: rate limited by the service