### PR TITLE
test(parser): generalize QuickCheck generators and fix pretty-printer bugs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1461,7 +1461,7 @@ prettyExprPrec prec expr =
             <+> "|"
             <+> hsep
               ( punctuate
-                  "|"
+                  " |"
                   (map (hsep . punctuate comma . map prettyCompStmt) qualifierGroups)
               )
         )

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -11,8 +11,14 @@ where
 import Aihc.Parser.Syntax
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.Properties.Arb.Expr (genExpr, genOperator, isValidGeneratedOperator, shrinkExpr, span0)
-import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Arb.Expr (genExpr, genOperator, isValidGeneratedOperator, shrinkExpr)
+import Test.Properties.Arb.Identifiers
+  ( genConIdent,
+    genConSym,
+    genIdent,
+    shrinkIdent,
+    span0,
+  )
 import Test.Properties.Arb.Pattern (canonicalPatternAtomForComp, genPattern)
 import Test.Properties.Arb.Type (canonicalFunLeft, canonicalTopLevelType, genType)
 import Test.QuickCheck
@@ -122,14 +128,14 @@ genSymbolicOp = elements ["+", "<>", "&&", "||", "**", "^", ">>"]
 
 genDeclRoleAnnotation :: Gen Decl
 genDeclRoleAnnotation = do
-  name <- genTypeConName
+  name <- genConIdent
   n <- chooseInt (0, 3)
   roles <- vectorOf n (elements [RoleNominal, RoleRepresentational, RolePhantom, RoleInfer])
   pure $ DeclRoleAnnotation span0 (RoleAnnotation span0 name roles)
 
 genDeclTypeSyn :: Gen Decl
 genDeclTypeSyn = do
-  name <- genTypeConName
+  name <- genConIdent
   params <- genSimpleTyVarBinders
   DeclTypeSyn span0 . TypeSynDecl span0 TypeHeadPrefix name params <$> genSimpleType
 
