### PR TITLE
fix(parser): cover proc roundtrip generation

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -214,7 +214,7 @@ buildAlt _scrutVar restVars resTy m = case matchPats m of
     pure (FcAlt DefaultAlt [] body)
 
 -- | Desugar a right-hand side.
-dsRhs :: Rhs -> DsM FcExpr
+dsRhs :: Rhs Expr -> DsM FcExpr
 dsRhs (UnguardedRhs _sp expr _decls) = dsExpr expr
 dsRhs (GuardedRhss _sp _guards _decls) = do
   v <- freshVar "_unimplemented" (TcTyCon (TyCon "?" 0) [])
@@ -273,7 +273,7 @@ dsExpr _ = do
   pure (FcVar v)
 
 -- | Desugar a case alternative.
-dsCaseAlt :: CaseAlt -> DsM FcAlt
+dsCaseAlt :: CaseAlt Expr -> DsM FcAlt
 dsCaseAlt (CaseAlt _anns pat rhs) = do
   let (con, binderNames) = dsPatternPure pat
   binders <- mapM (\nm -> freshVar nm (TcTyCon (TyCon "?" 0) [])) binderNames

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -7,7 +7,7 @@ where
 
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Common
-import {-# SOURCE #-} Aihc.Parser.Internal.Expr (exprParser, exprParserNoArrowTail, parseLetDeclsParser, parseLetDeclsStmtParser)
+import {-# SOURCE #-} Aihc.Parser.Internal.Expr (caseRhsParserWithBodyParser, exprParser, exprParserNoArrowTail, parseLetDeclsParser, parseLetDeclsStmtParser)
 import Aihc.Parser.Internal.Pattern (patternParser, simplePatternParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind)
 import Aihc.Parser.Syntax
@@ -116,12 +116,11 @@ cmdCaseParser = withSpanAnn (CmdAnn . mkAnnotation) $ do
   alts <- bracedSemiSep1 cmdCaseAltParser
   pure (CmdCase scrut alts)
 
-cmdCaseAltParser :: TokParser CmdCaseAlt
+cmdCaseAltParser :: TokParser (CaseAlt Cmd)
 cmdCaseAltParser = withSpan $ do
   pat <- patternParser
-  expectedTok TkReservedRightArrow
-  body <- cmdParser
-  pure (\span' -> CmdCaseAlt [mkAnnotation span'] pat body)
+  rhs <- caseRhsParserWithBodyParser cmdParser
+  pure (\span' -> CaseAlt [mkAnnotation span'] pat rhs)
 
 -- | Parse a command let: @let decls in cmd@
 cmdLetParser :: TokParser Cmd

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -37,23 +37,26 @@ cmdParser = do
       -- a do-block is a statement, not handled here.
       cmdOperandThenInfix cmdLetParser
     TkReservedBackslash -> cmdOperandThenInfix cmdLamParser
-    TkSpecialLParen -> cmdOperandThenInfix cmdParenParser
-    _ -> do
-      -- Not a keyword command: parse the left side as an expression while
-      -- leaving -< / -<< available for command parsing.
-      expr <- exprParserNoArrowTail
-      mArrowTail <- MP.optional cmdArrTailParser
-      case mArrowTail of
-        Just (appType, rhs) ->
-          cmdInfixChain (CmdArrApp expr appType rhs)
-        Nothing -> do
-          mTok <- MP.optional (lookAhead anySingle)
-          MP.customFailure
-            UnexpectedTokenExpecting
-              { unexpectedFound = mkFoundToken <$> mTok,
-                unexpectedExpecting = "arrow command (-< or -<<)",
-                unexpectedContext = []
-              }
+    TkSpecialLParen -> MP.try (cmdOperandThenInfix cmdParenParser) <|> exprHeadedCmdParser
+    _ -> exprHeadedCmdParser
+
+exprHeadedCmdParser :: TokParser Cmd
+exprHeadedCmdParser = do
+  -- Parse the left side as an expression while leaving -< / -<< available
+  -- for command parsing.
+  expr <- exprParserNoArrowTail
+  mArrowTail <- MP.optional cmdArrTailParser
+  case mArrowTail of
+    Just (appType, rhs) ->
+      cmdInfixChain (CmdArrApp expr appType rhs)
+    Nothing -> do
+      mTok <- MP.optional (lookAhead anySingle)
+      MP.customFailure
+        UnexpectedTokenExpecting
+          { unexpectedFound = mkFoundToken <$> mTok,
+            unexpectedExpecting = "arrow command (-< or -<<)",
+            unexpectedContext = []
+          }
 
 -- | Parse a cmd10 operand, then check for command-level infix.
 cmdOperandThenInfix :: TokParser Cmd -> TokParser Cmd

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -718,7 +718,7 @@ functionBinderNameParser =
           TkVarSym ident -> Just (mkUnqualifiedName NameVarSym ident)
           _ -> Nothing
 
-functionBindValue :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs -> ValueDecl
+functionBindValue :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs Expr -> ValueDecl
 functionBindValue headForm name pats rhs =
   FunctionBind
     name
@@ -730,7 +730,7 @@ functionBindValue headForm name pats rhs =
         }
     ]
 
-functionBindDecl :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs -> Decl
+functionBindDecl :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs Expr -> Decl
 functionBindDecl headForm name pats rhs =
   DeclValue (functionBindValue headForm name pats rhs)
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -212,7 +212,7 @@ qualifiedMdoExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
 procExprParser :: TokParser Expr
 procExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkKeywordProc
-  pat <- region "while parsing proc pattern" simplePatternParser
+  pat <- region "while parsing proc pattern" patternParser
   expectedTok TkReservedRightArrow
   body <- region "while parsing proc body" cmdParser
   pure (EProc pat body)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -5,6 +5,7 @@ module Aihc.Parser.Internal.Expr
   ( exprParser,
     atomExprParser,
     equationRhsParser,
+    caseRhsParserWithBodyParser,
     -- Re-exports from Pattern
     simplePatternParser,
     appPatternParser,
@@ -67,10 +68,6 @@ exprParserWithTypeSigParser :: TokParser Type -> TokParser Expr
 exprParserWithTypeSigParser typeSigParser =
   label "expression" $
     exprCoreParserWithTypeSigParserExcept typeSigParser []
-
-exprParserExcept :: [Text] -> TokParser Expr
-exprParserExcept =
-  exprCoreParserWithTypeSigParserExcept typeParser
 
 exprCoreParserWithoutTypeSigExcept :: [Text] -> TokParser Expr
 exprCoreParserWithoutTypeSigExcept forbiddenInfix = do
@@ -165,7 +162,7 @@ multiWayIfExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   rhss <- braces (MP.some multiWayIfAlternative)
   pure (EMultiWayIf rhss)
 
-multiWayIfAlternative :: TokParser GuardedRhs
+multiWayIfAlternative :: TokParser (GuardedRhs Expr)
 multiWayIfAlternative = withSpan $ do
   expectedTok TkReservedPipe
   guards <- layoutSepBy1 (guardQualifierParser RhsArrowCase) (expectedTok TkSpecialComma)
@@ -563,11 +560,14 @@ operatorExprNameParser =
       TkReservedDotDot -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym ".."))
       _ -> Nothing
 
-rhsParser :: TokParser Rhs
-rhsParser = label "right-hand side" (rhsParserWithArrow RhsArrowCase)
+rhsParser :: TokParser (Rhs Expr)
+rhsParser = label "right-hand side" (caseRhsParserWithBodyParser exprParser)
 
-equationRhsParser :: TokParser Rhs
-equationRhsParser = label "equation right-hand side" (rhsParserWithArrow RhsArrowEquation)
+equationRhsParser :: TokParser (Rhs Expr)
+equationRhsParser = label "equation right-hand side" (rhsParserWithBodyParser RhsArrowEquation exprParser)
+
+caseRhsParserWithBodyParser :: TokParser body -> TokParser (Rhs body)
+caseRhsParserWithBodyParser = rhsParserWithBodyParser RhsArrowCase
 
 data RhsArrowKind = RhsArrowCase | RhsArrowEquation
 
@@ -579,13 +579,13 @@ rhsArrowTok :: RhsArrowKind -> TokParser ()
 rhsArrowTok RhsArrowCase = expectedTok TkReservedRightArrow
 rhsArrowTok RhsArrowEquation = expectedTok TkReservedEquals
 
-rhsParserWithArrow :: RhsArrowKind -> TokParser Rhs
-rhsParserWithArrow arrowKind = do
+rhsParserWithBodyParser :: RhsArrowKind -> TokParser body -> TokParser (Rhs body)
+rhsParserWithBodyParser arrowKind bodyParser = do
   tok <- lookAhead anySingle
   case lexTokenKind tok of
-    TkReservedPipe -> guardedRhssParser arrowKind
-    TkReservedRightArrow | RhsArrowCase <- arrowKind -> unguardedRhsParser arrowKind
-    TkReservedEquals | RhsArrowEquation <- arrowKind -> unguardedRhsParser arrowKind
+    TkReservedPipe -> guardedRhssParserWithBodyParser arrowKind bodyParser
+    TkReservedRightArrow | RhsArrowCase <- arrowKind -> unguardedRhsParserWithBodyParser arrowKind bodyParser
+    TkReservedEquals | RhsArrowEquation <- arrowKind -> unguardedRhsParserWithBodyParser arrowKind bodyParser
     _ ->
       MP.customFailure
         UnexpectedTokenExpecting
@@ -594,10 +594,10 @@ rhsParserWithArrow arrowKind = do
             unexpectedContext = []
           }
 
-unguardedRhsParser :: RhsArrowKind -> TokParser Rhs
-unguardedRhsParser arrowKind = withSpan $ do
+unguardedRhsParserWithBodyParser :: RhsArrowKind -> TokParser body -> TokParser (Rhs body)
+unguardedRhsParserWithBodyParser arrowKind bodyParser = withSpan $ do
   rhsArrowTok arrowKind
-  body <- region (rhsContextText arrowKind) exprParser
+  body <- region (rhsContextText arrowKind) bodyParser
   whereDecls <- MP.optional whereClauseParser
   pure (\span' -> UnguardedRhs [mkAnnotation span'] body whereDecls)
 
@@ -605,18 +605,18 @@ rhsContextText :: RhsArrowKind -> Text
 rhsContextText RhsArrowCase = "while parsing case alternative right-hand side"
 rhsContextText RhsArrowEquation = "while parsing equation right-hand side"
 
-guardedRhssParser :: RhsArrowKind -> TokParser Rhs
-guardedRhssParser arrowKind = withSpan $ do
-  grhss <- MP.some (guardedRhsParser arrowKind)
+guardedRhssParserWithBodyParser :: RhsArrowKind -> TokParser body -> TokParser (Rhs body)
+guardedRhssParserWithBodyParser arrowKind bodyParser = withSpan $ do
+  grhss <- MP.some (guardedRhsParserWithBodyParser arrowKind bodyParser)
   whereDecls <- MP.optional whereClauseParser
   pure (\span' -> GuardedRhss [mkAnnotation span'] grhss whereDecls)
 
