### PR TITLE
fix(parser): handle tab-indented where layout

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -2161,6 +2161,14 @@ advanceChars chars st = foldl advanceOne st chars
               lexerByteOffset = lexerByteOffset acc + 1,
               lexerAtLineStart = True
             }
+        '\t' ->
+          let nextTabStop = 8 - ((lexerCol acc - 1) `mod` 8)
+           in acc
+                { lexerInput = drop 1 (lexerInput acc),
+                  lexerCol = lexerCol acc + nextTabStop,
+                  lexerByteOffset = lexerByteOffset acc + 1,
+                  lexerAtLineStart = False
+                }
         _ ->
           acc
             { lexerInput = drop 1 (lexerInput acc),

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -70,6 +70,7 @@ buildTests = do
             testCase "can lex lazily from chunks" test_lexerChunkLaziness,
             testCase "parser config passes extensions to lexer" test_parserConfigPassesExtensions,
             testCase "parser config sets source name in parse errors" test_parserConfigSetsSourceName,
+            testCase "parses tab-indented where after else branch" test_tabIndentedWhereAfterElseParses,
             testCase "generated identifiers reject reserved keyword as" test_generatedIdentifiersRejectReservedAs,
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
@@ -118,6 +119,25 @@ test_parserConfigSetsSourceName =
         else assertFailure ("expected source name in parse error, got: " <> errorBundlePretty (Just "module") err)
     ParseOk modu ->
       assertFailure ("expected parse failure, got: " <> show modu)
+
+test_tabIndentedWhereAfterElseParses :: Assertion
+test_tabIndentedWhereAfterElseParses =
+  let source =
+        T.pack $
+          unlines
+            [ "addExtension file ext = case B.uncons ext of",
+              "\tNothing -> file",
+              "\tJust (x,_xs) -> joinDrive a $",
+              "\t\tif isExtSeparator x",
+              "\t\t\tthen b <> ext",
+              "\t\t\telse b <> (extSeparator `B.cons` ext)",
+              "  where",
+              "\t(a,b) = splitDrive file"
+            ]
+   in case parseModule defaultConfig source of
+        ParseErr err ->
+          assertFailure ("expected parse success, got parse error: " <> errorBundlePretty Nothing err)
+        ParseOk _ -> pure ()
 
 test_readsHeaderLanguagePragmas :: Assertion
 test_readsHeaderLanguagePragmas = do

--- a/components/aihc-parser/test/Test/Fixtures/lexer/layout/where-tabs-after-else.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/layout/where-tabs-after-else.yaml
@@ -1,0 +1,65 @@
+extensions: []
+input: |
+  addExtension file ext = case B.uncons ext of
+  	Nothing -> file
+  	Just (x,_xs) -> joinDrive a $
+  		if isExtSeparator x
+  			then b <> ext
+  			else b <> (extSeparator `B.cons` ext)
+    where
+  	(a,b) = splitDrive file
+tokens:
+  - 'TkVarId "addExtension"'
+  - 'TkVarId "file"'
+  - 'TkVarId "ext"'
+  - 'TkReservedEquals'
+  - 'TkKeywordCase'
+  - 'TkQVarId "B.uncons"'
+  - 'TkVarId "ext"'
+  - 'TkKeywordOf'
+  - 'TkSpecialLBrace'
+  - 'TkConId "Nothing"'
+  - 'TkReservedRightArrow'
+  - 'TkVarId "file"'
+  - 'TkSpecialSemicolon'
+  - 'TkConId "Just"'
+  - 'TkSpecialLParen'
+  - 'TkVarId "x"'
+  - 'TkSpecialComma'
+  - 'TkVarId "_xs"'
+  - 'TkSpecialRParen'
+  - 'TkReservedRightArrow'
+  - 'TkVarId "joinDrive"'
+  - 'TkVarId "a"'
+  - 'TkVarSym "$"'
+  - 'TkKeywordIf'
+  - 'TkVarId "isExtSeparator"'
+  - 'TkVarId "x"'
+  - 'TkKeywordThen'
+  - 'TkVarId "b"'
+  - 'TkVarSym "<>"'
+  - 'TkVarId "ext"'
+  - 'TkKeywordElse'
+  - 'TkVarId "b"'
+  - 'TkVarSym "<>"'
+  - 'TkSpecialLParen'
+  - 'TkVarId "extSeparator"'
+  - 'TkSpecialBacktick'
+  - 'TkQVarId "B.cons"'
+  - 'TkSpecialBacktick'
+  - 'TkVarId "ext"'
+  - 'TkSpecialRParen'
+  - 'TkSpecialRBrace'
+  - 'TkKeywordWhere'
+  - 'TkSpecialLBrace'
+  - 'TkSpecialLParen'
+  - 'TkVarId "a"'
+  - 'TkSpecialComma'
+  - 'TkVarId "b"'
+  - 'TkSpecialRParen'
+  - 'TkReservedEquals'
+  - 'TkVarId "splitDrive"'
+  - 'TkVarId "file"'
+  - 'TkSpecialRBrace'
+  - 'TkEOF'
+status: pass


### PR DESCRIPTION
## Summary
- treat tab characters as advancing to the next 8-column tab stop when updating lexer columns
- add a parser regression for the `if ... else ... where` snippet from `filepath-bytestring`
- add a lexer golden fixture that locks in the correct `where` layout tokens for tab-indented bindings

## Verification
- `cabal test aihc-parser:spec`
- `nix flake check`
- `cabal run exe:hackage-tester -v0 -- filepath-bytestring`
- `coderabbit review --prompt-only` (`No findings`)

## Hackage Repro
- Before: `filepath-bytestring` reported 2 parse errors in `System/FilePath/Internal.hs`
- After: parse errors are gone; the package now reaches an unrelated existing roundtrip failure on `-<.>`

## Progress Counts
- Parser progress: `561 PASS / 54 XFAIL / 0 XPASS / 0 FAIL / 615 TOTAL` (`91.21%`), unchanged vs `origin/main`
- Parser extension progress: `53 supported / 19 in progress / 72 total`, unchanged vs `origin/main`
- CPP progress: `37 PASS / 0 XFAIL / 0 XPASS / 0 FAIL / 37 TOTAL` (`100.0%`), unchanged vs `origin/main`
