### PR TITLE
refactor: extract shared aihc-hackage library from duplicated code

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,5 +3,6 @@ packages:
   components/aihc-parser
   components/aihc-parser-cli
   components/aihc-resolve
+  tooling/aihc-hackage
 
 tests: True

--- a/components/aihc-parser-cli/aihc-parser-cli.cabal
+++ b/components/aihc-parser-cli/aihc-parser-cli.cabal
@@ -23,6 +23,7 @@ library
   build-depends:
       base >=4.16 && <5
     , aihc-cpp
+    , aihc-hackage
     , aihc-parser
     , text >=1.2
     , optparse-applicative
@@ -38,7 +39,6 @@ library
     , haskell-src-exts
     , http-client
     , http-client-tls
-    , http-types
     , tar
     , time
     , zlib

--- a/components/aihc-parser-cli/src/Aihc/Parser/Bench/Tarball.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Bench/Tarball.hs
@@ -26,6 +26,11 @@ module Aihc.Parser.Bench.Tarball
   )
 where
 
+import Aihc.Hackage.Cabal qualified as HC
+import Aihc.Hackage.Download qualified as HD
+import Aihc.Hackage.Stackage qualified as HS
+import Aihc.Hackage.Types (PackageSpec (..), formatPackage)
+import Aihc.Hackage.Util qualified as HU
 import Aihc.Parser.Bench.CLI (FilterOptions (..), GenerateOptions (..))
 import Aihc.Parser.Bench.Parsers (ParseResult (..), parseWithAihcExts, parseWithGhcExts, parseWithHseExts)
 import Codec.Archive.Tar qualified as Tar
@@ -35,23 +40,17 @@ import Control.Exception (SomeException, displayException, try)
 import Control.Monad (forM, when)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
-import Data.Char (isAlphaNum, isSpace)
-import Data.List (isPrefixOf, isSuffixOf, nub)
+import Data.Char (isAlphaNum)
+import Data.List (isPrefixOf, isSuffixOf)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
-import Data.Text.Lazy qualified as TL
-import Data.Text.Lazy.Encoding qualified as TLE
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Data.Version qualified as DV
-import Distribution.Compiler (CompilerFlavor (..))
-import Distribution.ModuleName (ModuleName, toFilePath)
+import Distribution.ModuleName (toFilePath)
 import Distribution.PackageDescription
