### PR TITLE
fix(parser): support MagicHash identifier suffix generation

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -786,10 +786,22 @@ startsWithContextType = MP.lookAhead (go [])
 startsWithTypeSig :: TokParser Bool
 startsWithTypeSig =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    _ <- binderNameParser
-    let moreNames = (expectedTok TkSpecialComma *> binderNameParser *> moreNames) <|> pure ()
+    _ <- sigBinderNameParser
+    let moreNames = (expectedTok TkSpecialComma *> sigBinderNameParser *> moreNames) <|> pure ()
     moreNames
     expectedTok TkReservedDoubleColon
+  where
+    sigBinderNameParser =
+      binderNameParser
+        <|> parens sigOperatorParser
+
+    sigOperatorParser =
+      tokenSatisfy "signature operator" $ \tok ->
+        case lexTokenKind tok of
+          TkVarSym op -> Just (mkUnqualifiedName NameVarSym op)
+          TkConSym op -> Just (mkUnqualifiedName NameConSym op)
+          TkReservedColon -> Just (mkUnqualifiedName NameConSym ":")
+          _ -> Nothing
 
 -- | Non-consuming lookahead: does the input start with @name \@@?
 startsWithAsPattern :: TokParser Bool

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -314,13 +314,6 @@ lexIdentifier env st =
                in gatherQualified hasMH (acc <> "." <> segWithHead) rest
         _ -> (acc, chars, T.any (== '.') acc)
 
-    consumeIdentTail :: Bool -> Text -> (Text, Text)
-    consumeIdentTail hasMH inp =
-      let (tailPart, rest) = T.span isIdentTail inp
-       in case rest of
-            '#' :< rest' | hasMH -> (tailPart <> "#", rest')
-            _ -> (tailPart, rest)
-
     -- Split a qualified identifier into (module part, name part).
     -- E.g. "Data.Maybe." ++ "++" -> ("Data.Maybe", "++")
     splitQualified :: Text -> Text -> (Text, Text)
@@ -344,6 +337,16 @@ lexIdentifier env st =
               | isConIdStart firstChar -> TkConId ident
               | otherwise -> TkVarId ident
 
+consumeIdentTail :: Bool -> Text -> (Text, Text)
+consumeIdentTail hasMH inp =
+  let (tailPart, rest) = T.span isIdentTail inp
+   in case rest of
+        '#' :< _
+          | hasMH ->
+              let hashes = T.takeWhile (== '#') rest
+               in (tailPart <> hashes, T.drop (T.length hashes) rest)
+        _ -> (tailPart, rest)
+
 lexImplicitParam :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexImplicitParam env st
   | not (hasExt ImplicitParams env) = Nothing
@@ -351,7 +354,8 @@ lexImplicitParam env st
       case lexerInput st of
         '?' :< rest0@(c :< _)
           | isVarIdentifierStartChar c ->
-              let tailChars = T.takeWhile isIdentTail (T.tail rest0)
+              let hasMagicHash = hasExt MagicHash env
+                  (tailChars, _rest) = consumeIdentTail hasMagicHash (T.tail rest0)
                   txt = T.take (2 + T.length tailChars) (lexerInput st)
                   st' = advanceChars txt st
                in Just (mkToken st st' txt (TkImplicitParam txt), st')

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -740,9 +740,11 @@ nameFromText txt =
         Nothing -> False
 
     isIdentifierSegment segment =
-      case T.uncons segment of
-        Just (c, rest) -> isIdentifierStartChar c && T.all isIdentChar rest
-        Nothing -> False
+      let magicHashes = T.takeWhileEnd (== '#') segment
+          baseSegment = T.dropEnd (T.length magicHashes) segment
+       in case T.uncons baseSegment of
+            Just (c, rest) -> isIdentifierStartChar c && T.all isIdentChar rest
+            Nothing -> False
 
 unqualifiedNameFromText :: Text -> UnqualifiedName
 unqualifiedNameFromText txt = UnqualifiedName (inferNameType txt) txt

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -235,9 +235,13 @@ buildTests = do
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
             testCase "generated identifiers accept unicode variable characters" test_generatedIdentifiersAcceptUnicodeVariableCharacters,
+            testCase "generated identifiers accept MagicHash suffixes" test_generatedIdentifiersAcceptMagicHashSuffixes,
             testCase "generated constructor identifiers accept unicode uppercase and number tails" test_generatedConstructorIdentifiersAcceptUnicodeCharacters,
+            testCase "generated constructor identifiers accept MagicHash suffixes" test_generatedConstructorIdentifiersAcceptMagicHashSuffixes,
             testCase "shrinking identifiers preserves the first character" test_shrunkIdentifiersPreserveFirstCharacter,
             testCase "shrinking constructor identifiers preserves the first character" test_shrunkConstructorIdentifiersPreserveFirstCharacter,
