### PR TITLE
fix(parser): preserve parens for parenthesized infix types

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -337,9 +337,7 @@ prettyTypePrec prec ty =
     TList _ promoted inner ->
       let listDoc = brackets (prettyTypePrec 0 inner)
        in if promoted == Promoted then "'" <> listDoc else listDoc
-    TParen _ inner
-      | isInfixTypeApp inner -> prettyTypePrec prec inner
-      | otherwise -> parens (prettyTypePrec 0 inner)
+    TParen _ inner -> parens (prettyTypePrec 0 inner)
     TContext _ constraints inner ->
       parenthesize
         (prec > 0)
@@ -369,12 +367,6 @@ isSymbolicTypeOperator op =
   case T.uncons op of
     Nothing -> False
     Just _ -> T.all (`elem` (":!#$%&*+./<=>?\\^|-~" :: String)) op
-
-isInfixTypeApp :: Type -> Bool
-isInfixTypeApp ty =
-  case ty of
-    TApp _ (TApp _ (TCon _ op _) _) _ -> isSymbolicTypeOperator op && op /= "->"
-    _ -> False
 
 prettyTypeLiteral :: TypeLiteral -> Doc ann
 prettyTypeLiteral lit =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/list-promoted-kind.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/list-promoted-kind.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail list promoted kind -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 module ListPromotedKind where
 


### PR DESCRIPTION
## Summary

This PR makes the `DataKinds/list-promoted-kind.hs` oracle fixture pass.

It preserves explicit parentheses when pretty-printing parenthesized infix types, which keeps `Proxy (() ': '[])` from round-tripping into `Proxy () ': '[]`.

## Root cause

The type pretty-printer special-cased parenthesized infix types and dropped the original parentheses unconditionally. That was harmless at top level, but it changed the parse when the parenthesized infix type appeared as a type application argument.

## Impact

`list-promoted-kind.hs` now moves from `xfail` to `pass`, and parenthesized infix types retain the grouping required for stable round-trips through the parser and pretty-printer.

## Validation

- `cabal test aihc-parser:spec --builddir dist-test`
- `nix flake check`
- `coderabbit review --prompt-only`

## Progress

- Oracle progress: `+1 pass / -1 xfail`
- Regression counts: `0 fail`, `0 xpass`

## CodeRabbit

CodeRabbit flagged the existing `promoted-cons-kind.hs` fixture for unbound type variables. I left it unchanged because this oracle suite is parse-based rather than typecheck-based, and that fixture already passes under the intended contract.
