### PR TITLE
test(parser): add oracle test cases for rollbar and union failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-backtick-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-backtick-continuation.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST xfail reason="infix backtick continuation after do block statement not parsed" -}
+{-# LANGUAGE GHC2021 #-}
+
+module RollbarInfixDo where
+
+catch :: IO a -> (String -> IO a) -> IO a
+catch = undefined
+
+test :: IO (Maybe Int)
+test = do
+    x <- return 42
+    return (Just x)
+    `catch` (\e -> return Nothing)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GADTs/gadt-promoted-cons-in-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GADTs/gadt-promoted-cons-in-type.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail reason="promoted cons operator colon in GADT type not parsed as type-level list cons" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoListTuplePuns #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module UnionPromotedCons where
+
+import Data.List (List)
+
+data Union f (as :: List u) where
+  This :: f a -> Union f (a : as)
+  That :: Union f as -> Union f (a : as)


### PR DESCRIPTION
# Add Oracle Test Cases for Rollbar and Union Parser Failures

## Summary

Adds minimal oracle test cases for two real-world parser failures discovered during hackage package testing.

## Test Cases Added

### 1. Rollbar: Infix Backtick Continuation in Do Block
- **File**: `DoAndIfThenElse/do-infix-backtick-continuation.hs`
- **Issue**: Parser fails to handle infix backtick operator (`` `catch` ``) continuing from a do block statement
- **Status**: xfail
- **Pattern**: GHC accepts do blocks where the last statement continues with an infix operator on the next line, but aihc-parser rejects it

### 2. Union: Promoted Cons Operator in GADT Type
- **File**: `GADTs/gadt-promoted-cons-in-type.hs`  
- **Issue**: Parser doesn't recognize promoted type-level cons operator (`:`) in GADT constructor return types
- **Status**: xfail
- **Pattern**: Uses `Data.List (List)` type-level lists with `a : as` syntax in GADT signatures

## Testing

Both fixtures:
- ✅ Accepted by GHC (oracle)
- ❌ Rejected by aihc-parser (matching expected xfail behavior)
- ✅ Tests pass as known failures

## Note

The `crypto-random-api` failure was investigated but determined to be a package configuration issue (GHC also rejects the file when tested), not a parser-specific bug. No fixture was added for that case.
