### PR TITLE
refactor(parser): use structured names in syntax AST

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -71,7 +71,7 @@ cmdInfixChain :: Cmd -> TokParser Cmd
 cmdInfixChain lhs = do
   rest <-
     MP.many
-      ( (,) . renderName
+      ( (,)
           <$> infixOperatorParserExcept []
           <*> cmdParser
       )

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -159,7 +159,7 @@ typeDeclarationParser = do
         DeclTypeSyn
           TypeSynDecl
             { typeSynHeadForm = headForm,
-              typeSynName = renderUnqualifiedName typeName,
+              typeSynName = typeName,
               typeSynParams = typeParams,
               typeSynBody = body
             }
@@ -170,7 +170,7 @@ roleAnnotationDeclParser :: TokParser Decl
 roleAnnotationDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   expectedTok TkVarRole
-  typeName <- constructorIdentifierParser <|> (renderName <$> parens constructorOperatorParser)
+  typeName <- constructorUnqualifiedNameParser <|> parens constructorOperatorUnqualifiedNameParser
   roles <- MP.many roleParser
   pure $
     DeclRoleAnnotation
@@ -708,7 +708,7 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   warningText <- MP.optional warningTextParser
   forallBinders <- MP.optional instanceForallParser
   context <- contextPrefixDispatch
-  (parenthesizedHead, headForm, className, instanceTypes) <- instanceHeadParser
+  (parenthesizedHead, headForm, className, instanceTypes) <- standaloneDerivingHeadParser
   pure $
     DeclStandaloneDeriving
       StandaloneDerivingDecl
@@ -720,11 +720,39 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           standaloneDerivingContext = fromMaybe [] context,
           standaloneDerivingParenthesizedHead = parenthesizedHead,
           standaloneDerivingHeadForm = headForm,
-          standaloneDerivingClassName = unqualifiedNameFromText className,
+          standaloneDerivingClassName = className,
           standaloneDerivingTypes = instanceTypes
         }
 
-instanceHeadParser :: TokParser (Bool, TypeHeadForm, Text, [Type])
+standaloneDerivingHeadParser :: TokParser (Bool, TypeHeadForm, Name, [Type])
+standaloneDerivingHeadParser =
+  MP.try
+    ( do
+        parsed <- parens bareStandaloneDerivingHeadParser
+        _ <- MP.notFollowedBy (lookAhead typeInfixOperatorParser)
+        let (headForm, className, instanceTypes) = parsed
+        pure (True, headForm, className, instanceTypes)
+    )
+    <|> ( do
+            (headForm, className, instanceTypes) <- bareStandaloneDerivingHeadParser
+            pure (False, headForm, className, instanceTypes)
+        )
+  where
+    bareStandaloneDerivingHeadParser = MP.try infixStandaloneDerivingHeadParser <|> prefixStandaloneDerivingHeadParser
+
+    prefixStandaloneDerivingHeadParser = do
+      className <- constructorNameParser <|> parens constructorOperatorParser
+      instanceTypes <- MP.many typeAtomParser
+      pure (TypeHeadPrefix, className, instanceTypes)
+
+    infixStandaloneDerivingHeadParser = do
+      lhs <- typeAtomParser
+      _ <- lookAhead typeInfixOperatorParser
+      op <- typeFamilyOperatorParser
+      rhs <- typeAtomParser
+      pure (TypeHeadInfix, op, [lhs, rhs])
+
+instanceHeadParser :: TokParser (Bool, TypeHeadForm, UnqualifiedName, [Type])
 instanceHeadParser =
   MP.try
     ( do
@@ -741,7 +769,7 @@ instanceHeadParser =
     bareInstanceHeadParser = MP.try infixInstanceHeadParser <|> prefixInstanceHeadParser
 
     prefixInstanceHeadParser = do
-      className <- constructorIdentifierParser <|> (renderName <$> parens constructorOperatorParser)
+      className <- nameToUnqualified <$> (constructorNameParser <|> parens constructorOperatorParser)
       instanceTypes <- MP.many typeAtomParser
       pure (TypeHeadPrefix, className, instanceTypes)
 
@@ -750,7 +778,7 @@ instanceHeadParser =
       _ <- lookAhead typeInfixOperatorParser
       op <- typeFamilyOperatorParser
       rhs <- typeAtomParser
-      pure (TypeHeadInfix, renderName op, [lhs, rhs])
+      pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs])
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]
 instanceWhereClauseParser = whereClauseItemsParser instanceItemsBracedParser instanceItemsPlainParser
@@ -1226,12 +1254,12 @@ typeFamilyLhsParser = do
       let opType = TCon op promoted
        in TApp (TApp opType left) right
 
-classHeadParser :: TokParser (TypeHeadForm, Text, [TyVarBinder])
+classHeadParser :: TokParser (TypeHeadForm, UnqualifiedName, [TyVarBinder])
 classHeadParser =
   MP.try infixDeclHeadParser <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
-      name <- constructorIdentifierParser
+      name <- constructorUnqualifiedNameParser
       params <- MP.many typeParamParser
       pure (TypeHeadPrefix, name, params)
 