-guardedRhsParser :: RhsArrowKind -> TokParser GuardedRhs
-guardedRhsParser arrowKind = withSpan $ do
+guardedRhsParserWithBodyParser :: RhsArrowKind -> TokParser body -> TokParser (GuardedRhs body)
+guardedRhsParserWithBodyParser arrowKind bodyParser = withSpan $ do
   expectedTok TkReservedPipe
   guards <- layoutSepBy1 (guardQualifierParser arrowKind) (expectedTok TkSpecialComma)
   rhsArrowTok arrowKind
-  body <- exprParserExcept ["|", rhsArrowText arrowKind]
+  body <- bodyParser
   pure $ \span' ->
     GuardedRhs
       { guardedRhsAnns = [mkAnnotation span'],
@@ -672,7 +672,7 @@ guardTypeSigParser :: RhsArrowKind -> TokParser Type
 guardTypeSigParser RhsArrowEquation = typeParser
 guardTypeSigParser RhsArrowCase = typeInfixParser
 
-caseAltParser :: TokParser CaseAlt
+caseAltParser :: TokParser (CaseAlt Expr)
 caseAltParser = withSpan $ do
   pat <- region "while parsing case alternative" patternParser
   rhs <- region "while parsing case alternative" rhsParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs-boot
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs-boot
@@ -20,7 +20,10 @@ atomExprParser :: TokParser Expr
 exprParserNoArrowTail :: TokParser Expr
 
 -- | Parse the right-hand side of an equation (guarded or unguarded)
-equationRhsParser :: TokParser Rhs
+equationRhsParser :: TokParser (Rhs Expr)
+
+-- | Parse a case-style right-hand side with a custom body parser.
+caseRhsParserWithBodyParser :: TokParser body -> TokParser (Rhs body)
 
 -- | Parse let declarations (keyword 'let' followed by braced or plain decls)
 parseLetDeclsParser :: TokParser [Decl]

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -283,7 +283,7 @@ varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
 
 recordFieldPatternParser :: TokParser (RecordField Pattern)
 recordFieldPatternParser = do
-  field <- identifierNameParser
+  field <- identifierNameParser <|> parens operatorNameParser
   mEq <- MP.optional (expectedTok TkReservedEquals)
   case mEq of
     Just () -> do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -383,7 +383,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
     -- Returns Nothing if the content is not a view pattern.
     viewPatternParser :: LexTokenKind -> TokParser (Maybe Pattern)
     viewPatternParser closeTok = MP.optional . MP.try $ do
-      expr <- exprParser
+      expr <- exprParser <* lookAhead (expectedTok TkReservedRightArrow)
       expectedTok TkReservedRightArrow
       inner <- subpatternWithBareViewParser
       expectedTok closeTok

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1136,9 +1136,14 @@ addPatternViewInnerParens pat =
 
 addViewExprParens :: Expr -> Expr
 addViewExprParens expr =
-  if endsWithTypeSig expr
+  if endsWithTypeSig expr || isProcExpr expr
     then wrapExpr True (addExprParens expr)
     else addExprParens expr
+  where
+    isProcExpr e =
+      case peelExprAnn e of
+        EProc {} -> True
+        _ -> False
 
 -- | Check if an operator is the cons operator ':'.
 isConsOperator :: Name -> Bool
@@ -1201,6 +1206,7 @@ addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
+    PTypeSyntax {} -> wrapPat True (addPatternParens pat)
     PCon _ typeArgs args
       | not (null typeArgs) || not (null args) -> wrapPat True (addPatternParens pat)
     PRecord {} -> addPatternParens pat
@@ -1225,6 +1231,7 @@ addPatternAtomStrictParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternAtomStrictParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
+    PTypeSyntax {} -> wrapPat True (addPatternParens pat)
     PCon _ (_ : _) [] -> wrapPat True (addPatternParens pat)
     PStrict {} -> wrapPat True (addPatternParens pat)
     PIrrefutable {} -> wrapPat True (addPatternParens pat)
@@ -1243,7 +1250,7 @@ addCmdParens cmd =
     CmdArrApp lhs appTy rhs ->
       CmdArrApp (addExprParensPrec 1 lhs) appTy (addExprParens rhs)
     CmdInfix l op r ->
-      CmdInfix (addCmdParens l) op (addCmdParens r)
+      CmdInfix (wrapCmdOperand (addCmdParens l)) op (wrapCmdOperand (addCmdParens r))
     CmdDo stmts ->
       CmdDo (map addCmdDoStmtParens stmts)
     CmdIf cond yes no ->
@@ -1258,6 +1265,16 @@ addCmdParens cmd =
       CmdApp (addCmdParens c) (addExprParensPrec 3 e)
     CmdPar c ->
       CmdPar (addCmdParens c)
+  where
+    wrapCmdOperand inner =
+      case peelCmdAnn inner of
+        CmdArrApp {} -> CmdPar inner
+        CmdLet {} -> CmdPar inner
+        CmdIf {} -> CmdPar inner
+        CmdCase {} -> CmdPar inner
+        CmdLam {} -> CmdPar inner
+        CmdInfix {} -> CmdPar inner
+        _ -> inner
 
 addCmdDoStmtParens :: DoStmt Cmd -> DoStmt Cmd
 addCmdDoStmtParens stmt =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -447,7 +447,7 @@ addFunctionHeadPats _name headForm pats =
                   lhs' : rhs' : map addFunctionHeadPatternAtomParens tailPats
         _ -> map addFunctionHeadPatternAtomParens pats
 
-addRhsParens :: Rhs -> Rhs
+addRhsParens :: Rhs Expr -> Rhs Expr
 addRhsParens rhs =
   case rhs of
     UnguardedRhs sp body whereDecls ->
@@ -455,7 +455,7 @@ addRhsParens rhs =
     GuardedRhss sp guards whereDecls ->
       GuardedRhss sp (map (addGuardedRhsParens GuardEquals) guards) (fmap (map addDeclParens) whereDecls)
 
-addGuardedRhsParens :: GuardArrow -> GuardedRhs -> GuardedRhs
+addGuardedRhsParens :: GuardArrow -> GuardedRhs Expr -> GuardedRhs Expr
 addGuardedRhsParens arrow grhs =
   grhs
     { guardedRhsGuards = map (addGuardQualifierParens arrow) (guardedRhsGuards grhs),
@@ -887,7 +887,7 @@ addNegateParens inner =
     then wrapExpr True (addExprParens inner)
     else addExprParensPrec 3 inner
 
-addCaseAltParens :: CaseAlt -> CaseAlt
+addCaseAltParens :: CaseAlt Expr -> CaseAlt Expr
 addCaseAltParens (CaseAlt sp pat rhs) =
   CaseAlt sp (addPatternParens pat) (addCaseAltRhsParens rhs)
 
@@ -899,7 +899,7 @@ addLambdaCaseAltParens (LambdaCaseAlt sp pats rhs) =
         _ -> map addPatternAtomParens pats
    in LambdaCaseAlt sp pats' (addCaseAltRhsParens rhs)
 
-addCaseAltRhsParens :: Rhs -> Rhs
+addCaseAltRhsParens :: Rhs Expr -> Rhs Expr
 addCaseAltRhsParens rhs =
   case rhs of
     UnguardedRhs sp body whereDecls ->
@@ -1285,9 +1285,21 @@ addCmdDoStmtParens stmt =
     DoExpr cmd' -> DoExpr (addCmdParens cmd')
     DoRecStmt stmts -> DoRecStmt (map addCmdDoStmtParens stmts)
 
-addCmdCaseAltParens :: CmdCaseAlt -> CmdCaseAlt
-addCmdCaseAltParens alt =
-  alt
-    { cmdCaseAltPat = addPatternParens (cmdCaseAltPat alt),
-      cmdCaseAltBody = addCmdParens (cmdCaseAltBody alt)
+addCmdCaseAltParens :: CaseAlt Cmd -> CaseAlt Cmd
+addCmdCaseAltParens (CaseAlt anns pat rhs) =
+  CaseAlt anns (addPatternParens pat) (addCmdCaseAltRhsParens rhs)
+
+addCmdCaseAltRhsParens :: Rhs Cmd -> Rhs Cmd
+addCmdCaseAltRhsParens rhs =
+  case rhs of
+    UnguardedRhs sp body whereDecls ->
+      UnguardedRhs sp (addCmdParens body) (fmap (map addDeclParens) whereDecls)
+    GuardedRhss sp guards whereDecls ->
+      GuardedRhss sp (map addCmdGuardedRhsParens guards) (fmap (map addDeclParens) whereDecls)
+
+addCmdGuardedRhsParens :: GuardedRhs Cmd -> GuardedRhs Cmd
+addCmdGuardedRhsParens grhs =
+  grhs
+    { guardedRhsGuards = map (addGuardQualifierParens GuardArrow) (guardedRhsGuards grhs),
+      guardedRhsBody = addCmdParens (guardedRhsBody grhs)
     }

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -354,22 +354,25 @@ prettyFunctionHead name headForm pats =
         _ ->
           hsep (prettyBinderUName name : map prettyPattern pats)
 
-prettyRhs :: Rhs -> Doc ann
-prettyRhs rhs =
+prettyRhsWith :: (body -> Doc ann) -> Text -> Rhs body -> Doc ann
+prettyRhsWith prettyBody arrow rhs =
   case rhs of
-    UnguardedRhs _ expr whereDecls ->
-      "="
-        <+> prettyExpr expr
+    UnguardedRhs _ body whereDecls ->
+      pretty arrow
+        <+> prettyBody body
         <> prettyWhereClause whereDecls
     GuardedRhss _ guards whereDecls ->
       hsep
         [ "|"
             <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
-            <+> "="
-            <+> prettyExpr (guardedRhsBody grhs)
+            <+> pretty arrow
+            <+> prettyBody (guardedRhsBody grhs)
         | grhs <- guards
         ]
         <> prettyWhereClause whereDecls
+
+prettyRhs :: Rhs Expr -> Doc ann
+prettyRhs = prettyRhsWith prettyExpr "="
 
 prettyWhereClause :: Maybe [Decl] -> Doc ann
 prettyWhereClause Nothing = mempty
@@ -1185,13 +1188,13 @@ prettyBinding field =
     then prettyName (recordFieldName field)
     else prettyName (recordFieldName field) <+> "=" <+> prettyExpr (recordFieldValue field)
 
-prettyCaseAlt :: CaseAlt -> Doc ann
-prettyCaseAlt (CaseAlt _ pat rhs) =
+prettyCaseAltWith :: (body -> Doc ann) -> CaseAlt body -> Doc ann
+prettyCaseAltWith prettyBody (CaseAlt _ pat rhs) =
   case rhs of
     UnguardedRhs _ body whereDecls ->
       prettyPattern pat
         <+> "->"
-        <+> prettyExpr body
+        <+> prettyBody body
         <> prettyWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
       hsep
@@ -1200,11 +1203,14 @@ prettyCaseAlt (CaseAlt _ pat rhs) =
             [ "|"
                 <+> hsep (punctuate comma (map prettyGuardQualifier (guardedRhsGuards grhs)))
                 <+> "->"
-                <+> prettyExpr (guardedRhsBody grhs)
+                <+> prettyBody (guardedRhsBody grhs)
             | grhs <- grhss
             ]
         ]
         <> prettyWhereClause whereDecls
+
+prettyCaseAlt :: CaseAlt Expr -> Doc ann
+prettyCaseAlt = prettyCaseAltWith prettyExpr
 
 prettyLambdaCaseAlt :: LambdaCaseAlt -> Doc ann
 prettyLambdaCaseAlt (LambdaCaseAlt _ pats rhs) =
@@ -1285,9 +1291,8 @@ prettyCmdStmt stmt =
     DoExpr cmd' -> prettyCmd cmd'
     DoRecStmt stmts -> "rec" <+> "{" <+> hsep (punctuate semi (map prettyCmdStmt stmts)) <+> "}"
 
-prettyCmdCaseAlt :: CmdCaseAlt -> Doc ann
-prettyCmdCaseAlt alt =
-  prettyPattern (cmdCaseAltPat alt) <+> "->" <+> prettyCmd (cmdCaseAltBody alt)
+prettyCmdCaseAlt :: CaseAlt Cmd -> Doc ann
+prettyCmdCaseAlt = prettyCaseAltWith prettyCmd
 
 prettyCompStmt :: CompStmt -> Doc ann
 prettyCompStmt stmt =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -495,19 +495,11 @@ prettyPattern pat =
     PSplice body -> "$" <> prettyExpr body
 
 -- | Pretty print a pattern field binding.
-<<<<<<< HEAD
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann
 prettyPatternFieldBinding field =
   if recordFieldPun field
     then pretty (recordFieldName field)
     else pretty (recordFieldName field) <+> "=" <+> prettyPattern (recordFieldValue field)
-=======
-prettyPatternFieldBinding :: Name -> Pattern -> Doc ann
-prettyPatternFieldBinding fieldName fieldPat =
-  case peelPatternAnn fieldPat of
-    PVar varName | renderUnqualifiedName varName == renderName fieldName -> prettyPrefixName fieldName
-    _ -> prettyPrefixName fieldName <+> "=" <+> prettyPattern fieldPat
->>>>>>> b7d5c7609 (fix(parser): cover proc roundtrip generation)
 
 prettyLiteral :: Literal -> Doc ann
 prettyLiteral lit =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -462,6 +462,7 @@ prettyPattern pat =
     PWildcard -> "_"
     PLit lit -> prettyLiteral lit
     PQuasiQuote quoter body -> prettyQuasiQuote quoter body
+    PTuple Unboxed [] -> "(# #)"
     PTuple tupleFlavor elems -> prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyPattern elems)))
     PUnboxedSum altIdx arity inner ->
       let slots = [if i == altIdx then prettyPattern inner else mempty | i <- [0 .. arity - 1]]
