### PR TITLE
fix(parser): accept nested prefix patterns in bind contexts

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -152,14 +152,17 @@ cmdStmtParser = do
     TkKeywordCase -> cmdBodyStmtParser
     TkReservedBackslash -> cmdBodyStmtParser
     TkSpecialLParen -> MP.try cmdBindOrBodyStmtParser <|> cmdBodyStmtParser
-    -- Pattern-only leading tokens: only valid in bind context.
-    TkPrefixBang -> cmdBindStmtParser
-    TkPrefixTilde -> cmdBindStmtParser
     _ -> do
-      isAs <- startsWithAsPattern
-      if isAs
+      isPatternBind <- startsWithPatternBind
+      if isPatternBind
         then cmdBindStmtParser
         else cmdBindOrBodyStmtParser
+
+startsWithPatternBind :: TokParser Bool
+startsWithPatternBind =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    _ <- patternParser
+    expectedTok TkReservedLeftArrow
 
 -- | Parse a command do-statement: @cmd@ or @pat <- cmd@.
 -- Uses the expression-first approach: parse as expression, check for @<-@.

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -209,13 +209,17 @@ doStmtParser = do
   case lexTokenKind tok of
     TkKeywordLet -> MP.try doLetStmtParser <|> doBindOrExprStmtParser
     TkKeywordRec -> doRecStmtParser
-    TkPrefixBang -> doPatBindStmtParser
-    TkPrefixTilde -> doPatBindStmtParser
     _ -> do
-      isAs <- startsWithAsPattern
-      if isAs
+      isPatternBind <- startsWithPatternBind
+      if isPatternBind
         then doPatBindStmtParser
         else doBindOrExprStmtParser
+
+startsWithPatternBind :: TokParser Bool
+startsWithPatternBind =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    _ <- patternParser
+    expectedTok TkReservedLeftArrow
 
 doBindOrExprStmtParser :: TokParser (DoStmt Expr)
 doBindOrExprStmtParser = withSpan $ do
@@ -579,11 +583,9 @@ guardQualifierParser = do
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkKeywordLet -> MP.try guardLetParser <|> guardBindOrExprParser
-    TkPrefixBang -> guardPatBindParser
-    TkPrefixTilde -> guardPatBindParser
     _ -> do
-      isAs <- startsWithAsPattern
-      if isAs
+      isPatternBind <- startsWithPatternBind
+      if isPatternBind
         then guardPatBindParser
         else guardBindOrExprParser
 
@@ -865,11 +867,9 @@ compStmtParser = do
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkKeywordLet -> MP.try compLetStmtParser <|> compGenOrGuardParser
-    TkPrefixBang -> compPatGenParser
-    TkPrefixTilde -> compPatGenParser
     _ -> do
-      isAs <- startsWithAsPattern
-      if isAs
+      isPatternBind <- startsWithPatternBind
+      if isPatternBind
         then compPatGenParser
         else compGenOrGuardParser
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -131,6 +131,7 @@ buildTests = do
             testCase "bang pattern: !x <- expr" test_doBindBangPattern,
             testCase "irrefutable pattern: ~(a, b) <- expr" test_doBindIrrefutablePattern,
             testCase "as pattern: x@(Just _) <- expr" test_doBindAsPattern,
+            testCase "nested prefix patterns: K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- expr" test_doBindNestedPrefixPattern,
             testCase "expression statement: expr" test_doExprStmt,
             testCase "let statement: let x = 5" test_doLetStmt,
             testCase "rejects if-then-else in pattern context" test_doBindRejectsIfExpr
@@ -146,7 +147,8 @@ buildTests = do
             testCase "guard bang pattern: f x | !y <- g x = y" test_guardBangBind,
             testCase "guard irrefutable pattern: f x | ~(a, b) <- g x = a" test_guardIrrefutableBind,
             testCase "guard as pattern: f x | y@(Just _) <- g x = y" test_guardAsBind,
