### PR TITLE
refactor(parser): hide FromTokens module from public API

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -15,7 +15,6 @@ library
     , Aihc.Parser.Syntax
     , Aihc.Parser.Lex
     , Aihc.Parser.Shorthand
-    , Aihc.Parser.Internal.FromTokens
   other-modules:
       Aihc.Parser.Pretty
     , Aihc.Parser.Types
@@ -31,6 +30,7 @@ library
     , Aihc.Parser.Internal.Expr
     , Aihc.Parser.Internal.Decl
     , Aihc.Parser.Internal.Module
+    , Aihc.Parser.Internal.FromTokens
   hs-source-dirs:   src
   build-depends:
       base >=4.16 && <5
@@ -49,9 +49,29 @@ test-suite spec
       test
     , app/stackage-progress
     , common
+    , src
   main-is:          Spec.hs
   other-modules:
-      CppSupport
+      Aihc.Parser
+    , Aihc.Parser.Syntax
+    , Aihc.Parser.Lex
+    , Aihc.Parser.Shorthand
+    , Aihc.Parser.Pretty
+    , Aihc.Parser.Types
+    , Aihc.Parser.Lex.Header
+    , Aihc.Parser.Lex.Layout
+    , Aihc.Parser.Lex.Numbers
+    , Aihc.Parser.Lex.Pragmas
+    , Aihc.Parser.Lex.Quoted
+    , Aihc.Parser.Lex.Trivia
+    , Aihc.Parser.Lex.Types
+    , Aihc.Parser.Internal.CheckPattern
+    , Aihc.Parser.Internal.Common
+    , Aihc.Parser.Internal.Expr
+    , Aihc.Parser.Internal.Decl
+    , Aihc.Parser.Internal.Module
+    , Aihc.Parser.Internal.FromTokens
+    , CppSupport
     , ExtensionSupport
     , GhcOracle
     , HackageSupport
@@ -85,7 +105,6 @@ test-suite spec
     , Test.StackageProgress.Summary
   build-depends:
       base >=4.16 && <5
-    , aihc-parser
     , aihc-cpp
     , megaparsec
     , text
@@ -108,7 +127,7 @@ test-suite spec
     , optparse-applicative
     , template-haskell
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable parser-progress
   hs-source-dirs:
@@ -140,9 +159,29 @@ executable parser-quickcheck-batch
       app/parser-quickcheck-batch
     , common
     , test
+    , src
   main-is:          Main.hs
   other-modules:
-      CppSupport
+      Aihc.Parser
+    , Aihc.Parser.Syntax
+    , Aihc.Parser.Lex
+    , Aihc.Parser.Shorthand
+    , Aihc.Parser.Pretty
+    , Aihc.Parser.Types
+    , Aihc.Parser.Lex.Header
+    , Aihc.Parser.Lex.Layout
+    , Aihc.Parser.Lex.Numbers
+    , Aihc.Parser.Lex.Pragmas
+    , Aihc.Parser.Lex.Quoted
+    , Aihc.Parser.Lex.Trivia
+    , Aihc.Parser.Lex.Types
+    , Aihc.Parser.Internal.CheckPattern
+    , Aihc.Parser.Internal.Common
+    , Aihc.Parser.Internal.Expr
+    , Aihc.Parser.Internal.Decl
+    , Aihc.Parser.Internal.Module
+    , Aihc.Parser.Internal.FromTokens
+    , CppSupport
     , ParserQuickCheck.CLI
     , ParserQuickCheck.Registry
     , ParserQuickCheck.Runner
@@ -157,7 +196,6 @@ executable parser-quickcheck-batch
     , Test.Properties.TypeRoundTrip
   build-depends:
       base >=4.16 && <5
-    , aihc-parser
     , aihc-cpp
     , text
     , aeson
@@ -171,7 +209,7 @@ executable parser-quickcheck-batch
     , time
     , prettyprinter
   ghc-options:        -Wall -Werror
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable lexer-progress
   hs-source-dirs:

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -152,7 +152,7 @@ executable parser-progress
     , Cabal-syntax
     , prettyprinter
   ghc-options:        -Wall -Werror
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable parser-quickcheck-batch
   hs-source-dirs:
