### PR TITLE
feat(parser): add support for lazy field annotations (~)

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -910,7 +910,7 @@ typeDataConDeclParser = withSpan $ do
   -- Parse arguments (no strictness, no records)
   -- Use typeAtomParser to parse individual type atoms as separate fields,
   -- rather than typeAppParser which would treat them as type application.
-  args <- MP.many $ BangType noSourceSpan NoSourceUnpackedness False <$> typeAtomParser
+  args <- MP.many $ BangType noSourceSpan NoSourceUnpackedness False False <$> typeAtomParser
   pure $ \span' -> PrefixCon span' [] context conName args
 
 -- | Parse GADT-style constructors for type data (after `where`)
@@ -954,7 +954,7 @@ gadtTypeDataBodyParser = do
   case allTypes of
     [resultTy] -> pure (GadtPrefixBody [] resultTy)
     _ ->
-      let argTypes = map (BangType noSourceSpan NoSourceUnpackedness False) (init allTypes)
+      let argTypes = map (BangType noSourceSpan NoSourceUnpackedness False False) (init allTypes)
           resultTy = last allTypes
        in pure (GadtPrefixBody argTypes resultTy)
 
@@ -1088,12 +1088,14 @@ gadtBangTypeParser :: TokParser BangType
 gadtBangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+  lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- typeInfixParser
   pure $ \span' ->
     BangType
       { bangSpan = span',
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
+        bangLazy = lazy,
         bangType = ty
       }
 
@@ -1317,12 +1319,14 @@ infixConstructorArgParser = MP.try $ do
   withSpan $ do
     unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
     strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+    lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
     ty <- typeAppParser
     pure $ \span' ->
       BangType
         { bangSpan = span',
           bangSourceUnpackedness = unpackedness,
           bangStrict = strict,
+          bangLazy = lazy,
           bangType = ty
         }
 
@@ -1337,12 +1341,14 @@ bangTypeParser :: TokParser BangType
 bangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+  lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- typeAtomParser
   pure $ \span' ->
     BangType
       { bangSpan = span',
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
+        bangLazy = lazy,
         bangType = ty
       }
 
@@ -1350,12 +1356,14 @@ recordFieldBangTypeParser :: TokParser BangType
 recordFieldBangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+  lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- constructorFieldTypeParser
   pure $ \span' ->
     BangType
       { bangSpan = span',
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
+        bangLazy = lazy,
         bangType = ty
       }
 

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -868,18 +868,20 @@ dataConQualifierPrefix forallVars constraints = forallPrefix forallVars <> conte
 -- foralls, and contexts need parentheses before -> in GADT syntax.
 prettyBangType :: BangType -> Doc ann
 prettyBangType bt =
-  hsep (prettySourceUnpackedness (bangSourceUnpackedness bt) <> [strictDoc])
+  hsep (prettySourceUnpackedness (bangSourceUnpackedness bt) <> [strictOrLazyDoc])
   where
-    strictDoc
+    strictOrLazyDoc
       | bangStrict bt = "!" <> prettyTypeIn CtxTypeAtom (bangType bt)
+      | bangLazy bt = "~" <> prettyTypeIn CtxTypeAtom (bangType bt)
       | otherwise = prettyTypeIn CtxTypeFunArg (bangType bt)
 
 prettyRecordFieldBangType :: BangType -> Doc ann
 prettyRecordFieldBangType bt =
-  hsep (prettySourceUnpackedness (bangSourceUnpackedness bt) <> [strictDoc])
+  hsep (prettySourceUnpackedness (bangSourceUnpackedness bt) <> [strictOrLazyDoc])
   where
-    strictDoc
+    strictOrLazyDoc
       | bangStrict bt = "!" <> prettyType (bangType bt)
+      | bangLazy bt = "~" <> prettyType (bangType bt)
       | otherwise = prettyType (bangType bt)
 
 -- | Pretty print a BangType as an atom (e.g., for infix data constructors).

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -358,6 +358,7 @@ docBangType bt =
     fields =
       sourceUnpackednessField (bangSourceUnpackedness bt)
         <> boolField "strict" (bangStrict bt)
