### PR TITLE
refactor(parser): make isReservedIdentifier extension-aware for QC generators

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -81,6 +81,8 @@ import Aihc.Parser.Syntax
 import Control.Applicative ((<|>))
 import Data.Char (GeneralCategory (..), generalCategory, isAscii, isAsciiLower, isAsciiUpper, isDigit, isSpace)
 import Data.Maybe (fromMaybe, isJust)
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text, pattern Empty, pattern (:<))
 import Data.Text qualified as T
 
@@ -335,15 +337,11 @@ lexIdentifier env st =
                 Just _ -> TkQVarId modName name
                 Nothing -> TkQVarId modName name
       | otherwise =
-          case keywordTokenKind ident of
+          case keywordTokenKind (lexerExtensions env) ident of
             Just kw -> kw
-            Nothing ->
-              case extensionKeywordTokenKind env ident of
-                Just kw -> kw
-                Nothing ->
-                  if isConIdStart firstChar
-                    then TkConId ident
-                    else TkVarId ident
+            Nothing
+              | isConIdStart firstChar -> TkConId ident
+              | otherwise -> TkVarId ident
 
 lexImplicitParam :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexImplicitParam env st
@@ -983,11 +981,13 @@ isUnicodeSymbolCategory c =
 isIdentTailOrStart :: Char -> Bool
 isIdentTailOrStart = isIdentTail
 
-isReservedIdentifier :: Text -> Bool
-isReservedIdentifier = isJust . keywordTokenKind
+-- | Check if an identifier is reserved given a set of enabled extensions.
+-- This includes both base keywords and extension-specific keywords.
+isReservedIdentifier :: Set Extension -> Text -> Bool
+isReservedIdentifier exts txt = isJust (keywordTokenKind exts txt)
 
-keywordTokenKind :: Text -> Maybe LexTokenKind
-keywordTokenKind txt =
+keywordTokenKind :: Set Extension -> Text -> Maybe LexTokenKind
+keywordTokenKind exts txt =
   case txt of
     "case" -> Just TkKeywordCase
     "class" -> Just TkKeywordClass
@@ -1013,15 +1013,10 @@ keywordTokenKind txt =
     "type" -> Just TkKeywordType
     "where" -> Just TkKeywordWhere
     "_" -> Just TkKeywordUnderscore
-    _ -> Nothing
-
-extensionKeywordTokenKind :: LexerEnv -> Text -> Maybe LexTokenKind
-extensionKeywordTokenKind env txt =
-  case txt of
-    "proc" | hasExt Arrows env -> Just TkKeywordProc
-    "rec" | hasExt Arrows env || hasExt RecursiveDo env -> Just TkKeywordRec
-    "mdo" | hasExt RecursiveDo env -> Just TkKeywordMdo
-    "pattern" | hasExt PatternSynonyms env -> Just TkKeywordPattern
+    "proc" | Set.member Arrows exts -> Just TkKeywordProc
+    "rec" | Set.member Arrows exts || Set.member RecursiveDo exts -> Just TkKeywordRec
+    "mdo" | Set.member RecursiveDo exts -> Just TkKeywordMdo
+    "pattern" | Set.member PatternSynonyms exts -> Just TkKeywordPattern
     _ -> Nothing
 
 reservedOpTokenKind :: Text -> Maybe LexTokenKind

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -10,7 +10,6 @@ module Test.Properties.Arb.Identifiers
     genIdent,
     shrinkIdent,
     isValidGeneratedIdent,
-    extensionReservedIdentifiers,
 
     -- * Constructor identifiers
     genConIdent,
@@ -45,10 +44,15 @@ module Test.Properties.Arb.Identifiers
 where
 
 import Aihc.Parser.Lex (isReservedIdentifier)
-import Aihc.Parser.Syntax (SourceSpan, noSourceSpan)
+import Aihc.Parser.Syntax (Extension, SourceSpan, allKnownExtensions, noSourceSpan)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.QuickCheck (Gen, chooseInt, chooseInteger, elements, shrink, shrinkIntegral, vectorOf)
+
+-- | All extensions enabled for maximum keyword coverage in testing.
+allExtensions :: Set.Set Extension
+allExtensions = Set.fromList allKnownExtensions
 
 -- | Canonical empty source span for normalization.
 span0 :: SourceSpan
@@ -83,12 +87,8 @@ isValidGeneratedIdent ident =
       ident /= "_"
         && (first `elem` (['a' .. 'z'] <> ['_']))
         && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
-        && ident `notElem` extensionReservedIdentifiers
-        && not (isReservedIdentifier ident)
+        && not (isReservedIdentifier allExtensions ident)
     Nothing -> False
-
-extensionReservedIdentifiers :: [Text]
-extensionReservedIdentifiers = ["mdo", "proc", "rec"]
 
 -------------------------------------------------------------------------------
 -- Constructor identifiers (uppercase-starting names)
@@ -174,7 +174,7 @@ genFieldName = do
   restLen <- chooseInt (0, 5)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
   let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate || candidate `elem` extensionReservedIdentifiers
+  if isReservedIdentifier allExtensions candidate
     then genFieldName
     else pure candidate
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -18,6 +18,7 @@ where
 
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Identifiers
@@ -32,6 +33,10 @@ import Test.Properties.Arb.Identifiers
     span0,
   )
 import Test.QuickCheck
+
+-- | All extensions enabled for maximum keyword coverage in testing.
+allExtensions :: Set.Set Extension
+allExtensions = Set.fromList allKnownExtensions
 
 instance Arbitrary Type where
   arbitrary = sized (genType . min 6)
@@ -259,7 +264,7 @@ genTypeVarName = do
   restLen <- chooseInt (0, 5)
   rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
   let candidate = T.pack (first : rest)
-  if isReservedIdentifier candidate
+  if isReservedIdentifier allExtensions candidate
     then genTypeVarName
     else pure (mkUnqualifiedName NameVarId candidate)
 


### PR DESCRIPTION
## Summary

Modified `isReservedIdentifier` to accept a `Set Extension` parameter, enabling QuickCheck generators to use all extensions and properly filter out extension-specific keywords.

## Changes

- **`Aihc.Parser.Lex`**: Updated `isReservedIdentifier` to take a `Set Extension` and check both base keywords and extension-specific keywords (`proc`, `rec`, `mdo`, `pattern`)
- **`Test.Properties.Arb.Type`**: Updated `genTypeVarName` to use `isReservedIdentifier` with all extensions enabled
- **`Test.Properties.Arb.Identifiers`**: 
  - Updated `isValidGeneratedIdent` and `genFieldName` to use the new signature
  - Removed duplicate `extensionReservedIdentifiers` list (single source of truth in `Aihc.Parser.Lex`)

## Benefits

1. **Single source of truth**: All keyword checking now goes through `isReservedIdentifier` in `Aihc.Parser.Lex`
2. **Better test coverage**: QC generators now filter out extension keywords when all extensions are enabled
3. **More accurate testing**: Type variable name generation now respects the full set of language extensions