### PR TITLE
refactor: sync downstream with ValueDecl and annotation AST

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -166,7 +166,7 @@ parseModule cfg input =
         Left bundle ->
           ( parseErrorsToSpannedText (NE.toList (MPE.bundleErrors bundle)),
             Module
-              { moduleSpan = NoSourceSpan,
+              { moduleAnns = [],
                 moduleHead = Nothing,
                 moduleLanguagePragmas = [],
                 moduleImports = [],

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -113,7 +113,7 @@ cmdCaseAltParser = withSpan $ do
   pat <- patternParser
   expectedTok TkReservedRightArrow
   body <- cmdParser
-  pure (\span' -> CmdCaseAlt span' pat body)
+  pure (\span' -> CmdCaseAlt [mkAnnotation span'] pat body)
 
 -- | Parse a command let: @let decls in cmd@
 cmdLetParser :: TokParser Cmd

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -44,7 +44,7 @@ cmdParser = do
       mArrowTail <- MP.optional cmdArrTailParser
       case mArrowTail of
         Just (appType, rhs) ->
-          let span' = mergeSourceSpans (getSourceSpan expr) (getSourceSpan rhs)
+          let span' = mergeSourceSpans (getExprSourceSpan expr) (getExprSourceSpan rhs)
            in cmdInfixChain (CmdAnn (mkAnnotation span') (CmdArrApp expr appType rhs))
         Nothing ->
           fail "expected arrow command (-< or -<<)"
@@ -79,7 +79,7 @@ cmdInfixChain lhs = do
   pure (foldl buildCmdInfix lhs rest)
   where
     buildCmdInfix l (op, r) =
-      CmdAnn (mkAnnotation (mergeSourceSpans (getSourceSpan l) (getSourceSpan r))) (CmdInfix l op r)
+      CmdAnn (mkAnnotation (mergeSourceSpans (getCmdSourceSpan l) (getCmdSourceSpan r))) (CmdInfix l op r)
 
 -- | Parse a command do-block: @do { cstmt ; ... }@
 cmdDoParser :: TokParser Cmd

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -640,10 +640,9 @@ functionBinderNameParser =
 functionBindValue :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs -> ValueDecl
 functionBindValue headForm name pats rhs =
   FunctionBind
-    NoSourceSpan
     name
     [ Match
-        { matchSpan = NoSourceSpan,
+        { matchAnns = [],
           matchHeadForm = headForm,
           matchPats = pats,
           matchRhs = rhs

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -535,9 +535,9 @@ contextItemParserWith typeParser typeAtomParser =
       rest <- MP.many typeAtomParser
       pure (foldl buildTypeApp first rest)
     buildTypeApp lhs rhs =
-      typeAnnSpan (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)) (TApp lhs rhs)
+      typeAnnSpan (mergeSourceSpans (getTypeSourceSpan lhs) (getTypeSourceSpan rhs)) (TApp lhs rhs)
     -- \| Parse a type expression that can appear as a kind annotation.
-    -- Handles function types (e.g., Type -> Constraint) and type applications,
+    -- Handles function types (e.g., Type -> Constraint) and type application,
     -- but NOT context types (C a => ...) to avoid parsing cycles.
     kindTypeParser = do
       first <- constraintTypeAppParser
@@ -548,12 +548,12 @@ contextItemParserWith typeParser typeAtomParser =
         Just rhs ->
           pure
             ( typeAnnSpan
-                (mergeSourceSpans (getSourceSpan baseType) (getSourceSpan rhs))
+                (mergeSourceSpans (getTypeSourceSpan baseType) (getTypeSourceSpan rhs))
                 (TFun baseType rhs)
             )
         Nothing -> pure baseType
     buildInfixType lhs ((op, promoted), rhs) =
-      let span' = mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)
+      let span' = mergeSourceSpans (getTypeSourceSpan lhs) (getTypeSourceSpan rhs)
           opType = typeAnnSpan span' (TCon op promoted)
        in typeAnnSpan span' (TApp (typeAnnSpan span' (TApp opType lhs)) rhs)
     constraintTypeInfixOperatorParser =
@@ -587,7 +587,7 @@ contextItemsParserWith typeParser typeAtomParser =
       -- correctly, where () ~ () is a single type-equality constraint.
       case items of
         [] -> fail "empty constraint list in parens"
-        [item] -> pure [typeAnnSpan (getSourceSpan item) (TParen item)]
+        [item] -> pure [typeAnnSpan (getTypeSourceSpan item) (TParen item)]
         _ -> pure items
 
 contextParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -109,7 +109,7 @@ nonBareVarPatternBindDeclParser = MP.try $ withSpanAnn (DeclAnn . mkAnnotation) 
   case pat of
     PVar {} -> fail "bare variable bindings are parsed as function declarations"
     _ -> do
-      DeclValue . PatternBind NoSourceSpan pat <$> equationRhsParser
+      DeclValue . PatternBind pat <$> equationRhsParser
 
 -- | Parse a pragma declaration (e.g. {-# INLINE f #-}, {-# SPECIALIZE ... #-})
 pragmaDeclParser :: TokParser Decl
@@ -266,14 +266,14 @@ closedTypeFamilyWhereParser =
 
 -- | Parse one closed type family equation: @[forall binders.] LhsType = RhsType@
 typeFamilyEqParser :: TokParser TypeFamilyEq
-typeFamilyEqParser = withSpan $ do
+typeFamilyEqParser = do
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
   rhs <- typeParser
-  pure $ \span' ->
+  pure
     TypeFamilyEq
-      { typeFamilyEqSpan = span',
+      { typeFamilyEqAnns = [],
         typeFamilyEqForall = forallBinders,
         typeFamilyEqHeadForm = headForm,
         typeFamilyEqLhs = lhs,
@@ -314,8 +314,7 @@ typeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclTypeFamilyInst
       TypeFamilyInst
-        { typeFamilyInstSpan = NoSourceSpan,
-          typeFamilyInstForall = forallBinders,
+        { typeFamilyInstForall = forallBinders,
           typeFamilyInstHeadForm = headForm,
           typeFamilyInstLhs = lhs,
           typeFamilyInstRhs = rhs
@@ -333,8 +332,7 @@ dataFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclDataFamilyInst
       DataFamilyInst
-        { dataFamilyInstSpan = NoSourceSpan,
-          dataFamilyInstIsNewtype = False,
+        { dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = forallBinders,
           dataFamilyInstHead = head',
           dataFamilyInstKind = kind,
@@ -365,8 +363,7 @@ newtypeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclDataFamilyInst
       DataFamilyInst
-        { dataFamilyInstSpan = NoSourceSpan,
-          dataFamilyInstIsNewtype = True,
+        { dataFamilyInstIsNewtype = True,
           dataFamilyInstForall = forallBinders,
           dataFamilyInstHead = head',
           dataFamilyInstKind = kind,
@@ -424,8 +421,7 @@ classDefaultTypeInstParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   pure
     ( ClassItemDefaultTypeInst
         TypeFamilyInst
-          { typeFamilyInstSpan = NoSourceSpan,
-            typeFamilyInstForall = forallBinders,
+          { typeFamilyInstForall = forallBinders,
             typeFamilyInstHeadForm = headForm,
             typeFamilyInstLhs = lhs,
             typeFamilyInstRhs = rhs
@@ -444,8 +440,7 @@ classDefaultTypeInstShorthandParser = withSpanAnn (ClassItemAnn . mkAnnotation) 
   pure
     ( ClassItemDefaultTypeInst
         TypeFamilyInst
-          { typeFamilyInstSpan = NoSourceSpan,
-            typeFamilyInstForall = forallBinders,
+          { typeFamilyInstForall = forallBinders,
             typeFamilyInstHeadForm = headForm,
             typeFamilyInstLhs = lhs,
             typeFamilyInstRhs = rhs
@@ -466,8 +461,7 @@ instanceTypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   pure $
     InstanceItemTypeFamilyInst
       TypeFamilyInst
-        { typeFamilyInstSpan = NoSourceSpan,
-          typeFamilyInstForall = forallBinders,
+        { typeFamilyInstForall = forallBinders,
           typeFamilyInstHeadForm = headForm,
           typeFamilyInstLhs = lhs,
           typeFamilyInstRhs = rhs
@@ -483,8 +477,7 @@ instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   pure $
     InstanceItemDataFamilyInst
       DataFamilyInst
-        { dataFamilyInstSpan = NoSourceSpan,
-          dataFamilyInstIsNewtype = False,
+        { dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
           dataFamilyInstKind = kind,
@@ -513,8 +506,7 @@ instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $
   pure $
     InstanceItemDataFamilyInst
       DataFamilyInst
-        { dataFamilyInstSpan = NoSourceSpan,
-          dataFamilyInstIsNewtype = True,
+        { dataFamilyInstIsNewtype = True,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
           dataFamilyInstKind = kind,
@@ -609,13 +601,13 @@ classFundepsParser = do
   classFundepParser `MP.sepBy1` expectedTok TkSpecialComma
 
 classFundepParser :: TokParser FunctionalDependency
-classFundepParser = withSpan $ do
+classFundepParser = do
   determinedBy <- MP.many lowerIdentifierParser
   expectedTok TkReservedRightArrow
   determines <- MP.many lowerIdentifierParser
-  pure $ \span' ->
+  pure
     FunctionalDependency
-      { functionalDependencySpan = span',
+      { functionalDependencyAnns = [],
         functionalDependencyDeterminers = determinedBy,
         functionalDependencyDetermined = determines
       }
@@ -937,7 +929,7 @@ typeDataConDeclParser = withSpan $ do
   -- Parse arguments (no strictness, no records)
   -- Use typeAtomParser to parse individual type atoms as separate fields,
   -- rather than typeAppParser which would treat them as type application.
-  args <- MP.many $ BangType noSourceSpan NoSourceUnpackedness False False <$> typeAtomParser
+  args <- MP.many $ BangType [] NoSourceUnpackedness False False <$> typeAtomParser
   pure $ \span' -> DataConAnn (mkAnnotation span') (PrefixCon [] context conName args)
 
 -- | Parse GADT-style constructors for type data (after `where`)
@@ -981,7 +973,7 @@ gadtTypeDataBodyParser = do
   case allTypes of
     [resultTy] -> pure (GadtPrefixBody [] resultTy)
     _ ->
-      let argTypes = map (BangType noSourceSpan NoSourceUnpackedness False False) (init allTypes)
+      let argTypes = map (BangType [] NoSourceUnpackedness False False) (init allTypes)
           resultTy = last allTypes
        in pure (GadtPrefixBody argTypes resultTy)
 
@@ -1110,14 +1102,14 @@ gadtPrefixBodyParser = do
 -- Uses 'typeInfixParser' so that infix type operators (e.g. @key := v@) are
 -- accepted as argument types without requiring parentheses.
 gadtBangTypeParser :: TokParser BangType
-gadtBangTypeParser = withSpan $ do
+gadtBangTypeParser = do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- typeInfixParser
-  pure $ \span' ->
+  pure
     BangType
-      { bangSpan = span',
+      { bangAnns = [],
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
         bangLazy = lazy,
@@ -1184,9 +1176,9 @@ typeFamilyHeadParser =
       op <- typeFamilyOperatorParser
       rhs <- typeParamParser
       let lhsType =
-            typeAnnSpan (tyVarBinderSpan lhs) (TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs)))
+            TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
           rhsType =
-            typeAnnSpan (tyVarBinderSpan rhs) (TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs)))
+            TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs))
       headType <- withSpan $ do
         pure $ \span' ->
           typeAnnSpan
@@ -1261,7 +1253,7 @@ typeParamParser =
                 | isTypeVarName name ->
                     Just name
               _ -> Nothing
-        pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified)
+        pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified)
     )
       <|> ( do
               expectedTok TkSpecialLParen
@@ -1269,7 +1261,7 @@ typeParamParser =
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified)
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified)
           )
 
 isTypeVarName :: Text -> Bool
@@ -1350,13 +1342,13 @@ recordFieldsParser :: TokParser [FieldDecl]
 recordFieldsParser = braces (recordFieldDeclParser `MP.sepEndBy` expectedTok TkSpecialComma)
 
 recordFieldDeclParser :: TokParser FieldDecl
-recordFieldDeclParser = withSpan $ do
+recordFieldDeclParser = do
   names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   fieldTy <- recordFieldBangTypeParser
-  pure $ \span' ->
+  pure
     FieldDecl
-      { fieldSpan = span',
+      { fieldAnns = [],
         fieldNames = names,
         fieldType = fieldTy
       }
@@ -1369,19 +1361,18 @@ constructorArgParser = MP.try $ do
 infixConstructorArgParser :: TokParser BangType
 infixConstructorArgParser = MP.try $ do
   MP.notFollowedBy derivingKeywordParser
-  withSpan $ do
-    unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
-    strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
-    lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
-    ty <- typeAppParser
-    pure $ \span' ->
-      BangType
-        { bangSpan = span',
-          bangSourceUnpackedness = unpackedness,
-          bangStrict = strict,
-          bangLazy = lazy,
-          bangType = ty
-        }
+  unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
+  strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+  lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
+  ty <- typeAppParser
+  pure
+    BangType
+      { bangAnns = [],
+        bangSourceUnpackedness = unpackedness,
+        bangStrict = strict,
+        bangLazy = lazy,
+        bangType = ty
+      }
 
 derivingKeywordParser :: TokParser ()
 derivingKeywordParser =
@@ -1391,14 +1382,14 @@ derivingKeywordParser =
       _ -> Nothing
 
 bangTypeParser :: TokParser BangType
-bangTypeParser = withSpan $ do
+bangTypeParser = do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- typeAtomParser
-  pure $ \span' ->
+  pure
     BangType
-      { bangSpan = span',
+      { bangAnns = [],
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
         bangLazy = lazy,
@@ -1406,14 +1397,14 @@ bangTypeParser = withSpan $ do
       }
 
 recordFieldBangTypeParser :: TokParser BangType
-recordFieldBangTypeParser = withSpan $ do
+recordFieldBangTypeParser = do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- constructorFieldTypeParser
-  pure $ \span' ->
+  pure
     BangType
-      { bangSpan = span',
+      { bangAnns = [],
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
         bangLazy = lazy,
@@ -1454,7 +1445,7 @@ constructorOperatorParser =
 patternBindDeclParser :: TokParser Decl
 patternBindDeclParser = MP.try $ withSpanAnn (DeclAnn . mkAnnotation) $ do
   pat <- region "while parsing pattern binding" patternParser
-  DeclValue . PatternBind NoSourceSpan pat <$> equationRhsParser
+  DeclValue . PatternBind pat <$> equationRhsParser
 
 valueDeclParser :: TokParser Decl
 valueDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
@@ -1566,7 +1557,7 @@ patSynWhereMatch = withSpan $ do
   rhs <- equationRhsParser
   pure $ \span' ->
     Match
-      { matchSpan = span',
+      { matchAnns = [mkAnnotation span'],
         matchHeadForm = headForm,
         matchPats = pats,
         matchRhs = rhs

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1223,7 +1223,7 @@ typeFamilyLhsParser = do
       pure (op, rhs)
 
     buildInfixType left ((op, promoted), right) =
-      let span' = mergeSourceSpans (getSourceSpan left) (getSourceSpan right)
+      let span' = mergeSourceSpans (getTypeSourceSpan left) (getTypeSourceSpan right)
           opType = typeAnnSpan span' (TCon op promoted)
        in typeAnnSpan span' (TApp (typeAnnSpan span' (TApp opType left)) right)
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -266,14 +266,14 @@ closedTypeFamilyWhereParser =
 
 -- | Parse one closed type family equation: @[forall binders.] LhsType = RhsType@
 typeFamilyEqParser :: TokParser TypeFamilyEq
-typeFamilyEqParser = do
+typeFamilyEqParser = withSpan $ do
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
   rhs <- typeParser
-  pure
+  pure $ \span' ->
     TypeFamilyEq
-      { typeFamilyEqAnns = [],
+      { typeFamilyEqAnns = [mkAnnotation span'],
         typeFamilyEqForall = forallBinders,
         typeFamilyEqHeadForm = headForm,
         typeFamilyEqLhs = lhs,
@@ -601,13 +601,13 @@ classFundepsParser = do
   classFundepParser `MP.sepBy1` expectedTok TkSpecialComma
 
 classFundepParser :: TokParser FunctionalDependency
-classFundepParser = do
+classFundepParser = withSpan $ do
   determinedBy <- MP.many lowerIdentifierParser
   expectedTok TkReservedRightArrow
   determines <- MP.many lowerIdentifierParser
-  pure
+  pure $ \span' ->
     FunctionalDependency
-      { functionalDependencyAnns = [],
+      { functionalDependencyAnns = [mkAnnotation span'],
         functionalDependencyDeterminers = determinedBy,
         functionalDependencyDetermined = determines
       }
@@ -1102,14 +1102,14 @@ gadtPrefixBodyParser = do
 -- Uses 'typeInfixParser' so that infix type operators (e.g. @key := v@) are
 -- accepted as argument types without requiring parentheses.
 gadtBangTypeParser :: TokParser BangType
-gadtBangTypeParser = do
+gadtBangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- typeInfixParser
-  pure
+  pure $ \span' ->
     BangType
-      { bangAnns = [],
+      { bangAnns = [mkAnnotation span'],
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
         bangLazy = lazy,
@@ -1342,13 +1342,13 @@ recordFieldsParser :: TokParser [FieldDecl]
 recordFieldsParser = braces (recordFieldDeclParser `MP.sepEndBy` expectedTok TkSpecialComma)
 
 recordFieldDeclParser :: TokParser FieldDecl
-recordFieldDeclParser = do
+recordFieldDeclParser = withSpan $ do
   names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   fieldTy <- recordFieldBangTypeParser
-  pure
+  pure $ \span' ->
     FieldDecl
-      { fieldAnns = [],
+      { fieldAnns = [mkAnnotation span'],
         fieldNames = names,
         fieldType = fieldTy
       }
@@ -1361,18 +1361,19 @@ constructorArgParser = MP.try $ do
 infixConstructorArgParser :: TokParser BangType
 infixConstructorArgParser = MP.try $ do
   MP.notFollowedBy derivingKeywordParser
-  unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
-  strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
-  lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
-  ty <- typeAppParser
-  pure
-    BangType
-      { bangAnns = [],
-        bangSourceUnpackedness = unpackedness,
-        bangStrict = strict,
-        bangLazy = lazy,
-        bangType = ty
-      }
+  withSpan $ do
+    unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
+    strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
+    lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
+    ty <- typeAppParser
+    pure $ \span' ->
+      BangType
+        { bangAnns = [mkAnnotation span'],
+          bangSourceUnpackedness = unpackedness,
+          bangStrict = strict,
+          bangLazy = lazy,
+          bangType = ty
+        }
 
 derivingKeywordParser :: TokParser ()
 derivingKeywordParser =
@@ -1382,14 +1383,14 @@ derivingKeywordParser =
       _ -> Nothing
 
 bangTypeParser :: TokParser BangType
-bangTypeParser = do
+bangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- typeAtomParser
-  pure
+  pure $ \span' ->
     BangType
-      { bangAnns = [],
+      { bangAnns = [mkAnnotation span'],
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
         bangLazy = lazy,
@@ -1397,14 +1398,14 @@ bangTypeParser = do
       }
 
 recordFieldBangTypeParser :: TokParser BangType
-recordFieldBangTypeParser = do
+recordFieldBangTypeParser = withSpan $ do
   unpackedness <- MP.option NoSourceUnpackedness sourceUnpackednessPragmaParser
   strict <- MP.option False (expectedTok TkPrefixBang >> pure True)
   lazy <- MP.option False (expectedTok TkPrefixTilde >> pure True)
   ty <- constructorFieldTypeParser
-  pure
+  pure $ \span' ->
     BangType
-      { bangAnns = [],
+      { bangAnns = [mkAnnotation span'],
         bangSourceUnpackedness = unpackedness,
         bangStrict = strict,
         bangLazy = lazy,

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -75,7 +75,7 @@ exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
   pure $ case afterArrow of
     Just (op, rhs) ->
       EAnn
-        (mkAnnotation (mergeSourceSpans (getSourceSpan withInfix) (getSourceSpan rhs)))
+        (mkAnnotation (mergeSourceSpans (getExprSourceSpan withInfix) (getExprSourceSpan rhs)))
         (EInfix withInfix op rhs)
     Nothing -> withInfix
 
@@ -85,7 +85,7 @@ exprCoreParserWithTypeSigParserExcept typeSigParser forbiddenInfix = do
   -- Optional type signature: expr :: type
   mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeSigParser)
   pure $ case mTypeSig of
-    Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty))) (ETypeSig withArrow ty)
+    Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan withArrow) (getTypeSourceSpan ty))) (ETypeSig withArrow ty)
     Nothing -> withArrow
 
 -- | The operator name used to represent @->@ in view-pattern expressions.
@@ -101,7 +101,7 @@ maybeViewPattern lhs = do
   case mArrow of
     Just () -> do
       viewRhs <- texprParser
-      let sp = mergeSourceSpans (getSourceSpan lhs) (getSourceSpan viewRhs)
+      let sp = mergeSourceSpans (getExprSourceSpan lhs) (getExprSourceSpan viewRhs)
       pure (EAnn (mkAnnotation sp) (EInfix lhs viewPatArrowName viewRhs))
     Nothing -> pure lhs
 
@@ -204,7 +204,7 @@ exprCoreParserNoArrowTail = do
   -- Optional type signature: expr :: type
   mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   pure $ case mTypeSig of
-    Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan base) (getSourceSpan ty))) (ETypeSig base ty)
+    Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan base) (getTypeSourceSpan ty))) (ETypeSig base ty)
     Nothing -> base
 
 doStmtParser :: TokParser (DoStmt Expr)
@@ -309,7 +309,7 @@ lexpParser =
 
 buildInfix :: Expr -> (Name, Expr) -> Expr
 buildInfix lhs (op, rhs) =
-  EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs))) (EInfix lhs op rhs)
+  EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan lhs) (getExprSourceSpan rhs))) (EInfix lhs op rhs)
 
 intExprParser :: TokParser Expr
 intExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
@@ -401,9 +401,9 @@ atomOrRecordExprParser = do
           let result = case peelExprAnn e of
                 EVar name
                   | isConLikeName name ->
-                      EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan e) (fieldsEndSpan fields))) (ERecordCon (renderName name) (map normalizeField fields) hasWildcard)
+                      EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan e) (fieldsEndSpan fields))) (ERecordCon (renderName name) (map normalizeField fields) hasWildcard)
                 _ ->
-                  EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan e) (fieldsEndSpan fields))) (ERecordUpd e (map normalizeField fields))
+                  EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan e) (fieldsEndSpan fields))) (ERecordUpd e (map normalizeField fields))
           applyRecordSuffixes result
 
     fieldsEndSpan :: [(Text, Maybe Expr, SourceSpan)] -> SourceSpan
@@ -710,11 +710,11 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                     Nothing -> do
                       mArrow <- MP.optional arrowTailParser
                       let withArrow = case mArrow of
-                            Just (arrowOp, arrowRhs) -> EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan base) (getSourceSpan arrowRhs))) (EInfix base arrowOp arrowRhs)
+                            Just (arrowOp, arrowRhs) -> EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan base) (getExprSourceSpan arrowRhs))) (EInfix base arrowOp arrowRhs)
                             Nothing -> base
                       mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
                       let typed = case mTypeSig of
-                            Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty))) (ETypeSig withArrow ty)
+                            Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan withArrow) (getTypeSourceSpan ty))) (ETypeSig withArrow ty)
                             Nothing -> withArrow
                       -- View pattern arrow: expr -> expr (inside parentheses)
                       finalExpr <- maybeViewPattern typed
