### PR TITLE
feat(parser): add PatternSynonyms support

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -182,7 +182,14 @@ importOperatorParser = operatorTextParser
 
 exportImportNamespaceParser :: TokParser Text
 exportImportNamespaceParser =
-  keywordTok TkKeywordType >> pure "type"
+  (keywordTok TkKeywordType >> pure "type")
+    <|> patternNamespaceParser
+  where
+    patternNamespaceParser = do
+      patSynEnabled <- isExtensionEnabled PatternSynonyms
+      if patSynEnabled
+        then varIdTok "pattern" >> pure "pattern"
+        else MP.empty
 
 declParser :: TokParser Decl
 declParser = do
@@ -224,11 +231,11 @@ declParser = do
         <|> typeSynDeclParser
     TkVarId ident ->
       case ident of
-        "pattern" -> unsupportedDeclParser "pattern synonym declarations are not implemented yet"
+        "pattern" -> patternSynonymParser
         _ -> typeSigOrValueOrSpliceParser
     TkConId ident ->
       case ident of
-        "pattern" -> unsupportedDeclParser "pattern synonym declarations are not implemented yet"
+        "pattern" -> patternSynonymParser
         _ -> typeSigOrValueOrSpliceParser
     TkSpecialLParen -> typeSigOrPatternOrValueOrSpliceParser
     TkSpecialLBracket -> patternOrSpliceParser
@@ -1250,9 +1257,6 @@ constructorOperatorParser =
       expectedTok TkSpecialBacktick
       pure op
 
-unsupportedDeclParser :: String -> TokParser Decl
-unsupportedDeclParser = fail
-
 -- | Parse a pattern binding declaration like @(x, y) = (1, 2)@.
 -- This handles bindings where the LHS is a pattern rather than a function name.
 patternBindDeclParser :: TokParser Decl
