### PR TITLE
test: add xfail oracle fixtures for generic-lens-core, row-types, and sop-core parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-paren-infix-type-family-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-paren-infix-type-family-xfail.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail parser rejects parenthesised infix type family head -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module GenericLensCoreParenInfixTypeFamily where
+
+type family (a ++ b)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/row-types-nbsp-layout-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/row-types-nbsp-layout-xfail.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail non-breaking space (U+00A0) indentation breaks layout in where block -}
+{-# LANGUAGE TypeFamilies #-}
+module RowTypesNbspLayout where
+
+type family F a where
+  F a = a
+  F b = b

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sop-core-paren-backtick-instance-head-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sop-core-paren-backtick-instance-head-xfail.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail parser rejects parenthesised backtick-operator instance head with trailing argument -}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleInstances #-}
+module SopCoreParenBacktickInstanceHead where
+
+class (f `C` g) x
+instance (f `C` g) x


### PR DESCRIPTION
## Summary

- Add 3 xfail oracle test fixtures derived from hackage package parse failures
- Progress: 0 pass, +3 xfail

## Fixtures

### `generic-lens-core-paren-infix-type-family-xfail.hs`
**Package:** generic-lens-core (24 files, 54% success rate)
**Root cause:** Parser rejects parenthesised infix type family head `type family (a ++ b)`. GHC treats `(a ++ b)` as equivalent to the unparenthesised infix form `a ++ b`, but aihc-parser does not recognise the parenthesised variant.

### `sop-core-paren-backtick-instance-head-xfail.hs`
**Package:** sop-core (8 files, 50% success rate)
**Root cause:** Parser rejects parenthesised backtick-operator instance heads like `instance (f \`C\` g) x`. The class declaration `class (f \`C\` g) x` parses correctly, but the corresponding instance form is misinterpreted as a value equation rather than an instance head.

### `row-types-nbsp-layout-xfail.hs`
**Package:** row-types (6 files, 50% success rate)
**Root cause:** Non-breaking space (U+00A0) used for indentation breaks layout column tracking. GHC treats U+00A0 as whitespace, so a `where` block indented with `\u00a0\u0020` is valid. The aihc-parser lexer miscounts the column width, causing the second equation in a closed type family `where` block to appear at a different column than the first, prematurely closing the block.