### PR TITLE
fix(parser): broaden unicode identifier and symbol generation

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -350,7 +350,7 @@ lexImplicitParam env st
   | otherwise =
       case lexerInput st of
         '?' :< rest0@(c :< _)
-          | isAsciiLower c || c == '_' ->
+          | isVarIdentifierStartChar c ->
               let tailChars = T.takeWhile isIdentTail (T.tail rest0)
                   txt = T.take (2 + T.length tailChars) (lexerInput st)
                   st' = advanceChars txt st
@@ -935,8 +935,11 @@ takeQuoter input =
 isIdentStart :: Char -> Bool
 isIdentStart c = isAsciiUpper c || isAsciiLower c || c == '_' || isUniSmall c || isUniLarge c
 
+isVarIdentifierStartChar :: Char -> Bool
+isVarIdentifierStartChar c = c == '_' || isAsciiLower c || isUniSmall c
+
 isIdentTail :: Char -> Bool
-isIdentTail c = isIdentStart c || isDigit c || c == '\''
+isIdentTail c = isIdentStart c || isIdentNumber c || c == '\''
 
 isConIdStart :: Char -> Bool
 isConIdStart c = isAsciiUpper c || isUniLarge c
@@ -946,6 +949,12 @@ isUniSmall c = not (isAscii c) && generalCategory c == LowercaseLetter
 
 isUniLarge :: Char -> Bool
 isUniLarge c = not (isAscii c) && generalCategory c `elem` [UppercaseLetter, TitlecaseLetter]
+
+isIdentNumber :: Char -> Bool
+isIdentNumber c =
+  isDigit c
+    || generalCategory c == DecimalNumber
+    || generalCategory c == OtherNumber
 
 isSymbolicOpChar :: Char -> Bool
 isSymbolicOpChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeSymbol c

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -29,7 +29,7 @@ where
 
 import Aihc.Parser.Parens (addDeclParens, addExprParens, addModuleParens, addPatternParens, addTypeParens)
 import Aihc.Parser.Syntax
