### PR TITLE
fix(parser): lex qualified '.' operators

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -285,11 +285,7 @@ lexIdentifier env st =
               (consumed, rest1, isQualified) = gatherQualified hasMagicHash firstChunk rest0
            in case (isQualified || isConIdStart c, rest1) of
                 (True, '.' :< dotRest@(opChar :< _))
-                  | isSymbolicOpChar opChar,
-                    -- When the first op char is '.', require at least one more
-                    -- non-dot symbolic char (e.g. ".&." in M..&.) to avoid
-                    -- consuming the ".." range token in expressions like [A..Z].
-                    opChar /= '.' || T.any (\ch -> isSymbolicOpChar ch && ch /= '.') dotRest ->
+                  | isSymbolicOpChar opChar ->
                       let opChars = T.takeWhile isSymbolicOpChar dotRest
                           fullOp = consumed <> "." <> opChars
                           (modName, opName) = splitQualified (consumed <> ".") opChars

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-dot-section-right.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/qualified-dot-section-right.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  (Foo.. x)
+ast: EParen (ESectionR "Foo.." (EVar "x"))
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/qualified-dot-section-right.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/qualified-dot-section-right.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+module ExprQualifiedDotSectionRight where
+
+import qualified Prelude as Foo
+
+x = (Foo.. Foo.id)

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -14,7 +14,6 @@ where
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Char (isSpace)
-import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Identifiers (extensionReservedIdentifiers, genIdent, shrinkIdent)
@@ -170,11 +169,7 @@ genOperatorName :: Gen Name
 genOperatorName = do
   qual <- genOptionalQualifier
   op <- mkUnqualifiedName NameVarSym <$> genOperator
-  -- NOTE: Qualified "." creates "Module.." which the lexer sees as ".." (range).
-  -- Skip qualified "." until the pretty-printer handles this case.
-  if isJust qual && unqualifiedNameText op == "."
-    then genOperatorName
-    else pure (qualifyName qual op)
+  pure (qualifyName qual op)
 
 -- | Generate a custom operator
 -- Only uses valid operator characters (matching isOperatorToken in Pretty.hs)


### PR DESCRIPTION
## Summary
- fix the lexer so `Foo..` is tokenized as the qualified `.` operator instead of the `..` range token
- add a golden regression for right sections using a qualified `.`
- add an oracle regression covering a Haskell module that uses `(Foo.. Foo.id)`
- remove the QuickCheck generator workaround that had been skipping qualified `.` operators

## Root Cause
The lexer had a special-case guard that refused to lex a qualified operator when the operator part started with `.` unless another non-dot operator character followed. That made pretty-printed `Foo..` get tokenized as a module qualifier plus `..` instead of `TkQVarSym "Foo" "."`.

## Impact
Pretty-printed ASTs that contain a qualified composition operator now round-trip through the lexer/parser path again, and the generator can cover that case instead of filtering it out.

## Progress Counts
- oracle fixtures: +1 pass case
- golden expression fixtures: +1 pass case

## Validation
- `cabal test -v0 aihc-parser:spec --test-options='--hide-successes --pattern qualified-dot-section-right'`
- `printf '%s\n' 'Foo..' | cabal run -v0 exe:aihc-parser -- --lex`
- `ghc -v0 -fno-code components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/qualified-dot-section-right.hs`

## Notes
- `nix flake check` still fails on existing unrelated QuickCheck regressions in `generated decl AST pretty-printer round-trip` during `aihc-parser:spec`.
- `coderabbit review --prompt-only` was not run because the repo instructions gate it on local checks passing, and `nix flake check` is currently red for that unrelated failure class.

Closes #677.