### PR TITLE
fix(parser): accept view patterns in record fields

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -268,7 +268,7 @@ recordFieldPatternParser = do
   mEq <- MP.optional (expectedTok TkReservedEquals)
   case mEq of
     Just () -> do
-      pat <- patternParser
+      pat <- subpatternWithBareViewParser
       pure (field, pat)
     Nothing -> do
       -- NamedFieldPuns: just "field" means "field = field"
@@ -299,12 +299,19 @@ listPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
     -- List elements can contain bare view patterns such as [id -> x].
     -- Try the expr -> pattern form first, then fall back to normal patterns.
     listPatternElementParser :: TokParser Pattern
-    listPatternElementParser = do
-      mView <- MP.optional . MP.try $ do
-        expr <- exprParser
-        expectedTok TkReservedRightArrow
-        PView expr <$> patternParser
-      maybe patternParser pure mView
+    listPatternElementParser = subpatternWithBareViewParser
+
+-- | Parse a subpattern position that admits a bare view pattern @expr -> pat@.
+-- This is needed in delimited pattern contexts like list elements and record
+-- fields, where there is no surrounding pair of parens to disambiguate the
+-- view-pattern arrow from the enclosing syntax.
+subpatternWithBareViewParser :: TokParser Pattern
+subpatternWithBareViewParser = do
+  mView <- MP.optional . MP.try $ do
+    expr <- exprParser
+    expectedTok TkReservedRightArrow
+    PView expr <$> patternParser
+  maybe patternParser pure mView
 
 parenOrTuplePatternParser :: TokParser Pattern
 parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -990,7 +990,7 @@ addPatternParens pat =
     PNegLit lit -> PNegLit lit
     PParen inner -> PParen (addPatternInDelimited inner)
     PRecord con fields hasWildcard ->
-      PRecord con [(fieldName, addPatternParens fieldPat) | (fieldName, fieldPat) <- fields] hasWildcard
+      PRecord con [(fieldName, addPatternInDelimited fieldPat) | (fieldName, fieldPat) <- fields] hasWildcard
     PTypeSig inner ty -> PTypeSig (addPatternParens inner) (addTypeParens ty)
     PSplice body -> PSplice (addSpliceBodyParens body)
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -2264,7 +2264,7 @@ test_generatedPatternsIncludeRecordFieldViewPatterns = do
         PRecord _ fields _ -> any (isView . snd) fields || any (hasRecordFieldViewPattern . snd) fields
         PTuple _ elems -> any hasRecordFieldViewPattern elems
         PList elems -> any hasRecordFieldViewPattern elems
-        PCon _ args -> any hasRecordFieldViewPattern args
+        PCon _ _ args -> any hasRecordFieldViewPattern args
         PInfix lhs _ rhs -> hasRecordFieldViewPattern lhs || hasRecordFieldViewPattern rhs
         PView _ inner -> hasRecordFieldViewPattern inner
         PAs _ inner -> hasRecordFieldViewPattern inner

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -28,6 +28,7 @@ import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
 import Test.Properties.Arb.Decl (genDeclDataFamilyInst, genDeclTypeFamilyInst)
 import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
+import Test.Properties.Arb.Pattern (genPattern)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, span0, stripTypeAnnotations)
 import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