-import Data.Char (GeneralCategory (..), generalCategory, isAscii, isAsciiLower, isAsciiUpper, isDigit)
+import Data.Char (GeneralCategory (..), generalCategory, isAscii)
 import Data.Maybe (catMaybes, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -1296,7 +1296,7 @@ thNameQuoteTextNeedsParens name
 splitQualifiedNameQuoteText :: Text -> Maybe (Text, Text)
 splitQualifiedNameQuoteText fullName =
   case T.uncons fullName of
-    Just (c, _) | isAsciiUpper c -> go fullName
+    Just (c, _) | isConIdentifierStartChar c -> go fullName
     _ -> Nothing
   where
     go txt =
@@ -1312,10 +1312,20 @@ splitQualifiedNameQuoteText fullName =
 
     isModuleSegment segment =
       case T.uncons segment of
-        Just (c, rest) -> isAsciiUpper c && T.all isIdentChar rest
+        Just (c, rest) -> isConIdentifierStartChar c && T.all isIdentChar rest
         Nothing -> False
 
-    isIdentChar c = isAsciiUpper c || isAsciiLower c || c == '_' || c == '\'' || c == '#' || isDigit c
+    isIdentChar c = isIdentifierStartChar c || isIdentifierNumberChar c || c == '\'' || c == '#'
+
+    isIdentifierStartChar c = c == '_' || generalCategory c == LowercaseLetter || isConIdentifierStartChar c
+
+    isConIdentifierStartChar c = generalCategory c `elem` [UppercaseLetter, TitlecaseLetter]
+
+    isIdentifierNumberChar c =
+      case generalCategory c of
+        DecimalNumber -> True
+        OtherNumber -> True
+        _ -> False
 
 isOperatorToken :: Text -> Bool
 isOperatorToken tok =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -154,7 +154,7 @@ module Aihc.Parser.Syntax
 where
 
 import Control.DeepSeq (NFData (..))
-import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+import Data.Char (GeneralCategory (..), generalCategory)
 import Data.Data (Constr, Data (..), DataType, Fixity (Prefix), mkConstr, mkDataType)
 import Data.Dynamic (Dynamic, Typeable, fromDynamic, toDyn)
 import Data.List (sort)
@@ -730,12 +730,12 @@ nameFromText txt =
 
     isModuleSegment segment =
       case T.uncons segment of
-        Just (c, rest) -> isAsciiUpper c && T.all isIdentChar rest
+        Just (c, rest) -> isConIdentifierStartChar c && T.all isIdentChar rest
         Nothing -> False
 
     isIdentifierSegment segment =
       case T.uncons segment of
-        Just (c, rest) -> (isAsciiUpper c || isAsciiLower c || c == '_') && T.all isIdentChar rest
+        Just (c, rest) -> isIdentifierStartChar c && T.all isIdentChar rest
         Nothing -> False
 
 unqualifiedNameFromText :: Text -> UnqualifiedName
@@ -749,16 +749,42 @@ inferNameType localName
         else NameVarSym
   | otherwise =
       case T.uncons localName of
-        Just (c, _) | isAsciiUpper c -> NameConId
-        Just (c, _) | isAsciiLower c || c == '_' -> NameVarId
+        Just (c, _) | isConIdentifierStartChar c -> NameConId
+        Just (c, _) | isIdentifierStartChar c -> NameVarId
         _ -> NameConId
 
 isIdentChar :: Char -> Bool
-isIdentChar c = isAsciiUpper c || isAsciiLower c || isDigit c || c == '_' || c == '\''
+isIdentChar c = isIdentifierStartChar c || isIdentifierNumberChar c || c == '\''
+
+isIdentifierStartChar :: Char -> Bool
+isIdentifierStartChar c = c == '_' || generalCategory c == LowercaseLetter || isConIdentifierStartChar c
+
+isConIdentifierStartChar :: Char -> Bool
+isConIdentifierStartChar c = generalCategory c `elem` [UppercaseLetter, TitlecaseLetter]
+
+isIdentifierNumberChar :: Char -> Bool
+isIdentifierNumberChar c =
+  case generalCategory c of
+    DecimalNumber -> True
+    OtherNumber -> True
+    _ -> False
 
 isOperatorLikeText :: Text -> Bool
 isOperatorLikeText op =
-  not (T.null op) && T.all (`elem` (":!#$%&*+./<=>?@\\^|-~" :: String)) op
+  not (T.null op) && T.all isOperatorChar op
+
+isOperatorChar :: Char -> Bool
+isOperatorChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeOperatorChar c
+
+isUnicodeOperatorChar :: Char -> Bool
+isUnicodeOperatorChar c =
+  case generalCategory c of
+    MathSymbol -> True
+    CurrencySymbol -> True
+    ModifierSymbol -> True
+    OtherSymbol -> True
+    OtherPunctuation -> c > '\x7f'
+    _ -> False
 
 type BinderName = UnqualifiedName
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -31,7 +31,16 @@ import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, span0, stripTypeAnnotations)
 import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
-import Test.Properties.Identifiers (isValidGeneratedIdent, shrinkIdent)
+import Test.Properties.Identifiers
+  ( genConSym,
+    genVarSym,
+    isValidConIdent,
+    isValidGeneratedConSym,
+    isValidGeneratedIdent,
+    isValidGeneratedVarSym,
+    shrinkConIdent,
+    shrinkIdent,
+  )
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip)
 import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
 import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
@@ -225,6 +234,12 @@ buildTests = do
             testCase "generated identifiers reject extension keyword rec" test_generatedIdentifiersRejectExtensionKeywordRec,
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
+            testCase "generated identifiers accept unicode variable characters" test_generatedIdentifiersAcceptUnicodeVariableCharacters,
+            testCase "generated constructor identifiers accept unicode uppercase and number tails" test_generatedConstructorIdentifiersAcceptUnicodeCharacters,
+            testCase "shrinking identifiers preserves the first character" test_shrunkIdentifiersPreserveFirstCharacter,
+            testCase "shrinking constructor identifiers preserves the first character" test_shrunkConstructorIdentifiersPreserveFirstCharacter,
+            testCase "generated constructor symbols reject reserved spellings" test_generatedConstructorSymbolsRejectReservedSpellings,
+            testCase "generated variable symbols reject reserved spellings" test_generatedVariableSymbolsRejectReservedSpellings,
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
             testCase "parses parenthesized kind signature type atoms" test_typeParsesParenthesizedKindSignature,
