### PR TITLE
fix(parser): parse injective type family result signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -231,10 +231,53 @@ instanceForallParser = do
   expectedTok (TkVarSym ".")
   pure binders
 
--- | Parse the optional @:: Kind@ result annotation on a type/data family head.
+-- | Parse an optional unnamed @:: Kind@ result signature for a family head.
 familyResultKindParser :: TokParser (Maybe Type)
 familyResultKindParser =
   MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
+
+-- | Parse an optional type family result signature. GHC admits either an unnamed
+-- @:: Kind@ annotation or a named result variable with injectivity annotation,
+-- such as @= r | r -> a@ or @= (r :: Type) | r -> a where ...@.
+typeFamilyResultSigParser :: TokParser (Maybe TypeFamilyResultSig)
+typeFamilyResultSigParser =
+  MP.optional (kindSigParser <|> injectiveSigParser)
+  where
+    kindSigParser =
+      TypeFamilyKindSig <$> (expectedTok TkReservedDoubleColon *> typeParser)
+
+    injectiveSigParser = do
+      expectedTok TkReservedEquals
+      result <- injectiveResultBinderParser
+      TypeFamilyInjectiveSig result <$> typeFamilyInjectivityParser
+
+    injectiveResultBinderParser =
+      withSpan $
+        ( do
+            ident <- lowerIdentifierParser
+            pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBVisible)
+        )
+          <|> ( do
+                  expectedTok TkSpecialLParen
+                  ident <- lowerIdentifierParser
+                  expectedTok TkReservedDoubleColon
+                  kind <- typeParser
+                  expectedTok TkSpecialRParen
+                  pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBVisible)
+              )
+
+typeFamilyInjectivityParser :: TokParser TypeFamilyInjectivity
+typeFamilyInjectivityParser = withSpan $ do
+  expectedTok TkReservedPipe
+  result <- lowerIdentifierParser
+  expectedTok TkReservedRightArrow
+  determined <- MP.some lowerIdentifierParser
+  pure $ \span' ->
+    TypeFamilyInjectivity
+      { typeFamilyInjectivityAnns = [mkAnnotation span'],
+        typeFamilyInjectivityResult = result,
+        typeFamilyInjectivityDetermined = determined
+      }
 
 -- ---------------------------------------------------------------------------
 -- TypeFamilies: top-level type family declaration
@@ -245,7 +288,7 @@ typeFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   expectedTok TkVarFamily
   (headForm, headType, params) <- typeFamilyHeadParser
-  kind <- familyResultKindParser
+  resultSig <- typeFamilyResultSigParser
   -- A closed type family has a `where` clause with equations.
   equations <- MP.optional (MP.try closedTypeFamilyWhereParser)
   pure $
@@ -254,7 +297,7 @@ typeFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
         { typeFamilyDeclHeadForm = headForm,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = params,
-          typeFamilyDeclKind = kind,
+          typeFamilyDeclResultSig = resultSig,
           typeFamilyDeclEquations = equations
         }
 
@@ -383,14 +426,14 @@ classTypeFamilyDeclParser :: TokParser ClassDeclItem
 classTypeFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   (headForm, headType, params) <- typeFamilyHeadParser
-  kind <- familyResultKindParser
+  resultSig <- typeFamilyResultSigParser
   pure $
     ClassItemTypeFamilyDecl
       TypeFamilyDecl
         { typeFamilyDeclHeadForm = headForm,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = params,
-          typeFamilyDeclKind = kind,
+          typeFamilyDeclResultSig = resultSig,
           typeFamilyDeclEquations = Nothing
         }
 
@@ -643,7 +686,7 @@ ordinaryClassDeclItemParser = do
     TkKeywordDefault -> classDefaultSigItemParser
     TkKeywordType
       | lexTokenKind nextTok == TkKeywordInstance -> classDefaultTypeInstParser
-    TkKeywordType -> MP.try classDefaultTypeInstShorthandParser <|> classTypeFamilyDeclParser
+    TkKeywordType -> MP.try classTypeFamilyDeclParser <|> classDefaultTypeInstShorthandParser
     _ -> do
       isSig <- startsWithTypeSig
       if isSig then classTypeSigItemParser else classDefaultItemParser

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -582,9 +582,15 @@ addTypeFamilyDeclParens :: TypeFamilyDecl -> TypeFamilyDecl
 addTypeFamilyDeclParens tf =
   tf
     { typeFamilyDeclHead = addTypeParens (typeFamilyDeclHead tf),
-      typeFamilyDeclKind = fmap addTypeParens (typeFamilyDeclKind tf),
+      typeFamilyDeclResultSig = fmap addTypeFamilyResultSigParens (typeFamilyDeclResultSig tf),
       typeFamilyDeclEquations = fmap (map addTypeFamilyEqParens) (typeFamilyDeclEquations tf)
     }
+
+addTypeFamilyResultSigParens :: TypeFamilyResultSig -> TypeFamilyResultSig
+addTypeFamilyResultSigParens sig =
+  case sig of
+    TypeFamilyKindSig kind -> TypeFamilyKindSig (addTypeParens kind)
+    TypeFamilyInjectiveSig result injectivity -> TypeFamilyInjectiveSig (addTyVarBinderParens result) injectivity
 
 addTypeFamilyEqParens :: TypeFamilyEq -> TypeFamilyEq
 addTypeFamilyEqParens eq =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -813,6 +813,14 @@ prettyFunctionalDependency dep =
       hsep (map pretty (functionalDependencyDetermined dep))
     ]
 
