### PR TITLE
fix(parser): handle multiline if in else-do layout

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -69,7 +69,7 @@ openPendingLayout st tok =
         PendingMaybeMultiWayIf ->
           case lexTokenKind tok of
             TkReservedPipe -> openImplicitLayout LayoutMultiWayIf st tok
-            _ -> ([], st {layoutPendingLayout = Nothing}, False)
+            _ -> ([], noteClassicIfInAfterThenElse (st {layoutPendingLayout = Nothing}), False)
         PendingMaybeLambdaCases ->
           case lexTokenKind tok of
             TkSpecialLBrace -> ([], st {layoutPendingLayout = Nothing}, False)
@@ -134,7 +134,8 @@ closeBeforeToken st tok =
           go ctxs =
             case ctxs of
               LayoutImplicit indent kind : rest
-                | kind == LayoutAfterThenElse,
+                | LayoutAfterThenElse nestedIfs <- kind,
+                  nestedIfs == 0,
                   col <= indent ->
                     ([closeTok], rest)
                 | col < indent ->
@@ -200,7 +201,7 @@ stepTokenContext st tok =
     TkKeywordDo
       | layoutPrevTokenKind st == Just TkKeywordThen
           || layoutPrevTokenKind st == Just TkKeywordElse ->
-          st {layoutPendingLayout = Just (PendingImplicitLayout LayoutAfterThenElse)}
+          st {layoutPendingLayout = Just (PendingImplicitLayout (LayoutAfterThenElse 0))}
       | otherwise -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordMdo -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordOf -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
@@ -215,6 +216,7 @@ stepTokenContext st tok =
     TkKeywordLet -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutLetBlock)}
     TkKeywordRec -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordWhere -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
+    TkKeywordElse -> decrementAfterThenElseClassicIfDepth st
     TkKeywordIf -> st {layoutPendingLayout = Just PendingMaybeMultiWayIf}
     TkTHDeclQuoteOpen ->
       st
@@ -230,6 +232,26 @@ stepTokenContext st tok =
     TkSpecialLBrace -> st {layoutContexts = LayoutExplicit : layoutContexts st}
     TkSpecialRBrace -> st {layoutContexts = popOneContext (layoutContexts st)}
     _ -> st
+
+noteClassicIfInAfterThenElse :: LayoutState -> LayoutState
+noteClassicIfInAfterThenElse st = st {layoutContexts = go (layoutContexts st)}
+  where
+    go contexts =
+      case contexts of
+        LayoutImplicit indent (LayoutAfterThenElse nestedIfs) : rest ->
+          LayoutImplicit indent (LayoutAfterThenElse (nestedIfs + 1)) : rest
+        ctx : rest -> ctx : go rest
+        [] -> []
+
+decrementAfterThenElseClassicIfDepth :: LayoutState -> LayoutState
+decrementAfterThenElseClassicIfDepth st = st {layoutContexts = go (layoutContexts st)}
+  where
+    go contexts =
+      case contexts of
+        LayoutImplicit indent (LayoutAfterThenElse nestedIfs) : rest ->
+          LayoutImplicit indent (LayoutAfterThenElse (max 0 (nestedIfs - 1))) : rest
+        ctx : rest -> ctx : go rest
+        [] -> []
 
 popToDelimiter :: [LayoutContext] -> [LayoutContext]
 popToDelimiter contexts =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -223,7 +223,7 @@ data ImplicitLayoutKind
   = LayoutOrdinary
   | LayoutLetBlock
   | LayoutMultiWayIf
-  | LayoutAfterThenElse -- do-block opened directly by a preceding 'then'/'else'
+  | LayoutAfterThenElse !Int -- do-block opened directly by a preceding 'then'/'else'; tracks nested classic ifs inside the block
   deriving (Eq, Show)
 
 data PendingLayout

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -232,6 +232,7 @@ buildTests = do
             testCase "parser config passes extensions to lexer" test_parserConfigPassesExtensions,
             testCase "parser config sets source name in parse errors" test_parserConfigSetsSourceName,
             testCase "parses tab-indented where after else branch" test_tabIndentedWhereAfterElseParses,
+            testCase "parses multiline if as first stmt in else-do block" test_elseDoMultilineInnerIfParses,
             testCase "parses non-aligned multi-way-if guards" test_nonAlignedMultiWayIfGuardsParse,
             testCase "lexes alternate valid character literal spellings" test_alternateCharLiteralSpellingsLexLikeGhc,
             testCase "lexes control-backslash character literal" test_controlBackslashCharLiteralLexes,
@@ -1018,6 +1019,24 @@ test_tabIndentedWhereAfterElseParses =
             ]
    in let (errs, _) = parseModule defaultConfig source
        in assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+
+test_elseDoMultilineInnerIfParses :: Assertion
+test_elseDoMultilineInnerIfParses =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE DoAndIfThenElse #-}",
+            "module M where",
+            "fn =",
+            "  if False then",
+            "    return True",
+            "  else do",
+            "      if hidden /= 0 then",
+            "        return True",
+            "      else",
+            "        return False"
+          ]
+      (errs, _) = parseModule defaultConfig source
+   in assertBool ("expected no parse errors, got: " <> show errs) (null errs)
 
 test_nonAlignedMultiWayIfGuardsParse :: Assertion
 test_nonAlignedMultiWayIfGuardsParse =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-else-do-multiline-inner-if.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-and-if-then-else-else-do-multiline-inner-if.hs
@@ -1,0 +1,16 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DoAndIfThenElse #-}
+
+-- Test case: multiline inner 'if-then-else' as the first statement in an
+-- 'else do' layout block. The outer else-do layout must not close on the
+-- inner branch markers before the statement finishes.
+module DoAndIfThenElseElseDoMultilineInnerIf where
+
+fn =
+  if False then
+    return True
+  else do
+      if hidden /= 0 then
+        return True
+      else
+        return False


### PR DESCRIPTION
## Summary
- add an oracle regression for a GHC-valid `else do` block whose first statement is a multiline `if`
- keep `then do`/`else do` layout contexts open until nested classic `if` branches are balanced, so inner `else` tokens do not close the outer do-block early
- Oracle progress: +1 passing oracle case, no xfail changes

## Verification
- `cabal test -v0 aihc-parser:spec --test-options='--pattern \"parses multiline if as first stmt in else-do block\"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern \"DoAndIfThenElse\" --hide-successes'`
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` reported that `hidden` is undefined in the new fixture. This is expected for a parser oracle fixture: the module only needs to parse and roundtrip against GHC's parser, not typecheck, and GHC accepts free variables in this context.