### PR TITLE
fix(parser): support data family instance kind signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -330,6 +330,7 @@ dataFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordInstance
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
   head' <- typeAppParser
+  kind <- familyResultKindParser
   (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
   pure $
     DeclDataFamilyInst
@@ -338,6 +339,7 @@ dataFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = forallBinders,
           dataFamilyInstHead = head',
+          dataFamilyInstKind = kind,
           dataFamilyInstConstructors = constructors,
           dataFamilyInstDeriving = derivingClauses
         }
@@ -358,6 +360,7 @@ newtypeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordInstance
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
   head' <- typeAppParser
+  kind <- familyResultKindParser
   expectedTok TkReservedEquals
   constructor <- newtypeConDeclParser
   derivingClauses <- MP.many derivingClauseParser
@@ -368,6 +371,7 @@ newtypeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           dataFamilyInstIsNewtype = True,
           dataFamilyInstForall = forallBinders,
           dataFamilyInstHead = head',
+          dataFamilyInstKind = kind,
           dataFamilyInstConstructors = [constructor],
           dataFamilyInstDeriving = derivingClauses
         }
@@ -481,6 +485,7 @@ instanceDataFamilyInstParser :: TokParser InstanceDeclItem
 instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   head' <- typeAppParser
+  kind <- familyResultKindParser
   (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
   pure $
     InstanceItemDataFamilyInst
@@ -489,6 +494,7 @@ instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
           dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
+          dataFamilyInstKind = kind,
           dataFamilyInstConstructors = constructors,
           dataFamilyInstDeriving = derivingClauses
         }
@@ -507,6 +513,7 @@ instanceNewtypeFamilyInstParser :: TokParser InstanceDeclItem
 instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
   head' <- typeAppParser
+  kind <- familyResultKindParser
   expectedTok TkReservedEquals
   constructor <- newtypeConDeclParser
   derivingClauses <- MP.many derivingClauseParser
@@ -517,6 +524,7 @@ instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $
           dataFamilyInstIsNewtype = True,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
+          dataFamilyInstKind = kind,
           dataFamilyInstConstructors = [constructor],
           dataFamilyInstDeriving = derivingClauses
         }

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -590,6 +590,7 @@ addDataFamilyInstParens :: DataFamilyInst -> DataFamilyInst
 addDataFamilyInstParens dfi =
   dfi
     { dataFamilyInstHead = addTypeParens (dataFamilyInstHead dfi),
+      dataFamilyInstKind = fmap addTypeParens (dataFamilyInstKind dfi),
       dataFamilyInstConstructors = map addDataConDeclParens (dataFamilyInstConstructors dfi),
       dataFamilyInstDeriving = map addDerivingClauseParens (dataFamilyInstDeriving dfi)
     }

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -29,7 +29,7 @@ where
 
 import Aihc.Parser.Parens (addDeclParens, addExprParens, addModuleParens, addPatternParens, addTypeParens)
 import Aihc.Parser.Syntax
