### PR TITLE
feat(resolve): add MVP local binding annotations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -62,6 +62,7 @@ module Aihc.Parser.Syntax
     NameType (..),
     UnqualifiedName (..),
     WarningText (..),
+    Annotation,
     NewtypeDecl (..),
     OperatorName,
     PatSynArgs (..),
@@ -118,13 +119,15 @@ module Aihc.Parser.Syntax
     moduleName,
     moduleWarningText,
     moduleExports,
+    mkAnnotation,
+    fromAnnotation,
   )
 where
 
 import Control.DeepSeq (NFData (..))
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Data (Constr, Data (..), DataType, Fixity (Prefix), mkConstr, mkDataType)
-import Data.Dynamic
+import Data.Dynamic (Dynamic, Typeable, fromDynamic, toDyn)
 import Data.List (sort)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
@@ -1536,6 +1539,12 @@ data ForeignSafety
 
 newtype Annotation = Annotation Dynamic
   deriving (Show, Generic)
+
+mkAnnotation :: (Typeable a) => a -> Annotation
+mkAnnotation = Annotation . toDyn
+
+fromAnnotation :: (Typeable a) => Annotation -> Maybe a
+fromAnnotation (Annotation value) = fromDynamic value
 
 instance Data Annotation where
   gfoldl _ z = z

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -778,7 +778,7 @@ data Module = Module
     moduleImports :: [ImportDecl],
     moduleDecls :: [Decl]
   }
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan Module where
   getSourceSpan = moduleSpan
@@ -789,7 +789,7 @@ data ModuleHead = ModuleHead
     moduleHeadWarningText :: Maybe WarningText,
     moduleHeadExports :: Maybe [ExportSpec]
   }
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan ModuleHead where
   getSourceSpan = moduleHeadSpan
@@ -825,7 +825,7 @@ data ExportSpec
   | ExportAbs SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name
   | ExportAll SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name
   | ExportWith SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name [IEBundledMember]
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan ExportSpec where
   getSourceSpan spec =
@@ -848,7 +848,7 @@ data ImportDecl = ImportDecl
     importDeclAs :: Maybe Text,
     importDeclSpec :: Maybe ImportSpec
   }
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan ImportDecl where
   getSourceSpan = importDeclSpan
@@ -856,14 +856,14 @@ instance HasSourceSpan ImportDecl where
 data ImportLevel
   = ImportLevelQuote
   | ImportLevelSplice
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 data ImportSpec = ImportSpec
   { importSpecSpan :: SourceSpan,
     importSpecHiding :: Bool,
     importSpecItems :: [ImportItem]
   }
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan ImportSpec where
   getSourceSpan = importSpecSpan
