### PR TITLE
fix(parser): support infix type family instance applications

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1231,29 +1231,25 @@ typeFamilyOperatorParser =
 
 typeFamilyLhsParser :: TokParser (TypeHeadForm, Type)
 typeFamilyLhsParser = do
-  lhs <- typeAtomParser
+  lhs <- typeAppParser
   hasInfixTail <- MP.optional (lookAhead typeInfixOperatorParser)
   case hasInfixTail of
     Just _ -> do
       rest <- typeHeadInfixTailParser
       pure (TypeHeadInfix, foldl buildInfixType lhs rest)
-    Nothing -> do
-      rest <- MP.many typeAtomParser
-      pure (TypeHeadPrefix, foldl buildTypeApp lhs rest)
+    Nothing ->
+      pure (TypeHeadPrefix, lhs)
   where
     typeHeadInfixTailParser :: TokParser [((Name, TypePromotion), Type)]
     typeHeadInfixTailParser = MP.many $ MP.try $ do
       op <- typeInfixOperatorParser
-      atom <- typeAtomParser
-      pure (op, atom)
+      rhs <- typeAppParser
+      pure (op, rhs)
 
     buildInfixType left ((op, promoted), right) =
       let span' = mergeSourceSpans (getSourceSpan left) (getSourceSpan right)
           opType = typeAnnSpan span' (TCon op promoted)
        in typeAnnSpan span' (TApp (typeAnnSpan span' (TApp opType left)) right)
-
-    buildTypeApp left right =
-      typeAnnSpan (mergeSourceSpans (getSourceSpan left) (getSourceSpan right)) (TApp left right)
 
 classHeadParser :: TokParser (TypeHeadForm, Text, [TyVarBinder])
 classHeadParser =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -255,6 +255,7 @@ matchSymbolicInfixTypeApp ty = do
 data TypeCtx
   = CtxTypeFunArg
   | CtxTypeAppArg
+  | CtxTypeFamilyOperand
   | CtxTypeAtom
   | CtxKindSig
 
@@ -281,6 +282,14 @@ needsTypeParens ctx ty =
         -- TImplicitParam parses greedily: as a TApp argument ?x :: T -> U absorbs
         -- the surrounding -> U into the implicit param type.
         TImplicitParam {} -> True
+        _ -> False
+    CtxTypeFamilyOperand ->
+      case ty of
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        TImplicitParam {} -> True
+        TKindSig {} -> True
         _ -> False
     CtxTypeAtom ->
       case ty of
@@ -580,8 +589,8 @@ addTypeFamilyDeclParens tf =
 addTypeFamilyEqParens :: TypeFamilyEq -> TypeFamilyEq
 addTypeFamilyEqParens eq =
   eq
