### PR TITLE
fix(parser): support parenthesized infix type family heads

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1208,7 +1208,9 @@ typeSynonymOperatorParser =
 
 typeFamilyHeadParser :: TokParser (TypeHeadForm, Type, [TyVarBinder])
 typeFamilyHeadParser =
-  MP.try infixHeadParser <|> prefixHeadParser
+  MP.try parenthesizedInfixHeadParser
+    <|> MP.try infixHeadParser
+    <|> prefixHeadParser
   where
     prefixHeadParser = do
       headType <- withSpan $ do
@@ -1230,6 +1232,21 @@ typeFamilyHeadParser =
       headType <- withSpan $ do
         pure $ \span' -> typeAnnSpan span' (TInfix lhsType op Unpromoted rhsType)
       pure (TypeHeadInfix, headType, [lhs, rhs])
+
+    parenthesizedInfixHeadParser = do
+      expectedTok TkSpecialLParen
+      lhs <- declTypeParamParser
+      op <- typeFamilyOperatorParser
+      rhs <- declTypeParamParser
+      expectedTok TkSpecialRParen
+      tailParams <- MP.many declTypeParamParser
+      let lhsType =
+            TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
+          rhsType =
+            TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs))
+      headType <- withSpan $ do
+        pure $ \span' -> typeAnnSpan span' (TInfix lhsType op Unpromoted rhsType)
+      pure (TypeHeadInfix, headType, [lhs, rhs] <> tailParams)
 
 -- | Parse an operator for type family declarations.
 -- Unlike 'constructorOperatorParser', this accepts both constructor symbols (@:+:@)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-paren-infix-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-paren-infix-type-family.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects parenthesised infix type family head -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 module GenericLensCoreParenInfixTypeFamily where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/paren-infix-type-family-backtick.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/paren-infix-type-family-backtick.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+
+module ParenInfixTypeFamilyBacktick where
+
+type family (a `And` b)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/paren-infix-type-family-with-result-sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/paren-infix-type-family-with-result-sig.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+
+module ParenInfixTypeFamilyWithResultSig where
+
+type family ((a :: [k]) ++ (b :: [k])) :: [k]


### PR DESCRIPTION
## Summary

- Add `parenthesizedInfixHeadParser` to `typeFamilyHeadParser`, fixing parsing of `type family (a ++ b)` and similar declarations
- Convert xfail fixture to passing test; add 2 edge case test fixtures

## Root Cause

`typeFamilyHeadParser` only supported two forms:
1. **Prefix:** `ConName params` or `(operator) params` (parenthesized operator *name*)
2. **Bare infix:** `param op param`

It lacked a **parenthesized infix** form `(param op param)` — a syntax variant GHC accepts where the entire infix application is wrapped in parentheses. Both `typeDeclHeadParser` and `classHeadParser` already had this alternative; `typeFamilyHeadParser` was the only head parser missing it.

When the parser encountered `(a ++ b)`, the prefix branch tried to match `(` as a parenthesized operator name `(++)`, failing when it found `a` (a variable) instead of an operator. The infix branch expected a bare type variable as LHS, failing on the `(` token. No branch could handle the parenthesized infix form.

## Solution

Added a `parenthesizedInfixHeadParser` alternative to `typeFamilyHeadParser`, following the established pattern from `typeDeclHeadParser` (line 1182) and `classHeadParser` (line 1284). The new parser:

1. Consumes `(`
2. Parses LHS binder via `declTypeParamParser`
3. Parses the operator via `typeFamilyOperatorParser` (supports both symbol and backtick operators)
4. Parses RHS binder via `declTypeParamParser`
5. Consumes `)`
6. Optionally parses trailing parameters

This generalizes beyond the specific test case to handle:
- Symbol operators: `type family (a ++ b)`
- Backtick operators: `type family (a \`And\` b)`
- Kinded parameters: `type family ((a :: [k]) ++ (b :: [k])) :: [k]`

## Changes

| File | Change |
|------|--------|
| `Decl.hs` | Add `parenthesizedInfixHeadParser` to `typeFamilyHeadParser` (+17 lines) |
| `generic-lens-core-paren-infix-type-family.hs` | Rename from `-xfail.hs`; change directive from `xfail` to `pass` |
| `paren-infix-type-family-backtick.hs` | New edge case: parenthesized backtick operator |
| `paren-infix-type-family-with-result-sig.hs` | New edge case: kinded params + result kind signature |

## Test Results

- `just check` passes (ormolu, hlint, full test suite — 1751 tests, 0 failures)
- All 3 parenthesized infix type family tests pass with oracle fingerprint match

## Progress

- xfail → pass: 1

## Follow-up

The three declaration head parsers (`typeDeclHeadParser`, `classHeadParser`, `typeFamilyHeadParser`) share significant structural overlap with their prefix/infix/parenthesized-infix alternatives. They could be unified into a parameterized generic head parser. Not included in this PR because the return types differ (`BinderHead UnqualifiedName` vs `(TypeHeadForm, Type, [TyVarBinder])`) and the refactoring would be larger in scope.