### PR TITLE
fix: exclude backtick from symbol generator

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -305,7 +305,7 @@ isValidIdentTailChar :: Char -> Bool
 isValidIdentTailChar c = c == '\'' || isValidGeneratedIdentStartChar c || isValidConIdentStartChar c || isValidIdentNumberChar c
 
 isValidSymbolChar :: Char -> Bool
-isValidSymbolChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isValidUnicodeSymbolChar c
+isValidSymbolChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isValidUnicodeSymbolChar c && c /= '`'
 
 isValidUnicodeSymbolChar :: Char -> Bool
 isValidUnicodeSymbolChar c =


### PR DESCRIPTION
## Summary

- Fix QuickCheck generator producing invalid Haskell symbols containing backtick (`` ` ``)
- Per Haskell Language Report, backtick is a `special` character and must be excluded from `symbol`
- Add explicit exclusion in `isValidSymbolChar` to prevent backtick generation

## Test Results

- Previously failing test now passes: `generated module AST pretty-printer round-trip`
- Full test suite passes: `just check` (1547 tests)