### PR TITLE
fix(parser): parse instance overlap pragmas

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -28,6 +28,13 @@ languagePragmaParser =
       TkPragmaLanguage names -> Just names
       _ -> Nothing
 
+instanceOverlapPragmaParser :: TokParser InstanceOverlapPragma
+instanceOverlapPragmaParser =
+  tokenSatisfy "instance overlap pragma" $ \tok ->
+    case lexTokenKind tok of
+      TkPragmaInstanceOverlap pragma' -> Just pragma'
+      _ -> Nothing
+
 moduleHeaderParser :: TokParser ModuleHead
 moduleHeaderParser = withSpan $ do
   keywordTok TkKeywordModule
@@ -717,6 +724,7 @@ classDefaultItemParser = withSpan $ do
 instanceDeclParser :: TokParser Decl
 instanceDeclParser = withSpan $ do
   keywordTok TkKeywordInstance
+  overlapPragma <- MP.optional instanceOverlapPragmaParser
   context <- MP.optional (MP.try (declContextParser <* expectedTok TkReservedDoubleArrow))
   className <- constructorIdentifierParser
   instanceTypes <- MP.some typeAtomParser
@@ -726,6 +734,7 @@ instanceDeclParser = withSpan $ do
       span'
       InstanceDecl
         { instanceDeclSpan = span',
+          instanceDeclOverlapPragma = overlapPragma,
           instanceDeclContext = fromMaybe [] context,
           instanceDeclClassName = className,
           instanceDeclTypes = instanceTypes,
@@ -738,6 +747,7 @@ standaloneDerivingDeclParser = withSpan $ do
   strategy <- MP.optional derivingStrategyParser
   viaTy <- MP.optional (MP.try derivingViaTypeParser)
   keywordTok TkKeywordInstance
+  overlapPragma <- MP.optional instanceOverlapPragmaParser
   context <- MP.optional (MP.try (declContextParser <* expectedTok TkReservedDoubleArrow))
   className <- constructorIdentifierParser
   instanceTypes <- MP.some typeAtomParser
@@ -747,6 +757,7 @@ standaloneDerivingDeclParser = withSpan $ do
       StandaloneDerivingDecl
         { standaloneDerivingSpan = span',
           standaloneDerivingStrategy = strategy,
+          standaloneDerivingOverlapPragma = overlapPragma,
           standaloneDerivingContext = fromMaybe [] context,
           standaloneDerivingClassName = className,
           standaloneDerivingTypes = instanceTypes,

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -164,6 +164,7 @@ data LexTokenKind
     TkTypeApp -- @ when tight on the right (type application)
   | -- Pragmas
     TkPragmaLanguage [ExtensionSetting]
+  | TkPragmaInstanceOverlap InstanceOverlapPragma
   | TkPragmaWarning Text
   | TkPragmaDeprecated Text
   | -- TemplateHaskellQuotes bracket tokens
@@ -625,6 +626,7 @@ noteModuleLayoutBeforeToken st tok =
     ModuleLayoutSeekStart ->
       case lexTokenKind tok of
         TkPragmaLanguage _ -> st
+        TkPragmaInstanceOverlap _ -> st
         TkPragmaWarning _ -> st
         TkPragmaDeprecated _ -> st
         TkKeywordModule -> st {layoutModuleMode = ModuleLayoutAwaitWhere}
@@ -970,6 +972,7 @@ virtualSymbolToken sym span' =
 lexKnownPragma :: LexerState -> Maybe (LexToken, LexerState)
 lexKnownPragma st
   | Just ((raw, kind), st') <- parsePragmaLike parseLanguagePragma st = Just (mkToken st st' raw kind, st')
+  | Just ((raw, kind), st') <- parsePragmaLike parseInstanceOverlapPragma st = Just (mkToken st st' raw kind, st')
   | Just ((raw, kind), st') <- parsePragmaLike parseOptionsPragma st = Just (mkToken st st' raw kind, st')
   | Just ((raw, kind), st') <- parsePragmaLike parseWarningPragma st = Just (mkToken st st' raw kind, st')
   | Just ((raw, kind), st') <- parsePragmaLike parseDeprecatedPragma st = Just (mkToken st st' raw kind, st')
@@ -1874,6 +1877,19 @@ parseLanguagePragma input = do
   let names = parseLanguagePragmaNames (T.pack body)
       raw = "{-# LANGUAGE " <> T.unpack (T.intercalate ", " (map extensionSettingName names)) <> " #-}"
   pure (length consumed, (T.pack raw, TkPragmaLanguage names))
+
+parseInstanceOverlapPragma :: String -> Maybe (Int, (Text, LexTokenKind))
+parseInstanceOverlapPragma input = do
+  (pragmaName, _, consumed) <- stripNamedPragma ["OVERLAPPING", "OVERLAPPABLE", "OVERLAPS", "INCOHERENT"] input
+  overlapPragma <-
+    case pragmaName of
+      "OVERLAPPING" -> Just Overlapping
+      "OVERLAPPABLE" -> Just Overlappable
+      "OVERLAPS" -> Just Overlaps
+      "INCOHERENT" -> Just Incoherent
+      _ -> Nothing
+  let raw = "{-# " <> pragmaName <> " #-}"
+  pure (length consumed, (T.pack raw, TkPragmaInstanceOverlap overlapPragma))
 
 parseOptionsPragma :: String -> Maybe (Int, (Text, LexTokenKind))
 parseOptionsPragma input = do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -702,6 +702,7 @@ prettyInstanceDecl decl =
   let headDoc =
         hsep
           ( ["instance"]
+              <> maybe [] (\pragma' -> [prettyInstanceOverlapPragma pragma']) (instanceDeclOverlapPragma decl)
               <> contextPrefix (instanceDeclContext decl)
               <> [pretty (instanceDeclClassName decl)]
               <> map (prettyTypeIn CtxTypeAtom) (instanceDeclTypes decl)
@@ -717,10 +718,19 @@ prettyStandaloneDeriving decl =
         <> maybe [] (\s -> [prettyDerivingStrategy s]) (standaloneDerivingStrategy decl)
         <> maybe [] (\ty -> ["via", prettyType ty]) (standaloneDerivingViaType decl)
         <> ["instance"]
+        <> maybe [] (\pragma' -> [prettyInstanceOverlapPragma pragma']) (standaloneDerivingOverlapPragma decl)
         <> contextPrefix (standaloneDerivingContext decl)
         <> [pretty (standaloneDerivingClassName decl)]
         <> map (prettyTypeIn CtxTypeAtom) (standaloneDerivingTypes decl)
     )
+
+prettyInstanceOverlapPragma :: InstanceOverlapPragma -> Doc ann
+prettyInstanceOverlapPragma pragma' =
+  case pragma' of
+    Overlapping -> "{-# OVERLAPPING #-}"
+    Overlappable -> "{-# OVERLAPPABLE #-}"
+    Overlaps -> "{-# OVERLAPS #-}"
+    Incoherent -> "{-# INCOHERENT #-}"
 
 prettyDerivingStrategy :: DerivingStrategy -> Doc ann
 prettyDerivingStrategy strategy =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -332,7 +332,8 @@ docInstanceDecl inst =
   "InstanceDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "className" (docText (instanceDeclClassName inst))]
+      optionalField "overlapPragma" docInstanceOverlapPragma (instanceDeclOverlapPragma inst)
+        <> [field "className" (docText (instanceDeclClassName inst))]
         <> listField "context" docConstraint (instanceDeclContext inst)
         <> [field "types" (brackets (hsep (punctuate comma (map docType (instanceDeclTypes inst)))))]
         <> listField "items" docInstanceDeclItem (instanceDeclItems inst)
@@ -351,11 +352,20 @@ docStandaloneDerivingDecl sd =
   "StandaloneDerivingDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "className" (docText (standaloneDerivingClassName sd))]
+      optionalField "overlapPragma" docInstanceOverlapPragma (standaloneDerivingOverlapPragma sd)
+        <> [field "className" (docText (standaloneDerivingClassName sd))]
         <> optionalField "strategy" docDerivingStrategy (standaloneDerivingStrategy sd)
         <> listField "context" docConstraint (standaloneDerivingContext sd)
         <> [field "types" (brackets (hsep (punctuate comma (map docType (standaloneDerivingTypes sd)))))]
         <> optionalField "viaType" docType (standaloneDerivingViaType sd)
+
+docInstanceOverlapPragma :: InstanceOverlapPragma -> Doc ann
+docInstanceOverlapPragma pragma' =
+  case pragma' of
+    Overlapping -> "Overlapping"
+    Overlappable -> "Overlappable"
+    Overlaps -> "Overlaps"
+    Incoherent -> "Incoherent"
 
 docForeignDecl :: ForeignDecl -> Doc ann
 docForeignDecl fd =
@@ -670,6 +680,7 @@ docTokenKind kind =
     TkPrefixBang -> "TkPrefixBang"
     TkPrefixTilde -> "TkPrefixTilde"
     TkPragmaLanguage settings -> "TkPragmaLanguage" <+> brackets (hsep (punctuate comma (map docExtensionSetting settings)))
+    TkPragmaInstanceOverlap pragma' -> "TkPragmaInstanceOverlap" <+> docInstanceOverlapPragma pragma'
     TkPragmaWarning msg -> "TkPragmaWarning" <+> docText msg
     TkPragmaDeprecated msg -> "TkPragmaDeprecated" <+> docText msg
     TkQuasiQuote quoter body -> "TkQuasiQuote" <+> docText quoter <+> docText body

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -43,6 +43,7 @@ module Aihc.Parser.Syntax
     ImportSpec (..),
     InstanceDecl (..),
     InstanceDeclItem (..),
+    InstanceOverlapPragma (..),
     LanguageEdition (..),
     Literal (..),
     Match (..),
@@ -1048,6 +1049,7 @@ data DerivingStrategy
 data StandaloneDerivingDecl = StandaloneDerivingDecl
   { standaloneDerivingSpan :: SourceSpan,
     standaloneDerivingStrategy :: Maybe DerivingStrategy,
+    standaloneDerivingOverlapPragma :: Maybe InstanceOverlapPragma,
     standaloneDerivingContext :: [Constraint],
     standaloneDerivingClassName :: Text,
     standaloneDerivingTypes :: [Type],
@@ -1104,6 +1106,7 @@ instance HasSourceSpan ClassDeclItem where
 
 data InstanceDecl = InstanceDecl
   { instanceDeclSpan :: SourceSpan,
+    instanceDeclOverlapPragma :: Maybe InstanceOverlapPragma,
     instanceDeclContext :: [Constraint],
     instanceDeclClassName :: Text,
     instanceDeclTypes :: [Type],
@@ -1113,6 +1116,13 @@ data InstanceDecl = InstanceDecl
 
 instance HasSourceSpan InstanceDecl where
   getSourceSpan = instanceDeclSpan
+
+data InstanceOverlapPragma
+  = Overlapping
+  | Overlappable
+  | Overlaps
+  | Incoherent
+  deriving (Data, Eq, Ord, Show, Read, Generic, NFData)
 
 data InstanceDeclItem
   = InstanceItemBind SourceSpan ValueDecl

--- a/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-incoherent-pragma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-incoherent-pragma.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+
+module InstanceIncoherentPragma where
+
+class Select a where
+  select :: a -> String
+
+instance {-# INCOHERENT #-} Select [a] where
+  select _ = "list"
+
+instance Select [Int] where
+  select _ = "ints"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-overlappable-pragma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-overlappable-pragma.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+
+module InstanceOverlappablePragma where
+
+class Select a where
+  select :: a -> String
+
+instance {-# OVERLAPPABLE #-} Select [a] where
+  select _ = "list"
+
+instance Select [Int] where
+  select _ = "ints"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-overlapping-pragma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-overlapping-pragma.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+
+module InstanceOverlappingPragma where
+
+class Select a where
+  select :: a -> String
+
+instance {-# OVERLAPPING #-} Select [Int] where
+  select _ = "ints"
+
+instance Select [a] where
+  select _ = "list"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-overlaps-pragma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/instance-overlaps-pragma.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+
+module InstanceOverlapsPragma where
+
+class Select a where
+  select :: a -> String
+
+instance {-# OVERLAPS #-} Select [Int] where
+  select _ = "ints"
+
+instance Select [a] where
+  select _ = "list"


### PR DESCRIPTION
## Summary
- parse `{-# OVERLAPPING #-}`, `{-# OVERLAPPABLE #-}`, `{-# OVERLAPS #-}`, and `{-# INCOHERENT #-}` immediately after `instance`
- keep instance overlap pragmas in the public parser AST and preserve them through pretty-print and shorthand rendering
- add oracle fixtures covering all four overlap pragma forms

## Verification
- `cabal test aihc-parser:test:spec`
- `nix flake check`
- `cabal run exe:hackage-tester -v0 -- servant-auth-swagger` (the reported parse error is fixed; the package now reaches a separate roundtrip mismatch)

## Progress Counts
Parser progress (`origin/main` -> this branch):
- PASS `550 -> 553`
- XFAIL `59 -> 60`
- XPASS `0 -> 0`
- FAIL `0 -> 0`
- TOTAL `609 -> 613`
- COMPLETE `90.31% -> 90.21%`

CPP progress:
- PASS `37 -> 37`
- XFAIL `0 -> 0`
- XPASS `0 -> 0`
- FAIL `0 -> 0`
- TOTAL `37 -> 37`
- COMPLETE `100.0% -> 100.0%`

## CodeRabbit
- skipped: `coderabbit review --prompt-only` hit a rate limit (`try after 8 minutes and 33 seconds`)
