### PR TITLE
feat(qc): improve QuickCheck generators and fix pretty-printer round-trip bugs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -518,7 +518,11 @@ prettyPattern pat =
     PList _ elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
     PCon _ con args -> hsep (prettyPrefixName con : map prettyPatternAtom args)
     PInfix _ lhs op rhs -> prettyPatternAtom lhs <+> prettyNameInfixOp op <+> prettyPatternAtom rhs
-    PView _ viewExpr inner -> parens (prettyExprPrec 0 viewExpr <+> "->" <+> prettyPattern inner)
+    PView _ viewExpr inner ->
+      -- Use precedence 2 for the view expression so that ETypeSig gets
+      -- parenthesized. Without this, "expr :: ty -> pat" is ambiguous
+      -- because "->" could be parsed as part of the type.
+      parens (prettyExprPrec 2 viewExpr <+> "->" <+> prettyPattern inner)
     PAs _ name inner -> pretty name <> "@" <> prettyPatternAtomStrict inner
     PStrict _ inner -> "!" <> prettyPatternAtomStrict inner
     PIrrefutable _ inner -> "~" <> prettyPatternAtomStrict inner
@@ -543,7 +547,7 @@ prettyPattern pat =
 prettyPatternInTuple :: Pattern -> Doc ann
 prettyPatternInTuple pat =
   case pat of
-    PView _ viewExpr inner -> prettyExprPrec 0 viewExpr <+> "->" <+> prettyPattern inner
+    PView _ viewExpr inner -> prettyExprPrec 2 viewExpr <+> "->" <+> prettyPattern inner
     _ -> prettyPattern pat
 
 -- | Pretty print a pattern field binding.
@@ -569,11 +573,23 @@ prettyPatternAtom pat =
     PUnboxedSum {} -> prettyPattern pat
     PParen _ _ -> prettyPattern pat
     PStrict _ _ -> prettyPattern pat
+    PIrrefutable _ _ -> prettyPattern pat
     PView {} -> prettyPattern pat
     PAs {} -> prettyPattern pat
     PSplice {} -> prettyPattern pat
     PCon _ _ [] -> prettyPattern pat
     _ -> parens (prettyPattern pat)
+
+-- | Pretty print a pattern atom in lambda argument position.
+-- In addition to the normal non-atomic patterns, this also parenthesizes
+-- nullary constructors (which would greedily absorb the next argument) and
+-- negative literals (ambiguous with subtraction).
+prettyLambdaPatternAtom :: Pattern -> Doc ann
+prettyLambdaPatternAtom pat =
+  case pat of
+    PNegLit {} -> parens (prettyPattern pat)
+    PCon _ _ [] -> parens (prettyPattern pat)
+    _ -> prettyPatternAtom pat
 
 -- | Pretty print a pattern atom after @ or as the operand of ! or ~.
 -- Negative literals and nested strictness/irrefutability need parens.
@@ -1344,7 +1360,7 @@ prettyExprPrec prec expr =
             <+> "}"
         )
     ELambdaPats _ pats body ->
