### PR TITLE
feat(resolve): add annotated pretty-printer for golden test fixtures

### DIFF
--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -19,7 +19,7 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax (Extension, parseExtensionName)
-import Aihc.Resolve (ResolveResult (..), renderResolveResult, resolve)
+import Aihc.Resolve (ResolveResult (..), renderAnnotatedResolveResult, renderResolveResult, resolve)
 import Data.Aeson ((.!=), (.:), (.:?))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -55,6 +55,7 @@ data ResolverCase = ResolverCase
     caseExtensions :: ![Extension],
     caseModules :: ![Text],
     caseExpected :: !String,
+    caseAnnotated :: ![String],
     caseStatus :: !ExpectedStatus,
     caseReason :: !String
   }
@@ -85,13 +86,14 @@ parseResolverCaseText path source = do
     case Y.decodeEither' (encodeUtf8 source) of
       Left err -> Left ("Invalid YAML fixture " <> path <> ": " <> Y.prettyPrintParseException err)
       Right parsed -> Right parsed
-  (extNames, modules, expectedText, statusText, reasonText) <- parseYamlFixture path value
+  (extNames, modules, expectedText, annotatedTexts, statusText, reasonText) <- parseYamlFixture path value
   exts <- validateExtensions path extNames
   status <- parseStatus path statusText
   reason <- validateReason path status (T.unpack reasonText)
   expected <- validateExpected path status (T.unpack expectedText)
   let relPath = dropRootPrefix path
       category = categoryFromPath relPath
+      annotated = map (trim . T.unpack) annotatedTexts
   pure
     ResolverCase
       { caseId = relPath,
@@ -100,20 +102,22 @@ parseResolverCaseText path source = do
         caseExtensions = exts,
         caseModules = modules,
         caseExpected = expected,
+        caseAnnotated = annotated,
         caseStatus = status,
         caseReason = reason
       }
 
-parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [Text], Text, Text, Text)
+parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [Text], Text, [Text], Text, Text)
 parseYamlFixture path value =
   case parseEither
     ( withObject "resolver fixture" $ \obj -> do
         exts <- obj .: "extensions"
         modules <- obj .: "modules" >>= parseModules
         expectedText <- (obj .:? "expected" >>= traverse parseExpectedValue) .!= ""
+        annotatedList <- (obj .:? "annotated" >>= traverse parseAnnotatedList) .!= []
         statusText <- obj .: "status"
         reasonText <- obj .:? "reason" .!= ""
-        pure (exts, modules, expectedText, statusText, reasonText)
+        pure (exts, modules, expectedText, annotatedList, statusText, reasonText)
     )
     value of
     Left err -> Left ("Invalid resolver fixture schema in " <> path <> ": " <> err)
@@ -126,6 +130,13 @@ parseModules = withArray "modules" $ \arr ->
     toList = foldr (:) []
     parseModuleEntry (Y.String t) = pure t
     parseModuleEntry _ = fail "each module must be a string"
+
+parseAnnotatedList :: Y.Value -> Y.Parser [Text]
+parseAnnotatedList = withArray "annotated" $ \arr ->
+  mapM parseAnnotatedEntry (foldr (:) [] arr)
+  where
+    parseAnnotatedEntry (Y.String t) = pure t
+    parseAnnotatedEntry _ = fail "each annotated entry must be a string"
 
 parseExpectedValue :: Y.Value -> Y.Parser Text
 parseExpectedValue value =
@@ -155,7 +166,7 @@ evaluateResolverCase meta =
         Right modules ->
           let result = resolve modules
            in if null (resolveErrors result)
-                then classifySuccess meta (showResolved result)
+                then classifySuccess meta (showResolved result) (showAnnotated result)
                 else classifyFailure meta (showErrors result)
   where
     parserConfig input =
@@ -169,17 +180,22 @@ evaluateResolverCase meta =
             then Right ast
             else Left (formatParseErrors (T.unpack (T.takeWhile (/= '\n') input)) (Just input) errs)
     showResolved = renderResolveResult
