### PR TITLE
fix(parser): support parenthesized infix instance heads with trailing type args

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -695,7 +695,8 @@ bareInstanceHeadParser = MP.try infixHeadParser <|> prefixHeadParser
       lhs <- typeAppParser
       _ <- lookAhead typeInfixOperatorParser
       op <- typeFamilyOperatorParser
-      InfixInstanceHead lhs op <$> typeAppParser
+      rhs <- typeAppParser
+      pure (InfixInstanceHead lhs op rhs [])
 
 standaloneDerivingHeadParser :: TokParser (Bool, InstanceHead Name)
 standaloneDerivingHeadParser =
@@ -703,7 +704,8 @@ standaloneDerivingHeadParser =
     ( do
         parsed <- parens bareInstanceHeadParser
         _ <- MP.notFollowedBy (lookAhead typeInfixOperatorParser)
-        pure (True, parsed)
+        tailTypes <- MP.many typeAtomParser
+        pure (True, addTailTypes tailTypes parsed)
     )
     <|> ( do
             instanceHead <- bareInstanceHeadParser
@@ -716,7 +718,8 @@ instanceHeadParser =
     ( do
         parsed <- parens bareInstanceHeadParser
         _ <- MP.notFollowedBy (lookAhead typeInfixOperatorParser)
-        pure (True, mapName parsed)
+        tailTypes <- MP.many typeAtomParser
+        pure (True, mapName (addTailTypes tailTypes parsed))
     )
     <|> ( do
             instanceHead <- bareInstanceHeadParser
@@ -727,8 +730,17 @@ instanceHeadParser =
       case head' of
         PrefixInstanceHead className instanceTypes ->
           PrefixInstanceHead (nameToUnqualified className) instanceTypes
-        InfixInstanceHead lhs op rhs ->
-          InfixInstanceHead lhs (nameToUnqualified op) rhs
+        InfixInstanceHead lhs op rhs tailTypes ->
+          InfixInstanceHead lhs (nameToUnqualified op) rhs tailTypes
+
+-- | Append trailing type arguments to an instance head.
+-- For prefix heads, the types are appended to the existing type list.
+-- For infix heads, the types are appended to the trailing types list.
+addTailTypes :: [Type] -> InstanceHead name -> InstanceHead name
+addTailTypes types head' =
+  case head' of
+    PrefixInstanceHead name tys -> PrefixInstanceHead name (tys <> types)
+    InfixInstanceHead lhs op rhs tailTypes -> InfixInstanceHead lhs op rhs (tailTypes <> types)
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]
 instanceWhereClauseParser = whereClauseItemsParser instanceDeclItemParser

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -623,7 +623,7 @@ addInstanceHeadParens :: InstanceHead name -> InstanceHead name
 addInstanceHeadParens head' =
   case head' of
     PrefixInstanceHead name tys -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys)
-    InfixInstanceHead lhs name rhs -> InfixInstanceHead (addTypeIn CtxTypeFamilyOperand lhs) name (addTypeIn CtxTypeFamilyOperand rhs)
+    InfixInstanceHead lhs name rhs tailTypes -> InfixInstanceHead (addTypeIn CtxTypeFamilyOperand lhs) name (addTypeIn CtxTypeFamilyOperand rhs) (map (addTypeIn CtxTypeAtom) tailTypes)
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl
 addForeignDeclParens decl =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -846,19 +846,34 @@ prettyStandaloneDeriving decl =
 
 instanceHeadDoc :: InstanceDecl -> Doc ann
 instanceHeadDoc decl =
-  maybeParenthesize (instanceDeclParenthesizedHead decl) $
-    prettyInstanceHead prettyConstructorUName prettyInfixOp (instanceDeclHead decl)
+  prettyInstanceHeadDoc
+    (instanceDeclParenthesizedHead decl)
+    prettyConstructorUName
+    prettyInfixOp
+    (instanceDeclHead decl)
 
 standaloneDerivingHeadDoc :: StandaloneDerivingDecl -> Doc ann
 standaloneDerivingHeadDoc decl =
