### PR TITLE
refactor(parser): share parser helper combinators

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -15,12 +15,14 @@ module Aihc.Parser.Internal.Common
     identifierUnqualifiedNameParser,
     identifierTextParser,
     lowerIdentifierParser,
+    tyVarNameParser,
     implicitParamNameParser,
     constructorNameParser,
     constructorUnqualifiedNameParser,
     constructorOperatorUnqualifiedNameParser,
     constructorIdentifierParser,
     binderNameParser,
+    recordFieldNameParser,
     operatorNameParser,
     operatorUnqualifiedNameParser,
     operatorTextParser,
@@ -29,6 +31,7 @@ module Aihc.Parser.Internal.Common
     stringTextParser,
     withSpan,
     withSpanAnn,
+    optionalSuffix,
     sourceSpanFromPositions,
     parens,
     braces,
@@ -47,6 +50,9 @@ module Aihc.Parser.Internal.Common
     functionBindDecl,
     isExtensionEnabled,
     thAnyEnabled,
+    asPatternParser,
+    tupleDelimsParser,
+    recordFieldsWithWildcardsParser,
     closeImplicitLayout,
     layoutSepEndBy,
     layoutSepBy1,
@@ -289,6 +295,11 @@ lowerIdentifierParser =
       TkQVarId modName ident -> Just (modName <> "." <> ident)
       _ -> Nothing
 
+tyVarNameParser :: TokParser Text
+tyVarNameParser =
+  lowerIdentifierParser
+    <|> (expectedTok TkKeywordUnderscore $> "_")
+
 implicitParamNameParser :: TokParser Text
 implicitParamNameParser =
   tokenSatisfy "implicit parameter" $ \tok ->
@@ -326,6 +337,11 @@ binderNameParser :: TokParser UnqualifiedName
 binderNameParser =
   identifierUnqualifiedNameParser
     <|> parens operatorUnqualifiedNameParser
+
+recordFieldNameParser :: TokParser Name
+recordFieldNameParser =
+  identifierNameParser
+    <|> parens operatorNameParser
 
 operatorTextParser :: TokParser Text
 operatorTextParser = renderName <$> operatorNameParser
@@ -444,6 +460,15 @@ withSpan parser = do
   let endSpan = maybe noSourceSpan lexTokenSpan lastToken
       parserSpan = mergeSourceSpans startSpan endSpan
   pure (out parserSpan)
+
+optionalSuffix :: TokParser b -> (a -> b -> a) -> TokParser a -> TokParser a
+optionalSuffix suffixParser attach parser = do
+  base <- parser
+  mSuffix <- MP.optional suffixParser
+  pure $
+    case mSuffix of
+      Just suffix -> attach base suffix
+      Nothing -> base
 
 sourceSpanFromPositions :: SourcePos -> SourcePos -> SourceSpan
 sourceSpanFromPositions start end =
@@ -769,6 +794,31 @@ thAnyEnabled = do
   thEnabled <- isExtensionEnabled TemplateHaskellQuotes
   thFullEnabled <- isExtensionEnabled TemplateHaskell
   pure (thEnabled || thFullEnabled)
+
+asPatternParser :: TokParser Pattern -> TokParser Pattern
+asPatternParser bodyParser = withSpanAnn (PAnn . mkAnnotation) $ do
+  name <- identifierTextParser
+  expectedTok TkReservedAt
+  PAs name <$> bodyParser
+
+tupleDelimsParser :: TokParser (TupleFlavor, LexTokenKind)
+tupleDelimsParser =
+  (expectedTok TkSpecialLParen $> (Boxed, TkSpecialRParen))
+    <|> (expectedTok TkSpecialUnboxedLParen $> (Unboxed, TkSpecialUnboxedRParen))
+
+recordFieldsWithWildcardsParser :: TokParser [a] -> TokParser ([a], Bool)
+recordFieldsWithWildcardsParser fieldsParser = do
+  rwcEnabled <- isExtensionEnabled RecordWildCards
+  fields <- fieldsParser
+  if rwcEnabled
+    then do
+      mDotDot <- MP.optional (expectedTok TkReservedDotDot)
+      case mDotDot of
+        Nothing -> pure (fields, False)
+        Just _ -> do
+          _ <- MP.optional (expectedTok TkSpecialComma)
+          pure (fields, True)
+    else pure (fields, False)
 
 -- | Signal to the layout engine that a virtual close brace should be inserted.
 -- This implements the parse-error rule: when the parser encounters a token that

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -37,7 +37,6 @@ import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexToken
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
 import Control.Monad (guard)
-import Data.Functor (($>))
 import Data.Text (Text)
 import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
