### PR TITLE
fix(parser): remove EWhereDecls from Expr, attach where-clauses to Rhs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -104,7 +104,6 @@ checkPattern expr = case expr of
   ELambdaPats {} -> Left "unexpected lambda in pattern"
   ELambdaCase {} -> Left "unexpected lambda-case in pattern"
   ELetDecls {} -> Left "unexpected let expression in pattern"
-  EWhereDecls {} -> Left "unexpected where clause in pattern"
   EArithSeq {} -> Left "unexpected arithmetic sequence in pattern"
   EListComp {} -> Left "unexpected list comprehension in pattern"
   EListCompParallel {} -> Left "unexpected parallel list comprehension in pattern"

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -46,32 +46,17 @@ exprParser =
 
 exprParserWithTypeSigParser :: TokParser Type -> TokParser Expr
 exprParserWithTypeSigParser typeSigParser =
-  label "expression" $ do
-    core <- exprCoreParserWithTypeSigParserExcept typeSigParser []
-    mWhere <- MP.optional whereClauseParser
-    pure $
-      case mWhere of
-        Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan core) (sourceSpanEnd decls)) core decls
-        Nothing -> core
+  label "expression" $
+    exprCoreParserWithTypeSigParserExcept typeSigParser []
 
 exprParserExcept :: [Text] -> TokParser Expr
-exprParserExcept forbiddenInfix = do
-  core <- exprCoreParserWithTypeSigParserExcept typeParser forbiddenInfix
-  mWhere <- MP.optional whereClauseParser
-  pure $
-    case mWhere of
-      Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan core) (sourceSpanEnd decls)) core decls
-      Nothing -> core
+exprParserExcept forbiddenInfix =
+  exprCoreParserWithTypeSigParserExcept typeParser forbiddenInfix
 
 exprParserNoTopLevelTypeSig :: TokParser Expr
 exprParserNoTopLevelTypeSig =
-  label "expression" $ do
-    core <- exprCoreParserWithoutTypeSigExcept []
-    mWhere <- MP.optional whereClauseParser
-    pure $
-      case mWhere of
-        Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan core) (sourceSpanEnd decls)) core decls
-        Nothing -> core
+  label "expression" $
+    exprCoreParserWithoutTypeSigExcept []
 
 exprCoreParserWithoutTypeSigExcept :: [Text] -> TokParser Expr
 exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
@@ -198,13 +183,8 @@ procExprParser = withSpan $ do
 -- command parser.
 exprParserNoArrowTail :: TokParser Expr
 exprParserNoArrowTail =
-  label "expression" $ do
-    core <- exprCoreParserNoArrowTail
-    mWhere <- MP.optional whereClauseParser
-    pure $
-      case mWhere of
-        Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan core) (sourceSpanEnd decls)) core decls
-        Nothing -> core
+  label "expression" $
+    exprCoreParserNoArrowTail
 
 exprCoreParserNoArrowTail :: TokParser Expr
 exprCoreParserNoArrowTail = do
@@ -569,7 +549,8 @@ unguardedRhsParser :: RhsArrowKind -> TokParser Rhs
 unguardedRhsParser arrowKind = withSpan $ do
   rhsArrowTok arrowKind
   body <- region (rhsContextText arrowKind) exprParser
-  pure (`UnguardedRhs` body)
+  whereDecls <- MP.optional whereClauseParser
+  pure (\span' -> UnguardedRhs span' body whereDecls)
 
 rhsContextText :: RhsArrowKind -> Text
 rhsContextText RhsArrowCase = "while parsing case alternative right-hand side"
@@ -578,7 +559,8 @@ rhsContextText RhsArrowEquation = "while parsing equation right-hand side"
 guardedRhssParser :: RhsArrowKind -> TokParser Rhs
 guardedRhssParser arrowKind = withSpan $ do
   grhss <- MP.some (guardedRhsParser arrowKind)
-  pure (`GuardedRhss` grhss)
+  whereDecls <- MP.optional whereClauseParser
+  pure (\span' -> GuardedRhss span' grhss whereDecls)
 
 guardedRhsParser :: RhsArrowKind -> TokParser GuardedRhs
 guardedRhsParser arrowKind = withSpan $ do
@@ -715,12 +697,8 @@ parenExprParser = withSpan $ do
                       let typed = case mTypeSig of
                             Just ty -> ETypeSig (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty)) withArrow ty
                             Nothing -> withArrow
-                      mWhere <- MP.optional whereClauseParser
-                      let expr' = case mWhere of
-                            Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan typed) (sourceSpanEnd decls)) typed decls
-                            Nothing -> typed
                       -- View pattern arrow: expr -> expr (inside parentheses)
-                      finalExpr <- maybeViewPattern expr'
+                      finalExpr <- maybeViewPattern typed
                       finishBoxed closeTok (Just finalExpr)
                 Just op -> do
                   mClose <- MP.optional (expectedTok closeTok)
@@ -752,12 +730,8 @@ parenExprParser = withSpan $ do
                           let typed = case mTypeSig of
                                 Just ty -> ETypeSig (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty)) withArrow ty
                                 Nothing -> withArrow
-                          mWhere <- MP.optional whereClauseParser
-                          let fullExpr = case mWhere of
-                                Just decls -> EWhereDecls (mergeSourceSpans (getSourceSpan typed) (sourceSpanEnd decls)) typed decls
-                                Nothing -> typed
                           -- View pattern arrow: expr -> expr (inside parentheses)
