### PR TITLE
feat(tc): implement pattern binding, multi-equation matching, and lambda-case

### DIFF
--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -87,8 +87,9 @@ renderTcType = go False
       paren parens $
         go True a ++ " -> " ++ go False b
     go parens (TcForAllTy tv body) =
-      paren parens $
-        "forall " ++ T.unpack (tvName tv) ++ ". " ++ go False body
+      let (tvs, inner) = collectForAlls body
+       in paren parens $
+            "forall " ++ unwords (map (T.unpack . tvName) (tv : tvs)) ++ ". " ++ go False inner
     go parens (TcQualTy preds body) =
       paren parens $
         "(" ++ unwords (map showPred preds) ++ ") => " ++ go False body
@@ -103,3 +104,10 @@ renderTcType = go False
 
     paren False s = s
     paren True s = "(" ++ s ++ ")"
+
+-- | Collect nested forall binders into a list.
+collectForAlls :: TcType -> ([TyVarId], TcType)
+collectForAlls (TcForAllTy tv body) =
+  let (tvs, inner) = collectForAlls body
+   in (tv : tvs, inner)
+collectForAlls ty = ([], ty)

--- a/components/aihc-tc/src/Aihc/Tc/Generalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generalize.hs
@@ -28,8 +28,9 @@ generalize ty preds = do
   preds' <- mapM zonkPred preds
   let freeMetaVars = collectMetaVars ty' ++ concatMap predMetaVars preds'
       uniqueMetaVars = nubOrd freeMetaVars
-  -- Create a skolem for each free meta-variable and substitute.
-  tvs <- mapM metaToTyVar uniqueMetaVars
+  -- Create a type variable for each free meta-variable, naming them
+  -- sequentially starting from 'a'.
+  tvs <- sequence [metaToTyVar i u | (i, u) <- zip [0 ..] uniqueMetaVars]
   let subst = zip uniqueMetaVars (map TcTyVar tvs)
   let ty'' = substMetas subst ty'
   let preds'' = map (substMetasPred subst) preds'
@@ -50,9 +51,11 @@ predMetaVars :: Pred -> [Unique]
 predMetaVars (ClassPred _ args) = concatMap collectMetaVars args
 predMetaVars (EqPred a b) = collectMetaVars a ++ collectMetaVars b
 
--- | Create a type variable from a meta-variable unique.
-metaToTyVar :: Unique -> TcM TyVarId
-metaToTyVar (Unique n) = freshSkolemTv (mkName n)
+-- | Create a type variable from a meta-variable unique, using a
+-- sequential index for naming (so the first generalized variable is
+-- 'a', the second 'b', etc.).
+metaToTyVar :: Int -> Unique -> TcM TyVarId
+metaToTyVar idx _u = freshSkolemTv (mkName idx)
   where
     mkName i =
       let c = toEnum (fromEnum 'a' + i `mod` 26)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -15,12 +15,18 @@ import Aihc.Parser.Syntax
     Decl (..),
     Match (..),
     Module (..),
+    Name (..),
+    NameType (..),
+    Pattern (..),
     Rhs (..),
     SourceSpan,
     UnqualifiedName (..),
     ValueDecl (..),
   )
+import Aihc.Tc.Constraint
+import Aihc.Tc.Generalize (generalize)
 import Aihc.Tc.Generate.Expr (inferExpr)
+import Aihc.Tc.Instantiate qualified
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
 import Aihc.Tc.Types
@@ -42,9 +48,56 @@ tcModule m = do
   -- Phase 1: collect data declarations, register constructors,
   --          and report their types.
   dataResults <- concat <$> mapM registerDecl (moduleDecls m)
-  -- Phase 2: type-check value bindings.
-  valueResults <- concat <$> mapM tcDecl (moduleDecls m)
+  -- Phase 2: group and type-check value bindings.
+  -- Multiple FunctionBind declarations with the same name are merged
+  -- into a single binding with combined match equations.
+  let grouped = groupValueDecls (moduleDecls m)
+  valueResults <- concat <$> mapM tcDeclGroup grouped
   pure (dataResults ++ valueResults)
