### PR TITLE
fix(pretty): recurse into EInfix in endsWithTypeSig and prettyIfBranch

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1291,6 +1291,7 @@ endsWithTypeSig = \case
   ETypeSig {} -> True
   ELetDecls _ _ body -> endsWithTypeSig body
   ELambdaPats _ _ body -> endsWithTypeSig body
+  EInfix _ _ _ rhs -> endsWithTypeSig rhs
   _ -> False
 
 -- | Print an expression used as the function in an application.
@@ -1327,7 +1328,9 @@ prettyIfBranch expr =
   case expr of
     -- Branch delimiters handle most greedy expressions, but postfix forms like
     -- type signatures need parens to stay inside the branch.
-    ETypeSig {} -> parens (prettyExprPrec 0 expr)
+    -- Use endsWithTypeSig to also catch indirect cases like infix expressions
+    -- whose RHS is a type signature (e.g. @a + b :: T@).
+    _ | endsWithTypeSig expr -> parens (prettyExprPrec 0 expr)
     _ -> prettyExprPrec 0 expr
 
 -- | Flatten a left-nested application chain into (root, args).


### PR DESCRIPTION
## Summary

- Fix `endsWithTypeSig` to recurse into `EInfix` RHS, so expressions like `a ‼ let {...} in x :: T` are correctly recognized as ending with a type signature
- Generalize `prettyIfBranch` to use `endsWithTypeSig` instead of matching only direct `ETypeSig`, catching indirect cases like `if ... else a + b :: T`

## Problem

`endsWithTypeSig` determines whether an expression's pretty-printed form ends with `:: Type`. It already recursed into `ELetDecls` and `ELambdaPats`, but not `EInfix`. When an infix expression had a RHS that ended with a type signature (e.g. `(#,#) ‼ let {...} in 0x22 :: LW`), the predicate returned `False`.

In guard-arrow contexts (multi-way `if`, case alternatives), this meant the trailing `:: LW` was not parenthesized, causing GHC to absorb the `->` guard arrow into the type (`:: LW -> (# #)`), producing unparseable output.

Repro: `just replay "(SMGen 2578528495492361283 12144059412406403927,90)"`

## Fix

1. **`endsWithTypeSig`**: Add `EInfix _ _ _ rhs -> endsWithTypeSig rhs` — an infix expression ends with whatever its RHS ends with. Follows the same structural recursion pattern as `isOpenEnded`.
2. **`prettyIfBranch`**: Replace the direct `ETypeSig {}` match with `endsWithTypeSig expr` guard, so else-branches like `a + b :: T` are also parenthesized.

## Test results

`just check` passes (ormolu, hlint, full test suite with 1000 QuickCheck tests).