### PR TITLE
fix(hackage): pin selected installed stackage packages

### DIFF
--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -35,3 +35,16 @@ library
     , zlib >= 0.5.4 && < 0.8
   ghc-options:        -Wall
   default-language: GHC2021
+
+test-suite spec
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Spec.hs
+  build-depends:
+      base >= 4.16 && < 5
+    , aihc-hackage
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+  ghc-options:        -Wall
+  default-language: GHC2021

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Stackage.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Stackage.hs
@@ -12,6 +12,7 @@ import Aihc.Hackage.Types (PackageSpec (..))
 import Control.Exception (SomeException, displayException, try)
 import Data.Char (isSpace)
 import Data.List (isPrefixOf)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Text.Lazy qualified as TL
@@ -97,8 +98,40 @@ parseConstraint entry
                 -- Snapshot constraints like "base installed" refer to compiler-provided
                 -- packages. We return a PackageSpec with version "installed" so that
                 -- downstream code can fetch the latest version from Hackage.
-                [name, "installed"] -> Just (PackageSpec (trim name) "installed")
+                [name, "installed"] ->
+                  let packageName = trim name
+                      version = Map.findWithDefault "installed" packageName installedPackageVersions
+                   in Just (PackageSpec packageName version)
                 _ -> Nothing
+
+installedPackageVersions :: Map.Map String String
+installedPackageVersions =
+  Map.fromList
+    [ ("binary", "0.8.9.3"),
+      ("bytestring", "0.12.2.0"),
+      ("containers", "0.7"),
+      ("Cabal", "3.14.2.0"),
+      ("Cabal-syntax", "3.14.2.0"),
+      ("array", "0.5.8.0"),
+      ("deepseq", "1.5.1.0"),
+      ("directory", "1.3.10.1"),
+      ("exceptions", "0.10.12"),
+      ("filepath", "1.5.5.0"),
+      ("mtl", "2.3.2"),
+      ("os-string", "2.0.10"),
+      ("parsec", "3.1.18.0"),
+      ("pretty", "1.1.3.6"),
+      ("process", "1.6.26.1"),
+      ("semaphore-compat", "1.0.0"),
+      ("stm", "2.5.3.1"),
+      ("template-haskell", "2.23.0.0"),
+      ("terminfo", "0.4.1.7"),
+      ("text", "2.1.4"),
+      ("time", "1.14"),
+      ("transformers", "0.6.3.0"),
+      ("unix", "2.8.8.0"),
+      ("xhtml", "3000.2.2.1")
+    ]
 
 breakOn :: String -> String -> Maybe (String, String)
 breakOn needle haystack =

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -4,7 +4,7 @@ import Aihc.Hackage.Stackage (parseSnapshotConstraints)
 import Aihc.Hackage.Types (PackageSpec (..))
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
-import qualified Test.Tasty.QuickCheck as QC
+import Test.Tasty.QuickCheck qualified as QC
 
 main :: IO ()
 main =

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -1,0 +1,38 @@
+module Main (main) where
+
+import Aihc.Hackage.Stackage (parseSnapshotConstraints)
+import Aihc.Hackage.Types (PackageSpec (..))
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import qualified Test.Tasty.QuickCheck as QC
+
+main :: IO ()
+main =
+  defaultMain . testGroup "aihc-hackage" $
+    [ testCase "maps selected installed packages to fixed versions" $ do
+        parseSnapshotConstraints "constraints: binary installed, bytestring installed, Cabal installed, unix installed"
+          @?= Right
+            [ PackageSpec "binary" "0.8.9.3",
+              PackageSpec "bytestring" "0.12.2.0",
+              PackageSpec "Cabal" "3.14.2.0",
+              PackageSpec "unix" "2.8.8.0"
+            ],
+      testCase "keeps installed for packages without a fixed override" $ do
+        parseSnapshotConstraints "constraints: base installed, custom-package installed"
+          @?= Right
+            [ PackageSpec "base" "installed",
+              PackageSpec "custom-package" "installed"
+            ],
+      QC.testProperty "dummy quickcheck property" prop_dummy
+    ]
+
+-- | Dummy QuickCheck property that always passes.
+-- Added so that --quickcheck-tests flag is accepted by the test suite.
+prop_dummy :: Bool
+prop_dummy = True
+
+(@?=) :: (Eq a, Show a) => Either String a -> Either String a -> Assertion
+actual @?= expected =
+  if actual == expected
+    then pure ()
+    else assertFailure ("expected: " <> show expected <> "\n but got: " <> show actual)


### PR DESCRIPTION
## Summary
- map selected `installed` Stackage constraints in `parseConstraint` to fixed package versions instead of leaving them unresolved
- keep `installed` as the fallback for compiler-provided packages without an explicit override
- add a dedicated `aihc-hackage` test suite covering both the pinned and fallback cases

## Checks
- `just fmt`
- `just check`

## Progress
- Stackage installed-package overrides added: 24/24

## Notes
- `coderabbit review --prompt-only` was attempted but rate-limited, so it was skipped per repository guidance.