### PR TITLE
fix(parser): support parenthesised infix type family heads

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1208,7 +1208,9 @@ typeSynonymOperatorParser =
 
 typeFamilyHeadParser :: TokParser (TypeHeadForm, Type, [TyVarBinder])
 typeFamilyHeadParser =
-  MP.try infixHeadParser <|> prefixHeadParser
+  MP.try parenthesizedInfixHeadParser
+    <|> MP.try infixHeadParser
+    <|> prefixHeadParser
   where
     prefixHeadParser = do
       headType <- withSpan $ do
@@ -1230,6 +1232,23 @@ typeFamilyHeadParser =
       headType <- withSpan $ do
         pure $ \span' -> typeAnnSpan span' (TInfix lhsType op Unpromoted rhsType)
       pure (TypeHeadInfix, headType, [lhs, rhs])
+
+    -- \| Parse a parenthesised infix type family head: @(a ++ b)@ or @(a ++ b) c@.
+    -- Mirrors 'parenthesizedInfixDeclHeadParser' from 'classHeadParser'.
+    parenthesizedInfixHeadParser = do
+      expectedTok TkSpecialLParen
+      lhs <- declTypeParamParser
+      op <- typeFamilyOperatorParser
+      rhs <- declTypeParamParser
+      expectedTok TkSpecialRParen
+      tailParams <- MP.many declTypeParamParser
+      let lhsType =
+            TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
+          rhsType =
+            TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs))
+      headType <- withSpan $ do
+        pure $ \span' -> typeAnnSpan span' (TInfix lhsType op Unpromoted rhsType)
+      pure (TypeHeadInfix, headType, [lhs, rhs] <> tailParams)
 
 -- | Parse an operator for type family declarations.
 -- Unlike 'constructorOperatorParser', this accepts both constructor symbols (@:+:@)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1430,6 +1430,13 @@ prettyTypeFamilyHead headForm headType params =
             (if promoted == Promoted then "'" else mempty) <> prettyNameInfixOp op,
             prettyTyVarBinder rhs
           ]
+        (lhs : rhs : tailPrms, Just (op, promoted, _, _)) ->
+          let infixHead =
+                prettyTyVarBinder lhs
+                  <+> (if promoted == Promoted then "'" else mempty)
+                  <> prettyNameInfixOp op
+                  <+> prettyTyVarBinder rhs
+           in parens infixHead : map prettyTyVarBinder tailPrms
         _ -> [prettyTypeFamilyInfix headType]
 
 prettyTypeFamilyLhs :: TypeHeadForm -> Type -> [Doc ann]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-paren-infix-type-family.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-paren-infix-type-family.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail parser rejects parenthesised infix type family head -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 module GenericLensCoreParenInfixTypeFamily where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/paren-infix-type-family-result-sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/paren-infix-type-family-result-sig.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE KindSignatures #-}
+module ParenInfixTypeFamilyResultSig where
+
+import Data.Kind (Type)
+
+type family (a ++ b) :: Type

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/paren-infix-type-family-tail-params.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/paren-infix-type-family-tail-params.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module ParenInfixTypeFamilyTailParams where
+
+type family (a ++ b) c


### PR DESCRIPTION
## Summary

- Fix parser to accept parenthesised infix type family heads like `type family (a ++ b)`, resolving the `generic-lens-core-paren-infix-type-family` xfail
- Add pretty-printer support for infix type families with tail parameters, e.g. `type family (a ++ b) c`
- Add two new oracle test fixtures for edge cases (tail params, result signature)

## Progress

- Parser oracle: pass 988 → 990 (+2), xfail 5 → 4 (−1)

## Root Cause

`typeFamilyHeadParser` in `Decl.hs` had only two alternatives:

1. `infixHeadParser` — parses bare `a ++ b` (tries `declTypeParamParser` first, which fails on `(` when it's not `(a :: Kind)`)
2. `prefixHeadParser` — parses `F a b` or `(++) a b` (tries `constructorNameParser` or `parens operatorUnqualifiedNameParser`, both fail on `(a ++ b)`)

Neither branch could handle `(a ++ b)` where the entire infix expression is parenthesised. The equivalent `classHeadParser` already handled this case via `parenthesizedInfixDeclHeadParser`, but `typeFamilyHeadParser` lacked a corresponding branch.

## Solution

Added a `parenthesizedInfixHeadParser` branch to `typeFamilyHeadParser`, tried first (with backtracking). This mirrors the existing `parenthesizedInfixDeclHeadParser` pattern from `classHeadParser:1284-1291`:

1. Consume `(`
2. Parse `lhs op rhs` using `declTypeParamParser` and `typeFamilyOperatorParser`
3. Consume `)`
4. Parse optional tail parameters
5. Produce `TypeHeadInfix` with `TInfix` head, generalising to `(a ++ b) c` with tail params

Extended `prettyTypeFamilyHead` to parenthesise the infix portion when tail parameters are present (matching GHC's behaviour).

## Follow-up

`TypeFamilyDecl` uses a different head representation (`TypeHeadForm` + `Type` + `[TyVarBinder]`) compared to `DataFamilyDecl`/`ClassDecl`/etc. which use `BinderHead`. Unifying these would eliminate the duplicated parsing logic but is a larger architectural change best done separately.