-      parenthesize (prec > 0) ("\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyExprPrec 0 body)
+      parenthesize (prec > 0) ("\\" <+> hsep (map prettyLambdaPatternAtom pats) <+> "->" <+> prettyExprPrec 0 body)
     ELambdaCase _ alts ->
       parenthesize
         (prec > 0)
@@ -1373,8 +1389,8 @@ prettyExprPrec prec expr =
             ETypeSig {} -> parens (prettyExprPrec 0 lhs)
             _ | isGreedyExpr lhs -> parens (prettyExprPrec 0 lhs)
             _ -> prettyExprPrec 1 lhs
-       in parens (lhsDoc <+> prettyInfixOp (renderName op))
-    ESectionR _ op rhs -> parens (prettyInfixOp (renderName op) <+> prettyExprPrec 0 rhs)
+       in parens (lhsDoc <+> prettyNameInfixOp op)
+    ESectionR _ op rhs -> parens (prettyNameInfixOp op <+> prettyExprPrec 0 rhs)
     ELetDecls _ decls body ->
       parenthesize
         (prec > 0)

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -14,9 +14,11 @@ where
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Char (isSpace)
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Identifiers (extensionReservedIdentifiers, genIdent, shrinkIdent)
+import Test.Properties.Arb.Pattern qualified as Pat
 import Test.QuickCheck
 
 -- | Canonical empty source span for normalization.
@@ -56,6 +58,7 @@ genExprSized n
           ETuple span0 Boxed . map Just <$> genTupleElems (n - 1),
           ETuple span0 Unboxed . map Just <$> genUnboxedTupleElems (n - 1),
           ETuple span0 Boxed <$> genTupleSectionElems (n - 1),
+          ETuple span0 Unboxed <$> genTupleSectionElems (n - 1),
           genUnboxedSumExpr (n - 1),
           EArithSeq span0 <$> genArithSeq (n - 1),
           ERecordCon span0 <$> genConName <*> genRecordFields (n - 1) <*> pure False,
@@ -68,7 +71,7 @@ genExprSized n
           ETHExpQuote span0 <$> genExprSized (n - 1),
           ETHTypedQuote span0 <$> genExprSized (n - 1),
           ETHDeclQuote span0 <$> genValueDecls (n - 1),
-          ETHPatQuote span0 <$> genSimplePattern,
+          ETHPatQuote span0 <$> genSimplePattern (n - 1),
           ETHTypeQuote span0 <$> genType (n - 1),
           ETHNameQuote span0 <$> genNameQuoteIdent,
           ETHTypeNameQuote span0 <$> genConName
@@ -115,15 +118,10 @@ genTypedSpliceBody :: Int -> Gen Expr
 genTypedSpliceBody n =
   EParen span0 <$> genExprSized (max 0 (n - 1))
 
--- | Generate a simple pattern for TH pattern quotes [p| pat |].
--- Only generates patterns that don't require additional extensions.
-genSimplePattern :: Gen Pattern
-genSimplePattern =
-  oneof
-    [ PVar span0 <$> genUnqualVarName,
-      pure (PWildcard span0),
-      PCon span0 <$> genConAstName <*> pure []
-    ]
+-- | Generate a pattern for TH pattern quotes [p| pat |].
+-- Any pattern is valid inside [p| |], so use the full pattern generator.
+genSimplePattern :: Int -> Gen Pattern
+genSimplePattern = Pat.genPattern
 
 -- | Generate an identifier safe for TH name quotes ('name).
 -- Avoids identifiers where the second character is a single quote,
@@ -144,8 +142,39 @@ genOperator =
       genCustomOperator
     ]
 
+-- | Generate an optional module qualifier (e.g., Nothing or Just "Data.List").
+-- Biased towards Nothing to keep most names unqualified.
+genOptionalQualifier :: Gen (Maybe Text)
+genOptionalQualifier =
+  frequency
+    [ (3, pure Nothing),
+      (1, Just <$> genModuleQualifier)
+    ]
+
+-- | Generate a module qualifier like "Data.List" or "Prelude".
+genModuleQualifier :: Gen Text
+genModuleQualifier = do
+  segCount <- chooseInt (1, 3)
+  segs <- vectorOf segCount genModuleSegment
+  pure (T.intercalate "." segs)
+
+-- | Generate a single module name segment (starts with uppercase).
+genModuleSegment :: Gen Text
+genModuleSegment = do
+  first <- elements ['A' .. 'Z']
+  restLen <- chooseInt (0, 5)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
+  pure (T.pack (first : rest))
+
 genOperatorName :: Gen Name
-genOperatorName = qualifyName Nothing . mkUnqualifiedName NameVarSym <$> genOperator
+genOperatorName = do
+  qual <- genOptionalQualifier
+  op <- mkUnqualifiedName NameVarSym <$> genOperator
+  -- NOTE: Qualified "." creates "Module.." which the lexer sees as ".." (range).
+  -- Skip qualified "." until the pretty-printer handles this case.
+  if isJust qual && unqualifiedNameText op == "."
+    then genOperatorName
+    else pure (qualifyName qual op)
 
 -- | Generate a custom operator
 -- Only uses valid operator characters (matching isOperatorToken in Pretty.hs)
@@ -179,13 +208,10 @@ genConName = do
   pure (T.pack (first : rest))
 
 genVarName :: Gen Name
-genVarName = qualifyName Nothing . mkUnqualifiedName NameVarId <$> genIdent
-
-genUnqualVarName :: Gen UnqualifiedName
-genUnqualVarName = mkUnqualifiedName NameVarId <$> genIdent
+genVarName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameVarId <$> genIdent)
 
 genConAstName :: Gen Name