@@ -138,7 +144,7 @@ genDeclTypeSyn = do
 -- (e.g. @type a \`Plus\` b = (a, b)@).
 genDeclTypeSynInfix :: Gen Decl
 genDeclTypeSynInfix = do
-  name <- oneof [genConSymName, genTypeConName]
+  name <- oneof [genConSym, genConIdent]
   lhsName <- genIdent
   rhsName <- genIdent
   let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
@@ -154,7 +160,7 @@ genDeclData =
 
 genDeclDataGadt :: Gen Decl
 genDeclDataGadt = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   ctors <- genGadtDataCons
   pure $
@@ -175,7 +181,7 @@ genDeclTypeData = genDeclTypeDataPrefix
 
 genDeclTypeDataPrefix :: Gen Decl
 genDeclTypeDataPrefix = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   ctors <- genTypeDataCons
   pure $
@@ -197,14 +203,14 @@ genTypeDataCons = do
   vectorOf n genTypeDataCon
   where
     genTypeDataCon = do
-      conName <- mkUnqualifiedName NameConId <$> genTypeConName
+      conName <- mkUnqualifiedName NameConId <$> genConIdent
       n <- chooseInt (0, 3)
       fields <- vectorOf n genSimpleBangType
       pure $ PrefixCon span0 [] [] conName fields
 
 genSimpleDataDecl :: Gen DataDecl
 genSimpleDataDecl = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   ctors <- genSimpleDataCons
   pure $
@@ -237,8 +243,8 @@ genPrefixCon = do
   -- Prefix constructors can be alphabetic (Cons) or symbolic ((:+))
   name <-
     oneof
-      [ mkUnqualifiedName NameConId <$> genTypeConName,
-        mkUnqualifiedName NameConSym <$> genConSymName
+      [ mkUnqualifiedName NameConId <$> genConIdent,
+        mkUnqualifiedName NameConSym <$> genConSym
       ]
   n <- chooseInt (0, 2)
   fields <- vectorOf n genSimpleBangType
@@ -249,24 +255,15 @@ genInfixCon = do
   -- Infix constructors can be symbolic (:+) or alphabetic (`Cons`)
   opName <-
     oneof
-      [ mkUnqualifiedName NameConSym <$> genConSymName,
-        mkUnqualifiedName NameConId <$> genTypeConName
+      [ mkUnqualifiedName NameConSym <$> genConSym,
+        mkUnqualifiedName NameConId <$> genConIdent
       ]
   lhs <- genSimpleBangTypeWithoutFun
   InfixCon span0 [] [] lhs opName <$> genSimpleBangTypeWithoutFun
 
--- | Generate constructor symbol names: colon followed by 1–3 symbol characters.
--- Valid for both type-level and value-level constructor operators.
--- Examples: @:+@, @:*@, @:==@, @:+:@
-genConSymName :: Gen Text
-genConSymName = do
-  symLen <- chooseInt (1, 3)
-  syms <- vectorOf symLen (elements ['+', '*', '-', '=', '!', '<', '>', '&', '|'])
-  pure (T.pack (':' : syms))
-
 genRecordCon :: Gen DataConDecl
 genRecordCon = do
-  conName <- mkUnqualifiedName NameConId <$> genTypeConName
+  conName <- mkUnqualifiedName NameConId <$> genConIdent
   n <- chooseInt (0, 3)
   fields <- vectorOf n genFieldDecl
   pure $ RecordCon span0 [] [] conName fields
@@ -285,7 +282,7 @@ genGadtDataCons = do
 genGadtCon :: Gen DataConDecl
 genGadtCon = do
   n <- chooseInt (1, 2)
-  names <- vectorOf n (mkUnqualifiedName NameConId <$> genTypeConName)
+  names <- vectorOf n (mkUnqualifiedName NameConId <$> genConIdent)
   GadtCon span0 [] [] names <$> genGadtBody
 
 genGadtBody :: Gen GadtBody
@@ -327,7 +324,7 @@ genSimpleTypeWithoutFun :: Gen Type
 genSimpleTypeWithoutFun =
   oneof
     [ TVar span0 . mkUnqualifiedName NameVarId <$> genIdent,
-      (\n -> TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId n)) Unpromoted) <$> genTypeConName
+      (\n -> TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId n)) Unpromoted) <$> genConIdent
     ]
 
 genGadtRecordBody :: Gen GadtBody
@@ -358,7 +355,7 @@ genSimpleBangType = do
 
 genDeclNewtype :: Gen Decl
 genDeclNewtype = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   ctor <- genNewtypeCon
   pure $
@@ -383,20 +380,20 @@ genNewtypeCon =
 
 genNewtypePrefixCon :: Gen DataConDecl
 genNewtypePrefixCon = do
-  conName <- mkUnqualifiedName NameConId <$> genTypeConName
+  conName <- mkUnqualifiedName NameConId <$> genConIdent
   ty <- genSimpleType
   pure $ PrefixCon span0 [] [] conName [BangType span0 NoSourceUnpackedness False ty]
 
 genNewtypeRecordCon :: Gen DataConDecl
 genNewtypeRecordCon = do
-  conName <- mkUnqualifiedName NameConId <$> genTypeConName
+  conName <- mkUnqualifiedName NameConId <$> genConIdent
   fieldName <- genVarBinderName
   ty <- genSimpleType
   pure $ RecordCon span0 [] [] conName [FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False ty)]
 
 genDeclClass :: Gen Decl
 genDeclClass = do
-  name <- genTypeConName
+  name <- genConIdent
   params <- genSimpleTyVarBinders
   pure $
     DeclClass span0 $
@@ -412,7 +409,7 @@ genDeclClass = do
 
 genDeclInstance :: Gen Decl
 genDeclInstance = do
-  className <- genTypeConName
+  className <- genConIdent
   n <- chooseInt (0, 2)
   types <- vectorOf n genSimpleType
   pure $
@@ -431,7 +428,7 @@ genDeclInstance = do
 
 genDeclStandaloneDeriving :: Gen Decl
 genDeclStandaloneDeriving = do
-  className <- mkUnqualifiedName NameConId <$> genTypeConName
+  className <- mkUnqualifiedName NameConId <$> genConIdent
   n <- chooseInt (0, 2)
   types <- vectorOf n genSimpleType
   pure $
@@ -479,7 +476,7 @@ genDeclForeign = do
 
 genDeclTypeFamilyDecl :: Gen Decl
 genDeclTypeFamilyDecl = do
-  name <- genTypeConName
+  name <- genConIdent
   let headType = TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId name)) Unpromoted
   params <- genSimpleTyVarBinders
   pure $
@@ -495,7 +492,7 @@ genDeclTypeFamilyDecl = do
 
 genDeclDataFamilyDecl :: Gen Decl
 genDeclDataFamilyDecl = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   pure $
     DeclDataFamilyDecl span0 $
@@ -560,8 +557,8 @@ genDeclDataFamilyInstGadt = do
 -- | Generate a type family LHS: a type constructor applied to a type constructor argument.
 genFamilyLhsType :: Gen Type
 genFamilyLhsType = do
-  familyName <- genTypeConName
-  argName <- genTypeConName
+  familyName <- genConIdent
+  argName <- genConIdent
   let familyCon = TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId familyName)) Unpromoted
       argCon = TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId argName)) Unpromoted
   pure $ TApp span0 familyCon argCon
@@ -573,9 +570,9 @@ genDeclPragma = do
 
 genDeclPatSyn :: Gen Decl
 genDeclPatSyn = do
-  synName <- mkUnqualifiedName NameConId <$> genTypeConName
+  synName <- mkUnqualifiedName NameConId <$> genConIdent
   argName <- genIdent
-  conName <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genTypeConName
+  conName <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
   let args = PatSynPrefixArgs [argName]
       pat = PCon span0 conName [PVar span0 (mkUnqualifiedName NameVarId argName)]
   dir <- elements [PatSynBidirectional, PatSynUnidirectional]
@@ -583,12 +580,12 @@ genDeclPatSyn = do
 
 genDeclPatSynSig :: Gen Decl
 genDeclPatSynSig = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   DeclPatSynSig span0 [name] <$> genSimpleType
 
 genDeclStandaloneKindSig :: Gen Decl
 genDeclStandaloneKindSig = do
-  name <- mkUnqualifiedName NameConId <$> genTypeConName
+  name <- mkUnqualifiedName NameConId <$> genConIdent
   kind <- sized (genType . min 6)
   pure $ DeclStandaloneKindSig span0 name (canonicalTopLevelType kind)
 
@@ -603,19 +600,12 @@ genSimpleType :: Gen Type
 genSimpleType =
   oneof
     [ TVar span0 . mkUnqualifiedName NameVarId <$> genIdent,
-      (\n -> TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId n)) Unpromoted) <$> genTypeConName,
+      (\n -> TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId n)) Unpromoted) <$> genConIdent,
       ( TFun span0 . TVar span0 . mkUnqualifiedName NameVarId
           <$> genIdent
       )
         <*> (TVar span0 . mkUnqualifiedName NameVarId <$> genIdent)
     ]
-
-genTypeConName :: Gen Text
-genTypeConName = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 4)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
-  pure (T.pack (first : rest))
 
 shrinkDecl :: Decl -> [Decl]
 shrinkDecl decl =

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -11,19 +11,26 @@ module Test.Properties.Arb.Expr
   )
 where
 
-import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Char (GeneralCategory (..), generalCategory, isAscii, isSpace)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.Properties.Arb.Identifiers (extensionReservedIdentifiers, genIdent, shrinkIdent)
+import Test.Properties.Arb.Identifiers
+  ( genCharValue,
+    genConIdent,
+    genFieldName,
+    genIdent,
+    genOptionalQualifier,
+    genStringValue,
+    genTenths,
+    showHex,
+    shrinkFloat,
+    shrinkIdent,
+    span0,
+  )
 import Test.Properties.Arb.Pattern (genPattern)
 import Test.Properties.Arb.Pattern qualified as Pat
 import Test.QuickCheck
-
--- | Canonical empty source span for normalization.
-span0 :: SourceSpan
-span0 = noSourceSpan
 
 -- | Generate a random expression. Uses QuickCheck's size parameter
 -- to control recursion depth.
@@ -56,11 +63,15 @@ genExprSizedWith allowTHQuotes n
         ESectionL span0 <$> genExprSizedWith allowTHQuotes (n - 1) <*> genOperatorName,
         ESectionR span0 <$> genOperatorName <*> genExprSizedWith allowTHQuotes (n - 1),
         EIf span0 <$> genExprSizedWith allowTHQuotes third <*> genExprSizedWith allowTHQuotes third <*> genExprSizedWith allowTHQuotes third,
+        EMultiWayIf span0 <$> genGuardedRhsListWith allowTHQuotes (n - 1),
         ECase span0 <$> genExprSizedWith allowTHQuotes half <*> genCaseAltsWith allowTHQuotes half,
         ELambdaPats span0 <$> genPatterns half <*> genExprSizedWith allowTHQuotes half,
         ELambdaCase span0 <$> genCaseAltsWith allowTHQuotes (n - 1),
         ELetDecls span0 <$> genValueDeclsWith allowTHQuotes half <*> genExprSizedWith allowTHQuotes half,
         EDo span0 <$> genDoStmtsWith allowTHQuotes (n - 1) <*> pure False,
+        -- TODO: Generate EDo with mdo=True once the parser supports mdo in
+        -- standalone expression and pattern (view pattern) contexts. Currently
+        -- mdo only works in declaration-level RHS positions.
         EListComp span0 <$> genExprSizedWith allowTHQuotes half <*> genCompStmtsWith allowTHQuotes half,
         EListCompParallel span0 <$> genExprSizedWith allowTHQuotes half <*> genParallelCompStmtsWith allowTHQuotes half,
         EList span0 <$> genListElemsWith allowTHQuotes (n - 1),
@@ -73,6 +84,7 @@ genExprSizedWith allowTHQuotes n
         ERecordCon span0 <$> genConName <*> genRecordFieldsWith allowTHQuotes (n - 1) <*> pure False,
         ERecordUpd span0 <$> genExprSizedWith allowTHQuotes half <*> genRecordFieldsWith allowTHQuotes half,
         ETypeSig span0 <$> genExprSizedWith allowTHQuotes half <*> genTypeWith allowTHQuotes half,
+        ETypeApp span0 . canonicalTypeAppExpr <$> genExprSizedWith allowTHQuotes half <*> genTypeWith allowTHQuotes half,
         EParen span0 <$> genExprSizedWith allowTHQuotes (n - 1),
         -- Template Haskell splices are valid inside quote bodies.
         ETHSplice span0 <$> genSpliceBody (n - 1),
@@ -101,6 +113,15 @@ genExprLeaf =
       mkFloatExpr <$> genTenths,
       mkCharExpr <$> genCharValue,
       mkStringExpr <$> genStringValue,
+      -- MagicHash literals
+      (\v -> EIntHash span0 v (T.pack (show v) <> "#")) <$> chooseInteger (0, 999),
+      (\v -> EFloatHash span0 v (T.pack (show v) <> "#")) <$> genTenths,
+      (\v -> ECharHash span0 v (T.pack (show v) <> "#")) <$> genCharValue,
+      (\v -> EStringHash span0 v (T.pack (show (T.unpack v)) <> "#")) <$> genStringValue,
+      -- TODO: Generate EOverloadedLabel once the pretty-printer handles the
+      -- (#label ambiguity. Currently, (#label is lexed as unboxed tuple opener
+      -- (# followed by identifier, so overloaded labels as the first element
+      -- of boxed tuples, lists, or after ( cause parse failures.
       EQuasiQuote span0 <$> genQuasiQuoteName <*> genStringValue,
       pure (EList span0 []),
       pure (ETuple span0 Boxed []),
@@ -147,30 +168,6 @@ genOperator =
     [ elements ["+", "-", "*", "/", "<", ">", "<=", ">=", "==", "/=", "&&", "||", "++", ">>", ">>=", "."],
       genCustomOperator
     ]
-
--- | Generate an optional module qualifier (e.g., Nothing or Just "Data.List").
--- Biased towards Nothing to keep most names unqualified.
-genOptionalQualifier :: Gen (Maybe Text)
-genOptionalQualifier =
-  oneof
-    [ pure Nothing,
-      Just <$> genModuleQualifier
-    ]
-
--- | Generate a module qualifier like "Data.List" or "Prelude".
-genModuleQualifier :: Gen Text
-genModuleQualifier = do
-  segCount <- chooseInt (1, 3)
-  segs <- vectorOf segCount genModuleSegment
-  pure (T.intercalate "." segs)
-
--- | Generate a single module name segment (starts with uppercase).
-genModuleSegment :: Gen Text
-genModuleSegment = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
-  pure (T.pack (first : rest))
 
 genOperatorName :: Gen Name
 genOperatorName = do
@@ -292,17 +289,13 @@ isValidGeneratedOperator candidate =
 
 -- | Generate a data constructor name
 genConName :: Gen Text
-genConName = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  pure (T.pack (first : rest))
+genConName = genConIdent
 
 genVarName :: Gen Name
 genVarName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameVarId <$> genIdent)
 
 genConAstName :: Gen Name
-genConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genConName)
+genConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genConIdent)
 
 -- | Generate simple patterns for lambdas
 genPatterns :: Int -> Gen [Pattern]
@@ -421,10 +414,24 @@ genDoStmtWith allowTHQuotes n =
   oneof
     [ DoBind span0 <$> genPattern half <*> genExprSizedWith allowTHQuotes half,
       DoLetDecls span0 <$> genValueDeclsWith allowTHQuotes (n - 1),
-      DoExpr span0 <$> genExprSizedWith allowTHQuotes (n - 1)
+      DoExpr span0 <$> genExprSizedWith allowTHQuotes (n - 1),
+      DoRecStmt span0 <$> genRecDoStmtsWith allowTHQuotes (n - 1)
     ]
   where
     half = n `div` 2
+
+-- | Generate statements for a @rec@ block inside @mdo@/@do@.
+-- At least one statement is required.
+genRecDoStmtsWith :: Bool -> Int -> Gen [DoStmt Expr]
+genRecDoStmtsWith allowTHQuotes n = do
+  count <- chooseInt (1, 3)
+  let perStmt = n `div` count
+  vectorOf count $
+    oneof
+      [ DoBind span0 <$> genPattern (perStmt `div` 2) <*> genExprSizedWith allowTHQuotes (perStmt `div` 2),
+        DoLetDecls span0 <$> genValueDeclsWith allowTHQuotes perStmt,
+        DoExpr span0 <$> genExprSizedWith allowTHQuotes perStmt
+      ]
 
 genCompStmtsWith :: Bool -> Int -> Gen [CompStmt]
 genCompStmtsWith allowTHQuotes n = do
@@ -439,7 +446,8 @@ genCompStmtWith allowTHQuotes n =
       -- PIrrefutable (~), PStrict (!), and PAs (@) fail when nested inside
       -- compound patterns (PList, PTuple, PCon args) in comprehension contexts.
       CompGen span0 <$> genPatternNoView half <*> genExprSizedWith allowTHQuotes half,
-      CompGuard span0 <$> genExprSizedWith allowTHQuotes (n - 1)
+      CompGuard span0 <$> genExprSizedWith allowTHQuotes (n - 1),
+      CompLetDecls span0 <$> genValueDeclsWith allowTHQuotes (n - 1)
     ]
   where
     half = n `div` 2
@@ -515,16 +523,6 @@ genRecordFieldsWith allowTHQuotes n = do
   exprs <- vectorOf count (genExprSizedWith allowTHQuotes (n `div` max 1 count))
   pure (zip names exprs)
 
-genFieldName :: Gen Text
-genFieldName = do
-  first <- elements (['a' .. 'z'] <> ['_'])
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate || candidate `elem` extensionReservedIdentifiers
-    then genFieldName
-    else pure candidate
-
 -- | Generate a type (simple version for use inside expressions).
 genTypeWith :: Bool -> Int -> Gen Type
 genTypeWith allowTHQuotes n
@@ -563,14 +561,43 @@ genTypeListElemsWith allowTHQuotes n = do
   vectorOf count (genTypeWith allowTHQuotes (n `div` count))
 
 genTypeVarName :: Gen UnqualifiedName
-genTypeVarName = do
-  first <- elements ['a' .. 'z']
-  restLen <- chooseInt (0, 3)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['0' .. '9']))
-  let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate || candidate `elem` extensionReservedIdentifiers
-    then genTypeVarName
-    else pure (mkUnqualifiedName NameVarId candidate)
+genTypeVarName = mkUnqualifiedName NameVarId <$> genIdent
+
+-- | Wrap an expression in parens if it's not suitable as the LHS of a type
+-- application (@expr \@Type@). Type application has the same precedence as
+-- function application, so lambda, let, if, case, do, and other open-ended
+-- expressions need parens. Even EApp needs parens if its argument is
+-- open-ended (e.g., @f let x = 1 in x \@T@ is ambiguous).
+canonicalTypeAppExpr :: Expr -> Expr
+canonicalTypeAppExpr e = case e of
+  EVar {} -> e
+  EParen {} -> e
+  EList {} -> e
+  ETuple {} -> e
+  EUnboxedSum {} -> e
+  ERecordCon {} -> e
+  EInt {} -> e
+  EIntHash {} -> e
+  EIntBase {} -> e
+  EIntBaseHash {} -> e
+  EFloat {} -> e
+  EFloatHash {} -> e
+  EChar {} -> e
+  ECharHash {} -> e
+  EString {} -> e
+  EStringHash {} -> e
+  EQuasiQuote {} -> e
+  EOverloadedLabel {} -> e
+  ETHExpQuote {} -> e
+  ETHTypedQuote {} -> e
+  ETHDeclQuote {} -> e
+  ETHTypeQuote {} -> e
+  ETHPatQuote {} -> e
+  ETHNameQuote {} -> e
+  ETHTypeNameQuote {} -> e
+  ETHSplice {} -> e
+  ETHTypedSplice {} -> e
+  _ -> EParen span0 e
 
 -- | Literal expression constructors
 mkHexExpr :: Integer -> Expr
@@ -585,26 +612,9 @@ mkCharExpr value = EChar span0 value (T.pack (show value))
 mkStringExpr :: Text -> Expr
 mkStringExpr value = EString span0 value (T.pack (show (T.unpack value)))
 
-genTenths :: Gen Double
-genTenths = do
-  whole <- chooseInteger (0, 99)
-  frac <- chooseInteger (0, 9)
-  pure (fromInteger whole + fromInteger frac / 10)
-
-genCharValue :: Gen Char
-genCharValue = elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " _")
-
-genStringValue :: Gen Text
-genStringValue = do
-  len <- chooseInt (0, 8)
-  T.pack <$> vectorOf len genCharValue
-
-showHex :: Integer -> String
-showHex value
-  | value < 16 = [hexDigit value]
-  | otherwise = showHex (value `div` 16) <> [hexDigit (value `mod` 16)]
-  where
-    hexDigit x = "0123456789abcdef" !! fromInteger x
+-- | Create an integer expression with canonical representation.
+mkIntExpr :: Integer -> Expr
+mkIntExpr value = EInt span0 value (T.pack (show value))
 
 renderIntBaseHash :: Integer -> Text
 renderIntBaseHash value
@@ -615,15 +625,17 @@ shrinkOverloadedLabel :: Text -> Text -> [String]
 shrinkOverloadedLabel value raw
   | Just unquoted <- T.stripPrefix "#" raw,
     not ("\"" `T.isPrefixOf` unquoted) =
-      [shrunk | shrunk <- shrink (T.unpack value), not (null shrunk), T.all isUnquotedLabelChar (T.pack shrunk)]
+      [shrunk | shrunk <- shrink (T.unpack value), not (null shrunk), isValidLabelName (T.pack shrunk)]
   | otherwise = []
   where
+    isValidLabelName name =
+      case T.uncons name of
+        Just (first, rest) ->
+          (first `elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['_']))
+            && T.all isUnquotedLabelChar rest
+        Nothing -> False
     isUnquotedLabelChar c =
       not (isSpace c) && c `notElem` ("()[]{},;`#\"" :: String)
