### PR TITLE
fix(parser): accept associated type defaults in class bodies

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -447,6 +447,26 @@ classDefaultTypeInstParser = withSpan $ do
           typeFamilyInstRhs = rhs
         }
 
+-- | Parse @type [forall binders.] LhsType = RhsType@ as a shorthand default
+-- associated type instance in a class body.
+classDefaultTypeInstShorthandParser :: TokParser ClassDeclItem
+classDefaultTypeInstShorthandParser = withSpan $ do
+  expectedTok TkKeywordType
+  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  (headForm, lhs) <- typeFamilyLhsParser
+  expectedTok TkReservedEquals
+  rhs <- typeParser
+  pure $ \span' ->
+    ClassItemDefaultTypeInst
+      span'
+      TypeFamilyInst
+        { typeFamilyInstSpan = span',
+          typeFamilyInstForall = forallBinders,
+          typeFamilyInstHeadForm = headForm,
+          typeFamilyInstLhs = lhs,
+          typeFamilyInstRhs = rhs
+        }
+
 -- ---------------------------------------------------------------------------
 -- TypeFamilies: instance body items
 
@@ -648,7 +668,7 @@ ordinaryClassDeclItemParser = do
     TkKeywordDefault -> classDefaultSigItemParser
     TkKeywordType
       | lexTokenKind nextTok == TkKeywordInstance -> classDefaultTypeInstParser
