### PR TITLE
fix(parser): preserve explicit record field bindings

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -82,7 +82,13 @@ checkPattern expr = case expr of
       _ -> Left "invalid pattern: application of non-constructor"
   -- Record construction -> record pattern
   ERecordCon name fields wc -> do
-    patFields <- traverse (\(n, e) -> (n,) <$> checkPattern e) fields
+    patFields <-
+      traverse
+        ( \field -> do
+            pat <- checkPattern (recordFieldValue field)
+            pure field {recordFieldValue = pat}
+        )
+        fields
     Right (PRecord name patFields wc)
   -- Literals
   EInt n nt repr -> Right (PLit (LitInt n nt repr))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -438,11 +438,11 @@ atomOrRecordExprParser = do
                   ERecordUpd e (map normalizeField fields)
           applyRecordSuffixes result
 
-    normalizeField :: (Name, Maybe Expr, SourceSpan) -> (Name, Expr)
+    normalizeField :: (Name, Maybe Expr, SourceSpan) -> RecordField Expr
     normalizeField (fieldName, mExpr, sp) =
       case mExpr of
-        Just expr' -> (fieldName, expr')
-        Nothing -> (fieldName, EAnn (mkAnnotation sp) (EVar fieldName))
+        Just expr' -> RecordField fieldName expr' False
+        Nothing -> RecordField fieldName (EAnn (mkAnnotation sp) (EVar fieldName)) True
 
 -- | Parse record braces: { field = value, field2 = value2, ... }
 recordBracesParser :: TokParser ([(Name, Maybe Expr, SourceSpan)], Bool)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -281,20 +281,20 @@ varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
           then PCon name [] []
           else PVar (mkUnqualifiedName (nameType name) (nameText name))
 
-recordFieldPatternParser :: TokParser (Name, Pattern)
+recordFieldPatternParser :: TokParser (RecordField Pattern)
 recordFieldPatternParser = do
   field <- identifierNameParser
   mEq <- MP.optional (expectedTok TkReservedEquals)
   case mEq of
     Just () -> do
       pat <- subpatternWithBareViewParser
-      pure (field, pat)
+      pure (RecordField field pat False)
     Nothing -> do
       -- NamedFieldPuns: just "field" means "field = field"
-      pure (field, PVar (mkUnqualifiedName (nameType field) (nameText field)))
+      pure (RecordField field (PVar (mkUnqualifiedName (nameType field) (nameText field))) True)
 
 -- | Parse the contents of record pattern braces, supporting RecordWildCards ".."
-recordPatternFieldListParser :: TokParser ([(Name, Pattern)], Bool)
+recordPatternFieldListParser :: TokParser ([RecordField Pattern], Bool)
 recordPatternFieldListParser = do
   rwcEnabled <- isExtensionEnabled RecordWildCards
   fields <- recordFieldPatternParser `MP.sepEndBy` expectedTok TkSpecialComma

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -824,9 +824,9 @@ addExprParensPrec prec expr =
       EListCompParallel (addExprParens body) (map (map addCompStmtParens) qualifierGroups)
     EArithSeq seqInfo -> EArithSeq (addArithSeqParens seqInfo)
     ERecordCon name fields hasWildcard ->
-      ERecordCon name [(n, addExprParens e) | (n, e) <- fields] hasWildcard
+      ERecordCon name [field {recordFieldValue = addExprParens (recordFieldValue field)} | field <- fields] hasWildcard
     ERecordUpd base fields ->
-      ERecordUpd (addExprParensPrec 3 base) [(n, addExprParens e) | (n, e) <- fields]
+      ERecordUpd (addExprParensPrec 3 base) [field {recordFieldValue = addExprParens (recordFieldValue field)} | field <- fields]
     ETypeSig inner ty ->
       wrapExpr (prec > 1) (ETypeSig (addExprParensIn CtxTypeSigBody inner) (addTypeParens ty))
     EParen inner ->
@@ -1109,7 +1109,7 @@ addPatternParens pat =
     PNegLit lit -> PNegLit lit
     PParen inner -> PParen (addPatternInDelimited inner)
     PRecord con fields hasWildcard ->