@@ -249,7 +264,9 @@ buildTests = do
             testCase "parses infix type family equations with application operands" test_infixTypeFamilyEquationWithApplicationOperands,
             QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
-            QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism
+            QC.testProperty "generated operators can produce unicode asterism" prop_generatedOperatorsCanProduceUnicodeAsterism,
+            QC.testProperty "generated constructor symbols are valid" prop_generatedConstructorSymbolsAreValid,
+            QC.testProperty "generated variable symbols are valid" prop_generatedVariableSymbolsAreValid
           ],
         testGroup
           "checkPattern (do-bind)"
@@ -1107,6 +1124,40 @@ test_shrunkIdentifiersRejectStandaloneUnderscore =
   assertBool "standalone underscore must not be produced by shrinking" $
     "_" `notElem` shrinkIdent "__"
 
+test_generatedIdentifiersAcceptUnicodeVariableCharacters :: Assertion
+test_generatedIdentifiersAcceptUnicodeVariableCharacters = do
+  assertBool "unicode lowercase letters and unicode numbers should be accepted in generated identifiers" $
+    isValidGeneratedIdent "a\x03b1\x00b2"
+  assertBool "unicode lowercase letters should be accepted at the start of generated identifiers" $
+    isValidGeneratedIdent "\x03bbx"
+
+test_generatedConstructorIdentifiersAcceptUnicodeCharacters :: Assertion
+test_generatedConstructorIdentifiersAcceptUnicodeCharacters = do
+  assertBool "unicode titlecase letters should be accepted at the start of constructor identifiers" $
+    isValidConIdent "\x01c5tail"
+  assertBool "unicode uppercase letters and unicode numbers should be accepted in constructor identifiers" $
+    isValidConIdent "\x0394\x0660"
+
+test_shrunkIdentifiersPreserveFirstCharacter :: Assertion
+test_shrunkIdentifiersPreserveFirstCharacter =
+  assertBool "identifier shrinking must preserve the first character" $
+    all ((== Just '\x03bb') . fmap fst . T.uncons) (shrinkIdent "\x03bbAlpha9")
+
+test_shrunkConstructorIdentifiersPreserveFirstCharacter :: Assertion
+test_shrunkConstructorIdentifiersPreserveFirstCharacter =
+  assertBool "constructor identifier shrinking must preserve the first character" $
+    all ((== Just '\x0394') . fmap fst . T.uncons) (shrinkConIdent "\x0394elta9")
+
+test_generatedConstructorSymbolsRejectReservedSpellings :: Assertion
+test_generatedConstructorSymbolsRejectReservedSpellings =
+  assertBool "reserved constructor symbol spellings must be rejected" $
+    not (any isValidGeneratedConSym [":", "::"])
+
+test_generatedVariableSymbolsRejectReservedSpellings :: Assertion
+test_generatedVariableSymbolsRejectReservedSpellings =
+  assertBool "reserved variable symbol spellings and dash runs must be rejected" $
+    not (any isValidGeneratedVarSym ["..", "=", "\\", "|", "<-", "->", "@", "~", "=>", "--", "---"])
+
 test_generatedOperatorsRejectArrowTailSpellings :: Assertion
 test_generatedOperatorsRejectArrowTailSpellings =
   assertBool "arrow-tail operators must not be treated as valid generated operators" $
@@ -1165,6 +1216,18 @@ prop_generatedOperatorsCanProduceUnicodeAsterism =
     QC.forAll (QC.vectorOf 2000 genOperator) $ \ops ->
       QC.counterexample "expected generator to include ⁂ in sampled operators" $
         "⁂" `elem` ops