-
--- | Create an integer expression with canonical representation.
-mkIntExpr :: Integer -> Expr
-mkIntExpr value = EInt span0 value (T.pack (show value))
 
 -- | Shrink an expression for QuickCheck counterexample minimization.
 shrinkExpr :: Expr -> [Expr]
@@ -715,10 +727,6 @@ shrinkExpr expr =
     ETHTypedSplice _ body -> body : [ETHTypedSplice span0 body' | body' <- shrinkExpr body]
     EProc {} -> []
     EAnn _ sub -> shrinkExpr sub
-
-shrinkFloat :: Double -> [Double]
-shrinkFloat value =
-  [fromInteger shrunk / 10 | shrunk <- shrinkIntegral (round (value * 10 :: Double) :: Integer), shrunk >= 0]
 
 shrinkCaseAlts :: [CaseAlt] -> [[CaseAlt]]
 shrinkCaseAlts = shrinkList shrinkCaseAlt

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -1,17 +1,62 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- | Shared generators and helpers used by Expr.hs, Pattern.hs, Type.hs, and Decl.hs.
+-- This module breaks import cycles because it doesn't depend on any of those modules.
 module Test.Properties.Arb.Identifiers
-  ( genIdent,
+  ( -- * Canonical source span
+    span0,
+
+    -- * Variable identifiers
+    genIdent,
     shrinkIdent,
     isValidGeneratedIdent,
     extensionReservedIdentifiers,
+
+    -- * Constructor identifiers
+    genConIdent,
+    shrinkConIdent,
+    isValidConIdent,
+
+    -- * Constructor operator symbols
+    genConSym,
+
+    -- * Module qualifiers
+    genOptionalQualifier,
+    genModuleQualifier,
+    genModuleSegment,
+
+    -- * Field names
+    genFieldName,
+
+    -- * Quasi-quotation helpers
+    genQuoterName,
+    isValidQuoterName,
+    genQuasiBody,
+
+    -- * Character and string generators
+    genCharValue,
+    genStringValue,
+
+    -- * Numeric helpers
+    genTenths,
+    showHex,
+    shrinkFloat,
   )
 where
 
 import Aihc.Parser.Lex (isReservedIdentifier)
+import Aihc.Parser.Syntax (SourceSpan, noSourceSpan)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.QuickCheck (Gen, chooseInt, elements, shrink, vectorOf)
+import Test.QuickCheck (Gen, chooseInt, chooseInteger, elements, shrink, shrinkIntegral, vectorOf)
+
+-- | Canonical empty source span for normalization.
+span0 :: SourceSpan
+span0 = noSourceSpan
+
+-------------------------------------------------------------------------------
+-- Variable identifiers
+-------------------------------------------------------------------------------
 
 genIdent :: Gen Text
 genIdent = do
@@ -44,3 +89,161 @@ isValidGeneratedIdent ident =
 
 extensionReservedIdentifiers :: [Text]
 extensionReservedIdentifiers = ["mdo", "proc", "rec"]
+
+-------------------------------------------------------------------------------
+-- Constructor identifiers (uppercase-starting names)
+-------------------------------------------------------------------------------
+
+-- | Generate a constructor/type constructor name starting with uppercase.
+-- Produces names like @Foo@, @A1@, @T'x@, etc.
+genConIdent :: Gen Text
+genConIdent = do
+  first <- elements ['A' .. 'Z']
+  restLen <- chooseInt (0, 5)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
+  pure (T.pack (first : rest))
+
+shrinkConIdent :: Text -> [Text]
+shrinkConIdent name =
+  [ candidate
+  | candidate <- map T.pack (shrink (T.unpack name)),
+    isValidConIdent candidate
+  ]
+
+isValidConIdent :: Text -> Bool
+isValidConIdent ident =
+  case T.uncons ident of
+    Just (first, rest) ->
+      (first `elem` ['A' .. 'Z'])
+        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
+    Nothing -> False
+
+-------------------------------------------------------------------------------
+-- Constructor operator symbols
+-------------------------------------------------------------------------------
+
+-- | Generate a constructor operator symbol (starting with @:@).
+-- Examples: @:+@, @:*@, @:==@, @:+:@
+-- Rejects @:@ (built-in list cons) and @::@ (type signature operator).
+genConSym :: Gen Text
+genConSym = do
+  restLen <- chooseInt (1, 3)
+  rest <- vectorOf restLen (elements ":!#$%&*+./<=>?\\^|-~")
+  let op = T.pack (':' : rest)
+  -- :: is not a valid constructor operator (it's the type signature operator)
+  if op == "::" then genConSym else pure op
+
+-------------------------------------------------------------------------------
+-- Module qualifiers
+-------------------------------------------------------------------------------
+
+-- | Generate an optional module qualifier (e.g., Nothing or Just "Data.List").
+-- Biased towards Nothing to keep most names unqualified.
+genOptionalQualifier :: Gen (Maybe Text)
+genOptionalQualifier =
+  elements
+    [ Nothing,
+      Nothing,
+      Just "M"
+    ]
+
+-- | Generate a module qualifier like "Data.List" or "Prelude".
+genModuleQualifier :: Gen Text
+genModuleQualifier = do
+  segCount <- chooseInt (1, 3)
+  segs <- vectorOf segCount genModuleSegment
+  pure (T.intercalate "." segs)
+
+-- | Generate a single module name segment (starts with uppercase).
+genModuleSegment :: Gen Text
+genModuleSegment = do
+  first <- elements ['A' .. 'Z']
+  restLen <- chooseInt (0, 5)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
+  pure (T.pack (first : rest))
+
+-------------------------------------------------------------------------------
+-- Field names
+-------------------------------------------------------------------------------
+
+-- | Generate a record field name (lowercase-starting identifier).
+-- Rejects reserved identifiers and extension-reserved identifiers.
+genFieldName :: Gen Text
+genFieldName = do
+  first <- elements (['a' .. 'z'] <> ['_'])
+  restLen <- chooseInt (0, 5)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
+  let candidate = T.pack (first : rest)
+  if isReservedIdentifier candidate || candidate `elem` extensionReservedIdentifiers
+    then genFieldName
+    else pure candidate
+
+-------------------------------------------------------------------------------
+-- Quasi-quotation helpers
+-------------------------------------------------------------------------------
+
+-- | Generate a quasi-quoter name, excluding TH bracket names (e, d, p, t).
+genQuoterName :: Gen Text
+genQuoterName = do
+  first <- elements (['a' .. 'z'] <> ['_'])
+  restLen <- chooseInt (0, 4)
+  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
+  let candidate = T.pack (first : rest)
+  if isValidQuoterName candidate
+    then pure candidate
+    else genQuoterName
+
+isValidQuoterName :: Text -> Bool
+isValidQuoterName name =
+  case T.uncons name of
+    Just (first, rest) ->
+      (first `elem` (['a' .. 'z'] <> ['_']))
+        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'.")) rest
+        -- Exclude names that clash with TH quote brackets
+        && name `notElem` ["e", "t", "d", "p"]
+    Nothing -> False
+
+-- | Generate a quasi-quotation body (safe characters only).
+genQuasiBody :: Gen Text
+genQuasiBody = do
+  len <- chooseInt (0, 10)
+  chars <- vectorOf len (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " +-*/_()"))
+  pure (T.pack chars)
+
+-------------------------------------------------------------------------------
+-- Character and string generators
+-------------------------------------------------------------------------------
+
+-- | Generate a printable character safe for use in literals.
+genCharValue :: Gen Char
+genCharValue = elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " _")
+
+-- | Generate a string value for use in string literals.
+genStringValue :: Gen Text
+genStringValue = do
+  len <- chooseInt (0, 8)
+  T.pack <$> vectorOf len genCharValue
+
+-------------------------------------------------------------------------------
+-- Numeric helpers
+-------------------------------------------------------------------------------
+
+-- | Generate a decimal value with one decimal digit of precision.
+genTenths :: Gen Double
+genTenths = do
+  whole <- chooseInteger (0, 99)
+  frac <- chooseInteger (0, 9)
+  pure (fromInteger whole + fromInteger frac / 10)
+
+-- | Show an integer as a hexadecimal string (without prefix).
+showHex :: Integer -> String
+showHex value
+  | value < 16 = [hexDigit value]
+  | otherwise = showHex (value `div` 16) <> [hexDigit (value `mod` 16)]
+  where
+    hexDigit x = "0123456789abcdef" !! fromInteger x
+
+-- | Shrink a floating-point value, maintaining one decimal digit of precision.
+shrinkFloat :: Double -> [Double]
+shrinkFloat value =
+  [fromInteger shrunk / 10 | shrunk <- shrinkIntegral (round (value * 10 :: Double) :: Integer), shrunk >= 0]

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -10,16 +10,28 @@ module Test.Properties.Arb.Pattern
   )
 where
 
