### PR TITLE
fix(parser): preserve paren boundary for prefix instance heads with trailing types

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -732,7 +732,7 @@ bareInstanceHeadParser = MP.try infixHeadParser <|> prefixHeadParser
     prefixHeadParser = do
       className <- constructorNameParser <|> parens operatorNameParser
       instanceTypes <- MP.many typeAtomParser
-      pure (PrefixInstanceHead className instanceTypes)
+      pure (PrefixInstanceHead className instanceTypes [])
 
     infixHeadParser = do
       lhs <- typeAppParser
@@ -771,8 +771,8 @@ instanceHeadParser =
   where
     mapName head' =
       case head' of
-        PrefixInstanceHead className instanceTypes ->
-          PrefixInstanceHead (nameToUnqualified className) instanceTypes
+        PrefixInstanceHead className instanceTypes tailTypes ->
+          PrefixInstanceHead (nameToUnqualified className) instanceTypes tailTypes
         InfixInstanceHead lhs op rhs tailTypes ->
           InfixInstanceHead lhs (nameToUnqualified op) rhs tailTypes
 
@@ -782,7 +782,7 @@ instanceHeadParser =
 addTailTypes :: [Type] -> InstanceHead name -> InstanceHead name
 addTailTypes types head' =
   case head' of
-    PrefixInstanceHead name tys -> PrefixInstanceHead name (tys <> types)
+    PrefixInstanceHead name tys tailTypes -> PrefixInstanceHead name tys (tailTypes <> types)
     InfixInstanceHead lhs op rhs tailTypes -> InfixInstanceHead lhs op rhs (tailTypes <> types)
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -730,12 +730,18 @@ bareInstanceHeadParser :: TokParser (InstanceHead Name)
 bareInstanceHeadParser = MP.try infixHeadParser <|> prefixHeadParser
   where
     prefixHeadParser = do
-      (className, nameParenthesized) <-
-        (,False) <$> constructorNameParser
-          <|> MP.try ((,True) <$> parens constructorNameParser)
-          <|> (,False) <$> parens operatorNameParser
+      (className, nameParens) <- classNameParser
       instanceTypes <- MP.many typeAtomParser
-      pure (PrefixInstanceHead className nameParenthesized instanceTypes [])
+      pure (PrefixInstanceHead className nameParens instanceTypes [])
+
+    -- Parses the class name, counting how many explicit constructor-paren
+    -- layers wrap it (e.g. 0 for C, 1 for (C), 2 for ((C))).
+    -- Operator names like (:+:) keep depth 0 since their parens are required.
+    classNameParser :: TokParser (Name, Int)
+    classNameParser =
+      (,0) <$> constructorNameParser
+        <|> MP.try (parens (classNameParser >>= \(n, d) -> pure (n, d + 1)))
+        <|> (,0) <$> parens operatorNameParser
 
     infixHeadParser = do
       lhs <- typeAppParser
@@ -774,8 +780,8 @@ instanceHeadParser =
   where
     mapName head' =
       case head' of
-        PrefixInstanceHead className nameParenthesized instanceTypes tailTypes ->
-          PrefixInstanceHead (nameToUnqualified className) nameParenthesized instanceTypes tailTypes
+        PrefixInstanceHead className nameParens instanceTypes tailTypes ->
+          PrefixInstanceHead (nameToUnqualified className) nameParens instanceTypes tailTypes
         InfixInstanceHead lhs op rhs tailTypes ->
           InfixInstanceHead lhs (nameToUnqualified op) rhs tailTypes
 
@@ -785,7 +791,7 @@ instanceHeadParser =
 addTailTypes :: [Type] -> InstanceHead name -> InstanceHead name
 addTailTypes types head' =
   case head' of
-    PrefixInstanceHead name nameParenthesized tys tailTypes -> PrefixInstanceHead name nameParenthesized tys (tailTypes <> types)
+    PrefixInstanceHead name nameParens tys tailTypes -> PrefixInstanceHead name nameParens tys (tailTypes <> types)
     InfixInstanceHead lhs op rhs tailTypes -> InfixInstanceHead lhs op rhs (tailTypes <> types)
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -730,9 +730,12 @@ bareInstanceHeadParser :: TokParser (InstanceHead Name)
 bareInstanceHeadParser = MP.try infixHeadParser <|> prefixHeadParser
   where
     prefixHeadParser = do
