### PR TITLE
refactor(cpp): derive MIN_VERSION_ macros from package dependencies

### DIFF
--- a/components/aihc-parser/app/hackage-tester/Main.hs
+++ b/components/aihc-parser/app/hackage-tester/Main.hs
@@ -127,7 +127,7 @@ processFile :: Options -> FilePath -> FileInfo -> IO FileResult
 processFile opts packageRoot info = do
   let file = fileInfoPath info
   source <- readTextFileLenient file
-  preprocessed <- preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (resolveIncludeBestEffort packageRoot file) source
+  preprocessed <- preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (fileInfoDependencies info) (resolveIncludeBestEffort packageRoot file) source
   let source' = resultOutput preprocessed
       cppErrs = [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error]
       headerPragmas = readModuleHeaderPragmas source'

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
@@ -148,7 +148,7 @@ checkFile parsers verbose packageRoot info = do
   source <- readTextFileLenient file
   (preprocessed, preprocessNanos) <-
     withElapsedNanos $
-      preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (resolveIncludeBestEffort packageRoot file) source
+      preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (fileInfoDependencies info) (resolveIncludeBestEffort packageRoot file) source
   let source' = resultOutput preprocessed
       cppErrors = [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error]
       cppErrorMsg =

--- a/components/aihc-parser/common/CppSupport.hs
+++ b/components/aihc-parser/common/CppSupport.hs
@@ -13,20 +13,16 @@ where
 
 import Aihc.Cpp
   ( Config (..),
-    IncludeKind (..),
     IncludeRequest (..),
     Result (..),
     Step (..),
     defaultConfig,
-    includeFrom,
-    includeKind,
-    includePath,
     preprocess,
   )
 import Aihc.Parser.Lex (readModuleHeaderExtensions, readModuleHeaderPragmas)
 import Aihc.Parser.Syntax (Extension (CPP), ExtensionSetting (..), ModuleHeaderPragmas (..))
 import Data.ByteString (ByteString)
-import Data.Char (isAsciiLower, isAsciiUpper, isDigit, toLower)
+import Data.Char (toLower)
 import Data.Functor.Identity (Identity (..), runIdentity)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -34,15 +30,15 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import System.FilePath (takeDirectory, takeExtension, (</>))
+import System.FilePath (takeExtension)
 
-preprocessForParser :: (Monad m) => FilePath -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result
-preprocessForParser inputFile resolveInclude source =
-  preprocessForParserWithCppOptions [] inputFile resolveInclude (normalizeSourceForParser inputFile source)
+preprocessForParser :: (Monad m) => FilePath -> [Text] -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result
+preprocessForParser inputFile deps resolveInclude source =
+  preprocessForParserWithCppOptions [] inputFile deps resolveInclude (normalizeSourceForParser inputFile source)
 
-preprocessForParserWithCppOptions :: (Monad m) => [String] -> FilePath -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result
-preprocessForParserWithCppOptions cppOptions inputFile resolveInclude source = do
-  minVersionMacros <- discoverMinVersionMacros inputFile resolveInclude source
+preprocessForParserWithCppOptions :: (Monad m) => [String] -> FilePath -> [Text] -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result
+preprocessForParserWithCppOptions cppOptions inputFile deps resolveInclude source = do
+  let minVersionMacros = minVersionMacroNamesFromDeps deps
   let injected = injectSyntheticCppMacros cppOptions minVersionMacros source
   let cfg =
         defaultConfig
@@ -54,21 +50,21 @@ preprocessForParserWithCppOptions cppOptions inputFile resolveInclude source = d
     drive (Done result) = pure result
     drive (NeedInclude req k) = resolveInclude req >>= drive . k
 
-preprocessForParserWithoutIncludes :: FilePath -> Text -> Result
-preprocessForParserWithoutIncludes inputFile source =
-  runIdentity (preprocessForParser inputFile (\_ -> Identity Nothing) source)
+preprocessForParserWithoutIncludes :: FilePath -> [Text] -> Text -> Result
+preprocessForParserWithoutIncludes inputFile deps source =
+  runIdentity (preprocessForParser inputFile deps (\_ -> Identity Nothing) source)
 
