### PR TITLE
fix(parser): preserve deriving parentheses and format instance bodies

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1388,12 +1388,12 @@ derivingClauseParser :: TokParser DerivingClause
 derivingClauseParser = do
   expectedTok TkKeywordDeriving
   strategy <- MP.optional derivingStrategyParser
-  classes <- parenClasses <|> singleClass
+  (classes, parenthesized) <- parenClasses <|> singleClass
   viaTy <- MP.optional derivingViaTypeParser
-  pure (DerivingClause strategy classes viaTy)
+  pure (DerivingClause strategy classes viaTy parenthesized)
   where
-    singleClass = (: []) <$> contextItemParserWith typeParser typeAtomParser
-    parenClasses = parens $ contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma
+    singleClass = (\c -> ([c], False)) <$> contextItemParserWith typeParser typeAtomParser
+    parenClasses = fmap (,True) $ parens $ contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma
 
 derivingViaTypeParser :: TokParser Type
 derivingViaTypeParser = do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -33,6 +33,7 @@ import Prettyprinter
     brackets,
     comma,
     hsep,
+    nest,
     parens,
     punctuate,
     semi,
@@ -652,7 +653,7 @@ derivingParts :: [DerivingClause] -> [Doc ann]
 derivingParts = concatMap derivingPart
 
 derivingPart :: DerivingClause -> [Doc ann]
-derivingPart (DerivingClause strategy classes viaTy) =
+derivingPart (DerivingClause strategy classes viaTy parenthesized) =
   ["deriving"] <> strategyPart strategy <> classesPart classes <> viaPart viaTy
   where
     strategyPart Nothing = []
@@ -662,7 +663,7 @@ derivingPart (DerivingClause strategy classes viaTy) =
 
     classesPart [] = ["()"]
     classesPart [single]
-      | Just DerivingStock <- strategy = [parens (prettyContextItem single)]
+      | parenthesized = [parens (prettyContextItem single)]
       | otherwise = [prettyContextItem single]
     classesPart _ = [parens (hsep (punctuate comma (map prettyContextItem classes)))]
 
@@ -880,7 +881,7 @@ prettyInstanceDecl decl =
           )
    in case instanceDeclItems decl of
         [] -> headDoc
-        items -> headDoc <+> "where" <+> braces (hsep (punctuate semi (map prettyInstanceItem items)))
+        items -> vsep [headDoc <+> "where", nest 2 (braces (vsep (punctuate semi (map prettyInstanceItem items))))]
 
 prettyInstanceWarning :: WarningText -> Doc ann
 prettyInstanceWarning (DeprText _ msg) = "{-# DEPRECATED " <> pretty (show msg) <> " #-}"

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -372,6 +372,7 @@ docDerivingClause dc =
       optionalField "strategy" docDerivingStrategy (derivingStrategy dc)
         <> listField "classes" docType (derivingClasses dc)
         <> optionalField "viaType" docType (derivingViaType dc)
+        <> boolField "parenthesized" (derivingParenthesized dc)
 
 docDerivingStrategy :: DerivingStrategy -> Doc ann
 docDerivingStrategy ds =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1244,7 +1244,8 @@ instance HasSourceSpan FieldDecl where
 data DerivingClause = DerivingClause
   { derivingStrategy :: Maybe DerivingStrategy,
     derivingClasses :: [Type],
-    derivingViaType :: Maybe Type
+    derivingViaType :: Maybe Type,
+    derivingParenthesized :: Bool
   }
   deriving (Data, Eq, Show, Generic, NFData)
 

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/parser-fuzz-data-deriving-empty.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/parser-fuzz-data-deriving-empty.yaml
@@ -1,5 +1,5 @@
 extensions: []
 input: |
   data A deriving ()
-ast: Module {decls = [DeclData (DataDecl {name = "A", deriving = [DerivingClause {}]})]}
+ast: Module {decls = [DeclData (DataDecl {name = "A", deriving = [DerivingClause {parenthesized = True}]})]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/pragma/SpecializeImportedUse.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/pragma/SpecializeImportedUse.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail SPECIALIZE pragma not preserved in pretty-printer roundtrip -}
+{- ORACLE_TEST pass -}
 module SpecializeImportedUse where
 
 import SpecializeImportedDef (lookupLike)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/pragma/SpecializeInstancePragma.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/pragma/SpecializeInstancePragma.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail SPECIALIZE instance pragma not preserved in pretty-printer roundtrip -}
+{- ORACLE_TEST pass -}
 module SpecializeInstancePragma where
 
 data Foo a = Foo a


### PR DESCRIPTION
## Root Cause

Two pretty-printing issues caused oracle roundtrip fingerprint mismatches (not SPECIALIZE pragma handling):

1. **Deriving clause parenthesization not tracked**: `DerivingClause` didn't record whether the source used `deriving (Eq)` vs `deriving Eq`. The pretty-printer defaulted to no parens for single-class deriving without an explicit strategy, causing GHC's `ppr` to produce different fingerprints.

2. **Instance body single-line formatting**: Instance bodies were rendered as `{ item1; item2 }` on one line via `hsep`, while GHC's `ppr` uses multi-line formatting, causing fingerprint differences.

## Solution

- Added `derivingParenthesized :: Bool` field to `DerivingClause` to track source format
- Updated parser to capture parenthesization (`parenClasses` → `True`, `singleClass` → `False`)
- Updated pretty-printer to preserve parentheses based on the tracked field
- Changed instance body formatting from `hsep` to `vsep` with `nest 2` for multi-line output

## Progress

- **Before**: 750 PASS / 16 XFAIL / 0 FAIL (97.91%)
- **After**: 752 PASS / 14 XFAIL / 0 FAIL (98.17%)

Fixed oracle tests:
- `pragma/SpecializeImportedUse`: xfail → pass
- `pragma/SpecializeInstancePragma`: xfail → pass