### PR TITLE
feat(parser-cli): add CPP preprocessing support with --cpp and --include flags

### DIFF
--- a/components/aihc-parser-cli/src/Aihc/Parser/CLI/Parser.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/CLI/Parser.hs
@@ -1,24 +1,96 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | CLI entry point for aihc-parser.
 --
 -- This is the unified CLI that supports both parsing (default) and lexing
--- (via @--lex@ flag) modes.
+-- (via @--lex@ flag) modes, plus CPP preprocessing support.
 module Aihc.Parser.CLI.Parser
   ( main,
   )
 where
 
 import Aihc.Parser.Run (CLIResult (..), runCLI)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
+import System.Directory (doesDirectoryExist, listDirectory)
 import System.Environment (getArgs)
 import System.Exit (exitWith)
+import System.FilePath (normalise, takeFileName, (</>))
 import System.IO (hPutStr, stderr)
 
 main :: IO ()
 main = do
   args <- getArgs
   stdin <- TIO.getContents
-  let result = runCLI args stdin
+  let includePaths = extractIncludePaths args
+  includeMap <- preloadIncludes includePaths
+  let result = runCLI includeMap args stdin
   putStr (T.unpack (cliStdout result))
   hPutStr stderr (T.unpack (cliStderr result))
   exitWith (cliExitCode result)
+
+-- | Extract --include=path values from raw arguments.
+-- This is a simple parser that only looks for --include flags.
+extractIncludePaths :: [String] -> [FilePath]
+extractIncludePaths = go []
+  where
+    go acc [] = reverse acc
+    go acc ("--include=" : rest) = go acc rest
+    go acc ("--include" : p : rest) = go (p : acc) rest
+    go acc (arg : rest) =
+      case T.breakOn "=" (T.pack arg) of
+        (prefix, suffix)
+          | prefix == "--include" && T.length suffix > 1 ->
+              go (T.unpack (T.drop 1 suffix) : acc) rest
+          | otherwise -> go acc rest
+
+-- | Preload include files from the given paths.
+-- File paths are loaded directly.
+-- Directory paths are recursively traversed and all files are loaded.
+-- Keys are normalized absolute paths.
+preloadIncludes :: [FilePath] -> IO (Map FilePath Text)
+preloadIncludes = foldr go (pure M.empty)
+  where
+    go path acc = do
+      m <- acc
+      contents <- loadPath path
+      pure (M.union contents m)
+
+-- | Load files from a path (file or directory).
+-- File paths are loaded with both absolute and basename keys.
+-- Directory paths are recursively traversed and all files are loaded.
+-- Keys are normalized absolute paths.
+loadPath :: FilePath -> IO (Map FilePath Text)
+loadPath path = do
+  isDir <- doesDirectoryExist path
+  if isDir
+    then loadDirectory path
+    else do
+      content <- TIO.readFile path
+      let absPath = normalise path
+          baseName = takeFileName path
+       in pure (M.fromList [(absPath, content), (baseName, content)])
+
+-- | Recursively load all files in a directory.
+-- Each file is indexed by both its absolute path and its basename.
+loadDirectory :: FilePath -> IO (Map FilePath Text)
+loadDirectory dir = do
+  entries <- listDirectory dir
+  foldr go (pure M.empty) entries
+  where
+    go entry acc = do
+      m <- acc
+      let path = dir </> entry
+      isDir <- doesDirectoryExist path
+      if isDir
+        then do
+          subMap <- loadDirectory path
+          pure (M.union subMap m)
+        else do
+          content <- TIO.readFile path
+          let absPath = normalise path
+              baseName = takeFileName path
+           in pure (M.union (M.fromList [(absPath, content), (baseName, content)]) m)

--- a/components/aihc-parser-cli/src/Aihc/Parser/Run.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Run.hs
@@ -5,24 +5,45 @@
 -- This module provides a pure function that handles argument parsing,
 -- enabling complete CLI testing without IO. By default, the CLI parses
 -- Haskell source code. Use @--lex@ to switch to lexer-only mode.