-preprocessForParserIfEnabled :: (Monad m) => [ExtensionSetting] -> [String] -> FilePath -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result
-preprocessForParserIfEnabled globalExtensionNames cppOptions inputFile resolveInclude source =
+preprocessForParserIfEnabled :: (Monad m) => [ExtensionSetting] -> [String] -> FilePath -> [Text] -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result
+preprocessForParserIfEnabled globalExtensionNames cppOptions inputFile deps resolveInclude source =
   let normalizedSource = normalizeSourceForParser inputFile source
       shouldPreprocess = cppEnabledInSourceWithGlobals globalExtensionNames normalizedSource
    in if shouldPreprocess
-        then preprocessForParserWithCppOptions cppOptions inputFile resolveInclude normalizedSource
+        then preprocessForParserWithCppOptions cppOptions inputFile deps resolveInclude normalizedSource
         else pure Result {resultOutput = normalizedSource, resultDiagnostics = []}
 
-preprocessForParserWithoutIncludesIfEnabled :: [ExtensionSetting] -> [String] -> FilePath -> Text -> Result
-preprocessForParserWithoutIncludesIfEnabled globalExtensionNames cppOptions inputFile source =
-  runIdentity (preprocessForParserIfEnabled globalExtensionNames cppOptions inputFile (\_ -> Identity Nothing) source)
+preprocessForParserWithoutIncludesIfEnabled :: [ExtensionSetting] -> [String] -> FilePath -> [Text] -> Text -> Result
+preprocessForParserWithoutIncludesIfEnabled globalExtensionNames cppOptions inputFile deps source =
+  runIdentity (preprocessForParserIfEnabled globalExtensionNames cppOptions inputFile deps (\_ -> Identity Nothing) source)
 
 moduleHeaderExtensionSettings :: Text -> [ExtensionSetting]
 moduleHeaderExtensionSettings = readModuleHeaderExtensions
@@ -167,32 +163,12 @@ unliterateIfNeeded inputFile source
       | inCode = line : unlitLatex inCode rest
       | otherwise = "" : unlitLatex inCode rest
 
-discoverMinVersionMacros :: (Monad m) => FilePath -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m (S.Set Text)
-discoverMinVersionMacros inputFile resolveInclude =
-  go S.empty S.empty inputFile
+minVersionMacroNamesFromDeps :: [Text] -> S.Set Text
+minVersionMacroNamesFromDeps = S.fromList . map toMinVersionMacroName
   where
