### PR TITLE
fix(parser): handle `->` in delimited expression contexts for view patterns

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -38,7 +38,12 @@ checkPattern expr = case expr of
     | isJust (nameQualifier name) -> Left "unexpected qualified name in pattern"
     | otherwise -> Right (PVar sp (mkUnqualifiedName (nameType name) (nameText name)))
   -- Parenthesized expression
-  EParen sp inner -> PParen sp <$> checkPattern inner
+  -- When the inner expression is a view-pattern arrow (@expr -> expr@), strip
+  -- the EParen wrapper so that @(f -> pat)@ maps to @PView f pat@ directly,
+  -- matching the AST shape produced by the dedicated pattern parser.
+  EParen _sp inner
+    | Just vp <- asViewPat inner -> Right vp
+    | otherwise -> PParen _sp <$> checkPattern inner
   -- Tuple
   ETuple sp fl elems -> do
     pats <- traverse checkTupleElement elems
@@ -47,8 +52,12 @@ checkPattern expr = case expr of
   EList sp elems -> PList sp <$> traverse checkPattern elems
   -- Unboxed sum
   EUnboxedSum sp i n e -> PUnboxedSum sp i n <$> checkPattern e
-  -- Infix: only constructor operators (starting with ':') are valid in patterns
+  -- Infix: only constructor operators (starting with ':') or the view-pattern
+  -- arrow @->@ are valid in patterns.
   EInfix sp l op r
+    | renderName op == "->" -> do
+        rPat <- checkPattern r
+        Right (PView sp l rPat)
     | isConLikeOp op -> do
         lPat <- checkPattern l
         rPat <- checkPattern r
@@ -138,3 +147,16 @@ checkNegLitPattern sp inner = case inner of
 -- variable operators like @+@ or @*@ are not.
 isConLikeOp :: Name -> Bool
 isConLikeOp = isConLikeName
+
+-- | Try to interpret an expression as a view pattern @expr -> expr@.
+-- Returns 'Just' the corresponding 'PView' when the expression is an
+-- 'EInfix' with @->@; 'Nothing' otherwise.  Used by the 'EParen' case of
+-- 'checkPattern' to strip the outer parentheses and produce @PView@
+-- directly (matching the AST shape that the dedicated pattern parser
+-- produces).
+asViewPat :: Expr -> Maybe Pattern
+asViewPat (EInfix sp l op r)
+  | renderName op == "->" = case checkPattern r of
+      Right rPat -> Just (PView sp l rPat)
+      Left _ -> Nothing
+asViewPat _ = Nothing

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -85,6 +85,30 @@ exprCoreParserExcept forbiddenInfix = do
     Just ty -> ETypeSig (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty)) withArrow ty
     Nothing -> withArrow
 
+-- | The operator name used to represent @->@ in view-pattern expressions.
+viewPatArrowName :: Name
+viewPatArrowName = qualifyName Nothing (mkUnqualifiedName NameVarSym "->")
+
+-- | Optionally consume a @->@ token and parse the right-hand side as a
+-- view-pattern expression.  Returns the original expression unchanged when
+-- no @->@ follows.
+maybeViewPattern :: Expr -> TokParser Expr
+maybeViewPattern lhs = do
+  mArrow <- MP.optional (expectedTok TkReservedRightArrow)
+  case mArrow of
+    Just () -> do
+      viewRhs <- texprParser
+      let sp = mergeSourceSpans (getSourceSpan lhs) (getSourceSpan viewRhs)
+      pure (EInfix sp lhs viewPatArrowName viewRhs)
+    Nothing -> pure lhs
+
+-- | Like 'exprParser' but also allows the view-pattern arrow @->@ at the
+-- top level.  This corresponds to GHC\'s @texp@ production, which is used
+-- inside delimited contexts such as parentheses @(…)@ and unboxed parens
+-- @(# … #)@.
+texprParser :: TokParser Expr
+texprParser = exprParser >>= maybeViewPattern
+
 -- | Parse an arrow tail operator (@-<@ or @-<<@) followed by its right-hand expression.
 arrowTailParser :: TokParser (Name, Expr)
 arrowTailParser = do
@@ -681,7 +705,9 @@ parenExprParser = withSpan $ do
                       let expr' = case mWhere of
                             Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan typed) (sourceSpanEnd decls)) typed decls
                             Nothing -> typed
-                      finishBoxed closeTok (Just expr')
+                      -- View pattern arrow: expr -> expr (inside parentheses)
+                      finalExpr <- maybeViewPattern expr'
+                      finishBoxed closeTok (Just finalExpr)
                 Just op -> do
                   mClose <- MP.optional (expectedTok closeTok)
                   case mClose of
@@ -716,7 +742,9 @@ parenExprParser = withSpan $ do
                           let fullExpr = case mWhere of
                                 Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan typed) (sourceSpanEnd decls)) typed decls
                                 Nothing -> typed