@@ -337,6 +338,7 @@ buildTests = do
           [ testCase "guard lambda round-trips with parentheses" test_prettyGuardLambdaRoundTrip,
             testCase "guard let expression stays unparenthesized" test_prettyGuardLetFormatting,
             testCase "function-head list view patterns stay bare" test_prettyFunctionHeadListViewPattern,
+            testCase "function-head record-field view patterns stay bare" test_prettyFunctionHeadRecordFieldViewPattern,
             testCase "unicode operator type signatures round-trip with parentheses" test_prettyUnicodeOperatorTypeSigRoundTrip,
             testCase "prefix function head record pattern stays bare" test_prettyPrefixFunctionHeadRecordPattern,
             testCase "infix function head constructor applications stay bare" test_prettyInfixFunctionHeadConstructorPatterns,
@@ -353,6 +355,7 @@ buildTests = do
             testCase "prefix operator name: (+) x y = x" test_funHeadPrefixOp,
             testCase "prefix constructor application arg: f (Just x) y = y" test_funHeadPrefixConstructorArg,
             testCase "prefix list view pattern arg: fn [id -> x] = x" test_funHeadPrefixListViewPattern,
+            testCase "prefix record field view pattern arg: f (Box {field = id -> x}) = x" test_funHeadPrefixRecordFieldViewPattern,
             testCase "prefix singleton unboxed tuple arg: f (# x #) = x" test_funHeadPrefixUnboxedTupleSingletonArg,
             testCase "infix: x + y = x" test_funHeadInfix,
             testCase "infix backtick: x `add` y = x" test_funHeadInfixBacktick,
@@ -376,6 +379,7 @@ buildTests = do
               QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
+              testCase "generated patterns include record-field view patterns" test_generatedPatternsIncludeRecordFieldViewPatterns,
               QC.testProperty "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip
             ],
         oracle,
@@ -1604,6 +1608,31 @@ test_prettyFunctionHeadListViewPattern = do
     ParseErr err ->
       assertFailure ("expected pretty-printed list view pattern to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
 
+test_prettyFunctionHeadRecordFieldViewPattern :: Assertion
+test_prettyFunctionHeadRecordFieldViewPattern = do
+  let box = qualifyName Nothing (mkUnqualifiedName NameConId "Box")
+      field = qualifyName Nothing (mkUnqualifiedName NameVarId "field")
+      decl =
+        DeclValue
+          ( FunctionBind
+              "f"
+              [ Match
+                  { matchAnns = [],
+                    matchHeadForm = MatchHeadPrefix,
+                    matchPats = [pat0 (PRecord box [(field, pat0 (PView (expr0 (EVar "id")) (pat0 (PVar "x"))))] False)],
+                    matchRhs = UnguardedRhs [] (expr0 (EVar "x")) Nothing
+                  }
+              ]
+          )
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+      expected = normalizeDecl decl
+  assertBool ("expected bare view pattern inside record field pattern, got:\n" <> T.unpack source) ("f Box {field = id -> x} = x" == source)
+  case parseDecl defaultConfig {parserExtensions = [ViewPatterns]} source of
+    ParseOk parsed ->
+      normalizeDecl parsed @?= expected
+    ParseErr err ->
+      assertFailure ("expected pretty-printed record-field view pattern to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
+
 test_prettyUnicodeOperatorTypeSigRoundTrip :: Assertion
 test_prettyUnicodeOperatorTypeSigRoundTrip = do
   let intTy = TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Int")) Unpromoted
@@ -2114,6 +2143,41 @@ test_funHeadPrefixListViewPattern =
   case parseTopDeclWithExts [ViewPatterns] "fn [id -> x] = x" of
     Right (DeclValue (FunctionBind "fn" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PList_ [PView_ (EVar_ "id") (PVar_ "x")]]}])) -> pure ()
     other -> assertFailure ("expected list view-pattern argument in prefix function head, got: " <> show other)
