### PR TITLE
fix(parser): tighten QC generators and bundled member printing

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -195,7 +195,7 @@ prettyImportItem item =
 
 prettyExportMember :: IEBundledMember -> Doc ann
 prettyExportMember (IEBundledMember namespace name) =
-  prettyMemberNamespacePrefix namespace <> prettyName name
+  prettyMemberNamespacePrefix namespace <> prettyBundledMemberName name
 
 prettyNamespacePrefix :: Maybe IEEntityNamespace -> Doc ann
 prettyNamespacePrefix namespace =
@@ -1021,6 +1021,20 @@ prettyName :: Name -> Doc ann
 prettyName name
   | nameType name == NameVarSym || nameType name == NameConSym = parens (pretty (renderName name))
   | otherwise = pretty (renderName name)
+
+prettyBundledMemberName :: Name -> Doc ann
+prettyBundledMemberName name
+  | isHashLeadingSymbolicName name = parens (" " <> pretty (renderName name) <> " ")
+  | otherwise = prettyName name
+
+isHashLeadingSymbolicName :: Name -> Bool
+isHashLeadingSymbolicName name =
+  isSymbolicName name
+    && case nameQualifier name of
+      Nothing -> case T.uncons (nameText name) of
+        Just ('#', _) -> True
+        _ -> False
+      Just _ -> False
 
 prettyConstructorName :: Text -> Doc ann
 prettyConstructorName name

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -253,6 +253,7 @@ buildTests = do
             testCase "captures known pragmas after ignored unknown pragmas" test_knownPragmaStillParsesAfterIgnoredUnknownPragma,
             testCase "roundtrips source unpackedness through pretty-printing" test_sourceUnpackednessRoundtrip,
             testCase "roundtrips warned export reexports" test_warnedExportReexportRoundtrip,
+            testCase "roundtrips symbolic bundled import members without unboxed tuple tokenization" test_symbolicBundledImportMemberRoundtrip,
             testCase "parses infix class heads" test_infixClassHeadParses,
             testCase "roundtrips else branches with local where clauses" test_ifElseWhereBranchRoundtrip,
             testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
@@ -373,6 +374,7 @@ buildTests = do
               QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
+              QC.testProperty "generated data family instance record fields use identifier labels" prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels,
               QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
@@ -584,6 +586,13 @@ test_warnedExportReexportRoundtrip =
    in case validateParser "WarnedExportReexport.hs" Haskell2010Edition [] source of
         Nothing -> pure ()
         Just err -> assertFailure ("expected warned exports roundtrip to validate, got: " <> show err)
+
+test_symbolicBundledImportMemberRoundtrip :: Assertion
+test_symbolicBundledImportMemberRoundtrip =
+  let source = T.unlines ["{-# LANGUAGE MagicHash #-}", "module M where", "import A (A(( # )))"]
+   in case validateParser "SymbolicBundledImportMember.hs" Haskell2010Edition [EnableExtension MagicHash] source of
+        Nothing -> pure ()
+        Just err -> assertFailure ("expected symbolic bundled import member to roundtrip, got: " <> show err)
 
 test_infixClassHeadParses :: Assertion
 test_infixClassHeadParses =
@@ -1771,6 +1780,26 @@ prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds =
         | decl@(DeclDataFamilyInst DataFamilyInst {dataFamilyInstKind = Just _}) <- samples
         ]
    in counterexample ("expected at least one generated data family instance with inline result kind; sampled " <> show (length samples)) (not (null matching))
+
+prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels :: Property
+prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels =
+  let samples = sampleGen 6000 genDeclDataFamilyInst
+      matching =
+        [ fieldName
+        | DeclDataFamilyInst DataFamilyInst {dataFamilyInstConstructors} <- samples,
+          ctor <- dataFamilyInstConstructors,
+          RecordCon {} <- [peelDataConAnn ctor],
+          RecordCon _ _ _ fields <- [peelDataConAnn ctor],
+          field <- fields,
+          fieldName <- fieldNames field
+        ]
+   in counterexample
+        ( "expected generated data family instances to include record fields with identifier labels only; sampled "
+            <> show (length samples)
+            <> ", record field labels="
+            <> show (length matching)
+        )
+        (not (null matching) && all ((== NameVarId) . unqualifiedNameType) matching)
 
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications :: Property
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -19,6 +19,7 @@ import Test.Properties.Arb.Expr (genExpr, isValidGeneratedOperator, shrinkExpr)
 import Test.Properties.Arb.Identifiers
   ( genConIdent,
     genConSym,
+    genFieldName,
     genIdent,
     genVarSym,
     shrinkConIdent,
@@ -386,8 +387,12 @@ genRecordCon = do
 genFieldDecl :: Gen FieldDecl
 genFieldDecl = do
   fieldCount <- chooseInt (1, 3)
-  fieldNames <- vectorOf fieldCount genVarBinderName
+  fieldNames <- vectorOf fieldCount genRecordFieldName
   FieldDecl [] fieldNames <$> genSimpleBangType
+
+genRecordFieldName :: Gen UnqualifiedName
+genRecordFieldName =
+  mkUnqualifiedName NameVarId <$> genFieldName
 
 genGadtDataCons :: Gen [DataConDecl]
 genGadtDataCons = do
@@ -563,7 +568,7 @@ genNewtypePrefixCon = do
 genNewtypeRecordCon :: Gen DataConDecl
 genNewtypeRecordCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
-  fieldName <- genVarBinderName
+  fieldName <- genRecordFieldName
   ty <- genSimpleType
   pure (RecordCon [] [] conName [FieldDecl [] [fieldName] (BangType [] NoSourceUnpackedness False False ty)])
 


### PR DESCRIPTION
## Summary
- fix the QuickCheck data-family-instance generator so record field labels are always identifier-style names, which matches Haskell record syntax and prevents invalid pretty-print round trips
- fix bundled import/export member pretty-printing for unqualified hash-leading symbolic names so forms like `A(( # ))` do not lex as unboxed tuple tokens
- add targeted regression coverage for both cases; progress counts unchanged

## Verification
- `cabal test -v0 aihc-parser:spec --test-options='--pattern \"/properties/&&/generated module AST pretty-printer round-trip/\" --quickcheck-replay=\"(SMGen 5420124830618797665 9138478461382261155,80)\" --hide-successes'`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)