### PR TITLE
refactor(lexer): deduplicate and simplify lexing code

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -388,16 +388,12 @@ isStandaloneMinus input =
 tryLexNumberAfterMinus :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 tryLexNumberAfterMinus env st = do
   let stAfterMinus = advanceChars "-" st
-  (numTok, stFinal) <- firstJust numberLexers stAfterMinus
+  (numTok, stFinal) <-
+    lexHexFloat env stAfterMinus
+      <|> lexFloat env stAfterMinus
+      <|> lexIntBase env stAfterMinus
+      <|> lexInt env stAfterMinus
   Just (negateToken st numTok, stFinal)
-  where
-    numberLexers = [lexHexFloat env, lexFloat env, lexIntBase env, lexInt env]
-
-    firstJust [] _ = Nothing
-    firstJust (f : fs) s =
-      case f s of
-        Just result -> Just result
-        Nothing -> firstJust fs s
 
 negateToken :: LexerState -> LexToken -> LexToken
 negateToken stBefore numTok =
@@ -502,14 +498,11 @@ lexTypeApplication env st
               -- With whitespace, it can be a type application (TkTypeApp).
               if lexerHadTrivia st
                 then
-                  let st' = advanceChars "@" st
-                      kind
+                  let kind
                         | canStartTypeAtomT rest = TkTypeApp
                         | otherwise = TkVarSym "@"
-                   in Just (mkToken st st' "@" kind, st')
-                else
-                  let st' = advanceChars "@" st
-                   in Just (mkToken st st' "@" TkReservedAt, st')
+                   in Just (emitToken st "@" kind)
+                else Just (emitToken st "@" TkReservedAt)
         _ -> Nothing
   where
     canStartTypeAtomT t =
@@ -578,9 +571,17 @@ lexOverloadedLabel env st
 lexBangOrTildeOperator :: LexerState -> Maybe (LexToken, LexerState)
 lexBangOrTildeOperator st =
   case lexerInput st of
-    '!' :< rest -> lexPrefixSensitiveOp st '!' "!" TkPrefixBang rest
-    '~' :< rest -> lexPrefixSensitiveOp st '~' "~" TkPrefixTilde rest
+    '!' :< rest -> lexPrefixSensitiveOp st '!' TkPrefixBang rest
+    '~' :< rest -> lexPrefixSensitiveOp st '~' TkPrefixTilde rest
     _ -> Nothing
+
+isPrefixPosition :: LexerState -> Bool
+isPrefixPosition st =
+  case lexerPrevTokenKind st of
+    Nothing -> True
+    Just prevKind
+      | lexerHadTrivia st -> True
+      | otherwise -> prevTokenAllowsTightPrefix prevKind
 
 lexPrefixDollar :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexPrefixDollar env st
@@ -589,44 +590,27 @@ lexPrefixDollar env st
       case lexerInput st of
         '$' :< ('$' :< rest)
           | not (startsWithSymOp rest),
-            isPrefixPosition,
+            isPrefixPosition st,
             canStartSpliceAtomT rest ->
-              let st' = advanceChars "$$" st
-               in Just (mkToken st st' "$$" TkTHTypedSplice, st')
+              Just (emitToken st "$$" TkTHTypedSplice)
         '$' :< rest
           | not (startsWithSymOp rest),
-            isPrefixPosition,
+            isPrefixPosition st,
             canStartSpliceAtomT rest ->
-              let st' = advanceChars "$" st
-               in Just (mkToken st st' "$" TkTHSplice, st')
+              Just (emitToken st "$" TkTHSplice)
         _ -> Nothing
   where
-    isPrefixPosition =
-      case lexerPrevTokenKind st of
-        Nothing -> True
-        Just prevKind
-          | lexerHadTrivia st -> True
-          | otherwise -> prevTokenAllowsTightPrefix prevKind
-
     canStartSpliceAtomT t =
       case t of
         c :< _ -> isIdentStart c || c == '('
         _ -> False
 
-lexPrefixSensitiveOp :: LexerState -> Char -> Text -> LexTokenKind -> Text -> Maybe (LexToken, LexerState)
-lexPrefixSensitiveOp st opChar opStr prefixKind rest
+lexPrefixSensitiveOp :: LexerState -> Char -> LexTokenKind -> Text -> Maybe (LexToken, LexerState)
+lexPrefixSensitiveOp st opChar prefixKind rest
   | startsWithSymOp rest = Nothing
