### PR TITLE
feat(parser): extend generator and fix pretty-printer for infix type syntax

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -12,7 +12,7 @@ import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (equationRhsParser, exprParser)
 import Aihc.Parser.Internal.Import (warningTextParser)
 import Aihc.Parser.Internal.Pattern (patternParser, simplePatternParser)
-import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeInfixOperatorParser, typeParser)
+import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind, pattern TkVarFamily, pattern TkVarPattern, pattern TkVarRole)
 import Aihc.Parser.Syntax
 import Control.Monad (when)
@@ -122,7 +122,7 @@ implicitSpliceDeclParser = withSpan $ do
 typeDeclarationParser :: TokParser Decl
 typeDeclarationParser = withSpan $ do
   expectedTok TkKeywordType
-  (typeName, typeParams) <- typeDeclHeadParser
+  (headForm, typeName, typeParams) <- typeDeclHeadParser
   nextTok <- anySingle
   case lexTokenKind nextTok of
     TkReservedDoubleColon -> do
@@ -140,6 +140,7 @@ typeDeclarationParser = withSpan $ do
           span'
           TypeSynDecl
             { typeSynSpan = span',
+              typeSynHeadForm = headForm,
               typeSynName = renderUnqualifiedName typeName,
               typeSynParams = typeParams,
               typeSynBody = body
@@ -831,7 +832,7 @@ dataDeclParser :: TokParser Decl
 dataDeclParser = withSpan $ do
   expectedTok TkKeywordData
   context <- contextPrefixDispatch
-  (typeName, typeParams) <- typeDeclHeadParser
+  (headForm, typeName, typeParams) <- typeDeclHeadParser
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
@@ -841,6 +842,7 @@ dataDeclParser = withSpan $ do
       span'
       DataDecl
         { dataDeclSpan = span',
+          dataDeclHeadForm = headForm,
           dataDeclContext = fromMaybe [] context,
           dataDeclName = typeName,
           dataDeclParams = typeParams,
@@ -870,7 +872,7 @@ typeDataDeclParser = withSpan $ do
   expectedTok TkKeywordType
   expectedTok TkKeywordData
   -- type data may not have a datatype context
-  (typeName, typeParams) <- typeDeclHeadParser
+  (headForm, typeName, typeParams) <- typeDeclHeadParser
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
@@ -881,6 +883,7 @@ typeDataDeclParser = withSpan $ do
       span'
       DataDecl
         { dataDeclSpan = span',
+          dataDeclHeadForm = headForm,
           dataDeclContext = [],
           dataDeclName = typeName,
           dataDeclParams = typeParams,
@@ -961,7 +964,7 @@ newtypeDeclParser :: TokParser Decl
 newtypeDeclParser = withSpan $ do
   expectedTok TkKeywordNewtype
   context <- contextPrefixDispatch
-  (typeName, typeParams) <- typeDeclHeadParser
+  (headForm, typeName, typeParams) <- typeDeclHeadParser
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
@@ -971,6 +974,7 @@ newtypeDeclParser = withSpan $ do
       span'
       NewtypeDecl
         { newtypeDeclSpan = span',
+          newtypeDeclHeadForm = headForm,
           newtypeDeclContext = fromMaybe [] context,
           newtypeDeclName = typeName,
           newtypeDeclParams = typeParams,
@@ -1075,11 +1079,13 @@ gadtPrefixBodyParser = do
 
 -- | Parse a potentially strict type for GADT prefix body: @!Type@ or @Type@
 -- This handles strictness annotations on both simple and complex (parenthesized) types.
+-- Uses 'typeInfixParser' so that infix type operators (e.g. @key := v@) are
+-- accepted as argument types without requiring parentheses.
 gadtBangTypeParser :: TokParser BangType
 gadtBangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
-  ty <- typeAppParser
+  ty <- typeInfixParser
   pure $ \span' ->
     BangType
       { bangSpan = span',
@@ -1096,20 +1102,20 @@ gadtResultTypeParser = typeParser
 declContextParser :: TokParser [Type]
 declContextParser = contextParserWith typeParser typeAtomParser
 
-typeDeclHeadParser :: TokParser (UnqualifiedName, [TyVarBinder])
+typeDeclHeadParser :: TokParser (TypeHeadForm, UnqualifiedName, [TyVarBinder])
 typeDeclHeadParser =
   MP.try infixDeclHeadParser <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
       params <- MP.many typeParamParser
-      pure (name, params)
+      pure (TypeHeadPrefix, name, params)
 
     infixDeclHeadParser = do
       lhs <- typeParamParser
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
       rhs <- typeParamParser
-      pure (op, [lhs, rhs])
+      pure (TypeHeadInfix, op, [lhs, rhs])
 
 typeSynonymOperatorParser :: TokParser Text
 typeSynonymOperatorParser =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -214,13 +214,14 @@ prettyDeclLines decl =
       ]
     DeclRoleAnnotation _ ann -> [prettyRoleAnnotation ann]
     DeclTypeSyn _ synDecl ->
-      [ hsep
-          [ "type",
-            prettyDeclHead [] (unqualifiedNameFromText (typeSynName synDecl)) (typeSynParams synDecl),
-            "=",
-            prettyType (typeSynBody synDecl)
-          ]
-      ]
+      let headDocs = case (typeSynHeadForm synDecl, typeSynParams synDecl) of
+            (TypeHeadInfix, [lhs, rhs]) ->
+              let name = typeSynName synDecl
+               in if isOperatorToken name
+                    then [pretty (tyVarBinderName lhs), pretty name, pretty (tyVarBinderName rhs)]
+                    else [pretty (tyVarBinderName lhs), "`" <> pretty name <> "`", pretty (tyVarBinderName rhs)]
+            _ -> [prettyDeclHead TypeHeadPrefix [] (unqualifiedNameFromText (typeSynName synDecl)) (typeSynParams synDecl)]
+       in [hsep (["type"] <> headDocs <> ["=", prettyType (typeSynBody synDecl)])]
     DeclData _ dataDecl -> [prettyDataDecl dataDecl]
     DeclTypeData _ dataDecl -> [prettyTypeDataDecl dataDecl]
     DeclNewtype _ newtypeDecl -> [prettyNewtypeDecl newtypeDecl]
@@ -389,8 +390,6 @@ needsTypeParens ctx ty =
         _ -> False
     CtxTypeAppArg ->
       case ty of
-        TApp _ (TApp _ (TCon _ op _) _) _
-          | isSymbolicTypeName op && renderName op /= "->" -> False
         TQuasiQuote {} -> False
         TApp {} -> True
         TForall {} -> True
@@ -631,7 +630,7 @@ prettyDataDecl :: DataDecl -> Doc ann
 prettyDataDecl decl =
   hsep
     ( [ "data",
-        prettyDeclHead (dataDeclContext decl) (dataDeclName decl) (dataDeclParams decl)
+        prettyDeclHead (dataDeclHeadForm decl) (dataDeclContext decl) (dataDeclName decl) (dataDeclParams decl)
       ]
         <> kindPart
         <> ctorPart
@@ -650,7 +649,7 @@ prettyTypeDataDecl :: DataDecl -> Doc ann
 prettyTypeDataDecl decl =
   hsep
     ( [ "type data",
-        prettyDeclHead (dataDeclContext decl) (dataDeclName decl) (dataDeclParams decl)
+        prettyDeclHead (dataDeclHeadForm decl) (dataDeclContext decl) (dataDeclName decl) (dataDeclParams decl)
       ]
         <> kindPart
         <> ctorPart
@@ -673,7 +672,7 @@ prettyNewtypeDecl :: NewtypeDecl -> Doc ann
 prettyNewtypeDecl decl =
   hsep
     ( [ "newtype",
-        prettyDeclHead (newtypeDeclContext decl) (newtypeDeclName decl) (newtypeDeclParams decl)
+        prettyDeclHead (newtypeDeclHeadForm decl) (newtypeDeclContext decl) (newtypeDeclName decl) (newtypeDeclParams decl)
       ]
         <> kindPart
         <> ctorPart
@@ -709,20 +708,16 @@ derivingPart (DerivingClause strategy classes viaTy parenthesized) =
     viaPart Nothing = []
     viaPart (Just ty) = ["via", prettyType ty]
 
-prettyDeclHead :: [Type] -> UnqualifiedName -> [TyVarBinder] -> Doc ann
-prettyDeclHead constraints name params =
+prettyDeclHead :: TypeHeadForm -> [Type] -> UnqualifiedName -> [TyVarBinder] -> Doc ann
+prettyDeclHead headForm constraints name params =
   hsep
     ( contextPrefix constraints
         <> prettyDeclHeadNameAndParams name params
     )
   where
-    -- Detect infix form: when name is an operator and there are exactly 2 params
-    prettyDeclHeadNameAndParams nm prms = case prms of
-      [lhs, rhs]
-        | isOperatorToken (renderUnqualifiedName nm) ->
-            [pretty (tyVarBinderName lhs), pretty nm, pretty (tyVarBinderName rhs)]
-        | otherwise ->
-            [prettyConstructorUName nm] <> map prettyTyVarBinder prms
+    prettyDeclHeadNameAndParams nm prms = case (headForm, prms) of
+      (TypeHeadInfix, [lhs, rhs]) ->
+        [pretty (tyVarBinderName lhs), pretty nm, pretty (tyVarBinderName rhs)]
       _ ->
         [prettyConstructorUName nm] <> map prettyTyVarBinder prms
 

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1198,6 +1198,7 @@ instance HasSourceSpan RoleAnnotation where
 
 data TypeSynDecl = TypeSynDecl
   { typeSynSpan :: SourceSpan,
+    typeSynHeadForm :: TypeHeadForm,
     typeSynName :: Text,
     typeSynParams :: [TyVarBinder],
     typeSynBody :: Type
@@ -1283,6 +1284,7 @@ instance HasSourceSpan DataFamilyInst where
 
 data DataDecl = DataDecl
   { dataDeclSpan :: SourceSpan,
+    dataDeclHeadForm :: TypeHeadForm,
     dataDeclContext :: [Type],
     dataDeclName :: UnqualifiedName,
     dataDeclParams :: [TyVarBinder],
@@ -1298,6 +1300,7 @@ instance HasSourceSpan DataDecl where
 
 data NewtypeDecl = NewtypeDecl
   { newtypeDeclSpan :: SourceSpan,
+    newtypeDeclHeadForm :: TypeHeadForm,
     newtypeDeclContext :: [Type],
     newtypeDeclName :: UnqualifiedName,
     newtypeDeclParams :: [TyVarBinder],

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-gadt-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-gadt-constraint.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail GADT constructor with type operator after constraint -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 module TypeLevelKVList where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -27,6 +27,7 @@ genDecl = sized $ \n ->
       genDeclFixity,
       genDeclRoleAnnotation,
       genDeclTypeSyn,
+      genDeclTypeSynInfix,
       genDeclData,
       genDeclTypeData,
       genDeclNewtype,
@@ -123,7 +124,19 @@ genDeclTypeSyn :: Gen Decl
 genDeclTypeSyn = do
   name <- genTypeConName
   params <- genSimpleTyVarBinders
-  DeclTypeSyn span0 . TypeSynDecl span0 name params <$> genSimpleType
+  DeclTypeSyn span0 . TypeSynDecl span0 TypeHeadPrefix name params <$> genSimpleType
+
+-- | Generate an infix type synonym, covering both symbolic operators
+-- (e.g. @type a :+: b = (a, b)@) and backtick-wrapped identifiers
+-- (e.g. @type a \`Plus\` b = (a, b)@).
+genDeclTypeSynInfix :: Gen Decl
+genDeclTypeSynInfix = do
+  name <- oneof [genConSymName, genTypeConName]
+  lhsName <- genIdent
+  rhsName <- genIdent
+  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
+      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+  DeclTypeSyn span0 . TypeSynDecl span0 TypeHeadInfix name [lhs, rhs] <$> genSimpleType
 
 genDeclData :: Gen Decl
 genDeclData =
@@ -141,6 +154,7 @@ genDeclDataGadt = do
     DeclData span0 $
       DataDecl
         { dataDeclSpan = span0,
+          dataDeclHeadForm = TypeHeadPrefix,
           dataDeclContext = [],
           dataDeclName = name,
           dataDeclParams = params,
@@ -161,6 +175,7 @@ genDeclTypeDataPrefix = do
     DeclTypeData span0 $
       DataDecl
         { dataDeclSpan = span0,
+          dataDeclHeadForm = TypeHeadPrefix,
           dataDeclContext = [],
           dataDeclName = name,
           dataDeclParams = params,
@@ -188,6 +203,7 @@ genSimpleDataDecl = do
   pure $
     DataDecl
       { dataDeclSpan = span0,
+        dataDeclHeadForm = TypeHeadPrefix,
         dataDeclContext = [],
         dataDeclName = name,
         dataDeclParams = params,
@@ -215,35 +231,28 @@ genPrefixCon = do
   name <-
     oneof
       [ mkUnqualifiedName NameConId <$> genTypeConName,
-        mkUnqualifiedName NameConSym <$> genPrefixSymConName
+        mkUnqualifiedName NameConSym <$> genConSymName
       ]
   n <- chooseInt (0, 2)
   fields <- vectorOf n genSimpleBangType
   pure $ PrefixCon span0 [] [] name fields
-
--- | Generate symbolic names for prefix constructors: colon followed by symbols.
--- Examples: :+, :*, :==
-genPrefixSymConName :: Gen Text
-genPrefixSymConName = do
-  symLen <- chooseInt (1, 3)
-  syms <- vectorOf symLen (elements ['+', '*', '-', '=', '!', '<', '>', '&', '|'])
-  pure (T.pack (':' : syms))
 
 genInfixCon :: Gen DataConDecl
 genInfixCon = do
   -- Infix constructors can be symbolic (:+) or alphabetic (`Cons`)
   opName <-
     oneof
-      [ mkUnqualifiedName NameConSym <$> genInfixSymConName,
+      [ mkUnqualifiedName NameConSym <$> genConSymName,
         mkUnqualifiedName NameConId <$> genTypeConName
       ]
   lhs <- genSimpleBangTypeWithoutFun
   InfixCon span0 [] [] lhs opName <$> genSimpleBangTypeWithoutFun
 
--- | Generate infix symbolic constructor names: colon followed by at least one symbol.
--- Examples: :+, :*, :==, :->, :||
-genInfixSymConName :: Gen Text
-genInfixSymConName = do
+-- | Generate constructor symbol names: colon followed by 1–3 symbol characters.
+-- Valid for both type-level and value-level constructor operators.
+-- Examples: @:+@, @:*@, @:==@, @:+:@
+genConSymName :: Gen Text
+genConSymName = do
   symLen <- chooseInt (1, 3)
   syms <- vectorOf symLen (elements ['+', '*', '-', '=', '!', '<', '>', '&', '|'])
   pure (T.pack (':' : syms))
@@ -281,10 +290,27 @@ genGadtBody =
 genGadtPrefixBody :: Gen GadtBody
 genGadtPrefixBody = do
   n <- chooseInt (0, 2)
-  -- Use simple types (not function types) for GADT args to avoid ambiguity
-  args <- vectorOf n genSimpleBangTypeWithoutFun
-  -- Result type should also not be a function type to avoid parsing ambiguity
+  args <- vectorOf n (oneof [genSimpleBangType, genInfixBangType])
+  -- Result type should not be a function type to avoid parsing ambiguity
   GadtPrefixBody args <$> genSimpleTypeWithoutFun
+
+-- | Generate an infix type operator application as a bang type,
+-- e.g. @a :+: b@ or @a :== b@.
+genInfixBangType :: Gen BangType
+genInfixBangType = do
+  lhs <- genSimpleTypeWithoutFun
+  op <- genConSymName
+  rhs <- genSimpleTypeWithoutFun
+  let ty =
+        TApp
+          span0
+          ( TApp
+              span0
+              (TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConSym op)) Unpromoted)
+              lhs
+          )
+          rhs
+  pure $ BangType span0 NoSourceUnpackedness False ty
 
 -- | Generate a BangType without function types at the top level.
 genSimpleBangTypeWithoutFun :: Gen BangType
@@ -333,6 +359,7 @@ genDeclNewtype = do
     DeclNewtype span0 $
       NewtypeDecl
         { newtypeDeclSpan = span0,
+          newtypeDeclHeadForm = TypeHeadPrefix,
           newtypeDeclContext = [],
           newtypeDeclName = name,
           newtypeDeclParams = params,

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -286,6 +286,7 @@ normalizeTypeSynDecl :: TypeSynDecl -> TypeSynDecl
 normalizeTypeSynDecl decl =
   TypeSynDecl
     { typeSynSpan = span0,
+      typeSynHeadForm = typeSynHeadForm decl,
       typeSynName = typeSynName decl,
       typeSynParams = map normalizeTyVarBinder (typeSynParams decl),
       typeSynBody = normalizeType (typeSynBody decl)
@@ -295,6 +296,7 @@ normalizeDataDecl :: DataDecl -> DataDecl
 normalizeDataDecl decl =
   DataDecl
     { dataDeclSpan = span0,
+      dataDeclHeadForm = dataDeclHeadForm decl,
       dataDeclContext = map normalizeType (dataDeclContext decl),
       dataDeclName = dataDeclName decl,
       dataDeclParams = map normalizeTyVarBinder (dataDeclParams decl),
@@ -307,6 +309,7 @@ normalizeNewtypeDecl :: NewtypeDecl -> NewtypeDecl
 normalizeNewtypeDecl decl =
   NewtypeDecl
     { newtypeDeclSpan = span0,
+      newtypeDeclHeadForm = newtypeDeclHeadForm decl,
       newtypeDeclContext = map normalizeType (newtypeDeclContext decl),
       newtypeDeclName = newtypeDeclName decl,
       newtypeDeclParams = map normalizeTyVarBinder (newtypeDeclParams decl),


### PR DESCRIPTION
## Summary

- Extend the QuickCheck generator (`Arb/Decl.hs`) to produce four previously-missing syntactic forms: infix type synonyms with symbolic operators (`type a ~> b = ...`), backtick identifiers (`type a \`Plus\` b = ...`), GADT constructors with function-type args, and GADT constructors with infix type operator args
- Fix parser bug: `gadtBangTypeParser` was using `typeAppParser` (no infix support) instead of `typeInfixParser`, preventing parsing of `key := v` in GADT constructor arguments
- Fix pretty-printer: `needsTypeParens CtxTypeAppArg` incorrectly returned `False` for infix operator types (e.g. `KVList (key := v ': xs)` would lose required parens around the arg)
- Fix pretty-printer: `prettyDeclHead` used an operator-name heuristic to pick prefix vs infix form, incorrectly printing `data (:=) key v` as `data key := v`. Fixed by threading `TypeHeadForm` through `DataDecl`, `NewtypeDecl`, and `TypeSynDecl`
- Promote oracle xfail `TypeOperators/type-operator-gadt-constraint` to pass

## Test plan

- [ ] All 1287 tests pass (`cabal test aihc-parser`)
- [ ] Oracle summary shows `pass=799 xfail=11 xpass=0 fail=0`
- [ ] `prop_declPrettyRoundTrip` exercises new infix type synonym and GADT argument forms