-                          finalExpr <- maybeViewPattern fullExpr
+                          finalExpr <- maybeViewPattern typed
                           finishBoxed closeTok (Just finalExpr)
       where
         parseSectionR forbidden = do
@@ -979,9 +953,10 @@ localTypeSigDeclsParser = do
       case names of
         [name] -> do
           rhsExpr <- exprParser
+          whereDecls <- MP.optional whereClauseParser
           let bindSpan = mergeSourceSpans sigSpan (getSourceSpan rhsExpr)
               pat = PTypeSig sigSpan (PVar sigSpan name) ty
-              rhs = UnguardedRhs bindSpan rhsExpr
+              rhs = UnguardedRhs bindSpan rhsExpr whereDecls
           pure [DeclValue bindSpan (PatternBind bindSpan pat rhs)]
         _ ->
           fail "local typed bindings with '=' require exactly one binder"
@@ -1004,14 +979,16 @@ localPatternDeclParser = withSpan $ do
   pat <- patternParser
   expectedTok TkReservedEquals
   rhsExpr <- exprParser
-  pure (\span' -> DeclValue span' (PatternBind span' pat (UnguardedRhs span' rhsExpr)))
+  whereDecls <- MP.optional whereClauseParser
+  pure (\span' -> DeclValue span' (PatternBind span' pat (UnguardedRhs span' rhsExpr whereDecls)))
 
 implicitParamDeclParser :: TokParser Decl
 implicitParamDeclParser = withSpan $ do
   name <- implicitParamNameParser
   expectedTok TkReservedEquals
   rhsExpr <- exprParser
