### PR TITLE
fix(parser): stop context lookahead at keyword boundaries in startsWithContextType

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -746,6 +746,12 @@ startsWithContextType = MP.lookAhead (go [])
         TkSpecialUnboxedLParen -> go [TkSpecialUnboxedRParen]
         TkSpecialLBracket -> go [TkSpecialRBracket]
         TkSpecialLBrace -> go [TkSpecialRBrace]
+        -- Keywords that cannot appear inside a type expression: stop scanning.
+        TkKeywordInstance -> pure False
+        TkKeywordWhere -> pure False
+        TkKeywordClass -> pure False
+        TkKeywordData -> pure False
+        TkKeywordNewtype -> pure False
         _ -> go []
     go stack@(expectedClose : rest) = do
       tok <- anySingle

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/standalone-via-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/standalone-via-instance.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="standalone deriving via with context constraint not parsed correctly" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DerivingVia #-}
 
 module StandaloneViaInstance where


### PR DESCRIPTION
## Root Cause

When parsing `deriving via <type> instance <ctx> => <cls>`, the `startsWithContextType` lookahead in `Common.hs` scanned the token stream looking for `=>` at bracket depth 0. The problem: when it encountered `instance` (a keyword that **cannot** appear inside a type expression), it fell through to the `_ -> go []` wildcard case and kept scanning. It then found the `=>` from the instance's own context constraint and incorrectly concluded the via type was a context type. This caused the via type parser to fail.

## Solution

Add explicit `pure False` branches for `TkKeywordInstance`, `TkKeywordWhere`, `TkKeywordClass`, `TkKeywordData`, and `TkKeywordNewtype` in the depth-0 branch of the scanner. These keywords can never appear inside a type expression, so encountering one is a clear signal that there is no context type at the current position.

Two other approaches were considered:
1. **Change `derivingViaTypeParser` to use a restricted parser** — avoids touching the lookahead but would require duplicating type-parser logic or adding a new mode.
2. **Use `MP.try` with a bounded token count** — fragile and hard to maintain.

The chosen approach is minimal, correct, and generalizes: any caller of `startsWithContextType` benefits from the fix.

## Changes

- `components/aihc-parser/src/Aihc/Parser/Internal/Common.hs`: add keyword stop cases in `startsWithContextType`
- `components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/standalone-via-instance.hs`: promote from `xfail` to `pass`

## Testing

All existing tests pass. The previously xfail oracle test `DerivingVia/standalone-via-instance` now passes.

## Follow-up

No additional refactoring needed. The fix is self-contained.