### PR TITLE
test: add oracle xfail cases for hackage parser failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-cons-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-cons-continuation.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST xfail cons operator at start of line after case expression not parsed -}
+{-# LANGUAGE LambdaCase #-}
+
+module CaseConsContinuation where
+
+data E = A | B | C
+
+f :: E -> String
+f x =
+  case x of
+    A -> "a"
+    B -> "b"
+    C -> "c"
+  : "tail"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_arrow_type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_arrow_type.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail TemplateHaskell type quote with parenthesized arrow ''(->) not parsed -}
+{-# LANGUAGE LambdaCase, TemplateHaskellQuotes #-}
+
+module THQuoteArrowType where
+
+data Type = ArrowT | AppT Type Type
+
+headOfType :: Type -> Name
+headOfType = \case
+  ArrowT -> ''(->)
+  AppT t _ -> headOfType t

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-asterism.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-asterism.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Unicode operator ⁂ (U+2042 ASTERISM) not recognized as varsym -}
+module UnicodeOperatorAsterism where
+
+(⁂) :: Int -> Int -> Int
+(⁂) = (+)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-double-exclamation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-double-exclamation.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Unicode operator ‼ (U+203C DOUBLE EXCLAMATION MARK) not recognized as varsym -}
+module UnicodeOperatorDoubleExclamation where
+
+(‼) :: [a] -> Int -> a
+(‼) = (!!)


### PR DESCRIPTION
## Summary

Adds 4 oracle test cases (all `xfail`) for parse failures discovered via `hackage-tester` across three packages:

| Test | Package | Issue |
|---|---|---|
| `thq_arrow_type` | dependent-sum-template | `''(->)` in `\case` not parsed |
| `case-cons-continuation` | select-rpms | Cons operator `:` at start of line after case expression not parsed |
| `unicode-operator-asterism` | base-unicode-symbols | `⁂` (U+2042) not recognized as varsym |
| `unicode-operator-double-exclamation` | base-unicode-symbols | `‼` (U+203C) not recognized as varsym |

## Progress

- **Oracle tests:** 829 → 833 (+4 new xfail)
- All tests pass (`just check` green)