### PR TITLE
refactor(parser): simplify appPatternParser, patternSynonymParser, move startsWithPatternBind

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1522,9 +1522,11 @@ valueDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
 -- | Parse a pattern synonym declaration or signature.
 -- Dispatches between @pattern Name :: Type@ (signature) and
 -- @pattern Name args = pat@ / @pattern Name args <- pat [where ...]@ (declaration).
+-- Uses a forward scan for @name(s) ::@ to avoid backtracking over a large parse.
 patternSynonymParser :: TokParser Decl
-patternSynonymParser =
-  MP.try patternSynonymSigDeclParser <|> patternSynonymDeclParser
+patternSynonymParser = do
+  isSig <- MP.lookAhead (expectedTok TkKeywordPattern *> startsWithTypeSig)
+  if isSig then patternSynonymSigDeclParser else patternSynonymDeclParser
 
 -- | Parse a pattern synonym type signature: @pattern Name1, Name2 :: Type@
 patternSynonymSigDeclParser :: TokParser Decl

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -238,6 +238,12 @@ exprCoreParserNoArrowTail =
         TkReservedBackslash -> lambdaExprParser
         _ -> infixExprParserExcept []
 
+startsWithPatternBind :: TokParser Bool
+startsWithPatternBind =
+  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
+    _ <- patternParser
+    expectedTok TkReservedLeftArrow
+
 doStmtParser :: TokParser (DoStmt Expr)
 doStmtParser = do
   tok <- lookAhead anySingle
@@ -249,12 +255,6 @@ doStmtParser = do
       if isPatternBind
         then doPatBindStmtParser
         else doBindOrExprStmtParser
-
-startsWithPatternBind :: TokParser Bool
-startsWithPatternBind =
-  fmap (either (const False) (const True)) . MP.observing . MP.try . MP.lookAhead $ do
-    _ <- patternParser
-    expectedTok TkReservedLeftArrow
 
 doBindOrExprStmtParser :: TokParser (DoStmt Expr)
 doBindOrExprStmtParser = withSpanAnn (DoAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -81,16 +81,11 @@ conOperatorParser =
 -- @Con (-0)@ — the @-@ is not valid inside an @apat@.
 appPatternParser :: TokParser Pattern
 appPatternParser =
-  negativeLiteralPatternParser
-    <|> conAppOrAtomParser
-  where
-    conAppOrAtomParser = do
-      first <- patternAtomParser
-      if isPatternAppHead first
-        then do
-          rest <- MP.many patternAtomParser
-          pure (foldl buildPatternApp first rest)
-        else pure first
+  negativeLiteralPatternParser <|> do
+    first <- patternAtomParser
+    if isPatternAppHead first
+      then foldl buildPatternApp first <$> MP.many patternAtomParser
+      else pure first
 
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =


### PR DESCRIPTION
## Summary

- **`Pattern.hs`**: inline the `conAppOrAtomParser` where-binding in `appPatternParser` and use applicative style (`<$>`), removing 6 lines with no behaviour change.
- **`Decl.hs`**: replace `MP.try patternSynonymSigDeclParser` in `patternSynonymParser` with a forward scan (`lookAhead` + `startsWithTypeSig`). Both alternatives start with the `pattern` keyword; scanning for `name(s) ::` is sufficient to distinguish sig from decl without backtracking over a full type parse.
- **`Expr.hs`**: move `startsWithPatternBind` definition above its first caller (`doStmtParser`) so the file reads top-to-bottom.

## What was investigated but not changed

Replacing `startsWithPatternBind` with cheaper token-kind dispatch (`TkPrefixBang`/`TkPrefixTilde`/`startsWithAsPattern`) was attempted but broke `K !y ~(z) q@r <- xs` style patterns in comprehension generators and guards — the `!`/`~`/`@` can appear as *arguments* to a constructor, not just as the leading token. The full `lookAhead (patternParser >> '<-')` is load-bearing for this class of inputs.

## Test plan

- [x] `cabal test -v0 aihc-parser:spec --test-options="--pattern parser-golden"` — all 228 pass
- [x] `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle"` — all 1046 pass
- [x] `cabal test -v0 aihc-parser:spec --test-options="--pattern properties"` — all 11 pass