### PR TITLE
test(parser): add minimized oracle hackage repros

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/BlockArguments/as-pattern-lambda.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/BlockArguments/as-pattern-lambda.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail block argument lambda with as-pattern binder -}
+{-# LANGUAGE GHC2021, BlockArguments #-}
+module AsPatternLambda where
+
+f = id \x@(Just y) -> y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-qualified-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-qualified-constraint.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail parenthesized type-operator constraint -}
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module TypeOperatorQualifiedConstraint where
+
+import GHC.TypeLits
+
+f :: (1 <= 2) => ()
+f = ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/declarations/infix-funlhs-instance-prefix-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/declarations/infix-funlhs-instance-prefix-pattern.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail infix instance method with prefix constructor patterns -}
+module InfixFunlhsInstancePrefixPattern where
+
+data P = Z | S P
+
+instance Num P where
+  S m - S n = m - n


### PR DESCRIPTION
## Summary
- add minimized oracle xfail repros for the `unconditional-jump`, `peano`, and `n-tuple` hackage failures
- cover three parser gaps: block-argument lambda binders with `@`, infix instance method equations with prefix constructor patterns, and parenthesized `<=` constraints
- keep the repros standalone and reduced to the smallest GHC-accepted shapes found locally

## Progress counts
- parser oracle PASS: `563 -> 563`
- parser oracle XFAIL: `54 -> 57`
- parser oracle TOTAL: `617 -> 620`
- parser oracle COMPLETE: `91.25% -> 90.80%`

## Validation
- `cabal test -v0 aihc-parser:spec --test-options='--pattern oracle'`
- `cabal test -v0 all --test-options=--hide-successes`
- `nix flake check`

## CodeRabbit
- `coderabbit review --prompt-only` was rate-limited and skipped per repo instructions
