### PR TITLE
fix(parser): handle pattern type signatures in top-level equations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -60,9 +60,9 @@ ordinaryDeclParser = do
           then MP.try nonBareVarPatternBindDeclParser <|> MP.try valueDeclParser <|> implicitSpliceDeclParser
           else MP.try nonBareVarPatternBindDeclParser <|> valueDeclParser
       typeSigOrValueOrSpliceParser =
-        MP.try typeSigDeclParser <|> valueOrSpliceParser
+        MP.try typeSigOrPatternTypeSigDeclParser <|> valueOrSpliceParser
       typeSigOrPatternOrValueOrSpliceParser =
-        MP.try typeSigDeclParser <|> patternOrValueOrSpliceParser
+        MP.try typeSigOrPatternTypeSigDeclParser <|> patternOrValueOrSpliceParser
   case tokKind of
     TkKeywordData ->
       case nextTokKind of
@@ -498,6 +498,33 @@ typeSigDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
   DeclTypeSig names <$> typeParser
+
+-- | Parse a type signature or a pattern-typed equation.
+--
+-- With @ScopedTypeVariables@, @f :: Int = 0@ is valid Haskell meaning the same
+-- as @(f :: Int) = 0@: a pattern bind whose LHS carries a type annotation.
+-- GHC parses @name :: Type@ and then, if @=@ (or a guard @|@) follows,
+-- reinterprets the construct as a 'PatternBind' with a 'PTypeSig' pattern.
+--
+-- This parser mirrors that behaviour at the top level.  It first parses
+-- @name(s) :: Type@ (the type-signature prefix), then peeks at the next
+-- token.  If the next token begins an equation RHS (@=@ or @|@), the result is
+-- reinterpreted as a pattern-typed equation; otherwise a plain type signature
+-- is returned.
+typeSigOrPatternTypeSigDeclParser :: TokParser Decl
+typeSigOrPatternTypeSigDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
+  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
+  expectedTok TkReservedDoubleColon
+  ty <- typeParser
+  nextKind <- lexTokenKind <$> lookAhead anySingle
+  if nextKind == TkReservedEquals || nextKind == TkReservedPipe
+    then case names of
+      [name] -> do
+        rhs <- equationRhsParser
+        let pat = PTypeSig (PVar name) ty
+        pure (DeclValue (PatternBind pat rhs))
+      _ -> fail "typed pattern bindings with '=' require exactly one binder"
+    else pure (DeclTypeSig names ty)
 
 defaultDeclParser :: TokParser Decl
 defaultDeclParser = do

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/pattern-type-sig-equation-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/pattern-type-sig-equation-where.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ScopedTypeVariables #-}
+module PatternTypeSigEquationWhere where
+
+f :: Int = x
+  where x = 42

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/pattern-type-sig-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/pattern-type-sig-equation.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail pattern type signature in equation not parsed -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE ScopedTypeVariables #-}
 module PatternTypeSigEquation where
 


### PR DESCRIPTION
## Summary

- Fix parsing of `f :: Int = 0` at the top level (ScopedTypeVariables pattern-typed equations)
- Add edge-case oracle fixture for pattern type sig with `where` clause

## Root Cause

GHC accepts `f :: Int = 0` at the top level as a pattern-typed equation (`PatBind` with a `SigPat` LHS) when `ScopedTypeVariables` is enabled. The aihc parser failed because `typeSigDeclParser` in `ordinaryDeclParser` successfully consumed `f :: Int` as a complete type signature, leaving `= 0` unconsumed and producing a parse error at `=`.

The local declaration parser (`localTypeSigDeclsParser` in `Expr.hs:981-1001`) already handled this ambiguity correctly by checking for a following `=` after parsing the type signature and reinterpreting as a `PatternBind`. The top-level parser lacked this logic.

## Solution

Add `typeSigOrPatternTypeSigDeclParser` in `Decl.hs` that:

1. Parses the type-signature prefix (`name(s) :: Type`)
2. Peeks at the next token
3. If `=` or `|` follows (indicating an equation RHS), reinterprets as `DeclValue (PatternBind (PTypeSig (PVar name) ty) rhs)`
4. Otherwise returns a plain `DeclTypeSig`

This mirrors the proven `localTypeSigDeclsParser` approach and uses `equationRhsParser` for the RHS, which handles both unguarded (`= expr`) and guarded (`| guard = expr`) forms, as well as `where` clauses.

The new parser replaces `typeSigDeclParser` in both `typeSigOrValueOrSpliceParser` and `typeSigOrPatternOrValueOrSpliceParser` within `ordinaryDeclParser`. The original `typeSigDeclParser` is preserved unchanged for other callers (class/instance contexts).

## Changes

- `Decl.hs`: Add `typeSigOrPatternTypeSigDeclParser`; use it in `ordinaryDeclParser`
- `pattern-type-sig-equation.hs`: `xfail` -> `pass`
- `pattern-type-sig-equation-where.hs`: New oracle fixture covering pattern type sig with `where` clause

## Progress

xfail 113 -> 112, pass 929 -> 931