### PR TITLE
fix(lexer): reject invalid leading underscores in numeric literals

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Numbers.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Numbers.hs
@@ -96,8 +96,14 @@ lexHexFloat env st =
 lexFloat :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexFloat env st =
   let allowUnderscores = hasExt NumericUnderscores env
-      (lhsRaw, rest) = takeDigitsWithUnderscores allowUnderscores isDigit (lexerInput st)
-   in if T.null lhsRaw
+      input = lexerInput st
+      -- Reject if input starts with underscore (e.g. _123 is not a number)
+      startsWithUnderscore =
+        case input of
+          '_' :< _ -> True
+          _ -> False
+      (lhsRaw, rest) = takeDigitsWithUnderscores allowUnderscores isDigit input
+   in if T.null lhsRaw || startsWithUnderscore
         then Nothing
         else case rest of
           '.' :< dotRest@(d :< _)
@@ -125,8 +131,14 @@ lexFloat env st =
 lexInt :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexInt env st =
   let allowUnderscores = hasExt NumericUnderscores env
-      (digitsRaw, _) = takeDigitsWithUnderscores allowUnderscores isDigit (lexerInput st)
-   in if T.null digitsRaw
+      input = lexerInput st
+      -- Reject if input starts with underscore (e.g. _123 is not a number)
+      startsWithUnderscore =
+        case input of
+          '_' :< _ -> True
+          _ -> False
+      (digitsRaw, _) = takeDigitsWithUnderscores allowUnderscores isDigit input
+   in if T.null digitsRaw || startsWithUnderscore
         then Nothing
         else
           let digits = T.filter (/= '_') digitsRaw
@@ -161,8 +173,13 @@ takeExponent allowUnderscores chars =
                             case rest2 of
                               sign :< more | sign `elem` ("+-" :: String) -> (T.singleton sign, more)
                               _ -> ("", rest2)
+                          -- Reject underscore after exponent sign (e.g. 1e+_23)
+                          digitsStartWithUnderscore =
+                            case rest3 of
+                              '_' :< _ -> True
+                              _ -> False
                           (digits, rest4) = takeDigitsWithUnderscores allowUnderscores isDigit rest3
-                       in if T.null digits
+                       in if T.null digits || digitsStartWithUnderscore
                             then ("", chars)
                             else
                               let consumed = T.take (T.length chars - T.length rest4) chars
@@ -174,8 +191,13 @@ takeExponent allowUnderscores chars =
                 case rest of
                   sign :< more | sign `elem` ("+-" :: String) -> (T.singleton sign, more)
                   _ -> ("", rest)
+              -- Reject underscore after exponent sign (e.g. 1e+_23 or 1e_23)
+              digitsStartWithUnderscore =
+                case rest1 of
+                  '_' :< _ -> True
+                  _ -> False
               (digits, rest2) = takeDigitsWithUnderscores allowUnderscores isDigit rest1
-           in if T.null digits then ("", chars) else let consumed = T.take (T.length chars - T.length rest2) chars in (consumed, rest2)
+           in if T.null digits || digitsStartWithUnderscore then ("", chars) else let consumed = T.take (T.length chars - T.length rest2) chars in (consumed, rest2)
     _ -> ("", chars)
 
 takeHexExponent :: Text -> Maybe Text

--- a/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/decimal-invalid-leading-underscore.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/decimal-invalid-leading-underscore.yaml
@@ -1,0 +1,9 @@
+# Testing: _0001 (invalid - leading underscore on integer)
+# GHC treats this as a variable/hole, not a number.
+extensions:
+  - NumericUnderscores
+input: "_0001"
+tokens:
+  - 'TkVarId "_0001"'
+  - "TkEOF"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/float-invalid-underscore-after-dot.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/float-invalid-underscore-after-dot.yaml
@@ -1,5 +1,5 @@
 # Testing: 0._0001
-# Match GHC by splitting this as 0 . _0001 rather than a float token.
+# GHC splits this as 0 . _0001 rather than a float token.
 extensions:
   - NumericUnderscores
 input: "0._0001"
@@ -8,5 +8,4 @@ tokens:
   - 'TkVarSym "."'
   - 'TkVarId "_0001"'
   - "TkEOF"
-status: xfail
-reason: "lexer accepts underscore after decimal point"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/float-invalid-underscore-after-e-no-sign.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/float-invalid-underscore-after-e-no-sign.yaml
@@ -1,0 +1,10 @@
+# Testing: 1e_23 (invalid - underscore directly after exponent marker)
+# GHC parses this as 1 followed by variable e_23, not a float.
+extensions:
+  - NumericUnderscores
+input: "1e_23"
+tokens:
+  - "TkInteger 1"
+  - 'TkVarId "e_23"'
+  - "TkEOF"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/float-invalid-underscore-after-sign.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/numeric-underscores/float-invalid-underscore-after-sign.yaml
@@ -1,5 +1,5 @@
 # Testing: 1e+_23 (invalid - underscore after sign in exponent)
-# Per GHC docs, this should be invalid
+# Per GHC docs, this should be invalid. Lexer splits it into separate tokens.
 extensions:
   - NumericUnderscores
 input: "1e+_23"
@@ -9,5 +9,4 @@ tokens:
   - 'TkVarSym "+"'
   - 'TkVarId "_23"'
   - "TkEOF"
-status: xfail
-reason: "lexer accepts underscore after sign in exponent"
+status: pass


### PR DESCRIPTION
## Summary

Fix three bugs in `NumericUnderscores` handling to match GHC behavior:

1. **`lexInt`** now rejects input starting with `_` (e.g., `_0001` is lexed as an identifier, not a number)
2. **`lexFloat`** now rejects input starting with `_` (e.g., `0._0001` is split into `0`, `.`, `_0001`)
3. **`takeExponent`** now rejects `_` after exponent marker or sign (e.g., `1e_23` and `1e+_23` are no longer accepted as floats)

### Underscore rules (matching GHC)
| Pattern | Valid? |
|---------|--------|
| `1_000` | Yes |
| `_1000` | No |
| `1000_` | No (split into `1000` + `_`) |
| `0x_10` | Yes |
| `_0x10` | No |
| `0._0001` | No (split into `0`, `.`, `_0001`) |
| `1e_23` | No (split into `1`, `e_23`) |
| `1e+_23` | No (split into `1`, `e`, `+`, `_23`) |
| `1_e23` | Yes |

## Progress Changes

Lexer tests: `81/81` → `83/83` (100% → 100%)
- Promoted 2 xfail fixtures to pass
- Added 2 new regression tests