### PR TITLE
refactor: clean up justfile and flake.nix devShell output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1178,13 +1178,6 @@
           pkgs.ormolu
           pkgs.hlint
         ];
-        shellHook = ''
-          echo "aihc development shell"
-          echo "  - GHC with project dependencies"
-          echo "  - cabal-install"
-          echo "  - ormolu"
-          echo "  - hlint"
-        '';
       };
     });
   };

--- a/justfile
+++ b/justfile
@@ -12,10 +12,10 @@ replay ARGUMENT:
 
 # Run QuickCheck with 10000 tests in a loop until failure
 qc:
-  while true; do cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000"; done
+  while true; do cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000" || break; done
 
 # Run full CI check: format, lint, then tests
 check:
-  nix develop --command bash -c 'ormolu --mode check $(find components -name "*.hs" -not -path "*/test/Test/Fixtures/*")'
-  nix develop --command bash -c 'hlint $(find components -name "*.hs" -not -path "*/test/Test/Fixtures/*")'
-  cabal test -v0 all --test-options='--hide-successes'
+  nix develop --quiet --command bash -c 'ormolu --mode check $(find components -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'hlint $(find components -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  just test


### PR DESCRIPTION
## Summary

- Exclude `dist-newstyle/` from `just check` ormolu/hlint scans to prevent auto-generated Cabal files from causing noise.
- Remove the `shellHook` banner from `flake.nix` devShell and use `--quiet` on `nix develop` calls to suppress build output.
- Call `just test` instead of duplicating the cabal command.
- Fix `just qc` loop to break on test failure (added `|| break`).

## Changes to progress counts

N/A