### PR TITLE
fix(parser): support minus as type-level infix operator

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -528,8 +528,7 @@ contextItemParserWith typeParser typeAtomParser =
         case lexTokenKind tok of
           TkVarSym op
             | op /= "."
-                && op /= "!"
-                && op /= "-" ->
+                && op /= "!" ->
                 Just (qualifyName Nothing (mkUnqualifiedName NameVarSym op), Unpromoted)
           TkConSym op -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym op), Unpromoted)
           TkQVarSym modName op ->

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1991,7 +1991,6 @@ typeInfixOperatorParser =
           TkVarSym op
             | op /= "."
                 && op /= "!"
-                && op /= "-"
                 && op /= "'" ->
                 Just (qualifyName Nothing (mkUnqualifiedName NameVarSym op), Unpromoted)
           TkConSym op -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym op), Unpromoted)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/parenthesized-minus-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/parenthesized-minus-operator.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeOperators #-}
+
+module ParenthesizedMinusOperator where
+
+f :: Int (-) String
+f = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/subtraction-in-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/subtraction-in-constraint.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail type-level subtraction operator in constraint fails to parse -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE DataKinds #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/subtraction-type-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/subtraction-type-signature.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeOperators #-}
+
+module TypeLevelSubtractionSignature where
+
+f :: Int - String -> Bool
+f = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/subtraction-type-synonym.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/subtraction-type-synonym.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeOperators #-}
+
+module TypeLevelSubtractionSynonym where
+
+type a - b = Either a b
+
+f :: Int - String
+f = undefined


### PR DESCRIPTION
## Root Cause

The minus operator `-` was explicitly excluded from type infix operator parsing in two locations:

1. `typeInfixOperatorParser` (Expr.hs:1994)
2. `constraintTypeInfixOperatorParser` (Common.hs:532)

Both had an `op /= "-"` guard that rejected `-` as a valid type infix operator, causing parse failures like:

```
f :: KnownNat (n - m) => proxy n -> proxy m
                 ^
unexpected TkVarSym "-"
expecting type
```

This exclusion was introduced in commit 0cbeea2 (type equality constraints) without a clear rationale for specifically blocking `-`. GHC accepts `-` as a type-level infix operator under `TypeOperators`, so the parser should too.

## Solution

Removed the `op /= "-"` guards from both type infix operator parsers. This is the minimal, correct fix that aligns parser behavior with GHC.

The pretty-printer already handles `-` correctly (via `isSymbolicTypeName`), so roundtrip fingerprinting works properly.

## Changes

- **src/Aihc/Parser/Internal/Expr.hs**: Remove `op /= "-"` from `typeInfixOperatorParser`
- **src/Aihc/Parser/Internal/Common.hs**: Remove `op /= "-"` from `constraintTypeInfixOperatorParser`
- **test/.../subtraction-in-constraint.hs**: Promoted from `xfail` to `pass`
- **test/.../subtraction-type-synonym.hs**: New oracle test for `type a - b = ...`
- **test/.../subtraction-type-signature.hs**: New oracle test for `f :: Int - String -> Bool`
- **test/.../parenthesized-minus-operator.hs**: New oracle test for `Int (-) String`

## Test Results

All 1303 tests pass. No regressions.