@@ -97,13 +96,11 @@ exprCoreParserWithoutTypeSigBody forbiddenInfix = do
     Nothing -> withInfix
 
 exprCoreParserWithTypeSigParserExcept :: TokParser Type -> [Text] -> TokParser Expr
-exprCoreParserWithTypeSigParserExcept typeSigParser forbiddenInfix = do
-  withArrow <- exprCoreParserWithoutTypeSigExcept forbiddenInfix
-  -- Optional type signature: expr :: type
-  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeSigParser)
-  pure $ case mTypeSig of
-    Just ty -> ETypeSig withArrow ty
-    Nothing -> withArrow
+exprCoreParserWithTypeSigParserExcept typeSigParser forbiddenInfix =
+  optionalSuffix
+    (expectedTok TkReservedDoubleColon *> typeSigParser)
+    ETypeSig
+    (exprCoreParserWithoutTypeSigExcept forbiddenInfix)
 
 -- | The operator name used to represent @->@ in view-pattern expressions.
 viewPatArrowName :: Name
@@ -222,24 +219,24 @@ exprParserNoArrowTail =
   label "expression" exprCoreParserNoArrowTail
 
 exprCoreParserNoArrowTail :: TokParser Expr
-exprCoreParserNoArrowTail = do
-  tok <- lookAhead anySingle
-  base <- case lexTokenKind tok of
-    TkKeywordDo -> doExprParser
-    TkKeywordMdo -> mdoExprParser
-    TkQualifiedDo {} -> qualifiedDoExprParser
-    TkQualifiedMdo {} -> qualifiedMdoExprParser
-    TkKeywordIf -> ifExprParser
-    TkKeywordLet -> letExprParser
-    TkKeywordProc -> procExprParser
-    TkReservedBackslash -> lambdaExprParser
-    _ -> infixExprParserExcept []
-  -- No arrow tail check here — leave -< / -<< for the command parser.
-  -- Optional type signature: expr :: type
-  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
-  pure $ case mTypeSig of
-    Just ty -> ETypeSig base ty
-    Nothing -> base
+exprCoreParserNoArrowTail =
+  optionalSuffix
+    (expectedTok TkReservedDoubleColon *> typeParser)
+    ETypeSig
+    baseParser
+  where
+    baseParser = do
+      tok <- lookAhead anySingle
+      case lexTokenKind tok of
+        TkKeywordDo -> doExprParser
+        TkKeywordMdo -> mdoExprParser
+        TkQualifiedDo {} -> qualifiedDoExprParser
+        TkQualifiedMdo {} -> qualifiedMdoExprParser
+        TkKeywordIf -> ifExprParser
+        TkKeywordLet -> letExprParser
+        TkKeywordProc -> procExprParser
+        TkReservedBackslash -> lambdaExprParser
+        _ -> infixExprParserExcept []
 
 doStmtParser :: TokParser (DoStmt Expr)
 doStmtParser = do
@@ -444,24 +441,12 @@ atomOrRecordExprParser = do
 -- | Parse record braces: { field = value, field2 = value2, ... }
 recordBracesParser :: TokParser ([(Name, Maybe Expr, SourceSpan)], Bool)
 recordBracesParser =
-  braces recordFieldListParser
-  where
-    recordFieldListParser = do
-      rwcEnabled <- isExtensionEnabled RecordWildCards
-      fields <- layoutSepEndBy recordFieldBindingParser (expectedTok TkSpecialComma)
-      if rwcEnabled
-        then do
-          mDotDot <- MP.optional (expectedTok TkReservedDotDot)
-          case mDotDot of
-            Nothing -> pure (fields, False)
-            Just _ -> do
-              _ <- MP.optional (expectedTok TkSpecialComma)
-              pure (fields, True)
-        else pure (fields, False)
+  braces $
+    recordFieldsWithWildcardsParser (layoutSepEndBy recordFieldBindingParser (expectedTok TkSpecialComma))
 
 recordFieldBindingParser :: TokParser (Name, Maybe Expr, SourceSpan)
 recordFieldBindingParser = withSpan $ do
-  fieldName <- identifierNameParser <|> parens operatorNameParser
+  fieldName <- recordFieldNameParser
   mAssign <- MP.optional (expectedTok TkReservedEquals *> exprParser)
   pure (fieldName,mAssign,)
 
@@ -707,9 +692,7 @@ caseExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
 
 parenExprParser :: TokParser Expr
 parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  (tupleFlavor, closeTok) <-
-    (expectedTok TkSpecialLParen $> (Boxed, TkSpecialRParen))
-      <|> (expectedTok TkSpecialUnboxedLParen $> (Unboxed, TkSpecialUnboxedRParen))
+  (tupleFlavor, closeTok) <- tupleDelimsParser
   mClosed <- MP.optional (expectedTok closeTok)
   case mClosed of
     Just () -> pure (ETuple tupleFlavor [])

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -16,7 +16,6 @@ import Aihc.Parser.Internal.Type (typeParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenText)
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
-import Data.Functor (($>))
 import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
 
