### PR TITLE
fix(nix): fail flake checks on component warnings

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -18,9 +18,11 @@ import Aihc.Parser.Syntax
   ( DataConDecl (..),
     Name (..),
     Pattern (..),
+    TupleFlavor (..),
     UnqualifiedName (..),
   )
 import Data.Text (Text)
+import Data.Text qualified as T
 
 -- | Desugar a surface pattern into a Core alt constructor, pure version.
 --
@@ -61,6 +63,23 @@ dsDataConPure (InfixCon _docs _ctx _lhs conName _rhs) =
 dsDataConPure (RecordCon _docs _ctx conName _fields) =
   (unqualifiedNameText conName, 0)
 dsDataConPure (GadtCon {}) = ("<gadt>", 0)
+dsDataConPure (TupleCon _docs _ctx flavor fields) =
+  (tupleConText flavor (length fields), length fields)
+dsDataConPure (UnboxedSumCon _docs _ctx pos arity _field) =
+  (unboxedSumConText pos arity, 1)
+dsDataConPure (ListCon {}) = ("[]", 0)
+
+tupleConText :: TupleFlavor -> Int -> Text
+tupleConText flavor fieldCount =
+  case flavor of
+    Boxed -> "(" <> T.replicate (max 0 (fieldCount - 1)) "," <> ")"
+    Unboxed -> "(#" <> T.replicate (max 0 (fieldCount - 1)) "," <> "#)"
+
+unboxedSumConText :: Int -> Int -> Text
+unboxedSumConText pos arity =
+  let leftBars = T.replicate (max 0 (pos - 1)) "| "
+      rightBars = T.replicate (max 0 (arity - pos)) " |"
+   in "(# " <> leftBars <> "_" <> rightBars <> " #)"
 
 -- | Convert a Name to Text.
 nameToText :: Name -> Text

--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -89,6 +89,7 @@ checkPattern expr = case expr of
   EString s repr -> Right (PLit (LitString s repr))
   EStringHash s repr -> Right (PLit (LitStringHash s repr))
   EOverloadedLabel {} -> Left "unexpected overloaded label in pattern"
+  EPragma {} -> Left "unexpected pragma in pattern"
   -- TH splice
   ETHSplice body -> Right (PSplice body)
   -- Quasi-quote

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -76,7 +76,7 @@ exprCoreParserWithoutTypeSigExcept :: [Text] -> TokParser Expr
 exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
   mSCC <- optionalHiddenPragma getSCCLabel
   case mSCC of
-    Just label -> EPragma (PragmaSCC label) <$> exprCoreParserWithoutTypeSigExcept forbiddenInfix
+    Just sccLabel -> EPragma (PragmaSCC sccLabel) <$> exprCoreParserWithoutTypeSigExcept forbiddenInfix
     Nothing -> exprCoreParserWithoutTypeSigBody forbiddenInfix
 
 exprCoreParserWithoutTypeSigBody :: [Text] -> TokParser Expr
@@ -322,11 +322,11 @@ lexpParser :: TokParser Expr
 lexpParser = do
   mSCC <- optionalHiddenPragma getSCCLabel
   case mSCC of
-    Just label -> EPragma (PragmaSCC label) <$> lexpParser
+    Just sccLabel -> EPragma (PragmaSCC sccLabel) <$> lexpParser
     Nothing -> doExprParser <|> mdoExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
 
 getSCCLabel :: Pragma -> Maybe Text
-getSCCLabel (PragmaSCC label) = Just label
+getSCCLabel (PragmaSCC sccLabel) = Just sccLabel
 getSCCLabel _ = Nothing
 
 buildInfix :: Expr -> (Name, Expr) -> Expr

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -560,6 +560,7 @@ docCallConv cc =
     CCall -> "CCall"
     StdCall -> "StdCall"
     CApi -> "CApi"
+    CPrim -> "CPrim"
 
 docForeignSafety :: ForeignSafety -> Doc ann
 docForeignSafety fs =

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -29,7 +29,6 @@ import Test.Properties.Arb.Identifiers
     genVarUnqualifiedName,
     isValidGeneratedVarSym,
     shrinkIdent,
-    shrinkName,
     shrinkUnqualifiedName,
   )
 import Test.Properties.Arb.Pattern (genPattern, shrinkPattern)
