### PR TITLE
fix(parser): parenthesize lambda guards in pretty-printer

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1526,9 +1526,18 @@ prettyCaseAlt (CaseAlt _ pat rhs) =
 prettyGuardQualifier :: GuardQualifier -> Doc ann
 prettyGuardQualifier qualifier =
   case qualifier of
-    GuardExpr _ expr -> prettyExprPrec 0 expr
+    GuardExpr _ expr
+      | guardExprNeedsParens expr -> parens (prettyExprPrec 0 expr)
+      | otherwise -> prettyExprPrec 0 expr
     GuardPat _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExprPrec 0 expr
     GuardLet _ decls -> "let" <+> braces (prettyInlineDecls decls)
+
+guardExprNeedsParens :: Expr -> Bool
+guardExprNeedsParens = \case
+  ELambdaPats {} -> True
+  EProc {} -> True
+  EApp _ _ arg | isBlockExpr arg -> guardExprNeedsParens arg
+  _ -> False
 
 -- | Pretty print a do statement.
 -- Since do blocks are always rendered with explicit braces and semicolons,

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -173,6 +173,11 @@ buildTests = do
             testCase "function bind guarded: f x | x > 0 = x" test_localDeclFunGuarded
           ],
         testGroup
+          "pretty"
+          [ testCase "guard lambda round-trips with parentheses" test_prettyGuardLambdaRoundTrip,
+            testCase "guard let expression stays unparenthesized" test_prettyGuardLetFormatting
+          ],
+        testGroup
           "functionHeadParserWith dispatch"
           [ testCase "prefix: f x y = x + y" test_funHeadPrefix,
             testCase "prefix no args: f = 5" test_funHeadPrefixNoArgs,
@@ -1034,6 +1039,94 @@ test_guardExpr =
   case parseGuards "f x | x > 0 = x" of
     Right [GuardExpr _ _] -> pure ()
     other -> assertFailure ("expected guard expression, got: " <> show other)
+
+test_prettyGuardLambdaRoundTrip :: Assertion
+test_prettyGuardLambdaRoundTrip = do
+  let decl =
+        DeclValue
+          span0
+          ( FunctionBind
+              span0
+              "f"
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadPrefix,
+                    matchPats = [PVar span0 "x"],
+                    matchRhs = UnguardedRhs span0 caseExpr
+                  }
+              ]
+          )
+      caseExpr =
+        ECase
+          span0
+          (EVar span0 "x")
+          [ CaseAlt
+              { caseAltSpan = span0,
+                caseAltPattern = PVar span0 "y",
+                caseAltRhs =
+                  GuardedRhss
+                    span0
+                    [ GuardedRhs
+                        { guardedRhsSpan = span0,
+                          guardedRhsGuards =
+                            [ GuardExpr
+                                span0
+                                ( ELambdaPats
+                                    span0
+                                    [PVar span0 "z"]
+                                    (EVar span0 "z")
+                                )
+                            ],
+                          guardedRhsBody = EVar span0 "x"
+                        }
+                    ]
+              }
+          ]
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+      expected = normalizeDecl decl
+  case parseDecl defaultConfig source of
+    ParseOk parsed ->
+      normalizeDecl parsed @?= expected
+    ParseErr err ->
+      assertFailure ("expected pretty-printed guard lambda to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
+
+test_prettyGuardLetFormatting :: Assertion
+test_prettyGuardLetFormatting = do
+  let decl =
+        DeclValue
+          span0
+          ( FunctionBind
+              span0
+              "f"
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadPrefix,
+                    matchPats = [PVar span0 "n"],
+                    matchRhs =
+                      GuardedRhss
+                        span0
+                        [ GuardedRhs
+                            { guardedRhsSpan = span0,
+                              guardedRhsGuards =
+                                [ GuardExpr
+                                    span0
+                                    ( ELetDecls
+                                        span0
+                                        [ DeclValue
+                                            span0
+                                            (FunctionBind span0 "x" [Match span0 MatchHeadPrefix [] (UnguardedRhs span0 (EInt span0 1 "1"))])
+                                        ]
+                                        (EInfix span0 (EVar span0 "x") (qualifyName Nothing ">") (EInt span0 0 "0"))
+                                    )
+                                ],
+                              guardedRhsBody = EVar span0 "n"
+                            }
+                        ]
+                  }
+              ]
+          )
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  assertBool ("expected guard let expression without extra parens, got:\n" <> T.unpack source) (not ("| (let" `T.isInfixOf` source))
 
 test_guardPatBind :: Assertion
 test_guardPatBind =


### PR DESCRIPTION
## Summary
- parenthesize lambda-like guard expressions in the pretty-printer when they appear in guarded contexts
- add regression coverage for guarded `case` alternatives with lambda guards
- add a formatting regression to ensure `let ... in ...` guard expressions stay unparenthesized

## Root Cause
The QuickCheck replay shrank to a declaration whose pretty-printed `case` alternative emitted a guard expression starting with `\\ ... -> ...` without parentheses. In a guarded case alternative, that `->` conflicts with the case-alternative separator, so the pretty-printed source was invalid even though the AST itself was fine.

The generated sample also used Template Haskell and quasiquote forms, so GHC would reject the exact printed snippet without the corresponding extensions enabled. That was incidental, not the root cause of the replay failure. With the needed extensions in place, the unparenthesized lambda guard was still the syntax bug.

## Validation
- `just replay '(SMGen 1867375660567187574 1699946860289546279,52)'`
- `cabal test -v0 aihc-parser:spec --test-options=--hide-successes`
- `just test`
- `nix flake check`

## Notes
- `coderabbit review --prompt-only` was attempted after local checks, but it did not return actionable output in this environment.