-    { typeFamilyEqLhs = addTypeParens (typeFamilyEqLhs eq),
-      typeFamilyEqRhs = addTypeParens (typeFamilyEqRhs eq)
+    { typeFamilyEqLhs = addTypeFamilyLhsParens (typeFamilyEqHeadForm eq) (typeFamilyEqLhs eq),
+      typeFamilyEqRhs = addTypeFamilyRhsParens (typeFamilyEqRhs eq)
     }
 
 addDataFamilyDeclParens :: DataFamilyDecl -> DataFamilyDecl
@@ -593,9 +602,27 @@ addDataFamilyDeclParens df =
 addTypeFamilyInstParens :: TypeFamilyInst -> TypeFamilyInst
 addTypeFamilyInstParens tfi =
   tfi
-    { typeFamilyInstLhs = addTypeParens (typeFamilyInstLhs tfi),
-      typeFamilyInstRhs = addTypeParens (typeFamilyInstRhs tfi)
+    { typeFamilyInstLhs = addTypeFamilyLhsParens (typeFamilyInstHeadForm tfi) (typeFamilyInstLhs tfi),
+      typeFamilyInstRhs = addTypeFamilyRhsParens (typeFamilyInstRhs tfi)
     }
+
+addTypeFamilyLhsParens :: TypeHeadForm -> Type -> Type
+addTypeFamilyLhsParens headForm ty =
+  case headForm of
+    TypeHeadPrefix -> addTypeParens ty
+    TypeHeadInfix ->
+      case peelTypeAnn ty of
+        TApp l r ->
+          case peelTypeAnn l of
+            TApp op lhs ->
+              TApp
+                (TApp (addTypeParens op) (addTypeIn CtxTypeFamilyOperand lhs))
+                (addTypeIn CtxTypeFamilyOperand r)
+            _ -> addTypeParens ty
+        _ -> addTypeParens ty
+
+addTypeFamilyRhsParens :: Type -> Type
+addTypeFamilyRhsParens = addTypeParensShared CtxTypeFamilyOperand 0
 
 addDataFamilyInstParens :: DataFamilyInst -> DataFamilyInst
 addDataFamilyInstParens dfi =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -25,7 +25,7 @@ import Test.Lexer.Suite (lexerTests)
 import Test.Oracle.Suite (oracleTests)
 import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
-import Test.Properties.Arb.Decl (genDeclDataFamilyInst)
+import Test.Properties.Arb.Decl (genDeclDataFamilyInst, genDeclTypeFamilyInst)
 import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, span0, stripTypeAnnotations)
@@ -321,6 +321,7 @@ buildTests = do
             testCase "prefix function head record pattern stays bare" test_prettyPrefixFunctionHeadRecordPattern,
             testCase "infix function head constructor applications stay bare" test_prettyInfixFunctionHeadConstructorPatterns,
             testCase "infix function head irrefutable patterns stay bare" test_prettyInfixFunctionHeadIrrefutablePatterns,
+            testCase "infix type family instances keep bare applications" test_typeFamilyInstanceInfixAppliedOperandsRoundTrip,
             testCase "view pattern with let-typed expr gets parenthesized" test_prettyViewLetTypeSigParens,
             testCase "guard pattern with type sig gets parenthesized" test_prettyGuardPatTypeSigParens,
             testCase "data family instance kind signatures round-trip" test_dataFamilyInstanceKindSignatureRoundTrip
@@ -352,6 +353,7 @@ buildTests = do
               QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
+              QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
               QC.testProperty "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip
@@ -1645,6 +1647,35 @@ test_dataFamilyInstanceKindSignatureRoundTrip = do
     ParseErr err ->
       assertFailure ("expected data family instance kind signature to parse, got:\n" <> MPE.errorBundlePretty err)
 
+test_typeFamilyInstanceInfixAppliedOperandsRoundTrip :: Assertion
+test_typeFamilyInstanceInfixAppliedOperandsRoundTrip = do
+  let lhs =
+        TApp
+          ( TApp
+              (TCon (qualifyName Nothing (mkUnqualifiedName NameVarSym "$")) Unpromoted)
+              (TApp (TVar "a") (TVar "b"))
+          )
+          (TVar "c")
+      rhs = TApp (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "F")) Unpromoted) (TVar "d")
+      decl =
+        DeclTypeFamilyInst
+          TypeFamilyInst
+            { typeFamilyInstSpan = span0,
+              typeFamilyInstForall = [],
+              typeFamilyInstHeadForm = TypeHeadInfix,
+              typeFamilyInstLhs = lhs,
+              typeFamilyInstRhs = rhs
+            }
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  assertBool
+    ("expected bare type applications in infix type family instance, got:\n" <> T.unpack source)
+    (source == "type instance a b $ c = F d")
+  case parseDecl defaultConfig source of
+    ParseOk parsed ->
+      normalizeDecl parsed @?= normalizeDecl decl
+    ParseErr err ->
+      assertFailure ("expected infix type family instance with bare applications to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
+
 prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds :: Property
 prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds =
   let samples = sampleGen 6000 genDeclDataFamilyInst
@@ -1653,6 +1684,36 @@ prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds =
         | decl@(DeclDataFamilyInst DataFamilyInst {dataFamilyInstKind = Just _}) <- samples
         ]
    in counterexample ("expected at least one generated data family instance with inline result kind; sampled " <> show (length samples)) (not (null matching))
