### PR TITLE
fix(parser): close case layout when where is at same column

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -109,18 +109,42 @@ openImplicitLayout kind st tok =
 {-# INLINE closeBeforeToken #-}
 closeBeforeToken :: LayoutState -> LexToken -> ([LexToken], LayoutState)
 closeBeforeToken st tok =
-  closeWith $
-    case lexTokenKind tok of
-      TkKeywordIn -> closeLeadingImplicitLet (lexTokenSpan tok)
-      kind
-        | closesImplicitBeforeDelimiter kind ->
-            closeImplicitLayouts (lexTokenSpan tok) (\_ _ -> True)
-      TkKeywordThen -> closeBeforeThenElse
-      TkKeywordElse -> closeBeforeThenElse
-      TkKeywordWhere ->
-        closeImplicitLayouts (lexTokenSpan tok) (\indent kind -> tokenStartCol tok <= indent && kind /= LayoutCaseAlternative)
-      _ -> noLayoutClosures
+  case lexTokenKind tok of
+    TkKeywordWhere -> closeBeforeWhere st tok
+    _ ->
+      closeWith $
+        case lexTokenKind tok of
+          TkKeywordIn -> closeLeadingImplicitLet (lexTokenSpan tok)
+          kind
+            | closesImplicitBeforeDelimiter kind ->
+                closeImplicitLayouts (lexTokenSpan tok) (\_ _ -> True)
+          TkKeywordThen -> closeBeforeThenElse
+          TkKeywordElse -> closeBeforeThenElse
+          _ -> noLayoutClosures
   where
+    closeBeforeWhere st' tok' =
+      let col = tokenStartCol tok'
+          anchor = lexTokenSpan tok'
+          closeTok = virtualSymbolToken "}" anchor
+          openTok = virtualSymbolToken "{" anchor
+          go ctxs =
+            case ctxs of
+              LayoutImplicit indent LayoutCaseAlternative : rest
+                | col <= indent ->
+                    let (pendingInserted, clearPending) =
+                          case layoutPendingLayout st' of
+                            Just (PendingImplicitLayout _) -> ([openTok, closeTok], True)
+                            _ -> ([], False)
+                        st'' =
+                          if clearPending
+                            then st' {layoutPendingLayout = Nothing}
+                            else st'
+                     in (pendingInserted <> [closeTok], st'' {layoutContexts = rest})
+                | otherwise ->
+                    ([], st')
+              _ -> ([], st')
+       in go (layoutContexts st')
+
     closeBeforeThenElse =
       let col = tokenStartCol tok
           anchor = lexTokenSpan tok

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/case-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/case-where.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+module CaseWhere where
+
+run r =
+    case r of
+    OK n             -> ()
+    where
+    x = ()


### PR DESCRIPTION
## Summary

- Fix parser to correctly handle `where` clauses at the same column as case alternatives
- When `where` appears at the case level, the case layout is now closed so the where clause attaches to the function binding
- Added oracle test case for the fix

## Problem

The following code failed to parse with aihc-parser but worked in GHC:

```haskell
run =
    case r of
    OK n             -> ()
    where
    x = ()
```

The error was:
```
unexpected '='
expecting -> or guarded right-hand side
context: while parsing case alternative
```

## Root Cause

The layout handler had a `kind /= LayoutCaseAlternative` protection that prevented `where` from ever closing case layouts. This caused `where` clauses at the case level to produce empty layouts, and subsequent bindings to be incorrectly parsed as case alternatives.

## Fix

Modified `closeBeforeToken` to handle `TkKeywordWhere` specially:
- When `where` is at or to the left of the case layout column, close the case layout
- If a pending layout exists from a more-indented `where` inside the case, emit it as empty `{}` before closing the case layout
- Clear the pending layout to prevent it from being opened again

This fix maintains compatibility with existing cases like duplicate where clauses (where an indented `where` inside a case is followed by a function-level `where`).

## Test Progress

Oracle tests: 924 pass (was 923 pass, +1 new test)