+
+test_funHeadPrefixRecordFieldViewPattern :: Assertion
+test_funHeadPrefixRecordFieldViewPattern =
+  case parseTopDeclWithExts [ViewPatterns] "f (Box {field = id -> x}) = x" of
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PRecord_ "Box" [(fieldName, PView_ (EVar_ "id") (PVar_ "x"))] False]}]))
+      | fieldName == qualifyName Nothing (mkUnqualifiedName NameVarId "field") -> pure ()
+    other -> assertFailure ("expected record-field view-pattern argument in prefix function head, got: " <> show other)
+
+test_generatedPatternsIncludeRecordFieldViewPatterns :: Assertion
+test_generatedPatternsIncludeRecordFieldViewPatterns = do
+  let samples = sampleGen 6000 (QC.resize 5 (genPattern 3))
+  assertBool "expected generated patterns to include a record field view pattern" (any hasRecordFieldViewPattern samples)
+  where
+    hasRecordFieldViewPattern :: Pattern -> Bool
+    hasRecordFieldViewPattern pat =
+      case peelPatternAnn pat of
+        PRecord _ fields _ -> any (isView . snd) fields || any (hasRecordFieldViewPattern . snd) fields
+        PTuple _ elems -> any hasRecordFieldViewPattern elems
+        PList elems -> any hasRecordFieldViewPattern elems
+        PCon _ args -> any hasRecordFieldViewPattern args
+        PInfix lhs _ rhs -> hasRecordFieldViewPattern lhs || hasRecordFieldViewPattern rhs
+        PView _ inner -> hasRecordFieldViewPattern inner
+        PAs _ inner -> hasRecordFieldViewPattern inner
+        PStrict inner -> hasRecordFieldViewPattern inner
+        PIrrefutable inner -> hasRecordFieldViewPattern inner
+        PParen inner -> hasRecordFieldViewPattern inner
+        PUnboxedSum _ _ inner -> hasRecordFieldViewPattern inner
+        PTypeSig inner _ -> hasRecordFieldViewPattern inner
+        _ -> False
+
+    isView :: Pattern -> Bool
+    isView fieldPat =
+      case peelPatternAnn fieldPat of
+        PView {} -> True
+        _ -> False
 
 test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
 test_funHeadPrefixUnboxedTupleSingletonArg =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -12,8 +12,6 @@ import Aihc.Parser.Pretty ()
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
 import Data.Char (ord)
-import Data.Data (Data)
-import Data.Data qualified as Data
 import Data.List (isInfixOf)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -30,7 +28,6 @@ import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
 import Test.Properties.Arb.Decl (genDeclDataFamilyInst, genDeclTypeFamilyInst)
 import Test.Properties.Arb.Expr (genOperator, isValidGeneratedOperator)
-import Test.Properties.Arb.Pattern (genPattern)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, span0, stripTypeAnnotations)
 import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
@@ -347,7 +344,6 @@ buildTests = do
           [ testCase "guard lambda round-trips with parentheses" test_prettyGuardLambdaRoundTrip,
             testCase "guard let expression stays unparenthesized" test_prettyGuardLetFormatting,
             testCase "function-head list view patterns stay bare" test_prettyFunctionHeadListViewPattern,
-            testCase "function-head record-field view patterns stay bare" test_prettyFunctionHeadRecordFieldViewPattern,
             testCase "unicode operator type signatures round-trip with parentheses" test_prettyUnicodeOperatorTypeSigRoundTrip,
             testCase "prefix function head record pattern stays bare" test_prettyPrefixFunctionHeadRecordPattern,
             testCase "infix function head constructor applications stay bare" test_prettyInfixFunctionHeadConstructorPatterns,
@@ -389,7 +385,6 @@ buildTests = do
               QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
-              testCase "generated patterns include record-field view patterns" test_generatedPatternsIncludeRecordFieldViewPatterns,
               QC.testProperty "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip
             ],
         oracle,
