### PR TITLE
refactor(pretty): separate parenthesization logic into Aihc.Parser.Parens

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -16,7 +16,8 @@ library
     , Aihc.Parser.Lex
     , Aihc.Parser.Shorthand
   other-modules:
-      Aihc.Parser.Pretty
+      Aihc.Parser.Parens
+    , Aihc.Parser.Pretty
     , Aihc.Parser.Types
     , Aihc.Parser.Lex.Header
     , Aihc.Parser.Lex.Layout
@@ -60,6 +61,7 @@ test-suite spec
     , Aihc.Parser.Syntax
     , Aihc.Parser.Lex
     , Aihc.Parser.Shorthand
+    , Aihc.Parser.Parens
     , Aihc.Parser.Pretty
     , Aihc.Parser.Types
     , Aihc.Parser.Lex.Header

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -383,7 +383,7 @@ addPatSynDirParens name (PatSynExplicitBidirectional matches) =
 addDataDeclParens :: DataDecl -> DataDecl
 addDataDeclParens decl =
   decl
-    { dataDeclContext = map addTypeParens (dataDeclContext decl),
+    { dataDeclContext = addContextConstraints (dataDeclContext decl),
       dataDeclKind = fmap addTypeParens (dataDeclKind decl),
       dataDeclConstructors = map addDataConDeclParens (dataDeclConstructors decl),
       dataDeclDeriving = map addDerivingClauseParens (dataDeclDeriving decl)
@@ -392,7 +392,7 @@ addDataDeclParens decl =
 addNewtypeDeclParens :: NewtypeDecl -> NewtypeDecl
 addNewtypeDeclParens decl =
   decl
-    { newtypeDeclContext = map addTypeParens (newtypeDeclContext decl),
+    { newtypeDeclContext = addContextConstraints (newtypeDeclContext decl),
       newtypeDeclKind = fmap addTypeParens (newtypeDeclKind decl),
       newtypeDeclConstructor = fmap addDataConDeclParens (newtypeDeclConstructor decl),
       newtypeDeclDeriving = map addDerivingClauseParens (newtypeDeclDeriving decl)
@@ -409,13 +409,13 @@ addDataConDeclParens :: DataConDecl -> DataConDecl
 addDataConDeclParens con =
   case con of
     PrefixCon sp forallVars constraints name fields ->
-      PrefixCon sp forallVars (map addTypeParens constraints) name (map addBangTypeParens fields)
+      PrefixCon sp forallVars (addContextConstraints constraints) name (map addBangTypeParens fields)
     InfixCon sp forallVars constraints lhs op rhs ->
-      InfixCon sp forallVars (map addTypeParens constraints) (addBangTypeAtomParens lhs) op (addBangTypeAtomParens rhs)
+      InfixCon sp forallVars (addContextConstraints constraints) (addBangTypeAtomParens lhs) op (addBangTypeAtomParens rhs)
     RecordCon sp forallVars constraints name fields ->
-      RecordCon sp forallVars (map addTypeParens constraints) name (map addRecordFieldDeclParens fields)
+      RecordCon sp forallVars (addContextConstraints constraints) name (map addRecordFieldDeclParens fields)
     GadtCon sp forallBinders constraints names body ->
-      GadtCon sp forallBinders (map addTypeParens constraints) names (addGadtBodyParens body)
+      GadtCon sp forallBinders (addContextConstraints constraints) names (addGadtBodyParens body)
 
 addBangTypeParens :: BangType -> BangType
 addBangTypeParens bt =
@@ -457,7 +457,7 @@ addGadtBodyParens body =
 addClassDeclParens :: ClassDecl -> ClassDecl
 addClassDeclParens decl =
   decl
-    { classDeclContext = fmap (map addTypeParens) (classDeclContext decl),
+    { classDeclContext = fmap addContextConstraints (classDeclContext decl),
       classDeclItems = map addClassItemParens (classDeclItems decl)
     }
 
@@ -476,7 +476,7 @@ addClassItemParens item =
 addInstanceDeclParens :: InstanceDecl -> InstanceDecl
 addInstanceDeclParens decl =
   decl
-    { instanceDeclContext = map addTypeParens (instanceDeclContext decl),
+    { instanceDeclContext = addContextConstraints (instanceDeclContext decl),
       instanceDeclTypes = map (addTypeIn CtxTypeAtom) (instanceDeclTypes decl),
       instanceDeclItems = map addInstanceItemParens (instanceDeclItems decl)
     }
@@ -495,7 +495,7 @@ addStandaloneDerivingParens :: StandaloneDerivingDecl -> StandaloneDerivingDecl
 addStandaloneDerivingParens decl =
   decl
     { standaloneDerivingViaType = fmap addTypeParens (standaloneDerivingViaType decl),
-      standaloneDerivingContext = map addTypeParens (standaloneDerivingContext decl),
+      standaloneDerivingContext = addContextConstraints (standaloneDerivingContext decl),
       standaloneDerivingTypes = map (addTypeIn CtxTypeAtom) (standaloneDerivingTypes decl)
     }
 
@@ -792,13 +792,17 @@ addTypeParensShared ctx prec ty =
           TTuple sp tupleFlavor promoted (map (atom 0) elems)
         TUnboxedSum sp elems -> TUnboxedSum sp (map (atom 0) elems)
         TList sp promoted elems -> TList sp promoted (map (atom 0) elems)
-        TParen sp inner -> TParen sp (atom 0 inner)
+        -- Inside an explicit TParen, the delimiter is already present, so we
+        -- process the inner type at prec 0 without adding extra wrapping.
+        -- Using CtxKindSig prevents double-wrapping TKindSig (which the
+        -- outer TParen already handles).
+        TParen sp inner -> TParen sp (addTypeParensInner inner)
         TKindSig sp ty' kind ->
           case ctx of
             CtxKindSig -> TKindSig sp (atom 0 ty') (atom 0 kind)
             _ -> wrapTy True (TKindSig sp (atom 0 ty') (atom 0 kind))
         TContext sp constraints inner ->
-          wrapTy (prec > 0) (TContext sp (map addTypeParens constraints) (atom 0 inner))
+          wrapTy (prec > 0) (TContext sp (addContextConstraints constraints) (atom 0 inner))
         TSplice sp body -> TSplice sp (addSpliceBodyParens body)
         TWildcard {} -> ty
   where
@@ -813,6 +817,44 @@ addTypeParensShared ctx prec ty =
 addTyVarBinderParens :: TyVarBinder -> TyVarBinder
 addTyVarBinderParens tvb =
   tvb {tyVarBinderKind = fmap addTypeParens (tyVarBinderKind tvb)}
+
+-- | Process a type inside explicit delimiters (TParen, TTuple, etc.).
+-- TKindSig does not need wrapping here because the enclosing delimiter
+-- already provides the necessary parenthesization.
+addTypeParensInner :: Type -> Type
+addTypeParensInner ty =
+  case ty of
+    TKindSig sp ty' kind ->
+      TKindSig sp (addTypeParensShared CtxTypeAtom 0 ty') (addTypeParensShared CtxTypeAtom 0 kind)
+    _ -> addTypeParensShared CtxTypeAtom 0 ty
+
+-- | Process constraint types in a TContext.
+-- In multi-constraint contexts, TKindSig doesn't need individual parens
+-- (commas delimit). In single-constraint contexts, TKindSig needs parens.
+addContextConstraints :: [Type] -> [Type]
+addContextConstraints constraints =
+  case constraints of
+    [single] -> [addContextConstraintSingle single]
+    _ -> map addContextConstraintMulti constraints
+
+-- | Add parens to a single constraint in a context.
+-- TKindSig needs wrapping here because there's no comma delimiter.
+addContextConstraintSingle :: Type -> Type
+addContextConstraintSingle = addTypeParens
+
+-- | Add parens to a constraint in a multi-constraint context.
+-- TKindSig doesn't need extra wrapping because commas delimit.
+-- Strip TParen around TKindSig since it's unnecessary here.
+addContextConstraintMulti :: Type -> Type
+addContextConstraintMulti ty =
+  case ty of
+    TKindSig sp ty' kind ->
+      -- In multi-constraint context, TKindSig doesn't need wrapping
+      TKindSig sp (addTypeParensShared CtxTypeAtom 0 ty') (addTypeParensShared CtxTypeAtom 0 kind)
+    TParen _ inner@(TKindSig {}) ->
+      -- Strip TParen around TKindSig in multi-constraint context
+      addContextConstraintMulti inner
+    _ -> addTypeParens ty
 
 -- ---------------------------------------------------------------------------
 -- Patterns
@@ -833,7 +875,7 @@ addPatternParens pat =
     PCon sp con args -> PCon sp con (map addPatternAtomParens args)
     PInfix sp lhs op rhs -> PInfix sp (addPatternAtomParens lhs) op (addPatternAtomParens rhs)
     PView sp viewExpr inner ->
-      PView sp (addViewExprParens viewExpr) (addPatternParens inner)
+      wrapPat True (PView sp (addViewExprParens viewExpr) (addPatternParens inner))
     PAs sp name inner -> PAs sp name (addPatternAtomStrictParens inner)
     PStrict sp inner -> PStrict sp (addPatternAtomStrictParens inner)
     PIrrefutable sp inner -> PIrrefutable sp (addPatternAtomStrictParens inner)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -307,8 +307,8 @@ addDeclParens decl =
 addDeclSpliceParens :: Expr -> Expr
 addDeclSpliceParens body =
   case body of
-    EVar {} -> addExprParens body
-    EParen {} -> addExprParens body
+    EVar {} -> body
+    EParen sp inner -> EParen sp (addExprParens inner)
     _ -> addExprParens body
 
 addValueDeclParens :: ValueDecl -> ValueDecl
@@ -697,9 +697,21 @@ getAppSpans = reverse . go
 addSpliceBodyParens :: Expr -> Expr
 addSpliceBodyParens body =
   case body of
+    -- EParen around a section: the pretty-printer's EParen transparency
+    -- means this would print as just the section's parens. We need an
+    -- extra EParen so the splice delimiter parens are not swallowed.
+    EParen sp inner@(ESectionL {}) -> EParen sp (EParen noSourceSpan (addExprParens inner))
+    EParen sp inner@(ESectionR {}) -> EParen sp (EParen noSourceSpan (addExprParens inner))
     EParen sp inner -> EParen sp (addExprParens inner)
     EVar {} -> body
-    _ -> addExprParens body
+    -- Sections print their own parens via prettyExpr, and EParen is
+    -- transparent around them in the pretty-printer (to avoid double parens
+    -- in normal code like `x = (+1)`). For splices, we need the EParen to
+    -- actually produce parens, so we double-wrap.
+    ESectionL {} -> EParen noSourceSpan (EParen noSourceSpan (addExprParens body))
+    ESectionR {} -> EParen noSourceSpan (EParen noSourceSpan (addExprParens body))
+    -- Any other body needs to be wrapped in EParen so it prints as $(expr).
+    _ -> EParen noSourceSpan (addExprParens body)
 
 addNegateParens :: Expr -> Expr
 addNegateParens inner =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1,0 +1,958 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Aihc.Parser.Parens
+-- Description : Parenthesization pass for AST
+--
+-- This module provides a parenthesization pass that inserts 'EParen', 'PParen',
+-- 'TParen', and 'CmdPar' nodes at all required positions in the AST. After this
+-- pass, the pretty-printer can format code without worrying about parentheses.
+--
+-- The pass is __idempotent__: calling it twice produces the same result as
+-- calling it once. It never adds unnecessary parentheses, so parsed code
+-- (which already has explicit paren nodes from the source) is not modified.
+--
+-- __Entry points:__
+--
+-- * 'addModuleParens'  — parenthesise an entire module
+-- * 'addDeclParens'    — parenthesise a declaration
+-- * 'addExprParens'    — parenthesise an expression
+-- * 'addPatternParens' — parenthesise a pattern
+-- * 'addTypeParens'    — parenthesise a type
+module Aihc.Parser.Parens
+  ( addModuleParens,
+    addDeclParens,
+    addExprParens,
+    addPatternParens,
+    addTypeParens,
+  )
+where
+
+import Aihc.Parser.Syntax
+import Data.Text (Text)
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+-- | Wrap an expression in 'EParen' if the predicate holds, unless it is
+-- already parenthesised.
+wrapExpr :: Bool -> Expr -> Expr
+wrapExpr True e@(EParen {}) = e
+wrapExpr True e = EParen noSourceSpan e
+wrapExpr False e = e
+
+-- | Wrap a pattern in 'PParen' if the predicate holds, unless already wrapped.
+wrapPat :: Bool -> Pattern -> Pattern
+wrapPat True p@(PParen {}) = p
+wrapPat True p = PParen noSourceSpan p
+wrapPat False p = p
+
+-- | Wrap a type in 'TParen' if the predicate holds, unless already wrapped.
+wrapTy :: Bool -> Type -> Type
+wrapTy True t@(TParen {}) = t
+wrapTy True t = TParen noSourceSpan t
+wrapTy False t = t
+
+-- ---------------------------------------------------------------------------
+-- Token classification helpers (mirrored from Pretty.hs)
+-- ---------------------------------------------------------------------------
+
+isSymbolicName :: Name -> Bool
+isSymbolicName name =
+  case nameType name of
+    NameVarSym -> True
+    NameConSym -> True
+    _ -> False
+
+isArrowTailOp :: Text -> Bool
+isArrowTailOp "-<" = True
+isArrowTailOp "-<<" = True
+isArrowTailOp _ = False
+
+-- ---------------------------------------------------------------------------
+-- Expression classification helpers (mirrored from Pretty.hs)
+-- ---------------------------------------------------------------------------
+
+-- | Check if an expression is a "block expression" that can appear without
+-- parentheses as a function argument when BlockArguments is enabled.
+isBlockExpr :: Expr -> Bool
+isBlockExpr = \case
+  EIf {} -> True
+  EMultiWayIf {} -> True
+  ECase {} -> True
+  EDo {} -> True
+  ELambdaPats {} -> True
+  ELambdaCase {} -> True
+  ELetDecls {} -> True
+  _ -> False
+
+-- | Check if an expression is "greedy" - i.e., it could consume trailing syntax.
+isGreedyExpr :: Expr -> Bool
+isGreedyExpr = \case
+  ECase {} -> True
+  EIf {} -> True
+  ELambdaPats {} -> True
+  ELambdaCase {} -> True
+  ELetDecls {} -> True
+  EDo {} -> True
+  EProc {} -> True
+  EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
+  _ -> False
+
+-- | Check if an expression is "open-ended" - its rightmost component can
+-- capture a trailing where clause.
+isOpenEnded :: Expr -> Bool
+isOpenEnded = \case
+  EIf {} -> True
+  ELambdaPats {} -> True
+  ELetDecls {} -> True
+  EProc {} -> True
+  EInfix _ _ _ rhs -> isOpenEnded rhs
+  EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
+  _ -> False
+
+-- | Does the pretty-printed form of an expression end with @:: Type@?
+endsWithTypeSig :: Expr -> Bool
+endsWithTypeSig = \case
+  ETypeSig {} -> True
+  ELetDecls _ _ body -> endsWithTypeSig body
+  ELambdaPats _ _ body -> endsWithTypeSig body
+  EInfix _ _ _ rhs -> endsWithTypeSig rhs
+  _ -> False
+
+-- | Check whether an expression's pretty-printed form starts with '$'.
+startsWithDollar :: Expr -> Bool
+startsWithDollar (ETHSplice {}) = True
+startsWithDollar (ETHTypedSplice {}) = True
+startsWithDollar (ERecordUpd _ base _) = startsWithDollar base
+startsWithDollar (EApp _ fn _) = startsWithDollar fn
+startsWithDollar _ = False
+
+startsWithOverloadedLabel :: Expr -> Bool
+startsWithOverloadedLabel = \case
+  EOverloadedLabel {} -> True
+  EAnn _ sub -> startsWithOverloadedLabel sub
+  EApp _ fn _ -> startsWithOverloadedLabel fn
+  EInfix _ lhs _ _ -> startsWithOverloadedLabel lhs
+  ERecordUpd _ base _ -> startsWithOverloadedLabel base
+  ETypeSig _ inner _ -> startsWithOverloadedLabel inner
+  ETypeApp _ fn _ -> startsWithOverloadedLabel fn
+  _ -> False
+
+-- ---------------------------------------------------------------------------
+-- Expression contexts
+-- ---------------------------------------------------------------------------
+
+data ExprCtx
+  = CtxInfixRhs Bool
+  | CtxInfixLhs
+  | CtxAppFun
+  | CtxAppArg
+  | CtxAppArgNoParens
+  | CtxTypeSigBody
+  | CtxGuarded
+
+needsExprParens :: ExprCtx -> Expr -> Bool
+needsExprParens ctx expr =
+  case ctx of
+    CtxInfixRhs protectOpenEnded ->
+      case expr of
+        EInfix {} -> True
+        ETypeSig {} -> True
+        ENegate {} -> True
+        _ | protectOpenEnded && isOpenEnded expr -> True
+        _ -> False
+    CtxInfixLhs ->
+      case expr of
+        ETypeSig {} -> True
+        ENegate {} -> True
+        _ -> isOpenEnded expr
+    CtxAppFun ->
+      case expr of
+        ENegate {} -> True
+        _ -> False
+    CtxAppArg ->
+      case expr of
+        _ | isBlockExpr expr -> False
+        _ -> False
+    CtxAppArgNoParens ->
+      False
+    CtxTypeSigBody ->
+      case expr of
+        ENegate {} -> True
+        ETypeSig {} -> True
+        ELambdaPats {} -> True
+        _ -> isOpenEnded expr
+    CtxGuarded -> isGreedyExpr expr
+
+exprCtxPrec :: ExprCtx -> Expr -> Int
+exprCtxPrec ctx expr =
+  case ctx of
+    CtxInfixRhs _
+      | isGreedyExpr expr -> 0
+      | otherwise -> 1
+    CtxInfixLhs -> 1
+    CtxAppFun -> 2
+    CtxAppArg -> 3
+    CtxAppArgNoParens -> 0
+    CtxTypeSigBody -> 1
+    CtxGuarded -> 0
+
+-- ---------------------------------------------------------------------------
+-- Type contexts
+-- ---------------------------------------------------------------------------
+
+data TypeCtx
+  = CtxTypeFunArg
+  | CtxTypeAppArg
+  | CtxTypeAtom
+  | CtxKindSig
+
+needsTypeParens :: TypeCtx -> Type -> Bool
+needsTypeParens ctx ty =
+  case ctx of
+    CtxTypeFunArg ->
+      case ty of
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        _ -> False
+    CtxTypeAppArg ->
+      case ty of
+        TQuasiQuote {} -> False
+        TApp {} -> True
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        _ -> False
+    CtxTypeAtom ->
+      case ty of
+        TVar {} -> False
+        TCon {} -> False
+        TImplicitParam {} -> False
+        TTypeLit {} -> False
+        TStar {} -> False
+        TQuasiQuote {} -> False
+        TList {} -> False
+        TTuple {} -> False
+        TUnboxedSum {} -> False
+        TParen {} -> False
+        TKindSig {} -> False
+        TWildcard {} -> False
+        _ -> True
+    CtxKindSig ->
+      case ty of
+        TKindSig {} -> False
+        _ -> True
+
+-- ---------------------------------------------------------------------------
+-- Guard contexts
+-- ---------------------------------------------------------------------------
+
+data GuardArrow = GuardArrow | GuardEquals
+
+guardExprNeedsParens :: GuardArrow -> Expr -> Bool
+guardExprNeedsParens arrow = \case
+  ELambdaPats {} -> True
+  EProc {} -> True
+  EApp _ _ arg | isBlockExpr arg -> guardExprNeedsParens arrow arg
+  expr -> case arrow of
+    GuardArrow -> endsWithTypeSig expr
+    GuardEquals -> False
+
+-- ---------------------------------------------------------------------------
+-- Module
+-- ---------------------------------------------------------------------------
+
+addModuleParens :: Module -> Module
+addModuleParens modu =
+  modu
+    { moduleDecls = map addDeclParens (moduleDecls modu)
+    }
+
+-- ---------------------------------------------------------------------------
+-- Declarations
+-- ---------------------------------------------------------------------------
+
+addDeclParens :: Decl -> Decl
+addDeclParens decl =
+  case decl of
+    DeclAnn ann sub -> DeclAnn ann (addDeclParens sub)
+    DeclValue sp vdecl -> DeclValue sp (addValueDeclParens vdecl)
+    DeclTypeSig sp names ty -> DeclTypeSig sp names (addTypeParens ty)
+    DeclPatSyn sp ps -> DeclPatSyn sp (addPatSynDeclParens ps)
+    DeclPatSynSig sp names ty -> DeclPatSynSig sp names (addTypeParens ty)
+    DeclStandaloneKindSig sp name kind -> DeclStandaloneKindSig sp name (addTypeParens kind)
+    DeclFixity {} -> decl
+    DeclRoleAnnotation {} -> decl
+    DeclTypeSyn sp synDecl ->
+      DeclTypeSyn sp synDecl {typeSynBody = addTypeParens (typeSynBody synDecl)}
+    DeclData sp dataDecl -> DeclData sp (addDataDeclParens dataDecl)
+    DeclTypeData sp dataDecl -> DeclTypeData sp (addDataDeclParens dataDecl)
+    DeclNewtype sp newtypeDecl -> DeclNewtype sp (addNewtypeDeclParens newtypeDecl)
+    DeclClass sp classDecl -> DeclClass sp (addClassDeclParens classDecl)
+    DeclInstance sp instanceDecl -> DeclInstance sp (addInstanceDeclParens instanceDecl)
+    DeclStandaloneDeriving sp derivingDecl -> DeclStandaloneDeriving sp (addStandaloneDerivingParens derivingDecl)
+    DeclDefault sp tys -> DeclDefault sp (map addTypeParens tys)
+    DeclForeign sp foreignDecl -> DeclForeign sp (addForeignDeclParens foreignDecl)
+    DeclSplice sp body -> DeclSplice sp (addDeclSpliceParens body)
+    DeclTypeFamilyDecl sp tf -> DeclTypeFamilyDecl sp (addTypeFamilyDeclParens tf)
+    DeclDataFamilyDecl sp df -> DeclDataFamilyDecl sp (addDataFamilyDeclParens df)
+    DeclTypeFamilyInst sp tfi -> DeclTypeFamilyInst sp (addTypeFamilyInstParens tfi)
+    DeclDataFamilyInst sp dfi -> DeclDataFamilyInst sp (addDataFamilyInstParens dfi)
+    DeclPragma {} -> decl
+
+addDeclSpliceParens :: Expr -> Expr
+addDeclSpliceParens body =
+  case body of
+    EVar {} -> addExprParens body
+    EParen {} -> addExprParens body
+    _ -> addExprParens body
+
+addValueDeclParens :: ValueDecl -> ValueDecl
+addValueDeclParens vdecl =
+  case vdecl of
+    PatternBind sp pat rhs -> PatternBind sp (addPatternParens pat) (addRhsParens rhs)
+    FunctionBind sp name matches -> FunctionBind sp name (map (addMatchParens name) matches)
+
+addMatchParens :: UnqualifiedName -> Match -> Match
+addMatchParens name match =
+  match
+    { matchPats = addFunctionHeadPats name (matchHeadForm match) (matchPats match),
+      matchRhs = addRhsParens (matchRhs match)
+    }
+
+addFunctionHeadPats :: UnqualifiedName -> MatchHeadForm -> [Pattern] -> [Pattern]
+addFunctionHeadPats _name headForm pats =
+  case headForm of
+    MatchHeadPrefix -> map addFunctionHeadPatternAtomParens pats
+    MatchHeadInfix ->
+      case pats of
+        lhs : rhs : tailPats ->
+          let lhs' = addInfixFunctionHeadPatternAtomParens lhs
+              rhs' = addInfixFunctionHeadPatternAtomParens rhs
+           in case tailPats of
+                [] -> [lhs', rhs']
+                _ ->
+                  -- When infix head has tail pats, the infix part is wrapped in parens
+                  -- and tail pats use function head atom rules
+                  lhs' : rhs' : map addFunctionHeadPatternAtomParens tailPats
+        _ -> map addFunctionHeadPatternAtomParens pats
+
+addRhsParens :: Rhs -> Rhs
+addRhsParens rhs =
+  case rhs of
+    UnguardedRhs sp body whereDecls ->
+      UnguardedRhs sp (addExprParens body) (fmap (map addDeclParens) whereDecls)
+    GuardedRhss sp guards whereDecls ->
+      GuardedRhss sp (map (addGuardedRhsParens GuardEquals) guards) (fmap (map addDeclParens) whereDecls)
+
+addGuardedRhsParens :: GuardArrow -> GuardedRhs -> GuardedRhs
+addGuardedRhsParens arrow grhs =
+  grhs
+    { guardedRhsGuards = map (addGuardQualifierParens arrow) (guardedRhsGuards grhs),
+      guardedRhsBody = addExprParens (guardedRhsBody grhs)
+    }
+
+addGuardQualifierParens :: GuardArrow -> GuardQualifier -> GuardQualifier
+addGuardQualifierParens arrow qual =
+  case qual of
+    GuardExpr sp expr -> GuardExpr sp (addGuardExprParens arrow expr)
+    GuardPat sp pat expr -> GuardPat sp (addPatternParens pat) (addGuardExprParens arrow expr)
+    GuardLet sp decls -> GuardLet sp (map addDeclParens decls)
+
+addGuardExprParens :: GuardArrow -> Expr -> Expr
+addGuardExprParens arrow expr =
+  wrapExpr (guardExprNeedsParens arrow expr) (addExprParens expr)
+
+addPatSynDeclParens :: PatSynDecl -> PatSynDecl
+addPatSynDeclParens ps =
+  ps
+    { patSynDeclPat = addPatternParens (patSynDeclPat ps),
+      patSynDeclDir = addPatSynDirParens (patSynDeclName ps) (patSynDeclDir ps)
+    }
+
+addPatSynDirParens :: UnqualifiedName -> PatSynDir -> PatSynDir
+addPatSynDirParens _ PatSynBidirectional = PatSynBidirectional
+addPatSynDirParens _ PatSynUnidirectional = PatSynUnidirectional
+addPatSynDirParens name (PatSynExplicitBidirectional matches) =
+  PatSynExplicitBidirectional (map (addMatchParens name) matches)
+
+addDataDeclParens :: DataDecl -> DataDecl
+addDataDeclParens decl =
+  decl
+    { dataDeclContext = map addTypeParens (dataDeclContext decl),
+      dataDeclKind = fmap addTypeParens (dataDeclKind decl),
+      dataDeclConstructors = map addDataConDeclParens (dataDeclConstructors decl),
+      dataDeclDeriving = map addDerivingClauseParens (dataDeclDeriving decl)
+    }
+
+addNewtypeDeclParens :: NewtypeDecl -> NewtypeDecl
+addNewtypeDeclParens decl =
+  decl
+    { newtypeDeclContext = map addTypeParens (newtypeDeclContext decl),
+      newtypeDeclKind = fmap addTypeParens (newtypeDeclKind decl),
+      newtypeDeclConstructor = fmap addDataConDeclParens (newtypeDeclConstructor decl),
+      newtypeDeclDeriving = map addDerivingClauseParens (newtypeDeclDeriving decl)
+    }
+
+addDerivingClauseParens :: DerivingClause -> DerivingClause
+addDerivingClauseParens dc =
+  dc
+    { derivingClasses = map addTypeParens (derivingClasses dc),
+      derivingViaType = fmap addTypeParens (derivingViaType dc)
+    }
+
+addDataConDeclParens :: DataConDecl -> DataConDecl
+addDataConDeclParens con =
+  case con of
+    PrefixCon sp forallVars constraints name fields ->
+      PrefixCon sp forallVars (map addTypeParens constraints) name (map addBangTypeParens fields)
+    InfixCon sp forallVars constraints lhs op rhs ->
+      InfixCon sp forallVars (map addTypeParens constraints) (addBangTypeAtomParens lhs) op (addBangTypeAtomParens rhs)
+    RecordCon sp forallVars constraints name fields ->
+      RecordCon sp forallVars (map addTypeParens constraints) name (map addRecordFieldDeclParens fields)
+    GadtCon sp forallBinders constraints names body ->
+      GadtCon sp forallBinders (map addTypeParens constraints) names (addGadtBodyParens body)
+
+addBangTypeParens :: BangType -> BangType
+addBangTypeParens bt =
+  bt
+    { bangType =
+        if bangStrict bt
+          then addTypeIn CtxTypeAtom (bangType bt)
+          else addTypeIn CtxTypeFunArg (bangType bt)
+    }
+
+addBangTypeAtomParens :: BangType -> BangType
+addBangTypeAtomParens bt =
+  let inner = addBangTypeParens bt
+   in inner
+        { bangType =
+            wrapTy (needsTypeParens CtxTypeFunArg (bangType bt)) (bangType inner)
+        }
+
+addRecordFieldDeclParens :: FieldDecl -> FieldDecl
+addRecordFieldDeclParens fd =
+  fd
+    { fieldType = addRecordFieldBangTypeParens (fieldType fd)
+    }
+
+addRecordFieldBangTypeParens :: BangType -> BangType
+addRecordFieldBangTypeParens bt =
+  bt
+    { bangType = addTypeParens (bangType bt)
+    }
+
+addGadtBodyParens :: GadtBody -> GadtBody
+addGadtBodyParens body =
+  case body of
+    GadtPrefixBody args resultTy ->
+      GadtPrefixBody (map addBangTypeParens args) (addTypeParens resultTy)
+    GadtRecordBody fields resultTy ->
+      GadtRecordBody (map addRecordFieldDeclParens fields) (addTypeParens resultTy)
+
+addClassDeclParens :: ClassDecl -> ClassDecl
+addClassDeclParens decl =
+  decl
+    { classDeclContext = fmap (map addTypeParens) (classDeclContext decl),
+      classDeclItems = map addClassItemParens (classDeclItems decl)
+    }
+
+addClassItemParens :: ClassDeclItem -> ClassDeclItem
+addClassItemParens item =
+  case item of
+    ClassItemTypeSig sp names ty -> ClassItemTypeSig sp names (addTypeParens ty)
+    ClassItemDefaultSig sp name ty -> ClassItemDefaultSig sp name (addTypeParens ty)
+    ClassItemFixity {} -> item
+    ClassItemDefault sp vdecl -> ClassItemDefault sp (addValueDeclParens vdecl)
+    ClassItemTypeFamilyDecl sp tf -> ClassItemTypeFamilyDecl sp (addTypeFamilyDeclParens tf)
+    ClassItemDataFamilyDecl sp df -> ClassItemDataFamilyDecl sp (addDataFamilyDeclParens df)
+    ClassItemDefaultTypeInst sp tfi -> ClassItemDefaultTypeInst sp (addTypeFamilyInstParens tfi)
+    ClassItemPragma {} -> item
+
+addInstanceDeclParens :: InstanceDecl -> InstanceDecl
+addInstanceDeclParens decl =
+  decl
+    { instanceDeclContext = map addTypeParens (instanceDeclContext decl),
+      instanceDeclTypes = map (addTypeIn CtxTypeAtom) (instanceDeclTypes decl),
+      instanceDeclItems = map addInstanceItemParens (instanceDeclItems decl)
+    }
+
+addInstanceItemParens :: InstanceDeclItem -> InstanceDeclItem
+addInstanceItemParens item =
+  case item of
+    InstanceItemBind sp vdecl -> InstanceItemBind sp (addValueDeclParens vdecl)
+    InstanceItemTypeSig sp names ty -> InstanceItemTypeSig sp names (addTypeParens ty)
+    InstanceItemFixity {} -> item
+    InstanceItemTypeFamilyInst sp tfi -> InstanceItemTypeFamilyInst sp (addTypeFamilyInstParens tfi)
+    InstanceItemDataFamilyInst sp dfi -> InstanceItemDataFamilyInst sp (addDataFamilyInstParens dfi)
+    InstanceItemPragma {} -> item
+
+addStandaloneDerivingParens :: StandaloneDerivingDecl -> StandaloneDerivingDecl
+addStandaloneDerivingParens decl =
+  decl
+    { standaloneDerivingViaType = fmap addTypeParens (standaloneDerivingViaType decl),
+      standaloneDerivingContext = map addTypeParens (standaloneDerivingContext decl),
+      standaloneDerivingTypes = map (addTypeIn CtxTypeAtom) (standaloneDerivingTypes decl)
+    }
+
+addForeignDeclParens :: ForeignDecl -> ForeignDecl
+addForeignDeclParens decl =
+  decl
+    { foreignType = addTypeParens (foreignType decl)
+    }
+
+addTypeFamilyDeclParens :: TypeFamilyDecl -> TypeFamilyDecl
+addTypeFamilyDeclParens tf =
+  tf
+    { typeFamilyDeclHead = addTypeParens (typeFamilyDeclHead tf),
+      typeFamilyDeclKind = fmap addTypeParens (typeFamilyDeclKind tf),
+      typeFamilyDeclEquations = fmap (map addTypeFamilyEqParens) (typeFamilyDeclEquations tf)
+    }
+
+addTypeFamilyEqParens :: TypeFamilyEq -> TypeFamilyEq
+addTypeFamilyEqParens eq =
+  eq
+    { typeFamilyEqLhs = addTypeParens (typeFamilyEqLhs eq),
+      typeFamilyEqRhs = addTypeParens (typeFamilyEqRhs eq)
+    }
+
+addDataFamilyDeclParens :: DataFamilyDecl -> DataFamilyDecl
+addDataFamilyDeclParens df =
+  df
+    { dataFamilyDeclKind = fmap addTypeParens (dataFamilyDeclKind df)
+    }
+
+addTypeFamilyInstParens :: TypeFamilyInst -> TypeFamilyInst
+addTypeFamilyInstParens tfi =
+  tfi
+    { typeFamilyInstLhs = addTypeParens (typeFamilyInstLhs tfi),
+      typeFamilyInstRhs = addTypeParens (typeFamilyInstRhs tfi)
+    }
+
+addDataFamilyInstParens :: DataFamilyInst -> DataFamilyInst
+addDataFamilyInstParens dfi =
+  dfi
+    { dataFamilyInstHead = addTypeParens (dataFamilyInstHead dfi),
+      dataFamilyInstConstructors = map addDataConDeclParens (dataFamilyInstConstructors dfi),
+      dataFamilyInstDeriving = map addDerivingClauseParens (dataFamilyInstDeriving dfi)
+    }
+
+-- ---------------------------------------------------------------------------
+-- Expressions
+-- ---------------------------------------------------------------------------
+
+-- | Add parentheses to an expression at all required positions.
+addExprParens :: Expr -> Expr
+addExprParens = addExprParensPrec 0
+
+addExprParensIn :: ExprCtx -> Expr -> Expr
+addExprParensIn ctx expr =
+  wrapExpr (needsExprParens ctx expr) (addExprParensPrec (exprCtxPrec ctx expr) expr)
+
+-- | Flatten a left-nested application chain.
+flattenApps :: Expr -> (Expr, [Expr])
+flattenApps = go []
+  where
+    go args (EApp _ fn arg) = go (arg : args) fn
+    go args root = (root, args)
+
+addExprParensPrec :: Int -> Expr -> Expr
+addExprParensPrec prec expr =
+  case expr of
+    EApp {} -> addAppsChainPrec prec expr
+    ETypeApp sp fn ty ->
+      wrapExpr (prec > 2) (ETypeApp sp (addExprParensIn CtxAppFun fn) (addTypeIn CtxTypeAtom ty))
+    EVar {} -> expr
+    EInt {} -> expr
+    EIntHash {} -> expr
+    EIntBase {} -> expr
+    EIntBaseHash {} -> expr
+    EFloat {} -> expr
+    EFloatHash {} -> expr
+    EChar {} -> expr
+    ECharHash {} -> expr
+    EString {} -> expr
+    EStringHash {} -> expr
+    EOverloadedLabel {} -> expr
+    EQuasiQuote {} -> expr
+    ETHExpQuote sp body -> ETHExpQuote sp (addExprParens body)
+    ETHTypedQuote sp body -> ETHTypedQuote sp (addExprParens body)
+    ETHDeclQuote sp decls -> ETHDeclQuote sp (map addDeclParens decls)
+    ETHTypeQuote sp ty -> ETHTypeQuote sp (addTypeParens ty)
+    ETHPatQuote sp pat -> ETHPatQuote sp (addPatternParens pat)
+    ETHNameQuote {} -> expr
+    ETHTypeNameQuote {} -> expr
+    ETHSplice sp body -> ETHSplice sp (addSpliceBodyParens body)
+    ETHTypedSplice sp body -> ETHTypedSplice sp (addSpliceBodyParens body)
+    EIf sp cond yes no ->
+      wrapExpr
+        (prec > 0)
+        (EIf sp (addExprParens cond) (addIfBranchParens yes) (addIfBranchParens no))
+    EMultiWayIf sp rhss ->
+      wrapExpr (prec > 0) (EMultiWayIf sp (map (addGuardedRhsParens GuardArrow) rhss))
+    ELambdaPats sp pats body ->
+      wrapExpr (prec > 0) (ELambdaPats sp (map addLambdaPatternAtomParens pats) (addExprParens body))
+    ELambdaCase sp alts ->
+      wrapExpr (prec > 0) (ELambdaCase sp (map addCaseAltParens alts))
+    EInfix sp lhs op rhs
+      | isArrowTailOp (renderName op) ->
+          -- Arrow tail operators always parenthesized, LHS also parenthesized
+          wrapExpr
+            True
+            ( EInfix
+                sp
+                (wrapExpr True (addExprParens lhs))
+                op
+                (addExprParens rhs)
+            )
+      | otherwise ->
+          wrapExpr
+            (prec > 1)
+            ( EInfix
+                sp
+                (addExprParensIn CtxInfixLhs lhs)
+                op
+                (addExprParensIn (CtxInfixRhs (prec == 1)) rhs)
+            )
+    ENegate sp inner ->
+      wrapExpr (prec > 2) (ENegate sp (addNegateParens inner))
+    ESectionL sp lhs op ->
+      -- Sections are always in parens (printed with parens in Pretty.hs)
+      -- The LHS needs special handling for greedy/typesig expressions
+      let lhs' =
+            if isGreedyExpr lhs || isTypeSig lhs
+              then wrapExpr True (addExprParens lhs)
+              else addExprParensPrec 1 lhs
+       in ESectionL sp lhs' op
+    ESectionR sp op rhs ->
+      ESectionR sp op (addExprParens rhs)
+    ELetDecls sp decls body ->
+      wrapExpr (prec > 0) (ELetDecls sp (map addDeclParens decls) (addExprParens body))
+    ECase sp scrutinee alts ->
+      wrapExpr (prec > 0) (ECase sp (addExprParens scrutinee) (map addCaseAltParens alts))
+    EDo sp stmts isMdo ->
+      wrapExpr (prec > 0) (EDo sp (map addDoStmtParens stmts) isMdo)
+    EListComp sp body quals ->
+      EListComp sp (addExprParens body) (map addCompStmtParens quals)
+    EListCompParallel sp body qualifierGroups ->
+      EListCompParallel sp (addExprParens body) (map (map addCompStmtParens) qualifierGroups)
+    EArithSeq sp seqInfo -> EArithSeq sp (addArithSeqParens seqInfo)
+    ERecordCon sp name fields hasWildcard ->
+      ERecordCon sp name [(n, addExprParens e) | (n, e) <- fields] hasWildcard
+    ERecordUpd sp base fields ->
+      ERecordUpd sp (addExprParensPrec 3 base) [(n, addExprParens e) | (n, e) <- fields]
+    ETypeSig sp inner ty ->
+      wrapExpr (prec > 1) (ETypeSig sp (addExprParensIn CtxTypeSigBody inner) (addTypeParens ty))
+    EParen sp inner ->
+      case inner of
+        -- Sections are already "in parens" via their EParen wrapper,
+        -- don't add double parens
+        ESectionL {} -> EParen sp (addExprParens inner)
+        ESectionR {} -> EParen sp (addExprParens inner)
+        _ -> EParen sp (addExprParens inner)
+    EList sp values -> EList sp (map addExprParens values)
+    ETuple sp tupleFlavor values -> ETuple sp tupleFlavor (map (fmap addExprParens) values)
+    EUnboxedSum sp altIdx arity inner -> EUnboxedSum sp altIdx arity (addExprParens inner)
+    EProc sp pat body ->
+      wrapExpr (prec > 0) (EProc sp (addPatternParens pat) (addCmdParens body))
+    EAnn ann sub -> EAnn ann (addExprParensPrec prec sub)
+  where
+    isTypeSig :: Expr -> Bool
+    isTypeSig (ETypeSig {}) = True
+    isTypeSig _ = False
+
+-- | Handle application chains, preserving original EApp spans.
+addAppsChainPrec :: Int -> Expr -> Expr
+addAppsChainPrec prec expr =
+  let (root, args) = flattenApps expr
+      -- Get the spans from the original EApp chain
+      appSpans = getAppSpans expr
+      root' = addExprParensIn CtxAppFun root
+      nArgs = length args
+      args' =
+        [ let isLast = i == nArgs - 1
+              ctx
+                | isLast, isBlockExpr a = CtxAppArgNoParens
+                | isLast = CtxAppArg
+                | otherwise = CtxAppArg
+           in addExprParensIn ctx a
+        | (i, a) <- Prelude.zip [0 :: Int ..] args
+        ]
+      -- Reconstruct the EApp chain with original spans
+      rebuilt = case Prelude.zip appSpans args' of
+        [] -> root'
+        pairs -> foldl (\fn (sp, arg) -> EApp sp fn arg) root' pairs
+   in wrapExpr (prec > 2) rebuilt
+
+getAppSpans :: Expr -> [SourceSpan]
+getAppSpans = reverse . go
+  where
+    go (EApp sp fn _) = sp : go fn
+    go _ = []
+
+addSpliceBodyParens :: Expr -> Expr
+addSpliceBodyParens body =
+  case body of
+    EParen sp inner -> EParen sp (addExprParens inner)
+    EVar {} -> body
+    _ -> addExprParens body
+
+addNegateParens :: Expr -> Expr
+addNegateParens inner =
+  if startsWithDollar inner || startsWithOverloadedLabel inner
+    then wrapExpr True (addExprParens inner)
+    else addExprParensPrec 3 inner
+
+addIfBranchParens :: Expr -> Expr
+addIfBranchParens expr =
+  if endsWithTypeSig expr
+    then wrapExpr True (addExprParens expr)
+    else addExprParens expr
+
+addCaseAltParens :: CaseAlt -> CaseAlt
+addCaseAltParens (CaseAlt sp pat rhs) =
+  CaseAlt sp (addPatternParens pat) (addCaseAltRhsParens rhs)
+
+addCaseAltRhsParens :: Rhs -> Rhs
+addCaseAltRhsParens rhs =
+  case rhs of
+    UnguardedRhs sp body whereDecls ->
+      UnguardedRhs sp (addExprParens body) (fmap (map addDeclParens) whereDecls)
+    GuardedRhss sp guards whereDecls ->
+      GuardedRhss sp (map (addGuardedRhsParens GuardArrow) guards) (fmap (map addDeclParens) whereDecls)
+
+addDoStmtParens :: DoStmt Expr -> DoStmt Expr
+addDoStmtParens stmt =
+  case stmt of
+    DoBind sp pat e -> DoBind sp (addPatternParens pat) (addExprParens e)
+    DoLetDecls sp decls -> DoLetDecls sp (map addDeclParens decls)
+    DoExpr sp e -> DoExpr sp (addExprParens e)
+    DoRecStmt sp stmts -> DoRecStmt sp (map addDoStmtParens stmts)
+
+addCompStmtParens :: CompStmt -> CompStmt
+addCompStmtParens stmt =
+  case stmt of
+    CompGen sp pat e -> CompGen sp (addPatternParens pat) (addExprParens e)
+    CompGuard sp e -> CompGuard sp (addExprParens e)
+    CompLet sp bindings -> CompLet sp [(n, addExprParens e) | (n, e) <- bindings]
+    CompLetDecls sp decls -> CompLetDecls sp (map addDeclParens decls)
+
+addArithSeqParens :: ArithSeq -> ArithSeq
+addArithSeqParens seqInfo =
+  case seqInfo of
+    ArithSeqFrom sp fromE -> ArithSeqFrom sp (addExprGuardedParens fromE)
+    ArithSeqFromThen sp fromE thenE -> ArithSeqFromThen sp (addExprGuardedParens fromE) (addExprGuardedParens thenE)
+    ArithSeqFromTo sp fromE toE -> ArithSeqFromTo sp (addExprGuardedParens fromE) (addExprParens toE)
+    ArithSeqFromThenTo sp fromE thenE toE -> ArithSeqFromThenTo sp (addExprGuardedParens fromE) (addExprGuardedParens thenE) (addExprParens toE)
+
+addExprGuardedParens :: Expr -> Expr
+addExprGuardedParens = addExprParensIn CtxGuarded
+
+-- ---------------------------------------------------------------------------
+-- Types
+-- ---------------------------------------------------------------------------
+
+-- | Add parentheses to a type at all required positions.
+addTypeParens :: Type -> Type
+addTypeParens = addTypeParensShared CtxTypeAtom 0
+
+addTypeIn :: TypeCtx -> Type -> Type
+addTypeIn ctx ty =
+  wrapTy (needsTypeParens ctx ty) (addTypeParensShared ctx 0 ty)
+
+addTypeParensShared :: TypeCtx -> Int -> Type -> Type
+addTypeParensShared ctx prec ty =
+  let atom = addTypeParensShared CtxTypeAtom
+   in case ty of
+        TAnn sp sub -> TAnn sp (addTypeParensShared ctx prec sub)
+        TVar {} -> ty
+        TCon sp name promoted
+          | isSymbolicName name, promoted /= Promoted -> TCon sp name promoted
+          | otherwise -> TCon sp name promoted
+        TImplicitParam sp name inner -> TImplicitParam sp name (addTypeParens inner)
+        TTypeLit {} -> ty
+        TStar {} -> ty
+        TQuasiQuote {} -> ty
+        TForall sp binders inner ->
+          wrapTy (prec > 0) (TForall sp (map addTyVarBinderParens binders) (atom 0 inner))
+        TApp _ (TApp _ op@(TCon _ opName _) lhs) rhs
+          | isSymbolicName opName,
+            renderName opName /= "->" ->
+              -- Infix type operator: args are treated as atoms
+              TApp (appSpan ty) (TApp (innerAppSpan ty) op (atom 0 lhs)) (atom 0 rhs)
+        TApp sp f x ->
+          wrapTy (prec > 2) (TApp sp (addTypeIn CtxTypeFunArg f) (addTypeIn CtxTypeAppArg x))
+        TFun sp a b ->
+          wrapTy (prec > 0) (TFun sp (addTypeIn CtxTypeFunArg a) (atom 0 b))
+        TTuple sp tupleFlavor promoted elems ->
+          TTuple sp tupleFlavor promoted (map (atom 0) elems)
+        TUnboxedSum sp elems -> TUnboxedSum sp (map (atom 0) elems)
+        TList sp promoted elems -> TList sp promoted (map (atom 0) elems)
+        TParen sp inner -> TParen sp (atom 0 inner)
+        TKindSig sp ty' kind ->
+          case ctx of
+            CtxKindSig -> TKindSig sp (atom 0 ty') (atom 0 kind)
+            _ -> wrapTy True (TKindSig sp (atom 0 ty') (atom 0 kind))
+        TContext sp constraints inner ->
+          wrapTy (prec > 0) (TContext sp (map addTypeParens constraints) (atom 0 inner))
+        TSplice sp body -> TSplice sp (addSpliceBodyParens body)
+        TWildcard {} -> ty
+  where
+    appSpan :: Type -> SourceSpan
+    appSpan (TApp sp _ _) = sp
+    appSpan _ = noSourceSpan
+
+    innerAppSpan :: Type -> SourceSpan
+    innerAppSpan (TApp _ inner _) = appSpan inner
+    innerAppSpan _ = noSourceSpan
+
+addTyVarBinderParens :: TyVarBinder -> TyVarBinder
+addTyVarBinderParens tvb =
+  tvb {tyVarBinderKind = fmap addTypeParens (tyVarBinderKind tvb)}
+
+-- ---------------------------------------------------------------------------
+-- Patterns
+-- ---------------------------------------------------------------------------
+
+-- | Add parentheses to a pattern at all required positions.
+addPatternParens :: Pattern -> Pattern
+addPatternParens pat =
+  case pat of
+    PAnn sp sub -> PAnn sp (addPatternParens sub)
+    PVar {} -> pat
+    PWildcard {} -> pat
+    PLit sp lit -> PLit sp lit
+    PQuasiQuote {} -> pat
+    PTuple sp tupleFlavor elems -> PTuple sp tupleFlavor (map addPatternInDelimited elems)
+    PUnboxedSum sp altIdx arity inner -> PUnboxedSum sp altIdx arity (addPatternInDelimited inner)
+    PList sp elems -> PList sp (map addPatternInDelimited elems)
+    PCon sp con args -> PCon sp con (map addPatternAtomParens args)
+    PInfix sp lhs op rhs -> PInfix sp (addPatternAtomParens lhs) op (addPatternAtomParens rhs)
+    PView sp viewExpr inner ->
+      PView sp (addViewExprParens viewExpr) (addPatternParens inner)
+    PAs sp name inner -> PAs sp name (addPatternAtomStrictParens inner)
+    PStrict sp inner -> PStrict sp (addPatternAtomStrictParens inner)
+    PIrrefutable sp inner -> PIrrefutable sp (addPatternAtomStrictParens inner)
+    PNegLit sp lit -> PNegLit sp lit
+    PParen sp inner -> PParen sp (addPatternParens inner)
+    PRecord sp con fields hasWildcard ->
+      PRecord sp con [(fieldName, addPatternParens fieldPat) | (fieldName, fieldPat) <- fields] hasWildcard
+    PTypeSig sp inner ty -> PTypeSig sp (addPatternParens inner) (addTypeParens ty)
+    PSplice sp body -> PSplice sp (addSpliceBodyParens body)
+
+-- | Add parens for a pattern inside a delimited context (tuples, lists, etc.).
+-- View patterns don't need extra parens there.
+addPatternInDelimited :: Pattern -> Pattern
+addPatternInDelimited pat =
+  case pat of
+    PView sp viewExpr inner -> PView sp (addViewExprParens viewExpr) (addPatternParens inner)
+    PAs sp name inner -> PAs sp name (addPatternAtomStrictParens inner)
+    PStrict sp inner -> PStrict sp (addPatternAtomStrictParens inner)
+    PIrrefutable sp inner -> PIrrefutable sp (addPatternAtomStrictParens inner)
+    _ -> addPatternParens pat
+
+addViewExprParens :: Expr -> Expr
+addViewExprParens expr =
+  if endsWithTypeSig expr
+    then wrapExpr True (addExprParens expr)
+    else addExprParens expr
+
+addPatternAtomParens :: Pattern -> Pattern
+addPatternAtomParens pat =
+  case pat of
+    PVar {} -> addPatternParens pat
+    PWildcard {} -> addPatternParens pat
+    PLit {} -> addPatternParens pat
+    PQuasiQuote {} -> addPatternParens pat
+    PNegLit {} -> addPatternParens pat
+    PList {} -> addPatternParens pat
+    PTuple {} -> addPatternParens pat
+    PUnboxedSum {} -> addPatternParens pat
+    PParen {} -> addPatternParens pat
+    PStrict {} -> addPatternParens pat
+    PIrrefutable {} -> addPatternParens pat
+    PView {} -> addPatternParens pat
+    PAs {} -> addPatternParens pat
+    PSplice {} -> addPatternParens pat
+    PCon _ _ [] -> addPatternParens pat
+    _ -> wrapPat True (addPatternParens pat)
+
+-- | Add parens for a pattern in lambda argument position.
+addLambdaPatternAtomParens :: Pattern -> Pattern
+addLambdaPatternAtomParens pat =
+  case pat of
+    PNegLit {} -> wrapPat True (addPatternParens pat)
+    PCon _ _ [] -> wrapPat True (addPatternParens pat)
+    _ -> addPatternAtomParens pat
+
+-- | Add parens for a pattern in function-head argument position.
+addFunctionHeadPatternAtomParens :: Pattern -> Pattern
+addFunctionHeadPatternAtomParens pat =
+  case pat of
+    PNegLit {} -> wrapPat True (addPatternParens pat)
+    PCon _ _ (_ : _) -> wrapPat True (addPatternParens pat)
+    PRecord {} -> addPatternParens pat
+    _ -> addPatternAtomParens pat
+
+-- | Add parens for infix function-head operands.
+addInfixFunctionHeadPatternAtomParens :: Pattern -> Pattern
+addInfixFunctionHeadPatternAtomParens pat =
+  case pat of
+    PNegLit {} -> wrapPat True (addPatternParens pat)
+    _ -> addPatternParens pat
+
+-- | Add parens for the inner pattern of @, !, ~.
+addPatternAtomStrictParens :: Pattern -> Pattern
+addPatternAtomStrictParens pat =
+  case pat of
+    PNegLit {} -> wrapPat True (addPatternParens pat)
+    PCon _ _ [] -> wrapPat True (addPatternParens pat)
+    PStrict {} -> wrapPat True (addPatternParens pat)
+    PIrrefutable {} -> wrapPat True (addPatternParens pat)
+    PRecord {} -> addPatternParens pat
+    _ -> addPatternAtomParens pat
+
+-- ---------------------------------------------------------------------------
+-- Arrow commands
+-- ---------------------------------------------------------------------------
+
+addCmdParens :: Cmd -> Cmd
+addCmdParens cmd =
+  case cmd of
+    CmdArrApp sp lhs appTy rhs ->
+      CmdArrApp sp (addExprParensPrec 1 lhs) appTy (addExprParens rhs)
+    CmdInfix sp l op r ->
+      CmdInfix sp (addCmdParens l) op (addCmdParens r)
+    CmdDo sp stmts ->
+      CmdDo sp (map addCmdDoStmtParens stmts)
+    CmdIf sp cond yes no ->
+      CmdIf sp (addExprParens cond) (addCmdParens yes) (addCmdParens no)
+    CmdCase sp scrut alts ->
+      CmdCase sp (addExprParens scrut) (map addCmdCaseAltParens alts)
+    CmdLet sp decls body ->
+      CmdLet sp (map addDeclParens decls) (addCmdParens body)
+    CmdLam sp pats body ->
+      CmdLam sp (map addPatternAtomParens pats) (addCmdParens body)
+    CmdApp sp c e ->
+      CmdApp sp (addCmdParens c) (addExprParensPrec 3 e)
+    CmdPar sp c ->
+      CmdPar sp (addCmdParens c)
+
+addCmdDoStmtParens :: DoStmt Cmd -> DoStmt Cmd
+addCmdDoStmtParens stmt =
+  case stmt of
+    DoBind sp pat cmd' -> DoBind sp (addPatternParens pat) (addCmdParens cmd')
+    DoLetDecls sp decls -> DoLetDecls sp (map addDeclParens decls)
+    DoExpr sp cmd' -> DoExpr sp (addCmdParens cmd')
+    DoRecStmt sp stmts -> DoRecStmt sp (map addCmdDoStmtParens stmts)
+
+addCmdCaseAltParens :: CmdCaseAlt -> CmdCaseAlt
+addCmdCaseAltParens alt =
+  alt
+    { cmdCaseAltPat = addPatternParens (cmdCaseAltPat alt),
+      cmdCaseAltBody = addCmdParens (cmdCaseAltBody alt)
+    }

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -804,15 +804,15 @@ addTypeParensShared ctx prec ty =
           TTuple sp tupleFlavor promoted (map (atom 0) elems)
         TUnboxedSum sp elems -> TUnboxedSum sp (map (atom 0) elems)
         TList sp promoted elems -> TList sp promoted (map (atom 0) elems)
-        -- Inside an explicit TParen, the delimiter is already present, so we
-        -- process the inner type at prec 0 without adding extra wrapping.
-        -- Using CtxKindSig prevents double-wrapping TKindSig (which the
-        -- outer TParen already handles).
+        -- Inside an explicit TParen, TKindSig does not need an additional
+        -- TParen wrapper since the enclosing delimiter already provides it.
         TParen sp inner -> TParen sp (addTypeParensInner inner)
+        -- TKindSig always needs parens in most contexts. The parser absorbs
+        -- (ty :: kind) as TKindSig directly, so the TParen is not preserved
+        -- through roundtrips. The pretty-printer relies on the TParen wrapper
+        -- to produce the required parentheses.
         TKindSig sp ty' kind ->
-          case ctx of
-            CtxKindSig -> TKindSig sp (atom 0 ty') (atom 0 kind)
-            _ -> wrapTy True (TKindSig sp (atom 0 ty') (atom 0 kind))
+          wrapTy True (TKindSig sp (atom 0 ty') (atom 0 kind))
         TContext sp constraints inner ->
           wrapTy (prec > 0) (TContext sp (addContextConstraints constraints) (atom 0 inner))
         TSplice sp body -> TSplice sp (addSpliceBodyParens body)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -148,11 +148,13 @@ prettyImportLevel level =
     ImportLevelQuote -> "quote"
     ImportLevelSplice -> "splice"
 
-prettyDeclSplice :: Expr -> Doc ann
-prettyDeclSplice body =
+-- | Pretty-print a top-level declaration splice.
+-- EVar and EParen get a @$@ prefix; other expressions are bare.
+prettyDeclSpliceExpr :: Expr -> Doc ann
+prettyDeclSpliceExpr body =
   case body of
-    EVar {} -> prettySplice "$" body
-    EParen {} -> prettySplice "$" body
+    EVar {} -> "$" <> prettyExpr body
+    EParen {} -> "$" <> prettyExpr body
     _ -> prettyExpr body
 
 prettyQuotedText :: Text -> Doc ann
@@ -237,7 +239,7 @@ prettyDeclLines decl =
     DeclStandaloneDeriving _ derivingDecl -> [prettyStandaloneDeriving derivingDecl]
     DeclDefault _ tys -> ["default" <+> parens (hsep (punctuate comma (map prettyType tys)))]
     DeclForeign _ foreignDecl -> [prettyForeignDecl foreignDecl]
-    DeclSplice _ body -> [prettyDeclSplice body]
+    DeclSplice _ body -> [prettyDeclSpliceExpr body]
     DeclTypeFamilyDecl _ tf -> [prettyTypeFamilyDecl tf]
     DeclDataFamilyDecl _ df -> [prettyDataFamilyDecl df]
     DeclTypeFamilyInst _ tfi -> [prettyTopTypeFamilyInst tfi]
@@ -405,7 +407,7 @@ prettyType ty =
       prettyType ty' <+> "::" <+> prettyType kind
     TContext _ constraints inner ->
       prettyContext constraints <+> "=>" <+> prettyType inner
-    TSplice _ body -> prettySplice "$" body
+    TSplice _ body -> "$" <> prettyExpr body
     TWildcard _ -> "_"
 
 prettyContext :: [Type] -> Doc ann
@@ -457,7 +459,7 @@ prettyPattern pat =
               )
           )
     PTypeSig _ inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
-    PSplice _ body -> prettySplice "$" body
+    PSplice _ body -> "$" <> prettyExpr body
 
 -- | Pretty print a pattern field binding.
 prettyPatternFieldBinding :: Name -> Pattern -> Doc ann
@@ -980,8 +982,8 @@ prettyExpr expr =
     ETHTypeNameQuote _ name
       | isOperatorToken name -> "''" <> parens (pretty name)
       | otherwise -> "''" <> pretty name
-    ETHSplice _ body -> prettySplice "$" body
-    ETHTypedSplice _ body -> prettySplice "$$" body
+    ETHSplice _ body -> "$" <> prettyExpr body
+    ETHTypedSplice _ body -> "$$" <> prettyExpr body
     EIf _ cond yes no ->
       "if" <+> prettyExpr cond <+> "then" <+> prettyExpr yes <+> "else" <+> prettyExpr no
     EMultiWayIf _ rhss ->
@@ -1204,14 +1206,6 @@ isUnicodeSymbolCategory c = case generalCategory c of
   OtherSymbol -> True
   OtherPunctuation -> not (isAscii c)
   _ -> False
-
--- | Pretty-print a TH splice with the given prefix ("$" or "$$").
-prettySplice :: Doc ann -> Expr -> Doc ann
-prettySplice prefix body =
-  case body of
-    EParen _ inner -> prefix <> parens (prettyExpr inner)
-    EVar {} -> prefix <> prettyExpr body
-    _ -> prefix <> parens (prettyExpr body)
 
 -- ---------------------------------------------------------------------------
 -- TypeFamilies pretty-printing helpers

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -12,6 +12,12 @@
 -- The 'Pretty' instances from 'Prettyprinter' are provided for the main
 -- AST types, allowing direct use of 'pretty' from @Prettyprinter@.
 --
+-- __Parenthesization__ is handled by the 'Aihc.Parser.Parens' module, which
+-- inserts 'EParen', 'PParen', 'TParen', and 'CmdPar' nodes at all required
+-- positions. The Pretty instances call the paren-insertion pass before
+-- formatting, so the formatting code here does not need to worry about
+-- operator precedence or context-sensitive parenthesization.
+--
 -- This module has an empty export list because it only provides typeclass
 -- instances. Import it to bring the 'Pretty' instances into scope.
 --
@@ -21,6 +27,7 @@ module Aihc.Parser.Pretty
   )
 where
 
+import Aihc.Parser.Parens (addDeclParens, addExprParens, addModuleParens, addPatternParens, addTypeParens)
 import Aihc.Parser.Syntax
 import Data.Char (GeneralCategory (..), generalCategory, isAscii)
 import Data.Maybe (catMaybes, isJust)
@@ -43,23 +50,23 @@ import Prettyprinter
 
 -- | Pretty instance for Module - renders to valid Haskell source code.
 instance Pretty Module where
-  pretty = prettyModuleDoc
+  pretty = prettyModuleDoc . addModuleParens
 
 -- | Pretty instance for Expr - renders to valid Haskell source code.
 instance Pretty Expr where
-  pretty = prettyExprPrec 0
+  pretty = prettyExpr . addExprParens
 
 -- | Pretty instance for Pattern - renders to valid Haskell source code.
 instance Pretty Pattern where
-  pretty = prettyPattern
+  pretty = prettyPattern . addPatternParens
 
 -- | Pretty instance for Decl - renders to valid Haskell source code.
 instance Pretty Decl where
-  pretty decl = vsep (prettyDeclLines decl)
+  pretty decl = vsep (prettyDeclLines (addDeclParens decl))
 
 -- | Pretty instance for Type - renders to valid Haskell source code.
 instance Pretty Type where
-  pretty = prettyType
+  pretty = prettyType . addTypeParens
 
 instance Pretty Name where
   pretty = pretty . renderName
@@ -146,7 +153,7 @@ prettyDeclSplice body =
   case body of
     EVar {} -> prettySplice "$" body
     EParen {} -> prettySplice "$" body
-    _ -> prettyExprPrec 0 body
+    _ -> prettyExpr body
 
 prettyQuotedText :: Text -> Doc ann
 prettyQuotedText txt = "\"" <> pretty txt <> "\""
@@ -263,8 +270,6 @@ prettyValueDeclLines valueDecl =
       concatMap (prettyFunctionMatchLines name) matches
 
 -- | Pretty-print a value declaration on a single line.
--- For function binds with multiple matches, each match becomes a semicolon-separated item.
--- For function binds with guards, the guards are space-separated.
 prettyValueDeclSingleLine :: ValueDecl -> Doc ann
 prettyValueDeclSingleLine valueDecl =
   case valueDecl of
@@ -287,7 +292,6 @@ prettyPatSynDecl ps =
     dirArrow PatSynUnidirectional = "<-"
     dirArrow (PatSynExplicitBidirectional _) = "<-"
 
--- | Pretty-print the LHS of a pattern synonym declaration (after @pattern@).
 prettyPatSynLhs :: UnqualifiedName -> PatSynArgs -> [Doc ann]
 prettyPatSynLhs name args =
   case args of
@@ -298,7 +302,6 @@ prettyPatSynLhs name args =
     PatSynRecordArgs fields ->
       [prettyConstructorUName name <+> braces (hsep (punctuate comma (map pretty fields)))]
 
--- | Pretty-print the where clause of an explicitly bidirectional pattern synonym.
 prettyPatSynWhere :: UnqualifiedName -> PatSynDir -> [Doc ann]
 prettyPatSynWhere _ PatSynBidirectional = []
 prettyPatSynWhere _ PatSynUnidirectional = []
@@ -312,9 +315,9 @@ prettyFunctionMatchLines name match =
     GuardedRhss _ grhss mWhereDecls ->
       prettyFunctionHead name (matchHeadForm match) (matchPats match)
         : [ "  |"
-              <+> hsep (punctuate comma (map (prettyGuardQualifier GuardEquals) (guardedRhsGuards grhs)))
+              <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
               <+> "="
-              <+> prettyExprPrec 0 (guardedRhsBody grhs)
+              <+> prettyExpr (guardedRhsBody grhs)
           | grhs <- grhss
           ]
           <> [prettyWhereClause mWhereDecls | isJust mWhereDecls]
@@ -327,35 +330,30 @@ prettyFunctionHead :: UnqualifiedName -> MatchHeadForm -> [Pattern] -> Doc ann
 prettyFunctionHead name headForm pats =
   case headForm of
     MatchHeadPrefix ->
-      hsep (prettyBinderUName name : map prettyFunctionHeadPatternAtom pats)
+      hsep (prettyBinderUName name : map prettyPattern pats)
     MatchHeadInfix ->
       case pats of
         lhs : rhsPat : tailPats ->
-          let infixHead = prettyInfixFunctionHeadPatternAtom lhs <+> prettyInfixOp (renderUnqualifiedName name) <+> prettyInfixFunctionHeadPatternAtom rhsPat
+          let infixHead = prettyPattern lhs <+> prettyInfixOp (renderUnqualifiedName name) <+> prettyPattern rhsPat
            in case tailPats of
                 [] -> infixHead
-                _ -> hsep (parens infixHead : map prettyFunctionHeadPatternAtom tailPats)
+                _ -> hsep (parens infixHead : map prettyPattern tailPats)
         _ ->
-          hsep (prettyBinderUName name : map prettyFunctionHeadPatternAtom pats)
+          hsep (prettyBinderUName name : map prettyPattern pats)
 
 prettyRhs :: Rhs -> Doc ann
 prettyRhs rhs =
   case rhs of
-    -- For UnguardedRhs, nothing follows the expression, so no parens needed
     UnguardedRhs _ expr whereDecls ->
       "="
-        <+> prettyExprPrec 0 expr
+        <+> prettyExpr expr
         <> prettyWhereClause whereDecls
-    -- For GuardedRhss, multiple guards can follow, but brace-terminated
-    -- expressions (do, case, \case) are safe. Open-ended expressions
-    -- (if, lambda, let, where) could capture trailing guards with layout,
-    -- but our pretty-printer doesn't use layout for guards.
     GuardedRhss _ guards whereDecls ->
       hsep
         [ "|"
-            <+> hsep (punctuate comma (map (prettyGuardQualifier GuardEquals) (guardedRhsGuards grhs)))
+            <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
             <+> "="
-            <+> prettyExprPrec 0 (guardedRhsBody grhs)
+            <+> prettyExpr (guardedRhsBody grhs)
         | grhs <- guards
         ]
         <> prettyWhereClause whereDecls
@@ -365,145 +363,56 @@ prettyWhereClause Nothing = mempty
 prettyWhereClause (Just []) = " where" <+> braces mempty
 prettyWhereClause (Just decls) = " where" <+> braces (prettyInlineDecls decls)
 
+-- | Pretty-print a type. The AST is assumed to already have TParen nodes
+-- in the correct positions (inserted by 'addTypeParens').
 prettyType :: Type -> Doc ann
-prettyType = prettyTypePrec 0
-
--- | Type context for parenthesization decisions.
--- CtxTypeFunArg: LHS of -> or function position of type application (same rules).
--- CtxTypeAppArg: argument position of type application.
--- CtxTypeAtom: must be syntactically atomic (e.g., context args, instance heads).
--- CtxKindSig: kind-annotation type inside a context item (TKindSig omits its parens).
-data TypeCtx
-  = CtxTypeFunArg
-  | CtxTypeAppArg
-  | CtxTypeAtom
-  | CtxKindSig
-
-needsTypeParens :: TypeCtx -> Type -> Bool
-needsTypeParens ctx ty =
-  case ctx of
-    CtxTypeFunArg ->
-      case ty of
-        TForall {} -> True
-        TFun {} -> True
-        TContext {} -> True
-        _ -> False
-    CtxTypeAppArg ->
-      case ty of
-        TQuasiQuote {} -> False
-        TApp {} -> True
-        TForall {} -> True
-        TFun {} -> True
-        TContext {} -> True
-        _ -> False
-    CtxTypeAtom ->
-      case ty of
-        TVar {} -> False
-        TCon {} -> False
-        TImplicitParam {} -> False
-        TTypeLit {} -> False
-        TStar {} -> False
-        TQuasiQuote {} -> False
-        TList {} -> False
-        TTuple {} -> False
-        TUnboxedSum {} -> False
-        TParen {} -> False
-        TKindSig {} -> False
-        TWildcard {} -> False
-        _ -> True
-    CtxKindSig ->
-      case ty of
-        TKindSig {} -> False
-        _ -> True
-
--- | Shared type pretty-printer parameterized by context.
--- CtxTypeAtom is equivalent to the original 'prettyTypePrec'.
--- CtxKindSig omits parens around TKindSig (used for kind annotations in context items).
-prettyTypeShared :: TypeCtx -> Int -> Type -> Doc ann
-prettyTypeShared ctx prec ty =
-  let atom = prettyTypeShared CtxTypeAtom
-   in case ty of
-        TAnn _ sub -> prettyTypeShared ctx prec sub
-        TVar _ name -> pretty name
-        TCon _ name promoted ->
-          let rendered = renderName name
-              base
-                | isSymbolicTypeName name = parens (pretty rendered)
-                | otherwise = pretty rendered
-           in if promoted == Promoted then "'" <> base else base
-        TImplicitParam _ name inner -> pretty name <+> "::" <+> prettyTypePrec 0 inner
-        TTypeLit _ lit -> prettyTypeLiteral lit
-        TStar _ -> "*"
-        TQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
-        TForall _ binders inner ->
-          parenthesize (prec > 0) ("forall" <+> hsep (map prettyTyVarBinder binders) <> "." <+> atom 0 inner)
-        TApp _ (TApp _ (TCon _ op promoted) lhs) rhs
-          | isSymbolicTypeName op && renderName op /= "->" ->
-              atom 0 lhs
-                <+> (if promoted == Promoted then "'" else mempty)
-                <> prettyNameInfixOp op
-                <+> atom 0 rhs
-        TApp _ f x ->
-          parenthesize (prec > 2) (prettyTypeIn CtxTypeFunArg f <+> prettyTypeIn CtxTypeAppArg x)
-        TFun _ a b ->
-          parenthesize (prec > 0) (prettyTypeIn CtxTypeFunArg a <+> "->" <+> atom 0 b)
-        TTuple _ tupleFlavor promoted elems ->
-          let tupleDoc = prettyTupleBody tupleFlavor (hsep (punctuate comma (map (atom 0) elems)))
-           in if promoted == Promoted then "'" <> tupleDoc else tupleDoc
-        TUnboxedSum _ elems ->
-          hsep ["(#", hsep (punctuate " |" (map (atom 0) elems)), "#)"]
-        TList _ promoted elems ->
-          let listDoc = brackets (hsep (punctuate comma (map (atom 0) elems)))
-           in if promoted == Promoted then "'" <> listDoc else listDoc
-        TParen _ inner -> parens (atom 0 inner)
-        TKindSig _ ty' kind ->
-          let doc = atom 0 ty' <+> "::" <+> atom 0 kind
-           in case ctx of
-                CtxKindSig -> doc
-                _ -> parens doc
-        TContext _ constraints inner ->
-          parenthesize (prec > 0) (prettyContext constraints <+> "=>" <+> atom 0 inner)
-        TSplice _ body -> prettySplice "$" body
-        TWildcard _ -> "_"
-
-prettyTypePrec :: Int -> Type -> Doc ann
-prettyTypePrec = prettyTypeShared CtxTypeAtom
-
-prettyTypeIn :: TypeCtx -> Type -> Doc ann
-prettyTypeIn ctx ty =
-  parenthesize (needsTypeParens ctx ty) (prettyTypeShared ctx 0 ty)
-
--- | Print a type as it appears in a context kind-annotation position.
--- Omits parens around TKindSig; the enclosing 'TParen' or
--- 'prettyConstraintTypeParens' provides them.
-prettyConstraintType :: Type -> Doc ann
-prettyConstraintType = prettyTypeShared CtxKindSig 0
-
--- | Like 'prettyConstraintType' but always wraps the result in parens.
--- Used for kind signatures that need parens in context position.
-prettyConstraintTypeParens :: Type -> Doc ann
-prettyConstraintTypeParens ty = parens (prettyTypeShared CtxKindSig 0 ty)
+prettyType ty =
+  case ty of
+    TAnn _ sub -> prettyType sub
+    TVar _ name -> pretty name
+    TCon _ name promoted ->
+      let rendered = renderName name
+          base
+            | isSymbolicTypeName name = parens (pretty rendered)
+            | otherwise = pretty rendered
+       in if promoted == Promoted then "'" <> base else base
+    TImplicitParam _ name inner -> pretty name <+> "::" <+> prettyType inner
+    TTypeLit _ lit -> prettyTypeLiteral lit
+    TStar _ -> "*"
+    TQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
+    TForall _ binders inner ->
+      "forall" <+> hsep (map prettyTyVarBinder binders) <> "." <+> prettyType inner
+    TApp _ (TApp _ (TCon _ op promoted) lhs) rhs
+      | isSymbolicTypeName op && renderName op /= "->" ->
+          prettyType lhs
+            <+> (if promoted == Promoted then "'" else mempty)
+            <> prettyNameInfixOp op
+            <+> prettyType rhs
+    TApp _ f x ->
+      prettyType f <+> prettyType x
+    TFun _ a b ->
+      prettyType a <+> "->" <+> prettyType b
+    TTuple _ tupleFlavor promoted elems ->
+      let tupleDoc = prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyType elems)))
+       in if promoted == Promoted then "'" <> tupleDoc else tupleDoc
+    TUnboxedSum _ elems ->
+      hsep ["(#", hsep (punctuate " |" (map prettyType elems)), "#)"]
+    TList _ promoted elems ->
+      let listDoc = brackets (hsep (punctuate comma (map prettyType elems)))
+       in if promoted == Promoted then "'" <> listDoc else listDoc
+    TParen _ inner -> parens (prettyType inner)
+    TKindSig _ ty' kind ->
+      prettyType ty' <+> "::" <+> prettyType kind
+    TContext _ constraints inner ->
+      prettyContext constraints <+> "=>" <+> prettyType inner
+    TSplice _ body -> prettySplice "$" body
+    TWildcard _ -> "_"
 
 prettyContext :: [Type] -> Doc ann
 prettyContext constraints =
   case constraints of
-    [single] -> prettyContextItem single
-    _ -> parens (hsep (punctuate comma (map prettyContextItemNoOuterParens constraints)))
-  where
-    prettyContextItemNoOuterParens :: Type -> Doc ann
-    prettyContextItemNoOuterParens ty =
-      case ty of
-        TKindSig {} -> prettyConstraintType ty
-        TParen _ inner@(TKindSig {}) -> prettyConstraintType inner
-        _ -> prettyContextItem ty
-
-prettyContextItem :: Type -> Doc ann
-prettyContextItem ty =
-  case ty of
-    TKindSig {} -> prettyConstraintTypeParens ty
-    TParen _ inner@(TKindSig {}) -> prettyConstraintTypeParens inner
-    TParen _ inner -> parens (prettyContextItem inner)
-    _ -> prettyConstraintType ty
+    [single] -> prettyType single
+    _ -> parens (hsep (punctuate comma (map prettyType constraints)))
 
 prettyTypeLiteral :: TypeLiteral -> Doc ann
 prettyTypeLiteral lit =
@@ -512,6 +421,8 @@ prettyTypeLiteral lit =
     TypeLitSymbol _ repr -> pretty repr
     TypeLitChar _ repr -> pretty repr
 
+-- | Pretty-print a pattern. The AST is assumed to already have PParen nodes
+-- in the correct positions (inserted by 'addPatternParens').
 prettyPattern :: Pattern -> Doc ann
 prettyPattern pat =
   case pat of
@@ -520,18 +431,18 @@ prettyPattern pat =
     PWildcard _ -> "_"
     PLit _ lit -> prettyLiteral lit
     PQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
-    PTuple _ tupleFlavor elems -> prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyPatternInDelimited elems)))
+    PTuple _ tupleFlavor elems -> prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyPattern elems)))
     PUnboxedSum _ altIdx arity inner ->
-      let slots = [if i == altIdx then prettyPatternInDelimited inner else mempty | i <- [0 .. arity - 1]]
+      let slots = [if i == altIdx then prettyPattern inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
-    PList _ elems -> brackets (hsep (punctuate comma (map prettyPatternInDelimited elems)))
-    PCon _ con args -> hsep (prettyPrefixName con : map prettyPatternAtom args)
-    PInfix _ lhs op rhs -> prettyPatternAtom lhs <+> prettyNameInfixOp op <+> prettyPatternAtom rhs
+    PList _ elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
+    PCon _ con args -> hsep (prettyPrefixName con : map prettyPattern args)
+    PInfix _ lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView _ viewExpr inner ->
-      parens (prettyViewExpr viewExpr <+> "->" <+> prettyPattern inner)
-    PAs _ name inner -> pretty name <> "@" <> prettyPatternAtomStrict inner
-    PStrict _ inner -> "!" <> prettyPatternAtomStrict inner
-    PIrrefutable _ inner -> "~" <> prettyPatternAtomStrict inner
+      prettyExpr viewExpr <+> "->" <+> prettyPattern inner
+    PAs _ name inner -> pretty name <> "@" <> prettyPattern inner
+    PStrict _ inner -> "!" <> prettyPattern inner
+    PIrrefutable _ inner -> "~" <> prettyPattern inner
     PNegLit _ lit -> "-" <> prettyLiteral lit
     PParen _ inner -> parens (prettyPattern inner)
     PRecord _ con fields hasWildcard ->
@@ -548,101 +459,12 @@ prettyPattern pat =
     PTypeSig _ inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
     PSplice _ body -> prettySplice "$" body
 
--- | Pretty print a pattern that appears inside a delimited context (tuples,
--- lists, unboxed sums, etc.). View patterns don't need extra parens there.
-prettyPatternInDelimited :: Pattern -> Doc ann
-prettyPatternInDelimited pat =
-  case pat of
-    PView _ viewExpr inner -> prettyViewExpr viewExpr <+> "->" <+> prettyPattern inner
-    PAs _ name inner -> pretty name <> "@" <> prettyPatternAtomStrict inner
-    PStrict _ inner -> "!" <> prettyPatternAtomStrict inner
-    PIrrefutable _ inner -> "~" <> prettyPatternAtomStrict inner
-    _ -> prettyPattern pat
-
-prettyViewExpr :: Expr -> Doc ann
-prettyViewExpr expr
-  -- Keep expressions that end with a type signature parenthesized so the
-  -- view-pattern arrow cannot be parsed as part of the signature's result type.
-  -- For example, @let {x = y} in z :: T -> p@ must be printed as
-  -- @(let {x = y} in z :: T) -> p@ to prevent @->@ from being absorbed into
-  -- the type @T -> …@.
-  | endsWithTypeSig expr = parens (prettyExprPrec 0 expr)
-  | otherwise = prettyExprPrec 0 expr
-
 -- | Pretty print a pattern field binding.
--- Supports NamedFieldPuns: if pattern is a variable with the same name as the field,
--- print just the field name (punned form).
--- Pattern fields are comma-separated, so greedy patterns don't need parens.
 prettyPatternFieldBinding :: Name -> Pattern -> Doc ann
 prettyPatternFieldBinding fieldName fieldPat =
   case fieldPat of
-    PVar _ varName | renderUnqualifiedName varName == renderName fieldName -> pretty fieldName -- NamedFieldPuns: punned form
+    PVar _ varName | renderUnqualifiedName varName == renderName fieldName -> pretty fieldName
     _ -> pretty fieldName <+> "=" <+> prettyPattern fieldPat
-
-prettyPatternAtom :: Pattern -> Doc ann
-prettyPatternAtom pat =
-  case pat of
-    PVar _ _ -> prettyPattern pat
-    PWildcard _ -> prettyPattern pat
-    PLit _ _ -> prettyPattern pat
-    PQuasiQuote {} -> prettyPattern pat
-    PNegLit _ _ -> prettyPattern pat
-    PList _ _ -> prettyPattern pat
-    PTuple {} -> prettyPattern pat
-    PUnboxedSum {} -> prettyPattern pat
-    PParen _ _ -> prettyPattern pat
-    PStrict _ _ -> prettyPattern pat
-    PIrrefutable _ _ -> prettyPattern pat
-    PView {} -> prettyPattern pat
-    PAs {} -> prettyPattern pat
-    PSplice {} -> prettyPattern pat
-    PCon _ _ [] -> prettyPattern pat
-    _ -> parens (prettyPattern pat)
-
--- | Pretty print a pattern atom in lambda argument position.
--- In addition to the normal non-atomic patterns, this also parenthesizes
--- nullary constructors (which would greedily absorb the next argument) and
--- negative literals (ambiguous with subtraction).
-prettyLambdaPatternAtom :: Pattern -> Doc ann
-prettyLambdaPatternAtom pat =
-  case pat of
-    PNegLit {} -> parens (prettyPattern pat)
-    PCon _ _ [] -> parens (prettyPattern pat)
-    _ -> prettyPatternAtom pat
-
--- | Pretty print a pattern in function-head argument position.
--- Function heads need the same nullary-constructor protection as lambda
--- patterns, and also need constructor applications parenthesized so they do not
--- get split into multiple head arguments by the parser.
-prettyFunctionHeadPatternAtom :: Pattern -> Doc ann
-prettyFunctionHeadPatternAtom pat =
-  case pat of
-    PNegLit {} -> parens (prettyPattern pat)
-    PCon _ _ (_ : _) -> parens (prettyPattern pat)
-    PRecord {} -> prettyPattern pat
-    _ -> prettyPatternAtom pat
-
--- | Pretty print a pattern as an infix function-head operand.
--- Infix operands are already delimited by the operator, so constructor
--- applications and unary-pattern forms can stay bare. Only negative literals
--- still need parens to avoid being read as subtraction.
-prettyInfixFunctionHeadPatternAtom :: Pattern -> Doc ann
-prettyInfixFunctionHeadPatternAtom pat =
-  case pat of
-    PNegLit {} -> parens (prettyPattern pat)
-    _ -> prettyPattern pat
-
--- | Pretty print a pattern atom after @ or as the operand of ! or ~.
--- Negative literals and nested strictness/irrefutability need parens.
-prettyPatternAtomStrict :: Pattern -> Doc ann
-prettyPatternAtomStrict pat =
-  case pat of
-    PNegLit {} -> parens (prettyPattern pat)
-    PCon _ _ [] -> parens (prettyPattern pat)
-    PStrict {} -> parens (prettyPattern pat)
-    PIrrefutable {} -> parens (prettyPattern pat)
-    PRecord {} -> prettyPattern pat
-    _ -> prettyPatternAtom pat
 
 prettyLiteral :: Literal -> Doc ann
 prettyLiteral lit =
@@ -695,7 +517,6 @@ prettyTypeDataDecl decl =
           | any isGadtCon ctors -> ["where", braces (hsep (punctuate semi (map prettyDataCon ctors)))]
           | otherwise -> ["=", hsep (punctuate " |" (map prettyDataCon ctors))]
 
--- | Check if a constructor uses GADT syntax
 isGadtCon :: DataConDecl -> Bool
 isGadtCon (GadtCon {}) = True
 isGadtCon _ = False
@@ -733,9 +554,9 @@ derivingPart (DerivingClause strategy classes viaTy parenthesized) =
 
     classesPart [] = ["()"]
     classesPart [single]
-      | parenthesized = [parens (prettyContextItem single)]
-      | otherwise = [prettyContextItem single]
-    classesPart _ = [parens (hsep (punctuate comma (map prettyContextItem classes)))]
+      | parenthesized = [parens (prettyType single)]
+      | otherwise = [prettyType single]
+    classesPart _ = [parens (hsep (punctuate comma (map prettyType classes)))]
 
     viaPart Nothing = []
     viaPart (Just ty) = ["via", prettyType ty]
@@ -767,7 +588,6 @@ contextPrefix constraints =
     [] -> []
     _ -> [prettyContext constraints, "=>"]
 
--- | Render a forall prefix for [TyVarBinder]
 forallTyVarBinderPrefix :: [TyVarBinder] -> [Doc ann]
 forallTyVarBinderPrefix [] = []
 forallTyVarBinderPrefix binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
@@ -780,7 +600,7 @@ prettyDataCon ctor =
     InfixCon _ forallVars constraints lhs op rhs ->
       hsep
         ( dataConQualifierPrefix forallVars constraints
-            <> [prettyBangTypeAtom lhs, prettyInfixOp (renderUnqualifiedName op), prettyBangTypeAtom rhs]
+            <> [prettyBangType lhs, prettyInfixOp (renderUnqualifiedName op), prettyBangType rhs]
         )
     RecordCon _ forallVars constraints name fields ->
       hsep (dataConQualifierPrefix forallVars constraints <> [prettyConstructorUName name])
@@ -798,7 +618,6 @@ prettyDataCon ctor =
               )
           )
       where
-        -- Wrap operator names in parentheses for correct parsing
         prettyFieldName :: UnqualifiedName -> Doc ann
         prettyFieldName fieldName
           | isOperatorToken (renderUnqualifiedName fieldName) = parens (pretty fieldName)
@@ -806,7 +625,6 @@ prettyDataCon ctor =
     GadtCon _ forallBinders constraints names body ->
       prettyGadtCon forallBinders constraints names body
 
--- | Pretty print a GADT constructor in GADT syntax: @Con :: forall a. Ctx => Type@
 prettyGadtCon :: [TyVarBinder] -> [Type] -> [UnqualifiedName] -> GadtBody -> Doc ann
 prettyGadtCon forallBinders constraints names body =
   hsep
@@ -823,7 +641,6 @@ prettyGadtCon forallBinders constraints names body =
       | null constraints = []
       | otherwise = [prettyContext constraints, "=>"]
 
--- | Pretty print the body of a GADT constructor
 prettyGadtBody :: GadtBody -> Doc ann
 prettyGadtBody body =
   case body of
@@ -834,7 +651,6 @@ prettyGadtBody body =
     GadtRecordBody fields resultTy ->
       braces (prettyRecordFields fields) <+> "->" <+> prettyType resultTy
 
--- | Pretty print record fields for GADT body
 prettyRecordFields :: [FieldDecl] -> Doc ann
 prettyRecordFields fields =
   hsep
@@ -849,7 +665,6 @@ prettyRecordFields fields =
         ]
     )
   where
-    -- Wrap operator names in parentheses for correct parsing
     prettyFieldName :: UnqualifiedName -> Doc ann
     prettyFieldName name
       | isOperatorToken (renderUnqualifiedName name) = parens (pretty name)
@@ -861,18 +676,14 @@ dataConQualifierPrefix forallVars constraints = forallPrefix forallVars <> conte
     forallPrefix [] = []
     forallPrefix binders = ["forall", hsep (map pretty binders) <> "."]
 
--- | Pretty print a BangType in GADT prefix body context.
--- For strict types (!Type), we use atomic type rendering to ensure the type is atomic
--- (e.g., !Int or !(Term a), not !Term a which would be parsed as (!Term) a).
--- For non-strict types, we use function-LHS context rendering since only function types,
--- foralls, and contexts need parentheses before -> in GADT syntax.
+-- | Pretty print a BangType. The type already has TParen nodes where needed.
 prettyBangType :: BangType -> Doc ann
 prettyBangType bt =
   hsep (prettySourceUnpackedness (bangSourceUnpackedness bt) <> [strictDoc])
   where
     strictDoc
-      | bangStrict bt = "!" <> prettyTypeIn CtxTypeAtom (bangType bt)
-      | otherwise = prettyTypeIn CtxTypeFunArg (bangType bt)
+      | bangStrict bt = "!" <> prettyType (bangType bt)
+      | otherwise = prettyType (bangType bt)
 
 prettyRecordFieldBangType :: BangType -> Doc ann
 prettyRecordFieldBangType bt =
@@ -881,12 +692,6 @@ prettyRecordFieldBangType bt =
     strictDoc
       | bangStrict bt = "!" <> prettyType (bangType bt)
       | otherwise = prettyType (bangType bt)
-
--- | Pretty print a BangType as an atom (e.g., for infix data constructors).
--- Wraps the entire bang type in parens if the underlying type needs it.
-prettyBangTypeAtom :: BangType -> Doc ann
-prettyBangTypeAtom bt =
-  parenthesize (needsTypeParens CtxTypeFunArg (bangType bt)) (prettyBangType bt)
 
 prettySourceUnpackedness :: SourceUnpackedness -> [Doc ann]
 prettySourceUnpackedness unpackedness =
@@ -982,12 +787,12 @@ prettyStandaloneDeriving decl =
 instanceHeadDoc :: InstanceDecl -> Doc ann
 instanceHeadDoc decl =
   maybeParenthesize (instanceDeclParenthesizedHead decl) $
-    hsep ([pretty (instanceDeclClassName decl)] <> map (prettyTypeIn CtxTypeAtom) (instanceDeclTypes decl))
+    hsep ([pretty (instanceDeclClassName decl)] <> map prettyType (instanceDeclTypes decl))
 
 standaloneDerivingHeadDoc :: StandaloneDerivingDecl -> Doc ann
 standaloneDerivingHeadDoc decl =
   maybeParenthesize (standaloneDerivingParenthesizedHead decl) $
-    hsep ([pretty (standaloneDerivingClassName decl)] <> map (prettyTypeIn CtxTypeAtom) (standaloneDerivingTypes decl))
+    hsep ([pretty (standaloneDerivingClassName decl)] <> map prettyType (standaloneDerivingTypes decl))
 
 maybeParenthesize :: Bool -> Doc ann -> Doc ann
 maybeParenthesize shouldParen doc
@@ -1118,13 +923,6 @@ isSymbolicName name =
 isSymbolicTypeName :: Name -> Bool
 isSymbolicTypeName = isSymbolicName
 
--- | Check whether an operator is an arrow tail operator (@-<@ or @-<<@).
--- These are special-cased in the pretty-printer to have the lowest precedence.
-isArrowTailOp :: Text -> Bool
-isArrowTailOp "-<" = True
-isArrowTailOp "-<<" = True
-isArrowTailOp _ = False
-
 prettyFunctionBinder :: UnqualifiedName -> Doc ann
 prettyFunctionBinder name
   | unqualifiedNameType name == NameVarSym || unqualifiedNameType name == NameConSym = parens (pretty (renderUnqualifiedName name))
@@ -1136,7 +934,6 @@ prettyBinderName = prettyFunctionBinder
 prettyBinderUName :: UnqualifiedName -> Doc ann
 prettyBinderUName = prettyFunctionBinder
 
--- | Pretty-print a Name, wrapping operators in parentheses regardless of qualification.
 prettyName :: Name -> Doc ann
 prettyName name
   | nameType name == NameVarSym || nameType name == NameConSym = parens (pretty (renderName name))
@@ -1150,223 +947,13 @@ prettyConstructorName name
 prettyConstructorUName :: UnqualifiedName -> Doc ann
 prettyConstructorUName = prettyConstructorName . renderUnqualifiedName
 
--- | Print an expression in a context-sensitive slot.
--- Nested infix expressions need context-sensitive parenthesization, not just
--- operator precedence. We model these slots explicitly.
-data ExprCtx
-  = CtxInfixRhs Bool
-  | CtxInfixLhs
-  | CtxAppFun
-  | -- | Last argument position in an application chain
-    CtxAppArg
-  | -- | Last argument position with block expr (no parens needed)
-    CtxAppArgNoParens
-  | CtxTypeSigBody
-  | CtxGuarded
-
-prettyExprIn :: ExprCtx -> Expr -> Doc ann
-prettyExprIn ctx expr =
-  parenthesize (needsExprParens ctx expr) (prettyExprPrec (exprCtxPrec ctx expr) expr)
-
-exprCtxPrec :: ExprCtx -> Expr -> Int
-exprCtxPrec ctx expr =
-  case ctx of
-    CtxInfixRhs _
-      | isGreedyExpr expr -> 0
-      | otherwise -> 1
-    CtxInfixLhs -> 1
-    CtxAppFun -> 2
-    CtxAppArg -> 3
-    CtxAppArgNoParens -> 0 -- Precedence 0 so EIf/ECase/etc don't add parens
-    CtxTypeSigBody -> 1
-    CtxGuarded -> 0
-
-needsExprParens :: ExprCtx -> Expr -> Bool
-needsExprParens ctx expr =
-  case ctx of
-    CtxInfixRhs protectOpenEnded ->
-      case expr of
-        EInfix {} -> True
-        ETypeSig {} -> True
-        ENegate {} -> True
-        _ | protectOpenEnded && isOpenEnded expr -> True
-        _ -> False
-    CtxInfixLhs ->
-      case expr of
-        ETypeSig {} -> True
-        ENegate {} -> True
-        _ -> isOpenEnded expr
-    CtxAppFun ->
-      case expr of
-        ENegate {} -> True
-        _ -> False
-    CtxAppArg ->
-      -- Block arguments don't need parentheses in the last argument position.
-      -- EParen adds its own parentheses in prettyExprPrec, so don't double-wrap.
-      case expr of
-        _ | isBlockExpr expr -> False
-        _ -> False
-    CtxAppArgNoParens ->
-      -- Never add parentheses - this is only used for block expressions in last arg position.
-      False
-    CtxTypeSigBody ->
-      case expr of
-        ENegate {} -> True
-        ETypeSig {} -> True
-        ELambdaPats {} -> True
-        _ -> isOpenEnded expr
-    CtxGuarded -> isGreedyExpr expr
-
--- | Check if an expression is a "block expression" that can appear without
--- parentheses as a function argument when BlockArguments is enabled.
--- Where clauses are attached to Rhs, not to block expressions.
-isBlockExpr :: Expr -> Bool
-isBlockExpr = \case
-  EIf {} -> True
-  EMultiWayIf {} -> True
-  ECase {} -> True
-  EDo {} -> True
-  ELambdaPats {} -> True
-  ELambdaCase {} -> True
-  ELetDecls {} -> True
-  _ -> False
-
--- | Check if an expression is "greedy" - i.e., it could consume trailing syntax.
--- These expressions may need special handling in certain contexts.
--- With BlockArguments, an application whose last argument is an open-ended
--- block expression is itself greedy, because the argument is printed without
--- parens and its rightmost component can capture trailing syntax.
-isGreedyExpr :: Expr -> Bool
-isGreedyExpr = \case
-  ECase {} -> True
-  EIf {} -> True
-  ELambdaPats {} -> True
-  ELambdaCase {} -> True
-  ELetDecls {} -> True
-  EDo {} -> True
-  EProc {} -> True
-  EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
-  _ -> False
-
--- | Print an expression in a "guarded" context where greedy expressions
--- need parentheses to prevent them from consuming trailing syntax.
-prettyExprGuarded :: Expr -> Doc ann
-prettyExprGuarded = prettyExprIn CtxGuarded
-
-startsWithOverloadedLabel :: Expr -> Bool
-startsWithOverloadedLabel = \case
-  EOverloadedLabel {} -> True
-  EAnn _ sub -> startsWithOverloadedLabel sub
-  EApp _ fn _ -> startsWithOverloadedLabel fn
-  EInfix _ lhs _ _ -> startsWithOverloadedLabel lhs
-  ERecordUpd _ base _ -> startsWithOverloadedLabel base
-  ETypeSig _ inner _ -> startsWithOverloadedLabel inner
-  ETypeApp _ fn _ -> startsWithOverloadedLabel fn
-  _ -> False
-
--- | Check if an expression is "open-ended" - its rightmost component can
--- capture a trailing where clause. This includes:
--- - Directly open-ended expressions (if, lambda, let)
--- - Infix expressions whose RHS is open-ended (recursively)
--- - Application chains whose last argument is a block expression that is
---   itself open-ended (with BlockArguments, the last arg is printed without
---   parens, so its open-endedness propagates to the application)
--- Brace-terminated expressions (do, case, \case) are NOT open-ended because
--- their explicit braces delimit them.
-isOpenEnded :: Expr -> Bool
-isOpenEnded = \case
-  EIf {} -> True
-  ELambdaPats {} -> True
-  ELetDecls {} -> True
-  EProc {} -> True
-  EInfix _ _ _ rhs -> isOpenEnded rhs
-  EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
-  _ -> False
-
--- | Does the pretty-printed form of an expression end with @:: Type@?
--- Such expressions need parenthesization in contexts where a following @->@
--- would be absorbed into the type (e.g. the view expression of a view pattern).
-endsWithTypeSig :: Expr -> Bool
-endsWithTypeSig = \case
-  ETypeSig {} -> True
-  ELetDecls _ _ body -> endsWithTypeSig body
-  ELambdaPats _ _ body -> endsWithTypeSig body
-  EInfix _ _ _ rhs -> endsWithTypeSig rhs
-  _ -> False
-
--- | Print an expression used as the function in an application.
-prettyExprApp :: Expr -> Doc ann
-prettyExprApp = prettyExprIn CtxAppFun
-
--- | Check whether an expression's pretty-printed form starts with '$'.
--- This matters for negation: -$x lexes as the operator -$ rather than
--- negate applied to a splice.
-startsWithDollar :: Expr -> Bool
-startsWithDollar (ETHSplice {}) = True
-startsWithDollar (ETHTypedSplice {}) = True
-startsWithDollar (ERecordUpd _ base _) = startsWithDollar base
-startsWithDollar (EApp _ fn _) = startsWithDollar fn
-startsWithDollar _ = False
-
--- | Print a negation expression.
-prettyNegate :: Expr -> Doc ann
-prettyNegate inner =
-  -- Splices start with $ which is a symbolic operator character.
-  -- Without parens, -$x lexes as the operator -$ followed by x,
-  -- and - $x lexes as a right section. The same applies when a splice
-  -- is the leading subexpression of a record update or application.
-  if startsWithDollar inner || startsWithOverloadedLabel inner
-    then "-" <> parens (prettyExprPrec 0 inner)
-    else "-" <> prettyExprPrec 3 inner
-
--- | Print the body of a type signature expression.
-prettyTypeSigBody :: Expr -> Doc ann
-prettyTypeSigBody = prettyExprIn CtxTypeSigBody
-
-prettyIfBranch :: Expr -> Doc ann
-prettyIfBranch expr =
+-- | Pretty-print an expression. The AST is assumed to already have EParen
+-- nodes in the correct positions (inserted by 'addExprParens').
+prettyExpr :: Expr -> Doc ann
+prettyExpr expr =
   case expr of
-    -- Branch delimiters handle most greedy expressions, but postfix forms like
-    -- type signatures need parens to stay inside the branch.
-    -- Use endsWithTypeSig to also catch indirect cases like infix expressions
-    -- whose RHS is a type signature (e.g. @a + b :: T@).
-    _ | endsWithTypeSig expr -> parens (prettyExprPrec 0 expr)
-    _ -> prettyExprPrec 0 expr
-
--- | Flatten a left-nested application chain into (root, args).
--- For example, @f x y z@ (parsed as @(((f x) y) z)@) becomes @(f, [x, y, z])@.
-flattenApps :: Expr -> (Expr, [Expr])
-flattenApps = go []
-  where
-    go args (EApp _ fn arg) = go (arg : args) fn
-    go args root = (root, args)
-
--- | Pretty-print a chain of applications.
--- The last argument can use BlockArguments (no parentheses for block expressions).
--- Intermediate arguments always need parentheses for block expressions.
-prettyAppsChain :: Int -> Expr -> Doc ann
-prettyAppsChain prec expr =
-  let (root, args) = flattenApps expr
-      rootDoc = prettyExprApp root
-      argDocs = map (\(isLast, a) -> prettyExprIn (argCtx isLast a) a) (markLast args)
-   in parenthesize (prec > 2) (hsep (rootDoc : argDocs))
-  where
-    -- For the last argument, if it's a block expression, use precedence 0 to avoid
-    -- parentheses from the expression's own parenthesization logic.
-    argCtx True a | isBlockExpr a = CtxAppArgNoParens
-    argCtx True _ = CtxAppArg
-    argCtx False _ = CtxAppArg
-
-    markLast [] = []
-    markLast [x] = [(True, x)]
-    markLast (x : xs) = (False, x) : markLast xs
-
-prettyExprPrec :: Int -> Expr -> Doc ann
-prettyExprPrec prec expr =
-  case expr of
-    EApp {} -> prettyAppsChain prec expr
-    ETypeApp _ fn ty ->
-      parenthesize (prec > 2) (prettyExprApp fn <+> "@" <> prettyTypeIn CtxTypeAtom ty)
+    EApp _ fn arg -> prettyExpr fn <+> prettyExpr arg
+    ETypeApp _ fn ty -> prettyExpr fn <+> "@" <> prettyType ty
     EVar _ name
       | isSymbolicName name -> parens (pretty (renderName name))
       | otherwise -> pretty name
@@ -1382,8 +969,8 @@ prettyExprPrec prec expr =
     EStringHash _ _ repr -> pretty repr
     EOverloadedLabel _ _ raw -> pretty (" " <> raw)
     EQuasiQuote _ quoter body -> prettyQuasiQuote quoter body
-    ETHExpQuote _ body -> "[|" <+> prettyExprPrec 0 body <+> "|]"
-    ETHTypedQuote _ body -> "[||" <+> prettyExprPrec 0 body <+> "||]"
+    ETHExpQuote _ body -> "[|" <+> prettyExpr body <+> "|]"
+    ETHTypedQuote _ body -> "[||" <+> prettyExpr body <+> "||]"
     ETHDeclQuote _ decls -> "[d|" <+> prettyInlineDecls decls <+> "|]"
     ETHTypeQuote _ ty -> "[t|" <+> prettyType ty <+> "|]"
     ETHPatQuote _ pat -> "[p|" <+> prettyPattern pat <+> "|]"
@@ -1396,98 +983,54 @@ prettyExprPrec prec expr =
     ETHSplice _ body -> prettySplice "$" body
     ETHTypedSplice _ body -> prettySplice "$$" body
     EIf _ cond yes no ->
-      -- The 'then' keyword delimits the condition, and 'else' delimits the then-branch,
-      -- so greedy expressions in those positions don't need parentheses.
-      -- Type signatures are different: without parens, `else x :: T` binds to
-      -- the whole `if`, not just the branch expression.
-      parenthesize
-        (prec > 0)
-        ("if" <+> prettyExprPrec 0 cond <+> "then" <+> prettyIfBranch yes <+> "else" <+> prettyIfBranch no)
+      "if" <+> prettyExpr cond <+> "then" <+> prettyExpr yes <+> "else" <+> prettyExpr no
     EMultiWayIf _ rhss ->
-      parenthesize
-        (prec > 0)
-        ( "if"
-            <+> "{"
-            <+> hsep
-              [ "|"
-                  <+> hsep (punctuate comma (map (prettyGuardQualifier GuardArrow) (guardedRhsGuards grhs)))
-                  <+> "->"
-                  <+> prettyExprPrec 0 (guardedRhsBody grhs)
-              | grhs <- rhss
-              ]
-            <+> "}"
-        )
+      "if"
+        <+> "{"
+        <+> hsep
+          [ "|"
+              <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
+              <+> "->"
+              <+> prettyExpr (guardedRhsBody grhs)
+          | grhs <- rhss
+          ]
+        <+> "}"
     ELambdaPats _ pats body ->
-      parenthesize (prec > 0) ("\\" <+> hsep (map prettyLambdaPatternAtom pats) <+> "->" <+> prettyExprPrec 0 body)
+      "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyExpr body
     ELambdaCase _ alts ->
-      parenthesize
-        (prec > 0)
-        ("\\" <> "case" <+> "{" <+> hsep (punctuate semi (map prettyCaseAlt alts)) <+> "}")
-    EInfix _ lhs op rhs
-      | isArrowTailOp (renderName op) ->
-          -- Arrow application operators (-<, -<<) are command-level syntax
-          -- in GHC.  The LHS is a command (which may be a greedy do/if/case)
-          -- and the RHS is a full expression.
-          -- Always parenthesize the whole expression to avoid ambiguity.
-          -- Also parenthesize the LHS to prevent constructs like `where` from
-          -- capturing the `-<` operator.
-          parenthesize
-            True
-            (parens (prettyExprPrec 0 lhs) <+> prettyNameInfixOp op <+> prettyExprPrec 0 rhs)
-      | otherwise ->
-          parenthesize
-            (prec > 1)
-            (prettyExprIn CtxInfixLhs lhs <+> prettyNameInfixOp op <+> prettyExprIn (CtxInfixRhs (prec == 1)) rhs)
-    ENegate _ inner -> parenthesize (prec > 2) (prettyNegate inner)
+      "\\" <> "case" <+> "{" <+> hsep (punctuate semi (map prettyCaseAlt alts)) <+> "}"
+    EInfix _ lhs op rhs ->
+      prettyExpr lhs <+> prettyNameInfixOp op <+> prettyExpr rhs
+    ENegate _ inner -> "-" <> prettyExpr inner
     ESectionL _ lhs op ->
-      -- Expressions that can capture trailing syntax need extra parens in section
-      -- LHS to prevent the parser from interpreting trailing operators as part of
-      -- the expression rather than as the section operator
-      let lhsDoc = case lhs of
-            ETypeSig {} -> parens (prettyExprPrec 0 lhs)
-            _ | isGreedyExpr lhs -> parens (prettyExprPrec 0 lhs)
-            _ -> prettyExprPrec 1 lhs
-       in parens (lhsDoc <+> prettyNameInfixOp op)
-    ESectionR _ op rhs -> parens (prettyNameInfixOp op <+> prettyExprPrec 0 rhs)
+      parens (prettyExpr lhs <+> prettyNameInfixOp op)
+    ESectionR _ op rhs -> parens (prettyNameInfixOp op <+> prettyExpr rhs)
     ELetDecls _ decls body ->
-      parenthesize
-        (prec > 0)
-        ( "let"
-            <+> braces (prettyInlineDecls decls)
-            <+> "in"
-            <+> prettyExprPrec 0 body
-        )
+      "let"
+        <+> braces (prettyInlineDecls decls)
+        <+> "in"
+        <+> prettyExpr body
     ECase _ scrutinee alts ->
-      -- The 'of' keyword delimits the scrutinee, so greedy expressions don't need parens
-      -- Use "{ " instead of braces to avoid {- being lexed as block comment start
-      parenthesize
-        (prec > 0)
-        ( "case"
-            <+> prettyExprPrec 0 scrutinee
-            <+> "of"
-            <+> "{"
-            <+> hsep (punctuate semi (map prettyCaseAlt alts))
-            <+> "}"
-        )
+      "case"
+        <+> prettyExpr scrutinee
+        <+> "of"
+        <+> "{"
+        <+> hsep (punctuate semi (map prettyCaseAlt alts))
+        <+> "}"
     EDo _ stmts isMdo ->
-      parenthesize
-        (prec > 0)
-        ( (if isMdo then "mdo" else "do")
-            <+> "{"
-            <+> hsep (punctuate semi (map prettyDoStmt stmts))
-            <+> "}"
-        )
+      (if isMdo then "mdo" else "do")
+        <+> "{"
+        <+> hsep (punctuate semi (map prettyDoStmt stmts))
+        <+> "}"
     EListComp _ body quals ->
-      -- Brace-terminated expressions in the body don't capture the |
       brackets
-        ( prettyExprPrec 0 body
+        ( prettyExpr body
             <+> "|"
             <+> hsep (punctuate comma (map prettyCompStmt quals))
         )
     EListCompParallel _ body qualifierGroups ->
-      -- Brace-terminated expressions in the body don't capture the |
       brackets
-        ( prettyExprPrec 0 body
+        ( prettyExpr body
             <+> "|"
             <+> hsep
               ( punctuate
@@ -1499,14 +1042,14 @@ prettyExprPrec prec expr =
     ERecordCon _ name fields hasWildcard ->
       pretty name <+> braces (hsep (punctuate comma (map prettyBinding fields ++ [".." | hasWildcard])))
     ERecordUpd _ base fields ->
-      prettyExprPrec 3 base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
-    ETypeSig _ inner ty -> parenthesize (prec > 1) (prettyTypeSigBody inner <+> "::" <+> prettyType ty)
+      prettyExpr base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
+    ETypeSig _ inner ty -> prettyExpr inner <+> "::" <+> prettyType ty
     EParen _ inner ->
       case inner of
-        ESectionL {} -> prettyExprPrec 0 inner
-        ESectionR {} -> prettyExprPrec 0 inner
-        _ -> parens (prettyExprPrec 0 inner)
-    EList _ values -> brackets (hsep (punctuate comma (map (prettyExprPrec 0) values)))
+        ESectionL {} -> prettyExpr inner
+        ESectionR {} -> prettyExpr inner
+        _ -> parens (prettyExpr inner)
+    EList _ values -> brackets (hsep (punctuate comma (map prettyExpr values)))
     ETuple _ tupleFlavor values ->
       prettyTupleBody
         tupleFlavor
@@ -1515,7 +1058,7 @@ prettyExprPrec prec expr =
                 comma
                 ( map
                     ( \case
-                        Just val -> prettyExprPrec 0 val
+                        Just val -> prettyExpr val
                         Nothing -> mempty
                     )
                     values
@@ -1523,11 +1066,11 @@ prettyExprPrec prec expr =
             )
         )
     EUnboxedSum _ altIdx arity inner ->
-      let slots = [if i == altIdx then prettyExprPrec 0 inner else mempty | i <- [0 .. arity - 1]]
+      let slots = [if i == altIdx then prettyExpr inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     EProc _ pat body ->
-      parenthesize (prec > 0) ("proc" <+> prettyPattern pat <+> "->" <+> prettyCmd body)
-    EAnn _ sub -> prettyExprPrec prec sub
+      "proc" <+> prettyPattern pat <+> "->" <+> prettyCmd body
+    EAnn _ sub -> prettyExpr sub
 
 prettyTupleBody :: TupleFlavor -> Doc ann -> Doc ann
 prettyTupleBody tupleFlavor inner =
@@ -1535,81 +1078,46 @@ prettyTupleBody tupleFlavor inner =
     Boxed -> parens inner
     Unboxed -> hsep ["(#", inner, "#)"]
 
--- | Pretty print a record field binding.
--- Supports NamedFieldPuns: if value is a variable with the same name as the field,
--- print just the field name (punned form).
--- Supports RecordWildCards: if name is "..", print just "..".
--- Record fields are comma-separated, so greedy expressions don't need parens.
 prettyBinding :: (Text, Expr) -> Doc ann
 prettyBinding (name, value) =
   case value of
-    EVar _ varName | renderName varName == name -> pretty name -- NamedFieldPuns: punned form
-    _ -> pretty name <+> "=" <+> prettyExprPrec 0 value
+    EVar _ varName | renderName varName == name -> pretty name
+    _ -> pretty name <+> "=" <+> prettyExpr value
 
--- | Pretty print a case alternative.
--- Since case alternatives are separated by semicolons (in explicit brace syntax),
--- greedy expressions in the body don't need parentheses.
 prettyCaseAlt :: CaseAlt -> Doc ann
 prettyCaseAlt (CaseAlt _ pat rhs) =
   case rhs of
-    UnguardedRhs _ expr whereDecls ->
+    UnguardedRhs _ body whereDecls ->
       prettyPattern pat
         <+> "->"
-        <+> prettyExprPrec 0 expr
+        <+> prettyExpr body
         <> prettyWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
       hsep
         [ prettyPattern pat,
           hsep
             [ "|"
-                <+> hsep (punctuate comma (map (prettyGuardQualifier GuardArrow) (guardedRhsGuards grhs)))
+                <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
                 <+> "->"
-                <+> prettyExprPrec 0 (guardedRhsBody grhs)
+                <+> prettyExpr (guardedRhsBody grhs)
             | grhs <- grhss
             ]
         ]
         <> prettyWhereClause whereDecls
 
--- | Context for guard qualifiers: whether the guard is followed by @->@ or @=@.
--- When followed by @->@, expressions ending with a type signature need
--- parenthesization because @->@ is valid in types and would be absorbed.
-data GuardArrow = GuardArrow | GuardEquals
-
-prettyGuardQualifier :: GuardArrow -> GuardQualifier -> Doc ann
-prettyGuardQualifier arrow qualifier =
+prettyGuardQualifier :: GuardQualifier -> Doc ann
+prettyGuardQualifier qualifier =
   case qualifier of
-    GuardExpr _ expr -> prettyGuardExpr arrow expr
-    GuardPat _ pat expr -> prettyPattern pat <+> "<-" <+> prettyGuardExpr arrow expr
+    GuardExpr _ expr -> prettyExpr expr
+    GuardPat _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     GuardLet _ decls -> "let" <+> braces (prettyInlineDecls decls)
 
--- | Pretty-print an expression in a guard qualifier position.
--- In @->@ contexts (multi-way if, case alternatives), expressions ending with
--- a type signature need parenthesization because the arrow would be absorbed
--- into the type.  For example, @| () <- 262 :: T -> ()@ must be printed as
--- @| () <- (262 :: T) -> ()@.
-prettyGuardExpr :: GuardArrow -> Expr -> Doc ann
-prettyGuardExpr arrow expr
-  | guardExprNeedsParens arrow expr = parens (prettyExprPrec 0 expr)
-  | otherwise = prettyExprPrec 0 expr
-
-guardExprNeedsParens :: GuardArrow -> Expr -> Bool
-guardExprNeedsParens arrow = \case
-  ELambdaPats {} -> True
-  EProc {} -> True
-  EApp _ _ arg | isBlockExpr arg -> guardExprNeedsParens arrow arg
-  expr -> case arrow of
-    GuardArrow -> endsWithTypeSig expr
-    GuardEquals -> False
-
--- | Pretty print a do statement.
--- Since do blocks are always rendered with explicit braces and semicolons,
--- statement boundaries are clear and greedy expressions don't need parens.
 prettyDoStmt :: DoStmt Expr -> Doc ann
 prettyDoStmt stmt =
   case stmt of
-    DoBind _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExprPrec 0 expr
+    DoBind _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     DoLetDecls _ decls -> "let" <+> braces (prettyInlineDecls decls)
-    DoExpr _ expr -> prettyExprPrec 0 expr
+    DoExpr _ expr -> prettyExpr expr
     DoRecStmt _ stmts -> "rec" <+> "{" <+> hsep (punctuate semi (map prettyDoStmt stmts)) <+> "}"
 
 -- | Pretty-print an arrow command.
@@ -1617,27 +1125,26 @@ prettyCmd :: Cmd -> Doc ann
 prettyCmd cmd =
   case cmd of
     CmdArrApp _ lhs HsFirstOrderApp rhs ->
-      prettyExprPrec 1 lhs <+> "-<" <+> prettyExprPrec 0 rhs
+      prettyExpr lhs <+> "-<" <+> prettyExpr rhs
     CmdArrApp _ lhs HsHigherOrderApp rhs ->
-      prettyExprPrec 1 lhs <+> "-<<" <+> prettyExprPrec 0 rhs
+      prettyExpr lhs <+> "-<<" <+> prettyExpr rhs
     CmdInfix _ l op r ->
       prettyCmd l <+> prettyInfixOp op <+> prettyCmd r
     CmdDo _ stmts ->
       "do" <+> "{" <+> hsep (punctuate semi (map prettyCmdStmt stmts)) <+> "}"
     CmdIf _ cond yes no ->
-      "if" <+> prettyExprPrec 0 cond <+> "then" <+> prettyCmd yes <+> "else" <+> prettyCmd no
+      "if" <+> prettyExpr cond <+> "then" <+> prettyCmd yes <+> "else" <+> prettyCmd no
     CmdCase _ scrut alts ->
-      "case" <+> prettyExprPrec 0 scrut <+> "of" <+> "{" <+> hsep (punctuate semi (map prettyCmdCaseAlt alts)) <+> "}"
+      "case" <+> prettyExpr scrut <+> "of" <+> "{" <+> hsep (punctuate semi (map prettyCmdCaseAlt alts)) <+> "}"
     CmdLet _ decls body ->
       "let" <+> braces (prettyInlineDecls decls) <+> "in" <+> prettyCmd body
     CmdLam _ pats body ->
-      "\\" <+> hsep (map prettyPatternAtom pats) <+> "->" <+> prettyCmd body
+      "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyCmd body
     CmdApp _ c e ->
-      prettyCmd c <+> prettyExprPrec 3 e
+      prettyCmd c <+> prettyExpr e
     CmdPar _ c ->
       parens (prettyCmd c)
 
--- | Pretty-print a do-statement in command context.
 prettyCmdStmt :: DoStmt Cmd -> Doc ann
 prettyCmdStmt stmt =
   case stmt of
@@ -1646,7 +1153,6 @@ prettyCmdStmt stmt =
     DoExpr _ cmd' -> prettyCmd cmd'
     DoRecStmt _ stmts -> "rec" <+> "{" <+> hsep (punctuate semi (map prettyCmdStmt stmts)) <+> "}"
 
--- | Pretty-print a command case alternative.
 prettyCmdCaseAlt :: CmdCaseAlt -> Doc ann
 prettyCmdCaseAlt alt =
   prettyPattern (cmdCaseAltPat alt) <+> "->" <+> prettyCmd (cmdCaseAltBody alt)
@@ -1654,8 +1160,8 @@ prettyCmdCaseAlt alt =
 prettyCompStmt :: CompStmt -> Doc ann
 prettyCompStmt stmt =
   case stmt of
-    CompGen _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExprPrec 0 expr
-    CompGuard _ expr -> prettyExprPrec 0 expr
+    CompGen _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
+    CompGuard _ expr -> prettyExpr expr
     CompLet _ bindings -> "let" <+> hsep (punctuate semi (map prettyBinding bindings))
     CompLetDecls _ decls -> "let" <+> braces (prettyInlineDecls decls)
 
@@ -1663,8 +1169,6 @@ prettyInlineDecls :: [Decl] -> Doc ann
 prettyInlineDecls decls =
   hsep (punctuate semi (map prettyInlineDecl decls))
   where
-    -- For value declarations, use single-line form to keep guarded bindings together.
-    -- For other declarations, join their lines with spaces.
     prettyInlineDecl decl = case decl of
       DeclValue _ valueDecl -> prettyValueDeclSingleLine valueDecl
       _ -> hsep (prettyDeclLines decl)
@@ -1672,16 +1176,11 @@ prettyInlineDecls decls =
 prettyArithSeq :: ArithSeq -> Doc ann
 prettyArithSeq seqInfo =
   case seqInfo of
-    ArithSeqFrom _ fromExpr -> brackets (prettyExprGuarded fromExpr <> " ..")
-    ArithSeqFromThen _ fromExpr thenExpr -> brackets (prettyExprGuarded fromExpr <> ", " <> prettyExprGuarded thenExpr <> " ..")
-    ArithSeqFromTo _ fromExpr toExpr -> brackets (prettyExprGuarded fromExpr <> " .. " <> prettyExprPrec 0 toExpr)
+    ArithSeqFrom _ fromExpr -> brackets (prettyExpr fromExpr <> " ..")
+    ArithSeqFromThen _ fromExpr thenExpr -> brackets (prettyExpr fromExpr <> ", " <> prettyExpr thenExpr <> " ..")
+    ArithSeqFromTo _ fromExpr toExpr -> brackets (prettyExpr fromExpr <> " .. " <> prettyExpr toExpr)
     ArithSeqFromThenTo _ fromExpr thenExpr toExpr ->
-      brackets (prettyExprGuarded fromExpr <> ", " <> prettyExprGuarded thenExpr <> " .. " <> prettyExprPrec 0 toExpr)
-
-parenthesize :: Bool -> Doc ann -> Doc ann
-parenthesize shouldWrap doc
-  | shouldWrap = parens doc
-  | otherwise = doc
+      brackets (prettyExpr fromExpr <> ", " <> prettyExpr thenExpr <> " .. " <> prettyExpr toExpr)
 
 quoted :: Text -> Doc ann
 quoted txt = pretty (show (T.unpack txt))
@@ -1693,8 +1192,6 @@ isOperatorToken :: Text -> Bool
 isOperatorToken tok =
   not (T.null tok) && T.all isSymbolicOpChar tok
 
--- | Matches operator characters per Haskell 2010 §2.2: ASCII symbol chars
--- plus Unicode characters with general category Sm, Sc, Sk, or So.
 isSymbolicOpChar :: Char -> Bool
 isSymbolicOpChar c =
   c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeSymbolCategory c
@@ -1709,19 +1206,16 @@ isUnicodeSymbolCategory c = case generalCategory c of
   _ -> False
 
 -- | Pretty-print a TH splice with the given prefix ("$" or "$$").
--- If the body is a parenthesized expression, print as $(expr) or $$(expr).
--- If the body is a bare variable, print as $name or $$name.
 prettySplice :: Doc ann -> Expr -> Doc ann
 prettySplice prefix body =
   case body of
-    EParen _ inner -> prefix <> parens (prettyExprPrec 0 inner)
-    EVar {} -> prefix <> prettyExprPrec 11 body
-    _ -> prefix <> parens (prettyExprPrec 0 body)
+    EParen _ inner -> prefix <> parens (prettyExpr inner)
+    EVar {} -> prefix <> prettyExpr body
+    _ -> prefix <> parens (prettyExpr body)
 
 -- ---------------------------------------------------------------------------
 -- TypeFamilies pretty-printing helpers
 
--- | @type family Name params [:: Kind] [where { equations }]@
 prettyTypeFamilyDecl :: TypeFamilyDecl -> Doc ann
 prettyTypeFamilyDecl tf =
   hsep $
@@ -1745,7 +1239,6 @@ prettyTypeFamilyEq eq =
     forallPart [] = []
     forallPart binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
 
--- | @data family Name params [:: Kind]@
 prettyDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyDataFamilyDecl df =
   hsep $
@@ -1756,7 +1249,6 @@ prettyDataFamilyDecl df =
     kindPart Nothing = []
     kindPart (Just k) = ["::", prettyType k]
 
--- | @type instance [forall.] LhsType = RhsType@ (top-level)
 prettyTopTypeFamilyInst :: TypeFamilyInst -> Doc ann
 prettyTopTypeFamilyInst tfi =
   hsep $
@@ -1768,7 +1260,6 @@ prettyTopTypeFamilyInst tfi =
     forallPart [] = []
     forallPart binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
 
--- | @(data|newtype) instance [forall.] HeadType = Cons@ (top-level)
 prettyTopDataFamilyInst :: DataFamilyInst -> Doc ann
 prettyTopDataFamilyInst dfi =
   hsep $
@@ -1787,7 +1278,6 @@ prettyTopDataFamilyInst dfi =
       | dataFamilyInstIsNewtype dfi = ["=", prettyDataCon c]
       | otherwise = ["=", hsep (punctuate " |" (map prettyDataCon ctors))]
 
--- | @type Name params [:: Kind]@ (associated type family inside a class, no @family@ keyword)
 prettyAssocTypeFamilyDecl :: TypeFamilyDecl -> Doc ann
 prettyAssocTypeFamilyDecl tf =
   hsep $
@@ -1810,7 +1300,6 @@ prettyTypeFamilyLhs headForm lhs =
     TypeHeadPrefix -> [prettyType lhs]
     TypeHeadInfix -> [prettyTypeFamilyInfix lhs]
 
--- | @data Name params [:: Kind]@ (associated data family inside a class, no @family@ keyword)
 prettyAssocDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyAssocDataFamilyDecl df =
   hsep $
@@ -1821,7 +1310,6 @@ prettyAssocDataFamilyDecl df =
     kindPart Nothing = []
     kindPart (Just k) = ["::", prettyType k]
 
--- | @type instance LhsType = RhsType@ (default type instance inside a class)
 prettyDefaultTypeInst :: TypeFamilyInst -> Doc ann
 prettyDefaultTypeInst tfi =
   hsep $
@@ -1833,7 +1321,6 @@ prettyDefaultTypeInst tfi =
     forallPart [] = []
     forallPart binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
 
--- | @type LhsType = RhsType@ inside an instance body (no @instance@ keyword)
 prettyInstTypeFamilyInst :: TypeFamilyInst -> Doc ann
 prettyInstTypeFamilyInst tfi =
   hsep $
@@ -1855,13 +1342,12 @@ prettyTypeFamilyInfix :: Type -> Doc ann
 prettyTypeFamilyInfix ty =
   case ty of
     TApp _ (TApp _ (TCon _ op promoted) lhs) rhs ->
-      prettyTypeIn CtxTypeAtom lhs
+      prettyType lhs
         <+> (if promoted == Promoted then "'" else mempty)
         <> prettyNameInfixOp op
-        <+> prettyTypeIn CtxTypeAtom rhs
+        <+> prettyType rhs
     _ -> prettyType ty
 
--- | @(data|newtype) HeadType = Cons@ inside an instance body
 prettyInstDataFamilyInst :: DataFamilyInst -> Doc ann
 prettyInstDataFamilyInst dfi =
   hsep $

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -6,6 +6,7 @@ module Test.Properties.TypeRoundTrip
 where
 
 import Aihc.Parser
+import Aihc.Parser.Parens (addTypeParens)
 import Aihc.Parser.Syntax
 import Data.Maybe (isJust)
 import Data.Text qualified as T
@@ -40,33 +41,39 @@ prop_typePrettyRoundTrip ty =
                     let actual = normalizeType parsed
                      in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
+-- | Normalize a type by stripping spans, stripping all paren nodes, then
+-- re-adding parens via the canonical paren-insertion pass.
 normalizeType :: Type -> Type
-normalizeType ty =
+normalizeType = addTypeParens . stripTypeParens
+
+-- | Strip source spans and remove all TParen nodes from a type.
+stripTypeParens :: Type -> Type
+stripTypeParens ty =
   case ty of
     TVar _ name -> TVar span0 name
     TCon _ name promoted -> TCon span0 name promoted
-    TImplicitParam _ name inner -> TImplicitParam span0 name (normalizeType inner)
+    TImplicitParam _ name inner -> TImplicitParam span0 name (stripTypeParens inner)
     TTypeLit _ lit -> TTypeLit span0 lit
     TStar _ -> TStar span0
     TWildcard _ -> TWildcard span0
     TQuasiQuote _ quoter body -> TQuasiQuote span0 quoter body
-    TForall _ binders inner -> TForall span0 (map normalizeTyVarBinder binders) (normalizeType inner)
-    TApp _ f x -> TApp span0 (normalizeType f) (normalizeType x)
-    TFun _ a b -> TFun span0 (normalizeType a) (normalizeType b)
-    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map normalizeType elems)
-    TList _ promoted elems -> TList span0 promoted (map normalizeType elems)
-    TParen _ inner -> TParen span0 (normalizeType inner)
-    TKindSig _ ty' kind -> TKindSig span0 (normalizeType ty') (normalizeType kind)
-    TUnboxedSum _ elems -> TUnboxedSum span0 (map normalizeType elems)
-    TContext _ constraints inner -> canonicalContextType (map normalizeType constraints) (normalizeType inner)
+    TForall _ binders inner -> TForall span0 (map stripTyVarBinderParens binders) (stripTypeParens inner)
+    TApp _ f x -> TApp span0 (stripTypeParens f) (stripTypeParens x)
+    TFun _ a b -> TFun span0 (stripTypeParens a) (stripTypeParens b)
+    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map stripTypeParens elems)
+    TList _ promoted elems -> TList span0 promoted (map stripTypeParens elems)
+    TParen _ inner -> stripTypeParens inner
+    TKindSig _ ty' kind -> TKindSig span0 (stripTypeParens ty') (stripTypeParens kind)
+    TUnboxedSum _ elems -> TUnboxedSum span0 (map stripTypeParens elems)
+    TContext _ constraints inner -> canonicalContextType (map stripTypeParens constraints) (stripTypeParens inner)
     TSplice _ body -> TSplice span0 (normalizeExpr body)
-    TAnn ann sub -> TAnn ann (normalizeType sub)
+    TAnn ann sub -> TAnn ann (stripTypeParens sub)
 
-normalizeTyVarBinder :: TyVarBinder -> TyVarBinder
-normalizeTyVarBinder tvb =
+stripTyVarBinderParens :: TyVarBinder -> TyVarBinder
+stripTyVarBinderParens tvb =
   tvb
     { tyVarBinderSpan = span0,
-      tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
+      tyVarBinderKind = fmap stripTypeParens (tyVarBinderKind tvb)
     }
 
 containsKindedInferredBinder :: Type -> Bool

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -6,13 +6,12 @@ module Test.Properties.TypeRoundTrip
 where
 
 import Aihc.Parser
-import Aihc.Parser.Parens (addTypeParens)
 import Aihc.Parser.Syntax
 import Data.Maybe (isJust)
 import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
-import Test.Properties.Arb.Type (canonicalContextType, canonicalTopLevelType)
+import Test.Properties.Arb.Type (canonicalTopLevelType)
 import Test.Properties.Coverage (assertCtorCoverage)
 import Test.Properties.ExprHelpers (normalizeExpr, span0)
 import Test.QuickCheck
@@ -41,39 +40,43 @@ prop_typePrettyRoundTrip ty =
                     let actual = normalizeType parsed
                      in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
--- | Normalize a type by stripping spans, stripping all paren nodes, then
--- re-adding parens via the canonical paren-insertion pass.
+-- | Normalize a type by stripping source spans.
+-- TParen nodes are preserved as-is, except TParen around TKindSig is
+-- stripped because the parser absorbs @(ty :: kind)@ as @TKindSig ty kind@
+-- without a TParen wrapper.
 normalizeType :: Type -> Type
-normalizeType = addTypeParens . stripTypeParens
-
--- | Strip source spans and remove all TParen nodes from a type.
-stripTypeParens :: Type -> Type
-stripTypeParens ty =
+normalizeType ty =
   case ty of
     TVar _ name -> TVar span0 name
     TCon _ name promoted -> TCon span0 name promoted
-    TImplicitParam _ name inner -> TImplicitParam span0 name (stripTypeParens inner)
+    TImplicitParam _ name inner -> TImplicitParam span0 name (normalizeType inner)
     TTypeLit _ lit -> TTypeLit span0 lit
     TStar _ -> TStar span0
     TWildcard _ -> TWildcard span0
     TQuasiQuote _ quoter body -> TQuasiQuote span0 quoter body
-    TForall _ binders inner -> TForall span0 (map stripTyVarBinderParens binders) (stripTypeParens inner)
-    TApp _ f x -> TApp span0 (stripTypeParens f) (stripTypeParens x)
-    TFun _ a b -> TFun span0 (stripTypeParens a) (stripTypeParens b)
-    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map stripTypeParens elems)
-    TList _ promoted elems -> TList span0 promoted (map stripTypeParens elems)
-    TParen _ inner -> stripTypeParens inner
-    TKindSig _ ty' kind -> TKindSig span0 (stripTypeParens ty') (stripTypeParens kind)
-    TUnboxedSum _ elems -> TUnboxedSum span0 (map stripTypeParens elems)
-    TContext _ constraints inner -> canonicalContextType (map stripTypeParens constraints) (stripTypeParens inner)
+    TForall _ binders inner -> TForall span0 (map normalizeTyVarBinder binders) (normalizeType inner)
+    TApp _ f x -> TApp span0 (normalizeType f) (normalizeType x)
+    TFun _ a b -> TFun span0 (normalizeType a) (normalizeType b)
+    TTuple _ tupleFlavor promoted elems -> TTuple span0 tupleFlavor promoted (map normalizeType elems)
+    TList _ promoted elems -> TList span0 promoted (map normalizeType elems)
+    -- Strip TParen around TKindSig: the parser absorbs (ty :: kind) parens
+    -- into the TKindSig node itself. Normalize the inner first to collapse
+    -- any chain of TParens, then strip if TKindSig is underneath.
+    TParen _ inner ->
+      case normalizeType inner of
+        result@(TKindSig {}) -> result
+        result -> TParen span0 result
+    TKindSig _ ty' kind -> TKindSig span0 (normalizeType ty') (normalizeType kind)
+    TUnboxedSum _ elems -> TUnboxedSum span0 (map normalizeType elems)
+    TContext _ constraints inner -> TContext span0 (map normalizeType constraints) (normalizeType inner)
     TSplice _ body -> TSplice span0 (normalizeExpr body)
