### PR TITLE
test: add oracle xfail parser cases

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generick-associated-type-default-signatures-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generick-associated-type-default-signatures-xfail.hs
@@ -1,0 +1,39 @@
+{- ORACLE_TEST xfail reason="associated type families with kind signatures followed by default signatures fail to parse" -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module GenericKAssociatedTypeDefaultSignaturesXFail where
+
+import Data.Kind (Type)
+
+class Generic a where
+  type Rep a :: Type
+  from :: a -> Rep a
+  to :: Rep a -> a
+
+class Conv rep repK x where
+  toKindGenerics :: rep -> repK x
+  toGhcGenerics :: repK x -> rep
+
+class GenericK (f :: k) where
+  type family RepK f :: LoT k -> Type
+
+  fromK :: f :@@: x -> RepK f x
+  default
+    fromK :: (Generic (f :@@: x), Conv (Rep (f :@@: x)) (RepK f) x)
+          => f :@@: x -> RepK f x
+  fromK = toKindGenerics . from
+
+  toK :: RepK f x -> f :@@: x
+  default
+    toK :: (Generic (f :@@: x), Conv (Rep (f :@@: x)) (RepK f) x)
+        => RepK f x -> f :@@: x
+  toK = to . toGhcGenerics
+
+data LoT k
+
+infixr 0 :@@:
+data (:@@:) (f :: k) (x :: LoT k)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/import-type-empty-constructors-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/import-type-empty-constructors-xfail.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail reason="import lists reject abstract type imports written as T()" -}
+module ImportTypeEmptyConstructorsXFail where
+
+import Data.Text (Text(), unpack)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-partial-application-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-partial-application-xfail.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail reason="type synonym equations reject visible kind application in the rhs" -}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeAbstractions #-}
+
+module TypeSynonymAbstractionPartialApplicationXFail where
+
+import Data.Kind (Type)
+
+type Witnessed :: forall k. k -> Type
+type Witnessed @k = PairType @k IOWitness


### PR DESCRIPTION
## Summary
- add oracle xfail fixtures for visible kind application in type synonym equations, associated type families followed by default signatures, and abstract type imports written as `T()`
- capture parser gaps where GHC accepts the snippet but `aihc-parser` currently rejects it
- CodeRabbit suggested defining `PairType` and `IOWitness` in the type-abstraction fixture, but this fixture is intentionally parse-only and the failure is still on the parser's handling of `@k` in the rhs

## Checks
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`

## Progress
- oracle xfail fixtures: 3 added