### PR TITLE
fix(resolve): return resolve errors alongside annotations

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -60,9 +60,10 @@ import Aihc.Parser.Syntax
     renderUnqualifiedName,
   )
 import Aihc.Resolve.Types
+import Data.Data (Data, cast, gmapQ)
 import Data.List (mapAccumL)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -125,7 +126,7 @@ resolve modules =
   ResolveResult
     { resolvedModules = modules',
       resolvedAnnotations = extraAnnotations,
-      resolveErrors = []
+      resolveErrors = collectResolveErrors modules' <> concatMap (mapMaybe annotationResolveError . snd) extraAnnotations
     }
   where
     step currentNextLocal modu =
@@ -135,6 +136,54 @@ resolve modules =
     modules' = map snd resolved
     extraAnnotations = map (\(annotations, modu) -> (moduleKey modu, annotations)) resolved
     exports = collectModuleExports modules
+
+collectResolveErrors :: (Data a) => a -> [ResolveError]
+collectResolveErrors node =
+  ownResolveErrors node <> concat (gmapQ collectResolveErrors node)
+
+ownResolveErrors :: (Data a) => a -> [ResolveError]
+ownResolveErrors node =
+  declResolutionErrors (cast node)
+    <> patternResolutionErrors (cast node)
+    <> typeResolutionErrors (cast node)
+    <> exprResolutionErrors (cast node)
+
+declResolutionErrors :: Maybe Decl -> [ResolveError]
+declResolutionErrors maybeDecl =
+  case maybeDecl of
+    Just (DeclResolution resolution) -> maybeToList (annotationResolveError resolution)
+    _ -> []
+
+patternResolutionErrors :: Maybe Pattern -> [ResolveError]
+patternResolutionErrors maybePattern =
+  case maybePattern of
+    Just (PResolution resolution) -> maybeToList (annotationResolveError resolution)
+    _ -> []
+
+typeResolutionErrors :: Maybe Type -> [ResolveError]
+typeResolutionErrors maybeType =
+  case maybeType of
+    Just (TResolution resolution) -> maybeToList (annotationResolveError resolution)
+    _ -> []
+
+exprResolutionErrors :: Maybe Expr -> [ResolveError]
+exprResolutionErrors maybeExpr =
+  case maybeExpr of
+    Just (EResolution resolution) -> maybeToList (annotationResolveError resolution)
+    _ -> []
+
+annotationResolveError :: ResolutionAnnotation -> Maybe ResolveError
+annotationResolveError resolution =
+  case resolutionTarget resolution of
+    ResolvedError msg ->
+      Just
+        ResolveResolutionError
+          { resolveErrorSpan = resolutionSpan resolution,
+            resolveErrorName = resolutionName resolution,
+            resolveErrorNamespace = resolutionNamespace resolution,
+            resolveErrorMessage = msg
+          }
+    _ -> Nothing
 
 resolveModule :: ModuleExports -> Int -> Module -> (Int, [ResolutionAnnotation], Module)
 resolveModule exports nextLocal modu =

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -58,8 +58,14 @@ data ResolutionAnnotation = ResolutionAnnotation
   }
   deriving (Eq, Show)
 
-newtype ResolveError
-  = ResolveNotImplemented String
+data ResolveError
+  = ResolveResolutionError
+      { resolveErrorSpan :: !SourceSpan,
+        resolveErrorName :: !Text,
+        resolveErrorNamespace :: !ResolutionNamespace,
+        resolveErrorMessage :: !String
+      }
+  | ResolveNotImplemented String
   deriving (Eq, Show)
 
 data ResolveResult = ResolveResult

--- a/components/aihc-resolve/test/Test/Resolver/Suite.hs
+++ b/components/aihc-resolve/test/Test/Resolver/Suite.hs
@@ -5,10 +5,22 @@ module Test.Resolver.Suite
   )
 where
 
+import Aihc.Parser
+  ( ParserConfig (..),
+    defaultConfig,
+    parseModule,
+  )
+import Aihc.Parser.Syntax (SourceSpan (..))
+import Aihc.Resolve
+  ( ResolutionNamespace (..),
+    ResolveError (..),
+    ResolveResult (..),
+    resolve,
+  )
 import Control.Monad (when)
 import qualified ResolverGolden as RG
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (Assertion, assertFailure, testCase, testCaseInfo)
+import Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCase, testCaseInfo)
 
 resolverGoldenTests :: IO TestTree
 resolverGoldenTests = do
@@ -18,7 +30,7 @@ resolverGoldenTests = do
   pure
     ( testGroup
         "resolver-golden"
-        (checks <> [summary])
+        (checks <> [summary, resolveErrorsTests])
     )
 
 mkResolverCaseTest :: RG.ResolverCase -> IO TestTree
@@ -104,3 +116,30 @@ pct :: Int -> Int -> Double
 pct done totalN
   | totalN <= 0 = 0.0
   | otherwise = fromIntegral (done * 10000 `div` totalN) / 100.0
+
+resolveErrorsTests :: TestTree
+resolveErrorsTests =
+  testGroup
+    "resolve-errors"
+    [ testCase "collects unresolved names into ResolveResult" $ do
+        let source = "module Main where\nx = unknownVar\n"
+            config = defaultConfig {parserSourceName = "<test>"}
+            (errs, parsed) = parseModule config source
+            result = resolve [parsed]
+        assertEqual "parser errors" [] errs
+        case resolveErrors result of
+          [ResolveResolutionError span' name namespace msg] -> do
+            assertEqual "error name" "unknownVar" name
+            assertEqual "error namespace" ResolutionNamespaceTerm namespace
+            assertEqual "error message" "unbound" msg
+            case span' of
+              SourceSpan _ 2 5 2 15 _ _ -> pure ()
+              _ ->
+                assertFailure
+                  ("unexpected error source span: " <> show span')
+          actual ->
+            assertEqual
+              "unresolved names should remain annotated and also populate resolveErrors"
+              1
+              (length actual)
+    ]


### PR DESCRIPTION
## Summary

- derive `resolveErrors` from resolver annotations whose targets are `ResolvedError`
- keep unresolved-name annotations unchanged so existing annotation consumers still work
- add a regression test that asserts unbound names are also surfaced through `ResolveResult.resolveErrors`

## Validation

- `just fmt`
- `just check`

## Progress counts

- `cabal run -v0 exe:resolve-progress`: PASS 0, XFAIL 0, XPASS 0, FAIL 0 (unchanged)

## CodeRabbit

- `coderabbit review --prompt-only` started but did not return findings, so this PR was opened without a CodeRabbit summary
