### PR TITLE
feat(parser): support type abstractions and required type arguments

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -41,7 +41,7 @@ import Aihc.Parser.Lex
     TokenOrigin (..),
   )
 import Aihc.Parser.Pretty ()
-import Aihc.Parser.Syntax (Decl, Expr, Module (..), Pattern, SourceSpan (..), Type)
+import Aihc.Parser.Syntax (Decl, Expr, Module (..), Pattern, SourceSpan (..), Type, applyImpliedExtensions)
 import Aihc.Parser.Types
 import Data.ByteString qualified as BS
 import Data.List qualified as List
@@ -97,7 +97,7 @@ defaultConfig =
 -- "error"
 parseExpr :: ParserConfig -> Text -> ParseResult Expr
 parseExpr cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (exprParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right expr -> ParseOk expr
@@ -111,7 +111,7 @@ parseExpr cfg input =
 -- ParseOk (PCon "Just" [PVar "x"])
 parsePattern :: ParserConfig -> Text -> ParseResult Pattern
 parsePattern cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (patternParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right pat -> ParseOk pat
@@ -125,7 +125,7 @@ parsePattern cfg input =
 -- ParseOk (TApp (TCon "Maybe") (TVar "a"))
 parseType :: ParserConfig -> Text -> ParseResult Type
 parseType cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (typeParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right ty -> ParseOk ty
@@ -136,7 +136,7 @@ parseType cfg input =
 -- ParseOk (DeclValue (FunctionBind "f" [Match {headForm = Prefix, pats = [PVar "x"], rhs = UnguardedRhs (EInfix (EVar "x") "+" (EInt 1))}]))
 parseDecl :: ParserConfig -> Text -> ParseResult Decl
 parseDecl cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (declParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right decl -> ParseOk decl
@@ -156,7 +156,7 @@ parseDecl cfg input =
 -- Nothing
 parseModule :: ParserConfig -> Text -> ([(SourceSpan, Text)], Module)
 parseModule cfg input =
-  let ts = mkTokStreamModule (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStreamModule (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
       parser = do
         modu <- moduleParser
         _ <- eofTok

--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -34,9 +34,10 @@ checkPattern expr = case expr of
   -- Variables and constructors
   EVar name
     | nameText name == "_" -> Right PWildcard
-    | isConLikeName name -> Right (PCon name [])
+    | isConLikeName name -> Right (PCon name [] [])
     | isJust (nameQualifier name) -> Left "unexpected qualified name in pattern"
     | otherwise -> Right (PVar (mkUnqualifiedName (nameType name) (nameText name)))
+  ETypeSyntax form ty -> Right (PTypeSyntax form ty)
   -- Parenthesized expression
   -- When the inner expression is a view-pattern arrow (@expr -> expr@),
   -- produce @PParen (PView f pat)@ to preserve the explicit parens in
@@ -74,7 +75,7 @@ checkPattern expr = case expr of
     fPat <- checkPattern f
     xPat <- checkPattern x
     case peelPatternAnn fPat of
-      PCon name args -> Right (PCon name (args ++ [xPat]))
+      PCon name typeArgs args -> Right (PCon name typeArgs (args ++ [xPat]))
       _ -> Left "invalid pattern: application of non-constructor"
   -- Record construction -> record pattern
   ERecordCon name fields wc -> do
@@ -110,7 +111,11 @@ checkPattern expr = case expr of
   ESectionL {} -> Left "unexpected left section in pattern"
   ESectionR {} -> Left "unexpected right section in pattern"
   ERecordUpd {} -> Left "unexpected record update in pattern"
-  ETypeApp {} -> Left "unexpected type application in pattern"
+  ETypeApp fun ty -> do
+    funPat <- checkPattern fun
+    case peelPatternAnn funPat of
+      PCon name typeArgs args -> Right (PCon name (typeArgs ++ [ty]) args)
+      _ -> Left "unexpected type application in pattern"
   ETHExpQuote {} -> Left "unexpected Template Haskell expression quote in pattern"
   ETHTypedQuote {} -> Left "unexpected Template Haskell typed quote in pattern"
   ETHDeclQuote {} -> Left "unexpected Template Haskell declaration quote in pattern"

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -51,6 +51,7 @@ module Aihc.Parser.Internal.Common
     startsWithContextType,
     startsWithTypeSig,
     startsWithAsPattern,
+    startsWithTypeBinder,
     isConLikeName,
     isConLikeNameType,
     qualifiedVarName,
@@ -64,6 +65,7 @@ import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), TokStream (..), mkFoundToken)
 import Control.Monad (guard)
 import Data.Char (isUpper)
+import Data.Functor (($>))
 import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -802,6 +804,13 @@ startsWithAsPattern =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
     _ <- identifierTextParser
     expectedTok TkReservedAt
+
+startsWithTypeBinder :: TokParser Bool
+startsWithTypeBinder =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    expectedTok TkReservedAt
+    _ <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+    pure ()
 
 -- | Check whether a name looks like a constructor (starts with uppercase or ':').
 isConLikeName :: Name -> Bool

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -808,7 +808,7 @@ startsWithAsPattern =
 startsWithTypeBinder :: TokParser Bool
 startsWithTypeBinder =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    expectedTok TkReservedAt
+    MP.choice [expectedTok TkReservedAt, expectedTok TkTypeApp]
     _ <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
     pure ()
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -805,10 +805,15 @@ startsWithAsPattern =
     _ <- identifierTextParser
     expectedTok TkReservedAt
 
+-- | Non-consuming lookahead: does the input start with a type binder (@\@@var or @\@@_)?
+-- 'TypeAbstractions' implies 'TypeApplications', so the lexer emits 'TkTypeApp' when @\@@
+-- is preceded by whitespace (e.g. in @f @a@ or @type T @k@) and 'TkReservedAt' when there
+-- is no preceding whitespace (e.g. as-pattern @x@p@). Both tokens are checked here so that
+-- this lookahead remains safe even in contexts where 'TypeApplications' is absent.
 startsWithTypeBinder :: TokParser Bool
 startsWithTypeBinder =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    MP.choice [expectedTok TkReservedAt, expectedTok TkTypeApp]
+    MP.choice [expectedTok TkTypeApp, expectedTok TkReservedAt]
     _ <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
     pure ()
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -799,14 +799,14 @@ startsWithAsPattern =
     expectedTok TkReservedAt
 
 -- | Non-consuming lookahead: does the input start with a type binder (@\@@var or @\@@_)?
--- 'TypeAbstractions' implies 'TypeApplications', so the lexer emits 'TkTypeApp' when @\@@
--- is preceded by whitespace (e.g. in @f @a@ or @type T @k@) and 'TkReservedAt' when there
--- is no preceding whitespace (e.g. as-pattern @x@p@). Both tokens are checked here so that
--- this lookahead remains safe even in contexts where 'TypeApplications' is absent.
+-- 'TypeAbstractions' implies 'TypeApplications', so the lexer always emits 'TkTypeApp' (not
+-- 'TkReservedAt') for @\@@ preceded by whitespace. All valid type binder positions have
+-- whitespace before @\@@, so only 'TkTypeApp' is checked. Accepting 'TkReservedAt' here
+-- would produce false positives for as-patterns such as @x\@p@.
 startsWithTypeBinder :: TokParser Bool
 startsWithTypeBinder =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    MP.choice [expectedTok TkTypeApp, expectedTok TkReservedAt]
+    expectedTok TkTypeApp
     _ <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
     pure ()
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1294,7 +1294,7 @@ declTypeParamParser = MP.try invisibleDeclTypeParamParser <|> explicitForallBind
 
 invisibleDeclTypeParamParser :: TokParser TyVarBinder
 invisibleDeclTypeParamParser = withSpan $ do
-  expectedTok TkReservedAt
+  expectedTok TkTypeApp
   ( do
       ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
       pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBInvisible)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1268,7 +1268,7 @@ invisibleDeclTypeParamParser = withSpan $ do
   expectedTok TkTypeApp
   ( do
       ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
-      pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBInvisible)
+      pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBInvisible)
     )
     <|> do
       expectedTok TkSpecialLParen
@@ -1276,7 +1276,7 @@ invisibleDeclTypeParamParser = withSpan $ do
       expectedTok TkReservedDoubleColon
       kind <- typeParser
       expectedTok TkSpecialRParen
-      pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified TyVarBInvisible)
+      pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBInvisible)
 
 isTypeVarName :: Text -> Bool
 isTypeVarName name =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -12,11 +12,12 @@ import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (equationRhsParser, exprParser)
 import Aihc.Parser.Internal.Import (warningTextParser)
 import Aihc.Parser.Internal.Pattern (patternParser, simplePatternParser)
-import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
+import Aihc.Parser.Internal.Type (forallTelescopeParser, typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind, pattern TkVarFamily, pattern TkVarRole)
 import Aihc.Parser.Syntax
 import Control.Monad (when)
 import Data.Char (isLower)
+import Data.Functor (($>))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -219,7 +220,7 @@ contextPrefixDispatchList = do
 typeFamilyForallParser :: TokParser [TyVarBinder]
 typeFamilyForallParser = do
   expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
+  binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
   pure binders
 
@@ -228,7 +229,7 @@ typeFamilyForallParser = do
 instanceForallParser :: TokParser [TyVarBinder]
 instanceForallParser = do
   expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
+  binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
   pure binders
 
@@ -292,7 +293,7 @@ dataFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   varIdTok "family"
   name <- constructorUnqualifiedNameParser
-  params <- MP.many typeParamParser
+  params <- MP.many declTypeParamParser
   kind <- familyResultKindParser
   pure $
     DeclDataFamilyDecl
@@ -409,7 +410,7 @@ classDataFamilyDeclParser :: TokParser ClassDeclItem
 classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   name <- constructorUnqualifiedNameParser