-      className <- constructorNameParser <|> parens operatorNameParser
+      (className, nameParenthesized) <-
+        (,False) <$> constructorNameParser
+          <|> MP.try ((,True) <$> parens constructorNameParser)
+          <|> (,False) <$> parens operatorNameParser
       instanceTypes <- MP.many typeAtomParser
-      pure (PrefixInstanceHead className instanceTypes [])
+      pure (PrefixInstanceHead className nameParenthesized instanceTypes [])
 
     infixHeadParser = do
       lhs <- typeAppParser
@@ -771,8 +774,8 @@ instanceHeadParser =
   where
     mapName head' =
       case head' of
-        PrefixInstanceHead className instanceTypes tailTypes ->
-          PrefixInstanceHead (nameToUnqualified className) instanceTypes tailTypes
+        PrefixInstanceHead className nameParenthesized instanceTypes tailTypes ->
+          PrefixInstanceHead (nameToUnqualified className) nameParenthesized instanceTypes tailTypes
         InfixInstanceHead lhs op rhs tailTypes ->
           InfixInstanceHead lhs (nameToUnqualified op) rhs tailTypes
 
@@ -782,7 +785,7 @@ instanceHeadParser =
 addTailTypes :: [Type] -> InstanceHead name -> InstanceHead name
 addTailTypes types head' =
   case head' of
-    PrefixInstanceHead name tys tailTypes -> PrefixInstanceHead name tys (tailTypes <> types)
+    PrefixInstanceHead name nameParenthesized tys tailTypes -> PrefixInstanceHead name nameParenthesized tys (tailTypes <> types)
     InfixInstanceHead lhs op rhs tailTypes -> InfixInstanceHead lhs op rhs (tailTypes <> types)
 
 instanceWhereClauseParser :: TokParser [InstanceDeclItem]

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -622,7 +622,7 @@ addStandaloneDerivingParens decl =
 addInstanceHeadParens :: InstanceHead name -> InstanceHead name
 addInstanceHeadParens head' =
   case head' of
-    PrefixInstanceHead name tys tailTypes -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys) (map (addTypeIn CtxTypeAtom) tailTypes)
+    PrefixInstanceHead name nameParenthesized tys tailTypes -> PrefixInstanceHead name nameParenthesized (map (addTypeIn CtxTypeAtom) tys) (map (addTypeIn CtxTypeAtom) tailTypes)
     InfixInstanceHead lhs name rhs tailTypes -> InfixInstanceHead (addTypeIn CtxTypeFamilyOperand lhs) name (addTypeIn CtxTypeFamilyOperand rhs) (map (addTypeIn CtxTypeAtom) tailTypes)
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -622,7 +622,7 @@ addStandaloneDerivingParens decl =
 addInstanceHeadParens :: InstanceHead name -> InstanceHead name
 addInstanceHeadParens head' =
   case head' of
-    PrefixInstanceHead name tys -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys)
+    PrefixInstanceHead name tys tailTypes -> PrefixInstanceHead name (map (addTypeIn CtxTypeAtom) tys) (map (addTypeIn CtxTypeAtom) tailTypes)
     InfixInstanceHead lhs name rhs tailTypes -> InfixInstanceHead (addTypeIn CtxTypeFamilyOperand lhs) name (addTypeIn CtxTypeFamilyOperand rhs) (map (addTypeIn CtxTypeAtom) tailTypes)
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -868,9 +868,9 @@ standaloneDerivingHeadDoc decl =
 prettyInstanceHeadDoc :: Bool -> (name -> Doc ann) -> (name -> Doc ann) -> InstanceHead name -> Doc ann
 prettyInstanceHeadDoc isParenthesized prettyPrefix prettyInfix head' =
   case head' of