+prettyTypeFamilyInjectivity :: TypeFamilyInjectivity -> Doc ann
+prettyTypeFamilyInjectivity injectivity =
+  hsep
+    [ pretty (typeFamilyInjectivityResult injectivity),
+      "->",
+      hsep (map pretty (typeFamilyInjectivityDetermined injectivity))
+    ]
+
 maybeContextPrefix :: Maybe [Type] -> [Doc ann]
 maybeContextPrefix maybeConstraints =
   case maybeConstraints of
@@ -1356,11 +1364,13 @@ prettyTypeFamilyDecl tf =
   hsep $
     ["type", "family"]
       <> prettyTypeFamilyHead (typeFamilyDeclHeadForm tf) (typeFamilyDeclHead tf) (typeFamilyDeclParams tf)
-      <> kindPart (typeFamilyDeclKind tf)
+      <> resultSigPart (typeFamilyDeclResultSig tf)
       <> eqsPart (typeFamilyDeclEquations tf)
   where
-    kindPart Nothing = []
-    kindPart (Just k) = ["::", prettyType k]
+    resultSigPart Nothing = []
+    resultSigPart (Just (TypeFamilyKindSig k)) = ["::", prettyType k]
+    resultSigPart (Just (TypeFamilyInjectiveSig result injectivity)) =
+      ["=", prettyTyVarBinder result, "|", prettyTypeFamilyInjectivity injectivity]
     eqsPart Nothing = []
     eqsPart (Just eqs) = ["where", braces (hsep (punctuate semi (map prettyTypeFamilyEq eqs)))]
 
@@ -1421,10 +1431,12 @@ prettyAssocTypeFamilyDecl tf =
   hsep $
     ["type"]
       <> prettyTypeFamilyHead (typeFamilyDeclHeadForm tf) (typeFamilyDeclHead tf) (typeFamilyDeclParams tf)
-      <> kindPart (typeFamilyDeclKind tf)
+      <> resultSigPart (typeFamilyDeclResultSig tf)
   where
-    kindPart Nothing = []
-    kindPart (Just k) = ["::", prettyType k]
+    resultSigPart Nothing = []
+    resultSigPart (Just (TypeFamilyKindSig k)) = ["::", prettyType k]
+    resultSigPart (Just (TypeFamilyInjectiveSig result injectivity)) =
+      ["=", prettyTyVarBinder result, "|", prettyTypeFamilyInjectivity injectivity]
 
 prettyTypeFamilyHead :: TypeHeadForm -> Type -> [TyVarBinder] -> [Doc ann]
 prettyTypeFamilyHead headForm headType params =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -426,6 +426,22 @@ docFunctionalDependency dep =
       listField "determiners" docText (functionalDependencyDeterminers dep)
         <> listField "determined" docText (functionalDependencyDetermined dep)
 
