### PR TITLE
fix(aihc-parser): support tuple constructor generator patterns

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -20,6 +20,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     UnqualifiedName (..),
   )
+import Data.String (fromString)
 import Data.Text (Text)
 
 -- | Desugar a surface pattern into a Core alt constructor, pure version.
@@ -61,9 +62,18 @@ dsDataConPure (InfixCon _docs _ctx _lhs conName _rhs) =
 dsDataConPure (RecordCon _docs _ctx conName _fields) =
   (unqualifiedNameText conName, 0)
 dsDataConPure (GadtCon {}) = ("<gadt>", 0)
+dsDataConPure (TupleCon _docs _ctx _flavor fields) =
+  ("<tuple>", length fields)
+dsDataConPure (UnboxedSumCon _docs _ctx pos arity _field) =
+  ("<sum:" <> showText pos <> "/" <> showText arity <> ">", 1)
+dsDataConPure (ListCon _docs _ctx) =
+  ("[]", 0)
 
 -- | Convert a Name to Text.
 nameToText :: Name -> Text
 nameToText n = case nameQualifier n of
   Nothing -> nameText n
   Just q -> q <> "." <> nameText n
+
+showText :: (Show a) => a -> Text
+showText = fromString . show

--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -22,7 +22,7 @@ where
 
 import Aihc.Parser.Internal.Common (isConLikeName)
 import Aihc.Parser.Syntax
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
 
 -- | Convert an expression tree into a pattern.
@@ -31,6 +31,7 @@ import Data.Text (Text)
 checkPattern :: Expr -> Either Text Pattern
 checkPattern expr = case expr of
   EAnn ann sub -> fmap (PAnn ann) (checkPattern sub)
+  EPragma pragma _ -> checkPragmaPattern pragma
   -- Variables and constructors
   EVar name
     | nameText name == "_" -> Right PWildcard
@@ -46,9 +47,11 @@ checkPattern expr = case expr of
     | Just vp <- asViewPat inner -> Right (PParen vp)
     | otherwise -> PParen <$> checkPattern inner
   -- Tuple
-  ETuple fl elems -> do
-    pats <- traverse checkTupleElement elems
-    Right (PTuple fl pats)
+  ETuple fl elems
+    | Just tupleCon <- tupleConstructorPattern fl elems -> Right tupleCon
+    | otherwise -> do
+        pats <- traverse checkTupleElement elems
+        Right (PTuple fl pats)
   -- List
   EList elems -> PList <$> traverse checkPattern elems
   -- Unboxed sum
@@ -123,6 +126,12 @@ checkPattern expr = case expr of
   ETHTypedSplice {} -> Left "unexpected typed Template Haskell splice in pattern"
   EProc {} -> Left "unexpected proc expression in pattern"
 
+checkPragmaPattern :: Pragma -> Either Text Pattern
+checkPragmaPattern pragma =
+  case pragma of
+    PragmaSCC {} -> Left "unexpected SCC pragma in pattern"
+    _ -> Left "unexpected pragma in pattern"
+
 -- | Convert a list of expressions into patterns.
 checkPatterns :: [Expr] -> Either Text [Pattern]
 checkPatterns = traverse checkPattern
@@ -131,6 +140,23 @@ checkPatterns = traverse checkPattern
 checkTupleElement :: Maybe Expr -> Either Text Pattern
 checkTupleElement Nothing = Left "unexpected tuple section in pattern"
 checkTupleElement (Just e) = checkPattern e