-    go seenFiles seenMacros filePath txt
-      | filePath `S.member` seenFiles = pure seenMacros
-      | otherwise = do
-          let seenFiles' = S.insert filePath seenFiles
-              found = extractMinVersionMacroNames txt
-              includeReqs = extractIncludeRequests filePath txt
-              seenMacros' = S.union seenMacros found
-          foldl
-            (\acc req -> acc >>= \curr -> collectInclude seenFiles' curr req)
-            (pure seenMacros')
-            includeReqs
-
-    collectInclude seenFiles seenMacros req = do
-      content <- resolveInclude req
-      case content of
-        Nothing -> pure seenMacros
-        Just includeBytes ->
-          let includeFilePath =
-                case includeKind req of
-                  IncludeLocal -> takeDirectory (includeFrom req) </> includePath req
-                  IncludeSystem -> includePath req
-           in go seenFiles seenMacros includeFilePath (TE.decodeUtf8 includeBytes)
+    toMinVersionMacroName pkg = "MIN_VERSION_" <> T.map sanitizePkgChar pkg
+    sanitizePkgChar '-' = '_'
+    sanitizePkgChar c = c
 
 injectSyntheticCppMacros :: [String] -> S.Set Text -> Text -> Text
 injectSyntheticCppMacros cppOptions minVersionMacroNames source =
@@ -226,66 +202,3 @@ cppDefinedOrUndefinedFromOptions =
       case option of
         CppDefine name _ -> S.insert name acc
         CppUndef name -> S.insert name acc
-
-extractMinVersionMacroNames :: Text -> S.Set Text
-extractMinVersionMacroNames = go S.empty
-  where
-    prefix = "MIN_VERSION_"
-    go acc txt =
-      case T.breakOn prefix txt of
-        (_, "") -> acc
-        (_, rest) ->
-          let candidateWithPrefix = T.takeWhile isMinVersionIdentChar rest
-              suffix = T.drop (T.length candidateWithPrefix) rest
-              acc' =
-                if T.length candidateWithPrefix > T.length prefix
-                  && case T.uncons suffix of
-                    Just ('(', _) -> True
-                    _ -> False
-                  then S.insert candidateWithPrefix acc
-                  else acc
-              nextTxt =
-                if T.null rest
-                  then ""
-                  else T.drop 1 rest
-           in go acc' nextTxt
-
-    isMinVersionIdentChar c = c == '_' || isAsciiAlphaNum c
-    isAsciiAlphaNum c = isAsciiLower c || isAsciiUpper c || isDigit c
-
-extractIncludeRequests :: FilePath -> Text -> [IncludeRequest]
-extractIncludeRequests filePath =
-  mapMaybe parseIncludeLine . T.lines
-  where
-    parseIncludeLine raw =
-      let line = T.stripStart raw
-       in case T.stripPrefix "#include" line of
-            Nothing -> Nothing
-            Just rest ->
-              let stripped = T.stripStart rest
-               in case T.uncons stripped of
-                    Just ('"', t1) ->
-                      let (path, t2) = T.breakOn "\"" t1
-                       in if T.null path || T.null t2
-                            then Nothing
-                            else
-                              Just
-                                IncludeRequest
-                                  { includePath = T.unpack path,
-                                    includeKind = IncludeLocal,
-                                    includeFrom = filePath,
-                                    includeLine = 1
-                                  }
-                    Just ('<', t1) ->
-                      let (path, t2) = T.breakOn ">" t1
-                       in if T.null path || T.null t2
-                            then Nothing
-                            else
-                              Just
-                                IncludeRequest
-                                  { includePath = T.unpack path,
-                                    includeKind = IncludeSystem,
-                                    includeFrom = filePath,
-                                    includeLine = 1
-                                  }
-                    _ -> Nothing

--- a/components/aihc-parser/common/ExtensionSupport.hs
+++ b/components/aihc-parser/common/ExtensionSupport.hs
@@ -83,6 +83,7 @@ evaluateCaseText meta source =
               (caseExtensions meta)
               []
               (casePath meta)
+              []
               source
           )
       oracleOk = either Just (const Nothing) (oracleModuleAstFingerprint (casePath meta) Syntax.Haskell2010Edition exts source')

--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -49,7 +49,7 @@ oracleModuleAstFingerprint sourceTag edition extNames input =
       initialExts = computeEffectiveExtensions edition extNames initialPragmas
       preprocessedInput =
         if Syntax.CPP `elem` initialExts
-          then resultOutput (preprocessForParserWithoutIncludes sourceTag input)
+          then resultOutput (preprocessForParserWithoutIncludes sourceTag [] input)
           else input
    in oracleModuleAstFingerprintNoCPP sourceTag edition extNames preprocessedInput
 

--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -53,10 +53,10 @@ import Distribution.PackageDescription
     oldExtensions,
     otherModules,
   )
-import Distribution.Types.BuildInfo (targetBuildDepends)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Pretty (prettyShow)
 import Distribution.System (buildArch, buildOS)
+import Distribution.Types.BuildInfo (targetBuildDepends)
 import Distribution.Types.CondTree
   ( CondBranch (CondBranch),
     CondTree (condTreeComponents, condTreeData),

--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -28,6 +28,7 @@ import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Version as DV
 import Distribution.Compiler (CompilerFlavor (..))
 import Distribution.ModuleName (ModuleName, toFilePath)
+import Distribution.Package (unPackageName)
 import Distribution.PackageDescription
   ( BuildInfo,
     Executable,
@@ -52,6 +53,7 @@ import Distribution.PackageDescription
     oldExtensions,
     otherModules,
   )
+import Distribution.Types.BuildInfo (targetBuildDepends)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Pretty (prettyShow)
 import Distribution.System (buildArch, buildOS)
@@ -61,6 +63,7 @@ import Distribution.Types.CondTree
   )
 import Distribution.Types.Condition (Condition (..))
 import Distribution.Types.ConfVar (ConfVar (..))
+import Distribution.Types.Dependency (depPkgName)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription, genPackageFlags)
 import Distribution.Utils.Path (getSymbolicPath)
 import Distribution.Version (mkVersion, withinRange)
