### PR TITLE
refactor(cpp): replace fixpoint macro expansion with blue-paint algorithm

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -35,7 +36,7 @@ where
 
 import Aihc.Cpp.Evaluator (evalCondition)
 import Aihc.Cpp.Parser (Directive (..), parseDirective)
-import Aihc.Cpp.Scanner (expandLineBySpan, lineScanFinalCDepth, lineScanFinalHsDepth, lineScanSpans, scanLine)
+import Aihc.Cpp.Scanner (expandLineBySpanMultiline, lineScanFinalCDepth, lineScanFinalHsDepth, lineScanSpans, scanLine)
 import Aihc.Cpp.Types
   ( CondFrame (..),
     Config (..),
@@ -246,7 +247,36 @@ processFile filePath ((lineNo, lineSpan, line) : restLines) stack st k =
         else case parsedDirective of
           Nothing ->
             if currentActive stack
-              then continue (emitLine (expandLineBySpan st (lineScanSpans lineScan)) st)
+              then
+                -- Try multi-line expansion: look ahead at future lines
+                let futureCodeLines = [l | (_, _, l) <- restLines]
+                    (expanded, extraConsumed) =
+                      expandLineBySpanMultiline st (lineScanSpans lineScan) futureCodeLines
+                 in if extraConsumed > 0
+                      then
+                        -- Skip consumed continuation lines
+                        let consumed = take extraConsumed restLines
+                            remaining = drop extraConsumed restLines
+                            -- Scan consumed lines to update comment depths
+                            (finalHs, finalC) =
+                              foldl'
+                                ( \(!hs, !c) (_, _, l) ->
+                                    let ls = scanLine hs c l
+                                     in (lineScanFinalHsDepth ls, lineScanFinalCDepth ls)
+                                )
+                                (lineScanFinalHsDepth lineScan, lineScanFinalCDepth lineScan)
+                                consumed
+                            nextLineNo' = case remaining of
+                              (n, _, _) : _ -> n
+                              [] -> lineNo + lineSpan + sum [s | (_, s, _) <- consumed]
+                            st' =
+                              (emitLine expanded st)
+                                { stCurrentLine = nextLineNo',
+                                  stHsBlockCommentDepth = finalHs,
+                                  stCBlockCommentDepth = finalC
+                                }
+                         in processFile filePath remaining stack st' k
+                      else continue (emitLine expanded st)
               else continue (emitBlankLines lineSpan st)
           Just directive ->
             handleDirective ctx st directive

--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -2,7 +2,7 @@
 
 module Aihc.Cpp.Evaluator
   ( expandMacros,
-    expandOnce,
+    expandMacrosMultiline,
     substituteParams,
     evalCondition,
     evalNumeric,
@@ -27,98 +27,193 @@ import Aihc.Cpp.Types (EngineState (..), MacroDef (..))
 import Data.Char (isDigit, isSpace)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import Data.Set (Set)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import qualified Data.Text.Read as TR
 
+-- | Expand macros in a single piece of text using the blue-paint algorithm.
+-- A single pass with a suppression set replaces the previous iterate-up-to-32
+-- fixpoint approach.
 expandMacros :: EngineState -> Text -> Text
-expandMacros st = applyDepth (32 :: Int)
-  where
-    applyDepth 0 t = t
-    applyDepth n t =
-      let next = expandOnce st t
-       in if next == t then t else applyDepth (n - 1) next
+expandMacros st txt =
+  builderToText (expandBlue st S.empty False False False (TB.fromText txt))
 
-expandOnce :: EngineState -> Text -> Text
-expandOnce st = go False False False
+-- | Expand macros with multi-line support. When a function-like macro call
+-- spans multiple lines, continuation lines are consumed from @moreLines@.
+-- Returns the expanded text and the number of extra lines consumed.
+expandMacrosMultiline :: EngineState -> Text -> [Text] -> (Text, Int)
+expandMacrosMultiline st txt moreLines =
+  let extraNeeded = countExtraLinesConsumed st txt moreLines
+   in if extraNeeded == 0
+        then (expandMacros st txt, 0)
+        else
+          let combinedLines = txt : take extraNeeded moreLines
+              combined = T.intercalate "\n" combinedLines
+              expanded = expandMacros st combined
+           in (expanded, extraNeeded)
+
+-- | Count how many extra lines a function macro call consumes.
+-- Scans the first line for an identifier that matches a function macro,
+-- then checks if parseCallArgs needs to span into continuation lines.
+countExtraLinesConsumed :: EngineState -> Text -> [Text] -> Int
+countExtraLinesConsumed st txt moreLines = scanForFunctionMacro False False False txt
   where
     macros = stMacros st
 
-    go :: Bool -> Bool -> Bool -> Text -> Text
-    go _ _ _ txt
-      | T.null txt = ""
-    go inString inChar escaped txt =
-      case T.uncons txt of
-        Nothing -> ""
+    scanForFunctionMacro :: Bool -> Bool -> Bool -> Text -> Int
+    scanForFunctionMacro _ _ _ t | T.null t = 0
+    scanForFunctionMacro inString inChar escaped t =
+      case T.uncons t of
+        Nothing -> 0
         Just (c, rest)
           | inString ->
               let escaped' = c == '\\' && not escaped
                   inString' = not (c == '"' && not escaped)
-               in T.cons c (go inString' False escaped' rest)
+               in scanForFunctionMacro inString' False escaped' rest
           | inChar ->
               let escaped' = c == '\\' && not escaped
                   inChar' = not (c == '\'' && not escaped)
-               in T.cons c (go False inChar' escaped' rest)
-          | c == '"' ->
-              T.cons c (go True False False rest)
-          | c == '\'' ->
-              T.cons c (go False True False rest)
+               in scanForFunctionMacro False inChar' escaped' rest
+          | c == '"' -> scanForFunctionMacro True False False rest
+          | c == '\'' -> scanForFunctionMacro False True False rest
           | isIdentStart c ->
-              expandIdentifier txt
-          | otherwise ->
-              T.cons c (go False False False rest)
+              let (ident, rest') = T.span isIdentChar t
+               in case M.lookup ident macros of
+                    Just (FunctionMacro _ _) ->
+                      case tryMultilineCallArgs rest' of
+                        Just n -> n
+                        Nothing -> scanForFunctionMacro False False False rest'
+                    _ -> scanForFunctionMacro False False False rest'
+          | otherwise -> scanForFunctionMacro False False False rest
 
-    expandIdentifier :: Text -> Text
-    expandIdentifier input =
-      let (ident, rest) = T.span isIdentChar input
-       in case ident of
-            "__LINE__" -> T.pack (show (stCurrentLine st)) <> go False False False rest
-            "__FILE__" -> T.pack (show (stCurrentFile st)) <> go False False False rest
-            _ ->
-              case M.lookup ident macros of
-                Just (ObjectMacro replacement) ->
-                  replacement <> go False False False rest
-                Just (FunctionMacro params body) ->
-                  case parseCallArgs rest of
-                    Nothing -> ident <> go False False False rest
-                    Just (args, restAfter)
-                      | length args == length params ->
-                          let body' = substituteParams (M.fromList (zip params args)) body
-                           in body' <> go False False False restAfter
-                      | otherwise -> ident <> go False False False rest
-                Nothing -> ident <> go False False False rest
+    -- Try to parse function call args, potentially spanning multiple lines.
+    -- Returns Just n if the call spans n extra lines, Nothing if no call.
+    tryMultilineCallArgs :: Text -> Maybe Int
+    tryMultilineCallArgs rest =
+      case T.uncons rest of
+        Just ('(', afterOpen) ->
+          findClosingParen 0 afterOpen 0
+        _ -> Nothing
 
-    parseCallArgs :: Text -> Maybe ([Text], Text)
-    parseCallArgs input = do
-      ('(', rest) <- T.uncons input
-      parseArgs 0 [] mempty rest
-
-    parseArgs :: Int -> [Text] -> TB.Builder -> Text -> Maybe ([Text], Text)
-    parseArgs depth argsRev current remaining =
+    findClosingParen :: Int -> Text -> Int -> Maybe Int
+    findClosingParen depth remaining extraLines =
       case T.uncons remaining of
-        Nothing -> Nothing
+        Nothing ->
+          -- Need more lines
+          case drop extraLines moreLines of
+            [] -> Nothing -- No more lines, unclosed call
+            (nextLine : _) ->
+              findClosingParen depth (T.cons '\n' nextLine) (extraLines + 1)
         Just (ch, rest)
-          | ch == '(' ->
-              parseArgs (depth + 1) argsRev (current <> TB.singleton ch) rest
-          | ch == ')' && depth > 0 ->
-              parseArgs (depth - 1) argsRev (current <> TB.singleton ch) rest
-          | ch == ')' && depth == 0 ->
-              let arg = trimSpacesText (builderToText current)
-                  argsRev' =
-                    if T.null arg && null argsRev
-                      then argsRev
-                      else arg : argsRev
-               in Just (reverse argsRev', rest)
-          | ch == ',' && depth == 0 ->
-              let arg = trimSpacesText (builderToText current)
-               in parseArgs depth (arg : argsRev) mempty rest
-          | otherwise ->
-              parseArgs depth argsRev (current <> TB.singleton ch) rest
+          | ch == '(' -> findClosingParen (depth + 1) rest extraLines
+          | ch == ')' && depth > 0 -> findClosingParen (depth - 1) rest extraLines
+          | ch == ')' -> Just extraLines
+          | otherwise -> findClosingParen depth rest extraLines
+
+-- | Blue-paint macro expansion engine. Uses a suppression set (@painted@)
+-- to prevent infinite recursion instead of iterating to a fixpoint.
+-- Output is accumulated via a lazy 'TB.Builder' for amortized O(n).
+expandBlue :: EngineState -> Set Text -> Bool -> Bool -> Bool -> TB.Builder -> TB.Builder
+expandBlue st painted inString inChar escaped input =
+  let txt = builderToText input
+   in goText st painted inString inChar escaped txt mempty
+
+-- | Walk the input text, expanding macros with blue-paint suppression.
+goText :: EngineState -> Set Text -> Bool -> Bool -> Bool -> Text -> TB.Builder -> TB.Builder
+goText _ _ _ _ _ txt acc | T.null txt = acc
+goText st painted inString inChar escaped txt acc =
+  case T.uncons txt of
+    Nothing -> acc
+    Just (c, rest)
+      | inString ->
+          let escaped' = c == '\\' && not escaped
+              inString' = not (c == '"' && not escaped)
+           in goText st painted inString' False escaped' rest (acc <> TB.singleton c)
+      | inChar ->
+          let escaped' = c == '\\' && not escaped
+              inChar' = not (c == '\'' && not escaped)
+           in goText st painted False inChar' escaped' rest (acc <> TB.singleton c)
+      | c == '"' ->
+          goText st painted True False False rest (acc <> TB.singleton c)
+      | c == '\'' ->
+          goText st painted False True False rest (acc <> TB.singleton c)
+      | isIdentStart c ->
+          expandIdentBlue st painted txt acc
+      | otherwise ->
+          goText st painted False False False rest (acc <> TB.singleton c)
+
+-- | Handle an identifier during blue-paint expansion.
+expandIdentBlue :: EngineState -> Set Text -> Text -> TB.Builder -> TB.Builder
+expandIdentBlue st painted txt acc =
+  let (ident, rest) = T.span isIdentChar txt
+   in if S.member ident painted
+        then -- Blue-painted: copy verbatim, don't expand
+          goText st painted False False False rest (acc <> TB.fromText ident)
+        else case ident of
+          "__LINE__" ->
+            goText st painted False False False rest (acc <> TB.fromString (show (stCurrentLine st)))
+          "__FILE__" ->
+            goText st painted False False False rest (acc <> TB.fromString (show (stCurrentFile st)))
+          _ ->
+            case M.lookup ident (stMacros st) of
+              Just (ObjectMacro replacement) ->
+                let painted' = S.insert ident painted
+                    expanded = builderToText (goText st painted' False False False replacement mempty)
+                 in goText st painted False False False rest (acc <> TB.fromText expanded)
+              Just (FunctionMacro params body) ->
+                case parseCallArgs rest of
+                  Nothing ->
+                    goText st painted False False False rest (acc <> TB.fromText ident)
+                  Just (args, restAfter)
+                    | length args == length params ->
+                        let body' = substituteParamsBuilder (M.fromList (zip params args)) body
+                            painted' = S.insert ident painted
+                            expanded = builderToText (goText st painted' False False False body' mempty)
+                         in goText st painted False False False restAfter (acc <> TB.fromText expanded)
+                    | otherwise ->
+                        goText st painted False False False rest (acc <> TB.fromText ident)
+              Nothing ->
+                goText st painted False False False rest (acc <> TB.fromText ident)
+
+-- | Parse function-like macro call arguments.
+parseCallArgs :: Text -> Maybe ([Text], Text)
+parseCallArgs input = do
+  ('(', rest) <- T.uncons input
+  parseArgs 0 [] mempty rest
+
+parseArgs :: Int -> [Text] -> TB.Builder -> Text -> Maybe ([Text], Text)
+parseArgs depth argsRev current remaining =
+  case T.uncons remaining of
+    Nothing -> Nothing
+    Just (ch, rest)
+      | ch == '(' ->
+          parseArgs (depth + 1) argsRev (current <> TB.singleton ch) rest
+      | ch == ')' && depth > 0 ->
+          parseArgs (depth - 1) argsRev (current <> TB.singleton ch) rest
+      | ch == ')' && depth == 0 ->
+          let arg = trimSpacesText (builderToText current)
+              argsRev' =
+                if T.null arg && null argsRev
+                  then argsRev
+                  else arg : argsRev
+           in Just (reverse argsRev', rest)
+      | ch == ',' && depth == 0 ->
+          let arg = trimSpacesText (builderToText current)
+           in parseArgs depth (arg : argsRev) mempty rest
+      | otherwise ->
+          parseArgs depth argsRev (current <> TB.singleton ch) rest
 
 substituteParams :: Map Text Text -> Text -> Text
-substituteParams subs = go False False False
+substituteParams = substituteParamsBuilder
+
+-- | Builder-based parameter substitution. Replaces identifiers found
+-- in the substitution map, respecting string and char literals.
+substituteParamsBuilder :: Map Text Text -> Text -> Text
+substituteParamsBuilder subs = go False False False
   where
     go :: Bool -> Bool -> Bool -> Text -> Text
     go _ _ _ txt

--- a/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
@@ -5,7 +5,7 @@ module Aihc.Cpp.Scanner
   ( LineSpan (..),
     LineScan (..),
     scanLine,
-    expandLineBySpan,
+    expandLineBySpanMultiline,
   )
 where
 
@@ -20,7 +20,7 @@ import Aihc.Cpp.Cursor
     peekByte2,
     sliceText,
   )
-import Aihc.Cpp.Evaluator (expandMacros)
+import Aihc.Cpp.Evaluator (expandMacros, expandMacrosMultiline)
 import Aihc.Cpp.Types (EngineState)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -37,6 +37,7 @@ data LineScan = LineScan
     lineScanFinalCDepth :: !Int
   }
 
+-- | Expand macros in a list of line spans (single-line, no lookahead).
 expandLineBySpan :: EngineState -> [LineSpan] -> Text
 expandLineBySpan st =
   T.concat . map expandSpan
@@ -44,6 +45,24 @@ expandLineBySpan st =
     expandSpan lineChunk
       | lineSpanInBlockComment lineChunk = lineSpanText lineChunk
       | otherwise = expandMacros st (lineSpanText lineChunk)
+
+-- | Expand macros in a list of line spans with multi-line lookahead.
+-- When a function macro call spans multiple lines, continuation lines
+-- are consumed from @futureCodeLines@.
+-- Returns (expanded text, number of extra lines consumed).
+--
+-- Multi-line expansion is only attempted for lines that consist entirely
+-- of code spans (no inline comments). Mixed code/comment lines use
+-- single-line expansion to preserve comment span positions.
+expandLineBySpanMultiline :: EngineState -> [LineSpan] -> [Text] -> (Text, Int)
+expandLineBySpanMultiline st spans futureCodeLines =
+  let hasCommentSpans = any lineSpanInBlockComment spans
+   in if hasCommentSpans
+        then -- Mixed line: fall back to single-line expansion
+          (expandLineBySpan st spans, 0)
+        else -- Pure code line: try multi-line expansion
+          let codeText = T.concat [lineSpanText s | s <- spans]
+           in expandMacrosMultiline st codeText futureCodeLines
 
 -- | Scan a line, tracking comment depths and splitting into spans that are
 -- either inside or outside block comments. Uses a byte-level cursor for

--- a/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -36,4 +36,4 @@ macro-name-in-string	macro	macro-name-in-string.hs	pass
 macro-expansion-not-in-string	macro	macro-expansion-not-in-string.hs	pass
 hpp-file-macro-string-pattern	macro	hpp-file-macro-string-pattern.hs	pass
 rules-pragma-cpp-branch	lexing	rules-pragma-cpp-branch.hs	pass
-macro-multiline-args	macro	macro-multiline-args.hs	xfail	broken multiline macro call
+macro-multiline-args	macro	macro-multiline-args.hs	pass


### PR DESCRIPTION
## Summary

Phase 2 of #472: Replace the iterate-up-to-32 fixpoint macro expansion with a single-pass blue-paint (suppression-set) algorithm, and add multi-line function macro call support.

- **Blue-paint algorithm**: `expandMacros` now uses a `Set Text` suppression set instead of iterating `expandOnce` up to 32 times. When a macro is expanded, its name is added to the suppression set; if the name appears again during recursive expansion, it is copied verbatim (preventing infinite recursion in one pass).
- **Builder-based output**: The expansion engine accumulates output via `TB.Builder` for amortized O(n), replacing per-character `T.cons` which was O(n²) worst case.
- **Multi-line function macro calls**: When a function-like macro call's argument list spans multiple lines (e.g. `DEBUG("a" ++\n "b")`), continuation lines are consumed from a lookahead buffer. `countExtraLinesConsumed` scans for unclosed parentheses and looks ahead into future lines. `Cpp.hs` skips consumed continuation lines and updates comment depth state.
- **Promoted `macro-multiline-args`** from `xfail` to `pass`.

Progress: 39 pass, 0 xfail, 0 fail (was 38 pass, 1 xfail, 0 fail)

## Changed files

- `Evaluator.hs`: Replaced `expandOnce`/`expandMacros` fixpoint loop with `expandBlue`/`goText`/`expandIdentBlue` blue-paint engine. Added `expandMacrosMultiline` and `countExtraLinesConsumed` for multi-line support.
- `Scanner.hs`: Added `expandLineBySpanMultiline` that falls back to single-line expansion for mixed code/comment lines, and uses multi-line expansion for pure code lines.
- `Cpp.hs`: Updated `processFile` to use `expandLineBySpanMultiline`, skip consumed continuation lines, and update comment depth state for skipped lines.
- `manifest.tsv`: Promoted `macro-multiline-args` from `xfail` to `pass`.