### PR TITLE
perf(parser): unified expr/pattern parsing phase 3 — localDeclParser

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1075,7 +1075,18 @@ bracedDeclsParser :: TokParser [Decl]
 bracedDeclsParser = bracedSemiSep1 localDeclParser
 
 localDeclParser :: TokParser Decl
-localDeclParser = MP.try localTypeSigDeclParser <|> MP.try localFunctionDeclParser <|> localPatternDeclParser
+localDeclParser = do
+  isTySig <- startsWithTypeSig
+  if isTySig
+    then -- Type signature: name1, name2 :: type
+    -- No MP.try needed; startsWithTypeSig confirmed '::' follows the names.
+      localTypeSigDeclParser
+    else -- Function or pattern binding.
+    -- MP.try around localFunctionDeclParser needed because function heads
+    -- and pattern binds can overlap (e.g. '(x, y) = expr' can be attempted
+    -- as an infix function head before falling back to pattern bind).
+    -- Phase 4 will address functionHeadParserWith to further reduce this.
+      MP.try localFunctionDeclParser <|> localPatternDeclParser
 
 localTypeSigDeclParser :: TokParser Decl
 localTypeSigDeclParser = withSpan $ do
@@ -1241,6 +1252,17 @@ startsWithAsPattern =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
     _ <- identifierTextParser
     expectedTok TkReservedAt
+
+-- | Non-consuming lookahead: does the input start with @name1, name2, ... ::@?
+-- Used by 'localDeclParser' to dispatch to the type-signature path without
+-- 'MP.try', eliminating backtracking over the name list.
+startsWithTypeSig :: TokParser Bool
+startsWithTypeSig =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    _ <- binderNameParser
+    let moreNames = (expectedTok TkSpecialComma *> binderNameParser *> moreNames) <|> pure ()
+    moreNames
+    expectedTok TkReservedDoubleColon
 
 startsWithContextType :: TokParser Bool
 startsWithContextType = MP.lookAhead (go [])

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -126,6 +126,18 @@ buildTests = do
             testCase "comp as gen: [y | y@(Just _) <- xs]" test_compAsGen,
             testCase "comp infix gen: [a | a : as <- xs]" test_compInfixGen
           ],
+        testGroup
+          "localDeclParser dispatch"
+          [ testCase "type sig: f :: Int" test_localDeclTypeSig,
+            testCase "type sig multi: f, g :: Int" test_localDeclTypeSigMulti,
+            testCase "type sig operator: (+) :: Int -> Int -> Int" test_localDeclTypeSigOp,
+            testCase "function bind prefix: f x = x" test_localDeclFunPrefix,
+            testCase "function bind no args: f = 5" test_localDeclFunNoArgs,
+            testCase "pattern bind tuple: (x, y) = expr" test_localDeclPatTuple,
+            testCase "pattern bind constructor: Just x = expr" test_localDeclPatCon,
+            testCase "pattern bind wildcard: _ = expr" test_localDeclPatWild,
+            testCase "function bind guarded: f x | x > 0 = x" test_localDeclFunGuarded
+          ],
         adjustOption (const tenMinutes) $
           testGroup
             "properties"
@@ -768,3 +780,76 @@ test_compInfixGen =
   case parseCompStmts "[a | a : as <- xs]" of
     Right [CompGen _ (PInfix _ (PVar _ "a") ":" (PVar _ "as")) _] -> pure ()
     other -> assertFailure ("expected comp infix gen, got: " <> show other)
