### PR TITLE
fix(parser): allow TH splices immediately inside quotes

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -449,6 +449,11 @@ allowsMergeOrPrefix prev hadTrivia =
 prevTokenAllowsTightPrefix :: LexTokenKind -> Bool
 prevTokenAllowsTightPrefix kind =
   case kind of
+    TkTHTypeQuoteOpen -> True
+    TkTHExpQuoteOpen -> True
+    TkTHTypedQuoteOpen -> True
+    TkTHDeclQuoteOpen -> True
+    TkTHPatQuoteOpen -> True
     TkSpecialLParen -> True
     TkSpecialLBracket -> True
     TkSpecialLBrace -> True

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -243,6 +243,7 @@ buildTests = do
             testCase "parses mdo view patterns" test_mdoViewPatternParses,
             testCase "TemplateHaskellQuotes parses top-level typed splices" test_templateHaskellQuotesParsesTopLevelTypedSpliceExpr,
             testCase "TemplateHaskellQuotes lexes typed splice tokens" test_templateHaskellQuotesLexesTypedSplice,
+            testCase "TemplateHaskell type quotes parse infix type splices" test_templateHaskellTypeQuoteParsesInfixSplices,
             testCase "parses and roundtrips infix type family heads" test_infixTypeFamilyHeadRoundtrip,
             QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
@@ -1910,6 +1911,18 @@ test_templateHaskellQuotesLexesTypedSplice =
   case map lexTokenKind (lexTokensWithExtensions [TemplateHaskellQuotes] "$$(x)") of
     [TkTHTypedSplice, TkSpecialLParen, TkVarId "x", TkSpecialRParen, TkEOF] -> pure ()
     other -> assertFailure ("expected typed splice tokens under TemplateHaskellQuotes, got: " <> show other)
+
+test_templateHaskellTypeQuoteParsesInfixSplices :: Assertion
+test_templateHaskellTypeQuoteParsesInfixSplices =
+  case parseExpr defaultConfig {parserExtensions = [TemplateHaskell, TypeOperators]} "[t|$c := $v|]" of
+    ParseOk expr
+      | ETHTypeQuote ty <- peelExprAnn expr,
+        TApp (TApp (TCon op Unpromoted) (TSplice lhs)) (TSplice rhs) <- stripTypeAnnotations ty,
+        renderName op == ":=",
+        EVar_ "c" <- lhs,
+        EVar_ "v" <- rhs ->
+          pure ()
+    other -> assertFailure ("expected type quote with infix TH splices to parse, got: " <> show other)
 
 -- Helper: parse a top-level declaration and extract the ValueDecl.
 parseTopDecl :: T.Text -> Either String Decl

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -9,6 +9,7 @@ import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions, readModuleHeaderExtensions, readModuleHeaderExtensionsFromChunks)
 import Aihc.Parser.Parens (addDeclParens)
 import Aihc.Parser.Pretty ()
+import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
 import Data.Char (ord)
 import Data.List (isInfixOf)
@@ -1914,15 +1915,10 @@ test_templateHaskellQuotesLexesTypedSplice =
 
 test_templateHaskellTypeQuoteParsesInfixSplices :: Assertion
 test_templateHaskellTypeQuoteParsesInfixSplices =
-  case parseExpr defaultConfig {parserExtensions = [TemplateHaskell, TypeOperators]} "[t|$c := $v|]" of
-    ParseOk expr
-      | ETHTypeQuote ty <- peelExprAnn expr,
-        TApp (TApp (TCon op Unpromoted) (TSplice lhs)) (TSplice rhs) <- stripTypeAnnotations ty,
-        renderName op == ":=",
-        EVar_ "c" <- lhs,
-        EVar_ "v" <- rhs ->
-          pure ()
-    other -> assertFailure ("expected type quote with infix TH splices to parse, got: " <> show other)
+  assertEqual
+    "expected type quote with infix TH splices shorthand"
+    "ParseOk (ETHTypeQuote (TApp (TApp (TCon \":=\") (TSplice (EVar \"c\"))) (TSplice (EVar \"v\"))))"
+    (show (shorthand (parseExpr defaultConfig {parserExtensions = [TemplateHaskell, TypeOperators]} "[t|$c := $v|]")))
 
 -- Helper: parse a top-level declaration and extract the ValueDecl.
 parseTopDecl :: T.Text -> Either String Decl

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/type-quote-splice-type-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskellQuotes/type-quote-splice-type-application.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="typed TH splices inside type quotations are rejected after an infix operator" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 


### PR DESCRIPTION
## Summary
- fix the lexer prefix-position rules so Template Haskell splices are recognized immediately after quote openers like `[t|`, instead of tokenizing `$` as a normal operator in quote bodies
- add a focused parser regression for `[t|$c := $v|]` and promote the oracle fixture `TemplateHaskellQuotes/type-quote-splice-type-application` from `xfail` to `pass`
- oracle progress: pass +1, xfail -1

## Root Cause
- The lexer only recognized tight-prefix `$` and `$$` splices after a limited set of preceding tokens.
- `TkTHTypeQuoteOpen` and the other TH quote opener tokens were missing from that allowlist.
- As a result, the first `$` in `[t|$c := $v|]` was lexed as `TkVarSym "$"` instead of `TkTHSplice`, so the type quote body failed before it could parse the infix operator chain.

## Solution
- Extend `prevTokenAllowsTightPrefix` to treat TH quote openers as valid prefix positions.
- This is the smallest long-term fix because it corrects the lexical classification at the source and automatically generalizes to all TH quote bodies, instead of adding special cases in the type parser.

## Testing
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "TemplateHaskell type quotes parse infix type splices"'`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` returned no findings

## Follow-up
- No additional follow-up is required for this fix.