### PR TITLE
fix(parser): support parenthesized prefix type heads in declarations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1155,7 +1155,10 @@ declContextParser = contextParserWith typeParser typeAtomParser
 
 typeDeclHeadParser :: TokParser (BinderHead UnqualifiedName)
 typeDeclHeadParser =
-  MP.try parenthesizedInfixDeclHeadParser <|> MP.try infixDeclHeadParser <|> prefixDeclHeadParser
+  MP.try parenthesizedInfixDeclHeadParser
+    <|> MP.try parenthesizedPrefixDeclHeadParser
+    <|> MP.try infixDeclHeadParser
+    <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
@@ -1176,6 +1179,14 @@ typeDeclHeadParser =
       expectedTok TkSpecialRParen
       tailParams <- MP.many declTypeParamParser
       pure (InfixBinderHead lhs op rhs tailParams)
+
+    parenthesizedPrefixDeclHeadParser = do
+      expectedTok TkSpecialLParen
+      name <- constructorUnqualifiedNameParser
+      params <- MP.some declTypeParamParser
+      expectedTok TkSpecialRParen
+      tailParams <- MP.many declTypeParamParser
+      pure (PrefixBinderHead name (params <> tailParams))
 
 typeSynonymOperatorParser :: TokParser Text
 typeSynonymOperatorParser =
@@ -1246,7 +1257,10 @@ typeFamilyLhsParser = do
 
 classHeadParser :: TokParser (BinderHead UnqualifiedName)
 classHeadParser =
-  MP.try parenthesizedInfixDeclHeadParser <|> MP.try infixDeclHeadParser <|> prefixDeclHeadParser
+  MP.try parenthesizedInfixDeclHeadParser
+    <|> MP.try parenthesizedPrefixDeclHeadParser
+    <|> MP.try infixDeclHeadParser
+    <|> prefixDeclHeadParser
   where
     prefixDeclHeadParser = do
       name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
@@ -1267,6 +1281,14 @@ classHeadParser =
       expectedTok TkSpecialRParen
       tailParams <- MP.many declTypeParamParser
       pure (InfixBinderHead lhs (nameToUnqualified op) rhs tailParams)
+
+    parenthesizedPrefixDeclHeadParser = do
+      expectedTok TkSpecialLParen
+      name <- constructorUnqualifiedNameParser
+      params <- MP.some declTypeParamParser
+      expectedTok TkSpecialRParen
+      tailParams <- MP.many declTypeParamParser
+      pure (PrefixBinderHead name (params <> tailParams))
 
 nameToUnqualified :: Name -> UnqualifiedName
 nameToUnqualified name = mkUnqualifiedName (nameType name) (nameText name)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/citeproc-newtype-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/citeproc-newtype-parens.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects parenthesised newtype constructor in newtype declaration -}
+{- ORACLE_TEST pass -}
 module CiteprocNewtypeParens where
 
 newtype (ReferenceMap a) = ReferenceMap { unReferenceMap :: [(a)] }

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-exactprint-parenthesised-class-head-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-exactprint-parenthesised-class-head-xfail.hs
@@ -1,5 +1,0 @@
-{- ORACLE_TEST xfail parser rejects parenthesised class head in class declaration -}
-module A where
-
-class (Monad m) => (HasTransform m) where
-  liftT :: Int -> m Int

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-exactprint-parenthesised-class-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-exactprint-parenthesised-class-head.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module A where
+
+class (Monad m) => (HasTransform m) where
+  liftT :: Int -> m Int

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/class-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/class-parens.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module A where
+
+class (MyClass a) where
+  myMethod :: a -> Int

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/data-parens-multi-params.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/data-parens-multi-params.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+
+data (Map k v) = Map [(k, v)]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/data-parens-tail-params.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/data-parens-tail-params.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+
+data (Pair a) b = Pair a b

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/newtype-parens-single-param.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/newtype-parens-single-param.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+
+newtype (Wrapper a) = Wrapper a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/type-synonym-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ParenthesizedTypeHead/type-synonym-parens.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+
+type (Synonym a) = [a]


### PR DESCRIPTION
## Summary

- Add `parenthesizedPrefixDeclHeadParser` to `typeDeclHeadParser` and `classHeadParser`
- Convert 2 xfail tests to passing tests
- Add 5 new edge case tests for parenthesized type heads

## Root Cause

The parser rejected valid Haskell syntax like:
```haskell
newtype (ReferenceMap a) = ReferenceMap { unReferenceMap :: [(a)] }
class (Monad m) => (HasTransform m) where ...
```

The `typeDeclHeadParser` had three alternatives:
1. `parenthesizedInfixDeclHeadParser` - handles `(a :+: b)`
2. `infixDeclHeadParser` - handles `a :+: b`
3. `prefixDeclHeadParser` - handles `Foo a` or `(+:) a`

None handled `(Foo a)` - a parenthesized prefix application. When encountering `(ReferenceMap a)`:
- `parenthesizedInfixDeclHeadParser` failed because `ReferenceMap` is not a type variable
- `infixDeclHeadParser` failed because `(` is not a type variable
- `prefixDeclHeadParser` failed because it only accepts bare names or parenthesized operators

## Solution

Add `parenthesizedPrefixDeclHeadParser` that matches the pattern `(Constructor params...) [tailParams...]` and produces a `PrefixBinderHead`. The fix is applied to both `typeDeclHeadParser` (for data/newtype/type declarations) and `classHeadParser` (for class declarations).

## Test Plan

- [x] Original xfail test `citeproc-newtype-parens` now passes
- [x] Related xfail test `ghc-exactprint-parenthesised-class-head` now passes
- [x] Added edge case tests for single param, multi param, tail params, type synonyms, and classes
- [x] All 1587 parser tests pass