### PR TITLE
fix(lexer): close implicit layouts before commas in record fields

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -673,10 +673,12 @@ closeBeforeToken st tok =
     TkKeywordIn ->
       let (inserted, contexts') = closeLeadingImplicitLets (lexTokenSpan tok) (layoutContexts st)
        in (inserted, st {layoutContexts = contexts'})
-    TkSpecialComma
-      | layoutDelimiterDepth st == 0 ->
-          let (inserted, contexts') = closeLeadingImplicitLets (lexTokenSpan tok) (layoutContexts st)
-           in (inserted, st {layoutContexts = contexts'})
+    TkSpecialComma ->
+      -- Close implicit layouts before commas, but only if there's an explicit context.
+      -- This handles: R { f = case y of A -> 1, g = 2 } (comma closes case layout)
+      -- But NOT: case x of A | p, q -> 1 (comma is guard separator, no explicit context)
+      let (inserted, contexts') = closeImplicitBeforeComma (lexTokenSpan tok) (layoutContexts st)
+       in (inserted, st {layoutContexts = contexts'})
     -- Close implicit layout contexts before closing delimiters (parse-error rule)
     TkSpecialRParen ->
       let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
@@ -828,6 +830,31 @@ closeAllImplicitBeforeDelimiter anchor = go []
         LayoutImplicitAfterThenElse _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
         _ -> (reverse acc, contexts)
 
+-- | Close implicit layouts before commas.
+-- - Always close leading LayoutImplicitLet contexts (for let guards like: | let x = 1, p x)
+-- - If there's an explicit context (LayoutExplicit or LayoutDelimiter), also close
+--   other implicit layouts up to it (for cases like: R { f = case y of A -> 1, g = 2 })
+-- - If no explicit context, don't close LayoutImplicit (guard commas like: | p, q -> 1)
+closeImplicitBeforeComma :: SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
+closeImplicitBeforeComma anchor contexts =
+  let -- First, close any leading LayoutImplicitLet contexts (original behavior)
+      (letInserted, afterLets) = closeLeadingImplicitLets anchor contexts
+      -- Then, if there's an explicit context, close remaining implicit layouts
+      (implicitInserted, afterImplicit) =
+        if hasExplicitContext afterLets
+          then closeAllImplicitBeforeDelimiter anchor afterLets
+          else ([], afterLets)
+   in (letInserted <> implicitInserted, afterImplicit)
+  where
+    hasExplicitContext :: [LayoutContext] -> Bool
+    hasExplicitContext = any isExplicitOrDelimiter
+    isExplicitOrDelimiter :: LayoutContext -> Bool
+    isExplicitOrDelimiter ctx =
+      case ctx of
+        LayoutExplicit -> True
+        LayoutDelimiter -> True
+        _ -> False
+
 stepTokenContext :: LayoutState -> LexToken -> LayoutState
 stepTokenContext st tok =
   case lexTokenKind tok of
@@ -878,7 +905,17 @@ stepTokenContext st tok =
         { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
           layoutContexts = LayoutDelimiter : layoutContexts st
         }
+    TkSpecialUnboxedLParen ->
+      st
+        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
+          layoutContexts = LayoutDelimiter : layoutContexts st
+        }
     TkSpecialRParen ->
+      st
+        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
+          layoutContexts = popToDelimiter (layoutContexts st)
+        }
+    TkSpecialUnboxedRParen ->
       st
         { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
           layoutContexts = popToDelimiter (layoutContexts st)

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/case-guarded-in-record-field.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/case-guarded-in-record-field.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: |
+  module CaseGuardedInRecordField where
+  x = R { f = case y of A | p -> 1 | q -> 2, g = 3 }
+ast: Module {name = "CaseGuardedInRecordField", decls = [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (ERecordCon "R" {"f" = ECase (EVar "y") [CaseAlt (PCon "A" []) (GuardedRhss [GuardedRhs {guards = [GuardExpr (EVar "p")], body = EInt 1}, GuardedRhs {guards = [GuardExpr (EVar "q")], body = EInt 2}])], "g" = EInt 3})}])]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/case-in-record-field.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/case-in-record-field.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: |
+  module CaseInRecordField where
+  x = R { f = case y of A -> 1, g = 3 }
+ast: Module {name = "CaseInRecordField", decls = [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (ERecordCon "R" {"f" = ECase (EVar "y") [CaseAlt (PCon "A" []) (UnguardedRhs (EInt 1))], "g" = EInt 3})}])]}
+status: pass


### PR DESCRIPTION
## Summary

Fixes parsing of case expressions (and other layout-sensitive constructs) inside record fields when no explicit braces are used.

**Before:** The following code failed to parse:
```haskell
x = R { f = case y of A -> 1, g = 3 }
-- Error: unexpected TkSpecialComma, expecting expression
```

**After:** Parses correctly, with the case expression properly terminated at the comma.

## Changes

The fix implements the Haskell Report's "parse-error" rule for commas in the lexer's layout processing:

1. **New `closeImplicitBeforeComma` function** that:
   - Always closes `LayoutImplicitLet` contexts (for let guards like `| let x = 1, p x`)
   - Closes other implicit layouts only when there's an explicit context (`{` braces or `(` `[` `(#` delimiters)
   - Does not close layouts when no explicit context exists (preserving guard comma semantics)

2. **Added handling for unboxed tuple parens** (`(#` and `#)`) as layout delimiters in `stepTokenContext`

3. **Two new golden test cases** for case expressions in record fields

## Test plan

- [x] All 885 existing tests pass
- [x] New golden tests for `case-in-record-field.yaml` and `case-guarded-in-record-field.yaml`
- [x] Original failing file (`wai-rate-limit-redis`) parses correctly
- [x] Guard commas (`| p, q -> 1`) still work correctly
- [x] Let guards (`| let x = 1, p x`) still work correctly
- [x] Unboxed tuples (`(# 1, 2 #)`) still work correctly