### PR TITLE
feat(bench): collect and supply CPP include files in tarball pipeline

### DIFF
--- a/components/aihc-parser-cli/src/Aihc/Parser/Bench/Benchmark.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Bench/Benchmark.hs
@@ -13,13 +13,14 @@ where
 
 import Aihc.Parser.Bench.CLI (BenchOptions (..), ParserChoice (..))
 import Aihc.Parser.Bench.Parsers (ParseResult (..), lexWithAihcExts, parseWithAihcExts, parseWithGhcExts, parseWithHseExts)
-import Aihc.Parser.Bench.Tarball (PackageInfo (..), PackageSpec (..), TarballEntry (..), isHaskellEntry, streamTarball)
+import Aihc.Parser.Bench.Tarball (PackageInfo (..), PackageSpec (..), TarballEntry (..), isHaskellEntry, isIncludeEntry, streamTarball)
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Control.Monad (replicateM)
 import Data.List (isPrefixOf)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, listToMaybe)
+import Data.Text (Text)
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats qualified as Stats
 import System.IO (hFlush, hPutStr, hPutStrLn, stderr)
@@ -60,6 +61,10 @@ runBenchmark opts = do
   hPutStrLn stderr $ "Loading tarball: " ++ benchTarball opts
   (rawEntries, packageInfos) <- streamTarball (benchTarball opts)
 
+  -- Build include map from non-Haskell, non-cabal entries
+  let includeEntries = filter isIncludeEntry rawEntries
+      includeMap = Map.fromList [(entryFilePath e, entryContents e) | e <- includeEntries]
+
   -- Filter to only Haskell files and enrich with extension info
   let hsEntries = filter isHaskellEntry rawEntries
       enrichedEntries = map (enrichEntry packageInfos) hsEntries
@@ -72,7 +77,7 @@ runBenchmark opts = do
   let !forcedEntries = forceEntries enrichedEntries
   hPutStrLn stderr " done"
 
-  let parser = selectParser opts
+  let parser = selectParser includeMap opts
       numWarmup = benchWarmup opts
       numMain = benchIterations opts
 
@@ -170,14 +175,14 @@ enrichEntry packageInfos entry =
     firstJust = listToMaybe . catMaybes
 
 -- | Select the parser function based on options.
--- Now uses the entry's extensions and language.
-selectParser :: BenchOptions -> (TarballEntry -> ParseResult)
-selectParser opts =
+-- Now uses the entry's extensions, language, and include map for CPP resolution.
+selectParser :: Map.Map FilePath Text -> BenchOptions -> (TarballEntry -> ParseResult)
+selectParser includeMap opts =
   case (benchParser opts, benchLexerOnly opts) of
-    (ParserAihc, True) -> \e -> lexWithAihcExts (entryExtensions e) (entryLanguage e) (entryContents e)
-    (ParserAihc, False) -> \e -> parseWithAihcExts (entryExtensions e) (entryLanguage e) (entryContents e)
-    (ParserHse, _) -> \e -> parseWithHseExts (entryExtensions e) (entryLanguage e) (entryContents e)
-    (ParserGhc, _) -> \e -> parseWithGhcExts (entryExtensions e) (entryLanguage e) (entryContents e)
+    (ParserAihc, True) -> \e -> lexWithAihcExts includeMap (entryFilePath e) (entryExtensions e) (entryLanguage e) (entryContents e)
+    (ParserAihc, False) -> \e -> parseWithAihcExts includeMap (entryFilePath e) (entryExtensions e) (entryLanguage e) (entryContents e)
+    (ParserHse, _) -> \e -> parseWithHseExts includeMap (entryFilePath e) (entryExtensions e) (entryLanguage e) (entryContents e)
+    (ParserGhc, _) -> \e -> parseWithGhcExts includeMap (entryFilePath e) (entryExtensions e) (entryLanguage e) (entryContents e)
 
 -- | Run a single benchmark iteration.
 runSingleIteration :: (TarballEntry -> ParseResult) -> [TarballEntry] -> IO IterationResult

--- a/components/aihc-parser-cli/src/Aihc/Parser/Bench/Parsers.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Bench/Parsers.hs
@@ -8,26 +8,26 @@
 module Aihc.Parser.Bench.Parsers
   ( ParseResult (..),
 
+    -- * CPP include collection
+    collectCppIncludes,
+
     -- * Parsing with explicit extensions (from cabal files)
     parseWithAihcExts,
     parseWithHseExts,
     parseWithGhcExts,
     lexWithAihcExts,
-
-    -- * Legacy: parsing without cabal extensions (uses defaults)
-    parseWithAihc,
-    parseWithHse,
-    parseWithGhc,
-    lexWithAihc,
   )
 where
 
 import Aihc.Cpp qualified as Cpp
