### PR TITLE
feat(tooling): add GHC bindist base API extractor

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,5 +5,6 @@ packages:
   components/aihc-resolve
   components/aihc-tc
   tooling/aihc-hackage
+  tooling/aihc-base-api
 
 tests: True

--- a/tooling/aihc-base-api/aihc-base-api.cabal
+++ b/tooling/aihc-base-api/aihc-base-api.cabal
@@ -1,0 +1,71 @@
+cabal-version:      3.8
+name:               aihc-base-api
+version:            0.1.0.0
+build-type:         Simple
+license:            Unlicense
+license-file:       ../../LICENSE
+author:             David Himmelstrup
+maintainer:         lemmih@gmail.com
+category:           Compilers
+synopsis:           Extract base API data from GHC interface files
+
+library
+  exposed-modules:
+      Aihc.BaseApi.Extractor
+  other-modules:
+      Aihc.BaseApi.Extractor.Bindist
+    , Aihc.BaseApi.Extractor.PackageConf
+  hs-source-dirs:   src
+  build-depends:
+      base >=4.16 && <5
+    , aeson
+    , containers
+    , directory
+    , filepath
+    , ghc
+    , optparse-applicative
+    , process
+    , text
+  ghc-options:      -Wall -Werror
+  default-language: GHC2021
+
+executable aihc-base-api
+  hs-source-dirs:   app
+  main-is:          Main.hs
+  build-depends:
+      base >=4.16 && <5
+    , aihc-base-api
+    , aeson
+    , bytestring
+    , filepath
+    , optparse-applicative
+    , text
+  ghc-options:      -Wall -Werror
+  default-language: GHC2021
+
+test-suite spec
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:
+      test
+    , src
+  main-is:          Spec.hs
+  other-modules:
+      Aihc.BaseApi.Extractor
+    , Test.Extractor.Suite
+    , Aihc.BaseApi.Extractor.Bindist
+    , Aihc.BaseApi.Extractor.PackageConf
+  build-depends:
+      base >=4.16 && <5
+    , aihc-base-api
+    , aeson
+    , bytestring
+    , containers
+    , directory
+    , filepath
+    , ghc
+    , process
+    , tasty
+    , tasty-hunit
+    , text
+  ghc-options:      -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  default-language: GHC2021

--- a/tooling/aihc-base-api/app/Main.hs
+++ b/tooling/aihc-base-api/app/Main.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Aihc.BaseApi.Extractor
+import Data.Aeson (encode)
+import Data.ByteString.Lazy qualified as BL
+import Options.Applicative
+import Data.Text (Text)
+
+data Cli = Cli
+  { cliGhcVersion :: !Text,
+    cliTarget :: !Text,
+    cliCacheDir :: !FilePath,
+    cliOutput :: !FilePath,
+    cliArchiveUrl :: !(Maybe Text)
+  }
+
+main :: IO ()
+main = do
+  cli <- execParser parserInfo
+  snapshot <-
+    extractBaseApi
+      ExtractOptions
+        { eoGhcVersion = cliGhcVersion cli,
+          eoTarget = cliTarget cli,
+          eoCacheDir = cliCacheDir cli,
+          eoArchiveUrl = cliArchiveUrl cli
+        }
+  BL.writeFile (cliOutput cli) (encode snapshot)
+
+parserInfo :: ParserInfo Cli
+parserInfo =
+  info (helper <*> cliParser) $
+    fullDesc
+      <> progDesc "Download a GHC bindist and extract base API data from interface files"
+
+cliParser :: Parser Cli
+cliParser =
+  Cli
+    <$> option str (long "ghc-version" <> metavar "VERSION")
+    <*> option str (long "target" <> metavar "TARGET")
+    <*> strOption (long "cache-dir" <> value ".cache/aihc-base-api" <> showDefault)
+    <*> strOption (long "output" <> value "base-api.json" <> showDefault)
+    <*> optional (option str (long "archive-url" <> metavar "URL"))

