### PR TITLE
fix: exclude backtick from symbol generator

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -41,7 +41,7 @@ import Aihc.Parser.Lex
     TokenOrigin (..),
   )
 import Aihc.Parser.Pretty ()
-import Aihc.Parser.Syntax (Decl, Expr, Module (..), Pattern, SourceSpan (..), Type)
+import Aihc.Parser.Syntax (Decl, Expr, Module (..), Pattern, SourceSpan (..), Type, applyImpliedExtensions)
 import Aihc.Parser.Types
 import Data.ByteString qualified as BS
 import Data.List qualified as List
@@ -97,7 +97,7 @@ defaultConfig =
 -- "error"
 parseExpr :: ParserConfig -> Text -> ParseResult Expr
 parseExpr cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (exprParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right expr -> ParseOk expr
@@ -111,7 +111,7 @@ parseExpr cfg input =
 -- ParseOk (PCon "Just" [PVar "x"])
 parsePattern :: ParserConfig -> Text -> ParseResult Pattern
 parsePattern cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (patternParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right pat -> ParseOk pat
@@ -125,7 +125,7 @@ parsePattern cfg input =
 -- ParseOk (TApp (TCon "Maybe") (TVar "a"))
 parseType :: ParserConfig -> Text -> ParseResult Type
 parseType cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (typeParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right ty -> ParseOk ty
@@ -136,7 +136,7 @@ parseType cfg input =
 -- ParseOk (DeclValue (FunctionBind "f" [Match {headForm = Prefix, pats = [PVar "x"], rhs = UnguardedRhs (EInfix (EVar "x") "+" (EInt 1))}]))
 parseDecl :: ParserConfig -> Text -> ParseResult Decl
 parseDecl cfg input =
-  let ts = mkTokStream (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (declParser <* eofTok) (parserSourceName cfg) ts of
         Left bundle -> ParseErr bundle
         Right decl -> ParseOk decl
@@ -156,7 +156,7 @@ parseDecl cfg input =
 -- Nothing
 parseModule :: ParserConfig -> Text -> ([(SourceSpan, Text)], Module)
 parseModule cfg input =
-  let ts = mkTokStreamModule (parserSourceName cfg) (parserExtensions cfg) input
+  let ts = mkTokStreamModule (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
       parser = do
         modu <- moduleParser
         _ <- eofTok

--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -34,9 +34,10 @@ checkPattern expr = case expr of
   -- Variables and constructors
   EVar name
     | nameText name == "_" -> Right PWildcard
-    | isConLikeName name -> Right (PCon name [])
+    | isConLikeName name -> Right (PCon name [] [])
     | isJust (nameQualifier name) -> Left "unexpected qualified name in pattern"
     | otherwise -> Right (PVar (mkUnqualifiedName (nameType name) (nameText name)))
+  ETypeSyntax form ty -> Right (PTypeSyntax form ty)
   -- Parenthesized expression
   -- When the inner expression is a view-pattern arrow (@expr -> expr@),
   -- produce @PParen (PView f pat)@ to preserve the explicit parens in
@@ -74,7 +75,7 @@ checkPattern expr = case expr of
     fPat <- checkPattern f
     xPat <- checkPattern x
     case peelPatternAnn fPat of
-      PCon name args -> Right (PCon name (args ++ [xPat]))
+      PCon name typeArgs args -> Right (PCon name typeArgs (args ++ [xPat]))
       _ -> Left "invalid pattern: application of non-constructor"
   -- Record construction -> record pattern
   ERecordCon name fields wc -> do
@@ -110,7 +111,11 @@ checkPattern expr = case expr of
   ESectionL {} -> Left "unexpected left section in pattern"
   ESectionR {} -> Left "unexpected right section in pattern"
   ERecordUpd {} -> Left "unexpected record update in pattern"
-  ETypeApp {} -> Left "unexpected type application in pattern"
+  ETypeApp fun ty -> do
+    funPat <- checkPattern fun
+    case peelPatternAnn funPat of
+      PCon name typeArgs args -> Right (PCon name (typeArgs ++ [ty]) args)
+      _ -> Left "unexpected type application in pattern"
   ETHExpQuote {} -> Left "unexpected Template Haskell expression quote in pattern"
   ETHTypedQuote {} -> Left "unexpected Template Haskell typed quote in pattern"
   ETHDeclQuote {} -> Left "unexpected Template Haskell declaration quote in pattern"

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -51,6 +51,7 @@ module Aihc.Parser.Internal.Common
     startsWithContextType,
     startsWithTypeSig,
     startsWithAsPattern,
+    startsWithTypeBinder,
     isConLikeName,
     isConLikeNameType,
     qualifiedVarName,
@@ -64,6 +65,7 @@ import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), TokStream (..), mkFoundToken)
 import Control.Monad (guard)
 import Data.Char (isUpper)
+import Data.Functor (($>))
 import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -795,6 +797,18 @@ startsWithAsPattern =
   fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
     _ <- identifierTextParser
     expectedTok TkReservedAt
+
+-- | Non-consuming lookahead: does the input start with a type binder (@\@@var or @\@@_)?
+-- 'TypeAbstractions' implies 'TypeApplications', so the lexer always emits 'TkTypeApp' (not
+-- 'TkReservedAt') for @\@@ preceded by whitespace. All valid type binder positions have
+-- whitespace before @\@@, so only 'TkTypeApp' is checked. Accepting 'TkReservedAt' here
+-- would produce false positives for as-patterns such as @x\@p@.
+startsWithTypeBinder :: TokParser Bool
+startsWithTypeBinder =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    expectedTok TkTypeApp
+    _ <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+    pure ()
 
 -- | Check whether a name looks like a constructor (starts with uppercase or ':').
 isConLikeName :: Name -> Bool

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -12,11 +12,12 @@ import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (equationRhsParser, exprParser)
 import Aihc.Parser.Internal.Import (warningTextParser)
 import Aihc.Parser.Internal.Pattern (patternParser, simplePatternParser)
-import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
+import Aihc.Parser.Internal.Type (forallTelescopeParser, typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind, pattern TkVarFamily, pattern TkVarRole)
 import Aihc.Parser.Syntax
 import Control.Monad (when)
 import Data.Char (isLower)
+import Data.Functor (($>))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -217,7 +218,7 @@ contextPrefixDispatchList = do
 typeFamilyForallParser :: TokParser [TyVarBinder]
 typeFamilyForallParser = do
   expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
+  binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
   pure binders
 
@@ -226,7 +227,7 @@ typeFamilyForallParser = do
 instanceForallParser :: TokParser [TyVarBinder]
 instanceForallParser = do
   expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
+  binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
   pure binders
 
@@ -289,7 +290,7 @@ dataFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   varIdTok "family"
   name <- constructorUnqualifiedNameParser
-  params <- MP.many typeParamParser
+  params <- MP.many declTypeParamParser
   kind <- familyResultKindParser
   pure $
     DeclDataFamilyDecl
@@ -398,7 +399,7 @@ classDataFamilyDeclParser :: TokParser ClassDeclItem
 classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   name <- constructorUnqualifiedNameParser
-  params <- MP.many typeParamParser
+  params <- MP.many declTypeParamParser
   kind <- familyResultKindParser
   pure
     ( ClassItemDataFamilyDecl
@@ -951,7 +952,7 @@ gadtTypeDataConDeclParser = withSpan $ do
   names <- gadtConNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   -- Parse optional forall
-  forallBinders <- MP.option [] gadtForallParser
+  forallBinders <- MP.many gadtForallParser
   -- Parse context (only equality constraints permitted, but we parse generally)
   context <- contextPrefixDispatchList
   -- Parse the body (prefix only for type data - no record style)
@@ -1039,7 +1040,7 @@ gadtConDeclParser = withSpan $ do
   names <- gadtConNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   -- Parse optional forall
-  forallBinders <- MP.option [] gadtForallParser
+  forallBinders <- MP.many gadtForallParser
   -- Parse optional context
   context <- contextPrefixDispatchList
   -- Parse the body (record or prefix style)
@@ -1053,12 +1054,8 @@ gadtConNameParser =
     <|> parens constructorOperatorUnqualifiedNameParser
 
 -- | Parse forall in GADT context: @forall a b.@
-gadtForallParser :: TokParser [TyVarBinder]
-gadtForallParser = do
-  expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
-  expectedTok (TkVarSym ".")
-  pure binders
+gadtForallParser :: TokParser ForallTelescope
+gadtForallParser = forallTelescopeParser
 
 -- | Parse the body of a GADT constructor (after :: and optional forall/context)
 -- Can be either prefix style: @a -> b -> T a@
@@ -1130,22 +1127,22 @@ typeDeclHeadParser =
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
-      params <- MP.many typeParamParser
+      params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, name, params)
 
     infixDeclHeadParser = do
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       pure (TypeHeadInfix, op, [lhs, rhs])
 
     parenthesizedInfixDeclHeadParser = do
       expectedTok TkSpecialLParen
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       expectedTok TkSpecialRParen
-      tailParams <- MP.many typeParamParser
+      tailParams <- MP.many declTypeParamParser
       pure (TypeHeadInfix, op, [lhs, rhs] <> tailParams)
 
 typeSynonymOperatorParser :: TokParser Text
@@ -1168,13 +1165,13 @@ typeFamilyHeadParser =
           constructorNameParser
             <|> (qualifyName Nothing <$> parens operatorUnqualifiedNameParser)
         pure (\span' -> typeAnnSpan span' (TCon name Unpromoted))
-      params <- MP.many typeParamParser
+      params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, headType, params)
 
     infixHeadParser = do
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- typeFamilyOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       let lhsType =
             TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
           rhsType =
@@ -1232,17 +1229,17 @@ classHeadParser =
   where
     prefixDeclHeadParser = do
       name <- constructorIdentifierParser
-      params <- MP.many typeParamParser
+      params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, name, params)
 
     infixDeclHeadParser = do
-      lhs <- typeParamParser
+      lhs <- declTypeParamParser
       op <- constructorOperatorParser
-      rhs <- typeParamParser
+      rhs <- declTypeParamParser
       pure (TypeHeadInfix, renderName op, [lhs, rhs])
 
-typeParamParser :: TokParser TyVarBinder
-typeParamParser =
+explicitForallBinderParser :: TokParser TyVarBinder
+explicitForallBinderParser =
   withSpan $
     ( do
         ident <-
@@ -1252,7 +1249,7 @@ typeParamParser =
                 | isTypeVarName name ->
                     Just name
               _ -> Nothing
-        pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified)
+        pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBVisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
@@ -1260,8 +1257,26 @@ typeParamParser =
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified)
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBVisible)
           )
+
+declTypeParamParser :: TokParser TyVarBinder
+declTypeParamParser = MP.try invisibleDeclTypeParamParser <|> explicitForallBinderParser
+
+invisibleDeclTypeParamParser :: TokParser TyVarBinder
+invisibleDeclTypeParamParser = withSpan $ do
+  expectedTok TkTypeApp
+  ( do
+      ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+      pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBInvisible)
+    )
+    <|> do
+      expectedTok TkSpecialLParen
+      ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+      expectedTok TkReservedDoubleColon
+      kind <- typeParser
+      expectedTok TkSpecialRParen
+      pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBInvisible)
 
 isTypeVarName :: Text -> Bool
 isTypeVarName name =