-    TAnn ann sub -> TAnn ann (stripTypeParens sub)
+    TAnn ann sub -> TAnn ann (normalizeType sub)
 
-stripTyVarBinderParens :: TyVarBinder -> TyVarBinder
-stripTyVarBinderParens tvb =
+normalizeTyVarBinder :: TyVarBinder -> TyVarBinder
+normalizeTyVarBinder tvb =
   tvb
     { tyVarBinderSpan = span0,
-      tyVarBinderKind = fmap stripTypeParens (tyVarBinderKind tvb)
+      tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
     }
 
 containsKindedInferredBinder :: Type -> Bool


### PR DESCRIPTION
## Summary

- Add new `Aihc.Parser.Parens` module that provides parenthesization as a standalone AST transformation pass
- Simplify `Pretty.hs` by having the `Pretty` instances call `addParens` at entry points and removing all parenthesization logic from the formatting code (~695 lines removed)
- Update `TypeRoundTrip` to use `addTypeParens` for normalization

## Details

The pretty-printer previously interleaved two concerns: deciding where parentheses are needed (context-sensitive precedence, open-endedness, greedy expressions, etc.) and formatting the AST into `Doc`. This made it complex and fragile.

### New module: `Aihc.Parser.Parens`

Exports:
- `addModuleParens :: Module -> Module`
- `addDeclParens :: Decl -> Decl`
- `addExprParens :: Expr -> Expr`
- `addPatternParens :: Pattern -> Pattern`
- `addTypeParens :: Type -> Type`

