### PR TITLE
refactor(cpp): add Cursor module and rewrite Scanner with byte-level cursor

### DIFF
--- a/components/aihc-cpp/aihc-cpp.cabal
+++ b/components/aihc-cpp/aihc-cpp.cabal
@@ -17,9 +17,11 @@ library
       Aihc.Cpp.Parser
       Aihc.Cpp.Evaluator
       Aihc.Cpp.Scanner
+      Aihc.Cpp.Cursor
   hs-source-dirs:   src
   build-depends:
       base >=4.16 && <5
+    , bytestring
     , text >=1.2
     , containers
     , filepath

--- a/components/aihc-cpp/src/Aihc/Cpp/Cursor.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Cursor.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- |
+-- Module      : Aihc.Cpp.Cursor
+-- Description : Zero-copy cursor over ByteString for efficient scanning
+-- License     : Unlicense
+--
+-- A lightweight cursor abstraction over a strict 'ByteString'. The cursor
+-- tracks a position into a shared buffer, enabling O(1) peeking and
+-- zero-copy slicing. All CPP-significant bytes are ASCII (0x00-0x7F),
+-- so byte-level operations are safe; non-ASCII bytes (>= 0x80) can be
+-- bulk-copied without decoding.
+module Aihc.Cpp.Cursor
+  ( Cursor (..),
+    fromByteString,
+    fromText,
+    toText,
+    null,
+    peekByte,
+    peekByte2,
+    advance,
+    advance2,
+    sliceText,
+    sliceSince,
+    skipWhile,
+    bufLength,
+  )
+where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import Data.Word (Word8)
+import Prelude hiding (null)
+
+-- | A position-based cursor into a 'ByteString' buffer.
+-- The buffer is shared across all cursors derived from the same input,
+-- enabling zero-copy slicing.
+data Cursor = Cursor
+  { curBuf :: {-# UNPACK #-} !ByteString,
+    curPos :: {-# UNPACK #-} !Int
+  }
+  deriving (Show)
+
+-- | Create a cursor at the start of a 'ByteString'.
+fromByteString :: ByteString -> Cursor
+fromByteString bs = Cursor bs 0
+
+-- | Create a cursor from 'Text' by encoding to UTF-8.
+fromText :: Text -> Cursor
+fromText = fromByteString . TE.encodeUtf8
+
+-- | Decode the remaining bytes from the cursor position as UTF-8 'Text'.
+toText :: Cursor -> Text
+toText (Cursor buf pos) = TE.decodeUtf8 (BS.drop pos buf)
+
+-- | Is the cursor at the end of input?
+null :: Cursor -> Bool
+null (Cursor buf pos) = pos >= BS.length buf
+{-# INLINE null #-}
+
+-- | Peek at the current byte without advancing. Returns 'Nothing' at end
+-- of input.
+peekByte :: Cursor -> Maybe Word8
+peekByte (Cursor buf pos)
+  | pos >= BS.length buf = Nothing
+  | otherwise = Just (BS.index buf pos)
+{-# INLINE peekByte #-}
+
+-- | Peek at the current and next byte without advancing. Returns 'Nothing'
+-- if fewer than 2 bytes remain.
+peekByte2 :: Cursor -> Maybe (Word8, Word8)
+peekByte2 (Cursor buf pos)
+  | pos + 1 >= BS.length buf = Nothing
+  | otherwise = Just (BS.index buf pos, BS.index buf (pos + 1))
+{-# INLINE peekByte2 #-}
+
+-- | Advance the cursor by one byte.
+advance :: Cursor -> Cursor
+advance (Cursor buf pos) = Cursor buf (pos + 1)
+{-# INLINE advance #-}
+
+-- | Advance the cursor by two bytes.
+advance2 :: Cursor -> Cursor
+advance2 (Cursor buf pos) = Cursor buf (pos + 2)
+{-# INLINE advance2 #-}
+
+-- | Extract a zero-copy 'Text' slice from position @start@ to position
+-- @end@ (exclusive) in the cursor's buffer.
+sliceText :: Int -> Int -> Cursor -> Text
+sliceText start end (Cursor buf _) =
+  TE.decodeUtf8 (BS.take (end - start) (BS.drop start buf))
+{-# INLINE sliceText #-}
+
+-- | Extract a zero-copy 'Text' slice from the given start position to
+-- the cursor's current position.
+sliceSince :: Int -> Cursor -> Text
+sliceSince start cur = sliceText start (curPos cur) cur
+{-# INLINE sliceSince #-}
+
+-- | Advance the cursor while the predicate holds for the current byte.
+skipWhile :: (Word8 -> Bool) -> Cursor -> Cursor
+skipWhile p = go
+  where
+    go !cur = case peekByte cur of
+      Just b | p b -> go (advance cur)
+      _ -> cur
+{-# INLINE skipWhile #-}
+
+-- | Total length of the underlying buffer.
+bufLength :: Cursor -> Int
+bufLength (Cursor buf _) = BS.length buf
+{-# INLINE bufLength #-}

--- a/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Aihc.Cpp.Scanner
@@ -8,12 +9,22 @@ module Aihc.Cpp.Scanner
   )
 where
 
+import Aihc.Cpp.Cursor
+  ( Cursor (..),
+    advance,
+    advance2,
+    bufLength,
+    fromText,
+    null,
+    peekByte,
+    peekByte2,
+    sliceText,
+  )
 import Aihc.Cpp.Evaluator (expandMacros)
 import Aihc.Cpp.Types (EngineState)
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Builder as TB
+import Prelude hiding (null)
 
 data LineSpan = LineSpan
   { lineSpanInBlockComment :: !Bool,
@@ -34,38 +45,40 @@ expandLineBySpan st =
       | lineSpanInBlockComment lineChunk = lineSpanText lineChunk
       | otherwise = expandMacros st (lineSpanText lineChunk)
 
+-- | Scan a line, tracking comment depths and splitting into spans that are
+-- either inside or outside block comments. Uses a byte-level cursor for
+-- efficient scanning instead of character-by-character T.uncons/T.cons.
+--
+-- The scanner splits the line into 'LineSpan' segments. Each segment is
+-- tagged with whether it is inside a block comment. Code spans (outside
+-- comments) are zero-copy slices of the UTF-8 encoded input. C89 comment
+-- content is replaced with spaces to preserve column alignment.
 scanLine :: Int -> Int -> Text -> LineScan
 scanLine hsDepth0 cDepth0 input =
-  let (spansRev, currentBuilder, hasCurrent, currentInComment, finalHsDepth, finalCDepth) =
-        go hsDepth0 cDepth0 False False False [] mempty False (hsDepth0 > 0 || cDepth0 > 0) input
-      spans = reverse (flushSpan spansRev currentBuilder hasCurrent currentInComment)
+  let cursor0 = fromText input
+      (spans, finalHsDepth, finalCDepth) =
+        go
+          hsDepth0
+          cDepth0
+          False
+          False
+          False
+          []
+          (curPos cursor0)
+          (hsDepth0 > 0 || cDepth0 > 0)
+          cursor0
    in LineScan
-        { lineScanSpans = spans,
+        { lineScanSpans = reverse spans,
           lineScanFinalHsDepth = finalHsDepth,
           lineScanFinalCDepth = finalCDepth
         }
   where
-    flushSpan :: [LineSpan] -> TB.Builder -> Bool -> Bool -> [LineSpan]
-    flushSpan spansRev currentBuilder hasCurrent inComment =
-      if not hasCurrent
-        then spansRev
-        else LineSpan {lineSpanInBlockComment = inComment, lineSpanText = builderToText currentBuilder} : spansRev
-
-    appendWithMode ::
-      [LineSpan] ->
-      TB.Builder ->
-      Bool ->
-      Bool ->
-      Bool ->
-      Text ->
-      ([LineSpan], TB.Builder, Bool, Bool)
-    appendWithMode spansRev currentBuilder hasCurrent currentInComment newInComment chunk
-      | T.null chunk = (spansRev, currentBuilder, hasCurrent, currentInComment)
-      | not hasCurrent = (spansRev, TB.fromText chunk, True, newInComment)
-      | currentInComment == newInComment = (spansRev, currentBuilder <> TB.fromText chunk, True, currentInComment)
-      | otherwise =
-          let spansRev' = flushSpan spansRev currentBuilder hasCurrent currentInComment
-           in (spansRev', TB.fromText chunk, True, newInComment)
+    -- \| Emit a span from @start@ to @end@ if non-empty, prepending to @acc@.
+    emit :: [LineSpan] -> Int -> Int -> Cursor -> Bool -> [LineSpan]
+    emit acc start end cur inComment
+      | start >= end = acc
+      | otherwise = LineSpan inComment (sliceText start end cur) : acc
+    {-# INLINE emit #-}
 
     go ::
       Int ->
@@ -74,92 +87,216 @@ scanLine hsDepth0 cDepth0 input =
       Bool ->
       Bool ->
       [LineSpan] ->
-      TB.Builder ->
+      Int ->
       Bool ->
-      Bool ->
-      Text ->
-      ([LineSpan], TB.Builder, Bool, Bool, Int, Int)
-    go hsDepth cDepth inString inChar escaped spansRev currentBuilder hasCurrent currentInComment remaining =
-      case T.uncons remaining of
-        Nothing -> (spansRev, currentBuilder, hasCurrent, currentInComment, hsDepth, cDepth)
-        Just (c1, rest1) ->
-          case T.uncons rest1 of
-            Nothing ->
-              let outChar = if cDepth > 0 then " " else T.singleton c1
-                  inCommentNow = hsDepth > 0 || cDepth > 0
-                  (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                    appendWithMode spansRev currentBuilder hasCurrent currentInComment inCommentNow outChar
-               in (spansRev', currentBuilder', hasCurrent', currentInComment', hsDepth, cDepth)
-            Just (c2, rest2) ->
-              if cDepth > 0
-                then
-                  if c1 == '*' && c2 == '/'
-                    then
-                      let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                            appendWithMode spansRev currentBuilder hasCurrent currentInComment True "  "
-                       in go hsDepth 0 False False False spansRev' currentBuilder' hasCurrent' currentInComment' rest2
-                    else
-                      let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                            appendWithMode spansRev currentBuilder hasCurrent currentInComment True " "
-                       in go hsDepth cDepth False False False spansRev' currentBuilder' hasCurrent' currentInComment' (T.cons c2 rest2)
-                else
-                  if not inString && not inChar && hsDepth == 0 && c1 == '-' && c2 == '-'
-                    then
-                      let lineTail = T.cons c1 (T.cons c2 rest2)
-                          (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                            appendWithMode spansRev currentBuilder hasCurrent currentInComment True lineTail
-                       in (spansRev', currentBuilder', hasCurrent', currentInComment', hsDepth, cDepth)
-                    else
-                      if inString
-                        then
-                          let escaped' = not escaped && c1 == '\\'
-                              inString' = escaped || c1 /= '"'
-                              (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                appendWithMode spansRev currentBuilder hasCurrent currentInComment (hsDepth > 0) (T.singleton c1)
-                           in go hsDepth cDepth inString' False escaped' spansRev' currentBuilder' hasCurrent' currentInComment' (T.cons c2 rest2)
-                        else
-                          if inChar
-                            then
-                              let escaped' = not escaped && c1 == '\\'
-                                  inChar' = escaped || c1 /= '\''
-                                  (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                    appendWithMode spansRev currentBuilder hasCurrent currentInComment (hsDepth > 0) (T.singleton c1)
-                               in go hsDepth cDepth False inChar' escaped' spansRev' currentBuilder' hasCurrent' currentInComment' (T.cons c2 rest2)
-                            else
-                              if hsDepth == 0 && c1 == '"'
-                                then
-                                  let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                        appendWithMode spansRev currentBuilder hasCurrent currentInComment False (T.singleton c1)
-                                   in go hsDepth cDepth True False False spansRev' currentBuilder' hasCurrent' currentInComment' (T.cons c2 rest2)
-                                else
-                                  if hsDepth == 0 && c1 == '\''
-                                    then
-                                      let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                            appendWithMode spansRev currentBuilder hasCurrent currentInComment False (T.singleton c1)
-                                       in go hsDepth cDepth False True False spansRev' currentBuilder' hasCurrent' currentInComment' (T.cons c2 rest2)
-                                    else
-                                      if hsDepth > 0 && c1 == '-' && c2 == '}'
-                                        then
-                                          let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                                appendWithMode spansRev currentBuilder hasCurrent currentInComment True "-}"
-                                              hsDepth' = hsDepth - 1
-                                           in go hsDepth' cDepth False False False spansRev' currentBuilder' hasCurrent' currentInComment' rest2
-                                        else
-                                          if c1 == '{' && c2 == '-' && not ("#" `T.isPrefixOf` rest2)
-                                            then
-                                              let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                                    appendWithMode spansRev currentBuilder hasCurrent currentInComment True "{-"
-                                               in go (hsDepth + 1) cDepth False False False spansRev' currentBuilder' hasCurrent' currentInComment' rest2
-                                            else
-                                              if hsDepth == 0 && c1 == '/' && c2 == '*'
-                                                then
-                                                  let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                                        appendWithMode spansRev currentBuilder hasCurrent currentInComment True "  "
-                                                   in go hsDepth 1 False False False spansRev' currentBuilder' hasCurrent' currentInComment' rest2
-                                                else
-                                                  let (spansRev', currentBuilder', hasCurrent', currentInComment') =
-                                                        appendWithMode spansRev currentBuilder hasCurrent currentInComment (hsDepth > 0) (T.singleton c1)
-                                                   in go hsDepth cDepth False False False spansRev' currentBuilder' hasCurrent' currentInComment' (T.cons c2 rest2)
-
-builderToText :: TB.Builder -> Text
-builderToText = TL.toStrict . TB.toLazyText
+      Cursor ->
+      ([LineSpan], Int, Int)
+    go
+      !hsDepth
+      !cDepth
+      !inString
+      !inChar
+      !escaped
+      !acc
+      !spanStart
+      !spanInComment
+      !cur
+        -- End of input: flush the accumulated span
+        | null cur =
+            (emit acc spanStart (curPos cur) cur spanInComment, hsDepth, cDepth)
+        | otherwise =
+            case peekByte2 cur of
+              Nothing ->
+                -- === Only one byte left ===
+                if cDepth > 0
+                  then
+                    -- In C comment: flush accumulated, emit space
+                    let acc' = emit acc spanStart (curPos cur) cur spanInComment
+                     in (LineSpan True " " : acc', hsDepth, cDepth)
+                  else
+                    -- Include this last byte in the accumulated span
+                    let inCommentNow = hsDepth > 0
+                        cur' = advance cur
+                     in (emit acc spanStart (curPos cur') cur inCommentNow, hsDepth, cDepth)
+              Just (b1, b2) ->
+                -- === C block comment mode ===
+                if cDepth > 0
+                  then
+                    if b1 == 0x2A && b2 == 0x2F -- '*/'
+                      then
+                        let acc' = emit acc spanStart (curPos cur) cur spanInComment
+                            cur' = advance2 cur
+                         in go
+                              hsDepth
+                              0
+                              False
+                              False
+                              False
+                              (LineSpan True "  " : acc')
+                              (curPos cur')
+                              False
+                              cur'
+                      else
+                        let acc' = emit acc spanStart (curPos cur) cur spanInComment
+                            cur' = advance cur
+                         in go
+                              hsDepth
+                              cDepth
+                              False
+                              False
+                              False
+                              (LineSpan True " " : acc')
+                              (curPos cur')
+                              True
+                              cur'
+                  -- === Line comment: -- (outside strings and hs comments) ===
+                  else
+                    if not inString
+                      && not inChar
+                      && hsDepth == 0
+                      && b1 == 0x2D
+                      && b2 == 0x2D -- '--'
+                      then
+                        let acc' = emit acc spanStart (curPos cur) cur spanInComment
+                            restText = sliceText (curPos cur) (bufLength cur) cur
+                         in (LineSpan True restText : acc', hsDepth, cDepth)
+                      -- === Inside string literal ===
+                      else
+                        if inString
+                          then
+                            let escaped' = not escaped && b1 == 0x5C -- '\\'
+                                inString' = escaped || b1 /= 0x22 -- '"'
+                             in go
+                                  hsDepth
+                                  cDepth
+                                  inString'
+                                  False
+                                  escaped'
+                                  acc
+                                  spanStart
+                                  spanInComment
+                                  (advance cur)
+                          -- === Inside char literal ===
+                          else
+                            if inChar
+                              then
+                                let escaped' = not escaped && b1 == 0x5C -- '\\'
+                                    inChar' = escaped || b1 /= 0x27 -- '\''
+                                 in go
+                                      hsDepth
+                                      cDepth
+                                      False
+                                      inChar'
+                                      escaped'
+                                      acc
+                                      spanStart
+                                      spanInComment
+                                      (advance cur)
+                              -- === Start of string literal ===
+                              else
+                                if hsDepth == 0 && b1 == 0x22 -- '"'
+                                  then
+                                    go
+                                      hsDepth
+                                      cDepth
+                                      True
+                                      False
+                                      False
+                                      acc
+                                      spanStart
+                                      spanInComment
+                                      (advance cur)
+                                  -- === Start of char literal ===
+                                  else
+                                    if hsDepth == 0 && b1 == 0x27 -- '\''
+                                      then
+                                        go
+                                          hsDepth
+                                          cDepth
+                                          False
+                                          True
+                                          False
+                                          acc
+                                          spanStart
+                                          spanInComment
+                                          (advance cur)
+                                      -- === End of Haskell block comment: -} ===
+                                      else
+                                        if hsDepth > 0 && b1 == 0x2D && b2 == 0x7D -- '-}'
+                                          then
+                                            let cur' = advance2 cur
+                                                hsDepth' = hsDepth - 1
+                                                -- Flush everything up to and including -} as a comment span
+                                                acc' = emit acc spanStart (curPos cur') cur True
+                                                inCommentAfter = hsDepth' > 0
+                                             in go
+                                                  hsDepth'
+                                                  cDepth
+                                                  False
+                                                  False
+                                                  False
+                                                  acc'
+                                                  (curPos cur')
+                                                  inCommentAfter
+                                                  cur'
+                                          -- === Start of Haskell block comment: {- (but not {-#) ===
+                                          else
+                                            if b1 == 0x7B && b2 == 0x2D -- '{-'
+                                              then
+                                                let cur' = advance2 cur
+                                                 in case peekByte cur' of
+                                                      Just 0x23 ->
+                                                        -- '#' => pragma {-#, not a block comment
+                                                        -- Advance past '{' only, continue in same mode
+                                                        go
+                                                          hsDepth
+                                                          cDepth
+                                                          False
+                                                          False
+                                                          False
+                                                          acc
+                                                          spanStart
+                                                          spanInComment
+                                                          (advance cur)
+                                                      _ ->
+                                                        -- Flush any text before {-, emit {- as comment
+                                                        let acc' = emit acc spanStart (curPos cur) cur spanInComment
+                                                            acc'' = LineSpan True "{-" : acc'
+                                                         in go
+                                                              (hsDepth + 1)
+                                                              cDepth
+                                                              False
+                                                              False
+                                                              False
+                                                              acc''
+                                                              (curPos cur')
+                                                              True
+                                                              cur'
+                                              -- === Start of C block comment: /* ===
+                                              else
+                                                if hsDepth == 0 && b1 == 0x2F && b2 == 0x2A -- '/*'
+                                                  then
+                                                    let acc' = emit acc spanStart (curPos cur) cur spanInComment
+                                                        cur' = advance2 cur
+                                                     in go
+                                                          hsDepth
+                                                          1
+                                                          False
+                                                          False
+                                                          False
+                                                          (LineSpan True "  " : acc')
+                                                          (curPos cur')
+                                                          True
+                                                          cur'
+                                                  -- === Normal byte: just advance ===
+                                                  else
+                                                    go
+                                                      hsDepth
+                                                      cDepth
+                                                      False
+                                                      False
+                                                      False
+                                                      acc
+                                                      spanStart
+                                                      spanInComment
+                                                      (advance cur)


### PR DESCRIPTION
## Summary

Phase 1 of the cursor-based engine rewrite (#472).

- Add `Aihc.Cpp.Cursor`, a zero-copy cursor over `ByteString` with O(1) peeking and position-based slicing
- Rewrite `Scanner.scanLine` to use byte-level cursor instead of `T.uncons`/`T.cons` character loops
- Eliminate per-character `Text` allocations in the scanning hot path
- Non-comment code spans are now zero-copy slices of the UTF-8 encoded input

The line-by-line processing structure is preserved; only the inner scanning loop changes.

## What changed

### New: `Aihc.Cpp.Cursor`

A lightweight cursor abstraction over a strict `ByteString`. The cursor tracks a position into a shared buffer, enabling:
- `peekByte` / `peekByte2`: O(1) lookahead (replaces `T.uncons` + `T.uncons`)
- `advance` / `advance2`: O(1) cursor movement (replaces `T.cons c2 rest2`)
- `sliceText`: zero-copy `Text` extraction via position range (replaces per-char `Builder` accumulation)

### Changed: `Scanner.hs`

Replaced the character-by-character `T.uncons`/`T.cons` scanning loop with cursor-based byte-level operations:
- **Before**: Each iteration called `T.uncons` twice (for two-char lookahead), then `T.cons c2 rest2` to re-cons the second character — O(n) allocation per step
- **After**: `peekByte2` does two O(1) array indexing, `advance` just increments a position counter. Non-comment spans are materialized as zero-copy `Text` slices only when flushed

### Changed: `aihc-cpp.cabal`

Added `bytestring` dependency and `Aihc.Cpp.Cursor` to `other-modules`.

## Progress counts

Unchanged: 37 pass, 1 xfail (`macro-multiline-args`).