### PR TITLE
fix(parser): support parenthesized operators in TH type quotes (''(:>))

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1082,17 +1082,17 @@ thNameQuoteExprParser = thValueNameQuoteParser <|> thTypeNameQuoteParser
 thValueNameQuoteParser :: TokParser Expr
 thValueNameQuoteParser = withSpan $ do
   expectedTok TkTHQuoteTick
-  name <- identifierTextParser <|> parenOperatorNameParser
+  name <- identifierTextParser <|> parenOperatorTextParser
   pure (`ETHNameQuote` name)
 
 thTypeNameQuoteParser :: TokParser Expr
 thTypeNameQuoteParser = withSpan $ do
   expectedTok TkTHTypeQuoteTick
-  name <- identifierTextParser
+  name <- identifierNameParser <|> parenOperatorNameParser
   pure (`ETHTypeNameQuote` name)
 
-parenOperatorNameParser :: TokParser Text
-parenOperatorNameParser = do
+parenOperatorTextParser :: TokParser Text
+parenOperatorTextParser = do
   expectedTok TkSpecialLParen
   op <- tokenSatisfy "operator" $ \tok ->
     case lexTokenKind tok of
@@ -1102,6 +1102,18 @@ parenOperatorNameParser = do
       _ -> Nothing
   expectedTok TkSpecialRParen
   pure ("(" <> op <> ")")
+
+parenOperatorNameParser :: TokParser Name
+parenOperatorNameParser = do
+  expectedTok TkSpecialLParen
+  op <- tokenSatisfy "operator" $ \tok ->
+    case lexTokenKind tok of
+      TkVarSym sym -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym sym))
+      TkConSym sym -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym sym))
+      TkReservedColon -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym ":"))
+      _ -> Nothing
+  expectedTok TkSpecialRParen
+  pure op
 
 quasiQuoteExprParser :: TokParser Expr
 quasiQuoteExprParser =

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -857,7 +857,7 @@ lexTHNameQuote env st
   | otherwise =
       case lexerInput st of
         '\'' :< ('\'' :< (c :< _))
-          | isIdentStart c ->
+          | isIdentStart c || c == '(' ->
               let raw = "''"
                   st' = advanceChars raw st
                in Just (mkToken st st' raw TkTHTypeQuoteTick, st')

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1391,7 +1391,7 @@ prettyExprPrec prec expr =
       | isOperatorToken name -> "'" <> parens (pretty name)
       | otherwise -> "'" <> pretty name
     ETHTypeNameQuote _ name
-      | isOperatorToken name -> "''" <> parens (pretty name)
+      | isOperatorName name -> "''" <> parens (pretty name)
       | otherwise -> "''" <> pretty name
     ETHSplice _ body -> prettySplice "$" body
     ETHTypedSplice _ body -> prettySplice "$$" body
@@ -1688,6 +1688,11 @@ quoted txt = pretty (show (T.unpack txt))
 
 prettyQuasiQuote :: Text -> Text -> Doc ann
 prettyQuasiQuote quoter body = "[" <> pretty quoter <> "|" <> pretty body <> "|]"
+
+isOperatorName :: Name -> Bool
+isOperatorName name =
+  let ty = nameType name
+   in ty == NameVarSym || ty == NameConSym
 
 isOperatorToken :: Text -> Bool
 isOperatorToken tok =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -662,7 +662,7 @@ docExpr expr =
     ETHTypeQuote _ ty -> "ETHTypeQuote" <+> parens (docType ty)
     ETHPatQuote _ pat -> "ETHPatQuote" <+> parens (docPattern pat)
     ETHNameQuote _ name -> "ETHNameQuote" <+> docText name
-    ETHTypeNameQuote _ name -> "ETHTypeNameQuote" <+> docText name
+    ETHTypeNameQuote _ name -> "ETHTypeNameQuote" <+> docName name
     ETHSplice _ body -> "ETHSplice" <+> parens (docExpr body)
     ETHTypedSplice _ body -> "ETHTypedSplice" <+> parens (docExpr body)
     EIf _ cond yes no -> "EIf" <+> parens (docExpr cond) <+> parens (docExpr yes) <+> parens (docExpr no)

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1615,7 +1615,7 @@ data Expr
   | ETHTypeQuote SourceSpan Type -- [t| type |]
   | ETHPatQuote SourceSpan Pattern -- [p| pat |]
   | ETHNameQuote SourceSpan Text -- 'name
