### PR TITLE
test(resolve): add let and where shadowing golden case

### DIFF
--- a/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
@@ -1,0 +1,16 @@
+extensions: []
+modules:
+  - |
+    module Main where
+    fn x = let x = x in x where x = x
+expected:
+  Main:
+    - "2:1-2:3 fn => Main.fn"
+    - "2:4-2:5 x => Local 0 x"
+    - "2:12-2:13 x => Local 1 x"
+    - "2:16-2:17 x => Local 1 x"
+    - "2:21-2:22 x => Local 1 x"
+    - "2:29-2:30 x => Local 2 x"
+    - "2:33-2:34 x => Local 2 x"
+status: pass
+reason: ""


### PR DESCRIPTION
## Summary
- Add a resolver golden case covering `fn x = let x = x in x where x = x` to lock in nested `let` and `where` shadowing behavior.
- Verify `aihc-resolve` resolves the argument binder, recursive `let` binder, and `where` binder to distinct locals in the expected scopes.

## Testing
- `cabal test -v0 spec --test-options="--pattern resolver-golden"` in `components/aihc-resolve`
- `cabal test -v0 all --test-options=--hide-successes` in `components/aihc-resolve`
- `just check`

## Progress
- Resolver golden progress: PASS 5 -> 6, XFAIL 0 -> 0, XPASS 0 -> 0, FAIL 0 -> 0, COMPLETE 100.0% -> 100.0%

## CodeRabbit
- `coderabbit review --prompt-only` reported two pre-existing `Aihc.Resolve` issues unrelated to this fixture-only change; no changes were needed for this PR.