-            testCase "guard infix pattern: f x | a : as <- g x = a" test_guardInfixBind
+            testCase "guard infix pattern: f x | a : as <- g x = a" test_guardInfixBind,
+            testCase "guard nested prefix patterns: f x | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs = y" test_guardNestedPrefixBind
           ],
         testGroup
           "checkPattern (list comprehension)"
@@ -159,7 +161,8 @@ buildTests = do
             testCase "comp bang gen: [y | !y <- xs]" test_compBangGen,
             testCase "comp irrefutable gen: [a | ~(a, b) <- xs]" test_compIrrefutableGen,
             testCase "comp as gen: [y | y@(Just _) <- xs]" test_compAsGen,
-            testCase "comp infix gen: [a | a : as <- xs]" test_compInfixGen
+            testCase "comp infix gen: [a | a : as <- xs]" test_compInfixGen,
+            testCase "comp nested prefix gen: [y | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs]" test_compNestedPrefixGen
           ],
         testGroup
           "localDeclParser dispatch"
@@ -1006,6 +1009,12 @@ test_doBindAsPattern =
     Right [DoBind _ (PAs _ "x" (PParen _ (PCon _ "Just" [PWildcard _]))) _, DoExpr _ _] -> pure ()
     other -> assertFailure ("expected as-pattern bind, got: " <> show other)
 
+test_doBindNestedPrefixPattern :: Assertion
+test_doBindNestedPrefixPattern =
+  case parseDoStmtsExt [BangPatterns, ViewPatterns] "do { K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs; pure y }" of
+    Right [DoBind _ (PCon _ "K" [PStrict _ (PVar _ "y"), PIrrefutable _ (PParen _ (PCon _ "Just" [PVar _ "z"])), PAs _ "q" (PParen _ (PCon _ "Right" [PWildcard _])), PParen _ (PView _ _ (PVar _ "n")), PParen _ (PNegLit _ (LitInt _ 1 _))]) _, DoExpr _ _] -> pure ()
+    other -> assertFailure ("expected nested prefix-pattern bind, got: " <> show other)
+
 test_doExprStmt :: Assertion
 test_doExprStmt =
   case parseDoStmts "do { putStrLn \"hello\"; return () }" of
@@ -1268,6 +1277,12 @@ test_guardAsBind =
     Right [GuardPat _ (PAs _ "y" (PParen _ (PCon _ "Just" [PWildcard _]))) _] -> pure ()
     other -> assertFailure ("expected guard as-pattern bind, got: " <> show other)
 
+test_guardNestedPrefixBind :: Assertion
+test_guardNestedPrefixBind =
+  case parseGuardsExt [BangPatterns, ViewPatterns] "f xs | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs = y" of
+    Right [GuardPat _ (PCon _ "K" [PStrict _ (PVar _ "y"), PIrrefutable _ (PParen _ (PCon _ "Just" [PVar _ "z"])), PAs _ "q" (PParen _ (PCon _ "Right" [PWildcard _])), PParen _ (PView _ _ (PVar _ "n")), PParen _ (PNegLit _ (LitInt _ 1 _))]) _] -> pure ()
+    other -> assertFailure ("expected nested prefix-pattern guard, got: " <> show other)
+
 test_guardInfixBind :: Assertion
 test_guardInfixBind =
   case parseGuards "f x | a : as <- g x = a" of
@@ -1353,6 +1368,12 @@ test_compAsGen =
   case parseCompStmts "[y | y@(Just _) <- xs]" of
     Right [CompGen _ (PAs _ "y" (PParen _ (PCon _ "Just" [PWildcard _]))) _] -> pure ()
     other -> assertFailure ("expected comp as-pattern gen, got: " <> show other)
