### PR TITLE
fix(parser): limit where-clause generation to binding rhs

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -59,7 +59,6 @@ genExprSizedWith allowTHQuotes n
         ELambdaPats span0 <$> genPatterns half <*> genExprSizedWith allowTHQuotes half,
         ELambdaCase span0 <$> genCaseAltsWith allowTHQuotes (n - 1),
         ELetDecls span0 <$> genValueDeclsWith allowTHQuotes half <*> genExprSizedWith allowTHQuotes half,
-        EWhereDecls span0 <$> genExprSizedWith allowTHQuotes half <*> genValueDeclsWith allowTHQuotes half,
         EDo span0 <$> genDoStmtsWith allowTHQuotes (n - 1) <*> pure False,
         EListComp span0 <$> genExprSizedWith allowTHQuotes half <*> genCompStmtsWith allowTHQuotes half,
         EListCompParallel span0 <$> genExprSizedWith allowTHQuotes half <*> genParallelCompStmtsWith allowTHQuotes half,
@@ -256,7 +255,7 @@ genCaseAltWith allowTHQuotes n = do
 genRhsWith :: Bool -> Int -> Gen Rhs
 genRhsWith allowTHQuotes n =
   oneof
-    [ UnguardedRhs span0 <$> genExprSizedWith allowTHQuotes n,
+    [ UnguardedRhs span0 <$> genBindingExprWith allowTHQuotes n,
       GuardedRhss span0 <$> genGuardedRhsListWith allowTHQuotes n
     ]
 
@@ -269,7 +268,7 @@ genGuardedRhsWith :: Bool -> Int -> Gen GuardedRhs
 genGuardedRhsWith allowTHQuotes n = do
   guardCount <- chooseInt (1, 2)
   guards <- vectorOf guardCount (genGuardQualifierWith allowTHQuotes (half `div` guardCount))
-  body <- genExprSizedWith allowTHQuotes half
+  body <- genBindingExprWith allowTHQuotes half
   pure $
     GuardedRhs
       { guardedRhsSpan = span0,
@@ -312,7 +311,7 @@ genValueDeclsWith :: Bool -> Int -> Gen [Decl]
 genValueDeclsWith allowTHQuotes n = do
   count <- chooseInt (0, 3)
   names <- vectorOf count (mkUnqualifiedName NameVarId <$> genIdent)
-  exprs <- vectorOf count (genExprSizedWith allowTHQuotes (n `div` max 1 count))
+  exprs <- vectorOf count (genBindingExprWith allowTHQuotes (n `div` max 1 count))
   pure
     [ DeclValue
         span0
@@ -329,6 +328,17 @@ genValueDeclsWith allowTHQuotes n = do
         )
     | (name, expr) <- zip names exprs
     ]
+
+genBindingExprWith :: Bool -> Int -> Gen Expr
+genBindingExprWith allowTHQuotes n
+  | n <= 0 = genExprLeaf
+  | otherwise =
+      frequency
+        [ (4, genExprSizedWith allowTHQuotes n),
+          (1, EWhereDecls span0 <$> genExprSizedWith allowTHQuotes half <*> genValueDeclsWith allowTHQuotes half)
+        ]
+  where
+    half = n `div` 2
 
 genDoStmtsWith :: Bool -> Int -> Gen [DoStmt Expr]
 genDoStmtsWith allowTHQuotes n = do


### PR DESCRIPTION
## Summary
- stop generating `EWhereDecls` as a free-form expression in the general QuickCheck expression generator
- keep `where` clauses in declaration right-hand sides, where the pretty-printer and Haskell surface syntax can represent them
- preserve `where` coverage for generated bindings and guarded RHS bodies through a dedicated binding-expression generator

## Root Cause
The failing replay produced a guard qualifier containing a nested `EWhereDecls` expression. Our parser accepts that AST shape, but GHC does not accept the pretty-printed source in that context. This was not a parser round-trip regression in valid Haskell; it was the generator constructing an AST shape that is only valid in binding RHS positions.

## Validation
- `just replay "(SMGen 17698424306086588282 16901332186361700647,71)"`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "generated module AST pretty-printer round-trip"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "generated decl AST pretty-printer round-trip"'`
- `just test`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)