@@ -743,11 +743,11 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                         Nothing -> do
                           mArrow <- MP.optional arrowTailParser
                           let withArrow = case mArrow of
-                                Just (arrowOp, arrowRhs) -> EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan fullInfix) (getSourceSpan arrowRhs))) (EInfix fullInfix arrowOp arrowRhs)
+                                Just (arrowOp, arrowRhs) -> EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan fullInfix) (getExprSourceSpan arrowRhs))) (EInfix fullInfix arrowOp arrowRhs)
                                 Nothing -> fullInfix
                           mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
                           let typed = case mTypeSig of
-                                Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getSourceSpan withArrow) (getSourceSpan ty))) (ETypeSig withArrow ty)
+                                Just ty -> EAnn (mkAnnotation (mergeSourceSpans (getExprSourceSpan withArrow) (getTypeSourceSpan ty))) (ETypeSig withArrow ty)
                                 Nothing -> withArrow
                           -- View pattern arrow: expr -> expr (inside parentheses)
                           finalExpr <- maybeViewPattern typed
@@ -972,7 +972,7 @@ localTypeSigDeclsParser = do
         [name] -> do
           rhsExpr <- exprParser
           whereDecls <- MP.optional whereClauseParser
-          let bindSpan = mergeSourceSpans NoSourceSpan (getSourceSpan rhsExpr)
+          let bindSpan = mergeSourceSpans NoSourceSpan (getExprSourceSpan rhsExpr)
               bindAnns = [mkAnnotation bindSpan]
               pat = PAnn (mkAnnotation bindSpan) (PTypeSig (PAnn (mkAnnotation bindSpan) (PVar name)) ty)
               rhs = UnguardedRhs bindAnns rhsExpr whereDecls

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -156,7 +156,7 @@ multiWayIfAlternative = withSpan $ do
   body <- exprParser
   pure $ \span' ->
     GuardedRhs
-      { guardedRhsSpan = span',
+      { guardedRhsAnns = [mkAnnotation span'],
         guardedRhsGuards = guards,
         guardedRhsBody = body
       }
@@ -556,7 +556,7 @@ unguardedRhsParser arrowKind = withSpan $ do
   rhsArrowTok arrowKind
   body <- region (rhsContextText arrowKind) exprParser
   whereDecls <- MP.optional whereClauseParser
-  pure (\span' -> UnguardedRhs span' body whereDecls)
+  pure (\span' -> UnguardedRhs [mkAnnotation span'] body whereDecls)
 
 rhsContextText :: RhsArrowKind -> Text
 rhsContextText RhsArrowCase = "while parsing case alternative right-hand side"
@@ -566,7 +566,7 @@ guardedRhssParser :: RhsArrowKind -> TokParser Rhs
 guardedRhssParser arrowKind = withSpan $ do
   grhss <- MP.some (guardedRhsParser arrowKind)
   whereDecls <- MP.optional whereClauseParser
-  pure (\span' -> GuardedRhss span' grhss whereDecls)
+  pure (\span' -> GuardedRhss [mkAnnotation span'] grhss whereDecls)
 
 guardedRhsParser :: RhsArrowKind -> TokParser GuardedRhs
 guardedRhsParser arrowKind = withSpan $ do
@@ -576,7 +576,7 @@ guardedRhsParser arrowKind = withSpan $ do
   body <- exprParserExcept ["|", rhsArrowText arrowKind]
   pure $ \span' ->
     GuardedRhs
