### PR TITLE
test(oracle): add minimal xfail cases for containers, hledger-lib, dhall

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/NonEmptyPattern/associativity.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NonEmptyPattern/associativity.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail NonEmpty pattern associativity mismatch -}
+{-# LANGUAGE GHC2021 #-}
+module NonEmptyPattern where
+
+import Data.List.NonEmpty (NonEmpty(..))
+
+f (x :| y : ys) = undefined
+f _ = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TuplePatterns/list-comp.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TuplePatterns/list-comp.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail tuple constructor pattern in list comprehension generator -}
+{-# LANGUAGE GHC2021 #-}
+module TuplePatterns where
+
+f = [(,) x () | (,) x () <- []]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeSignatureGuards/where-clause.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeSignatureGuards/where-clause.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail type signature followed by guards in where clause -}
+{-# LANGUAGE GHC2021 #-}
+module TypeSignatureGuards where
+
+f = y
+  where
+    y :: Int
+      | True = 1


### PR DESCRIPTION
## Summary

Add minimal xfail oracle test cases for three failing Hackage packages:

### containers
- `TuplePatterns/list-comp.hs`: Tuple constructor pattern in list comprehension generator causes `unexpected tuple section in pattern`

### hledger-lib
- `TypeSignatureGuards/where-clause.hs`: Type signature followed by guards inside a `where` clause causes `unexpected | expecting end of input`

### dhall
- `NonEmptyPattern/associativity.hs`: NonEmpty pattern associativity (`x :| y : ys`) causes a roundtrip mismatch because aihc-parser groups it differently than GHC

All cases are reduced to the smallest snippet that still reproduces the failure while being accepted by GHC.