### PR TITLE
fix(parser): parse type data constructor fields as separate atoms

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -902,7 +902,9 @@ typeDataConDeclParser = withSpan $ do
   -- Parse constructor name
   conName <- constructorUnqualifiedNameParser
   -- Parse arguments (no strictness, no records)
-  args <- MP.many $ BangType noSourceSpan NoSourceUnpackedness False <$> typeAppParser
+  -- Use typeAtomParser to parse individual type atoms as separate fields,
+  -- rather than typeAppParser which would treat them as type application.
+  args <- MP.many $ BangType noSourceSpan NoSourceUnpackedness False <$> typeAtomParser
   pure $ \span' -> PrefixCon span' [] context conName args
 
 -- | Parse GADT-style constructors for type data (after `where`)

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -130,11 +130,6 @@ genDeclData = DeclData span0 <$> genSimpleDataDecl
 
 genDeclTypeData :: Gen Decl
 genDeclTypeData = do
-  -- FIXME: type data constructors with multiple fields round-trip incorrectly
-  -- because the parser treats adjacent type atoms as type application rather
-  -- than separate constructor fields (e.g. "KFj A B" parses as "KFj (A B)"
-  -- instead of two fields). Restrict to at most 1 field until the parser or
-  -- pretty-printer is fixed.
   name <- mkUnqualifiedName NameConId <$> genTypeConName
   params <- genSimpleTyVarBinders
   ctors <- genTypeDataCons
@@ -155,7 +150,7 @@ genDeclTypeData = do
       vectorOf n genTypeDataCon
     genTypeDataCon = do
       conName <- mkUnqualifiedName NameConId <$> genTypeConName
-      n <- chooseInt (0, 1)
+      n <- chooseInt (0, 3)
       fields <- vectorOf n genSimpleBangType
       pure $ PrefixCon span0 [] [] conName fields
 


### PR DESCRIPTION
## Summary

Fixed a round-trip issue with type data constructor fields.

## Root Cause

The parser used `typeAppParser` for type data constructor fields, which treats adjacent type atoms as type application. So `KFj A B` was parsed as `KFj (A B)` instead of two separate fields.

## Fix

Changed `typeDataConDeclParser` to use `typeAtomParser` instead of `typeAppParser`, so each type atom is parsed as a separate constructor field.

## Changes

- **Parser**: Changed `typeAppParser` → `typeAtomParser` in `typeDataConDeclParser`
- **QuickCheck generator**: Increased max fields from 1 to 3 in `genTypeDataCon`
- Removed the FIXME comment since the issue is now resolved

## Testing

All 14 tests pass (`cabal test -v0 all --test-options=--hide-successes`)