### PR TITLE
fix(parser): support infix continuation after do blocks

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -69,10 +69,12 @@ exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
     TkKeywordProc -> procExprParser
     TkReservedBackslash -> lambdaExprParser
     _ -> infixExprParserExcept forbiddenInfix
+  rest <- MP.many ((,) <$> infixOperatorParserExcept forbiddenInfix <*> region "after infix operator" lexpParser)
   afterArrow <- MP.optional arrowTailParser
+  let withInfix = foldl buildInfix base rest
   pure $ case afterArrow of
-    Just (op, rhs) -> EInfix (mergeSourceSpans (getSourceSpan base) (getSourceSpan rhs)) base op rhs
-    Nothing -> base
+    Just (op, rhs) -> EInfix (mergeSourceSpans (getSourceSpan withInfix) (getSourceSpan rhs)) withInfix op rhs
+    Nothing -> withInfix
 
 exprCoreParserWithTypeSigParserExcept :: TokParser Type -> [Text] -> TokParser Expr
 exprCoreParserWithTypeSigParserExcept typeSigParser forbiddenInfix = do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -106,13 +106,11 @@ isGreedyExpr = \case
 -- can parse the resulting @expr { ... } op rhs@ without parentheses.
 -- Self-delimiting expressions do not need parentheses on the left-hand side of
 -- an infix operator, because the closing @}@ unambiguously ends the expression.
---
--- Note: 'EDo' and 'ELambdaCase' also use explicit braces in the pretty-printer,
--- but their parsers still use a dedicated dispatch that does not handle trailing
--- infix operators. They are excluded here until those parsers are fixed.
 isBracedExpr :: Expr -> Bool
 isBracedExpr = \case
   ECase {} -> True
+  EDo {} -> True
+  ELambdaCase {} -> True
   _ -> False
 
 -- | Check if an expression is "open-ended" - its rightmost component can

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -120,7 +120,6 @@ buildTests = do
             testCase "roundtrips warned export reexports" test_warnedExportReexportRoundtrip,
             testCase "parses warned export module reexports" test_warnedExportModuleReexportParses,
             testCase "parses infix class heads" test_infixClassHeadParses,
-            testCase "roundtrips do statements continued by infix operators" test_doInfixContinuationRoundtrip,
             testCase "roundtrips else branches with local where clauses" test_ifElseWhereBranchRoundtrip,
             testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
             testCase "parses mdo view patterns" test_mdoViewPatternParses,
@@ -467,25 +466,6 @@ test_infixClassHeadParses =
             DeclClass _ ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified, TyVarBinder _ "b" Nothing TyVarBSpecified], classDeclItems = [ClassItemTypeSig _ ["proof"] _]}
             ] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
-
-test_doInfixContinuationRoundtrip :: Assertion
-test_doInfixContinuationRoundtrip =
-  let source =
-        T.unlines
-          [ "{-# LANGUAGE GHC2021 #-}",
-            "module M where",
-            "rassocP :: Maybe Int",
-            "rassocP = do",
-            "  f <- Just 1",
-            "  y <- do",
-            "    z <- Just 2",
-            "    Just (f + z)",
-            "  pure (f + y)",
-            "  <|> Just 0"
-          ]
-   in case validateParser "DoInfixContinuation.hs" Haskell2010Edition [] source of
-        Nothing -> pure ()
-        Just err -> assertFailure ("expected do infix continuation roundtrip to validate, got: " <> show err)
 
 test_ifElseWhereBranchRoundtrip :: Assertion
 test_ifElseWhereBranchRoundtrip =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -120,6 +120,7 @@ buildTests = do
             testCase "roundtrips warned export reexports" test_warnedExportReexportRoundtrip,
             testCase "parses warned export module reexports" test_warnedExportModuleReexportParses,
             testCase "parses infix class heads" test_infixClassHeadParses,
+            testCase "roundtrips do statements continued by infix operators" test_doInfixContinuationRoundtrip,
             testCase "roundtrips else branches with local where clauses" test_ifElseWhereBranchRoundtrip,
             testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
             testCase "parses mdo view patterns" test_mdoViewPatternParses,
@@ -466,6 +467,25 @@ test_infixClassHeadParses =
             DeclClass _ ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified, TyVarBinder _ "b" Nothing TyVarBSpecified], classDeclItems = [ClassItemTypeSig _ ["proof"] _]}
             ] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
+
+test_doInfixContinuationRoundtrip :: Assertion
+test_doInfixContinuationRoundtrip =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE GHC2021 #-}",
+            "module M where",
+            "rassocP :: Maybe Int",
+            "rassocP = do",
+            "  f <- Just 1",
+            "  y <- do",
+            "    z <- Just 2",
+            "    Just (f + z)",
+            "  pure (f + y)",
+            "  <|> Just 0"
+          ]
+   in case validateParser "DoInfixContinuation.hs" Haskell2010Edition [] source of
+        Nothing -> pure ()
+        Just err -> assertFailure ("expected do infix continuation roundtrip to validate, got: " <> show err)
 
 test_ifElseWhereBranchRoundtrip :: Assertion
 test_ifElseWhereBranchRoundtrip =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-block-alternative.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-block-alternative.hs
