### PR TITLE
feat(ci): add aihc-tc progress tracking and extension support reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Can gpt-5.4, Claude Opus 4.5 and Qwen-3.6 write a Haskell compiler? Probably not
 Find more information here:
 - [**aihc-cpp** README](https://github.com/ai-haskell-compiler/aihc/tree/main/components/aihc-cpp#readme)
 - [**aihc-parser** README](https://github.com/ai-haskell-compiler/aihc/tree/main/components/aihc-parser#readme)
+- [**aihc-tc** README](https://github.com/ai-haskell-compiler/aihc/tree/main/components/aihc-tc#readme)
 - [Supported extensions](https://github.com/ai-haskell-compiler/aihc/blob/main/docs/haskell-parser-extension-support.md)
+- [TC supported extensions](https://github.com/ai-haskell-compiler/aihc/blob/main/docs/aihc-tc-supported-extensions.md)
 
 ## Progress
 
@@ -22,6 +24,7 @@ Find more information here:
 | Parser Tests     | <!-- AUTO-GENERATED: START parser-progress --> `798/821` (`97.20%`) <!-- AUTO-GENERATED: END parser-progress -->                     |
 | Lexer Tests      | <!-- AUTO-GENERATED: START lexer-progress --> `90/90` (`100.00%`) <!-- AUTO-GENERATED: END lexer-progress -->                         |
 | CPP Tests        | <!-- AUTO-GENERATED: START cpp-progress --> `38/38` (`100.00%`) <!-- AUTO-GENERATED: END cpp-progress -->                            |
+| TC Tests         | <!-- AUTO-GENERATED: START tc-progress --> `6/6` (`100.00%`) <!-- AUTO-GENERATED: END tc-progress -->                                  |
 
 ## Lines of code
 
@@ -59,10 +62,13 @@ nix flake check
 | ------------------------------------- | ----------------------------------------- |
 | `nix run .#parser-test`               | Run parser test suite                     |
 | `nix run .#cpp-test`                  | Run CPP preprocessor test suite           |
+| `nix run .#tc-test`                   | Run type checker test suite               |
 | `nix run .#parser-progress`           | Show parser oracle test progress          |
 | `nix run .#lexer-progress`            | Show lexer oracle test progress           |
 | `nix run .#parser-extension-progress` | Show parser extension test progress       |
 | `nix run .#cpp-progress`              | Show CPP preprocessor test progress       |
+| `nix run .#tc-progress`               | Show type checker test progress           |
+| `nix run .#tc-extension-progress`     | Show type checker extension test progress |
 | `nix run .#stackage-progress`         | Show parser progress on Stackage packages |
 | `nix run .#prompt`                    | Generate a prompt for contributing        |
 | `nix run .#hackage-tester`            | Test parser against Hackage packages      |
@@ -70,4 +76,4 @@ nix flake check
 | `nix run .#generate-reports`          | Update generated README content           |
 | `nix run .#check-reports`             | Check if generated content is up-to-date  |
 
-Strict variants (fail on unexpected results): `parser-progress-strict`, `lexer-progress-strict`, `parser-extension-progress-strict`, `cpp-progress-strict`.
+Strict variants (fail on unexpected results): `parser-progress-strict`, `lexer-progress-strict`, `parser-extension-progress-strict`, `cpp-progress-strict`, `tc-progress-strict`.

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -66,7 +66,7 @@ test-suite spec
     , bytestring
     , yaml
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable tc-progress
   hs-source-dirs:

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -67,3 +67,45 @@ test-suite spec
     , yaml
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
+
+executable tc-progress
+  hs-source-dirs:
+      app/tc-progress
+    , common
+  main-is:          Main.hs
+  other-modules:
+      TcGolden
+  build-depends:
+      base >=4.16 && <5
+    , aihc-tc
+    , aihc-parser
+    , text
+    , containers
+    , directory
+    , filepath
+    , yaml
+    , aeson
+    , bytestring
+  ghc-options:        -Wall -Werror
+  default-language: GHC2021
+
+executable tc-extension-progress
+  hs-source-dirs:
+      app/tc-extension-progress
+    , common
+  main-is:          Main.hs
+  other-modules:
+      TcGolden
+  build-depends:
+      base >=4.16 && <5
+    , aihc-tc
+    , aihc-parser
+    , text
+    , containers
+    , directory
+    , filepath
+    , yaml
+    , aeson
+    , bytestring
+  ghc-options:        -Wall -Werror
+  default-language: GHC2021

--- a/components/aihc-tc/app/tc-extension-progress/Main.hs
+++ b/components/aihc-tc/app/tc-extension-progress/Main.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Extension support reporting for the type checker.
+--
+-- Groups TC golden test cases by language extension and
+-- produces a summary similar to the parser extension support report.
+module Main (main) where
+
+import Aihc.Parser.Syntax qualified as Syntax
+import Data.List (sortOn)
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import System.Exit (exitFailure, exitSuccess)
+import TcGolden
+
+data SupportStatus = Supported | InProgress deriving (Eq, Show)
+
+data ExtensionResult = ExtensionResult
+  { erName :: !String,
+    erStatus :: !SupportStatus,
+    erPassN :: !Int,
+    erXFailN :: !Int,
+    erXPassN :: !Int,
+    erFailN :: !Int,
+    erTotalN :: !Int
+  }
+
+main :: IO ()
+main = do
+  cases <- loadTcCases
+  let evaluated = [(tc, outcome, details) | tc <- cases, let (outcome, details) = evaluateTcCase tc]
+      grouped = groupByExtension evaluated
+      results = map mkExtensionResult (sortOn fst (M.toList grouped))
+
+  putStrLn (renderMarkdown results)
+
+  let failN = sum [erFailN result | result <- results]
+      xpassN = sum [erXPassN result | result <- results]
+  if failN == 0 && xpassN == 0
+    then exitSuccess
+    else exitFailure
+
+groupByExtension ::
+  [(TcCase, Outcome, String)] ->
+  M.Map Syntax.Extension [(TcCase, Outcome, String)]
+groupByExtension =
+  foldl' insertCase M.empty
+  where
+    insertCase :: M.Map Syntax.Extension [(TcCase, Outcome, String)] -> (TcCase, Outcome, String) -> M.Map Syntax.Extension [(TcCase, Outcome, String)]
+    insertCase acc (tc, outcome, details) =
+      foldl' (\m ext -> M.insertWith (++) ext [(tc, outcome, details)] m) acc (caseExtensions tc)
+
+mkExtensionResult :: (Syntax.Extension, [(TcCase, Outcome, String)]) -> ExtensionResult
+mkExtensionResult (name, outcomes) =
+  let passN = countOutcome OutcomePass outcomes
+      xfailN = countOutcome OutcomeXFail outcomes
+      xpassN = countOutcome OutcomeXPass outcomes
+      failN = countOutcome OutcomeFail outcomes
+      totalN = passN + xfailN + xpassN + failN
+      status
+        | failN == 0 && xpassN == 0 = Supported
+        | otherwise = InProgress
+   in ExtensionResult
+        { erName = T.unpack (Syntax.extensionName name),
+          erStatus = status,
+          erPassN = passN,
+          erXFailN = xfailN,
+          erXPassN = xpassN,
+          erFailN = failN,
+          erTotalN = totalN
+        }
+
+countOutcome :: Outcome -> [(a, Outcome, String)] -> Int
+countOutcome target = length . filter (\(_, outcome, _) -> outcome == target)
+
+renderMarkdown :: [ExtensionResult] -> String
+renderMarkdown results =
+  unlines
+    ( [ "# Type Checker Extension Support Status",
+        "",
+        "## Summary",
+        "",
+        "- Total Extensions: " <> show totalN,
+        "- Supported: " <> show supportedN,
+        "- In Progress: " <> show inProgressN,
+        "",
+        "## Extension Status",
+        "",
+        renderTableHeader col1W col2W col3W,
+        renderTableSep col1W col2W col3W
+      ]
+        <> map (renderResultRow col1W col2W col3W) results
+    )
+  where
+    supportedN = length [() | result <- results, erStatus result == Supported]
+    inProgressN = length [() | result <- results, erStatus result == InProgress]
+    totalN = length results
+    col1W = maximum $ length ("Extension" :: String) : map (length . erName) results
+    col2W = maximum $ length ("Status" :: String) : map (length . statusEmoji) results
+    col3W = maximum $ length ("Tests Passing" :: String) : map (length . testsPassingStr) results
+    testsPassingStr result = show (erPassN result) <> "/" <> show (erTotalN result)
+
+padRight :: Int -> String -> String
+padRight n s = s <> replicate (n - length s) ' '
+
+padCenter :: Int -> String -> String
+padCenter n s =
+  let total = n - length s
+      left = total `div` 2
+      right = total - left
+   in replicate left ' ' <> s <> replicate right ' '
+
+renderTableHeader :: Int -> Int -> Int -> String
+renderTableHeader w1 w2 w3 =
+  "| " <> padRight w1 "Extension" <> " | " <> padCenter w2 "Status" <> " | " <> padRight w3 "Tests Passing" <> " |"
+
+renderTableSep :: Int -> Int -> Int -> String
+renderTableSep w1 w2 w3 =
+  "|" <> replicate (w1 + 2) '-' <> "|:" <> replicate w2 '-' <> ":|" <> replicate (w3 + 2) '-' <> "|"
+
+renderResultRow :: Int -> Int -> Int -> ExtensionResult -> String
+renderResultRow w1 w2 w3 result =
+  "| "
+    <> padRight w1 (erName result)
+    <> " | "
+    <> padCenter w2 (statusEmoji result)
+    <> " | "
+    <> padRight w3 (show (erPassN result) <> "/" <> show (erTotalN result))
+    <> " |"
+
+statusEmoji :: ExtensionResult -> String
+statusEmoji result
+  | erTotalN result == 0 = "⚪"
+  | erPassN result == erTotalN result = "🟢"
+  | erTotalN result > 0 && fromIntegral (erPassN result) / fromIntegral (erTotalN result) >= (0.9 :: Double) = "🟡"
+  | otherwise = "🔴"

--- a/components/aihc-tc/app/tc-progress/Main.hs
+++ b/components/aihc-tc/app/tc-progress/Main.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Progress reporting for the type checker.
+--
+-- Loads YAML fixtures from the golden test directory, evaluates
+-- each case, and outputs a summary in the standard
+-- PASS/XFAIL/XPASS/FAIL/TOTAL/COMPLETE format.
+module Main (main) where
+
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+import TcGolden
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let strict = "--strict" `elem` args
+
+  cases <- loadTcCases
+  let evaluated = [(tc, outcome, details) | tc <- cases, let (outcome, details) = evaluateTcCase tc]
+      (passN, xfailN, xpassN, failN) = progressSummary evaluated
+      totalN = passN + xfailN + xpassN + failN
+      completion = pct (passN + xpassN) totalN
+
+  putStrLn "Type checker progress"
+  putStrLn "====================="
+  putStrLn ("PASS      " <> show passN)
+  putStrLn ("XFAIL     " <> show xfailN)
+  putStrLn ("XPASS     " <> show xpassN)
+  putStrLn ("FAIL      " <> show failN)
+  putStrLn ("TOTAL     " <> show totalN)
+  putStrLn ("COMPLETE  " <> show completion <> "%")
+
+  let failures = [(tc, details) | (tc, OutcomeFail, details) <- evaluated]
+      xpasses = [(tc, details) | (tc, OutcomeXPass, details) <- evaluated]
+
+  mapM_ printFailure failures
+  mapM_ printXPass xpasses
+
+  if null failures && (not strict || null xpasses)
+    then exitSuccess
+    else exitFailure
+
+pct :: Int -> Int -> Double
+pct done totalN
+  | totalN <= 0 = 0.0
+  | otherwise = fromIntegral (done * 10000 `div` totalN) / 100.0
+
+printFailure :: (TcCase, String) -> IO ()
+printFailure (tc, details) =
+  putStrLn
+    ( "FAIL "
+        <> caseId tc
+        <> " ["
+        <> caseCategory tc
+        <> "] "
+        <> details
+    )
+
+printXPass :: (TcCase, String) -> IO ()
+printXPass (tc, details) =
+  putStrLn
+    ( "XPASS "
+        <> caseId tc
+        <> " ["
+        <> caseCategory tc
+        <> "] "
+        <> details
+    )

--- a/components/aihc-tc/common/TcGolden.hs
+++ b/components/aihc-tc/common/TcGolden.hs
@@ -24,14 +24,14 @@ import Aihc.Parser
 import Aihc.Parser.Syntax (Extension, parseExtensionName)
 import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), renderTcType, typecheckModule)
 import Data.Aeson ((.!=), (.:), (.:?))
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort, sortOn)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Yaml as Y
+import Data.Text qualified as T
+import Data.Yaml qualified as Y
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
 

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -10,7 +10,7 @@ import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExp
 import Aihc.Parser.Syntax (Expr)
 import Aihc.Tc
 import Data.Text (Text)
-import qualified TcGolden as TG
+import TcGolden qualified as TG
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
 

--- a/docs/aihc-tc-supported-extensions.md
+++ b/docs/aihc-tc-supported-extensions.md
@@ -1,0 +1,13 @@
+# Type Checker Extension Support Status
+
+## Summary
+
+- Total Extensions: 1
+- Supported: 1
+- In Progress: 0
+
+## Extension Status
+
+| Extension  | Status | Tests Passing |
+|------------|:------:|---------------|
+| LambdaCase |   🟢    | 1/1           |

--- a/flake.nix
+++ b/flake.nix
@@ -727,6 +727,8 @@
       extensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "extension-progress";
       cppProgressExe = pkgs.lib.getExe' hsPkgs.aihc-cpp "cpp-progress";
       resolveProgressExe = pkgs.lib.getExe' hsPkgs.aihc-resolve "resolve-progress";
+      tcProgressExe = pkgs.lib.getExe' hsPkgs.aihc-tc "tc-progress";
+      tcExtensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-tc "tc-extension-progress";
       hackageTesterExe = pkgs.lib.getExe' hsPkgs.aihc-parser "hackage-tester";
       stackageProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "stackage-progress";
       aihcParserExe = pkgs.lib.getExe' hsPkgs.aihc-parser-cli "aihc-parser";
@@ -955,6 +957,46 @@
         }
         cd components/aihc-resolve
         ${resolveProgressExe} --strict "$@"
+      '';
+
+      tc-progress = mkApp "tc-progress" ''
+        set -euo pipefail
+        test -d components/aihc-tc || {
+          echo "Run this app from the repository root." >&2
+          exit 1
+        }
+        cd components/aihc-tc
+        ${tcProgressExe} "$@"
+      '';
+
+      tc-progress-strict = mkApp "tc-progress-strict" ''
+        set -euo pipefail
+        test -d components/aihc-tc || {
+          echo "Run this app from the repository root." >&2
+          exit 1
+        }
+        cd components/aihc-tc
+        ${tcProgressExe} --strict "$@"
+      '';
+
+      tc-test = mkApp "tc-test" ''
+        set -euo pipefail
+        test -d components/aihc-tc || {
+          echo "Run this app from the repository root." >&2
+          exit 1
+        }
+        cd components/aihc-tc
+        cabal test --test-show-details=direct
+      '';
+
+      tc-extension-progress = mkApp "tc-extension-progress" ''
+        set -euo pipefail
+        test -d components/aihc-tc || {
+          echo "Run this app from the repository root." >&2
+          exit 1
+        }
+        cd components/aihc-tc
+        ${tcExtensionProgressExe} "$@"
       '';
 
       generate-reports = mkReportsApp "generate-reports" ''

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -43,6 +43,8 @@ extension_markdown_cmd="${PARSER_EXTENSION_PROGRESS_CMD:-nix run .#parser-extens
 extension_progress_cmd="${PARSER_EXTENSION_PROGRESS_TEXT_CMD:-nix run .#parser-extension-progress}"
 cpp_cmd="${CPP_PROGRESS_CMD:-nix run .#cpp-progress}"
 resolve_cmd="${RESOLVE_PROGRESS_CMD:-nix run .#resolve-progress}"
+tc_cmd="${TC_PROGRESS_CMD:-nix run .#tc-progress}"
+tc_extension_markdown_cmd="${TC_EXTENSION_PROGRESS_CMD:-nix run .#tc-extension-progress}"
 stackage_cmd="${PARSER_STACKAGE_PROGRESS_CMD:-nix run .#stackage-progress -- --snapshot lts-24.33}"
 line_counts_cmd="${LINE_COUNTS_CMD:-nix run .#line-counts}"
 
@@ -58,6 +60,8 @@ extension_out="$tmpdir/extension-progress.md"
 extension_progress_out="$tmpdir/extension-progress.txt"
 cpp_out="$tmpdir/cpp-progress.txt"
 resolve_out="$tmpdir/resolve-progress.txt"
+tc_out="$tmpdir/tc-progress.txt"
+tc_extension_out="$tmpdir/tc-extension-progress.md"
 stackage_out="$tmpdir/stackage-progress.txt"
 line_counts_out="$tmpdir/line-counts.txt"
 
@@ -67,6 +71,8 @@ run_cmd "$extension_markdown_cmd" | sed -n '/^# Haskell Parser Extension Support
 run_cmd "$extension_progress_cmd" >"$extension_progress_out"
 run_cmd "$cpp_cmd" >"$cpp_out"
 run_cmd "$resolve_cmd" >"$resolve_out"
+run_cmd "$tc_cmd" >"$tc_out"
+run_cmd "$tc_extension_markdown_cmd" | sed -n '/^# Type Checker Extension Support Status/,$p' >"$tc_extension_out"
 run_cmd "$stackage_cmd" >"$stackage_out" || true
 run_cmd "$line_counts_cmd" >"$line_counts_out"
 
@@ -214,6 +220,18 @@ resolve_total="${resolve_vals[4]}"
 resolve_implemented="${resolve_vals[5]}"
 resolve_complete="${resolve_vals[6]}"
 
+tc_vals=($(parse_progress "$tc_out")) || {
+	echo "update-generated-content.sh: could not parse tc-progress summary (expected PASS/XFAIL/XPASS/FAIL/TOTAL/COMPLETE on stdout)." >&2
+	exit 2
+}
+tc_pass="${tc_vals[0]}"
+tc_xfail="${tc_vals[1]}"
+tc_xpass="${tc_vals[2]}"
+tc_fail="${tc_vals[3]}"
+tc_total="${tc_vals[4]}"
+tc_implemented="${tc_vals[5]}"
+tc_complete="${tc_vals[6]}"
+
 ext_vals=($(parse_extension_summary "$extension_out")) || {
 	echo "update-generated-content.sh: could not parse extension markdown summary (expected Total Extensions, Supported, In Progress lines after --markdown)." >&2
 	exit 2
@@ -263,6 +281,10 @@ EOF2
 
 cat >"$tmpdir/readme-root-resolve.txt" <<EOF2
 \`${resolve_implemented}/${resolve_total}\` (\`${resolve_complete}%\`)
+EOF2
+
+cat >"$tmpdir/readme-root-tc.txt" <<EOF2
+\`${tc_implemented}/${tc_total}\` (\`${tc_complete}%\`)
 EOF2
 
 cat >"$tmpdir/readme-parser-h2010.txt" <<EOF2
@@ -383,11 +405,21 @@ else
 	fi
 fi
 
+if [ "$mode" = "--update" ]; then
+	cp "$tc_extension_out" docs/aihc-tc-supported-extensions.md
+else
+	if ! cmp -s docs/aihc-tc-supported-extensions.md "$tc_extension_out"; then
+		echo "Generated file out of date: docs/aihc-tc-supported-extensions.md" >&2
+		stale=1
+	fi
+fi
+
 replace_marker_inline README.md "parser-progress" "$tmpdir/readme-root-parser.txt"
 replace_marker_inline README.md "lexer-progress" "$tmpdir/readme-root-lexer.txt"
 replace_marker_inline README.md "parser-stackage-progress" "$tmpdir/readme-root-stackage.txt"
 replace_marker_inline README.md "cpp-progress" "$tmpdir/readme-root-cpp.txt"
 replace_marker_inline README.md "resolve-progress" "$tmpdir/readme-root-resolve.txt"
+replace_marker_inline README.md "tc-progress" "$tmpdir/readme-root-tc.txt"
 replace_marker_block README.md "line-counts" "$line_counts_out"
 replace_marker_block components/aihc-parser/README.md "haskell2010-progress" "$tmpdir/readme-parser-h2010.txt"
 replace_marker_block components/aihc-parser/README.md "extension-progress" "$tmpdir/readme-parser-extension.txt"


### PR DESCRIPTION
Add tc-progress and tc-extension-progress executables that evaluate YAML golden test fixtures and output PASS/XFAIL/XPASS/FAIL/TOTAL/COMPLETE summaries. Wire them into the report generation pipeline.

## Changes

- **components/aihc-tc/app/tc-progress/Main.hs** — New executable that loads YAML golden test fixtures, evaluates each case, and outputs a standard progress summary
- **components/aihc-tc/app/tc-extension-progress/Main.hs** — Groups TC test cases by language extension and produces a markdown status table
- **docs/aihc-tc-supported-extensions.md** — Generated extension support report (analogous to docs/haskell-parser-extension-support.md)
- **scripts/update-generated-content.sh** — Added tc-progress command invocation, output parsing, README marker replacement, and TC extension markdown generation
- **flake.nix** — Added tc-progress, tc-progress-strict, tc-test, and tc-extension-progress apps
- **README.md** — Added TC Tests row to progress table, new commands to the Apps table, and links to aihc-tc docs

## Current Status

| Metric | Value |
|--------|-------|
| TC Tests | 6/6 (100.00%) |
| TC Extensions | 1/1 supported (LambdaCase) |

## New Commands

| Command | Description |
|---------|-------------|
| `nix run .#tc-test` | Run type checker test suite |
| `nix run .#tc-progress` | Show type checker test progress |
| `nix run .#tc-progress-strict` | Strict variant (XPASS treated as failure) |
| `nix run .#tc-extension-progress` | Show TC extension support markdown |