### PR TITLE
test(parser): add MatchHeadInfix generation to QC decl round-trip tests

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -54,23 +54,47 @@ genDeclValue n = do
 
 genFunctionDecl :: (UnqualifiedName, Expr) -> Gen Decl
 genFunctionDecl (name, expr) = do
-  -- TODO: Restore MatchHeadInfix generation once the standalone declaration parser
-  -- (parseDecl) supports infix function bindings. Currently, infix bindings like
-  -- `x \`f\` y = ...` only parse at the module level, not via parseDecl.
-  pure $
-    DeclValue
-      span0
-      ( FunctionBind
+  headForm <- elements [MatchHeadPrefix, MatchHeadInfix]
+  case headForm of
+    MatchHeadPrefix ->
+      pure $
+        DeclValue
           span0
-          name
-          [ Match
-              { matchSpan = span0,
-                matchHeadForm = MatchHeadPrefix,
-                matchPats = [],
-                matchRhs = UnguardedRhs span0 expr
-              }
+          ( FunctionBind
+              span0
+              name
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadPrefix,
+                    matchPats = [],
+                    matchRhs = UnguardedRhs span0 expr
+                  }
+              ]
+          )
+    MatchHeadInfix -> do
+      -- For infix bindings, generate an operator name and two PVar patterns.
+      -- Symbolic operators: x + y = ..., backtick identifiers: x `f` y = ...
+      opName <-
+        oneof
+          [ mkUnqualifiedName NameVarSym <$> genSymbolicOp,
+            mkUnqualifiedName NameVarId <$> genIdent
           ]
-      )
+      lhsPat <- PVar span0 . mkUnqualifiedName NameVarId <$> genIdent
+      rhsPat <- PVar span0 . mkUnqualifiedName NameVarId <$> genIdent
+      pure $
+        DeclValue
+          span0
+          ( FunctionBind
+              span0
+              opName
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadInfix,
+                    matchPats = [lhsPat, rhsPat],
+                    matchRhs = UnguardedRhs span0 expr
+                  }
+              ]
+          )
 
 genDeclTypeSig :: Gen Decl
 genDeclTypeSig = do


### PR DESCRIPTION
## Summary

- Restore `MatchHeadInfix` generation in the QC declaration round-trip property test, which was disabled by an outdated TODO
- The `parseDecl` standalone parser already supports infix function bindings (both symbolic operators like `x + y = ...` and backtick identifiers like `` x `f` y = ... ``); the generator was unnecessarily restricted to `MatchHeadPrefix` only
- The updated generator produces both prefix and infix head forms with equal probability, using either `NameVarSym` operators or `NameVarId` backtick identifiers with two `PVar` patterns

## Progress count changes

No progress count changes — this adds QC coverage for an already-supported parser feature.

## Testing

- `cabal test -v0 all --test-options=--hide-successes` — all 1344 tests pass
- `just check` — ormolu, hlint, and tests all pass
- Deep QC: 10,000 iterations of the decl round-trip property pass with the new generator