-  ( BuildInfo,
-    Executable,
-    FlagName,
+  ( Executable,
     Library,
     autogenModules,
     buildInfo,
@@ -59,52 +58,27 @@ import Distribution.PackageDescription
     condExecutables,
     condLibrary,
     condSubLibraries,
-    defaultExtensions,
-    defaultLanguage,
     exeModules,
     exposedModules,
-    flagDefault,
-    flagName,
     hsSourceDirs,
     libBuildInfo,
     modulePath,
-    oldExtensions,
     otherModules,
   )
 import Distribution.PackageDescription.Parsec qualified as Cabal
-import Distribution.Pretty (prettyShow)
-import Distribution.System (buildArch, buildOS)
-import Distribution.Types.CondTree
-  ( CondBranch (CondBranch),
-    CondTree (condTreeComponents, condTreeData),
-  )
-import Distribution.Types.Condition (Condition (..))
-import Distribution.Types.ConfVar (ConfVar (..))
-import Distribution.Types.GenericPackageDescription (GenericPackageDescription, genPackageFlags)
+import Distribution.Types.CondTree (CondTree (condTreeData))
+import Distribution.Types.Condition (Condition)
+import Distribution.Types.ConfVar (ConfVar)
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
 import Distribution.Utils.Path (getSymbolicPath)
-import Distribution.Version (mkVersion, withinRange)
-import Network.HTTP.Client (Manager, httpLbs, newManager, parseRequest, responseBody, responseStatus)
+import Network.HTTP.Client (Manager, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
-import Network.HTTP.Types.Status (statusCode)
 import System.Directory
-  ( XdgDirectory (XdgCache),
-    createDirectoryIfMissing,
-    doesDirectoryExist,
-    doesFileExist,
-    getXdgDirectory,
+  ( doesDirectoryExist,
     listDirectory,
-    removeDirectoryRecursive,
   )
-import System.FilePath (makeRelative, normalise, takeDirectory, takeExtension, (<.>), (</>))
+import System.FilePath (makeRelative, takeDirectory, takeExtension, (</>))
 import System.IO (hPutStrLn, stderr)
-import System.Info (compilerName, compilerVersion)
-
--- | A package specification.
-data PackageSpec = PackageSpec
-  { pkgName :: !String,
-    pkgVersion :: !String
-  }
-  deriving (Eq, Show)
 
 -- | An entry to be written to the tarball.
 -- This can be either a Haskell source file or a .cabal file.
@@ -163,7 +137,7 @@ generateTarball :: GenerateOptions -> IO (Either String GenerateResult)
 generateTarball opts = do
   -- Create a single HTTP manager to reuse for all requests
   manager <- newManager tlsManagerSettings
-  snapshotResult <- loadStackageSnapshot manager (genSnapshot opts) (genOffline opts)
+  snapshotResult <- HS.loadStackageSnapshot (Just manager) (genSnapshot opts) (genOffline opts)
   case snapshotResult of
     Left err -> pure (Left err)
     Right packages -> do
@@ -209,6 +183,13 @@ generateTarball opts = do
           writeTarball outputPath allEntries
           pure (Right summary)
 
+sanitizeName :: String -> String
+sanitizeName = map sanitizeChar
+  where
+    sanitizeChar c
+      | isAlphaNum c || c == '-' || c == '_' = c
+      | otherwise = '_'
+
 -- | Process all packages sequentially.
 processPackages :: Manager -> GenerateOptions -> [PackageSpec] -> IO [Either (PackageSpec, FilterReason) [TarballEntry]]
 processPackages manager opts packages = forM packages (processPackage manager opts)
@@ -216,7 +197,13 @@ processPackages manager opts packages = forM packages (processPackage manager op
 -- | Process a single package.
 processPackage :: Manager -> GenerateOptions -> PackageSpec -> IO (Either (PackageSpec, FilterReason) [TarballEntry])
 processPackage manager opts pkg = do
-  downloadResult <- try $ downloadPackage manager (genOffline opts) pkg
+  let dlOpts =
+        HD.defaultDownloadOptions
+          { HD.downloadVerbose = False,
+            HD.downloadAllowNetwork = not (genOffline opts),
+            HD.downloadManager = Just manager
+          }
+  downloadResult <- try $ HD.downloadPackageWithOptions dlOpts pkg
   case downloadResult of
     Left (err :: SomeException) ->
       pure (Left (pkg, FilterDownloadFailed (displayException err)))
@@ -233,7 +220,7 @@ processPackage manager opts pkg = do
             else do
               -- Read all files with their extension info from the cabal file
               entries <- forM hsFiles $ \file -> do
-                contents <- readTextFileLenient file
+                contents <- HU.readTextFileLenient file
                 let relPath = formatPackage pkg </> makeRelative pkgDir file
                     -- Look up extension info for this file
                     info = Map.lookup (makeRelative pkgDir file) fileInfoMap
@@ -259,12 +246,12 @@ processPackage manager opts pkg = do
 -- | Find and read the .cabal file, returning the entry and a map of file paths to their extensions
 findAndReadCabalFile :: FilePath -> PackageSpec -> IO (TarballEntry, Map.Map FilePath ([String], Maybe String))
 findAndReadCabalFile pkgDir pkg = do
-  cabalFiles <- findCabalFiles pkgDir
+  cabalFiles <- findCabalFilesFlat pkgDir
   cabalFile <- case cabalFiles of
     [f] -> pure f
     [] -> ioError (userError ("No .cabal file found in " ++ pkgDir))
     (f : _) -> pure f -- Take first one if multiple
-  contents <- readTextFileLenient cabalFile
+  contents <- HU.readTextFileLenient cabalFile
   let relPath = formatPackage pkg </> makeRelative pkgDir cabalFile
       cabalEntry =
         TarballEntry
@@ -291,129 +278,13 @@ parseCabalForExtensions pkgDir cabalFile = do
       hPutStrLn stderr $ "Warning: Failed to parse " ++ cabalFile ++ ": " ++ show errs
       pure Map.empty
     Right gpd -> do
-      fileInfos <- collectComponentFilesSimple gpd (takeDirectory cabalFile)
+      fileInfos <- HC.collectComponentFiles gpd (takeDirectory cabalFile)
       -- Build map from relative paths to their extensions
       pure $
         Map.fromList
-          [ (makeRelative pkgDir path, (exts, lang))
-          | (path, exts, lang) <- fileInfos
+          [ (makeRelative pkgDir (HC.fileInfoPath fi), (HC.fileInfoExtensions fi, HC.fileInfoLanguage fi))
+          | fi <- fileInfos
           ]
-
--- | Simplified version of collectComponentFiles that just gets paths and extensions
-collectComponentFilesSimple :: GenericPackageDescription -> FilePath -> IO [(FilePath, [String], Maybe String)]
-collectComponentFilesSimple gpd packageRoot = do
-  let evalCond = conditionEvaluator gpd
-      libraryTrees = maybe [] pure (condLibrary gpd) <> map snd (condSubLibraries gpd)
-      executableTrees = map snd (condExecutables gpd)
-
-  libraryFiles <- fmap concat (forM libraryTrees (libraryFilesSimple evalCond packageRoot))
-  executableFiles <- fmap concat (forM executableTrees (executableFilesSimple evalCond packageRoot))
-
-  pure (libraryFiles <> executableFiles)
-
-libraryFilesSimple :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Library -> IO [(FilePath, [String], Maybe String)]
-libraryFilesSimple evalCond packageRoot tree = do
-  let library = condTreeData tree
-      build = collectMergedBuildInfo evalCond libBuildInfo tree
-      moduleNames = exposedModules library <> otherModules build <> autogenModules build
-      exts = extractExtensions build
-      lang = extractLanguage build
-  if not (buildable build)
-    then pure []
-    else do
-      paths <- moduleFilesForBuildInfo packageRoot build moduleNames
-      pure [(path, exts, lang) | path <- paths]
-
-executableFilesSimple :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Executable -> IO [(FilePath, [String], Maybe String)]
-executableFilesSimple evalCond packageRoot tree = do
-  let executable = condTreeData tree
-      build = collectMergedBuildInfo evalCond buildInfo tree
-      moduleNames = otherModules build <> exeModules executable <> autogenModules build
-      mainPath = modulePath executable
-      exts = extractExtensions build
-      lang = extractLanguage build
-  if not (buildable build)
-    then pure []
-    else do
-      moduleFiles <- moduleFilesForBuildInfo packageRoot build moduleNames
-      mainFiles <- existingPaths [dir </> mainPath | dir <- sourceDirs packageRoot build]
-      pure [(path, exts, lang) | path <- moduleFiles <> mainFiles]
-
-extractExtensions :: BuildInfo -> [String]
-extractExtensions bi = nub (map prettyShow (defaultExtensions bi <> oldExtensions bi))
-
-extractLanguage :: BuildInfo -> Maybe String
-extractLanguage bi =
-  case defaultLanguage bi of
-    Just lang -> Just (prettyShow lang)
-    Nothing -> Nothing -- Don't default, let the parser decide
-
-collectCondTreeData :: (Condition v -> Bool) -> CondTree v c a -> [a]
-collectCondTreeData evalCond tree =
-  condTreeData tree : concatMap collectBranch (condTreeComponents tree)
-  where
-    collectBranch (CondBranch cond thenTree elseTree) =
-      if evalCond cond
-        then collectCondTreeData evalCond thenTree
-        else maybe [] (collectCondTreeData evalCond) elseTree
-
-collectMergedBuildInfo :: (Monoid b) => (Condition v -> Bool) -> (a -> b) -> CondTree v c a -> b
-collectMergedBuildInfo evalCond toBuildInfo =
-  mconcat . map toBuildInfo . collectCondTreeData evalCond
-
-conditionEvaluator :: GenericPackageDescription -> Condition ConfVar -> Bool
-conditionEvaluator gpd = eval
-  where
-    defaultFlags :: Map.Map FlagName Bool
-    defaultFlags =
-      Map.fromList [(flagName flag, flagDefault flag) | flag <- genPackageFlags gpd]
-
-    compilerFlavor :: CompilerFlavor
-    compilerFlavor =
-      case compilerName of
-        "ghc" -> GHC
-        "ghcjs" -> GHCJS
-        other -> OtherCompiler other
-
-    compilerVer = mkVersion (DV.versionBranch compilerVersion)
-
-    eval (Var confVar) =
-      case confVar of
-        OS os -> os == buildOS
-        Arch arch -> arch == buildArch
-        PackageFlag flag -> Map.findWithDefault False flag defaultFlags
-        Impl flavor range -> flavor == compilerFlavor && withinRange compilerVer range
-    eval (Lit b) = b
-    eval (CNot c) = not (eval c)
-    eval (COr a b) = eval a || eval b
-    eval (CAnd a b) = eval a && eval b
-
-moduleFilesForBuildInfo :: FilePath -> BuildInfo -> [ModuleName] -> IO [FilePath]
-moduleFilesForBuildInfo packageRoot build modules = do
-  let dirs = sourceDirs packageRoot build
-      moduleCandidates =
-        [ dir </> toFilePath modu <.> ext
-        | dir <- dirs,
-          modu <- modules,
-          ext <- ["hs", "lhs"]
-        ]
-  dedupeExistingFiles moduleCandidates
-
-sourceDirs :: FilePath -> BuildInfo -> [FilePath]
-sourceDirs packageRoot build =
-  case map getSymbolicPath (hsSourceDirs build) of
-    [] -> [packageRoot]
-    dirs -> [packageRoot </> dir | dir <- dirs]
-
-existingPaths :: [FilePath] -> IO [FilePath]
-existingPaths candidates = do
-  existing <- forM candidates $ \candidate -> do
-    fileExists <- doesFileExist candidate
-    pure (if fileExists then Just (normalise candidate) else Nothing)
-  pure (catMaybes existing)
-
-dedupeExistingFiles :: [FilePath] -> IO [FilePath]
-dedupeExistingFiles files = fmap nub (existingPaths files)
 
 -- | Check if a package passes all filters.
 -- Returns the first filter failure reason, or Nothing if all pass.
@@ -560,10 +431,14 @@ parseSingleCabal pkg cabalPath content =
         then drop (length prefix) s
         else s
 
--- | Extract file info from a parsed GenericPackageDescription
+-- | Extract file info from a parsed GenericPackageDescription.
+--
+-- This variant works on in-memory tarball paths (with forward slashes) rather
+-- than filesystem paths, so it does NOT use the IO-based file-discovery in
+-- 'HC.collectComponentFiles'.
 extractFileInfoFromGPD :: GenericPackageDescription -> String -> Map.Map FilePath ([String], Maybe String)
 extractFileInfoFromGPD gpd pkgRoot =
-  let evalCond = conditionEvaluator gpd
+  let evalCond = HC.conditionEvaluator gpd
       libraryTrees = maybe [] pure (condLibrary gpd) <> map snd (condSubLibraries gpd)
       executableTrees = map snd (condExecutables gpd)
 
@@ -574,10 +449,10 @@ extractFileInfoFromGPD gpd pkgRoot =
 libraryFileInfos :: (Condition ConfVar -> Bool) -> String -> CondTree ConfVar c Library -> [(FilePath, ([String], Maybe String))]
 libraryFileInfos evalCond pkgRoot tree =
   let library = condTreeData tree
-      build = collectMergedBuildInfo evalCond libBuildInfo tree
+      build = HC.collectMergedBuildInfo evalCond libBuildInfo tree
       moduleNames = exposedModules library <> otherModules build <> autogenModules build
-      exts = extractExtensions build
-      lang = extractLanguage build
+      exts = HC.extractExtensions build
+      lang = HC.extractLanguage build
       dirs = case map getSymbolicPath (hsSourceDirs build) of
         [] -> [""]
         ds -> ds
@@ -593,11 +468,11 @@ libraryFileInfos evalCond pkgRoot tree =
 executableFileInfos :: (Condition ConfVar -> Bool) -> String -> CondTree ConfVar c Executable -> [(FilePath, ([String], Maybe String))]
 executableFileInfos evalCond pkgRoot tree =
   let executable = condTreeData tree
-      build = collectMergedBuildInfo evalCond buildInfo tree
+      build = HC.collectMergedBuildInfo evalCond buildInfo tree
       moduleNames = otherModules build <> exeModules executable <> autogenModules build
       mainPath = modulePath executable
-      exts = extractExtensions build
-      lang = extractLanguage build
+      exts = HC.extractExtensions build
+      lang = HC.extractLanguage build
       dirs = case map getSymbolicPath (hsSourceDirs build) of
         [] -> [""]
         ds -> ds
@@ -626,157 +501,9 @@ breakOnLast c s =
         [] -> (s, "")
         _ : rest -> (reverse rest, reverse after)
 
--- | Load a Stackage snapshot.
-loadStackageSnapshot :: Manager -> String -> Bool -> IO (Either String [PackageSpec])
-loadStackageSnapshot manager snapshot offline = do
-  cacheFile <- snapshotCacheFile snapshot
-  hasCache <- doesFileExist cacheFile
-  if hasCache
-    then do
-      cachedBody <- readFile cacheFile
-      pure (parseSnapshotConstraints cachedBody)
-    else
-      if offline
-        then pure (Left ("Snapshot missing from cache in offline mode: " ++ snapshot))
-        else do
-          let url = "https://www.stackage.org/" ++ snapshot ++ "/cabal.config"
-          fetched <- httpGetString manager url
-          case fetched of
-            Left err -> pure (Left err)
-            Right body ->
-              case parseSnapshotConstraints body of
-                Left parseErr -> pure (Left parseErr)
-                Right specs -> do
-                  writeFile cacheFile body
-                  pure (Right specs)
-
-snapshotCacheFile :: String -> IO FilePath
-snapshotCacheFile snapshot = do
-  base <- getXdgDirectory XdgCache "aihc"
-  let dir = base </> "stackage"
-      file = sanitizeName snapshot ++ "-cabal.config"
-  createDirectoryIfMissing True dir
-  pure (dir </> file)
-
-sanitizeName :: String -> String
-sanitizeName = map sanitizeChar
-  where
-    sanitizeChar c
-      | isAlphaNum c || c == '-' || c == '_' = c
-      | otherwise = '_'
-
-parseSnapshotConstraints :: String -> Either String [PackageSpec]
-parseSnapshotConstraints content = do
-  let section = constraintLines (lines content)
-      entries = map trim (splitComma (concat section))
-      specs = mapMaybe parseConstraint entries
-  if null specs
-    then Left "No package constraints found"
-    else Right specs
-
-constraintLines :: [String] -> [String]
-constraintLines ls =
-  case break (isPrefixOf "constraints:" . trimLeft) ls of
-    (_, []) -> []
-    (_, firstRaw : restRaw) ->
-      let firstLine = trimLeft firstRaw
-          start = [drop 12 firstLine]
-          cont = [trimLeft line | line <- takeWhile isConstraintContinuation restRaw]
-       in start <> cont
-
-isConstraintContinuation :: String -> Bool
-isConstraintContinuation line =
-  case line of
-    c : _ -> isSpace c
-    [] -> False
-
-trimLeft :: String -> String
-trimLeft = dropWhile isSpace
-
-parseConstraint :: String -> Maybe PackageSpec
-parseConstraint entry
-  | null entry = Nothing
-  | "--" `isPrefixOf` trim entry = Nothing
-  | otherwise =
-      case breakOn "==" entry of
-        Just (name, ver) -> Just (PackageSpec (trim name) (trim ver))
-        Nothing ->
-          let ws = words entry
-           in case ws of
-                [_, "installed"] -> Nothing
-                _ -> Nothing
-
-breakOn :: String -> String -> Maybe (String, String)
-breakOn needle haystack =
-  case findNeedle needle haystack of
-    Nothing -> Nothing
-    Just i ->
-      let (left, right) = splitAt i haystack
-       in Just (left, drop (length needle) right)
-
-findNeedle :: String -> String -> Maybe Int
-findNeedle needle = go 0
-  where
-    go _ [] = Nothing
-    go i xs
-      | needle `isPrefixOf` xs = Just i
-      | otherwise = go (i + 1) (drop 1 xs)
-
-splitComma :: String -> [String]
-splitComma s =
-  case break (== ',') s of
-    (chunk, []) -> [chunk]
-    (chunk, _ : rest) -> chunk : splitComma rest
-
-trim :: String -> String
-trim = dropWhileEnd isSpace . dropWhile isSpace
-  where
-    dropWhileEnd p = reverse . dropWhile p . reverse
-
--- | Download a package from Hackage.
-downloadPackage :: Manager -> Bool -> PackageSpec -> IO FilePath
-downloadPackage manager offline pkg = do
-  cacheDir <- getCacheDir
-  let pkgDir = cacheDir </> formatPackage pkg
-      markerFile = pkgDir </> ".complete"
-  markerExists <- doesFileExist markerFile
-  if markerExists
-    then pure pkgDir
-    else
-      if offline
-        then ioError (userError ("Package missing from cache in offline mode: " ++ formatPackage pkg))
-        else do
-          createDirectoryIfMissing True cacheDir
-          let url =
-                "https://hackage.haskell.org/package/"
-                  ++ formatPackage pkg
-                  ++ "/"
-                  ++ formatPackage pkg
-                  ++ ".tar.gz"
-          -- Download tarball
-          tarballBytes <- httpGetLBS manager url
-          case tarballBytes of
-            Left err -> ioError (userError ("Failed to download " ++ formatPackage pkg ++ ": " ++ err))
-            Right lbs -> do
-              -- Extract using Codec.Archive.Tar
-              let entries = Tar.read (GZip.decompress lbs)
-              pkgDirExists <- doesDirectoryExist pkgDir
-              when pkgDirExists $ removeDirectoryRecursive pkgDir
-              Tar.unpack cacheDir entries
-              writeFile markerFile ""
-              pure pkgDir
-
-getCacheDir :: IO FilePath
-getCacheDir = do
-  cacheBase <- getXdgDirectory XdgCache "aihc"
-  pure (cacheBase </> "hackage")
-
-formatPackage :: PackageSpec -> String
-formatPackage pkg = pkgName pkg ++ "-" ++ pkgVersion pkg
-
--- | Find all .cabal files in a directory.
-findCabalFiles :: FilePath -> IO [FilePath]
-findCabalFiles dir = do
+-- | Find all .cabal files in a directory (non-recursive, top-level only).
+findCabalFilesFlat :: FilePath -> IO [FilePath]
+findCabalFilesFlat dir = do
   entries <- listDirectory dir
   paths <- forM entries $ \entry -> do
     let fullPath = dir </> entry
@@ -807,12 +534,6 @@ findHaskellFiles dir = do
           else pure []
   pure (concat paths)
 
--- | Read a file as Text with lenient UTF-8 decoding.
-readTextFileLenient :: FilePath -> IO Text
-readTextFileLenient path = do
-  bytes <- BS.readFile path
-  pure (decodeUtf8With lenientDecode bytes)
-
 -- | Partition results into successes and failures.
 partitionResults :: [Either (PackageSpec, FilterReason) [TarballEntry]] -> ([[TarballEntry]], [(PackageSpec, FilterReason)])
 partitionResults = go [] []
@@ -820,28 +541,3 @@ partitionResults = go [] []
     go successes failures [] = (reverse successes, reverse failures)
     go successes failures (Left f : rest) = go successes (f : failures) rest
     go successes failures (Right s : rest) = go (s : successes) failures rest
-
---------------------------------------------------------------------------------
--- HTTP utilities
---------------------------------------------------------------------------------
-
--- | Perform an HTTP GET request and return the response body as a String.
--- Uses lenient UTF-8 decoding to handle malformed sequences.
-httpGetString :: Manager -> String -> IO (Either String String)
-httpGetString manager url = do
-  result <- httpGetLBS manager url
-  pure $ fmap (TL.unpack . TLE.decodeUtf8With lenientDecode) result
-
--- | Perform an HTTP GET request and return the response body as lazy ByteString.
-httpGetLBS :: Manager -> String -> IO (Either String LBS.ByteString)
-httpGetLBS manager url = do
-  result <- try $ do
-    request <- parseRequest url
-    response <- httpLbs request manager
-    let status = statusCode (responseStatus response)
-    if status >= 200 && status < 300
-      then pure (Right (responseBody response))
-      else pure (Left ("HTTP " ++ show status ++ " for " ++ url))
-  case result of
-    Left (err :: SomeException) -> pure (Left (displayException err))
-    Right r -> pure r

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -121,6 +121,7 @@ test-suite spec
   build-depends:
       base >=4.16 && <5
     , aihc-cpp
+    , aihc-hackage
     , megaparsec
     , text
     , containers
@@ -237,16 +238,15 @@ executable hackage-tester
       base >=4.16 && <5
     , aihc-parser
     , aihc-cpp
+    , aihc-hackage
     , text
     , containers
     , deepseq
     , directory
     , filepath
     , ghc-lib-parser
-    , Cabal
     , Cabal-syntax
     , bytestring
-    , process
     , async
     , aeson
     , http-client
@@ -280,15 +280,14 @@ executable stackage-progress
       base >=4.16 && <5
     , aihc-parser
     , aihc-cpp
+    , aihc-hackage
     , text
     , containers
     , deepseq
     , directory
     , filepath
     , ghc-lib-parser
-    , process
     , async
-    , Cabal
     , Cabal-syntax
     , bytestring
     , haskell-src-exts

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/Snapshot.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/Snapshot.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | Stackage snapshot fetching and parsing.
+--
+-- Thin re-export layer over "Aihc.Hackage.Stackage".
 module StackageProgress.Snapshot
   ( loadStackageSnapshotWithMode,
     parseSnapshotConstraints,
@@ -8,127 +8,13 @@ module StackageProgress.Snapshot
   )
 where
 
-import Control.Exception (SomeException, displayException, try)
-import Data.Char (isAlphaNum, isSpace)
-import Data.List (isPrefixOf)
-import Data.Maybe (mapMaybe)
-import StackageProgress.Summary (PackageSpec (..))
-import System.Directory
-  ( XdgDirectory (XdgCache),
-    createDirectoryIfMissing,
-    doesFileExist,
-    getXdgDirectory,
-  )
-import System.FilePath ((</>))
-import System.Process (readProcess)
+import Aihc.Hackage.Cache (snapshotCacheFile)
+import Aihc.Hackage.Stackage (loadStackageSnapshot, parseSnapshotConstraints)
+import Aihc.Hackage.Types (PackageSpec)
 
 -- | Load a Stackage snapshot, either from cache or by fetching it.
+--
+-- Wraps 'loadStackageSnapshot' without a shared HTTP manager (creates one
+-- on demand).
 loadStackageSnapshotWithMode :: String -> Bool -> IO (Either String [PackageSpec])
-loadStackageSnapshotWithMode snapshot offline = do
-  cacheFile <- snapshotCacheFile snapshot
-  hasCache <- doesFileExist cacheFile
-  if hasCache
-    then do
-      cachedBody <- readFile cacheFile
-      pure (parseSnapshotConstraints cachedBody)
-    else
-      if offline
-        then pure (Left ("Snapshot missing from cache in offline mode: " ++ snapshot))
-        else do
-          let url = "https://www.stackage.org/" ++ snapshot ++ "/cabal.config"
-          fetched <- try (readProcess "curl" ["-s", "-f", url] "")
-          case fetched of
-            Left err -> pure (Left (displayException (err :: SomeException)))
-            Right body ->
-              case parseSnapshotConstraints body of
-                Left parseErr -> pure (Left parseErr)
-                Right specs -> do
-                  writeFile cacheFile body
-                  pure (Right specs)
-
--- | Get the cache file path for a snapshot.
-snapshotCacheFile :: String -> IO FilePath
-snapshotCacheFile snapshot = do
-  base <- getXdgDirectory XdgCache "aihc"
-  let dir = base </> "stackage"
-      file = sanitizeSnapshotName snapshot ++ "-cabal.config"
-  createDirectoryIfMissing True dir
-  pure (dir </> file)
-
-sanitizeSnapshotName :: String -> String
-sanitizeSnapshotName = map sanitizeChar
-  where
-    sanitizeChar c
-      | isAlphaNum c || c == '-' || c == '_' = c
-      | otherwise = '_'
-
--- | Parse package constraints from a snapshot's cabal.config.
-parseSnapshotConstraints :: String -> Either String [PackageSpec]
-parseSnapshotConstraints content = do
-  let section = constraintLines (lines content)
-      entries = map trim (splitComma (concat section))
-      specs = mapMaybe parseConstraint entries
-  if null specs
-    then Left "No package constraints found"
-    else Right specs
-
-constraintLines :: [String] -> [String]
-constraintLines ls =
-  case break (isPrefixOf "constraints:" . trimLeft) ls of
-    (_, []) -> []
-    (_, firstRaw : restRaw) ->
-      let firstLine = trimLeft firstRaw
-          start = [drop 12 firstLine]
-          cont = [trimLeft line | line <- takeWhile isConstraintContinuation restRaw]
-       in start <> cont
-
-isConstraintContinuation :: String -> Bool
-isConstraintContinuation line =
-  case line of
-    c : _ -> isSpace c
-    [] -> False
-
-trimLeft :: String -> String
-trimLeft = dropWhile isSpace
-
-parseConstraint :: String -> Maybe PackageSpec
-parseConstraint entry
-  | null entry = Nothing
-  | "--" `isPrefixOf` trim entry = Nothing
-  | otherwise =
-      case breakOn "==" entry of
-        Just (name, ver) -> Just (PackageSpec (trim name) (trim ver))
-        Nothing ->
-          let ws = words entry
-           in case ws of
-                -- Snapshot constraints like "base installed" refer to compiler-provided
-                -- packages and do not map to downloadable Hackage tarballs.
-                [_, "installed"] -> Nothing
-                _ -> Nothing
-
-breakOn :: String -> String -> Maybe (String, String)
-breakOn needle haystack =
-  case findNeedle needle haystack of
-    Nothing -> Nothing
-    Just i ->
-      let (left, right) = splitAt i haystack
-       in Just (left, drop (length needle) right)
-
-findNeedle :: String -> String -> Maybe Int
-findNeedle needle = go 0
-  where
-    go _ [] = Nothing
-    go i xs
-      | needle `isPrefixOf` xs = Just i
-      | otherwise = go (i + 1) (drop 1 xs)
-
-splitComma :: String -> [String]
-splitComma s =
-  case break (== ',') s of
-    (chunk, []) -> [chunk]
-    (chunk, _ : rest) -> chunk : splitComma rest
-
-trim :: String -> String
-trim = dropWhileEnd isSpace . dropWhile isSpace
-  where
-    dropWhileEnd p = reverse . dropWhile p . reverse
+loadStackageSnapshotWithMode = loadStackageSnapshot Nothing

--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- | Thin adapter over "Aihc.Hackage" that converts string-typed results
+-- to the rich types used by @aihc-parser@ executables and tests.
 module HackageSupport
   ( downloadPackage,
     downloadPackageQuiet,
@@ -14,128 +16,41 @@ module HackageSupport
 where
 
 import Aihc.Cpp (Diagnostic (..), IncludeKind (..), IncludeRequest (..), Severity (..))
+import Aihc.Hackage.Cabal qualified as HC
+import Aihc.Hackage.Download qualified as HD
+import Aihc.Hackage.Types qualified as HT
+import Aihc.Hackage.Util qualified as HU
 import Aihc.Parser.Syntax qualified as Syntax
-import Control.Monad (forM, when)
 import Data.ByteString qualified as BS
-import Data.Char (toLower)
-import Data.List (isPrefixOf, isSuffixOf, nub, sortOn)
-import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.List (nub)
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Encoding (decodeUtf8With)
-import Data.Text.Encoding.Error (lenientDecode)
-import Data.Version qualified as DV
-import Distribution.Compiler (CompilerFlavor (..))
-import Distribution.ModuleName (ModuleName, toFilePath)
-import Distribution.Package (unPackageName)
-import Distribution.PackageDescription
-  ( BuildInfo,
-    Executable,
-    FlagName,
-    Library,
-    autogenModules,
-    buildInfo,
-    buildable,
-    condExecutables,
-    condLibrary,
-    condSubLibraries,
-    cppOptions,
-    defaultExtensions,
-    defaultLanguage,
-    exeModules,
-    exposedModules,
-    flagDefault,
-    flagName,
-    hsSourceDirs,
-    libBuildInfo,
-    modulePath,
-    oldExtensions,
-    otherModules,
-  )
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
-import Distribution.Pretty (prettyShow)
-import Distribution.System (buildArch, buildOS)
-import Distribution.Types.BuildInfo (targetBuildDepends)
-import Distribution.Types.CondTree
-  ( CondBranch (CondBranch),
-    CondTree (condTreeComponents, condTreeData),
-  )
-import Distribution.Types.Condition (Condition (..))
-import Distribution.Types.ConfVar (ConfVar (..))
-import Distribution.Types.Dependency (depPkgName)
-import Distribution.Types.GenericPackageDescription (GenericPackageDescription, genPackageFlags)
-import Distribution.Utils.Path (getSymbolicPath)
-import Distribution.Version (mkVersion, withinRange)
-import System.Directory
-  ( XdgDirectory (XdgCache),
-    createDirectoryIfMissing,
-    doesDirectoryExist,
-    doesFileExist,
-    getXdgDirectory,
-    listDirectory,
-    removeDirectoryRecursive,
-    removeFile,
-    renameDirectory,
-  )
-import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, takeDirectory, takeFileName, (<.>), (</>))
-import System.Info (compilerName, compilerVersion)
-import System.Process (callCommand)
+import System.Directory (doesFileExist)
+import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, takeDirectory, (</>))
 
+-- | Download a Hackage package with verbose logging.
 downloadPackage :: String -> String -> IO FilePath
-downloadPackage = downloadPackageWithLogs True
+downloadPackage name version =
+  HD.downloadPackage (HT.PackageSpec name version)
 
+-- | Download a Hackage package silently.
 downloadPackageQuiet :: String -> String -> IO FilePath
-downloadPackageQuiet = downloadPackageWithLogs False
+downloadPackageQuiet name version =
+  HD.downloadPackageQuiet (HT.PackageSpec name version)
 
+-- | Download a Hackage package, controlling network access.
 downloadPackageQuietWithNetwork :: Bool -> String -> String -> IO FilePath
-downloadPackageQuietWithNetwork = downloadPackageWithMode False
+downloadPackageQuietWithNetwork allowNetwork name version =
+  HD.downloadPackageWithOptions
+    HD.defaultDownloadOptions
+      { HD.downloadVerbose = False,
+        HD.downloadAllowNetwork = allowNetwork
+      }
+    (HT.PackageSpec name version)
 
-downloadPackageWithLogs :: Bool -> String -> String -> IO FilePath
-downloadPackageWithLogs withLogs = downloadPackageWithMode withLogs True
-
-downloadPackageWithMode :: Bool -> Bool -> String -> String -> IO FilePath
-downloadPackageWithMode withLogs allowNetwork packageName version = do
-  cacheDir <- getCacheDir
-  let pkgDir = cacheDir </> packageName ++ "-" ++ version
-      markerFile = pkgDir </> ".complete"
-  markerExists <- doesFileExist markerFile
-  if markerExists
-    then do
-      when withLogs $ putStrLn ("Cache hit: " ++ packageName ++ "-" ++ version)
-      pure pkgDir
-    else
-      if not allowNetwork
-        then ioError (userError ("Package missing from cache in offline mode: " ++ packageName ++ "-" ++ version))
-        else do
-          createDirectoryIfMissing True cacheDir
-          when withLogs $ putStrLn ("Downloading " ++ packageName ++ "-" ++ version ++ " from Hackage...")
-          let url = "https://hackage.haskell.org/package/" ++ packageName ++ "-" ++ version ++ "/" ++ packageName ++ "-" ++ version ++ ".tar.gz"
-          let tarball = cacheDir </> packageName ++ "-" ++ version ++ ".tar.gz"
-          let tempDir = cacheDir </> packageName ++ "-" ++ version ++ ".tmp"
-          downloadFile url tarball
-          extractTarball tarball tempDir
-          removeFile tarball
-          dirExists <- doesDirectoryExist pkgDir
-          when dirExists $ removeDirectoryRecursive pkgDir
-          renameDirectory tempDir pkgDir
-          writeFile markerFile ""
-          pure pkgDir
-
-downloadFile :: String -> FilePath -> IO ()
-downloadFile url dest =
-  callCommand ("curl -s -f -o " ++ show dest ++ " " ++ show url)
-
-extractTarball :: FilePath -> FilePath -> IO ()
-extractTarball tarball destDir = do
-  createDirectoryIfMissing True destDir
-  callCommand ("tar -xzf " ++ show tarball ++ " -C " ++ show destDir)
-
-getCacheDir :: IO FilePath
-getCacheDir = do
-  cacheBase <- getXdgDirectory XdgCache "aihc"
-  pure (cacheBase </> "hackage")
-
+-- | Rich file info with parser-typed extensions and language.
 data FileInfo = FileInfo
   { fileInfoPath :: FilePath,
     fileInfoExtensions :: [Syntax.ExtensionSetting],
@@ -145,9 +60,13 @@ data FileInfo = FileInfo
   }
   deriving (Show)
 
+-- | Find target Haskell source files from a @.cabal@ file.
+--
+-- Delegates to 'Aihc.Hackage.Cabal.collectComponentFiles' and then converts
+-- the string-typed results to the rich types used by @aihc-parser@.
 findTargetFilesFromCabal :: FilePath -> IO [FileInfo]
 findTargetFilesFromCabal extractedRoot = do
-  cabalFiles <- findCabalFiles extractedRoot
+  cabalFiles <- HU.findCabalFiles extractedRoot
   cabalFile <-
     case cabalFiles of
       [file] -> pure file
@@ -156,7 +75,7 @@ findTargetFilesFromCabal extractedRoot = do
           ( userError
               ("No .cabal file found under extracted package root: " ++ extractedRoot)
           )
-      files -> pure (chooseBestCabalFile extractedRoot files)
+      files -> pure (HU.chooseBestCabalFile extractedRoot files)
   cabalBytes <- BS.readFile cabalFile
   let (_, parseResult) = runParseResult (parseGenericPackageDescription cabalBytes)
   gpd <-
@@ -167,202 +86,22 @@ findTargetFilesFromCabal extractedRoot = do
           ( userError
               ("Failed to parse cabal file " ++ cabalFile ++ ": " ++ show errs)
           )
-  collectComponentFiles gpd cabalFile
+  rawFiles <- HC.collectComponentFiles gpd (takeDirectory cabalFile)
+  pure (map convertFileInfo rawFiles)
 
-collectComponentFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
-collectComponentFiles gpd cabalFile = do
-  let packageRoot = takeDirectory cabalFile
-      evalCond = conditionEvaluator gpd
-      -- We flatten the GPD to get a fixed set of components. This isn't perfect
-      -- as it might pick branches that aren't usually active, but it's better
-      -- than trying to resolve conditions without a proper environment.
-      libraryTrees = maybe [] pure (condLibrary gpd) <> map snd (condSubLibraries gpd)
-      executableTrees = map snd (condExecutables gpd)
-
-  -- We use the flattened PD to get the actual components but they don't
-  -- easily map back to the files. Let's try to extract info from the CondTree
-  -- but also carry the BuildInfo.
-
-  libraryFiles <- fmap concat (forM libraryTrees (libraryFilesFor evalCond packageRoot))
-  executableFiles <- fmap concat (forM executableTrees (executableFilesFor evalCond packageRoot))
-
-  -- Dedupe by checking the path
-  let allFiles = libraryFiles <> executableFiles
-  pure (dedupeFiles allFiles)
-
-dedupeFiles :: [FileInfo] -> [FileInfo]
-dedupeFiles [] = []
-dedupeFiles (f : fs) = f : dedupeFiles (filter (\x -> fileInfoPath x /= fileInfoPath f) fs)
-
-libraryFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Library -> IO [FileInfo]
-libraryFilesFor evalCond packageRoot tree = do
-  let library = condTreeData tree
-      build = collectMergedBuildInfo evalCond libBuildInfo tree
-      moduleNames = exposedModules library <> otherModules build <> autogenModules build
-      exts = extractExtensions build
-      cppOpts = cppOptions build
-      lang = extractLanguage build
-      deps = extractDependencies build
-  if not (buildable build)
-    then pure []
-    else do
-      paths <- moduleFilesForBuildInfo packageRoot build moduleNames
-      pure [FileInfo path exts cppOpts lang deps | path <- paths]
-
-executableFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Executable -> IO [FileInfo]
-executableFilesFor evalCond packageRoot tree = do
-  let executable = condTreeData tree
-      build = collectMergedBuildInfo evalCond buildInfo tree
-      moduleNames = otherModules build <> exeModules executable <> autogenModules build
-      mainPath = modulePath executable
-      exts = extractExtensions build
-      cppOpts = cppOptions build
-      lang = extractLanguage build
-      deps = extractDependencies build
-  if not (buildable build)
-    then pure []
-    else do
-      moduleFiles <- moduleFilesForBuildInfo packageRoot build moduleNames
-      mainFiles <- existingPaths [dir </> mainPath | dir <- sourceDirs packageRoot build]
-      pure [FileInfo path exts cppOpts lang deps | path <- moduleFiles <> mainFiles]
-
-extractExtensions :: BuildInfo -> [Syntax.ExtensionSetting]
-extractExtensions bi = mapMaybe (Syntax.parseExtensionSettingName . T.pack) (nub (map prettyShow (defaultExtensions bi <> oldExtensions bi)))
-
-extractLanguage :: BuildInfo -> Maybe Syntax.LanguageEdition
-extractLanguage bi =
-  case defaultLanguage bi of
-    Just lang -> Syntax.parseLanguageEdition (T.pack (prettyShow lang))
-    Nothing -> Nothing
-
-extractDependencies :: BuildInfo -> [Text]
-extractDependencies bi =
-  map (T.pack . unPackageName . depPkgName) (targetBuildDepends bi)
-
-collectCondTreeData :: (Condition v -> Bool) -> CondTree v c a -> [a]
-collectCondTreeData evalCond tree =
-  condTreeData tree : concatMap collectBranch (condTreeComponents tree)
-  where
-    collectBranch (CondBranch cond thenTree elseTree) =
-      if evalCond cond
-        then collectCondTreeData evalCond thenTree
-        else maybe [] (collectCondTreeData evalCond) elseTree
-
-collectMergedBuildInfo :: (Monoid b) => (Condition v -> Bool) -> (a -> b) -> CondTree v c a -> b
-collectMergedBuildInfo evalCond toBuildInfo =
-  mconcat . map toBuildInfo . collectCondTreeData evalCond
-
-conditionEvaluator :: GenericPackageDescription -> Condition ConfVar -> Bool
-conditionEvaluator gpd = eval
-  where
-    defaultFlags :: Map.Map FlagName Bool
-    defaultFlags =
-      Map.fromList [(flagName flag, flagDefault flag) | flag <- genPackageFlags gpd]
-
-    compilerFlavor :: CompilerFlavor
-    compilerFlavor =
-      case compilerName of
-        "ghc" -> GHC
-        "ghcjs" -> GHCJS
-        other -> OtherCompiler other
-
-    compilerVer = mkVersion (DV.versionBranch compilerVersion)
-
-    eval (Var confVar) =
-      case confVar of
-        OS os -> os == buildOS
-        Arch arch -> arch == buildArch
-        PackageFlag flag -> Map.findWithDefault False flag defaultFlags
-        Impl flavor range -> flavor == compilerFlavor && withinRange compilerVer range
-    eval (Lit b) = b
-    eval (CNot c) = not (eval c)
-    eval (COr a b) = eval a || eval b
-    eval (CAnd a b) = eval a && eval b
-
-moduleFilesForBuildInfo :: FilePath -> BuildInfo -> [ModuleName] -> IO [FilePath]
-moduleFilesForBuildInfo packageRoot build modules = do
-  let dirs = sourceDirs packageRoot build
-      moduleCandidates =
-        [ dir </> toFilePath modu <.> ext
-        | dir <- dirs,
-          modu <- modules,
-          ext <- ["hs", "lhs"]
-        ]
-  dedupeExistingFiles moduleCandidates
-
-sourceDirs :: FilePath -> BuildInfo -> [FilePath]
-sourceDirs packageRoot build =
-  case map getSymbolicPath (hsSourceDirs build) of
-    [] -> [packageRoot]
-    dirs -> [packageRoot </> dir | dir <- dirs]
-
-findCabalFiles :: FilePath -> IO [FilePath]
-findCabalFiles dir = do
-  entries <- listDirectory dir
-  paths <- fmap concat $
-    forM entries $ \entry -> do
-      let fullPath = dir </> entry
-      isDir <- doesDirectoryExist fullPath
-      if isDir
-        then
-          if ".git" `isPrefixOf` entry
-            then pure []
-            else findCabalFiles fullPath
-        else
-          if ".cabal" `isSuffixOf` entry
-            then pure [fullPath]
-            else pure []
-  pure (nub (map normalise paths))
-
-existingPaths :: [FilePath] -> IO [FilePath]
-existingPaths candidates = do
-  existing <- forM candidates $ \candidate -> do
-    fileExists <- doesFileExist candidate
-    pure (if fileExists then Just (normalise candidate) else Nothing)
-  pure (catMaybes existing)
-
-dedupeExistingFiles :: [FilePath] -> IO [FilePath]
-dedupeExistingFiles files = fmap nub (existingPaths files)
-
-chooseBestCabalFile :: FilePath -> [FilePath] -> FilePath
-chooseBestCabalFile extractedRoot files =
-  case sortOn rank files of
-    best : _ -> best
-    [] -> error ("chooseBestCabalFile: no .cabal files found under " ++ extractedRoot)
-  where
-    rank file =
-      let rel = splitDirectories (makeRelative extractedRoot file)
-          dirParts = case reverse rel of
-            _fileName : restRev -> reverse restRev
-            [] -> []
-          lowerDirParts = map (map toLower) dirParts
-          isLikelyFixtureDir = any (`elem` fixtureDirNames) lowerDirParts
-       in ( if isLikelyFixtureDir then (1 :: Int) else 0,
-            length rel,
-            length dirParts,
-            scoreByFileName (map toLower (takeFileName file)),
-            file
-          )
-
-    scoreByFileName fileNameLower
-      | "test-" `isPrefixOf` fileNameLower = 1 :: Int
-      | "example-" `isPrefixOf` fileNameLower = 1
-      | otherwise = 0
-
-    fixtureDirNames =
-      [ "test",
-        "tests",
-        "testing",
-        "example",
-        "examples",
-        "benchmark",
-        "benchmarks"
-      ]
+-- | Convert a string-typed 'HC.FileInfo' to the rich-typed local 'FileInfo'.
+convertFileInfo :: HC.FileInfo -> FileInfo
+convertFileInfo raw =
+  FileInfo
+    { fileInfoPath = HC.fileInfoPath raw,
+      fileInfoExtensions = mapMaybe (Syntax.parseExtensionSettingName . T.pack) (HC.fileInfoExtensions raw),
+      fileInfoCppOptions = HC.fileInfoCppOptions raw,
+      fileInfoLanguage = HC.fileInfoLanguage raw >>= Syntax.parseLanguageEdition . T.pack,
+      fileInfoDependencies = HC.fileInfoDependencies raw
+    }
 
 readTextFileLenient :: FilePath -> IO Text
-readTextFileLenient filePath = do
-  bytes <- BS.readFile filePath
-  pure (decodeUtf8With lenientDecode bytes)
+readTextFileLenient = HU.readTextFileLenient
 
 resolveIncludeBestEffort :: FilePath -> FilePath -> IncludeRequest -> IO (Maybe BS.ByteString)
 resolveIncludeBestEffort packageRoot currentFile req = do

--- a/components/aihc-parser/common/StackageProgress/Summary.hs
+++ b/components/aihc-parser/common/StackageProgress/Summary.hs
@@ -25,14 +25,9 @@ module StackageProgress.Summary
   )
 where
 
+import Aihc.Hackage.Types (PackageSpec (..), formatPackage)
 import Data.Char (isSpace)
 import Data.List qualified as List
-
-data PackageSpec = PackageSpec
-  { pkgName :: String,
-    pkgVersion :: String
-  }
-  deriving (Eq, Show)
 
 data PackageResult = PackageResult
   { package :: PackageSpec,
@@ -138,9 +133,6 @@ summaryFailedPackages = summaryFailedPackagesAcc
 
 summaryGhcErrors :: RunSummary -> [(String, String)]
 summaryGhcErrors = summaryGhcErrorsAcc
-
-formatPackage :: PackageSpec -> String
-formatPackage spec = pkgName spec ++ "-" ++ pkgVersion spec
 
 packageParserFailed :: PackageResult -> Bool
 packageParserFailed result = not (packageOursOk result) && packageSourceSize result > 0

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,19 @@
           isDir || isHaskell || isCabal || isYaml || isLicense;
       };
 
+    hackageSrc = pkgs:
+      pkgs.lib.cleanSourceWith {
+        src = ./tooling/aihc-hackage;
+        filter = path: type: let
+          baseName = baseNameOf path;
+          isHaskell = pkgs.lib.hasSuffix ".hs" baseName;
+          isCabal = pkgs.lib.hasSuffix ".cabal" baseName;
+          isLicense = baseName == "LICENSE";
+          isDir = type == "directory";
+        in
+          isDir || isHaskell || isCabal || isLicense;
+      };
+
     # Filtered source for nix linting - only nix files
     nixSrc = pkgs:
       pkgs.lib.cleanSourceWith {
@@ -93,11 +106,11 @@
           type == "directory" || isNix;
       };
 
-    # Filtered source for Haskell linting/formatting - .hs files and .cabal files in components
+    # Filtered source for Haskell linting/formatting - .hs files and .cabal files in components and tooling
     # (.cabal files needed for ormolu to detect language settings like GHC2021)
     haskellSrc = pkgs:
       pkgs.lib.cleanSourceWith {
-        src = ./components;
+        src = ./.;
         filter = path: type: let
           baseName = baseNameOf path;
           isHaskell = pkgs.lib.hasSuffix ".hs" baseName;
@@ -105,8 +118,12 @@
           # Exclude test fixtures from linting
           pathStr = toString path;
           isFixture = pkgs.lib.hasInfix "/test/Test/Fixtures/" pathStr;
+          # Only include files under components/ or tooling/
+          inComponents = pkgs.lib.hasInfix "/components/" pathStr;
+          inTooling = pkgs.lib.hasInfix "/tooling/" pathStr;
+          isRelevant = inComponents || inTooling;
         in
-          type == "directory" || isCabal || (isHaskell && !isFixture);
+          type == "directory" || (isRelevant && (isCabal || (isHaskell && !isFixture)));
       };
 
     # Filtered source for scripts - only shell scripts
@@ -132,7 +149,8 @@
           inComponents =
             pkgs.lib.hasInfix "/components/aihc-parser/" pathStr
             || pkgs.lib.hasInfix "/components/aihc-parser-cli/" pathStr
-            || pkgs.lib.hasInfix "/components/aihc-cpp/" pathStr;
+            || pkgs.lib.hasInfix "/components/aihc-cpp/" pathStr
+            || pkgs.lib.hasInfix "/tooling/aihc-hackage/" pathStr;
           isHaskell = pkgs.lib.hasSuffix ".hs" baseName;
           isCabal = pkgs.lib.hasSuffix ".cabal" baseName;
           isYaml = pkgs.lib.hasSuffix ".yaml" baseName || pkgs.lib.hasSuffix ".yml" baseName;
@@ -153,6 +171,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           # Disable tests by default - tests are run explicitly via the checks
           aihc-parser = pkgs.haskell.lib.dontCheck (
             pkgs.haskell.lib.disableExecutableProfiling (
@@ -176,6 +195,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           # Checks should compile quickly; keep profiling disabled and optimization off.
           aihc-parser = pkgs.haskell.lib.dontCheck (
             pkgs.haskell.lib.disableOptimization (
@@ -206,6 +226,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           aihc-parser =
             pkgs.haskell.lib.overrideCabal
             (pkgs.haskell.lib.disableExecutableProfiling (
@@ -246,6 +267,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           aihc-parser =
             pkgs.haskell.lib.overrideCabal
             (pkgs.haskell.lib.disableOptimization (
@@ -293,6 +315,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           aihc-parser = pkgs.haskell.lib.dontCheck (
             pkgs.haskell.lib.doHaddock (
               pkgs.haskell.lib.disableExecutableProfiling (
@@ -321,6 +344,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           aihc-parser = pkgs.haskell.lib.dontCheck (
             pkgs.haskell.lib.doHaddock (
               pkgs.haskell.lib.disableOptimization (
@@ -428,6 +452,7 @@
       pkgs.haskellPackages.override {
         overrides = final: prev: {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
+          aihc-hackage = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (hackageSrc pkgs) {}));
           # Parser with coverage enabled
           aihc-parser = enableCoverageWithExport (
             pkgs.haskell.lib.disableExecutableProfiling (

--- a/tooling/aihc-hackage/LICENSE
+++ b/tooling/aihc-hackage/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -1,0 +1,35 @@
+cabal-version:      3.8
+name:               aihc-hackage
+version:            0.1.0.0
+build-type:         Simple
+license:            MIT
+license-file:       LICENSE
+author:             David Himmelstrup
+maintainer:         lemmih@gmail.com
+category:           Development
+synopsis:           Shared Hackage/Stackage download and cabal-file utilities
+
+library
+  exposed-modules:
+      Aihc.Hackage.Types
+    , Aihc.Hackage.Cache
+    , Aihc.Hackage.Download
+    , Aihc.Hackage.Stackage
+    , Aihc.Hackage.Cabal
+    , Aihc.Hackage.Util
+  hs-source-dirs:   src
+  build-depends:
+      base >=4.16 && <5
+    , bytestring
+    , Cabal-syntax
+    , containers
+    , directory
+    , filepath
+    , http-client
+    , http-client-tls
+    , http-types
+    , tar
+    , text
+    , zlib
+  ghc-options:        -Wall -Werror
+  default-language: GHC2021

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -1,0 +1,190 @@
+-- | Cabal-file parsing utilities: condition evaluation, component file discovery.
+module Aihc.Hackage.Cabal
+  ( -- * File info
+    FileInfo (..),
+
+    -- * Component file discovery
+    collectComponentFiles,
+
+    -- * Condition evaluation
+    conditionEvaluator,
+    collectCondTreeData,
+    collectMergedBuildInfo,
+
+    -- * Extension / language extraction
+    extractExtensions,
+    extractLanguage,
+    extractDependencies,
+  )
+where
+
+import Aihc.Hackage.Util (existingPaths, moduleFilesForBuildInfo, sourceDirs)
+import Data.List (nub)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Version qualified as DV
+import Distribution.Compiler (CompilerFlavor (..))
+import Distribution.Package (unPackageName)
+import Distribution.PackageDescription
+  ( BuildInfo,
+    Executable,
+    FlagName,
+    Library,
+    autogenModules,
+    buildInfo,
+    buildable,
+    condExecutables,
+    condLibrary,
+    condSubLibraries,
+    cppOptions,
+    defaultExtensions,
+    defaultLanguage,
+    exeModules,
+    exposedModules,
+    flagDefault,
+    flagName,
+    libBuildInfo,
+    modulePath,
+    oldExtensions,
+    otherModules,
+  )
+import Distribution.Pretty (prettyShow)
+import Distribution.System (buildArch, buildOS)
+import Distribution.Types.BuildInfo (targetBuildDepends)
+import Distribution.Types.CondTree
+  ( CondBranch (CondBranch),
+    CondTree (condTreeComponents, condTreeData),
+  )
+import Distribution.Types.Condition (Condition (..))
+import Distribution.Types.ConfVar (ConfVar (..))
+import Distribution.Types.Dependency (depPkgName)
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription, genPackageFlags)
+import Distribution.Version (mkVersion, withinRange)
+import System.FilePath ((</>))
+import System.Info (compilerName, compilerVersion)
+
+-- | Information about a Haskell source file discovered via a @.cabal@ file.
+data FileInfo = FileInfo
+  { fileInfoPath :: FilePath,
+    -- | Extension names as strings (e.g. @\"OverloadedStrings\"@, @\"NoImplicitPrelude\"@).
+    fileInfoExtensions :: [String],
+    -- | CPP options from the @cpp-options@ field.
+    fileInfoCppOptions :: [String],
+    -- | Default language from the @default-language@ field.
+    fileInfoLanguage :: Maybe String,
+    -- | Build dependency package names.
+    fileInfoDependencies :: [Text]
+  }
+  deriving (Show)
+
+-- | Collect all source files from a parsed @GenericPackageDescription@.
+--
+-- Returns deduplicated 'FileInfo' records for every library and executable
+-- component whose @buildable@ flag is true.
+collectComponentFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
+collectComponentFiles gpd packageRoot = do
+  let evalCond = conditionEvaluator gpd
+      libraryTrees = maybe [] pure (condLibrary gpd) <> map snd (condSubLibraries gpd)
+      executableTrees = map snd (condExecutables gpd)
+
+  libraryFiles <- fmap concat (mapM (libraryFilesFor evalCond packageRoot) libraryTrees)
+  executableFiles <- fmap concat (mapM (executableFilesFor evalCond packageRoot) executableTrees)
+
+  let allFiles = libraryFiles <> executableFiles
+  pure (dedupeFiles allFiles)
+
+dedupeFiles :: [FileInfo] -> [FileInfo]
+dedupeFiles [] = []
+dedupeFiles (f : fs) = f : dedupeFiles (filter (\x -> fileInfoPath x /= fileInfoPath f) fs)
+
+libraryFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Library -> IO [FileInfo]
+libraryFilesFor evalCond packageRoot tree = do
+  let library = condTreeData tree
+      build = collectMergedBuildInfo evalCond libBuildInfo tree
+      moduleNames = exposedModules library <> otherModules build <> autogenModules build
+      exts = extractExtensions build
+      cppOpts = cppOptions build
+      lang = extractLanguage build
+      deps = extractDependencies build
+  if not (buildable build)
+    then pure []
+    else do
+      paths <- moduleFilesForBuildInfo packageRoot build moduleNames
+      pure [FileInfo path exts cppOpts lang deps | path <- paths]
+
+executableFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Executable -> IO [FileInfo]
+executableFilesFor evalCond packageRoot tree = do
+  let executable = condTreeData tree
+      build = collectMergedBuildInfo evalCond buildInfo tree
+      moduleNames = otherModules build <> exeModules executable <> autogenModules build
+      mainPath = modulePath executable
+      exts = extractExtensions build
+      cppOpts = cppOptions build
+      lang = extractLanguage build
+      deps = extractDependencies build
+  if not (buildable build)
+    then pure []
+    else do
+      moduleFiles <- moduleFilesForBuildInfo packageRoot build moduleNames
+      mainFiles <- existingPaths [dir </> mainPath | dir <- sourceDirs packageRoot build]
+      pure [FileInfo path exts cppOpts lang deps | path <- moduleFiles <> mainFiles]
+
+-- | Evaluate cabal conditions using the host compiler and default flag values.
+conditionEvaluator :: GenericPackageDescription -> Condition ConfVar -> Bool
+conditionEvaluator gpd = eval
+  where
+    defaultFlags :: Map.Map FlagName Bool
+    defaultFlags =
+      Map.fromList [(flagName flag, flagDefault flag) | flag <- genPackageFlags gpd]
+
+    compilerFlavor :: CompilerFlavor
+    compilerFlavor =
+      case compilerName of
+        "ghc" -> GHC
+        "ghcjs" -> GHCJS
+        other -> OtherCompiler other
+
+    compilerVer = mkVersion (DV.versionBranch compilerVersion)
+
+    eval (Var confVar) =
+      case confVar of
+        OS os -> os == buildOS
+        Arch arch -> arch == buildArch
+        PackageFlag flag -> Map.findWithDefault False flag defaultFlags
+        Impl flavor range -> flavor == compilerFlavor && withinRange compilerVer range
+    eval (Lit b) = b
+    eval (CNot c) = not (eval c)
+    eval (COr a b) = eval a || eval b
+    eval (CAnd a b) = eval a && eval b
+
+-- | Collect all data nodes from a 'CondTree', evaluating conditions.
+collectCondTreeData :: (Condition v -> Bool) -> CondTree v c a -> [a]
+collectCondTreeData evalCond tree =
+  condTreeData tree : concatMap collectBranch (condTreeComponents tree)
+  where
+    collectBranch (CondBranch cond thenTree elseTree) =
+      if evalCond cond
+        then collectCondTreeData evalCond thenTree
+        else maybe [] (collectCondTreeData evalCond) elseTree
+
+-- | Merge 'BuildInfo' from all active branches of a 'CondTree'.
+collectMergedBuildInfo :: (Monoid b) => (Condition v -> Bool) -> (a -> b) -> CondTree v c a -> b
+collectMergedBuildInfo evalCond toBuildInfo =
+  mconcat . map toBuildInfo . collectCondTreeData evalCond
+
+-- | Extract extension names as strings from a 'BuildInfo'.
+extractExtensions :: BuildInfo -> [String]
+extractExtensions bi = nub (map prettyShow (defaultExtensions bi <> oldExtensions bi))
+
+-- | Extract the default language as a string from a 'BuildInfo'.
+extractLanguage :: BuildInfo -> Maybe String
+extractLanguage bi =
+  case defaultLanguage bi of
+    Just lang -> Just (prettyShow lang)
+    Nothing -> Nothing
+
+-- | Extract build dependency package names from a 'BuildInfo'.
+extractDependencies :: BuildInfo -> [Text]
+extractDependencies bi =
+  map (T.pack . unPackageName . depPkgName) (targetBuildDepends bi)

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cache.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cache.hs
@@ -1,0 +1,49 @@
+-- | XDG cache layout for downloaded Hackage packages and Stackage snapshots.
+module Aihc.Hackage.Cache
+  ( getHackageCacheDir,
+    getStackageCacheDir,
+    snapshotCacheFile,
+    sanitizeName,
+  )
+where
+
+import Data.Char (isAlphaNum)
+import System.Directory
+  ( XdgDirectory (XdgCache),
+    createDirectoryIfMissing,
+    getXdgDirectory,
+  )
+import System.FilePath ((</>))
+
+-- | XDG cache directory for downloaded Hackage packages.
+--
+-- @~\/.cache\/aihc\/hackage@
+getHackageCacheDir :: IO FilePath
+getHackageCacheDir = do
+  cacheBase <- getXdgDirectory XdgCache "aihc"
+  pure (cacheBase </> "hackage")
+
+-- | XDG cache directory for Stackage snapshot data.
+--
+-- @~\/.cache\/aihc\/stackage@
+getStackageCacheDir :: IO FilePath
+getStackageCacheDir = do
+  cacheBase <- getXdgDirectory XdgCache "aihc"
+  let dir = cacheBase </> "stackage"
+  createDirectoryIfMissing True dir
+  pure dir
+
+-- | Get the cache file path for a snapshot.
+snapshotCacheFile :: String -> IO FilePath
+snapshotCacheFile snapshot = do
+  dir <- getStackageCacheDir
+  let file = sanitizeName snapshot ++ "-cabal.config"
+  pure (dir </> file)
+
+-- | Sanitize a string for use as a filename.
+sanitizeName :: String -> String
+sanitizeName = map sanitizeChar
+  where
+    sanitizeChar c
+      | isAlphaNum c || c == '-' || c == '_' = c
+      | otherwise = '_'

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Download.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Download.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Download Hackage packages into the local XDG cache.
+module Aihc.Hackage.Download
+  ( downloadPackage,
+    downloadPackageQuiet,
+    downloadPackageWithOptions,
+    DownloadOptions (..),
+    defaultDownloadOptions,
+  )
+where
+
+import Aihc.Hackage.Cache (getHackageCacheDir)
+import Aihc.Hackage.Types (PackageSpec (..), formatPackage)
+import Codec.Archive.Tar qualified as Tar
+import Codec.Compression.GZip qualified as GZip
+import Control.Exception (SomeException, displayException, try)
+import Control.Monad (when)
+import Data.ByteString.Lazy qualified as LBS
+import Network.HTTP.Client (Manager, httpLbs, newManager, parseRequest, responseBody, responseStatus)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Status (statusCode)
+import System.Directory
+  ( createDirectoryIfMissing,
+    doesDirectoryExist,
+    doesFileExist,
+    removeDirectoryRecursive,
+  )
+import System.FilePath ((</>))
+import System.IO (hPutStrLn, stderr)
+
+-- | Options for downloading a package.
+data DownloadOptions = DownloadOptions
+  { downloadVerbose :: !Bool,
+    downloadAllowNetwork :: !Bool,
+    downloadManager :: !(Maybe Manager)
+  }
+
+-- | Default download options: verbose, network allowed, no shared manager.
+defaultDownloadOptions :: DownloadOptions
+defaultDownloadOptions =
+  DownloadOptions
+    { downloadVerbose = True,
+      downloadAllowNetwork = True,
+      downloadManager = Nothing
+    }
+
+-- | Download a package with default (verbose) logging.
+downloadPackage :: PackageSpec -> IO FilePath
+downloadPackage = downloadPackageWithOptions defaultDownloadOptions
+
+-- | Download a package without logging.
+downloadPackageQuiet :: PackageSpec -> IO FilePath
+downloadPackageQuiet = downloadPackageWithOptions defaultDownloadOptions {downloadVerbose = False}
+
+-- | Download a package with the given options.
+downloadPackageWithOptions :: DownloadOptions -> PackageSpec -> IO FilePath
+downloadPackageWithOptions opts pkg = do
+  cacheDir <- getHackageCacheDir
+  let pkgDir = cacheDir </> formatPackage pkg
+      markerFile = pkgDir </> ".complete"
+  markerExists <- doesFileExist markerFile
+  if markerExists
+    then do
+      when (downloadVerbose opts) $
+        hPutStrLn stderr ("Cache hit: " ++ formatPackage pkg)
+      pure pkgDir
+    else
+      if not (downloadAllowNetwork opts)
+        then ioError (userError ("Package missing from cache in offline mode: " ++ formatPackage pkg))
+        else do
+          createDirectoryIfMissing True cacheDir
+          when (downloadVerbose opts) $
+            hPutStrLn stderr ("Downloading " ++ formatPackage pkg ++ " from Hackage...")
+          let url =
+                "https://hackage.haskell.org/package/"
+                  ++ formatPackage pkg
+                  ++ "/"
+                  ++ formatPackage pkg
+                  ++ ".tar.gz"
+          manager <- case downloadManager opts of
+            Just m -> pure m
+            Nothing -> newManager tlsManagerSettings
+          tarballBytes <- httpGetLBS manager url
+          case tarballBytes of
+            Left err -> ioError (userError ("Failed to download " ++ formatPackage pkg ++ ": " ++ err))
+            Right lbs -> do
+              let entries = Tar.read (GZip.decompress lbs)
+              pkgDirExists <- doesDirectoryExist pkgDir
+              when pkgDirExists $ removeDirectoryRecursive pkgDir
+              Tar.unpack cacheDir entries
+              writeFile markerFile ""
+              pure pkgDir
+
+-- | Perform an HTTP GET request and return the response body as lazy ByteString.
+httpGetLBS :: Manager -> String -> IO (Either String LBS.ByteString)
+httpGetLBS manager url = do
+  result <- try $ do
+    request <- parseRequest url
+    response <- httpLbs request manager
+    let status = statusCode (responseStatus response)
+    if status >= 200 && status < 300
+      then pure (Right (responseBody response))
+      else pure (Left ("HTTP " ++ show status ++ " for " ++ url))
+  case result of
+    Left (err :: SomeException) -> pure (Left (displayException err))
+    Right r -> pure r

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Stackage.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Stackage.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Stackage snapshot fetching and parsing.
+module Aihc.Hackage.Stackage
+  ( loadStackageSnapshot,
+    parseSnapshotConstraints,
+  )
+where
+
+import Aihc.Hackage.Cache (snapshotCacheFile)
+import Aihc.Hackage.Types (PackageSpec (..))
+import Control.Exception (SomeException, displayException, try)
+import Data.Char (isSpace)
+import Data.List (isPrefixOf)
+import Data.Maybe (mapMaybe)
+import Data.Text.Encoding.Error (lenientDecode)
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Encoding qualified as TLE
+import Network.HTTP.Client (Manager, httpLbs, newManager, parseRequest, responseBody, responseStatus)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Status (statusCode)
+import System.Directory (doesFileExist)
+
+-- | Load a Stackage snapshot, either from cache or by fetching it.
+--
+-- When @offline@ is 'True', only the cache is consulted.  A shared
+-- 'Manager' can be provided; if 'Nothing', a fresh one is created.
+loadStackageSnapshot :: Maybe Manager -> String -> Bool -> IO (Either String [PackageSpec])
+loadStackageSnapshot mManager snapshot offline = do
+  cacheFile <- snapshotCacheFile snapshot
+  hasCache <- doesFileExist cacheFile
+  if hasCache
+    then do
+      cachedBody <- readFile cacheFile
+      pure (parseSnapshotConstraints cachedBody)
+    else
+      if offline
+        then pure (Left ("Snapshot missing from cache in offline mode: " ++ snapshot))
+        else do
+          manager <- case mManager of
+            Just m -> pure m
+            Nothing -> newManager tlsManagerSettings
+          let url = "https://www.stackage.org/" ++ snapshot ++ "/cabal.config"
+          fetched <- httpGetString manager url
+          case fetched of
+            Left err -> pure (Left err)
+            Right body ->
+              case parseSnapshotConstraints body of
+                Left parseErr -> pure (Left parseErr)
+                Right specs -> do
+                  writeFile cacheFile body
+                  pure (Right specs)
+
+-- | Parse package constraints from a snapshot's @cabal.config@.
+parseSnapshotConstraints :: String -> Either String [PackageSpec]
+parseSnapshotConstraints content = do
+  let section = constraintLines (lines content)
+      entries = map trim (splitComma (concat section))
+      specs = mapMaybe parseConstraint entries
+  if null specs
+    then Left "No package constraints found"
+    else Right specs
+
+--------------------------------------------------------------------------------
+-- Internal helpers
+--------------------------------------------------------------------------------
+
+constraintLines :: [String] -> [String]
+constraintLines ls =
+  case break (isPrefixOf "constraints:" . trimLeft) ls of
+    (_, []) -> []
+    (_, firstRaw : restRaw) ->
+      let firstLine = trimLeft firstRaw
+          start = [drop 12 firstLine]
+          cont = [trimLeft line | line <- takeWhile isConstraintContinuation restRaw]
+       in start <> cont
+
+isConstraintContinuation :: String -> Bool
+isConstraintContinuation line =
+  case line of
+    c : _ -> isSpace c
+    [] -> False
+
+trimLeft :: String -> String
+trimLeft = dropWhile isSpace
+
+parseConstraint :: String -> Maybe PackageSpec
+parseConstraint entry
+  | null entry = Nothing
+  | "--" `isPrefixOf` trim entry = Nothing
+  | otherwise =
+      case breakOn "==" entry of
+        Just (name, ver) -> Just (PackageSpec (trim name) (trim ver))
+        Nothing ->
+          let ws = words entry
+           in case ws of
+                -- Snapshot constraints like "base installed" refer to compiler-provided
+                -- packages and do not map to downloadable Hackage tarballs.
+                [_, "installed"] -> Nothing
+                _ -> Nothing
+
+breakOn :: String -> String -> Maybe (String, String)
+breakOn needle haystack =
+  case findNeedle needle haystack of
+    Nothing -> Nothing
+    Just i ->
+      let (left, right) = splitAt i haystack
+       in Just (left, drop (length needle) right)
+
+findNeedle :: String -> String -> Maybe Int
+findNeedle needle = go 0
+  where
+    go _ [] = Nothing
+    go i xs
+      | needle `isPrefixOf` xs = Just i
+      | otherwise = go (i + 1) (drop 1 xs)
+
+splitComma :: String -> [String]
+splitComma s =
+  case break (== ',') s of
+    (chunk, []) -> [chunk]
+    (chunk, _ : rest) -> chunk : splitComma rest
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace
+  where
+    dropWhileEnd p = reverse . dropWhile p . reverse
+
+-- | Perform an HTTP GET request and return the response body as a String.
+-- Uses lenient UTF-8 decoding to handle malformed sequences.
+httpGetString :: Manager -> String -> IO (Either String String)
+httpGetString manager url = do
+  result <- try $ do
+    request <- parseRequest url
+    response <- httpLbs request manager
+    let status = statusCode (responseStatus response)
+    if status >= 200 && status < 300
+      then pure (Right (TL.unpack (TLE.decodeUtf8With lenientDecode (responseBody response))))
+      else pure (Left ("HTTP " ++ show status ++ " for " ++ url))
+  case result of
+    Left (err :: SomeException) -> pure (Left (displayException err))
+    Right r -> pure r

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Types.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Types.hs
@@ -1,0 +1,17 @@
+-- | Core types for Hackage package identification.
+module Aihc.Hackage.Types
+  ( PackageSpec (..),
+    formatPackage,
+  )
+where
+
+-- | A package specification: name and version.
+data PackageSpec = PackageSpec
+  { pkgName :: !String,
+    pkgVersion :: !String
+  }
+  deriving (Eq, Show)
+
+-- | Format a package spec as @name-version@.
+formatPackage :: PackageSpec -> String
+formatPackage spec = pkgName spec ++ "-" ++ pkgVersion spec

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Util.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Util.hs
@@ -1,0 +1,124 @@
+-- | Shared file-system utilities for Hackage package processing.
+module Aihc.Hackage.Util
+  ( readTextFileLenient,
+    existingPaths,
+    dedupeExistingFiles,
+    findCabalFiles,
+    chooseBestCabalFile,
+    moduleFilesForBuildInfo,
+    sourceDirs,
+  )
+where
+
+import Control.Monad (forM)
+import Data.ByteString qualified as BS
+import Data.Char (toLower)
+import Data.List (isPrefixOf, isSuffixOf, nub, sortOn)
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (lenientDecode)
+import Distribution.ModuleName (ModuleName, toFilePath)
+import Distribution.PackageDescription (BuildInfo, hsSourceDirs)
+import Distribution.Utils.Path (getSymbolicPath)
+import System.Directory
+  ( doesDirectoryExist,
+    doesFileExist,
+    listDirectory,
+  )
+import System.FilePath (makeRelative, normalise, splitDirectories, takeFileName, (<.>), (</>))
+
+-- | Read a file as 'Text' with lenient UTF-8 decoding.
+readTextFileLenient :: FilePath -> IO Text
+readTextFileLenient filePath = do
+  bytes <- BS.readFile filePath
+  pure (decodeUtf8With lenientDecode bytes)
+
+-- | Return only the paths that exist on disk, normalised.
+existingPaths :: [FilePath] -> IO [FilePath]
+existingPaths candidates = do
+  existing <- forM candidates $ \candidate -> do
+    fileExists <- doesFileExist candidate
+    pure (if fileExists then Just (normalise candidate) else Nothing)
+  pure (catMaybes existing)
+
+-- | Deduplicate and filter to existing files.
+dedupeExistingFiles :: [FilePath] -> IO [FilePath]
+dedupeExistingFiles files = fmap nub (existingPaths files)
+
+-- | Find all @.cabal@ files under a directory (recursive, skips @.git@).
+findCabalFiles :: FilePath -> IO [FilePath]
+findCabalFiles dir = do
+  entries <- listDirectory dir
+  paths <- fmap concat $
+    forM entries $ \entry -> do
+      let fullPath = dir </> entry
+      isDir <- doesDirectoryExist fullPath
+      if isDir
+        then
+          if ".git" `isPrefixOf` entry
+            then pure []
+            else findCabalFiles fullPath
+        else
+          if ".cabal" `isSuffixOf` entry
+            then pure [fullPath]
+            else pure []
+  pure (nub (map normalise paths))
+
+-- | When multiple @.cabal@ files are found, pick the \"best\" one.
+--
+-- Heuristic: prefer files closer to the root and outside test\/example
+-- directories.
+chooseBestCabalFile :: FilePath -> [FilePath] -> FilePath
+chooseBestCabalFile extractedRoot files =
+  case sortOn rank files of
+    best : _ -> best
+    [] -> error ("chooseBestCabalFile: no .cabal files found under " ++ extractedRoot)
+  where
+    rank file =
+      let rel = splitDirectories (makeRelative extractedRoot file)
+          dirParts = case reverse rel of
+            _fileName : restRev -> reverse restRev
+            [] -> []
+          lowerDirParts = map (map toLower) dirParts
+          isLikelyFixtureDir = any (`elem` fixtureDirNames) lowerDirParts
+       in ( if isLikelyFixtureDir then (1 :: Int) else 0,
+            length rel,
+            length dirParts,
+            scoreByFileName (map toLower (takeFileName file)),
+            file
+          )
+
+    scoreByFileName fileNameLower
+      | "test-" `isPrefixOf` fileNameLower = 1 :: Int
+      | "example-" `isPrefixOf` fileNameLower = 1
+      | otherwise = 0
+
+    fixtureDirNames =
+      [ "test",
+        "tests",
+        "testing",
+        "example",
+        "examples",
+        "benchmark",
+        "benchmarks"
+      ]
+
+-- | Resolve module names to existing source files for a 'BuildInfo'.
+moduleFilesForBuildInfo :: FilePath -> BuildInfo -> [ModuleName] -> IO [FilePath]
+moduleFilesForBuildInfo packageRoot build modules = do
+  let dirs = sourceDirs packageRoot build
+      moduleCandidates =
+        [ dir </> toFilePath modu <.> ext
+        | dir <- dirs,
+          modu <- modules,
+          ext <- ["hs", "lhs"]
+        ]
+  dedupeExistingFiles moduleCandidates
+
+-- | Compute source directories from a 'BuildInfo'.
+sourceDirs :: FilePath -> BuildInfo -> [FilePath]
+sourceDirs packageRoot build =
+  case map getSymbolicPath (hsSourceDirs build) of
+    [] -> [packageRoot]
+    dirs -> [packageRoot </> dir | dir <- dirs]


### PR DESCRIPTION
## Summary

- Extract a new shared `tooling/aihc-hackage` library consolidating Hackage/Stackage download, snapshot parsing, and cabal-file utilities that were duplicated across `stackage-progress`, `hackage-tester`, and `aihc-parser-bench`
- Replace shell-based `curl`+`tar` downloading with pure Haskell `http-client`+`Codec.Archive.Tar` in all consumers
- Refactor `HackageSupport.hs`, `Snapshot.hs`, `Summary.hs`, and `Tarball.hs` into thin adapters over the shared library

## Motivation

`HackageSupport.hs` (compiled via `hs-source-dirs` into each executable) and `Tarball.hs` contained ~19 exactly-duplicated functions and ~10 structurally-duplicated functions for:
- Hackage package downloading and caching
- Stackage snapshot fetching and parsing
- Cabal condition evaluation and component file discovery
- File-system utilities (`readTextFileLenient`, `existingPaths`, etc.)

This duplication was a maintenance burden and source of subtle bugs (e.g. different `findCabalFiles` behaviors, shell injection risk in `curl` calls).

## New library: `tooling/aihc-hackage`

| Module | Purpose |
|---|---|
| `Aihc.Hackage.Types` | `PackageSpec`, `formatPackage` |
| `Aihc.Hackage.Cache` | XDG cache directories, snapshot cache file paths |
| `Aihc.Hackage.Download` | Package downloading via `http-client` |
| `Aihc.Hackage.Stackage` | Snapshot fetching and constraint parsing |
| `Aihc.Hackage.Cabal` | Condition evaluation, component file discovery, extension/language extraction |
| `Aihc.Hackage.Util` | `readTextFileLenient`, file path utilities, `findCabalFiles` |

## Consumer changes

- **`HackageSupport.hs`**: Thin adapter converting `[String]` to `[Syntax.ExtensionSetting]`. Retains CPP-specific utilities (`resolveIncludeBestEffort`, `diagToText`)
- **`Snapshot.hs`**: 3-function re-export layer over `Aihc.Hackage.Stackage`
- **`Summary.hs`**: `PackageSpec`/`formatPackage` now re-exported from `Aihc.Hackage.Types`
- **`Tarball.hs`**: ~400 lines of duplicated code removed

## Dependency changes

- `aihc-parser.cabal`: Added `aihc-hackage`, removed `Cabal`/`process` from `stackage-progress`
- `aihc-parser-cli.cabal`: Added `aihc-hackage`, removed `http-types`
- `flake.nix`: Added `hackageSrc` filter and `aihc-hackage` to all 7 override blocks

## Progress count changes

No test count changes. All 1270 parser tests, 44 CPP tests, 14 CLI tests, and 9 resolve tests pass.