### PR TITLE
test(parser): add Type and Decl variety to QuickCheck generators

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -205,14 +205,28 @@ genTypeDataCons = do
     genTypeDataCon = do
       conName <- mkUnqualifiedName NameConId <$> genConIdent
       n <- chooseInt (0, 3)
-      fields <- vectorOf n genSimpleBangType
+      -- Type data constructors don't support strictness annotations
+      fields <- vectorOf n genNonStrictBangType
       pure $ PrefixCon span0 [] [] conName fields
+
+-- | Generate a BangType that is never strict (for type data constructors).
+genNonStrictBangType :: Gen BangType
+genNonStrictBangType = do
+  ty <- genSimpleType
+  pure $
+    BangType
+      { bangSpan = span0,
+        bangSourceUnpackedness = NoSourceUnpackedness,
+        bangStrict = False,
+        bangType = ty
+      }
 
 genSimpleDataDecl :: Gen DataDecl
 genSimpleDataDecl = do
   name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   ctors <- genSimpleDataCons
+  deriving' <- genDerivingClauses
   pure $
     DataDecl
       { dataDeclSpan = span0,
@@ -222,7 +236,7 @@ genSimpleDataDecl = do
         dataDeclParams = params,
         dataDeclKind = Nothing,
         dataDeclConstructors = ctors,
-        dataDeclDeriving = []
+        dataDeclDeriving = deriving'
       }
 
 genSimpleDataCons :: Gen [DataConDecl]
@@ -345,11 +359,12 @@ genGadtFieldDecl = do
 genSimpleBangType :: Gen BangType
 genSimpleBangType = do
   ty <- genSimpleType
+  strict <- elements [False, False, False, True]
   pure $
     BangType
       { bangSpan = span0,
         bangSourceUnpackedness = NoSourceUnpackedness,
-        bangStrict = False,
+        bangStrict = strict,
         bangType = ty
       }
 
@@ -358,6 +373,7 @@ genDeclNewtype = do
   name <- mkUnqualifiedName NameConId <$> genConIdent
   params <- genSimpleTyVarBinders
   ctor <- genNewtypeCon
+  deriving' <- genDerivingClauses
   pure $
     DeclNewtype span0 $
       NewtypeDecl
@@ -368,7 +384,7 @@ genDeclNewtype = do
           newtypeDeclParams = params,
           newtypeDeclKind = Nothing,
           newtypeDeclConstructor = Just ctor,
-          newtypeDeclDeriving = []
+          newtypeDeclDeriving = deriving'
         }
 
 genNewtypeCon :: Gen DataConDecl
@@ -395,11 +411,12 @@ genDeclClass :: Gen Decl
 genDeclClass = do
   name <- genConIdent
   params <- genSimpleTyVarBinders
