### PR TITLE
fix(cpp): expand multiline function-like macro calls

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -93,11 +93,20 @@ countExtraLinesConsumed st txt moreLines = scanForFunctionMacro False False Fals
     -- Try to parse function call args, potentially spanning multiple lines.
     -- Returns Just n if the call spans n extra lines, Nothing if no call.
     tryMultilineCallArgs :: Text -> Maybe Int
-    tryMultilineCallArgs rest =
-      case T.uncons rest of
+    tryMultilineCallArgs rest = seekOpenParen (T.dropWhile isSpace rest) 0
+
+    seekOpenParen :: Text -> Int -> Maybe Int
+    seekOpenParen remaining extraLines =
+      case T.uncons remaining of
         Just ('(', afterOpen) ->
-          findClosingParen 0 afterOpen 0
-        _ -> Nothing
+          findClosingParen 0 afterOpen extraLines
+        Just _ ->
+          Nothing
+        Nothing ->
+          case drop extraLines moreLines of
+            [] -> Nothing
+            (nextLine : _) ->
+              seekOpenParen (T.dropWhile isSpace nextLine) (extraLines + 1)
 
     findClosingParen :: Int -> Text -> Int -> Maybe Int
     findClosingParen depth remaining extraLines =
@@ -186,7 +195,7 @@ expandIdentBlue st painted txt acc =
 -- | Parse function-like macro call arguments.
 parseCallArgs :: Text -> Maybe ([Text], Text)
 parseCallArgs input = do
-  ('(', rest) <- T.uncons input
+  ('(', rest) <- T.uncons (T.dropWhile isSpace input)
   parseArgs 0 [] mempty rest
 
 parseArgs :: Int -> [Text] -> TB.Builder -> Text -> Maybe ([Text], Text)

--- a/components/aihc-cpp/test/Test/Fixtures/progress/macro-comment-replacement.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/macro-comment-replacement.hs
@@ -1,0 +1,2 @@
+#  define DEBUG_TRACE(s)    {- nothing -}
+DEBUG_TRACE(id)

--- a/components/aihc-cpp/test/Test/Fixtures/progress/macro-comment-replacement.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/macro-comment-replacement.hs
@@ -1,2 +1,3 @@
 #  define DEBUG_TRACE(s)    {- nothing -}
-DEBUG_TRACE(id)
+DEBUG_TRACE
+  (id)

--- a/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -38,3 +38,4 @@ hpp-file-macro-string-pattern	macro	hpp-file-macro-string-pattern.hs	pass
 rules-pragma-cpp-branch	lexing	rules-pragma-cpp-branch.hs	pass
 macro-multiline-args	macro	macro-multiline-args.hs	pass
 stringify-paste-pair	macro	stringify-paste-pair.hs	pass
+macro-comment-replacement	macro	macro-comment-replacement.hs	pass


### PR DESCRIPTION
## Summary
- add a CPP oracle regression fixture for a function-like macro whose replacement list is only a Haskell block comment and whose invocation places `(` on the next line
- teach function-like macro expansion to skip intervening whitespace, including newlines, before checking for the opening parenthesis
- keep CPP progress at 100% while increasing covered pass cases

## Why
This macro shape appears in the wild and `cpphs` treats the split invocation as a valid function-like macro call. Our preprocessor was leaving `DEBUG_TRACE` unexpanded when the opening parenthesis appeared on the next line.

## Impact
`aihc-cpp` now matches the oracle for multiline whitespace-separated function-like macro calls, including comment-only replacement lists.

## Root Cause
The function-like macro path only recognized a call when `(` appeared immediately after the macro name on the same line. That restriction existed both in normal argument parsing and in the multiline lookahead used to join subsequent lines before expansion.

## Progress
CPP oracle progress: PASS 40 (was 39), XFAIL 0, XPASS 0, FAIL 0.

## Validation
- `cabal test -v0 aihc-cpp:spec --test-options='--pattern macro-comment-replacement --hide-successes'`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (started earlier, but did not return a result in time)
