### PR TITLE
fix(lexer): stop gathering qualified identifiers when prefix is lowercase

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -307,7 +307,8 @@ lexIdentifier env st =
       case chars of
         '.' :< dotRest@(c' :< more)
           | isIdentStart c',
-            not (T.isSuffixOf "#" acc) ->
+            not (T.isSuffixOf "#" acc),
+            isConIdStart (T.head acc) ->
               let (seg, rest) = consumeIdentTail hasMH more
                   segWithHead = T.take (1 + T.length seg) dotRest
                in gatherQualified hasMH (acc <> "." <> segWithHead) rest

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-no-space-after-dot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-no-space-after-dot.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="lexer does not handle 'forall a.Floating' without space after dot" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Haskell2010, ExplicitForAll, RankNTypes #-}
 module ForallNoSpaceAfterDot where
 


### PR DESCRIPTION
## Root Cause

`gatherQualified` in `Lex.hs` greedily accumulated dot-separated identifiers to build qualified names (e.g. `Data.Map.lookup`). It only checked that the character *after* the dot was a valid identifier start (`isIdentStart`), but never checked that the accumulated prefix was a valid module name.

In Haskell, module names always start with an uppercase letter. So `a.Floating` can never be a qualified name — `a` is a variable, not a module. But the lexer was greedily consuming it as `TkQConId "a" "Floating"`.

The forall type parser at `Type.hs:54` expects a standalone `TkVarSym "."` token after the binders, so it failed when it received `TkQConId "a" "Floating"` instead.

## Solution

Add `isConIdStart (T.head acc)` to the guard in `gatherQualified`. This ensures the lexer only extends an identifier with dot-qualified segments when the accumulated prefix starts with an uppercase letter (i.e., is a valid module name).

This is a one-line fix that precisely targets the root cause without affecting any other lexer behavior.

## Changes

- `components/aihc-parser/src/Aihc/Parser/Lex.hs`: Add `isConIdStart (T.head acc)` guard to `gatherQualified`
- `components/aihc-parser/test/Test/Fixtures/oracle/ExplicitForAll/forall-no-space-after-dot.hs`: Promote from `xfail` to `pass`

## Testing

All 1348 tests pass (no regressions).

## Follow-up

The `gatherQualified` function could additionally validate that each intermediate segment (not just the first) starts with uppercase, preventing edge cases like `Data.map.lookup` being accumulated. However, that would be a pre-existing edge case that produces invalid Haskell anyway and the parser would reject it. Filed separately if needed.