### PR TITLE
fix(parser): resolve as-pattern vs type application ambiguity in lexer

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -483,11 +483,19 @@ lexTypeApplication env st
       case lexerInput st of
         '@' :< rest
           | not (startsWithSymOp rest) ->
-              let st' = advanceChars "@" st
-                  kind
-                    | canStartTypeAtomT rest = TkTypeApp
-                    | otherwise = TkVarSym "@"
-               in Just (mkToken st st' "@" kind, st')
+              -- GHC requires whitespace before @ in type applications.
+              -- Without whitespace, @ is the as-pattern operator (TkReservedAt).
+              -- With whitespace, it can be a type application (TkTypeApp).
+              if lexerHadTrivia st
+                then
+                  let st' = advanceChars "@" st
+                      kind
+                        | canStartTypeAtomT rest = TkTypeApp
+                        | otherwise = TkVarSym "@"
+                   in Just (mkToken st st' "@" kind, st')
+                else
+                  let st' = advanceChars "@" st
+                   in Just (mkToken st st' "@" TkReservedAt, st')
         _ -> Nothing
   where
     canStartTypeAtomT t =

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/block-args-lambda-as-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/block-args-lambda-as-pattern.yaml
@@ -1,5 +1,0 @@
-extensions: [GHC2021, BlockArguments]
-input: |
-  f = g \x@(Y a) -> z
-status: xfail
-reason: As-pattern in lambda passed as argument with BlockArguments and GHC2021.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/block-args-lambda-as-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/block-args-lambda-as-pattern.yaml
@@ -1,0 +1,5 @@
+extensions: [GHC2021, BlockArguments]
+input: |
+  f = g \x@(Y a) -> z
+ast: Module {decls = [DeclValue (FunctionBind "f" [Match {headForm = Prefix, rhs = UnguardedRhs (EApp (EVar "g") (ELambdaPats [PAs "x" (PParen (PCon "Y" [PVar "a"]))] (EVar "z")))}])]}
+status: pass


### PR DESCRIPTION
## Root Cause

The lexer incorrectly tokenized `@` as `TkTypeApp` in as-pattern contexts like `\x@(Y a)`, causing parse failures when `BlockArguments` was enabled.

The lexer's `lexTypeApplication` function checked if the character after `@` could start a type atom (`(` can), but didn't consider whether whitespace preceded the `@`. This caused it to emit `TkTypeApp` for as-patterns, which the parser rejected.

## Solution

GHC requires whitespace before `@` in type applications (e.g., `g @Int`), while as-patterns have no whitespace (e.g., `x@(Y a)`). The fix uses `lexerHadTrivia` to disambiguate:

- **Whitespace before `@`**: produce `TkTypeApp` (type application)
- **No whitespace**: produce `TkReservedAt` (as-pattern operator)

This matches GHC's behavior, which rejects `g@Int` with: *"Type application syntax requires a space before '@'"*.

## Changes

| File | Change |
|------|--------|
| `src/Aihc/Parser/Lex.hs` | Updated `lexTypeApplication` to check `lexerHadTrivia` before producing `TkTypeApp` |
| `test/.../expr/block-args-lambda-as-pattern.yaml` | Moved to `module/` folder (contains module-level code) |
| `test/.../module/block-args-lambda-as-pattern.yaml` | Updated status from `xfail` to `pass` with AST |

## Test Results

- All 1201 parser tests pass
- `nix flake check` passes (all 18 checks)
- Oracle test `BlockArguments/as-pattern-lambda` also passes

## Progress

This PR increases the parser completion count by 1 (resolves an `xfail` test).