### PR TITLE
fix(parser): round-trip typed patterns without generator hacks

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -8,7 +8,8 @@ where
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (exprParser, exprParserNoArrowTail, parseLetDeclsParser, parseLetDeclsStmtParser)
-import Aihc.Parser.Internal.Pattern (patternParser, simplePatternParser)
+import Aihc.Parser.Internal.Pattern (patternParser, patternParserWithTypeSigParser, simplePatternParser)
+import Aihc.Parser.Internal.Type (typeInfixParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind)
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
@@ -115,7 +116,7 @@ cmdCaseParser = withSpanAnn (CmdAnn . mkAnnotation) $ do
 
 cmdCaseAltParser :: TokParser CmdCaseAlt
 cmdCaseAltParser = withSpan $ do
-  pat <- patternParser
+  pat <- patternParserWithTypeSigParser typeInfixParser
   expectedTok TkReservedRightArrow
   body <- cmdParser
   pure (\span' -> CmdCaseAlt [mkAnnotation span'] pat body)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -30,7 +30,7 @@ import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
 import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser, typeSigDeclParser)
-import Aihc.Parser.Internal.Pattern (appPatternParser, patternParser, simplePatternParser)
+import Aihc.Parser.Internal.Pattern (appPatternParser, patternParser, patternParserWithTypeSigParser, simplePatternParser)
 import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeHeadInfixParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
 import Aihc.Parser.Syntax
@@ -674,7 +674,7 @@ guardTypeSigParser RhsArrowCase = typeInfixParser
 
 caseAltParser :: TokParser CaseAlt
 caseAltParser = withSpan $ do
-  pat <- region "while parsing case alternative" patternParser
+  pat <- region "while parsing case alternative" (patternParserWithTypeSigParser typeInfixParser)
   rhs <- region "while parsing case alternative" rhsParser
   pure $ \span' ->
     CaseAlt
@@ -1162,20 +1162,16 @@ localTypeSigDeclsParser = do
         case peelDeclAnn sig of
           DeclTypeSig sigNames sigTy -> (sigNames, sigTy)
           _ -> error "typeSigDeclParser must produce DeclTypeSig"
-  mEq <- MP.optional (expectedTok TkReservedEquals)
-  case mEq of
-    Nothing -> pure [sig]
-    Just () ->
-      case names of
-        [name] -> do
-          rhsExpr <- exprParser
-          whereDecls <- MP.optional whereClauseParser
-          let bindAnns = []
-              pat = PTypeSig (PVar name) ty
-              rhs = UnguardedRhs bindAnns rhsExpr whereDecls
-          pure [DeclValue (PatternBind pat rhs)]
-        _ ->
-          fail "local typed bindings with '=' require exactly one binder"
+  nextKind <- lexTokenKind <$> lookAhead anySingle
+  if nextKind == TkReservedEquals || nextKind == TkReservedPipe
+    then case names of
+      [name] -> do
+        rhs <- equationRhsParser
+        let pat = PTypeSig (PVar name) ty
+        pure [DeclValue (PatternBind pat rhs)]
+      _ ->
+        fail "local typed bindings with '=' or guards require exactly one binder"
+    else pure [sig]
 
 localFunctionDeclParser :: TokParser Decl
 localFunctionDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -2,6 +2,7 @@
 
 module Aihc.Parser.Internal.Pattern
   ( patternParser,
+    patternParserWithTypeSigParser,
     simplePatternParser,
     appPatternParser,
     literalParser,
@@ -20,9 +21,12 @@ import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
 
 patternParser :: TokParser Pattern
-patternParser = label "pattern" $ do
+patternParser = patternParserWithTypeSigParser typeParser
+
+patternParserWithTypeSigParser :: TokParser Type -> TokParser Pattern
+patternParserWithTypeSigParser typeSigParser = label "pattern" $ do
   pat <- infixPatternParser
-  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
+  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeSigParser)
   case mTypeSig of
     Just ty -> pure (PTypeSig pat ty)
     Nothing -> pure pat

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -789,7 +789,7 @@ addExprParensPrec prec expr =
     EMultiWayIf rhss ->
       wrapExpr (prec > 0) (EMultiWayIf (map (addGuardedRhsParens GuardArrow) rhss))
     ELambdaPats pats body ->
-      wrapExpr (prec > 0) (ELambdaPats (map addLambdaPatternAtomParens pats) (addExprParens body))
+      wrapExpr (prec > 0) (ELambdaPats (map addArrowBndrPatternParens pats) (addExprParens body))
     ELambdaCase alts ->
       wrapExpr (prec > 0) (ELambdaCase (map addCaseAltParens alts))
     ELambdaCases alts ->
