### PR TITLE
test: add oracle xfail cases for exact-pi parser failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-no-space-after-dot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-no-space-after-dot.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail reason="lexer does not handle 'forall a.Floating' without space after dot" -}
+{-# LANGUAGE Haskell2010, ExplicitForAll, RankNTypes #-}
+module ForallNoSpaceAfterDot where
+
+data ExactPi = Approximate (forall a.Floating a => a)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail reason="type family equations with infix operator * not parsed correctly" -}
+{-# LANGUAGE GHC2021, DataKinds, TypeFamilies, TypeOperators, NoStarIsType #-}
+
+type family (a :: ExactPi') * (b :: ExactPi') :: ExactPi' where
+  'ExactPi z p q * 'ExactPi z' p' q' = 'ExactPi undefined undefined undefined


### PR DESCRIPTION
# Test: Add Oracle XFail Cases for exact-pi Parser Failures

## Summary

Add minimal oracle test cases covering parser failures discovered while testing the `exact-pi` package from Hackage.

## Parser Issues Covered

### 1. `forall` without space after dot (e.g., `forall a.Floating`)

**Affected files:** `ExplicitForAll/forall-no-space-after-dot.hs`

**Issue:** The lexer fails to tokenize `a.Floating` as two separate tokens (`a.` and `Floating`) when there's no space after the dot. This affects:
- Data constructor fields: `data ExactPi = Approximate (forall a.Floating a => a)`
- Type signatures: `approx1 :: (forall a.Floating a => a) -> ExactPi -> ExactPi`

**GHC behavior:** Accepts both `a.Floating` and `a. Floating` (treats them identically)
**aihc-parser behavior:** Rejects `a.Floating` with "unexpected 'forall' expecting pattern"

### 2. Type family equations with infix `*` operator

**Affected files:** `TypeFamilies/type-family-infix-star-equation.hs`

**Issue:** The parser doesn't handle infix operators in type family equations when using `NoStarIsType`. Example:

```haskell
type family (a :: ExactPi') * (b :: ExactPi') :: ExactPi' where
  'ExactPi z p q * 'ExactPi z' p' q' = 'ExactPi undefined undefined undefined
```

**GHC behavior:** Accepts with `NoStarIsType` enabled
**aihc-parser behavior:** Fails with "unexpected * expecting constructor operator or symbol"

## Test Coverage

- **New xfail cases:** 2
- **Previous xfail count:** 11
- **New xfail count:** 13
- **Pass count:** 800 (unchanged)
- **Completion rate:** 98.52% → 98.29% (slight decrease due to新增 xfail cases)

## Validation

All tests pass:
```bash
just check
# ✅ ormolu format check
# ✅ hlint
# ✅ All 1287 tests passed
```