### PR TITLE
test(aihc-parser): add xfail oracle test for ghc-events record pattern roundtrip

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-record-pattern-roundtrip-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-record-pattern-roundtrip-xfail.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail record pattern {x = x} pretty-prints as {x} losing explicit binding -}
+module GhcEventsRecordPatternRoundtripXfail where
+data Event = Event { ref :: Int }
+f (Event {ref = ref}) = ref


### PR DESCRIPTION
## Summary
- Add xfail oracle test for ghc-events record pattern roundtrip mismatch (`{ref = ref}` pretty-prints as `{ref}`)

## Notes
- **happy-meta**: All 6 parse failures are in `.lhs` (literate Haskell) files. The parser does not support bird-style literate Haskell syntax (`>` prefix). This cannot be captured as an oracle fixture since fixtures must be `.hs` files.
- **ghc-events/Binary.hs**: The parse error occurs after CPP preprocessing with missing includes (`EventLogFormat.h`). Cannot be faithfully reproduced without the preprocessed output.
- **ghc-events/Events.hs**: Roundtrip failure captured in this PR - explicit record pattern `{ref = ref}` is pretty-printed as pun `{ref}`, changing the AST fingerprint.

Progress: 1 xfail test case added for the ghc-events record pattern roundtrip issue.