-import Data.Char (GeneralCategory (..), generalCategory, isAscii)
+import Data.Char (GeneralCategory (..), generalCategory, isAscii, isAsciiLower, isAsciiUpper, isDigit, isUpper)
 import Data.Maybe (catMaybes, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -1287,11 +1287,18 @@ thNameQuoteTextNeedsParens name
   | isOperatorToken name = True
   | not (T.any (== '.') name) = False
   | otherwise =
-      case T.split (== '.') name of
-        [] -> False
-        parts ->
-          let suffix = last parts
-           in not (T.null suffix) && isOperatorToken suffix
+      case span isModuleSegment (T.split (== '.') name) of
+        ([], _) -> False
+        (_, []) -> False
+        (qualifiers, remainder) -> not (all T.null qualifiers) && isOperatorToken (T.intercalate "." remainder)
+  where
+    isModuleSegment segment =
+      case T.uncons segment of
+        Just (c, rest) -> isUpper c && T.all isModuleSegmentChar rest
+        Nothing -> False
+
+    isModuleSegmentChar c =
+      isAsciiLower c || isAsciiUpper c || isDigit c
 
 isOperatorToken :: Text -> Bool
 isOperatorToken tok =
@@ -1363,12 +1370,15 @@ prettyTopDataFamilyInst dfi =
     [keyword, "instance"]
       <> forallPart (dataFamilyInstForall dfi)
       <> [prettyType (dataFamilyInstHead dfi)]
+      <> kindPart (dataFamilyInstKind dfi)
       <> ctorPart (dataFamilyInstConstructors dfi)
       <> derivingParts (dataFamilyInstDeriving dfi)
   where
     keyword = if dataFamilyInstIsNewtype dfi then "newtype" else "data"
     forallPart [] = []
     forallPart binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
+    kindPart Nothing = []
+    kindPart (Just k) = ["::", prettyType k]
     ctorPart [] = []
     ctorPart ctors@(c : _)
       | any isGadtCon ctors = ["where", braces (hsep (punctuate semi (map prettyDataCon ctors)))]
@@ -1459,10 +1469,13 @@ prettyInstDataFamilyInst :: DataFamilyInst -> Doc ann
 prettyInstDataFamilyInst dfi =
   hsep $
     [keyword, prettyType (dataFamilyInstHead dfi)]
+      <> kindPart (dataFamilyInstKind dfi)
       <> ctorPart (dataFamilyInstConstructors dfi)
       <> derivingParts (dataFamilyInstDeriving dfi)
   where
     keyword = if dataFamilyInstIsNewtype dfi then "newtype" else "data"
+    kindPart Nothing = []
+    kindPart (Just k) = ["::", prettyType k]
     ctorPart [] = []
     ctorPart ctors@(c : _)
       | any isGadtCon ctors = ["where", braces (hsep (punctuate semi (map prettyDataCon ctors)))]

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -978,5 +978,6 @@ docDataFamilyInst dfi =
       boolField "isNewtype" (dataFamilyInstIsNewtype dfi)
         <> listField "forall" docTyVarBinder (dataFamilyInstForall dfi)
         <> [field "head" (docType (dataFamilyInstHead dfi))]
+        <> optionalField "kind" docType (dataFamilyInstKind dfi)
         <> listField "constructors" docDataConDecl (dataFamilyInstConstructors dfi)
         <> listField "deriving" docDerivingClause (dataFamilyInstDeriving dfi)

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1293,6 +1293,8 @@ data DataFamilyInst = DataFamilyInst
     dataFamilyInstForall :: [TyVarBinder],
     -- | The LHS type-application pattern (e.g. @GMap (Either a b) v@)
     dataFamilyInstHead :: Type,
+    -- | Optional inline result kind annotation (@:: Kind@) before @=@ or @where@
+    dataFamilyInstKind :: Maybe Type,
     dataFamilyInstConstructors :: [DataConDecl],
     dataFamilyInstDeriving :: [DerivingClause]
   }

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -24,6 +24,7 @@ import Test.Lexer.Suite (lexerTests)
 import Test.Oracle.Suite (oracleTests)
 import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
+import Test.Properties.Arb.Decl (genDeclDataFamilyInst)
 import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, span0, stripTypeAnnotations)
@@ -32,6 +33,7 @@ import Test.Properties.Identifiers (isValidGeneratedIdent, shrinkIdent)
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip)
 import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
 import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
+import Test.QuickCheck (Gen, Property, counterexample)
 import Test.QuickCheck.Gen qualified as QGen
 import Test.QuickCheck.Random qualified as QRandom
 import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimingTests)
@@ -43,6 +45,9 @@ import Text.Megaparsec.Error qualified as MPE
 
 tenMinutes :: Timeout
 tenMinutes = Timeout (10 * 60 * 1000000) "10m"
+
+sampleGen :: Int -> Gen a -> [a]
+sampleGen count gen = QGen.unGen (QC.vectorOf count gen) (QRandom.mkQCGen 20260415) 5
 
 expr0 :: Expr -> Expr
 expr0 = EAnn (mkAnnotation span0)
@@ -220,6 +225,7 @@ buildTests = do
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
+            testCase "qualified TH value-name quotes parenthesize dotted operators" test_prettyQualifiedTHNameQuoteParens,
             testCase "parses parenthesized kind signature type atoms" test_typeParsesParenthesizedKindSignature,
             testCase "parses parenthesized kind signatures in application heads" test_typeParsesKindSignatureApplicationHead,
             testCase "parses empty list type constructor" test_typeParsesEmptyListConstructor,