@@ -1300,7 +1315,7 @@ dataConQualifiersParser = do
 forallBindersParser :: TokParser [Text]
 forallBindersParser = do
   expectedTok TkKeywordForall
-  binders <- MP.some typeParamParser
+  binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
   pure (map tyVarBinderName binders)
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -439,10 +439,14 @@ atomExprParser = do
   blockArgsEnabled <- isExtensionEnabled BlockArguments
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
+  explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
+  requiredTypeArgumentsEnabled <- isExtensionEnabled RequiredTypeArguments
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkImplicitParam {} -> implicitParamExprParser
+    TkKeywordType
+      | explicitNamespacesEnabled || requiredTypeArgumentsEnabled -> explicitTypeExprParser
     _ ->
       MP.try prefixNegateAtomExprParser
         <|> MP.try parenOperatorExprParser
@@ -468,6 +472,11 @@ atomExprParser = do
         <|> overloadedLabelExprParser
         <|> wildcardExprParser
         <|> varExprParser
+
+explicitTypeExprParser :: TokParser Expr
+explicitTypeExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  expectedTok TkKeywordType
+  ETypeSyntax TypeSyntaxExplicitNamespace <$> typeParser
 
 prefixNegateAtomExprParser :: TokParser Expr
 prefixNegateAtomExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
@@ -915,7 +924,7 @@ lambdaExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
       ELambdaCase <$> bracedAlts
 
     lambdaPatsParser = do
-      pats <- MP.some patternParser
+      pats <- MP.some simplePatternParser
       expectedTok TkReservedRightArrow
       body <- region "while parsing lambda body" exprParser
       pure (ELambdaPats pats body)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -94,7 +94,10 @@ appPatternParser =
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =
   case peelPatternAnn lhs of
-    PCon name args -> PCon name (args <> [rhs])
+    PCon name typeArgs args ->
+      PAnn
+        (mkAnnotation (mergeSourceSpans (getPatternSourceSpan lhs) (getPatternSourceSpan rhs)))
+        (PCon name typeArgs (args <> [rhs]))
     _ -> lhs
 
 -- | Parse an atomic pattern (@apat@ in the Haskell Report).
@@ -105,11 +108,18 @@ patternAtomParser :: TokParser Pattern
 patternAtomParser = do
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
+  explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
+  requiredTypeArgumentsEnabled <- isExtensionEnabled RequiredTypeArguments
+  typeAbstractionsEnabled <- isExtensionEnabled TypeAbstractions
   let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
+    TkTypeApp
+      | typeAbstractionsEnabled -> typeBinderPatternParser
     TkPrefixBang -> strictPatternParser
     TkPrefixTilde -> irrefutablePatternParser
+    TkKeywordType
+      | explicitNamespacesEnabled || requiredTypeArgumentsEnabled -> explicitTypePatternParser
     TkQuasiQuote {} -> quasiQuotePatternParser
     TkTHSplice | thAny -> thSplicePatternParser
     TkKeywordUnderscore -> wildcardPatternParser
@@ -138,6 +148,16 @@ patternAtomParser = do
       name <- identifierTextParser
       expectedTok TkReservedAt
       PAs name <$> patternAtomParser
+
+typeBinderPatternParser :: TokParser Pattern
+typeBinderPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
+  expectedTok TkTypeApp
+  PTypeBinder <$> visibleTypeBinderCoreParser
+
+explicitTypePatternParser :: TokParser Pattern
+explicitTypePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
+  expectedTok TkKeywordType
+  PTypeSyntax TypeSyntaxExplicitNamespace <$> typeParser
 
 strictPatternParser :: TokParser Pattern
 strictPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -239,13 +259,33 @@ thSplicePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
 
 simplePatternParser :: TokParser Pattern
 simplePatternParser =
-  MP.try
-    ( withSpanAnn (PAnn . mkAnnotation) $ do
-        name <- identifierTextParser
-        expectedTok TkReservedAt
-        PAs name <$> patternAtomParser
+  do
+    typeAbstractionsEnabled <- isExtensionEnabled TypeAbstractions
+    let typeBinderParser = if typeAbstractionsEnabled then MP.try typeBinderPatternParser else MP.empty
+    MP.try
+      ( withSpanAnn (PAnn . mkAnnotation) $ do
+          name <- identifierTextParser
+          expectedTok TkReservedAt
+          PAs name <$> patternAtomParser
+      )
+      <|> typeBinderParser
+      <|> patternAtomParser
+
+visibleTypeBinderCoreParser :: TokParser TyVarBinder
+visibleTypeBinderCoreParser =
+  withSpan $
+    ( do
+        ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+        pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBInvisible)
     )
-    <|> patternAtomParser
+      <|> ( do
+              expectedTok TkSpecialLParen
+              ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+              expectedTok TkReservedDoubleColon
+              kind <- typeParser
+              expectedTok TkSpecialRParen
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBInvisible)
+          )
 
 varOrConPatternParser :: TokParser Pattern
 varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -259,7 +299,7 @@ varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
     _ ->
       pure $
         if isConLikeName name
-          then PCon name []
+          then PCon name [] []
           else PVar (mkUnqualifiedName (nameType name) (nameText name))
 
 recordFieldPatternParser :: TokParser (Name, Pattern)
@@ -393,7 +433,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
           tok' <- anySingle
           case lexTokenKind tok' of
             TkVarSym op -> pure (PVar (mkUnqualifiedName NameVarSym op))
-            TkConSym op -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym op)) [])
+            TkConSym op -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym op)) [] [])
             _ -> fail "expected operator token"
 
     -- Try to parse as expression, then reclassify via checkPattern.

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -2,6 +2,7 @@
 
 module Aihc.Parser.Internal.Type
   ( typeParser,
+    forallTelescopeParser,
     typeInfixParser,
     typeInfixOperatorParser,
     typeHeadInfixParser,
@@ -48,10 +49,17 @@ contextOrFunTypeParser = do
 
 forallTypeParser :: TokParser Type
 forallTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
+  telescope <- forallTelescopeParser
+  TForall telescope <$> typeParser
+
+forallTelescopeParser :: TokParser ForallTelescope
+forallTelescopeParser = do
   expectedTok TkKeywordForall
   binders <- MP.some forallBinderParser
-  expectedTok (TkVarSym ".")
-  TForall binders <$> contextOrFunTypeParser
+  visibility <-
+    (expectedTok (TkVarSym ".") $> ForallInvisible)
+      <|> (expectedTok TkReservedRightArrow $> ForallVisible)
+  pure (ForallTelescope visibility binders)
 
 -- | Parse a single forall binder: {k} | (k :: *) | k
 forallBinderParser :: TokParser TyVarBinder
@@ -60,23 +68,28 @@ forallBinderParser =
     -- Inferred binder: {k} | {k :: Type}
     ( do
         expectedTok TkSpecialLBrace
-        ident <- lowerIdentifierParser
+        ident <- forallBinderNameParser
         mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
         expectedTok TkSpecialRBrace
-        pure (\span' -> TyVarBinder [mkAnnotation span'] ident mKind TyVarBInferred)
+        pure (\span' -> TyVarBinder [mkAnnotation span'] ident mKind TyVarBInferred TyVarBVisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
-              ident <- lowerIdentifierParser
+              ident <- forallBinderNameParser
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
-              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified)
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBVisible)
           )
       <|> ( do
-              ident <- lowerIdentifierParser
-              pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified)
+              ident <- forallBinderNameParser
+              pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBVisible)
           )
+
+forallBinderNameParser :: TokParser Text
+forallBinderNameParser =
+  lowerIdentifierParser
+    <|> (expectedTok TkKeywordUnderscore $> "_")
 
 contextTypeParser :: TokParser Type
 contextTypeParser = do

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -288,8 +288,9 @@ lexIdentifier env st =
                 (True, '.' :< dotRest@(opChar :< _))
                   | isSymbolicOpChar opChar ->
                       let opChars = T.takeWhile isSymbolicOpChar dotRest
+                          opChars' = unescapeOpText opChars
                           fullOp = consumed <> "." <> opChars
-                          (modName, opName) = splitQualified (consumed <> ".") opChars
+                          (modName, opName) = splitQualified (consumed <> ".") opChars'
                           kind =
                             if opChar == ':'
                               then TkQConSym modName opName
@@ -647,16 +648,22 @@ lexOperator env st =
                in Just (mkToken st st' bananaText TkBananaClose, st')
             _ ->
               let st' = advanceChars opText st
+                  opText' = unescapeOpText opText
                   hasUnicode = hasExt UnicodeSyntax env
                   kind =
-                    case reservedOpTokenKind opText of
+                    case reservedOpTokenKind opText' of
                       Just reserved -> reserved
                       Nothing