-  pure (\span' -> DeclValue span' (PatternBind span' (PVar span' (mkUnqualifiedName NameVarId name)) (UnguardedRhs span' rhsExpr)))
+  whereDecls <- MP.optional whereClauseParser
+  pure (\span' -> DeclValue span' (PatternBind span' (PVar span' (mkUnqualifiedName NameVarId name)) (UnguardedRhs span' rhsExpr whereDecls)))
 
 varExprParser :: TokParser Expr
 varExprParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -50,8 +50,8 @@ exprParserWithTypeSigParser typeSigParser =
     exprCoreParserWithTypeSigParserExcept typeSigParser []
 
 exprParserExcept :: [Text] -> TokParser Expr
-exprParserExcept forbiddenInfix =
-  exprCoreParserWithTypeSigParserExcept typeParser forbiddenInfix
+exprParserExcept =
+  exprCoreParserWithTypeSigParserExcept typeParser
 
 exprParserNoTopLevelTypeSig :: TokParser Expr
 exprParserNoTopLevelTypeSig =
@@ -183,8 +183,7 @@ procExprParser = withSpan $ do
 -- command parser.
 exprParserNoArrowTail :: TokParser Expr
 exprParserNoArrowTail =
-  label "expression" $
-    exprCoreParserNoArrowTail
+  label "expression" exprCoreParserNoArrowTail
 
 exprCoreParserNoArrowTail :: TokParser Expr
 exprCoreParserNoArrowTail = do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -307,8 +307,8 @@ prettyPatSynWhere name (PatSynExplicitBidirectional matches) =
 prettyFunctionMatchLines :: UnqualifiedName -> Match -> [Doc ann]
 prettyFunctionMatchLines name match =
   case matchRhs match of
-    UnguardedRhs _ _ -> [prettyFunctionMatch name match]
-    GuardedRhss _ grhss ->
+    UnguardedRhs _ _ _ -> [prettyFunctionMatch name match]
+    GuardedRhss _ grhss mWhereDecls ->
       prettyFunctionHead name (matchHeadForm match) (matchPats match)
         : [ "  |"
               <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
@@ -316,6 +316,7 @@ prettyFunctionMatchLines name match =
               <+> prettyExprPrec 0 (guardedRhsBody grhs)
           | grhs <- grhss
           ]
+          <> [prettyWhereClause mWhereDecls | mWhereDecls /= Nothing]
 
 prettyFunctionMatch :: UnqualifiedName -> Match -> Doc ann
 prettyFunctionMatch name match =
@@ -340,12 +341,14 @@ prettyRhs :: Rhs -> Doc ann
 prettyRhs rhs =
   case rhs of
     -- For UnguardedRhs, nothing follows the expression, so no parens needed
-    UnguardedRhs _ expr -> "=" <+> prettyExprPrec 0 expr
+    UnguardedRhs _ expr whereDecls ->
+      "=" <+> prettyExprPrec 0 expr
+        <> prettyWhereClause whereDecls
     -- For GuardedRhss, multiple guards can follow, but brace-terminated
     -- expressions (do, case, \case) are safe. Open-ended expressions
     -- (if, lambda, let, where) could capture trailing guards with layout,
     -- but our pretty-printer doesn't use layout for guards.
-    GuardedRhss _ guards ->
+    GuardedRhss _ guards whereDecls ->
       hsep
         [ "|"
             <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
@@ -353,6 +356,12 @@ prettyRhs rhs =
             <+> prettyExprPrec 0 (guardedRhsBody grhs)
         | grhs <- guards
         ]
+        <> prettyWhereClause whereDecls
+
+prettyWhereClause :: Maybe [Decl] -> Doc ann
+prettyWhereClause Nothing = mempty
+prettyWhereClause (Just []) = " where" <+> braces mempty
+prettyWhereClause (Just decls) = " where" <+> braces (prettyInlineDecls decls)
 
 prettyType :: Type -> Doc ann
 prettyType = prettyTypePrec 0
@@ -1119,7 +1128,6 @@ prettyConstructorUName = prettyConstructorName . renderUnqualifiedName
 data ExprCtx
   = CtxInfixRhs Bool
   | CtxInfixLhs
-  | CtxWhereBody
   | CtxAppFun
   | -- | Last argument position in an application chain
     CtxAppArg
@@ -1139,7 +1147,6 @@ exprCtxPrec ctx expr =
       | isGreedyExpr expr -> 0
       | otherwise -> 1
     CtxInfixLhs -> 1
-    CtxWhereBody -> 0
     CtxAppFun -> 2
     CtxAppArg -> 3
     CtxAppArgNoParens -> 0 -- Precedence 0 so EIf/ECase/etc don't add parens
@@ -1154,16 +1161,11 @@ needsExprParens ctx expr =
         EInfix {} -> True
         ETypeSig {} -> True
         ENegate {} -> True
-        EWhereDecls {} -> True
         _ | protectOpenEnded && isOpenEnded expr -> True
         _ -> False
     CtxInfixLhs ->
       case expr of
         ETypeSig {} -> True
-        ENegate {} -> True
-        _ -> isOpenEnded expr
-    CtxWhereBody ->
-      case expr of
         ENegate {} -> True
         _ -> isOpenEnded expr
     CtxAppFun ->
@@ -1189,8 +1191,7 @@ needsExprParens ctx expr =
 
 -- | Check if an expression is a "block expression" that can appear without
 -- parentheses as a function argument when BlockArguments is enabled.
--- Note: EWhereDecls is NOT included because its where clause needs to be
--- clearly delimited when wrapping open-ended expressions.
+-- Where clauses are attached to Rhs, not to block expressions.
 isBlockExpr :: Expr -> Bool
 isBlockExpr = \case
   EIf {} -> True
@@ -1214,7 +1215,6 @@ isGreedyExpr = \case
   ELambdaPats {} -> True
   ELambdaCase {} -> True
   ELetDecls {} -> True
-  EWhereDecls {} -> True
   EDo {} -> True
   EProc {} -> True
   EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
@@ -1239,15 +1239,10 @@ isOpenEnded = \case
   EIf {} -> True
   ELambdaPats {} -> True
   ELetDecls {} -> True
-  EWhereDecls {} -> True
   EProc {} -> True
   EInfix _ _ _ rhs -> isOpenEnded rhs
   EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
   _ -> False
-
--- | Print the body of a where expression.
-prettyWhereBody :: Expr -> Doc ann
-prettyWhereBody = prettyExprIn CtxWhereBody
 
 -- | Print an expression used as the function in an application.
 prettyExprApp :: Expr -> Doc ann
@@ -1282,9 +1277,8 @@ prettyIfBranch :: Expr -> Doc ann
 prettyIfBranch expr =
   case expr of
     -- Branch delimiters handle most greedy expressions, but postfix forms like
-    -- type signatures and where-clauses need parens to stay inside the branch.
+    -- type signatures need parens to stay inside the branch.
     ETypeSig {} -> parens (prettyExprPrec 0 expr)
-    EWhereDecls {} -> parens (prettyExprPrec 0 expr)
     _ -> prettyExprPrec 0 expr
 
 -- | Flatten a left-nested application chain into (root, args).
@@ -1460,10 +1454,6 @@ prettyExprPrec prec expr =
         ESectionL {} -> prettyExprPrec 0 inner
         ESectionR {} -> prettyExprPrec 0 inner
         _ -> parens (prettyExprPrec 0 inner)
-    EWhereDecls _ body decls ->
-      parenthesize
-        (prec > 0)
-        (prettyWhereBody body <+> "where" <+> braces (prettyInlineDecls decls))
     EList _ values -> brackets (hsep (punctuate comma (map (prettyExprPrec 0) values)))
     ETuple _ tupleFlavor values ->
       prettyTupleBody
@@ -1510,8 +1500,10 @@ prettyBinding (name, value) =
 prettyCaseAlt :: CaseAlt -> Doc ann
 prettyCaseAlt (CaseAlt _ pat rhs) =
   case rhs of
-    UnguardedRhs _ expr -> prettyPattern pat <+> "->" <+> prettyExprPrec 0 expr
-    GuardedRhss _ grhss ->
+    UnguardedRhs _ expr whereDecls ->
+      prettyPattern pat <+> "->" <+> prettyExprPrec 0 expr
+        <> prettyWhereClause whereDecls
+    GuardedRhss _ grhss whereDecls ->
       hsep
         [ prettyPattern pat,
           hsep
@@ -1522,6 +1514,7 @@ prettyCaseAlt (CaseAlt _ pat rhs) =
             | grhs <- grhss
             ]
         ]
+        <> prettyWhereClause whereDecls
 
 prettyGuardQualifier :: GuardQualifier -> Doc ann
 prettyGuardQualifier qualifier =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -23,7 +23,7 @@ where
 
 import Aihc.Parser.Syntax
 import Data.Char (GeneralCategory (..), generalCategory)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Prettyprinter
@@ -307,7 +307,7 @@ prettyPatSynWhere name (PatSynExplicitBidirectional matches) =
 prettyFunctionMatchLines :: UnqualifiedName -> Match -> [Doc ann]
 prettyFunctionMatchLines name match =
   case matchRhs match of
-    UnguardedRhs _ _ _ -> [prettyFunctionMatch name match]
+    UnguardedRhs {} -> [prettyFunctionMatch name match]
     GuardedRhss _ grhss mWhereDecls ->
       prettyFunctionHead name (matchHeadForm match) (matchPats match)
         : [ "  |"
@@ -316,7 +316,7 @@ prettyFunctionMatchLines name match =
               <+> prettyExprPrec 0 (guardedRhsBody grhs)
           | grhs <- grhss
           ]
-          <> [prettyWhereClause mWhereDecls | mWhereDecls /= Nothing]
+          <> [prettyWhereClause mWhereDecls | isJust mWhereDecls]
 
 prettyFunctionMatch :: UnqualifiedName -> Match -> Doc ann
 prettyFunctionMatch name match =
@@ -342,7 +342,8 @@ prettyRhs rhs =
   case rhs of
     -- For UnguardedRhs, nothing follows the expression, so no parens needed
     UnguardedRhs _ expr whereDecls ->
-      "=" <+> prettyExprPrec 0 expr
+      "="
+        <+> prettyExprPrec 0 expr
         <> prettyWhereClause whereDecls
     -- For GuardedRhss, multiple guards can follow, but brace-terminated
     -- expressions (do, case, \case) are safe. Open-ended expressions
@@ -1501,7 +1502,9 @@ prettyCaseAlt :: CaseAlt -> Doc ann
 prettyCaseAlt (CaseAlt _ pat rhs) =
   case rhs of
     UnguardedRhs _ expr whereDecls ->
-      prettyPattern pat <+> "->" <+> prettyExprPrec 0 expr
+      prettyPattern pat
+        <+> "->"
+        <+> prettyExprPrec 0 expr
         <> prettyWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
       hsep

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -265,8 +265,10 @@ docMatchHeadForm headForm =
 docRhs :: Rhs -> Doc ann
 docRhs rhs =
   case rhs of
-    UnguardedRhs _ expr -> "UnguardedRhs" <+> parens (docExpr expr)
-    GuardedRhss _ grhss -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map docGuardedRhs grhss)))
+    UnguardedRhs _ expr Nothing -> "UnguardedRhs" <+> parens (docExpr expr)
+    UnguardedRhs _ expr (Just decls) -> "UnguardedRhs" <+> parens (docExpr expr) <+> "where" <+> brackets (hsep (punctuate comma (map docDecl decls)))
+    GuardedRhss _ grhss Nothing -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map docGuardedRhs grhss)))
+    GuardedRhss _ grhss (Just decls) -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map docGuardedRhs grhss))) <+> "where" <+> brackets (hsep (punctuate comma (map docDecl decls)))
 
 docGuardedRhs :: GuardedRhs -> Doc ann
 docGuardedRhs grhs =
