### PR TITLE
fix(parser): accept incomplete case expression with empty alternatives

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -653,7 +653,7 @@ caseExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkKeywordCase
   scrutinee <- region "while parsing case expression" exprParser
   expectedTok TkKeywordOf
-  alts <- bracedAlts <|> plainAlts
+  alts <- bracedAlts <|> plainAlts <|> pure []
   pure (ECase scrutinee alts)
   where
     plainAlts = plainSemiSep1 caseAltParser

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Declarations/incomplete-case.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Declarations/incomplete-case.hs
@@ -1,3 +1,3 @@
-{- ORACLE_TEST xfail Incomplete case expression -}
+{- ORACLE_TEST pass -}
 instance Cls T1 where
   val = case val of


### PR DESCRIPTION
## Root Cause

The parser's `caseExprParser` required at least one case alternative after `case x of`. It tried two paths:
- `bracedAlts`: requires explicit `{...}` braces — fails without them
- `plainAlts`: calls `plainSemiSep1`, requiring ≥1 alternative — fails on empty body

With no fallback, `case val of` (no alternatives) produced a parse error.

GHC recovers from this by accepting zero alternatives (representing the case body as `{}`), so the oracle considered GHC's output valid while our parser rejected it — causing the xfail.

## Solution

Add `<|> pure []` as a final fallback in `caseExprParser`:

```haskell
-- Before
alts <- bracedAlts <|> plainAlts

-- After
alts <- bracedAlts <|> plainAlts <|> pure []
```

The `ECase` constructor already accepts `[CaseAlt]` (an empty list is structurally valid), so no AST changes were needed.

## Changes

- `src/Aihc/Parser/Internal/Expr.hs`: add `<|> pure []` fallback in `caseExprParser`
- `test/Test/Fixtures/oracle/Declarations/incomplete-case.hs`: promote from `xfail` to `pass`

## Testing

All 1519 tests pass, including the now-promoted `Declarations/incomplete-case` oracle test.