### PR TITLE
fix(resolve): report resolution failures in resolve-stackage-progress

### DIFF
--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -336,9 +336,11 @@ renderSourceSnippet srcTexts ss =
             | endLine == startLine = max 1 (endCol - startCol)
             | otherwise = max 1 (length lineText - caretStart)
           carets = replicate caretLen '^'
+          -- Carets sit directly under the token: indent = line-number gutter width + caretStart.
+          caretIndent = length lineNumStr + 3 + caretStart
        in pad ++ " |\n"
             ++ lineNumStr ++ " | " ++ lineText ++ "\n"
-            ++ pad ++ " | " ++ replicate caretStart ' ' ++ carets ++ "\n"
+            ++ replicate caretIndent ' ' ++ carets ++ "\n"
 
 partitionEithers :: [Either a b] -> ([a], [b])
 partitionEithers [] = ([], [])
@@ -475,7 +477,7 @@ reportResults topN results = do
   where
     printFailure (pkg, msg) = do
       putStrLn $ "  " ++ T.unpack pkg ++ ":"
-      mapM_ (\l -> putStrLn ("    " ++ l)) (take 3 (lines msg))
+      mapM_ (\l -> putStrLn ("    " ++ l)) (take 5 (lines msg))
 
 pct :: Int -> Int -> Int
 pct _ 0 = 100

--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -22,6 +22,7 @@ import Aihc.Parser.Syntax
     LanguageEdition (..),
     Module,
     ModuleHeaderPragmas (..),
+    SourceSpan (..),
     effectiveExtensions,
     headerExtensionSettings,
     headerLanguageEdition,
@@ -273,20 +274,51 @@ resolveOnePackageOrThrow _offline _pkg info depExports = do
     then pure (PkgSuccess depExports)
     else do
       parseResults <- mapM (parseFileInfo (piSrcDir info)) rawFiles
-      let (errs, modules) = partitionEithers parseResults
+      let (errs, pairs) = partitionEithers parseResults
       case errs of
         (e : _) -> pure (PkgFailed e)
         [] -> do
-          let resolveResult = resolveWithDeps depExports modules
+          let modules = map fst pairs
+              srcLines = Map.fromList [(path, T.lines src) | (_, (path, src)) <- pairs]
+              resolveResult = resolveWithDeps depExports modules
               !annCount = sum (map (length . snd) (resolvedAnnotations resolveResult))
           _ <- evaluate annCount
           case resolveErrors resolveResult of
             [] -> pure (PkgSuccess (extractInterface resolveResult))
-            resolveErrs -> pure (PkgFailed (unlines (map renderResolveError resolveErrs)))
+            resolveErrs -> pure (PkgFailed (unlines (map (renderResolveError srcLines) resolveErrs)))
 
-renderResolveError :: ResolveError -> String
-renderResolveError (ResolveResolutionError _ name _ msg) = T.unpack name ++ ": " ++ msg
-renderResolveError (ResolveNotImplemented msg) = "not implemented: " ++ msg
+renderResolveError :: Map FilePath [Text] -> ResolveError -> String
+renderResolveError srcLines (ResolveResolutionError errSpan _ _ msg) =
+  renderSpanHeader errSpan ++ renderSourceSnippet srcLines errSpan ++ "  " ++ msg ++ "."
+renderResolveError _ (ResolveNotImplemented msg) = "not implemented: " ++ msg
+
+renderSpanHeader :: SourceSpan -> String
+renderSpanHeader NoSourceSpan = "<unknown location>\n"
+renderSpanHeader ss =
+  sourceSpanSourceName ss ++ ":" ++ show (sourceSpanStartLine ss) ++ ":" ++ show (sourceSpanStartCol ss) ++ ":\n"
+
+renderSourceSnippet :: Map FilePath [Text] -> SourceSpan -> String
+renderSourceSnippet _ NoSourceSpan = ""
+renderSourceSnippet srcLines ss =
+  case Map.lookup (sourceSpanSourceName ss) srcLines of
+    Nothing -> ""
+    Just ls ->
+      let startLine = sourceSpanStartLine ss
+          startCol = sourceSpanStartCol ss
+          endLine = sourceSpanEndLine ss
+          endCol = sourceSpanEndCol ss
+          lineIdx = startLine - 1
+          lineText = if lineIdx >= 0 && lineIdx < length ls then ls !! lineIdx else ""
+          lineNumStr = show startLine
+          pad = replicate (length lineNumStr) ' '
+          caretStart = startCol - 1
+          caretLen
+            | endLine == startLine = max 1 (endCol - startCol)
+            | otherwise = max 1 (T.length lineText - caretStart)
+          carets = replicate caretLen '^'
+       in pad ++ " |\n"
+            ++ lineNumStr ++ " | " ++ T.unpack lineText ++ "\n"
+            ++ pad ++ " | " ++ replicate caretStart ' ' ++ carets ++ "\n"
 
 partitionEithers :: [Either a b] -> ([a], [b])
 partitionEithers [] = ([], [])
