### PR TITLE
test(parser): add minimal oracle xfails for hackage regressions

### DIFF
--- a/components/aihc-parser/common/ExtensionSupport.hs
+++ b/components/aihc-parser/common/ExtensionSupport.hs
@@ -19,7 +19,6 @@ import Aihc.Parser.Syntax qualified as Syntax
 import CppSupport (moduleHeaderExtensionSettings, preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd, sort, sortOn)
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO.Utf8 qualified as Utf8
@@ -76,7 +75,6 @@ evaluateCaseFromFile meta = do
 evaluateCaseText :: CaseMeta -> Text -> (CaseMeta, Outcome, String)
 evaluateCaseText meta source =
   let exts = caseExtensions meta
-      edition = fromMaybe Syntax.Haskell2010Edition (Syntax.editionFromExtensionSettings exts)
       source' =
         resultOutput
           ( preprocessForParserWithoutIncludesIfEnabled
@@ -86,8 +84,8 @@ evaluateCaseText meta source =
               []
               source
           )
-      oracleOk = either Just (const Nothing) (oracleModuleAstFingerprint (casePath meta) edition exts source')
-      validationOk = fmap show (validateParser (casePath meta) edition exts source')
+      oracleOk = either Just (const Nothing) (oracleModuleAstFingerprint (casePath meta) Syntax.Haskell2010Edition exts source')
+      validationOk = fmap show (validateParser (casePath meta) Syntax.Haskell2010Edition exts source')
    in finalizeOutcome meta oracleOk validationOk
 
 trim :: String -> String

--- a/components/aihc-parser/common/ExtensionSupport.hs
+++ b/components/aihc-parser/common/ExtensionSupport.hs
@@ -19,6 +19,7 @@ import Aihc.Parser.Syntax qualified as Syntax
 import CppSupport (moduleHeaderExtensionSettings, preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd, sort, sortOn)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO.Utf8 qualified as Utf8
@@ -74,9 +75,8 @@ evaluateCaseFromFile meta = do
 
 evaluateCaseText :: CaseMeta -> Text -> (CaseMeta, Outcome, String)
 evaluateCaseText meta source =
-  -- Use Haskell2010 as the base language for oracle tests, as these fixtures
-  -- are meant to be valid Haskell2010 code (possibly with extensions)
   let exts = caseExtensions meta
+      edition = fromMaybe Syntax.Haskell2010Edition (Syntax.editionFromExtensionSettings exts)
       source' =
         resultOutput
           ( preprocessForParserWithoutIncludesIfEnabled
@@ -86,8 +86,8 @@ evaluateCaseText meta source =
               []
               source
           )
-      oracleOk = either Just (const Nothing) (oracleModuleAstFingerprint (casePath meta) Syntax.Haskell2010Edition exts source')
-      validationOk = fmap show (validateParser (casePath meta) Syntax.Haskell2010Edition exts source')
+      oracleOk = either Just (const Nothing) (oracleModuleAstFingerprint (casePath meta) edition exts source')
+      validationOk = fmap show (validateParser (casePath meta) edition exts source')
    in finalizeOutcome meta oracleOk validationOk
 
 trim :: String -> String

--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -14,7 +14,7 @@ import Aihc.Parser.Lex qualified as Lex
 import Aihc.Parser.Syntax qualified as Syntax
 import Control.Exception (catch, displayException, evaluate)
 import CppSupport (preprocessForParserWithoutIncludes)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Data.EnumSet qualified as EnumSet
@@ -174,4 +174,5 @@ computeEffectiveExtensions ::
   -- | Effective set of extensions
   [Syntax.Extension]
 computeEffectiveExtensions edition extensionSettings headerPragmas =
-  Syntax.effectiveExtensions edition (extensionSettings ++ Syntax.headerExtensionSettings headerPragmas)
+  let effectiveEdition = fromMaybe edition (Syntax.headerLanguageEdition headerPragmas)
+   in Syntax.effectiveExtensions effectiveEdition (extensionSettings ++ Syntax.headerExtensionSettings headerPragmas)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/resourcet-export-pattern-synonym-after-dotdot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/resourcet-export-pattern-synonym-after-dotdot.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="export lists reject pattern synonym names after .. in a constructor export" -}
+{-# LANGUAGE PatternSynonyms #-}
+
+module M (T (.., P)) where
+
+data T = A
+
+pattern P :: T
+pattern P = A

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/roundingfiasco-word64-binary-literal-case-alt.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/roundingfiasco-word64-binary-literal-case-alt.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail reason="binary extended literals with primitive suffixes fail in case alternatives" -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE ExtendedLiterals #-}
+{-# LANGUAGE MagicHash #-}
+
+module M where
+
+f x = case x of
+  0b0#Word64 -> 0#


### PR DESCRIPTION
## Summary
- add minimal oracle xfail fixtures for the `resourcet` export-list regression and the `RoundingFiasco` primitive binary-literal case-alternative regression
- fix oracle fixture evaluation so fixture-selected language editions such as `GHC2021` are passed through to both the GHC oracle and parser validation
- reproduce `co-log-core`, but leave it out of oracle fixtures because CPP preprocessing removes the failure before oracle validation

## Progress Counts
- oracle progress: `pass=856 xfail=13 xpass=0 fail=0` (was `pass=856 xfail=11 xpass=0 fail=0` before this PR)
- completion is now `98.50%`

## Validation
- `just fmt`
- `just check`

## Review
- `coderabbit review --prompt-only` was attempted but rate-limited by the service