### PR TITLE
fix(cpp): require # to immediately precede parameter for stringification

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -285,11 +285,10 @@ substituteParamsBuilder subs = renderPieces . collapseTokenPastes . collapseStri
 
     collapseStringizing :: [Piece] -> [Piece]
     collapseStringizing [] = []
+    collapseStringizing (PieceRaw "#" : PieceParam name : rest) =
+      PieceRaw (stringizeArgument (lookupParam name)) : collapseStringizing rest
     collapseStringizing (PieceRaw "#" : rest) =
-      case span isWhitespacePiece rest of
-        (_, PieceParam name : remaining) ->
-          PieceRaw (stringizeArgument (lookupParam name)) : collapseStringizing remaining
-        _ -> PieceRaw "#" : collapseStringizing rest
+      PieceRaw "#" : collapseStringizing rest
     collapseStringizing (piece : rest) = piece : collapseStringizing rest
 
     collapseTokenPastes :: [Piece] -> [Piece]

--- a/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -37,3 +37,4 @@ macro-expansion-not-in-string	macro	macro-expansion-not-in-string.hs	pass
 hpp-file-macro-string-pattern	macro	hpp-file-macro-string-pattern.hs	pass
 rules-pragma-cpp-branch	lexing	rules-pragma-cpp-branch.hs	pass
 macro-multiline-args	macro	macro-multiline-args.hs	pass
+stringify-paste-pair	macro	stringify-paste-pair.hs	pass

--- a/components/aihc-cpp/test/Test/Fixtures/progress/stringify-paste-pair.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/stringify-paste-pair.hs
@@ -1,0 +1,2 @@
+#define PAIR(a,b) (# a, b #)
+PAIR(a,b)


### PR DESCRIPTION
## Summary

- Fix `#` stringification operator in macro expansion to require immediate adjacency to parameter name
- Add oracle test `stringify-paste-pair` covering `# a, b #` pattern

## Root Cause

`collapseStringizing` in `Evaluator.hs` used `span isWhitespacePiece` to skip whitespace between `#` and a parameter name, incorrectly treating `# a` as stringification. In C preprocessor semantics, `#` only stringifies when it **immediately** precedes a parameter name — no whitespace allowed.

## Changes

- `components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs`: Changed pattern match from `PieceRaw "#" : rest` with `span isWhitespacePiece` to `PieceRaw "#" : PieceParam name : rest` directly
- `components/aihc-cpp/test/Test/Fixtures/progress/stringify-paste-pair.hs`: New test fixture
- `components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv`: Added test entry