@@ -137,7 +140,8 @@ data FileInfo = FileInfo
   { fileInfoPath :: FilePath,
     fileInfoExtensions :: [Syntax.ExtensionSetting],
     fileInfoCppOptions :: [String],
-    fileInfoLanguage :: Maybe Syntax.LanguageEdition
+    fileInfoLanguage :: Maybe Syntax.LanguageEdition,
+    fileInfoDependencies :: [Text]
   }
   deriving (Show)
 
@@ -198,11 +202,12 @@ libraryFilesFor evalCond packageRoot tree = do
       exts = extractExtensions build
       cppOpts = cppOptions build
       lang = extractLanguage build
+      deps = extractDependencies build
   if not (buildable build)
     then pure []
     else do
       paths <- moduleFilesForBuildInfo packageRoot build moduleNames
-      pure [FileInfo path exts cppOpts lang | path <- paths]
+      pure [FileInfo path exts cppOpts lang deps | path <- paths]
 
 executableFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Executable -> IO [FileInfo]
 executableFilesFor evalCond packageRoot tree = do
@@ -213,12 +218,13 @@ executableFilesFor evalCond packageRoot tree = do
       exts = extractExtensions build
       cppOpts = cppOptions build
       lang = extractLanguage build
+      deps = extractDependencies build
   if not (buildable build)
     then pure []
     else do
       moduleFiles <- moduleFilesForBuildInfo packageRoot build moduleNames
       mainFiles <- existingPaths [dir </> mainPath | dir <- sourceDirs packageRoot build]
-      pure [FileInfo path exts cppOpts lang | path <- moduleFiles <> mainFiles]
+      pure [FileInfo path exts cppOpts lang deps | path <- moduleFiles <> mainFiles]
 
 extractExtensions :: BuildInfo -> [Syntax.ExtensionSetting]
 extractExtensions bi = mapMaybe (Syntax.parseExtensionSettingName . T.pack) (nub (map prettyShow (defaultExtensions bi <> oldExtensions bi)))
@@ -228,6 +234,10 @@ extractLanguage bi =
   case defaultLanguage bi of
     Just lang -> Syntax.parseLanguageEdition (T.pack (prettyShow lang))
     Nothing -> Nothing
+
+extractDependencies :: BuildInfo -> [Text]
+extractDependencies bi =
+  map (T.pack . unPackageName . depPkgName) (targetBuildDepends bi)
 
 collectCondTreeData :: (Condition v -> Bool) -> CondTree v c a -> [a]
 collectCondTreeData evalCond tree =

--- a/components/aihc-parser/test/Test/HackageTester/Suite.hs
+++ b/components/aihc-parser/test/Test/HackageTester/Suite.hs
@@ -330,7 +330,7 @@ test_resolveIncludeLenientDecode =
 
 test_cppMinVersionBaseTrue :: Assertion
 test_cppMinVersionBaseTrue = do
-  out <- preprocessWithIncludes "A.hs" mempty source
+  out <- preprocessWithIncludes "A.hs" ["base"] [] source
   assertBool "expected true branch for MIN_VERSION_base" ("hit\n" `T.isInfixOf` out)
   where
     source =
@@ -345,7 +345,7 @@ test_cppMinVersionBaseTrue = do
 
 test_cppMinVersionGhcTrue :: Assertion
 test_cppMinVersionGhcTrue = do
-  out <- preprocessWithIncludes "A.hs" mempty source
+  out <- preprocessWithIncludes "A.hs" [] [] source
   assertBool "expected true branch for MIN_VERSION_ghc" ("hit\n" `T.isInfixOf` out)
   where
     source =
@@ -360,7 +360,7 @@ test_cppMinVersionGhcTrue = do
 
 test_cppNegatedMinVersionGhcFalse :: Assertion
 test_cppNegatedMinVersionGhcFalse = do
-  out <- preprocessWithIncludes "A.hs" mempty source
+  out <- preprocessWithIncludes "A.hs" [] [] source
   assertBool "expected negated branch to be false for MIN_VERSION_ghc" ("miss\n" `T.isInfixOf` out)
   where
     source =
@@ -375,7 +375,7 @@ test_cppNegatedMinVersionGhcFalse = do
 
 test_cppMinVersionGlasgowHaskellTrue :: Assertion
 test_cppMinVersionGlasgowHaskellTrue = do
