### PR TITLE
fix(aihc-cpp): suppress cpphs warnings in oracle tests

### DIFF
--- a/components/aihc-cpp/test/Test/Progress.hs
+++ b/components/aihc-cpp/test/Test/Progress.hs
@@ -190,7 +190,14 @@ resolveIncludePath rootPath req =
 runOracle :: FilePath -> IO (Either String Text)
 runOracle sourcePath = do
   source <- TIO.readFile sourcePath
-  let cpphsOptions = defaultCpphsOptions {boolopts = (boolopts defaultCpphsOptions) {stripC89 = True}}
+  let cpphsOptions =
+        defaultCpphsOptions
+          { boolopts =
+              (boolopts defaultCpphsOptions)
+                { stripC89 = True,
+                  warnings = False
+                }
+          }
   oracleOut <-
     (E.try (runCpphs cpphsOptions sourcePath (T.unpack source)) :: IO (Either E.SomeException String))
   pure $


### PR DESCRIPTION
**Description:**
This PR suppresses warning messages generated by the `cpphs` preprocessor during the `aihc-cpp` test suite execution. By setting `warnings = False` within the `cpphs` options in the `runOracle` function, we prevent these warnings from cluttering the test output while ensuring all tests continue to pass correctly.

**Changes:**
- Updated `runOracle` in `components/aihc-cpp/test/Test/Progress.hs` to set `warnings = False` in `cpphsOptions`.

**Review:**
CodeRabbit review was skipped due to an API rate limit.