### PR TITLE
refactor(parser): deduplicate parsing patterns across Type, Expr, Decl, and Common modules

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -31,6 +31,7 @@ module Aihc.Parser.Internal.Common
     sourceSpanFromPositions,
     parens,
     braces,
+    thQuoteParser,
     skipSemicolons,
     bracedSemiSep,
     bracedSemiSep1,
@@ -44,6 +45,7 @@ module Aihc.Parser.Internal.Common
     functionBindValue,
     functionBindDecl,
     isExtensionEnabled,
+    thAnyEnabled,
     closeImplicitLayout,
     layoutSepEndBy,
     layoutSepBy1,
@@ -441,6 +443,16 @@ braces parser = do
   closeAndExpectRBrace
   pure res
 
+-- | Parse a delimited construct with an annotation wrapper.
+-- Used for Template Haskell quotes: @open body close@.
+thQuoteParser :: (SourceSpan -> c -> c) -> LexTokenKind -> LexTokenKind -> TokParser a -> (a -> c) -> TokParser c
+thQuoteParser ann openTok closeTok bodyParser ctor =
+  withSpanAnn ann $ do
+    expectedTok openTok
+    body <- bodyParser
+    expectedTok closeTok
+    pure (ctor body)
+
 -- | Expect a @}@ token, closing implicit layout contexts if needed.
 -- This implements the parse-error rule for closing braces: if @}@ is not found
 -- but there is an implicit layout context, close it (which buffers a virtual @}@)
@@ -710,6 +722,13 @@ isExtensionEnabled :: Extension -> TokParser Bool
 isExtensionEnabled ext = do
   pst <- MP.getParserState
   pure (ext `elem` tokStreamExtensions (MP.stateInput pst))
+
+-- | Check whether any Template Haskell extension is enabled (quotes or full TH).
+thAnyEnabled :: TokParser Bool
+thAnyEnabled = do
+  thEnabled <- isExtensionEnabled TemplateHaskellQuotes
+  thFullEnabled <- isExtensionEnabled TemplateHaskell
+  pure (thEnabled || thFullEnabled)
 
 -- | Signal to the layout engine that a virtual close brace should be inserted.
 -- This implements the parse-error rule: when the parser encounters a token that

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -6,6 +6,7 @@ module Aihc.Parser.Internal.Decl
   ( declParser,
     fixityDeclParser,
     pragmaDeclParser,
+    typeSigDeclParser,
   )
 where
 