-  | isPrefixPosition && canStartPrefixPatternAtom rest =
-      let st' = advanceChars opStr st
-       in Just (mkToken st st' (T.singleton opChar) prefixKind, st')
+  | isPrefixPosition st && canStartPrefixPatternAtom rest =
+      Just (emitToken st (T.singleton opChar) prefixKind)
   | otherwise = Nothing
-  where
-    isPrefixPosition =
-      case lexerPrevTokenKind st of
-        Nothing -> True
-        Just prevKind
-          | lexerHadTrivia st -> True
-          | otherwise -> prevTokenAllowsTightPrefix prevKind
 
 canStartPrefixPatternAtom :: Text -> Bool
 canStartPrefixPatternAtom rest =
@@ -693,7 +677,7 @@ unicodeOpTokenKind hasArrows txt firstChar
 
 lexSymbol :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexSymbol env st =
-  firstJust symbols
+  firstTextKind st symbols
   where
     symbols =
       ( if hasExt UnboxedTuples env || hasExt UnboxedSums env
@@ -717,15 +701,11 @@ lexSymbol env st =
         c :< _ -> not (isSymbolicOpChar c)
         _ -> True
 
-    firstJust xs =
-      case xs of
-        [] -> Nothing
-        (sym, kind) : rest ->
-          if sym `T.isPrefixOf` lexerInput st
-            then
-              let st' = advanceChars sym st
-               in Just (mkToken st st' sym kind, st')
-            else firstJust rest
+isValidCharLiteral :: Text -> Bool
+isValidCharLiteral chars =
+  case scanQuoted '\'' chars of
+    Right (body, _) -> isJust (readMaybeChar ("'" <> body <> "'"))
+    Left _ -> False
 
 lexPromotedQuote :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexPromotedQuote _env st =
@@ -738,11 +718,6 @@ lexPromotedQuote _env st =
       | otherwise -> Nothing
     _ -> Nothing
   where
-    isValidCharLiteral chars =
-      case scanQuoted '\'' chars of
-        Right (body, _) -> isJust (readMaybeChar ("'" <> body <> "'"))
-        Left _ -> False
-
     isPromotionStart chars =
       case skipHorizontalWhitespace chars of
         c :< _
@@ -753,10 +728,7 @@ lexPromotedQuote _env st =
           | isSymbolicOpChar c -> True
         _ -> False
 
-    skipHorizontalWhitespace chars =
-      case chars of
-        c :< rest | c == ' ' || c == '\t' -> skipHorizontalWhitespace rest
-        _ -> chars
+    skipHorizontalWhitespace = T.dropWhile (\c -> c == ' ' || c == '\t')
 
 lexChar :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexChar env st =
@@ -835,12 +807,23 @@ lexQuasiQuote st =
                       else Just (quoter, body)
               _ -> Nothing
 
+emitToken :: LexerState -> Text -> LexTokenKind -> (LexToken, LexerState)
+emitToken st raw kind =
+  let st' = advanceChars raw st
+   in (mkToken st st' raw kind, st')
+
+firstTextKind :: LexerState -> [(Text, LexTokenKind)] -> Maybe (LexToken, LexerState)
+firstTextKind _ [] = Nothing
+firstTextKind st ((sym, kind) : rest)
+  | sym `T.isPrefixOf` lexerInput st = Just (emitToken st sym kind)
+  | otherwise = firstTextKind st rest
+
 lexTHQuoteBracket :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexTHQuoteBracket env st
   | not (thQuotesEnabled env st) = Nothing
   | otherwise =
       case lexerInput st of
-        '[' :< _ -> firstJust brackets
+        '[' :< _ -> firstTextKind st brackets
         _ -> Nothing
   where
     brackets =
@@ -853,24 +836,11 @@ lexTHQuoteBracket env st
         ("[p|", TkTHPatQuoteOpen)
       ]
 
-    firstJust [] = Nothing
-    firstJust ((sym, kind) : rest)
-      | sym `T.isPrefixOf` lexerInput st =
-          let st' = advanceChars sym st
-           in Just (mkToken st st' sym kind, st')
-      | otherwise = firstJust rest
-
 lexTHCloseQuote :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexTHCloseQuote env st
   | not (thQuotesEnabled env st) = Nothing