+        <> boolField "lazy" (bangLazy bt)
         <> [field "type" (docType (bangType bt))]
 
 sourceUnpackednessField :: SourceUnpackedness -> [Doc ann]

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1353,6 +1353,7 @@ data BangType = BangType
   { bangSpan :: SourceSpan,
     bangSourceUnpackedness :: SourceUnpackedness,
     bangStrict :: Bool,
+    bangLazy :: Bool,
     bangType :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/StrictData/lazy-field-annotation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/StrictData/lazy-field-annotation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="lazy field annotation in data constructor not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE StrictData #-}
 
 module LazyFieldAnnotation where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -23,6 +23,10 @@ import Test.Properties.Arb.Pattern (canonicalPatternAtom, genPattern)
 import Test.Properties.Arb.Type (canonicalFunLeft, canonicalTopLevelType, genType)
 import Test.QuickCheck
 
+-- | Annotation choices for BangType
+data FieldAnnotation = NoAnnotation | StrictAnnotation | LazyAnnotation
+  deriving (Eq, Ord, Enum, Bounded)
+
 instance Arbitrary Decl where
   arbitrary = genDecl
   shrink = shrinkDecl
@@ -210,6 +214,7 @@ genTypeDataCons = do
       pure $ PrefixCon span0 [] [] conName fields
 
 -- | Generate a BangType that is never strict (for type data constructors).
+-- Type data constructors don't support strictness or lazy annotations.
 genNonStrictBangType :: Gen BangType
 genNonStrictBangType = do
   ty <- genSimpleType
@@ -218,6 +223,7 @@ genNonStrictBangType = do
       { bangSpan = span0,
         bangSourceUnpackedness = NoSourceUnpackedness,
         bangStrict = False,
+        bangLazy = False,
         bangType = ty
       }
 
@@ -316,22 +322,58 @@ genGadtPrefixBody = do
 -- | Generate a BangType for GADT prefix body arg position.
 -- Uses the full type generator with canonicalFunLeft applied, since the parser
 -- uses typeInfixParser (which cannot parse bare forall/->/(=>) without parens).
+-- Does not generate lazy/strict annotations on kind-like types (TStar, etc.) since
+-- GHC rejects those (e.g., ~* or !* are treated as operators).
 genGadtBangType :: Gen BangType
 genGadtBangType = do
   ty <- canonicalFunLeft . canonicalTopLevelType <$> sized (genType . min 6)
-  pure $ BangType span0 NoSourceUnpackedness False ty
+  -- Only generate lazy/strict annotations on non-kind types
+  let canAnnotate = case ty of
+        TStar {} -> False
+        TKindSig {} -> False
+        _ -> True
+  annotation <- if canAnnotate then elements [NoAnnotation, StrictAnnotation, LazyAnnotation] else pure NoAnnotation
+  case annotation of
+    NoAnnotation -> pure $ BangType span0 NoSourceUnpackedness False False ty
+    StrictAnnotation -> pure $ BangType span0 NoSourceUnpackedness True False ty
+    LazyAnnotation -> pure $ BangType span0 NoSourceUnpackedness False True ty
 
 -- | Generate a BangType without function types at the top level.
+-- Does not generate lazy/strict annotations on kind-like types (TStar, etc.) since
+-- GHC rejects those (e.g., ~* or !* are treated as operators).
 genSimpleBangTypeWithoutFun :: Gen BangType
 genSimpleBangTypeWithoutFun = do
   ty <- genSimpleTypeWithoutFun
-  pure $
-    BangType
-      { bangSpan = span0,
-        bangSourceUnpackedness = NoSourceUnpackedness,
-        bangStrict = False,
-        bangType = ty
-      }
+  -- genSimpleTypeWithoutFun only generates TVar and TCon, which are safe for annotations
+  annotation <- elements [NoAnnotation, StrictAnnotation, LazyAnnotation]
+  case annotation of
+    NoAnnotation ->
+      pure $
+        BangType
+          { bangSpan = span0,
+            bangSourceUnpackedness = NoSourceUnpackedness,
+            bangStrict = False,
+            bangLazy = False,
+            bangType = ty
+          }
+    StrictAnnotation ->
+      pure $
+        BangType
+          { bangSpan = span0,
+            bangSourceUnpackedness = NoSourceUnpackedness,
+            bangStrict = True,
+            bangLazy = False,
+            bangType = ty
+          }
+    LazyAnnotation ->
+      pure $
+        BangType
+          { bangSpan = span0,
+            bangSourceUnpackedness = NoSourceUnpackedness,
+            bangStrict = False,
+            bangLazy = True,
+            bangType = ty
+          }
 
 -- | Generate a simple type without function types at the top level.
 genSimpleTypeWithoutFun :: Gen Type
@@ -354,19 +396,41 @@ genGadtFieldDecl :: Gen FieldDecl
 genGadtFieldDecl = do
   fieldName <- mkUnqualifiedName NameVarId <$> genIdent
   ty <- canonicalTopLevelType <$> sized (genType . min 6)
-  pure $ FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False ty)
+  pure $ FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False False ty)
 
 genSimpleBangType :: Gen BangType
 genSimpleBangType = do
   ty <- genSimpleType