+
+prop_generatedConstructorSymbolsAreValid :: QC.Property
+prop_generatedConstructorSymbolsAreValid =
+  QC.forAll (QC.vectorOf 2000 genConSym) $ \ops ->
+    let invalid = filter (not . isValidGeneratedConSym) ops
+     in QC.counterexample ("invalid generated constructor symbols: " <> show invalid) (null invalid)
+
+prop_generatedVariableSymbolsAreValid :: QC.Property
+prop_generatedVariableSymbolsAreValid =
+  QC.forAll (QC.vectorOf 2000 genVarSym) $ \ops ->
+    let invalid = filter (not . isValidGeneratedVarSym) ops
+     in QC.counterexample ("invalid generated variable symbols: " <> show invalid) (null invalid)
 
 assertCharLiteralLexesLikeGhc :: T.Text -> Assertion
 assertCharLiteralLexesLikeGhc raw =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-subscript-identifier.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-subscript-identifier.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="subscript digit identifiers break value bindings after the lhs" -}
+{- ORACLE_TEST pass -}
 
 module M where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-superscript-identifier.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/manifolds-core-unicode-superscript-identifier.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="superscript digit identifiers are rejected in type constructor names" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE UnicodeSyntax #-}
 
 module M where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -15,11 +15,12 @@ import Data.Char (isAlpha)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.Properties.Arb.Expr (genExpr, genOperator, isValidGeneratedOperator, shrinkExpr)
+import Test.Properties.Arb.Expr (genExpr, isValidGeneratedOperator, shrinkExpr)
 import Test.Properties.Arb.Identifiers
   ( genConIdent,
     genConSym,
     genIdent,
+    genVarSym,
     shrinkConIdent,
     shrinkIdent,
   )
@@ -164,7 +165,7 @@ genVarBinderName :: Gen UnqualifiedName
 genVarBinderName =
   oneof
     [ mkUnqualifiedName NameVarId <$> genIdent,
-      mkUnqualifiedName NameVarSym <$> genOperator
+      mkUnqualifiedName NameVarSym <$> genVarSym
     ]
 
 genDeclFixity :: Gen Decl
@@ -968,7 +969,7 @@ genTypeFamilyInstOperator =
 
 genFamilyInstVarOperator :: Gen Text
 genFamilyInstVarOperator =
-  suchThat genOperator (`notElem` ["*", ".", "!", "'"])
+  suchThat genVarSym (`notElem` ["*", ".", "!", "'"])
 
 genFamilyInstConOperator :: Gen Text
 genFamilyInstConOperator =
