### PR TITLE
fix(parser): accept kind-annotated type synonym rhs literals

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -40,7 +40,16 @@ thSpliceTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
       EVar <$> identifierNameParser
 
 typeParser :: TokParser Type
-typeParser = label "type" $ forallTypeParser <|> contextOrFunTypeParser
+typeParser = label "type" $ forallTypeParser <|> kindSigTypeParser
+
+kindSigTypeParser :: TokParser Type
+kindSigTypeParser = do
+  ty <- contextOrFunTypeParser
+  mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
+  pure $
+    case mKind of
+      Just kind -> TKindSig ty kind
+      Nothing -> ty
 
 contextOrFunTypeParser :: TokParser Type
 contextOrFunTypeParser = do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -352,7 +352,7 @@ addDeclParens decl =
     DeclFixity {} -> decl
     DeclRoleAnnotation {} -> decl
     DeclTypeSyn synDecl ->
-      DeclTypeSyn (synDecl {typeSynBody = addTypeParens (typeSynBody synDecl)})
+      DeclTypeSyn (synDecl {typeSynBody = addTypeTopLevelParens (typeSynBody synDecl)})
     DeclData dataDecl -> DeclData (addDataDeclParens dataDecl)
     DeclTypeData dataDecl -> DeclTypeData (addDataDeclParens dataDecl)
     DeclNewtype newtypeDecl -> DeclNewtype (addNewtypeDeclParens newtypeDecl)
@@ -848,6 +848,11 @@ addExprGuardedParens = addExprParensIn CtxGuarded
 -- | Add parentheses to a type at all required positions.
 addTypeParens :: Type -> Type
 addTypeParens = addTypeParensShared CtxTypeAtom 0
+
+addTypeTopLevelParens :: Type -> Type
+addTypeTopLevelParens (TAnn ann sub) = TAnn ann (addTypeTopLevelParens sub)
+addTypeTopLevelParens (TKindSig ty kind) = TKindSig (addTypeParensShared CtxTypeAtom 0 ty) (addTypeParensShared CtxTypeAtom 0 kind)
+addTypeTopLevelParens ty = addTypeParens ty
 
 addTypeIn :: TypeCtx -> Type -> Type
 addTypeIn ctx ty =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -248,6 +248,9 @@ buildTests = do
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
             testCase "parses parenthesized kind signature type atoms" test_typeParsesParenthesizedKindSignature,
             testCase "parses parenthesized kind signatures in application heads" test_typeParsesKindSignatureApplicationHead,
+            testCase "parses top-level kind signatures on type literals" test_typeParsesTopLevelKindSignatureOnTypeLiteral,
+            testCase "parses type synonym rhs with top-level kind signatures" test_typeSynonymRhsParsesTopLevelKindSignature,
+            testCase "pretty-prints type synonym rhs kind signatures without extra parens" test_typeSynonymRhsKindSignaturePrettyPrintsWithoutExtraParens,
             testCase "parses empty list type constructor" test_typeParsesEmptyListConstructor,
             testCase "parses promoted empty list type constructor" test_typeParsesPromotedEmptyListConstructor,
             testCase "parses parenthesized empty list in instance heads" test_instanceParsesParenthesizedEmptyListType,
@@ -451,6 +454,34 @@ test_typeParsesKindSignatureApplicationHead =
           stripTypeAnnotations ty ->
           pure ()
     other -> assertFailure ("expected kind-signature application head, got: " <> show other)
+
+test_typeParsesTopLevelKindSignatureOnTypeLiteral :: Assertion
+test_typeParsesTopLevelKindSignatureOnTypeLiteral =
+  case parseType defaultConfig {parserExtensions = [DataKinds, KindSignatures]} "\"UTF8\" :: NameStyle" of
+    ParseOk ty
+      | TKindSig (TTypeLit (TypeLitSymbol "UTF8" "\"UTF8\"")) (TCon "NameStyle" Unpromoted) <- stripTypeAnnotations ty ->
+          pure ()
+    other -> assertFailure ("expected top-level kind signature on type literal, got: " <> show other)
+
+test_typeSynonymRhsParsesTopLevelKindSignature :: Assertion
+test_typeSynonymRhsParsesTopLevelKindSignature =
+  case parseDecl
+    defaultConfig {parserExtensions = [DataKinds, KindSignatures]}
+    "type UTF8 = \"UTF8\" :: NameStyle" of
+    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "UTF8", typeSynBody = body})
+      | TKindSig (TTypeLit (TypeLitSymbol "UTF8" "\"UTF8\"")) (TCon "NameStyle" Unpromoted) <- stripTypeAnnotations body ->
+          pure ()
+    other -> assertFailure ("expected type synonym rhs kind signature, got: " <> show other)
+
+test_typeSynonymRhsKindSignaturePrettyPrintsWithoutExtraParens :: Assertion
+test_typeSynonymRhsKindSignaturePrettyPrintsWithoutExtraParens =
+  case parseDecl
+    defaultConfig {parserExtensions = [DataKinds, KindSignatures]}
+    "type UTF8 = \"UTF8\" :: NameStyle" of
+    ParseOk decl ->
+      let source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+       in assertEqual "pretty-printed declaration" "type UTF8 = \"UTF8\" :: NameStyle" source
+    other -> assertFailure ("expected parse success, got: " <> show other)
 
 test_typeParsesEmptyListConstructor :: Assertion
 test_typeParsesEmptyListConstructor =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/named-text-kind-annotated-type-synonym.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/named-text-kind-annotated-type-synonym.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="kind-annotated type synonym rhs is rejected after the promoted literal" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 


### PR DESCRIPTION
## Summary
- parse top-level kind signatures in the general type grammar so type synonym RHS literals like `\"UTF8\" :: NameStyle` no longer stop at the literal
- preserve bare top-level `TKindSig` when pretty-printing type synonym RHSes so oracle roundtrips match GHC without inserting extra parentheses
- add parser and pretty-print regression tests and convert `Hackage/named-text-kind-annotated-type-synonym` from `xfail` to `pass`

## Root Cause
The parser only accepted kind signatures in selected subcontexts such as parenthesized types and context items. A type synonym RHS was parsed through the general type grammar, which treated `\"UTF8\"` as a complete type atom and rejected the trailing `:: NameStyle`.

Once parsing was fixed, the parenthesization pass still wrapped every `TKindSig` in `TParen`, so pretty-printing changed the declaration to `type UTF8 = (\"UTF8\" :: NameStyle)`. That caused the oracle fingerprint to drift from GHC.

## Solution
I considered three approaches:
- special-case kind-annotated literals in type synonym RHS parsing
- extend the main type grammar to accept a low-precedence top-level kind signature
- special-case oracle fixtures and keep the parser limitation

I chose the grammar fix because it matches the language more accurately and generalizes beyond this single literal case. I paired it with a narrow parenthesization change for top-level type synonym RHSes so the AST still prints conservatively in contexts that require parentheses while matching GHC's unparenthesized form after `=`.

## Testing
- `cabal test -v0 aihc-parser:spec --test-options=--pattern=literals`
- `cabal test -v0 aihc-parser:spec --test-options=--pattern=synonym`
- `just fmt`
- `just check`

## Progress
- Hackage oracle coverage: `named-text-kind-annotated-type-synonym` moved from `XFAIL` to `PASS`

## CodeRabbit
- `coderabbit review --prompt-only` was attempted but skipped because the service was rate-limited

## Follow-up
- No additional follow-up work is required for this fix