-  params <- MP.many typeParamParser
+  params <- MP.many declTypeParamParser
   kind <- familyResultKindParser
   pure
     ( ClassItemDataFamilyDecl
@@ -974,7 +975,7 @@ gadtTypeDataConDeclParser = withSpan $ do
   names <- gadtConNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   -- Parse optional forall
-  forallBinders <- MP.option [] gadtForallParser
+  forallBinders <- MP.many gadtForallParser
   -- Parse context (only equality constraints permitted, but we parse generally)
   context <- contextPrefixDispatchList
   -- Parse the body (prefix only for type data - no record style)
@@ -1063,7 +1064,7 @@ gadtConDeclParser = withSpan $ do
   names <- gadtConNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   -- Parse optional forall
-  forallBinders <- MP.option [] gadtForallParser
+  forallBinders <- MP.many gadtForallParser
   -- Parse optional context
   context <- contextPrefixDispatchList
   -- Parse the body (record or prefix style)
@@ -1077,12 +1078,8 @@ gadtConNameParser =
     <|> parens constructorOperatorUnqualifiedNameParser
 
 -- | Parse forall in GADT context: @forall a b.@
-gadtForallParser :: TokParser [TyVarBinder]
-gadtForallParser = do
-  expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
-  expectedTok (TkVarSym ".")
-  pure binders
+gadtForallParser :: TokParser ForallTelescope
+gadtForallParser = forallTelescopeParser
 
 -- | Parse the body of a GADT constructor (after :: and optional forall/context)
 -- Can be either prefix style: @a -> b -> T a@
@@ -1154,22 +1151,22 @@ typeDeclHeadParser =
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
-      params <- MP.many typeParamParser
+      params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, name, params)
 
     infixDeclHeadParser = do
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       pure (TypeHeadInfix, op, [lhs, rhs])
 
     parenthesizedInfixDeclHeadParser = do
       expectedTok TkSpecialLParen
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       expectedTok TkSpecialRParen
-      tailParams <- MP.many typeParamParser
+      tailParams <- MP.many declTypeParamParser
       pure (TypeHeadInfix, op, [lhs, rhs] <> tailParams)
 
 typeSynonymOperatorParser :: TokParser Text
@@ -1192,13 +1189,13 @@ typeFamilyHeadParser =
           constructorNameParser
             <|> (qualifyName Nothing <$> parens operatorUnqualifiedNameParser)
         pure (\span' -> typeAnnSpan span' (TCon name Unpromoted))
-      params <- MP.many typeParamParser
+      params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, headType, params)
 
     infixHeadParser = do
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- typeFamilyOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       let lhsType =
             typeAnnSpan (tyVarBinderSpan lhs) (TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs)))
           rhsType =
@@ -1261,17 +1258,17 @@ classHeadParser =
   where
     prefixDeclHeadParser = do
       name <- constructorIdentifierParser
-      params <- MP.many typeParamParser
+      params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, name, params)
 
     infixDeclHeadParser = do
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- constructorOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       pure (TypeHeadInfix, renderName op, [lhs, rhs])
 
-typeParamParser :: TokParser TyVarBinder
-typeParamParser =
+explicitForallBinderParser :: TokParser TyVarBinder
+explicitForallBinderParser =
   withSpan $
     ( do
         ident <-
@@ -1281,7 +1278,7 @@ typeParamParser =
                 | isTypeVarName name ->
                     Just name
               _ -> Nothing
-        pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified)
+        pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBVisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
@@ -1289,8 +1286,26 @@ typeParamParser =
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified)
+              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified TyVarBVisible)
           )
+
+declTypeParamParser :: TokParser TyVarBinder
+declTypeParamParser = MP.try invisibleDeclTypeParamParser <|> explicitForallBinderParser
+
+invisibleDeclTypeParamParser :: TokParser TyVarBinder
+invisibleDeclTypeParamParser = withSpan $ do
+  expectedTok TkReservedAt
+  ( do
+      ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+      pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBInvisible)
+    )
+    <|> do
+      expectedTok TkSpecialLParen
+      ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+      expectedTok TkReservedDoubleColon
+      kind <- typeParser
+      expectedTok TkSpecialRParen
+      pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified TyVarBInvisible)
 
 isTypeVarName :: Text -> Bool
 isTypeVarName name =
@@ -1329,7 +1344,7 @@ dataConQualifiersParser = do
 forallBindersParser :: TokParser [Text]
 forallBindersParser = do
   expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
+  binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
   pure (map tyVarBinderName binders)
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -448,10 +448,13 @@ atomExprParser = do
   blockArgsEnabled <- isExtensionEnabled BlockArguments
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
+  explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkImplicitParam {} -> implicitParamExprParser
+    TkKeywordType
+      | explicitNamespacesEnabled -> explicitTypeExprParser
     _ ->
       MP.try prefixNegateAtomExprParser
         <|> MP.try parenOperatorExprParser
@@ -477,6 +480,11 @@ atomExprParser = do
         <|> overloadedLabelExprParser
         <|> wildcardExprParser
         <|> varExprParser
+
+explicitTypeExprParser :: TokParser Expr
+explicitTypeExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  expectedTok TkKeywordType
+  ETypeSyntax TypeSyntaxExplicitNamespace <$> typeParser
 
 prefixNegateAtomExprParser :: TokParser Expr
 prefixNegateAtomExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
@@ -924,7 +932,7 @@ lambdaExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
       ELambdaCase <$> bracedAlts
 
     lambdaPatsParser = do
-      pats <- MP.some patternParser
+      pats <- MP.some simplePatternParser
       expectedTok TkReservedRightArrow
       body <- region "while parsing lambda body" exprParser
       pure (ELambdaPats pats body)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -440,12 +440,13 @@ atomExprParser = do
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
   explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
+  requiredTypeArgumentsEnabled <- isExtensionEnabled RequiredTypeArguments
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkImplicitParam {} -> implicitParamExprParser
     TkKeywordType
-      | explicitNamespacesEnabled -> explicitTypeExprParser
+      | explicitNamespacesEnabled || requiredTypeArgumentsEnabled -> explicitTypeExprParser
     _ ->
       MP.try prefixNegateAtomExprParser
         <|> MP.try parenOperatorExprParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -109,6 +109,7 @@ patternAtomParser = do
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
   explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
+  requiredTypeArgumentsEnabled <- isExtensionEnabled RequiredTypeArguments
   typeAbstractionsEnabled <- isExtensionEnabled TypeAbstractions
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
@@ -118,7 +119,7 @@ patternAtomParser = do
     TkPrefixBang -> strictPatternParser
     TkPrefixTilde -> irrefutablePatternParser
     TkKeywordType
-      | explicitNamespacesEnabled -> explicitTypePatternParser
+      | explicitNamespacesEnabled || requiredTypeArgumentsEnabled -> explicitTypePatternParser
     TkQuasiQuote {} -> quasiQuotePatternParser
     TkTHSplice | thAny -> thSplicePatternParser
     TkKeywordUnderscore -> wildcardPatternParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -96,7 +96,7 @@ buildPatternApp lhs rhs =
   case peelPatternAnn lhs of
     PCon name typeArgs args ->
       PAnn
-        (mkAnnotation (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)))
+        (mkAnnotation (mergeSourceSpans (getPatternSourceSpan lhs) (getPatternSourceSpan rhs)))
         (PCon name typeArgs (args <> [rhs]))
     _ -> lhs
 
@@ -275,7 +275,7 @@ visibleTypeBinderCoreParser =
   withSpan $
     ( do
         ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
-        pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBInvisible)
+        pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBInvisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
@@ -283,7 +283,7 @@ visibleTypeBinderCoreParser =
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified TyVarBInvisible)
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBInvisible)
           )
 
 varOrConPatternParser :: TokParser Pattern

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -113,7 +113,7 @@ patternAtomParser = do
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
-    TkReservedAt
+    TkTypeApp
       | typeAbstractionsEnabled -> typeBinderPatternParser
     TkPrefixBang -> strictPatternParser
     TkPrefixTilde -> irrefutablePatternParser
@@ -150,7 +150,7 @@ patternAtomParser = do
 
 typeBinderPatternParser :: TokParser Pattern
 typeBinderPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
-  expectedTok TkReservedAt
+  expectedTok TkTypeApp
   PTypeBinder <$> visibleTypeBinderCoreParser
 
 explicitTypePatternParser :: TokParser Pattern

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -94,7 +94,10 @@ appPatternParser =
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =
   case peelPatternAnn lhs of
-    PCon name args -> PAnn (mkAnnotation (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs))) (PCon name (args <> [rhs]))
+    PCon name typeArgs args ->
+      PAnn
+        (mkAnnotation (mergeSourceSpans (getSourceSpan lhs) (getSourceSpan rhs)))
+        (PCon name typeArgs (args <> [rhs]))
     _ -> lhs
 
 -- | Parse an atomic pattern (@apat@ in the Haskell Report).
@@ -105,11 +108,17 @@ patternAtomParser :: TokParser Pattern
 patternAtomParser = do
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
+  explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
+  typeAbstractionsEnabled <- isExtensionEnabled TypeAbstractions
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
+    TkReservedAt
+      | typeAbstractionsEnabled -> typeBinderPatternParser
     TkPrefixBang -> strictPatternParser
     TkPrefixTilde -> irrefutablePatternParser
+    TkKeywordType
+      | explicitNamespacesEnabled -> explicitTypePatternParser
     TkQuasiQuote {} -> quasiQuotePatternParser
     TkTHSplice | thAny -> thSplicePatternParser
     TkKeywordUnderscore -> wildcardPatternParser
@@ -138,6 +147,16 @@ patternAtomParser = do
       name <- identifierTextParser
       expectedTok TkReservedAt
       PAs name <$> patternAtomParser
+
+typeBinderPatternParser :: TokParser Pattern
+typeBinderPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
+  expectedTok TkReservedAt
+  PTypeBinder <$> visibleTypeBinderCoreParser
+
+explicitTypePatternParser :: TokParser Pattern
+explicitTypePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
+  expectedTok TkKeywordType
+  PTypeSyntax TypeSyntaxExplicitNamespace <$> typeParser
 
 strictPatternParser :: TokParser Pattern
 strictPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -239,13 +258,33 @@ thSplicePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
 
 simplePatternParser :: TokParser Pattern
 simplePatternParser =
-  MP.try
-    ( withSpanAnn (PAnn . mkAnnotation) $ do
-        name <- identifierTextParser
-        expectedTok TkReservedAt
-        PAs name <$> patternAtomParser
+  do
+    typeAbstractionsEnabled <- isExtensionEnabled TypeAbstractions
+    let typeBinderParser = if typeAbstractionsEnabled then MP.try typeBinderPatternParser else MP.empty
+    MP.try
+      ( withSpanAnn (PAnn . mkAnnotation) $ do
+          name <- identifierTextParser
+          expectedTok TkReservedAt
+          PAs name <$> patternAtomParser
+      )
+      <|> typeBinderParser
+      <|> patternAtomParser
+
+visibleTypeBinderCoreParser :: TokParser TyVarBinder
+visibleTypeBinderCoreParser =
+  withSpan $
+    ( do
+        ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+        pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBInvisible)
     )
-    <|> patternAtomParser
+      <|> ( do
+              expectedTok TkSpecialLParen
+              ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+              expectedTok TkReservedDoubleColon
+              kind <- typeParser
+              expectedTok TkSpecialRParen
+              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified TyVarBInvisible)
+          )
 
 varOrConPatternParser :: TokParser Pattern
 varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -259,7 +298,7 @@ varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
     _ ->
       pure $
         if isConLikeName name