@@ -1239,7 +1267,10 @@ classHeadParser =
       lhs <- typeParamParser
       op <- constructorOperatorParser
       rhs <- typeParamParser
-      pure (TypeHeadInfix, renderName op, [lhs, rhs])
+      pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs])
+
+nameToUnqualified :: Name -> UnqualifiedName
+nameToUnqualified name = mkUnqualifiedName (nameType name) (nameText name)
 
 typeParamParser :: TokParser TyVarBinder
 typeParamParser =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1083,7 +1083,7 @@ thValueNameQuoteParser :: TokParser Expr
 thValueNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkTHQuoteTick
   name <- identifierNameParser <|> parenOperatorNameParser <|> bracketConstructorNameParser
-  pure (ETHNameQuote (renderName name))
+  pure (ETHNameQuote name)
 
 thTypeNameQuoteParser :: TokParser Expr
 thTypeNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -243,10 +243,10 @@ prettyDeclLines decl =
       let headDocs = case (typeSynHeadForm synDecl, typeSynParams synDecl) of
             (TypeHeadInfix, [lhs, rhs]) ->
               let name = typeSynName synDecl
-               in if isOperatorToken name
-                    then [pretty (tyVarBinderName lhs), pretty name, pretty (tyVarBinderName rhs)]
-                    else [pretty (tyVarBinderName lhs), "`" <> pretty name <> "`", pretty (tyVarBinderName rhs)]
-            _ -> [prettyDeclHead TypeHeadPrefix [] (unqualifiedNameFromText (typeSynName synDecl)) (typeSynParams synDecl)]
+               in if unqualifiedNameType name == NameConSym || unqualifiedNameType name == NameVarSym
+                    then [pretty (tyVarBinderName lhs), prettyInfixOp (renderUnqualifiedName name), pretty (tyVarBinderName rhs)]
+                    else [pretty (tyVarBinderName lhs), "`" <> pretty (renderUnqualifiedName name) <> "`", pretty (tyVarBinderName rhs)]
+            _ -> [prettyDeclHead TypeHeadPrefix [] (typeSynName synDecl) (typeSynParams synDecl)]
        in [hsep (["type"] <> headDocs <> ["=", prettyType (typeSynBody synDecl)])]
     DeclData dataDecl -> [prettyDataDecl dataDecl]
     DeclTypeData dataDecl -> [prettyTypeDataDecl dataDecl]
@@ -268,7 +268,7 @@ prettyRoleAnnotation ann =
   hsep
     ( [ "type",
         "role",
-        prettyConstructorName (roleAnnotationName ann)
+        prettyConstructorUName (roleAnnotationName ann)
       ]
         <> map prettyRole (roleAnnotationRoles ann)
     )
@@ -864,16 +864,22 @@ instanceHeadDoc decl =
 standaloneDerivingHeadDoc :: StandaloneDerivingDecl -> Doc ann
 standaloneDerivingHeadDoc decl =
   maybeParenthesize (standaloneDerivingParenthesizedHead decl) $
-    prettyInstanceLikeHead
+    prettyStandaloneDerivingHead
       (standaloneDerivingHeadForm decl)
-      (renderUnqualifiedName (standaloneDerivingClassName decl))
+      (standaloneDerivingClassName decl)
       (standaloneDerivingTypes decl)
 
-prettyInstanceLikeHead :: TypeHeadForm -> Text -> [Type] -> Doc ann
+prettyInstanceLikeHead :: TypeHeadForm -> UnqualifiedName -> [Type] -> Doc ann
 prettyInstanceLikeHead headForm className tys =
   case (headForm, tys) of
-    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyInfixOp className <+> prettyType rhs
-    _ -> hsep (pretty className : map prettyType tys)
+    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyInfixOp (renderUnqualifiedName className) <+> prettyType rhs
+    _ -> hsep (prettyConstructorUName className : map prettyType tys)
+
+prettyStandaloneDerivingHead :: TypeHeadForm -> Name -> [Type] -> Doc ann
+prettyStandaloneDerivingHead headForm className tys =
+  case (headForm, tys) of
+    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyNameInfixOp className <+> prettyType rhs
+    _ -> hsep (prettyPrefixName className : map prettyType tys)
 
 maybeParenthesize :: Bool -> Doc ann -> Doc ann
 maybeParenthesize shouldParen doc
@@ -1058,7 +1064,7 @@ prettyExpr expr =
     ETHTypeQuote ty -> "[t|" <+> prettyType ty <+> "|]"
     ETHPatQuote pat -> "[p|" <+> prettyPattern pat <+> "|]"
     ETHNameQuote name
-      | thNameQuoteTextNeedsParens name -> "'" <> parens (pretty name)
+      | thNameQuoteNeedsParens name -> "'" <> parens (pretty name)
       | otherwise -> "'" <> pretty name
     ETHTypeNameQuote name
       | isOperatorName name -> "''" <> parens (pretty name)
@@ -1215,7 +1221,7 @@ prettyCmd cmd =
     CmdArrApp lhs HsHigherOrderApp rhs ->
       prettyExpr lhs <+> "-<<" <+> prettyExpr rhs
     CmdInfix l op r ->