+-- Use @--cpp@ to run only the C preprocessor.
 module Aihc.Parser.Run
   ( runCLI,
     CLIResult (..),
   )
 where
 
+import Aihc.Cpp
+  ( Diagnostic (..),
+    IncludeKind (..),
+    IncludeRequest (..),
+    Result (..),
+    Severity (..),
+    Step (..),
+    preprocess,
+  )
+import Aihc.Cpp qualified as Cpp
 import Aihc.Parser (ParserConfig (..), defaultConfig, formatParseErrors, parseModule)
 import Aihc.Parser.Lex (lexModuleTokensWithExtensions, readModuleHeaderPragmas)
 import Aihc.Parser.Shorthand (Shorthand (..))
-import Aihc.Parser.Syntax (ExtensionSetting (..), Module, parseExtensionSettingName)
+import Aihc.Parser.Syntax
+  ( Extension (..),
+    ExtensionSetting (..),
+    Module,
+    parseExtensionSettingName,
+  )
 import Aihc.Parser.Syntax qualified as Syntax
+import Data.ByteString qualified as BS
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Options.Applicative
 import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty)
 import Prettyprinter.Render.String (renderString)
 import System.Exit (ExitCode (..))
+import System.FilePath (normalise, takeDirectory, (</>))
 
 -- | Result of running a CLI command.
 data CLIResult = CLIResult
@@ -32,8 +53,8 @@ data CLIResult = CLIResult
   }
   deriving (Eq, Show)
 
--- | CLI mode: parse (default) or lex.
-data Mode = ModeParse | ModeLex
+-- | CLI mode: parse (default), lex, or cpp-only.
+data Mode = ModeParse | ModeLex | ModeCpp
   deriving (Eq, Show)
 
 -- | Output format: AST shorthand (default) or pretty-printed source.
@@ -46,20 +67,23 @@ data Options = Options
     optExtensions :: ![ExtensionSetting]
   }
 
--- | Run the CLI with given arguments and stdin.
+-- | Run the CLI with given arguments, stdin, and include map.
 -- Returns exit code, stdout, and stderr.
 -- This is a pure function that can be tested without IO.
 --
 -- By default, parses Haskell source code. Use @--lex@ to switch to lexer mode.
+-- Use @--cpp@ to run only the preprocessor.
 --
--- Note: File arguments are parsed but ignored; input is always from stdin parameter.
-runCLI :: [String] -> Text -> CLIResult
-runCLI args stdin =
+-- The include map should contain preloaded file contents keyed by normalized paths.
+-- Files not in the map will fail to resolve during CPP preprocessing.
+runCLI :: Map FilePath Text -> [String] -> Text -> CLIResult
+runCLI includeMap args stdin =
   case execParserPure defaultPrefs optionsParser args of
     Success opts ->
       let extensions = optExtensions opts
        in case optMode opts of
-            ModeParse -> runParseMode (optOutputFormat opts) extensions stdin
+            ModeCpp -> runCppMode includeMap stdin
+            ModeParse -> runParseMode (optOutputFormat opts) extensions includeMap stdin
             ModeLex -> runLexMode extensions stdin
     Failure failure ->
       let (msg, exitCode) = renderFailure failure "aihc-parser"
@@ -69,19 +93,65 @@ runCLI args stdin =
     CompletionInvoked _ ->
       CLIResult ExitSuccess "" ""
 
+-- | Run in CPP-only mode: preprocess and output the result.
+runCppMode :: Map FilePath Text -> Text -> CLIResult
+runCppMode includeMap stdin =
+  let cfg =
+        Cpp.defaultConfig
+          { Cpp.configInputFile = "<stdin>",
+            Cpp.configMacros = M.empty
+          }
+      step = preprocess cfg (TE.encodeUtf8 stdin)
+      result = resolveCppStep includeMap step
+   in if hasCppErrors result
+        then CLIResult (ExitFailure 1) (resultOutput result) (formatCppDiagnostics (resultDiagnostics result))
+        else CLIResult ExitSuccess (resultOutput result) ""
+
 -- | Run in parse mode: parse a Haskell module and output the AST.
