### PR TITLE
fix(parser): avoid tuple-pattern function head rescans

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -988,7 +988,7 @@ parenOrTuplePatternParser = withSpan $ do
     _ -> do
       canBeViewPattern <-
         if tupleFlavor == Boxed
-          then hasTopLevelRightArrowBefore closeTok
+          then hasTopLevelViewPatternArrowBefore closeTok
           else pure False
       if canBeViewPattern
         then MP.try (viewPatternParser tupleFlavor closeTok) <|> tupleOrParenPatternParser tupleFlavor closeTok
@@ -1108,8 +1108,8 @@ startsWithContextType = MP.lookAhead (go [])
         TkSpecialLBrace -> go (TkSpecialRBrace : stack)
         _ -> go stack
 
-hasTopLevelRightArrowBefore :: LexTokenKind -> TokParser Bool
-hasTopLevelRightArrowBefore closeTok = MP.lookAhead (go [closeTok])
+hasTopLevelViewPatternArrowBefore :: LexTokenKind -> TokParser Bool
+hasTopLevelViewPatternArrowBefore closeTok = MP.lookAhead (go [closeTok])
   where
     go [] = pure False
     go stack@(expectedClose : rest) = do
@@ -1117,6 +1117,7 @@ hasTopLevelRightArrowBefore closeTok = MP.lookAhead (go [closeTok])
       case lexTokenKind tok of
         TkEOF -> pure False
         TkReservedRightArrow | [_] <- stack -> pure True
+        TkSpecialComma | [_] <- stack -> pure False
         kind
           | kind == expectedClose ->
               case rest of

--- a/components/aihc-parser/test/Test/Performance/Suite.hs
+++ b/components/aihc-parser/test/Test/Performance/Suite.hs
@@ -188,6 +188,8 @@ generatedPerfCases =
     mkGeneratedPerfCase "tuple-type-wide" (mkTypeModule (wideTupleType generatedCaseSize)),
     mkGeneratedPerfCase "tuple-pattern-nested" (mkPatternModule (nestedTuplePattern generatedCaseSize)),
     mkGeneratedPerfCase "tuple-pattern-wide" (mkPatternModule (wideTuplePattern generatedCaseSize)),
+    mkGeneratedPerfCase "tuple-pattern-function-nested" (mkTuplePatternFunctionModule (nestedTuplePattern generatedCaseSize)),
+    mkGeneratedPerfCase "tuple-pattern-function-wide" (mkTuplePatternFunctionModule (wideTuplePattern generatedCaseSize)),
     mkGeneratedPerfCase "enum-data-constructors" (mkDataModule (enumDataDecl generatedCaseSize)),
     mkGeneratedPerfCase "record-data-fields" (mkDataModule (recordDataDecl generatedCaseSize)),
     mkGeneratedPerfCase "type-right-leaning-terms" (mkTypeModule (rightLeaningType generatedCaseSize)),
@@ -220,6 +222,9 @@ mkTypeModule ty = T.unlines ["module Generated where", "value :: " <> ty, "value
 
 mkPatternModule :: Text -> Text
 mkPatternModule pat = T.unlines ["module Generated where", "value " <> pat <> " = x1", "  where", "    x1 = 1"]
+
+mkTuplePatternFunctionModule :: Text -> Text
+mkTuplePatternFunctionModule pat = T.unlines ["module Generated where", "fn " <> pat <> " = ()"]
 
 mkDataModule :: Text -> Text
 mkDataModule decl = T.unlines ["module Generated where", decl]


### PR DESCRIPTION
## Summary
- add generated performance cases for function bindings shaped like `fn (x1, x2, x3, ...) = ()` for both nested and wide tuple patterns
- stop boxed tuple-pattern view-pattern lookahead at the first top-level comma, avoiding repeated full scans of tuple function heads while preserving view-pattern parsing
- local checks passed: `cabal test -v0 aihc-parser:spec --test-options=\"--pattern performance\"`, `cabal test -v0 all --test-options=--hide-successes`, `nix flake check`; CodeRabbit prompt-only review reported no findings

## Progress
- performance generated cases: 15 -> 17