### PR TITLE
perf(parser): unified expr/pattern parsing phase 4 — functionHeadParserWith

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -407,8 +407,15 @@ contextParserWith :: TokParser Type -> TokParser [Constraint]
 contextParserWith = constraintsParserWith
 
 functionHeadParserWith :: TokParser Pattern -> TokParser Pattern -> TokParser (MatchHeadForm, Text, [Pattern])
-functionHeadParserWith fullPatternParser prefixPatternParser =
-  MP.try parenthesizedInfixHeadParser <|> MP.try infixHeadParser <|> prefixHeadParser
+functionHeadParserWith fullPatternParser prefixPatternParser = do
+  isParenInfix <- startsWithParenInfixHead
+  if isParenInfix
+    then parenthesizedInfixHeadParser
+    else do
+      isInfix <- startsWithInfixHead
+      if isInfix
+        then infixHeadParser
+        else prefixHeadParser
   where
     prefixHeadParser = do
       name <- binderNameParser
@@ -429,6 +436,110 @@ functionHeadParserWith fullPatternParser prefixPatternParser =
       expectedTok TkSpecialRParen
       tailPats <- MP.many prefixPatternParser
       pure (MatchHeadInfix, op, [lhsPat, rhsPat] <> tailPats)
+
+-- | Non-consuming lookahead: does the input start with a parenthesized infix
+-- function head @( pat varop pat ) ...@?
+--
+-- Scans inside the outermost parentheses for a variable operator ('TkVarSym')
+-- or backtick-quoted variable at bracket depth 0. Excludes the case where
+-- the parenthesised content is a single operator like @(+)@ — that is a
+-- parenthesised operator name (prefix head), not a parenthesised infix head.
+startsWithParenInfixHead :: TokParser Bool
+startsWithParenInfixHead = MP.lookAhead $ do
+  tok <- anySingle
+  case lexTokenKind tok of
+    TkSpecialLParen -> do
+      -- Peek at the first token inside parens. If it is already a varop,
+      -- this is @(op)@ — a parenthesised operator name, not an infix head.
+      inner <- anySingle
+      case lexTokenKind inner of
+        TkVarSym _ -> pure False -- (op) or (op ...) — treated as prefix name
+        TkSpecialBacktick -> pure False
+        TkEOF -> pure False
+        TkSpecialRParen -> pure False -- empty parens
+        -- First token inside is not an operator → scan for a varop
+        _ -> goInner []
+    _ -> pure False
+  where
+    -- Scan inside the outermost parens (we already consumed '(' and one token).
+    -- We're looking for a TkVarSym or TkSpecialBacktick at depth 0.
+    goInner :: [LexTokenKind] -> TokParser Bool
+    -- At depth 0 (inside the outermost parens)
+    goInner [] = do
+      tok <- anySingle
+      case lexTokenKind tok of
+        TkEOF -> pure False
+        TkSpecialRParen -> pure False -- closed without finding varop
+        TkVarSym _ -> pure True
+        TkSpecialBacktick -> pure True
+        TkSpecialLParen -> goInner [TkSpecialRParen]
+        TkSpecialUnboxedLParen -> goInner [TkSpecialUnboxedRParen]
+        TkSpecialLBracket -> goInner [TkSpecialRBracket]
+        TkSpecialLBrace -> goInner [TkSpecialRBrace]
+        _ -> goInner []
+    -- Inside nested brackets
+    goInner stack@(expectedClose : rest) = do
+      tok <- anySingle
+      case lexTokenKind tok of
+        TkEOF -> pure False
+        kind
+          | kind == expectedClose ->
+              case rest of
+                [] -> goInner []
+                _ -> goInner rest
+        TkSpecialLParen -> goInner (TkSpecialRParen : stack)
+        TkSpecialUnboxedLParen -> goInner (TkSpecialUnboxedRParen : stack)
+        TkSpecialLBracket -> goInner (TkSpecialRBracket : stack)
+        TkSpecialLBrace -> goInner (TkSpecialRBrace : stack)
+        _ -> goInner stack
+
+-- | Non-consuming lookahead: does the input start with an infix function head
+-- @pat varop pat@?
+--
+-- Scans the token stream at bracket depth 0 for a variable operator
+-- ('TkVarSym') or backtick-quoted variable before reaching @=@ or @|@.
+-- Returns 'False' for prefix heads like @f x y = ...@ (no varop before @=@).
+startsWithInfixHead :: TokParser Bool
+startsWithInfixHead = MP.lookAhead (go [])
+  where
+    go :: [LexTokenKind] -> TokParser Bool
+    -- At depth 0
+    go [] = do
+      tok <- anySingle
+      case lexTokenKind tok of
+        TkEOF -> pure False
+        -- Stop tokens: we reached '=' or '|' without finding a varop
+        TkReservedEquals -> pure False
+        TkReservedPipe -> pure False
+        -- Statement/declaration boundaries
+        TkSpecialSemicolon -> pure False
+        TkSpecialRBrace -> pure False
+        TkSpecialRParen -> pure False
+        TkSpecialRBracket -> pure False
+        -- Found a varop at the top level → infix head
+        TkVarSym _ -> pure True
+        TkSpecialBacktick -> pure True
+        -- Nested brackets
+        TkSpecialLParen -> go [TkSpecialRParen]
+        TkSpecialUnboxedLParen -> go [TkSpecialUnboxedRParen]
+        TkSpecialLBracket -> go [TkSpecialRBracket]
+        TkSpecialLBrace -> go [TkSpecialRBrace]
+        _ -> go []
+    -- Inside nested brackets
+    go stack@(expectedClose : rest) = do
+      tok <- anySingle
+      case lexTokenKind tok of
+        TkEOF -> pure False
+        kind
+          | kind == expectedClose ->
+              case rest of
+                [] -> go []
+                _ -> go rest
+        TkSpecialLParen -> go (TkSpecialRParen : stack)
+        TkSpecialUnboxedLParen -> go (TkSpecialUnboxedRParen : stack)
+        TkSpecialLBracket -> go (TkSpecialRBracket : stack)
+        TkSpecialLBrace -> go (TkSpecialRBrace : stack)
+        _ -> go stack
 
 functionBindValue :: SourceSpan -> MatchHeadForm -> Text -> [Pattern] -> Rhs -> ValueDecl
 functionBindValue span' headForm name pats rhs =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -138,6 +138,19 @@ buildTests = do
             testCase "pattern bind wildcard: _ = expr" test_localDeclPatWild,
             testCase "function bind guarded: f x | x > 0 = x" test_localDeclFunGuarded
           ],