+  ctx <- genOptionalSimpleContext
   pure $
     DeclClass span0 $
       ClassDecl
         { classDeclSpan = span0,
-          classDeclContext = Nothing,
+          classDeclContext = ctx,
           classDeclHeadForm = TypeHeadPrefix,
           classDeclName = name,
           classDeclParams = params,
@@ -412,6 +429,7 @@ genDeclInstance = do
   className <- genConIdent
   n <- chooseInt (0, 2)
   types <- vectorOf n genSimpleType
+  ctx <- genSimpleContext
   pure $
     DeclInstance span0 $
       InstanceDecl
@@ -419,7 +437,7 @@ genDeclInstance = do
           instanceDeclOverlapPragma = Nothing,
           instanceDeclWarning = Nothing,
           instanceDeclForall = [],
-          instanceDeclContext = [],
+          instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
           instanceDeclClassName = className,
           instanceDeclTypes = types,
@@ -431,16 +449,18 @@ genDeclStandaloneDeriving = do
   className <- mkUnqualifiedName NameConId <$> genConIdent
   n <- chooseInt (0, 2)
   types <- vectorOf n genSimpleType
+  strategy <- elements [Nothing, Just DerivingStock, Just DerivingNewtype, Just DerivingAnyclass]
+  ctx <- genSimpleContext
   pure $
     DeclStandaloneDeriving span0 $
       StandaloneDerivingDecl
         { standaloneDerivingSpan = span0,
-          standaloneDerivingStrategy = Nothing,
+          standaloneDerivingStrategy = strategy,
           standaloneDerivingViaType = Nothing,
           standaloneDerivingOverlapPragma = Nothing,
           standaloneDerivingWarning = Nothing,
           standaloneDerivingForall = [],
-          standaloneDerivingContext = [],
+          standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
           standaloneDerivingClassName = className,
           standaloneDerivingTypes = types
@@ -459,16 +479,21 @@ genDeclSplice = do
 
 genDeclForeign :: Gen Decl
 genDeclForeign = do
-  callConv <- elements [CCall, StdCall]
+  callConv <- elements [CCall, StdCall, CApi]
+  direction <- elements [ForeignImport, ForeignExport]
+  -- Safety is only valid for imports, not exports
+  safety <- case direction of
+    ForeignImport -> elements [Nothing, Just Safe, Just Unsafe]
+    ForeignExport -> pure Nothing
   name <- genIdent
   ty <- genSimpleType
   pure $
     DeclForeign span0 $
       ForeignDecl
         { foreignDeclSpan = span0,
-          foreignDirection = ForeignImport,
+          foreignDirection = direction,
           foreignCallConv = callConv,
-          foreignSafety = Nothing,
+          foreignSafety = safety,
           foreignEntity = ForeignEntityOmitted,
           foreignName = name,
           foreignType = ty
@@ -606,6 +631,54 @@ genSimpleType =
       )
         <*> (TVar span0 . mkUnqualifiedName NameVarId <$> genIdent)
     ]
+
+-- | Generate deriving clauses (0-2).
+genDerivingClauses :: Gen [DerivingClause]
+genDerivingClauses = do
+  n <- frequency [(3, pure 0), (2, pure 1), (1, pure 2)]
+  vectorOf n genDerivingClause
+
+genDerivingClause :: Gen DerivingClause
+genDerivingClause = do
+  strategy <- elements [Nothing, Just DerivingStock]
+  n <- chooseInt (0, 3)
+  classes <- vectorOf n genSimpleConType
+  pure $
+    DerivingClause
+      { derivingStrategy = strategy,
+        derivingClasses = classes,
+        derivingViaType = Nothing,
+        derivingParenthesized = n /= 1
+      }
+
+-- | Generate a simple constructor type (used in deriving/context).
+genSimpleConType :: Gen Type
+genSimpleConType =
+  (\n -> TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId n)) Unpromoted) <$> genConIdent
+
+-- | Generate a simple constraint context (0-2 constraints).
+-- For instance contexts, 0 constraints means no context at all.
+genSimpleContext :: Gen [Type]
+genSimpleContext = do
+  n <- frequency [(3, pure 0), (2, pure 1), (1, pure 2)]
+  vectorOf n genSimpleConstraint
+
+-- | Generate an optional context (Nothing or Just [constraints]).
+-- Never generates Just [] since that prints as () => which roundtrips
+-- to a unit tuple in the constraint list.
+genOptionalSimpleContext :: Gen (Maybe [Type])
+genOptionalSimpleContext =
+  frequency
+    [ (3, pure Nothing),
+      (1, Just <$> do n <- chooseInt (1, 2); vectorOf n genSimpleConstraint)
+    ]
+
+-- | Generate a simple constraint: ClassName tyvar
+genSimpleConstraint :: Gen Type
+genSimpleConstraint =
+  TApp span0
+    <$> genSimpleConType
+    <*> (TVar span0 . mkUnqualifiedName NameVarId <$> genIdent)
 
 shrinkDecl :: Decl -> [Decl]
 shrinkDecl decl =

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -24,6 +24,7 @@ import Test.Properties.Arb.Identifiers
   ( genCharValue,
     genConIdent,
     genIdent,
+    genOptionalQualifier,
     genQuasiBody,
     genQuoterName,
     shrinkConIdent,
@@ -42,6 +43,7 @@ genType depth
       oneof
         [ TVar span0 <$> genTypeVarName,
           (\name -> TCon span0 name Unpromoted) <$> genTypeConAstName,
+          (\name -> TCon span0 name Promoted) <$> genPromotableTypeConName,
           TTypeLit span0 <$> genTypeLiteral,
           pure (TStar span0),
           pure (TWildcard span0),
@@ -56,6 +58,7 @@ genType depth
       frequency
         [ (3, TVar span0 <$> genTypeVarName),
           (3, (\name -> TCon span0 name Unpromoted) <$> genTypeConAstName),
+          (1, (\name -> TCon span0 name Promoted) <$> genPromotableTypeConName),
           (1, TTypeLit span0 <$> genTypeLiteral),
           (1, pure (TStar span0)),
           (1, pure (TWildcard span0)),
@@ -64,11 +67,18 @@ genType depth
           (4, genTypeApp depth),
           (4, genTypeFun depth),
           (3, TTuple span0 Boxed Unpromoted <$> genTypeTupleElems (depth - 1)),
+          (1, TTuple span0 Boxed Promoted <$> genPromotedTupleElems),
           (2, TTuple span0 Unboxed Unpromoted <$> genTypeTupleElems (depth - 1)),
           (2, TUnboxedSum span0 <$> genUnboxedSumElems (depth - 1)),
           (3, TList span0 Unpromoted <$> genTypeListElems (depth - 1)),
+          (1, TList span0 Promoted <$> genPromotedListElems),
           (3, TParen span0 <$> genType (depth - 1)),
-          (2, TSplice span0 <$> genTypeSpliceBody)
+          (2, TSplice span0 <$> genTypeSpliceBody),
+          (2, genTypeContext depth),
+          -- TODO: Generate TImplicitParam once the type parser supports ?name :: Type
+          -- in standalone type contexts. Currently only supported in declaration-level
+          -- type signatures.
+          (2, TKindSig span0 <$> genKindSigSubject (depth - 1) <*> genKindSigKind (depth - 1))
         ]
 
 genTypeApp :: Int -> Gen Type
@@ -99,6 +109,36 @@ genTypeSpliceBody =
       EParen span0 . EVar span0 <$> genTypeVarExprName
     ]
 
+-- | Generate a type with a context (constraints => type).
+-- Always wrapped in parens because constraints => type is a top-level
+-- form that needs parens in sub-type positions.
+genTypeContext :: Int -> Gen Type
+genTypeContext depth = do
+  n <- chooseInt (1, 3)
+  constraints <- vectorOf n (genConstraintType (depth - 1))
+  inner <- genType (depth - 1)
+  pure $ TParen span0 (canonicalContextType (map canonicalContextItem constraints) inner)
+
+-- | Generate a constraint type (used in contexts).
+-- Typically a type constructor applied to some arguments.
+genConstraintType :: Int -> Gen Type
+genConstraintType depth = do
+  className <- (\n -> TCon span0 n Unpromoted) <$> genTypeConAstName
+  oneof
+    [ -- Simple constraint: ClassName tyvar
+      TApp span0 className . TVar span0 <$> genTypeVarName,
+      -- Applied constraint: ClassName (Type)
+      TApp span0 className . TParen span0 <$> genType (max 0 depth)
+    ]
+
+-- TODO: Generate TImplicitParam once the type parser supports ?name :: Type
+-- in standalone type contexts.
+-- genTypeImplicitParam :: Int -> Gen Type
+-- genTypeImplicitParam depth = do
+--   name <- ("?" <>) <$> genIdent
+--   inner <- canonicalImplicitParamType <$> genType (depth - 1)
+--   pure $ TParen span0 (TImplicitParam span0 name inner)
+
 genTypeTupleElems :: Int -> Gen [Type]
 genTypeTupleElems depth = do
   isUnit <- arbitrary
@@ -117,6 +157,47 @@ genUnboxedSumElems :: Int -> Gen [Type]
 genUnboxedSumElems depth = do
   n <- chooseInt (2, 4)
   vectorOf n (genType depth)
+
+-- | Generate elements for a promoted tuple or list. Uses simple types only
+-- to avoid nesting ambiguities with kind signatures and unboxed tuples
+-- inside promoted containers.
+genPromotedTupleElems :: Gen [Type]
+genPromotedTupleElems = do
+  isUnit <- arbitrary
+  if isUnit
+    then pure []
+    else do
+      n <- chooseInt (2, 3)
+      vectorOf n genPromotedElem
+
+genPromotedListElems :: Gen [Type]
+genPromotedListElems = do
+  n <- chooseInt (1, 3)
+  vectorOf n genPromotedElem
+
+-- | Generate a simple type suitable for use inside promoted tuples/lists.
+-- Avoids character type literals since 'c' conflicts with the promotion tick.
+genPromotedElem :: Gen Type
+genPromotedElem =
+  oneof
+    [ TVar span0 <$> genTypeVarName,
+      (\name -> TCon span0 name Unpromoted) <$> genTypeConAstName,
+      genPromotedSafeTypeLiteral,
+      pure (TStar span0)
+    ]
+
+-- | Generate type literals safe for use in promoted contexts (no char literals).
+genPromotedSafeTypeLiteral :: Gen Type
+genPromotedSafeTypeLiteral =
+  TTypeLit span0
+    <$> oneof
+      [ do
+          n <- chooseInteger (0, 1000)
+          pure (TypeLitInteger n (T.pack (show n))),
+        do
+          txt <- genSymbolText
+          pure (TypeLitSymbol txt (T.pack (show (T.unpack txt))))
+      ]
 
 genTypeAtom :: Int -> Gen Type
 genTypeAtom depth =
@@ -161,7 +242,17 @@ genTypeBinders = do
 genTyVarBinder :: Gen TyVarBinder
 genTyVarBinder = do
   name <- genTypeVarName
-  pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBSpecified)
+  oneof
+    [ -- Plain specified binder: a
+      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBSpecified),
+      -- Plain inferred binder: {a}
+      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBInferred),
+      -- Kinded specified binder: (a :: Kind)
+      -- NOTE: Kinded inferred binders ({a :: Kind}) are not supported by the parser.
+      do
+        kind <- genSimpleTypeAtom 0
+        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBSpecified)
+    ]
 
 genTypeVarName :: Gen UnqualifiedName
 genTypeVarName = do
