### PR TITLE
test: add oracle regressions for minimized hackage parser gaps

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-multiline-nested-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-multiline-nested-constraint.hs
@@ -1,0 +1,21 @@
+{- ORACLE_TEST xfail data-compat multiline forall with nested constraint applications -}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module ForallMultilineNestedConstraint where
+
+import Data.Kind (Constraint, Type)
+
+class Compat a where
+  type CompatConstraint a :: Type -> Constraint
+  type CompatF a :: Type -> Type
+
+getCompatible
+    :: forall a.
+       ( Compat a
+       , (CompatConstraint a) a
+       )
+    => (forall c. (Compat c, (CompatConstraint a) c) => (CompatF a) c)
+    -> (CompatF a) a
+getCompatible = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/NullaryTypeClasses/nullary-class.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NullaryTypeClasses/nullary-class.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail servant-auth-client nullary class declaration -}
+module NullaryClass where
+
+class BearerAuthNotEnabled

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_quote_then_promoted_cons.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_quote_then_promoted_cons.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail polysemy-fs template haskell quote before promoted cons -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TH_Quote_Then_Promoted_Cons where
+
+data FSDir
+''FSDir
+
+f :: x (FSDir ': r)
+f = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-equation-backtick-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-equation-backtick-operator.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST xfail generic-type-asserts backticked type operator in family equation -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TypeFamilyEquationBacktickOperator where
+
+data a :+: b
+
+type family F a where
+  F (l :+: r) = l `And` r
+
+type family l `And` r where
+  l `And` r = l

--- a/components/aihc-parser/test/Test/Fixtures/oracle/pragma/declaration-warning.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/pragma/declaration-warning.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail tasty-focus declaration warning after binding -}
+module DeclarationWarning where
+
+x = ()
+{-# WARNING x "w" #-}


### PR DESCRIPTION
## Summary
- add minimized oracle regression fixtures for parser failures found in `tasty-focus`, `data-compat`, `servant-auth-client`, `polysemy-fs`, and `generic-type-asserts`
- record each case as an `xfail` oracle fixture so the current parser gap is tracked without regressing the suite
- isolate the underlying parser shapes: declaration warning pragmas, multiline explicit `forall` with nested constraint applications, nullary class declarations, Template Haskell name quotes before promoted cons, and backticked type operators in type family equations

## Progress Counts
- oracle fixtures: `563 pass / 57 xfail / 0 xpass / 0 fail` -> `563 pass / 62 xfail / 0 xpass / 0 fail`
- oracle total: `620` -> `625`

## Verification
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle --hide-successes"`
- `cabal test -v0 all --test-options=--hide-successes`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)
