### PR TITLE
test: add minimal oracle xfails for hackage parser failures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-concat-if-chain-roundtrip-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ghc-events-concat-if-chain-roundtrip-xfail.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail roundtrip re-associates multiline <> chains that end in if -}
+module GhcEventsConcatIfChainRoundtripXfail where
+
+f a b c d e =
+  "cost centre " <> a
+  <> " " <> b
+  <> " in " <> c
+  <> " at " <> d
+  <> if e then " CAF" else ""

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/test-fun-type-operator-context-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/test-fun-type-operator-context-xfail.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail parser rejects infix constructor syntax in data declarations -}
+{-# LANGUAGE TypeOperators #-}
+module TestFunTypeOperatorContextXfail where
+
+data Var = Var
+
+data Expr = Expr
+
+data Ctx = (Var, Expr) :. Ctx


### PR DESCRIPTION
## Summary
- add a minimal oracle xfail for the `test-fun` infix `:.` data-constructor parse failure
- add a minimal oracle xfail for the `ghc-events` multiline `<>` chain roundtrip mismatch
- leave the `ghc-events` `Binary.hs` parse failure out of this PR because it did not reduce to a trustworthy standalone oracle repro without changing the failure mode

## Progress Counts
- parser progress: `PASS 1021`, `XFAIL 2`, `XPASS 0`, `FAIL 0`, `TOTAL 1023`, `COMPLETE 99.8%`
- extension progress: `TypeOperators` is now `PASS 56`, `XFAIL 1`, `XPASS 0`, `FAIL 0`

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern test-fun-type-operator-context-xfail --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern ghc-events-concat-if-chain-roundtrip-xfail --hide-successes"`
- `just fmt`
- `just check`

## Pre-PR Review
- `coderabbit review --prompt-only` was attempted after local checks passed, but the service was rate-limited and could not start a review.
