### PR TITLE
feat: resolve latest version for installed packages from Hackage

### DIFF
--- a/components/aihc-parser/app/hackage-tester/Main.hs
+++ b/components/aihc-parser/app/hackage-tester/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import Aihc.Cpp (Severity (..), diagSeverity, resultDiagnostics, resultOutput)
+import Aihc.Hackage.VersionResolver (getLatestVersion)
 import Aihc.Parser.Lex (readModuleHeaderPragmas)
 import Aihc.Parser.Syntax qualified as Syntax
 import ConcurrentProgress (mapConcurrentlyBounded)
@@ -10,17 +11,12 @@ import Control.Exception (SomeException, displayException, try)
 import Control.Monad (unless, when)
 import CppSupport (preprocessForParserIfEnabled)
 import Data.Aeson qualified as Aeson
-import Data.ByteString qualified as BS
-import Data.ByteString.Lazy qualified as LBS
+import Data.Bifunctor (first)
 import Data.ByteString.Lazy.Char8 qualified as LBS8
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
-import Distribution.Package (packageId, pkgVersion)
-import Distribution.PackageDescription (GenericPackageDescription (..))
-import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
-import Distribution.Pretty (prettyShow)
 import GHC.Conc (getNumProcessors)
 import GhcOracle qualified
 import HackageSupport
@@ -33,8 +29,6 @@ import HackageSupport
   )
 import HackageTester.CLI (Options (..), parseOptionsIO)
 import HackageTester.Model (FileResult (..), Outcome (..), Summary (..), failureLabel, shouldFailSummary, summarizeResults)
-import Network.HTTP.Client (HttpException, Manager, Request (responseTimeout), httpLbs, newManager, parseRequest, responseBody, responseTimeoutMicro)
-import Network.HTTP.Client.TLS (tlsManagerSettings)
 import ParserValidation (ValidationError (..), ValidationErrorKind (..), validateParser)
 import System.Exit (exitFailure, exitSuccess)
 import System.FilePath (takeFileName)
@@ -66,7 +60,9 @@ runTester opts = do
   versionResult <-
     case optVersion opts of
       Just forced -> pure (Right forced)
-      Nothing -> getLatestVersion (optPackage opts)
+      Nothing -> do
+        result <- getLatestVersion Nothing (optPackage opts)
+        pure (first T.pack result)
 
   case versionResult of
     Left err -> pure (Left err)
@@ -94,30 +90,6 @@ runTesterWithVersion opts version = do
       let summary = summarizeResults results
       emitSummary opts (RunInfo (optPackage opts) version summary)
       pure (Right (not (shouldFailSummary summary)))
-
-getLatestVersion :: String -> IO (Either Text String)
-getLatestVersion packageName = do
-  manager <- newManager tlsManagerSettings
-  let url = "https://hackage.haskell.org/package/" ++ packageName ++ "/" ++ packageName ++ ".cabal"
-  requestResult <- try (parseRequest url)
-  case requestResult of
-    Left err -> pure (Left ("Failed to build Hackage request: " <> T.pack (displayException (err :: HttpException))))
-    Right request -> do
-      fetchResult <- try (fetchCabalFile manager request)
-      case fetchResult of
-        Left err -> pure (Left ("Failed to fetch package metadata from Hackage: " <> T.pack (displayException (err :: HttpException))))
-        Right cabalBytes ->
-          case runParseResult (parseGenericPackageDescription (LBS.toStrict cabalBytes :: BS.ByteString)) of
-            (_, Left (_, errs)) -> pure (Left ("Failed to parse Hackage cabal file: " <> T.pack (show errs)))
-            (_, Right gpd) ->
-              let ver = pkgVersion (packageId (packageDescription gpd))
-               in pure (Right (prettyShow ver))
-
-fetchCabalFile :: Manager -> Request -> IO LBS.ByteString
-fetchCabalFile manager request = do
-  let request' = request {responseTimeout = responseTimeoutMicro (30 * 1000 * 1000)}
-  response <- httpLbs request' manager
-  pure (responseBody response)
 
 processFiles :: Options -> Int -> FilePath -> [FileInfo] -> IO [FileResult]
 processFiles opts jobs packageRoot =

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -9,6 +9,7 @@ module StackageProgress.PackageRunner
   )
 where
 
