### PR TITLE
fix(lexer): require column 1 for #line directives, not just line start

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
@@ -30,11 +30,22 @@ tryConsumeLineDirective st
   | otherwise =
       let inp = lexerInput st
           (spaces, rest) = T.span (\c -> c == ' ' || c == '\t') inp
+          -- CPP #line directives require '#' at column 1 (no leading
+          -- whitespace).  GHC enforces the same rule: an indented '#' is
+          -- never a line directive.  Shebangs, however, are allowed with
+          -- optional leading whitespace.
+          --
+          -- Note: skipTrivia may have already consumed leading whitespace
+          -- before calling us, so we check lexerCol rather than whether
+          -- 'spaces' is empty.  The column after consuming 'spaces' is
+          -- where '#' would sit.
+          hashCol = lexerCol st + T.length spaces
+          atColumn1 = hashCol == 1
        in case rest of
             '#' :< more ->
               let lineText = "#" <> takeLineRemainder more
                   consumed = spaces <> lineText
-               in case classifyHashLineTrivia lineText of
+               in case classifyHashLineTrivia atColumn1 lineText of
                     Just (HashLineDirective update) ->
                       Just (Nothing, applyDirectiveAdvance consumed update st)
                     Just HashLineShebang ->
@@ -126,9 +137,17 @@ applyDirectiveAdvance consumed update st =
           lexerAtLineStart = hasTrailingNewline || (Just 1 == directiveCol update)
         }
 
-classifyHashLineTrivia :: Text -> Maybe HashLineTrivia
-classifyHashLineTrivia raw
+-- | Classify a line beginning with @#@.
+--
+-- @atColumn1@ is 'True' when @#@ sits at column 1 of the physical source
+-- line (no leading whitespace).  CPP @#line@ directives are only
+-- recognised at column 1, matching GHC behaviour.  Shebangs (@#!@) are
+-- accepted regardless of column.
+classifyHashLineTrivia :: Bool -> Text -> Maybe HashLineTrivia
+classifyHashLineTrivia _atColumn1 raw
   | isHashBangLine raw = Just HashLineShebang
+classifyHashLineTrivia atColumn1 raw
+  | not atColumn1 = Nothing
   | looksLikeHashLineDirective raw =
       case parseHashLineDirective raw of
         Just update -> Just (HashLineDirective update)

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -231,6 +231,7 @@ buildTests = do
             testCase "sets lexTokenAtLineStart correctly" test_tokenAtLineStartWithoutDirective,
             testCase "hash line directive sets lexTokenAtLineStart" test_hashLineDirectiveSetsAtLineStart,
             testCase "hash line directive preserves layout" test_hashLineDirectivePreservesLayout,
+            testCase "indented hash-line is operator, not directive" test_indentedHashLineIsOperator,
             testCase "can lex lazily from chunks" test_lexerChunkLaziness,
             testCase "parser config passes extensions to lexer" test_parserConfigPassesExtensions,
             testCase "parser config sets source name in parse errors" test_parserConfigSetsSourceName,
@@ -1435,6 +1436,18 @@ test_hashLineDirectivePreservesLayout =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         assertEqual "expected two declarations" 2 (length (moduleDecls modu))
+
+test_indentedHashLineIsOperator :: Assertion
+test_indentedHashLineIsOperator =
+  -- '# line' on an indented continuation line must lex as operator '#'
+  -- plus identifier 'line', not as a CPP #line directive.
+  case lexTokens "x\n  # line" of
+    [ LexToken {lexTokenKind = TkVarId "x"},
+      LexToken {lexTokenKind = TkVarSym "#"},
+      LexToken {lexTokenKind = TkVarId "line"},
+      LexToken {lexTokenKind = TkEOF}
+      ] -> pure ()
+    other -> assertFailure ("expected indented '# line' to lex as operator + identifier, got: " <> show other)
 
 assertSourceSpan :: FilePath -> Int -> Int -> Int -> Int -> Int -> Int -> SourceSpan -> Assertion
 assertSourceSpan expectedName expectedStartLine expectedStartCol expectedEndLine expectedEndCol expectedStartOffset expectedEndOffset span' =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-hash-line-directive-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-hash-line-directive-xfail.hs
@@ -1,4 +1,0 @@
-{- ORACLE_TEST xfail lexer treats # at start of continuation line followed by 'line' as a CPP directive -}
-module A where
-r = x
-  # line

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-hash-line-directive.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-contrib-hash-line-directive.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+r = x
+  # line


### PR DESCRIPTION
## Summary

- Fix lexer incorrectly treating indented `# line` as a CPP `#line` directive instead of the Haskell infix operator `#` followed by identifier `line`
- Add column-1 check to `tryConsumeLineDirective` so only `#` at column 1 is recognized as a potential `#line` directive (shebangs still accepted at any column)
- Promote oracle fixture from xfail to pass and add a dedicated unit test

## Root Cause

`tryConsumeLineDirective` gated directive recognition on `lexerAtLineStart`, which is `True` for any line preceded only by whitespace — including indented continuation lines. For the snippet:

```haskell
r = x
  # line
```

the lexer consumed `# line` as a malformed `#line` directive because `lexerAtLineStart` was `True` at column 3, and `looksLikeHashLineDirective` matched the `"line"` prefix after `#`.

GHC requires `#` to be at column 1 for `#line` directives. An indented `#` is never a directive.

## Solution

Compute the physical column where `#` would sit (`lexerCol st + T.length spaces`) and pass an `atColumn1` flag to `classifyHashLineTrivia`. When `atColumn1` is `False`, only shebangs (`#!`) are recognized — `#line` directives and malformed directive errors are suppressed, allowing `#` to fall through to normal Haskell operator lexing.

This approach was chosen over alternatives because:
- Checking `T.null spaces` alone is insufficient: `skipTrivia` consumes whitespace before calling `tryConsumeLineDirective`, so `spaces` is typically empty regardless of indentation
- Using `lexerCol` directly reflects the true physical column, generalizing correctly for all call sites

## Changes

- `Aihc.Parser.Lex.Trivia`: `tryConsumeLineDirective` computes `hashCol` and `atColumn1`; `classifyHashLineTrivia` accepts `Bool` parameter and rejects non-column-1 `#line` directives
- `Spec.hs`: New unit test `test_indentedHashLineIsOperator` verifying `"x\n  # line"` lexes as `x`, `#`, `line`
- Oracle fixture `diagrams-contrib-hash-line-directive`: renamed from `-xfail` to pass

Progress: xfail 13/955 (was 14/955)