@@ -1165,6 +1164,14 @@ shrinkDataConDecl con =
         <> [GadtCon forall' ctx names body' | body' <- shrinkGadtBody body]
         <> [GadtCon forall' ctx' names body | ctx' <- shrinkList shrinkType ctx]
         <> [GadtCon forall'' ctx names body | forall'' <- shrinkForallTelescopes forall']
+    TupleCon forall' ctx flavor fields ->
+      [TupleCon forall' ctx flavor fields' | fields' <- shrinkList shrinkBangType fields]
+        <> [TupleCon forall' ctx' flavor fields | ctx' <- shrinkList shrinkType ctx]
+    UnboxedSumCon forall' ctx pos arity field ->
+      [UnboxedSumCon forall' ctx pos arity field' | field' <- shrinkBangType field]
+        <> [UnboxedSumCon forall' ctx' pos arity field | ctx' <- shrinkList shrinkType ctx]
+    ListCon forall' ctx ->
+      [ListCon forall' ctx' | ctx' <- shrinkList shrinkType ctx]
 
 shrinkGadtBody :: GadtBody -> [GadtBody]
 shrinkGadtBody body =
@@ -1321,12 +1328,6 @@ shrinkTypeHeadParams headForm params =
   case headForm of
     TypeHeadPrefix -> shrinkTyVarBinders params
     TypeHeadInfix -> [ps' | ps' <- shrinkTyVarBinders params, length ps' >= 2]
-
-shrinkTypeHeadTypes :: TypeHeadForm -> [Type] -> [[Type]]
-shrinkTypeHeadTypes headForm tys =
-  case headForm of
-    TypeHeadPrefix -> shrinkList shrinkType tys
-    TypeHeadInfix -> [tys' | tys' <- shrinkList shrinkType tys, length tys' >= 2]
 
 shrinkBinderHeadName :: (name -> [name]) -> BinderHead name -> [BinderHead name]
 shrinkBinderHeadName shrinkNameFn head' =

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -472,6 +472,7 @@ shrinkExpr expr =
     EStringHash value _ -> [EStringHash (T.pack shrunk) (T.pack (show shrunk) <> "#") | shrunk <- shrink (T.unpack value)]
     EOverloadedLabel value raw ->
       [EOverloadedLabel (T.pack shrunk) ("#" <> T.pack shrunk) | shrunk <- shrinkOverloadedLabel value raw]
+    EPragma pragma inner -> inner : [EPragma pragma inner' | inner' <- shrinkExpr inner]
     EQuasiQuote quoter body ->
       [EQuasiQuote quoter (T.pack shrunk) | shrunk <- shrink (T.unpack body)]
     EApp fn arg ->

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -470,6 +470,12 @@ normalizeDataConInner (RecordCon forallVars constraints name fields) =
   RecordCon forallVars (map normalizeType constraints) name (map normalizeFieldDecl fields)
 normalizeDataConInner (GadtCon forallBinders constraints names body) =
   GadtCon (map normalizeForallTelescope forallBinders) (map normalizeType constraints) names (normalizeGadtBody body)
+normalizeDataConInner (TupleCon forallVars constraints flavor fields) =
+  TupleCon forallVars (map normalizeType constraints) flavor (map normalizeBangType fields)
+normalizeDataConInner (UnboxedSumCon forallVars constraints pos arity field) =
+  UnboxedSumCon forallVars (map normalizeType constraints) pos arity (normalizeBangType field)
+normalizeDataConInner (ListCon forallVars constraints) =
+  ListCon forallVars (map normalizeType constraints)
 
 normalizeBangType :: BangType -> BangType
 normalizeBangType bt =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -43,6 +43,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     Rhs (..),
     SourceSpan (..),
+    TupleFlavor (..),
     TyVarBinder (..),
     Type (..),
     UnqualifiedName,
@@ -503,6 +504,12 @@ resolveDataConDecl scope dataConDecl =
       RecordCon forallVars (map (resolveType scope) context) name (map resolveFieldDecl fields)
     GadtCon forallVars context names body ->
       GadtCon forallVars (map (resolveType scope) context) names (resolveGadtBody scope body)
+    TupleCon forallVars context flavor bangTypes ->
+      TupleCon forallVars (map (resolveType scope) context) flavor (map resolveBangType bangTypes)
+    UnboxedSumCon forallVars context pos arity bangType ->
+      UnboxedSumCon forallVars (map (resolveType scope) context) pos arity (resolveBangType bangType)
+    ListCon forallVars context ->
+      ListCon forallVars (map (resolveType scope) context)
   where
     resolveBangType bt = bt {bangType = resolveType scope (bangType bt)}
     resolveFieldDecl fieldDecl = fieldDecl {fieldType = resolveBangType (fieldType fieldDecl)}
@@ -717,16 +724,16 @@ dataConAnnotation scope dataConDecl =
       go d =
         case d of
           DataConAnn _ inner -> go inner
-          PrefixCon _ _ name _ ->
-            topLevelNameAnnotation scope span' name
-          RecordCon _ _ name _ ->
-            topLevelNameAnnotation scope span' name
-          InfixCon _ _ _ name _ ->
-            topLevelNameAnnotation scope span' name
+          PrefixCon _ _ name _ -> topLevelNameAnnotation scope span' name
+          RecordCon _ _ name _ -> topLevelNameAnnotation scope span' name
+          InfixCon _ _ _ name _ -> topLevelNameAnnotation scope span' name
           GadtCon _ _ names _ ->
             case names of
               name : _ -> topLevelNameAnnotation scope span' name
               [] -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "missing GADT constructor name")
+          TupleCon _ _ flavor fields -> topLevelNameAnnotation scope span' (tupleConName flavor (length fields))
+          UnboxedSumCon _ _ pos arity _ -> topLevelNameAnnotation scope span' (unboxedSumConName pos arity)
+          ListCon {} -> topLevelNameAnnotation scope span' (mkUnqualifiedName NameConId "[]")
    in go dataConDecl
 
 topLevelNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
@@ -788,7 +795,25 @@ dataConDeclNames dataConDecl =
           InfixCon _ _ _ name _ -> [name]
           RecordCon _ _ name _ -> [name]
           GadtCon _ _ names _ -> names
+          TupleCon _ _ flavor fields -> [tupleConName flavor (length fields)]
+          UnboxedSumCon _ _ pos arity _ -> [unboxedSumConName pos arity]
+          ListCon {} -> [mkUnqualifiedName NameConId "[]"]
    in go dataConDecl
+
+tupleConName :: TupleFlavor -> Int -> UnqualifiedName
+tupleConName flavor fieldCount =
+  let arity = max 0 fieldCount
+      tupleText =
+        case flavor of
+          Boxed -> "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
+          Unboxed -> "(#" <> T.replicate (max 0 (arity - 1)) "," <> "#)"
+   in mkUnqualifiedName NameConId tupleText
+
+unboxedSumConName :: Int -> Int -> UnqualifiedName
+unboxedSumConName pos arity =
+  let leftBars = T.replicate (max 0 (pos - 1)) "| "
+      rightBars = T.replicate (max 0 (arity - pos)) " |"
+   in mkUnqualifiedName NameConId ("(# " <> leftBars <> "_" <> rightBars <> " #)")
 
 moduleScope :: ModuleExports -> Module -> Scope
 moduleScope exports modu =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -287,29 +287,11 @@ registerDataCon :: TyCon -> Map Text TyVarId -> [TyVarId] -> DataConDecl -> TcM 
 registerDataCon tc paramMap paramVarIds con = case con of
   DataConAnn _ inner -> registerDataCon tc paramMap paramVarIds inner
   PrefixCon _docs _ctx conName _args ->
-    let name = unqualifiedNameText conName
-        resTy = TcTyCon tc (map TcTyVar paramVarIds)
-        scheme = ForAll paramVarIds [] resTy
-     in do
-          extendTermEnvPermanent name (TcIdBinder name scheme)
-          zonkedTy <- zonkType resTy
-          pure (TcBindingResult name zonkedTy)
+    registerNamedDataCon (unqualifiedNameText conName)
   InfixCon _docs _ctx _lhs conName _rhs ->
-    let name = unqualifiedNameText conName
-        resTy = TcTyCon tc (map TcTyVar paramVarIds)
-        scheme = ForAll paramVarIds [] resTy
-     in do
-          extendTermEnvPermanent name (TcIdBinder name scheme)
-          zonkedTy <- zonkType resTy
-          pure (TcBindingResult name zonkedTy)
+    registerNamedDataCon (unqualifiedNameText conName)
   RecordCon _docs _ctx conName _fields ->
-    let name = unqualifiedNameText conName
-        resTy = TcTyCon tc (map TcTyVar paramVarIds)
-        scheme = ForAll paramVarIds [] resTy
-     in do
-          extendTermEnvPermanent name (TcIdBinder name scheme)
-          zonkedTy <- zonkType resTy
-          pure (TcBindingResult name zonkedTy)
+    registerNamedDataCon (unqualifiedNameText conName)
   GadtCon _forallBinders _ctx names body ->
     -- Parse the GADT constructor's declared result type.
     let resultSurfTy = gadtBodyResultType body
@@ -320,12 +302,12 @@ registerDataCon tc paramMap paramVarIds con = case con of
         conTy = foldr TcFunTy gadtResTy gadtArgTys
         -- GADT constructors are universally quantified over no extra vars
         -- (the data type's params are handled via given equalities on match).
-        scheme = ForAll [] [] conTy
+        gadtScheme = ForAll [] [] conTy
      in do
           mapM_
             ( \n -> do
                 let nm = unqualifiedNameText n
-                extendTermEnvPermanent nm (TcIdBinder nm scheme)
+                extendTermEnvPermanent nm (TcIdBinder nm gadtScheme)
                 markGadtCon nm
             )
             names
@@ -334,6 +316,21 @@ registerDataCon tc paramMap paramVarIds con = case con of
               zonkedTy <- zonkType conTy
               pure (TcBindingResult (unqualifiedNameText n) zonkedTy)
             [] -> pure (TcBindingResult "<gadt>" gadtResTy)
+  TupleCon _docs _ctx _flavor _fields -> registerAnonymousDataCon "<tuple-con>"
+  UnboxedSumCon _docs _ctx _pos _arity _field -> registerAnonymousDataCon "<unboxed-sum-con>"
+  ListCon _docs _ctx -> registerAnonymousDataCon "[]"
+  where
+    resTy = TcTyCon tc (map TcTyVar paramVarIds)
+    scheme = ForAll paramVarIds [] resTy
+
+    registerNamedDataCon name = do
+      extendTermEnvPermanent name (TcIdBinder name scheme)
+      zonkedTy <- zonkType resTy
+      pure (TcBindingResult name zonkedTy)
+
+    registerAnonymousDataCon displayName = do
+      zonkedTy <- zonkType resTy
+      pure (TcBindingResult displayName zonkedTy)
 
 -- | Extract argument types from a GadtBody.
 gadtBodyArgTypes :: GadtBody -> [Type]

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -16,6 +16,7 @@ import Aihc.Parser.Syntax
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
+    FieldDecl (..),
     GadtBody (..),
     Match (..),
     Module (..),
@@ -286,12 +287,12 @@ registerDataDecl dd = do
 registerDataCon :: TyCon -> Map Text TyVarId -> [TyVarId] -> DataConDecl -> TcM TcBindingResult
 registerDataCon tc paramMap paramVarIds con = case con of
   DataConAnn _ inner -> registerDataCon tc paramMap paramVarIds inner
-  PrefixCon _docs _ctx conName _args ->
-    registerNamedDataCon (unqualifiedNameText conName)
-  InfixCon _docs _ctx _lhs conName _rhs ->
-    registerNamedDataCon (unqualifiedNameText conName)
-  RecordCon _docs _ctx conName _fields ->
-    registerNamedDataCon (unqualifiedNameText conName)
+  PrefixCon _docs _ctx conName args ->
+    registerNamedDataCon (unqualifiedNameText conName) (map (convertSurfaceType paramMap . bangType) args)
+  InfixCon _docs _ctx lhs conName rhs ->
+    registerNamedDataCon (unqualifiedNameText conName) (map (convertSurfaceType paramMap . bangType) [lhs, rhs])
+  RecordCon _docs _ctx conName fields ->
+    registerNamedDataCon (unqualifiedNameText conName) (map (convertSurfaceType paramMap . bangType . fieldType) fields)
   GadtCon _forallBinders _ctx names body ->
     -- Parse the GADT constructor's declared result type.
     let resultSurfTy = gadtBodyResultType body
@@ -316,20 +317,25 @@ registerDataCon tc paramMap paramVarIds con = case con of
               zonkedTy <- zonkType conTy
               pure (TcBindingResult (unqualifiedNameText n) zonkedTy)
             [] -> pure (TcBindingResult "<gadt>" gadtResTy)
-  TupleCon _docs _ctx _flavor _fields -> registerAnonymousDataCon "<tuple-con>"
-  UnboxedSumCon _docs _ctx _pos _arity _field -> registerAnonymousDataCon "<unboxed-sum-con>"
-  ListCon _docs _ctx -> registerAnonymousDataCon "[]"
+  TupleCon _docs _ctx _flavor fields ->
+    registerAnonymousDataCon "<tuple-con>" (map (convertSurfaceType paramMap . bangType) fields)
+  UnboxedSumCon _docs _ctx _pos _arity field ->
+    registerAnonymousDataCon "<unboxed-sum-con>" [convertSurfaceType paramMap (bangType field)]
+  ListCon _docs _ctx -> registerAnonymousDataCon "[]" []
   where
     resTy = TcTyCon tc (map TcTyVar paramVarIds)
-    scheme = ForAll paramVarIds [] resTy
+    conScheme argTys = ForAll paramVarIds [] (foldr TcFunTy resTy argTys)
 
-    registerNamedDataCon name = do
+    registerNamedDataCon name argTys = do
+      let conTy = foldr TcFunTy resTy argTys
+          scheme = conScheme argTys
       extendTermEnvPermanent name (TcIdBinder name scheme)
-      zonkedTy <- zonkType resTy
+      zonkedTy <- zonkType conTy
       pure (TcBindingResult name zonkedTy)
 
-    registerAnonymousDataCon displayName = do
-      zonkedTy <- zonkType resTy
+    registerAnonymousDataCon displayName argTys = do
+      let conTy = foldr TcFunTy resTy argTys
+      zonkedTy <- zonkType conTy
       pure (TcBindingResult displayName zonkedTy)
 
 -- | Extract argument types from a GadtBody.

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -30,6 +30,7 @@
   parserTests = mkPackageTest hsPkgs.aihc-parser;
   parserCliTests = mkPackageTest hsPkgs.aihc-parser-cli;
   cppTests = mkPackageTest hsPkgs.aihc-cpp;
+  fcTests = mkPackageTest hsPkgs.aihc-fc;
   resolveTests = mkPackageTest hsPkgs.aihc-resolve;
   tcTests = mkPackageTest hsPkgs.aihc-tc;
 
@@ -95,6 +96,7 @@ in {
   parser-tests = parserTests;
   parser-cli-tests = parserCliTests;
   cpp-tests = cppTests;
+  fc-tests = fcTests;
   resolve-tests = resolveTests;
   tc-tests = tcTests;
   cpp-doctest = cppDoctest;
@@ -120,6 +122,10 @@ in {
     {
       name = "cpp-tests";
       path = cppTests;
+    }
+    {
+      name = "fc-tests";
+      path = fcTests;
     }
     {
       name = "resolve-tests";

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -24,6 +24,13 @@
       supportsDocs = true;
       supportsCoverage = true;
     };
+    aihc-fc = {
+      src = sources.fcSrc;
+      disableProfiling = true;
+      optimizeForChecks = true;
+      supportsDocs = false;
+      supportsCoverage = false;
+    };
     aihc-resolve = {
       src = sources.resolveSrc;
       disableProfiling = true;
@@ -98,9 +105,17 @@ in rec {
     disableOptimization ? false,
     enableDocs ? false,
     enableCoverage ? false,
+    warningsAsErrors ? false,
   }: let
     hsLib = pkgs.haskell.lib;
     localPackageNames = (builtins.attrNames componentSpecs) ++ ["aihc-hackage"];
+    enableWarningsAsErrors = drv:
+      if warningsAsErrors
+      then
+        hsLib.overrideCabal drv (old: {
+          configureFlags = (old.configureFlags or []) ++ ["--ghc-options=-Werror"];
+        })
+      else drv;
 
     mkComponent = final: name: spec: let
       baseDrv = final.callCabal2nix name (spec.src pkgs) {};
@@ -116,7 +131,8 @@ in rec {
         if enableCoverage && spec.supportsCoverage
         then enableCoverageWithExport hsLib optimizationAdjusted
         else optimizationAdjusted;
-      checksAdjusted = hsLib.dontCheck coverageAdjusted;
+      warningsAdjusted = enableWarningsAsErrors coverageAdjusted;
+      checksAdjusted = hsLib.dontCheck warningsAdjusted;
       haddockMode =
         if enableDocs
         then
@@ -145,6 +161,7 @@ in rec {
   mkHsPkgsForChecks = pkgs:
     mkHsPkgsVariant pkgs {
       disableOptimization = true;
+      warningsAsErrors = true;
     };
 
   mkHsPkgsWithHaddock = pkgs:

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -30,6 +30,13 @@ in rec {
     ".inc"
   ];
 
+  fcSrc = mkComponentSrc "/components/aihc-fc" [
+    ".hs"
+    ".cabal"
+    ".yaml"
+    ".yml"
+  ];
+
   parserCliSrc = mkComponentSrc "/components/aihc-parser-cli" [
     ".hs"
     ".cabal"


### PR DESCRIPTION
## Summary
- make the Nix check package set treat component warnings as fatal by enabling `-Werror` for `mkHsPkgsForChecks`
- include `aihc-fc` in the flake check package set and `checks` output so `nix flake check` covers every current component
- fix the warning and constructor-registration issues exposed by the stricter check path across parser, resolve, tc, and fc

## Progress Counts
- Components covered by flake package checks: 5 -> 6
- Branch commits: 2
- Files changed: 12

## Verification
- ran `just fmt`
- ran `just check`

## Review
- ran `coderabbit review --prompt-only` once and addressed the reported constructor-type issue in `aihc-tc`
- skipped a second CodeRabbit run because the service hit a rate limit