-      PRecord con [(fieldName, addPatternInDelimited fieldPat) | (fieldName, fieldPat) <- fields] hasWildcard
+      PRecord con [field {recordFieldValue = addPatternInDelimited (recordFieldValue field)} | field <- fields] hasWildcard
     PTypeSig inner ty -> PTypeSig (addPatternParens inner) (addTypeParens ty)
     PSplice body -> PSplice (addSpliceBodyParens body)
 

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -482,7 +482,7 @@ prettyPattern pat =
           ( hsep
               ( punctuate
                   comma
-                  ( [prettyPatternFieldBinding fieldName fieldPat | (fieldName, fieldPat) <- fields]
+                  ( [prettyPatternFieldBinding field | field <- fields]
                       ++ [".." | hasWildcard]
                   )
               )
@@ -491,11 +491,11 @@ prettyPattern pat =
     PSplice body -> "$" <> prettyExpr body
 
 -- | Pretty print a pattern field binding.
-prettyPatternFieldBinding :: Name -> Pattern -> Doc ann
-prettyPatternFieldBinding fieldName fieldPat =
-  case peelPatternAnn fieldPat of
-    PVar varName | renderUnqualifiedName varName == renderName fieldName -> pretty fieldName
-    _ -> pretty fieldName <+> "=" <+> prettyPattern fieldPat
+prettyPatternFieldBinding :: RecordField Pattern -> Doc ann
+prettyPatternFieldBinding field =
+  if recordFieldPun field
+    then pretty (recordFieldName field)
+    else pretty (recordFieldName field) <+> "=" <+> prettyPattern (recordFieldValue field)
 
 prettyLiteral :: Literal -> Doc ann
 prettyLiteral lit =
@@ -1169,11 +1169,11 @@ prettyTupleBody tupleFlavor inner =
     Boxed -> parens inner
     Unboxed -> hsep ["(#", inner, "#)"]
 
-prettyBinding :: (Name, Expr) -> Doc ann
-prettyBinding (name, value) =
-  case peelExprAnn value of
-    EVar varName | varName == name -> prettyName name
-    _ -> prettyName name <+> "=" <+> prettyExpr value
+prettyBinding :: RecordField Expr -> Doc ann
+prettyBinding field =
+  if recordFieldPun field
+    then prettyName (recordFieldName field)
+    else prettyName (recordFieldName field) <+> "=" <+> prettyExpr (recordFieldValue field)
 
 prettyCaseAlt :: CaseAlt -> Doc ann
 prettyCaseAlt (CaseAlt _ pat rhs) =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -735,7 +735,7 @@ docPattern pat =
     PIrrefutable inner -> "PIrrefutable" <+> parens (docPattern inner)
     PNegLit lit -> "PNegLit" <+> parens (docLiteral lit)
     PParen inner -> "PParen" <+> parens (docPattern inner)
-    PRecord name fields' hasWildcard -> "PRecord" <+> docName name <+> braces (hsep (punctuate comma ([docName fn <+> "=" <+> docPattern fp | (fn, fp) <- fields'] ++ [".." | hasWildcard])))
+    PRecord name fields' hasWildcard -> "PRecord" <+> docName name <+> braces (hsep (punctuate comma ([docPatternRecordField recordField | recordField <- fields'] ++ [".." | hasWildcard])))
     PTypeSig inner ty -> "PTypeSig" <+> parens (docPattern inner) <+> parens (docType ty)
     PSplice body -> "PSplice" <+> parens (docExpr body)
 
@@ -789,8 +789,8 @@ docExpr expr =
     EListComp body quals -> "EListComp" <+> parens (docExpr body) <+> brackets (hsep (punctuate comma (map docCompStmt quals)))
     EListCompParallel body qualGroups -> "EListCompParallel" <+> parens (docExpr body) <+> brackets (hsep (punctuate "|" [brackets (hsep (punctuate comma (map docCompStmt qs))) | qs <- qualGroups]))
     EArithSeq seqInfo -> "EArithSeq" <+> parens (docArithSeq seqInfo)
