### PR TITLE
fix(parser): preserve open-ended section lhs grouping

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -279,6 +279,24 @@ exprCtxPrec ctx expr =
     CtxTypeSigBody -> 1
     CtxGuarded -> 0
 
+-- | Parenthesize a left section operand while protecting any rightmost
+-- open-ended infix RHS from absorbing the section operator.
+addSectionLhsParens :: Expr -> Expr
+addSectionLhsParens expr =
+  case peelExprAnn expr of
+    EInfix lhs op rhs ->
+      EInfix
+        (addExprParensIn CtxInfixLhs lhs)
+        op
+        (addSectionInfixRhsParens rhs)
+    _ -> addExprParensPrec 1 expr
+  where
+    addSectionInfixRhsParens rhs =
+      case peelExprAnn rhs of
+        EInfix {} -> addSectionLhsParens rhs
+        _ | isOpenEnded rhs -> wrapExpr True (addExprParens rhs)
+        _ -> addExprParensIn (CtxInfixRhs False) rhs
+
 -- ---------------------------------------------------------------------------
 -- Type contexts
 -- ---------------------------------------------------------------------------
@@ -876,7 +894,7 @@ addExprParensPrec prec expr =
       let lhs' =
             if isGreedyExpr lhs || isTypeSig lhs
               then wrapExpr True (addExprParens lhs)
-              else addExprParensPrec 1 lhs
+              else addSectionLhsParens lhs
        in EParen (ESectionL lhs' op)
     ESectionR op rhs ->
       EParen (ESectionR op (addExprParens rhs))

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -5,7 +5,7 @@ module Main (main) where
 
 import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
-import Aihc.Parser.Parens (addDeclParens)
+import Aihc.Parser.Parens (addDeclParens, addExprParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import Data.Char (ord)
@@ -121,6 +121,7 @@ buildTests = do
             testCase "generated variable symbols reject reserved spellings" test_generatedVariableSymbolsRejectReservedSpellings,
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
+            testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
             localOption (QC.QuickCheckTests 2000) $
               QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
@@ -690,6 +691,25 @@ test_bundledExportWildcardPosition = do
                 assertFailure ("unexpected reparsed export AST: " <> show other)
           other ->
             assertFailure ("unexpected export AST: " <> show other)
+
+test_prettyInfixRhsOpenEndedInsideSection :: Assertion
+test_prettyInfixRhsOpenEndedInsideSection = do
+  let config = defaultConfig {parserExtensions = [LambdaCase]}
+      op = qualifyName Nothing (mkUnqualifiedName NameVarId "a")
+      expr =
+        ESectionL
+          ( EInfix
+              (ELambdaCase [])
+              op
+              (ELambdaPats [PLit (LitInt 0 TInteger "0")] (EChar ' ' "' '"))
+          )
+          op
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+  case parseExpr config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
 
 test_associatedDataFamilyOperatorName :: Assertion
 test_associatedDataFamilyOperatorName = do


### PR DESCRIPTION
## Summary
- preserve left-section grouping when the left operand ends in an infix expression whose rightmost RHS is open-ended
- add a regression test covering the replayed lambda-case/section round-trip failure

## Verification
- `just replay "(SMGen 4862032834652784284 4079606875146905715,94)"`
- `just check`

## Progress counts
- unchanged

## Pre-PR review
- `coderabbit review --prompt-only` was skipped because CodeRabbit was rate-limited for the organization
