### PR TITLE
test(fixtures): add xfail oracle fixtures for thyme, ihaskell, and citeproc

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/citeproc-newtype-parens-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/citeproc-newtype-parens-xfail.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail parser rejects parenthesised newtype constructor in newtype declaration -}
+module CiteprocNewtypeParens where
+
+newtype (ReferenceMap a) = ReferenceMap { unReferenceMap :: [(a)] }
+  deriving (Show)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ihaskell-type-annotation-in-do-case-if-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ihaskell-type-annotation-in-do-case-if-xfail.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail parser fails on type annotation in then-branch of if inside do-case alternative -}
+module IHaskellTypeAnnotationInDoCaseIf where
+
+f flag y = do
+  case y of
+    Right b ->
+      if flag
+        then b :: [Int]
+        else b

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/thyme-lambda-record-wildcard-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/thyme-lambda-record-wildcard-xfail.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail pretty-printer wraps Con{..} lambda patterns in extra parens causing roundtrip mismatch -}
+{-# LANGUAGE RecordWildCards #-}
+module ThymeLambdaRecordWildcard where
+
+f = (\ TimeZone {..} -> undefined, \ TimeZone {..} -> undefined)


### PR DESCRIPTION
## Summary

Minimized three Hackage parse failures into oracle xfail regression fixtures.

- **citeproc** (`citeproc-newtype-parens-xfail.hs`): parser rejects `newtype (T a) = ...` — parenthesised constructor name in newtype declaration is valid GHC syntax but fails in aihc-parser
- **ihaskell** (`ihaskell-type-annotation-in-do-case-if-xfail.hs`): parser fails on a type annotation (`b :: [Int]`) in the `then`-branch of an `if` expression inside a `do`-`case` alternative
- **thyme** (`thyme-lambda-record-wildcard-xfail.hs`): pretty-printer wraps `Con {..}` lambda patterns in extra parens (`\ (TimeZone {..}) ->` instead of `\ TimeZone {..} ->`), causing roundtrip fingerprint mismatch

## Test plan
- [x] Each snippet is accepted by GHC (no parse errors, only scope errors)
- [x] Each snippet fails in aihc-parser for the expected reason
- [x] `cabal run aihc-parser:spec -- --pattern "Hackage"` shows all 3 new fixtures as `OK` (xfail confirmed)