@@ -669,7 +671,6 @@ docExpr expr =
     ERecordUpd _ base fields' -> "ERecordUpd" <+> parens (docExpr base) <+> braces (hsep (punctuate comma [docText fn <+> "=" <+> docExpr fv | (fn, fv) <- fields']))
     ETypeSig _ inner ty -> "ETypeSig" <+> parens (docExpr inner) <+> parens (docType ty)
     EParen _ inner -> "EParen" <+> parens (docExpr inner)
-    EWhereDecls _ body decls -> "EWhereDecls" <+> parens (docExpr body) <+> brackets (hsep (punctuate comma (map docDecl decls)))
     EList _ elems -> "EList" <+> brackets (hsep (punctuate comma (map docExpr elems)))
     ETuple _ tupleFlavor elems ->
       (if tupleFlavor == Boxed then "ETuple" else "ETupleUnboxed")

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -991,15 +991,15 @@ instance HasSourceSpan PatSynDecl where
   getSourceSpan = patSynDeclSpan
 
 data Rhs
-  = UnguardedRhs SourceSpan Expr
-  | GuardedRhss SourceSpan [GuardedRhs]
+  = UnguardedRhs SourceSpan Expr (Maybe [Decl])
+  | GuardedRhss SourceSpan [GuardedRhs] (Maybe [Decl])
   deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan Rhs where
   getSourceSpan rhs =
     case rhs of
-      UnguardedRhs span' _ -> span'
-      GuardedRhss span' _ -> span'
+      UnguardedRhs span' _ _ -> span'
+      GuardedRhss span' _ _ -> span'
 
 data GuardedRhs = GuardedRhs
   { guardedRhsSpan :: SourceSpan,
@@ -1597,7 +1597,6 @@ data Expr
   | ERecordUpd SourceSpan Expr [(Text, Expr)]
   | ETypeSig SourceSpan Expr Type
   | EParen SourceSpan Expr
-  | EWhereDecls SourceSpan Expr [Decl]
   | EList SourceSpan [Expr]
   | ETuple SourceSpan TupleFlavor [Maybe Expr]
   | EUnboxedSum SourceSpan Int Int Expr
@@ -1653,7 +1652,6 @@ instance HasSourceSpan Expr where
       ERecordUpd span' _ _ -> span'
       ETypeSig span' _ _ -> span'
       EParen span' _ -> span'
-      EWhereDecls span' _ _ -> span'
       EList span' _ -> span'
       ETuple span' _ _ -> span'
       EUnboxedSum span' _ _ _ -> span'

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -212,7 +212,7 @@ test_moduleParsesDecls =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case moduleDecls modu of
-          [ DeclValue _ (FunctionBind _ "x" [Match {matchPats = [], matchRhs = UnguardedRhs _ (EIf _ (EVar _ "y") (EVar _ "z") (EVar _ "w"))}])
+          [ DeclValue _ (FunctionBind _ "x" [Match {matchPats = [], matchRhs = UnguardedRhs _ (EIf _ (EVar _ "y") (EVar _ "z") (EVar _ "w")) _}])
             ] ->
               pure ()
           other ->
@@ -436,10 +436,7 @@ test_infixClassHeadParses =
 test_ifElseWhereBranchRoundtrip :: Assertion
 test_ifElseWhereBranchRoundtrip =
   let elseBranch =
-        EWhereDecls
-          span0
-          (ETypeSig span0 (ETuple span0 Boxed []) (TTuple span0 Boxed Unpromoted []))
-          []
+        ETypeSig span0 (ETuple span0 Boxed []) (TTuple span0 Boxed Unpromoted [])
       expectedDecl =
         DeclValue
           span0
@@ -450,7 +447,7 @@ test_ifElseWhereBranchRoundtrip =
                   { matchSpan = span0,
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [],
-                    matchRhs = UnguardedRhs span0 (EIf span0 (EVar span0 "b") (ETuple span0 Boxed []) elseBranch)
+                    matchRhs = UnguardedRhs span0 (EIf span0 (EVar span0 "b") (ETuple span0 Boxed []) elseBranch) Nothing
                   }
               ]
           )
