### PR TITLE
fix(parser): parse type applications (@T) in constraint item contexts

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -617,9 +617,13 @@ contextItemParserWith typeParser typeAtomParser =
       pure (foldInfixR buildInfixType first rest)
     constraintTypeAppParser = do
       first <- typeAtomParser
-      rest <- MP.many typeAtomParser
-      pure (foldl buildTypeApp first rest)
-    buildTypeApp = TApp
+      rest <- MP.many constraintTypeAppArgParser
+      pure (foldl applyConstraintAppArg first rest)
+    constraintTypeAppArgParser =
+      (Left <$> MP.try (expectedTok TkTypeApp *> typeAtomParser))
+        <|> (Right <$> typeAtomParser)
+    applyConstraintAppArg fn (Left ty) = TTypeApp fn ty
+    applyConstraintAppArg fn (Right ty) = TApp fn ty
     -- \| Parse a type expression that can appear as a kind annotation.
     -- Handles function types (e.g., Type -> Constraint) and type application,
     -- but NOT context types (C a => ...) to avoid parsing cycles.

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-type-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-type-application.hs
@@ -1,5 +1,9 @@
 {- ORACLE_TEST pass -}
-{-# LANGUAGE PatternSynonyms, TypeApplications #-}
+{-# LANGUAGE ExplicitForAll, KindSignatures, PatternSynonyms, PolyKinds, TypeApplications #-}
 module PatternSynonymsSignatureTypeApplication where
+
+import Data.Kind (Type)
+import Data.Typeable (Typeable)
+import Type.Reflection (TypeRep)
 
 pattern TypeRep :: forall {k :: Type} (a :: k). () => Typeable @k a => TypeRep @k a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-type-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-type-application.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE PatternSynonyms, TypeApplications #-}
+module PatternSynonymsSignatureTypeApplication where
+
+pattern TypeRep :: forall {k :: Type} (a :: k). () => Typeable @k a => TypeRep @k a


### PR DESCRIPTION
## Root Cause

`constraintTypeAppParser` inside `contextItemParserWith` (Common.hs:618) used `MP.many typeAtomParser` to collect type application arguments. The `typeAtomParser` function does not handle `TkTypeApp` (`@`) tokens — those are only handled by the dedicated `invisibleTypeAppParser` used in the full `typeAppParser`.

This meant that a constraint like `Typeable @k a` was parsed as just `Typeable`, leaving `@k a =>` unconsumed, so the `=>` could not be found and the whole parse failed.

**Failing input:**
```haskell
{-# LANGUAGE PatternSynonyms, TypeApplications #-}
pattern TypeRep :: forall {k :: Type} (a :: k). () => Typeable @k a => TypeRep @k a
```

## Solution

Replaced `MP.many typeAtomParser` in `constraintTypeAppParser` with a new `constraintTypeAppArgParser` that first tries `TkTypeApp *> typeAtomParser` (producing `TTypeApp`) and falls back to `typeAtomParser` (producing `TApp`). This mirrors the approach used by `typeAppArgParser` / `invisibleTypeAppParser` in `Type.hs`.

## Changes

- `components/aihc-parser/src/Aihc/Parser/Internal/Common.hs`: Update `constraintTypeAppParser` to handle `@T` type application tokens in constraint contexts
- `components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-signature-type-application.hs`: New oracle test for the motivating case

## Testing

All 1524 existing tests continue to pass. The new oracle test exercises the fixed case: a pattern synonym signature with `forall`-bound inferred kind variables and a constraint containing visible type applications.