-    ERecordCon name fields' hasWildcard -> "ERecordCon" <+> docName name <+> braces (hsep (punctuate comma ([docName fn <+> "=" <+> docExpr fv | (fn, fv) <- fields'] ++ [".." | hasWildcard])))
-    ERecordUpd base fields' -> "ERecordUpd" <+> parens (docExpr base) <+> braces (hsep (punctuate comma [docName fn <+> "=" <+> docExpr fv | (fn, fv) <- fields']))
+    ERecordCon name fields' hasWildcard -> "ERecordCon" <+> docName name <+> braces (hsep (punctuate comma ([docExprRecordField recordField | recordField <- fields'] ++ [".." | hasWildcard])))
+    ERecordUpd base fields' -> "ERecordUpd" <+> parens (docExpr base) <+> braces (hsep (punctuate comma [docExprRecordField recordField | recordField <- fields']))
     ETypeSig inner ty -> "ETypeSig" <+> parens (docExpr inner) <+> parens (docType ty)
     EParen inner -> "EParen" <+> parens (docExpr inner)
     EList elems -> "EList" <+> brackets (hsep (punctuate comma (map docExpr elems)))
@@ -804,6 +804,18 @@ docExpr expr =
     EProc pat body -> "EProc" <+> parens (docPattern pat) <+> parens (docCmd body)
     EPragma pragma inner -> "EPragma" <+> parens (docPragma pragma) <+> parens (docExpr inner)
     EAnn _ sub -> docExpr sub
+
+docPatternRecordField :: RecordField Pattern -> Doc ann
+docPatternRecordField recordField =
+  docName (recordFieldName recordField)
+    <+> (if recordFieldPun recordField then "~pun" else "=")
+    <+> docPattern (recordFieldValue recordField)
+
+docExprRecordField :: RecordField Expr -> Doc ann
+docExprRecordField recordField =
+  docName (recordFieldName recordField)
+    <+> (if recordFieldPun recordField then "~pun" else "=")
+    <+> docExpr (recordFieldValue recordField)
 
 docCaseAlt :: CaseAlt -> Doc ann
 docCaseAlt (CaseAlt _ pat rhs) =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -76,6 +76,7 @@ module Aihc.Parser.Syntax
     PatSynDecl (..),
     PatSynDir (..),
     Pattern (..),
+    RecordField (..),
     Pragma (..),
     PragmaUnpackKind (..),
     Role (..),
@@ -1099,6 +1100,13 @@ data TupleFlavor
   | Unboxed
   deriving (Data, Eq, Show, Generic, NFData)
 
+data RecordField a = RecordField
+  { recordFieldName :: Name,
+    recordFieldValue :: a,
+    recordFieldPun :: Bool
+  }
+  deriving (Data, Eq, Show, Generic, NFData)
+
 data Pattern
   = PAnn Annotation Pattern
   | PVar UnqualifiedName
@@ -1118,7 +1126,7 @@ data Pattern
   | PIrrefutable Pattern
   | PNegLit Literal
   | PParen Pattern
-  | PRecord Name [(Name, Pattern)] Bool -- Bool: wildcard present
+  | PRecord Name [RecordField Pattern] Bool -- Bool: wildcard present
   | PTypeSig Pattern Type
   | PSplice Expr
   -- \$pat or $(pat) (TH pattern splice)
@@ -1707,8 +1715,8 @@ data Expr
   | EListComp Expr [CompStmt]
   | EListCompParallel Expr [[CompStmt]]
   | EArithSeq ArithSeq
-  | ERecordCon Name [(Name, Expr)] Bool -- Bool: wildcard present
-  | ERecordUpd Expr [(Name, Expr)]
+  | ERecordCon Name [RecordField Expr] Bool -- Bool: wildcard present
+  | ERecordUpd Expr [RecordField Expr]
   | ETypeSig Expr Type
   | EParen Expr
   | EList [Expr]

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -104,7 +104,7 @@ pattern PNegLit_ lit <- (peelPatternAnn -> PNegLit lit)
 pattern PParen_ :: Pattern -> Pattern
 pattern PParen_ pat <- (peelPatternAnn -> PParen pat)
 
-pattern PRecord_ :: Name -> [(Name, Pattern)] -> Bool -> Pattern
+pattern PRecord_ :: Name -> [RecordField Pattern] -> Bool -> Pattern
 pattern PRecord_ con fields rwc <- (peelPatternAnn -> PRecord con fields rwc)
 
 pattern PUnboxedSum_ :: Int -> Int -> Pattern -> Pattern