@@ -42,9 +43,7 @@ declParser = do
 ordinaryDeclParser :: TokParser Decl
 ordinaryDeclParser = do
   (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
-  thEnabled <- isExtensionEnabled TemplateHaskellQuotes
-  thFullEnabled <- isExtensionEnabled TemplateHaskell
-  let thAny = thEnabled || thFullEnabled
+  thAny <- thAnyEnabled
   let tokKind = lexTokenKind tok
       nextTokKind = lexTokenKind nextTok
       valueOrSpliceParser =
@@ -200,25 +199,12 @@ contextPrefixDispatch = do
 
 -- | Like 'contextPrefixDispatch' but returns @[]@ instead of @Nothing@.
 contextPrefixDispatchList :: TokParser [Type]
-contextPrefixDispatchList = do
-  hasContext <- startsWithContextType
-  if hasContext
-    then declContextParser <* expectedTok TkReservedDoubleArrow
-    else pure []
+contextPrefixDispatchList = fromMaybe [] <$> contextPrefixDispatch
 
--- | Parse an optional explicit forall for type family instances/equations.
--- Handles @forall a (b :: Kind).@ syntax.
-typeFamilyForallParser :: TokParser [TyVarBinder]
-typeFamilyForallParser = do
-  expectedTok TkKeywordForall
-  binders <- MP.some explicitForallBinderParser
-  expectedTok (TkVarSym ".")
-  pure binders
-
--- | Parse an optional explicit forall for instance heads.
--- Handles @forall a (b :: Kind).@ syntax.
-instanceForallParser :: TokParser [TyVarBinder]
-instanceForallParser = do
+-- | Parse an explicit forall telescope: @forall a (b :: Kind).@.
+-- Used for type family instances, data family instances, and instance heads.
+explicitForallParser :: TokParser [TyVarBinder]
+explicitForallParser = do
   expectedTok TkKeywordForall
   binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
@@ -287,15 +273,12 @@ typeFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
 
 -- | Parse the @where { eq; ... }@ block of a closed type family.
 closedTypeFamilyWhereParser :: TokParser [TypeFamilyEq]
-closedTypeFamilyWhereParser =
-  whereClauseItemsParser
-    (bracedSemiSep typeFamilyEqParser)
-    (plainSemiSep1 typeFamilyEqParser)
+closedTypeFamilyWhereParser = whereClauseItemsParser typeFamilyEqParser
 
 -- | Parse one closed type family equation: @[forall binders.] LhsType = RhsType@
 typeFamilyEqParser :: TokParser TypeFamilyEq
 typeFamilyEqParser = withSpan $ do
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  forallBinders <- forallPrefixDispatch explicitForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
   rhs <- typeParser
@@ -335,7 +318,7 @@ typeFamilyInstParser :: TokParser Decl
 typeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   expectedTok TkKeywordInstance
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  forallBinders <- forallPrefixDispatch explicitForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
   rhs <- typeParser
@@ -353,10 +336,10 @@ dataFamilyInstParser :: TokParser Decl
 dataFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   expectedTok TkKeywordInstance
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  forallBinders <- forallPrefixDispatch explicitForallParser
   (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
-  (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
+  (constructors, derivingClauses) <- gadtDataDeclParser <|> traditionalDataDeclParser
   pure $
     DeclDataFamilyInst
       DataFamilyInst
@@ -367,26 +350,17 @@ dataFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           dataFamilyInstConstructors = constructors,
           dataFamilyInstDeriving = derivingClauses
         }
-  where
-    traditionalStyleDataDecl = do
-      constructors <- MP.optional (expectedTok TkReservedEquals *> dataConDeclParser `MP.sepBy1` expectedTok TkReservedPipe)
-      derivingClauses <- MP.many derivingClauseParser
-      pure (fromMaybe [] constructors, derivingClauses)
-    gadtStyleDataDecl = do
-      constructors <- gadtWhereClauseParser
-      derivingClauses <- MP.many derivingClauseParser
-      pure (constructors, derivingClauses)
 
 -- | Parse @newtype instance [forall binders.] HeadType = Constructor@
 newtypeFamilyInstParser :: TokParser Decl
 newtypeFamilyInstParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
   expectedTok TkKeywordInstance
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  forallBinders <- forallPrefixDispatch explicitForallParser
   (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   expectedTok TkReservedEquals
-  constructor <- newtypeConDeclParser
+  constructor <- dataConDeclParser
   derivingClauses <- MP.many derivingClauseParser
   pure $
     DeclDataFamilyInst
@@ -427,29 +401,18 @@ classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
 
 -- | Parse @type instance LhsType = RhsType@ as a default type family instance in a class.
 classDefaultTypeInstParser :: TokParser ClassDeclItem
-classDefaultTypeInstParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
-  expectedTok TkKeywordType
-  expectedTok TkKeywordInstance
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
-  (headForm, lhs) <- typeFamilyLhsParser
-  expectedTok TkReservedEquals
-  rhs <- typeParser
-  pure
-    ( ClassItemDefaultTypeInst
-        TypeFamilyInst
-          { typeFamilyInstForall = forallBinders,
-            typeFamilyInstHeadForm = headForm,
-            typeFamilyInstLhs = lhs,
-            typeFamilyInstRhs = rhs
-          }
-    )
+classDefaultTypeInstParser = classDefaultTypeInstParser' True
 
 -- | Parse @type [forall binders.] LhsType = RhsType@ as a shorthand default
 -- associated type instance in a class body.
 classDefaultTypeInstShorthandParser :: TokParser ClassDeclItem
-classDefaultTypeInstShorthandParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
+classDefaultTypeInstShorthandParser = classDefaultTypeInstParser' False
+
+classDefaultTypeInstParser' :: Bool -> TokParser ClassDeclItem
+classDefaultTypeInstParser' requireInstance = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  when requireInstance (expectedTok TkKeywordInstance)
+  forallBinders <- forallPrefixDispatch explicitForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
   rhs <- typeParser
@@ -473,7 +436,7 @@ instanceTypeFamilyInstParser :: TokParser InstanceDeclItem
 instanceTypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   _ <- MP.optional (expectedTok TkKeywordInstance)
-  forallBinders <- forallPrefixDispatch typeFamilyForallParser
+  forallBinders <- forallPrefixDispatch explicitForallParser
   (headForm, lhs) <- typeFamilyLhsParser
   expectedTok TkReservedEquals
   rhs <- typeParser
@@ -494,7 +457,7 @@ instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   _ <- MP.optional (expectedTok TkKeywordInstance)
   (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
-  (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
+  (constructors, derivingClauses) <- gadtDataDeclParser <|> traditionalDataDeclParser
   pure $
     InstanceItemDataFamilyInst
       DataFamilyInst
@@ -505,15 +468,6 @@ instanceDataFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
           dataFamilyInstConstructors = constructors,
           dataFamilyInstDeriving = derivingClauses
         }
-  where
-    traditionalStyleDataDecl = do
-      constructors <- MP.optional (expectedTok TkReservedEquals *> dataConDeclParser `MP.sepBy1` expectedTok TkReservedPipe)
-      derivingClauses <- MP.many derivingClauseParser
-      pure (fromMaybe [] constructors, derivingClauses)
-    gadtStyleDataDecl = do
-      constructors <- gadtWhereClauseParser
-      derivingClauses <- MP.many derivingClauseParser
-      pure (constructors, derivingClauses)
 
 -- | Parse @newtype [instance] HeadType = Constructor@ inside an instance body.
 -- The @instance@ keyword is accepted but optional.
@@ -524,7 +478,7 @@ instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $
   (_, head') <- typeFamilyLhsParser
   kind <- familyResultKindParser
   expectedTok TkReservedEquals
-  constructor <- newtypeConDeclParser
+  constructor <- dataConDeclParser
   derivingClauses <- MP.many derivingClauseParser
   pure $
     InstanceItemDataFamilyInst
@@ -636,18 +590,12 @@ classFundepParser = withSpan $ do
       }
 
 classWhereClauseParser :: TokParser [ClassDeclItem]
-classWhereClauseParser = whereClauseItemsParser classItemsBracedParser classItemsPlainParser
+classWhereClauseParser = whereClauseItemsParser classDeclItemParser
 
-whereClauseItemsParser :: TokParser [item] -> TokParser [item] -> TokParser [item]
-whereClauseItemsParser bracedParser plainParser = do
+whereClauseItemsParser :: TokParser a -> TokParser [a]
+whereClauseItemsParser itemParser = do
   expectedTok TkKeywordWhere
-  bracedParser <|> plainParser <|> pure []
-
-classItemsPlainParser :: TokParser [ClassDeclItem]
-classItemsPlainParser = plainSemiSep1 classDeclItemParser
-
-classItemsBracedParser :: TokParser [ClassDeclItem]
-classItemsBracedParser = bracedSemiSep classDeclItemParser
+  bracedSemiSep itemParser <|> plainSemiSep1 itemParser <|> pure []
 
 classDeclItemParser :: TokParser ClassDeclItem
 classDeclItemParser = do
@@ -676,10 +624,7 @@ classPragmaItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   pure (ClassItemPragma pragma)
 
 classTypeSigItemParser :: TokParser ClassDeclItem
-classTypeSigItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
-  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
-  expectedTok TkReservedDoubleColon
-  ClassItemTypeSig names <$> typeParser
+classTypeSigItemParser = typeSigItemParser (ClassItemAnn . mkAnnotation) ClassItemTypeSig
 
 classDefaultSigItemParser :: TokParser ClassDeclItem
 classDefaultSigItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
@@ -689,21 +634,17 @@ classDefaultSigItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   ClassItemDefaultSig name <$> typeParser
 
 classFixityItemParser :: TokParser ClassDeclItem
-classFixityItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
-  (assoc, prec, mNamespace, ops) <- fixityDeclPartsParser
-  pure (ClassItemFixity assoc mNamespace prec ops)
+classFixityItemParser = fixityItemParser (ClassItemAnn . mkAnnotation) ClassItemFixity
 
 classDefaultItemParser :: TokParser ClassDeclItem
-classDefaultItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
-  ClassItemDefault . functionBindValue headForm name pats <$> equationRhsParser
+classDefaultItemParser = valueItemParser (ClassItemAnn . mkAnnotation) ClassItemDefault
 
 instanceDeclParser :: TokParser Decl
 instanceDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordInstance
   overlapPragma <- MP.optional instanceOverlapPragmaParser
   warningText <- MP.optional warningTextParser
-  forallBinders <- MP.optional instanceForallParser
+  forallBinders <- MP.optional explicitForallParser
   context <- contextPrefixDispatch
   (parenthesizedHead, headForm, className, instanceTypes) <- instanceHeadParser
   items <- MP.option [] instanceWhereClauseParser
@@ -729,7 +670,7 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordInstance
   overlapPragma <- MP.optional instanceOverlapPragmaParser
   warningText <- MP.optional warningTextParser
-  forallBinders <- MP.optional instanceForallParser
+  forallBinders <- MP.optional explicitForallParser
   context <- contextPrefixDispatch
   (parenthesizedHead, headForm, className, instanceTypes) <- standaloneDerivingHeadParser
   pure $
@@ -747,36 +688,25 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           standaloneDerivingTypes = instanceTypes
         }
 
-standaloneDerivingHeadParser :: TokParser (Bool, TypeHeadForm, Name, [Type])
-standaloneDerivingHeadParser =
-  MP.try
-    ( do
-        parsed <- parens bareStandaloneDerivingHeadParser
-        _ <- MP.notFollowedBy (lookAhead typeInfixOperatorParser)
-        let (headForm, className, instanceTypes) = parsed
-        pure (True, headForm, className, instanceTypes)
-    )
-    <|> ( do
-            (headForm, className, instanceTypes) <- bareStandaloneDerivingHeadParser
-            pure (False, headForm, className, instanceTypes)
-        )
+-- | Shared helper for parsing instance / standalone deriving heads.
+-- Returns the parenthesized flag, head form, class name (as 'Name'), and argument types.
+bareInstanceHeadParser :: TokParser (TypeHeadForm, Name, [Type])
+bareInstanceHeadParser = MP.try infixHeadParser <|> prefixHeadParser
   where
-    bareStandaloneDerivingHeadParser = MP.try infixStandaloneDerivingHeadParser <|> prefixStandaloneDerivingHeadParser
-
-    prefixStandaloneDerivingHeadParser = do
+    prefixHeadParser = do
       className <- constructorNameParser <|> parens operatorNameParser
       instanceTypes <- MP.many typeAtomParser
       pure (TypeHeadPrefix, className, instanceTypes)
 
-    infixStandaloneDerivingHeadParser = do
+    infixHeadParser = do
       lhs <- typeAtomParser
       _ <- lookAhead typeInfixOperatorParser
       op <- typeFamilyOperatorParser
       rhs <- typeAtomParser
       pure (TypeHeadInfix, op, [lhs, rhs])
 
-instanceHeadParser :: TokParser (Bool, TypeHeadForm, UnqualifiedName, [Type])
-instanceHeadParser =
+standaloneDerivingHeadParser :: TokParser (Bool, TypeHeadForm, Name, [Type])
+standaloneDerivingHeadParser =
   MP.try
     ( do
         parsed <- parens bareInstanceHeadParser
@@ -788,29 +718,15 @@ instanceHeadParser =
             (headForm, className, instanceTypes) <- bareInstanceHeadParser
             pure (False, headForm, className, instanceTypes)
         )
+
+instanceHeadParser :: TokParser (Bool, TypeHeadForm, UnqualifiedName, [Type])
+instanceHeadParser = fmap mapName standaloneDerivingHeadParser
   where
-    bareInstanceHeadParser = MP.try infixInstanceHeadParser <|> prefixInstanceHeadParser
-
-    prefixInstanceHeadParser = do
-      className <- nameToUnqualified <$> (constructorNameParser <|> parens operatorNameParser)
-      instanceTypes <- MP.many typeAtomParser
-      pure (TypeHeadPrefix, className, instanceTypes)
-
-    infixInstanceHeadParser = do
-      lhs <- typeAtomParser
-      _ <- lookAhead typeInfixOperatorParser
-      op <- typeFamilyOperatorParser
-      rhs <- typeAtomParser
-      pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs])
+    mapName (parenthesized, headForm, className, instanceTypes) =
+      (parenthesized, headForm, nameToUnqualified className, instanceTypes)
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]
-instanceWhereClauseParser = whereClauseItemsParser instanceItemsBracedParser instanceItemsPlainParser
-
-instanceItemsPlainParser :: TokParser [InstanceDeclItem]
-instanceItemsPlainParser = plainSemiSep1 instanceDeclItemParser
-
-instanceItemsBracedParser :: TokParser [InstanceDeclItem]
-instanceItemsBracedParser = bracedSemiSep instanceDeclItemParser
+instanceWhereClauseParser = whereClauseItemsParser instanceDeclItemParser
 
 instanceDeclItemParser :: TokParser InstanceDeclItem
 instanceDeclItemParser = do
