### PR TITLE
test(parser): use full type generator for standalone kind signatures

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -13,6 +13,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Expr (genExpr, shrinkExpr, span0)
 import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Arb.Type (canonicalTopLevelType, genType)
 import Test.QuickCheck
 
 instance Arbitrary Decl where
@@ -583,7 +584,8 @@ genDeclPatSynSig = do
 genDeclStandaloneKindSig :: Gen Decl
 genDeclStandaloneKindSig = do
   name <- mkUnqualifiedName NameConId <$> genTypeConName
-  DeclStandaloneKindSig span0 name <$> genSimpleType
+  kind <- sized (genType . min 6)
+  pure $ DeclStandaloneKindSig span0 name (canonicalTopLevelType kind)
 
 -- | Generate simple type variable binders (0-2 params).
 genSimpleTyVarBinders :: Gen [TyVarBinder]


### PR DESCRIPTION
## Summary

- `genDeclStandaloneKindSig` was using `genSimpleType`, which only generates `TVar`, `TCon`, or a bare `TFun`. Standalone kind signatures accept arbitrarily complex kinds (e.g. `type X :: ((Int -> Bool) -> a) -> (# Word# #) -> [] -> _`), so the generator was not exercising the parser/pretty-printer for these cases.
- Switched to `sized (genType . min 6)` — the same full type generator used by the `Arbitrary Type` instance — and apply `canonicalTopLevelType` for correct round-trip normalisation.
- No bugs were found in the pretty-printer or parser; all 2000 round-trip tests pass.

## Test plan

- [x] `cabal run spec -- -p "generated decl" --quickcheck-tests 2000` passes
- [x] Full `cabal run spec` (1300 tests) passes