### PR TITLE
fix(nix): skip tests, profiling, and haddock for upstream deps; use nixpkgs ormolu/hlint

### DIFF
--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -42,12 +42,12 @@
     alejandra --check .
   '';
 
-  haskellLint = mkSourceCheck "aihc-haskell-lint" (sources.haskellSrc pkgs) [(projectHsPackages pkgs).hlint pkgs.findutils] ''
+  haskellLint = mkSourceCheck "aihc-haskell-lint" (sources.haskellSrc pkgs) [pkgs.hlint pkgs.findutils] ''
     find . -type f -name '*.hs' -print0 \
       | xargs -0 -r hlint
   '';
 
-  haskellFormat = mkSourceCheck "aihc-haskell-format" (sources.haskellSrc pkgs) [(projectHsPackages pkgs).ormolu pkgs.findutils] ''
+  haskellFormat = mkSourceCheck "aihc-haskell-format" (sources.haskellSrc pkgs) [pkgs.ormolu pkgs.findutils] ''
     find . -type f -name '*.hs' -print0 \
       | xargs -0 -r ormolu --mode check
   '';

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -98,7 +98,10 @@
       name: drv:
         if builtins.elem name localPackageNames || !(isOverridableHaskellDrv pkgs drv)
         then drv
-        else hsLib.dontCheck drv
+        else
+          hsLib.dontCheck
+          (hsLib.dontHaddock
+            (hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling drv)))
     )
     prev;
 in rec {

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -91,7 +91,7 @@
     else drv;
 
   isOverridableHaskellDrv = pkgs: drv:
-    pkgs.lib.isDerivation drv && drv ? overrideScope;
+    pkgs.lib.isDerivation drv && drv.isHaskellLibrary or false;
 
   disableUpstreamChecks = pkgs: hsLib: localPackageNames: _final: prev:
     builtins.mapAttrs (

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -157,10 +157,15 @@ in rec {
         disableUpstreamChecks pkgs hsLib localPackageNames final prev
         // hackageDepTestFixes pkgs final prev
         // {
-          ghc-lib-parser = pkgs.haskell.lib.dontHaddock final.ghc-lib-parser_9_14_1_20251220;
-          aihc-hackage = pkgs.haskell.lib.dontCheck (
-            pkgs.haskell.lib.dontHaddock (final.callCabal2nix "aihc-hackage" (sources.hackageSrc pkgs) {})
-          );
+          ghc-lib-parser = hsLib.dontCheck (hsLib.dontHaddock (
+            hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling
+              final.ghc-lib-parser_9_14_1_20251220)
+          ));
+          aihc-hackage = hsLib.dontCheck (hsLib.dontHaddock (
+            hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling (
+              final.callCabal2nix "aihc-hackage" (sources.hackageSrc pkgs) {}
+            ))
+          ));
         }
         // builtins.mapAttrs (mkComponent final) componentSpecs;
     };


### PR DESCRIPTION
## Summary

- `disableUpstreamChecks` now applies `dontCheck`, `dontHaddock`, `disableLibraryProfiling`, and `disableExecutableProfiling` to all upstream (non-local) Haskell dependencies, eliminating unnecessary test runs, Haddock builds, and profiling variants for deps during `nix flake check`.
- `haskell-lint` and `haskell-format` checks now use `pkgs.hlint` and `pkgs.ormolu` from plain nixpkgs instead of the project's Haskell package set, improving binary cache hit rates.