### PR TITLE
test(parser): generalize function declaration patterns

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -594,15 +594,10 @@ contextParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]
 contextParserWith = contextItemsParserWith
 
 functionHeadParserWith :: TokParser Pattern -> TokParser Pattern -> TokParser (MatchHeadForm, UnqualifiedName, [Pattern])
-functionHeadParserWith fullPatternParser prefixPatternParser = do
-  isParenInfix <- startsWithParenInfixHead
-  if isParenInfix
-    then parenthesizedInfixHeadParser
-    else do
-      isInfix <- startsWithInfixHead
-      if isInfix
-        then infixHeadParser
-        else prefixHeadParser
+functionHeadParserWith fullPatternParser prefixPatternParser =
+  MP.try parenthesizedInfixHeadParser
+    <|> MP.try infixHeadParser
+    <|> prefixHeadParser
   where
     prefixHeadParser = do
       name <- binderNameParser
@@ -623,110 +618,6 @@ functionHeadParserWith fullPatternParser prefixPatternParser = do
       expectedTok TkSpecialRParen
       tailPats <- MP.many prefixPatternParser
       pure (MatchHeadInfix, op, [lhsPat, rhsPat] <> tailPats)
-
--- | Non-consuming lookahead: does the input start with a parenthesized infix
--- function head @( pat varop pat ) ...@?
---
--- Scans inside the outermost parentheses for a variable operator ('TkVarSym')
--- or backtick-quoted variable at bracket depth 0. Excludes the case where
--- the parenthesised content is a single operator like @(+)@ — that is a
--- parenthesised operator name (prefix head), not a parenthesised infix head.
-startsWithParenInfixHead :: TokParser Bool
-startsWithParenInfixHead = MP.lookAhead $ do
-  tok <- anySingle
-  case lexTokenKind tok of
-    TkSpecialLParen -> do
-      -- Peek at the first token inside parens. If it is already a varop,
-      -- this is @(op)@ — a parenthesised operator name, not an infix head.
-      inner <- anySingle
-      case lexTokenKind inner of
-        TkVarSym _ -> pure False -- (op) or (op ...) — treated as prefix name
-        TkSpecialBacktick -> pure False
-        TkEOF -> pure False
-        TkSpecialRParen -> pure False -- empty parens
-        -- First token inside is not an operator → scan for a varop
-        _ -> goInner []
-    _ -> pure False
-  where
-    -- Scan inside the outermost parens (we already consumed '(' and one token).
-    -- We're looking for a TkVarSym or TkSpecialBacktick at depth 0.
-    goInner :: [LexTokenKind] -> TokParser Bool
-    -- At depth 0 (inside the outermost parens)
-    goInner [] = do
-      tok <- anySingle
-      case lexTokenKind tok of
-        TkEOF -> pure False
-        TkSpecialRParen -> pure False -- closed without finding varop
-        TkVarSym _ -> pure True
-        TkSpecialBacktick -> pure True
-        TkSpecialLParen -> goInner [TkSpecialRParen]
-        TkSpecialUnboxedLParen -> goInner [TkSpecialUnboxedRParen]
-        TkSpecialLBracket -> goInner [TkSpecialRBracket]
-        TkSpecialLBrace -> goInner [TkSpecialRBrace]
-        _ -> goInner []
-    -- Inside nested brackets
-    goInner stack@(expectedClose : rest) = do
-      tok <- anySingle
-      case lexTokenKind tok of
-        TkEOF -> pure False
-        kind
-          | kind == expectedClose ->
-              case rest of
-                [] -> goInner []
-                _ -> goInner rest
-        TkSpecialLParen -> goInner (TkSpecialRParen : stack)
-        TkSpecialUnboxedLParen -> goInner (TkSpecialUnboxedRParen : stack)
-        TkSpecialLBracket -> goInner (TkSpecialRBracket : stack)
-        TkSpecialLBrace -> goInner (TkSpecialRBrace : stack)
-        _ -> goInner stack
-
--- | Non-consuming lookahead: does the input start with an infix function head
--- @pat varop pat@?
---
--- Scans the token stream at bracket depth 0 for a variable operator
--- ('TkVarSym') or backtick-quoted variable before reaching @=@ or @|@.
--- Returns 'False' for prefix heads like @f x y = ...@ (no varop before @=@).
-startsWithInfixHead :: TokParser Bool
-startsWithInfixHead = MP.lookAhead (go [])
-  where
-    go :: [LexTokenKind] -> TokParser Bool
-    -- At depth 0
-    go [] = do
-      tok <- anySingle
-      case lexTokenKind tok of
-        TkEOF -> pure False
-        -- Stop tokens: we reached '=' or '|' without finding a varop
-        TkReservedEquals -> pure False
-        TkReservedPipe -> pure False
-        -- Statement/declaration boundaries
-        TkSpecialSemicolon -> pure False
-        TkSpecialRBrace -> pure False
-        TkSpecialRParen -> pure False
-        TkSpecialRBracket -> pure False
-        -- Found a varop at the top level → infix head
-        TkVarSym _ -> pure True
-        TkSpecialBacktick -> pure True
-        -- Nested brackets
-        TkSpecialLParen -> go [TkSpecialRParen]
-        TkSpecialUnboxedLParen -> go [TkSpecialUnboxedRParen]
-        TkSpecialLBracket -> go [TkSpecialRBracket]
-        TkSpecialLBrace -> go [TkSpecialRBrace]
-        _ -> go []
-    -- Inside nested brackets
-    go stack@(expectedClose : rest) = do
-      tok <- anySingle
-      case lexTokenKind tok of
-        TkEOF -> pure False
-        kind
-          | kind == expectedClose ->
-              case rest of
-                [] -> go []
-                _ -> go rest
-        TkSpecialLParen -> go (TkSpecialRParen : stack)
-        TkSpecialUnboxedLParen -> go (TkSpecialUnboxedRParen : stack)
-        TkSpecialLBracket -> go (TkSpecialRBracket : stack)
-        TkSpecialLBrace -> go (TkSpecialRBrace : stack)
-        _ -> go stack
 
 functionBindValue :: SourceSpan -> MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs -> ValueDecl
 functionBindValue span' headForm name pats rhs =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1391,7 +1391,7 @@ constructorOperatorParser =
 -- | Parse a pattern binding declaration like @(x, y) = (1, 2)@.
 -- This handles bindings where the LHS is a pattern rather than a function name.
 patternBindDeclParser :: TokParser Decl