+
+-- Helper: parse a let-expression and extract the local declarations.
+-- Input: "let { decl1; decl2 } in body"
+parseLetDecls :: T.Text -> Either String [Decl]
+parseLetDecls src =
+  let fullSrc = "x = " <> src
+      (errs, modu) = parseModule defaultConfig fullSrc
+   in if not (null errs)
+        then Left ("parse errors: " <> show errs)
+        else case moduleDecls modu of
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (ELetDecls _ decls _)}])] ->
+            Right decls
+          other ->
+            Left ("unexpected AST: " <> show other)
+
+test_localDeclTypeSig :: Assertion
+test_localDeclTypeSig =
+  case parseLetDecls "let { f :: Int } in f" of
+    Right [DeclTypeSig _ ["f"] _] -> pure ()
+    other -> assertFailure ("expected type sig, got: " <> show other)
+
+test_localDeclTypeSigMulti :: Assertion
+test_localDeclTypeSigMulti =
+  case parseLetDecls "let { f, g :: Int } in f" of
+    Right [DeclTypeSig _ ["f", "g"] _] -> pure ()
+    other -> assertFailure ("expected multi-name type sig, got: " <> show other)
+
+test_localDeclTypeSigOp :: Assertion
+test_localDeclTypeSigOp =
+  case parseLetDecls "let { (+) :: Int -> Int -> Int } in 1 + 2" of
+    Right [DeclTypeSig _ ["+"] _] -> pure ()
+    other -> assertFailure ("expected operator type sig, got: " <> show other)
+
+test_localDeclFunPrefix :: Assertion
+test_localDeclFunPrefix =
+  case parseLetDecls "let { f x = x } in f 1" of
+    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"]}])] -> pure ()
+    other -> assertFailure ("expected prefix function bind, got: " <> show other)
+
+test_localDeclFunNoArgs :: Assertion
+test_localDeclFunNoArgs =
+  case parseLetDecls "let { f = 5 } in f" of
+    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = []}])] -> pure ()
+    other -> assertFailure ("expected no-args function bind, got: " <> show other)
+
+test_localDeclPatTuple :: Assertion
+test_localDeclPatTuple =
+  case parseLetDecls "let { (x, y) = (1, 2) } in x" of
+    Right [DeclValue _ (PatternBind _ (PTuple _ Boxed [PVar _ "x", PVar _ "y"]) _)] -> pure ()
+    other -> assertFailure ("expected tuple pattern bind, got: " <> show other)
+
+test_localDeclPatCon :: Assertion
+test_localDeclPatCon =
+  -- NOTE: GHC parses 'Just x = Nothing' in a let-binding as a PatBind with
+  -- a constructor pattern. Our parser currently treats it as a FunctionBind
+  -- for 'Just' because localFunctionDeclParser is tried before
+  -- localPatternDeclParser. This is a pre-existing issue unrelated to the
+  -- Phase 3 refactoring; fixing it is deferred to Phase 4.
+  case parseLetDecls "let { Just x = Nothing } in x" of
+    Right [DeclValue _ (FunctionBind _ "Just" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"]}])] -> pure ()
+    other -> assertFailure ("expected function bind for constructor name (pre-existing behaviour), got: " <> show other)
+
+test_localDeclPatWild :: Assertion
+test_localDeclPatWild =
+  case parseLetDecls "let { _ = 5 } in 0" of
+    Right [DeclValue _ (PatternBind _ (PWildcard _) _)] -> pure ()
+    other -> assertFailure ("expected wildcard pattern bind, got: " <> show other)
+
+test_localDeclFunGuarded :: Assertion
+test_localDeclFunGuarded =
+  case parseLetDecls "let { f x | x > 0 = x } in f 1" of
+    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss _ _}])] -> pure ()
+    other -> assertFailure ("expected guarded function bind, got: " <> show other)


### PR DESCRIPTION
## Summary

Phase 3 of the unified expression/pattern parsing strategy (#473). Eliminates the `MP.try` around `localTypeSigDeclParser` by introducing a non-consuming `startsWithTypeSig` lookahead that detects `name (, name)* ::` before committing to the type-signature path.

- Add `startsWithTypeSig` lookahead helper that scans for `binderName (,binderName)* ::` without consuming input
- Refactor `localDeclParser` to dispatch on the lookahead result: type-sig path (no `MP.try`) vs function/pattern binding path

## Test changes

- **+9 new integration tests** covering local declarations:
  - Type sig (single name, multi-name, operator)
  - Function bind (prefix with args, no args, guarded)
  - Pattern bind (tuple, constructor, wildcard)
- All 1000 tests pass (991 existing + 9 new)
- `nix flake check` passes

## Design

The type-signature path (`name1, name2 :: type`) is the most expensive `MP.try` to backtrack from because it can consume an arbitrarily long comma-separated name list before failing at `::`. The `startsWithTypeSig` lookahead eliminates this by verifying the `::` token is present before committing.

The remaining `MP.try` around `localFunctionDeclParser` is kept because function heads and pattern binds can overlap (e.g., `(x, y) = expr` is attempted as an infix function head via `functionHeadParserWith` before falling back to pattern bind). Phase 4 will address `functionHeadParserWith` to further reduce this.

### `MP.try` reduction

| Parser | Before | After |
|---|---|---|
| `localDeclParser` | 2 (`localTypeSigDeclParser` + `localFunctionDeclParser`) | 1 (`localFunctionDeclParser` only) |
| **Total eliminated** | **1** | |

### Note: constructor pattern binds

During testing, I discovered that `Just x = Nothing` in a let-binding is parsed as `FunctionBind "Just" [PVar "x"]` rather than `PatternBind (PCon "Just" [PVar "x"])` as GHC does. This is a pre-existing issue (the old `localDeclParser` also tried `localFunctionDeclParser` before `localPatternDeclParser`), not introduced by this change. Fixing it would require changes to `functionHeadParserWith` to distinguish constructor names from function names, which is deferred to Phase 4.

Closes the Phase 3 checkbox in #473.