### PR TITLE
test(parser): cover singleton unboxed tuple patterns

### DIFF
--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -189,6 +189,7 @@ buildTests = do
             testCase "prefix no args: f = 5" test_funHeadPrefixNoArgs,
             testCase "prefix operator name: (+) x y = x" test_funHeadPrefixOp,
             testCase "prefix constructor application arg: f (Just x) y = y" test_funHeadPrefixConstructorArg,
+            testCase "prefix singleton unboxed tuple arg: f (# x #) = x" test_funHeadPrefixUnboxedTupleSingletonArg,
             testCase "infix: x + y = x" test_funHeadInfix,
             testCase "infix backtick: x `add` y = x" test_funHeadInfixBacktick,
             testCase "infix record rhs: x `f` (R {}) = x" test_funHeadInfixRecordRhs,
@@ -1481,6 +1482,12 @@ test_funHeadPrefixConstructorArg =
   case parseTopDecl "f (Just x) y = y" of
     Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PParen _ (PCon _ "Just" [PVar _ "x"]), PVar _ "y"]}])) -> pure ()
     other -> assertFailure ("expected constructor application argument in prefix function head, got: " <> show other)
+
+test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
+test_funHeadPrefixUnboxedTupleSingletonArg =
+  case parseTopDeclWithExts [UnboxedTuples] "f (# x #) = x" of
+    Right (DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTuple _ Unboxed [PVar _ "x"]]}])) -> pure ()
+    other -> assertFailure ("expected singleton unboxed tuple argument in prefix function head, got: " <> show other)
 
 test_funHeadInfix :: Assertion
 test_funHeadInfix =

--- a/components/aihc-parser/test/Test/Fixtures/golden/pattern/unboxed-tuple-singleton.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pattern/unboxed-tuple-singleton.yaml
@@ -1,0 +1,5 @@
+extensions: [UnboxedTuples]
+input: |
+  (# x #)
+ast: PTupleUnboxed [PVar "x"]
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/singleton-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/singleton-pattern.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedTuples #-}
+
+module SingletonPattern where
+
+f (# x #) = x

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -67,7 +67,7 @@ genPatternWith allowAll depth =
         PNegLit span0 <$> genNumericLiteral,
         PSplice span0 <$> genPatSpliceBody,
         PTuple span0 Boxed <$> elements [[], [PVar span0 (mkUnqualifiedName NameVarId "x"), PWildcard span0]],
-        PTuple span0 Unboxed <$> elements [[], [PVar span0 (mkUnqualifiedName NameVarId "x"), PWildcard span0]],
+        PTuple span0 Unboxed <$> elements [[], [PVar span0 (mkUnqualifiedName NameVarId "x")], [PVar span0 (mkUnqualifiedName NameVarId "x"), PWildcard span0]],
         pure (PList span0 []),
         PCon span0 <$> genPatternConAstName <*> pure [],
         genUnboxedSumPatternWith allowAll 0
@@ -140,14 +140,12 @@ genTupleElemsWith allowView depth = do
       n <- chooseInt (2, 4)
       vectorOf n (genPatternWith allowView depth)
 
--- | Generate elements for an unboxed tuple pattern (0 or 2-4 elements).
+-- | Generate elements for an unboxed tuple pattern (0-4 elements).
 -- Unlike boxed tuples, unboxed tuples with 0 elements are valid Haskell.
--- NOTE: 1-element unboxed tuples are valid Haskell but the parser doesn't
--- accept them yet, so we skip generating them for now.
 genUnboxedTupleElemsWith :: Bool -> Int -> Gen [Pattern]
 genUnboxedTupleElemsWith allowView depth = do
   n <- chooseInt (0, 4)
-  if n == 1 then pure [] else vectorOf n (genPatternWith allowView depth)
+  vectorOf n (genPatternWith allowView depth)
 
 genUnboxedSumPatternWith :: Bool -> Int -> Gen Pattern
 genUnboxedSumPatternWith allowView depth = do
@@ -320,7 +318,7 @@ shrinkPatternTupleElems tupleFlavor elems =
   | shrunk <- shrinkList shrinkPattern elems,
     candidate <- case shrunk of
       [] -> [PTuple span0 tupleFlavor []]
-      [_] -> []
+      [_] -> [PTuple span0 tupleFlavor shrunk | tupleFlavor == Unboxed]
       _ -> [PTuple span0 tupleFlavor shrunk]
   ]
 


### PR DESCRIPTION
## Summary
- Extend the pattern QuickCheck generator and shrinker to include 1-element unboxed tuple patterns, matching the parser's current support.
- Add focused regression coverage for `(# x #)` via a pattern golden fixture, an oracle fixture, and a direct function-head parser test for `f (# x #) = x`.
- Progress counts: parser golden pass +1 and oracle pass +1. CodeRabbit prompt-only review reported no findings.

Closes #740.