-      { guardedRhsSpan = span',
+      { guardedRhsAnns = [mkAnnotation span'],
         guardedRhsGuards = guards,
         guardedRhsBody = body
       }
@@ -637,7 +637,7 @@ caseAltParser = withSpan $ do
   rhs <- region "while parsing case alternative" rhsParser
   pure $ \span' ->
     CaseAlt
-      { caseAltSpan = span',
+      { caseAltAnns = [mkAnnotation span'],
         caseAltPattern = pat,
         caseAltRhs = rhs
       }
@@ -973,9 +973,10 @@ localTypeSigDeclsParser = do
           rhsExpr <- exprParser
           whereDecls <- MP.optional whereClauseParser
           let bindSpan = mergeSourceSpans NoSourceSpan (getSourceSpan rhsExpr)
+              bindAnns = [mkAnnotation bindSpan]
               pat = PAnn (mkAnnotation bindSpan) (PTypeSig (PAnn (mkAnnotation bindSpan) (PVar name)) ty)
-              rhs = UnguardedRhs bindSpan rhsExpr whereDecls
-          pure [DeclValue (PatternBind bindSpan pat rhs)]
+              rhs = UnguardedRhs bindAnns rhsExpr whereDecls
+          pure [DeclValue (PatternBind pat rhs)]
         _ ->
           fail "local typed bindings with '=' require exactly one binder"
 
@@ -993,7 +994,7 @@ localFunctionDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
 localPatternDeclParser :: TokParser Decl
 localPatternDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pat <- patternParser
-  DeclValue . PatternBind NoSourceSpan pat <$> equationRhsParser
+  DeclValue . PatternBind pat <$> equationRhsParser
 
 implicitParamDeclParser :: TokParser Decl
 implicitParamDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
@@ -1004,9 +1005,8 @@ implicitParamDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclValue
       ( PatternBind
-          NoSourceSpan
           (PAnn (mkAnnotation NoSourceSpan) (PVar (mkUnqualifiedName NameVarId name)))
-          (UnguardedRhs NoSourceSpan rhsExpr whereDecls)
+          (UnguardedRhs [] rhsExpr whereDecls)
       )
 
 varExprParser :: TokParser Expr

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
@@ -37,7 +37,7 @@ moduleHeaderParser = withSpan $ do
   expectedTok TkKeywordWhere
   pure $ \span' ->
     ModuleHead
-      { moduleHeadSpan = span',
+      { moduleHeadAnns = [mkAnnotation span'],
         moduleHeadName = name,
         moduleHeadWarningText = mWarning,
         moduleHeadExports = exports
@@ -143,7 +143,7 @@ importDeclParser = withSpan $ do
   let isQualified = preQualified || isJust postQualified
   pure $ \span' ->
     ImportDecl
-      { importDeclSpan = span',
+      { importDeclAnns = [mkAnnotation span'],
         importDeclLevel = importedLevel,
         importDeclPackage = importedPackage,
         importDeclSource = importedSource,
@@ -170,7 +170,7 @@ importSpecParser = withSpan $ do
   items <- parens $ importItemParser `MP.sepEndBy` expectedTok TkSpecialComma
   pure $ \span' ->
     ImportSpec
-      { importSpecSpan = span',
+      { importSpecAnns = [mkAnnotation span'],
         importSpecHiding = isHiding,
         importSpecItems = items
       }

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Module.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Module.hs
@@ -14,7 +14,7 @@ import Aihc.Parser.Internal.Common (TokParser, braces, expectedTok, skipSemicolo
 import Aihc.Parser.Internal.Decl (declParser)
 import Aihc.Parser.Internal.Import (importDeclParser, languagePragmaParser, moduleHeaderParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind)
-import Aihc.Parser.Syntax (Decl, ImportDecl, Module (..))
+import Aihc.Parser.Syntax (Decl, ImportDecl, Module (..), mkAnnotation)
 import Control.Monad (void)
 import Text.Megaparsec qualified as MP
 
@@ -30,7 +30,7 @@ moduleParser = withSpan $ do
   (imports, decls) <- moduleBodyParser
   pure $ \span' ->
     Module
-      { moduleSpan = span',
+      { moduleAnns = [mkAnnotation span'],
         moduleHead = mHeader,
         moduleLanguagePragmas = concat languagePragmas,
         moduleImports = imports,

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -23,7 +23,7 @@ patternParser = label "pattern" $ do
   pat <- infixPatternParser
   mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   case mTypeSig of
-    Just ty -> pure (PAnn (mkAnnotation (mergeSourceSpans (getSourceSpan pat) (getSourceSpan ty))) (PTypeSig pat ty))
+    Just ty -> pure (PAnn (mkAnnotation (mergeSourceSpans (getPatternSourceSpan pat) (getTypeSourceSpan ty))) (PTypeSig pat ty))
     Nothing -> pure pat
 
 infixPatternParser :: TokParser Pattern
@@ -47,7 +47,7 @@ asOrAppPatternParser = do
 
 buildInfixPattern :: Pattern -> (Name, Pattern) -> Pattern
 buildInfixPattern lhs (op, rhs) =
-  PAnn (mkAnnotation (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs))) (PInfix lhs op rhs)
+  PAnn (mkAnnotation (mergeSourceSpans (getPatternSourceSpan lhs) (getPatternSourceSpan rhs))) (PInfix lhs op rhs)
 
 conOperatorParser :: TokParser Name
 conOperatorParser =
@@ -94,7 +94,7 @@ appPatternParser =
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =
   case peelPatternAnn lhs of
-    PCon name args -> PAnn (mkAnnotation (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs))) (PCon name (args <> [rhs]))
+    PCon name args -> PAnn (mkAnnotation (mergeSourceSpans (getPatternSourceSpan lhs) (getPatternSourceSpan rhs))) (PCon name (args <> [rhs]))
     _ -> lhs
 
 -- | Parse an atomic pattern (@apat@ in the Haskell Report).
@@ -304,7 +304,7 @@ listPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
         expr <- exprParser
         expectedTok TkReservedRightArrow
         inner <- patternParser
-        let sp = mergeSourceSpans (getSourceSpan expr) (getSourceSpan inner)
+        let sp = mergeSourceSpans (getExprSourceSpan expr) (getPatternSourceSpan inner)
         pure (PAnn (mkAnnotation sp) (PView expr inner))
       maybe patternParser pure mView
 
@@ -343,7 +343,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
       expectedTok TkReservedRightArrow
       inner <- patternParser
       expectedTok closeTok
-      let sp = mergeSourceSpans (getSourceSpan expr) (getSourceSpan inner)
+      let sp = mergeSourceSpans (getExprSourceSpan expr) (getPatternSourceSpan inner)
       pure (PParen (PAnn (mkAnnotation sp) (PView expr inner)))
 
     -- Parse a single element inside a paren/tuple/unboxed-sum pattern.
@@ -427,7 +427,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
           -- View pattern: expr -> pattern
           expectedTok TkReservedRightArrow
           inner <- patternParser
-          let sp = mergeSourceSpans (getSourceSpan expr) (getSourceSpan inner)
+          let sp = mergeSourceSpans (getExprSourceSpan expr) (getPatternSourceSpan inner)
           pure (PAnn (mkAnnotation sp) (PView expr inner))
         Just (Right pat) ->
           pure pat

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -63,7 +63,7 @@ forallBinderParser =
         ident <- lowerIdentifierParser
         mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
         expectedTok TkSpecialRBrace
-        pure (\span' -> TyVarBinder span' ident mKind TyVarBInferred)
+        pure (\span' -> TyVarBinder [mkAnnotation span'] ident mKind TyVarBInferred)
     )
       <|> ( do
               expectedTok TkSpecialLParen
@@ -71,11 +71,11 @@ forallBinderParser =
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified)
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified)
           )
       <|> ( do
               ident <- lowerIdentifierParser
-              pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified)
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified)
           )
 
 contextTypeParser :: TokParser Type

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -85,7 +85,7 @@ contextTypeParser = do
   inner <- typeParser
   pure
     ( typeAnnSpan
-        (mergeSourceSpans (constraintHeadSpan constraints) (getSourceSpan inner))
+        (mergeSourceSpans (constraintHeadSpan constraints) (getTypeSourceSpan inner))
         (TContext constraints inner)
     )
 
@@ -93,7 +93,7 @@ constraintHeadSpan :: [Type] -> SourceSpan
 constraintHeadSpan constraints =
   case constraints of
     [] -> NoSourceSpan
-    constraint : _ -> getSourceSpan constraint
+    constraint : _ -> getTypeSourceSpan constraint
 
 contextItemsParser :: TokParser [Type]
 contextItemsParser = contextItemsParserWith typeParser typeAtomParser
@@ -106,7 +106,7 @@ typeFunParser = do
     case mRhs of
       Just rhs ->
         typeAnnSpan
-          (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs))
+          (mergeSourceSpans (getTypeSourceSpan lhs) (getTypeSourceSpan rhs))
           (TFun lhs rhs)
       Nothing -> lhs
 
@@ -132,7 +132,7 @@ typeHeadInfixLoopParser = MP.many $ MP.try $ do
 
 buildInfixType :: Type -> ((Name, TypePromotion), Type) -> Type
 buildInfixType lhs ((op, promoted), rhs) =
-  let span' = mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)
+  let span' = mergeSourceSpans (getTypeSourceSpan lhs) (getTypeSourceSpan rhs)
       opType = typeAnnSpan span' (TCon op promoted)
    in typeAnnSpan span' (TApp (typeAnnSpan span' (TApp opType lhs)) rhs)
 
@@ -193,7 +193,7 @@ typeAppParser = do
 
 buildTypeApp :: Type -> Type -> Type
 buildTypeApp lhs rhs =
-  typeAnnSpan (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)) (TApp lhs rhs)
+  typeAnnSpan (mergeSourceSpans (getTypeSourceSpan lhs) (getTypeSourceSpan rhs)) (TApp lhs rhs)
 
 typeAtomParser :: TokParser Type
 typeAtomParser = do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -378,8 +378,8 @@ addDeclSpliceParens body =
 addValueDeclParens :: ValueDecl -> ValueDecl
 addValueDeclParens vdecl =
   case vdecl of
-    PatternBind sp pat rhs -> PatternBind sp (addPatternParens pat) (addRhsParens rhs)
-    FunctionBind sp name matches -> FunctionBind sp name (map (addMatchParens name) matches)
+    PatternBind pat rhs -> PatternBind (addPatternParens pat) (addRhsParens rhs)
+    FunctionBind name matches -> FunctionBind name (map (addMatchParens name) matches)
 
 addMatchParens :: UnqualifiedName -> Match -> Match
 addMatchParens name match =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -284,16 +284,16 @@ prettyRole role =
 prettyValueDeclLines :: ValueDecl -> [Doc ann]
 prettyValueDeclLines valueDecl =
   case valueDecl of
-    PatternBind _ pat rhs -> [prettyPattern pat <+> prettyRhs rhs]
-    FunctionBind _ name matches ->
+    PatternBind pat rhs -> [prettyPattern pat <+> prettyRhs rhs]
+    FunctionBind name matches ->
       concatMap (prettyFunctionMatchLines name) matches
 
 -- | Pretty-print a value declaration on a single line.
 prettyValueDeclSingleLine :: ValueDecl -> Doc ann
 prettyValueDeclSingleLine valueDecl =
   case valueDecl of
-    PatternBind _ pat rhs -> prettyPattern pat <+> prettyRhs rhs
-    FunctionBind _ name matches ->
+    PatternBind pat rhs -> prettyPattern pat <+> prettyRhs rhs
+    FunctionBind name matches ->
       hsep (punctuate semi (map (prettyFunctionMatch name) matches))
 
 -- | Pretty-print a pattern synonym declaration.

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -234,8 +234,8 @@ docDecl decl =
 docValueDecl :: ValueDecl -> Doc ann
 docValueDecl vdecl =
   case vdecl of
-    FunctionBind _ name matches -> "FunctionBind" <+> docUnqualifiedName name <+> brackets (hsep (punctuate comma (map docMatch matches)))
-    PatternBind _ pat rhs -> "PatternBind" <+> docPattern pat <+> docRhs rhs
+    FunctionBind name matches -> "FunctionBind" <+> docUnqualifiedName name <+> brackets (hsep (punctuate comma (map docMatch matches)))
+    PatternBind pat rhs -> "PatternBind" <+> docPattern pat <+> docRhs rhs
 
 docPatSynDecl :: PatSynDecl -> Doc ann
 docPatSynDecl ps =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -791,7 +791,7 @@ instance HasSourceSpan WarningText where
         | otherwise -> getSourceSpan sub
 
 data Module = Module
-  { moduleSpan :: SourceSpan,
+  { moduleAnns :: [Annotation],
     moduleHead :: Maybe ModuleHead,
     moduleLanguagePragmas :: [ExtensionSetting],
     moduleImports :: [ImportDecl],
@@ -799,19 +799,13 @@ data Module = Module
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Module where
-  getSourceSpan = moduleSpan
-
 data ModuleHead = ModuleHead
-  { moduleHeadSpan :: SourceSpan,
+  { moduleHeadAnns :: [Annotation],
     moduleHeadName :: Text,
     moduleHeadWarningText :: Maybe WarningText,
     moduleHeadExports :: Maybe [ExportSpec]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan ModuleHead where
-  getSourceSpan = moduleHeadSpan
 
 moduleName :: Module -> Maybe Text
 moduleName modu = moduleHeadName <$> moduleHead modu
@@ -857,7 +851,7 @@ instance HasSourceSpan ExportSpec where
       _ -> NoSourceSpan
 
 data ImportDecl = ImportDecl
-  { importDeclSpan :: SourceSpan,
+  { importDeclAnns :: [Annotation],
     importDeclLevel :: Maybe ImportLevel,
     importDeclPackage :: Maybe Text,
     importDeclSource :: Bool,
@@ -870,23 +864,17 @@ data ImportDecl = ImportDecl
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan ImportDecl where
-  getSourceSpan = importDeclSpan
-
 data ImportLevel
   = ImportLevelQuote
   | ImportLevelSplice
   deriving (Data, Eq, Show, Generic, NFData)
 
 data ImportSpec = ImportSpec
-  { importSpecSpan :: SourceSpan,
+  { importSpecAnns :: [Annotation],
     importSpecHiding :: Bool,
     importSpecItems :: [ImportItem]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan ImportSpec where
-  getSourceSpan = importSpecSpan
 
 data ImportItem
   = ImportItemVar (Maybe IEEntityNamespace) UnqualifiedName
@@ -947,26 +935,17 @@ peelDeclAnn (DeclAnn _ inner) = peelDeclAnn inner
 peelDeclAnn d = d
 
 data ValueDecl
-  = FunctionBind SourceSpan BinderName [Match]
-  | PatternBind SourceSpan Pattern Rhs
+  = FunctionBind BinderName [Match]
+  | PatternBind Pattern Rhs
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan ValueDecl where
-  getSourceSpan valueDecl =
-    case valueDecl of
-      FunctionBind span' _ _ -> span'
-      PatternBind span' _ _ -> span'
-
 data Match = Match
-  { matchSpan :: SourceSpan,
+  { matchAnns :: [Annotation],
     matchHeadForm :: MatchHeadForm,
     matchPats :: [Pattern],
     matchRhs :: Rhs
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan Match where
-  getSourceSpan = matchSpan
 
 data MatchHeadForm
   = MatchHeadPrefix
@@ -1003,25 +982,16 @@ data PatSynDecl = PatSynDecl
   deriving (Data, Eq, Show, Generic, NFData)
 
 data Rhs
-  = UnguardedRhs SourceSpan Expr (Maybe [Decl])
-  | GuardedRhss SourceSpan [GuardedRhs] (Maybe [Decl])
+  = UnguardedRhs [Annotation] Expr (Maybe [Decl])
+  | GuardedRhss [Annotation] [GuardedRhs] (Maybe [Decl])
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Rhs where
-  getSourceSpan rhs =
-    case rhs of
-      UnguardedRhs span' _ _ -> span'
-      GuardedRhss span' _ _ -> span'
-
 data GuardedRhs = GuardedRhs
-  { guardedRhsSpan :: SourceSpan,
+  { guardedRhsAnns :: [Annotation],
     guardedRhsGuards :: [GuardQualifier],
     guardedRhsBody :: Expr
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan GuardedRhs where
-  getSourceSpan = guardedRhsSpan
 
 data GuardQualifier
   = -- | Metadata for the whole guard qualifier (typically a 'SourceSpan' via 'mkAnnotation').
@@ -1176,7 +1146,7 @@ data TyVarBSpecificity
   deriving (Data, Eq, Show, Generic, NFData)
 
 data TyVarBinder = TyVarBinder
-  { tyVarBinderSpan :: SourceSpan,
+  { tyVarBinderAnns :: [Annotation],
     tyVarBinderName :: Text,
     -- | Optional kind annotation. Examples: @(a :: Type)@ and @{a :: Type}@.
     tyVarBinderKind :: Maybe Type,
@@ -1185,9 +1155,6 @@ data TyVarBinder = TyVarBinder
     tyVarBinderSpecificity :: TyVarBSpecificity
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan TyVarBinder where
-  getSourceSpan = tyVarBinderSpan
 
 data TypeHeadForm
   = TypeHeadPrefix
@@ -1232,16 +1199,13 @@ data TypeFamilyDecl = TypeFamilyDecl
 
 -- | One equation in a closed type family: @[forall binders.] LhsType = RhsType@
 data TypeFamilyEq = TypeFamilyEq
-  { typeFamilyEqSpan :: SourceSpan,
+  { typeFamilyEqAnns :: [Annotation],
     typeFamilyEqForall :: [TyVarBinder],
     typeFamilyEqHeadForm :: TypeHeadForm,
     typeFamilyEqLhs :: Type,
     typeFamilyEqRhs :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan TypeFamilyEq where
-  getSourceSpan = typeFamilyEqSpan
 
 -- | Data family declaration (standalone or associated in a class body).
 data DataFamilyDecl = DataFamilyDecl
@@ -1254,21 +1218,16 @@ data DataFamilyDecl = DataFamilyDecl
 
 -- | Type family instance: @type [instance] [forall binders.] LhsType = RhsType@
 data TypeFamilyInst = TypeFamilyInst
-  { typeFamilyInstSpan :: SourceSpan,
-    typeFamilyInstForall :: [TyVarBinder],
+  { typeFamilyInstForall :: [TyVarBinder],
     typeFamilyInstHeadForm :: TypeHeadForm,
     typeFamilyInstLhs :: Type,
     typeFamilyInstRhs :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan TypeFamilyInst where
-  getSourceSpan = typeFamilyInstSpan
-
 -- | Data or newtype family instance (standalone or in an instance body).
 data DataFamilyInst = DataFamilyInst
-  { dataFamilyInstSpan :: SourceSpan,
-    -- | @True@ when declared with @newtype instance@
+  { -- | @True@ when declared with @newtype instance@
     dataFamilyInstIsNewtype :: Bool,
     dataFamilyInstForall :: [TyVarBinder],
     -- | The LHS type-application pattern (e.g. @GMap (Either a b) v@)
@@ -1279,9 +1238,6 @@ data DataFamilyInst = DataFamilyInst
     dataFamilyInstDeriving :: [DerivingClause]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan DataFamilyInst where
-  getSourceSpan = dataFamilyInstSpan
 
 data DataDecl = DataDecl
   { dataDeclHeadForm :: TypeHeadForm,
@@ -1347,16 +1303,13 @@ instance HasSourceSpan DataConDecl where
       _ -> NoSourceSpan
 
 data BangType = BangType
-  { bangSpan :: SourceSpan,
+  { bangAnns :: [Annotation],
     bangSourceUnpackedness :: SourceUnpackedness,
     bangStrict :: Bool,
     bangLazy :: Bool,
     bangType :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan BangType where
-  getSourceSpan = bangSpan
 
 data SourceUnpackedness
   = NoSourceUnpackedness
@@ -1365,14 +1318,11 @@ data SourceUnpackedness
   deriving (Data, Eq, Show, Generic, NFData)
 
 data FieldDecl = FieldDecl
-  { fieldSpan :: SourceSpan,
+  { fieldAnns :: [Annotation],
     fieldNames :: [UnqualifiedName],
     fieldType :: BangType
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan FieldDecl where
-  getSourceSpan = fieldSpan
 
 data DerivingClause = DerivingClause
   { derivingStrategy :: Maybe DerivingStrategy,
@@ -1413,14 +1363,11 @@ data ClassDecl = ClassDecl
   deriving (Data, Eq, Show, Generic, NFData)
 
 data FunctionalDependency = FunctionalDependency
-  { functionalDependencySpan :: SourceSpan,
+  { functionalDependencyAnns :: [Annotation],
     functionalDependencyDeterminers :: [Text],
     functionalDependencyDetermined :: [Text]
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan FunctionalDependency where
-  getSourceSpan = functionalDependencySpan
 
 data ClassDeclItem
   = ClassItemAnn Annotation ClassDeclItem
@@ -1628,14 +1575,11 @@ peelExprAnn (EAnn _ x) = peelExprAnn x
 peelExprAnn x = x
 
 data CaseAlt = CaseAlt
-  { caseAltSpan :: SourceSpan,
+  { caseAltAnns :: [Annotation],
     caseAltPattern :: Pattern,
     caseAltRhs :: Rhs
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan CaseAlt where
-  getSourceSpan = caseAltSpan
 
 data DoStmt body
   = -- | Metadata for the whole do-statement (typically a 'SourceSpan' via 'mkAnnotation').
@@ -1702,14 +1646,11 @@ instance HasSourceSpan Cmd where
 
 -- | Case alternative with a command body (used in arrow @case@ commands).
 data CmdCaseAlt = CmdCaseAlt
-  { cmdCaseAltSpan :: SourceSpan,
+  { cmdCaseAltAnns :: [Annotation],
     cmdCaseAltPat :: Pattern,
     cmdCaseAltBody :: Cmd
   }
   deriving (Data, Eq, Show, Generic, NFData)
-
-instance HasSourceSpan CmdCaseAlt where
-  getSourceSpan = cmdCaseAltSpan
 
 data CompStmt
   = -- | Metadata for the whole comprehension statement (typically a 'SourceSpan' via 'mkAnnotation').

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -75,7 +75,6 @@ module Aihc.Parser.Syntax
     Role (..),
     RoleAnnotation (..),
     Rhs (..),
-    HasSourceSpan (..),
     SourceSpan (..),
     SourceUnpackedness (..),
     StandaloneDerivingDecl (..),
@@ -113,7 +112,6 @@ module Aihc.Parser.Syntax
     qualifyName,
     renderName,
     renderUnqualifiedName,
-    sourceSpanEnd,
     unqualifiedNameFromText,
     moduleName,
     moduleWarningText,
@@ -136,6 +134,22 @@ module Aihc.Parser.Syntax
     literalAnnSpan,
     peelLiteralAnn,
     typeAnnSpan,
+    getArithSeqSourceSpan,
+    getClassDeclItemSourceSpan,
+    getCmdSourceSpan,
+    getCompStmtSourceSpan,
+    getDataConDeclSourceSpan,
+    getDeclSourceSpan,
+    getDoStmtSourceSpan,
+    getExportSpecSourceSpan,
+    getExprSourceSpan,
+    getGuardQualifierSourceSpan,
+    getImportItemSourceSpan,
+    getInstanceDeclItemSourceSpan,
+    getLiteralSourceSpan,
+    getPatternSourceSpan,
+    getTypeSourceSpan,
+    getWarningTextSourceSpan,
   )
 where
 
@@ -627,9 +641,6 @@ instance Show SourceSpan where
 noSourceSpan :: SourceSpan
 noSourceSpan = NoSourceSpan
 
-class HasSourceSpan a where
-  getSourceSpan :: a -> SourceSpan
-
 mergeSourceSpans :: SourceSpan -> SourceSpan -> SourceSpan
 mergeSourceSpans left right =
   case (left, right) of
@@ -639,12 +650,6 @@ mergeSourceSpans left right =
         SourceSpan name l1 c1 l2 c2 startOffset endOffset
     (NoSourceSpan, span') -> span'
     (span', NoSourceSpan) -> span'
-
-sourceSpanEnd :: (HasSourceSpan a) => [a] -> SourceSpan
-sourceSpanEnd xs =
-  case reverse xs of
-    [] -> NoSourceSpan
-    x : _ -> getSourceSpan x
 
 -- | A qualified or unqualified name with type information.
 --
@@ -781,14 +786,14 @@ data Pragma
   | PragmaUnknown Text
   deriving (Data, Eq, Ord, Show, Read, Generic, NFData)
 
-instance HasSourceSpan WarningText where
-  getSourceSpan warningText =
-    case warningText of
-      DeprText _ -> NoSourceSpan
-      WarnText _ -> NoSourceSpan
-      WarningTextAnn ann sub
-        | Just srcSpan <- fromAnnotation ann -> srcSpan
-        | otherwise -> getSourceSpan sub
+getWarningTextSourceSpan :: WarningText -> SourceSpan
+getWarningTextSourceSpan warningText =
+  case warningText of
+    DeprText _ -> NoSourceSpan
+    WarnText _ -> NoSourceSpan
+    WarningTextAnn ann sub
+      | Just srcSpan <- fromAnnotation ann -> srcSpan
+      | otherwise -> getWarningTextSourceSpan sub
 
 data Module = Module
   { moduleAnns :: [Annotation],
@@ -842,13 +847,13 @@ data ExportSpec
   | ExportAnn Annotation ExportSpec
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan ExportSpec where
-  getSourceSpan spec =
-    case spec of
-      ExportAnn ann sub
-        | Just srcSpan <- fromAnnotation ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getExportSpecSourceSpan :: ExportSpec -> SourceSpan
+getExportSpecSourceSpan spec =
+  case spec of
+    ExportAnn ann sub
+      | Just srcSpan <- fromAnnotation ann -> srcSpan
+      | otherwise -> getExportSpecSourceSpan sub
+    _ -> NoSourceSpan
 
 data ImportDecl = ImportDecl
   { importDeclAnns :: [Annotation],
@@ -885,13 +890,13 @@ data ImportItem
   | ImportAnn Annotation ImportItem
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan ImportItem where
-  getSourceSpan item =
-    case item of
-      ImportAnn ann sub
-        | Just srcSpan <- fromAnnotation ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getImportItemSourceSpan :: ImportItem -> SourceSpan
+getImportItemSourceSpan item =
+  case item of
+    ImportAnn ann sub
+      | Just srcSpan <- fromAnnotation ann -> srcSpan
+      | otherwise -> getImportItemSourceSpan sub
+    _ -> NoSourceSpan
 
 data Decl
   = DeclAnn Annotation Decl
@@ -921,13 +926,13 @@ data Decl
     DeclPragma Pragma
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Decl where
-  getSourceSpan decl =
-    case decl of
-      DeclAnn ann sub
-        | Just srcSpan <- fromAnnotation ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getDeclSourceSpan :: Decl -> SourceSpan
+getDeclSourceSpan decl =
+  case decl of
+    DeclAnn ann sub
+      | Just srcSpan <- fromAnnotation ann -> srcSpan
+      | otherwise -> getDeclSourceSpan sub
+    _ -> NoSourceSpan
 
 -- | Peel nested 'DeclAnn' wrappers.
 peelDeclAnn :: Decl -> Decl
@@ -1005,13 +1010,13 @@ peelGuardQualifierAnn :: GuardQualifier -> GuardQualifier
 peelGuardQualifierAnn (GuardAnn _ inner) = peelGuardQualifierAnn inner
 peelGuardQualifierAnn q = q
 
-instance HasSourceSpan GuardQualifier where
-  getSourceSpan qualifier =
-    case qualifier of
-      GuardAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getGuardQualifierSourceSpan :: GuardQualifier -> SourceSpan
+getGuardQualifierSourceSpan qualifier =
+  case qualifier of
+    GuardAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getGuardQualifierSourceSpan sub
+    _ -> NoSourceSpan
 
 data Literal
   = LitAnn Annotation Literal
@@ -1027,13 +1032,13 @@ data Literal
   | LitStringHash Text Text
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Literal where
-  getSourceSpan literal =
-    case literal of
-      LitAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getLiteralSourceSpan :: Literal -> SourceSpan
+getLiteralSourceSpan literal =
+  case literal of
+    LitAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getLiteralSourceSpan sub
+    _ -> NoSourceSpan
 
 literalAnnSpan :: SourceSpan -> Literal -> Literal
 literalAnnSpan sp = LitAnn (mkAnnotation sp)
@@ -1070,13 +1075,13 @@ data Pattern
   -- \$pat or $(pat) (TH pattern splice)
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Pattern where
-  getSourceSpan pat =
-    case pat of
-      PAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getPatternSourceSpan :: Pattern -> SourceSpan
+getPatternSourceSpan pat =
+  case pat of
+    PAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getPatternSourceSpan sub
+    _ -> NoSourceSpan
 
 -- | Peel nested 'PAnn' wrappers.
 peelPatternAnn :: Pattern -> Pattern
@@ -1106,13 +1111,13 @@ data Type
     TWildcard
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Type where
-  getSourceSpan ty =
-    case ty of
-      TAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getTypeSourceSpan :: Type -> SourceSpan
+getTypeSourceSpan ty =
+  case ty of
+    TAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getTypeSourceSpan sub
+    _ -> NoSourceSpan
 
 typeAnnSpan :: SourceSpan -> Type -> Type
 typeAnnSpan sp = TAnn (mkAnnotation sp)
@@ -1294,13 +1299,13 @@ gadtBodyResultType body =
     GadtPrefixBody _ ty -> ty
     GadtRecordBody _ ty -> ty
 
-instance HasSourceSpan DataConDecl where
-  getSourceSpan dataConDecl =
-    case dataConDecl of
-      DataConAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getDataConDeclSourceSpan :: DataConDecl -> SourceSpan
+getDataConDeclSourceSpan dataConDecl =
+  case dataConDecl of
+    DataConAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getDataConDeclSourceSpan sub
+    _ -> NoSourceSpan
 
 data BangType = BangType
   { bangAnns :: [Annotation],
@@ -1382,13 +1387,13 @@ data ClassDeclItem
     ClassItemPragma Pragma
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan ClassDeclItem where
-  getSourceSpan classDeclItem =
-    case classDeclItem of
-      ClassItemAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getClassDeclItemSourceSpan :: ClassDeclItem -> SourceSpan
+getClassDeclItemSourceSpan classDeclItem =
+  case classDeclItem of
+    ClassItemAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getClassDeclItemSourceSpan sub
+    _ -> NoSourceSpan
 
 peelClassDeclItemAnn :: ClassDeclItem -> ClassDeclItem
 peelClassDeclItemAnn (ClassItemAnn _ inner) = peelClassDeclItemAnn inner
@@ -1430,13 +1435,13 @@ peelInstanceDeclItemAnn :: InstanceDeclItem -> InstanceDeclItem
 peelInstanceDeclItemAnn (InstanceItemAnn _ inner) = peelInstanceDeclItemAnn inner
 peelInstanceDeclItemAnn item = item
 
-instance HasSourceSpan InstanceDeclItem where
-  getSourceSpan instanceDeclItem =
-    case instanceDeclItem of
-      InstanceItemAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getInstanceDeclItemSourceSpan :: InstanceDeclItem -> SourceSpan
+getInstanceDeclItemSourceSpan instanceDeclItem =
+  case instanceDeclItem of
+    InstanceItemAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getInstanceDeclItemSourceSpan sub
+    _ -> NoSourceSpan
 
 data FixityAssoc
   = Infix
@@ -1561,13 +1566,13 @@ data Expr
     EProc Pattern Cmd -- proc pat -> cmd
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Expr where
-  getSourceSpan expr =
-    case expr of
-      EAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getExprSourceSpan :: Expr -> SourceSpan
+getExprSourceSpan expr =
+  case expr of
+    EAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getExprSourceSpan sub
+    _ -> NoSourceSpan
 
 -- | Peel nested 'EAnn' layers (e.g. span-only dynamic annotations).
 peelExprAnn :: Expr -> Expr
@@ -1594,13 +1599,13 @@ peelDoStmtAnn :: DoStmt body -> DoStmt body
 peelDoStmtAnn (DoAnn _ inner) = peelDoStmtAnn inner
 peelDoStmtAnn s = s
 
-instance HasSourceSpan (DoStmt body) where
-  getSourceSpan doStmt =
-    case doStmt of
-      DoAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getDoStmtSourceSpan :: DoStmt body -> SourceSpan
+getDoStmtSourceSpan doStmt =
+  case doStmt of
+    DoAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getDoStmtSourceSpan sub
+    _ -> NoSourceSpan
 
 -- | Arrow command type (used inside 'proc' expressions).
 -- Commands mirror expressions but live in a separate namespace so the
@@ -1636,13 +1641,13 @@ peelCmdAnn c = c
 data ArrAppType = HsFirstOrderApp | HsHigherOrderApp
   deriving (Data, Eq, Show, Generic, NFData)
 
-instance HasSourceSpan Cmd where
-  getSourceSpan cmd =
-    case cmd of
-      CmdAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getCmdSourceSpan :: Cmd -> SourceSpan
+getCmdSourceSpan cmd =
+  case cmd of
+    CmdAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getCmdSourceSpan sub
+    _ -> NoSourceSpan
 
 -- | Case alternative with a command body (used in arrow @case@ commands).
 data CmdCaseAlt = CmdCaseAlt
@@ -1664,13 +1669,13 @@ peelCompStmtAnn :: CompStmt -> CompStmt
 peelCompStmtAnn (CompAnn _ inner) = peelCompStmtAnn inner
 peelCompStmtAnn s = s
 
-instance HasSourceSpan CompStmt where
-  getSourceSpan compStmt =
-    case compStmt of
-      CompAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getCompStmtSourceSpan :: CompStmt -> SourceSpan
+getCompStmtSourceSpan compStmt =
+  case compStmt of
+    CompAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getCompStmtSourceSpan sub
+    _ -> NoSourceSpan
 
 data ArithSeq
   = -- | Metadata for the whole arithmetic sequence (typically a 'SourceSpan' via 'mkAnnotation').
@@ -1685,10 +1690,10 @@ peelArithSeqAnn :: ArithSeq -> ArithSeq
 peelArithSeqAnn (ArithSeqAnn _ inner) = peelArithSeqAnn inner
 peelArithSeqAnn s = s
 
-instance HasSourceSpan ArithSeq where
-  getSourceSpan arithSeq =
-    case arithSeq of
-      ArithSeqAnn ann sub
-        | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-        | otherwise -> getSourceSpan sub
-      _ -> NoSourceSpan
+getArithSeqSourceSpan :: ArithSeq -> SourceSpan
+getArithSeqSourceSpan arithSeq =
+  case arithSeq of
+    ArithSeqAnn ann sub
+      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
+      | otherwise -> getArithSeqSourceSpan sub
+    _ -> NoSourceSpan

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -374,7 +374,7 @@ test_moduleParsesDecls =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [ DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (EIf_ (EVar_ "y") (EVar_ "z") (EVar_ "w")) _))
+          [ DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (EIf_ (EVar_ "y") (EVar_ "z") (EVar_ "w")) _))
             ] ->
               pure ()
           other ->
@@ -594,20 +594,19 @@ test_ifElseWhereBranchRoundtrip =
       expectedDecl =
         DeclValue
           ( FunctionBind
-              span0
               "x"
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [],
-                    matchRhs = UnguardedRhs span0 (expr0 (EIf (expr0 (EVar "b")) (expr0 (ETuple Boxed [])) elseBranch)) Nothing
+                    matchRhs = UnguardedRhs [] (expr0 (EIf (expr0 (EVar "b")) (expr0 (ETuple Boxed [])) elseBranch)) Nothing
                   }
               ]
           )
       source =
         renderStrict . layoutPretty defaultLayoutOptions . pretty $
           Module
-            { moduleSpan = span0,
+            { moduleAnns = [],
               moduleHead = Nothing,
               moduleLanguagePragmas = [],
               moduleImports = [],
@@ -640,7 +639,7 @@ test_mdoViewPatternParses =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (FunctionBind _ "f" [Match {matchPats = [PView_ (EDo_ [DoExpr_ (EApp_ (EVar_ "pure") (EVar_ "x"))] True) (PVar_ "y")], matchRhs = UnguardedRhs _ (EVar_ "y") _}])] -> pure ()
+          [DeclValue (FunctionBind "f" [Match {matchPats = [PView_ (EDo_ [DoExpr_ (EApp_ (EVar_ "pure") (EVar_ "x"))] True) (PVar_ "y")], matchRhs = UnguardedRhs _ (EVar_ "y") _}])] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_infixTypeFamilyHeadRoundtrip :: Assertion
@@ -1019,8 +1018,8 @@ test_overloadedLabelExprParses =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [ DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (EOverloadedLabel_ "typeUrl" "#typeUrl") _)),
-            DeclValue (PatternBind _ (PVar_ "y") (UnguardedRhs _ (EOverloadedLabel_ "The quick brown fox" "#\"The quick brown fox\"") _))
+          [ DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (EOverloadedLabel_ "typeUrl" "#typeUrl") _)),
+            DeclValue (PatternBind (PVar_ "y") (UnguardedRhs _ (EOverloadedLabel_ "The quick brown fox" "#\"The quick brown fox\"") _))
             ] -> pure ()
           other -> assertFailure ("expected overloaded label expressions in AST, got: " <> show other)
 
@@ -1280,7 +1279,7 @@ parseDoStmts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (EDo_ stmts _) _))] ->
+          [DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (EDo_ stmts _) _))] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1293,7 +1292,7 @@ parseDoStmtsExt exts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (EDo_ stmts _) _))] ->
+          [DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (EDo_ stmts _) _))] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1408,7 +1407,7 @@ parseGuards src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (FunctionBind _ _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}] _}])] ->
+          [DeclValue (FunctionBind _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}] _}])] ->
             Right guards
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1419,7 +1418,7 @@ parseGuardsExt exts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (FunctionBind _ _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}] _}])] ->
+          [DeclValue (FunctionBind _ [Match {matchRhs = GuardedRhss _ [GuardedRhs {guardedRhsGuards = guards}] _}])] ->
             Right guards
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1437,13 +1436,12 @@ test_prettyGuardLambdaRoundTrip = do
   let decl =
         DeclValue
           ( FunctionBind
-              span0
               "f"
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [pat0 (PVar "x")],
-                    matchRhs = UnguardedRhs span0 caseExpr Nothing
+                    matchRhs = UnguardedRhs [] caseExpr Nothing
                   }
               ]
           )
@@ -1452,13 +1450,13 @@ test_prettyGuardLambdaRoundTrip = do
           ( ECase
               (expr0 (EVar "x"))
               [ CaseAlt
-                  { caseAltSpan = span0,
+                  { caseAltAnns = [],
                     caseAltPattern = pat0 (PVar "y"),
                     caseAltRhs =
                       GuardedRhss
-                        span0
+                        []
                         [ GuardedRhs
-                            { guardedRhsSpan = span0,
+                            { guardedRhsAnns = [],
                               guardedRhsGuards =
                                 [ GuardAnn
                                     (mkAnnotation span0)
@@ -1486,17 +1484,16 @@ test_prettyGuardLetFormatting = do
   let decl =
         DeclValue
           ( FunctionBind
-              span0
               "f"
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [pat0 (PVar "n")],
                     matchRhs =
                       GuardedRhss
-                        span0
+                        []
                         [ GuardedRhs
-                            { guardedRhsSpan = span0,
+                            { guardedRhsAnns = [],
                               guardedRhsGuards =
                                 [ GuardAnn
                                     (mkAnnotation span0)
@@ -1504,7 +1501,7 @@ test_prettyGuardLetFormatting = do
                                         ( expr0
                                             ( ELetDecls
                                                 [ DeclValue
-                                                    (FunctionBind span0 "x" [Match {matchSpan = span0, matchHeadForm = MatchHeadPrefix, matchPats = [], matchRhs = UnguardedRhs span0 (expr0 (EInt 1 "1")) Nothing}])
+                                                    (FunctionBind "x" [Match {matchAnns = [], matchHeadForm = MatchHeadPrefix, matchPats = [], matchRhs = UnguardedRhs [] (expr0 (EInt 1 "1")) Nothing}])
                                                 ]
                                                 (expr0 (EInfix (expr0 (EVar "x")) (qualifyName Nothing ">") (expr0 (EInt 0 "0"))))
                                             )
@@ -1526,13 +1523,12 @@ test_prettyFunctionHeadListViewPattern = do
   let decl =
         DeclValue
           ( FunctionBind
-              span0
               "fn"
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [pat0 (PList [pat0 (PView (expr0 (EVar "id")) (pat0 (PVar "x")))])],
-                    matchRhs = UnguardedRhs span0 (expr0 (EVar "x")) Nothing
+                    matchRhs = UnguardedRhs [] (expr0 (EVar "x")) Nothing
                   }
               ]
           )
@@ -1565,13 +1561,12 @@ test_prettyPrefixFunctionHeadRecordPattern = do
   let decl =
         DeclValue
           ( FunctionBind
-              span0
               "f"
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadPrefix,
                     matchPats = [pat0 (PRecord (qualifyName Nothing (mkUnqualifiedName NameConId "Point")) [] True)],
-                    matchRhs = UnguardedRhs span0 (expr0 (EInt 0 "0")) Nothing
+                    matchRhs = UnguardedRhs [] (expr0 (EInt 0 "0")) Nothing
                   }
               ]
           )
@@ -1584,13 +1579,12 @@ test_prettyInfixFunctionHeadConstructorPatterns = do
       decl =
         DeclValue
           ( FunctionBind
-              span0
               "=="
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadInfix,
                     matchPats = [box "x", box "y"],
-                    matchRhs = UnguardedRhs span0 (expr0 (EVar "x")) Nothing
+                    matchRhs = UnguardedRhs [] (expr0 (EVar "x")) Nothing
                   }
               ]
           )
@@ -1602,13 +1596,12 @@ test_prettyInfixFunctionHeadIrrefutablePatterns = do
   let decl =
         DeclValue
           ( FunctionBind
-              span0
               "combine"
               [ Match
-                  { matchSpan = span0,
+                  { matchAnns = [],
                     matchHeadForm = MatchHeadInfix,
                     matchPats = [pat0 (PIrrefutable (pat0 (PVar "x"))), pat0 (PVar "y")],
-                    matchRhs = UnguardedRhs span0 (expr0 (EVar "x")) Nothing
+                    matchRhs = UnguardedRhs [] (expr0 (EVar "x")) Nothing
                   }
               ]
           )
@@ -1627,7 +1620,7 @@ test_prettyViewLetTypeSigParens = do
       viewExpr =
         expr0
           ( ELetDecls
-              [DeclValue (PatternBind span0 (pat0 (PVar (mkUnqualifiedName NameVarId "x"))) (UnguardedRhs span0 unboxedUnit Nothing))]
+              [DeclValue (PatternBind (pat0 (PVar (mkUnqualifiedName NameVarId "x"))) (UnguardedRhs [] unboxedUnit Nothing))]
               (expr0 (ETypeSig unboxedUnit tyCon))
           )
       pat = pat0 (PView viewExpr (pat0 (PList [])))
@@ -1647,7 +1640,7 @@ test_prettyGuardPatTypeSigParens = do
       guardExpr = expr0 (ETypeSig (expr0 (EInt 262 "262")) tyCon)
       grhs =
         GuardedRhs
-          { guardedRhsSpan = span0,
+          { guardedRhsAnns = [],
             guardedRhsGuards = [GuardAnn (mkAnnotation span0) (GuardPat (pat0 (PTuple Boxed [])) guardExpr)],
             guardedRhsBody = expr0 (ETuple Boxed [])
           }
@@ -1692,8 +1685,7 @@ test_typeFamilyInstanceInfixAppliedOperandsRoundTrip = do
       decl =
         DeclTypeFamilyInst
           TypeFamilyInst
-            { typeFamilyInstSpan = span0,
-              typeFamilyInstForall = [],
+            { typeFamilyInstForall = [],
               typeFamilyInstHeadForm = TypeHeadInfix,
               typeFamilyInstLhs = lhs,
               typeFamilyInstRhs = rhs
@@ -1822,7 +1814,7 @@ parseCompStmts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (EListComp_ _ stmts) _))] ->
+          [DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (EListComp_ _ stmts) _))] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1834,7 +1826,7 @@ parseCompStmtsExt exts src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (EListComp_ _ stmts) _))] ->
+          [DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (EListComp_ _ stmts) _))] ->
             Right stmts
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1914,7 +1906,7 @@ parseLetDecls src =
    in if not (null errs)
         then Left ("parse errors: " <> show errs)
         else case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (PatternBind _ (PVar_ "x") (UnguardedRhs _ (ELetDecls_ decls _) _))] ->
+          [DeclValue (PatternBind (PVar_ "x") (UnguardedRhs _ (ELetDecls_ decls _) _))] ->
             Right decls
           other ->
             Left ("unexpected AST: " <> show other)
@@ -1947,49 +1939,49 @@ test_localDeclTypeSigUnicodeOp =
 test_localDeclFunPrefix :: Assertion
 test_localDeclFunPrefix =
   case parseLetDecls "let { f x = x } in f 1" of
-    Right [DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x"]}])] -> pure ()
+    Right [DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x"]}])] -> pure ()
     other -> assertFailure ("expected prefix function bind, got: " <> show other)
 
 test_localDeclFunNoArgs :: Assertion
 test_localDeclFunNoArgs =
   case parseLetDecls "let { f = 5 } in f" of
-    Right [DeclValue (PatternBind _ (PVar_ "f") _)] -> pure ()
+    Right [DeclValue (PatternBind (PVar_ "f") _)] -> pure ()
     other -> assertFailure ("expected no-args function bind, got: " <> show other)
 
 test_localDeclPatTuple :: Assertion
 test_localDeclPatTuple =
   case parseLetDecls "let { (x, y) = (1, 2) } in x" of
-    Right [DeclValue (PatternBind _ (PTuple_ Boxed [PVar_ "x", PVar_ "y"]) _)] -> pure ()
+    Right [DeclValue (PatternBind (PTuple_ Boxed [PVar_ "x", PVar_ "y"]) _)] -> pure ()
     other -> assertFailure ("expected tuple pattern bind, got: " <> show other)
 
 test_localDeclPatCon :: Assertion
 test_localDeclPatCon =
   case parseLetDecls "let { Just x = Nothing } in x" of
-    Right [DeclValue (PatternBind _ (PCon_ "Just" [PVar_ "x"]) _)] -> pure ()
+    Right [DeclValue (PatternBind (PCon_ "Just" [PVar_ "x"]) _)] -> pure ()
     other -> assertFailure ("expected constructor pattern bind, got: " <> show other)
 
 test_localDeclPatWild :: Assertion
 test_localDeclPatWild =
   case parseLetDecls "let { _ = 5 } in 0" of
-    Right [DeclValue (PatternBind _ PWildcard_ _)] -> pure ()
+    Right [DeclValue (PatternBind PWildcard_ _)] -> pure ()
     other -> assertFailure ("expected wildcard pattern bind, got: " <> show other)
 
 test_localDeclFunGuarded :: Assertion
 test_localDeclFunGuarded =
   case parseLetDecls "let { f x | x > 0 = x } in f 1" of
-    Right [DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x"], matchRhs = GuardedRhss {}}])] -> pure ()
+    Right [DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x"], matchRhs = GuardedRhss {}}])] -> pure ()
     other -> assertFailure ("expected guarded function bind, got: " <> show other)
 
 test_localDeclPatRecordCon :: Assertion
 test_localDeclPatRecordCon =
   case parseTopDecl "BYys {} = ()" of
-    Right (DeclValue (PatternBind _ (PRecord_ "BYys" [] False) _)) -> pure ()
+    Right (DeclValue (PatternBind (PRecord_ "BYys" [] False) _)) -> pure ()
     other -> assertFailure ("expected record constructor pattern bind, got: " <> show other)
 
 test_localDeclPatUnboxedSum :: Assertion
 test_localDeclPatUnboxedSum =
   case parseTopDeclWithExts [UnboxedSums] "(#  |  |  | a #) = ()" of
-    Right (DeclValue (PatternBind _ (PUnboxedSum_ 3 4 (PVar_ "a")) _)) -> pure ()
+    Right (DeclValue (PatternBind (PUnboxedSum_ 3 4 (PVar_ "a")) _)) -> pure ()
     other -> assertFailure ("expected unboxed sum pattern bind, got: " <> show other)
 
 test_templateHaskellQuotesParsesTopLevelTypedSpliceExpr :: Assertion
@@ -2033,101 +2025,101 @@ parseTopDeclWithExts exts src =
 test_funHeadPrefix :: Assertion
 test_funHeadPrefix =
   case parseTopDecl "f x y = x + y" of
-    Right (DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected prefix function bind, got: " <> show other)
 
 test_funHeadPrefixNoArgs :: Assertion
 test_funHeadPrefixNoArgs =
   case parseTopDecl "f = 5" of
-    Right (DeclValue (PatternBind _ (PVar_ "f") _)) -> pure ()
+    Right (DeclValue (PatternBind (PVar_ "f") _)) -> pure ()
     other -> assertFailure ("expected prefix function bind with no args, got: " <> show other)
 
 test_funHeadPrefixOp :: Assertion
 test_funHeadPrefixOp =
   case parseTopDecl "(+) x y = x" of
-    Right (DeclValue (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected prefix operator function bind, got: " <> show other)
 
 test_funHeadPrefixConstructorArg :: Assertion
 test_funHeadPrefixConstructorArg =
   case parseTopDecl "f (Just x) y = y" of
-    Right (DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PCon_ "Just" [PVar_ "x"], PVar_ "y"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PCon_ "Just" [PVar_ "x"], PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected constructor application argument in prefix function head, got: " <> show other)
 
 test_funHeadPrefixListViewPattern :: Assertion
 test_funHeadPrefixListViewPattern =
   case parseTopDeclWithExts [ViewPatterns] "fn [id -> x] = x" of
-    Right (DeclValue (FunctionBind _ "fn" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PList_ [PView_ (EVar_ "id") (PVar_ "x")]]}])) -> pure ()
+    Right (DeclValue (FunctionBind "fn" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PList_ [PView_ (EVar_ "id") (PVar_ "x")]]}])) -> pure ()
     other -> assertFailure ("expected list view-pattern argument in prefix function head, got: " <> show other)
 
 test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
 test_funHeadPrefixUnboxedTupleSingletonArg =
   case parseTopDeclWithExts [UnboxedTuples] "f (# x #) = x" of
-    Right (DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTuple_ Unboxed [PVar_ "x"]]}])) -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTuple_ Unboxed [PVar_ "x"]]}])) -> pure ()
     other -> assertFailure ("expected singleton unboxed tuple argument in prefix function head, got: " <> show other)
 
 test_funHeadInfix :: Assertion
 test_funHeadInfix =
   case parseTopDecl "x + y = x" of
