### PR TITLE
fix(parser): preserve bundled export wildcard positions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
@@ -73,7 +73,7 @@ exportNameParser mWarning = do
     case members of
       Just MembersAll -> ExportAll mWarning namespace name
       Just (MembersList names) -> ExportWith mWarning namespace name names
-      Just (MembersListAll names) -> ExportWithAll mWarning namespace name names
+      Just (MembersListAll wildcardIndex names) -> ExportWithAll mWarning namespace name wildcardIndex names
       Nothing
         | namespace == Just IEEntityNamespaceType || isTypeName name ->
             ExportAbs mWarning namespace name
@@ -83,19 +83,40 @@ exportNameParser mWarning = do
 data MembersResult
   = MembersAll
   | MembersList [IEBundledMember]
-  | MembersListAll [IEBundledMember]
+  | MembersListAll Int [IEBundledMember]
 
 exportMembersParser :: TokParser MembersResult
 exportMembersParser =
   parens $
-    (expectedTok TkReservedDotDot >> pure MembersAll)
-      <|> parseMemberList
+    parseDotDotFirst <|> parseMemberList
   where
+    parseDotDotFirst = do
+      expectedTok TkReservedDotDot
+      MP.optional (expectedTok TkSpecialComma) >>= \case
+        Nothing -> pure MembersAll
+        Just _ -> do
+          trailingMembers <- memberNameParser `MP.sepBy` expectedTok TkSpecialComma
+          pure (MembersListAll 0 trailingMembers)
+
     parseMemberList = do
-      members <- memberNameParser `MP.sepEndBy` expectedTok TkSpecialComma
-      hasTrailingDotDot <-
-        MP.option False (expectedTok TkReservedDotDot >> MP.optional (expectedTok TkSpecialComma) >> pure True)
-      pure $ if hasTrailingDotDot then MembersListAll members else MembersList members
+      firstMember <- memberNameParser
+      parseMemberSegments [firstMember]
+
+    parseMemberSegments members =
+      MP.optional (expectedTok TkSpecialComma) >>= \case
+        Nothing -> pure (MembersList members)
+        Just _ ->
+          (expectedTok TkReservedDotDot >> parseWildcardTail members)
+            <|> do
+              nextMember <- memberNameParser
+              parseMemberSegments (members <> [nextMember])
+
+    parseWildcardTail members =
+      MP.optional (expectedTok TkSpecialComma) >>= \case
+        Nothing -> pure (MembersListAll (length members) members)
+        Just _ -> do
+          trailingMembers <- memberNameParser `MP.sepBy` expectedTok TkSpecialComma
+          pure (MembersListAll (length members) (members <> trailingMembers))
     memberNameParser = do
       namespace <- MP.optional bundledNamespaceParser
       name <- identifierNameParser <|> parens operatorNameParser
@@ -190,7 +211,7 @@ importItemParser = withSpanAnn (ImportAnn . mkAnnotation) $ do
     case members of
       Just MembersAll -> ImportItemAll effectiveNamespace itemName
       Just (MembersList names) -> ImportItemWith effectiveNamespace itemName names
-      Just (MembersListAll names) -> ImportItemAllWith effectiveNamespace itemName names
+      Just (MembersListAll wildcardIndex names) -> ImportItemAllWith effectiveNamespace itemName wildcardIndex names
       Nothing
         | effectiveNamespace == Just IEEntityNamespaceType || isTypeName (qualifyName Nothing itemName) -> ImportItemAbs effectiveNamespace itemName
         | otherwise -> ImportItemVar effectiveNamespace itemName

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -124,10 +124,10 @@ prettyExportSpec spec =
       prettyExportWarning
         mWarning
         (prettyNamespacePrefix namespace <> prettyName name <> parens (hsep (punctuate comma (map prettyExportMember members))))
-    ExportWithAll mWarning namespace name members ->
+    ExportWithAll mWarning namespace name wildcardIndex members ->
       prettyExportWarning
         mWarning
