### PR TITLE
fix(parser): parse infix pattern synonym where heads with parenthesized lhs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1693,7 +1693,7 @@ patSynWhereClauseParser _name = whereClauseItemsParser patSynWhereMatch
 -- head parser compete for the same constructor operators.
 patSynWhereMatch :: TokParser Match
 patSynWhereMatch = withSpan $ do
-  (headForm, _name, pats) <- functionHeadParserWithBinder patSynNameParser constructorInfixOperatorNameParser appPatternParser simplePatternParser
+  (headForm, _name, pats) <- patSynWhereHeadParser
   rhs <- equationRhsParser
   pure $ \span' ->
     Match
@@ -1702,3 +1702,32 @@ patSynWhereMatch = withSpan $ do
         matchPats = pats,
         matchRhs = rhs
       }
+
+patSynWhereHeadParser :: TokParser (MatchHeadForm, UnqualifiedName, [Pattern])
+patSynWhereHeadParser =
+  MP.try infixHeadParser
+    <|> MP.try parenthesizedInfixHeadParser
+    <|> prefixHeadParser
+  where
+    prefixHeadParser = do
+      name <- patSynNameParser
+      pats <- MP.many simplePatternParser
+      pure (MatchHeadPrefix, name, pats)
+
+    infixHeadParser = do
+      lhsPat <- appPatternParser
+      op <- constructorInfixOperatorNameParser
+      rhsPat <- appPatternParser
+      pure (MatchHeadInfix, op, [lhsPat, rhsPat])
+
+    -- Prefer the plain infix form above so a parenthesized infix sub-pattern on
+    -- the left-hand side, e.g. @(a :<| b) :> c = ...@, is not mistaken for the
+    -- entire function head.
+    parenthesizedInfixHeadParser = do
+      expectedTok TkSpecialLParen
+      lhsPat <- appPatternParser
+      op <- constructorInfixOperatorNameParser
+      rhsPat <- appPatternParser
+      expectedTok TkSpecialRParen
+      tailPats <- MP.many simplePatternParser
+      pure (MatchHeadInfix, op, [lhsPat, rhsPat] <> tailPats)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-pattern-synonym-where-infix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/nonempty-containers-pattern-synonym-where-infix.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail pattern synonym where clause with parenthesized infix sub-pattern on LHS -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE PatternSynonyms #-}
 module A where
 


### PR DESCRIPTION
## Summary
- add a pattern-synonym-specific `where` match-head parser that prefers plain infix heads before parenthesized infix heads
- fix parsing of explicitly bidirectional infix pattern synonym equations like `(a :<| b) :> c = ...`
- promote `Hackage/nonempty-containers-pattern-synonym-where-infix` from `xfail` to `pass`

## Progress
- Oracle progress: `pass +1`, `xfail -1`

## Validation
- `just fmt`
- `just check`

## Review
- `coderabbit review --prompt-only` was attempted but skipped due to CodeRabbit rate limiting