### PR TITLE
fix: use token end line for layout BOL detection

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -342,7 +342,7 @@ layoutTransition st tok =
               else layoutPrevTokenEndSpan stAfterToken
           stNext =
             stAfterToken
-              { layoutPrevLine = Just (tokenStartLine tok),
+              { layoutPrevLine = Just (tokenEndLine tok),
                 layoutPrevTokenKind = Just (lexTokenKind tok),
                 layoutPrevTokenEndSpan = newEndSpan,
                 layoutBuffer = []

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -35,6 +35,7 @@ module Aihc.Parser.Lex.Types
     advanceN,
     consumeWhile,
     tokenStartLine,
+    tokenEndLine,
     tokenStartCol,
     virtualSymbolToken,
   )
@@ -356,6 +357,12 @@ tokenStartLine :: LexToken -> Int
 tokenStartLine tok =
   case lexTokenSpan tok of
     SourceSpan {sourceSpanStartLine = line} -> line
+    NoSourceSpan -> 1
+
+tokenEndLine :: LexToken -> Int
+tokenEndLine tok =
+  case lexTokenSpan tok of
+    SourceSpan {sourceSpanEndLine = line} -> line
     NoSourceSpan -> 1
 
 tokenStartCol :: LexToken -> Int

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/string-gap-operator-continuation.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/string-gap-operator-continuation.yaml
@@ -1,0 +1,13 @@
+extensions: []
+input: |
+  module StringGapLayout where
+  f = "hello\
+      \world" ++ "!"
+ast: 'Module {name = "StringGapLayout", decls = [DeclValue (FunctionBind "f" [Match {headForm = Prefix, rhs = UnguardedRhs (EInfix (EString "helloworld") "++" (EString "!"))}])]}'
+status: pass
+comment: |
+  Operator continuation after a string gap must not trigger
+  premature layout closure. The string ends on the same line as
+  the operator, so no BOL processing should occur between them.
+  This tests that layout uses the end line (not start line) of
+  multi-line tokens for BOL detection.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/string-gap-where-layout.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/string-gap-where-layout.yaml
@@ -1,0 +1,17 @@
+extensions: []
+input: |
+  module StringGapWhere where
+  f = header ++ footer
+    where
+      header = "hello\
+               \world"
+      footer = "bye"
+ast: 'Module {name = "StringGapWhere", decls = [DeclValue (FunctionBind "f" [Match {headForm = Prefix, rhs = UnguardedRhs (EInfix (EVar "header") "++" (EVar "footer")) where [DeclValue (FunctionBind "header" [Match {headForm = Prefix, rhs = UnguardedRhs (EString "helloworld")}]), DeclValue (FunctionBind "footer" [Match {headForm = Prefix, rhs = UnguardedRhs (EString "bye")}])]}])]}'
+status: pass
+comment: |
+  String gap inside a where block must not trigger premature layout
+  closure. When a string literal with gaps spans multiple lines, the
+  next token after the closing quote may appear on the same line as
+  the string end but a different line from the string start. The
+  layout engine must use the end line of the previous token for BOL
+  detection, not the start line.

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/help-message-unicode-quote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/help-message-unicode-quote.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail String with Unicode quote -}
+{- ORACLE_TEST pass -}
 helpMessage :: Bool -- ^ 'True' when showing in a terminal.
             -> String -- ^ Executable program name.
             -> String


### PR DESCRIPTION
## Summary

- **Fix**: Changed layout BOL (beginning-of-line) detection to use the previous token's **end line** instead of its **start line** for `layoutPrevLine` tracking.
- **Root Cause**: When a string literal with gaps spans multiple lines (e.g., `"hello\n\\\n\"`), the lexer produces a single `TkString` token whose start line differs from its end line. The layout engine stored `tokenStartLine` in `layoutPrevLine`, so when the next token (e.g., `++`) appeared on the same line as the string's end but a different line from its start, `isBOL` incorrectly returned True, causing premature `}` insertion and a parse error.
- **Promotes oracle test**: `MultilineStrings/help-message-unicode-quote` from `xfail` to `pass`.
- **Adds golden tests**: `module/string-gap-operator-continuation.yaml` and `module/string-gap-where-layout.yaml` covering string-gap layout interactions.

## Root Cause Analysis

In `Aihc.Parser.Lex.Layout.layoutTransition` (line 345), `layoutPrevLine` was set to `tokenStartLine tok`. For multi-line tokens (string literals with gaps), this meant the layout engine compared the current token's start line against the previous token's **start** line, not its **end** line. When a string gap caused the string to start on line N and end on line M (M > N), and the next token appeared on line M, the BOL check `tokenStartLine tok > layoutPrevLine` evaluated `M > N` → True, incorrectly triggering layout closure.

The fix uses `tokenEndLine` instead, so the BOL check becomes `M > M` → False, correctly recognizing that the next token is a continuation on the same line as the previous token's end.

## Changes

| File | Change |
|------|--------|
| `Lex/Layout.hs:345` | `tokenStartLine tok` → `tokenEndLine tok` |
| `Lex/Types.hs` | Added `tokenEndLine` function and export |
| `oracle/MultilineStrings/help-message-unicode-quote.hs` | `xfail` → `pass` |
| `golden/module/string-gap-operator-continuation.yaml` | New test |
| `golden/module/string-gap-where-layout.yaml` | New test |

## Progress

- **Oracle tests**: xfail count decreased by 1 (Promotes: `MultilineStrings/help-message-unicode-quote`)
- **Golden tests**: +2 new passing tests