+
+tupleConstructorPattern :: TupleFlavor -> [Maybe Expr] -> Maybe Pattern
+tupleConstructorPattern fl elems
+  | null elems = Nothing
+  | all isNothing elems = Just (PCon (tupleConstructorName fl (length elems)) [] [])
+  | otherwise = Nothing
+
+tupleConstructorName :: TupleFlavor -> Int -> Name
+tupleConstructorName fl arity =
+  qualifyName Nothing (mkUnqualifiedName NameConSym symbol)
+  where
+    symbol = case fl of
+      Boxed -> tupleCommas
+      Unboxed -> "#" <> tupleCommas <> "#"
+    tupleCommas
+      | arity == 1 = ""
+      | otherwise = mconcat (replicate (arity - 1) ",")
 
 -- | Check that a negated expression is a literal (for PNegLit patterns).
 checkNegLitPattern :: Expr -> Either Text Pattern

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -327,6 +327,7 @@ buildTests = do
           "checkPattern (do-bind)"
           [ testCase "variable pattern: x <- expr" test_doBindVarPattern,
             testCase "constructor pattern: Just x <- expr" test_doBindConPattern,
+            testCase "tuple constructor pattern: (,) x () <- expr" test_doBindTupleConstructorPattern,
             testCase "wildcard pattern: _ <- expr" test_doBindWildcardPattern,
             testCase "tuple pattern: (a, b) <- expr" test_doBindTuplePattern,
             testCase "list pattern: [a, b] <- expr" test_doBindListPattern,
@@ -366,6 +367,7 @@ buildTests = do
             testCase "comp wildcard gen: [1 | _ <- xs]" test_compWildcardGen,
             testCase "comp tuple gen: [a | (a, b) <- xs]" test_compTupleGen,
             testCase "comp constructor gen: [y | Just y <- xs]" test_compConGen,
+            testCase "comp tuple-constructor gen: [(x, ()) | (,) x () <- xs]" test_compTupleConstructorGen,
             testCase "comp bang gen: [y | !y <- xs]" test_compBangGen,
             testCase "comp irrefutable gen: [a | ~(a, b) <- xs]" test_compIrrefutableGen,
             testCase "comp as gen: [y | y@(Just _) <- xs]" test_compAsGen,
@@ -1785,6 +1787,12 @@ test_doBindConPattern =
     Right [DoBind_ (PCon_ "Just" [PVar_ "x"]) _, DoExpr_ _] -> pure ()
     other -> assertFailure ("expected constructor bind, got: " <> show other)
 
+test_doBindTupleConstructorPattern :: Assertion
+test_doBindTupleConstructorPattern =
+  case parseDoStmts "do { (,) x () <- return (1, ()); return x }" of
+    Right [DoBind_ (PCon_ tupleCon [PVar_ "x", PTuple_ Boxed []]) _, DoExpr_ _] | tupleCon == qualifyName Nothing (mkUnqualifiedName NameConSym ",") -> pure ()
+    other -> assertFailure ("expected tuple constructor bind, got: " <> show other)
+
 test_doBindWildcardPattern :: Assertion
 test_doBindWildcardPattern =
   case parseDoStmts "do { _ <- return 1; return 2 }" of
@@ -2396,6 +2404,12 @@ test_compConGen =
   case parseCompStmts "[y | Just y <- xs]" of
     Right [CompGen_ (PCon_ "Just" [PVar_ "y"]) _] -> pure ()
     other -> assertFailure ("expected comp constructor gen, got: " <> show other)
+
+test_compTupleConstructorGen :: Assertion
+test_compTupleConstructorGen =
+  case parseCompStmts "[(x, ()) | (,) x () <- xs]" of
+    Right [CompGen_ (PCon_ tupleCon [PVar_ "x", PTuple_ Boxed []]) _] | tupleCon == qualifyName Nothing (mkUnqualifiedName NameConSym ",") -> pure ()
+    other -> assertFailure ("expected comp tuple-constructor gen, got: " <> show other)
 
 test_compBangGen :: Assertion
 test_compBangGen =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TuplePatterns/list-comp.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TuplePatterns/list-comp.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail tuple constructor pattern in list comprehension generator -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 module TuplePatterns where
 

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -43,6 +43,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     Rhs (..),
     SourceSpan (..),
+    TupleFlavor (..),
     TyVarBinder (..),
     Type (..),
     UnqualifiedName,
@@ -503,6 +504,12 @@ resolveDataConDecl scope dataConDecl =
       RecordCon forallVars (map (resolveType scope) context) name (map resolveFieldDecl fields)
     GadtCon forallVars context names body ->
       GadtCon forallVars (map (resolveType scope) context) names (resolveGadtBody scope body)
+    TupleCon forallVars context flavor fields ->
+      TupleCon forallVars (map (resolveType scope) context) flavor (map resolveBangType fields)
+    UnboxedSumCon forallVars context pos arity field ->
+      UnboxedSumCon forallVars (map (resolveType scope) context) pos arity (resolveBangType field)
+    ListCon forallVars context ->
+      ListCon forallVars (map (resolveType scope) context)
   where
     resolveBangType bt = bt {bangType = resolveType scope (bangType bt)}
     resolveFieldDecl fieldDecl = fieldDecl {fieldType = resolveBangType (fieldType fieldDecl)}
@@ -727,6 +734,12 @@ dataConAnnotation scope dataConDecl =
             case names of
               name : _ -> topLevelNameAnnotation scope span' name
               [] -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "missing GADT constructor name")
