### PR TITLE
test: add xfail oracle fixtures for snap-core, alex, and aftovolio parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-bang-pattern-on-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-bang-pattern-on-constructor.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail pretty-printer wraps banged constructor pattern in extra parens causing roundtrip mismatch -}
+{-# LANGUAGE BangPatterns #-}
+module A where
+f x = case x of
+  !EQ -> True
+  _ -> False

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-negation-operator-precedence.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-negation-operator-precedence.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST xfail negation operator precedence mishandled causing roundtrip mismatch -}
+module A where
+f l = (-l - 1)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-negative-literal-spacing.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-negative-literal-spacing.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST xfail pretty-printer parenthesizes spaced negative literal causing roundtrip mismatch -}
+module A where
+f x = x == - 1

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/alex-conapp-pattern-in-cons.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/alex-conapp-pattern-in-cons.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail pretty-printer wraps constructor-application pattern in cons with extra parens causing roundtrip mismatch -}
+module A where
+data T = C Int
+f (C x : xs) = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-parenthesized-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-parenthesized-instance-head.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail parenthesized multi-param type class instance head not parsed -}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module A where
+class C a b
+instance (C Int) Bool where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-scc-pragma-in-binding.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-scc-pragma-in-binding.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail SCC pragma dropped during roundtrip causing fingerprint mismatch -}
+module A where
+f = g
+  where
+    g = {-# SCC "name" #-} undefined


### PR DESCRIPTION
## Summary

- Add 6 new xfail oracle test fixtures derived from parse failures in snap-core, alex, and aftovolio Hackage packages
- Xfail count: 6 → 12 (+6)

## New Fixtures

### snap-core (1.0.5.1)

| Fixture | Root Cause |
|---------|-----------|
| `snap-core-mptc-parenthesized-instance-head` | Parser rejects `instance (C Int) Bool where` — parenthesized multi-param type class application as instance head |
| `snap-core-scc-pragma-in-binding` | SCC pragma `{-# SCC "name" #-}` dropped from AST during parse, causing roundtrip fingerprint mismatch |

### alex (3.5.4.2)

| Fixture | Root Cause |
|---------|-----------|
| `alex-conapp-pattern-in-cons` | Pretty-printer wraps constructor-application pattern in cons with extra parens: `C x : xs` → `(C x) : xs` |

### aftovolio (0.8.0.0)

| Fixture | Root Cause |
|---------|-----------|
| `aftovolio-negative-literal-spacing` | Pretty-printer parenthesizes spaced negative literal: `x == - 1` → `x == (- 1)` |
| `aftovolio-negation-operator-precedence` | Negation precedence mishandled: `(-l - 1)` → `(-(l - 1))`, changing semantics |
| `aftovolio-bang-pattern-on-constructor` | Pretty-printer wraps banged constructor in extra parens: `!EQ` → `!(EQ)` |

## Skipped (already covered)

Two failure patterns from these packages were already covered by existing xfail fixtures:
- **Type signature in if-then-else** (snap-core `Types.hs`) — covered by `mixed-types-num-type-sig-in-if-then-branch`
- **Record pattern parens in lambda** (alex `ParseMonad.hs`) — covered by `thyme-lambda-record-wildcard-xfail`

One failure was a GHC error (not an aihc-parser issue):
- **alex `Parser.hs`** — GHC itself rejects the file due to a missing `MachDeps.h` CPP include