-          then PCon name []
+          then PCon name [] []
           else PVar (mkUnqualifiedName (nameType name) (nameText name))
 
 recordFieldPatternParser :: TokParser (Name, Pattern)
@@ -396,7 +435,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
           tok' <- anySingle
           case lexTokenKind tok' of
             TkVarSym op -> pure (PVar (mkUnqualifiedName NameVarSym op))
-            TkConSym op -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym op)) [])
+            TkConSym op -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym op)) [] [])
             _ -> fail "expected operator token"
 
     -- Try to parse as expression, then reclassify via checkPattern.

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -2,6 +2,7 @@
 
 module Aihc.Parser.Internal.Type
   ( typeParser,
+    forallTelescopeParser,
     typeInfixParser,
     typeInfixOperatorParser,
     typeHeadInfixParser,
@@ -48,10 +49,17 @@ contextOrFunTypeParser = do
 
 forallTypeParser :: TokParser Type
 forallTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
+  telescope <- forallTelescopeParser
+  TForall telescope <$> typeParser
+
+forallTelescopeParser :: TokParser ForallTelescope
+forallTelescopeParser = do
   expectedTok TkKeywordForall
   binders <- MP.some forallBinderParser
-  expectedTok (TkVarSym ".")
-  TForall binders <$> contextOrFunTypeParser
+  visibility <-
+    (expectedTok (TkVarSym ".") $> ForallInvisible)
+      <|> (expectedTok TkReservedRightArrow $> ForallVisible)
+  pure (ForallTelescope visibility binders)
 
 -- | Parse a single forall binder: {k} | (k :: *) | k
 forallBinderParser :: TokParser TyVarBinder
@@ -60,23 +68,28 @@ forallBinderParser =
     -- Inferred binder: {k} | {k :: Type}
     ( do
         expectedTok TkSpecialLBrace
-        ident <- lowerIdentifierParser
+        ident <- forallBinderNameParser
         mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
         expectedTok TkSpecialRBrace
-        pure (\span' -> TyVarBinder span' ident mKind TyVarBInferred)
+        pure (\span' -> TyVarBinder span' ident mKind TyVarBInferred TyVarBVisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
-              ident <- lowerIdentifierParser
+              ident <- forallBinderNameParser
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified)
+              pure (\span' -> TyVarBinder span' ident (Just kind) TyVarBSpecified TyVarBVisible)
           )
       <|> ( do
-              ident <- lowerIdentifierParser
-              pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified)
+              ident <- forallBinderNameParser
+              pure (\span' -> TyVarBinder span' ident Nothing TyVarBSpecified TyVarBVisible)
           )
+
+forallBinderNameParser :: TokParser Text
+forallBinderNameParser =
+  lowerIdentifierParser
+    <|> (expectedTok TkKeywordUnderscore $> "_")
 
 contextTypeParser :: TokParser Type
 contextTypeParser = do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1040,8 +1040,8 @@ addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ typeArgs (_ : _)
-      | null typeArgs -> wrapPat True (addPatternParens pat)
+    PCon _ typeArgs args
+      | not (null typeArgs) || not (null args) -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat
     _ -> addPatternAtomParens pat
 

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -632,6 +632,7 @@ addExprParensPrec prec expr =
     EApp {} -> addAppsChainPrec prec expr
     ETypeApp fn ty ->
       wrapExpr (prec > 2) (ETypeApp (addExprParensIn CtxAppFun fn) (addTypeIn CtxTypeAtom ty))
+    ETypeSyntax form ty -> wrapExpr (prec > 2) (ETypeSyntax form (addTypeParens ty))
     EVar {} -> expr
     EInt {} -> expr
     EIntHash {} -> expr
@@ -838,10 +839,15 @@ addTypeParensShared ctx prec ty =
         TTypeLit {} -> ty
         TStar {} -> ty
         TQuasiQuote {} -> ty
-        TForall binders inner ->
+        TForall telescope inner ->
           -- forallTypeParser uses contextOrFunTypeParser (not typeParser) for its
           -- body, so a bare nested TForall would fail to parse. Wrap it in TParen.
-          wrapTy (prec > 0) (TForall (map addTyVarBinderParens binders) (addForallBodyParens inner))
+          wrapTy
+            (prec > 0)
+            ( TForall
+                (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
+                (addForallBodyParens inner)
+            )
         tyInfix
           | Just (op, lhs, rhs) <- matchSymbolicInfixTypeApp tyInfix ->
               -- Infix type operator: args are treated as atoms
@@ -947,13 +953,15 @@ addPatternParens pat =
   case pat of
     PAnn sp sub -> PAnn sp (addPatternParens sub)
     PVar {} -> pat
+    PTypeBinder binder -> PTypeBinder (addTyVarBinderParens binder)
+    PTypeSyntax form ty -> PTypeSyntax form (addTypeParens ty)
     PWildcard {} -> pat
     PLit lit -> PLit lit
     PQuasiQuote {} -> pat
     PTuple tupleFlavor elems -> PTuple tupleFlavor (map addPatternInDelimited elems)
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (addPatternInDelimited inner)
     PList elems -> PList (map addPatternInDelimited elems)
-    PCon con args -> PCon con (map addPatternAtomParens args)
+    PCon con typeArgs args -> PCon con (map (addTypeIn CtxTypeAtom) typeArgs) (map addPatternAtomParens args)
     PInfix lhs op rhs -> PInfix (addPatternAtomParens lhs) op (addPatternAtomParens rhs)
     PView viewExpr inner ->
       wrapPat True (PView (addViewExprParens viewExpr) (addPatternParens inner))
@@ -994,6 +1002,8 @@ addPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternAtomParens sub)
     PVar {} -> addPatternParens pat
+    PTypeBinder {} -> addPatternParens pat
+    PTypeSyntax {} -> addPatternParens pat
     PWildcard {} -> addPatternParens pat
     PLit {} -> addPatternParens pat
     PQuasiQuote {} -> addPatternParens pat
@@ -1007,7 +1017,7 @@ addPatternAtomParens pat =
     PView {} -> addPatternParens pat
     PAs {} -> addPatternParens pat
     PSplice {} -> addPatternParens pat
-    PCon _ [] -> addPatternParens pat
+    PCon _ [] [] -> addPatternParens pat
     PInfix _ op _
       | isConsOperator op ->
           -- Cons operator (:) is right-associative, so nested cons patterns
@@ -1021,7 +1031,7 @@ addLambdaPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addLambdaPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ [] -> wrapPat True (addPatternParens pat)
+    PCon _ _ [] -> wrapPat True (addPatternParens pat)
     _ -> addPatternAtomParens pat
 
 -- | Add parens for a pattern in function-head argument position.
@@ -1030,7 +1040,8 @@ addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ (_ : _) -> wrapPat True (addPatternParens pat)
+    PCon _ typeArgs (_ : _)
+      | null typeArgs -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat
     _ -> addPatternAtomParens pat
 
@@ -1048,7 +1059,7 @@ addPatternAtomStrictParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternAtomStrictParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ [] -> wrapPat True (addPatternParens pat)
+    PCon _ _ [] -> wrapPat True (addPatternParens pat)
     PStrict {} -> wrapPat True (addPatternParens pat)
     PIrrefutable {} -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -437,8 +437,8 @@ prettyType ty =
     TTypeLit lit -> prettyTypeLiteral lit
     TStar -> "*"
     TQuasiQuote quoter body -> prettyQuasiQuote quoter body
-    TForall binders inner ->
-      "forall" <+> hsep (map prettyTyVarBinder binders) <> "." <+> prettyType inner
+    TForall telescope inner ->
+      prettyForallTelescope telescope <+> prettyType inner
     -- Before infix detection: required grouping from the parser ('TParen',
     -- @(a :+: b) -> c@, constraints, nested @(c => t)@).
     TParen inner -> parens (prettyType inner)
@@ -490,6 +490,9 @@ prettyPattern pat =
   case pat of
     PAnn _ sub -> prettyPattern sub
     PVar name -> pretty name
+    PTypeBinder binder -> prettyTyVarBinder binder
+    PTypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
+    PTypeSyntax TypeSyntaxInTerm ty -> prettyType ty
     PWildcard -> "_"
     PLit lit -> prettyLiteral lit
     PQuasiQuote quoter body -> prettyQuasiQuote quoter body
