### PR TITLE
fix(parser): handle NondecreasingIndentation in layout engine

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -119,7 +119,7 @@ lexTokensFromChunksWithExtensions = lexChunksWithExtensions False "<input>"
 
 lexChunksWithExtensions :: Bool -> FilePath -> [Extension] -> [Text] -> [LexToken]
 lexChunksWithExtensions enableModuleLayout sourceName exts chunks =
-  applyLayoutTokens enableModuleLayout (scanTokens env initialLexerState)
+  applyLayoutTokens enableModuleLayout exts (scanTokens env initialLexerState)
   where
     (env, initialLexerState) = mkInitialLexerState sourceName exts (T.concat chunks)
 

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -8,12 +8,12 @@ module Aihc.Parser.Lex.Layout
 where
 
 import Aihc.Parser.Lex.Types
-import Aihc.Parser.Syntax (SourceSpan (..))
+import Aihc.Parser.Syntax (Extension, SourceSpan (..))
 import Data.Maybe (fromMaybe)
 
-applyLayoutTokens :: Bool -> [LexToken] -> [LexToken]
-applyLayoutTokens enableModuleLayout =
-  go (mkInitialLayoutState enableModuleLayout)
+applyLayoutTokens :: Bool -> [Extension] -> [LexToken] -> [LexToken]
+applyLayoutTokens enableModuleLayout exts =
+  go (mkInitialLayoutState enableModuleLayout exts)
   where
     go st toks =
       case toks of
@@ -82,7 +82,10 @@ openImplicitLayout kind st tok =
       openTok = virtualSymbolToken "{" (lexTokenSpan tok)
       closeTok = virtualSymbolToken "}" (lexTokenSpan tok)
       newContext = LayoutImplicit col kind
-   in if col <= parentIndent
+      -- Under NondecreasingIndentation, a nested context at the same level
+      -- as its parent is allowed (produces normal layout, not empty {}).
+      opensEmpty = if layoutNondecreasingIndent st then col < parentIndent else col <= parentIndent
+   in if opensEmpty
         then ([openTok, closeTok], st {layoutPendingLayout = Nothing}, False)
         else
           ( [openTok],

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -42,6 +42,7 @@ module Aihc.Parser.Lex.Types
 where
 
 import Aihc.Parser.Syntax
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.DeepSeq (NFData)
 import Data.Char (ord)
 import Data.Set (Set)
@@ -252,7 +253,8 @@ data LayoutState = LayoutState
     layoutPrevTokenKind :: !(Maybe LexTokenKind),
     layoutModuleMode :: !ModuleLayoutMode,
     layoutPrevTokenEndSpan :: !(Maybe SourceSpan),
-    layoutBuffer :: [LexToken]
+    layoutBuffer :: [LexToken],
+    layoutNondecreasingIndent :: !Bool
   }
   deriving (Eq, Show)
 
@@ -287,8 +289,8 @@ mkInitialLexerState sourceName exts input =
       }
   )
 
-mkInitialLayoutState :: Bool -> LayoutState
-mkInitialLayoutState enableModuleLayout =
+mkInitialLayoutState :: Bool -> [Extension] -> LayoutState
+mkInitialLayoutState enableModuleLayout exts =
   LayoutState
     { layoutContexts = [],
       layoutPendingLayout = Nothing,
@@ -299,7 +301,8 @@ mkInitialLayoutState enableModuleLayout =
           then ModuleLayoutSeekStart
           else ModuleLayoutOff,
       layoutPrevTokenEndSpan = Nothing,
-      layoutBuffer = []
+      layoutBuffer = [],
+      layoutNondecreasingIndent = Syntax.NondecreasingIndentation `elem` exts
     }
 
 mkToken :: LexerState -> LexerState -> Text -> LexTokenKind -> LexToken

