### PR TITLE
test(parser): add minimal hackage oracle xfails

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-hs-meta-record-field-view-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-hs-meta-record-field-view-pattern.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail reason="view patterns inside record field patterns are rejected" -}
+{-# LANGUAGE ViewPatterns #-}
+
+module M where
+
+data Box = Box {field :: Int}
+
+f (Box {field = id -> x}) = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/json-spec-elm-lambda-cases.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/json-spec-elm-lambda-cases.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail reason="multi-argument \\cases alternatives are rejected after the first branch" -}
+{-# LANGUAGE LambdaCase #-}
+
+module M where
+
+f = \cases
+  True False -> 0
+  _ _ -> 1

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/termbox-bundled-pattern-export.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/termbox-bundled-pattern-export.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="bundled pattern synonym export after .. is rejected" -}
+{-# LANGUAGE PatternSynonyms #-}
+
+module M (T (.., P)) where
+
+data T = T
+
+pattern P :: T
+pattern P = T


### PR DESCRIPTION
## Summary
- add minimal oracle `xfail` fixtures reduced from `termbox`, `ghc-hs-meta`, and `json-spec-elm`
- cover three parser gaps: bundled pattern synonym exports, record-field view patterns, and multi-argument `\\cases` alternatives
- keep the changes fixture-only so downstream package regressions are captured without changing parser behavior

## Progress
- oracle fixtures: `863 -> 866`
- oracle xfails: `7 -> 10`

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`

## CodeRabbit
- reported one unrelated potential issue in `components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs`
- left out of this PR because it is outside the new fixture-only change set