### PR TITLE
fix(parser): accept parenthesized operator names in class declaration heads

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1285,7 +1285,7 @@ classHeadParser =
   MP.try infixDeclHeadParser <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
-      name <- constructorUnqualifiedNameParser
+      name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
       params <- MP.many declTypeParamParser
       pure (TypeHeadPrefix, name, params)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/constraint-operator-class.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/constraint-operator-class.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects multi-parameter constraint operator in class head -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ConstraintKinds #-}
 


### PR DESCRIPTION
## Root Cause

The `classHeadParser` in `Decl.hs:1287` only accepted `constructorUnqualifiedNameParser` for prefix-form class names, which only matches uppercase-starting identifiers (`TkConId` tokens like `Eq`, `Functor`). It did not allow parenthesized operator names like `(:&&:)`.

In contrast, `typeDeclHeadParser` already supported this via `constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser` (line 1197), and several other declaration forms (role annotations, GADT constructors, instance heads, deriving heads) similarly accept parenthesized operators.

## Solution

Added `<|> parens operatorUnqualifiedNameParser` to `classHeadParser`'s `prefixDeclHeadParser`, matching the existing pattern used in `typeDeclHeadParser` and other declaration parsers. This correctly parses class declarations of the form:

```haskell
class (c1 a, c2 a) => (:&&:) c1 c2 a
```

This is valid Haskell syntax (accepted by GHC's parser) with `TypeOperators` and `ConstraintKinds` enabled.

## Changes

- **`Decl.hs`**: Added `<|> parens operatorUnqualifiedNameParser` alternative to `classHeadParser.prefixDeclHeadParser`
- **`constraint-operator-class.hs`**: Updated oracle test from `xfail` to `pass`

All 1519 tests pass, including the promoted xfail case.