### PR TITLE
test(parser): add minimal hackage oracle xfails

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-subscript-identifier.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-subscript-identifier.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail reason="subscript digit identifiers break value bindings after the lhs" -}
+
+module M where
+
+f p₀ = p₀

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-superscript-identifier.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-superscript-identifier.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="superscript digit identifiers are rejected in type constructor names" -}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module M where
+
+data S⁰_ r = PositiveHalfSphere

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/named-text-kind-annotated-type-synonym.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/named-text-kind-annotated-type-synonym.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="kind-annotated type synonym rhs is rejected after the promoted literal" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+
+module M where
+
+import GHC.TypeLits (Symbol)
+
+type NameStyle = Symbol
+
+type UTF8 = "UTF8" :: NameStyle

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/oops-injective-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/oops-injective-type-family.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="injective type families with result kind signatures stop at the equals sign" -}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+module M where
+
+import Data.Kind (Constraint)
+
+type family All (cs :: [Constraint]) = (c :: Constraint) | c -> cs where
+  All '[] = ()


### PR DESCRIPTION
## Summary
- add four minimized oracle `xfail` fixtures derived from `named-text`, `manifolds-core`, and `oops`
- cover distinct parser gaps for kind-annotated type synonym rhs, unicode superscript/subscript identifiers, and injective type family result kind signatures
- keep the cases standalone and package-minimal so they are stable regression fixtures

## Checks
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)

## Progress
- overall extension progress remains `SUPPORTED 76`, `IN_PROGRESS 8`, `TOTAL 84`
- fixture counts changed by: `DataKinds +2 xfail`, `KindSignatures +1 xfail`, `ConstraintKinds +1 xfail`, `TypeFamilyDependencies +1 xfail`, `UnicodeSyntax +1 xfail`