-  | ETHTypeNameQuote SourceSpan Text -- ''Name
+  | ETHTypeNameQuote SourceSpan Name -- ''Name
   | -- Template Haskell splices
     ETHSplice SourceSpan Expr
   | -- \$expr or $(expr)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-tick-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-tick-operator.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="TemplateHaskell quote tick for type operator not handled" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE DataKinds #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_paren_op.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_paren_op.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail TH quote tick with parenthesized operator -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -94,7 +94,7 @@ genExprSizedWith allowTHQuotes n
             ETHPatQuote span0 <$> genPattern (n - 1),
             ETHTypeQuote span0 <$> genTypeWith False (n - 1),
             ETHNameQuote span0 <$> genNameQuoteIdent,
-            ETHTypeNameQuote span0 <$> genConName
+            ETHTypeNameQuote span0 <$> genTypeNameQuote
           ]
       | otherwise =
           []
@@ -289,6 +289,16 @@ isValidGeneratedOperator candidate =
 -- | Generate a data constructor name
 genConName :: Gen Text
 genConName = genConIdent
+
+-- | Generate a type name for TH type quotes (''Name).
+-- Can produce either a constructor name (e.g., ''Maybe) or an operator name (e.g., ''(:>)).
+genTypeNameQuote :: Gen Name
+genTypeNameQuote =
+  oneof
+    [ qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent,
+      -- Generate operator name for type quotes (use NameVarSym to match lexer behavior)
+      qualifyName Nothing . mkUnqualifiedName NameVarSym <$> genOperator
+    ]
 
 genVarName :: Gen Name
 genVarName = qualifyName <$> genOptionalQualifier <*> (mkUnqualifiedName NameVarId <$> genIdent)


### PR DESCRIPTION
## Summary

Changed `ETHTypeNameQuote` AST field from `Text` to `Name` and fixed Template Haskell type quotes for parenthesized operators like `''(:>)` not being parsed, generated, or pretty-printed correctly.

## AST Change

```haskell
-- Before:
ETHTypeNameQuote SourceSpan Text  -- ''Name

-- After:
ETHTypeNameQuote SourceSpan Name  -- ''Name
```

Example: `''(:>)` now parses to:
```haskell
ETHTypeNameQuote (Name Nothing NameConSym ":>")
```

## Changes

### Lexer (`Lex.hs`)
- Updated `lexTHNameQuote` to recognize `''(` as `TkTHTypeQuoteTick` (previously only matched `''` followed by identifier start characters)

### Parser (`Expr.hs`)
- Updated `thTypeNameQuoteParser` to accept parenthesized operators via `parenOperatorNameParser`
- Changed from `identifierTextParser` to `identifierNameParser` to produce `Name` instead of `Text`
- Added `parenOperatorNameParser` that produces `Name` (preserves VarSym/ConSym from lexer)
- Kept `parenOperatorTextParser` for `ETHNameQuote` (which remains `Text`)

### Generator (`Arb/Expr.hs`)
- Updated `genTypeNameQuote` to produce `Name` instead of `Text`
- Uses `NameVarSym` for operators to match lexer behavior and ensure roundtrip

### Pretty Printer (`Pretty.hs`)
- Added `isOperatorName :: Name -> Bool` helper to check if a Name is an operator
- Updated `ETHTypeNameQuote` pretty-printing to use `isOperatorName`

### Shorthand (`Shorthand.hs`)
- Updated `ETHTypeNameQuote` to use `docName` instead of `docText`

### Tests
- Promoted two oracle tests from `xfail` to `pass`:
  - `TemplateHaskell/th-quote-tick-operator`
  - `TemplateHaskellQuotes/thq_paren_op`

## Testing
- All 849 oracle tests pass
- All QuickCheck property tests pass
- `just check` passes (ormolu, hlint, full test suite)