-  out <- preprocessWithIncludes "A.hs" mempty source
+  out <- preprocessWithIncludes "A.hs" [] [] source
   assertBool "expected true branch for MIN_VERSION_GLASGOW_HASKELL" ("hit\n" `T.isInfixOf` out)
   where
     source =
@@ -390,7 +390,7 @@ test_cppMinVersionGlasgowHaskellTrue = do
 
 test_cppUnknownMinVersionFromIncludeTrue :: Assertion
 test_cppUnknownMinVersionFromIncludeTrue = do
-  out <- preprocessWithIncludes "A.hs" includes source
+  out <- preprocessWithIncludes "A.hs" ["custompkg"] includes source
   assertBool "expected true branch for unknown MIN_VERSION in include" ("hit\n" `T.isInfixOf` out)
   where
     source =
@@ -405,7 +405,7 @@ test_cppUnknownMinVersionFromIncludeTrue = do
 test_cppOptionsWithoutCppExtensionDoNotPreprocess :: Assertion
 test_cppOptionsWithoutCppExtensionDoNotPreprocess = do
   Result {resultOutput = out} <-
-    preprocessForParserIfEnabled [] ["-DTEST=1"] "A.hs" (\_ -> pure Nothing) source
+    preprocessForParserIfEnabled [] ["-DTEST=1"] "A.hs" [] (\_ -> pure Nothing) source
   assertEqual "expected source to remain unchanged when CPP extension is not enabled" source out
   where
     source =
@@ -418,10 +418,10 @@ test_cppOptionsWithoutCppExtensionDoNotPreprocess = do
           "#endif"
         ]
 
-preprocessWithIncludes :: FilePath -> [(FilePath, T.Text)] -> T.Text -> IO T.Text
-preprocessWithIncludes inputFile includeFiles source = do
+preprocessWithIncludes :: FilePath -> [T.Text] -> [(FilePath, T.Text)] -> T.Text -> IO T.Text
+preprocessWithIncludes inputFile deps includeFiles source = do
   Result {resultOutput = out} <-
-    preprocessForParserIfEnabled [] [] inputFile resolve source
+    preprocessForParserIfEnabled [] [] inputFile deps resolve source
   pure out
   where
     resolve req = pure (TE.encodeUtf8 <$> lookup (includePath req) includeFiles)

--- a/components/aihc-parser/test/Test/Properties/NoExceptions.hs
+++ b/components/aihc-parser/test/Test/Properties/NoExceptions.hs
@@ -46,7 +46,7 @@ prop_preprocessorArbitraryTextNoExceptions =
     ioProperty $
       noExceptionProperty
         "preprocessForParserWithoutIncludes"
-        (preprocessForParserWithoutIncludes "QuickCheck.hs" source)
+        (preprocessForParserWithoutIncludes "QuickCheck.hs" [] source)
 
 prop_lexerArbitraryTextNoExceptions :: Property
 prop_lexerArbitraryTextNoExceptions =


### PR DESCRIPTION
## Summary

Replace `discoverMinVersionMacros` with `minVersionMacroNamesFromDeps`. Instead of scanning source files (and their includes) for `MIN_VERSION_*` patterns, we now generate `MIN_VERSION_` macros directly from the package's `targetBuildDepends` in the `.cabal` file.

## Changes

- **`CppSupport.hs`**: Removed `discoverMinVersionMacros` and `extractMinVersionMacroNames`. Added `minVersionMacroNamesFromDeps` which converts dependency package names to macro names (e.g. `"base"` → `"MIN_VERSION_base"`). Updated all `preprocessForParser*` signatures to accept a `[Text]` dependency list.
- **`HackageSupport.hs`**: Added `fileInfoDependencies` field to `FileInfo`. Extracts `targetBuildDepends` from `BuildInfo` and converts to package names.
- **Callers**: Updated `FileChecker.hs`, `hackage-tester/Main.hs`, `GhcOracle.hs`, `ExtensionSupport.hs`, and all tests to pass the new dependency parameter.
- All `MIN_VERSION_` macros still evaluate to `1` (version-agnostic), matching previous behavior.

## Progress

No changes to overall pass/xfail/fail/xpass counts — all 1200 spec tests pass.