### PR TITLE
fix(parser): ban ★ (U+2605) from generated operator symbols

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -274,7 +274,8 @@ bannedUnicodeOperatorChars =
     '⦈',
     '⟦',
     '⟧',
-    '⊸'
+    '⊸',
+    '★'
   ]
 
 isValidGeneratedOperator :: Text -> Bool


### PR DESCRIPTION
## Summary

- Add `★` (U+2605, BLACK STAR) to `bannedUnicodeOperatorChars` in the property test operator generator
- With `UnicodeSyntax` enabled, `★` is the Unicode spelling of `*` (star/kind), so the lexer normalizes it to `TkVarSym "*"`, breaking the pretty-printer round-trip property test
- This is the same treatment already applied to other `UnicodeSyntax` reserved symbols (`→`, `←`, `⇒`, `∷`, `∀`, etc.)

## Progress counts

No change in pass/fail/xfail counts — this fixes a flaky property test failure, not a parser feature.

## Reproduction

```
just replay "(SMGen 8100914092320579018 2678760998639333697,59)"
```