### PR TITLE
fix(parser): allow promoted types in type family equation LHS

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1961,7 +1961,8 @@ typeInfixOperatorParser =
           TkVarSym op
             | op /= "."
                 && op /= "!"
-                && op /= "-" ->
+                && op /= "-"
+                && op /= "'" ->
                 Just (op, Unpromoted)
           TkConSym op -> Just (op, Unpromoted)
           TkQVarSym op -> Just (op, Unpromoted)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/promoted-types-in-equations.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/promoted-types-in-equations.hs
@@ -1,0 +1,27 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds, TypeFamilies, KindSignatures #-}
+module PromotedTypesInTypeFamilyEquations where
+
+-- Type family with promoted empty list in equation
+type family HeadList (xs :: [*]) :: * where
+  HeadList '[] = Int
+  HeadList (x ': xs) = x
+
+-- Type family with promoted cons in equation
+type family Append (xs :: [*]) (ys :: [*]) :: [*] where
+  Append '[] ys = ys
+  Append (x ': xs) ys = x ': Append xs ys
+
+-- Type family with promoted tuple
+type family FstPair (a :: *) (b :: *) :: * where
+  FstPair '(a, b) = a
+
+-- Type family with promoted constructor
+type family IsTrue (b :: Bool) where
+  IsTrue 'True = Int
+  IsTrue 'False = Char
+
+-- Type family combining [*] kind parameter and promoted equations
+type family F (xs :: [*]) (r :: *) :: * where
+  F '[] r = r
+  F (x ': xs) r = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/star-list-kind-equations.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/star-list-kind-equations.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail type family with [*] kind parameter and equations fails to parse -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds, TypeFamilies #-}
 module StarListKindTypeFamily where
 


### PR DESCRIPTION
## Root Cause

The tick symbol (`'`) was incorrectly accepted as an infix type operator by `unpromotedInfixOperatorParser` in `typeInfixOperatorParser`. This caused type family equation LHS expressions like `F '[]` to be parsed as infix applications (`F` applied infix `'` to `[]`) instead of prefix applications (`F` applied to the promoted empty list `'[]`).

### Why This Happened

The `unpromotedInfixOperatorParser` accepts any `TkVarSym` that isn't `.`, `!`, or `-`. Since `'` (used for type promotion with `DataKinds`) is tokenized as `TkVarSym "'"`, it matched this pattern and was incorrectly treated as an infix operator.

### Impact

This broke parsing of type family equations using any promoted types in their patterns:
- `F '[] = ...` - promoted empty list
- `F 'True = ...` - promoted constructors
- `F '(a, b) = ...` - promoted tuples
- `F (x ': xs) = ...` - promoted cons (when combined with other patterns)

## Solution

Added `'` to the exclusion list in `unpromotedInfixOperatorParser`, alongside the already-excluded `.`, `!`, and `-` symbols. This is the minimal fix that prevents `'` from being treated as an infix operator while preserving all legitimate infix type operator functionality.

### Tradeoffs Considered

1. **Modify `typeFamilyLhsParser` directly** - Would be more localized but wouldn't fix the root cause for other parsers that use `typeInfixOperatorParser`.
2. **Fix in the lexer** - Could prevent `'` from being tokenized as `TkVarSym` in certain contexts, but this would be more complex and might break other valid uses.
3. **Selected: Exclude `'` from infix operators** - Clean, minimal, and fixes the issue at its source for all consumers of `typeInfixOperatorParser`.

## Changes

- **`components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs`**: Added `&& op /= "'"` to the guard in `unpromotedInfixOperatorParser`.
- **`components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/star-list-kind-equations.hs`**: Changed from `xfail` to `pass` (original failing test now works).
- **`components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/promoted-types-in-equations.hs`**: New comprehensive test covering promoted empty list, cons, tuples, and constructors in type family equations.

## Test Results

- All 1198 parser tests pass
- All 765 oracle tests pass (including 2 new/updated tests for this fix)
- No regressions detected