+import Aihc.Hackage.VersionResolver (getLatestVersion)
 import Control.Exception (IOException, SomeException, displayException, try)
 import HackageSupport
   ( FileInfo (..),
@@ -50,21 +51,35 @@ runPackage opts spec = do
 -- | Process a package, potentially throwing exceptions.
 runPackageOrThrow :: Options -> PackageSpec -> IO PackageResult
 runPackageOrThrow opts spec = do
-  if pkgVersion spec == "installed"
-    then
-      pure
-        PackageResult
-          { package = spec,
-            packageOursOk = False,
-            packageHseOk = False,
-            packageGhcOk = False,
-            packageReason = "installed package has no downloadable snapshot version",
-            packageGhcError = Nothing,
-            packageSourceSize = 0,
-            packageFileErrors = []
-          }
-    else do
-      srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) (pkgVersion spec)
+  versionResult <- resolveVersion
+  case versionResult of
+    Left errResult -> pure errResult
+    Right version -> runWithVersion version
+  where
+    resolveVersion :: IO (Either PackageResult String)
+    resolveVersion =
+      if pkgVersion spec == "installed"
+        then do
+          latestResult <- getLatestVersion Nothing (pkgName spec)
+          pure $ case latestResult of
+            Left err ->
+              Left
+                PackageResult
+                  { package = spec,
+                    packageOursOk = False,
+                    packageHseOk = False,
+                    packageGhcOk = False,
+                    packageReason = "failed to resolve latest version for installed package: " ++ err,
+                    packageGhcError = Nothing,
+                    packageSourceSize = 0,
+                    packageFileErrors = []
+                  }
+            Right ver -> Right ver
+        else pure (Right (pkgVersion spec))
+
+    runWithVersion :: String -> IO PackageResult
+    runWithVersion version = do
+      srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) version
       files <- findTargetFilesFromCabal srcDir
       totalSize <- if optPrintFailedTable opts then totalSourceSize files else pure 0
       if null files

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -18,6 +18,7 @@ library
     , Aihc.Hackage.Stackage
     , Aihc.Hackage.Cabal
     , Aihc.Hackage.Util
+    , Aihc.Hackage.VersionResolver
   hs-source-dirs:   src
   build-depends:
       base >=4.16 && <5

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Stackage.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Stackage.hs
@@ -95,8 +95,9 @@ parseConstraint entry
           let ws = words entry
            in case ws of
                 -- Snapshot constraints like "base installed" refer to compiler-provided
-                -- packages and do not map to downloadable Hackage tarballs.
-                [_, "installed"] -> Nothing
+                -- packages. We return a PackageSpec with version "installed" so that
+                -- downstream code can fetch the latest version from Hackage.
+                [name, "installed"] -> Just (PackageSpec (trim name) "installed")
                 _ -> Nothing
 
 breakOn :: String -> String -> Maybe (String, String)

--- a/tooling/aihc-hackage/src/Aihc/Hackage/VersionResolver.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/VersionResolver.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Resolve package versions from Hackage.
+module Aihc.Hackage.VersionResolver
+  ( getLatestVersion,
+  )
+where
+
+import Control.Exception (displayException, try)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Distribution.Package (packageId, pkgVersion)
+import Distribution.PackageDescription (packageDescription)
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Pretty (prettyShow)
+import Network.HTTP.Client (HttpException, Manager, Request (responseTimeout), httpLbs, newManager, parseRequest, responseBody, responseStatus, responseTimeoutMicro)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Status (statusCode)
+
+-- | Fetch the latest version of a package from Hackage.
+--
+-- Downloads the .cabal file for the package and parses the version from it.
+getLatestVersion :: Maybe Manager -> String -> IO (Either String String)
+getLatestVersion mManager packageName = do
+  manager <- case mManager of
+    Just m -> pure m
+    Nothing -> newManager tlsManagerSettings
+  let url = "https://hackage.haskell.org/package/" ++ packageName ++ "/" ++ packageName ++ ".cabal"
+  requestResult <- try (parseRequest url)
+  case requestResult of
+    Left err -> pure (Left ("Failed to build Hackage request: " ++ displayException (err :: HttpException)))
+    Right request -> do
+      fetchResult <- try (fetchCabalFile manager request)
+      case fetchResult of
+        Left err -> pure (Left ("Failed to fetch package metadata from Hackage: " ++ displayException (err :: HttpException)))
+        Right cabalBytes ->
+          case runParseResult (parseGenericPackageDescription (LBS.toStrict cabalBytes :: BS.ByteString)) of
+            (_, Left (_, errs)) -> pure (Left ("Failed to parse Hackage cabal file: " ++ show errs))
+            (_, Right gpd) ->
+              let ver = pkgVersion (packageId (packageDescription gpd))
+               in pure (Right (prettyShow ver))
+
+-- | Fetch a .cabal file from Hackage with a 30-second timeout.
+fetchCabalFile :: Manager -> Request -> IO LBS.ByteString
+fetchCabalFile manager request = do
+  let request' = request {responseTimeout = responseTimeoutMicro (30 * 1000 * 1000)}
+  response <- httpLbs request' manager
+  let status = statusCode (responseStatus response)
+  if status >= 200 && status < 300
+    then pure (responseBody response)
+    else ioError (userError ("HTTP " ++ show status ++ " for " ++ show request))


### PR DESCRIPTION
## Summary

Changed the behavior for packages marked as `installed` in Stackage snapshots. Instead of skipping them, we now fetch the latest version from Hackage and test that.

## Changes

- **Stackage.hs**: Modified `parseConstraint` to return `PackageSpec` with version `"installed"` instead of returning `Nothing` for installed packages
- **VersionResolver.hs**: New module that provides `getLatestVersion` function to fetch the latest version from Hackage by downloading and parsing the `.cabal` file
- **PackageRunner.hs**: Updated `runPackageOrThrow` to resolve the latest version when version is `"installed"` instead of skipping the package

## Progress Counts

No changes to parser progress counts - this change only affects which packages are tested, not parser behavior.