### PR TITLE
fix(parser): support guarded RHS in pattern bindings

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -978,10 +978,8 @@ localFunctionDeclParser = withSpan $ do
 localPatternDeclParser :: TokParser Decl
 localPatternDeclParser = withSpan $ do
   pat <- patternParser
-  expectedTok TkReservedEquals
-  rhsExpr <- exprParser
-  whereDecls <- MP.optional whereClauseParser
-  pure (\span' -> DeclValue span' (PatternBind span' pat (UnguardedRhs span' rhsExpr whereDecls)))
+  rhs <- equationRhsParser
+  pure (\span' -> DeclValue span' (PatternBind span' pat rhs))
 
 implicitParamDeclParser :: TokParser Decl
 implicitParamDeclParser = withSpan $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -48,6 +48,13 @@ import Prettyprinter
     (<+>),
   )
 
+-- | Wrap a document in braces with interior spaces: @{ content }@.
+-- Unlike 'braces' which produces @{content}@, this version avoids the
+-- @{-@ block-comment ambiguity that occurs when the content starts with a
+-- minus sign (e.g. a negated literal pattern in a let binding).
+spacedBraces :: Doc ann -> Doc ann
+spacedBraces d = "{" <+> d <+> "}"
+
 -- | Pretty instance for Module - renders to valid Haskell source code.
 instance Pretty Module where
   pretty = prettyModuleDoc . addModuleParens
@@ -368,8 +375,8 @@ prettyRhs rhs =
 
 prettyWhereClause :: Maybe [Decl] -> Doc ann
 prettyWhereClause Nothing = mempty
-prettyWhereClause (Just []) = " where" <+> braces mempty
-prettyWhereClause (Just decls) = " where" <+> braces (prettyInlineDecls decls)
+prettyWhereClause (Just []) = " where" <+> spacedBraces mempty
+prettyWhereClause (Just decls) = " where" <+> spacedBraces (prettyInlineDecls decls)
 
 -- | Pretty-print a type. The AST is assumed to already have TParen nodes
 -- in the correct positions (inserted by 'addTypeParens').
@@ -1017,7 +1024,7 @@ prettyExpr expr =
     ESectionR _ op rhs -> parens (prettyNameInfixOp op <+> prettyExpr rhs)
     ELetDecls _ decls body ->
       "let"
-        <+> braces (prettyInlineDecls decls)
+        <+> spacedBraces (prettyInlineDecls decls)
         <+> "in"
         <+> prettyExpr body
     ECase _ scrutinee alts ->
@@ -1120,13 +1127,13 @@ prettyGuardQualifier qualifier =
   case qualifier of
     GuardExpr _ expr -> prettyExpr expr
     GuardPat _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
-    GuardLet _ decls -> "let" <+> braces (prettyInlineDecls decls)
+    GuardLet _ decls -> "let" <+> spacedBraces (prettyInlineDecls decls)
 
 prettyDoStmt :: DoStmt Expr -> Doc ann
 prettyDoStmt stmt =
   case stmt of
     DoBind _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
-    DoLetDecls _ decls -> "let" <+> braces (prettyInlineDecls decls)
+    DoLetDecls _ decls -> "let" <+> spacedBraces (prettyInlineDecls decls)
     DoExpr _ expr -> prettyExpr expr
     DoRecStmt _ stmts -> "rec" <+> "{" <+> hsep (punctuate semi (map prettyDoStmt stmts)) <+> "}"
 
@@ -1147,7 +1154,7 @@ prettyCmd cmd =
     CmdCase _ scrut alts ->
       "case" <+> prettyExpr scrut <+> "of" <+> "{" <+> hsep (punctuate semi (map prettyCmdCaseAlt alts)) <+> "}"
     CmdLet _ decls body ->
-      "let" <+> braces (prettyInlineDecls decls) <+> "in" <+> prettyCmd body
+      "let" <+> spacedBraces (prettyInlineDecls decls) <+> "in" <+> prettyCmd body
     CmdLam _ pats body ->
       "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyCmd body
     CmdApp _ c e ->
@@ -1159,7 +1166,7 @@ prettyCmdStmt :: DoStmt Cmd -> Doc ann
 prettyCmdStmt stmt =
   case stmt of
     DoBind _ pat cmd' -> prettyPattern pat <+> "<-" <+> prettyCmd cmd'
-    DoLetDecls _ decls -> "let" <+> braces (prettyInlineDecls decls)
+    DoLetDecls _ decls -> "let" <+> spacedBraces (prettyInlineDecls decls)
     DoExpr _ cmd' -> prettyCmd cmd'
     DoRecStmt _ stmts -> "rec" <+> "{" <+> hsep (punctuate semi (map prettyCmdStmt stmts)) <+> "}"
 
@@ -1173,7 +1180,7 @@ prettyCompStmt stmt =
     CompGen _ pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     CompGuard _ expr -> prettyExpr expr
     CompLet _ bindings -> "let" <+> hsep (punctuate semi (map prettyBinding bindings))
-    CompLetDecls _ decls -> "let" <+> braces (prettyInlineDecls decls)
+    CompLetDecls _ decls -> "let" <+> spacedBraces (prettyInlineDecls decls)
 
 prettyInlineDecls :: [Decl] -> Doc ann
 prettyInlineDecls decls =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1320,7 +1320,7 @@ test_prettyInfixFunctionHeadIrrefutablePatterns = do
 -- | Regression test: a view pattern whose view expression is a let-expression
 -- ending with a type signature must parenthesize the let so the view-pattern
 -- arrow is not absorbed into the type.
--- Without the fix, this would produce @(let {x = (#  #)} in (#  #) :: T -> [])@
+-- Without the fix, this would produce @(let { x = (#  #) } in (#  #) :: T -> [])@
 -- which GHC rejects because @:: T -> []@ is parsed as a single type signature.
 test_prettyViewLetTypeSigParens :: Assertion
 test_prettyViewLetTypeSigParens = do
@@ -1335,7 +1335,7 @@ test_prettyViewLetTypeSigParens = do
       source = renderStrict (layoutPretty defaultLayoutOptions (pretty pat))
   assertBool
     ("expected parenthesized let-expression in view pattern, got:\n" <> T.unpack source)
-    ("((let {x = (#  #)} in (#  #) :: T) -> [])" == source)
+    ("((let { x = (#  #) } in (#  #) :: T) -> [])" == source)
 
 -- | Regression test: a guard pattern whose expression ends with a type
 -- signature must parenthesize the expression so the multi-way if arrow @->@

--- a/components/aihc-parser/test/Test/Fixtures/oracle/BangPatterns/bang-let-guarded.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/BangPatterns/bang-let-guarded.hs
@@ -1,8 +1,9 @@
-{- ORACLE_TEST xfail bang pattern with guards in let binding -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE BangPatterns #-}
+
 module BangPatternsLetGuarded where
 
 test :: Bool -> Int
 test positive =
   let !x | True = 1
-  in x
+   in x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Declarations/guarded-where-tuple-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Declarations/guarded-where-tuple-pattern.hs
@@ -1,11 +1,13 @@
-{- ORACLE_TEST xfail reason="guarded patterns with tuple patterns in where clauses not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Haskell2010 #-}
 
 module GuardedWhereTuplePattern where
 
 -- Parser fails to handle guarded patterns with tuple patterns in where clauses
 f :: Int -> Int
-f x = y where
-  (a,b) | x <= 0 = (0,1)
-        | otherwise = (1,0)
-  y = a
+f x = y
+  where
+    (a, b)
+      | x <= 0 = (0, 1)
+      | otherwise = (1, 0)
+    y = a

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -373,23 +373,62 @@ genGuardQualifierWith allowTHQuotes n =
     half = n `div` 2
 
 -- | Generate value declarations for let/where.
--- Zero-argument bindings are generated as PatternBind so they keep the same
--- AST shape after pretty-print/parser roundtrip.
+-- Produces a mix of simple pattern bindings (@x = expr@) and function bindings
+-- (@f pat ... = expr@ or @f pat ... | guard = expr@), mirroring the parser
+-- which creates each equation as a separate 'FunctionBind' with a single
+-- 'Match'.
 genValueDeclsWith :: Bool -> Int -> Gen [Decl]
 genValueDeclsWith allowTHQuotes n = do
   count <- chooseInt (0, 3)
-  names <- vectorOf count (mkUnqualifiedName NameVarId <$> genIdent)
-  exprs <- vectorOf count (genBindingExprWith allowTHQuotes (n `div` max 1 count))
-  pure
-    [ DeclValue
-        span0
-        ( PatternBind
-            span0
-            (PVar span0 name)
-            (UnguardedRhs span0 expr Nothing)
-        )
-    | (name, expr) <- zip names exprs
+  vectorOf count (genValueDeclWith allowTHQuotes (n `div` max 1 count))
+
+-- | Generate a single value declaration: either a simple pattern binding or a
+-- function binding with argument patterns and optional guards.
+genValueDeclWith :: Bool -> Int -> Gen Decl
+genValueDeclWith allowTHQuotes n =
+  oneof
+    [ genPatternBindDecl allowTHQuotes n,
+      genFunctionBindDecl allowTHQuotes n
     ]
+
+-- | Generate a pattern binding: @pat = expr@ or @pat | guard = expr@.
+-- The pattern can be any pattern (bang, as, irrefutable, etc.) and the RHS
+-- can be guarded, matching what GHC accepts.
+genPatternBindDecl :: Bool -> Int -> Gen Decl
+genPatternBindDecl allowTHQuotes n = do
+  pat <- genPattern half
+  rhs <- genRhsWith allowTHQuotes half
+  pure $
+    DeclValue
+      span0
+      (PatternBind span0 pat rhs)
+  where
+    half = n `div` 2
+
+-- | Generate a function binding: @f pat ... = expr@ or @f pat ... | guard = expr@.
+-- Produces a single 'Match', consistent with the parser which creates one
+-- 'FunctionBind' per equation.
+genFunctionBindDecl :: Bool -> Int -> Gen Decl
+genFunctionBindDecl allowTHQuotes n = do
+  name <- mkUnqualifiedName NameVarId <$> genIdent
+  patCount <- chooseInt (1, 3)
+  let perItem = n `div` max 1 (patCount + 1)
+  pats <- vectorOf patCount (genPattern perItem)
+  rhs <- genRhsWith allowTHQuotes perItem
+  pure $
+    DeclValue
+      span0
+      ( FunctionBind
+          span0
+          name
+          [ Match
+              { matchSpan = span0,
+                matchHeadForm = MatchHeadPrefix,
+                matchPats = pats,
+                matchRhs = rhs
+              }
+          ]
+      )
 
 genBindingExprWith :: Bool -> Int -> Gen Expr
 genBindingExprWith = genExprSizedWith
@@ -743,6 +782,15 @@ shrinkLetDecl decl =
   case decl of
     DeclValue _ (PatternBind _ pat (UnguardedRhs _ expr _)) ->
       [DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 expr' Nothing)) | expr' <- shrinkExpr expr]
+    DeclValue _ (PatternBind _ pat (GuardedRhss _ rhss _)) ->
+      -- Shrink to unguarded using the first guard's body
+      [ DeclValue span0 (PatternBind span0 pat (UnguardedRhs span0 (guardedRhsBody firstRhs) Nothing))
+      | firstRhs : _ <- [rhss]
+      ]
+        <> [ DeclValue span0 (PatternBind span0 pat (GuardedRhss span0 rhss' Nothing)) -- Shrink the guard list
+           | rhss' <- shrinkList shrinkGuardedRhs rhss,
+             not (null rhss')
+           ]
     DeclValue _ (FunctionBind _ name [match@Match {matchRhs = UnguardedRhs _ expr _}]) ->
       [ DeclValue
           span0
@@ -753,6 +801,27 @@ shrinkLetDecl decl =
           )
       | expr' <- shrinkExpr expr
       ]
+    DeclValue _ (FunctionBind _ name [match@Match {matchRhs = GuardedRhss _ rhss _}]) ->
+      -- Shrink to unguarded using the first guard's body
+      [ DeclValue
+          span0
+          ( FunctionBind
+              span0
+              name
+              [match {matchSpan = span0, matchRhs = UnguardedRhs span0 (guardedRhsBody firstRhs) Nothing}]
+          )
+      | firstRhs : _ <- [rhss]
+      ]
+        <> [ DeclValue -- Shrink the guard list
+               span0
+               ( FunctionBind
+                   span0
+                   name
+                   [match {matchSpan = span0, matchRhs = GuardedRhss span0 rhss' Nothing}]
+               )
+           | rhss' <- shrinkList shrinkGuardedRhs rhss,
+             not (null rhss')
+           ]
     _ -> []
 
 shrinkDoStmts :: [DoStmt Expr] -> [[DoStmt Expr]]


### PR DESCRIPTION
## Summary

- Fix `localPatternDeclParser` to use `equationRhsParser` instead of hardcoding `expectedTok TkReservedEquals`, enabling guarded pattern bindings like `let !x | True = 1 in x`
- Extend the QuickCheck generator to produce `FunctionBind` declarations with argument patterns/guards and `PatternBind` declarations with arbitrary patterns and guarded RHS
- Introduce `spacedBraces` (`{ content }`) for inline declaration contexts to prevent the `{-` block-comment ambiguity when content starts with a negated literal
- Promote 2 oracle xfail cases to pass: `BangPatterns/bang-let-guarded`, `Declarations/guarded-where-tuple-pattern`

## Progress

pass: 832 (+2), xfail: 7 (-2)