@@ -407,7 +407,9 @@ buildTests = do
           "pretty"
           [ testCase "infix type family instances keep bare applications" test_typeFamilyInstanceInfixAppliedOperandsRoundTrip,
             testCase "symbolic type application parenthesizes context arguments" test_symbolicTypeApplicationContextArgRoundTrip,
-            testCase "data family instance kind signatures round-trip" test_dataFamilyInstanceKindSignatureRoundTrip
+            testCase "data family instance kind signatures round-trip" test_dataFamilyInstanceKindSignatureRoundTrip,
+            testCase "record patterns preserve explicit same-name bindings" test_recordPatternExplicitSameNameBindingRoundTrip,
+            testCase "record expressions preserve explicit same-name bindings" test_recordExprExplicitSameNameBindingRoundTrip
           ],
         testGroup
           "functionHeadParserWith dispatch"
@@ -2737,9 +2739,28 @@ test_funHeadPrefixListViewPattern =
 test_funHeadPrefixRecordFieldViewPattern :: Assertion
 test_funHeadPrefixRecordFieldViewPattern =
   case parseTopDeclWithExts [ViewPatterns] "f (Box {field = id -> x}) = x" of
-    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PRecord_ "Box" [(fieldName, PView_ (EVar_ "id") (PVar_ "x"))] False]}]))
-      | fieldName == qualifyName Nothing (mkUnqualifiedName NameVarId "field") -> pure ()
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PRecord_ "Box" [field] False]}]))
+      | recordFieldName field == qualifyName Nothing (mkUnqualifiedName NameVarId "field")
+          && not (recordFieldPun field)
+          && recordFieldValue field == PView (EVar "id") (PVar "x") ->
+          pure ()
     other -> assertFailure ("expected record-field view-pattern argument in prefix function head, got: " <> show other)
+
+test_recordPatternExplicitSameNameBindingRoundTrip :: Assertion
+test_recordPatternExplicitSameNameBindingRoundTrip =
+  let input = T.unlines ["module RecordPatternExplicit where", "data Event = Event { ref :: Int }", "f (Event {ref = ref}) = ref"]
+      (errs, modu) = parseModule defaultConfig input
+   in if not (null errs)
+        then assertFailure (show errs)
+        else renderStrict (layoutPretty defaultLayoutOptions (pretty modu)) @?= T.intercalate "\n" ["module RecordPatternExplicit where", "data Event = Event {ref :: Int}", "f (Event {ref = ref}) = ref"]
+
+test_recordExprExplicitSameNameBindingRoundTrip :: Assertion
+test_recordExprExplicitSameNameBindingRoundTrip =
+  let input = T.unlines ["module RecordExprExplicit where", "data Event = Event { ref :: Int }", "mk ref = Event {ref = ref}"]
+      (errs, modu) = parseModule defaultConfig input
+   in if not (null errs)
+        then assertFailure (show errs)
+        else renderStrict (layoutPretty defaultLayoutOptions (pretty modu)) @?= T.intercalate "\n" ["module RecordExprExplicit where", "data Event = Event {ref :: Int}", "mk ref = Event {ref = ref}"]
 
 test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
 test_funHeadPrefixUnboxedTupleSingletonArg =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-record-pattern-roundtrip-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-record-pattern-roundtrip-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail record pattern {x = x} pretty-prints as {x} losing explicit binding -}
+{- ORACLE_TEST pass -}
 module GhcEventsRecordPatternRoundtripXfail where
 data Event = Event { ref :: Int }
 f (Event {ref = ref}) = ref

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -379,10 +379,10 @@ genArithSeqWith allowTHQuotes =
         ArithSeqFromThenTo <$> genExprWith allowTHQuotes <*> genExprWith allowTHQuotes <*> genExprWith allowTHQuotes
       ]
 
-genRecordFieldsWith :: Bool -> Gen [(Name, Expr)]
+genRecordFieldsWith :: Bool -> Gen [RecordField Expr]
 genRecordFieldsWith allowTHQuotes =
   smallList0 $