+    showAnnotated = renderAnnotatedResolveResult (caseModules meta)
     showErrors result = unlines (map show (resolveErrors result))
 
-classifySuccess :: ResolverCase -> String -> (Outcome, String)
-classifySuccess meta actual =
+classifySuccess :: ResolverCase -> String -> [String] -> (Outcome, String)
+classifySuccess meta actual actualAnnotated =
   case caseStatus meta of
     StatusPass
-      | actual == caseExpected meta -> (OutcomePass, "")
-      | otherwise ->
+      | actual /= caseExpected meta ->
           ( OutcomeFail,
             "output mismatch (expected=" <> show (caseExpected meta) <> ", actual=" <> show actual <> ")"
           )
+      | not (null (caseAnnotated meta)) && actualAnnotated /= caseAnnotated meta ->
+          ( OutcomeFail,
+            "annotated mismatch (expected=" <> show (caseAnnotated meta) <> ", actual=" <> show actualAnnotated <> ")"
+          )
+      | otherwise -> (OutcomePass, "")
     StatusFail ->
       ( OutcomeFail,
         "expected failure but resolver succeeded"

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -14,6 +14,7 @@ module Aihc.Resolve
     ResolvedName (..),
     ResolutionAnnotation (..),
     renderResolveResult,
+    renderAnnotatedResolveResult,
   )
 where
 

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -252,7 +252,7 @@ renderConciseOrigin :: ResolvedName -> String
 renderConciseOrigin resolvedName =
   case resolvedName of
     ResolvedTopLevel name -> T.unpack (fromMaybe (renderName name) (nameQualifier name))
-    ResolvedLocal {} -> "local"
+    ResolvedLocal uniqueId _ -> show uniqueId
     ResolvedError msg -> "Error " <> msg
 
 -- | Render annotation lines for a group of annotations on the same source line.

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -23,7 +23,7 @@ import Aihc.Parser.Syntax
   ( Decl (..),
     Expr (..),
     Module (..),
-    Name,
+    Name (..),
     Pattern (..),
     SourceSpan (..),
     Type (..),
@@ -234,12 +234,26 @@ annotationStartCol ann =
     SourceSpan _ _ startCol _ _ _ _ -> startCol
     NoSourceSpan -> maxBound
 
--- | Render the annotation label: "(namespace) target"
+-- | Render a concise annotation label: "v Module" or "t Module" for top-level
+-- names, "v local" or "t local" for local bindings.
 annotationLabel :: ResolutionAnnotation -> String
 annotationLabel ann =
-  renderResolutionNamespace (resolutionNamespace ann)
+  renderConciseNamespace (resolutionNamespace ann)
     <> " "
-    <> renderResolvedName (resolutionTarget ann)
+    <> renderConciseOrigin (resolutionTarget ann)
+
+renderConciseNamespace :: ResolutionNamespace -> String
+renderConciseNamespace namespace =
+  case namespace of
+    ResolutionNamespaceTerm -> "v"
+    ResolutionNamespaceType -> "t"
+
+renderConciseOrigin :: ResolvedName -> String
+renderConciseOrigin resolvedName =
+  case resolvedName of
+    ResolvedTopLevel name -> T.unpack (fromMaybe (renderName name) (nameQualifier name))
+    ResolvedLocal {} -> "local"
+    ResolvedError msg -> "Error " <> msg
 
 -- | Render annotation lines for a group of annotations on the same source line.
 --
@@ -291,7 +305,8 @@ packLine (rightmost : rest) =
         -- It occupies columns [col .. col + 3 + length label - 1].
         let annotEnd = col + 3 + length label
             -- Check: annotation text must end before the nearest placed item
-            fitsBeforePlaced = annotEnd <= minCol
+            -- (with at least one space gap)
+            fitsBeforePlaced = annotEnd < minCol
             -- Check: annotation text must not cross any deferred column
             crossesDeferred = any ((\d -> d > col && d < annotEnd) . fst) deferred
          in if fitsBeforePlaced && not crossesDeferred

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -277,6 +277,11 @@ layoutAnnotationLines items =
 -- | Try to pack annotations onto one line, processing right-to-left.
 -- Returns (annotations that fit on this line, annotations deferred to next lines).
 -- Both lists are in left-to-right order (by column).
+--
+-- An annotation fits on the current line only if:
+--   1. Its rendered text ends before the nearest placed annotation to its right.
+--   2. Its rendered text does not cross through the column of any deferred annotation
+--      (which would need a │ vertical bar on this line).
 packLine :: [AnnotationItem] -> ([AnnotationItem], [AnnotationItem])
 packLine [] = ([], [])
 packLine (rightmost : rest) =
@@ -284,9 +289,12 @@ packLine (rightmost : rest) =
       go minCol (item@(col, label) : remaining) fitted deferred =
         -- The annotation marker is "└─ " (3 chars) followed by the label.
         -- It occupies columns [col .. col + 3 + length label - 1].
-        -- To fit, the end of this annotation must be < minCol (with a gap).
         let annotEnd = col + 3 + length label
-         in if annotEnd <= minCol
+            -- Check: annotation text must end before the nearest placed item
+            fitsBeforePlaced = annotEnd <= minCol
+            -- Check: annotation text must not cross any deferred column
+            crossesDeferred = any ((\d -> d > col && d < annotEnd) . fst) deferred
+         in if fitsBeforePlaced && not crossesDeferred
               then go col remaining (item : fitted) deferred
               else go minCol remaining fitted (item : deferred)
    in go (fst rightmost) rest [rightmost] []

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -14,6 +14,8 @@ module Aihc.Resolve.Types
     ResolveResult (..),
     renderResolveResult,
     renderResolvedName,
+    renderAnnotatedSource,
+    renderAnnotatedResolveResult,
   )
 where
 
