### PR TITLE
feat(parser): support QualifiedDo bind and mdo syntax

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -85,6 +85,8 @@ exprCoreParserWithoutTypeSigBody forbiddenInfix = do
   base <- case lexTokenKind tok of
     TkKeywordDo -> doExprParser
     TkKeywordMdo -> mdoExprParser
+    TkQualifiedDo {} -> qualifiedDoExprParser
+    TkQualifiedMdo {} -> qualifiedMdoExprParser
     TkKeywordIf -> ifExprParser
     TkKeywordLet -> letExprParser
     TkKeywordProc -> procExprParser
@@ -180,13 +182,31 @@ doExprParser :: TokParser Expr
 doExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkKeywordDo
   stmts <- bracedSemiSep1 doStmtParser
-  pure (EDo stmts False)
+  pure (EDo stmts DoPlain)
 
 mdoExprParser :: TokParser Expr
 mdoExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkKeywordMdo
   stmts <- bracedSemiSep1 doStmtParser
-  pure (EDo stmts True)
+  pure (EDo stmts DoMdo)
+
+qualifiedDoExprParser :: TokParser Expr
+qualifiedDoExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  modName <- tokenSatisfy "qualified do" $ \tok ->
+    case lexTokenKind tok of
+      TkQualifiedDo m -> Just m
+      _ -> Nothing
+  stmts <- bracedSemiSep1 doStmtParser
+  pure (EDo stmts (DoQualified modName))
+
+qualifiedMdoExprParser :: TokParser Expr
+qualifiedMdoExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  modName <- tokenSatisfy "qualified mdo" $ \tok ->
+    case lexTokenKind tok of
+      TkQualifiedMdo m -> Just m
+      _ -> Nothing
+  stmts <- bracedSemiSep1 doStmtParser
+  pure (EDo stmts (DoQualifiedMdo modName))
 
 -- | Parse a proc expression: @proc pat -> cmd@
 procExprParser :: TokParser Expr
@@ -210,6 +230,8 @@ exprCoreParserNoArrowTail = do
   base <- case lexTokenKind tok of
     TkKeywordDo -> doExprParser
     TkKeywordMdo -> mdoExprParser
+    TkQualifiedDo {} -> qualifiedDoExprParser
+    TkQualifiedMdo {} -> qualifiedMdoExprParser
     TkKeywordIf -> ifExprParser
     TkKeywordLet -> letExprParser
     TkKeywordProc -> procExprParser
@@ -323,7 +345,7 @@ lexpParser = do
   mSCC <- optionalHiddenPragma getSCCLabel
   case mSCC of
     Just sccLabel -> EPragma (PragmaSCC sccLabel) <$> lexpParser
-    Nothing -> doExprParser <|> mdoExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
+    Nothing -> doExprParser <|> mdoExprParser <|> qualifiedDoExprParser <|> qualifiedMdoExprParser <|> ifExprParser <|> caseExprParser <|> letExprParser <|> procExprParser <|> lambdaExprParser <|> MP.try negateExprParser <|> appExprParser
 
 getSCCLabel :: Pragma -> Maybe Text
 getSCCLabel (PragmaSCC sccLabel) = Just sccLabel
@@ -464,6 +486,8 @@ atomExprParser = do
         <|> letExprParser
         <|> (if blockArgsEnabled then MP.try doExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try mdoExprParser else MP.empty)
+        <|> (if blockArgsEnabled then MP.try qualifiedDoExprParser else MP.empty)
+        <|> (if blockArgsEnabled then MP.try qualifiedMdoExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try caseExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try ifExprParser else MP.empty)
         <|> (if blockArgsEnabled then MP.try procExprParser else MP.empty)
@@ -996,6 +1020,8 @@ compTransformExprParser =
     base <- case lexTokenKind tok of
       TkKeywordDo -> doExprParser
       TkKeywordMdo -> mdoExprParser
+      TkQualifiedDo {} -> qualifiedDoExprParser
+      TkQualifiedMdo {} -> qualifiedMdoExprParser
       TkKeywordIf -> ifExprParser
       TkKeywordLet -> letExprParser
       TkKeywordProc -> procExprParser
@@ -1008,6 +1034,8 @@ compTransformLexpParser :: TokParser Expr
 compTransformLexpParser =
   doExprParser
     <|> mdoExprParser
+    <|> qualifiedDoExprParser
+    <|> qualifiedMdoExprParser
     <|> ifExprParser
     <|> caseExprParser
     <|> letExprParser

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -327,7 +327,10 @@ lexIdentifier env st =
               modName = T.reverse (T.drop 1 revRest)
               name = T.reverse revName
            in case T.uncons name of