@@ -852,7 +852,7 @@ addExprParensPrec prec expr =
     ETuple tupleFlavor values -> ETuple tupleFlavor (map (fmap addExprParens) values)
     EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (addExprParens inner)
     EProc pat body ->
-      wrapExpr (prec > 0) (EProc (addPatternParens pat) (addCmdParens body))
+      wrapExpr (prec > 0) (EProc (addArrowBndrPatternParens pat) (addCmdParens body))
     EPragma pragma inner ->
       wrapExpr (prec > 0) (EPragma pragma (addExprParens inner))
     EAnn ann sub -> EAnn ann (addExprParensPrec prec sub)
@@ -1205,14 +1205,16 @@ addPatternInfixOperandParens pat =
     PCon {} -> addPatternParens pat
     _ -> addPatternAtomParens pat
 
--- | Add parens for a pattern in lambda argument position.
-addLambdaPatternAtomParens :: Pattern -> Pattern
-addLambdaPatternAtomParens pat =
-  case pat of
-    PAnn ann sub -> PAnn ann (addLambdaPatternAtomParens sub)
-    PNegLit {} -> wrapPat True (addPatternParens pat)
-    PCon _ _ [] -> wrapPat True (addPatternParens pat)
-    _ -> addPatternAtomParens pat
+-- | Add parens for a pattern in arrow binder position (lambda/proc).
+-- Type-signatured, negated literal, infix, and non-nullary constructor patterns
+-- must be parenthesized to avoid ambiguity.
+addArrowBndrPatternParens :: Pattern -> Pattern
+addArrowBndrPatternParens p@(PTypeSig {}) = wrapPat True (addPatternParens p)
+addArrowBndrPatternParens p@(PNegLit {}) = wrapPat True (addPatternParens p)
+addArrowBndrPatternParens p@(PInfix {}) = wrapPat True (addPatternParens p)
+addArrowBndrPatternParens p@(PCon _ (_ : _) _) = wrapPat True (addPatternParens p)
+addArrowBndrPatternParens p@(PCon _ [] (_ : _)) = wrapPat True (addPatternParens p)
+addArrowBndrPatternParens pat = addPatternParens pat
 
 -- | Add parens for a pattern in function-head argument position.
 addFunctionHeadPatternAtomParens :: Pattern -> Pattern

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -31,6 +31,7 @@ where
 
 import Aihc.Parser.Syntax
 import Control.Monad (guard)
+import Data.Maybe (isNothing)
 import Data.Text (Text)
 
 -- ---------------------------------------------------------------------------
@@ -420,8 +421,24 @@ addDeclSpliceParens = addExprParens
 addValueDeclParens :: ValueDecl -> ValueDecl
 addValueDeclParens vdecl =
   case vdecl of
-    PatternBind pat rhs -> PatternBind (addPatternParens pat) (addRhsParens rhs)
+    PatternBind pat rhs -> PatternBind (addPatternBindLhsParens pat rhs) (addRhsParens rhs)
     FunctionBind name matches -> FunctionBind name (map (addMatchParens name) matches)
+
+addPatternBindLhsParens :: Pattern -> Rhs -> Pattern
+addPatternBindLhsParens pat rhs =
+  case pat of
+    PAnn ann sub -> PAnn ann (addPatternBindLhsParens sub rhs)
+    -- Bare @name :: ty = rhs@ is valid declaration syntax and is handled by a
+    -- dedicated decl parser path. Other typed patterns, and guarded typed binds,
+    -- must stay grouped so the parser does not reinterpret them as signatures.
+    PTypeSig inner@(PVar {}) ty
+      | isUnguardedRhs rhs -> PTypeSig (addPatternAtomParens inner) (addTypeParens ty)
+    PTypeSig {} -> wrapPat True (addPatternParens pat)
+    _ -> addPatternParens pat
+
+isUnguardedRhs :: Rhs -> Bool
+isUnguardedRhs UnguardedRhs {} = True
+isUnguardedRhs GuardedRhss {} = False
 
 addMatchParens :: UnqualifiedName -> Match -> Match
 addMatchParens name match =
@@ -873,8 +890,10 @@ addSpliceBodyParens :: Expr -> Expr
 addSpliceBodyParens body =
   case body of
     EAnn ann sub -> EAnn ann (addSpliceBodyParens sub)
-    -- Bare variable: $name is valid splice syntax without parens.
-    EVar {} -> body
+    -- Bare unqualified variables and operators use the compact splice syntax.
+    -- Qualified names require $(M.name) to remain parseable.
+    EVar name
+      | isNothing (nameQualifier name) -> body
     -- For everything else (including sections, which addExprParens now wraps
     -- in EParen): wrap in one outer EParen so the body prints as $(expr).
     -- Sections become EParen(EParen(section)) which prints as $((lhs op)).
