### PR TITLE
fix(parser): support invisible type applications in type syntax

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -193,11 +193,23 @@ typeInfixOperatorParser =
 typeAppParser :: TokParser Type
 typeAppParser = do
   first <- typeAtomParser
-  rest <- MP.many typeAtomParser
-  pure (foldl buildTypeApp first rest)
+  rest <- MP.many typeAppArgParser
+  pure (foldl applyTypeAppArg first rest)
 
 buildTypeApp :: Type -> Type -> Type
 buildTypeApp = TApp
+
+typeAppArgParser :: TokParser (Either Type Type)
+typeAppArgParser = (Left <$> MP.try invisibleTypeAppParser) <|> (Right <$> typeAtomParser)
+
+invisibleTypeAppParser :: TokParser Type
+invisibleTypeAppParser = do
+  expectedTok TkTypeApp
+  typeAtomParser
+
+applyTypeAppArg :: Type -> Either Type Type -> Type
+applyTypeAppArg fn (Left ty) = TTypeApp fn ty
+applyTypeAppArg fn (Right ty) = TApp fn ty
 
 typeAtomParser :: TokParser Type
 typeAtomParser = do
@@ -402,4 +414,5 @@ markTypePromoted ty =
     TCon name _ -> Just (TCon name Promoted)
     TList _ elems -> Just (TList Promoted elems)
     TTuple tupleFlavor _ elems -> Just (TTuple tupleFlavor Promoted elems)
+    TTypeApp fn arg -> TTypeApp <$> markTypePromoted fn <*> pure arg
     _ -> Nothing

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -281,6 +281,7 @@ needsTypeParens ctx ty =
       case ty of
         TQuasiQuote {} -> False
         TApp {} -> True
+        TTypeApp {} -> True
         TForall {} -> True
         TFun {} -> True
         TContext {} -> True
@@ -944,6 +945,8 @@ addTypeParensShared ctx prec ty =
           wrapTy (prec > 0) (TInfix (atom 0 lhs) op promoted (atom 0 rhs))
         TApp f x ->
           wrapTy (prec > 2) (TApp (addTypeIn CtxTypeFunArg f) (addTypeIn CtxTypeAppArg x))
+        TTypeApp f x ->
+          wrapTy (prec > 2) (TTypeApp (addTypeIn CtxTypeFunArg f) (addTypeIn CtxTypeAtom x))
         TFun a b ->
           wrapTy (prec > 0) (TFun (addTypeIn CtxTypeFunArg a) (atom 0 b))
         TTuple tupleFlavor promoted elems ->

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -422,6 +422,8 @@ prettyType ty =
         <+> prettyType rhs
     TApp f x ->
       prettyType f <+> prettyType x
+    TTypeApp f x ->
+      prettyType f <+> "@" <> prettyType x
     TFun a b ->
       prettyType a <+> "->" <+> prettyType b
     TTuple tupleFlavor promoted elems ->

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -600,6 +600,7 @@ docType ty =
             <+> parens (docType inner)
         ForallVisible -> "TForall" <+> parens (docForallTelescope telescope) <+> parens (docType inner)
     TApp f x -> "TApp" <+> parens (docType f) <+> parens (docType x)
+    TTypeApp f x -> "TTypeApp" <+> parens (docType f) <+> parens (docType x)
     TInfix lhs op promoted rhs ->
       "TInfix"
         <+> parens (docType lhs)

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1151,6 +1151,7 @@ data Type
   | TQuasiQuote Text Text
   | TForall ForallTelescope Type
   | TApp Type Type
+  | TTypeApp Type Type
   | TInfix Type Name TypePromotion Type
   | TFun Type Type
   | TTuple TupleFlavor TypePromotion [Type]

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -283,6 +283,7 @@ buildTests = do
             testCase "parses lambda type binders" test_lambdaTypeBinderParses,
             testCase "parses function head type binders" test_functionHeadTypeBinderParses,
             testCase "parses invisible type declaration binders" test_invisibleTypeDeclBinderParses,
+            testCase "parses invisible type applications in type synonym rhs" test_typeSynonymRhsInvisibleTypeAppParses,
             testCase "parses constructor patterns with type arguments" test_constructorPatternWithTypeArgParses,
             testCase "parses infix type family equations with application operands" test_infixTypeFamilyEquationWithApplicationOperands,
             localOption (QC.QuickCheckTests 2000) $
@@ -906,6 +907,16 @@ test_invisibleTypeDeclBinderParses =
         TVar "a" <- stripTypeAnnotations body ->
           pure ()
     other -> assertFailure ("expected invisible type declaration binder, got: " <> show other)