-patternBindDeclParser = withSpan $ do
+patternBindDeclParser = MP.try $ withSpan $ do
   pat <- region "while parsing pattern binding" patternParser
   rhs <- equationRhsParser
   pure (\span' -> DeclValue span' (PatternBind span' pat rhs))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -82,7 +82,10 @@ ordinaryDeclParser = do
     TkSpecialLBracket -> typeSigOrPatternOrValueOrSpliceParser
     TkPrefixTilde -> typeSigOrPatternOrValueOrSpliceParser
     TkKeywordUnderscore -> typeSigOrPatternOrValueOrSpliceParser
-    TkTHSplice -> spliceDeclParser
+    TkTHSplice ->
+      if thFullEnabled
+        then MP.try valueDeclParser <|> spliceDeclParser
+        else spliceDeclParser
     _ -> typeSigOrValueOrSpliceParser
 
 -- | Parse a pragma declaration (e.g. {-# INLINE f #-}, {-# SPECIALIZE ... #-})

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -327,16 +327,16 @@ prettyFunctionHead :: UnqualifiedName -> MatchHeadForm -> [Pattern] -> Doc ann
 prettyFunctionHead name headForm pats =
   case headForm of
     MatchHeadPrefix ->
-      hsep (prettyBinderUName name : map prettyPattern pats)
+      hsep (prettyBinderUName name : map prettyFunctionHeadPatternAtom pats)
     MatchHeadInfix ->
       case pats of
         lhs : rhsPat : tailPats ->
           let infixHead = prettyPattern lhs <+> prettyInfixOp (renderUnqualifiedName name) <+> prettyPattern rhsPat
            in case tailPats of
                 [] -> infixHead
-                _ -> hsep (parens infixHead : map prettyPattern tailPats)
+                _ -> hsep (parens infixHead : map prettyFunctionHeadPatternAtom tailPats)
         _ ->
-          hsep (prettyBinderUName name : map prettyPattern pats)
+          hsep (prettyBinderUName name : map prettyFunctionHeadPatternAtom pats)
 
 prettyRhs :: Rhs -> Doc ann
 prettyRhs rhs =
@@ -599,6 +599,17 @@ prettyLambdaPatternAtom pat =
   case pat of
     PNegLit {} -> parens (prettyPattern pat)
     PCon _ _ [] -> parens (prettyPattern pat)
+    _ -> prettyPatternAtom pat
+
+-- | Pretty print a pattern in function-head argument position.
+-- Function heads need the same nullary-constructor protection as lambda
+-- patterns, and also need constructor applications parenthesized so they do not
+-- get split into multiple head arguments by the parser.
+prettyFunctionHeadPatternAtom :: Pattern -> Doc ann
+prettyFunctionHeadPatternAtom pat =
+  case pat of
+    PNegLit {} -> parens (prettyPattern pat)
+    PCon {} -> parens (prettyPattern pat)
     _ -> prettyPatternAtom pat
 
 -- | Pretty print a pattern atom after @ or as the operand of ! or ~.

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -331,7 +331,7 @@ prettyFunctionHead name headForm pats =
     MatchHeadInfix ->
       case pats of
         lhs : rhsPat : tailPats ->
-          let infixHead = prettyPattern lhs <+> prettyInfixOp (renderUnqualifiedName name) <+> prettyPattern rhsPat
+          let infixHead = prettyInfixFunctionHeadPatternAtom lhs <+> prettyInfixOp (renderUnqualifiedName name) <+> prettyInfixFunctionHeadPatternAtom rhsPat
            in case tailPats of
                 [] -> infixHead
                 _ -> hsep (parens infixHead : map prettyFunctionHeadPatternAtom tailPats)
@@ -558,6 +558,9 @@ prettyPatternInDelimited :: Pattern -> Doc ann
 prettyPatternInDelimited pat =
   case pat of
     PView _ viewExpr inner -> prettyExprPrec 2 viewExpr <+> "->" <+> prettyPattern inner
+    PAs _ name inner -> pretty name <> "@" <> prettyPatternAtomStrict inner
+    PStrict _ inner -> "!" <> prettyPatternAtomStrict inner
+    PIrrefutable _ inner -> "~" <> prettyPatternAtomStrict inner
     _ -> prettyPattern pat
 
 -- | Pretty print a pattern field binding.
@@ -609,8 +612,19 @@ prettyFunctionHeadPatternAtom :: Pattern -> Doc ann
 prettyFunctionHeadPatternAtom pat =
   case pat of
     PNegLit {} -> parens (prettyPattern pat)
-    PCon {} -> parens (prettyPattern pat)
+    PCon _ _ (_ : _) -> parens (prettyPattern pat)
+    PRecord {} -> prettyPattern pat
     _ -> prettyPatternAtom pat
+
+-- | Pretty print a pattern as an infix function-head operand.
+-- Infix operands are already delimited by the operator, so constructor
+-- applications and unary-pattern forms can stay bare. Only negative literals
+-- still need parens to avoid being read as subtraction.
+prettyInfixFunctionHeadPatternAtom :: Pattern -> Doc ann
+prettyInfixFunctionHeadPatternAtom pat =
+  case pat of
+    PNegLit {} -> parens (prettyPattern pat)
+    _ -> prettyPattern pat
 
 -- | Pretty print a pattern atom after @ or as the operand of ! or ~.
 -- Negative literals and nested strictness/irrefutability need parens.
@@ -618,6 +632,7 @@ prettyPatternAtomStrict :: Pattern -> Doc ann
 prettyPatternAtomStrict pat =
   case pat of
     PNegLit {} -> parens (prettyPattern pat)
+    PCon _ _ [] -> parens (prettyPattern pat)
     PStrict {} -> parens (prettyPattern pat)
     PIrrefutable {} -> parens (prettyPattern pat)
     PRecord {} -> prettyPattern pat

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -178,7 +178,10 @@ buildTests = do
           "pretty"
           [ testCase "guard lambda round-trips with parentheses" test_prettyGuardLambdaRoundTrip,
             testCase "guard let expression stays unparenthesized" test_prettyGuardLetFormatting,
-            testCase "unicode operator type signatures round-trip with parentheses" test_prettyUnicodeOperatorTypeSigRoundTrip
+            testCase "unicode operator type signatures round-trip with parentheses" test_prettyUnicodeOperatorTypeSigRoundTrip,
+            testCase "prefix function head record pattern stays bare" test_prettyPrefixFunctionHeadRecordPattern,
+            testCase "infix function head constructor applications stay bare" test_prettyInfixFunctionHeadConstructorPatterns,
+            testCase "infix function head irrefutable patterns stay bare" test_prettyInfixFunctionHeadIrrefutablePatterns
           ],
         testGroup
           "functionHeadParserWith dispatch"
@@ -188,6 +191,9 @@ buildTests = do
             testCase "prefix constructor application arg: f (Just x) y = y" test_funHeadPrefixConstructorArg,
             testCase "infix: x + y = x" test_funHeadInfix,
             testCase "infix backtick: x `add` y = x" test_funHeadInfixBacktick,
+            testCase "infix record rhs: x `f` (R {}) = x" test_funHeadInfixRecordRhs,
+            testCase "infix tuple lhs and qualified record rhs" test_funHeadInfixTupleLhsQualifiedRecordRhs,
+            testCase "infix complex tuple lhs and qualified record rhs" test_funHeadInfixComplexTupleLhsQualifiedRecordRhs,
             testCase "infix backtick with TH splice lhs: $splice `fn` () = ()" test_funHeadInfixThSpliceLhs,
             testCase "parenthesized infix: (x + y) = x" test_funHeadParenInfix,
             testCase "parenthesized infix with tail: (x + y) z = x" test_funHeadParenInfixTail,
@@ -1155,6 +1161,64 @@ test_prettyUnicodeOperatorTypeSigRoundTrip = do
     ParseErr err ->
       assertFailure ("expected unicode operator type signature to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
 
+test_prettyPrefixFunctionHeadRecordPattern :: Assertion
+test_prettyPrefixFunctionHeadRecordPattern = do
+  let decl =
+        DeclValue
+          span0
+          ( FunctionBind
+              span0
+              "f"
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadPrefix,
+                    matchPats = [PRecord span0 (qualifyName Nothing (mkUnqualifiedName NameConId "Point")) [] True],
+                    matchRhs = UnguardedRhs span0 (EInt span0 0 "0") Nothing
+                  }
+              ]
+          )
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  assertBool ("expected bare record pattern in prefix function head, got:\n" <> T.unpack source) ("f Point {..} = 0" == source)
+
+test_prettyInfixFunctionHeadConstructorPatterns :: Assertion
+test_prettyInfixFunctionHeadConstructorPatterns = do
+  let box name = PCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId "Box")) [PVar span0 name]
+      decl =
+        DeclValue
+          span0
+          ( FunctionBind
+              span0
+              "=="
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadInfix,
+                    matchPats = [box "x", box "y"],
+                    matchRhs = UnguardedRhs span0 (EVar span0 "x") Nothing
+                  }
+              ]
+          )
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  assertBool ("expected bare constructor applications in infix function head, got:\n" <> T.unpack source) ("Box x == Box y = x" == source)
+
+test_prettyInfixFunctionHeadIrrefutablePatterns :: Assertion
+test_prettyInfixFunctionHeadIrrefutablePatterns = do
+  let decl =
+        DeclValue
+          span0
+          ( FunctionBind
+              span0
+              "combine"
+              [ Match
+                  { matchSpan = span0,
+                    matchHeadForm = MatchHeadInfix,
+                    matchPats = [PIrrefutable span0 (PVar span0 "x"), PVar span0 "y"],
+                    matchRhs = UnguardedRhs span0 (EVar span0 "x") Nothing
+                  }
+              ]
+          )
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  assertBool ("expected bare irrefutable pattern in infix function head, got:\n" <> T.unpack source) ("~x `combine` y = x" == source)
+
 test_guardPatBind :: Assertion
 test_guardPatBind =
   case parseGuards "f x | Just y <- g x = y" of
