### PR TITLE
feat(parser): implement TransformListComp extension support

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -943,11 +943,126 @@ compStmtParser = do
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkKeywordLet -> MP.try compLetStmtParser <|> compGenOrGuardParser
+    TkKeywordThen -> compTransformStmtParser <|> compGenOrGuardParser
     _ -> do
       isPatternBind <- startsWithPatternBind
       if isPatternBind
         then compPatGenParser
         else compGenOrGuardParser
+
+-- | Parse a TransformListComp qualifier: @then f@, @then f by e@,
+-- @then group by e using f@, or @then group using f@.
+-- Only attempted when the 'TransformListComp' extension is enabled.
+compTransformStmtParser :: TokParser CompStmt
+compTransformStmtParser = MP.try $ withSpanAnn (CompAnn . mkAnnotation) $ do
+  enabled <- isExtensionEnabled TransformListComp
+  guard enabled
+  expectedTok TkKeywordThen
+  -- Check for 'group' forms first
+  tok <- lookAhead anySingle
+  case lexTokenKind tok of
+    TkVarId "group" -> compGroupStmtParser
+    _ -> compThenStmtParser
+
+-- | Parse @group by e using f@ or @group using f@ (after 'then' has been consumed).
+compGroupStmtParser :: TokParser CompStmt
+compGroupStmtParser = do
+  varIdTok "group"
+  tok <- lookAhead anySingle
+  case lexTokenKind tok of
+    TkVarId "by" -> do
+      varIdTok "by"
+      e <- compTransformExprParser
+      varIdTok "using"
+      CompGroupByUsing e <$> exprParser
+    TkVarId "using" -> do
+      varIdTok "using"
+      CompGroupUsing <$> exprParser
+    _ -> fail "expected 'by' or 'using' after 'group'"
+
+-- | Parse @f@ or @f by e@ (after 'then' has been consumed).
+-- Uses a restricted expression parser that excludes 'by' and 'using'
+-- from being consumed as variable identifiers at the top level.
+compThenStmtParser :: TokParser CompStmt
+compThenStmtParser = do
+  f <- compTransformExprParser
+  mBy <- MP.optional (varIdTok "by")
+  case mBy of
+    Just () -> CompThenBy f <$> exprParser
+    Nothing -> pure (CompThen f)
+
+-- | Expression parser for TransformListComp context.
+-- Parses an expression but treats bare 'by' and 'using' as terminators
+-- (they are not consumed as variable identifiers at the application level).
+compTransformExprParser :: TokParser Expr
+compTransformExprParser =
+  label "expression" $ do
+    tok <- lookAhead anySingle
+    base <- case lexTokenKind tok of
+      TkKeywordDo -> doExprParser
+      TkKeywordMdo -> mdoExprParser
+      TkKeywordIf -> ifExprParser
+      TkKeywordLet -> letExprParser
+      TkKeywordProc -> procExprParser
+      TkReservedBackslash -> lambdaExprParser
+      _ -> compTransformInfixExprParser
+    rest <- MP.many ((,) <$> infixOperatorParserExcept [] <*> compTransformLexpParser)
+    pure (foldl buildInfix base rest)
+
+compTransformLexpParser :: TokParser Expr
+compTransformLexpParser =
+  doExprParser
+    <|> mdoExprParser
+    <|> ifExprParser
+    <|> caseExprParser
+    <|> letExprParser
+    <|> procExprParser
+    <|> lambdaExprParser
+    <|> MP.try negateExprParser
+    <|> compTransformAppExprParser
+
+compTransformInfixExprParser :: TokParser Expr
+compTransformInfixExprParser = do
+  lhs <- MP.try negateExprParser <|> compTransformLexpParser
+  rest <-
+    MP.many
+      ( (,)
+          <$> infixOperatorParserExcept []
+          <*> region "after infix operator" compTransformLexpParser
+      )
+  pure (foldl buildInfix lhs rest)
+
+compTransformAppExprParser :: TokParser Expr
+compTransformAppExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  typeAppsEnabled <- isExtensionEnabled TypeApplications
+  first <- compTransformAtomExprParser
+  rest <- MP.many (compTransformAppArg typeAppsEnabled)
+  pure $
+    foldl applyArg first rest
+  where
+    compTransformAppArg :: Bool -> TokParser (Either Type Expr)
+    compTransformAppArg typeAppsEnabled
+      | typeAppsEnabled = (Left <$> compTransformTypeAppArg) <|> (Right <$> compTransformAtomExprParser)
+      | otherwise = Right <$> compTransformAtomExprParser
+
+    compTransformTypeAppArg :: TokParser Type
+    compTransformTypeAppArg = MP.try $ do
+      expectedTok TkTypeApp
+      typeAtomParser
+
+    applyArg :: Expr -> Either Type Expr -> Expr
+    applyArg fn (Left ty) = ETypeApp fn ty
+    applyArg fn (Right arg) = EApp fn arg
+
+-- | Like 'atomExprParser' but rejects bare 'by' and 'using' identifiers.
+-- These are treated as contextual keywords in TransformListComp context.
+compTransformAtomExprParser :: TokParser Expr
+compTransformAtomExprParser = do
+  tok <- lookAhead anySingle
+  case lexTokenKind tok of
+    TkVarId "by" -> MP.empty
+    TkVarId "using" -> MP.empty
+    _ -> atomExprParser
 
 compGenOrGuardParser :: TokParser CompStmt
 compGenOrGuardParser =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -947,6 +947,10 @@ addCompStmtParens stmt =
     CompGen pat e -> CompGen (addPatternParens pat) (addExprParens e)
     CompGuard e -> CompGuard (addExprParens e)
     CompLetDecls decls -> CompLetDecls (map addDeclParens decls)
