### PR TITLE
fix(parser): support kinded inferred forall binders

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -59,12 +59,13 @@ forallTypeParser = withSpan $ do
 forallBinderParser :: TokParser TyVarBinder
 forallBinderParser =
   withSpan $
-    -- Inferred binder: {k}
+    -- Inferred binder: {k} | {k :: Type}
     ( do
         expectedTok TkSpecialLBrace
         ident <- lowerIdentifierParser
+        mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
         expectedTok TkSpecialRBrace
-        pure (\span' -> TyVarBinder span' ident Nothing TyVarBInferred)
+        pure (\span' -> TyVarBinder span' ident mKind TyVarBInferred)
     )
       <|> ( do
               expectedTok TkSpecialLParen

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -582,7 +582,19 @@ docTyVarBinder tvb =
   where
     fields =
       [field "name" (docText (tyVarBinderName tvb))]
+        <> optionalField "specificity" docTyVarBSpecificity (specificityField tvb)
         <> optionalField "kind" docType (tyVarBinderKind tvb)
+
+    specificityField binder =
+      case tyVarBinderSpecificity binder of
+        TyVarBSpecified -> Nothing
+        specificity -> Just specificity
+
+docTyVarBSpecificity :: TyVarBSpecificity -> Doc ann
+docTyVarBSpecificity specificity =
+  case specificity of
+    TyVarBInferred -> "TyVarBInferred"
+    TyVarBSpecified -> "TyVarBSpecified"
 
 -- Patterns
 

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1166,7 +1166,10 @@ data TyVarBSpecificity
 data TyVarBinder = TyVarBinder
   { tyVarBinderSpan :: SourceSpan,
     tyVarBinderName :: Text,
+    -- | Optional kind annotation. Examples: @(a :: Type)@ and @{a :: Type}@.
     tyVarBinderKind :: Maybe Type,
+    -- | Whether the binder was written as specified (@a@, @(a :: k)@)
+    -- or inferred (@{a}@, @{a :: k}@).
     tyVarBinderSpecificity :: TyVarBSpecificity
   }
   deriving (Data, Eq, Show, Generic, NFData)

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/forall-kinded-inferred-binder.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/forall-kinded-inferred-binder.yaml
@@ -1,0 +1,13 @@
+extensions:
+  - ExplicitForAll
+  - KindSignatures
+input: |
+  module ForallKindedInferredBinder where
+
+  import Data.Kind (Type)
+
+  f :: forall {a :: Type}. a -> a
+  f x = x
+status: pass
+ast: |
+  Module {name = "ForallKindedInferredBinder", imports = [ImportDecl {module = "Data.Kind", spec = ImportSpec {items = [ImportItemAbs{name = "Type"}]}}], decls = [DeclTypeSig {names = ["f"], type = TForall [TyVarBinder {name = "a", specificity = TyVarBInferred, kind = TCon "Type"}] (TFun (TVar "a") (TVar "a"))}, DeclValue (FunctionBind "f" [Match {headForm = Prefix, pats = [PVar "x"], rhs = UnguardedRhs (EVar "x")}])]} 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-kinded-inferred-binder.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-kinded-inferred-binder.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+
+module ForallKindedInferredBinder where
+
+import Data.Kind (Type)
+
+f :: forall {a :: Type}. a -> a
+f x = x

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -247,8 +247,11 @@ genTyVarBinder = do
       pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBSpecified),
       -- Plain inferred binder: {a}
       pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBInferred),
+      -- Kinded inferred binder: {a :: Kind}
+      do
+        kind <- genSimpleTypeAtom 0
+        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBInferred),
       -- Kinded specified binder: (a :: Kind)
-      -- NOTE: Kinded inferred binders ({a :: Kind}) are not supported by the parser.
       do
         kind <- genSimpleTypeAtom 0
         pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBSpecified)

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -7,6 +7,7 @@ where
 
 import Aihc.Parser
 import Aihc.Parser.Syntax
+import Data.Maybe (isJust)
 import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
@@ -26,16 +27,18 @@ prop_typePrettyRoundTrip :: Type -> Property
 prop_typePrettyRoundTrip ty =
   let source = renderStrict (layoutPretty defaultLayoutOptions (pretty ty))
       expected = normalizeType (canonicalTopLevelType ty)
+      hasKindedInferredBinder = containsKindedInferredBinder ty
    in checkCoverage $
         withMaxShrinks 100 $
-          assertCtorCoverage ["TAnn", "TImplicitParam"] ty $
-            counterexample (T.unpack source) $
-              case parseType typeConfig source of
-                ParseErr err ->
-                  counterexample (MPE.errorBundlePretty err) False
-                ParseOk parsed ->
-                  let actual = normalizeType parsed
-                   in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
+          cover 1 hasKindedInferredBinder "kinded inferred forall binder" $
+            assertCtorCoverage ["TAnn", "TImplicitParam"] ty $
+              counterexample (T.unpack source) $
+                case parseType typeConfig source of
+                  ParseErr err ->
+                    counterexample (MPE.errorBundlePretty err) False
+                  ParseOk parsed ->
+                    let actual = normalizeType parsed
+                     in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
 normalizeType :: Type -> Type
 normalizeType ty =
@@ -65,3 +68,24 @@ normalizeTyVarBinder tvb =
     { tyVarBinderSpan = span0,
       tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
     }
+
+containsKindedInferredBinder :: Type -> Bool
+containsKindedInferredBinder ty =
+  case ty of
+    TForall _ binders inner -> any isKindedInferredBinder binders || containsKindedInferredBinder inner
+    TImplicitParam _ _ inner -> containsKindedInferredBinder inner
+    TApp _ f x -> containsKindedInferredBinder f || containsKindedInferredBinder x
+    TFun _ a b -> containsKindedInferredBinder a || containsKindedInferredBinder b
+    TTuple _ _ _ elems -> any containsKindedInferredBinder elems
+    TList _ _ elems -> any containsKindedInferredBinder elems
+    TParen _ inner -> containsKindedInferredBinder inner
+    TKindSig _ ty' kind -> containsKindedInferredBinder ty' || containsKindedInferredBinder kind
+    TUnboxedSum _ elems -> any containsKindedInferredBinder elems
+    TContext _ constraints inner -> any containsKindedInferredBinder constraints || containsKindedInferredBinder inner
+    TSplice _ _ -> False
+    TAnn _ sub -> containsKindedInferredBinder sub
+    _ -> False
+
+isKindedInferredBinder :: TyVarBinder -> Bool
+isKindedInferredBinder binder =
+  tyVarBinderSpecificity binder == TyVarBInferred && isJust (tyVarBinderKind binder)


### PR DESCRIPTION
## Summary
- accept kind-annotated inferred `forall` binders like `{a :: Type}` in the type parser and document the binder shape in the syntax AST
- extend the QuickCheck type generator and round-trip coverage so kinded inferred binders are generated and exercised explicitly
- add oracle and golden regressions for `forall {a :: Type}. a -> a`

## Progress
- Parser progress: PASS 807/829 on `main` -> PASS 808/830 on this branch

## Validation
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)