@@ -174,7 +265,15 @@ genTypeVarName = do
     else pure (mkUnqualifiedName NameVarId candidate)
 
 genTypeConAstName :: Gen Name
-genTypeConAstName = qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
+genTypeConAstName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameConId <$> genConIdent)
+
+-- | Generate a type constructor name that is safe for promotion with @'@.
+-- Avoids names containing @'@ since @'Name'rest@ would be lexed as
+-- a character literal @'N'@ followed by @amerest@.
+genPromotableTypeConName :: Gen Name
+genPromotableTypeConName = do
+  name <- suchThat genConIdent (\n -> T.length n >= 2 && not (T.any (== '\'') n))
+  pure (qualifyName Nothing (mkUnqualifiedName NameConId name))
 
 genTypeVarExprName :: Gen Name
 genTypeVarExprName = qualifyName Nothing . mkUnqualifiedName NameVarId <$> genIdent
@@ -243,6 +342,7 @@ canonicalFunLeft ty =
     TForall {} -> TParen span0 ty
     TFun {} -> TParen span0 ty
     TContext {} -> TParen span0 ty
+    TImplicitParam {} -> TParen span0 ty
     _ -> ty
 
 canonicalAppHead :: Type -> Type
@@ -251,6 +351,7 @@ canonicalAppHead ty =
     TForall {} -> TParen span0 ty
     TFun {} -> TParen span0 ty
     TContext {} -> TParen span0 ty