@@ -837,20 +753,32 @@ instancePragmaItemParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
   pure (InstanceItemPragma pragma)
 
 instanceTypeSigItemParser :: TokParser InstanceDeclItem
-instanceTypeSigItemParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
-  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
-  expectedTok TkReservedDoubleColon
-  InstanceItemTypeSig names <$> typeParser
+instanceTypeSigItemParser = typeSigItemParser (InstanceItemAnn . mkAnnotation) InstanceItemTypeSig
 
 instanceFixityItemParser :: TokParser InstanceDeclItem
-instanceFixityItemParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
-  (assoc, prec, mNamespace, ops) <- fixityDeclPartsParser
-  pure (InstanceItemFixity assoc mNamespace prec ops)
+instanceFixityItemParser = fixityItemParser (InstanceItemAnn . mkAnnotation) InstanceItemFixity
 
 instanceValueItemParser :: TokParser InstanceDeclItem
-instanceValueItemParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
+instanceValueItemParser = valueItemParser (InstanceItemAnn . mkAnnotation) InstanceItemBind
+
+-- ---------------------------------------------------------------------------
+-- Shared class/instance item helpers
+
+typeSigItemParser :: (SourceSpan -> a -> a) -> ([UnqualifiedName] -> Type -> a) -> TokParser a
+typeSigItemParser ann ctor = withSpanAnn ann $ do
+  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
+  expectedTok TkReservedDoubleColon
+  ctor names <$> typeParser
+
+fixityItemParser :: (SourceSpan -> a -> a) -> (FixityAssoc -> Maybe IEEntityNamespace -> Maybe Int -> [UnqualifiedName] -> a) -> TokParser a
+fixityItemParser ann ctor = withSpanAnn ann $ do
+  (assoc, prec, mNamespace, ops) <- fixityDeclPartsParser
+  pure (ctor assoc mNamespace prec ops)
+
+valueItemParser :: (SourceSpan -> a -> a) -> (ValueDecl -> a) -> TokParser a
+valueItemParser ann ctor = withSpanAnn ann $ do
   (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
-  InstanceItemBind . functionBindValue headForm name pats <$> equationRhsParser
+  ctor . functionBindValue headForm name pats <$> equationRhsParser
 
 foreignDeclParser :: TokParser Decl
 foreignDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
@@ -906,6 +834,18 @@ foreignEntityFromString txt
   | Just rest <- T.stripPrefix "&" txt = ForeignEntityAddress (Just rest)
   | otherwise = ForeignEntityNamed txt
 
+traditionalDataDeclParser :: TokParser ([DataConDecl], [DerivingClause])
+traditionalDataDeclParser = do
+  constructors <- MP.optional (expectedTok TkReservedEquals *> dataConDeclParser `MP.sepBy1` expectedTok TkReservedPipe)
+  derivingClauses <- MP.many derivingClauseParser
+  pure (fromMaybe [] constructors, derivingClauses)
+
+gadtDataDeclParser :: TokParser ([DataConDecl], [DerivingClause])
+gadtDataDeclParser = do
+  constructors <- gadtWhereClauseParser
+  derivingClauses <- MP.many derivingClauseParser
+  pure (constructors, derivingClauses)
+
 dataDeclParser :: TokParser Decl
 dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
@@ -914,7 +854,7 @@ dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
-  (constructors, derivingClauses) <- gadtStyleDataDecl <|> traditionalStyleDataDecl
+  (constructors, derivingClauses) <- gadtDataDeclParser <|> traditionalDataDeclParser
   pure $
     DeclData
       DataDecl
@@ -926,16 +866,6 @@ dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           dataDeclConstructors = constructors,
           dataDeclDeriving = derivingClauses
         }
