### PR TITLE
fix(parser): preserve typed if branches in round-trips

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -42,8 +42,12 @@ import Text.Megaparsec qualified as MP
 
 exprParser :: TokParser Expr
 exprParser =
+  exprParserWithTypeSigParser typeParser
+
+exprParserWithTypeSigParser :: TokParser Type -> TokParser Expr
+exprParserWithTypeSigParser typeSigParser =
   label "expression" $ do
-    core <- exprCoreParser
+    core <- exprCoreParserWithTypeSigParserExcept typeSigParser []
     mWhere <- MP.optional whereClauseParser
     pure $
       case mWhere of
@@ -52,18 +56,25 @@ exprParser =
 
 exprParserExcept :: [Text] -> TokParser Expr
 exprParserExcept forbiddenInfix = do
-  core <- exprCoreParserExcept forbiddenInfix
+  core <- exprCoreParserWithTypeSigParserExcept typeParser forbiddenInfix
   mWhere <- MP.optional whereClauseParser
   pure $
     case mWhere of
       Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan core) (sourceSpanEnd decls)) core decls
       Nothing -> core
 
-exprCoreParser :: TokParser Expr
-exprCoreParser = exprCoreParserExcept []
+exprParserNoTopLevelTypeSig :: TokParser Expr
+exprParserNoTopLevelTypeSig =
+  label "expression" $ do
+    core <- exprCoreParserWithoutTypeSigExcept []
+    mWhere <- MP.optional whereClauseParser
+    pure $
+      case mWhere of
+        Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan core) (sourceSpanEnd decls)) core decls
+        Nothing -> core
 
-exprCoreParserExcept :: [Text] -> TokParser Expr
-exprCoreParserExcept forbiddenInfix = do
+exprCoreParserWithoutTypeSigExcept :: [Text] -> TokParser Expr
+exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
   tok <- lookAhead anySingle
   base <- case lexTokenKind tok of
     TkKeywordDo -> doExprParser
@@ -74,13 +85,16 @@ exprCoreParserExcept forbiddenInfix = do
     TkKeywordProc -> procExprParser
     TkReservedBackslash -> lambdaExprParser
     _ -> infixExprParserExcept forbiddenInfix
-  -- Arrow application: expr -< expr / expr -<< expr
   afterArrow <- MP.optional arrowTailParser
-  let withArrow = case afterArrow of
-        Just (op, rhs) -> EInfix (mergeSourceSpans (getSourceSpan base) (getSourceSpan rhs)) base op rhs
-        Nothing -> base
+  pure $ case afterArrow of
+    Just (op, rhs) -> EInfix (mergeSourceSpans (getSourceSpan base) (getSourceSpan rhs)) base op rhs
+    Nothing -> base
+
+exprCoreParserWithTypeSigParserExcept :: TokParser Type -> [Text] -> TokParser Expr
+exprCoreParserWithTypeSigParserExcept typeSigParser forbiddenInfix = do
+  withArrow <- exprCoreParserWithoutTypeSigExcept forbiddenInfix
   -- Optional type signature: expr :: type
-  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
+  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeSigParser)
   pure $ case mTypeSig of
     Just ty -> ETypeSig (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty)) withArrow ty
     Nothing -> withArrow
@@ -133,10 +147,10 @@ classicIfExprParser = withSpan $ do
   cond <- region "while parsing if condition" exprParser
   skipSemicolons
   expectedTok TkKeywordThen
-  yes <- region "while parsing then branch" exprParser
+  yes <- region "while parsing then branch" exprParserNoTopLevelTypeSig
   skipSemicolons
   expectedTok TkKeywordElse
-  no <- region "while parsing else branch" exprParser
+  no <- region "while parsing else branch" exprParserNoTopLevelTypeSig
   pure (\span' -> EIf span' cond yes no)
 
 multiWayIfExprParser :: TokParser Expr
@@ -594,7 +608,7 @@ guardQualifierParser = do
 
 guardBindOrExprParser :: TokParser GuardQualifier
 guardBindOrExprParser = withSpan $ do