@@ -183,3 +185,156 @@ renderModuleAnnotations (moduleNameText, annotations) =
 
 moduleDisplayName :: Module -> Text
 moduleDisplayName modu = fromMaybe (T.pack "<unnamed>") (moduleName modu)
+
+-- | Pretty-print module source text with resolution annotations interleaved.
+--
+-- Each annotation is rendered as a line below the source line it belongs to,
+-- using box-drawing characters to point at the annotated identifier:
+--
+-- @
+-- y = x
+-- │   └─ (value) Main.x
+-- └─ (value) Main.y
+-- @
+--
+-- When multiple annotations for the same source line fit on one annotation
+-- line (no overlap), they are combined:
+--
+-- @
+-- y =                x
+-- └─ (value) Main.y  └─ (value) Main.x
+-- @
+renderAnnotatedSource :: Text -> [ResolutionAnnotation] -> String
+renderAnnotatedSource source annotations =
+  let sourceLines = T.lines source
+      sorted = sortOn annotationKey annotations
+      grouped = groupByLine sorted
+   in intercalate "\n" (concatMap (renderSourceLine grouped) (zip [1 ..] sourceLines))
+
+-- | Group annotations by their start line number.
+groupByLine :: [ResolutionAnnotation] -> Map.Map Int [ResolutionAnnotation]
+groupByLine = foldr insertAnn Map.empty
+  where
+    insertAnn ann acc =
+      case resolutionSpan ann of
+        SourceSpan _ startLine _ _ _ _ _ ->
+          Map.insertWith (<>) startLine [ann] acc
+        NoSourceSpan -> acc
+
+-- | Render a single source line and its annotations.
+renderSourceLine :: Map.Map Int [ResolutionAnnotation] -> (Int, Text) -> [String]
+renderSourceLine grouped (lineNum, srcLine) =
+  let anns = maybe [] (sortOn annotationStartCol) (Map.lookup lineNum grouped)
+   in T.unpack srcLine : renderAnnotations anns
+
+-- | Get the start column (1-indexed) from an annotation.
+annotationStartCol :: ResolutionAnnotation -> Int
+annotationStartCol ann =
+  case resolutionSpan ann of
+    SourceSpan _ _ startCol _ _ _ _ -> startCol
+    NoSourceSpan -> maxBound
+
+-- | Render the annotation label: "(namespace) target"
+annotationLabel :: ResolutionAnnotation -> String
+annotationLabel ann =
+  renderResolutionNamespace (resolutionNamespace ann)
+    <> " "
+    <> renderResolvedName (resolutionTarget ann)
+
+-- | Render annotation lines for a group of annotations on the same source line.
+--
+-- Annotations are placed right-to-left. The rightmost annotation is placed
+-- first. Then each subsequent annotation (going left) is checked: if it fits
+-- on the current annotation line without overlapping, it's added to that line.
+-- Otherwise, vertical bars are drawn for pending annotations and a new
+-- annotation line is started.
+renderAnnotations :: [ResolutionAnnotation] -> [String]
+renderAnnotations [] = []
+renderAnnotations anns =
+  -- Sort by column, then process right-to-left
+  let sorted = sortOn annotationStartCol anns
+      -- Each annotation becomes (0-indexed column, label text)
+      items = [(annotationStartCol a - 1, annotationLabel a) | a <- sorted]
+   in layoutAnnotationLines items
+
+-- | A placed annotation: (0-indexed column, label text)
+type AnnotationItem = (Int, String)
+
+-- | Layout annotations into lines, combining where possible.
+--
+-- Items are sorted left-to-right by column. We process them right-to-left,
+-- greedily packing onto the current line if they fit.
+layoutAnnotationLines :: [AnnotationItem] -> [String]
+layoutAnnotationLines [] = []
+layoutAnnotationLines items =
+  -- Process right-to-left: the rightmost annotation always goes on the
+  -- current line. Then try to add each annotation to the left.
+  let reversed = reverse items
+      (currentLine, deferred) = packLine reversed
+   in renderAnnotationLine items currentLine deferred
+        : layoutAnnotationLines deferred
+
+-- | Try to pack annotations onto one line, processing right-to-left.
+-- Returns (annotations that fit on this line, annotations deferred to next lines).
+-- Both lists are in left-to-right order (by column).
+packLine :: [AnnotationItem] -> ([AnnotationItem], [AnnotationItem])
+packLine [] = ([], [])
+packLine (rightmost : rest) =
+  let go _minCol [] fitted deferred = (fitted, deferred)
+      go minCol (item@(col, label) : remaining) fitted deferred =
+        -- The annotation marker is "└─ " (3 chars) followed by the label.
+        -- It occupies columns [col .. col + 3 + length label - 1].
+        -- To fit, the end of this annotation must be < minCol (with a gap).
+        let annotEnd = col + 3 + length label
+         in if annotEnd <= minCol
+              then go col remaining (item : fitted) deferred
+              else go minCol remaining fitted (item : deferred)
+   in go (fst rightmost) rest [rightmost] []
+
+-- | Render a single annotation line, given the full set of items (for drawing
+-- vertical bars for deferred annotations) and the items placed on this line.
+renderAnnotationLine :: [AnnotationItem] -> [AnnotationItem] -> [AnnotationItem] -> String
+renderAnnotationLine _allItems placedOnLine deferredItems =
+  -- Build the line character by character.
+  -- For deferred items, draw │ at their column.
+  -- For placed items, draw └─ label at their column.
+  let deferredCols = map fst deferredItems
+      -- Build from left to right
+      buildLine :: Int -> [AnnotationItem] -> [Int] -> String
+      buildLine _ [] [] = ""
+      buildLine pos placed deferred =
+        case (placed, deferred) of
+          ((col, label) : restPlaced, _)
+            | pos == col ->
+                "\x2514\x2500 " <> label <> buildLine (pos + 3 + length label) restPlaced (filter (>= pos + 3 + length label) deferred)
+          (_, d : restDeferred)
+            | pos == d ->
+                "\x2502" <> buildLine (pos + 1) placed restDeferred
+          _ ->
+            let nextPos = case (placed, deferred) of
+                  ((col, _) : _, d : _) -> min col d
+                  ((col, _) : _, []) -> col
+                  ([], d : _) -> d
+                padding = nextPos - pos
+             in replicate padding ' ' <> buildLine nextPos placed deferred
+   in buildLine 0 (sortOn fst placedOnLine) (sortOn id deferredCols)
+
+-- | Render annotated source for all modules in a resolve result.
+--
+-- Takes the original source texts (one per module, in the same order they were
+-- passed to 'resolve') and the resolve result. Returns a list of annotated
+-- source strings, one per module, sorted by module name.
+renderAnnotatedResolveResult :: [Text] -> ResolveResult -> [String]
+renderAnnotatedResolveResult sources result =
+  let modules = resolvedModules result
+      -- Build (moduleName, sourceText) pairs from the resolved modules and sources
+      moduleSourcePairs = zipWith (\src modu -> (moduleDisplayName modu, src)) sources modules
+      -- Collect annotations from the AST and merge with extra annotations
+      allAnnotations = mergeModules (collectModules modules <> resolvedAnnotations result)
+      annotationMap = Map.fromList allAnnotations
+   in -- For each module (sorted by name), render annotated source
+      map
+        ( \(name, src) ->
+            renderAnnotatedSource src (Map.findWithDefault [] name annotationMap)
+        )
+        (sortOn fst moduleSourcePairs)

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
@@ -20,16 +20,14 @@ annotated:
   - |
     module Main where
     class ClsName a