@@ -498,7 +501,7 @@ prettyPattern pat =
       let slots = [if i == altIdx then prettyPattern inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     PList elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
-    PCon con args -> hsep (prettyPrefixName con : map prettyPattern args)
+    PCon con typeArgs args -> hsep ([prettyPrefixName con] <> map prettyInvisibleTypeArg typeArgs <> map prettyPattern args)
     PInfix lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView viewExpr inner ->
       prettyExpr viewExpr <+> "->" <+> prettyPattern inner
@@ -643,11 +646,18 @@ prettyDeclHead headForm constraints name params =
 
 prettyTyVarBinder :: TyVarBinder -> Doc ann
 prettyTyVarBinder binder =
-  case (tyVarBinderSpecificity binder, tyVarBinderKind binder) of
-    (TyVarBInferred, Nothing) -> braces (pretty (tyVarBinderName binder))
-    (TyVarBInferred, Just kind) -> braces (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
-    (TyVarBSpecified, Nothing) -> pretty (tyVarBinderName binder)
-    (TyVarBSpecified, Just kind) -> parens (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
+  visibleDoc
+  where
+    coreDoc =
+      case (tyVarBinderSpecificity binder, tyVarBinderKind binder) of
+        (TyVarBInferred, Nothing) -> braces (pretty (tyVarBinderName binder))
+        (TyVarBInferred, Just kind) -> braces (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
+        (TyVarBSpecified, Nothing) -> pretty (tyVarBinderName binder)
+        (TyVarBSpecified, Just kind) -> parens (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
+    visibleDoc =
+      case tyVarBinderVisibility binder of
+        TyVarBVisible -> coreDoc
+        TyVarBInvisible -> "@" <> coreDoc
 
 contextPrefix :: [Type] -> [Doc ann]
 contextPrefix constraints =
@@ -658,6 +668,17 @@ contextPrefix constraints =
 forallTyVarBinderPrefix :: [TyVarBinder] -> [Doc ann]
 forallTyVarBinderPrefix [] = []
 forallTyVarBinderPrefix binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
+
+prettyForallTelescope :: ForallTelescope -> Doc ann
+prettyForallTelescope telescope =
+  "forall"
+    <+> hsep (map prettyTyVarBinder (forallTelescopeBinders telescope))
+    <> case forallTelescopeVisibility telescope of
+      ForallInvisible -> "."
+      ForallVisible -> " ->"
+
+prettyInvisibleTypeArg :: Type -> Doc ann
+prettyInvisibleTypeArg ty = "@" <> prettyType ty
 
 prettyDataCon :: DataConDecl -> Doc ann
 prettyDataCon ctor =
@@ -690,10 +711,10 @@ prettyDataCon ctor =
         prettyFieldName fieldName
           | isOperatorToken (renderUnqualifiedName fieldName) = parens (pretty fieldName)
           | otherwise = pretty fieldName
-    GadtCon forallBinders constraints names body ->
-      prettyGadtCon forallBinders constraints names body
+    GadtCon foralls constraints names body ->
+      prettyGadtCon foralls constraints names body
 
-prettyGadtCon :: [TyVarBinder] -> [Type] -> [UnqualifiedName] -> GadtBody -> Doc ann
+prettyGadtCon :: [ForallTelescope] -> [Type] -> [UnqualifiedName] -> GadtBody -> Doc ann
 prettyGadtCon forallBinders constraints names body =
   hsep
     ( [hsep (punctuate comma (map prettyConstructorUName names)), "::"]
@@ -702,9 +723,7 @@ prettyGadtCon forallBinders constraints names body =
         <> [prettyGadtBody body]
     )
   where
-    forallPart
-      | null forallBinders = []
-      | otherwise = ["forall", hsep (map prettyTyVarBinder forallBinders) <> "."]
+    forallPart = map prettyForallTelescope forallBinders
     contextPart
       | null constraints = []
       | otherwise = [prettyContext constraints, "=>"]
@@ -1040,6 +1059,8 @@ prettyExpr expr =
     EVar name
       | isSymbolicName name -> parens (pretty (renderName name))
       | otherwise -> pretty name
+    ETypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
+    ETypeSyntax TypeSyntaxInTerm ty -> prettyType ty
     EInt _ repr -> pretty repr
     EIntHash _ repr -> pretty repr
     EIntBase _ repr -> pretty repr

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -358,7 +358,7 @@ docDataConDecl dcd =
     RecordCon forallVars constraints name fields' ->
       "RecordCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> listField "fields" docFieldDecl fields')))
     GadtCon forallBinders constraints names body ->
-      "GadtCon" <+> braces (hsep (punctuate comma (listField "names" docUnqualifiedName names <> listField "forallBinders" docTyVarBinder forallBinders <> listField "constraints" docType constraints <> [field "body" (docGadtBody body)])))
+      "GadtCon" <+> braces (hsep (punctuate comma (listField "names" docUnqualifiedName names <> listField "forallBinders" docForallTelescope forallBinders <> listField "constraints" docType constraints <> [field "body" (docGadtBody body)])))
 
 -- | Document a GADT body
 docGadtBody :: GadtBody -> Doc ann
@@ -569,7 +569,13 @@ docType ty =
     TTypeLit lit -> "TTypeLit" <+> docTypeLiteral lit
     TStar -> "TStar"
     TQuasiQuote quoter body -> "TQuasiQuote" <+> docText quoter <+> docText body
-    TForall binders inner -> "TForall" <+> brackets (hsep (punctuate comma (map docTyVarBinder binders))) <+> parens (docType inner)
+    TForall telescope inner ->
+      case forallTelescopeVisibility telescope of
+        ForallInvisible ->
+          "TForall"
+            <+> brackets (hsep (punctuate comma (map docTyVarBinder (forallTelescopeBinders telescope))))
+            <+> parens (docType inner)
+        ForallVisible -> "TForall" <+> parens (docForallTelescope telescope) <+> parens (docType inner)
     TApp f x -> "TApp" <+> parens (docType f) <+> parens (docType x)
     TFun a b -> "TFun" <+> parens (docType a) <+> parens (docType b)
     TTuple tupleFlavor promoted elems ->
@@ -607,6 +613,7 @@ docTyVarBinder tvb =
     fields =
       [field "name" (docText (tyVarBinderName tvb))]
         <> optionalField "specificity" docTyVarBSpecificity (specificityField tvb)
+        <> optionalField "visibility" docTyVarBVisibility (visibilityField tvb)
         <> optionalField "kind" docType (tyVarBinderKind tvb)
 
     specificityField binder =
@@ -614,11 +621,41 @@ docTyVarBinder tvb =
         TyVarBSpecified -> Nothing
         specificity -> Just specificity
 
+    visibilityField binder =
+      case tyVarBinderVisibility binder of
+        TyVarBVisible -> Nothing
+        visibility -> Just visibility
+
 docTyVarBSpecificity :: TyVarBSpecificity -> Doc ann
 docTyVarBSpecificity specificity =
   case specificity of
     TyVarBInferred -> "TyVarBInferred"
     TyVarBSpecified -> "TyVarBSpecified"
+
+docTyVarBVisibility :: TyVarBVisibility -> Doc ann
+docTyVarBVisibility visibility =
+  case visibility of
+    TyVarBVisible -> "TyVarBVisible"
+    TyVarBInvisible -> "TyVarBInvisible"
+
+docForallVis :: ForallVis -> Doc ann
+docForallVis visibility =
+  case visibility of
+    ForallInvisible -> "ForallInvisible"
+    ForallVisible -> "ForallVisible"
+
+docForallTelescope :: ForallTelescope -> Doc ann
+docForallTelescope telescope =
+  "ForallTelescope"
+    <+> braces
+      ( hsep
+          ( punctuate
+              comma
+              ( [field "visibility" (docForallVis (forallTelescopeVisibility telescope))]
+                  <> listField "binders" docTyVarBinder (forallTelescopeBinders telescope)
+              )
+          )
+      )
 
 -- Patterns
 
@@ -627,6 +664,8 @@ docPattern pat =
   case pat of
     PAnn _ sub -> docPattern sub
     PVar name -> "PVar" <+> docUnqualifiedName name
+    PTypeBinder binder -> "PTypeBinder" <+> parens (docTyVarBinder binder)
+    PTypeSyntax form ty -> "PTypeSyntax" <+> docTypeSyntaxForm form <+> parens (docType ty)
     PWildcard -> "PWildcard"
     PLit lit -> "PLit" <+> parens (docLiteral lit)
     PQuasiQuote quoter body -> "PQuasiQuote" <+> docText quoter <+> docText body
@@ -636,7 +675,21 @@ docPattern pat =
     PUnboxedSum altIdx arity inner ->
       "PUnboxedSum" <+> pretty altIdx <+> pretty arity <+> docPattern inner
     PList elems -> "PList" <+> brackets (hsep (punctuate comma (map docPattern elems)))
-    PCon name args -> "PCon" <+> docName name <+> brackets (hsep (punctuate comma (map docPattern args)))
+    PCon name typeArgs args ->
+      case typeArgs of
+        [] -> "PCon" <+> docName name <+> brackets (hsep (punctuate comma (map docPattern args)))
+        _ ->
+          "PCon"
+            <+> docName name
+            <+> braces
+              ( hsep
+                  ( punctuate
+                      comma
+                      ( listField "typeArgs" docType typeArgs
+                          <> listField "args" docPattern args
+                      )
+                  )
+              )
     PInfix lhs op rhs -> "PInfix" <+> parens (docPattern lhs) <+> docName op <+> parens (docPattern rhs)
     PView expr inner -> "PView" <+> parens (docExpr expr) <+> parens (docPattern inner)
     PAs name inner -> "PAs" <+> docText name <+> parens (docPattern inner)
@@ -669,6 +722,7 @@ docExpr :: Expr -> Doc ann
 docExpr expr =
   case expr of
     EVar name -> "EVar" <+> docName name
+    ETypeSyntax form ty -> "ETypeSyntax" <+> docTypeSyntaxForm form <+> parens (docType ty)
     EInt n _ -> "EInt" <+> pretty n
     EIntHash n repr -> "EIntHash" <+> pretty n <+> docText repr
     EIntBase n repr -> "EIntBase" <+> pretty n <+> docText repr
@@ -889,6 +943,12 @@ docTokenKind kind =
     TkTHTypedSplice -> "TkTHTypedSplice"
     TkError msg -> "TkError" <+> docText msg
     TkEOF -> "TkEOF"
+
+docTypeSyntaxForm :: TypeSyntaxForm -> Doc ann
+docTypeSyntaxForm form =
+  case form of
+    TypeSyntaxExplicitNamespace -> "TypeSyntaxExplicitNamespace"
+    TypeSyntaxInTerm -> "TypeSyntaxInTerm"
 
 -- Helpers
 

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -140,7 +140,6 @@ module Aihc.Parser.Syntax
     literalAnnSpan,
     peelLiteralAnn,
     typeAnnSpan,
-    tyVarBinderNameText,
   )
 where
 
@@ -580,9 +579,11 @@ impliedExtensions =
     (Strict, [EnableExtension StrictData]),
     (TemplateHaskell, [EnableExtension TemplateHaskellQuotes]),
     (TypeFamilies, [EnableExtension ExplicitNamespaces, EnableExtension KindSignatures, EnableExtension MonoLocalBinds]),
+    (TypeAbstractions, [EnableExtension TypeApplications]),
     (TypeFamilyDependencies, [EnableExtension TypeFamilies]),
     (TypeInType, [EnableExtension PolyKinds, EnableExtension DataKinds, EnableExtension KindSignatures]),
     (TypeOperators, [EnableExtension ExplicitNamespaces]),
+    (RequiredTypeArguments, [EnableExtension TypeApplications]),
     (UnboxedTuples, [EnableExtension UnboxedSums]),
     (UnliftedDatatypes, [EnableExtension DataKinds, EnableExtension StandaloneKindSignatures])
   ]
@@ -1222,9 +1223,6 @@ data TyVarBinder = TyVarBinder
 
 instance HasSourceSpan TyVarBinder where
   getSourceSpan = tyVarBinderSpan
-
-tyVarBinderNameText :: TyVarBinder -> Text
-tyVarBinderNameText = tyVarBinderName
 
 data TypeHeadForm
   = TypeHeadPrefix

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -81,9 +81,13 @@ module Aihc.Parser.Syntax
     StandaloneDerivingDecl (..),
     Type (..),
     TupleFlavor (..),
+    TypeSyntaxForm (..),
     TypeLiteral (..),
     TypePromotion (..),
+    ForallVis (..),
+    ForallTelescope (..),
     TyVarBSpecificity (..),
+    TyVarBVisibility (..),
     TyVarBinder (..),
     TypeSynDecl (..),
     TypeFamilyDecl (..),
@@ -136,6 +140,7 @@ module Aihc.Parser.Syntax
     literalAnnSpan,
     peelLiteralAnn,
     typeAnnSpan,
+    tyVarBinderNameText,
   )
 where
 
@@ -1084,13 +1089,15 @@ data TupleFlavor
 data Pattern
   = PAnn Annotation Pattern
   | PVar UnqualifiedName
+  | PTypeBinder TyVarBinder
+  | PTypeSyntax TypeSyntaxForm Type
   | PWildcard
   | PLit Literal
   | PQuasiQuote Text Text
   | PTuple TupleFlavor [Pattern]
   | PUnboxedSum Int Int Pattern
   | PList [Pattern]
-  | PCon Name [Pattern]
+  | PCon Name [Type] [Pattern]
   | PInfix Pattern Name Pattern
   | PView Expr Pattern
   | PAs Text Pattern
@@ -1117,6 +1124,22 @@ peelPatternAnn :: Pattern -> Pattern
 peelPatternAnn (PAnn _ inner) = peelPatternAnn inner
 peelPatternAnn p = p
 
+data TypeSyntaxForm
+  = TypeSyntaxExplicitNamespace
+  | TypeSyntaxInTerm
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data ForallVis
+  = ForallInvisible
+  | ForallVisible
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data ForallTelescope = ForallTelescope
+  { forallTelescopeVisibility :: ForallVis,
+    forallTelescopeBinders :: [TyVarBinder]
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
 data Type
   = TAnn Annotation Type
   | TVar UnqualifiedName
@@ -1125,7 +1148,7 @@ data Type
   | TTypeLit TypeLiteral
   | TStar
   | TQuasiQuote Text Text
-  | TForall [TyVarBinder] Type
+  | TForall ForallTelescope Type
   | TApp Type Type
   | TFun Type Type
   | TTuple TupleFlavor TypePromotion [Type]
@@ -1179,6 +1202,11 @@ data TyVarBSpecificity
   | TyVarBSpecified
   deriving (Data, Eq, Show, Generic, NFData)
 
+data TyVarBVisibility
+  = TyVarBVisible
+  | TyVarBInvisible
+  deriving (Data, Eq, Show, Generic, NFData)
+
 data TyVarBinder = TyVarBinder
   { tyVarBinderSpan :: SourceSpan,
     tyVarBinderName :: Text,
@@ -1186,12 +1214,17 @@ data TyVarBinder = TyVarBinder
     tyVarBinderKind :: Maybe Type,
     -- | Whether the binder was written as specified (@a@, @(a :: k)@)
     -- or inferred (@{a}@, @{a :: k}@).
-    tyVarBinderSpecificity :: TyVarBSpecificity
+    tyVarBinderSpecificity :: TyVarBSpecificity,
+    -- | Whether the binder was written visibly (@a@) or invisibly (@@a@).
+    tyVarBinderVisibility :: TyVarBVisibility
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
 instance HasSourceSpan TyVarBinder where
   getSourceSpan = tyVarBinderSpan
+
+tyVarBinderNameText :: TyVarBinder -> Text
+tyVarBinderNameText = tyVarBinderName
 
 data TypeHeadForm
   = TypeHeadPrefix
@@ -1343,7 +1376,7 @@ data DataConDecl
   | RecordCon [Text] [Type] UnqualifiedName [FieldDecl]
   | -- | GADT-style constructor: @Con :: forall a. Ctx => Type@
     -- The list of names supports multiple constructors: @T1, T2 :: Type@
-    GadtCon [TyVarBinder] [Type] [UnqualifiedName] GadtBody
+    GadtCon [ForallTelescope] [Type] [UnqualifiedName] GadtBody
   deriving (Data, Eq, Show, Generic, NFData)
 
 -- | Strip nested 'DataConAnn' wrappers.
@@ -1607,6 +1640,7 @@ instance NFData Annotation where
 data Expr
   = EAnn Annotation Expr
   | EVar Name
+  | ETypeSyntax TypeSyntaxForm Type
   | EInt Integer Text
   | EIntHash Integer Text
   | EIntBase Integer Text

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -75,7 +75,7 @@ pattern PList_ :: [Pattern] -> Pattern
 pattern PList_ elems <- (peelPatternAnn -> PList elems)
 
 pattern PCon_ :: Name -> [Pattern] -> Pattern
-pattern PCon_ con args <- (peelPatternAnn -> PCon con args)
+pattern PCon_ con args <- (peelPatternAnn -> PCon con [] args)
 
 pattern PInfix_ :: Pattern -> Name -> Pattern -> Pattern
 pattern PInfix_ lhs op rhs <- (peelPatternAnn -> PInfix lhs op rhs)
@@ -244,6 +244,11 @@ buildTests = do
             testCase "TemplateHaskellQuotes parses top-level typed splices" test_templateHaskellQuotesParsesTopLevelTypedSpliceExpr,
             testCase "TemplateHaskellQuotes lexes typed splice tokens" test_templateHaskellQuotesLexesTypedSplice,
             testCase "parses and roundtrips infix type family heads" test_infixTypeFamilyHeadRoundtrip,
+            testCase "parses explicit type syntax expressions" test_explicitTypeSyntaxExprParses,
+            testCase "parses explicit type syntax patterns" test_explicitTypeSyntaxPatternParses,
+            testCase "parses lambda type binders" test_lambdaTypeBinderParses,
+            testCase "parses function head type binders" test_functionHeadTypeBinderParses,
+            testCase "parses invisible type declaration binders" test_invisibleTypeDeclBinderParses,
             QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
             QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism
@@ -578,7 +583,7 @@ test_infixClassHeadParses =
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
           [ DeclFixity {},
-            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified, TyVarBinder _ "b" Nothing TyVarBSpecified], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
+            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "b" Nothing TyVarBSpecified TyVarBVisible], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
             ] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
@@ -656,7 +661,7 @@ test_infixTypeFamilyHeadRoundtrip =
               TypeFamilyDecl
                 { typeFamilyDeclHeadForm = TypeHeadInfix,
                   typeFamilyDeclHead = h,
-                  typeFamilyDeclParams = [TyVarBinder _ "l" Nothing TyVarBSpecified, TyVarBinder _ "r" Nothing TyVarBSpecified],
+                  typeFamilyDeclParams = [TyVarBinder _ "l" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "r" Nothing TyVarBSpecified TyVarBVisible],
                   typeFamilyDeclEquations = Just [TypeFamilyEq {typeFamilyEqHeadForm = TypeHeadInfix, typeFamilyEqLhs = lhs, typeFamilyEqRhs = rhs}]
                 }
             ]
@@ -676,6 +681,58 @@ test_parserConfigPassesExtensions =
       | EInt_ (-1) _ <- normalizeExpr parsed -> pure ()
     ParseOk other -> assertFailure ("expected negative literal expression, got: " <> show other)
     ParseErr err -> assertFailure ("expected parse success, got parse error: " <> MPE.errorBundlePretty err)
+
+test_explicitTypeSyntaxExprParses :: Assertion
+test_explicitTypeSyntaxExprParses =
+  case parseExpr defaultConfig {parserExtensions = [ExplicitNamespaces, RequiredTypeArguments]} "type Int" of
+    ParseOk parsed
+      | ETypeSyntax TypeSyntaxExplicitNamespace ty <- normalizeExpr parsed,
+        TCon "Int" Unpromoted <- stripTypeAnnotations ty ->
+          pure ()
+    other -> assertFailure ("expected explicit type syntax expression, got: " <> show other)
+
+test_explicitTypeSyntaxPatternParses :: Assertion
+test_explicitTypeSyntaxPatternParses =
+  case parsePattern defaultConfig {parserExtensions = [ExplicitNamespaces, RequiredTypeArguments]} "type a" of
+    ParseOk parsed
+      | PTypeSyntax TypeSyntaxExplicitNamespace ty <- peelPatternAnn parsed,
+        TVar "a" <- stripTypeAnnotations ty ->
+          pure ()
+    other -> assertFailure ("expected explicit type syntax pattern, got: " <> show other)
+
+test_lambdaTypeBinderParses :: Assertion
+test_lambdaTypeBinderParses =
+  case parseExpr defaultConfig {parserExtensions = [TypeAbstractions]} "\\ @a x -> x" of
+    ParseOk parsed
+      | ELambdaPats [PTypeBinder binder, PVar_ "x"] (EVar_ "x") <- normalizeExpr parsed,
+        tyVarBinderName binder == "a",
+        tyVarBinderVisibility binder == TyVarBInvisible ->
+          pure ()
+    other -> assertFailure ("expected lambda type binder, got: " <> show other)
+
+test_functionHeadTypeBinderParses :: Assertion
+test_functionHeadTypeBinderParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "f @a x = x" of
+    ParseOk parsed ->
+      case normalizeDecl parsed of
+        DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTypeBinder binder, PVar_ "x"], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+          | tyVarBinderName binder == "a",
+            tyVarBinderVisibility binder == TyVarBInvisible ->
+              pure ()
+        other -> assertFailure ("expected function head type binder, got normalized decl: " <> show other)
+    other -> assertFailure ("expected function head type binder, got: " <> show other)
+
+test_invisibleTypeDeclBinderParses :: Assertion
+test_invisibleTypeDeclBinderParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "type T @k a = a" of
+    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "T", typeSynParams = [kBinder, aBinder], typeSynBody = body})
+      | tyVarBinderName kBinder == "k",
+        tyVarBinderVisibility kBinder == TyVarBInvisible,
+        tyVarBinderName aBinder == "a",
+        tyVarBinderVisibility aBinder == TyVarBVisible,
+        TVar "a" <- stripTypeAnnotations body ->
+          pure ()
+    other -> assertFailure ("expected invisible type declaration binder, got: " <> show other)
 
 test_parserConfigSetsSourceName :: Assertion
 test_parserConfigSetsSourceName =