-                Just (c', _) | isConIdStart c' -> TkQConId modName name
+                Just (c', _)
+                  | isConIdStart c' -> TkQConId modName name
+                  | name == "do" && hasExt QualifiedDo env -> TkQualifiedDo modName
+                  | name == "mdo" && hasExt QualifiedDo env && hasExt RecursiveDo env -> TkQualifiedMdo modName
                 Just _ -> TkQVarId modName name
                 Nothing -> TkQVarId modName name
       | otherwise =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -230,6 +230,12 @@ stepTokenContext st tok =
           st {layoutPendingLayout = Just (PendingImplicitLayout (LayoutAfterThenElse 0))}
       | otherwise -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordMdo -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
+    TkQualifiedDo {}
+      | layoutPrevTokenKind st == Just TkKeywordThen
+          || layoutPrevTokenKind st == Just TkKeywordElse ->
+          st {layoutPendingLayout = Just (PendingImplicitLayout (LayoutAfterThenElse 0))}
+      | otherwise -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
+    TkQualifiedMdo {} -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     TkKeywordOf -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutCaseAlternative)}
     TkKeywordCase
       | layoutPrevTokenKind st == Just TkReservedBackslash ->

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -85,6 +85,12 @@ data LexTokenKind
   | TkKeywordRec
   | TkKeywordMdo
   | TkKeywordPattern
+  | -- QualifiedDo tokens (extension-conditional)
+
+    -- | @M.do@ — carries the module qualifier
+    TkQualifiedDo Text
+  | -- | @M.mdo@ — carries the module qualifier
+    TkQualifiedMdo Text
   | -- Reserved operators (per Haskell Report Section 2.4)
     TkReservedDotDot
   | TkReservedColon

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -807,8 +807,8 @@ addExprParensPrec prec expr =
       wrapExpr (prec > 0) (ELetDecls (map addDeclParens decls) (addExprParens body))
     ECase scrutinee alts ->
       wrapExpr (prec > 0) (ECase (addExprParens scrutinee) (map addCaseAltParens alts))
-    EDo stmts isMdo ->
-      wrapExpr (prec > 0) (EDo (map addDoStmtParens stmts) isMdo)
+    EDo stmts flavor ->
+      wrapExpr (prec > 0) (EDo (map addDoStmtParens stmts) flavor)
     EListComp body quals ->
       EListComp (addExprParens body) (map addCompStmtParens quals)
     EListCompParallel body qualifierGroups ->

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1110,8 +1110,8 @@ prettyExpr expr =
         <+> "{"
         <+> hsep (punctuate semi (map prettyCaseAlt alts))
         <+> "}"
-    EDo stmts isMdo ->
-      (if isMdo then "mdo" else "do")
+    EDo stmts flavor ->
+      prettyDoFlavor flavor
         <+> "{"
         <+> hsep (punctuate semi (map prettyDoStmt stmts))
         <+> "}"
@@ -1224,6 +1224,12 @@ prettyGuardQualifier qualifier =
     GuardExpr expr -> prettyExpr expr
     GuardPat pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     GuardLet decls -> "let" <+> spacedBraces (prettyInlineDecls decls)
+
+prettyDoFlavor :: DoFlavor -> Doc ann
+prettyDoFlavor DoPlain = "do"
+prettyDoFlavor DoMdo = "mdo"
+prettyDoFlavor (DoQualified m) = pretty m <> ".do"
+prettyDoFlavor (DoQualifiedMdo m) = pretty m <> ".mdo"
 
 prettyDoStmt :: DoStmt Expr -> Doc ann
 prettyDoStmt stmt =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -785,7 +785,7 @@ docExpr expr =
     ESectionR op rhs -> "ESectionR" <+> docName op <+> parens (docExpr rhs)
     ELetDecls decls body -> "ELetDecls" <+> brackets (hsep (punctuate comma (map docDecl decls))) <+> parens (docExpr body)
     ECase scrutinee alts -> "ECase" <+> parens (docExpr scrutinee) <+> brackets (hsep (punctuate comma (map docCaseAlt alts)))