-      prettyCmd l <+> prettyInfixOp op <+> prettyCmd r
+      prettyCmd l <+> prettyNameInfixOp op <+> prettyCmd r
     CmdDo stmts ->
       "do" <+> "{" <+> hsep (punctuate semi (map prettyCmdStmt stmts)) <+> "}"
     CmdIf cond yes no ->
@@ -1285,47 +1291,13 @@ isOperatorName name =
 --
 -- Unqualified operators need @'(+), ...@. Qualified operators such as @P.+@
 -- must be written @'(P.+), ...@ because @'P.+@ is not a single lexeme.
-thNameQuoteTextNeedsParens :: Text -> Bool
-thNameQuoteTextNeedsParens name
-  | isOperatorToken name = True
+thNameQuoteNeedsParens :: Name -> Bool
+thNameQuoteNeedsParens name
+  | isOperatorName name = True
   | otherwise =
-      case splitQualifiedNameQuoteText name of
-        Just (_, quotedName) -> isOperatorToken quotedName
+      case nameQualifier name of
+        Just _ -> isOperatorToken (nameText name)
         Nothing -> False
-
-splitQualifiedNameQuoteText :: Text -> Maybe (Text, Text)
-splitQualifiedNameQuoteText fullName =
-  case T.uncons fullName of
-    Just (c, _) | isConIdentifierStartChar c -> go fullName
-    _ -> Nothing
-  where
-    go txt =
-      let (segment, rest) = T.breakOn "." txt
-       in case T.stripPrefix "." rest of
-            Just next
-              | isModuleSegment segment,
-                not (T.null next) ->
-                  case go next of
-                    Just (qualifier, quotedName) -> Just (segment <> "." <> qualifier, quotedName)
-                    Nothing -> Just (segment, next)
-            _ -> Nothing
-
-    isModuleSegment segment =
-      case T.uncons segment of
-        Just (c, rest) -> isConIdentifierStartChar c && T.all isIdentChar rest
-        Nothing -> False
-
-    isIdentChar c = isIdentifierStartChar c || isIdentifierNumberChar c || c == '\'' || c == '#'
-
-    isIdentifierStartChar c = c == '_' || generalCategory c == LowercaseLetter || isConIdentifierStartChar c
-
-    isConIdentifierStartChar c = generalCategory c `elem` [UppercaseLetter, TitlecaseLetter]
-
-    isIdentifierNumberChar c =
-      case generalCategory c of
-        DecimalNumber -> True
-        OtherNumber -> True
-        _ -> False
 
 isOperatorToken :: Text -> Bool
 isOperatorToken tok =
@@ -1473,7 +1445,7 @@ prettyInstTypeFamilyInst tfi =
     forallPart [] = []
     forallPart binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
 
-prettyNamedTypeHead :: TypeHeadForm -> Text -> [TyVarBinder] -> [Doc ann]
+prettyNamedTypeHead :: TypeHeadForm -> UnqualifiedName -> [TyVarBinder] -> [Doc ann]
 prettyNamedTypeHead headForm name params =
   case (headForm, params) of
     (TypeHeadInfix, [lhs, rhs]) ->
@@ -1481,10 +1453,10 @@ prettyNamedTypeHead headForm name params =
         prettyTypeHeadInfixName name,
         prettyTyVarBinder rhs
       ]
-    _ -> [prettyConstructorName name] <> map prettyTyVarBinder params
+    _ -> [prettyConstructorUName name] <> map prettyTyVarBinder params
 
-prettyTypeHeadInfixName :: Text -> Doc ann
-prettyTypeHeadInfixName = prettyInfixOp
+prettyTypeHeadInfixName :: UnqualifiedName -> Doc ann
+prettyTypeHeadInfixName = prettyInfixOp . renderUnqualifiedName
 
 prettyTypeFamilyInfix :: Type -> Doc ann
 prettyTypeFamilyInfix ty =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -29,7 +29,6 @@ where
 
 import Aihc.Parser.Parens (addDeclParens, addExprParens, addModuleParens, addPatternParens, addTypeParens)
 import Aihc.Parser.Syntax
-import Data.Char (GeneralCategory (..), generalCategory, isAscii)
 import Data.Maybe (catMaybes, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -235,7 +234,7 @@ prettyDeclLines decl =
           ( [prettyFixityAssoc assoc]
               <> maybe [] (pure . pretty . show) prec
               <> maybe [] (pure . prettyNamespace) mNamespace
-              <> punctuate comma (map (prettyInfixOp . renderUnqualifiedName) ops)
+              <> punctuate comma (map prettyInfixOp ops)
           )
       ]
     DeclRoleAnnotation ann -> [prettyRoleAnnotation ann]
@@ -243,9 +242,7 @@ prettyDeclLines decl =
       let headDocs = case (typeSynHeadForm synDecl, typeSynParams synDecl) of
             (TypeHeadInfix, [lhs, rhs]) ->
               let name = typeSynName synDecl
