### PR TITLE
test(parser): add oracle xfails for hackage parser gaps

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/capi-interruptible-header-symbol.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/capi-interruptible-header-symbol.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="interruptible capi imports with a combined header and symbol string are parsed as if the string started a type signature" -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE InterruptibleFFI #-}
+
+module X where
+
+import Foreign.C.Types (CInt (..))
+
+foreign import capi interruptible "termbox.h tb_peek_event"
+  tb_peek_event :: IO CInt

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/escaped-backslash-cons-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/escaped-backslash-cons-pattern.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="character literals like '\^\\' in case alternative right-hand sides are rejected after escaped-backslash cons patterns" -}
+module X where
+
+go xs = case xs of
+  '^' : '\\' : xs -> '\^\' : go xs
+  ys -> ys

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-empty-list-quote-after-arrow.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-empty-list-quote-after-arrow.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="a following equation with a quoted empty-list TH name is rejected after a quoted arrow-name equation" -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module X where
+
+import Language.Haskell.TH
+
+headOfType ArrowT = ''(->)
+headOfType ListT = ''[]


### PR DESCRIPTION
## Summary
- Add oracle `xfail` fixtures for three minimized Hackage repros from `th-extras`, `interpolate`, and `termbox-bindings-c`.
- Cover parser gaps in Template Haskell quoted empty-list names after a quoted arrow case, escaped control-character literals in case alternative RHSs, and `foreign import capi interruptible` declarations with combined header/symbol strings.
- Oracle progress after this change: `pass=832`, `xfail=13`, `xpass=0`, `fail=0`, completion `98.47%`.

## Validation
- `just fmt`
- `just check`
- `cabal test -v0 aihc-parser:spec --test-options=--hide-successes`

## Review
- `coderabbit review --prompt-only` could not run because CodeRabbit returned a rate-limit error.