@@ -229,7 +229,7 @@ executable lexer-progress
     , aeson
     , yaml
   ghc-options:        -Wall -Werror
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable extension-progress
   hs-source-dirs:
@@ -258,7 +258,7 @@ executable extension-progress
     , aeson
     , bytestring
   ghc-options:        -Wall -Werror
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable hackage-tester
   hs-source-dirs:
@@ -297,7 +297,7 @@ executable hackage-tester
     , haskell-src-exts
     , prettyprinter
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable stackage-progress
   hs-source-dirs:
@@ -337,7 +337,7 @@ executable stackage-progress
     , optparse-applicative
     , prettyprinter
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable parser-fuzz
   hs-source-dirs:
@@ -396,4 +396,4 @@ test-suite parser-quickcheck-tests
     , time
     , optparse-applicative
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-  default-language: Haskell2010
+  default-language: GHC2021

--- a/components/aihc-parser/app/extension-progress/Main.hs
+++ b/components/aihc-parser/app/extension-progress/Main.hs
@@ -2,12 +2,12 @@
 
 module Main (main) where
 
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Data.List (sortOn)
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
 import ExtensionSupport
-import qualified ParserGolden as PG
+import ParserGolden qualified as PG
 import System.Environment (getArgs)
 import System.Exit (exitFailure, exitSuccess)
 

--- a/components/aihc-parser/app/hackage-tester/Main.hs
+++ b/components/aihc-parser/app/hackage-tester/Main.hs
@@ -4,25 +4,25 @@ module Main (main) where
 
 import Aihc.Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
 import Aihc.Parser.Lex (readModuleHeaderPragmas)
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import ConcurrentProgress (mapConcurrentlyBounded)
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (unless, when)
 import CppSupport (preprocessForParserIfEnabled)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Lazy.Char8 as LBS8
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS8
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import Distribution.Package (packageId, pkgVersion)
 import Distribution.PackageDescription (GenericPackageDescription (..))
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Pretty (prettyShow)
 import GHC.Conc (getNumProcessors)
