### PR TITLE
fix(parser): allow type applications in infix instance heads

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -692,10 +692,10 @@ bareInstanceHeadParser = MP.try infixHeadParser <|> prefixHeadParser
       pure (PrefixInstanceHead className instanceTypes)
 
     infixHeadParser = do
-      lhs <- typeAtomParser
+      lhs <- typeAppParser
       _ <- lookAhead typeInfixOperatorParser
       op <- typeFamilyOperatorParser
-      InfixInstanceHead lhs op <$> typeAtomParser
+      InfixInstanceHead lhs op <$> typeAppParser
 
 standaloneDerivingHeadParser :: TokParser (Bool, InstanceHead Name)
 standaloneDerivingHeadParser =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -623,7 +623,7 @@ addInstanceHeadParens :: InstanceHead name -> InstanceHead name
 addInstanceHeadParens head' =
   case head' of
     PrefixInstanceHead name tys -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys)
-    InfixInstanceHead lhs name rhs -> InfixInstanceHead (addTypeIn CtxTypeAtom lhs) name (addTypeIn CtxTypeAtom rhs)
+    InfixInstanceHead lhs name rhs -> InfixInstanceHead (addTypeIn CtxTypeFamilyOperand lhs) name (addTypeIn CtxTypeFamilyOperand rhs)
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl
 addForeignDeclParens decl =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/infix-instance-head-type-app.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/infix-instance-head-type-app.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeOperators #-}
+
+module InfixInstanceHeadTypeApp where
+
+class a :=> b where
+  ins :: a -> b
+
+instance Class b a => () :=> Class b a where
+  ins = Sub Dict

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -616,6 +616,7 @@ isInfixInstanceHeadType ty =
     TStar -> True
     TTuple {} -> True
     TList {} -> True
+    TApp fn arg -> isInfixInstanceHeadType fn && isInfixInstanceHeadType arg
     TTypeApp inner _ -> isInfixInstanceHeadType inner
     TParen inner -> isInfixInstanceHeadType inner
     _ -> False


### PR DESCRIPTION
## Summary

Fix parsing of infix instance heads where one or both operands are type applications (e.g. `() :=> Class b a`).

## Changes

- **Parser (`Decl.hs`)**: Changed `infixHeadParser` to use `typeAppParser` instead of `typeAtomParser` for both operands, matching GHC's `btype` grammar for infix instance heads.
- **Parens (`Parens.hs`)**: Updated infix instance head operands to use `CtxTypeFamilyOperand` instead of `CtxTypeAtom`, preventing unnecessary parentheses during pretty-printing and ensuring GHC fingerprint round-trip equality.
- **Oracle test**: Added regression test `TypeOperators/infix-instance-head-type-app`.
- **QuickCheck generator (`Arb/Decl.hs`)**: Extended `isInfixInstanceHeadType` to accept `TApp`, so generated test cases now cover type applications in infix instance heads.

## Verification

- `just check` passes (ormolu, hlint, full test suite).
- All 1537 parser spec tests pass.