### PR TITLE
test(parser): add minimal oracle fixtures for hackage parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/multiple-operator-patterns.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/multiple-operator-patterns.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail multiple operator patterns in function definition -}
+module MultipleOperatorPatterns where
+
+data Expr a = Const a | Plus a a | Minus a a | Times a a | Divide a a
+
+foldExpr c (+) (-) (*) (/) = fold
+  where
+    fold x = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/question-mark-operator-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/question-mark-operator-pattern.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail operator pattern with question marks -}
+module QuestionMarkOperatorPattern where
+
+foldl' (??) z xs = (foldr (?!) id xs) z
+  where
+    x ?! g = g . (?? x)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RecordWildCards/do-tuple-as-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RecordWildCards/do-tuple-as-pattern.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail do-block tuple pattern with as-pattern and record wildcards -}
+{-# LANGUAGE RecordWildCards #-}
+module DoTupleAsPattern where
+
+data T = T { field :: Int }
+
+f mx = do
+  (a, b@T {..}) <- mx
+  return undefined


### PR DESCRIPTION
## Summary

Add minimized oracle test cases for three parse failures discovered during hackage package testing.

## Test Cases Added

### 1. `RecordWildCards/do-tuple-as-pattern.hs` (from aws-xray-client-wai)
- **Parser gap**: Do-block tuple pattern with as-pattern and record wildcards
- **Fails with**: `unexpected TkReservedAt` in `(a, b@T {..}) <- mx`
- **GHC accepts**: Yes

### 2. `PatternSyntax/multiple-operator-patterns.hs` (from dice)  
- **Parser gap**: Multiple operator patterns in function definition
- **Fails with**: `unexpected TkVarSym "+"` in `foldExpr c (+) (-) (*) (/) = fold`
- **GHC accepts**: Yes

### 3. `PatternSyntax/question-mark-operator-pattern.hs` (from transaction)
- **Parser gap**: Operator pattern with question mark operators
- **Fails with**: `unexpected TkVarSym "??"` in `foldl' (??) z xs = ...`
- **GHC accepts**: Yes

## Progress Counts

- New xfail test cases: 3
- Total parser fixtures: 784 → 787