@@ -24,12 +23,12 @@ patternParser :: TokParser Pattern
 patternParser = patternParserWithTypeSigParser typeParser
 
 patternParserWithTypeSigParser :: TokParser Type -> TokParser Pattern
-patternParserWithTypeSigParser typeSigParser = label "pattern" $ do
-  pat <- infixPatternParser
-  mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeSigParser)
-  case mTypeSig of
-    Just ty -> pure (PTypeSig pat ty)
-    Nothing -> pure pat
+patternParserWithTypeSigParser typeSigParser =
+  label "pattern" $
+    optionalSuffix
+      (expectedTok TkReservedDoubleColon *> typeSigParser)
+      PTypeSig
+      infixPatternParser
 
 infixPatternParser :: TokParser Pattern
 infixPatternParser = do
@@ -44,10 +43,7 @@ asOrAppPatternParser :: TokParser Pattern
 asOrAppPatternParser = do
   isAsPattern <- startsWithAsPattern
   if isAsPattern
-    then withSpanAnn (PAnn . mkAnnotation) $ do
-      name <- identifierTextParser
-      expectedTok TkReservedAt
-      PAs name <$> patternAtomParser
+    then asPatternParser patternAtomParser
     else appPatternParser
 
 buildInfixPattern :: Pattern -> (Name, Pattern) -> Pattern
@@ -143,10 +139,7 @@ patternAtomParser = do
     -- This allows as-patterns within constructor application patterns
     -- (e.g., Con x@(Con' y z)).
     atomAsPatternParser :: TokParser Pattern
-    atomAsPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
-      name <- identifierTextParser
-      expectedTok TkReservedAt
-      PAs name <$> patternAtomParser
+    atomAsPatternParser = asPatternParser patternAtomParser
 
 typeBinderPatternParser :: TokParser Pattern
 typeBinderPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -246,22 +239,19 @@ simplePatternParser = do
   let typeBinderParser = if typeAbstractionsEnabled then MP.try typeBinderPatternParser else MP.empty
   isAsPat <- startsWithAsPattern
   if isAsPat
-    then withSpanAnn (PAnn . mkAnnotation) $ do
-      name <- identifierTextParser
-      expectedTok TkReservedAt
-      PAs name <$> patternAtomParser
+    then asPatternParser patternAtomParser
     else typeBinderParser <|> patternAtomParser
 
 visibleTypeBinderCoreParser :: TokParser TyVarBinder
 visibleTypeBinderCoreParser =
   withSpan $
     ( do
-        ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+        ident <- tyVarNameParser
         pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBInvisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
-              ident <- lowerIdentifierParser <|> (expectedTok TkKeywordUnderscore $> "_")
+              ident <- tyVarNameParser
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
@@ -285,7 +275,7 @@ varOrConPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
 
 recordFieldPatternParser :: TokParser (RecordField Pattern)
 recordFieldPatternParser = do
-  field <- identifierNameParser <|> parens operatorNameParser
+  field <- recordFieldNameParser
   mEq <- MP.optional (expectedTok TkReservedEquals)
   case mEq of
     Just () -> do
@@ -297,18 +287,8 @@ recordFieldPatternParser = do
 
 -- | Parse the contents of record pattern braces, supporting RecordWildCards ".."
 recordPatternFieldListParser :: TokParser ([RecordField Pattern], Bool)
-recordPatternFieldListParser = do
-  rwcEnabled <- isExtensionEnabled RecordWildCards
-  fields <- recordFieldPatternParser `MP.sepEndBy` expectedTok TkSpecialComma
-  if rwcEnabled
-    then do
-      mDotDot <- MP.optional (expectedTok TkReservedDotDot)
-      case mDotDot of
-        Nothing -> pure (fields, False)
-        Just _ -> do
-          _ <- MP.optional (expectedTok TkSpecialComma)
-          pure (fields, True)
-    else pure (fields, False)
+recordPatternFieldListParser =
+  recordFieldsWithWildcardsParser (recordFieldPatternParser `MP.sepEndBy` expectedTok TkSpecialComma)
 
 listPatternParser :: TokParser Pattern
 listPatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -340,9 +320,7 @@ subpatternWithBareViewParser = do
 
 parenOrTuplePatternParser :: TokParser Pattern
 parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
-  (tupleFlavor, closeTok) <-
-    (expectedTok TkSpecialLParen $> (Boxed, TkSpecialRParen))
-      <|> (expectedTok TkSpecialUnboxedLParen $> (Unboxed, TkSpecialUnboxedRParen))
+  (tupleFlavor, closeTok) <- tupleDelimsParser
   mNextTok <- MP.optional (lookAhead anySingle)
   case fmap lexTokenKind mNextTok of
     Just nextKind

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -43,13 +43,11 @@ typeParser :: TokParser Type
 typeParser = label "type" $ forallTypeParser <|> kindSigTypeParser
 
 kindSigTypeParser :: TokParser Type
-kindSigTypeParser = do
-  ty <- contextOrFunTypeParser
-  mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
-  pure $
-    case mKind of
-      Just kind -> TKindSig ty kind
-      Nothing -> ty
+kindSigTypeParser =
+  optionalSuffix
+    (expectedTok TkReservedDoubleColon *> typeParser)
+    TKindSig
+    contextOrFunTypeParser
 
 contextOrFunTypeParser :: TokParser Type
 contextOrFunTypeParser = do
@@ -77,28 +75,23 @@ forallBinderParser =
     -- Inferred binder: {k} | {k :: Type}
     ( do
         expectedTok TkSpecialLBrace
-        ident <- forallBinderNameParser
+        ident <- tyVarNameParser
         mKind <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
         expectedTok TkSpecialRBrace
         pure (\span' -> TyVarBinder [mkAnnotation span'] ident mKind TyVarBInferred TyVarBVisible)
     )
       <|> ( do
               expectedTok TkSpecialLParen
-              ident <- forallBinderNameParser
+              ident <- tyVarNameParser
               expectedTok TkReservedDoubleColon
               kind <- typeParser
               expectedTok TkSpecialRParen
               pure (\span' -> TyVarBinder [mkAnnotation span'] ident (Just kind) TyVarBSpecified TyVarBVisible)
           )
       <|> ( do
-              ident <- forallBinderNameParser
+              ident <- tyVarNameParser
               pure (\span' -> TyVarBinder [mkAnnotation span'] ident Nothing TyVarBSpecified TyVarBVisible)
           )
