### PR TITLE
feat(tc): implement GADT support with implication constraints

### DIFF
--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -71,37 +71,42 @@ annotateDecl :: TcAnnotation -> Decl -> Decl
 annotateDecl ann = DeclAnn (mkAnnotation ann)
 
 -- | Render a 'TcType' as a human-readable string.
+--
+-- Uses a precedence level to decide when to insert parentheses:
+--   0 = no parens needed (top level or right of ->)
+--   1 = parens needed for function types (left of ->)
+--   2 = parens needed for function types and type applications (inside type con args)
 renderTcType :: TcType -> String
-renderTcType = go False
+renderTcType = go 0
   where
-    go :: Bool -> TcType -> String
+    go :: Int -> TcType -> String
     go _ (TcTyVar tv) = T.unpack (tvName tv)
     go _ (TcMetaTv (Unique u)) = "?" ++ show u
     go _ (TcTyCon tc []) = T.unpack (tyConName tc)
-    go parens (TcTyCon tc args) =
-      paren parens $
-        unwords (T.unpack (tyConName tc) : map (go True) args)
-    go parens (TcFunTy a b) =
-      paren parens $
-        go True a ++ " -> " ++ go False b
-    go parens (TcForAllTy tv body) =
+    go p (TcTyCon tc args) =
+      parenIf (p >= 2) $
+        unwords (T.unpack (tyConName tc) : map (go 2) args)
+    go p (TcFunTy a b) =
+      parenIf (p >= 1) $
+        go 1 a ++ " -> " ++ go 0 b
+    go p (TcForAllTy tv body) =
       let (tvs, inner) = collectForAlls body
-       in paren parens $
-            "forall " ++ unwords (map (T.unpack . tvName) (tv : tvs)) ++ ". " ++ go False inner
-    go parens (TcQualTy preds body) =
-      paren parens $
-        "(" ++ unwords (map showPred preds) ++ ") => " ++ go False body
-    go parens (TcAppTy f a) =
-      paren parens $
-        go True f ++ " " ++ go True a
+       in parenIf (p >= 1) $
+            "forall " ++ unwords (map (T.unpack . tvName) (tv : tvs)) ++ ". " ++ go 0 inner
+    go p (TcQualTy preds body) =
+      parenIf (p >= 1) $
+        "(" ++ unwords (map showPred preds) ++ ") => " ++ go 0 body
+    go p (TcAppTy f a) =
+      parenIf (p >= 2) $
+        go 1 f ++ " " ++ go 2 a
 
     showPred (ClassPred cls args) =
-      T.unpack cls ++ " " ++ unwords (map (go True) args)
+      T.unpack cls ++ " " ++ unwords (map (go 2) args)
     showPred (EqPred t1 t2) =
-      go True t1 ++ " ~ " ++ go True t2
+      go 2 t1 ++ " ~ " ++ go 2 t2
 
