### PR TITLE
fix(parser): parse infix type operators in type family equations with NoStarIsType

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1191,31 +1191,34 @@ typeFamilyOperatorParser =
       expectedTok TkSpecialBacktick
       pure op
 
+-- | Parse the LHS of a type family equation or instance.
+-- Uses full type infix parsing to handle operators like @*@ in equations.
 typeFamilyLhsParser :: TokParser (TypeHeadForm, Type)
-typeFamilyLhsParser = do
-  lhs <- typeAtomParser
-  hasInfixTail <- MP.optional (lookAhead typeInfixOperatorParser)
-  case hasInfixTail of
-    Just _ -> do
-      rest <- typeHeadInfixTailParser
-      pure (TypeHeadInfix, foldl buildInfixType lhs rest)
-    Nothing -> do
-      rest <- MP.many typeAtomParser
-      pure (TypeHeadPrefix, foldl buildTypeApp lhs rest)
+typeFamilyLhsParser = typeFamilyInfixParserWith typeInfixParser
+
+-- | Parse a type family LHS using a given type parser, detecting infix form.
+typeFamilyInfixParserWith :: TokParser Type -> TokParser (TypeHeadForm, Type)
+typeFamilyInfixParserWith fullTypeParser = do
+  -- Try infix form first: typeApp `op` typeApp (with possible additional infix ops)
+  MP.try
+    ( do
+        lhs <- typeAppParser
+        opsAndRhs <- MP.many ((,) <$> typeInfixOperatorParser <*> typeAppParser)
+        case opsAndRhs of
+          [] -> fail "expected at least one infix operator"
+          (op, rhs) : rest ->
+            let baseType = foldl buildInfixType (buildInfixType lhs (op, rhs)) rest
+             in pure (TypeHeadInfix, baseType)
+    )
+    <|> ( do
+            ty <- fullTypeParser
+            pure (TypeHeadPrefix, ty)
+        )
   where
-    typeHeadInfixTailParser :: TokParser [((Name, TypePromotion), Type)]
-    typeHeadInfixTailParser = MP.many $ MP.try $ do
-      op <- typeInfixOperatorParser
-      atom <- typeAtomParser
-      pure (op, atom)
-
-    buildInfixType left ((op, promoted), right) =
+    buildInfixType left (op, right) =
       let span' = mergeSourceSpans (getSourceSpan left) (getSourceSpan right)
-          opType = TCon span' op promoted
+          opType = uncurry (TCon span') op
        in TApp span' (TApp span' opType left) right
-
-    buildTypeApp left right =
-      TApp (mergeSourceSpans (getSourceSpan left) (getSourceSpan right)) left right
 
 classHeadParser :: TokParser (TypeHeadForm, Text, [TyVarBinder])
 classHeadParser =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1306,7 +1306,38 @@ prettyTypeFamilyHead :: TypeHeadForm -> Type -> [TyVarBinder] -> [Doc ann]
 prettyTypeFamilyHead headForm headType params =
   case headForm of
     TypeHeadPrefix -> [prettyType headType] <> map prettyTyVarBinder params
-    TypeHeadInfix -> [prettyTypeFamilyInfix headType]
+    TypeHeadInfix -> prettyTypeFamilyInfixHead headType params
+
+-- | Pretty-print an infix type family head with kind annotations from params.
+prettyTypeFamilyInfixHead :: Type -> [TyVarBinder] -> [Doc ann]
+prettyTypeFamilyInfixHead headType params =
+  case headType of
+    TApp _ (TApp _ (TCon _ op promoted) lhs) rhs ->
+      let lhsDoc = prettyTypeWithParamKinds lhs params
+          rhsDoc = prettyTypeWithParamKinds rhs (drop 1 params)
+          opDoc = (if promoted == Promoted then "'" else mempty) <> prettyNameInfixOp op
+       in [lhsDoc <+> opDoc <+> rhsDoc]
+    _ -> [prettyType headType]
+
+-- | Pretty-print a type, but if it's a type variable that matches a param, include its kind annotation.
+prettyTypeWithParamKinds :: Type -> [TyVarBinder] -> Doc ann
+prettyTypeWithParamKinds ty params =
+  case ty of
+    TVar _ varName ->
+      case findParamByName varName params of
+        Just param -> prettyTyVarBinder param
+        Nothing -> prettyType ty
+    _ -> prettyType ty
+
+-- | Find a TyVarBinder by matching its name to a TVar's UnqualifiedName.
+findParamByName :: UnqualifiedName -> [TyVarBinder] -> Maybe TyVarBinder
+findParamByName varName =
+  find (\param -> mkUnqualifiedName NameVarId (tyVarBinderName param) == varName)
+  where
+    find _ [] = Nothing
+    find predicate (x : xs)
+      | predicate x = Just x
+      | otherwise = find predicate xs
 
 prettyTypeFamilyLhs :: TypeHeadForm -> Type -> [Doc ann]
 prettyTypeFamilyLhs headForm lhs =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type family equations with infix operator * not parsed correctly" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021, DataKinds, TypeFamilies, TypeOperators, NoStarIsType #-}
 
 type family (a :: ExactPi') * (b :: ExactPi') :: ExactPi' where


### PR DESCRIPTION
## Root Cause

`typeFamilyLhsParser` only looked for infix operators immediately after the first type atom. When parsing type family equation LHS patterns like `'ExactPi z p q * 'ExactPi z' p' q'`, it would:

1. Parse `'ExactPi` (first atom)
2. Look ahead and see `z` (not an infix operator)
3. Fall back to prefix branch
4. Fail when reaching `*` because `typeAtomParser` cannot parse `*` under `NoStarIsType`

## Solution

Replace the manual atom-chaining logic with `typeInfixParser` which properly handles full type applications followed by infix operators. Also fix pretty-printing to preserve kind annotations on infix type family parameters.

## Changes

- **`Decl.hs`**: Rewrite `typeFamilyLhsParser` to use `typeFamilyInfixParserWith` helper that tries infix form first (`typeApp \`op\` typeApp`) before falling back to prefix form
- **`Pretty.hs`**: Add `prettyTypeFamilyInfixHead` to correctly print infix heads with kind annotations from params
- **Test**: Mark `type-family-infix-star-equation` oracle test as passing

## Test Results

All 1352 tests pass, including the previously xfail test case.