@@ -491,11 +492,19 @@ prettyPattern pat =
     PSplice body -> "$" <> prettyExpr body
 
 -- | Pretty print a pattern field binding.
+<<<<<<< HEAD
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann
 prettyPatternFieldBinding field =
   if recordFieldPun field
     then pretty (recordFieldName field)
     else pretty (recordFieldName field) <+> "=" <+> prettyPattern (recordFieldValue field)
+=======
+prettyPatternFieldBinding :: Name -> Pattern -> Doc ann
+prettyPatternFieldBinding fieldName fieldPat =
+  case peelPatternAnn fieldPat of
+    PVar varName | renderUnqualifiedName varName == renderName fieldName -> prettyPrefixName fieldName
+    _ -> prettyPrefixName fieldName <+> "=" <+> prettyPattern fieldPat
+>>>>>>> b7d5c7609 (fix(parser): cover proc roundtrip generation)
 
 prettyLiteral :: Literal -> Doc ann
 prettyLiteral lit =
@@ -1139,6 +1148,7 @@ prettyExpr expr =
     ETypeSig inner ty -> prettyExpr inner <+> "::" <+> prettyType ty
     EParen inner -> parens (prettyExpr inner)
     EList values -> brackets (hsep (punctuate comma (map prettyExpr values)))
+    ETuple Unboxed [] -> "(# #)"
     ETuple tupleFlavor values ->
       prettyTupleBody
         tupleFlavor

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -286,17 +286,23 @@ docMatchHeadForm headForm =
     MatchHeadPrefix -> "Prefix"
     MatchHeadInfix -> "Infix"
 
-docRhs :: Rhs -> Doc ann
-docRhs rhs =
+docRhsWith :: (body -> Doc ann) -> Rhs body -> Doc ann
+docRhsWith docBody rhs =
   case rhs of
-    UnguardedRhs _ expr Nothing -> "UnguardedRhs" <+> parens (docExpr expr)
-    UnguardedRhs _ expr (Just decls) -> "UnguardedRhs" <+> parens (docExpr expr) <+> "where" <+> brackets (hsep (punctuate comma (map docDecl decls)))
-    GuardedRhss _ grhss Nothing -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map docGuardedRhs grhss)))
-    GuardedRhss _ grhss (Just decls) -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map docGuardedRhs grhss))) <+> "where" <+> brackets (hsep (punctuate comma (map docDecl decls)))
+    UnguardedRhs _ body Nothing -> "UnguardedRhs" <+> parens (docBody body)
+    UnguardedRhs _ body (Just decls) -> "UnguardedRhs" <+> parens (docBody body) <+> "where" <+> brackets (hsep (punctuate comma (map docDecl decls)))
+    GuardedRhss _ grhss Nothing -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map (docGuardedRhsWith docBody) grhss)))
+    GuardedRhss _ grhss (Just decls) -> "GuardedRhss" <+> brackets (hsep (punctuate comma (map (docGuardedRhsWith docBody) grhss))) <+> "where" <+> brackets (hsep (punctuate comma (map docDecl decls)))
 
-docGuardedRhs :: GuardedRhs -> Doc ann
-docGuardedRhs grhs =
-  "GuardedRhs" <+> braces (hsep (punctuate comma [field "guards" (brackets (hsep (punctuate comma (map docGuardQualifier (guardedRhsGuards grhs))))), field "body" (docExpr (guardedRhsBody grhs))]))
+docRhs :: Rhs Expr -> Doc ann
+docRhs = docRhsWith docExpr
+
+docGuardedRhsWith :: (body -> Doc ann) -> GuardedRhs body -> Doc ann
+docGuardedRhsWith docBody grhs =
+  "GuardedRhs" <+> braces (hsep (punctuate comma [field "guards" (brackets (hsep (punctuate comma (map docGuardQualifier (guardedRhsGuards grhs))))), field "body" (docBody (guardedRhsBody grhs))]))
+
+docGuardedRhs :: GuardedRhs Expr -> Doc ann
+docGuardedRhs = docGuardedRhsWith docExpr
 
 docGuardQualifier :: GuardQualifier -> Doc ann
 docGuardQualifier gq =
@@ -817,9 +823,12 @@ docExprRecordField recordField =
     <+> (if recordFieldPun recordField then "~pun" else "=")
     <+> docExpr (recordFieldValue recordField)
 
-docCaseAlt :: CaseAlt -> Doc ann
-docCaseAlt (CaseAlt _ pat rhs) =
-  "CaseAlt" <+> parens (docPattern pat) <+> parens (docRhs rhs)
+docCaseAltWith :: (body -> Doc ann) -> CaseAlt body -> Doc ann
+docCaseAltWith docBody (CaseAlt _ pat rhs) =
+  "CaseAlt" <+> parens (docPattern pat) <+> parens (docRhsWith docBody rhs)
+
+docCaseAlt :: CaseAlt Expr -> Doc ann
+docCaseAlt = docCaseAltWith docExpr
 
 docLambdaCaseAlt :: LambdaCaseAlt -> Doc ann
 docLambdaCaseAlt (LambdaCaseAlt _ pats rhs) =
@@ -876,9 +885,8 @@ docCmdStmt stmt =
     DoExpr cmd' -> "DoExpr" <+> parens (docCmd cmd')
     DoRecStmt stmts -> "DoRecStmt" <+> brackets (hsep (punctuate comma (map docCmdStmt stmts)))
 
-docCmdCaseAlt :: CmdCaseAlt -> Doc ann
-docCmdCaseAlt alt =
-  "CmdCaseAlt" <+> parens (docPattern (cmdCaseAltPat alt)) <+> parens (docCmd (cmdCaseAltBody alt))
+docCmdCaseAlt :: CaseAlt Cmd -> Doc ann
+docCmdCaseAlt = docCaseAltWith docCmd
 
 docArithSeq :: ArithSeq -> Doc ann
 docArithSeq seqInfo =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -20,7 +20,6 @@ module Aihc.Parser.Syntax
     ClassDecl (..),
     ClassDeclItem (..),
     Cmd (..),
-    CmdCaseAlt (..),
     CompStmt (..),
     FunctionalDependency (..),
     TypeFamilyResultSig (..),
@@ -993,14 +992,14 @@ peelDeclAnn d = d
 
 data ValueDecl
   = FunctionBind BinderName [Match]
