### PR TITLE
feat(cpp): define WORD_SIZE_IN_BITS and WORD_SIZE_IN_BITS_FLOAT macros

### DIFF
--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cpp.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cpp.hs
@@ -29,7 +29,9 @@ builtinCppMacros =
     [ ("__GLASGOW_HASKELL__", "906"),
       ("__GLASGOW_HASKELL_FULL_VERSION__", "\"9.6.7\""),
       ("__GLASGOW_HASKELL_PATCHLEVEL1__", "7"),
-      ("__GLASGOW_HASKELL_PATCHLEVEL2__", "0")
+      ("__GLASGOW_HASKELL_PATCHLEVEL2__", "0"),
+      ("WORD_SIZE_IN_BITS", "64"),
+      ("WORD_SIZE_IN_BITS_FLOAT", "64.0")
     ]
 
 -- | Build the macro map for the CPP config from a list of @cpp-options@ strings.


### PR DESCRIPTION
## Summary

Define `WORD_SIZE_IN_BITS=64` and `WORD_SIZE_IN_BITS_FLOAT=64.0` in `builtinCppMacros` so these macros are available whenever CPP preprocessing is used.

## Changes

- Added `WORD_SIZE_IN_BITS` and `WORD_SIZE_IN_BITS_FLOAT` to `Aihc.Hackage.Cpp.builtinCppMacros`

## Affected Tools

This change affects all tools that use the shared CPP preprocessing machinery:
- `stackage-progress`
- `hackage-tester`
- `aihc-parser-cli`

## Testing

- Full test suite passes (`just check`)
- Existing test fixtures (`hashable-mix-cpp-if.hs`, `rules-pragma-cpp-branch.hs`) already exercise `WORD_SIZE_IN_BITS` and continue to pass