### PR TITLE
feat(parser): support local fixity declarations in where and let clauses

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -4,6 +4,7 @@
 
 module Aihc.Parser.Internal.Decl
   ( declParser,
+    fixityDeclParser,
     pragmaDeclParser,
   )
 where
@@ -815,17 +816,18 @@ instanceDeclItemParser = do
   maybe ordinaryInstanceDeclItemParser pure mPragmaItem
 
 ordinaryInstanceDeclItemParser :: TokParser InstanceDeclItem
-ordinaryInstanceDeclItemParser =
-  instanceFixityItemParser
-    <|> instanceFixityItemParser
-    <|> instanceFixityItemParser
-    <|> instanceTypeFamilyInstParser
-    <|> instanceDataFamilyInstParser
-    <|> instanceNewtypeFamilyInstParser
-    <|> ( do
-            isSig <- startsWithTypeSig
-            if isSig then instanceTypeSigItemParser else instanceValueItemParser
-        )
+ordinaryInstanceDeclItemParser = do
+  tok <- lookAhead anySingle
+  case lexTokenKind tok of
+    TkKeywordInfix -> instanceFixityItemParser
+    TkKeywordInfixl -> instanceFixityItemParser
+    TkKeywordInfixr -> instanceFixityItemParser
+    TkKeywordData -> instanceDataFamilyInstParser
+    TkKeywordNewtype -> instanceNewtypeFamilyInstParser
+    TkKeywordType -> instanceTypeFamilyInstParser
+    _ -> do
+      isSig <- startsWithTypeSig
+      if isSig then instanceTypeSigItemParser else instanceValueItemParser
 
 instancePragmaItemParser :: TokParser InstanceDeclItem
 instancePragmaItemParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -29,7 +29,7 @@ where
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
-import Aihc.Parser.Internal.Decl (declParser, pragmaDeclParser)
+import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser)
 import Aihc.Parser.Internal.Pattern (appPatternParser, patternParser, simplePatternParser)
 import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeHeadInfixParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
@@ -967,6 +967,9 @@ localDeclsParser = do
           tok <- lookAhead anySingle
           case lexTokenKind tok of
             TkImplicitParam {} -> pure <$> implicitParamDeclParser
+            TkKeywordInfix -> pure <$> fixityDeclParser Infix
+            TkKeywordInfixl -> pure <$> fixityDeclParser InfixL
+            TkKeywordInfixr -> pure <$> fixityDeclParser InfixR
             _ -> pure <$> (MP.try localFunctionDeclParser <|> localPatternDeclParser)
 
 localTypeSigDeclsParser :: TokParser [Decl]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ExtendedLiterals/custom-operator-hash.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ExtendedLiterals/custom-operator-hash.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail ExtendedLiterals with custom operator -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ExtendedLiterals #-}
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-let.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-let.hs
@@ -1,0 +1,2 @@
+{- ORACLE_TEST pass -}
+main = let { infixl 7 *%; x = 5 *% 3 *% 2 } in x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-multi-ops.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-multi-ops.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+f x = x .>. (y .<. z)
+  where
+    infixl 4 .>., .<.
+    (.>.) = (>)
+    (.<.) = (<)
+    y = 10
+    z = 5

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-multiple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-multiple.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+f x y = x .+. y
+  where
+    infixl 6 .+.
+    infixr 5 .*.
+    (.+.) a b = a + b
+    (.*.) a b = a * b

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LocalFixity/local-infix-where.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Local infix operator in where clause -}
+{- ORACLE_TEST pass -}
 instance FromHttpApiData (BackendKey DB.MongoContext) where
     parseUrlPiece input = do
       MongoKey <$> readTextData s


### PR DESCRIPTION
## Summary

- **Root cause**: `localDeclsParser` in `Expr.hs` had no dispatch cases for `TkKeywordInfix`/`Infixl`/`Infixr`, causing local fixity declarations inside `where` clauses and `let` bindings to fall through to function/pattern binding parsing and fail with a parse error.
- **Fix**: Added fixity keyword dispatch to `localDeclsParser`, routing to the existing `fixityDeclParser`. This mirrors how `ordinaryClassDeclItemParser` and `ordinaryDeclParser` already handle these tokens.
- **Side fix**: Corrected `ordinaryInstanceDeclItemParser` which had `instanceFixityItemParser` duplicated three times in the `<|>` chain. Replaced with proper token-based dispatch matching the class parser pattern.

## Changes

- `Expr.hs`: Add `TkKeywordInfix`/`Infixl`/`Infixr` cases to `localDeclsParser`; import `fixityDeclParser` from `Decl`
- `Decl.hs`: Export `fixityDeclParser`; fix `ordinaryInstanceDeclItemParser` dispatch (was: 3x duplicate `instanceFixityItemParser <|>`; now: proper `lookAhead` + `case`)
- `local-infix-where.hs`: `xfail` → `pass` (was the target test)
- `custom-operator-hash.hs`: `xfail` → `pass` (same root cause — local fixity in where clause)
- Added 3 new `LocalFixity` oracle test fixtures: `local-infix-let`, `local-infix-multiple`, `local-infix-multi-ops`

## Test results

All 1522 tests pass (was: 2 failures before this fix).

Progress: +2 pass (local-infix-where, custom-operator-hash), previously xfail.