### PR TITLE
test: add oracle xfail cases for hackage package parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Declarations/guarded-where-tuple-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Declarations/guarded-where-tuple-pattern.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="guarded patterns with tuple patterns in where clauses not parsed" -}
+{-# LANGUAGE Haskell2010 #-}
+
+module GuardedWhereTuplePattern where
+
+-- Parser fails to handle guarded patterns with tuple patterns in where clauses
+f :: Int -> Int
+f x = y where
+  (a,b) | x <= 0 = (0,1)
+        | otherwise = (1,0)
+  y = a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/type-synonym-implicit-param.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/type-synonym-implicit-param.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail reason="implicit parameter syntax in type synonyms not recognized" -}
+{-# LANGUAGE Haskell2010, ImplicitParams, ConstraintKinds #-}
+
+-- Parser fails on implicit parameter syntax in type synonyms
+type CanCheck = (?checker :: Int)
+
+f :: CanCheck => Int
+f = ?checker

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/cons-pattern-nested-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/cons-pattern-nested-parens.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail reason="roundtrip adds extra parentheses around nested cons patterns" -}
+{-# LANGUAGE Haskell2010 #-}
+
+-- Roundtrip fails: parser adds extra parentheses around nested cons patterns
+f xs = go xs where
+  go (x1:x2:xs) = (x1, x2) : go (x2:xs)
+  go [x] = []
+  go _ = []

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-let.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-let.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail reason="explicit semicolons followed by let in do notation not parsed" -}
+{-# LANGUAGE Haskell2010 #-}
+
+-- Parser fails on explicit semicolons followed by let in do notation
+f = do
+  ;let x = 1
+  ;x


### PR DESCRIPTION
Add oracle xfail test cases for parser failures found in three Hackage packages.

## Summary

Found and minimized parse failures from real-world Hackage packages, creating regression test fixtures for each:

### 1. **testing-feat** - Guarded Patterns with Tuple Patterns
Parser fails to handle guarded patterns when the pattern is a tuple in a `where` clause.
```haskell
f x = y where
  (a,b) | x <= 0 = (0,1)
        | otherwise = (1,0)
  y = a
```

### 2. **hgal** - Explicit Semicolons with Let in Do Notation  
Parser doesn't accept `let` statements after explicit semicolons in do-notation (valid Haskell2010).
```haskell
f = do
  ;let x = 1
  ;x
```

### 3. **hgal** - Nested Cons Pattern Parenthesization (Roundtrip)
Parser accepts the code but roundtrip pretty-printing changes parenthesization of nested cons patterns.
```haskell
f xs = go xs where
  go (x1:x2:xs) = (x1, x2) : go (x2:xs)
  go [x] = []
  go _ = []
```

### 4. **tasty-checklist** - Implicit Parameters in Type Synonyms
Parser doesn't recognize implicit parameter syntax (`?name`) in type synonym definitions.
```haskell
type CanCheck = (?checker :: Int)

f :: CanCheck => Int
f = ?checker
```

## Test Results

All fixtures marked as `xfail` with descriptive reasons. Tests pass locally with `just check`.

**Progress:** 4 new parser gaps identified and documented for future fixes.