+import Aihc.Hackage.Util qualified as HU
 import Aihc.Parser qualified as Aihc
 import Aihc.Parser.Lex qualified as AihcLex
 import Aihc.Parser.Syntax qualified as Syntax
 import Control.DeepSeq (NFData (..), deepseq)
 import Data.List qualified as List
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -51,6 +51,8 @@ import GHC.Types.SrcLoc (mkRealSrcLoc)
 import GHC.Utils.Error (emptyDiagOpts, pprMessages)
 import GHC.Utils.Outputable (showSDocUnsafe)
 import Language.Haskell.Exts qualified as HSE
+import System.Directory (doesFileExist)
+import System.FilePath (normalise, takeDirectory, (</>))
 import Text.Read (readMaybe)
 
 -- | Result of attempting to parse a file.
@@ -69,9 +71,9 @@ instance NFData ParseResult where
 
 -- | Parse with aihc-parser using extensions from cabal file.
 -- Handles CPP preprocessing if CPP extension is enabled.
-parseWithAihcExts :: [String] -> Maybe String -> Text -> ParseResult
-parseWithAihcExts cabalExts langName source =
-  let (preprocessedSource, extensions) = prepareSourceAndExtensions cabalExts langName source
+parseWithAihcExts :: Map FilePath Text -> FilePath -> [String] -> Maybe String -> Text -> ParseResult
+parseWithAihcExts includeMap filePath cabalExts langName source =
+  let (preprocessedSource, extensions) = prepareSourceAndExtensions includeMap filePath cabalExts langName source
       config = Aihc.defaultConfig {Aihc.parserExtensions = extensions}
       (errs, m) = Aihc.parseModule config preprocessedSource
    in if null errs
@@ -80,17 +82,17 @@ parseWithAihcExts cabalExts langName source =
 
 -- | Lex with aihc-parser using extensions from cabal file (lexer-only mode).
 -- Handles CPP preprocessing if CPP extension is enabled.
-lexWithAihcExts :: [String] -> Maybe String -> Text -> ParseResult
-lexWithAihcExts cabalExts langName source =
-  let (preprocessedSource, extensions) = prepareSourceAndExtensions cabalExts langName source
+lexWithAihcExts :: Map FilePath Text -> FilePath -> [String] -> Maybe String -> Text -> ParseResult
+lexWithAihcExts includeMap filePath cabalExts langName source =
+  let (preprocessedSource, extensions) = prepareSourceAndExtensions includeMap filePath cabalExts langName source
       tokens = AihcLex.lexModuleTokensWithExtensions extensions preprocessedSource
    in tokens `deepseq` ParseSuccess
 
 -- | Parse with haskell-src-exts using extensions from cabal file.
 -- Handles CPP preprocessing if CPP extension is enabled.
-parseWithHseExts :: [String] -> Maybe String -> Text -> ParseResult
-parseWithHseExts cabalExts langName source =
-  let (preprocessedSource, extensions) = prepareSourceAndExtensions cabalExts langName source
+parseWithHseExts :: Map FilePath Text -> FilePath -> [String] -> Maybe String -> Text -> ParseResult
+parseWithHseExts includeMap filePath cabalExts langName source =
+  let (preprocessedSource, extensions) = prepareSourceAndExtensions includeMap filePath cabalExts langName source
       hseExts = toHseExtensions extensions
       langExts = languageToHseExtensions langName
       baseLang = languageToHseLanguage langName
@@ -106,9 +108,9 @@ parseWithHseExts cabalExts langName source =
 -- | Parse with ghc-lib-parser using extensions from cabal file.
 -- Handles CPP preprocessing if CPP extension is enabled.
 -- Note: GHC can return POk with errors, so we check for errors even on success.
-parseWithGhcExts :: [String] -> Maybe String -> Text -> ParseResult
-parseWithGhcExts cabalExts langName source =
-  let (preprocessedSource, extensions) = prepareSourceAndExtensions cabalExts langName source
+parseWithGhcExts :: Map FilePath Text -> FilePath -> [String] -> Maybe String -> Text -> ParseResult
+parseWithGhcExts includeMap filePath cabalExts langName source =
+  let (preprocessedSource, extensions) = prepareSourceAndExtensions includeMap filePath cabalExts langName source
       -- Start with language base extensions
       langExts = languageToGhcExtensions langName
       baseExtSet = EnumSet.fromList langExts :: EnumSet.EnumSet GHC.Extension