-import qualified GhcOracle
+import GhcOracle qualified
 import HackageSupport
   ( FileInfo (..),
     diagToText,

--- a/components/aihc-parser/app/parser-quickcheck-batch/Main.hs
+++ b/components/aihc-parser/app/parser-quickcheck-batch/Main.hs
@@ -1,9 +1,9 @@
 module Main (main) where
 
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy.Char8 as BL8
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy.Char8 qualified as BL8
 import Data.Maybe (fromMaybe)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Time.Clock (getCurrentTime)
 import ParserQuickCheck.CLI (optMaxSuccess, optProperty, optSeed, parseOptionsIO)
 import ParserQuickCheck.Registry (registeredParserProperties)

--- a/components/aihc-parser/app/stackage-progress/Main.hs
+++ b/components/aihc-parser/app/stackage-progress/Main.hs
@@ -9,7 +9,7 @@ import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
 import Control.Monad (forM_, replicateM_, when)
 import Data.List (sortBy)
 import Data.Maybe (mapMaybe)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Conc (getNumProcessors)
 import StackageProgress.CLI

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/CLI.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/CLI.hs
@@ -11,7 +11,7 @@ module StackageProgress.CLI
 where
 
 import Data.List (nub)
-import qualified Options.Applicative as OA
+import Options.Applicative qualified as OA
 import StackageProgress.Summary (SummaryOptions (..))
 
 -- | Type of parser to use on each file.

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
@@ -17,18 +17,18 @@ module StackageProgress.FileChecker
 where
 
 import Aihc.Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
-import qualified Aihc.Parser
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser qualified
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.DeepSeq (deepseq)
 import Control.Exception (evaluate)
 import Control.Monad (when)
 import CppSupport (moduleHeaderPragmas, preprocessForParserIfEnabled)
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Word (Word64)
 import GHC.Clock (getMonotonicTimeNSec)
-import qualified GhcOracle
+import GhcOracle qualified
 import HackageSupport
   ( FileInfo (..),
     diagToText,
@@ -37,7 +37,7 @@ import HackageSupport
     resolveIncludeBestEffort,
   )
 import HseExtensions (fromParserExtensions)
-import qualified Language.Haskell.Exts as HSE
+import Language.Haskell.Exts qualified as HSE
 import StackageProgress.CLI (Parser (..))
 import StackageProgress.FileCheckerTiming (maybeVerboseTimingParts)
 import StackageProgress.Summary (forceString)

--- a/components/aihc-parser/common/CppSupport.hs
+++ b/components/aihc-parser/common/CppSupport.hs
@@ -28,12 +28,12 @@ import Aihc.Parser.Syntax (Extension (CPP), ExtensionSetting (..), ModuleHeaderP
 import Data.ByteString (ByteString)
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit, toLower)
 import Data.Functor.Identity (Identity (..), runIdentity)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import System.FilePath (takeDirectory, takeExtension, (</>))
 
 preprocessForParser :: (Monad m) => FilePath -> (IncludeRequest -> m (Maybe ByteString)) -> Text -> m Result

--- a/components/aihc-parser/common/ExtensionSupport.hs
+++ b/components/aihc-parser/common/ExtensionSupport.hs
@@ -15,13 +15,13 @@ module ExtensionSupport
 where
 
 import Aihc.Cpp (resultOutput)
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import CppSupport (moduleHeaderExtensionSettings, preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd, sort, sortOn)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.IO.Utf8 as Utf8
+import Data.Text qualified as T
+import Data.Text.IO.Utf8 qualified as Utf8
 import GhcOracle (oracleModuleAstFingerprint)
 import ParserValidation (validateParser)
 import System.Directory (doesDirectoryExist, listDirectory)

--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -10,18 +10,18 @@ module GhcOracle
 where
 
 import Aihc.Cpp (resultOutput)
-import qualified Aihc.Parser.Lex as Lex
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Lex qualified as Lex
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.Exception (catch, displayException, evaluate)
 import CppSupport (preprocessForParserWithoutIncludes)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified GHC.Data.EnumSet as EnumSet
+import Data.Text qualified as T
+import GHC.Data.EnumSet qualified as EnumSet
 import GHC.Data.FastString (mkFastString)
 import GHC.Data.StringBuffer (stringToStringBuffer)
 import GHC.Hs (GhcPs, HsModule)
-import qualified GHC.LanguageExtensions.Type as GHC
+import GHC.LanguageExtensions.Type qualified as GHC
 import GHC.Parser (parseModule)
 import GHC.Parser.Lexer
   ( PState,

--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -14,18 +14,18 @@ module HackageSupport
 where
 
 import Aihc.Cpp (Diagnostic (..), IncludeKind (..), IncludeRequest (..), Severity (..))
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.Monad (forM, when)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Char (toLower)
 import Data.List (isPrefixOf, isSuffixOf, nub, sortOn)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
-import qualified Data.Version as DV
+import Data.Version qualified as DV
 import Distribution.Compiler (CompilerFlavor (..))
 import Distribution.ModuleName (ModuleName, toFilePath)
 import Distribution.PackageDescription

--- a/components/aihc-parser/common/HackageTester/CLI.hs
+++ b/components/aihc-parser/common/HackageTester/CLI.hs
@@ -5,7 +5,7 @@ module HackageTester.CLI
   )
 where
 
-import qualified Options.Applicative as OA
+import Options.Applicative qualified as OA
 
 data Options = Options
   { optPackage :: String,

--- a/components/aihc-parser/common/HseExtensions.hs
+++ b/components/aihc-parser/common/HseExtensions.hs
@@ -9,10 +9,10 @@ module HseExtensions
   )
 where
 
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Data.Maybe (listToMaybe, mapMaybe)
-import qualified Data.Text as T
-import qualified Language.Haskell.Exts as HSE
+import Data.Text qualified as T
+import Language.Haskell.Exts qualified as HSE
 import Text.Read (readMaybe)
 
 toHseExtension :: Syntax.Extension -> Maybe HSE.Extension

--- a/components/aihc-parser/common/LexerGolden.hs
+++ b/components/aihc-parser/common/LexerGolden.hs
@@ -24,10 +24,10 @@ import Data.Aeson.Types (parseEither, withObject)
 import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, isPrefixOf, sort)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.IO.Utf8 as Utf8
