### PR TITLE
fix(parser): accept promoted string type applications in patterns

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -61,6 +61,9 @@ dsDataConPure (InfixCon _docs _ctx _lhs conName _rhs) =
 dsDataConPure (RecordCon _docs _ctx conName _fields) =
   (unqualifiedNameText conName, 0)
 dsDataConPure (GadtCon {}) = ("<gadt>", 0)
+dsDataConPure (TupleCon _docs _ctx _flavor args) = ("<tuple>", length args)
+dsDataConPure (UnboxedSumCon _docs _ctx _pos _arity _field) = ("<unboxed-sum>", 1)
+dsDataConPure (ListCon _docs _ctx) = ("[]", 0)
 
 -- | Convert a Name to Text.
 nameToText :: Name -> Text

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -539,10 +539,12 @@ lexTypeApplication env st
       case t of
         c :< _
           | isIdentStart c -> True
+          | isDigit c -> True
           | c == '(' -> True
           | c == '[' -> True
           | c == '_' -> True
           | c == '\'' -> True
+          | c == '"' -> True
         _ -> False
 
 lexOverloadedLabel :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -313,7 +313,9 @@ buildTests = do
             testCase "parses function head type binders" test_functionHeadTypeBinderParses,
             testCase "parses invisible type declaration binders" test_invisibleTypeDeclBinderParses,
             testCase "parses invisible type applications in type synonym rhs" test_typeSynonymRhsInvisibleTypeAppParses,
+            testCase "parses expression type applications with string literals" test_exprStringTypeApplicationParses,
             testCase "parses constructor patterns with type arguments" test_constructorPatternWithTypeArgParses,
+            testCase "parses constructor patterns with string type arguments" test_constructorPatternWithStringTypeArgParses,
             testCase "parses infix type family equations with application operands" test_infixTypeFamilyEquationWithApplicationOperands,
             localOption (QC.QuickCheckTests 2000) $
               QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
@@ -1047,6 +1049,15 @@ test_typeSynonymRhsInvisibleTypeAppParses =
           pure ()
     other -> assertFailure ("expected invisible type application in type synonym rhs, got: " <> show other)
 
+test_exprStringTypeApplicationParses :: Assertion
+test_exprStringTypeApplicationParses =
+  case parseExpr defaultConfig {parserExtensions = [TypeApplications, DataKinds]} "id @\"xs\" ()" of
+    ParseOk parsed
+      | EApp (ETypeApp (EVar "id") typeArg) (ETuple Boxed []) <- normalizeExpr parsed,
+        TTypeLit (TypeLitSymbol "xs" "\"xs\"") <- stripTypeAnnotations typeArg ->
+          pure ()
+    other -> assertFailure ("expected expression string type application, got: " <> show other)
+
 test_constructorPatternWithTypeArgParses :: Assertion
 test_constructorPatternWithTypeArgParses =
   case parseDecl defaultConfig {parserExtensions = [TypeApplications, TypeAbstractions]} "f (Just @Int x) = x" of
@@ -1060,6 +1071,21 @@ test_constructorPatternWithTypeArgParses =
             [PVar_ "x"] <- args ->
               pure ()
         other -> assertFailure ("expected constructor pattern with type arg, got: " <> show other)
+    other -> assertFailure ("expected parse success, got: " <> show other)
+
+test_constructorPatternWithStringTypeArgParses :: Assertion
+test_constructorPatternWithStringTypeArgParses =
+  case parseDecl defaultConfig {parserExtensions = [TypeApplications, TypeAbstractions, DataKinds]} "f (Forall @\"xs\" x) = x" of
+    ParseOk parsed ->
+      case normalizeDecl parsed of
+        DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [outerPat], matchRhs = UnguardedRhs _ (EVar_ "x") _}])
+          | PCon con typeArgs args <- peelPatternAnn outerPat,
+            nameText con == "Forall",
+            [typeArg] <- typeArgs,
+            TTypeLit (TypeLitSymbol "xs" "\"xs\"") <- stripTypeAnnotations typeArg,
+            [PVar_ "x"] <- args ->
+              pure ()
+        other -> assertFailure ("expected constructor pattern with string type arg, got: " <> show other)
     other -> assertFailure ("expected parse success, got: " <> show other)
 
 test_parserConfigSetsSourceName :: Assertion

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-promoted-string-type-app-pattern-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-promoted-string-type-app-pattern-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail promoted string literal in pattern type application not supported -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeAbstractions #-}
 {-# LANGUAGE DataKinds #-}

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -503,6 +503,12 @@ resolveDataConDecl scope dataConDecl =
       RecordCon forallVars (map (resolveType scope) context) name (map resolveFieldDecl fields)
     GadtCon forallVars context names body ->
       GadtCon forallVars (map (resolveType scope) context) names (resolveGadtBody scope body)
+    TupleCon forallVars context flavor bangTypes ->
+      TupleCon forallVars (map (resolveType scope) context) flavor (map resolveBangType bangTypes)
+    UnboxedSumCon forallVars context pos arity field ->
+      UnboxedSumCon forallVars (map (resolveType scope) context) pos arity (resolveBangType field)
+    ListCon forallVars context ->
+      ListCon forallVars (map (resolveType scope) context)
   where
     resolveBangType bt = bt {bangType = resolveType scope (bangType bt)}
     resolveFieldDecl fieldDecl = fieldDecl {fieldType = resolveBangType (fieldType fieldDecl)}
@@ -727,6 +733,9 @@ dataConAnnotation scope dataConDecl =
             case names of
               name : _ -> topLevelNameAnnotation scope span' name
               [] -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "missing GADT constructor name")
