### PR TITLE
test: add xfail oracle fixtures for linear-base and BNFC packages

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/multiway-if-infix-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/multiway-if-infix-roundtrip.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail roundtrip mismatch: aihc-parser over-parenthesizes MultiWayIf in infix context -}
+{-# LANGUAGE MultiWayIf #-}
+module MultiWayIfInfixRoundtrip where
+
+f = x ++
+  if | True -> ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-do-bind.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-do-bind.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail aihc-parser does not support QualifiedDo bind syntax -}
+{-# LANGUAGE QualifiedDo #-}
+module QualifiedDoBind where
+
+f = M.do
+  x <- action
+  return x


### PR DESCRIPTION
test: add xfail oracle fixtures for linear-base and BNFC packages

## Summary

Add minimal xfail oracle test cases derived from Hackage package testing.

### linear-base — QualifiedDo parse failure

`aihc-parser` does not support `QualifiedDo` syntax. When a module uses `M.do` followed by a bind statement (`x <- action`), the parser treats `M.do` as a regular function application rather than a qualified do-block introducer, causing `<-` to be rejected.

Fixture: `components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-do-bind.hs`

### BNFC — MultiWayIf roundtrip mismatch

`aihc-parser` parses `MultiWayIf` correctly but its pretty-printer over-parenthesizes the expression when it appears as the right-hand side of an infix operator. GHC's pretty-printer does not add parentheses in this context, causing a fingerprint mismatch on roundtrip.

Fixture: `components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/multiway-if-infix-roundtrip.hs`

### alex

No parser gap was found. The only hackage-tester failure was a GHC error on `src/Parser.hs` caused by missing CPP includes (`MachDeps.h`), which is a build-environment issue rather than a parser gap.

## Progress

- oracle xfail: +2
