### PR TITLE
fix(parser): allow variable-symbol operators in class, instance, and deriving heads

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -764,7 +764,7 @@ standaloneDerivingHeadParser =
     bareStandaloneDerivingHeadParser = MP.try infixStandaloneDerivingHeadParser <|> prefixStandaloneDerivingHeadParser
 
     prefixStandaloneDerivingHeadParser = do
-      className <- constructorNameParser <|> parens constructorOperatorParser
+      className <- constructorNameParser <|> parens operatorNameParser
       instanceTypes <- MP.many typeAtomParser
       pure (TypeHeadPrefix, className, instanceTypes)
 
@@ -792,7 +792,7 @@ instanceHeadParser =
     bareInstanceHeadParser = MP.try infixInstanceHeadParser <|> prefixInstanceHeadParser
 
     prefixInstanceHeadParser = do
-      className <- nameToUnqualified <$> (constructorNameParser <|> parens constructorOperatorParser)
+      className <- nameToUnqualified <$> (constructorNameParser <|> parens operatorNameParser)
       instanceTypes <- MP.many typeAtomParser
       pure (TypeHeadPrefix, className, instanceTypes)
 
@@ -1295,14 +1295,14 @@ classHeadParser =
 
     infixDeclHeadParser = do
       lhs <- declTypeParamParser
-      op <- constructorOperatorParser
+      op <- typeFamilyOperatorParser
       rhs <- declTypeParamParser
       pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs])
 
     parenthesizedInfixDeclHeadParser = do
       expectedTok TkSpecialLParen
       lhs <- declTypeParamParser
-      op <- constructorOperatorParser
+      op <- typeFamilyOperatorParser
       rhs <- declTypeParamParser
       expectedTok TkSpecialRParen
       tailParams <- MP.many declTypeParamParser

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -272,6 +272,7 @@ buildTests = do
             testCase "roundtrips abstract import items written as T()" test_emptyBundledImportRoundtrip,
             testCase "roundtrips symbolic bundled import members without unboxed tuple tokenization" test_symbolicBundledImportMemberRoundtrip,
             testCase "parses infix class heads" test_infixClassHeadParses,
+            testCase "parses infix class heads with variable-symbol operators" test_infixClassHeadVarSymParses,
             testCase "parses class operator type signatures in where blocks" test_classOperatorTypeSigParses,
             testCase "parses explicit associated type family declarations" test_explicitAssociatedTypeFamilyDeclParses,
             testCase "roundtrips explicit associated type family declarations with default signatures" test_explicitAssociatedTypeFamilyWithDefaultSignatureRoundtrip,
@@ -729,6 +730,24 @@ test_infixClassHeadParses =
         case map normalizeDecl (moduleDecls modu) of
           [ DeclFixity {},
             DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "b" Nothing TyVarBSpecified TyVarBVisible], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
+            ] -> pure ()
+          other -> assertFailure ("unexpected parsed declarations: " <> show other)
+
+test_infixClassHeadVarSymParses :: Assertion
+test_infixClassHeadVarSymParses =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE QuantifiedConstraints #-}",
+            "module M where",
+            "class (p => q) => p |- q",
+            "class (p, q) => p & q"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        case map normalizeDecl (moduleDecls modu) of
+          [ DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = "|-", classDeclParams = [TyVarBinder _ "p" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "q" Nothing TyVarBSpecified TyVarBVisible]},
+            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = "&", classDeclParams = [TyVarBinder _ "p" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "q" Nothing TyVarBSpecified TyVarBVisible]}
             ] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QuantifiedConstraints/constraint-operators.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QuantifiedConstraints/constraint-operators.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects multi-constraint class with (|-) and (&) operators -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE QuantifiedConstraints #-}
 
 module QuantifiedConstraintOperators where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/constraint-implication.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/constraint-implication.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Constraint implication -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeOperators, DataKinds #-}
 class (ks :: [(Type -> Type -> Type) -> Constraint]) |- (k :: (Type -> Type -> Type) -> Constraint) where
   implies :: Satisfies p ks => (k p => p a b) -> p a b


### PR DESCRIPTION
## Summary

Fixes the parser to accept variable-symbol operators (e.g. `|-`, `&`) as class names in infix class heads, and consistently allows them in parenthesized prefix instance and standalone-deriving heads. This aligns aihc-parser with GHC's deviation from the Haskell Language Report, where class names may be `con-id`, `con-sym`, or `var-sym` (but not `var-id`).

## Root Cause

`classHeadParser` used `constructorOperatorParser` for infix operators, which only accepts `con-sym` tokens (`TkConSym`, `TkQConSym`, `TkReservedColon`). GHC additionally permits `var-sym` tokens (e.g. `|-`, `&`) as class names. The same inconsistency existed in `prefixInstanceHeadParser` and `prefixStandaloneDerivingHeadParser`, which only accepted `constructorOperatorParser` inside parentheses.

## Solution

- `classHeadParser` infix forms: replaced `constructorOperatorParser` with `typeFamilyOperatorParser`, which already accepts both `var-sym` and `con-sym` tokens (it was introduced for type families, which share the same naming rules).
- `instanceHeadParser` prefix form: replaced `parens constructorOperatorParser` with `parens operatorNameParser`.
- `standaloneDerivingHeadParser` prefix form: same replacement as above.

## Changes

- `components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs`: widened operator parsers in class, instance, and standalone-deriving heads.
- `components/aihc-parser/test/Test/Fixtures/oracle/QuantifiedConstraints/constraint-operators.hs`: promoted from `xfail` to `pass`.
- `components/aihc-parser/test/Test/Fixtures/oracle/TypeLevelOperators/constraint-implication.hs`: promoted from `xfail` to `pass`.
- `components/aihc-parser/test/Spec.hs`: added `test_infixClassHeadVarSymParses` unit test covering `|-` and `&` infix class heads.

## Testing

- `just check` passes (format, lint, full test suite).
- All 1530 aihc-parser tests pass.
- Two previously failing oracle fixtures now parse and roundtrip successfully against GHC.

## Follow-up

None. The fix is complete and targeted.