### PR TITLE
fix(stackage-progress): avoid duplicating source name in parse errors

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -43,15 +43,15 @@ test-suite spec
   main-is:          Spec.hs
   other-modules:
       CppSupport
-      , ExtensionSupport
-      , GhcOracle
-      , HackageSupport
-      , HackageTester.CLI
-      , HackageTester.Model
-      , HseExtensions
-      , LexerGolden
-      , ParserErrorGolden
-      , ParserGolden
+    , ExtensionSupport
+    , GhcOracle
+    , HackageSupport
+    , HackageTester.CLI
+    , HackageTester.Model
+    , HseExtensions
+    , LexerGolden
+    , ParserErrorGolden
+    , ParserGolden
     , OracleExtensions
     , ParserValidation
     , ShrinkUtils


### PR DESCRIPTION
Fix `stackage-progress` parse error formatting so it uses the real file path as the parser source name and lets Megaparsec render the location header once.

## What changed
- `StackageProgress.FileChecker` now parses each file with `parserSourceName = file` instead of `"<input>"`.
- Parse errors are no longer manually prefixed with `file:` before being passed through `errorBundlePretty`.
- Added a regression test that checks a failing file reports the real path and never emits `<input>`.

## Why
- The previous flow produced duplicated prefixes such as `path:<input>:8:1:` because the checker added the file path on top of the parser output.
- The root cause was mixing manual prefixing with the parser default source name.

## Impact
- `stackage-progress` now reports parse errors with a single source header from the error printer.
- Progress counts are unchanged; this is a formatting/source-name fix only.

## Validation
- `cabal test aihc-parser:spec`
- `nix flake check` currently hits an existing flaky QuickCheck failure in `generated expr AST pretty-printer round-trip`, unrelated to this change.
