### PR TITLE
test(parser): add xfail fixtures for else-do/then-do layout with inner if-then-else

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-else-do-if-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-else-do-if-layout.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST xfail else-do layout block closed prematurely by inner then/else -}
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: inner 'if-then-else' inside 'else do' layout block where the
+-- outer if-then-else is on one line. The 'do' in the else branch starts a
+-- layout block, but the lexer's closeBeforeThenElse incorrectly closes the
+-- do-layout when it encounters the inner 'then' (whose column is less than
+-- the outer 'else' column). GHC accepts this; aihc-parser rejects it.
+-- Minimized from http-download-0.2.1.0 Verified.hs:322.
+module DoAndIfThenElseElseDoIfLayout where
+
+foo = if a then b else do
+    if c then d else e

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-then-do-if-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-then-do-if-layout.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST xfail then-do layout block closed prematurely by inner then/else -}
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: inner 'if-then-else' inside 'then do' layout block where the
+-- outer if-then-else has 'then do' on one line. The 'do' in the then branch
+-- starts a layout block, but the lexer's closeBeforeThenElse incorrectly
+-- closes the do-layout when it encounters the inner 'then' (whose column is
+-- less than the outer 'then' column). GHC accepts this; aihc-parser rejects
+-- it. Minimized from http-download-0.2.1.0 Verified.hs:322.
+module DoAndIfThenElseThenDoIfLayout where
+
+foo = if a then do
+    if c then d else e
+    else b


### PR DESCRIPTION
## Summary

- Add two xfail oracle fixtures for a `DoAndIfThenElse` layout bug where the lexer's `closeBeforeThenElse` prematurely closes a `do`-layout block when an inner `if-then-else` appears inside `else do` or `then do`
- Minimized from `http-download-0.2.1.0` `Verified.hs:322`

## Root Cause

When the outer `if-then-else` is on a single line (e.g., `if a then b else do`), the lexer creates a `LayoutAfterThenElse` context with `thenCol` set to the outer `else` column. When the inner `then` is encountered on a subsequent line at a lower column, `closeBeforeThenElse` checks `col <= thenCol` and incorrectly closes the `do`-layout. The fix should also check that the `then`/`else` is outside the layout block (`col < indent`) before closing it.

## Progress

- DoAndIfThenElse oracle: 15 pass → 15 pass + 2 xfail