@@ -1385,6 +1449,15 @@ parseTopDecl src =
           [decl] -> Right decl
           other -> Left ("expected one decl, got: " <> show (length other))
 
+parseTopDeclWithExts :: [Extension] -> T.Text -> Either String Decl
+parseTopDeclWithExts exts src =
+  let (errs, modu) = parseModule defaultConfig {parserExtensions = exts} src
+   in if not (null errs)
+        then Left ("parse errors: " <> show errs)
+        else case moduleDecls modu of
+          [decl] -> Right decl
+          other -> Left ("expected one decl, got: " <> show (length other))
+
 test_funHeadPrefix :: Assertion
 test_funHeadPrefix =
   case parseTopDecl "f x y = x + y" of
@@ -1420,6 +1493,24 @@ test_funHeadInfixBacktick =
   case parseTopDecl "x `add` y = x" of
     Right (DeclValue _ (FunctionBind _ "add" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
     other -> assertFailure ("expected backtick infix function bind, got: " <> show other)
+
+test_funHeadInfixRecordRhs :: Assertion
+test_funHeadInfixRecordRhs =
+  case parseTopDecl "x `f` (R {}) = x" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PParen _ (PRecord _ "R" [] False)]}])) -> pure ()
+    other -> assertFailure ("expected infix function bind with record rhs pattern, got: " <> show other)
+
+test_funHeadInfixTupleLhsQualifiedRecordRhs :: Assertion
+test_funHeadInfixTupleLhsQualifiedRecordRhs =
+  case parseTopDecl "((x, _), K []) `f` (M.N.R {}) = x" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PTuple _ Boxed _, PParen _ (PRecord _ "M.N.R" [] False)]}])) -> pure ()
+    other -> assertFailure ("expected infix function bind with tuple lhs and qualified record rhs pattern, got: " <> show other)
+
+test_funHeadInfixComplexTupleLhsQualifiedRecordRhs :: Assertion
+test_funHeadInfixComplexTupleLhsQualifiedRecordRhs =
+  case parseTopDeclWithExts [UnboxedTuples, UnboxedSums, QuasiQuotes] "((#  |  | -0xbe |  #), ([g|f|]), (# x, _ #), M.C [] []) `f` (N.R {}) = ()" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PTuple _ Boxed _, PParen _ (PRecord _ "N.R" [] False)]}])) -> pure ()
+    other -> assertFailure ("expected infix function bind with complex tuple lhs and qualified record rhs pattern, got: " <> show other)
 
 test_funHeadInfixThSpliceLhs :: Assertion
 test_funHeadInfixThSpliceLhs =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -185,8 +185,10 @@ buildTests = do
           [ testCase "prefix: f x y = x + y" test_funHeadPrefix,
             testCase "prefix no args: f = 5" test_funHeadPrefixNoArgs,
             testCase "prefix operator name: (+) x y = x" test_funHeadPrefixOp,
+            testCase "prefix constructor application arg: f (Just x) y = y" test_funHeadPrefixConstructorArg,
             testCase "infix: x + y = x" test_funHeadInfix,
             testCase "infix backtick: x `add` y = x" test_funHeadInfixBacktick,
+            testCase "infix backtick with TH splice lhs: $splice `fn` () = ()" test_funHeadInfixThSpliceLhs,
             testCase "parenthesized infix: (x + y) = x" test_funHeadParenInfix,
             testCase "parenthesized infix with tail: (x + y) z = x" test_funHeadParenInfixTail,
             testCase "local prefix: let f x = x" test_funHeadLocalPrefix,
@@ -1401,6 +1403,12 @@ test_funHeadPrefixOp =
     Right (DeclValue _ (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
     other -> assertFailure ("expected prefix operator function bind, got: " <> show other)
 
+test_funHeadPrefixConstructorArg :: Assertion
+test_funHeadPrefixConstructorArg =
+  case parseTopDecl "f (Just x) y = y" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PParen _ (PCon _ "Just" [PVar _ "x"]), PVar _ "y"]}])) -> pure ()
+    other -> assertFailure ("expected constructor application argument in prefix function head, got: " <> show other)
+
 test_funHeadInfix :: Assertion
 test_funHeadInfix =
   case parseTopDecl "x + y = x" of