+
+prop_generatedTypeFamilyInstancesCanUseBareInfixApplications :: Property
+prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =
+  let samples = sampleGen 6000 genDeclTypeFamilyInst
+      lhsMatches =
+        [ decl
+        | decl@(DeclTypeFamilyInst TypeFamilyInst {typeFamilyInstHeadForm = TypeHeadInfix, typeFamilyInstLhs}) <- samples,
+          case stripTypeAnnotations typeFamilyInstLhs of
+            TApp (TApp _ lhsOperand) rhsOperand -> isBareTypeApp lhsOperand || isBareTypeApp rhsOperand
+            _ -> False
+        ]
+      rhsMatches =
+        [ decl
+        | decl@(DeclTypeFamilyInst TypeFamilyInst {typeFamilyInstRhs}) <- samples,
+          isBareTypeApp (stripTypeAnnotations typeFamilyInstRhs)
+        ]
+   in counterexample
+        ( "expected generated type family instances with bare applications in infix operands and rhs; sampled "
+            <> show (length samples)
+            <> ", lhs matches="
+            <> show (length lhsMatches)
+            <> ", rhs matches="
+            <> show (length rhsMatches)
+        )
+        (not (null lhsMatches) && not (null rhsMatches))
+  where
+    isBareTypeApp ty =
+      case ty of
+        TApp {} -> True
+        _ -> False
 
 test_guardPatBind :: Assertion
 test_guardPatBind =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type-set uses the type-level application operator $ in type instance heads, which the parser rejects" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -4,6 +4,7 @@
 module Test.Properties.Arb.Decl
   ( genDecl,
     genDeclDataFamilyInst,
+    genDeclTypeFamilyInst,
     genFunctionDecl,
     shrinkDecl,
   )
@@ -865,9 +866,16 @@ genDeclDataFamilyDecl = do
         }
 
 genDeclTypeFamilyInst :: Gen Decl
-genDeclTypeFamilyInst = do
+genDeclTypeFamilyInst =
+  oneof
+    [ genDeclTypeFamilyInstPrefix,
+      genDeclTypeFamilyInstInfix
+    ]
+
+genDeclTypeFamilyInstPrefix :: Gen Decl
+genDeclTypeFamilyInstPrefix = do
   lhs <- genFamilyLhsType
-  rhs <- genSimpleType
+  rhs <- genFamilyRhsType
   pure $
     DeclTypeFamilyInst $
       TypeFamilyInst
@@ -875,6 +883,22 @@ genDeclTypeFamilyInst = do
           typeFamilyInstForall = [],
           typeFamilyInstHeadForm = TypeHeadPrefix,
           typeFamilyInstLhs = lhs,
+          typeFamilyInstRhs = rhs
+        }
+
+genDeclTypeFamilyInstInfix :: Gen Decl
+genDeclTypeFamilyInstInfix = do
+  op <- genTypeFamilyInstOperator
+  lhsArg <- genFamilyInfixOperand
+  rhsArg <- genFamilyInfixOperand
+  rhs <- genFamilyRhsType
+  pure $
+    DeclTypeFamilyInst $
+      TypeFamilyInst
+        { typeFamilyInstSpan = span0,
+          typeFamilyInstForall = [],
+          typeFamilyInstHeadForm = TypeHeadInfix,
+          typeFamilyInstLhs = TApp (TApp (TCon op Unpromoted) lhsArg) rhsArg,
           typeFamilyInstRhs = rhs
         }
 
@@ -936,6 +960,46 @@ genFamilyLhsType = do
   familyName <- genConIdent
   let familyCon = TCon (qualifyName Nothing (mkUnqualifiedName NameConId familyName)) Unpromoted
   TApp familyCon <$> genFamilyLhsArg
