### PR TITLE
fix(parser): exclude extension reserved identifiers from QuickCheck type variable generation

### DIFF
--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -18,7 +18,7 @@ import Aihc.Parser.Syntax
 import Data.Char (isSpace)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.Properties.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Identifiers (extensionReservedIdentifiers, genIdent, shrinkIdent)
 import Test.QuickCheck
 
 -- | Canonical empty source span for normalization.
@@ -439,7 +439,7 @@ genTypeVarName = do
   restLen <- chooseInt (0, 3)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['0' .. '9']))
   let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate
+  if isReservedIdentifier candidate || candidate `elem` extensionReservedIdentifiers
     then genTypeVarName
     else pure (mkUnqualifiedName NameVarId candidate)
 

--- a/components/aihc-parser/test/Test/Properties/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Identifiers.hs
@@ -4,6 +4,7 @@ module Test.Properties.Identifiers
   ( genIdent,
     shrinkIdent,
     isValidGeneratedIdent,
+    extensionReservedIdentifiers,
   )
 where
 

--- a/justfile
+++ b/justfile
@@ -3,12 +3,12 @@
 
 # Run all tests with hidden successes
 test:
-  cabal test -v0 all --test-options='--hide-successes'
+  cabal test -v0 all --test-options='--hide-successes' --test-show-details=failures
 
 # Replay a specific QuickCheck test case
 # Usage: just replay "<replay-string>"
 replay ARGUMENT:
-  cabal test aihc-parser:spec -v0 --test-options='--pattern properties --quickcheck-replay="{{ARGUMENT}}"'
+  cabal test aihc-parser:spec -v0 --test-options='--pattern properties --quickcheck-replay="{{ARGUMENT}}" --hide-successes'
 
 # Run QuickCheck with 10000 tests in a loop until failure
 qc:


### PR DESCRIPTION
## Summary

QuickCheck property tests were generating type variable names like `rec` which are reserved by language extensions (Arrows, RecursiveDo). When Template Haskell and Arrows were both enabled, `rec` inside a `[t|..|]` quote was tokenized as `TkKeywordRec`, triggering layout insertion and corrupting the parse.

## Fix

- **ExprHelpers.hs**: Updated `genTypeVarName` to exclude `extensionReservedIdentifiers` (`mdo`, `proc`, `rec`), matching the existing check in `isValidGeneratedIdent`.
- **Identifiers.hs**: Exported `extensionReservedIdentifiers` for reuse.
- **justfile**: Added `--hide-successes` to `replay` and `--test-show-details=failures` to `test` commands.

## Test Results

All 44 tests pass, including the previously failing seed:
```
just replay "(SMGen 3993269990324214422 16798228000110160783,22)"
All 5 tests passed (0.04s)
```
