### PR TITLE
fix(parens): disambiguate infix instance head LHS starting with parens

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -623,7 +623,33 @@ addInstanceHeadParens :: InstanceHead name -> InstanceHead name
 addInstanceHeadParens head' =
   case head' of
     PrefixInstanceHead name tys -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys)
-    InfixInstanceHead lhs name rhs -> InfixInstanceHead (addTypeIn CtxTypeFamilyOperand lhs) name (addTypeIn CtxTypeFamilyOperand rhs)
+    InfixInstanceHead lhs name rhs ->
+      let lhs' = addTypeIn CtxTypeFamilyOperand lhs
+          -- When the LHS of an infix instance head is a TApp whose leftmost
+          -- atom is a TParen, the parser's standaloneDerivingHeadParser /
+          -- instanceHeadParser would greedily consume the initial (...) as a
+          -- parenthesized prefix instance head, leaving the remaining tokens
+          -- orphaned.  Wrapping the entire LHS in parens prevents this
+          -- ambiguity.
+          --
+          -- Example: @deriving instance (C) '() :+ D@ is misparsed because
+          -- @(C)@ is consumed as the full parenthesized head.  Emitting
+          -- @deriving instance ((C) '()) :+ D@ is unambiguous.
+          needsWrap = case peelTypeAnn lhs' of
+            TApp {} -> typeStartsWithParen lhs'
+            _ -> False
+       in InfixInstanceHead (wrapTy needsWrap lhs') name (addTypeIn CtxTypeFamilyOperand rhs)
+
+-- | Check whether a type's pretty-printed form starts with @(@, which
+-- would be consumed as a parenthesized instance head by the parser.
+typeStartsWithParen :: Type -> Bool
+typeStartsWithParen (TAnn _ sub) = typeStartsWithParen sub
+typeStartsWithParen (TApp f _) = typeStartsWithParen f
+typeStartsWithParen (TTypeApp f _) = typeStartsWithParen f
+typeStartsWithParen (TParen _) = True
+typeStartsWithParen (TTuple Boxed Unpromoted _) = True
+typeStartsWithParen (TKindSig {}) = True
+typeStartsWithParen _ = False
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl
 addForeignDeclParens decl =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -635,10 +635,33 @@ addInstanceHeadParens head' =
           -- Example: @deriving instance (C) '() :+ D@ is misparsed because
           -- @(C)@ is consumed as the full parenthesized head.  Emitting
           -- @deriving instance ((C) '()) :+ D@ is unambiguous.
-          needsWrap = case peelTypeAnn lhs' of
-            TApp {} -> typeStartsWithParen lhs'
-            _ -> False
+          needsWrap = infixLhsNeedsOuterParen lhs'
        in InfixInstanceHead (wrapTy needsWrap lhs') name (addTypeIn CtxTypeFamilyOperand rhs)
+
+-- | Determine whether the LHS of an infix instance head needs to be
+-- wrapped in an outer TParen to prevent the parser from greedily
+-- consuming an initial @(...)@ as a parenthesized prefix instance head.
+--
+-- The parser's @standaloneDerivingHeadParser@ / @instanceHeadParser@ first
+-- tries @parens bareInstanceHeadParser@.  When the LHS pretty-prints as
+-- @(C) '() :+ D@, the parser matches @(C)@ as the full parenthesized
+-- head and orphans everything else.
+--
+-- We detect this by checking two conditions:
+--
+-- 1. The LHS is a multi-atom type application (@TApp@).
+-- 2. The leftmost atom of the application starts with @(@.
+--
+-- When both hold, we wrap the entire LHS in TParen so it prints as
+-- @((C) '()) :+ D@, which is unambiguous.
+--
+-- A bare @TParen@ at the top level (without @TApp@) is safe: the parser's
+-- @notFollowedBy typeInfixOperatorParser@ guard fails because the infix
+-- operator follows immediately.
+infixLhsNeedsOuterParen :: Type -> Bool
+infixLhsNeedsOuterParen (TAnn _ sub) = infixLhsNeedsOuterParen sub
+infixLhsNeedsOuterParen (TApp f _) = typeStartsWithParen f
+infixLhsNeedsOuterParen _ = False
 
 -- | Check whether a type's pretty-printed form starts with @(@, which
 -- would be consumed as a parenthesized instance head by the parser.

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/standalone-deriving-infix-paren-lhs.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/standalone-deriving-infix-paren-lhs.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: |
+  deriving instance ((C) '()) :+ ()
+ast: |
+  Module {decls = [DeclStandaloneDeriving (StandaloneDerivingDecl {headForm = TypeHeadInfix, className = ":+", types = [TParen (TApp (TParen (TCon "C")) (TTuplePromoted [])), TTuple []]})]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/standalone-deriving-infix-promoted-lhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/standalone-deriving-infix-promoted-lhs.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module StandaloneDerivingInfixPromotedLHS where
+
+class a :+ b
+
+deriving instance ((C) '()) :+ ()


### PR DESCRIPTION
## Summary

- Fix pretty-printer round-trip failure for infix instance heads whose LHS is a `TApp` starting with `TParen`

## Problem

When the LHS of an `InfixInstanceHead` is a `TApp` whose leftmost atom is a `TParen` (e.g. `(C) '()`), the parser's `standaloneDerivingHeadParser` / `instanceHeadParser` greedily consumes the initial `(...)` as a parenthesized prefix instance head. The remaining tokens are then orphaned and parsed as a separate declaration.

Example: `deriving newtype instance (C) '() :+ (# #)` is misparsed as:
1. `deriving newtype instance (C)` — prefix standalone deriving with class `C`
2. `' () :+ (# #)` — a TH splice expression

## Fix

In `addInstanceHeadParens`, detect when the parenthesized LHS of an `InfixInstanceHead` would create this ambiguity (via a new `typeStartsWithParen` helper) and wrap the entire LHS in `TParen`. This produces unambiguous output like `deriving instance ((C) '()) :+ D`.

## Reproduction

```
just replay "(SMGen 13501682295651192118 10869109792948424913,73)"
```

## Testing

- `just check` passes (ormolu, hlint, full test suite with 1000 QuickCheck tests)
- Deep fuzzy testing with 10,000 QuickCheck tests passes