### PR TITLE
fix(parser): preserve kind signatures in existential forall binders

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -993,13 +993,13 @@ dataConDeclParser = withSpan $ do
         <|> MP.try (boxedTupleConDeclParser forallVars context)
         <|> dataConRecordOrPrefixParser forallVars context
 
-listConDeclParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+listConDeclParser :: [TyVarBinder] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
 listConDeclParser forallVars context = do
   expectedTok TkSpecialLBracket
   expectedTok TkSpecialRBracket
   pure $ \span' -> DataConAnn (mkAnnotation span') (ListCon forallVars context)
 
-boxedTupleConDeclParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+boxedTupleConDeclParser :: [TyVarBinder] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
 boxedTupleConDeclParser forallVars context = do
   expectedTok TkSpecialLParen
   mClose <- MP.optional (expectedTok TkSpecialRParen)
@@ -1017,7 +1017,7 @@ boxedTupleConDeclParser forallVars context = do
       expectedTok TkSpecialRParen
       pure $ \span' -> DataConAnn (mkAnnotation span') (TupleCon forallVars context Boxed (firstField : rest))
 
-unboxedConDeclParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+unboxedConDeclParser :: [TyVarBinder] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
 unboxedConDeclParser forallVars context = do
   expectedTok TkSpecialUnboxedLParen
   mClose <- MP.optional (expectedTok TkSpecialUnboxedRParen)
@@ -1359,7 +1359,7 @@ derivingStrategyParser =
     <|> (expectedTok TkKeywordNewtype >> pure DerivingNewtype)
     <|> (varIdTok "anyclass" >> pure DerivingAnyclass)
 
-dataConQualifiersParser :: TokParser ([Text], [Type])
+dataConQualifiersParser :: TokParser ([TyVarBinder], [Type])
 dataConQualifiersParser = do
   foralls <- MP.option [] forallBindersParser
   context <- contextPrefixDispatchList
@@ -1391,14 +1391,14 @@ typeFamilyDeclBodyParser familyKeywordMode = do
         typeFamilyDeclEquations = equations
       }
 
-forallBindersParser :: TokParser [Text]
+forallBindersParser :: TokParser [TyVarBinder]
 forallBindersParser = do
   expectedTok TkKeywordForall
   binders <- MP.some explicitForallBinderParser
   expectedTok (TkVarSym ".")
-  pure (map tyVarBinderName binders)
+  pure binders
 
-dataConRecordOrPrefixParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+dataConRecordOrPrefixParser :: [TyVarBinder] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
 dataConRecordOrPrefixParser forallVars context = do
   name <- constructorUnqualifiedNameParser <|> parens operatorUnqualifiedNameParser
   mRecordFields <- MP.optional (MP.try recordFieldsParserAfterLayoutSemicolon)
@@ -1418,7 +1418,7 @@ dataConRecordOrPrefixParser forallVars context = do
       recordFieldsParser
         <|> (expectedTok TkSpecialSemicolon *> recordFieldsParser)
 
-dataConInfixParser :: [Text] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
+dataConInfixParser :: [TyVarBinder] -> [Type] -> TokParser (SourceSpan -> DataConDecl)
 dataConInfixParser forallVars context = do
   lhs <- infixConstructorArgParser
   op <- constructorOperatorUnqualifiedNameParser <|> backtickConstructorUnqualifiedParser

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -564,19 +564,19 @@ addDataConDeclParens con =
   case con of
     DataConAnn ann inner -> DataConAnn ann (addDataConDeclParens inner)
     PrefixCon forallVars constraints name fields ->
-      PrefixCon forallVars (addContextConstraints constraints) name (map addPrefixConBangTypeParens fields)
+      PrefixCon (map addTyVarBinderParens forallVars) (addContextConstraints constraints) name (map addPrefixConBangTypeParens fields)
     InfixCon forallVars constraints lhs op rhs ->
-      InfixCon forallVars (addContextConstraints constraints) (addInfixConBangTypeParens lhs) op (addInfixConBangTypeParens rhs)
+      InfixCon (map addTyVarBinderParens forallVars) (addContextConstraints constraints) (addInfixConBangTypeParens lhs) op (addInfixConBangTypeParens rhs)
     RecordCon forallVars constraints name fields ->