@@ -1546,7 +1603,7 @@ test_prettyPrefixFunctionHeadRecordPattern = do
 
 test_prettyInfixFunctionHeadConstructorPatterns :: Assertion
 test_prettyInfixFunctionHeadConstructorPatterns = do
-  let box name = pat0 (PCon (qualifyName Nothing (mkUnqualifiedName NameConId "Box")) [pat0 (PVar name)])
+  let box name = pat0 (PCon (qualifyName Nothing (mkUnqualifiedName NameConId "Box")) [] [pat0 (PVar name)])
       decl =
         DeclValue
           ( FunctionBind

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -249,6 +249,7 @@ buildTests = do
             testCase "parses lambda type binders" test_lambdaTypeBinderParses,
             testCase "parses function head type binders" test_functionHeadTypeBinderParses,
             testCase "parses invisible type declaration binders" test_invisibleTypeDeclBinderParses,
+            testCase "parses constructor patterns with type arguments" test_constructorPatternWithTypeArgParses,
             QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
             QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism
@@ -733,6 +734,21 @@ test_invisibleTypeDeclBinderParses =
         TVar "a" <- stripTypeAnnotations body ->
           pure ()
     other -> assertFailure ("expected invisible type declaration binder, got: " <> show other)
+
+test_constructorPatternWithTypeArgParses :: Assertion
+test_constructorPatternWithTypeArgParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeApplications, TypeAbstractions]} "f (Just @Int x) = x" of
+    ParseOk parsed ->
+      case normalizeDecl parsed of
+        DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [outerPat], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+          | PCon con typeArgs args <- peelPatternAnn outerPat,
+            nameText con == "Just",
+            [typeArg] <- typeArgs,
+            TCon "Int" Unpromoted <- stripTypeAnnotations typeArg,
+            [PVar_ "x"] <- args ->
+              pure ()
+        other -> assertFailure ("expected constructor pattern with type arg, got: " <> show other)
+    other -> assertFailure ("expected parse success, got: " <> show other)
 
 test_parserConfigSetsSourceName :: Assertion
 test_parserConfigSetsSourceName =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -749,7 +749,7 @@ test_functionHeadTypeBinderParses =
   case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "f @a x = x" of
     ParseOk parsed ->
       case normalizeDecl parsed of
