### PR TITLE
feat(parser): support non-standard GHC-prim constructs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -586,7 +586,7 @@ fixityPrecedenceParser =
   tokenSatisfy "fixity precedence" $ \tok ->
     case lexTokenKind tok of
       TkInteger n _
-        | n >= 0 && n <= 9 -> Just (fromInteger n)
+        | n <= 9 -> Just (fromInteger n)
       _ -> Nothing
 
 fixityOperatorParser :: TokParser UnqualifiedName
@@ -598,6 +598,8 @@ fixityOperatorParser =
         case lexTokenKind tok of
           TkVarSym op -> Just (mkUnqualifiedName NameVarSym op)
           TkConSym op -> Just (mkUnqualifiedName NameConSym op)
+          TkReservedColon -> Just (mkUnqualifiedName NameConSym ":")
+          TkReservedRightArrow -> Just (mkUnqualifiedName NameVarSym "->")
           _ -> Nothing
     backtickIdentifierParser = do
       expectedTok TkSpecialBacktick
@@ -820,6 +822,7 @@ callConvParser =
   (varIdTok "ccall" >> pure CCall)
     <|> (varIdTok "stdcall" >> pure StdCall)
     <|> (varIdTok "capi" >> pure CApi)
+    <|> (varIdTok "prim" >> pure CPrim)
 
 foreignSafetyParser :: TokParser ForeignSafety
 foreignSafetyParser =
@@ -979,7 +982,70 @@ gadtTypeDataBodyParser = do
 dataConDeclParser :: TokParser DataConDecl
 dataConDeclParser = withSpan $ do
   (forallVars, context) <- dataConQualifiersParser
-  MP.try (dataConRecordOrPrefixParser forallVars context) <|> dataConInfixParser forallVars context
+  MP.try (boxedTupleConDeclParser forallVars context)
+    <|> MP.try (unboxedConDeclParser forallVars context)
+    <|> MP.try (listConDeclParser forallVars context)
+    <|> MP.try (dataConRecordOrPrefixParser forallVars context)
+    <|> dataConInfixParser forallVars context
+
+listConDeclParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+listConDeclParser forallVars context = do
+  expectedTok TkSpecialLBracket
+  expectedTok TkSpecialRBracket
+  pure $ \span' -> DataConAnn (mkAnnotation span') (ListCon forallVars context)
+
+boxedTupleConDeclParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+boxedTupleConDeclParser forallVars context = do
+  expectedTok TkSpecialLParen
+  mClose <- MP.optional (expectedTok TkSpecialRParen)
+  case mClose of
+    Just () ->
+      pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Boxed [])
+    Nothing -> do
+      firstField <- constructorArgParser
+      mComma <- MP.optional (expectedTok TkSpecialComma)
+      case mComma of
+        Nothing -> do
+          expectedTok TkSpecialRParen
+          pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Boxed [firstField])
+        Just () -> do
+          rest <- constructorArgParser `MP.sepBy1` expectedTok TkSpecialComma
+          expectedTok TkSpecialRParen
+          pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Boxed (firstField : rest))
+
+unboxedConDeclParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+unboxedConDeclParser forallVars context = do
+  expectedTok TkSpecialUnboxedLParen
+  mClose <- MP.optional (expectedTok TkSpecialUnboxedRParen)
+  case mClose of
+    Just () ->
+      pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Unboxed [])
+    Nothing -> do
+      leadingPipes <- MP.many (MP.try (expectedTok TkReservedPipe))
+      if not (null leadingPipes)
+        then do
+          field <- constructorArgParser
+          trailingPipes <- MP.many (expectedTok TkReservedPipe)
+          expectedTok TkSpecialUnboxedRParen
+          let pos = length leadingPipes + 1
+              arity = length leadingPipes + 1 + length trailingPipes
+          pure $ \span' -> DataConAnn (mkAnnotation span') (UnboxedSumCon forallVars context pos arity field)
+        else do
+          firstField <- constructorArgParser
+          mSep <- MP.optional (MP.try ((Left () <$ expectedTok TkSpecialComma) <|> (Right () <$ expectedTok TkReservedPipe)))
+          case mSep of
+            Nothing -> do
+              expectedTok TkSpecialUnboxedRParen
+              pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Unboxed [firstField])
+            Just (Left ()) -> do
+              rest <- constructorArgParser `MP.sepBy1` expectedTok TkSpecialComma
+              expectedTok TkSpecialUnboxedRParen
+              pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Unboxed (firstField : rest))
+            Just (Right ()) -> do
+              trailingPipes <- MP.many (expectedTok TkReservedPipe)
+              expectedTok TkSpecialUnboxedRParen
+              let arity = 1 + 1 + length trailingPipes
+              pure $ \span' -> DataConAnn (mkAnnotation span') (UnboxedSumCon forallVars context 1 arity firstField)
 
 newtypeDeclParser :: TokParser Decl
 newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -513,6 +513,12 @@ addDataConDeclParens con =
       RecordCon forallVars (addContextConstraints constraints) name (map addRecordFieldDeclParens fields)
     GadtCon forallBinders constraints names body ->
       GadtCon forallBinders (addContextConstraints constraints) names (addGadtBodyParens body)