@@ -1692,31 +1687,6 @@ test_prettyFunctionHeadListViewPattern = do
     ParseErr err ->
       assertFailure ("expected pretty-printed list view pattern to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
 
-test_prettyFunctionHeadRecordFieldViewPattern :: Assertion
-test_prettyFunctionHeadRecordFieldViewPattern = do
-  let box = qualifyName Nothing (mkUnqualifiedName NameConId "Box")
-      field = qualifyName Nothing (mkUnqualifiedName NameVarId "field")
-      decl =
-        DeclValue
-          ( FunctionBind
-              "f"
-              [ Match
-                  { matchAnns = [],
-                    matchHeadForm = MatchHeadPrefix,
-                    matchPats = [pat0 (PRecord box [(field, pat0 (PView (expr0 (EVar "id")) (pat0 (PVar "x"))))] False)],
-                    matchRhs = UnguardedRhs [] (expr0 (EVar "x")) Nothing
-                  }
-              ]
-          )
-      source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
-      expected = normalizeDecl decl
-  assertBool ("expected bare view pattern inside record field pattern, got:\n" <> T.unpack source) ("f Box {field = id -> x} = x" == source)
-  case parseDecl defaultConfig {parserExtensions = [ViewPatterns]} source of
-    ParseOk parsed ->
-      normalizeDecl parsed @?= expected
-    ParseErr err ->
-      assertFailure ("expected pretty-printed record-field view pattern to parse, got:\n" <> MPE.errorBundlePretty err <> "\nsource:\n" <> T.unpack source)
-
 test_prettyUnicodeOperatorTypeSigRoundTrip :: Assertion
 test_prettyUnicodeOperatorTypeSigRoundTrip = do
   let intTy = TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Int")) Unpromoted
@@ -2254,29 +2224,6 @@ test_funHeadPrefixRecordFieldViewPattern =
     Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PRecord_ "Box" [(fieldName, PView_ (EVar_ "id") (PVar_ "x"))] False]}]))
       | fieldName == qualifyName Nothing (mkUnqualifiedName NameVarId "field") -> pure ()
     other -> assertFailure ("expected record-field view-pattern argument in prefix function head, got: " <> show other)
-
-test_generatedPatternsIncludeRecordFieldViewPatterns :: Assertion
-test_generatedPatternsIncludeRecordFieldViewPatterns = do
-  let samples = sampleGen 6000 (QC.resize 5 (genPattern 3))
-  assertBool "expected generated patterns to include a record field view pattern" (any hasRecordFieldViewPattern samples)
-  where
-    hasRecordFieldViewPattern :: Pattern -> Bool
-    hasRecordFieldViewPattern = go
-      where
-        go :: (Data a) => a -> Bool
-        go x
-          | hasRecordFieldWithPView x = True
-          | otherwise = any go (Data.gmapQ go x)
-
-        hasRecordFieldWithPView :: (Data a) => a -> Bool
-        hasRecordFieldWithPView r = case Data.cast r of
-          Just (PRecord _ fields _) -> any (isPView . snd) fields
-          _ -> False
-
-        isPView :: (Data a) => a -> Bool
-        isPView p = case Data.cast p of
-          Just (PView _ _) -> True
-          _ -> False
 
 test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
 test_funHeadPrefixUnboxedTupleSingletonArg =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -12,6 +12,8 @@ import Aihc.Parser.Pretty ()
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
 import Data.Char (ord)
+import Data.Data (Data)
+import Data.Data qualified as Data
 import Data.List (isInfixOf)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -2259,27 +2261,22 @@ test_generatedPatternsIncludeRecordFieldViewPatterns = do
   assertBool "expected generated patterns to include a record field view pattern" (any hasRecordFieldViewPattern samples)
   where
     hasRecordFieldViewPattern :: Pattern -> Bool
-    hasRecordFieldViewPattern pat =
-      case peelPatternAnn pat of
-        PRecord _ fields _ -> any (isView . snd) fields || any (hasRecordFieldViewPattern . snd) fields
-        PTuple _ elems -> any hasRecordFieldViewPattern elems
-        PList elems -> any hasRecordFieldViewPattern elems
-        PCon _ _ args -> any hasRecordFieldViewPattern args
-        PInfix lhs _ rhs -> hasRecordFieldViewPattern lhs || hasRecordFieldViewPattern rhs
-        PView _ inner -> hasRecordFieldViewPattern inner
-        PAs _ inner -> hasRecordFieldViewPattern inner
-        PStrict inner -> hasRecordFieldViewPattern inner
-        PIrrefutable inner -> hasRecordFieldViewPattern inner
-        PParen inner -> hasRecordFieldViewPattern inner
-        PUnboxedSum _ _ inner -> hasRecordFieldViewPattern inner
-        PTypeSig inner _ -> hasRecordFieldViewPattern inner
-        _ -> False
+    hasRecordFieldViewPattern = go
+      where
+        go :: (Data a) => a -> Bool
+        go x
+          | hasRecordFieldWithPView x = True
+          | otherwise = any go (Data.gmapQ go x)
 
