### PR TITLE
fix(parens): parenthesize ENegate when argument is a type-applied TH splice

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -160,6 +160,7 @@ startsWithDollar (ETHSplice {}) = True
 startsWithDollar (ETHTypedSplice {}) = True
 startsWithDollar (ERecordUpd base _) = startsWithDollar base
 startsWithDollar (EApp fn _) = startsWithDollar fn
+startsWithDollar (ETypeApp fn _) = startsWithDollar fn
 startsWithDollar _ = False
 
 startsWithOverloadedLabel :: Expr -> Bool

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_negated_typed_splice_type_app.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_negated_typed_splice_type_app.hs
@@ -1,0 +1,16 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+module TH_Negated_Typed_Splice_TypeApp where
+
+-- Regression test: negation of a type-applied typed splice.
+-- The pretty-printer must parenthesize the argument of ENegate when it
+-- starts with a TH typed splice ($$), even after a type application is
+-- applied to it, so that the lexer does not merge '-' and '$$' into the
+-- single operator token '-$$'.
+--
+-- Without the fix, addDeclParens produced  f = -$$("") @C
+-- which the lexer tokenised as TkVarSym "-$$", causing a parse failure.
+-- With the fix it produces  f = -($$("") @C)  which round-trips correctly.
+f = -($$("") @C)
+g = -($$expr @T)


### PR DESCRIPTION
## Summary

- `startsWithDollar` in `Parens.hs` was missing the `ETypeApp` case, causing `ENegate (ETypeApp (ETHTypedSplice ...) ...)` to be pretty-printed as `-$$(...) @T`
- The lexer greedily merges `-` and `$$` into a single `TkVarSym "-$$"` token when they appear without whitespace, making the output unparseable
- Fix: add `ETypeApp fn _ -> startsWithDollar fn` to propagate the dollar-start check through type applications, causing `addNegateParens` to wrap with `EParen` and produce `-($$(...) @T)` instead

## Test plan

- [x] Reproduces with `just replay "(SMGen 17996516050084521382 5629600603173055173,49)"` before fix, passes after
- [x] All 1543 oracle/unit tests pass
- [x] Added oracle regression test `th_negated_typed_splice_type_app.hs`