### PR TITLE
fix(parser): support infix associated data family instances

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -358,7 +358,7 @@ dataFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   expectedTok TkKeywordInstance
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
-  head' <- typeAppParser
+  (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
   pure $
@@ -387,7 +387,7 @@ newtypeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
   expectedTok TkKeywordInstance
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
-  head' <- typeAppParser
+  (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   expectedTok TkReservedEquals
   constructor <- newtypeConDeclParser
@@ -491,7 +491,7 @@ instanceTypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
 instanceDataFamilyInstParser :: TokParser InstanceDeclItem
 instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
-  head' <- typeAppParser
+  (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
   pure $
@@ -518,7 +518,7 @@ instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
 instanceNewtypeFamilyInstParser :: TokParser InstanceDeclItem
 instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
-  head' <- typeAppParser
+  (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   expectedTok TkReservedEquals
   constructor <- newtypeConDeclParser

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -39,7 +39,6 @@ import Prettyprinter
     brackets,
     comma,
     hsep,
-    nest,
     parens,
     punctuate,
     semi,
@@ -832,7 +831,7 @@ prettyInstanceDecl decl =
           )
    in case instanceDeclItems decl of
         [] -> headDoc
-        items -> vsep [headDoc <+> "where", nest 2 (braces (vsep (punctuate semi (map prettyInstanceItem items))))]
+        items -> headDoc <+> "where" <+> braces (hsep (punctuate semi (map prettyInstanceItem items)))
 
 prettyInstanceWarning :: WarningText -> Doc ann
 prettyInstanceWarning (DeprText msg) = "{-# DEPRECATED " <> pretty (show msg) <> " #-}"

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -218,6 +218,7 @@ buildTests = do
             testCase "preserves bundled export wildcard position" test_bundledExportWildcardPosition,
             testCase "parses associated data family operator names" test_associatedDataFamilyOperatorName,
             testCase "parses infix associated data family operator names" test_associatedDataFamilyInfixOperatorName,
+            testCase "parses infix associated data family instances inside instance bodies" test_associatedDataFamilyInfixInstanceItem,
             testCase "pretty-prints associated data family operator names" test_prettyAssocDataFamilyOperatorName,
             testCase "pretty-prints infix associated data family operator names" test_prettyAssocDataFamilyInfixOperatorName,
             testCase "lexes quoted overloaded labels" test_quotedOverloadedLabelLexes,
@@ -407,6 +408,7 @@ buildTests = do
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
               QC.testProperty "generated data family instance record fields use identifier labels" prop_generatedDataFamilyInstanceRecordFieldsUseIdentifierLabels,
               QC.testProperty "generated class declarations can include associated data family operators" prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators,
+              QC.testProperty "generated instance declarations can include infix associated data family instances" prop_generatedInstanceDeclsCanIncludeInfixAssociatedDataFamilyInstances,
               QC.testProperty "generated type family instances can use bare infix applications" prop_generatedTypeFamilyInstancesCanUseBareInfixApplications,
               QC.testProperty "generated class items include explicit associated type family syntax" prop_generatedAssociatedTypeFamiliesCanUseExplicitFamilyKeyword,
               QC.testProperty "generated modules can include empty bundled imports" prop_generatedModulesCanIncludeEmptyBundledImports,
@@ -1874,6 +1876,46 @@ test_associatedDataFamilyInfixOperatorName = do
     (errs, _) ->
       assertFailure ("expected infix associated data family operator declaration to parse, got: " <> show errs)
 
+test_associatedDataFamilyInfixInstanceItem :: Assertion
+test_associatedDataFamilyInfixInstanceItem = do
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE TypeFamilies #-}",
+            "{-# LANGUAGE TypeOperators #-}",
+            "class C x where",
+            "  data x :->: y",
+            "instance C X where",
+            "  data a :->: b = VoidTrie"
+          ]
+      expectedOp = qualifyName Nothing (mkUnqualifiedName NameConSym ":->:")
+  case parseModule defaultConfig source of
+    ([], modu) ->
+      case map peelDeclAnn (moduleDecls modu) of
+        [ DeclClass {},
+          DeclInstance
+            InstanceDecl
+              { instanceDeclItems =
+                  [ InstanceItemAnn
+                      _
+                      ( InstanceItemDataFamilyInst
+                          DataFamilyInst
+                            { dataFamilyInstHead = head',
+                              dataFamilyInstConstructors = [constructor]
+                            }
+                        )
+                    ]
+              }
+          ]
+            | TInfix (TVar "a") op Unpromoted (TVar "b") <- stripTypeAnnotations head',
+              op == expectedOp,
+              PrefixCon _ _ ctorName [] <- peelDataConAnn constructor,
+              ctorName == mkUnqualifiedName NameConId "VoidTrie" ->
+                pure ()
+        other ->
+          assertFailure ("expected infix associated data family instance item, got: " <> show other)
+    (errs, _) ->
+      assertFailure ("expected infix associated data family instance item to parse, got: " <> show errs)
+
 test_prettyAssocDataFamilyOperatorName :: Assertion
 test_prettyAssocDataFamilyOperatorName = do
   let decl =
@@ -2011,6 +2053,26 @@ prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators =
             <> show (length infixMatches)
         )
         (not (null prefixMatches) && not (null infixMatches))
+
+prop_generatedInstanceDeclsCanIncludeInfixAssociatedDataFamilyInstances :: Property
+prop_generatedInstanceDeclsCanIncludeInfixAssociatedDataFamilyInstances =
+  let samples = sampleGen 6000 (arbitrary :: Gen Module)
+      matching =
+        [ modu
+        | modu@Module {moduleDecls} <- samples,
+          DeclInstance InstanceDecl {instanceDeclItems} <- moduleDecls,
+          InstanceItemDataFamilyInst DataFamilyInst {dataFamilyInstHead} <- map peelInstanceDeclItemAnn instanceDeclItems,
+          case stripTypeAnnotations dataFamilyInstHead of
+            TInfix {} -> True
+            _ -> False
+        ]
+   in counterexample
+        ( "expected generated modules to include infix associated data family instances in instance bodies; sampled "
+            <> show (length samples)
+            <> ", matches="
+            <> show (length matching)
+        )
+        (not (null matching))
 
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications :: Property
 prop_generatedTypeFamilyInstancesCanUseBareInfixApplications =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-data-family-infix-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/associated-data-family-infix-instance.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module AssociatedDataFamilyInfixInstance where
+
+data X = X
+
+class C a where
+  data a :->: b
+
+instance C X where
+  data a :->: b = VoidTrie

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -624,12 +624,25 @@ genDeclClassInfix = do
 genDeclInstance :: Gen Decl
 genDeclInstance = oneof [genDeclInstancePrefix, genDeclInstanceInfix]
 
+genInstanceDeclItems :: Gen [InstanceDeclItem]
+genInstanceDeclItems =
+  frequency
+    [ (4, pure []),
+      (1, (: []) <$> genInstanceAssociatedDataFamilyInstItem)
+    ]
+
+genInstanceAssociatedDataFamilyInstItem :: Gen InstanceDeclItem
+genInstanceAssociatedDataFamilyInstItem = do
+  inst <- genDataFamilyInstWith genFamilyInfixHead genSimpleDataCons
+  pure (InstanceItemDataFamilyInst inst)
+
 genDeclInstancePrefix :: Gen Decl
 genDeclInstancePrefix = do
   className <- genConId
   n <- chooseInt (0, 2)
   types <- vectorOf n genInstanceHeadType
   ctx <- genSimpleContext
+  items <- if null types then pure [] else genInstanceDeclItems
   pure $
     DeclInstance $
       InstanceDecl
@@ -641,7 +654,7 @@ genDeclInstancePrefix = do
           instanceDeclHeadForm = TypeHeadPrefix,
           instanceDeclClassName = mkUnqualifiedName NameConId className,
           instanceDeclTypes = types,
-          instanceDeclItems = []
+          instanceDeclItems = items
         }
 
 genDeclInstanceInfix :: Gen Decl