-  where
-    traditionalStyleDataDecl = do
-      constructors <- MP.optional (expectedTok TkReservedEquals *> dataConDeclParser `MP.sepBy1` expectedTok TkReservedPipe)
-      derivingClauses <- MP.many derivingClauseParser
-      pure (fromMaybe [] constructors, derivingClauses)
-
-    gadtStyleDataDecl = do
-      constructors <- gadtWhereClauseParser
-      derivingClauses <- MP.many derivingClauseParser
-      pure (constructors, derivingClauses)
 
 -- | Parse a @type data@ declaration.
 -- Similar to @data@ but with restrictions:
@@ -1008,13 +938,7 @@ typeDataConArgParser = BangType [] NoSourceUnpackedness False False <$> typeAtom
 -- | Parse GADT-style constructors for type data (after `where`)
 -- No labelled fields, no strictness annotations
 gadtTypeDataWhereClauseParser :: TokParser [DataConDecl]
-gadtTypeDataWhereClauseParser = whereClauseItemsParser gadtTypeDataConsBracedParser gadtTypeDataConsPlainParser
-
-gadtTypeDataConsPlainParser :: TokParser [DataConDecl]
-gadtTypeDataConsPlainParser = plainSemiSep1 gadtTypeDataConDeclParser
-
-gadtTypeDataConsBracedParser :: TokParser [DataConDecl]
-gadtTypeDataConsBracedParser = bracedSemiSep gadtTypeDataConDeclParser
+gadtTypeDataWhereClauseParser = whereClauseItemsParser gadtTypeDataConDeclParser
 
 -- | Parse a GADT constructor for type data
 -- Only equality constraints permitted, no strictness, no records