-    PrefixInstanceHead name tys ->
-      maybeParenthesize isParenthesized $
-        hsep (prettyPrefix name : map prettyType tys)
+    PrefixInstanceHead name tys tailTypes ->
+      let prefixPart = maybeParenthesize isParenthesized $ hsep (prettyPrefix name : map prettyType tys)
+       in hsep (prefixPart : map prettyType tailTypes)
     InfixInstanceHead lhs name rhs tailTypes ->
       let infixPart = prettyType lhs <+> prettyInfix name <+> prettyType rhs
        in hsep (maybeParenthesize isParenthesized infixPart : map prettyType tailTypes)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -868,8 +868,9 @@ standaloneDerivingHeadDoc decl =
 prettyInstanceHeadDoc :: Bool -> (name -> Doc ann) -> (name -> Doc ann) -> InstanceHead name -> Doc ann
 prettyInstanceHeadDoc isParenthesized prettyPrefix prettyInfix head' =
   case head' of
-    PrefixInstanceHead name tys tailTypes ->
-      let prefixPart = maybeParenthesize isParenthesized $ hsep (prettyPrefix name : map prettyType tys)
+    PrefixInstanceHead name nameParenthesized tys tailTypes ->
+      let prettyName = maybeParenthesize nameParenthesized (prettyPrefix name)
+          prefixPart = maybeParenthesize isParenthesized $ hsep (prettyName : map prettyType tys)
        in hsep (prefixPart : map prettyType tailTypes)
     InfixInstanceHead lhs name rhs tailTypes ->
       let infixPart = prettyType lhs <+> prettyInfix name <+> prettyType rhs

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -868,8 +868,8 @@ standaloneDerivingHeadDoc decl =
 prettyInstanceHeadDoc :: Bool -> (name -> Doc ann) -> (name -> Doc ann) -> InstanceHead name -> Doc ann
 prettyInstanceHeadDoc isParenthesized prettyPrefix prettyInfix head' =
   case head' of
-    PrefixInstanceHead name nameParenthesized tys tailTypes ->
-      let prettyName = maybeParenthesize nameParenthesized (prettyPrefix name)
+    PrefixInstanceHead name nameParens tys tailTypes ->
+      let prettyName = applyParens nameParens (prettyPrefix name)
           prefixPart = maybeParenthesize isParenthesized $ hsep (prettyName : map prettyType tys)
        in hsep (prefixPart : map prettyType tailTypes)
     InfixInstanceHead lhs name rhs tailTypes ->
@@ -880,6 +880,9 @@ maybeParenthesize :: Bool -> Doc ann -> Doc ann
 maybeParenthesize shouldParen doc
   | shouldParen = parens doc
   | otherwise = doc
+
+applyParens :: Int -> Doc ann -> Doc ann
+applyParens n doc = iterate parens doc !! n
 
 prettyInstanceOverlapPragma :: InstanceOverlapPragma -> Doc ann
 prettyInstanceOverlapPragma pragma' =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1286,7 +1286,7 @@ binderHeadParams head' =
     InfixBinderHead lhs _ rhs tailParams -> lhs : rhs : tailParams
 
 data InstanceHead name
-  = PrefixInstanceHead name [Type] [Type]
+  = PrefixInstanceHead name Bool [Type] [Type]
   | InfixInstanceHead Type name Type [Type]
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -1299,13 +1299,13 @@ instanceHeadForm head' =
 instanceHeadName :: InstanceHead name -> name
 instanceHeadName head' =
   case head' of
-    PrefixInstanceHead name _ _ -> name
+    PrefixInstanceHead name _ _ _ -> name
     InfixInstanceHead _ name _ _ -> name
 
 instanceHeadTypes :: InstanceHead name -> [Type]
 instanceHeadTypes head' =
   case head' of
-    PrefixInstanceHead _ tys tailTypes -> tys <> tailTypes
+    PrefixInstanceHead _ _ tys tailTypes -> tys <> tailTypes
     InfixInstanceHead lhs _ rhs tailTypes -> lhs : rhs : tailTypes
 
 data Role

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1286,7 +1286,7 @@ binderHeadParams head' =
     InfixBinderHead lhs _ rhs tailParams -> lhs : rhs : tailParams
 
 data InstanceHead name
-  = PrefixInstanceHead name [Type]
+  = PrefixInstanceHead name [Type] [Type]
   | InfixInstanceHead Type name Type [Type]
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -1299,13 +1299,13 @@ instanceHeadForm head' =
 instanceHeadName :: InstanceHead name -> name
 instanceHeadName head' =
   case head' of