-      RecordCon forallVars (addContextConstraints constraints) name (map addRecordFieldDeclParens fields)
+      RecordCon (map addTyVarBinderParens forallVars) (addContextConstraints constraints) name (map addRecordFieldDeclParens fields)
     GadtCon forallBinders constraints names body ->
       GadtCon forallBinders (addContextConstraints constraints) names (addGadtBodyParens body)
     TupleCon forallVars constraints flavor fields ->
-      TupleCon forallVars (addContextConstraints constraints) flavor (map addPrefixConBangTypeParens fields)
+      TupleCon (map addTyVarBinderParens forallVars) (addContextConstraints constraints) flavor (map addPrefixConBangTypeParens fields)
     UnboxedSumCon forallVars constraints pos arity field ->
-      UnboxedSumCon forallVars (addContextConstraints constraints) pos arity (addPrefixConBangTypeParens field)
+      UnboxedSumCon (map addTyVarBinderParens forallVars) (addContextConstraints constraints) pos arity (addPrefixConBangTypeParens field)
     ListCon forallVars constraints ->
-      ListCon forallVars (addContextConstraints constraints)
+      ListCon (map addTyVarBinderParens forallVars) (addContextConstraints constraints)
 
 addBangTypeParens :: BangType -> BangType
 addBangTypeParens bt =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -734,11 +734,8 @@ prettyRecordFields fields =
       | isSymbolicUName name = parens (pretty name)
       | otherwise = pretty name
 
-dataConQualifierPrefix :: [Text] -> [Type] -> [Doc ann]
-dataConQualifierPrefix forallVars constraints = forallPrefix forallVars <> contextPrefix constraints
-  where
-    forallPrefix [] = []
-    forallPrefix binders = ["forall", hsep (map pretty binders) <> "."]
+dataConQualifierPrefix :: [TyVarBinder] -> [Type] -> [Doc ann]
+dataConQualifierPrefix forallVars constraints = forallTyVarBinderPrefix forallVars <> contextPrefix constraints
 
 -- | Pretty print a BangType. The type already has TParen nodes where needed.
 prettyBangType :: BangType -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -367,19 +367,19 @@ docDataConDecl dcd =
   case dcd of
     DataConAnn _ inner -> docDataConDecl inner
     PrefixCon forallVars constraints name fields' ->
-      "PrefixCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> listField "fields" docBangType fields')))
+      "PrefixCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docTyVarBinder forallVars <> listField "constraints" docType constraints <> listField "fields" docBangType fields')))
     InfixCon forallVars constraints lhs op rhs ->
-      "InfixCon" <+> braces (hsep (punctuate comma ([field "op" (docUnqualifiedName op), field "lhs" (docBangType lhs), field "rhs" (docBangType rhs)] <> listField "forallVars" docText forallVars <> listField "constraints" docType constraints)))
+      "InfixCon" <+> braces (hsep (punctuate comma ([field "op" (docUnqualifiedName op), field "lhs" (docBangType lhs), field "rhs" (docBangType rhs)] <> listField "forallVars" docTyVarBinder forallVars <> listField "constraints" docType constraints)))
     RecordCon forallVars constraints name fields' ->