@@ -1077,7 +1001,7 @@ newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
         }
   where
     traditionalStyleNewtypeDecl = do
-      constructor <- MP.optional (expectedTok TkReservedEquals *> newtypeConDeclParser)
+      constructor <- MP.optional (expectedTok TkReservedEquals *> dataConDeclParser)
       derivingClauses <- MP.many derivingClauseParser
       pure (constructor, derivingClauses)
 
@@ -1090,20 +1014,9 @@ newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           pure (Just ctor, derivingClauses)
         _ -> fail "newtype must have exactly one constructor"
 
-newtypeConDeclParser :: TokParser DataConDecl
-newtypeConDeclParser = withSpan $ do
-  (forallVars, context) <- dataConQualifiersParser
-  MP.try (dataConRecordOrPrefixParser forallVars context) <|> dataConInfixParser forallVars context
-
 -- | Parse GADT-style constructors after 'where'
 gadtWhereClauseParser :: TokParser [DataConDecl]
-gadtWhereClauseParser = whereClauseItemsParser gadtConsBracedParser gadtConsPlainParser
-
-gadtConsPlainParser :: TokParser [DataConDecl]
-gadtConsPlainParser = plainSemiSep1 gadtConDeclParser
-
-gadtConsBracedParser :: TokParser [DataConDecl]
-gadtConsBracedParser = bracedSemiSep gadtConDeclParser
+gadtWhereClauseParser = whereClauseItemsParser gadtConDeclParser
 
 -- | Parse a GADT constructor declaration: @Con1, Con2 :: forall a. Ctx => Type@
 gadtConDeclParser :: TokParser DataConDecl