+          TupleCon {} -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "tuple constructors are not top-level binders")
+          UnboxedSumCon {} -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "unboxed sum constructors are not top-level binders")
+          ListCon {} -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "list constructors are not top-level binders")
    in go dataConDecl
 
 topLevelNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
@@ -788,6 +797,9 @@ dataConDeclNames dataConDecl =
           InfixCon _ _ _ name _ -> [name]
           RecordCon _ _ name _ -> [name]
           GadtCon _ _ names _ -> names
+          TupleCon {} -> []
+          UnboxedSumCon {} -> []
+          ListCon {} -> []
    in go dataConDecl
 
 moduleScope :: ModuleExports -> Module -> Scope

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -334,6 +334,12 @@ registerDataCon tc paramMap paramVarIds con = case con of
               zonkedTy <- zonkType conTy
               pure (TcBindingResult (unqualifiedNameText n) zonkedTy)
             [] -> pure (TcBindingResult "<gadt>" gadtResTy)
+  TupleCon {} ->
+    pure (TcBindingResult "<tuple-constructor>" (TcTyCon tc (map TcTyVar paramVarIds)))
+  UnboxedSumCon {} ->
+    pure (TcBindingResult "<unboxed-sum-constructor>" (TcTyCon tc (map TcTyVar paramVarIds)))
+  ListCon {} ->
+    pure (TcBindingResult "<list-constructor>" (TcTyCon tc (map TcTyVar paramVarIds)))
 
 -- | Extract argument types from a GadtBody.
 gadtBodyArgTypes :: GadtBody -> [Type]


### PR DESCRIPTION
## Summary
- fix `@` type-application tokenization so invisible type applications accept all valid type atoms, including promoted string literals like `@\"xs\"`
- add parser regressions for expression and constructor-pattern string type applications, and promote `sbv-promoted-string-type-app-pattern-xfail.hs` from `xfail` to `pass`
- cover newly introduced parser `DataConDecl` forms in `aihc-resolve`, `aihc-tc`, and `aihc-fc` so `just check` passes again under `-Werror`

## Root Cause
The failing oracle case was rejected before pattern parsing reached constructor invisible type arguments. `PCon` already stores invisible type arguments, `checkPattern` already reclassifies `ETypeApp` into pattern type args, and pretty-printing already roundtrips them. The actual gap was lower in the lexer: `lexTypeApplication` only emitted `TkTypeApp` when `@` was followed by a narrow subset of type atoms and excluded digits and string literals. As a result, `@\"xs\"` was tokenized as a value operator instead of an invisible type application marker, so the parser reported an unexpected `@`.

## Solution
I considered three approaches:
- teach only the pattern parser about `@\"...\"`: too narrow, because expressions would still mis-tokenize the same syntax
- special-case promoted string literals in `lexTypeApplication`: fixes this test, but leaves the lexer inconsistent for other valid type atoms
- broaden `lexTypeApplication` to recognize the full class of type-atom starters already accepted elsewhere: chosen, because it fixes the root cause once and generalizes beyond this fixture

The implemented fix extends `lexTypeApplication` to treat digits and string literals as valid starts for invisible type applications. That covers promoted string literals and also keeps invisible type applications consistent across expression and pattern contexts.

## Testing
- added a parser regression for `id @\"xs\" ()`
- added a parser regression for `f (Forall @\"xs\" x) = x`
- promoted `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-promoted-string-type-app-pattern-xfail.hs` from `xfail` to `pass`
- ran `just fmt`
- ran `just check`
- ran `coderabbit review --prompt-only` with no findings

## Progress
- oracle xfail count decreases by 1 because `sbv-promoted-string-type-app-pattern-xfail.hs` now passes

## Follow-up
The only extra changes outside `aihc-parser` are exhaustive matches for `TupleCon`, `UnboxedSumCon`, and `ListCon` in `aihc-resolve`, `aihc-tc`, and `aihc-fc`. Those were required because `just check` was already failing on this branch under `-Werror` for the newer `DataConDecl` constructors. I kept those fixes minimal and did not bundle any broader refactoring into this PR.