### PR TITLE
fix(parser): support infix operator continuation after case expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -65,7 +65,6 @@ exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
     TkKeywordDo -> doExprParser
     TkKeywordMdo -> mdoExprParser
     TkKeywordIf -> ifExprParser
-    TkKeywordCase -> caseExprParser
     TkKeywordLet -> letExprParser
     TkKeywordProc -> procExprParser
     TkReservedBackslash -> lambdaExprParser
@@ -192,7 +191,6 @@ exprCoreParserNoArrowTail = do
     TkKeywordDo -> doExprParser
     TkKeywordMdo -> mdoExprParser
     TkKeywordIf -> ifExprParser
-    TkKeywordCase -> caseExprParser
     TkKeywordLet -> letExprParser
     TkKeywordProc -> procExprParser
     TkReservedBackslash -> lambdaExprParser

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -101,6 +101,20 @@ isGreedyExpr = \case
   EApp _ _ arg | isBlockExpr arg -> isOpenEnded arg
   _ -> False
 
+-- | Check if an expression is "braced" - i.e., the pretty-printer always
+-- wraps it in explicit @{ }@ braces, making it self-delimiting, AND the parser
+-- can parse the resulting @expr { ... } op rhs@ without parentheses.
+-- Self-delimiting expressions do not need parentheses on the left-hand side of
+-- an infix operator, because the closing @}@ unambiguously ends the expression.
+--
+-- Note: 'EDo' and 'ELambdaCase' also use explicit braces in the pretty-printer,
+-- but their parsers still use a dedicated dispatch that does not handle trailing
+-- infix operators. They are excluded here until those parsers are fixed.
+isBracedExpr :: Expr -> Bool
+isBracedExpr = \case
+  ECase {} -> True
+  _ -> False
+
 -- | Check if an expression is "open-ended" - its rightmost component can
 -- capture a trailing where clause.
 isOpenEnded :: Expr -> Bool
@@ -193,7 +207,9 @@ exprCtxPrec ctx expr =
     CtxInfixRhs _
       | isGreedyExpr expr -> 0
       | otherwise -> 1
-    CtxInfixLhs -> 1
+    CtxInfixLhs
+      | isBracedExpr expr -> 0
+      | otherwise -> 1
     CtxAppFun -> 2
     CtxAppArg -> 3
     CtxAppArgNoParens -> 0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/configurator-export-case-alt-dollar-plus.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/configurator-export-case-alt-dollar-plus.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="configurator-export uses a case alternative continuation line beginning with infix operator $+$ that the parser rejects" -}
+{- ORACLE_TEST pass -}
 
 module M where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-cons-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-cons-continuation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail cons operator at start of line after case expression not parsed -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE LambdaCase #-}
 
 module CaseConsContinuation where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-dollar-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSyntax/case-dollar-continuation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="operator continuation after case expression is not parsed" -}
+{- ORACLE_TEST pass -}
 module CaseDollarContinuation where
 
 f x y =


### PR DESCRIPTION
## Summary

- Remove special `TkKeywordCase` dispatch from `exprCoreParserWithoutTypeSigExcept` and `exprCoreParserNoArrowTail`, routing case expressions through `infixExprParserExcept` so trailing infix operators are parsed correctly
- Add `isBracedExpr` predicate in `Parens.hs` and update `exprCtxPrec` so `ECase` is not unnecessarily parenthesized on the LHS of infix operators (since its explicit `{}` braces make it self-delimiting)

## Root Cause

`exprCoreParserWithoutTypeSigExcept` had a special case `TkKeywordCase -> caseExprParser` that bypassed `infixExprParserExcept`. This meant:

```haskell
f x y =
  case x of
    Just z -> z
    Nothing -> id
    $ y    -- left unparsed, causing a top-level parse error
```

GHC parses this as `(case x of { ... }) $ y`, but our parser left `$ y` unconsumed after the case expression.

## Solution

**Parser fix**: Removing the `TkKeywordCase` dispatch sends case expressions through `infixExprParserExcept` (via `lexpParser`). `caseExprParser` already uses `bracedSemiSep` which closes the implicit layout via `closeAndExpectRBrace`, so the `$` token is correctly available to `infixOperatorParserExcept` after the case expression.

**Pretty-printer fix**: Since `ECase` always renders with explicit `{}` braces, the closing `}` self-delimits the expression — no `EParen` wrapper is needed on the infix LHS. Previously, unnecessary parens added a `HsPar` node in GHC's AST that changed the roundtrip fingerprint. Added `isBracedExpr` predicate and a special case in `exprCtxPrec` to pass precedence 0 (not 1) for `ECase` in `CtxInfixLhs`.

## Test plan

- [x] `PatternSyntax/case-dollar-continuation` promoted from xfail → pass
- [x] `PatternSyntax/case-cons-continuation` promoted from xfail → pass
- [x] `Hackage/configurator-export-case-alt-dollar-plus` promoted from xfail → pass
- [x] All 1371 existing tests continue to pass (no regressions)

## Follow-up

`EDo` and `ELambdaCase` also use explicit braces in the pretty-printer, but their parser dispatches (`TkKeywordDo`, `TkKeywordMdo`, `TkReservedBackslash`) still bypass `infixExprParserExcept`. They are excluded from `isBracedExpr` until those parsers receive the same fix.