### PR TITLE
fix(parser): allow function type arrows in equation guard type signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -151,7 +151,7 @@ multiWayIfExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
 multiWayIfAlternative :: TokParser GuardedRhs
 multiWayIfAlternative = withSpan $ do
   expectedTok TkReservedPipe
-  guards <- layoutSepBy1 guardQualifierParser (expectedTok TkSpecialComma)
+  guards <- layoutSepBy1 (guardQualifierParser RhsArrowCase) (expectedTok TkSpecialComma)
   expectedTok TkReservedRightArrow
   body <- exprParser
   pure $ \span' ->
@@ -570,7 +570,7 @@ guardedRhssParser arrowKind = withSpan $ do
 guardedRhsParser :: RhsArrowKind -> TokParser GuardedRhs
 guardedRhsParser arrowKind = withSpan $ do
   expectedTok TkReservedPipe
-  guards <- layoutSepBy1 guardQualifierParser (expectedTok TkSpecialComma)
+  guards <- layoutSepBy1 (guardQualifierParser arrowKind) (expectedTok TkSpecialComma)
   rhsArrowTok arrowKind
   body <- exprParserExcept ["|", rhsArrowText arrowKind]
   pure $ \span' ->
@@ -580,20 +580,29 @@ guardedRhsParser arrowKind = withSpan $ do
         guardedRhsBody = body
       }
 
-guardQualifierParser :: TokParser GuardQualifier
-guardQualifierParser = do
+-- | Parse a guard qualifier. The 'RhsArrowKind' determines the type parser
+-- used for type signatures in guard expressions: in equation context (@=@),
+-- the full 'typeParser' is used (allowing @->@ in types); in case/multi-way-if
+-- context (@->@), 'typeInfixParser' is used to avoid consuming the alternative
+-- arrow as a function type arrow.
+guardQualifierParser :: RhsArrowKind -> TokParser GuardQualifier
+guardQualifierParser arrowKind = do
   tok <- lookAhead anySingle
   case lexTokenKind tok of
-    TkKeywordLet -> MP.try guardLetParser <|> guardBindOrExprParser
+    TkKeywordLet -> MP.try guardLetParser <|> guardBindOrExprParser arrowKind
     _ -> do
       isPatternBind <- startsWithPatternBind
       if isPatternBind
         then guardPatBindParser
-        else guardBindOrExprParser
+        else guardBindOrExprParser arrowKind
 
-guardBindOrExprParser :: TokParser GuardQualifier
-guardBindOrExprParser = withSpanAnn (GuardAnn . mkAnnotation) $ do
-  expr <- exprParserWithTypeSigParser typeInfixParser
+-- | Parse a guard expression or pattern bind. The 'RhsArrowKind' selects the
+-- type parser for @::@ annotations: 'RhsArrowEquation' uses 'typeParser'
+-- (which includes @->@), while 'RhsArrowCase' uses 'typeInfixParser' (which
+-- does not), matching GHC's behaviour.
+guardBindOrExprParser :: RhsArrowKind -> TokParser GuardQualifier
+guardBindOrExprParser arrowKind = withSpanAnn (GuardAnn . mkAnnotation) $ do
+  expr <- exprParserWithTypeSigParser (guardTypeSigParser arrowKind)
   mArrow <- MP.optional (expectedTok TkReservedLeftArrow)
   case mArrow of
     Just () -> do
@@ -611,6 +620,15 @@ guardPatBindParser = withSpanAnn (GuardAnn . mkAnnotation) $ do
 guardLetParser :: TokParser GuardQualifier
 guardLetParser = withSpanAnn (GuardAnn . mkAnnotation) $ do
   GuardLet <$> parseLetDeclsStmtParser
+
+-- | Select the type parser for guard expression type signatures based on the
+-- RHS arrow kind.  In equation context the full @typeParser@ is used so that
+-- @->@ is accepted inside types (e.g. @x | y :: Int -> Int = z@).  In case
+-- and multi-way-if contexts the arrow would be ambiguous with the alternative
+-- arrow, so @typeInfixParser@ is used instead, matching GHC behaviour.
+guardTypeSigParser :: RhsArrowKind -> TokParser Type
+guardTypeSigParser RhsArrowEquation = typeParser
+guardTypeSigParser RhsArrowCase = typeInfixParser
 
 caseAltParser :: TokParser CaseAlt
 caseAltParser = withSpan $ do

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_decl_quote_guard_fun_sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_decl_quote_guard_fun_sig.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- Guard expression inside a TH declaration quote with a function-type
+-- annotation.  The '->' in 'Int -> Bool' must be parsed as a function
+-- type arrow, not confused with a case alternative arrow.  Regression
+-- test for a parser bug that caused the outer declaration to misparse
+-- when the inner guarded RHS contained ':: T -> T2'.
+
+module THDeclQuoteGuardFunSig where
+
+f = [d|y | z :: Int -> Bool = z|]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/guard-expression-type-signature-fun.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/guard-expression-type-signature-fun.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+-- Guard expression type signatures may contain function arrows.
+-- In equation context the arrow is unambiguous (RHS uses '=', not '->'),
+-- so ':: T -> T2' must be parsed as a function type, not as the alternative
+-- arrow. Regression test for a bug where typeInfixParser was used in all
+-- guard contexts, rejecting '->' in types.
+
+module GuardExpressionTypeSignatureFun where
+
+f :: (Int -> Bool) -> Int -> Int
+f p x
+  | p :: Int -> Bool = x + 1
+  | otherwise = x


### PR DESCRIPTION
## Summary

- Fixes a parser bug where `->` in guard expression type signatures was rejected in equation context (e.g. `x | y :: Int -> Bool = z`), causing pretty-printer round-trip failures
- Parameterizes `guardQualifierParser` and `guardBindOrExprParser` by `RhsArrowKind` to select `typeParser` (with `->`) for equations and `typeInfixParser` (without `->`) for case/multi-way-if alternatives, matching GHC's behaviour
- Adds two oracle regression tests covering the equation context and TH declaration quote context

## Test plan

- `just replay "(SMGen 7954231812393276439 18158499151626554047,96)"` — previously FAIL, now PASS
- `just check` — all 1385+ tests pass
- 10,000 QuickCheck property tests pass

## Progress

+2 pass (oracle fixtures)