-    TkKeywordType -> classTypeFamilyDeclParser
+    TkKeywordType -> MP.try classDefaultTypeInstShorthandParser <|> classTypeFamilyDeclParser
     _ -> do
       isSig <- startsWithTypeSig
       if isSig then classTypeSigItemParser else classDefaultItemParser

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -62,7 +62,6 @@ buildTests = do
           [ testCase "module parses declaration list" test_moduleParsesDecls,
             testCase "module parses nullary class declaration" test_moduleParsesNullaryClassDecl,
             testCase "module parses nullary class declaration with where block" test_moduleParsesNullaryClassDeclWithWhere,
-            testCase "parses shorthand associated type defaults in class bodies" test_classParsesAssociatedTypeDefaultShorthand,
             testCase "reads header LANGUAGE pragmas" test_readsHeaderLanguagePragmas,
             testCase "reads header LANGUAGE pragmas case-insensitively" test_readsHeaderLanguagePragmasCaseInsensitive,
             testCase "reads chunked header LANGUAGE pragmas" test_readsChunkedHeaderLanguagePragmas,
@@ -270,51 +269,6 @@ test_moduleParsesNullaryClassDeclWithWhere =
             pure ()
           other ->
             assertFailure ("unexpected parsed declarations: " <> show other)
-
-test_classParsesAssociatedTypeDefaultShorthand :: Assertion
-test_classParsesAssociatedTypeDefaultShorthand =
-  let source =
-        T.unlines
-          [ "{-# LANGUAGE TypeFamilies #-}",
-            "module M where",
-            "class Foo n where",
-            "  type O n",
-            "  type O n = Int"
-          ]
-      (errs, modu) = parseModule defaultConfig source
-   in do
-        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
-        case moduleDecls modu of
-          [ DeclClass
-              _
-              ClassDecl
-                { classDeclName = "Foo",
-                  classDeclParams = [TyVarBinder _ "n" Nothing TyVarBSpecified],
-                  classDeclItems =
-                    [ ClassItemTypeFamilyDecl
-                        _
-                        TypeFamilyDecl
-                          { typeFamilyDeclHeadForm = TypeHeadPrefix,
-                            typeFamilyDeclHead = TCon _ "O" Unpromoted,
-                            typeFamilyDeclParams = [TyVarBinder _ "n" Nothing TyVarBSpecified],
-                            typeFamilyDeclKind = Nothing,
-                            typeFamilyDeclEquations = Nothing
-                          },
-                      ClassItemDefaultTypeInst
-                        _
-                        TypeFamilyInst
-                          { typeFamilyInstForall = [],
-                            typeFamilyInstHeadForm = TypeHeadPrefix,
-                            typeFamilyInstLhs = TApp _ (TCon _ "O" Unpromoted) (TVar _ "n"),
-                            typeFamilyInstRhs = TCon _ "Int" Unpromoted
-                          }
-                      ]
-                }
-            ] -> pure ()
-          other -> assertFailure ("unexpected parsed declarations: " <> show other)
-        case validateParser "AssociatedTypeDefault.hs" Haskell2010Edition [EnableExtension TypeFamilies] source of
-          Nothing -> pure ()
-          Just err -> assertFailure ("expected associated type default shorthand to validate, got: " <> show err)
 
 test_typeParsesParenthesizedKindSignature :: Assertion
 test_typeParsesParenthesizedKindSignature =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -62,6 +62,7 @@ buildTests = do
           [ testCase "module parses declaration list" test_moduleParsesDecls,
             testCase "module parses nullary class declaration" test_moduleParsesNullaryClassDecl,
             testCase "module parses nullary class declaration with where block" test_moduleParsesNullaryClassDeclWithWhere,
+            testCase "parses shorthand associated type defaults in class bodies" test_classParsesAssociatedTypeDefaultShorthand,
             testCase "reads header LANGUAGE pragmas" test_readsHeaderLanguagePragmas,
             testCase "reads header LANGUAGE pragmas case-insensitively" test_readsHeaderLanguagePragmasCaseInsensitive,
             testCase "reads chunked header LANGUAGE pragmas" test_readsChunkedHeaderLanguagePragmas,
@@ -269,6 +270,51 @@ test_moduleParsesNullaryClassDeclWithWhere =
             pure ()
           other ->
             assertFailure ("unexpected parsed declarations: " <> show other)
+
+test_classParsesAssociatedTypeDefaultShorthand :: Assertion
+test_classParsesAssociatedTypeDefaultShorthand =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE TypeFamilies #-}",
+            "module M where",
+            "class Foo n where",
+            "  type O n",
+            "  type O n = Int"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        case moduleDecls modu of
+          [ DeclClass
+              _
+              ClassDecl
+                { classDeclName = "Foo",
+                  classDeclParams = [TyVarBinder _ "n" Nothing TyVarBSpecified],
+                  classDeclItems =
+                    [ ClassItemTypeFamilyDecl
+                        _
+                        TypeFamilyDecl
+                          { typeFamilyDeclHeadForm = TypeHeadPrefix,
+                            typeFamilyDeclHead = TCon _ "O" Unpromoted,
+                            typeFamilyDeclParams = [TyVarBinder _ "n" Nothing TyVarBSpecified],
+                            typeFamilyDeclKind = Nothing,
+                            typeFamilyDeclEquations = Nothing
+                          },
+                      ClassItemDefaultTypeInst
+                        _
+                        TypeFamilyInst
+                          { typeFamilyInstForall = [],
+                            typeFamilyInstHeadForm = TypeHeadPrefix,
+                            typeFamilyInstLhs = TApp _ (TCon _ "O" Unpromoted) (TVar _ "n"),
+                            typeFamilyInstRhs = TCon _ "Int" Unpromoted
+                          }
+                      ]
+                }
+            ] -> pure ()
+          other -> assertFailure ("unexpected parsed declarations: " <> show other)
+        case validateParser "AssociatedTypeDefault.hs" Haskell2010Edition [EnableExtension TypeFamilies] source of
+          Nothing -> pure ()
+          Just err -> assertFailure ("expected associated type default shorthand to validate, got: " <> show err)
 
 test_typeParsesParenthesizedKindSignature :: Assertion
 test_typeParsesParenthesizedKindSignature =

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/associated-type-default-shorthand.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/associated-type-default-shorthand.yaml
@@ -1,0 +1,10 @@
+extensions: [TypeFamilies]
+input: |
+  {-# LANGUAGE TypeFamilies #-}
+  module M where
+  class Foo n where
+    type O n
+    type O n = Int
+ast: |
+  Module {name = "M", languagePragmas = [EnableExtension TypeFamilies], decls = [DeclClass (ClassDecl {headForm = TypeHeadPrefix, name = "Foo", params = [TyVarBinder {name = "n"}], items = [ClassItemTypeFamilyDecl (TypeFamilyDecl {headForm = TypeHeadPrefix, head = TCon "O", params = [TyVarBinder {name = "n"}]}), ClassItemDefaultTypeInst (TypeFamilyInst {headForm = TypeHeadPrefix, lhs = TApp (TCon "O") (TVar "n"), rhs = TCon "Int"})]})]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-type-default.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-type-default.hs
@@ -1,10 +1,11 @@
-{- ORACLE_TEST xfail associated type default equation without 'instance' keyword is not yet supported -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
+
 module AssociatedTypeDefault where
 
 -- Type family default equation without 'instance' keyword.
 -- GHC allows: type F a = <rhs> inside a class body as shorthand for
--- type instance F a = <rhs>.  Parser currently rejects the '=' here.
+-- type instance F a = <rhs>.
 class Foo n where
   type O n
   type O n = Int

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -527,6 +527,7 @@ genDeclClass = do
   name <- genConIdent
   params <- genSimpleTyVarBinders
   ctx <- genOptionalSimpleContext
+  items <- genClassDeclItems params
   pure $
     DeclClass span0 $
       ClassDecl
@@ -536,8 +537,68 @@ genDeclClass = do
           classDeclName = name,
           classDeclParams = params,
           classDeclFundeps = [],
-          classDeclItems = []
+          classDeclItems = items
         }
+
+genClassDeclItems :: [TyVarBinder] -> Gen [ClassDeclItem]
+genClassDeclItems params =
+  frequency
+    [ (3, pure []),
+      (2, (: []) <$> genClassTypeSigItem),
+      (2, (: []) <$> genClassAssociatedTypeDeclItem params),
+      (1, genClassAssociatedTypeItems params)
+    ]
+
+genClassTypeSigItem :: Gen ClassDeclItem
+genClassTypeSigItem = do
+  name <- genVarBinderName
+  ClassItemTypeSig span0 [name] <$> genSimpleType
+
+genClassAssociatedTypeDeclItem :: [TyVarBinder] -> Gen ClassDeclItem
+genClassAssociatedTypeDeclItem params = do
+  tf <- genAssociatedTypeFamilyDecl params
+  pure $ ClassItemTypeFamilyDecl span0 tf
+
+genClassAssociatedTypeItems :: [TyVarBinder] -> Gen [ClassDeclItem]
+genClassAssociatedTypeItems params = do
+  tf <- genAssociatedTypeFamilyDecl params
+  mDefault <- genAssociatedTypeDefaultInst tf params
+  pure $ ClassItemTypeFamilyDecl span0 tf : maybe [] (pure . ClassItemDefaultTypeInst span0) mDefault
+
+genAssociatedTypeFamilyDecl :: [TyVarBinder] -> Gen TypeFamilyDecl
+genAssociatedTypeFamilyDecl classParams = do
+  name <- genConIdent
+  paramCount <- chooseInt (0, min 2 (length classParams))
+  params <- take paramCount <$> shuffle classParams
+  let headType = TCon span0 (qualifyName Nothing (mkUnqualifiedName NameConId name)) Unpromoted
+  pure $
+    TypeFamilyDecl
+      { typeFamilyDeclSpan = span0,
+        typeFamilyDeclHeadForm = TypeHeadPrefix,
+        typeFamilyDeclHead = headType,
+        typeFamilyDeclParams = params,
+        typeFamilyDeclKind = Nothing,
+        typeFamilyDeclEquations = Nothing
+      }
+
+genAssociatedTypeDefaultInst :: TypeFamilyDecl -> [TyVarBinder] -> Gen (Maybe TypeFamilyInst)
+genAssociatedTypeDefaultInst tf classParams =
+  if null classParams || null (typeFamilyDeclParams tf)
+    then pure Nothing
+    else frequency [(1, pure Nothing), (3, Just <$> mkDefaultInst)]
+  where
+    mkDefaultInst = do
+      rhs <- genSimpleType
+      let argTypes = [TVar span0 (mkUnqualifiedName NameVarId (tyVarBinderName param)) | param <- typeFamilyDeclParams tf]
+          lhs = foldl (TApp span0) (typeFamilyDeclHead tf) argTypes
+      pure $
+        TypeFamilyInst
+          { typeFamilyInstSpan = span0,
+            typeFamilyInstForall = [],
+            typeFamilyInstHeadForm = typeFamilyDeclHeadForm tf,
+            typeFamilyInstLhs = lhs,
+            typeFamilyInstRhs = rhs
+          }
 
 genDeclInstance :: Gen Decl
 genDeclInstance = do


### PR DESCRIPTION
## Summary
- accept `type O n = Int` shorthand for default associated type instances inside class bodies, mapping it to the existing `ClassItemDefaultTypeInst` AST path
- extend declaration generation so QuickCheck now produces class items, including associated type declarations and default associated type instances
- convert `components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-type-default.hs` from `xfail` to `pass` and add a focused parser regression test

## Verification
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (returned unrelated fixture findings only)

## Progress Counts
- oracle fixture status: `XFAIL -> PASS` for `TypeFamilies/associated-type-default.hs`
- no README progress files updated per repo policy