-                        | hasArrows, Just arrowKind <- arrowOpTokenKind opText -> arrowKind
-                        | hasUnicode -> unicodeOpTokenKind hasArrows opText c
-                        | c == ':' -> TkConSym opText
-                        | otherwise -> TkVarSym opText
-               in Just (mkToken st st' opText kind, st')
+                        | hasArrows, Just arrowKind <- arrowOpTokenKind opText' -> arrowKind
+                        | hasUnicode -> unicodeOpTokenKind hasArrows opText' c
+                        | c == ':' -> TkConSym opText'
+                        | otherwise -> TkVarSym opText'
+               in Just (mkToken st st' opText' kind, st')
+
+-- | Unescape operator text. The only escape sequence in operators is
+-- '\`' for a literal backtick character.
+unescapeOpText :: Text -> Text
+unescapeOpText = T.replace "\\`" "`"
 
 unicodeOpTokenKind :: Bool -> Text -> Char -> LexTokenKind
 unicodeOpTokenKind hasArrows txt firstChar

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -659,6 +659,7 @@ addExprParensPrec prec expr =
     EApp {} -> addAppsChainPrec prec expr
     ETypeApp fn ty ->
       wrapExpr (prec > 2) (ETypeApp (addExprParensIn CtxAppFun fn) (addTypeIn CtxTypeAtom ty))
+    ETypeSyntax form ty -> wrapExpr (prec > 2) (ETypeSyntax form (addTypeParens ty))
     EVar {} -> expr
     EInt {} -> expr
     EIntHash {} -> expr
@@ -865,10 +866,15 @@ addTypeParensShared ctx prec ty =
         TTypeLit {} -> ty
         TStar {} -> ty
         TQuasiQuote {} -> ty
-        TForall binders inner ->
+        TForall telescope inner ->
           -- forallTypeParser uses contextOrFunTypeParser (not typeParser) for its
           -- body, so a bare nested TForall would fail to parse. Wrap it in TParen.
-          wrapTy (prec > 0) (TForall (map addTyVarBinderParens binders) (addForallBodyParens inner))
+          wrapTy
+            (prec > 0)
+            ( TForall
+                (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
+                (addForallBodyParens inner)
+            )
         tyInfix
           | Just (op, lhs, rhs) <- matchSymbolicInfixTypeApp tyInfix ->
               -- Infix type operator: args are treated as atoms
@@ -974,13 +980,15 @@ addPatternParens pat =
   case pat of
     PAnn sp sub -> PAnn sp (addPatternParens sub)
     PVar {} -> pat
+    PTypeBinder binder -> PTypeBinder (addTyVarBinderParens binder)
+    PTypeSyntax form ty -> PTypeSyntax form (addTypeParens ty)
     PWildcard {} -> pat
     PLit lit -> PLit lit
     PQuasiQuote {} -> pat
     PTuple tupleFlavor elems -> PTuple tupleFlavor (map addPatternInDelimited elems)
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (addPatternInDelimited inner)
     PList elems -> PList (map addPatternInDelimited elems)
-    PCon con args -> PCon con (map addPatternAtomParens args)
+    PCon con typeArgs args -> PCon con (map (addTypeIn CtxTypeAtom) typeArgs) (map addPatternAtomParens args)
     PInfix lhs op rhs -> PInfix (addPatternAtomParens lhs) op (addPatternAtomParens rhs)
     PView viewExpr inner ->
       wrapPat True (PView (addViewExprParens viewExpr) (addPatternParens inner))
@@ -1021,6 +1029,8 @@ addPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternAtomParens sub)
     PVar {} -> addPatternParens pat
+    PTypeBinder {} -> addPatternParens pat
+    PTypeSyntax {} -> addPatternParens pat
     PWildcard {} -> addPatternParens pat
     PLit {} -> addPatternParens pat
     PQuasiQuote {} -> addPatternParens pat
@@ -1034,7 +1044,7 @@ addPatternAtomParens pat =
     PView {} -> addPatternParens pat
     PAs {} -> addPatternParens pat
     PSplice {} -> addPatternParens pat
-    PCon _ [] -> addPatternParens pat
+    PCon _ [] [] -> addPatternParens pat
     PInfix _ op _
       | isConsOperator op ->
           -- Cons operator (:) is right-associative, so nested cons patterns
@@ -1048,7 +1058,7 @@ addLambdaPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addLambdaPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ [] -> wrapPat True (addPatternParens pat)
+    PCon _ _ [] -> wrapPat True (addPatternParens pat)
     _ -> addPatternAtomParens pat
 
 -- | Add parens for a pattern in function-head argument position.
@@ -1057,7 +1067,8 @@ addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ (_ : _) -> wrapPat True (addPatternParens pat)
+    PCon _ typeArgs args
+      | not (null typeArgs) || not (null args) -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat
     _ -> addPatternAtomParens pat
 
@@ -1075,7 +1086,7 @@ addPatternAtomStrictParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternAtomStrictParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ [] -> wrapPat True (addPatternParens pat)
+    PCon _ _ [] -> wrapPat True (addPatternParens pat)
     PStrict {} -> wrapPat True (addPatternParens pat)
     PIrrefutable {} -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -195,7 +195,7 @@ prettyImportItem item =
 
 prettyExportMember :: IEBundledMember -> Doc ann
 prettyExportMember (IEBundledMember namespace name) =
-  prettyMemberNamespacePrefix namespace <> prettyName name
+  prettyMemberNamespacePrefix namespace <> prettyBundledMemberName name
 
 prettyNamespacePrefix :: Maybe IEEntityNamespace -> Doc ann
 prettyNamespacePrefix namespace =
@@ -1050,6 +1050,20 @@ prettyName :: Name -> Doc ann
 prettyName name
   | nameType name == NameVarSym || nameType name == NameConSym = parens (pretty (renderSymbolName' name))
   | otherwise = pretty (renderName name)
+
+prettyBundledMemberName :: Name -> Doc ann
+prettyBundledMemberName name
+  | isHashLeadingSymbolicName name = parens (" " <> pretty (renderName name) <> " ")
+  | otherwise = prettyName name
+
+isHashLeadingSymbolicName :: Name -> Bool
+isHashLeadingSymbolicName name =
+  isSymbolicName name
+    && case nameQualifier name of
+      Nothing -> case T.uncons (nameText name) of
+        Just ('#', _) -> True
+        _ -> False
+      Just _ -> False
 
 prettyConstructorName :: Text -> Doc ann
 prettyConstructorName name

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -437,8 +437,8 @@ prettyType ty =
     TTypeLit lit -> prettyTypeLiteral lit
     TStar -> "*"
     TQuasiQuote quoter body -> prettyQuasiQuote quoter body
-    TForall binders inner ->
-      "forall" <+> hsep (map prettyTyVarBinder binders) <> "." <+> prettyType inner
+    TForall telescope inner ->
+      prettyForallTelescope telescope <+> prettyType inner
     -- Before infix detection: required grouping from the parser ('TParen',
     -- @(a :+: b) -> c@, constraints, nested @(c => t)@).
     TParen inner -> parens (prettyType inner)
@@ -490,6 +490,9 @@ prettyPattern pat =
   case pat of
     PAnn _ sub -> prettyPattern sub
     PVar name -> pretty name
+    PTypeBinder binder -> prettyTyVarBinder binder
+    PTypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
+    PTypeSyntax TypeSyntaxInTerm ty -> prettyType ty
     PWildcard -> "_"
     PLit lit -> prettyLiteral lit
     PQuasiQuote quoter body -> prettyQuasiQuote quoter body
@@ -498,7 +501,7 @@ prettyPattern pat =
       let slots = [if i == altIdx then prettyPattern inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     PList elems -> brackets (hsep (punctuate comma (map prettyPattern elems)))
-    PCon con args -> hsep (prettyPrefixName con : map prettyPattern args)
+    PCon con typeArgs args -> hsep ([prettyPrefixName con] <> map prettyInvisibleTypeArg typeArgs <> map prettyPattern args)
     PInfix lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView viewExpr inner ->
       prettyExpr viewExpr <+> "->" <+> prettyPattern inner
@@ -643,11 +646,18 @@ prettyDeclHead headForm constraints name params =
 
 prettyTyVarBinder :: TyVarBinder -> Doc ann
 prettyTyVarBinder binder =
-  case (tyVarBinderSpecificity binder, tyVarBinderKind binder) of
-    (TyVarBInferred, Nothing) -> braces (pretty (tyVarBinderName binder))
-    (TyVarBInferred, Just kind) -> braces (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
-    (TyVarBSpecified, Nothing) -> pretty (tyVarBinderName binder)
-    (TyVarBSpecified, Just kind) -> parens (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
+  visibleDoc
+  where
+    coreDoc =
+      case (tyVarBinderSpecificity binder, tyVarBinderKind binder) of
+        (TyVarBInferred, Nothing) -> braces (pretty (tyVarBinderName binder))
+        (TyVarBInferred, Just kind) -> braces (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
+        (TyVarBSpecified, Nothing) -> pretty (tyVarBinderName binder)
+        (TyVarBSpecified, Just kind) -> parens (pretty (tyVarBinderName binder) <+> "::" <+> prettyType kind)
+    visibleDoc =
+      case tyVarBinderVisibility binder of
+        TyVarBVisible -> coreDoc
+        TyVarBInvisible -> "@" <> coreDoc
 
 contextPrefix :: [Type] -> [Doc ann]
 contextPrefix constraints =
@@ -658,6 +668,17 @@ contextPrefix constraints =
 forallTyVarBinderPrefix :: [TyVarBinder] -> [Doc ann]
 forallTyVarBinderPrefix [] = []
 forallTyVarBinderPrefix binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
+
+prettyForallTelescope :: ForallTelescope -> Doc ann
+prettyForallTelescope telescope =
+  "forall"
+    <+> hsep (map prettyTyVarBinder (forallTelescopeBinders telescope))
+    <> case forallTelescopeVisibility telescope of
+      ForallInvisible -> "."
+      ForallVisible -> " ->"
+
+prettyInvisibleTypeArg :: Type -> Doc ann
+prettyInvisibleTypeArg ty = "@" <> prettyType ty
 
 prettyDataCon :: DataConDecl -> Doc ann
 prettyDataCon ctor =
@@ -690,10 +711,10 @@ prettyDataCon ctor =
         prettyFieldName fieldName
           | isOperatorToken (renderUnqualifiedName fieldName) = parens (pretty fieldName)
           | otherwise = pretty fieldName
-    GadtCon forallBinders constraints names body ->
-      prettyGadtCon forallBinders constraints names body
+    GadtCon foralls constraints names body ->
+      prettyGadtCon foralls constraints names body
 
-prettyGadtCon :: [TyVarBinder] -> [Type] -> [UnqualifiedName] -> GadtBody -> Doc ann
+prettyGadtCon :: [ForallTelescope] -> [Type] -> [UnqualifiedName] -> GadtBody -> Doc ann
 prettyGadtCon forallBinders constraints names body =
   hsep
     ( [hsep (punctuate comma (map prettyConstructorUName names)), "::"]
@@ -702,9 +723,7 @@ prettyGadtCon forallBinders constraints names body =
         <> [prettyGadtBody body]
     )
   where
-    forallPart
-      | null forallBinders = []
-      | otherwise = ["forall", hsep (map prettyTyVarBinder forallBinders) <> "."]
+    forallPart = map prettyForallTelescope forallBinders
     contextPart
       | null constraints = []
       | otherwise = [prettyContext constraints, "=>"]
@@ -1006,9 +1025,19 @@ isSymbolicName name =
 isSymbolicTypeName :: Name -> Bool
 isSymbolicTypeName = isSymbolicName
 
+-- | Render a symbolic name, escaping backtick characters so the output
+-- can be re-parsed. A bare backtick is lexed as 'TkSpecialBacktick',
+-- not as an operator, so it must be escaped as '\`'.
+renderSymbolName :: UnqualifiedName -> Text
+renderSymbolName name = T.replace "`" "\\`" (renderUnqualifiedName name)
+
+-- | Render a symbolic 'Name', escaping backtick characters.
+renderSymbolName' :: Name -> Text
+renderSymbolName' name = T.replace "`" "\\`" (renderName name)
+
 prettyFunctionBinder :: UnqualifiedName -> Doc ann
 prettyFunctionBinder name
-  | unqualifiedNameType name == NameVarSym || unqualifiedNameType name == NameConSym = parens (pretty (renderUnqualifiedName name))
+  | unqualifiedNameType name == NameVarSym || unqualifiedNameType name == NameConSym = parens (pretty (renderSymbolName name))
   | otherwise = pretty (renderUnqualifiedName name)
 
 prettyBinderName :: UnqualifiedName -> Doc ann
@@ -1019,7 +1048,7 @@ prettyBinderUName = prettyFunctionBinder
 
 prettyName :: Name -> Doc ann
 prettyName name
-  | nameType name == NameVarSym || nameType name == NameConSym = parens (pretty (renderName name))
+  | nameType name == NameVarSym || nameType name == NameConSym = parens (pretty (renderSymbolName' name))
   | otherwise = pretty (renderName name)
 
 prettyConstructorName :: Text -> Doc ann
@@ -1038,8 +1067,10 @@ prettyExpr expr =
     EApp fn arg -> prettyExpr fn <+> prettyExpr arg
     ETypeApp fn ty -> prettyExpr fn <+> "@" <> prettyType ty
     EVar name
-      | isSymbolicName name -> parens (pretty (renderName name))
+      | isSymbolicName name -> parens (pretty (renderSymbolName' name))
       | otherwise -> pretty name
+    ETypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
+    ETypeSyntax TypeSyntaxInTerm ty -> prettyType ty
     EInt _ repr -> pretty repr
     EIntHash _ repr -> pretty repr
     EIntBase _ repr -> pretty repr

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -358,7 +358,7 @@ docDataConDecl dcd =
     RecordCon forallVars constraints name fields' ->
       "RecordCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> listField "fields" docFieldDecl fields')))
     GadtCon forallBinders constraints names body ->
-      "GadtCon" <+> braces (hsep (punctuate comma (listField "names" docUnqualifiedName names <> listField "forallBinders" docTyVarBinder forallBinders <> listField "constraints" docType constraints <> [field "body" (docGadtBody body)])))
+      "GadtCon" <+> braces (hsep (punctuate comma (listField "names" docUnqualifiedName names <> listField "forallBinders" docForallTelescope forallBinders <> listField "constraints" docType constraints <> [field "body" (docGadtBody body)])))
 
 -- | Document a GADT body
 docGadtBody :: GadtBody -> Doc ann
@@ -569,7 +569,13 @@ docType ty =
     TTypeLit lit -> "TTypeLit" <+> docTypeLiteral lit
     TStar -> "TStar"
     TQuasiQuote quoter body -> "TQuasiQuote" <+> docText quoter <+> docText body
-    TForall binders inner -> "TForall" <+> brackets (hsep (punctuate comma (map docTyVarBinder binders))) <+> parens (docType inner)
+    TForall telescope inner ->
+      case forallTelescopeVisibility telescope of
+        ForallInvisible ->
+          "TForall"
+            <+> brackets (hsep (punctuate comma (map docTyVarBinder (forallTelescopeBinders telescope))))
+            <+> parens (docType inner)
+        ForallVisible -> "TForall" <+> parens (docForallTelescope telescope) <+> parens (docType inner)
     TApp f x -> "TApp" <+> parens (docType f) <+> parens (docType x)
     TFun a b -> "TFun" <+> parens (docType a) <+> parens (docType b)
     TTuple tupleFlavor promoted elems ->
@@ -607,6 +613,7 @@ docTyVarBinder tvb =
     fields =
       [field "name" (docText (tyVarBinderName tvb))]
         <> optionalField "specificity" docTyVarBSpecificity (specificityField tvb)
+        <> optionalField "visibility" docTyVarBVisibility (visibilityField tvb)
         <> optionalField "kind" docType (tyVarBinderKind tvb)
 
     specificityField binder =
@@ -614,11 +621,41 @@ docTyVarBinder tvb =
         TyVarBSpecified -> Nothing
         specificity -> Just specificity
 
+    visibilityField binder =
+      case tyVarBinderVisibility binder of
+        TyVarBVisible -> Nothing
+        visibility -> Just visibility
+
 docTyVarBSpecificity :: TyVarBSpecificity -> Doc ann
 docTyVarBSpecificity specificity =
   case specificity of
     TyVarBInferred -> "TyVarBInferred"
     TyVarBSpecified -> "TyVarBSpecified"
+
+docTyVarBVisibility :: TyVarBVisibility -> Doc ann
+docTyVarBVisibility visibility =
+  case visibility of
+    TyVarBVisible -> "TyVarBVisible"
+    TyVarBInvisible -> "TyVarBInvisible"
+
+docForallVis :: ForallVis -> Doc ann
+docForallVis visibility =
+  case visibility of
+    ForallInvisible -> "ForallInvisible"
+    ForallVisible -> "ForallVisible"
+
+docForallTelescope :: ForallTelescope -> Doc ann
+docForallTelescope telescope =
+  "ForallTelescope"
+    <+> braces
+      ( hsep
+          ( punctuate
+              comma
+              ( [field "visibility" (docForallVis (forallTelescopeVisibility telescope))]
+                  <> listField "binders" docTyVarBinder (forallTelescopeBinders telescope)
+              )
+          )
+      )
 
 -- Patterns
 
@@ -627,6 +664,8 @@ docPattern pat =
   case pat of
     PAnn _ sub -> docPattern sub
     PVar name -> "PVar" <+> docUnqualifiedName name
+    PTypeBinder binder -> "PTypeBinder" <+> parens (docTyVarBinder binder)
+    PTypeSyntax form ty -> "PTypeSyntax" <+> docTypeSyntaxForm form <+> parens (docType ty)
     PWildcard -> "PWildcard"
     PLit lit -> "PLit" <+> parens (docLiteral lit)
     PQuasiQuote quoter body -> "PQuasiQuote" <+> docText quoter <+> docText body
@@ -636,7 +675,21 @@ docPattern pat =
     PUnboxedSum altIdx arity inner ->
       "PUnboxedSum" <+> pretty altIdx <+> pretty arity <+> docPattern inner
     PList elems -> "PList" <+> brackets (hsep (punctuate comma (map docPattern elems)))
-    PCon name args -> "PCon" <+> docName name <+> brackets (hsep (punctuate comma (map docPattern args)))
+    PCon name typeArgs args ->
+      case typeArgs of
+        [] -> "PCon" <+> docName name <+> brackets (hsep (punctuate comma (map docPattern args)))
+        _ ->
+          "PCon"
+            <+> docName name
+            <+> braces
+              ( hsep
+                  ( punctuate
+                      comma
+                      ( listField "typeArgs" docType typeArgs
+                          <> listField "args" docPattern args
+                      )
+                  )
+              )
     PInfix lhs op rhs -> "PInfix" <+> parens (docPattern lhs) <+> docName op <+> parens (docPattern rhs)
     PView expr inner -> "PView" <+> parens (docExpr expr) <+> parens (docPattern inner)
     PAs name inner -> "PAs" <+> docText name <+> parens (docPattern inner)
@@ -669,6 +722,7 @@ docExpr :: Expr -> Doc ann
 docExpr expr =
   case expr of
     EVar name -> "EVar" <+> docName name
+    ETypeSyntax form ty -> "ETypeSyntax" <+> docTypeSyntaxForm form <+> parens (docType ty)
     EInt n _ -> "EInt" <+> pretty n
     EIntHash n repr -> "EIntHash" <+> pretty n <+> docText repr
     EIntBase n repr -> "EIntBase" <+> pretty n <+> docText repr
@@ -889,6 +943,12 @@ docTokenKind kind =
     TkTHTypedSplice -> "TkTHTypedSplice"
     TkError msg -> "TkError" <+> docText msg
     TkEOF -> "TkEOF"
+
+docTypeSyntaxForm :: TypeSyntaxForm -> Doc ann
+docTypeSyntaxForm form =
+  case form of
+    TypeSyntaxExplicitNamespace -> "TypeSyntaxExplicitNamespace"
+    TypeSyntaxInTerm -> "TypeSyntaxInTerm"
 
 -- Helpers
 

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -80,9 +80,13 @@ module Aihc.Parser.Syntax
     StandaloneDerivingDecl (..),
     Type (..),
     TupleFlavor (..),
+    TypeSyntaxForm (..),
     TypeLiteral (..),
     TypePromotion (..),
+    ForallVis (..),
+    ForallTelescope (..),
     TyVarBSpecificity (..),
+    TyVarBVisibility (..),
     TyVarBinder (..),
     TypeSynDecl (..),
     TypeFamilyDecl (..),
@@ -589,9 +593,11 @@ impliedExtensions =
     (Strict, [EnableExtension StrictData]),
     (TemplateHaskell, [EnableExtension TemplateHaskellQuotes]),
     (TypeFamilies, [EnableExtension ExplicitNamespaces, EnableExtension KindSignatures, EnableExtension MonoLocalBinds]),
+    (TypeAbstractions, [EnableExtension TypeApplications]),
     (TypeFamilyDependencies, [EnableExtension TypeFamilies]),
     (TypeInType, [EnableExtension PolyKinds, EnableExtension DataKinds, EnableExtension KindSignatures]),
     (TypeOperators, [EnableExtension ExplicitNamespaces]),
+    (RequiredTypeArguments, [EnableExtension TypeApplications]),
     (UnboxedTuples, [EnableExtension UnboxedSums]),
     (UnliftedDatatypes, [EnableExtension DataKinds, EnableExtension StandaloneKindSignatures])
   ]
@@ -1081,13 +1087,15 @@ data TupleFlavor
 data Pattern
   = PAnn Annotation Pattern
   | PVar UnqualifiedName
+  | PTypeBinder TyVarBinder
+  | PTypeSyntax TypeSyntaxForm Type
   | PWildcard
   | PLit Literal
   | PQuasiQuote Text Text
   | PTuple TupleFlavor [Pattern]
   | PUnboxedSum Int Int Pattern
   | PList [Pattern]
-  | PCon Name [Pattern]
+  | PCon Name [Type] [Pattern]
   | PInfix Pattern Name Pattern
   | PView Expr Pattern
   | PAs Text Pattern
@@ -1114,6 +1122,22 @@ peelPatternAnn :: Pattern -> Pattern
 peelPatternAnn (PAnn _ inner) = peelPatternAnn inner
 peelPatternAnn p = p
 
+data TypeSyntaxForm
+  = TypeSyntaxExplicitNamespace
+  | TypeSyntaxInTerm
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data ForallVis
+  = ForallInvisible
+  | ForallVisible
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data ForallTelescope = ForallTelescope
+  { forallTelescopeVisibility :: ForallVis,
+    forallTelescopeBinders :: [TyVarBinder]
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
 data Type
   = TAnn Annotation Type
   | TVar UnqualifiedName
@@ -1122,7 +1146,7 @@ data Type
   | TTypeLit TypeLiteral
   | TStar
   | TQuasiQuote Text Text
-  | TForall [TyVarBinder] Type
+  | TForall ForallTelescope Type
   | TApp Type Type
   | TFun Type Type
   | TTuple TupleFlavor TypePromotion [Type]
@@ -1176,6 +1200,11 @@ data TyVarBSpecificity
   | TyVarBSpecified
   deriving (Data, Eq, Show, Generic, NFData)
 
+data TyVarBVisibility
+  = TyVarBVisible
+  | TyVarBInvisible
+  deriving (Data, Eq, Show, Generic, NFData)
+
 data TyVarBinder = TyVarBinder
   { tyVarBinderAnns :: [Annotation],
     tyVarBinderName :: Text,
@@ -1183,7 +1212,9 @@ data TyVarBinder = TyVarBinder
     tyVarBinderKind :: Maybe Type,
     -- | Whether the binder was written as specified (@a@, @(a :: k)@)
     -- or inferred (@{a}@, @{a :: k}@).
-    tyVarBinderSpecificity :: TyVarBSpecificity
+    tyVarBinderSpecificity :: TyVarBSpecificity,
+    -- | Whether the binder was written visibly (@a@) or invisibly (@@a@).
+    tyVarBinderVisibility :: TyVarBVisibility
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -1302,7 +1333,7 @@ data DataConDecl
   | RecordCon [Text] [Type] UnqualifiedName [FieldDecl]
   | -- | GADT-style constructor: @Con :: forall a. Ctx => Type@
     -- The list of names supports multiple constructors: @T1, T2 :: Type@
-    GadtCon [TyVarBinder] [Type] [UnqualifiedName] GadtBody
+    GadtCon [ForallTelescope] [Type] [UnqualifiedName] GadtBody
   deriving (Data, Eq, Show, Generic, NFData)
 
 -- | Strip nested 'DataConAnn' wrappers.
@@ -1541,6 +1572,7 @@ instance NFData Annotation where
 data Expr
   = EAnn Annotation Expr
   | EVar Name
+  | ETypeSyntax TypeSyntaxForm Type
   | EInt Integer Text
   | EIntHash Integer Text
   | EIntBase Integer Text

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -253,6 +253,7 @@ buildTests = do
             testCase "captures known pragmas after ignored unknown pragmas" test_knownPragmaStillParsesAfterIgnoredUnknownPragma,
             testCase "roundtrips source unpackedness through pretty-printing" test_sourceUnpackednessRoundtrip,
             testCase "roundtrips warned export reexports" test_warnedExportReexportRoundtrip,
+            testCase "roundtrips symbolic bundled import members without unboxed tuple tokenization" test_symbolicBundledImportMemberRoundtrip,
             testCase "parses infix class heads" test_infixClassHeadParses,
             testCase "roundtrips else branches with local where clauses" test_ifElseWhereBranchRoundtrip,
             testCase "parses standalone mdo expressions" test_standaloneMdoExprParses,
@@ -379,6 +380,7 @@ buildTests = do
               QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
+              QC.testProperty "generated data family instance record fields use identifier labels" prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels,
               QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
@@ -590,6 +592,13 @@ test_warnedExportReexportRoundtrip =
    in case validateParser "WarnedExportReexport.hs" Haskell2010Edition [] source of
         Nothing -> pure ()
         Just err -> assertFailure ("expected warned exports roundtrip to validate, got: " <> show err)
+
+test_symbolicBundledImportMemberRoundtrip :: Assertion
+test_symbolicBundledImportMemberRoundtrip =
+  let source = T.unlines ["{-# LANGUAGE MagicHash #-}", "module M where", "import A (A(( # )))"]
+   in case validateParser "SymbolicBundledImportMember.hs" Haskell2010Edition [EnableExtension MagicHash] source of
+        Nothing -> pure ()
+        Just err -> assertFailure ("expected symbolic bundled import member to roundtrip, got: " <> show err)
 
 test_infixClassHeadParses :: Assertion
 test_infixClassHeadParses =
@@ -1844,6 +1853,26 @@ prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds =
         | decl@(DeclDataFamilyInst DataFamilyInst {dataFamilyInstKind = Just _}) <- samples
         ]
    in counterexample ("expected at least one generated data family instance with inline result kind; sampled " <> show (length samples)) (not (null matching))
+
+prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels :: Property
+prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels =
+  let samples = sampleGen 6000 genDeclDataFamilyInst
+      matching =
+        [ fieldName
+        | DeclDataFamilyInst DataFamilyInst {dataFamilyInstConstructors} <- samples,
+          ctor <- dataFamilyInstConstructors,
+          RecordCon {} <- [peelDataConAnn ctor],
+          RecordCon _ _ _ fields <- [peelDataConAnn ctor],
+          field <- fields,
+          fieldName <- fieldNames field
+        ]
+   in counterexample
+        ( "expected generated data family instances to include record fields with identifier labels only; sampled "
+            <> show (length samples)
+            <> ", record field labels="
+            <> show (length matching)
+        )
+        (not (null matching) && all ((== NameVarId) . unqualifiedNameType) matching)
 
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications :: Property
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -85,7 +85,7 @@ pattern PList_ :: [Pattern] -> Pattern
 pattern PList_ elems <- (peelPatternAnn -> PList elems)
 
 pattern PCon_ :: Name -> [Pattern] -> Pattern
-pattern PCon_ con args <- (peelPatternAnn -> PCon con args)
+pattern PCon_ con args <- (peelPatternAnn -> PCon con [] args)
 
 pattern PInfix_ :: Pattern -> Name -> Pattern -> Pattern
 pattern PInfix_ lhs op rhs <- (peelPatternAnn -> PInfix lhs op rhs)
@@ -261,6 +261,12 @@ buildTests = do
             testCase "TemplateHaskellQuotes lexes typed splice tokens" test_templateHaskellQuotesLexesTypedSplice,
             testCase "TemplateHaskell type quotes parse infix type splices" test_templateHaskellTypeQuoteParsesInfixSplices,
             testCase "parses and roundtrips infix type family heads" test_infixTypeFamilyHeadRoundtrip,
+            testCase "parses explicit type syntax expressions" test_explicitTypeSyntaxExprParses,
+            testCase "parses explicit type syntax patterns" test_explicitTypeSyntaxPatternParses,
+            testCase "parses lambda type binders" test_lambdaTypeBinderParses,
+            testCase "parses function head type binders" test_functionHeadTypeBinderParses,
+            testCase "parses invisible type declaration binders" test_invisibleTypeDeclBinderParses,
+            testCase "parses constructor patterns with type arguments" test_constructorPatternWithTypeArgParses,
             testCase "parses infix type family equations with application operands" test_infixTypeFamilyEquationWithApplicationOperands,
             QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
@@ -600,7 +606,7 @@ test_infixClassHeadParses =
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
           [ DeclFixity {},
-            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified, TyVarBinder _ "b" Nothing TyVarBSpecified], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
+            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "b" Nothing TyVarBSpecified TyVarBVisible], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
             ] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
@@ -677,7 +683,7 @@ test_infixTypeFamilyHeadRoundtrip =
               TypeFamilyDecl
                 { typeFamilyDeclHeadForm = TypeHeadInfix,
                   typeFamilyDeclHead = h,
-                  typeFamilyDeclParams = [TyVarBinder _ "l" Nothing TyVarBSpecified, TyVarBinder _ "r" Nothing TyVarBSpecified],
+                  typeFamilyDeclParams = [TyVarBinder _ "l" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "r" Nothing TyVarBSpecified TyVarBVisible],
                   typeFamilyDeclEquations = Just [TypeFamilyEq {typeFamilyEqHeadForm = TypeHeadInfix, typeFamilyEqLhs = lhs, typeFamilyEqRhs = rhs}]
                 }
             ]
@@ -726,6 +732,73 @@ test_parserConfigPassesExtensions =
       | EInt_ (-1) _ <- normalizeExpr parsed -> pure ()
     ParseOk other -> assertFailure ("expected negative literal expression, got: " <> show other)
     ParseErr err -> assertFailure ("expected parse success, got parse error: " <> MPE.errorBundlePretty err)
+
+test_explicitTypeSyntaxExprParses :: Assertion
+test_explicitTypeSyntaxExprParses =
+  case parseExpr defaultConfig {parserExtensions = [ExplicitNamespaces, RequiredTypeArguments]} "type Int" of
+    ParseOk parsed
+      | ETypeSyntax TypeSyntaxExplicitNamespace ty <- normalizeExpr parsed,
+        TCon "Int" Unpromoted <- stripTypeAnnotations ty ->
+          pure ()
+    other -> assertFailure ("expected explicit type syntax expression, got: " <> show other)
+
+test_explicitTypeSyntaxPatternParses :: Assertion
+test_explicitTypeSyntaxPatternParses =
+  case parsePattern defaultConfig {parserExtensions = [ExplicitNamespaces, RequiredTypeArguments]} "type a" of
+    ParseOk parsed
+      | PTypeSyntax TypeSyntaxExplicitNamespace ty <- peelPatternAnn parsed,
+        TVar "a" <- stripTypeAnnotations ty ->
+          pure ()
+    other -> assertFailure ("expected explicit type syntax pattern, got: " <> show other)
+
+test_lambdaTypeBinderParses :: Assertion
+test_lambdaTypeBinderParses =
+  case parseExpr defaultConfig {parserExtensions = [TypeAbstractions]} "\\ @a x -> x" of
+    ParseOk parsed
+      | ELambdaPats [PTypeBinder binder, PVar_ "x"] (EVar_ "x") <- normalizeExpr parsed,
+        tyVarBinderName binder == "a",
+        tyVarBinderVisibility binder == TyVarBInvisible ->
+          pure ()
+    other -> assertFailure ("expected lambda type binder, got: " <> show other)
+
+test_functionHeadTypeBinderParses :: Assertion
+test_functionHeadTypeBinderParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "f @a x = x" of
+    ParseOk parsed ->
+      case normalizeDecl parsed of
+        DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PTypeBinder binder, PVar_ "x"], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+          | tyVarBinderName binder == "a",
+            tyVarBinderVisibility binder == TyVarBInvisible ->
+              pure ()
+        other -> assertFailure ("expected function head type binder, got normalized decl: " <> show other)
+    other -> assertFailure ("expected function head type binder, got: " <> show other)
+
+test_invisibleTypeDeclBinderParses :: Assertion
+test_invisibleTypeDeclBinderParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "type T @k a = a" of
+    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "T", typeSynParams = [kBinder, aBinder], typeSynBody = body})
+      | tyVarBinderName kBinder == "k",
+        tyVarBinderVisibility kBinder == TyVarBInvisible,
+        tyVarBinderName aBinder == "a",
+        tyVarBinderVisibility aBinder == TyVarBVisible,
+        TVar "a" <- stripTypeAnnotations body ->
+          pure ()
+    other -> assertFailure ("expected invisible type declaration binder, got: " <> show other)
+
+test_constructorPatternWithTypeArgParses :: Assertion
+test_constructorPatternWithTypeArgParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeApplications, TypeAbstractions]} "f (Just @Int x) = x" of
+    ParseOk parsed ->
+      case normalizeDecl parsed of
+        DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [outerPat], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+          | PCon con typeArgs args <- peelPatternAnn outerPat,
+            nameText con == "Just",
+            [typeArg] <- typeArgs,
+            TCon "Int" Unpromoted <- stripTypeAnnotations typeArg,
+            [PVar_ "x"] <- args ->
+              pure ()
+        other -> assertFailure ("expected constructor pattern with type arg, got: " <> show other)
+    other -> assertFailure ("expected parse success, got: " <> show other)
 
 test_parserConfigSetsSourceName :: Assertion
 test_parserConfigSetsSourceName =
@@ -1638,7 +1711,7 @@ test_prettyPrefixFunctionHeadRecordPattern = do
 
 test_prettyInfixFunctionHeadConstructorPatterns :: Assertion
 test_prettyInfixFunctionHeadConstructorPatterns = do
-  let box name = pat0 (PCon (qualifyName Nothing (mkUnqualifiedName NameConId "Box")) [pat0 (PVar name)])
+  let box name = pat0 (PCon (qualifyName Nothing (mkUnqualifiedName NameConId "Box")) [] [pat0 (PVar name)])
       decl =
         DeclValue
           ( FunctionBind

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/basic.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/basic.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail required type argument in expression -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RequiredTypeArguments #-}
 module Basic where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/RequiredTypeArguments/pattern.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail required type argument in pattern -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RequiredTypeArguments #-}
 module Pattern where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type synonym declarations with visible type abstractions are rejected" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeAbstractions #-}

--- a/components/aihc-parser/test/Test/Oracle/Suite.hs
+++ b/components/aihc-parser/test/Test/Oracle/Suite.hs
@@ -5,7 +5,7 @@ module Test.Oracle.Suite
   )
 where
 
-import Aihc.Parser.Syntax (Extension (RequiredTypeArguments), ExtensionSetting (EnableExtension))
+import Aihc.Parser.Syntax (Extension (TemplateHaskell), ExtensionSetting (EnableExtension))
 import Control.Monad (when)
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
@@ -138,10 +138,10 @@ frameworkTests =
                     casePath = "framework-xfail-details.hs",
                     caseExpected = ExpectXFail,
                     caseReason = "regression coverage",
-                    caseExtensions = [EnableExtension RequiredTypeArguments]
+                    caseExtensions = [EnableExtension TemplateHaskell]
                   }
            in do
-                let (_, outcome, details) = evaluateCaseText meta "module Basic where\n\nx = f (type Int) 5\n"
+                let (_, outcome, details) = evaluateCaseText meta "module Basic where\n\nf = ''(,)\n"
                 case outcome of
                   OutcomeXFail
                     | null details -> assertFailure "expected xfail details to be non-empty"

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -151,7 +151,7 @@ genPatternWithoutLeadingNegArg n =
 startsWithConstructorNegativeLiteral :: Pattern -> Bool
 startsWithConstructorNegativeLiteral pat =
   case pat of
-    PCon _ (PNegLit {} : _) -> True
+    PCon _ _ (PNegLit {} : _) -> True
     PParen inner -> startsWithConstructorNegativeLiteral inner
     _ -> False
 
@@ -213,8 +213,8 @@ genDeclTypeSynInfix = do
   name <- oneof [genConSym, genConIdent]
   lhsName <- genIdent
   rhsName <- genIdent
-  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified TyVarBVisible
   body <- genSimpleType
   pure $
     DeclTypeSyn
@@ -260,9 +260,9 @@ genDeclDataInfix = do
   rhsName <- genIdent
   extraCount <- chooseInt (0, 2)
   extraNames <- vectorOf extraCount genIdent
-  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
-      extraParams = [TyVarBinder [] n Nothing TyVarBSpecified | n <- extraNames]
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified TyVarBVisible
+      extraParams = [TyVarBinder [] n Nothing TyVarBSpecified TyVarBVisible | n <- extraNames]
   ctors <- genSimpleDataCons
   deriving' <- genDerivingClauses
   pure $
@@ -651,8 +651,8 @@ genDeclClassInfix = do
   lhsName <- genIdent
   rhsName <- genIdent
   ctx <- genOptionalSimpleContext
-  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified TyVarBVisible
       params = [lhs, rhs]
   items <- genClassDeclItems params
   pure $
@@ -840,8 +840,8 @@ genDeclTypeFamilyDeclInfix = do
   name <- nameText
   lhsName <- genIdent
   rhsName <- genIdent
-  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified
-      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified
+  let lhs = TyVarBinder [] lhsName Nothing TyVarBSpecified TyVarBVisible
+      rhs = TyVarBinder [] rhsName Nothing TyVarBSpecified TyVarBVisible
       lhsType = TVar (mkUnqualifiedName NameVarId lhsName)
       rhsType = TVar (mkUnqualifiedName NameVarId rhsName)
       headType = TApp (TApp (TCon (qualifyName Nothing (mkUnqualifiedName nameType name)) Unpromoted) lhsType) rhsType
@@ -1017,7 +1017,7 @@ genDeclPatSyn = do
   argName <- genIdent
   conName <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConIdent
   let args = PatSynPrefixArgs [argName]
-      pat = PCon conName [PVar (mkUnqualifiedName NameVarId argName)]
+      pat = PCon conName [] [PVar (mkUnqualifiedName NameVarId argName)]
   dir <- elements [PatSynBidirectional, PatSynUnidirectional]
   pure $ DeclPatSyn (PatSynDecl synName args pat dir)
 
@@ -1036,7 +1036,7 @@ genDeclStandaloneKindSig = do
 genSimpleTyVarBinders :: Gen [TyVarBinder]
 genSimpleTyVarBinders = do
   n <- chooseInt (0, 2)
-  vectorOf n (TyVarBinder [] <$> genIdent <*> pure Nothing <*> pure TyVarBSpecified)
+  vectorOf n (TyVarBinder [] <$> genIdent <*> pure Nothing <*> pure TyVarBSpecified <*> pure TyVarBVisible)
 
 -- | Generate a simple type for use in declaration contexts.
 genSimpleType :: Gen Type
@@ -1275,7 +1275,7 @@ shrinkDataConDecl con =
       [GadtCon forall' ctx names' body | names' <- shrinkList (const []) names, not (null names')]
         <> [GadtCon forall' ctx names body' | body' <- shrinkGadtBody body]
         <> [GadtCon forall' ctx' names body | ctx' <- shrinkList shrinkType ctx]
-        <> [GadtCon forall'' ctx names body | forall'' <- shrinkTyVarBinders forall']
+        <> [GadtCon forall'' ctx names body | forall'' <- shrinkForallTelescopes forall']
 
 shrinkGadtBody :: GadtBody -> [GadtBody]
 shrinkGadtBody body =
@@ -1419,6 +1419,14 @@ shrinkTyVarBinders = shrinkList shrinkTyVarBinder
   where
     shrinkTyVarBinder tvb =
       [tvb {tyVarBinderName = n'} | n' <- shrinkIdent (tyVarBinderName tvb)]
+
+shrinkForallTelescopes :: [ForallTelescope] -> [[ForallTelescope]]
+shrinkForallTelescopes = shrinkList shrinkForallTelescope
+  where
+    shrinkForallTelescope telescope =
+      [ telescope {forallTelescopeBinders = binders'}
+      | binders' <- shrinkTyVarBinders (forallTelescopeBinders telescope)
+      ]
 
 shrinkTypeHeadParams :: TypeHeadForm -> [TyVarBinder] -> [[TyVarBinder]]
 shrinkTypeHeadParams headForm params =

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -19,6 +19,7 @@ import Test.Properties.Arb.Expr (genExpr, isValidGeneratedOperator, shrinkExpr)
 import Test.Properties.Arb.Identifiers
   ( genConIdent,
     genConSym,
+    genFieldName,
     genIdent,
     genVarSym,
     shrinkConIdent,
@@ -386,8 +387,12 @@ genRecordCon = do
 genFieldDecl :: Gen FieldDecl
 genFieldDecl = do
   fieldCount <- chooseInt (1, 3)
-  fieldNames <- vectorOf fieldCount genVarBinderName
+  fieldNames <- vectorOf fieldCount genRecordFieldName
   FieldDecl [] fieldNames <$> genSimpleBangType
+
+genRecordFieldName :: Gen UnqualifiedName
+genRecordFieldName =
+  mkUnqualifiedName NameVarId <$> genFieldName
 
 genGadtDataCons :: Gen [DataConDecl]
 genGadtDataCons = do
@@ -563,7 +568,7 @@ genNewtypePrefixCon = do
 genNewtypeRecordCon :: Gen DataConDecl
 genNewtypeRecordCon = do
   conName <- mkUnqualifiedName NameConId <$> genConIdent
-  fieldName <- genVarBinderName
+  fieldName <- genRecordFieldName
   ty <- genSimpleType
   pure (RecordCon [] [] conName [FieldDecl [] [fieldName] (BangType [] NoSourceUnpackedness False False ty)])
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -693,6 +693,7 @@ shrinkExpr :: Expr -> [Expr]
 shrinkExpr expr =
   case expr of
     EVar name -> [EVar (name {nameText = shrunk}) | shrunk <- shrinkIdent (nameText name)]
+    ETypeSyntax form ty -> [ETypeSyntax form ty' | ty' <- shrinkType ty]
     EInt value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]
     EIntHash value _ -> [EIntHash shrunk (T.pack (show shrunk) <> "#") | shrunk <- shrinkIntegral value]
     EIntBase value _ -> [mkIntExpr shrunk | shrunk <- shrinkIntegral value]

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -305,7 +305,7 @@ isValidIdentTailChar :: Char -> Bool
 isValidIdentTailChar c = c == '\'' || isValidGeneratedIdentStartChar c || isValidConIdentStartChar c || isValidIdentNumberChar c
 
 isValidSymbolChar :: Char -> Bool
-isValidSymbolChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isValidUnicodeSymbolChar c
+isValidSymbolChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isValidUnicodeSymbolChar c && c /= '`'
 
 isValidUnicodeSymbolChar :: Char -> Bool
 isValidUnicodeSymbolChar c =

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -28,6 +28,7 @@ import Test.Properties.Arb.Identifiers
     shrinkFloat,
     shrinkIdent,
   )
+import Test.Properties.Arb.Type (shrinkType)
 import Test.QuickCheck
 
 instance Arbitrary Pattern where
@@ -56,7 +57,7 @@ genPatternWith allowAll depth =
         PTuple Boxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
         PTuple Unboxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x")], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
         pure (PList []),
-        (`PCon` []) <$> genPatternConAstName,
+        (\name -> PCon name [] []) <$> genPatternConAstName,
         genUnboxedSumPatternWith allowAll 0
       ]
     recursiveGenerators =
@@ -81,7 +82,7 @@ genPatternConWith allowView depth = do
   con <- genPatternConAstName
   argCount <- chooseInt (0, 3)
   args <- vectorOf argCount (canonicalPatternAtom <$> genPatternWith allowView (depth - 1))
-  pure (PCon con args)
+  pure (PCon con [] args)
 
 genPatternTypeSigWith :: Bool -> Int -> Gen Pattern
 genPatternTypeSigWith allowAll depth = do
@@ -210,7 +211,7 @@ isPatternAtom pat =
     PView {} -> True
     PAs {} -> True
     PUnboxedSum {} -> True
-    PCon _ [] -> True
+    PCon _ [] [] -> True
     _ -> False
 
 mkIntLiteral :: Integer -> Literal
@@ -234,6 +235,8 @@ shrinkPattern pat =
     PAnn _ sub -> shrinkPattern sub
     PVar name ->
       [PVar (name {unqualifiedNameText = shrunk}) | shrunk <- shrinkIdent (unqualifiedNameText name)]
+    PTypeBinder binder -> [PTypeBinder binder' | binder' <- shrinkTyVarBinder binder]
+    PTypeSyntax form ty -> [PTypeSyntax form ty' | ty' <- shrinkType ty]
     PWildcard -> []
     PLit lit ->
       [PLit shrunk | shrunk <- shrinkLiteral lit]
@@ -244,9 +247,9 @@ shrinkPattern pat =
       shrinkPatternTupleElems tupleFlavor elems
     PList elems ->
       [PList elems' | elems' <- shrinkList shrinkPattern elems]
-    PCon con args ->
-      [PCon con [] | not (null args)]
-        <> [PCon con args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
+    PCon con typeArgs args ->
+      [PCon con typeArgs [] | not (null args)]
+        <> [PCon con typeArgs args' | args' <- shrinkList (map canonicalPatternAtom . shrinkPattern) args]
     PInfix lhs op rhs ->
       [canonicalPatternAtom lhs, canonicalPatternAtom rhs]
         <> [PInfix (canonicalPatternAtom lhs') op (canonicalPatternAtom rhs) | lhs' <- shrinkPattern lhs]
@@ -280,6 +283,10 @@ shrinkPattern pat =
         <> [PTypeSig inner' ty | inner' <- shrinkPattern inner]
     PSplice {} ->
       []
+
+shrinkTyVarBinder :: TyVarBinder -> [TyVarBinder]
+shrinkTyVarBinder tvb =
+  [tvb {tyVarBinderName = name'} | name' <- shrinkIdent (tyVarBinderName tvb)]
 
 shrinkPatternTupleElems :: TupleFlavor -> [Pattern] -> [Pattern]
 shrinkPatternTupleElems tupleFlavor elems =

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -58,7 +58,7 @@ genType depth
           (1, pure TStar),
           (1, pure TWildcard),
           (2, TQuasiQuote <$> genQuoterName <*> genQuasiBody),
-          (2, TForall <$> genTypeBinders <*> genForallInner (depth - 1)),
+          (2, TForall <$> genForallTelescope <*> genForallInner (depth - 1)),
           (4, genTypeApp depth),
           (4, genTypeFun depth),
           (3, TTuple Boxed Unpromoted <$> genTypeTupleElems (depth - 1)),
@@ -214,22 +214,26 @@ genTypeBinders = do
   n <- chooseInt (1, 3)
   vectorOf n genTyVarBinder
 
+genForallTelescope :: Gen ForallTelescope
+genForallTelescope =
+  ForallTelescope <$> elements [ForallInvisible, ForallVisible] <*> genTypeBinders
+
 genTyVarBinder :: Gen TyVarBinder
 genTyVarBinder = do
   name <- genTypeVarName
   oneof
     [ -- Plain specified binder: a
-      pure (TyVarBinder [] (renderUnqualifiedName name) Nothing TyVarBSpecified),
+      pure (TyVarBinder [] (renderUnqualifiedName name) Nothing TyVarBSpecified TyVarBVisible),
       -- Plain inferred binder: {a}
-      pure (TyVarBinder [] (renderUnqualifiedName name) Nothing TyVarBInferred),
+      pure (TyVarBinder [] (renderUnqualifiedName name) Nothing TyVarBInferred TyVarBVisible),
       -- Kinded inferred binder: {a :: Kind}
       do
         kind <- genSimpleTypeAtom 0
-        pure (TyVarBinder [] (renderUnqualifiedName name) (Just kind) TyVarBInferred),
+        pure (TyVarBinder [] (renderUnqualifiedName name) (Just kind) TyVarBInferred TyVarBVisible),
       -- Kinded specified binder: (a :: Kind)
       do
         kind <- genSimpleTypeAtom 0
-        pure (TyVarBinder [] (renderUnqualifiedName name) (Just kind) TyVarBSpecified)
+        pure (TyVarBinder [] (renderUnqualifiedName name) (Just kind) TyVarBSpecified TyVarBVisible)
     ]
 
 genTypeVarName :: Gen UnqualifiedName
@@ -297,10 +301,10 @@ shrinkType ty =
     TQuasiQuote quoter body ->
       [TQuasiQuote q body | q <- shrinkIdent quoter]
         <> [TQuasiQuote quoter b | b <- map T.pack (shrink (T.unpack body))]
-    TForall binders inner ->
+    TForall telescope inner ->
       [inner]
-        <> [TForall binders' inner | binders' <- shrinkTypeBinders binders]
-        <> [TForall binders inner' | inner' <- shrinkType inner]
+        <> [TForall telescope' inner | telescope' <- shrinkForallTelescope telescope]
+        <> [TForall telescope inner' | inner' <- shrinkType inner]
     TApp fn arg ->
       [fn, arg]
         <> [TApp fn' arg | fn' <- shrinkType fn]
@@ -342,6 +346,15 @@ shrinkTypeBinders binders =
 shrinkTyVarBinder :: TyVarBinder -> [TyVarBinder]
 shrinkTyVarBinder tvb =
   [tvb {tyVarBinderName = name'} | name' <- shrinkIdent (tyVarBinderName tvb)]
+
+shrinkForallTelescope :: ForallTelescope -> [ForallTelescope]
+shrinkForallTelescope telescope =
+  [ telescope {forallTelescopeBinders = binders'}
+  | binders' <- shrinkTypeBinders (forallTelescopeBinders telescope)
+  ]
+    <> [ telescope {forallTelescopeVisibility = ForallInvisible}
+       | forallTelescopeVisibility telescope == ForallVisible
+       ]
 
 shrinkTypeTupleElems :: TupleFlavor -> [Type] -> [Type]
 shrinkTypeTupleElems tupleFlavor elems =

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -20,7 +20,7 @@ import Text.Megaparsec.Error qualified as MPE
 declConfig :: ParserConfig
 declConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension PatternSynonyms, EnableExtension UnicodeSyntax, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension PatternSynonyms, EnableExtension UnicodeSyntax, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments]
     }
 
 prop_declPrettyRoundTrip :: Decl -> Property

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -33,6 +33,7 @@ normalizeExpr expr =
     EString value repr -> EString value repr
     EStringHash value repr -> EStringHash value repr
     EOverloadedLabel value repr -> EOverloadedLabel value repr
+    ETypeSyntax form ty -> ETypeSyntax form (normalizeType ty)
     EQuasiQuote quoter body -> EQuasiQuote quoter body
     EApp fn arg -> EApp (normalizeExpr fn) (normalizeExpr arg)
     EInfix lhs op rhs -> EInfix (normalizeExpr lhs) op (normalizeExpr rhs)
@@ -106,12 +107,14 @@ normalizePattern pat =
   case pat of
     PAnn _ sub -> normalizePattern sub
     PVar name -> PVar name
+    PTypeBinder binder -> PTypeBinder (normalizeTyVarBinder binder)
+    PTypeSyntax form ty -> PTypeSyntax form (normalizeType ty)
     PWildcard -> PWildcard
     PLit lit -> PLit (normalizeLiteral lit)
     PQuasiQuote quoter body -> PQuasiQuote quoter body
     PTuple tupleFlavor elems -> PTuple tupleFlavor (map normalizePattern elems)
     PList elems -> PList (map normalizePattern elems)
-    PCon con args -> PCon con (map normalizePattern args)
+    PCon con typeArgs args -> PCon con (map normalizeType typeArgs) (map normalizePattern args)
     PInfix lhs op rhs -> PInfix (normalizePattern lhs) op (normalizePattern rhs)
     PView e inner -> PView (normalizeExpr e) (normalizePattern inner)
     PAs name inner -> PAs name (normalizeUnaryPatInner inner)
@@ -322,7 +325,7 @@ stripTypeAnnotations ty =
     TTypeLit l -> TTypeLit l
     TStar -> TStar
     TQuasiQuote q b -> TQuasiQuote q b
-    TForall bs t -> TForall bs (stripTypeAnnotations t)
+    TForall telescope t -> TForall (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)}) (stripTypeAnnotations t)
     TApp a b -> TApp (stripTypeAnnotations a) (stripTypeAnnotations b)
     TFun a b -> TFun (stripTypeAnnotations a) (stripTypeAnnotations b)
     TTuple fl pr es -> TTuple fl pr (map stripTypeAnnotations es)
@@ -343,7 +346,10 @@ normalizeType ty =
     TTypeLit lit -> TTypeLit lit
     TStar -> TStar
     TQuasiQuote quoter body -> TQuasiQuote quoter body
-    TForall binders inner -> TForall (map normalizeTyVarBinder binders) (normalizeType inner)
+    TForall telescope inner ->
+      TForall
+        (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)})
+        (normalizeType inner)
     TApp fn arg -> TApp (normalizeType fn) (normalizeType arg)
     TFun lhs rhs -> TFun (normalizeType lhs) (normalizeType rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
@@ -361,6 +367,12 @@ normalizeTyVarBinder tvb =
   tvb
     { tyVarBinderAnns = [],
       tyVarBinderKind = fmap normalizeType (tyVarBinderKind tvb)
+    }
+
+normalizeForallTelescope :: ForallTelescope -> ForallTelescope
+normalizeForallTelescope telescope =
+  telescope
+    { forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)
     }
 
 normalizeWarningText :: WarningText -> WarningText
@@ -433,7 +445,7 @@ normalizeDataConInner (InfixCon forallVars constraints lhs op rhs) =
 normalizeDataConInner (RecordCon forallVars constraints name fields) =
   RecordCon forallVars (map normalizeType constraints) name (map normalizeFieldDecl fields)
 normalizeDataConInner (GadtCon forallBinders constraints names body) =
-  GadtCon (map normalizeTyVarBinder forallBinders) (map normalizeType constraints) names (normalizeGadtBody body)
+  GadtCon (map normalizeForallTelescope forallBinders) (map normalizeType constraints) names (normalizeGadtBody body)
 
 normalizeBangType :: BangType -> BangType
 normalizeBangType bt =

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -23,7 +23,7 @@ import Text.Megaparsec.Error qualified as MPE
 exprConfig :: ParserConfig
 exprConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments]
     }
 
 prop_exprPrettyRoundTrip :: Expr -> Property

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -31,7 +31,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments]
     }
 
 -- Module normalization

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -21,7 +21,7 @@ import Text.Megaparsec.Error qualified as MPE
 patternConfig :: ParserConfig
 patternConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams]