-  | PatternBind Pattern Rhs
+  | PatternBind Pattern (Rhs Expr)
   deriving (Data, Eq, Show, Generic, NFData)
 
 data Match = Match
   { matchAnns :: [Annotation],
     matchHeadForm :: MatchHeadForm,
     matchPats :: [Pattern],
-    matchRhs :: Rhs
+    matchRhs :: Rhs Expr
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -1038,15 +1037,15 @@ data PatSynDecl = PatSynDecl
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
-data Rhs
-  = UnguardedRhs [Annotation] Expr (Maybe [Decl])
-  | GuardedRhss [Annotation] [GuardedRhs] (Maybe [Decl])
+data Rhs body
+  = UnguardedRhs [Annotation] body (Maybe [Decl])
+  | GuardedRhss [Annotation] [GuardedRhs body] (Maybe [Decl])
   deriving (Data, Eq, Show, Generic, NFData)
 
-data GuardedRhs = GuardedRhs
+data GuardedRhs body = GuardedRhs
   { guardedRhsAnns :: [Annotation],
     guardedRhsGuards :: [GuardQualifier],
-    guardedRhsBody :: Expr
+    guardedRhsBody :: body
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -1701,16 +1700,16 @@ data Expr
   | EOverloadedLabel Text Text
   | EQuasiQuote Text Text
   | EIf Expr Expr Expr
-  | EMultiWayIf [GuardedRhs]
+  | EMultiWayIf [GuardedRhs Expr]
   | ELambdaPats [Pattern] Expr
-  | ELambdaCase [CaseAlt]
+  | ELambdaCase [CaseAlt Expr]
   | ELambdaCases [LambdaCaseAlt]
   | EInfix Expr Name Expr
   | ENegate Expr
   | ESectionL Expr Name
   | ESectionR Name Expr
   | ELetDecls [Decl] Expr
-  | ECase Expr [CaseAlt]
+  | ECase Expr [CaseAlt Expr]
   | EDo [DoStmt Expr] DoFlavor
   | EListComp Expr [CompStmt]
   | EListCompParallel Expr [[CompStmt]]
@@ -1754,17 +1753,17 @@ peelExprAnn :: Expr -> Expr
 peelExprAnn (EAnn _ x) = peelExprAnn x
 peelExprAnn x = x
 
-data CaseAlt = CaseAlt
+data CaseAlt body = CaseAlt
   { caseAltAnns :: [Annotation],
     caseAltPattern :: Pattern,
-    caseAltRhs :: Rhs
+    caseAltRhs :: Rhs body
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
 data LambdaCaseAlt = LambdaCaseAlt
   { lambdaCaseAltAnns :: [Annotation],
     lambdaCaseAltPats :: [Pattern],
-    lambdaCaseAltRhs :: Rhs
+    lambdaCaseAltRhs :: Rhs Expr
   }
   deriving (Data, Eq, Show, Generic, NFData)
 
@@ -1815,7 +1814,7 @@ data Cmd
   | -- | @if exp then cmd else cmd@
     CmdIf Expr Cmd Cmd
   | -- | @case exp of { calts }@
-    CmdCase Expr [CmdCaseAlt]
+    CmdCase Expr [CaseAlt Cmd]
   | -- | @let decls in cmd@
     CmdLet [Decl] Cmd
   | -- | @\\pats -> cmd@
@@ -1841,14 +1840,6 @@ getCmdSourceSpan cmd =
       | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
       | otherwise -> getCmdSourceSpan sub
     _ -> NoSourceSpan
-
--- | Case alternative with a command body (used in arrow @case@ commands).
-data CmdCaseAlt = CmdCaseAlt
-  { cmdCaseAltAnns :: [Annotation],
-    cmdCaseAltPat :: Pattern,
-    cmdCaseAltBody :: Cmd
-  }
-  deriving (Data, Eq, Show, Generic, NFData)
 
 data CompStmt
   = -- | Metadata for the whole comprehension statement (typically a 'SourceSpan' via 'mkAnnotation').

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -31,7 +31,7 @@ import Test.Properties.Arb.Decl (genDeclClass, genDeclDataFamilyInst, genDeclTyp
 import Test.Properties.Arb.Module (genTypeName)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprHelpers (normalizeDecl, normalizeExpr, stripTypeAnnotations)
-import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
+import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip, test_exprPrettyRoundTrip_procExpression, test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote)
 import Test.Properties.Identifiers
   ( genConSym,
     genVarSym,
@@ -438,6 +438,7 @@ buildTests = do
           testGroup
             "properties"
             [ testCase "qualified Unicode TH name quote round-trips" test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote,
+              testCase "proc expression round-trips" test_exprPrettyRoundTrip_procExpression,
               QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/pandoc-arrow-case-pattern-guard-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/pandoc-arrow-case-pattern-guard-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail pattern guard in arrow case expression not supported -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE PatternGuards #-}
 module PandocArrowCasePatternGuard where

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -1070,7 +1070,7 @@ shrinkMatch match =
 
 -- | Shrink an RHS: try removing the where clause, simplifying guards to
 -- unguarded, and recursively shrinking sub-expressions.
-shrinkRhs :: Rhs -> [Rhs]
+shrinkRhs :: Rhs Expr -> [Rhs Expr]
 shrinkRhs rhs =
   case rhs of
     UnguardedRhs _ expr mWhere ->
@@ -1097,7 +1097,7 @@ shrinkWhereDecls ds =
   [ds' | ds' <- shrinkList shrinkDecl ds, not (null ds')]
 
 -- | Shrink a guarded RHS: shrink the body and the guards.
-shrinkGuardedRhs :: GuardedRhs -> [GuardedRhs]
+shrinkGuardedRhs :: GuardedRhs Expr -> [GuardedRhs Expr]
 shrinkGuardedRhs grhs =
   [grhs {guardedRhsBody = body'} | body' <- shrinkExpr (guardedRhsBody grhs)]
     <> [grhs {guardedRhsGuards = gs'} | gs' <- shrinkList shrinkGuardQualifier (guardedRhsGuards grhs), not (null gs')]

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -77,6 +77,7 @@ genExprWith allowTHQuotes = scale (`div` 2) $ do
         ETypeSig <$> genExprWith allowTHQuotes <*> genTypeWith allowTHQuotes,
         ETypeApp <$> genExprWith allowTHQuotes <*> genTypeWith allowTHQuotes,
         EParen <$> genExprWith allowTHQuotes,
+        EProc <$> genSimplePatternWith allowTHQuotes <*> genCmdWith allowTHQuotes,
         -- Template Haskell splices are valid inside quote bodies.
         ETHSplice <$> genSpliceBody,
         ETHTypedSplice <$> genTypedSpliceBody
@@ -170,6 +171,97 @@ genTypeNameQuoteType =
 -- | Generate simple patterns for lambdas
 genPatterns :: Gen [Pattern]
 genPatterns = smallList1 genPattern
+
+-- | Generate a subset accepted by 'simplePatternParser', used in @proc@ and
+-- command lambda binders.
+genSimplePatternWith :: Bool -> Gen Pattern
+genSimplePatternWith allowTHQuotes = scale (`div` 2) $ do
+  n <- getSize
+  if n <= 0
+    then oneof simplePatternLeafGenerators
+    else oneof (simplePatternLeafGenerators <> simplePatternRecursiveGenerators)
+  where
+    simplePatternLeafGenerators =
+      [ PVar <$> genSimplePatternUnqualVarName,
+        pure PWildcard,
+        PLit <$> genLiteral,
+        PQuasiQuote <$> genQuasiQuoteName <*> genStringValue,
+        PTuple Boxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
+        pure (PList []),
+        PCon <$> genConName <*> pure [] <*> pure []
+      ]
+    simplePatternRecursiveGenerators =
+      [ PAs <$> genVarId <*> genSimplePatternAtomWith allowTHQuotes,
+        PStrict <$> genSimplePatternAtomWith allowTHQuotes,
+        PIrrefutable <$> genSimplePatternAtomWith allowTHQuotes,
+        PList <$> smallList0 (genSimplePatternAtomWith allowTHQuotes),
+        PTuple Boxed <$> genSimpleTupleElemsWith allowTHQuotes,
+        genSimpleRecordPatternWith allowTHQuotes
+      ]
+
+genSimplePatternAtomWith :: Bool -> Gen Pattern
+genSimplePatternAtomWith _ =
+  oneof
+    [ PVar <$> genSimplePatternUnqualVarName,
+      pure PWildcard,
+      PLit <$> genLiteral,
+      PQuasiQuote <$> genQuasiQuoteName <*> genStringValue,
+      pure (PTuple Boxed []),
+      pure (PList []),
+      PCon <$> genConName <*> pure [] <*> pure []
+    ]
+
+genSimpleTupleElemsWith :: Bool -> Gen [Pattern]
+genSimpleTupleElemsWith allowTHQuotes =
+  oneof
+    [ pure [],
+      do
+        count <- chooseInt (2, 4)
+        scale (`div` count) $ vectorOf count (genSimplePatternAtomWith allowTHQuotes)
+    ]
+
+genSimpleRecordPatternWith :: Bool -> Gen Pattern
+genSimpleRecordPatternWith allowTHQuotes = do
+  con <- genConName
+  count <- chooseInt (0, 3)
+  names <- vectorOf count genVarName
+  pats <- vectorOf count (genSimplePatternAtomWith allowTHQuotes)
+  pure (PRecord con (zip names pats) False)
+
+genSimplePatternUnqualVarName :: Gen UnqualifiedName
+genSimplePatternUnqualVarName = mkUnqualifiedName NameVarId <$> genVarId
+
+genLiteral :: Gen Literal
+genLiteral =
+  oneof
+    [ mkIntLiteral <$> chooseInteger (0, 999),
+      mkHexLiteral <$> chooseInteger (0, 255),
+      mkFloatLiteral <$> genTenths,
+      mkCharLiteral <$> genCharValue,
+      mkStringLiteral <$> genStringValue
+    ]
+
+genCmdWith :: Bool -> Gen Cmd
+genCmdWith allowTHQuotes = scale (`div` 2) $ genCmdLeafWith allowTHQuotes
+
+genCmdLeafWith :: Bool -> Gen Cmd
+genCmdLeafWith allowTHQuotes =
+  CmdArrApp <$> genCmdExprWith allowTHQuotes <*> genArrAppType <*> genCmdExprWith allowTHQuotes
+
+genArrAppType :: Gen ArrAppType
+genArrAppType = elements [HsFirstOrderApp, HsHigherOrderApp]
+
+genCmdExprWith :: Bool -> Gen Expr
+genCmdExprWith _ =
+  oneof
+    [ EVar <$> genVarName,
+      mkIntExpr <$> chooseInteger (0, 999),
+      mkFloatExpr <$> genTenths,
+      mkCharExpr <$> genCharValue,
+      mkStringExpr <$> genStringValue,
+      pure (EList []),
+      pure (ETuple Boxed [])
+    ]
 
 genCaseAltsWith :: Bool -> Gen [CaseAlt]
 genCaseAltsWith allowTHQuotes = smallList0 (genCaseAltWith allowTHQuotes)
@@ -425,6 +517,21 @@ genTypeListElemsWith allowTHQuotes = do
 genTypeVarName :: Gen UnqualifiedName
 genTypeVarName = mkUnqualifiedName NameVarId <$> genVarId
 
+mkIntLiteral :: Integer -> Literal
+mkIntLiteral value = LitInt value TInteger (T.pack (show value))
+
+mkHexLiteral :: Integer -> Literal
+mkHexLiteral value = LitInt value TInteger ("0x" <> T.pack (showHex value))
+
+mkFloatLiteral :: Rational -> Literal
+mkFloatLiteral value = LitFloat value TFractional (renderFloat value)
+
+mkCharLiteral :: Char -> Literal
+mkCharLiteral value = LitChar value (T.pack (show value))
+
+mkStringLiteral :: Text -> Literal
+mkStringLiteral value = LitString value (T.pack (show (T.unpack value)))
+
 -- | Literal expression constructors
 mkHexExpr :: Integer -> Expr
 mkHexExpr value = EInt value TInteger ("0x" <> T.pack (showHex value))
@@ -573,8 +680,136 @@ shrinkExpr expr =
     ETHTypeNameQuote ty -> [ETHTypeNameQuote ty' | ty' <- shrinkType ty]
     ETHSplice body -> body : [ETHSplice body' | body' <- shrinkExpr body]
     ETHTypedSplice body -> body : [ETHTypedSplice body' | body' <- shrinkExpr body]
-    EProc {} -> []
+    EProc pat body ->
+      [EProc pat' body | pat' <- shrinkSimplePattern pat]
+        <> [EProc pat body' | body' <- shrinkCmd body]
     EAnn _ sub -> shrinkExpr sub
+
+shrinkSimplePattern :: Pattern -> [Pattern]
+shrinkSimplePattern = filter isSimplePattern . shrinkPattern
+
+isSimplePattern :: Pattern -> Bool
+isSimplePattern pat =
+  case pat of
+    PAnn _ sub -> isSimplePattern sub
+    PVar {} -> True
+    PTypeBinder {} -> True
+    PTypeSyntax {} -> True
+    PWildcard -> True
+    PLit {} -> True
+    PQuasiQuote {} -> True
+    PTuple _ elems -> all isDelimitedSimplePattern elems
+    PList elems -> all isDelimitedSimplePattern elems
+    PCon _ [] [] -> True
+    PView {} -> False
+    PAs _ inner -> isSimplePatternAtom inner
+    PStrict inner -> isSimplePatternAtom inner
+    PIrrefutable inner -> isSimplePatternAtom inner
+    PNegLit {} -> False
+    PParen inner -> isDelimitedSimplePattern inner
+    PUnboxedSum {} -> False
+    PRecord _ fields _ -> all (isDelimitedSimplePattern . snd) fields
+    PTypeSig {} -> False
+    PSplice {} -> True
+    PCon {} -> False
+    PInfix {} -> False
+
+isSimplePatternAtom :: Pattern -> Bool
+isSimplePatternAtom pat =
+  case pat of
+    PAnn _ sub -> isSimplePatternAtom sub
+    PVar {} -> True
+    PWildcard -> True
+    PLit {} -> True
+    PQuasiQuote {} -> True
+    PTuple _ elems -> all isDelimitedSimplePattern elems
+    PList elems -> all isDelimitedSimplePattern elems
+    PCon _ [] [] -> True
+    PParen inner -> isDelimitedSimplePattern inner
+    PSplice {} -> True
+    _ -> False
+
+isDelimitedSimplePattern :: Pattern -> Bool
+isDelimitedSimplePattern pat =
+  case pat of
+    PAnn _ sub -> isDelimitedSimplePattern sub
+    PView _ inner -> isDelimitedSimplePattern inner
+    PNegLit {} -> True
+    PTypeSig inner ty -> isDelimitedSimplePattern inner && isClosedType ty
+    PUnboxedSum _ _ inner -> isDelimitedSimplePattern inner
+    PCon _ _ args -> all isDelimitedSimplePattern args
+    PInfix lhs _ rhs -> isDelimitedSimplePattern lhs && isDelimitedSimplePattern rhs
+    _ -> isSimplePattern pat
+
+isClosedType :: Type -> Bool
+isClosedType ty =
+  case ty of
+    TAnn _ sub -> isClosedType sub
+    TVar {} -> True
+    TCon {} -> True
+    TApp a b -> isClosedType a && isClosedType b
+    TFun a b -> isClosedType a && isClosedType b
+    TList _ elems -> all isClosedType elems
+    TTuple _ _ elems -> all isClosedType elems
+    TParen inner -> isClosedType inner
+    _ -> False
+
+shrinkCmd :: Cmd -> [Cmd]
+shrinkCmd cmd =
+  case peelCmdAnn cmd of
+    CmdAnn _ inner -> shrinkCmd inner
+    CmdArrApp lhs appTy rhs ->
+      [CmdArrApp lhs' appTy rhs | lhs' <- shrinkExpr lhs]
+        <> [CmdArrApp lhs appTy rhs' | rhs' <- shrinkExpr rhs]
+    CmdInfix lhs op rhs ->
+      [lhs, rhs]
+        <> [CmdInfix lhs' op rhs | lhs' <- shrinkCmd lhs]
+        <> [CmdInfix lhs op' rhs | op' <- shrinkName op]
+        <> [CmdInfix lhs op rhs' | rhs' <- shrinkCmd rhs]
+    CmdDo stmts -> [CmdDo stmts' | stmts' <- shrinkCmdDoStmts stmts, not (null stmts')]
+    CmdIf cond yes no ->
+      [yes, no]
+        <> [CmdIf cond' yes no | cond' <- shrinkExpr cond]
+        <> [CmdIf cond yes' no | yes' <- shrinkCmd yes]
+        <> [CmdIf cond yes no' | no' <- shrinkCmd no]
+    CmdCase scrut alts ->
+      [CmdCase scrut' alts | scrut' <- shrinkExpr scrut]
+        <> [CmdCase scrut alts' | alts' <- shrinkCmdCaseAlts alts, not (null alts')]
+    CmdLet decls body ->
+      body
+        : [CmdLet decls' body | decls' <- shrinkDecls decls, not (null decls')]
+          <> [CmdLet decls body' | body' <- shrinkCmd body]
+    CmdLam pats body ->
+      body
+        : [CmdLam pats' body | pats' <- shrinkList shrinkSimplePattern pats, not (null pats'), all isSimplePattern pats']
+          <> [CmdLam pats body' | body' <- shrinkCmd body]
+    CmdApp cmd' expr ->
+      cmd'
+        : [CmdApp cmd'' expr | cmd'' <- shrinkCmd cmd']
+          <> [CmdApp cmd' expr' | expr' <- shrinkExpr expr]
+    CmdPar inner -> inner : [CmdPar inner' | inner' <- shrinkCmd inner]
+
+shrinkCmdDoStmts :: [DoStmt Cmd] -> [[DoStmt Cmd]]
+shrinkCmdDoStmts = shrinkList shrinkCmdDoStmt
+
+shrinkCmdDoStmt :: DoStmt Cmd -> [DoStmt Cmd]
+shrinkCmdDoStmt stmt =
+  case peelDoStmtAnn stmt of
+    DoBind pat cmd ->
+      [DoBind pat' cmd | pat' <- shrinkPattern pat]
+        <> [DoBind pat cmd' | cmd' <- shrinkCmd cmd]
+    DoLetDecls decls -> [DoLetDecls decls' | decls' <- shrinkDecls decls, not (null decls')]
+    DoExpr cmd -> [DoExpr cmd' | cmd' <- shrinkCmd cmd]
+    DoRecStmt stmts -> [DoRecStmt stmts' | stmts' <- shrinkCmdDoStmts stmts, not (null stmts')]
+    DoAnn _ _ -> []
+
+shrinkCmdCaseAlts :: [CmdCaseAlt] -> [[CmdCaseAlt]]
+shrinkCmdCaseAlts = shrinkList shrinkCmdCaseAlt
+
+shrinkCmdCaseAlt :: CmdCaseAlt -> [CmdCaseAlt]
+shrinkCmdCaseAlt alt =
+  [alt {cmdCaseAltPat = pat'} | pat' <- shrinkPattern (cmdCaseAltPat alt)]
+    <> [alt {cmdCaseAltBody = body'} | body' <- shrinkCmd (cmdCaseAltBody alt)]
 
 shrinkCaseAlts :: [CaseAlt] -> [[CaseAlt]]
 shrinkCaseAlts = shrinkList shrinkCaseAlt

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -179,7 +179,7 @@ genCmdWith allowTHQuotes = scale (`div` 2) $ do
 
 genCmdLeafWith :: Bool -> Gen Cmd
 genCmdLeafWith allowTHQuotes =
-  CmdArrApp <$> genCmdExprWith allowTHQuotes <*> genArrAppType <*> genCmdExprWith allowTHQuotes
+  CmdArrApp <$> genExprWith allowTHQuotes <*> genArrAppType <*> genExprWith allowTHQuotes
 
 genCmdRecursiveWith :: Bool -> [Gen Cmd]
 genCmdRecursiveWith allowTHQuotes =
@@ -194,9 +194,6 @@ genCmdRecursiveWith allowTHQuotes =
 
 genArrAppType :: Gen ArrAppType
 genArrAppType = elements [HsFirstOrderApp, HsHigherOrderApp]
-
-genCmdExprWith :: Bool -> Gen Expr
-genCmdExprWith = genExprWith
 
 genCmdCaseAltsWith :: Bool -> Gen [CmdCaseAlt]
 genCmdCaseAltsWith allowTHQuotes = smallList1 (genCmdCaseAltWith allowTHQuotes)
@@ -480,21 +477,6 @@ genTypeListElemsWith allowTHQuotes = do
 genTypeVarName :: Gen UnqualifiedName
 genTypeVarName = mkUnqualifiedName NameVarId <$> genVarId
 
-mkIntLiteral :: Integer -> Literal
-mkIntLiteral value = LitInt value TInteger (T.pack (show value))
-
-mkHexLiteral :: Integer -> Literal
-mkHexLiteral value = LitInt value TInteger ("0x" <> T.pack (showHex value))
-
-mkFloatLiteral :: Rational -> Literal
-mkFloatLiteral value = LitFloat value TFractional (renderFloat value)
-
-mkCharLiteral :: Char -> Literal
-mkCharLiteral value = LitChar value (T.pack (show value))
-
-mkStringLiteral :: Text -> Literal
-mkStringLiteral value = LitString value (T.pack (show (T.unpack value)))
-
 -- | Literal expression constructors
 mkHexExpr :: Integer -> Expr
 mkHexExpr value = EInt value TInteger ("0x" <> T.pack (showHex value))
@@ -644,78 +626,9 @@ shrinkExpr expr =
     ETHSplice body -> body : [ETHSplice body' | body' <- shrinkExpr body]
     ETHTypedSplice body -> body : [ETHTypedSplice body' | body' <- shrinkExpr body]
     EProc pat body ->
-      [EProc pat' body | pat' <- shrinkSimplePattern pat]
+      [EProc pat' body | pat' <- shrinkPattern pat]
         <> [EProc pat body' | body' <- shrinkCmd body]
     EAnn _ sub -> shrinkExpr sub
-
-shrinkSimplePattern :: Pattern -> [Pattern]
-shrinkSimplePattern = filter isSimplePattern . shrinkPattern
-
-isSimplePattern :: Pattern -> Bool
-isSimplePattern pat =
-  case pat of
-    PAnn _ sub -> isSimplePattern sub
-    PVar {} -> True
-    PTypeBinder {} -> True
-    PTypeSyntax {} -> True
-    PWildcard -> True
-    PLit {} -> True
-    PQuasiQuote {} -> True
-    PTuple _ elems -> all isDelimitedSimplePattern elems
-    PList elems -> all isDelimitedSimplePattern elems
-    PCon _ [] [] -> True
-    PView {} -> False
-    PAs _ inner -> isSimplePatternAtom inner
-    PStrict inner -> isSimplePatternAtom inner
-    PIrrefutable inner -> isSimplePatternAtom inner
-    PNegLit {} -> False
-    PParen inner -> isDelimitedSimplePattern inner
-    PUnboxedSum {} -> False
-    PRecord _ fields _ -> all (isDelimitedSimplePattern . snd) fields
-    PTypeSig {} -> False
-    PSplice {} -> True
-    PCon {} -> False
-    PInfix {} -> False
-
-isSimplePatternAtom :: Pattern -> Bool
-isSimplePatternAtom pat =
-  case pat of
-    PAnn _ sub -> isSimplePatternAtom sub
-    PVar {} -> True
-    PWildcard -> True
-    PLit {} -> True
-    PQuasiQuote {} -> True
-    PTuple _ elems -> all isDelimitedSimplePattern elems
-    PList elems -> all isDelimitedSimplePattern elems
-    PCon _ [] [] -> True
-    PParen inner -> isDelimitedSimplePattern inner
-    PSplice {} -> True
-    _ -> False
-
-isDelimitedSimplePattern :: Pattern -> Bool
-isDelimitedSimplePattern pat =
-  case pat of
-    PAnn _ sub -> isDelimitedSimplePattern sub
-    PView _ inner -> isDelimitedSimplePattern inner
-    PNegLit {} -> True
-    PTypeSig inner ty -> isDelimitedSimplePattern inner && isClosedType ty
-    PUnboxedSum _ _ inner -> isDelimitedSimplePattern inner
-    PCon _ _ args -> all isDelimitedSimplePattern args
-    PInfix lhs _ rhs -> isDelimitedSimplePattern lhs && isDelimitedSimplePattern rhs
-    _ -> isSimplePattern pat
-
-isClosedType :: Type -> Bool
-isClosedType ty =
-  case ty of
-    TAnn _ sub -> isClosedType sub
-    TVar {} -> True
-    TCon {} -> True
-    TApp a b -> isClosedType a && isClosedType b
-    TFun a b -> isClosedType a && isClosedType b
-    TList _ elems -> all isClosedType elems
-    TTuple _ _ elems -> all isClosedType elems
-    TParen inner -> isClosedType inner
-    _ -> False
 
 shrinkCmd :: Cmd -> [Cmd]
 shrinkCmd cmd =
@@ -744,7 +657,7 @@ shrinkCmd cmd =
           <> [CmdLet decls body' | body' <- shrinkCmd body]
     CmdLam pats body ->
       body
-        : [CmdLam pats' body | pats' <- shrinkList shrinkSimplePattern pats, not (null pats'), all isSimplePattern pats']
+        : [CmdLam pats' body | pats' <- shrinkList shrinkPattern pats, not (null pats')]
           <> [CmdLam pats body' | body' <- shrinkCmd body]
     CmdApp cmd' expr ->
       cmd'

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -195,12 +195,12 @@ genCmdRecursiveWith allowTHQuotes =
 genArrAppType :: Gen ArrAppType
 genArrAppType = elements [HsFirstOrderApp, HsHigherOrderApp]
 
-genCmdCaseAltsWith :: Bool -> Gen [CmdCaseAlt]
+genCmdCaseAltsWith :: Bool -> Gen [CaseAlt Cmd]
 genCmdCaseAltsWith allowTHQuotes = smallList1 (genCmdCaseAltWith allowTHQuotes)
 
-genCmdCaseAltWith :: Bool -> Gen CmdCaseAlt
+genCmdCaseAltWith :: Bool -> Gen (CaseAlt Cmd)
 genCmdCaseAltWith allowTHQuotes = scale (`div` 2) $ do
-  CmdCaseAlt [] <$> genPattern <*> genCmdWith allowTHQuotes
+  CaseAlt [] <$> genPattern <*> genCmdRhsWith allowTHQuotes
 
 genCmdDoStmtsWith :: Bool -> Gen [DoStmt Cmd]
 genCmdDoStmtsWith allowTHQuotes = smallList1 (genCmdDoStmtWith allowTHQuotes)
@@ -223,10 +223,10 @@ genCmdRecDoStmtsWith allowTHQuotes =
         DoExpr <$> genCmdWith allowTHQuotes
       ]
 
-genCaseAltsWith :: Bool -> Gen [CaseAlt]
+genCaseAltsWith :: Bool -> Gen [CaseAlt Expr]
 genCaseAltsWith allowTHQuotes = smallList0 (genCaseAltWith allowTHQuotes)
 
-genCaseAltWith :: Bool -> Gen CaseAlt
+genCaseAltWith :: Bool -> Gen (CaseAlt Expr)
 genCaseAltWith allowTHQuotes = scale (`div` 2) $ do
   CaseAlt [] <$> genPattern <*> genRhsWith allowTHQuotes
 
@@ -237,18 +237,31 @@ genLambdaCaseAltWith :: Bool -> Gen LambdaCaseAlt
 genLambdaCaseAltWith allowTHQuotes = scale (`div` 2) $ do
   LambdaCaseAlt [] <$> genPatterns <*> genRhsWith allowTHQuotes
 
-genRhsWith :: Bool -> Gen Rhs
+genRhsWith :: Bool -> Gen (Rhs Expr)
 genRhsWith allowTHQuotes =
   oneof
     [ UnguardedRhs [] <$> genExprWith allowTHQuotes <*> genWhereDecls,
       GuardedRhss [] <$> genGuardedRhsListWith allowTHQuotes <*> genWhereDecls
     ]
 
-genGuardedRhsListWith :: Bool -> Gen [GuardedRhs]
+genCmdRhsWith :: Bool -> Gen (Rhs Cmd)
+genCmdRhsWith allowTHQuotes =
+  oneof
+    [ UnguardedRhs [] <$> genCmdWith allowTHQuotes <*> genWhereDecls,
+      GuardedRhss [] <$> genCmdGuardedRhsListWith allowTHQuotes <*> genWhereDecls
+    ]
+
+genGuardedRhsListWith :: Bool -> Gen [GuardedRhs Expr]
 genGuardedRhsListWith allowTHQuotes = smallList1 (genGuardedRhsWith allowTHQuotes)
 
-genGuardedRhsWith :: Bool -> Gen GuardedRhs
+genGuardedRhsWith :: Bool -> Gen (GuardedRhs Expr)
 genGuardedRhsWith allowTHQuotes = GuardedRhs [] <$> smallList1 (genGuardQualifierWith allowTHQuotes) <*> genExprWith allowTHQuotes
+
+genCmdGuardedRhsListWith :: Bool -> Gen [GuardedRhs Cmd]
+genCmdGuardedRhsListWith allowTHQuotes = smallList1 (genCmdGuardedRhsWith allowTHQuotes)
+
+genCmdGuardedRhsWith :: Bool -> Gen (GuardedRhs Cmd)
+genCmdGuardedRhsWith allowTHQuotes = GuardedRhs [] <$> smallList1 (genGuardQualifierWith allowTHQuotes) <*> genCmdWith allowTHQuotes
 
 -- | Generate a guard qualifier.
 genGuardQualifierWith :: Bool -> Gen GuardQualifier
@@ -679,21 +692,21 @@ shrinkCmdDoStmt stmt =
     DoRecStmt stmts -> [DoRecStmt stmts' | stmts' <- shrinkCmdDoStmts stmts, not (null stmts')]
     DoAnn _ _ -> []
 
-shrinkCmdCaseAlts :: [CmdCaseAlt] -> [[CmdCaseAlt]]
+shrinkCmdCaseAlts :: [CaseAlt Cmd] -> [[CaseAlt Cmd]]
 shrinkCmdCaseAlts = shrinkList shrinkCmdCaseAlt
 
-shrinkCmdCaseAlt :: CmdCaseAlt -> [CmdCaseAlt]
+shrinkCmdCaseAlt :: CaseAlt Cmd -> [CaseAlt Cmd]
 shrinkCmdCaseAlt alt =
-  [alt {cmdCaseAltPat = pat'} | pat' <- shrinkPattern (cmdCaseAltPat alt)]
-    <> [alt {cmdCaseAltBody = body'} | body' <- shrinkCmd (cmdCaseAltBody alt)]
+  [alt {caseAltPattern = pat'} | pat' <- shrinkPattern (caseAltPattern alt)]
+    <> [alt {caseAltRhs = rhs'} | rhs' <- shrinkCmdRhs (caseAltRhs alt)]
 
-shrinkCaseAlts :: [CaseAlt] -> [[CaseAlt]]
+shrinkCaseAlts :: [CaseAlt Expr] -> [[CaseAlt Expr]]
 shrinkCaseAlts = shrinkList shrinkCaseAlt
 
 shrinkLambdaCaseAlts :: [LambdaCaseAlt] -> [[LambdaCaseAlt]]
 shrinkLambdaCaseAlts = shrinkList shrinkLambdaCaseAlt
 
-shrinkCaseAlt :: CaseAlt -> [CaseAlt]
+shrinkCaseAlt :: CaseAlt Expr -> [CaseAlt Expr]
 shrinkCaseAlt alt =
   case caseAltRhs alt of
     UnguardedRhs _ expr _ ->
@@ -712,9 +725,14 @@ shrinkLambdaCaseAlt alt =
       [alt {lambdaCaseAltRhs = UnguardedRhs [] (guardedRhsBody firstRhs) Nothing} | firstRhs : _ <- [rhss]]
         <> [alt {lambdaCaseAltRhs = GuardedRhss [] rhss' Nothing} | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
 
-shrinkGuardedRhs :: GuardedRhs -> [GuardedRhs]
+shrinkGuardedRhs :: GuardedRhs Expr -> [GuardedRhs Expr]
 shrinkGuardedRhs grhs =
   [grhs {guardedRhsBody = body'} | body' <- shrinkExpr (guardedRhsBody grhs)]
+    <> [grhs {guardedRhsGuards = gs'} | gs' <- shrinkList shrinkGuardQualifier (guardedRhsGuards grhs), not (null gs')]
+
+shrinkCmdGuardedRhs :: GuardedRhs Cmd -> [GuardedRhs Cmd]
+shrinkCmdGuardedRhs grhs =
+  [grhs {guardedRhsBody = body'} | body' <- shrinkCmd (guardedRhsBody grhs)]
     <> [grhs {guardedRhsGuards = gs'} | gs' <- shrinkList shrinkGuardQualifier (guardedRhsGuards grhs), not (null gs')]
 
 -- | Shrink a guard qualifier.
@@ -754,7 +772,7 @@ shrinkLetMatch match =
   [match {matchAnns = [], matchRhs = rhs'} | rhs' <- shrinkLetRhs (matchRhs match)]
 
 -- | Shrink an RHS within let/where/TH contexts.
-shrinkLetRhs :: Rhs -> [Rhs]
+shrinkLetRhs :: Rhs Expr -> [Rhs Expr]
 shrinkLetRhs rhs =
   case rhs of
     UnguardedRhs _ expr mWhere ->
@@ -766,6 +784,19 @@ shrinkLetRhs rhs =
       [UnguardedRhs [] (guardedRhsBody firstRhs) Nothing | firstRhs : _ <- [rhss]]
         <> [GuardedRhss [] rhss Nothing | isJust mWhere]
         <> [GuardedRhss [] rhss' mWhere | rhss' <- shrinkList shrinkGuardedRhs rhss, not (null rhss')]
+        <> [GuardedRhss [] rhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
+
+shrinkCmdRhs :: Rhs Cmd -> [Rhs Cmd]
+shrinkCmdRhs rhs =
+  case rhs of
+    UnguardedRhs _ body mWhere ->
+      [UnguardedRhs [] body Nothing | isJust mWhere]
+        <> [UnguardedRhs [] body' mWhere | body' <- shrinkCmd body]
+        <> [UnguardedRhs [] body (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
+    GuardedRhss _ rhss mWhere ->
+      [UnguardedRhs [] (guardedRhsBody firstRhs) Nothing | firstRhs : _ <- [rhss]]
+        <> [GuardedRhss [] rhss Nothing | isJust mWhere]
+        <> [GuardedRhss [] rhss' mWhere | rhss' <- shrinkList shrinkCmdGuardedRhs rhss, not (null rhss')]
         <> [GuardedRhss [] rhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
 
 shrinkDoStmts :: [DoStmt Expr] -> [[DoStmt Expr]]

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -77,7 +77,7 @@ genExprWith allowTHQuotes = scale (`div` 2) $ do
         ETypeSig <$> genExprWith allowTHQuotes <*> genTypeWith allowTHQuotes,
         ETypeApp <$> genExprWith allowTHQuotes <*> genTypeWith allowTHQuotes,
         EParen <$> genExprWith allowTHQuotes,
-        EProc <$> genSimplePatternWith allowTHQuotes <*> genCmdWith allowTHQuotes,
+        EProc <$> genPattern <*> genCmdWith allowTHQuotes,
         -- Template Haskell splices are valid inside quote bodies.
         ETHSplice <$> genSpliceBody,
         ETHTypedSplice <$> genTypedSpliceBody
@@ -172,96 +172,59 @@ genTypeNameQuoteType =
 genPatterns :: Gen [Pattern]
 genPatterns = smallList1 genPattern
 
--- | Generate a subset accepted by 'simplePatternParser', used in @proc@ and
--- command lambda binders.
-genSimplePatternWith :: Bool -> Gen Pattern
-genSimplePatternWith allowTHQuotes = scale (`div` 2) $ do
-  n <- getSize
-  if n <= 0
-    then oneof simplePatternLeafGenerators
-    else oneof (simplePatternLeafGenerators <> simplePatternRecursiveGenerators)
-  where
-    simplePatternLeafGenerators =
-      [ PVar <$> genSimplePatternUnqualVarName,
-        pure PWildcard,
-        PLit <$> genLiteral,
-        PQuasiQuote <$> genQuasiQuoteName <*> genStringValue,
-        PTuple Boxed <$> elements [[], [PVar (mkUnqualifiedName NameVarId "x"), PWildcard]],
-        pure (PList []),
-        PCon <$> genConName <*> pure [] <*> pure []
-      ]
-    simplePatternRecursiveGenerators =
-      [ PAs <$> genVarId <*> genSimplePatternAtomWith allowTHQuotes,
-        PStrict <$> genSimplePatternAtomWith allowTHQuotes,
-        PIrrefutable <$> genSimplePatternAtomWith allowTHQuotes,
-        PList <$> smallList0 (genSimplePatternAtomWith allowTHQuotes),
-        PTuple Boxed <$> genSimpleTupleElemsWith allowTHQuotes,
-        genSimpleRecordPatternWith allowTHQuotes
-      ]
-
-genSimplePatternAtomWith :: Bool -> Gen Pattern
-genSimplePatternAtomWith _ =
-  oneof
-    [ PVar <$> genSimplePatternUnqualVarName,
-      pure PWildcard,
-      PLit <$> genLiteral,
-      PQuasiQuote <$> genQuasiQuoteName <*> genStringValue,
-      pure (PTuple Boxed []),
-      pure (PList []),
-      PCon <$> genConName <*> pure [] <*> pure []
-    ]
-
-genSimpleTupleElemsWith :: Bool -> Gen [Pattern]
-genSimpleTupleElemsWith allowTHQuotes =
-  oneof
-    [ pure [],
-      do
-        count <- chooseInt (2, 4)
-        scale (`div` count) $ vectorOf count (genSimplePatternAtomWith allowTHQuotes)
-    ]
-
-genSimpleRecordPatternWith :: Bool -> Gen Pattern
-genSimpleRecordPatternWith allowTHQuotes = do
-  con <- genConName
-  count <- chooseInt (0, 3)
-  names <- vectorOf count genVarName
-  pats <- vectorOf count (genSimplePatternAtomWith allowTHQuotes)
-  pure (PRecord con (zip names pats) False)
-
-genSimplePatternUnqualVarName :: Gen UnqualifiedName
-genSimplePatternUnqualVarName = mkUnqualifiedName NameVarId <$> genVarId
-
-genLiteral :: Gen Literal
-genLiteral =
-  oneof
-    [ mkIntLiteral <$> chooseInteger (0, 999),
-      mkHexLiteral <$> chooseInteger (0, 255),
-      mkFloatLiteral <$> genTenths,
-      mkCharLiteral <$> genCharValue,
-      mkStringLiteral <$> genStringValue
-    ]
-
 genCmdWith :: Bool -> Gen Cmd
-genCmdWith allowTHQuotes = scale (`div` 2) $ genCmdLeafWith allowTHQuotes
+genCmdWith allowTHQuotes = scale (`div` 2) $ do
+  n <- getSize
+  if n <= 0 then genCmdLeafWith allowTHQuotes else oneof (genCmdLeafWith allowTHQuotes : genCmdRecursiveWith allowTHQuotes)
 
 genCmdLeafWith :: Bool -> Gen Cmd
 genCmdLeafWith allowTHQuotes =
   CmdArrApp <$> genCmdExprWith allowTHQuotes <*> genArrAppType <*> genCmdExprWith allowTHQuotes
 
+genCmdRecursiveWith :: Bool -> [Gen Cmd]
+genCmdRecursiveWith allowTHQuotes =
+  [ CmdInfix <$> genCmdWith allowTHQuotes <*> genVarName <*> genCmdWith allowTHQuotes,
+    CmdDo <$> genCmdDoStmtsWith allowTHQuotes,
+    CmdIf <$> genExprWith allowTHQuotes <*> genCmdWith allowTHQuotes <*> genCmdWith allowTHQuotes,
+    CmdCase <$> genExprWith allowTHQuotes <*> genCmdCaseAltsWith allowTHQuotes,
+    CmdLet <$> genValueDeclsWith allowTHQuotes <*> genCmdWith allowTHQuotes,
+    CmdLam <$> genPatterns <*> genCmdWith allowTHQuotes,
+    CmdPar <$> genCmdWith allowTHQuotes
+  ]
+
 genArrAppType :: Gen ArrAppType
 genArrAppType = elements [HsFirstOrderApp, HsHigherOrderApp]
 
 genCmdExprWith :: Bool -> Gen Expr
-genCmdExprWith _ =
-  oneof
-    [ EVar <$> genVarName,
-      mkIntExpr <$> chooseInteger (0, 999),
-      mkFloatExpr <$> genTenths,
-      mkCharExpr <$> genCharValue,
-      mkStringExpr <$> genStringValue,
-      pure (EList []),
-      pure (ETuple Boxed [])
+genCmdExprWith = genExprWith
+
+genCmdCaseAltsWith :: Bool -> Gen [CmdCaseAlt]
+genCmdCaseAltsWith allowTHQuotes = smallList1 (genCmdCaseAltWith allowTHQuotes)
+
+genCmdCaseAltWith :: Bool -> Gen CmdCaseAlt
+genCmdCaseAltWith allowTHQuotes = scale (`div` 2) $ do
+  CmdCaseAlt [] <$> genPattern <*> genCmdWith allowTHQuotes
+
+genCmdDoStmtsWith :: Bool -> Gen [DoStmt Cmd]
+genCmdDoStmtsWith allowTHQuotes = smallList1 (genCmdDoStmtWith allowTHQuotes)
+
+genCmdDoStmtWith :: Bool -> Gen (DoStmt Cmd)
+genCmdDoStmtWith allowTHQuotes =
+  scale (`div` 2) . oneof $
+    [ DoBind <$> genPattern <*> genCmdWith allowTHQuotes,
+      DoLetDecls <$> genValueDeclsWith allowTHQuotes,
+      DoExpr <$> genCmdWith allowTHQuotes,
+      DoRecStmt <$> genCmdRecDoStmtsWith allowTHQuotes
     ]
+
+genCmdRecDoStmtsWith :: Bool -> Gen [DoStmt Cmd]
+genCmdRecDoStmtsWith allowTHQuotes =
+  scale (`div` 2) . smallList1 $
+    oneof
+      [ DoBind <$> genPattern <*> genCmdWith allowTHQuotes,
+        DoLetDecls <$> genValueDeclsWith allowTHQuotes,
+        DoExpr <$> genCmdWith allowTHQuotes
+      ]
 
 genCaseAltsWith :: Bool -> Gen [CaseAlt]
 genCaseAltsWith allowTHQuotes = smallList0 (genCaseAltWith allowTHQuotes)

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs-boot
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs-boot
@@ -10,6 +10,6 @@ import Aihc.Parser.Syntax (Expr, GuardQualifier, Rhs)
 import Test.QuickCheck (Gen)
 
 genExpr :: Gen Expr
-genRhsWith :: Bool -> Gen Rhs
+genRhsWith :: Bool -> Gen (Rhs Expr)
 shrinkExpr :: Expr -> [Expr]
 shrinkGuardQualifier :: GuardQualifier -> [GuardQualifier]

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -20,7 +20,7 @@ import Text.Megaparsec.Error qualified as MPE
 declConfig :: ParserConfig
 declConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension PatternSynonyms, EnableExtension UnicodeSyntax, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension UnicodeSyntax, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension TypeApplications, EnableExtension TupleSections, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension ExplicitNamespaces, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments, EnableExtension LambdaCase]
     }
 
 prop_declPrettyRoundTrip :: Decl -> Property

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -84,7 +84,7 @@ normalizeExpr expr =
     EPragma pragma body -> EPragma pragma (normalizeExpr body)
     EAnn _ sub -> normalizeExpr sub
 
-normalizeCaseAlt :: CaseAlt -> CaseAlt
+normalizeCaseAlt :: CaseAlt Expr -> CaseAlt Expr
 normalizeCaseAlt alt =
   CaseAlt
     { caseAltAnns = [],
@@ -100,13 +100,13 @@ normalizeLambdaCaseAlt alt =
       lambdaCaseAltRhs = normalizeRhs (lambdaCaseAltRhs alt)
     }
 
-normalizeRhs :: Rhs -> Rhs
+normalizeRhs :: Rhs Expr -> Rhs Expr
 normalizeRhs rhs =
   case rhs of
     UnguardedRhs _ body mDecls -> UnguardedRhs [] (normalizeExpr body) (fmap (map normalizeDecl) mDecls)
     GuardedRhss _ guards mDecls -> GuardedRhss [] (map normalizeGuardedRhs guards) (fmap (map normalizeDecl) mDecls)
 
-normalizeGuardedRhs :: GuardedRhs -> GuardedRhs
+normalizeGuardedRhs :: GuardedRhs Expr -> GuardedRhs Expr
 normalizeGuardedRhs grhs =
   GuardedRhs
     { guardedRhsAnns = [],
@@ -307,12 +307,26 @@ normalizeDoCmdStmtInner (DoLetDecls decls) = DoLetDecls (map normalizeDecl decls
 normalizeDoCmdStmtInner (DoExpr c) = DoExpr (normalizeCmd c)
 normalizeDoCmdStmtInner (DoRecStmt stmts) = DoRecStmt (map normalizeDoCmdStmt stmts)
 
-normalizeCmdCaseAlt :: CmdCaseAlt -> CmdCaseAlt
+normalizeCmdCaseAlt :: CaseAlt Cmd -> CaseAlt Cmd
 normalizeCmdCaseAlt alt =
-  alt
-    { cmdCaseAltAnns = [],
-      cmdCaseAltPat = normalizePattern (cmdCaseAltPat alt),
-      cmdCaseAltBody = normalizeCmd (cmdCaseAltBody alt)
+  CaseAlt
+    { caseAltAnns = [],
+      caseAltPattern = normalizePattern (caseAltPattern alt),
+      caseAltRhs = normalizeCmdRhs (caseAltRhs alt)
+    }
+
+normalizeCmdRhs :: Rhs Cmd -> Rhs Cmd
+normalizeCmdRhs rhs =
+  case rhs of
+    UnguardedRhs _ body mDecls -> UnguardedRhs [] (normalizeCmd body) (fmap (map normalizeDecl) mDecls)
+    GuardedRhss _ guards mDecls -> GuardedRhss [] (map normalizeCmdGuardedRhs guards) (fmap (map normalizeDecl) mDecls)
+
+normalizeCmdGuardedRhs :: GuardedRhs Cmd -> GuardedRhs Cmd
+normalizeCmdGuardedRhs grhs =
+  GuardedRhs
+    { guardedRhsAnns = [],
+      guardedRhsGuards = map normalizeGuardQualifier (guardedRhsGuards grhs),
+      guardedRhsBody = normalizeCmd (guardedRhsBody grhs)
     }
 
 normalizeCompStmt :: CompStmt -> CompStmt

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -2,6 +2,7 @@
 
 module Test.Properties.ExprRoundTrip
   ( prop_exprPrettyRoundTrip,
+    test_exprPrettyRoundTrip_procExpression,
     test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote,
   )
 where
@@ -23,7 +24,7 @@ import Text.Megaparsec.Error qualified as MPE
 exprConfig :: ParserConfig
 exprConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments, LambdaCase]
+    { parserExtensions = [Arrows, BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, MultiWayIf, RecursiveDo, TypeApplications, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments, LambdaCase]
     }
 
 prop_exprPrettyRoundTrip :: Expr -> Property
@@ -44,6 +45,22 @@ test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote :: Assertion
 test_exprPrettyRoundTrip_qualifiedUnicodeOperatorNameQuote =
   let expr = EAnn (mkAnnotation span0) (ETHNameQuote (EVar (mkName (Just "H3xVBC.NB.Y") NameVarSym "‼.")))
       source = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+      expected = normalizeExpr (addExprParens expr)
+   in case parseExpr exprConfig source of
+        ParseErr err -> assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> MPE.errorBundlePretty err)
+        ParseOk parsed ->
+          let actual = normalizeExpr parsed
+           in if actual == expected
+                then pure ()
+                else assertFailure ("expected: " <> show expected <> "\nactual: " <> show actual)
+
+test_exprPrettyRoundTrip_procExpression :: Assertion
+test_exprPrettyRoundTrip_procExpression =
+  let expr =
+        EProc
+          (PVar (mkUnqualifiedName NameVarId "x"))
+          (CmdArrApp (EVar (qualifyName Nothing (mkUnqualifiedName NameVarId "f"))) HsFirstOrderApp (EVar (qualifyName Nothing (mkUnqualifiedName NameVarId "x"))))
+      source = renderStrict (layoutPretty defaultLayoutOptions (pretty (addExprParens expr)))
       expected = normalizeExpr (addExprParens expr)
    in case parseExpr exprConfig source of
         ParseErr err -> assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> MPE.errorBundlePretty err)

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -34,7 +34,7 @@ prop_modulePrettyRoundTrip modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments]
+    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension TypeApplications, EnableExtension TupleSections, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension ExplicitNamespaces, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments, EnableExtension LambdaCase]
     }
 
 -- Module normalization

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -21,7 +21,7 @@ import Text.Megaparsec.Error qualified as MPE
 patternConfig :: ParserConfig
 patternConfig =
   defaultConfig
-    { parserExtensions = [BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments, LambdaCase]
+    { parserExtensions = [Arrows, BlockArguments, UnboxedTuples, UnboxedSums, TemplateHaskell, MagicHash, OverloadedLabels, TypeApplications, MultiWayIf, RecursiveDo, TupleSections, ImplicitParams, ExplicitNamespaces, TypeAbstractions, RequiredTypeArguments, LambdaCase]
     }
 
 prop_patternPrettyRoundTrip :: Pattern -> Property

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -106,7 +106,7 @@ peelDataConSpan :: SourceSpan -> DataConDecl -> SourceSpan
 peelDataConSpan ambient (DataConAnn ann inner) = peelDataConSpan (pushSpanFromAnn ambient ann) inner
 peelDataConSpan ambient _ = ambient
 
-rhsSpan :: Rhs -> SourceSpan
+rhsSpan :: Rhs body -> SourceSpan
 rhsSpan rhs =
   case rhs of
     UnguardedRhs anns _ _ -> sourceSpanFromAnns anns
@@ -235,7 +235,7 @@ resolveMatch scope ambient nextLocal match =
       (nextLocal'', rhs') = resolveRhs scoped nextLocal' rhsHere (matchRhs match)
    in (nextLocal'', match {matchPats = pats', matchRhs = rhs'})
 
-resolveRhs :: Scope -> Int -> SourceSpan -> Rhs -> (Int, Rhs)
+resolveRhs :: Scope -> Int -> SourceSpan -> Rhs Expr -> (Int, Rhs Expr)
 resolveRhs scope nextLocal ambient rhs =
   case rhs of
     UnguardedRhs anns expr mDecls ->
@@ -257,7 +257,7 @@ resolveWhereDecls scope nextLocal (Just decls) =
       (nextLocal'', decls') = resolveBoundDecls scoped binderAnnotations nextLocal' Map.empty decls
    in (nextLocal'', Just decls')
 
-resolveGuardedRhs :: Scope -> SourceSpan -> Int -> GuardedRhs -> (Int, GuardedRhs)
+resolveGuardedRhs :: Scope -> SourceSpan -> Int -> GuardedRhs Expr -> (Int, GuardedRhs Expr)
 resolveGuardedRhs scope ambient nextLocal guardedRhs =
   let here = effectiveResolutionSpan ambient (sourceSpanFromAnns (guardedRhsAnns guardedRhs))
       (nextLocal', scope', guards') = resolveGuardQualifiers scope nextLocal here (guardedRhsGuards guardedRhs)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -16,6 +16,7 @@ import Aihc.Parser.Syntax
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
+    Expr,
     FieldDecl (..),
     GadtBody (..),
     Match (..),
@@ -540,14 +541,14 @@ withPatBindings ((name, ty) : rest) m =
   extendTermEnv name (TcMonoIdBinder name ty) (withPatBindings rest m)
 
 -- | Infer the type of a right-hand side expression.
-inferRhsExpr :: Rhs -> TcM (TcType, [Ct])
+inferRhsExpr :: Rhs Expr -> TcM (TcType, [Ct])
 inferRhsExpr (UnguardedRhs _sp expr _decls) = inferExpr expr
 inferRhsExpr (GuardedRhss _sp _guards _decls) = do
   ty <- freshMetaTv
   pure (ty, [])
 
 -- | Type-check a right-hand side (solving constraints immediately).
-tcRhs :: Rhs -> TcM TcType
+tcRhs :: Rhs Expr -> TcM TcType
 tcRhs (UnguardedRhs _sp expr _decls) = do
   (ty, cts) <- inferExpr expr
   _ <- solveConstraints cts

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -135,7 +135,7 @@ inferLambda _sp pats body = do
 -- @\\case { pat1 -> e1; pat2 -> e2; ... }@ is treated as a function
 -- from a fresh argument type to the result type of the case
 -- alternatives.
-inferLambdaCase :: SourceSpan -> [CaseAlt] -> TcM (TcType, [Ct])
+inferLambdaCase :: SourceSpan -> [CaseAlt Expr] -> TcM (TcType, [Ct])
 inferLambdaCase sp alts = do
   argTy <- freshMetaTv
   resTy <- freshMetaTv
@@ -147,7 +147,7 @@ inferLambdaCase sp alts = do
 -- @case scrutinee of { pat1 -> e1; pat2 -> e2; ... }@ is inferred by
 -- checking each alternative against the scrutinee type and unifying all
 -- branch result types with a fresh result type.
-inferCase :: SourceSpan -> Expr -> [CaseAlt] -> TcM (TcType, [Ct])
+inferCase :: SourceSpan -> Expr -> [CaseAlt Expr] -> TcM (TcType, [Ct])
 inferCase sp scrutinee alts = do
   (scrutTy, scrutCts) <- inferExpr scrutinee
   resTy <- freshMetaTv
@@ -166,7 +166,7 @@ inferLambdaCases sp alts = do
 --
 -- Each alternative's pattern is checked against the scrutinee type,
 -- and each RHS must unify with the expected result type.
-inferCaseAlts :: SourceSpan -> TcType -> TcType -> [CaseAlt] -> TcM [Ct]
+inferCaseAlts :: SourceSpan -> TcType -> TcType -> [CaseAlt Expr] -> TcM [Ct]
 inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
   where
     inferAlt (CaseAlt altAnns pat rhs) = do
@@ -236,7 +236,7 @@ combineSourceSpan NoSourceSpan fallback = fallback
 combineSourceSpan span' _ = span'
 
 -- | Infer the type of a right-hand side (for case alternatives).
-inferRhs :: Rhs -> TcM (TcType, [Ct])
+inferRhs :: Rhs Expr -> TcM (TcType, [Ct])
 inferRhs (UnguardedRhs _sp expr _decls) = inferExpr expr
 inferRhs (GuardedRhss _sp _guards _decls) = do
   ty <- freshMetaTv


### PR DESCRIPTION
## Summary
- extend the expression QuickCheck generator and shrinker to cover `EProc` with a parser-stable command/pattern subset
- enable `Arrows` and related parser extensions in roundtrip property configs and add an explicit `proc` roundtrip regression test
- fix proc-related parser and pretty-printer roundtrip bugs for command heads, operator record fields, and command infix parenthesization