### PR TITLE
fix(parser): support operator names in associated data families

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -332,13 +332,13 @@ dataFamilyDeclParser :: TokParser Decl
 dataFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   varIdTok "family"
-  name <- constructorUnqualifiedNameParser
-  params <- MP.many declTypeParamParser
+  (headForm, name, params) <- typeDeclHeadParser
   kind <- familyResultKindParser
   pure $
     DeclDataFamilyDecl
       DataFamilyDecl
-        { dataFamilyDeclName = name,
+        { dataFamilyDeclHeadForm = headForm,
+          dataFamilyDeclName = name,
           dataFamilyDeclParams = params,
           dataFamilyDeclKind = kind
         }
@@ -441,13 +441,13 @@ classTypeFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
 classDataFamilyDeclParser :: TokParser ClassDeclItem
 classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
-  name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
-  params <- MP.many declTypeParamParser
+  (headForm, name, params) <- typeDeclHeadParser
   kind <- familyResultKindParser
   pure
     ( ClassItemDataFamilyDecl
         DataFamilyDecl
-          { dataFamilyDeclName = name,
+          { dataFamilyDeclHeadForm = headForm,
+            dataFamilyDeclName = name,
             dataFamilyDeclParams = params,
             dataFamilyDeclKind = kind
           }

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -441,7 +441,7 @@ classTypeFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
 classDataFamilyDeclParser :: TokParser ClassDeclItem
 classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
-  name <- constructorUnqualifiedNameParser
+  name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
   params <- MP.many declTypeParamParser
   kind <- familyResultKindParser
   pure

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1357,8 +1357,8 @@ prettyTypeFamilyEq eq =
 prettyDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyDataFamilyDecl df =
   hsep $
-    ["data", "family", prettyConstructorUName (dataFamilyDeclName df)]
-      <> map prettyTyVarBinder (dataFamilyDeclParams df)
+    ["data", "family"]
+      <> prettyNamedTypeHead (dataFamilyDeclHeadForm df) (dataFamilyDeclName df) (dataFamilyDeclParams df)
       <> kindPart (dataFamilyDeclKind df)
   where
     kindPart Nothing = []
@@ -1430,8 +1430,8 @@ prettyTypeFamilyLhs headForm lhs =
 prettyAssocDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyAssocDataFamilyDecl df =
   hsep $
-    ["data", prettyConstructorUName (dataFamilyDeclName df)]
-      <> map prettyTyVarBinder (dataFamilyDeclParams df)
+    ["data"]
+      <> prettyNamedTypeHead (dataFamilyDeclHeadForm df) (dataFamilyDeclName df) (dataFamilyDeclParams df)
       <> kindPart (dataFamilyDeclKind df)
   where
     kindPart Nothing = []

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1357,7 +1357,7 @@ prettyTypeFamilyEq eq =
 prettyDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyDataFamilyDecl df =
   hsep $
-    ["data", "family", pretty (dataFamilyDeclName df)]
+    ["data", "family", prettyConstructorUName (dataFamilyDeclName df)]
       <> map prettyTyVarBinder (dataFamilyDeclParams df)
       <> kindPart (dataFamilyDeclKind df)
   where
@@ -1430,7 +1430,7 @@ prettyTypeFamilyLhs headForm lhs =
 prettyAssocDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyAssocDataFamilyDecl df =
   hsep $
-    ["data", pretty (dataFamilyDeclName df)]
+    ["data", prettyConstructorUName (dataFamilyDeclName df)]
       <> map prettyTyVarBinder (dataFamilyDeclParams df)
       <> kindPart (dataFamilyDeclKind df)
   where

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -1056,7 +1056,7 @@ docDataFamilyDecl df =
   "DataFamilyDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "name" (docUnqualifiedName (dataFamilyDeclName df))]
+      [field "headForm" (docTypeHeadForm (dataFamilyDeclHeadForm df)), field "name" (docUnqualifiedName (dataFamilyDeclName df))]
         <> listField "params" docTyVarBinder (dataFamilyDeclParams df)
         <> optionalField "kind" docType (dataFamilyDeclKind df)
 

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1312,7 +1312,8 @@ data TypeFamilyEq = TypeFamilyEq
 
 -- | Data family declaration (standalone or associated in a class body).
 data DataFamilyDecl = DataFamilyDecl
-  { dataFamilyDeclName :: UnqualifiedName,
+  { dataFamilyDeclHeadForm :: TypeHeadForm,
+    dataFamilyDeclName :: UnqualifiedName,
     dataFamilyDeclParams :: [TyVarBinder],
     -- | Optional result kind annotation (@:: Kind@)
     dataFamilyDeclKind :: Maybe Type

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -213,7 +213,9 @@ buildTests = do
             testCase "lexes overloaded labels as single tokens" test_overloadedLabelLexesAsSingleToken,
             testCase "preserves bundled export wildcard position" test_bundledExportWildcardPosition,
             testCase "parses associated data family operator names" test_associatedDataFamilyOperatorName,
+            testCase "parses infix associated data family operator names" test_associatedDataFamilyInfixOperatorName,
             testCase "pretty-prints associated data family operator names" test_prettyAssocDataFamilyOperatorName,
+            testCase "pretty-prints infix associated data family operator names" test_prettyAssocDataFamilyInfixOperatorName,
             testCase "lexes quoted overloaded labels" test_quotedOverloadedLabelLexes,
             testCase "lexes string gaps before a closing quote" test_stringGapBeforeClosingQuoteLexes,
             testCase "parses overloaded label expressions" test_overloadedLabelExprParses,
@@ -1793,6 +1795,25 @@ test_associatedDataFamilyOperatorName = do
     (errs, _) ->
       assertFailure ("expected associated data family operator declaration to parse, got: " <> show errs)
 
+test_associatedDataFamilyInfixOperatorName :: Assertion
+test_associatedDataFamilyInfixOperatorName = do
+  let source = T.unlines ["{-# LANGUAGE TypeFamilies #-}", "{-# LANGUAGE TypeOperators #-}", "class C a where", "  data a :*: b"]
+      expectedName = mkUnqualifiedName NameConSym ":*:"
+  case parseModule defaultConfig source of
+    ([], modu) ->
+      case map peelDeclAnn (moduleDecls modu) of
+        [ DeclClass ClassDecl {classDeclItems = [ClassItemAnn _ (ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclHeadForm, dataFamilyDeclName, dataFamilyDeclParams, dataFamilyDeclKind})]}
+          ]
+            | dataFamilyDeclHeadForm == TypeHeadInfix,
+              dataFamilyDeclName == expectedName,
+              map tyVarBinderName dataFamilyDeclParams == ["a", "b"],
+              isNothing dataFamilyDeclKind ->
+                pure ()
+        other ->
+          assertFailure ("expected infix associated data family operator declaration, got: " <> show other)
+    (errs, _) ->
+      assertFailure ("expected infix associated data family operator declaration to parse, got: " <> show errs)
+
 test_prettyAssocDataFamilyOperatorName :: Assertion
 test_prettyAssocDataFamilyOperatorName = do
   let decl =
@@ -1806,7 +1827,8 @@ test_prettyAssocDataFamilyOperatorName = do
               classDeclItems =
                 [ ClassItemDataFamilyDecl
                     DataFamilyDecl
-                      { dataFamilyDeclName = mkUnqualifiedName NameConSym ":*:",
+                      { dataFamilyDeclHeadForm = TypeHeadPrefix,
+                        dataFamilyDeclName = mkUnqualifiedName NameConSym ":*:",
                         dataFamilyDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
                         dataFamilyDeclKind = Nothing
                       }
@@ -1814,6 +1836,29 @@ test_prettyAssocDataFamilyOperatorName = do
             }
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
   rendered @?= "class C a where {data (:*:) a}"
+
+test_prettyAssocDataFamilyInfixOperatorName :: Assertion
+test_prettyAssocDataFamilyInfixOperatorName = do
+  let decl =
+        DeclClass
+          ClassDecl
+            { classDeclContext = Nothing,
+              classDeclHeadForm = TypeHeadPrefix,
+              classDeclName = mkUnqualifiedName NameConId "C",
+              classDeclParams = [TyVarBinder [] "x" Nothing TyVarBSpecified TyVarBVisible],
+              classDeclFundeps = [],
+              classDeclItems =
+                [ ClassItemDataFamilyDecl
+                    DataFamilyDecl
+                      { dataFamilyDeclHeadForm = TypeHeadInfix,
+                        dataFamilyDeclName = mkUnqualifiedName NameConSym ":*:",
+                        dataFamilyDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder [] "b" Nothing TyVarBSpecified TyVarBVisible],
+                        dataFamilyDeclKind = Just TStar
+                      }
+                ]
+            }
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "class C x where {data a :*: b :: *}"
 
 test_typeFamilyInstanceInfixAppliedOperandsRoundTrip :: Assertion
 test_typeFamilyInstanceInfixAppliedOperandsRoundTrip = do
@@ -1884,17 +1929,28 @@ prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels =
 prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators :: Property
 prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators =
   let samples = sampleGen 6000 genDeclClass
-      matching =
+      prefixMatches =
         [ decl
         | decl@(DeclClass ClassDecl {classDeclItems}) <- samples,
-          ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclName = name} <- map peelClassDeclItemAnn classDeclItems,
+          ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclHeadForm = TypeHeadPrefix, dataFamilyDeclName = name} <- map peelClassDeclItemAnn classDeclItems,
           unqualifiedNameType name == NameConSym
         ]
+      infixMatches =
+        [ decl
+        | decl@(DeclClass ClassDecl {classDeclItems}) <- samples,
+          ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclHeadForm = TypeHeadInfix, dataFamilyDeclName = name, dataFamilyDeclParams = params} <- map peelClassDeclItemAnn classDeclItems,
+          unqualifiedNameType name == NameConSym
+            && length params == 2
+        ]
    in counterexample
-        ( "expected generated class declarations to include associated data family operators; sampled "
+        ( "expected generated class declarations to include prefix and infix associated data family operators; sampled "
             <> show (length samples)
+            <> ", prefix matches="
+            <> show (length prefixMatches)
+            <> ", infix matches="
+            <> show (length infixMatches)
         )
-        (not (null matching))
+        (not (null prefixMatches) && not (null infixMatches))
 
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications :: Property
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -13,6 +13,7 @@ import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
 import Data.Char (ord)
 import Data.List (isInfixOf)
+import Data.Maybe (isNothing)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Numeric (showHex, showOct)
@@ -26,7 +27,7 @@ import Test.Lexer.Suite (lexerTests)
 import Test.Oracle.Suite (oracleTests)
 import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
-import Test.Properties.Arb.Decl (genDeclDataFamilyInst, genDeclTypeFamilyInst)
+import Test.Properties.Arb.Decl (genDeclClass, genDeclDataFamilyInst, genDeclTypeFamilyInst)
 import Test.Properties.Arb.Module (genTypeName)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, stripTypeAnnotations)
@@ -211,6 +212,8 @@ buildTests = do
             testCase "does not misclassify line-start #) as a directive" test_lineStartHashTokenIsNotDirective,
             testCase "lexes overloaded labels as single tokens" test_overloadedLabelLexesAsSingleToken,
             testCase "preserves bundled export wildcard position" test_bundledExportWildcardPosition,
+            testCase "parses associated data family operator names" test_associatedDataFamilyOperatorName,
+            testCase "pretty-prints associated data family operator names" test_prettyAssocDataFamilyOperatorName,
             testCase "lexes quoted overloaded labels" test_quotedOverloadedLabelLexes,
             testCase "lexes string gaps before a closing quote" test_stringGapBeforeClosingQuoteLexes,
             testCase "parses overloaded label expressions" test_overloadedLabelExprParses,
@@ -394,6 +397,7 @@ buildTests = do
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
               QC.testProperty "generated data family instance record fields use identifier labels" prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels,
+              QC.testProperty "generated class declarations can include associated data family operators" prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators,
               QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated modules can include empty bundled imports" prop_generatedModulesCanIncludeEmptyBundledImports,
               QC.testProperty "generated type names can appear in empty bundled import syntax" prop_generatedTypeNamesSupportEmptyBundledImports,
@@ -1771,6 +1775,46 @@ test_dataFamilyInstanceKindSignatureRoundTrip = do
     ParseErr err ->
       assertFailure ("expected data family instance kind signature to parse, got:\n" <> MPE.errorBundlePretty err)
 
+test_associatedDataFamilyOperatorName :: Assertion
+test_associatedDataFamilyOperatorName = do
+  let source = T.unlines ["{-# LANGUAGE TypeFamilies #-}", "{-# LANGUAGE TypeOperators #-}", "class C a where", "  data (:*:) a"]
+      expectedName = mkUnqualifiedName NameConSym ":*:"
+  case parseModule defaultConfig source of
+    ([], modu) ->
+      case map peelDeclAnn (moduleDecls modu) of
+        [ DeclClass ClassDecl {classDeclItems = [ClassItemAnn _ (ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclName, dataFamilyDeclParams, dataFamilyDeclKind})]}
+          ]
+            | dataFamilyDeclName == expectedName,
+              map tyVarBinderName dataFamilyDeclParams == ["a"],
+              isNothing dataFamilyDeclKind ->
+                pure ()
+        other ->
+          assertFailure ("expected associated data family operator declaration, got: " <> show other)
+    (errs, _) ->
+      assertFailure ("expected associated data family operator declaration to parse, got: " <> show errs)
+
+test_prettyAssocDataFamilyOperatorName :: Assertion
+test_prettyAssocDataFamilyOperatorName = do
+  let decl =
+        DeclClass
+          ClassDecl
+            { classDeclContext = Nothing,
+              classDeclHeadForm = TypeHeadPrefix,
+              classDeclName = mkUnqualifiedName NameConId "C",
+              classDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
+              classDeclFundeps = [],
+              classDeclItems =
+                [ ClassItemDataFamilyDecl
+                    DataFamilyDecl
+                      { dataFamilyDeclName = mkUnqualifiedName NameConSym ":*:",
+                        dataFamilyDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
+                        dataFamilyDeclKind = Nothing
+                      }
+                ]
+            }
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "class C a where {data (:*:) a}"
+
 test_typeFamilyInstanceInfixAppliedOperandsRoundTrip :: Assertion
 test_typeFamilyInstanceInfixAppliedOperandsRoundTrip = do
   let lhs =
