### PR TITLE
fix(parser): accept named type family result signature without injectivity

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -230,21 +230,24 @@ familyResultKindParser =
   MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
 
 -- | Parse an optional type family result signature. GHC admits either an unnamed
--- @:: Kind@ annotation or a named result variable with injectivity annotation,
--- such as @= r | r -> a@ or @= (r :: Type) | r -> a where ...@.
+-- @:: Kind@ annotation or a named result variable with optional injectivity annotation,
+-- such as @= r@, @= r | r -> a@, or @= (r :: Type) | r -> a where ...@.
 typeFamilyResultSigParser :: TokParser (Maybe TypeFamilyResultSig)
 typeFamilyResultSigParser =
-  MP.optional (kindSigParser <|> injectiveSigParser)
+  MP.optional (kindSigParser <|> namedSigParser)
   where
     kindSigParser =
       TypeFamilyKindSig <$> (expectedTok TkReservedDoubleColon *> typeParser)
 
-    injectiveSigParser = do
+    namedSigParser = do
       expectedTok TkReservedEquals
-      result <- injectiveResultBinderParser
-      TypeFamilyInjectiveSig result <$> typeFamilyInjectivityParser
+      result <- namedResultBinderParser
+      mInjectivity <- MP.optional typeFamilyInjectivityParser
+      pure $ case mInjectivity of
+        Just injectivity -> TypeFamilyInjectiveSig result injectivity
+        Nothing -> TypeFamilyTyVarSig result
 
-    injectiveResultBinderParser =
+    namedResultBinderParser =
       withSpan $
         ( do
             ident <- lowerIdentifierParser

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -638,6 +638,7 @@ addTypeFamilyResultSigParens :: TypeFamilyResultSig -> TypeFamilyResultSig
 addTypeFamilyResultSigParens sig =
   case sig of
     TypeFamilyKindSig kind -> TypeFamilyKindSig (addTypeParens kind)
+    TypeFamilyTyVarSig result -> TypeFamilyTyVarSig (addTyVarBinderParens result)
     TypeFamilyInjectiveSig result injectivity -> TypeFamilyInjectiveSig (addTyVarBinderParens result) injectivity
 
 addTypeFamilyEqParens :: TypeFamilyEq -> TypeFamilyEq

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1347,6 +1347,7 @@ prettyTypeFamilyDecl tf =
     familyKeywordPart False = []
     resultSigPart Nothing = []
     resultSigPart (Just (TypeFamilyKindSig k)) = ["::", prettyType k]
+    resultSigPart (Just (TypeFamilyTyVarSig result)) = ["=", prettyTyVarBinder result]
     resultSigPart (Just (TypeFamilyInjectiveSig result injectivity)) =
       ["=", prettyTyVarBinder result, "|", prettyTypeFamilyInjectivity injectivity]
     eqsPart Nothing = []
@@ -1416,6 +1417,7 @@ prettyAssocTypeFamilyDecl tf =
     familyKeywordPart False = []
     resultSigPart Nothing = []
     resultSigPart (Just (TypeFamilyKindSig k)) = ["::", prettyType k]
+    resultSigPart (Just (TypeFamilyTyVarSig result)) = ["=", prettyTyVarBinder result]
     resultSigPart (Just (TypeFamilyInjectiveSig result injectivity)) =
       ["=", prettyTyVarBinder result, "|", prettyTypeFamilyInjectivity injectivity]
 

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -447,6 +447,8 @@ docTypeFamilyResultSig :: TypeFamilyResultSig -> Doc ann
 docTypeFamilyResultSig sig =
   case sig of
     TypeFamilyKindSig kind -> "TypeFamilyKindSig" <+> parens (docType kind)
+    TypeFamilyTyVarSig result ->
+      "TypeFamilyTyVarSig" <+> braces (hsep (punctuate comma [field "result" (docTyVarBinder result)]))
     TypeFamilyInjectiveSig result injectivity ->
       "TypeFamilyInjectiveSig" <+> braces (hsep (punctuate comma [field "result" (docTyVarBinder result), field "injectivity" (docTypeFamilyInjectivity injectivity)]))
 

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1293,6 +1293,7 @@ data TypeFamilyDecl = TypeFamilyDecl
 
 data TypeFamilyResultSig
   = TypeFamilyKindSig Type
+  | TypeFamilyTyVarSig TyVarBinder
   | TypeFamilyInjectiveSig TyVarBinder TypeFamilyInjectivity
   deriving (Data, Eq, Show, Generic, NFData)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-unicode-quote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-family-unicode-quote.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Unicode quote in type family RHS -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -584,6 +584,7 @@ normalizeTypeFamilyResultSig :: TypeFamilyResultSig -> TypeFamilyResultSig
 normalizeTypeFamilyResultSig sig =
   case sig of
     TypeFamilyKindSig kind -> TypeFamilyKindSig (normalizeType kind)
+    TypeFamilyTyVarSig result -> TypeFamilyTyVarSig (normalizeTyVarBinder result)
     TypeFamilyInjectiveSig result injectivity ->
       TypeFamilyInjectiveSig (normalizeTyVarBinder result) injectivity
 


### PR DESCRIPTION
## Root Cause

The parser's `typeFamilyResultSigParser` only accepted two forms of type family result signatures:
1. `:: Kind` (unnamed kind annotation)
2. `= r | r -> a` (named result variable with injectivity annotation)

However, GHC also accepts a named result variable *without* an injectivity annotation:
```haskell
type family Map (f :: k -> l) (xs :: [k]) = (ys :: [l]) where
```

When the parser encountered `= (ys :: [l]) where`, it failed because `typeFamilyInjectivityParser` unconditionally expected a `|` token after the result binder.

## Solution

Added a new AST constructor `TypeFamilyTyVarSig TyVarBinder` to represent a named result variable without injectivity, and updated the parser to make the injectivity annotation optional after `= result`.

### Changes

- **`Syntax.hs`**: Added `TypeFamilyTyVarSig` constructor to `TypeFamilyResultSig`
- **`Internal/Decl.hs`**: Updated `typeFamilyResultSigParser` to produce `TypeFamilyTyVarSig` when no injectivity annotation follows the named result binder
- **`Pretty.hs`**: Added pretty-printing for `TypeFamilyTyVarSig`
- **`Shorthand.hs`**: Added shorthand rendering for `TypeFamilyTyVarSig`
- **`Parens.hs`**: Added paren insertion logic for `TypeFamilyTyVarSig`
- **`ExprHelpers.hs`**: Added normalization for `TypeFamilyTyVarSig`
- **`type-family-unicode-quote.hs`**: Changed `xfail` to `pass`

## Follow-up Work

None. This is a minimal, targeted fix that aligns the parser with GHC's accepted syntax.