-               in if unqualifiedNameType name == NameConSym || unqualifiedNameType name == NameVarSym
-                    then [pretty (tyVarBinderName lhs), prettyInfixOp (renderUnqualifiedName name), pretty (tyVarBinderName rhs)]
-                    else [pretty (tyVarBinderName lhs), "`" <> pretty (renderUnqualifiedName name) <> "`", pretty (tyVarBinderName rhs)]
+               in [pretty (tyVarBinderName lhs), prettyInfixOp name, pretty (tyVarBinderName rhs)]
             _ -> [prettyDeclHead TypeHeadPrefix [] (typeSynName synDecl) (typeSynParams synDecl)]
        in [hsep (["type"] <> headDocs <> ["=", prettyType (typeSynBody synDecl)])]
     DeclData dataDecl -> [prettyDataDecl dataDecl]
@@ -317,7 +314,7 @@ prettyPatSynLhs name args =
     PatSynPrefixArgs vars ->
       prettyConstructorUName name : map pretty vars
     PatSynInfixArgs lhs rhs ->
-      [pretty lhs, prettyInfixOp (renderUnqualifiedName name), pretty rhs]
+      [pretty lhs, prettyInfixOp name, pretty rhs]
     PatSynRecordArgs fields ->
       [prettyConstructorUName name <+> braces (hsep (punctuate comma (map pretty fields)))]
 
@@ -353,7 +350,7 @@ prettyFunctionHead name headForm pats =
     MatchHeadInfix ->
       case pats of
         lhs : rhsPat : tailPats ->
-          let infixHead = prettyPattern lhs <+> prettyInfixOp (renderUnqualifiedName name) <+> prettyPattern rhsPat
+          let infixHead = prettyPattern lhs <+> prettyInfixOp name <+> prettyPattern rhsPat
            in case tailPats of
                 [] -> infixHead
                 _ -> hsep (parens infixHead : map prettyPattern tailPats)
@@ -637,7 +634,7 @@ prettyDeclHead headForm constraints name params =
   where
     prettyDeclHeadNameAndParams nm prms = case (headForm, prms) of
       (TypeHeadInfix, lhs : rhs : tailPrms) ->
-        let infixHead = pretty (tyVarBinderName lhs) <+> prettyInfixOp (renderUnqualifiedName nm) <+> pretty (tyVarBinderName rhs)
+        let infixHead = pretty (tyVarBinderName lhs) <+> prettyInfixOp nm <+> pretty (tyVarBinderName rhs)
          in case tailPrms of
               [] -> [infixHead]
               _ -> parens infixHead : map prettyTyVarBinder tailPrms
@@ -689,7 +686,7 @@ prettyDataCon ctor =
     InfixCon forallVars constraints lhs op rhs ->
       hsep
         ( dataConQualifierPrefix forallVars constraints
-            <> [prettyBangType lhs, prettyInfixOp (renderUnqualifiedName op), prettyBangType rhs]
+            <> [prettyBangType lhs, prettyInfixOp op, prettyBangType rhs]
         )
     RecordCon forallVars constraints name fields ->
       hsep (dataConQualifierPrefix forallVars constraints <> [prettyConstructorUName name])
@@ -709,7 +706,7 @@ prettyDataCon ctor =
       where
         prettyFieldName :: UnqualifiedName -> Doc ann
         prettyFieldName fieldName
-          | isOperatorToken (renderUnqualifiedName fieldName) = parens (pretty fieldName)
+          | isSymbolicUName fieldName = parens (pretty fieldName)
           | otherwise = pretty fieldName
     GadtCon foralls constraints names body ->
       prettyGadtCon foralls constraints names body
@@ -754,7 +751,7 @@ prettyRecordFields fields =
   where
     prettyFieldName :: UnqualifiedName -> Doc ann
     prettyFieldName name
-      | isOperatorToken (renderUnqualifiedName name) = parens (pretty name)
+      | isSymbolicUName name = parens (pretty name)
       | otherwise = pretty name
 
 dataConQualifierPrefix :: [Text] -> [Type] -> [Doc ann]
@@ -833,7 +830,7 @@ prettyClassItem item =
         ( [prettyFixityAssoc assoc]
             <> maybe [] (pure . pretty . show) prec
             <> maybe [] (pure . prettyNamespace) mNamespace
-            <> map (prettyInfixOp . renderUnqualifiedName) ops
+            <> map prettyInfixOp ops
         )
     ClassItemDefault valueDecl -> prettyValueDeclSingleLine valueDecl
     ClassItemTypeFamilyDecl tf -> prettyAssocTypeFamilyDecl tf
@@ -891,7 +888,7 @@ standaloneDerivingHeadDoc decl =
 prettyInstanceLikeHead :: TypeHeadForm -> UnqualifiedName -> [Type] -> Doc ann
 prettyInstanceLikeHead headForm className tys =
   case (headForm, tys) of
-    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyInfixOp (renderUnqualifiedName className) <+> prettyType rhs
+    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyInfixOp className <+> prettyType rhs
     _ -> hsep (prettyConstructorUName className : map prettyType tys)
 
 prettyStandaloneDerivingHead :: TypeHeadForm -> Name -> [Type] -> Doc ann
