### PR TITLE
test(oracle): add xfail for ''(->) TemplateHaskell quote parsing

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-promoted-arrow.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-promoted-arrow.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="TemplateHaskell type quote with parenthesized arrow ''(->) not parsed" -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module THQuotePromotedArrow where
+
+f = ''(->)


### PR DESCRIPTION
## Summary

Added an oracle xfail test case for a TemplateHaskell parsing limitation: `''(->)` (type quote with parenthesized arrow) is not parsed correctly by aihc-parser but is accepted by GHC.

## Minimized Test Case

```haskell
{-# LANGUAGE TemplateHaskell #-}

module THQuotePromotedArrow where

f = ''(->)
```

## Details

- GHC accepts this code without parse errors
- aihc-parser fails with `unexpected = expecting end of input`
- The issue is specific to `''(->)` - other type quotes like `''Maybe` parse correctly