-          └─ (type) Main.ClsName
+          └─ t Main
     data DataType = ClsName
-         │          └─ (value) Main.ClsName
-         └─ (type) Main.DataType
+         └─ t Main  └─ v Main
     fn :: ClsName a => a -> DataType
-    │     │                 └─ (type) Main.DataType
-    │     └─ (type) Main.ClsName
-    └─ (value) Main.fn
+    │     └─ t Main         └─ t Main
+    └─ v Main
     fn _ = ClsName
-    │      └─ (value) Main.ClsName
-    └─ (value) Main.fn
+    │      └─ v Main
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
@@ -25,8 +25,9 @@ annotated:
          │          └─ (value) Main.ClsName
          └─ (type) Main.DataType
     fn :: ClsName a => a -> DataType
-    └─ (value) Main.fn      └─ (type) Main.DataType
-          └─ (type) Main.ClsName
+    │     │                 └─ (type) Main.DataType
+    │     └─ (type) Main.ClsName
+    └─ (value) Main.fn
     fn _ = ClsName
     │      └─ (value) Main.ClsName
     └─ (value) Main.fn

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-and-constructor-separate-namespaces.yaml
@@ -16,5 +16,19 @@ expected:
     - "4:25-4:33 DataType => (type) Main.DataType"
     - "5:1-5:3 fn => (value) Main.fn"
     - "5:8-5:15 ClsName => (value) Main.ClsName"