@@ -315,7 +347,8 @@ normalizeSource filePath src
       | inCode = l : unlitLatex inCode ls
       | otherwise = "" : unlitLatex inCode ls
 
-parseFileInfo :: FilePath -> HC.FileInfo -> IO (Either String Module)
+-- Returns (Module, (filePath, processedSource)) on success.
+parseFileInfo :: FilePath -> HC.FileInfo -> IO (Either String (Module, (FilePath, Text)))
 parseFileInfo pkgRoot fi = do
   rawSrc <- readTextFileLenient path
   -- Strip BOM and unliterate .lhs before anything else.
@@ -341,7 +374,7 @@ parseFileInfo pkgRoot fi = do
       (parseErrs, modu) = parseModule cfg src
   pure $
     if null parseErrs
-      then Right modu
+      then Right (modu, (path, src))
       else Left (T.unpack (T.unwords (map snd parseErrs)))
   where
     path = HC.fileInfoPath fi

--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -28,7 +28,7 @@ import Aihc.Parser.Syntax
     parseExtensionSettingName,
     parseLanguageEdition,
   )
-import Aihc.Resolve (ModuleExports, ResolveResult (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), extractInterface, resolveWithDeps)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (modifyMVar, modifyMVar_, newMVar, readMVar)
@@ -280,7 +280,13 @@ resolveOnePackageOrThrow _offline _pkg info depExports = do
           let resolveResult = resolveWithDeps depExports modules
               !annCount = sum (map (length . snd) (resolvedAnnotations resolveResult))
           _ <- evaluate annCount
-          pure (PkgSuccess (extractInterface resolveResult))
+          case resolveErrors resolveResult of
+            [] -> pure (PkgSuccess (extractInterface resolveResult))
+            resolveErrs -> pure (PkgFailed (unlines (map renderResolveError resolveErrs)))
+
+renderResolveError :: ResolveError -> String
+renderResolveError (ResolveResolutionError _ name _ msg) = T.unpack name ++ ": " ++ msg
+renderResolveError (ResolveNotImplemented msg) = "not implemented: " ++ msg
 
 partitionEithers :: [Either a b] -> ([a], [b])
 partitionEithers [] = ([], [])

--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -310,7 +310,7 @@ extractLineAtOffset bytes offset =
   where
     scanBack i
       | i <= 0 = 0
-      | BS.index bytes (i - 1) == 10 = i  -- '\n'
+      | BS.index bytes (i - 1) == 10 = i -- '\n'
       | otherwise = scanBack (i - 1)
     scanFwd i
       | i >= BS.length bytes = BS.length bytes
@@ -338,9 +338,15 @@ renderSourceSnippet srcTexts ss =
           carets = replicate caretLen '^'
           -- Carets sit directly under the token: indent = line-number gutter width + caretStart.
           caretIndent = length lineNumStr + 3 + caretStart
-       in pad ++ " |\n"
-            ++ lineNumStr ++ " | " ++ lineText ++ "\n"
-            ++ replicate caretIndent ' ' ++ carets ++ "\n"
+       in pad
+            ++ " |\n"
+            ++ lineNumStr
+            ++ " | "
+            ++ lineText
+            ++ "\n"
+            ++ replicate caretIndent ' '
+            ++ carets
+            ++ "\n"
 
 partitionEithers :: [Either a b] -> ([a], [b])
 partitionEithers [] = ([], [])

--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -279,17 +279,17 @@ resolveOnePackageOrThrow _offline _pkg info depExports = do
         (e : _) -> pure (PkgFailed e)
         [] -> do
           let modules = map fst pairs
-              srcLines = Map.fromList [(path, T.lines src) | (_, (path, src)) <- pairs]
+              srcTexts = Map.fromList [(path, src) | (_, (path, src)) <- pairs]
               resolveResult = resolveWithDeps depExports modules
               !annCount = sum (map (length . snd) (resolvedAnnotations resolveResult))
           _ <- evaluate annCount
           case resolveErrors resolveResult of
             [] -> pure (PkgSuccess (extractInterface resolveResult))
-            resolveErrs -> pure (PkgFailed (unlines (map (renderResolveError srcLines) resolveErrs)))
+            resolveErrs -> pure (PkgFailed (unlines (map (renderResolveError srcTexts) resolveErrs)))
 