+
+genTypeFamilyInstOperator :: Gen Name
+genTypeFamilyInstOperator =
+  oneof
+    [ qualifyName Nothing . mkUnqualifiedName NameVarSym <$> genFamilyInstVarOperator,
+      qualifyName Nothing . mkUnqualifiedName NameConSym <$> genFamilyInstConOperator,
+      qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
+    ]
+
+genFamilyInstVarOperator :: Gen Text
+genFamilyInstVarOperator =
+  suchThat genOperator (`notElem` ["*", ".", "!", "'"])
+
+genFamilyInstConOperator :: Gen Text
+genFamilyInstConOperator =
+  suchThat genConSym (`notElem` ["!"])
+
+genFamilyInfixOperand :: Gen Type
+genFamilyInfixOperand =
+  frequency
+    [ (1, genFamilyTypeAtom),
+      (3, genFamilyTypeApp)
+    ]
+
+genFamilyRhsType :: Gen Type
+genFamilyRhsType =
+  frequency
+    [ (2, genSimpleType),
+      (3, genFamilyTypeApp)
+    ]
+
+genFamilyTypeApp :: Gen Type
+genFamilyTypeApp = do
+  f <- genFamilyTypeAtom
+  argCount <- chooseInt (1, 2)
+  args <- vectorOf argCount genFamilyTypeAtom
+  pure (foldl TApp f args)
+
+genFamilyTypeAtom :: Gen Type
+genFamilyTypeAtom = genSimpleTypeWithoutFun
 
 genFamilyLhsArg :: Gen Type
 genFamilyLhsArg = suchThat (sized (genType . min 4)) (not . isStarType)
@@ -1286,8 +1350,19 @@ shrinkDataFamilyDecl df =
 
 shrinkTypeFamilyInst :: TypeFamilyInst -> [TypeFamilyInst]
 shrinkTypeFamilyInst tfi =
-  [tfi {typeFamilyInstLhs = lhs'} | lhs' <- shrinkType (typeFamilyInstLhs tfi)]
+  [tfi {typeFamilyInstLhs = lhs'} | lhs' <- shrinkTypeFamilyInstLhs (typeFamilyInstHeadForm tfi) (typeFamilyInstLhs tfi)]
     <> [tfi {typeFamilyInstRhs = rhs'} | rhs' <- shrinkType (typeFamilyInstRhs tfi)]
+
+shrinkTypeFamilyInstLhs :: TypeHeadForm -> Type -> [Type]
+shrinkTypeFamilyInstLhs headForm lhs =
+  case headForm of
+    TypeHeadPrefix -> shrinkType lhs
+    TypeHeadInfix ->
+      case lhs of
+        TApp (TApp op lhsArg) rhsArg ->
+          [TApp (TApp op lhsArg') rhsArg | lhsArg' <- shrinkType lhsArg]
+            <> [TApp (TApp op lhsArg) rhsArg' | rhsArg' <- shrinkType rhsArg]
+        _ -> []
 
 shrinkDataFamilyInst :: DataFamilyInst -> [DataFamilyInst]
 shrinkDataFamilyInst dfi =


### PR DESCRIPTION
## Summary
- parse type family instance heads as infix even when either operand is a type application, so cases like `type instance a b $ c = F d` round-trip without extra parentheses
- extend the declaration generator to produce infix type family instances with bare type applications on the lhs and rhs, and keep the shrinker within valid infix-head shapes
- promote `test/Test/Fixtures/oracle/Hackage/type-set-type-instance-dollar-application.hs` from xfail to pass and add regression/property coverage for the new syntax

## Validation
- `just check`
- focused spec runs for the new pretty/parser regression, the new generator property, and the promoted oracle fixture

## Progress
- oracle counts: `xfail -1`, `pass +1`

## CodeRabbit
- `coderabbit review --prompt-only` was skipped because the service was rate-limited