@@ -650,6 +663,7 @@ genDeclInstanceInfix = do
   lhs <- genInfixInstanceHeadType
   rhs <- genInfixInstanceHeadType
   ctx <- genSimpleContext
+  items <- genInstanceDeclItems
   pure $
     DeclInstance $
       InstanceDecl
@@ -661,7 +675,7 @@ genDeclInstanceInfix = do
           instanceDeclHeadForm = TypeHeadInfix,
           instanceDeclClassName = mkUnqualifiedName NameConId className,
           instanceDeclTypes = [lhs, rhs],
-          instanceDeclItems = []
+          instanceDeclItems = items
         }
 
 genDeclStandaloneDeriving :: Gen Decl
@@ -876,40 +890,36 @@ genDeclDataFamilyInst :: Gen Decl
 genDeclDataFamilyInst =
   oneof
     [ genDeclDataFamilyInstPrefix,
+      genDeclDataFamilyInstInfix,
       genDeclDataFamilyInstGadt
     ]
 
+genDataFamilyInstWith :: Gen Type -> Gen [DataConDecl] -> Gen DataFamilyInst
+genDataFamilyInstWith genHead genConstructors = do
+  head' <- genHead
+  kind <- genOptionalDataFamilyInstKind
+  ctors <- genConstructors
+  pure $
+    DataFamilyInst
+      { dataFamilyInstIsNewtype = False,
+        dataFamilyInstForall = [],
+        dataFamilyInstHead = head',
+        dataFamilyInstKind = kind,
+        dataFamilyInstConstructors = ctors,
+        dataFamilyInstDeriving = []
+      }
+
 genDeclDataFamilyInstPrefix :: Gen Decl
 genDeclDataFamilyInstPrefix = do
