### PR TITLE
fix(parser): support infix family operands with type applications

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1231,7 +1231,7 @@ typeFamilyOperatorParser =
 
 typeFamilyLhsParser :: TokParser (TypeHeadForm, Type)
 typeFamilyLhsParser = do
-  lhs <- typeAtomParser
+  lhs <- typeAppParser
   hasInfixTail <- MP.optional (lookAhead typeInfixOperatorParser)
   case hasInfixTail of
     Just _ -> do
@@ -1244,8 +1244,8 @@ typeFamilyLhsParser = do
     typeHeadInfixTailParser :: TokParser [((Name, TypePromotion), Type)]
     typeHeadInfixTailParser = MP.many $ MP.try $ do
       op <- typeInfixOperatorParser
-      atom <- typeAtomParser
-      pure (op, atom)
+      rhs <- typeAppParser
+      pure (op, rhs)
 
     buildInfixType left ((op, promoted), right) =
       let span' = mergeSourceSpans (getSourceSpan left) (getSourceSpan right)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1416,7 +1416,14 @@ prettyTypeFamilyHead :: TypeHeadForm -> Type -> [TyVarBinder] -> [Doc ann]
 prettyTypeFamilyHead headForm headType params =
   case headForm of
     TypeHeadPrefix -> [prettyType headType] <> map prettyTyVarBinder params
-    TypeHeadInfix -> [prettyTypeFamilyInfix headType]
+    TypeHeadInfix ->
+      case (params, typeFamilyInfixAppView headType) of
+        ([lhs, rhs], Just (op, promoted, _, _)) ->
+          [ prettyTyVarBinder lhs,
+            (if promoted == Promoted then "'" else mempty) <> prettyNameInfixOp op,
+            prettyTyVarBinder rhs
+          ]
+        _ -> [prettyTypeFamilyInfix headType]
 
 prettyTypeFamilyLhs :: TypeHeadForm -> Type -> [Doc ann]
 prettyTypeFamilyLhs headForm lhs =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -244,6 +244,7 @@ buildTests = do
             testCase "TemplateHaskellQuotes parses top-level typed splices" test_templateHaskellQuotesParsesTopLevelTypedSpliceExpr,
             testCase "TemplateHaskellQuotes lexes typed splice tokens" test_templateHaskellQuotesLexesTypedSplice,
             testCase "parses and roundtrips infix type family heads" test_infixTypeFamilyHeadRoundtrip,
+            testCase "parses infix type family equations with application operands" test_infixTypeFamilyEquationWithApplicationOperands,
             QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
             QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism
@@ -668,6 +669,35 @@ test_infixTypeFamilyHeadRoundtrip =
         case validateParser "InfixTypeFamilyHead.hs" Haskell2010Edition [EnableExtension TypeFamilies, EnableExtension TypeOperators] source of
           Nothing -> pure ()
           Just err -> assertFailure ("expected infix type family head roundtrip to validate, got: " <> show err)
+
+test_infixTypeFamilyEquationWithApplicationOperands :: Assertion
+test_infixTypeFamilyEquationWithApplicationOperands =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE GHC2021, DataKinds, TypeFamilies, TypeOperators, NoStarIsType #-}",
+            "module M where",
+            "type family (a :: ExactPi') * (b :: ExactPi') :: ExactPi' where",
+            "  'ExactPi z p q * 'ExactPi z' p' q' = 'ExactPi undefined undefined undefined"
+          ]
+      exts = [EnableExtension GHC2021, EnableExtension DataKinds, EnableExtension TypeFamilies, EnableExtension TypeOperators, DisableExtension StarIsType]
+      (errs, modu) = parseModule defaultConfig {parserExtensions = effectiveExtensions Haskell2010Edition exts} source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        case map normalizeDecl (moduleDecls modu) of
+          [ DeclTypeFamilyDecl
+              TypeFamilyDecl
+                { typeFamilyDeclHeadForm = TypeHeadInfix,
+                  typeFamilyDeclEquations = Just [TypeFamilyEq {typeFamilyEqHeadForm = TypeHeadInfix, typeFamilyEqLhs = lhs}]
+                }
+            ]
+              | TApp (TApp (TCon "*" Unpromoted) lhsArg) rhsArg <- stripTypeAnnotations lhs,
+                TApp (TApp (TApp (TCon "ExactPi" Promoted) (TVar "z")) (TVar "p")) (TVar "q") <- stripTypeAnnotations lhsArg,
+                TApp (TApp (TApp (TCon "ExactPi" Promoted) (TVar "z'")) (TVar "p'")) (TVar "q'") <- stripTypeAnnotations rhsArg ->
+                  pure ()
+          other -> assertFailure ("unexpected parsed declarations: " <> show other)
+        case validateParser "TypeFamilyInfixStarEquation.hs" Haskell2010Edition exts source of
+          Nothing -> pure ()
+          Just err -> assertFailure ("expected infix type family equation with application operands to validate, got: " <> show err)
 
 test_parserConfigPassesExtensions :: Assertion
 test_parserConfigPassesExtensions =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type-set uses the type-level application operator $ in type instance heads, which the parser rejects" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
@@ -1,5 +1,13 @@
-{- ORACLE_TEST xfail reason="type family equations with infix operator * not parsed correctly" -}
-{-# LANGUAGE GHC2021, DataKinds, TypeFamilies, TypeOperators, NoStarIsType #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeOperators #-}
+{- ORACLE_TEST pass -}
+{-# LANGUAGE NoStarIsType #-}
 
 type family (a :: ExactPi') * (b :: ExactPi') :: ExactPi' where
   'ExactPi z p q * 'ExactPi z' p' q' = 'ExactPi undefined undefined undefined


### PR DESCRIPTION
## Summary
- parse infix type family equations and type instance heads when either operand is a type application instead of a single atom
- preserve kind-annotated binders when pretty-printing infix type family heads so roundtrip validation stays stable
- add regression coverage and promote two oracle fixtures from xfail to pass

## Root Cause
The parser's `typeFamilyLhsParser` only accepted `typeAtomParser` operands around infix family operators. That rejected valid equations and instance heads such as `'ExactPi z p q * 'ExactPi z' p' q'` and `InsertElse t t' ts $ '()`, because both sides start as type applications.

A second issue showed up once parsing succeeded: the pretty-printer rendered infix family heads from the synthesized head type alone, which dropped kind annotations from the original binders and changed the GHC oracle fingerprint.

## Solution
The parser now uses `typeAppParser` for both sides of infix type-family/operator heads, which generalizes to application operands instead of only atomic operands. The pretty-printer now prefers the stored type-family binders for infix heads so binder kind annotations are preserved during roundtrip printing.

## Testing
- added a regression spec for infix type family equations whose operands are promoted type applications
- ran `just fmt`
- ran `just check`
- ran `coderabbit review --prompt-only` with no findings

## Progress
- Oracle progress: `pass=854 xfail=5` -> `pass=856 xfail=3`

## Follow-up
- No additional follow-up work identified from this fix