@@ -143,8 +145,8 @@ parseWithGhcExts cabalExts langName source =
 -- 1. Check if CPP is enabled (from cabal extensions or initial LANGUAGE pragmas)
 -- 2. If CPP is enabled, preprocess the source
 -- 3. Re-scan the (possibly preprocessed) source for final LANGUAGE pragmas
-prepareSourceAndExtensions :: [String] -> Maybe String -> Text -> (Text, [Syntax.Extension])
-prepareSourceAndExtensions cabalExts langName source =
+prepareSourceAndExtensions :: Map FilePath Text -> FilePath -> [String] -> Maybe String -> Text -> (Text, [Syntax.Extension])
+prepareSourceAndExtensions includeMap filePath cabalExts langName source =
   let -- Convert cabal extension names to settings
       cabalSettings = extensionNamesToSettings cabalExts
       -- Get initial extensions from LANGUAGE pragmas (before CPP)
@@ -157,7 +159,7 @@ prepareSourceAndExtensions cabalExts langName source =
       -- Preprocess if CPP is enabled
       preprocessedSource =
         if cppEnabled
-          then runCppPreprocessor source
+          then runCppWithIncludes includeMap filePath source
           else source
       -- Re-scan for extensions after preprocessing (CPP can affect LANGUAGE pragmas)
       finalHeaderSettings = AihcLex.readModuleHeaderExtensions preprocessedSource
@@ -165,40 +167,48 @@ prepareSourceAndExtensions cabalExts langName source =
       finalExtensions = applyExtensionSettings finalSettings baseExts
    in (preprocessedSource, finalExtensions)
 
--- | Run CPP preprocessor on source, ignoring includes.
--- For benchmarking purposes, we don't resolve includes - just process the source.
-runCppPreprocessor :: Text -> Text
-runCppPreprocessor source =
-  let cfg = Cpp.defaultConfig {Cpp.configInputFile = "<bench>"}
-      result = runCppWithoutIncludes cfg source
-   in Cpp.resultOutput result
-
--- | Run CPP without resolving includes (return Nothing for all include requests).
-runCppWithoutIncludes :: Cpp.Config -> Text -> Cpp.Result
-runCppWithoutIncludes cfg source = go (Cpp.preprocess cfg (TE.encodeUtf8 source))
+-- | Run CPP preprocessor on source, resolving includes from the provided map.
+-- Include paths not found in the map are treated as missing.
+runCppWithIncludes :: Map FilePath Text -> FilePath -> Text -> Text
+runCppWithIncludes includeMap filePath source =
+  let cfg = Cpp.defaultConfig {Cpp.configInputFile = filePath}
+   in Cpp.resultOutput (go (Cpp.preprocess cfg (TE.encodeUtf8 source)))
   where
     go (Cpp.Done result) = result
-    go (Cpp.NeedInclude _ k) = go (k Nothing)
+    go (Cpp.NeedInclude req k) =
+      let resolved = normalise (takeDirectory (Cpp.includeFrom req) </> Cpp.includePath req)
+          mContents = fmap TE.encodeUtf8 (Map.lookup resolved includeMap)
+       in go (k mContents)
 