-  head' <- genFamilyLhsType
-  kind <- genOptionalDataFamilyInstKind
-  ctors <- genSimpleDataCons
-  pure $
-    DeclDataFamilyInst $
-      DataFamilyInst
-        { dataFamilyInstIsNewtype = False,
-          dataFamilyInstForall = [],
-          dataFamilyInstHead = head',
-          dataFamilyInstKind = kind,
-          dataFamilyInstConstructors = ctors,
-          dataFamilyInstDeriving = []
-        }
+  DeclDataFamilyInst <$> genDataFamilyInstWith genFamilyLhsType genSimpleDataCons
+
+genDeclDataFamilyInstInfix :: Gen Decl
+genDeclDataFamilyInstInfix =
+  DeclDataFamilyInst <$> genDataFamilyInstWith genFamilyInfixHead genSimpleDataCons
 
 genDeclDataFamilyInstGadt :: Gen Decl
 genDeclDataFamilyInstGadt = do
-  head' <- genFamilyLhsType
-  kind <- genOptionalDataFamilyInstKind
-  ctors <- genGadtDataCons
-  pure $
-    DeclDataFamilyInst $
-      DataFamilyInst
-        { dataFamilyInstIsNewtype = False,
-          dataFamilyInstForall = [],
-          dataFamilyInstHead = head',
-          dataFamilyInstKind = kind,
-          dataFamilyInstConstructors = ctors,
-          dataFamilyInstDeriving = []
-        }
+  DeclDataFamilyInst <$> genDataFamilyInstWith genFamilyLhsType genGadtDataCons
 
 genOptionalDataFamilyInstKind :: Gen (Maybe Type)
 genOptionalDataFamilyInstKind =
@@ -951,6 +961,12 @@ genFamilyInfixOperand =
     [ (1, genFamilyTypeAtom),
       (3, genFamilyTypeApp)
     ]
+
+genFamilyInfixHead :: Gen Type
+genFamilyInfixHead = do
+  op <- genTypeFamilyInstOperator
+  lhs <- genFamilyInfixOperand
+  TInfix lhs op Unpromoted <$> genFamilyInfixOperand
 
 genFamilyRhsType :: Gen Type
 genFamilyRhsType =


### PR DESCRIPTION
## Summary
- accept infix associated data family instance heads in both top-level and instance-body `data`/`newtype` family instance parsers
- add an oracle regression fixture and parser spec coverage for `instance C X where data a :->: b = VoidTrie`
- extend QuickCheck generation to produce infix associated data family instances in valid instance bodies and keep instance pretty-printing roundtrippable

## Testing
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`

## Progress
- Oracle progress is now 908 passing cases locally, up by 1 from this new regression fixture