+
+-- | A group of declarations that should be typechecked together.
+-- Multiple FunctionBind equations for the same name are merged.
+data DeclGroup
+  = SingleDecl Decl
+  | MergedFunctionBind SourceSpan UnqualifiedName [Match]
+
+-- | Group consecutive FunctionBind declarations with the same name.
+groupValueDecls :: [Decl] -> [DeclGroup]
+groupValueDecls [] = []
+groupValueDecls (d : ds) = case extractFunctionBind d of
+  Just (sp, name, matches) ->
+    let (sameNameDecls, rest) = span (hasSameName name) ds
+        allMatches = matches ++ concatMap (maybe [] (\(_, _, ms) -> ms) . extractFunctionBind) sameNameDecls
+     in MergedFunctionBind sp name allMatches : groupValueDecls rest
+  Nothing -> SingleDecl d : groupValueDecls ds
+
+-- | Extract function bind info from a declaration.
+extractFunctionBind :: Decl -> Maybe (SourceSpan, UnqualifiedName, [Match])
+extractFunctionBind (DeclValue sp (FunctionBind _fsp name matches)) = Just (sp, name, matches)
+extractFunctionBind (DeclAnn _ inner) = extractFunctionBind inner
+extractFunctionBind _ = Nothing
+
+-- | Check if a declaration is a FunctionBind with the given name.
+hasSameName :: UnqualifiedName -> Decl -> Bool
+hasSameName name d = case extractFunctionBind d of
+  Just (_, n, _) -> unqualifiedNameText n == unqualifiedNameText name
+  Nothing -> False
+
+-- | Type-check a declaration group.
+tcDeclGroup :: DeclGroup -> TcM [TcBindingResult]
+tcDeclGroup (SingleDecl d) = tcDecl d
+tcDeclGroup (MergedFunctionBind _sp binder matches) = do
+  let name = unqualifiedNameText binder
+      displayName = renderBinderName binder
+  (ty, cts) <- tcMatches matches
+  _ <- solveConstraints cts
+  -- Generalize over free meta-variables to produce a type scheme.
+  scheme <- generalize ty []
+  let schemeTy = schemeToType scheme
+  zonkedTy <- zonkType schemeTy
+  -- Register the binding so later bindings can reference it.
+  extendTermEnvPermanent name (TcIdBinder name scheme)
+  pure [TcBindingResult displayName zonkedTy]
 
 -- | Register a declaration in the environment (data types, etc.).
 -- Returns binding results for the declared names.
@@ -108,23 +161,150 @@ tcDecl _ = pure []
 tcValueDecl :: SourceSpan -> ValueDecl -> TcM [TcBindingResult]
 tcValueDecl _sp (FunctionBind _fsp binder matches) = do
   let name = unqualifiedNameText binder
-  ty <- tcMatches matches
-  zonkedTy <- zonkType ty
+      displayName = renderBinderName binder
+  (ty, cts) <- tcMatches matches
+  _ <- solveConstraints cts
+  -- Generalize over free meta-variables to produce a type scheme.
+  scheme <- generalize ty []
+  let schemeTy = schemeToType scheme
+  zonkedTy <- zonkType schemeTy
   -- Register the binding so later bindings can reference it.
-  extendTermEnvPermanent name (TcIdBinder name (ForAll [] [] zonkedTy))
-  pure [TcBindingResult name zonkedTy]
+  extendTermEnvPermanent name (TcIdBinder name scheme)
+  pure [TcBindingResult displayName zonkedTy]
 tcValueDecl _sp (PatternBind _psp _pat rhs) = do
   ty <- tcRhs rhs
   zonkedTy <- zonkType ty
   pure [TcBindingResult "<pattern>" zonkedTy]
 
