### PR TITLE
fix(stackage-progress): avoid retaining optional failure details

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -94,6 +94,7 @@ test-suite spec
     , ParserValidation
     , ShrinkUtils
     , StackageProgress.CLI
+    , StackageProgress.FileChecker
     , StackageProgress.Summary
     , StackageProgress.FileCheckerTiming
     , Test.ErrorMessages.Suite
@@ -119,6 +120,7 @@ test-suite spec
     , Test.Properties.TypeRoundTrip
     , Test.Parser.Suite
     , Test.StackageProgress.FileCheckerTiming
+    , Test.StackageProgress.FileChecker
     , Test.StackageProgress.Summary
   build-depends:
       base >=4.16 && <5

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/FileChecker.hs
@@ -5,6 +5,7 @@
 -- | File-level validation checks for Haskell source files.
 module StackageProgress.FileChecker
   ( -- * File checking
+    FileCheckOptions (..),
     FileResult (..),
     PackageFileSummary (..),
     checkFile,
@@ -23,7 +24,8 @@ import Control.DeepSeq (deepseq)
 import Control.Exception (evaluate)
 import Control.Monad (when)
 import CppSupport (moduleHeaderPragmas, preprocessForParserIfEnabled)
-import Data.Maybe (fromMaybe, isNothing)
+import Data.List qualified as List
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word64)
@@ -57,11 +59,17 @@ aihcParseTimeoutMicros = 5 * 60 * 1_000_000
 
 -- | Result of checking a single file.
 data FileResult = FileResult
