### PR TITLE
fix(lexer): add DashPunctuation and ConnectorPunctuation to unicode symbol categories

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -430,5 +430,7 @@ isUnicodeSymbolCategory c =
     CurrencySymbol -> True
     ModifierSymbol -> not (isAscii c)
     OtherSymbol -> True
+    ConnectorPunctuation -> not (isAscii c)
+    DashPunctuation -> not (isAscii c)
     OtherPunctuation -> not (isAscii c)
     _ -> False

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -804,6 +804,8 @@ isUnicodeOperatorChar c =
     CurrencySymbol -> True
     ModifierSymbol -> True
     OtherSymbol -> True
+    ConnectorPunctuation -> c > '\x7f'
+    DashPunctuation -> c > '\x7f'
     OtherPunctuation -> c > '\x7f'
     _ -> False
 

--- a/components/aihc-parser/test/Test/Fixtures/lexer/symbols/unicode-em-dash-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/symbols/unicode-em-dash-operator.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "——"
+tokens:
+  - 'TkVarSym "——"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/symbols/unicode-en-dash-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/symbols/unicode-en-dash-operator.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "–"
+tokens:
+  - 'TkVarSym "–"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/symbols/unicode-undertie-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/symbols/unicode-undertie-operator.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "‿"
+tokens:
+  - 'TkVarSym "‿"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-unicode-operator-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-unicode-operator-xfail.hs
@@ -1,4 +1,0 @@
-{- ORACLE_TEST xfail lexer rejects unicode em-dash as operator character -}
-{-# LANGUAGE UnicodeSyntax #-}
-module A where
-(——) = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-unicode-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hmatrix-unicode-operator.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnicodeSyntax #-}
+module A where
+(——) = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-en-dash.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-en-dash.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module UnicodeOperatorEnDash where
+
+(–) :: Int -> Int -> Int
+(–) = (+)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-undertie.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-operator-undertie.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module UnicodeOperatorUndertie where
+
+(‿) :: Int -> Int -> Int
+(‿) = (+)

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -378,6 +378,8 @@ isValidUnicodeSymbolChar c =
     CurrencySymbol -> True
     ModifierSymbol -> True
     OtherSymbol -> True
+    ConnectorPunctuation -> c > '\x7f'
+    DashPunctuation -> c > '\x7f'
     OtherPunctuation -> c > '\x7f'
     _ -> False
 


### PR DESCRIPTION
## Summary

- Add `DashPunctuation` (Pd) and `ConnectorPunctuation` (Pc) unicode general categories to the lexer's symbol classification, matching GHC's `okSymChar` (from `GHC.Internal.Lexeme`)
- Promote `Hackage/hmatrix-unicode-operator` oracle test from xfail to pass
- Add edge case oracle and lexer fixtures for en-dash (Pd), em-dash (Pd), and undertie (Pc) operators

## Root Cause

The lexer's `isUnicodeSymbolCategory` function (in `Lex/Types.hs`) accepted five unicode general categories as valid symbol characters: `MathSymbol` (Sm), `CurrencySymbol` (Sc), `ModifierSymbol` (Sk), `OtherSymbol` (So), and `OtherPunctuation` (Po). However, GHC's `okSymChar` also accepts `DashPunctuation` (Pd) and `ConnectorPunctuation` (Pc). This caused characters like em-dash `—` (U+2014, Pd) and undertie `‿` (U+203F, Pc) to be rejected by aihc-parser as "unexpected character" while GHC accepts them as valid operator characters.

The same omission existed in two other parallel classification functions: `isUnicodeOperatorChar` in `Syntax.hs` (used by the pretty-printer) and `isValidUnicodeSymbolChar` in `Arb/Identifiers.hs` (used by QuickCheck test generators).

## Solution

Add `DashPunctuation -> not (isAscii c)` and `ConnectorPunctuation -> not (isAscii c)` to all three classification functions. The ASCII guards are necessary because:
- ASCII hyphen-minus `-` (U+002D) has category Pd but is already handled by the ASCII symbol set `":!#$%&*+./<=>?@\\^|-~"`
- ASCII underscore `_` (U+005F) has category Pc but is handled as an identifier character, not a symbol

This exactly mirrors GHC's behavior, which accepts all Pc/Pd characters in `okSymChar` and then separately excludes `_` from the special character set `(),;[]`{}_"'`.

## Changes

- `components/aihc-parser/src/Aihc/Parser/Lex/Types.hs`: Add Pd and Pc to `isUnicodeSymbolCategory`
- `components/aihc-parser/src/Aihc/Parser/Syntax.hs`: Add Pd and Pc to `isUnicodeOperatorChar`
- `components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs`: Add Pd and Pc to `isValidUnicodeSymbolChar`
- Rename `hmatrix-unicode-operator-xfail.hs` to `hmatrix-unicode-operator.hs` and promote to pass
- Add oracle test fixtures: `unicode-operator-en-dash.hs`, `unicode-operator-undertie.hs`
- Add lexer test fixtures: `unicode-em-dash-operator.yaml`, `unicode-en-dash-operator.yaml`, `unicode-undertie-operator.yaml`

## Progress

Oracle tests: 987 pass, 4 xfail (was 986 pass, 5 xfail)

## Follow-up

There is a pre-existing minor inconsistency in `Syntax.hs:isUnicodeOperatorChar` where `ModifierSymbol -> True` accepts all Sk characters including ASCII backtick (U+0060), while `Lex/Types.hs:isUnicodeSymbolCategory` correctly uses `ModifierSymbol -> not (isAscii c)`. This has no practical impact since backtick is parsed as a special token before reaching operator classification, but could be cleaned up in a separate PR for consistency.