### PR TITLE
test(parser): add oracle xfails for hackage parser gaps

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/type-quote-splice-type-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/type-quote-splice-type-application.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="typed TH splices inside type quotations are rejected after an infix operator" -}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TypeQuoteSpliceTypeApplication where
+
+import Language.Haskell.TH
+
+data a := b
+
+f c v = [t|$c := $v|]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST xfail reason="type synonym declarations with visible type abstractions are rejected" -}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeAbstractions #-}
+
+module TypeSynonymAbstraction where
+
+import Data.Kind (Type)
+
+data Proxy (a :: k) = Proxy
+
+type Witnessed :: forall k. (k -> Type) -> k -> Type
+type Witnessed @k (f :: k -> Type) (a :: k) = Proxy a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/data-instance-kind-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/data-instance-kind-signature.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="data family instances with inline result kind signatures are not parsed" -}
+{-# LANGUAGE TypeFamilies #-}
+
+module DataInstanceKindSignature where
+
+import Data.Kind (Type)
+
+data family Fam a :: Type -> Type
+
+data instance Fam () :: Type -> Type where
+  F :: Fam () Int


### PR DESCRIPTION
## Summary
- add oracle xfail fixtures reduced from hackage failures in `constraints-extras`, `open-witness`, and `labels`
- cover parser gaps for inline result kind signatures on `data instance`, visible type abstractions in type synonyms, and typed TH splices inside type quotations
- oracle parser progress after this change: PASS 832, XFAIL 13, XPASS 0, FAIL 0, TOTAL 845, COMPLETE 98.46%

## Validation
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)