### PR TITLE
test: add xfail oracle fixtures for bytesmith and cauldron parse failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/pattern-type-sig-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/pattern-type-sig-equation.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail pattern type signature in equation not parsed -}
+{-# LANGUAGE ScopedTypeVariables #-}
+module PatternTypeSigEquation where
+
+f :: Int = 0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/case-in-unboxed-tuple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/case-in-unboxed-tuple.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail case expression not accepted as unboxed tuple element -}
+{-# LANGUAGE UnboxedTuples #-}
+module CaseInUnboxedTuple where
+
+f x = (# case x of y -> y #)


### PR DESCRIPTION
## Summary

- Add 2 xfail oracle test cases from Hackage package parse failures (bytesmith, cauldron)
- Progress: 0 pass → 0 pass, 0 xfail → 2 xfail

## Fixtures added

### `UnboxedTuples/case-in-unboxed-tuple.hs` (from bytesmith)

`case` expression is not accepted as an unboxed tuple element. GHC parses `(# case x of y -> y #)` but aihc-parser rejects it.

```haskell
{-# LANGUAGE UnboxedTuples #-}
f x = (# case x of y -> y #)
```

### `ScopedTypeVariables/pattern-type-sig-equation.hs` (from cauldron)

Pattern type signature in equation LHS (`f :: T = e`) is not parsed. With `ScopedTypeVariables`, GHC allows annotating the LHS of an equation with a type signature, but aihc-parser rejects the `=` after the type annotation.

```haskell
{-# LANGUAGE ScopedTypeVariables #-}
f :: Int = 0
```

## ghc-events note

The ghc-events package had a `PARSE_ERROR` in the hackage tester, but investigation showed this is a **CPP preprocessor bug**, not a parser gap. The `#define` values in `EventLogFormat.h` contain C-style comments (e.g., `#define EVENT_ET_BEGIN 0x65746200 /* 'e' 't' 'b' 0 */`). The aihc-cpp preprocessor stores the full text including the `/* ... */` comment as the macro value, and after expansion these C-style comments leak into the Haskell source causing parse failures. Standard C preprocessor behavior is to strip comments before tokenization. This should be addressed separately in aihc-cpp.