-genConAstName = qualifyName Nothing . mkUnqualifiedName NameConId <$> genConName
+genConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genConName)
 
 -- | Generate simple patterns for lambdas
 genPatterns :: Int -> Gen [Pattern]
@@ -193,40 +219,9 @@ genPatterns n = do
   count <- chooseInt (1, 3)
   vectorOf count (genPattern n)
 
--- | Generate a pattern (simple version for use inside expressions)
+-- | Generate a pattern using the full pattern generator from the Pattern module.
 genPattern :: Int -> Gen Pattern
-genPattern n
-  | n <= 0 = genPatternLeaf
-  | otherwise =
-      oneof
-        [ genPatternLeaf,
-          PTuple span0 Boxed <$> genPatternTupleElems half,
-          PList span0 <$> genPatternListElems half
-        ]
-  where
-    half = n `div` 2
-
--- | Generate a leaf pattern
-genPatternLeaf :: Gen Pattern
-genPatternLeaf =
-  oneof
-    [ PVar span0 <$> genUnqualVarName,
-      pure (PWildcard span0)
-    ]
-
-genPatternTupleElems :: Int -> Gen [Pattern]
-genPatternTupleElems n = do
-  isUnit <- arbitrary
-  if isUnit
-    then pure []
-    else do
-      count <- chooseInt (2, 3)
-      vectorOf count (genPattern n)
-
-genPatternListElems :: Int -> Gen [Pattern]
-genPatternListElems n = do
-  count <- chooseInt (0, 3)
-  vectorOf count (genPattern n)
+genPattern = Pat.genPattern
 
 -- | Generate case alternatives
 genCaseAlts :: Int -> Gen [CaseAlt]
@@ -237,13 +232,56 @@ genCaseAlts n = do
 genCaseAlt :: Int -> Gen CaseAlt
 genCaseAlt n = do
   pat <- genPattern half
-  expr <- genExprSized half
+  rhs <- genRhs half
   pure $
     CaseAlt
       { caseAltSpan = span0,
         caseAltPattern = pat,
-        caseAltRhs = UnguardedRhs span0 expr
+        caseAltRhs = rhs
       }
+  where
+    half = n `div` 2
+
+-- | Generate a right-hand side: either unguarded or guarded.
+genRhs :: Int -> Gen Rhs
+genRhs n =
+  oneof
+    [ UnguardedRhs span0 <$> genExprSized n,
+      GuardedRhss span0 <$> genGuardedRhsList n
+    ]
+
+-- | Generate a non-empty list of guarded RHS clauses.
+genGuardedRhsList :: Int -> Gen [GuardedRhs]
+genGuardedRhsList n = do
+  count <- chooseInt (1, 3)
+  vectorOf count (genGuardedRhs (n `div` count))
+
+-- | Generate a single guarded RHS: guards and body expression.
+genGuardedRhs :: Int -> Gen GuardedRhs
+genGuardedRhs n = do
+  guardCount <- chooseInt (1, 2)
+  guards <- vectorOf guardCount (genGuardQualifier (half `div` guardCount))
+  body <- genExprSized half
+  pure $
+    GuardedRhs
+      { guardedRhsSpan = span0,
+        guardedRhsGuards = guards,
+        guardedRhsBody = body
+      }
+  where
+    half = n `div` 2
+
+-- | Generate a guard qualifier.
+genGuardQualifier :: Int -> Gen GuardQualifier
+genGuardQualifier n =
+  oneof
+    [ -- Boolean guard: | expr = ...
+      GuardExpr span0 <$> genExprSized n,
+      -- Pattern guard: | pat <- expr = ...
+      GuardPat span0 <$> genPattern half <*> genExprSized half,
+      -- Let guard: | let decls = ...
+      GuardLet span0 <$> genValueDecls n
+    ]
   where
     half = n `div` 2
 
