### PR TITLE
fix: default to Haskell98 when default-language is missing from cabal file

### DIFF
--- a/components/aihc-parser-cli/src/Aihc/Parser/Bench/Parsers.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Bench/Parsers.hs
@@ -31,6 +31,7 @@ import Aihc.Parser.Lex (readModuleHeaderExtensions)
 import Aihc.Parser.Lex qualified as AihcLex
 import Aihc.Parser.Syntax
   ( Extension (CPP),
+    LanguageEdition (Haskell98Edition),
     applyExtensionSetting,
     editionFromExtensionSettings,
     extensionName,
@@ -44,7 +45,7 @@ import Control.Monad (mplus)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -189,7 +190,8 @@ prepareSourceAndExtensionsWithCpp noCpp includeMap filePath cabalExts cppOptions
       headerEdition = editionFromExtensionSettings initialSettings
       cabalEdition = langName >>= parseLanguageEdition . T.pack
       initialEdition = headerEdition `mplus` cabalEdition
-      baseExts = maybe [] languageEditionExtensions initialEdition
+      -- Get base extensions for the edition, defaulting to Haskell98 per Cabal spec
+      baseExts = languageEditionExtensions (fromMaybe Haskell98Edition initialEdition)
       initialExtensions = foldr applyExtensionSetting baseExts initialSettings
       cppEnabled = CPP `elem` initialExtensions
       -- Preprocess if CPP is enabled and noCpp is False
@@ -201,7 +203,8 @@ prepareSourceAndExtensionsWithCpp noCpp includeMap filePath cabalExts cppOptions
       finalHeaderSettings = readModuleHeaderExtensions preprocessedSource
       finalSettings = cabalSettings <> finalHeaderSettings
       finalEdition = editionFromExtensionSettings finalSettings `mplus` (langName >>= parseLanguageEdition . T.pack)
-      finalBaseExts = maybe [] languageEditionExtensions finalEdition
+      -- Get base extensions for the edition, defaulting to Haskell98 per Cabal spec
+      finalBaseExts = languageEditionExtensions (fromMaybe Haskell98Edition finalEdition)
       finalExtensions = foldr applyExtensionSetting finalBaseExts finalSettings
    in (preprocessedSource, finalExtensions)
 
@@ -235,7 +238,8 @@ collectCppIncludes absFile cabalExts cppOptions langName deps source = do
       initialHeaderSettings = readModuleHeaderExtensions source
       initialSettings = cabalSettings <> initialHeaderSettings
       initialEdition = editionFromExtensionSettings initialSettings `mplus` (langName >>= parseLanguageEdition . T.pack)
-      baseExts = maybe [] languageEditionExtensions initialEdition
+      -- Get base extensions for the edition, defaulting to Haskell98 per Cabal spec
+      baseExts = languageEditionExtensions (fromMaybe Haskell98Edition initialEdition)
       initialExtensions = foldr applyExtensionSetting baseExts initialSettings
       cppEnabled = CPP `elem` initialExtensions
   if not cppEnabled

--- a/components/aihc-parser-cli/src/Aihc/Parser/Bench/Tarball.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Bench/Tarball.hs
@@ -39,6 +39,7 @@ import Aihc.Parser.Bench.Parsers (ParseResult (..), collectCppIncludes, parseWit
 import Aihc.Parser.Lex (readModuleHeaderExtensions)
 import Aihc.Parser.Syntax
   ( Extension (CPP),
+    LanguageEdition (Haskell98Edition),
     applyExtensionSetting,
     editionFromExtensionSettings,
     languageEditionExtensions,
@@ -55,7 +56,7 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Char (isAlphaNum)
 import Data.List (isPrefixOf, isSuffixOf)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
@@ -393,8 +394,8 @@ preprocessSource _pkg cabalExts cppOptions langName deps source =
       headerEdition = editionFromExtensionSettings allSettings
       cabalEdition = langName >>= parseLanguageEdition . T.pack
       effectiveEdition = headerEdition `mplus` cabalEdition
-      -- Get base extensions for the edition
-      baseExts = maybe [] languageEditionExtensions effectiveEdition
+      -- Get base extensions for the edition, defaulting to Haskell98 per Cabal spec
+      baseExts = languageEditionExtensions (fromMaybe Haskell98Edition effectiveEdition)
       -- Apply settings to get final extensions
       finalExtensions = foldr applyExtensionSetting baseExts allSettings
       cppEnabled = CPP `elem` finalExtensions

--- a/components/aihc-parser/app/hackage-tester/Main.hs
+++ b/components/aihc-parser/app/hackage-tester/Main.hs
@@ -131,7 +131,7 @@ processFile opts packageRoot info = do
   let source' = resultOutput preprocessed
       cppErrs = [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error]
       headerPragmas = readModuleHeaderPragmas source'
-      defaultEdition = fromMaybe Syntax.Haskell2010Edition (fileInfoLanguage info)
+      defaultEdition = fromMaybe Syntax.Haskell98Edition (fileInfoLanguage info)
       edition = fromMaybe defaultEdition (Syntax.headerLanguageEdition headerPragmas)
       extensionSettings = fileInfoExtensions info ++ Syntax.headerExtensionSettings headerPragmas
       ghcResult = GhcOracle.oracleModuleAstFingerprint file edition extensionSettings source'

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
@@ -157,7 +157,7 @@ checkFile parsers verbose packageRoot info = do
           else Just (T.intercalate "\n" cppErrors)
       -- Read module header pragmas to get any LANGUAGE pragma overrides
       headerPragmas = moduleHeaderPragmas source'
-      defaultEdition = fromMaybe Syntax.Haskell2010Edition (fileInfoLanguage info)
+      defaultEdition = fromMaybe Syntax.Haskell98Edition (fileInfoLanguage info)
       edition = fromMaybe defaultEdition (Syntax.headerLanguageEdition headerPragmas)
       -- Compute the effective extensions using unified extension handling
       extensionSettings = fileInfoExtensions info ++ Syntax.headerExtensionSettings headerPragmas


### PR DESCRIPTION
## Summary

When a `.cabal` file omits the `default-language` field, the Cabal specification defaults to Haskell98, not Haskell2010. This PR corrects the default in both the hackage-tester and stackage-progress file checkers.

## Changes

- `components/aihc-parser/app/hackage-tester/Main.hs`: Changed default language from `Haskell2010Edition` to `Haskell98Edition`
- `components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs`: Changed default language from `Haskell2010Edition` to `Haskell98Edition`

## Testing

- All existing tests pass (24 hackage-tester tests)
- Full test suite passes (`just check`)
- No test updates required since this only affects packages without explicit `default-language` in their `.cabal` files