### PR TITLE
fix(pretty): parenthesize view expressions ending with type signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -560,12 +560,14 @@ prettyPatternInDelimited pat =
     _ -> prettyPattern pat
 
 prettyViewExpr :: Expr -> Doc ann
-prettyViewExpr expr =
-  case expr of
-    -- Keep type signatures parenthesized so the view-pattern arrow cannot be
-    -- parsed as part of the signature's result type.
-    ETypeSig {} -> parens (prettyExprPrec 0 expr)
-    _ -> prettyExprPrec 0 expr
+prettyViewExpr expr
+  -- Keep expressions that end with a type signature parenthesized so the
+  -- view-pattern arrow cannot be parsed as part of the signature's result type.
+  -- For example, @let {x = y} in z :: T -> p@ must be printed as
+  -- @(let {x = y} in z :: T) -> p@ to prevent @->@ from being absorbed into
+  -- the type @T -> …@.
+  | endsWithTypeSig expr = parens (prettyExprPrec 0 expr)
+  | otherwise = prettyExprPrec 0 expr
 
 -- | Pretty print a pattern field binding.
 -- Supports NamedFieldPuns: if pattern is a variable with the same name as the field,
@@ -1279,6 +1281,16 @@ isOpenEnded = \case
   EProc {} -> True
   EInfix _ _ _ rhs -> isOpenEnded rhs
   EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
+  _ -> False
+
+-- | Does the pretty-printed form of an expression end with @:: Type@?
+-- Such expressions need parenthesization in contexts where a following @->@
+-- would be absorbed into the type (e.g. the view expression of a view pattern).
+endsWithTypeSig :: Expr -> Bool
+endsWithTypeSig = \case
+  ETypeSig {} -> True
+  ELetDecls _ _ body -> endsWithTypeSig body
+  ELambdaPats _ _ body -> endsWithTypeSig body
   _ -> False
 
 -- | Print an expression used as the function in an application.

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -192,7 +192,8 @@ buildTests = do
             testCase "unicode operator type signatures round-trip with parentheses" test_prettyUnicodeOperatorTypeSigRoundTrip,
             testCase "prefix function head record pattern stays bare" test_prettyPrefixFunctionHeadRecordPattern,
             testCase "infix function head constructor applications stay bare" test_prettyInfixFunctionHeadConstructorPatterns,
-            testCase "infix function head irrefutable patterns stay bare" test_prettyInfixFunctionHeadIrrefutablePatterns
+            testCase "infix function head irrefutable patterns stay bare" test_prettyInfixFunctionHeadIrrefutablePatterns,
+            testCase "view pattern with let-typed expr gets parenthesized" test_prettyViewLetTypeSigParens
           ],
         testGroup
           "functionHeadParserWith dispatch"
@@ -1312,6 +1313,26 @@ test_prettyInfixFunctionHeadIrrefutablePatterns = do
           )
       source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
   assertBool ("expected bare irrefutable pattern in infix function head, got:\n" <> T.unpack source) ("~x `combine` y = x" == source)
+
+-- | Regression test: a view pattern whose view expression is a let-expression
+-- ending with a type signature must parenthesize the let so the view-pattern
+-- arrow is not absorbed into the type.
+-- Without the fix, this would produce @(let {x = (#  #)} in (#  #) :: T -> [])@
+-- which GHC rejects because @:: T -> []@ is parsed as a single type signature.
+test_prettyViewLetTypeSigParens :: Assertion
+test_prettyViewLetTypeSigParens = do
+  let tyCon = TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId "T")) Unpromoted
+      unboxedUnit = ETuple span0 Unboxed []
+      viewExpr =
+        ELetDecls
+          span0
+          [DeclValue span0 (PatternBind span0 (PVar span0 (mkUnqualifiedName NameVarId "x")) (UnguardedRhs span0 unboxedUnit Nothing))]
+          (ETypeSig span0 unboxedUnit tyCon)
+      pat = PView span0 viewExpr (PList span0 [])
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty pat))
+  assertBool
+    ("expected parenthesized let-expression in view pattern, got:\n" <> T.unpack source)
+    ("((let {x = (#  #)} in (#  #) :: T) -> [])" == source)
 
 test_guardPatBind :: Assertion
 test_guardPatBind =


### PR DESCRIPTION
## Summary

- Fix pretty-printer to parenthesize view-pattern expressions whose trailing subexpression is a type signature (e.g., `let {...} in e :: T` in a view pattern), preventing the `->` arrow from being absorbed into the type
- Add `endsWithTypeSig` helper that recursively detects expressions ending with `:: Type` through `ELetDecls` and `ELambdaPats` bodies
- Add regression test constructing the exact failing AST and verifying correct parenthesization

## Problem

The pretty-printer for view patterns only handled direct `ETypeSig` expressions, but not open-ended expressions like `ELetDecls` whose body ends with a type signature. This produced:

```
(let {x = (# #)} in (# #) :: T -> [])
```

GHC parses this as `let {x = (# #)} in ((# #) :: T -> [])` because `:: T -> []` is interpreted as the function type `T -> []`.

## Fix

The corrected output parenthesizes the let-expression:

```
((let {x = (# #)} in (# #) :: T) -> [])
```

Discovered via QuickCheck with seed `(SMGen 9946166173370120826 9328394170479583769,89)`.

## Test changes

- **1 new test**: `test_prettyViewLetTypeSigParens` — regression test for the exact failing pattern