### PR TITLE
refactor(parser): simplify lexer layout state

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -228,21 +228,17 @@ data LexerState = LexerState
 
 data LayoutContext
   = LayoutExplicit
-  | LayoutImplicit !Int
-  | LayoutImplicitLet !Int
-  | -- | Implicit layout opened after 'then do' or 'else do'.
-    -- This variant allows 'then' and 'else' to close it at the same indent level.
-    LayoutImplicitAfterThenElse !Int
+  | LayoutImplicit !Int !ImplicitLayoutKind
   | -- | Marker for ( or [ to scope implicit layout closures
     LayoutDelimiter
   deriving (Eq, Show)
 
-data PendingLayout
-  = PendingLayoutGeneric
-  | PendingLayoutLet
-  | -- | Pending layout from 'do' after 'then' or 'else'.
-    -- The resulting layout can be closed by 'then'/'else' at the same indent.
-    PendingLayoutAfterThenElse
+data ImplicitLayoutKind
+  = LayoutOrdinary
+  | LayoutLetBlock
+  | -- | Implicit layout opened after 'then do' or 'else do'.
+    -- These blocks can be closed by 'then'/'else' at the same indent level.
+    LayoutAfterThenElse
   deriving (Eq, Show)
 
 data ModuleLayoutMode
@@ -255,10 +251,9 @@ data ModuleLayoutMode
 
 data LayoutState = LayoutState
   { layoutContexts :: [LayoutContext],
-    layoutPendingLayout :: !(Maybe PendingLayout),
+    layoutPendingLayout :: !(Maybe ImplicitLayoutKind),
     layoutPrevLine :: !(Maybe Int),
     layoutPrevTokenKind :: !(Maybe LexTokenKind),
-    layoutDelimiterDepth :: !Int,
     layoutModuleMode :: !ModuleLayoutMode,
     -- | End span of the previous real (non-virtual) token, used to anchor
     -- virtual semicolons to the end of the previous line rather than the
@@ -571,20 +566,7 @@ nextToken st =
 
 applyLayoutTokens :: Bool -> [LexToken] -> [LexToken]
 applyLayoutTokens enableModuleLayout =
-  go
-    LayoutState
-      { layoutContexts = [],
-        layoutPendingLayout = Nothing,
-        layoutPrevLine = Nothing,
-        layoutPrevTokenKind = Nothing,
-        layoutDelimiterDepth = 0,
-        layoutModuleMode =
-          if enableModuleLayout
-            then ModuleLayoutSeekStart
-            else ModuleLayoutOff,
-        layoutPrevTokenEndSpan = Nothing,
-        layoutBuffer = []
-      }
+  go (mkInitialLayoutState enableModuleLayout)
   where
     go st toks =
       case toks of
@@ -594,32 +576,9 @@ applyLayoutTokens enableModuleLayout =
           let eofAnchor = NoSourceSpan
               (moduleInserted, stAfterModule) = finalizeModuleLayoutAtEOF st eofAnchor
            in moduleInserted <> closeAllImplicit (layoutContexts stAfterModule) eofAnchor
-        [eofTok]
-          | lexTokenKind eofTok == TkEOF ->
-              -- Use previous token's end span for closing virtual braces (if available),
-              -- falling back to EOF span. This improves error messages by pointing to
-              -- the end of the last real token rather than the empty line after.
-              let eofAnchor = fromMaybe (lexTokenSpan eofTok) (layoutPrevTokenEndSpan st)
-                  (moduleInserted, stAfterModule) = finalizeModuleLayoutAtEOF st eofAnchor
-               in moduleInserted <> closeAllImplicit (layoutContexts stAfterModule) eofAnchor <> [eofTok]
         tok : rest ->
-          let stModule = noteModuleLayoutBeforeToken st tok
-              (preInserted, stBeforePending) = closeBeforeToken stModule tok
-              (pendingInserted, stAfterPending, skipBOL) = openPendingLayout stBeforePending tok
-              (bolInserted, stAfterBOL) = if skipBOL then ([], stAfterPending) else bolLayout stAfterPending tok
-              stAfterToken = noteModuleLayoutAfterToken (stepTokenContext stAfterBOL tok) tok
-              -- Track end span of real (non-virtual) tokens for BOL anchoring
-              newEndSpan =
-                if lexTokenOrigin tok == FromSource
-                  then Just (lexTokenSpan tok)
-                  else layoutPrevTokenEndSpan stAfterToken
-              stNext =
-                stAfterToken
-                  { layoutPrevLine = Just (tokenStartLine tok),
-                    layoutPrevTokenKind = Just (lexTokenKind tok),
-                    layoutPrevTokenEndSpan = newEndSpan
-                  }
-           in preInserted <> pendingInserted <> bolInserted <> (tok : go stNext rest)
+          let (emitted, stNext) = layoutTransition st tok
+           in emitted <> go stNext rest
 
 finalizeModuleLayoutAtEOF :: LayoutState -> SourceSpan -> ([LexToken], LayoutState)
 finalizeModuleLayoutAtEOF st anchor =
@@ -645,7 +604,7 @@ noteModuleLayoutBeforeToken st tok =
         TkPragmaWarning _ -> st
         TkPragmaDeprecated _ -> st
         TkKeywordModule -> st {layoutModuleMode = ModuleLayoutAwaitWhere}
-        _ -> st {layoutModuleMode = ModuleLayoutDone, layoutPendingLayout = Just PendingLayoutGeneric}
+        _ -> st {layoutModuleMode = ModuleLayoutDone, layoutPendingLayout = Just LayoutOrdinary}
     _ -> st
 
 noteModuleLayoutAfterToken :: LayoutState -> LexToken -> LayoutState
@@ -653,7 +612,7 @@ noteModuleLayoutAfterToken st tok =
   case layoutModuleMode st of
     ModuleLayoutAwaitWhere
       | lexTokenKind tok == TkKeywordWhere ->
-          st {layoutModuleMode = ModuleLayoutAwaitBody, layoutPendingLayout = Just PendingLayoutGeneric}
+          st {layoutModuleMode = ModuleLayoutAwaitBody, layoutPendingLayout = Just LayoutOrdinary}
     _ -> st
 
 openPendingLayout :: LayoutState -> LexToken -> ([LexToken], LayoutState, Bool)
@@ -668,11 +627,7 @@ openPendingLayout st tok =
               parentIndent = currentLayoutIndent (layoutContexts st)
               openTok = virtualSymbolToken "{" (lexTokenSpan tok)
               closeTok = virtualSymbolToken "}" (lexTokenSpan tok)
-              newContext =
-                case pending of
-                  PendingLayoutGeneric -> LayoutImplicit col
-                  PendingLayoutLet -> LayoutImplicitLet col
-                  PendingLayoutAfterThenElse -> LayoutImplicitAfterThenElse col
+              newContext = LayoutImplicit col pending
            in if col <= parentIndent
                 then ([openTok, closeTok], st {layoutPendingLayout = Nothing}, False)
                 else
@@ -686,51 +641,37 @@ openPendingLayout st tok =
 
 closeBeforeToken :: LayoutState -> LexToken -> ([LexToken], LayoutState)
 closeBeforeToken st tok =
-  case lexTokenKind tok of
-    TkKeywordIn ->
-      let (inserted, contexts') = closeLeadingImplicitLets (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    -- Close implicit layout contexts before closing delimiters (parse-error rule)
-    TkSpecialRParen ->
-      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    TkSpecialRBracket ->
-      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    TkTHExpQuoteClose ->
-      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    TkTHTypedQuoteClose ->
-      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    TkSpecialRBrace ->
-      let (inserted, contexts') = closeAllImplicitBeforeDelimiter (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    -- Close implicit layout contexts before 'then' and 'else' keywords (parse-error rule)
-    -- These keywords cannot appear inside a do block, so we close contexts at >= their column.
-    TkKeywordThen ->
+  closeWith $
+    case lexTokenKind tok of
+      TkKeywordIn -> closeLeadingImplicitLet (lexTokenSpan tok)
+      kind
+        | closesImplicitBeforeDelimiter kind ->
+            closeImplicitLayouts (lexTokenSpan tok) (\_ _ -> True)
+      TkKeywordThen -> closeBeforeThenElse
+      TkKeywordElse -> closeBeforeThenElse
+      -- 'where' at the same column as an implicit layout closes that layout,
+      -- allowing it to attach to the enclosing definition.
+      TkKeywordWhere ->
+        closeImplicitLayouts (lexTokenSpan tok) (\indent _ -> tokenStartCol tok <= indent)
+      _ -> noLayoutClosures
+  where
+    closeBeforeThenElse =
       let col = tokenStartCol tok
-          (inserted, contexts') = closeForDedentInclusive col (lexTokenSpan tok) (layoutContexts st)
+       in closeImplicitLayouts (lexTokenSpan tok) $
+            \indent kind -> col < indent || (kind == LayoutAfterThenElse && col <= indent)
+
+    closeWith closeContexts =
+      let (inserted, contexts') = closeContexts (layoutContexts st)
        in (inserted, st {layoutContexts = contexts'})
-    TkKeywordElse ->
-      let col = tokenStartCol tok
-          (inserted, contexts') = closeForDedentInclusive col (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    -- Close implicit layout contexts before 'where' keyword (parse-error rule)
-    -- 'where' at the same column as an implicit layout closes that layout,
-    -- allowing it to attach to the enclosing definition.
-    TkKeywordWhere ->
-      let col = tokenStartCol tok
-          (inserted, contexts') = closeForDedentInclusiveAll col (lexTokenSpan tok) (layoutContexts st)
-       in (inserted, st {layoutContexts = contexts'})
-    _ -> ([], st)
+
+    noLayoutClosures contexts = ([], contexts)
 
 bolLayout :: LayoutState -> LexToken -> ([LexToken], LayoutState)
 bolLayout st tok
   | not (isBOL st tok) = ([], st)
   | otherwise =
       let col = tokenStartCol tok
-          (inserted, contexts') = closeForDedent col (lexTokenSpan tok) (layoutContexts st)
+          (inserted, contexts') = closeImplicitLayouts (lexTokenSpan tok) (\indent _ -> col < indent) (layoutContexts st)
           -- Use end of previous token for semicolon span (improves error messages
           -- by pointing to the end of the incomplete declaration rather than the
           -- start of the next one)
@@ -756,88 +697,26 @@ suppressesVirtualSemicolon tok =
     TkReservedDoubleColon -> True -- ::
     _ -> False
 
-closeForDedent :: Int -> SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
-closeForDedent col anchor = go []
+closeImplicitLayouts :: SourceSpan -> (Int -> ImplicitLayoutKind -> Bool) -> [LayoutContext] -> ([LexToken], [LayoutContext])
+closeImplicitLayouts anchor shouldClose = go []
   where
-    go acc contexts =
-      case contexts of
-        LayoutImplicit indent : rest
-          | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        LayoutImplicitLet indent : rest
-          | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        LayoutImplicitAfterThenElse indent : rest
-          | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        _ -> (reverse acc, contexts)
+    closeTok = virtualSymbolToken "}" anchor
 
--- | Close layout contexts opened after 'then do' or 'else do' when encountering
--- 'then' or 'else' at the same or lesser indent. This handles the parse-error rule
--- for these specific cases where the keyword cannot be part of the do block.
---
--- This function first closes any implicit layouts with indent > col (regular dedent),
--- then closes LayoutImplicitAfterThenElse contexts where col <= indent.
--- This ensures that nested layouts (like case blocks) are closed before
--- the then/else-specific layout closing.
-closeForDedentInclusive :: Int -> SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
-closeForDedentInclusive col anchor = go []
-  where
     go acc contexts =
       case contexts of
-        -- Close any implicit layout with indent > col (dedent rule)
-        LayoutImplicit indent : rest
-          | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        LayoutImplicitLet indent : rest
-          | col < indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        -- Close LayoutImplicitAfterThenElse where col <= indent (parse-error rule)
-        LayoutImplicitAfterThenElse indent : rest
-          | col <= indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        _ -> (reverse acc, contexts)
-
--- | Close all implicit layout contexts at or above the given column.
--- Used for 'where' which needs to close all enclosing implicit layouts
--- (not just LayoutImplicitAfterThenElse like then/else).
-closeForDedentInclusiveAll :: Int -> SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
-closeForDedentInclusiveAll col anchor = go []
-  where
-    go acc contexts =
-      case contexts of
-        LayoutImplicit indent : rest
-          | col <= indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        LayoutImplicitLet indent : rest
-          | col <= indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
-        LayoutImplicitAfterThenElse indent : rest
-          | col <= indent -> go (virtualSymbolToken "}" anchor : acc) rest
-          | otherwise -> (reverse acc, contexts)
+        LayoutImplicit indent kind : rest
+          | shouldClose indent kind -> go (closeTok : acc) rest
         _ -> (reverse acc, contexts)
 
 closeAllImplicit :: [LayoutContext] -> SourceSpan -> [LexToken]
 closeAllImplicit contexts anchor =
   [virtualSymbolToken "}" anchor | ctx <- contexts, isImplicitLayoutContext ctx]
 
-closeLeadingImplicitLets :: SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
-closeLeadingImplicitLets anchor contexts =
+closeLeadingImplicitLet :: SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
+closeLeadingImplicitLet anchor contexts =
   case contexts of
-    LayoutImplicitLet _ : rest -> ([virtualSymbolToken "}" anchor], rest)
+    LayoutImplicit _ LayoutLetBlock : rest -> ([virtualSymbolToken "}" anchor], rest)
     _ -> ([], contexts)
-
--- | Close all implicit layout contexts up to (but not including) the first explicit context.
--- Used to implement the Haskell Report's "parse-error" rule for closing delimiters.
-closeAllImplicitBeforeDelimiter :: SourceSpan -> [LayoutContext] -> ([LexToken], [LayoutContext])
-closeAllImplicitBeforeDelimiter anchor = go []
-  where
-    go acc contexts =
-      case contexts of
-        LayoutImplicit _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
-        LayoutImplicitLet _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
-        LayoutImplicitAfterThenElse _ : rest -> go (virtualSymbolToken "}" anchor : acc) rest
-        _ -> (reverse acc, contexts)
 
 -- | Update the layout state for the context changes caused by a token.
 -- This pushes/pops layout contexts for braces, brackets, keywords that
@@ -848,80 +727,21 @@ stepTokenContext st tok =
     TkKeywordDo
       | layoutPrevTokenKind st == Just TkKeywordThen
           || layoutPrevTokenKind st == Just TkKeywordElse ->
-          st {layoutPendingLayout = Just PendingLayoutAfterThenElse}
-      | otherwise -> st {layoutPendingLayout = Just PendingLayoutGeneric}
-    TkKeywordOf -> st {layoutPendingLayout = Just PendingLayoutGeneric}
+          st {layoutPendingLayout = Just LayoutAfterThenElse}
+      | otherwise -> st {layoutPendingLayout = Just LayoutOrdinary}
+    TkKeywordOf -> st {layoutPendingLayout = Just LayoutOrdinary}
     TkKeywordCase
       | layoutPrevTokenKind st == Just TkReservedBackslash ->
-          st {layoutPendingLayout = Just PendingLayoutGeneric}
+          st {layoutPendingLayout = Just LayoutOrdinary}
       | otherwise -> st
-    TkKeywordLet -> st {layoutPendingLayout = Just PendingLayoutLet}
-    TkKeywordWhere -> st {layoutPendingLayout = Just PendingLayoutGeneric}
-    TkSpecialLParen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkSpecialLBracket ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkTHExpQuoteOpen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkTHTypedQuoteOpen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkTHDeclQuoteOpen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkTHTypeQuoteOpen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkTHPatQuoteOpen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkSpecialUnboxedLParen ->
-      st
-        { layoutDelimiterDepth = layoutDelimiterDepth st + 1,
-          layoutContexts = LayoutDelimiter : layoutContexts st
-        }
-    TkSpecialRParen ->
-      st
-        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
-          layoutContexts = popToDelimiter (layoutContexts st)
-        }
-    TkSpecialUnboxedRParen ->
-      st
-        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
-          layoutContexts = popToDelimiter (layoutContexts st)
-        }
-    TkSpecialRBracket ->
-      st
-        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
-          layoutContexts = popToDelimiter (layoutContexts st)
-        }
-    TkTHExpQuoteClose ->
-      st
-        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
-          layoutContexts = popToDelimiter (layoutContexts st)
-        }
-    TkTHTypedQuoteClose ->
-      st
-        { layoutDelimiterDepth = max 0 (layoutDelimiterDepth st - 1),
-          layoutContexts = popToDelimiter (layoutContexts st)
-        }
+    TkKeywordLet -> st {layoutPendingLayout = Just LayoutLetBlock}
+    TkKeywordWhere -> st {layoutPendingLayout = Just LayoutOrdinary}
+    kind
+      | opensDelimiter kind ->
+          st {layoutContexts = LayoutDelimiter : layoutContexts st}
+    kind
+      | closesDelimiter kind ->
+          st {layoutContexts = popToDelimiter (layoutContexts st)}
     TkSpecialLBrace -> st {layoutContexts = LayoutExplicit : layoutContexts st}
     TkSpecialRBrace -> st {layoutContexts = popOneContext (layoutContexts st)}
     _ -> st
@@ -946,19 +766,48 @@ currentLayoutIndent contexts = fromMaybe 0 (currentLayoutIndentMaybe contexts)
 currentLayoutIndentMaybe :: [LayoutContext] -> Maybe Int
 currentLayoutIndentMaybe contexts =
   case contexts of
-    LayoutImplicit indent : _ -> Just indent
-    LayoutImplicitLet indent : _ -> Just indent
-    LayoutImplicitAfterThenElse indent : _ -> Just indent
+    LayoutImplicit indent _ : _ -> Just indent
     _ -> Nothing
 
 isImplicitLayoutContext :: LayoutContext -> Bool
 isImplicitLayoutContext ctx =
   case ctx of
-    LayoutImplicit _ -> True
-    LayoutImplicitLet _ -> True
-    LayoutImplicitAfterThenElse _ -> True
+    LayoutImplicit _ _ -> True
     LayoutExplicit -> False
     LayoutDelimiter -> False
+
+opensDelimiter :: LexTokenKind -> Bool
+opensDelimiter kind =
+  case kind of
+    TkSpecialLParen -> True
+    TkSpecialLBracket -> True
+    TkTHExpQuoteOpen -> True
+    TkTHTypedQuoteOpen -> True
+    TkTHDeclQuoteOpen -> True
+    TkTHTypeQuoteOpen -> True
+    TkTHPatQuoteOpen -> True
+    TkSpecialUnboxedLParen -> True
+    _ -> False
+
+closesDelimiter :: LexTokenKind -> Bool
+closesDelimiter kind =
+  case kind of
+    TkSpecialRParen -> True
+    TkSpecialUnboxedRParen -> True
+    TkSpecialRBracket -> True
+    TkTHExpQuoteClose -> True
+    TkTHTypedQuoteClose -> True
+    _ -> False
+
+closesImplicitBeforeDelimiter :: LexTokenKind -> Bool
+closesImplicitBeforeDelimiter kind =
+  case kind of
+    TkSpecialRParen -> True
+    TkSpecialRBracket -> True
+    TkTHExpQuoteClose -> True
+    TkTHTypedQuoteClose -> True
+    TkSpecialRBrace -> True
+    _ -> False
 
 isBOL :: LayoutState -> LexToken -> Bool
 isBOL st tok =
@@ -1019,7 +868,6 @@ mkInitialLayoutState enableModuleLayout =
       layoutPendingLayout = Nothing,
       layoutPrevLine = Nothing,
       layoutPrevTokenKind = Nothing,
-      layoutDelimiterDepth = 0,
       layoutModuleMode =
         if enableModuleLayout
           then ModuleLayoutSeekStart
@@ -1048,8 +896,7 @@ stepNextToken lexSt laySt =
       case scanOneToken lexSt of
         Nothing -> Nothing -- input exhausted & EOF already emitted
         Just (rawTok, lexSt') ->
-          let allToks = layoutStep laySt rawTok
-              laySt' = layoutStepState laySt rawTok
+          let (allToks, laySt') = layoutTransition laySt rawTok
            in case allToks of
                 [] -> Just (rawTok, lexSt', laySt') -- shouldn't happen, but be safe
                 first : rest ->
@@ -1100,50 +947,34 @@ scanOneToken st0 =
                       st'' = st' {lexerPrevTokenKind = Just (lexTokenKind tok), lexerHadTrivia = False}
                    in Just (tok, st'')
 
--- | Run one step of the layout engine on a raw token.
--- Returns the list of tokens to emit (virtual tokens + the raw token itself,
--- or for EOF, the closing virtual braces + EOF).
-layoutStep :: LayoutState -> LexToken -> [LexToken]
-layoutStep st tok =
+layoutTransition :: LayoutState -> LexToken -> ([LexToken], LayoutState)
+layoutTransition st tok =
   case lexTokenKind tok of
     TkEOF ->
-      -- Close all remaining implicit contexts and emit EOF
       let eofAnchor = fromMaybe (lexTokenSpan tok) (layoutPrevTokenEndSpan st)
           (moduleInserted, stAfterModule) = finalizeModuleLayoutAtEOF st eofAnchor
-       in moduleInserted <> closeAllImplicit (layoutContexts stAfterModule) eofAnchor <> [tok]
+       in ( moduleInserted <> closeAllImplicit (layoutContexts stAfterModule) eofAnchor <> [tok],
+            stAfterModule {layoutContexts = [], layoutBuffer = []}
+          )
     _ ->
       let stModule = noteModuleLayoutBeforeToken st tok
           (preInserted, stBeforePending) = closeBeforeToken stModule tok
           (pendingInserted, stAfterPending, skipBOL) = openPendingLayout stBeforePending tok
-          (bolInserted, _stAfterBOL) = if skipBOL then ([], stAfterPending) else bolLayout stAfterPending tok
-       in preInserted <> pendingInserted <> bolInserted <> [tok]
-
--- | Compute the updated layout state after processing a raw token.
--- This mirrors the state updates in 'layoutStep' without producing tokens.
-layoutStepState :: LayoutState -> LexToken -> LayoutState
-layoutStepState st tok =
-  case lexTokenKind tok of
-    TkEOF ->
-      let eofAnchor = fromMaybe (lexTokenSpan tok) (layoutPrevTokenEndSpan st)
-          (_moduleInserted, stAfterModule) = finalizeModuleLayoutAtEOF st eofAnchor
-       in stAfterModule {layoutContexts = []}
-    _ ->
-      let stModule = noteModuleLayoutBeforeToken st tok
-          (_preInserted, stBeforePending) = closeBeforeToken stModule tok
-          (_pendingInserted, stAfterPending, skipBOL) = openPendingLayout stBeforePending tok
-          (_bolInserted, stAfterBOL) = if skipBOL then ([], stAfterPending) else bolLayout stAfterPending tok
+          (bolInserted, stAfterBOL) = if skipBOL then ([], stAfterPending) else bolLayout stAfterPending tok
           stAfterToken = noteModuleLayoutAfterToken (stepTokenContext stAfterBOL tok) tok
           -- Track end span of real (non-virtual) tokens for BOL anchoring
           newEndSpan =
             if lexTokenOrigin tok == FromSource
               then Just (lexTokenSpan tok)
               else layoutPrevTokenEndSpan stAfterToken
-       in stAfterToken
-            { layoutPrevLine = Just (tokenStartLine tok),
-              layoutPrevTokenKind = Just (lexTokenKind tok),
-              layoutPrevTokenEndSpan = newEndSpan,
-              layoutBuffer = []
-            }
+          stNext =
+            stAfterToken
+              { layoutPrevLine = Just (tokenStartLine tok),
+                layoutPrevTokenKind = Just (lexTokenKind tok),
+                layoutPrevTokenEndSpan = newEndSpan,
+                layoutBuffer = []
+              }
+       in (preInserted <> pendingInserted <> bolInserted <> [tok], stNext)
 
 -- | Close the innermost implicit layout context, as if a virtual @}@ was inserted.
 -- This implements the parse-error rule: when the parser encounters a token that
@@ -1157,9 +988,7 @@ layoutStepState st tok =
 closeImplicitLayoutContext :: LayoutState -> Maybe LayoutState
 closeImplicitLayoutContext st =
   case layoutContexts st of
-    LayoutImplicit _ : rest -> Just (closeWith rest)
-    LayoutImplicitLet _ : rest -> Just (closeWith rest)
-    LayoutImplicitAfterThenElse _ : rest -> Just (closeWith rest)
+    LayoutImplicit _ _ : rest -> Just (closeWith rest)
     _ -> Nothing
   where
     anchor = fromMaybe noSpan (layoutPrevTokenEndSpan st)

--- a/components/aihc-parser/test/Test/Fixtures/lexer/layout/then-do-single-stmt.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/layout/then-do-single-stmt.yaml
@@ -1,0 +1,24 @@
+extensions: [DoAndIfThenElse]
+input: |
+  if True
+    then do
+    error "err"
+    else do
+    error "blah"
+tokens:
+  - 'TkKeywordIf'
+  - 'TkConId "True"'
+  - 'TkKeywordThen'
+  - 'TkKeywordDo'
+  - 'TkSpecialLBrace'
+  - 'TkVarId "error"'
+  - 'TkString "err"'
+  - 'TkSpecialRBrace'
+  - 'TkKeywordElse'
+  - 'TkKeywordDo'
+  - 'TkSpecialLBrace'
+  - 'TkVarId "error"'
+  - 'TkString "blah"'
+  - 'TkSpecialRBrace'
+  - 'TkEOF'
+status: pass


### PR DESCRIPTION
## Summary
- simplify the lexer layout stack to a single implicit context shape with a small kind tag
- collapse duplicated layout-closing code into shared helpers and a single `layoutTransition` path used by both batch and incremental lexing
- add a focused lexer regression for `then do` / `else do` single-statement layout handling

## Why
GHC's layout machinery stays close to a small stack-plus-flags model. Our lexer had accumulated extra state in the stack itself and duplicated the same transition logic in two paths, which made the code harder to reason about than the behavior required.

## Root Cause
The layout implementation had split one concept into several constructors and several near-duplicate closing functions:
- separate implicit constructors for ordinary, `let`, and `then/else do` layouts
- duplicate batch and incremental layout pipelines
- redundant delimiter-depth bookkeeping

That made the code larger and more brittle without adding behavior.

## Impact
- no intended parser behavior change
- shorter, more local layout logic in `Lex.hs`
- keeps the existing `then do` / `else do` parse-error behavior explicit through the layout kind policy instead of a separate stack constructor

## Progress Counts
Compared with `origin/main`, progress counts are unchanged:
- parser progress: `PASS 563 / XFAIL 54 / XPASS 0 / FAIL 0 / TOTAL 617 / COMPLETE 91.24%`
- parser extension progress: `SUPPORTED 53 / IN_PROGRESS 19 / TOTAL 72`
- cpp progress: `PASS 37 / XFAIL 0 / XPASS 0 / FAIL 0 / TOTAL 37 / COMPLETE 100.0%`

## Validation
- `cabal test aihc-parser:spec`
- `nix flake check`

## Pre-PR Review
- attempted `coderabbit review --prompt-only`
- skipped including findings because the command stalled without producing review output
