### PR TITLE
fix(parser): allow type-equality constraints starting with tuple types

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -521,9 +521,14 @@ contextItemsParserWith typeParser typeAtomParser =
   where
     parenthesizedContextItemsParser = do
       items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
-      pure $ case items of
-        [item] -> [TParen (getSourceSpan item) item]
-        _ -> items
+      -- Fail if no items were parsed: empty parens () in a constraint context should be
+      -- handled by contextItemParserWith (which parses () as a tuple type), not treated
+      -- as an empty constraint list. This allows constraints like () ~ () => a to parse
+      -- correctly, where () ~ () is a single type-equality constraint.
+      case items of
+        [] -> fail "empty constraint list in parens"
+        [item] -> pure [TParen (getSourceSpan item) item]
+        _ -> pure items
 
 contextParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]
 contextParserWith = contextItemsParserWith

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-poly-arity-zero.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-poly-arity-zero.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects tilde in constrained type with zero-arity constraint -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 
 f :: (() ~ () => a) -> a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-poly-type-equality.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-poly-type-equality.hs
@@ -1,0 +1,31 @@
+{- ORACLE_TEST pass -}
+{- Tests constraint polymorphism with type equality constraints using (~). -}
+{-# LANGUAGE GHC2021 #-}
+
+-- Zero-arity constraint in parenthesized constrained type
+f1 :: (() ~ () => a) -> a
+f1 x = x
+
+-- Zero-arity constraint without outer parens
+f2 :: () ~ () => a -> a
+f2 x = x
+
+-- Multiple type equalities
+f3 :: (a ~ b, b ~ c) => a -> c
+f3 x = x
+
+-- Type equality with complex types
+f4 :: (Maybe a ~ Maybe b) => a -> b
+f4 x = x
+
+-- Type equality mixed with class constraints
+f5 :: (Eq a, a ~ b) => b -> Bool
+f5 x = x == x
+
+-- Nested constrained type
+f6 :: ((a ~ b) => a) -> b
+f6 x = x
+
+-- Type equality with Proxy
+f7 :: Proxy a ~ Proxy b => a -> b
+f7 x = x


### PR DESCRIPTION
## Root Cause

The parser rejected constraints like `()\ ~\ () => a` because `parenthesizedContextItemsParser` greedily consumed `()` as empty parentheses (returning an empty constraint list `[]`), preventing the tilde operator from being parsed as part of a type-equality constraint.

When parsing `()\ ~\ () => a`:
1. `contextItemsParserWith` tried `parenthesizedContextItemsParser`
2. `parens` opened `(`, then `contextItemParserWith` failed on `)` (not a valid constraint start inside parens)
3. `sepEndBy` returned `[]` (zero items), making the parser think the parens were empty
4. `contextTypeParser` then expected `=>` but found `~` → failure

The issue was that `()` is a valid TYPE (empty tuple), not empty parentheses. The parser confused empty constraint lists with tuple types.

## Solution

Made `parenthesizedContextItemsParser` fail when it parses zero items. This allows `contextItemParserWith` to correctly parse `()` as a tuple type via `constraintTypeParser`, and `()\ ~\ ()` as an infix type-equality constraint.

The fix is a single change in `contextItemsParserWith`:
```haskell
case items of
  [] -> fail "empty constraint list in parens"  -- NEW
  [item] -> pure [TParen (getSourceSpan item) item]
  _ -> pure items
```

## Changes

- **src/Aihc/Parser/Internal/Common.hs**: Modified `parenthesizedContextItemsParser` to fail on empty constraint lists
- **test/.../constraint-poly-arity-zero.hs**: Changed from `xfail` to `pass`
- **test/.../constraint-poly-type-equality.hs**: Added comprehensive edge case tests for type-equality constraints

## Test Results

All 1212 parser tests pass (up from 1211). `nix flake check` passes.