### PR TITLE
fix: add expression-level SCC pragma support to parser

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -79,6 +79,13 @@ exprParserNoTopLevelTypeSig =
 
 exprCoreParserWithoutTypeSigExcept :: [Text] -> TokParser Expr
 exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
+  mSCC <- optionalHiddenPragma getSCCLabel
+  case mSCC of
+    Just label -> EPragma (PragmaSCC label) <$> exprCoreParserWithoutTypeSigExcept forbiddenInfix
+    Nothing -> exprCoreParserWithoutTypeSigBody forbiddenInfix
+
+exprCoreParserWithoutTypeSigBody :: [Text] -> TokParser Expr
+exprCoreParserWithoutTypeSigBody forbiddenInfix = do
   tok <- lookAhead anySingle
   base <- case lexTokenKind tok of
     TkKeywordDo -> doExprParser
@@ -317,8 +324,15 @@ infixExprParserExcept forbidden = do
 
 -- | Parse an lexp (left-expression) - includes do, if, case, let, lambda, and fexp.
 lexpParser :: TokParser Expr
-lexpParser =
-  doExprParser <|> mdoExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
+lexpParser = do
+  mSCC <- optionalHiddenPragma getSCCLabel
+  case mSCC of
+    Just label -> EPragma (PragmaSCC label) <$> lexpParser
+    Nothing -> doExprParser <|> mdoExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
+
+getSCCLabel :: Pragma -> Maybe Text
+getSCCLabel (PragmaSCC label) = Just label
+getSCCLabel _ = Nothing
 
 buildInfix :: Expr -> (Name, Expr) -> Expr
 buildInfix lhs (op, rhs) =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Pragmas.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Pragmas.hs
@@ -65,6 +65,7 @@ tryParseNamedPragma body upperBody
   | Just pragma <- parseInlinePragma body upperBody = Just pragma
   | Just pragma <- parseUnpackPragma body upperBody = Just pragma
   | Just pragma <- parseSourcePragma body upperBody = Just pragma
+  | Just pragma <- parseSCCPragma body upperBody = Just pragma
   | otherwise = Nothing
 
 parseLanguagePragma :: Text -> Text -> Maybe Pragma
@@ -171,6 +172,14 @@ parseSourcePragma body upperBody
     isPragmaBodyEnd rest =
       let fullBody = T.strip (dropPragmaName "SOURCE" body)
        in Just (PragmaSource fullBody fullBody)
+  | otherwise = Nothing
+
+parseSCCPragma :: Text -> Text -> Maybe Pragma
+parseSCCPragma body upperBody
+  | Just rest <- T.stripPrefix "SCC" upperBody,
+    isPragmaBodyEnd rest =
+      let label = T.strip (dropPragmaName "SCC" body)
+       in Just (PragmaSCC label)
   | otherwise = Nothing
 
 dropPragmaName :: Text -> Text -> Text

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -811,6 +811,8 @@ addExprParensPrec prec expr =
     EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (addExprParens inner)
     EProc pat body ->
       wrapExpr (prec > 0) (EProc (addPatternParens pat) (addCmdParens body))
+    EPragma pragma inner ->
+      wrapExpr (prec > 0) (EPragma pragma (addExprParens inner))
     EAnn ann sub -> EAnn ann (addExprParensPrec prec sub)
   where
     isTypeSig :: Expr -> Bool

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -886,6 +886,7 @@ prettyPragma pragma =
         UnpackPragma -> "{-# UNPACK #-}"
         NoUnpackPragma -> "{-# NOUNPACK #-}"
     PragmaSource sourceText _ -> "{-# SOURCE " <> pretty sourceText <> " #-}"
+    PragmaSCC label -> "{-# SCC " <> pretty label <> " #-}"
     PragmaUnknown text -> pretty text
 
 prettyDerivingStrategy :: DerivingStrategy -> Doc ann
@@ -1166,6 +1167,8 @@ prettyExpr expr =
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     EProc pat body ->
       "proc" <+> prettyPattern pat <+> "->" <+> prettyCmd body
+    EPragma pragma inner ->
+      prettyPragma pragma <+> prettyExpr inner
     EAnn _ sub -> prettyExpr sub
 
 prettyTupleBody :: TupleFlavor -> Doc ann -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -533,6 +533,7 @@ docPragma pragma =
     PragmaInline kind body -> "PragmaInline" <+> docText kind <+> docText body
     PragmaUnpack unpackKind -> "PragmaUnpack" <+> docPragmaUnpackKind unpackKind
     PragmaSource sourceText _ -> "PragmaSource" <+> docText sourceText
+    PragmaSCC label -> "PragmaSCC" <+> docText label
     PragmaUnknown text -> "PragmaUnknown" <+> docText text
 
 docForeignDecl :: ForeignDecl -> Doc ann
@@ -800,6 +801,7 @@ docExpr expr =
     ETypeApp inner ty -> "ETypeApp" <+> parens (docExpr inner) <+> parens (docType ty)
     EApp f x -> "EApp" <+> parens (docExpr f) <+> parens (docExpr x)
     EProc pat body -> "EProc" <+> parens (docPattern pat) <+> parens (docCmd body)
