### PR TITLE
test(parser): add oracle xfail fixtures for hackage regressions

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-dollar-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-dollar-continuation.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail reason="operator continuation after case expression is not parsed" -}
+module CaseDollarContinuation where
+
+f x y =
+  case x of
+    Just z -> z
+    Nothing -> id
+    $ y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/domain-aeson-qualified-operator-name-quote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/domain-aeson-qualified-operator-name-quote.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="qualified operator name quotes in Template Haskell are not parsed" -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module DomainAesonQualifiedOperatorNameQuote where
+
+import qualified Prelude as P
+
+f required =
+  if required
+    then '(P.+)
+    else '(P.-)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/file-embed-lzma-typed-quote-let-splice.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/file-embed-lzma-typed-quote-let-splice.hs
@@ -1,0 +1,15 @@
+{- ORACLE_TEST xfail reason="typed Template Haskell quote with let-bound typed splice is not parsed" -}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module FileEmbedLzmaTypedQuoteLetSplice where
+
+import Language.Haskell.TH.Syntax (Code, Q)
+
+x :: Code Q Int
+x = [||1||]
+
+f =
+  [||
+  let embedded = $$(x)
+   in embedded
+  ||]


### PR DESCRIPTION
## Summary
- add minimized oracle `xfail` fixtures for the `file-embed-lzma`, `domain-aeson`, and `pkgtreediff` hackage parser regressions
- capture three parser gaps as stable repros: typed TH quote with a let-bound typed splice, qualified TH operator name quotes, and operator continuation after a `case` expression
- progress counts after this change: `TemplateHaskell` 33/35 passing, `TemplateHaskellQuotes` 10/11 passing, and `TypeOperators` 33/34 passing remain unchanged; `GHC2021` remains 20/24 passing because the new fixtures document known gaps rather than fixing them

## Testing
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)