-    Right (DeclValue (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected infix function bind, got: " <> show other)
 
 test_funHeadInfixBacktick :: Assertion
 test_funHeadInfixBacktick =
   case parseTopDecl "x `add` y = x" of
-    Right (DeclValue (FunctionBind _ "add" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "add" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected backtick infix function bind, got: " <> show other)
 
 test_funHeadInfixRecordRhs :: Assertion
 test_funHeadInfixRecordRhs =
   case parseTopDecl "x `f` (R {}) = x" of
-    Right (DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PRecord_ "R" [] False]}])) -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PRecord_ "R" [] False]}])) -> pure ()
     other -> assertFailure ("expected infix function bind with record rhs pattern, got: " <> show other)
 
 test_funHeadInfixTupleLhsQualifiedRecordRhs :: Assertion
 test_funHeadInfixTupleLhsQualifiedRecordRhs =
   case parseTopDecl "((x, _), K []) `f` (M.N.R {}) = x" of
-    Right (DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PTuple_ Boxed _, PRecord_ "M.N.R" [] False]}])) -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PTuple_ Boxed _, PRecord_ "M.N.R" [] False]}])) -> pure ()
     other -> assertFailure ("expected infix function bind with tuple lhs and qualified record rhs pattern, got: " <> show other)
 
 test_funHeadInfixComplexTupleLhsQualifiedRecordRhs :: Assertion
 test_funHeadInfixComplexTupleLhsQualifiedRecordRhs =
   case parseTopDeclWithExts [UnboxedTuples, UnboxedSums, QuasiQuotes] "((#  |  | -0xbe |  #), ([g|f|]), (# x, _ #), M.C [] []) `f` (N.R {}) = ()" of
