### PR TITLE
fix(cpp): support token pasting across Haskell block comments

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -78,6 +78,9 @@ countExtraLinesConsumed st txt moreLines = scanForFunctionMacro False False Fals
               let escaped' = c == '\\' && not escaped
                   inChar' = not (c == '\'' && not escaped)
                in scanForFunctionMacro False inChar' escaped' rest
+          | startsHsBlockComment t ->
+              let (_, remaining) = consumeHsBlockComment t
+               in scanForFunctionMacro False False False remaining
           | c == '"' -> scanForFunctionMacro True False False rest
           | c == '\'' -> scanForFunctionMacro False True False rest
           | isIdentStart c ->
@@ -146,6 +149,9 @@ goText st painted inString inChar escaped txt acc =
           let escaped' = c == '\\' && not escaped
               inChar' = not (c == '\'' && not escaped)
            in goText st painted False inChar' escaped' rest (acc <> TB.singleton c)
+      | startsHsBlockComment txt ->
+          let (commentText, remaining) = consumeHsBlockComment txt
+           in goText st painted False False False remaining (acc <> TB.fromText commentText)
       | c == '"' ->
           goText st painted True False False rest (acc <> TB.singleton c)
       | c == '\'' ->
@@ -253,6 +259,10 @@ parseArgs depth argsRev current remaining =
   case T.uncons remaining of
     Nothing -> Nothing
     Just (ch, rest)
+      | ch == '{',
+        Just ('-', _) <- T.uncons rest ->
+          let (commentText, afterComment) = consumeHsBlockComment remaining
+           in parseArgs depth argsRev (current <> TB.fromText commentText) afterComment
       | ch == '(' ->
           parseArgs (depth + 1) argsRev (current <> TB.singleton ch) rest
       | ch == ')' && depth > 0 ->
@@ -290,6 +300,39 @@ findLastCloseParen txt =
     Just revIdx ->
       let idx = T.length txt - revIdx - 1
        in Just (T.take idx txt, T.drop (idx + 1) txt)