+
+test_typeSynonymRhsInvisibleTypeAppParses :: Assertion
+test_typeSynonymRhsInvisibleTypeAppParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "type Witnessed @k = PairType @k IOWitness" of
+    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "Witnessed", typeSynParams = [kBinder], typeSynBody = body})
+      | tyVarBinderName kBinder == "k",
+        tyVarBinderVisibility kBinder == TyVarBInvisible,
+        TApp (TTypeApp (TCon "PairType" Unpromoted) (TVar "k")) (TCon "IOWitness" Unpromoted) <- stripTypeAnnotations body ->
+          pure ()
+    other -> assertFailure ("expected invisible type application in type synonym rhs, got: " <> show other)
 
 test_constructorPatternWithTypeArgParses :: Assertion
 test_constructorPatternWithTypeArgParses =
@@ -1865,6 +1876,7 @@ prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =
     isBareTypeApp ty =
       case ty of
         TApp {} -> True
+        TTypeApp {} -> True
         _ -> False
 
 prop_generatedModulesCanIncludeEmptyBundledImports :: Property

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-chained-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-chained-application.hs
@@ -1,0 +1,17 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeAbstractions #-}
+
+module TypeSynonymAbstractionChainedApplication where
+
+import Data.Kind (Type)
+
+type PairType :: forall k. (k -> Type) -> (k -> Type) -> k -> Type
+data PairType f g a
+
+type IOWitness :: forall k. k -> Type
+data IOWitness a
+
+type Witnessed :: forall k. k -> Type
+type Witnessed @k = PairType @k (IOWitness @k) (IOWitness @k)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-parenthesized-partial-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-parenthesized-partial-application.hs
@@ -1,0 +1,17 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeAbstractions #-}
+
+module TypeSynonymAbstractionParenthesizedPartialApplication where
+
+import Data.Kind (Type)
+
+type PairType :: forall k. (k -> Type) -> k -> Type
+data PairType f a
+
+type IOWitness :: forall k. k -> Type
+data IOWitness a
+
+type Witnessed :: forall k. k -> Type
+type Witnessed @k = (PairType @k) IOWitness

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-partial-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeAbstractions/type-synonym-abstraction-partial-application.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail reason="type synonym equations reject visible kind application in the rhs" -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeAbstractions #-}
@@ -6,6 +6,12 @@
 module TypeSynonymAbstractionPartialApplicationXFail where
 
 import Data.Kind (Type)
+
+type PairType :: forall k. (k -> Type) -> k -> Type
+data PairType f a
+
+type IOWitness :: forall k. k -> Type
+data IOWitness a
 
 type Witnessed :: forall k. k -> Type
 type Witnessed @k = PairType @k IOWitness

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -686,6 +686,7 @@ isValidInstanceHeadType ty =
     TForall {} -> False
     TContext {} -> False
     TImplicitParam {} -> False
+    TTypeApp {} -> False
     TAnn _ inner -> isValidInstanceHeadType inner
     _ -> True
 
@@ -698,6 +699,7 @@ isInfixInstanceHeadType ty =
     TStar -> True
     TTuple {} -> True
     TList {} -> True
+    TTypeApp inner _ -> isInfixInstanceHeadType inner
     TParen inner -> isInfixInstanceHeadType inner
     _ -> False
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -278,6 +278,10 @@ shrinkType ty =
       [fn, arg]
         <> [TApp fn' arg | fn' <- shrinkType fn]
         <> [TApp fn arg' | arg' <- shrinkType arg]
+    TTypeApp fn arg ->
+      [fn, arg]
+        <> [TTypeApp fn' arg | fn' <- shrinkType fn]
+        <> [TTypeApp fn arg' | arg' <- shrinkType arg]
     TFun lhs rhs ->
       [lhs, rhs]
         <> [TFun lhs' rhs | lhs' <- shrinkType lhs]

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -331,6 +331,7 @@ stripTypeAnnotations ty =
     TQuasiQuote q b -> TQuasiQuote q b
     TForall telescope t -> TForall (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)}) (stripTypeAnnotations t)
     TApp a b -> TApp (stripTypeAnnotations a) (stripTypeAnnotations b)
+    TTypeApp a b -> TTypeApp (stripTypeAnnotations a) (stripTypeAnnotations b)
     TInfix lhs op promoted rhs -> TInfix (stripTypeAnnotations lhs) op promoted (stripTypeAnnotations rhs)
     TFun a b -> TFun (stripTypeAnnotations a) (stripTypeAnnotations b)
     TTuple fl pr es -> TTuple fl pr (map stripTypeAnnotations es)
