### PR TITLE
test(parser): add hackage oracle xfail fixtures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/configurator-export-case-alt-dollar-plus.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/configurator-export-case-alt-dollar-plus.hs
@@ -1,0 +1,20 @@
+{- ORACLE_TEST xfail reason="configurator-export uses a case alternative continuation line beginning with infix operator $+$ that the parser rejects" -}
+
+module M where
+
+import Data.List.NonEmpty (NonEmpty (..), toList)
+import Text.PrettyPrint (Doc, ($+$), (<+>))
+import qualified Text.PrettyPrint as P
+
+keysToDoc :: NonEmpty (String, Either Int String) -> Doc
+keysToDoc l@((_, Right _) :| _) =
+  P.vcat . addSep 0 $
+    [groupToDoc n g | (n, Right g) <- toList l]
+  where
+    addSep _ = id
+    groupToDoc k g =
+      case True of
+        True -> P.text k <+> P.lbrace
+        False -> P.text k $+$ P.lbrace
+        $+$ P.nest 4 (P.text g)
+        $+$ P.rbrace

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs
@@ -1,0 +1,17 @@
+{- ORACLE_TEST xfail reason="type-set uses the type-level application operator $ in type instance heads, which the parser rejects" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module M where
+
+import Data.Kind (Type)
+
+type a >-> b = (b -> Type) -> a -> Type
+
+type family ($) (f :: a >-> b) (x :: a) :: b
+
+data InsertElse t t' ts :: () >-> k
+
+type instance InsertElse t t' ts $ '() = t

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/typelevel-tools-yj-infix-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/typelevel-tools-yj-infix-instance-head.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail reason="typelevel-tools-yj uses promoted list syntax in infix typeclass instance heads, which the parser rejects" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module M where
+
+class (xs :: [k]) `IsPrefixOf` (ys :: [k])
+
+instance '[] `IsPrefixOf` ys


### PR DESCRIPTION
## Summary
- add oracle `xfail` fixtures for package-derived parser gaps from `configurator-export`, `typelevel-tools-yj`, and `type-set`
- capture the minimal standalone repros for infix `$+$` continuation layout, infix instance heads over promoted lists, and type instance heads using type-level `$`
- parser progress after this change: PASS 832, XFAIL 13, XPASS 0, FAIL 0, TOTAL 845, COMPLETE 98.46%

## Validation
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "configurator-export-case-alt-dollar-plus"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "type-set-type-instance-dollar-application"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "typelevel-tools-yj-infix-instance-head"'`
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` could not run because the service returned a rate-limit error