### PR TITLE
test: filter all unicode operators from symbol generators

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -70,14 +70,20 @@ conIdentStartChars = filter isValidConIdentStartChar allChars
 identTailChars :: [Char]
 identTailChars = filter isValidIdentTailChar allChars
 
+-- | Unicode characters that the lexer maps to reserved tokens or normalized
+-- ASCII operator names (see 'unicodeOpTokenKind' in Lex.hs). These must be
+-- excluded from symbol generation to prevent round-trip mismatches.
+unicodeOpChars :: [Char]
+unicodeOpChars = ['∷', '⇒', '→', '←', '∀', '★', '⤙', '⤚', '⤛', '⤜', '⦇', '⦈', '⟦', '⟧', '⊸']
+
 symbolChars :: [Char]
-symbolChars = filter isValidSymbolChar allChars
+symbolChars = filter (\c -> isValidSymbolChar c && c `notElem` unicodeOpChars) allChars
 
 varSymStartChars :: [Char]
 varSymStartChars = filter (/= ':') symbolChars
 
 reservedOperators :: Set.Set Text
-reservedOperators = Set.fromList ["..", ":", "::", "=", "\\", "|", "<-", "->", "@", "~", "=>", "→", "←", "⇒", "∷"]
+reservedOperators = Set.fromList ["..", ":", "::", "=", "\\", "|", "<-", "->", "@", "~", "=>"]
 
 -- | Canonical empty source span for normalization.
 span0 :: SourceSpan


### PR DESCRIPTION
## Summary

- **Filter all Unicode operators from property test generators** — Instead of listing individual Unicode reserved operators in `reservedOperators`, added `unicodeOpChars` (matching `unicodeOpTokenKind` in Lex.hs) that filters these characters out of `symbolChars` at the source. This prevents all 15 Unicode operators (`∷`, `⇒`, `→`, `←`, `∀`, `★`, `⤙`, `⤚`, `⤛`, `⤜`, `⦇`, `⦈`, `⟦`, `⟧`, `⊸`) from being generated in property tests, eliminating round-trip mismatches.

## Why

The lexer maps Unicode reserved operators to the same tokens as their ASCII equivalents (e.g., `→` → `TkReservedRightArrow` → normalized to `"->"`). When property tests generate ASTs containing these Unicode characters, the parser reads them back as ASCII, causing round-trip mismatches.

Previously only `→`, `←`, `⇒`, `∷` were added to `reservedOperators`. This commit takes the comprehensive approach: filter all Unicode operators from `unicodeOpTokenKind` out of `symbolChars`, so they never appear in generated operator names.

## Test Results

- Full test suite passes: `just check` — 1431 tests pass