### PR TITLE
test: add oracle tests for unicode module names and imports

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-export-module.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-export-module.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+
+module UnicodeExportModule (module ℳℴ𝒹1.ℳℴ𝒹2.ℳℴ𝒹3) where
+
+import ℳℴ𝒹1.ℳℴ𝒹2.ℳℴ𝒹3 (x)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-import-multiple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-import-multiple.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+
+module UnicodeImportMultiple where
+
+import ℳℴ𝒹1.ℳℴ𝒹2.ℳℴ𝒹3 (x)
+import 𝔐𝔬𝔡1.𝔐𝔬𝔡2.𝔐𝔬𝔡3 (y)
+import qualified 𝓜𝓸𝓭𝟏.𝓜𝓸𝓭𝟐.𝓜𝓸𝓭𝟑 as M
+
+combined :: Int
+combined = x + y + M.z

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-import-qualified.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-import-qualified.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+
+module UnicodeImportQualified where
+
+import qualified 𝔐𝔬𝔡1.𝔐𝔬𝔡2.𝔐𝔬𝔡3 as M
+
+useY :: Int
+useY = M.y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-import-simple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-import-simple.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+
+module UnicodeImportSimple where
+
+import ℳℴ𝒹1.ℳℴ𝒹2.ℳℴ𝒹3 (x)
+
+useX :: Int
+useX = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-module-bold-script.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-module-bold-script.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+
+module 𝓜𝓸𝓭𝟏.𝓜𝓸𝓭𝟐.𝓜𝓸𝓭𝟑 where
+
+z :: Int
+z = 3

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-module-fraktur.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-module-fraktur.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+
+module 𝔐𝔬𝔡1.𝔐𝔬𝔡2.𝔐𝔬𝔡3 where
+
+y :: Int
+y = 2

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-module-math-bold-italic.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeModuleNames/unicode-module-math-bold-italic.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+
+module ℳℴ𝒹1.ℳℴ𝒹2.ℳℴ𝒹3 where
+
+x :: Int
+x = 1


### PR DESCRIPTION
## Summary

- Add 7 oracle test fixtures for unicode module identifiers using three different Unicode scripts (mathematical bold italic, fraktur, and bold script)
- Include tests for importing and exporting unicode modules
- All tests pass without parser changes needed (the parser already handles unicode conid segments correctly)

## Test Coverage

- `unicode-module-math-bold-italic.hs` — module `ℳℴ𝒹1.ℳℴ𝒹2.ℳℴ𝒹3`
- `unicode-module-fraktur.hs` — module `𝔐𝔬𝔡1.𝔐𝔬𝔡2.𝔐𝔬𝔡3`
- `unicode-module-bold-script.hs` — module `𝓜𝓸𝓭𝟏.𝓜𝓸𝓭𝟐.𝓜𝓸𝓭𝟑`
- `unicode-import-simple.hs` — simple import of unicode module
- `unicode-import-qualified.hs` — qualified import with alias
- `unicode-import-multiple.hs` — multiple imports mixing all three scripts
- `unicode-export-module.hs` — export entire unicode module