### PR TITLE
test(parser): fix star equation oracle fixture

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-infix-star-equation.hs
@@ -1,12 +1,8 @@
 {- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
-{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
-{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
-{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeOperators #-}
-{- ORACLE_TEST pass -}
 {-# LANGUAGE NoStarIsType #-}
 
 type family (a :: ExactPi') * (b :: ExactPi') :: ExactPi' where


### PR DESCRIPTION
## Summary
- remove the duplicated `ORACLE_TEST pass` markers from `type-family-infix-star-equation.hs`
- keep the fixture semantics unchanged while restoring a normal pragma header layout
- ensure the oracle fixture matches the intended post-merge parser behavior

## Root Cause
The previous PR fixed the parser, but this fixture file was left with repeated `ORACLE_TEST` comments interleaved between `LANGUAGE` pragmas. That made the test input malformed relative to the intended single oracle header plus extension pragmas.

## Solution
Keep the same enabled extensions and test case body, but reduce the header to one `ORACLE_TEST` block followed by the existing `LANGUAGE` pragmas.

## Testing
- ran `just fmt`
- ran `just check`
- attempted `coderabbit review --prompt-only`, but CodeRabbit was rate-limited and skipped per repo instructions

## Progress
- Oracle progress counts unchanged; this is a fixture normalization follow-up after merged PR #814

## Follow-up
- No additional follow-up work identified