### PR TITLE
fix(parser): close implicit layout before unboxed tuple delimiter

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -316,10 +316,8 @@ opensDelimiter kind =
 --
 -- Related: 'closesImplicitBeforeDelimiter' determines which closing tokens
 -- also force all intervening implicit layouts to emit virtual @}@ tokens
--- before the delimiter is popped.  'TkSpecialUnboxedRParen' is absent from
--- that predicate because BOL rules and the parse-error rule handle its
--- implicit-layout closure; 'TkSpecialRBrace' is present there (but absent
--- here) because it closes 'LayoutExplicit', not 'LayoutDelimiter'.
+-- before the delimiter is popped.  'TkSpecialRBrace' is present there (but
+-- absent here) because it closes 'LayoutExplicit', not 'LayoutDelimiter'.
 closesDelimiter :: LexTokenKind -> Bool
 closesDelimiter kind =
   case kind of
@@ -337,6 +335,7 @@ closesImplicitBeforeDelimiter :: LexTokenKind -> Bool
 closesImplicitBeforeDelimiter kind =
   case kind of
     TkSpecialRParen -> True
+    TkSpecialUnboxedRParen -> True
     TkSpecialRBracket -> True
     TkTHExpQuoteClose -> True
     TkTHTypedQuoteClose -> True

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/case-in-unboxed-tuple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/case-in-unboxed-tuple.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail case expression not accepted as unboxed tuple element -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE UnboxedTuples #-}
 module CaseInUnboxedTuple where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/layout-expressions.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/layout-expressions.hs
@@ -1,0 +1,25 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE LambdaCase #-}
+module LayoutExpressions where
+
+-- do expression in unboxed tuple
+f1 = (# do x <- pure 1; pure x #)
+
+-- if expression in unboxed tuple
+f2 x = (# if x then 1 else 2 #)
+
+-- let expression in unboxed tuple
+f3 = (# let y = 1 in y #)
+
+-- lambda in unboxed tuple
+f4 = (# \x -> x + 1 #)
+
+-- lambda-case in unboxed tuple
+f5 = (# \case 0 -> "zero"; _ -> "other" #)
+
+-- nested case in unboxed tuple
+f6 x y = (# case x of { 0 -> case y of { 0 -> 0; _ -> 1 }; _ -> 2 } #)
+
+-- multiple layout expressions in unboxed tuple
+f7 x = (# case x of y -> y, do pure 1 #)

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -317,8 +317,29 @@ genTupleElemsWith allowTHQuotes =
 
 -- | Generate elements for an unboxed tuple (0-4 elements).
 -- Unlike boxed tuples, unboxed tuples with 0 elements are valid Haskell.
+-- Sometimes generates layout-sensitive expressions (case, do, if, let, lambda)
+-- to ensure proper implicit layout handling with unboxed tuple delimiters.
 genUnboxedTupleElemsWith :: Bool -> Gen [Expr]
-genUnboxedTupleElemsWith allowTHQuotes = smallList0 (genExprWith allowTHQuotes)
+genUnboxedTupleElemsWith allowTHQuotes =
+  oneof
+    [ smallList0 (genExprWith allowTHQuotes),
+      smallList0 (genLayoutExprWith allowTHQuotes)
+    ]
+
+-- | Generate expressions that trigger implicit layout (case, do, if, let, lambda).
+-- These require special handling when nested inside delimiters like @(# ... #)@.
+genLayoutExprWith :: Bool -> Gen Expr
+genLayoutExprWith allowTHQuotes =
+  scale (`div` 2) $
+    oneof
+      [ ECase <$> genExprWith allowTHQuotes <*> genCaseAltsWith allowTHQuotes,
+        EDo <$> genDoStmtsWith allowTHQuotes <*> arbitrary,
+        EIf <$> genExprWith allowTHQuotes <*> genExprWith allowTHQuotes <*> genExprWith allowTHQuotes,
+        ELetDecls <$> genValueDeclsWith allowTHQuotes <*> genExprWith allowTHQuotes,
+        ELambdaPats <$> genPatterns <*> genExprWith allowTHQuotes,
+        ELambdaCase <$> genCaseAltsWith allowTHQuotes,
+        ELambdaCases <$> genLambdaCaseAltsWith allowTHQuotes
+      ]
 
 genUnboxedSumExprWith :: Bool -> Gen Expr
 genUnboxedSumExprWith allowTHQuotes = do


### PR DESCRIPTION
## Summary

- Fix parsing of layout-sensitive expressions (case, do, if, let, lambda) inside unboxed tuples
- Add `TkSpecialUnboxedRParen` to `closesImplicitBeforeDelimiter` so the lexer emits virtual `}` tokens to close implicit layout before `#)`
- Add `genLayoutExprWith` to QuickCheck generator to explicitly test this scenario

## Root Cause

The `#)` token was not listed in `closesImplicitBeforeDelimiter`, meaning implicit layout contexts were not closed when the unboxed tuple delimiter was encountered. This caused expressions like:

```haskell
f x = (# case x of y -> y #)
```

to fail with a parse error because the case alternative's implicit layout wasn't properly terminated.

## Test plan

- [x] `UnboxedTuples/case-in-unboxed-tuple.hs` now passes (was xfail)
- [x] New `UnboxedTuples/layout-expressions.hs` fixture covers do, if, let, lambda, and lambda-case inside unboxed tuples
- [x] Full test suite passes (1572 tests)