### PR TITLE
fix(parser): support type namespace in import/export member lists

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Import.hs
@@ -241,4 +241,5 @@ exportImportNamespaceParser =
 
 bundledNamespaceParser :: TokParser IEBundledNamespace
 bundledNamespaceParser =
-  expectedTok TkKeywordData >> pure IEBundledNamespaceData
+  (expectedTok TkKeywordType >> pure IEBundledNamespaceType)
+    <|> (expectedTok TkKeywordData >> pure IEBundledNamespaceData)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -222,6 +222,7 @@ prettyMemberNamespacePrefix namespace =
 prettyMemberNamespace :: IEBundledNamespace -> Doc ann
 prettyMemberNamespace namespace =
   case namespace of
+    IEBundledNamespaceType -> "type"
     IEBundledNamespaceData -> "data"
 
 prettyDeclLines :: Decl -> [Doc ann]

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -203,6 +203,7 @@ docIENamespace namespace =
 docIEBundledNamespace :: IEBundledNamespace -> Doc ann
 docIEBundledNamespace namespace =
   case namespace of
+    IEBundledNamespaceType -> docText "type"
     IEBundledNamespaceData -> docText "data"
 
 docExportMember :: IEBundledMember -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -867,7 +867,8 @@ data IEEntityNamespace
   deriving (Data, Eq, Show, Generic, NFData)
 
 data IEBundledNamespace
-  = IEBundledNamespaceData
+  = IEBundledNamespaceType
+  | IEBundledNamespaceData
   deriving (Data, Eq, Show, Generic, NFData)
 
 data IEBundledMember = IEBundledMember

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/multiline-import-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/multiline-import-type-family.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Multi-line import with TypeFamilies -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 import Generic.Data.Function.FoldMap.Constructor
   ( GFoldMapC(gFoldMapC)

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -199,11 +199,12 @@ instance Arbitrary IEEntityNamespace where
       IEEntityNamespaceData -> [IEEntityNamespaceType]
 
 instance Arbitrary IEBundledNamespace where
-  arbitrary = pure IEBundledNamespaceData
+  arbitrary = elements [IEBundledNamespaceType, IEBundledNamespaceData]
 
   shrink namespace =
     case namespace of
-      IEBundledNamespaceData -> []
+      IEBundledNamespaceType -> []
+      IEBundledNamespaceData -> [IEBundledNamespaceType]
 
 instance Arbitrary ImportSpec where
   arbitrary =
@@ -431,7 +432,8 @@ genMemberNamespace :: Gen (Maybe IEBundledNamespace)
 genMemberNamespace =
   frequency
     [ (4, pure Nothing),
-      (1, pure (Just IEBundledNamespaceData))
+      (1, pure (Just IEBundledNamespaceData)),
+      (1, pure (Just IEBundledNamespaceType))
     ]
 
 genUnqualifiedVarName :: Gen UnqualifiedName


### PR DESCRIPTION
## Root Cause

`bundledNamespaceParser` only accepted the `data` keyword, not `type`. When parsing `GenericFoldMap(type GenericFoldMapM)`, the `type` keyword inside the member list was lexed as `TkKeywordType` but never consumed by the namespace parser, causing a parse error. The `IEBundledNamespace` type only had `IEBundledNamespaceData`, lacking a `Type` variant.

## Solution

Add `IEBundledNamespaceType` constructor to `IEBundledNamespace` and update `bundledNamespaceParser` to accept both `type` and `data` keywords. This mirrors the existing `IEEntityNamespace` which already has both `Type` and `Data` constructors. All consumers (Pretty, Shorthand, Arbitrary) updated accordingly.

## Changes

- **Syntax.hs**: Add `IEBundledNamespaceType` constructor to `IEBundledNamespace`
- **Import.hs**: Update `bundledNamespaceParser` to accept `TkKeywordType` → `IEBundledNamespaceType`
- **Pretty.hs**: Add `IEBundledNamespaceType -> "type"` case
- **Shorthand.hs**: Add `IEBundledNamespaceType -> docText "type"` case
- **Arb/Module.hs**: Update `Arbitrary IEBundledNamespace` and `genMemberNamespace` to include `IEBundledNamespaceType`
- **oracle fixture**: Promote `multiline-import-type-family.hs` from `xfail` to `pass`

## Progress

- Oracle xfail progress: **−1** (promoted to pass)