-    isView :: Pattern -> Bool
-    isView fieldPat =
-      case peelPatternAnn fieldPat of
-        PView {} -> True
-        _ -> False
+        hasRecordFieldWithPView :: (Data a) => a -> Bool
+        hasRecordFieldWithPView r = case Data.cast r of
+          Just (PRecord _ fields _) -> any (isPView . snd) fields
+          _ -> False
+
+        isPView :: (Data a) => a -> Bool
+        isPView p = case Data.cast p of
+          Just (PView _ _) -> True
+          _ -> False
 
 test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
 test_funHeadPrefixUnboxedTupleSingletonArg =

--- a/components/aihc-parser/test/Test/Fixtures/golden/pattern/record-field-view-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pattern/record-field-view-pattern.yaml
@@ -1,0 +1,5 @@
+extensions: [ViewPatterns]
+input: |
+  Box {field = id -> x}
+ast: PRecord "Box" {"field" = PView (EVar "id") (PVar "x")}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-hs-meta-record-field-view-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-hs-meta-record-field-view-pattern.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="view patterns inside record field patterns are rejected" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ViewPatterns #-}
 
 module M where

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -36,13 +36,7 @@ instance Arbitrary Pattern where
   shrink = shrinkPattern
 
 genPattern :: Int -> Gen Pattern
-genPattern = genPatternWith True
-
--- | Internal pattern generator parameterized by whether all pattern constructors
--- are allowed. When @allowAll@ is False, PView, PIrrefutable, PStrict, and PAs
--- are excluded at all depths (for use in comprehension/guard contexts).
-genPatternWith :: Bool -> Int -> Gen Pattern
-genPatternWith allowAll depth =
+genPattern depth =
   oneof (leafGenerators <> recursiveGenerators)
   where
     allowRecursive = depth > 0
@@ -58,39 +52,39 @@ genPatternWith allowAll depth =
         PTuple Unboxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x")], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
         pure (PList []),
         (\name -> PCon name [] []) <$> genPatternConAstName,
-        genUnboxedSumPatternWith allowAll 0
+        genUnboxedSumPatternWith 0
       ]
     recursiveGenerators =