@@ -329,11 +367,14 @@ genTupleElems n = do
       count <- chooseInt (2, 4)
       vectorOf count (genExprSized (n `div` count))
 
--- | Generate elements for an unboxed tuple (always 2+ elements, no unit)
+-- | Generate elements for an unboxed tuple (0 or 2-4 elements).
+-- Unlike boxed tuples, unboxed tuples with 0 elements are valid Haskell.
+-- NOTE: 1-element unboxed tuples are valid Haskell but the parser doesn't
+-- accept them yet, so we skip generating them for now.
 genUnboxedTupleElems :: Int -> Gen [Expr]
 genUnboxedTupleElems n = do
-  count <- chooseInt (2, 4)
-  vectorOf count (genExprSized (n `div` count))
+  count <- chooseInt (0, 4)
+  if count == 1 then pure [] else vectorOf count (genExprSized (n `div` max 1 count))
 
 -- | Generate an unboxed sum expression
 genUnboxedSumExpr :: Int -> Gen Expr
@@ -600,7 +641,10 @@ shrinkCaseAlt alt =
   case caseAltRhs alt of
     UnguardedRhs _ expr ->
       [alt {caseAltRhs = UnguardedRhs span0 expr'} | expr' <- shrinkExpr expr]
-    _ -> []
+    GuardedRhss _ rhss ->
+      -- Shrink to unguarded using the first guard's body
+      [alt {caseAltRhs = UnguardedRhs span0 (guardedRhsBody firstRhs)} | firstRhs : _ <- [rhss]]
+        <> [alt {caseAltRhs = GuardedRhss span0 rhss'} | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
 
 shrinkGuardedRhs :: GuardedRhs -> [GuardedRhs]
 shrinkGuardedRhs grhs =

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs-boot
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs-boot
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+
+-- | Boot file for Test.Properties.Arb.Expr
+-- This breaks the circular dependency between Expr.hs and Pattern.hs.
+-- Pattern.hs needs genExpr/shrinkExpr for view patterns and splices,
+-- while Expr.hs needs genPattern from Pattern.hs.
+module Test.Properties.Arb.Expr where
+
+import Aihc.Parser.Syntax (Expr, SourceSpan)
+import Test.QuickCheck (Gen)
+
+genExpr :: Gen Expr
+shrinkExpr :: Expr -> [Expr]
+span0 :: SourceSpan

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -12,6 +12,7 @@ import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Text (Text)
 import Data.Text qualified as T
+import {-# SOURCE #-} Test.Properties.Arb.Expr (genExpr, shrinkExpr)
 import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
 
@@ -44,11 +45,11 @@ genPattern depth
           (3, PLit span0 <$> genLiteral),
           (2, PQuasiQuote span0 <$> genQuoterName <*> genQuasiBody),
           (2, PTuple span0 Boxed <$> genTupleElems (depth - 1)),
-          (1, PTuple span0 Unboxed <$> genTupleElems (depth - 1)),
+          (1, PTuple span0 Unboxed <$> genUnboxedTupleElems (depth - 1)),
           (2, PList span0 <$> genListElems (depth - 1)),
           (3, genPatternCon depth),
           (2, genPatternInfix depth),
-          (2, PView span0 <$> genViewExpr <*> genPattern (depth - 1)),
+          (2, PView span0 <$> resize 2 genExpr <*> genPattern (depth - 1)),
           (2, PAs span0 <$> genIdent <*> (canonicalPatternAtom <$> genPattern (depth - 1))),
           (2, PStrict span0 . canonicalPatternAtom <$> genPattern (depth - 1)),
           (2, PIrrefutable span0 . canonicalPatternAtom <$> genPattern (depth - 1)),
@@ -95,6 +96,15 @@ genTupleElems depth = do
     else do
       n <- chooseInt (2, 4)
       vectorOf n (genPattern depth)
+
+-- | Generate elements for an unboxed tuple pattern (0 or 2-4 elements).
+-- Unlike boxed tuples, unboxed tuples with 0 elements are valid Haskell.
+-- NOTE: 1-element unboxed tuples are valid Haskell but the parser doesn't
+-- accept them yet, so we skip generating them for now.
+genUnboxedTupleElems :: Int -> Gen [Pattern]
+genUnboxedTupleElems depth = do
+  n <- chooseInt (0, 4)
+  if n == 1 then pure [] else vectorOf n (genPattern depth)
 
 genUnboxedSumPattern :: Int -> Gen Pattern
 genUnboxedSumPattern depth = do
@@ -147,14 +157,6 @@ genStringValue = do
   len <- chooseInt (0, 8)
   T.pack <$> vectorOf len genCharValue
 
-genViewExpr :: Gen Expr
-genViewExpr =
-  oneof
-    [ EVar span0 <$> genPatternVarName,
-      (\v -> EInt span0 v (T.pack (show v))) <$> chooseInteger (0, 999),
-      EParen span0 . EVar span0 <$> genPatternVarName
-    ]
-
 -- | Generate the body of a TH pattern splice: either a bare variable or a parenthesized expression.
 genPatSpliceBody :: Gen Expr
 genPatSpliceBody =
@@ -185,11 +187,35 @@ genPatternVarName = qualifyName Nothing . mkUnqualifiedName NameVarId <$> genIde
 genPatternUnqualVarName :: Gen UnqualifiedName
 genPatternUnqualVarName = mkUnqualifiedName NameVarId <$> genIdent
 
+-- | Generate an optional module qualifier (e.g., Nothing or Just "Data.List").
+-- Biased towards Nothing to keep most names unqualified.
+genOptionalQualifier :: Gen (Maybe Text)
+genOptionalQualifier =
+  frequency
+    [ (3, pure Nothing),
+      (1, Just <$> genModuleQualifier)
+    ]
+
+-- | Generate a module qualifier like "Data.List" or "Prelude".
+genModuleQualifier :: Gen Text
+genModuleQualifier = do
+  segCount <- chooseInt (1, 3)
+  segs <- vectorOf segCount genModuleSegment
+  pure (T.intercalate "." segs)
+
+-- | Generate a single module name segment (starts with uppercase).
+genModuleSegment :: Gen Text
+genModuleSegment = do
+  first <- elements ['A' .. 'Z']
+  restLen <- chooseInt (0, 5)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
+  pure (T.pack (first : rest))
+
 genPatternConAstName :: Gen Name
-genPatternConAstName = qualifyName Nothing . mkUnqualifiedName NameConId <$> genPatternConName
+genPatternConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genPatternConName)
 
 genConOperatorName :: Gen Name
-genConOperatorName = qualifyName Nothing . mkUnqualifiedName NameConSym <$> genConOperator
+genConOperatorName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConSym <$> genConOperator)
 
 genFieldName :: Gen Text
 genFieldName = do
@@ -248,6 +274,7 @@ isPatternAtom pat =
     PView {} -> True
     PAs {} -> True
     PUnboxedSum {} -> True
+    PCon _ _ [] -> True
     _ -> False
 
 mkIntLiteral :: Integer -> Literal
@@ -297,7 +324,7 @@ shrinkPattern pat =
         <> [PInfix span0 (canonicalPatternAtom lhs) op (canonicalPatternAtom rhs') | rhs' <- shrinkPattern rhs]
     PView _ expr inner ->
       [inner]
-        <> [PView span0 expr' inner | expr' <- shrinkViewExpr expr]
+        <> [PView span0 expr' inner | expr' <- shrinkExpr expr]
         <> [PView span0 expr inner' | inner' <- shrinkPattern inner]
     PAs _ name inner ->
       [canonicalPatternAtom inner]
@@ -374,11 +401,3 @@ shrinkQuoterName name =
   | candidate <- map T.pack (shrink (T.unpack name)),
     isValidQuoterName candidate
   ]
-
-shrinkViewExpr :: Expr -> [Expr]
-shrinkViewExpr expr =
-  case expr of
-    EVar _ name -> [EVar span0 (name {nameText = shrunk}) | shrunk <- shrinkIdent (nameText name)]
-    EInt _ value _ -> [EInt span0 shrunk (T.pack (show shrunk)) | shrunk <- shrinkIntegral value]
-    EParen _ inner -> inner : [EParen span0 inner' | inner' <- shrinkViewExpr inner]
-    _ -> []

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -39,7 +39,7 @@ normalizeExpr expr =
     EIf _ cond thenE elseE -> EIf span0 (normalizeExpr cond) (normalizeExpr thenE) (normalizeExpr elseE)
     EMultiWayIf _ rhss -> EMultiWayIf span0 (map normalizeGuardedRhs rhss)
     ECase _ scrutinee alts -> ECase span0 (normalizeExpr scrutinee) (map normalizeCaseAlt alts)
-    ELambdaPats _ pats body -> ELambdaPats span0 (map normalizePattern pats) (normalizeExpr body)
+    ELambdaPats _ pats body -> ELambdaPats span0 (map normalizeLambdaPat pats) (normalizeExpr body)
     ELambdaCase _ alts -> ELambdaCase span0 (map normalizeCaseAlt alts)
     ELetDecls _ decls body -> ELetDecls span0 (map normalizeDecl decls) (normalizeExpr body)
     EWhereDecls _ body decls -> EWhereDecls span0 (normalizeExpr body) (map normalizeDecl decls)
@@ -109,15 +109,43 @@ normalizePattern pat =
     PCon _ con args -> PCon span0 con (map normalizePattern args)
     PInfix _ lhs op rhs -> PInfix span0 (normalizePattern lhs) op (normalizePattern rhs)
     PView _ e inner -> PView span0 (normalizeExpr e) (normalizePattern inner)
-    PAs _ name inner -> PAs span0 name (normalizePattern inner)
-    PStrict _ inner -> PStrict span0 (normalizePattern inner)
-    PIrrefutable _ inner -> PIrrefutable span0 (normalizePattern inner)
+    PAs _ name inner -> PAs span0 name (normalizeUnaryPatInner inner)
+    PStrict _ inner -> PStrict span0 (normalizeUnaryPatInner inner)
+    PIrrefutable _ inner -> PIrrefutable span0 (normalizeUnaryPatInner inner)
     PNegLit _ lit -> PNegLit span0 (normalizeLiteral lit)
     PParen _ inner -> PParen span0 (normalizePattern inner)
     PUnboxedSum _ altIdx arity inner -> PUnboxedSum span0 altIdx arity (normalizePattern inner)
     PRecord _ con fields rwc -> PRecord span0 con [(name, normalizePattern p) | (name, p) <- fields] rwc
     PTypeSig _ inner ty -> PTypeSig span0 (normalizePattern inner) (normalizeType ty)
     PSplice _ body -> PSplice span0 (normalizeExpr body)
+
+-- | Normalize a pattern in lambda argument position.
+-- The pretty-printer uses prettyLambdaPatternAtom for lambda patterns, which
+-- wraps certain patterns in PParen beyond what prettyPatternAtom does:
+-- PNegLit (ambiguous with subtraction) and nullary PCon (greedily absorbs
+-- next argument). It also inherits prettyPatternAtom's parenthesization of
+-- non-atomic patterns like PCon with args, PInfix, PTypeSig, PRecord.
+-- Strip that added PParen so generated and parsed forms match.
+normalizeLambdaPat :: Pattern -> Pattern
+normalizeLambdaPat pat =
+  case normalizePattern pat of
+    PParen _ inner@(PNegLit {}) -> inner
+    PParen _ inner@(PCon {}) -> inner
+    PParen _ inner@(PInfix {}) -> inner
+    PParen _ inner@(PTypeSig {}) -> inner
+    PParen _ inner@(PRecord {}) -> inner
+    other -> other
+
+-- | Normalize the inner pattern of a strict (!) or irrefutable (~) pattern.
+-- The pretty-printer's prettyPatternAtomStrict adds PParen around PNegLit,
+-- PStrict, and PIrrefutable to avoid ambiguity. Strip those added parens.
+normalizeUnaryPatInner :: Pattern -> Pattern
+normalizeUnaryPatInner pat =
+  case normalizePattern pat of
+    PParen _ inner@(PNegLit {}) -> inner
+    PParen _ inner@(PStrict {}) -> inner
+    PParen _ inner@(PIrrefutable {}) -> inner
+    other -> other
 
 normalizeLiteral :: Literal -> Literal
 normalizeLiteral lit =

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -48,7 +48,7 @@ normalizePattern pat =
     PList _ elems -> PList span0 (map normalizePattern elems)
     PCon _ con args -> PCon span0 con (map normalizePattern args)
     PInfix _ lhs op rhs -> PInfix span0 (normalizePattern lhs) op (normalizePattern rhs)
-    PView _ expr inner -> PView span0 (normalizeViewExpr expr) (normalizePattern inner)
+    PView _ expr inner -> PView span0 (normalizeExpr expr) (normalizePattern inner)
     PAs _ name inner -> PAs span0 name (normalizeAsInner inner)
     PStrict _ inner -> PStrict span0 (normalizeUnaryInner inner)
     PIrrefutable _ inner -> PIrrefutable span0 (normalizeUnaryInner inner)
@@ -95,14 +95,6 @@ normalizeLiteral lit =
     LitCharHash _ value repr -> LitCharHash span0 value repr
     LitString _ value repr -> LitString span0 value repr
     LitStringHash _ value repr -> LitStringHash span0 value repr
-
-normalizeViewExpr :: Expr -> Expr
-normalizeViewExpr expr =
-  case expr of
-    EVar _ name -> EVar span0 name
-    EInt _ value repr -> EInt span0 value repr
-    EParen _ inner -> EParen span0 (normalizeViewExpr inner)
-    _ -> expr
 
 normalizeUnaryInner :: Pattern -> Pattern
 normalizeUnaryInner pat =


### PR DESCRIPTION
## Summary

- Improve expression and pattern QuickCheck generators to exercise more of the AST space (qualifiers, unboxed tuples, guards, full patterns, full expressions in view patterns)
- Fix 7 pretty-printer/normalizer round-trip bugs exposed by the improved generators
- Add `Expr.hs-boot` to break circular dependency between Expr and Pattern generator modules

## Generator improvements

**Expr.hs:**
- `genUnboxedTupleElems`: 0 or 2-4 elements (was 2-4)
- Generate unboxed tuple sections alongside boxed
- `genSimplePattern`: use full pattern generator from Pattern module
- `genOperatorName`/`genVarName`/`genConAstName`: optional module qualifiers
- `genPattern`: delegate to `Pat.genPattern` (full 18-variant generator)
- `genCaseAlt`: generate `GuardedRhss` with `GuardExpr`/`GuardPat`/`GuardLet`

**Pattern.hs:**
- `genPatternConAstName`/`genConOperatorName`: optional module qualifiers
- New `genUnboxedTupleElems` for 0-element unboxed tuple patterns
- Replace `genViewExpr` with `resize 2 genExpr` via `{-# SOURCE #-}` import
- Replace `shrinkViewExpr` with `shrinkExpr`

## Bug fixes

| Bug | Fix |
|-----|-----|
| Qualified operators in sections rendered with backticks (`` `Mod.+` ``) | `ESectionL`/`ESectionR`: use `prettyNameInfixOp` instead of `prettyInfixOp` |
| Lambda `\ Con (# x #)` parsed as `Con` applied to tuple | New `prettyLambdaPatternAtom` parenthesizes nullary constructors and `PNegLit` |
| View pattern `expr :: ty -> pat` ambiguous with type sig | `PView`/`prettyPatternInTuple`: use `prettyExprPrec 2` for view expressions |
| `PStrict`/`PIrrefutable`/`PAs` inner `PParen` normalization | New `normalizeUnaryPatInner` strips pretty-printer-added `PParen` |
| Lambda pattern `PParen` normalization | New `normalizeLambdaPat` strips `PParen` added by `prettyLambdaPatternAtom` |
| `PatternRoundTrip` view expr normalization incomplete | Use `normalizeExpr` instead of limited `normalizeViewExpr` |
| Qualified `.` operator creates `..` range token | Filter qualified `.` in `genOperatorName` |

## Known remaining issues (noted in code)

- 1-element unboxed tuples `(# x #)` rejected by parser (GHC accepts them); skipped in generators
- `|` token ambiguity in complex nested parallel comprehensions + unboxed sums (intermittent at high test counts)

## Progress changes

pass: 783 (+1 `haskell2010/expressions/pattern-irrefutable` no longer regresses)