+    CompThen f -> CompThen (addExprParens f)
+    CompThenBy f e -> CompThenBy (addExprParens f) (addExprParens e)
+    CompGroupUsing f -> CompGroupUsing (addExprParens f)
+    CompGroupByUsing e f -> CompGroupByUsing (addExprParens e) (addExprParens f)
 
 addArithSeqParens :: ArithSeq -> ArithSeq
 addArithSeqParens seqInfo =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1303,6 +1303,10 @@ prettyCompStmt stmt =
     CompGen pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     CompGuard expr -> prettyExpr expr
     CompLetDecls decls -> "let" <+> spacedBraces (prettyInlineDecls decls)
+    CompThen f -> "then" <+> prettyExpr f
+    CompThenBy f e -> "then" <+> prettyExpr f <+> "by" <+> prettyExpr e
+    CompGroupUsing f -> "then" <+> "group" <+> "using" <+> prettyExpr f
+    CompGroupByUsing e f -> "then" <+> "group" <+> "by" <+> prettyExpr e <+> "using" <+> prettyExpr f
 
 prettyInlineDecls :: [Decl] -> Doc ann
 prettyInlineDecls decls =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -828,6 +828,10 @@ docCompStmt stmt =
     CompGen pat expr -> "CompGen" <+> parens (docPattern pat) <+> parens (docExpr expr)
     CompGuard expr -> "CompGuard" <+> parens (docExpr expr)
     CompLetDecls decls -> "CompLetDecls" <+> brackets (hsep (punctuate comma (map docDecl decls)))
+    CompThen f -> "CompThen" <+> parens (docExpr f)
+    CompThenBy f e -> "CompThenBy" <+> parens (docExpr f) <+> parens (docExpr e)
+    CompGroupUsing f -> "CompGroupUsing" <+> parens (docExpr f)
+    CompGroupByUsing e f -> "CompGroupByUsing" <+> parens (docExpr e) <+> parens (docExpr f)
 
 docCmd :: Cmd -> Doc ann
 docCmd cmd =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1813,6 +1813,14 @@ data CompStmt
   | CompGen Pattern Expr
   | CompGuard Expr
   | CompLetDecls [Decl]
+  | -- | @then f@ (TransformListComp)
+    CompThen Expr
+  | -- | @then f by e@ (TransformListComp)
+    CompThenBy Expr Expr
+  | -- | @then group using f@ (TransformListComp)
+    CompGroupUsing Expr
+  | -- | @then group by e using f@ (TransformListComp)
+    CompGroupByUsing Expr Expr
   deriving (Data, Eq, Show, Generic, NFData)
 
 peelCompStmtAnn :: CompStmt -> CompStmt

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -149,6 +149,18 @@ pattern CompGuard_ e <- (peelCompStmtAnn -> CompGuard e)
 pattern CompLetDecls_ :: [Decl] -> CompStmt
 pattern CompLetDecls_ decls <- (peelCompStmtAnn -> CompLetDecls decls)
 
