### PR TITLE
refactor(parser): remove special top-level $ splice parsing, use expression fallback

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -44,25 +44,29 @@ declParser = do
 ordinaryDeclParser :: TokParser Decl
 ordinaryDeclParser = do
   (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
-  thAny <- thAnyEnabled
+  exprFallback <- exprDeclEnabled
   let tokKind = lexTokenKind tok
       nextTokKind = lexTokenKind nextTok
-      valueOrSpliceParser =
-        if thAny
-          then MP.try valueDeclParser <|> implicitSpliceDeclParser
+      -- When TemplateHaskell, TemplateHaskellQuotes, or QuasiQuotes is
+      -- enabled, GHC allows top-level expressions as declaration splices.
+      -- The expression parser itself handles extension-specific constructs
+      -- (e.g. @$expr@ via TH, @[qq|...|]@ via QuasiQuotes).
+      valueOrExprParser =
+        if exprFallback
+          then MP.try valueDeclParser <|> exprDeclParser
           else valueDeclParser
-      patternOrValueOrSpliceParser =
-        if thAny
-          then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> implicitSpliceDeclParser
+      patternOrValueOrExprParser =
+        if exprFallback
+          then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> exprDeclParser
           else MP.try patternBindDeclParser <|> valueDeclParser
-      nonBareVarPatternOrValueOrSpliceParser =
-        if thAny
-          then MP.try nonBareVarPatternBindDeclParser <|> MP.try valueDeclParser <|> implicitSpliceDeclParser
+      nonBareVarPatternOrValueOrExprParser =
+        if exprFallback
+          then MP.try nonBareVarPatternBindDeclParser <|> MP.try valueDeclParser <|> exprDeclParser
           else MP.try nonBareVarPatternBindDeclParser <|> valueDeclParser
-      typeSigOrValueOrSpliceParser =
-        MP.try typeSigOrPatternTypeSigDeclParser <|> valueOrSpliceParser
-      typeSigOrPatternOrValueOrSpliceParser =
-        MP.try typeSigOrPatternTypeSigDeclParser <|> patternOrValueOrSpliceParser
+      typeSigOrValueOrExprParser =
+        MP.try typeSigOrPatternTypeSigDeclParser <|> valueOrExprParser
+      typeSigOrPatternOrValueOrExprParser =
+        MP.try typeSigOrPatternTypeSigDeclParser <|> patternOrValueOrExprParser
   case tokKind of
     TkKeywordData ->
       case nextTokKind of
@@ -90,15 +94,11 @@ ordinaryDeclParser = do
     TkKeywordPattern -> patternSynonymParser
     TkVarId {} ->
       case nextTokKind of
-        TkReservedDoubleColon -> typeSigOrValueOrSpliceParser
-        TkSpecialComma -> typeSigOrValueOrSpliceParser
-        TkReservedEquals -> valueOrSpliceParser
-        _ -> nonBareVarPatternOrValueOrSpliceParser
-    TkTHSplice ->
-      if thAny
-        then MP.try patternBindDeclParser <|> MP.try valueDeclParser <|> spliceDeclParser
-        else spliceDeclParser
-    _ -> typeSigOrPatternOrValueOrSpliceParser
+        TkReservedDoubleColon -> typeSigOrValueOrExprParser
+        TkSpecialComma -> typeSigOrValueOrExprParser
+        TkReservedEquals -> valueOrExprParser
+        _ -> nonBareVarPatternOrValueOrExprParser
+    _ -> typeSigOrPatternOrValueOrExprParser
 
 -- | Like 'patternBindDeclParser' but rejects bare variable patterns.
 -- When the leading token is a variable identifier, a bare @x = 5@ must be
@@ -117,17 +117,25 @@ nonBareVarPatternBindDeclParser = MP.try $ withSpanAnn (DeclAnn . mkAnnotation) 
 pragmaDeclParser :: TokParser Decl
 pragmaDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ DeclPragma <$> anyPragmaParser "pragma declaration"
 
--- | Parse a top-level Template Haskell declaration splice: $expr or $(expr)
-spliceDeclParser :: TokParser Decl
-spliceDeclParser = do
-  expectedTok TkTHSplice
-  DeclSplice <$> exprParser
+-- | Check whether the expression-as-declaration fallback is enabled.
+-- GHC allows top-level expressions under TemplateHaskell (bare splices),
+-- TemplateHaskellQuotes, and QuasiQuotes (e.g. @[qq|...|]@ at the top level).
+exprDeclEnabled :: TokParser Bool
+exprDeclEnabled = do
+  th <- isExtensionEnabled TemplateHaskell
+  thq <- isExtensionEnabled TemplateHaskellQuotes
+  qq <- isExtensionEnabled QuasiQuotes
+  pure (th || thq || qq)
 
--- | Parse an implicit top-level Template Haskell declaration splice: @expr@.
--- GHC accepts bare declaration splices under TemplateHaskell and also pretty-prints
--- them as explicit @$...@ splices, so we parse the expression body directly here.
-implicitSpliceDeclParser :: TokParser Decl
-implicitSpliceDeclParser = DeclSplice <$> exprParser
+-- | Parse a top-level expression as a declaration.
+--
+-- GHC allows arbitrary expressions at the top level under TemplateHaskell
+-- (interpreted as declaration splices). This parser wraps the expression in
+-- 'DeclSplice'. The expression parser itself handles extension-specific
+-- constructs (e.g. @$expr@, @$(expr)@ via TH, @[qq|...|]@ via QuasiQuotes),
+-- so no special dispatch is needed here.
+exprDeclParser :: TokParser Decl
+exprDeclParser = DeclSplice <$> exprParser
 
 -- | Parse a @type@ declaration after the @type@ keyword has been consumed.
 -- Uses 'typeDeclHeadParser' to handle both prefix and infix type heads,

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -381,11 +381,7 @@ addDeclParens decl =
     DeclPragma {} -> decl
 
 addDeclSpliceParens :: Expr -> Expr
-addDeclSpliceParens body =
-  case body of
-    EVar {} -> body
-    EParen inner -> EParen (addExprParens inner)
-    _ -> addExprParens body
+addDeclSpliceParens = addExprParens
 
 addValueDeclParens :: ValueDecl -> ValueDecl
 addValueDeclParens vdecl =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -161,13 +161,10 @@ prettyImportLevel level =
     ImportLevelSplice -> "splice"
 
 -- | Pretty-print a top-level declaration splice.
--- EVar and EParen get a @$@ prefix; other expressions are bare.
+-- The expression is printed as-is; explicit TH splices appear as @$expr@ or
+-- @$(expr)@ through the normal 'ETHSplice' pretty-printer.
 prettyDeclSpliceExpr :: Expr -> Doc ann
-prettyDeclSpliceExpr body =
-  case peelExprAnn body of
-    EVar {} -> "$" <> prettyExpr body
-    EParen {} -> "$" <> prettyExpr body
-    _ -> prettyExpr body
+prettyDeclSpliceExpr = prettyExpr
 
 prettyQuotedText :: Text -> Doc ann
 prettyQuotedText txt = "\"" <> pretty txt <> "\""

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/th-decl-quote-multi-decl.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/th-decl-quote-multi-decl.yaml
@@ -8,5 +8,5 @@ input: |
     f x = x
     |])
 ast: |