--- a/tooling/aihc-base-api/src/Aihc/BaseApi/Extractor.hs
+++ b/tooling/aihc-base-api/src/Aihc/BaseApi/Extractor.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.BaseApi.Extractor
+  ( ExtractOptions (..),
+    BaseApiSnapshot (..),
+    BaseApiModule (..),
+    BaseApiExport (..),
+    ExportKind (..),
+    extractBaseApi,
+    extractBaseApiFromPaths,
+  )
+where
+
+import Aihc.BaseApi.Extractor.Bindist
+import Aihc.BaseApi.Extractor.PackageConf
+import Control.Monad (forM)
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON)
+import Data.List (isPrefixOf, sortOn)
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC
+import GHC.Core.Class (className)
+import GHC.Core.ConLike (ConLike (..))
+import GHC.Core.DataCon (dataConDisplayType, dataConOrigTyCon)
+import GHC.Core.PatSyn (patSynSig)
+import GHC.Core.TyCon (isAlgTyCon, isDataFamilyTyCon)
+import GHC.Data.FastString (fsLit)
+import GHC.Types.Name (nameOccName)
+import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Utils.Outputable (Outputable, showSDocUnsafe, ppr)
+import System.Directory (listDirectory)
+import System.FilePath ((</>))
+import GHC.Generics (Generic)
+
+data ExtractOptions = ExtractOptions
+  { eoGhcVersion :: !Text,
+    eoTarget :: !Text,
+    eoCacheDir :: !FilePath,
+    eoArchiveUrl :: !(Maybe Text)
+  }
+  deriving (Eq, Show)
+
+data BaseApiSnapshot = BaseApiSnapshot
+  { snapshotSchemaVersion :: !Int,
+    snapshotGhcVersion :: !Text,
+    snapshotBaseVersion :: !Text,
+    snapshotPackageId :: !Text,
+    snapshotTarget :: !Text,
+    snapshotModules :: ![BaseApiModule]
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON BaseApiSnapshot
+
+data BaseApiModule = BaseApiModule
+  { apiModuleName :: !Text,
+    apiModuleExports :: ![BaseApiExport]
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON BaseApiModule
+
+data ExportKind
+  = ExportValue
+  | ExportConstructor
+  | ExportPattern
+  | ExportClass
+  | ExportType
+  | ExportNewtype
+  | ExportTypeSynonym
+  | ExportTypeFamily
+  deriving (Eq, Show, Generic)
+
+instance ToJSON ExportKind
+
+data BaseApiExport = BaseApiExport
+  { exportName :: !Text,
+    exportModule :: !Text,
+    exportKind :: !ExportKind,
+    exportSignature :: !(Maybe Text),
+    exportParent :: !(Maybe Text)
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON BaseApiExport
+
+extractBaseApi :: ExtractOptions -> IO BaseApiSnapshot
+extractBaseApi options = do
+  validateLocalCompilerVersion (eoGhcVersion options)
+  prepared <- downloadAndPrepareBindist (eoCacheDir options) (eoGhcVersion options) (eoTarget options) (eoArchiveUrl options)
+  extractBaseApiFromPaths (eoGhcVersion options) (eoTarget options) (preparedLibdir prepared) (preparedPackageDb prepared)
+
+extractBaseApiFromPaths :: Text -> Text -> FilePath -> FilePath -> IO BaseApiSnapshot
+extractBaseApiFromPaths ghcVersion target libdir packageDb = do
+  baseConf <- readBasePackageInfo packageDb
+  modules <- extractModules libdir baseConf
+  pure
+    BaseApiSnapshot
+      { snapshotSchemaVersion = 1,
+        snapshotGhcVersion = ghcVersion,
+        snapshotBaseVersion = basePackageVersion baseConf,
+        snapshotPackageId = basePackageId baseConf,
+        snapshotTarget = target,
+        snapshotModules = sortOn apiModuleName modules
+      }
+
+readBasePackageInfo :: FilePath -> IO BasePackageInfo
+readBasePackageInfo packageDb = do
+  entries <- listDirectory packageDb
+  case sortOn id [packageDb </> entry | entry <- entries, "base-" `isPrefixOf` entry, ".conf" `T.isSuffixOf` T.pack entry] of
+    [] -> fail ("could not find base package conf under " <> packageDb)
+    path : _ -> do
+      source <- T.pack <$> readFile path
+      either fail pure (parseBasePackageConf packageDb source)
+
+extractModules :: FilePath -> BasePackageInfo -> IO [BaseApiModule]
+extractModules libdir baseInfo =
+  runGhc (Just libdir) $ do
+    dflags <- getSessionDynFlags
+    _ <- setSessionDynFlags dflags
+    forM (baseExposedModules baseInfo) $ \modu -> do
+      moduleRef <- findModule (mkModuleName (T.unpack modu)) (Just (fsLit "base"))
+      maybeInfo <- getModuleInfo moduleRef
+      case maybeInfo of
+        Nothing -> liftIO (fail ("failed to load module info for " <> T.unpack modu))
+        Just info -> do
+          exports <- catMaybes <$> mapM lookupExport (modInfoExports info)
+          pure
+            BaseApiModule
+              { apiModuleName = modu,
+                apiModuleExports = sortOn exportName exports
+              }
+
+lookupExport :: Name -> Ghc (Maybe BaseApiExport)
+lookupExport name = do
+  lookupName name >>= \case
+    Nothing -> pure Nothing
+    Just thing -> pure (Just (toExport thing))
+
+toExport :: TyThing -> BaseApiExport
+toExport thing =
+  case thing of
+    AnId ident ->
+      BaseApiExport
+        { exportName = T.pack (getOccString ident),
+          exportModule = nameModuleText ident,
+          exportKind = ExportValue,
+          exportSignature = Just (renderType (idType ident)),
+          exportParent = T.pack . getOccString . className <$> isClassOpId_maybe ident
+        }
+    AConLike conLike ->
+      case conLike of
+        RealDataCon dataCon ->
+          BaseApiExport
+            { exportName = T.pack (getOccString dataCon),
+              exportModule = nameModuleText dataCon,
+              exportKind = ExportConstructor,
+              exportSignature = Just (renderType (dataConDisplayType True dataCon)),
+              exportParent = Just (T.pack (getOccString (dataConOrigTyCon dataCon)))
+            }
+        PatSynCon patSyn ->
+          let (_, reqTheta, _, provTheta, argTys, resultTy) = patSynSig patSyn
+              rendered =
+                T.intercalate
+                  " -> "
+                  (map renderType argTys <> [renderContext reqTheta provTheta resultTy])
+           in BaseApiExport
+                { exportName = T.pack (getOccString patSyn),
+                  exportModule = nameModuleText patSyn,
+                  exportKind = ExportPattern,
+                  exportSignature = Just rendered,
+                  exportParent = Nothing
+                }
+    ATyCon tyCon ->
+      BaseApiExport
+        { exportName = T.pack (getOccString tyCon),
+          exportModule = nameModuleText tyCon,
+          exportKind = tyConExportKind tyCon,
+          exportSignature = Just (renderType (tyConKind tyCon)),
+          exportParent = Nothing
+        }
+    ACoAxiom axiom ->
+      BaseApiExport
+        { exportName = T.pack (getOccString axiom),
+          exportModule = nameModuleText axiom,
+          exportKind = ExportTypeFamily,
+          exportSignature = Nothing,
+          exportParent = Nothing
+        }
+
+tyConExportKind :: TyCon -> ExportKind
+tyConExportKind tyCon
+  | isClassTyCon tyCon = ExportClass
+  | isTypeSynonymTyCon tyCon = ExportTypeSynonym
+  | isDataFamilyTyCon tyCon || isOpenFamilyTyCon tyCon || isFamilyTyCon tyCon = ExportTypeFamily
+  | isNewTyCon tyCon = ExportNewtype
+  | isAlgTyCon tyCon = ExportType
+  | otherwise = ExportType
+
+nameModuleText :: NamedThing a => a -> Text
+nameModuleText thing =
+  T.pack (moduleNameString (moduleName (nameModule (getName thing))))
+
+renderType :: Outputable a => a -> Text
+renderType = T.pack . showSDocUnsafe . ppr
+
+getOccString :: NamedThing a => a -> String
+getOccString = occNameString . nameOccName . getName
+
+renderContext :: [PredType] -> [PredType] -> Type -> Text
+renderContext reqTheta provTheta resultTy =
+  let constraints = reqTheta <> provTheta
+      body = renderType resultTy
+   in if null constraints
+        then body
+        else T.intercalate ", " (map renderType constraints) <> " => " <> body

--- a/tooling/aihc-base-api/src/Aihc/BaseApi/Extractor/Bindist.hs
+++ b/tooling/aihc-base-api/src/Aihc/BaseApi/Extractor/Bindist.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.BaseApi.Extractor.Bindist
+  ( PreparedBindist (..),
+    downloadAndPrepareBindist,
+    inferArchiveUrl,
+    validateLocalCompilerVersion,
+  )
+where
+
+import Control.Monad (unless, when)
+import Data.List (sortOn)
+import Data.Text (Text)
+import Data.Text qualified as T
+import System.Directory
+  ( createDirectoryIfMissing,
+    doesDirectoryExist,
+    doesFileExist,
+    findExecutable,
+    listDirectory,
+    makeAbsolute,
+  )
+import System.FilePath (takeDirectory, (</>))
+import System.Process (readProcess, readProcessWithExitCode)
+import System.Exit (ExitCode (..))
+
+data PreparedBindist = PreparedBindist
+  { preparedArchivePath :: !FilePath,
+    preparedRootDir :: !FilePath,
+    preparedLibdir :: !FilePath,
+    preparedPackageDb :: !FilePath
+  }
+  deriving (Eq, Show)
+
+downloadAndPrepareBindist :: FilePath -> Text -> Text -> Maybe Text -> IO PreparedBindist
+downloadAndPrepareBindist cacheDir ghcVersion target archiveUrl = do
+  createDirectoryIfMissing True cacheDir
+  curl <- requireProgram "curl"
+  tar <- requireProgram "tar"
+  let archivePath = cacheDir </> T.unpack ("ghc-" <> ghcVersion <> "-" <> target <> ".tar.xz")
+      unpackRoot = cacheDir </> T.unpack ("ghc-" <> ghcVersion <> "-" <> target <> "-unpacked")
+      url = maybe (inferArchiveUrl ghcVersion target) id archiveUrl
+  archiveExists <- doesFileExist archivePath
+  unless archiveExists $
+    runProgram curl ["-L", "--fail", "--output", archivePath, T.unpack url]
+  unpackExists <- doesDirectoryExist unpackRoot
+  unless unpackExists $ do
+    createDirectoryIfMissing True unpackRoot
+    runProgram tar ["-xf", archivePath, "-C", unpackRoot]
+  libdir <- findLibdir unpackRoot
+  packageDb <- findPackageDb libdir
+  pure
+    PreparedBindist
+      { preparedArchivePath = archivePath,
+        preparedRootDir = unpackRoot,
+        preparedLibdir = libdir,
+        preparedPackageDb = packageDb
+      }
+
+inferArchiveUrl :: Text -> Text -> Text
+inferArchiveUrl ghcVersion target =
+  "https://downloads.haskell.org/~ghc/"
+    <> ghcVersion
+    <> "/ghc-"
+    <> ghcVersion
+    <> "-"
+    <> target
+    <> ".tar.xz"
+
+validateLocalCompilerVersion :: Text -> IO ()
+validateLocalCompilerVersion requested = do
+  ghc <- requireProgram "ghc"
+  version <- fmap (T.strip . T.pack) (readProcess ghc ["--numeric-version"] "")
+  when (version /= requested) $
+    fail
+      ( "requested GHC "
+          <> T.unpack requested
+          <> " but local compiler is "
+          <> T.unpack version
+          <> "; the extractor currently requires a matching local GHC to read interfaces safely"
+      )
+
+requireProgram :: FilePath -> IO FilePath
+requireProgram name = do
+  mPath <- findExecutable name
+  maybe (fail ("required program not found: " <> name)) pure mPath
+
+runProgram :: FilePath -> [String] -> IO ()
+runProgram exe args = do
+  (exitCode, _stdout, stderr) <- readProcessWithExitCode exe args ""
+  case exitCode of
+    ExitSuccess -> pure ()
+    ExitFailure code ->
+      fail
+        ( unlines
+            [ "command failed: " <> unwords (exe : args),
+              "exit code: " <> show code,
+              stderr
+            ]
+        )
+
+findLibdir :: FilePath -> IO FilePath
+findLibdir unpackRoot = do
+  settingsFiles <- findFilesNamed "settings" unpackRoot
+  case sortOn length settingsFiles of
+    [] -> fail ("could not find GHC libdir under " <> unpackRoot)
+    path : _ -> makeAbsolute (takeDirectory path)
+
+findPackageDb :: FilePath -> IO FilePath
+findPackageDb libdir = do
+  let candidate = libdir </> "package.conf.d"
+  exists <- doesDirectoryExist candidate
+  if exists
+    then makeAbsolute candidate
+    else fail ("could not find package.conf.d under " <> libdir)
+
+findFilesNamed :: FilePath -> FilePath -> IO [FilePath]
+findFilesNamed target root = do
+  entries <- listDirectory root
+  fmap concat $
+    mapM
+      ( \entry -> do
+          let path = root </> entry
+          isDir <- doesDirectoryExist path
+          if isDir
+            then findFilesNamed target path
+            else pure [path | entry == target]
+      )
+      entries

--- a/tooling/aihc-base-api/src/Aihc/BaseApi/Extractor/PackageConf.hs
+++ b/tooling/aihc-base-api/src/Aihc/BaseApi/Extractor/PackageConf.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.BaseApi.Extractor.PackageConf
+  ( BasePackageInfo (..),
+    parseBasePackageConf,
+    splitExposedModules,
+    resolvePkgroot,
+  )
+where
+
+import Data.Char (isSpace)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import System.FilePath ((</>))
+
+data BasePackageInfo = BasePackageInfo
+  { basePackageId :: !Text,
+    basePackageVersion :: !Text,
+    baseExposedModules :: ![Text],
+    baseImportDirs :: ![FilePath]
+  }
+  deriving (Eq, Show)
+
+parseBasePackageConf :: FilePath -> Text -> Either String BasePackageInfo
+parseBasePackageConf pkgroot raw = do
+  let fields = parseFields raw
+      requiredField key =
+        maybe
+          (Left ("missing field: " <> T.unpack key))
+          Right
+          (Map.lookup key fields)
+  name <- requiredField "name"
+  if name /= "base"
+    then Left ("expected package name 'base', got " <> T.unpack name)
+    else do
+      packageId <- requiredField "id"
+      version <- requiredField "version"
+      exposedModules <- splitExposedModules <$> requiredField "exposed-modules"
+      importDirsField <- requiredField "import-dirs"
+      let importDirs =
+            [ resolvePkgroot pkgroot (T.unpack (T.strip dir))
+            | dir <- T.splitOn "," importDirsField,
+              not (T.null (T.strip dir))
+            ]
+      pure
+        BasePackageInfo
+          { basePackageId = packageId,
+            basePackageVersion = version,
+            baseExposedModules = exposedModules,
+            baseImportDirs = importDirs
+          }
+
+parseFields :: Text -> Map Text Text
+parseFields source =
+  finalize (foldl' step (Nothing, mempty) (T.lines source))
+  where
+    step (Nothing, acc) line
+      | T.null (T.strip line) = (Nothing, acc)
+      | isIndented line = (Nothing, acc)
+      | otherwise =
+          case T.breakOn ":" line of
+            (key, rest)
+              | T.null rest -> (Nothing, acc)
+              | otherwise -> (Just (T.strip key), Map.insert (T.strip key) (T.strip (T.drop 1 rest)) acc)
+    step (Just current, acc) line
+      | T.null line = (Just current, acc)
+      | isIndented line =
+          let appended = Map.findWithDefault "" current acc <> "\n" <> T.strip line
+           in (Just current, Map.insert current appended acc)
+      | otherwise =
+          case T.breakOn ":" line of
+            (key, rest)
+              | T.null rest -> (Nothing, acc)
+              | otherwise -> (Just (T.strip key), Map.insert (T.strip key) (T.strip (T.drop 1 rest)) acc)
+
+    finalize (_, acc) = acc
+
+    isIndented line =
+      case T.uncons line of
+        Just (c, _) -> isSpace c
+        Nothing -> False
+
+splitExposedModules :: Text -> [Text]
+splitExposedModules txt =
+  [ stripModuleQualification (T.strip modu)
+  | modu <- T.splitOn "," (T.replace "\n" " " txt),
+    not (T.null (T.strip modu))
+  ]
+
+stripModuleQualification :: Text -> Text
+stripModuleQualification modu =
+  case T.breakOn " from " modu of
+    (name, _) -> name
+
+resolvePkgroot :: FilePath -> FilePath -> FilePath
+resolvePkgroot pkgroot rawPath =
+  case stripPrefix "${pkgroot}" rawPath of
+    Just suffix -> pkgroot </> dropWhile (== '/') suffix
+    Nothing -> rawPath
+  where
+    stripPrefix prefix path =
+      if prefix == take (length prefix) path
+        then Just (drop (length prefix) path)
+        else Nothing

--- a/tooling/aihc-base-api/test/Spec.hs
+++ b/tooling/aihc-base-api/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Test.Tasty (defaultMain)
+import Test.Extractor.Suite (tests)
+
+main :: IO ()
+main = defaultMain tests

--- a/tooling/aihc-base-api/test/Test/Extractor/Suite.hs
+++ b/tooling/aihc-base-api/test/Test/Extractor/Suite.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Extractor.Suite
+  ( tests,
+  )
+where
+
+import Aihc.BaseApi.Extractor
+import Aihc.BaseApi.Extractor.PackageConf
+import Data.List (dropWhileEnd, find)
+import Data.Text qualified as T
+import System.Process (readProcess)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "aihc-base-api"
+    [ testCase "package conf parser handles pkgroot" test_parsePackageConf,
+      testCase "local extraction finds Prelude.id" test_extractLocalPreludeId
+    ]
+
+test_parsePackageConf :: IO ()
+test_parsePackageConf = do
+  let pkgroot = "/tmp/pkgdb"
+      conf =
+        T.unlines
+          [ "name: base",
+            "version: 4.20.2.0",
+            "id: base-4.20.2.0-754f",
+            "exposed-modules:",
+            "  Prelude, Data.Maybe, GHC.Num.Integer from ghc-bignum-1.3-8849:GHC.Num.Integer",
+            "import-dirs: ${pkgroot}/../lib/example-base"
+          ]
+  parsed <- either fail pure (parseBasePackageConf pkgroot conf)
+  assertEqual "version" "4.20.2.0" (basePackageVersion parsed)
+  assertEqual "modules" ["Prelude", "Data.Maybe", "GHC.Num.Integer"] (baseExposedModules parsed)
+  assertEqual "import dir" ["/tmp/pkgdb/../lib/example-base"] (baseImportDirs parsed)
+
+test_extractLocalPreludeId :: IO ()
+test_extractLocalPreludeId = do
+  ghcVersion <- T.strip . T.pack <$> readProcess "ghc" ["--numeric-version"] ""
+  libdir <- dropWhileEnd (== '\n') <$> readProcess "ghc" ["--print-libdir"] ""
+  packageDb <- dropWhileEnd (== '\n') <$> readProcess "ghc" ["--print-global-package-db"] ""
+  snapshot <- extractBaseApiFromPaths ghcVersion "local-test" libdir packageDb
+  let preludeModule = find ((== "Prelude") . apiModuleName) (snapshotModules snapshot)
+      idExport = preludeModule >>= find ((== "id") . exportName) . apiModuleExports
+  assertBool "Prelude module exists" (maybe False (const True) preludeModule)
+  assertBool "Prelude.id exists" (maybe False (const True) idExport)


### PR DESCRIPTION
## Summary
- add a standalone `aihc-base-api` tool that downloads a GHC bindist, locates the installed `base` package metadata, and extracts exported names and signatures from interface files via the GHC API
- emit a structured JSON snapshot tagged with the requested GHC version and the discovered `base` version
- cover package-conf parsing and a local extraction smoke test for `Prelude.id`

## Checks
- `cabal test -v0 aihc-base-api:spec --test-options=--hide-successes`
- `just check`
- `coderabbit review --prompt-only`

## Notes
- the current extractor still requires the locally installed `ghc` version to match `--ghc-version`, because it uses the local `ghc` library to interpret the downloaded interface files
