### PR TITLE
fix(parser): treat MultiWayIf as braced expression in parenthesization

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -120,6 +120,7 @@ isBracedExpr :: Expr -> Bool
 isBracedExpr = \case
   EAnn _ sub -> isBracedExpr sub
   ECase {} -> True
+  EMultiWayIf {} -> True
   EDo {} -> True
   ELambdaCase {} -> True
   ELambdaCases {} -> True
@@ -248,6 +249,7 @@ exprCtxPrec ctx expr =
   case ctx of
     CtxInfixRhs _
       | isGreedyExpr expr -> 0
+      | isBracedExpr expr -> 0
       | otherwise -> 1
     CtxInfixLhs
       | isBracedExpr expr -> 0

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/multiway-if-infix-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/multiway-if-infix-roundtrip.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail roundtrip mismatch: aihc-parser over-parenthesizes MultiWayIf in infix context -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE MultiWayIf #-}
 module MultiWayIfInfixRoundtrip where
 


### PR DESCRIPTION
## Summary

- **Root Cause:** `EMultiWayIf` was missing from `isBracedExpr` in `Parens.hs`, causing over-parenthesization when MultiWayIf appeared in infix context (e.g., `x ++ if | c -> e`). Additionally, `exprCtxPrec` for `CtxInfixRhs` did not check `isBracedExpr`, so braced expressions on the RHS of infix operators were unnecessarily wrapped.
- **Fix:** Added `EMultiWayIf {} -> True` to `isBracedExpr` and extended `exprCtxPrec CtxInfixRhs` to return `0` for braced expressions.
- **Result:** The xfail test `multiway-if-infix-roundtrip` now passes. All 1650 parser tests pass.

## Changes

| File | Change |
|------|--------|
| `components/aihc-parser/src/Aihc/Parser/Parens.hs` | Add `EMultiWayIf` to `isBracedExpr`; check `isBracedExpr` in `exprCtxPrec CtxInfixRhs` |
| `test/Test/Fixtures/oracle/MultiWayIf/multiway-if-infix-roundtrip.hs` | Update from `xfail` to `pass` |

## Before/After

**Before:** `f = x ++ (if { \| True -> () })` (over-parenthesized)
**After:** `f = x ++ if { \| True -> () }` (correct)