### PR TITLE
test(parser): add minimal xfail fixtures for MemoTrie and related packages

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indexed-profunctors-hash-dot-export.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indexed-profunctors-hash-dot-export.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="overloaded labels lex #. as a label instead of an exported operator" -}
+{-# LANGUAGE OverloadedLabels #-}
+
+module IndexedProfunctorsHashDotExport
+  ( (#.),
+  )
+where
+
+(#.) x y = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/memotrie-associated-data-family-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/memotrie-associated-data-family-operator.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail reason="associated data family declarations reject operator names" -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module MemoTrieAssociatedDataFamilyOperator where
+
+class C a where
+  data (:*:) a :: * -> *

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/traverse-with-class-th-tuple-name-quote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/traverse-with-class-th-tuple-name-quote.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="template haskell type-name quotes reject tuple constructors" -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module TraverseWithClassTHTupleNameQuote where
+
+f = ''(,)


### PR DESCRIPTION
## Summary
- Add three minimal oracle `xfail` fixtures derived from `MemoTrie`, `traverse-with-class`, and `indexed-profunctors` hackage failures.
- Reduce each case to the smallest GHC-accepted snippet that still reproduces the parser gap: associated data family operator heads, Template Haskell tuple type-name quotes, and `OverloadedLabels` treating `#.` as an overloaded label in exports.
- Oracle fixture progress: `xfail` count increases from 7 to 10.

## Validation
- Ran `just fmt`
- Ran `just check`
- Ran targeted oracle cases for all three new fixtures

## CodeRabbit
- `coderabbit review --prompt-only` was attempted but rate-limited by the service
