### PR TITLE
fix(parser): parse singleton unboxed tuple types

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -398,9 +398,9 @@ typeParenOrTupleParser = withSpanAnn (TAnn . mkAnnotation) $ do
                   pure (TUnboxedSum (first : rest))
                 Nothing -> do
                   expectedTok closeTok
-                  if tupleFlavor == Boxed
-                    then pure (TParen first)
-                    else fail "not an unboxed tuple type"
+                  case tupleFlavor of
+                    Boxed -> pure (TParen first)
+                    Unboxed -> pure (TTuple Unboxed Unpromoted [first])
             Just () -> do
               second <- typeParser
               more <- MP.many (expectedTok TkSpecialComma *> typeParser)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/singleton-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/singleton-type.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedTuples #-}
+module SingletonType where
+
+f :: (# Int #) -> (# Int #)
+f (# x #) = (# x #)
+
+g :: (# "hello" #) -> (# "hello" #)
+g (# x #) = (# x #)
+
+h :: (# 42 #) -> (# 42 #)
+h (# x #) = (# x #)

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -397,7 +397,7 @@ genNewtypeCon =
 genNewtypePrefixCon :: Gen DataConDecl
 genNewtypePrefixCon = do
   conName <- genConUnqualifiedName
-  ty <- genSimpleType
+  ty <- genType
   pure (PrefixCon [] [] conName [BangType [] NoSourceUnpackedness False False ty])
 
 genNewtypeRecordCon :: Gen DataConDecl

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -19,6 +19,7 @@ import Test.Properties.Arb.Identifiers
     shrinkConIdent,
     shrinkIdent,
   )
+import Test.Properties.Arb.Utils (smallList0)
 import Test.QuickCheck
 
 instance Arbitrary Type where
@@ -178,7 +179,7 @@ genSimpleTypeAtom =
       pure TWildcard,
       TQuasiQuote <$> genQuoterName <*> genQuasiBody,
       TTuple Boxed Unpromoted <$> genTypeTupleElems,
-      TTuple Unboxed Unpromoted <$> genTypeTupleElems,
+      TTuple Unboxed Unpromoted <$> smallList0 genType,
       TUnboxedSum <$> genUnboxedSumElems,
       TList Unpromoted <$> genTypeListElems,
       TParen <$> genType
@@ -340,7 +341,7 @@ shrinkTypeTupleElems tupleFlavor elems =
   | shrunk <- shrinkList shrinkType elems,
     candidate <- case shrunk of
       [] -> [TTuple tupleFlavor Unpromoted []]
-      [_] -> []
+      [_] | tupleFlavor == Boxed -> []
       _ -> [TTuple tupleFlavor Unpromoted shrunk]
   ]
 


### PR DESCRIPTION
## Summary

- Fix parser to accept singleton unboxed tuple types like `(# Int #)`, `(# "hello" #)`, and `(# 42 #)`
- Update type generators and shrinkers to properly handle singleton unboxed tuples in property tests
- Add regression oracle test file `singleton-type.hs` covering singleton unboxed tuple types with various type literals

## Changes

The type parser was incorrectly rejecting singleton unboxed tuples with the error "not an unboxed tuple type". The fix allows `(# Type #)` to parse as `TTuple Unboxed Unpromoted [Type]`, matching GHC's behavior.

The arbitrary type generator was also updated to generate singleton unboxed tuples (previously they were excluded), and the shrinker was updated to avoid shrinking boxed singletons to empty tuples while still allowing unboxed singletons.

## Test Coverage

- All 1533 parser tests pass
- New oracle test: `UnboxedTuples/singleton-type.hs`