### PR TITLE
fix(parser): preserve layout across CPP #line directives

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -405,7 +405,8 @@ negateToken stBefore numTok =
     { lexTokenKind = negateKind (lexTokenKind numTok),
       lexTokenText = "-" <> lexTokenText numTok,
       lexTokenSpan = extendSpanLeft (lexTokenSpan numTok),
-      lexTokenOrigin = lexTokenOrigin numTok
+      lexTokenOrigin = lexTokenOrigin numTok,
+      lexTokenAtLineStart = lexerAtLineStart stBefore
     }
   where
     negateKind k =
@@ -937,7 +938,8 @@ eofToken st =
         { lexTokenKind = TkEOF,
           lexTokenText = "",
           lexTokenSpan = eofSpan,
-          lexTokenOrigin = FromSource
+          lexTokenOrigin = FromSource,
+          lexTokenAtLineStart = lexerAtLineStart st
         }
 
 takeQuoter :: Text -> (Text, Text)

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -318,10 +318,7 @@ closesImplicitBeforeDelimiter kind =
     _ -> False
 
 isBOL :: LayoutState -> LexToken -> Bool
-isBOL st tok =
-  case layoutPrevLine st of
-    Just prevLine -> tokenStartLine tok > prevLine
-    Nothing -> False
+isBOL _ = lexTokenAtLineStart
 
 layoutTransition :: LayoutState -> LexToken -> ([LexToken], LayoutState)
 layoutTransition st tok =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -190,7 +190,8 @@ data LexToken = LexToken
   { lexTokenKind :: !LexTokenKind,
     lexTokenText :: !Text,
     lexTokenSpan :: !SourceSpan,
-    lexTokenOrigin :: !TokenOrigin
+    lexTokenOrigin :: !TokenOrigin,
+    lexTokenAtLineStart :: !Bool
   }
   deriving (Eq, Ord, Show, Generic, NFData)
 
@@ -307,7 +308,8 @@ mkToken start end tokTxt kind =
     { lexTokenKind = kind,
       lexTokenText = tokTxt,
       lexTokenSpan = mkSpan start end,
-      lexTokenOrigin = FromSource
+      lexTokenOrigin = FromSource,
+      lexTokenAtLineStart = lexerAtLineStart start
     }
 
 mkErrorToken :: LexerState -> LexerState -> Text -> Text -> LexToken
@@ -379,10 +381,11 @@ virtualSymbolToken sym span' =
         "{" -> TkSpecialLBrace
         "}" -> TkSpecialRBrace
         ";" -> TkSpecialSemicolon
-        _ -> error ("virtualSymbolToken: unexpected symbol " ++ T.unpack sym),
+        _ -> error ("virtualSymbolToken: unknown symbol: " ++ show sym),
       lexTokenText = sym,
       lexTokenSpan = span',
-      lexTokenOrigin = InsertedLayout
+      lexTokenOrigin = InsertedLayout,
+      lexTokenAtLineStart = False
     }
 
 utf8CharWidth :: Char -> Int

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -228,6 +228,9 @@ buildTests = do
             testCase "applies LINE pragmas to subsequent tokens" test_linePragmaUpdatesSpan,
             testCase "applies COLUMN pragmas to subsequent tokens" test_columnPragmaUpdatesSpan,
             testCase "applies COLUMN pragmas in the middle of a line" test_inlineColumnPragmaUpdatesSpan,
+            testCase "sets lexTokenAtLineStart correctly" test_tokenAtLineStartWithoutDirective,
+            testCase "hash line directive sets lexTokenAtLineStart" test_hashLineDirectiveSetsAtLineStart,
+            testCase "hash line directive preserves layout" test_hashLineDirectivePreservesLayout,
             testCase "can lex lazily from chunks" test_lexerChunkLaziness,
             testCase "parser config passes extensions to lexer" test_parserConfigPassesExtensions,
             testCase "parser config sets source name in parse errors" test_parserConfigSetsSourceName,