-      [ PTuple Boxed <$> genTupleElemsWith allowAll nextDepth
+      [ PTuple Boxed <$> genTupleElemsWith nextDepth
       | allowRecursive
       ]
-        <> [PTuple Unboxed <$> genUnboxedTupleElemsWith allowAll nextDepth | allowRecursive]
-        <> [PList <$> genListElemsWith allowAll nextDepth | allowRecursive]
-        <> [genPatternConWith allowAll depth | allowRecursive]
-        <> [genPatternInfixWith allowAll depth | allowRecursive]
-        <> [PParen <$> genPatternWith allowAll nextDepth | allowRecursive]
-        <> [genRecordPatternWith allowAll nextDepth | allowRecursive]
-        <> [genPatternTypeSigWith allowAll depth | allowRecursive]
-        <> [genUnboxedSumPatternWith allowAll nextDepth | allowRecursive]
-        <> [PView <$> resize 2 genExpr <*> genPatternWith allowAll nextDepth | allowRecursive, allowAll]
-        <> [PAs <$> genIdent <*> (canonicalPatternAtom <$> genPatternWith allowAll nextDepth) | allowRecursive, allowAll]
-        <> [PStrict . canonicalPatternAtom <$> genPatternWith allowAll nextDepth | allowRecursive, allowAll]
-        <> [PIrrefutable . canonicalPatternAtom <$> genPatternWith allowAll nextDepth | allowRecursive, allowAll]
+        <> [PTuple Unboxed <$> genUnboxedTupleElemsWith nextDepth | allowRecursive]
+        <> [PList <$> genListElemsWith nextDepth | allowRecursive]
+        <> [genPatternConWith depth | allowRecursive]
+        <> [genPatternInfixWith depth | allowRecursive]
+        <> [PParen <$> genPattern nextDepth | allowRecursive]
+        <> [genRecordPatternWith nextDepth | allowRecursive]
+        <> [genPatternTypeSigWith depth | allowRecursive]
+        <> [genUnboxedSumPatternWith nextDepth | allowRecursive]
+        <> [PView <$> resize 2 genExpr <*> genPattern nextDepth | allowRecursive]
+        <> [PAs <$> genIdent <*> (canonicalPatternAtom <$> genPattern nextDepth) | allowRecursive]
+        <> [PStrict . canonicalPatternAtom <$> genPattern nextDepth | allowRecursive]
+        <> [PIrrefutable . canonicalPatternAtom <$> genPattern nextDepth | allowRecursive]
 
-genPatternConWith :: Bool -> Int -> Gen Pattern
-genPatternConWith allowView depth = do
+genPatternConWith :: Int -> Gen Pattern
+genPatternConWith depth = do
   con <- genPatternConAstName
   argCount <- chooseInt (0, 3)
-  args <- vectorOf argCount (canonicalPatternAtom <$> genPatternWith allowView (depth - 1))
+  args <- vectorOf argCount (canonicalPatternAtom <$> genPattern (depth - 1))
   pure (PCon con [] args)
 
-genPatternTypeSigWith :: Bool -> Int -> Gen Pattern
-genPatternTypeSigWith allowAll depth = do
+genPatternTypeSigWith :: Int -> Gen Pattern
+genPatternTypeSigWith depth = do
   -- TODO: Remove the PNegLit wrapping once the pretty-printer correctly
   -- parenthesizes PNegLit inside PTypeSig. Currently, PTypeSig (PNegLit 66) T
   -- prints as (-66 :: T) which the parser interprets as negation applied to
   -- (66 :: T) rather than a type signature on -66.
-  inner <- wrapNegLit <$> genPatternWith allowAll (depth - 1)
+  inner <- wrapNegLit <$> genPattern (depth - 1)
   PParen . PTypeSig inner <$> genPatternType
   where
     -- FIXME: This is a hack to get the pretty-printer to correctly parenthesize PNegLit inside PTypeSig. Remove!
@@ -105,66 +99,66 @@ genPatternType =
       (`TCon` Unpromoted) <$> genPatternConAstName
     ]
 
-genPatternInfixWith :: Bool -> Int -> Gen Pattern
-genPatternInfixWith allowAll depth = do
+genPatternInfixWith :: Int -> Gen Pattern
+genPatternInfixWith depth = do
   -- TODO: Switch back to canonicalPatternAtom once the pretty-printer correctly
   -- parenthesizes PNegLit as an infix operand. Currently, PInfix (PNegLit 433)
   -- ":+" (PVar "y") prints as (-433 :+ y) which is misparsed as negation of
   -- (433 :+ y).
-  lhs <- canonicalPatternAtom <$> genPatternWith allowAll (depth - 1)
+  lhs <- canonicalPatternAtom <$> genPattern (depth - 1)
   op <- genConOperatorName
-  rhs <- canonicalPatternAtom <$> genPatternWith allowAll (depth - 1)
+  rhs <- canonicalPatternAtom <$> genPattern (depth - 1)
   pure (PInfix lhs op rhs)
 
-genTupleElemsWith :: Bool -> Int -> Gen [Pattern]
-genTupleElemsWith allowView depth = do
+genTupleElemsWith :: Int -> Gen [Pattern]
+genTupleElemsWith depth = do
   isUnit <- arbitrary
   if isUnit
     then pure []
     else do
       n <- chooseInt (2, 4)
-      vectorOf n (genPatternWith allowView depth)
+      vectorOf n (genPattern depth)
 
 -- | Generate elements for an unboxed tuple pattern (0-4 elements).
 -- Unlike boxed tuples, unboxed tuples with 0 elements are valid Haskell.