--- | Type-check a list of matches (equations for a function binding).
--- For MVP, just check the first match.
-tcMatches :: [Match] -> TcM TcType
-tcMatches [] = freshMetaTv
-tcMatches (m : _) = tcRhs (matchRhs m)
+-- | Convert a type scheme to a displayable type.
+schemeToType :: TypeScheme -> TcType
+schemeToType (ForAll [] [] ty) = ty
+schemeToType (ForAll tvs [] ty) = foldr TcForAllTy ty tvs
+schemeToType (ForAll [] preds ty) = TcQualTy preds ty
+schemeToType (ForAll tvs preds ty) = foldr TcForAllTy (TcQualTy preds ty) tvs
 
--- | Type-check a right-hand side.
+-- | Type-check a list of matches (equations for a function binding).
+--
+-- All equations must have the same number of patterns and produce
+-- a consistent function type. We infer the type from each equation
+-- and unify them.
+tcMatches :: [Match] -> TcM (TcType, [Ct])
+tcMatches [] = do
+  ty <- freshMetaTv
+  pure (ty, [])
+tcMatches matches@(m0 : _) = do
+  let nArgs = length (matchPats m0)
+  if nArgs == 0
+    then do
+      -- No patterns: just infer the RHS of the first match.
+      -- All match RHSes should agree on a type.
+      (ty0, cts0) <- inferRhsExpr (matchRhs m0)
+      restCts <- concatMapM (unifyMatchRhs ty0) (drop 1 matches)
+      pure (ty0, cts0 ++ restCts)
+    else do
+      -- Create fresh meta-variables for the argument types and result type.
+      argTys <- mapM (const freshMetaTv) [1 .. nArgs]
+      resTy <- freshMetaTv
+      -- Process each equation.
+      allCts <- concatMapM (tcMatchEquation argTys resTy) matches
+      let funTy = foldr TcFunTy resTy argTys
+      pure (funTy, allCts)
+
+-- | Type-check a single match equation against expected arg/result types.
+tcMatchEquation :: [TcType] -> TcType -> Match -> TcM [Ct]
+tcMatchEquation argTys resTy match = do
+  let pats = matchPats match
+  -- Bind pattern variables with their corresponding arg types.
+  let bindings = concatMap extractPatternBindings (zip pats argTys)
+  -- Also emit constraints from constructor patterns.
+  patCts <- concatMapM (uncurry inferPatCts) (zip pats argTys)
+  -- Infer the RHS under the extended environment.
+  (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
+  -- RHS type must match the expected result type.
+  ev <- freshEvVar
+  let sp = matchSpan match
+  let resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
+  pure (patCts ++ rhsCts ++ [resCt])
+
+-- | Unify an additional match equation's RHS with the expected type.
+unifyMatchRhs :: TcType -> Match -> TcM [Ct]
+unifyMatchRhs expectedTy match = do
+  (rhsTy, rhsCts) <- inferRhsExpr (matchRhs match)
+  ev <- freshEvVar
+  let sp = matchSpan match
+  let eqCt = mkWantedCt (EqPred rhsTy expectedTy) ev (AppOrigin sp) sp
+  pure (rhsCts ++ [eqCt])
+
+-- | Infer constraints from a pattern matching against a scrutinee type.
+--
+-- For constructor patterns, emit that the scrutinee type matches the
+-- constructor's result type. For variable and wildcard patterns, no
+-- extra constraints are needed.
+inferPatCts :: Pattern -> TcType -> TcM [Ct]
+inferPatCts pat scrutTy = case pat of
+  PCon sp name _subPats -> do
+    let conName = patNameToText name
+    mBinder <- lookupTerm conName
+    case mBinder of
+      Just (TcIdBinder _ scheme) -> do
+        (conTy, _preds) <- instantiateSch scheme
+        let conResTy = resultType conTy
+        ev <- freshEvVar
+        pure [mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp]
+      _ -> pure []
+  PAnn _ann inner -> inferPatCts inner scrutTy
+  PParen _sp inner -> inferPatCts inner scrutTy
+  PStrict _sp inner -> inferPatCts inner scrutTy
+  PIrrefutable _sp inner -> inferPatCts inner scrutTy
+  _ -> pure []
+
+-- | Convert a Name to Text for lookup.
+patNameToText :: Name -> Text
+patNameToText n = case nameQualifier n of
+  Nothing -> nameText n
+  Just q -> q <> "." <> nameText n
+
+-- | Extract the result type from a (possibly nested) function type.
+resultType :: TcType -> TcType
+resultType (TcFunTy _ res) = resultType res
+resultType ty = ty
+
+-- | Instantiate a type scheme (delegating to the Instantiate module).
+instantiateSch :: TypeScheme -> TcM (TcType, [Pred])
+instantiateSch = Aihc.Tc.Instantiate.instantiate
+
+-- | Extract variable bindings from a pattern paired with its expected type.
+extractPatternBindings :: (Pattern, TcType) -> [(Text, TcType)]
+extractPatternBindings (pat, ty) = case pat of
+  PVar _sp uname -> [(unqualifiedNameText uname, ty)]
+  PAnn _ann inner -> extractPatternBindings (inner, ty)
+  PParen _sp inner -> extractPatternBindings (inner, ty)
+  PWildcard {} -> []
+  PLit {} -> []
+  PNegLit {} -> []
+  PAs _sp name inner -> (name, ty) : extractPatternBindings (inner, ty)
+  PStrict _sp inner -> extractPatternBindings (inner, ty)
+  PIrrefutable _sp inner -> extractPatternBindings (inner, ty)
+  PCon _sp _name subPats ->
+    concatMap (\p -> extractPatternBindings (p, ty)) subPats
+  PInfix _sp lhs _name rhs ->
+    extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)
+  _ -> []
+
+-- | Run a computation with pattern bindings in scope.
+withPatBindings :: [(Text, TcType)] -> TcM a -> TcM a
+withPatBindings [] m = m
+withPatBindings ((name, ty) : rest) m =
+  extendTermEnv name (TcMonoIdBinder name ty) (withPatBindings rest m)
+
+-- | Infer the type of a right-hand side expression.
+inferRhsExpr :: Rhs -> TcM (TcType, [Ct])
+inferRhsExpr (UnguardedRhs _sp expr) = inferExpr expr
+inferRhsExpr (GuardedRhss _sp _guards) = do
+  ty <- freshMetaTv
+  pure (ty, [])
+
+-- | Type-check a right-hand side (solving constraints immediately).
 tcRhs :: Rhs -> TcM TcType
 tcRhs (UnguardedRhs _sp expr) = do
   (ty, cts) <- inferExpr expr