-    Right (DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PTuple_ Boxed _, PRecord_ "N.R" [] False]}])) -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PTuple_ Boxed _, PRecord_ "N.R" [] False]}])) -> pure ()
     other -> assertFailure ("expected infix function bind with complex tuple lhs and qualified record rhs pattern, got: " <> show other)
 
 test_funHeadInfixThSpliceLhs :: Assertion
 test_funHeadInfixThSpliceLhs =
   case parseTopDecl "{-# LANGUAGE TemplateHaskell #-}\n$splice `fn` () = ()" of
-    Right (DeclValue (FunctionBind _ "fn" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PSplice_ (EVar_ "splice"), PTuple_ Boxed []]}])) -> pure ()
+    Right (DeclValue (FunctionBind "fn" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PSplice_ (EVar_ "splice"), PTuple_ Boxed []]}])) -> pure ()
     other -> assertFailure ("expected TH splice lhs infix function bind, got: " <> show other)
 
 test_funHeadParenInfix :: Assertion
 test_funHeadParenInfix =
   case parseTopDecl "(x + y) = x" of
-    Right (DeclValue (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected parenthesized infix function bind, got: " <> show other)
 
 test_funHeadParenInfixTail :: Assertion
 test_funHeadParenInfixTail =
   case parseTopDecl "(x + y) z = x" of
-    Right (DeclValue (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y", PVar_ "z"]}])) -> pure ()
+    Right (DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y", PVar_ "z"]}])) -> pure ()
     other -> assertFailure ("expected parenthesized infix with tail, got: " <> show other)
 
 test_funHeadLocalPrefix :: Assertion
 test_funHeadLocalPrefix =
   case parseLetDecls "let { f x = x } in f 1" of
-    Right [DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x"]}])] -> pure ()
+    Right [DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x"]}])] -> pure ()
     other -> assertFailure ("expected local prefix function bind, got: " <> show other)
 
 test_funHeadLocalInfix :: Assertion
 test_funHeadLocalInfix =
   case parseLetDecls "let { x + y = x } in 1 + 2" of
-    Right [DeclValue (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])] -> pure ()
+    Right [DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadInfix, matchPats = [PVar_ "x", PVar_ "y"]}])] -> pure ()
     other -> assertFailure ("expected local infix function bind, got: " <> show other)
 
 test_funHeadLocalPrefixOp :: Assertion
 test_funHeadLocalPrefixOp =
   case parseLetDecls "let { (+) x y = x } in 1 + 2" of
-    Right [DeclValue (FunctionBind _ "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x", PVar_ "y"]}])] -> pure ()
+    Right [DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PVar_ "x", PVar_ "y"]}])] -> pure ()
     other -> assertFailure ("expected local prefix operator function bind, got: " <> show other)

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -22,7 +22,6 @@ import Test.Properties.Arb.Identifiers
     genIdent,
     shrinkConIdent,
     shrinkIdent,
-    span0,
   )
 import Test.Properties.Arb.Pattern (canonicalPatternAtom, genPattern, shrinkPattern)
 import Test.Properties.Arb.Type (genType, shrinkType)
@@ -82,7 +81,7 @@ genPatternValueDecl :: Int -> Gen Decl
 genPatternValueDecl n = do
   pat <- genPatternBindPattern n
   expr <- resize n genExpr
-  pure $ DeclValue (PatternBind span0 pat (UnguardedRhs span0 expr Nothing))
+  pure $ DeclValue (PatternBind pat (UnguardedRhs [] expr Nothing))
 
 genPatternBindPattern :: Int -> Gen Pattern
 genPatternBindPattern n =