@@ -314,7 +320,8 @@ buildTests = do
             testCase "infix function head constructor applications stay bare" test_prettyInfixFunctionHeadConstructorPatterns,
             testCase "infix function head irrefutable patterns stay bare" test_prettyInfixFunctionHeadIrrefutablePatterns,
             testCase "view pattern with let-typed expr gets parenthesized" test_prettyViewLetTypeSigParens,
-            testCase "guard pattern with type sig gets parenthesized" test_prettyGuardPatTypeSigParens
+            testCase "guard pattern with type sig gets parenthesized" test_prettyGuardPatTypeSigParens,
+            testCase "data family instance kind signatures round-trip" test_dataFamilyInstanceKindSignatureRoundTrip
           ],
         testGroup
           "functionHeadParserWith dispatch"
@@ -341,6 +348,7 @@ buildTests = do
             "properties"
             [ QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
+              QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
               QC.testProperty "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip
@@ -1077,6 +1085,18 @@ test_generatedExpressionsCanIncludeMdo =
     isMdo (EDo_ _ True) = True
     isMdo _ = False
 
+test_prettyQualifiedTHNameQuoteParens :: Assertion
+test_prettyQualifiedTHNameQuoteParens = do
+  let expr = expr0 (ETHNameQuote "LumN.-.")
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+      config = defaultConfig {parserExtensions = [TemplateHaskell]}
+  assertEqual "pretty-printed qualified TH name quote" "'(LumN.-.)" source
+  case parseExpr config source of
+    ParseOk parsed
+      | normalizeExpr parsed == normalizeExpr expr -> pure ()
+    ParseOk other -> assertFailure ("expected qualified TH name quote AST, got: " <> show other)
+    ParseErr err -> assertFailure ("expected qualified TH name quote to parse, got:\n" <> MPE.errorBundlePretty err)
+
 test_alternateCharLiteralSpellingsLexLikeGhc :: Assertion
 test_alternateCharLiteralSpellingsLexLikeGhc =
   mapM_ assertCharLiteralLexesLikeGhc finiteAlternateCharLiteralSpellings
@@ -1611,6 +1631,37 @@ test_prettyGuardPatTypeSigParens = do
   assertBool
     ("expected parenthesized type sig in guard pattern, got:\n" <> T.unpack source)
     ("if { | () <- (262 :: T) -> () }" == source)
+
+test_dataFamilyInstanceKindSignatureRoundTrip :: Assertion
+test_dataFamilyInstanceKindSignatureRoundTrip = do
+  let source = T.unlines ["data instance Fam () :: Type -> Type where", "  F :: Fam () Int"]
+      expectedKind = TFun (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Type")) Unpromoted) (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Type")) Unpromoted)
+  case parseDecl defaultConfig source of
+    ParseOk parsed ->
+      case normalizeDecl parsed of
+        DeclDataFamilyInst DataFamilyInst {dataFamilyInstHead, dataFamilyInstKind = Just kind, dataFamilyInstConstructors = [ctor]}
+          | stripTypeAnnotations dataFamilyInstHead == TApp (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Fam")) Unpromoted) (TTuple Boxed Unpromoted []),
+            stripTypeAnnotations kind == expectedKind ->
+              case peelDataConAnn ctor of
+                GadtCon _ _ [conName] (GadtPrefixBody [] resultTy)
+                  | conName == mkUnqualifiedName NameConId "F",
+                    stripTypeAnnotations resultTy == TApp (TApp (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Fam")) Unpromoted) (TTuple Boxed Unpromoted [])) (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Int")) Unpromoted) ->
+                      pure ()
+                other ->
+                  assertFailure ("expected GADT constructor for data family instance kind signature, got: " <> show other)
+        other ->
+          assertFailure ("expected parsed data family instance kind signature AST, got: " <> show other)
+    ParseErr err ->
+      assertFailure ("expected data family instance kind signature to parse, got:\n" <> MPE.errorBundlePretty err)
+
+prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds :: Property
+prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds =
+  let samples = sampleGen 6000 genDeclDataFamilyInst
+      matching =
+        [ decl
+        | decl@(DeclDataFamilyInst DataFamilyInst {dataFamilyInstKind = Just _}) <- samples
+        ]
+   in counterexample ("expected at least one generated data family instance with inline result kind; sampled " <> show (length samples)) (not (null matching))
 
 test_guardPatBind :: Assertion
 test_guardPatBind =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/data-instance-kind-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/data-instance-kind-signature.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="data family instances with inline result kind signatures are not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 
 module DataInstanceKindSignature where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -3,6 +3,7 @@
 
 module Test.Properties.Arb.Decl
   ( genDecl,
+    genDeclDataFamilyInst,
     genFunctionDecl,
     shrinkDecl,
   )
