### PR TITLE
fix(lexer): recognize promotion tick with horizontal whitespace and without DataKinds

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -728,17 +728,15 @@ lexSymbol env st =
             else firstJust rest
 
 lexPromotedQuote :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
-lexPromotedQuote env st
-  | not (hasExt DataKinds env) = Nothing
-  | otherwise =
-      case lexerInput st of
-        '\'' :< rest
-          | isValidCharLiteral rest -> Nothing
-          | isPromotionStart rest ->
-              let st' = advanceChars "'" st
-               in Just (mkToken st st' "'" (TkVarSym "'"), st')
-          | otherwise -> Nothing
-        _ -> Nothing
+lexPromotedQuote _env st =
+  case lexerInput st of
+    '\'' :< rest
+      | isValidCharLiteral rest -> Nothing
+      | isPromotionStart rest ->
+          let st' = advanceChars "'" st
+           in Just (mkToken st st' "'" (TkVarSym "'"), st')
+      | otherwise -> Nothing
+    _ -> Nothing
   where
     isValidCharLiteral chars =
       case scanQuoted '\'' chars of
@@ -746,7 +744,7 @@ lexPromotedQuote env st
         Left _ -> False
 
     isPromotionStart chars =
-      case chars of
+      case skipHorizontalWhitespace chars of
         c :< _
           | c == '[' -> True
           | c == '(' -> True
@@ -754,6 +752,11 @@ lexPromotedQuote env st
           | isConIdStart c -> True
           | isSymbolicOpChar c -> True
         _ -> False
+
+    skipHorizontalWhitespace chars =
+      case chars of
+        c :< rest | c == ' ' || c == '\t' -> skipHorizontalWhitespace rest
+        _ -> chars
 
 lexChar :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexChar env st =

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/promoted-type-without-datakinds.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/promoted-type-without-datakinds.yaml
@@ -1,0 +1,7 @@
+extensions: []
+input: "'True"
+tokens:
+  - "TkVarSym \"'\""
+  - "TkConId \"True\""
+  - "TkEOF"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/symbols/promoted-operator-with-space.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/symbols/promoted-operator-with-space.yaml
@@ -1,0 +1,8 @@
+extensions:
+  - DataKinds
+input: "' :<>:"
+tokens:
+  - "TkVarSym \"'\""
+  - "TkConSym \":<>:\""
+  - "TkEOF"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/promoted-type-operator-with-space.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/promoted-type-operator-with-space.hs
@@ -1,0 +1,21 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module PromotedTypeOperatorWithSpace where
+
+import GHC.TypeLits (TypeError, ErrorMessage(..), Symbol, Nat)
+
+-- Regression test: the promotion tick before a type operator with intervening
+-- whitespace (e.g. ' :<>:) was not recognized by the lexer, causing the
+-- 'where' keyword in a closed type family to be mis-parsed as an unexpected
+-- token.  This snippet parses with GHC but previously failed with aihc-parser.
+
+type family ShowConstraint (s :: Symbol) (n :: Nat) :: Symbol where
+  ShowConstraint s n = TypeError ('Text "value " ' :<>: 'ShowType n ' :<>: 'Text " exceeds limit for " ' :<>: 'ShowType s)
+
+-- Multiple chained promoted operators with space before tick.
+type family ConstraintMsg (s :: Symbol) (n :: Nat) :: Symbol where
+  ConstraintMsg s n = TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ' :<>: 'ShowType n ' :<>: 'Text " characters. Has " ' :<>: 'ShowType n ' :<>: 'Text " characters.")


### PR DESCRIPTION
## Summary

- Remove `DataKinds` extension gate from `lexPromotedQuote` — GHC's parser recognizes the `'` promotion tick regardless of `DataKinds`; the check is deferred to the type checker
- Add `skipHorizontalWhitespace` in `isPromotionStart` so that `' :<>:` (tick + space + operator) is correctly lexed as `TkVarSym "'"` + `TkConSym ":<>:"` instead of falling through to `lexChar` and producing `TkError`
- Newlines are not skipped, matching GHC behavior (GHC rejects `'` followed by newline with a lexical error)

## Root Cause

The reported snippet `'Text "msg" ' :<>: 'ShowType n` inside a closed type family equation failed because:

1. The tick `'` before `:<>:` had intervening whitespace, which `isPromotionStart` did not skip — it only checked the character immediately after `'`
2. This caused `lexChar` to produce `TkError`, which then backtracked through `MP.try` in `closedTypeFamilyWhereParser`, erasing the consumed `where` token and producing a misleading "unexpected where" error

## Test Progress

- Oracle: +1 pass (`DataKinds/promoted-type-operator-with-space`)
- Lexer golden: +2 pass (`promoted-operator-with-space`, `promoted-type-without-datakinds`)
- Total: 1501 tests passing (was 1498)