### PR TITLE
test: add oracle xfail cases for hackage package parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/StrictData/lazy-field-annotation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/StrictData/lazy-field-annotation.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="lazy field annotation in data constructor not parsed" -}
+{-# LANGUAGE StrictData #-}
+
+module LazyFieldAnnotation where
+
+data MapF k v r = TipF | BinF Int k ~v r r

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-composition-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-composition-operator.hs
@@ -1,0 +1,16 @@
+{- ORACLE_TEST xfail reason="Unicode bullet operator not recognized by lexer" -}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeCompositionOperator where
+
+infixr 9 •
+(•) :: (b -> c) -> (a -> b) -> (a -> c)
+f • g = \x -> f (g x)
+
+data SpecificScreenNumber = SpecificScreenNumber Int
+
+fromSpecificScreenNumber :: SpecificScreenNumber -> Int
+fromSpecificScreenNumber = undefined
+
+instance Show SpecificScreenNumber where
+  show = fromSpecificScreenNumber • succ • show

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/view-pattern-case-alternative.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/view-pattern-case-alternative.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail reason="view patterns in case alternatives not parsed correctly" -}
+{-# LANGUAGE ViewPatterns #-}
+
+module ViewPatternCaseAlternative where
+
+anyIdx :: a -> Maybe Int
+anyIdx = undefined
+
+f :: [a] -> Int
+f x = case x of
+  [anyIdx -> Just i] -> i
+  _ -> 0


### PR DESCRIPTION
## Summary

Add three oracle test cases covering parser gaps discovered from hackage package testing.

## New Oracle Tests

| Package | Category | Test | Issue |
|---------|----------|------|-------|
| rank1dynamic | ViewPatterns | view-pattern-case-alternative | View patterns in case alternatives with list constructors |
| place-cursor-at | UnicodeSyntax | unicode-composition-operator | Unicode bullet operator (•) not recognized by lexer |
| yaya-containers | StrictData | lazy-field-annotation | Lazy `~` field annotations in data constructors |

## Test Details

### ViewPatterns/view-pattern-case-alternative
```haskell
f x = case x of
  [anyIdx -> Just i] -> i
  _ -> 0
```
**Parser gap:** View patterns (`anyIdx -> Just i`) inside case alternative patterns within list constructors are not parsed correctly.

### UnicodeSyntax/unicode-composition-operator
```haskell
infixr 9 •
(•) :: (b -> c) -> (a -> b) -> (a -> c)
f • g = \x -> f (g x)
```
**Parser gap:** The lexer doesn't recognize the Unicode bullet character `•` (U+2022) as a valid operator symbol. This is a lexical issue, not a parser issue.

### StrictData/lazy-field-annotation
```haskell
data MapF k v r = TipF | BinF Int k ~v r r
```
**Parser gap:** Lazy `~` field annotations in data constructor declarations are not parsed.

## Progress Counts
- Oracle tests: 812 → 815 (+3 xfail)
- Oracle completion: unchanged (all 3 are xfail)