@@ -1230,7 +1231,7 @@ shrinkPatSynDecl ps =
 shrinkTypeSynDecl :: TypeSynDecl -> [TypeSynDecl]
 shrinkTypeSynDecl ts =
   [ts {typeSynBody = ty'} | ty' <- shrinkType (typeSynBody ts)]
-    <> [ts {typeSynParams = ps'} | ps' <- shrinkTyVarBinders (typeSynParams ts)]
+    <> [ts {typeSynParams = ps'} | ps' <- shrinkTypeHeadParams (typeSynHeadForm ts) (typeSynParams ts)]
 
 -- ---------------------------------------------------------------------------
 -- Data declarations
@@ -1243,7 +1244,7 @@ shrinkDataDecl dd =
     -- Shrink deriving clauses
     <> [dd {dataDeclDeriving = ds'} | ds' <- shrinkList shrinkDerivingClause (dataDeclDeriving dd)]
     -- Shrink type parameters
-    <> [dd {dataDeclParams = ps'} | ps' <- shrinkTyVarBinders (dataDeclParams dd)]
+    <> [dd {dataDeclParams = ps'} | ps' <- shrinkTypeHeadParams (dataDeclHeadForm dd) (dataDeclParams dd)]
     -- Shrink context
     <> [dd {dataDeclContext = ctx'} | ctx' <- shrinkList shrinkType (dataDeclContext dd)]
 
@@ -1306,13 +1307,13 @@ shrinkDerivingClause dc =
 shrinkClassDecl :: ClassDecl -> [ClassDecl]
 shrinkClassDecl cd =
   [cd {classDeclItems = is'} | is' <- shrinkList (const []) (classDeclItems cd)]
-    <> [cd {classDeclParams = ps'} | ps' <- shrinkTyVarBinders (classDeclParams cd)]
+    <> [cd {classDeclParams = ps'} | ps' <- shrinkTypeHeadParams (classDeclHeadForm cd) (classDeclParams cd)]
     <> [cd {classDeclContext = ctx'} | Just ctx <- [classDeclContext cd], ctx' <- Nothing : [Just ctx'' | ctx'' <- shrinkList shrinkType ctx]]
 
 shrinkInstanceDecl :: InstanceDecl -> [InstanceDecl]
 shrinkInstanceDecl inst =
   [inst {instanceDeclItems = is'} | is' <- shrinkList (const []) (instanceDeclItems inst)]
-    <> [inst {instanceDeclTypes = ts'} | ts' <- shrinkList shrinkType (instanceDeclTypes inst)]
+    <> [inst {instanceDeclTypes = ts'} | ts' <- shrinkTypeHeadTypes (instanceDeclHeadForm inst) (instanceDeclTypes inst)]
     <> [inst {instanceDeclContext = ctx'} | ctx' <- shrinkList shrinkType (instanceDeclContext inst)]
 
 -- ---------------------------------------------------------------------------
@@ -1339,7 +1340,7 @@ shrinkForeignDecl fd =
 
 shrinkTypeFamilyDecl :: TypeFamilyDecl -> [TypeFamilyDecl]
 shrinkTypeFamilyDecl tf =
-  [tf {typeFamilyDeclParams = ps'} | ps' <- shrinkTyVarBinders (typeFamilyDeclParams tf)]
+  [tf {typeFamilyDeclParams = ps'} | ps' <- shrinkTypeHeadParams (typeFamilyDeclHeadForm tf) (typeFamilyDeclParams tf)]
 
 shrinkDataFamilyDecl :: DataFamilyDecl -> [DataFamilyDecl]
 shrinkDataFamilyDecl df =
@@ -1418,6 +1419,18 @@ shrinkTyVarBinders = shrinkList shrinkTyVarBinder
   where
     shrinkTyVarBinder tvb =
       [tvb {tyVarBinderName = n'} | n' <- shrinkIdent (tyVarBinderName tvb)]
+
+shrinkTypeHeadParams :: TypeHeadForm -> [TyVarBinder] -> [[TyVarBinder]]
+shrinkTypeHeadParams headForm params =
+  case headForm of
+    TypeHeadPrefix -> shrinkTyVarBinders params
+    TypeHeadInfix -> [ps' | ps' <- shrinkTyVarBinders params, length ps' >= 2]
+
+shrinkTypeHeadTypes :: TypeHeadForm -> [Type] -> [[Type]]
+shrinkTypeHeadTypes headForm tys =
+  case headForm of
+    TypeHeadPrefix -> shrinkList shrinkType tys
+    TypeHeadInfix -> [tys' | tys' <- shrinkList shrinkType tys, length tys' >= 2]
 
 shrinkFunctionHeadPats :: MatchHeadForm -> [Pattern] -> [[Pattern]]
 shrinkFunctionHeadPats headForm pats =

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -18,6 +18,9 @@ module Test.Properties.Arb.Identifiers
 
     -- * Constructor operator symbols
     genConSym,
+    isValidGeneratedConSym,
+    genVarSym,
+    isValidGeneratedVarSym,
 
     -- * Module qualifiers
     genOptionalQualifier,
@@ -45,6 +48,7 @@ where
 
 import Aihc.Parser.Lex (isReservedIdentifier)
 import Aihc.Parser.Syntax (Extension, SourceSpan, allKnownExtensions, noSourceSpan)
+import Data.Char (GeneralCategory (..), generalCategory)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -53,6 +57,27 @@ import Test.QuickCheck (Gen, chooseInt, chooseInteger, elements, shrink, shrinkI
 -- | All extensions enabled for maximum keyword coverage in testing.
 allExtensions :: Set.Set Extension
 allExtensions = Set.fromList allKnownExtensions
+
+allChars :: [Char]
+allChars = [minBound .. maxBound]
+
+varIdentStartChars :: [Char]
+varIdentStartChars = filter isValidGeneratedIdentStartChar allChars
+
+conIdentStartChars :: [Char]
+conIdentStartChars = filter isValidConIdentStartChar allChars
+
+identTailChars :: [Char]
+identTailChars = filter isValidIdentTailChar allChars
+
+symbolChars :: [Char]
+symbolChars = filter isValidSymbolChar allChars
+
+varSymStartChars :: [Char]
+varSymStartChars = filter (/= ':') symbolChars
+
+reservedOperators :: Set.Set Text
+reservedOperators = Set.fromList ["..", ":", "::", "=", "\\", "|", "<-", "->", "@", "~", "=>"]
 
 -- | Canonical empty source span for normalization.
 span0 :: SourceSpan
@@ -64,29 +89,24 @@ span0 = noSourceSpan
 
 genIdent :: Gen Text
 genIdent = do
-  first <- elements (['a' .. 'z'] <> ['_'])
+  first <- elements varIdentStartChars
   restLen <- chooseInt (0, 8)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
+  rest <- vectorOf restLen (elements identTailChars)
   let candidate = T.pack (first : rest)
   if isValidGeneratedIdent candidate
     then pure candidate
     else genIdent
 
 shrinkIdent :: Text -> [Text]
-shrinkIdent name =
-  [ candidate
-  | candidate <- map T.pack (shrink (T.unpack name)),
-    not (T.null candidate),
-    isValidGeneratedIdent candidate
-  ]
+shrinkIdent = shrinkWithPreservedFirstChar isValidGeneratedIdent
 
 isValidGeneratedIdent :: Text -> Bool
 isValidGeneratedIdent ident =
   case T.uncons ident of
     Just (first, rest) ->
       ident /= "_"
-        && (first `elem` (['a' .. 'z'] <> ['_']))
-        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
+        && isValidGeneratedIdentStartChar first
+        && T.all isValidIdentTailChar rest
         && not (isReservedIdentifier allExtensions ident)
     Nothing -> False
 
@@ -98,24 +118,20 @@ isValidGeneratedIdent ident =
 -- Produces names like @Foo@, @A1@, @T'x@, etc.
 genConIdent :: Gen Text
 genConIdent = do
-  first <- elements ['A' .. 'Z']
+  first <- elements conIdentStartChars
   restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'"))
+  rest <- vectorOf restLen (elements identTailChars)
   pure (T.pack (first : rest))
 
 shrinkConIdent :: Text -> [Text]
-shrinkConIdent name =
-  [ candidate
-  | candidate <- map T.pack (shrink (T.unpack name)),
-    isValidConIdent candidate
-  ]
+shrinkConIdent = shrinkWithPreservedFirstChar isValidConIdent
 
 isValidConIdent :: Text -> Bool
 isValidConIdent ident =
   case T.uncons ident of
     Just (first, rest) ->
-      (first `elem` ['A' .. 'Z'])
-        && T.all (`elem` (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_'")) rest
+      isValidConIdentStartChar first
+        && T.all isValidIdentTailChar rest
     Nothing -> False
 
 -------------------------------------------------------------------------------
@@ -128,10 +144,34 @@ isValidConIdent ident =
 genConSym :: Gen Text
 genConSym = do
   restLen <- chooseInt (1, 3)
-  rest <- vectorOf restLen (elements ":!#$%&*+./<=>?\\^|-~")
+  rest <- vectorOf restLen (elements symbolChars)
   let op = T.pack (':' : rest)
-  -- :: is not a valid constructor operator (it's the type signature operator)
-  if op == "::" then genConSym else pure op
+  if isValidGeneratedConSym op then pure op else genConSym
+
+isValidGeneratedConSym :: Text -> Bool
+isValidGeneratedConSym op =
+  case T.uncons op of
+    Just (':', rest) -> not (T.null rest) && T.all isValidSymbolChar rest && op `Set.notMember` reservedOperators
+    _ -> False
+
+genVarSym :: Gen Text
+genVarSym = do
+  first <- elements varSymStartChars
+  restLen <- chooseInt (0, 3)
+  rest <- vectorOf restLen (elements symbolChars)
+  let op = T.pack (first : rest)
+  if isValidGeneratedVarSym op then pure op else genVarSym
+
+isValidGeneratedVarSym :: Text -> Bool
+isValidGeneratedVarSym op =
+  case T.uncons op of
+    Just (first, rest) ->
+      first /= ':'
+        && isValidSymbolChar first
+        && T.all isValidSymbolChar rest
+        && op `Set.notMember` reservedOperators
+        && not (isDashRun op)
+    Nothing -> False
 
 -------------------------------------------------------------------------------
 -- Module qualifiers
@@ -247,3 +287,46 @@ showHex value
 shrinkFloat :: Double -> [Double]
 shrinkFloat value =
   [fromInteger shrunk / 10 | shrunk <- shrinkIntegral (round (value * 10 :: Double) :: Integer), shrunk >= 0]
+
+isValidGeneratedIdentStartChar :: Char -> Bool
+isValidGeneratedIdentStartChar c = c == '_' || generalCategory c == LowercaseLetter
+
+isValidConIdentStartChar :: Char -> Bool
+isValidConIdentStartChar c = generalCategory c `elem` [UppercaseLetter, TitlecaseLetter]
+
+isValidIdentNumberChar :: Char -> Bool
+isValidIdentNumberChar c =
+  case generalCategory c of
+    DecimalNumber -> True
+    OtherNumber -> True
+    _ -> False
+
+isValidIdentTailChar :: Char -> Bool
+isValidIdentTailChar c = c == '\'' || isValidGeneratedIdentStartChar c || isValidConIdentStartChar c || isValidIdentNumberChar c
+
+isValidSymbolChar :: Char -> Bool
+isValidSymbolChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isValidUnicodeSymbolChar c
+
+isValidUnicodeSymbolChar :: Char -> Bool
+isValidUnicodeSymbolChar c =
+  case generalCategory c of
+    MathSymbol -> True
+    CurrencySymbol -> True
+    ModifierSymbol -> True
+    OtherSymbol -> True
+    OtherPunctuation -> c > '\x7f'
+    _ -> False
+
+isDashRun :: Text -> Bool
+isDashRun op = T.length op >= 2 && T.all (== '-') op
+
+shrinkWithPreservedFirstChar :: (Text -> Bool) -> Text -> [Text]
+shrinkWithPreservedFirstChar isValid name =
+  case T.uncons name of
+    Just (first, rest) ->
+      [ candidate
+      | shrunkRest <- shrink (T.unpack rest),
+        let candidate = T.pack (first : shrunkRest),
+        isValid candidate
+      ]
+    Nothing -> []

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -16,8 +16,8 @@ import Data.Char (isUpper)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Properties.Arb.Decl ()
-import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
-import Test.Properties.Arb.Identifiers (genIdent, shrinkIdent)
+import Test.Properties.Arb.Expr (isValidGeneratedOperator)
+import Test.Properties.Arb.Identifiers (genIdent, genVarSym, shrinkIdent)
 import Test.QuickCheck
 
 instance Arbitrary Module where
@@ -409,7 +409,7 @@ genUnqualifiedVarName :: Gen UnqualifiedName
 genUnqualifiedVarName =
   oneof
     [ mkUnqualifiedName NameVarId <$> genIdent,
-      mkUnqualifiedName NameVarSym <$> genOperator
+      mkUnqualifiedName NameVarSym <$> genVarSym
     ]
 
 shrinkUnqualifiedVarName :: UnqualifiedName -> [UnqualifiedName]


### PR DESCRIPTION
## Summary
- broaden identifier and symbol generators to sample Unicode variable, constructor, varsym, and consym characters uniformly while preserving the first character during shrinking
- align lexer, syntax, and pretty-printer name classification with the same Unicode identifier and operator rules so generated ASTs still round-trip
- add regression coverage for Unicode identifiers and symbols, and update the two Hackage oracle fixtures that now pass with Unicode numeric identifiers

## Checks
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)