### PR TITLE
test(parser): xfail fixture for associated type default without 'instance'

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-type-default.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-type-default.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST xfail associated type default equation without 'instance' keyword is not yet supported -}
+{-# LANGUAGE TypeFamilies #-}
+module AssociatedTypeDefault where
+
+-- Type family default equation without 'instance' keyword.
+-- GHC allows: type F a = <rhs> inside a class body as shorthand for
+-- type instance F a = <rhs>.  Parser currently rejects the '=' here.
+class Foo n where
+  type O n
+  type O n = Int


### PR DESCRIPTION
## Summary

- Adds an `xfail` oracle fixture for the parser gap where `type F a = <rhs>` inside a class body is rejected with `unexpected =`
- GHC accepts this as shorthand for `type instance F a = <rhs>` (associated type default equation without the `instance` keyword)
- Repro sourced from `newtype-generics-0.6.2`

## Repro

```haskell
{-# LANGUAGE TypeFamilies #-}
class Foo n where
  type O n
  type O n = Int   -- aihc-parser: unexpected =
```

## Test plan

- [ ] `cabal run -v0 spec -- -p "associated-type-default"` passes as known failure