### PR TITLE
fix(parser): support interruptible FFI safety modifier

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -859,6 +859,7 @@ foreignSafetyParser :: TokParser ForeignSafety
 foreignSafetyParser =
   (varIdTok "safe" >> pure Safe)
     <|> (varIdTok "unsafe" >> pure Unsafe)
+    <|> (varIdTok "interruptible" >> pure Interruptible)
 
 foreignEntityParser :: TokParser ForeignEntitySpec
 foreignEntityParser = foreignEntityFromString <$> stringTextParser

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -900,6 +900,7 @@ prettySafety safety =
   case safety of
     Safe -> "safe"
     Unsafe -> "unsafe"
+    Interruptible -> "interruptible"
 
 prettyForeignEntity :: ForeignEntitySpec -> Maybe (Doc ann)
 prettyForeignEntity spec =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -527,6 +527,7 @@ docForeignSafety fs =
   case fs of
     Safe -> "Safe"
     Unsafe -> "Unsafe"
+    Interruptible -> "Interruptible"
 
 docForeignEntitySpec :: ForeignEntitySpec -> Doc ann
 docForeignEntitySpec spec =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1545,6 +1545,7 @@ data CallConv
 data ForeignSafety
   = Safe
   | Unsafe
+  | Interruptible
   deriving (Data, Eq, Show, Generic, NFData)
 
 newtype Annotation = Annotation Dynamic

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/capi-interruptible-header-symbol.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/capi-interruptible-header-symbol.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="interruptible capi imports with a combined header and symbol string are parsed as if the string started a type signature" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE InterruptibleFFI #-}


### PR DESCRIPTION
## Root Cause

`foreign import capi interruptible "termbox.h tb_peek_event" tb_peek_event :: IO CInt` failed to parse because `foreignSafetyParser` only recognized `safe` and `unsafe` — not `interruptible`. As a result:

1. The safety parser saw `interruptible` (a plain `TkVarId`) and backtracked.
2. The entity parser saw `interruptible` (not a string literal) and backtracked.
3. The name parser consumed `interruptible` as the foreign name.
4. The parser then expected `::` but saw the string `"termbox.h tb_peek_event"`, which was subsequently mis-parsed as a type literal.

The `ForeignSafety` data type had no `Interruptible` constructor, despite `InterruptibleFFI` being listed as a supported language extension.

## Solution

- Added `Interruptible` constructor to `ForeignSafety` in `Syntax.hs`.
- Added `interruptible` branch to `foreignSafetyParser` in `Decl.hs`.
- Added `Interruptible` cases to `prettySafety` (`Pretty.hs`) and `docForeignSafety` (`Shorthand.hs`).
- Promoted the xfail oracle fixture to `pass`.

## Changes

- `Syntax.hs`: `ForeignSafety` gains `Interruptible` constructor
- `Decl.hs`: `foreignSafetyParser` recognizes `"interruptible"`
- `Pretty.hs`: `prettySafety` prints `"interruptible"`
- `Shorthand.hs`: `docForeignSafety` prints `"Interruptible"`
- `capi-interruptible-header-symbol.hs`: fixture promoted from `xfail` to `pass`