+    TupleCon forallVars constraints flavor fields ->
+      TupleCon forallVars (addContextConstraints constraints) flavor (map addPrefixConBangTypeParens fields)
+    UnboxedSumCon forallVars constraints pos arity field ->
+      UnboxedSumCon forallVars (addContextConstraints constraints) pos arity (addPrefixConBangTypeParens field)
+    ListCon forallVars constraints ->
+      ListCon forallVars (addContextConstraints constraints)
 
 addBangTypeParens :: BangType -> BangType
 addBangTypeParens bt =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -671,6 +671,19 @@ prettyDataCon ctor =
           | otherwise = pretty fieldName
     GadtCon foralls constraints names body ->
       prettyGadtCon foralls constraints names body
+    TupleCon forallVars constraints Boxed fields ->
+      hsep (dataConQualifierPrefix forallVars constraints)
+        <+> parens (hsep (punctuate comma (map prettyBangType fields)))
+    TupleCon forallVars constraints Unboxed fields ->
+      hsep (dataConQualifierPrefix forallVars constraints)
+        <+> "(#" <+> hsep (punctuate comma (map prettyBangType fields)) <+> "#)"
+    UnboxedSumCon forallVars constraints pos arity field ->
+      hsep (dataConQualifierPrefix forallVars constraints)
+        <+> "(#"
+        <+> hsep (replicate (pos - 1) "|" <> [prettyBangType field] <> replicate (arity - pos) "|")
+        <+> "#)"
+    ListCon forallVars constraints ->
+      hsep (dataConQualifierPrefix forallVars constraints <> ["[]"])
 
 prettyGadtCon :: [ForallTelescope] -> [Type] -> [UnqualifiedName] -> GadtBody -> Doc ann
 prettyGadtCon forallBinders constraints names body =
@@ -921,6 +934,7 @@ prettyCallConv cc =
     CCall -> "ccall"
     StdCall -> "stdcall"
     CApi -> "capi"
+    CPrim -> "prim"
 
 prettySafety :: ForeignSafety -> Doc ann
 prettySafety safety =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -676,7 +676,9 @@ prettyDataCon ctor =
         <+> parens (hsep (punctuate comma (map prettyBangType fields)))
     TupleCon forallVars constraints Unboxed fields ->
       hsep (dataConQualifierPrefix forallVars constraints)
-        <+> "(#" <+> hsep (punctuate comma (map prettyBangType fields)) <+> "#)"
+        <+> "(#"
+        <+> hsep (punctuate comma (map prettyBangType fields))
+        <+> "#)"
     UnboxedSumCon forallVars constraints pos arity field ->
       hsep (dataConQualifierPrefix forallVars constraints)
         <+> "(#"

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -368,6 +368,12 @@ docDataConDecl dcd =
       "RecordCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> listField "fields" docFieldDecl fields')))
     GadtCon forallBinders constraints names body ->
       "GadtCon" <+> braces (hsep (punctuate comma (listField "names" docUnqualifiedName names <> listField "forallBinders" docForallTelescope forallBinders <> listField "constraints" docType constraints <> [field "body" (docGadtBody body)])))