-import qualified Data.Yaml as Y
+import Data.Text.IO.Utf8 qualified as Utf8
+import Data.Yaml qualified as Y
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
 import Text.Read (readMaybe)

--- a/components/aihc-parser/common/ParserErrorGolden.hs
+++ b/components/aihc-parser/common/ParserErrorGolden.hs
@@ -12,18 +12,18 @@ module ParserErrorGolden
 where
 
 import Aihc.Parser (ParserConfig (..), defaultConfig, formatParseErrors, parseModule)
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Data.Aeson ((.:))
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Types (parseEither, withObject)
 import Data.Char (toLower)
 import Data.List (sort)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.IO as TIO
-import qualified Data.Yaml as Y
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
 import GhcOracle (oracleModuleAstFingerprint)
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (makeRelative, takeDirectory, takeExtension, (</>))

--- a/components/aihc-parser/common/ParserGolden.hs
+++ b/components/aihc-parser/common/ParserGolden.hs
@@ -36,13 +36,13 @@ import Data.Aeson.Types (parseEither, withObject)
 import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.IO as TIO
-import qualified Data.Yaml as Y
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
-import qualified Text.Megaparsec.Error as MPE
+import Text.Megaparsec.Error qualified as MPE
 
 data CaseKind = CaseExpr | CaseModule | CasePattern deriving (Eq, Show)
 

--- a/components/aihc-parser/common/ParserQuickCheck/CLI.hs
+++ b/components/aihc-parser/common/ParserQuickCheck/CLI.hs
@@ -5,7 +5,7 @@ module ParserQuickCheck.CLI
   )
 where
 
-import qualified Options.Applicative as OA
+import Options.Applicative qualified as OA
 
 data Options = Options
   { optMaxSuccess :: Int,

--- a/components/aihc-parser/common/ParserQuickCheck/Runner.hs
+++ b/components/aihc-parser/common/ParserQuickCheck/Runner.hs
@@ -16,7 +16,7 @@ where
 import Data.Char (ord)
 import Data.List (find)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)

--- a/components/aihc-parser/common/ParserQuickCheck/Types.hs
+++ b/components/aihc-parser/common/ParserQuickCheck/Types.hs
@@ -15,9 +15,9 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Bits (xor)
 import Data.Char (ord)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 

--- a/components/aihc-parser/common/ParserValidation.hs
+++ b/components/aihc-parser/common/ParserValidation.hs
@@ -8,10 +8,10 @@ module ParserValidation
 where
 
 import Aihc.Parser (ParserConfig (..), defaultConfig, formatParseErrors, parseModule)
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified GhcOracle
+import Data.Text qualified as T
+import GhcOracle qualified
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 

--- a/components/aihc-parser/common/ShrinkUtils.hs
+++ b/components/aihc-parser/common/ShrinkUtils.hs
@@ -24,7 +24,7 @@ where
 
 import Data.Char (isAlphaNum, isUpper)
 import Data.List (intercalate)
-import qualified Language.Haskell.Exts as HSE
+import Language.Haskell.Exts qualified as HSE
 
 candidateTransformsWith :: (String -> [String]) -> HSE.Module HSE.SrcSpanInfo -> [HSE.Module HSE.SrcSpanInfo]
 candidateTransformsWith shrinkSegment modu =

--- a/components/aihc-parser/common/StackageProgress/Summary.hs
+++ b/components/aihc-parser/common/StackageProgress/Summary.hs
@@ -26,7 +26,7 @@ module StackageProgress.Summary
 where
 
 import Data.Char (isSpace)
