### PR TITLE
fix(cpp): support Haskell line comments inside function macro argument lists

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -143,6 +143,9 @@ goText st painted inString inChar escaped txt acc =
           goText st painted False True False rest (acc <> TB.singleton c)
       | isIdentStart c ->
           expandIdentBlue st painted txt acc
+      | c == '-', Just ('-', _) <- T.uncons rest ->
+          -- Haskell line comment: copy remainder verbatim without macro expansion
+          acc <> TB.fromText txt
       | otherwise ->
           goText st painted False False False rest (acc <> TB.singleton c)
 
@@ -204,8 +207,28 @@ parseArgs depth argsRev current remaining =
       | ch == ',' && depth == 0 ->
           let arg = trimSpacesText (builderToText current)
            in parseArgs depth (arg : argsRev) mempty rest
+      | ch == '-' && depth == 0, Just ('-', afterDash) <- T.uncons rest ->
+          -- Haskell line comment inside arg list: close the arg, find ')' in comment
+          let commentText = "--" <> afterDash
+           in case findLastCloseParen commentText of
+                Nothing -> Nothing
+                Just (commentPrefix, afterClose) ->
+                  let currentText = builderToText current
+                      arg = trimSpacesText currentText
+                      trailingWS = T.takeWhileEnd isSpace currentText
+                      argsRev' = if T.null arg && null argsRev then [""] else arg : argsRev
+                   in Just (reverse argsRev', trailingWS <> commentPrefix <> afterClose)
       | otherwise ->
           parseArgs depth argsRev (current <> TB.singleton ch) rest
+
+-- | Find the last ')' in text and split before it.
+findLastCloseParen :: Text -> Maybe (Text, Text)
+findLastCloseParen txt =
+  case T.findIndex (== ')') (T.reverse txt) of
+    Nothing -> Nothing
+    Just revIdx ->
+      let idx = T.length txt - revIdx - 1
+       in Just (T.take idx txt, T.drop (idx + 1) txt)
 
 data Piece
   = PieceWhitespace !Text

--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -143,7 +143,8 @@ goText st painted inString inChar escaped txt acc =
           goText st painted False True False rest (acc <> TB.singleton c)
       | isIdentStart c ->
           expandIdentBlue st painted txt acc
-      | c == '-', Just ('-', _) <- T.uncons rest ->
+      | c == '-',
+        Just ('-', _) <- T.uncons rest ->
           -- Haskell line comment: copy remainder verbatim without macro expansion
           acc <> TB.fromText txt
       | otherwise ->
@@ -207,7 +208,8 @@ parseArgs depth argsRev current remaining =
       | ch == ',' && depth == 0 ->
           let arg = trimSpacesText (builderToText current)
            in parseArgs depth (arg : argsRev) mempty rest
-      | ch == '-' && depth == 0, Just ('-', afterDash) <- T.uncons rest ->
+      | ch == '-' && depth == 0,
+        Just ('-', afterDash) <- T.uncons rest ->
           -- Haskell line comment inside arg list: close the arg, find ')' in comment
           let commentText = "--" <> afterDash
            in case findLastCloseParen commentText of

--- a/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
@@ -59,14 +59,20 @@ expandLineBySpan st =
 -- single-line expansion to preserve comment span positions.
 expandLineBySpanMultiline :: EngineState -> [LineSpan] -> Cursor -> (Text, Int)
 expandLineBySpanMultiline st spans futureCursor =
-  let hasCommentSpans = any lineSpanInBlockComment spans
-   in if hasCommentSpans
-        then -- Mixed line: fall back to single-line expansion
-          (expandLineBySpan st spans, 0)
-        else -- Pure code line: try multi-line expansion
-          let codeText = T.concat [lineSpanText s | s <- spans]
-              futureCodeLines = cursorToLines futureCursor
-           in expandMacrosMultiline st codeText futureCodeLines
+  let commentSpans = filter lineSpanInBlockComment spans
+      hasLineComment = any (\s -> "--" `T.isPrefixOf` lineSpanText s) commentSpans
+      hasBlockComment = any (\s -> not ("--" `T.isPrefixOf` lineSpanText s)) commentSpans
+   in if hasLineComment && not hasBlockComment
+        then -- Line with -- comment: full-line expansion so macro args can span into the comment
+          let fullText = T.concat [lineSpanText s | s <- spans]
+           in (expandMacros st fullText, 0)
+        else if hasBlockComment
+          then -- Block comment spans: fall back to per-span expansion
+            (expandLineBySpan st spans, 0)
+          else -- Pure code line: try multi-line expansion
+            let codeText = T.concat [lineSpanText s | s <- spans]
+                futureCodeLines = cursorToLines futureCursor
+             in expandMacrosMultiline st codeText futureCodeLines
 
 -- | Extract lines from a cursor as a lazy list of Text values.
 -- Each line is the text up to the next newline (or EOF).

--- a/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
@@ -66,13 +66,14 @@ expandLineBySpanMultiline st spans futureCursor =
         then -- Line with -- comment: full-line expansion so macro args can span into the comment
           let fullText = T.concat [lineSpanText s | s <- spans]
            in (expandMacros st fullText, 0)
-        else if hasBlockComment
-          then -- Block comment spans: fall back to per-span expansion
-            (expandLineBySpan st spans, 0)
-          else -- Pure code line: try multi-line expansion
-            let codeText = T.concat [lineSpanText s | s <- spans]
-                futureCodeLines = cursorToLines futureCursor
-             in expandMacrosMultiline st codeText futureCodeLines
+        else
+          if hasBlockComment
+            then -- Block comment spans: fall back to per-span expansion
+              (expandLineBySpan st spans, 0)
+            else -- Pure code line: try multi-line expansion
+              let codeText = T.concat [lineSpanText s | s <- spans]
+                  futureCodeLines = cursorToLines futureCursor
+               in expandMacrosMultiline st codeText futureCodeLines
 
 -- | Extract lines from a cursor as a lazy list of Text values.
 -- Each line is the text up to the next newline (or EOF).

--- a/components/aihc-cpp/test/Spec.hs
+++ b/components/aihc-cpp/test/Spec.hs
@@ -19,7 +19,7 @@ main = do
     ( testGroup
         "cpp-oracle"
         ( checks
-            <> [linePragmaTest, dateTimeTest, functionMacroArgumentTest, functionMacroUnclosedCallTest, definedConditionSpacingTest, tokenPastingTests]
+            <> [linePragmaTest, dateTimeTest, functionMacroArgumentTest, functionMacroUnclosedCallTest, definedConditionSpacingTest, tokenPastingTests, ccallLineCommentTest]
             <> [QC.testProperty "dummy quickcheck property" prop_dummy]
         )
     )
@@ -154,6 +154,28 @@ tokenPastingTests =
           Done result ->
             resultOutput result @?= "#line 1 \"<input>\"\n\nfoobar\n"
           _ -> assertFailure "expected Done"
+    ]
+
+ccallLineCommentTest :: TestTree
+ccallLineCommentTest =
+  testCase "CCALL macro with -- comment in argument list" $
+    case preprocess defaultConfig (TE.encodeUtf8 ccallLineCommentInput) of
+      Done result ->
+        if "foreign import ccall unsafe \"xls_wb_sheetcount\"" `T.isInfixOf` resultOutput result
+          && "c_xls_wb_sheetcount :: XLSWorkbook -> IO CInt" `T.isInfixOf` resultOutput result
+          && " -- Int32" `T.isInfixOf` resultOutput result
+          then pure ()
+          else assertFailure ("expected CCALL expansion with line comment, got: " <> show (resultOutput result))
+      _ -> assertFailure "expected Done"
+
+ccallLineCommentInput :: T.Text
+ccallLineCommentInput =
+  T.unlines
+    [ "#define CCALL(name,signature) \\",
+      "foreign import ccall unsafe #name \\",
+      "    c_##name :: signature",
+      "",
+      "CCALL(xls_wb_sheetcount, XLSWorkbook -> IO CInt -- Int32)"
     ]
 
 ccallMacroInput :: T.Text


### PR DESCRIPTION
## Summary

- `CCALL(xls_wb_sheetcount, XLSWorkbook -> IO CInt -- Int32)` previously failed to expand because the scanner split the line at `--`, leaving the code span without a closing `)`.
- `expandLineBySpanMultiline` now uses full-line expansion for lines whose only comment spans are `--` line comments (not `{- -}` block comments).
- `goText` stops macro expansion when it encounters `--`, copying the rest of the line verbatim.
- `parseArgs` handles `--` at depth 0 by finding the last `)` in the comment text to close the argument list, and preserving the comment as a suffix in `restAfter`.

## Test plan

- [ ] New unit test `ccallLineCommentTest` verifies `CCALL(xls_wb_sheetcount, XLSWorkbook -> IO CInt -- Int32)` expands correctly and includes `-- Int32` in the output.
- [ ] All 51 existing tests continue to pass (`cabal test aihc-cpp`).