@@ -946,7 +943,7 @@ prettyInstanceItem item =
         ( [prettyFixityAssoc assoc]
             <> maybe [] (pure . pretty . show) prec
             <> maybe [] (pure . prettyNamespace) mNamespace
-            <> map (prettyInfixOp . renderUnqualifiedName) ops
+            <> map prettyInfixOp ops
         )
     InstanceItemTypeFamilyInst tfi -> prettyInstTypeFamilyInst tfi
     InstanceItemDataFamilyInst dfi -> prettyInstDataFamilyInst dfi
@@ -1004,10 +1001,10 @@ prettyForeignEntity spec =
     ForeignEntityAddress (Just name) -> Just (quoted ("&" <> name))
     ForeignEntityNamed name -> Just (quoted name)
 
-prettyInfixOp :: Text -> Doc ann
-prettyInfixOp op
-  | isOperatorToken op = pretty op
-  | otherwise = "`" <> pretty op <> "`"
+prettyInfixOp :: UnqualifiedName -> Doc ann
+prettyInfixOp name
+  | isSymbolicUName name = pretty (renderUnqualifiedName name)
+  | otherwise = "`" <> pretty (renderUnqualifiedName name) <> "`"
 
 prettyNameInfixOp :: Name -> Doc ann
 prettyNameInfixOp name
@@ -1020,6 +1017,13 @@ prettyPrefixName name
   | otherwise = pretty rendered
   where
     rendered = renderName name
+
+isSymbolicUName :: UnqualifiedName -> Bool
+isSymbolicUName name =
+  case unqualifiedNameType name of
+    NameVarSym -> True
+    NameConSym -> True
+    _ -> False
 
 isSymbolicName :: Name -> Bool
 isSymbolicName name =
@@ -1079,13 +1083,10 @@ isHashLeadingSymbolicName name =
         _ -> False
       Just _ -> False
 
-prettyConstructorName :: Text -> Doc ann
-prettyConstructorName name
-  | isOperatorToken name = parens (pretty name)
-  | otherwise = pretty name
-
 prettyConstructorUName :: UnqualifiedName -> Doc ann
-prettyConstructorUName = prettyConstructorName . renderUnqualifiedName
+prettyConstructorUName name
+  | isSymbolicUName name = parens (pretty (renderUnqualifiedName name))
+  | otherwise = pretty (renderUnqualifiedName name)
 
 -- | Pretty-print an expression. The AST is assumed to already have EParen
 -- nodes in the correct positions (inserted by 'addExprParens').
@@ -1345,29 +1346,7 @@ isOperatorName name =
 -- Unqualified operators need @'(+), ...@. Qualified operators such as @P.+@
 -- must be written @'(P.+), ...@ because @'P.+@ is not a single lexeme.
 thNameQuoteNeedsParens :: Name -> Bool
-thNameQuoteNeedsParens name
-  | isOperatorName name = True
-  | otherwise =
-      case nameQualifier name of
-        Just _ -> isOperatorToken (nameText name)
-        Nothing -> False
-
-isOperatorToken :: Text -> Bool
-isOperatorToken tok =
-  not (T.null tok) && T.all isSymbolicOpChar tok
-
-isSymbolicOpChar :: Char -> Bool
-isSymbolicOpChar c =
-  c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeSymbolCategory c
-
-isUnicodeSymbolCategory :: Char -> Bool
-isUnicodeSymbolCategory c = case generalCategory c of
-  MathSymbol -> True
-  CurrencySymbol -> True
-  ModifierSymbol -> True
-  OtherSymbol -> True
-  OtherPunctuation -> not (isAscii c)
-  _ -> False
+thNameQuoteNeedsParens = isOperatorName
 
 -- ---------------------------------------------------------------------------
 -- TypeFamilies pretty-printing helpers
@@ -1509,7 +1488,7 @@ prettyNamedTypeHead headForm name params =
     _ -> [prettyConstructorUName name] <> map prettyTyVarBinder params
 
 prettyTypeHeadInfixName :: UnqualifiedName -> Doc ann
-prettyTypeHeadInfixName = prettyInfixOp . renderUnqualifiedName
+prettyTypeHeadInfixName = prettyInfixOp
 
 prettyTypeFamilyInfix :: Type -> Doc ann
 prettyTypeFamilyInfix ty =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -303,7 +303,7 @@ docTypeSynDecl syn =
   "TypeSynDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "name" (docText (typeSynName syn))]
+      [field "name" (docUnqualifiedName (typeSynName syn))]
         <> listField "params" docTyVarBinder (typeSynParams syn)
         <> [field "body" (docType (typeSynBody syn))]
 
@@ -312,7 +312,7 @@ docRoleAnnotation ann =
   "RoleAnnotation" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "name" (docText (roleAnnotationName ann))]
+      [field "name" (docUnqualifiedName (roleAnnotationName ann))]
         <> [field "roles" (brackets (hsep (punctuate comma (map docRole (roleAnnotationRoles ann)))))]
 
 docRole :: Role -> Doc ann
@@ -412,7 +412,7 @@ docClassDecl cd =
   "ClassDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "headForm" (docTypeHeadForm (classDeclHeadForm cd)), field "name" (docText (classDeclName cd))]