@@ -1266,3 +1270,115 @@ valueDeclParser = withSpan $ do
   (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
   rhs <- equationRhsParser
   pure (\span' -> functionBindDecl span' headForm name pats rhs)
+
+-- ---------------------------------------------------------------------------
+-- Pattern synonyms
+
+-- | Parse a pattern synonym declaration or signature.
+-- Dispatches between @pattern Name :: Type@ (signature) and
+-- @pattern Name args = pat@ / @pattern Name args <- pat [where ...]@ (declaration).
+patternSynonymParser :: TokParser Decl
+patternSynonymParser =
+  MP.try patternSynonymSigDeclParser <|> patternSynonymDeclParser
+
+-- | Parse a pattern synonym type signature: @pattern Name1, Name2 :: Type@
+patternSynonymSigDeclParser :: TokParser Decl
+patternSynonymSigDeclParser = withSpan $ do
+  varIdTok "pattern"
+  names <- patSynNameParser `MP.sepBy1` expectedTok TkSpecialComma
+  expectedTok TkReservedDoubleColon
+  ty <- typeParser
+  pure (\span' -> DeclPatSynSig span' names ty)
+
+-- | Parse a pattern synonym name (constructor identifier or parenthesized operator).
+patSynNameParser :: TokParser Text
+patSynNameParser =
+  constructorIdentifierParser <|> parens constructorOperatorParser
+
+-- | Parse a pattern synonym declaration.
+-- Handles prefix, infix, and record forms with all three directionalities.
+patternSynonymDeclParser :: TokParser Decl
+patternSynonymDeclParser = withSpan $ do
+  varIdTok "pattern"
+  (name, args) <- patSynLhsParser
+  (dir, pat) <- patSynDirAndPatParser name
+  pure $ \span' ->
+    DeclPatSyn
+      span'
+      PatSynDecl
+        { patSynDeclSpan = span',
+          patSynDeclName = name,
+          patSynDeclArgs = args,
+          patSynDeclPat = pat,
+          patSynDeclDir = dir
+        }
+
+-- | Parse the LHS of a pattern synonym declaration.
+-- Returns the name and the argument form.
+patSynLhsParser :: TokParser (Text, PatSynArgs)
+patSynLhsParser =
+  MP.try patSynInfixLhsParser <|> patSynRecordOrPrefixLhsParser
+
+-- | Parse an infix pattern synonym LHS: @var ConOp var@ or @var \`Con\` var@
+patSynInfixLhsParser :: TokParser (Text, PatSynArgs)
+patSynInfixLhsParser = do
+  lhs <- lowerIdentifierParser
+  op <- constructorOperatorParser
+  rhs <- lowerIdentifierParser
+  pure (op, PatSynInfixArgs lhs rhs)
+
+-- | Parse a record or prefix pattern synonym LHS.
+-- Record: @Con {field1, field2, ...}@
+-- Prefix: @Con var1 var2 ...@
+patSynRecordOrPrefixLhsParser :: TokParser (Text, PatSynArgs)
+patSynRecordOrPrefixLhsParser = do
+  name <- patSynNameParser
+  mFields <- MP.optional (MP.try patSynRecordFieldsParser)
+  case mFields of
+    Just fields -> pure (name, PatSynRecordArgs fields)
+    Nothing -> do
+      args <- MP.many lowerIdentifierParser
+      pure (name, PatSynPrefixArgs args)
+
+-- | Parse the record fields of a pattern synonym: @{field1, field2, ...}@
+patSynRecordFieldsParser :: TokParser [Text]
+patSynRecordFieldsParser = braces (lowerIdentifierParser `MP.sepEndBy` expectedTok TkSpecialComma)
+
+-- | Parse the direction marker and RHS pattern of a pattern synonym.
+patSynDirAndPatParser :: Text -> TokParser (PatSynDir, Pattern)
+patSynDirAndPatParser name = do
+  tok <- lookAhead anySingle
+  case lexTokenKind tok of
+    TkReservedEquals -> do
+      expectedTok TkReservedEquals
+      pat <- patternParser
+      pure (PatSynBidirectional, pat)
+    TkReservedLeftArrow -> do
+      expectedTok TkReservedLeftArrow
+      pat <- patternParser
+      mMatches <- MP.optional (patSynWhereClauseParser name)
+      case mMatches of
+        Nothing -> pure (PatSynUnidirectional, pat)
+        Just matches -> pure (PatSynExplicitBidirectional matches, pat)
+    _ -> fail "expected '=' or '<-' in pattern synonym declaration"
+
+-- | Parse the where clause of an explicitly bidirectional pattern synonym.
+-- @where { Name pats = expr; ... }@
+patSynWhereClauseParser :: Text -> TokParser [Match]
+patSynWhereClauseParser _name =
+  whereClauseItemsParser
+    (bracedSemiSep patSynWhereMatch)
+    (plainSemiSep1 patSynWhereMatch)
+
+-- | Parse one equation in a pattern synonym where clause.
+patSynWhereMatch :: TokParser Match
+patSynWhereMatch = withSpan $ do
+  (headForm, _name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  rhs <- equationRhsParser
+  pure $ \span' ->
+    Match
+      { matchSpan = span',
+        matchHeadForm = headForm,
+        matchPats = pats,
+        matchRhs = rhs
+      }

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -431,12 +431,20 @@ buildInfixPattern lhs (op, rhs) =
 
 conOperatorParser :: TokParser Text
 conOperatorParser =
-  tokenSatisfy "constructor operator" $ \tok ->
-    case lexTokenKind tok of
-      TkConSym op -> Just op
-      TkQConSym op -> Just op
-      TkReservedColon -> Just ":"
-      _ -> Nothing
+  symbolicConOp <|> backtickConOp
+  where
+    symbolicConOp =
+      tokenSatisfy "constructor operator" $ \tok ->
+        case lexTokenKind tok of
+          TkConSym op -> Just op
+          TkQConSym op -> Just op
+          TkReservedColon -> Just ":"
+          _ -> Nothing
+    backtickConOp = MP.try $ do
+      expectedTok TkSpecialBacktick
+      name <- constructorIdentifierParser
+      expectedTok TkSpecialBacktick
+      pure name
 
 appPatternParser :: TokParser Pattern
 appPatternParser = do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -153,6 +153,8 @@ prettyDeclLines decl =
   case decl of
     DeclValue _ valueDecl -> prettyValueDeclLines valueDecl
     DeclTypeSig _ names ty -> [hsep [hsep (punctuate comma (map prettyBinderName names)), "::", prettyType ty]]
+    DeclPatSyn _ patSynDecl -> [prettyPatSynDecl patSynDecl]
+    DeclPatSynSig _ names ty -> [hsep ["pattern", hsep (punctuate comma (map prettyConstructorName names)), "::", prettyType ty]]
     DeclStandaloneKindSig _ name kind -> [hsep ["type", prettyConstructorName name, "::", prettyType kind]]
     DeclFixity _ assoc prec ops ->
       [ hsep
@@ -218,6 +220,39 @@ prettyValueDeclSingleLine valueDecl =
     PatternBind _ pat rhs -> prettyPattern pat <+> prettyRhs rhs
     FunctionBind _ name matches ->
       hsep (punctuate semi (map (prettyFunctionMatch name) matches))
+
+-- | Pretty-print a pattern synonym declaration.
+prettyPatSynDecl :: PatSynDecl -> Doc ann
+prettyPatSynDecl ps =
+  hsep
+    ( ["pattern"]
+        <> prettyPatSynLhs (patSynDeclName ps) (patSynDeclArgs ps)
+        <> [dirArrow (patSynDeclDir ps)]
+        <> [prettyPattern (patSynDeclPat ps)]
+        <> prettyPatSynWhere (patSynDeclName ps) (patSynDeclDir ps)
+    )
+  where
+    dirArrow PatSynBidirectional = "="
+    dirArrow PatSynUnidirectional = "<-"
+    dirArrow (PatSynExplicitBidirectional _) = "<-"
+
+-- | Pretty-print the LHS of a pattern synonym declaration (after @pattern@).
+prettyPatSynLhs :: Text -> PatSynArgs -> [Doc ann]
+prettyPatSynLhs name args =
+  case args of
+    PatSynPrefixArgs vars ->
+      prettyConstructorName name : map pretty vars
+    PatSynInfixArgs lhs rhs ->
+      [pretty lhs, prettyInfixOp name, pretty rhs]
+    PatSynRecordArgs fields ->
+      [prettyConstructorName name <+> braces (hsep (punctuate comma (map pretty fields)))]
+
+-- | Pretty-print the where clause of an explicitly bidirectional pattern synonym.
+prettyPatSynWhere :: Text -> PatSynDir -> [Doc ann]
+prettyPatSynWhere _ PatSynBidirectional = []
+prettyPatSynWhere _ PatSynUnidirectional = []
+prettyPatSynWhere name (PatSynExplicitBidirectional matches) =
+  ["where", braces (hsep (punctuate semi (map (prettyFunctionMatch name) matches)))]
 
 prettyFunctionMatchLines :: Text -> Match -> [Doc ann]
 prettyFunctionMatchLines name match =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -162,6 +162,8 @@ docDecl decl =
   case decl of
     DeclValue _ vdecl -> "DeclValue" <+> parens (docValueDecl vdecl)
     DeclTypeSig _ names ty -> "DeclTypeSig" <+> braces (hsep (punctuate comma [field "names" (docTextList names), field "type" (docType ty)]))
+    DeclPatSyn _ ps -> "DeclPatSyn" <+> parens (docPatSynDecl ps)
+    DeclPatSynSig _ names ty -> "DeclPatSynSig" <+> braces (hsep (punctuate comma [field "names" (docTextList names), field "type" (docType ty)]))
     DeclStandaloneKindSig _ name kind -> "DeclStandaloneKindSig" <+> braces (hsep (punctuate comma [field "name" (docText name), field "kind" (docType kind)]))
     DeclFixity _ assoc mPrec ops -> "DeclFixity" <+> braces (hsep (punctuate comma ([field "assoc" (docFixityAssoc assoc)] <> optionalField "prec" pretty mPrec <> [field "ops" (docTextList ops)])))
     DeclRoleAnnotation _ ann -> "DeclRoleAnnotation" <+> parens (docRoleAnnotation ann)
@@ -184,6 +186,31 @@ docValueDecl vdecl =
   case vdecl of
     FunctionBind _ name matches -> "FunctionBind" <+> docText name <+> brackets (hsep (punctuate comma (map docMatch matches)))
     PatternBind _ pat rhs -> "PatternBind" <+> docPattern pat <+> docRhs rhs
+
+docPatSynDecl :: PatSynDecl -> Doc ann
+docPatSynDecl ps =
+  "PatSynDecl" <+> braces (hsep (punctuate comma fields))
+  where
+    fields =
+      [field "name" (docText (patSynDeclName ps))]
+        <> [field "args" (docPatSynArgs (patSynDeclArgs ps))]
+        <> [field "dir" (docPatSynDir (patSynDeclDir ps))]
+        <> [field "pat" (docPattern (patSynDeclPat ps))]
+
+docPatSynDir :: PatSynDir -> Doc ann
+docPatSynDir dir =
+  case dir of
+    PatSynUnidirectional -> "Unidirectional"
+    PatSynBidirectional -> "Bidirectional"
+    PatSynExplicitBidirectional matches ->
+      "ExplicitBidirectional" <+> brackets (hsep (punctuate comma (map docMatch matches)))
+
+docPatSynArgs :: PatSynArgs -> Doc ann
+docPatSynArgs args =
+  case args of
+    PatSynPrefixArgs vars -> "PrefixArgs" <+> docTextList vars
+    PatSynInfixArgs lhs rhs -> "InfixArgs" <+> docText lhs <+> docText rhs
+    PatSynRecordArgs fields' -> "RecordArgs" <+> docTextList fields'
 
 docMatch :: Match -> Doc ann
 docMatch m =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -54,6 +54,9 @@ module Aihc.Parser.Syntax
     WarningText (..),
     NewtypeDecl (..),
     OperatorName,
+    PatSynArgs (..),
+    PatSynDecl (..),
+    PatSynDir (..),
     Pattern (..),
     Role (..),
     RoleAnnotation (..),
@@ -694,6 +697,8 @@ data ImportItem
 data Decl
   = DeclValue SourceSpan ValueDecl
   | DeclTypeSig SourceSpan [BinderName] Type
+  | DeclPatSyn SourceSpan PatSynDecl
+  | DeclPatSynSig SourceSpan [BinderName] Type
   | DeclStandaloneKindSig SourceSpan BinderName Type
   | DeclFixity SourceSpan FixityAssoc (Maybe Int) [OperatorName]
   | DeclRoleAnnotation SourceSpan RoleAnnotation
@@ -718,6 +723,8 @@ instance HasSourceSpan Decl where
     case decl of
       DeclValue span' _ -> span'
       DeclTypeSig span' _ _ -> span'
+      DeclPatSyn span' _ -> span'
+      DeclPatSynSig span' _ _ -> span'
       DeclStandaloneKindSig span' _ _ -> span'
       DeclFixity span' _ _ _ -> span'
       DeclRoleAnnotation span' _ -> span'
@@ -761,6 +768,39 @@ data MatchHeadForm
   = MatchHeadPrefix
   | MatchHeadInfix
   deriving (Data, Eq, Show, Generic, NFData)
+
+-- | Pattern synonym declaration direction.
+data PatSynDir
+  = -- | @pattern P x <- pat@
+    PatSynUnidirectional
+  | -- | @pattern P x = pat@
+    PatSynBidirectional
+  | -- | @pattern P x <- pat where P x = expr@
+    PatSynExplicitBidirectional [Match]
+  deriving (Data, Eq, Show, Generic, NFData)
+
+-- | Pattern synonym argument form.
+data PatSynArgs
+  = -- | @pattern Name arg1 arg2 ...@
+    PatSynPrefixArgs [Text]
+  | -- | @pattern arg1 \`Name\` arg2@ or @pattern arg1 :+: arg2@
+    PatSynInfixArgs Text Text
+  | -- | @pattern Name {field1, field2}@
+    PatSynRecordArgs [Text]
+  deriving (Data, Eq, Show, Generic, NFData)
+
+-- | Pattern synonym declaration.
+data PatSynDecl = PatSynDecl
+  { patSynDeclSpan :: SourceSpan,
+    patSynDeclName :: Text,
+    patSynDeclArgs :: PatSynArgs,
+    patSynDeclPat :: Pattern,
+    patSynDeclDir :: PatSynDir
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
+instance HasSourceSpan PatSynDecl where
+  getSourceSpan = patSynDeclSpan
 
 data Rhs
   = UnguardedRhs SourceSpan Expr

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/pattern-synonym-basic.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/pattern-synonym-basic.yaml
@@ -1,0 +1,7 @@
+extensions:
+  - PatternSynonyms
+input: |
+  pattern Pair x y = (x, y)
+ast: |
+  Module {decls = [DeclPatSyn (PatSynDecl {name = "Pair", args = PrefixArgs ["x", "y"], dir = Bidirectional, pat = PTuple [PVar "x", PVar "y"]})]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/pattern-synonym-unsupported.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/pattern-synonym-unsupported.yaml
@@ -1,6 +1,0 @@
-extensions:
-  - PatternSynonyms
-input: |
-  pattern Pair x y = (x, y)
-status: fail
-reason: pattern synonym declarations should fail explicitly until the AST and parser support them

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-bidirectional-prefix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-bidirectional-prefix.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsBidirectionalPrefix where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-complete-pragma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-complete-pragma.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST xfail COMPLETE/INLINE pragmas not in token stream -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsCompletePragma where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-explicitly-bidirectional.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-explicitly-bidirectional.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsExplicitlyBidirectional where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-data-keyword.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-data-keyword.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsExportDataKeyword

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-pattern-keyword.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-pattern-keyword.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-import-data-keyword.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-import-data-keyword.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsImportDataKeyword where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-import-pattern-keyword.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-import-pattern-keyword.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-infix-backticks.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-infix-backticks.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsInfixBackticks where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-infix-symbol.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-infix-symbol.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsInfixSymbol where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-inline-pragmas.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-inline-pragmas.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST xfail COMPLETE/INLINE pragmas not in token stream -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsInlinePragmas where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-record-bidirectional.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-record-bidirectional.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsRecordBidirectional where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-record-unidirectional.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-record-unidirectional.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsRecordUnidirectional where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-basic.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-basic.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsSignatureBasic where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-dual-context.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-dual-context.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsSignatureDualContext where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-unidirectional-prefix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-unidirectional-prefix.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser support pending -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module PatternSynonymsUnidirectionalPrefix where


### PR DESCRIPTION
## Summary

- Add full parser support for the `PatternSynonyms` extension: declarations (prefix, infix, record), all three directionalities (unidirectional `<-`, bidirectional `=`, explicitly bidirectional `<- ... where`), type signatures (including dual-context), and `pattern` keyword in import/export lists
- Add backtick-wrapped constructor support in infix pattern positions (fixes `conOperatorParser` to handle `` `Con` `` syntax with proper backtracking)
- New AST types: `PatSynDecl`, `PatSynDir`, `PatSynArgs` with `DeclPatSyn` and `DeclPatSynSig` constructors on `Decl`

## Progress

| Extension | Before | After |
|---|---|---|
| PatternSynonyms | 3/20 | 16/20 |

Two oracle tests remain xfail: `COMPLETE` and `INLINE`/`NOINLINE` pragmas are consumed by the lexer as unknown pragmas and don't appear in the token stream, so the round-trip test cannot preserve them.