### PR TITLE
feat(parser): support infix decl heads with extra parameters

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1140,7 +1140,7 @@ declContextParser = contextParserWith typeParser typeAtomParser
 
 typeDeclHeadParser :: TokParser (TypeHeadForm, UnqualifiedName, [TyVarBinder])
 typeDeclHeadParser =
-  MP.try infixDeclHeadParser <|> prefixDeclHeadParser
+  MP.try parenthesizedInfixDeclHeadParser <|> MP.try infixDeclHeadParser <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
@@ -1152,6 +1152,15 @@ typeDeclHeadParser =
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
       rhs <- typeParamParser
       pure (TypeHeadInfix, op, [lhs, rhs])
+
+    parenthesizedInfixDeclHeadParser = do
+      expectedTok TkSpecialLParen
+      lhs <- typeParamParser
+      op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
+      rhs <- typeParamParser
+      expectedTok TkSpecialRParen
+      tailParams <- MP.many typeParamParser
+      pure (TypeHeadInfix, op, [lhs, rhs] <> tailParams)
 
 typeSynonymOperatorParser :: TokParser Text
 typeSynonymOperatorParser =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -633,8 +633,11 @@ prettyDeclHead headForm constraints name params =
     )
   where
     prettyDeclHeadNameAndParams nm prms = case (headForm, prms) of
-      (TypeHeadInfix, [lhs, rhs]) ->
-        [pretty (tyVarBinderName lhs), pretty nm, pretty (tyVarBinderName rhs)]
+      (TypeHeadInfix, lhs : rhs : tailPrms) ->
+        let infixHead = pretty (tyVarBinderName lhs) <+> prettyInfixOp (renderUnqualifiedName nm) <+> pretty (tyVarBinderName rhs)
+         in case tailPrms of
+              [] -> [infixHead]
+              _ -> parens infixHead : map prettyTyVarBinder tailPrms
       _ ->
         [prettyConstructorUName nm] <> map prettyTyVarBinder prms
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-data.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-operator-data.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="data declaration with type operator symbol :+: in parentheses not parsed correctly" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 
 module TypeOperatorData where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -122,6 +122,8 @@ genFunctionDecl (name, expr) = do
       do
         lhsPat <- genInfixLhsPattern
         rhsPat <- canonicalPatternAtom <$> sized (genPattern . min 3)
+        extraCount <- chooseInt (0, 2)
+        extraPats <- vectorOf extraCount (canonicalPatternAtom <$> sized (genPattern . min 3))
         pure $
           DeclValue
             ( FunctionBind
@@ -130,7 +132,7 @@ genFunctionDecl (name, expr) = do
                 [ Match
                     { matchSpan = span0,
                       matchHeadForm = MatchHeadInfix,
-                      matchPats = [lhsPat, rhsPat],
+                      matchPats = [lhsPat, rhsPat] <> extraPats,
                       matchRhs = UnguardedRhs span0 expr Nothing
                     }
                 ]
@@ -204,7 +206,8 @@ genDeclData :: Gen Decl
 genDeclData =
   oneof
     [ DeclData <$> genSimpleDataDecl,
-      genDeclDataGadt
+      genDeclDataGadt,
+      genDeclDataInfix
     ]
 
 genDeclDataGadt :: Gen Decl
@@ -223,6 +226,34 @@ genDeclDataGadt = do
           dataDeclKind = Nothing,
           dataDeclConstructors = ctors,
           dataDeclDeriving = []
+        }
+
+-- | Generate an infix data declaration with 2-4 type parameters,
+-- covering both symbolic operators (e.g. @data (f :+: g) x = ...@)
+-- and backtick-wrapped identifiers (e.g. @data (f \`Dot\` g) x = ...@).
+genDeclDataInfix :: Gen Decl
+genDeclDataInfix = do
+  name <- oneof [mkUnqualifiedName NameConSym <$> genConSym, mkUnqualifiedName NameConId <$> genConIdent]
+  lhsName <- genIdent
+  rhsName <- genIdent
+  extraCount <- chooseInt (0, 2)
+  extraNames <- vectorOf extraCount genIdent
+  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
+      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+      extraParams = [TyVarBinder span0 n Nothing TyVarBSpecified | n <- extraNames]
+  ctors <- genSimpleDataCons
+  deriving' <- genDerivingClauses
+  pure $
+    DeclData $
+      DataDecl
+        { dataDeclSpan = span0,
+          dataDeclHeadForm = TypeHeadInfix,
+          dataDeclContext = [],
+          dataDeclName = name,
+          dataDeclParams = [lhs, rhs] <> extraParams,
+          dataDeclKind = Nothing,
+          dataDeclConstructors = ctors,
+          dataDeclDeriving = deriving'
         }
 
 genDeclTypeData :: Gen Decl


### PR DESCRIPTION
## Summary

- Generate infix function definitions with 2–4 arguments (e.g. `(f . g) x = f (g x)`) instead of always exactly 2
- Add infix data declaration generator with 2–4 type parameters (e.g. `data (f :+: g) x = ...` and `data (f \`Dot\` g) x = ...`)
- Update `typeDeclHeadParser` to support parenthesized infix type declaration heads with trailing parameters
- Fix `prettyDeclHead` to render >2 params with parenthesized infix head and add proper backtick rendering for non-operator names
- Promote `TypeOperators/type-operator-data` oracle test from xfail to pass

## Progress

Oracle: pass=847 xfail=7 (was pass=846 xfail=8)