+    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments]
     }
 
 prop_patternPrettyRoundTrip :: Pattern -> Property
@@ -29,7 +29,7 @@ prop_patternPrettyRoundTrip pat =
   let source = renderStrict (layoutPretty defaultLayoutOptions (pretty pat))
       expected = normalizePattern (addPatternParens pat)
    in checkCoverage $
-        assertCtorCoverage ["PAnn"] pat $
+        assertCtorCoverage ["PAnn", "PTypeBinder", "PTypeSyntax"] pat $
           counterexample (T.unpack source) $
             case parsePattern patternConfig source of
               ParseErr err ->
@@ -43,12 +43,14 @@ normalizePattern pat =
   case pat of
     PAnn _ sub -> normalizePattern sub
     PVar name -> PVar name
+    PTypeBinder binder -> PTypeBinder (normalizeTyVarBinderSpan binder)
+    PTypeSyntax form ty -> PTypeSyntax form (normalizeTypeSpan ty)
     PWildcard -> PWildcard
     PLit lit -> PLit (normalizeLiteral lit)
     PQuasiQuote quoter body -> PQuasiQuote quoter body
     PTuple tupleFlavor elems -> PTuple tupleFlavor (map normalizePattern elems)
     PList elems -> PList (map normalizePattern elems)
