### PR TITLE
perf(cpp): add fast paths for inactive branches and bulk byte skipping

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp.hs
@@ -36,7 +36,7 @@ where
 
 import Aihc.Cpp.Evaluator (evalCondition)
 import Aihc.Cpp.Parser (Directive (..), parseDirective)
-import Aihc.Cpp.Scanner (expandLineBySpanMultiline, lineScanFinalCDepth, lineScanFinalHsDepth, lineScanSpans, scanLine)
+import Aihc.Cpp.Scanner (expandLineBySpanMultiline, lineScanFinalCDepth, lineScanFinalHsDepth, lineScanSpans, scanLine, scanLineDepthOnly)
 import Aihc.Cpp.Types
   ( CondFrame (..),
     Config (..),
@@ -258,73 +258,104 @@ pullContinuation acc remaining
 processFile :: FilePath -> [(Int, Int, Text)] -> [CondFrame] -> EngineState -> Continuation -> Step
 processFile _ [] _ st k = k st
 processFile filePath ((lineNo, lineSpan, line) : restLines) stack st k =
-  let lineScan = scanLine (stHsBlockCommentDepth st) (stCBlockCommentDepth st) line
-      startsInBlockComment = stHsBlockCommentDepth st > 0 || stCBlockCommentDepth st > 0
+  let startsInBlockComment = stHsBlockCommentDepth st > 0 || stCBlockCommentDepth st > 0
       parsedDirective =
         if startsInBlockComment
           then Nothing
           else parseDirective line
-      nextLineNo = case restLines of
-        (n, _, _) : _ -> n
-        [] -> lineNo + lineSpan
-      advanceLineState st' =
-        st'
-          { stCurrentLine = nextLineNo,
-            stHsBlockCommentDepth = lineScanFinalHsDepth lineScan,
-            stCBlockCommentDepth = lineScanFinalCDepth lineScan
-          }
-      continue st' = processFile filePath restLines stack (advanceLineState st') k
-      continueWith stack' st' = processFile filePath restLines stack' (advanceLineState st') k
-      ctx =
-        LineContext
-          { lcFilePath = filePath,
-            lcLineNo = lineNo,
-            lcLineSpan = lineSpan,
-            lcNextLineNo = nextLineNo,
-            lcRestLines = restLines,
-            lcStack = stack,
-            lcContinue = continue,
-            lcContinueWith = continueWith,
-            lcDone = k
-          }
-   in if stSkippingDanglingElse st
-        then recoverDanglingElse ctx parsedDirective st
-        else case parsedDirective of
-          Nothing ->
-            if currentActive stack
-              then
-                -- Try multi-line expansion: look ahead at future lines
-                let futureCodeLines = [l | (_, _, l) <- restLines]
-                    (expanded, extraConsumed) =
-                      expandLineBySpanMultiline st (lineScanSpans lineScan) futureCodeLines
-                 in if extraConsumed > 0
-                      then
-                        -- Skip consumed continuation lines
-                        let consumed = take extraConsumed restLines
-                            remaining = drop extraConsumed restLines
-                            -- Scan consumed lines to update comment depths
-                            (finalHs, finalC) =
-                              foldl'
-                                ( \(!hs, !c) (_, _, l) ->
-                                    let ls = scanLine hs c l
-                                     in (lineScanFinalHsDepth ls, lineScanFinalCDepth ls)
-                                )
-                                (lineScanFinalHsDepth lineScan, lineScanFinalCDepth lineScan)
-                                consumed
-                            nextLineNo' = case remaining of
-                              (n, _, _) : _ -> n
-                              [] -> lineNo + lineSpan + sum [s | (_, s, _) <- consumed]
-                            st' =
-                              (emitLine expanded st)
-                                { stCurrentLine = nextLineNo',
-                                  stHsBlockCommentDepth = finalHs,
-                                  stCBlockCommentDepth = finalC
-                                }
-                         in processFile filePath remaining stack st' k
-                      else continue (emitLine expanded st)
-              else continue (emitBlankLines lineSpan st)
-          Just directive ->
-            handleDirective ctx st directive
+      isActive = currentActive stack
+   in if not isActive && not (stSkippingDanglingElse st)
+        then -- === Fast path for inactive branches ===
+        -- Only track comment depth; skip full span scanning and macro expansion.
+          let (finalHs, finalC) = scanLineDepthOnly (stHsBlockCommentDepth st) (stCBlockCommentDepth st) line
+              nextLineNo = case restLines of
+                (n, _, _) : _ -> n
+                [] -> lineNo + lineSpan
+              advanceSt st' =
+                st'
+                  { stCurrentLine = nextLineNo,
+                    stHsBlockCommentDepth = finalHs,
+                    stCBlockCommentDepth = finalC
+                  }
+              continueInactive st' = processFile filePath restLines stack (advanceSt st') k
+              continueInactiveWith stack' st' = processFile filePath restLines stack' (advanceSt st') k
+           in case parsedDirective of
+                Nothing ->
+                  continueInactive (emitBlankLines lineSpan st)
+                Just directive ->
+                  let ctx =
+                        LineContext
+                          { lcFilePath = filePath,
+                            lcLineNo = lineNo,
+                            lcLineSpan = lineSpan,
+                            lcNextLineNo = nextLineNo,
+                            lcRestLines = restLines,
+                            lcStack = stack,
+                            lcContinue = continueInactive,
+                            lcContinueWith = continueInactiveWith,
+                            lcDone = k
+                          }
+                   in handleDirective ctx st directive
+        else -- === Normal path: full scan + expansion ===
+          let lineScan = scanLine (stHsBlockCommentDepth st) (stCBlockCommentDepth st) line
+              nextLineNo = case restLines of
+                (n, _, _) : _ -> n
+                [] -> lineNo + lineSpan
+              advanceLineState st' =
+                st'
+                  { stCurrentLine = nextLineNo,
+                    stHsBlockCommentDepth = lineScanFinalHsDepth lineScan,
+                    stCBlockCommentDepth = lineScanFinalCDepth lineScan
+                  }
+              continue st' = processFile filePath restLines stack (advanceLineState st') k
+              continueWith stack' st' = processFile filePath restLines stack' (advanceLineState st') k
+              ctx =
+                LineContext
+                  { lcFilePath = filePath,
+                    lcLineNo = lineNo,
+                    lcLineSpan = lineSpan,
+                    lcNextLineNo = nextLineNo,
+                    lcRestLines = restLines,
+                    lcStack = stack,
+                    lcContinue = continue,
+                    lcContinueWith = continueWith,
+                    lcDone = k
+                  }
+           in if stSkippingDanglingElse st
+                then recoverDanglingElse ctx parsedDirective st
+                else case parsedDirective of
+                  Nothing ->
+                    -- Try multi-line expansion: look ahead at future lines
+                    let futureCodeLines = [l | (_, _, l) <- restLines]
+                        (expanded, extraConsumed) =
+                          expandLineBySpanMultiline st (lineScanSpans lineScan) futureCodeLines
+                     in if extraConsumed > 0
+                          then
+                            -- Skip consumed continuation lines
+                            let consumed = take extraConsumed restLines
+                                remaining = drop extraConsumed restLines
+                                -- Scan consumed lines to update comment depths
+                                (finalHs, finalC) =
+                                  foldl'
+                                    ( \(!hs, !c) (_, _, l) ->
+                                        let ls = scanLine hs c l
+                                         in (lineScanFinalHsDepth ls, lineScanFinalCDepth ls)
+                                    )
+                                    (lineScanFinalHsDepth lineScan, lineScanFinalCDepth lineScan)
+                                    consumed
+                                nextLineNo' = case remaining of
+                                  (n, _, _) : _ -> n
+                                  [] -> lineNo + lineSpan + sum [s | (_, s, _) <- consumed]
+                                st' =
+                                  (emitLine expanded st)
+                                    { stCurrentLine = nextLineNo',
+                                      stHsBlockCommentDepth = finalHs,
+                                      stCBlockCommentDepth = finalC
+                                    }
+                             in processFile filePath remaining stack st' k
+                          else continue (emitLine expanded st)
+                  Just directive ->
+                    handleDirective ctx st directive
 
 recoverDanglingElse :: LineContext -> Maybe Directive -> EngineState -> Step
 recoverDanglingElse ctx parsedDirective st =