@@ -873,7 +873,7 @@ data ImportItem
   | ImportItemAbs SourceSpan (Maybe IEEntityNamespace) UnqualifiedName
   | ImportItemAll SourceSpan (Maybe IEEntityNamespace) UnqualifiedName
   | ImportItemWith SourceSpan (Maybe IEEntityNamespace) UnqualifiedName [IEBundledMember]
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Generic, NFData)
 
 data Decl
   = DeclAnn Annotation Decl

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -19,7 +19,7 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax (Extension, parseExtensionName)
-import Aihc.Resolve (ResolveResult (..), resolve)
+import Aihc.Resolve (ResolveResult (..), renderResolveResult, resolve)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
@@ -108,7 +108,7 @@ parseYamlFixture path value =
     ( withObject "resolver fixture" $ \obj -> do
         exts <- obj .: "extensions"
         modules <- obj .: "modules" >>= parseModules
-        expectedText <- obj .:? "expected" .!= ""
+        expectedText <- (obj .:? "expected" >>= traverse parseExpectedValue) .!= ""
         statusText <- obj .: "status"
         reasonText <- obj .:? "reason" .!= ""
         pure (exts, modules, expectedText, statusText, reasonText)
@@ -124,6 +124,17 @@ parseModules = withArray "modules" $ \arr ->
     toList = foldr (:) []
     parseModuleEntry (Y.String t) = pure t
     parseModuleEntry _ = fail "each module must be a string"
+
+parseExpectedValue :: Y.Value -> Y.Parser Text
+parseExpectedValue value =
+  case value of
+    Y.String txt -> pure txt
+    Y.Array arr -> T.intercalate "\n" <$> mapM parseExpectedLine (toList arr)
+    _ -> fail "expected must be a string or a list of strings"
+  where
+    toList = foldr (:) []
+    parseExpectedLine (Y.String txt) = pure txt
+    parseExpectedLine _ = fail "each expected list entry must be a string"
 
 evaluateResolverCase :: ResolverCase -> (Outcome, String)
 evaluateResolverCase meta =
@@ -146,7 +157,7 @@ evaluateResolverCase meta =
        in if null errs
             then Right ast
             else Left (formatParseErrors (T.unpack (T.takeWhile (/= '\n') input)) (Just input) errs)
-    showResolved result = show (resolvedModules result)
+    showResolved = renderResolveResult
     showErrors result = unlines (map show (resolveErrors result))
 
 classifySuccess :: ResolverCase -> String -> (Outcome, String)

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -21,9 +21,11 @@ import Aihc.Parser
 import Aihc.Parser.Syntax (Extension, parseExtensionName)
 import Aihc.Resolve (ResolveResult (..), renderResolveResult, resolve)
 import Data.Aeson ((.!=), (.:), (.:?))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
-import Data.List (dropWhileEnd, sort)
+import Data.List (dropWhileEnd, sort, sortOn)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
@@ -130,9 +132,18 @@ parseExpectedValue value =
   case value of
     Y.String txt -> pure txt
     Y.Array arr -> T.intercalate "\n" <$> mapM parseExpectedLine (toList arr)
+    Y.Object obj ->
+      T.intercalate "\n"
+        <$> mapM parseExpectedModule (sortOn (Key.toText . fst) (KeyMap.toList obj))
     _ -> fail "expected must be a string or a list of strings"
   where
     toList = foldr (:) []
+    parseExpectedModule (moduleName, moduleValue) = do
+      moduleLines <- parseExpectedModuleLines moduleValue
+      pure (Key.toText moduleName <> ":\n" <> T.intercalate "\n" (map ("  " <>) moduleLines))
+    parseExpectedModuleLines (Y.String txt) = pure [txt]
+    parseExpectedModuleLines (Y.Array arr) = mapM parseExpectedLine (toList arr)
+    parseExpectedModuleLines _ = fail "each expected module value must be a string or a list of strings"
     parseExpectedLine (Y.String txt) = pure txt
     parseExpectedLine _ = fail "each expected list entry must be a string"
 

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -1,20 +1,387 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Aihc.Resolve
   ( resolve,
     ResolveError (..),
     ResolveResult (..),
+    ResolvedName (..),
+    ResolutionAnnotation (..),
+    renderResolveResult,
   )
 where
 
-import Aihc.Parser.Syntax (Module)
+import Aihc.Parser.Syntax
+  ( Decl (..),
+    Expr (..),
+    GuardQualifier (..),
+    GuardedRhs (..),
+    ImportDecl (..),
+    ImportItem (..),
+    ImportSpec (..),
+    Match (..),
+    Module (..),
+    Name (..),
+    NameType (..),
+    Pattern (..),
+    Rhs (..),
+    SourceSpan (..),
+    UnqualifiedName,
+    ValueDecl (..),
+    mkAnnotation,
+    mkQualifiedName,
+    mkUnqualifiedName,
+    moduleName,
+    renderUnqualifiedName,
+  )
 import Aihc.Resolve.Types
+import Data.List (mapAccumL)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
 
--- | Resolve names in a group of modules.
---
--- Takes a list of parsed modules and returns the same modules
--- with resolution annotations attached, or errors.
+type Scope = Map.Map Text ResolvedName
+
+type ModuleExports = Map.Map Text Scope
+
 resolve :: [Module] -> ResolveResult
-resolve _modules =
+resolve modules =
   ResolveResult
-    { resolvedModules = [],
-      resolveErrors = [ResolveNotImplemented "name resolution is not yet implemented"]
+    { resolvedModules = snd (mapAccumL (resolveModule exports) 0 modules),
+      resolveErrors = []
     }
+  where
+    exports = collectModuleExports modules
+
+resolveModule :: ModuleExports -> Int -> Module -> (Int, Module)
+resolveModule exports nextLocal modu =
+  let scope = moduleScope exports modu
+      (nextLocal', decls') = mapAccumL (resolveTopLevelDecl scope) nextLocal (moduleDecls modu)
+   in (nextLocal', modu {moduleDecls = decls'})
+
+resolveTopLevelDecl :: Scope -> Int -> Decl -> (Int, Decl)
+resolveTopLevelDecl scope nextLocal decl =
+  let (nextLocal', decl') = resolveDecl scope nextLocal decl
+   in (nextLocal', maybe decl' (`annotateDecl` decl') (topLevelBinderAnnotation decl scope))
+
+resolveDecl :: Scope -> Int -> Decl -> (Int, Decl)
+resolveDecl scope nextLocal decl =
+  case decl of
+    DeclAnn _ inner -> resolveDecl scope nextLocal inner
+    DeclValue span' valueDecl ->
+      case valueDecl of
+        FunctionBind bindSpan name matches ->
+          let (nextLocal', matches') = mapAccumL (resolveMatch scope) nextLocal matches
+           in (nextLocal', DeclValue span' (FunctionBind bindSpan name matches'))
+        PatternBind bindSpan pat rhs ->
+          let (nextLocal', rhs') = resolveRhs scope nextLocal rhs
+           in (nextLocal', DeclValue span' (PatternBind bindSpan pat rhs'))
+    DeclSplice span' expr ->
+      let (nextLocal', expr') = resolveExpr scope nextLocal expr
+       in (nextLocal', DeclSplice span' expr')
+    _ -> (nextLocal, decl)
+
+resolveMatch :: Scope -> Int -> Match -> (Int, Match)
+resolveMatch scope nextLocal match =
+  let (nextLocal', patScope, pats') = bindPatterns nextLocal (matchPats match)
+      scoped = patScope `Map.union` scope
+      (nextLocal'', rhs') = resolveRhs scoped nextLocal' (matchRhs match)
+   in (nextLocal'', match {matchPats = pats', matchRhs = rhs'})
+
+resolveRhs :: Scope -> Int -> Rhs -> (Int, Rhs)
+resolveRhs scope nextLocal rhs =
+  case rhs of
+    UnguardedRhs span' expr ->
+      let (nextLocal', expr') = resolveExpr scope nextLocal expr
+       in (nextLocal', UnguardedRhs span' expr')
+    GuardedRhss span' guardedRhss ->
+      let (nextLocal', guardedRhss') = mapAccumL (resolveGuardedRhs scope) nextLocal guardedRhss
+       in (nextLocal', GuardedRhss span' guardedRhss')
+
+resolveGuardedRhs :: Scope -> Int -> GuardedRhs -> (Int, GuardedRhs)
+resolveGuardedRhs scope nextLocal guardedRhs =
+  let (nextLocal', scope', guards') = resolveGuardQualifiers scope nextLocal (guardedRhsGuards guardedRhs)
+      (nextLocal'', body') = resolveExpr scope' nextLocal' (guardedRhsBody guardedRhs)
+   in (nextLocal'', guardedRhs {guardedRhsGuards = guards', guardedRhsBody = body'})
+
+resolveGuardQualifiers :: Scope -> Int -> [GuardQualifier] -> (Int, Scope, [GuardQualifier])
+resolveGuardQualifiers scope nextLocal qualifiers =
+  case qualifiers of
+    [] -> (nextLocal, scope, [])
+    qualifier : rest ->
+      let (nextLocal', scope', qualifier') = resolveGuardQualifier scope nextLocal qualifier
+          (nextLocal'', scope'', rest') = resolveGuardQualifiers scope' nextLocal' rest
+       in (nextLocal'', scope'', qualifier' : rest')
+
+resolveGuardQualifier :: Scope -> Int -> GuardQualifier -> (Int, Scope, GuardQualifier)
+resolveGuardQualifier scope nextLocal qualifier =
+  case qualifier of
+    GuardExpr span' expr ->
+      let (nextLocal', expr') = resolveExpr scope nextLocal expr
+       in (nextLocal', scope, GuardExpr span' expr')
+    GuardPat span' pat expr ->
+      let (nextLocal', expr') = resolveExpr scope nextLocal expr
+          (nextLocal'', patScope, pat') = bindPattern nextLocal' pat
+       in (nextLocal'', patScope `Map.union` scope, GuardPat span' pat' expr')
+    GuardLet span' decls ->
+      let (nextLocal', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal decls
+          scoped = localScope `Map.union` scope
+          (nextLocal'', decls') = mapAccumL (resolveBoundDecl scoped binderAnnotations) nextLocal' decls
+       in (nextLocal'', scoped, GuardLet span' decls')
+
+resolveExpr :: Scope -> Int -> Expr -> (Int, Expr)
+resolveExpr scope nextLocal expr =
+  case expr of
+    EAnn _ inner -> resolveExpr scope nextLocal inner
+    EVar span' name ->
+      ( nextLocal,
+        annotateExpr
+          (ResolutionAnnotation span' (nameText name) (resolveName scope name))
+          (EVar span' name)
+      )
+    EIf span' cond trueBranch falseBranch ->
+      let (nextLocal', cond') = resolveExpr scope nextLocal cond
+          (nextLocal'', trueBranch') = resolveExpr scope nextLocal' trueBranch
+          (nextLocal''', falseBranch') = resolveExpr scope nextLocal'' falseBranch
+       in (nextLocal''', EIf span' cond' trueBranch' falseBranch')
+    EInfix span' left op right ->
+      let (nextLocal', left') = resolveExpr scope nextLocal left
+          (nextLocal'', right') = resolveExpr scope nextLocal' right
+       in (nextLocal'', EInfix span' left' op right')
+    ENegate span' inner ->
+      let (nextLocal', inner') = resolveExpr scope nextLocal inner
+       in (nextLocal', ENegate span' inner')
+    ESectionL span' inner op ->
+      let (nextLocal', inner') = resolveExpr scope nextLocal inner
+       in (nextLocal', ESectionL span' inner' op)
+    ESectionR span' op inner ->
+      let (nextLocal', inner') = resolveExpr scope nextLocal inner
+       in (nextLocal', ESectionR span' op inner')
+    ELetDecls span' decls body ->
+      let (nextLocal', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal decls
+          scoped = localScope `Map.union` scope
+          (nextLocal'', decls') = mapAccumL (resolveBoundDecl scoped binderAnnotations) nextLocal' decls
+          (nextLocal''', body') = resolveExpr scoped nextLocal'' body
+       in (nextLocal''', ELetDecls span' decls' body')
+    ETypeSig span' inner ty ->
+      let (nextLocal', inner') = resolveExpr scope nextLocal inner
+       in (nextLocal', ETypeSig span' inner' ty)
+    EParen span' inner ->
+      let (nextLocal', inner') = resolveExpr scope nextLocal inner
+       in (nextLocal', EParen span' inner')
+    EWhereDecls span' inner decls ->
+      let (nextLocal', inner') = resolveExpr scope nextLocal inner
+          (nextLocal'', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal' decls
+          scoped = localScope `Map.union` scope
+          (nextLocal''', decls') = mapAccumL (resolveBoundDecl scoped binderAnnotations) nextLocal'' decls
+       in (nextLocal''', EWhereDecls span' inner' decls')
+    ETypeApp span' fun ty ->
+      let (nextLocal', fun') = resolveExpr scope nextLocal fun
+       in (nextLocal', ETypeApp span' fun' ty)
+    EApp span' fun arg ->
+      let (nextLocal', fun') = resolveExpr scope nextLocal fun
+          (nextLocal'', arg') = resolveExpr scope nextLocal' arg
+       in (nextLocal'', EApp span' fun' arg')
+    _ -> (nextLocal, expr)
+
+resolveBoundDecl :: Scope -> Map.Map Text ResolutionAnnotation -> Int -> Decl -> (Int, Decl)
+resolveBoundDecl scope binderAnnotations nextLocal decl =
+  let (nextLocal', decl') = resolveDecl scope nextLocal decl
+   in (nextLocal', maybe decl' (`annotateDecl` decl') (declBinderAnnotation decl binderAnnotations))
+
+bindPatterns :: Int -> [Pattern] -> (Int, Scope, [Pattern])
+bindPatterns nextLocal pats =
+  let (nextLocal', scopedEntries, pats') = foldl' step (nextLocal, [], []) pats
+   in (nextLocal', Map.fromList scopedEntries, reverse pats')
+  where
+    step (currentId, entries, acc) pat =
+      let (nextId, scope, pat') = bindPattern currentId pat
+       in (nextId, Map.toList scope <> entries, pat' : acc)
+
+bindPattern :: Int -> Pattern -> (Int, Scope, Pattern)
+bindPattern nextLocal pat =
+  case pat of
+    PAnn _ inner -> bindPattern nextLocal inner
+    PVar span' name ->
+      let resolvedName = ResolvedLocal nextLocal name
+          annotation = ResolutionAnnotation span' (renderUnqualifiedName name) resolvedName
+       in (nextLocal + 1, Map.singleton (renderUnqualifiedName name) resolvedName, annotatePattern annotation (PVar span' name))
+    PTuple span' flavor pats ->
+      let (nextLocal', scope, pats') = bindPatterns nextLocal pats
+       in (nextLocal', scope, PTuple span' flavor pats')
+    PList span' pats ->
+      let (nextLocal', scope, pats') = bindPatterns nextLocal pats
+       in (nextLocal', scope, PList span' pats')
+    PCon span' name pats ->
+      let (nextLocal', scope, pats') = bindPatterns nextLocal pats
+       in (nextLocal', scope, PCon span' name pats')
+    PInfix span' left name right ->
+      let (nextLocal', leftScope, left') = bindPattern nextLocal left
+          (nextLocal'', rightScope, right') = bindPattern nextLocal' right
+       in (nextLocal'', rightScope `Map.union` leftScope, PInfix span' left' name right')
+    PView span' expr inner ->
+      let (nextLocal', scope, inner') = bindPattern nextLocal inner
+       in (nextLocal', scope, PView span' expr inner')
+    PAs span' alias inner ->
+      let aliasName = mkUnqualifiedName NameVarId alias
+          aliasResolved = ResolvedLocal nextLocal aliasName
+          aliasAnnotation = ResolutionAnnotation (spanStartNameSpan span' alias) alias aliasResolved
+          (nextLocal', innerScope, inner') = bindPattern (nextLocal + 1) inner
+          aliasScope = Map.singleton alias aliasResolved
+       in (nextLocal', innerScope `Map.union` aliasScope, annotatePattern aliasAnnotation (PAs span' alias inner'))
+    PStrict span' inner ->
+      let (nextLocal', scope, inner') = bindPattern nextLocal inner
+       in (nextLocal', scope, PStrict span' inner')
+    PIrrefutable span' inner ->
+      let (nextLocal', scope, inner') = bindPattern nextLocal inner
+       in (nextLocal', scope, PIrrefutable span' inner')
+    PParen span' inner ->
+      let (nextLocal', scope, inner') = bindPattern nextLocal inner
+       in (nextLocal', scope, PParen span' inner')
+    PRecord span' name fields wildcard ->
+      let (nextLocal', entries, fields') =
+            foldl'
+              ( \(currentId, currentEntries, acc) (fieldName, fieldPat) ->
+                  let (nextId, fieldScope, fieldPat') = bindPattern currentId fieldPat
+                   in (nextId, Map.toList fieldScope <> currentEntries, (fieldName, fieldPat') : acc)
+              )
+              (nextLocal, [], [])
+              fields
+       in (nextLocal', Map.fromList entries, PRecord span' name (reverse fields') wildcard)
+    PTypeSig span' inner ty ->
+      let (nextLocal', scope, inner') = bindPattern nextLocal inner
+       in (nextLocal', scope, PTypeSig span' inner' ty)
+    _ -> (nextLocal, Map.empty, pat)
+
+allocateLocalDeclBinders :: Int -> [Decl] -> (Int, Map.Map Text ResolutionAnnotation, Scope)
+allocateLocalDeclBinders nextLocal =
+  foldl' step (nextLocal, Map.empty, Map.empty)
+  where
+    step (currentId, annotations, scope) decl =
+      case declBinderCandidate decl of
+        Just (span', name) ->
+          let resolvedName = ResolvedLocal currentId name
+              key = renderUnqualifiedName name
+              annotation = ResolutionAnnotation span' key resolvedName
+           in ( currentId + 1,
+                Map.insert key annotation annotations,
+                Map.insert key resolvedName scope
+              )
+        Nothing -> (currentId, annotations, scope)
+
+declBinderAnnotation :: Decl -> Map.Map Text ResolutionAnnotation -> Maybe ResolutionAnnotation
+declBinderAnnotation decl binderAnnotations =
+  case declBinderCandidate decl of
+    Just (_, name) -> Map.lookup (renderUnqualifiedName name) binderAnnotations
+    Nothing -> Nothing
+
+topLevelBinderAnnotation :: Decl -> Scope -> Maybe ResolutionAnnotation
+topLevelBinderAnnotation decl scope =
+  case declBinderCandidate decl of
+    Just (span', name) ->
+      let key = renderUnqualifiedName name
+       in Just (ResolutionAnnotation span' key (fromMaybe (ResolvedError ("missing top-level binding for " <> T.unpack key)) (Map.lookup key scope)))
+    Nothing -> Nothing
+
+declBinderCandidate :: Decl -> Maybe (SourceSpan, UnqualifiedName)
+declBinderCandidate decl =
+  case decl of
+    DeclValue _ valueDecl ->
+      case valueDecl of
+        FunctionBind span' name _ -> Just (spanStartNameSpan span' (renderUnqualifiedName name), name)
+        PatternBind _ pat _ ->
+          case pat of
+            PVar span' name -> Just (span', name)
+            _ -> Nothing
+    _ -> Nothing
+
+collectModuleExports :: [Module] -> ModuleExports
+collectModuleExports modules =
+  Map.fromList
+    [ (moduleKey modu, topLevelScope modu)
+    | modu <- modules
+    ]
+
+topLevelScope :: Module -> Scope
+topLevelScope modu =
+  Map.fromList
+    [ (key, ResolvedTopLevel (mkQualifiedName name (Just moduleKeyText)))
+    | decl <- moduleDecls modu,
+      Just (_, name) <- [declBinderCandidate decl],
+      let key = renderUnqualifiedName name,
+      let moduleKeyText = moduleKey modu
+    ]
+
+moduleScope :: ModuleExports -> Module -> Scope
+moduleScope exports modu =
+  ownScope `Map.union` importedScope exports modu
+  where
+    ownScope = Map.findWithDefault Map.empty (moduleKey modu) exports
+
+importedScope :: ModuleExports -> Module -> Scope
+importedScope exports modu =
+  foldl' addImport Map.empty (moduleImports modu)
+  where
+    addImport acc importDecl
+      | importDeclQualified importDecl || importDeclQualifiedPost importDecl = acc
+      | otherwise =
+          let imported = Map.findWithDefault Map.empty (importDeclModule importDecl) exports
+           in Map.union acc (filterImportSpec (importDeclSpec importDecl) imported)
+
+filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
+filterImportSpec maybeSpec scope =
+  case maybeSpec of
+    Nothing -> scope
+    Just ImportSpec {importSpecHiding = False, importSpecItems} ->
+      Map.filterWithKey (\name _ -> name `elem` allowedNames importSpecItems) scope
+    Just ImportSpec {importSpecHiding = True, importSpecItems} ->
+      Map.filterWithKey (\name _ -> name `notElem` allowedNames importSpecItems) scope
+
+allowedNames :: [ImportItem] -> [Text]
+allowedNames items =
+  [ name
+  | item <- items,
+    name <- case item of
+      ImportItemVar _ _ itemName -> [renderUnqualifiedName itemName]
+      ImportItemAbs _ _ itemName -> [renderUnqualifiedName itemName]
+      ImportItemAll _ _ itemName -> [renderUnqualifiedName itemName]
+      ImportItemWith _ _ itemName _ -> [renderUnqualifiedName itemName]
+  ]
+
+resolveName :: Scope -> Name -> ResolvedName
+resolveName scope name =
+  case nameQualifier name of
+    Just qualifier ->
+      ResolvedTopLevel (name {nameQualifier = Just qualifier})
+    Nothing ->
+      Map.findWithDefault
+        (ResolvedError ("unbound name: " <> T.unpack (nameText name)))
+        (nameText name)
+        scope
+
+moduleKey :: Module -> Text
+moduleKey modu = fromMaybe (T.pack "Main") (moduleName modu)
+
+spanStartNameSpan :: SourceSpan -> Text -> SourceSpan
+spanStartNameSpan span' name =
+  case span' of
+    SourceSpan sourceName startLine startCol _ _ startOffset endOffset ->
+      let width = T.length name
+       in SourceSpan
+            sourceName
+            startLine
+            startCol
+            startLine
+            (startCol + width)
+            startOffset
+            (min endOffset (startOffset + width))
+    NoSourceSpan -> NoSourceSpan
+
+annotateDecl :: ResolutionAnnotation -> Decl -> Decl
+annotateDecl annotation = DeclAnn (mkAnnotation annotation)
+
+annotateExpr :: ResolutionAnnotation -> Expr -> Expr
+annotateExpr annotation = EAnn (mkAnnotation annotation)
+
+annotatePattern :: ResolutionAnnotation -> Pattern -> Pattern
+annotatePattern annotation = PAnn (mkAnnotation annotation)

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Aihc.Resolve
-  ( resolve,
+  ( pattern DeclResolution,
+    pattern EResolution,
+    pattern PResolution,
+    pattern TResolution,
+    resolve,
     ResolveError (..),
     ResolveResult (..),
     ResolvedName (..),

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -1,10 +1,56 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
 module Aihc.Resolve.Types
-  ( ResolveError (..),
+  ( ResolvedName (..),
+    ResolutionAnnotation (..),
+    ResolveError (..),
     ResolveResult (..),
+    renderResolveResult,
+    renderResolvedName,
   )
 where
 
-import Aihc.Parser.Syntax (Module)
+import Aihc.Parser.Syntax
+  ( ArithSeq (..),
+    CaseAlt (..),
+    Cmd (..),
+    CmdCaseAlt (..),
+    CompStmt (..),
+    Decl (..),
+    DoStmt (..),
+    Expr (..),
+    GuardQualifier (..),
+    GuardedRhs (..),
+    Match (..),
+    Module (..),
+    Name,
+    Pattern (..),
+    Rhs (..),
+    SourceSpan (..),
+    Type (..),
+    UnqualifiedName,
+    ValueDecl (..),
+    fromAnnotation,
+    renderName,
+    renderUnqualifiedName,
+  )
+import Data.List (intercalate, sortOn)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Typeable (Typeable)
+
+data ResolvedName
+  = ResolvedTopLevel Name
+  | ResolvedLocal Int UnqualifiedName
+  | ResolvedError String
+  deriving (Eq, Show, Typeable)
+
+data ResolutionAnnotation = ResolutionAnnotation
+  { resolutionSpan :: !SourceSpan,
+    resolutionName :: !Text,
+    resolutionTarget :: !ResolvedName
+  }
+  deriving (Eq, Show, Typeable)
 
 newtype ResolveError
   = ResolveNotImplemented String
@@ -15,3 +61,283 @@ data ResolveResult = ResolveResult
     resolveErrors :: [ResolveError]
   }
   deriving (Show)
+
+renderResolveResult :: ResolveResult -> String
+renderResolveResult result =
+  intercalate "\n" (map renderResolutionAnnotation (sortOn annotationKey (collectModules (resolvedModules result))))
+
+renderResolvedName :: ResolvedName -> String
+renderResolvedName resolvedName =
+  case resolvedName of
+    ResolvedTopLevel name -> T.unpack (renderName name)
+    ResolvedLocal uniqueId localName -> "Local " <> show uniqueId <> " " <> T.unpack (renderUnqualifiedName localName)
+    ResolvedError msg -> "Error " <> msg
+
+renderResolutionAnnotation :: ResolutionAnnotation -> String
+renderResolutionAnnotation ann =
+  renderSourceSpan (resolutionSpan ann)
+    <> " "
+    <> T.unpack (resolutionName ann)
+    <> " => "
+    <> renderResolvedName (resolutionTarget ann)
+
+annotationKey :: ResolutionAnnotation -> (FilePath, Int, Int, Int, Int, Text)
+annotationKey ann =
+  case resolutionSpan ann of
+    SourceSpan path startLine startCol endLine endCol _ _ ->
+      (path, startLine, startCol, endLine, endCol, resolutionName ann)
+    NoSourceSpan ->
+      ("", maxBound, maxBound, maxBound, maxBound, resolutionName ann)
+
+renderSourceSpan :: SourceSpan -> String
+renderSourceSpan span' =
+  case span' of
+    SourceSpan _ startLine startCol endLine endCol _ _ ->
+      show startLine
+        <> ":"
+        <> show startCol
+        <> "-"
+        <> show endLine
+        <> ":"
+        <> show endCol
+    NoSourceSpan -> "<no-source>"
+
+collectModules :: [Module] -> [ResolutionAnnotation]
+collectModules = concatMap collectModule
+
+collectModule :: Module -> [ResolutionAnnotation]
+collectModule modu = concatMap collectDecl (moduleDecls modu)
+
+collectDecl :: Decl -> [ResolutionAnnotation]
+collectDecl decl =
+  ownDeclAnnotation decl
+    <> case decl of
+      DeclAnn _ inner -> collectDecl inner
+      DeclValue _ valueDecl ->
+        case valueDecl of
+          FunctionBind _ _ matches -> concatMap collectMatch matches
+          PatternBind _ pat rhs -> collectPattern pat <> collectRhs rhs
+      DeclTypeSig {} -> []
+      DeclPatSyn {} -> []
+      DeclPatSynSig {} -> []
+      DeclStandaloneKindSig {} -> []
+      DeclFixity {} -> []
+      DeclRoleAnnotation {} -> []
+      DeclTypeSyn {} -> []
+      DeclTypeData {} -> []
+      DeclData {} -> []
+      DeclNewtype {} -> []
+      DeclClass {} -> []
+      DeclInstance {} -> []
+      DeclStandaloneDeriving {} -> []
+      DeclDefault {} -> []
+      DeclSplice _ expr -> collectExpr expr
+      DeclForeign {} -> []
+      DeclTypeFamilyDecl {} -> []
+      DeclDataFamilyDecl {} -> []
+      DeclTypeFamilyInst {} -> []
+      DeclDataFamilyInst {} -> []
+      DeclPragma {} -> []
+
+collectMatch :: Match -> [ResolutionAnnotation]
+collectMatch match =
+  concatMap collectPattern (matchPats match) <> collectRhs (matchRhs match)
+
+collectRhs :: Rhs -> [ResolutionAnnotation]
+collectRhs rhs =
+  case rhs of
+    UnguardedRhs _ expr -> collectExpr expr
+    GuardedRhss _ guardedRhss -> concatMap collectGuardedRhs guardedRhss
+
+collectGuardedRhs :: GuardedRhs -> [ResolutionAnnotation]
+collectGuardedRhs guardedRhs =
+  concatMap collectGuardQualifier (guardedRhsGuards guardedRhs) <> collectExpr (guardedRhsBody guardedRhs)
+
+collectGuardQualifier :: GuardQualifier -> [ResolutionAnnotation]
+collectGuardQualifier qualifier =
+  case qualifier of
+    GuardExpr _ expr -> collectExpr expr
+    GuardPat _ pat expr -> collectPattern pat <> collectExpr expr
+    GuardLet _ decls -> concatMap collectDecl decls
+
+collectPattern :: Pattern -> [ResolutionAnnotation]
+collectPattern pat =
+  ownPatternAnnotation pat
+    <> case pat of
+      PAnn _ inner -> collectPattern inner
+      PTuple _ _ pats -> concatMap collectPattern pats
+      PUnboxedSum _ _ _ inner -> collectPattern inner
+      PList _ pats -> concatMap collectPattern pats
+      PCon _ _ pats -> concatMap collectPattern pats
+      PInfix _ left _ right -> collectPattern left <> collectPattern right
+      PView _ expr inner -> collectExpr expr <> collectPattern inner
+      PAs _ _ inner -> collectPattern inner
+      PStrict _ inner -> collectPattern inner
+      PIrrefutable _ inner -> collectPattern inner
+      PParen _ inner -> collectPattern inner
+      PRecord _ _ fields _ -> concatMap (collectPattern . snd) fields
+      PTypeSig _ inner ty -> collectPattern inner <> collectType ty
+      PSplice _ expr -> collectExpr expr
+      PVar {} -> []
+      PWildcard {} -> []
+      PLit {} -> []
+      PQuasiQuote {} -> []
+      PNegLit {} -> []
+
+collectExpr :: Expr -> [ResolutionAnnotation]
+collectExpr expr =
+  ownExprAnnotation expr
+    <> case expr of
+      EAnn _ inner -> collectExpr inner
+      EIf _ cond trueBranch falseBranch -> collectExpr cond <> collectExpr trueBranch <> collectExpr falseBranch
+      EMultiWayIf _ guardedRhss -> concatMap collectGuardedRhs guardedRhss
+      ELambdaPats _ pats body -> concatMap collectPattern pats <> collectExpr body
+      ELambdaCase _ alts -> concatMap collectCaseAlt alts
+      EInfix _ left _ right -> collectExpr left <> collectExpr right
+      ENegate _ inner -> collectExpr inner
+      ESectionL _ inner _ -> collectExpr inner
+      ESectionR _ _ inner -> collectExpr inner
+      ELetDecls _ decls body -> concatMap collectDecl decls <> collectExpr body
+      ECase _ scrutinee alts -> collectExpr scrutinee <> concatMap collectCaseAlt alts
+      EDo _ stmts _ -> concatMap collectDoStmtExpr stmts
+      EListComp _ inner stmts -> collectExpr inner <> concatMap collectCompStmt stmts
+      EListCompParallel _ inner stmtGroups -> collectExpr inner <> concatMap (concatMap collectCompStmt) stmtGroups
+      EArithSeq _ arithSeq -> collectArithSeq arithSeq
+      ERecordCon _ _ fields _ -> concatMap (collectExpr . snd) fields
+      ERecordUpd _ inner fields -> collectExpr inner <> concatMap (collectExpr . snd) fields
+      ETypeSig _ inner ty -> collectExpr inner <> collectType ty
+      EParen _ inner -> collectExpr inner
+      EWhereDecls _ inner decls -> collectExpr inner <> concatMap collectDecl decls
+      EList _ exprs -> concatMap collectExpr exprs
+      ETuple _ _ exprs -> concatMap collectExpr (foldr maybeCons [] exprs)
+      EUnboxedSum _ _ _ inner -> collectExpr inner
+      ETypeApp _ inner ty -> collectExpr inner <> collectType ty
+      EApp _ fun arg -> collectExpr fun <> collectExpr arg
+      ETHExpQuote _ inner -> collectExpr inner
+      ETHTypedQuote _ inner -> collectExpr inner
+      ETHDeclQuote _ decls -> concatMap collectDecl decls
+      ETHTypeQuote _ ty -> collectType ty
+      ETHPatQuote _ pat -> collectPattern pat
+      ETHSplice _ inner -> collectExpr inner
+      ETHTypedSplice _ inner -> collectExpr inner
+      EProc _ pat cmd -> collectPattern pat <> collectCmd cmd
+      EVar {} -> []
+      EInt {} -> []
+      EIntHash {} -> []
+      EIntBase {} -> []
+      EIntBaseHash {} -> []
+      EFloat {} -> []
+      EFloatHash {} -> []
+      EChar {} -> []
+      ECharHash {} -> []
+      EString {} -> []
+      EStringHash {} -> []
+      EOverloadedLabel {} -> []
+      EQuasiQuote {} -> []
+      ETHNameQuote {} -> []
+      ETHTypeNameQuote {} -> []
+
+collectCaseAlt :: CaseAlt -> [ResolutionAnnotation]
+collectCaseAlt alt = collectPattern (caseAltPattern alt) <> collectRhs (caseAltRhs alt)
+
+collectDoStmtExpr :: DoStmt Expr -> [ResolutionAnnotation]
+collectDoStmtExpr stmt =
+  case stmt of
+    DoBind _ pat expr -> collectPattern pat <> collectExpr expr
+    DoLet _ bindings -> concatMap (collectExpr . snd) bindings
+    DoLetDecls _ decls -> concatMap collectDecl decls
+    DoExpr _ expr -> collectExpr expr
+    DoRecStmt _ stmts -> concatMap collectDoStmtExpr stmts
+
+collectCompStmt :: CompStmt -> [ResolutionAnnotation]
+collectCompStmt stmt =
+  case stmt of
+    CompGen _ pat expr -> collectPattern pat <> collectExpr expr
+    CompGuard _ expr -> collectExpr expr
+    CompLet _ bindings -> concatMap (collectExpr . snd) bindings
+    CompLetDecls _ decls -> concatMap collectDecl decls
+
+collectArithSeq :: ArithSeq -> [ResolutionAnnotation]
+collectArithSeq arithSeq =
+  case arithSeq of
+    ArithSeqFrom _ start -> collectExpr start
+    ArithSeqFromThen _ start next -> collectExpr start <> collectExpr next
+    ArithSeqFromTo _ start end -> collectExpr start <> collectExpr end
+    ArithSeqFromThenTo _ start next end -> collectExpr start <> collectExpr next <> collectExpr end
+
+collectCmd :: Cmd -> [ResolutionAnnotation]
+collectCmd cmd =
+  case cmd of
+    CmdArrApp _ left _ right -> collectExpr left <> collectExpr right
+    CmdApp _ inner expr -> collectCmd inner <> collectExpr expr
+    CmdLam _ pats inner -> concatMap collectPattern pats <> collectCmd inner
+    CmdPar _ inner -> collectCmd inner
+    CmdIf _ expr thenCmd elseCmd -> collectExpr expr <> collectCmd thenCmd <> collectCmd elseCmd
+    CmdCase _ expr alts -> collectExpr expr <> concatMap collectCmdCaseAlt alts
+    CmdLet _ decls inner -> concatMap collectDecl decls <> collectCmd inner
+    CmdDo _ stmts -> concatMap collectDoStmtCmd stmts
+    CmdInfix _ left _ right -> collectCmd left <> collectCmd right
+
+collectCmdCaseAlt :: CmdCaseAlt -> [ResolutionAnnotation]
+collectCmdCaseAlt alt = collectPattern (cmdCaseAltPat alt) <> collectCmd (cmdCaseAltBody alt)
+
+collectDoStmtCmd :: DoStmt Cmd -> [ResolutionAnnotation]
+collectDoStmtCmd stmt =
+  case stmt of
+    DoBind _ pat cmd -> collectPattern pat <> collectCmd cmd
+    DoLet _ bindings -> concatMap (collectExpr . snd) bindings
+    DoLetDecls _ decls -> concatMap collectDecl decls
+    DoExpr _ cmd -> collectCmd cmd
+    DoRecStmt _ stmts -> concatMap collectDoStmtCmd stmts
+
+collectType :: Type -> [ResolutionAnnotation]
+collectType ty =
+  case ty of
+    TAnn _ inner -> collectType inner
+    TImplicitParam _ _ inner -> collectType inner
+    TForall _ _ inner -> collectType inner
+    TApp _ left right -> collectType left <> collectType right
+    TFun _ left right -> collectType left <> collectType right
+    TTuple _ _ _ tys -> concatMap collectType tys
+    TUnboxedSum _ tys -> concatMap collectType tys
+    TList _ _ tys -> concatMap collectType tys
+    TParen _ inner -> collectType inner
+    TKindSig _ inner kind -> collectType inner <> collectType kind
+    TContext _ constraints inner -> concatMap collectType constraints <> collectType inner
+    TSplice _ expr -> collectExpr expr
+    TVar {} -> []
+    TCon {} -> []
+    TTypeLit {} -> []
+    TStar {} -> []
+    TQuasiQuote {} -> []
+    TWildcard {} -> []
+
+ownDeclAnnotation :: Decl -> [ResolutionAnnotation]
+ownDeclAnnotation decl =
+  case decl of
+    DeclAnn ann _ -> maybeToList (fromAnnotation ann :: Maybe ResolutionAnnotation)
+    _ -> []
+
+ownPatternAnnotation :: Pattern -> [ResolutionAnnotation]
+ownPatternAnnotation pat =
+  case pat of
+    PAnn ann _ -> maybeToList (fromAnnotation ann :: Maybe ResolutionAnnotation)
+    _ -> []
+
+ownExprAnnotation :: Expr -> [ResolutionAnnotation]
+ownExprAnnotation expr =
+  case expr of
+    EAnn ann _ -> maybeToList (fromAnnotation ann :: Maybe ResolutionAnnotation)
+    _ -> []
+
+maybeToList :: Maybe a -> [a]
+maybeToList maybeValue =
+  case maybeValue of
+    Just value -> [value]
+    Nothing -> []
+
+maybeCons :: Maybe a -> [a] -> [a]
+maybeCons maybeValue rest =
+  case maybeValue of
+    Just value -> value : rest
+    Nothing -> rest

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -11,29 +11,19 @@ module Aihc.Resolve.Types
 where
 
 import Aihc.Parser.Syntax
-  ( ArithSeq (..),
-    CaseAlt (..),
-    Cmd (..),
-    CmdCaseAlt (..),
-    CompStmt (..),
+  ( Annotation,
     Decl (..),
-    DoStmt (..),
     Expr (..),
-    GuardQualifier (..),
-    GuardedRhs (..),
-    Match (..),
     Module (..),
     Name,
     Pattern (..),
-    Rhs (..),
     SourceSpan (..),
-    Type (..),
     UnqualifiedName,
-    ValueDecl (..),
     fromAnnotation,
     renderName,
     renderUnqualifiedName,
   )
+import Data.Data (Data, cast, gmapQ)
 import Data.List (intercalate, sortOn)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -103,241 +93,35 @@ renderSourceSpan span' =
     NoSourceSpan -> "<no-source>"
 
 collectModules :: [Module] -> [ResolutionAnnotation]
-collectModules = concatMap collectModule
+collectModules = concatMap (concatMap collectAnnotations . moduleDecls)
 
-collectModule :: Module -> [ResolutionAnnotation]
-collectModule modu = concatMap collectDecl (moduleDecls modu)
+collectAnnotations :: (Data a) => a -> [ResolutionAnnotation]
+collectAnnotations node =
+  ownAnnotation node <> concat (gmapQ collectAnnotations node)
 
-collectDecl :: Decl -> [ResolutionAnnotation]
-collectDecl decl =
-  ownDeclAnnotation decl
-    <> case decl of
-      DeclAnn _ inner -> collectDecl inner
-      DeclValue _ valueDecl ->
-        case valueDecl of
-          FunctionBind _ _ matches -> concatMap collectMatch matches
-          PatternBind _ pat rhs -> collectPattern pat <> collectRhs rhs
-      DeclTypeSig {} -> []
-      DeclPatSyn {} -> []
-      DeclPatSynSig {} -> []
-      DeclStandaloneKindSig {} -> []
-      DeclFixity {} -> []
-      DeclRoleAnnotation {} -> []
-      DeclTypeSyn {} -> []
-      DeclTypeData {} -> []
-      DeclData {} -> []
-      DeclNewtype {} -> []
-      DeclClass {} -> []
-      DeclInstance {} -> []
-      DeclStandaloneDeriving {} -> []
-      DeclDefault {} -> []
-      DeclSplice _ expr -> collectExpr expr
-      DeclForeign {} -> []
-      DeclTypeFamilyDecl {} -> []
-      DeclDataFamilyDecl {} -> []
-      DeclTypeFamilyInst {} -> []
-      DeclDataFamilyInst {} -> []
-      DeclPragma {} -> []
+ownAnnotation :: (Data a) => a -> [ResolutionAnnotation]
+ownAnnotation node =
+  case cast node of
+    Just decl ->
+      case decl of
+        DeclAnn ann _ -> maybeAnnotation ann
+        _ -> []
+    Nothing ->
+      case cast node of
+        Just pat ->
+          case pat of
+            PAnn ann _ -> maybeAnnotation ann
+            _ -> []
+        Nothing ->
+          case cast node of
+            Just expr ->
+              case expr of
+                EAnn ann _ -> maybeAnnotation ann
+                _ -> []
+            Nothing -> []
 
-collectMatch :: Match -> [ResolutionAnnotation]
-collectMatch match =
-  concatMap collectPattern (matchPats match) <> collectRhs (matchRhs match)
-
-collectRhs :: Rhs -> [ResolutionAnnotation]
-collectRhs rhs =
-  case rhs of
-    UnguardedRhs _ expr -> collectExpr expr
-    GuardedRhss _ guardedRhss -> concatMap collectGuardedRhs guardedRhss
-
-collectGuardedRhs :: GuardedRhs -> [ResolutionAnnotation]
-collectGuardedRhs guardedRhs =
-  concatMap collectGuardQualifier (guardedRhsGuards guardedRhs) <> collectExpr (guardedRhsBody guardedRhs)
-
-collectGuardQualifier :: GuardQualifier -> [ResolutionAnnotation]
-collectGuardQualifier qualifier =
-  case qualifier of
-    GuardExpr _ expr -> collectExpr expr
-    GuardPat _ pat expr -> collectPattern pat <> collectExpr expr
-    GuardLet _ decls -> concatMap collectDecl decls
-
-collectPattern :: Pattern -> [ResolutionAnnotation]
-collectPattern pat =
-  ownPatternAnnotation pat
-    <> case pat of
-      PAnn _ inner -> collectPattern inner
-      PTuple _ _ pats -> concatMap collectPattern pats
-      PUnboxedSum _ _ _ inner -> collectPattern inner
-      PList _ pats -> concatMap collectPattern pats
-      PCon _ _ pats -> concatMap collectPattern pats
-      PInfix _ left _ right -> collectPattern left <> collectPattern right
-      PView _ expr inner -> collectExpr expr <> collectPattern inner
-      PAs _ _ inner -> collectPattern inner
-      PStrict _ inner -> collectPattern inner
-      PIrrefutable _ inner -> collectPattern inner
-      PParen _ inner -> collectPattern inner
-      PRecord _ _ fields _ -> concatMap (collectPattern . snd) fields
-      PTypeSig _ inner ty -> collectPattern inner <> collectType ty
-      PSplice _ expr -> collectExpr expr
-      PVar {} -> []
-      PWildcard {} -> []
-      PLit {} -> []
-      PQuasiQuote {} -> []
-      PNegLit {} -> []
-
-collectExpr :: Expr -> [ResolutionAnnotation]
-collectExpr expr =
-  ownExprAnnotation expr
-    <> case expr of
-      EAnn _ inner -> collectExpr inner
-      EIf _ cond trueBranch falseBranch -> collectExpr cond <> collectExpr trueBranch <> collectExpr falseBranch
-      EMultiWayIf _ guardedRhss -> concatMap collectGuardedRhs guardedRhss
-      ELambdaPats _ pats body -> concatMap collectPattern pats <> collectExpr body
-      ELambdaCase _ alts -> concatMap collectCaseAlt alts
-      EInfix _ left _ right -> collectExpr left <> collectExpr right
-      ENegate _ inner -> collectExpr inner
-      ESectionL _ inner _ -> collectExpr inner
-      ESectionR _ _ inner -> collectExpr inner
-      ELetDecls _ decls body -> concatMap collectDecl decls <> collectExpr body
-      ECase _ scrutinee alts -> collectExpr scrutinee <> concatMap collectCaseAlt alts
-      EDo _ stmts _ -> concatMap collectDoStmtExpr stmts
-      EListComp _ inner stmts -> collectExpr inner <> concatMap collectCompStmt stmts
-      EListCompParallel _ inner stmtGroups -> collectExpr inner <> concatMap (concatMap collectCompStmt) stmtGroups
-      EArithSeq _ arithSeq -> collectArithSeq arithSeq
-      ERecordCon _ _ fields _ -> concatMap (collectExpr . snd) fields
-      ERecordUpd _ inner fields -> collectExpr inner <> concatMap (collectExpr . snd) fields
-      ETypeSig _ inner ty -> collectExpr inner <> collectType ty
-      EParen _ inner -> collectExpr inner
-      EWhereDecls _ inner decls -> collectExpr inner <> concatMap collectDecl decls
-      EList _ exprs -> concatMap collectExpr exprs
-      ETuple _ _ exprs -> concatMap collectExpr (foldr maybeCons [] exprs)
-      EUnboxedSum _ _ _ inner -> collectExpr inner
-      ETypeApp _ inner ty -> collectExpr inner <> collectType ty
-      EApp _ fun arg -> collectExpr fun <> collectExpr arg
-      ETHExpQuote _ inner -> collectExpr inner
-      ETHTypedQuote _ inner -> collectExpr inner
-      ETHDeclQuote _ decls -> concatMap collectDecl decls
-      ETHTypeQuote _ ty -> collectType ty
-      ETHPatQuote _ pat -> collectPattern pat
-      ETHSplice _ inner -> collectExpr inner
-      ETHTypedSplice _ inner -> collectExpr inner
-      EProc _ pat cmd -> collectPattern pat <> collectCmd cmd
-      EVar {} -> []
-      EInt {} -> []
-      EIntHash {} -> []
-      EIntBase {} -> []
-      EIntBaseHash {} -> []
-      EFloat {} -> []
-      EFloatHash {} -> []
-      EChar {} -> []
-      ECharHash {} -> []
-      EString {} -> []
-      EStringHash {} -> []
-      EOverloadedLabel {} -> []
-      EQuasiQuote {} -> []
-      ETHNameQuote {} -> []
-      ETHTypeNameQuote {} -> []
-
-collectCaseAlt :: CaseAlt -> [ResolutionAnnotation]
-collectCaseAlt alt = collectPattern (caseAltPattern alt) <> collectRhs (caseAltRhs alt)
-
-collectDoStmtExpr :: DoStmt Expr -> [ResolutionAnnotation]
-collectDoStmtExpr stmt =
-  case stmt of
-    DoBind _ pat expr -> collectPattern pat <> collectExpr expr
-    DoLet _ bindings -> concatMap (collectExpr . snd) bindings
-    DoLetDecls _ decls -> concatMap collectDecl decls
-    DoExpr _ expr -> collectExpr expr
-    DoRecStmt _ stmts -> concatMap collectDoStmtExpr stmts
-
-collectCompStmt :: CompStmt -> [ResolutionAnnotation]
-collectCompStmt stmt =
-  case stmt of
-    CompGen _ pat expr -> collectPattern pat <> collectExpr expr
-    CompGuard _ expr -> collectExpr expr
-    CompLet _ bindings -> concatMap (collectExpr . snd) bindings
-    CompLetDecls _ decls -> concatMap collectDecl decls
-
-collectArithSeq :: ArithSeq -> [ResolutionAnnotation]
-collectArithSeq arithSeq =
-  case arithSeq of
-    ArithSeqFrom _ start -> collectExpr start
-    ArithSeqFromThen _ start next -> collectExpr start <> collectExpr next
-    ArithSeqFromTo _ start end -> collectExpr start <> collectExpr end
-    ArithSeqFromThenTo _ start next end -> collectExpr start <> collectExpr next <> collectExpr end
-
-collectCmd :: Cmd -> [ResolutionAnnotation]
-collectCmd cmd =
-  case cmd of
-    CmdArrApp _ left _ right -> collectExpr left <> collectExpr right
-    CmdApp _ inner expr -> collectCmd inner <> collectExpr expr
-    CmdLam _ pats inner -> concatMap collectPattern pats <> collectCmd inner
-    CmdPar _ inner -> collectCmd inner
-    CmdIf _ expr thenCmd elseCmd -> collectExpr expr <> collectCmd thenCmd <> collectCmd elseCmd
-    CmdCase _ expr alts -> collectExpr expr <> concatMap collectCmdCaseAlt alts
-    CmdLet _ decls inner -> concatMap collectDecl decls <> collectCmd inner
-    CmdDo _ stmts -> concatMap collectDoStmtCmd stmts
-    CmdInfix _ left _ right -> collectCmd left <> collectCmd right
-
-collectCmdCaseAlt :: CmdCaseAlt -> [ResolutionAnnotation]
-collectCmdCaseAlt alt = collectPattern (cmdCaseAltPat alt) <> collectCmd (cmdCaseAltBody alt)
-
-collectDoStmtCmd :: DoStmt Cmd -> [ResolutionAnnotation]
-collectDoStmtCmd stmt =
-  case stmt of
-    DoBind _ pat cmd -> collectPattern pat <> collectCmd cmd
-    DoLet _ bindings -> concatMap (collectExpr . snd) bindings
-    DoLetDecls _ decls -> concatMap collectDecl decls
-    DoExpr _ cmd -> collectCmd cmd
-    DoRecStmt _ stmts -> concatMap collectDoStmtCmd stmts
-
-collectType :: Type -> [ResolutionAnnotation]
-collectType ty =
-  case ty of
-    TAnn _ inner -> collectType inner
-    TImplicitParam _ _ inner -> collectType inner
-    TForall _ _ inner -> collectType inner
-    TApp _ left right -> collectType left <> collectType right
-    TFun _ left right -> collectType left <> collectType right
-    TTuple _ _ _ tys -> concatMap collectType tys
-    TUnboxedSum _ tys -> concatMap collectType tys
-    TList _ _ tys -> concatMap collectType tys
-    TParen _ inner -> collectType inner
-    TKindSig _ inner kind -> collectType inner <> collectType kind
-    TContext _ constraints inner -> concatMap collectType constraints <> collectType inner
-    TSplice _ expr -> collectExpr expr
-    TVar {} -> []
-    TCon {} -> []
-    TTypeLit {} -> []
-    TStar {} -> []
-    TQuasiQuote {} -> []
-    TWildcard {} -> []
-
-ownDeclAnnotation :: Decl -> [ResolutionAnnotation]
-ownDeclAnnotation decl =
-  case decl of
-    DeclAnn ann _ -> maybeToList (fromAnnotation ann :: Maybe ResolutionAnnotation)
-    _ -> []
-
-ownPatternAnnotation :: Pattern -> [ResolutionAnnotation]
-ownPatternAnnotation pat =
-  case pat of
-    PAnn ann _ -> maybeToList (fromAnnotation ann :: Maybe ResolutionAnnotation)
-    _ -> []
-
-ownExprAnnotation :: Expr -> [ResolutionAnnotation]
-ownExprAnnotation expr =
-  case expr of
-    EAnn ann _ -> maybeToList (fromAnnotation ann :: Maybe ResolutionAnnotation)
-    _ -> []
-
-maybeToList :: Maybe a -> [a]
-maybeToList maybeValue =
-  case maybeValue of
-    Just value -> [value]
+maybeAnnotation :: Annotation -> [ResolutionAnnotation]
+maybeAnnotation ann =
+  case fromAnnotation ann :: Maybe ResolutionAnnotation of
+    Just resolution -> [resolution]
     Nothing -> []
-
-maybeCons :: Maybe a -> [a] -> [a]
-maybeCons maybeValue rest =
-  case maybeValue of
-    Just value -> value : rest
-    Nothing -> rest

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -1,7 +1,13 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Aihc.Resolve.Types
-  ( ResolvedName (..),
+  ( pattern DeclResolution,
+    pattern EResolution,
+    pattern PResolution,
+    pattern TResolution,
+    ResolvedName (..),
     ResolutionAnnotation (..),
     ResolveError (..),
     ResolveResult (..),
@@ -11,20 +17,22 @@ module Aihc.Resolve.Types
 where
 
 import Aihc.Parser.Syntax
-  ( Annotation,
-    Decl (..),
+  ( Decl (..),
     Expr (..),
     Module (..),
     Name,
     Pattern (..),
     SourceSpan (..),
+    Type (..),
     UnqualifiedName,
     fromAnnotation,
+    moduleName,
     renderName,
     renderUnqualifiedName,
   )
 import Data.Data (Data, cast, gmapQ)
 import Data.List (intercalate, sortOn)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Typeable (Typeable)
@@ -52,9 +60,21 @@ data ResolveResult = ResolveResult
   }
   deriving (Show)
 
+pattern DeclResolution :: ResolutionAnnotation -> Decl
+pattern DeclResolution resolution <- DeclAnn (fromAnnotation -> Just resolution) _
+
+pattern PResolution :: ResolutionAnnotation -> Pattern
+pattern PResolution resolution <- PAnn (fromAnnotation -> Just resolution) _
+
+pattern TResolution :: ResolutionAnnotation -> Type
+pattern TResolution resolution <- TAnn (fromAnnotation -> Just resolution) _
+
+pattern EResolution :: ResolutionAnnotation -> Expr
+pattern EResolution resolution <- EAnn (fromAnnotation -> Just resolution) _
+
 renderResolveResult :: ResolveResult -> String
 renderResolveResult result =
-  intercalate "\n" (map renderResolutionAnnotation (sortOn annotationKey (collectModules (resolvedModules result))))
+  intercalate "\n" (map renderModuleAnnotations (sortOn fst (collectModules (resolvedModules result))))
 
 renderResolvedName :: ResolvedName -> String
 renderResolvedName resolvedName =
@@ -71,13 +91,13 @@ renderResolutionAnnotation ann =
     <> " => "
     <> renderResolvedName (resolutionTarget ann)
 
-annotationKey :: ResolutionAnnotation -> (FilePath, Int, Int, Int, Int, Text)
+annotationKey :: ResolutionAnnotation -> (Int, Int, Int, Int, Text)
 annotationKey ann =
   case resolutionSpan ann of
-    SourceSpan path startLine startCol endLine endCol _ _ ->
-      (path, startLine, startCol, endLine, endCol, resolutionName ann)
+    SourceSpan _ startLine startCol endLine endCol _ _ ->
+      (startLine, startCol, endLine, endCol, resolutionName ann)
     NoSourceSpan ->
-      ("", maxBound, maxBound, maxBound, maxBound, resolutionName ann)
+      (maxBound, maxBound, maxBound, maxBound, resolutionName ann)
 
 renderSourceSpan :: SourceSpan -> String
 renderSourceSpan span' =
@@ -92,8 +112,12 @@ renderSourceSpan span' =
         <> show endCol
     NoSourceSpan -> "<no-source>"
 
-collectModules :: [Module] -> [ResolutionAnnotation]
-collectModules = concatMap (concatMap collectAnnotations . moduleDecls)
+collectModules :: [Module] -> [(Text, [ResolutionAnnotation])]
+collectModules = map collectModuleAnnotations
+
+collectModuleAnnotations :: Module -> (Text, [ResolutionAnnotation])
+collectModuleAnnotations modu =
+  (moduleDisplayName modu, collectAnnotations modu)
 
 collectAnnotations :: (Data a) => a -> [ResolutionAnnotation]
 collectAnnotations node =
@@ -101,27 +125,40 @@ collectAnnotations node =
 
 ownAnnotation :: (Data a) => a -> [ResolutionAnnotation]
 ownAnnotation node =
-  case cast node of
-    Just decl ->
-      case decl of
-        DeclAnn ann _ -> maybeAnnotation ann
-        _ -> []
-    Nothing ->
-      case cast node of
-        Just pat ->
-          case pat of
-            PAnn ann _ -> maybeAnnotation ann
-            _ -> []
-        Nothing ->
-          case cast node of
-            Just expr ->
-              case expr of
-                EAnn ann _ -> maybeAnnotation ann
-                _ -> []
-            Nothing -> []
+  declResolution (cast node)
+    <> patternResolution (cast node)
+    <> typeResolution (cast node)
+    <> exprResolution (cast node)
 
-maybeAnnotation :: Annotation -> [ResolutionAnnotation]
-maybeAnnotation ann =
-  case fromAnnotation ann :: Maybe ResolutionAnnotation of
-    Just resolution -> [resolution]
-    Nothing -> []
+declResolution :: Maybe Decl -> [ResolutionAnnotation]
+declResolution maybeDecl =
+  case maybeDecl of
+    Just (DeclResolution resolution) -> [resolution]
+    _ -> []
+
+patternResolution :: Maybe Pattern -> [ResolutionAnnotation]
+patternResolution maybePattern =
+  case maybePattern of
+    Just (PResolution resolution) -> [resolution]
+    _ -> []
+
+typeResolution :: Maybe Type -> [ResolutionAnnotation]
+typeResolution maybeType =
+  case maybeType of
+    Just (TResolution resolution) -> [resolution]
+    _ -> []
+
+exprResolution :: Maybe Expr -> [ResolutionAnnotation]
+exprResolution maybeExpr =
+  case maybeExpr of
+    Just (EResolution resolution) -> [resolution]
+    _ -> []
+
+renderModuleAnnotations :: (Text, [ResolutionAnnotation]) -> String
+renderModuleAnnotations (moduleNameText, annotations) =
+  T.unpack moduleNameText
+    <> ":\n"
+    <> intercalate "\n" (map (("  " <>) . renderResolutionAnnotation) (sortOn annotationKey annotations))
+
+moduleDisplayName :: Module -> Text
+moduleDisplayName modu = fromMaybe (T.pack "<unnamed>") (moduleName modu)

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
@@ -7,6 +7,9 @@ modules:
     module Main where
     import Lib
     x = helper
-expected: ~
-status: xfail
-reason: Name resolution not yet implemented
+expected:
+  - "2:1-2:7 helper => Lib.helper"
+  - "3:1-3:2 x => Main.x"
+  - "3:5-3:11 helper => Lib.helper"
+status: pass
+reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
@@ -8,8 +8,10 @@ modules:
     import Lib
     x = helper
 expected:
-  - "2:1-2:7 helper => Lib.helper"
-  - "3:1-3:2 x => Main.x"
-  - "3:5-3:11 helper => Lib.helper"
+  Lib:
+    - "2:1-2:7 helper => Lib.helper"
+  Main:
+    - "3:1-3:2 x => Main.x"
+    - "3:5-3:11 helper => Lib.helper"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -3,6 +3,9 @@ modules:
   - |
     module Main where
     f = let y = 10 in y
-expected: ~
-status: xfail
-reason: Name resolution not yet implemented
+expected:
+  - "2:1-2:2 f => Main.f"
+  - "2:9-2:10 y => Local 0 y"
+  - "2:19-2:20 y => Local 0 y"
+status: pass
+reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -4,8 +4,9 @@ modules:
     module Main where
     f = let y = 10 in y
 expected:
-  - "2:1-2:2 f => Main.f"
-  - "2:9-2:10 y => Local 0 y"
-  - "2:19-2:20 y => Local 0 y"
+  Main:
+    - "2:1-2:2 f => Main.f"
+    - "2:9-2:10 y => Local 0 y"
+    - "2:19-2:20 y => Local 0 y"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
@@ -3,6 +3,7 @@ modules:
   - |
     module Main where
     x = 1
-expected: ~
-status: xfail
-reason: Name resolution not yet implemented
+expected:
+  - "2:1-2:2 x => Main.x"
+status: pass
+reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
@@ -4,6 +4,7 @@ modules:
     module Main where
     x = 1
 expected:
-  - "2:1-2:2 x => Main.x"
+  Main:
+    - "2:1-2:2 x => Main.x"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
@@ -5,8 +5,9 @@ modules:
     x = 1
     y = x
 expected:
-  - "2:1-2:2 x => Main.x"
-  - "3:1-3:2 y => Main.y"
-  - "3:5-3:6 x => Main.x"
+  Main:
+    - "2:1-2:2 x => Main.x"
+    - "3:1-3:2 y => Main.y"
+    - "3:5-3:6 x => Main.x"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
@@ -4,6 +4,9 @@ modules:
     module Main where
     x = 1
     y = x
-expected: ~
-status: xfail
-reason: Name resolution not yet implemented
+expected:
+  - "2:1-2:2 x => Main.x"
+  - "3:1-3:2 y => Main.y"
+  - "3:5-3:6 x => Main.x"
+status: pass
+reason: ""


### PR DESCRIPTION
## Summary
- add an MVP resolver that annotates top-level bindings, imported unqualified names, local binders, and variable references with globally unique names
- expose parser annotation helpers plus `DeclResolution`/`PResolution`/`TResolution`/`EResolution` pattern synonyms for consuming resolution annotations
- switch resolver goldens to compare module-indexed rendered annotations, and derive `Data` for `Module` so annotation collection can traverse whole modules generically

## Why
`aihc-resolve` was still a stub, so even the minimal local-binding scenario could not produce any resolution output. This change adds the smallest viable pass that keeps the AST shape intact, stores results as annotations, and makes the annotation consumption API less brittle.

## Progress Counts
- `aihc-resolve` golden progress: PASS `0 -> 4`, XFAIL `4 -> 0`, XPASS `0 -> 0`, FAIL `0 -> 0`

## Validation
- `cabal test -v0 aihc-resolve:spec --test-options=--hide-successes`
- `cabal test -v0 all --test-options=--hide-successes`
- `nix flake check`

## CodeRabbit
- `coderabbit review --prompt-only` was attempted, but it hung while connecting to the review service, so it was skipped per repo guidance.
