### PR TITLE
test: show xfail failure details

### DIFF
--- a/components/aihc-cpp/test/Test/Progress.hs
+++ b/components/aihc-cpp/test/Test/Progress.hs
@@ -18,9 +18,11 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import Language.Preprocessor.Cpphs (BoolOptions (..), CpphsOptions (..), defaultCpphsOptions, runCpphs)
-import System.Directory (doesFileExist)
+import System.Directory (doesFileExist, getTemporaryDirectory, removeFile)
 import System.FilePath (takeDirectory, (</>))
+import System.IO (IOMode (ReadMode), hClose, hFlush, openTempFile, stderr, withFile)
 
 data Expected = ExpectPass | ExpectXFail deriving (Eq, Show)
 
@@ -199,12 +201,54 @@ runOracle sourcePath = do
                   warnings = False
                 }
           }
-  oracleOut <-
-    (E.try (runCpphs cpphsOptions sourcePath (T.unpack source)) :: IO (Either E.SomeException String))
+  (oracleOut, capturedStderr) <-
+    captureStderrText
+      ( ( E.try $ do
+            out <- runCpphs cpphsOptions sourcePath (T.unpack source)
+            _ <- E.evaluate (length out)
+            pure out
+        ) ::
+          IO (Either E.SomeException String)
+      )
   pure $
     case oracleOut of
       Right out -> Right (T.pack out)
-      Left err -> Left ("cpphs failed: " <> show err)
+      Left err ->
+        Left
+          ( "cpphs failed: "
+              <> show err
+              <> stderrSuffix capturedStderr
+          )
+
+captureStderrText :: IO a -> IO (a, Text)
+captureStderrText action = do
+  tempDir <- getTemporaryDirectory
+  (tempPath, tempHandle) <- openTempFile tempDir "cpphs-stderr.txt"
+  originalStderr <- hDuplicate stderr
+  let restoreStderr = hFlush stderr >> hDuplicateTo originalStderr stderr
+      cleanup = do
+        hClose tempHandle
+        hClose originalStderr
+        removeFile tempPath
+  E.bracketOnError
+    (pure ())
+    (const (restoreStderr >> cleanup))
+    $ \() -> do
+      hFlush stderr
+      hDuplicateTo tempHandle stderr
+      result <- action `E.finally` restoreStderr
+      hClose tempHandle
+      captured <- withFile tempPath ReadMode TIO.hGetContents
+      hClose originalStderr
+      removeFile tempPath
+      pure (result, captured)
+
+stderrSuffix :: Text -> String
+stderrSuffix captured
+  | T.null stripped = ""
+  | otherwise = " stderr=" <> T.unpack stripped
+  where
+    stripped = T.strip captured
 
 loadManifest :: IO [CaseMeta]
 loadManifest = do

--- a/components/aihc-parser/common/ExtensionSupport.hs
+++ b/components/aihc-parser/common/ExtensionSupport.hs
@@ -59,7 +59,7 @@ classifyOutcome :: Expected -> Maybe Text -> Maybe String -> (Outcome, String)
 classifyOutcome _expected (Just oracleErr) _roundtripOk = (OutcomeFail, T.unpack oracleErr)
 classifyOutcome ExpectPass Nothing (Just err) = (OutcomeFail, err)
 classifyOutcome ExpectPass Nothing Nothing = (OutcomePass, "")
-classifyOutcome ExpectXFail Nothing Just {} = (OutcomeXFail, "")
+classifyOutcome ExpectXFail Nothing (Just err) = (OutcomeXFail, err)
 classifyOutcome ExpectXFail Nothing Nothing = (OutcomeXPass, "test case passed unexpectedly. Maybe update testcase from xfail to pass.")
 
 finalizeOutcome :: CaseMeta -> Maybe Text -> Maybe String -> (CaseMeta, Outcome, String)

--- a/components/aihc-parser/common/LexerGolden.hs
+++ b/components/aihc-parser/common/LexerGolden.hs
@@ -138,7 +138,11 @@ evaluateLexerCase meta =
               )
         StatusXFail
           | tokenMatch -> (OutcomeFail, "expected xfail (known failing bug), but tokens now match")
