### PR TITLE
chore: remove unnecessary source spans from AST

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -158,8 +158,7 @@ typeDeclarationParser = do
       pure $
         DeclTypeSyn
           TypeSynDecl
-            { typeSynSpan = NoSourceSpan,
-              typeSynHeadForm = headForm,
+            { typeSynHeadForm = headForm,
               typeSynName = renderUnqualifiedName typeName,
               typeSynParams = typeParams,
               typeSynBody = body
@@ -176,8 +175,7 @@ roleAnnotationDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclRoleAnnotation
       RoleAnnotation
-        { roleAnnotationSpan = NoSourceSpan,
-          roleAnnotationName = typeName,
+        { roleAnnotationName = typeName,
           roleAnnotationRoles = roles
         }
 
@@ -252,8 +250,7 @@ typeFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclTypeFamilyDecl
       TypeFamilyDecl
-        { typeFamilyDeclSpan = NoSourceSpan,
-          typeFamilyDeclHeadForm = headForm,
+        { typeFamilyDeclHeadForm = headForm,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = params,
           typeFamilyDeclKind = kind,
@@ -297,8 +294,7 @@ dataFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclDataFamilyDecl
       DataFamilyDecl
-        { dataFamilyDeclSpan = NoSourceSpan,
-          dataFamilyDeclName = name,
+        { dataFamilyDeclName = name,
           dataFamilyDeclParams = params,
           dataFamilyDeclKind = kind
         }
@@ -386,23 +382,19 @@ newtypeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
 -- Callers must ensure the next token after @type@ is not @instance@
 -- (which is handled by 'classDefaultTypeInstParser' via token dispatch).
 classTypeFamilyDeclParser :: TokParser ClassDeclItem
-classTypeFamilyDeclParser = withSpan $ do
+classTypeFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   (headForm, headType, params) <- typeFamilyHeadParser
   kind <- familyResultKindParser
-  pure $ \span' ->
-    ClassItemAnn
-      (mkAnnotation span')
-      ( ClassItemTypeFamilyDecl
-          TypeFamilyDecl
-            { typeFamilyDeclSpan = span',
-              typeFamilyDeclHeadForm = headForm,
-              typeFamilyDeclHead = headType,
-              typeFamilyDeclParams = params,
-              typeFamilyDeclKind = kind,
-              typeFamilyDeclEquations = Nothing
-            }
-      )
+  pure $
+    ClassItemTypeFamilyDecl
+      TypeFamilyDecl
+        { typeFamilyDeclHeadForm = headForm,
+          typeFamilyDeclHead = headType,
+          typeFamilyDeclParams = params,
+          typeFamilyDeclKind = kind,
+          typeFamilyDeclEquations = Nothing
+        }
 
 -- | Parse @data Name params [:: Kind]@ as an associated data family in a class.
 classDataFamilyDeclParser :: TokParser ClassDeclItem
@@ -414,8 +406,7 @@ classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   pure
     ( ClassItemDataFamilyDecl
         DataFamilyDecl
-          { dataFamilyDeclSpan = NoSourceSpan,
-            dataFamilyDeclName = name,
+          { dataFamilyDeclName = name,
             dataFamilyDeclParams = params,
             dataFamilyDeclKind = kind
           }
@@ -604,8 +595,7 @@ classDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclClass
       ClassDecl
-        { classDeclSpan = NoSourceSpan,
-          classDeclContext = context,
+        { classDeclContext = context,
           classDeclHeadForm = headForm,
           classDeclName = className,
           classDeclParams = classParams,
@@ -705,8 +695,7 @@ instanceDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclInstance
       InstanceDecl
-        { instanceDeclSpan = NoSourceSpan,
-          instanceDeclOverlapPragma = overlapPragma,
+        { instanceDeclOverlapPragma = overlapPragma,
           instanceDeclWarning = warningText,
           instanceDeclForall = fromMaybe [] forallBinders,
           instanceDeclContext = fromMaybe [] context,
@@ -731,8 +720,7 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclStandaloneDeriving
       StandaloneDerivingDecl
-        { standaloneDerivingSpan = NoSourceSpan,
-          standaloneDerivingStrategy = strategy,
+        { standaloneDerivingStrategy = strategy,
           standaloneDerivingViaType = viaTy,
           standaloneDerivingOverlapPragma = overlapPragma,
           standaloneDerivingWarning = warningText,
@@ -836,8 +824,7 @@ foreignDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclForeign
       ForeignDecl
-        { foreignDeclSpan = NoSourceSpan,
-          foreignDirection = direction,
+        { foreignDirection = direction,
           foreignCallConv = callConv,
           foreignSafety = safety,
           foreignEntity = fromMaybe ForeignEntityOmitted entity,
@@ -887,8 +874,7 @@ dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclData
       DataDecl
-        { dataDeclSpan = NoSourceSpan,
-          dataDeclHeadForm = headForm,
+        { dataDeclHeadForm = headForm,
           dataDeclContext = fromMaybe [] context,
           dataDeclName = typeName,
           dataDeclParams = typeParams,
@@ -927,8 +913,7 @@ typeDataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclTypeData
       DataDecl
-        { dataDeclSpan = NoSourceSpan,
-          dataDeclHeadForm = headForm,
+        { dataDeclHeadForm = headForm,
           dataDeclContext = [],
           dataDeclName = typeName,
           dataDeclParams = typeParams,
@@ -1006,7 +991,7 @@ dataConDeclParser = withSpan $ do
   MP.try (dataConRecordOrPrefixParser forallVars context) <|> dataConInfixParser forallVars context
 
 newtypeDeclParser :: TokParser Decl
-newtypeDeclParser = withSpan $ do
+newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
   context <- contextPrefixDispatch
   (headForm, typeName, typeParams) <- typeDeclHeadParser
@@ -1014,11 +999,10 @@ newtypeDeclParser = withSpan $ do
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
   (constructor, derivingClauses) <- gadtStyleNewtypeDecl <|> traditionalStyleNewtypeDecl
-  pure $ \span' ->
+  pure $
     DeclNewtype
       NewtypeDecl
-        { newtypeDeclSpan = span',
-          newtypeDeclHeadForm = headForm,
+        { newtypeDeclHeadForm = headForm,
           newtypeDeclContext = fromMaybe [] context,
           newtypeDeclName = typeName,
           newtypeDeclParams = typeParams,
@@ -1505,15 +1489,14 @@ patSynNameParser =
 -- | Parse a pattern synonym declaration.
 -- Handles prefix, infix, and record forms with all three directionalities.
 patternSynonymDeclParser :: TokParser Decl
-patternSynonymDeclParser = withSpan $ do
+patternSynonymDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordPattern
   (name, args) <- patSynLhsParser
   (dir, pat) <- patSynDirAndPatParser name
-  pure $ \span' ->
+  pure $
     DeclPatSyn
       PatSynDecl
-        { patSynDeclSpan = span',
-          patSynDeclName = name,
+        { patSynDeclName = name,
           patSynDeclArgs = args,
           patSynDeclPat = pat,
           patSynDeclDir = dir

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -995,16 +995,12 @@ data PatSynArgs
 
 -- | Pattern synonym declaration.
 data PatSynDecl = PatSynDecl
-  { patSynDeclSpan :: SourceSpan,
-    patSynDeclName :: UnqualifiedName,
+  { patSynDeclName :: UnqualifiedName,
     patSynDeclArgs :: PatSynArgs,
     patSynDeclPat :: Pattern,
     patSynDeclDir :: PatSynDir
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan PatSynDecl where
-  getSourceSpan = patSynDeclSpan
 
 data Rhs
   = UnguardedRhs SourceSpan Expr (Maybe [Decl])
@@ -1206,32 +1202,23 @@ data Role
   deriving (Data, Eq, Show, Generic, NFData)
 
 data RoleAnnotation = RoleAnnotation
-  { roleAnnotationSpan :: SourceSpan,
-    roleAnnotationName :: Text,
+  { roleAnnotationName :: Text,
     roleAnnotationRoles :: [Role]
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan RoleAnnotation where
-  getSourceSpan = roleAnnotationSpan
-
 data TypeSynDecl = TypeSynDecl
-  { typeSynSpan :: SourceSpan,
-    typeSynHeadForm :: TypeHeadForm,
+  { typeSynHeadForm :: TypeHeadForm,
     typeSynName :: Text,
     typeSynParams :: [TyVarBinder],
     typeSynBody :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan TypeSynDecl where
-  getSourceSpan = typeSynSpan
-
 -- | Open or closed type synonym family declaration.
 -- Used for top-level @type family F a@ and associated @type F a :: Kind@ in class bodies.
 data TypeFamilyDecl = TypeFamilyDecl
-  { typeFamilyDeclSpan :: SourceSpan,
-    typeFamilyDeclHeadForm :: TypeHeadForm,
+  { typeFamilyDeclHeadForm :: TypeHeadForm,
     -- | Family head type. For simple families like @type family F a@, this is @TCon "F"@.
     -- For infix families like @type family l `And` r@, this is the full infix type.
     typeFamilyDeclHead :: Type,
@@ -1242,9 +1229,6 @@ data TypeFamilyDecl = TypeFamilyDecl
     typeFamilyDeclEquations :: Maybe [TypeFamilyEq]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan TypeFamilyDecl where
-  getSourceSpan = typeFamilyDeclSpan
 
 -- | One equation in a closed type family: @[forall binders.] LhsType = RhsType@
 data TypeFamilyEq = TypeFamilyEq
@@ -1261,16 +1245,12 @@ instance HasSourceSpan TypeFamilyEq where
 
 -- | Data family declaration (standalone or associated in a class body).
 data DataFamilyDecl = DataFamilyDecl
-  { dataFamilyDeclSpan :: SourceSpan,
-    dataFamilyDeclName :: UnqualifiedName,
+  { dataFamilyDeclName :: UnqualifiedName,
     dataFamilyDeclParams :: [TyVarBinder],
     -- | Optional result kind annotation (@:: Kind@)
     dataFamilyDeclKind :: Maybe Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan DataFamilyDecl where
-  getSourceSpan = dataFamilyDeclSpan
 
 -- | Type family instance: @type [instance] [forall binders.] LhsType = RhsType@
 data TypeFamilyInst = TypeFamilyInst
@@ -1304,8 +1284,7 @@ instance HasSourceSpan DataFamilyInst where
   getSourceSpan = dataFamilyInstSpan
 
 data DataDecl = DataDecl
-  { dataDeclSpan :: SourceSpan,
-    dataDeclHeadForm :: TypeHeadForm,
+  { dataDeclHeadForm :: TypeHeadForm,
     dataDeclContext :: [Type],
     dataDeclName :: UnqualifiedName,
     dataDeclParams :: [TyVarBinder],
@@ -1316,12 +1295,8 @@ data DataDecl = DataDecl
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan DataDecl where
-  getSourceSpan = dataDeclSpan
-
 data NewtypeDecl = NewtypeDecl
-  { newtypeDeclSpan :: SourceSpan,
-    newtypeDeclHeadForm :: TypeHeadForm,
+  { newtypeDeclHeadForm :: TypeHeadForm,
     newtypeDeclContext :: [Type],
     newtypeDeclName :: UnqualifiedName,
     newtypeDeclParams :: [TyVarBinder],
@@ -1331,9 +1306,6 @@ data NewtypeDecl = NewtypeDecl
     newtypeDeclDeriving :: [DerivingClause]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan NewtypeDecl where
-  getSourceSpan = newtypeDeclSpan
 
 data DataConDecl
   = -- | Metadata for the whole constructor declaration (typically a 'SourceSpan' via 'mkAnnotation').
@@ -1417,8 +1389,7 @@ data DerivingStrategy
   deriving (Data, Eq, Show, Generic, NFData)
 
 data StandaloneDerivingDecl = StandaloneDerivingDecl
-  { standaloneDerivingSpan :: SourceSpan,
-    standaloneDerivingStrategy :: Maybe DerivingStrategy,
+  { standaloneDerivingStrategy :: Maybe DerivingStrategy,
     standaloneDerivingViaType :: Maybe Type,
     standaloneDerivingOverlapPragma :: Maybe InstanceOverlapPragma,
     standaloneDerivingWarning :: Maybe WarningText,
@@ -1431,12 +1402,8 @@ data StandaloneDerivingDecl = StandaloneDerivingDecl
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan StandaloneDerivingDecl where
-  getSourceSpan = standaloneDerivingSpan
-
 data ClassDecl = ClassDecl
-  { classDeclSpan :: SourceSpan,
-    classDeclContext :: Maybe [Type],
+  { classDeclContext :: Maybe [Type],
     classDeclHeadForm :: TypeHeadForm,
     classDeclName :: Text,
     classDeclParams :: [TyVarBinder],
@@ -1444,9 +1411,6 @@ data ClassDecl = ClassDecl
     classDeclItems :: [ClassDeclItem]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan ClassDecl where
-  getSourceSpan = classDeclSpan
 
 data FunctionalDependency = FunctionalDependency
   { functionalDependencySpan :: SourceSpan,
@@ -1484,8 +1448,7 @@ peelClassDeclItemAnn (ClassItemAnn _ inner) = peelClassDeclItemAnn inner
 peelClassDeclItemAnn item = item
 
 data InstanceDecl = InstanceDecl
-  { instanceDeclSpan :: SourceSpan,
-    instanceDeclOverlapPragma :: Maybe InstanceOverlapPragma,
+  { instanceDeclOverlapPragma :: Maybe InstanceOverlapPragma,
     instanceDeclWarning :: Maybe WarningText,
     instanceDeclForall :: [TyVarBinder],
     instanceDeclContext :: [Type],
@@ -1496,9 +1459,6 @@ data InstanceDecl = InstanceDecl
     instanceDeclItems :: [InstanceDeclItem]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan InstanceDecl where
-  getSourceSpan = instanceDeclSpan
 
 data InstanceOverlapPragma
   = Overlapping
@@ -1538,8 +1498,7 @@ data FixityAssoc
   deriving (Data, Eq, Show, Generic, NFData)
 
 data ForeignDecl = ForeignDecl
-  { foreignDeclSpan :: SourceSpan,
-    foreignDirection :: ForeignDirection,
+  { foreignDirection :: ForeignDirection,
     foreignCallConv :: CallConv,
     foreignSafety :: Maybe ForeignSafety,
     foreignEntity :: ForeignEntitySpec,
@@ -1547,9 +1506,6 @@ data ForeignDecl = ForeignDecl
     foreignType :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan ForeignDecl where
-  getSourceSpan = foreignDeclSpan
 
 data ForeignEntitySpec
   = ForeignEntityDynamic

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -186,13 +186,13 @@ genDeclRoleAnnotation = do
   name <- genConIdent
   n <- chooseInt (0, 3)
   roles <- vectorOf n (elements [RoleNominal, RoleRepresentational, RolePhantom, RoleInfer])
-  pure $ DeclRoleAnnotation (RoleAnnotation span0 name roles)
+  pure $ DeclRoleAnnotation (RoleAnnotation name roles)
 
 genDeclTypeSyn :: Gen Decl
 genDeclTypeSyn = do
   name <- genConIdent
   params <- genSimpleTyVarBinders
-  DeclTypeSyn . TypeSynDecl span0 TypeHeadPrefix name params <$> genSimpleType
+  DeclTypeSyn . TypeSynDecl TypeHeadPrefix name params <$> genSimpleType
 
 -- | Generate an infix type synonym, covering both symbolic operators
 -- (e.g. @type a :+: b = (a, b)@) and backtick-wrapped identifiers
@@ -204,7 +204,7 @@ genDeclTypeSynInfix = do
   rhsName <- genIdent
   let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
       rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
-  DeclTypeSyn . TypeSynDecl span0 TypeHeadInfix name [lhs, rhs] <$> genSimpleType
+  DeclTypeSyn . TypeSynDecl TypeHeadInfix name [lhs, rhs] <$> genSimpleType
 
 genDeclData :: Gen Decl
 genDeclData =
@@ -222,8 +222,7 @@ genDeclDataGadt = do
   pure $
     DeclData $
       DataDecl
-        { dataDeclSpan = span0,
-          dataDeclHeadForm = TypeHeadPrefix,
+        { dataDeclHeadForm = TypeHeadPrefix,
           dataDeclContext = [],
           dataDeclName = name,
           dataDeclParams = params,
@@ -250,8 +249,7 @@ genDeclDataInfix = do
   pure $
     DeclData $
       DataDecl
-        { dataDeclSpan = span0,
-          dataDeclHeadForm = TypeHeadInfix,
+        { dataDeclHeadForm = TypeHeadInfix,
           dataDeclContext = [],
           dataDeclName = name,
           dataDeclParams = [lhs, rhs] <> extraParams,
@@ -271,8 +269,7 @@ genDeclTypeDataPrefix = do
   pure $
     DeclTypeData $
       DataDecl
-        { dataDeclSpan = span0,
-          dataDeclHeadForm = TypeHeadPrefix,
+        { dataDeclHeadForm = TypeHeadPrefix,
           dataDeclContext = [],
           dataDeclName = name,
           dataDeclParams = params,
@@ -315,8 +312,7 @@ genSimpleDataDecl = do
   deriving' <- genDerivingClauses
   pure $
     DataDecl
-      { dataDeclSpan = span0,
-        dataDeclHeadForm = TypeHeadPrefix,
+      { dataDeclHeadForm = TypeHeadPrefix,
         dataDeclContext = [],
         dataDeclName = name,
         dataDeclParams = params,
@@ -523,8 +519,7 @@ genDeclNewtype = do
   pure $
     DeclNewtype $
       NewtypeDecl
-        { newtypeDeclSpan = span0,
-          newtypeDeclHeadForm = TypeHeadPrefix,
+        { newtypeDeclHeadForm = TypeHeadPrefix,
           newtypeDeclContext = [],
           newtypeDeclName = name,
           newtypeDeclParams = params,
@@ -565,8 +560,7 @@ genDeclClassPrefix = do
   pure $
     DeclClass $
       ClassDecl
-        { classDeclSpan = span0,
-          classDeclContext = ctx,
+        { classDeclContext = ctx,
           classDeclHeadForm = TypeHeadPrefix,
           classDeclName = name,
           classDeclParams = params,
@@ -607,8 +601,7 @@ genAssociatedTypeFamilyDecl classParams = do
   let headType = TCon (qualifyName Nothing (mkUnqualifiedName NameConId name)) Unpromoted
   pure $
     TypeFamilyDecl
-      { typeFamilyDeclSpan = span0,
-        typeFamilyDeclHeadForm = TypeHeadPrefix,
+      { typeFamilyDeclHeadForm = TypeHeadPrefix,
         typeFamilyDeclHead = headType,
         typeFamilyDeclParams = params,
         typeFamilyDeclKind = Nothing,
@@ -647,8 +640,7 @@ genDeclClassInfix = do
   pure $
     DeclClass $
       ClassDecl
-        { classDeclSpan = span0,
-          classDeclContext = ctx,
+        { classDeclContext = ctx,
           classDeclHeadForm = TypeHeadInfix,
           classDeclName = name,
           classDeclParams = params,
@@ -668,8 +660,7 @@ genDeclInstancePrefix = do
   pure $
     DeclInstance $
       InstanceDecl
-        { instanceDeclSpan = span0,
-          instanceDeclOverlapPragma = Nothing,
+        { instanceDeclOverlapPragma = Nothing,
           instanceDeclWarning = Nothing,
           instanceDeclForall = [],
           instanceDeclContext = ctx,
@@ -689,8 +680,7 @@ genDeclInstanceInfix = do
   pure $
     DeclInstance $
       InstanceDecl
-        { instanceDeclSpan = span0,
-          instanceDeclOverlapPragma = Nothing,
+        { instanceDeclOverlapPragma = Nothing,
           instanceDeclWarning = Nothing,
           instanceDeclForall = [],
           instanceDeclContext = ctx,
@@ -714,8 +704,7 @@ genDeclStandaloneDerivingPrefix = do
   pure $
     DeclStandaloneDeriving $
       StandaloneDerivingDecl
-        { standaloneDerivingSpan = span0,
-          standaloneDerivingStrategy = strategy,
+        { standaloneDerivingStrategy = strategy,
           standaloneDerivingViaType = Nothing,
           standaloneDerivingOverlapPragma = Nothing,
           standaloneDerivingWarning = Nothing,
@@ -737,8 +726,7 @@ genDeclStandaloneDerivingInfix = do
   pure $
     DeclStandaloneDeriving $
       StandaloneDerivingDecl
-        { standaloneDerivingSpan = span0,
-          standaloneDerivingStrategy = strategy,
+        { standaloneDerivingStrategy = strategy,
           standaloneDerivingViaType = Nothing,
           standaloneDerivingOverlapPragma = Nothing,
           standaloneDerivingWarning = Nothing,
@@ -802,8 +790,7 @@ genDeclForeign = do
   pure $
     DeclForeign $
       ForeignDecl
-        { foreignDeclSpan = span0,
-          foreignDirection = direction,
+        { foreignDirection = direction,
           foreignCallConv = callConv,
           foreignSafety = safety,
           foreignEntity = ForeignEntityOmitted,
@@ -819,8 +806,7 @@ genDeclTypeFamilyDecl = do
   pure $
     DeclTypeFamilyDecl $
       TypeFamilyDecl
-        { typeFamilyDeclSpan = span0,
-          typeFamilyDeclHeadForm = TypeHeadPrefix,
+        { typeFamilyDeclHeadForm = TypeHeadPrefix,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = params,
           typeFamilyDeclKind = Nothing,
@@ -844,8 +830,7 @@ genDeclTypeFamilyDeclInfix = do
   pure $
     DeclTypeFamilyDecl $
       TypeFamilyDecl
-        { typeFamilyDeclSpan = span0,
-          typeFamilyDeclHeadForm = TypeHeadInfix,
+        { typeFamilyDeclHeadForm = TypeHeadInfix,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = [lhs, rhs],
           typeFamilyDeclKind = Nothing,
@@ -859,8 +844,7 @@ genDeclDataFamilyDecl = do
   pure $
     DeclDataFamilyDecl $
       DataFamilyDecl
-        { dataFamilyDeclSpan = span0,
-          dataFamilyDeclName = name,
+        { dataFamilyDeclName = name,
           dataFamilyDeclParams = params,
           dataFamilyDeclKind = Nothing
         }
@@ -1021,7 +1005,7 @@ genDeclPatSyn = do
   let args = PatSynPrefixArgs [argName]
       pat = PCon conName [PVar (mkUnqualifiedName NameVarId argName)]
   dir <- elements [PatSynBidirectional, PatSynUnidirectional]
-  pure $ DeclPatSyn (PatSynDecl span0 synName args pat dir)
+  pure $ DeclPatSyn (PatSynDecl synName args pat dir)
 
 genDeclPatSynSig :: Gen Decl
 genDeclPatSynSig = do

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -165,7 +165,7 @@ normalizeDecl decl =
     DeclPatSynSig names ty -> DeclPatSynSig names (normalizeType ty)
     DeclStandaloneKindSig name kind -> DeclStandaloneKindSig name (normalizeType kind)
     DeclFixity assoc mNs prec ops -> DeclFixity assoc mNs prec ops
-    DeclRoleAnnotation ann -> DeclRoleAnnotation (normalizeRoleAnnotation ann)
+    DeclRoleAnnotation ann -> DeclRoleAnnotation ann
     DeclTypeSyn synDecl -> DeclTypeSyn (normalizeTypeSynDecl synDecl)
     DeclTypeData dataDecl -> DeclTypeData (normalizeDataDecl dataDecl)
     DeclData dataDecl -> DeclData (normalizeDataDecl dataDecl)
@@ -373,8 +373,7 @@ normalizeWarningText wt =
 normalizePatSynDecl :: PatSynDecl -> PatSynDecl
 normalizePatSynDecl ps =
   PatSynDecl
-    { patSynDeclSpan = span0,
-      patSynDeclName = patSynDeclName ps,
+    { patSynDeclName = patSynDeclName ps,
       patSynDeclArgs = patSynDeclArgs ps,
       patSynDeclPat = normalizePattern (patSynDeclPat ps),
       patSynDeclDir = normalizePatSynDir (patSynDeclDir ps)
@@ -387,14 +386,10 @@ normalizePatSynDir dir =
     PatSynBidirectional -> PatSynBidirectional
     PatSynExplicitBidirectional matches -> PatSynExplicitBidirectional (map normalizeMatch matches)
 
-normalizeRoleAnnotation :: RoleAnnotation -> RoleAnnotation
-normalizeRoleAnnotation ann = ann {roleAnnotationSpan = span0}
-
 normalizeTypeSynDecl :: TypeSynDecl -> TypeSynDecl
 normalizeTypeSynDecl decl =
   TypeSynDecl
-    { typeSynSpan = span0,
-      typeSynHeadForm = typeSynHeadForm decl,
+    { typeSynHeadForm = typeSynHeadForm decl,
       typeSynName = typeSynName decl,
       typeSynParams = map normalizeTyVarBinder (typeSynParams decl),
       typeSynBody = normalizeType (typeSynBody decl)
@@ -403,8 +398,7 @@ normalizeTypeSynDecl decl =
 normalizeDataDecl :: DataDecl -> DataDecl
 normalizeDataDecl decl =
   DataDecl
-    { dataDeclSpan = span0,
-      dataDeclHeadForm = dataDeclHeadForm decl,
+    { dataDeclHeadForm = dataDeclHeadForm decl,
       dataDeclContext = map normalizeType (dataDeclContext decl),
       dataDeclName = dataDeclName decl,
       dataDeclParams = map normalizeTyVarBinder (dataDeclParams decl),
@@ -416,8 +410,7 @@ normalizeDataDecl decl =
 normalizeNewtypeDecl :: NewtypeDecl -> NewtypeDecl
 normalizeNewtypeDecl decl =
   NewtypeDecl
-    { newtypeDeclSpan = span0,
-      newtypeDeclHeadForm = newtypeDeclHeadForm decl,
+    { newtypeDeclHeadForm = newtypeDeclHeadForm decl,
       newtypeDeclContext = map normalizeType (newtypeDeclContext decl),
       newtypeDeclName = newtypeDeclName decl,
       newtypeDeclParams = map normalizeTyVarBinder (newtypeDeclParams decl),
@@ -478,8 +471,7 @@ normalizeDerivingClause dc =
 normalizeClassDecl :: ClassDecl -> ClassDecl
 normalizeClassDecl decl =
   ClassDecl
-    { classDeclSpan = span0,
-      classDeclContext = fmap (map normalizeType) (classDeclContext decl),
+    { classDeclContext = fmap (map normalizeType) (classDeclContext decl),
       classDeclHeadForm = classDeclHeadForm decl,
       classDeclName = classDeclName decl,
       classDeclParams = map normalizeTyVarBinder (classDeclParams decl),
@@ -506,8 +498,7 @@ normalizeClassDeclItem item =
 normalizeInstanceDecl :: InstanceDecl -> InstanceDecl
 normalizeInstanceDecl decl =
   InstanceDecl
-    { instanceDeclSpan = span0,
-      instanceDeclOverlapPragma = instanceDeclOverlapPragma decl,
+    { instanceDeclOverlapPragma = instanceDeclOverlapPragma decl,
       instanceDeclWarning = fmap normalizeWarningText (instanceDeclWarning decl),
       instanceDeclForall = map normalizeTyVarBinder (instanceDeclForall decl),
       instanceDeclContext = map normalizeType (instanceDeclContext decl),
@@ -534,8 +525,7 @@ normalizeInstanceDeclItemInner (InstanceItemPragma pragma) = InstanceItemPragma 
 normalizeStandaloneDerivingDecl :: StandaloneDerivingDecl -> StandaloneDerivingDecl
 normalizeStandaloneDerivingDecl decl =
   StandaloneDerivingDecl
-    { standaloneDerivingSpan = span0,
-      standaloneDerivingStrategy = standaloneDerivingStrategy decl,
+    { standaloneDerivingStrategy = standaloneDerivingStrategy decl,
       standaloneDerivingViaType = fmap normalizeType (standaloneDerivingViaType decl),
       standaloneDerivingOverlapPragma = standaloneDerivingOverlapPragma decl,
       standaloneDerivingWarning = fmap normalizeWarningText (standaloneDerivingWarning decl),
@@ -550,8 +540,7 @@ normalizeStandaloneDerivingDecl decl =
 normalizeForeignDecl :: ForeignDecl -> ForeignDecl
 normalizeForeignDecl decl =
   ForeignDecl
-    { foreignDeclSpan = span0,
-      foreignDirection = foreignDirection decl,
+    { foreignDirection = foreignDirection decl,
       foreignCallConv = foreignCallConv decl,
       foreignSafety = foreignSafety decl,
       foreignEntity = foreignEntity decl,
@@ -562,8 +551,7 @@ normalizeForeignDecl decl =
 normalizeTypeFamilyDecl :: TypeFamilyDecl -> TypeFamilyDecl
 normalizeTypeFamilyDecl tf =
   TypeFamilyDecl
-    { typeFamilyDeclSpan = span0,
-      typeFamilyDeclHeadForm = typeFamilyDeclHeadForm tf,
+    { typeFamilyDeclHeadForm = typeFamilyDeclHeadForm tf,
       typeFamilyDeclHead = normalizeType (typeFamilyDeclHead tf),
       typeFamilyDeclParams = map normalizeTyVarBinder (typeFamilyDeclParams tf),
       typeFamilyDeclKind = fmap normalizeType (typeFamilyDeclKind tf),
@@ -583,8 +571,7 @@ normalizeTypeFamilyEq eq =
 normalizeDataFamilyDecl :: DataFamilyDecl -> DataFamilyDecl
 normalizeDataFamilyDecl df =
   DataFamilyDecl
-    { dataFamilyDeclSpan = span0,
-      dataFamilyDeclName = dataFamilyDeclName df,
+    { dataFamilyDeclName = dataFamilyDeclName df,
       dataFamilyDeclParams = map normalizeTyVarBinder (dataFamilyDeclParams df),
       dataFamilyDeclKind = fmap normalizeType (dataFamilyDeclKind df)
     }

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -649,7 +649,7 @@ topLevelDeclAnnotations decl scope =
     (declSpan, DeclTypeData dataDecl) -> dataDeclAnnotations declSpan "type data " dataDecl
     (declSpan, DeclData dataDecl) -> dataDeclAnnotations declSpan "data " dataDecl
     (declSpan, DeclNewtype newtypeDecl) ->
-      let span' = effectiveResolutionSpan declSpan (newtypeDeclSpan newtypeDecl)
+      let span' = declSpan
           typeAnnotation =
             ResolutionAnnotation
               (declKeywordNameSpan "newtype " span' (renderUnqualifiedName (newtypeDeclName newtypeDecl)))
@@ -662,7 +662,7 @@ topLevelDeclAnnotations decl scope =
     _ -> []
   where
     dataDeclAnnotations declSpan keyword dataDecl =
-      let span' = effectiveResolutionSpan declSpan (dataDeclSpan dataDecl)
+      let span' = declSpan
           typeAnnotation =
             ResolutionAnnotation
               (declKeywordNameSpan keyword span' (renderUnqualifiedName (dataDeclName dataDecl)))
@@ -674,7 +674,7 @@ topLevelDeclAnnotations decl scope =
 classAnnotation :: Scope -> SourceSpan -> ClassDecl -> ResolutionAnnotation
 classAnnotation scope declSpan classDecl =
   let className = mkUnqualifiedName NameConId (classDeclName classDecl)
-      span' = effectiveResolutionSpan declSpan (classDeclSpan classDecl)
+      span' = declSpan
    in ResolutionAnnotation
         (declKeywordNameSpan "class " span' (classDeclName classDecl))
         (classDeclName classDecl)


### PR DESCRIPTION
This change trims redundant source span fields from the parser AST so less location metadata is carried where it is not needed.

Parser construction (`Internal/Decl`, `Syntax`), QuickCheck generators (`Arb/Decl`, `ExprHelpers`), and resolve (`Resolve`) were updated to match the slimmer shapes.

Local verification: `just fmt` and `just check`.
