### PR TITLE
fix(nix): include hidden modules in coverage reports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
     };
     coverage = import ./scripts/nix/coverage.nix {
       inherit (core) projectHsPackages;
+      inherit sources;
       inherit (haskell) mkHsPkgsWithCoverage;
     };
     wasm = import ./scripts/nix/wasm.nix {

--- a/scripts/nix/coverage.nix
+++ b/scripts/nix/coverage.nix
@@ -1,19 +1,69 @@
 {
   projectHsPackages,
+  sources,
   mkHsPkgsWithCoverage,
 }: {
   mkCoverageReport = pkgs: let
     hsPkgsCoverage = mkHsPkgsWithCoverage pkgs;
     parserWithCoverage = pkgs.haskell.lib.doCheck hsPkgsCoverage.aihc-parser;
     cppWithCoverage = pkgs.haskell.lib.doCheck hsPkgsCoverage.aihc-cpp;
+    parserSrc = sources.parserSrc pkgs;
+    cppSrc = sources.cppSrc pkgs;
   in
     pkgs.runCommand "aihc-coverage" {
-      nativeBuildInputs = [(projectHsPackages pkgs).ghc pkgs.gnused pkgs.gnugrep];
-      inherit parserWithCoverage cppWithCoverage;
+      nativeBuildInputs = [(projectHsPackages pkgs).ghc pkgs.findutils pkgs.gnused pkgs.gnugrep];
+      inherit parserWithCoverage cppWithCoverage parserSrc cppSrc;
     } ''
       mkdir -p "$out"
 
       echo "=== Collecting HPC Coverage Data ==="
+
+      build_module_list() {
+        local src_dir="$1"
+        local output_file="$2"
+
+        find "$src_dir" -type f -name '*.hs' ! -name '*.hs-boot' | sort | while IFS= read -r source_file; do
+          local rel_path module_name
+          rel_path="''${source_file#"$src_dir"/}"
+          module_name="''${rel_path%.hs}"
+          printf '%s\n' "''${module_name//\//.}"
+        done > "$output_file"
+      }
+
+      render_hpc_html() {
+        local package_name="$1"
+        local hpc_root="$2"
+        local html_dir="$3"
+        local src_root="$4"
+        local module_list="$5"
+
+        local tix_file
+        tix_file=$(find "$hpc_root" -type f -name '*.tix' | head -n1)
+        if [ -z "$tix_file" ]; then
+          echo "No .tix file found for $package_name under $hpc_root"
+          return 1
+        fi
+
+        if [ ! -d "$hpc_root/vanilla/mix" ]; then
+          echo "No mix directory found for $package_name under $hpc_root"
+          return 1
+        fi
+
+        local stage_root
+        stage_root=$(mktemp -d)
+        cp -r "$src_root"/. "$stage_root/"
+        mkdir -p "$stage_root/.hpc"
+        cp -r "$hpc_root/vanilla/mix"/. "$stage_root/.hpc/"
+
+        local -a module_args
+        mapfile -t module_args < "$module_list"
+        if [ "''${#module_args[@]}" -eq 0 ]; then
+          echo "No modules found under $src_root/src for $package_name"
+          return 1
+        fi
+
+        hpc markup "$tix_file" "--destdir=$html_dir" "--srcdir=$stage_root" "''${module_args[@]}"
+      }
 
       # Function to extract expression coverage percentage from HPC HTML
       # and generate a shields.io compatible JSON badge file.
@@ -60,8 +110,9 @@
       if [ -d "$parserWithCoverage/hpc" ]; then
         echo "Found parser coverage data"
         cp -r "$parserWithCoverage/hpc" "$out/aihc-parser-hpc"
-        if [ -d "$parserWithCoverage/hpc/vanilla/html" ]; then
-          cp -r "$parserWithCoverage/hpc/vanilla/html" "$out/aihc-parser-html"
+        parser_modules="$TMPDIR/aihc-parser-modules.txt"
+        build_module_list "$parserSrc/src" "$parser_modules"
+        if render_hpc_html "aihc-parser" "$out/aihc-parser-hpc" "$out/aihc-parser-html" "$parserSrc" "$parser_modules"; then
           extract_coverage_badge \
             "$out/aihc-parser-html/hpc_index.html" \
             "$out/aihc-parser-badge.json" \
@@ -75,8 +126,9 @@
       if [ -d "$cppWithCoverage/hpc" ]; then
         echo "Found cpp coverage data"
         cp -r "$cppWithCoverage/hpc" "$out/aihc-cpp-hpc"
-        if [ -d "$cppWithCoverage/hpc/vanilla/html" ]; then
-          cp -r "$cppWithCoverage/hpc/vanilla/html" "$out/aihc-cpp-html"
+        cpp_modules="$TMPDIR/aihc-cpp-modules.txt"
+        build_module_list "$cppSrc/src" "$cpp_modules"
+        if render_hpc_html "aihc-cpp" "$out/aihc-cpp-hpc" "$out/aihc-cpp-html" "$cppSrc" "$cpp_modules"; then
           extract_coverage_badge \
             "$out/aihc-cpp-html/hpc_index.html" \
             "$out/aihc-cpp-badge.json" \

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -74,6 +74,12 @@
             mkdir -p "$out/hpc"
             cp -r dist/hpc/* "$out/hpc/"
           fi
+
+          target_mix=dist/build/extra-compilation-artifacts/hpc/vanilla/mix
+          if [ -d "$target_mix" ]; then
+            mkdir -p "$out/hpc/vanilla/mix"
+            cp -r "$target_mix"/* "$out/hpc/vanilla/mix/"
+          fi
         '';
     });
 


### PR DESCRIPTION
## Summary

- regenerate HPC HTML from raw `.tix` and exported `.mix` data instead of reusing Cabal's exposed-only report output
- export coverage `.mix` files from coverage-enabled package builds so `hpc markup` can render all compiled modules
- build the module list from each component's `src/` tree so hidden library modules appear in the published coverage index

## Why

`nix build .#coverage` was only surfacing exposed modules for `aihc-parser`, even though the tests compile and exercise hidden modules where most parser logic lives. The root cause was twofold:

1. the coverage artifact exported `.tix` and Cabal's prebuilt HTML, but not the `.mix` files needed to regenerate coverage pages
2. the published report reused Cabal's HTML, which only indexed the exposed surface modules for this package

This change stages the component source tree with a `.hpc` directory and runs `hpc markup` over every source module, so the coverage report includes hidden modules such as `Aihc.Parser.Internal.*` and lexer internals.

## Impact

Users of `.#coverage` now get a parser coverage report that reflects the real implementation surface, not just the exposed API.

Progress counts: no parser/lexer progress counts changed in this PR.

## Validation

- `nix build .#coverage`
- `just fmt`
- `just check`

## Pre-PR Review

- `coderabbit review --prompt-only` was attempted after local checks passed
- CodeRabbit returned a rate-limit error, so no review output was available to address before opening this PR