-    (,) <$> genVarName <*> genExprWith allowTHQuotes
+    RecordField <$> genVarName <*> genExprWith allowTHQuotes <*> pure False
 
 -- | Generate a type (simple version for use inside expressions).
 genTypeWith :: Bool -> Gen Type
@@ -729,11 +729,13 @@ shrinkArithSeq seq' =
           <> [ArithSeqFromThenTo from thenE to' | to' <- shrinkExpr to]
     ArithSeqAnn _ _ -> []
 
-shrinkRecordFields :: [(Name, Expr)] -> [[(Name, Expr)]]
+shrinkRecordFields :: [RecordField Expr] -> [[RecordField Expr]]
 shrinkRecordFields = shrinkList shrinkRecordField
 
-shrinkRecordField :: (Name, Expr) -> [(Name, Expr)]
-shrinkRecordField (name, expr) = [(name', expr) | name' <- shrinkName name] <> [(name, expr') | expr' <- shrinkExpr expr]
+shrinkRecordField :: RecordField Expr -> [RecordField Expr]
+shrinkRecordField field =
+  [field {recordFieldName = name'} | name' <- shrinkName (recordFieldName field)]
+    <> [field {recordFieldValue = expr'} | expr' <- shrinkExpr (recordFieldValue field)]
 
 instance Arbitrary Expr where
   arbitrary = resize 5 genExpr

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -137,14 +137,14 @@ genRecordPatternWith = do
   fields <- genRecordFieldsWith
   pure (PRecord con fields False)
 
-genRecordFieldsWith :: Gen [(Name, Pattern)]
+genRecordFieldsWith :: Gen [RecordField Pattern]
 genRecordFieldsWith = do
   n <- chooseInt (0, 3)
   names <- vectorOf n genFieldName
   pats <- vectorOf n genPattern
   quals <- vectorOf n genOptionalQualifier
   let qualifiedNames = zipWith (\q name -> qualifyName q (mkUnqualifiedName NameVarId name)) quals names
-  pure (zip qualifiedNames pats)
+  pure [RecordField fieldName fieldPat False | (fieldName, fieldPat) <- zip qualifiedNames pats]
 
 genLiteral :: Gen Literal
 genLiteral =
@@ -274,10 +274,10 @@ shrinkPatternTupleElems tupleFlavor elems =
            _ -> [PTuple tupleFlavor shrunk]
        ]
 
-shrinkField :: (Name, Pattern) -> [(Name, Pattern)]
-shrinkField (fieldName, fieldPat) =
-  [(fieldName', fieldPat) | fieldName' <- shrinkName fieldName]
-    <> [(fieldName, shrunk) | shrunk <- shrinkPattern fieldPat]
+shrinkField :: RecordField Pattern -> [RecordField Pattern]
+shrinkField field =
+  [field {recordFieldName = fieldName'} | fieldName' <- shrinkName (recordFieldName field)]
+    <> [field {recordFieldValue = shrunk} | shrunk <- shrinkPattern (recordFieldValue field)]
 
 shrinkLiteral :: Literal -> [Literal]
 shrinkLiteral lit =

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -65,8 +65,8 @@ normalizeExpr expr =
     EList elems -> EList (map normalizeExpr elems)
     ETuple tupleFlavor elems -> ETuple tupleFlavor (map (fmap normalizeExpr) elems)
     EArithSeq seq' -> EArithSeq (normalizeArithSeq seq')
-    ERecordCon con fields rwc -> ERecordCon con [(name, normalizeExpr e) | (name, e) <- fields] rwc
-    ERecordUpd target fields -> ERecordUpd (normalizeExpr target) [(name, normalizeExpr e) | (name, e) <- fields]
+    ERecordCon con fields rwc -> ERecordCon con [field {recordFieldValue = normalizeExpr (recordFieldValue field)} | field <- fields] rwc
+    ERecordUpd target fields -> ERecordUpd (normalizeExpr target) [field {recordFieldValue = normalizeExpr (recordFieldValue field)} | field <- fields]
     ETypeSig inner ty -> ETypeSig (normalizeExpr inner) (normalizeType ty)
     ETypeApp inner ty -> ETypeApp (normalizeExpr inner) (normalizeType ty)
     EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (normalizeExpr inner)
@@ -149,7 +149,7 @@ normalizePattern pat =
             PCon con [] [] | nameType con == NameConSym -> normInner
             _ -> PParen normInner
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (normalizePattern inner)
-    PRecord con fields rwc -> PRecord con [(name, normalizePattern p) | (name, p) <- fields] rwc
+    PRecord con fields rwc -> PRecord con [field {recordFieldValue = normalizePattern (recordFieldValue field)} | field <- fields] rwc
     PTypeSig inner ty -> PTypeSig (normalizePattern inner) (normalizeType ty)
     PSplice body -> PSplice (normalizeExpr body)
 

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -63,7 +63,7 @@ normalizePattern pat =
             PCon con [] [] | nameType con == NameConSym -> normInner
             _ -> PParen normInner
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (normalizePattern inner)
-    PRecord con fields rwc -> PRecord con [(fieldName, normalizePattern fieldPat) | (fieldName, fieldPat) <- fields] rwc
+    PRecord con fields rwc -> PRecord con [field {recordFieldValue = normalizePattern (recordFieldValue field)} | field <- fields] rwc
     PTypeSig inner ty -> PTypeSig (normalizePattern inner) (normalizeTypeSpan ty)
     PSplice body -> PSplice (normalizeExpr body)
 

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -56,6 +56,7 @@ import Aihc.Parser.Syntax
     moduleName,
     peelGuardQualifierAnn,
     peelPatternAnn,
+    recordFieldValue,
     renderUnqualifiedName,
   )
 import Aihc.Resolve.Types
@@ -471,9 +472,9 @@ bindPattern typeScope lastSeen nextLocal pat =
       let here = peelPatternSpan lastSeen pat
           (nextLocal', entries, fields') =
             foldl'
-              ( \(currentId, currentEntries, acc) (fieldName, fieldPat) ->
-                  let (nextId, fieldScope, fieldPat') = bindPattern typeScope here currentId fieldPat
-                   in (nextId, Map.toList (scopeTerms fieldScope) <> currentEntries, (fieldName, fieldPat') : acc)
+              ( \(currentId, currentEntries, acc) field ->
+                  let (nextId, fieldScope, fieldPat') = bindPattern typeScope here currentId (recordFieldValue field)
+                   in (nextId, Map.toList (scopeTerms fieldScope) <> currentEntries, field {recordFieldValue = fieldPat'} : acc)
               )
               (nextLocal, [], [])
               fields


### PR DESCRIPTION
## Summary
- preserve whether record fields were written as puns or explicit bindings so pretty-printing no longer rewrites `field = field` into `field`
- fix the Hackage oracle regression for `ghc-events-record-pattern-roundtrip-xfail` and add direct pretty-roundtrip tests for both record patterns and record expressions
- thread the new record-field representation through parser normalization, shorthand output, property generators, and `aihc-resolve`

## Root Cause
The parser normalized record fields down to plain `(Name, value)` pairs. That lost whether the source wrote a pun like `{field}` or an explicit binding like `{field = field}`. The pretty-printer then tried to reconstruct pun syntax by comparing the field name to the value AST, which incorrectly collapsed explicit same-name bindings into puns.

## Solution Design
I considered three approaches:
- keep the current AST and special-case the pretty-printer for `field = field`
- preserve source syntax in annotations/spans and teach the pretty-printer to inspect them
- store pun-vs-explicit directly in the record-field AST node

I chose the third option because it fixes the lossy representation at the source, keeps the pretty-printer simple, and generalizes to both expressions and patterns without relying on fragile source-span heuristics.

## Testing
- changed `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-record-pattern-roundtrip-xfail.hs` from `xfail` to `pass`
- added parser pretty-roundtrip coverage for explicit same-name bindings in both record patterns and record expressions
- ran `just fmt`
- ran `just check`

## Progress
- oracle fixtures fixed: 1 xfail -> pass

## Follow-up
I did not include broader AST refactors beyond record fields. Other xfails are unrelated and should stay in separate PRs.

## CodeRabbit
`coderabbit review --prompt-only` was attempted after local checks passed, but CodeRabbit was rate-limited and could not start the review.