+            testCase "lexes identifiers with repeated MagicHash suffixes" test_magicHashIdentifierLexes,
+            testCase "parses repeated MagicHash suffixes in exports" test_magicHashExportParses,
             testCase "generated constructor symbols reject reserved spellings" test_generatedConstructorSymbolsRejectReservedSpellings,
             testCase "generated variable symbols reject reserved spellings" test_generatedVariableSymbolsRejectReservedSpellings,
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
@@ -254,6 +258,7 @@ buildTests = do
             testCase "roundtrips source unpackedness through pretty-printing" test_sourceUnpackednessRoundtrip,
             testCase "roundtrips warned export reexports" test_warnedExportReexportRoundtrip,
             testCase "parses infix class heads" test_infixClassHeadParses,
+            testCase "parses class operator type signatures in where blocks" test_classOperatorTypeSigParses,
             testCase "roundtrips else branches with local where clauses" test_ifElseWhereBranchRoundtrip,
             testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
             testCase "parses mdo view patterns" test_mdoViewPatternParses,
@@ -608,6 +613,22 @@ test_infixClassHeadParses =
           [ DeclFixity {},
             DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "b" Nothing TyVarBSpecified TyVarBVisible], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
             ] -> pure ()
+          other -> assertFailure ("unexpected parsed declarations: " <> show other)
+
+test_classOperatorTypeSigParses :: Assertion
+test_classOperatorTypeSigParses =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE MagicHash #-}",
+            "{-# LANGUAGE TypeOperators #-}",
+            "module M where",
+            "class a `C#` b where { (##) :: x### -> y## }"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        case map normalizeDecl (moduleDecls modu) of
+          [DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = "C#", classDeclItems = [ClassItemTypeSig_ [UnqualifiedName NameVarSym "##"] _]}] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_ifElseWhereBranchRoundtrip :: Assertion
@@ -1204,12 +1225,26 @@ test_generatedIdentifiersAcceptUnicodeVariableCharacters = do
   assertBool "unicode lowercase letters should be accepted at the start of generated identifiers" $
     isValidGeneratedIdent "\x03bbx"
 
+test_generatedIdentifiersAcceptMagicHashSuffixes :: Assertion
+test_generatedIdentifiersAcceptMagicHashSuffixes = do
+  assertBool "MagicHash should allow a single trailing hash on variable identifiers" $
+    isValidGeneratedIdent "x#"
+  assertBool "MagicHash should allow repeated trailing hashes on variable identifiers" $
+    isValidGeneratedIdent "x####"
+
 test_generatedConstructorIdentifiersAcceptUnicodeCharacters :: Assertion
 test_generatedConstructorIdentifiersAcceptUnicodeCharacters = do
   assertBool "unicode titlecase letters should be accepted at the start of constructor identifiers" $
     isValidConIdent "\x01c5tail"
   assertBool "unicode uppercase letters and unicode numbers should be accepted in constructor identifiers" $
     isValidConIdent "\x0394\x0660"
+
+test_generatedConstructorIdentifiersAcceptMagicHashSuffixes :: Assertion
+test_generatedConstructorIdentifiersAcceptMagicHashSuffixes = do
+  assertBool "MagicHash should allow a single trailing hash on constructor identifiers" $
+    isValidConIdent "T#"
+  assertBool "MagicHash should allow repeated trailing hashes on constructor identifiers" $
+    isValidConIdent "T####"
 
 test_shrunkIdentifiersPreserveFirstCharacter :: Assertion
 test_shrunkIdentifiersPreserveFirstCharacter =
@@ -1220,6 +1255,28 @@ test_shrunkConstructorIdentifiersPreserveFirstCharacter :: Assertion
 test_shrunkConstructorIdentifiersPreserveFirstCharacter =
   assertBool "constructor identifier shrinking must preserve the first character" $
     all ((== Just '\x0394') . fmap fst . T.uncons) (shrinkConIdent "\x0394elta9")