@@ -1412,6 +1420,12 @@ test_funHeadInfixBacktick =
   case parseTopDecl "x `add` y = x" of
     Right (DeclValue _ (FunctionBind _ "add" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar _ "x", PVar _ "y"]}])) -> pure ()
     other -> assertFailure ("expected backtick infix function bind, got: " <> show other)
+
+test_funHeadInfixThSpliceLhs :: Assertion
+test_funHeadInfixThSpliceLhs =
+  case parseTopDecl "{-# LANGUAGE TemplateHaskell #-}\n$splice `fn` () = ()" of
+    Right (DeclValue _ (FunctionBind _ "fn" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PSplice _ (EVar _ "splice"), PTuple _ Boxed []]}])) -> pure ()
+    other -> assertFailure ("expected TH splice lhs infix function bind, got: " <> show other)
 
 test_funHeadParenInfix :: Assertion
 test_funHeadParenInfix =

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/infix-funlhs-th-splice-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/infix-funlhs-th-splice-pattern.yaml
@@ -1,0 +1,8 @@
+extensions: [TemplateHaskell]
+input: |
+  {-# LANGUAGE TemplateHaskell #-}
+  module InfixFunlhsThSplicePattern where
+
+  $splice `fn` () = ()
+ast: Module {name = "InfixFunlhsThSplicePattern", languagePragmas = [EnableExtension TemplateHaskell], decls = [DeclValue (FunctionBind "fn" [Match {headForm = Infix, pats = [PSplice (EVar "splice"), PTuple []], rhs = UnguardedRhs (ETuple [])}])]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/infix-funlhs-th-splice-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/infix-funlhs-th-splice-pattern.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module InfixFunlhsThSplicePattern where
+
+$splice `fn` () = ()

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -13,6 +13,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Expr (genExpr, genOperator, isValidGeneratedOperator, shrinkExpr, span0)
 import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Arb.Pattern (genPattern)
 import Test.Properties.Arb.Type (canonicalFunLeft, canonicalTopLevelType, genType)
 import Test.QuickCheck
 
@@ -60,12 +61,8 @@ genFunctionDecl (name, expr) = do
   case headForm of
     MatchHeadPrefix ->
       do
-        pats <-
-          case unqualifiedNameType name of
-            NameVarSym -> do
-              patCount <- chooseInt (1, 2)
-              vectorOf patCount (PVar span0 . mkUnqualifiedName NameVarId <$> genIdent)
-            _ -> pure []
+        patCount <- chooseInt (0, 3)
+        pats <- vectorOf patCount (sized (genPattern . min 3))
         pure $
           DeclValue
             span0
@@ -80,27 +77,24 @@ genFunctionDecl (name, expr) = do
                     }
                 ]
             )