+    TImplicitParam {} -> TParen span0 ty
     _ -> ty
 
 canonicalAppArg :: Type -> Type
@@ -260,6 +361,7 @@ canonicalAppArg ty =
     TForall {} -> TParen span0 ty
     TFun {} -> TParen span0 ty
     TContext {} -> TParen span0 ty
+    TImplicitParam {} -> TParen span0 ty
     _ -> ty
 
 canonicalKindSigSubject :: Type -> Type
@@ -281,13 +383,30 @@ canonicalImplicitParamType ty =
     TContext {} -> TParen span0 ty
     _ -> ty
 
+-- | Types that require parentheses when appearing inside compound types
+-- (tuples, lists, application arguments, etc.). These are "top-level" type
+-- forms whose syntax is ambiguous without parens.
+needsParensInSubPosition :: Type -> Bool
+needsParensInSubPosition ty =
+  case ty of
+    TImplicitParam {} -> True
+    TContext {} -> True
+    TForall {} -> True
+    TFun {} -> True
+    _ -> False
+
 shrinkType :: Type -> [Type]
 shrinkType ty =
   case ty of
     TVar _ name ->
       [TVar span0 (mkUnqualifiedName NameVarId shrunk) | shrunk <- shrinkIdent (renderUnqualifiedName name)]
     TCon _ name promoted ->
-      [TCon span0 (name {nameText = shrunk}) promoted | shrunk <- shrinkConIdent (nameText name)]
+      [ TCon span0 (name {nameText = shrunk}) promoted
+      | shrunk <- shrinkConIdent (nameText name),
+        -- For promoted constructors, avoid names that cause ambiguity
+        -- with character literals (e.g., 'A'x lexed as char 'A' + var x)
+        promoted == Unpromoted || (T.length shrunk >= 2 && not (T.any (== '\'') shrunk))
+      ]
     TImplicitParam _ name inner ->
       [inner]
         <> [TImplicitParam span0 name' (canonicalImplicitParamType inner) | name' <- shrinkImplicitParamName name]