-  expr <- exprParser
+  expr <- exprParserWithTypeSigParser typeInfixParser
   mArrow <- MP.optional (expectedTok TkReservedLeftArrow)
   case mArrow of
     Just () -> do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1278,6 +1278,12 @@ prettyNegate inner =
 prettyTypeSigBody :: Expr -> Doc ann
 prettyTypeSigBody = prettyExprIn CtxTypeSigBody
 
+prettyIfBranch :: Expr -> Doc ann
+prettyIfBranch expr =
+  case expr of
+    ETypeSig {} -> parens (prettyExprPrec 0 expr)
+    _ -> prettyExprPrec 0 expr
+
 -- | Flatten a left-nested application chain into (root, args).
 -- For example, @f x y z@ (parsed as @(((f x) y) z)@) becomes @(f, [x, y, z])@.
 flattenApps :: Expr -> (Expr, [Expr])
@@ -1343,9 +1349,11 @@ prettyExprPrec prec expr =
     EIf _ cond yes no ->
       -- The 'then' keyword delimits the condition, and 'else' delimits the then-branch,
       -- so greedy expressions in those positions don't need parentheses.
+      -- Type signatures are different: without parens, `else x :: T` binds to
+      -- the whole `if`, not just the branch expression.
       parenthesize
         (prec > 0)
-        ("if" <+> prettyExprPrec 0 cond <+> "then" <+> prettyExprPrec 0 yes <+> "else" <+> prettyExprPrec 0 no)
+        ("if" <+> prettyExprPrec 0 cond <+> "then" <+> prettyIfBranch yes <+> "else" <+> prettyIfBranch no)
     EMultiWayIf _ rhss ->
       parenthesize
         (prec > 0)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/lambda-case-quasiquote-guard.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/lambda-case-quasiquote-guard.hs
@@ -1,0 +1,19 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+module LambdaCaseQuasiQuoteGuard where
+
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
+
+j :: QuasiQuoter
+j =
+  QuasiQuoter
+    { quoteExp = \_ -> [| True |],
+      quotePat = error "quotePat unused",
+      quoteType = error "quoteType unused",
+      quoteDec = error "quoteDec unused"
+    }
+
+a = \case
+  x | [j|ok|] -> '5'

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -55,6 +55,8 @@ baseModuleLanguagePragmas =
     EnableExtension UnboxedTuples,
     EnableExtension UnboxedSums,
     EnableExtension TemplateHaskell,
+    EnableExtension LambdaCase,
+    EnableExtension QuasiQuotes,
     EnableExtension ExplicitNamespaces,
     EnableExtension PatternSynonyms
   ]

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -30,7 +30,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, ExplicitNamespaces, PatternSynonyms]
+    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms]
     }
 
 -- Module normalization


### PR DESCRIPTION
## Summary
- fix expression parsing so `if` branches do not absorb a guarded-rhs `->` as part of a branch-local type signature
- parenthesize typed `then`/`else` branches when pretty-printing to preserve the original AST on round-trip
- extend the module round-trip property coverage to generated `LambdaCase` and `QuasiQuotes`, and add an oracle regression for a lambda-case quasiquote guard

## Root Cause
The QuickCheck replay generated a module whose AST intended `if ... else (() :: oh)` inside a guarded `\case` alternative. The pretty-printer emitted `else () :: oh`, which reparses as a type signature on the whole `if`. The module generator also allowed `LambdaCase` and `QuasiQuotes` without emitting those pragmas in generated modules.

## Progress Counts
- oracle: `pass 798 -> 799`, `xfail 10 -> 10`, `total 808 -> 809`
- oracle completion: `98.75% -> 98.76%`

## Validation
- `just replay "(SMGen 10958702963456751290 11927975414554794369,66)"`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern lambda-case-quasiquote-guard'`
- `cabal test -v0 aihc-parser:spec --test-options=--hide-successes`
- `nix flake check`
- `coderabbit review --prompt-only`

## CodeRabbit
- Addressed the prompt-only finding by making the oracle fixture use a real `QuasiQuoter` that expands to `True`.