@@ -356,6 +357,7 @@ normalizeType ty =
         (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)})
         (normalizeType inner)
     TApp fn arg -> TApp (normalizeType fn) (normalizeType arg)
+    TTypeApp fn arg -> TTypeApp (normalizeType fn) (normalizeType arg)
     TInfix lhs op promoted rhs -> TInfix (normalizeType lhs) op promoted (normalizeType rhs)
     TFun lhs rhs -> TFun (normalizeType lhs) (normalizeType rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -75,6 +75,7 @@ normalizeTypeSpan ty =
     TQuasiQuote quoter body -> TQuasiQuote quoter body
     TForall telescope inner -> TForall (normalizeForallTelescope telescope) (normalizeTypeSpan inner)
     TApp lhs rhs -> TApp (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
+    TTypeApp lhs rhs -> TTypeApp (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
     TInfix lhs op promoted rhs -> TInfix (normalizeTypeSpan lhs) op promoted (normalizeTypeSpan rhs)
     TFun lhs rhs -> TFun (normalizeTypeSpan lhs) (normalizeTypeSpan rhs)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeTypeSpan elems)

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -32,7 +32,7 @@ prop_typePrettyRoundTrip ty =
    in checkCoverage $
         withMaxShrinks 100 $
           cover 1 hasKindedInferredBinder "kinded inferred forall binder" $
-            assertCtorCoverage ["TAnn", "TInfix"] ty $
+            assertCtorCoverage ["TAnn", "TInfix", "TTypeApp"] ty $
               counterexample (T.unpack source) $
                 case parseType typeConfig source of
                   ParseErr err ->
@@ -57,6 +57,7 @@ normalizeType ty =
         (telescope {forallTelescopeBinders = map normalizeTyVarBinder (forallTelescopeBinders telescope)})
         (normalizeType inner)
     TApp f x -> TApp (normalizeType f) (normalizeType x)
+    TTypeApp f x -> TTypeApp (normalizeType f) (normalizeType x)
     TInfix lhs op promoted rhs -> TInfix (normalizeType lhs) op promoted (normalizeType rhs)
     TFun a b -> TFun (normalizeType a) (normalizeType b)
     TTuple tupleFlavor promoted elems -> TTuple tupleFlavor promoted (map normalizeType elems)
@@ -83,6 +84,7 @@ containsKindedInferredBinder ty =
     TForall telescope inner -> any isKindedInferredBinder (forallTelescopeBinders telescope) || containsKindedInferredBinder inner
     TImplicitParam _name inner -> containsKindedInferredBinder inner
     TApp f x -> containsKindedInferredBinder f || containsKindedInferredBinder x
+    TTypeApp f x -> containsKindedInferredBinder f || containsKindedInferredBinder x
     TInfix lhs _ _ rhs -> containsKindedInferredBinder lhs || containsKindedInferredBinder rhs
     TFun a b -> containsKindedInferredBinder a || containsKindedInferredBinder b
     TTuple _tupleFlavor _promoted elems -> any containsKindedInferredBinder elems


### PR DESCRIPTION
## Summary
- add a first-class `TTypeApp` node so type syntax can represent invisible `@` applications on the RHS of type synonyms instead of stopping at the head constructor
- fix the former `type-synonym-abstraction-partial-application` xfail and add oracle coverage for parenthesized and chained visible kind applications in type synonym RHSs
- update parser, pretty-printing, paren insertion, and normalization helpers so the new syntax round-trips cleanly across specs and property tests

## Root Cause
- The lexer already tokenized whitespace-delimited `@` in type syntax as `TkTypeApp`, but `typeAppParser` only accepted ordinary type atoms after a type head.
- As a result, a declaration like `type Witnessed @k = PairType @k IOWitness` parsed the RHS as just `PairType` and then failed on the trailing `@k`.
- The underlying weakness was that the type AST had no way to preserve invisible type applications, so the parser could not generalize the existing expression-level `ETypeApp` behavior to type syntax.

## Solution
- Introduce `TTypeApp Type Type` and teach the type application parser to fold `TkTypeApp` arguments into that node.
- Thread the new constructor through pretty-printing, paren insertion, promotion handling, normalization, and the relevant generators/helpers.
- Keep broad property generation unchanged apart from shrink/normalization support, and cover the new syntax with targeted unit and oracle tests.

## Testing
- `just check`

## Progress
- oracle pass count increases by 3
- oracle xfail count decreases by 1

## Notes
- I tried `coderabbit review --prompt-only`, but CodeRabbit was rate-limited (`Rate limit exceeded, please try after 12 minutes and 12 seconds`), so I skipped it and opened the PR.