### PR TITLE
test(cpp): add multiline macro argument regression test

### DIFF
--- a/components/aihc-cpp/test/Test/Fixtures/progress/macro-multiline-args.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/macro-multiline-args.hs
@@ -1,0 +1,5 @@
+#define DEBUG(s) {- -}
+
+DEBUG("line1" ++
+      "line2" ++
+      "line3")

--- a/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -36,3 +36,4 @@ macro-name-in-string	macro	macro-name-in-string.hs	pass
 macro-expansion-not-in-string	macro	macro-expansion-not-in-string.hs	pass
 hpp-file-macro-string-pattern	macro	hpp-file-macro-string-pattern.hs	pass
 rules-pragma-cpp-branch	lexing	rules-pragma-cpp-branch.hs	pass
+macro-multiline-args	macro	macro-multiline-args.hs	xfail	broken multiline macro call


### PR DESCRIPTION
test(cpp): add multiline macro argument regression test

A failure was found in `aihc-cpp` where multiline macro calls in Haskell (like those using `++` for string concatenation) are not handled correctly.

Specifically:
```cpp
#define DEBUG(s) {- -}

DEBUG("line1" ++
      "line2" ++
      "line3")
```

This PR adds a test case marked as `xfail` to track this regression.

### Progress Summary
- PASS: 37
- XFAIL: 1 (+1)
- TOTAL: 38 (+1)