+          TupleCon _ _ flavor fields ->
+            topLevelNameAnnotation scope span' (tupleConName flavor (length fields))
+          UnboxedSumCon _ _ pos arity _ ->
+            topLevelNameAnnotation scope span' (unboxedSumConName pos arity)
+          ListCon {} ->
+            topLevelNameAnnotation scope span' listConName
    in go dataConDecl
 
 topLevelNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
@@ -788,7 +801,33 @@ dataConDeclNames dataConDecl =
           InfixCon _ _ _ name _ -> [name]
           RecordCon _ _ name _ -> [name]
           GadtCon _ _ names _ -> names
+          TupleCon _ _ flavor fields -> [tupleConName flavor (length fields)]
+          UnboxedSumCon _ _ pos arity _ -> [unboxedSumConName pos arity]
+          ListCon {} -> [listConName]
    in go dataConDecl
+
+tupleConName :: TupleFlavor -> Int -> UnqualifiedName
+tupleConName flavor arity =
+  mkUnqualifiedName NameConSym $ case flavor of
+    Boxed -> "(" <> commas arity <> ")"
+    Unboxed -> "(#" <> commas arity <> "#)"
+
+unboxedSumConName :: Int -> Int -> UnqualifiedName
+unboxedSumConName pos arity =
+  mkUnqualifiedName NameConSym ("(#" <> bars (pos - 1) <> "_" <> bars (arity - pos) <> "#)")
+
+listConName :: UnqualifiedName
+listConName = mkUnqualifiedName NameConSym "[]"
+
+commas :: Int -> Text
+commas n
+  | n <= 1 = ""
+  | otherwise = T.replicate (n - 1) ","
+
+bars :: Int -> Text
+bars n
+  | n <= 0 = ""
+  | otherwise = T.replicate n "|"
 
 moduleScope :: ModuleExports -> Module -> Scope
 moduleScope exports modu =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -24,6 +24,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     Rhs (..),
     SourceSpan (..),
+    TupleFlavor (..),
     Type (..),
     UnqualifiedName (..),
     ValueDecl (..),
@@ -287,29 +288,17 @@ registerDataCon :: TyCon -> Map Text TyVarId -> [TyVarId] -> DataConDecl -> TcM 
 registerDataCon tc paramMap paramVarIds con = case con of
   DataConAnn _ inner -> registerDataCon tc paramMap paramVarIds inner
   PrefixCon _docs _ctx conName _args ->
-    let name = unqualifiedNameText conName
-        resTy = TcTyCon tc (map TcTyVar paramVarIds)
-        scheme = ForAll paramVarIds [] resTy
-     in do
-          extendTermEnvPermanent name (TcIdBinder name scheme)
-          zonkedTy <- zonkType resTy
-          pure (TcBindingResult name zonkedTy)
+    registerSimpleCon conName
   InfixCon _docs _ctx _lhs conName _rhs ->
-    let name = unqualifiedNameText conName
-        resTy = TcTyCon tc (map TcTyVar paramVarIds)
-        scheme = ForAll paramVarIds [] resTy
-     in do
-          extendTermEnvPermanent name (TcIdBinder name scheme)
-          zonkedTy <- zonkType resTy
-          pure (TcBindingResult name zonkedTy)
+    registerSimpleCon conName
   RecordCon _docs _ctx conName _fields ->