+      [field "headForm" (docTypeHeadForm (classDeclHeadForm cd)), field "name" (docUnqualifiedName (classDeclName cd))]
         <> optionalField "context" (brackets . hsep . punctuate comma . map docType) (classDeclContext cd)
         <> listField "params" docTyVarBinder (classDeclParams cd)
         <> listField "fundeps" docFunctionalDependency (classDeclFundeps cd)
@@ -449,7 +449,7 @@ docInstanceDecl inst =
         <> listField "forall" docTyVarBinder (instanceDeclForall inst)
         <> boolField "parenthesizedHead" (instanceDeclParenthesizedHead inst)
         <> [field "headForm" (docTypeHeadForm (instanceDeclHeadForm inst))]
-        <> [field "className" (docText (instanceDeclClassName inst))]
+        <> [field "className" (docUnqualifiedName (instanceDeclClassName inst))]
         <> listField "context" docType (instanceDeclContext inst)
         <> [field "types" (brackets (hsep (punctuate comma (map docType (instanceDeclTypes inst)))))]
         <> listField "items" docInstanceDeclItem (instanceDeclItems inst)
@@ -474,7 +474,7 @@ docStandaloneDerivingDecl sd =
         <> optionalField "warning" docWarningText (standaloneDerivingWarning sd)
         <> boolField "parenthesizedHead" (standaloneDerivingParenthesizedHead sd)
         <> [field "headForm" (docTypeHeadForm (standaloneDerivingHeadForm sd))]
-        <> [field "className" (docUnqualifiedName (standaloneDerivingClassName sd))]
+        <> [field "className" (docName (standaloneDerivingClassName sd))]
         <> optionalField "strategy" docDerivingStrategy (standaloneDerivingStrategy sd)
         <> listField "context" docType (standaloneDerivingContext sd)
         <> [field "types" (brackets (hsep (punctuate comma (map docType (standaloneDerivingTypes sd)))))]
@@ -686,7 +686,7 @@ docExpr expr =
     ETHDeclQuote decls -> "ETHDeclQuote" <+> brackets (hsep (punctuate comma (map docDecl decls)))
     ETHTypeQuote ty -> "ETHTypeQuote" <+> parens (docType ty)
     ETHPatQuote pat -> "ETHPatQuote" <+> parens (docPattern pat)
-    ETHNameQuote name -> "ETHNameQuote" <+> docText name
+    ETHNameQuote name -> "ETHNameQuote" <+> docName name
     ETHTypeNameQuote name -> "ETHTypeNameQuote" <+> docName name
     ETHSplice body -> "ETHSplice" <+> parens (docExpr body)
     ETHTypedSplice body -> "ETHTypedSplice" <+> parens (docExpr body)
@@ -746,7 +746,7 @@ docCmd cmd =
     CmdAnn _ inner -> docCmd inner
     CmdArrApp lhs HsFirstOrderApp rhs -> "CmdArrApp" <+> parens (docExpr lhs) <+> "HsFirstOrderApp" <+> parens (docExpr rhs)
     CmdArrApp lhs HsHigherOrderApp rhs -> "CmdArrApp" <+> parens (docExpr lhs) <+> "HsHigherOrderApp" <+> parens (docExpr rhs)
-    CmdInfix l op r -> "CmdInfix" <+> parens (docCmd l) <+> docText op <+> parens (docCmd r)
+    CmdInfix l op r -> "CmdInfix" <+> parens (docCmd l) <+> docName op <+> parens (docCmd r)
     CmdDo stmts -> "CmdDo" <+> brackets (hsep (punctuate comma (map docCmdStmt stmts)))
     CmdIf cond yes no -> "CmdIf" <+> parens (docExpr cond) <+> parens (docCmd yes) <+> parens (docCmd no)
     CmdCase scrut alts -> "CmdCase" <+> parens (docExpr scrut) <+> brackets (hsep (punctuate comma (map docCmdCaseAlt alts)))

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1200,14 +1200,14 @@ data Role
   deriving (Data, Eq, Show, Generic, NFData)
 
 data RoleAnnotation = RoleAnnotation