+docTypeFamilyInjectivity :: TypeFamilyInjectivity -> Doc ann
+docTypeFamilyInjectivity injectivity =
+  "TypeFamilyInjectivity" <+> braces (hsep (punctuate comma fields))
+  where
+    fields =
+      [ field "result" (docText (typeFamilyInjectivityResult injectivity))
+      ]
+        <> listField "determined" docText (typeFamilyInjectivityDetermined injectivity)
+
+docTypeFamilyResultSig :: TypeFamilyResultSig -> Doc ann
+docTypeFamilyResultSig sig =
+  case sig of
+    TypeFamilyKindSig kind -> "TypeFamilyKindSig" <+> parens (docType kind)
+    TypeFamilyInjectiveSig result injectivity ->
+      "TypeFamilyInjectiveSig" <+> braces (hsep (punctuate comma [field "result" (docTyVarBinder result), field "injectivity" (docTypeFamilyInjectivity injectivity)]))
+
 docClassDeclItem :: ClassDeclItem -> Doc ann
 docClassDeclItem item =
   case item of
@@ -994,7 +1010,7 @@ docTypeFamilyDecl tf =
     fields =
       [field "headForm" (docTypeHeadForm (typeFamilyDeclHeadForm tf)), field "head" (docType (typeFamilyDeclHead tf))]
         <> listField "params" docTyVarBinder (typeFamilyDeclParams tf)
-        <> optionalField "kind" docType (typeFamilyDeclKind tf)
+        <> optionalField "resultSig" docTypeFamilyResultSig (typeFamilyDeclResultSig tf)
         <> case typeFamilyDeclEquations tf of
           Nothing -> []
           Just eqs -> [field "equations" (brackets (hsep (punctuate comma (map docTypeFamilyEq eqs))))]

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -22,6 +22,8 @@ module Aihc.Parser.Syntax
     CmdCaseAlt (..),
     CompStmt (..),
     FunctionalDependency (..),
+    TypeFamilyResultSig (..),
+    TypeFamilyInjectivity (..),
     TypeHeadForm (..),
     DataConDecl (..),
     DataDecl (..),
@@ -1254,10 +1256,23 @@ data TypeFamilyDecl = TypeFamilyDecl
     -- For infix families like @type family l `And` r@, this is the full infix type.
     typeFamilyDeclHead :: Type,
     typeFamilyDeclParams :: [TyVarBinder],
-    -- | Optional result kind annotation (@:: Kind@)
-    typeFamilyDeclKind :: Maybe Type,
+    -- | Optional result signature, either an unnamed kind annotation (@:: Kind@)
+    -- or a named result variable with injectivity annotation (@= r | r -> a@).
+    typeFamilyDeclResultSig :: Maybe TypeFamilyResultSig,
     -- | @Nothing@ = open family; @Just eqs@ = closed family with equations
     typeFamilyDeclEquations :: Maybe [TypeFamilyEq]
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data TypeFamilyResultSig
+  = TypeFamilyKindSig Type
+  | TypeFamilyInjectiveSig TyVarBinder TypeFamilyInjectivity
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data TypeFamilyInjectivity = TypeFamilyInjectivity
+  { typeFamilyInjectivityAnns :: [Annotation],
+    typeFamilyInjectivityResult :: Text,
+    typeFamilyInjectivityDetermined :: [Text]
   }
   deriving (Data, Eq, Show, Generic, NFData)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/functor-products-associated-injective-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/functor-products-associated-injective-type-family.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="associated type families with injectivity annotations stop at the bar" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/kind-apply-spine-lot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/kind-apply-spine-lot.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type family injectivity annotation with equality constraint is not parsed" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/oops-injective-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/oops-injective-type-family.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="injective type families with result kind signatures stop at the equals sign" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilyDependencies #-}

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -628,7 +628,7 @@ genAssociatedTypeFamilyDecl classParams = do
       { typeFamilyDeclHeadForm = TypeHeadPrefix,
         typeFamilyDeclHead = headType,
         typeFamilyDeclParams = params,
-        typeFamilyDeclKind = Nothing,
+        typeFamilyDeclResultSig = Nothing,
         typeFamilyDeclEquations = Nothing
       }
 