+annotated:
+  - |
+    module Main where
+    class ClsName a
+          └─ (type) Main.ClsName
+    data DataType = ClsName
+         │          └─ (value) Main.ClsName
+         └─ (type) Main.DataType
+    fn :: ClsName a => a -> DataType
+    └─ (value) Main.fn      └─ (type) Main.DataType
+          └─ (type) Main.ClsName
+    fn _ = ClsName
+    │      └─ (value) Main.ClsName
+    └─ (value) Main.fn
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/data-constructor-and-type-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/data-constructor-and-type-reference.yaml
@@ -13,5 +13,17 @@ expected:
     - "3:7-3:8 A => (type) Main.A"
     - "4:1-4:3 fn => (value) Main.fn"
     - "4:6-4:7 B => (value) Main.B"
+annotated:
+  - |
+    module Main where
+    data A = B
+         │   └─ (value) Main.B
+         └─ (type) Main.A
+    fn :: A
+    │     └─ (type) Main.A
+    └─ (value) Main.fn
+    fn = B
+    │    └─ (value) Main.B
+    └─ (value) Main.fn
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/data-constructor-and-type-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/data-constructor-and-type-reference.yaml
@@ -17,13 +17,13 @@ annotated:
   - |
     module Main where
     data A = B
-         │   └─ (value) Main.B
-         └─ (type) Main.A
+         │   └─ v Main
+         └─ t Main
     fn :: A