@@ -1110,7 +1129,7 @@ addPatternParens pat =
     PParen inner -> PParen (addPatternInDelimited inner)
     PRecord con fields hasWildcard ->
       PRecord con [field {recordFieldValue = addPatternInDelimited (recordFieldValue field)} | field <- fields] hasWildcard
-    PTypeSig inner ty -> PTypeSig (addPatternParens inner) (addTypeParens ty)
+    PTypeSig inner ty -> PTypeSig (addPatternAtomParens inner) (addTypeParens ty)
     PSplice body -> PSplice (addSpliceBodyParens body)
 
 -- | Add parens for a pattern inside a delimited context (tuples, lists, etc.).
@@ -1212,6 +1231,7 @@ addInfixFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addInfixFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
+    PTypeSig {} -> wrapPat True (addPatternParens pat)
     _ -> addPatternParens pat
 
 -- | Add parens for the inner pattern of @, !, ~.

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -429,16 +429,11 @@ addPatternBindLhsParens pat rhs =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternBindLhsParens sub rhs)
     -- Bare @name :: ty = rhs@ is valid declaration syntax and is handled by a
-    -- dedicated decl parser path. Other typed patterns, and guarded typed binds,
-    -- must stay grouped so the parser does not reinterpret them as signatures.
-    PTypeSig inner@(PVar {}) ty
-      | isUnguardedRhs rhs -> PTypeSig (addPatternAtomParens inner) (addTypeParens ty)
+    -- dedicated decl parser path. Other typed patterns must stay grouped so the
+    -- parser does not reinterpret them as signatures.
+    PTypeSig inner@(PVar {}) ty -> PTypeSig (addPatternAtomParens inner) (addTypeParens ty)
     PTypeSig {} -> wrapPat True (addPatternParens pat)
     _ -> addPatternParens pat
-
-isUnguardedRhs :: Rhs -> Bool
-isUnguardedRhs UnguardedRhs {} = True
-isUnguardedRhs GuardedRhss {} = False
 
 addMatchParens :: UnqualifiedName -> Match -> Match
 addMatchParens name match =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -424,7 +424,7 @@ addValueDeclParens vdecl =
     PatternBind pat rhs -> PatternBind (addPatternBindLhsParens pat rhs) (addRhsParens rhs)
     FunctionBind name matches -> FunctionBind name (map (addMatchParens name) matches)
 
-addPatternBindLhsParens :: Pattern -> Rhs -> Pattern
+addPatternBindLhsParens :: Pattern -> Rhs Expr -> Pattern
 addPatternBindLhsParens pat rhs =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternBindLhsParens sub rhs)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -494,6 +494,13 @@ prettyPattern pat =
     PTypeSig inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
     PSplice body -> "$" <> prettyExpr body
 
+-- | Pretty print a pattern that appears before @->@ (in proc or lambda).
+-- Type-signatured patterns must be parenthesized to avoid ambiguity with
+-- function types.
+prettyPatternArrowBndr :: Pattern -> Doc ann
+prettyPatternArrowBndr p@(PTypeSig {}) = parens (prettyPattern p)
+prettyPatternArrowBndr pat = prettyPattern pat
+
 -- | Pretty print a pattern field binding.
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann
 prettyPatternFieldBinding field =
@@ -1091,7 +1098,7 @@ prettyExpr expr =
           ]
         <+> "}"
     ELambdaPats pats body ->
-      "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyExpr body
+      "\\" <+> hsep (map prettyPatternArrowBndr pats) <+> "->" <+> prettyExpr body
     ELambdaCase alts ->
       "\\" <> "case" <+> "{" <+> hsep (punctuate semi (map prettyCaseAlt alts)) <+> "}"
     ELambdaCases alts ->
@@ -1163,7 +1170,7 @@ prettyExpr expr =
       let slots = [if i == altIdx then prettyExpr inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     EProc pat body ->
-      "proc" <+> prettyPattern pat <+> "->" <+> prettyCmd body
+      "proc" <+> prettyPatternArrowBndr pat <+> "->" <+> prettyCmd body
     EPragma pragma inner ->
       prettyPragma pragma <+> prettyExpr inner
     EAnn _ sub -> prettyExpr sub

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -494,13 +494,6 @@ prettyPattern pat =
     PTypeSig inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
     PSplice body -> "$" <> prettyExpr body
 
--- | Pretty print a pattern that appears before @->@ (in proc or lambda).
--- Type-signatured patterns must be parenthesized to avoid ambiguity with
--- function types.
-prettyPatternArrowBndr :: Pattern -> Doc ann
-prettyPatternArrowBndr p@(PTypeSig {}) = parens (prettyPattern p)
-prettyPatternArrowBndr pat = prettyPattern pat
-
 -- | Pretty print a pattern field binding.
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann
 prettyPatternFieldBinding field =
@@ -1098,7 +1091,7 @@ prettyExpr expr =
           ]
         <+> "}"
     ELambdaPats pats body ->
