### PR TITLE
test: add oracle xfail cases for hackage parser failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/BangPatterns/bang-let-guarded.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/BangPatterns/bang-let-guarded.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail bang pattern with guards in let binding -}
+{-# LANGUAGE BangPatterns #-}
+module BangPatternsLetGuarded where
+
+test :: Bool -> Int
+test positive =
+  let !x | True = 1
+  in x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-double-dot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-double-dot.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail double-dot in export list with pattern synonyms -}
+{-# LANGUAGE PatternSynonyms #-}
+module PatternSynonymsExportDoubleDot
+  ( X
+      ( A,
+        B,
+        ..
+      ),
+  )
+where
+
+data X = A | B


### PR DESCRIPTION
## Summary

Adds two oracle test fixtures (xfail) derived from hackage package parse failures:

### PatternSynonyms/pattern-synonyms-export-double-dot
- **Source**: gogol-fonts package
- **Issue**: Double-dot (`..`) in export lists with pattern synonyms is not recognized by the parser
- **Minimal repro**: Export list with `( A, B, .. )` syntax

### BangPatterns/bang-let-guarded
- **Source**: attoparsec-aeson package
- **Issue**: Bang patterns combined with guards in `let` bindings fail to parse
- **Minimal repro**: `let !x | True = 1 in x`

### indexed-profunctors
The indexed-profunctors package (`#.` and `.#` operators) now parses successfully with the current parser version - no fixture needed.