+    TupleCon forallVars constraints flavor fields' ->
+      "TupleCon" <+> braces (hsep (punctuate comma (listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> [field "flavor" (pretty (show flavor))] <> listField "fields" docBangType fields')))
+    UnboxedSumCon forallVars constraints pos arity field' ->
+      "UnboxedSumCon" <+> braces (hsep (punctuate comma (listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> [field "pos" (pretty (show pos)), field "arity" (pretty (show arity)), field "field" (docBangType field')])))
+    ListCon forallVars constraints ->
+      "ListCon" <+> braces (hsep (punctuate comma (listField "forallVars" docText forallVars <> listField "constraints" docType constraints)))
 
 -- | Document a GADT body
 docGadtBody :: GadtBody -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1444,6 +1444,13 @@ data DataConDecl
   | -- | GADT-style constructor: @Con :: forall a. Ctx => Type@
     -- The list of names supports multiple constructors: @T1, T2 :: Type@
     GadtCon [ForallTelescope] [Type] [UnqualifiedName] GadtBody
+  | -- | Tuple-style constructor: @()@, @(a,b)@, @(# #)@, @(# a,b #)@
+    TupleCon [Text] [Type] TupleFlavor [BangType]
+  | -- | Unboxed sum constructor: @(# a | #)@, @(# | b #)@
+    -- Fields: forall vars, context, position (1-based), total arity, field type
+    UnboxedSumCon [Text] [Type] Int Int BangType
+  | -- | List constructor: @[]@
+    ListCon [Text] [Type]
   deriving (Data, Eq, Show, Generic, NFData)
 
 -- | Strip nested 'DataConAnn' wrappers.
@@ -1636,6 +1643,7 @@ data CallConv
   = CCall
   | StdCall
   | CApi
+  | CPrim
   deriving (Data, Eq, Show, Generic, NFData)
 
 data ForeignSafety

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/foreign-import-prim.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/foreign-import-prim.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHCForeignImportPrim #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+module ForeignImportPrim where
+
+import GHC.Exts (Addr#, State#, RealWorld)
+
+foreign import prim "stg_myPrimOp" myPrimOp# :: Addr# -> State# RealWorld -> (# State# RealWorld, Int# #)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/list-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/list-constructor.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module ListConstructor where
+
+data List a = [] | a : List a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/negative-fixity.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/negative-fixity.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE NegativeLiterals #-}
+module NegativeFixity where
+
+infixr -1 ->

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/reserved-op-fixity.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/reserved-op-fixity.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module ReservedOpFixity where
+
+infixr 5 :
+infix 4 ~

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/tuple-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/tuple-constructor.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+module TupleConstructor where
+
+data Unit = ()
+
+data Tuple2 a b = (a, b)
+
+data Tuple3 a b c = (a, b, c)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/unboxed-sum-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/unboxed-sum-constructor.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedSums #-}
+module UnboxedSumConstructor where
+
+data Sum2# a b
+  = (# a | #)
+  | (# | b #)
+
+data Sum3# a b c
+  = (# a | | #)
+  | (# | b | #)
+  | (# | | c #)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/unboxed-tuple-constructor.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/GHCPrimSpecific/unboxed-tuple-constructor.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+module UnboxedTupleConstructor where
+
+data Unit# = (# #)
+
+data Tuple2# a b = (# a, b #)
+
+data Tuple3# a b c = (# a, b, c #)


### PR DESCRIPTION
## Summary

Adds parsing support for non-standard Haskell constructs found in the `ghc-prim` library, enabling `cabal run exe:hackage-tester -v0 -- ghc-prim` to pass with 0 parse errors.

**New `DataConDecl` variants:**
- `TupleCon` — tuple-style constructors: `()`, `(a,b)`, `(# #)`, `(# a,b #)`
- `UnboxedSumCon` — unboxed sum constructors: `(# a | #)`, `(# | b #)`, `(# a | | | #)`
- `ListCon` — list constructor: `[]`

**New `CallConv` variant:** `CPrim` for `foreign import prim`

**Parser relaxations (always-on, no extension required):**
- `fixityPrecedenceParser`: accept negative precedences (e.g. `infixr -1 ->`)
- `fixityOperatorParser`: accept reserved operators `:` and `->` as fixity names
- `callConvParser`: accept `prim` calling convention
- `dataConDeclParser`: try `boxedTupleConDeclParser`, `unboxedConDeclParser`, and `listConDeclParser` before existing alternatives

**Pretty, Parens, Shorthand** updated to handle all new variants.

## Test plan

- [ ] 7 new oracle tests in `GHCPrimSpecific/` cover each new construct
- [ ] Full test suite passes: 1641 tests (up from 1634)
- [ ] `cabal run exe:hackage-tester -v0 -- ghc-prim`: 0 parse errors, 0 GHC errors