### PR TITLE
test: add xfail oracle fixtures for pqueue, mixed-types-num, and dns parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/dns-transform-list-comp.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/dns-transform-list-comp.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail TransformListComp syntax not supported -}
+{-# LANGUAGE TransformListComp #-}
+module A where
+import GHC.Exts (the, groupWith)
+f ts = [ (the x, y) | t <- ts, let x = t, let y = t, then group by x using groupWith ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/mixed-types-num-type-sig-in-if-then-branch.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/mixed-types-num-type-sig-in-if-then-branch.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST xfail type signature in if-then branch rejected -}
+module A where
+f = if True then x :: Int else x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/pqueue-infix-pattern-synonym-where-clause.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/pqueue-infix-pattern-synonym-where-clause.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail infix explicitly-bidirectional pattern synonym where clause not parsed -}
+{-# LANGUAGE PatternSynonyms #-}
+module A where
+pattern (:<) :: (a, b) -> [(a, b)] -> [(a, b)]
+pattern x :< xs <- (x : xs)
+  where
+    (a, b) :< xs = (a, b) : xs


### PR DESCRIPTION
## Summary

- Add 3 minimized xfail oracle fixtures from Hackage parse failures (xfail: 924 → 927)

### Fixtures

**`Hackage/pqueue-infix-pattern-synonym-where-clause.hs`**
The `where` clause of an infix explicitly-bidirectional pattern synonym is not parsed as part of the pattern synonym declaration. The builder equations leak out as top-level declarations. When the builder uses a tuple pattern on the LHS (e.g., `(a, b) :< xs = ...`), this causes a parse error.

**`Hackage/mixed-types-num-type-sig-in-if-then-branch.hs`**
A type signature (`::`) in the `then` branch of an `if-then-else` expression is rejected. `if True then x :: Int else x` is valid Haskell (GHC accepts it) but aihc-parser fails with `unexpected '::'`.

**`Hackage/dns-transform-list-comp.hs`**
`TransformListComp` extension syntax (`then group by ... using ...` in list comprehensions) is not supported. The `then` keyword is unexpected in comprehension position.