-  { roleAnnotationName :: Text,
+  { roleAnnotationName :: UnqualifiedName,
     roleAnnotationRoles :: [Role]
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
 data TypeSynDecl = TypeSynDecl
   { typeSynHeadForm :: TypeHeadForm,
-    typeSynName :: Text,
+    typeSynName :: UnqualifiedName,
     typeSynParams :: [TyVarBinder],
     typeSynBody :: Type
   }
@@ -1378,7 +1378,7 @@ data StandaloneDerivingDecl = StandaloneDerivingDecl
     standaloneDerivingContext :: [Type],
     standaloneDerivingParenthesizedHead :: Bool,
     standaloneDerivingHeadForm :: TypeHeadForm,
-    standaloneDerivingClassName :: UnqualifiedName,
+    standaloneDerivingClassName :: Name,
     standaloneDerivingTypes :: [Type]
   }
   deriving (Data, Eq, Show, Generic, NFData)
@@ -1386,7 +1386,7 @@ data StandaloneDerivingDecl = StandaloneDerivingDecl
 data ClassDecl = ClassDecl
   { classDeclContext :: Maybe [Type],
     classDeclHeadForm :: TypeHeadForm,
-    classDeclName :: Text,
+    classDeclName :: UnqualifiedName,
     classDeclParams :: [TyVarBinder],
     classDeclFundeps :: [FunctionalDependency],
     classDeclItems :: [ClassDeclItem]
@@ -1432,7 +1432,7 @@ data InstanceDecl = InstanceDecl
     instanceDeclContext :: [Type],
     instanceDeclParenthesizedHead :: Bool,
     instanceDeclHeadForm :: TypeHeadForm,
-    instanceDeclClassName :: Text,
+    instanceDeclClassName :: UnqualifiedName,
     instanceDeclTypes :: [Type],
     instanceDeclItems :: [InstanceDeclItem]
   }
@@ -1582,7 +1582,7 @@ data Expr
   | ETHDeclQuote [Decl] -- [d| decls |]
   | ETHTypeQuote Type -- [t| type |]
   | ETHPatQuote Pattern -- [p| pat |]
-  | ETHNameQuote Text -- 'name
+  | ETHNameQuote Name -- 'name
   | ETHTypeNameQuote Name -- ''Name
   | -- Template Haskell splices
     ETHSplice Expr
@@ -1642,7 +1642,7 @@ data Cmd
   | -- | @exp -\< exp@ or @exp -\<\< exp@
     CmdArrApp Expr ArrAppType Expr
   | -- | Command-level infix: @cmd1 op cmd2@
-    CmdInfix Cmd Text Cmd
+    CmdInfix Cmd Name Cmd
   | -- | @do { cstmts }@
     CmdDo [DoStmt Cmd]
   | -- | @if exp then cmd else cmd@

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -187,7 +187,7 @@ genDeclRoleAnnotation = do
   pure $
     DeclRoleAnnotation
       RoleAnnotation
-        { roleAnnotationName = name,
+        { roleAnnotationName = mkUnqualifiedName NameConId name,
           roleAnnotationRoles = roles
         }
 
@@ -200,7 +200,7 @@ genDeclTypeSyn = do
     DeclTypeSyn
       TypeSynDecl
         { typeSynHeadForm = TypeHeadPrefix,
-          typeSynName = name,
+          typeSynName = mkUnqualifiedName NameConId name,
           typeSynParams = params,
           typeSynBody = body
         }
@@ -220,7 +220,7 @@ genDeclTypeSynInfix = do
     DeclTypeSyn
       TypeSynDecl
         { typeSynHeadForm = TypeHeadInfix,
-          typeSynName = name,
+          typeSynName = unqualifiedNameFromText name,
           typeSynParams = [lhs, rhs],
           typeSynBody = body
         }
@@ -581,7 +581,7 @@ genDeclClassPrefix = do
       ClassDecl
         { classDeclContext = ctx,
           classDeclHeadForm = TypeHeadPrefix,
-          classDeclName = name,
+          classDeclName = mkUnqualifiedName NameConId name,
           classDeclParams = params,
           classDeclFundeps = [],
           classDeclItems = items
@@ -660,7 +660,7 @@ genDeclClassInfix = do
       ClassDecl
         { classDeclContext = ctx,
           classDeclHeadForm = TypeHeadInfix,
-          classDeclName = name,
+          classDeclName = mkUnqualifiedName NameConId name,
           classDeclParams = params,
           classDeclFundeps = [],
           classDeclItems = items
@@ -684,7 +684,7 @@ genDeclInstancePrefix = do
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
           instanceDeclHeadForm = TypeHeadPrefix,
-          instanceDeclClassName = className,
+          instanceDeclClassName = mkUnqualifiedName NameConId className,
           instanceDeclTypes = types,
           instanceDeclItems = []
         }
@@ -704,7 +704,7 @@ genDeclInstanceInfix = do
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
           instanceDeclHeadForm = TypeHeadInfix,
-          instanceDeclClassName = className,
+          instanceDeclClassName = mkUnqualifiedName NameConId className,
           instanceDeclTypes = [lhs, rhs],
           instanceDeclItems = []
         }
@@ -714,7 +714,7 @@ genDeclStandaloneDeriving = oneof [genDeclStandaloneDerivingPrefix, genDeclStand
 
 genDeclStandaloneDerivingPrefix :: Gen Decl
 genDeclStandaloneDerivingPrefix = do
-  className <- mkUnqualifiedName NameConId <$> genConIdent
+  className <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
   n <- chooseInt (0, 2)
   types <- vectorOf n genInstanceHeadType
   strategy <- elements [Nothing, Just DerivingStock, Just DerivingNewtype, Just DerivingAnyclass]
@@ -736,7 +736,7 @@ genDeclStandaloneDerivingPrefix = do
 
 genDeclStandaloneDerivingInfix :: Gen Decl
 genDeclStandaloneDerivingInfix = do
-  className <- mkUnqualifiedName NameConId <$> genConIdent
+  className <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
   lhs <- genInfixInstanceHeadType
   rhs <- genInfixInstanceHeadType
   strategy <- elements [Nothing, Just DerivingStock, Just DerivingNewtype, Just DerivingAnyclass]
@@ -1375,7 +1375,7 @@ shrinkDataFamilyInst dfi =
 shrinkRoleAnnotation :: RoleAnnotation -> [RoleAnnotation]
 shrinkRoleAnnotation ra =
   [ra {roleAnnotationRoles = rs'} | rs' <- shrinkList (const []) (roleAnnotationRoles ra)]
-    <> [ra {roleAnnotationName = n'} | n' <- shrinkConIdent (roleAnnotationName ra)]
+    <> [ra {roleAnnotationName = n'} | n' <- shrinkConName (roleAnnotationName ra)]
 
 -- ---------------------------------------------------------------------------
 -- Name shrinking helpers

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -96,7 +96,7 @@ genExprSizedWith allowTHQuotes n
             ETHDeclQuote <$> genValueDeclsWith False (n - 1),
             ETHPatQuote <$> genPattern (n - 1),
             ETHTypeQuote <$> genTypeWith False (n - 1),
-            ETHNameQuote . renderName <$> genNameQuoteName,
+            ETHNameQuote <$> genNameQuoteName,
             ETHTypeNameQuote <$> genTypeNameQuote
           ]
       | otherwise =
@@ -309,7 +309,8 @@ isValidGeneratedOperator candidate =
         candidate
           `elem` ["..", "::", "=", "\\", "|", "<-", "->", "~", "=>", "--", "-<", ">-", "-<<", ">>-"]
       dashOnly = T.length candidate >= 2 && T.all (== '-') candidate
-   in not reserved && not dashOnly
+      hasCanonicalizedUnicode = T.any (`elem` bannedUnicodeOperatorChars) candidate
+   in not reserved && not dashOnly && not hasCanonicalizedUnicode
 
 -- | Generate a data constructor name
 genConName :: Gen Text

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -167,11 +167,33 @@ isValidGeneratedVarSym op =
   case T.uncons op of
     Just (first, rest) ->
       first /= ':'
+        && first /= '`'
         && isValidSymbolChar first
+        && T.all (/= '`') rest
         && T.all isValidSymbolChar rest
         && op `Set.notMember` reservedOperators
         && not (isDashRun op)
+        && not (T.any (`elem` bannedUnicodeOperatorChars) op)
     Nothing -> False
+
+bannedUnicodeOperatorChars :: [Char]
+bannedUnicodeOperatorChars =
+  [ '→',
+    '←',
+    '⇒',
+    '∷',
+    '∀',
+    '⤙',
+    '⤚',
+    '⤛',
+    '⤜',
+    '⦇',
+    '⦈',
+    '⟦',
+    '⟧',
+    '⊸',
+    '★'
+  ]
 
 -------------------------------------------------------------------------------
 -- Module qualifiers

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -41,7 +41,7 @@ prop_exprPrettyRoundTrip expr =
 
 test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote :: Assertion
 test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote =
-  let expr = EAnn (mkAnnotation span0) (ETHNameQuote "H3xVBC.NB.Y.‼.")
+  let expr = EAnn (mkAnnotation span0) (ETHNameQuote (mkName (Just "H3xVBC.NB.Y") NameVarSym "‼."))
       source = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
       expected = normalizeExpr (addExprParens expr)
    in case parseExpr exprConfig source of

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -680,11 +680,11 @@ topLevelDeclAnnotations decl scope =
 
 classAnnotation :: Scope -> SourceSpan -> ClassDecl -> ResolutionAnnotation
 classAnnotation scope declSpan classDecl =
-  let className = mkUnqualifiedName NameConId (classDeclName classDecl)
+  let className = classDeclName classDecl
       span' = declSpan
    in ResolutionAnnotation
-        (declKeywordNameSpan "class " span' (classDeclName classDecl))
-        (classDeclName classDecl)
+        (declKeywordNameSpan "class " span' (renderUnqualifiedName className))
+        (renderUnqualifiedName className)
         ResolutionNamespaceType
         (resolveTopLevelType scope className)
 
@@ -750,7 +750,7 @@ declExportedNames decl =
             PVar name -> ([name], [])
             _ -> ([], [])
     DeclTypeSig names _ -> (names, [])
-    DeclClass classDecl -> ([], [mkUnqualifiedName NameConId (classDeclName classDecl)])
+    DeclClass classDecl -> ([], [classDeclName classDecl])
     DeclTypeData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [dataDeclName dataDecl])
     DeclData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [dataDeclName dataDecl])
     DeclNewtype newtypeDecl ->


### PR DESCRIPTION
## Summary
- switch the requested parser AST fields from raw `Text` to `Name`/`UnqualifiedName`, including TH name quotes and command infix operators
- simplify parser and pretty-printer handling by preserving structured names instead of re-inferring them from text, while keeping standalone deriving heads qualified where needed
- update resolve and property tests/generators to match the stronger AST types and existing unicode operator canonicalization

## Validation
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)

## Progress
- pass=858
- xfail=19
- xpass=0
- fail=0
- completion=97.82%
