### PR TITLE
fix(parser): eliminate spurious parens for record patterns and infix operands

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1072,7 +1072,7 @@ addPatternParens pat =
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (addPatternInDelimited inner)
     PList elems -> PList (map addPatternInDelimited elems)
     PCon con typeArgs args -> PCon con (map (addTypeIn CtxTypeAtom) typeArgs) (map addPatternAtomParens args)
-    PInfix lhs op rhs -> PInfix (addPatternAtomParens lhs) op (addPatternAtomParens rhs)
+    PInfix lhs op rhs -> PInfix (addPatternInfixOperandParens lhs) op (addPatternInfixOperandParens rhs)
     PView viewExpr inner ->
       wrapPat True (PView (addViewExprParens viewExpr) (addPatternViewInnerParens inner))
     PAs name inner -> PAs name (addPatternAtomStrictParens inner)
@@ -1137,6 +1137,7 @@ addPatternAtomParens pat =
     PView {} -> addPatternParens pat
     PAs {} -> addPatternParens pat
     PSplice {} -> addPatternParens pat
+    PRecord {} -> addPatternParens pat
     PCon _ [] [] -> addPatternParens pat
     PInfix _ op _
       | isConsOperator op ->
@@ -1144,6 +1145,18 @@ addPatternAtomParens pat =
           -- don't need parentheses: x1:x2:xs parses as x1:(x2:xs)
           addPatternParens pat
     _ -> wrapPat True (addPatternParens pat)
+
+-- | Add parens for a pattern in infix-pattern operand position.
+-- In Haskell's grammar, infix patterns have the form @pat10 conop pat10@,
+-- where @pat10@ allows constructor application patterns. Non-nullary 'PCon'
+-- does not need wrapping here because constructor application binds tighter
+-- than infix operators.
+addPatternInfixOperandParens :: Pattern -> Pattern
+addPatternInfixOperandParens pat =
+  case pat of
+    PAnn ann sub -> PAnn ann (addPatternInfixOperandParens sub)
+    PCon {} -> addPatternParens pat
+    _ -> addPatternAtomParens pat
 
 -- | Add parens for a pattern in lambda argument position.
 addLambdaPatternAtomParens :: Pattern -> Pattern

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/alex-conapp-pattern-in-cons.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/alex-conapp-pattern-in-cons.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail pretty-printer wraps constructor-application pattern in cons with extra parens causing roundtrip mismatch -}
+{- ORACLE_TEST pass -}
 module A where
 data T = C Int
 f (C x : xs) = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/thyme-lambda-record-wildcard-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/thyme-lambda-record-wildcard-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail pretty-printer wraps Con{..} lambda patterns in extra parens causing roundtrip mismatch -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RecordWildCards #-}
 module ThymeLambdaRecordWildcard where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/web3-ethereum-conpat-infix-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/web3-ethereum-conpat-infix-parens.hs
@@ -1,3 +1,3 @@
-{- ORACLE_TEST xfail constructor application pattern gets spurious parens in infix position -}
+{- ORACLE_TEST pass -}
 module Web3EthereumConpatInfixParens where
 f (Just _ : _) = ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/web3-ethereum-record-wildcard-lambda-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/web3-ethereum-record-wildcard-lambda-parens.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail record wildcard pattern gets spurious parens in lambda -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE RecordWildCards #-}
 module Web3EthereumRecordWildcardLambdaParens where
 data T = T {x :: Int}


### PR DESCRIPTION
## Summary

- Fix `PRecord` patterns (e.g. `T{..}`) getting spurious parentheses in atom contexts (lambda args, etc.)
- Fix non-nullary `PCon` patterns (e.g. `Just _`) getting spurious parentheses as infix pattern operands

**Progress: xfail 33 → 29, pass 926 → 930**

## Root Cause

Two bugs in the pattern parenthesization pass (`Aihc.Parser.Parens`):

1. **`PRecord` missing from `addPatternAtomParens`**: The function had no explicit case for `PRecord`, causing it to fall through to the catch-all `_ -> wrapPat True (addPatternParens pat)`. Record patterns are self-delimiting (braces act as delimiters) and never need wrapping. Other pattern-atom functions (`addFunctionHeadPatternAtomParens`, `addPatternAtomStrictParens`) already had explicit `PRecord` arms.

2. **`PInfix` operands too restrictive**: `addPatternParens` used `addPatternAtomParens` for `PInfix` operands, which wraps non-nullary `PCon` in `PParen`. In Haskell's grammar, infix patterns have the form `pat10 conop pat10`, where `pat10` allows constructor application patterns — constructor application binds tighter than infix operators, so `Just _ : _` is valid without parentheses.

## Solution

1. Added `PRecord {} -> addPatternParens pat` to `addPatternAtomParens`
2. Introduced `addPatternInfixOperandParens` — a dedicated function for infix pattern operands that allows `PCon` (with any number of args) through without wrapping, while delegating all other patterns to `addPatternAtomParens`
3. Changed the `PInfix` handler in `addPatternParens` to use the new function

## Fixtures Updated (xfail → pass)

| Fixture | Issue |
|---------|-------|
| `web3-ethereum-record-wildcard-lambda-parens` | `\T{..} -> x` → `\(T{..}) -> x` |
| `web3-ethereum-conpat-infix-parens` | `(Just _ : _)` → `((Just _) : _)` |
| `thyme-lambda-record-wildcard-xfail` | `\ TimeZone{..} -> ...` → `\ (TimeZone{..}) -> ...` |
| `alex-conapp-pattern-in-cons` | `(C x : xs)` → `((C x) : xs)` |