-      "\\" <+> hsep (map prettyPatternArrowBndr pats) <+> "->" <+> prettyExpr body
+      "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyExpr body
     ELambdaCase alts ->
       "\\" <> "case" <+> "{" <+> hsep (punctuate semi (map prettyCaseAlt alts)) <+> "}"
     ELambdaCases alts ->
@@ -1170,7 +1163,7 @@ prettyExpr expr =
       let slots = [if i == altIdx then prettyExpr inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", hsep (punctuate " |" slots), "#)"]
     EProc pat body ->
-      "proc" <+> prettyPatternArrowBndr pat <+> "->" <+> prettyCmd body
+      "proc" <+> prettyPattern pat <+> "->" <+> prettyCmd body
     EPragma pragma inner ->
       prettyPragma pragma <+> prettyExpr inner
     EAnn _ sub -> prettyExpr sub

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -408,6 +408,8 @@ buildTests = do
           [ testCase "infix type family instances keep bare applications" test_typeFamilyInstanceInfixAppliedOperandsRoundTrip,
             testCase "symbolic type application parenthesizes context arguments" test_symbolicTypeApplicationContextArgRoundTrip,
             testCase "data family instance kind signatures round-trip" test_dataFamilyInstanceKindSignatureRoundTrip,
+            testCase "case alternatives keep typed strict negative patterns" test_caseAltTypedStrictNegativePatternParses,
+            testCase "local guarded typed binds in where clauses parse and round-trip" test_localGuardedTypedBindWhereRoundTrip,
             testCase "record patterns preserve explicit same-name bindings" test_recordPatternExplicitSameNameBindingRoundTrip,
             testCase "record expressions preserve explicit same-name bindings" test_recordExprExplicitSameNameBindingRoundTrip
           ],
@@ -417,6 +419,9 @@ buildTests = do
             testCase "prefix no args: f = 5" test_funHeadPrefixNoArgs,
             testCase "prefix operator name: (+) x y = x" test_funHeadPrefixOp,
             testCase "prefix constructor application arg: f (Just x) y = y" test_funHeadPrefixConstructorArg,
+            testCase "prefix quasiquote arg: f [qq||] = ()" test_funHeadPrefixQuasiQuoteArg,
+            testCase "symbolic prefix name with quasiquote arg: (+) [qq||] = ()" test_funHeadPrefixOpQuasiQuoteArg,
+            testCase "unicode symbolic prefix name with quasiquote arg" test_funHeadPrefixUnicodeOpQuasiQuoteArg,
             testCase "prefix list view pattern arg: fn [id -> x] = x" test_funHeadPrefixListViewPattern,
             testCase "prefix record field view pattern arg: f (Box {field = id -> x}) = x" test_funHeadPrefixRecordFieldViewPattern,
             testCase "prefix singleton unboxed tuple arg: f (# x #) = x" test_funHeadPrefixUnboxedTupleSingletonArg,
@@ -428,6 +433,8 @@ buildTests = do
             testCase "infix backtick with TH splice lhs: $splice `fn` () = ()" test_funHeadInfixThSpliceLhs,
             testCase "prefix with TH operator splice pattern: x $(*) = ()" test_funHeadPrefixThOperatorSplicePattern,
             testCase "prefix with TH negative splice pattern: x $(-()) = ()" test_funHeadPrefixThNegativeSplicePattern,
+            testCase "top-level nullary symbolic constructor pattern bind" test_topLevelNullarySymConPatternBind,
+            testCase "top-level nullary symbolic constructor pattern bind with where" test_topLevelNullarySymConPatternBindWhere,
             testCase "parenthesized infix: (x + y) = x" test_funHeadParenInfix,
             testCase "parenthesized infix with tail: (x + y) z = x" test_funHeadParenInfixTail,
             testCase "local prefix: let f x = x" test_funHeadLocalPrefix,
@@ -451,7 +458,9 @@ buildTests = do
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
               testCase "pretty-prints negative literal pattern type signatures with inner parens" test_patternTypeSigNegativeLiteralPrettyPrints,
               testCase "pretty-prints non-variable typed pattern binds with outer parens" test_patternBindTypedConstructorPrettyPrints,
+              testCase "pretty-prints guarded variable typed pattern binds without outer parens" test_patternBindGuardedVarTypeSigPrettyPrints,
               testCase "pretty-prints infix function head typed patterns with parens" test_infixFunctionHeadTypedPatternPrettyPrints,
+              testCase "top-level unboxed sum pattern binds round-trip" test_topLevelUnboxedSumPatternBindRoundTrip,
               testCase "pretty-prints qualified TH splice pattern bodies with explicit parens" test_qualifiedSplicePatternBodyPrettyPrints,
               QC.testProperty "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip
             ],