@@ -1659,10 +1572,7 @@ patSynDirAndPatParser name =
 -- | Parse the where clause of an explicitly bidirectional pattern synonym.
 -- @where { Name pats = expr; ... }@
 patSynWhereClauseParser :: Text -> TokParser [Match]
-patSynWhereClauseParser _name =
-  whereClauseItemsParser
-    (bracedSemiSep patSynWhereMatch)
-    (plainSemiSep1 patSynWhereMatch)
+patSynWhereClauseParser _name = whereClauseItemsParser patSynWhereMatch
 
 -- | Parse one equation in a pattern synonym where clause.
 patSynWhereMatch :: TokParser Match

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -29,7 +29,7 @@ where
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
-import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser)
+import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser, typeSigDeclParser)
 import Aihc.Parser.Internal.Pattern (appPatternParser, patternParser, simplePatternParser)
 import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeHeadInfixParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
@@ -40,6 +40,24 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
+
+-- | Parse an expression, then optionally consume @<-@ and a right-hand side.
+-- If the arrow is present, the expression is converted to a pattern via
+-- 'checkPattern' and the result is a bind; otherwise it is an expression.
+exprOrPatternBindParser ::
+  TokParser Expr ->
+  TokParser Expr ->
+  (Pattern -> Expr -> a) ->
+  (Expr -> a) ->
+  TokParser a
+exprOrPatternBindParser exprP rhsP bindCtor exprCtor = do
+  expr <- exprP
+  mArrow <- MP.optional (expectedTok TkReservedLeftArrow)
+  case mArrow of
+    Just () -> do
+      pat <- liftCheck (checkPattern expr)
+      bindCtor pat <$> rhsP
+    Nothing -> pure (exprCtor expr)
 
 exprParser :: TokParser Expr
 exprParser =
@@ -325,30 +343,27 @@ tokenExprParser expected matchToken =
   withSpanAnn (EAnn . mkAnnotation) (tokenSatisfy expected matchToken)
 
 charExprParser :: TokParser Expr
-charExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  (ctor, c, repr) <- tokenSatisfy "character literal" $ \tok ->
+charExprParser =
+  tokenExprParser "character literal" $ \tok ->
     case lexTokenKind tok of
-      TkChar x -> Just (EChar, x, lexTokenText tok)
-      TkCharHash x txt -> Just (ECharHash, x, txt)
+      TkChar x -> Just (EChar x (lexTokenText tok))
+      TkCharHash x txt -> Just (ECharHash x txt)
       _ -> Nothing
-  pure (ctor c repr)
 
 stringExprParser :: TokParser Expr
-stringExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  (ctor, s, repr) <- tokenSatisfy "string literal" $ \tok ->
+stringExprParser =
+  tokenExprParser "string literal" $ \tok ->
     case lexTokenKind tok of
-      TkString x -> Just (EString, x, lexTokenText tok)
-      TkStringHash x txt -> Just (EStringHash, x, txt)
+      TkString x -> Just (EString x (lexTokenText tok))
+      TkStringHash x txt -> Just (EStringHash x txt)
       _ -> Nothing
-  pure (ctor s repr)
 
 overloadedLabelExprParser :: TokParser Expr
-overloadedLabelExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  (labelName, raw) <- tokenSatisfy "overloaded label" $ \tok ->
+overloadedLabelExprParser =
+  tokenExprParser "overloaded label" $ \tok ->
     case lexTokenKind tok of
-      TkOverloadedLabel lbl repr -> Just (lbl, repr)
+      TkOverloadedLabel lbl repr -> Just (EOverloadedLabel lbl repr)
       _ -> Nothing
-  pure (EOverloadedLabel labelName raw)
 
 appExprParser :: TokParser Expr
 appExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
@@ -425,11 +440,9 @@ recordFieldBindingParser = withSpan $ do
 atomExprParser :: TokParser Expr
 atomExprParser = do
   blockArgsEnabled <- isExtensionEnabled BlockArguments
-  thEnabled <- isExtensionEnabled TemplateHaskellQuotes
-  thFullEnabled <- isExtensionEnabled TemplateHaskell
+  thAny <- thAnyEnabled
   explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
   requiredTypeArgumentsEnabled <- isExtensionEnabled RequiredTypeArguments
-  let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkImplicitParam {} -> implicitParamExprParser
@@ -593,15 +606,13 @@ guardQualifierParser arrowKind = do
 -- (which includes @->@), while 'RhsArrowCase' uses 'typeInfixParser' (which
 -- does not), matching GHC's behaviour.
 guardBindOrExprParser :: RhsArrowKind -> TokParser GuardQualifier