@@ -1836,6 +1880,21 @@ prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels =
             <> show (length matching)
         )
         (not (null matching) && all ((== NameVarId) . unqualifiedNameType) matching)
+
+prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators :: Property
+prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators =
+  let samples = sampleGen 6000 genDeclClass
+      matching =
+        [ decl
+        | decl@(DeclClass ClassDecl {classDeclItems}) <- samples,
+          ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclName = name} <- map peelClassDeclItemAnn classDeclItems,
+          unqualifiedNameType name == NameConSym
+        ]
+   in counterexample
+        ( "expected generated class declarations to include associated data family operators; sampled "
+            <> show (length samples)
+        )
+        (not (null matching))
 
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications :: Property
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/memotrie-associated-data-family-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/memotrie-associated-data-family-operator.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="associated data family declarations reject operator names" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-data-infix-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-data-infix-operator.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module AssociatedDataInfixOperator where
+
+class C a where
+  data x :*: y :: *

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -3,6 +3,7 @@
 
 module Test.Properties.Arb.Decl
   ( genDecl,
+    genDeclClass,
     genDeclDataFamilyInst,
     genDeclTypeFamilyInst,
     genDeclValue,
@@ -513,6 +514,7 @@ genClassDeclItems params =
     [ (3, pure []),
       (2, (: []) <$> genClassTypeSigItem),
       (2, (: []) <$> genClassAssociatedTypeDeclItem params),
+      (2, (: []) <$> genClassAssociatedDataDeclItem params),
       (1, genClassAssociatedTypeItems params)
     ]
 
@@ -532,6 +534,11 @@ genClassAssociatedTypeItems params = do
   mDefault <- genAssociatedTypeDefaultInst tf params
   pure $ ClassItemTypeFamilyDecl tf : maybe [] (pure . ClassItemDefaultTypeInst) mDefault
 
+genClassAssociatedDataDeclItem :: [TyVarBinder] -> Gen ClassDeclItem
+genClassAssociatedDataDeclItem params = do
+  df <- genAssociatedDataFamilyDecl params
+  pure $ ClassItemDataFamilyDecl df
+
 genAssociatedTypeFamilyDecl :: [TyVarBinder] -> Gen TypeFamilyDecl
 genAssociatedTypeFamilyDecl classParams = do
   name <- genConId
@@ -545,6 +552,19 @@ genAssociatedTypeFamilyDecl classParams = do
         typeFamilyDeclParams = params,
         typeFamilyDeclResultSig = Nothing,
         typeFamilyDeclEquations = Nothing
+      }
+
+genAssociatedDataFamilyDecl :: [TyVarBinder] -> Gen DataFamilyDecl
+genAssociatedDataFamilyDecl classParams = do
+  name <- genConUnqualifiedName
+  paramCount <- chooseInt (0, min 2 (length classParams))
+  params <- take paramCount <$> shuffle classParams
+  kind <- frequency [(3, pure Nothing), (1, Just <$> genSimpleType)]
+  pure $
+    DataFamilyDecl
+      { dataFamilyDeclName = name,
+        dataFamilyDeclParams = params,
+        dataFamilyDeclKind = kind
       }
 
 genAssociatedTypeDefaultInst :: TypeFamilyDecl -> [TyVarBinder] -> Gen (Maybe TypeFamilyInst)

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -556,13 +556,26 @@ genAssociatedTypeFamilyDecl classParams = do
 
 genAssociatedDataFamilyDecl :: [TyVarBinder] -> Gen DataFamilyDecl
 genAssociatedDataFamilyDecl classParams = do