-    PrefixInstanceHead name _ -> name
+    PrefixInstanceHead name _ _ -> name
     InfixInstanceHead _ name _ _ -> name
 
 instanceHeadTypes :: InstanceHead name -> [Type]
 instanceHeadTypes head' =
   case head' of
-    PrefixInstanceHead _ tys -> tys
+    PrefixInstanceHead _ tys tailTypes -> tys <> tailTypes
     InfixInstanceHead lhs _ rhs tailTypes -> lhs : rhs : tailTypes
 
 data Role

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1286,7 +1286,7 @@ binderHeadParams head' =
     InfixBinderHead lhs _ rhs tailParams -> lhs : rhs : tailParams
 
 data InstanceHead name
-  = PrefixInstanceHead name Bool [Type] [Type]
+  = PrefixInstanceHead name Int [Type] [Type]
   | InfixInstanceHead Type name Type [Type]
   deriving (Data, Eq, Show, Generic, NFData)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-double-paren-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-double-paren-instance-head.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+module A where
+class C a b
+instance ((C) Int) Bool where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-parenthesized-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-parenthesized-instance-head.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parenthesized prefix instance head merges trailing types losing paren boundary in roundtrip -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module A where
 class C a b

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-triple-paren-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/snap-core-mptc-triple-paren-instance-head.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+module A where
+class C a b
+instance (((C)) Int) Bool where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -528,7 +528,7 @@ genDeclInstancePrefix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
-          instanceDeclHead = PrefixInstanceHead className False types [],
+          instanceDeclHead = PrefixInstanceHead className 0 types [],
           instanceDeclItems = items
         }
 
@@ -590,7 +590,7 @@ genDeclInstanceParenPrefix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = True,
-          instanceDeclHead = PrefixInstanceHead className False innerTypes tailTypes,
+          instanceDeclHead = PrefixInstanceHead className 0 innerTypes tailTypes,
           instanceDeclItems = items
         }
 
@@ -613,7 +613,7 @@ genDeclStandaloneDerivingPrefix = do
           standaloneDerivingForall = [],
           standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
-          standaloneDerivingHead = PrefixInstanceHead className False types []
+          standaloneDerivingHead = PrefixInstanceHead className 0 types []
         }
 
 genDeclStandaloneDerivingInfix :: Gen Decl

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -504,7 +504,7 @@ genDeclClassInfix = do
         }
 
 genDeclInstance :: Gen Decl
-genDeclInstance = oneof [genDeclInstancePrefix, genDeclInstanceInfix, genDeclInstanceParenInfix]
+genDeclInstance = oneof [genDeclInstancePrefix, genDeclInstanceInfix, genDeclInstanceParenInfix, genDeclInstanceParenPrefix]
 
 genInstanceDeclItems :: Gen [InstanceDeclItem]
 genInstanceDeclItems = smallList0 genInstanceAssociatedDataFamilyInstItem
@@ -528,7 +528,7 @@ genDeclInstancePrefix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
-          instanceDeclHead = PrefixInstanceHead className types,
+          instanceDeclHead = PrefixInstanceHead className types [],
           instanceDeclItems = items
         }
 
@@ -573,6 +573,27 @@ genDeclInstanceParenInfix = do
           instanceDeclItems = items
         }
 
+-- | Generate a parenthesized prefix instance head with trailing type arguments.
+-- Covers syntax like @instance (C Int) Bool@.
+genDeclInstanceParenPrefix :: Gen Decl
+genDeclInstanceParenPrefix = do
+  className <- genConUnqualifiedName
+  innerTypes <- smallList1 genInstanceHeadType
+  tailTypes <- smallList1 genInstanceHeadType
+  ctx <- genSimpleContext
+  items <- genInstanceDeclItems
+  pure $
+    DeclInstance $
+      InstanceDecl
+        { instanceDeclOverlapPragma = Nothing,
+          instanceDeclWarning = Nothing,
+          instanceDeclForall = [],
+          instanceDeclContext = ctx,
+          instanceDeclParenthesizedHead = True,
+          instanceDeclHead = PrefixInstanceHead className innerTypes tailTypes,
+          instanceDeclItems = items
+        }
+
 genDeclStandaloneDeriving :: Gen Decl
 genDeclStandaloneDeriving = oneof [genDeclStandaloneDerivingPrefix, genDeclStandaloneDerivingInfix, genDeclStandaloneDerivingParenInfix]
 
