### PR TITLE
fix(layout): close nested LayoutCaseAlternative contexts before where

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -125,21 +125,34 @@ closeBeforeToken st tok =
     anchor = lexTokenSpan tok
     closeTok = virtualSymbolToken "}" anchor
 
-    -- Close an immediately enclosing LayoutCaseAlternative when 'where'
-    -- appears at or to the left of its indent column.  This is a single-step
-    -- check on the top of the context stack (not a loop).
+    -- Close enclosing LayoutCaseAlternative contexts when 'where' appears
+    -- at or to the left of their indent column.  This loops through the
+    -- stack to handle nested case expressions (inner case inside outer
+    -- case alternative) where multiple LayoutCaseAlternative contexts
+    -- need closing.
     closeBeforeWhere =
-      case layoutContexts st of
-        LayoutImplicit indent LayoutCaseAlternative : rest
-          | tokenStartCol tok <= indent ->
-              let openTok = virtualSymbolToken "{" anchor
-                  (pendingInserted, st') =
-                    case layoutPendingLayout st of
-                      Just (PendingImplicitLayout _) ->
-                        ([openTok, closeTok], st {layoutPendingLayout = Nothing})
-                      _ -> ([], st)
-               in (pendingInserted <> [closeTok], st' {layoutContexts = rest})
-        _ -> ([], st)
+      let col = tokenStartCol tok
+          openTok = virtualSymbolToken "{" anchor
+          -- Flush any pending implicit layout as an empty block before
+          -- closing contexts.
+          (pendingInserted, st0) =
+            case layoutPendingLayout st of
+              Just (PendingImplicitLayout _) ->
+                ([openTok, closeTok], st {layoutPendingLayout = Nothing})
+              _ -> ([], st)
+          go ctxs =
+            case ctxs of
+              LayoutImplicit indent LayoutCaseAlternative : rest
+                | col <= indent ->
+                    let (inner, rest') = go rest
+                     in (closeTok : inner, rest')
+              LayoutImplicit indent _ : rest
+                | col < indent ->
+                    let (inner, rest') = go rest
+                     in (closeTok : inner, rest')
+              _ -> ([], ctxs)
+          (closed, ctxs') = go (layoutContexts st0)
+       in (pendingInserted <> closed, st0 {layoutContexts = ctxs'})
 
     -- Close implicit layouts before 'then'/'else'.
     -- A `then do`/`else do` block stays open across nested conditionals inside

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-where-indent.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-where-indent.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail where clause under case alt with operator continuation attaches at wrong indentation level -}
+{- ORACLE_TEST pass -}
 module A where
 f k m0
   = case compare k 0 of

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/nested-case-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/nested-case-where.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+module NestedCaseWhere where
+
+-- where clause after nested case expressions should attach to the
+-- enclosing function binding, not the outer case alternative.
+f k m0
+  = case compare k 0 of
+      GT
+        -> case m0 of
+             [] -> Nothing
+             _ -> Just k
+      where
+          g = k + 1

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/triple-nested-case-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/triple-nested-case-where.hs
@@ -1,0 +1,16 @@
+{- ORACLE_TEST pass -}
+module TripleNestedCaseWhere where
+
+-- where clause after triply nested case expressions.
+-- Tests that closeBeforeWhere correctly closes all enclosing
+-- LayoutCaseAlternative contexts.
+f x y z =
+  case x of
+    True ->
+      case y of
+        True ->
+          case z of
+            True -> x
+            False -> y
+    where
+        g = x


### PR DESCRIPTION
## Summary

- Fix `closeBeforeWhere` in the layout engine to loop through the context stack instead of only checking the top, correctly closing all enclosing `LayoutCaseAlternative` contexts when `where` appears at or to the left of their indent column
- Convert `nonempty-containers-where-indent` from xfail to pass and add two new regression tests for nested and triple-nested case+where scenarios

## Root Cause

`closeBeforeWhere` (`Layout.hs:131-142`) was a single-step check that only popped one `LayoutCaseAlternative` from the top of the layout context stack. When case expressions were nested (inner case inside an outer case alternative), the inner case's `LayoutCaseAlternative` sat on top of the outer's. `closeBeforeWhere` removed the inner one and stopped. `bolLayout` didn't close the outer because `col == indent` (not `<`). The `where` keyword was then consumed by the case alt's `rhsParser` instead of the enclosing function binding's `equationRhsParser`, causing the where clause to attach at the wrong indentation level.

## Solution

Changed `closeBeforeWhere` from a single-step check to a recursive loop that:
1. Closes `LayoutCaseAlternative` contexts where `col <= indent` (the `where` is at or left of the case alt)
2. Closes any intervening implicit layout contexts where `col < indent` (strictly nested)
3. Stops at explicit layout or contexts the `where` cannot escape

This mirrors the existing `closeBeforeThenElse` pattern and generalizes correctly for arbitrary nesting depth.

## Progress

- pass: 958 (+3)
- xfail: 14 (-1)