-    EDo stmts isMdo -> (if isMdo then "EMdo" else "EDo") <+> brackets (hsep (punctuate comma (map docDoStmt stmts)))
+    EDo stmts flavor -> docDoFlavorTag flavor <+> brackets (hsep (punctuate comma (map docDoStmt stmts)))
     EListComp body quals -> "EListComp" <+> parens (docExpr body) <+> brackets (hsep (punctuate comma (map docCompStmt quals)))
     EListCompParallel body qualGroups -> "EListCompParallel" <+> parens (docExpr body) <+> brackets (hsep (punctuate "|" [brackets (hsep (punctuate comma (map docCompStmt qs))) | qs <- qualGroups]))
     EArithSeq seqInfo -> "EArithSeq" <+> parens (docArithSeq seqInfo)
@@ -812,6 +812,12 @@ docCaseAlt (CaseAlt _ pat rhs) =
 docLambdaCaseAlt :: LambdaCaseAlt -> Doc ann
 docLambdaCaseAlt (LambdaCaseAlt _ pats rhs) =
   "LambdaCaseAlt" <+> brackets (hsep (punctuate comma (map docPattern pats))) <+> parens (docRhs rhs)
+
+docDoFlavorTag :: DoFlavor -> Doc ann
+docDoFlavorTag DoPlain = "EDo"
+docDoFlavorTag DoMdo = "EMdo"
+docDoFlavorTag (DoQualified m) = "EQualifiedDo" <+> pretty m
+docDoFlavorTag (DoQualifiedMdo m) = "EQualifiedMdo" <+> pretty m
 
 docDoStmt :: DoStmt Expr -> Doc ann
 docDoStmt stmt =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -913,6 +913,8 @@ docTokenKind kind =
     TkKeywordPattern -> "TkKeywordPattern"
     TkKeywordRec -> "TkKeywordRec"
     TkKeywordMdo -> "TkKeywordMdo"
+    TkQualifiedDo modName -> "TkQualifiedDo" <+> docText modName
+    TkQualifiedMdo modName -> "TkQualifiedMdo" <+> docText modName
     TkArrowTail -> "TkArrowTail"
     TkArrowTailReverse -> "TkArrowTailReverse"
     TkDoubleArrowTail -> "TkDoubleArrowTail"

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -31,6 +31,7 @@ module Aihc.Parser.Syntax
     Decl (..),
     DerivingClause (..),
     DerivingStrategy (..),
+    DoFlavor (..),
     DoStmt (..),
     Expr (..),
     Extension (..),
@@ -1702,7 +1703,7 @@ data Expr
   | ESectionR Name Expr
   | ELetDecls [Decl] Expr
   | ECase Expr [CaseAlt]
-  | EDo [DoStmt Expr] Bool -- Bool: True = mdo, False = do
+  | EDo [DoStmt Expr] DoFlavor
   | EListComp Expr [CompStmt]
   | EListCompParallel Expr [[CompStmt]]
   | EArithSeq ArithSeq