+pattern CompThen_ :: Expr -> CompStmt
+pattern CompThen_ f <- (peelCompStmtAnn -> CompThen f)
+
+pattern CompThenBy_ :: Expr -> Expr -> CompStmt
+pattern CompThenBy_ f e <- (peelCompStmtAnn -> CompThenBy f e)
+
+pattern CompGroupUsing_ :: Expr -> CompStmt
+pattern CompGroupUsing_ f <- (peelCompStmtAnn -> CompGroupUsing f)
+
+pattern CompGroupByUsing_ :: Expr -> Expr -> CompStmt
+pattern CompGroupByUsing_ e f <- (peelCompStmtAnn -> CompGroupByUsing e f)
+
 pattern GuardExpr_ :: Expr -> GuardQualifier
 pattern GuardExpr_ e <- (peelGuardQualifierAnn -> GuardExpr e)
 
@@ -358,6 +370,18 @@ buildTests = do
             testCase "comp as gen: [y | y@(Just _) <- xs]" test_compAsGen,
             testCase "comp infix gen: [a | a : as <- xs]" test_compInfixGen,
             testCase "comp nested prefix gen: [y | K !y ~(Just z) q@(Right _) ((negate -> n)) (-1) <- xs]" test_compNestedPrefixGen
+          ],
+        testGroup
+          "TransformListComp"
+          [ testCase "then f: [x | x <- xs, then take 5]" test_compThen,
+            testCase "then f (single arg): [x | x <- xs, then reverse]" test_compThenSingleArg,
+            testCase "then f by e: [x | x <- xs, then sortWith by x]" test_compThenBy,
+            testCase "then group by e using f" test_compGroupByUsing,
+            testCase "then group using f" test_compGroupUsing,
+            testCase "multiple transform stmts" test_compTransformMultiple,
+            testCase "transform with let" test_compTransformWithLet,
+            testCase "by/using as vars without ext" test_compByUsingAsVarsWithoutExt,
+            testCase "then f by (paren expr)" test_compThenByParenExpr
           ],
         testGroup
           "localDeclParser dispatch"
@@ -2389,6 +2413,63 @@ test_compInfixGen =
   case parseCompStmts "[a | a : as <- xs]" of
     Right [CompGen_ (PInfix_ (PVar_ "a") ":" (PVar_ "as")) _] -> pure ()
     other -> assertFailure ("expected comp infix gen, got: " <> show other)
+
+-- TransformListComp tests
+
+test_compThen :: Assertion
+test_compThen =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then take 5]" of
+    Right [CompGen_ _ _, CompThen_ _] -> pure ()
+    other -> assertFailure ("expected comp then, got: " <> show other)
+
+test_compThenSingleArg :: Assertion
+test_compThenSingleArg =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then reverse]" of
+    Right [CompGen_ _ _, CompThen_ (EVar_ "reverse")] -> pure ()
+    other -> assertFailure ("expected comp then reverse, got: " <> show other)
+
+test_compThenBy :: Assertion
+test_compThenBy =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then sortWith by x]" of
+    Right [CompGen_ _ _, CompThenBy_ _ _] -> pure ()
+    other -> assertFailure ("expected comp then-by, got: " <> show other)
+
+test_compGroupByUsing :: Assertion
+test_compGroupByUsing =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then group by x using groupWith]" of
+    Right [CompGen_ _ _, CompGroupByUsing_ _ _] -> pure ()
+    other -> assertFailure ("expected comp group-by-using, got: " <> show other)
+
+test_compGroupUsing :: Assertion
+test_compGroupUsing =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then group using inits]" of
+    Right [CompGen_ _ _, CompGroupUsing_ _] -> pure ()
+    other -> assertFailure ("expected comp group-using, got: " <> show other)
+
+test_compTransformMultiple :: Assertion
+test_compTransformMultiple =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then group by x using groupWith, then sortWith by x, then take 5]" of
+    Right [CompGen_ _ _, CompGroupByUsing_ _ _, CompThenBy_ _ _, CompThen_ _] -> pure ()
+    other -> assertFailure ("expected multiple transform stmts, got: " <> show other)
+
+test_compTransformWithLet :: Assertion
+test_compTransformWithLet =
+  case parseCompStmtsExt [TransformListComp] "[y | x <- xs, let { y = x }, then group by y using groupWith]" of
+    Right [CompGen_ _ _, CompLetDecls_ _, CompGroupByUsing_ _ _] -> pure ()
+    other -> assertFailure ("expected transform with let, got: " <> show other)
+
+test_compByUsingAsVarsWithoutExt :: Assertion
+test_compByUsingAsVarsWithoutExt =
+  -- Without TransformListComp, 'by' and 'using' should be parsed as regular variables
+  case parseCompStmts "[by | using <- xs]" of
+    Right [CompGen_ (PVar_ "using") _] -> pure ()
+    other -> assertFailure ("expected by/using as regular vars, got: " <> show other)
+
+test_compThenByParenExpr :: Assertion
+test_compThenByParenExpr =
+  case parseCompStmtsExt [TransformListComp] "[x | x <- xs, then sortWith by (sum salary)]" of
+    Right [CompGen_ _ _, CompThenBy_ _ _] -> pure ()
+    other -> assertFailure ("expected comp then-by with paren expr, got: " <> show other)
 
 -- Helper: parse a let-expression and extract the local declarations.
 -- Input: "let { decl1; decl2 } in body"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/dns-transform-list-comp.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/dns-transform-list-comp.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail TransformListComp syntax not supported -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TransformListComp #-}
 module A where
 import GHC.Exts (the, groupWith)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/group-after-guard.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/group-after-guard.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module GroupAfterGuard where
