### PR TITLE
fix(parser): accept 1-element unboxed tuples

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -760,7 +760,9 @@ parenExprParser = withSpan $ do
                   expectedTok closeTok
                   let arity = 2 + length trailingBars
                   pure (\span' -> EUnboxedSum span' 0 arity e)
-                Nothing -> fail "not an unboxed tuple"
+                Nothing -> do
+                  expectedTok closeTok
+                  pure (\span' -> ETuple span' Unboxed [Just e])
         (_, Just ()) -> do
           rest <- parseTupleElems closeTok
           pure (\span' -> ETuple span' tupleFlavor (first : rest))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -423,7 +423,7 @@ parenOrTuplePatternParser = withSpan $ do
               expectedTok closeTok
               if tupleFlavor == Boxed
                 then pure (`PParen` first)
-                else fail "not an unboxed tuple pattern"
+                else pure (\span' -> PTuple span' Unboxed [first])
         Just () -> do
           second <- parenPatElementParser
           more <- MP.many (expectedTok TkSpecialComma *> parenPatElementParser)

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/unboxed-tuples-singleton.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/unboxed-tuples-singleton.yaml
@@ -1,0 +1,8 @@
+extensions: [UnboxedTuples]
+input: |
+  {-# LANGUAGE UnboxedTuples #-}
+  module UnboxedTuplesSingleton where
+  x = (# 1 #)
+  f (# y #) = y
+ast: Module {name = "UnboxedTuplesSingleton", languagePragmas = [EnableExtension UnboxedTuples], decls = [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (ETupleUnboxed [EInt 1])}]), DeclValue (FunctionBind "f" [Match {headForm = Prefix, pats = [PTupleUnboxed [PVar "y"]], rhs = UnguardedRhs (EVar "y")}])]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/singleton.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/singleton.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedTuples #-}
+module Singleton where
+
+x = (# 1 #)
+
+f (# y #) = y


### PR DESCRIPTION
## Summary
- accept `(# x #)` as a 1-element unboxed tuple expression instead of rejecting it unless it is an unboxed sum
- accept `(# x #)` as a 1-element unboxed tuple pattern instead of failing in pattern context
- add golden and oracle regression coverage for singleton unboxed tuples

## Root Cause
The parser treated the no-comma, no-pipe path inside unboxed tuple parsing as an error. That was correct for boxed tuples becoming parenthesized expressions/patterns, but incorrect for unboxed tuples where `(# x #)` is a valid singleton tuple in both expression and pattern positions.

## Validation
- `cabal test -v0 aihc-parser:spec --test-options='--pattern unboxed-tuples-singleton.yaml --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern UnboxedTuples --hide-successes'`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)

## Progress Counts
- parser golden `pass`: +1
- oracle `pass`: +1

Closes #676.