@@ -133,3 +313,16 @@ tcRhs (UnguardedRhs _sp expr) = do
 tcRhs (GuardedRhss _sp _guards) =
   -- Guarded RHS not handled in MVP.
   freshMetaTv
+
+-- | Render an unqualified name for display.
+-- Operators (NameVarSym, NameConSym) are wrapped in parentheses.
+renderBinderName :: UnqualifiedName -> Text
+renderBinderName uname =
+  case unqualifiedNameType uname of
+    NameVarSym -> "(" <> unqualifiedNameText uname <> ")"
+    NameConSym -> "(" <> unqualifiedNameText uname <> ")"
+    _ -> unqualifiedNameText uname
+
+-- | Strict 'concatMap' in a monad.
+concatMapM :: (Monad m) => (a -> m [b]) -> [a] -> m [b]
+concatMapM f xs = concat <$> mapM f xs

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -15,9 +15,13 @@ module Aihc.Tc.Generate.Expr
 where
 
 import Aihc.Parser.Syntax
-  ( Expr (..),
+  ( CaseAlt (..),
+    Expr (..),
     Name (..),
+    Pattern (..),
+    Rhs (..),
     SourceSpan (..),
+    UnqualifiedName (..),
     getSourceSpan,
   )
 import Aihc.Tc.Constraint
@@ -57,6 +61,8 @@ inferExpr expr = case expr of
       _ = sp
   -- Lambda: \x -> body
   ELambdaPats sp pats body -> inferLambda sp pats body
+  -- Lambda case: \case { pat -> body; ... }
+  ELambdaCase sp alts -> inferLambdaCase sp alts
   -- Application: f x
   EApp sp fun arg -> inferApp sp fun arg
   -- If-then-else
@@ -121,15 +127,85 @@ predToCt sp name p = do
     mkWantedCt p ev (OccurrenceOf name) sp
 
 -- | Infer the type of a lambda expression.
-inferLambda :: SourceSpan -> [a] -> Expr -> TcM (TcType, [Ct])
+inferLambda :: SourceSpan -> [Pattern] -> Expr -> TcM (TcType, [Ct])
 inferLambda _sp pats body = do
-  -- Create a fresh meta-variable for each pattern.
+  -- Create a fresh meta-variable for each pattern and bind pattern
+  -- variables into the environment.
   argTys <- mapM (const freshMetaTv) pats
-  -- For MVP, we don't bind pattern variables (would need pattern analysis).
-  -- Just infer the body with a fresh result type.
-  (bodyTy, bodyCts) <- inferExpr body
+  let bindings = concatMap extractPatternBindings (zip pats argTys)
+  -- Infer the body under the extended environment.
+  (bodyTy, bodyCts) <- withPatternBindings bindings (inferExpr body)
   let funTy = foldr TcFunTy bodyTy argTys
   pure (funTy, bodyCts)
+
+-- | Infer the type of a lambda-case expression.
+--
+-- @\\case { pat1 -> e1; pat2 -> e2; ... }@ is treated as a function
+-- from a fresh argument type to the result type of the case
+-- alternatives.
+inferLambdaCase :: SourceSpan -> [CaseAlt] -> TcM (TcType, [Ct])
+inferLambdaCase sp alts = do
+  argTy <- freshMetaTv
+  resTy <- freshMetaTv
+  cts <- inferCaseAlts sp argTy resTy alts
+  pure (TcFunTy argTy resTy, cts)
+
+-- | Infer constraints from case alternatives.
+--
+-- Each alternative's pattern is checked against the scrutinee type,
+-- and each RHS must unify with the expected result type.
+inferCaseAlts :: SourceSpan -> TcType -> TcType -> [CaseAlt] -> TcM [Ct]
+inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
+  where
+    inferAlt (CaseAlt _altSp pat rhs) = do
+      let bindings = extractPatternBindings (pat, scrutTy)
+      -- Emit constraint: pattern's constructor result type ~ scrutinee type.
+      patCts <- inferPatternConstraints sp scrutTy pat
+      -- Infer the RHS under the pattern bindings.
+      (rhsTy, rhsCts) <- withPatternBindings bindings (inferRhs rhs)
+      -- RHS must match the expected result type.
+      ev <- freshEvVar
+      let rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
+      pure (patCts ++ rhsCts ++ [rhsCt])
+
+-- | Infer constraints from a pattern.
+--
+-- For constructor patterns, we emit an equality between the constructor's
+-- result type and the scrutinee type. For variable/wildcard/literal patterns,
+-- no extra constraints are needed (the variable just gets the scrutinee type).
+inferPatternConstraints :: SourceSpan -> TcType -> Pattern -> TcM [Ct]
+inferPatternConstraints sp scrutTy pat = case pat of
+  PCon _patSp name _subPats -> do
+    -- Look up the constructor; if found, emit scrutTy ~ constructor result type.
+    let conName = nameToText name
+    mBinder <- lookupTerm conName
+    case mBinder of
+      Just (TcIdBinder _ scheme) -> do
+        (conTy, _preds) <- instantiate scheme
+        -- For a nullary constructor (no args), conTy is the result type.
+        -- For a constructor with args, conTy is a function type whose
+        -- result is the data type. We need to extract the result type.
+        let conResTy = resultType conTy
+        ev <- freshEvVar
+        pure [mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp]
+      _ -> pure []
+  PAnn _ann inner -> inferPatternConstraints sp scrutTy inner
+  PParen _patSp inner -> inferPatternConstraints sp scrutTy inner
+  PStrict _patSp inner -> inferPatternConstraints sp scrutTy inner
+  PIrrefutable _patSp inner -> inferPatternConstraints sp scrutTy inner
+  _ -> pure []
+
+-- | Extract the result type from a (possibly nested) function type.
+resultType :: TcType -> TcType
+resultType (TcFunTy _ res) = resultType res
+resultType ty = ty
+
+-- | Infer the type of a right-hand side (for case alternatives).
+inferRhs :: Rhs -> TcM (TcType, [Ct])
+inferRhs (UnguardedRhs _sp expr) = inferExpr expr
+inferRhs (GuardedRhss _sp _guards) = do
+  ty <- freshMetaTv
+  pure (ty, [])
 
 -- | Infer the type of a function application.
 inferApp :: SourceSpan -> Expr -> Expr -> TcM (TcType, [Ct])
@@ -212,3 +288,39 @@ stringTyCon = TcTyCon (TyCon "String" 0) []
 
 boolTyCon :: TcType
 boolTyCon = TcTyCon (TyCon "Bool" 0) []
+
+-- | Extract variable bindings from a pattern paired with its expected type.
+--
+-- For a 'PVar', we bind the variable name to the given type.
+-- For a 'PCon' (constructor pattern), we return bindings for sub-patterns
+-- but assign fresh types to them (the constructor arg types are not yet
+-- tracked in the MVP).
+-- Other patterns are handled minimally for the MVP.
+extractPatternBindings :: (Pattern, TcType) -> [(Text, TcType)]
+extractPatternBindings (pat, ty) = case pat of
+  PVar _sp uname -> [(unqualifiedNameText uname, ty)]
+  PAnn _ann inner -> extractPatternBindings (inner, ty)
+  PParen _sp inner -> extractPatternBindings (inner, ty)
+  PWildcard {} -> []
+  PLit {} -> []
+  PNegLit {} -> []
+  PAs _sp name inner -> (name, ty) : extractPatternBindings (inner, ty)
+  PStrict _sp inner -> extractPatternBindings (inner, ty)
+  PIrrefutable _sp inner -> extractPatternBindings (inner, ty)
+  -- For constructor patterns like (True), (Just x), etc. the overall
+  -- pattern type doesn't directly give us the sub-pattern types. But
+  -- we can still extract the variable names for binding purposes.
+  PCon _sp _name subPats ->
+    -- Each sub-pattern gets an unknown type (we'd need constructor info
+    -- to assign proper types). For the MVP, they're not needed since
+    -- constructor pattern matching in function heads is handled by tcMatches.
+    concatMap (\p -> extractPatternBindings (p, ty)) subPats
+  PInfix _sp lhs _name rhs ->
+    extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)
+  _ -> []
+
+-- | Run a computation with pattern bindings in scope.
+withPatternBindings :: [(Text, TcType)] -> TcM a -> TcM a
+withPatternBindings [] m = m
+withPatternBindings ((name, ty) : rest) m =
+  extendTermEnv name (TcMonoIdBinder name ty) (withPatternBindings rest m)

