### PR TITLE
test(oracle): add regression tests for c-struct and reactive-balsa parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/do-where-after-module.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/do-where-after-module.hs
@@ -1,0 +1,18 @@
+{- ORACLE_TEST xfail reason="TH name quote of empty list constructor in where clause causes layout parser to reject subsequent function definition" -}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Foreign.C.Struct.Ord where
+
+import Language.Haskell.TH
+
+f xs = do
+	cr <- newName "checkResult"
+	letE [valD (varP cr) (normalB $ g cr) []]
+		undefined
+
+g fn = do
+	x <- newName "x"
+	undefined
+	where
+	h = '[]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/identifiers/pattern-keyword.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/identifiers/pattern-keyword.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail reason="'pattern' treated as reserved keyword but should be valid identifier in Haskell2010 without PatternSynonyms" -}
+module PatternAsIdentifier where
+
+pattern :: Int -> Int
+pattern x = x


### PR DESCRIPTION
## Summary

Added two oracle test fixtures from real Hackage parse failures:

### 1. `haskell2010/identifiers/pattern-keyword` (reactive-balsa)

`pattern` is incorrectly treated as a reserved keyword even without the `PatternSynonyms` extension enabled. In Haskell2010, `pattern` should be a valid identifier.

**Source:** `reactive-balsa-0.4.0.1`, `Reactive/Banana/ALSA/Example.hs`

### 2. `LambdaCase/do-where-after-module` (c-struct)

The layout parser rejects a function with a `do`-`where` clause when preceded by other `do` blocks under `LambdaCase` + `TemplateHaskell`.

**Source:** `c-struct-0.1.3.0`, `Foreign/C/Struct/Ord.hs`

### Note on RoundingFiasco

The RoundingFiasco binary literal parse failure could not be reduced to a minimal oracle test case. The original file fails in aihc-parser but GHC's behavior differs when extensions are passed explicitly vs. read from file pragmas, making it unsuitable for the oracle test framework.