### PR TITLE
test: add xfail oracle fixtures for hmatrix, diagrams-contrib, and nonempty-containers

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-hash-line-directive-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-hash-line-directive-xfail.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail lexer treats # at start of continuation line followed by 'line' as a CPP directive -}
+module A where
+r = x
+  # line

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-negation-precedence-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-negation-precedence-xfail.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST xfail negation prefix precedence: pretty-printer emits (- 1) / 2 instead of - 1 / 2 -}
+module A where
+f = - 1 / 2

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-scc-pragma-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-scc-pragma-xfail.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST xfail SCC pragma in expression silently dropped during parse -}
+module A where
+f x = {-# SCC "name" #-} x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-unicode-operator-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-unicode-operator-xfail.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail lexer rejects unicode em-dash as operator character -}
+{-# LANGUAGE UnicodeSyntax #-}
+module A where
+(——) = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-qualified-instance-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-qualified-instance-xfail.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail qualified class name in instance head loses module qualifier during roundtrip -}
+module A where
+import qualified Data.Aeson as A
+instance A.ToJSON a => A.ToJSON [a] where
+  toJSON = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-where-indent-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-where-indent-xfail.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail where clause under case alt with operator continuation attaches at wrong indentation level -}
+module A where
+f k m0
+  = case compare k 0 of
+      GT
+        -> Just
+             $ case (g m1, g m2) of
+                 (Nothing, Nothing) -> x
+                 (Just _, Just n2) -> y
+      where
+          (m1, m2) = split k m0


### PR DESCRIPTION
## Summary

- Add 6 minimal xfail oracle fixtures from hackage-tester runs on **hmatrix**, **diagrams-contrib**, and **nonempty-containers**
- The nonempty-containers infix pattern synonym where-clause parse error was already covered by `pqueue-infix-pattern-synonym-where-clause.hs`

## New Fixtures

### Parse Failures (parser rejects valid Haskell)

| Fixture | Package | Root Cause |
|---|---|---|
| `hmatrix-unicode-operator-xfail` | hmatrix | Lexer rejects unicode em-dash `——` as operator character |
| `diagrams-contrib-hash-line-directive-xfail` | diagrams-contrib | `#` at start of continuation line followed by `line` is lexed as a CPP directive instead of the operator `#` |

### Roundtrip Failures (parser succeeds but AST diverges from GHC)

| Fixture | Package | Root Cause |
|---|---|---|
| `hmatrix-scc-pragma-xfail` | hmatrix | `{-# SCC "name" #-}` pragma in expression is silently dropped |
| `diagrams-contrib-negation-precedence-xfail` | diagrams-contrib | Negation prefix precedence: `- 1 / 2` roundtrips to `(- 1) / 2` |
| `nonempty-containers-where-indent-xfail` | nonempty-containers | `where` clause under case alt with operator continuation attaches at wrong indentation level |
| `nonempty-containers-qualified-instance-xfail` | nonempty-containers | Qualified class name `A.ToJSON` in instance head loses module qualifier |

## Progress

- Hackage xfail fixtures: 27 → 33 (+6)