-genUnboxedTupleElemsWith :: Bool -> Int -> Gen [Pattern]
-genUnboxedTupleElemsWith allowView depth = do
+genUnboxedTupleElemsWith :: Int -> Gen [Pattern]
+genUnboxedTupleElemsWith depth = do
   n <- chooseInt (0, 4)
-  vectorOf n (genPatternWith allowView depth)
+  vectorOf n (genPattern depth)
 
-genUnboxedSumPatternWith :: Bool -> Int -> Gen Pattern
-genUnboxedSumPatternWith allowView depth = do
+genUnboxedSumPatternWith :: Int -> Gen Pattern
+genUnboxedSumPatternWith depth = do
   arity <- chooseInt (2, 4)
   altIdx <- chooseInt (0, arity - 1)
-  inner <- genPatternWith allowView depth
+  inner <- genPattern depth
   pure (PUnboxedSum altIdx arity inner)
 
-genListElemsWith :: Bool -> Int -> Gen [Pattern]
-genListElemsWith allowView depth = do
+genListElemsWith :: Int -> Gen [Pattern]
+genListElemsWith depth = do
   n <- chooseInt (0, 4)
-  vectorOf n (genPatternWith allowView depth)
+  vectorOf n (genPattern depth)
 
-genRecordPatternWith :: Bool -> Int -> Gen Pattern
-genRecordPatternWith allowAll depth = do
+genRecordPatternWith :: Int -> Gen Pattern
+genRecordPatternWith depth = do
   con <- genPatternConAstName
-  fields <- genRecordFieldsWith allowAll depth
+  fields <- genRecordFieldsWith depth
   pure (PRecord con fields False)
 
-genRecordFieldsWith :: Bool -> Int -> Gen [(Name, Pattern)]
-genRecordFieldsWith allowView depth = do
+genRecordFieldsWith :: Int -> Gen [(Name, Pattern)]
+genRecordFieldsWith depth = do
   n <- chooseInt (0, 3)
   names <- vectorOf n genFieldName
-  pats <- vectorOf n (genRecordFieldPatternWith allowView depth)
+  pats <- vectorOf n (genRecordFieldPatternWith depth)
   pure (zip (map (qualifyName Nothing . mkUnqualifiedName NameVarId) names) pats)
 
-genRecordFieldPatternWith :: Bool -> Int -> Gen Pattern
-genRecordFieldPatternWith allowAll depth
-  | allowAll && depth > 0 =
+genRecordFieldPatternWith :: Int -> Gen Pattern
+genRecordFieldPatternWith depth
+  | depth > 0 =
       frequency