-    MatchHeadInfix -> do
-      -- For infix bindings, generate an operator name and two PVar patterns.
-      -- Symbolic operators: x + y = ..., backtick identifiers: x `f` y = ...
-      opName <-
-        genVarBinderName
-      lhsPat <- PVar span0 . mkUnqualifiedName NameVarId <$> genIdent
-      rhsPat <- PVar span0 . mkUnqualifiedName NameVarId <$> genIdent
-      pure $
-        DeclValue
-          span0
-          ( FunctionBind
-              span0
-              opName
-              [ Match
-                  { matchSpan = span0,
-                    matchHeadForm = MatchHeadInfix,
-                    matchPats = [lhsPat, rhsPat],
-                    matchRhs = UnguardedRhs span0 expr Nothing
-                  }
-              ]
-          )
+    MatchHeadInfix ->
+      do
+        lhsPat <- sized (genPattern . min 3)
+        rhsPat <- sized (genPattern . min 3)
+        pure $
+          DeclValue
+            span0
+            ( FunctionBind
+                span0
+                name
+                [ Match
+                    { matchSpan = span0,
+                      matchHeadForm = MatchHeadInfix,
+                      matchPats = [lhsPat, rhsPat],
+                      matchRhs = UnguardedRhs span0 expr Nothing
+                    }
+                ]
+            )
 
 genDeclTypeSig :: Gen Decl
 genDeclTypeSig = do

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -61,7 +61,7 @@ genFunctionDecl (name, expr) = do
   case headForm of
     MatchHeadPrefix ->
       do
