### PR TITLE
fix(parser): preserve then/else do layout across nested conditionals

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -123,14 +123,14 @@ closeBeforeToken st tok =
       let col = tokenStartCol tok
           anchor = lexTokenSpan tok
           closeTok = virtualSymbolToken "}" anchor
-          -- Close non-LayoutAfterThenElse contexts with col < indent (normal),
-          -- then close at most ONE matching LayoutAfterThenElse with col <= thenCol
-          -- and stop. This prevents a nested else from closing outer then-do layouts.
+          -- A `then do`/`else do` block stays open across nested conditionals inside
+          -- the block. Only a `then`/`else` at or to the left of the block's own
+          -- layout column can terminate it.
           go ctxs =
             case ctxs of
               LayoutImplicit indent kind : rest
-                | LayoutAfterThenElse thenCol <- kind,
-                  col <= thenCol ->
+                | kind == LayoutAfterThenElse,
+                  col <= indent ->
                     ([closeTok], rest)
                 | col < indent ->
                     let (inserted, rest') = go rest
@@ -195,11 +195,7 @@ stepTokenContext st tok =
     TkKeywordDo
       | layoutPrevTokenKind st == Just TkKeywordThen
           || layoutPrevTokenKind st == Just TkKeywordElse ->
-          let thenCol = fromMaybe 1 (layoutThenColumn st)
-           in st
-                { layoutPendingLayout = Just (PendingImplicitLayout (LayoutAfterThenElse thenCol)),
-                  layoutThenColumn = Nothing
-                }
+          st {layoutPendingLayout = Just (PendingImplicitLayout LayoutAfterThenElse)}
       | otherwise -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordMdo -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordOf -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
@@ -211,8 +207,6 @@ stepTokenContext st tok =
     TkKeywordRec -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordWhere -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordIf -> st {layoutPendingLayout = Just PendingMaybeMultiWayIf}
-    TkKeywordThen -> st {layoutThenColumn = Just (tokenStartCol tok)}
-    TkKeywordElse -> st {layoutThenColumn = Just (tokenStartCol tok)}
     TkTHDeclQuoteOpen ->
       st
         { layoutContexts = LayoutDelimiter : layoutContexts st,

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -227,7 +227,7 @@ data ImplicitLayoutKind
   = LayoutOrdinary
   | LayoutLetBlock
   | LayoutMultiWayIf
-  | LayoutAfterThenElse !Int -- column of the 'then'/'else' keyword that opened this do-block
+  | LayoutAfterThenElse -- do-block opened directly by a preceding 'then'/'else'
   deriving (Eq, Show)
 
 data PendingLayout
@@ -251,8 +251,7 @@ data LayoutState = LayoutState
     layoutModuleMode :: !ModuleLayoutMode,
     layoutPrevTokenEndSpan :: !(Maybe SourceSpan),
     layoutBuffer :: [LexToken],
-    layoutNondecreasingIndent :: !Bool,
-    layoutThenColumn :: !(Maybe Int) -- column of most recent 'then'/'else' awaiting 'do'
+    layoutNondecreasingIndent :: !Bool
   }
   deriving (Eq, Show)
 
@@ -300,8 +299,7 @@ mkInitialLayoutState enableModuleLayout exts =
           else ModuleLayoutOff,
       layoutPrevTokenEndSpan = Nothing,
       layoutBuffer = [],
-      layoutNondecreasingIndent = Syntax.NondecreasingIndentation `elem` exts,
-      layoutThenColumn = Nothing
+      layoutNondecreasingIndent = Syntax.NondecreasingIndentation `elem` exts
     }
 
 mkToken :: LexerState -> LexerState -> Text -> LexTokenKind -> LexToken

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-else-do-if-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-else-do-if-layout.hs
@@ -1,11 +1,9 @@
-{- ORACLE_TEST xfail else-do layout block closed prematurely by inner then/else -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DoAndIfThenElse #-}
 
 -- Test case: inner 'if-then-else' inside 'else do' layout block where the
--- outer if-then-else is on one line. The 'do' in the else branch starts a
--- layout block, but the lexer's closeBeforeThenElse incorrectly closes the
--- do-layout when it encounters the inner 'then' (whose column is less than
--- the outer 'else' column). GHC accepts this; aihc-parser rejects it.
+-- outer if-then-else is on one line. The else-do layout must stay open across
+-- the nested conditional and only close when the outer branch ends.
 -- Minimized from http-download-0.2.1.0 Verified.hs:322.
 module DoAndIfThenElseElseDoIfLayout where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-then-do-if-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-then-do-if-layout.hs
@@ -1,12 +1,9 @@
-{- ORACLE_TEST xfail then-do layout block closed prematurely by inner then/else -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DoAndIfThenElse #-}
 
 -- Test case: inner 'if-then-else' inside 'then do' layout block where the
--- outer if-then-else has 'then do' on one line. The 'do' in the then branch
--- starts a layout block, but the lexer's closeBeforeThenElse incorrectly
--- closes the do-layout when it encounters the inner 'then' (whose column is
--- less than the outer 'then' column). GHC accepts this; aihc-parser rejects
--- it. Minimized from http-download-0.2.1.0 Verified.hs:322.
+-- outer if-then-else has 'then do' on one line. The then-do layout must stay
+-- open across the nested conditional and only close for the outer else.
 module DoAndIfThenElseThenDoIfLayout where
 
 foo = if a then do

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -386,8 +386,11 @@ genRecordCon = do
 genFieldDecl :: Gen FieldDecl
 genFieldDecl = do
   fieldCount <- chooseInt (1, 3)
-  fieldNames <- vectorOf fieldCount genVarBinderName
+  fieldNames <- vectorOf fieldCount genRecordFieldName
   FieldDecl [] fieldNames <$> genSimpleBangType
+
+genRecordFieldName :: Gen UnqualifiedName
+genRecordFieldName = mkUnqualifiedName NameVarId <$> genIdent
 
 genGadtDataCons :: Gen [DataConDecl]
 genGadtDataCons = do
@@ -563,7 +566,7 @@ genNewtypePrefixCon = do
 genNewtypeRecordCon :: Gen DataConDecl
 genNewtypeRecordCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
-  fieldName <- genVarBinderName
+  fieldName <- genRecordFieldName
   ty <- genSimpleType
   pure (RecordCon [] [] conName [FieldDecl [] [fieldName] (BangType [] NoSourceUnpackedness False False ty)])
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -309,7 +309,8 @@ isValidGeneratedOperator candidate =
         candidate
           `elem` ["..", "::", "=", "\\", "|", "<-", "->", "~", "=>", "--", "-<", ">-", "-<<", ">>-"]
       dashOnly = T.length candidate >= 2 && T.all (== '-') candidate
-   in not reserved && not dashOnly
+      hasBacktick = T.any (== '`') candidate
+   in not reserved && not dashOnly && not hasBacktick
 
 -- | Generate a data constructor name
 genConName :: Gen Text


### PR DESCRIPTION
## Summary
- fix `then do`/`else do` layout handling so nested inner `if ... then ... else ...` no longer closes the outer layout block prematurely
- promote the two `DoAndIfThenElse` oracle fixtures from `xfail` to `pass` and keep the surrounding regression coverage green
- harden property generators so `just check` stays green by avoiding invalid backtick operators and invalid symbolic record field names

## Root Cause
- `closeBeforeThenElse` treated `LayoutAfterThenElse` blocks as closable when a later `then` or `else` appeared at or left of the outer branch keyword column.
- That heuristic is wrong for nested conditionals inside a `then do` or `else do` block: an inner `then` can appear further left than the outer keyword while still belonging to the nested `if`, so the lexer inserted a virtual `}` too early.
- The design weakness was storing branch-keyword column state (`layoutThenColumn`) instead of using the opened layout block's own indentation, which is the stable boundary GHC's layout rule actually cares about.

## Solution
- Simplified `LayoutAfterThenElse` so it only marks the special layout kind; it no longer stores the outer `then`/`else` column.
- Changed `closeBeforeThenElse` to close a `LayoutAfterThenElse` block only when the incoming `then`/`else` is at or to the left of that block's own indentation.
- This generalizes to nested conditionals inside the block while preserving the existing behavior where the outer `else` closes the preceding `then do` block.

## Alternatives Considered
- Keep tracking the outer `then`/`else` column and add extra nesting state for inner `if`s. This is more complex and duplicates information the layout context already has.
- Special-case only the two failing fixtures. That would be brittle and would not address the underlying layout rule.
- The chosen fix is smaller and aligns the close condition with layout indentation directly.

## Testing
- Ran the targeted `DoAndIfThenElse` oracle group and confirmed all 17 cases pass.
- Ran `just fmt` and `just check` successfully.
- CodeRabbit prompt-only review completed with no findings.

## Progress
- Parser progress is now `PASS 860 / XFAIL 17 / XPASS 0 / FAIL 0` (was `PASS 858 / XFAIL 19 / XPASS 0 / FAIL 0`).

## Follow-up
- No additional follow-up is required for the layout fix.
- The small property-generator hardening included here was necessary to keep the mandatory full suite green after `just check` exposed pre-existing invalid AST generation cases.