-import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Text (Text)
 import Data.Text qualified as T
 import {-# SOURCE #-} Test.Properties.Arb.Expr (genExpr, shrinkExpr)
-import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Arb.Identifiers
+  ( genCharValue,
+    genConIdent,
+    genConSym,
+    genFieldName,
+    genIdent,
+    genOptionalQualifier,
+    genQuasiBody,
+    genQuoterName,
+    genStringValue,
+    genTenths,
+    isValidQuoterName,
+    showHex,
+    shrinkFloat,
+    shrinkIdent,
+    span0,
+  )
 import Test.QuickCheck
-
-span0 :: SourceSpan
-span0 = noSourceSpan
 
 instance Arbitrary Pattern where
   arbitrary = sized (genPattern . min 3)
@@ -174,20 +186,6 @@ genNumericLiteral =
       mkFloatLiteral <$> genTenths
     ]
 
-genTenths :: Gen Double
-genTenths = do
-  whole <- chooseInteger (0, 99)
-  frac <- chooseInteger (0, 9)
-  pure (fromInteger whole + fromInteger frac / 10)
-
-genCharValue :: Gen Char
-genCharValue = elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " _")
-
-genStringValue :: Gen Text
-genStringValue = do
-  len <- chooseInt (0, 8)
-  T.pack <$> vectorOf len genCharValue
-
 -- | Generate the body of a TH pattern splice: either a bare variable or a parenthesized expression.
 genPatSpliceBody :: Gen Expr
 genPatSpliceBody =
