### PR TITLE
feat(parser): support mixed explicit members with double-dot in export/import lists

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
@@ -72,20 +72,31 @@ exportNameParser mWarning = do
   members <- MP.optional exportMembersParser
   pure $ \span' ->
     case members of
-      Just Nothing -> ExportAll span' mWarning namespace name
-      Just (Just names) -> ExportWith span' mWarning namespace name names
+      Just MembersAll -> ExportAll span' mWarning namespace name
+      Just (MembersList names) -> ExportWith span' mWarning namespace name names
+      Just (MembersListAll names) -> ExportWithAll span' mWarning namespace name names
       Nothing
         | namespace == Just IEEntityNamespaceType || isTypeName name ->
             ExportAbs span' mWarning namespace name
         | otherwise ->
             ExportVar span' mWarning namespace name
 
-exportMembersParser :: TokParser (Maybe [IEBundledMember])
+data MembersResult
+  = MembersAll
+  | MembersList [IEBundledMember]
+  | MembersListAll [IEBundledMember]
+
+exportMembersParser :: TokParser MembersResult
 exportMembersParser =
   parens $
-    (expectedTok TkReservedDotDot >> pure Nothing)
-      <|> (Just <$> (memberNameParser `MP.sepEndBy` expectedTok TkSpecialComma))
+    (expectedTok TkReservedDotDot >> pure MembersAll)
+      <|> parseMemberList
   where
+    parseMemberList = do
+      members <- memberNameParser `MP.sepEndBy` expectedTok TkSpecialComma
+      hasTrailingDotDot <-
+        MP.option False (expectedTok TkReservedDotDot >> MP.optional (expectedTok TkSpecialComma) >> pure True)
+      pure $ if hasTrailingDotDot then MembersListAll members else MembersList members
     memberNameParser = do
       namespace <- MP.optional bundledNamespaceParser
       name <- identifierNameParser <|> parens operatorNameParser
@@ -178,8 +189,9 @@ importItemParser = withSpan $ do
   let effectiveNamespace = namespace
   pure $ \span' ->
     case members of
-      Just Nothing -> ImportItemAll span' effectiveNamespace itemName
-      Just (Just names) -> ImportItemWith span' effectiveNamespace itemName names
+      Just MembersAll -> ImportItemAll span' effectiveNamespace itemName
+      Just (MembersList names) -> ImportItemWith span' effectiveNamespace itemName names
+      Just (MembersListAll names) -> ImportItemAllWith span' effectiveNamespace itemName names
       Nothing
         | effectiveNamespace == Just IEEntityNamespaceType || isTypeName (qualifyName Nothing itemName) -> ImportItemAbs span' effectiveNamespace itemName
         | otherwise -> ImportItemVar span' effectiveNamespace itemName

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -116,6 +116,10 @@ prettyExportSpec spec =
       prettyExportWarning
         mWarning
         (prettyNamespacePrefix namespace <> prettyName name <> parens (hsep (punctuate comma (map prettyExportMember members))))
+    ExportWithAll _ mWarning namespace name members ->
+      prettyExportWarning
+        mWarning
+        (prettyNamespacePrefix namespace <> prettyName name <> parens (hsep (punctuate comma (map prettyExportMember members <> [".."]))))
 
 prettyExportWarning :: Maybe WarningText -> Doc ann -> Doc ann
 prettyExportWarning mWarning doc =
@@ -175,6 +179,8 @@ prettyImportItem item =
     ImportItemAll _ namespace name -> prettyNamespacePrefix namespace <> prettyConstructorUName name <> "(..)"
     ImportItemWith _ namespace name members ->
       prettyNamespacePrefix namespace <> prettyConstructorUName name <> parens (hsep (punctuate comma (map prettyExportMember members)))