-        DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTypeBinder binder, PVar_ "x"], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+        DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTypeBinder binder, PVar_ "x"], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
           | tyVarBinderName binder == "a",
             tyVarBinderVisibility binder == TyVarBInvisible ->
               pure ()
@@ -773,7 +773,7 @@ test_constructorPatternWithTypeArgParses =
   case parseDecl defaultConfig {parserExtensions = [TypeApplications, TypeAbstractions]} "f (Just @Int x) = x" of
     ParseOk parsed ->
       case normalizeDecl parsed of
-        DeclValue (FunctionBind _ "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [outerPat], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+        DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [outerPat], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
           | PCon con typeArgs args <- peelPatternAnn outerPat,
             nameText con == "Just",
             [typeArg] <- typeArgs,

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/basic.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/basic.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail required type argument in expression -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RequiredTypeArguments #-}
 module Basic where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/pattern.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail required type argument in pattern -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RequiredTypeArguments #-}
 module Pattern where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type synonym declarations with visible type abstractions are rejected" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeAbstractions #-}

--- a/components/aihc-parser/test/Test/Oracle/Suite.hs
+++ b/components/aihc-parser/test/Test/Oracle/Suite.hs
@@ -5,7 +5,7 @@ module Test.Oracle.Suite
   )
 where
 
-import Aihc.Parser.Syntax (Extension (RequiredTypeArguments), ExtensionSetting (EnableExtension))
+import Aihc.Parser.Syntax (Extension (TemplateHaskell), ExtensionSetting (EnableExtension))
 import Control.Monad (when)
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
@@ -138,10 +138,10 @@ frameworkTests =
                     casePath = "framework-xfail-details.hs",
                     caseExpected = ExpectXFail,
                     caseReason = "regression coverage",
-                    caseExtensions = [EnableExtension RequiredTypeArguments]
+                    caseExtensions = [EnableExtension TemplateHaskell]
                   }
            in do
-                let (_, outcome, details) = evaluateCaseText meta "module Basic where\n\nx = f (type Int) 5\n"
+                let (_, outcome, details) = evaluateCaseText meta "module Basic where\n\nf = ''(,)\n"
                 case outcome of
                   OutcomeXFail
                     | null details -> assertFailure "expected xfail details to be non-empty"

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -152,7 +152,7 @@ genPatternWithoutLeadingNegArg n =
 startsWithConstructorNegativeLiteral :: Pattern -> Bool
 startsWithConstructorNegativeLiteral pat =
   case pat of
-    PCon _ (PNegLit {} : _) -> True
+    PCon _ _ (PNegLit {} : _) -> True
     PParen inner -> startsWithConstructorNegativeLiteral inner
     _ -> False
 
@@ -201,8 +201,8 @@ genDeclTypeSynInfix = do
   name <- oneof [genConSym, genConIdent]
   lhsName <- genIdent
   rhsName <- genIdent
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified TyVarBVisible
   DeclTypeSyn . TypeSynDecl span0 TypeHeadInfix name [lhs, rhs] <$> genSimpleType
 
 genDeclData :: Gen Decl
@@ -241,9 +241,9 @@ genDeclDataInfix = do
   rhsName <- genIdent
   extraCount <- chooseInt (0, 2)
   extraNames <- vectorOf extraCount genIdent
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
-      extraParams = [TyVarBinder span0 n Nothing TyVarBSpecified | n <- extraNames]
+  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified TyVarBVisible
+      extraParams = [TyVarBinder span0 n Nothing TyVarBSpecified TyVarBVisible | n <- extraNames]
   ctors <- genSimpleDataCons
   deriving' <- genDerivingClauses
   pure $
@@ -639,8 +639,8 @@ genDeclClassInfix = do
   lhsName <- genIdent
   rhsName <- genIdent
   ctx <- genOptionalSimpleContext
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified TyVarBVisible
       params = [lhs, rhs]
   items <- genClassDeclItems params
   pure $
@@ -835,8 +835,8 @@ genDeclTypeFamilyDeclInfix = do
   name <- nameText
   lhsName <- genIdent
   rhsName <- genIdent
-  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder span0 lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder span0 rhsName Nothing TyVarBSpecified TyVarBVisible
       lhsType = TVar (mkUnqualifiedName NameVarId lhsName)
       rhsType = TVar (mkUnqualifiedName NameVarId rhsName)
       headType = TApp (TApp (TCon (qualifyName Nothing (mkUnqualifiedName nameType name)) Unpromoted) lhsType) rhsType
@@ -955,7 +955,7 @@ genDeclPatSyn = do
   argName <- genIdent
   conName <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
   let args = PatSynPrefixArgs [argName]
-      pat = PCon conName [PVar (mkUnqualifiedName NameVarId argName)]
+      pat = PCon conName [] [PVar (mkUnqualifiedName NameVarId argName)]
   dir <- elements [PatSynBidirectional, PatSynUnidirectional]
   pure $ DeclPatSyn (PatSynDecl span0 synName args pat dir)
 
@@ -974,7 +974,7 @@ genDeclStandaloneKindSig = do
 genSimpleTyVarBinders :: Gen [TyVarBinder]
 genSimpleTyVarBinders = do
   n <- chooseInt (0, 2)
-  vectorOf n (TyVarBinder span0 <$> genIdent <*> pure Nothing <*> pure TyVarBSpecified)
+  vectorOf n (TyVarBinder span0 <$> genIdent <*> pure Nothing <*> pure TyVarBSpecified <*> pure TyVarBVisible)
 
 -- | Generate a simple type for use in declaration contexts.
 genSimpleType :: Gen Type