-    PCon con args -> PCon con (map normalizePattern args)
+    PCon con typeArgs args -> PCon con (map normalizeTypeSpan typeArgs) (map normalizePattern args)
     PInfix lhs op rhs -> PInfix (normalizePattern lhs) op (normalizePattern rhs)
     PView expr inner -> PView (normalizeExpr expr) (normalizePattern inner)
     PAs name inner -> PAs name (normalizeAsInner inner)
@@ -71,7 +73,7 @@ normalizeTypeSpan ty =
     TTypeLit lit -> TTypeLit lit
     TStar -> TStar
     TQuasiQuote quoter body -> TQuasiQuote quoter body
-    TForall binders inner -> TForall (map normalizeTyVarBinderSpan binders) (normalizeTypeSpan inner)
+    TForall telescope inner -> TForall (normalizeForallTelescope telescope) (normalizeTypeSpan inner)
     TApp lhs rhs -> TApp (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
     TFun lhs rhs -> TFun (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeTypeSpan elems)
@@ -128,4 +130,10 @@ normalizeTyVarBinderSpan tvb =
   tvb
     { tyVarBinderAnns = [],
       tyVarBinderKind = fmap normalizeTypeSpan (tyVarBinderKind tvb)
+    }
+
+normalizeForallTelescope :: ForallTelescope -> ForallTelescope
+normalizeForallTelescope telescope =
+  telescope
+    { forallTelescopeBinders = map normalizeTyVarBinderSpan (forallTelescopeBinders telescope)
     }

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -52,7 +52,10 @@ normalizeType ty =
     TStar -> TStar
     TWildcard -> TWildcard
     TQuasiQuote quoter body -> TQuasiQuote quoter body
-    TForall binders inner -> TForall (map normalizeTyVarBinder binders) (normalizeType inner)
+    TForall telescope inner ->
+      TForall
+        (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)})
+        (normalizeType inner)
     TApp f x -> TApp (normalizeType f) (normalizeType x)
     TFun a b -> TFun (normalizeType a) (normalizeType b)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
