### PR TITLE
test(parser): add xfail oracle fixtures for typelevel-tools-yj and kind-apply

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/kind-apply-spine-lot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/kind-apply-spine-lot.hs
@@ -1,0 +1,16 @@
+{- ORACLE_TEST xfail reason="type family injectivity annotation with equality constraint is not parsed" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module M where
+
+data LoT k
+
+data a :&&: b
+
+type family SpineLoT (tys :: LoT k) = (tys' :: LoT k) | tys' -> tys where
+  SpineLoT (a ':&&: as) = a ':&&: SpineLoT as
+  SpineLoT 'LoT0 = 'LoT0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/typelevel-tools-yj-infix-instance-context.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/typelevel-tools-yj-infix-instance-context.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail reason="infix type operator in instance context roundtrips to prefix form" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module M where
+
+class (xs :: [k]) `IsPrefixOf` (ys :: [k])
+
+instance (xs `IsPrefixOf` ys) => (x ': xs) `IsPrefixOf` (x ': ys)


### PR DESCRIPTION
## Summary

- Add xfail oracle fixture for `typelevel-tools-yj`: infix type operator in instance context roundtrips to prefix form
- Add xfail oracle fixture for `kind-apply`: type family injectivity annotation with equality constraint is not parsed
- `http-download` failure does not reproduce as a standalone xfail; the original error was a layout recovery issue in the larger file context that disappears when isolated

## New Fixtures

- `Hackage/typelevel-tools-yj-infix-instance-context` (xfail)
- `Hackage/kind-apply-spine-lot` (xfail)