### PR TITLE
test: add literate Haskell golden tests (xfail)

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/golden/module/literate/bird-style-indented.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/literate/bird-style-indented.yaml
@@ -1,0 +1,10 @@
+extensions: []
+input: |
+  > module IndentedBird where
+  > 
+  > main = do
+  >   putStrLn "Hello"
+  >   where
+  >     x = 1
+status: xfail
+reason: Bird-style with indented Haskell code.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/literate/bird-style-interleaved.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/literate/bird-style-interleaved.yaml
@@ -1,0 +1,13 @@
+extensions: []
+input: |
+  > module BirdStyleInterleaved where
+
+  Interleaving some text.
+
+  > x = 1
+
+  More text.
+
+  > y = 2
+status: xfail
+reason: Interleaved Bird-style literate Haskell.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/literate/bird-style.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/literate/bird-style.yaml
@@ -1,0 +1,12 @@
+extensions: []
+input: |
+  This is a literate Haskell file.
+  The code starts with a greater-than sign.
+
+  > module BirdStyle where
+  > 
+  > main = putStrLn "Bird style!"
+
+  And then some more text here.
+status: xfail
+reason: Basic Bird-style literate Haskell.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/literate/latex-style-interleaved.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/literate/latex-style-interleaved.yaml
@@ -1,0 +1,13 @@
+extensions: []
+input: |
+  \begin{code}
+  module LatexInterleaved where
+  \end{code}
+
+  Some text in between.
+
+  \begin{code}
+  x = 1
+  \end{code}
+status: xfail
+reason: Interleaved LaTeX-style literate Haskell.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/literate/latex-style-with-other-envs.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/literate/latex-style-with-other-envs.yaml
@@ -1,0 +1,16 @@
+extensions: []
+input: |
+  \begin{document}
+  This is a LaTeX document.
+
+  \begin{code}
+  module LatexWithOtherEnvs where
+  x = 1
+  \end{code}
+
+  \begin{itemize}
+    \item Point 1
+  \end{itemize}
+  \end{document}
+status: xfail
+reason: LaTeX-style with other LaTeX environments.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/literate/latex-style.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/literate/latex-style.yaml
@@ -1,0 +1,14 @@
+extensions: []
+input: |
+  This is a LaTeX-style literate Haskell file.
+
+  \begin{code}
+  module LatexStyle where
+
+  main :: IO ()
+  main = putStrLn "LaTeX style!"
+  \end{code}
+
+  Outside the code environment, everything is a comment.
+status: xfail
+reason: Basic LaTeX-style literate Haskell.


### PR DESCRIPTION
feat: add Literate Haskell tests (xfail)

This PR adds several golden tests covering both Bird-style and LaTeX-style Literate Haskell. These tests are currently marked as `xfail` since the parser does not yet support the `.lhs` format or the prerequisite code extraction (similar to GHC's `unlit` preprocessor).

### Added Test Cases:
- **Bird-style**: Basic, Interleaved, Indented
- **LaTeX-style**: Basic, Interleaved, With other LaTeX environments

Progress summary:
- PASS: 514
- XFAIL: 92 (+6)
- TOTAL: 606 (+6)
