### PR TITLE
fix(nix): avoid redundant check builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     };
     docs = import ./scripts/nix/docs.nix {
       inherit (core) projectHsPackages;
-      inherit (haskell) mkHsPkgsWithHaddock mkHsPkgsWithHaddockForChecks;
+      inherit (haskell) mkHsPkgsWithHaddock;
     };
     coverage = import ./scripts/nix/coverage.nix {
       inherit (core) projectHsPackages;
@@ -43,8 +43,7 @@
     mkChecks = import ./scripts/nix/checks.nix {
       inherit (core) projectHsPackages;
       inherit sources;
-      inherit (haskell) mkHsPkgsForChecks mkHsPkgsWithTestsForChecks;
-      inherit (docs) mkCombinedDocsForChecks;
+      inherit (haskell) mkHsPkgsForChecks;
     };
     mkDevShells = import ./scripts/nix/dev-shells.nix {
       inherit (haskell) mkHsPkgs;

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -2,11 +2,18 @@
   projectHsPackages,
   sources,
   mkHsPkgsForChecks,
-  mkHsPkgsWithTestsForChecks,
-  mkCombinedDocsForChecks,
 }: pkgs: let
   hsPkgs = mkHsPkgsForChecks pkgs;
-  hsPkgsWithTests = mkHsPkgsWithTestsForChecks pkgs;
+
+  addHiddenSuccesses = old: {
+    # Hide passing tests so failures are visible in Nix's truncated output.
+    testFlags = (old.testFlags or []) ++ ["--hide-successes"];
+  };
+
+  mkPackageTest = drv:
+    pkgs.haskell.lib.doCheck (
+      pkgs.haskell.lib.dontHaddock (pkgs.haskell.lib.overrideCabal drv addHiddenSuccesses)
+    );
 
   mkSourceCheck = name: src: nativeBuildInputs: text:
     pkgs.runCommand name {
@@ -20,11 +27,11 @@
   mkProgressCheck = name: src: package: command:
     mkSourceCheck name src [package] command;
 
-  parserTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgsWithTests.aihc-parser);
-  parserCliTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgsWithTests.aihc-parser-cli);
-  cppTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgsWithTests.aihc-cpp);
-  resolveTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgsWithTests.aihc-resolve);
-  tcTests = pkgs.haskell.lib.doCheck (pkgs.haskell.lib.dontHaddock hsPkgsWithTests.aihc-tc);
+  parserTests = mkPackageTest hsPkgs.aihc-parser;
+  parserCliTests = mkPackageTest hsPkgs.aihc-parser-cli;
+  cppTests = mkPackageTest hsPkgs.aihc-cpp;
+  resolveTests = mkPackageTest hsPkgs.aihc-resolve;
+  tcTests = mkPackageTest hsPkgs.aihc-tc;
 
   nixLint = mkSourceCheck "aihc-nix-lint" (sources.nixSrc pkgs) [pkgs.statix] ''
     statix check flake.nix
@@ -60,8 +67,6 @@
     cpp-progress --strict
   '';
 