---------------------------------------------------------------------------------
--- Legacy functions (no cabal extensions)
---------------------------------------------------------------------------------
-
--- | Parse with aihc-parser using only LANGUAGE pragmas from source.
-parseWithAihc :: Text -> ParseResult
-parseWithAihc = parseWithAihcExts [] Nothing
-
--- | Lex with aihc-parser (lexer-only mode).
-lexWithAihc :: Text -> ParseResult
-lexWithAihc = lexWithAihcExts [] Nothing
-
--- | Parse with haskell-src-exts using only LANGUAGE pragmas from source.
-parseWithHse :: Text -> ParseResult
-parseWithHse = parseWithHseExts [] Nothing
-
--- | Parse with ghc-lib-parser using only LANGUAGE pragmas from source.
-parseWithGhc :: Text -> ParseResult
-parseWithGhc = parseWithGhcExts [] Nothing
+-- | Collect all CPP include files needed by a Haskell source file.
+-- Only runs CPP if the CPP extension is enabled for this file.
+-- Returns (absolutePath, content) for all transitively included files.
+collectCppIncludes :: FilePath -> [String] -> Maybe String -> Text -> IO [(FilePath, Text)]
+collectCppIncludes absFile cabalExts langName source = do
+  let cabalSettings = extensionNamesToSettings cabalExts
+      initialHeaderSettings = AihcLex.readModuleHeaderExtensions source
+      initialSettings = cabalSettings <> initialHeaderSettings
+      baseExts = languageBaseExtensions langName
+      initialExtensions = applyExtensionSettings initialSettings baseExts
+      cppEnabled = Syntax.CPP `elem` initialExtensions
+  if not cppEnabled
+    then pure []
+    else
+      let cfg = Cpp.defaultConfig {Cpp.configInputFile = absFile}
+       in Map.toList <$> go Map.empty (Cpp.preprocess cfg (TE.encodeUtf8 source))
+  where
+    go acc (Cpp.Done _) = pure acc
+    go acc (Cpp.NeedInclude req k) = do
+      let resolved = normalise (takeDirectory (Cpp.includeFrom req) </> Cpp.includePath req)
+      case Map.lookup resolved acc of
+        Just contents -> go acc (k (Just (TE.encodeUtf8 contents)))
+        Nothing -> do
+          exists <- doesFileExist resolved
+          if not exists
+            then go acc (k Nothing)
+            else do
+              contents <- HU.readTextFileLenient resolved
+              go (Map.insert resolved contents acc) (k (Just (TE.encodeUtf8 contents)))
 
 --------------------------------------------------------------------------------
 -- Extension conversion utilities

--- a/components/aihc-parser-cli/src/Aihc/Parser/Bench/Tarball.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Bench/Tarball.hs
@@ -19,6 +19,7 @@ module Aihc.Parser.Bench.Tarball
     -- * Filtering
     checkPackageFilters,
     FilterReason (..),
+    isIncludeEntry,
 
     -- * Tarball I/O
     writeTarball,
@@ -32,7 +33,7 @@ import Aihc.Hackage.Stackage qualified as HS
 import Aihc.Hackage.Types (PackageSpec (..), formatPackage)
 import Aihc.Hackage.Util qualified as HU
 import Aihc.Parser.Bench.CLI (FilterOptions (..), GenerateOptions (..))
-import Aihc.Parser.Bench.Parsers (ParseResult (..), parseWithAihcExts, parseWithGhcExts, parseWithHseExts)
+import Aihc.Parser.Bench.Parsers (ParseResult (..), collectCppIncludes, parseWithAihcExts, parseWithGhcExts, parseWithHseExts)
 import Codec.Archive.Tar qualified as Tar
 import Codec.Archive.Tar.Entry qualified as Tar
 import Codec.Compression.GZip qualified as GZip
@@ -103,6 +104,10 @@ isHaskellEntry :: TarballEntry -> Bool
 isHaskellEntry e =
   let ext = takeExtension (entryFilePath e)
    in ext == ".hs" || ext == ".lhs"
+
+-- | Check if an entry is a CPP include file (not .hs/.lhs and not .cabal)
+isIncludeEntry :: TarballEntry -> Bool
+isIncludeEntry e = not (isCabalEntry e) && not (isHaskellEntry e)
 
 -- | Why a package was filtered out.
 data FilterReason
@@ -236,12 +241,16 @@ processPackage manager opts pkg = do
                       entryLanguage = lang
                     }
 
-              -- Check filters (only for Haskell files)
-              filterResult <- checkPackageFilters (genFilters opts) entries
+              -- Collect CPP include files for all Haskell entries
+              includeFileMap <- collectIncludeFiles pkgDir pkg entries
+              let includeEntries = buildIncludeEntries pkg includeFileMap
+
+              -- Check filters (only for Haskell files, with include map for CPP)
+              filterResult <- checkPackageFilters includeFileMap (genFilters opts) entries
               case filterResult of
                 Just reason -> pure (Left (pkg, reason))
-                -- Include the .cabal file along with the Haskell files
-                Nothing -> pure (Right (cabalEntry : entries))
+                -- Include the .cabal file along with the Haskell files and include files
+                Nothing -> pure (Right (cabalEntry : entries ++ includeEntries))
 
 -- | Find and read the .cabal file, returning the entry and a map of file paths to their extensions
 findAndReadCabalFile :: FilePath -> PackageSpec -> IO (TarballEntry, Map.Map FilePath ([String], Maybe String))
@@ -286,10 +295,34 @@ parseCabalForExtensions pkgDir cabalFile = do
           | fi <- fileInfos
           ]
 