-          | otherwise -> (OutcomeXFail, "")
+          | otherwise ->
+              ( OutcomeXFail,
+                "known bug still present"
+                  <> detailsSuffix actualKinds expectedKinds
+              )
         StatusXPass
           | tokenMatch -> (OutcomeXPass, "known bug still passes unexpectedly")
           | otherwise -> (OutcomeFail, "expected xpass (known passing bug), but tokens no longer match")

--- a/components/aihc-parser/common/ParserGolden.hs
+++ b/components/aihc-parser/common/ParserGolden.hs
@@ -232,7 +232,10 @@ classifyFailure meta errDetails =
         "expected parse success, got parse error: " <> errDetails
       )
     StatusFail -> (OutcomePass, "")
-    StatusXFail -> (OutcomeXFail, "")
+    StatusXFail ->
+      ( OutcomeXFail,
+        "known bug still present: " <> errDetails
+      )
 
 progressSummary :: [(ParserCase, Outcome, String)] -> (Int, Int, Int, Int)
 progressSummary outcomes =

--- a/components/aihc-parser/test/Test/Lexer/Suite.hs
+++ b/components/aihc-parser/test/Test/Lexer/Suite.hs
@@ -21,8 +21,15 @@ lexerTests = do
 
 mkCaseTest :: LG.LexerCase -> IO TestTree
 mkCaseTest meta = pure $ case LG.caseStatus meta of
-  LG.StatusXFail -> testCaseInfo (LG.caseId meta) (assertCase meta >> pure "Known failure - to be fixed")
+  LG.StatusXFail -> testCaseInfo (LG.caseId meta) (xfailDetails (LG.evaluateLexerCase meta) <* assertCase meta)
   _ -> testCase (LG.caseId meta) (assertCase meta)
+
+xfailDetails :: (LG.Outcome, String) -> IO String
+xfailDetails (outcome, details) = do
+  case outcome of
+    LG.OutcomeXFail -> pure ()
+    _ -> assertFailure ("expected xfail outcome, got: " <> show outcome)
+  pure details
 
 mkSummaryTest :: [LG.LexerCase] -> IO TestTree
 mkSummaryTest cases = do
@@ -104,6 +111,15 @@ fixtureValidationTests =
             if LG.caseStatus parsed == LG.StatusXPass
               then pure ()
               else assertFailure "expected xpass status",
+      testCase "xfail lexer mismatches retain details" $
+        case LG.parseLexerCaseText "xfail-details.yaml" validXFailFixture of
+          Left err -> assertFailure ("expected parse success, got: " <> err)
+          Right parsed ->
+            case LG.evaluateLexerCase parsed of
+              (LG.OutcomeXFail, details)
+                | null details -> assertFailure "expected xfail details to be non-empty"
+                | otherwise -> pure ()
+              other -> assertFailure ("expected xfail outcome with details, got: " <> show other),
       testCase "only YAML fixtures are loaded" $ do
         cases <- LG.loadLexerCases
         mapM_
@@ -122,6 +138,17 @@ validXFailMissingReason =
       "tokens:",
       "  - 'TkVarId \"bad\"'",
       "status: xfail"
+    ]
+
+validXFailFixture :: T.Text
+validXFailFixture =
+  T.unlines
+    [ "extensions: []",
+      "input: \"-10\"",
+      "tokens:",
+      "  - 'TkInteger 10'",
+      "status: xfail",
+      "reason: known bug"
     ]
 
 validXPassFixture :: T.Text

--- a/components/aihc-parser/test/Test/Oracle/Suite.hs
+++ b/components/aihc-parser/test/Test/Oracle/Suite.hs
@@ -5,6 +5,7 @@ module Test.Oracle.Suite
   )
 where
 
+import Aihc.Parser.Syntax (Extension (RequiredTypeArguments), ExtensionSetting (EnableExtension))
 import Control.Monad (when)
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
@@ -32,8 +33,15 @@ mkCaseTest :: CaseMeta -> IO TestTree
 mkCaseTest meta = do
   source <- TIO.readFile (caseSourcePath meta)
   pure $ case caseExpected meta of