+    EPragma pragma inner -> "EPragma" <+> parens (docPragma pragma) <+> parens (docExpr inner)
     EAnn _ sub -> docExpr sub
 
 docCaseAlt :: CaseAlt -> Doc ann
@@ -957,6 +959,7 @@ docTokenKind kind =
         PragmaInline inlineKind body -> "TkPragma" <+> ("PragmaInline" <+> docText inlineKind <+> docText body)
         PragmaUnpack unpackKind -> "TkPragma" <+> ("PragmaUnpack" <+> docPragmaUnpackKind unpackKind)
         PragmaSource sourceText _ -> "TkPragma" <+> ("PragmaSource" <+> docText sourceText)
+        PragmaSCC label -> "TkPragma" <+> ("PragmaSCC" <+> docText label)
         PragmaUnknown text -> "TkPragma" <+> ("PragmaUnknown" <+> docText text)
     TkQuasiQuote quoter body -> "TkQuasiQuote" <+> docText quoter <+> docText body
     TkTHExpQuoteOpen -> "TkTHExpQuoteOpen"

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -830,6 +830,7 @@ data Pragma
   | PragmaInline Text Text
   | PragmaUnpack PragmaUnpackKind
   | PragmaSource Text Text
+  | PragmaSCC Text
   | PragmaUnknown Text
   deriving (Data, Eq, Ord, Show, Read, Generic, NFData)
 
@@ -1705,6 +1706,7 @@ data Expr
     ETHTypedSplice Expr -- \$$expr or $$(expr)
   | -- Arrow notation (Arrows extension)
     EProc Pattern Cmd -- proc pat -> cmd
+  | EPragma Pragma Expr
   deriving (Data, Eq, Show, Generic, NFData)
 
 getExprSourceSpan :: Expr -> SourceSpan

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-meta-scc-pragma-expr.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-meta-scc-pragma-expr.hs
@@ -1,3 +1,3 @@
-{- ORACLE_TEST xfail expression-level SCC pragma annotation is dropped -}
+{- ORACLE_TEST pass -}
 module HappyMetaSccPragmaExpr where
 f x = {-# SCC "label" #-} x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-scc-pragma-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-scc-pragma-xfail.hs
@@ -1,3 +1,3 @@
-{- ORACLE_TEST xfail SCC pragma in expression silently dropped during parse -}
+{- ORACLE_TEST pass -}
 module A where
 f x = {-# SCC "name" #-} x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-scc-pragma-in-binding.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-scc-pragma-in-binding.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail SCC pragma dropped during roundtrip causing fingerprint mismatch -}
+{- ORACLE_TEST pass -}
 module A where
 f = g
   where


### PR DESCRIPTION
## Root Cause

`{-# SCC "label" #-}` pragmas in expressions were silently dropped during parsing. The root cause was two-fold:

1. **Missing `PragmaSCC` constructor**: The `Pragma` data type had no variant for SCC pragmas, so they fell through to `PragmaUnknown`.
2. **Expression parsers never consumed pending pragmas**: The token stream normalizer moves all pragma tokens into `tokStreamPendingPragmas`, but expression parsers (`lexpParser`, `exprCoreParserWithoutTypeSigExcept`) never called `optionalHiddenPragma` to consume them — unlike declaration parsers which do. This caused pending SCC pragmas to be permanently discarded.

## Solution

Added full support for expression-level SCC pragmas by:

- Adding `PragmaSCC Text` to the `Pragma` data type
- Adding `EPragma Pragma Expr` to the `Expr` data type (a pragma annotation wrapping an expression)
- Parsing `{-# SCC "label" #-}` in `Pragmas.hs`
- Checking for pending SCC pragmas at the top of `lexpParser` (handles `a + {-# SCC "s" #-} b`) and `exprCoreParserWithoutTypeSigExcept` (handles SCC before keyword expressions like `do`/`if`/`let`)
- Adding pretty printing: `{-# SCC label #-} inner`
- Adding parenthesization rules (SCC expressions are wrapped in parens when used as function arguments, same as lambda/let/if)
- Updating `Shorthand.hs` debug documentation

## Changes

- `Syntax.hs`: New `PragmaSCC Text` pragma constructor; new `EPragma Pragma Expr` expression constructor
- `Pragmas.hs`: `parseSCCPragma` function wired into `tryParseNamedPragma`
- `Expr.hs`: SCC pragma handling in `lexpParser` and `exprCoreParserWithoutTypeSigExcept`
- `Pretty.hs`: Pretty printing for `PragmaSCC` and `EPragma`
- `Parens.hs`: Parenthesization for `EPragma` (prec > 0 needs wrapping)
- `Shorthand.hs`: Debug doc for `PragmaSCC` and `EPragma`
- 3 oracle fixtures promoted from `xfail` to `pass`

## Testing

All 970 tests pass. The 3 SCC oracle fixtures now pass:
- `Hackage/hmatrix-scc-pragma-xfail`
- `Hackage/happy-meta-scc-pragma-expr`
- `Hackage/snap-core-scc-pragma-in-binding`