@@ -1410,6 +1413,28 @@ test_inlineColumnPragmaUpdatesSpan =
         assertSourceSpan "<input>" 1 1 1 2 0 1 xSpan
         assertSourceSpan "<input>" 1 7 1 8 17 18 ySpan
     other -> assertFailure ("expected inline COLUMN pragma to update same-line column, got: " <> show other)
+
+test_tokenAtLineStartWithoutDirective :: Assertion
+test_tokenAtLineStartWithoutDirective =
+  case lexTokens "x y" of
+    [LexToken {lexTokenKind = TkVarId "x", lexTokenAtLineStart = True}, LexToken {lexTokenKind = TkVarId "y", lexTokenAtLineStart = False}, LexToken {lexTokenKind = TkEOF}] ->
+      pure ()
+    other -> assertFailure ("expected x at line start and y not at line start, got: " <> show other)
+
+test_hashLineDirectiveSetsAtLineStart :: Assertion
+test_hashLineDirectiveSetsAtLineStart =
+  case lexTokens "x\n#line 1 \"foo.hs\"\ny" of
+    [LexToken {lexTokenKind = TkVarId "x", lexTokenAtLineStart = True}, LexToken {lexTokenKind = TkVarId "y", lexTokenAtLineStart = True}, LexToken {lexTokenKind = TkEOF}] ->
+      pure ()
+    other -> assertFailure ("expected x and y both at line start, got: " <> show other)
+
+test_hashLineDirectivePreservesLayout :: Assertion
+test_hashLineDirectivePreservesLayout =
+  let source = T.unlines ["module Test where", "x = 1", "#line 1 \"foo.hs\"", "y = 2"]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        assertEqual "expected two declarations" 2 (length (moduleDecls modu))
 
 assertSourceSpan :: FilePath -> Int -> Int -> Int -> Int -> Int -> Int -> SourceSpan -> Assertion
 assertSourceSpan expectedName expectedStartLine expectedStartCol expectedEndLine expectedEndCol expectedStartOffset expectedEndOffset span' =

--- a/components/aihc-parser/test/Test/Properties/NoExceptions.hs
+++ b/components/aihc-parser/test/Test/Properties/NoExceptions.hs
@@ -116,7 +116,8 @@ genLexToken = do
   tokenText <- genTokenText
   span' <- genSourceSpan
   tokenOrigin <- elements [FromSource, InsertedLayout]
-  pure LexToken {lexTokenKind = kind, lexTokenText = tokenText, lexTokenSpan = span', lexTokenOrigin = tokenOrigin}
+  atLineStart <- arbitrary
+  pure LexToken {lexTokenKind = kind, lexTokenText = tokenText, lexTokenSpan = span', lexTokenOrigin = tokenOrigin, lexTokenAtLineStart = atLineStart}
 
 shrinkLexToken :: LexToken -> [LexToken]
 shrinkLexToken token =


### PR DESCRIPTION
## Summary

Fixes a class of parse failures in files that use CPP `#include` directives.

### Root cause

After CPP preprocessing, `#line` directives reset the logical line number (e.g. `#line 1 "./emojis.inc"`). The layout algorithm previously detected "beginning of line" by comparing a token's start line to the previous token's end line. When a `#line` directive reset the line number to something lower than the previous token's line, this comparison returned `False`, so the layout system failed to insert virtual semicolons between declarations.

### Fix

Propagate the lexer's existing `lexerAtLineStart` flag into each `LexToken` as `lexTokenAtLineStart`, and use it directly for BOL detection instead of comparing logical line numbers. This reflects the physical source layout and is immune to `#line` renumbering.

### CodeRabbit review

Addressed 1 finding: negated literal tokens (`-42`) now correctly derive `lexTokenAtLineStart` from the lexer state before the minus sign, rather than from the number token.

### Impact

- The `emojis` Hackage package now parses successfully (was failing with `unexpected =` after `#include "emojis.inc"`).
- Any package using `#include` with CPP-generated `#line` directives should benefit.
- Parser stackage progress likely improves, though exact counts depend on the next cron run.

### Tests

Added regression tests:
- `test_tokenAtLineStartWithoutDirective`
- `test_hashLineDirectiveSetsAtLineStart`
- `test_hashLineDirectivePreservesLayout`