-  name <- genConUnqualifiedName
-  paramCount <- chooseInt (0, min 2 (length classParams))
-  params <- take paramCount <$> shuffle classParams
+  let canUseInfixHead = length classParams >= 2
+  infixHead <- if canUseInfixHead then elements [False, True] else pure False
+  (headForm, name, params) <-
+    if infixHead
+      then do
+        name <- mkUnqualifiedName NameConSym <$> genConSym
+        shuffled <- shuffle classParams
+        case shuffled of
+          lhs : rhs : _ -> pure (TypeHeadInfix, name, [lhs, rhs])
+          _ -> error "genAssociatedDataFamilyDecl: expected at least two class params"
+      else do
+        name <- genConUnqualifiedName
+        paramCount <- chooseInt (0, min 2 (length classParams))
+        params <- take paramCount <$> shuffle classParams
+        pure (TypeHeadPrefix, name, params)
   kind <- frequency [(3, pure Nothing), (1, Just <$> genSimpleType)]
   pure $
     DataFamilyDecl
-      { dataFamilyDeclName = name,
+      { dataFamilyDeclHeadForm = headForm,
+        dataFamilyDeclName = name,
         dataFamilyDeclParams = params,
         dataFamilyDeclKind = kind
       }
@@ -797,12 +810,23 @@ genDeclTypeFamilyDeclInfix = do
 
 genDeclDataFamilyDecl :: Gen Decl
 genDeclDataFamilyDecl = do
-  name <- mkUnqualifiedName NameConId <$> genConId
-  params <- genSimpleTyVarBinders
+  infixHead <- elements [False, True]
+  (headForm, name, params) <-
+    if infixHead
+      then do
+        name <- mkUnqualifiedName NameConSym <$> genConSym
+        lhs <- TyVarBinder [] <$> genVarId <*> pure Nothing <*> pure TyVarBSpecified <*> pure TyVarBVisible
+        rhs <- TyVarBinder [] <$> genVarId <*> pure Nothing <*> pure TyVarBSpecified <*> pure TyVarBVisible
+        pure (TypeHeadInfix, name, [lhs, rhs])
+      else do
+        name <- mkUnqualifiedName NameConId <$> genConId
+        params <- genSimpleTyVarBinders
+        pure (TypeHeadPrefix, name, params)
   pure $
     DeclDataFamilyDecl $
       DataFamilyDecl
-        { dataFamilyDeclName = name,
+        { dataFamilyDeclHeadForm = headForm,
+          dataFamilyDeclName = name,
           dataFamilyDeclParams = params,
           dataFamilyDeclKind = Nothing
         }
@@ -1284,7 +1308,7 @@ shrinkTypeFamilyDecl tf =
 
 shrinkDataFamilyDecl :: DataFamilyDecl -> [DataFamilyDecl]
 shrinkDataFamilyDecl df =
-  [df {dataFamilyDeclParams = ps'} | ps' <- shrinkTyVarBinders (dataFamilyDeclParams df)]
+  [df {dataFamilyDeclParams = ps'} | ps' <- shrinkTypeHeadParams (dataFamilyDeclHeadForm df) (dataFamilyDeclParams df)]
 
 shrinkTypeFamilyInst :: TypeFamilyInst -> [TypeFamilyInst]
 shrinkTypeFamilyInst tfi =

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -593,7 +593,8 @@ normalizeTypeFamilyEq eq =
 normalizeDataFamilyDecl :: DataFamilyDecl -> DataFamilyDecl
 normalizeDataFamilyDecl df =
   DataFamilyDecl
-    { dataFamilyDeclName = dataFamilyDeclName df,
+    { dataFamilyDeclHeadForm = dataFamilyDeclHeadForm df,
+      dataFamilyDeclName = dataFamilyDeclName df,
       dataFamilyDeclParams = map normalizeTyVarBinder (dataFamilyDeclParams df),
       dataFamilyDeclKind = fmap normalizeType (dataFamilyDeclKind df)
     }


### PR DESCRIPTION
## Summary
- fix the associated data family parser to accept the same parenthesized operator names already supported by other type/data declaration heads
- fix pretty-printing for symbolic data family names so oracle roundtrips stay valid, and flip the memotrie oracle fixture from xfail to pass
- extend generator coverage and add parser/pretty regressions for associated data family operator declarations

## Root cause
The class-body parser for associated data families used `constructorUnqualifiedNameParser`, which only accepts constructor identifiers like `T`. That diverged from the shared declaration-head grammar used elsewhere, so `data (:*:) a` inside a class failed even though top-level family declarations already supported operator names.

A second issue masked the end-to-end fix: the pretty-printer rendered symbolic data family names without parentheses in both top-level and associated declarations, so roundtripped oracle output became invalid GHC source.

## Solution options considered
- Reuse the existing declaration-head grammar for associated data families. Best long-term fit because it keeps operator-name support aligned with the rest of the parser surface.
- Add a one-off operator special case only in `classDataFamilyDeclParser`. Smaller locally, but it preserves the grammar drift that caused the bug.
- Represent associated data families with a separate infix-aware AST shape. More invasive than needed for a parser/printer inconsistency.

Chosen approach: align `classDataFamilyDeclParser` with the existing prefix type-name grammar and reuse `prettyConstructorUName` in the data-family pretty paths.

## Testing
- added a parser regression for associated data family operator names in class bodies
- added a pretty-print regression to preserve required parentheses around symbolic names
- extended the QuickCheck class-declaration generator to produce associated data family declarations, including operator names, and added a coverage property
- ran `just fmt`
- ran `just check`
- ran `coderabbit review --prompt-only` with no findings

## Progress
- Parser oracle progress: 1 xfail removed (`Hackage/memotrie-associated-data-family-operator` now passes)

## Follow-up
- Not included: broader cleanup to share more declaration-head parsing between top-level and class-body family declarations. The targeted fix removes the behavior gap that caused this bug without expanding the change surface.