-        patCount <- chooseInt (0, 3)
+        patCount <- chooseInt (1, 3)
         pats <- vectorOf patCount (sized (genPattern . min 3))
         pure $
           DeclValue

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -13,7 +13,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Expr (genExpr, genOperator, isValidGeneratedOperator, shrinkExpr, span0)
 import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
-import Test.Properties.Arb.Pattern (genPattern)
+import Test.Properties.Arb.Pattern (canonicalPatternAtomForComp, genPattern)
 import Test.Properties.Arb.Type (canonicalFunLeft, canonicalTopLevelType, genType)
 import Test.QuickCheck
 
@@ -79,8 +79,8 @@ genFunctionDecl (name, expr) = do
             )
     MatchHeadInfix ->
       do
-        lhsPat <- sized (genPattern . min 3)
-        rhsPat <- sized (genPattern . min 3)
+        lhsPat <- canonicalPatternAtomForComp <$> sized (genPattern . min 3)
+        rhsPat <- canonicalPatternAtomForComp <$> sized (genPattern . min 3)
         pure $
           DeclValue
             span0

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -386,8 +386,8 @@ genGuardQualifierWith allowTHQuotes n =
     parenTypeSig e = e
 
 -- | Generate value declarations for let/where.
--- We use FunctionBind format because that's what the parser produces for simple
--- variable bindings like `x = e`.
+-- Zero-argument bindings are generated as PatternBind so they keep the same
+-- AST shape after pretty-print/parser roundtrip.
 genValueDeclsWith :: Bool -> Int -> Gen [Decl]
 genValueDeclsWith allowTHQuotes n = do
   count <- chooseInt (0, 3)