Key properties:
- **Idempotent:** `addParens . addParens = addParens`
- **Mirrors the old Pretty.hs logic:** ExprCtx, TypeCtx, needsExprParens, needsTypeParens, isBlockExpr, isGreedyExpr, isOpenEnded, etc.

### Simplified `Pretty.hs`

All parenthesization logic has been removed. The formatting functions now simply format the AST nodes, trusting that paren nodes (`EParen`/`PParen`/`TParen`/`CmdPar`) are already in the correct positions.

Removed from Pretty.hs:
- `ExprCtx`, `TypeCtx`, `GuardArrow` types and all context-passing
- `prettyExprPrec`, `prettyExprIn`, `prettyExprApp`, `prettyExprGuarded`, `prettyTypeSigBody`, `prettyIfBranch`, `prettyNegate`, `prettyViewExpr`
- `prettyTypeShared`, `prettyTypePrec`, `prettyTypeIn`, `prettyConstraintType`, `prettyConstraintTypeParens`, `prettyContextItem`
- `prettyPatternAtom`, `prettyLambdaPatternAtom`, `prettyFunctionHeadPatternAtom`, `prettyInfixFunctionHeadPatternAtom`, `prettyPatternAtomStrict`, `prettyPatternInDelimited`
- `flattenApps`, `prettyAppsChain`, `parenthesize`
- `needsExprParens`, `needsTypeParens`, `isBlockExpr`, `isGreedyExpr`, `isOpenEnded`, `endsWithTypeSig`, `startsWithDollar`, `startsWithOverloadedLabel`, `isArrowTailOp`, `guardExprNeedsParens`

## Verification

- `just check` passes (ormolu + hlint + full test suite with 1000 QuickCheck iterations)