@@ -1,12 +1,14 @@
-{- ORACLE_TEST xfail do-block infix continuation with <|> operator -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
+
 module AttoparsecExpr where
 
 rassocP :: Maybe Int
-rassocP = do
-  f <- Just 1
-  y <- do
-    z <- Just 2
-    Just (f + z)
-  pure (f + y)
-  <|> Just 0
+rassocP =
+  do
+    f <- Just 1
+    y <- do
+      z <- Just 2
+      Just (f + z)
+    pure (f + y)
+    <|> Just 0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-block-alternative.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-block-alternative.hs
@@ -1,14 +1,12 @@
 {- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
-
 module AttoparsecExpr where
 
 rassocP :: Maybe Int
-rassocP =
-  do
-    f <- Just 1
-    y <- do
-      z <- Just 2
-      Just (f + z)
-    pure (f + y)
-    <|> Just 0
+rassocP = do
+  f <- Just 1
+  y <- do
+    z <- Just 2
+    Just (f + z)
+  pure (f + y)
+  <|> Just 0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-backtick-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-backtick-continuation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="infix backtick continuation after do block statement not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 
 module RollbarInfixDo where
@@ -7,7 +7,8 @@ catch :: IO a -> (String -> IO a) -> IO a
 catch = undefined
 
 test :: IO (Maybe Int)
-test = do
+test =
+  do
     x <- return 42
     return (Just x)
     `catch` (\e -> return Nothing)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-backtick-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-backtick-continuation.hs
@@ -7,8 +7,7 @@ catch :: IO a -> (String -> IO a) -> IO a
 catch = undefined
 
 test :: IO (Maybe Int)
-test =
-  do
+test = do
     x <- return 42
     return (Just x)
     `catch` (\e -> return Nothing)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-continuation.hs
@@ -1,11 +1,9 @@
 {- ORACLE_TEST pass -}
 {-# LANGUAGE DoAndIfThenElse #-}
-
 module DoInfixContinuation where
 
 -- Infix operator at the same indent level continues the previous
 -- expression rather than starting a new statement (parse-error rule).
-f x y =
-  do
-    x
-    + y
+f x y = do
+  x
+  + y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-infix-continuation.hs
@@ -1,9 +1,11 @@
-{- ORACLE_TEST xfail do-statement infix continuation (parse-error rule) -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DoAndIfThenElse #-}
+
 module DoInfixContinuation where
 
 -- Infix operator at the same indent level continues the previous
 -- expression rather than starting a new statement (parse-error rule).
-f x y = do
-  x
-  + y
+f x y =
+  do
+    x
+    + y


### PR DESCRIPTION
## Summary
- fix expression parsing so block-headed expressions like `do`, `mdo`, `if`, `let`, `proc`, and lambdas can continue into ordinary infix operators instead of stopping after the block parser branch
- update parenthesization so braced expressions that now support trailing infix (`do` and `\case`) are no longer wrapped unnecessarily on the left-hand side of infix applications
- convert the now-working oracle fixtures for symbolic and backtick `do` continuations from `xfail` to `pass`, and add a direct roundtrip regression test

## Root Cause
The failure was not in the oracle harness. The parser had a split expression path:
- non-block expressions went through `infixExprParserExcept`, which consumes ordinary infix operators
- block-headed expressions (`do`, `if`, `let`, `proc`, lambdas, `mdo`) used dedicated dispatch in `exprCoreParserWithoutTypeSigExcept` and only looked for arrow-tail operators afterward

That meant inputs like:
- `do ... <|> Just 0`
- `do ... `catch` ...`

were parsed as if the expression ended at the `do` block, even though GHC treats the `do` expression as the left-hand side of a larger infix application. The parenthesization pass had a matching stale assumption and still treated only `case` as a braced expression that could appear unparenthesized on the left of an infix operator.

## Solution Options Considered
- adjust layout token insertion for infix-start lines only: rejected because it breaks valid `do`-statement continuations like `x` followed by `+ y`
- special-case `do` in one parser branch: rejected because the same bug affects other block-headed expressions and backtick operators
- generalize the block-headed expression path to consume ordinary infix tails and update the parens pass accordingly: chosen because it fixes the root parser split and extends naturally to the whole expression family

## Testing
- ran `just fmt`
- ran focused parser/oracle regressions for `do-block-alternative` and `do-infix-continuation`
- ran `just check`

## Progress
- PASS: 841
- XFAIL: 13
- XPASS: 0
- FAIL: 0
- TOTAL: 854
- COMPLETE: 98.47%

## Follow-up
- filed #799 for unrelated broken oracle fixtures surfaced by `coderabbit review --prompt-only`; they were intentionally left out of this PR to keep the change scoped to the `do` infix-continuation parser fix