-  strict <- elements [False, False, False, True]
-  pure $
-    BangType
-      { bangSpan = span0,
-        bangSourceUnpackedness = NoSourceUnpackedness,
-        bangStrict = strict,
-        bangType = ty
-      }
+  -- genSimpleType only generates TVar and TCon, which are safe for lazy annotations
+  annotation <- elements [NoAnnotation, StrictAnnotation, LazyAnnotation]
+  case annotation of
+    NoAnnotation ->
+      pure $
+        BangType
+          { bangSpan = span0,
+            bangSourceUnpackedness = NoSourceUnpackedness,
+            bangStrict = False,
+            bangLazy = False,
+            bangType = ty
+          }
+    StrictAnnotation ->
+      pure $
+        BangType
+          { bangSpan = span0,
+            bangSourceUnpackedness = NoSourceUnpackedness,
+            bangStrict = True,
+            bangLazy = False,
+            bangType = ty
+          }
+    LazyAnnotation ->
+      pure $
+        BangType
+          { bangSpan = span0,
+            bangSourceUnpackedness = NoSourceUnpackedness,
+            bangStrict = False,
+            bangLazy = True,
+            bangType = ty
+          }
 
 genDeclNewtype :: Gen Decl
 genDeclNewtype = do
@@ -398,14 +462,14 @@ genNewtypePrefixCon :: Gen DataConDecl
 genNewtypePrefixCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
   ty <- genSimpleType
-  pure $ PrefixCon span0 [] [] conName [BangType span0 NoSourceUnpackedness False ty]
+  pure $ PrefixCon span0 [] [] conName [BangType span0 NoSourceUnpackedness False False ty]
 
 genNewtypeRecordCon :: Gen DataConDecl
 genNewtypeRecordCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
   fieldName <- genVarBinderName
   ty <- genSimpleType
-  pure $ RecordCon span0 [] [] conName [FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False ty)]
+  pure $ RecordCon span0 [] [] conName [FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False False ty)]
 
 genDeclClass :: Gen Decl
 genDeclClass = do

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -353,6 +353,7 @@ normalizeBangType bt =
     { bangSpan = span0,
       bangSourceUnpackedness = bangSourceUnpackedness bt,
       bangStrict = bangStrict bt,
+      bangLazy = bangLazy bt,
       bangType = normalizeType (bangType bt)
     }
 


### PR DESCRIPTION
## Summary

Adds support for lazy field annotations (`~`) in data constructor fields, which are used with `StrictData` to opt out of strictness on individual fields.

## Changes

- **Syntax**: Added `bangLazy :: Bool` field to `BangType`
- **Parser**: Updated `bangTypeParser`, `recordFieldBangTypeParser`, `gadtBangTypeParser`, and `infixConstructorArgParser` to parse `~` annotations
- **Pretty**: Updated `prettyBangType` and `prettyRecordFieldBangType` to render `~Type`
- **Shorthand**: Updated `docBangType` to display the `lazy` field
- **QuickCheck**: Updated all `BangType` generators to produce lazy annotations, enabling property-based testing to find this feature
- **Oracle**: `StrictData/lazy-field-annotation` moved from `xfail` to `pass`

## Example

```haskell
{-# LANGUAGE StrictData #-}
data MapF k v r = TipF | BinF Int k ~v r r
```

## Progress

816 pass, 19 xfail, 0 xpass, 0 fail (97.72% completion)