-guardBindOrExprParser arrowKind = withSpanAnn (GuardAnn . mkAnnotation) $ do
-  expr <- exprParserWithTypeSigParser (guardTypeSigParser arrowKind)
-  mArrow <- MP.optional (expectedTok TkReservedLeftArrow)
-  case mArrow of
-    Just () -> do
-      pat <- liftCheck (checkPattern expr)
-      GuardPat pat <$> exprParser
-    Nothing ->
-      pure (GuardExpr expr)
+guardBindOrExprParser arrowKind =
+  withSpanAnn (GuardAnn . mkAnnotation) $
+    exprOrPatternBindParser
+      (exprParserWithTypeSigParser (guardTypeSigParser arrowKind))
+      exprParser
+      GuardPat
+      GuardExpr
 
 guardPatBindParser :: TokParser GuardQualifier
 guardPatBindParser = withSpanAnn (GuardAnn . mkAnnotation) $ do
@@ -894,16 +905,9 @@ compStmtParser = do
         else compGenOrGuardParser
 
 compGenOrGuardParser :: TokParser CompStmt
-compGenOrGuardParser = withSpanAnn (CompAnn . mkAnnotation) $ do
-  expr <- exprParser
-  mArrow <- MP.optional (expectedTok TkReservedLeftArrow)
-  case mArrow of
-    Just () -> do
-      pat <- liftCheck (checkPattern expr)
-      rhs <- region "while parsing '<-' generator" exprParser
-      pure (CompGen pat rhs)
-    Nothing ->
-      pure (CompGuard expr)
+compGenOrGuardParser =
+  withSpanAnn (CompAnn . mkAnnotation) $
+    exprOrPatternBindParser exprParser (region "while parsing '<-' generator" exprParser) CompGen CompGuard
 
 compPatGenParser :: TokParser CompStmt
 compPatGenParser = withSpanAnn (CompAnn . mkAnnotation) $ do
@@ -970,11 +974,11 @@ localDeclsParser = do
 
 localTypeSigDeclsParser :: TokParser [Decl]
 localTypeSigDeclsParser = do
-  sig <- localTypeSigDeclParser
+  sig <- typeSigDeclParser
   let (names, ty) =
         case peelDeclAnn sig of
           DeclTypeSig sigNames sigTy -> (sigNames, sigTy)
-          _ -> error "localTypeSigDeclParser must produce DeclTypeSig"
+          _ -> error "typeSigDeclParser must produce DeclTypeSig"
   mEq <- MP.optional (expectedTok TkReservedEquals)
   case mEq of
     Nothing -> pure [sig]
@@ -989,12 +993,6 @@ localTypeSigDeclsParser = do
           pure [DeclValue (PatternBind pat rhs)]
         _ ->
           fail "local typed bindings with '=' require exactly one binder"
-
-localTypeSigDeclParser :: TokParser Decl
-localTypeSigDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
-  expectedTok TkReservedDoubleColon
-  DeclTypeSig names <$> typeParser
 
 localFunctionDeclParser :: TokParser Decl
 localFunctionDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
@@ -1042,39 +1040,19 @@ thQuoteExprParser =
     <|> thPatQuoteParser
 
 thExpQuoteParser :: TokParser Expr
-thExpQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  expectedTok TkTHExpQuoteOpen
-  body <- exprParser
-  expectedTok TkTHExpQuoteClose
-  pure (ETHExpQuote body)
+thExpQuoteParser = thQuoteParser (EAnn . mkAnnotation) TkTHExpQuoteOpen TkTHExpQuoteClose exprParser ETHExpQuote
 
 thTypedQuoteParser :: TokParser Expr
-thTypedQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  expectedTok TkTHTypedQuoteOpen
-  body <- exprParser
-  expectedTok TkTHTypedQuoteClose
-  pure (ETHTypedQuote body)
+thTypedQuoteParser = thQuoteParser (EAnn . mkAnnotation) TkTHTypedQuoteOpen TkTHTypedQuoteClose exprParser ETHTypedQuote
 
 thDeclQuoteParser :: TokParser Expr
-thDeclQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  expectedTok TkTHDeclQuoteOpen
-  decls <- bracedSemiSep declParser <|> plainSemiSep declParser
-  expectedTok TkTHExpQuoteClose
-  pure (ETHDeclQuote decls)
+thDeclQuoteParser = thQuoteParser (EAnn . mkAnnotation) TkTHDeclQuoteOpen TkTHExpQuoteClose (bracedSemiSep declParser <|> plainSemiSep declParser) ETHDeclQuote
 
 thTypeQuoteParser :: TokParser Expr
-thTypeQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  expectedTok TkTHTypeQuoteOpen
-  ty <- typeParser
-  expectedTok TkTHExpQuoteClose
-  pure (ETHTypeQuote ty)
+thTypeQuoteParser = thQuoteParser (EAnn . mkAnnotation) TkTHTypeQuoteOpen TkTHExpQuoteClose typeParser ETHTypeQuote
 
 thPatQuoteParser :: TokParser Expr
-thPatQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  expectedTok TkTHPatQuoteOpen
-  pat <- patternParser
-  expectedTok TkTHExpQuoteClose
-  pure (ETHPatQuote pat)
+thPatQuoteParser = thQuoteParser (EAnn . mkAnnotation) TkTHPatQuoteOpen TkTHExpQuoteClose patternParser ETHPatQuote
 
 thUntypedSpliceParser :: TokParser Expr
 thUntypedSpliceParser = withSpanAnn (EAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -106,12 +106,10 @@ buildPatternApp lhs rhs =
 -- which belong to the @lpat@ level ('appPatternParser').
 patternAtomParser :: TokParser Pattern
 patternAtomParser = do
-  thEnabled <- isExtensionEnabled TemplateHaskellQuotes
-  thFullEnabled <- isExtensionEnabled TemplateHaskell
+  thAny <- thAnyEnabled
   explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
   requiredTypeArgumentsEnabled <- isExtensionEnabled RequiredTypeArguments
   typeAbstractionsEnabled <- isExtensionEnabled TypeAbstractions
-  let thAny = thEnabled || thFullEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkTypeApp

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -215,10 +215,8 @@ applyTypeAppArg fn (Right ty) = TApp fn ty
 
 typeAtomParser :: TokParser Type
 typeAtomParser = do
-  thEnabled <- isExtensionEnabled TemplateHaskellQuotes
-  thFullEnabled <- isExtensionEnabled TemplateHaskell
+  thAny <- thAnyEnabled
   ipEnabled <- isExtensionEnabled ImplicitParams
-  let thAny = thEnabled || thFullEnabled
   MP.try promotedTypeParser
     <|> typeLiteralTypeParser
     <|> typeQuasiQuoteParser


### PR DESCRIPTION
## Summary

This PR reduces code duplication and complexity across the parser internals by extracting shared combinators and merging near-identical parser definitions.

### Changes

- **Extract `thAnyEnabled` to Common.hs** — Replaces the repeated `thEnabled || thFullEnabled` pattern in Type.hs, Expr.hs, Decl.hs, and Pattern.hs.
- **Merge forall parsers** — `typeFamilyForallParser` and `instanceForallParser` were byte-for-byte identical; merged into `explicitForallParser` in Decl.hs.
- **Extract `thQuoteParser` combinator** — All five Template Haskell quote parsers in Expr.hs shared the same `withSpanAnn (EAnn . mkAnnotation) *> expectedTok open *> body *> expectedTok close` structure. Replaced with a single parameterized combinator in Common.hs.
- **Unify `tokenExprParser` usage** — `charExprParser`, `stringExprParser`, and `overloadedLabelExprParser` in Expr.hs reimplemented the same `withSpanAnn` + `tokenSatisfy` logic manually. Now they all use `tokenExprParser`.
- **Generalize `whereClauseItemsParser`** — Eliminated 8 trivial `bracedSemiSep itemParser` / `plainSemiSep1 itemParser` wrapper definitions by accepting the item parser directly.
- **Export `typeSigDeclParser` from Decl.hs** — Removed the duplicate `localTypeSigDeclParser` from Expr.hs.
- **Parameterize `classDefaultTypeInstParser`** — Merged `classDefaultTypeInstParser` and `classDefaultTypeInstShorthandParser` into one parameterized parser.
- **Extract shared class/instance item helpers** — `fixityItemParser`, `typeSigItemParser`, and `valueItemParser` deduplicate the near-identical class and instance fixity / type-sig / value parsers.
- **Extract `exprOrPatternBindParser` combinator** — `compGenOrGuardParser` and `guardBindOrExprParser` shared the same expression-then-optional-arrow pattern. Extracted into Expr.hs.
- **Simplify `contextPrefixDispatchList`** — Defined as `fromMaybe [] <$> contextPrefixDispatch` instead of duplicating the body.
- **Remove duplicate `newtypeConDeclParser`** — Was identical to `dataConDeclParser`; deleted and replaced references.
- **Extract `traditionalDataDeclParser` / `gadtDataDeclParser`** — Three declarations (`dataDeclParser`, `dataFamilyInstParser`, `instanceDataFamilyInstParser`) each had identical local definitions. Moved to top-level.
- **Extract `bareInstanceHeadParser`** — `standaloneDerivingHeadParser` and `instanceHeadParser` shared the same prefix/infix head parsing logic. Extracted a shared helper.

### Impact

- **-97 lines** across 5 files (250 deletions, 153 insertions).
- No behavioral changes; all 1660 tests pass.