### PR TITLE
fix(parser): handle empty where clauses and empty declaration quotes

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -33,6 +33,7 @@ module Aihc.Parser.Internal.Common
     skipSemicolons,
     bracedSemiSep,
     bracedSemiSep1,
+    plainSemiSep,
     plainSemiSep1,
     contextItemParserWith,
     contextItemsParserWith,
@@ -428,6 +429,11 @@ bracedSemiSep1 parser =
   braces $ do
     skipSemicolons
     parser `MP.sepEndBy1` expectedTok TkSpecialSemicolon
+
+-- | Zero-or-more variant of 'plainSemiSep1'.
+-- Parses zero or more items separated by semicolons (no surrounding braces).
+plainSemiSep :: TokParser a -> TokParser [a]
+plainSemiSep parser = MP.many (parser <* skipSemicolons)
 
 plainSemiSep1 :: TokParser a -> TokParser [a]
 plainSemiSep1 parser = MP.some (parser <* skipSemicolons)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1439,7 +1439,7 @@ plainDeclsParser :: TokParser [Decl]
 plainDeclsParser = concat <$> plainSemiSep1 localDeclsParser
 
 bracedDeclsParser :: TokParser [Decl]
-bracedDeclsParser = concat <$> bracedSemiSep1 localDeclsParser
+bracedDeclsParser = concat <$> bracedSemiSep localDeclsParser
 
 -- Some local declaration items lower to a single binding carrying an inline
 -- type signature, so the parser emits a declaration group rather than a
@@ -1845,7 +1845,7 @@ thTypedQuoteParser = withSpan $ do
 thDeclQuoteParser :: TokParser Expr
 thDeclQuoteParser = withSpan $ do
   expectedTok TkTHDeclQuoteOpen
-  decls <- plainSemiSep1 declParser
+  decls <- plainSemiSep declParser
   expectedTok TkTHExpQuoteClose
   pure (`ETHDeclQuote` decls)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/bare-let-in-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/bare-let-in-do.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="Bare let in do block without bindings not handled" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Haskell2010 #-}
 
 module BareLetInDo where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_decl_quote_empty.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_decl_quote_empty.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+module TH_Decl_Quote_Empty where
+
+import Language.Haskell.TH (Dec, Q)
+
+-- Empty declaration quotes are valid syntax
+emptyDecls :: Q [Dec]
+emptyDecls = [d| |]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/declarations/infix-funlhs-where-empty.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/declarations/infix-funlhs-where-empty.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module InfixFunlhsWhereEmpty where
+-- An infix function definition with an explicit empty where clause
+x `myOp` y = x where {}

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/declarations/where-empty-braces.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/declarations/where-empty-braces.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module WhereEmptyBraces where
+-- An explicit empty where clause is valid syntax
+f x = x where {}

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -254,7 +254,7 @@ genCaseAlt n = do
 -- variable bindings like `x = e`.
 genValueDecls :: Int -> Gen [Decl]
 genValueDecls n = do
-  count <- chooseInt (1, 3)
+  count <- chooseInt (0, 3)
   names <- vectorOf count (mkUnqualifiedName NameVarId <$> genIdent)
   exprs <- vectorOf count (genExprSized (n `div` count))
   pure


### PR DESCRIPTION
## Summary

Two related QuickCheck failures caused by `Sep1` parsers rejecting valid zero-item bodies:

### Bug 1: `[d| |]` (empty TH declaration quote)

`thDeclQuoteParser` used `plainSemiSep1` (requires ≥1 item) to parse declarations inside `[d| ... |]`. An empty declaration quote is valid Haskell, so this caused a parse failure.

**Fix:** Switch to new `plainSemiSep` (≥0 items). Also adds `plainSemiSep` as a general utility alongside `plainSemiSep1` in `Common.hs`.

### Bug 2: `f = e where {}` (explicit empty where clause)

`bracedDeclsParser` used `bracedSemiSep1` (requires ≥1 item). The failure mode was subtle: after consuming `{`, the parser failed inside the braces, and the `<|>` in `whereClauseParser` could not backtrack to `plainDeclsParser` (because `{` was already consumed). This caused the whole where clause to be rejected, which in turn caused `valueDeclParser` to fail under `MP.try`, leaving `implicitSpliceDeclParser` to consume only the infix function head — then `= rhs where {}` became unexpected input.

**Fix:** Switch `bracedDeclsParser` to `bracedSemiSep` (≥0 items).

### Bonus fix: bare `let` in do-blocks

The same `bracedSemiSep` fix also correctly handles `let {}` (a `let` in a do-block with an empty layout-inserted brace pair, i.e., `let` followed by nothing). The `bare-let-in-do` oracle fixture is promoted from `xfail` to `pass`.

## Test plan

- [x] Replay seed `(SMGen 12008668351762829020 15359023544040686051,9)` passes
- [x] All 1266 tests pass
- [x] New oracle fixtures: `th_decl_quote_empty`, `where-empty-braces`, `infix-funlhs-where-empty`
- [x] `genValueDecls` in QuickCheck generator now generates 0–3 declarations (was 1–3) to keep exercising these empty-body cases