-        (prettyNamespacePrefix namespace <> prettyName name <> parens (hsep (punctuate comma (map prettyExportMember members <> [".."]))))
+        (prettyNamespacePrefix namespace <> prettyName name <> parens (hsep (punctuate comma (insertWildcard wildcardIndex (map prettyExportMember members)))))
 
 prettyExportWarning :: Maybe WarningText -> Doc ann -> Doc ann
 prettyExportWarning mWarning doc =
@@ -189,8 +189,13 @@ prettyImportItem item =
     ImportItemAll namespace name -> prettyNamespacePrefix namespace <> prettyConstructorUName name <> "(..)"
     ImportItemWith namespace name members ->
       prettyNamespacePrefix namespace <> prettyConstructorUName name <> parens (hsep (punctuate comma (map prettyExportMember members)))
-    ImportItemAllWith namespace name members ->
-      prettyNamespacePrefix namespace <> prettyConstructorUName name <> parens (hsep (punctuate comma (map prettyExportMember members <> [".."])))
+    ImportItemAllWith namespace name wildcardIndex members ->
+      prettyNamespacePrefix namespace <> prettyConstructorUName name <> parens (hsep (punctuate comma (insertWildcard wildcardIndex (map prettyExportMember members))))
+
+insertWildcard :: Int -> [Doc ann] -> [Doc ann]
+insertWildcard wildcardIndex members =
+  let (before, after) = splitAt wildcardIndex members
+   in before <> [".."] <> after
 
 prettyExportMember :: IEBundledMember -> Doc ann
 prettyExportMember (IEBundledMember namespace name) =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -126,13 +126,13 @@ docExportSpec spec =
           optionalField "warningText" docWarningText mWarning
             <> optionalField "namespace" docIENamespace mNamespace
             <> [field "name" (docName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
-    ExportWithAll mWarning mNamespace name members ->
+    ExportWithAll mWarning mNamespace name wildcardIndex members ->
       "ExportWithAll" <> braces (hsep (punctuate comma fields))
       where
         fields =
           optionalField "warningText" docWarningText mWarning
             <> optionalField "namespace" docIENamespace mNamespace
-            <> [field "name" (docName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
+            <> [field "name" (docName name), field "wildcardIndex" (pretty wildcardIndex), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
 
 docImportDecl :: ImportDecl -> Doc ann
 docImportDecl decl =
@@ -179,12 +179,12 @@ docImportItem item =
         fields =
           optionalField "namespace" docIENamespace mNamespace
             <> [field "name" (docUnqualifiedName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
-    ImportItemAllWith mNamespace name members ->
+    ImportItemAllWith mNamespace name wildcardIndex members ->
       "ImportItemAllWith" <> braces (hsep (punctuate comma fields))
       where
         fields =
           optionalField "namespace" docIENamespace mNamespace
-            <> [field "name" (docUnqualifiedName name), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
+            <> [field "name" (docUnqualifiedName name), field "wildcardIndex" (pretty wildcardIndex), field "members" (brackets (hsep (punctuate comma (map docExportMember members))))]
 
 docIENamespace :: IEEntityNamespace -> Doc ann
 docIENamespace namespace =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -877,7 +877,7 @@ data ExportSpec
   | ExportAbs (Maybe WarningText) (Maybe IEEntityNamespace) Name
   | ExportAll (Maybe WarningText) (Maybe IEEntityNamespace) Name
   | ExportWith (Maybe WarningText) (Maybe IEEntityNamespace) Name [IEBundledMember]
-  | ExportWithAll (Maybe WarningText) (Maybe IEEntityNamespace) Name [IEBundledMember]
+  | ExportWithAll (Maybe WarningText) (Maybe IEEntityNamespace) Name Int [IEBundledMember]
   | ExportAnn Annotation ExportSpec
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -920,7 +920,7 @@ data ImportItem
   | ImportItemAbs (Maybe IEEntityNamespace) UnqualifiedName
   | ImportItemAll (Maybe IEEntityNamespace) UnqualifiedName
   | ImportItemWith (Maybe IEEntityNamespace) UnqualifiedName [IEBundledMember]
-  | ImportItemAllWith (Maybe IEEntityNamespace) UnqualifiedName [IEBundledMember]
+  | ImportItemAllWith (Maybe IEEntityNamespace) UnqualifiedName Int [IEBundledMember]
   | ImportAnn Annotation ImportItem
   deriving (Data, Eq, Show, Generic, NFData)
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -216,6 +216,7 @@ buildTests = do
             testCase "skips mid-stream shebang lines as trivia" test_midStreamShebangIsSkipped,
             testCase "does not misclassify line-start #) as a directive" test_lineStartHashTokenIsNotDirective,
             testCase "lexes overloaded labels as single tokens" test_overloadedLabelLexesAsSingleToken,
+            testCase "preserves bundled export wildcard position" test_bundledExportWildcardPosition,
             testCase "lexes quoted overloaded labels" test_quotedOverloadedLabelLexes,
             testCase "lexes string gaps before a closing quote" test_stringGapBeforeClosingQuoteLexes,
             testCase "parses overloaded label expressions" test_overloadedLabelExprParses,
@@ -1626,6 +1627,35 @@ parseGuardsExt exts src =
             Left ("unexpected AST: " <> show other)
   where
     fullSrc = "{-# LANGUAGE " <> T.intercalate ", " (map (T.pack . show) exts) <> " #-}\n" <> src
+
+test_bundledExportWildcardPosition :: Assertion
+test_bundledExportWildcardPosition = do
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE PatternSynonyms #-}",
+            "{-# LANGUAGE ExplicitNamespaces #-}",
+            "module M (T (.., P, data Q)) where",
+            "data T = A | B",
+            "pattern P :: T",
+            "pattern P = A",
+            "pattern Q :: T",
+            "pattern Q = B"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty modu))
+      (reparseErrs, reparsed) = parseModule defaultConfig rendered
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        assertBool ("expected reparsed pretty output to succeed, got: " <> show reparseErrs) (null reparseErrs)
+        case moduleExports modu of
+          Just [ExportAnn _ (ExportWithAll _ Nothing "T" 0 [IEBundledMember Nothing "P", IEBundledMember (Just IEBundledNamespaceData) "Q"])] ->
+            case moduleExports reparsed of
+              Just [ExportAnn _ (ExportWithAll _ Nothing "T" 0 [IEBundledMember Nothing "P", IEBundledMember (Just IEBundledNamespaceData) "Q"])] ->
+                pure ()
+              other ->
+                assertFailure ("unexpected reparsed export AST: " <> show other)
+          other ->
+            assertFailure ("unexpected export AST: " <> show other)
 
 test_guardExpr :: Assertion
 test_guardExpr =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/resourcet-export-pattern-synonym-after-dotdot.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/resourcet-export-pattern-synonym-after-dotdot.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="export lists reject pattern synonym names after .. in a constructor export" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module M (T (.., P)) where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/termbox-bundled-pattern-export.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/termbox-bundled-pattern-export.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="bundled pattern synonym export after .. is rejected" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 
 module M (T (.., P)) where

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -160,7 +160,7 @@ instance Arbitrary ExportSpec where
         ExportAbs <$> arbitrary <*> arbitrary <*> genExportTypeName,
         ExportAll <$> arbitrary <*> arbitrary <*> genExportTypeName,
         ExportWith <$> arbitrary <*> arbitrary <*> genExportTypeName <*> genExportMembers,
-        ExportWithAll <$> arbitrary <*> arbitrary <*> genExportTypeName <*> genExportMembers
+        genExportWithAll
       ]
 
   shrink spec =
@@ -183,11 +183,12 @@ instance Arbitrary ExportSpec where
           <> [ExportWith Nothing namespace name members | Just _ <- [mWarning]]
           <> [ExportWith mWarning namespace shrunk members | shrunk <- shrinkExportTypeName name]
           <> [ExportWith mWarning namespace name shrunk | shrunk <- shrinkList shrink members, not (null shrunk)]
-      ExportWithAll mWarning namespace name members ->
+      ExportWithAll mWarning namespace name wildcardIndex members ->
         [ExportWith mWarning namespace name members]
-          <> [ExportWithAll Nothing namespace name members | Just _ <- [mWarning]]
-          <> [ExportWithAll mWarning namespace shrunk members | shrunk <- shrinkExportTypeName name]
-          <> [ExportWithAll mWarning namespace name shrunk | shrunk <- shrinkList shrink members]
+          <> [ExportWithAll Nothing namespace name wildcardIndex members | Just _ <- [mWarning]]
+          <> [ExportWithAll mWarning namespace shrunk wildcardIndex members | shrunk <- shrinkExportTypeName name]
+          <> [ExportWithAll mWarning namespace name shrunkIndex members | shrunkIndex <- shrinkWildcardIndex wildcardIndex members]
+          <> [ExportWithAll mWarning namespace name (min wildcardIndex (length shrunk)) shrunk | shrunk <- shrinkList shrink members]
 
 instance Arbitrary IEEntityNamespace where
   arbitrary = elements [IEEntityNamespaceType, IEEntityNamespacePattern, IEEntityNamespaceData]
@@ -222,7 +223,7 @@ instance Arbitrary ImportItem where
         ImportItemAbs <$> genTypeNamespace <*> genTypeName,
         ImportItemAll <$> genTypeNamespace <*> genTypeName,
         ImportItemWith <$> genBundledNamespace <*> genTypeName <*> genExportMembers,
-        ImportItemAllWith <$> genBundledNamespace <*> genTypeName <*> genExportMembers
+        genImportItemAllWith
       ]
 
   shrink item =
@@ -239,10 +240,11 @@ instance Arbitrary ImportItem where
         [ImportItemAbs namespace name | not (null members)]
           <> [ImportItemWith namespace shrunk members | shrunk <- shrinkTypeName name]
           <> [ImportItemWith namespace name shrunk | shrunk <- shrinkList shrink members, not (null shrunk)]
-      ImportItemAllWith namespace name members ->
+      ImportItemAllWith namespace name wildcardIndex members ->
         [ImportItemWith namespace name members]
-          <> [ImportItemAllWith namespace shrunk members | shrunk <- shrinkTypeName name]
-          <> [ImportItemAllWith namespace name shrunk | shrunk <- shrinkList shrink members]
+          <> [ImportItemAllWith namespace shrunk wildcardIndex members | shrunk <- shrinkTypeName name]
+          <> [ImportItemAllWith namespace name shrunkIndex members | shrunkIndex <- shrinkWildcardIndex wildcardIndex members]
+          <> [ImportItemAllWith namespace name (min wildcardIndex (length shrunk)) shrunk | shrunk <- shrinkList shrink members]
 
 instance Arbitrary IEBundledMember where
   arbitrary = do
@@ -275,6 +277,27 @@ genMemberNameFor namespace =
   case namespace of
     Nothing -> genMemberName
     Just _ -> qualifyName Nothing <$> genTypeName
+
+genExportWithAll :: Gen ExportSpec
+genExportWithAll = do
+  mWarning <- arbitrary
+  namespace <- arbitrary
+  name <- genExportTypeName
+  members <- genExportMembers
+  wildcardIndex <- chooseInt (0, length members)
+  pure (ExportWithAll mWarning namespace name wildcardIndex members)
+
+genImportItemAllWith :: Gen ImportItem
+genImportItemAllWith = do
+  namespace <- genBundledNamespace
+  name <- genTypeName
+  members <- genExportMembers
+  wildcardIndex <- chooseInt (0, length members)
+  pure (ImportItemAllWith namespace name wildcardIndex members)
+
+shrinkWildcardIndex :: Int -> [a] -> [Int]
+shrinkWildcardIndex wildcardIndex members =
+  [shrunk | shrunk <- shrink wildcardIndex, shrunk >= 0, shrunk <= length members]
 
 shrinkMemberNameFor :: Maybe IEBundledNamespace -> Name -> [Name]
 shrinkMemberNameFor namespace name =

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -63,7 +63,7 @@ normalizeExportSpec spec =
     ExportAbs mWarning namespace name -> ExportAbs (normalizeWarningText <$> mWarning) namespace name
     ExportAll mWarning namespace name -> ExportAll (normalizeWarningText <$> mWarning) namespace name
     ExportWith mWarning namespace name members -> ExportWith (normalizeWarningText <$> mWarning) namespace name (map normalizeExportMember members)
-    ExportWithAll mWarning namespace name members -> ExportWithAll (normalizeWarningText <$> mWarning) namespace name (map normalizeExportMember members)
+    ExportWithAll mWarning namespace name wildcardIndex members -> ExportWithAll (normalizeWarningText <$> mWarning) namespace name wildcardIndex (map normalizeExportMember members)
 
 normalizeExportMember :: IEBundledMember -> IEBundledMember
 normalizeExportMember (IEBundledMember namespace name) = IEBundledMember namespace name
@@ -106,4 +106,4 @@ normalizeImportItem item =
     ImportItemAbs namespace name -> ImportItemAbs namespace name
     ImportItemAll namespace name -> ImportItemAll namespace name
     ImportItemWith namespace name members -> ImportItemWith namespace name (map normalizeExportMember members)
-    ImportItemAllWith namespace name members -> ImportItemAllWith namespace name (map normalizeExportMember members)
+    ImportItemAllWith namespace name wildcardIndex members -> ImportItemAllWith namespace name wildcardIndex (map normalizeExportMember members)

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -826,7 +826,7 @@ allowedNames items =
       ImportItemAbs _ itemName -> [renderUnqualifiedName itemName]
       ImportItemAll _ itemName -> [renderUnqualifiedName itemName]
       ImportItemWith _ itemName _ -> [renderUnqualifiedName itemName]
-      ImportItemAllWith _ itemName _ -> [renderUnqualifiedName itemName]
+      ImportItemAllWith _ itemName _ _ -> [renderUnqualifiedName itemName]
       ImportAnn _ sub -> allowedNames [sub]
   ]
 


### PR DESCRIPTION
## Summary
- preserve bundled export and import wildcard positions in the parser AST so forms like `T(.., P)` roundtrip without losing information
- teach the parser and pretty-printer to handle `..` before, between, or after bundled members, and update generators and normalization for the richer shape
- promote the two bundled pattern synonym oracle fixtures from xfail to pass and add a regression test for wildcard-position preservation

## Root Cause
- the parser only modeled bundled exports as either `(..)`, an explicit member list, or a list with a trailing `..`
- GHC preserves wildcard placement with an explicit index in its import/export AST, but our `ExportWithAll` and `ImportItemAllWith` constructors erased that position
- as a result, `T(.., P)` was rejected during parsing and could not be represented losslessly for roundtrip comparison against GHC

## Chosen Solution
- extend `ExportWithAll` and `ImportItemAllWith` to store the wildcard insertion index, matching GHC's information model closely enough to preserve roundtrip fidelity
- this is the smallest long-term fix because it solves both parsing and pretty-printing without introducing ad hoc normalization rules that would still lose source information

## Testing
- `just fmt`
- `just check`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "preserves bundled export wildcard position"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "termbox-bundled-pattern-export"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "resourcet-export-pattern-synonym-after-dotdot"'`

## Progress
- oracle cases fixed: 2
- new regression tests added: 1

## CodeRabbit
- `coderabbit review --prompt-only` reported no findings