-    let name = unqualifiedNameText conName
-        resTy = TcTyCon tc (map TcTyVar paramVarIds)
-        scheme = ForAll paramVarIds [] resTy
-     in do
-          extendTermEnvPermanent name (TcIdBinder name scheme)
-          zonkedTy <- zonkType resTy
-          pure (TcBindingResult name zonkedTy)
+    registerSimpleCon conName
+  TupleCon _docs _ctx flavor fields ->
+    registerSyntheticCon (tupleConText flavor (length fields))
+  UnboxedSumCon _docs _ctx pos arity _field ->
+    registerSyntheticCon (unboxedSumConText pos arity)
+  ListCon {} ->
+    registerSyntheticCon "[]"
   GadtCon _forallBinders _ctx names body ->
     -- Parse the GADT constructor's declared result type.
     let resultSurfTy = gadtBodyResultType body
@@ -334,6 +323,35 @@ registerDataCon tc paramMap paramVarIds con = case con of
               zonkedTy <- zonkType conTy
               pure (TcBindingResult (unqualifiedNameText n) zonkedTy)
             [] -> pure (TcBindingResult "<gadt>" gadtResTy)
+  where
+    registerSimpleCon = registerSyntheticCon . unqualifiedNameText
+
+    registerSyntheticCon name =
+      let resTy = TcTyCon tc (map TcTyVar paramVarIds)
+          scheme = ForAll paramVarIds [] resTy
+       in do
+            extendTermEnvPermanent name (TcIdBinder name scheme)
+            zonkedTy <- zonkType resTy
+            pure (TcBindingResult name zonkedTy)
+
+tupleConText :: TupleFlavor -> Int -> Text
+tupleConText flavor arity =
+  case flavor of
+    Boxed -> "(" <> commas arity <> ")"
+    Unboxed -> "(#" <> commas arity <> "#)"
+
+unboxedSumConText :: Int -> Int -> Text
+unboxedSumConText pos arity = "(#" <> bars (pos - 1) <> "_" <> bars (arity - pos) <> "#)"
+
+commas :: Int -> Text
+commas n
+  | n <= 1 = ""
+  | otherwise = mconcat (replicate (n - 1) ",")
+
+bars :: Int -> Text
+bars n
+  | n <= 0 = ""
+  | otherwise = mconcat (replicate n "|")
 
 -- | Extract argument types from a GadtBody.
 gadtBodyArgTypes :: GadtBody -> [Type]


### PR DESCRIPTION
## Summary
- fix expression-to-pattern reclassification so fully saturated tuple constructor heads like `(,)` are accepted in generator and bind contexts instead of being rejected as tuple sections
- promote `TuplePatterns/list-comp` from `xfail` to `pass` and add parser regressions covering tuple constructor generators in do-blocks and list comprehensions
- make downstream constructor handling exhaustive for tuple, list, and unboxed-sum constructor declarations so `just check` passes under `-Werror`

## Root Cause
The parser's unified "parse as expression, then reclassify as pattern" path parsed `(,)` as `ETuple Boxed [Nothing, Nothing]`. `checkPattern` treated every tuple section as invalid, so `(,) x () <- ...` failed in generator contexts even though GHC accepts it as a saturated tuple constructor pattern.

A second issue appeared once that rejection was removed: tuple-constructor patterns must roundtrip through the parser's canonical constructor-name representation, or the pretty-printer emits invalid source and the oracle fixture still fails.

## Solution
I considered three approaches:
- special-case tuple constructor heads only in list-comprehension generators
- special-case tuple constructor parsing in the pattern parser before expression reclassification
- teach `checkPattern` to recognize all-hole tuple expressions as tuple constructor heads

I chose the third option because it fixes the root abstraction boundary: any pattern context using expression reclassification now handles saturated tuple constructor heads consistently, not just this single list-comprehension path.

## Testing
- added focused parser regressions for do-bind and list-comprehension tuple constructor generators
- promoted `components/aihc-parser/test/Test/Fixtures/oracle/TuplePatterns/list-comp.hs` from `xfail` to `pass`
- ran `just fmt`
- ran `just check`

## Progress
- Oracle progress changed from `pass=1004 xfail=9` to `pass=1005 xfail=8` for this fixture set

## Follow-up
- CodeRabbit `review --prompt-only` was attempted but skipped because the service returned a rate-limit error
- no additional follow-up issue is needed from this fix; the extra downstream edits were required to keep branch-wide `-Werror` checks exhaustive after the new constructor variants were surfaced