+-- | Collect CPP include files for a list of Haskell tarball entries.
+-- Returns a map from tarball-relative path to file contents.
+collectIncludeFiles :: FilePath -> PackageSpec -> [TarballEntry] -> IO (Map.Map FilePath Text)
+collectIncludeFiles pkgDir pkg entries = do
+  includeLists <- forM (filter isHaskellEntry entries) $ \e -> do
+    let absFile = pkgDir </> makeRelative (formatPackage pkg) (entryFilePath e)
+    pairs <- collectCppIncludes absFile (entryExtensions e) (entryLanguage e) (entryContents e)
+    pure [(formatPackage pkg </> makeRelative pkgDir absPath, text) | (absPath, text) <- pairs]
+  pure $ Map.fromList (concat includeLists)
+
+-- | Build TarballEntry items from a map of include files.
+buildIncludeEntries :: PackageSpec -> Map.Map FilePath Text -> [TarballEntry]
+buildIncludeEntries pkg includeMap =
+  [ TarballEntry
+      { entryPackage = pkg,
+        entryFilePath = tarPath,
+        entryContents = contents,
+        entryByteSize = BS.length (encodeUtf8 contents),
+        entryExtensions = [],
+        entryLanguage = Nothing
+      }
+  | (tarPath, contents) <- Map.toList includeMap
+  ]
+
 -- | Check if a package passes all filters.
 -- Returns the first filter failure reason, or Nothing if all pass.
-checkPackageFilters :: FilterOptions -> [TarballEntry] -> IO (Maybe FilterReason)
-checkPackageFilters opts entries
+checkPackageFilters :: Map.Map FilePath Text -> FilterOptions -> [TarballEntry] -> IO (Maybe FilterReason)
+checkPackageFilters includeMap opts entries
   | not (filterAihc opts || filterHse opts || filterGhc opts) = pure Nothing
   | otherwise = pure $ listToMaybe $ mapMaybe checkEntry (filter isHaskellEntry entries)
   where
@@ -300,17 +333,17 @@ checkPackageFilters opts entries
           lang = entryLanguage e
           checks =
             [ if filterAihc opts
-                then case parseWithAihcExts exts lang source of
+                then case parseWithAihcExts includeMap path exts lang source of
                   ParseSuccess -> Nothing
                   ParseFailure err -> Just (FilterAihcFailed path err)
                 else Nothing,
               if filterHse opts
-                then case parseWithHseExts exts lang source of
+                then case parseWithHseExts includeMap path exts lang source of
                   ParseSuccess -> Nothing
                   ParseFailure err -> Just (FilterHseFailed path err)
                 else Nothing,
               if filterGhc opts
-                then case parseWithGhcExts exts lang source of
+                then case parseWithGhcExts includeMap path exts lang source of
                   ParseSuccess -> Nothing
                   ParseFailure err -> Just (FilterGhcFailed path err)
                 else Nothing


### PR DESCRIPTION
## Summary

- **Tarball generation**: Run the CPP preprocessor on each Haskell source file during tarball building to discover `#include` dependencies. Intercept `NeedInclude` requests, read the files from the filesystem (transitively), and store them as additional `TarballEntry` items alongside the `.hs` sources.
- **Benchmarking**: Build a `Map FilePath Text` from the stored include entries when loading a tarball, then supply it to the CPP preprocessor so `#include` directives resolve correctly instead of being silently dropped.
- **Filter checks**: The `--filter-aihc / --filter-hse / --filter-ghc` passes now also use the include map for consistent CPP preprocessing.

## Design

Include files are identified at benchmark time via the new `isIncludeEntry` predicate (not `.hs`/`.lhs` and not `.cabal`). The path structure is consistent: tarball paths like `pkg-1.0/src/Config.h` are the map keys, and CPP's `includeFrom` + `includePath` resolve to the same keys via `normalise (takeDirectory includeFrom </> includePath)`.

Transitive includes are handled naturally by the CPP coroutine: when an include file's content is provided, the preprocessor continues and may emit further `NeedInclude` requests for that file's own includes.

## Test plan

- [x] `cabal build aihc-parser-cli` — all three components compile cleanly
- [x] `cabal test aihc-parser-cli` — all 14 existing tests pass
- [ ] Generate a tarball with `aihc-parser-bench generate` and verify `.h` files appear alongside `.hs` files
- [ ] Run `aihc-parser-bench bench` on the generated tarball and confirm no regressions in parse success rate