### PR TITLE
fix(parser): use right-association for all infix chains

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -60,6 +60,7 @@ module Aihc.Parser.Internal.Common
     qualifiedVarName,
     liftCheck,
     infixOperatorParserExcept,
+    foldInfixR,
   )
 where
 
@@ -588,7 +589,7 @@ contextItemParserWith typeParser typeAtomParser =
     constraintTypeParser = do
       first <- constraintTypeAppParser
       rest <- MP.many ((,) <$> constraintTypeInfixOperatorParser <*> constraintTypeAppParser)
-      pure (foldl buildInfixType first rest)
+      pure (foldInfixR buildInfixType first rest)
     constraintTypeAppParser = do
       first <- typeAtomParser
       rest <- MP.many typeAtomParser
@@ -600,7 +601,7 @@ contextItemParserWith typeParser typeAtomParser =
     kindTypeParser = do
       first <- constraintTypeAppParser
       rest <- MP.many ((,) <$> constraintTypeInfixOperatorParser <*> constraintTypeAppParser)
-      let baseType = foldl buildInfixType first rest
+      let baseType = foldInfixR buildInfixType first rest
       mRhs <- MP.optional (expectedTok TkReservedRightArrow *> kindTypeParser)
       case mRhs of
         Just rhs ->
@@ -973,3 +974,16 @@ infixOperatorParserExcept forbidden =
       op <- identifierNameParser
       expectedTok TkSpecialBacktick
       if allowed op then pure op else fail "forbidden infix operator"