--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -152,7 +152,7 @@ emptyTokStream :: FilePath -> TokStream
 emptyTokStream _sourcePath =
   TokStream
     { tokStreamRawTokens = [],
-      tokStreamLayoutState = mkInitialLayoutState False,
+      tokStreamLayoutState = mkInitialLayoutState False [],
       tokStreamPendingPragmas = [],
       tokStreamPrevToken = Nothing,
       tokStreamExtensions = [],
@@ -166,7 +166,7 @@ mkTokStream sourceName exts input =
    in normalizeTokStream
         TokStream
           { tokStreamRawTokens = scanAllTokens env lexSt,
-            tokStreamLayoutState = mkInitialLayoutState False,
+            tokStreamLayoutState = mkInitialLayoutState False exts,
             tokStreamPendingPragmas = [],
             tokStreamPrevToken = Nothing,
             tokStreamExtensions = exts,
@@ -181,7 +181,7 @@ mkTokStreamModule sourceName baseExts input =
    in normalizeTokStream
         TokStream
           { tokStreamRawTokens = scanAllTokens env lexSt,
-            tokStreamLayoutState = mkInitialLayoutState True,
+            tokStreamLayoutState = mkInitialLayoutState True effectiveExts,
             tokStreamPendingPragmas = [],
             tokStreamPrevToken = Nothing,
             tokStreamExtensions = effectiveExts,
@@ -200,7 +200,7 @@ mkTokStreamFromTokens toks =
         TokStream
           { tokStreamRawTokens = scanAllTokens env lexSt,
             tokStreamLayoutState =
-              (mkInitialLayoutState False)
+              (mkInitialLayoutState False [])
                 { layoutBuffer = toks
                 },
             tokStreamPendingPragmas = [],

--- a/components/aihc-parser/test/Test/Fixtures/oracle/NondecreasingIndentation/nested-do-deep.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NondecreasingIndentation/nested-do-deep.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE NondecreasingIndentation #-}
+
+-- NondecreasingIndentation: deeply nested do blocks at the same indentation.
+
+module NondecreasingDeepNestedDo where
+
+f = do
+  do
+    do
+      do
+      action
+  where
+    action = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/NondecreasingIndentation/nested-do-lambda.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NondecreasingIndentation/nested-do-lambda.hs
@@ -1,8 +1,8 @@
-{- ORACLE_TEST xfail NondecreasingIndentation with nested do blocks in lambda fails to parse -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 -- NondecreasingIndentation allows nested do blocks at the same indentation level,
--- but the parser fails to handle this correctly with nested lambdas.
+-- including with nested lambdas.
 
 module NondecreasingNestedDo where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/NondecreasingIndentation/nested-do-simple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NondecreasingIndentation/nested-do-simple.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE NondecreasingIndentation #-}
+
+-- NondecreasingIndentation: simple nested do at same indentation level.
+
+module NondecreasingNestedDoSimple where
+
+f = do
+  do
+  action
+  where
+    action = undefined


### PR DESCRIPTION
## Root Cause

The layout engine did not respect the `NondecreasingIndentation` extension, causing nested do-blocks at the same indentation level to produce empty layout (`{}`), which made the parser reject valid GHC code.

**Exact root cause:** `openImplicitLayout` in `Layout.hs` used `col <= parentIndent` to decide whether a new layout context should be empty. Under `NondecreasingIndentation`, nested contexts at the same column as their parent are valid and should open normally.

**Why the current implementation allowed this:** The `LayoutState` had no access to extension flags, so the layout engine always used the standard Haskell layout rule regardless of enabled extensions.

## Solution

Added a `layoutNondecreasingIndent :: Bool` flag to `LayoutState`, passed through `applyLayoutTokens`, and used in `openImplicitLayout` to switch between:
- Standard: `col <= parentIndent` → empty layout
- NondecreasingIndentation: `col < parentIndent` → empty layout (same-level is allowed)

## Changes

- **`LayoutState`** (Types.hs): Added `layoutNondecreasingIndent` field
- **`mkInitialLayoutState`** (Types.hs): Now accepts extensions list to initialize the flag
- **`applyLayoutTokens`** (Layout.hs): Now accepts extensions parameter
- **`openImplicitLayout`** (Layout.hs): Uses relaxed check when flag is set
- **`Lex.hs`**: Updated call site to pass extensions
- **`Types.hs`**: Updated all `mkInitialLayoutState` call sites
- Updated `nested-do-lambda.hs` from xfail → pass
- Added 2 new edge case test fixtures: `nested-do-simple.hs`, `nested-do-deep.hs`

## Progress Count

xfail count: 23 → 22 (1 fixed)

## Testing

- All 1207 parser tests pass
- All 251 golden tests pass
- All 44 cpp-oracle tests pass