### PR TITLE
fix(parser): accept deeply nested view patterns without redundant parens

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -325,12 +325,16 @@ listPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
 -- This is needed in delimited pattern contexts like list elements and record
 -- fields, where there is no surrounding pair of parens to disambiguate the
 -- view-pattern arrow from the enclosing syntax.
+--
+-- This parser is recursive so that deeply nested view patterns such as
+-- @expr1 -> expr2 -> pat@ are accepted without requiring explicit parentheses
+-- around each intermediate view pattern.
 subpatternWithBareViewParser :: TokParser Pattern
 subpatternWithBareViewParser = do
   mView <- MP.optional . MP.try $ do
     expr <- exprParser
     expectedTok TkReservedRightArrow
-    PView expr <$> patternParser
+    PView expr <$> subpatternWithBareViewParser
   maybe patternParser pure mView
 
 parenOrTuplePatternParser :: TokParser Pattern
@@ -382,7 +386,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
     viewPatternParser closeTok = MP.optional . MP.try $ do
       expr <- exprParser
       expectedTok TkReservedRightArrow
-      inner <- patternParser
+      inner <- subpatternWithBareViewParser
       expectedTok closeTok
       pure (PParen (PView expr inner))
 
@@ -468,7 +472,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
         Just (Left expr) -> do
           -- View pattern: expr -> pattern
           expectedTok TkReservedRightArrow
-          PView expr <$> patternParser
+          PView expr <$> subpatternWithBareViewParser
         Just (Right pat) ->
           pure pat
         Nothing ->

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1066,7 +1066,7 @@ addPatternParens pat =
     PCon con typeArgs args -> PCon con (map (addTypeIn CtxTypeAtom) typeArgs) (map addPatternAtomParens args)
     PInfix lhs op rhs -> PInfix (addPatternAtomParens lhs) op (addPatternAtomParens rhs)
     PView viewExpr inner ->
-      wrapPat True (PView (addViewExprParens viewExpr) (addPatternParens inner))
+      wrapPat True (PView (addViewExprParens viewExpr) (addPatternViewInnerParens inner))
     PAs name inner -> PAs name (addPatternAtomStrictParens inner)
     PStrict inner -> PStrict (addPatternAtomStrictParens inner)
     PIrrefutable inner -> PIrrefutable (addPatternAtomStrictParens inner)
@@ -1082,10 +1082,20 @@ addPatternParens pat =
 addPatternInDelimited :: Pattern -> Pattern
 addPatternInDelimited pat =
   case peelPatternAnn pat of
-    PView viewExpr inner -> PView (addViewExprParens viewExpr) (addPatternParens inner)
+    PView viewExpr inner -> PView (addViewExprParens viewExpr) (addPatternViewInnerParens inner)
     PAs name inner -> PAs name (addPatternAtomStrictParens inner)
     PStrict inner -> PStrict (addPatternAtomStrictParens inner)
     PIrrefutable inner -> PIrrefutable (addPatternAtomStrictParens inner)
+    _ -> addPatternParens pat
+
+-- | Add parens for a pattern nested inside a view pattern.
+-- Nested view patterns do not need extra parens.
+addPatternViewInnerParens :: Pattern -> Pattern
+addPatternViewInnerParens pat =
+  case pat of
+    PAnn sp sub -> PAnn sp (addPatternViewInnerParens sub)
+    PView viewExpr inner ->
+      PView (addViewExprParens viewExpr) (addPatternViewInnerParens inner)
     _ -> addPatternParens pat
 
 addViewExprParens :: Expr -> Expr

--- a/components/aihc-parser/test/Test/Fixtures/golden/pattern/deep-view-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pattern/deep-view-pattern.yaml
@@ -1,0 +1,5 @@
+extensions: [ViewPatterns]
+input: |
+  (a -> b -> c)
+ast: PParen (PView (EVar "a") (PView (EVar "b") (PVar "c")))
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/pattern/list-deep-view-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pattern/list-deep-view-pattern.yaml
@@ -1,0 +1,5 @@
+extensions: [ViewPatterns]
+input: |
+  [a -> b -> c]
+ast: PList [PView (EVar "a") (PView (EVar "b") (PVar "c"))]
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/nested-view-pattern-lambda.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/nested-view-pattern-lambda.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects deeply nested view patterns in lambda expression -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ViewPatterns #-}
 
 module NestedViewPatternLambda where


### PR DESCRIPTION
## Root Cause

The parser rejected deeply nested view patterns such as:

```haskell
(unLoc -> map unLoc -> ps)
```

because the inner `map unLoc -> ps` was parsed with `patternParser`, which does not support bare view patterns. View patterns were only handled in three specific contexts:

1. **Parenthesized patterns** — via `viewPatternParser`, which called `patternParser` for the inner pattern.
2. **List elements / record fields** — via `subpatternWithBareViewParser`, which supported a single top-level `expr -> pat` but called `patternParser` for the inner pattern, so nesting deeper than one level failed.
3. **Tuple elements** — via `exprThenReclassify`, which also called `patternParser` for the inner pattern.

Consequently, any view pattern containing another unparenthesized view pattern as its inner pattern would fail to parse.

## Solution

1. **Make `subpatternWithBareViewParser` recursive** — it now calls itself for the inner pattern instead of `patternParser`, enabling arbitrarily deep nesting like `a -> b -> c -> d`.

2. **Use `subpatternWithBareViewParser` in all view-pattern inner-pattern positions**:
   - `viewPatternParser` (parenthesized patterns)
   - `exprThenReclassify` (tuple elements)
   - `subpatternWithBareViewParser` itself (lists, record fields)

3. **Update `addPatternParens`** — added `addPatternViewInnerParens` so the pretty-printer does not wrap nested view patterns in redundant `PParen`. This preserves correct roundtrips for sources like `(a -> b -> c)`.

## Tradeoffs Considered

- **Global `patternParser` change**: Adding bare view-pattern support directly to `patternParser` would break case-alternative parsing (where `->` separates the pattern from the RHS), so the localized fix in delimited-context parsers is the correct approach.

- **Pretty-printer changes**: Without updating `addPatternParens`, parsing `(a -> b -> c)` and pretty-printing it would yield `(a -> (b -> c))`, causing roundtrip mismatches. The new `addPatternViewInnerParens` resolves this cleanly.

## Changes

- `components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs`
- `components/aihc-parser/src/Aihc/Parser/Parens.hs`
- `components/aihc-parser/test/Test/Fixtures/oracle/ViewPatterns/nested-view-pattern-lambda.hs` (xfail → pass)
- New golden tests:
  - `pattern/deep-view-pattern.yaml`
  - `pattern/list-deep-view-pattern.yaml`

## Test Results

- `just check` passes for `aihc-parser:spec` (1531 tests).
- The previously xfail oracle test `ViewPatterns/nested-view-pattern-lambda` now passes.

## Follow-up Work

None identified; the fix generalizes naturally to all delimited pattern contexts.
