### PR TITLE
fix(parser): allow multiple consecutive semicolons in do blocks

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -438,7 +438,10 @@ bracedSemiSep1 :: TokParser a -> TokParser [a]
 bracedSemiSep1 parser =
   braces $ do
     skipSemicolons
-    parser `MP.sepEndBy1` expectedTok TkSpecialSemicolon
+    x <- parser
+    skipSemicolons
+    rest <- MP.many (parser <* skipSemicolons)
+    pure (x : rest)
 
 -- | Zero-or-more variant of 'plainSemiSep1'.
 -- Parses zero or more items separated by semicolons (no surrounding braces).

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-let.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-let.hs
@@ -1,7 +1,7 @@
-{- ORACLE_TEST xfail reason="explicit semicolons followed by let in do notation not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Haskell2010 #-}
 
--- Parser fails on explicit semicolons followed by let in do notation
+-- Explicit semicolons followed by let in do notation
 f = do
   ;let x = 1
   ;x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-mixed.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-mixed.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Haskell2010 #-}
+
+-- Explicit semicolons with different statement types
+f = do
+  ;let x = 1
+  ;y <- return x
+  ;return y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-multiple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/do-semicolon-multiple.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Haskell2010 #-}
+
+-- Multiple explicit semicolons in do notation
+f = do
+  ;;let x = 1
+  ;;x


### PR DESCRIPTION
## Summary

Fixed a parser bug where explicit semicolons at the beginning of a line in do blocks would cause parse failures when followed by `let` statements or other statements.

## Root Cause

When an explicit semicolon `;` appears at the beginning of a line at the same column as the current layout indentation, the layout engine inserts **both**:
1. The explicit semicolon token from the source code
2. A virtual semicolon (because `col == indent` in the `bolLayout` function)

This creates consecutive semicolons (`;;`), which the original `bracedSemiSep1` implementation couldn't handle because it used `MP.sepEndBy1` expecting exactly ONE semicolon between statements.

GHC accepts consecutive semicolons as valid syntax, treating extras as harmless empty statements.

## Solution

Modified `bracedSemiSep1` to use `skipSemicolons` after each parsed statement instead of `MP.sepEndBy1 expectedTok TkSpecialSemicolon`. This allows multiple consecutive semicolons to be absorbed correctly, matching GHC's behavior.

### Changes
- **Fixed** `bracedSemiSep1` in `Common.hs` - now handles consecutive semicolons
- **Updated** `do-semicolon-let.hs` test from `xfail` to `pass`
- **Added** 2 new test cases for edge cases:
  - `do-semicolon-multiple.hs` - Tests `;;` consecutive semicolons
  - `do-semicolon-mixed.hs` - Tests semicolons with mixed statement types

## Progress
- **Before**: 98.45% completion (825 pass, 13 xfail, 1 xpass, 0 fail)
- **After**: 98.59% completion (828 pass, 12 xfail, 0 xpass, 0 fail)
- **Change**: +3 passing tests, -1 xfail, -1 xpass