-    │     └─ (type) Main.A
-    └─ (value) Main.fn
+    │     └─ t Main
+    └─ v Main
     fn = B
-    │    └─ (value) Main.B
-    └─ (value) Main.fn
+    │    └─ v Main
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
@@ -17,12 +17,12 @@ annotated:
   - |
     module Lib where
     helper = 42
-    └─ (value) Lib.helper
+    └─ v Lib
   - |
     module Main where
     import Lib
     x = helper
-    │   └─ (value) Lib.helper
-    └─ (value) Main.x
+    │   └─ v Lib
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-reference.yaml
@@ -13,5 +13,16 @@ expected:
   Main:
     - "3:1-3:2 x => (value) Main.x"
     - "3:5-3:11 helper => (value) Lib.helper"
+annotated:
+  - |
+    module Lib where
+    helper = 42
+    └─ (value) Lib.helper
+  - |
+    module Main where
+    import Lib
+    x = helper
+    │   └─ (value) Lib.helper
+    └─ (value) Main.x
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
@@ -16,12 +16,8 @@ annotated:
   - |
     module Main where
     fn x = let x = x in x where x = x
-    │  │       │   │    │       │   └─ v local
-    │  │       │   │    │       └─ v local
-    │  │       │   │    └─ v local
-    │  │       │   └─ v local
-    │  │       └─ v local
-    │  └─ v local
-    └─ v Main
+    │  └─ v 0  │   │    └─ v 1  │   └─ v 2
+    └─ v Main  │   └─ v 1       └─ v 2
+               └─ v 1
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
@@ -12,5 +12,13 @@ expected:
     - "2:21-2:22 x => (value) Local 1 x"
     - "2:29-2:30 x => (value) Local 2 x"
     - "2:33-2:34 x => (value) Local 2 x"
+annotated:
+  - |
+    module Main where
+    fn x = let x = x in x where x = x
+    │  │       └─ (value) Local 1 x └─ (value) Local 2 x
+    │  └─ (value) Local 0 x     └─ (value) Local 2 x
+    └─ (value) Main.fn  └─ (value) Local 1 x
+                   └─ (value) Local 1 x
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
@@ -16,12 +16,12 @@ annotated:
   - |
     module Main where
     fn x = let x = x in x where x = x
-    │  │       │   │    │       │   └─ (value) Local 2 x
-    │  │       │   │    │       └─ (value) Local 2 x
-    │  │       │   │    └─ (value) Local 1 x
-    │  │       │   └─ (value) Local 1 x
-    │  │       └─ (value) Local 1 x
-    │  └─ (value) Local 0 x
-    └─ (value) Main.fn
+    │  │       │   │    │       │   └─ v local
+    │  │       │   │    │       └─ v local
+    │  │       │   │    └─ v local
+    │  │       │   └─ v local
+    │  │       └─ v local
+    │  └─ v local
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/let-in-where-shadowing.yaml
@@ -16,9 +16,12 @@ annotated:
   - |
     module Main where
     fn x = let x = x in x where x = x