+
+test_magicHashIdentifierLexes :: Assertion
+test_magicHashIdentifierLexes = do
+  let varTokens = lexTokensWithExtensions [MagicHash] "x####"
+      conTokens = lexTokensWithExtensions [MagicHash] "T####"
+  case varTokens of
+    [LexToken {lexTokenKind = TkVarId "x####"}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    other -> assertFailure ("expected MagicHash var identifier token, got: " <> show other)
+  case conTokens of
+    [LexToken {lexTokenKind = TkConId "T####"}, LexToken {lexTokenKind = TkEOF}] -> pure ()
+    other -> assertFailure ("expected MagicHash constructor identifier token, got: " <> show other)
+
+test_magicHashExportParses :: Assertion
+test_magicHashExportParses =
+  let source = T.unlines ["{-# LANGUAGE MagicHash #-}", "module M (f##) where", "", "f## = undefined"]
+      (errs, modu) = parseModule defaultConfig source
+   in case errs of
+        [] ->
+          case moduleHead modu of
+            Just ModuleHead {moduleHeadExports = Just [ExportAnn _ (ExportVar _ _ name)]} | name == qualifyName Nothing (mkUnqualifiedName NameVarId "f##") -> pure ()
+            other -> assertFailure ("expected export of f##, got: " <> show other)
+        _ -> assertFailure ("expected parse success for MagicHash export, got: " <> formatParseErrors "<quickcheck>" (Just source) errs)
 
 test_generatedConstructorSymbolsRejectReservedSpellings :: Assertion
 test_generatedConstructorSymbolsRejectReservedSpellings =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/symbolize-export-double-hash-identifier.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/symbolize-export-double-hash-identifier.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="module export lists reject identifiers that end in double hashes" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE MagicHash #-}
 
 module M (f##) where

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -128,13 +128,13 @@ genExprLeaf =
 
 genOverloadedLabel :: Gen Expr
 genOverloadedLabel = do
-  labelName <- genIdent
+  labelName <- suchThat genIdent (not . T.isSuffixOf "#")
   pure (EOverloadedLabel labelName ("#" <> labelName))
 
 -- | Generate a quasi-quote name, excluding TH bracket names (e, d, p, t) which
 -- would collide with Template Haskell bracket syntax ([e|...|], [d|...|], etc.).
 genQuasiQuoteName :: Gen Text
-genQuasiQuoteName = suchThat genIdent (`notElem` ["e", "d", "p", "t"])
+genQuasiQuoteName = suchThat genIdent (\name -> name `notElem` ["e", "d", "p", "t"] && not (T.isSuffixOf "#" name))
 
 -- | Generate the body of a TH splice: either a bare variable or a parenthesized expression.
 -- Bare variables produce $name syntax; parenthesized produce $(expr) syntax.

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -92,7 +92,8 @@ genIdent = do
   first <- elements varIdentStartChars
   restLen <- chooseInt (0, 8)
   rest <- vectorOf restLen (elements identTailChars)
-  let candidate = T.pack (first : rest)
+  hashCount <- chooseInt (0, 4)
+  let candidate = T.pack (first : rest) <> T.replicate hashCount "#"
   if isValidGeneratedIdent candidate
     then pure candidate
     else genIdent
@@ -102,13 +103,22 @@ shrinkIdent = shrinkWithPreservedFirstChar isValidGeneratedIdent
 
 isValidGeneratedIdent :: Text -> Bool
 isValidGeneratedIdent ident =
-  case T.uncons ident of
-    Just (first, rest) ->
-      ident /= "_"
-        && isValidGeneratedIdentStartChar first
-        && T.all isValidIdentTailChar rest
-        && not (isReservedIdentifier allExtensions ident)
+  case unsnocMagicHash ident of
+    Just (baseIdent, _magicHashes) ->
+      case T.uncons baseIdent of
+        Just (first, rest) ->
+          baseIdent /= "_"
+            && isValidGeneratedIdentStartChar first
+            && T.all isValidIdentTailChar rest
+            && not (isReservedIdentifier allExtensions ident)
+        Nothing -> False
     Nothing -> False
+
+unsnocMagicHash :: Text -> Maybe (Text, Text)
+unsnocMagicHash ident =
+  let magicHashes = T.takeWhileEnd (== '#') ident
+      baseIdent = T.dropEnd (T.length magicHashes) ident
+   in if T.null ident || T.null baseIdent then Nothing else Just (baseIdent, magicHashes)
 
 -------------------------------------------------------------------------------
 -- Constructor identifiers (uppercase-starting names)
@@ -121,17 +131,21 @@ genConIdent = do
   first <- elements conIdentStartChars
   restLen <- chooseInt (0, 5)
   rest <- vectorOf restLen (elements identTailChars)
-  pure (T.pack (first : rest))
+  hashCount <- chooseInt (0, 4)
+  pure (T.pack (first : rest) <> T.replicate hashCount "#")
 
 shrinkConIdent :: Text -> [Text]
 shrinkConIdent = shrinkWithPreservedFirstChar isValidConIdent
 
 isValidConIdent :: Text -> Bool
 isValidConIdent ident =
-  case T.uncons ident of
-    Just (first, rest) ->
-      isValidConIdentStartChar first
-        && T.all isValidIdentTailChar rest
+  case unsnocMagicHash ident of
+    Just (baseIdent, _magicHashes) ->
+      case T.uncons baseIdent of
+        Just (first, rest) ->
+          isValidConIdentStartChar first
+            && T.all isValidIdentTailChar rest
+        Nothing -> False
     Nothing -> False
 
 -------------------------------------------------------------------------------

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -21,7 +21,7 @@ import Text.Megaparsec.Error qualified as MPE
 typeConfig :: ParserConfig
 typeConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension ImplicitParams]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension MagicHash, EnableExtension ImplicitParams]
     }
 
 prop_typePrettyRoundTrip :: Type -> Property


### PR DESCRIPTION
## Summary
- extend generated variable and constructor identifiers to include arbitrary trailing `#` suffixes, and enable `MagicHash` in type roundtrip properties
- fix MagicHash-aware name handling in the lexer and parser for repeated hash suffixes, implicit parameters, export lists, and class operator signatures
- update the oracle fixture for double-hash exports and add focused regression tests for repeated-hash identifiers and class item signatures

## Validation
- `just fmt`
- `just check`

## Progress
- Oracle completion: 100.00% (pass=864, xfail=0, xpass=0, fail=0)

## CodeRabbit
- Skipped: `coderabbit review --prompt-only` was rate-limited