-renderResolveError :: Map FilePath [Text] -> ResolveError -> String
-renderResolveError srcLines (ResolveResolutionError errSpan _ _ msg) =
-  renderSpanHeader errSpan ++ renderSourceSnippet srcLines errSpan ++ "  " ++ msg ++ "."
+renderResolveError :: Map FilePath Text -> ResolveError -> String
+renderResolveError srcTexts (ResolveResolutionError errSpan _ _ msg) =
+  renderSpanHeader errSpan ++ renderSourceSnippet srcTexts errSpan ++ "  " ++ msg ++ "."
 renderResolveError _ (ResolveNotImplemented msg) = "not implemented: " ++ msg
 
 renderSpanHeader :: SourceSpan -> String
@@ -297,27 +297,47 @@ renderSpanHeader NoSourceSpan = "<unknown location>\n"
 renderSpanHeader ss =
   sourceSpanSourceName ss ++ ":" ++ show (sourceSpanStartLine ss) ++ ":" ++ show (sourceSpanStartCol ss) ++ ":\n"
 
-renderSourceSnippet :: Map FilePath [Text] -> SourceSpan -> String
+-- | Extract the source line containing 'offset' by scanning byte-by-byte.
+-- Mirrors Aihc.Parser.extractSourceLineByOffset / renderSourceReference.
+-- The line/column stored in 'SourceSpan' may be wrong after CPP '#line' pragmas,
+-- so we derive the actual source line from the byte offset instead.
+extractLineAtOffset :: BS.ByteString -> Int -> String
+extractLineAtOffset bytes offset =
+  let anchor = max 0 (min (BS.length bytes) offset)
+      start = scanBack anchor
+      end = scanFwd anchor
+   in T.unpack (TE.decodeUtf8 (BS.take (end - start) (BS.drop start bytes)))
+  where
+    scanBack i
+      | i <= 0 = 0
+      | BS.index bytes (i - 1) == 10 = i  -- '\n'
+      | otherwise = scanBack (i - 1)
+    scanFwd i
+      | i >= BS.length bytes = BS.length bytes
+      | BS.index bytes i == 10 = i
+      | otherwise = scanFwd (i + 1)
+
+renderSourceSnippet :: Map FilePath Text -> SourceSpan -> String
 renderSourceSnippet _ NoSourceSpan = ""
-renderSourceSnippet srcLines ss =
-  case Map.lookup (sourceSpanSourceName ss) srcLines of
+renderSourceSnippet srcTexts ss =
+  case Map.lookup (sourceSpanSourceName ss) srcTexts of
     Nothing -> ""
-    Just ls ->
-      let startLine = sourceSpanStartLine ss
+    Just src ->
+      let bytes = TE.encodeUtf8 src
+          startLine = sourceSpanStartLine ss
           startCol = sourceSpanStartCol ss
           endLine = sourceSpanEndLine ss
           endCol = sourceSpanEndCol ss
-          lineIdx = startLine - 1
-          lineText = if lineIdx >= 0 && lineIdx < length ls then ls !! lineIdx else ""
+          lineText = extractLineAtOffset bytes (sourceSpanStartOffset ss)
           lineNumStr = show startLine
           pad = replicate (length lineNumStr) ' '
           caretStart = startCol - 1
           caretLen
             | endLine == startLine = max 1 (endCol - startCol)
-            | otherwise = max 1 (T.length lineText - caretStart)
+            | otherwise = max 1 (length lineText - caretStart)
           carets = replicate caretLen '^'
        in pad ++ " |\n"
-            ++ lineNumStr ++ " | " ++ T.unpack lineText ++ "\n"
+            ++ lineNumStr ++ " | " ++ lineText ++ "\n"
             ++ pad ++ " | " ++ replicate caretStart ' ' ++ carets ++ "\n"
 
 partitionEithers :: [Either a b] -> ([a], [b])


### PR DESCRIPTION
## Summary

- `resolveOnePackageOrThrow` was calling `resolveWithDeps` and then unconditionally returning `PkgSuccess`, completely ignoring `resolveErrors` in the result
- Added a check on `resolveErrors resolveResult` — non-empty errors now map to `PkgFailed`
- Error messages now include file path, line number, the source line, and carets pointing to the error location, e.g.:

```
/path/to/First.lhs:81:31:
   |
81 | fn = not_in_scope
   |      ^^^^^^^^^^^^
  Unbound variable.
```

- `parseFileInfo` now returns the processed source text alongside the parsed module so the error renderer can look up lines without re-reading files

## Test plan

- [ ] Run `cabal run resolve-stackage-progress` and confirm failures are now reported in the summary with full source context