-                          finishBoxed closeTok (Just fullExpr)
+                          -- View pattern arrow: expr -> expr (inside parentheses)
+                          finalExpr <- maybeViewPattern fullExpr
+                          finishBoxed closeTok (Just finalExpr)
       where
         parseSectionR forbidden = do
           op <- infixOperatorParserExcept forbidden <|> arrowSectionOperatorParser
@@ -744,7 +772,7 @@ parenExprParser = withSpan $ do
           fail "expected expression or closing paren"
 
     parseTupleOrParen tupleFlavor closeTok = do
-      first <- MP.optional exprParser
+      first <- MP.optional texprParser
       mComma <- MP.optional (expectedTok TkSpecialComma)
       case (first, mComma) of
         (Just e, Nothing) ->
@@ -768,7 +796,7 @@ parenExprParser = withSpan $ do
           fail "expected expression or closing paren"
 
     parseTupleElems closeTok = do
-      e <- MP.optional exprParser
+      e <- MP.optional texprParser
       mComma <- MP.optional (expectedTok TkSpecialComma)
       case mComma of
         Just () -> (e :) <$> parseTupleElems closeTok
@@ -780,7 +808,7 @@ parenExprParser = withSpan $ do
       _ <- expectedTok TkReservedPipe
       leadingBars <- MP.many (MP.try (expectedTok TkReservedPipe))
       let altIdx = 1 + length leadingBars
-      inner <- exprParser
+      inner <- texprParser
       trailingBars <- MP.many (expectedTok TkReservedPipe)
       expectedTok closeTok
       let arity = altIdx + 1 + length trailingBars

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -511,9 +511,9 @@ prettyPattern pat =
     PWildcard _ -> "_"
     PLit _ lit -> prettyLiteral lit
     PQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
-    PTuple _ tupleFlavor elems -> prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyPatternInTuple elems)))
+    PTuple _ tupleFlavor elems -> prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyPatternInDelimited elems)))
     PUnboxedSum _ altIdx arity inner ->
-      let slots = [if i == altIdx then prettyPattern inner else mempty | i <- [0 .. arity - 1]]
+      let slots = [if i == altIdx then prettyPatternInDelimited inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     PList _ elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
     PCon _ con args -> hsep (prettyPrefixName con : map prettyPatternAtom args)
@@ -542,10 +542,11 @@ prettyPattern pat =
     PTypeSig _ inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
     PSplice _ body -> prettySplice "$" body
 
--- | Pretty print a pattern that appears as a tuple element.
--- View patterns don't need extra parens when they're already inside a tuple's parens.
-prettyPatternInTuple :: Pattern -> Doc ann
-prettyPatternInTuple pat =
+-- | Pretty print a pattern that appears inside a delimited context (tuples,
+-- unboxed sums, etc.).  View patterns don't need extra parens when they're
+-- already inside a delimiter's parens.
+prettyPatternInDelimited :: Pattern -> Doc ann
+prettyPatternInDelimited pat =
   case pat of
     PView _ viewExpr inner -> prettyExprPrec 2 viewExpr <+> "->" <+> prettyPattern inner
     _ -> prettyPattern pat

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedSums/unboxed-sum-list-comp.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedSums/unboxed-sum-list-comp.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ParallelListComp #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedSums #-}
+
+module UnboxedSumListComp where
+
+-- List comprehension nested inside an unboxed sum expression.
+-- The first | is the comprehension qualifier separator;
+-- the second | is the unboxed sum alternative separator.
+x src = (# [e | e <- src] | #)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/viewpatterns-comp-parallel.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/viewpatterns-comp-parallel.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ParallelListComp #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ViewPatterns #-}
+
+module ViewPatternsCompParallel where
+
+-- View pattern inside a parallel list comprehension generator.
+-- The first | separates the comprehension body from qualifiers;
+-- the second | starts a parallel qualifier group.
+x e y = [e | (() -> r) <- [e] | x <- y]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/viewpatterns-unboxed-sum.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/viewpatterns-unboxed-sum.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedSums #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ViewPatterns #-}
+
+module ViewPatternsUnboxedSum where
+
+-- View pattern inside an unboxed sum pattern.
+-- The -> is the view pattern arrow; the | is the unboxed sum separator.
+f :: (# Int | () #) -> Int
+f (# g -> x | #) = x


### PR DESCRIPTION
## Summary

- Introduces `texprParser` (matching GHC's `texp` production) to handle the view-pattern arrow `->` inside delimited contexts—parentheses, unboxed parens, and tuple elements—without affecting top-level expression parsing where `->` acts as a separator
- Extends `checkPattern` to convert `EInfix _ l (->)  r` to `PView`, with a special case for `EParen` wrapping to strip unnecessary parens and match GHC's AST shape
- Fixes the pattern pretty-printer to omit redundant parens around `PView` inside unboxed sums by generalizing `prettyPatternInTuple` to `prettyPatternInDelimited`

## Test changes

- **3 new oracle tests (pass):** `viewpatterns-comp-parallel`, `viewpatterns-unboxed-sum`, `unboxed-sum-list-comp`
- Progress: pass=787 xfail=10 (was pass=784)

Closes #678