### PR TITLE
fix(parser): remove unnecessary parenthesization of ENegate in infix RHS

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -210,7 +210,12 @@ needsExprParens ctx expr =
       case expr of
         EInfix {} -> True
         ETypeSig {} -> True
-        ENegate {} -> True
+        -- ENegate does NOT need parenthesization in infix RHS position.
+        -- GHC already rejects `x + - 1` (precedence >= 6) at parse time,
+        -- so any ENegate appearing as the RHS of an infix operator in a
+        -- successfully parsed module is guaranteed to be valid without
+        -- parentheses. Wrapping in EParen would introduce a spurious HsPar
+        -- in the GHC AST, causing roundtrip fingerprint mismatches.
         _ | protectOpenEnded && isOpenEnded expr -> True
         _ -> False
     CtxInfixLhs ->

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-negative-literal-spacing.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/aftovolio-negative-literal-spacing.hs
@@ -1,3 +1,3 @@
-{- ORACLE_TEST xfail pretty-printer parenthesizes spaced negative literal causing roundtrip mismatch -}
+{- ORACLE_TEST pass -}
 module A where
 f x = x == - 1


### PR DESCRIPTION
## Summary

- Remove unnecessary `EParen` wrapping of `ENegate` in infix RHS position, fixing a roundtrip fingerprint mismatch
- Promote `aftovolio-negative-literal-spacing` oracle test from xfail to pass

## Root Cause

When `ENegate` appeared as the RHS of an infix operator (e.g., `x == - 1`), `needsExprParens (CtxInfixRhs _) (ENegate {})` returned `True`, unconditionally wrapping it in `EParen`. This produced `x == (-1)` on roundtrip.

GHC parses the original `x == - 1` as `OpApp ... (NegApp ...)` (no `HsPar`), but the roundtripped `x == (-1)` as `OpApp ... (HsPar (NegApp ...))` (with `HsPar`). The GHC AST fingerprints differ, causing the oracle test to fail.

## Solution

**Remove `ENegate` from `needsExprParens` for `CtxInfixRhs`.**

GHC already rejects bare prefix negation when the surrounding operator has precedence ≥ 6 (e.g., `x + - 1` is a parse error). Therefore, any `ENegate` appearing as the RHS of an infix operator in successfully parsed source is guaranteed valid without parentheses. The parenthesization was always unnecessary for valid Haskell source and actively harmful for roundtrip fidelity.

### Alternatives considered

1. **Add space in pretty-printer** (`"-" <+> prettyExpr inner` instead of `"-" <> prettyExpr inner`): Doesn't fix the core issue since `EParen` is still added, and `HsPar` still appears in the GHC AST.
2. **Make parenthesization conditional on operator precedence**: The parser doesn't track operator fixity, making this infeasible without significant architectural changes.

## Changes

| File | Change |
|------|--------|
| `Parens.hs:209-220` | Remove `ENegate {}` from `CtxInfixRhs` case in `needsExprParens`; add explanatory comment |
| `aftovolio-negative-literal-spacing.hs` | Promote from `xfail` to `pass` |

## Testing

- All 1631 tests pass (oracle, golden, QuickCheck properties)
- QuickCheck properties verified with 5000 iterations
- `just check` passes (ormolu + hlint + full test suite)

Progress: xfail 2 → 1