-        [ (3, genPatternWith allowAll depth),
-          (1, PView <$> resize 2 genExpr <*> genPatternWith allowAll (depth - 1))
+        [ (3, genPattern depth),
+          (1, PView <$> resize 2 genExpr <*> genPattern (depth - 1))
         ]
-  | otherwise = genPatternWith allowAll depth
+  | otherwise = genPattern depth
 
 genLiteral :: Gen Literal
 genLiteral =

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -148,17 +148,8 @@ genRecordFieldsWith :: Int -> Gen [(Name, Pattern)]
 genRecordFieldsWith depth = do
   n <- chooseInt (0, 3)
   names <- vectorOf n genFieldName
-  pats <- vectorOf n (genRecordFieldPatternWith depth)
+  pats <- vectorOf n (genPattern depth)
   pure (zip (map (qualifyName Nothing . mkUnqualifiedName NameVarId) names) pats)
-
-genRecordFieldPatternWith :: Int -> Gen Pattern
-genRecordFieldPatternWith depth
-  | depth > 0 =
-      frequency
-        [ (3, genPattern depth),
-          (1, PView <$> resize 2 genExpr <*> genPattern (depth - 1))
-        ]
-  | otherwise = genPattern depth
 
 genLiteral :: Gen Literal
 genLiteral =

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -68,7 +68,7 @@ genPatternWith allowAll depth =
         <> [genPatternConWith allowAll depth | allowRecursive]
         <> [genPatternInfixWith allowAll depth | allowRecursive]
         <> [PParen <$> genPatternWith allowAll nextDepth | allowRecursive]
-        <> [(\name fields -> PRecord name fields False) <$> genPatternConAstName <*> genRecordFieldsWith allowAll nextDepth | allowRecursive]
+        <> [genRecordPatternWith allowAll nextDepth | allowRecursive]
         <> [genPatternTypeSigWith allowAll depth | allowRecursive]
         <> [genUnboxedSumPatternWith allowAll nextDepth | allowRecursive]
         <> [PView <$> resize 2 genExpr <*> genPatternWith allowAll nextDepth | allowRecursive, allowAll]
@@ -143,12 +143,27 @@ genListElemsWith allowView depth = do
   n <- chooseInt (0, 4)
   vectorOf n (genPatternWith allowView depth)
 
+genRecordPatternWith :: Bool -> Int -> Gen Pattern
+genRecordPatternWith allowAll depth = do
+  con <- genPatternConAstName
+  fields <- genRecordFieldsWith allowAll depth
+  pure (PRecord con fields False)
+
 genRecordFieldsWith :: Bool -> Int -> Gen [(Name, Pattern)]
 genRecordFieldsWith allowView depth = do
   n <- chooseInt (0, 3)
   names <- vectorOf n genFieldName
-  pats <- vectorOf n (genPatternWith allowView depth)
+  pats <- vectorOf n (genRecordFieldPatternWith allowView depth)
   pure (zip (map (qualifyName Nothing . mkUnqualifiedName NameVarId) names) pats)
+
+genRecordFieldPatternWith :: Bool -> Int -> Gen Pattern
+genRecordFieldPatternWith allowAll depth
+  | allowAll && depth > 0 =
+      frequency
+        [ (3, genPatternWith allowAll depth),
+          (1, PView <$> resize 2 genExpr <*> genPatternWith allowAll (depth - 1))
+        ]
+  | otherwise = genPatternWith allowAll depth
 
 genLiteral :: Gen Literal
 genLiteral =


### PR DESCRIPTION
## Summary
- accept bare view patterns in record field pattern bindings by reusing the same subpattern parser used for other delimited pattern contexts
- keep record-field pretty-printing stable by treating field values like other delimited patterns, so `field = id -> x` roundtrips without spurious parentheses
- extend pattern test coverage with direct parser/pretty regressions and generator coverage for record-field view patterns

## Root Cause
- `recordFieldPatternParser` parsed the right-hand side with `patternParser`, which does not recognize bare `expr -> pat` in delimited subpattern positions.
- list and tuple pattern elements already had special handling for bare view patterns, so record fields diverged from the rest of the parser.
- even after parsing was fixed, record-field pretty-printing still routed field patterns through top-level paren insertion, which forced `field = (id -> x)` and broke oracle roundtrips.

## Solution
- added a shared `subpatternWithBareViewParser` for delimited subpattern positions and used it for record fields as well as list elements
- changed record-field paren insertion to use `addPatternInDelimited`, matching the contexts where bare view patterns are syntactically valid
- updated the Hackage oracle fixture from `xfail` to `pass`

## Alternatives Considered
- teach `patternParser` itself to accept bare view patterns everywhere: broader surface area and higher regression risk in non-delimited contexts
- special-case record fields only: smaller patch than a full parser rewrite, but would duplicate logic already needed in other delimited contexts
- chosen approach: share the existing delimited-subpattern behavior so the fix is minimal, consistent, and generalizes to similar nested pattern positions

## Testing
- `just fmt`
- `just check`
- targeted regressions for direct parsing, pretty roundtrip, generator coverage, and the Hackage oracle fixture

## Progress Counts
- Hackage oracle xfails: 1 fewer (`ghc-hs-meta-record-field-view-pattern` changed from `xfail` to `pass`)

## CodeRabbit
- `coderabbit review --prompt-only` reported no findings

## Follow-up
- none identified for this fix