@@ -487,6 +496,25 @@ test_patternBindTypedConstructorPrettyPrints = do
   assertBool ("expected no parse errors, got: " <> show errs) (null errs)
   map normalizeDecl (moduleDecls modu) @?= [normalizeDecl decl]
 
+test_patternBindGuardedVarTypeSigPrettyPrints :: Assertion
+test_patternBindGuardedVarTypeSigPrettyPrints = do
+  let decl =
+        DeclValue
+          ( PatternBind
+              (PTypeSig (PVar (mkUnqualifiedName NameVarId "y")) (TVar (mkUnqualifiedName NameVarId "t")))
+              ( GuardedRhss
+                  []
+                  [ GuardedRhs [] [GuardExpr (EVar (qualifyName Nothing (mkUnqualifiedName NameVarId "cond")))] (EInt 0 TInteger "0")
+                  ]
+                  Nothing
+              )
+          )
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "y :: t | cond = 0"
+  case parseTopDecl rendered of
+    Right actual -> normalizeDecl actual @?= normalizeDecl decl
+    Left err -> assertFailure (show err)
+
 test_infixFunctionHeadTypedPatternPrettyPrints :: Assertion
 test_infixFunctionHeadTypedPatternPrettyPrints = do
   let match =
@@ -505,6 +533,20 @@ test_infixFunctionHeadTypedPatternPrettyPrints = do
   let (errs, modu) = parseModule defaultConfig {parserExtensions = [UnboxedSums]} rendered
   assertBool ("expected no parse errors, got: " <> show errs) (null errs)
   map normalizeDecl (moduleDecls modu) @?= [normalizeDecl decl]
+
+test_topLevelUnboxedSumPatternBindRoundTrip :: Assertion
+test_topLevelUnboxedSumPatternBindRoundTrip = do
+  let decl =
+        DeclValue
+          ( PatternBind
+              (PUnboxedSum 0 2 (PVar (mkUnqualifiedName NameVarId "a")))
+              (UnguardedRhs [] (EVar (qualifyName Nothing (mkUnqualifiedName NameVarSym "+"))) Nothing)
+          )
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "(# a |  #) = (+)"
+  case parseTopDeclWithExts [UnboxedSums] rendered of
+    Right actual -> normalizeDecl actual @?= normalizeDecl decl
+    Left err -> assertFailure (show err)
 
 test_qualifiedSplicePatternBodyPrettyPrints :: Assertion
 test_qualifiedSplicePatternBodyPrettyPrints = do
@@ -2794,6 +2836,24 @@ test_funHeadPrefixConstructorArg =
     Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PCon_ "Just" [PVar_ "x"], PVar_ "y"]}])) -> pure ()
     other -> assertFailure ("expected constructor application argument in prefix function head, got: " <> show other)
 
+test_funHeadPrefixQuasiQuoteArg :: Assertion
+test_funHeadPrefixQuasiQuoteArg =
+  case parseTopDeclWithExts [QuasiQuotes] "f [qq||] = ()" of
+    Right (DeclValue (FunctionBind "f" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PQuasiQuote "qq" ""]}])) -> pure ()
+    other -> assertFailure ("expected quasiquote argument in prefix function head, got: " <> show other)
+
+test_funHeadPrefixOpQuasiQuoteArg :: Assertion
+test_funHeadPrefixOpQuasiQuoteArg =
+  case parseTopDeclWithExts [QuasiQuotes] "(+) [qq||] = ()" of
+    Right (DeclValue (FunctionBind "+" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PQuasiQuote "qq" ""]}])) -> pure ()
+    other -> assertFailure ("expected quasiquote argument after symbolic prefix name, got: " <> show other)
+
+test_funHeadPrefixUnicodeOpQuasiQuoteArg :: Assertion
+test_funHeadPrefixUnicodeOpQuasiQuoteArg =
+  case parseTopDeclWithExts [QuasiQuotes] "(꩸) [a||] = ()" of
+    Right (DeclValue (FunctionBind "꩸" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PQuasiQuote "a" ""]}])) -> pure ()
+    other -> assertFailure ("expected quasiquote argument after unicode symbolic prefix name, got: " <> show other)
+
 test_funHeadPrefixListViewPattern :: Assertion
 test_funHeadPrefixListViewPattern =
   case parseTopDeclWithExts [ViewPatterns] "fn [id -> x] = x" of