+
+test_compNestedPrefixGen :: Assertion
+test_compNestedPrefixGen =
+  case parseCompStmtsExt [BangPatterns, ViewPatterns] "[y | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs]" of
+    Right [CompGen _ (PCon _ "K" [PStrict _ (PVar _ "y"), PIrrefutable _ (PParen _ (PCon _ "Just" [PVar _ "z"])), PAs _ "q" (PParen _ (PCon _ "Right" [PWildcard _])), PParen _ (PView _ _ (PVar _ "n")), PParen _ (PNegLit _ (LitInt _ 1 _))]) _] -> pure ()
+    other -> assertFailure ("expected nested prefix-pattern generator, got: " <> show other)
 
 test_compInfixGen :: Assertion
 test_compInfixGen =

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/prefix-pattern-qualifiers.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/prefix-pattern-qualifiers.yaml
@@ -1,0 +1,19 @@
+extensions:
+  - BangPatterns
+  - ViewPatterns
+input: |
+  {-# LANGUAGE BangPatterns #-}
+  {-# LANGUAGE ViewPatterns #-}
+  module PrefixPatternQualifiers where
+
+  comp xs = [y | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs]
+
+  guardK xs
+    | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs = y
+  guardK _ = 0
+
+  doK xs = do
+    K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs
+    pure y
+ast: Module {name = "PrefixPatternQualifiers", languagePragmas = [EnableExtension BangPatterns, EnableExtension ViewPatterns], decls = [DeclValue (FunctionBind "comp" [Match {headForm = Prefix, pats = [PVar "xs"], rhs = UnguardedRhs (EListComp (EVar "y") [CompGen (PCon "K" [PStrict (PVar "y"), PIrrefutable (PParen (PCon "Just" [PVar "z"])), PAs "q" (PParen (PCon "Right" [PWildcard])), PParen (PView (EVar "negate") (PVar "n")), PParen (PNegLit (LitInt 1))]) (EVar "xs")])}]), DeclValue (FunctionBind "guardK" [Match {headForm = Prefix, pats = [PVar "xs"], rhs = GuardedRhss [GuardedRhs {guards = [GuardPat (PCon "K" [PStrict (PVar "y"), PIrrefutable (PParen (PCon "Just" [PVar "z"])), PAs "q" (PParen (PCon "Right" [PWildcard])), PParen (PView (EVar "negate") (PVar "n")), PParen (PNegLit (LitInt 1))]) (EVar "xs")], body = EVar "y"}]}]), DeclValue (FunctionBind "guardK" [Match {headForm = Prefix, pats = [PWildcard], rhs = UnguardedRhs (EInt 0)}]), DeclValue (FunctionBind "doK" [Match {headForm = Prefix, pats = [PVar "xs"], rhs = UnguardedRhs (EDo [DoBind (PCon "K" [PStrict (PVar "y"), PIrrefutable (PParen (PCon "Just" [PVar "z"])), PAs "q" (PParen (PCon "Right" [PWildcard])), PParen (PView (EVar "negate") (PVar "n")), PParen (PNegLit (LitInt 1))]) (EVar "xs"), DoExpr (EApp (EVar "pure") (EVar "y"))])}])]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/BangPatterns/prefix-pattern-qualifiers.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/BangPatterns/prefix-pattern-qualifiers.hs
@@ -1,0 +1,15 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module PrefixPatternQualifiers where
+
+comp xs = [y | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs]
+
+guardK xs
+  | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs = y
+guardK _ = 0
+
+doK xs = do
+  K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs
+  pure y

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -19,7 +19,7 @@ import Test.Properties.Arb.Identifiers
     shrinkIdent,
     span0,
   )
-import Test.Properties.Arb.Pattern (canonicalPatternAtomForComp, genPattern)
+import Test.Properties.Arb.Pattern (canonicalPatternAtom, genPattern)
 import Test.Properties.Arb.Type (canonicalFunLeft, canonicalTopLevelType, genType)
 import Test.QuickCheck
 
@@ -85,8 +85,8 @@ genFunctionDecl (name, expr) = do
             )
     MatchHeadInfix ->
       do
-        lhsPat <- canonicalPatternAtomForComp <$> sized (genPattern . min 3)
-        rhsPat <- canonicalPatternAtomForComp <$> sized (genPattern . min 3)
+        lhsPat <- canonicalPatternAtom <$> sized (genPattern . min 3)
+        rhsPat <- canonicalPatternAtom <$> sized (genPattern . min 3)
         pure $
           DeclValue
             span0

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -29,7 +29,6 @@ import Test.Properties.Arb.Identifiers
     span0,
   )
 import Test.Properties.Arb.Pattern (genPattern)