+import GHC.Exts (groupWith)
+f xs = [ x | x <- xs, x > 0, then group by x using groupWith ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/group-by-using.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/group-by-using.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module GroupByUsing where
+import GHC.Exts (the, groupWith)
+f xs = [ (the x, y) | x <- xs, y <- ys, then group by x using groupWith ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/group-using.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/group-using.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module GroupUsing where
+f xs = [ x | x <- xs, then group using inits ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/let-before-group.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/let-before-group.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module LetBeforeGroup where
+import GHC.Exts (the, groupWith)
+f xs = [ (the k, vs) | x <- xs, let k = fst x, let vs = snd x, then group by k using groupWith ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/multiple-transforms.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/multiple-transforms.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module MultipleTransforms where
+import GHC.Exts (the, groupWith, sortWith)
+output = [ (the dept, sum salary)
+         | (name, dept, salary) <- employees
+         , then group by dept using groupWith
+         , then sortWith by (sum salary)
+         , then take 5 ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-by-complex-expr.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-by-complex-expr.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenByComplexExpr where
+f xs = [ (x, y) | x <- xs, y <- ys, then sortWith by (x + y) ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-f-by-e.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-f-by-e.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenFByE where
+f xs = [ x | x <- xs, then sortWith by x ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-f-single.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-f-single.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenFSingle where
+f xs = [ x | x <- xs, then reverse ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-f.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-f.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenF where
+f xs = [ x | x <- xs, then take 5 ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-infix-expr.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-infix-expr.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenInfixExpr where
+f xs = [ x | x <- xs, then reverse . sort ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-paren-fn.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-paren-fn.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenParenFn where
+f xs = [ x | x <- xs, then (take 3) ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-qualified-fn.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TransformListComp/then-qualified-fn.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TransformListComp #-}
+module ThenQualifiedFn where
+f xs = [ x | x <- xs, then Data.List.sort ]

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -686,6 +686,10 @@ shrinkCompStmt stmt =
     CompGen pat expr -> [CompGen pat expr' | expr' <- shrinkExpr expr]
     CompGuard expr -> [CompGuard expr' | expr' <- shrinkExpr expr]
     CompLetDecls decls -> [CompLetDecls decls' | decls' <- shrinkDecls decls, not (null decls')]
+    CompThen f -> [CompThen f' | f' <- shrinkExpr f]
+    CompThenBy f e -> [CompThenBy f' e | f' <- shrinkExpr f] <> [CompThenBy f e' | e' <- shrinkExpr e]
+    CompGroupUsing f -> [CompGroupUsing f' | f' <- shrinkExpr f]
+    CompGroupByUsing e f -> [CompGroupByUsing e' f | e' <- shrinkExpr e] <> [CompGroupByUsing e f' | f' <- shrinkExpr f]
     CompAnn _ _ -> []
 
 shrinkTupleMaybeElems :: (a -> [a]) -> [a] -> [[a]]

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -310,6 +310,10 @@ normalizeCompStmtInner (CompAnn _ inner) = normalizeCompStmtInner inner
 normalizeCompStmtInner (CompGen pat e) = CompGen (normalizePattern pat) (normalizeExpr e)
 normalizeCompStmtInner (CompGuard e) = CompGuard (normalizeExpr e)
 normalizeCompStmtInner (CompLetDecls decls) = CompLetDecls (map normalizeDecl decls)
+normalizeCompStmtInner (CompThen f) = CompThen (normalizeExpr f)
+normalizeCompStmtInner (CompThenBy f e) = CompThenBy (normalizeExpr f) (normalizeExpr e)
+normalizeCompStmtInner (CompGroupUsing f) = CompGroupUsing (normalizeExpr f)
+normalizeCompStmtInner (CompGroupByUsing e f) = CompGroupByUsing (normalizeExpr e) (normalizeExpr f)
 
 normalizeArithSeq :: ArithSeq -> ArithSeq
 normalizeArithSeq seq' =


### PR DESCRIPTION
## Summary

Implement support for GHC's `TransformListComp` extension, which introduces SQL-like generalised list comprehension syntax. This resolves the `dns-transform-list-comp` oracle test failure (previously marked `xfail`).

**Progress: +1 pass, -1 xfail**

## Root Cause

The parser had no support for the four transform/group qualifier forms introduced by `TransformListComp`:
- `then f` — apply a list transformation function
- `then f by e` — apply a transformation with a projection
- `then group by e using f` — group elements by a key using a grouping function
- `then group using f` — group elements directly

## Solution

### AST Changes (`Syntax.hs`)
Four new constructors added to `CompStmt`:
- `CompThen Expr` — `then f`
- `CompThenBy Expr Expr` — `then f by e`
- `CompGroupUsing Expr` — `then group using f`
- `CompGroupByUsing Expr Expr` — `then group by e using f`

### Parser Changes (`Internal/Expr.hs`)
- `compStmtParser` now dispatches on `TkKeywordThen` when `TransformListComp` is enabled
- `compTransformStmtParser` handles all four forms, gated on the extension
- A restricted expression parser (`compTransformExprParser`) treats `by` and `using` as contextual keywords (expression terminators) within transform qualifiers
- `group`, `by`, and `using` remain valid variable names in all other contexts (no lexer changes needed)

### Design Decision: Restricted Expression Parser
The key challenge was preventing the expression parser from consuming `by` and `using` as regular variable identifiers inside transform qualifiers (e.g., in `then sortWith by x`, the parser must stop after `sortWith` and not consume `by` as an argument). Rather than making these words lexer-level keywords (which would break their use as variables elsewhere), the solution creates a restricted expression pipeline (`compTransformAtomExprParser`) that guards against consuming `by`/`using` at the atom level. This approach:
- Requires no lexer changes
- Preserves backward compatibility
- Matches GHC's context-sensitive keyword behavior

## Changes Made
- **`Syntax.hs`**: 4 new `CompStmt` constructors
- **`Internal/Expr.hs`**: Parser for all four transform forms + restricted expression parser
- **`Pretty.hs`**: Pretty printer cases for new constructors
- **`Shorthand.hs`**: Debug rendering for new constructors
- **`Parens.hs`**: Parenthesization for new constructors
- **`ExprHelpers.hs`**: Test normalization for new constructors
- **`Arb/Expr.hs`**: QuickCheck shrinker for new constructors
- **`Spec.hs`**: 9 unit tests + test infrastructure (pattern synonyms, test group)
- **`oracle/TransformListComp/`**: 12 oracle tests covering all forms and corner cases
- **`dns-transform-list-comp.hs`**: Flipped from `xfail` to `pass`

## Test Coverage
- **Unit tests** (9): All four forms, single-arg function, parenthesized expressions, multiple transforms, let-before-group, by/using as regular vars without extension
- **Oracle tests** (12): then-f, then-f-single, then-f-by-e, group-by-using, group-using, multiple-transforms, then-infix-expr, then-qualified-fn, then-paren-fn, then-by-complex-expr, group-after-guard, let-before-group
- **Hackage oracle** (1): dns-transform-list-comp (existing, now passing)