### PR TITLE
fix(parser): support implicit parameters (?name :: Type) in standalone type parsing

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -193,16 +193,26 @@ buildTypeApp lhs rhs =
 typeAtomParser :: TokParser Type
 typeAtomParser = do
   thFullEnabled <- isExtensionEnabled TemplateHaskell
+  ipEnabled <- isExtensionEnabled ImplicitParams
   MP.try promotedTypeParser
     <|> typeLiteralTypeParser
     <|> typeQuasiQuoteParser
     <|> (if thFullEnabled then thSpliceTypeParser else MP.empty)
+    <|> (if ipEnabled then typeImplicitParamParser else MP.empty)
     <|> typeListParser
     <|> MP.try typeParenOperatorParser
     <|> typeParenOrTupleParser
     <|> typeStarParser
     <|> typeWildcardParser
     <|> typeIdentifierParser
+
+-- | Parse an implicit parameter type: @?name :: Type@
+typeImplicitParamParser :: TokParser Type
+typeImplicitParamParser = withSpan $ do
+  name <- implicitParamNameParser
+  expectedTok TkReservedDoubleColon
+  ty <- typeParser
+  pure $ \span' -> TImplicitParam span' name ty
 
 typeWildcardParser :: TokParser Type
 typeWildcardParser = withSpan $ do

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/type-synonym-implicit-param.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/type-synonym-implicit-param.yaml
@@ -1,0 +1,6 @@
+extensions: [ImplicitParams, ConstraintKinds]
+input: |
+  module M where
+  type CanCheck = (?checker :: Int)
+ast: "Module {name = \"M\", decls = [DeclTypeSyn (TypeSynDecl {name = \"CanCheck\", body = TParen (TImplicitParam \"?checker\" (TCon \"Int\"))})]}"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/standalone-implicit-param.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/standalone-implicit-param.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ImplicitParams #-}
+
+module StandaloneImplicitParam where
+
+-- Implicit parameter in standalone type position (e.g. type synonym body)
+f :: (?x :: Int) => (?y :: Bool) => Int -> Int
+f = ?x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/type-synonym-implicit-param.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ImplicitParams/type-synonym-implicit-param.hs
@@ -1,7 +1,7 @@
-{- ORACLE_TEST xfail reason="implicit parameter syntax in type synonyms not recognized" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Haskell2010, ImplicitParams, ConstraintKinds #-}
 
--- Parser fails on implicit parameter syntax in type synonyms
+-- Implicit parameter syntax in type synonyms
 type CanCheck = (?checker :: Int)
 
 f :: CanCheck => Int

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -75,9 +75,7 @@ genType depth
           (3, TParen span0 <$> genType (depth - 1)),
           (2, TSplice span0 <$> genTypeSpliceBody),
           (2, genTypeContext depth),
-          -- TODO: Generate TImplicitParam once the type parser supports ?name :: Type
-          -- in standalone type contexts. Currently only supported in declaration-level
-          -- type signatures.
+          (2, genTypeImplicitParam depth),
           (2, TKindSig span0 <$> genKindSigSubject (depth - 1) <*> genKindSigKind (depth - 1))
         ]
 
@@ -131,13 +129,11 @@ genConstraintType depth = do
       TApp span0 className . TParen span0 <$> genType (max 0 depth)
     ]
 
--- TODO: Generate TImplicitParam once the type parser supports ?name :: Type
--- in standalone type contexts.
--- genTypeImplicitParam :: Int -> Gen Type
--- genTypeImplicitParam depth = do
---   name <- ("?" <>) <$> genIdent
---   inner <- canonicalImplicitParamType <$> genType (depth - 1)
---   pure $ TParen span0 (TImplicitParam span0 name inner)
+genTypeImplicitParam :: Int -> Gen Type
+genTypeImplicitParam depth = do
+  name <- ("?" <>) <$> genIdent
+  inner <- canonicalImplicitParamType <$> genType (depth - 1)
+  pure $ TParen span0 (TImplicitParam span0 name inner)
 
 genTypeTupleElems :: Int -> Gen [Type]
 genTypeTupleElems depth = do

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 declConfig :: ParserConfig
 declConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, PatternSynonyms, UnicodeSyntax, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, DerivingStrategies, CApiFFI]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, PatternSynonyms, UnicodeSyntax, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, DerivingStrategies, CApiFFI, ImplicitParams]
     }
 
 prop_declPrettyRoundTrip :: Decl -> Property

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 exprConfig :: ParserConfig
 exprConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams]
     }
 
 prop_exprPrettyRoundTrip :: Expr -> Property

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -30,7 +30,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, UnicodeSyntax, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, DerivingStrategies, CApiFFI]
+    { parserExtensions = [BlockArguments, Arrows, UnboxedTuples, UnboxedSums, TemplateHaskell, UnicodeSyntax, LambdaCase, QuasiQuotes, ExplicitNamespaces, PatternSynonyms, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, DerivingStrategies, CApiFFI, ImplicitParams]
     }
 
 -- Module normalization

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Error qualified as MPE
 patternConfig :: ParserConfig
 patternConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams]
     }
 
 prop_patternPrettyRoundTrip :: Pattern -> Property

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -31,7 +31,7 @@ prop_typePrettyRoundTrip ty =
    in checkCoverage $
         withMaxShrinks 100 $
           cover 1 hasKindedInferredBinder "kinded inferred forall binder" $
-            assertCtorCoverage ["TAnn", "TImplicitParam"] ty $
+            assertCtorCoverage ["TAnn"] ty $
               counterexample (T.unpack source) $
                 case parseType typeConfig source of
                   ParseErr err ->


### PR DESCRIPTION
## Summary

- Add `typeImplicitParamParser` to `typeAtomParser` so `?name :: Type` is recognized in all type positions (e.g. type synonym bodies), not only inside constraint context items
- Uncomment and enable `genTypeImplicitParam` in the QuickCheck type generator (~25% coverage at 10k tests)
- Remove `TImplicitParam` from the `assertCtorCoverage` exclusion list in `TypeRoundTrip`
- Add `ImplicitParams` extension to all round-trip test parser configs (type, expr, pattern, decl, module)

## Test Changes

- **Oracle**: Promote `type-synonym-implicit-param.hs` from `xfail` to `pass` (1 xfail → pass)
- **Oracle**: Add `standalone-implicit-param.hs` test (1 new pass)
- **Golden**: Add `type-synonym-implicit-param.yaml` module golden test (1 new pass)

## Progress

- Oracle: 1 xfail → pass, 1 new pass
- Golden: 1 new pass

Closes #735