-    ExpectXFail -> testCaseInfo (caseId meta) (assertCase meta source >> pure "Known failure - to be fixed")
+    ExpectXFail -> testCaseInfo (caseId meta) (xfailDetails (evaluateCaseText meta source) <* assertCase meta source)
     _ -> testCase (caseId meta) (assertCase meta source)
+
+xfailDetails :: (CaseMeta, Outcome, String) -> IO String
+xfailDetails (_, outcome, details) = do
+  case outcome of
+    OutcomeXFail -> pure ()
+    _ -> assertFailure ("expected xfail outcome, got: " <> show outcome)
+  pure details
 
 mkSummaryTest :: [CaseMeta] -> IO TestTree
 mkSummaryTest cases = do
@@ -122,6 +130,23 @@ frameworkTests =
                 if outcome == OutcomeFail
                   then pure ()
                   else assertFailure ("expected OutcomeFail when oracle rejects fixture, got " <> show outcome),
+        testCase "oracle xfail retains details" $
+          let meta =
+                CaseMeta
+                  { caseId = "framework-xfail-details",
+                    caseCategory = "framework",
+                    casePath = "framework-xfail-details.hs",
+                    caseExpected = ExpectXFail,
+                    caseReason = "regression coverage",
+                    caseExtensions = [EnableExtension RequiredTypeArguments]
+                  }
+           in do
+                let (_, outcome, details) = evaluateCaseText meta "module Basic where\n\nx = f (type Int) 5\n"
+                case outcome of
+                  OutcomeXFail
+                    | null details -> assertFailure "expected xfail details to be non-empty"
+                    | otherwise -> pure ()
+                  _ -> assertFailure ("expected OutcomeXFail, got " <> show outcome),
         testCase "oracle rejects top-level block-argument lambda" $
           let meta =
                 CaseMeta

--- a/components/aihc-parser/test/Test/Parser/Suite.hs
+++ b/components/aihc-parser/test/Test/Parser/Suite.hs
@@ -40,18 +40,25 @@ parserGoldenTests = do
 
 mkExprCaseTest :: PG.ParserCase -> IO TestTree
 mkExprCaseTest meta = pure $ case PG.caseStatus meta of
-  PG.StatusXFail -> testCaseInfo (PG.caseId meta) (assertExprCase meta >> pure "Known failure - to be fixed")
+  PG.StatusXFail -> testCaseInfo (PG.caseId meta) (xfailDetails (PG.evaluateExprCase meta) <* assertExprCase meta)
   _ -> testCase (PG.caseId meta) (assertExprCase meta)
 
 mkModuleCaseTest :: PG.ParserCase -> IO TestTree
 mkModuleCaseTest meta = pure $ case PG.caseStatus meta of
-  PG.StatusXFail -> testCaseInfo (PG.caseId meta) (assertModuleCase meta >> pure "Known failure - to be fixed")
+  PG.StatusXFail -> testCaseInfo (PG.caseId meta) (xfailDetails (PG.evaluateModuleCase meta) <* assertModuleCase meta)
   _ -> testCase (PG.caseId meta) (assertModuleCase meta)
 
 mkPatternCaseTest :: PG.ParserCase -> IO TestTree
 mkPatternCaseTest meta = pure $ case PG.caseStatus meta of
-  PG.StatusXFail -> testCaseInfo (PG.caseId meta) (assertPatternCase meta >> pure "Known failure - to be fixed")
+  PG.StatusXFail -> testCaseInfo (PG.caseId meta) (xfailDetails (PG.evaluatePatternCase meta) <* assertPatternCase meta)
   _ -> testCase (PG.caseId meta) (assertPatternCase meta)
+
+xfailDetails :: (PG.Outcome, String) -> IO String
+xfailDetails (outcome, details) = do
+  case outcome of
+    PG.OutcomeXFail -> pure ()
+    _ -> assertFailure ("expected xfail outcome, got: " <> show outcome)
+  pure details
 
 mkSummaryTest :: String -> (PG.ParserCase -> (PG.Outcome, String)) -> [PG.ParserCase] -> IO TestTree
 mkSummaryTest label evaluateCase cases = do
@@ -161,6 +168,15 @@ fixtureValidationTests =
             if PG.caseStatus parsed == PG.StatusXFail && null (PG.caseAst parsed)
               then pure ()
               else assertFailure "expected xfail status with empty ast",
