### PR TITLE
fix(parser,parens): preserve EParen/TParen through roundtrips properly

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -364,7 +364,7 @@ typeParenOrTupleParser = withSpanAnn (TAnn . mkAnnotation) $ do
       case mKind of
         Just kind -> do
           expectedTok closeTok
-          pure (TKindSig first kind)
+          pure (TParen (TKindSig first kind))
         Nothing -> do
           mComma <- MP.optional (expectedTok TkSpecialComma)
           case mComma of

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -267,6 +267,9 @@ needsTypeParens ctx ty =
         TForall {} -> True
         TFun {} -> True
         TContext {} -> True
+        -- TImplicitParam parses greedily: ?x :: T -> U absorbs -> U into the
+        -- implicit param type, so TFun (TImplicitParam ..) .. needs parens.
+        TImplicitParam {} -> True
         _ -> False
     CtxTypeAppArg ->
       case ty of
@@ -275,6 +278,9 @@ needsTypeParens ctx ty =
         TForall {} -> True
         TFun {} -> True
         TContext {} -> True
+        -- TImplicitParam parses greedily: as a TApp argument ?x :: T -> U absorbs
+        -- the surrounding -> U into the implicit param type.
+        TImplicitParam {} -> True
         _ -> False
     CtxTypeAtom ->
       case ty of
@@ -501,8 +507,13 @@ addGadtBodyParens :: GadtBody -> GadtBody
 addGadtBodyParens body =
   case body of
     GadtPrefixBody args resultTy ->
-      GadtPrefixBody (map addBangTypeParens args) (addTypeParens resultTy)
+      -- The GADT prefix body parser splits on -> arrows (using typeInfixParser
+      -- per component). A result type that is itself a TFun, TForall, TContext,
+      -- TImplicitParam, or TKindSig would be misinterpreted as additional
+      -- constructor arguments, so we use addTypeIn CtxTypeFunArg to wrap it.
+      GadtPrefixBody (map addBangTypeParens args) (addTypeIn CtxTypeFunArg resultTy)
     GadtRecordBody fields resultTy ->
+      -- Record GADT result type uses typeParser so any type is fine here.
       GadtRecordBody (map addRecordFieldDeclParens fields) (addTypeParens resultTy)
 
 addClassDeclParens :: ClassDecl -> ClassDecl
@@ -823,12 +834,14 @@ addTypeParensShared ctx prec ty =
         TCon name promoted
           | isSymbolicName name, promoted /= Promoted -> TCon name promoted
           | otherwise -> TCon name promoted
-        TImplicitParam name inner -> TImplicitParam name (addTypeParens inner)
+        TImplicitParam name inner -> TImplicitParam name (addImplicitParamBodyParens inner)
         TTypeLit {} -> ty
         TStar {} -> ty
         TQuasiQuote {} -> ty
         TForall binders inner ->
-          wrapTy (prec > 0) (TForall (map addTyVarBinderParens binders) (atom 0 inner))
+          -- forallTypeParser uses contextOrFunTypeParser (not typeParser) for its
+          -- body, so a bare nested TForall would fail to parse. Wrap it in TParen.
+          wrapTy (prec > 0) (TForall (map addTyVarBinderParens binders) (addForallBodyParens inner))
         tyInfix
           | Just (op, lhs, rhs) <- matchSymbolicInfixTypeApp tyInfix ->
               -- Infix type operator: args are treated as atoms
@@ -858,6 +871,24 @@ addTypeParensShared ctx prec ty =
 addTyVarBinderParens :: TyVarBinder -> TyVarBinder
 addTyVarBinderParens tvb =
   tvb {tyVarBinderKind = fmap addTypeParens (tyVarBinderKind tvb)}