@@ -21,7 +22,7 @@ import Test.Properties.Arb.Identifiers
     span0,
   )
 import Test.Properties.Arb.Pattern (canonicalPatternAtom, genPattern, shrinkPattern)
-import Test.Properties.Arb.Type (canonicalAppArg, canonicalFunLeft, canonicalTopLevelType, genType)
+import Test.Properties.Arb.Type (canonicalAppArg, canonicalFunLeft, canonicalKindSigKind, canonicalTopLevelType, genType)
 import Test.QuickCheck
 
 -- | Annotation choices for BangType
@@ -856,6 +857,7 @@ genDeclDataFamilyInst =
 genDeclDataFamilyInstPrefix :: Gen Decl
 genDeclDataFamilyInstPrefix = do
   head' <- genFamilyLhsType
+  kind <- genOptionalDataFamilyInstKind
   ctors <- genSimpleDataCons
   pure $
     DeclDataFamilyInst $
@@ -864,6 +866,7 @@ genDeclDataFamilyInstPrefix = do
           dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
+          dataFamilyInstKind = kind,
           dataFamilyInstConstructors = ctors,
           dataFamilyInstDeriving = []
         }
@@ -871,6 +874,7 @@ genDeclDataFamilyInstPrefix = do
 genDeclDataFamilyInstGadt :: Gen Decl
 genDeclDataFamilyInstGadt = do
   head' <- genFamilyLhsType
+  kind <- genOptionalDataFamilyInstKind
   ctors <- genGadtDataCons
   pure $
     DeclDataFamilyInst $
@@ -879,9 +883,21 @@ genDeclDataFamilyInstGadt = do
           dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
+          dataFamilyInstKind = kind,
           dataFamilyInstConstructors = ctors,
           dataFamilyInstDeriving = []
         }
+
+genOptionalDataFamilyInstKind :: Gen (Maybe Type)
+genOptionalDataFamilyInstKind =
+  frequency
+    [ (3, pure Nothing),
+      (1, Just <$> genDataFamilyInstKind)
+    ]
+
+genDataFamilyInstKind :: Gen Type
+genDataFamilyInstKind =
+  canonicalKindSigKind . canonicalTopLevelType <$> sized (genType . min 6)
 
 -- | Generate a type family LHS: a type constructor applied to an arbitrary type argument.
 genFamilyLhsType :: Gen Type

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -607,6 +607,7 @@ normalizeDataFamilyInst dfi =
       dataFamilyInstIsNewtype = dataFamilyInstIsNewtype dfi,
       dataFamilyInstForall = map normalizeTyVarBinder (dataFamilyInstForall dfi),
       dataFamilyInstHead = normalizeType (dataFamilyInstHead dfi),
+      dataFamilyInstKind = fmap normalizeType (dataFamilyInstKind dfi),
       dataFamilyInstConstructors = map normalizeDataConDecl (dataFamilyInstConstructors dfi),
       dataFamilyInstDeriving = map normalizeDerivingClause (dataFamilyInstDeriving dfi)
     }


### PR DESCRIPTION
## Summary
- add inline result kind support to `DataFamilyInst`, preserving and pretty-printing declarations such as `data instance Fam () :: Type -> Type`
- update the declaration generator and regression coverage so data family instances can produce and round-trip inline result kinds, and flip the existing oracle fixture from `xfail` to `pass`
- fix qualified Template Haskell dotted name quotes so `just check` stays green while exercising the new coverage

## Progress Counts
- TypeFamilies oracle fixtures: `pass +1`, `xfail -1`

## Validation
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)