### PR TITLE
fix(parser): handle parenthesized arrow in TH type quotes

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1111,6 +1111,7 @@ parenOperatorNameParser = do
       TkVarSym sym -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym sym))
       TkConSym sym -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym sym))
       TkReservedColon -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym ":"))
+      TkReservedRightArrow -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym "->"))
       _ -> Nothing
   expectedTok TkSpecialRParen
   pure op

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-promoted-arrow.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-quote-promoted-arrow.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="TemplateHaskell type quote with parenthesized arrow ''(->) not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TemplateHaskell #-}
 
 module THQuotePromotedArrow where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_arrow_type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_arrow_type.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail TemplateHaskell type quote with parenthesized arrow ''(->) not parsed -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE LambdaCase, TemplateHaskellQuotes #-}
 
 module THQuoteArrowType where


### PR DESCRIPTION
## Root Cause

`parenOperatorNameParser` in `Expr.hs` did not handle `TkReservedRightArrow`, causing `''(->)` to fail parsing in TemplateHaskell type quotes. The type parser (`typeParenOperatorParser` in `Type.hs`) already handled this case correctly; the expression parser was missing it.

## Solution

Added the missing `TkReservedRightArrow` handler to `parenOperatorNameParser`, matching the existing handling in `typeParenOperatorParser`.

## Changes

- **`components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs`** — Added `TkReservedRightArrow` case to `parenOperatorNameParser`
- **`test/Test/Fixtures/oracle/TemplateHaskellQuotes/thq_arrow_type.hs`** — xfail → pass
- **`test/Test/Fixtures/oracle/TemplateHaskell/th-quote-promoted-arrow.hs`** — xfail → pass

## Testing

Both previously-xfail oracle tests now pass. Full test suite (`just check`) passes with no regressions.