-import qualified Data.List as List
+import Data.List qualified as List
 
 data PackageSpec = PackageSpec
   { pkgName :: String,

--- a/components/aihc-parser/src/Aihc/Parser/Internal/FromTokens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/FromTokens.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_HADDOCK hide #-}
-
 -- |
 -- Module      : Aihc.Parser.Internal.FromTokens
 -- Description : Internal parsing functions from token streams

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -7,7 +7,7 @@ import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions, readModuleHeaderExtensions, readModuleHeaderExtensionsFromChunks)
 import Aihc.Parser.Syntax
 import Data.List (isInfixOf)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import ParserValidation (validateParser)
 import Test.ErrorMessages.Suite (errorMessageTests)
 import Test.ExtensionMapping.Suite (extensionMappingTests)
@@ -26,8 +26,8 @@ import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimin
 import Test.StackageProgress.Summary (stackageProgressSummaryTests)
 import Test.Tasty
 import Test.Tasty.HUnit
-import qualified Test.Tasty.QuickCheck as QC
-import qualified Text.Megaparsec.Error as MPE
+import Test.Tasty.QuickCheck qualified as QC
+import Text.Megaparsec.Error qualified as MPE
 
 tenMinutes :: Timeout
 tenMinutes = Timeout (10 * 60 * 1000000) "10m"

--- a/components/aihc-parser/test/Test/ErrorMessages/Suite.hs
+++ b/components/aihc-parser/test/Test/ErrorMessages/Suite.hs
@@ -6,8 +6,8 @@ module Test.ErrorMessages.Suite
 where
 
 import Control.Monad (unless, when)
-import qualified Data.Text as T
-import qualified ParserErrorGolden as PEG
+import Data.Text qualified as T
+import ParserErrorGolden qualified as PEG
 import System.FilePath (takeExtension)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase)

--- a/components/aihc-parser/test/Test/ExtensionMapping/Suite.hs
+++ b/components/aihc-parser/test/Test/ExtensionMapping/Suite.hs
@@ -3,15 +3,15 @@ module Test.ExtensionMapping.Suite
   )
 where
 
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Data.List (intercalate, sort)
 import Data.Maybe (isNothing)
-import qualified Data.Set as Set
-import qualified Data.Text as T
-import qualified GHC.Driver.DynFlags as DynFlags
-import qualified GHC.LanguageExtensions.Type as GHC
-import qualified Language.Haskell.Extension as Cabal
-import qualified Language.Haskell.TH.Syntax as TH
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import GHC.Driver.DynFlags qualified as DynFlags
+import GHC.LanguageExtensions.Type qualified as GHC
+import Language.Haskell.Extension qualified as Cabal
+import Language.Haskell.TH.Syntax qualified as TH
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
 

--- a/components/aihc-parser/test/Test/HackageTester/Suite.hs
+++ b/components/aihc-parser/test/Test/HackageTester/Suite.hs
@@ -6,13 +6,13 @@ module Test.HackageTester.Suite
 where
 
 import Aihc.Cpp (IncludeKind (..), IncludeRequest (..), Result (..))
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.Exception (bracket)
 import CppSupport (preprocessForParserIfEnabled)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.List (isSuffixOf)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import GhcOracle (oracleModuleAstFingerprint)
 import HackageSupport (fileInfoPath, findTargetFilesFromCabal, resolveIncludeBestEffort)
 import HackageTester.CLI (Options (..), parseOptionsPure)

--- a/components/aihc-parser/test/Test/Lexer/Suite.hs
+++ b/components/aihc-parser/test/Test/Lexer/Suite.hs
@@ -6,8 +6,8 @@ module Test.Lexer.Suite
 where
 
 import Control.Monad (unless, when)
-import qualified Data.Text as T
-import qualified LexerGolden as LG
+import Data.Text qualified as T
+import LexerGolden qualified as LG
 import System.FilePath (takeExtension)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase, testCaseInfo)

--- a/components/aihc-parser/test/Test/Oracle/Suite.hs
+++ b/components/aihc-parser/test/Test/Oracle/Suite.hs
@@ -7,7 +7,7 @@ where
 
 import Control.Monad (when)
 import Data.Text (Text)