+    ImportItemAllWith _ namespace name members ->
+      prettyNamespacePrefix namespace <> prettyConstructorUName name <> parens (hsep (punctuate comma (map prettyExportMember members <> [".."])))
 
 prettyExportMember :: IEBundledMember -> Doc ann
 prettyExportMember (IEBundledMember namespace name) =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -124,6 +124,13 @@ docExportSpec spec =
           optionalField "warningText" docWarningText mWarning
             <> optionalField "namespace" docIENamespace mNamespace
             <> [field "name" (docName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
+    ExportWithAll _ mWarning mNamespace name members ->
+      "ExportWithAll" <> braces (hsep (punctuate comma fields))
+      where
+        fields =
+          optionalField "warningText" docWarningText mWarning
+            <> optionalField "namespace" docIENamespace mNamespace
+            <> [field "name" (docName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
 
 docImportDecl :: ImportDecl -> Doc ann
 docImportDecl decl =
@@ -165,6 +172,12 @@ docImportItem item =
       "ImportItemAll" <> braces (hsep (punctuate comma (optionalField "namespace" docIENamespace mNamespace <> [field "name" (docUnqualifiedName name)])))
     ImportItemWith _ mNamespace name members ->
       "ImportItemWith" <> braces (hsep (punctuate comma fields))
+      where
+        fields =
+          optionalField "namespace" docIENamespace mNamespace
+            <> [field "name" (docUnqualifiedName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
+    ImportItemAllWith _ mNamespace name members ->
+      "ImportItemAllWith" <> braces (hsep (punctuate comma fields))
       where
         fields =
           optionalField "namespace" docIENamespace mNamespace

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -825,6 +825,7 @@ data ExportSpec
   | ExportAbs SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name
   | ExportAll SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name
   | ExportWith SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name [IEBundledMember]
+  | ExportWithAll SourceSpan (Maybe WarningText) (Maybe IEEntityNamespace) Name [IEBundledMember]
   deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan ExportSpec where
@@ -835,6 +836,7 @@ instance HasSourceSpan ExportSpec where
       ExportAbs span' _ _ _ -> span'
       ExportAll span' _ _ _ -> span'
       ExportWith span' _ _ _ _ -> span'
+      ExportWithAll span' _ _ _ _ -> span'
 
 data ImportDecl = ImportDecl
   { importDeclSpan :: SourceSpan,
@@ -873,6 +875,7 @@ data ImportItem
   | ImportItemAbs SourceSpan (Maybe IEEntityNamespace) UnqualifiedName
   | ImportItemAll SourceSpan (Maybe IEEntityNamespace) UnqualifiedName
   | ImportItemWith SourceSpan (Maybe IEEntityNamespace) UnqualifiedName [IEBundledMember]
+  | ImportItemAllWith SourceSpan (Maybe IEEntityNamespace) UnqualifiedName [IEBundledMember]
   deriving (Data, Eq, Show, Generic, NFData)
 
 data Decl

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-double-dot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-export-double-dot.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail double-dot in export list with pattern synonyms -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 module PatternSynonymsExportDoubleDot
   ( X

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -166,7 +166,8 @@ instance Arbitrary ExportSpec where
         ExportVar span0 <$> arbitrary <*> pure Nothing <*> genExportVarName,
         ExportAbs span0 <$> arbitrary <*> arbitrary <*> genExportTypeName,
         ExportAll span0 <$> arbitrary <*> arbitrary <*> genExportTypeName,
-        ExportWith span0 <$> arbitrary <*> arbitrary <*> genExportTypeName <*> genExportMembers
+        ExportWith span0 <$> arbitrary <*> arbitrary <*> genExportTypeName <*> genExportMembers,
+        ExportWithAll span0 <$> arbitrary <*> arbitrary <*> genExportTypeName <*> genExportMembers
       ]
 
   shrink spec =
@@ -188,6 +189,11 @@ instance Arbitrary ExportSpec where
           <> [ExportWith span0 Nothing namespace name members | Just _ <- [mWarning]]
           <> [ExportWith span0 mWarning namespace shrunk members | shrunk <- shrinkExportTypeName name]
           <> [ExportWith span0 mWarning namespace name shrunk | shrunk <- shrinkList shrink members, not (null shrunk)]
+      ExportWithAll _ mWarning namespace name members ->
+        [ExportWith span0 mWarning namespace name members]
+          <> [ExportWithAll span0 Nothing namespace name members | Just _ <- [mWarning]]
+          <> [ExportWithAll span0 mWarning namespace shrunk members | shrunk <- shrinkExportTypeName name]
+          <> [ExportWithAll span0 mWarning namespace name shrunk | shrunk <- shrinkList shrink members]
 
 instance Arbitrary IEEntityNamespace where
   arbitrary = elements [IEEntityNamespaceType, IEEntityNamespacePattern, IEEntityNamespaceData]
@@ -221,7 +227,8 @@ instance Arbitrary ImportItem where
       [ ImportItemVar span0 Nothing <$> genUnqualifiedVarName,
         ImportItemAbs span0 <$> genTypeNamespace <*> genTypeName,
         ImportItemAll span0 <$> genTypeNamespace <*> genTypeName,
-        ImportItemWith span0 <$> genBundledNamespace <*> genTypeName <*> genExportMembers
+        ImportItemWith span0 <$> genBundledNamespace <*> genTypeName <*> genExportMembers,
+        ImportItemAllWith span0 <$> genBundledNamespace <*> genTypeName <*> genExportMembers
       ]
 
   shrink item =
@@ -237,6 +244,10 @@ instance Arbitrary ImportItem where
         [ImportItemAbs span0 namespace name | not (null members)]
           <> [ImportItemWith span0 namespace shrunk members | shrunk <- shrinkTypeName name]
           <> [ImportItemWith span0 namespace name shrunk | shrunk <- shrinkList shrink members, not (null shrunk)]
+      ImportItemAllWith _ namespace name members ->
+        [ImportItemWith span0 namespace name members]
+          <> [ImportItemAllWith span0 namespace shrunk members | shrunk <- shrinkTypeName name]
+          <> [ImportItemAllWith span0 namespace name shrunk | shrunk <- shrinkList shrink members]
 
 instance Arbitrary IEBundledMember where
   arbitrary = do

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -61,6 +61,7 @@ normalizeExportSpec spec =
     ExportAbs _ mWarning namespace name -> ExportAbs span0 (normalizeWarningText <$> mWarning) namespace name
     ExportAll _ mWarning namespace name -> ExportAll span0 (normalizeWarningText <$> mWarning) namespace name
     ExportWith _ mWarning namespace name members -> ExportWith span0 (normalizeWarningText <$> mWarning) namespace name (map normalizeExportMember members)
+    ExportWithAll _ mWarning namespace name members -> ExportWithAll span0 (normalizeWarningText <$> mWarning) namespace name (map normalizeExportMember members)
 
 normalizeExportMember :: IEBundledMember -> IEBundledMember
 normalizeExportMember (IEBundledMember namespace name) = IEBundledMember namespace name
@@ -101,3 +102,4 @@ normalizeImportItem item =
     ImportItemAbs _ namespace name -> ImportItemAbs span0 namespace name
     ImportItemAll _ namespace name -> ImportItemAll span0 namespace name
     ImportItemWith _ namespace name members -> ImportItemWith span0 namespace name (map normalizeExportMember members)
+    ImportItemAllWith _ namespace name members -> ImportItemAllWith span0 namespace name (map normalizeExportMember members)

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -661,6 +661,7 @@ allowedNames items =
       ImportItemAbs _ _ itemName -> [renderUnqualifiedName itemName]
       ImportItemAll _ _ itemName -> [renderUnqualifiedName itemName]
       ImportItemWith _ _ itemName _ -> [renderUnqualifiedName itemName]
+      ImportItemAllWith _ _ itemName _ -> [renderUnqualifiedName itemName]
   ]
 
 resolveTermName :: Scope -> Name -> ResolvedName


### PR DESCRIPTION
## Root Cause

The `exportMembersParser` function in `Import.hs` only handled two cases for bundled member lists:
- `(..)` — wildcard, all constructors → `ExportAll`
- `(A, B, ...)` — explicit member list → `ExportWith`

GHC supports a third form: `X(A, B, ..)` where explicit members are combined with a trailing `..`. The parser had no representation for this and would fail to parse it.

## Solution

Added two new AST constructors and updated the parser to handle the trailing `..` case:

- **`ExportWithAll`** (`ExportSpec`) — export with explicit members + wildcard: `X(A, B, ..)`
- **`ImportItemAllWith`** (`ImportItem`) — import with explicit members + wildcard: `X(A, B, ..)`

The `exportMembersParser` now uses a local `MembersResult` sum type (`MembersAll` / `MembersList` / `MembersListAll`) instead of `Maybe [IEBundledMember]`, which cleanly distinguishes all three cases.

## Changes

- `Syntax.hs`: New `ExportWithAll` and `ImportItemAllWith` constructors
- `Import.hs`: `exportMembersParser` updated to detect trailing `..`; local `MembersResult` type
- `Pretty.hs`: Pretty-print new constructors as `name(A, B, ..)`
- `Shorthand.hs`: Doc rendering for new constructors
- `Resolve.hs`: Handle `ImportItemAllWith` in `allowedNames`
- `ModuleRoundTrip.hs` / `Arb/Module.hs`: Normalize and arbitrary instances for new constructors
- Oracle test `pattern-synonyms-export-double-dot.hs`: Promoted from `xfail` to `pass`

## Testing

All 1348 parser tests and 19 resolver tests pass. The previously-failing oracle test now passes.