### PR TITLE
fix(parser): parenthesize qualified TH operator name quotes

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -29,7 +29,7 @@ where
 
 import Aihc.Parser.Parens (addDeclParens, addExprParens, addModuleParens, addPatternParens, addTypeParens)
 import Aihc.Parser.Syntax
-import Data.Char (GeneralCategory (..), generalCategory, isAscii)
+import Data.Char (GeneralCategory (..), generalCategory, isAscii, isAsciiLower, isAsciiUpper, isDigit)
 import Data.Maybe (catMaybes, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -1288,13 +1288,34 @@ isOperatorName name =
 thNameQuoteTextNeedsParens :: Text -> Bool
 thNameQuoteTextNeedsParens name
   | isOperatorToken name = True
-  | not (T.any (== '.') name) = False
   | otherwise =
-      case T.split (== '.') name of
-        [] -> False
-        parts ->
-          let suffix = last parts
-           in not (T.null suffix) && isOperatorToken suffix
+      case splitQualifiedNameQuoteText name of
+        Just (_, quotedName) -> isOperatorToken quotedName
+        Nothing -> False
+
+splitQualifiedNameQuoteText :: Text -> Maybe (Text, Text)
+splitQualifiedNameQuoteText fullName =
+  case T.uncons fullName of
+    Just (c, _) | isAsciiUpper c -> go fullName
+    _ -> Nothing
+  where
+    go txt =
+      let (segment, rest) = T.breakOn "." txt
+       in case T.stripPrefix "." rest of
+            Just next
+              | isModuleSegment segment,
+                not (T.null next) ->
+                  case go next of
+                    Just (qualifier, quotedName) -> Just (segment <> "." <> qualifier, quotedName)
+                    Nothing -> Just (segment, next)
+            _ -> Nothing
+
+    isModuleSegment segment =
+      case T.uncons segment of
+        Just (c, rest) -> isAsciiUpper c && T.all isIdentChar rest
+        Nothing -> False
+
+    isIdentChar c = isAsciiUpper c || isAsciiLower c || c == '_' || c == '\'' || c == '#' || isDigit c
 
 isOperatorToken :: Text -> Bool
 isOperatorToken tok =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -27,7 +27,7 @@ import Test.Performance.Suite (parserPerformanceTests)
 import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, span0, stripTypeAnnotations)
-import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip)
+import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
 import Test.Properties.Identifiers (isValidGeneratedIdent, shrinkIdent)
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip)
 import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
@@ -339,7 +339,8 @@ buildTests = do
         adjustOption (const tenMinutes) $
           testGroup
             "properties"
-            [ QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
+            [ testCase "qualified Unicode TH name quote round-trips" test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote,
+              QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -2,19 +2,22 @@
 
 module Test.Properties.ExprRoundTrip
   ( prop_exprPrettyRoundTrip,
+    test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote,
   )
 where
 
 import Aihc.Parser
 import Aihc.Parser.Parens (addExprParens)
+import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Arb.Expr ()
 import Test.Properties.Coverage (assertCtorCoverage)
-import Test.Properties.ExprHelpers (normalizeExpr)
+import Test.Properties.ExprHelpers (normalizeExpr, span0)
 import Test.QuickCheck
+import Test.Tasty.HUnit (Assertion, assertFailure)
 import Text.Megaparsec.Error qualified as MPE
 
 exprConfig :: ParserConfig
@@ -35,3 +38,16 @@ prop_exprPrettyRoundTrip expr =
             ParseOk parsed ->
               let actual = normalizeExpr parsed
                in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
+
+test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote :: Assertion
+test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote =
+  let expr = EAnn (mkAnnotation span0) (ETHNameQuote "H3xVBC.NB.Y.‼.")
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+      expected = normalizeExpr (addExprParens expr)
+   in case parseExpr exprConfig source of
+        ParseErr err -> assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> MPE.errorBundlePretty err)
+        ParseOk parsed ->
+          let actual = normalizeExpr parsed
+           in if actual == expected
+                then pure ()
+                else assertFailure ("expected: " <> show expected <> "\nactual: " <> show actual)


### PR DESCRIPTION
## Summary
- Fix `ETHNameQuote` pretty-printing for qualified operator names whose operator text contains `.` so they are emitted with the parentheses required by the lexer.
- Add a targeted regression test for the replayed qualified Unicode operator case alongside the existing expression round-trip property coverage.
- Progress counts unchanged.

## Validation
- `just replay "(SMGen 6461164248906658410 9865617002453834367,83)"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern qualified --hide-successes"`
- `just fmt`
- `just check`

## Review
- `coderabbit review --prompt-only` could not run because the service was rate-limited.