@@ -2825,6 +2885,38 @@ test_recordExprExplicitSameNameBindingRoundTrip =
    in if not (null errs)
         then assertFailure (show errs)
         else renderStrict (layoutPretty defaultLayoutOptions (pretty modu)) @?= T.intercalate "\n" ["module RecordExprExplicit where", "data Event = Event {ref :: Int}", "mk ref = Event {ref = ref}"]
+
+test_localGuardedTypedBindWhereRoundTrip :: Assertion
+test_localGuardedTypedBindWhereRoundTrip =
+  let input = T.unlines ["module TypeSignatureGuards where", "f x = y", "  where", "    y :: Int", "      | x > 0 = 1", "      | otherwise = 0"]
+      (errs, modu) = parseModule defaultConfig input
+   in if not (null errs)
+        then assertFailure (show errs)
+        else do
+          let rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty modu))
+              (roundtripErrs, roundtripModu) = parseModule defaultConfig rendered
+          assertBool ("expected pretty-printed module to parse, got: " <> show roundtripErrs) (null roundtripErrs)
+          map normalizeDecl (moduleDecls roundtripModu) @?= map normalizeDecl (moduleDecls modu)
+
+test_caseAltTypedStrictNegativePatternParses :: Assertion
+test_caseAltTypedStrictNegativePatternParses =
+  case parseExpr defaultConfig {parserExtensions = [UnicodeSyntax]} "case 'r' of { !(-21.8) :: (Ⱁϗẙ.:⸹) -> () }" of
+    ParseOk _ -> pure ()
+    other -> assertFailure ("expected typed strict negative case pattern to parse, got: " <> show other)
+
+test_topLevelNullarySymConPatternBind :: Assertion
+test_topLevelNullarySymConPatternBind =
+  case parseTopDecl "(:+) = []" of
+    Right (DeclValue (PatternBind (PCon_ op []) _))
+      | op == qualifyName Nothing (mkUnqualifiedName NameConSym ":+") -> pure ()
+    other -> assertFailure ("expected nullary symbolic constructor pattern bind, got: " <> show other)
+
+test_topLevelNullarySymConPatternBindWhere :: Assertion
+test_topLevelNullarySymConPatternBindWhere =
+  case parseTopDecl "(:+) = [] where { x = () }" of
+    Right (DeclValue (PatternBind (PCon_ op []) (UnguardedRhs _ _ (Just _))))
+      | op == qualifyName Nothing (mkUnqualifiedName NameConSym ":+") -> pure ()
+    other -> assertFailure ("expected nullary symbolic constructor pattern bind with where, got: " <> show other)
 
 test_funHeadPrefixUnboxedTupleSingletonArg :: Assertion
 test_funHeadPrefixUnboxedTupleSingletonArg =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -43,7 +43,7 @@ import Test.Properties.Identifiers
     shrinkIdent,
   )
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip)
-import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
+import Test.Properties.PatternRoundTrip (normalizePattern, prop_patternPrettyRoundTrip)
 import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
 import Test.QuickCheck (Arbitrary (arbitrary), Gen, Property, counterexample)
 import Test.QuickCheck.Gen qualified as QGen
@@ -449,6 +449,10 @@ buildTests = do
               QC.testProperty "generated type names can appear in empty bundled import syntax" prop_generatedTypeNamesSupportEmptyBundledImports,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
               QC.testProperty "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
+              testCase "pretty-prints negative literal pattern type signatures with inner parens" test_patternTypeSigNegativeLiteralPrettyPrints,
+              testCase "pretty-prints non-variable typed pattern binds with outer parens" test_patternBindTypedConstructorPrettyPrints,
+              testCase "pretty-prints infix function head typed patterns with parens" test_infixFunctionHeadTypedPatternPrettyPrints,
+              testCase "pretty-prints qualified TH splice pattern bodies with explicit parens" test_qualifiedSplicePatternBodyPrettyPrints,
               QC.testProperty "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip
             ],
         oracle,
@@ -458,6 +462,66 @@ buildTests = do
         stackageProgressFileCheckerTimingTests,
         stackageProgressSummaryTests
       ]
