### PR TITLE
fix(parser): handle prefix (:) constructor in parenthesized patterns

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -411,6 +411,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
         TkVarSym {} -> operatorOrExprPatternParser
         TkConSym {} -> operatorOrExprPatternParser
         TkQConSym {} -> operatorOrExprPatternParser
+        TkReservedColon -> operatorOrExprPatternParser
         _ -> do
           isAs <- startsWithAsPattern
           if isAs
@@ -442,6 +443,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
             TkVarSym op -> pure (PVar (mkUnqualifiedName NameVarSym op))
             TkConSym op -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym op)) [] [])
             TkQConSym modName op -> pure (PCon (mkName (Just modName) NameConSym op) [] [])
+            TkReservedColon -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym ":")) [] [])
             _ ->
               MP.customFailure
                 UnexpectedTokenExpecting

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-nested-prefix-cons-pattern-pass.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-nested-prefix-cons-pattern-pass.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+
+f ((:) ((:) a b) c) = a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-prefix-cons-pattern-pass.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-prefix-cons-pattern-pass.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+module A where
+
+f xs = case xs of
+  (:) x ys -> x
+  [] -> error "empty"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-prefix-cons-pattern-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/bnfc-meta-prefix-cons-pattern-xfail.hs
@@ -1,6 +1,0 @@
-{- ORACLE_TEST xfail parser rejects prefix-section (:) constructor in case pattern -}
-module A where
-
-f xs = case xs of
-  (:) x ys -> x
-  [] -> error "empty"


### PR DESCRIPTION
## Summary

Fixes the parser to accept prefix-form cons constructor patterns like `(:) x ys` in case alternatives and function equations.

**Progress: xfail -1, pass +2**

## Root Cause

The parenthesized pattern parser (`parenPatElementParser`) dispatches on token kinds to decide how to parse inner content. It handled `TkVarSym`, `TkConSym`, and `TkQConSym` as operator-in-parens cases, but not `TkReservedColon` — the cons operator `:`, which the lexer emits as a reserved token rather than `TkConSym`.

This caused `(:)` to fall through to `exprThenReclassify`, where the expression parser cannot handle a bare `:` (only the parenthesized form `(:)` via `parenOperatorExprParser`, which expects to consume its own opening paren). The parse failed with `unexpected ':'`.

## Solution

Add `TkReservedColon` to both the `parenPatElementParser` dispatch (so it routes to `operatorOrExprPatternParser`) and `operatorPatternParser` (so it produces `PCon ":" [] []`), following the exact same pattern already used for `TkConSym`.

This was chosen over alternatives:
- **Generalizing with a predicate function**: Overengineered — `:` is the only constructor symbol lexed as a reserved token.
- **Making `exprThenReclassify` handle it**: Would leak context-sensitivity into the expression parser, violating separation of concerns.

## Changes

- `Pattern.hs`: Added `TkReservedColon` case to `parenPatElementParser` dispatch and `operatorPatternParser`
- Renamed `bnfc-meta-prefix-cons-pattern-xfail.hs` → `bnfc-meta-prefix-cons-pattern-pass.hs`
- Added `bnfc-meta-nested-prefix-cons-pattern-pass.hs` edge case test (nested `(:) ((:) a b) c`)