@@ -1213,7 +1213,7 @@ shrinkDataConDecl con =
       [GadtCon forall' ctx names' body | names' <- shrinkList (const []) names, not (null names')]
         <> [GadtCon forall' ctx names body' | body' <- shrinkGadtBody body]
         <> [GadtCon forall' ctx' names body | ctx' <- shrinkList shrinkType ctx]
-        <> [GadtCon forall'' ctx names body | forall'' <- shrinkTyVarBinders forall']
+        <> [GadtCon forall'' ctx names body | forall'' <- shrinkForallTelescopes forall']
 
 shrinkGadtBody :: GadtBody -> [GadtBody]
 shrinkGadtBody body =
@@ -1346,6 +1346,14 @@ shrinkTyVarBinders = shrinkList shrinkTyVarBinder
   where
     shrinkTyVarBinder tvb =
       [tvb {tyVarBinderName = n'} | n' <- shrinkIdent (tyVarBinderName tvb)]
+
+shrinkForallTelescopes :: [ForallTelescope] -> [[ForallTelescope]]
+shrinkForallTelescopes = shrinkList shrinkForallTelescope
+  where
+    shrinkForallTelescope telescope =
+      [ telescope {forallTelescopeBinders = binders'}
+      | binders' <- shrinkTyVarBinders (forallTelescopeBinders telescope)
+      ]
 
 shrinkFunctionHeadPats :: MatchHeadForm -> [Pattern] -> [[Pattern]]
 shrinkFunctionHeadPats headForm pats =

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -694,6 +694,7 @@ shrinkExpr :: Expr -> [Expr]
 shrinkExpr expr =
   case expr of
     EVar name -> [EVar (name {nameText = shrunk}) | shrunk <- shrinkIdent (nameText name)]
+    ETypeSyntax form ty -> [ETypeSyntax form ty' | ty' <- shrinkType ty]
     EInt value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
     EIntHash value _ -> [EIntHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkIntegral value]
     EIntBase value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -28,6 +28,7 @@ import Test.Properties.Arb.Identifiers
     shrinkFloat,
     shrinkIdent,
   )
+import Test.Properties.Arb.Type (shrinkType)
 import Test.QuickCheck
 
 instance Arbitrary Pattern where
@@ -56,7 +57,7 @@ genPatternWith allowAll depth =
         PTuple Boxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
         PTuple Unboxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x")], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
         pure (PList []),
-        (`PCon` []) <$> genPatternConAstName,
+        (\name -> PCon name [] []) <$> genPatternConAstName,
         genUnboxedSumPatternWith allowAll 0
       ]
     recursiveGenerators =
@@ -81,7 +82,7 @@ genPatternConWith allowView depth = do
   con <- genPatternConAstName
   argCount <- chooseInt (0, 3)
   args <- vectorOf argCount (canonicalPatternAtom <$> genPatternWith allowView (depth - 1))
-  pure (PCon con args)
+  pure (PCon con [] args)
 
 genPatternTypeSigWith :: Bool -> Int -> Gen Pattern
 genPatternTypeSigWith allowAll depth = do
@@ -210,7 +211,7 @@ isPatternAtom pat =
     PView {} -> True
     PAs {} -> True
     PUnboxedSum {} -> True
-    PCon _ [] -> True
+    PCon _ [] [] -> True
     _ -> False
 
 mkIntLiteral :: Integer -> Literal
@@ -234,6 +235,8 @@ shrinkPattern pat =
     PAnn _ sub -> shrinkPattern sub
     PVar name ->
       [PVar (name {unqualifiedNameText = shrunk}) | shrunk <- shrinkIdent (unqualifiedNameText name)]
+    PTypeBinder binder -> [PTypeBinder binder' | binder' <- shrinkTyVarBinder binder]
+    PTypeSyntax form ty -> [PTypeSyntax form ty' | ty' <- shrinkType ty]
     PWildcard -> []
     PLit lit ->
       [PLit shrunk | shrunk <- shrinkLiteral lit]
@@ -244,9 +247,9 @@ shrinkPattern pat =
       shrinkPatternTupleElems tupleFlavor elems
     PList elems ->
       [PList elems' | elems' <- shrinkList shrinkPattern elems]
-    PCon con args ->
-      [PCon con [] | not (null args)]
-        <> [PCon con args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
+    PCon con typeArgs args ->
+      [PCon con typeArgs [] | not (null args)]
+        <> [PCon con typeArgs args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
     PInfix lhs op rhs ->
       [canonicalPatternAtom lhs, canonicalPatternAtom rhs]
         <> [PInfix (canonicalPatternAtom lhs') op (canonicalPatternAtom rhs) | lhs' <- shrinkPattern lhs]
@@ -280,6 +283,10 @@ shrinkPattern pat =
         <> [PTypeSig inner' ty | inner' <- shrinkPattern inner]
     PSplice {} ->
       []
+
+shrinkTyVarBinder :: TyVarBinder -> [TyVarBinder]
+shrinkTyVarBinder tvb =
+  [tvb {tyVarBinderName = name'} | name' <- shrinkIdent (tyVarBinderName tvb)]
 
 shrinkPatternTupleElems :: TupleFlavor -> [Pattern] -> [Pattern]
 shrinkPatternTupleElems tupleFlavor elems =

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -353,6 +353,9 @@ shrinkForallTelescope telescope =
   [ telescope {forallTelescopeBinders = binders'}
   | binders' <- shrinkTypeBinders (forallTelescopeBinders telescope)
   ]
+    <> [ telescope {forallTelescopeVisibility = ForallInvisible}
+       | forallTelescopeVisibility telescope == ForallVisible
+       ]
 
 shrinkTypeTupleElems :: TupleFlavor -> [Type] -> [Type]
 shrinkTypeTupleElems tupleFlavor elems =

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -59,7 +59,7 @@ genType depth
           (1, pure TStar),
           (1, pure TWildcard),
           (2, TQuasiQuote <$> genQuoterName <*> genQuasiBody),
-          (2, TForall <$> genTypeBinders <*> genForallInner (depth - 1)),
+          (2, TForall <$> genForallTelescope <*> genForallInner (depth - 1)),
           (4, genTypeApp depth),
           (4, genTypeFun depth),
           (3, TTuple Boxed Unpromoted <$> genTypeTupleElems (depth - 1)),
@@ -215,22 +215,26 @@ genTypeBinders = do
   n <- chooseInt (1, 3)
   vectorOf n genTyVarBinder
 
+genForallTelescope :: Gen ForallTelescope
+genForallTelescope =
+  ForallTelescope <$> elements [ForallInvisible, ForallVisible] <*> genTypeBinders
+
 genTyVarBinder :: Gen TyVarBinder
 genTyVarBinder = do
   name <- genTypeVarName
   oneof
     [ -- Plain specified binder: a
-      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBSpecified),
+      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBSpecified TyVarBVisible),
       -- Plain inferred binder: {a}
-      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBInferred),
+      pure (TyVarBinder span0 (renderUnqualifiedName name) Nothing TyVarBInferred TyVarBVisible),
       -- Kinded inferred binder: {a :: Kind}
       do
         kind <- genSimpleTypeAtom 0
-        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBInferred),
+        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBInferred TyVarBVisible),
       -- Kinded specified binder: (a :: Kind)
       do
         kind <- genSimpleTypeAtom 0
-        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBSpecified)
+        pure (TyVarBinder span0 (renderUnqualifiedName name) (Just kind) TyVarBSpecified TyVarBVisible)
     ]
 
 genTypeVarName :: Gen UnqualifiedName
@@ -298,10 +302,10 @@ shrinkType ty =
     TQuasiQuote quoter body ->
       [TQuasiQuote q body | q <- shrinkIdent quoter]
         <> [TQuasiQuote quoter b | b <- map T.pack (shrink (T.unpack body))]
-    TForall binders inner ->
+    TForall telescope inner ->
       [inner]
-        <> [TForall binders' inner | binders' <- shrinkTypeBinders binders]
-        <> [TForall binders inner' | inner' <- shrinkType inner]
+        <> [TForall telescope' inner | telescope' <- shrinkForallTelescope telescope]
+        <> [TForall telescope inner' | inner' <- shrinkType inner]
     TApp fn arg ->
       [fn, arg]
         <> [TApp fn' arg | fn' <- shrinkType fn]
@@ -343,6 +347,12 @@ shrinkTypeBinders binders =
 shrinkTyVarBinder :: TyVarBinder -> [TyVarBinder]
 shrinkTyVarBinder tvb =
   [tvb {tyVarBinderName = name'} | name' <- shrinkIdent (tyVarBinderName tvb)]
+
+shrinkForallTelescope :: ForallTelescope -> [ForallTelescope]
+shrinkForallTelescope telescope =
+  [ telescope {forallTelescopeBinders = binders'}
+  | binders' <- shrinkTypeBinders (forallTelescopeBinders telescope)
+  ]
 
 shrinkTypeTupleElems :: TupleFlavor -> [Type] -> [Type]
 shrinkTypeTupleElems tupleFlavor elems =

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -20,7 +20,7 @@ import Text.Megaparsec.Error qualified as MPE
 declConfig :: ParserConfig
 declConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension PatternSynonyms, EnableExtension UnicodeSyntax, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension PatternSynonyms, EnableExtension UnicodeSyntax, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments]
     }
 
 prop_declPrettyRoundTrip :: Decl -> Property

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -33,6 +33,7 @@ normalizeExpr expr =
     EString value repr -> EString value repr
     EStringHash value repr -> EStringHash value repr
     EOverloadedLabel value repr -> EOverloadedLabel value repr
+    ETypeSyntax form ty -> ETypeSyntax form (normalizeType ty)
     EQuasiQuote quoter body -> EQuasiQuote quoter body
     EApp fn arg -> EApp (normalizeExpr fn) (normalizeExpr arg)
     EInfix lhs op rhs -> EInfix (normalizeExpr lhs) op (normalizeExpr rhs)
@@ -106,12 +107,14 @@ normalizePattern pat =
   case pat of
     PAnn _ sub -> normalizePattern sub
     PVar name -> PVar name
+    PTypeBinder binder -> PTypeBinder (normalizeTyVarBinder binder)
+    PTypeSyntax form ty -> PTypeSyntax form (normalizeType ty)
     PWildcard -> PWildcard
     PLit lit -> PLit (normalizeLiteral lit)
     PQuasiQuote quoter body -> PQuasiQuote quoter body
     PTuple tupleFlavor elems -> PTuple tupleFlavor (map normalizePattern elems)
     PList elems -> PList (map normalizePattern elems)
-    PCon con args -> PCon con (map normalizePattern args)
+    PCon con typeArgs args -> PCon con (map normalizeType typeArgs) (map normalizePattern args)
     PInfix lhs op rhs -> PInfix (normalizePattern lhs) op (normalizePattern rhs)
     PView e inner -> PView (normalizeExpr e) (normalizePattern inner)
     PAs name inner -> PAs name (normalizeUnaryPatInner inner)
@@ -322,7 +325,7 @@ stripTypeAnnotations ty =
     TTypeLit l -> TTypeLit l
     TStar -> TStar
     TQuasiQuote q b -> TQuasiQuote q b
-    TForall bs t -> TForall bs (stripTypeAnnotations t)
+    TForall telescope t -> TForall (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)}) (stripTypeAnnotations t)
     TApp a b -> TApp (stripTypeAnnotations a) (stripTypeAnnotations b)
     TFun a b -> TFun (stripTypeAnnotations a) (stripTypeAnnotations b)
     TTuple fl pr es -> TTuple fl pr (map stripTypeAnnotations es)
@@ -343,7 +346,10 @@ normalizeType ty =
     TTypeLit lit -> TTypeLit lit
     TStar -> TStar
     TQuasiQuote quoter body -> TQuasiQuote quoter body
-    TForall binders inner -> TForall (map normalizeTyVarBinder binders) (normalizeType inner)
+    TForall telescope inner ->
+      TForall
+        (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)})
+        (normalizeType inner)
     TApp fn arg -> TApp (normalizeType fn) (normalizeType arg)
     TFun lhs rhs -> TFun (normalizeType lhs) (normalizeType rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
@@ -361,6 +367,12 @@ normalizeTyVarBinder tvb =
   tvb
     { tyVarBinderSpan = span0,
       tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
+    }
+
+normalizeForallTelescope :: ForallTelescope -> ForallTelescope
+normalizeForallTelescope telescope =
+  telescope
+    { forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)
     }
 
 normalizeWarningText :: WarningText -> WarningText
@@ -440,7 +452,7 @@ normalizeDataConInner (InfixCon forallVars constraints lhs op rhs) =
 normalizeDataConInner (RecordCon forallVars constraints name fields) =
   RecordCon forallVars (map normalizeType constraints) name (map normalizeFieldDecl fields)
 normalizeDataConInner (GadtCon forallBinders constraints names body) =
-  GadtCon (map normalizeTyVarBinder forallBinders) (map normalizeType constraints) names (normalizeGadtBody body)
+  GadtCon (map normalizeForallTelescope forallBinders) (map normalizeType constraints) names (normalizeGadtBody body)
 
 normalizeBangType :: BangType -> BangType
 normalizeBangType bt =

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -23,7 +23,7 @@ import Text.Megaparsec.Error qualified as MPE
 exprConfig :: ParserConfig
 exprConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments]
     }
 
 prop_exprPrettyRoundTrip :: Expr -> Property

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -31,7 +31,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments]
     }
 
 -- Module normalization

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -21,7 +21,7 @@ import Text.Megaparsec.Error qualified as MPE
 patternConfig :: ParserConfig
 patternConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments]
     }
 
 prop_patternPrettyRoundTrip :: Pattern -> Property
@@ -29,7 +29,7 @@ prop_patternPrettyRoundTrip pat =
   let source = renderStrict (layoutPretty defaultLayoutOptions (pretty pat))
       expected = normalizePattern (addPatternParens pat)
    in checkCoverage $
-        assertCtorCoverage ["PAnn"] pat $
+        assertCtorCoverage ["PAnn", "PTypeBinder", "PTypeSyntax"] pat $
           counterexample (T.unpack source) $
             case parsePattern patternConfig source of
               ParseErr err ->
@@ -43,12 +43,14 @@ normalizePattern pat =
   case pat of
     PAnn _ sub -> normalizePattern sub
     PVar name -> PVar name
+    PTypeBinder binder -> PTypeBinder (normalizeTyVarBinderSpan binder)
+    PTypeSyntax form ty -> PTypeSyntax form (normalizeTypeSpan ty)
     PWildcard -> PWildcard
     PLit lit -> PLit (normalizeLiteral lit)
     PQuasiQuote quoter body -> PQuasiQuote quoter body
     PTuple tupleFlavor elems -> PTuple tupleFlavor (map normalizePattern elems)
     PList elems -> PList (map normalizePattern elems)