-runParseMode :: OutputFormat -> [ExtensionSetting] -> Text -> CLIResult
-runParseMode outputFormat extensionSettings stdin =
+-- If CPP extension is enabled, preprocess first.
+runParseMode :: OutputFormat -> [ExtensionSetting] -> Map FilePath Text -> Text -> CLIResult
+runParseMode outputFormat extensionSettings includeMap stdin =
+  let headerPragmas = readModuleHeaderPragmas stdin
+      defaultEdition = fromMaybe Syntax.Haskell2010Edition (Syntax.editionFromExtensionSettings extensionSettings)
+      edition = fromMaybe defaultEdition (Syntax.headerLanguageEdition headerPragmas)
+      finalExts = Syntax.effectiveExtensions edition (extensionSettings ++ Syntax.headerExtensionSettings headerPragmas)
+      cppEnabled = CPP `elem` finalExts
+   in if cppEnabled
+        then runParseModeWithCpp outputFormat finalExts includeMap stdin
+        else runParseModeDirect outputFormat finalExts stdin
+
+-- | Parse directly without CPP preprocessing.
+runParseModeDirect :: OutputFormat -> [Extension] -> Text -> CLIResult
+runParseModeDirect outputFormat finalExts stdin =
   let (errs, modu) = parseModule cfg stdin
    in if null errs
         then CLIResult ExitSuccess (formatOutput outputFormat modu <> "\n") ""
         else CLIResult (ExitFailure 1) "" (T.pack (formatParseErrors (parserSourceName cfg) (Just stdin) errs))
   where
-    headerPragmas = readModuleHeaderPragmas stdin
-    defaultEdition = fromMaybe Syntax.Haskell2010Edition (Syntax.editionFromExtensionSettings extensionSettings)
-    edition = fromMaybe defaultEdition (Syntax.headerLanguageEdition headerPragmas)
-    finalExts = Syntax.effectiveExtensions edition (extensionSettings ++ Syntax.headerExtensionSettings headerPragmas)
     cfg = defaultConfig {parserExtensions = finalExts, parserSourceName = "<stdin>"}
+
+-- | Parse with CPP preprocessing first.
+runParseModeWithCpp :: OutputFormat -> [Extension] -> Map FilePath Text -> Text -> CLIResult
+runParseModeWithCpp outputFormat finalExts includeMap stdin =
+  let cfg =
+        Cpp.defaultConfig
+          { Cpp.configInputFile = "<stdin>",
+            Cpp.configMacros = M.empty
+          }
+      cppStep = preprocess cfg (TE.encodeUtf8 stdin)
+      cppResult = resolveCppStep includeMap cppStep
+      cppDiagnostics = resultDiagnostics cppResult
+      cppErrors = [d | d <- cppDiagnostics, diagSeverity d == Error]
+   in if not (null cppErrors)
+        then CLIResult (ExitFailure 1) "" (formatCppDiagnostics cppErrors)
+        else
+          let preprocessed = resultOutput cppResult
+              (errs, modu) = parseModule parseCfg preprocessed
+           in if null errs
+                then CLIResult ExitSuccess (formatOutput outputFormat modu <> "\n") (formatCppDiagnostics [d | d <- cppDiagnostics, diagSeverity d == Warning])
+                else CLIResult (ExitFailure 1) "" (T.pack (formatParseErrors (parserSourceName parseCfg) (Just preprocessed) errs))
+  where
+    parseCfg = defaultConfig {parserExtensions = finalExts, parserSourceName = "<stdin>"}
 
 formatOutput :: OutputFormat -> Module -> Text
 formatOutput OutputShorthand modu = T.pack (show (shorthand modu))
