### PR TITLE
fix(parser): recognize string gaps before quoted terminators

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs
@@ -24,16 +24,20 @@ scanQuoted :: Char -> Text -> Either Text (Text, Text)
 scanQuoted endCh input = go 0 input
   where
     go consumed rest =
-      let (plain, special) = T.break (\c -> c == '\\' || c == endCh) rest
-          consumed' = consumed + T.length plain
-       in case T.uncons special of
-            Nothing -> Left (T.take consumed' input)
-            Just (c, tailText)
-              | c == endCh -> Right (T.take consumed' input, tailText)
-              | otherwise ->
-                  case consumedEscapeTail tailText of
-                    Just tailLen -> go (consumed' + 1 + tailLen) (T.drop tailLen tailText)
-                    Nothing -> Left (T.take (consumed' + 1) input)
+      case T.findIndex (\c -> c == '\\' || c == endCh) rest of
+        Nothing -> Left (T.take (consumed + T.length rest) input)
+        Just i ->
+          let consumed' = consumed + i
+              special = T.drop i rest
+           in if T.null special
+                then Left (T.take consumed' input)
+                else case T.head special of
+                  c
+                    | c == endCh -> Right (T.take consumed' input, T.drop 1 special)
+                    | otherwise ->
+                        case consumedEscapeTail (T.drop 1 special) of
+                          Just tailLen -> go (consumed' + 1 + tailLen) (T.drop tailLen (T.drop 1 special))
+                          Nothing -> Left (T.take (consumed' + 1) input)
 
 -- | Scan a multiline string body (after the opening @\"\"\"@) until an
 -- unescaped closing @\"\"\"@.  Returns @Right (body, rest)@ on success or
@@ -42,20 +46,26 @@ scanMultilineString :: Text -> Either Text (Text, Text)
 scanMultilineString input = go 0 input
   where
     go consumed rest =
-      let (plain, special) = T.break (\c -> c == '\\' || c == '"') rest
-          consumed' = consumed + T.length plain
-       in case T.uncons special of
-            Nothing -> Left (T.take consumed' input)
-            Just ('\\', tailText) ->
-              case consumedEscapeTail tailText of
-                Just tailLen -> go (consumed' + 1 + tailLen) (T.drop tailLen tailText)
-                Nothing -> Left (T.take (consumed' + 1) input)
-            Just ('"', _) ->
-              let (quotes, tailText) = T.span (== '"') special
-               in if T.length quotes >= 3
-                    then Right (T.take consumed' input, T.drop 3 tailText)
-                    else go (consumed' + T.length quotes) tailText
-            Just _ -> error "unreachable: break predicate only matches backslash or quote"
+      case T.findIndex (\c -> c == '\\' || c == '"') rest of
+        Nothing -> Left (T.take (consumed + T.length rest) input)
+        Just i ->
+          let consumed' = consumed + i
+              special = T.drop i rest
+           in if T.null special
+                then Left (T.take consumed' input)
+                else case T.head special of
+                  '\\' ->
+                    case consumedEscapeTail (T.drop 1 special) of
+                      Just tailLen -> go (consumed' + 1 + tailLen) (T.drop tailLen (T.drop 1 special))
+                      Nothing -> Left (T.take (consumed' + 1) input)
+                  '"' ->
+                    if "\"\"\"" `T.isPrefixOf` special
+                      then Right (T.take consumed' input, T.drop 3 special)
+                      else
+                        if "\"\"" `T.isPrefixOf` special
+                          then go (consumed' + 2) (T.drop 2 special)
+                          else go (consumed' + 1) (T.drop 1 special)
+                  _ -> error "unreachable: findIndex only returns backslash or quote"
 
 -- | Determine how much text after a backslash belongs to the current
 -- escape-like sequence for delimiter scanning purposes.
@@ -64,15 +74,15 @@ scanMultilineString input = go 0 input
 -- not incorrectly escape the following quote.
 consumedEscapeTail :: Text -> Maybe Int
 consumedEscapeTail rest =
-  case T.uncons rest of
-    Nothing -> Nothing
-    Just (c, _)
-      | isSpace c ->
-          let (ws, suffix) = T.span isSpace rest
-           in case T.uncons suffix of
-                Just ('\\', _) -> Just (T.length ws + 1)
-                _ -> Just 1
-      | otherwise -> Just 1
+  if T.null rest
+    then Nothing
+    else
+      let c = T.head rest
+       in if isSpace c
+            then case T.findIndex (not . isSpace) rest of
+              Just i | T.index rest i == '\\' -> Just (i + 1)
+              _ -> Just 1
+            else Just 1
 
 -- | Decode the body of a Haskell string literal (content between the quotes,
 -- without the surrounding @\"@ characters) natively on 'Text', avoiding the

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs
@@ -9,11 +9,9 @@ module Aihc.Parser.Lex.Quoted
   )
 where
 
-import Control.Monad.ST (runST)
 import Data.Char (chr, digitToInt, isDigit, isHexDigit, isSpace, ord)
 import Data.List qualified as List
 import Data.Maybe (mapMaybe)
-import Data.STRef.Strict (newSTRef, readSTRef, writeSTRef)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
@@ -22,63 +20,59 @@ import Data.Text.Lazy.Builder qualified as TLB
 -- | Scan a quoted string body (after the opening delimiter) until the
 -- unescaped closing character.  Returns @Right (body, rest)@ on success or
 -- @Left body@ if the input ends without a closing delimiter.
---
--- The predicate is stateful (tracking whether the previous character was an
--- unescaped backslash) via an STRef, so the only allocation is the single
--- @(Text, Text)@ pair produced by 'T.spanM'.
 scanQuoted :: Char -> Text -> Either Text (Text, Text)
-scanQuoted endCh input = runST $ do
-  escapedRef <- newSTRef False
-  (body, rest) <- T.spanM (step escapedRef) input
-  pure $ case T.uncons rest of
-    Just (_, rest') -> Right (body, rest')
-    Nothing -> Left body
+scanQuoted endCh input = go 0 input
   where
-    step escapedRef c = do
-      escaped <- readSTRef escapedRef
-      if escaped
-        then writeSTRef escapedRef False >> pure True
-        else
-          if c == endCh
-            then pure False
-            else writeSTRef escapedRef (c == '\\') >> pure True
+    go consumed rest =
+      let (plain, special) = T.break (\c -> c == '\\' || c == endCh) rest
+          consumed' = consumed + T.length plain
+       in case T.uncons special of
+            Nothing -> Left (T.take consumed' input)
+            Just (c, tailText)
+              | c == endCh -> Right (T.take consumed' input, tailText)
+              | otherwise ->
+                  case consumedEscapeTail tailText of
+                    Just tailLen -> go (consumed' + 1 + tailLen) (T.drop tailLen tailText)
+                    Nothing -> Left (T.take (consumed' + 1) input)
 
 -- | Scan a multiline string body (after the opening @\"\"\"@) until an
 -- unescaped closing @\"\"\"@.  Returns @Right (body, rest)@ on success or
 -- @Left body@ if the input ends without a closing delimiter.
---
--- Two STRefs track the escape flag and the count of consecutive unescaped
--- @\"@ characters seen so far (0, 1, or 2).  'T.spanM' stops when the third
--- @\"@ is encountered; the two accumulated quotes are stripped from the body
--- tail with 'T.dropEnd'.
 scanMultilineString :: Text -> Either Text (Text, Text)
-scanMultilineString input = runST $ do
-  escapedRef <- newSTRef False
-  quotesRef <- newSTRef (0 :: Int)
-  (body, rest) <- T.spanM (step escapedRef quotesRef) input
-  pure $
-    if T.null rest
-      then Left body
-      else Right (T.dropEnd 2 body, T.tail rest)
+scanMultilineString input = go 0 input
   where
-    step escapedRef quotesRef c = do
-      escaped <- readSTRef escapedRef
-      if escaped
-        then do
-          writeSTRef escapedRef False
-          writeSTRef quotesRef 0
-          pure True
-        else case c of
-          '\\' -> do
-            writeSTRef escapedRef True
-            writeSTRef quotesRef 0
-            pure True
-          '"' -> do
-            q <- readSTRef quotesRef
-            if q == 2
-              then pure False
-              else writeSTRef quotesRef (q + 1) >> pure True
-          _ -> writeSTRef quotesRef 0 >> pure True
+    go consumed rest =
+      let (plain, special) = T.break (\c -> c == '\\' || c == '"') rest
+          consumed' = consumed + T.length plain
+       in case T.uncons special of
+            Nothing -> Left (T.take consumed' input)
+            Just ('\\', tailText) ->
+              case consumedEscapeTail tailText of
+                Just tailLen -> go (consumed' + 1 + tailLen) (T.drop tailLen tailText)
+                Nothing -> Left (T.take (consumed' + 1) input)
+            Just ('"', _) ->
+              let (quotes, tailText) = T.span (== '"') special
+               in if T.length quotes >= 3
+                    then Right (T.take consumed' input, T.drop 3 tailText)
+                    else go (consumed' + T.length quotes) tailText
+            Just _ -> error "unreachable: break predicate only matches backslash or quote"
+
+-- | Determine how much text after a backslash belongs to the current
+-- escape-like sequence for delimiter scanning purposes.
+--
+-- We intentionally recognize string gaps here so a gap-closing backslash does
+-- not incorrectly escape the following quote.
+consumedEscapeTail :: Text -> Maybe Int
+consumedEscapeTail rest =
+  case T.uncons rest of
+    Nothing -> Nothing
+    Just (c, _)
+      | isSpace c ->
+          let (ws, suffix) = T.span isSpace rest
+           in case T.uncons suffix of
+                Just ('\\', _) -> Just (T.length ws + 1)
+                _ -> Just 1
+      | otherwise -> Just 1
 
 -- | Decode the body of a Haskell string literal (content between the quotes,
 -- without the surrounding @\"@ characters) natively on 'Text', avoiding the

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -78,6 +78,7 @@ buildTests = do
             testCase "does not misclassify line-start #) as a directive" test_lineStartHashTokenIsNotDirective,
             testCase "lexes overloaded labels as single tokens" test_overloadedLabelLexesAsSingleToken,
             testCase "lexes quoted overloaded labels" test_quotedOverloadedLabelLexes,
+            testCase "lexes string gaps before a closing quote" test_stringGapBeforeClosingQuoteLexes,
             testCase "parses overloaded label expressions" test_overloadedLabelExprParses,
             testCase "applies LINE pragmas to subsequent tokens" test_linePragmaUpdatesSpan,
             testCase "applies COLUMN pragmas to subsequent tokens" test_columnPragmaUpdatesSpan,
@@ -738,6 +739,15 @@ test_quotedOverloadedLabelLexes =
   case lexTokensWithExtensions [OverloadedLabels] "#\"The quick brown fox\"" of
     [LexToken {lexTokenKind = TkOverloadedLabel "The quick brown fox" "#\"The quick brown fox\""}, LexToken {lexTokenKind = TkEOF}] -> pure ()
     other -> assertFailure ("expected quoted overloaded label token, got: " <> show other)
+
+test_stringGapBeforeClosingQuoteLexes :: Assertion
+test_stringGapBeforeClosingQuoteLexes = do
+  case lexTokens (T.pack "\"\\\n\\\"") of
+    [LexToken {lexTokenKind = TkString ""}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    other -> assertFailure ("expected empty string token after string gap, got: " <> show other)
+  case lexTokens (T.pack "\"\\\n\\c\"") of
+    [LexToken {lexTokenKind = TkString "c"}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    other -> assertFailure ("expected string token with literal c after string gap, got: " <> show other)
 
 test_overloadedLabelExprParses :: Assertion
 test_overloadedLabelExprParses =

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/multiline-trailing-gap-before-close.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/multiline-trailing-gap-before-close.yaml
@@ -1,0 +1,12 @@
+extensions: [MultilineStrings]
+input: |
+  """
+  Line 1
+  Line 2
+  Line 3\
+  \"""
+ast: "EString \"Line 1\nLine 2\nLine 3\""
+status: pass
+comment: |
+  A string gap can appear immediately before the closing multiline delimiter.
+  The gap is collapsed before delimiter detection, so the trailing newline is omitted.

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/multiline-escaped-triple-quote.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/multiline-escaped-triple-quote.yaml
@@ -1,0 +1,9 @@
+extensions: [MultilineStrings]
+input: |
+  """
+  \"\"\"
+  """
+tokens:
+  - 'TkString "\"\"\""'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/multiline-string-gap-before-close.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/multiline-string-gap-before-close.yaml
@@ -1,0 +1,11 @@
+extensions: [MultilineStrings]
+input: |
+  """
+  Line 1
+  Line 2
+  Line 3\
+  \"""
+tokens:
+  - 'TkString "Line 1\nLine 2\nLine 3"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/multiline-unescaped-quotes.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/multiline-unescaped-quotes.yaml
@@ -1,0 +1,9 @@
+extensions: [MultilineStrings]
+input: |
+  """
+  "Hello"
+  """
+tokens:
+  - 'TkString "\"Hello\""'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-escaped-quote.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-escaped-quote.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "\"a\\\"b\""
+tokens:
+  - 'TkString "a\"b"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-escaped-quote.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-escaped-quote.yaml
@@ -1,5 +1,5 @@
 extensions: []
-input: "\"a\\\"b\""
+input: '"a\"b"'
 tokens:
   - 'TkString "a\"b"'
   - 'TkEOF'

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-close.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-close.yaml
@@ -1,5 +1,6 @@
 extensions: []
-input: "\"\\\n\\\""
+input: '"\
+  \"'
 tokens:
   - 'TkString ""'
   - 'TkEOF'

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-close.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-close.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "\"\\\n\\\""
+tokens:
+  - 'TkString ""'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-escape-looking-char.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-escape-looking-char.yaml
@@ -1,5 +1,6 @@
 extensions: []
-input: "\"\\\n\\c\""
+input: '"\
+  \c"'
 tokens:
   - 'TkString "c"'
   - 'TkEOF'

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-escape-looking-char.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-before-escape-looking-char.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "\"\\\n\\c\""
+tokens:
+  - 'TkString "c"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-mid-body.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-mid-body.yaml
@@ -1,5 +1,6 @@
 extensions: []
-input: "\"ab\\\n\\cd\""
+input: '"ab\
+  \cd"'
 tokens:
   - 'TkString "abcd"'
   - 'TkEOF'

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-mid-body.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-gap-mid-body.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "\"ab\\\n\\cd\""
+tokens:
+  - 'TkString "abcd"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/escaped-quote-with-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/escaped-quote-with-continuation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail multiline string with escaped quote and backslash-newline continuation -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE OverloadedStrings #-}
 
 x = [


### PR DESCRIPTION
## Summary
Fix quoted-literal scanning so string gaps are recognized before delimiter detection. This turns the known oracle xfail in `escaped-quote-with-continuation.hs` into a passing case and adds multiline-string coverage for the same underlying rule.

## Root cause
`scanQuoted` and `scanMultilineString` treated every unescaped backslash as "the next character is escaped".
That is not correct for Haskell string gaps.

For input like:

```haskell
"\
\"
```

GHC collapses the `\ <whitespace> \` gap first, so the following `"` is the string terminator, not an escaped quote.
Our scanner instead treated the gap-closing backslash as starting a new escape, which made it swallow the real closing quote. In the failing oracle case that caused the first string literal to consume too much input and fail the parse.

The same design weakness existed in multiline-string scanning: delimiter detection and escape processing had separate logic, and the scanner knew nothing about the string-gap grammar that the decoder already handled.

## Solution options considered
1. Patch only the oracle fixture by reclassifying it from `xfail` to `pass`.
   This would hide the bug and leave the lexer wrong for both ordinary and multiline strings.
2. Add ad-hoc special cases only to `scanQuoted`.
   This would fix the reported case but leave the same architectural hole in `scanMultilineString`.
3. Teach the shared quoted-literal scanners to recognize string gaps as a first-class lexical construct.
   This fixes ordinary strings and multiline strings with one coherent rule while keeping the change localized.

I chose option 3. It matches GHC's processing order, generalizes beyond the fixture, and keeps the implementation small enough to review.

## Changes made
- Replaced the stateful one-character escape tracking in [`Quoted.hs`](components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs) with scanners that look ahead enough to recognize string gaps.
- Added a focused unit test for normal string gaps immediately before a closing quote and before an escape-looking character.
- Added a golden parser fixture covering a multiline string gap immediately before the closing `"""` delimiter.
- Promoted `components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/escaped-quote-with-continuation.hs` from `xfail` to `pass`.

## Testing
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "string gaps before a closing quote" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern escaped-quote-with-continuation --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern multiline-trailing-gap-before-close --hide-successes'`
- `cabal test -v0 all --test-options=--hide-successes`
- `nix flake check`

## Progress impact
- Parser oracle progress improves by 1 case: `732/788` -> `733/788` (`92.89%` -> `93.02%`).
- README progress markers were not updated, per repo guidance.

## Follow-up work
- Opened #634 to track the larger refactor of sharing quoted-literal escape classification across scanning and decoding.

## CodeRabbit
- `coderabbit review --prompt-only` was attempted after local checks passed, but the review service did not return a result in a reasonable time, so this PR proceeds without a CodeRabbit report.
