### PR TITLE
fix(parser): prevent shrinker self-loops

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -785,7 +785,7 @@ fixityItemParser ann ctor = withSpanAnn ann $ do
 
 valueItemParser :: (SourceSpan -> a -> a) -> (ValueDecl -> a) -> TokParser a
 valueItemParser ann ctor = withSpanAnn ann $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  (headForm, name, pats) <- functionHeadParserWith appPatternParser simplePatternParser
   ctor . functionBindValue headForm name pats <$> equationRhsParser
 
 foreignDeclParser :: TokParser Decl
@@ -1581,7 +1581,7 @@ patternBindDeclParser = MP.try $ withSpanAnn (DeclAnn . mkAnnotation) $ do
 
 valueDeclParser :: TokParser Decl
 valueDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  (headForm, name, pats) <- functionHeadParserWith appPatternParser simplePatternParser
   functionBindDecl headForm name pats <$> equationRhsParser
 
 -- ---------------------------------------------------------------------------

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1179,7 +1179,7 @@ localTypeSigDeclsParser = do
 
 localFunctionDeclParser :: TokParser Decl
 localFunctionDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  (headForm, name, pats) <- functionHeadParserWith appPatternParser simplePatternParser
   functionBindDecl headForm name pats <$> equationRhsParser
 
 localPatternDeclParser :: TokParser Decl

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -147,6 +147,11 @@ endsWithTypeSig = \case
   ETypeSig {} -> True
   ELetDecls _ body -> endsWithTypeSig body
   ELambdaPats _ body -> endsWithTypeSig body
+  EIf _ _ elseBranch -> endsWithTypeSig elseBranch
+  EMultiWayIf guardedRhss ->
+    case guardedRhss of
+      [] -> False
+      _ -> endsWithTypeSig (guardedRhsBody (last guardedRhss))
   EInfix _ _ rhs -> endsWithTypeSig rhs
   _ -> False
 
@@ -1211,6 +1216,8 @@ addInfixFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addInfixFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
+    PInfix {} -> wrapPat True (addPatternParens pat)
+    PTypeSig {} -> wrapPat True (addPatternParens pat)
     _ -> addPatternParens pat
 
 -- | Add parens for the inner pattern of @, !, ~.

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -29,6 +29,7 @@ import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
 import Test.Properties.Arb.Decl (genDeclClass, genDeclDataFamilyInst, genDeclTypeFamilyInst)
 import Test.Properties.Arb.Module (genTypeName)
+import Test.Properties.Arb.Type (shrinkType)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, stripTypeAnnotations)
 import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
@@ -256,6 +257,7 @@ buildTests = do
             testCase "generated identifiers reject extension keyword rec" test_generatedIdentifiersRejectExtensionKeywordRec,
             testCase "generated identifiers reject standalone underscore" test_generatedIdentifiersRejectStandaloneUnderscore,
             testCase "shrunk identifiers reject standalone underscore" test_shrunkIdentifiersRejectStandaloneUnderscore,
+            testCase "shrinking minimal type variables does not reproduce the original type" test_shrunkMinimalTypeVariablesDoNotReproduceOriginalType,
             testCase "generated identifiers accept unicode variable characters" test_generatedIdentifiersAcceptUnicodeVariableCharacters,
             testCase "generated identifiers accept MagicHash suffixes" test_generatedIdentifiersAcceptMagicHashSuffixes,
             testCase "generated constructor identifiers accept unicode uppercase and number tails" test_generatedConstructorIdentifiersAcceptUnicodeCharacters,
@@ -311,6 +313,7 @@ buildTests = do
             testCase "parses explicit type syntax patterns" test_explicitTypeSyntaxPatternParses,
             testCase "parses lambda type binders" test_lambdaTypeBinderParses,
             testCase "parses function head type binders" test_functionHeadTypeBinderParses,
+            testCase "parses backquoted variable infix function heads" test_backquotedVariableInfixFunctionHeadParses,
             testCase "parses invisible type declaration binders" test_invisibleTypeDeclBinderParses,
             testCase "parses invisible type applications in type synonym rhs" test_typeSynonymRhsInvisibleTypeAppParses,
             testCase "parses expression type applications with string literals" test_exprStringTypeApplicationParses,
@@ -820,6 +823,18 @@ test_classOperatorTypeSigParses =
               binderHeadName (classDeclHead classDecl) == "C#" ->
                 pure ()
           other -> assertFailure ("unexpected parsed declarations: " <> show other)
+
+test_backquotedVariableInfixFunctionHeadParses :: Assertion
+test_backquotedVariableInfixFunctionHeadParses =
+  case parseDecl defaultConfig "[] `a` (:+) = ()" of
+    ParseOk decl ->
+      case normalizeDecl decl of
+        DeclValue (FunctionBind name [Match {matchHeadForm = MatchHeadInfix, matchPats = [PList [], PCon con [] []]}])
+          | name == mkUnqualifiedName NameVarId "a",
+            con == mkName Nothing NameConSym ":+" ->
+              pure ()
+        other -> assertFailure ("unexpected parsed declaration: " <> show other)
+    other -> assertFailure ("expected parse success, got: " <> show other)
 
 test_explicitAssociatedTypeFamilyDeclParses :: Assertion
 test_explicitAssociatedTypeFamilyDeclParses =