-
-forallBinderNameParser :: TokParser Text
-forallBinderNameParser =
-  lowerIdentifierParser
-    <|> (expectedTok TkKeywordUnderscore $> "_")
 
 contextTypeParser :: TokParser Type
 contextTypeParser = do
@@ -110,13 +103,11 @@ contextItemsParser :: TokParser [Type]
 contextItemsParser = contextItemsParserWith typeParser typeAtomParser
 
 typeFunParser :: TokParser Type
-typeFunParser = do
-  lhs <- typeInfixParser
-  mRhs <- MP.optional (expectedTok TkReservedRightArrow *> typeParser)
-  pure $
-    case mRhs of
-      Just rhs -> TFun lhs rhs
-      Nothing -> lhs
+typeFunParser =
+  optionalSuffix
+    (expectedTok TkReservedRightArrow *> typeParser)
+    TFun
+    typeInfixParser
 
 typeInfixParser :: TokParser Type
 typeInfixParser = do
@@ -355,9 +346,7 @@ typeListParser = withSpanAnn (TAnn . mkAnnotation) $ do
 
 typeParenOrTupleParser :: TokParser Type
 typeParenOrTupleParser = withSpanAnn (TAnn . mkAnnotation) $ do
-  (tupleFlavor, closeTok) <-
-    (expectedTok TkSpecialLParen $> (Boxed, TkSpecialRParen))
-      <|> (expectedTok TkSpecialUnboxedLParen $> (Unboxed, TkSpecialUnboxedRParen))
+  (tupleFlavor, closeTok) <- tupleDelimsParser
   mClosed <- MP.optional (expectedTok closeTok)
   case mClosed of
     Just () -> pure (TTuple tupleFlavor Unpromoted [])


### PR DESCRIPTION
## Summary
- factor shared parser utilities into `Common.hs` for optional suffixes, type variable names, tuple delimiters, as-patterns, and record-field parsing
- simplify `Type`, `Pattern`, and `Expr` call sites to use those helpers and remove duplicated local parsing code
- keep the `do`-statement pattern-bind lookahead intact after validating that prefix-pattern qualifiers still require the dedicated disambiguation path

## Why
The parser modules had several repeated shapes that made them longer and harder to scan: optional `::`/`->` suffix handling, record field lists with `..`, tuple delimiter parsing, and repeated as-pattern / type-binder boilerplate. Pulling those into shared helpers makes the modules smaller while keeping the grammar decisions explicit.

## Impact
- no intended grammar change
- parser internals are smaller and more uniform across type, pattern, and expression parsing
- progress counts: unchanged

## Validation
- `just fmt`
- `just check`

## Review
- `coderabbit review --prompt-only` did not return usable output in time, so no CodeRabbit findings were applied