+
+-- | Process the body of a TForall. The forall body is parsed by
+-- 'contextOrFunTypeParser' (not 'typeParser'), so a bare nested TForall
+-- would fail to parse and must be wrapped in TParen.
+addForallBodyParens :: Type -> Type
+addForallBodyParens (TAnn ann sub) = TAnn ann (addForallBodyParens sub)
+addForallBodyParens ty@(TForall {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
+addForallBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
+
+-- | Process the body of a TImplicitParam. Although 'typeImplicitParamParser'
+-- uses 'typeParser' (which handles TContext), the 'startsWithContextType'
+-- lookahead will mistake @?x :: C a => T@ for an outer context, consuming
+-- the entire implicit param as a constraint item and then failing to find @=>@.
+-- Wrap a bare TContext in TParen to prevent this misinterpretation.
+addImplicitParamBodyParens :: Type -> Type
+addImplicitParamBodyParens (TAnn ann sub) = TAnn ann (addImplicitParamBodyParens sub)
+addImplicitParamBodyParens ty@(TContext {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
+addImplicitParamBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
 
 -- | Process a type inside explicit delimiters (TParen, TTuple, etc.).
 -- TKindSig does not need wrapping here because the enclosing delimiter

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -885,9 +885,15 @@ addForallBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
 -- lookahead will mistake @?x :: C a => T@ for an outer context, consuming
 -- the entire implicit param as a constraint item and then failing to find @=>@.
 -- Wrap a bare TContext in TParen to prevent this misinterpretation.
+--
+-- Similarly, a bare TForall whose body contains a TContext produces a @=>@ that
+-- is visible to 'startsWithContextType' (the forall binders are balanced braces,
+-- but the body's @=>@ appears at top bracket depth after them). Wrapping TForall
+-- in TParen hides the inner @=>@ behind a bracket pair.
 addImplicitParamBodyParens :: Type -> Type
 addImplicitParamBodyParens (TAnn ann sub) = TAnn ann (addImplicitParamBodyParens sub)
 addImplicitParamBodyParens ty@(TContext {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
+addImplicitParamBodyParens ty@(TForall {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
 addImplicitParamBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
 
 -- | Process a type inside explicit delimiters (TParen, TTuple, etc.).

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -674,15 +674,15 @@ addExprParensPrec prec expr =
     ENegate inner ->
       wrapExpr (prec > 2) (ENegate (addNegateParens inner))
     ESectionL lhs op ->
-      -- Sections are always in parens (printed with parens in Pretty.hs)
-      -- The LHS needs special handling for greedy/typesig expressions
+      -- Sections always require surrounding parens in source syntax.
+      -- Wrap in EParen so the AST matches what the parser produces.
       let lhs' =
             if isGreedyExpr lhs || isTypeSig lhs
               then wrapExpr True (addExprParens lhs)
               else addExprParensPrec 1 lhs
-       in ESectionL lhs' op
+       in EParen (ESectionL lhs' op)
     ESectionR op rhs ->
-      ESectionR op (addExprParens rhs)
+      EParen (ESectionR op (addExprParens rhs))
     ELetDecls decls body ->
       wrapExpr (prec > 0) (ELetDecls (map addDeclParens decls) (addExprParens body))
     ECase scrutinee alts ->
@@ -701,11 +701,11 @@ addExprParensPrec prec expr =
     ETypeSig inner ty ->
       wrapExpr (prec > 1) (ETypeSig (addExprParensIn CtxTypeSigBody inner) (addTypeParens ty))
     EParen inner ->
-      case inner of
-        -- Sections are already "in parens" via their EParen wrapper,
-        -- don't add double parens
-        ESectionL {} -> EParen (addExprParens inner)
-        ESectionR {} -> EParen (addExprParens inner)
+      -- If inner is a section, addExprParens(inner) already produces EParen(section).
+      -- Delegating avoids double-wrapping and maintains idempotency.
+      case peelExprAnn inner of
+        ESectionL {} -> addExprParens inner
+        ESectionR {} -> addExprParens inner
         _ -> EParen (addExprParens inner)
     EList values -> EList (map addExprParens values)
     ETuple tupleFlavor values -> ETuple tupleFlavor (map (fmap addExprParens) values)
@@ -741,22 +741,12 @@ addSpliceBodyParens :: Expr -> Expr
 addSpliceBodyParens body =
   case body of
     EAnn ann sub -> EAnn ann (addSpliceBodyParens sub)
-    -- EParen around a section: the pretty-printer's EParen transparency
-    -- means this would print as just the section's parens. We need an
-    -- extra EParen so the splice delimiter parens are not swallowed.
-    EParen inner
-      | ESectionL {} <- peelExprAnn inner -> EParen (EParen (addExprParens inner))
-      | ESectionR {} <- peelExprAnn inner -> EParen (EParen (addExprParens inner))
-    EParen inner -> EParen (addExprParens inner)
+    -- Bare variable: $name is valid splice syntax without parens.
     EVar {} -> body
-    -- Sections print their own parens via prettyExpr, and EParen is
-    -- transparent around them in the pretty-printer (to avoid double parens
-    -- in normal code like `x = (+1)`). For splices, we need the EParen to
-    -- actually produce parens, so we double-wrap.
-    _
-      | ESectionL {} <- peelExprAnn body -> EParen (EParen (addExprParens body))
-      | ESectionR {} <- peelExprAnn body -> EParen (EParen (addExprParens body))
-    -- Any other body needs to be wrapped in EParen so it prints as $(expr).
+    -- For everything else (including sections, which addExprParens now wraps
+    -- in EParen): wrap in one outer EParen so the body prints as $(expr).
+    -- Sections become EParen(EParen(section)) which prints as $((lhs op)).
+    EParen inner -> EParen (addExprParens inner)
     _ -> EParen (addExprParens body)
 
 addNegateParens :: Expr -> Expr

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -7,6 +7,7 @@ module Main (main) where
 
 import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions, readModuleHeaderExtensions, readModuleHeaderExtensionsFromChunks)
+import Aihc.Parser.Parens (addDeclParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import Data.Char (ord)
@@ -440,7 +441,7 @@ test_instanceParsesParenthesizedEmptyListType =
             ]
               | instanceDeclClassName inst == "C",
                 [ity] <- instanceDeclTypes inst,
-                TCon "[]" Unpromoted <- stripTypeAnnotations ity ->
+                TParen (TCon "[]" Unpromoted) <- stripTypeAnnotations ity ->
                   pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
@@ -601,7 +602,7 @@ test_ifElseWhereBranchRoundtrip =
    in do
         assertBool ("expected no parse errors, got: " <> show errs <> "\nsource:\n" <> T.unpack source) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [actualDecl] -> assertEqual "roundtripped declaration" (normalizeDecl expectedDecl) actualDecl
+          [actualDecl] -> assertEqual "roundtripped declaration" (normalizeDecl (addDeclParens expectedDecl)) actualDecl
           other -> assertFailure ("unexpected parsed declarations: " <> show other <> "\nsource:\n" <> T.unpack source)
 
 test_standaloneMdoExprParses :: Assertion

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -402,7 +402,7 @@ test_typeParsesParenthesizedKindSignature :: Assertion
 test_typeParsesParenthesizedKindSignature =
   case parseType defaultConfig {parserExtensions = [KindSignatures, StarIsType]} "(x :: *)" of
     ParseOk ty
-      | TKindSig (TVar "x") TStar <- stripTypeAnnotations ty ->
+      | TParen (TKindSig (TVar "x") TStar) <- stripTypeAnnotations ty ->
           pure ()
     other -> assertFailure ("expected parenthesized kind signature type, got: " <> show other)
 
@@ -410,7 +410,7 @@ test_typeParsesKindSignatureApplicationHead :: Assertion
 test_typeParsesKindSignatureApplicationHead =
   case parseType defaultConfig {parserExtensions = [KindSignatures]} "(f :: Type -> Type) a" of
     ParseOk ty
-      | TApp (TKindSig (TVar "f") (TFun (TCon "Type" Unpromoted) (TCon "Type" Unpromoted))) (TVar "a") <-
+      | TApp (TParen (TKindSig (TVar "f") (TFun (TCon "Type" Unpromoted) (TCon "Type" Unpromoted)))) (TVar "a") <-
           stripTypeAnnotations ty ->
           pure ()
     other -> assertFailure ("expected kind-signature application head, got: " <> show other)
@@ -461,7 +461,7 @@ test_gadtConstructorParsesKindAnnotatedArgument =
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
           [DeclData DataDecl {dataDeclConstructors = [DataConAnn _ (GadtCon [] [] ["C"] (GadtPrefixBody [BangType {bangType = kb}] rb))]}]
-            | TKindSig (TVar "x") TStar <- stripTypeAnnotations kb,
+            | TParen (TKindSig (TVar "x") TStar) <- stripTypeAnnotations kb,
               TCon "T" Unpromoted <- stripTypeAnnotations rb ->
                 pure ()
           other ->

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -22,7 +22,7 @@ import Test.Properties.Arb.Identifiers
     span0,
   )
 import Test.Properties.Arb.Pattern (canonicalPatternAtom, genPattern, shrinkPattern)
-import Test.Properties.Arb.Type (canonicalAppArg, canonicalFunLeft, canonicalKindSigKind, canonicalTopLevelType, genType)
+import Test.Properties.Arb.Type (genType)
 import Test.QuickCheck
 
 -- | Annotation choices for BangType
@@ -393,7 +393,7 @@ genGadtPrefixBody :: Gen GadtBody
 genGadtPrefixBody = do
   n <- chooseInt (0, 2)
   args <- vectorOf n genGadtBangType
-  result <- canonicalFunLeft . canonicalTopLevelType <$> sized (genType . min 6)
+  result <- sized (genType . min 6)
   pure $ GadtPrefixBody args result
 
 -- | Generate a BangType for GADT prefix body arg position.
@@ -404,7 +404,7 @@ genGadtPrefixBody = do
 -- as single operator tokens.
 genGadtBangType :: Gen BangType
 genGadtBangType = do
-  ty <- canonicalFunLeft . canonicalTopLevelType <$> sized (genType . min 6)
+  ty <- sized (genType . min 6)
   -- Only generate lazy/strict annotations on types that start with alphabetic characters
   let canAnnotate = typeStartsWithAlpha ty
   annotation <- if canAnnotate then elements [NoAnnotation, StrictAnnotation, LazyAnnotation] else pure NoAnnotation
@@ -468,7 +468,7 @@ genGadtRecordBody :: Gen GadtBody
 genGadtRecordBody = do
   n <- chooseInt (1, 3)
   fields <- vectorOf n genGadtFieldDecl
-  result <- canonicalTopLevelType <$> sized (genType . min 6)
+  result <- sized (genType . min 6)
   pure $ GadtRecordBody fields result
 
 -- | Generate a field declaration for GADT record body position.
@@ -476,7 +476,7 @@ genGadtRecordBody = do
 genGadtFieldDecl :: Gen FieldDecl
 genGadtFieldDecl = do
   fieldName <- mkUnqualifiedName NameVarId <$> genIdent
-  ty <- canonicalTopLevelType <$> sized (genType . min 6)
+  ty <- sized (genType . min 6)
   pure $ FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False False ty)
 
 genSimpleBangType :: Gen BangType
@@ -928,14 +928,14 @@ genOptionalDataFamilyInstKind =
 
 genDataFamilyInstKind :: Gen Type
 genDataFamilyInstKind =
-  canonicalKindSigKind . canonicalTopLevelType <$> sized (genType . min 6)
+  sized (genType . min 6)
 
 -- | Generate a type family LHS: a type constructor applied to an arbitrary type argument.
 genFamilyLhsType :: Gen Type
 genFamilyLhsType = do
   familyName <- genConIdent
   let familyCon = TCon (qualifyName Nothing (mkUnqualifiedName NameConId familyName)) Unpromoted
-  TApp familyCon . canonicalAppArg <$> genFamilyLhsArg
+  TApp familyCon <$> genFamilyLhsArg
 
 genFamilyLhsArg :: Gen Type
 genFamilyLhsArg = suchThat (sized (genType . min 4)) (not . isStarType)
@@ -968,7 +968,7 @@ genDeclStandaloneKindSig :: Gen Decl
 genDeclStandaloneKindSig = do
   name <- mkUnqualifiedName NameConId <$> genConIdent
   kind <- sized (genType . min 6)
-  pure $ DeclStandaloneKindSig name (canonicalTopLevelType kind)
+  pure $ DeclStandaloneKindSig name kind
 
 -- | Generate simple type variable binders (0-2 params).
 genSimpleTyVarBinders :: Gen [TyVarBinder]

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -24,7 +24,7 @@ import Test.Properties.Arb.Identifiers
     span0,
   )
 import Test.Properties.Arb.Pattern (canonicalPatternAtom, genPattern, shrinkPattern)
-import Test.Properties.Arb.Type (canonicalAppArg, canonicalFunLeft, canonicalKindSigKind, canonicalTopLevelType, genType, shrinkType)
+import Test.Properties.Arb.Type (genType, shrinkType)
 import Test.QuickCheck
 
 -- | Annotation choices for BangType
@@ -399,8 +399,6 @@ genGadtPrefixBody = do
   pure $ GadtPrefixBody args result
 
 -- | Generate a BangType for GADT prefix body arg position.
--- Uses the full type generator with canonicalFunLeft applied, since the parser
--- uses typeInfixParser (which cannot parse bare forall/->/(=>) without parens).
 -- Does not generate lazy/strict annotations on types that start with symbolic
 -- characters (TStar, TTHSplice, TTuple, etc.) since the lexer treats ~! or !*
 -- as single operator tokens.

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -94,15 +94,12 @@ genTypeFun :: Int -> Gen Type
 genTypeFun depth = do
   lhs <- genType (depth - 1)
   rhs <- genType (depth - 1)
-  pure (TFun (canonicalFunLeft lhs) rhs)
+  pure (TFun (canonicalFunLeft lhs) (canonicalAtomType rhs))
 
 genForallInner :: Int -> Gen Type
 genForallInner depth = do
   inner <- genType depth
-  pure $
-    case inner of
-      TForall {} -> TParen inner
-      _ -> inner
+  pure (canonicalForallInner inner)
 
 -- | Generate the body of a TH type splice: either a bare variable or a parenthesized expression.
 genTypeSpliceBody :: Gen Expr
@@ -120,7 +117,7 @@ genTypeContext depth = do
   n <- chooseInt (1, 3)
   constraints <- vectorOf n (genConstraintType (depth - 1))
   inner <- genType (depth - 1)
-  pure $ TParen (canonicalContextType (map canonicalContextItem constraints) inner)
+  pure $ TParen (canonicalContextType (map canonicalContextItem constraints) (canonicalAtomType inner))
 
 -- | Generate a constraint type (used in contexts).
 -- Typically a type constructor applied to some arguments.
@@ -147,17 +144,17 @@ genTypeTupleElems depth = do
     then pure []
     else do
       n <- chooseInt (2, 4)
-      vectorOf n (genType depth)
+      fmap canonicalAtomType <$> vectorOf n (genType depth)
 
 genTypeListElems :: Int -> Gen [Type]
 genTypeListElems depth = do
   n <- chooseInt (1, 4)
-  vectorOf n (genType depth)
+  fmap canonicalAtomType <$> vectorOf n (genType depth)
 
 genUnboxedSumElems :: Int -> Gen [Type]
 genUnboxedSumElems depth = do
   n <- chooseInt (2, 4)
-  vectorOf n (genType depth)
+  fmap canonicalAtomType <$> vectorOf n (genType depth)
 
 -- | Generate elements for a promoted tuple or list. Uses simple types only
 -- to avoid nesting ambiguities with kind signatures and unboxed tuples
@@ -306,7 +303,10 @@ canonicalTopLevelType :: Type -> Type
 canonicalTopLevelType ty =
   case ty of
     TContext constraints inner -> canonicalContextType constraints inner
-    _ -> canonicalTypeSplice ty
+    -- TKindSig always gets wrapped in TParen by addTypeParens, and the
+    -- parser now preserves that TParen.
+    TKindSig inner kind -> TParen (TKindSig inner kind)
+    _ -> ty
 
 canonicalContextType :: [Type] -> Type -> Type
 canonicalContextType constraints = TContext (canonicalContextItems constraints)
@@ -326,15 +326,13 @@ canonicalContextItem ty =
     TKindSig inner kind -> TParen (TKindSig (canonicalKindSigSubject inner) (canonicalKindSigKind kind))
     TTuple Boxed Unpromoted [] -> TParen (TTuple Boxed Unpromoted [])
     TContext constraints inner -> canonicalContextType constraints inner
-    _ -> canonicalTypeSplice ty
-
-canonicalTypeSplice :: Type -> Type
-canonicalTypeSplice ty = ty
+    _ -> ty
 
 canonicalForallInner :: Type -> Type
 canonicalForallInner ty =
   case ty of
     TForall {} -> TParen ty
+    TKindSig {} -> TParen ty
     _ -> ty
 
 canonicalFunLeft :: Type -> Type
@@ -344,6 +342,7 @@ canonicalFunLeft ty =
     TFun {} -> TParen ty
     TContext {} -> TParen ty
     TImplicitParam {} -> TParen ty
+    TKindSig {} -> TParen ty
     _ -> ty
 
 canonicalAppHead :: Type -> Type
@@ -353,6 +352,7 @@ canonicalAppHead ty =
     TFun {} -> TParen ty
     TContext {} -> TParen ty
     TImplicitParam {} -> TParen ty
+    TKindSig {} -> TParen ty
     _ -> ty
 
 canonicalAppArg :: Type -> Type
@@ -363,6 +363,7 @@ canonicalAppArg ty =
     TFun {} -> TParen ty
     TContext {} -> TParen ty
     TImplicitParam {} -> TParen ty
+    TKindSig {} -> TParen ty
     _ -> ty
 
 canonicalKindSigSubject :: Type -> Type
@@ -375,13 +376,23 @@ canonicalKindSigSubject ty =
     _ -> TParen ty
 
 canonicalKindSigKind :: Type -> Type
-canonicalKindSigKind = id
+canonicalKindSigKind = canonicalAtomType
+
+-- | Canonicalize a type that appears in "atom" position
+-- (list/tuple/unboxed-sum elements, TFun RHS, TContext body, TKindSig subject/kind).
+-- addTypeParens unconditionally wraps TKindSig in TParen in these positions.
+canonicalAtomType :: Type -> Type
+canonicalAtomType ty =
+  case ty of
+    TKindSig {} -> TParen ty
+    _ -> ty
 
 canonicalImplicitParamType :: Type -> Type
 canonicalImplicitParamType ty =
   case ty of
     TForall {} -> TParen ty
     TContext {} -> TParen ty
+    TKindSig {} -> TParen ty
     _ -> ty
 
 -- | Types that require parentheses when appearing inside compound types

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -4,15 +4,6 @@
 module Test.Properties.Arb.Type
   ( genType,
     shrinkType,
-    canonicalTopLevelType,
-    canonicalContextType,
-    canonicalFunLeft,
-    canonicalAppHead,
-    canonicalAppArg,
-    canonicalKindSigSubject,
-    canonicalKindSigKind,
-    canonicalImplicitParamType,
-    canonicalForallInner,
   )
 where
 
@@ -85,21 +76,13 @@ genType depth
         ]
 
 genTypeApp :: Int -> Gen Type
-genTypeApp depth = do
-  fn <- genType (depth - 1)
-  arg <- genType (depth - 1)
-  pure (TApp (canonicalAppHead fn) (canonicalAppArg arg))
+genTypeApp depth = TApp <$> genType (depth - 1) <*> genType (depth - 1)
 
 genTypeFun :: Int -> Gen Type
-genTypeFun depth = do
-  lhs <- genType (depth - 1)
-  rhs <- genType (depth - 1)
-  pure (TFun (canonicalFunLeft lhs) (canonicalAtomType rhs))
+genTypeFun depth = TFun <$> genType (depth - 1) <*> genType (depth - 1)
 
 genForallInner :: Int -> Gen Type
-genForallInner depth = do
-  inner <- genType depth
-  pure (canonicalForallInner inner)
+genForallInner = genType
 
 -- | Generate the body of a TH type splice: either a bare variable or a parenthesized expression.
 genTypeSpliceBody :: Gen Expr
@@ -109,15 +92,12 @@ genTypeSpliceBody =
       EParen . EVar <$> genTypeVarExprName
     ]
 
--- | Generate a type with a context (constraints => type).
--- Always wrapped in parens because constraints => type is a top-level
--- form that needs parens in sub-type positions.
 genTypeContext :: Int -> Gen Type
 genTypeContext depth = do
   n <- chooseInt (1, 3)
   constraints <- vectorOf n (genConstraintType (depth - 1))
   inner <- genType (depth - 1)
-  pure $ TParen (canonicalContextType (map canonicalContextItem constraints) (canonicalAtomType inner))
+  pure $ TContext constraints inner
 
 -- | Generate a constraint type (used in contexts).
 -- Typically a type constructor applied to some arguments.
@@ -134,8 +114,8 @@ genConstraintType depth = do
 genTypeImplicitParam :: Int -> Gen Type
 genTypeImplicitParam depth = do
   name <- ("?" <>) <$> genIdent
-  inner <- canonicalImplicitParamType <$> genType (depth - 1)
-  pure $ TParen (TImplicitParam name inner)
+  inner <- genType (depth - 1)
+  pure $ TImplicitParam name inner
 
 genTypeTupleElems :: Int -> Gen [Type]
 genTypeTupleElems depth = do
@@ -144,17 +124,17 @@ genTypeTupleElems depth = do
     then pure []
     else do
       n <- chooseInt (2, 4)
-      fmap canonicalAtomType <$> vectorOf n (genType depth)
+      vectorOf n (genType depth)
 
 genTypeListElems :: Int -> Gen [Type]
 genTypeListElems depth = do
   n <- chooseInt (1, 4)
-  fmap canonicalAtomType <$> vectorOf n (genType depth)
+  vectorOf n (genType depth)
 
 genUnboxedSumElems :: Int -> Gen [Type]
 genUnboxedSumElems depth = do
   n <- chooseInt (2, 4)
-  fmap canonicalAtomType <$> vectorOf n (genType depth)
+  vectorOf n (genType depth)
 
 -- | Generate elements for a promoted tuple or list. Uses simple types only
 -- to avoid nesting ambiguities with kind signatures and unboxed tuples
@@ -221,9 +201,7 @@ genSimpleTypeAtom depth =
     ]
 
 genKindSigSubject :: Int -> Gen Type
-genKindSigSubject depth = do
-  subject <- genSimpleTypeAtom depth
-  pure (canonicalKindSigSubject subject)
+genKindSigSubject = genSimpleTypeAtom
 
 genKindSigKind :: Int -> Gen Type
 genKindSigKind depth =
@@ -299,114 +277,6 @@ genSymbolText = do
   chars <- vectorOf len genCharValue
   pure (T.pack chars)
 
-canonicalTopLevelType :: Type -> Type
-canonicalTopLevelType ty =
-  case ty of
-    TContext constraints inner -> canonicalContextType constraints inner
-    -- TKindSig always gets wrapped in TParen by addTypeParens, and the
-    -- parser now preserves that TParen.
-    TKindSig inner kind -> TParen (TKindSig inner kind)
-    _ -> ty
-
-canonicalContextType :: [Type] -> Type -> Type
-canonicalContextType constraints = TContext (canonicalContextItems constraints)
-
-canonicalContextItems :: [Type] -> [Type]
-canonicalContextItems constraints =
-  case map canonicalContextItem constraints of
-    [TTuple Boxed Unpromoted []] -> []
-    [TParen (TTuple Boxed Unpromoted [])] -> []
-    items -> items
-
-canonicalContextItem :: Type -> Type
-canonicalContextItem ty =
-  case ty of
-    TParen inner@(TParen (TKindSig {})) -> TParen (canonicalContextItem inner)
-    TParen inner -> TParen (canonicalContextItem inner)
-    TKindSig inner kind -> TParen (TKindSig (canonicalKindSigSubject inner) (canonicalKindSigKind kind))
-    TTuple Boxed Unpromoted [] -> TParen (TTuple Boxed Unpromoted [])
-    TContext constraints inner -> canonicalContextType constraints inner
-    _ -> ty
-
-canonicalForallInner :: Type -> Type
-canonicalForallInner ty =
-  case ty of
-    TForall {} -> TParen ty
-    TKindSig {} -> TParen ty
-    _ -> ty
-
-canonicalFunLeft :: Type -> Type
-canonicalFunLeft ty =
-  case ty of
-    TForall {} -> TParen ty
-    TFun {} -> TParen ty
-    TContext {} -> TParen ty
-    TImplicitParam {} -> TParen ty
-    TKindSig {} -> TParen ty
-    _ -> ty
-
-canonicalAppHead :: Type -> Type
-canonicalAppHead ty =
-  case ty of
-    TForall {} -> TParen ty
-    TFun {} -> TParen ty
-    TContext {} -> TParen ty
-    TImplicitParam {} -> TParen ty
-    TKindSig {} -> TParen ty
-    _ -> ty
-
-canonicalAppArg :: Type -> Type
-canonicalAppArg ty =
-  case ty of
-    TApp {} -> TParen ty
-    TForall {} -> TParen ty
-    TFun {} -> TParen ty
-    TContext {} -> TParen ty
-    TImplicitParam {} -> TParen ty
-    TKindSig {} -> TParen ty
-    _ -> ty
-
-canonicalKindSigSubject :: Type -> Type
-canonicalKindSigSubject ty =
-  case ty of
-    TTuple {} -> ty
-    TUnboxedSum {} -> ty
-    TList {} -> ty
-    TParen {} -> ty
-    _ -> TParen ty
-
-canonicalKindSigKind :: Type -> Type
-canonicalKindSigKind = canonicalAtomType
-
--- | Canonicalize a type that appears in "atom" position
--- (list/tuple/unboxed-sum elements, TFun RHS, TContext body, TKindSig subject/kind).
--- addTypeParens unconditionally wraps TKindSig in TParen in these positions.
-canonicalAtomType :: Type -> Type
-canonicalAtomType ty =
-  case ty of
-    TKindSig {} -> TParen ty
-    _ -> ty
-
-canonicalImplicitParamType :: Type -> Type
-canonicalImplicitParamType ty =
-  case ty of
-    TForall {} -> TParen ty
-    TContext {} -> TParen ty
-    TKindSig {} -> TParen ty
-    _ -> ty
-
--- | Types that require parentheses when appearing inside compound types
--- (tuples, lists, application arguments, etc.). These are "top-level" type
--- forms whose syntax is ambiguous without parens.
-needsParensInSubPosition :: Type -> Bool
-needsParensInSubPosition ty =
-  case ty of
-    TImplicitParam {} -> True
-    TContext {} -> True
-    TForall {} -> True
-    TFun {} -> True
-    _ -> False
-
 shrinkType :: Type -> [Type]
 shrinkType ty =
   case ty of
@@ -415,14 +285,12 @@ shrinkType ty =
     TCon name promoted ->
       [ TCon (name {nameText = shrunk}) promoted
       | shrunk <- shrinkConIdent (nameText name),
-        -- For promoted constructors, avoid names that cause ambiguity
-        -- with character literals (e.g., 'A'x lexed as char 'A' + var x)
         promoted == Unpromoted || (T.length shrunk >= 2 && not (T.any (== '\'') shrunk))
       ]
     TImplicitParam name inner ->
       [inner]
-        <> [TImplicitParam name' (canonicalImplicitParamType inner) | name' <- shrinkImplicitParamName name]
-        <> [TImplicitParam name (canonicalImplicitParamType inner') | inner' <- shrinkType inner]
+        <> [TImplicitParam name' inner | name' <- shrinkImplicitParamName name]
+        <> [TImplicitParam name inner' | inner' <- shrinkType inner]
     TTypeLit {} ->
       []
     TStar ->
@@ -431,35 +299,34 @@ shrinkType ty =
       [TQuasiQuote q body | q <- shrinkIdent quoter]
         <> [TQuasiQuote quoter b | b <- map T.pack (shrink (T.unpack body))]
     TForall binders inner ->
-      [canonicalForallInner inner]
-        <> [TForall binders' (canonicalForallInner inner) | binders' <- shrinkTypeBinders binders]
-        <> [TForall binders (canonicalForallInner inner') | inner' <- shrinkType inner]
+      [inner]
+        <> [TForall binders' inner | binders' <- shrinkTypeBinders binders]
+        <> [TForall binders inner' | inner' <- shrinkType inner]
     TApp fn arg ->
-      [canonicalAppHead fn, canonicalAppArg arg]
-        <> [TApp (canonicalAppHead fn') (canonicalAppArg arg) | fn' <- shrinkType fn]
-        <> [TApp (canonicalAppHead fn) (canonicalAppArg arg') | arg' <- shrinkType arg]
+      [fn, arg]
+        <> [TApp fn' arg | fn' <- shrinkType fn]
+        <> [TApp fn arg' | arg' <- shrinkType arg]
     TFun lhs rhs ->
-      [canonicalFunLeft lhs, rhs]
-        <> [TFun (canonicalFunLeft lhs') rhs | lhs' <- shrinkType lhs]
-        <> [TFun (canonicalFunLeft lhs) rhs' | rhs' <- shrinkType rhs]
+      [lhs, rhs]
+        <> [TFun lhs' rhs | lhs' <- shrinkType lhs]
+        <> [TFun lhs rhs' | rhs' <- shrinkType rhs]
     TTuple tupleFlavor _ elems ->
       shrinkTypeTupleElems tupleFlavor elems
     TList _ elems ->
       [TList Unpromoted elems' | elems' <- shrinkList shrinkType elems, not (null elems')]
     TParen inner ->
-      -- Don't unwrap parens around types that require them in sub-type positions
-      [inner | not (needsParensInSubPosition inner)]
+      [inner]
         <> [TParen inner' | inner' <- shrinkType inner]
     TKindSig ty' kind ->
-      [canonicalKindSigSubject ty', canonicalKindSigKind kind]
-        <> [TKindSig (canonicalKindSigSubject ty'') (canonicalKindSigKind kind) | ty'' <- shrinkType ty']
-        <> [TKindSig (canonicalKindSigSubject ty') (canonicalKindSigKind kind') | kind' <- shrinkType kind]
+      [ty', kind]
+        <> [TKindSig ty'' kind | ty'' <- shrinkType ty']
+        <> [TKindSig ty' kind' | kind' <- shrinkType kind]
     TUnboxedSum elems ->
       [TUnboxedSum elems' | elems' <- shrinkList shrinkType elems, length elems' >= 2]
     TContext constraints inner ->
       [inner]
-        <> [canonicalContextType constraints' inner | constraints' <- shrinkContextItems constraints]
-        <> [canonicalContextType constraints inner' | inner' <- shrinkType inner]
+        <> [TContext constraints' inner | constraints' <- shrinkList shrinkType constraints, not (null constraints')]
+        <> [TContext constraints inner' | inner' <- shrinkType inner]
     TSplice {} ->
       []
     TWildcard ->
@@ -486,24 +353,6 @@ shrinkTypeTupleElems tupleFlavor elems =
       [_] -> []
       _ -> [TTuple tupleFlavor Unpromoted shrunk]
   ]
-
-shrinkContextItems :: [Type] -> [[Type]]
-shrinkContextItems = shrinkList shrinkContextItem
-
-shrinkContextItem :: Type -> [Type]
-shrinkContextItem ty =
-  case ty of
-    TImplicitParam name inner ->
-      [inner]
-        <> [TImplicitParam name' (canonicalImplicitParamType inner) | name' <- shrinkImplicitParamName name]
-        <> [TImplicitParam name (canonicalImplicitParamType inner') | inner' <- shrinkType inner]
-    TParen inner ->
-      inner : [TParen inner' | inner' <- shrinkContextItem inner]
-    TKindSig subj kind ->
-      [canonicalKindSigSubject subj, canonicalKindSigKind kind]
-        <> [canonicalContextItem (TKindSig subj' (canonicalKindSigKind kind)) | subj' <- shrinkType subj]
-        <> [TKindSig (canonicalKindSigSubject subj) (canonicalKindSigKind kind') | kind' <- shrinkType kind]
-    _ -> shrinkType ty
 
 shrinkImplicitParamName :: Text -> [Text]
 shrinkImplicitParamName name =

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -329,10 +329,7 @@ canonicalContextItem ty =
     _ -> canonicalTypeSplice ty
 
 canonicalTypeSplice :: Type -> Type
-canonicalTypeSplice ty =
-  case ty of
-    TSplice (EVar name) -> TSplice (EParen (EVar name))
-    _ -> ty
+canonicalTypeSplice ty = ty
 
 canonicalForallInner :: Type -> Type
 canonicalForallInner ty =

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -56,16 +56,7 @@ normalizeExpr expr =
     ETypeSig inner ty -> ETypeSig (normalizeExpr inner) (normalizeType ty)
     ETypeApp inner ty -> ETypeApp (normalizeExpr inner) (normalizeType ty)
     EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (normalizeExpr inner)
-    EParen inner ->
-      -- Sections (ESectionL/ESectionR) always print with their own parens, so
-      -- EParen around them is transparent. The parser always wraps sections in
-      -- EParen, but addExprParens leaves sections bare. Strip EParen around
-      -- sections to unify both representations.
-      let ni = normalizeExpr inner
-       in case ni of
-            ESectionL {} -> ni
-            ESectionR {} -> ni
-            _ -> EParen ni
+    EParen inner -> EParen (normalizeExpr inner)
     ETHExpQuote body -> ETHExpQuote (normalizeExpr body)
     ETHTypedQuote body -> ETHTypedQuote (normalizeExpr body)
     ETHDeclQuote decls -> ETHDeclQuote (map normalizeDecl decls)
@@ -357,13 +348,7 @@ normalizeType ty =
     TFun lhs rhs -> TFun (normalizeType lhs) (normalizeType rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
     TList promoted elems -> TList promoted (map normalizeType elems)
-    -- Preserve TParen except when wrapping TKindSig: the parser absorbs
-    -- (ty :: kind) into TKindSig directly without a TParen wrapper.
-    TParen inner ->
-      let ni = normalizeType inner
-       in case peelTypeAnn ni of
-            TKindSig {} -> ni
-            _ -> TParen ni
+    TParen inner -> TParen (normalizeType inner)
     TKindSig inner kind -> TKindSig (normalizeType inner) (normalizeType kind)
     TUnboxedSum elems -> TUnboxedSum (map normalizeType elems)
     TContext constraints inner -> TContext (map normalizeType constraints) (normalizeType inner)

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -56,7 +56,16 @@ normalizeExpr expr =
     ETypeSig inner ty -> ETypeSig (normalizeExpr inner) (normalizeType ty)
     ETypeApp inner ty -> ETypeApp (normalizeExpr inner) (normalizeType ty)
     EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (normalizeExpr inner)
-    EParen inner -> normalizeExpr inner
+    EParen inner ->
+      -- Sections (ESectionL/ESectionR) always print with their own parens, so
+      -- EParen around them is transparent. The parser always wraps sections in
+      -- EParen, but addExprParens leaves sections bare. Strip EParen around
+      -- sections to unify both representations.
+      let ni = normalizeExpr inner
+       in case ni of
+            ESectionL {} -> ni
+            ESectionR {} -> ni
+            _ -> EParen ni
     ETHExpQuote body -> ETHExpQuote (normalizeExpr body)
     ETHTypedQuote body -> ETHTypedQuote (normalizeExpr body)
     ETHDeclQuote decls -> ETHDeclQuote (map normalizeDecl decls)
@@ -348,8 +357,13 @@ normalizeType ty =
     TFun lhs rhs -> TFun (normalizeType lhs) (normalizeType rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
     TList promoted elems -> TList promoted (map normalizeType elems)
-    -- Remove redundant parentheses from types
-    TParen inner -> normalizeType inner
+    -- Preserve TParen except when wrapping TKindSig: the parser absorbs
+    -- (ty :: kind) into TKindSig directly without a TParen wrapper.
+    TParen inner ->
+      let ni = normalizeType inner
+       in case peelTypeAnn ni of
+            TKindSig {} -> ni
+            _ -> TParen ni
     TKindSig inner kind -> TKindSig (normalizeType inner) (normalizeType kind)
     TUnboxedSum elems -> TUnboxedSum (map normalizeType elems)
     TContext constraints inner -> TContext (map normalizeType constraints) (normalizeType inner)

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -42,9 +42,6 @@ prop_typePrettyRoundTrip ty =
                      in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)
 
 -- | Normalize a type by stripping source spans.
--- TParen nodes are preserved as-is, except TParen around TKindSig is
--- stripped because the parser absorbs @(ty :: kind)@ as @TKindSig ty kind@
--- without a TParen wrapper.
 normalizeType :: Type -> Type
 normalizeType ty =
   case ty of
@@ -60,15 +57,7 @@ normalizeType ty =
     TFun a b -> TFun (normalizeType a) (normalizeType b)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
     TList promoted elems -> TList promoted (map normalizeType elems)
-    -- Strip TParen around TKindSig: the parser absorbs (ty :: kind) parens
-    -- into the TKindSig node itself. Normalize the inner first to collapse
-    -- any chain of TParens, then strip if TKindSig is underneath (possibly
-    -- behind span-only 'TAnn' from 'typeAnnSpan span0').
-    TParen inner ->
-      let ni = normalizeType inner
-       in case peelTypeAnn ni of
-            result@(TKindSig {}) -> result
-            _ -> TParen ni
+    TParen inner -> TParen (normalizeType inner)
     TKindSig ty' kind -> TKindSig (normalizeType ty') (normalizeType kind)
     TUnboxedSum elems -> TUnboxedSum (map normalizeType elems)
     TContext constraints inner -> TContext (map normalizeType constraints) (normalizeType inner)

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -7,12 +7,12 @@ module Test.Properties.TypeRoundTrip
 where
 
 import Aihc.Parser
+import Aihc.Parser.Parens (addTypeParens)
 import Aihc.Parser.Syntax
 import Data.Maybe (isJust)
 import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
-import Test.Properties.Arb.Type (canonicalTopLevelType)
 import Test.Properties.Coverage (assertCtorCoverage)
 import Test.Properties.ExprHelpers (normalizeExpr, span0)
 import Test.QuickCheck
@@ -27,7 +27,7 @@ typeConfig =
 prop_typePrettyRoundTrip :: Type -> Property
 prop_typePrettyRoundTrip ty =
   let source = renderStrict (layoutPretty defaultLayoutOptions (pretty ty))
-      expected = normalizeType (canonicalTopLevelType ty)
+      expected = normalizeType (addTypeParens ty)
       hasKindedInferredBinder = containsKindedInferredBinder ty
    in checkCoverage $
         withMaxShrinks 100 $


### PR DESCRIPTION
## Summary

Moves all parenthesisation logic into the \`Parens\` module and ensures \`EParen\`/\`TParen\` nodes are preserved through parse–pretty-print roundtrips.

### Parser (\`Internal/Type.hs\`)
- \`typeParenOrTupleParser\`: produce \`TParen (TKindSig ty kind)\` for \`(ty :: kind)\` instead of bare \`TKindSig\`. Explicit parentheses in source are now preserved in the AST.

### Parens module (\`Parens.hs\`)
- \`addExprParens\`: wrap \`ESectionL\`/\`ESectionR\` in \`EParen\` — sections always require surrounding parens in Haskell syntax.
- \`addTypeParens\` (CtxTypeAppArg): add \`TImplicitParam\` — when used as a \`TApp\` argument, an implicit param greedily absorbs the surrounding \`->\` into its body; \`TParen\` prevents this.
- \`addImplicitParamBodyParens\`: new helper (analogous to \`addForallBodyParens\`) that wraps a bare \`TContext\` in \`TParen\`. The \`startsWithContextType\` lookahead otherwise mistakes \`?x :: C a => T\` for an outer context, consuming the whole implicit param as a constraint item and then failing to find \`=>\`.
- \`addForallBodyParens\`: new helper that wraps a nested \`TForall\` body in \`TParen\`, because \`forallTypeParser\` uses \`contextOrFunTypeParser\` (not \`typeParser\`) for its body.
- \`addGadtBodyParens\`: use \`addTypeIn CtxTypeFunArg\` for the GADT prefix result type so that \`TFun\`/\`TForall\`/\`TContext\`/\`TImplicitParam\` result types are parenthesised correctly.

### Normalizers (test helpers)
- \`normalizeExpr\`: preserve \`EParen\` — no more stripping.
- \`normalizeType\`: preserve \`TParen\` — no more stripping.

### Test generators (\`Arb/Type.hs\`, \`Arb/Decl.hs\`)
- Removed all \`canonical*\` pre-canonicalization helpers from the generators. \`addTypeParens\` now handles all these cases directly, so the generators emit raw ASTs and the parens pass produces the canonical form.

### Golden test updates (\`Spec.hs\`)
- Updated tests that checked for bare \`TKindSig\` to now check for \`TParen (TKindSig ...)\`.

## Test plan
- [x] All 1383 tests pass