-  maybeParenthesize (standaloneDerivingParenthesizedHead decl) $
-    prettyInstanceHead prettyPrefixName prettyNameInfixOp (standaloneDerivingHead decl)
+  prettyInstanceHeadDoc
+    (standaloneDerivingParenthesizedHead decl)
+    prettyPrefixName
+    prettyNameInfixOp
+    (standaloneDerivingHead decl)
 
-prettyInstanceHead :: (name -> Doc ann) -> (name -> Doc ann) -> InstanceHead name -> Doc ann
-prettyInstanceHead prettyPrefix prettyInfix head' =
+-- | Pretty-print an instance head, handling parenthesization of infix heads
+-- with trailing type arguments.
+--
+-- For @instance (f \`C\` g) x@, the infix part @f \`C\` g@ is parenthesized
+-- and the trailing @x@ appears outside the parens.
+prettyInstanceHeadDoc :: Bool -> (name -> Doc ann) -> (name -> Doc ann) -> InstanceHead name -> Doc ann
+prettyInstanceHeadDoc isParenthesized prettyPrefix prettyInfix head' =
   case head' of
-    PrefixInstanceHead name tys -> hsep (prettyPrefix name : map prettyType tys)
-    InfixInstanceHead lhs name rhs -> prettyType lhs <+> prettyInfix name <+> prettyType rhs
+    PrefixInstanceHead name tys ->
+      maybeParenthesize isParenthesized $
+        hsep (prettyPrefix name : map prettyType tys)
+    InfixInstanceHead lhs name rhs tailTypes ->
+      let infixPart = prettyType lhs <+> prettyInfix name <+> prettyType rhs
+       in hsep (maybeParenthesize isParenthesized infixPart : map prettyType tailTypes)
 
 maybeParenthesize :: Bool -> Doc ann -> Doc ann
 maybeParenthesize shouldParen doc

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1286,7 +1286,7 @@ binderHeadParams head' =
 
 data InstanceHead name
   = PrefixInstanceHead name [Type]
-  | InfixInstanceHead Type name Type
+  | InfixInstanceHead Type name Type [Type]
   deriving (Data, Eq, Show, Generic, NFData)
 
 instanceHeadForm :: InstanceHead name -> TypeHeadForm
@@ -1299,13 +1299,13 @@ instanceHeadName :: InstanceHead name -> name
 instanceHeadName head' =
   case head' of
     PrefixInstanceHead name _ -> name
-    InfixInstanceHead _ name _ -> name
+    InfixInstanceHead _ name _ _ -> name
 
 instanceHeadTypes :: InstanceHead name -> [Type]
 instanceHeadTypes head' =
   case head' of
     PrefixInstanceHead _ tys -> tys
-    InfixInstanceHead lhs _ rhs -> [lhs, rhs]
+    InfixInstanceHead lhs _ rhs tailTypes -> lhs : rhs : tailTypes
 
 data Role
   = RoleNominal

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/barbies-parenthesized-infix-operator-instance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/barbies-parenthesized-infix-operator-instance.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects parenthesized infix type operator applied to argument in instance head -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeOperators #-}
 module BarbiesParenthesizedInfixOperatorInstance where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-parenthesized-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-parenthesized-instance-head.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parenthesized multi-param type class instance head not parsed -}
+{- ORACLE_TEST xfail parenthesized prefix instance head merges trailing types losing paren boundary in roundtrip -}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module A where
 class C a b

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sop-core-paren-backtick-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sop-core-paren-backtick-instance-head.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects parenthesised backtick-operator instance head with trailing argument -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleInstances #-}
 module SopCoreParenBacktickInstanceHead where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -504,7 +504,7 @@ genDeclClassInfix = do
         }
 
 genDeclInstance :: Gen Decl
-genDeclInstance = oneof [genDeclInstancePrefix, genDeclInstanceInfix]
+genDeclInstance = oneof [genDeclInstancePrefix, genDeclInstanceInfix, genDeclInstanceParenInfix]
 
 genInstanceDeclItems :: Gen [InstanceDeclItem]
 genInstanceDeclItems = smallList0 genInstanceAssociatedDataFamilyInstItem
@@ -547,12 +547,34 @@ genDeclInstanceInfix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
-          instanceDeclHead = InfixInstanceHead lhs className rhs,
+          instanceDeclHead = InfixInstanceHead lhs className rhs [],
+          instanceDeclItems = items
+        }
+
+-- | Generate a parenthesized infix instance head with trailing type arguments.
+-- Covers syntax like @instance (f \`C\` g) x@ and @instance (c & d) a@.
+genDeclInstanceParenInfix :: Gen Decl
+genDeclInstanceParenInfix = do
+  className <- genConUnqualifiedName
+  lhs <- genInfixInstanceHeadType
+  rhs <- genInfixInstanceHeadType
+  tailTypes <- smallList1 genInstanceHeadType
+  ctx <- genSimpleContext
+  items <- genInstanceDeclItems
+  pure $
+    DeclInstance $
+      InstanceDecl
+        { instanceDeclOverlapPragma = Nothing,
+          instanceDeclWarning = Nothing,
+          instanceDeclForall = [],
+          instanceDeclContext = ctx,
+          instanceDeclParenthesizedHead = True,
+          instanceDeclHead = InfixInstanceHead lhs className rhs tailTypes,
           instanceDeclItems = items
         }
 
 genDeclStandaloneDeriving :: Gen Decl
-genDeclStandaloneDeriving = oneof [genDeclStandaloneDerivingPrefix, genDeclStandaloneDerivingInfix]
+genDeclStandaloneDeriving = oneof [genDeclStandaloneDerivingPrefix, genDeclStandaloneDerivingInfix, genDeclStandaloneDerivingParenInfix]
 
 genDeclStandaloneDerivingPrefix :: Gen Decl
 genDeclStandaloneDerivingPrefix = do
@@ -590,7 +612,30 @@ genDeclStandaloneDerivingInfix = do
           standaloneDerivingForall = [],
           standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
-          standaloneDerivingHead = InfixInstanceHead lhs className rhs
+          standaloneDerivingHead = InfixInstanceHead lhs className rhs []
+        }
+
+-- | Generate a parenthesized infix standalone deriving head with trailing type arguments.
+-- Covers syntax like @deriving instance (f \`C\` g) x@.
+genDeclStandaloneDerivingParenInfix :: Gen Decl
+genDeclStandaloneDerivingParenInfix = do
+  className <- genConName
+  lhs <- genInfixInstanceHeadType
+  rhs <- genInfixInstanceHeadType
+  tailTypes <- smallList1 genInstanceHeadType
+  strategy <- elements [Nothing, Just DerivingStock, Just DerivingNewtype, Just DerivingAnyclass]
+  ctx <- genSimpleContext
+  pure $
+    DeclStandaloneDeriving $
+      StandaloneDerivingDecl
+        { standaloneDerivingStrategy = strategy,
+          standaloneDerivingViaType = Nothing,
+          standaloneDerivingOverlapPragma = Nothing,
+          standaloneDerivingWarning = Nothing,
+          standaloneDerivingForall = [],
+          standaloneDerivingContext = ctx,
+          standaloneDerivingParenthesizedHead = True,
+          standaloneDerivingHead = InfixInstanceHead lhs className rhs tailTypes
         }
 
 genInstanceHeadType :: Gen Type
@@ -1314,16 +1359,17 @@ shrinkInstanceHeadName :: (name -> [name]) -> InstanceHead name -> [InstanceHead
 shrinkInstanceHeadName shrinkNameFn head' =
   case head' of
     PrefixInstanceHead name tys -> [PrefixInstanceHead name' tys | name' <- shrinkNameFn name]
-    InfixInstanceHead lhs name rhs -> [InfixInstanceHead lhs name' rhs | name' <- shrinkNameFn name]
+    InfixInstanceHead lhs name rhs tailTypes -> [InfixInstanceHead lhs name' rhs tailTypes | name' <- shrinkNameFn name]
 
 shrinkInstanceHeadTypes :: InstanceHead name -> [InstanceHead name]
 shrinkInstanceHeadTypes head' =
   case head' of
     PrefixInstanceHead name tys ->
       [PrefixInstanceHead name tys' | tys' <- shrinkTypeHeadTypes TypeHeadPrefix tys]
-    InfixInstanceHead lhs name rhs ->
-      [InfixInstanceHead lhs' name rhs | lhs' <- shrinkType lhs]
-        <> [InfixInstanceHead lhs name rhs' | rhs' <- shrinkType rhs]
+    InfixInstanceHead lhs name rhs tailTypes ->
+      [InfixInstanceHead lhs' name rhs tailTypes | lhs' <- shrinkType lhs]
+        <> [InfixInstanceHead lhs name rhs' tailTypes | rhs' <- shrinkType rhs]
+        <> [InfixInstanceHead lhs name rhs tailTypes' | tailTypes' <- shrinkList shrinkType tailTypes]
 
 shrinkFunctionHeadPats :: MatchHeadForm -> [Pattern] -> [[Pattern]]
 shrinkFunctionHeadPats headForm pats =

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -608,7 +608,7 @@ normalizeInstanceHead :: InstanceHead name -> InstanceHead name
 normalizeInstanceHead head' =
   case head' of
     PrefixInstanceHead name tys -> PrefixInstanceHead name (map normalizeType tys)
-    InfixInstanceHead lhs name rhs -> InfixInstanceHead (normalizeType lhs) name (normalizeType rhs)
+    InfixInstanceHead lhs name rhs tailTypes -> InfixInstanceHead (normalizeType lhs) name (normalizeType rhs) (map normalizeType tailTypes)
 
 normalizeTypeFamilyInst :: TypeFamilyInst -> TypeFamilyInst
 normalizeTypeFamilyInst tfi =


### PR DESCRIPTION
## Summary

- Add trailing `[Type]` field to `InfixInstanceHead` to represent syntax like `instance (f `C` g) x` and `instance (c & d) a`
- Parse trailing type atoms after parenthesized instance/standalone-deriving heads
- Extend QuickCheck generators with `genDeclInstanceParenInfix` and `genDeclStandaloneDerivingParenInfix`

## Root Cause

The `InstanceHead` AST type had no way to represent trailing type arguments after a parenthesized infix head:

```haskell
-- Before
data InstanceHead name
  = PrefixInstanceHead name [Type]
  | InfixInstanceHead Type name Type     -- no room for trailing args
```

When parsing `instance (f `C` g) x`, the parser successfully consumed `(f `C` g)` as a parenthesized infix head but left `x` unconsumed, causing a parse error. This parallels how `InfixBinderHead` already supports trailing params for class heads: `InfixBinderHead TyVarBinder name TyVarBinder [TyVarBinder]`.

## Solution

Add `[Type]` to `InfixInstanceHead` for trailing type arguments, mirroring `InfixBinderHead`:

```haskell
-- After
data InstanceHead name
  = PrefixInstanceHead name [Type]
  | InfixInstanceHead Type name Type [Type]  -- trailing args after parens
```

The parser's parenthesized path (`instanceHeadParser`, `standaloneDerivingHeadParser`) now consumes `MP.many typeAtomParser` after the closing paren and attaches them via `addTailTypes`. The pretty printer places trailing types outside the parenthesized infix part.

## Progress

- 2 xfail → pass: `sop-core-paren-backtick-instance-head`, `barbies-parenthesized-infix-operator-instance`
- 1 xfail reason updated: `snap-core-mptc-parenthesized-instance-head` (parse error → roundtrip mismatch; prefix paren boundary lost when merging trailing types)

## Follow-up

The `snap-core-mptc-parenthesized-instance-head` case (`instance (C Int) Bool`) now parses but fails roundtrip because `PrefixInstanceHead` merges inner and outer types, losing the parenthesization boundary. Fixing this would require tracking which prefix types are inside vs outside the parens — a separate structural change.