-  | "||]" `T.isPrefixOf` lexerInput st =
-      let raw = "||]"
-          st' = advanceChars raw st
-       in Just (mkToken st st' raw TkTHTypedQuoteClose, st')
-  | "|]" `T.isPrefixOf` lexerInput st =
-      let raw = "|]"
-          st' = advanceChars raw st
-       in Just (mkToken st st' raw TkTHExpQuoteClose, st')
+  | "||]" `T.isPrefixOf` lexerInput st = Just (emitToken st "||]" TkTHTypedQuoteClose)
+  | "|]" `T.isPrefixOf` lexerInput st = Just (emitToken st "|]" TkTHExpQuoteClose)
   | otherwise = Nothing
 
 lexTHNameQuote :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
@@ -881,21 +851,12 @@ lexTHNameQuote env st
         '\'' :< ('\'' :< rest)
           | Just c <- nextNonTriviaChar rest,
             isIdentStart c || c == '(' || c == '[' ->
-              let raw = "''"
-                  st' = advanceChars raw st
-               in Just (mkToken st st' raw TkTHTypeQuoteTick, st')
+              Just (emitToken st "''" TkTHTypeQuoteTick)
         '\'' :< rest0
           | not (isValidCharLiteral rest0) ->
-              let raw = "'"
-                  st' = advanceChars raw st
-               in Just (mkToken st st' raw TkTHQuoteTick, st')
+              Just (emitToken st "'" TkTHQuoteTick)
         _ -> Nothing
   where
-    isValidCharLiteral chars =
-      case scanQuoted '\'' chars of
-        Right (body, _) -> isJust (readMaybeChar ("'" <> body <> "'"))
-        Left _ -> False
-
     nextNonTriviaChar chars =
       case skipTrivia (st {lexerInput = chars}) of
         SkipDone st' ->
@@ -945,7 +906,7 @@ takeQuoter input =
   case input of
     c :< rest
       | isIdentStart c ->
-          let tailChars = T.takeWhile isIdentTailOrStart rest
+          let tailChars = T.takeWhile isIdentTail rest
               firstSeg = T.take (1 + T.length tailChars) input
               rest0 = T.drop (T.length tailChars) rest
            in go (T.length firstSeg) rest0
