### PR TITLE
fix(parser): support parenthesized operators in type family names

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1298,7 +1298,9 @@ typeFamilyHeadParser =
   where
     prefixHeadParser = do
       headType <- withSpan $ do
-        name <- constructorNameParser
+        name <-
+          constructorNameParser
+            <|> (qualifyName Nothing <$> parens operatorUnqualifiedNameParser)
         pure (\span' -> TCon span' name Unpromoted)
       params <- MP.many typeParamParser
       pure (TypeHeadPrefix, headType, params)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-family-operator-extended.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-family-operator-extended.hs
@@ -1,0 +1,19 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeOperators, TypeFamilies #-}
+
+-- Additional test cases for type families with operator names.
+
+module TypeFamilyOperatorExtended where
+
+-- Parenthesized variable operator (starts with non-:)
+type family (++) a b
+
+-- Parenthesized constructor operator (starts with :)
+type family (:++:) a b
+
+-- Type family with operator and kind signature
+type family (<?>) a b :: Bool
+
+-- Multiple type families with operators
+type family (<>) a b
+type family (><) a b c

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-family-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-family-operator.hs
@@ -1,7 +1,7 @@
-{- ORACLE_TEST xfail TypeFamilies with TypeOperators fails to parse operator as type family name -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeOperators, TypeFamilies #-}
 
--- Type families with operator names are not supported by the parser.
+-- Type families with operator names are supported.
 
 module TypeFamilyOperator where
 


### PR DESCRIPTION
## Root Cause

The parser rejected type family declarations with parenthesized operator names like `type family (++) a b` because `typeFamilyHeadParser` only accepted constructor identifiers (`TkConId`) via `constructorNameParser`, not parenthesized operators.

When the lexer encountered `(++)`, it produced `TkSpecialLParen TkVarSym "++" TkSpecialRParen`, but the parser's `constructorNameParser` only matches `TkConId` or `TkQConId` tokens, causing a parse failure with the misleading error "expecting lowercase identifier".

## Solution

Added `operatorUnqualifiedNameParser` as an alternative in `typeFamilyHeadParser`, following the exact same pattern used in `typeDeclHeadParser` for type synonym declarations. This accepts both variable operators (`TkVarSym`) and constructor operators (`TkConSym`) when parenthesized.

The fix is minimal (2 lines changed), follows existing patterns, and generalizes beyond the specific failing test to support all operator forms in type family names.

## Changes

- **Parser**: Update `typeFamilyHeadParser` to accept parenthesized operators alongside constructor identifiers
- **Tests**: 
  - Changed `type-family-operator.hs` from `xfail` to `pass`
  - Added `type-family-operator-extended.hs` with comprehensive coverage:
    - Variable operators: `(++)`, `(<?>)`, `(<>)`, `(><)`
    - Constructor operators: `(:++:)`
    - Kind signatures with operators
- **Results**: All 1228 parser tests pass, including full oracle suite with no regressions

## Test Coverage

The extended test validates:
- Parenthesized variable operators (non-`:` prefix)
- Parenthesized constructor operators (`:` prefix)  
- Operators with explicit kind signatures
- Multiple operator type families in one module

## Notes

No refactoring opportunities identified. The pattern is already established in the codebase and this change maintains consistency.