@@ -1757,6 +1758,17 @@ data LambdaCaseAlt = LambdaCaseAlt
     lambdaCaseAltPats :: [Pattern],
     lambdaCaseAltRhs :: Rhs
   }
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data DoFlavor
+  = -- | @do { stmts }@
+    DoPlain
+  | -- | @mdo { stmts }@
+    DoMdo
+  | -- | @M.do { stmts }@ (QualifiedDo)
+    DoQualified Text
+  | -- | @M.mdo { stmts }@ (QualifiedDo + RecursiveDo)
+    DoQualifiedMdo Text
   deriving (Data, Eq, Show, Generic, NFData)
 
 data DoStmt body

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -125,8 +125,8 @@ pattern EOverloadedLabel_ value repr <- (peelExprAnn -> EOverloadedLabel value r
 pattern EIf_ :: Expr -> Expr -> Expr -> Expr
 pattern EIf_ cond thenE elseE <- (peelExprAnn -> EIf cond thenE elseE)
 
-pattern EDo_ :: [DoStmt Expr] -> Bool -> Expr
-pattern EDo_ stmts isMdo <- (peelExprAnn -> EDo stmts isMdo)
+pattern EDo_ :: [DoStmt Expr] -> DoFlavor -> Expr
+pattern EDo_ stmts flavor <- (peelExprAnn -> EDo stmts flavor)
 
 pattern DoBind_ :: Pattern -> Expr -> DoStmt Expr
 pattern DoBind_ pat e <- (peelDoStmtAnn -> DoBind pat e)
@@ -898,7 +898,7 @@ test_standaloneMdoExprParses :: Assertion
 test_standaloneMdoExprParses =
   case parseExpr defaultConfig {parserExtensions = [RecursiveDo]} "mdo { pure x }" of
     ParseOk parsed
-      | EDo_ [DoExpr_ (EApp_ (EVar_ "pure") (EVar_ "x"))] True <- normalizeExpr parsed -> pure ()
+      | EDo_ [DoExpr_ (EApp_ (EVar_ "pure") (EVar_ "x"))] DoMdo <- normalizeExpr parsed -> pure ()
     other -> assertFailure ("expected standalone mdo expression, got: " <> show other)
 
 test_mdoViewPatternParses :: Assertion
@@ -914,7 +914,7 @@ test_mdoViewPatternParses =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         case map normalizeDecl (moduleDecls modu) of
-          [DeclValue (FunctionBind "f" [Match {matchPats = [PView_ (EDo_ [DoExpr_ (EApp_ (EVar_ "pure") (EVar_ "x"))] True) (PVar_ "y")], matchRhs = UnguardedRhs _ (EVar_ "y") _}])] -> pure ()
+          [DeclValue (FunctionBind "f" [Match {matchPats = [PView_ (EDo_ [DoExpr_ (EApp_ (EVar_ "pure") (EVar_ "x"))] DoMdo) (PVar_ "y")], matchRhs = UnguardedRhs _ (EVar_ "y") _}])] -> pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
 
 test_infixTypeFamilyHeadRoundtrip :: Assertion
@@ -1615,7 +1615,7 @@ test_generatedExpressionsCanIncludeMdo =
    in assertBool "expected expression generator to include at least one mdo expression" $
         any isMdo samples
   where
-    isMdo (EDo_ _ True) = True
+    isMdo (EDo_ _ DoMdo) = True
     isMdo _ = False
 
 test_alternateCharLiteralSpellingsLexLikeGhc :: Assertion

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-do-let.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-do-let.hs
@@ -1,7 +1,7 @@
 {- ORACLE_TEST pass -}
 {-# LANGUAGE QualifiedDo #-}
-module QualifiedDoBind where
+module QualifiedDoLet where
 
 f = M.do
-  x <- action
+  let x = 1
   return x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-mdo-bind.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/QualifiedDo/qualified-mdo-bind.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE QualifiedDo, RecursiveDo #-}
+module QualifiedMdoBind where
+
+f = M.mdo
+  x <- action
+  return x

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -62,7 +62,7 @@ genExprWith allowTHQuotes = scale (`div` 2) $ do
         ELambdaCase <$> genCaseAltsWith allowTHQuotes,
         ELambdaCases <$> genLambdaCaseAltsWith allowTHQuotes,
         ELetDecls <$> genValueDeclsWith allowTHQuotes <*> genExprWith allowTHQuotes,
-        EDo <$> genDoStmtsWith allowTHQuotes <*> arbitrary,
+        EDo <$> genDoStmtsWith allowTHQuotes <*> genDoFlavor,
         EListComp <$> genExprWith allowTHQuotes <*> genCompStmtsWith allowTHQuotes,
         EListCompParallel <$> genExprWith allowTHQuotes <*> genParallelCompStmtsWith allowTHQuotes,
         EList <$> genListElemsWith allowTHQuotes,
@@ -256,6 +256,9 @@ genFunctionBindDecl allowTHQuotes = do
         ]
     )
 
+genDoFlavor :: Gen DoFlavor
+genDoFlavor = elements [DoPlain, DoMdo]
+
 genDoStmtsWith :: Bool -> Gen [DoStmt Expr]
 genDoStmtsWith allowTHQuotes = do
   stmts <- smallList0 (genDoStmtWith allowTHQuotes)
