### PR TITLE
refactor(parser): split binder and instance heads

### DIFF
--- a/components/aihc-parser-cli/src/Aihc/Parser/Run.hs
+++ b/components/aihc-parser-cli/src/Aihc/Parser/Run.hs
@@ -32,7 +32,6 @@ import Aihc.Parser.Syntax
     parseExtensionSettingName,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Data.ByteString qualified as BS
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
@@ -168,7 +167,7 @@ runLexMode extensionSettings stdin =
 
 -- | Resolve all include requests in a CPP step, returning the final result.
 resolveCppStep :: Map FilePath Text -> Step -> Result
-resolveCppStep includeMap (Done result) = result
+resolveCppStep _ (Done result) = result
 resolveCppStep includeMap (NeedInclude req k) =
   let resolved = resolveInclude includeMap req
    in resolveCppStep includeMap (k (fmap TE.encodeUtf8 resolved))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -137,14 +137,14 @@ implicitSpliceDeclParser = DeclSplice <$> exprParser
 typeDeclarationParser :: TokParser Decl
 typeDeclarationParser = do
   expectedTok TkKeywordType
-  (headForm, typeName, typeParams) <- typeDeclHeadParser
+  typeHead <- typeDeclHeadParser
   nextTok <- anySingle
   case lexTokenKind nextTok of
     TkReservedDoubleColon -> do
       -- Standalone kind signature: cannot have type parameters
-      if null typeParams
+      if null (binderHeadParams typeHead)
         then
-          DeclStandaloneKindSig typeName <$> typeParser
+          DeclStandaloneKindSig (binderHeadName typeHead) <$> typeParser
         else
           fail "Standalone kind signatures cannot have type parameters."
     TkReservedEquals -> do
@@ -152,9 +152,7 @@ typeDeclarationParser = do
       pure $
         DeclTypeSyn
           TypeSynDecl
-            { typeSynHeadForm = headForm,
-              typeSynName = typeName,
-              typeSynParams = typeParams,
+            { typeSynHead = typeHead,
               typeSynBody = body
             }
     _ ->
@@ -316,14 +314,12 @@ dataFamilyDeclParser :: TokParser Decl
 dataFamilyDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   varIdTok "family"
-  (headForm, name, params) <- typeDeclHeadParser
+  head' <- typeDeclHeadParser
   kind <- familyResultKindParser
   pure $
     DeclDataFamilyDecl
       DataFamilyDecl
-        { dataFamilyDeclHeadForm = headForm,
-          dataFamilyDeclName = name,
-          dataFamilyDeclParams = params,
+        { dataFamilyDeclHead = head',
           dataFamilyDeclKind = kind
         }
 
@@ -413,14 +409,12 @@ classTypeFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
 classDataFamilyDeclParser :: TokParser ClassDeclItem
 classDataFamilyDeclParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
-  (headForm, name, params) <- typeDeclHeadParser
+  head' <- typeDeclHeadParser
   kind <- familyResultKindParser
   pure
     ( ClassItemDataFamilyDecl
         DataFamilyDecl
-          { dataFamilyDeclHeadForm = headForm,
-            dataFamilyDeclName = name,
-            dataFamilyDeclParams = params,
+          { dataFamilyDeclHead = head',
             dataFamilyDeclKind = kind
           }
     )
@@ -604,16 +598,14 @@ classDeclParser :: TokParser Decl
 classDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordClass
   context <- contextPrefixDispatch
-  (headForm, className, classParams) <- classHeadParser
+  classHead <- classHeadParser
   classFundeps <- MP.option [] (MP.try classFundepsParser)
   items <- MP.option [] classWhereClauseParser
   pure $
     DeclClass
       ClassDecl
         { classDeclContext = context,
-          classDeclHeadForm = headForm,
-          classDeclName = className,
-          classDeclParams = classParams,
+          classDeclHead = classHead,
           classDeclFundeps = classFundeps,
           classDeclItems = items
         }
@@ -705,7 +697,7 @@ instanceDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   warningText <- MP.optional warningTextParser
   forallBinders <- MP.optional instanceForallParser
   context <- contextPrefixDispatch
-  (parenthesizedHead, headForm, className, instanceTypes) <- instanceHeadParser
+  (parenthesizedHead, instanceHead) <- instanceHeadParser
   items <- MP.option [] instanceWhereClauseParser
   pure $
     DeclInstance
@@ -715,9 +707,7 @@ instanceDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           instanceDeclForall = fromMaybe [] forallBinders,
           instanceDeclContext = fromMaybe [] context,
           instanceDeclParenthesizedHead = parenthesizedHead,
-          instanceDeclHeadForm = headForm,
-          instanceDeclClassName = className,
-          instanceDeclTypes = instanceTypes,
+          instanceDeclHead = instanceHead,
           instanceDeclItems = items
         }
 
@@ -731,7 +721,7 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   warningText <- MP.optional warningTextParser
   forallBinders <- MP.optional instanceForallParser
   context <- contextPrefixDispatch
-  (parenthesizedHead, headForm, className, instanceTypes) <- standaloneDerivingHeadParser
+  (parenthesizedHead, derivingHead) <- standaloneDerivingHeadParser
   pure $
     DeclStandaloneDeriving
       StandaloneDerivingDecl
@@ -742,23 +732,20 @@ standaloneDerivingDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
           standaloneDerivingForall = fromMaybe [] forallBinders,
           standaloneDerivingContext = fromMaybe [] context,
           standaloneDerivingParenthesizedHead = parenthesizedHead,
-          standaloneDerivingHeadForm = headForm,
-          standaloneDerivingClassName = className,
-          standaloneDerivingTypes = instanceTypes
+          standaloneDerivingHead = derivingHead
         }
 
-standaloneDerivingHeadParser :: TokParser (Bool, TypeHeadForm, Name, [Type])
+standaloneDerivingHeadParser :: TokParser (Bool, InstanceHead Name)
 standaloneDerivingHeadParser =
   MP.try
     ( do
         parsed <- parens bareStandaloneDerivingHeadParser
         _ <- MP.notFollowedBy (lookAhead typeInfixOperatorParser)
-        let (headForm, className, instanceTypes) = parsed
-        pure (True, headForm, className, instanceTypes)
+        pure (True, parsed)
     )
     <|> ( do
-            (headForm, className, instanceTypes) <- bareStandaloneDerivingHeadParser
-            pure (False, headForm, className, instanceTypes)
+            derivingHead <- bareStandaloneDerivingHeadParser
+            pure (False, derivingHead)
         )
   where
     bareStandaloneDerivingHeadParser = MP.try infixStandaloneDerivingHeadParser <|> prefixStandaloneDerivingHeadParser
@@ -766,27 +753,25 @@ standaloneDerivingHeadParser =
     prefixStandaloneDerivingHeadParser = do
       className <- constructorNameParser <|> parens operatorNameParser
       instanceTypes <- MP.many typeAtomParser
-      pure (TypeHeadPrefix, className, instanceTypes)
+      pure (PrefixInstanceHead className instanceTypes)
 
     infixStandaloneDerivingHeadParser = do
       lhs <- typeAtomParser
       _ <- lookAhead typeInfixOperatorParser
       op <- typeFamilyOperatorParser
-      rhs <- typeAtomParser
-      pure (TypeHeadInfix, op, [lhs, rhs])
+      InfixInstanceHead lhs op <$> typeAtomParser
 
-instanceHeadParser :: TokParser (Bool, TypeHeadForm, UnqualifiedName, [Type])
+instanceHeadParser :: TokParser (Bool, InstanceHead UnqualifiedName)
 instanceHeadParser =
   MP.try
     ( do
         parsed <- parens bareInstanceHeadParser
         _ <- MP.notFollowedBy (lookAhead typeInfixOperatorParser)
-        let (headForm, className, instanceTypes) = parsed
-        pure (True, headForm, className, instanceTypes)
+        pure (True, parsed)
     )
     <|> ( do
-            (headForm, className, instanceTypes) <- bareInstanceHeadParser
-            pure (False, headForm, className, instanceTypes)
+            instanceHead <- bareInstanceHeadParser
+            pure (False, instanceHead)
         )
   where
     bareInstanceHeadParser = MP.try infixInstanceHeadParser <|> prefixInstanceHeadParser
@@ -794,14 +779,13 @@ instanceHeadParser =
     prefixInstanceHeadParser = do
       className <- nameToUnqualified <$> (constructorNameParser <|> parens operatorNameParser)
       instanceTypes <- MP.many typeAtomParser
-      pure (TypeHeadPrefix, className, instanceTypes)
+      pure (PrefixInstanceHead className instanceTypes)
 
     infixInstanceHeadParser = do
       lhs <- typeAtomParser
       _ <- lookAhead typeInfixOperatorParser
       op <- typeFamilyOperatorParser
-      rhs <- typeAtomParser
-      pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs])
+      InfixInstanceHead lhs (nameToUnqualified op) <$> typeAtomParser
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]
 instanceWhereClauseParser = whereClauseItemsParser instanceItemsBracedParser instanceItemsPlainParser
@@ -910,7 +894,7 @@ dataDeclParser :: TokParser Decl
 dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
   context <- contextPrefixDispatch
-  (headForm, typeName, typeParams) <- typeDeclHeadParser
+  typeHead <- typeDeclHeadParser
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
@@ -918,10 +902,8 @@ dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclData
       DataDecl
