### PR TITLE
feat(parser): support quasi-quote expressions

### DIFF
--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -17,6 +17,7 @@ module GhcOracle
     oracleParsesWithParserExtensionsAt,
     oracleDetailedParsesWithParserExtensions,
     oracleDetailedParsesWithParserExtensionsAt,
+    oracleModuleAstFingerprintWithNamesAt,
     computeEffectiveExtensions,
     toGhcExtension,
     fromGhcExtension,
@@ -77,6 +78,26 @@ oracleModuleAstFingerprintWithExtensionsAt :: String -> [GHC.Extension] -> Text 
 oracleModuleAstFingerprintWithExtensionsAt sourceTag exts input = do
   parsed <- parseWithGhcWithExtensions sourceTag exts input
   pure (T.pack (showSDocUnsafe (ppr parsed)))
+
+-- | Compute an AST fingerprint using extension names and a language edition,
+-- reading in-file pragmas to determine the full effective extension set.
+-- This mirrors the logic in 'oracleDetailedParsesModuleWithNamesAt'.
+oracleModuleAstFingerprintWithNamesAt :: String -> [String] -> Maybe String -> Text -> Either Text Text
+oracleModuleAstFingerprintWithNamesAt sourceTag extNames langName input =
+  let defaultEdition = langName >>= Syntax.parseLanguageEdition . T.pack
+      initialPragmas = Lex.readModuleHeaderPragmas input
+      initialExts = computeEffectiveExtensions defaultEdition extNames initialPragmas
+      preprocessedInput =
+        if Syntax.CPP `elem` initialExts
+          then resultOutput (preprocessForParserWithoutIncludes sourceTag input)
+          else input
+      finalPragmas =
+        if Syntax.CPP `elem` initialExts
+          then Lex.readModuleHeaderPragmas preprocessedInput
+          else initialPragmas
+      finalExts = computeEffectiveExtensions defaultEdition extNames finalPragmas
+      ghcExts = mapMaybe toGhcExtension finalExts
+   in oracleModuleAstFingerprintWithExtensionsAt sourceTag ghcExts preprocessedInput
 
 parseWithGhcWithExtensions :: String -> [GHC.Extension] -> Text -> Either Text (HsModule GhcPs)
 parseWithGhcWithExtensions sourceTag exts input =

--- a/components/aihc-parser/common/ParserValidation.hs
+++ b/components/aihc-parser/common/ParserValidation.hs
@@ -48,9 +48,13 @@ validateParserDetailedWithExtensions = validateParserDetailedCore
 
 -- | Validate parser with extension names (as strings) and optional language.
 -- This is a convenience function for use with cabal file metadata.
+-- In-file pragmas are read from the source to determine the full GHC extension set,
+-- matching the behaviour of the GHC pre-check in the hackage-tester.
 validateParserDetailedWithExtensionNames :: [String] -> Maybe String -> Text -> Maybe ValidationError
-validateParserDetailedWithExtensionNames extNames langName =
-  validateParserDetailedWithExtensions (GhcOracle.extensionNamesToGhcExtensions extNames langName)
+validateParserDetailedWithExtensionNames extNames langName source =
+  let parserExts = GhcOracle.extensionNamesToParserExtensions extNames
+      fingerprint = GhcOracle.oracleModuleAstFingerprintWithNamesAt "parser-validation" extNames langName
+   in validateParserDetailedCoreWithFingerprint parserExts fingerprint source
 
 -- | Validate parser with parser extensions directly.
 -- This is the preferred way to validate when using unified extension handling.
@@ -62,7 +66,14 @@ validateParserDetailedWithParserExtensions parserExts =
 -- | Core validation that accepts both parser extensions and GHC extensions.
 -- This ensures both parsers use exactly the same extensions.
 validateParserDetailedCoreWithParserExts :: [Syntax.Extension] -> [Extension] -> Text -> Maybe ValidationError
-validateParserDetailedCoreWithParserExts parserExts ghcExts source =
+validateParserDetailedCoreWithParserExts parserExts ghcExts =
+  validateParserDetailedCoreWithFingerprint parserExts (GhcOracle.oracleModuleAstFingerprintWithExtensionsAt "parser-validation" ghcExts)
+
+-- | Core validation with a caller-supplied fingerprint function.
+-- This allows the caller to choose how GHC extensions are determined (e.g. from
+-- pre-computed extension lists or by reading in-file pragmas).
+validateParserDetailedCoreWithFingerprint :: [Syntax.Extension] -> (Text -> Either Text Text) -> Text -> Maybe ValidationError
+validateParserDetailedCoreWithFingerprint parserExts fingerprint source =
   case parseModule parserConfig source of
     ParseErr err ->
       Just