@@ -95,6 +165,48 @@ runLexMode extensionSettings stdin =
       finalExts = Syntax.effectiveExtensions edition (extensionSettings ++ Syntax.headerExtensionSettings headerPragmas)
       tokens = lexModuleTokensWithExtensions finalExts stdin
    in CLIResult ExitSuccess (T.unlines (map (T.pack . show . shorthand) tokens)) ""
+
+-- | Resolve all include requests in a CPP step, returning the final result.
+resolveCppStep :: Map FilePath Text -> Step -> Result
+resolveCppStep includeMap (Done result) = result
+resolveCppStep includeMap (NeedInclude req k) =
+  let resolved = resolveInclude includeMap req
+   in resolveCppStep includeMap (k (fmap TE.encodeUtf8 resolved))
+
+-- | Resolve an include request using the include map.
+-- For local includes, first try relative to the including file, then search the map.
+-- For system includes, search the map directly.
+resolveInclude :: Map FilePath Text -> IncludeRequest -> Maybe Text
+resolveInclude includeMap req =
+  case includeKind req of
+    IncludeLocal ->
+      let relativePath = normalise (takeDirectory (includeFrom req) </> includePath req)
+       in case M.lookup relativePath includeMap of
+            Just contents -> Just contents
+            Nothing -> M.lookup (includePath req) includeMap
+    IncludeSystem ->
+      M.lookup (includePath req) includeMap
+
+-- | Format CPP diagnostics for stderr output.
+formatCppDiagnostics :: [Diagnostic] -> Text
+formatCppDiagnostics [] = ""
+formatCppDiagnostics diags =
+  T.unlines (map formatDiagnostic diags)
+  where
+    formatDiagnostic d =
+      T.pack (diagFile d)
+        <> ":"
+        <> T.pack (show (diagLine d))
+        <> ": "
+        <> severityText (diagSeverity d)
+        <> ": "
+        <> diagMessage d
+    severityText Error = "error"
+    severityText Warning = "warning"
+
+-- | Check if a CPP result contains any errors.
+hasCppErrors :: Result -> Bool
+hasCppErrors result = any (\d -> diagSeverity d == Error) (resultDiagnostics result)
 
 optionsParser :: ParserInfo Options
 optionsParser =
@@ -111,6 +223,7 @@ optionsP =
     <$> modeOption
     <*> outputFormatOption
     <*> many extensionOption
+    <* many includeOption
     <* optional (argument (str :: ReadM String) (metavar "FILE" <> help "Input file (reads stdin if omitted)"))
 
 modeOption :: Parser Mode
@@ -121,6 +234,11 @@ modeOption =
     ( long "lex"
         <> help "Lex only, do not parse (output token stream)"
     )
+    <|> flag'
+      ModeCpp
+      ( long "cpp"
+          <> help "Run C preprocessor only (output preprocessed source)"
+      )
 
 outputFormatOption :: Parser OutputFormat
 outputFormatOption =
@@ -138,6 +256,16 @@ extensionOption =
     ( short 'X'
         <> metavar "EXTENSION"
         <> help "Enable a language extension (e.g., -XNegativeLiterals)"
+    )
+
+-- | Parse an --include=path argument.
+includeOption :: Parser FilePath
+includeOption =
+  option
+    str
+    ( long "include"
+        <> metavar "PATH"
+        <> help "Add directory to include search path"
     )
 
 parseExtensionSetting :: ReadM ExtensionSetting

--- a/components/aihc-parser-cli/test/CLIGolden.hs
+++ b/components/aihc-parser-cli/test/CLIGolden.hs
@@ -26,6 +26,7 @@ import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withObject)
 import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