+
+test_patternTypeSigNegativeLiteralPrettyPrints :: Assertion
+test_patternTypeSigNegativeLiteralPrettyPrints = do
+  let pat = PTypeSig (PNegLit (LitInt 66 TInteger "66")) (TVar (mkUnqualifiedName NameVarId "t"))
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty pat))
+  rendered @?= "(-66) :: t"
+  case parsePattern defaultConfig rendered of
+    ParseOk actual ->
+      normalizePattern actual @?= PTypeSig (PParen (PNegLit (LitInt 66 TInteger "66"))) (TVar (mkUnqualifiedName NameVarId "t"))
+    ParseErr err -> assertFailure (MPE.errorBundlePretty err)
+
+test_patternBindTypedConstructorPrettyPrints :: Assertion
+test_patternBindTypedConstructorPrettyPrints = do
+  let decl =
+        DeclValue
+          ( PatternBind
+              (PTypeSig (PCon (qualifyName Nothing (mkUnqualifiedName NameConId "K")) [] []) (TVar (mkUnqualifiedName NameVarId "t")))
+              (UnguardedRhs [] (ETuple Boxed []) Nothing)
+          )
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "(K :: t) = ()"
+  let (errs, modu) = parseModule defaultConfig rendered
+  assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+  map normalizeDecl (moduleDecls modu) @?= [normalizeDecl decl]
+
+test_infixFunctionHeadTypedPatternPrettyPrints :: Assertion
+test_infixFunctionHeadTypedPatternPrettyPrints = do
+  let match =
+        Match
+          { matchAnns = [],
+            matchHeadForm = MatchHeadInfix,
+            matchPats =
+              [ PTypeSig (PUnboxedSum 1 3 (PVar (mkUnqualifiedName NameVarId "a"))) (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "T")) Unpromoted),
+                PRecord (qualifyName Nothing (mkUnqualifiedName NameConSym ":+")) [] False
+              ],
+            matchRhs = UnguardedRhs [] (EArithSeq (ArithSeqFrom (ETuple Boxed []))) Nothing
+          }
+      decl = DeclValue (FunctionBind (mkUnqualifiedName NameVarSym "++") [match])
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "((#  | a |  #) :: T) ++ (:+) {} = [() ..]"
+  let (errs, modu) = parseModule defaultConfig {parserExtensions = [UnboxedSums]} rendered
+  assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+  map normalizeDecl (moduleDecls modu) @?= [normalizeDecl decl]
+
+test_qualifiedSplicePatternBodyPrettyPrints :: Assertion
+test_qualifiedSplicePatternBodyPrettyPrints = do
+  let spliceExpr = EVar (mkName (Just "M") NameVarId "pat")
+      match =
+        Match
+          { matchAnns = [],
+            matchHeadForm = MatchHeadPrefix,
+            matchPats = [PSplice spliceExpr],
+            matchRhs = UnguardedRhs [] (ETuple Boxed []) Nothing
+          }
+      decl = DeclValue (FunctionBind (mkUnqualifiedName NameVarId "f") [match])
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty decl))
+  rendered @?= "f $(M.pat) = ()"
+  let (errs, modu) = parseModule defaultConfig {parserExtensions = [TemplateHaskell]} rendered
+  assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+  map normalizeDecl (moduleDecls modu) @?= [normalizeDecl decl]
 
 test_moduleParsesDecls :: Assertion
 test_moduleParsesDecls =
@@ -2813,7 +2877,7 @@ test_funHeadPrefixThOperatorSplicePattern =
 test_funHeadPrefixThNegativeSplicePattern :: Assertion
 test_funHeadPrefixThNegativeSplicePattern =
   case parseTopDecl "{-# LANGUAGE TemplateHaskell #-}\nx $(-()) = ()" of
-    Right (DeclValue (FunctionBind "x" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PSplice_ (EParen (ENegate (ETuple Boxed [])))], matchRhs = UnguardedRhs _ (ETuple Boxed []) _}])) -> pure ()
+    Right (DeclValue (FunctionBind "x" [Match {matchHeadForm = MatchHeadPrefix, matchPats = [PSplice_ (ENegate (ETuple Boxed []))], matchRhs = UnguardedRhs _ (ETuple Boxed []) _}])) -> pure ()
     other -> assertFailure ("expected TH negative splice pattern in prefix function bind, got: " <> show other)
 
 test_funHeadParenInfix :: Assertion

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/agda-where-guarded-type-sig-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/agda-where-guarded-type-sig-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail type signature followed by guarded definition in where clause not supported -}
+{- ORACLE_TEST pass -}
 module AgdaWhereGuardedTypeSig where
 
 f x = y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/constructor-pattern-type-sig-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ScopedTypeVariables/constructor-pattern-type-sig-equation.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ScopedTypeVariables #-}
