### PR TITLE
fix(parser): resolve QuickCheck shrink loop and lambda case spacing

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -148,6 +148,7 @@ endsWithTypeSig = \case
   ELetDecls _ body -> endsWithTypeSig body
   ELambdaPats _ body -> endsWithTypeSig body
   EInfix _ _ rhs -> endsWithTypeSig rhs
+  EIf _ _ no -> endsWithTypeSig no
   _ -> False
 
 -- | Check whether an expression's pretty-printed form starts with '$'.

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -252,7 +252,7 @@ shrinkType :: Type -> [Type]
 shrinkType ty =
   case ty of
     TVar name ->
-      [TVar $ unqualifiedNameFromText "a"]
+      [TVar $ unqualifiedNameFromText "a" | renderUnqualifiedName name /= "a"]
         <> [TVar (mkUnqualifiedName NameVarId shrunk) | shrunk <- shrinkIdent (renderUnqualifiedName name)]
     TCon name promoted ->
       [TCon (nameFromText "C") promoted | renderName name /= "C"]


### PR DESCRIPTION
## Summary

- Fix infinite shrinker loop in `shrinkType` for `TVar` by guarding against producing the input value as a shrink candidate
- Fix `endsWithTypeSig` in the parenthesization pass to handle `EIf` whose else branch ends with a type signature

## Details

### Shrink loop (test infra)

`shrinkType` for `TVar` unconditionally included `TVar "a"` in its shrink candidates. When the input was already `TVar "a"`, this produced the same value, violating QuickCheck's contract that `shrink x` must never contain `x`. Any failing test case containing `TVar "a"` would cause the shrinker to loop forever.

The fix adds a guard: `[TVar $ unqualifiedNameFromText "a" | renderUnqualifiedName name /= "a"]`, matching the pattern already used by `TCon`.

### Type-sig arrow ambiguity in multiway if guards (parenthesization)

When an `if-then-else` whose else branch contains a type signature appeared as a guard expression in a multiway if (`if { | guard -> body }`), the type parser consumed `->` as a function arrow in the type, leaving no arrow for the guard body separator.

For example, `if { | if c then x else "" :: T -> a }` was misparsed: the type parser read `:: T -> a` as a function type `T -> a` instead of stopping at `->`.

The fix adds `EIf _ _ no -> endsWithTypeSig no` to `endsWithTypeSig` in `Parens.hs`, so the parenthesization pass wraps the guard expression in `EParen` when the else branch ends with a type signature.

## Reproduction

```
cabal test aihc-parser:spec -v0 --test-options='--pattern properties --quickcheck-replay="(SMGen 9315586775711303627 8693113555380999953,65)" --hide-successes --quickcheck-shrinks 20000'
```

Before this fix: the shrink loop caused QuickCheck to run forever.

After this fix: shrinking terminates (24 shrinks), and `just check` passes (1000 QuickCheck tests per property).