+
+-- | Build a right-associated infix chain from a left operand and a list
+-- of @(operator, operand)@ pairs.  Given @lhs@ and
+-- @[(op1, a), (op2, b), (op3, c)]@ this produces
+-- @lhs \`op1\` (a \`op2\` (b \`op3\` c))@.
+--
+-- Right-association is the correct default when no fixity information is
+-- available: the end-user of the library is responsible for
+-- re-associating the tree according to operator precedence.
+foldInfixR :: (a -> (op, a) -> a) -> a -> [(op, a)] -> a
+foldInfixR _ lhs [] = lhs
+foldInfixR build lhs ((op, rhs) : rest) =
+  build lhs (op, foldInfixR build rhs rest)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1279,7 +1279,7 @@ typeFamilyLhsParser = do
   case hasInfixTail of
     Just _ -> do
       rest <- typeHeadInfixTailParser
-      pure (TypeHeadInfix, foldl buildInfixType lhs rest)
+      pure (TypeHeadInfix, foldInfixR buildInfixType lhs rest)
     Nothing ->
       pure (TypeHeadPrefix, lhs)
   where

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -92,7 +92,7 @@ exprCoreParserWithoutTypeSigBody forbiddenInfix = do
     _ -> infixExprParserExcept forbiddenInfix
   rest <- MP.many ((,) <$> infixOperatorParserExcept forbiddenInfix <*> region "after infix operator" lexpParser)
   afterArrow <- MP.optional arrowTailParser
-  let withInfix = foldl buildInfix base rest
+  let withInfix = foldInfixR buildInfix base rest
   pure $ case afterArrow of
     Just (op, rhs) -> EInfix withInfix op rhs
     Nothing -> withInfix
@@ -315,7 +315,7 @@ infixExprParserExcept forbidden = do
           <$> infixOperatorParserExcept forbidden
           <*> region "after infix operator" lexpParser
       )
-  pure (foldl buildInfix lhs rest)
+  pure (foldInfixR buildInfix lhs rest)
 
 -- | Parse an lexp (left-expression) - includes do, if, case, let, lambda, and fexp.
 lexpParser :: TokParser Expr
@@ -714,7 +714,7 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                   <*> region "after infix operator" lexpParser
               )
           )
-      let withInfix = foldl buildInfix negBase rest
+      let withInfix = foldInfixR buildInfix negBase rest
       mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
       let typed = case mTypeSig of
             Just ty -> ETypeSig withInfix ty
@@ -787,7 +787,7 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                                   <*> region "after infix operator" lexpParser
                               )
                           )
-                      let fullInfix = foldl buildInfix base ((op, rhs) : more)
+                      let fullInfix = foldInfixR buildInfix base ((op, rhs) : more)
                       mTrailingOp <- MP.optional (infixOperatorParserExcept [])
                       case mTrailingOp of
                         Just trailOp -> do
@@ -1002,7 +1002,7 @@ compTransformExprParser =
       TkReservedBackslash -> lambdaExprParser
       _ -> compTransformInfixExprParser
     rest <- MP.many ((,) <$> infixOperatorParserExcept [] <*> compTransformLexpParser)
-    pure (foldl buildInfix base rest)
+    pure (foldInfixR buildInfix base rest)
 
 compTransformLexpParser :: TokParser Expr
 compTransformLexpParser =
@@ -1025,7 +1025,7 @@ compTransformInfixExprParser = do
           <$> infixOperatorParserExcept []
           <*> region "after infix operator" compTransformLexpParser
       )
-  pure (foldl buildInfix lhs rest)
+  pure (foldInfixR buildInfix lhs rest)
 
 compTransformAppExprParser :: TokParser Expr
 compTransformAppExprParser = withSpanAnn (EAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -31,7 +31,7 @@ infixPatternParser :: TokParser Pattern
 infixPatternParser = do
   lhs <- asOrAppPatternParser
   rest <- MP.many ((,) <$> conOperatorParser <*> asOrAppPatternParser)
-  pure (foldl buildInfixPattern lhs rest)
+  pure (foldInfixR buildInfixPattern lhs rest)
 
 -- | Parse either an as-pattern (name@atom) or an application pattern.
 -- As-patterns bind tighter than infix but looser than application,

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -122,7 +122,7 @@ typeInfixParser :: TokParser Type
 typeInfixParser = do
   lhs <- typeAppParser
   rest <- MP.many ((,) <$> typeInfixOperatorParser <*> typeAppParser)
-  pure (foldl buildInfixType lhs rest)
+  pure (foldInfixR buildInfixType lhs rest)
 
 -- | Parse a type head that may contain infix operators but NOT type applications.
 -- Used for type family heads like @type family l `And` r@ where the head is
@@ -130,7 +130,7 @@ typeInfixParser = do
 typeHeadInfixParser :: TokParser Type
 typeHeadInfixParser = do
   lhs <- typeAtomParser
-  foldl buildInfixType lhs <$> typeHeadInfixLoopParser
+  foldInfixR buildInfixType lhs <$> typeHeadInfixLoopParser
 
 typeHeadInfixLoopParser :: TokParser [((Name, TypePromotion), Type)]
 typeHeadInfixLoopParser = MP.many $ MP.try $ do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -209,7 +209,10 @@ needsExprParens ctx expr =
   case ctx of
     CtxInfixRhs protectOpenEnded ->
       case expr of
-        EInfix {} -> True
+        -- EInfix on the RHS does NOT need parenthesization: the parser
+        -- builds right-associated chains, so nested infix on the RHS is
+        -- the natural nesting direction.  Printing without parens
+        -- produces the same text as the original source.
         ETypeSig {} -> True
         -- ENegate does NOT need parenthesization in infix RHS position.
         -- GHC already rejects `x + - 1` (precedence >= 6) at parse time,
@@ -221,6 +224,11 @@ needsExprParens ctx expr =
         _ -> False
     CtxInfixLhs ->
       case expr of
+        -- EInfix on the LHS needs parenthesization: the parser builds
+        -- right-associated chains, so a nested EInfix on the LHS can only
+        -- appear when the source had explicit parentheses.  Without the
+        -- wrapping, the re-parsed tree would right-associate differently.
+        EInfix {} -> True
         ETypeSig {} -> True
         _ -> isOpenEnded expr
     CtxAppFun ->

--- a/components/aihc-parser/test/Test/Fixtures/oracle/NonEmptyPattern/cons-chain.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NonEmptyPattern/cons-chain.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+module ConsChain where
+
+f (x : y : z : zs) = undefined
+f _ = undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/NonEmptyPattern/explicit-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/NonEmptyPattern/explicit-parens.hs
@@ -1,8 +1,8 @@
 {- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
-module NonEmptyPattern where
+module ExplicitParens where
 
 import Data.List.NonEmpty (NonEmpty(..))
 
-f (x :| y : ys) = undefined
+f ((x :| y) : ys) = undefined
 f _ = undefined


### PR DESCRIPTION
## Summary

- Replace `foldl` with right-folding `foldInfixR` for all infix chain construction (patterns, expressions, types)
- Update expression parenthesization pass to match right-association semantics
- Resolve `NonEmptyPattern/associativity` xfail and add 2 new oracle test fixtures

## Root Cause

The parser used `foldl` to build infix operator chains, producing unconditionally left-associated trees. For patterns like `x :| y : ys`, AIHC parsed as `(x :| y) : ys` while GHC (using fixity resolution) parsed as `x :| (y : ys)`. When AIHC pretty-printed its AST and GHC re-parsed the output, the association changed, causing a roundtrip fingerprint mismatch.

## Solution

Right-association is the correct default when no fixity information is available:

1. **Parser**: Introduced `foldInfixR` — a generic right-fold helper for infix chains. Applied consistently across all infix construction sites: patterns (`Pattern.hs`), expressions (`Expr.hs` — 5 sites), types (`Type.hs`, `Common.hs`), and declarations (`Decl.hs`).

2. **Parenthesization**: Updated the expression parens pass (`Parens.hs`) to match right-association:
   - `CtxInfixRhs`: no longer wraps `EInfix` (right-nesting is now the natural direction)
   - `CtxInfixLhs`: now wraps `EInfix` (left-nesting can only appear with explicit source parens)
   
   Pattern parenthesization required no changes — the existing cons-operator special case already handled right-associated `:` chains correctly.

## Testing

- Original xfail test (`NonEmptyPattern/associativity`) now passes
- Added 2 new oracle tests: `cons-chain` (triple cons chain) and `explicit-parens` (explicit LHS parens)
- All 1657 parser tests pass
- All 1788 tests across all components pass
- 10,000 QuickCheck property tests pass for expressions, patterns, types, declarations, and modules
- `just check` passes (ormolu + hlint + full test suite)

## Progress

xfail -1, pass +3