@@ -396,16 +396,10 @@ genValueDeclsWith allowTHQuotes n = do
   pure
     [ DeclValue
         span0
-        ( FunctionBind
+        ( PatternBind
             span0
-            name
-            [ Match
-                { matchSpan = span0,
-                  matchHeadForm = MatchHeadPrefix,
-                  matchPats = [],
-                  matchRhs = UnguardedRhs span0 expr Nothing
-                }
-            ]
+            (PVar span0 name)
+            (UnguardedRhs span0 expr Nothing)
         )
     | (name, expr) <- zip names exprs
     ]

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -6,6 +6,7 @@ module Test.Properties.Arb.Pattern
     genPatternNoView,
     shrinkPattern,
     canonicalPatternAtom,
+    canonicalPatternAtomForComp,
   )
 where
 

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -198,9 +198,23 @@ normalizeMatch m =
   Match
     { matchSpan = span0,
       matchHeadForm = matchHeadForm m,
-      matchPats = map normalizePattern (matchPats m),
+      matchPats = map normalizeFunctionHeadPat (matchPats m),
       matchRhs = normalizeRhs (matchRhs m)
     }
+
+-- | Normalize a pattern in function-head argument position.
+-- The pretty-printer wraps constructor applications, infix patterns, type
+-- signatures, records, and negative literals in parens when they appear as
+-- head arguments so the parser does not split them into multiple patterns.
+normalizeFunctionHeadPat :: Pattern -> Pattern
+normalizeFunctionHeadPat pat =
+  case normalizePattern pat of
+    PParen _ inner@(PNegLit {}) -> inner
+    PParen _ inner@(PCon {}) -> inner
+    PParen _ inner@(PInfix {}) -> inner
+    PParen _ inner@(PTypeSig {}) -> inner
+    PParen _ inner@(PRecord {}) -> inner
+    other -> other
 
 normalizeDoStmt :: DoStmt Expr -> DoStmt Expr
 normalizeDoStmt stmt =

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -141,6 +141,7 @@ normalizeLambdaPat pat =
 normalizeUnaryPatInner :: Pattern -> Pattern
 normalizeUnaryPatInner pat =
   case normalizePattern pat of
