### PR TITLE
test(oracle): xfail for pattern-synonym where clause with infix sub-pattern

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-pattern-synonym-where-infix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-pattern-synonym-where-infix.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail pattern synonym where clause with parenthesized infix sub-pattern on LHS -}
+{-# LANGUAGE PatternSynonyms #-}
+module A where
+
+data T a = a :<| a
+
+pattern x :> y <- x :<| y
+  where
+    (a :<| b) :> c = a :<| (b :<| c)


### PR DESCRIPTION
## Summary

Adds an xfail oracle test case for the pattern-synonym `where` clause parse gap found in `nonempty-containers`.

### nonempty-containers

The package defines a bidirectional pattern synonym with a `where` clause that uses parenthesized infix sub-patterns on the LHS of equations:

```haskell
pattern xs :||> x <- (unsnoc -> (!xs, x))
  where
    (x :<| xs) :||> y = x :<|| (xs :|> y)
    Empty :||> y      = y :<|| Empty
```

aihc-parser rejects `(x :<| xs) :||> y` because it does not expect an infix pattern constructor after a parenthesized infix pattern on the LHS of a pattern-synonym equation. GHC accepts this syntax.

The minimized fixture reproduces the same parse shape with a tiny standalone module.

### happy-lib and thyme

After investigation, these packages do **not** have aihc-parser parse failures. Their hackage-tester failures are CPP preprocessing issues:

- **happy-lib**: The generated parser files contain `#if !defined(__GLASGOW_HASKELL__)` / `#error ...`. aihc-cpp does not pre-define `__GLASGOW_HASKELL__`, so the `#error` branch is taken and GHC never sees valid source.
- **thyme**: The `LENS` macro uses `/**/` as a token-paste operator (cpphs behavior). aihc-cpp replaces `/**/` with a space, producing `_ F` instead of `_F`, which GHC rejects.

When both packages are preprocessed with the correct tools (GHC cpp / cpphs), aihc-parser parses the resulting source successfully with no roundtrip mismatches.