### PR TITLE
fix(resolve): export parenthesized operator pattern bindings

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -875,9 +875,7 @@ declExportedNames decl =
       case valueDecl of
         FunctionBind name _ -> ([name], [])
         PatternBind pat _ ->
-          case peelPatternAnn pat of
-            PVar name -> ([name], [])
-            _ -> ([], [])
+          (map snd (collectPatVarBinders NoSourceSpan pat), [])
     DeclTypeSig names _ -> (names, [])
     DeclClass classDecl ->
       ( classDeclMethodNames (classDeclItems classDecl),

--- a/components/aihc-resolve/test/Test/Fixtures/golden/pattern-bindings.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/pattern-bindings.yaml
@@ -1,0 +1,39 @@
+extensions: []
+modules:
+  - |
+    module Main where
+    (f . g) x = f (g x)
+    (.*) = (.) . (.)
+    (.**) = (.) . (.*)
+expected:
+  Main:
+    - "2:1-2:2 . => (value) Main.."
+    - "2:2-2:3 f => (value) Local 0 f"
+    - "2:6-2:7 g => (value) Local 1 g"
+    - "2:9-2:10 x => (value) Local 2 x"
+    - "2:13-2:14 f => (value) Local 0 f"
+    - "2:16-2:17 g => (value) Local 1 g"
+    - "2:18-2:19 x => (value) Local 2 x"
+    - "3:8-3:11 . => (value) Main.."
+    - "3:14-3:17 . => (value) Main.."
+    - "4:9-4:12 . => (value) Main.."
+    - "4:15-4:19 .* => (value) Main..*"
+annotated:
+  - |
+    module Main where
+    (f . g) x = f (g x)
+    ││   │  │   │  │ └─ v 2
+    ││   │  │   │  └─ v 1
+    ││   │  │   └─ v 0
+    ││   │  └─ v 2
+    ││   └─ v 1
+    │└─ v 0
+    └─ v Main
+    (.*) = (.) . (.)
+           │     └─ v Main
+           └─ v Main
+    (.**) = (.) . (.*)
+            │     └─ v Main
+            └─ v Main
+status: pass
+reason: ""


### PR DESCRIPTION
## Summary

- `declExportedNames` only matched bare `PVar` in `PatternBind`, so definitions like `(.*) = ...` — parsed as `PatternBind (PParen (PVar ".*"))` — were never added to the module scope
- Replaced the narrow match with `collectPatVarBinders`, which already handles `PParen`, `PTuple`, and other wrapper patterns
- Fixes resolution of operator names defined via parenthesized pattern bindings (e.g. `(.*)` on the RHS of `(.**) = (.) . (.*)` resolving as `Error unbound`)

## Test plan

- [ ] `cabal test aihc-resolve` — all 21 tests pass, including the previously failing `pattern-bindings.yaml` golden test