@@ -72,8 +83,8 @@ validateParserDetailedCoreWithParserExts parserExts ghcExts source =
           }
     ParseOk parsed ->
       let rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty parsed))
-          sourceAst = GhcOracle.oracleModuleAstFingerprintWithExtensionsAt "parser-validation" ghcExts source
-          renderedAst = GhcOracle.oracleModuleAstFingerprintWithExtensionsAt "parser-validation" ghcExts rendered
+          sourceAst = fingerprint source
+          renderedAst = fingerprint rendered
        in case (sourceAst, renderedAst) of
             (Right sourceFp, Right renderedFp)
               | sourceFp == renderedFp -> Nothing

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -341,6 +341,7 @@ atomExprParser = do
     <|> (if thAny then thQuoteExprParser else MP.empty)
     <|> (if thAny then thNameQuoteExprParser else MP.empty)
     <|> (if thFullEnabled then thSpliceExprParser else MP.empty)
+    <|> quasiQuoteExprParser
     <|> parenExprParser
     <|> listExprParser
     <|> intBaseExprParser
@@ -514,6 +515,13 @@ quasiQuotePatternParser = withSpan $ do
       TkQuasiQuote q b -> Just (q, b)
       _ -> Nothing
   pure (\span' -> PQuasiQuote span' quoter body)
+
+quasiQuoteExprParser :: TokParser Expr
+quasiQuoteExprParser =
+  tokenSatisfy "quasi quote" $ \tok ->
+    case lexTokenKind tok of
+      TkQuasiQuote quoter body -> Just (EQuasiQuote (lexTokenSpan tok) quoter body)
+      _ -> Nothing
 
 literalParser :: TokParser Literal
 literalParser = intLiteralParser <|> intBaseLiteralParser <|> floatLiteralParser <|> charLiteralParser <|> stringLiteralParser

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QuasiQuotes/expr-quasiquote-jmacro.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QuasiQuotes/expr-quasiquote-jmacro.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE QuasiQuotes #-}
+module ExprQuasiQuoteJMacro where
+
+-- Regression test for quasi-quote expressions in equation right-hand sides
+-- (e.g. happstack-jmacro style)
+scoped :: a -> b
+scoped js = [jmacro| (function { `(js)`; })(); |]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QuasiQuotes/expr-quasiquote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QuasiQuotes/expr-quasiquote.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser intentionally disabled -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE QuasiQuotes #-}
 module ExprQuasiQuote where
 

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -88,13 +88,18 @@ genExprLeaf =
       mkFloatExpr <$> genTenths,
       mkCharExpr <$> genCharValue,
       mkStringExpr <$> genStringValue,
-      -- Note: EQuasiQuote requires QuasiQuotes extension, skip for now
+      EQuasiQuote span0 <$> genQuasiQuoteName <*> genStringValue,
       pure (EList span0 []),
       pure (ETuple span0 Boxed []),
       pure (ETuple span0 Unboxed []),
       ETupleCon span0 Boxed <$> chooseInt (2, 5),
       ETupleCon span0 Unboxed <$> chooseInt (2, 5)
     ]
+
+-- | Generate a quasi-quote name, excluding TH bracket names (e, d, p, t) which
+-- would collide with Template Haskell bracket syntax ([e|...|], [d|...|], etc.).
+genQuasiQuoteName :: Gen Text
+genQuasiQuoteName = suchThat genIdent (`notElem` ["e", "d", "p", "t"])
 
 -- | Generate the body of a TH splice: either a bare variable or a parenthesized expression.
 -- Bare variables produce $name syntax; parenthesized produce $(expr) syntax.


### PR DESCRIPTION
## Summary

- Add `quasiQuoteExprParser` to parse `[quoter|body|]` in expression position (was already supported in pattern and type positions)
- Add regression test fixture `expr-quasiquote-jmacro.hs` covering the happstack-jmacro style of quasi-quotes in equation right-hand sides
- Fix `validateParserDetailedWithExtensionNames` to read in-file language pragmas (e.g. `{-# LANGUAGE QuasiQuotes #-}`) when computing GHC extensions for roundtrip validation — this ensures the GHC fingerprint check uses the same extension set as the pre-check
- Enable `EQuasiQuote` generation in the QuickCheck roundtrip tests, excluding TH bracket names (`e`, `d`, `p`, `t`) that would collide with TH bracket syntax

## Reproducer

Before this fix, parsing `happstack-jmacro` would fail:

```
scoped = [jmacro| (function { `(js)`; })(); |]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unexpected TkQuasiQuote "jmacro" " (function { `(js)`; })(); "
expecting expression
```

After: 100% success rate.

## Test plan

- [x] `cabal test spec` — all 885 tests pass
- [x] `cabal test parser-quickcheck-tests` — all 9 tests pass
- [x] `cabal run exe:hackage-tester -- happstack-jmacro` — 100% success rate