@@ -112,13 +111,12 @@ genFunctionDecl (name, expr) = do
         pure $
           DeclValue
             ( FunctionBind
-                span0
                 name
                 [ Match
-                    { matchSpan = span0,
+                    { matchAnns = [],
                       matchHeadForm = MatchHeadPrefix,
                       matchPats = pats,
-                      matchRhs = UnguardedRhs span0 expr Nothing
+                      matchRhs = UnguardedRhs [] expr Nothing
                     }
                 ]
             )
@@ -131,13 +129,12 @@ genFunctionDecl (name, expr) = do
         pure $
           DeclValue
             ( FunctionBind
-                span0
                 name
                 [ Match
-                    { matchSpan = span0,
+                    { matchAnns = [],
                       matchHeadForm = MatchHeadInfix,
                       matchPats = [lhsPat, rhsPat] <> extraPats,
-                      matchRhs = UnguardedRhs span0 expr Nothing
+                      matchRhs = UnguardedRhs [] expr Nothing
                     }
                 ]
             )
@@ -186,13 +183,26 @@ genDeclRoleAnnotation = do
   name <- genConIdent
   n <- chooseInt (0, 3)
   roles <- vectorOf n (elements [RoleNominal, RoleRepresentational, RolePhantom, RoleInfer])
-  pure $ DeclRoleAnnotation (RoleAnnotation name roles)
+  pure $
+    DeclRoleAnnotation
+      RoleAnnotation
+        { roleAnnotationName = name,
+          roleAnnotationRoles = roles
+        }
 
 genDeclTypeSyn :: Gen Decl
 genDeclTypeSyn = do
   name <- genConIdent
   params <- genSimpleTyVarBinders
-  DeclTypeSyn . TypeSynDecl TypeHeadPrefix name params <$> genSimpleType
+  body <- genSimpleType
+  pure $
+    DeclTypeSyn
+      TypeSynDecl
+        { typeSynHeadForm = TypeHeadPrefix,
+          typeSynName = name,
+          typeSynParams = params,
+          typeSynBody = body
+        }
 
 -- | Generate an infix type synonym, covering both symbolic operators
 -- (e.g. @type a :+: b = (a, b)@) and backtick-wrapped identifiers
@@ -202,9 +212,17 @@ genDeclTypeSynInfix = do
   name <- oneof [genConSym, genConIdent]
   lhsName <- genIdent
   rhsName <- genIdent
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
-  DeclTypeSyn . TypeSynDecl TypeHeadInfix name [lhs, rhs] <$> genSimpleType
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
+  body <- genSimpleType
+  pure $
+    DeclTypeSyn
+      TypeSynDecl
+        { typeSynHeadForm = TypeHeadInfix,
+          typeSynName = name,
+          typeSynParams = [lhs, rhs],
+          typeSynBody = body
+        }
 
 genDeclData :: Gen Decl
 genDeclData =
@@ -241,9 +259,9 @@ genDeclDataInfix = do
   rhsName <- genIdent
   extraCount <- chooseInt (0, 2)
   extraNames <- vectorOf extraCount genIdent
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
-      extraParams = [TyVarBinder span0 n Nothing TyVarBSpecified | n <- extraNames]
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
+      extraParams = [TyVarBinder [] n Nothing TyVarBSpecified | n <- extraNames]
   ctors <- genSimpleDataCons
   deriving' <- genDerivingClauses
   pure $
@@ -297,7 +315,7 @@ genNonStrictBangType = do
   ty <- genSimpleType
   pure $
     BangType
-      { bangSpan = span0,
+      { bangAnns = [],
         bangSourceUnpackedness = NoSourceUnpackedness,
         bangStrict = False,
         bangLazy = False,
@@ -368,7 +386,7 @@ genFieldDecl :: Gen FieldDecl
 genFieldDecl = do
   fieldCount <- chooseInt (1, 3)
   fieldNames <- vectorOf fieldCount genVarBinderName
-  FieldDecl span0 fieldNames <$> genSimpleBangType
+  FieldDecl [] fieldNames <$> genSimpleBangType
 
 genGadtDataCons :: Gen [DataConDecl]
 genGadtDataCons = do
@@ -406,9 +424,9 @@ genGadtBangType = do
   let canAnnotate = typeStartsWithAlpha ty
   annotation <- if canAnnotate then elements [NoAnnotation, StrictAnnotation, LazyAnnotation] else pure NoAnnotation
   case annotation of
-    NoAnnotation -> pure $ BangType span0 NoSourceUnpackedness False False ty
-    StrictAnnotation -> pure $ BangType span0 NoSourceUnpackedness True False ty
-    LazyAnnotation -> pure $ BangType span0 NoSourceUnpackedness False True ty
+    NoAnnotation -> pure $ BangType [] NoSourceUnpackedness False False ty
+    StrictAnnotation -> pure $ BangType [] NoSourceUnpackedness True False ty
+    LazyAnnotation -> pure $ BangType [] NoSourceUnpackedness False True ty
   where
     typeStartsWithAlpha :: Type -> Bool
     typeStartsWithAlpha (TVar _) = True
@@ -428,7 +446,7 @@ genSimpleBangTypeWithoutFun = do
     NoAnnotation ->
       pure $
         BangType
-          { bangSpan = span0,
+          { bangAnns = [],
             bangSourceUnpackedness = NoSourceUnpackedness,
             bangStrict = False,
             bangLazy = False,
@@ -437,7 +455,7 @@ genSimpleBangTypeWithoutFun = do
     StrictAnnotation ->
       pure $
         BangType
-          { bangSpan = span0,
+          { bangAnns = [],
             bangSourceUnpackedness = NoSourceUnpackedness,
             bangStrict = True,
             bangLazy = False,
@@ -446,7 +464,7 @@ genSimpleBangTypeWithoutFun = do
     LazyAnnotation ->
       pure $
         BangType
-          { bangSpan = span0,
+          { bangAnns = [],
             bangSourceUnpackedness = NoSourceUnpackedness,
             bangStrict = False,
             bangLazy = True,
@@ -474,7 +492,7 @@ genGadtFieldDecl :: Gen FieldDecl
 genGadtFieldDecl = do
   fieldName <- mkUnqualifiedName NameVarId <$> genIdent
   ty <- sized (genType . min 6)
-  pure $ FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False False ty)
+  pure $ FieldDecl [] [fieldName] (BangType [] NoSourceUnpackedness False False ty)
 
 genSimpleBangType :: Gen BangType
 genSimpleBangType = do
@@ -485,7 +503,7 @@ genSimpleBangType = do
     NoAnnotation ->
       pure $
         BangType
-          { bangSpan = span0,
+          { bangAnns = [],
             bangSourceUnpackedness = NoSourceUnpackedness,
             bangStrict = False,
             bangLazy = False,
@@ -494,7 +512,7 @@ genSimpleBangType = do
     StrictAnnotation ->
       pure $
         BangType
-          { bangSpan = span0,
+          { bangAnns = [],
             bangSourceUnpackedness = NoSourceUnpackedness,
             bangStrict = True,
             bangLazy = False,
@@ -503,7 +521,7 @@ genSimpleBangType = do
     LazyAnnotation ->
       pure $
         BangType
-          { bangSpan = span0,
+          { bangAnns = [],
             bangSourceUnpackedness = NoSourceUnpackedness,
             bangStrict = False,
             bangLazy = True,
@@ -539,14 +557,14 @@ genNewtypePrefixCon :: Gen DataConDecl
 genNewtypePrefixCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
   ty <- genSimpleType
-  pure (PrefixCon [] [] conName [BangType span0 NoSourceUnpackedness False False ty])
+  pure (PrefixCon [] [] conName [BangType [] NoSourceUnpackedness False False ty])
 
 genNewtypeRecordCon :: Gen DataConDecl
 genNewtypeRecordCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
   fieldName <- genVarBinderName
   ty <- genSimpleType
-  pure (RecordCon [] [] conName [FieldDecl span0 [fieldName] (BangType span0 NoSourceUnpackedness False False ty)])
+  pure (RecordCon [] [] conName [FieldDecl [] [fieldName] (BangType [] NoSourceUnpackedness False False ty)])
 
 genDeclClass :: Gen Decl
 genDeclClass = oneof [genDeclClassPrefix, genDeclClassInfix]
@@ -620,8 +638,7 @@ genAssociatedTypeDefaultInst tf classParams =
           lhs = foldl TApp (typeFamilyDeclHead tf) argTypes
       pure $
         TypeFamilyInst
-          { typeFamilyInstSpan = span0,
-            typeFamilyInstForall = [],
+          { typeFamilyInstForall = [],
             typeFamilyInstHeadForm = typeFamilyDeclHeadForm tf,
             typeFamilyInstLhs = lhs,
             typeFamilyInstRhs = rhs
@@ -633,8 +650,8 @@ genDeclClassInfix = do
   lhsName <- genIdent
   rhsName <- genIdent
   ctx <- genOptionalSimpleContext
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
       params = [lhs, rhs]
   items <- genClassDeclItems params
   pure $
@@ -822,8 +839,8 @@ genDeclTypeFamilyDeclInfix = do
   name <- nameText
   lhsName <- genIdent
   rhsName <- genIdent
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
       lhsType = TVar (mkUnqualifiedName NameVarId lhsName)
       rhsType = TVar (mkUnqualifiedName NameVarId rhsName)
       headType = TApp (TApp (TCon (qualifyName Nothing (mkUnqualifiedName nameType name)) Unpromoted) lhsType) rhsType
@@ -863,8 +880,7 @@ genDeclTypeFamilyInstPrefix = do
   pure $
     DeclTypeFamilyInst $
       TypeFamilyInst
-        { typeFamilyInstSpan = span0,
-          typeFamilyInstForall = [],
+        { typeFamilyInstForall = [],
           typeFamilyInstHeadForm = TypeHeadPrefix,
           typeFamilyInstLhs = lhs,
           typeFamilyInstRhs = rhs
@@ -879,8 +895,7 @@ genDeclTypeFamilyInstInfix = do
   pure $
     DeclTypeFamilyInst $
       TypeFamilyInst
-        { typeFamilyInstSpan = span0,
-          typeFamilyInstForall = [],
+        { typeFamilyInstForall = [],
           typeFamilyInstHeadForm = TypeHeadInfix,
           typeFamilyInstLhs = TApp (TApp (TCon op Unpromoted) lhsArg) rhsArg,
           typeFamilyInstRhs = rhs
@@ -901,8 +916,7 @@ genDeclDataFamilyInstPrefix = do
   pure $
     DeclDataFamilyInst $
       DataFamilyInst
-        { dataFamilyInstSpan = span0,
-          dataFamilyInstIsNewtype = False,
+        { dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
           dataFamilyInstKind = kind,
@@ -918,8 +932,7 @@ genDeclDataFamilyInstGadt = do
   pure $
     DeclDataFamilyInst $
       DataFamilyInst
-        { dataFamilyInstSpan = span0,
-          dataFamilyInstIsNewtype = False,
+        { dataFamilyInstIsNewtype = False,
           dataFamilyInstForall = [],
           dataFamilyInstHead = head',
           dataFamilyInstKind = kind,
@@ -1022,7 +1035,7 @@ genDeclStandaloneKindSig = do
 genSimpleTyVarBinders :: Gen [TyVarBinder]
 genSimpleTyVarBinders = do
   n <- chooseInt (0, 2)
-  vectorOf n (TyVarBinder span0 <$> genIdent <*> pure Nothing <*> pure TyVarBSpecified)
+  vectorOf n (TyVarBinder [] <$> genIdent <*> pure Nothing <*> pure TyVarBSpecified)
 
 -- | Generate a simple type for use in declaration contexts.
 genSimpleType :: Gen Type
@@ -1145,24 +1158,24 @@ shrinkDecl decl =
 shrinkValueDecl :: ValueDecl -> [ValueDecl]
 shrinkValueDecl vd =
   case vd of
-    PatternBind _ pat rhs ->
-      [PatternBind span0 pat rhs' | rhs' <- shrinkRhs rhs]
-        <> [PatternBind span0 pat' rhs | pat' <- shrinkPattern pat]
-    FunctionBind _ name matches ->
+    PatternBind pat rhs ->
+      [PatternBind pat rhs' | rhs' <- shrinkRhs rhs]
+        <> [PatternBind pat' rhs | pat' <- shrinkPattern pat]
+    FunctionBind name matches ->
       -- Shrink multiple matches to a single match
-      [FunctionBind span0 name [m {matchSpan = span0}] | length matches > 1, m <- matches]
+      [FunctionBind name [m {matchAnns = []}] | length matches > 1, m <- matches]
         -- Shrink the list of matches
-        <> [FunctionBind span0 name ms' | ms' <- shrinkList shrinkMatch matches, not (null ms')]
+        <> [FunctionBind name ms' | ms' <- shrinkList shrinkMatch matches, not (null ms')]
         -- Shrink the function name
-        <> [FunctionBind span0 name' matches | name' <- shrinkBinderName name]
+        <> [FunctionBind name' matches | name' <- shrinkBinderName name]
 
 -- | Shrink an individual match clause.
 shrinkMatch :: Match -> [Match]
 shrinkMatch match =
   -- Shrink the RHS
-  [match {matchSpan = span0, matchRhs = rhs'} | rhs' <- shrinkRhs (matchRhs match)]
+  [match {matchAnns = [], matchRhs = rhs'} | rhs' <- shrinkRhs (matchRhs match)]
     -- Shrink the patterns
-    <> [match {matchSpan = span0, matchPats = pats'} | pats' <- shrinkFunctionHeadPats (matchHeadForm match) (matchPats match)]
+    <> [match {matchAnns = [], matchPats = pats'} | pats' <- shrinkFunctionHeadPats (matchHeadForm match) (matchPats match)]
 
 -- ---------------------------------------------------------------------------
 -- Right-hand sides
@@ -1175,20 +1188,20 @@ shrinkRhs rhs =
   case rhs of
     UnguardedRhs _ expr mWhere ->
       -- Drop the where clause first (big win)
-      [UnguardedRhs span0 expr Nothing | isJust mWhere]
+      [UnguardedRhs [] expr Nothing | isJust mWhere]
         -- Shrink the expression
-        <> [UnguardedRhs span0 expr' mWhere | expr' <- shrinkExpr expr]
+        <> [UnguardedRhs [] expr' mWhere | expr' <- shrinkExpr expr]
         -- Shrink the where clause
-        <> [UnguardedRhs span0 expr (Just ds') | Just ds <- [mWhere], ds' <- shrinkWhereDecls ds]
+        <> [UnguardedRhs [] expr (Just ds') | Just ds <- [mWhere], ds' <- shrinkWhereDecls ds]
     GuardedRhss _ grhss mWhere ->
       -- Collapse to unguarded using the first guard's body
-      [UnguardedRhs span0 (guardedRhsBody firstGrhs) Nothing | firstGrhs : _ <- [grhss]]
+      [UnguardedRhs [] (guardedRhsBody firstGrhs) Nothing | firstGrhs : _ <- [grhss]]
         -- Drop the where clause
-        <> [GuardedRhss span0 grhss Nothing | isJust mWhere]
+        <> [GuardedRhss [] grhss Nothing | isJust mWhere]
         -- Shrink the guard list (keep at least one)
-        <> [GuardedRhss span0 grhss' mWhere | grhss' <- shrinkList shrinkGuardedRhs grhss, not (null grhss')]
+        <> [GuardedRhss [] grhss' mWhere | grhss' <- shrinkList shrinkGuardedRhs grhss, not (null grhss')]
         -- Shrink the where clause
-        <> [GuardedRhss span0 grhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkWhereDecls ds]
+        <> [GuardedRhss [] grhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkWhereDecls ds]
 
 -- | Shrink a where-clause declaration list (keep at least one decl).
 shrinkWhereDecls :: [Decl] -> [[Decl]]

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -348,7 +348,7 @@ genCaseAltWith allowTHQuotes n = do
   rhs <- genRhsWith allowTHQuotes half
   pure $
     CaseAlt
-      { caseAltSpan = span0,
+      { caseAltAnns = [],
         caseAltPattern = pat,
         caseAltRhs = rhs
       }
@@ -358,8 +358,8 @@ genCaseAltWith allowTHQuotes n = do
 genRhsWith :: Bool -> Int -> Gen Rhs
 genRhsWith allowTHQuotes n =
   oneof
-    [ (\e -> UnguardedRhs span0 e Nothing) <$> genBindingExprWith allowTHQuotes n,
-      (\gs -> GuardedRhss span0 gs Nothing) <$> genGuardedRhsListWith allowTHQuotes n
+    [ (\e -> UnguardedRhs [] e Nothing) <$> genBindingExprWith allowTHQuotes n,
+      (\gs -> GuardedRhss [] gs Nothing) <$> genGuardedRhsListWith allowTHQuotes n
     ]
 
 genGuardedRhsListWith :: Bool -> Int -> Gen [GuardedRhs]
@@ -374,7 +374,7 @@ genGuardedRhsWith allowTHQuotes n = do
   body <- genBindingExprWith allowTHQuotes half
   pure $
     GuardedRhs
-      { guardedRhsSpan = span0,
+      { guardedRhsAnns = [],
         guardedRhsGuards = guards,
         guardedRhsBody = body
       }
@@ -425,7 +425,7 @@ genPatternBindDecl allowTHQuotes n = do
   rhs <- genRhsWith allowTHQuotes half
   pure $
     DeclValue
-      (PatternBind span0 pat rhs)
+      (PatternBind pat rhs)
   where
     half = n `div` 2
 
@@ -442,10 +442,9 @@ genFunctionBindDecl allowTHQuotes n = do
   pure $
     DeclValue
       ( FunctionBind
-          span0
           name
           [ Match
-              { matchSpan = span0,
+              { matchAnns = [],
                 matchHeadForm = MatchHeadPrefix,
                 matchPats = pats,
                 matchRhs = rhs
@@ -800,11 +799,11 @@ shrinkCaseAlt :: CaseAlt -> [CaseAlt]
 shrinkCaseAlt alt =
   case caseAltRhs alt of
     UnguardedRhs _ expr _ ->
-      [alt {caseAltRhs = UnguardedRhs span0 expr' Nothing} | expr' <- shrinkExpr expr]
+      [alt {caseAltRhs = UnguardedRhs [] expr' Nothing} | expr' <- shrinkExpr expr]
     GuardedRhss _ rhss _ ->
       -- Shrink to unguarded using the first guard's body
-      [alt {caseAltRhs = UnguardedRhs span0 (guardedRhsBody firstRhs) Nothing} | firstRhs : _ <- [rhss]]
-        <> [alt {caseAltRhs = GuardedRhss span0 rhss' Nothing} | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
+      [alt {caseAltRhs = UnguardedRhs [] (guardedRhsBody firstRhs) Nothing} | firstRhs : _ <- [rhss]]
+        <> [alt {caseAltRhs = GuardedRhss [] rhss' Nothing} | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
 
 shrinkGuardedRhs :: GuardedRhs -> [GuardedRhs]
 shrinkGuardedRhs grhs =
@@ -830,14 +829,14 @@ shrinkLetDecl :: Decl -> [Decl]
 shrinkLetDecl decl =
   case decl of
     DeclAnn _ inner -> inner : shrinkLetDecl inner
-    DeclValue (PatternBind _ pat rhs) ->
-      [DeclValue (PatternBind span0 pat rhs') | rhs' <- shrinkLetRhs rhs]
-        <> [DeclValue (PatternBind span0 pat' rhs) | pat' <- shrinkPattern pat]
-    DeclValue (FunctionBind _ name matches) ->
+    DeclValue (PatternBind pat rhs) ->
+      [DeclValue (PatternBind pat rhs') | rhs' <- shrinkLetRhs rhs]
+        <> [DeclValue (PatternBind pat' rhs) | pat' <- shrinkPattern pat]
+    DeclValue (FunctionBind name matches) ->
       -- Shrink multiple matches to a single match
-      [DeclValue (FunctionBind span0 name [m {matchSpan = span0}]) | length matches > 1, m <- matches]
+      [DeclValue (FunctionBind name [m {matchAnns = []}]) | length matches > 1, m <- matches]
         -- Shrink individual matches
-        <> [DeclValue (FunctionBind span0 name ms') | ms' <- shrinkList shrinkLetMatch matches, not (null ms')]
+        <> [DeclValue (FunctionBind name ms') | ms' <- shrinkList shrinkLetMatch matches, not (null ms')]
     DeclTypeSig names ty ->
       [DeclTypeSig names ty' | ty' <- shrinkType ty]
     _ -> []
@@ -845,22 +844,22 @@ shrinkLetDecl decl =
 -- | Shrink a match clause within let/where/TH contexts.
 shrinkLetMatch :: Match -> [Match]
 shrinkLetMatch match =
-  [match {matchSpan = span0, matchRhs = rhs'} | rhs' <- shrinkLetRhs (matchRhs match)]
+  [match {matchAnns = [], matchRhs = rhs'} | rhs' <- shrinkLetRhs (matchRhs match)]
 
 -- | Shrink an RHS within let/where/TH contexts.
 shrinkLetRhs :: Rhs -> [Rhs]
 shrinkLetRhs rhs =
   case rhs of
     UnguardedRhs _ expr mWhere ->
-      [UnguardedRhs span0 expr Nothing | isJust mWhere]
-        <> [UnguardedRhs span0 expr' mWhere | expr' <- shrinkExpr expr]
-        <> [UnguardedRhs span0 expr (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
+      [UnguardedRhs [] expr Nothing | isJust mWhere]
+        <> [UnguardedRhs [] expr' mWhere | expr' <- shrinkExpr expr]
+        <> [UnguardedRhs [] expr (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
     GuardedRhss _ rhss mWhere ->
       -- Collapse to unguarded using the first guard's body
-      [UnguardedRhs span0 (guardedRhsBody firstRhs) Nothing | firstRhs : _ <- [rhss]]
-        <> [GuardedRhss span0 rhss Nothing | isJust mWhere]
-        <> [GuardedRhss span0 rhss' mWhere | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
-        <> [GuardedRhss span0 rhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
+      [UnguardedRhs [] (guardedRhsBody firstRhs) Nothing | firstRhs : _ <- [rhss]]
+        <> [GuardedRhss [] rhss Nothing | isJust mWhere]
+        <> [GuardedRhss [] rhss' mWhere | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
+        <> [GuardedRhss [] rhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
 
 shrinkDoStmts :: [DoStmt Expr] -> [[DoStmt Expr]]
 shrinkDoStmts stmts =

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -16,7 +16,7 @@ import Data.Char (isUpper)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Decl ()
-import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator, span0)
+import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
 import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
 import Test.QuickCheck
 
@@ -28,7 +28,7 @@ instance Arbitrary Module where
     decls <- vectorOf n arbitrary
     pure $
       Module
-        { moduleSpan = span0,
+        { moduleAnns = [],
           moduleHead = mHead,
           moduleLanguagePragmas = [],
           moduleImports = imports,
@@ -63,7 +63,7 @@ genModuleHead = do
   warningText <- frequency [(4, pure Nothing), (1, Just <$> arbitrary)]
   pure $
     ModuleHead
-      { moduleHeadSpan = span0,
+      { moduleHeadAnns = [],
         moduleHeadName = name,
         moduleHeadWarningText = warningText,
         moduleHeadExports = exports
@@ -207,7 +207,7 @@ instance Arbitrary IEBundledNamespace where
 
 instance Arbitrary ImportSpec where
   arbitrary =
-    ImportSpec span0
+    ImportSpec []
       <$> arbitrary
       <*> genImportItems
 
@@ -306,7 +306,7 @@ instance Arbitrary ImportDecl where
     spec <- genMaybeImportSpec
     pure $
       ImportDecl
-        { importDeclSpan = span0,
+        { importDeclAnns = [],
           importDeclLevel = Nothing,
           importDeclPackage = Nothing,
           importDeclSource = False,

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -21,7 +21,6 @@ import Test.Properties.Arb.Identifiers
     genQuoterName,
     shrinkConIdent,
     shrinkIdent,
-    span0,
   )
 import Test.QuickCheck
 
@@ -220,17 +219,17 @@ genTyVarBinder = do
   name <- genTypeVarName
   oneof
     [ -- Plain specified binder: a
-      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBSpecified),
+      pure (TyVarBinder [] (renderUnqualifiedName name) Nothing TyVarBSpecified),
       -- Plain inferred binder: {a}
-      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBInferred),
+      pure (TyVarBinder [] (renderUnqualifiedName name) Nothing TyVarBInferred),
       -- Kinded inferred binder: {a :: Kind}
       do
         kind <- genSimpleTypeAtom 0
-        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBInferred),
+        pure (TyVarBinder [] (renderUnqualifiedName name) (Just kind) TyVarBInferred),
       -- Kinded specified binder: (a :: Kind)
       do
         kind <- genSimpleTypeAtom 0
-        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBSpecified)
+        pure (TyVarBinder [] (renderUnqualifiedName name) (Just kind) TyVarBSpecified)
     ]
 
 genTypeVarName :: Gen UnqualifiedName

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -438,7 +438,7 @@ normalizeDataConInner (GadtCon forallBinders constraints names body) =
 normalizeBangType :: BangType -> BangType
 normalizeBangType bt =
   BangType
-    { bangAnns = bangAnns bt,
+    { bangAnns = [],
       bangSourceUnpackedness = bangSourceUnpackedness bt,
       bangStrict = bangStrict bt,
       bangLazy = bangLazy bt,
@@ -448,7 +448,7 @@ normalizeBangType bt =
 normalizeFieldDecl :: FieldDecl -> FieldDecl
 normalizeFieldDecl fd =
   FieldDecl
-    { fieldAnns = fieldAnns fd,
+    { fieldAnns = [],
       fieldNames = fieldNames fd,
       fieldType = normalizeBangType (fieldType fd)
     }

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -72,7 +72,7 @@ normalizeExpr expr =
 normalizeCaseAlt :: CaseAlt -> CaseAlt
 normalizeCaseAlt alt =
   CaseAlt
-    { caseAltSpan = span0,
+    { caseAltAnns = [],
       caseAltPattern = normalizePattern (caseAltPattern alt),
       caseAltRhs = normalizeRhs (caseAltRhs alt)
     }
@@ -80,13 +80,13 @@ normalizeCaseAlt alt =
 normalizeRhs :: Rhs -> Rhs
 normalizeRhs rhs =
   case rhs of
-    UnguardedRhs _ body mDecls -> UnguardedRhs span0 (normalizeExpr body) (fmap (map normalizeDecl) mDecls)
-    GuardedRhss _ guards mDecls -> GuardedRhss span0 (map normalizeGuardedRhs guards) (fmap (map normalizeDecl) mDecls)
+    UnguardedRhs _ body mDecls -> UnguardedRhs [] (normalizeExpr body) (fmap (map normalizeDecl) mDecls)
+    GuardedRhss _ guards mDecls -> GuardedRhss [] (map normalizeGuardedRhs guards) (fmap (map normalizeDecl) mDecls)
 
 normalizeGuardedRhs :: GuardedRhs -> GuardedRhs
 normalizeGuardedRhs grhs =
   GuardedRhs
-    { guardedRhsSpan = span0,
+    { guardedRhsAnns = [],
       guardedRhsGuards = map normalizeGuardQualifier (guardedRhsGuards grhs),
       guardedRhsBody = normalizeExpr (guardedRhsBody grhs)
     }
@@ -185,15 +185,15 @@ normalizeDecl decl =
 normalizeValueDecl :: ValueDecl -> ValueDecl
 normalizeValueDecl vdecl =
   case vdecl of
-    PatternBind _ pat rhs -> PatternBind span0 (normalizePattern pat) (normalizeRhs rhs)
-    FunctionBind _ name [Match {matchHeadForm = MatchHeadPrefix, matchPats = [], matchRhs = rhs}] ->
-      PatternBind span0 (PVar name) (normalizeRhs rhs)
-    FunctionBind _ name matches -> FunctionBind span0 name (map normalizeMatch matches)
+    PatternBind pat rhs -> PatternBind (normalizePattern pat) (normalizeRhs rhs)
+    FunctionBind name [Match {matchHeadForm = MatchHeadPrefix, matchPats = [], matchRhs = rhs}] ->
+      PatternBind (PVar name) (normalizeRhs rhs)
+    FunctionBind name matches -> FunctionBind name (map normalizeMatch matches)
 
 normalizeMatch :: Match -> Match
 normalizeMatch m =
   Match
-    { matchSpan = span0,
+    { matchAnns = [],
       matchHeadForm = matchHeadForm m,
       matchPats = map normalizeFunctionHeadPat (matchPats m),
       matchRhs = normalizeRhs (matchRhs m)
@@ -285,7 +285,7 @@ normalizeDoCmdStmtInner (DoRecStmt stmts) = DoRecStmt (map normalizeDoCmdStmt st
 normalizeCmdCaseAlt :: CmdCaseAlt -> CmdCaseAlt
 normalizeCmdCaseAlt alt =
   alt
-    { cmdCaseAltSpan = span0,
+    { cmdCaseAltAnns = [],
       cmdCaseAltPat = normalizePattern (cmdCaseAltPat alt),
       cmdCaseAltBody = normalizeCmd (cmdCaseAltBody alt)
     }
@@ -359,7 +359,7 @@ normalizeType ty =
 normalizeTyVarBinder :: TyVarBinder -> TyVarBinder
 normalizeTyVarBinder tvb =
   tvb
-    { tyVarBinderSpan = span0,
+    { tyVarBinderAnns = [],
       tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
     }
 
@@ -438,7 +438,7 @@ normalizeDataConInner (GadtCon forallBinders constraints names body) =
 normalizeBangType :: BangType -> BangType
 normalizeBangType bt =
   BangType
-    { bangSpan = span0,
+    { bangAnns = bangAnns bt,
       bangSourceUnpackedness = bangSourceUnpackedness bt,
       bangStrict = bangStrict bt,
       bangLazy = bangLazy bt,
@@ -448,7 +448,7 @@ normalizeBangType bt =
 normalizeFieldDecl :: FieldDecl -> FieldDecl
 normalizeFieldDecl fd =
   FieldDecl
-    { fieldSpan = span0,
+    { fieldAnns = fieldAnns fd,
       fieldNames = fieldNames fd,
       fieldType = normalizeBangType (fieldType fd)
     }
@@ -475,12 +475,9 @@ normalizeClassDecl decl =
       classDeclHeadForm = classDeclHeadForm decl,
       classDeclName = classDeclName decl,
       classDeclParams = map normalizeTyVarBinder (classDeclParams decl),
-      classDeclFundeps = map normalizeFunctionalDependency (classDeclFundeps decl),
+      classDeclFundeps = classDeclFundeps decl,
       classDeclItems = map normalizeClassDeclItem (classDeclItems decl)
     }
-
-normalizeFunctionalDependency :: FunctionalDependency -> FunctionalDependency
-normalizeFunctionalDependency dep = dep {functionalDependencySpan = span0}
 
 normalizeClassDeclItem :: ClassDeclItem -> ClassDeclItem
 normalizeClassDeclItem item =
@@ -561,7 +558,7 @@ normalizeTypeFamilyDecl tf =
 normalizeTypeFamilyEq :: TypeFamilyEq -> TypeFamilyEq
 normalizeTypeFamilyEq eq =
   TypeFamilyEq
-    { typeFamilyEqSpan = span0,
+    { typeFamilyEqAnns = typeFamilyEqAnns eq,
       typeFamilyEqForall = map normalizeTyVarBinder (typeFamilyEqForall eq),
       typeFamilyEqHeadForm = typeFamilyEqHeadForm eq,
       typeFamilyEqLhs = normalizeType (typeFamilyEqLhs eq),
@@ -579,8 +576,7 @@ normalizeDataFamilyDecl df =
 normalizeTypeFamilyInst :: TypeFamilyInst -> TypeFamilyInst
 normalizeTypeFamilyInst tfi =
   TypeFamilyInst
-    { typeFamilyInstSpan = span0,
-      typeFamilyInstForall = map normalizeTyVarBinder (typeFamilyInstForall tfi),
+    { typeFamilyInstForall = map normalizeTyVarBinder (typeFamilyInstForall tfi),
       typeFamilyInstHeadForm = typeFamilyInstHeadForm tfi,
       typeFamilyInstLhs = normalizeType (typeFamilyInstLhs tfi),
       typeFamilyInstRhs = normalizeType (typeFamilyInstRhs tfi)
@@ -589,8 +585,7 @@ normalizeTypeFamilyInst tfi =
 normalizeDataFamilyInst :: DataFamilyInst -> DataFamilyInst
 normalizeDataFamilyInst dfi =
   DataFamilyInst
-    { dataFamilyInstSpan = span0,
-      dataFamilyInstIsNewtype = dataFamilyInstIsNewtype dfi,
+    { dataFamilyInstIsNewtype = dataFamilyInstIsNewtype dfi,
       dataFamilyInstForall = map normalizeTyVarBinder (dataFamilyInstForall dfi),
       dataFamilyInstHead = normalizeType (dataFamilyInstHead dfi),
       dataFamilyInstKind = fmap normalizeType (dataFamilyInstKind dfi),

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -12,7 +12,7 @@ import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Arb.Module ()
-import Test.Properties.ExprHelpers (normalizeDecl, span0)
+import Test.Properties.ExprHelpers (normalizeDecl)
 import Test.QuickCheck
 
 prop_modulePrettyRoundTrip :: Module -> Property
@@ -38,7 +38,7 @@ moduleConfig =
 normalizeModule :: Module -> Module
 normalizeModule modu =
   Module
-    { moduleSpan = span0,
+    { moduleAnns = [],
       moduleHead = fmap normalizeModuleHead (moduleHead modu),
       moduleLanguagePragmas = [],
       moduleImports = map normalizeImportDecl (moduleImports modu),
@@ -48,7 +48,7 @@ normalizeModule modu =
 normalizeModuleHead :: ModuleHead -> ModuleHead
 normalizeModuleHead head' =
   ModuleHead
-    { moduleHeadSpan = span0,
+    { moduleHeadAnns = [],
       moduleHeadName = moduleHeadName head',
       moduleHeadWarningText = fmap normalizeWarningText (moduleHeadWarningText head'),
       moduleHeadExports = fmap (map normalizeExportSpec) (moduleHeadExports head')
@@ -78,7 +78,7 @@ normalizeWarningText warningText =
 normalizeImportDecl :: ImportDecl -> ImportDecl
 normalizeImportDecl decl =
   ImportDecl
-    { importDeclSpan = span0,
+    { importDeclAnns = [],
       importDeclLevel = importDeclLevel decl,
       importDeclPackage = importDeclPackage decl,
       importDeclSource = importDeclSource decl,
@@ -93,7 +93,7 @@ normalizeImportDecl decl =
 normalizeImportSpec :: ImportSpec -> ImportSpec
 normalizeImportSpec spec =
   ImportSpec
-    { importSpecSpan = span0,
+    { importSpecAnns = [],
       importSpecHiding = importSpecHiding spec,
       importSpecItems = map normalizeImportItem (importSpecItems spec)
     }

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -14,7 +14,7 @@ import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Arb.Pattern ()
 import Test.Properties.Coverage (assertCtorCoverage)
-import Test.Properties.ExprHelpers (normalizeExpr, span0)
+import Test.Properties.ExprHelpers (normalizeExpr)
 import Test.QuickCheck
 import Text.Megaparsec.Error qualified as MPE
 
@@ -126,6 +126,6 @@ normalizeAsInner pat =
 normalizeTyVarBinderSpan :: TyVarBinder -> TyVarBinder
 normalizeTyVarBinderSpan tvb =
   tvb
-    { tyVarBinderSpan = span0,
+    { tyVarBinderAnns = [],
       tyVarBinderKind = fmap normalizeTypeSpan (tyVarBinderKind tvb)
     }

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -14,7 +14,7 @@ import Data.Text qualified as T
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Properties.Coverage (assertCtorCoverage)
-import Test.Properties.ExprHelpers (normalizeExpr, span0)
+import Test.Properties.ExprHelpers (normalizeExpr)
 import Test.QuickCheck
 import Text.Megaparsec.Error qualified as MPE
 
@@ -69,7 +69,7 @@ normalizeType ty =
 normalizeTyVarBinder :: TyVarBinder -> TyVarBinder
 normalizeTyVarBinder tvb =
   tvb
-    { tyVarBinderSpan = span0,
+    { tyVarBinderAnns = [],
       tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
     }
 

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -47,6 +47,7 @@ import Aihc.Parser.Syntax
     UnqualifiedName,
     ValueDecl (..),
     fromAnnotation,
+    mergeSourceSpans,
     mkAnnotation,
     mkQualifiedName,
     mkUnqualifiedName,
@@ -58,7 +59,7 @@ import Aihc.Parser.Syntax
 import Aihc.Resolve.Types
 import Data.List (mapAccumL)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -72,6 +73,13 @@ effectiveResolutionSpan ambient localSpan =
   case localSpan of
     NoSourceSpan -> ambient
     _ -> localSpan
+
+-- | Merge concrete source spans embedded in a list of annotations.
+sourceSpanFromAnns :: [Annotation] -> SourceSpan
+sourceSpanFromAnns anns =
+  case mapMaybe (fromAnnotation @SourceSpan) anns of
+    [] -> NoSourceSpan
+    s : ss -> foldl mergeSourceSpans s ss
 
 -- | Resolver-owned span tracking for nodes that now store source spans only in
 -- annotations.
@@ -98,8 +106,8 @@ peelDataConSpan ambient _ = ambient
 rhsSpan :: Rhs -> SourceSpan
 rhsSpan rhs =
   case rhs of
-    UnguardedRhs span' _ _ -> span'
-    GuardedRhss span' _ _ -> span'
+    UnguardedRhs anns _ _ -> sourceSpanFromAnns anns
+    GuardedRhss anns _ _ -> sourceSpanFromAnns anns
 
 data Scope = Scope
   { scopeTerms :: Map.Map Text ResolvedName,
@@ -186,14 +194,14 @@ resolveDeclCore scope nextLocal lastSeen decl =
   case decl of
     DeclValue valueDecl ->
       case valueDecl of
-        FunctionBind bindSpan name matches ->
-          let ambient = effectiveResolutionSpan lastSeen bindSpan
+        FunctionBind name matches ->
+          let ambient = effectiveResolutionSpan lastSeen NoSourceSpan
               (nextLocal', matches') = mapAccumL (resolveMatch scope ambient) nextLocal matches
-           in (nextLocal', DeclValue (FunctionBind bindSpan name matches'))
-        PatternBind bindSpan pat rhs ->
-          let ambient = effectiveResolutionSpan lastSeen bindSpan
+           in (nextLocal', DeclValue (FunctionBind name matches'))
+        PatternBind pat rhs ->
+          let ambient = effectiveResolutionSpan lastSeen NoSourceSpan
               (nextLocal', rhs') = resolveRhs scope nextLocal ambient rhs
-           in (nextLocal', DeclValue (PatternBind bindSpan pat rhs'))
+           in (nextLocal', DeclValue (PatternBind pat rhs'))
     DeclTypeSig names ty ->
       let ty' = resolveTypeAt scope lastSeen ty
        in (nextLocal, DeclTypeSig names ty')
@@ -217,7 +225,7 @@ resolveDeclCore scope nextLocal lastSeen decl =
 
 resolveMatch :: Scope -> SourceSpan -> Int -> Match -> (Int, Match)
 resolveMatch scope ambient nextLocal match =
-  let here = effectiveResolutionSpan ambient (matchSpan match)
+  let here = effectiveResolutionSpan ambient (sourceSpanFromAnns (matchAnns match))
       (nextLocal', patScope, pats') = bindPatterns scope here nextLocal (matchPats match)
       scoped = unionScope patScope scope
       rhsHere = effectiveResolutionSpan here (rhsSpan (matchRhs match))
@@ -227,16 +235,16 @@ resolveMatch scope ambient nextLocal match =
 resolveRhs :: Scope -> Int -> SourceSpan -> Rhs -> (Int, Rhs)
 resolveRhs scope nextLocal ambient rhs =
   case rhs of
-    UnguardedRhs span' expr mDecls ->
-      let bodyHere = effectiveResolutionSpan ambient span'
+    UnguardedRhs anns expr mDecls ->
+      let bodyHere = effectiveResolutionSpan ambient (sourceSpanFromAnns anns)
           (nextLocal', expr') = resolveExprAt scope nextLocal bodyHere expr
           (nextLocal'', mDecls') = resolveWhereDecls scope nextLocal' mDecls
-       in (nextLocal'', UnguardedRhs span' expr' mDecls')
-    GuardedRhss span' guardedRhss mDecls ->
-      let here = effectiveResolutionSpan ambient span'
+       in (nextLocal'', UnguardedRhs anns expr' mDecls')
+    GuardedRhss anns guardedRhss mDecls ->
+      let here = effectiveResolutionSpan ambient (sourceSpanFromAnns anns)
           (nextLocal', guardedRhss') = mapAccumL (resolveGuardedRhs scope here) nextLocal guardedRhss
           (nextLocal'', mDecls') = resolveWhereDecls scope nextLocal' mDecls
-       in (nextLocal'', GuardedRhss span' guardedRhss' mDecls')
+       in (nextLocal'', GuardedRhss anns guardedRhss' mDecls')
 
 resolveWhereDecls :: Scope -> Int -> Maybe [Decl] -> (Int, Maybe [Decl])
 resolveWhereDecls _ nextLocal Nothing = (nextLocal, Nothing)
@@ -248,7 +256,7 @@ resolveWhereDecls scope nextLocal (Just decls) =
 
 resolveGuardedRhs :: Scope -> SourceSpan -> Int -> GuardedRhs -> (Int, GuardedRhs)
 resolveGuardedRhs scope ambient nextLocal guardedRhs =
-  let here = effectiveResolutionSpan ambient (guardedRhsSpan guardedRhs)
+  let here = effectiveResolutionSpan ambient (sourceSpanFromAnns (guardedRhsAnns guardedRhs))
       (nextLocal', scope', guards') = resolveGuardQualifiers scope nextLocal here (guardedRhsGuards guardedRhs)
       (nextLocal'', body') = resolveExprAt scope' nextLocal' here (guardedRhsBody guardedRhs)
    in (nextLocal'', guardedRhs {guardedRhsGuards = guards', guardedRhsBody = body'})
@@ -626,15 +634,15 @@ declBinderCandidate decl =
    in case innerDecl of
         DeclValue valueDecl ->
           case valueDecl of
-            FunctionBind span' name _ ->
-              let loc = effectiveResolutionSpan outerSp span'
+            FunctionBind name _ ->
+              let loc = effectiveResolutionSpan outerSp NoSourceSpan
                in Just (spanStartNameSpan loc (renderUnqualifiedName name), name)
-            PatternBind bindSp pat _ ->
+            PatternBind pat _ ->
               case peelPatternAnn pat of
                 PVar name ->
                   let loc =
                         effectiveResolutionSpan
-                          (effectiveResolutionSpan outerSp bindSp)
+                          (effectiveResolutionSpan outerSp NoSourceSpan)
                           (peelPatternSpan NoSourceSpan pat)
                    in Just (spanStartNameSpan loc (renderUnqualifiedName name), name)
                 _ -> Nothing
@@ -737,8 +745,8 @@ declExportedNames decl =
     DeclAnn _ inner -> declExportedNames inner
     DeclValue valueDecl ->
       case valueDecl of
-        FunctionBind _ name _ -> ([name], [])
-        PatternBind _ pat _ ->
+        FunctionBind name _ -> ([name], [])
+        PatternBind pat _ ->
           case peelPatternAnn pat of
             PVar name -> ([name], [])
             _ -> ([], [])

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -15,7 +15,6 @@ import Aihc.Parser.Syntax
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
-    HasSourceSpan (getSourceSpan),
     Match (..),
     Module (..),
     Name (..),
@@ -26,6 +25,8 @@ import Aihc.Parser.Syntax
     UnqualifiedName (..),
     ValueDecl (..),
     fromAnnotation,
+    getDeclSourceSpan,
+    getPatternSourceSpan,
     mergeSourceSpans,
     peelDeclAnn,
   )
@@ -90,7 +91,7 @@ extractFunctionBind :: Decl -> Maybe (SourceSpan, UnqualifiedName, [Match])
 extractFunctionBind decl =
   case peelDeclAnn decl of
     DeclValue (FunctionBind name matches) ->
-      let sp = getSourceSpan decl
+      let sp = getDeclSourceSpan decl
        in Just (sp, name, matches)
     _ -> Nothing
 
@@ -268,7 +269,7 @@ inferPatCts pat scrutTy = case pat of
         (conTy, _preds) <- instantiateSch scheme
         let conResTy = resultType conTy
         ev <- freshEvVar
-        let sp = getSourceSpan pat
+        let sp = getPatternSourceSpan pat
         pure [mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp]
       _ -> pure []
   PAnn _ann inner -> inferPatCts inner scrutTy

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Constraint generation for declarations.
 --
@@ -10,7 +11,8 @@ module Aihc.Tc.Generate.Decl
 where
 
 import Aihc.Parser.Syntax
-  ( DataConDecl (..),
+  ( Annotation,
+    DataConDecl (..),
     DataDecl (..),
     Decl (..),
     HasSourceSpan (getSourceSpan),
@@ -23,6 +25,8 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     UnqualifiedName (..),
     ValueDecl (..),
+    fromAnnotation,
+    mergeSourceSpans,
     peelDeclAnn,
   )
 import Aihc.Tc.Constraint
@@ -33,7 +37,15 @@ import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
+
+-- | Merge concrete source spans embedded in a list of annotations.
+sourceSpanFromAnns :: [Annotation] -> SourceSpan
+sourceSpanFromAnns anns =
+  case mapMaybe (fromAnnotation @SourceSpan) anns of
+    [] -> NoSourceSpan
+    s : ss -> foldl mergeSourceSpans s ss
 
 -- | Result of type-checking a single binding.
 data TcBindingResult = TcBindingResult
@@ -77,8 +89,8 @@ groupValueDecls (d : ds) = case extractFunctionBind d of
 extractFunctionBind :: Decl -> Maybe (SourceSpan, UnqualifiedName, [Match])
 extractFunctionBind decl =
   case peelDeclAnn decl of
-    DeclValue (FunctionBind fsp name matches) ->
-      let sp = case fsp of NoSourceSpan -> getSourceSpan decl; _ -> fsp
+    DeclValue (FunctionBind name matches) ->
+      let sp = getSourceSpan decl
        in Just (sp, name, matches)
     _ -> Nothing
 
@@ -165,7 +177,7 @@ tcDecl _ = pure []
 
 -- | Type-check a value declaration.
 tcValueDecl :: ValueDecl -> TcM [TcBindingResult]
-tcValueDecl (FunctionBind _fsp binder matches) = do
+tcValueDecl (FunctionBind binder matches) = do
   let name = unqualifiedNameText binder
       displayName = renderBinderName binder
   (ty, cts) <- tcMatches matches
@@ -177,7 +189,7 @@ tcValueDecl (FunctionBind _fsp binder matches) = do
   -- Register the binding so later bindings can reference it.
   extendTermEnvPermanent name (TcIdBinder name scheme)
   pure [TcBindingResult displayName zonkedTy]
-tcValueDecl (PatternBind _psp _pat rhs) = do
+tcValueDecl (PatternBind _pat rhs) = do
   ty <- tcRhs rhs
   zonkedTy <- zonkType ty
   pure [TcBindingResult "<pattern>" zonkedTy]
@@ -228,7 +240,7 @@ tcMatchEquation argTys resTy match = do
   (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.
   ev <- freshEvVar
-  let sp = matchSpan match
+  let sp = sourceSpanFromAnns (matchAnns match)
   let resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
   pure (patCts ++ rhsCts ++ [resCt])
 
@@ -237,7 +249,7 @@ unifyMatchRhs :: TcType -> Match -> TcM [Ct]
 unifyMatchRhs expectedTy match = do
   (rhsTy, rhsCts) <- inferRhsExpr (matchRhs match)
   ev <- freshEvVar
-  let sp = matchSpan match
+  let sp = sourceSpanFromAnns (matchAnns match)
   let eqCt = mkWantedCt (EqPred rhsTy expectedTy) ev (AppOrigin sp) sp
   pure (rhsCts ++ [eqCt])
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -22,7 +22,7 @@ import Aihc.Parser.Syntax
     Rhs (..),
     SourceSpan (..),
     UnqualifiedName (..),
-    getSourceSpan,
+    getExprSourceSpan,
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
@@ -38,7 +38,7 @@ import Data.Text qualified as T
 inferExpr :: Expr -> TcM (TcType, [Ct])
 inferExpr expr = case expr of
   -- Variables: look up in environment, instantiate if polymorphic.
-  EVar name -> inferVar (getSourceSpan expr) (nameToText name)
+  EVar name -> inferVar (getExprSourceSpan expr) (nameToText name)
   -- Integer literals: monomorphic Int for MVP.
   -- (Full version would use Num constraint.)
   EInt _ _ -> pure (intTyCon, [])
@@ -50,13 +50,13 @@ inferExpr expr = case expr of
   -- String literals.
   EString _ _ -> pure (stringTyCon, [])
   -- Lambda: \x -> body
-  ELambdaPats pats body -> inferLambda (getSourceSpan expr) pats body
+  ELambdaPats pats body -> inferLambda (getExprSourceSpan expr) pats body
   -- Lambda case: \case { pat -> body; ... }
-  ELambdaCase alts -> inferLambdaCase (getSourceSpan expr) alts
+  ELambdaCase alts -> inferLambdaCase (getExprSourceSpan expr) alts
   -- Application: f x
-  EApp fun arg -> inferApp (getSourceSpan expr) fun arg
+  EApp fun arg -> inferApp (getExprSourceSpan expr) fun arg
   -- If-then-else
-  EIf cond thenE elseE -> inferIf (getSourceSpan expr) cond thenE elseE
+  EIf cond thenE elseE -> inferIf (getExprSourceSpan expr) cond thenE elseE
   -- Let expression
   ELetDecls _decls body -> do
     -- MVP: infer body only (let bindings not yet processed).
@@ -77,12 +77,12 @@ inferExpr expr = case expr of
   -- Annotated expression (from other passes, e.g. resolve).
   EAnn _ann inner -> inferExpr inner
   -- Tuple
-  ETuple _flavor elems -> inferTuple (getSourceSpan expr) elems
+  ETuple _flavor elems -> inferTuple (getExprSourceSpan expr) elems
   -- List
-  EList elems -> inferList (getSourceSpan expr) elems
+  EList elems -> inferList (getExprSourceSpan expr) elems
   -- Unsupported expression forms for MVP.
   other -> do
-    let sp = getSourceSpan other
+    let sp = getExprSourceSpan other
     emitError sp (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
     ty <- freshMetaTv
     pure (ty, [])


### PR DESCRIPTION
## Summary

This change keeps the parser, name resolution, and the lightweight type-checker in sync with the current AST: `ValueDecl` uses two-argument `FunctionBind` and `PatternBind`, and several nodes now carry explicit annotation lists where the tree shape requires them.

## Progress counts

No changes to progress manifests or golden fixture totals in this pull request.

## Checks

Local `just check` (ormolu, hlint, full test suite with `-Werror`) passes.

## CodeRabbit

`coderabbit review --prompt-only` reported one item on the untracked local file `test.hs`, which is not part of this branch or the commit.
