### PR TITLE
fix(parser): support TH name quotes for empty list constructor '[] and ''[]

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1080,13 +1080,13 @@ thNameQuoteExprParser = thValueNameQuoteParser <|> thTypeNameQuoteParser
 thValueNameQuoteParser :: TokParser Expr
 thValueNameQuoteParser = withSpan $ do
   expectedTok TkTHQuoteTick
-  name <- identifierTextParser <|> parenOperatorTextParser
+  name <- identifierTextParser <|> parenOperatorTextParser <|> bracketConstructorTextParser
   pure (`ETHNameQuote` name)
 
 thTypeNameQuoteParser :: TokParser Expr
 thTypeNameQuoteParser = withSpan $ do
   expectedTok TkTHTypeQuoteTick
-  name <- identifierNameParser <|> parenOperatorNameParser
+  name <- identifierNameParser <|> parenOperatorNameParser <|> bracketConstructorNameParser
   pure (`ETHTypeNameQuote` name)
 
 parenOperatorTextParser :: TokParser Text
@@ -1113,6 +1113,20 @@ parenOperatorNameParser = do
       _ -> Nothing
   expectedTok TkSpecialRParen
   pure op
+
+-- | Parse the empty-list constructor name @[]@ in a TH name quote context,
+-- i.e. the @[]@ in @'[]@ or the type-level @''[]@.
+bracketConstructorTextParser :: TokParser Text
+bracketConstructorTextParser = do
+  expectedTok TkSpecialLBracket
+  expectedTok TkSpecialRBracket
+  pure "[]"
+
+bracketConstructorNameParser :: TokParser Name
+bracketConstructorNameParser = do
+  expectedTok TkSpecialLBracket
+  expectedTok TkSpecialRBracket
+  pure (qualifyName Nothing (mkUnqualifiedName NameConId "[]"))
 
 quasiQuoteExprParser :: TokParser Expr
 quasiQuoteExprParser =

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -858,7 +858,7 @@ lexTHNameQuote env st
   | otherwise =
       case lexerInput st of
         '\'' :< ('\'' :< (c :< _))
-          | isIdentStart c || c == '(' ->
+          | isIdentStart c || c == '(' || c == '[' ->
               let raw = "''"
                   st' = advanceChars raw st
                in Just (mkToken st st' raw TkTHTypeQuoteTick, st')

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/do-where-after-module.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/do-where-after-module.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="TH name quote of empty list constructor in where clause causes layout parser to reject subsequent function definition" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-empty-list-name-quote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-empty-list-name-quote.hs
@@ -1,0 +1,20 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module THEmptyListNameQuote where
+
+import Language.Haskell.TH
+
+-- TH value name quote for the empty list constructor
+emptyListName :: Name
+emptyListName = '[]
+
+-- TH type name quote for the list type constructor
+listTypeName :: Name
+listTypeName = ''[]
+
+-- Both in a where clause to exercise layout interaction
+f :: Name -> Name
+f x = result
+  where
+    result = if x == '[] then ''[] else x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-empty-list-quote-after-arrow.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th-empty-list-quote-after-arrow.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="a following equation with a quoted empty-list TH name is rejected after a quoted arrow-name equation" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TemplateHaskell #-}
 
 module X where


### PR DESCRIPTION
## Root Cause

`'[]` (TH value name-quote for the empty list constructor) and `''[]` (type
name-quote for the list type constructor) were not parsed correctly due to
two related bugs.

**Bug 1 — Parser (`'[]`):**  
`thValueNameQuoteParser` accepted only identifiers or `(op)` after the quote
tick. For `'[]`, it consumed `TkTHQuoteTick` then failed on `TkSpecialLBracket`
(neither an identifier nor `(`). This produced a *consumed-and-failed* error.
The surrounding `MP.try valueDeclParser` caught the error and backtracked
past the entire declaration. `MP.optional declParser` then returned `Nothing`,
causing the module body to parse as empty — producing `Module {}` and a
spurious "unexpected = expecting end of input" error at the `=` of the
*following* function definition.

**Bug 2 — Lexer (`''[]`):**  
`lexTHNameQuote` emitted `TkTHTypeQuoteTick` for `''` only when the next
character was an identifier start or `(`. For `''[`, the `[` didn't match,
so `''[]` was tokenised as two `TkTHQuoteTick` tokens rather than one
`TkTHTypeQuoteTick` + `[` + `]`. The parser then saw a single-tick name-quote
followed by another tick and the same failure as Bug 1.

## Solution

**Lexer fix** (`Lex.hs`):  
Extend the `''`-prefix guard to also fire when followed by `[`, so `''[` is
emitted as `TkTHTypeQuoteTick`.

**Parser fix** (`Expr.hs`):  
Add `bracketConstructorTextParser` / `bracketConstructorNameParser` which
consume `TkSpecialLBracket TkSpecialRBracket` and return the name `"[]"`.
These are added as alternatives in both `thValueNameQuoteParser` and
`thTypeNameQuoteParser`.

## Changes

- `src/Aihc/Parser/Lex.hs`: emit `TkTHTypeQuoteTick` for `''[`
- `src/Aihc/Parser/Internal/Expr.hs`: add bracket constructor parsers for `[]` in TH name quotes
- Remove xfail from `LambdaCase/do-where-after-module`
- Remove xfail from `TemplateHaskell/th-empty-list-quote-after-arrow`
- Add new passing fixture `TemplateHaskell/th-empty-list-name-quote`

## Follow-up

Tuple constructor name quotes (`'(,)`, `'(,,)`, …) and unit constructor
`'()` / `''()` have similar gaps. They are not part of this PR — separate
issues can be filed if needed.