@@ -805,8 +802,8 @@ test_overloadedLabelExprParses =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case moduleDecls modu of
-          [ DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EOverloadedLabel _ "typeUrl" "#typeUrl")}]),
-            DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EOverloadedLabel _ "The quick brown fox" "#\"The quick brown fox\"")}])
+          [ DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EOverloadedLabel _ "typeUrl" "#typeUrl") _}]),
+            DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EOverloadedLabel _ "The quick brown fox" "#\"The quick brown fox\"") _}])
             ] -> pure ()
           other -> assertFailure ("expected overloaded label expressions in AST, got: " <> show other)
 
@@ -894,7 +891,7 @@ parseDoStmts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EDo _ stmts _)}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EDo _ stmts _) _}])] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -907,7 +904,7 @@ parseDoStmtsExt exts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EDo _ stmts _)}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EDo _ stmts _) _}])] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1016,7 +1013,7 @@ parseGuards src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}]}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}] _}])] ->
             Right guards
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1027,7 +1024,7 @@ parseGuardsExt exts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}]}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}] _}])] ->
             Right guards
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1052,7 +1049,7 @@ test_prettyGuardLambdaRoundTrip = do
                   { matchSpan = span0,
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [PVar span0 "x"],
-                    matchRhs = UnguardedRhs span0 caseExpr
+                    matchRhs = UnguardedRhs span0 caseExpr Nothing
                   }
               ]
           )
@@ -1080,6 +1077,7 @@ test_prettyGuardLambdaRoundTrip = do
                           guardedRhsBody = EVar span0 "x"
                         }
                     ]
+                    Nothing
               }
           ]
       source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
@@ -1114,7 +1112,7 @@ test_prettyGuardLetFormatting = do
                                         span0
                                         [ DeclValue
                                             span0
-                                            (FunctionBind span0 "x" [Match span0 MatchHeadPrefix [] (UnguardedRhs span0 (EInt span0 1 "1"))])
+                                            (FunctionBind span0 "x" [Match span0 MatchHeadPrefix [] (UnguardedRhs span0 (EInt span0 1 "1") Nothing)])
                                         ]
                                         (EInfix span0 (EVar span0 "x") (qualifyName Nothing ">") (EInt span0 0 "0"))
                                     )
@@ -1122,6 +1120,7 @@ test_prettyGuardLetFormatting = do
                               guardedRhsBody = EVar span0 "n"
                             }
                         ]
+                        Nothing
                   }
               ]
           )
@@ -1191,7 +1190,7 @@ parseCompStmts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EListComp _ _ stmts)}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EListComp _ _ stmts) _}])] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1203,7 +1202,7 @@ parseCompStmtsExt exts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EListComp _ _ stmts)}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (EListComp _ _ stmts) _}])] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1277,7 +1276,7 @@ parseLetDecls src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case moduleDecls modu of
-          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (ELetDecls _ decls _)}])] ->
+          [DeclValue _ (FunctionBind _ _ [Match {matchRhs = UnguardedRhs _ (ELetDecls _ decls _) _}])] ->
             Right decls
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1338,7 +1337,7 @@ test_localDeclPatWild =
 test_localDeclFunGuarded :: Assertion
 test_localDeclFunGuarded =
   case parseLetDecls "let { f x | x > 0 = x } in f 1" of
-    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss _ _}])] -> pure ()
+    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss _ _ _}])] -> pure ()
     other -> assertFailure ("expected guarded function bind, got: " <> show other)
 
 -- Helper: parse a top-level declaration and extract the ValueDecl.

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1337,7 +1337,7 @@ test_localDeclPatWild =
 test_localDeclFunGuarded :: Assertion
 test_localDeclFunGuarded =
   case parseLetDecls "let { f x | x > 0 = x } in f 1" of
-    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss _ _ _}])] -> pure ()
+    Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss {}}])] -> pure ()
     other -> assertFailure ("expected guarded function bind, got: " <> show other)
 
 -- Helper: parse a top-level declaration and extract the ValueDecl.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/do-where-layout-multi.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/do-where-layout-multi.yaml
@@ -7,5 +7,5 @@ input: |
     where
       x = a
       y = b