-  { fileOursOk :: Bool,
-    fileHseOk :: Bool,
-    fileGhcOk :: Bool,
-    fileError :: Maybe String,
-    fileGhcError :: Maybe String
+  { fileOursOk :: !Bool,
+    fileHseOk :: !Bool,
+    fileGhcOk :: !Bool,
+    fileError :: !(Maybe String),
+    fileGhcError :: !(Maybe String)
+  }
+
+data FileCheckOptions = FileCheckOptions
+  { fileCheckKeepFirstFailure :: !Bool,
+    fileCheckKeepFileErrors :: !Bool,
+    fileCheckKeepGhcError :: !Bool
   }
 
 -- | Accumulated summary for a package's files.
@@ -69,9 +77,9 @@ data PackageFileSummary = PackageFileSummary
   { packageFileOursOk :: !Bool,
     packageFileHseOk :: !Bool,
     packageFileGhcOk :: !Bool,
-    packageFileFirstFailure :: Maybe String,
-    packageFileGhcError :: Maybe String,
-    packageFileErrorsList :: [(String, String)] -- [(filePath, errorMessage)]
+    packageFileFirstFailure :: !(Maybe String),
+    packageFileGhcError :: !(Maybe String),
+    packageFileErrorsList :: ![(String, String)] -- [(filePath, errorMessage)]
   }
 
 -- | Empty file summary (all checks pass).
@@ -88,33 +96,38 @@ emptyFileSummary =
 
 -- | Get the file errors from a summary.
 getPackageFileErrors :: PackageFileSummary -> [(String, String)]
-getPackageFileErrors = packageFileErrorsList
+getPackageFileErrors = List.reverse . packageFileErrorsList
 
 -- | Check a file and accumulate results.
-checkAndAccumulateFile :: [Parser] -> Bool -> FilePath -> PackageFileSummary -> FileInfo -> IO PackageFileSummary
-checkAndAccumulateFile parsers verbose packageRoot summary info = do
-  result <- checkFile parsers verbose packageRoot info
+checkAndAccumulateFile :: FileCheckOptions -> [Parser] -> Bool -> FilePath -> PackageFileSummary -> FileInfo -> IO PackageFileSummary
+checkAndAccumulateFile checkOpts parsers verbose packageRoot summary info = do
+  result <- checkFile checkOpts parsers verbose packageRoot info
   let !oursOk = packageFileOursOk summary && fileOursOk result
       !hseOk = packageFileHseOk summary && fileHseOk result
       !ghcOk = packageFileGhcOk summary && fileGhcOk result
-      firstFailure =
-        case packageFileFirstFailure summary of
-          Just err -> Just err
-          Nothing ->
-            case fileError result of
-              Just err -> Just (forceString err)
+      !firstFailure
+        | not (fileCheckKeepFirstFailure checkOpts) = Nothing
+        | otherwise =
+            case packageFileFirstFailure summary of
+              Just err -> Just err
               Nothing ->
-                if fileOursOk result
-                  then Nothing
-                  else Just "ours failed"
-      ghcError =
-        case packageFileGhcError summary of
-          Just err -> Just err
-          Nothing -> fmap forceString (fileGhcError result)
-      errorsList =
+                case fileError result of
+                  Just err -> Just (forceString err)
+                  Nothing ->
+                    if fileOursOk result
+                      then Nothing
+                      else Just "ours failed"
+      !ghcError
+        | not (fileCheckKeepGhcError checkOpts) = Nothing
+        | otherwise =
+            case packageFileGhcError summary of
+              Just err -> Just err
+              Nothing -> fmap forceString (fileGhcError result)
+      !errorsList =
         case fileError result of
-          Just err -> packageFileErrorsList summary ++ [(fileInfoPath info, forceString err)]
+          Just err | fileCheckKeepFileErrors checkOpts -> (fileInfoPath info, forceString err) : packageFileErrorsList summary
           Nothing -> packageFileErrorsList summary
+          _ -> packageFileErrorsList summary
   pure
     PackageFileSummary
       { packageFileOursOk = oursOk,
@@ -131,30 +144,32 @@ firstFailureMessage summary =
   fromMaybe "unknown failure" (packageFileFirstFailure summary)
 
 -- | Fold over files, checking each and accumulating results.
-foldFilesForPackage :: [Parser] -> Bool -> FilePath -> PackageFileSummary -> [FileInfo] -> IO PackageFileSummary
-foldFilesForPackage _ _ _ summary [] = pure summary
-foldFilesForPackage parsers verbose packageRoot summary (info : rest) =
+foldFilesForPackage :: FileCheckOptions -> [Parser] -> Bool -> FilePath -> PackageFileSummary -> [FileInfo] -> IO PackageFileSummary
+foldFilesForPackage _ _ _ _ summary [] = pure summary
+foldFilesForPackage checkOpts parsers verbose packageRoot summary (info : rest) =
   do
-    summary' <- checkAndAccumulateFile parsers verbose packageRoot summary info
-    foldFilesForPackage parsers verbose packageRoot summary' rest
+    summary' <- checkAndAccumulateFile checkOpts parsers verbose packageRoot summary info
+    foldFilesForPackage checkOpts parsers verbose packageRoot summary' rest
 
 -- | Check a single file.
 -- This uses unified extension handling: the default edition comes from the cabal file,
 -- each file may override the language edition via pragmas, and we use our own mapping
 -- to compute the final set of enabled extensions. This set is used by all parsers.
-checkFile :: [Parser] -> Bool -> FilePath -> FileInfo -> IO FileResult
-checkFile parsers verbose packageRoot info = do
+checkFile :: FileCheckOptions -> [Parser] -> Bool -> FilePath -> FileInfo -> IO FileResult
+checkFile checkOpts parsers verbose packageRoot info = do
   let file = fileInfoPath info
   source <- readTextFileLenient file
   (preprocessed, preprocessNanos) <-
     withElapsedNanos $
       preprocessForParserIfEnabled (fileInfoExtensions info) (fileInfoCppOptions info) file (fileInfoDependencies info) (resolveIncludeBestEffort packageRoot file) source
   let source' = resultOutput preprocessed
-      cppErrors = [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error]
-      cppErrorMsg =
-        if null cppErrors
-          then Nothing
-          else Just (T.intercalate "\n" cppErrors)
+      keepAihcErrorDetail = fileCheckKeepFirstFailure checkOpts || fileCheckKeepFileErrors checkOpts
+      cppErrorMsg
+        | keepAihcErrorDetail =
+            case [diagToText diag | diag <- resultDiagnostics preprocessed, diagSeverity diag == Error] of
+              [] -> Nothing
+              cppErrors -> Just (T.intercalate "\n" cppErrors)
+        | otherwise = Nothing
       -- Read module header pragmas to get any LANGUAGE pragma overrides
       headerPragmas = moduleHeaderPragmas source'
       defaultEdition = fromMaybe Syntax.Haskell98Edition (fileInfoLanguage info)
@@ -169,45 +184,55 @@ checkFile parsers verbose packageRoot info = do
             Aihc.Parser.parserExtensions = effectiveExts
           }
 
-  (aihcErrMsg, aihcNanos) <-
+  (aihcOk, aihcErrMsg, aihcNanos) <-
     if ParserAihc `elem` parsers
       then do
         (parseOutcome, parseNanos) <-
           withElapsedNanos $
             timeout aihcParseTimeoutMicros $
               evaluate (let r = Aihc.Parser.parseModule parserConfig source' in r `deepseq` r)
-        let aihcErr = case parseOutcome of
-              Nothing ->
-                let errorDetails = "AIHC parser timed out after 5 minutes"
-                    errorMsg = prefixCppErrors cppErrorMsg errorDetails
-                 in Just (T.unpack errorMsg)
-              Just (parseErrs, _parsed) ->
-                case parseErrs of
-                  [] -> Nothing
-                  _ ->
-                    let errorDetails = T.pack (Aihc.Parser.formatParseErrors file (Just source') parseErrs)
-                        errorMsg = prefixCppErrors cppErrorMsg errorDetails
-                     in Just (T.unpack errorMsg)
-        pure (aihcErr, parseNanos)
-      else pure (Nothing, 0)
+        let (!aihcParseOk, aihcErr) =
+              case parseOutcome of
+                Nothing ->
+                  ( False,
+                    if keepAihcErrorDetail
+                      then
+                        let errorDetails = "AIHC parser timed out after 5 minutes"
+                            errorMsg = prefixCppErrors cppErrorMsg errorDetails
+                         in Just (T.unpack errorMsg)
+                      else Nothing
+                  )
+                Just (parseErrs, _parsed) ->
+                  case parseErrs of
+                    [] -> (True, Nothing)
+                    _
+                      | keepAihcErrorDetail ->
+                          let errorDetails = T.pack (Aihc.Parser.formatParseErrors file (Just source') parseErrs)
+                              errorMsg = prefixCppErrors cppErrorMsg errorDetails
+                           in (False, Just (T.unpack errorMsg))
+                    _ -> (False, Nothing)
+        pure (aihcParseOk, aihcErr, parseNanos)
+      else pure (True, Nothing, 0)
 
   hseOk <-
     if ParserHse `elem` parsers
       then pure $ checkHse effectiveExts source'
       else pure True
 
-  (ghcErrMsg, ghcNanos) <-
+  (ghcOk, ghcErrMsg, ghcNanos) <-
     if ParserGhc `elem` parsers
       then do
         let ghcRes = GhcOracle.oracleModuleAstFingerprintNoCPP file edition extensionSettings source'
-        (ghcRes', ns) <- withElapsedNanos (evaluate (ghcRes `deepseq` ghcRes))
-        pure
-          ( case ghcRes' of
-              Right {} -> Nothing
-              Left err -> Just (T.unpack err),
-            ns
-          )
-      else pure (Nothing, 0)
+        ((ghcParseOk, ghcErr), ns) <-
+          withElapsedNanos $
+            evaluate $
+              case ghcRes of
+                Right {} -> (True, Nothing)
+                Left err
+                  | fileCheckKeepGhcError checkOpts -> (False, Just (T.unpack err))
+                  | otherwise -> (False, Nothing)
+        pure (ghcParseOk, ghcErr, ns)
+      else pure (True, Nothing, 0)
 
   let processedBytes = T.length source'
   when verbose $
@@ -219,9 +244,9 @@ checkFile parsers verbose packageRoot info = do
 
   pure
     FileResult
-      { fileOursOk = isNothing aihcErrMsg,
+      { fileOursOk = aihcOk,
         fileHseOk = hseOk,
-        fileGhcOk = isNothing ghcErrMsg,
+        fileGhcOk = ghcOk,
         fileError = aihcErrMsg,
         fileGhcError = ghcErrMsg
       }

--- a/components/aihc-parser/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/components/aihc-parser/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -11,6 +11,7 @@ where
 
 import Aihc.Hackage.VersionResolver (getLatestVersion)
 import Control.Exception (IOException, SomeException, displayException, try)
+import Data.Maybe (isJust)
 import HackageSupport
   ( FileInfo (..),
     downloadPackageQuietWithNetwork,
@@ -18,7 +19,8 @@ import HackageSupport
   )
 import StackageProgress.CLI (Options (..))
 import StackageProgress.FileChecker
-  ( PackageFileSummary (..),
+  ( FileCheckOptions (..),
+    PackageFileSummary (..),
     emptyFileSummary,
     firstFailureMessage,
     foldFilesForPackage,
@@ -82,6 +84,12 @@ runPackageOrThrow opts spec = do
       srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) version
       files <- findTargetFilesFromCabal srcDir
       totalSize <- if optPrintFailedTable opts then totalSourceSize files else pure 0
+      let checkOpts =
+            FileCheckOptions
+              { fileCheckKeepFirstFailure = optPrompt opts || isJust (optGhcErrorsFile opts),
+                fileCheckKeepFileErrors = optPrintFailedTable opts,
+                fileCheckKeepGhcError = isJust (optGhcErrorsFile opts)
+              }
       if null files
         then
           pure
@@ -96,12 +104,15 @@ runPackageOrThrow opts spec = do
                 packageFileErrors = []
               }
         else do
-          fileSummary <- foldFilesForPackage (optParsers opts) (optVerbose opts) srcDir emptyFileSummary files
+          fileSummary <- foldFilesForPackage checkOpts (optParsers opts) (optVerbose opts) srcDir emptyFileSummary files
           let hseOk = packageFileHseOk fileSummary
               ghcOk = packageFileGhcOk fileSummary
               ghcError = packageFileGhcError fileSummary
               oursOk = packageFileOursOk fileSummary
               errors = getPackageFileErrors fileSummary
+              reason
+                | fileCheckKeepFirstFailure checkOpts = firstFailureMessage fileSummary
+                | otherwise = ""
           if oursOk
             then
               pure
@@ -122,7 +133,7 @@ runPackageOrThrow opts spec = do
                     packageOursOk = False,
                     packageHseOk = hseOk,
                     packageGhcOk = ghcOk,
-                    packageReason = firstFailureMessage fileSummary,
+                    packageReason = reason,
                     packageGhcError = ghcError,
                     packageSourceSize = totalSize,
                     packageFileErrors = errors

--- a/components/aihc-parser/common/StackageProgress/Summary.hs
+++ b/components/aihc-parser/common/StackageProgress/Summary.hs
@@ -30,42 +30,42 @@ import Data.Char (isSpace)
 import Data.List qualified as List
 
 data PackageResult = PackageResult
-  { package :: PackageSpec,
-    packageOursOk :: Bool,
-    packageHseOk :: Bool,
-    packageGhcOk :: Bool,
-    packageReason :: String,
-    packageGhcError :: Maybe String,
-    packageSourceSize :: Integer,
-    packageFileErrors :: [(String, String)] -- [(filePath, errorMessage)]
+  { package :: !PackageSpec,
+    packageOursOk :: !Bool,
+    packageHseOk :: !Bool,
+    packageGhcOk :: !Bool,
+    packageReason :: !String,
+    packageGhcError :: !(Maybe String),
+    packageSourceSize :: !Integer,
+    packageFileErrors :: ![(String, String)] -- [(filePath, errorMessage)]
   }
 
 data FailedPackage = FailedPackage
-  { failedPackageName :: String,
-    failedPackageSourceSize :: Integer,
-    failedPackageErrors :: [(String, String)] -- [(filePath, errorMessage)]
+  { failedPackageName :: !String,
+    failedPackageSourceSize :: !Integer,
+    failedPackageErrors :: ![(String, String)] -- [(filePath, errorMessage)]
   }
   deriving (Eq, Show)
 
 data PromptCandidate = PromptCandidate
-  { promptPackageName :: String,
-    promptErrorMessage :: String
+  { promptPackageName :: !String,
+    promptErrorMessage :: !String
   }
   deriving (Eq, Show)
 
 data SummaryOptions = SummaryOptions
-  { summaryKeepSucceeded :: Bool,
-    summaryKeepFailedPackages :: Bool,
-    summaryGhcErrorLimit :: Int
+  { summaryKeepSucceeded :: !Bool,
+    summaryKeepFailedPackages :: !Bool,
+    summaryGhcErrorLimit :: !Int
   }
 
 data RunSummary = RunSummary
   { summarySuccessOursN :: !Int,
     summarySuccessHseN :: !Int,
     summarySuccessGhcN :: !Int,
-    summarySucceededPackagesAcc :: [String],
-    summaryFailedPackagesAcc :: [FailedPackage],
-    summaryGhcErrorsAcc :: [(String, String)],
+    summarySucceededPackagesAcc :: ![String],
+    summaryFailedPackagesAcc :: ![FailedPackage],
+    summaryGhcErrorsAcc :: ![(String, String)],
     summaryGhcErrorsStored :: !Int
   }
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -47,6 +47,7 @@ import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
 import Test.QuickCheck (Arbitrary (arbitrary), Gen, Property, counterexample)
 import Test.QuickCheck.Gen qualified as QGen
 import Test.QuickCheck.Random qualified as QRandom
+import Test.StackageProgress.FileChecker (stackageProgressFileCheckerTests)
 import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimingTests)
 import Test.StackageProgress.Summary (stackageProgressSummaryTests)
 import Test.Tasty
@@ -404,6 +405,7 @@ buildTests = do
         oracle,
         extensionMappingTests,
         hackageTester,
+        stackageProgressFileCheckerTests,
         stackageProgressFileCheckerTimingTests,
         stackageProgressSummaryTests
       ]

--- a/components/aihc-parser/test/Test/StackageProgress/FileChecker.hs
+++ b/components/aihc-parser/test/Test/StackageProgress/FileChecker.hs
@@ -1,0 +1,80 @@
+module Test.StackageProgress.FileChecker (stackageProgressFileCheckerTests) where
+
+import Control.Exception (bracket)
+import HackageSupport (FileInfo (..))
+import StackageProgress.CLI (Parser (..))
+import StackageProgress.FileChecker
+  ( FileCheckOptions (..),
+    FileResult (..),
+    PackageFileSummary (..),
+    checkFile,
+    emptyFileSummary,
+    foldFilesForPackage,
+    getPackageFileErrors,
+  )
+import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.IO (hClose, openTempFile)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+stackageProgressFileCheckerTests :: TestTree
+stackageProgressFileCheckerTests =
+  testGroup
+    "stackage progress file checker"
+    [ testCase "failed parse stays failed when detail retention is disabled" test_failedParseWithoutDetail,
+      testCase "package fold preserves failure without retained file errors" test_foldWithoutDetail
+    ]
+
+test_failedParseWithoutDetail :: Assertion
+test_failedParseWithoutDetail =
+  withTempDir "stackage-progress-file-checker" $ \root -> do
+    let file = root ++ "/Broken.hs"
+        info = brokenFileInfo file
+        checkOpts =
+          FileCheckOptions
+            { fileCheckKeepFirstFailure = False,
+              fileCheckKeepFileErrors = False,
+              fileCheckKeepGhcError = False
+            }
+    writeFile file "module Broken where\nvalue =\n"
+    result <- checkFile checkOpts [ParserAihc] False root info
+    assertBool "parse failure must still count as failure" (not (fileOursOk result))
+    assertEqual "detail is dropped in count-only mode" Nothing (fileError result)
+
+test_foldWithoutDetail :: Assertion
+test_foldWithoutDetail =
+  withTempDir "stackage-progress-file-checker" $ \root -> do
+    let file = root ++ "/Broken.hs"
+        info = brokenFileInfo file
+        checkOpts =
+          FileCheckOptions
+            { fileCheckKeepFirstFailure = False,
+              fileCheckKeepFileErrors = False,
+              fileCheckKeepGhcError = False
+            }
+    writeFile file "module Broken where\nvalue =\n"
+    summary <- foldFilesForPackage checkOpts [ParserAihc] False root emptyFileSummary [info]
+    assertBool "package summary must record parser failure" (not (packageFileOursOk summary))
+    assertEqual "file errors remain omitted" [] (getPackageFileErrors summary)
+
+brokenFileInfo :: FilePath -> FileInfo
+brokenFileInfo file =
+  FileInfo
+    { fileInfoPath = file,
+      fileInfoExtensions = [],
+      fileInfoCppOptions = [],
+      fileInfoLanguage = Nothing,
+      fileInfoDependencies = []
+    }
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+  tempRoot <- getTemporaryDirectory
+  (tempFile, tempHandle) <- openTempFile tempRoot (prefix ++ "-XXXXXX")
+  hClose tempHandle
+  removeFile tempFile
+  createDirectory tempFile
+  bracket
+    (pure tempFile)
+    removeDirectoryRecursive
+    action


### PR DESCRIPTION
## Summary
- make `stackage-progress` keep success/failure accounting strict while only retaining detailed failure text when output modes actually need it
- avoid quadratic per-file error accumulation and add regression coverage for count-only mode so dropped detail cannot change success totals
- reduce `stackage-progress --offline --jobs=1 +RTS -s` max residency from 4,038,999,712 bytes to 86,652,824 bytes while preserving the parser progress count at 3318/3427

## Testing
- `just fmt`
- `just check`
- `cabal run -O2 -v0 exe:stackage-progress -- --offline --jobs=1 +RTS -s`

## CodeRabbit
- `coderabbit review --prompt-only` was rate-limited, so no review was available before opening this PR