### PR TITLE
fix(parser): preserve nested let layout before in

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -813,12 +813,10 @@ closeAllImplicit contexts anchor =
   [virtualSymbolToken "}" anchor | ctx <- contexts, isImplicitLayoutContext ctx]
 
 closeLeadingImplicitLets :: SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
-closeLeadingImplicitLets anchor = go []
-  where
-    go acc contexts =
-      case contexts of
-        LayoutImplicitLet _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
-        _ -> (reverse acc, contexts)
+closeLeadingImplicitLets anchor contexts =
+  case contexts of
+    LayoutImplicitLet _ : rest -> ([virtualSymbolToken "}" anchor], rest)
+    _ -> ([], contexts)
 
 -- | Close all implicit layout contexts up to (but not including) the first explicit context.
 -- Used to implement the Haskell Report's "parse-error" rule for closing delimiters.

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/nested-let-layout-in.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/nested-let-layout-in.yaml
@@ -1,0 +1,26 @@
+extensions: []
+input: |
+  x = let y =
+            let z = 1
+             in z
+       in y
+tokens:
+  - 'TkVarId "x"'
+  - 'TkReservedEquals'
+  - 'TkKeywordLet'
+  - 'TkSpecialLBrace'
+  - 'TkVarId "y"'
+  - 'TkReservedEquals'
+  - 'TkKeywordLet'
+  - 'TkSpecialLBrace'
+  - 'TkVarId "z"'
+  - 'TkReservedEquals'
+  - 'TkInteger 1'
+  - 'TkSpecialRBrace'
+  - 'TkKeywordIn'
+  - 'TkVarId "z"'
+  - 'TkSpecialRBrace'
+  - 'TkKeywordIn'
+  - 'TkVarId "y"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/let-nested-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/let-nested-layout.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+module ExprS312LetNestedLayout where
+
+x = let y =
+          let z = 1
+           in z
+     in y


### PR DESCRIPTION
## Summary
- fix nested implicit `let` layout handling so `in` only closes the innermost layout block
- add a lexer regression for the nested-layout token stream
- add an oracle regression for nested layout `let` expressions

## Root Cause
The layout lexer closed all leading `LayoutImplicitLet` contexts when it saw `in`. For nested implicit `let` blocks, that prematurely closed both blocks and stranded the inner `in`, which surfaced as a parse failure on valid code.

## Impact
Valid nested layout `let` expressions now parse correctly, including the `genvalidity-bytestring` hackage case that previously failed parser validation.

## Validation
- `cabal test aihc-parser:test:spec`
- `cabal run -v0 exe:hackage-tester -- genvalidity-bytestring`

## Progress
- Parser progress after this change: `PASS 562`, `XFAIL 54`, `XPASS 0`, `FAIL 0`, `TOTAL 616`, `COMPLETE 91.23%`
- Progress counts are unchanged by this fix; this PR adds regression coverage rather than new parser feature coverage.

## Pre-PR Review
- `coderabbit review --prompt-only` did not return a review result, so the PR is opened without CodeRabbit feedback.