@@ -592,7 +613,7 @@ genDeclStandaloneDerivingPrefix = do
           standaloneDerivingForall = [],
           standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
-          standaloneDerivingHead = PrefixInstanceHead className types
+          standaloneDerivingHead = PrefixInstanceHead className types []
         }
 
 genDeclStandaloneDerivingInfix :: Gen Decl
@@ -1358,14 +1379,15 @@ shrinkBinderHeadParams head' =
 shrinkInstanceHeadName :: (name -> [name]) -> InstanceHead name -> [InstanceHead name]
 shrinkInstanceHeadName shrinkNameFn head' =
   case head' of
-    PrefixInstanceHead name tys -> [PrefixInstanceHead name' tys | name' <- shrinkNameFn name]
+    PrefixInstanceHead name tys tailTypes -> [PrefixInstanceHead name' tys tailTypes | name' <- shrinkNameFn name]
     InfixInstanceHead lhs name rhs tailTypes -> [InfixInstanceHead lhs name' rhs tailTypes | name' <- shrinkNameFn name]
 
 shrinkInstanceHeadTypes :: InstanceHead name -> [InstanceHead name]
 shrinkInstanceHeadTypes head' =
   case head' of
-    PrefixInstanceHead name tys ->
-      [PrefixInstanceHead name tys' | tys' <- shrinkTypeHeadTypes TypeHeadPrefix tys]
+    PrefixInstanceHead name tys tailTypes ->
+      [PrefixInstanceHead name tys' tailTypes | tys' <- shrinkTypeHeadTypes TypeHeadPrefix tys]
+        <> [PrefixInstanceHead name tys tailTypes' | tailTypes' <- shrinkList shrinkType tailTypes]
     InfixInstanceHead lhs name rhs tailTypes ->
       [InfixInstanceHead lhs' name rhs tailTypes | lhs' <- shrinkType lhs]
         <> [InfixInstanceHead lhs name rhs' tailTypes | rhs' <- shrinkType rhs]

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -528,7 +528,7 @@ genDeclInstancePrefix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = False,
-          instanceDeclHead = PrefixInstanceHead className types [],
+          instanceDeclHead = PrefixInstanceHead className False types [],
           instanceDeclItems = items
         }
 
@@ -590,7 +590,7 @@ genDeclInstanceParenPrefix = do
           instanceDeclForall = [],
           instanceDeclContext = ctx,
           instanceDeclParenthesizedHead = True,
-          instanceDeclHead = PrefixInstanceHead className innerTypes tailTypes,
+          instanceDeclHead = PrefixInstanceHead className False innerTypes tailTypes,
           instanceDeclItems = items
         }
 
@@ -613,7 +613,7 @@ genDeclStandaloneDerivingPrefix = do
           standaloneDerivingForall = [],
           standaloneDerivingContext = ctx,
           standaloneDerivingParenthesizedHead = False,
-          standaloneDerivingHead = PrefixInstanceHead className types []
+          standaloneDerivingHead = PrefixInstanceHead className False types []
         }
 
 genDeclStandaloneDerivingInfix :: Gen Decl
@@ -1379,15 +1379,15 @@ shrinkBinderHeadParams head' =
 shrinkInstanceHeadName :: (name -> [name]) -> InstanceHead name -> [InstanceHead name]
 shrinkInstanceHeadName shrinkNameFn head' =
   case head' of
-    PrefixInstanceHead name tys tailTypes -> [PrefixInstanceHead name' tys tailTypes | name' <- shrinkNameFn name]
+    PrefixInstanceHead name nameParenthesized tys tailTypes -> [PrefixInstanceHead name' nameParenthesized tys tailTypes | name' <- shrinkNameFn name]
     InfixInstanceHead lhs name rhs tailTypes -> [InfixInstanceHead lhs name' rhs tailTypes | name' <- shrinkNameFn name]
 
 shrinkInstanceHeadTypes :: InstanceHead name -> [InstanceHead name]
 shrinkInstanceHeadTypes head' =
   case head' of