@@ -832,7 +832,7 @@ genDeclTypeFamilyDecl = do
         { typeFamilyDeclHeadForm = TypeHeadPrefix,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = params,
-          typeFamilyDeclKind = Nothing,
+          typeFamilyDeclResultSig = Nothing,
           typeFamilyDeclEquations = Nothing
         }
 
@@ -856,7 +856,7 @@ genDeclTypeFamilyDeclInfix = do
         { typeFamilyDeclHeadForm = TypeHeadInfix,
           typeFamilyDeclHead = headType,
           typeFamilyDeclParams = [lhs, rhs],
-          typeFamilyDeclKind = Nothing,
+          typeFamilyDeclResultSig = Nothing,
           typeFamilyDeclEquations = Nothing
         }
 

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -563,9 +563,16 @@ normalizeTypeFamilyDecl tf =
     { typeFamilyDeclHeadForm = typeFamilyDeclHeadForm tf,
       typeFamilyDeclHead = normalizeType (typeFamilyDeclHead tf),
       typeFamilyDeclParams = map normalizeTyVarBinder (typeFamilyDeclParams tf),
-      typeFamilyDeclKind = fmap normalizeType (typeFamilyDeclKind tf),
+      typeFamilyDeclResultSig = fmap normalizeTypeFamilyResultSig (typeFamilyDeclResultSig tf),
       typeFamilyDeclEquations = fmap (map normalizeTypeFamilyEq) (typeFamilyDeclEquations tf)
     }
+
+normalizeTypeFamilyResultSig :: TypeFamilyResultSig -> TypeFamilyResultSig
+normalizeTypeFamilyResultSig sig =
+  case sig of
+    TypeFamilyKindSig kind -> TypeFamilyKindSig (normalizeType kind)
+    TypeFamilyInjectiveSig result injectivity ->
+      TypeFamilyInjectiveSig (normalizeTyVarBinder result) injectivity
 
 normalizeTypeFamilyEq :: TypeFamilyEq -> TypeFamilyEq
 normalizeTypeFamilyEq eq =


### PR DESCRIPTION
## Summary
- parse injective type family result signatures as first-class AST nodes so top-level and associated families can accept `= r | r -> ...` and `= (r :: Kind) | r -> ...`
- fix class-body `type` item dispatch so associated injective family declarations are not misparsed as shorthand default instances
- convert three Hackage oracle fixtures from xfail to pass, changing parser progress by +3 pass and -3 xfail

## Root Cause
The parser modeled type family declarations as `type family ... [:: Kind] [where ...]`, but GHC also allows a distinct result-signature grammar after `=` for injective type families. The AST had no way to represent that result binder or its injectivity dependency list, so declarations either stopped at `=` or were routed down the wrong class-body parser path.

## Chosen Solution
I added explicit `TypeFamilyResultSig` and `TypeFamilyInjectivity` syntax nodes and updated the declaration grammar, pretty-printer, shorthand renderer, paren normalization, and test helpers to use them. This keeps the grammar faithful to GHC instead of special-casing the failing fixtures or overloading the existing unnamed `:: Kind` slot.

## Testing
- `cabal test -v0 aihc-parser:test:spec --test-options='--pattern \"$0 ~ /oops-injective-type-family/\"'`
- `cabal test -v0 aihc-parser:test:spec --test-options='--pattern \"$0 ~ /functor-products-associated-injective-type-family/\"'`
- `cabal test -v0 aihc-parser:test:spec --test-options='--pattern \"$0 ~ /kind-apply-spine-lot/\"'`
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` was attempted but CodeRabbit was rate-limited at PR time

## Follow-up
- none identified within scope of this fix