### PR TITLE
fix(parser): support mdo in expression and view-pattern contexts (#737)

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -190,6 +190,7 @@ exprCoreParserNoArrowTail = do
   tok <- lookAhead anySingle
   base <- case lexTokenKind tok of
     TkKeywordDo -> doExprParser
+    TkKeywordMdo -> mdoExprParser
     TkKeywordIf -> ifExprParser
     TkKeywordCase -> caseExprParser
     TkKeywordLet -> letExprParser
@@ -302,7 +303,7 @@ infixExprParserExcept forbidden = do
 -- | Parse an lexp (left-expression) - includes do, if, case, let, lambda, and fexp.
 lexpParser :: TokParser Expr
 lexpParser =
-  doExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
+  doExprParser <|> mdoExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
 
 buildInfix :: Expr -> (Name, Expr) -> Expr
 buildInfix lhs (op, rhs) =
@@ -455,6 +456,7 @@ atomExprParser = do
         <|> lambdaExprParser
         <|> letExprParser
         <|> (if blockArgsEnabled then MP.try doExprParser else MP.empty)
+        <|> (if blockArgsEnabled then MP.try mdoExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try caseExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try ifExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try procExprParser else MP.empty)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -528,10 +528,7 @@ prettyPattern pat =
     PCon _ con args -> hsep (prettyPrefixName con : map prettyPatternAtom args)
     PInfix _ lhs op rhs -> prettyPatternAtom lhs <+> prettyNameInfixOp op <+> prettyPatternAtom rhs
     PView _ viewExpr inner ->
-      -- Use precedence 2 for the view expression so that ETypeSig gets
-      -- parenthesized. Without this, "expr :: ty -> pat" is ambiguous
-      -- because "->" could be parsed as part of the type.
-      parens (prettyExprPrec 2 viewExpr <+> "->" <+> prettyPattern inner)
+      parens (prettyViewExpr viewExpr <+> "->" <+> prettyPattern inner)
     PAs _ name inner -> pretty name <> "@" <> prettyPatternAtomStrict inner
     PStrict _ inner -> "!" <> prettyPatternAtomStrict inner
     PIrrefutable _ inner -> "~" <> prettyPatternAtomStrict inner
@@ -557,11 +554,19 @@ prettyPattern pat =
 prettyPatternInDelimited :: Pattern -> Doc ann
 prettyPatternInDelimited pat =
   case pat of
-    PView _ viewExpr inner -> prettyExprPrec 2 viewExpr <+> "->" <+> prettyPattern inner
+    PView _ viewExpr inner -> prettyViewExpr viewExpr <+> "->" <+> prettyPattern inner
     PAs _ name inner -> pretty name <> "@" <> prettyPatternAtomStrict inner
     PStrict _ inner -> "!" <> prettyPatternAtomStrict inner
     PIrrefutable _ inner -> "~" <> prettyPatternAtomStrict inner
     _ -> prettyPattern pat
+
+prettyViewExpr :: Expr -> Doc ann
+prettyViewExpr expr =
+  case expr of
+    -- Keep type signatures parenthesized so the view-pattern arrow cannot be
+    -- parsed as part of the signature's result type.
+    ETypeSig {} -> parens (prettyExprPrec 0 expr)
+    _ -> prettyExprPrec 0 expr
 
 -- | Pretty print a pattern field binding.
 -- Supports NamedFieldPuns: if pattern is a variable with the same name as the field,

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -675,7 +675,7 @@ docExpr expr =
     ESectionR _ op rhs -> "ESectionR" <+> docName op <+> parens (docExpr rhs)
     ELetDecls _ decls body -> "ELetDecls" <+> brackets (hsep (punctuate comma (map docDecl decls))) <+> parens (docExpr body)
     ECase _ scrutinee alts -> "ECase" <+> parens (docExpr scrutinee) <+> brackets (hsep (punctuate comma (map docCaseAlt alts)))
-    EDo _ stmts _ -> "EDo" <+> brackets (hsep (punctuate comma (map docDoStmt stmts)))
+    EDo _ stmts isMdo -> (if isMdo then "EMdo" else "EDo") <+> brackets (hsep (punctuate comma (map docDoStmt stmts)))
     EListComp _ body quals -> "EListComp" <+> parens (docExpr body) <+> brackets (hsep (punctuate comma (map docCompStmt quals)))
     EListCompParallel _ body qualGroups -> "EListCompParallel" <+> parens (docExpr body) <+> brackets (hsep (punctuate "|" [brackets (hsep (punctuate comma (map docCompStmt qs))) | qs <- qualGroups]))
     EArithSeq _ seqInfo -> "EArithSeq" <+> parens (docArithSeq seqInfo)

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -27,6 +27,8 @@ import Test.Properties.Identifiers (isValidGeneratedIdent, shrinkIdent)
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip)
 import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
 import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
