### PR TITLE
feat(tc): support case expressions

### DIFF
--- a/components/aihc-parser-cli/src/Aihc/Parser/Run.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Run.hs
@@ -32,7 +32,6 @@ import Aihc.Parser.Syntax
     parseExtensionSettingName,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Data.ByteString qualified as BS
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
@@ -168,7 +167,7 @@ runLexMode extensionSettings stdin =
 
 -- | Resolve all include requests in a CPP step, returning the final result.
 resolveCppStep :: Map FilePath Text -> Step -> Result
-resolveCppStep includeMap (Done result) = result
+resolveCppStep _ (Done result) = result
 resolveCppStep includeMap (NeedInclude req k) =
   let resolved = resolveInclude includeMap req
    in resolveCppStep includeMap (k (fmap TE.encodeUtf8 resolved))

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Constraint generation for expressions.
 --
@@ -15,7 +16,8 @@ module Aihc.Tc.Generate.Expr
 where
 
 import Aihc.Parser.Syntax
-  ( CaseAlt (..),
+  ( Annotation,
+    CaseAlt (..),
     Expr (..),
     LambdaCaseAlt (..),
     Name (..),
@@ -23,6 +25,7 @@ import Aihc.Parser.Syntax
     Rhs (..),
     SourceSpan (..),
     UnqualifiedName (..),
+    fromAnnotation,
     getExprSourceSpan,
   )
 import Aihc.Tc.Constraint
@@ -30,6 +33,7 @@ import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Instantiate (instantiate)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -59,6 +63,8 @@ inferExpr expr = case expr of
   EApp fun arg -> inferApp (getExprSourceSpan expr) fun arg
   -- If-then-else
   EIf cond thenE elseE -> inferIf (getExprSourceSpan expr) cond thenE elseE
+  -- Case expression
+  ECase scrutinee alts -> inferCase (getExprSourceSpan expr) scrutinee alts
   -- Let expression
   ELetDecls _decls body -> do
     -- MVP: infer body only (let bindings not yet processed).
@@ -136,6 +142,18 @@ inferLambdaCase sp alts = do
   cts <- inferCaseAlts sp argTy resTy alts
   pure (TcFunTy argTy resTy, cts)
 
+-- | Infer the type of a case expression.
+--
+-- @case scrutinee of { pat1 -> e1; pat2 -> e2; ... }@ is inferred by
+-- checking each alternative against the scrutinee type and unifying all
+-- branch result types with a fresh result type.
+inferCase :: SourceSpan -> Expr -> [CaseAlt] -> TcM (TcType, [Ct])
+inferCase sp scrutinee alts = do
+  (scrutTy, scrutCts) <- inferExpr scrutinee
+  resTy <- freshMetaTv
+  altCts <- inferCaseAlts sp scrutTy resTy alts
+  pure (resTy, scrutCts ++ altCts)
+
 inferLambdaCases :: SourceSpan -> [LambdaCaseAlt] -> TcM (TcType, [Ct])
 inferLambdaCases sp alts = do
   let arity = maximum (0 : map (length . lambdaCaseAltPats) alts)
@@ -151,15 +169,17 @@ inferLambdaCases sp alts = do
 inferCaseAlts :: SourceSpan -> TcType -> TcType -> [CaseAlt] -> TcM [Ct]
 inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
   where
-    inferAlt (CaseAlt _altSp pat rhs) = do
+    inferAlt (CaseAlt altAnns pat rhs) = do
+      let altSp = sourceSpanFromAnns altAnns
+          branchSp = combineSourceSpan altSp sp
       let bindings = extractPatternBindings (pat, scrutTy)
       -- Emit constraint: pattern's constructor result type ~ scrutinee type.
-      patCts <- inferPatternConstraints sp scrutTy pat
+      patCts <- inferPatternConstraints branchSp scrutTy pat
       -- Infer the RHS under the pattern bindings.
       (rhsTy, rhsCts) <- withPatternBindings bindings (inferRhs rhs)
       -- RHS must match the expected result type.
       ev <- freshEvVar
-      let rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
+      let rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (CaseBranchOrigin branchSp) branchSp
       pure (patCts ++ rhsCts ++ [rhsCt])
 
 inferLambdaCaseAlt :: SourceSpan -> [TcType] -> TcType -> LambdaCaseAlt -> TcM [Ct]
@@ -204,6 +224,16 @@ inferPatternConstraints sp scrutTy pat = case pat of
 resultType :: TcType -> TcType
 resultType (TcFunTy _ res) = resultType res
 resultType ty = ty
+
+sourceSpanFromAnns :: [Annotation] -> SourceSpan
+sourceSpanFromAnns anns =
+  case mapMaybe (fromAnnotation @SourceSpan) anns of
+    [] -> NoSourceSpan
+    sp : _ -> sp
+
+combineSourceSpan :: SourceSpan -> SourceSpan -> SourceSpan
+combineSourceSpan NoSourceSpan fallback = fallback
+combineSourceSpan span' _ = span'
 
 -- | Infer the type of a right-hand side (for case alternatives).
 inferRhs :: Rhs -> TcM (TcType, [Ct])

--- a/components/aihc-tc/test/Test/Fixtures/golden/case-expression.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/case-expression.yaml
@@ -11,5 +11,5 @@ expected:
   - "True :: Bool"
   - "False :: Bool"
   - "f :: Bool -> Bool"
-status: xfail
-reason: "case expressions not yet supported in type checker"
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Fixtures/golden/case-variable-pattern.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/case-variable-pattern.yaml
@@ -10,5 +10,5 @@ expected:
   - "True :: Bool"
   - "False :: Bool"
   - "f :: forall a. a -> a"
-status: xfail
-reason: "case with variable pattern not yet supported"
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -20,6 +20,7 @@ tcTests =
     "tc-unit"
     [ testGroup "literals" literalTests,
       testGroup "application" applicationTests,
+      testGroup "case" caseTests,
       testGroup "if-then-else" ifTests,
       testGroup "lambda" lambdaTests,
       testGroup "variables" variableTests,
@@ -112,6 +113,15 @@ ifTests =
       let result = tc "if True then 1 else 2"
       let ty = tcResultType result
       assertBool "should produce a type" (ty /= TcMetaTv (Unique (-1)))
+  ]
+
+-- | Tests for case expressions.
+caseTests :: [TestTree]
+caseTests =
+  [ testCase "case expression threads scrutinee type into branches" $ do
+      let result = tc "\\x -> case x of { y -> y }"
+      assertBool "should succeed" (tcResultSuccess result)
+      assertBool "should be function type" (isFunTy (tcResultType result))
   ]
 
 -- | Tests for lambda expressions.


### PR DESCRIPTION
## Summary
- add direct `case ... of` inference in `aihc-tc` by reusing the existing alternative-checking path
- mark the constructor-pattern and variable-pattern case golden fixtures as passing and add a focused unit test
- remove two parser-cli warnings that were blocking `just check` under `-Werror`

## Why
`lambda-case` already had branch inference, but plain `case` still fell through the unsupported-expression path in the type checker. That left straightforward case expressions stuck as expected failures.

## Progress
- TC progress: `9/28` (`32.14%`) -> `11/28` (`39.28%`)
- Newly passing fixtures: `case-expression.yaml`, `case-variable-pattern.yaml`

## Validation
- `cabal test -v0 spec --test-options=--hide-successes` (in `components/aihc-tc`)
- `just fmt`
- `just check`

## CodeRabbit
- attempted `coderabbit review --prompt-only`, but it did not return a review result in this environment, so I skipped it and proceeded with the PR