@@ -76,7 +79,7 @@ normalizeTyVarBinder tvb =
 containsKindedInferredBinder :: Type -> Bool
 containsKindedInferredBinder ty =
   case ty of
-    TForall binders inner -> any isKindedInferredBinder binders || containsKindedInferredBinder inner
+    TForall telescope inner -> any isKindedInferredBinder (forallTelescopeBinders telescope) || containsKindedInferredBinder inner
     TImplicitParam _name inner -> containsKindedInferredBinder inner
     TApp f x -> containsKindedInferredBinder f || containsKindedInferredBinder x
     TFun a b -> containsKindedInferredBinder a || containsKindedInferredBinder b

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -28,6 +28,7 @@ import Aihc.Parser.Syntax
     Decl (..),
     Expr (..),
     FieldDecl (..),
+    ForallTelescope (..),
     GadtBody (..),
     GuardQualifier (..),
     GuardedRhs (..),
@@ -335,6 +336,9 @@ resolveExprAt scope nextLocal lastSeen expr =
       let here = peelExprSpan lastSeen expr
           (nextLocal', inner') = resolveExprAt scope nextLocal here inner
        in (nextLocal', ETypeSig inner' (resolveTypeAt scope here ty))
+    ETypeSyntax form ty ->
+      let here = peelExprSpan lastSeen expr
+       in (nextLocal, ETypeSyntax form (resolveTypeAt scope here ty))
     EParen inner ->
       let here = peelExprSpan lastSeen expr
           (nextLocal', inner') = resolveExprAt scope nextLocal here inner