--- a/components/aihc-tc/test/Test/Fixtures/golden/dollar-operator.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/dollar-operator.yaml
@@ -4,6 +4,6 @@ modules:
     module Test where
     f $ x = f x
 expected:
-  - "($) :: (a -> b) -> a -> b"
-status: xfail
-reason: "tcMatches ignores function argument patterns, so `f` and `x` in the RHS are unbound variables"
+  - "($) :: forall a b. (a -> b) -> a -> b"
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Fixtures/golden/id-function.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/id-function.yaml
@@ -5,5 +5,5 @@ modules:
     id x = x
 expected:
   - "id :: forall a. a -> a"
-status: xfail
-reason: "Function argument patterns are not yet bound into the environment (tcMatches ignores Match patterns)"
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Fixtures/golden/id-lambda.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/id-lambda.yaml
@@ -5,5 +5,5 @@ modules:
     id = \x -> x
 expected:
   - "id :: forall a. a -> a"
-status: xfail
-reason: "inferLambda does not bind pattern variables into the environment, so `x` in the body is unbound"
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Fixtures/golden/not-lambda-case.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/not-lambda-case.yaml
@@ -11,5 +11,5 @@ expected:
   - "True :: Bool"
   - "False :: Bool"
   - "not :: Bool -> Bool"
