### PR TITLE
fix(parser): cover pattern binds in decl roundtrips

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -41,7 +41,9 @@ ordinaryDeclParser :: TokParser Decl
 ordinaryDeclParser = do
   (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
   thFullEnabled <- isExtensionEnabled TemplateHaskell
-  let valueOrSpliceParser =
+  let tokKind = lexTokenKind tok
+      nextTokKind = lexTokenKind nextTok
+      valueOrSpliceParser =
         if thFullEnabled
           then MP.try valueDeclParser <|> implicitSpliceDeclParser
           else valueDeclParser
@@ -57,9 +59,9 @@ ordinaryDeclParser = do
         MP.try typeSigDeclParser <|> valueOrSpliceParser
       typeSigOrPatternOrValueOrSpliceParser =
         MP.try typeSigDeclParser <|> patternOrValueOrSpliceParser
-  case lexTokenKind tok of
+  case tokKind of
     TkKeywordData ->
-      case lexTokenKind nextTok of
+      case nextTokKind of
         TkVarFamily -> dataFamilyDeclParser
         TkKeywordInstance -> dataFamilyInstParser
         _ -> dataDeclParser
@@ -72,10 +74,10 @@ ordinaryDeclParser = do
     TkKeywordInfixr -> fixityDeclParser InfixR
     TkKeywordInstance -> instanceDeclParser
     TkKeywordNewtype
-      | lexTokenKind nextTok == TkKeywordInstance -> newtypeFamilyInstParser
+      | nextTokKind == TkKeywordInstance -> newtypeFamilyInstParser
     TkKeywordNewtype -> newtypeDeclParser
     TkKeywordType ->
-      case lexTokenKind nextTok of
+      case nextTokKind of
         TkVarRole -> roleAnnotationDeclParser
         TkVarFamily -> typeFamilyDeclParser
         TkKeywordData -> typeDataDeclParser
@@ -89,33 +91,39 @@ ordinaryDeclParser = do
     TkPrefixBang -> patternOrValueOrSpliceParser
     TkKeywordUnderscore -> typeSigOrPatternOrValueOrSpliceParser
     TkVarId {} ->
-      case lexTokenKind nextTok of
+      case nextTokKind of
         TkReservedDoubleColon -> typeSigOrValueOrSpliceParser
         TkSpecialComma -> typeSigOrValueOrSpliceParser
         TkReservedEquals -> valueOrSpliceParser
         _ -> nonBareVarPatternOrValueOrSpliceParser
-    TkVarSym "-" -> patternOrValueOrSpliceParser
-    TkConId {} -> patternOrValueOrSpliceParser
-    TkQConId {} -> patternOrValueOrSpliceParser
-    TkConSym {} -> patternOrValueOrSpliceParser
-    TkQConSym {} -> patternOrValueOrSpliceParser
-    TkReservedColon -> patternOrValueOrSpliceParser
-    TkInteger {} -> patternOrValueOrSpliceParser
-    TkIntegerHash {} -> patternOrValueOrSpliceParser
-    TkIntegerBase {} -> patternOrValueOrSpliceParser
-    TkIntegerBaseHash {} -> patternOrValueOrSpliceParser
-    TkFloat {} -> patternOrValueOrSpliceParser
-    TkFloatHash {} -> patternOrValueOrSpliceParser
-    TkChar {} -> patternOrValueOrSpliceParser
-    TkCharHash {} -> patternOrValueOrSpliceParser
-    TkString {} -> patternOrValueOrSpliceParser
-    TkStringHash {} -> patternOrValueOrSpliceParser
-    TkQuasiQuote {} -> patternOrValueOrSpliceParser
+    _
+      | startsLikePatternBindHead tokKind -> patternOrValueOrSpliceParser
     TkTHSplice ->
       if thFullEnabled
         then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> spliceDeclParser
         else spliceDeclParser
     _ -> typeSigOrValueOrSpliceParser
+
+startsLikePatternBindHead :: LexTokenKind -> Bool
+startsLikePatternBindHead = \case
+  TkVarSym "-" -> True
+  TkConId {} -> True
+  TkQConId {} -> True
+  TkConSym {} -> True
+  TkQConSym {} -> True
+  TkReservedColon -> True
+  TkInteger {} -> True
+  TkIntegerHash {} -> True
+  TkIntegerBase {} -> True
+  TkIntegerBaseHash {} -> True
+  TkFloat {} -> True
+  TkFloatHash {} -> True
+  TkChar {} -> True
+  TkCharHash {} -> True
+  TkString {} -> True
+  TkStringHash {} -> True
+  TkQuasiQuote {} -> True
+  _ -> False
 
 nonBareVarPatternBindDeclParser :: TokParser Decl
 nonBareVarPatternBindDeclParser = MP.try $ withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -41,6 +41,8 @@ ordinaryDeclParser :: TokParser Decl
 ordinaryDeclParser = do
   (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
   thFullEnabled <- isExtensionEnabled TemplateHaskell
+  startsWithPatternBind <- startsWithTopLevelPatternBind
+  startsWithBareVarPatternBind <- startsWithBareVarPatternBindHead
   let valueOrSpliceParser =
         if thFullEnabled
           then MP.try valueDeclParser <|> implicitSpliceDeclParser
@@ -80,13 +82,69 @@ ordinaryDeclParser = do
     TkKeywordPattern -> patternSynonymParser
     TkSpecialLParen -> typeSigOrPatternOrValueOrSpliceParser
     TkSpecialLBracket -> typeSigOrPatternOrValueOrSpliceParser
+    TkSpecialUnboxedLParen
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkSpecialUnboxedLParen -> valueOrSpliceParser
     TkPrefixTilde -> typeSigOrPatternOrValueOrSpliceParser
+    TkPrefixBang
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkPrefixBang -> valueOrSpliceParser
     TkKeywordUnderscore -> typeSigOrPatternOrValueOrSpliceParser
+    TkVarId {}
+      | startsWithPatternBind && not startsWithBareVarPatternBind -> patternOrSpliceParser
+    TkVarSym "-"
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkConId {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkQConId {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkConSym {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkQConSym {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkReservedColon
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkInteger {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkIntegerHash {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkIntegerBase {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkIntegerBaseHash {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkFloat {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkFloatHash {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkChar {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkCharHash {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkString {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkStringHash {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkQuasiQuote {}
+      | startsWithPatternBind -> patternOrSpliceParser
+    TkTHSplice
+      | startsWithPatternBind -> patternOrSpliceParser
     TkTHSplice ->
       if thFullEnabled
         then MP.try valueDeclParser <|> spliceDeclParser
         else spliceDeclParser
     _ -> typeSigOrValueOrSpliceParser
+
+startsWithTopLevelPatternBind :: TokParser Bool
+startsWithTopLevelPatternBind =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    _ <- patternParser
+    expectedTok TkReservedEquals
+
+startsWithBareVarPatternBindHead :: TokParser Bool
+startsWithBareVarPatternBindHead =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    _ <- identifierTextParser
+    expectedTok TkReservedEquals
 
 -- | Parse a pragma declaration (e.g. {-# INLINE f #-}, {-# SPECIALIZE ... #-})
 pragmaDeclParser :: TokParser Decl

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -84,47 +84,23 @@ ordinaryDeclParser = do
         TkKeywordInstance -> typeFamilyInstParser
         _ -> typeDeclarationParser
     TkKeywordPattern -> patternSynonymParser
-    TkSpecialLParen -> typeSigOrPatternOrValueOrSpliceParser
-    TkSpecialLBracket -> typeSigOrPatternOrValueOrSpliceParser
-    TkSpecialUnboxedLParen -> patternOrValueOrSpliceParser
-    TkPrefixTilde -> typeSigOrPatternOrValueOrSpliceParser
-    TkPrefixBang -> patternOrValueOrSpliceParser
-    TkKeywordUnderscore -> typeSigOrPatternOrValueOrSpliceParser
     TkVarId {} ->
       case nextTokKind of
         TkReservedDoubleColon -> typeSigOrValueOrSpliceParser
         TkSpecialComma -> typeSigOrValueOrSpliceParser
         TkReservedEquals -> valueOrSpliceParser
         _ -> nonBareVarPatternOrValueOrSpliceParser
-    _
-      | startsLikePatternBindHead tokKind -> patternOrValueOrSpliceParser
     TkTHSplice ->
       if thFullEnabled
         then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> spliceDeclParser
         else spliceDeclParser
-    _ -> typeSigOrValueOrSpliceParser
+    _ -> typeSigOrPatternOrValueOrSpliceParser
 
-startsLikePatternBindHead :: LexTokenKind -> Bool
-startsLikePatternBindHead = \case
-  TkVarSym "-" -> True
-  TkConId {} -> True
-  TkQConId {} -> True
-  TkConSym {} -> True
-  TkQConSym {} -> True
-  TkReservedColon -> True
-  TkInteger {} -> True
-  TkIntegerHash {} -> True
-  TkIntegerBase {} -> True
-  TkIntegerBaseHash {} -> True
-  TkFloat {} -> True
-  TkFloatHash {} -> True
-  TkChar {} -> True
-  TkCharHash {} -> True
-  TkString {} -> True
-  TkStringHash {} -> True
-  TkQuasiQuote {} -> True
-  _ -> False
-
+-- | Like 'patternBindDeclParser' but rejects bare variable patterns.
+-- When the leading token is a variable identifier, a bare @x = 5@ must be
+-- parsed as a zero-argument function bind, not a pattern bind.  This parser
+-- detects that case early (after parsing the pattern) and fails, letting
+-- 'valueDeclParser' handle it instead.
 nonBareVarPatternBindDeclParser :: TokParser Decl
 nonBareVarPatternBindDeclParser = MP.try $ withSpan $ do
   pat <- region "while parsing pattern binding" patternParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -41,20 +41,22 @@ ordinaryDeclParser :: TokParser Decl
 ordinaryDeclParser = do
   (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
   thFullEnabled <- isExtensionEnabled TemplateHaskell
-  startsWithPatternBind <- startsWithTopLevelPatternBind
-  startsWithBareVarPatternBind <- startsWithBareVarPatternBindHead
   let valueOrSpliceParser =
         if thFullEnabled
           then MP.try valueDeclParser <|> implicitSpliceDeclParser
           else valueDeclParser
-      patternOrSpliceParser =
+      patternOrValueOrSpliceParser =
         if thFullEnabled
           then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> implicitSpliceDeclParser
-          else MP.try patternBindDeclParser
+          else MP.try patternBindDeclParser <|> valueDeclParser
+      nonBareVarPatternOrValueOrSpliceParser =
+        if thFullEnabled
+          then MP.try nonBareVarPatternBindDeclParser <|> MP.try valueDeclParser <|> implicitSpliceDeclParser
+          else MP.try nonBareVarPatternBindDeclParser <|> valueDeclParser
       typeSigOrValueOrSpliceParser =
         MP.try typeSigDeclParser <|> valueOrSpliceParser
       typeSigOrPatternOrValueOrSpliceParser =
-        MP.try typeSigDeclParser <|> patternOrSpliceParser <|> valueOrSpliceParser
+        MP.try typeSigDeclParser <|> patternOrValueOrSpliceParser
   case lexTokenKind tok of
     TkKeywordData ->
       case lexTokenKind nextTok of
@@ -82,69 +84,47 @@ ordinaryDeclParser = do
     TkKeywordPattern -> patternSynonymParser
     TkSpecialLParen -> typeSigOrPatternOrValueOrSpliceParser
     TkSpecialLBracket -> typeSigOrPatternOrValueOrSpliceParser
-    TkSpecialUnboxedLParen
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkSpecialUnboxedLParen -> valueOrSpliceParser
+    TkSpecialUnboxedLParen -> patternOrValueOrSpliceParser
     TkPrefixTilde -> typeSigOrPatternOrValueOrSpliceParser
-    TkPrefixBang
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkPrefixBang -> valueOrSpliceParser
+    TkPrefixBang -> patternOrValueOrSpliceParser
     TkKeywordUnderscore -> typeSigOrPatternOrValueOrSpliceParser
-    TkVarId {}
-      | startsWithPatternBind && not startsWithBareVarPatternBind -> patternOrSpliceParser
-    TkVarSym "-"
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkConId {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkQConId {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkConSym {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkQConSym {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkReservedColon
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkInteger {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkIntegerHash {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkIntegerBase {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkIntegerBaseHash {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkFloat {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkFloatHash {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkChar {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkCharHash {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkString {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkStringHash {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkQuasiQuote {}
-      | startsWithPatternBind -> patternOrSpliceParser
-    TkTHSplice
-      | startsWithPatternBind -> patternOrSpliceParser
+    TkVarId {} ->
+      case lexTokenKind nextTok of
+        TkReservedDoubleColon -> typeSigOrValueOrSpliceParser
+        TkSpecialComma -> typeSigOrValueOrSpliceParser
+        TkReservedEquals -> valueOrSpliceParser
+        _ -> nonBareVarPatternOrValueOrSpliceParser
+    TkVarSym "-" -> patternOrValueOrSpliceParser
+    TkConId {} -> patternOrValueOrSpliceParser
+    TkQConId {} -> patternOrValueOrSpliceParser
+    TkConSym {} -> patternOrValueOrSpliceParser
+    TkQConSym {} -> patternOrValueOrSpliceParser
+    TkReservedColon -> patternOrValueOrSpliceParser
+    TkInteger {} -> patternOrValueOrSpliceParser
+    TkIntegerHash {} -> patternOrValueOrSpliceParser
+    TkIntegerBase {} -> patternOrValueOrSpliceParser
+    TkIntegerBaseHash {} -> patternOrValueOrSpliceParser
+    TkFloat {} -> patternOrValueOrSpliceParser
+    TkFloatHash {} -> patternOrValueOrSpliceParser
+    TkChar {} -> patternOrValueOrSpliceParser
+    TkCharHash {} -> patternOrValueOrSpliceParser
+    TkString {} -> patternOrValueOrSpliceParser
+    TkStringHash {} -> patternOrValueOrSpliceParser
+    TkQuasiQuote {} -> patternOrValueOrSpliceParser
     TkTHSplice ->
       if thFullEnabled
-        then MP.try valueDeclParser <|> spliceDeclParser
+        then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> spliceDeclParser
         else spliceDeclParser
     _ -> typeSigOrValueOrSpliceParser
 
-startsWithTopLevelPatternBind :: TokParser Bool
-startsWithTopLevelPatternBind =
-  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    _ <- patternParser
-    expectedTok TkReservedEquals
-
-startsWithBareVarPatternBindHead :: TokParser Bool
-startsWithBareVarPatternBindHead =
-  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    _ <- identifierTextParser
-    expectedTok TkReservedEquals
+nonBareVarPatternBindDeclParser :: TokParser Decl
+nonBareVarPatternBindDeclParser = MP.try $ withSpan $ do
+  pat <- region "while parsing pattern binding" patternParser
+  case pat of
+    PVar {} -> fail "bare variable bindings are parsed as function declarations"
+    _ -> do
+      rhs <- equationRhsParser
+      pure (\span' -> DeclValue span' (PatternBind span' pat rhs))
 
 -- | Parse a pragma declaration (e.g. {-# INLINE f #-}, {-# SPECIALIZE ... #-})
 pragmaDeclParser :: TokParser Decl

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -182,7 +182,9 @@ buildTests = do
             testCase "pattern bind tuple: (x, y) = expr" test_localDeclPatTuple,
             testCase "pattern bind constructor: Just x = expr" test_localDeclPatCon,
             testCase "pattern bind wildcard: _ = expr" test_localDeclPatWild,
-            testCase "function bind guarded: f x | x > 0 = x" test_localDeclFunGuarded
+            testCase "function bind guarded: f x | x > 0 = x" test_localDeclFunGuarded,
+            testCase "pattern bind record constructor: R {} = expr" test_localDeclPatRecordCon,
+            testCase "pattern bind unboxed sum: (# | | | x #) = expr" test_localDeclPatUnboxedSum
           ],
         testGroup
           "pretty"
@@ -1588,6 +1590,18 @@ test_localDeclFunGuarded =
   case parseLetDecls "let { f x | x > 0 = x } in f 1" of
     Right [DeclValue _ (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar _ "x"], matchRhs = GuardedRhss {}}])] -> pure ()
     other -> assertFailure ("expected guarded function bind, got: " <> show other)
+
+test_localDeclPatRecordCon :: Assertion
+test_localDeclPatRecordCon =
+  case parseTopDecl "BYys {} = ()" of
+    Right (DeclValue _ (PatternBind _ (PRecord _ "BYys" [] False) _)) -> pure ()
+    other -> assertFailure ("expected record constructor pattern bind, got: " <> show other)
+
+test_localDeclPatUnboxedSum :: Assertion
+test_localDeclPatUnboxedSum =
+  case parseTopDeclWithExts [UnboxedSums] "(#  |  |  | a #) = ()" of
+    Right (DeclValue _ (PatternBind _ (PUnboxedSum _ 3 4 (PVar _ "a")) _)) -> pure ()
+    other -> assertFailure ("expected unboxed sum pattern bind, got: " <> show other)
 
 -- Helper: parse a top-level declaration and extract the ValueDecl.
 parseTopDecl :: T.Text -> Either String Decl

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -62,10 +62,40 @@ genDecl = sized $ \n ->
     ]
 
 genDeclValue :: Int -> Gen Decl
-genDeclValue n = do
+genDeclValue n =
+  oneof
+    [ genFunctionValueDecl n,
+      genPatternValueDecl n
+    ]
+
+genFunctionValueDecl :: Int -> Gen Decl
+genFunctionValueDecl n = do
   name <- genVarBinderName
   expr <- resize n genExpr
   genFunctionDecl (name, expr)
+
+genPatternValueDecl :: Int -> Gen Decl
+genPatternValueDecl n = do
+  pat <- genPatternBindPattern n
+  expr <- resize n genExpr
+  pure $ DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr Nothing))
+
+genPatternBindPattern :: Int -> Gen Pattern
+genPatternBindPattern n =
+  frequency
+    [ (1, PVar span0 . mkUnqualifiedName NameVarId <$> genIdent),
+      (4, sized (genGeneralPatternBindPattern . min 3 . min n))
+    ]
+
+genGeneralPatternBindPattern :: Int -> Gen Pattern
+genGeneralPatternBindPattern n =
+  suchThat (genPattern n) isGeneralPatternBindPattern
+
+isGeneralPatternBindPattern :: Pattern -> Bool
+isGeneralPatternBindPattern pat =
+  case pat of
+    PVar {} -> False
+    _ -> True
 
 genFunctionDecl :: (UnqualifiedName, Expr) -> Gen Decl
 genFunctionDecl (name, expr) = do
@@ -795,6 +825,7 @@ shrinkDecl decl =
   case decl of
     DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr _)) ->
       [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr' Nothing)) | expr' <- shrinkExpr expr]
+        <> [DeclValue span0 (PatternBind span0 pat' (UnguardedRhs span0 expr Nothing)) | pat' <- shrinkPatternBindPat pat]
     DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr _}]) ->
       [ DeclValue
           span0
@@ -818,6 +849,9 @@ shrinkDecl decl =
     DeclTypeSig _ names ty ->
       [DeclTypeSig span0 names' ty | names' <- shrinkList shrinkBinderName names, not (null names')]
     _ -> []
+
+shrinkPatternBindPat :: Pattern -> [Pattern]
+shrinkPatternBindPat = shrinkPattern
 
 shrinkUnqualifiedVarName :: UnqualifiedName -> [UnqualifiedName]
 shrinkUnqualifiedVarName name =

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -27,11 +27,17 @@ prop_declPrettyRoundTrip :: Decl -> Property
 prop_declPrettyRoundTrip decl =
   let source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
       expected = normalizeDecl (addDeclParens decl)
-   in assertCtorCoverage ["DeclAnn"] decl $
-        counterexample (T.unpack source) $
-          case parseDecl declConfig source of
-            ParseErr err ->
-              counterexample (MPE.errorBundlePretty err) False
-            ParseOk parsed ->
-              let actual = normalizeDecl parsed
-               in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
+      addValueDeclCoverage prop =
+        case decl of
+          DeclValue _ valueDecl -> assertCtorCoverage [] valueDecl prop
+          _ -> prop
+   in checkCoverage $
+        addValueDeclCoverage $
+          assertCtorCoverage ["DeclAnn"] decl $
+            counterexample (T.unpack source) $
+              case parseDecl declConfig source of
+                ParseErr err ->
+                  counterexample (MPE.errorBundlePretty err) False
+                ParseOk parsed ->
+                  let actual = normalizeDecl parsed
+                   in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)


### PR DESCRIPTION
## Summary
- generate `PatternBind` declarations in the decl QuickCheck arb and enforce `ValueDecl` constructor coverage in decl roundtrip properties
- fix top-level declaration dispatch so pretty-printed pattern bindings starting with records, unboxed tuples/sums, literals, qualified constructors, and TH splices roundtrip correctly
- add parser regressions for top-level record-constructor and unboxed-sum pattern bindings

## Checks
- `just check`
- `coderabbit review --prompt-only` (no findings)