-        { dataDeclHeadForm = headForm,
+        { dataDeclHead = typeHead,
           dataDeclContext = fromMaybe [] context,
-          dataDeclName = typeName,
-          dataDeclParams = typeParams,
           dataDeclKind = inlineKind,
           dataDeclConstructors = constructors,
           dataDeclDeriving = derivingClauses
@@ -948,7 +930,7 @@ typeDataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   expectedTok TkKeywordData
   -- type data may not have a datatype context
-  (headForm, typeName, typeParams) <- typeDeclHeadParser
+  typeHead <- typeDeclHeadParser
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
@@ -957,10 +939,8 @@ typeDataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclTypeData
       DataDecl
-        { dataDeclHeadForm = headForm,
+        { dataDeclHead = typeHead,
           dataDeclContext = [],
-          dataDeclName = typeName,
-          dataDeclParams = typeParams,
           dataDeclKind = inlineKind,
           dataDeclConstructors = constructors,
           dataDeclDeriving = []
@@ -1059,7 +1039,7 @@ newtypeDeclParser :: TokParser Decl
 newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
   context <- contextPrefixDispatch
-  (headForm, typeName, typeParams) <- typeDeclHeadParser
+  typeHead <- typeDeclHeadParser
   -- Parse optional inline kind signature: @:: Kind@
   inlineKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
   -- GADT syntax starts with `where`, traditional syntax starts with `=` or nothing
@@ -1067,10 +1047,8 @@ newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   pure $
     DeclNewtype
       NewtypeDecl
-        { newtypeDeclHeadForm = headForm,
+        { newtypeDeclHead = typeHead,
           newtypeDeclContext = fromMaybe [] context,
-          newtypeDeclName = typeName,
-          newtypeDeclParams = typeParams,
           newtypeDeclKind = inlineKind,
           newtypeDeclConstructor = constructor,
           newtypeDeclDeriving = derivingClauses
@@ -1193,20 +1171,20 @@ gadtResultTypeParser = typeParser
 declContextParser :: TokParser [Type]
 declContextParser = contextParserWith typeParser typeAtomParser
 
-typeDeclHeadParser :: TokParser (TypeHeadForm, UnqualifiedName, [TyVarBinder])
+typeDeclHeadParser :: TokParser (BinderHead UnqualifiedName)
 typeDeclHeadParser =
   MP.try parenthesizedInfixDeclHeadParser <|> MP.try infixDeclHeadParser <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
       params <- MP.many declTypeParamParser
-      pure (TypeHeadPrefix, name, params)
+      pure (PrefixBinderHead name params)
 
     infixDeclHeadParser = do
       lhs <- declTypeParamParser
       op <- unqualifiedNameFromText <$> typeSynonymOperatorParser
       rhs <- declTypeParamParser
-      pure (TypeHeadInfix, op, [lhs, rhs])
+      pure (InfixBinderHead lhs op rhs [])
 
     parenthesizedInfixDeclHeadParser = do
       expectedTok TkSpecialLParen
@@ -1215,7 +1193,7 @@ typeDeclHeadParser =
       rhs <- declTypeParamParser
       expectedTok TkSpecialRParen
       tailParams <- MP.many declTypeParamParser
-      pure (TypeHeadInfix, op, [lhs, rhs] <> tailParams)
+      pure (InfixBinderHead lhs op rhs tailParams)
 
 typeSynonymOperatorParser :: TokParser Text
 typeSynonymOperatorParser =
@@ -1284,20 +1262,20 @@ typeFamilyLhsParser = do
 
     buildInfixType left ((op, promoted), right) = TInfix left op promoted right
 
-classHeadParser :: TokParser (TypeHeadForm, UnqualifiedName, [TyVarBinder])
+classHeadParser :: TokParser (BinderHead UnqualifiedName)
 classHeadParser =
   MP.try parenthesizedInfixDeclHeadParser <|> MP.try infixDeclHeadParser <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
       params <- MP.many declTypeParamParser
-      pure (TypeHeadPrefix, name, params)
+      pure (PrefixBinderHead name params)
 
     infixDeclHeadParser = do
       lhs <- declTypeParamParser
       op <- typeFamilyOperatorParser
       rhs <- declTypeParamParser
-      pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs])
+      pure (InfixBinderHead lhs (nameToUnqualified op) rhs [])
 
     parenthesizedInfixDeclHeadParser = do
       expectedTok TkSpecialLParen
@@ -1306,7 +1284,7 @@ classHeadParser =
       rhs <- declTypeParamParser
       expectedTok TkSpecialRParen
       tailParams <- MP.many declTypeParamParser
-      pure (TypeHeadInfix, nameToUnqualified op, [lhs, rhs] <> tailParams)
+      pure (InfixBinderHead lhs (nameToUnqualified op) rhs tailParams)
 
 nameToUnqualified :: Name -> UnqualifiedName
 nameToUnqualified name = mkUnqualifiedName (nameType name) (nameText name)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -596,7 +596,7 @@ addInstanceDeclParens :: InstanceDecl -> InstanceDecl
 addInstanceDeclParens decl =
   decl
     { instanceDeclContext = addContextConstraints (instanceDeclContext decl),
-      instanceDeclTypes = map (addTypeIn CtxTypeAtom) (instanceDeclTypes decl),
+      instanceDeclHead = addInstanceHeadParens (instanceDeclHead decl),
       instanceDeclItems = map addInstanceItemParens (instanceDeclItems decl)
     }
 
@@ -616,8 +616,14 @@ addStandaloneDerivingParens decl =
   decl
     { standaloneDerivingViaType = fmap addTypeParens (standaloneDerivingViaType decl),
       standaloneDerivingContext = addContextConstraints (standaloneDerivingContext decl),
-      standaloneDerivingTypes = map (addTypeIn CtxTypeAtom) (standaloneDerivingTypes decl)
+      standaloneDerivingHead = addInstanceHeadParens (standaloneDerivingHead decl)
     }
+
+addInstanceHeadParens :: InstanceHead name -> InstanceHead name
+addInstanceHeadParens head' =
+  case head' of
+    PrefixInstanceHead name tys -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys)
+    InfixInstanceHead lhs name rhs -> InfixInstanceHead (addTypeIn CtxTypeAtom lhs) name (addTypeIn CtxTypeAtom rhs)
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl
 addForeignDeclParens decl =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -244,15 +244,7 @@ prettyDeclLines decl =
       ]
     DeclRoleAnnotation ann -> [prettyRoleAnnotation ann]
     DeclTypeSyn synDecl ->
-      let headDocs = case (typeSynHeadForm synDecl, typeSynParams synDecl) of
-            (TypeHeadInfix, lhs : rhs : tailPrms) ->
-              let name = typeSynName synDecl
-                  infixHead = pretty (tyVarBinderName lhs) <+> prettyInfixOp name <+> pretty (tyVarBinderName rhs)
-               in case tailPrms of
-                    [] -> [infixHead]
-                    _ -> parens infixHead : map prettyTyVarBinder tailPrms
-            _ -> [prettyDeclHead TypeHeadPrefix [] (typeSynName synDecl) (typeSynParams synDecl)]
-       in [hsep (["type"] <> headDocs <> ["=", prettyType (typeSynBody synDecl)])]
+      [hsep (["type"] <> prettyDeclBinderHead [] (typeSynHead synDecl) <> ["=", prettyType (typeSynBody synDecl)])]
     DeclData dataDecl -> [prettyDataDecl dataDecl]
     DeclTypeData dataDecl -> [prettyTypeDataDecl dataDecl]
     DeclNewtype newtypeDecl -> [prettyNewtypeDecl newtypeDecl]
@@ -522,9 +514,8 @@ prettyLiteral lit =
 prettyDataDecl :: DataDecl -> Doc ann
 prettyDataDecl decl =
   hsep
-    ( [ "data",
-        prettyDeclHead (dataDeclHeadForm decl) (dataDeclContext decl) (dataDeclName decl) (dataDeclParams decl)
-      ]
+    ( ["data"]
+        <> prettyDeclBinderHead (dataDeclContext decl) (dataDeclHead decl)
         <> kindPart
         <> ctorPart
         <> derivingParts (dataDeclDeriving decl)
@@ -541,9 +532,8 @@ prettyDataDecl decl =
 prettyTypeDataDecl :: DataDecl -> Doc ann
 prettyTypeDataDecl decl =
   hsep
-    ( [ "type data",
-        prettyDeclHead (dataDeclHeadForm decl) (dataDeclContext decl) (dataDeclName decl) (dataDeclParams decl)
-      ]
+    ( ["type data"]
+        <> prettyDeclBinderHead (dataDeclContext decl) (dataDeclHead decl)
         <> kindPart
         <> ctorPart
     )
@@ -564,9 +554,8 @@ isGadtCon _ = False
 prettyNewtypeDecl :: NewtypeDecl -> Doc ann
 prettyNewtypeDecl decl =
   hsep
-    ( [ "newtype",
-        prettyDeclHead (newtypeDeclHeadForm decl) (newtypeDeclContext decl) (newtypeDeclName decl) (newtypeDeclParams decl)
-      ]
+    ( ["newtype"]
+        <> prettyDeclBinderHead (newtypeDeclContext decl) (newtypeDeclHead decl)
         <> kindPart
         <> ctorPart
         <> derivingParts (newtypeDeclDeriving decl)
@@ -601,21 +590,20 @@ derivingPart (DerivingClause strategy classes viaTy parenthesized) =
     viaPart Nothing = []
     viaPart (Just ty) = ["via", prettyType ty]
 
-prettyDeclHead :: TypeHeadForm -> [Type] -> UnqualifiedName -> [TyVarBinder] -> Doc ann
-prettyDeclHead headForm constraints name params =
-  hsep
-    ( contextPrefix constraints
-        <> prettyDeclHeadNameAndParams name params
-    )
+prettyDeclBinderHead :: [Type] -> BinderHead UnqualifiedName -> [Doc ann]
+prettyDeclBinderHead constraints head' =
+  contextPrefix constraints
+    <> prettyDeclHeadNameAndParams head'
   where
-    prettyDeclHeadNameAndParams nm prms = case (headForm, prms) of
-      (TypeHeadInfix, lhs : rhs : tailPrms) ->
-        let infixHead = pretty (tyVarBinderName lhs) <+> prettyInfixOp nm <+> pretty (tyVarBinderName rhs)
-         in case tailPrms of
-              [] -> [infixHead]
-              _ -> parens infixHead : map prettyTyVarBinder tailPrms
-      _ ->
-        [prettyConstructorUName nm] <> map prettyTyVarBinder prms
+    prettyDeclHeadNameAndParams binderHead =
+      case binderHead of
+        PrefixBinderHead name params ->
+          [prettyConstructorUName name] <> map prettyTyVarBinder params
+        InfixBinderHead lhs name rhs tailPrms ->
+          let infixHead = pretty (tyVarBinderName lhs) <+> prettyInfixOp name <+> pretty (tyVarBinderName rhs)
+           in case tailPrms of
+                [] -> [infixHead]
+                _ -> parens infixHead : map prettyTyVarBinder tailPrms
 
 prettyTyVarBinder :: TyVarBinder -> Doc ann
 prettyTyVarBinder binder =
@@ -768,7 +756,7 @@ prettyClassDecl decl =
         hsep
           ( ["class"]
               <> maybeContextPrefix (classDeclContext decl)
-              <> prettyNamedTypeHead (classDeclHeadForm decl) (classDeclName decl) (classDeclParams decl)
+              <> prettyNamedBinderHead (classDeclHead decl)
               <> prettyClassFundeps (classDeclFundeps decl)
           )
    in case classDeclItems decl of
@@ -859,27 +847,18 @@ prettyStandaloneDeriving decl =
 instanceHeadDoc :: InstanceDecl -> Doc ann
 instanceHeadDoc decl =
   maybeParenthesize (instanceDeclParenthesizedHead decl) $
-    prettyInstanceLikeHead (instanceDeclHeadForm decl) (instanceDeclClassName decl) (instanceDeclTypes decl)
+    prettyInstanceHead prettyConstructorUName prettyInfixOp (instanceDeclHead decl)
 
 standaloneDerivingHeadDoc :: StandaloneDerivingDecl -> Doc ann
 standaloneDerivingHeadDoc decl =
   maybeParenthesize (standaloneDerivingParenthesizedHead decl) $
-    prettyStandaloneDerivingHead
-      (standaloneDerivingHeadForm decl)
-      (standaloneDerivingClassName decl)
-      (standaloneDerivingTypes decl)
+    prettyInstanceHead prettyPrefixName prettyNameInfixOp (standaloneDerivingHead decl)
 
-prettyInstanceLikeHead :: TypeHeadForm -> UnqualifiedName -> [Type] -> Doc ann
-prettyInstanceLikeHead headForm className tys =
-  case (headForm, tys) of
-    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyInfixOp className <+> prettyType rhs
-    _ -> hsep (prettyConstructorUName className : map prettyType tys)
-
-prettyStandaloneDerivingHead :: TypeHeadForm -> Name -> [Type] -> Doc ann
-prettyStandaloneDerivingHead headForm className tys =
-  case (headForm, tys) of
-    (TypeHeadInfix, [lhs, rhs]) -> prettyType lhs <+> prettyNameInfixOp className <+> prettyType rhs
-    _ -> hsep (prettyPrefixName className : map prettyType tys)
+prettyInstanceHead :: (name -> Doc ann) -> (name -> Doc ann) -> InstanceHead name -> Doc ann
+prettyInstanceHead prettyPrefix prettyInfix head' =
+  case head' of
+    PrefixInstanceHead name tys -> hsep (prettyPrefix name : map prettyType tys)
+    InfixInstanceHead lhs name rhs -> prettyType lhs <+> prettyInfix name <+> prettyType rhs
 
 maybeParenthesize :: Bool -> Doc ann -> Doc ann
 maybeParenthesize shouldParen doc
@@ -1367,7 +1346,7 @@ prettyDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyDataFamilyDecl df =
   hsep $
     ["data", "family"]
-      <> prettyNamedTypeHead (dataFamilyDeclHeadForm df) (dataFamilyDeclName df) (dataFamilyDeclParams df)
+      <> prettyNamedBinderHead (dataFamilyDeclHead df)
       <> kindPart (dataFamilyDeclKind df)
   where
     kindPart Nothing = []
@@ -1444,7 +1423,7 @@ prettyAssocDataFamilyDecl :: DataFamilyDecl -> Doc ann
 prettyAssocDataFamilyDecl df =
   hsep $
     ["data"]
-      <> prettyNamedTypeHead (dataFamilyDeclHeadForm df) (dataFamilyDeclName df) (dataFamilyDeclParams df)
+      <> prettyNamedBinderHead (dataFamilyDeclHead df)
       <> kindPart (dataFamilyDeclKind df)
   where
     kindPart Nothing = []
@@ -1472,15 +1451,16 @@ prettyInstTypeFamilyInst tfi =
     forallPart [] = []
     forallPart binders = ["forall", hsep (map prettyTyVarBinder binders) <> "."]
 
-prettyNamedTypeHead :: TypeHeadForm -> UnqualifiedName -> [TyVarBinder] -> [Doc ann]
-prettyNamedTypeHead headForm name params =
-  case (headForm, params) of
-    (TypeHeadInfix, lhs : rhs : tailPrms) ->
+prettyNamedBinderHead :: BinderHead UnqualifiedName -> [Doc ann]
+prettyNamedBinderHead head' =
+  case head' of
+    PrefixBinderHead name params ->
+      [prettyConstructorUName name] <> map prettyTyVarBinder params
+    InfixBinderHead lhs name rhs tailPrms ->
       let infixHead = prettyTyVarBinder lhs <+> prettyTypeHeadInfixName name <+> prettyTyVarBinder rhs
        in case tailPrms of
             [] -> [infixHead]
             _ -> parens infixHead : map prettyTyVarBinder tailPrms
-    _ -> [prettyConstructorUName name] <> map prettyTyVarBinder params
 
 prettyTypeHeadInfixName :: UnqualifiedName -> Doc ann
 prettyTypeHeadInfixName = prettyInfixOp

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -311,8 +311,8 @@ docTypeSynDecl syn =
   "TypeSynDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "name" (docUnqualifiedName (typeSynName syn))]
-        <> listField "params" docTyVarBinder (typeSynParams syn)
+      [field "name" (docUnqualifiedName (binderHeadName (typeSynHead syn)))]
+        <> listField "params" docTyVarBinder (binderHeadParams (typeSynHead syn))
         <> [field "body" (docType (typeSynBody syn))]
 
 docRoleAnnotation :: RoleAnnotation -> Doc ann
@@ -336,9 +336,9 @@ docDataDecl dd =
   "DataDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "name" (docUnqualifiedName (dataDeclName dd))]
+      [field "name" (docUnqualifiedName (binderHeadName (dataDeclHead dd)))]
         <> listField "context" docType (dataDeclContext dd)
-        <> listField "params" docTyVarBinder (dataDeclParams dd)
+        <> listField "params" docTyVarBinder (binderHeadParams (dataDeclHead dd))
         <> optionalField "kind" docType (dataDeclKind dd)
         <> listField "constructors" docDataConDecl (dataDeclConstructors dd)
         <> listField "deriving" docDerivingClause (dataDeclDeriving dd)
@@ -348,9 +348,9 @@ docNewtypeDecl nd =
   "NewtypeDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "name" (docUnqualifiedName (newtypeDeclName nd))]
+      [field "name" (docUnqualifiedName (binderHeadName (newtypeDeclHead nd)))]
         <> listField "context" docType (newtypeDeclContext nd)
-        <> listField "params" docTyVarBinder (newtypeDeclParams nd)
+        <> listField "params" docTyVarBinder (binderHeadParams (newtypeDeclHead nd))
         <> optionalField "kind" docType (newtypeDeclKind nd)
         <> optionalField "constructor" docDataConDecl (newtypeDeclConstructor nd)
         <> listField "deriving" docDerivingClause (newtypeDeclDeriving nd)
@@ -420,9 +420,9 @@ docClassDecl cd =
   "ClassDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "headForm" (docTypeHeadForm (classDeclHeadForm cd)), field "name" (docUnqualifiedName (classDeclName cd))]
+      [field "headForm" (docTypeHeadForm (binderHeadForm (classDeclHead cd))), field "name" (docUnqualifiedName (binderHeadName (classDeclHead cd)))]
         <> optionalField "context" (brackets . hsep . punctuate comma . map docType) (classDeclContext cd)
-        <> listField "params" docTyVarBinder (classDeclParams cd)
+        <> listField "params" docTyVarBinder (binderHeadParams (classDeclHead cd))
         <> listField "fundeps" docFunctionalDependency (classDeclFundeps cd)
         <> listField "items" docClassDeclItem (classDeclItems cd)
 
@@ -474,10 +474,10 @@ docInstanceDecl inst =
         <> optionalField "warning" docWarningText (instanceDeclWarning inst)
         <> listField "forall" docTyVarBinder (instanceDeclForall inst)
         <> boolField "parenthesizedHead" (instanceDeclParenthesizedHead inst)
-        <> [field "headForm" (docTypeHeadForm (instanceDeclHeadForm inst))]
-        <> [field "className" (docUnqualifiedName (instanceDeclClassName inst))]
+        <> [field "headForm" (docTypeHeadForm (instanceHeadForm (instanceDeclHead inst)))]
+        <> [field "className" (docUnqualifiedName (instanceHeadName (instanceDeclHead inst)))]
         <> listField "context" docType (instanceDeclContext inst)
-        <> [field "types" (brackets (hsep (punctuate comma (map docType (instanceDeclTypes inst)))))]
+        <> [field "types" (brackets (hsep (punctuate comma (map docType (instanceHeadTypes (instanceDeclHead inst))))))]
         <> listField "items" docInstanceDeclItem (instanceDeclItems inst)
 
 docInstanceDeclItem :: InstanceDeclItem -> Doc ann
@@ -499,11 +499,11 @@ docStandaloneDerivingDecl sd =
       optionalField "overlapPragma" docInstanceOverlapPragma (standaloneDerivingOverlapPragma sd)
         <> optionalField "warning" docWarningText (standaloneDerivingWarning sd)
         <> boolField "parenthesizedHead" (standaloneDerivingParenthesizedHead sd)
-        <> [field "headForm" (docTypeHeadForm (standaloneDerivingHeadForm sd))]
-        <> [field "className" (docName (standaloneDerivingClassName sd))]
+        <> [field "headForm" (docTypeHeadForm (instanceHeadForm (standaloneDerivingHead sd)))]
+        <> [field "className" (docName (instanceHeadName (standaloneDerivingHead sd)))]
         <> optionalField "strategy" docDerivingStrategy (standaloneDerivingStrategy sd)
         <> listField "context" docType (standaloneDerivingContext sd)
-        <> [field "types" (brackets (hsep (punctuate comma (map docType (standaloneDerivingTypes sd)))))]
+        <> [field "types" (brackets (hsep (punctuate comma (map docType (instanceHeadTypes (standaloneDerivingHead sd))))))]
         <> optionalField "viaType" docType (standaloneDerivingViaType sd)
 
 docInstanceOverlapPragma :: InstanceOverlapPragma -> Doc ann
@@ -1063,8 +1063,8 @@ docDataFamilyDecl df =
   "DataFamilyDecl" <+> braces (hsep (punctuate comma fields))
   where
     fields =
-      [field "headForm" (docTypeHeadForm (dataFamilyDeclHeadForm df)), field "name" (docUnqualifiedName (dataFamilyDeclName df))]
-        <> listField "params" docTyVarBinder (dataFamilyDeclParams df)
+      [field "headForm" (docTypeHeadForm (binderHeadForm (dataFamilyDeclHead df))), field "name" (docUnqualifiedName (binderHeadName (dataFamilyDeclHead df)))]
+        <> listField "params" docTyVarBinder (binderHeadParams (dataFamilyDeclHead df))
         <> optionalField "kind" docType (dataFamilyDeclKind df)
 
 docTypeFamilyInst :: TypeFamilyInst -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -14,6 +14,7 @@ module Aihc.Parser.Syntax
     ArrAppType (..),
     BangType (..),
     BinderName,
+    BinderHead (..),
     CallConv (..),
     CaseAlt (..),
     ClassDecl (..),
@@ -65,6 +66,7 @@ module Aihc.Parser.Syntax
     Name (..),
     NameType (..),
     UnqualifiedName (..),
+    InstanceHead (..),
     WarningText (..),
     Annotation,
     NewtypeDecl (..),
@@ -103,6 +105,9 @@ module Aihc.Parser.Syntax
     allKnownExtensions,
     applyExtensionSetting,
     applyImpliedExtensions,
+    binderHeadForm,
+    binderHeadName,
+    binderHeadParams,
     effectiveExtensions,
     extensionName,
     extensionSettingName,
@@ -125,6 +130,9 @@ module Aihc.Parser.Syntax
     moduleName,
     moduleWarningText,
     moduleExports,
+    instanceHeadForm,
+    instanceHeadName,
+    instanceHeadTypes,
     mkAnnotation,
     fromAnnotation,
     peelArithSeqAnn,
@@ -1253,6 +1261,52 @@ data TypeHeadForm
   | TypeHeadInfix
   deriving (Data, Eq, Show, Generic, NFData)
 
+data BinderHead name
+  = PrefixBinderHead name [TyVarBinder]
+  | InfixBinderHead TyVarBinder name TyVarBinder [TyVarBinder]
+  deriving (Data, Eq, Show, Generic, NFData)
+
+binderHeadForm :: BinderHead name -> TypeHeadForm
+binderHeadForm head' =
+  case head' of
+    PrefixBinderHead {} -> TypeHeadPrefix
+    InfixBinderHead {} -> TypeHeadInfix
+
+binderHeadName :: BinderHead name -> name
+binderHeadName head' =
+  case head' of
+    PrefixBinderHead name _ -> name
+    InfixBinderHead _ name _ _ -> name
+
+binderHeadParams :: BinderHead name -> [TyVarBinder]
+binderHeadParams head' =
+  case head' of
+    PrefixBinderHead _ params -> params
+    InfixBinderHead lhs _ rhs tailParams -> lhs : rhs : tailParams
+
+data InstanceHead name
+  = PrefixInstanceHead name [Type]
+  | InfixInstanceHead Type name Type
+  deriving (Data, Eq, Show, Generic, NFData)
+
+instanceHeadForm :: InstanceHead name -> TypeHeadForm
+instanceHeadForm head' =
+  case head' of
+    PrefixInstanceHead {} -> TypeHeadPrefix
+    InfixInstanceHead {} -> TypeHeadInfix
+
+instanceHeadName :: InstanceHead name -> name
+instanceHeadName head' =
+  case head' of
+    PrefixInstanceHead name _ -> name
+    InfixInstanceHead _ name _ -> name
+
+instanceHeadTypes :: InstanceHead name -> [Type]
+instanceHeadTypes head' =
+  case head' of
+    PrefixInstanceHead _ tys -> tys
+    InfixInstanceHead lhs _ rhs -> [lhs, rhs]
+
 data Role
   = RoleNominal
   | RoleRepresentational
@@ -1267,9 +1321,7 @@ data RoleAnnotation = RoleAnnotation
   deriving (Data, Eq, Show, Generic, NFData)
 
 data TypeSynDecl = TypeSynDecl
-  { typeSynHeadForm :: TypeHeadForm,
-    typeSynName :: UnqualifiedName,
-    typeSynParams :: [TyVarBinder],
+  { typeSynHead :: BinderHead UnqualifiedName,
     typeSynBody :: Type
   }
   deriving (Data, Eq, Show, Generic, NFData)
@@ -1316,9 +1368,7 @@ data TypeFamilyEq = TypeFamilyEq
 
 -- | Data family declaration (standalone or associated in a class body).
 data DataFamilyDecl = DataFamilyDecl
-  { dataFamilyDeclHeadForm :: TypeHeadForm,
-    dataFamilyDeclName :: UnqualifiedName,
-    dataFamilyDeclParams :: [TyVarBinder],
+  { dataFamilyDeclHead :: BinderHead UnqualifiedName,
     -- | Optional result kind annotation (@:: Kind@)
     dataFamilyDeclKind :: Maybe Type
   }
@@ -1348,10 +1398,8 @@ data DataFamilyInst = DataFamilyInst
   deriving (Data, Eq, Show, Generic, NFData)
 
 data DataDecl = DataDecl
-  { dataDeclHeadForm :: TypeHeadForm,
+  { dataDeclHead :: BinderHead UnqualifiedName,
     dataDeclContext :: [Type],
-    dataDeclName :: UnqualifiedName,
-    dataDeclParams :: [TyVarBinder],
     -- | Optional inline kind annotation (@:: Kind@) before @=@ or @where@
     dataDeclKind :: Maybe Type,
     dataDeclConstructors :: [DataConDecl],
@@ -1360,10 +1408,8 @@ data DataDecl = DataDecl
   deriving (Data, Eq, Show, Generic, NFData)
 
 data NewtypeDecl = NewtypeDecl
-  { newtypeDeclHeadForm :: TypeHeadForm,
+  { newtypeDeclHead :: BinderHead UnqualifiedName,
     newtypeDeclContext :: [Type],
-    newtypeDeclName :: UnqualifiedName,
-    newtypeDeclParams :: [TyVarBinder],
     -- | Optional inline kind annotation (@:: Kind@) before @=@ or @where@
     newtypeDeclKind :: Maybe Type,
     newtypeDeclConstructor :: Maybe DataConDecl,
@@ -1454,17 +1500,13 @@ data StandaloneDerivingDecl = StandaloneDerivingDecl
     standaloneDerivingForall :: [TyVarBinder],
     standaloneDerivingContext :: [Type],
     standaloneDerivingParenthesizedHead :: Bool,
-    standaloneDerivingHeadForm :: TypeHeadForm,
-    standaloneDerivingClassName :: Name,
-    standaloneDerivingTypes :: [Type]
+    standaloneDerivingHead :: InstanceHead Name
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
 data ClassDecl = ClassDecl
   { classDeclContext :: Maybe [Type],
-    classDeclHeadForm :: TypeHeadForm,
-    classDeclName :: UnqualifiedName,
-    classDeclParams :: [TyVarBinder],
+    classDeclHead :: BinderHead UnqualifiedName,
     classDeclFundeps :: [FunctionalDependency],
     classDeclItems :: [ClassDeclItem]
   }
@@ -1508,9 +1550,7 @@ data InstanceDecl = InstanceDecl
     instanceDeclForall :: [TyVarBinder],
     instanceDeclContext :: [Type],
     instanceDeclParenthesizedHead :: Bool,
-    instanceDeclHeadForm :: TypeHeadForm,
-    instanceDeclClassName :: UnqualifiedName,
-    instanceDeclTypes :: [Type],
+    instanceDeclHead :: InstanceHead UnqualifiedName,
     instanceDeclItems :: [InstanceDeclItem]
   }
   deriving (Data, Eq, Show, Generic, NFData)

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -444,8 +444,10 @@ test_moduleParsesNullaryClassDecl =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [DeclClass ClassDecl {classDeclName = "C", classDeclParams = [], classDeclItems = []}] ->
-            pure ()
+          [DeclClass classDecl@ClassDecl {classDeclItems = []}]
+            | binderHeadName (classDeclHead classDecl) == "C",
+              null (binderHeadParams (classDeclHead classDecl)) ->
+                pure ()
           other ->
             assertFailure ("unexpected parsed declarations: " <> show other)
 
@@ -456,8 +458,10 @@ test_moduleParsesNullaryClassDeclWithWhere =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [DeclClass ClassDecl {classDeclName = "C", classDeclParams = [], classDeclItems = [ClassItemTypeSig_ ["method"] ty]}]
-            | TCon "Int" Unpromoted <- stripTypeAnnotations ty ->
+          [DeclClass classDecl@ClassDecl {classDeclItems = [ClassItemTypeSig_ ["method"] ty]}]
+            | binderHeadName (classDeclHead classDecl) == "C",
+              null (binderHeadParams (classDeclHead classDecl)),
+              TCon "Int" Unpromoted <- stripTypeAnnotations ty ->
                 pure ()
           other ->
             assertFailure ("unexpected parsed declarations: " <> show other)
@@ -492,8 +496,11 @@ test_typeSynonymRhsParsesTopLevelKindSignature =
   case parseDecl
     defaultConfig {parserExtensions = [DataKinds, KindSignatures]}
     "type UTF8 = \"UTF8\" :: NameStyle" of
-    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "UTF8", typeSynBody = body})
-      | TKindSig (TTypeLit (TypeLitSymbol "UTF8" "\"UTF8\"")) (TCon "NameStyle" Unpromoted) <- stripTypeAnnotations body ->
+    ParseOk (DeclTypeSyn typeSyn)
+      | binderHeadName (typeSynHead typeSyn) == "UTF8",
+        null (binderHeadParams (typeSynHead typeSyn)),
+        let body = typeSynBody typeSyn,
+        TKindSig (TTypeLit (TypeLitSymbol "UTF8" "\"UTF8\"")) (TCon "NameStyle" Unpromoted) <- stripTypeAnnotations body ->
           pure ()
     other -> assertFailure ("expected type synonym rhs kind signature, got: " <> show other)
 
@@ -522,10 +529,11 @@ test_symbolicTypeDataConstructorParses =
 test_symbolicTypeDataHeadAndConstructorParses :: Assertion
 test_symbolicTypeDataHeadAndConstructorParses =
   case parseDecl defaultConfig {parserExtensions = [TemplateHaskell, TypeData]} "type data (:*) = (:**)" of
-    ParseOk decl@(DeclAnn _ (DeclTypeData DataDecl {dataDeclHeadForm = TypeHeadPrefix, dataDeclName, dataDeclConstructors = [ctor]})) -> do
+    ParseOk decl@(DeclAnn _ (DeclTypeData dataDecl@DataDecl {dataDeclConstructors = [ctor]})) -> do
       let source = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
       assertEqual "pretty-printed declaration" "type data (:*) = (:**)" source
-      assertEqual "type data head" (mkUnqualifiedName NameConSym ":*") dataDeclName
+      assertEqual "type data head form" TypeHeadPrefix (binderHeadForm (dataDeclHead dataDecl))
+      assertEqual "type data head" (mkUnqualifiedName NameConSym ":*") (binderHeadName (dataDeclHead dataDecl))
       case peelDataConAnn ctor of
         PrefixCon [] [] name []
           | name == mkUnqualifiedName NameConSym ":**" -> pure ()
@@ -576,11 +584,11 @@ test_instanceParsesParenthesizedEmptyListType =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [ DeclClass ClassDecl {classDeclName = "C", classDeclParams = [_]},
+          [ DeclClass classDecl,
             DeclInstance inst
             ]
-              | instanceDeclClassName inst == "C",
-                [ity] <- instanceDeclTypes inst,
+              | binderHeadName (classDeclHead classDecl) == "C",
+                [ity] <- instanceHeadTypes (instanceDeclHead inst),
                 TParen (TCon "[]" Unpromoted) <- stripTypeAnnotations ity ->
                   pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
@@ -729,8 +737,12 @@ test_infixClassHeadParses =
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
           [ DeclFixity {},
-            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = ":=:", classDeclParams = [TyVarBinder _ "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "b" Nothing TyVarBSpecified TyVarBVisible], classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
-            ] -> pure ()
+            DeclClass classDecl@ClassDecl {classDeclItems = [ClassItemTypeSig_ ["proof"] _]}
+            ]
+              | binderHeadForm (classDeclHead classDecl) == TypeHeadInfix,
+                binderHeadName (classDeclHead classDecl) == ":=:",
+                [TyVarBinder _ "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "b" Nothing TyVarBSpecified TyVarBVisible] <- binderHeadParams (classDeclHead classDecl) ->
+                  pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_infixClassHeadVarSymParses :: Assertion
@@ -746,9 +758,16 @@ test_infixClassHeadVarSymParses =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [ DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = "|-", classDeclParams = [TyVarBinder _ "p" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "q" Nothing TyVarBSpecified TyVarBVisible]},
-            DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = "&", classDeclParams = [TyVarBinder _ "p" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "q" Nothing TyVarBSpecified TyVarBVisible]}
-            ] -> pure ()
+          [ DeclClass classDecl1,
+            DeclClass classDecl2
+            ]
+              | binderHeadForm (classDeclHead classDecl1) == TypeHeadInfix,
+                binderHeadName (classDeclHead classDecl1) == "|-",
+                [TyVarBinder _ "p" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "q" Nothing TyVarBSpecified TyVarBVisible] <- binderHeadParams (classDeclHead classDecl1),
+                binderHeadForm (classDeclHead classDecl2) == TypeHeadInfix,
+                binderHeadName (classDeclHead classDecl2) == "&",
+                [TyVarBinder _ "p" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder _ "q" Nothing TyVarBSpecified TyVarBVisible] <- binderHeadParams (classDeclHead classDecl2) ->
+                  pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_classOperatorTypeSigParses :: Assertion
@@ -764,7 +783,10 @@ test_classOperatorTypeSigParses =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [DeclClass ClassDecl {classDeclHeadForm = TypeHeadInfix, classDeclName = "C#", classDeclItems = [ClassItemTypeSig_ [UnqualifiedName NameVarSym "##"] _]}] -> pure ()
+          [DeclClass classDecl@ClassDecl {classDeclItems = [ClassItemTypeSig_ [UnqualifiedName NameVarSym "##"] _]}]
+            | binderHeadForm (classDeclHead classDecl) == TypeHeadInfix,
+              binderHeadName (classDeclHead classDecl) == "C#" ->
+                pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_explicitAssociatedTypeFamilyDeclParses :: Assertion
@@ -974,22 +996,26 @@ test_functionHeadTypeBinderParses =
 test_invisibleTypeDeclBinderParses :: Assertion
 test_invisibleTypeDeclBinderParses =
   case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "type T @k a = a" of
-    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "T", typeSynParams = [kBinder, aBinder], typeSynBody = body})
-      | tyVarBinderName kBinder == "k",
+    ParseOk (DeclTypeSyn typeSyn)
+      | binderHeadName (typeSynHead typeSyn) == "T",
+        [kBinder, aBinder] <- binderHeadParams (typeSynHead typeSyn),
+        tyVarBinderName kBinder == "k",
         tyVarBinderVisibility kBinder == TyVarBInvisible,
         tyVarBinderName aBinder == "a",
         tyVarBinderVisibility aBinder == TyVarBVisible,
-        TVar "a" <- stripTypeAnnotations body ->
+        TVar "a" <- stripTypeAnnotations (typeSynBody typeSyn) ->
           pure ()
     other -> assertFailure ("expected invisible type declaration binder, got: " <> show other)
 
 test_typeSynonymRhsInvisibleTypeAppParses :: Assertion
 test_typeSynonymRhsInvisibleTypeAppParses =
   case parseDecl defaultConfig {parserExtensions = [TypeAbstractions]} "type Witnessed @k = PairType @k IOWitness" of
-    ParseOk (DeclTypeSyn TypeSynDecl {typeSynName = "Witnessed", typeSynParams = [kBinder], typeSynBody = body})
-      | tyVarBinderName kBinder == "k",
+    ParseOk (DeclTypeSyn typeSyn)
+      | binderHeadName (typeSynHead typeSyn) == "Witnessed",
+        [kBinder] <- binderHeadParams (typeSynHead typeSyn),
+        tyVarBinderName kBinder == "k",
         tyVarBinderVisibility kBinder == TyVarBInvisible,
-        TApp (TTypeApp (TCon "PairType" Unpromoted) (TVar "k")) (TCon "IOWitness" Unpromoted) <- stripTypeAnnotations body ->
+        TApp (TTypeApp (TCon "PairType" Unpromoted) (TVar "k")) (TCon "IOWitness" Unpromoted) <- stripTypeAnnotations (typeSynBody typeSyn) ->
           pure ()
     other -> assertFailure ("expected invisible type application in type synonym rhs, got: " <> show other)
 
@@ -1877,11 +1903,11 @@ test_associatedDataFamilyOperatorName = do
   case parseModule defaultConfig source of
     ([], modu) ->
       case map peelDeclAnn (moduleDecls modu) of
-        [ DeclClass ClassDecl {classDeclItems = [ClassItemAnn _ (ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclName, dataFamilyDeclParams, dataFamilyDeclKind})]}
+        [ DeclClass ClassDecl {classDeclItems = [ClassItemAnn _ (ClassItemDataFamilyDecl dataFamilyDecl)]}
           ]
-            | dataFamilyDeclName == expectedName,
-              map tyVarBinderName dataFamilyDeclParams == ["a"],
-              isNothing dataFamilyDeclKind ->
+            | binderHeadName (dataFamilyDeclHead dataFamilyDecl) == expectedName,
+              map tyVarBinderName (binderHeadParams (dataFamilyDeclHead dataFamilyDecl)) == ["a"],
+              isNothing (dataFamilyDeclKind dataFamilyDecl) ->
                 pure ()
         other ->
           assertFailure ("expected associated data family operator declaration, got: " <> show other)
@@ -1895,12 +1921,12 @@ test_associatedDataFamilyInfixOperatorName = do
   case parseModule defaultConfig source of
     ([], modu) ->
       case map peelDeclAnn (moduleDecls modu) of
-        [ DeclClass ClassDecl {classDeclItems = [ClassItemAnn _ (ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclHeadForm, dataFamilyDeclName, dataFamilyDeclParams, dataFamilyDeclKind})]}
+        [ DeclClass ClassDecl {classDeclItems = [ClassItemAnn _ (ClassItemDataFamilyDecl dataFamilyDecl)]}
           ]
-            | dataFamilyDeclHeadForm == TypeHeadInfix,
-              dataFamilyDeclName == expectedName,
-              map tyVarBinderName dataFamilyDeclParams == ["a", "b"],
-              isNothing dataFamilyDeclKind ->
+            | binderHeadForm (dataFamilyDeclHead dataFamilyDecl) == TypeHeadInfix,
+              binderHeadName (dataFamilyDeclHead dataFamilyDecl) == expectedName,
+              map tyVarBinderName (binderHeadParams (dataFamilyDeclHead dataFamilyDecl)) == ["a", "b"],
+              isNothing (dataFamilyDeclKind dataFamilyDecl) ->
                 pure ()
         other ->
           assertFailure ("expected infix associated data family operator declaration, got: " <> show other)
@@ -1953,16 +1979,12 @@ test_prettyAssocDataFamilyOperatorName = do
         DeclClass
           ClassDecl
             { classDeclContext = Nothing,
-              classDeclHeadForm = TypeHeadPrefix,
-              classDeclName = mkUnqualifiedName NameConId "C",
-              classDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
+              classDeclHead = PrefixBinderHead (mkUnqualifiedName NameConId "C") [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
               classDeclFundeps = [],
               classDeclItems =
                 [ ClassItemDataFamilyDecl
                     DataFamilyDecl
-                      { dataFamilyDeclHeadForm = TypeHeadPrefix,
-                        dataFamilyDeclName = mkUnqualifiedName NameConSym ":*:",
-                        dataFamilyDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
+                      { dataFamilyDeclHead = PrefixBinderHead (mkUnqualifiedName NameConSym ":*:") [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible],
                         dataFamilyDeclKind = Nothing
                       }
                 ]
@@ -1976,16 +1998,17 @@ test_prettyAssocDataFamilyInfixOperatorName = do
         DeclClass
           ClassDecl
             { classDeclContext = Nothing,
-              classDeclHeadForm = TypeHeadPrefix,
-              classDeclName = mkUnqualifiedName NameConId "C",
-              classDeclParams = [TyVarBinder [] "x" Nothing TyVarBSpecified TyVarBVisible],
+              classDeclHead = PrefixBinderHead (mkUnqualifiedName NameConId "C") [TyVarBinder [] "x" Nothing TyVarBSpecified TyVarBVisible],
               classDeclFundeps = [],
               classDeclItems =
                 [ ClassItemDataFamilyDecl
                     DataFamilyDecl
-                      { dataFamilyDeclHeadForm = TypeHeadInfix,
-                        dataFamilyDeclName = mkUnqualifiedName NameConSym ":*:",
-                        dataFamilyDeclParams = [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible, TyVarBinder [] "b" Nothing TyVarBSpecified TyVarBVisible],
+                      { dataFamilyDeclHead =
+                          InfixBinderHead
+                            (TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible)
+                            (mkUnqualifiedName NameConSym ":*:")
+                            (TyVarBinder [] "b" Nothing TyVarBSpecified TyVarBVisible)
+                            [],
                         dataFamilyDeclKind = Just TStar
                       }
                 ]
@@ -2045,13 +2068,18 @@ prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators =
       prefixMatches =
         [ decl
         | decl@(DeclClass ClassDecl {classDeclItems}) <- samples,
-          ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclHeadForm = TypeHeadPrefix, dataFamilyDeclName = name} <- map peelClassDeclItemAnn classDeclItems,
+          ClassItemDataFamilyDecl dataFamilyDecl <- map peelClassDeclItemAnn classDeclItems,
+          binderHeadForm (dataFamilyDeclHead dataFamilyDecl) == TypeHeadPrefix,
+          let name = binderHeadName (dataFamilyDeclHead dataFamilyDecl),
           unqualifiedNameType name == NameConSym
         ]
       infixMatches =
         [ decl
         | decl@(DeclClass ClassDecl {classDeclItems}) <- samples,
-          ClassItemDataFamilyDecl DataFamilyDecl {dataFamilyDeclHeadForm = TypeHeadInfix, dataFamilyDeclName = name, dataFamilyDeclParams = params} <- map peelClassDeclItemAnn classDeclItems,
+          ClassItemDataFamilyDecl dataFamilyDecl <- map peelClassDeclItemAnn classDeclItems,
+          binderHeadForm (dataFamilyDeclHead dataFamilyDecl) == TypeHeadInfix,
+          let name = binderHeadName (dataFamilyDeclHead dataFamilyDecl),
+          let params = binderHeadParams (dataFamilyDeclHead dataFamilyDecl),
           unqualifiedNameType name == NameConSym
             && length params == 2
         ]

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -143,13 +143,16 @@ genDeclRoleAnnotation =
     <*> smallList0 (elements [RoleNominal, RoleRepresentational, RolePhantom, RoleInfer])
 
 genDeclTypeSyn :: Gen TypeSynDecl
-genDeclTypeSyn = TypeSynDecl TypeHeadPrefix <$> genConUnqualifiedName <*> genSimpleTyVarBinders <*> genType
+genDeclTypeSyn = TypeSynDecl <$> (PrefixBinderHead <$> genConUnqualifiedName <*> genSimpleTyVarBinders) <*> genType
 
 -- | Generate an infix type synonym, covering both symbolic operators
 -- (e.g. @type a :+: b = (a, b)@) and backtick-wrapped identifiers
 -- (e.g. @type a \`Plus\` b = (a, b)@).
 genDeclTypeSynInfix :: Gen TypeSynDecl
-genDeclTypeSynInfix = TypeSynDecl TypeHeadInfix <$> genConUnqualifiedName <*> smallList2 genSimpleTyVarBinder <*> genType
+genDeclTypeSynInfix =
+  TypeSynDecl
+    <$> (InfixBinderHead <$> genSimpleTyVarBinder <*> genConUnqualifiedName <*> genSimpleTyVarBinder <*> smallList0 genSimpleTyVarBinder)
+    <*> genType
 
 genDeclData :: Gen Decl
 genDeclData =
@@ -166,10 +169,8 @@ genDeclDataGadt = do
   ctors <- genGadtDataCons
   pure $
     DataDecl
-      { dataDeclHeadForm = TypeHeadPrefix,
+      { dataDeclHead = PrefixBinderHead name params,
         dataDeclContext = [],
-        dataDeclName = name,
-        dataDeclParams = params,
         dataDeclKind = Nothing,
         dataDeclConstructors = ctors,
         dataDeclDeriving = []
@@ -187,10 +188,11 @@ genDeclDataInfix = do
   deriving' <- genDerivingClauses
   pure $
     DataDecl
-      { dataDeclHeadForm = TypeHeadInfix,
+      { dataDeclHead =
+          case params of
+            lhs : rhs : tailParams -> InfixBinderHead lhs name rhs tailParams
+            _ -> error "genDeclDataInfix: expected at least two parameters",
         dataDeclContext = [],
-        dataDeclName = name,
-        dataDeclParams = params,
         dataDeclKind = kind,
         dataDeclConstructors = ctors,
         dataDeclDeriving = deriving'
@@ -207,10 +209,8 @@ genDeclTypeDataPrefix = do
   pure $
     DeclTypeData $
       DataDecl
-        { dataDeclHeadForm = TypeHeadPrefix,
+        { dataDeclHead = PrefixBinderHead name params,
           dataDeclContext = [],
-          dataDeclName = name,
-          dataDeclParams = params,
           dataDeclKind = Nothing,
           dataDeclConstructors = ctors,
           dataDeclDeriving = []
@@ -242,10 +242,8 @@ genSimpleDataDecl = do
   deriving' <- genDerivingClauses
   pure $
     DataDecl
-      { dataDeclHeadForm = TypeHeadPrefix,
+      { dataDeclHead = PrefixBinderHead name params,
         dataDeclContext = [],
-        dataDeclName = name,
-        dataDeclParams = params,
         dataDeclKind = kind,
         dataDeclConstructors = ctors,
         dataDeclDeriving = deriving'
@@ -378,10 +376,8 @@ genDeclNewtype = do
   pure $
     DeclNewtype $
       NewtypeDecl
-        { newtypeDeclHeadForm = TypeHeadPrefix,
+        { newtypeDeclHead = PrefixBinderHead name params,
           newtypeDeclContext = [],
-          newtypeDeclName = name,
-          newtypeDeclParams = params,
           newtypeDeclKind = Nothing,
           newtypeDeclConstructor = Just ctor,
           newtypeDeclDeriving = deriving'
@@ -420,9 +416,7 @@ genDeclClassPrefix = do
     DeclClass $
       ClassDecl
         { classDeclContext = ctx,
-          classDeclHeadForm = TypeHeadPrefix,
-          classDeclName = name,
-          classDeclParams = params,
+          classDeclHead = PrefixBinderHead name params,
           classDeclFundeps = [],
           classDeclItems = items
         }
@@ -478,25 +472,23 @@ genAssociatedDataFamilyDecl :: [TyVarBinder] -> Gen DataFamilyDecl
 genAssociatedDataFamilyDecl classParams = do
   let canUseInfixHead = length classParams >= 2
   infixHead <- if canUseInfixHead then elements [False, True] else pure False
-  (headForm, name, params) <-
+  head' <-
     if infixHead
       then do
         name <- mkUnqualifiedName NameConSym <$> genConSym
         shuffled <- shuffle classParams
         case shuffled of
-          lhs : rhs : _ -> pure (TypeHeadInfix, name, [lhs, rhs])
+          lhs : rhs : _ -> pure (InfixBinderHead lhs name rhs [])
           _ -> error "genAssociatedDataFamilyDecl: expected at least two class params"
       else do
         name <- genConUnqualifiedName
         paramCount <- chooseInt (0, min 2 (length classParams))
         params <- take paramCount <$> shuffle classParams
-        pure (TypeHeadPrefix, name, params)
+        pure (PrefixBinderHead name params)
   kind <- frequency [(3, pure Nothing), (1, Just <$> genSimpleType)]
   pure $
     DataFamilyDecl
-      { dataFamilyDeclHeadForm = headForm,
-        dataFamilyDeclName = name,
-        dataFamilyDeclParams = params,
+      { dataFamilyDeclHead = head',
         dataFamilyDeclKind = kind
       }
 
@@ -522,9 +514,10 @@ genDeclClassInfix = do
     DeclClass $
       ClassDecl
         { classDeclContext = ctx,
-          classDeclHeadForm = TypeHeadInfix,
-          classDeclName = name,
-          classDeclParams = params,
+          classDeclHead =
+            case params of
+              lhs : rhs : tailParams -> InfixBinderHead lhs name rhs tailParams
+              _ -> error "genDeclClassInfix: expected at least two parameters",
           classDeclFundeps = [],
           classDeclItems = items
         }
@@ -554,9 +547,7 @@ genDeclInstancePrefix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
-          instanceDeclHeadForm = TypeHeadPrefix,
-          instanceDeclClassName = className,
-          instanceDeclTypes = types,
+          instanceDeclHead = PrefixInstanceHead className types,
           instanceDeclItems = items
         }
 
@@ -575,9 +566,7 @@ genDeclInstanceInfix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
-          instanceDeclHeadForm = TypeHeadInfix,
-          instanceDeclClassName = className,
-          instanceDeclTypes = [lhs, rhs],
+          instanceDeclHead = InfixInstanceHead lhs className rhs,
           instanceDeclItems = items
         }
 
@@ -600,9 +589,7 @@ genDeclStandaloneDerivingPrefix = do
           standaloneDerivingForall = [],
           standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
-          standaloneDerivingHeadForm = TypeHeadPrefix,
-          standaloneDerivingClassName = className,
-          standaloneDerivingTypes = types
+          standaloneDerivingHead = PrefixInstanceHead className types
         }
 
 genDeclStandaloneDerivingInfix :: Gen Decl
@@ -622,9 +609,7 @@ genDeclStandaloneDerivingInfix = do
           standaloneDerivingForall = [],
           standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
-          standaloneDerivingHeadForm = TypeHeadInfix,
-          standaloneDerivingClassName = className,
-          standaloneDerivingTypes = [lhs, rhs]
+          standaloneDerivingHead = InfixInstanceHead lhs className rhs
         }
 
 genInstanceHeadType :: Gen Type
@@ -729,22 +714,21 @@ genDeclTypeFamilyDeclInfix = do
 genDeclDataFamilyDecl :: Gen Decl
 genDeclDataFamilyDecl = do
   infixHead <- elements [False, True]
-  (headForm, name, params) <-
+  head' <-
     if infixHead
       then do
         name <- mkUnqualifiedName NameConSym <$> genConSym
         params <- smallList2 genSimpleTyVarBinder
-        pure (TypeHeadInfix, name, params)
+        case params of
+          lhs : rhs : tailParams -> pure (InfixBinderHead lhs name rhs tailParams)
+          _ -> error "genDeclDataFamilyDecl: expected at least two parameters"
       else do
         name <- mkUnqualifiedName NameConId <$> genConId
-        params <- genSimpleTyVarBinders
-        pure (TypeHeadPrefix, name, params)
+        PrefixBinderHead name <$> genSimpleTyVarBinders
   pure $
     DeclDataFamilyDecl $
       DataFamilyDecl
-        { dataFamilyDeclHeadForm = headForm,
-          dataFamilyDeclName = name,
-          dataFamilyDeclParams = params,
+        { dataFamilyDeclHead = head',
           dataFamilyDeclKind = Nothing
         }
 
@@ -1113,9 +1097,9 @@ shrinkPatSynDecl ps =
 
 shrinkTypeSynDecl :: TypeSynDecl -> [TypeSynDecl]
 shrinkTypeSynDecl ts =
-  [ts {typeSynName = name'} | name' <- shrinkUnqualifiedName (typeSynName ts)]
+  [ts {typeSynHead = head'} | head' <- shrinkBinderHeadName shrinkUnqualifiedName (typeSynHead ts)]
     <> [ts {typeSynBody = ty'} | ty' <- shrinkType (typeSynBody ts)]
-    <> [ts {typeSynParams = ps'} | ps' <- shrinkTypeHeadParams (typeSynHeadForm ts) (typeSynParams ts)]
+    <> [ts {typeSynHead = head'} | head' <- shrinkBinderHeadParams (typeSynHead ts)]
 
 -- ---------------------------------------------------------------------------
 -- Data declarations
@@ -1128,7 +1112,7 @@ shrinkDataDecl dd =
     -- Shrink deriving clauses
     <> [dd {dataDeclDeriving = ds'} | ds' <- shrinkList shrinkDerivingClause (dataDeclDeriving dd)]
     -- Shrink type parameters
-    <> [dd {dataDeclParams = ps'} | ps' <- shrinkTypeHeadParams (dataDeclHeadForm dd) (dataDeclParams dd)]
+    <> [dd {dataDeclHead = head'} | head' <- shrinkBinderHeadParams (dataDeclHead dd)]
     -- Shrink context
     <> [dd {dataDeclContext = ctx'} | ctx' <- shrinkList shrinkType (dataDeclContext dd)]
 
@@ -1137,7 +1121,7 @@ shrinkNewtypeDecl nd =
   -- Shrink deriving
   [nd {newtypeDeclDeriving = ds'} | ds' <- shrinkList shrinkDerivingClause (newtypeDeclDeriving nd)]
     -- Shrink type parameters
-    <> [nd {newtypeDeclParams = ps'} | ps' <- shrinkTyVarBinders (newtypeDeclParams nd)]
+    <> [nd {newtypeDeclHead = head'} | head' <- shrinkBinderHeadParams (newtypeDeclHead nd)]
     -- Shrink context
     <> [nd {newtypeDeclContext = ctx'} | ctx' <- shrinkList shrinkType (newtypeDeclContext nd)]
 
@@ -1190,15 +1174,15 @@ shrinkDerivingClause dc =
 
 shrinkClassDecl :: ClassDecl -> [ClassDecl]
 shrinkClassDecl cd =
-  [cd {classDeclName = name'} | name' <- shrinkConName (classDeclName cd)]
+  [cd {classDeclHead = head'} | head' <- shrinkBinderHeadName shrinkConName (classDeclHead cd)]
     <> [cd {classDeclItems = is'} | is' <- shrinkList (const []) (classDeclItems cd)]
-    <> [cd {classDeclParams = ps'} | ps' <- shrinkTypeHeadParams (classDeclHeadForm cd) (classDeclParams cd)]
+    <> [cd {classDeclHead = head'} | head' <- shrinkBinderHeadParams (classDeclHead cd)]
     <> [cd {classDeclContext = ctx'} | Just ctx <- [classDeclContext cd], ctx' <- Nothing : [Just ctx'' | ctx'' <- shrinkList shrinkType ctx]]
 
 shrinkInstanceDecl :: InstanceDecl -> [InstanceDecl]
 shrinkInstanceDecl inst =
   [inst {instanceDeclItems = is'} | is' <- shrinkList (const []) (instanceDeclItems inst)]
-    <> [inst {instanceDeclTypes = ts'} | ts' <- shrinkTypeHeadTypes (instanceDeclHeadForm inst) (instanceDeclTypes inst)]
+    <> [inst {instanceDeclHead = head'} | head' <- shrinkInstanceHeadTypes (instanceDeclHead inst)]
     <> [inst {instanceDeclContext = ctx'} | ctx' <- shrinkList shrinkType (instanceDeclContext inst)]
 
 -- ---------------------------------------------------------------------------
@@ -1207,8 +1191,8 @@ shrinkInstanceDecl inst =
 
 shrinkStandaloneDerivingDecl :: StandaloneDerivingDecl -> [StandaloneDerivingDecl]
 shrinkStandaloneDerivingDecl sd =
-  [sd {standaloneDerivingClassName = name'} | name' <- shrinkName (standaloneDerivingClassName sd)]
-    <> [sd {standaloneDerivingTypes = ts'} | ts' <- shrinkList shrinkType (standaloneDerivingTypes sd), standaloneDerivingHeadForm sd /= TypeHeadInfix || length ts' >= 2]
+  [sd {standaloneDerivingHead = head'} | head' <- shrinkInstanceHeadName shrinkName (standaloneDerivingHead sd)]
+    <> [sd {standaloneDerivingHead = head'} | head' <- shrinkInstanceHeadTypes (standaloneDerivingHead sd)]
     <> [sd {standaloneDerivingContext = ctx'} | ctx' <- shrinkList shrinkType (standaloneDerivingContext sd)]
 
 -- ---------------------------------------------------------------------------
@@ -1231,7 +1215,7 @@ shrinkTypeFamilyDecl tf =
 
 shrinkDataFamilyDecl :: DataFamilyDecl -> [DataFamilyDecl]
 shrinkDataFamilyDecl df =
-  [df {dataFamilyDeclParams = ps'} | ps' <- shrinkTypeHeadParams (dataFamilyDeclHeadForm df) (dataFamilyDeclParams df)]
+  [df {dataFamilyDeclHead = head'} | head' <- shrinkBinderHeadParams (dataFamilyDeclHead df)]
 
 shrinkTypeFamilyInst :: TypeFamilyInst -> [TypeFamilyInst]
 shrinkTypeFamilyInst tfi =
@@ -1323,6 +1307,41 @@ shrinkTypeHeadTypes headForm tys =
   case headForm of
     TypeHeadPrefix -> shrinkList shrinkType tys
     TypeHeadInfix -> [tys' | tys' <- shrinkList shrinkType tys, length tys' >= 2]
+
+shrinkBinderHeadName :: (name -> [name]) -> BinderHead name -> [BinderHead name]
+shrinkBinderHeadName shrinkNameFn head' =
+  case head' of
+    PrefixBinderHead name params -> [PrefixBinderHead name' params | name' <- shrinkNameFn name]
+    InfixBinderHead lhs name rhs tailParams ->
+      [InfixBinderHead lhs name' rhs tailParams | name' <- shrinkNameFn name]
+
+shrinkBinderHeadParams :: BinderHead name -> [BinderHead name]
+shrinkBinderHeadParams head' =
+  case head' of
+    PrefixBinderHead name params ->
+      [PrefixBinderHead name params' | params' <- shrinkTyVarBinders params]
+    InfixBinderHead lhs name rhs tailParams ->
+      [ head''
+      | params' <- shrinkTypeHeadParams TypeHeadInfix (lhs : rhs : tailParams),
+        head'' <- case params' of
+          lhs' : rhs' : tailParams' -> [InfixBinderHead lhs' name rhs' tailParams']
+          _ -> []
+      ]
+
+shrinkInstanceHeadName :: (name -> [name]) -> InstanceHead name -> [InstanceHead name]
+shrinkInstanceHeadName shrinkNameFn head' =
+  case head' of
+    PrefixInstanceHead name tys -> [PrefixInstanceHead name' tys | name' <- shrinkNameFn name]
+    InfixInstanceHead lhs name rhs -> [InfixInstanceHead lhs name' rhs | name' <- shrinkNameFn name]
+
+shrinkInstanceHeadTypes :: InstanceHead name -> [InstanceHead name]
+shrinkInstanceHeadTypes head' =
+  case head' of
+    PrefixInstanceHead name tys ->
+      [PrefixInstanceHead name tys' | tys' <- shrinkTypeHeadTypes TypeHeadPrefix tys]
+    InfixInstanceHead lhs name rhs ->
+      [InfixInstanceHead lhs' name rhs | lhs' <- shrinkType lhs]
+        <> [InfixInstanceHead lhs name rhs' | rhs' <- shrinkType rhs]
 
 shrinkFunctionHeadPats :: MatchHeadForm -> [Pattern] -> [[Pattern]]
 shrinkFunctionHeadPats headForm pats =

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -413,19 +413,15 @@ normalizePatSynDir dir =
 normalizeTypeSynDecl :: TypeSynDecl -> TypeSynDecl
 normalizeTypeSynDecl decl =
   TypeSynDecl
-    { typeSynHeadForm = typeSynHeadForm decl,
-      typeSynName = typeSynName decl,
-      typeSynParams = map normalizeTyVarBinder (typeSynParams decl),
+    { typeSynHead = normalizeBinderHead (typeSynHead decl),
       typeSynBody = normalizeType (typeSynBody decl)
     }
 
 normalizeDataDecl :: DataDecl -> DataDecl
 normalizeDataDecl decl =
   DataDecl
-    { dataDeclHeadForm = dataDeclHeadForm decl,
+    { dataDeclHead = normalizeBinderHead (dataDeclHead decl),
       dataDeclContext = map normalizeType (dataDeclContext decl),
-      dataDeclName = dataDeclName decl,
-      dataDeclParams = map normalizeTyVarBinder (dataDeclParams decl),
       dataDeclKind = fmap normalizeType (dataDeclKind decl),
       dataDeclConstructors = map normalizeDataConDecl (dataDeclConstructors decl),
       dataDeclDeriving = map normalizeDerivingClause (dataDeclDeriving decl)
@@ -434,10 +430,8 @@ normalizeDataDecl decl =
 normalizeNewtypeDecl :: NewtypeDecl -> NewtypeDecl
 normalizeNewtypeDecl decl =
   NewtypeDecl
-    { newtypeDeclHeadForm = newtypeDeclHeadForm decl,
+    { newtypeDeclHead = normalizeBinderHead (newtypeDeclHead decl),
       newtypeDeclContext = map normalizeType (newtypeDeclContext decl),
-      newtypeDeclName = newtypeDeclName decl,
-      newtypeDeclParams = map normalizeTyVarBinder (newtypeDeclParams decl),
       newtypeDeclKind = fmap normalizeType (newtypeDeclKind decl),
       newtypeDeclConstructor = fmap normalizeDataConDecl (newtypeDeclConstructor decl),
       newtypeDeclDeriving = map normalizeDerivingClause (newtypeDeclDeriving decl)
@@ -496,9 +490,7 @@ normalizeClassDecl :: ClassDecl -> ClassDecl
 normalizeClassDecl decl =
   ClassDecl
     { classDeclContext = fmap (map normalizeType) (classDeclContext decl),
-      classDeclHeadForm = classDeclHeadForm decl,
-      classDeclName = classDeclName decl,
-      classDeclParams = map normalizeTyVarBinder (classDeclParams decl),
+      classDeclHead = normalizeBinderHead (classDeclHead decl),
       classDeclFundeps = classDeclFundeps decl,
       classDeclItems = map normalizeClassDeclItem (classDeclItems decl)
     }
@@ -524,9 +516,7 @@ normalizeInstanceDecl decl =
       instanceDeclForall = map normalizeTyVarBinder (instanceDeclForall decl),
       instanceDeclContext = map normalizeType (instanceDeclContext decl),
       instanceDeclParenthesizedHead = instanceDeclParenthesizedHead decl,
-      instanceDeclHeadForm = instanceDeclHeadForm decl,
-      instanceDeclClassName = instanceDeclClassName decl,
-      instanceDeclTypes = map normalizeType (instanceDeclTypes decl),
+      instanceDeclHead = normalizeInstanceHead (instanceDeclHead decl),
       instanceDeclItems = map normalizeInstanceDeclItem (instanceDeclItems decl)
     }
 
@@ -553,9 +543,7 @@ normalizeStandaloneDerivingDecl decl =
       standaloneDerivingForall = map normalizeTyVarBinder (standaloneDerivingForall decl),
       standaloneDerivingContext = map normalizeType (standaloneDerivingContext decl),
       standaloneDerivingParenthesizedHead = standaloneDerivingParenthesizedHead decl,
-      standaloneDerivingHeadForm = standaloneDerivingHeadForm decl,
-      standaloneDerivingClassName = standaloneDerivingClassName decl,
-      standaloneDerivingTypes = map normalizeType (standaloneDerivingTypes decl)
+      standaloneDerivingHead = normalizeInstanceHead (standaloneDerivingHead decl)
     }
 
 normalizeForeignDecl :: ForeignDecl -> ForeignDecl
@@ -601,11 +589,26 @@ normalizeTypeFamilyEq eq =
 normalizeDataFamilyDecl :: DataFamilyDecl -> DataFamilyDecl
 normalizeDataFamilyDecl df =
   DataFamilyDecl
-    { dataFamilyDeclHeadForm = dataFamilyDeclHeadForm df,
-      dataFamilyDeclName = dataFamilyDeclName df,
-      dataFamilyDeclParams = map normalizeTyVarBinder (dataFamilyDeclParams df),
+    { dataFamilyDeclHead = normalizeBinderHead (dataFamilyDeclHead df),
       dataFamilyDeclKind = fmap normalizeType (dataFamilyDeclKind df)
     }
+
+normalizeBinderHead :: BinderHead name -> BinderHead name
+normalizeBinderHead head' =
+  case head' of
+    PrefixBinderHead name params -> PrefixBinderHead name (map normalizeTyVarBinder params)
+    InfixBinderHead lhs name rhs tailParams ->
+      InfixBinderHead
+        (normalizeTyVarBinder lhs)
+        name
+        (normalizeTyVarBinder rhs)
+        (map normalizeTyVarBinder tailParams)
+
+normalizeInstanceHead :: InstanceHead name -> InstanceHead name
+normalizeInstanceHead head' =
+  case head' of
+    PrefixInstanceHead name tys -> PrefixInstanceHead name (map normalizeType tys)
+    InfixInstanceHead lhs name rhs -> InfixInstanceHead (normalizeType lhs) name (normalizeType rhs)
 
 normalizeTypeFamilyInst :: TypeFamilyInst -> TypeFamilyInst
 normalizeTypeFamilyInst tfi =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -47,6 +47,7 @@ import Aihc.Parser.Syntax
     Type (..),
     UnqualifiedName,
     ValueDecl (..),
+    binderHeadName,
     fromAnnotation,
     mkAnnotation,
     mkQualifiedName,
@@ -671,12 +672,13 @@ topLevelDeclAnnotations decl scope =
     (declSpan, DeclData dataDecl) -> dataDeclAnnotations declSpan "data " dataDecl
     (declSpan, DeclNewtype newtypeDecl) ->
       let span' = declSpan
+          typeName = binderHeadName (newtypeDeclHead newtypeDecl)
           typeAnnotation =
             ResolutionAnnotation
-              (declKeywordNameSpan "newtype " span' (renderUnqualifiedName (newtypeDeclName newtypeDecl)))
-              (renderUnqualifiedName (newtypeDeclName newtypeDecl))
+              (declKeywordNameSpan "newtype " span' (renderUnqualifiedName typeName))
+              (renderUnqualifiedName typeName)
               ResolutionNamespaceType
-              (resolveTopLevelType scope (newtypeDeclName newtypeDecl))
+              (resolveTopLevelType scope typeName)
           constructorAnnotations =
             maybe [] (\ctor -> [dataConAnnotation scope ctor]) (newtypeDeclConstructor newtypeDecl)
        in typeAnnotation : constructorAnnotations
@@ -684,17 +686,18 @@ topLevelDeclAnnotations decl scope =
   where
     dataDeclAnnotations declSpan keyword dataDecl =
       let span' = declSpan
+          typeName = binderHeadName (dataDeclHead dataDecl)
           typeAnnotation =
             ResolutionAnnotation
-              (declKeywordNameSpan keyword span' (renderUnqualifiedName (dataDeclName dataDecl)))
-              (renderUnqualifiedName (dataDeclName dataDecl))
+              (declKeywordNameSpan keyword span' (renderUnqualifiedName typeName))
+              (renderUnqualifiedName typeName)
               ResolutionNamespaceType
-              (resolveTopLevelType scope (dataDeclName dataDecl))
+              (resolveTopLevelType scope typeName)
        in typeAnnotation : map (dataConAnnotation scope) (dataDeclConstructors dataDecl)
 
 classAnnotation :: Scope -> SourceSpan -> ClassDecl -> ResolutionAnnotation
 classAnnotation scope declSpan classDecl =
-  let className = classDeclName classDecl
+  let className = binderHeadName (classDeclHead classDecl)
       span' = declSpan
    in ResolutionAnnotation
         (declKeywordNameSpan "class " span' (renderUnqualifiedName className))
@@ -764,12 +767,12 @@ declExportedNames decl =
             PVar name -> ([name], [])
             _ -> ([], [])
     DeclTypeSig names _ -> (names, [])
-    DeclClass classDecl -> ([], [classDeclName classDecl])
-    DeclTypeData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [dataDeclName dataDecl])
-    DeclData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [dataDeclName dataDecl])
+    DeclClass classDecl -> ([], [binderHeadName (classDeclHead classDecl)])
+    DeclTypeData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [binderHeadName (dataDeclHead dataDecl)])
+    DeclData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [binderHeadName (dataDeclHead dataDecl)])
     DeclNewtype newtypeDecl ->
       ( maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl),
-        [newtypeDeclName newtypeDecl]
+        [binderHeadName (newtypeDeclHead newtypeDecl)]
       )
     _ -> ([], [])
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -24,6 +24,7 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     UnqualifiedName (..),
     ValueDecl (..),
+    binderHeadName,
     fromAnnotation,
     getDeclSourceSpan,
     getPatternSourceSpan,
@@ -131,7 +132,7 @@ registerDecl _ = pure []
 --   - @False :: Bool@
 registerDataDecl :: DataDecl -> TcM [TcBindingResult]
 registerDataDecl dd = do
-  let tyName = unqualifiedNameText (dataDeclName dd)
+  let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
       resTy = TcTyCon (TyCon tyName 0) []
       starKind = TcTyCon (TyCon "*" 0) []
       tyConResult = TcBindingResult tyName starKind


### PR DESCRIPTION
## Summary
- replace overloaded `TypeHeadForm` usage for binder-headed declarations with `BinderHead`
- replace overloaded `TypeHeadForm` usage for instance-like declarations with `InstanceHead`
- update parser, pretty-printing, shorthand rendering, normalization, generators, and downstream consumers in resolve/tc to use the new structural heads

## Why
`TypeHeadForm` was encoding several different syntactic situations behind the same prefix/infix tag. For declarations like type synonyms, data/newtype declarations, classes, and data families, an infix head has a stronger structural invariant: it always has explicit left and right binders, with optional tail binders only for parenthesized infix heads. Representing those declarations with `BinderHead` makes that invariant part of the AST instead of a convention on separate fields.

For instances and standalone deriving, the corresponding invariant is different: infix heads are binary operand types, not binders. `InstanceHead` captures that shape directly without conflating it with binder-headed declarations.

## Impact
- illegal binder-headed and instance-headed AST states are no longer representable through separate `headForm`/`name`/`params` or `headForm`/`className`/`types` fields
- parser and pretty-printer logic now consume the structural head values directly
- downstream resolver and typechecker code now read declaration names from the new head structures
- shorthand output stays compatible by projecting the structural heads back to the existing rendered `headForm`/`name`/`params` or `types` fields

## Validation
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` was attempted after local checks passed, but the service returned a rate-limit error for the organization, so no review prompt was produced

## Progress Counts
- unchanged
