### PR TITLE
fix(lexer): merge minus into negative MagicHash literals

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -363,7 +363,7 @@ lexImplicitParam env st
 
 lexNegativeLiteralOrMinus :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexNegativeLiteralOrMinus env st
-  | not hasNegExt = Nothing
+  | not hasNegExt && not hasMH = Nothing
   | not (isStandaloneMinus (lexerInput st)) = Nothing
   | otherwise =
       let prevAllows = allowsMergeOrPrefix (lexerPrevTokenKind st) (lexerHadTrivia st)
@@ -372,11 +372,29 @@ lexNegativeLiteralOrMinus env st
             then case tryLexNumberAfterMinus env st of
               Just result -> Just result
               Nothing -> lexMinusOperator env st rest prevAllows
-            else lexMinusOperator env st rest prevAllows
+            else
+              -- GHC merges minus into primitive unboxed literals (Int#, Word#,
+              -- Float#, Double#, and ExtendedLiterals types) even without
+              -- NegativeLiterals.  When only MagicHash is active, speculatively
+              -- lex the number after the minus and keep the merged token only
+              -- when the result carries a primitive suffix.
+              if hasMH && prevAllows
+                then case tryLexNumberAfterMinus env st of
+                  Just (tok, st')
+                    | isPrimitiveNumericToken (lexTokenKind tok) -> Just (tok, st')
+                  _ ->
+                    if hasNegExt
+                      then lexMinusOperator env st rest prevAllows
+                      else Nothing
+                else
+                  if hasNegExt
+                    then lexMinusOperator env st rest prevAllows
+                    else Nothing
   where
     hasNegExt =
       hasExt NegativeLiterals env
         || hasExt LexicalNegation env
+    hasMH = hasExt MagicHash env
 
 isStandaloneMinus :: Text -> Bool
 isStandaloneMinus input =
@@ -424,6 +442,17 @@ negateToken stBefore numTok =
               sourceSpanEndOffset = sourceSpanEndOffset
             }
         NoSourceSpan -> NoSourceSpan
+
+-- | Does the token kind represent a primitive (unboxed) numeric literal?
+-- These are MagicHash types (Int#, Word#, Float#, Double#) and ExtendedLiterals
+-- types (Int8#, Int16#, etc.).  Plain boxed types (TInteger, TFractional) return
+-- False.
+isPrimitiveNumericToken :: LexTokenKind -> Bool
+isPrimitiveNumericToken k =
+  case k of
+    TkInteger _ nt -> nt /= TInteger
+    TkFloat _ ft -> ft /= TFractional
+    _ -> False
 
 lexMinusOperator :: LexerEnv -> LexerState -> Text -> Bool -> Maybe (LexToken, LexerState)
 lexMinusOperator env st rest prevAllows

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -169,6 +169,25 @@ startsWithOverloadedLabel = \case
   ETypeApp fn _ -> startsWithOverloadedLabel fn
   _ -> False
 
+-- | Check whether an expression is a compound form (not a bare literal)
+-- whose pretty-printed output starts with a primitive (unboxed) numeric
+-- literal.  When such an expression appears under 'ENegate', the preceding
+-- @-@ merges with the literal at the lexer level, changing the parse.
+-- Bare literals (e.g., @EInt 42 TIntHash@) are excluded because
+-- @ENegate (EInt n hash)@ → @-n#@ is correctly normalised by the roundtrip
+-- test infrastructure.
+startsWithPrimitiveLiteral :: Expr -> Bool
+startsWithPrimitiveLiteral = go False
+  where
+    go _ (EAnn _ sub) = go False sub
+    go compound (EInt _ nt _) = compound && nt /= TInteger
+    go compound (EFloat _ ft _) = compound && ft /= TFractional
+    go _ (EApp fn _) = go True fn
+    go _ (ERecordUpd base _) = go True base
+    go _ (ETypeApp fn _) = go True fn
+    go _ (ETypeSig inner _) = go True inner
+    go _ _ = False
+
 -- ---------------------------------------------------------------------------
 -- Expression contexts
 -- ---------------------------------------------------------------------------
@@ -897,7 +916,7 @@ addSpliceBodyParens body =
 
 addNegateParens :: Expr -> Expr
 addNegateParens inner =
-  if startsWithDollar inner || startsWithOverloadedLabel inner
+  if startsWithDollar inner || startsWithOverloadedLabel inner || startsWithPrimitiveLiteral inner
     then wrapExpr True (addExprParens inner)
     else addExprParensPrec 3 inner
 

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-double.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-double.yaml
@@ -1,0 +1,7 @@
+extensions:
+  - MagicHash
+input: "-2.5##"
+tokens:
+  - 'TkFloat (-5 % 2) TDoubleHash'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-float.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-float.yaml
@@ -1,0 +1,7 @@
+extensions:
+  - MagicHash
+input: "-3.14#"
+tokens:
+  - 'TkFloat (-157 % 50) TFloatHash'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-int.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-int.yaml
@@ -1,0 +1,7 @@
+extensions:
+  - MagicHash
+input: "-1#"
+tokens:
+  - 'TkInteger (-1) TIntHash'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-no-merge-plain.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/negative-magic-hash-no-merge-plain.yaml
@@ -1,0 +1,8 @@
+extensions:
+  - MagicHash
+input: "-1"
+tokens:
+  - 'TkVarSym "-"'
+  - 'TkInteger 1 TInteger'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-expression.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-expression.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MagicHash #-}
+module A where
+
+import GHC.Exts
+
+-- Negative MagicHash literal in expression context.
+-- GHC treats -42# as a single literal token, not negation applied to 42#.
+x :: Int#
+x = -42#

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-multiple-patterns.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-multiple-patterns.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MagicHash #-}
+module A where
+
+import GHC.Exts
+
+-- Multiple negative MagicHash patterns in function equations.
+f :: Int# -> Int
+f  0#   = 0
+f -1#   = 1
+f -100# = 2
+f  _    = 3

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-pattern.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/happy-lib-negative-magic-hash-pattern.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail negative MagicHash literal in function equation pattern misparses as infix minus -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE MagicHash #-}
 module A where
 

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -36,7 +36,20 @@ normalizeExpr expr =
     EQuasiQuote quoter body -> EQuasiQuote quoter body
     EApp fn arg -> EApp (normalizeExpr fn) (normalizeExpr arg)
     EInfix lhs op rhs -> EInfix (normalizeExpr lhs) op (normalizeExpr rhs)
-    ENegate inner -> ENegate (normalizeExpr inner)
+    ENegate inner ->
+      let normInner = normalizeExpr inner
+          -- Strip parentheses added by the parenthesization pass around
+          -- primitive-literal-starting compound expressions.
+          stripped = case normInner of
+            EParen e -> e
+            _ -> normInner
+       in case stripped of
+            -- The lexer merges minus into primitive (MagicHash) numeric
+            -- literals, so ENegate around a numeric literal normalizes
+            -- to a single negative literal.
+            EInt n _ _ -> EInt (negate n) TInteger (T.pack (show (negate n)))
+            EFloat r _ _ -> EFloat (negate r) TFractional (renderFloat (negate r))
+            _ -> ENegate stripped
     ESectionL inner op -> ESectionL (normalizeExpr inner) op
     ESectionR op inner -> ESectionR op (normalizeExpr inner)
     EIf cond thenE elseE -> EIf (normalizeExpr cond) (normalizeExpr thenE) (normalizeExpr elseE)
@@ -68,6 +81,7 @@ normalizeExpr expr =
     ETHSplice body -> ETHSplice (normalizeExpr body)
     ETHTypedSplice body -> ETHTypedSplice (normalizeExpr body)
     EProc pat body -> EProc (normalizePattern pat) (normalizeCmd body)
+    EPragma pragma body -> EPragma pragma (normalizeExpr body)
     EAnn _ sub -> normalizeExpr sub
 
 normalizeCaseAlt :: CaseAlt -> CaseAlt


### PR DESCRIPTION
## Summary

Resolves the `happy-lib-negative-magic-hash-pattern-xfail` oracle test by fixing the lexer to merge minus signs into negative unboxed (MagicHash) literals, matching GHC's behavior.

**Progress: xfail -1, pass +1**

## Root Cause

When the lexer encountered `f -1# = 1` with only `MagicHash` enabled (no `NegativeLiterals`), it produced three separate tokens: `f`, `-`, `1#`. The parser's `functionHeadParserWithBinder` tried infix before prefix, so it parsed `f - 1#` as an infix function definition with operator `-`, instead of `f` applied to the negative literal pattern `-1#`.

GHC merges `-` into primitive unboxed literals (`Int#`, `Word#`, `Float#`, `Double#`, and `ExtendedLiterals` types) at the lexer level even without `NegativeLiterals`. This is correct because unboxed types have no `Num` instance, so overloaded `negate` is not applicable — the literal representation must include the sign.

## Solution

**Lexer-level merge for MagicHash literals** (chosen over parser-level alternatives):

In `lexNegativeLiteralOrMinus`, when `MagicHash` is enabled (even without `NegativeLiterals`), speculatively lex the number after the minus. If the resulting token carries a primitive suffix (`TIntHash`, `TWordHash`, `TFloatHash`, `TDoubleHash`, or `ExtendedLiterals` types), keep the merge. Plain boxed types (`TInteger`, `TFractional`) are left unmerged.

This approach:
- Matches GHC's semantics exactly
- Generalizes correctly across all contexts (patterns, expressions, guards)
- Requires no parser changes — the token stream naturally carries the right information
- Respects existing context sensitivity (no merge for tight `x-1#`)

## Changes

- **`Lex.hs`**: Extended `lexNegativeLiteralOrMinus` to also activate when `MagicHash` is enabled. Added `isPrimitiveNumericToken` helper to distinguish boxed from unboxed numeric token kinds.
- **`Parens.hs`**: Added `startsWithPrimitiveLiteral` to detect compound expressions whose textual form begins with a primitive numeric literal. `addNegateParens` now wraps these in parens to prevent the lexer from spuriously merging `-` with the literal in `ENegate(ERecordUpd(EInt 947 TIntHash) [])` → `-(947# {})`.
- **`ExprHelpers.hs`**: Normalize `ENegate(EInt/EFloat)` to a single negative literal in roundtrip tests, since the lexer now merges these. Also added the missing `EPragma` case to fix a pre-existing `-Wincomplete-patterns` warning under `-Werror`.
- **Oracle fixture**: Renamed `happy-lib-negative-magic-hash-pattern-xfail.hs` → `happy-lib-negative-magic-hash-pattern.hs`, changed header from `xfail` to `pass`.
- **New test fixtures**: 4 lexer golden tests (`negative-magic-hash-int`, `negative-magic-hash-float`, `negative-magic-hash-double`, `negative-magic-hash-no-merge-plain`) and 2 oracle tests (`happy-lib-negative-magic-hash-expression`, `happy-lib-negative-magic-hash-multiple-patterns`).

## Testing

- All 1,624 tests pass including 1,000 QuickCheck property tests per roundtrip suite
- Verified with 10,000 QuickCheck tests: all pass
- `just check` passes (ormolu + hlint + full test suite)