### PR TITLE
fix(parser): restrict negative literal patterns to numeric literals

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -135,8 +135,13 @@ irrefutablePatternParser = withSpan $ do
 negativeLiteralPatternParser :: TokParser Pattern
 negativeLiteralPatternParser = MP.try $ withSpan $ do
   expectedTok (TkVarSym "-")
-  lit <- literalParser
+  lit <- numericLiteralParser
   pure (`PNegLit` lit)
+
+-- | Parse only numeric literals (integer or float), used for negative literal
+-- patterns where GHC only allows @-@ before numeric literals, not strings or chars.
+numericLiteralParser :: TokParser Literal
+numericLiteralParser = intLiteralParser <|> intBaseLiteralParser <|> floatLiteralParser
 
 wildcardPatternParser :: TokParser Pattern
 wildcardPatternParser = withSpan $ do

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/infix-funlhs-minus-string-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/infix-funlhs-minus-string-pattern.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  M.H - "" = x
+ast: Module {decls = [DeclValue (FunctionBind "-" [Match {headForm = Infix, pats = [PCon "M.H" [], PLit (LitString "")], rhs = UnguardedRhs (EVar "x")}])]}
+status: pass


### PR DESCRIPTION
## Summary

- **Fix:** `negativeLiteralPatternParser` was using the general `literalParser` (which accepts strings and chars), causing it to greedily consume `- ""` as a negative string literal pattern inside constructor application. This prevented infix function bindings like `M.H - "" = x` from being parsed.
- **Change:** Introduce `numericLiteralParser` (int/float only) and use it in `negativeLiteralPatternParser`, matching GHC's behavior where `-` in patterns only negates numeric literals.

## Reproduction

```
just replay "(SMGen 2687885358196735454 9424186880824938439,66)"
```

Generated input: `M.H - "" = ''(⁍⁂╢)`

The pattern parser consumed `M.H - ""` as `PCon "M.H" [PNegLit (LitString "")]` instead of leaving `-` for the infix function head parser.

## Verification

- `just check` passes (ormolu, hlint, full test suite with 1000 QuickCheck tests)
- GHC rejects `-""` and `-'a'` as patterns, confirming only numeric negation is valid