+      testCase "xfail parse failures retain details" $
+        case PG.parseParserCaseText PG.CaseExpr "xfail-details.yaml" validXFailWithParseFailure of
+          Left err -> assertFailure ("expected parse success, got: " <> err)
+          Right parsed ->
+            case PG.evaluateExprCase parsed of
+              (PG.OutcomeXFail, details)
+                | null details -> assertFailure "expected xfail details to be non-empty"
+                | otherwise -> pure ()
+              other -> assertFailure ("expected xfail outcome with details, got: " <> show other),
       testCase "only YAML fixtures are loaded" $ do
         exprCases <- PG.loadExprCases
         moduleCases <- PG.loadModuleCases
@@ -187,6 +203,15 @@ validXFailNoAst =
   T.unlines
     [ "extensions: []",
       "input: bad",
+      "status: xfail",
+      "reason: known bug"
+    ]
+
+validXFailWithParseFailure :: T.Text
+validXFailWithParseFailure =
+  T.unlines
+    [ "extensions: []",
+      "input: \"(\"",
       "status: xfail",
       "reason: known bug"
     ]

--- a/components/aihc-parser/test/Test/Performance/Suite.hs
+++ b/components/aihc-parser/test/Test/Performance/Suite.hs
@@ -58,8 +58,30 @@ parserPerformanceTests = do
 
 mkPerfCaseTest :: PerfCase -> TestTree
 mkPerfCaseTest perfCase = case perfCaseStatus perfCase of
-  StatusXFail -> testCaseInfo (perfCaseId perfCase) (assertPerfCase perfCase >> pure "Known failure - to be fixed")
+  StatusXFail -> testCaseInfo (perfCaseId perfCase) (xfailDetails perfCase <* assertPerfCase perfCase)
   _ -> testCase (perfCaseId perfCase) (assertPerfCase perfCase)
+
+xfailDetails :: PerfCase -> IO String
+xfailDetails perfCase = do
+  outcome <-
+    timeout timeoutMicros $
+      evaluate $
+        force $
+          parseModule
+            defaultConfig
+              { parserSourceName = perfCaseSourceName perfCase,
+                parserExtensions = perfCaseExtensions perfCase
+              }
+            (perfCaseInput perfCase)
+  case outcome of
+    Nothing -> pure ("known bug still present: module parse exceeded " <> show timeoutMicros <> "us")
+    Just (errs, _)
+      | null errs -> assertFailure "expected xfail performance case to still fail"
+      | otherwise ->
+          pure
+            ( "known bug still present: "
+                <> formatParseErrors (perfCaseSourceName perfCase) (Just (perfCaseInput perfCase)) errs
+            )
 
 assertPerfCase :: PerfCase -> Assertion
 assertPerfCase perfCase = do
@@ -197,7 +219,8 @@ generatedPerfCases =
     mkGeneratedPerfCase "type-left-leaning-terms" (mkTypeModule (leftLeaningType generatedCaseSize)),
     mkGeneratedPerfCase "type-parameters" (mkTypeModule (typeWithParameters generatedCaseSize)),
     mkGeneratedPerfCase "string-escapes" (mkExprModule (escapedStringExpr (generatedCaseSize * 100))),
-    mkGeneratedPerfCase "nested-application" (mkExprModule (nestedAppExpr generatedCaseSize))
+    mkGeneratedPerfCase "nested-application" (mkExprModule (nestedAppExpr generatedCaseSize)),
+    mkGeneratedPerfCaseWithStatus "xfail-invalid-module" "module Generated where\nvalue = { x = 1, }\n" StatusXFail "regression coverage"
   ]
 
 mkGeneratedPerfCase :: String -> Text -> PerfCase


### PR DESCRIPTION
## Summary
- include evaluated failure details in parser, lexer, oracle, and performance xfail `testCaseInfo` output instead of the generic placeholder
- add regression coverage to keep xfail detail strings non-empty and keep the generated performance suite exercising the xfail path
- capture lazy `cpphs` stderr in the cpp oracle test harness so malformed-fixture warnings no longer leak into `just check`

## Checks
- just check
- coderabbit review --prompt-only (no findings)