### PR TITLE
fix(parser): correct negation operator precedence in parenthesized expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -703,12 +703,37 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
       minusTok <- minusTokenValueParser
       nextTok <- lookAhead anySingle
       guard (parenNegateAllowed minusTok nextTok)
-      inner <- exprParser
+      -- Parse only the application-level expression as the negation's
+      -- immediate operand.  This matches GHC, where negation binds tighter
+      -- than any infix operator, so @(-l - 1)@ is @((negate l) - 1)@, not
+      -- @(negate (l - 1))@.
+      negOperand <- appExprParser
+      let negBase = ENegate negOperand
+      -- Continue with any infix operator chain, type signature, and view
+      -- pattern that may follow the negated expression inside the parens.
+      rest <-
+        MP.many
+          ( MP.try
+              ( (,)
+                  <$> infixOperatorParserExcept []
+                  <*> region "after infix operator" lexpParser
+              )
+          )
+      let withInfix = foldl buildInfix negBase rest
+      mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
+      let typed = case mTypeSig of
+            Just ty -> ETypeSig withInfix ty
+            Nothing -> withInfix
+      finalExpr <- maybeViewPattern typed
       expectedTok closeTok
+      -- The negation is already embedded in finalExpr (as negBase).
+      -- With TkPrefixMinus (LexicalNegation), the surrounding parens are
+      -- just grouping — no EParen wrapper.  Otherwise the parens are part
+      -- of the negation-section syntax and need an EParen wrapper.
       pure $
         case lexTokenKind minusTok of
-          TkPrefixMinus -> ENegate inner
-          _ -> EParen (ENegate inner)
+          TkPrefixMinus -> finalExpr
+          _ -> EParen finalExpr
 
     parenNegateAllowed minusTok nextTok =
       case lexTokenKind minusTok of

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -197,7 +197,6 @@ needsExprParens ctx expr =
     CtxInfixLhs ->
       case expr of
         ETypeSig {} -> True
-        ENegate {} -> True
         _ -> isOpenEnded expr
     CtxAppFun ->
       case expr of

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-negation-precedence-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-negation-precedence-xfail.hs
@@ -1,3 +1,0 @@
-{- ORACLE_TEST xfail negation prefix precedence: pretty-printer emits (- 1) / 2 instead of - 1 / 2 -}
-module A where
-f = - 1 / 2

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-negation-precedence.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-negation-precedence.hs
@@ -1,3 +1,3 @@
 {- ORACLE_TEST pass -}
 module A where
-f l = (-l - 1)
+f = - 1 / 2

--- a/components/aihc-parser/test/Test/Fixtures/oracle/negation-infix-chain-in-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/negation-infix-chain-in-parens.hs
@@ -1,3 +1,3 @@
 {- ORACLE_TEST pass -}
 module A where
-f l = (-l - 1)
+f x = (-x + 1)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/negation-infix-chain-top-level.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/negation-infix-chain-top-level.hs
@@ -1,3 +1,3 @@
 {- ORACLE_TEST pass -}
 module A where
-f l = (-l - 1)
+f x = - x + 1

--- a/components/aihc-parser/test/Test/Fixtures/oracle/negation-multi-operator-chain-in-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/negation-multi-operator-chain-in-parens.hs
@@ -1,3 +1,3 @@
 {- ORACLE_TEST pass -}
 module A where
-f l = (-l - 1)
+f x y z = (-x * y + z)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/negation-multi-operator-chain-top-level.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/negation-multi-operator-chain-top-level.hs
@@ -1,3 +1,3 @@
 {- ORACLE_TEST pass -}
 module A where
-f l = (-l - 1)
+f = - 1 * 2 + 3

--- a/components/aihc-parser/test/Test/Fixtures/oracle/negation-of-parenthesized-expr.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/negation-of-parenthesized-expr.hs
@@ -1,3 +1,3 @@
 {- ORACLE_TEST pass -}
 module A where
-f l = (-l - 1)
+f x y = (-(x + y))


### PR DESCRIPTION
## Summary

- Fix `parseNegateParen` to bind negation at application level instead of greedily consuming the entire infix chain
- Remove unnecessary parenthesization of `ENegate` in `CtxInfixLhs` context
- Convert 2 xfail oracle fixtures to pass, add 5 new edge case oracle fixtures

## Root Cause

`parseNegateParen` in `Expr.hs` called `exprParser` for the negation operand. `exprParser` parses the full infix chain, so `(-l - 1)` was parsed as `ENegate (EInfix l (-) 1)` — meaning `negate (l - 1)`. GHC parses this as `OpApp (NegApp l) (-) 1` — meaning `(negate l) - 1` — because negation binds tighter than any binary operator.

After pretty-printing, the roundtrip produced `(- (l - 1))` instead of `(- l - 1)`, causing a GHC fingerprint mismatch.

A secondary issue was that `Parens.hs` unconditionally parenthesized `ENegate` in `CtxInfixLhs`, producing `((- l) - 1)` even with the correct AST. This was unnecessary because the parser always tries `negateExprParser` before infix operators, making the prefix minus unambiguous.

## Solution

**Parser (`Expr.hs`)**: In `parseNegateParen`, replace `inner <- exprParser` with `appExprParser` for just the negation operand, then continue parsing the infix operator chain, type signatures, and view patterns. This matches GHC's precedence semantics and generalizes to arbitrary infix chains like `(-x * y + z)`.

**Parens (`Parens.hs`)**: Remove `ENegate {} -> True` from the `CtxInfixLhs` branch of `needsExprParens`. The parser's structure (negation tried before infix operators) guarantees unambiguous re-parsing without extra parentheses.

## Alternatives Considered

1. **Eliminate `parseNegateParen` entirely, letting `parseBoxedContent` handle negation via its existing `negateExprParser` path**: Would fix the precedence issue but loses the `TkPrefixMinus` distinction (LexicalNegation extension: no `EParen` wrapper). Rejected to preserve existing extension semantics.

2. **Fix only in `Parens.hs` by adding smarter parenthesization**: Cannot work because the AST itself was structurally wrong (`ENegate` wrapping the entire infix chain). The fix must be at the parser level.

## Test Changes

- `aftovolio-negation-operator-precedence.hs`: xfail → pass
- `diagrams-contrib-negation-precedence-xfail.hs`: renamed to `diagrams-contrib-negation-precedence.hs`, xfail → pass
- 5 new oracle fixtures covering negation + infix chains (in parens, at top level, multi-operator, parenthesized operand)

## Progress

pass: 935 → 942 (+7), xfail: 22 → 20 (−2)