### PR TITLE
fix(parser): accept optional 'instance' keyword in instance body family declarations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -470,10 +470,13 @@ classDefaultTypeInstShorthandParser = withSpanAnn (ClassItemAnn . mkAnnotation) 
 -- ---------------------------------------------------------------------------
 -- TypeFamilies: instance body items
 
--- | Parse @type LhsType = RhsType@ inside an instance body (no @instance@ keyword here).
+-- | Parse @type [instance] LhsType = RhsType@ inside an instance body.
+-- The @instance@ keyword is accepted but optional (GHC normalizes both forms
+-- to the same AST, so we treat them identically).
 instanceTypeFamilyInstParser :: TokParser InstanceDeclItem
 instanceTypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
+  _ <- MP.optional (expectedTok TkKeywordInstance)
   forallBinders <- forallPrefixDispatch typeFamilyForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
@@ -487,10 +490,12 @@ instanceTypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
           typeFamilyInstRhs = rhs
         }
 
--- | Parse @data HeadType = Cons | ...@ (or GADT style) inside an instance body.
+-- | Parse @data [instance] HeadType = Cons | ...@ (or GADT style) inside an instance body.
+-- The @instance@ keyword is accepted but optional.
 instanceDataFamilyInstParser :: TokParser InstanceDeclItem
 instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
+  _ <- MP.optional (expectedTok TkKeywordInstance)
   (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
@@ -514,10 +519,12 @@ instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
       derivingClauses <- MP.many derivingClauseParser
       pure (constructors, derivingClauses)
 
--- | Parse @newtype HeadType = Constructor@ inside an instance body.
+-- | Parse @newtype [instance] HeadType = Constructor@ inside an instance body.
+-- The @instance@ keyword is accepted but optional.
 instanceNewtypeFamilyInstParser :: TokParser InstanceDeclItem
 instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
+  _ <- MP.optional (expectedTok TkKeywordInstance)
   (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   expectedTok TkReservedEquals

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/data-instance-in-class-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/data-instance-in-class-instance.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+
+module DataInstanceInClassInstance where
+
+import qualified Data.Map as Map
+
+class Lookupable v where
+    data Lookup v a
+
+instance Lookupable (Map.Map k v) where
+    data instance Lookup (Map.Map k v) a = LookupResult (Maybe a)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/newtype-instance-in-class-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/newtype-instance-in-class-instance.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+
+module NewtypeInstanceInClassInstance where
+
+import qualified Data.Map as Map
+
+class Wrappable v where
+    type Wrap v a
+
+instance Wrappable (Map.Map k v) where
+    newtype instance Wrap (Map.Map k v) a = WrapResult (Maybe a)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-function-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-function-instance.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects type family instance with Function class syntax -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 
 module TypeFamilyFunctionInstance where


### PR DESCRIPTION
## Root Cause

The parser's instance body item parsers (`instanceTypeFamilyInstParser`, `instanceDataFamilyInstParser`, `instanceNewtypeFamilyInstParser`) only accepted `type`, `data`, and `newtype` respectively — without the optional `instance` keyword that GHC also accepts inside class instance bodies.

GHC treats `type instance`, `data instance`, and `newtype instance` inside instance bodies as valid (the `instance` keyword is redundant but accepted, and normalized away in the AST). The parser rejected these forms, causing a parse error on valid Haskell input.

## Solution

Added `_ <- MP.optional (expectedTok TkKeywordInstance)` after the initial keyword in each of the three instance body parsers. This matches the pattern already used in the class body (`classDefaultTypeInstParser`), which explicitly consumes `type instance`.

The `instance` keyword is optional — both `type F a = Int` and `type instance F a = Int` produce identical AST nodes. This mirrors GHC's own normalization, which drops the redundant `instance` in its AST output, ensuring roundtrip fingerprint tests pass.

## Changes

- `instanceTypeFamilyInstParser`: Accept optional `instance` after `type`
- `instanceDataFamilyInstParser`: Accept optional `instance` after `data`
- `instanceNewtypeFamilyInstParser`: Accept optional `instance` after `newtype`
- Converted `type-family-function-instance.hs` oracle test from `xfail` to `pass`
- Added `data-instance-in-class-instance.hs` oracle test (pass)
- Added `newtype-instance-in-class-instance.hs` oracle test (pass)

## Progress

- TypeFamilies: +3 pass (1 xfail → pass, 2 new pass fixtures)