### PR TITLE
fix(parser): do not close case-alternative layout on where

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -74,7 +74,7 @@ openPendingLayout st tok =
           case lexTokenKind tok of
             TkSpecialLBrace -> ([], st {layoutPendingLayout = Nothing}, False)
             TkReservedRightArrow -> ([], st {layoutPendingLayout = Nothing}, False)
-            _ -> openImplicitLayout LayoutOrdinary st tok
+            _ -> openImplicitLayout LayoutCaseAlternative st tok
         PendingImplicitLayout kind ->
           case lexTokenKind tok of
             TkSpecialLBrace -> ([], st {layoutPendingLayout = Nothing}, False)
@@ -121,7 +121,7 @@ closeBeforeToken st tok =
       TkKeywordThen -> closeBeforeThenElse
       TkKeywordElse -> closeBeforeThenElse
       TkKeywordWhere ->
-        closeImplicitLayouts (lexTokenSpan tok) (\indent _ -> tokenStartCol tok <= indent)
+        closeImplicitLayouts (lexTokenSpan tok) (\indent kind -> tokenStartCol tok <= indent && kind /= LayoutCaseAlternative)
       _ -> noLayoutClosures
   where
     closeBeforeThenElse =
@@ -161,7 +161,9 @@ bolLayout st tok
           eqSemi =
             case currentLayoutIndentMaybe contexts' of
               Just indent
-                | col == indent && currentLayoutAllowsSemicolon contexts' ->
+                | col == indent,
+                  currentLayoutAllowsSemicolon contexts',
+                  lexTokenKind tok /= TkKeywordWhere ->
                     [virtualSymbolToken ";" semiAnchor]
               _ -> []
        in (inserted <> eqSemi, st {layoutContexts = contexts'})
@@ -204,10 +206,10 @@ stepTokenContext st tok =
           st {layoutPendingLayout = Just (PendingImplicitLayout (LayoutAfterThenElse 0))}
       | otherwise -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordMdo -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
-    TkKeywordOf -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
+    TkKeywordOf -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutCaseAlternative)}
     TkKeywordCase
       | layoutPrevTokenKind st == Just TkReservedBackslash ->
-          st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
+          st {layoutPendingLayout = Just (PendingImplicitLayout LayoutCaseAlternative)}
       | otherwise -> st
     TkVarId "cases"
       | layoutPrevTokenKind st == Just TkReservedBackslash ->

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -225,6 +225,7 @@ data ImplicitLayoutKind
   | LayoutLetBlock
   | LayoutMultiWayIf
   | LayoutAfterThenElse !Int -- do-block opened directly by a preceding 'then'/'else'; tracks nested classic ifs inside the block
+  | LayoutCaseAlternative
   deriving (Eq, Show)
 
 data PendingLayout

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/duplicate-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/duplicate-where.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects duplicate where clauses -}
+{- ORACLE_TEST pass -}
 module DuplicateWhere where
 
 selectByEntity :: [Int] -> (String, String) -> Maybe String


### PR DESCRIPTION
## Root Cause

The layout engine's `closeBeforeToken` handler for `where` closed **all**
implicit layouts with `indent >= col`, including the `case`-alternative
context itself.  When a case alternative's `where` block ended and a
second `where` appeared at the enclosing binding's column, the engine
inserted a virtual `}` that terminated the alternative.  The parser then
saw orphaned `where` tokens and failed.

In the failing fixture the first `where` belongs to the case-alternative
RHS and the second `where` belongs to the function-binding RHS — each RHS
still has exactly one `where` clause.  The bug is purely in layout
token insertion.

## Solution

Layout-engine only (3 files, no AST or parser changes):

1. **Add `LayoutCaseAlternative`** as a new `ImplicitLayoutKind` so the
   engine can distinguish contexts opened by `of`, `\case`, and `\cases`.
2. **Keep `closeBeforeToken` for `where` from closing
   `LayoutCaseAlternative` contexts.**  The case context will be closed
   naturally by BOL layout once the alternative's own `where` block ends.
3. **Suppress semicolon insertion before `where` in `bolLayout`.**  A
   `where` keyword is always a subordinate layout item, never a peer item
   that needs a semicolon separator.

## Testing

- `Layout/duplicate-where.hs` changed from `xfail` to `pass`.
- `just check` passes cleanly (ormolu, hlint, full test suite with 1,529 tests).