### PR TITLE
test(parser): add xfail oracle cases for known parser failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/deriving-via-mvector.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DerivingVia/deriving-via-mvector.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST xfail parser rejects deriving via with GM.MVector and G.Vector constraints -}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingVia #-}
+
+module DerivingViaMVector where
+
+import qualified Data.Vector.Generic as G
+import qualified Data.Vector.Generic.Mutable as GM
+import qualified Data.Vector.Unboxed as U
+
+data TestPair a b = TestPair a b
+
+deriving via (TestPair a b `U.As` (a, b)) instance (U.Unbox a, U.Unbox b) => GM.MVector U.MVector (TestPair a b)
+deriving via (TestPair a b `U.As` (a, b)) instance (U.Unbox a, U.Unbox b) => G.Vector   U.Vector  (TestPair a b)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/duplicate-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/duplicate-where.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail parser rejects duplicate where clauses -}
+module DuplicateWhere where
+
+selectByEntity :: [Int] -> (String, String) -> Maybe String
+selectByEntity inputs (tSel, tName) = case gerArgs (filter areEq inputs) of
+  [] -> Nothing
+  args -> Just (tSel ++ tName ++ show args)
+    where
+
+  where
+    gerArgs = map show
+    areEq (sel, v) = sel == 0 && tName == v

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QuantifiedConstraints/constraint-operators.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QuantifiedConstraints/constraint-operators.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail parser rejects multi-constraint class with (|-) and (&) operators -}
+{-# LANGUAGE QuantifiedConstraints #-}
+
+module QuantifiedConstraintOperators where
+
+class (p => q) => p |- q
+instance (p => q) => p |- q
+class (p,q) => p & q
+instance (p,q) => p & q

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-function-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-function-instance.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST xfail parser rejects type family instance with Function class syntax -}
+{-# LANGUAGE TypeFamilies #-}
+
+module TypeFamilyFunctionInstance where
+
+import qualified Data.Map as Map
+
+instance Ord k => Function (Map.Map k v) where
+    type instance Domain (Map.Map k v) = k
+    type instance Codomain (Map.Map k v) = Maybe v

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/constraint-operator-class.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/constraint-operator-class.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail parser rejects multi-parameter constraint operator in class head -}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ConstraintKinds #-}
+
+module ConstraintOperatorClass where
+
+class (c1 a, c2 a) => (:&&:) c1 c2 a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-compose-constraint.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-compose-constraint.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail parser rejects type operator applied to type arguments in class context -}
+{-# LANGUAGE TypeOperators #-}
+
+module TypeComposeConstraint where
+
+import Data.Functor.Compose
+
+class (f (g x)) => (f `Compose` g) x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/nested-view-pattern-lambda.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/nested-view-pattern-lambda.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail parser rejects deeply nested view patterns in lambda expression -}
+{-# LANGUAGE ViewPatterns #-}
+
+module NestedViewPatternLambda where
+
+import Language.Haskell.TH
+
+toExp :: Expr -> TH.Exp
+toExp d (Expr.HsLam _ _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (unLoc -> map unLoc -> ps) (Expr.GRHSs _ (NE.toList -> [unLoc -> Expr.GRHS _ _ (unLoc -> e)]) _)])))) = TH.LamE (fmap (toPat d) ps) (toExp d e)


### PR DESCRIPTION
## Summary

- Add 7 xfail oracle test cases for Haskell snippets that GHC accepts but aihc-parser currently rejects
- All cases marked with expected failure reasons for tracking parser gaps
- Tests cover: TypeFamilies, QuantifiedConstraints, TypeOperators, Layout, ViewPatterns, DerivingVia

## Test Cases

| File | Extension | Issue |
|------|-----------|-------|
| `TypeFamilies/type-family-function-instance.hs` | TypeFamilies | Function class instance with type family syntax |
| `QuantifiedConstraints/constraint-operators.hs` | QuantifiedConstraints | Constraint operators (|-) and (&) |
| `TypeOperators/constraint-operator-class.hs` | TypeOperators | Multi-parameter constraint operator class |
| `TypeOperators/type-compose-constraint.hs` | TypeOperators | Backtick type operator applied in class context |
| `Layout/duplicate-where.hs` | (none) | Duplicate where clauses |
| `ViewPatterns/nested-view-pattern-lambda.hs` | ViewPatterns | Deeply nested view patterns in lambda |
| `DerivingVia/deriving-via-mvector.hs` | DerivingVia, StandaloneDeriving | Standalone deriving via with MVector constraints |

## Progress

- Oracle test count: 898 → 905 (+7 xfail cases)
- All tests pass (xfail cases correctly marked as expected failures)