### PR TITLE
fix(resolve): separate type and term namespaces

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -10,6 +10,7 @@ module Aihc.Resolve
     resolve,
     ResolveError (..),
     ResolveResult (..),
+    ResolutionNamespace (..),
     ResolvedName (..),
     ResolutionAnnotation (..),
     renderResolveResult,
@@ -181,7 +182,7 @@ resolveExpr scope nextLocal expr =
     EVar span' name ->
       ( nextLocal,
         annotateExpr
-          (ResolutionAnnotation span' (nameText name) (resolveTermName scope name))
+          (ResolutionAnnotation span' (nameText name) ResolutionNamespaceTerm (resolveTermName scope name))
           (EVar span' name)
       )
     EIf span' cond trueBranch falseBranch ->
@@ -249,7 +250,7 @@ bindPattern nextLocal pat =
     PAnn _ inner -> bindPattern nextLocal inner
     PVar span' name ->
       let resolvedName = ResolvedLocal nextLocal name
-          annotation = ResolutionAnnotation span' (renderUnqualifiedName name) resolvedName
+          annotation = ResolutionAnnotation span' (renderUnqualifiedName name) ResolutionNamespaceTerm resolvedName
        in (nextLocal + 1, Scope (Map.singleton (renderUnqualifiedName name) resolvedName) Map.empty, annotatePattern annotation (PVar span' name))
     PTuple span' flavor pats ->
       let (nextLocal', scope, pats') = bindPatterns nextLocal pats
@@ -270,7 +271,7 @@ bindPattern nextLocal pat =
     PAs span' alias inner ->
       let aliasName = mkUnqualifiedName NameVarId alias
           aliasResolved = ResolvedLocal nextLocal aliasName
-          aliasAnnotation = ResolutionAnnotation (spanStartNameSpan span' alias) alias aliasResolved
+          aliasAnnotation = ResolutionAnnotation (spanStartNameSpan span' alias) alias ResolutionNamespaceTerm aliasResolved
           (nextLocal', innerScope, inner') = bindPattern (nextLocal + 1) inner
           aliasScope = Scope (Map.singleton alias aliasResolved) Map.empty
        in (nextLocal', unionScope innerScope aliasScope, annotatePattern aliasAnnotation (PAs span' alias inner'))
@@ -338,7 +339,7 @@ resolveType scope ty =
     TAnn _ inner -> resolveType scope inner
     TCon span' name promoted ->
       annotateType
-        (ResolutionAnnotation span' (nameText name) (resolveTypeName scope name))
+        (ResolutionAnnotation span' (nameText name) ResolutionNamespaceType (resolveTypeName scope name))
         (TCon span' name promoted)
     TImplicitParam span' name inner ->
       TImplicitParam span' name (resolveType scope inner)
@@ -373,7 +374,7 @@ allocateLocalDeclBinders nextLocal =
         Just (span', name) ->
           let resolvedName = ResolvedLocal currentId name
               key = renderUnqualifiedName name
-              annotation = ResolutionAnnotation span' (renderUnqualifiedName name) resolvedName
+              annotation = ResolutionAnnotation span' (renderUnqualifiedName name) ResolutionNamespaceTerm resolvedName
            in ( currentId + 1,
                 Map.insert key annotation annotations,
                 insertTerm key resolvedName scope
@@ -391,7 +392,7 @@ topLevelBinderAnnotation decl scope =
   case declBinderCandidate decl of
     Just (span', name) ->
       let rendered = renderUnqualifiedName name
-       in Just (ResolutionAnnotation span' rendered (lookupTerm rendered scope))
+       in Just (ResolutionAnnotation span' rendered ResolutionNamespaceTerm (lookupTerm rendered scope))
     Nothing -> Nothing
 
 declBinderCandidate :: Decl -> Maybe (SourceSpan, UnqualifiedName)
@@ -418,6 +419,7 @@ topLevelDeclAnnotations decl scope =
             ResolutionAnnotation
               (declKeywordNameSpan "newtype " (newtypeDeclSpan newtypeDecl) (renderUnqualifiedName (newtypeDeclName newtypeDecl)))
               (renderUnqualifiedName (newtypeDeclName newtypeDecl))
+              ResolutionNamespaceType
               (resolveTopLevelType scope (newtypeDeclName newtypeDecl))
           constructorAnnotations =
             maybe [] (\ctor -> [dataConAnnotation scope ctor]) (newtypeDeclConstructor newtypeDecl)
@@ -429,6 +431,7 @@ topLevelDeclAnnotations decl scope =
             ResolutionAnnotation
               (declKeywordNameSpan keyword (dataDeclSpan dataDecl) (renderUnqualifiedName (dataDeclName dataDecl)))
               (renderUnqualifiedName (dataDeclName dataDecl))
+              ResolutionNamespaceType
               (resolveTopLevelType scope (dataDeclName dataDecl))
        in typeAnnotation : map (dataConAnnotation scope) (dataDeclConstructors dataDecl)
 
@@ -438,6 +441,7 @@ classAnnotation scope classDecl =
    in ResolutionAnnotation
         (declKeywordNameSpan "class " (classDeclSpan classDecl) (classDeclName classDecl))
         (classDeclName classDecl)
+        ResolutionNamespaceType
         (resolveTopLevelType scope className)
 
 resolveTopLevelType :: Scope -> UnqualifiedName -> ResolvedName
@@ -458,13 +462,14 @@ dataConAnnotation scope dataConDecl =
     GadtCon span' _ _ names _ ->
       case names of
         name : _ -> topLevelNameAnnotation scope span' name
-        [] -> ResolutionAnnotation NoSourceSpan "" (ResolvedError "missing GADT constructor name")
+        [] -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "missing GADT constructor name")
 
 topLevelNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
 topLevelNameAnnotation scope span' name =
   ResolutionAnnotation
     (spanStartNameSpan span' (renderUnqualifiedName name))
     (renderUnqualifiedName name)
+    ResolutionNamespaceTerm
     (resolveTopLevelTerm scope name)
 
 collectModuleExports :: [Module] -> ModuleExports

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -18,6 +18,7 @@ where
 
 import Aihc.Parser.Syntax
   ( BangType (..),
+    ClassDecl (..),
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
@@ -53,7 +54,10 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-type Scope = Map.Map Text ResolvedName
+data Scope = Scope
+  { scopeTerms :: Map.Map Text ResolvedName,
+    scopeTypes :: Map.Map Text ResolvedName
+  }
 
 type ModuleExports = Map.Map Text Scope
 
@@ -125,7 +129,7 @@ resolveDecl scope nextLocal decl =
 resolveMatch :: Scope -> Int -> Match -> (Int, Match)
 resolveMatch scope nextLocal match =
   let (nextLocal', patScope, pats') = bindPatterns nextLocal (matchPats match)
-      scoped = patScope `Map.union` scope
+      scoped = unionScope patScope scope
       (nextLocal'', rhs') = resolveRhs scoped nextLocal' (matchRhs match)
    in (nextLocal'', match {matchPats = pats', matchRhs = rhs'})
 
@@ -163,10 +167,10 @@ resolveGuardQualifier scope nextLocal qualifier =
     GuardPat span' pat expr ->
       let (nextLocal', expr') = resolveExpr scope nextLocal expr
           (nextLocal'', patScope, pat') = bindPattern nextLocal' pat
-       in (nextLocal'', patScope `Map.union` scope, GuardPat span' pat' expr')
+       in (nextLocal'', unionScope patScope scope, GuardPat span' pat' expr')
     GuardLet span' decls ->
       let (nextLocal', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal decls
-          scoped = localScope `Map.union` scope
+          scoped = unionScope localScope scope
           (nextLocal'', decls') = mapAccumL (resolveBoundDecl scoped binderAnnotations) nextLocal' decls
        in (nextLocal'', scoped, GuardLet span' decls')
 
@@ -177,7 +181,7 @@ resolveExpr scope nextLocal expr =
     EVar span' name ->
       ( nextLocal,
         annotateExpr
-          (ResolutionAnnotation span' (nameText name) (resolveName scope name))
+          (ResolutionAnnotation span' (nameText name) (resolveTermName scope name))
           (EVar span' name)
       )
     EIf span' cond trueBranch falseBranch ->
@@ -200,7 +204,7 @@ resolveExpr scope nextLocal expr =
        in (nextLocal', ESectionR span' op inner')
     ELetDecls span' decls body ->
       let (nextLocal', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal decls
-          scoped = localScope `Map.union` scope
+          scoped = unionScope localScope scope
           (nextLocal'', decls') = mapAccumL (resolveBoundDecl scoped binderAnnotations) nextLocal' decls
           (nextLocal''', body') = resolveExpr scoped nextLocal'' body
        in (nextLocal''', ELetDecls span' decls' body')
@@ -213,7 +217,7 @@ resolveExpr scope nextLocal expr =
     EWhereDecls span' inner decls ->
       let (nextLocal', inner') = resolveExpr scope nextLocal inner
           (nextLocal'', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal' decls
-          scoped = localScope `Map.union` scope
+          scoped = unionScope localScope scope
           (nextLocal''', decls') = mapAccumL (resolveBoundDecl scoped binderAnnotations) nextLocal'' decls
        in (nextLocal''', EWhereDecls span' inner' decls')
     ETypeApp span' fun ty ->
@@ -233,11 +237,11 @@ resolveBoundDecl scope binderAnnotations nextLocal decl =
 bindPatterns :: Int -> [Pattern] -> (Int, Scope, [Pattern])
 bindPatterns nextLocal pats =
   let (nextLocal', scopedEntries, pats') = foldl' step (nextLocal, [], []) pats
-   in (nextLocal', Map.fromList scopedEntries, reverse pats')
+   in (nextLocal', Scope (Map.fromList scopedEntries) Map.empty, reverse pats')
   where
     step (currentId, entries, acc) pat =
       let (nextId, scope, pat') = bindPattern currentId pat
-       in (nextId, Map.toList scope <> entries, pat' : acc)
+       in (nextId, Map.toList (scopeTerms scope) <> entries, pat' : acc)
 
 bindPattern :: Int -> Pattern -> (Int, Scope, Pattern)
 bindPattern nextLocal pat =
@@ -246,7 +250,7 @@ bindPattern nextLocal pat =
     PVar span' name ->
       let resolvedName = ResolvedLocal nextLocal name
           annotation = ResolutionAnnotation span' (renderUnqualifiedName name) resolvedName
-       in (nextLocal + 1, Map.singleton (renderUnqualifiedName name) resolvedName, annotatePattern annotation (PVar span' name))
+       in (nextLocal + 1, Scope (Map.singleton (renderUnqualifiedName name) resolvedName) Map.empty, annotatePattern annotation (PVar span' name))
     PTuple span' flavor pats ->
       let (nextLocal', scope, pats') = bindPatterns nextLocal pats
        in (nextLocal', scope, PTuple span' flavor pats')
@@ -259,7 +263,7 @@ bindPattern nextLocal pat =
     PInfix span' left name right ->
       let (nextLocal', leftScope, left') = bindPattern nextLocal left
           (nextLocal'', rightScope, right') = bindPattern nextLocal' right
-       in (nextLocal'', rightScope `Map.union` leftScope, PInfix span' left' name right')
+       in (nextLocal'', unionScope rightScope leftScope, PInfix span' left' name right')
     PView span' expr inner ->
       let (nextLocal', scope, inner') = bindPattern nextLocal inner
        in (nextLocal', scope, PView span' expr inner')
@@ -268,8 +272,8 @@ bindPattern nextLocal pat =
           aliasResolved = ResolvedLocal nextLocal aliasName
           aliasAnnotation = ResolutionAnnotation (spanStartNameSpan span' alias) alias aliasResolved
           (nextLocal', innerScope, inner') = bindPattern (nextLocal + 1) inner
-          aliasScope = Map.singleton alias aliasResolved
-       in (nextLocal', innerScope `Map.union` aliasScope, annotatePattern aliasAnnotation (PAs span' alias inner'))
+          aliasScope = Scope (Map.singleton alias aliasResolved) Map.empty
+       in (nextLocal', unionScope innerScope aliasScope, annotatePattern aliasAnnotation (PAs span' alias inner'))
     PStrict span' inner ->
       let (nextLocal', scope, inner') = bindPattern nextLocal inner
        in (nextLocal', scope, PStrict span' inner')
@@ -284,15 +288,15 @@ bindPattern nextLocal pat =
             foldl'
               ( \(currentId, currentEntries, acc) (fieldName, fieldPat) ->
                   let (nextId, fieldScope, fieldPat') = bindPattern currentId fieldPat
-                   in (nextId, Map.toList fieldScope <> currentEntries, (fieldName, fieldPat') : acc)
+                   in (nextId, Map.toList (scopeTerms fieldScope) <> currentEntries, (fieldName, fieldPat') : acc)
               )
               (nextLocal, [], [])
               fields
-       in (nextLocal', Map.fromList entries, PRecord span' name (reverse fields') wildcard)
+       in (nextLocal', Scope (Map.fromList entries) Map.empty, PRecord span' name (reverse fields') wildcard)
     PTypeSig span' inner ty ->
       let (nextLocal', scope, inner') = bindPattern nextLocal inner
        in (nextLocal', scope, PTypeSig span' inner' (resolveType scope ty))
-    _ -> (nextLocal, Map.empty, pat)
+    _ -> (nextLocal, emptyScope, pat)
 
 resolveDataDecl :: Scope -> DataDecl -> DataDecl
 resolveDataDecl scope dataDecl =
@@ -334,7 +338,7 @@ resolveType scope ty =
     TAnn _ inner -> resolveType scope inner
     TCon span' name promoted ->
       annotateType
-        (ResolutionAnnotation span' (nameText name) (resolveName scope name))
+        (ResolutionAnnotation span' (nameText name) (resolveTypeName scope name))
         (TCon span' name promoted)
     TImplicitParam span' name inner ->
       TImplicitParam span' name (resolveType scope inner)
@@ -362,17 +366,17 @@ resolveType scope ty =
 
 allocateLocalDeclBinders :: Int -> [Decl] -> (Int, Map.Map Text ResolutionAnnotation, Scope)
 allocateLocalDeclBinders nextLocal =
-  foldl' step (nextLocal, Map.empty, Map.empty)
+  foldl' step (nextLocal, Map.empty, emptyScope)
   where
     step (currentId, annotations, scope) decl =
       case declBinderCandidate decl of
         Just (span', name) ->
           let resolvedName = ResolvedLocal currentId name
               key = renderUnqualifiedName name
-              annotation = ResolutionAnnotation span' key resolvedName
+              annotation = ResolutionAnnotation span' (renderUnqualifiedName name) resolvedName
            in ( currentId + 1,
                 Map.insert key annotation annotations,
-                Map.insert key resolvedName scope
+                insertTerm key resolvedName scope
               )
         Nothing -> (currentId, annotations, scope)
 
@@ -386,8 +390,8 @@ topLevelBinderAnnotation :: Decl -> Scope -> Maybe ResolutionAnnotation
 topLevelBinderAnnotation decl scope =
   case declBinderCandidate decl of
     Just (span', name) ->
-      let key = renderUnqualifiedName name
-       in Just (ResolutionAnnotation span' key (fromMaybe (ResolvedError ("missing top-level binding for " <> T.unpack key)) (Map.lookup key scope)))
+      let rendered = renderUnqualifiedName name
+       in Just (ResolutionAnnotation span' rendered (lookupTerm rendered scope))
     Nothing -> Nothing
 
 declBinderCandidate :: Decl -> Maybe (SourceSpan, UnqualifiedName)
@@ -406,6 +410,7 @@ declBinderCandidate decl =
 topLevelDeclAnnotations :: Decl -> Scope -> [ResolutionAnnotation]
 topLevelDeclAnnotations decl scope =
   case decl of
+    DeclClass _ classDecl -> [classAnnotation scope classDecl]
     DeclTypeData _ dataDecl -> dataDeclAnnotations "type data " dataDecl
     DeclData _ dataDecl -> dataDeclAnnotations "data " dataDecl
     DeclNewtype _ newtypeDecl ->
@@ -413,7 +418,7 @@ topLevelDeclAnnotations decl scope =
             ResolutionAnnotation
               (declKeywordNameSpan "newtype " (newtypeDeclSpan newtypeDecl) (renderUnqualifiedName (newtypeDeclName newtypeDecl)))
               (renderUnqualifiedName (newtypeDeclName newtypeDecl))
-              (resolveTopLevel scope (newtypeDeclName newtypeDecl))
+              (resolveTopLevelType scope (newtypeDeclName newtypeDecl))
           constructorAnnotations =
             maybe [] (\ctor -> [dataConAnnotation scope ctor]) (newtypeDeclConstructor newtypeDecl)
        in typeAnnotation : constructorAnnotations
@@ -424,14 +429,22 @@ topLevelDeclAnnotations decl scope =
             ResolutionAnnotation
               (declKeywordNameSpan keyword (dataDeclSpan dataDecl) (renderUnqualifiedName (dataDeclName dataDecl)))
               (renderUnqualifiedName (dataDeclName dataDecl))
-              (resolveTopLevel scope (dataDeclName dataDecl))
+              (resolveTopLevelType scope (dataDeclName dataDecl))
        in typeAnnotation : map (dataConAnnotation scope) (dataDeclConstructors dataDecl)
 
-resolveTopLevel :: Scope -> UnqualifiedName -> ResolvedName
-resolveTopLevel scope name =
-  fromMaybe
-    (ResolvedError ("missing top-level binding for " <> T.unpack (renderUnqualifiedName name)))
-    (Map.lookup (renderUnqualifiedName name) scope)
+classAnnotation :: Scope -> ClassDecl -> ResolutionAnnotation
+classAnnotation scope classDecl =
+  let className = mkUnqualifiedName NameConId (classDeclName classDecl)
+   in ResolutionAnnotation
+        (declKeywordNameSpan "class " (classDeclSpan classDecl) (classDeclName classDecl))
+        (classDeclName classDecl)
+        (resolveTopLevelType scope className)
+
+resolveTopLevelType :: Scope -> UnqualifiedName -> ResolvedName
+resolveTopLevelType scope name = lookupType (renderUnqualifiedName name) scope
+
+resolveTopLevelTerm :: Scope -> UnqualifiedName -> ResolvedName
+resolveTopLevelTerm scope name = lookupTerm (renderUnqualifiedName name) scope
 
 dataConAnnotation :: Scope -> DataConDecl -> ResolutionAnnotation
 dataConAnnotation scope dataConDecl =
@@ -452,7 +465,7 @@ topLevelNameAnnotation scope span' name =
   ResolutionAnnotation
     (spanStartNameSpan span' (renderUnqualifiedName name))
     (renderUnqualifiedName name)
-    (resolveTopLevel scope name)
+    (resolveTopLevelTerm scope name)
 
 collectModuleExports :: [Module] -> ModuleExports
 collectModuleExports modules =
@@ -463,30 +476,34 @@ collectModuleExports modules =
 
 topLevelScope :: Module -> Scope
 topLevelScope modu =
-  Map.fromList
-    [ (key, ResolvedTopLevel (mkQualifiedName name (Just moduleKeyText)))
-    | decl <- moduleDecls modu,
-      name <- declExportedNames decl,
-      let key = renderUnqualifiedName name,
-      let moduleKeyText = moduleKey modu
-    ]
+  foldl' addDecl emptyScope (moduleDecls modu)
+  where
+    moduleKeyText = moduleKey modu
+    qualify = ResolvedTopLevel . (`mkQualifiedName` Just moduleKeyText)
+    addDecl scope decl =
+      let (termNames, typeNames) = declExportedNames decl
+          scope' = foldl' (\acc name -> insertTerm (renderUnqualifiedName name) (qualify name) acc) scope termNames
+       in foldl' (\acc name -> insertType (renderUnqualifiedName name) (qualify name) acc) scope' typeNames
 
-declExportedNames :: Decl -> [UnqualifiedName]
+declExportedNames :: Decl -> ([UnqualifiedName], [UnqualifiedName])
 declExportedNames decl =
   case decl of
     DeclValue _ valueDecl ->
       case valueDecl of
-        FunctionBind _ name _ -> [name]
+        FunctionBind _ name _ -> ([name], [])
         PatternBind _ pat _ ->
           case pat of
-            PVar _ name -> [name]
-            _ -> []
-    DeclTypeSig _ names _ -> names
-    DeclTypeData _ dataDecl -> dataDeclName dataDecl : dataDeclConstructorNames (dataDeclConstructors dataDecl)
-    DeclData _ dataDecl -> dataDeclName dataDecl : dataDeclConstructorNames (dataDeclConstructors dataDecl)
+            PVar _ name -> ([name], [])
+            _ -> ([], [])
+    DeclTypeSig _ names _ -> (names, [])
+    DeclClass _ classDecl -> ([], [mkUnqualifiedName NameConId (classDeclName classDecl)])
+    DeclTypeData _ dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [dataDeclName dataDecl])
+    DeclData _ dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [dataDeclName dataDecl])
     DeclNewtype _ newtypeDecl ->
-      newtypeDeclName newtypeDecl : maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl)
-    _ -> []
+      ( maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl),
+        [newtypeDeclName newtypeDecl]
+      )
+    _ -> ([], [])
 
 dataDeclConstructorNames :: [DataConDecl] -> [UnqualifiedName]
 dataDeclConstructorNames = concatMap dataConDeclNames
@@ -501,28 +518,28 @@ dataConDeclNames dataConDecl =
 
 moduleScope :: ModuleExports -> Module -> Scope
 moduleScope exports modu =
-  ownScope `Map.union` importedScope exports modu
+  ownScope `unionScope` importedScope exports modu
   where
-    ownScope = Map.findWithDefault Map.empty (moduleKey modu) exports
+    ownScope = Map.findWithDefault emptyScope (moduleKey modu) exports
 
 importedScope :: ModuleExports -> Module -> Scope
 importedScope exports modu =
-  foldl' addImport Map.empty (moduleImports modu)
+  foldl' addImport emptyScope (moduleImports modu)
   where
     addImport acc importDecl
       | importDeclQualified importDecl || importDeclQualifiedPost importDecl = acc
       | otherwise =
-          let imported = Map.findWithDefault Map.empty (importDeclModule importDecl) exports
-           in Map.union acc (filterImportSpec (importDeclSpec importDecl) imported)
+          let imported = Map.findWithDefault emptyScope (importDeclModule importDecl) exports
+           in unionScope acc (filterImportSpec (importDeclSpec importDecl) imported)
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =
   case maybeSpec of
     Nothing -> scope
     Just ImportSpec {importSpecHiding = False, importSpecItems} ->
-      Map.filterWithKey (\name _ -> name `elem` allowedNames importSpecItems) scope
+      filterScopeByNames (`elem` allowedNames importSpecItems) scope
     Just ImportSpec {importSpecHiding = True, importSpecItems} ->
-      Map.filterWithKey (\name _ -> name `notElem` allowedNames importSpecItems) scope
+      filterScopeByNames (`notElem` allowedNames importSpecItems) scope
 
 allowedNames :: [ImportItem] -> [Text]
 allowedNames items =
@@ -535,19 +552,61 @@ allowedNames items =
       ImportItemWith _ _ itemName _ -> [renderUnqualifiedName itemName]
   ]
 
-resolveName :: Scope -> Name -> ResolvedName
-resolveName scope name =
+resolveTermName :: Scope -> Name -> ResolvedName
+resolveTermName scope name =
   case nameQualifier name of
     Just qualifier ->
       ResolvedTopLevel (name {nameQualifier = Just qualifier})
     Nothing ->
-      Map.findWithDefault
-        (ResolvedError ("unbound name: " <> T.unpack (nameText name)))
-        (nameText name)
-        scope
+      lookupTerm (nameText name) scope
+
+resolveTypeName :: Scope -> Name -> ResolvedName
+resolveTypeName scope name =
+  case nameQualifier name of
+    Just qualifier ->
+      ResolvedTopLevel (name {nameQualifier = Just qualifier})
+    Nothing ->
+      lookupType (nameText name) scope
 
 moduleKey :: Module -> Text
 moduleKey modu = fromMaybe (T.pack "Main") (moduleName modu)
+
+emptyScope :: Scope
+emptyScope = Scope Map.empty Map.empty
+
+unionScope :: Scope -> Scope -> Scope
+unionScope left right =
+  Scope
+    { scopeTerms = scopeTerms left `Map.union` scopeTerms right,
+      scopeTypes = scopeTypes left `Map.union` scopeTypes right
+    }
+
+insertTerm :: Text -> ResolvedName -> Scope -> Scope
+insertTerm name resolved scope = scope {scopeTerms = Map.insert name resolved (scopeTerms scope)}
+
+insertType :: Text -> ResolvedName -> Scope -> Scope
+insertType name resolved scope = scope {scopeTypes = Map.insert name resolved (scopeTypes scope)}
+
+lookupTerm :: Text -> Scope -> ResolvedName
+lookupTerm name scope =
+  Map.findWithDefault
+    (ResolvedError ("unbound name: " <> T.unpack name))
+    name
+    (scopeTerms scope)
+
+lookupType :: Text -> Scope -> ResolvedName
+lookupType name scope =
+  Map.findWithDefault
+    (ResolvedError ("unbound name: " <> T.unpack name))
+    name
+    (scopeTypes scope)
+
+filterScopeByNames :: (Text -> Bool) -> Scope -> Scope
+filterScopeByNames keep scope =
+  Scope
+    { scopeTerms = Map.filterWithKey (\name _ -> keep name) (scopeTerms scope),
+      scopeTypes = Map.filterWithKey (\name _ -> keep name) (scopeTypes scope)
+    }
 
 spanStartNameSpan :: SourceSpan -> Text -> SourceSpan
 spanStartNameSpan span' name =

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -7,6 +7,7 @@ module Aihc.Resolve.Types
     pattern EResolution,
     pattern PResolution,
     pattern TResolution,
+    ResolutionNamespace (..),
     ResolvedName (..),
     ResolutionAnnotation (..),
     ResolveError (..),
@@ -44,9 +45,15 @@ data ResolvedName
   | ResolvedError String
   deriving (Eq, Show, Typeable)
 
+data ResolutionNamespace
+  = ResolutionNamespaceTerm
+  | ResolutionNamespaceType
+  deriving (Eq, Show, Typeable)
+
 data ResolutionAnnotation = ResolutionAnnotation
   { resolutionSpan :: !SourceSpan,
     resolutionName :: !Text,
+    resolutionNamespace :: !ResolutionNamespace,
     resolutionTarget :: !ResolvedName
   }
   deriving (Eq, Show, Typeable)
@@ -91,7 +98,15 @@ renderResolutionAnnotation ann =
     <> " "
     <> T.unpack (resolutionName ann)
     <> " => "
+    <> renderResolutionNamespace (resolutionNamespace ann)
+    <> " "
     <> renderResolvedName (resolutionTarget ann)
+
+renderResolutionNamespace :: ResolutionNamespace -> String
+renderResolutionNamespace namespace =
+  case namespace of
+    ResolutionNamespaceTerm -> "(value)"
+    ResolutionNamespaceType -> "(type)"
 
 annotationKey :: ResolutionAnnotation -> (Int, Int, Int, Int, Text)
 annotationKey ann =

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
@@ -8,13 +8,13 @@ modules:
     fn _ = ClsName
 expected:
   Main:
-    - "2:7-2:14 ClsName => Main.ClsName"
-    - "3:6-3:14 DataType => Main.DataType"
-    - "3:17-3:24 ClsName => Main.ClsName"
-    - "4:1-4:3 fn => Main.fn"
-    - "4:7-4:14 ClsName => Main.ClsName"
-    - "4:25-4:33 DataType => Main.DataType"
-    - "5:1-5:3 fn => Main.fn"
-    - "5:8-5:15 ClsName => Main.ClsName"
+    - "2:7-2:14 ClsName => (type) Main.ClsName"
+    - "3:6-3:14 DataType => (type) Main.DataType"
+    - "3:17-3:24 ClsName => (value) Main.ClsName"
+    - "4:1-4:3 fn => (value) Main.fn"
+    - "4:7-4:14 ClsName => (type) Main.ClsName"
+    - "4:25-4:33 DataType => (type) Main.DataType"
+    - "5:1-5:3 fn => (value) Main.fn"
+    - "5:8-5:15 ClsName => (value) Main.ClsName"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
@@ -1,0 +1,20 @@
+extensions: []
+modules:
+  - |
+    module Main where
+    class ClsName a
+    data DataType = ClsName
+    fn :: ClsName a => a -> DataType
+    fn _ = ClsName
+expected:
+  Main:
+    - "2:7-2:14 ClsName => Main.ClsName"
+    - "3:6-3:14 DataType => Main.DataType"
+    - "3:17-3:24 ClsName => Main.ClsName"
+    - "4:1-4:3 fn => Main.fn"
+    - "4:7-4:14 ClsName => Main.ClsName"
+    - "4:25-4:33 DataType => Main.DataType"
+    - "5:1-5:3 fn => Main.fn"
+    - "5:8-5:15 ClsName => Main.ClsName"
+status: pass
+reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/data-constructor-and-type-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/data-constructor-and-type-reference.yaml
@@ -7,11 +7,11 @@ modules:
     fn = B
 expected:
   Main:
-    - "2:6-2:7 A => Main.A"
-    - "2:10-2:11 B => Main.B"
-    - "3:1-3:3 fn => Main.fn"
-    - "3:7-3:8 A => Main.A"
-    - "4:1-4:3 fn => Main.fn"
-    - "4:6-4:7 B => Main.B"
+    - "2:6-2:7 A => (type) Main.A"
+    - "2:10-2:11 B => (value) Main.B"
+    - "3:1-3:3 fn => (value) Main.fn"
+    - "3:7-3:8 A => (type) Main.A"
+    - "4:1-4:3 fn => (value) Main.fn"
+    - "4:6-4:7 B => (value) Main.B"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
@@ -9,9 +9,9 @@ modules:
     x = helper
 expected:
   Lib:
-    - "2:1-2:7 helper => Lib.helper"
+    - "2:1-2:7 helper => (value) Lib.helper"
   Main:
-    - "3:1-3:2 x => Main.x"
-    - "3:5-3:11 helper => Lib.helper"
+    - "3:1-3:2 x => (value) Main.x"
+    - "3:5-3:11 helper => (value) Lib.helper"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
@@ -5,12 +5,12 @@ modules:
     fn x = let x = x in x where x = x
 expected:
   Main:
-    - "2:1-2:3 fn => Main.fn"
-    - "2:4-2:5 x => Local 0 x"
-    - "2:12-2:13 x => Local 1 x"
-    - "2:16-2:17 x => Local 1 x"
-    - "2:21-2:22 x => Local 1 x"
-    - "2:29-2:30 x => Local 2 x"
-    - "2:33-2:34 x => Local 2 x"
+    - "2:1-2:3 fn => (value) Main.fn"
+    - "2:4-2:5 x => (value) Local 0 x"
+    - "2:12-2:13 x => (value) Local 1 x"
+    - "2:16-2:17 x => (value) Local 1 x"
+    - "2:21-2:22 x => (value) Local 1 x"
+    - "2:29-2:30 x => (value) Local 2 x"
+    - "2:33-2:34 x => (value) Local 2 x"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -5,8 +5,8 @@ modules:
     f = let y = 10 in y
 expected:
   Main:
-    - "2:1-2:2 f => Main.f"
-    - "2:9-2:10 y => Local 0 y"
-    - "2:19-2:20 y => Local 0 y"
+    - "2:1-2:2 f => (value) Main.f"
+    - "2:9-2:10 y => (value) Local 0 y"
+    - "2:19-2:20 y => (value) Local 0 y"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
@@ -5,6 +5,6 @@ modules:
     x = 1
 expected:
   Main:
-    - "2:1-2:2 x => Main.x"
+    - "2:1-2:2 x => (value) Main.x"
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
@@ -6,8 +6,8 @@ modules:
     y = x
 expected:
   Main:
-    - "2:1-2:2 x => Main.x"
-    - "3:1-3:2 y => Main.y"
-    - "3:5-3:6 x => Main.x"
+    - "2:1-2:2 x => (value) Main.x"
+    - "3:1-3:2 y => (value) Main.y"
+    - "3:5-3:6 x => (value) Main.x"
 status: pass
 reason: ""


### PR DESCRIPTION
## Summary
- add a resolver golden regression for a module where a class name and a data constructor share the same identifier, and verify the class constraint still resolves independently from the constructor use
- split `aihc-resolve` top-level and local resolution into separate type and term scopes so class/type names no longer collide with constructor/value names
- progress: resolver golden pass count increased from 6 to 7 cases

## Validation
- `cabal test -v0 aihc-resolve:spec --test-options=\"--pattern resolver-golden\"`
- `just test`
- `nix flake check`

## Notes
- `coderabbit review --prompt-only` was attempted but skipped because the service returned a rate-limit error