### PR TITLE
test(parser): add minimal hackage xfails for functor-products and symbolize

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/functor-products-associated-injective-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/functor-products-associated-injective-type-family.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="associated type families with injectivity annotations stop at the bar" -}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+module M where
+
+import Data.Kind (Type)
+
+class FProd (f :: Type -> Type) where
+  type Elem f = (i :: f k -> k -> Type) | i -> f

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/symbolize-export-double-hash-identifier.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/symbolize-export-double-hash-identifier.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail reason="module export lists reject identifiers that end in double hashes" -}
+{-# LANGUAGE MagicHash #-}
+
+module M (f##) where
+
+f## = undefined


### PR DESCRIPTION
## Summary
- add minimal oracle `xfail` fixtures for `functor-products` and `symbolize`
- capture the `functor-products` associated injective type family parse failure at the `|` token
- capture the `symbolize` export-list parse failure for identifiers ending in `##`

## Progress
- Oracle fixture count: 2 new minimal `Hackage` xfails added
- Remaining package from the requested set: `diagrams-postscript` still reproduces in `hackage-tester`, but did not shrink to a stable standalone oracle fixture in this pass

## Validation
- ran `just fmt`
- ran `just check`
- ran `coderabbit review --prompt-only` with no findings