@@ -955,7 +916,7 @@ takeQuoter input =
       case chars of
         '.' :< (c' :< more)
           | isIdentStart c' ->
-              let tailChars = T.takeWhile isIdentTailOrStart more
+              let tailChars = T.takeWhile isIdentTail more
                   segLen = 1 + 1 + T.length tailChars
                in go (n + segLen) (T.drop (T.length tailChars) more)
         _ -> (T.take n input, chars)
@@ -984,45 +945,11 @@ isIdentNumber c =
     || generalCategory c == DecimalNumber
     || generalCategory c == OtherNumber
 
-isSymbolicOpChar :: Char -> Bool
-isSymbolicOpChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeSymbol c
-
 startsWithSymOp :: Text -> Bool
 startsWithSymOp t =
   case t of
     c :< _ -> isSymbolicOpChar c
     _ -> False
-
-isUnicodeSymbol :: Char -> Bool
-isUnicodeSymbol c =
-  isUnicodeSymbolCategory c
-    || c == '∷'
-    || c == '⇒'
-    || c == '→'
-    || c == '←'
-    || c == '∀'
-    || c == '⤙'
-    || c == '⤚'
-    || c == '⤛'
-    || c == '⤜'
-    || c == '⦇'
-    || c == '⦈'
-    || c == '⟦'
-    || c == '⟧'
-    || c == '⊸'
-
-isUnicodeSymbolCategory :: Char -> Bool
-isUnicodeSymbolCategory c =
-  case generalCategory c of
-    MathSymbol -> True
-    CurrencySymbol -> True
-    ModifierSymbol -> not (isAscii c)
-    OtherSymbol -> True
-    OtherPunctuation -> not (isAscii c)
-    _ -> False
-
-isIdentTailOrStart :: Char -> Bool
-isIdentTailOrStart = isIdentTail
 
 -- | Check if an identifier is reserved given a set of enabled extensions.
 -- This includes both base keywords and extension-specific keywords.

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -28,14 +28,11 @@ applyLayoutTokens enableModuleLayout exts =
 finalizeModuleLayoutAtEOF :: LayoutState -> SourceSpan -> ([LexToken], LayoutState)
 finalizeModuleLayoutAtEOF st anchor =
   case layoutModuleMode st of
-    ModuleLayoutSeekStart ->
-      ( [virtualSymbolToken "{" anchor, virtualSymbolToken "}" anchor],
-        st {layoutModuleMode = ModuleLayoutDone}
-      )
-    ModuleLayoutAwaitBody ->
-      ( [virtualSymbolToken "{" anchor, virtualSymbolToken "}" anchor],
-        st {layoutModuleMode = ModuleLayoutDone, layoutPendingLayout = Nothing}
-      )
+    mode
+      | mode == ModuleLayoutSeekStart || mode == ModuleLayoutAwaitBody ->
+          ( [virtualSymbolToken "{" anchor, virtualSymbolToken "}" anchor],
+            st {layoutModuleMode = ModuleLayoutDone, layoutPendingLayout = Nothing}
+          )
     _ -> ([], st)
 
 {-# INLINE noteModuleLayoutBeforeToken #-}
@@ -235,25 +232,21 @@ stepTokenContext st tok =
     TkSpecialRBrace -> st {layoutContexts = popOneContext (layoutContexts st)}
     _ -> st
 
-noteClassicIfInAfterThenElse :: LayoutState -> LayoutState
-noteClassicIfInAfterThenElse st = st {layoutContexts = go (layoutContexts st)}
+mapAfterThenElse :: (Int -> Int) -> [LayoutContext] -> [LayoutContext]
+mapAfterThenElse f = go
   where
     go contexts =
       case contexts of
         LayoutImplicit indent (LayoutAfterThenElse nestedIfs) : rest ->
-          LayoutImplicit indent (LayoutAfterThenElse (nestedIfs + 1)) : rest
+          LayoutImplicit indent (LayoutAfterThenElse (f nestedIfs)) : rest
         ctx : rest -> ctx : go rest
         [] -> []
 
+noteClassicIfInAfterThenElse :: LayoutState -> LayoutState
+noteClassicIfInAfterThenElse st = st {layoutContexts = mapAfterThenElse (+ 1) (layoutContexts st)}
+
 decrementAfterThenElseClassicIfDepth :: LayoutState -> LayoutState
-decrementAfterThenElseClassicIfDepth st = st {layoutContexts = go (layoutContexts st)}
-  where
-    go contexts =
-      case contexts of
-        LayoutImplicit indent (LayoutAfterThenElse nestedIfs) : rest ->
-          LayoutImplicit indent (LayoutAfterThenElse (max 0 (nestedIfs - 1))) : rest
-        ctx : rest -> ctx : go rest
-        [] -> []
+decrementAfterThenElseClassicIfDepth st = st {layoutContexts = mapAfterThenElse (max 0 . subtract 1) (layoutContexts st)}
 
 popToDelimiter :: [LayoutContext] -> [LayoutContext]
 popToDelimiter contexts =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Numbers.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Numbers.hs
@@ -125,12 +125,28 @@ lexInt env st =
                 lexIntSuffix env st digitsRaw n
            in Just (mkToken st st' tokTxt tokKind, st')
 
+-- | Parse optional MagicHash suffix (# or ##) and return the hash text and new state.
+magicHashSuffix :: LexerEnv -> LexerState -> Maybe (Text, LexerState)
+magicHashSuffix env st =
+  case lexerInput st of
+    '#' :< rest
+      | hasExt MagicHash env ->
+          case rest of
+            '#' :< _ -> Just ("##", advanceN 2 st)
+            _ -> Just ("#", advanceN 1 st)
+    _ -> Nothing
+
 -- | Parse optional MagicHash and ExtendedLiterals suffix for integers.
 -- Handles: (nothing), #, ##, #Int8, #Int16, #Int32, #Int64, #Int, #Word8, #Word16, #Word32, #Word64, #Word
 lexIntSuffix :: LexerEnv -> LexerState -> Text -> Integer -> (Text, LexTokenKind, LexerState)
 lexIntSuffix env st raw n =
   let st' = advanceChars raw st
       input = lexerInput st'
+      withMagicHash =
+        case magicHashSuffix env st' of
+          Just ("##", st'') -> (raw <> "##", TkInteger n TWordHash, st'')
+          Just ("#", st'') -> (raw <> "#", TkInteger n TIntHash, st'')
+          _ -> (raw, TkInteger n TInteger, st')
    in case input of
         '#' :< rest
           | hasExt ExtendedLiterals env ->
@@ -139,29 +155,8 @@ lexIntSuffix env st raw n =
                   let fullRaw = raw <> T.take (1 + suffixLen) input
                       st'' = advanceN (1 + suffixLen) st'
                    in (fullRaw, TkInteger n typeName, st'')
-                Nothing
-                  | hasExt MagicHash env ->
-                      case rest of
-                        '#' :< _ ->
-                          let fullRaw = raw <> "##"
-                              st'' = advanceN 2 st'
-                           in (fullRaw, TkInteger n TWordHash, st'')
-                        _ ->
-                          let fullRaw = raw <> "#"
-                              st'' = advanceN 1 st'
-                           in (fullRaw, TkInteger n TIntHash, st'')
-                  | otherwise ->
-                      (raw, TkInteger n TInteger, st')
-          | hasExt MagicHash env ->
-              case rest of
-                '#' :< _ ->
-                  let fullRaw = raw <> "##"
-                      st'' = advanceN 2 st'
-                   in (fullRaw, TkInteger n TWordHash, st'')
-                _ ->
-                  let fullRaw = raw <> "#"
-                      st'' = advanceN 1 st'
-                   in (fullRaw, TkInteger n TIntHash, st'')
+                Nothing -> withMagicHash
+          | otherwise -> withMagicHash
         _ -> (raw, TkInteger n TInteger, st')
 
 -- | Parse optional MagicHash and ExtendedLiterals suffix for floats.
@@ -169,19 +164,9 @@ lexIntSuffix env st raw n =
 lexFloatSuffix :: LexerEnv -> LexerState -> Text -> Rational -> (Text, LexTokenKind, LexerState)
 lexFloatSuffix env st raw value =
   let st' = advanceChars raw st
-      input = lexerInput st'
-   in case input of
-        '#' :< rest
-          | hasExt MagicHash env ->
-              case rest of
-                '#' :< _ ->
-                  let fullRaw = raw <> "##"
-                      st'' = advanceN 2 st'
-                   in (fullRaw, TkFloat value TDoubleHash, st'')
-                _ ->
-                  let fullRaw = raw <> "#"
-                      st'' = advanceN 1 st'
-                   in (fullRaw, TkFloat value TFloatHash, st'')
+   in case magicHashSuffix env st' of
+        Just ("##", st'') -> (raw <> "##", TkFloat value TDoubleHash, st'')
+        Just ("#", st'') -> (raw <> "#", TkFloat value TFloatHash, st'')
         _ -> (raw, TkFloat value TFractional, st')
 
 -- | Parse an ExtendedLiterals type suffix after the initial '#'.
@@ -285,23 +270,20 @@ takeHexExponent chars =
            in if T.null digits then Nothing else Just (T.take (T.length chars - T.length rest1 + T.length digits) chars)
     _ -> Nothing
 
-readHexLiteral :: Text -> Integer
-readHexLiteral txt =
-  case readHex (T.unpack (T.filter (/= '_') (T.drop 2 txt))) of
+readBaseLiteral :: String -> (String -> [(Integer, String)]) -> Text -> Integer
+readBaseLiteral label parser txt =
+  case parser (T.unpack (T.filter (/= '_') (T.drop 2 txt))) of
     [(n, "")] -> n
-    _ -> error ("invalid hex literal: " ++ T.unpack txt)
+    _ -> error ("invalid " ++ label ++ " literal: " ++ T.unpack txt)
+
+readHexLiteral :: Text -> Integer
+readHexLiteral = readBaseLiteral "hex" readHex
 
 readOctLiteral :: Text -> Integer
-readOctLiteral txt =
-  case readOct (T.unpack (T.filter (/= '_') (T.drop 2 txt))) of
-    [(n, "")] -> n
-    _ -> error ("invalid octal literal: " ++ T.unpack txt)
+readOctLiteral = readBaseLiteral "octal" readOct
 
 readBinLiteral :: Text -> Integer
-readBinLiteral txt =
-  case readInt 2 (`elem` ("01" :: String)) digitToInt (T.unpack (T.filter (/= '_') (T.drop 2 txt))) of
-    [(n, "")] -> n
-    _ -> error ("invalid binary literal: " ++ T.unpack txt)
+readBinLiteral = readBaseLiteral "binary" (readInt 2 (`elem` ("01" :: String)) digitToInt)
 
 parseDecimalFloatLiteral :: Text -> Rational
 parseDecimalFloatLiteral txt =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
@@ -14,7 +14,7 @@ where
 
 import Aihc.Parser.Lex.Pragmas (parseControlPragma)
 import Aihc.Parser.Lex.Types
-import Data.Char (GeneralCategory (..), generalCategory, isAscii, isDigit, isSpace)
+import Data.Char (isDigit, isSpace)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pattern (:<))
 import Data.Text qualified as T
@@ -191,37 +191,6 @@ isLineComment rest =
       | isSymbolicOpChar c -> False
       | otherwise -> True
     _ -> True
-
-isSymbolicOpChar :: Char -> Bool
-isSymbolicOpChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeSymbol c
-
-isUnicodeSymbol :: Char -> Bool
-isUnicodeSymbol c =
-  isUnicodeSymbolCategory c
-    || c == '∷'
-    || c == '⇒'
-    || c == '→'
-    || c == '←'
-    || c == '∀'
-    || c == '⤙'
-    || c == '⤚'
-    || c == '⤛'
-    || c == '⤜'
-    || c == '⦇'
-    || c == '⦈'
-    || c == '⟦'
-    || c == '⟧'
-    || c == '⊸'
-
-isUnicodeSymbolCategory :: Char -> Bool
-isUnicodeSymbolCategory c =
-  case generalCategory c of
-    MathSymbol -> True
-    CurrencySymbol -> True
-    ModifierSymbol -> not (isAscii c)
-    OtherSymbol -> True
-    OtherPunctuation -> not (isAscii c)
-    _ -> False
 
 readBoundedInt :: Text -> Maybe Int
 readBoundedInt txt = do

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -38,13 +38,16 @@ module Aihc.Parser.Lex.Types
     tokenEndLine,
     tokenStartCol,
     virtualSymbolToken,
+    isSymbolicOpChar,
+    isUnicodeSymbol,
+    isUnicodeSymbolCategory,
   )
 where
 
 import Aihc.Parser.Syntax
 import Aihc.Parser.Syntax qualified as Syntax
 import Control.DeepSeq (NFData)
-import Data.Char (ord)
+import Data.Char (GeneralCategory (..), generalCategory, isAscii, ord)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -393,3 +396,34 @@ utf8CharWidth ch =
       | code <= 0x7FF -> 2
       | code <= 0xFFFF -> 3
       | otherwise -> 4
+
+isSymbolicOpChar :: Char -> Bool
+isSymbolicOpChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isUnicodeSymbol c
+
+isUnicodeSymbol :: Char -> Bool
+isUnicodeSymbol c =
+  isUnicodeSymbolCategory c
+    || c == '∷'
+    || c == '⇒'
+    || c == '→'
+    || c == '←'
+    || c == '∀'
+    || c == '⤙'
+    || c == '⤚'
+    || c == '⤛'
+    || c == '⤜'
+    || c == '⦇'
+    || c == '⦈'
+    || c == '⟦'
+    || c == '⟧'
+    || c == '⊸'
+
+isUnicodeSymbolCategory :: Char -> Bool
+isUnicodeSymbolCategory c =
+  case generalCategory c of
+    MathSymbol -> True
+    CurrencySymbol -> True
+    ModifierSymbol -> not (isAscii c)
+    OtherSymbol -> True
+    OtherPunctuation -> not (isAscii c)
+    _ -> False


### PR DESCRIPTION
## Summary

This PR reduces lexer code size and complexity by extracting shared helpers and eliminating duplication across `Lex.hs`, `Lex/Layout.hs`, `Lex/Numbers.hs`, `Lex/Trivia.hs`, and `Lex/Types.hs`.

### Changes

- **Move shared character classification** (`isSymbolicOpChar`, `isUnicodeSymbol`, `isUnicodeSymbolCategory`) from `Lex.hs` and `Trivia.hs` into `Lex.Types` to eliminate a ~30-line copy-paste.
- **Extract reusable `firstTextKind` scanner**, replacing three local `firstJust` copies in `Lex.hs`.
- **Extract `isPrefixPosition` helper** used by `lexPrefixDollar` and `lexPrefixSensitiveOp`.
- **Extract `isValidCharLiteral` helper** used by `lexPromotedQuote` and `lexTHNameQuote`.
- **Introduce `emitToken` helper** for the common `advanceChars` + `mkToken` pattern.
- **De-duplicate MagicHash suffix parsing** in `Numbers.hs` with `magicHashSuffix`.
- **Abstract `readHexLiteral`/`readOctLiteral`/`readBinLiteral`** into `readBaseLiteral`.
- **Collapse identical branches** in `finalizeModuleLayoutAtEOF`.
- **Abstract `LayoutAfterThenElse` traversal** into `mapAfterThenElse`.
- **Remove `isIdentTailOrStart` alias** (inline `isIdentTail`).
- **Replace `tryLexNumberAfterMinus` local `firstJust`** with chained `(<|>)`.
- **Reuse `T.dropWhile`** instead of local `skipHorizontalWhitespace`.

### Metrics

- **Net reduction:** ~95 lines across 5 files.
- **All tests pass:** `just check` (ormolu, hlint, full test suite).