### PR TITLE
test: add xfail oracle fixtures for barbies, slack-web, vinyl parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/barbies-parenthesized-infix-operator-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/barbies-parenthesized-infix-operator-instance.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail parser rejects parenthesized infix type operator applied to argument in instance head -}
+{-# LANGUAGE TypeOperators #-}
+module BarbiesParenthesizedInfixOperatorInstance where
+
+instance (c & d) a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/slack-web-type-annotation-in-if-then-else.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/slack-web-type-annotation-in-if-then-else.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail parser rejects type annotation in if-then branch expression -}
+module SlackWebTypeAnnotationInIfThenElse where
+
+f = if x then y :: T else z

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/vinyl-type-family-default-compound-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/vinyl-type-family-default-compound-rhs.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail parser rejects type family default with compound right-hand side -}
+{-# LANGUAGE TypeFamilies #-}
+module VinylTypeFamilyDefaultCompoundRhs where
+
+class C f where
+  type T f = f Int


### PR DESCRIPTION
## Summary

- Add 3 xfail oracle test cases minimized from Hackage package parse failures
- All cases: GHC accepts, aihc-parser rejects
- `just check` passes (all fixtures classified as XFAIL)

## New Fixtures

### `barbies-parenthesized-infix-operator-instance.hs`
Parser rejects parenthesized infix type operator applied to an argument in an instance head.
```haskell
instance (c & d) a
```
Source: `barbies-2.1.1.0` / `Barbies.Internal.ConstraintsB`

### `slack-web-type-annotation-in-if-then-else.hs`
Parser rejects type annotation (`::`) in an if-then branch expression.
```haskell
f = if x then y :: T else z
```
Source: `slack-web-2.2.0.0` / `Web.Slack.Conversation`

### `vinyl-type-family-default-compound-rhs.hs`
Parser rejects type family default when the right-hand side is a type application.
```haskell
class C f where
  type T f = f Int
```
Source: `vinyl-0.14.3` / `Data.Vinyl.XRec`

## Progress Counts

- Oracle xfail: +3