### PR TITLE
fix(parser): allow type annotations in if-then-else branch expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -72,11 +72,6 @@ exprParserExcept :: [Text] -> TokParser Expr
 exprParserExcept =
   exprCoreParserWithTypeSigParserExcept typeParser
 
-exprParserNoTopLevelTypeSig :: TokParser Expr
-exprParserNoTopLevelTypeSig =
-  label "expression" $
-    exprCoreParserWithoutTypeSigExcept []
-
 exprCoreParserWithoutTypeSigExcept :: [Text] -> TokParser Expr
 exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
   mSCC <- optionalHiddenPragma getSCCLabel
@@ -156,10 +151,10 @@ classicIfExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   cond <- region "while parsing if condition" exprParser
   skipSemicolons
   expectedTok TkKeywordThen
-  yes <- region "while parsing then branch" exprParserNoTopLevelTypeSig
+  yes <- region "while parsing then branch" exprParser
   skipSemicolons
   expectedTok TkKeywordElse
-  no <- region "while parsing else branch" exprParserNoTopLevelTypeSig
+  no <- region "while parsing else branch" exprParser
   pure (EIf cond yes no)
 
 multiWayIfExprParser :: TokParser Expr

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -791,7 +791,7 @@ addExprParensPrec prec expr =
     EIf cond yes no ->
       wrapExpr
         (prec > 0)
-        (EIf (addExprParens cond) (addIfBranchParens yes) (addIfBranchParens no))
+        (EIf (addExprParens cond) (addExprParens yes) (addExprParens no))
     EMultiWayIf rhss ->
       wrapExpr (prec > 0) (EMultiWayIf (map (addGuardedRhsParens GuardArrow) rhss))
     ELambdaPats pats body ->
@@ -904,12 +904,6 @@ addNegateParens inner =
   if startsWithDollar inner || startsWithOverloadedLabel inner
     then wrapExpr True (addExprParens inner)
     else addExprParensPrec 3 inner
-
-addIfBranchParens :: Expr -> Expr
-addIfBranchParens expr =
-  if endsWithTypeSig expr
-    then wrapExpr True (addExprParens expr)
-    else addExprParens expr
 
 addCaseAltParens :: CaseAlt -> CaseAlt
 addCaseAltParens (CaseAlt sp pat rhs) =

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/if-both-branches-type-sig.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/if-both-branches-type-sig.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  if x then y :: T else z :: U
+ast: EIf (EVar "x") (ETypeSig (EVar "y") (TCon "T")) (ETypeSig (EVar "z") (TCon "U"))
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/if-else-type-sig.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/if-else-type-sig.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  if x then y else z :: T
+ast: EIf (EVar "x") (EVar "y") (ETypeSig (EVar "z") (TCon "T"))
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/if-then-type-sig-arrow.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/if-then-type-sig-arrow.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  if x then y :: T -> U else z
+ast: EIf (EVar "x") (ETypeSig (EVar "y") (TFun (TCon "T") (TCon "U"))) (EVar "z")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/if-then-type-sig.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/if-then-type-sig.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  if x then y :: T else z
+ast: EIf (EVar "x") (ETypeSig (EVar "y") (TCon "T")) (EVar "z")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ihaskell-type-annotation-in-do-case-if-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ihaskell-type-annotation-in-do-case-if-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser fails on type annotation in then-branch of if inside do-case alternative -}
+{- ORACLE_TEST pass -}
 module IHaskellTypeAnnotationInDoCaseIf where
 
 f flag y = do

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/mixed-types-num-type-sig-in-if-then-branch.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/mixed-types-num-type-sig-in-if-then-branch.hs
@@ -1,3 +1,3 @@
-{- ORACLE_TEST xfail type signature in if-then branch rejected -}
+{- ORACLE_TEST pass -}
 module A where
 f = if True then x :: Int else x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/slack-web-type-annotation-in-if-then-else.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/slack-web-type-annotation-in-if-then-else.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects type annotation in if-then branch expression -}
+{- ORACLE_TEST pass -}
 module SlackWebTypeAnnotationInIfThenElse where
 
 f = if x then y :: T else z


### PR DESCRIPTION
## Summary

- Fixes the parser to accept type annotations (`::`) in `then` and `else` branches of if-then-else expressions, matching GHC's grammar
- Removes defensive parenthesization in the pretty-printer that broke AST roundtrip fingerprints

## Root Cause

`classicIfExprParser` used `exprParserNoTopLevelTypeSig` for the then/else branches, which calls `exprCoreParserWithoutTypeSigExcept` directly — bypassing the `::` type signature parsing layer. This caused expressions like `if x then y :: T else z` to be rejected with a parse error at `::`.

GHC's grammar uses the full `exp` production (which includes `:: sigtype`) for all three sub-expressions of `if-then-else`. The `then` and `else` keywords act as natural terminators for the type parser, so there is no ambiguity.

Additionally, the pretty-printer's `addIfBranchParens` function unconditionally parenthesized branch expressions ending with type signatures (e.g., printing `if x then (y :: T) else z`), which broke AST roundtrip fingerprint validation against GHC.

## Solution

1. **Parser**: Replace `exprParserNoTopLevelTypeSig` with `exprParser` in both the then and else branches of `classicIfExprParser`. Remove the now-unused `exprParserNoTopLevelTypeSig` function.

2. **Pretty-printer**: Replace `addIfBranchParens` (which wrapped branches ending with `::` in parentheses) with plain `addExprParens` in the `EIf` case. Remove the now-unused `addIfBranchParens` function.

## Changes

| File | Change |
|------|--------|
| `Expr.hs` | Use `exprParser` for if-then-else branches; remove `exprParserNoTopLevelTypeSig` |
| `Parens.hs` | Use `addExprParens` for if-then-else branches; remove `addIfBranchParens` |
| 3 oracle fixtures | Promote `xfail` → `pass` |
| 4 golden fixtures | New regression tests for `::` in then-branch, else-branch, both branches, and arrow types |

## Test Results

- **3 xfail → pass**: `slack-web-type-annotation-in-if-then-else`, `mixed-types-num-type-sig-in-if-then-branch`, `ihaskell-type-annotation-in-do-case-if-xfail`
- **4 new golden tests**: `if-then-type-sig`, `if-else-type-sig`, `if-both-branches-type-sig`, `if-then-type-sig-arrow`
- Full test suite passes (1727 tests)

Note: `just check` has a pre-existing failure on `main` due to `-Werror` catching `-Wname-shadowing` and `-Wincomplete-patterns` warnings unrelated to this PR.