-  Module {name = "TH_Decl_Quote_MultiDecl", languagePragmas = [EnableExtension TemplateHaskell, EnableExtension QuasiQuotes], decls = [DeclSplice (EParen (EApp (EVar "undefined") (ETHDeclQuote [DeclData (DataDecl {name = "Nat", constructors = [PrefixCon {name = "Z"}, PrefixCon {name = "S", fields = [BangType {type = TCon "Nat"}]}]}), DeclValue (FunctionBind "f" [Match {headForm = Prefix, pats = [PVar "x"], rhs = UnguardedRhs (EVar "x")}])])))]}
+  Module {name = "TH_Decl_Quote_MultiDecl", languagePragmas = [EnableExtension TemplateHaskell, EnableExtension QuasiQuotes], decls = [DeclSplice (ETHSplice (EParen (EApp (EVar "undefined") (ETHDeclQuote [DeclData (DataDecl {name = "Nat", constructors = [PrefixCon {name = "Z"}, PrefixCon {name = "S", fields = [BangType {type = TCon "Nat"}]}]}), DeclValue (FunctionBind "f" [Match {headForm = Prefix, pats = [PVar "x"], rhs = UnguardedRhs (EVar "x")}])]))))]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QuasiQuotes/decl-quasiquote.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QuasiQuotes/decl-quasiquote.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail top-level quasiquote splice not supported as declaration -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE QuasiQuotes #-}
 module DeclQuasiQuote where
 [qq||]


### PR DESCRIPTION
## Summary

- Remove the dedicated `spliceDeclParser` and `TkTHSplice` case from the top-level declaration dispatcher. Instead, `$expr` / `$(expr)` at the top level are now parsed as regular expressions through the generic expression-as-declaration fallback, producing `DeclSplice (ETHSplice ...)` instead of `DeclSplice (EVar/EParen ...)`.
- Gate the expression-as-declaration fallback on `TemplateHaskell`, `TemplateHaskellQuotes`, or `QuasiQuotes`, matching GHC's parser behavior.
- Fix the `decl-quasiquote` xfail: `[qq||]` at the top level with only `QuasiQuotes` enabled now parses correctly.

## Root Cause

The parser had a dedicated `spliceDeclParser` that consumed the `TkTHSplice` token (`$`) and then parsed the following expression. The implicit expression fallback (`implicitSpliceDeclParser`) was gated solely on `thAnyEnabled` (TemplateHaskell or TemplateHaskellQuotes). This meant:

1. Top-level quasiquotes like `[qq||]` with only `QuasiQuotes` enabled had no path to be parsed as declarations, since QuasiQuotes did not trigger the expression fallback.
2. The `$` prefix was handled in two disconnected places: once at the declaration level (consuming `TkTHSplice`), and once in the expression parser (`ETHSplice`), creating unnecessary structural duplication.

## Solution

The cleanest fix is to remove the special `$` handling at the declaration level entirely:

- The expression parser already knows how to handle `$` as `ETHSplice`. By routing through it, `$(blah)` naturally becomes `DeclSplice (ETHSplice (EParen ...))`.
- The extension gate is broadened from `thAnyEnabled` to also include `QuasiQuotes`, matching GHC's behavior where top-level quasiquotes are accepted under just `QuasiQuotes`.
- Renamed `implicitSpliceDeclParser` → `exprDeclParser` and `spliceDeclParser` is removed entirely.

## Changes

| File | Change |
|------|--------|
| `Decl.hs` | Removed `spliceDeclParser`, `implicitSpliceDeclParser`, and `TkTHSplice` dispatch case. Added `exprDeclEnabled` (checks TH/THQ/QQ) and `exprDeclParser`. |
| `Pretty.hs` | `prettyDeclSpliceExpr` simplified to delegate to `prettyExpr` (the `$` now comes from `ETHSplice` rendering). |
| `Parens.hs` | `addDeclSpliceParens` simplified to `addExprParens` (no special-casing for `EVar`/`EParen`). |
| `th-decl-quote-multi-decl.yaml` | Golden AST updated: `DeclSplice (EParen ...)` → `DeclSplice (ETHSplice (EParen ...))`. |
| `decl-quasiquote.hs` | `xfail` → `pass`. |

Progress: xfail -1