-    PCon con args -> PCon con (map normalizePattern args)
+    PCon con typeArgs args -> PCon con (map normalizeTypeSpan typeArgs) (map normalizePattern args)
     PInfix lhs op rhs -> PInfix (normalizePattern lhs) op (normalizePattern rhs)
     PView expr inner -> PView (normalizeExpr expr) (normalizePattern inner)
     PAs name inner -> PAs name (normalizeAsInner inner)
@@ -71,7 +73,7 @@ normalizeTypeSpan ty =
     TTypeLit lit -> TTypeLit lit
     TStar -> TStar
     TQuasiQuote quoter body -> TQuasiQuote quoter body
-    TForall binders inner -> TForall (map normalizeTyVarBinderSpan binders) (normalizeTypeSpan inner)
+    TForall telescope inner -> TForall (normalizeForallTelescope telescope) (normalizeTypeSpan inner)
     TApp lhs rhs -> TApp (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
     TFun lhs rhs -> TFun (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeTypeSpan elems)
@@ -128,4 +130,10 @@ normalizeTyVarBinderSpan tvb =
   tvb
     { tyVarBinderSpan = span0,
       tyVarBinderKind = fmap normalizeTypeSpan (tyVarBinderKind tvb)
+    }
+
+normalizeForallTelescope :: ForallTelescope -> ForallTelescope
+normalizeForallTelescope telescope =
+  telescope
+    { forallTelescopeBinders = map normalizeTyVarBinderSpan (forallTelescopeBinders telescope)
     }

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -52,7 +52,10 @@ normalizeType ty =
     TStar -> TStar
     TWildcard -> TWildcard
     TQuasiQuote quoter body -> TQuasiQuote quoter body
-    TForall binders inner -> TForall (map normalizeTyVarBinder binders) (normalizeType inner)
+    TForall telescope inner ->
+      TForall
+        (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)})
+        (normalizeType inner)
     TApp f x -> TApp (normalizeType f) (normalizeType x)
     TFun a b -> TFun (normalizeType a) (normalizeType b)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
@@ -76,7 +79,7 @@ normalizeTyVarBinder tvb =
 containsKindedInferredBinder :: Type -> Bool
 containsKindedInferredBinder ty =
   case ty of
-    TForall binders inner -> any isKindedInferredBinder binders || containsKindedInferredBinder inner
+    TForall telescope inner -> any isKindedInferredBinder (forallTelescopeBinders telescope) || containsKindedInferredBinder inner
     TImplicitParam _name inner -> containsKindedInferredBinder inner
     TApp f x -> containsKindedInferredBinder f || containsKindedInferredBinder x
     TFun a b -> containsKindedInferredBinder a || containsKindedInferredBinder b

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -28,6 +28,7 @@ import Aihc.Parser.Syntax
     Decl (..),
     Expr (..),
     FieldDecl (..),
+    ForallTelescope (..),
     GadtBody (..),
     GuardQualifier (..),
     GuardedRhs (..),
@@ -328,6 +329,9 @@ resolveExprAt scope nextLocal lastSeen expr =
       let here = peelExprSpan lastSeen expr
           (nextLocal', inner') = resolveExprAt scope nextLocal here inner
        in (nextLocal', ETypeSig inner' (resolveTypeAt scope here ty))
+    ETypeSyntax form ty ->
+      let here = peelExprSpan lastSeen expr
+       in (nextLocal, ETypeSyntax form (resolveTypeAt scope here ty))
     EParen inner ->
       let here = peelExprSpan lastSeen expr
           (nextLocal', inner') = resolveExprAt scope nextLocal here inner
@@ -335,7 +339,7 @@ resolveExprAt scope nextLocal lastSeen expr =
     ETypeApp fun ty ->
       let here = peelExprSpan lastSeen expr
           (nextLocal', fun') = resolveExprAt scope nextLocal here fun
-       in (nextLocal', ETypeApp fun' ty)
+       in (nextLocal', ETypeApp fun' (resolveTypeAt scope here ty))
     EApp fun arg ->
       let here = peelExprSpan lastSeen expr
           (nextLocal', fun') = resolveExprAt scope nextLocal here fun
@@ -402,6 +406,16 @@ bindPattern typeScope lastSeen nextLocal pat =
           resolvedName = ResolvedLocal nextLocal name
           annotation = ResolutionAnnotation sp (renderUnqualifiedName name) ResolutionNamespaceTerm resolvedName
        in (nextLocal + 1, Scope (Map.singleton (renderUnqualifiedName name) resolvedName) Map.empty Map.empty, annotatePattern annotation (PVar name))
+    PTypeBinder binder ->
+      let scoped = unionScope emptyScope typeScope
+          binderName = mkUnqualifiedName NameVarId (tyVarBinderName binder)
+          resolvedName = ResolvedLocal nextLocal binderName
+          binder' = binder {tyVarBinderKind = fmap (resolveTypeAt scoped NoSourceSpan) (tyVarBinderKind binder)}
+          binderScope = Scope Map.empty (Map.singleton (tyVarBinderName binder) resolvedName) Map.empty
+       in (nextLocal + 1, binderScope, PTypeBinder binder')
+    PTypeSyntax form ty ->
+      let here = peelPatternSpan lastSeen pat
+       in (nextLocal, emptyScope, PTypeSyntax form (resolveTypeAt typeScope here ty))
     PTuple flavor pats ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, pats') = bindPatterns typeScope here nextLocal pats
@@ -410,10 +424,10 @@ bindPattern typeScope lastSeen nextLocal pat =
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, pats') = bindPatterns typeScope here nextLocal pats
        in (nextLocal', scope, PList pats')
-    PCon name pats ->
+    PCon name typeArgs pats ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, pats') = bindPatterns typeScope here nextLocal pats
-       in (nextLocal', scope, PCon name pats')
+       in (nextLocal', scope, PCon name (map (resolveTypeAt typeScope here) typeArgs) pats')
     PInfix left name right ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', leftScope, left') = bindPattern typeScope here nextLocal left
@@ -515,11 +529,11 @@ resolveTypeAt scope lastSeen ty =
     TImplicitParam name inner ->
       let here = lastSeen
        in TImplicitParam name (resolveTypeAt scope here inner)
-    TForall binders inner ->
+    TForall telescope inner ->
       let here = lastSeen
-          (binderScope, binders') = bindTyVarBinders scope binders
+          (binderScope, binders') = bindTyVarBinders scope (forallTelescopeBinders telescope)
           scoped = unionScope binderScope scope
-       in TForall binders' (resolveTypeAt scoped here inner)
+       in TForall (telescope {forallTelescopeBinders = binders'}) (resolveTypeAt scoped here inner)
     TApp left right ->
       let here = lastSeen
        in TApp (resolveTypeAt scope here left) (resolveTypeAt scope here right)
@@ -567,10 +581,10 @@ resolveTypeSignatureAt scope nextLocal ambient ty =
     -- Type signatures may carry span-only 'TAnn' wrappers (see 'typeAnnSpan'); peel
     -- them so we still allocate scoped type variables and advance 'nextLocal'.
     TAnn ann sub -> resolveTypeSignatureAt scope nextLocal (pushSpanFromAnn ambient ann) sub
-    TForall binders inner ->
-      let (nextLocal', binderScope, binders') = bindTyVarBindersWithIds scope nextLocal binders
+    TForall telescope inner ->
+      let (nextLocal', binderScope, binders') = bindTyVarBindersWithIds scope nextLocal (forallTelescopeBinders telescope)
           scoped = unionScope binderScope scope
-       in (nextLocal', binderScope, TForall binders' (resolveTypeAt scoped ambient inner))
+       in (nextLocal', binderScope, TForall (telescope {forallTelescopeBinders = binders'}) (resolveTypeAt scoped ambient inner))
     _ -> (nextLocal, emptyScope, resolveTypeAt scope ambient ty)
 
 bindTyVarBinders :: Scope -> [TyVarBinder] -> (Scope, [TyVarBinder])

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -248,7 +248,7 @@ unifyMatchRhs expectedTy match = do
 -- extra constraints are needed.
 inferPatCts :: Pattern -> TcType -> TcM [Ct]
 inferPatCts pat scrutTy = case pat of
-  PCon name _subPats -> do
+  PCon name _typeArgs _subPats -> do
     let conName = patNameToText name
     mBinder <- lookupTerm conName
     case mBinder of
@@ -292,7 +292,7 @@ extractPatternBindings (pat, ty) = case pat of
   PAs name inner -> (name, ty) : extractPatternBindings (inner, ty)
   PStrict inner -> extractPatternBindings (inner, ty)
   PIrrefutable inner -> extractPatternBindings (inner, ty)
-  PCon _name subPats ->
+  PCon _name _typeArgs subPats ->
     concatMap (\p -> extractPatternBindings (p, ty)) subPats
   PInfix lhs _name rhs ->
     extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -159,7 +159,7 @@ inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
 -- no extra constraints are needed (the variable just gets the scrutinee type).
 inferPatternConstraints :: SourceSpan -> TcType -> Pattern -> TcM [Ct]
 inferPatternConstraints sp scrutTy pat = case pat of
-  PCon name _subPats -> do
+  PCon name _typeArgs _subPats -> do
     -- Look up the constructor; if found, emit scrutTy ~ constructor result type.
     let conName = nameToText name
     mBinder <- lookupTerm conName
@@ -294,7 +294,7 @@ extractPatternBindings (pat, ty) = case pat of
   -- For constructor patterns like (True), (Just x), etc. the overall
   -- pattern type doesn't directly give us the sub-pattern types. But
   -- we can still extract the variable names for binding purposes.
-  PCon _name subPats ->
+  PCon _name _typeArgs subPats ->
     -- Each sub-pattern gets an unknown type (we'd need constructor info
     -- to assign proper types). For the MVP, they're not needed since
     -- constructor pattern matching in function heads is handled by tcMatches.


### PR DESCRIPTION
## Summary
- add parser and AST support for `TypeAbstractions` and `RequiredTypeArguments`, including explicit `type` syntax in expressions and patterns, type binders in lambdas and function heads, invisible declaration binders, and GADT forall telescopes
- update pretty-printing, paren insertion, shorthand rendering, roundtrip helpers, generators, and downstream resolver/typechecker code to understand the new syntax shapes without churning existing shorthand output unnecessarily
- add focused regression coverage and promote the `TypeAbstractions/type-synonym-abstraction.hs` oracle fixture from `xfail` to `pass`

## Progress
- parser/oracle/unit/property coverage updated for the new syntax forms
- `just fmt` passed
- `just check` passed
- `coderabbit review --prompt-only` run locally; addressed the reported `@` tokenization issue in `startsWithTypeBinder`