@@ -1538,6 +1553,12 @@ test_shrunkIdentifiersRejectStandaloneUnderscore :: Assertion
 test_shrunkIdentifiersRejectStandaloneUnderscore =
   assertBool "standalone underscore must not be produced by shrinking" $
     "_" `notElem` shrinkIdent "__"
+
+test_shrunkMinimalTypeVariablesDoNotReproduceOriginalType :: Assertion
+test_shrunkMinimalTypeVariablesDoNotReproduceOriginalType =
+  let ty = TVar (mkUnqualifiedName NameVarId "a")
+   in assertBool "type shrinking must not return the original input" $
+        ty `notElem` shrinkType ty
 
 test_generatedIdentifiersAcceptUnicodeVariableCharacters :: Assertion
 test_generatedIdentifiersAcceptUnicodeVariableCharacters = do

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -989,7 +989,10 @@ genSimpleConstraint =
 -- ---------------------------------------------------------------------------
 
 shrinkDecl :: Decl -> [Decl]
-shrinkDecl decl =
+shrinkDecl decl = filter (/= decl) (shrinkDeclCandidates decl)
+
+shrinkDeclCandidates :: Decl -> [Decl]
+shrinkDeclCandidates decl =
   case decl of
     DeclAnn _ inner -> inner : shrinkDecl inner
     DeclValue vd -> map DeclValue (shrinkValueDecl vd)

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -463,7 +463,10 @@ shrinkOverloadedLabel value raw
 
 -- | Shrink an expression for QuickCheck counterexample minimization.
 shrinkExpr :: Expr -> [Expr]
-shrinkExpr expr =
+shrinkExpr expr = filter (/= expr) (shrinkExprCandidates expr)
+
+shrinkExprCandidates :: Expr -> [Expr]
+shrinkExprCandidates expr =
   case expr of
     EVar name -> [EVar name' | name' <- shrinkName name]
     ETypeSyntax form ty -> [ETypeSyntax form ty' | ty' <- shrinkType ty]

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -194,7 +194,10 @@ renderFloat :: Rational -> T.Text
 renderFloat value = T.pack (show (fromRational value :: Double))
 
 shrinkPattern :: Pattern -> [Pattern]
-shrinkPattern pat =
+shrinkPattern pat = filter (/= pat) (shrinkPatternCandidates pat)
+
+shrinkPatternCandidates :: Pattern -> [Pattern]
+shrinkPatternCandidates pat =
   case pat of
     PAnn _ sub -> shrinkPattern sub
     PVar name ->

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -249,7 +249,10 @@ genSymbolText = do
   pure (T.pack chars)
 
 shrinkType :: Type -> [Type]
-shrinkType ty =
+shrinkType ty = filter (/= ty) (shrinkTypeCandidates ty)
+
+shrinkTypeCandidates :: Type -> [Type]
+shrinkTypeCandidates ty =
   case ty of
     TVar name ->
       [TVar $ unqualifiedNameFromText "a"]

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -18,14 +18,15 @@ import Test.QuickCheck
 
 prop_modulePrettyRoundTrip :: Module -> Property
 prop_modulePrettyRoundTrip modu =
-  let source = renderStrict (layoutPretty defaultLayoutOptions (pretty modu))
+  let parenthesized = addModuleParens modu
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty parenthesized))
       (errs, reparsed) = parseModule moduleConfig source
       reparsedSource = renderStrict (layoutPretty defaultLayoutOptions (pretty reparsed))
    in counterexample ("Original source:\n" <> T.unpack source) $
         counterexample ("Reparsed source:\n" <> T.unpack reparsedSource) $
           case errs of
             [] ->
-              let expected = normalizeModule (addModuleParens modu)
+              let expected = normalizeModule parenthesized
                   actual = normalizeModule reparsed
                in counterexample ("Original AST:\n" <> show (shorthand expected) <> "\nActual AST:\n" <> show (shorthand actual)) (expected == actual)
             _ ->


### PR DESCRIPTION
## Summary

- Prevent parser property shrinkers from returning the original AST value, fixing the broken shrinker invariant that could lead to non-terminating shrinking.
- Parse backquoted variable infix function heads using application-pattern operands so forms like <code>[] `a` (:+) = ()</code> round-trip correctly.
- Tighten paren insertion for infix function-head operands and guard expressions ending in type signatures, and make module round-trip tests pretty-print the normalized AST they compare against.

## Root Cause

A minimal type variable shrink could reproduce the original value, so QuickCheck could keep accepting a self-shrink. Once that was fixed, the replay exposed real minimized parser/pretty-printer cases around infix function heads and guard arrows after type signatures.

## Progress Counts

No parser progress counts changed.

## Validation

- `just fmt`
- `cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-replay=\"(SMGen 9315586775711303627 8693113555380999953,65)\" --hide-successes --quickcheck-shrinks 10000"`
- `just check`
- `coderabbit review --prompt-only` (no findings)