-import Test.Properties.Arb.Pattern qualified as Pat
 import Test.QuickCheck
 
 -- | Generate a random expression. Uses QuickCheck's size parameter
@@ -303,11 +302,6 @@ genPatterns n = do
   count <- chooseInt (1, 3)
   vectorOf count (genPattern n)
 
--- | Generate a pattern safe for comprehension/guard contexts.
--- Excludes PView, PIrrefutable, PStrict, and PAs at all depths.
-genPatternNoView :: Int -> Gen Pattern
-genPatternNoView = Pat.genPatternNoView
-
 genCaseAltsWith :: Bool -> Int -> Gen [CaseAlt]
 genCaseAltsWith allowTHQuotes n = do
   count <- chooseInt (0, 3)
@@ -363,12 +357,9 @@ genGuardQualifierWith allowTHQuotes n =
       -- a function type rather than the guard's arrow.
       GuardExpr span0 . parenTypeSig <$> genExprSizedWith allowTHQuotes n,
       -- Pattern guard: | pat <- expr = ...
-      -- TODO: Restore genPattern here once the parser supports view patterns inside
-      -- guard qualifiers. Currently, the '->' in view patterns (PView) conflicts
-      -- with guard/case-alternative syntax and causes parse failures.
       -- The expression is also parenthesized if it's an ETypeSig, since
       -- `| pat <- expr :: Type -> body` has the same ambiguity.
-      GuardPat span0 <$> genPatternNoView half <*> (parenTypeSig <$> genExprSizedWith allowTHQuotes half),
+      GuardPat span0 <$> genPattern half <*> (parenTypeSig <$> genExprSizedWith allowTHQuotes half),
       -- Let guard: | let decls = ...
       GuardLet span0 <$> genValueDeclsWith allowTHQuotes n
     ]
@@ -441,11 +432,7 @@ genCompStmtsWith allowTHQuotes n = do
 genCompStmtWith :: Bool -> Int -> Gen CompStmt
 genCompStmtWith allowTHQuotes n =
   oneof
