### PR TITLE
feat(parser): support RoleAnnotations declarations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -210,7 +210,8 @@ declParser = do
       MP.try newtypeFamilyInstParser
         <|> newtypeDeclParser
     TkKeywordType ->
-      MP.try typeFamilyDeclParser
+      MP.try roleAnnotationDeclParser
+        <|> MP.try typeFamilyDeclParser
         <|> MP.try typeFamilyInstParser
         <|> MP.try standaloneKindSigDeclParser
         <|> typeSynDeclParser
@@ -259,6 +260,28 @@ standaloneKindSigDeclParser = withSpan $ do
   expectedTok TkReservedDoubleColon
   kind <- typeParser
   pure (\span' -> DeclStandaloneKindSig span' typeName kind)
+
+roleAnnotationDeclParser :: TokParser Decl
+roleAnnotationDeclParser = withSpan $ do
+  keywordTok TkKeywordType
+  varIdTok "role"
+  typeName <- constructorIdentifierParser
+  roles <- MP.some roleParser
+  pure $ \span' ->
+    DeclRoleAnnotation
+      span'
+      RoleAnnotation
+        { roleAnnotationSpan = span',
+          roleAnnotationName = typeName,
+          roleAnnotationRoles = roles
+        }
+
+roleParser :: TokParser Role
+roleParser =
+  (varIdTok "nominal" >> pure RoleNominal)
+    <|> (varIdTok "representational" >> pure RoleRepresentational)
+    <|> (varIdTok "phantom" >> pure RolePhantom)
+    <|> (keywordTok TkKeywordUnderscore >> pure RoleInfer)
 
 typeSynDeclParser :: TokParser Decl
 typeSynDeclParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -161,6 +161,7 @@ prettyDeclLines decl =
               <> map prettyInfixOp ops
           )
       ]
