### PR TITLE
test(parser): add minimal oracle tests for hackage parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-block-alternative.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-block-alternative.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail do-block infix continuation with <|> operator -}
+{-# LANGUAGE GHC2021 #-}
+module AttoparsecExpr where
+
+rassocP :: Maybe Int
+rassocP = do
+  f <- Just 1
+  y <- do
+    z <- Just 2
+    Just (f + z)
+  pure (f + y)
+  <|> Just 0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/gadt-pattern-match.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/gadt-pattern-match.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeApplications #-}
+module LiftTypeRepro where
+
+typeRepToType :: SomeTypeRep -> Type
+typeRepToType (SomeTypeRep a) = go a
+  where
+    go :: Type
+    go = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/gadt-pattern-match.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/gadt-pattern-match.hs
@@ -1,9 +1,0 @@
-{- ORACLE_TEST pass -}
-{-# LANGUAGE TypeApplications #-}
-module LiftTypeRepro where
-
-typeRepToType :: SomeTypeRep -> Type
-typeRepToType (SomeTypeRep a) = go a
-  where
-    go :: Type
-    go = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-gadt-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-gadt-constraint.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail GADT constructor with type operator after constraint -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+module TypeLevelKVList where
+
+data (:=) key v
+
+data KVList xs where
+  KVCons :: KnownSymbol key => key := v -> KVList xs -> KVList ((key := v) ': xs)


### PR DESCRIPTION
## Summary

Add minimal oracle test cases reproducing parser failures found during hackage testing.

## Test Cases

### 1. Type Operator in GADT Constraint (`TypeOperators/type-operator-gadt-constraint.hs`)
- **Status**: ❌ XFAIL
- **Source**: Inspired by `type-level-kv-list-2.0.2.0`
- **Description**: Type operator `:=` after constraint in GADT constructor not parsed correctly
- **Error**: `unexpected :=` at position 9:36

### 2. Do-Block Infix Continuation (`DoAndIfThenElse/do-block-alternative.hs`)
- **Status**: ❌ XFAIL
- **Source**: Inspired by `attoparsec-expr-0.1.1.2`
- **Description**: Infix continuation with `<|>` operator in do blocks fails
- **Error**: `unexpected <|>` at position 12:3

## Investigated But Not Reproducible

### lift-type-0.1.2.0
- **Original Error**: `unexpected =` at line 78:31 in `typeRepToType (SomeTypeRep a) = go a`
- **Investigation**: The parser accepts all minimal variants I tried. The failure only occurs with the full original file (200 lines). 
- **Hypothesis**: There may be a layout-sensitive bug or cumulative parser state issue that only manifests with the complete file content.
- **Recommendation**: Fix the two xfails above first, then retest lift-type to see if the issue persists or resolves.

## Progress Counts

- **Oracle tests added**: 2
- **New xfails**: 2