### PR TITLE
fix(parser): resolve type family default with compound RHS ambiguity

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -222,8 +222,17 @@ familyResultKindParser =
 -- | Parse an optional type family result signature. GHC admits either an unnamed
 -- @:: Kind@ annotation or a named result variable with optional injectivity annotation,
 -- such as @= r@, @= r | r -> a@, or @= (r :: Type) | r -> a where ...@.
-typeFamilyResultSigParser :: TokParser (Maybe TypeFamilyResultSig)
-typeFamilyResultSigParser =
+--
+-- The 'Bool' parameter indicates whether the @family@ keyword was explicitly
+-- present.  When it was /not/ present (i.e. the shorthand @type T a …@ form
+-- inside a class body), @= r@ is syntactically ambiguous with a default type
+-- instance (@type T a = r@).  GHC resolves this by treating @= binder |@ as a
+-- named result signature with injectivity, while @= expr@ without @|@ is
+-- always a default type instance.  We mirror that behaviour: without an
+-- explicit @family@ keyword, @namedSigParser@ requires the @|@ injectivity
+-- annotation that follows the binder.
+typeFamilyResultSigParser :: Bool -> TokParser (Maybe TypeFamilyResultSig)
+typeFamilyResultSigParser explicitFamily =
   MP.optional (kindSigParser <|> namedSigParser)
   where
     kindSigParser =
@@ -233,9 +242,16 @@ typeFamilyResultSigParser =
       expectedTok TkReservedEquals
       result <- namedResultBinderParser
       mInjectivity <- MP.optional typeFamilyInjectivityParser
-      pure $ case mInjectivity of
-        Just injectivity -> TypeFamilyInjectiveSig result injectivity
-        Nothing -> TypeFamilyTyVarSig result
+      case mInjectivity of
+        Just injectivity -> pure $ TypeFamilyInjectiveSig result injectivity
+        Nothing
+          -- With an explicit @family@ keyword, @= r@ on its own is
+          -- unambiguously a named result signature.
+          | explicitFamily -> pure $ TypeFamilyTyVarSig result
+          -- Without @family@, @= r@ (no injectivity @|@) is ambiguous with a
+          -- default type instance.  Fail so the caller can backtrack and try
+          -- the default-instance parser instead.
+          | otherwise -> fail "named result sig without injectivity requires explicit 'family' keyword"
 
     namedResultBinderParser =
       withSpan $
@@ -1308,7 +1324,7 @@ typeFamilyDeclBodyParser familyKeywordMode = do
     FamilyKeywordRequired -> expectedTok TkVarFamily $> True
     FamilyKeywordOptional -> isJust <$> MP.optional (expectedTok TkVarFamily)
   (headForm, headType, params) <- typeFamilyHeadParser
-  resultSig <- typeFamilyResultSigParser
+  resultSig <- typeFamilyResultSigParser explicitFamilyKeyword
   equations <-
     case familyKeywordMode of
       FamilyKeywordRequired -> MP.optional (MP.try closedTypeFamilyWhereParser)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/vinyl-type-family-default-compound-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/vinyl-type-family-default-compound-rhs.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects type family default with compound right-hand side -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 module VinylTypeFamilyDefaultCompoundRhs where
 


### PR DESCRIPTION
## Summary

Fixes the xfail oracle test `vinyl-type-family-default-compound-rhs` by correctly disambiguating between type family declarations with named result signatures and default type instances in class bodies.

## Root Cause

When parsing `type T f = f Int` inside a class body, `classTypeFamilyDeclParser` (via `typeFamilyResultSigParser`) greedily consumed `= f` as a named type family result signature (analogous to `= r` in `type family F a = r | r -> a`). This left `Int` unconsumed in the token stream, causing a parse error. Because `classTypeFamilyDeclParser` *succeeded* (it just produced the wrong result), `MP.try` did not trigger backtracking to the `classDefaultTypeInstShorthandParser` alternative.

## Solution

GHC disambiguates this syntax as follows:
- `type T a = r | r -> a` → type family declaration with injectivity (the `|` disambiguates)
- `type T a = r` (no `|`) → default type instance (when `family` keyword is absent)
- `type family T a = r` → type family declaration with named result sig (explicit `family` keyword makes it unambiguous)

The fix passes the `explicitFamilyKeyword` flag from `typeFamilyDeclBodyParser` into `typeFamilyResultSigParser`. When `family` is absent, `= binder` is only accepted as a named result signature if followed by `|` (injectivity annotation). Without `|`, the parser fails, allowing `MP.try` to backtrack to `classDefaultTypeInstShorthandParser`, which correctly parses `type T f = f Int` as a default type instance.

## Changes

- **`Decl.hs`**: Added `Bool` parameter to `typeFamilyResultSigParser` indicating whether the `family` keyword was explicit. When `family` is absent and no injectivity `|` follows `= binder`, the parser fails to trigger backtracking.
- **`vinyl-type-family-default-compound-rhs.hs`**: Changed from `xfail` to `pass`.

## Progress

xfail 78 → 77, pass 929 → 930.