-      "RecordCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> listField "fields" docFieldDecl fields')))
+      "RecordCon" <+> braces (hsep (punctuate comma ([field "name" (docUnqualifiedName name)] <> listField "forallVars" docTyVarBinder forallVars <> listField "constraints" docType constraints <> listField "fields" docFieldDecl fields')))
     GadtCon forallBinders constraints names body ->
       "GadtCon" <+> braces (hsep (punctuate comma (listField "names" docUnqualifiedName names <> listField "forallBinders" docForallTelescope forallBinders <> listField "constraints" docType constraints <> [field "body" (docGadtBody body)])))
     TupleCon forallVars constraints flavor fields' ->
-      "TupleCon" <+> braces (hsep (punctuate comma (listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> [field "flavor" (pretty (show flavor))] <> listField "fields" docBangType fields')))
+      "TupleCon" <+> braces (hsep (punctuate comma (listField "forallVars" docTyVarBinder forallVars <> listField "constraints" docType constraints <> [field "flavor" (pretty (show flavor))] <> listField "fields" docBangType fields')))
     UnboxedSumCon forallVars constraints pos arity field' ->
-      "UnboxedSumCon" <+> braces (hsep (punctuate comma (listField "forallVars" docText forallVars <> listField "constraints" docType constraints <> [field "pos" (pretty (show pos)), field "arity" (pretty (show arity)), field "field" (docBangType field')])))
+      "UnboxedSumCon" <+> braces (hsep (punctuate comma (listField "forallVars" docTyVarBinder forallVars <> listField "constraints" docType constraints <> [field "pos" (pretty (show pos)), field "arity" (pretty (show arity)), field "field" (docBangType field')])))
     ListCon forallVars constraints ->
-      "ListCon" <+> braces (hsep (punctuate comma (listField "forallVars" docText forallVars <> listField "constraints" docType constraints)))
+      "ListCon" <+> braces (hsep (punctuate comma (listField "forallVars" docTyVarBinder forallVars <> listField "constraints" docType constraints)))
 
 -- | Document a GADT body
 docGadtBody :: GadtBody -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1448,19 +1448,19 @@ data NewtypeDecl = NewtypeDecl
 data DataConDecl
   = -- | Metadata for the whole constructor declaration (typically a 'SourceSpan' via 'mkAnnotation').
     DataConAnn Annotation DataConDecl
-  | PrefixCon [Text] [Type] UnqualifiedName [BangType]
-  | InfixCon [Text] [Type] BangType UnqualifiedName BangType
-  | RecordCon [Text] [Type] UnqualifiedName [FieldDecl]
+  | PrefixCon [TyVarBinder] [Type] UnqualifiedName [BangType]
+  | InfixCon [TyVarBinder] [Type] BangType UnqualifiedName BangType
+  | RecordCon [TyVarBinder] [Type] UnqualifiedName [FieldDecl]
   | -- | GADT-style constructor: @Con :: forall a. Ctx => Type@
     -- The list of names supports multiple constructors: @T1, T2 :: Type@
     GadtCon [ForallTelescope] [Type] [UnqualifiedName] GadtBody
   | -- | Tuple-style constructor: @()@, @(a,b)@, @(# #)@, @(# a,b #)@
-    TupleCon [Text] [Type] TupleFlavor [BangType]
+    TupleCon [TyVarBinder] [Type] TupleFlavor [BangType]
   | -- | Unboxed sum constructor: @(# a | #)@, @(# | b #)@
     -- Fields: forall vars, context, position (1-based), total arity, field type
-    UnboxedSumCon [Text] [Type] Int Int BangType
+    UnboxedSumCon [TyVarBinder] [Type] Int Int BangType
   | -- | List constructor: @[]@
-    ListCon [Text] [Type]
+    ListCon [TyVarBinder] [Type]
   deriving (Data, Eq, Show, Generic, NFData)
 
 -- | Strip nested 'DataConAnn' wrappers.

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/data-forall-kind-sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/data-forall-kind-sig.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module M where
+
+data T = forall (a :: T). C a


### PR DESCRIPTION
## Summary

- `DataConDecl` stored existential forall binders (e.g. `forall (a :: T).`) as `[Text]` (names only), silently dropping kind annotations
- Changed the field type to `[TyVarBinder]` across `PrefixCon`, `InfixCon`, `RecordCon`, `TupleCon`, `UnboxedSumCon`, and `ListCon`
- Updated parser (`forallBindersParser`, `dataConQualifiersParser`), pretty-printer (`dataConQualifierPrefix`), parenthesisation pass (`addDataConDeclParens`), and debug shorthand (`docDataConDecl`) accordingly
- Removed the `xfail` annotation from `Parens/data-forall-kind-sig` oracle test, which now passes

## Test plan

- [ ] `cabal test aihc-parser:spec --test-options="--pattern data-forall-kind-sig"` passes
- [ ] Full `cabal build aihc-parser` succeeds with no errors