### PR TITLE
ci: add dummy QuickCheck tests to support --quickcheck-tests flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,23 @@
 - Deep fuzzy testing: `cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000"`
 - Run full test suite (fast): `just check`
 - Run full test suite (slow, isolated sandbox): `nix flake check`
+
+## Mandatory Pre-Commit Workflow
+
+**These steps MUST be completed before every commit. No exceptions.**
+
+1. **Run `just fmt`** — Auto-formats all Haskell files with ormolu. Always run this before committing to ensure correct formatting.
+2. **Run `just check`** — MUST pass. This runs:
+   - `ormolu` format check (verifies step 1 was done)
+   - `hlint` linting (no linting errors allowed)
+   - Full test suite (`just test`)
+
+If `just check` fails, do NOT commit. Fix the issues first.
+
+> **Rule of thumb:** Write code → `just fmt` → `just check` → if it passes, commit.
+
+## PR Workflow
+
 - Include changes to progress counts in PR descriptions. Do not update the READMEs, though. They are updated by a cron workflow.
 - Create PRs: `gh pr create --base main --head <branch> --title "<title>" --body $(cat <file>)`
 - PR titles should follow the same Conventional Commits format as commit messages (see below)
@@ -15,10 +32,11 @@
 
 This project uses [Just](https://just.systems) as a command runner. Common commands:
 
+- `just fmt` — **Auto-format all Haskell files with ormolu. Run this before committing.**
 - `just test` — Run all tests with hidden successes
 - `just replay "<seed>"` — Replay a specific QuickCheck test case (e.g., `just replay "(SMGen 6995563131902519991 12189532712049121349,3)"`)
 - `just qc` — Run QuickCheck with 10,000 tests in an infinite loop until failure
-- `just check` — Run ormolu format check, hlint, then full test suite (useful before opening a PR)
+- `just check` — Run ormolu format check, hlint, then full test suite
 
 ## Branch Policy
 

--- a/components/aihc-cpp/aihc-cpp.cabal
+++ b/components/aihc-cpp/aihc-cpp.cabal
@@ -46,6 +46,7 @@ test-suite spec
     , filepath
     , tasty
     , tasty-hunit
+    , tasty-quickcheck
   ghc-options:        -Wall -Werror
   default-language: Haskell2010
 

--- a/components/aihc-cpp/test/Spec.hs
+++ b/components/aihc-cpp/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Data.Text.Encoding as TE
 import Test.Progress (CaseMeta (..), Outcome (..), evaluateCase, loadManifest)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import qualified Test.Tasty.QuickCheck as QC
 
 main :: IO ()
 main = do
@@ -17,8 +18,16 @@ main = do
   defaultMain
     ( testGroup
         "cpp-oracle"
-        (checks <> [linePragmaTest, dateTimeTest, functionMacroArgumentTest, functionMacroUnclosedCallTest, definedConditionSpacingTest])
+        ( checks
+            <> [linePragmaTest, dateTimeTest, functionMacroArgumentTest, functionMacroUnclosedCallTest, definedConditionSpacingTest]
+            <> [QC.testProperty "dummy quickcheck property" prop_dummy]
+        )
     )
+
+-- | Dummy QuickCheck property that always passes.
+-- Added so that --quickcheck-tests flag is accepted by the test suite.
+prop_dummy :: Bool
+prop_dummy = True
 
 dateTimeTest :: TestTree
 dateTimeTest =

--- a/components/aihc-parser-cli/aihc-parser-cli.cabal
+++ b/components/aihc-parser-cli/aihc-parser-cli.cabal
@@ -83,6 +83,7 @@ test-suite spec
     , filepath
     , tasty
     , tasty-hunit
+    , tasty-quickcheck
     , yaml
   ghc-options:        -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010

--- a/components/aihc-parser-cli/test/Spec.hs
+++ b/components/aihc-parser-cli/test/Spec.hs
@@ -2,6 +2,15 @@ module Main (main) where
 
 import Test.CLI.Suite (cliTests)
 import Test.Tasty
+import qualified Test.Tasty.QuickCheck as QC
 
 main :: IO ()
-main = cliTests >>= defaultMain
+main = do
+  cliTestsTree <- cliTests
+  let dummyQC = QC.testProperty "dummy quickcheck property" prop_dummy
+  defaultMain (testGroup "aihc-parser-cli" [cliTestsTree, dummyQC])
+
+-- | Dummy QuickCheck property that always passes.
+-- Added so that --quickcheck-tests flag is accepted by the test suite.
+prop_dummy :: Bool
+prop_dummy = True

--- a/components/aihc-resolve/aihc-resolve.cabal
+++ b/components/aihc-resolve/aihc-resolve.cabal
@@ -83,6 +83,7 @@ test-suite spec
     , filepath
     , tasty
     , tasty-hunit
+    , tasty-quickcheck
     , aeson
     , bytestring
     , yaml

--- a/components/aihc-resolve/test/Spec.hs
+++ b/components/aihc-resolve/test/Spec.hs
@@ -2,8 +2,15 @@ module Main (main) where
 
 import Test.Resolver.Suite (resolverGoldenTests)
 import Test.Tasty
+import qualified Test.Tasty.QuickCheck as QC
 
 main :: IO ()
 main = do
   resolverGolden <- resolverGoldenTests
-  defaultMain (testGroup "aihc-resolve" [resolverGolden])
+  let dummyQC = QC.testProperty "dummy quickcheck property" prop_dummy
+  defaultMain (testGroup "aihc-resolve" [resolverGolden, dummyQC])
+
+-- | Dummy QuickCheck property that always passes.
+-- Added so that --quickcheck-tests flag is accepted by the test suite.
+prop_dummy :: Bool
+prop_dummy = True

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ replay ARGUMENT:
 qc:
   while true; do cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000" || break; done
 
+# Auto-format all Haskell files (excludes dist-newstyle and test fixtures)
+fmt:
+  nix develop --quiet --command bash -c 'ormolu --mode inplace $(find components -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+
 # Run full CI check: format, lint, then tests
 check:
   nix develop --quiet --command bash -c 'ormolu --mode check $(find components -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'

--- a/justfile
+++ b/justfile
@@ -1,9 +1,9 @@
 # Test runner for aihc project
 # See https://just.systems for Just documentation
 
-# Run all tests with hidden successes
+# Run all tests with hidden successes (1000 QuickCheck tests per property)
 test:
-  cabal test -v0 all --test-options='--hide-successes' --test-show-details=failures
+  cabal test -v0 all --test-options='--hide-successes --quickcheck-tests 1000' --test-show-details=failures
 
 # Replay a specific QuickCheck test case
 # Usage: just replay "<replay-string>"


### PR DESCRIPTION
## Summary

Added trivial QuickCheck properties to test suites that previously only had HUnit tests, enabling the `--quickcheck-tests` flag to be used globally without failures.

## Changes

- **aihc-cpp**: Added `tasty-quickcheck` dependency and dummy QC property
- **aihc-parser-cli**: Added `tasty-quickcheck` dependency and dummy QC property  
- **aihc-resolve**: Added `tasty-quickcheck` dependency and dummy QC property
- **justfile**: Updated `just test` to run 1000 QuickCheck tests per property (increased from default 100)

## Testing

All tests pass with `just test`:
```
cabal test -v0 all --test-options='--hide-successes --quickcheck-tests 1000' --test-show-details=failures
```

## Progress Counts

No changes to test progress counts - all tests pass as expected.