### PR TITLE
fix(pretty-printer): stop wrapping nullary constructors in parens inside bang/irrefutable/as patterns

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1187,12 +1187,17 @@ addInfixFunctionHeadPatternAtomParens pat =
     _ -> addPatternParens pat
 
 -- | Add parens for the inner pattern of @, !, ~.
+--
+-- A nullary constructor without type arguments (e.g., @EQ@) is an atom and
+-- needs no wrapping: @!EQ@, @~EQ@, @y\@EQ@ are all valid Haskell. However,
+-- a constructor with type arguments (e.g., @Nothing \@Int@) must be wrapped
+-- because @!Nothing \@Int@ is a parse error in GHC — it needs @!(Nothing \@Int)@.
 addPatternAtomStrictParens :: Pattern -> Pattern
 addPatternAtomStrictParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternAtomStrictParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ _ [] -> wrapPat True (addPatternParens pat)
+    PCon _ (_ : _) [] -> wrapPat True (addPatternParens pat)
     PStrict {} -> wrapPat True (addPatternParens pat)
     PIrrefutable {} -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-bang-pattern-on-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-bang-pattern-on-constructor.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail pretty-printer wraps banged constructor pattern in extra parens causing roundtrip mismatch -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE BangPatterns #-}
 module A where
 f x = case x of


### PR DESCRIPTION
## Summary

Fixes the `aftovolio-bang-pattern-on-constructor` xfail oracle test by correcting the parenthesization logic for patterns inside `!`, `~`, and `@` contexts.

## Root Cause

`addPatternAtomStrictParens` in `Parens.hs` unconditionally wrapped **all** nullary constructors (`PCon _ _ []`) in parentheses when they appeared inside `!`, `~`, or `@` patterns. This caused `!EQ` to pretty-print as `!(EQ)`, which re-parses to a different AST (`PStrict (PParen (PCon "EQ" []))` instead of `PStrict (PCon "EQ" [])`), producing a roundtrip mismatch.

A nullary constructor without type arguments is already an atom in Haskell's grammar — `!EQ`, `~EQ`, and `y@EQ` are all valid without parentheses. Only constructors with visible type arguments need wrapping (e.g., `!(Nothing @Int)`) because `!Nothing @Int` is a parse error in GHC.

## Solution

Changed the pattern match from `PCon _ _ []` (matches all nullary constructors) to `PCon _ (_ : _) []` (matches only constructors with type arguments). This is the minimal, correct fix — nullary constructors without type args fall through to `addPatternAtomParens` which correctly identifies them as atoms needing no wrapping.

Two alternative solutions were considered and rejected:
1. **Special-casing in `prettyPattern`**: Would duplicate parenthesization logic between `Pretty.hs` and `Parens.hs`, violating the existing design where `addPatternParens` is the single parenthesization pass.
2. **Adding a `PCon _ [] []` branch explicitly**: Unnecessary — the existing fallthrough to `addPatternAtomParens` already handles `PCon _ [] []` correctly (it matches the `PCon _ [] []` atom case there).

## Changes

- `Parens.hs`: Narrowed `PCon _ _ []` to `PCon _ (_ : _) []` in `addPatternAtomStrictParens`; added Haddock explaining the distinction
- `aftovolio-bang-pattern-on-constructor.hs`: Changed from `xfail` to `pass`

## Progress

- Oracle: 1 xfail → pass (23 → 22 xfail remaining)