@@ -33,7 +34,7 @@ import qualified Data.Text.IO as TIO
 import qualified Data.Yaml as Y
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.Exit (ExitCode (..))
-import System.FilePath (takeDirectory, takeExtension, (</>))
+import System.FilePath (normalise, takeDirectory, takeExtension, (</>))
 
 data ExpectedStatus
   = StatusPass
@@ -57,7 +58,8 @@ data CLICase = CLICase
     caseExpectedOutput :: !Text,
     caseExpectedExitCode :: !Int,
     caseStatus :: !ExpectedStatus,
-    caseReason :: !String
+    caseReason :: !String,
+    caseIncludes :: !(M.Map FilePath Text)
   }
   deriving (Eq, Show)
 
@@ -98,7 +100,7 @@ parseCLICaseText root path source = do
     case Y.decodeEither' (encodeUtf8 source) of
       Left err -> Left ("Invalid YAML fixture " <> path <> ": " <> Y.prettyPrintParseException err)
       Right parsed -> Right parsed
-  (args, inputText, expectedOutput, exitCode, statusText, reasonText) <-
+  (includesMap, args, inputText, expectedOutput, exitCode, statusText, reasonText) <-
     parseYamlFixture path value
   status <- parseStatus path statusText
   reason <- validateReason path status (T.unpack reasonText)
@@ -114,23 +116,25 @@ parseCLICaseText root path source = do
         caseExpectedOutput = expectedOutput,
         caseExpectedExitCode = exitCode,
         caseStatus = status,
-        caseReason = reason
+        caseReason = reason,
+        caseIncludes = M.fromList [(normalise (T.unpack k), v) | (k, v) <- M.toList includesMap]
       }
 
 parseYamlFixture ::
   FilePath ->
   Y.Value ->
-  Either String ([Text], Text, Text, Int, Text, Text)
+  Either String (M.Map Text Text, [Text], Text, Text, Int, Text, Text)
 parseYamlFixture path value =
   case parseEither
     ( withObject "cli fixture" $ \obj -> do
+        includesMap <- obj .:? "includes" .!= M.empty
         args <- obj .:? "args" .!= []
         inputText <- obj .: "input"
         expectedOutput <- obj .: "output"
         exitCode <- obj .:? "exit_code" .!= 0
         statusText <- obj .: "status"
         reasonText <- obj .:? "reason" .!= ""
-        pure (args, inputText, expectedOutput, exitCode, statusText, reasonText)
+        pure (includesMap, args, inputText, expectedOutput, exitCode, statusText, reasonText)
     )
     value of
     Left err -> Left ("Invalid CLI fixture schema in " <> path <> ": " <> err)
@@ -142,7 +146,7 @@ parseYamlFixture path value =
 -- All tests use the unified aihc-parser CLI. Lexer tests pass @--lex@ in their args.
 evaluateCLICase :: CLICase -> IO (Outcome, String)
 evaluateCLICase meta = do
-  let result = runCLIInProcess (caseArgs meta) (caseInput meta)
+  let result = runCLIInProcess (caseIncludes meta) (caseArgs meta) (caseInput meta)
       -- Combine stdout and stderr for output comparison
       actualOutput = T.stripEnd (cliStdout result <> cliStderr result)
       expectedOutput = T.stripEnd (caseExpectedOutput meta)
@@ -175,9 +179,9 @@ data CLIResult = CLIResult
 
 -- | Run the unified aihc-parser CLI in-process with full argument parsing.
 -- This calls the pure CLI functions directly without IO.
-runCLIInProcess :: [String] -> Text -> CLIResult
-runCLIInProcess args input =
-  let r = Run.runCLI args input
+runCLIInProcess :: M.Map FilePath Text -> [String] -> Text -> CLIResult
+runCLIInProcess includeMap args input =
+  let r = Run.runCLI includeMap args input
    in CLIResult (Run.cliExitCode r) (Run.cliStdout r) (Run.cliStderr r)
 
 exitCodeToInt :: ExitCode -> Int

