### PR TITLE
fix(parser): handle full character literal escape spellings

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Quoted.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Aihc.Parser.Lex.Quoted
@@ -76,13 +77,9 @@ consumedEscapeTail :: Text -> Maybe Int
 consumedEscapeTail rest =
   if T.null rest
     then Nothing
-    else
-      let c = T.head rest
-       in if isSpace c
-            then case T.findIndex (not . isSpace) rest of
-              Just i | T.index rest i == '\\' -> Just (i + 1)
-              _ -> Just 1
-            else Just 1
+    else do
+      (_, rest') <- parseEscape rest
+      pure (T.length rest - T.length rest')
 
 -- | Decode the body of a Haskell string literal (content between the quotes,
 -- without the surrounding @\"@ characters) natively on 'Text', avoiding the
@@ -105,64 +102,66 @@ decodeStringBody inp
               Just (mc, rest') ->
                 go (maybe acc' (\c -> acc' <> TLB.singleton c) mc) rest'
             _ -> Just acc' -- unreachable: T.break stops at '\\'
-    parseEscape :: Text -> Maybe (Maybe Char, Text)
-    parseEscape t = case T.uncons t of
-      Nothing -> Nothing
-      Just (c, rest) -> case c of
-        'a' -> Just (Just '\a', rest)
-        'b' -> Just (Just '\b', rest)
-        'f' -> Just (Just '\f', rest)
-        'n' -> Just (Just '\n', rest)
-        'r' -> Just (Just '\r', rest)
-        't' -> Just (Just '\t', rest)
-        'v' -> Just (Just '\v', rest)
-        '\\' -> Just (Just '\\', rest)
-        '"' -> Just (Just '"', rest)
-        '\'' -> Just (Just '\'', rest)
-        '&' -> Just (Nothing, rest) -- empty escape
-        '^' -> case T.uncons rest of -- control character \^X
-          Just (cc, rest')
-            | cc >= '@' && cc <= '_' ->
-                Just (Just (chr (ord cc - 64)), rest')
-          _ -> Nothing
-        'x' ->
-          -- hex escape \xNN  (use Integer to prevent Int overflow on long inputs)
-          let (digits, rest') = T.span isHexDigit rest
-           in if T.null digits
-                then Nothing
-                else
-                  let n = T.foldl' (\a d -> a * 16 + toInteger (digitToInt d)) (0 :: Integer) digits
-                   in if n > 0x10FFFF then Nothing else Just (Just (chr (fromIntegral n)), rest')
-        'o' ->
-          -- octal escape \oNN  (use Integer to prevent Int overflow on long inputs)
-          let (digits, rest') = T.span isOctDigit rest
-           in if T.null digits
-                then Nothing
-                else
-                  let n = T.foldl' (\a d -> a * 8 + toInteger (digitToInt d)) (0 :: Integer) digits
-                   in if n > 0x10FFFF then Nothing else Just (Just (chr (fromIntegral n)), rest')
-        _
-          | isDigit c -> -- decimal escape \NNN  (use Integer to prevent Int overflow on long inputs)
-              let (moreDigits, rest') = T.span isDigit rest
-                  n = T.foldl' (\a d -> a * 10 + toInteger (digitToInt d)) (toInteger (digitToInt c)) moreDigits
-               in if n > 0x10FFFF then Nothing else Just (Just (chr (fromIntegral n)), rest')
-          | isSpace c -> -- gap escape \ whitespace \
-              let rest' = T.dropWhile isSpace rest
-               in case T.uncons rest' of
-                    Just ('\\', rest'') -> Just (Nothing, rest'')
-                    _ -> Nothing
-          | otherwise -> parseNamedEscape t
-
-    parseNamedEscape :: Text -> Maybe (Maybe Char, Text)
-    parseNamedEscape t = foldr tryMatch Nothing namedEscapeTable
-      where
-        tryMatch (name, ch) fallback =
-          case T.stripPrefix name t of
-            Just rest -> Just (Just ch, rest)
-            Nothing -> fallback
 
 isOctDigit :: Char -> Bool
 isOctDigit c = c >= '0' && c <= '7'
+
+parseEscape :: Text -> Maybe (Maybe Char, Text)
+parseEscape t = case T.uncons t of
+  Nothing -> Nothing
+  Just (c, rest) -> case c of
+    'a' -> Just (Just '\a', rest)
+    'b' -> Just (Just '\b', rest)
+    'f' -> Just (Just '\f', rest)
+    'n' -> Just (Just '\n', rest)
+    'r' -> Just (Just '\r', rest)
+    't' -> Just (Just '\t', rest)
+    'v' -> Just (Just '\v', rest)
+    '\\' -> Just (Just '\\', rest)
+    '"' -> Just (Just '"', rest)
+    '\'' -> Just (Just '\'', rest)
+    '&' -> Just (Nothing, rest) -- empty escape
+    '^' -> case T.uncons rest of -- control character \^X
+      Just (cc, rest')
+        | cc >= '@' && cc <= '_' ->
+            Just (Just (chr (ord cc - 64)), rest')
+      _ -> Nothing
+    'x' ->
+      -- hex escape \xNN  (use Integer to prevent Int overflow on long inputs)
+      let (digits, rest') = T.span isHexDigit rest
+       in if T.null digits
+            then Nothing
+            else decodeNumericEscape 16 digits rest'
+    'o' ->
+      -- octal escape \oNN  (use Integer to prevent Int overflow on long inputs)
+      let (digits, rest') = T.span isOctDigit rest
+       in if T.null digits
+            then Nothing
+            else decodeNumericEscape 8 digits rest'
+    _
+      | isDigit c -> -- decimal escape \NNN  (use Integer to prevent Int overflow on long inputs)
+          let (moreDigits, rest') = T.span isDigit rest
+              digits = T.cons c moreDigits
+           in decodeNumericEscape 10 digits rest'
+      | isSpace c -> -- gap escape \ whitespace \
+          let rest' = T.dropWhile isSpace rest
+           in case T.uncons rest' of
+                Just ('\\', rest'') -> Just (Nothing, rest'')
+                _ -> Nothing
+      | otherwise -> parseNamedEscape t
+  where
+    decodeNumericEscape :: Integer -> Text -> Text -> Maybe (Maybe Char, Text)
+    decodeNumericEscape !base digits rest' =
+      let n = T.foldl' (\a d -> a * base + toInteger (digitToInt d)) (0 :: Integer) digits
+       in if n > 0x10FFFF then Nothing else Just (Just (chr (fromIntegral n)), rest')
+
+parseNamedEscape :: Text -> Maybe (Maybe Char, Text)
+parseNamedEscape t = foldr tryMatch Nothing namedEscapeTable
+  where
+    tryMatch (name, ch) fallback =
+      case T.stripPrefix name t of
+        Just rest -> Just (Just ch, rest)
+        Nothing -> fallback
 
 -- Named ASCII escape sequences per the Haskell 2010 report.
 -- SOH must appear before SO so the longest prefix wins.

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -7,8 +7,10 @@ import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions, readModuleHeaderExtensions, readModuleHeaderExtensionsFromChunks)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
+import Data.Char (ord)
 import Data.List (isInfixOf)
 import Data.Text qualified as T
+import Numeric (showHex, showOct)
 import ParserValidation (validateParser)
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
@@ -96,6 +98,9 @@ buildTests = do
             testCase "parser config sets source name in parse errors" test_parserConfigSetsSourceName,
             testCase "parses tab-indented where after else branch" test_tabIndentedWhereAfterElseParses,
             testCase "parses non-aligned multi-way-if guards" test_nonAlignedMultiWayIfGuardsParse,
+            testCase "lexes alternate valid character literal spellings" test_alternateCharLiteralSpellingsLexLikeGhc,
+            testCase "lexes control-backslash character literal" test_controlBackslashCharLiteralLexes,
+            testCase "parses character literals after escaped backslash cons patterns" test_escapedBackslashConsPatternCharLiteralParses,
             testCase "generated identifiers reject extension keyword rec" test_generatedIdentifiersRejectExtensionKeywordRec,
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
@@ -119,6 +124,7 @@ buildTests = do
             testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
             testCase "parses mdo view patterns" test_mdoViewPatternParses,
             testCase "parses and roundtrips infix type family heads" test_infixTypeFamilyHeadRoundtrip,
+            QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
             QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism
           ],
@@ -955,6 +961,38 @@ test_generatedExpressionsCanIncludeMdo =
     isMdo (EDo _ _ True) = True
     isMdo _ = False
 
+test_alternateCharLiteralSpellingsLexLikeGhc :: Assertion
+test_alternateCharLiteralSpellingsLexLikeGhc =
+  mapM_ assertCharLiteralLexesLikeGhc finiteAlternateCharLiteralSpellings
+
+test_controlBackslashCharLiteralLexes :: Assertion
+test_controlBackslashCharLiteralLexes =
+  assertCharLiteralLexesLikeGhc "'\\^\\'"
+
+test_escapedBackslashConsPatternCharLiteralParses :: Assertion
+test_escapedBackslashConsPatternCharLiteralParses =
+  let source =
+        T.unlines
+          [ "module X where",
+            "",
+            "go xs = case xs of",
+            "  '^' : '\\\\' : xs -> '\\^\\' : go xs",
+            "  ys -> ys"
+          ]
+      (errs, _) = parseModule defaultConfig source
+   in assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+
+prop_validGeneratedCharLiteralSpellingsLexLikeGhc :: QC.Property
+prop_validGeneratedCharLiteralSpellingsLexLikeGhc =
+  QC.withMaxSuccess 2000 $ QC.forAll genValidCharLiteral $ \raw ->
+    QC.counterexample ("literal: " <> T.unpack raw) $
+      case ghcReadCharLiteral raw of
+        Nothing -> QC.counterexample "generator produced an invalid literal" False
+        Just expected ->
+          case lexTokens raw of
+            [LexToken {lexTokenKind = TkChar actual}, LexToken {lexTokenKind = TkEOF}] -> actual QC.=== expected
+            other -> QC.counterexample ("unexpected tokens: " <> show other) False
+
 prop_generatedOperatorsRejectDashOnlyCommentStarters :: QC.Property
 prop_generatedOperatorsRejectDashOnlyCommentStarters =
   QC.forAll (QC.vectorOf 2000 genOperator) $ \ops ->
@@ -967,6 +1005,111 @@ prop_generatedOperatorsCanProduceUnicodeAsterism =
     QC.forAll (QC.vectorOf 2000 genOperator) $ \ops ->
       QC.counterexample "expected generator to include ⁂ in sampled operators" $
         "⁂" `elem` ops
+
+assertCharLiteralLexesLikeGhc :: T.Text -> Assertion
+assertCharLiteralLexesLikeGhc raw =
+  case ghcReadCharLiteral raw of
+    Nothing -> assertFailure ("expected GHC to accept valid char literal: " <> show raw)
+    Just expected ->
+      case lexTokens raw of
+        [LexToken {lexTokenKind = TkChar actual}, LexToken {lexTokenKind = TkEOF}] ->
+          assertEqual ("character mismatch for literal " <> T.unpack raw) expected actual
+        other ->
+          assertFailure ("expected char token for literal " <> T.unpack raw <> ", got: " <> show other)
+
+ghcReadCharLiteral :: T.Text -> Maybe Char
+ghcReadCharLiteral raw =
+  case reads (T.unpack raw) of
+    [(c, "")] -> Just c
+    _ -> Nothing
+
+genValidCharLiteral :: QC.Gen T.Text
+genValidCharLiteral =
+  QC.oneof
+    [ T.pack . show <$> (QC.arbitrary :: QC.Gen Char),
+      QC.elements finiteAlternateCharLiteralSpellings,
+      genNumericCharLiteral,
+      genHexCharLiteral,
+      genOctalCharLiteral
+    ]
+
+genNumericCharLiteral :: QC.Gen T.Text
+genNumericCharLiteral = do
+  c <- QC.arbitrary :: QC.Gen Char
+  leadingZeros <- QC.chooseInt (0, 4)
+  pure (mkCharLiteral ("\\" <> T.replicate leadingZeros "0" <> T.pack (show (ord c))))
+
+genHexCharLiteral :: QC.Gen T.Text
+genHexCharLiteral = do
+  c <- QC.arbitrary :: QC.Gen Char
+  leadingZeros <- QC.chooseInt (0, 4)
+  uppercase <- QC.arbitrary
+  let digits = showHex (ord c) ""
+      rendered = if uppercase then map toUpperAscii digits else digits
+  pure (mkCharLiteral ("\\x" <> T.replicate leadingZeros "0" <> T.pack rendered))
+
+genOctalCharLiteral :: QC.Gen T.Text
+genOctalCharLiteral = do
+  c <- QC.arbitrary :: QC.Gen Char
+  leadingZeros <- QC.chooseInt (0, 4)
+  pure (mkCharLiteral ("\\o" <> T.replicate leadingZeros "0" <> T.pack (showOct (ord c) "")))
+
+mkCharLiteral :: T.Text -> T.Text
+mkCharLiteral body = "'" <> body <> "'"
+
+finiteAlternateCharLiteralSpellings :: [T.Text]
+finiteAlternateCharLiteralSpellings = map mkCharLiteral (simpleEscapeBodies <> controlEscapeBodies <> namedEscapeBodies)
+
+simpleEscapeBodies :: [T.Text]
+simpleEscapeBodies = ["\\a", "\\b", "\\f", "\\n", "\\r", "\\t", "\\v", "\\\\", "\\\"", "\\'"]
+
+controlEscapeBodies :: [T.Text]
+controlEscapeBodies = [T.pack ['\\', '^', c] | c <- ['@' .. '_']]
+
+namedEscapeBodies :: [T.Text]
+namedEscapeBodies =
+  map
+    ("\\" <>)
+    [ "NUL",
+      "SOH",
+      "STX",
+      "ETX",
+      "EOT",
+      "ENQ",
+      "ACK",
+      "BEL",
+      "BS",
+      "HT",
+      "LF",
+      "VT",
+      "FF",
+      "CR",
+      "SO",
+      "SI",
+      "DLE",
+      "DC1",
+      "DC2",
+      "DC3",
+      "DC4",
+      "NAK",
+      "SYN",
+      "ETB",
+      "CAN",
+      "EM",
+      "SUB",
+      "ESC",
+      "FS",
+      "GS",
+      "RS",
+      "US",
+      "SP",
+      "DEL"
+    ]
+
+toUpperAscii :: Char -> Char
+toUpperAscii c
+  | 'a' <= c && c <= 'f' = toEnum (fromEnum c - 32)
+  | otherwise = c
 
 -- Helper: parse a do-expression and extract the do-statements.
 parseDoStmts :: T.Text -> Either String [DoStmt Expr]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/escaped-backslash-cons-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Patterns/escaped-backslash-cons-pattern.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="character literals like '\^\\' in case alternative right-hand sides are rejected after escaped-backslash cons patterns" -}
+{- ORACLE_TEST pass -}
 module X where
 
 go xs = case xs of


### PR DESCRIPTION
## Summary
- fix quoted literal scanning so character literals consume full escape spellings instead of treating every backslash escape as one character
- add parser and property coverage that compares valid character literal spellings against GHC, including the `\^` control escape regression after escaped-backslash cons patterns
- promote `escaped-backslash-cons-pattern.hs` from oracle xfail to pass

## Checks
- just fmt
- just check
- coderabbit review --prompt-only