### PR TITLE
test(parser): add minimized oracle test cases for hackage failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/bare-let-in-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/bare-let-in-do.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="Bare let in do block without bindings not handled" -}
+{-# LANGUAGE Haskell2010 #-}
+
+module BareLetInDo where
+
+test = do
+  let
+  x <- undefined
+  return ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/operator-section-in-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/operator-section-in-pattern.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST xfail reason="Operator section in pattern position not handled" -}
+{-# LANGUAGE Haskell2010 #-}
+
+module OperatorSectionInPattern where
+
+class Eq1 f where
+  liftEq :: (a -> b -> Bool) -> f a -> f b -> Bool
+
+data Free f a = Pure a | Impure (f (Free f a))
+
+instance Eq1 f => Eq1 (Free f) where
+  liftEq (==) (Pure a) (Pure b) = a == b
+  liftEq (==) (Impure a) (Impure b) = undefined
+  liftEq _ _ _ = False

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-tick-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-tick-operator.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="TemplateHaskell quote tick for type operator not handled" -}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE DataKinds #-}
+
+module THQuoteTickOperator where
+
+type (:>) a b = '(a, b)
+
+test = ''(:>)


### PR DESCRIPTION
## Summary

Add three minimized oracle test cases from real-world Hackage parser failures. All tests are marked `xfail` and demonstrate parser gaps that need to be addressed.

## Test Cases

### 1. Bare `let` in do block (ses-html)
- **Fixture**: `DoAndIfThenElse/bare-let-in-do.hs`
- **Issue**: Parser rejects bare `let` keyword without bindings in do blocks
- **Original Package**: ses-html-0.4.0.0

### 2. TemplateHaskell quote tick for operators (effectful-th)
- **Fixture**: `TemplateHaskell/th-quote-tick-operator.hs`
- **Issue**: Parser doesn't handle `''(:>)` syntax for quoting type operators
- **Original Package**: effectful-th-1.0.0.3

### 3. Operator sections in patterns (control-monad-free)
- **Fixture**: `PatternSyntax/operator-section-in-pattern.hs`
- **Issue**: Parser rejects operator sections like `(==)` used as function arguments in instance declarations
- **Original Package**: control-monad-free-0.6.2

## Test Results

All oracle tests pass (marked as `xfail`):
- `DoAndIfThenElse/bare-let-in-do`: Known failure
- `TemplateHaskell/th-quote-tick-operator`: Known failure
- `PatternSyntax/operator-section-in-pattern`: Known failure

Full test suite: ✅ All 1247 parser tests pass