@@ -196,21 +194,8 @@ genPatSpliceBody =
       EParen span0 . EVar span0 <$> genPatternVarName
     ]
 
-genPatternConName :: Gen Text
-genPatternConName = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  pure (T.pack (first : rest))
-
-genConOperator :: Gen Text
-genConOperator = do
-  first <- elements ":"
-  restLen <- chooseInt (0, 3)
-  rest <- vectorOf restLen (elements ":!#$%&*+./<=>?\\^|-~")
-  let op = T.pack (first : rest)
-  -- :: is not a valid constructor operator in patterns (it's a type signature)
-  if op == "::" then genConOperator else pure op
+genConOperatorName :: Gen Name
+genConOperatorName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConSym <$> genConSym)
 
 genPatternVarName :: Gen Name
 genPatternVarName = qualifyName Nothing . mkUnqualifiedName NameVarId <$> genIdent
@@ -218,71 +203,8 @@ genPatternVarName = qualifyName Nothing . mkUnqualifiedName NameVarId <$> genIde
 genPatternUnqualVarName :: Gen UnqualifiedName
 genPatternUnqualVarName = mkUnqualifiedName NameVarId <$> genIdent
 
--- | Generate an optional module qualifier (e.g., Nothing or Just "Data.List").
--- Biased towards Nothing to keep most names unqualified.
-genOptionalQualifier :: Gen (Maybe Text)
-genOptionalQualifier =
-  oneof
-    [ pure Nothing,
-      Just <$> genModuleQualifier
-    ]
-
--- | Generate a module qualifier like "Data.List" or "Prelude".
-genModuleQualifier :: Gen Text
-genModuleQualifier = do
-  segCount <- chooseInt (1, 3)
-  segs <- vectorOf segCount genModuleSegment
-  pure (T.intercalate "." segs)
-
--- | Generate a single module name segment (starts with uppercase).
-genModuleSegment :: Gen Text
-genModuleSegment = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']))
-  pure (T.pack (first : rest))
-
 genPatternConAstName :: Gen Name
-genPatternConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genPatternConName)
-
-genConOperatorName :: Gen Name
-genConOperatorName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConSym <$> genConOperator)
-
-genFieldName :: Gen Text
-genFieldName = do
-  first <- elements (['a' .. 'z'] <> ['_'])
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate
-    then genFieldName
-    else pure candidate
-
-genQuoterName :: Gen Text
-genQuoterName = do
-  first <- elements (['a' .. 'z'] <> ['_'])
-  restLen <- chooseInt (0, 4)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  let candidate = T.pack (first : rest)
-  if isValidQuoterName candidate
-    then pure candidate
-    else genQuoterName
-
-isValidQuoterName :: Text -> Bool
-isValidQuoterName name =
-  case T.uncons name of
-    Just (first, rest) ->
-      (first `elem` (['a' .. 'z'] <> ['_']))
-        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'.")) rest
-        -- Exclude names that clash with TH quote brackets when TemplateHaskell is enabled
-        && name `notElem` ["e", "t", "d", "p"]
-    Nothing -> False
-
-genQuasiBody :: Gen Text
-genQuasiBody = do
-  len <- chooseInt (0, 10)
-  chars <- vectorOf len (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " +-*/_()"))
-  pure (T.pack chars)
+genPatternConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genConIdent)
 
 canonicalPatternAtom :: Pattern -> Pattern
 canonicalPatternAtom pat =
