### PR TITLE
fix(parser): prevent guard arrow from being consumed as function type arrow

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -607,10 +607,7 @@ guardPatBindParser :: TokParser GuardQualifier
 guardPatBindParser = withSpan $ do
   pat <- patternParser
   expectedTok TkReservedLeftArrow
-  -- Use typeInfixParser so that '->' is not consumed as a function type arrow.
-  -- In guard context, '->' is the guard arrow that separates guards from the body.
-  -- This matches the behavior of guardBindOrExprParser (line 594).
-  expr <- exprParserWithTypeSigParser typeInfixParser
+  expr <- exprParser
   pure (\span' -> GuardPat span' pat expr)
 
 guardLetParser :: TokParser GuardQualifier

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -607,7 +607,10 @@ guardPatBindParser :: TokParser GuardQualifier
 guardPatBindParser = withSpan $ do
   pat <- patternParser
   expectedTok TkReservedLeftArrow
-  expr <- exprParser
+  -- Use typeInfixParser so that '->' is not consumed as a function type arrow.
+  -- In guard context, '->' is the guard arrow that separates guards from the body.
+  -- This matches the behavior of guardBindOrExprParser (line 594).
+  expr <- exprParserWithTypeSigParser typeInfixParser
   pure (\span' -> GuardPat span' pat expr)
 
 guardLetParser :: TokParser GuardQualifier

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1248,6 +1248,23 @@ isGreedyExpr = \case
   EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
   _ -> False
 
+-- | Check if an expression ends with a type signature (@:: type@) when rendered.
+-- In guard contexts where @->@ follows the expression, the parser would greedily
+-- consume @->@ as a function type arrow inside the type signature. Expressions
+-- matching this predicate need parenthesization to prevent this ambiguity.
+exprEndsWithTypeSig :: Expr -> Bool
+exprEndsWithTypeSig = \case
+  ETypeSig {} -> True
+  -- Open-ended expressions whose trailing subexpression is the issue:
+  ELetDecls _ _ body -> exprEndsWithTypeSig body
+  EIf _ _ _ elseE -> exprEndsWithTypeSig elseE
+  -- Infix: the RHS is the trailing part; if it has a type sig that's at the
+  -- top level of exprParser, it shows up as ETypeSig wrapping the whole infix.
+  -- But the pretty-printer renders EInfix at prec 1 so ETypeSig (prec > 1)
+  -- won't add parens. Check the RHS too.
+  EInfix _ _ _ rhs -> exprEndsWithTypeSig rhs
+  _ -> False
+
 -- | Print an expression in a "guarded" context where greedy expressions
 -- need parentheses to prevent them from consuming trailing syntax.
 prettyExprGuarded :: Expr -> Doc ann
@@ -1573,7 +1590,13 @@ prettyGuardQualifier qualifier =
     GuardExpr _ expr
       | guardExprNeedsParens expr -> parens (prettyExprPrec 0 expr)
       | otherwise -> prettyExprPrec 0 expr
-    GuardPat _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExprPrec 0 expr
+    GuardPat _ pat expr
+      -- In guard context, '->' follows the expression as the guard arrow.
+      -- If the expression ends with a type signature (e.g. 'let {..} in x :: v'),
+      -- the '->' would be consumed as a function type arrow by the parser.
+      -- Parenthesize such expressions to prevent this ambiguity.
+      | exprEndsWithTypeSig expr -> prettyPattern pat <+> "<-" <+> parens (prettyExprPrec 0 expr)
+      | otherwise -> prettyPattern pat <+> "<-" <+> prettyExprPrec 0 expr
     GuardLet _ decls -> "let" <+> braces (prettyInlineDecls decls)
 
 guardExprNeedsParens :: Expr -> Bool

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/guard-pat-type-sig-arrow.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/guard-pat-type-sig-arrow.yaml
@@ -1,0 +1,20 @@
+src: |
+  {-# LANGUAGE MultiWayIf #-}
+  a = if
+    | True <- let {p = 1} in 2 :: v -> 3
+ghc: |
+  test.hs:4:1: error: [GHC-58481]
+      parse error (possibly incorrect indentation or mismatched brackets)
+aihc: |
+  test.hs:3:38:
+  3 |   | True <- let {p = 1} in 2 :: v -> 3
+    |                                      ^
+  unexpected end of input
+  expecting expression
+  context: while parsing equation right-hand side
+
+  test.hs:3:38:
+  3 |   | True <- let {p = 1} in 2 :: v -> 3
+    |                                      ^
+  unexpected }
+  expecting end of input


### PR DESCRIPTION
## Summary

- Fix pretty-printer to parenthesize guard pattern expressions that end with a type signature (`:: type`), preventing the following `->` guard arrow from being greedily consumed as a function type arrow
- Add error message test confirming AIHC correctly rejects `| pat <- let {..} in expr :: type -> body` (matching GHC behavior)

## Problem

In guard pattern bindings (`pat <- expr`), when the expression ends with a type signature—either directly (`expr :: type`) or nested inside an open-ended expression like `let {..} in expr :: type`—the `->` guard arrow that follows is consumed by the type parser as a function type arrow.

This is **correct parser behavior** (GHC does the same), so the fix is in the pretty-printer: when generating code from an AST with a type-sig-ending guard expression, parenthesize it to avoid the ambiguity.

Minimal reproduction of the round-trip failure:
```haskell
-- The pretty-printer generated this (invalid):
a = if { | True <- let {p = 1} in 2 :: v -> 3 }
-- Parser reads: True <- let {p = 1} in (2 :: v -> 3)  -- no guard arrow left

-- The fix parenthesizes the expression:
a = if { | True <- (let {p = 1} in 2 :: v) -> 3 }
```

Found via QuickCheck: `just replay "(SMGen 10294274578642533712 1335181653854191273,91)"`

## Changes

**Pretty-printer** (`Pretty.hs`):
- New `exprEndsWithTypeSig` predicate that recursively checks whether an expression's trailing tokens are `:: type` (handles `ETypeSig`, `ELetDecls`, `EIf`, `EInfix`)
- `prettyGuardQualifier` now parenthesizes `GuardPat` expressions matching this predicate

**Test** (`error-messages/module/guard-pat-type-sig-arrow.yaml`):
- New error message fixture confirming the invalid syntax is rejected by both GHC and AIHC

## Progress

- Error message fixtures: 18 → 19