@@ -342,7 +346,7 @@ resolveExprAt scope nextLocal lastSeen expr =
     ETypeApp fun ty ->
       let here = peelExprSpan lastSeen expr
           (nextLocal', fun') = resolveExprAt scope nextLocal here fun
-       in (nextLocal', ETypeApp fun' ty)
+       in (nextLocal', ETypeApp fun' (resolveTypeAt scope here ty))
     EApp fun arg ->
       let here = peelExprSpan lastSeen expr
           (nextLocal', fun') = resolveExprAt scope nextLocal here fun
@@ -409,6 +413,16 @@ bindPattern typeScope lastSeen nextLocal pat =
           resolvedName = ResolvedLocal nextLocal name
           annotation = ResolutionAnnotation sp (renderUnqualifiedName name) ResolutionNamespaceTerm resolvedName
        in (nextLocal + 1, Scope (Map.singleton (renderUnqualifiedName name) resolvedName) Map.empty Map.empty, annotatePattern annotation (PVar name))
+    PTypeBinder binder ->
+      let scoped = unionScope emptyScope typeScope
+          binderName = mkUnqualifiedName NameVarId (tyVarBinderName binder)
+          resolvedName = ResolvedLocal nextLocal binderName
+          binder' = binder {tyVarBinderKind = fmap (resolveTypeAt scoped NoSourceSpan) (tyVarBinderKind binder)}
+          binderScope = Scope Map.empty (Map.singleton (tyVarBinderName binder) resolvedName) Map.empty
+       in (nextLocal + 1, binderScope, PTypeBinder binder')
+    PTypeSyntax form ty ->
+      let here = peelPatternSpan lastSeen pat
+       in (nextLocal, emptyScope, PTypeSyntax form (resolveTypeAt typeScope here ty))
     PTuple flavor pats ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, pats') = bindPatterns typeScope here nextLocal pats
@@ -417,10 +431,10 @@ bindPattern typeScope lastSeen nextLocal pat =
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, pats') = bindPatterns typeScope here nextLocal pats
        in (nextLocal', scope, PList pats')
-    PCon name pats ->
+    PCon name typeArgs pats ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, pats') = bindPatterns typeScope here nextLocal pats
-       in (nextLocal', scope, PCon name pats')
+       in (nextLocal', scope, PCon name (map (resolveTypeAt typeScope here) typeArgs) pats')
     PInfix left name right ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', leftScope, left') = bindPattern typeScope here nextLocal left