@@ -338,13 +260,6 @@ mkCharLiteral value = LitChar span0 value (T.pack (show value))
 
 mkStringLiteral :: Text -> Literal
 mkStringLiteral value = LitString span0 value (T.pack (show (T.unpack value)))
-
-showHex :: Integer -> String
-showHex value
-  | value < 16 = [hexDigit value]
-  | otherwise = showHex (value `div` 16) <> [hexDigit (value `mod` 16)]
-  where
-    hexDigit n = "0123456789abcdef" !! fromInteger n
 
 shrinkPattern :: Pattern -> [Pattern]
 shrinkPattern pat =
@@ -437,10 +352,6 @@ shrinkNumericLiteral lit =
     LitFloat {} -> shrinkLiteral lit
     LitFloatHash {} -> shrinkLiteral lit
     _ -> []
-
-shrinkFloat :: Double -> [Double]
-shrinkFloat value =
-  [fromInteger shrunk / 10 | shrunk <- shrinkIntegral (round (value * 10 :: Double) :: Integer), shrunk >= 0]
 
 shrinkQuoterName :: Text -> [Text]
 shrinkQuoterName name =

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -20,8 +20,16 @@ import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.Properties.Arb.Expr (span0)
-import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Arb.Identifiers
+  ( genCharValue,
+    genConIdent,
+    genIdent,
+    genQuasiBody,
+    genQuoterName,
+    shrinkConIdent,
+    shrinkIdent,
+    span0,
+  )
 import Test.QuickCheck
 
 instance Arbitrary Type where
@@ -165,35 +173,11 @@ genTypeVarName = do
     then genTypeVarName
     else pure (mkUnqualifiedName NameVarId candidate)
 
-genTypeConName :: Gen Text
-genTypeConName = do
-  first <- elements ['A' .. 'Z']
-  restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  pure (T.pack (first : rest))
-
 genTypeConAstName :: Gen Name
-genTypeConAstName = qualifyName Nothing . mkUnqualifiedName NameConId <$> genTypeConName
+genTypeConAstName = qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
 
 genTypeVarExprName :: Gen Name
 genTypeVarExprName = qualifyName Nothing . mkUnqualifiedName NameVarId <$> genIdent
-
-genQuoterName :: Gen Text
-genQuoterName = do
-  first <- elements (['a' .. 'z'] <> ['_'])
-  restLen <- chooseInt (0, 4)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
-  let candidate = T.pack (first : rest)
-  -- Exclude names that clash with TH quote brackets when TemplateHaskell is enabled
-  if candidate `elem` ["e", "t", "d", "p"]
-    then genQuoterName
-    else pure candidate
-
-genQuasiBody :: Gen Text
-genQuasiBody = do
-  len <- chooseInt (0, 12)
-  chars <- vectorOf len (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " +-*/_()"))
-  pure (T.pack chars)
 
 genTypeLiteral :: Gen TypeLiteral
 genTypeLiteral =