-ast: Module {name = "DoWhereLayoutMulti", decls = [DeclValue (FunctionBind "testMulti" [Match {headForm = Prefix, pats = [PVar "a", PVar "b"], rhs = UnguardedRhs (EWhereDecls (EDo [DoExpr (EVar "x"), DoExpr (EVar "y")]) [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (EVar "a")}]), DeclValue (FunctionBind "y" [Match {headForm = Prefix, rhs = UnguardedRhs (EVar "b")}])])}])]}
+ast: Module {name = "DoWhereLayoutMulti", decls = [DeclValue (FunctionBind "testMulti" [Match {headForm = Prefix, pats = [PVar "a", PVar "b"], rhs = UnguardedRhs (EDo [DoExpr (EVar "x"), DoExpr (EVar "y")]) where [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (EVar "a")}]), DeclValue (FunctionBind "y" [Match {headForm = Prefix, rhs = UnguardedRhs (EVar "b")}])]}])]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/do-where-layout.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/do-where-layout.yaml
@@ -4,5 +4,5 @@ input: |
   testDoWhereLayout a = do
     action
     where action = a
-ast: Module {name = "DoWhereLayout", decls = [DeclValue (FunctionBind "testDoWhereLayout" [Match {headForm = Prefix, pats = [PVar "a"], rhs = UnguardedRhs (EWhereDecls (EDo [DoExpr (EVar "action")]) [DeclValue (FunctionBind "action" [Match {headForm = Prefix, rhs = UnguardedRhs (EVar "a")}])])}])]}
+ast: Module {name = "DoWhereLayout", decls = [DeclValue (FunctionBind "testDoWhereLayout" [Match {headForm = Prefix, pats = [PVar "a"], rhs = UnguardedRhs (EDo [DoExpr (EVar "action")]) where [DeclValue (FunctionBind "action" [Match {headForm = Prefix, rhs = UnguardedRhs (EVar "a")}])]}])]}
 status: pass

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -67,7 +67,7 @@ genFunctionDecl (name, expr) = do
                   { matchSpan = span0,
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [],
-                    matchRhs = UnguardedRhs span0 expr
+                    matchRhs = UnguardedRhs span0 expr Nothing
                   }
               ]
           )
@@ -91,7 +91,7 @@ genFunctionDecl (name, expr) = do
                   { matchSpan = span0,
                     matchHeadForm = MatchHeadInfix,
                     matchPats = [lhsPat, rhsPat],
-                    matchRhs = UnguardedRhs span0 expr
+                    matchRhs = UnguardedRhs span0 expr Nothing
                   }
               ]
           )
@@ -586,19 +586,19 @@ genTypeConName = do
 shrinkDecl :: Decl -> [Decl]
 shrinkDecl decl =
   case decl of