-    paren False s = s
-    paren True s = "(" ++ s ++ ")"
+    parenIf False s = s
+    parenIf True s = "(" ++ s ++ ")"
 
 -- | Collect nested forall binders into a list.
 collectForAlls :: TcType -> ([TyVarId], TcType)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -321,10 +321,13 @@ registerDataCon tc paramMap paramVarIds con = case con of
         -- (the data type's params are handled via given equalities on match).
         scheme = ForAll [] [] conTy
      in do
-          mapM_ (\n -> do
-            let nm = unqualifiedNameText n
-            extendTermEnvPermanent nm (TcIdBinder nm scheme)
-            markGadtCon nm) names
+          mapM_
+            ( \n -> do
+                let nm = unqualifiedNameText n
+                extendTermEnvPermanent nm (TcIdBinder nm scheme)
+                markGadtCon nm
+            )
+            names
           case names of
             (n : _) -> do
               zonkedTy <- zonkType conTy
@@ -462,12 +465,12 @@ inferPatConstraints sp pat scrutTy = case pat of
             -- Regular constructor: emit as a WANTED constraint.
             let wantedCt = mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp
             pure [([wantedCt], [])]
-      _ -> pure [([],[])]
+      _ -> pure [([], [])]
   PAnn _ann inner -> inferPatConstraints sp inner scrutTy
   PParen inner -> inferPatConstraints sp inner scrutTy
   PStrict inner -> inferPatConstraints sp inner scrutTy
   PIrrefutable inner -> inferPatConstraints sp inner scrutTy
-  _ -> pure [([],[])]
+  _ -> pure [([], [])]
 
 -- | Unify an additional match equation's RHS with the expected type.
 unifyMatchRhs :: TcType -> Match -> TcM [Ct]

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -402,7 +402,7 @@ tcMatchEquation argTys resTy match = do
   let bindings = concatMap extractPatternBindings (zip pats argTys)
   -- Collect pattern constraints, separating GADT givens from regular wanteds.
   (wantedPatCts, givenCts) <-
-    (unzipPair . concat) <$> mapM (\(pat, argTy) -> inferPatConstraints sp pat argTy) (zip pats argTys)
+    unzipPair . concat <$> mapM (uncurry (inferPatConstraints sp)) (zip pats argTys)
   -- Infer the RHS under the extended environment.
   (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -402,8 +402,7 @@ tcMatchEquation argTys resTy match = do
   let bindings = concatMap extractPatternBindings (zip pats argTys)
   -- Collect pattern constraints, separating GADT givens from regular wanteds.
   (wantedPatCts, givenCts) <-
-    fmap (unzipPair . concat) $
-      mapM (\(pat, argTy) -> inferPatConstraints sp pat argTy) (zip pats argTys)
+    (unzipPair . concat) <$> mapM (\(pat, argTy) -> inferPatConstraints sp pat argTy) (zip pats argTys)
   -- Infer the RHS under the extended environment.
   (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.
@@ -438,7 +437,7 @@ unzipPair pairs =
 -- constructors that refine the scrutinee's type parameters).
 --
 -- Returns @(wantedCts, givenCts)@.
-inferPatConstraints :: SourceSpan -> Pattern -> TcType -> TcM ([([Ct], [Ct])])
+inferPatConstraints :: SourceSpan -> Pattern -> TcType -> TcM [([Ct], [Ct])]
 inferPatConstraints sp pat scrutTy = case pat of
   PCon name _typeArgs _subPats -> do
     let conName = patNameToText name

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -12,9 +12,11 @@ where
 
 import Aihc.Parser.Syntax
   ( Annotation,
+    BangType (..),
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
+    GadtBody (..),
     Match (..),
     Module (..),
     Name (..),
@@ -22,22 +24,29 @@ import Aihc.Parser.Syntax
     Pattern (..),
     Rhs (..),
     SourceSpan (..),
+    Type (..),
     UnqualifiedName (..),
     ValueDecl (..),
     binderHeadName,
+    binderHeadParams,
     fromAnnotation,
+    gadtBodyResultType,
     getDeclSourceSpan,
-    getPatternSourceSpan,
     peelDeclAnn,
+    peelTypeHead,
+    tyVarBinderName,
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Generalize (generalize)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Instantiate qualified
 import Aihc.Tc.Monad
-import Aihc.Tc.Solve (solveConstraints)
+import Aihc.Tc.Solve (solveConstraints, solveWithImpls)
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)
+import Data.List (nub)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 
@@ -63,12 +72,106 @@ tcModule m = do
   -- Phase 1: collect data declarations, register constructors,
   --          and report their types.
   dataResults <- concat <$> mapM registerDecl (moduleDecls m)
-  -- Phase 2: group and type-check value bindings.
-  -- Multiple FunctionBind declarations with the same name are merged
-  -- into a single binding with combined match equations.
+  -- Phase 2: collect type signatures and convert them to schemes.
+  let rawSigs = collectRawSigs (moduleDecls m)
+  schemes <- traverse sigToScheme rawSigs
+  -- Phase 3: group and type-check value bindings using signatures.
   let grouped = groupValueDecls (moduleDecls m)
-  valueResults <- concat <$> mapM tcDeclGroup grouped
+  valueResults <- concat <$> mapM (tcDeclGroup schemes) grouped
   pure (dataResults ++ valueResults)
+
+-- | Collect type signatures from a list of declarations.
+collectRawSigs :: [Decl] -> Map Text Type
+collectRawSigs decls = Map.fromList $ concatMap extractSig decls
+  where
+    extractSig (DeclTypeSig names ty) =
+      [(unqualifiedNameText n, ty) | n <- names]
+    extractSig (DeclAnn _ inner) = extractSig inner
+    extractSig _ = []
+
+-- | Collect free type variable names from a surface type.
+freeTypeVars :: Type -> [Text]
+freeTypeVars = nub . go
+  where
+    go (TVar name) = [unqualifiedNameText name]
+    go (TApp f a) = go f ++ go a
+    go (TFun a b) = go a ++ go b
+    go (TParen inner) = go inner
+    go (TAnn _ inner) = go inner
+    go (TContext _preds inner) = go inner
+    go (TForall _ inner) = go inner
+    go _ = []
+
+-- | Convert a surface type to a TcType, using a map from variable names to
+-- TyVarIds for any type variables in scope.
+convertSurfaceType :: Map Text TyVarId -> Type -> TcType
+convertSurfaceType tvMap ty = case peelTypeHead ty of
+  TVar name ->
+    let n = unqualifiedNameText name
+     in case Map.lookup n tvMap of
+          Just tvId -> TcTyVar tvId
+          Nothing -> TcTyCon (TyCon n 0) []
+  TCon name _ ->
+    TcTyCon (TyCon (nameText name) 0) []
+  TApp {} ->
+    -- Collect the full application chain to get the arity right.
+    let (headTy, args) = collectTApps ty
+        convertedArgs = map (convertSurfaceType tvMap) args
+        arity = length args
+     in case peelTypeHead headTy of
+          TCon name _ ->
+            TcTyCon (TyCon (nameText name) arity) convertedArgs
+          TVar name ->
+            let n = unqualifiedNameText name
+             in case Map.lookup n tvMap of
+                  Just tvId -> foldl TcAppTy (TcTyVar tvId) convertedArgs
+                  Nothing -> foldl TcAppTy (TcTyCon (TyCon n 0) []) convertedArgs
+          _ -> foldl TcAppTy (convertSurfaceType tvMap headTy) convertedArgs
+  TFun a b ->
+    TcFunTy (convertSurfaceType tvMap a) (convertSurfaceType tvMap b)
+  TTuple _ _ args ->
+    let tys = map (convertSurfaceType tvMap) args
+        n = length tys
+        tc = TyCon ("(" <> mconcat (replicate (n - 1) ",") <> ")") n
+     in TcTyCon tc tys
+  _ -> TcMetaTv (Unique (-1))
+
+-- | Collect the head and all arguments from a chain of type applications.
+collectTApps :: Type -> (Type, [Type])
+collectTApps ty = go ty []
+  where
+    go (TApp f a) acc = go (peelTypeHead f) (a : acc)
+    go t acc = (t, acc)
+
+-- | Convert a surface type signature to a TypeScheme.
+-- Free type variables become universally quantified type variables.
+sigToScheme :: Type -> TcM TypeScheme
+sigToScheme ty = do
+  let freeVars = freeTypeVars ty
+  tvIds <- mapM freshSkolemTv freeVars
+  let tvMap = Map.fromList (zip freeVars tvIds)
+      tcTy = convertSurfaceType tvMap ty
+  pure (ForAll tvIds [] tcTy)
+
+-- | Instantiate a type scheme with fresh skolems for type-checking.
+-- Unlike regular instantiation (which uses metas), this produces rigid
+-- type variables that cannot be unified during constraint solving.
+skolemize :: TypeScheme -> TcM TcType
+skolemize (ForAll tvs _preds body) = do
+  subst <- Map.fromList <$> mapM mkSubst tvs
+  pure (Aihc.Tc.Instantiate.applySubst subst body)
+  where
+    mkSubst tv = do
+      sk <- freshSkolemTv (tvName tv)
+      pure (tvUnique tv, TcTyVar sk)
+
+-- | Split a function type into argument types and result type.
+splitFunTy :: TcType -> Int -> ([TcType], TcType)
+splitFunTy ty 0 = ([], ty)
+splitFunTy (TcFunTy a rest) n =
+  let (args, res) = splitFunTy rest (n - 1)
+   in (a : args, res)
+splitFunTy ty _ = ([], ty)
 
 -- | A group of declarations that should be typechecked together.
 -- Multiple FunctionBind equations for the same name are merged.
@@ -102,18 +205,51 @@ hasSameName name d = case extractFunctionBind d of
   Nothing -> False
 
 -- | Type-check a declaration group.
-tcDeclGroup :: DeclGroup -> TcM [TcBindingResult]
-tcDeclGroup (SingleDecl d) = tcDecl d
-tcDeclGroup (MergedFunctionBind _sp binder matches) = do
+tcDeclGroup :: Map Text TypeScheme -> DeclGroup -> TcM [TcBindingResult]
+tcDeclGroup _ (SingleDecl d) = tcDecl d
+tcDeclGroup sigs (MergedFunctionBind _sp binder matches) = do
   let name = unqualifiedNameText binder
       displayName = renderBinderName binder
-  (ty, cts) <- tcMatches matches
-  _ <- solveConstraints cts
-  -- Generalize over free meta-variables to produce a type scheme.
+  case Map.lookup name sigs of
+    Just scheme -> do
+      -- Use the declared type signature for checking.
+      tcFunctionWithSig displayName name scheme matches
+    Nothing -> do
+      -- No signature: infer the type.
+      tcFunctionInfer displayName name matches
+
+-- | Type-check a function with a known type signature.
+-- The signature's type variables are opened as rigid skolems so that
+-- the body is checked against them. GADT patterns generate implication
+-- constraints using the signature's skolems as given equalities.
+tcFunctionWithSig :: Text -> Text -> TypeScheme -> [Match] -> TcM [TcBindingResult]
+tcFunctionWithSig displayName name scheme matches = do
+  -- Open the scheme with skolems (not metas) for checking.
+  sigTy <- skolemize scheme
+  let nArgs = case matches of
+        (m : _) -> length (matchPats m)
+        [] -> 0
+      (argTys, resTy) = splitFunTy sigTy nArgs
+  -- Check each equation against the signature types.
+  results <- mapM (tcMatchEquation argTys resTy) matches
+  let (ctsList, implsList) = unzip results
+      allCts = concat ctsList
+      allImpls = concat implsList
+  _ <- solveWithImpls allCts allImpls
+  -- Report the declared scheme as the binding's type.
+  let declaredTy = schemeToType scheme
+  zonkedTy <- zonkType declaredTy
+  extendTermEnvPermanent name (TcIdBinder name scheme)
+  pure [TcBindingResult displayName zonkedTy]
+
+-- | Type-check a function without a type signature (infer).
+tcFunctionInfer :: Text -> Text -> [Match] -> TcM [TcBindingResult]
+tcFunctionInfer displayName name matches = do
+  (ty, cts, impls) <- tcMatches matches
+  _ <- solveWithImpls cts impls
   scheme <- generalize ty []
   let schemeTy = schemeToType scheme
   zonkedTy <- zonkType schemeTy
-  -- Register the binding so later bindings can reference it.
   extendTermEnvPermanent name (TcIdBinder name scheme)
   pure [TcBindingResult displayName zonkedTy]
 
@@ -133,42 +269,72 @@ registerDecl _ = pure []
 registerDataDecl :: DataDecl -> TcM [TcBindingResult]
 registerDataDecl dd = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
-      resTy = TcTyCon (TyCon tyName 0) []
+      params = binderHeadParams (dataDeclHead dd)
+      arity = length params
       starKind = TcTyCon (TyCon "*" 0) []
       tyConResult = TcBindingResult tyName starKind
-  conResults <- mapM (registerDataCon resTy) (dataDeclConstructors dd)
+  -- Create TyVarIds for the type parameters.
+  paramVarIds <- mapM (freshSkolemTv . tyVarBinderName) params
+  let paramMap = Map.fromList (zip (map tyVarBinderName params) paramVarIds)
+      tc = TyCon tyName arity
+  conResults <- mapM (registerDataCon tc paramMap paramVarIds) (dataDeclConstructors dd)
   pure (tyConResult : conResults)
 
 -- | Register a single data constructor as a polymorphic binding.
 -- Returns the binding result for the constructor.
-registerDataCon :: TcType -> DataConDecl -> TcM TcBindingResult
-registerDataCon resTy con = case con of
-  DataConAnn _ inner -> registerDataCon resTy inner
-  PrefixCon _docs _ctx conName args ->
+registerDataCon :: TyCon -> Map Text TyVarId -> [TyVarId] -> DataConDecl -> TcM TcBindingResult
+registerDataCon tc paramMap paramVarIds con = case con of
+  DataConAnn _ inner -> registerDataCon tc paramMap paramVarIds inner
+  PrefixCon _docs _ctx conName _args ->
     let name = unqualifiedNameText conName
-        -- For each argument type, create a function type.
-        -- For MVP, we ignore the actual types and treat nullary
-        -- constructors as just returning the result type.
-        -- Constructors with args get a function type with fresh args.
-        scheme
-          | null args = ForAll [] [] resTy
-          | otherwise = ForAll [] [] resTy -- TODO: parse arg types
+        resTy = TcTyCon tc (map TcTyVar paramVarIds)
+        scheme = ForAll paramVarIds [] resTy
      in do
           extendTermEnvPermanent name (TcIdBinder name scheme)
-          pure (TcBindingResult name resTy)
+          zonkedTy <- zonkType resTy
+          pure (TcBindingResult name zonkedTy)
   InfixCon _docs _ctx _lhs conName _rhs ->
     let name = unqualifiedNameText conName
+        resTy = TcTyCon tc (map TcTyVar paramVarIds)
+        scheme = ForAll paramVarIds [] resTy
      in do
-          extendTermEnvPermanent name (TcIdBinder name (ForAll [] [] resTy))
-          pure (TcBindingResult name resTy)
+          extendTermEnvPermanent name (TcIdBinder name scheme)
+          zonkedTy <- zonkType resTy
+          pure (TcBindingResult name zonkedTy)
   RecordCon _docs _ctx conName _fields ->
     let name = unqualifiedNameText conName
+        resTy = TcTyCon tc (map TcTyVar paramVarIds)
+        scheme = ForAll paramVarIds [] resTy
      in do
-          extendTermEnvPermanent name (TcIdBinder name (ForAll [] [] resTy))
-          pure (TcBindingResult name resTy)
-  GadtCon {} ->
-    -- GADTs not handled in MVP.
-    pure (TcBindingResult "<gadt>" resTy)
+          extendTermEnvPermanent name (TcIdBinder name scheme)
+          zonkedTy <- zonkType resTy
+          pure (TcBindingResult name zonkedTy)
+  GadtCon _forallBinders _ctx names body ->
+    -- Parse the GADT constructor's declared result type.
+    let resultSurfTy = gadtBodyResultType body
+        argSurfTys = gadtBodyArgTypes body
+        gadtResTy = convertSurfaceType paramMap resultSurfTy
+        gadtArgTys = map (convertSurfaceType paramMap) argSurfTys
+        -- The constructor's full type: arg1 -> arg2 -> ... -> resultType
+        conTy = foldr TcFunTy gadtResTy gadtArgTys
+        -- GADT constructors are universally quantified over no extra vars
+        -- (the data type's params are handled via given equalities on match).
+        scheme = ForAll [] [] conTy
+     in do
+          mapM_ (\n -> do
+            let nm = unqualifiedNameText n
+            extendTermEnvPermanent nm (TcIdBinder nm scheme)
+            markGadtCon nm) names
+          case names of
+            (n : _) -> do
+              zonkedTy <- zonkType conTy
+              pure (TcBindingResult (unqualifiedNameText n) zonkedTy)
+            [] -> pure (TcBindingResult "<gadt>" gadtResTy)
+
+-- | Extract argument types from a GadtBody.
+gadtBodyArgTypes :: GadtBody -> [Type]
+gadtBodyArgTypes (GadtPrefixBody bangTys _) = map bangType bangTys
+gadtBodyArgTypes _ = []
 
 -- | Type-check a declaration, returning binding results for value bindings.
 tcDecl :: Decl -> TcM [TcBindingResult]
@@ -181,15 +347,7 @@ tcValueDecl :: ValueDecl -> TcM [TcBindingResult]
 tcValueDecl (FunctionBind binder matches) = do
   let name = unqualifiedNameText binder
       displayName = renderBinderName binder
-  (ty, cts) <- tcMatches matches
-  _ <- solveConstraints cts
-  -- Generalize over free meta-variables to produce a type scheme.
-  scheme <- generalize ty []
-  let schemeTy = schemeToType scheme
-  zonkedTy <- zonkType schemeTy
-  -- Register the binding so later bindings can reference it.
-  extendTermEnvPermanent name (TcIdBinder name scheme)
-  pure [TcBindingResult displayName zonkedTy]
+  tcFunctionInfer displayName name matches
 tcValueDecl (PatternBind _pat rhs) = do
   ty <- tcRhs rhs
   zonkedTy <- zonkType ty
@@ -207,43 +365,109 @@ schemeToType (ForAll tvs preds ty) = foldr TcForAllTy (TcQualTy preds ty) tvs
 -- All equations must have the same number of patterns and produce
 -- a consistent function type. We infer the type from each equation
 -- and unify them.
-tcMatches :: [Match] -> TcM (TcType, [Ct])
+tcMatches :: [Match] -> TcM (TcType, [Ct], [Implication])
 tcMatches [] = do
   ty <- freshMetaTv
-  pure (ty, [])
+  pure (ty, [], [])
 tcMatches matches@(m0 : _) = do
   let nArgs = length (matchPats m0)
   if nArgs == 0
     then do
       -- No patterns: just infer the RHS of the first match.
-      -- All match RHSes should agree on a type.
       (ty0, cts0) <- inferRhsExpr (matchRhs m0)
       restCts <- concatMapM (unifyMatchRhs ty0) (drop 1 matches)
-      pure (ty0, cts0 ++ restCts)
+      pure (ty0, cts0 ++ restCts, [])
     else do
       -- Create fresh meta-variables for the argument types and result type.
       argTys <- mapM (const freshMetaTv) [1 .. nArgs]
       resTy <- freshMetaTv
       -- Process each equation.
-      allCts <- concatMapM (tcMatchEquation argTys resTy) matches
-      let funTy = foldr TcFunTy resTy argTys
-      pure (funTy, allCts)
+      results <- mapM (tcMatchEquation argTys resTy) matches
+      let (ctsList, implsList) = unzip results
+          allCts = concat ctsList
+          allImpls = concat implsList
+          funTy = foldr TcFunTy resTy argTys
+      pure (funTy, allCts, allImpls)
 
 -- | Type-check a single match equation against expected arg/result types.
-tcMatchEquation :: [TcType] -> TcType -> Match -> TcM [Ct]
+-- Returns flat wanted constraints and implication constraints.
+tcMatchEquation :: [TcType] -> TcType -> Match -> TcM ([Ct], [Implication])
 tcMatchEquation argTys resTy match = do
   let pats = matchPats match
+      sp = sourceSpanFromAnns (matchAnns match)
   -- Bind pattern variables with their corresponding arg types.
   let bindings = concatMap extractPatternBindings (zip pats argTys)
-  -- Also emit constraints from constructor patterns.
-  patCts <- concatMapM (uncurry inferPatCts) (zip pats argTys)
+  -- Collect pattern constraints, separating GADT givens from regular wanteds.
+  (wantedPatCts, givenCts) <-
+    fmap (unzipPair . concat) $
+      mapM (\(pat, argTy) -> inferPatConstraints sp pat argTy) (zip pats argTys)
   -- Infer the RHS under the extended environment.
   (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.
   ev <- freshEvVar
-  let sp = sourceSpanFromAnns (matchAnns match)
   let resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
-  pure (patCts ++ rhsCts ++ [resCt])
+  let bodyWanteds = wantedPatCts ++ rhsCts ++ [resCt]
+  if null givenCts
+    then -- No GADT givens: emit everything as flat wanteds.
+      pure (bodyWanteds, [])
+    else do
+      -- GADT givens: wrap body wanteds in an implication.
+      level <- getTcLevel
+      let impl =
+            Implication
+              { implSkols = [],
+                implGivenEvs = map ctEvVar givenCts,
+                implGivenCts = givenCts,
+                implWantedCts = bodyWanteds,
+                implTcLevel = level,
+                implInfo = AppOrigin sp
+              }
+      pure ([], [impl])
+
+-- | Unzip a list of pairs of constraint lists.
+unzipPair :: [([Ct], [Ct])] -> ([Ct], [Ct])
+unzipPair pairs =
+  let (as, bs) = unzip pairs
+   in (concat as, concat bs)
+
+-- | Infer constraints from a single pattern, separated into regular wanted
+-- constraints (for non-GADT constructors) and given constraints (for GADT
+-- constructors that refine the scrutinee's type parameters).
+--
+-- Returns @(wantedCts, givenCts)@.
+inferPatConstraints :: SourceSpan -> Pattern -> TcType -> TcM ([([Ct], [Ct])])
+inferPatConstraints sp pat scrutTy = case pat of
+  PCon name _typeArgs _subPats -> do
+    let conName = patNameToText name
+    mBinder <- lookupTerm conName
+    case mBinder of
+      Just (TcIdBinder _ scheme) -> do
+        (conTy, _preds) <- instantiateSch scheme
+        let conResTy = resultType conTy
+        ev <- freshEvVar
+        gadtCon <- isGadtCon conName
+        if gadtCon
+          then do
+            -- GADT constructor: emit the scrutinee equality as a GIVEN.
+            let givenCt =
+                  Ct
+                    { ctPred = EqPred scrutTy conResTy,
+                      ctFlavor = Given,
+                      ctEvVar = ev,
+                      ctOrigin = AppOrigin sp,
+                      ctLoc = sp
+                    }
+            pure [([], [givenCt])]
+          else do
+            -- Regular constructor: emit as a WANTED constraint.
+            let wantedCt = mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp
+            pure [([wantedCt], [])]
+      _ -> pure [([],[])]
+  PAnn _ann inner -> inferPatConstraints sp inner scrutTy
+  PParen inner -> inferPatConstraints sp inner scrutTy
+  PStrict inner -> inferPatConstraints sp inner scrutTy
+  PIrrefutable inner -> inferPatConstraints sp inner scrutTy
+  _ -> pure [([],[])]
 
 -- | Unify an additional match equation's RHS with the expected type.
 unifyMatchRhs :: TcType -> Match -> TcM [Ct]
@@ -253,30 +477,6 @@ unifyMatchRhs expectedTy match = do
   let sp = sourceSpanFromAnns (matchAnns match)
   let eqCt = mkWantedCt (EqPred rhsTy expectedTy) ev (AppOrigin sp) sp
   pure (rhsCts ++ [eqCt])
-
--- | Infer constraints from a pattern matching against a scrutinee type.
---
--- For constructor patterns, emit that the scrutinee type matches the
--- constructor's result type. For variable and wildcard patterns, no
--- extra constraints are needed.
-inferPatCts :: Pattern -> TcType -> TcM [Ct]
-inferPatCts pat scrutTy = case pat of
-  PCon name _typeArgs _subPats -> do
-    let conName = patNameToText name
-    mBinder <- lookupTerm conName
-    case mBinder of
-      Just (TcIdBinder _ scheme) -> do
-        (conTy, _preds) <- instantiateSch scheme
-        let conResTy = resultType conTy
-        ev <- freshEvVar
-        let sp = getPatternSourceSpan pat
-        pure [mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp]
-      _ -> pure []
-  PAnn _ann inner -> inferPatCts inner scrutTy
-  PParen inner -> inferPatCts inner scrutTy
-  PStrict inner -> inferPatCts inner scrutTy
-  PIrrefutable inner -> inferPatCts inner scrutTy
-  _ -> pure []
 
 -- | Convert a Name to Text for lookup.
 patNameToText :: Name -> Text

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -402,7 +402,7 @@ tcMatchEquation argTys resTy match = do
   let bindings = concatMap extractPatternBindings (zip pats argTys)
   -- Collect pattern constraints, separating GADT givens from regular wanteds.
   (wantedPatCts, givenCts) <-
-    unzipPair . concat <$> mapM (uncurry (inferPatConstraints sp)) (zip pats argTys)
+    unzipPair . concat <$> zipWithM (inferPatConstraints sp) pats argTys
   -- Infer the RHS under the extended environment.
   (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -44,6 +44,7 @@ import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints, solveWithImpls)
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)
+import Control.Monad (zipWithM)
 import Data.List (nub)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map

--- a/components/aihc-tc/src/Aihc/Tc/Instantiate.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Instantiate.hs
@@ -5,6 +5,7 @@
 -- predicates.
 module Aihc.Tc.Instantiate
   ( instantiate,
+    applySubst,
   )
 where
 

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -32,6 +32,10 @@ module Aihc.Tc.Monad
     getTcLevel,
     withTcLevel,
 
+    -- * GADT constructor registry
+    markGadtCon,
+    isGadtCon,
+
     -- * Diagnostics
     emitDiagnostic,
     emitError,
@@ -48,6 +52,8 @@ import Control.Monad.Trans.Reader (ReaderT, asks, local, runReaderT)
 import Control.Monad.Trans.State.Strict (StateT, get, gets, modify', runStateT)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 
 -- | The type checker monad.
@@ -105,7 +111,9 @@ data TcState = TcState
     -- | Diagnostics (errors and warnings) collected.
     tcsDiagnostics :: ![TcDiagnostic],
     -- | Global term bindings (accumulated by top-level declarations).
-    tcsGlobalTerms :: !(Map Text TcBinder)
+    tcsGlobalTerms :: !(Map Text TcBinder),
+    -- | Names of GADT constructors (have non-trivial result types).
+    tcsGadtCons :: !(Set Text)
   }
   deriving (Show)
 
@@ -117,7 +125,8 @@ initTcState =
       tcsMetaSolutions = Map.empty,
       tcsEvBinds = Map.empty,
       tcsDiagnostics = [],
-      tcsGlobalTerms = Map.empty
+      tcsGlobalTerms = Map.empty,
+      tcsGadtCons = Set.empty
     }
 
 -- | Allocate a fresh 'Unique'.
@@ -211,3 +220,13 @@ emitError loc kind =
 -- | Get all diagnostics collected so far.
 getDiagnostics :: TcM [TcDiagnostic]
 getDiagnostics = lift $ gets (reverse . tcsDiagnostics)
+
+-- | Record that a constructor is a GADT constructor.
+markGadtCon :: Text -> TcM ()
+markGadtCon name = lift $ modify' $ \s ->
+  s {tcsGadtCons = Set.insert name (tcsGadtCons s)}
+
+-- | Check whether a constructor is a GADT constructor.
+isGadtCon :: Text -> TcM Bool
+isGadtCon name = lift $ gets $ \s ->
+  Set.member name (tcsGadtCons s)

--- a/components/aihc-tc/src/Aihc/Tc/Solve.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve.hs
@@ -14,6 +14,7 @@
 -- @
 module Aihc.Tc.Solve
   ( solveConstraints,
+    solveWithImpls,
     SolveResult (..),
   )
 where
@@ -26,7 +27,8 @@ import Aihc.Tc.Solve.Dict (DictResult (..), solveDict)
 import Aihc.Tc.Solve.Equality (EqResult (..), solveEquality)
 import Aihc.Tc.Solve.InertSet (InertSet, addInertDict, emptyInertSet)
 import Aihc.Tc.Solve.Worklist
-import Aihc.Tc.Types (Pred (..))
+import Aihc.Tc.Types (Pred (..), TcType (..))
+import Aihc.Tc.Zonk (zonkType)
 
 -- | Result of solving constraints.
 data SolveResult = SolveResult
@@ -39,8 +41,13 @@ data SolveResult = SolveResult
 
 -- | Solve a list of wanted constraints.
 solveConstraints :: [Ct] -> TcM SolveResult
-solveConstraints wanteds = do
-  let wl = foldr addWork emptyWorkList wanteds
+solveConstraints wanteds = solveWithImpls wanteds []
+
+-- | Solve wanted constraints together with implication constraints.
+solveWithImpls :: [Ct] -> [Implication] -> TcM SolveResult
+solveWithImpls wanteds impls = do
+  let wl0 = foldr addWork emptyWorkList wanteds
+      wl = foldr addImpl wl0 impls
   solveLoop wl emptyInertSet
 
 -- | Add a constraint to the appropriate bucket in the worklist.
@@ -58,9 +65,9 @@ solveLoop wl inerts = case popWork wl of
   Just (Left ct, wl') ->
     -- Process a flat constraint.
     processConstraint ct wl' inerts
-  Just (Right _impl, wl') ->
-    -- Implications: for MVP, skip and continue.
-    -- Full implementation will enter nested solver scope.
+  Just (Right impl, wl') -> do
+    -- Solve the implication by using its given constraints to satisfy wanteds.
+    solveImplication impl
     solveLoop wl' inerts
 
 -- | Process a single constraint from the worklist.
@@ -98,6 +105,77 @@ processEq wl ct = do
         p ->
           emitError (ctLoc errCt) (UnsolvedWanted p (ctOrigin errCt))
       pure wl
+
+-- | Solve an implication constraint.
+--
+-- The implication's given constraints (from GADT pattern matches) are
+-- canonicalized into atomic equalities, which are then used as rewrite
+-- rules to solve the implication's wanted constraints.
+solveImplication :: Implication -> TcM ()
+solveImplication impl = withTcLevel $ do
+  let rawGivens = implGivenCts impl
+      wanteds = implWantedCts impl
+  -- Canonicalize the given equalities by structural decomposition.
+  givenEqs <- concat <$> mapM (canonicalizeGiven) rawGivens
+  -- Solve each wanted using the given equalities as rewrite rules.
+  mapM_ (solveWantedWithGivens givenEqs) wanteds
+
+-- | Decompose a given constraint into atomic equalities.
+-- For example, @GADT a ~ GADT Bool@ decomposes into @[(a, Bool)]@.
+canonicalizeGiven :: Ct -> TcM [(TcType, TcType)]
+canonicalizeGiven ct = case ctPred ct of
+  EqPred t1 t2 -> do
+    t1' <- zonkType t1
+    t2' <- zonkType t2
+    pure (decomposeEq t1' t2')
+  _ -> pure []
+  where
+    decomposeEq t1 t2
+      | t1 == t2 = []
+    decomposeEq (TcTyCon tc1 args1) (TcTyCon tc2 args2)
+      | tc1 == tc2,
+        length args1 == length args2 =
+          concatMap (uncurry decomposeEq) (zip args1 args2)
+    decomposeEq (TcFunTy a1 b1) (TcFunTy a2 b2) =
+      decomposeEq a1 a2 ++ decomposeEq b1 b2
+    decomposeEq t1 t2 = [(t1, t2)]
+
+-- | Apply a list of given equalities as a substitution to a type.
+-- Each given @(lhs, rhs)@ rewrites occurrences of @lhs@ with @rhs@.
+applyGivenSubst :: [(TcType, TcType)] -> TcType -> TcType
+applyGivenSubst givens ty = foldr applyOne ty givens
+  where
+    applyOne (lhs, rhs) t
+      | t == lhs = rhs
+      | otherwise =
+          case t of
+            TcTyCon tc args -> TcTyCon tc (map (applyOne (lhs, rhs)) args)
+            TcFunTy a b -> TcFunTy (applyOne (lhs, rhs) a) (applyOne (lhs, rhs) b)
+            TcAppTy f a -> TcAppTy (applyOne (lhs, rhs) f) (applyOne (lhs, rhs) a)
+            TcForAllTy tv body -> TcForAllTy tv (applyOne (lhs, rhs) body)
+            _ -> t
+
+-- | Attempt to solve a wanted constraint using given equalities.
+-- Rewrites both sides of the wanted using the given substitution and
+-- then tries to solve the resulting equality.
+solveWantedWithGivens :: [(TcType, TcType)] -> Ct -> TcM ()
+solveWantedWithGivens givens ct = case ctPred ct of
+  EqPred t1 t2 -> do
+    t1' <- zonkType t1
+    t2' <- zonkType t2
+    let t1'' = applyGivenSubst givens t1'
+        t2'' = applyGivenSubst givens t2'
+    result <- solveEquality (ct {ctPred = EqPred t1'' t2''})
+    case result of
+      EqSolved -> pure ()
+      EqStuck _ -> pure ()
+      EqError errCt ->
+        case ctPred errCt of
+          EqPred et1 et2 ->
+            emitError (ctLoc errCt) (UnificationError et1 et2 (ctOrigin errCt))
+          p ->
+            emitError (ctLoc errCt) (UnsolvedWanted p (ctOrigin errCt))
+  _ -> pure ()
 
 -- | Strict left fold in a monad.
 foldM :: (Monad m) => (a -> b -> m a) -> a -> [b] -> m a

--- a/components/aihc-tc/src/Aihc/Tc/Solve.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve.hs
@@ -116,7 +116,7 @@ solveImplication impl = withTcLevel $ do
   let rawGivens = implGivenCts impl
       wanteds = implWantedCts impl
   -- Canonicalize the given equalities by structural decomposition.
-  givenEqs <- concat <$> mapM (canonicalizeGiven) rawGivens
+  givenEqs <- concat <$> mapM canonicalizeGiven rawGivens
   -- Solve each wanted using the given equalities as rewrite rules.
   mapM_ (solveWantedWithGivens givenEqs) wanteds
 

--- a/components/aihc-tc/test/Test/Fixtures/golden/basic-gadt.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/basic-gadt.yaml
@@ -1,0 +1,21 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = True | False
+    data GADT a where
+      IsBool :: GADT Bool
+    not True = False
+    not False = True
+
+    fn :: a -> GADT a -> a
+    fn x IsBool = not x
+expected:
+  - "Bool :: *"
+  - "True :: Bool"
+  - "False :: Bool"
+  - "GADT :: *"
+  - "IsBool :: GADT Bool"
+  - "not :: Bool -> Bool"
+  - "fn :: forall a. a -> GADT a -> a"
+status: pass


### PR DESCRIPTION
Add OutsideIn(X) implication-based coercion propagation for GADT pattern matching. When matching a GADT constructor, the scrutinee equality becomes a given constraint inside an implication, which the solver uses to satisfy branch-local wanteds via rewriting.

Key changes:
- Monad: track GADT constructor names for implication generation
- Decl: parse GadtCon syntax and register constructors with proper types; handle DeclTypeSig to skolemize declared signatures; generate Implication constraints (given scrutinee equality, wanted body) for GADT constructor patterns; convert surface types to TcTypes
- Instantiate: export applySubst for use in skolemization
- Solve: implement solveImplication using given equality rewriting to satisfy branch-local wanteds; add solveWithImpls entry point
- Annotations: fix renderTcType to use precedence-based parenthesization so type constructor applications (e.g. GADT a) are not needlessly wrapped in parens as -> arguments
- golden/basic-gadt.yaml: promote from xfail to pass