+import Test.QuickCheck.Gen qualified as QGen
+import Test.QuickCheck.Random qualified as QRandom
 import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimingTests)
 import Test.StackageProgress.Summary (stackageProgressSummaryTests)
 import Test.Tasty
@@ -98,6 +100,7 @@ buildTests = do
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
+            testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
             testCase "parses parenthesized kind signature type atoms" test_typeParsesParenthesizedKindSignature,
             testCase "parses parenthesized kind signatures in application heads" test_typeParsesKindSignatureApplicationHead,
             testCase "parses empty list type constructor" test_typeParsesEmptyListConstructor,
@@ -113,6 +116,8 @@ buildTests = do
             testCase "parses warned export module reexports" test_warnedExportModuleReexportParses,
             testCase "parses infix class heads" test_infixClassHeadParses,
             testCase "roundtrips else branches with local where clauses" test_ifElseWhereBranchRoundtrip,
+            testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
+            testCase "parses mdo view patterns" test_mdoViewPatternParses,
             testCase "parses and roundtrips infix type family heads" test_infixTypeFamilyHeadRoundtrip,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
             QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism
@@ -482,6 +487,28 @@ test_ifElseWhereBranchRoundtrip =
         case map normalizeDecl (moduleDecls modu) of
           [actualDecl] -> assertEqual "roundtripped declaration" (normalizeDecl expectedDecl) actualDecl
           other -> assertFailure ("unexpected parsed declarations: " <> show other <> "\nsource:\n" <> T.unpack source)
+
+test_standaloneMdoExprParses :: Assertion
+test_standaloneMdoExprParses =
+  case parseExpr defaultConfig {parserExtensions = [RecursiveDo]} "mdo { pure x }" of
+    ParseOk (EDo _ [DoExpr _ (EApp _ (EVar _ "pure") (EVar _ "x"))] True) -> pure ()
+    other -> assertFailure ("expected standalone mdo expression, got: " <> show other)
+
+test_mdoViewPatternParses :: Assertion
+test_mdoViewPatternParses =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE RecursiveDo #-}",
+            "{-# LANGUAGE ViewPatterns #-}",
+            "module M where",
+            "f (mdo { pure x } -> y) = y"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        case moduleDecls modu of
+          [DeclValue _ (FunctionBind _ "f" [Match {matchPats = [PView _ (EDo _ [DoExpr _ (EApp _ (EVar _ "pure") (EVar _ "x"))] True) (PVar _ "y")], matchRhs = UnguardedRhs _ (EVar _ "y") _}])] -> pure ()
+          other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_infixTypeFamilyHeadRoundtrip :: Assertion
 test_infixTypeFamilyHeadRoundtrip =
@@ -911,6 +938,15 @@ test_generatedOperatorsRejectArrowTailSpellings :: Assertion
 test_generatedOperatorsRejectArrowTailSpellings =
   assertBool "arrow-tail operators must not be treated as valid generated operators" $
     not (any isValidGeneratedOperator ["-<", ">-", "-<<", ">>-"])