+    PParen _ inner@(PCon {}) -> inner
     PParen _ inner@(PNegLit {}) -> inner
     PParen _ inner@(PStrict {}) -> inner
     PParen _ inner@(PIrrefutable {}) -> inner

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -191,6 +191,8 @@ normalizeValueDecl :: ValueDecl -> ValueDecl
 normalizeValueDecl vdecl =
   case vdecl of
     PatternBind _ pat rhs -> PatternBind span0 (normalizePattern pat) (normalizeRhs rhs)
+    FunctionBind _ name [Match {matchHeadForm = MatchHeadPrefix, matchPats = [], matchRhs = rhs}] ->
+      PatternBind span0 (PVar span0 name) (normalizeRhs rhs)
     FunctionBind _ name matches -> FunctionBind span0 name (map normalizeMatch matches)
 
 normalizeMatch :: Match -> Match

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -99,6 +99,7 @@ normalizeLiteral lit =
 normalizeUnaryInner :: Pattern -> Pattern
 normalizeUnaryInner pat =
   case normalizePattern pat of
+    PParen _ inner@(PCon {}) -> inner
     PParen _ inner@(PNegLit {}) -> inner
     PParen _ inner@(PStrict {}) -> inner
     PParen _ inner@(PIrrefutable {}) -> inner
@@ -111,6 +112,7 @@ normalizeUnaryInner pat =
 normalizeAsInner :: Pattern -> Pattern
 normalizeAsInner pat =
   case normalizePattern pat of
+    PParen _ inner@(PCon {}) -> inner
     PParen _ inner@(PNegLit {}) -> inner
     PParen _ inner@(PStrict {}) -> inner
     PParen _ inner@(PIrrefutable {}) -> inner


### PR DESCRIPTION
## Summary
- generalize `genFunctionDecl` so prefix function bindings generate `0..3` arbitrary patterns for any binder name
- generalize infix function bindings so both operands are arbitrary patterns instead of `PVar`s
- surface real decl pretty-printer/parser round-trip failures exposed by the broader generator

## Checks
- `coderabbit review --prompt-only`
- `just check` (fails in `aihc-parser` decl round-trip property)
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "generated decl AST pretty-printer round-trip" --hide-successes'` (fails)

## Failures Found
- Infix head parsing rejects some pretty-printed arbitrary patterns, for example:
  - `$p_ \`a\` uV@73.5 = ''LlOB4`
  - parser error: `unexpected \`` / `expecting end of input`
- Prefix head round-tripping can split constructor patterns with arguments into multiple head patterns, for example a pretty-printed form like:
  - `(/) Dp3AeW.R.Yd'a7 (DD7 {...}) (~(_ :: p)) 'N' = (#  #)`
  - parses back as separate head patterns instead of a single constructor application pattern

## Progress
- Progress counts unchanged; no README updates included per repo policy.