-    [ -- TODO: Restore genPattern here once the parser supports all pattern
-      -- constructors inside list comprehension generators. Currently, PView (->),
-      -- PIrrefutable (~), PStrict (!), and PAs (@) fail when nested inside
-      -- compound patterns (PList, PTuple, PCon args) in comprehension contexts.
-      CompGen span0 <$> genPatternNoView half <*> genExprSizedWith allowTHQuotes half,
+    [ CompGen span0 <$> genPattern half <*> genExprSizedWith allowTHQuotes half,
       CompGuard span0 <$> genExprSizedWith allowTHQuotes (n - 1),
       CompLetDecls span0 <$> genValueDeclsWith allowTHQuotes (n - 1)
     ]

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -3,10 +3,8 @@
 
 module Test.Properties.Arb.Pattern
   ( genPattern,
-    genPatternNoView,
     shrinkPattern,
     canonicalPatternAtom,
-    canonicalPatternAtomForComp,
   )
 where
 
@@ -39,16 +37,6 @@ instance Arbitrary Pattern where
 
 genPattern :: Int -> Gen Pattern
 genPattern = genPatternWith True
-
--- | Generate a pattern safe for use in list comprehension generators and guard
--- qualifiers. Excludes PView, PIrrefutable, PStrict, and PAs at all depths.
--- TODO: Restore full pattern generation once the parser supports these patterns
--- in nested positions (inside PList, PTuple, PCon args, etc.) within list
--- comprehension generators and guard qualifiers. Currently, the prefix tokens
--- @->@, @~@, @!@, @\@@ are not recognized as pattern starters in these nested
--- contexts because the parser uses expression parsing rules there.
-genPatternNoView :: Int -> Gen Pattern
-genPatternNoView = genPatternWith False
 
 -- | Internal pattern generator parameterized by whether all pattern constructors
 -- are allowed. When @allowAll@ is False, PView, PIrrefutable, PStrict, and PAs
@@ -93,11 +81,7 @@ genPatternConWith :: Bool -> Int -> Gen Pattern
 genPatternConWith allowView depth = do
   con <- genPatternConAstName
   argCount <- chooseInt (0, 3)
-  -- TODO: Switch back to canonicalPatternAtom once the parser handles PNegLit,
-  -- PAs, PStrict, and PIrrefutable as constructor arguments in all pattern
-  -- contexts (currently they fail in list comp generators, guard qualifiers,
-  -- and do-binds because the prefix tokens @-@, @\@@, @!@, @~@ are misparsed).
-  args <- vectorOf argCount (canonicalPatternAtomForComp <$> genPatternWith allowView (depth - 1))
+  args <- vectorOf argCount (canonicalPatternAtom <$> genPatternWith allowView (depth - 1))
   pure (PCon span0 con args)
 
 genPatternTypeSigWith :: Bool -> Int -> Gen Pattern
@@ -126,9 +110,9 @@ genPatternInfixWith allowAll depth = do
   -- parenthesizes PNegLit as an infix operand. Currently, PInfix (PNegLit 433)
   -- ":+" (PVar "y") prints as (-433 :+ y) which is misparsed as negation of
   -- (433 :+ y).
-  lhs <- canonicalPatternAtomForComp <$> genPatternWith allowAll (depth - 1)
+  lhs <- canonicalPatternAtom <$> genPatternWith allowAll (depth - 1)
   op <- genConOperatorName
-  rhs <- canonicalPatternAtomForComp <$> genPatternWith allowAll (depth - 1)
+  rhs <- canonicalPatternAtom <$> genPatternWith allowAll (depth - 1)
   pure (PInfix span0 lhs op rhs)
 
 genTupleElemsWith :: Bool -> Int -> Gen [Pattern]
@@ -209,22 +193,6 @@ canonicalPatternAtom pat =
   if isPatternAtom pat
     then pat
     else PParen span0 pat
-
--- | Like 'canonicalPatternAtom' but also wraps PNegLit, PAs, PStrict, and
--- PIrrefutable in parens.
--- TODO: Remove once the parser supports these patterns as constructor arguments
--- in list comprehension generators and guard qualifiers. Currently, patterns
--- starting with special prefix tokens (@-@, @\@@, @!@, @~@) fail to parse when
--- used as constructor arguments in these contexts (e.g., @K -72.1@ or @K !x@ in
--- a list comp generator is misparsed).
-canonicalPatternAtomForComp :: Pattern -> Pattern
-canonicalPatternAtomForComp pat =
-  case pat of
-    PNegLit {} -> PParen span0 pat
-    PAs {} -> PParen span0 pat
-    PStrict {} -> PParen span0 pat
-    PIrrefutable {} -> PParen span0 pat
-    _ -> canonicalPatternAtom pat
 
 isPatternAtom :: Pattern -> Bool
 isPatternAtom pat =


### PR DESCRIPTION
## Summary
- fix ambiguous `pat <- expr` dispatch in do-binds, guard qualifiers, list comprehensions, and arrow-command do-blocks by probing for a full pattern bind instead of only special leading tokens
- remove QuickCheck generator workarounds that excluded or over-parenthesized nested `!`, `~`, `@`, `-`, and view patterns in these contexts
- add regression coverage in unit tests, oracle fixtures, and parser golden fixtures for nested prefix patterns in qualifier and do-bind positions

## Validation
- `cabal test -j1 -v0 aihc-parser:spec --test-options="--pattern \"nested prefix\""`
- `cabal test -j1 -v0 aihc-parser:spec --test-options="--pattern \"parser-golden\""`
- `cabal test -j1 -v0 aihc-parser:spec --test-options="--pattern \"oracle\""`
- `just fmt`
- `just check`

## Progress
- parser golden: pass=180 xfail=6 xpass=0 fail=0
- oracle: this change adds 1 passing oracle case and leaves existing known xfails unchanged

## CodeRabbit
- `coderabbit review --prompt-only` was attempted but rate-limited by the service, so no review prompt was available for this PR.

Closes #738.