-    PrefixInstanceHead name tys tailTypes ->
-      [PrefixInstanceHead name tys' tailTypes | tys' <- shrinkTypeHeadTypes TypeHeadPrefix tys]
-        <> [PrefixInstanceHead name tys tailTypes' | tailTypes' <- shrinkList shrinkType tailTypes]
+    PrefixInstanceHead name nameParenthesized tys tailTypes ->
+      [PrefixInstanceHead name nameParenthesized tys' tailTypes | tys' <- shrinkTypeHeadTypes TypeHeadPrefix tys]
+        <> [PrefixInstanceHead name nameParenthesized tys tailTypes' | tailTypes' <- shrinkList shrinkType tailTypes]
     InfixInstanceHead lhs name rhs tailTypes ->
       [InfixInstanceHead lhs' name rhs tailTypes | lhs' <- shrinkType lhs]
         <> [InfixInstanceHead lhs name rhs' tailTypes | rhs' <- shrinkType rhs]

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -607,7 +607,7 @@ normalizeBinderHead head' =
 normalizeInstanceHead :: InstanceHead name -> InstanceHead name
 normalizeInstanceHead head' =
   case head' of
-    PrefixInstanceHead name tys tailTypes -> PrefixInstanceHead name (map normalizeType tys) (map normalizeType tailTypes)
+    PrefixInstanceHead name nameParenthesized tys tailTypes -> PrefixInstanceHead name nameParenthesized (map normalizeType tys) (map normalizeType tailTypes)
     InfixInstanceHead lhs name rhs tailTypes -> InfixInstanceHead (normalizeType lhs) name (normalizeType rhs) (map normalizeType tailTypes)
 
 normalizeTypeFamilyInst :: TypeFamilyInst -> TypeFamilyInst

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -607,7 +607,7 @@ normalizeBinderHead head' =
 normalizeInstanceHead :: InstanceHead name -> InstanceHead name
 normalizeInstanceHead head' =
   case head' of
-    PrefixInstanceHead name tys -> PrefixInstanceHead name (map normalizeType tys)
+    PrefixInstanceHead name tys tailTypes -> PrefixInstanceHead name (map normalizeType tys) (map normalizeType tailTypes)
     InfixInstanceHead lhs name rhs tailTypes -> InfixInstanceHead (normalizeType lhs) name (normalizeType rhs) (map normalizeType tailTypes)
 
 normalizeTypeFamilyInst :: TypeFamilyInst -> TypeFamilyInst


### PR DESCRIPTION
## Root Cause

When parsing `instance (C Int) Bool where`, the parser correctly identified the parenthesized head but then merged the inner types and trailing types into a single flat list in `PrefixInstanceHead`. The data structure had no way to record where the paren boundary was:

```haskell
-- Before
data InstanceHead name
  = PrefixInstanceHead name [Type]           -- no trailing-type slot
  | InfixInstanceHead Type name Type [Type]  -- has trailing-type slot
```

`addTailTypes` appended `Bool` into the same list as `Int`, producing `PrefixInstanceHead C [Int, Bool]`. Pretty-printing then parenthesized everything, emitting `(C Int Bool)` instead of `(C Int) Bool`.

## Solution

Mirror the existing `InfixInstanceHead` design by adding a second `[Type]` field to `PrefixInstanceHead` for trailing types that live outside the parentheses:

```haskell
-- After
PrefixInstanceHead name [Type] [Type]  -- inner types, trailing types
```

`addTailTypes` now appends to the trailing list, and the pretty-printer parenthesizes only the inner part before appending trailing types — identical to the infix path.

## Changes

- `Syntax.hs`: `PrefixInstanceHead name [Type]` → `PrefixInstanceHead name [Type] [Type]`
- `Internal/Decl.hs`: `bareInstanceHeadParser` produces empty trailing list; `addTailTypes` appends to it
- `Pretty.hs`: prefix pretty-print now mirrors infix: parenthesize inner part, then append trailing types
- `Parens.hs`, `ExprHelpers.hs`: updated pattern matches
- `Arb/Decl.hs`: updated generators/shrinkers; added `genDeclInstanceParenPrefix` covering `(C Int) Bool` shape
- Oracle fixture: promoted from `xfail` to `pass`

## Testing

- Previously xfailing oracle test `snap-core-mptc-parenthesized-instance-head` now passes
- All 972 oracle tests pass
- All 14 property tests pass (including new `genDeclInstanceParenPrefix` generator)