+
+startsHsBlockComment :: Text -> Bool
+startsHsBlockComment txt =
+  case T.uncons txt of
+    Just ('{', rest) ->
+      case T.uncons rest of
+        Just ('-', rest') ->
+          case T.uncons rest' of
+            Just ('#', _) -> False
+            _ -> True
+        _ -> False
+    _ -> False
+
+consumeHsBlockComment :: Text -> (Text, Text)
+consumeHsBlockComment = go 0 mempty
+  where
+    go :: Int -> TB.Builder -> Text -> (Text, Text)
+    go depth acc txt =
+      case T.uncons txt of
+        Nothing -> (builderToText acc, "")
+        Just (c, rest) ->
+          case T.uncons rest of
+            Just ('-', rest')
+              | c == '{' ->
+                  go (depth + 1) (acc <> TB.fromText "{-") rest'
+            Just ('}', rest')
+              | c == '-' && depth <= 1 ->
+                  (builderToText (acc <> TB.fromText "-}"), rest')
+            Just ('}', rest')
+              | c == '-' ->
+                  go (depth - 1) (acc <> TB.fromText "-}") rest'
+            _ ->
+              go depth (acc <> TB.singleton c) rest
 
 data Piece
   = PieceWhitespace !Text

--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -259,8 +259,7 @@ parseArgs depth argsRev current remaining =
   case T.uncons remaining of
     Nothing -> Nothing
     Just (ch, rest)
-      | ch == '{',
-        Just ('-', _) <- T.uncons rest ->
+      | startsHsBlockComment remaining ->
           let (commentText, afterComment) = consumeHsBlockComment remaining
            in parseArgs depth argsRev (current <> TB.fromText commentText) afterComment
       | ch == '(' ->

--- a/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Scanner.hs
@@ -61,14 +61,17 @@ expandLineBySpanMultiline :: EngineState -> [LineSpan] -> Cursor -> (Text, Int)
 expandLineBySpanMultiline st spans futureCursor =
   let commentSpans = filter lineSpanInBlockComment spans
       hasLineComment = any (\s -> "--" `T.isPrefixOf` lineSpanText s) commentSpans
-      hasBlockComment = any (\s -> not ("--" `T.isPrefixOf` lineSpanText s)) commentSpans
-   in if hasLineComment && not hasBlockComment
-        then -- Line with -- comment: full-line expansion so macro args can span into the comment
+      hasCBlockComment = any (T.all (== ' ') . lineSpanText) commentSpans
+      hasHsComment = case commentSpans of
+        [] -> False
+        _ -> not hasCBlockComment
+   in if hasLineComment || hasHsComment
+        then -- Haskell comments stay in the token stream, so expand the full line.
           let fullText = T.concat [lineSpanText s | s <- spans]
            in (expandMacros st fullText, 0)
         else
-          if hasBlockComment
-            then -- Block comment spans: fall back to per-span expansion
+          if hasCBlockComment
+            then -- C comments are stripped to spaces, so preserve per-span handling.
               (expandLineBySpan st spans, 0)
             else -- Pure code line: try multi-line expansion
               let codeText = T.concat [lineSpanText s | s <- spans]

--- a/components/aihc-cpp/test/Spec.hs
+++ b/components/aihc-cpp/test/Spec.hs
@@ -153,6 +153,12 @@ tokenPastingTests =
         case preprocess defaultConfig (TE.encodeUtf8 tokenPasteChainedInput) of
           Done result ->
             resultOutput result @?= "#line 1 \"<input>\"\n\nfoobar\n"
+          _ -> assertFailure "expected Done",
+      testCase "token pasting survives Haskell block comments in arguments" $
+        case preprocess defaultConfig (TE.encodeUtf8 tokenPasteHsCommentInput) of
+          Done result ->
+            resultOutput result
+              @?= "#line 1 \"<input>\"\n\n{-# INLINE _bar #-}; _bar :: LensP Foo Baz{-comment-}; _bar = lens bar $ \\ Foo {..} bar_ -> Foo {bar = bar_, ..}\n"
           _ -> assertFailure "expected Done"
     ]
 
@@ -217,4 +223,11 @@ tokenPasteChainedInput =
   T.unlines
     [ "#define CHAIN(a,b,c) a##b##c",
       "CHAIN(foo,bar,)"
+    ]
+
+tokenPasteHsCommentInput :: T.Text
+tokenPasteHsCommentInput =
+  T.unlines
+    [ "#define LENS(S,F,A) {-# INLINE _/**/F #-}; _/**/F :: LensP S A; _/**/F = lens F $ \\ S {..} F/**/_ -> S {F = F/**/_, ..}",
+      "LENS(Foo,bar,Baz{-comment-})"
     ]

--- a/components/aihc-cpp/test/Test/Fixtures/progress/thyme-lens-comment-paste.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/thyme-lens-comment-paste.hs
@@ -1,2 +1,3 @@
 #define LENS(S,F,A) {-# INLINE _/**/F #-}; _/**/F :: LensP S A; _/**/F = lens F $ \ S {..} F/**/_ -> S {F = F/**/_, ..}
 LENS(Foo,bar,Baz)
+LENS(Foo,bar,Baz{-comment-})


### PR DESCRIPTION
## Summary
- treat Haskell block comments as opaque text during macro scanning and expansion so function-like macro calls can span `{- ... -}` without expanding identifiers inside the comment
- keep inline Haskell-comment lines on the whole-line expansion path so token pasting continues to work for macros like `LENS(Foo,bar,Baz{-comment-})`
- add regression coverage in `aihc-cpp` unit tests and the `thyme-lens-comment-paste` progress fixture

## Testing
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`

## Progress Counts
- `aihc-cpp` progress/oracle regression suite now passes 57/57 tests locally