+module ConstructorPatternTypeSigEquation where
+
+C :: forall a. Show a => a = C

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeSignatureGuards/constructor-equation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeSignatureGuards/constructor-equation.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module TypeSignatureGuardsConstructorEquation where
+
+C :: D = C

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeSignatureGuards/where-clause.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeSignatureGuards/where-clause.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail type signature followed by guards in where clause -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE GHC2021 #-}
 module TypeSignatureGuards where
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -29,7 +29,7 @@ instance Arbitrary Module where
       Module
         { moduleAnns = [],
           moduleHead = mHead,
-          moduleLanguagePragmas = [],
+          moduleLanguagePragmas = generatedModuleExtensions,
           moduleImports = imports,
           moduleDecls = decls
         }
@@ -45,6 +45,29 @@ instance Arbitrary Module where
       <> [ modu {moduleHead = shrunk}
          | shrunk <- shrinkMaybeModuleHead (moduleHead modu)
          ]
+
+generatedModuleExtensions :: [ExtensionSetting]
+generatedModuleExtensions =
+  map
+    EnableExtension
+    [ BlockArguments,
+      Arrows,
+      UnboxedTuples,
+      UnboxedSums,
+      TemplateHaskell,
+      UnicodeSyntax,
+      QuasiQuotes,
+      PatternSynonyms,
+      MagicHash,
+      OverloadedLabels,
+      MultiWayIf,
+      RecursiveDo,
+      CApiFFI,
+      ImplicitParams,
+      TypeAbstractions,
+      RequiredTypeArguments,
+      LambdaCase
+    ]
 
 -- | Generate an optional module head.
 -- Most modules have explicit headers, but implicit modules (Nothing) are also valid.

--- a/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Pattern.hs
@@ -79,16 +79,7 @@ genPatternConWith = do
 
 genPatternTypeSigWith :: Gen Pattern
 genPatternTypeSigWith = do
-  -- TODO: Remove the PNegLit wrapping once the pretty-printer correctly
-  -- parenthesizes PNegLit inside PTypeSig. Currently, PTypeSig (PNegLit 66) T
-  -- prints as (-66 :: T) which the parser interprets as negation applied to
-  -- (66 :: T) rather than a type signature on -66.
-  inner <- wrapNegLit <$> genPattern
-  PParen . PTypeSig inner <$> genPatternType
-  where
-    -- FIXME: This is a hack to get the pretty-printer to correctly parenthesize PNegLit inside PTypeSig. Remove!
-    wrapNegLit p@(PNegLit {}) = PParen p
-    wrapNegLit p = p
+  PTypeSig <$> genPattern <*> genPatternType
 
 -- | Generate a simple type for use in pattern type signatures.
 genPatternType :: Gen Type

--- a/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprHelpers.hs
@@ -147,11 +147,19 @@ normalizePattern pat =
       let normInner = normalizePattern inner
        in case normInner of
             PCon con [] [] | nameType con == NameConSym -> normInner
+            PSplice {} -> normInner
+            PTypeSig {} -> normInner
             _ -> PParen normInner
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (normalizePattern inner)
     PRecord con fields rwc -> PRecord con [field {recordFieldValue = normalizePattern (recordFieldValue field)} | field <- fields] rwc
     PTypeSig inner ty -> PTypeSig (normalizePattern inner) (normalizeType ty)
-    PSplice body -> PSplice (normalizeExpr body)
+    PSplice body -> PSplice (normalizeSpliceBody body)
+
+normalizeSpliceBody :: Expr -> Expr
+normalizeSpliceBody expr =
+  case normalizeExpr expr of
+    EParen inner -> inner
+    other -> other
 
 -- | Normalize a pattern in lambda argument position.
 -- The pretty-printer uses prettyLambdaPatternAtom for lambda patterns, which

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Properties.PatternRoundTrip
-  ( prop_patternPrettyRoundTrip,
+  ( normalizePattern,
+    prop_patternPrettyRoundTrip,
   )
 where
 
@@ -61,6 +62,8 @@ normalizePattern pat =
       let normInner = normalizePattern inner
        in case normInner of
             PCon con [] [] | nameType con == NameConSym -> normInner
+            PSplice {} -> normInner
+            PTypeSig {} -> normInner
             _ -> PParen normInner
     PUnboxedSum altIdx arity inner -> PUnboxedSum altIdx arity (normalizePattern inner)
     PRecord con fields rwc -> PRecord con [field {recordFieldValue = normalizePattern (recordFieldValue field)} | field <- fields] rwc


### PR DESCRIPTION
## Summary
- remove the `genPatternTypeSigWith` workaround so typed patterns are generated directly without extra `PParen`/`wrapNegLit` hacks
- fix pattern parenthesization for typed patterns in pretty-printed patterns, declaration heads, infix function heads, and qualified TH splice bodies
- add focused regressions and normalize parser-added wrapper parens so typed pattern and splice roundtrips stay stable