-  haddockDocs = mkCombinedDocsForChecks pkgs;
-
   cppDoctest =
     mkSourceCheck "aihc-cpp-doctest" (sources.cppSrc pkgs) [
       (projectHsPackages pkgs).doctest
@@ -94,7 +99,6 @@ in {
   tc-tests = tcTests;
   cpp-doctest = cppDoctest;
   parser-doctest = parserDoctest;
-  haddock-docs = haddockDocs;
   parser-progress-strict = parserProgressStrict;
   lexer-progress-strict = lexerProgressStrict;
   parser-extension-progress-strict = parserExtensionProgressStrict;
@@ -132,10 +136,6 @@ in {
     {
       name = "parser-doctest";
       path = parserDoctest;
-    }
-    {
-      name = "haddock-docs";
-      path = haddockDocs;
     }
     {
       name = "parser-progress-strict";

--- a/scripts/nix/docs.nix
+++ b/scripts/nix/docs.nix
@@ -1,7 +1,6 @@
 {
   projectHsPackages,
   mkHsPkgsWithHaddock,
-  mkHsPkgsWithHaddockForChecks,
 }: let
   mkCombinedDocsFrom = mkHsPkgsBuilder: pkgs: let
     hsPkgsHaddock = mkHsPkgsBuilder pkgs;
@@ -40,5 +39,4 @@
     '';
 in {
   mkCombinedDocs = mkCombinedDocsFrom mkHsPkgsWithHaddock;
-  mkCombinedDocsForChecks = mkCombinedDocsFrom mkHsPkgsWithHaddockForChecks;
 }

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -40,11 +40,6 @@
     };
   };
 
-  addHiddenSuccesses = old: {
-    # Hide passing tests so failures are visible in Nix's truncated output.
-    testFlags = (old.testFlags or []) ++ ["--hide-successes"];
-  };
-
   enableCoverageWithExport = hsLib: drv:
     hsLib.overrideCabal drv (old: {
       configureFlags = (old.configureFlags or []) ++ ["--enable-coverage"];
@@ -67,25 +62,30 @@
     then hsLib.dontHaddock drv
     else drv;
 
-  applyCheckMode = hsLib: mode: drv:
-    if mode == "disable"
-    then hsLib.dontCheck drv
-    else if mode == "hide-successes"
-    then hsLib.overrideCabal drv addHiddenSuccesses
-    else drv;
+  isOverridableHaskellDrv = pkgs: drv:
+    pkgs.lib.isDerivation drv && drv ? overrideScope;
+
+  disableUpstreamChecks = pkgs: hsLib: localPackageNames: _final: prev:
+    builtins.mapAttrs (
+      name: drv:
+        if builtins.elem name localPackageNames || !(isOverridableHaskellDrv pkgs drv)
+        then drv
+        else hsLib.dontCheck drv
+    )
+    prev;
 in rec {
-  # Hackage dependencies whose test suites are unsuitable for the Nix build sandbox.
+  # Hackage dependencies whose build settings need manual adjustment.
   hackageDepTestFixes = pkgs: _final: prev: {
     network = pkgs.haskell.lib.dontCheck prev.network;
   };
 
   mkHsPkgsVariant = pkgs: {
     disableOptimization ? false,
-    checkMode ? "disable",
     enableDocs ? false,
     enableCoverage ? false,
   }: let
     hsLib = pkgs.haskell.lib;
+    localPackageNames = (builtins.attrNames componentSpecs) ++ ["aihc-hackage"];
 
     mkComponent = final: name: spec: let
       baseDrv = final.callCabal2nix name (spec.src pkgs) {};
@@ -101,6 +101,7 @@ in rec {
         if enableCoverage && spec.supportsCoverage
         then enableCoverageWithExport hsLib optimizationAdjusted
         else optimizationAdjusted;
+      checksAdjusted = hsLib.dontCheck coverageAdjusted;
       haddockMode =
         if enableDocs
         then
@@ -108,16 +109,13 @@ in rec {
           then "do"
           else "dont"
         else "leave";
-      effectiveCheckMode =
-        if enableCoverage && spec.supportsCoverage
-        then "default"
-        else checkMode;
     in
-      applyCheckMode hsLib effectiveCheckMode (applyHaddockMode hsLib haddockMode coverageAdjusted);
+      applyHaddockMode hsLib haddockMode checksAdjusted;
   in
     (projectHsPackages pkgs).override {
       overrides = final: prev:
-        hackageDepTestFixes pkgs final prev
+        disableUpstreamChecks pkgs hsLib localPackageNames final prev
+        // hackageDepTestFixes pkgs final prev
         // {
           ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
           aihc-hackage = pkgs.haskell.lib.dontCheck (
@@ -134,25 +132,8 @@ in rec {
       disableOptimization = true;
     };
 
-  mkHsPkgsWithTests = pkgs:
-    mkHsPkgsVariant pkgs {
-      checkMode = "hide-successes";
-    };
-
-  mkHsPkgsWithTestsForChecks = pkgs:
-    mkHsPkgsVariant pkgs {
-      disableOptimization = true;
-      checkMode = "hide-successes";
-    };
-
   mkHsPkgsWithHaddock = pkgs:
     mkHsPkgsVariant pkgs {
-      enableDocs = true;
-    };
-
-  mkHsPkgsWithHaddockForChecks = pkgs:
-    mkHsPkgsVariant pkgs {
-      disableOptimization = true;
       enableDocs = true;
     };
 


### PR DESCRIPTION
## Summary
- disable test suites for upstream Haskell dependencies in the Nix package set and keep local package tests opt-in per top-level check
- collapse redundant flake check package variants so docs reuse the base package set and check jobs no longer pull in transitive local test suites
- remove haddock docs from `flake check` while keeping docs available under `packages.docs`

## Validation
- `just fmt`
- `just check`
- `nix flake check`
- `coderabbit review --prompt-only` (no findings)

## Progress Counts
| Component       |   Code |   Tests |   Total |
|-----------------|--------|---------|---------|
| aihc-cpp        |   1523 |     531 |    2054 |
| aihc-parser     |  11183 |   15074 |   26257 |
| aihc-parser-cli |   1804 |     385 |    2189 |
| aihc-resolve    |   1036 |    1002 |    2038 |
| aihc-tc         |   1537 |     976 |    2513 |
| **Total**       |  17083 |   17968 |   35051 |