--- a/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/conditional.yaml
+++ b/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/conditional.yaml
@@ -1,0 +1,10 @@
+input: "#define DEBUG 1\n#if DEBUG\ndebug mode\n#else\nrelease mode\n#endif"
+args: ["--cpp"]
+output: |
+  #line 1 "<stdin>"
+
+
+  debug mode
+
+
+status: pass

--- a/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/include-resolved.yaml
+++ b/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/include-resolved.yaml
@@ -1,0 +1,14 @@
+input: |
+  #include "header.h"
+  main = FOO
+args: ["--cpp"]
+includes:
+  header.h: |
+    #define FOO 42
+output: |
+  #line 1 "<stdin>"
+  #line 1 "header.h"
+
+  #line 2 "<stdin>"
+  main = 42
+status: pass

--- a/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/missing-include.yaml
+++ b/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/missing-include.yaml
@@ -1,0 +1,10 @@
+input: |
+  #include "missing.h"
+  main = undefined
+args: ["--cpp"]
+output: |
+  <stdin>:1: error: missing include: missing.h
+  #line 1 "<stdin>"
+  main = undefined
+exit_code: 1
+status: pass

--- a/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/simple-macro.yaml
+++ b/components/aihc-parser-cli/test/Test/Fixtures/cli/cpp/simple-macro.yaml
@@ -1,0 +1,9 @@
+input: |
+  #define FOO 42
+  The answer is FOO
+args: ["--cpp"]
+output: |
+  #line 1 "<stdin>"
+
+  The answer is 42
+status: pass

--- a/components/aihc-parser-cli/test/Test/Fixtures/cli/parser/cpp/cpp-before-parsing.yaml
+++ b/components/aihc-parser-cli/test/Test/Fixtures/cli/parser/cpp/cpp-before-parsing.yaml
@@ -1,0 +1,8 @@
+input: |
+  {-# LANGUAGE CPP #-}
+  module Demo where
+  #define VALUE 42
+  x = VALUE
+output: |
+  Module {name = "Demo", languagePragmas = [EnableExtension CPP], decls = [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (EInt 42 TInteger)}])]}
+status: pass

--- a/components/aihc-parser-cli/test/Test/Fixtures/cli/parser/cpp/cpp-flag.yaml
+++ b/components/aihc-parser-cli/test/Test/Fixtures/cli/parser/cpp/cpp-flag.yaml
@@ -1,0 +1,8 @@
+input: |
+  module Demo where
+  #define VALUE 42
+  x = VALUE
+args: ["-XCPP"]
+output: |
+  Module {name = "Demo", decls = [DeclValue (FunctionBind "x" [Match {headForm = Prefix, rhs = UnguardedRhs (EInt 42 TInteger)}])]}
+status: pass


### PR DESCRIPTION
## Summary

- Add `--cpp` flag to run only the C preprocessor and output preprocessed source
- Add `--include=path` flag to preload include files from the filesystem (files and directories, recursively)
- When CPP extension is enabled (via `-XCPP` or `{-# LANGUAGE CPP #-}`), preprocessing runs automatically before parsing
- CPP diagnostics (warnings and errors) are always shown to stderr

## Changes

**`Run.hs`** — Added `ModeCpp`, `--cpp`/`--include` flags, `runCppMode` for CPP-only output, `runParseModeWithCpp` for CPP-before-parsing, include map resolution, and diagnostic formatting.

**`Parser.hs`** — Added `preloadIncludes` to recursively load files from `--include` paths into a map, with both absolute and basename keys for flexible include resolution.

**`CLIGolden.hs`** — Extended fixture format to support `includes` field mapping paths to content for CPP tests.

**Test fixtures** — 6 new fixtures covering CPP macros, conditionals, missing includes, resolved includes, and CPP-before-parsing.

## Progress

- 1630 tests pass (1504 QuickCheck + 126 CLI golden)
- 6 new CLI golden test fixtures added