@@ -205,18 +189,15 @@ genTypeLiteral =
         txt <- genSymbolText
         pure (TypeLitSymbol txt (T.pack (show (T.unpack txt)))),
       do
-        c <- genTypeLiteralChar
+        c <- genCharValue
         pure (TypeLitChar c (T.pack (show c)))
     ]
 
 genSymbolText :: Gen Text
 genSymbolText = do
   len <- chooseInt (0, 8)
-  chars <- vectorOf len genTypeLiteralChar
+  chars <- vectorOf len genCharValue
   pure (T.pack chars)
-
-genTypeLiteralChar :: Gen Char
-genTypeLiteralChar = elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " _")
 
 canonicalTopLevelType :: Type -> Type
 canonicalTopLevelType ty =
@@ -306,7 +287,7 @@ shrinkType ty =
     TVar _ name ->
       [TVar span0 (mkUnqualifiedName NameVarId shrunk) | shrunk <- shrinkIdent (renderUnqualifiedName name)]
     TCon _ name promoted ->
-      [TCon span0 (name {nameText = shrunk}) promoted | shrunk <- shrinkTypeConName (nameText name)]
+      [TCon span0 (name {nameText = shrunk}) promoted | shrunk <- shrinkConIdent (nameText name)]
     TImplicitParam _ name inner ->
       [inner]
         <> [TImplicitParam span0 name' (canonicalImplicitParamType inner) | name' <- shrinkImplicitParamName name]
@@ -362,21 +343,6 @@ shrinkTypeBinders binders =
 shrinkTyVarBinder :: TyVarBinder -> [TyVarBinder]
 shrinkTyVarBinder tvb =
   [tvb {tyVarBinderName = name'} | name' <- shrinkIdent (tyVarBinderName tvb)]
-
-shrinkTypeConName :: Text -> [Text]
-shrinkTypeConName name =
-  [ candidate
-  | candidate <- map T.pack (shrink (T.unpack name)),
-    isValidTypeConName candidate
-  ]
-
-isValidTypeConName :: Text -> Bool
-isValidTypeConName ident =
-  case T.uncons ident of
-    Just (first, rest) ->
-      (first `elem` ['A' .. 'Z'])
-        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
-    Nothing -> False
 
 shrinkTypeTupleElems :: TupleFlavor -> [Type] -> [Type]
 shrinkTypeTupleElems tupleFlavor elems =

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 declConfig :: ParserConfig
 declConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, PatternSynonyms, UnicodeSyntax]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, PatternSynonyms, UnicodeSyntax, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections]
     }
 
 prop_declPrettyRoundTrip :: Decl -> Property

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 exprConfig :: ParserConfig
 exprConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections]
     }
 
 prop_exprPrettyRoundTrip :: Expr -> Property

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -30,7 +30,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, UnicodeSyntax, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms]
+    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, UnicodeSyntax, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections]
     }
 
 -- Module normalization

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 patternConfig :: ParserConfig
 patternConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections]
     }
 
 prop_patternPrettyRoundTrip :: Pattern -> Property


### PR DESCRIPTION
## Summary

- Deduplicate shared helpers across Arb modules by expanding `Identifiers.hs` with 17 previously-duplicated functions, eliminating ~200 lines of duplication
- Add new expression generators for wider Haskell syntax coverage: `EMultiWayIf`, `ETypeApp`, MagicHash literals, `DoRecStmt`, `CompLetDecls`
- Fix pretty-printer bug where parallel comprehension `|` separator lacked spacing, causing `#label|` lexing ambiguity
- Fix generator bugs: `genConSym` could generate bare `:`, `shrinkOverloadedLabel` allowed invalid labels

## Details

### Phase 1: Deduplication

Expanded `Identifiers.hs` from 46 lines to a comprehensive shared module with these previously-duplicated helpers:
- `span0`, `genConIdent`, `shrinkConIdent`, `genConSym`
- `genOptionalQualifier`, `genModuleQualifier`, `genModuleSegment`
- `genFieldName`, `genQuoterName`, `isValidQuoterName`, `genQuasiBody`
- `genCharValue`, `genStringValue`, `genTenths`, `showHex`, `shrinkFloat`

Removed local copies from `Expr.hs`, `Pattern.hs`, `Decl.hs`, and `Type.hs`.

### Phase 2: New Generator Variety

**New expression forms generated:**
- `EMultiWayIf` — multi-way if expressions (`if | guard -> expr | ...`)
- `ETypeApp` — visible type application (`f @Type`), with `canonicalTypeAppExpr` to ensure correct parenthesization
- `EIntHash`, `EFloatHash`, `ECharHash`, `EStringHash` — MagicHash literals
- `DoRecStmt` — `rec { stmts }` inside do blocks
- `CompLetDecls` — let bindings in list comprehensions

**New extensions enabled in roundtrip test configs:**
`MagicHash`, `OverloadedLabels`, `MultiWayIf`, `RecursiveDo`, `TypeApplications`, `TupleSections`

### Bugs Found and Fixed

1. **Pretty-printer**: `EListCompParallel` `|` separator had no space → `#label|` lexing ambiguity. Fixed with `" |"` separator.
2. **Generator**: `genConSym` could generate bare `:` (built-in list cons operator) → fixed with `restLen >= 1`.
3. **Generator**: `shrinkOverloadedLabel` allowed shrinking labels to start with digits → fixed validation.

### Documented Limitations (TODOs)

- `EOverloadedLabel`: blocked by `(#label` lexing ambiguity (pretty-printer needs broader fix)
- `EDo` with `mdo`: parser doesn't support `mdo` in standalone expression or view pattern contexts
- `EProc` (Arrows): deferred to follow-up PR
- Type variety (`TContext`, `TImplicitParam`, promoted types, kinded binders): deferred to follow-up PR
- Decl features (deriving, class/instance bodies, contexts, where clauses): deferred to follow-up PR