@@ -333,7 +336,7 @@ genLayoutExprWith allowTHQuotes =
   scale (`div` 2) $
     oneof
       [ ECase <$> genExprWith allowTHQuotes <*> genCaseAltsWith allowTHQuotes,
-        EDo <$> genDoStmtsWith allowTHQuotes <*> arbitrary,
+        EDo <$> genDoStmtsWith allowTHQuotes <*> genDoFlavor,
         EIf <$> genExprWith allowTHQuotes <*> genExprWith allowTHQuotes <*> genExprWith allowTHQuotes,
         ELetDecls <$> genValueDeclsWith allowTHQuotes <*> genExprWith allowTHQuotes,
         ELambdaPats <$> genPatterns <*> genExprWith allowTHQuotes,
@@ -517,8 +520,8 @@ shrinkExpr expr =
       body
         : [ELetDecls decls body' | body' <- shrinkExpr body]
           <> [ELetDecls decls' body | decls' <- shrinkDecls decls, not (null decls')]
-    EDo stmts isMdo ->
-      [EDo stmts' isMdo | stmts' <- shrinkDoStmts stmts, not (null stmts')]
+    EDo stmts flavor ->
+      [EDo stmts' flavor | stmts' <- shrinkDoStmts stmts, not (null stmts')]
     EListComp body stmts ->
       body
         : [EListComp body' stmts | body' <- shrinkExpr body]

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -59,7 +59,7 @@ normalizeExpr expr =
     ELambdaCase alts -> ELambdaCase (map normalizeCaseAlt alts)
     ELambdaCases alts -> ELambdaCases (map normalizeLambdaCaseAlt alts)
     ELetDecls decls body -> ELetDecls (map normalizeDecl decls) (normalizeExpr body)
-    EDo stmts isMdo -> EDo (map normalizeDoStmt stmts) isMdo
+    EDo stmts flavor -> EDo (map normalizeDoStmt stmts) flavor
     EListComp body stmts -> EListComp (normalizeExpr body) (map normalizeCompStmt stmts)
     EListCompParallel body stmtss -> EListCompParallel (normalizeExpr body) (map (map normalizeCompStmt) stmtss)
     EList elems -> EList (map normalizeExpr elems)


### PR DESCRIPTION
## Summary

- Implement full QualifiedDo extension support, fixing the xfail `qualified-do-bind` oracle test
- Add dedicated lexer tokens, layout engine handling, parser support, and AST representation for qualified do/mdo expressions
- Add new oracle test fixtures for qualified do with let bindings and qualified mdo

## Root Cause

The failure was caused by a three-layer gap in the parser pipeline:

1. **Lexer** (`Lex.hs:323`): `M.do` was lexed as `TkQVarId "M" "do"` — a qualified variable identifier, not a do-keyword. The `classifyIdentifier` function only applied `keywordTokenKind` to unqualified identifiers.
2. **Layout engine** (`Layout.hs:227`): Because the token wasn't `TkKeywordDo`, the layout engine didn't insert implicit braces/semicolons after `M.do`, so `x <- action` and `return x` weren't treated as separate statements.
3. **Parser** (`Expr.hs:86`): The expression parser dispatched on `TkKeywordDo` to enter `doExprParser`. Since `M.do` was `TkQVarId`, it fell through to `varExprParser`, treating `M.do` as a regular variable. The `<-` on the next line then failed as an unexpected token.
4. **AST** (`Syntax.hs:1705`): `EDo` used a `Bool` (True=mdo, False=do) with no field for a module qualifier, so the AST couldn't represent the difference between `do` and `M.do`.

## Solution

Introduced dedicated `TkQualifiedDo Text` and `TkQualifiedMdo Text` token kinds in the lexer, following GHC's approach of producing a special token when the `QualifiedDo` extension is active. This is the cleanest design because:
- The lexer already has extension-awareness via `hasExt`
- Dedicated token kinds make the intent explicit in the layout engine and parser
- Layout and parser dispatch logic is simple pattern matching, not content inspection

### Changes

| File | Change |
|------|--------|
| `Lex/Types.hs` | Add `TkQualifiedDo Text`, `TkQualifiedMdo Text` token kinds |
| `Lex.hs` | Emit new tokens in `classifyIdentifier` when QualifiedDo is active |
| `Lex/Layout.hs` | Trigger implicit layout for `TkQualifiedDo`/`TkQualifiedMdo` |
| `Syntax.hs` | Replace `EDo [DoStmt Expr] Bool` with `EDo [DoStmt Expr] DoFlavor`; add `DoFlavor` data type |
| `Expr.hs` | Add `qualifiedDoExprParser`/`qualifiedMdoExprParser`; wire into all 6 dispatch sites |
| `Pretty.hs` | Add `prettyDoFlavor` to emit `M.do`/`M.mdo` with qualifier |
| `Shorthand.hs` | Add `docDoFlavorTag` for `EQualifiedDo`/`EQualifiedMdo` shorthand tags |
| `Parens.hs` | Update `EDo` pattern match for new `DoFlavor` field |
| Test files | Update `EDo_` pattern, generators, normalizers, and shrink functions |

### Test Fixtures

| Fixture | Before | After |
|---------|--------|-------|
| `QualifiedDo/basic.hs` | pass | pass |
| `QualifiedDo/qualified-do-bind.hs` | **xfail** | **pass** |
| `QualifiedDo/qualified-do-let.hs` | — | **pass** (new) |
| `QualifiedDo/qualified-mdo-bind.hs` | — | **pass** (new) |

## Progress

QualifiedDo oracle: 1/1 pass, 1 xfail → 4/4 pass, 0 xfail