### PR TITLE
fix(parser): preserve column positions in bird-track unliteration

### DIFF
--- a/components/aihc-parser/common/CppSupport.hs
+++ b/components/aihc-parser/common/CppSupport.hs
@@ -105,9 +105,15 @@ unliterateIfNeeded inputFile source
             then T.unlines (unlitLatex False ls)
             else T.unlines (map unlitBirdLine ls)
   where
+    -- Replace the leading '>' with a space instead of stripping it.
+    -- This preserves original column positions, which is critical for
+    -- layout-sensitive parsing when tabs are present.  Stripping "> "
+    -- shifts columns by 2, but tab stops depend on absolute column
+    -- position, so tab-aligned code and space-aligned code would end
+    -- up at different columns after the shift.
     unlitBirdLine line =
       case T.stripPrefix ">" line of
-        Just rest -> fromMaybe rest (T.stripPrefix " " rest)
+        Just _rest -> " " <> _rest
         Nothing -> ""
 
     unlitLatex _ [] = []

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -3,11 +3,13 @@
 
 module Main (main) where
 
+import Aihc.Cpp (resultOutput)
 import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
 import Aihc.Parser.Parens (addDeclParens, addExprParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
+import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (ord)
 import Data.Maybe (isNothing)
 import Data.Text qualified as T
@@ -122,6 +124,7 @@ buildTests = do
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
+            testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
             localOption (QC.QuickCheckTests 2000) $
               QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
             QC.testProperty "generated operators reject dash-only comment starters" prop_generatedOperatorsRejectDashOnlyCommentStarters,
@@ -710,6 +713,29 @@ test_prettyInfixRhsOpenEndedInsideSection = do
       assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
     ParseErr bundle ->
       assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
+
+-- | Regression test: bird-track unliteration must preserve column positions so
+-- that tab-aligned case alternatives remain in the same layout context.
+-- Before the fix, stripping "> " shifted columns by 2, causing tab-expanded
+-- and space-only lines to land at different indentation columns.
+test_birdTrackUnlitPreservesTabColumns :: Assertion
+test_birdTrackUnlitPreservesTabColumns = do
+  -- Literate Haskell with tab-indented case alternatives.
+  -- The tab on the "Just" line and the spaces on the "Nothing" line
+  -- are carefully chosen so they align at the same column in the original
+  -- (with "> " prefix) but diverge after naively stripping "> ".
+  let lhsSource =
+        T.unlines
+          [ "> module LitTest where",
+            "> f x = case x of",
+            ">          \t        Just y  -> y",
+            ">                       Nothing -> 0"
+          ]
+      preprocessed = resultOutput (preprocessForParserWithoutIncludesIfEnabled [] [] "LitTest.lhs" [] lhsSource)
+      (errs, _modu) = parseModule defaultConfig preprocessed
+  assertBool
+    ("expected no parse errors for bird-track .lhs with tabs, got:\n" <> formatParseErrors "LitTest.lhs" (Just preprocessed) errs)
+    (null errs)
 
 test_associatedDataFamilyOperatorName :: Assertion
 test_associatedDataFamilyOperatorName = do

--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -368,8 +368,11 @@ normalizeSource filePath src
             else T.unlines (map unlitBird ls)
   where
     stripBom t = Data.Maybe.fromMaybe t (T.stripPrefix "\xfeff" t)
+    -- Replace the leading '>' with a space instead of stripping it.
+    -- This preserves original column positions, which is critical for
+    -- layout-sensitive parsing when tabs are present.
     unlitBird line = case T.stripPrefix ">" line of
-      Just rest -> Data.Maybe.fromMaybe rest (T.stripPrefix " " rest)
+      Just rest -> " " <> rest
       Nothing -> ""
     unlitLatex _ [] = []
     unlitLatex inCode (l : ls)


### PR DESCRIPTION
## Summary

- Fix bird-track (`.lhs`) unliteration to replace `>` with a space instead of stripping `> `, preserving original column positions for layout-sensitive parsing with tabs
- Apply the same fix to the duplicate unliteration in `resolve-stackage-progress`
- Add regression test with tab-aligned case alternatives that reproduced the exact failure

## Problem

Bird-track unliteration stripped the `> ` prefix (2 characters), shifting all column positions by 2. This broke the layout rule when tabs were present: tab expansion depends on absolute column position, so tab-aligned code and space-aligned code would land at different indentation columns after the shift. The layout rule would then incorrectly close implicit blocks (e.g., `case` alternatives).

Concrete example from `happy-meta`: a `case` expression where `Just` was aligned via tab+spaces (col 25 after tab expansion) and `Nothing` via pure spaces (col 25 in original). After stripping `> `, `Just` remained at col 25 (tab alignment is absolute) but `Nothing` shifted to col 23, causing the layout rule to close the case block prematurely.

## Result

`happy-meta` parse success rate: 62% → 100% (all 6 previously failing `.lhs` files now pass).