--- a/components/aihc-cpp/src/Aihc/Cpp/Cursor.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Cursor.hs
@@ -23,6 +23,7 @@ module Aihc.Cpp.Cursor
     sliceText,
     sliceSince,
     skipWhile,
+    skipToInteresting,
     bufLength,
   )
 where
@@ -112,3 +113,31 @@ skipWhile p = go
 bufLength :: Cursor -> Int
 bufLength (Cursor buf _) = BS.length buf
 {-# INLINE bufLength #-}
+
+-- | Advance the cursor past bytes that cannot start any CPP-significant
+-- two-character sequence. Stops at: @\"@ (0x22), @\'@ (0x27), @*@ (0x2A),
+-- @-@ (0x2D), @/@ (0x2F), @\\@ (0x5C), @{@ (0x7B), @}@ (0x7D),
+-- or end of input. This allows bulk-copying runs of plain text
+-- (identifiers, whitespace, operators, non-ASCII UTF-8) without
+-- per-byte dispatch.
+skipToInteresting :: Cursor -> Cursor
+skipToInteresting = go
+  where
+    go !cur = case peekByte cur of
+      Nothing -> cur
+      Just b
+        | isInteresting b -> cur
+        | otherwise -> go (advance cur)
+
+    isInteresting :: Word8 -> Bool
+    isInteresting b =
+      b == 0x22 -- '"'
+        || b == 0x27 -- '\''
+        || b == 0x2A -- '*'
+        || b == 0x2D -- '-'
+        || b == 0x2F -- '/'
+        || b == 0x5C -- '\\'
+        || b == 0x7B -- '{'
+        || b == 0x7D -- '}'
+    {-# INLINE isInteresting #-}
+{-# INLINE skipToInteresting #-}

--- a/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
@@ -5,6 +5,7 @@ module Aihc.Cpp.Scanner
   ( LineSpan (..),
     LineScan (..),
     scanLine,
+    scanLineDepthOnly,
     expandLineBySpanMultiline,
   )
 where
@@ -18,6 +19,7 @@ import Aihc.Cpp.Cursor
     null,
     peekByte,
     peekByte2,
+    skipToInteresting,
     sliceText,
   )
 import Aihc.Cpp.Evaluator (expandMacros, expandMacrosMultiline)
@@ -63,6 +65,45 @@ expandLineBySpanMultiline st spans futureCodeLines =
         else -- Pure code line: try multi-line expansion
           let codeText = T.concat [lineSpanText s | s <- spans]
            in expandMacrosMultiline st codeText futureCodeLines
+
+-- | Lightweight scan that only tracks block comment depth changes.
+-- Does not build 'LineSpan' segments or track string/char literals.
+-- Used for inactive conditional branches where only comment depth
+-- tracking is needed (no macro expansion or span splitting).
+scanLineDepthOnly :: Int -> Int -> Text -> (Int, Int)
+scanLineDepthOnly hsDepth0 cDepth0 input =
+  let cursor0 = fromText input
+   in goDepth hsDepth0 cDepth0 cursor0
+  where
+    goDepth :: Int -> Int -> Cursor -> (Int, Int)
+    goDepth !hsDepth !cDepth !cur
+      | null cur = (hsDepth, cDepth)
+      | otherwise =
+          case peekByte2 cur of
+            Nothing ->
+              -- One byte left, no two-char sequence possible
+              (hsDepth, cDepth)
+            Just (b1, b2)
+              | cDepth > 0 ->
+                  if b1 == 0x2A && b2 == 0x2F -- '*/'
+                    then goDepth hsDepth 0 (advance2 cur)
+                    else goDepth hsDepth cDepth (advance cur)
+              | hsDepth > 0 && b1 == 0x2D && b2 == 0x7D -> -- '-}'
+                  goDepth (hsDepth - 1) cDepth (advance2 cur)
+              | b1 == 0x7B && b2 == 0x2D -> -- '{-'
+                  let cur' = advance2 cur
+                   in case peekByte cur' of
+                        Just 0x23 ->
+                          -- {-# is a pragma, not a comment
+                          goDepth hsDepth cDepth (advance cur)
+                        _ ->
+                          goDepth (hsDepth + 1) cDepth cur'
+              | hsDepth == 0 && b1 == 0x2F && b2 == 0x2A -> -- '/*'
+                  goDepth hsDepth 1 (advance2 cur)
+              | hsDepth == 0 && b1 == 0x2D && b2 == 0x2D -> -- '--' line comment
+                  (hsDepth, cDepth)
+              | otherwise ->
+                  goDepth hsDepth cDepth (advance cur)
 
 -- | Scan a line, tracking comment depths and splitting into spans that are
 -- either inside or outside block comments. Uses a byte-level cursor for
@@ -307,15 +348,16 @@ scanLine hsDepth0 cDepth0 input =
                                                           (curPos cur')
                                                           True
                                                           cur'
-                                                  -- === Normal byte: just advance ===
+                                                  -- === Normal byte: bulk-skip non-interesting bytes ===
                                                   else
-                                                    go
-                                                      hsDepth
-                                                      cDepth
-                                                      False
-                                                      False
-                                                      False
-                                                      acc
-                                                      spanStart
-                                                      spanInComment
-                                                      (advance cur)
+                                                    let cur' = skipToInteresting (advance cur)
+                                                     in go
+                                                          hsDepth
+                                                          cDepth
+                                                          False
+                                                          False
+                                                          False
+                                                          acc
+                                                          spanStart
+                                                          spanInComment
+                                                          cur'


### PR DESCRIPTION
## Summary

Phase 4 of #472: Add fast paths for dead branches and bulk byte skipping.

**Three optimizations:**

1. **Fast-path for inactive conditional branches** (`Cpp.hs`): When processing lines inside `#if 0` / inactive `#else` branches, `processFile` now uses `scanLineDepthOnly` instead of the full `scanLine`. This lightweight scan only tracks Haskell `{-`/`-}` and C89 `/*`/`*/` block comment depth without building `LineSpan` segments, tracking string/char literals, or doing macro expansion. Directives within inactive branches still go through `handleDirective` for `#if`/`#endif` nesting.

2. **`skipToInteresting` in `Cursor.hs`**: New cursor operation that advances past runs of bytes that cannot start any CPP-significant sequence. The "interesting" byte set is: `"` `'` `*` `-` `/` `\` `{` `}`. Everything else — identifiers, whitespace, operators, non-ASCII UTF-8 continuation bytes (>= 0x80) — is bulk-skipped without per-byte dispatch.

3. **Bulk skip in `Scanner.hs`**: The scanner's "normal byte" case now calls `skipToInteresting(advance cur)` instead of single-byte `advance cur`, allowing large runs of plain text to be consumed in one jump rather than one byte at a time.

## Changed files

- `Cursor.hs`: Added `skipToInteresting` with `isInteresting` byte predicate.
- `Scanner.hs`: Added `scanLineDepthOnly` lightweight depth-only scan. Updated `scanLine` normal-byte case to use `skipToInteresting`. Added export of `scanLineDepthOnly`.
- `Cpp.hs`: Restructured `processFile` with a fast path for inactive branches that avoids full `scanLine` and macro expansion.

Progress: 39 pass, 0 xfail, 0 fail (unchanged).