-status: xfail
-reason: "ELambdaCase is not handled in inferExpr (falls through to the unsupported-expression error path)"
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Fixtures/golden/not-pattern-matching.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/not-pattern-matching.yaml
@@ -10,5 +10,5 @@ expected:
   - "True :: Bool"
   - "False :: Bool"
   - "not :: Bool -> Bool"
-status: xfail
-reason: "tcMatches ignores patterns and uses only the first equation's RHS, yielding `not :: Bool` twice instead of `Bool -> Bool` once; requires pattern binding and multi-equation matching"
+status: pass
+reason: ""


### PR DESCRIPTION
## Summary

- Fix all 5 xfail golden test cases in aihc-tc by implementing core type-checking features that were previously stubbed out
- Golden test progress: pass 6/6, xfail 0/6

## Changes

### Constraint generation (`Generate/Expr.hs`)
- **Pattern variable binding in lambdas**: `inferLambda` now extracts variable names from `Pattern` nodes and binds them as monomorphic local variables in the environment before inferring the body
- **Lambda-case support**: Added `ELambdaCase` handler that creates a fresh arg type, infers case alternative constraints (pattern matching + RHS), and produces a function type
- **Case alternative inference**: Added `inferCaseAlts`, `inferPatternConstraints`, and `inferRhs` for typechecking case alternatives with proper pattern-to-type bindings
- **Pattern extraction utilities**: `extractPatternBindings` handles `PVar`, `PAnn`, `PParen`, `PWildcard`, `PLit`, `PAs`, `PStrict`, `PIrrefutable`, `PCon`, `PInfix` patterns