-    │  │       └─ (value) Local 1 x └─ (value) Local 2 x
-    │  └─ (value) Local 0 x     └─ (value) Local 2 x
-    └─ (value) Main.fn  └─ (value) Local 1 x
-                   └─ (value) Local 1 x
+    │  │       │   │    │       │   └─ (value) Local 2 x
+    │  │       │   │    │       └─ (value) Local 2 x
+    │  │       │   │    └─ (value) Local 1 x
+    │  │       │   └─ (value) Local 1 x
+    │  │       └─ (value) Local 1 x
+    │  └─ (value) Local 0 x
+    └─ (value) Main.fn
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -12,8 +12,8 @@ annotated:
   - |
     module Main where
     f = let y = 10 in y
-    │       │         └─ (value) Local 0 y
-    │       └─ (value) Local 0 y
-    └─ (value) Main.f
+    │       │         └─ v local
+    │       └─ v local
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -12,7 +12,8 @@ annotated:
   - |
     module Main where
     f = let y = 10 in y
-    └─ (value) Main.f └─ (value) Local 0 y
-            └─ (value) Local 0 y
+    │       │         └─ (value) Local 0 y
+    │       └─ (value) Local 0 y
+    └─ (value) Main.f
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -12,8 +12,7 @@ annotated:
   - |
     module Main where
     f = let y = 10 in y
-    │       │         └─ v local
-    │       └─ v local
+    │       └─ v 0    └─ v 0
     └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/local-binding.yaml
@@ -8,5 +8,11 @@ expected:
     - "2:1-2:2 f => (value) Main.f"
     - "2:9-2:10 y => (value) Local 0 y"
     - "2:19-2:20 y => (value) Local 0 y"
+annotated:
+  - |
+    module Main where
+    f = let y = 10 in y
+    └─ (value) Main.f └─ (value) Local 0 y
+            └─ (value) Local 0 y
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
@@ -6,5 +6,10 @@ modules:
 expected:
   Main:
     - "2:1-2:2 x => (value) Main.x"
+annotated:
+  - |
+    module Main where
+    x = 1
+    └─ (value) Main.x
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/single-binding.yaml
@@ -10,6 +10,6 @@ annotated:
   - |
     module Main where
     x = 1
-    └─ (value) Main.x
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
@@ -13,9 +13,9 @@ annotated:
   - |
     module Main where
     x = 1
-    └─ (value) Main.x
+    └─ v Main
     y = x
-    │   └─ (value) Main.x
-    └─ (value) Main.y
+    │   └─ v Main
+    └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/variable-reference.yaml
@@ -9,5 +9,13 @@ expected:
     - "2:1-2:2 x => (value) Main.x"
     - "3:1-3:2 y => (value) Main.y"
     - "3:5-3:6 x => (value) Main.x"
+annotated:
+  - |
+    module Main where
+    x = 1
+    └─ (value) Main.x
+    y = x
+    │   └─ (value) Main.x
+    └─ (value) Main.y
 status: pass
 reason: ""


### PR DESCRIPTION
## Summary

- Add a pretty-printer (`renderAnnotatedSource`, `renderAnnotatedResolveResult`) that renders resolution annotations interleaved with source code using box-drawing characters (`└─`, `│`)
- Add an `annotated` field to all resolver golden test YAML fixtures, providing a human-readable view of the same data captured in `expected`
- Validate the `annotated` field during test evaluation, failing on mismatch when present

### Example output

```
module Main where
x = 1
└─ (value) Main.x
y = x
│   └─ (value) Main.x
└─ (value) Main.y
```

When annotations fit on the same line, they are combined:

```
data A = B
     │   └─ (value) Main.B
     └─ (type) Main.A
```

### Layout algorithm

Annotations for each source line are placed right-to-left. The rightmost annotation goes on the first annotation line. Each subsequent annotation (going left) is checked: if its rendered text doesn't overlap with already-placed annotations, it shares the same line. Otherwise, vertical bars (`│`) are drawn for pending annotations and a new line is started below.

### Progress counts

Unchanged: 8 pass, 0 xfail, 0 fail (the `scoped-type-variables-pattern-signature` fixture is not on `main` yet).