+    DeclRoleAnnotation _ ann -> [prettyRoleAnnotation ann]
     DeclTypeSyn _ synDecl ->
       [ hsep
           [ "type",
@@ -182,6 +183,24 @@ prettyDeclLines decl =
     DeclDataFamilyDecl _ df -> [prettyDataFamilyDecl df]
     DeclTypeFamilyInst _ tfi -> [prettyTopTypeFamilyInst tfi]
     DeclDataFamilyInst _ dfi -> [prettyTopDataFamilyInst dfi]
+
+prettyRoleAnnotation :: RoleAnnotation -> Doc ann
+prettyRoleAnnotation ann =
+  hsep
+    ( [ "type",
+        "role",
+        prettyConstructorName (roleAnnotationName ann)
+      ]
+        <> map prettyRole (roleAnnotationRoles ann)
+    )
+
+prettyRole :: Role -> Doc ann
+prettyRole role =
+  case role of
+    RoleNominal -> "nominal"
+    RoleRepresentational -> "representational"
+    RolePhantom -> "phantom"
+    RoleInfer -> "_"
 
 prettyValueDeclLines :: ValueDecl -> [Doc ann]
 prettyValueDeclLines valueDecl =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -164,6 +164,7 @@ docDecl decl =
     DeclTypeSig _ names ty -> "DeclTypeSig" <+> braces (hsep (punctuate comma [field "names" (docTextList names), field "type" (docType ty)]))
     DeclStandaloneKindSig _ name kind -> "DeclStandaloneKindSig" <+> braces (hsep (punctuate comma [field "name" (docText name), field "kind" (docType kind)]))
     DeclFixity _ assoc mPrec ops -> "DeclFixity" <+> braces (hsep (punctuate comma ([field "assoc" (docFixityAssoc assoc)] <> optionalField "prec" pretty mPrec <> [field "ops" (docTextList ops)])))
+    DeclRoleAnnotation _ ann -> "DeclRoleAnnotation" <+> parens (docRoleAnnotation ann)
     DeclTypeSyn _ syn -> "DeclTypeSyn" <+> parens (docTypeSynDecl syn)
     DeclData _ dd -> "DeclData" <+> parens (docDataDecl dd)
     DeclNewtype _ nd -> "DeclNewtype" <+> parens (docNewtypeDecl nd)
@@ -225,6 +226,22 @@ docTypeSynDecl syn =
       [field "name" (docText (typeSynName syn))]
         <> listField "params" docTyVarBinder (typeSynParams syn)
         <> [field "body" (docType (typeSynBody syn))]
+
+docRoleAnnotation :: RoleAnnotation -> Doc ann
+docRoleAnnotation ann =
+  "RoleAnnotation" <+> braces (hsep (punctuate comma fields))
+  where
+    fields =
+      [field "name" (docText (roleAnnotationName ann))]
+        <> [field "roles" (brackets (hsep (punctuate comma (map docRole (roleAnnotationRoles ann)))))]
+
+docRole :: Role -> Doc ann
+docRole role =
+  case role of
+    RoleNominal -> "RoleNominal"
+    RoleRepresentational -> "RoleRepresentational"
+    RolePhantom -> "RolePhantom"
+    RoleInfer -> "RoleInfer"
 
 docDataDecl :: DataDecl -> Doc ann
 docDataDecl dd =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -54,6 +54,8 @@ module Aihc.Parser.Syntax
     NewtypeDecl (..),
     OperatorName,
     Pattern (..),
+    Role (..),
+    RoleAnnotation (..),
     Rhs (..),
     HasSourceSpan (..),
     SourceSpan (..),
@@ -625,6 +627,7 @@ data Decl
   | DeclTypeSig SourceSpan [BinderName] Type
   | DeclStandaloneKindSig SourceSpan BinderName Type
   | DeclFixity SourceSpan FixityAssoc (Maybe Int) [OperatorName]
+  | DeclRoleAnnotation SourceSpan RoleAnnotation
   | DeclTypeSyn SourceSpan TypeSynDecl
   | DeclData SourceSpan DataDecl
   | DeclNewtype SourceSpan NewtypeDecl
@@ -648,6 +651,7 @@ instance HasSourceSpan Decl where
       DeclTypeSig span' _ _ -> span'
       DeclStandaloneKindSig span' _ _ -> span'
       DeclFixity span' _ _ _ -> span'
+      DeclRoleAnnotation span' _ -> span'
       DeclTypeSyn span' _ -> span'
       DeclData span' _ -> span'
       DeclNewtype span' _ -> span'
@@ -873,6 +877,23 @@ data TyVarBinder = TyVarBinder
 
 instance HasSourceSpan TyVarBinder where
   getSourceSpan = tyVarBinderSpan
+
+data Role
+  = RoleNominal
+  | RoleRepresentational
+  | RolePhantom
+  | RoleInfer
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data RoleAnnotation = RoleAnnotation
+  { roleAnnotationSpan :: SourceSpan,
+    roleAnnotationName :: Text,
+    roleAnnotationRoles :: [Role]
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
+instance HasSourceSpan RoleAnnotation where
+  getSourceSpan = roleAnnotationSpan
 
 data TypeSynDecl = TypeSynDecl
   { typeSynSpan :: SourceSpan,

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-multi-parameter.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-multi-parameter.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RoleAnnotations #-}
 
 module RoleMultiParameter where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-on-class-after-definition.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-on-class-after-definition.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE RoleAnnotations #-}
+
+module RoleOnClassAfterDefinition where
+
+class C a b where
+  method :: a -> b -> ()
+
+type role C representational _

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-on-newtype.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-on-newtype.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RoleAnnotations #-}
 
 module RoleOnNewtype where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-single-parameter.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-single-parameter.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RoleAnnotations #-}
 
 module RoleSingleParameter where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-with-infer.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RoleAnnotations/role-with-infer.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RoleAnnotations #-}
 
 module RoleWithInfer where


### PR DESCRIPTION
## Summary
- add a standalone `DeclRoleAnnotation` AST node plus `Role`/`RoleAnnotation` syntax types
- parse `type role` declarations in top-level declaration parsing and pretty-print/shorthand round-trip them
- flip the existing `RoleAnnotations` oracle fixtures to `pass` and add class coverage with a post-definition annotation

## Testing
- `cabal test -j1 aihc-parser:test:spec`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)

## Progress
- Parser progress: `PASS 550 -> 554`, `XFAIL 59 -> 56`, `XPASS 0 -> 0`, `FAIL 0 -> 0`, `TOTAL 609 -> 610`, `COMPLETE 90.31% -> 90.81%`
- Extension progress: `RoleAnnotations` from `In Progress (PASS=0 XFAIL=4 XPASS=0 FAIL=0)` to `Supported (PASS=5 XFAIL=0 XPASS=0 FAIL=0)`