+
+test_generatedExpressionsCanIncludeMdo :: Assertion
+test_generatedExpressionsCanIncludeMdo =
+  let samples = QGen.unGen (QC.vectorOf 4000 (QC.resize 5 (QC.arbitrary :: QC.Gen Expr))) (QRandom.mkQCGen 737) 5
+   in assertBool "expected expression generator to include at least one mdo expression" $
+        any isMdo samples
+  where
+    isMdo (EDo _ _ True) = True
+    isMdo _ = False
 
 prop_generatedOperatorsRejectDashOnlyCommentStarters :: QC.Property
 prop_generatedOperatorsRejectDashOnlyCommentStarters =

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/mdo-explicit-braces.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/mdo-explicit-braces.yaml
@@ -1,0 +1,5 @@
+extensions: [RecursiveDo]
+input: |
+  mdo { pure x }
+ast: EMdo [DoExpr (EApp (EVar "pure") (EVar "x"))]
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/pattern/mdo-view-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pattern/mdo-view-pattern.yaml
@@ -1,0 +1,5 @@
+extensions: [RecursiveDo, ViewPatterns]
+input: |
+  (mdo { pure x } -> y)
+ast: PView (EMdo [DoExpr (EApp (EVar "pure") (EVar "x"))]) (PVar "y")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RecursiveDo/mdo-view-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RecursiveDo/mdo-view-pattern.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module MDoViewPattern where
+
+f :: a -> a
+f (mdo pure x -> y) = y

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -67,10 +67,7 @@ genExprSizedWith allowTHQuotes n
         ELambdaPats span0 <$> genPatterns half <*> genExprSizedWith allowTHQuotes half,
         ELambdaCase span0 <$> genCaseAltsWith allowTHQuotes (n - 1),
         ELetDecls span0 <$> genValueDeclsWith allowTHQuotes half <*> genExprSizedWith allowTHQuotes half,
-        EDo span0 <$> genDoStmtsWith allowTHQuotes (n - 1) <*> pure False,
-        -- TODO: Generate EDo with mdo=True once the parser supports mdo in
-        -- standalone expression and pattern (view pattern) contexts. Currently
-        -- mdo only works in declaration-level RHS positions.
+        EDo span0 <$> genDoStmtsWith allowTHQuotes (n - 1) <*> arbitrary,
         EListComp span0 <$> genExprSizedWith allowTHQuotes half <*> genCompStmtsWith allowTHQuotes half,
         EListCompParallel span0 <$> genExprSizedWith allowTHQuotes half <*> genParallelCompStmtsWith allowTHQuotes half,
         EList span0 <$> genListElemsWith allowTHQuotes (n - 1),
@@ -675,8 +672,8 @@ shrinkExpr expr =
       body
         : [ELetDecls span0 decls body' | body' <- shrinkExpr body]
           <> [ELetDecls span0 decls' body | decls' <- shrinkDecls decls, not (null decls')]
-    EDo _ stmts _ ->
-      [EDo span0 stmts' False | stmts' <- shrinkDoStmts stmts, not (null stmts')]
+    EDo _ stmts isMdo ->
+      [EDo span0 stmts' isMdo | stmts' <- shrinkDoStmts stmts, not (null stmts')]
     EListComp _ body stmts ->
       body
         : [EListComp span0 body' stmts | body' <- shrinkExpr body]


### PR DESCRIPTION
## Summary
- recognize `mdo` in the same nested expression entry points that already handled `do`, including standalone expression parsing, block-argument expression atoms, and parenthesized/view-pattern contexts
- extend parser regression coverage with a QuickCheck generator assertion, a new oracle case, and new golden fixtures for both standalone `mdo` expressions and `mdo` view patterns
- keep pretty-printing and shorthand output aligned so `mdo` round-trips through the oracle and remains distinguishable from `do` in golden expectations

## Progress
- parser golden pass count: +2
- oracle pass count: +1

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern mdo --hide-successes"`
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` was attempted but skipped because the service returned a rate-limit error