-    DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr)) ->
-      [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr')) | expr' <- shrinkExpr expr]
-    DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr}]) ->
+    DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr _)) ->
+      [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr' Nothing)) | expr' <- shrinkExpr expr]
+    DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr _}]) ->
       [ DeclValue
           span0
           ( FunctionBind
               span0
               name
-              [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr'}]
+              [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr' Nothing}]
           )
       | expr' <- shrinkExpr expr
       ]
-        <> [DeclValue span0 (FunctionBind span0 name' [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr}]) | name' <- shrinkUnqualifiedVarName name]
+        <> [DeclValue span0 (FunctionBind span0 name' [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr Nothing}]) | name' <- shrinkUnqualifiedVarName name]
     DeclTypeSig _ names ty ->
       [DeclTypeSig span0 names' ty | names' <- shrinkList shrinkBinderName names, not (null names')]
     _ -> []

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -330,7 +330,7 @@ genValueDeclsWith allowTHQuotes n = do
     ]
 
 genBindingExprWith :: Bool -> Int -> Gen Expr
-genBindingExprWith allowTHQuotes n = genExprSizedWith allowTHQuotes n
+genBindingExprWith = genExprSizedWith
 
 genDoStmtsWith :: Bool -> Int -> Gen [DoStmt Expr]
 genDoStmtsWith allowTHQuotes n = do

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -255,8 +255,8 @@ genCaseAltWith allowTHQuotes n = do
 genRhsWith :: Bool -> Int -> Gen Rhs
 genRhsWith allowTHQuotes n =
   oneof
-    [ UnguardedRhs span0 <$> genBindingExprWith allowTHQuotes n,
-      GuardedRhss span0 <$> genGuardedRhsListWith allowTHQuotes n
+    [ (\e -> UnguardedRhs span0 e Nothing) <$> genBindingExprWith allowTHQuotes n,
+      (\gs -> GuardedRhss span0 gs Nothing) <$> genGuardedRhsListWith allowTHQuotes n
     ]
 
 genGuardedRhsListWith :: Bool -> Int -> Gen [GuardedRhs]
@@ -322,7 +322,7 @@ genValueDeclsWith allowTHQuotes n = do
                 { matchSpan = span0,
                   matchHeadForm = MatchHeadPrefix,
                   matchPats = [],
-                  matchRhs = UnguardedRhs span0 expr
+                  matchRhs = UnguardedRhs span0 expr Nothing
                 }
             ]
         )
@@ -330,15 +330,7 @@ genValueDeclsWith allowTHQuotes n = do
     ]
 
 genBindingExprWith :: Bool -> Int -> Gen Expr
-genBindingExprWith allowTHQuotes n
-  | n <= 0 = genExprLeaf
-  | otherwise =
-      frequency
-        [ (4, genExprSizedWith allowTHQuotes n),
-          (1, EWhereDecls span0 <$> genExprSizedWith allowTHQuotes half <*> genValueDeclsWith allowTHQuotes half)
-        ]
-  where
-    half = n `div` 2
+genBindingExprWith allowTHQuotes n = genExprSizedWith allowTHQuotes n
 
 genDoStmtsWith :: Bool -> Int -> Gen [DoStmt Expr]
 genDoStmtsWith allowTHQuotes n = do
@@ -609,10 +601,6 @@ shrinkExpr expr =
       body
         : [ELetDecls span0 decls body' | body' <- shrinkExpr body]
           <> [ELetDecls span0 decls' body | decls' <- shrinkDecls decls, not (null decls')]
-    EWhereDecls _ body decls ->
-      body
-        : [EWhereDecls span0 body' decls | body' <- shrinkExpr body]
-          <> [EWhereDecls span0 body decls' | decls' <- shrinkDecls decls, not (null decls')]
     EDo _ stmts _ ->
       [EDo span0 stmts' False | stmts' <- shrinkDoStmts stmts, not (null stmts')]
     EListComp _ body stmts ->
@@ -665,12 +653,12 @@ shrinkCaseAlts = shrinkList shrinkCaseAlt
 shrinkCaseAlt :: CaseAlt -> [CaseAlt]
 shrinkCaseAlt alt =
   case caseAltRhs alt of
-    UnguardedRhs _ expr ->
-      [alt {caseAltRhs = UnguardedRhs span0 expr'} | expr' <- shrinkExpr expr]
-    GuardedRhss _ rhss ->
+    UnguardedRhs _ expr _ ->
+      [alt {caseAltRhs = UnguardedRhs span0 expr' Nothing} | expr' <- shrinkExpr expr]
+    GuardedRhss _ rhss _ ->
       -- Shrink to unguarded using the first guard's body
-      [alt {caseAltRhs = UnguardedRhs span0 (guardedRhsBody firstRhs)} | firstRhs : _ <- [rhss]]
-        <> [alt {caseAltRhs = GuardedRhss span0 rhss'} | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
+      [alt {caseAltRhs = UnguardedRhs span0 (guardedRhsBody firstRhs) Nothing} | firstRhs : _ <- [rhss]]
+        <> [alt {caseAltRhs = GuardedRhss span0 rhss' Nothing} | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
 
 shrinkGuardedRhs :: GuardedRhs -> [GuardedRhs]
 shrinkGuardedRhs grhs =
@@ -682,15 +670,15 @@ shrinkDecls = shrinkList shrinkLetDecl
 shrinkLetDecl :: Decl -> [Decl]
 shrinkLetDecl decl =
   case decl of
-    DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr)) ->
-      [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr')) | expr' <- shrinkExpr expr]
-    DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr}]) ->
+    DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr _)) ->
+      [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr' Nothing)) | expr' <- shrinkExpr expr]
+    DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr _}]) ->
       [ DeclValue
           span0
           ( FunctionBind
               span0
               name
-              [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr'}]
+              [match {matchSpan = span0, matchRhs = UnguardedRhs span0 expr' Nothing}]
           )
       | expr' <- shrinkExpr expr
       ]

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -42,7 +42,6 @@ normalizeExpr expr =
     ELambdaPats _ pats body -> ELambdaPats span0 (map normalizeLambdaPat pats) (normalizeExpr body)
     ELambdaCase _ alts -> ELambdaCase span0 (map normalizeCaseAlt alts)
     ELetDecls _ decls body -> ELetDecls span0 (map normalizeDecl decls) (normalizeExpr body)
-    EWhereDecls _ body decls -> EWhereDecls span0 (normalizeExpr body) (map normalizeDecl decls)
     EDo _ stmts isMdo -> EDo span0 (map normalizeDoStmt stmts) isMdo
     EListComp _ body stmts -> EListComp span0 (normalizeExpr body) (map normalizeCompStmt stmts)
     EListCompParallel _ body stmtss -> EListCompParallel span0 (normalizeExpr body) (map (map normalizeCompStmt) stmtss)
@@ -78,8 +77,8 @@ normalizeCaseAlt alt =
 normalizeRhs :: Rhs -> Rhs
 normalizeRhs rhs =
   case rhs of
-    UnguardedRhs _ body -> UnguardedRhs span0 (normalizeExpr body)
-    GuardedRhss _ guards -> GuardedRhss span0 (map normalizeGuardedRhs guards)
+    UnguardedRhs _ body mDecls -> UnguardedRhs span0 (normalizeExpr body) (fmap (map normalizeDecl) mDecls)
+    GuardedRhss _ guards mDecls -> GuardedRhss span0 (map normalizeGuardedRhs guards) (fmap (map normalizeDecl) mDecls)
 
 normalizeGuardedRhs :: GuardedRhs -> GuardedRhs
 normalizeGuardedRhs grhs =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -166,12 +166,22 @@ resolveMatch scope nextLocal match =
 resolveRhs :: Scope -> Int -> Rhs -> (Int, Rhs)
 resolveRhs scope nextLocal rhs =
   case rhs of
-    UnguardedRhs span' expr ->
+    UnguardedRhs span' expr mDecls ->
       let (nextLocal', expr') = resolveExpr scope nextLocal expr
-       in (nextLocal', UnguardedRhs span' expr')
-    GuardedRhss span' guardedRhss ->
+          (nextLocal'', mDecls') = resolveWhereDecls scope nextLocal' mDecls
+       in (nextLocal'', UnguardedRhs span' expr' mDecls')
+    GuardedRhss span' guardedRhss mDecls ->
       let (nextLocal', guardedRhss') = mapAccumL (resolveGuardedRhs scope) nextLocal guardedRhss
-       in (nextLocal', GuardedRhss span' guardedRhss')
+          (nextLocal'', mDecls') = resolveWhereDecls scope nextLocal' mDecls
+       in (nextLocal'', GuardedRhss span' guardedRhss' mDecls')
+
+resolveWhereDecls :: Scope -> Int -> Maybe [Decl] -> (Int, Maybe [Decl])
+resolveWhereDecls _ nextLocal Nothing = (nextLocal, Nothing)
+resolveWhereDecls scope nextLocal (Just decls) =
+  let (nextLocal', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal decls
+      scoped = unionScope localScope scope
+      (nextLocal'', decls') = resolveBoundDecls scoped binderAnnotations nextLocal' Map.empty decls
+   in (nextLocal'', Just decls')
 
 resolveGuardedRhs :: Scope -> Int -> GuardedRhs -> (Int, GuardedRhs)
 resolveGuardedRhs scope nextLocal guardedRhs =
@@ -244,12 +254,6 @@ resolveExpr scope nextLocal expr =
     EParen span' inner ->
       let (nextLocal', inner') = resolveExpr scope nextLocal inner
        in (nextLocal', EParen span' inner')
-    EWhereDecls span' inner decls ->
-      let (nextLocal', inner') = resolveExpr scope nextLocal inner
-          (nextLocal'', binderAnnotations, localScope) = allocateLocalDeclBinders nextLocal' decls
-          scoped = unionScope localScope scope
-          (nextLocal''', decls') = resolveBoundDecls scoped binderAnnotations nextLocal'' Map.empty decls
-       in (nextLocal''', EWhereDecls span' inner' decls')
     ETypeApp span' fun ty ->
       let (nextLocal', fun') = resolveExpr scope nextLocal fun
        in (nextLocal', ETypeApp span' fun' ty)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -299,18 +299,18 @@ withPatBindings ((name, ty) : rest) m =
 
 -- | Infer the type of a right-hand side expression.
 inferRhsExpr :: Rhs -> TcM (TcType, [Ct])
-inferRhsExpr (UnguardedRhs _sp expr) = inferExpr expr
-inferRhsExpr (GuardedRhss _sp _guards) = do
+inferRhsExpr (UnguardedRhs _sp expr _decls) = inferExpr expr
+inferRhsExpr (GuardedRhss _sp _guards _decls) = do
   ty <- freshMetaTv
   pure (ty, [])
 
 -- | Type-check a right-hand side (solving constraints immediately).
 tcRhs :: Rhs -> TcM TcType
-tcRhs (UnguardedRhs _sp expr) = do
+tcRhs (UnguardedRhs _sp expr _decls) = do
   (ty, cts) <- inferExpr expr
   _ <- solveConstraints cts
   pure ty
-tcRhs (GuardedRhss _sp _guards) =
+tcRhs (GuardedRhss _sp _guards _decls) =
   -- Guarded RHS not handled in MVP.
   freshMetaTv
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -202,8 +202,8 @@ resultType ty = ty
 
 -- | Infer the type of a right-hand side (for case alternatives).
 inferRhs :: Rhs -> TcM (TcType, [Ct])
-inferRhs (UnguardedRhs _sp expr) = inferExpr expr
-inferRhs (GuardedRhss _sp _guards) = do
+inferRhs (UnguardedRhs _sp expr _decls) = inferExpr expr
+inferRhs (GuardedRhss _sp _guards _decls) = do
   ty <- freshMetaTv
   pure (ty, [])
 

--- a/docs/unified-expr-pattern-parsing.md
+++ b/docs/unified-expr-pattern-parsing.md
@@ -167,7 +167,6 @@ checkPattern = \case
   ELambdaPats {}    -> Left "unexpected lambda in pattern"
   ELambdaCase {}    -> Left "unexpected lambda-case in pattern"
   ELetDecls {}      -> Left "unexpected let expression in pattern"
-  EWhereDecls {}    -> Left "unexpected where clause in pattern"
   EArithSeq {}      -> Left "unexpected arithmetic sequence in pattern"
   EListComp {}      -> Left "unexpected list comprehension in pattern"
   ESectionL {}      -> Left "unexpected left section in pattern"


### PR DESCRIPTION
## Summary

- Removes the `EWhereDecls` constructor from the `Expr` data type — there is no "where-expression" in Haskell; where-clauses are syntactically attached to bindings, not expressions
- Moves where-clause storage into `Rhs` as `Maybe [Decl]`: `Nothing` = no where clause, `Just []` = explicit empty `where {}`, `Just decls` = non-empty where clause
- Updates parser, pretty-printer, shorthand renderer, name resolver, type-checker, QuickCheck generators, and golden tests accordingly
- Fixes 3 oracle roundtrip test failures caused by `where {}` (empty where braces) being silently dropped

## Test plan

- [ ] All 4 test suites pass (`aihc-parser`, `aihc-resolve`, `aihc-tc`, `aihc-parser-cli`)
- [ ] Oracle tests for `empty-where`, `infix-funlhs-where-empty`, and `where-empty-braces` now roundtrip correctly
- [ ] QuickCheck roundtrip properties still hold