### PR TITLE
test(fixtures): add xfail oracle fixtures for ghc-exactprint, BNFC-meta, and happy-lib

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-prefix-cons-pattern-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-prefix-cons-pattern-xfail.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail parser rejects prefix-section (:) constructor in case pattern -}
+module A where
+
+f xs = case xs of
+  (:) x ys -> x
+  [] -> error "empty"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-exactprint-parenthesised-class-head-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-exactprint-parenthesised-class-head-xfail.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail parser rejects parenthesised class head in class declaration -}
+module A where
+
+class (Monad m) => (HasTransform m) where
+  liftT :: Int -> m Int

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-pattern-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-pattern-xfail.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST xfail negative MagicHash literal in function equation pattern misparses as infix minus -}
+{-# LANGUAGE MagicHash #-}
+module A where
+
+import GHC.Exts
+
+f :: Int# -> Int
+f  0# = 0
+f -1# = 1
+f  _  = 2


### PR DESCRIPTION
## Summary

Three minimal xfail oracle fixtures for parse failures found via `hackage-tester`:

- **ghc-exactprint** — parenthesised class head `(HasTransform m)` in a class declaration; aihc-parser rejects the extra parens around the class head constructor
- **BNFC-meta** — prefix `(:)` constructor used as a case pattern; aihc-parser rejects the operator-section form in pattern position
- **happy-lib** — negative `MagicHash` literal `-1#` in a function equation LHS; aihc-parser misparses it as infix minus applied to `f` and `1#`

All three snippets are accepted by GHC and rejected/misparsed by aihc-parser with the same root cause as the originating package failures.

## Test plan

- [ ] `cabal test aihc-parser` — all three new fixtures register as `OutcomeXFail`, no regressions