### PR TITLE
test(parser): add ghc-events CPP block comment oracle xfail

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/CPP/macro-expansion-block-comment-literal.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/CPP/macro-expansion-block-comment-literal.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail aihc cpp preprocessing leaves C-style block comments in expanded source, so the parser sees '/*' that GHC strips on a second CPP pass -}
+{-# LANGUAGE CPP #-}
+module MacroExpansionBlockCommentLiteral where
+
+#define HET 0x68657462 /* 'h' 'e' 't' 'b' */
+
+f x = case x of
+  HET -> ()
+  _ -> ()


### PR DESCRIPTION
## Summary
- add a minimal oracle `xfail` reproducer for the `ghc-events` parse failure in `GHC.RTS.Events.Binary`
- capture that `aihc` currently sees `/* ... */` from CPP macro expansion as source, while GHC accepts the same module after its own preprocessing path
- progress counts: pass=1030 xfail=13 xpass=0 fail=0 completion=99.16%

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle"`
- `just fmt`
- `just check`

## CodeRabbit
- skipped because `coderabbit review --prompt-only` hit a rate limit
