### PR TITLE
test(parser): add oracle test cases for hackage parser failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExportSyntax/qualified-constructor-export.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExportSyntax/qualified-constructor-export.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="qualified constructor names in export list not handled" -}
+{-# LANGUAGE GHC2021 #-}
+
+module QualifiedConstructorExport (
+  M.C(M.A)
+  ) where
+
+data M = C A | B
+data A

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_singletons_type_sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_singletons_type_sig.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="TemplateHaskell singletons function with declaration quote and type signature not handled" -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module THSingletonsWithTypeSig where
+
+x = singletons [d|
+  f :: Int -> Int
+  f y = y
+  |]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-data.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-data.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="data declaration with type operator symbol :+: in parentheses not parsed correctly" -}
+{-# LANGUAGE GHC2021 #-}
+
+module TypeOperatorData where
+
+data (f :+: g) e = Left' (f e) | Right' (g e)


### PR DESCRIPTION
## Summary

Add minimal oracle test cases for three parser failures discovered during hackage package testing.

## Test Cases Added

### 1. TypeOperators/type-operator-data (from free-alacarte)
**Failure**: Data declaration with type operator symbol `:+:` in parentheses not parsed correctly
```haskell
data (f :+: g) e = Left' (f e) | Right' (g e)
```
**Error**: `unexpected :+:, expecting operator '::'`

### 2. TemplateHaskell/th_singletons_type_sig (from singleton-nats)
**Failure**: `singletons` function with declaration quote and type signature not handled
```haskell
x = singletons [d|
  f :: Int -> Int
  f y = y
  |]
```
**Error**: `unexpected =, expecting end of input`

### 3. ExportSyntax/qualified-constructor-export (from sample-frame-np)
**Failure**: Qualified constructor names in export list not handled
```haskell
module Test (M.C(M.A)) where
```
**Error**: `unexpected M.A, expecting keyword 'data', operator '..', symbol '(', symbol ')', or unqualified identifier`

## Test Results

All three test cases:
- ✅ Accepted by GHC (syntactically valid)
- ✅ Rejected by aihc-parser (parser failures confirmed)
- ✅ Added as `xfail` oracle tests with appropriate failure reasons

## Progress

This PR adds 3 new xfail test cases to the oracle test suite. These represent real-world parser gaps found during hackage package testing and will serve as regression tests once fixed.