@@ -522,11 +536,11 @@ resolveTypeAt scope lastSeen ty =
     TImplicitParam name inner ->
       let here = lastSeen
        in TImplicitParam name (resolveTypeAt scope here inner)
-    TForall binders inner ->
+    TForall telescope inner ->
       let here = lastSeen
-          (binderScope, binders') = bindTyVarBinders scope binders
+          (binderScope, binders') = bindTyVarBinders scope (forallTelescopeBinders telescope)
           scoped = unionScope binderScope scope
-       in TForall binders' (resolveTypeAt scoped here inner)
+       in TForall (telescope {forallTelescopeBinders = binders'}) (resolveTypeAt scoped here inner)
     TApp left right ->
       let here = lastSeen
        in TApp (resolveTypeAt scope here left) (resolveTypeAt scope here right)
@@ -574,10 +588,10 @@ resolveTypeSignatureAt scope nextLocal ambient ty =
     -- Type signatures may carry span-only 'TAnn' wrappers (see 'typeAnnSpan'); peel
     -- them so we still allocate scoped type variables and advance 'nextLocal'.
     TAnn ann sub -> resolveTypeSignatureAt scope nextLocal (pushSpanFromAnn ambient ann) sub
-    TForall binders inner ->
-      let (nextLocal', binderScope, binders') = bindTyVarBindersWithIds scope nextLocal binders
+    TForall telescope inner ->
+      let (nextLocal', binderScope, binders') = bindTyVarBindersWithIds scope nextLocal (forallTelescopeBinders telescope)
           scoped = unionScope binderScope scope
-       in (nextLocal', binderScope, TForall binders' (resolveTypeAt scoped ambient inner))
+       in (nextLocal', binderScope, TForall (telescope {forallTelescopeBinders = binders'}) (resolveTypeAt scoped ambient inner))
     _ -> (nextLocal, emptyScope, resolveTypeAt scope ambient ty)
 
 bindTyVarBinders :: Scope -> [TyVarBinder] -> (Scope, [TyVarBinder])

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -260,7 +260,7 @@ unifyMatchRhs expectedTy match = do
 -- extra constraints are needed.
 inferPatCts :: Pattern -> TcType -> TcM [Ct]
 inferPatCts pat scrutTy = case pat of
-  PCon name _subPats -> do
+  PCon name _typeArgs _subPats -> do
     let conName = patNameToText name
     mBinder <- lookupTerm conName
     case mBinder of
@@ -304,7 +304,7 @@ extractPatternBindings (pat, ty) = case pat of
   PAs name inner -> (name, ty) : extractPatternBindings (inner, ty)
   PStrict inner -> extractPatternBindings (inner, ty)
   PIrrefutable inner -> extractPatternBindings (inner, ty)
-  PCon _name subPats ->
+  PCon _name _typeArgs subPats ->
     concatMap (\p -> extractPatternBindings (p, ty)) subPats
   PInfix lhs _name rhs ->
     extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -159,7 +159,7 @@ inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
 -- no extra constraints are needed (the variable just gets the scrutinee type).
 inferPatternConstraints :: SourceSpan -> TcType -> Pattern -> TcM [Ct]
 inferPatternConstraints sp scrutTy pat = case pat of
-  PCon name _subPats -> do
+  PCon name _typeArgs _subPats -> do
     -- Look up the constructor; if found, emit scrutTy ~ constructor result type.
     let conName = nameToText name
     mBinder <- lookupTerm conName
@@ -294,7 +294,7 @@ extractPatternBindings (pat, ty) = case pat of
   -- For constructor patterns like (True), (Just x), etc. the overall
   -- pattern type doesn't directly give us the sub-pattern types. But
   -- we can still extract the variable names for binding purposes.
-  PCon _name subPats ->
+  PCon _name _typeArgs subPats ->
     -- Each sub-pattern gets an unknown type (we'd need constructor info
     -- to assign proper types). For the MVP, they're not needed since
     -- constructor pattern matching in function heads is handled by tcMatches.


### PR DESCRIPTION
## Summary

- Fix QuickCheck generator producing invalid Haskell symbols containing backtick (`` ` ``)
- Per Haskell Language Report, backtick is a `special` character and must be excluded from `symbol`
- Add explicit exclusion in `isValidSymbolChar` to prevent backtick generation

## Test Results

- Previously failing test now passes: `generated module AST pretty-printer round-trip`
- Full test suite passes: `just check` (1549 tests)