### PR TITLE
test(parser): add oracle regressions for minimized package failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-instance-head.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail dependent-sum explicit forall in instance head -}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ForallInstanceHead where
+
+class C a
+
+instance forall a. C a where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LocalTypeSignatures/let-binding-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LocalTypeSignatures/let-binding-signature.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail mathexpr let-bound signature before rhs -}
+module LetBindingSignature where
+
+f = let x :: Double = 1 in x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MagicHash/word-literal-double-hash.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MagicHash/word-literal-double-hash.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail Mantissa boxed Word# literal with 0## -}
+{-# LANGUAGE MagicHash #-}
+
+module WordLiteralDoubleHash where
+
+import GHC.Exts
+
+f = W# 0##

--- a/components/aihc-parser/test/Test/Fixtures/oracle/OverloadedLabels/infix-overloaded-label.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/OverloadedLabels/infix-overloaded-label.hs
@@ -1,0 +1,20 @@
+{- ORACLE_TEST xfail yggdrasil-schema infix overloaded label after operator -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+module InfixOverloadedLabel where
+
+import GHC.OverloadedLabels
+
+data L = L
+
+instance IsLabel "a" L where
+  fromLabel = L
+
+(^.) :: a -> L -> ()
+(^.) = undefined
+
+f :: ()
+f = undefined ^. #a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/prefix-constructor-nothing.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/prefix-constructor-nothing.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail emojis prefix constructor patterns roundtrip with Nothing arguments -}
+module PrefixConstructorNothing where
+
+data T = T (Maybe Int) (Maybe Int)
+
+f (T Nothing Nothing) = ()
+f _ = ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Whitespace/form-feed-top-level.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Whitespace/form-feed-top-level.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail stringable form-feed between module header and binding -}
+module FormFeedTopLevel where
+
+x = 1


### PR DESCRIPTION
## Summary
- add minimized oracle regressions for package failures from `yggdrasil-schema`, `mathexpr`, `emojis`, `stringable`, `dependent-sum`, and `Mantissa`
- keep each fixture to the smallest GHC-accepted snippet that still reproduces the current parser or roundtrip gap
- cover the `emojis` package via its minimized `Trie` roundtrip mismatch, since the original failure path depends on hackage-tester CPP/include preprocessing rather than an oracle-stable standalone snippet

## Added regressions
- `yggdrasil-schema` -> `OverloadedLabels/infix-overloaded-label.hs`
- `mathexpr` -> `LocalTypeSignatures/let-binding-signature.hs`
- `emojis` -> `Patterns/prefix-constructor-nothing.hs`
- `stringable` -> `Whitespace/form-feed-top-level.hs`
- `dependent-sum` -> `ExplicitForAll/forall-instance-head.hs`
- `Mantissa` -> `MagicHash/word-literal-double-hash.hs`

## Checks
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle"`
- `cabal test -v0 all --test-options=--hide-successes`
- `nix flake check`
- `coderabbit review --prompt-only`

## Progress counts
- oracle progress before this PR: `pass=579 xfail=46 completion=92.64%`
- oracle progress after this PR: `pass=579 xfail=52 completion=91.76%`

## CodeRabbit
- addressed the only prompt by making the `emojis` fixture match total with a fallback clause
