### PR TITLE
fix(parser): accept infix operators after parenthesized context items

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -495,7 +495,17 @@ contextItemParserWith typeParser typeAtomParser =
       expectedTok TkSpecialLParen
       item <- contextItemParserWith typeParser typeAtomParser
       expectedTok TkSpecialRParen
+      guardNotFollowedByConstraintInfixOp
       pure (TParen item)
+      where
+        guardNotFollowedByConstraintInfixOp = do
+          isFollowed <-
+            fmap (either (const False) (const True))
+              . MP.observing
+              . MP.try
+              . MP.lookAhead
+              $ constraintTypeInfixOperatorParser
+          guard (not isFollowed)
     -- \| Parse a type followed by `::` and another type (kind annotation).
     -- This handles cases like `(c :: Type -> Constraint)` in superclass contexts,
     -- both as standalone parenthesized constraints and as items in comma-separated lists.
@@ -595,14 +605,31 @@ contextItemsParserWith typeParser typeAtomParser =
   where
     parenthesizedContextItemsParser = do
       items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
-      -- Fail if no items were parsed: empty parens () in a constraint context should be
-      -- handled by contextItemParserWith (which parses () as a tuple type), not treated
-      -- as an empty constraint list. This allows constraints like () ~ () => a to parse
-      -- correctly, where () ~ () is a single type-equality constraint.
+      guardNotFollowedByConstraintInfixOp
       case items of
         [] -> fail "empty constraint list in parens"
         [item] -> pure [typeAnnSpan (getTypeSourceSpan item) (TParen item)]
         _ -> pure items
+    guardNotFollowedByConstraintInfixOp = do
+      isFollowed <-
+        fmap (either (const False) (const True))
+          . MP.observing
+          . MP.try
+          . MP.lookAhead
+          $ constraintInfixOpStartParser
+      guard (not isFollowed)
+    constraintInfixOpStartParser =
+      tokenSatisfy "constraint infix operator" $ \tok ->
+        case lexTokenKind tok of
+          TkVarSym op
+            | op /= "."
+                && op /= "!" ->
+                Just ()
+          TkConSym _ -> Just ()
+          TkQVarSym _ _ -> Just ()
+          TkQConSym _ _ -> Just ()
+          TkSpecialBacktick -> Just ()
+          _ -> Nothing
 
 contextParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]
 contextParserWith = contextItemsParserWith

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-poly-paren-infix-equality.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-poly-paren-infix-equality.hs
@@ -1,0 +1,28 @@
+{- ORACLE_TEST pass -}
+{- Tests infix type operators after parenthesized expressions in constraints. -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+import Data.Type.Equality (type (==))
+
+-- Parenthesized infix type expression followed by ~ in constraint
+f1 :: (a == b) ~ 'True => a -> b
+f1 = undefined
+
+-- Same with double parens (the workaround that always worked)
+f2 :: ((a == b) ~ 'True) => a -> b
+f2 = undefined
+
+-- Parenthesized type application followed by ~ in constraint
+f3 :: (Maybe a) ~ Maybe b => a -> b
+f3 = undefined
+
+-- Type family application with parens followed by ~
+type family F a
+f4 :: (F a) ~ Bool => a -> a
+f4 = undefined
+
+-- In comma-separated constraint list with parenthesized infix item
+f5 :: (Eq a, (a == b) ~ 'True) => a -> b
+f5 = undefined


### PR DESCRIPTION
## Summary

- Fix parser rejection of valid Haskell context syntax like `fn :: (a == b) ~ b => ()` where a parenthesized type expression is followed by an infix operator in a constraint
- Add guard after `parenthesizedContextItemsParser` and `parenthesizedContextItemParser` that checks whether the next token after `)` is a constraint infix operator; if so, `MP.try` backtracking falls through to `bareContextItemParser` which handles the full infix expression correctly
- Both `fn :: (a == b) ~ b => ()` and `fn :: ((a == b) ~ b) => ()` now parse identically, matching GHC behavior

## Root Cause

The grammar creates an ambiguity between two interpretations of `(expr)` in a context position:

1. **Parenthesized constraint item**: `(expr)` is a complete, closed constraint
2. **Parenthesized type atom**: `(expr)` is a sub-expression within a larger infix constraint like `(a == b) ~ b`

The parenthesized context parsers always chose interpretation 1, greedily closing the parentheses and leaving `~` dangling. The fix adds a lookahead guard — when `)` is followed by an infix operator, the guard fails, `MP.try` backtracks, and `bareContextItemParser` → `constraintTypeParser` handles the expression correctly, treating `(a == b)` as a type atom.

This follows the same pattern used in `Decl.hs:752` (`notFollowedBy (lookAhead typeInfixOperatorParser)`) for the analogous ambiguity in standalone deriving heads.

## Test coverage

- New oracle test fixture: `ConstraintPolymorphism/constraint-poly-paren-infix-equality` (5 cases)
  - `(a == b) ~ 'True` — parenthesized infix type expression followed by `~`
  - `((a == b) ~ 'True)` — double-parens workaround (regression guard)
  - `(Maybe a) ~ Maybe b` — parenthesized type application followed by `~`
  - `(F a) ~ Bool` — type family application with parens followed by `~`
  - `(Eq a, (a == b) ~ 'True)` — comma-separated list with parenthesized infix item
- All 1499 tests pass (1498 existing + 1 new)
- ormolu format check: pass
- hlint: no hints