+        testGroup
+          "functionHeadParserWith dispatch"
+          [ testCase "prefix: f x y = x + y" test_funHeadPrefix,
+            testCase "prefix no args: f = 5" test_funHeadPrefixNoArgs,
+            testCase "prefix operator name: (+) x y = x" test_funHeadPrefixOp,
+            testCase "infix: x + y = x" test_funHeadInfix,
+            testCase "infix backtick: x `add` y = x" test_funHeadInfixBacktick,
+            testCase "parenthesized infix: (x + y) = x" test_funHeadParenInfix,
+            testCase "parenthesized infix with tail: (x + y) z = x" test_funHeadParenInfixTail,
+            testCase "local prefix: let f x = x" test_funHeadLocalPrefix,
+            testCase "local infix: let x + y = x" test_funHeadLocalInfix,
+            testCase "local paren op name: let (+) x y = x" test_funHeadLocalPrefixOp
+          ],
         adjustOption (const tenMinutes) $
           testGroup
             "properties"
@@ -853,3 +866,73 @@ test_localDeclFunGuarded =
   case parseLetDecls "let { f x | x > 0 = x } in f 1" of
     Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss _ _}])] -> pure ()
     other -> assertFailure ("expected guarded function bind, got: " <> show other)
+
+-- Helper: parse a top-level declaration and extract the ValueDecl.
+parseTopDecl :: T.Text -> Either String Decl
+parseTopDecl src =
+  let (errs, modu) = parseModule defaultConfig src
+   in if not (null errs)
+        then Left ("parse errors: " <> show errs)
+        else case moduleDecls modu of
+          [decl] -> Right decl
+          other -> Left ("expected one decl, got: " <> show (length other))
+
+test_funHeadPrefix :: Assertion
+test_funHeadPrefix =
+  case parseTopDecl "f x y = x + y" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
+    other -> assertFailure ("expected prefix function bind, got: " <> show other)
+
+test_funHeadPrefixNoArgs :: Assertion
+test_funHeadPrefixNoArgs =
+  case parseTopDecl "f = 5" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = []}])) -> pure ()
+    other -> assertFailure ("expected prefix function bind with no args, got: " <> show other)
+
+test_funHeadPrefixOp :: Assertion
+test_funHeadPrefixOp =
+  case parseTopDecl "(+) x y = x" of
+    Right (DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
+    other -> assertFailure ("expected prefix operator function bind, got: " <> show other)
+
+test_funHeadInfix :: Assertion
+test_funHeadInfix =
+  case parseTopDecl "x + y = x" of
+    Right (DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
+    other -> assertFailure ("expected infix function bind, got: " <> show other)
+
+test_funHeadInfixBacktick :: Assertion
+test_funHeadInfixBacktick =
+  case parseTopDecl "x `add` y = x" of
+    Right (DeclValue _ (FunctionBind _ "add" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
+    other -> assertFailure ("expected backtick infix function bind, got: " <> show other)
+
+test_funHeadParenInfix :: Assertion
+test_funHeadParenInfix =
+  case parseTopDecl "(x + y) = x" of
+    Right (DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
+    other -> assertFailure ("expected parenthesized infix function bind, got: " <> show other)
+
+test_funHeadParenInfixTail :: Assertion
+test_funHeadParenInfixTail =
+  case parseTopDecl "(x + y) z = x" of
+    Right (DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y", PVar _ "z"]}])) -> pure ()
+    other -> assertFailure ("expected parenthesized infix with tail, got: " <> show other)
+
+test_funHeadLocalPrefix :: Assertion
+test_funHeadLocalPrefix =
+  case parseLetDecls "let { f x = x } in f 1" of
+    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"]}])] -> pure ()
+    other -> assertFailure ("expected local prefix function bind, got: " <> show other)
+
+test_funHeadLocalInfix :: Assertion
+test_funHeadLocalInfix =
+  case parseLetDecls "let { x + y = x } in 1 + 2" of
+    Right [DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y"]}])] -> pure ()
+    other -> assertFailure ("expected local infix function bind, got: " <> show other)
+
+test_funHeadLocalPrefixOp :: Assertion
+test_funHeadLocalPrefixOp =
+  case parseLetDecls "let { (+) x y = x } in 1 + 2" of
+    Right [DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x", PVar _ "y"]}])] -> pure ()
+    other -> assertFailure ("expected local prefix operator function bind, got: " <> show other)


### PR DESCRIPTION
## Summary

Phase 4 of the unified expression/pattern parsing strategy (#473). Replaces the three-way `MP.try` chain in `functionHeadParserWith` with bracket-depth-aware token-stream lookaheads that determine the function head form (prefix, infix, or parenthesized infix) before committing to a parsing path.

- Add `startsWithParenInfixHead` lookahead: scans inside outermost parens for a varop at bracket depth 0, excluding the `(op)` case (parenthesized operator name)
- Add `startsWithInfixHead` lookahead: scans the token stream at bracket depth 0 for a varop (`TkVarSym` or backtick) before reaching `=` or `|`
- Refactor `functionHeadParserWith` to dispatch on lookahead results instead of `MP.try` alternatives

This benefits all 5 call sites of `functionHeadParserWith`: `localFunctionDeclParser`, `valueDeclParser`, `classDefaultItemParser`, `instanceValueItemParser`, and `patSynWhereMatch`.

## Test changes

- **+10 new integration tests** covering all function head forms:
  - Top-level: prefix, prefix no args, prefix operator name `(+)`, infix, infix backtick, parenthesized infix, parenthesized infix with tail patterns
  - Local (let-binding): prefix, infix, prefix operator name
- All 1010 tests pass (1000 existing + 10 new)
- `nix flake check` passes

## Design

The key insight is that the three function head forms are distinguishable by the position of a variable operator (`TkVarSym` or backtick-quoted identifier) in the token stream:

| Head form | Token pattern | Varop position |
|---|---|---|
| Prefix | `name pat* =` | No varop before `=`/`\|` |
| Infix | `pat varop pat =` | Varop at top-level before `=`/`\|` |
| Parenthesized infix | `( pat varop pat ) pat* =` | Varop inside outermost parens |

Both lookaheads use bracket-depth tracking (same pattern as `startsWithContextType`) to avoid false positives from varops nested inside parentheses, brackets, or braces.

**Subtlety**: `(op)` (a parenthesized operator name for prefix heads like `(+) x y = x`) must NOT be classified as a parenthesized infix head. The `startsWithParenInfixHead` lookahead handles this by checking whether the first token inside the parens is itself a varop — if so, it's an operator name, not an infix pattern.

### `MP.try` reduction

| Location | Before | After |
|---|---|---|
| `functionHeadParserWith` (internal) | 2 (`parenthesizedInfixHead` + `infixHead`) | 0 |
| **Total eliminated** | **2** | |

Note: The `MP.try` around `localFunctionDeclParser` in `localDeclParser` remains — it handles the case where the function head parser succeeds but the caller's RHS parser fails (e.g., for pattern binds that overlap with zero-arg function binds). This outer `MP.try` is cheap since the internal backtracking has been eliminated.

Closes the Phase 4 checkbox in #473.