-import qualified Data.Text.IO as TIO
+import Data.Text.IO qualified as TIO
 import ExtensionSupport
   ( CaseMeta (..),
     Expected (..),

--- a/components/aihc-parser/test/Test/Parser/Suite.hs
+++ b/components/aihc-parser/test/Test/Parser/Suite.hs
@@ -6,8 +6,8 @@ module Test.Parser.Suite
 where
 
 import Control.Monad (unless, when)
-import qualified Data.Text as T
-import qualified ParserGolden as PG
+import Data.Text qualified as T
+import ParserGolden qualified as PG
 import System.FilePath (takeExtension)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase, testCaseInfo)

--- a/components/aihc-parser/test/Test/Performance/Suite.hs
+++ b/components/aihc-parser/test/Test/Performance/Suite.hs
@@ -14,10 +14,10 @@ import Data.Aeson.Types (parseEither, withObject)
 import Data.Char (chr, toLower)
 import Data.List (sort)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import qualified Data.Text.IO as TIO
-import qualified Data.Yaml as Y
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
 import ParserGolden (ExpectedStatus (..))
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (takeExtension, (</>))

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -17,7 +17,7 @@ import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Char (isSpace)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
 

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -8,13 +8,13 @@ where
 
 import Aihc.Parser
 import Aihc.Parser.Syntax
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Coverage (assertCtorCoverage)
 import Test.Properties.ExprHelpers (genExpr, normalizeExpr, shrinkExpr)
 import Test.QuickCheck
-import qualified Text.Megaparsec.Error as MPE
+import Text.Megaparsec.Error qualified as MPE
 
 exprConfig :: ParserConfig
 exprConfig =

--- a/components/aihc-parser/test/Test/Properties/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Identifiers.hs
@@ -9,7 +9,7 @@ where
 
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Test.QuickCheck (Gen, chooseInt, elements, shrink, vectorOf)
 
 genIdent :: Gen Text

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -10,7 +10,7 @@ import Aihc.Parser
 import Aihc.Parser.Syntax
 import Data.List (nub)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.ExprHelpers (genExpr, normalizeExpr, shrinkExpr, span0)

--- a/components/aihc-parser/test/Test/Properties/NoExceptions.hs
+++ b/components/aihc-parser/test/Test/Properties/NoExceptions.hs
@@ -32,12 +32,12 @@ import Aihc.Parser.Lex
     lexTokens,
   )
 import Aihc.Parser.Syntax (ExtensionSetting (..), SourceSpan (..))
-import qualified Aihc.Parser.Syntax as Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.DeepSeq (NFData (..), force)
 import Control.Exception (SomeException, evaluate, try)
 import CppSupport (preprocessForParserWithoutIncludes)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Test.QuickCheck
 
 prop_preprocessorArbitraryTextNoExceptions :: Property

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -10,14 +10,14 @@ import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parsePat
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Coverage (assertCtorCoverage)
 import Test.Properties.ExprHelpers (normalizeExpr)
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
-import qualified Text.Megaparsec.Error as MPE
+import Text.Megaparsec.Error qualified as MPE
 
 span0 :: SourceSpan
 span0 = noSourceSpan

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -10,14 +10,14 @@ import Aihc.Parser
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Coverage (assertCtorCoverage)
 import Test.Properties.ExprHelpers (normalizeExpr)
 import Test.Properties.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
-import qualified Text.Megaparsec.Error as MPE
+import Text.Megaparsec.Error qualified as MPE
 
 span0 :: SourceSpan
 span0 = noSourceSpan

--- a/components/aihc-parser/test/quickcheck-batch/Test/ParserQuickCheck/Runner.hs
+++ b/components/aihc-parser/test/quickcheck-batch/Test/ParserQuickCheck/Runner.hs
@@ -6,7 +6,7 @@ module Test.ParserQuickCheck.Runner
   )
 where
 
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime (..))


### PR DESCRIPTION
Move `Aihc.Parser.Internal.FromTokens` from `exposed-modules` to `other-modules` in the library, and compile it directly in the test suite and `parser-quickcheck-batch` executable via `src` in `hs-source-dirs`.

Also remove the `OPTIONS_HADDOCK hide` pragma since the module is no longer exposed.

This keeps the module hidden from external consumers while still allowing the test suite to use its functions.