### PR TITLE
fix(parser): minimize roundtrip mismatch diffs

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -127,6 +127,7 @@ test-suite spec
       base >=4.16 && <5
     , aihc-cpp
     , aihc-hackage
+    , Diff
     , megaparsec
     , text
     , containers
@@ -165,6 +166,7 @@ executable parser-progress
     , aihc-parser
     , aihc-cpp
     , aihc-hackage
+    , Diff
     , bytestring
     , text
     , containers
@@ -212,6 +214,7 @@ executable extension-progress
     , aihc-parser
     , aihc-cpp
     , aihc-hackage
+    , Diff
     , text
     , containers
     , directory
@@ -246,6 +249,7 @@ executable hackage-tester
     , aihc-parser
     , aihc-cpp
     , aihc-hackage
+    , Diff
     , text
     , containers
     , deepseq
@@ -288,6 +292,7 @@ executable stackage-progress
     , aihc-parser
     , aihc-cpp
     , aihc-hackage
+    , Diff
     , text
     , containers
     , deepseq

--- a/components/aihc-parser/common/ParserValidation.hs
+++ b/components/aihc-parser/common/ParserValidation.hs
@@ -3,12 +3,14 @@
 module ParserValidation
   ( ValidationErrorKind (..),
     ValidationError (..),
+    formatDiff,
     validateParser,
   )
 where
 
 import Aihc.Parser (ParserConfig (..), defaultConfig, formatParseErrors, parseModule)
 import Aihc.Parser.Syntax qualified as Syntax
+import Data.Algorithm.Diff (PolyDiff (..), getDiff)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GhcOracle qualified
@@ -121,24 +123,30 @@ formatDiff before after =
       suffixLen = commonSuffixLen beforeRest afterRest
       changedBefore = take (length beforeRest - suffixLen) beforeRest
       changedAfter = take (length afterRest - suffixLen) afterRest
-      removed = map ("- " <>) (take 30 changedBefore)
-      added = map ("+ " <>) (take 30 changedAfter)
-   in if null changedBefore && null changedAfter
+      diffLines = concatMap renderDiffLine (getDiff changedBefore changedAfter)
+      shownDiffLines = take 30 diffLines
+   in if null diffLines
         then Nothing
         else
           Just
             ( T.unlines
                 ( ["@@ line " <> T.pack (show (prefixLen + 1)) <> " @@"]
-                    <> removed
-                    <> added
-                    <> [truncationNote (length changedBefore) (length changedAfter)]
+                    <> shownDiffLines
+                    <> truncationNote diffLines
                 )
             )
 
-truncationNote :: Int -> Int -> Text
-truncationNote removedN addedN
-  | removedN <= 30 && addedN <= 30 = ""
-  | otherwise = "...diff truncated..."
+renderDiffLine :: PolyDiff Text Text -> [Text]
+renderDiffLine diffLine =
+  case diffLine of
+    First lineText -> ["- " <> lineText]
+    Second lineText -> ["+ " <> lineText]
+    Both _ _ -> []
+
+truncationNote :: [Text] -> [Text]
+truncationNote diffLines
+  | length diffLines <= 30 = []
+  | otherwise = ["...diff truncated..."]
 
 commonPrefixLen :: (Eq a) => [a] -> [a] -> Int
 commonPrefixLen = go 0

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -14,7 +14,7 @@ import Data.Char (ord)
 import Data.Maybe (isNothing)
 import Data.Text qualified as T
 import Numeric (showHex, showOct)
-import ParserValidation (validateParser)
+import ParserValidation (formatDiff, validateParser)
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.ErrorMessages.Suite (errorMessageTests)
@@ -124,6 +124,7 @@ buildTests = do
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
+            testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
             localOption (QC.QuickCheckTests 2000) $
               QC.testProperty "generated valid char literal spellings lex like GHC" prop_validGeneratedCharLiteralSpellingsLexLikeGhc,
@@ -713,6 +714,38 @@ test_prettyInfixRhsOpenEndedInsideSection = do
       assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
     ParseErr bundle ->
       assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
+
+test_roundtripDiffIsMinimal :: Assertion
+test_roundtripDiffIsMinimal =
+  let before =
+        T.unlines
+          [ "data CtOrigin",
+            "  = forall (p :: Pass). (OutputableBndrId p) =>",
+            "    ExpectedFunTySyntaxOp !CtOrigin !(HsExpr (GhcPass p)) |",
+            "    ExpectedFunTyViewPat !(HsExpr GhcRn) |",
+            "    forall (p :: Pass). Outputable (HsExpr (GhcPass p)) =>",
+            "    Thing"
+          ]
+      rendered =
+        T.unlines
+          [ "data CtOrigin",
+            "  = forall p. (OutputableBndrId p) =>",
+            "    ExpectedFunTySyntaxOp !CtOrigin !(HsExpr (GhcPass p)) |",
+            "    ExpectedFunTyViewPat !(HsExpr GhcRn) |",
+            "    forall p. Outputable (HsExpr (GhcPass p)) =>",
+            "    Thing"
+          ]
+      expected =
+        Just
+          ( T.unlines
+              [ "@@ line 2 @@",
+                "-   = forall (p :: Pass). (OutputableBndrId p) =>",
+                "+   = forall p. (OutputableBndrId p) =>",
+                "-     forall (p :: Pass). Outputable (HsExpr (GhcPass p)) =>",
+                "+     forall p. Outputable (HsExpr (GhcPass p)) =>"
+              ]
+          )
+   in assertEqual "minimal diff" expected (formatDiff before rendered)
 
 -- | Regression test: bird-track unliteration must preserve column positions so
 -- that tab-aligned case alternatives remain in the same layout context.


### PR DESCRIPTION
## Summary
- switch `ParserValidation.formatDiff` to `Data.Algorithm.Diff` so roundtrip mismatch output only prints the inserted and removed lines inside the changed region
- add a regression test for the minimal diff output shown in roundtrip failures
- add the `Diff` dependency to the parser test and progress executables that compile `ParserValidation`

## Checks
- `just fmt`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern=\"formats roundtrip diffs minimally\"'`
- `just check`

## Progress
- parser roundtrip diff formatting: improved minimal hunk output for mismatch reports