@@ -316,7 +435,9 @@ shrinkType ty =
     TList _ _ elems ->
       [TList span0 Unpromoted elems' | elems' <- shrinkList shrinkType elems, not (null elems')]
     TParen _ inner ->
-      [inner] <> [TParen span0 inner' | inner' <- shrinkType inner]
+      -- Don't unwrap parens around types that require them in sub-type positions
+      [inner | not (needsParensInSubPosition inner)]
+        <> [TParen span0 inner' | inner' <- shrinkType inner]
     TKindSig _ ty' kind ->
       [canonicalKindSigSubject ty', canonicalKindSigKind kind]
         <> [TKindSig span0 (canonicalKindSigSubject ty'') (canonicalKindSigKind kind) | ty'' <- shrinkType ty']

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 declConfig :: ParserConfig
 declConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, PatternSynonyms, UnicodeSyntax, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, PatternSynonyms, UnicodeSyntax, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, DerivingStrategies, CApiFFI]
     }
 
 prop_declPrettyRoundTrip :: Decl -> Property

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -30,7 +30,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, UnicodeSyntax, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections]
+    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, UnicodeSyntax, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, DerivingStrategies, CApiFFI]
     }
 
 -- Module normalization

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 typeConfig :: ParserConfig
 typeConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, DataKinds, ImplicitParams, KindSignatures, ExplicitForAll, RankNTypes]
     }
 
 prop_typePrettyRoundTrip :: Type -> Property
@@ -28,7 +28,7 @@ prop_typePrettyRoundTrip ty =
       expected = normalizeType (canonicalTopLevelType ty)
    in checkCoverage $
         withMaxShrinks 100 $
-          assertCtorCoverage ["TAnn", "TContext", "TImplicitParam"] ty $
+          assertCtorCoverage ["TAnn", "TImplicitParam"] ty $
             counterexample (T.unpack source) $
               case parseType typeConfig source of
                 ParseErr err ->


### PR DESCRIPTION
## Summary

- Add Type generator coverage: `TContext`, promoted types (DataKinds), kinded/inferred type variable binders, qualified type constructors, `TKindSig` in recursive position
- Add Decl generator coverage: deriving clauses, strictness annotations, class/instance contexts, standalone deriving strategies, foreign exports/safety/CApi
- Enable required extensions in roundtrip test configs

Follow-up to #731 (Phase 1-2).

## Type Generator Improvements

**New type forms generated:**
- `TContext` — constraint contexts (`Eq a => ...`), always wrapped in `TParen` for safe sub-positioning
- Promoted types via `DataKinds` — `TCon`/`TTuple`/`TList` with `Promoted` flag
- Kinded type variable binders — `(a :: Kind)` in `forall`
- Inferred type variable binders — `{a}` in `forall`
- Qualified type constructors — `M.Type`
- `TKindSig` in recursive position (not just leaves)

**Supporting changes:**
- `genPromotableTypeConName`: filters names where `'Name` would be ambiguous with character literals (requires no `'` in constructor name, ≥2 chars)
- `needsParensInSubPosition`: prevents shrinker from unwrapping parens around `TImplicitParam`/`TContext`/`TForall`/`TFun`
- Added `TImplicitParam` to all `canonical*` functions (`canonicalFunLeft`, `canonicalAppHead`, `canonicalAppArg`)

## Decl Generator Improvements

- **Deriving clauses** on data/newtype: `DerivingClause` with optional `DerivingStock` strategy
- **Strictness annotations** (`!`) on constructor fields
- **Class contexts**: `class Eq a => Ord a where`
- **Instance contexts**: `instance Eq a => Eq [a] where`
- **Standalone deriving strategies**: `stock`, `newtype`, `anyclass`
- **Foreign exports**: `ForeignExport` direction
- **CApi calling convention**: `CApi` added to foreign call conventions
- **Safety annotations**: `Safe`/`Unsafe` for foreign imports (correctly excluded from exports)

## Extensions Added to Test Configs

`DataKinds`, `ImplicitParams`, `KindSignatures`, `ExplicitForAll`, `RankNTypes`, `DerivingStrategies`, `CApiFFI`

## Documented Limitations (TODOs)

- `TImplicitParam`: parser doesn't support `?name :: Type` in standalone type parsing
- Kinded inferred binders (`{a :: Kind}`): parser doesn't support them
- `TContext` generated only in wrapped `TParen` form to avoid sub-position ambiguity