### Declaration processing (`Generate/Decl.hs`)
- **Multi-equation function matching**: `tcMatches` now processes all match equations by creating shared fresh arg/result type variables and checking each equation against them
- **Declaration grouping**: `groupValueDecls` merges consecutive `FunctionBind` declarations with the same name (e.g., `not True = False; not False = True`) into a single binding with combined match equations
- **Pattern constraint emission**: `inferPatCts` emits equality constraints between constructor pattern result types and scrutinee types
- **Let-generalization**: `tcValueDecl` and `tcDeclGroup` now call `generalize` to produce `forall`-quantified type schemes for top-level bindings
- **Operator name rendering**: `renderBinderName` wraps `NameVarSym`/`NameConSym` names in parentheses (e.g., `($)`)

### Type rendering (`Annotations.hs`)
- **Collapsed forall rendering**: Multiple nested `TcForAllTy` nodes are collapsed into a single `forall a b. ...` rather than `forall a. forall b. ...`

### Generalization (`Generalize.hs`)
- **Sequential variable naming**: Generalized type variables are now named starting from 'a' based on their position (not their internal unique), producing consistent `forall a. a -> a` output

### Fixtures
- All 5 xfail fixtures updated to `pass` status
- `dollar-operator.yaml` expected output updated to include `forall a b.` quantifier and `($)` name format