### PR TITLE
feat: add justfile with common development commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@
 - Create PRs: `gh pr create --base main --head <branch> --title "<title>" --body $(cat <file>)`
 - PR titles should follow the same Conventional Commits format as commit messages (see below)
 
+## Just Commands
+
+This project uses [Just](https://just.systems) as a command runner. Common commands:
+
+- `just test` — Run all tests with hidden successes
+- `just replay "<seed>"` — Replay a specific QuickCheck test case (e.g., `just replay "(SMGen 6995563131902519991 12189532712049121349,3)"`)
+- `just qc` — Run QuickCheck with 10,000 tests in an infinite loop until failure
+- `just check` — Run ormolu format check, hlint, then full test suite (useful before opening a PR)
+
+## Branch Policy
+
+**Pushes to `main` are blocked.** All work should be done in feature branches. Create a feature branch for any changes, then open a PR to merge into `main`.
+
 ## Cheatsheet
 
 - Test whether a file is accepted by GHC: `ghc -v0 -fno-code -ddump-parsed file.hs`. Return code 0 means the snippet is valid, non-zero means it is invalid.

--- a/flake.nix
+++ b/flake.nix
@@ -1224,11 +1224,15 @@
         buildInputs = [
           hsPkgs.ghc
           pkgs.cabal-install
+          pkgs.ormolu
+          pkgs.hlint
         ];
         shellHook = ''
           echo "aihc development shell"
           echo "  - GHC with project dependencies"
           echo "  - cabal-install"
+          echo "  - ormolu"
+          echo "  - hlint"
         '';
       };
     });

--- a/justfile
+++ b/justfile
@@ -16,6 +16,6 @@ qc:
 
 # Run full CI check: format, lint, then tests
 check:
-  nix develop -c ormolu --mode check $(find . -name '*.hs' -not -path './dist-*/*')
-  nix develop -c hlint .
+  nix develop --command bash -c 'ormolu --mode check $(find components -name "*.hs" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --command bash -c 'hlint $(find components -name "*.hs" -not -path "*/test/Test/Fixtures/*")'
   cabal test -v0 all --test-options='--hide-successes'

--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+# Test runner for aihc project
+# See https://just.systems for Just documentation
+
+# Run all tests with hidden successes
+test:
+  cabal test -v0 all --test-options='--hide-successes'
+
+# Replay a specific QuickCheck test case
+# Usage: just replay "<replay-string>"
+replay ARGUMENT:
+  cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-replay={{ARGUMENT}}"
+
+# Run QuickCheck with 10000 tests in a loop until failure
+qc:
+  while true; do cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000"; done
+
+# Run full CI check: format, lint, then tests
+check:
+  nix develop -c ormolu --mode check $(find . -name '*.hs' -not -path './dist-*/*')
+  nix develop -c hlint .
+  cabal test -v0 all --test-options='--hide-successes'


### PR DESCRIPTION
## Summary

Adds a `justfile` for common development commands and updates project configuration.

## Changes

- **justfile**: Added with four commands:
  - `just test` — Run all tests with hidden successes
  - `just replay "<seed>"` — Replay a specific QuickCheck test case
  - `just qc` — Run QuickCheck with 10,000 tests in an infinite loop until failure
  - `just check` — Run ormolu format check, hlint, then full test suite

- **flake.nix**: Added `ormolu` and `hlint` to the devShell

- **AGENTS.md**: 
  - Documented just commands
  - Added branch policy section (pushes to `main` are blocked)