### PR TITLE
feat(parser): add support for capi calling convention (CApiFFI)

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -871,6 +871,7 @@ callConvParser :: TokParser CallConv
 callConvParser =
   (varIdTok "ccall" >> pure CCall)
     <|> (varIdTok "stdcall" >> pure StdCall)
+    <|> (varIdTok "capi" >> pure CApi)
 
 foreignSafetyParser :: TokParser ForeignSafety
 foreignSafetyParser =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -803,6 +803,7 @@ prettyCallConv cc =
   case cc of
     CCall -> "ccall"
     StdCall -> "stdcall"
+    CApi -> "capi"
 
 prettySafety :: ForeignSafety -> Doc ann
 prettySafety safety =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -409,6 +409,7 @@ docCallConv cc =
   case cc of
     CCall -> "CCall"
     StdCall -> "StdCall"
+    CApi -> "CApi"
 
 docForeignSafety :: ForeignSafety -> Doc ann
 docForeignSafety fs =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1269,6 +1269,7 @@ data ForeignDirection
 data CallConv
   = CCall
   | StdCall
+  | CApi
   deriving (Data, Eq, Show, Generic, NFData)
 
 data ForeignSafety

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/corpus/hashable/hashable-ffi-capi-calling-convention.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/corpus/hashable/hashable-ffi-capi-calling-convention.hs
@@ -1,7 +1,9 @@
-{- ORACLE_TEST xfail from hashable/src/Data/Hashable/FFI.hs; parser does not support capi calling convention (CApiFFI) -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE MagicHash #-}
 module X where
 
-foreign import capi unsafe "HsXXHash.h hs_XXH3_64bits_withSeed_offset" unsafe_xxh3_64bit_withSeed_ba :: Int -> Int
+import Foreign.C.Types (CULLong)
+
+foreign import capi unsafe "HsXXHash.h hs_XXH3_64bits_withSeed_offset" unsafe_xxh3_64bit_withSeed_ba :: Int -> Int -> IO CULLong


### PR DESCRIPTION
## Summary

Implements parser support for the capi calling convention used in Foreign Function Interface declarations. This allows the parser to handle foreign import declarations with the capi calling convention, as specified by the CApiFFI language extension.

## Changes

- Add `CApi` to the `CallConv` data type in `Syntax.hs`
- Add capi parser to `callConvParser` in `Decl.hs`
- Update `prettyCallConv` in `Pretty.hs` to handle CApi
- Update `docCallConv` in `Shorthand.hs` to handle CApi
- Update test case to pass for `hashable-ffi-capi-calling-convention.hs`

## Test Results

All 938 parser tests pass, including the previously failing CApiFFI test case.