### PR TITLE
test(oracle): add xfail fixtures for CTYPE pragma, kind sig, and type operator roundtrip gaps

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/ctype-data-two-strings.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/ctype-data-two-strings.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail CTYPE pragma on data declaration is not preserved in roundtrip -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE CApiFFI #-}
+
+module CtypeDataTwoStrings where
+
+data {-# CTYPE "termbox.h" "struct tb_cell" #-} Tb_cell = Tb_cell

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/ctype-newtype.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ForeignFunctionInterface/ctype-newtype.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail CTYPE pragma on newtype declaration is not preserved in roundtrip -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE CApiFFI #-}
+
+module CtypeNewtype where
+
+import Foreign.C.Types (CInt (..))
+
+newtype {-# CTYPE "signed int" #-} Fixed = Fixed CInt

--- a/components/aihc-parser/test/Test/Fixtures/oracle/StandaloneKindSignatures/standalone-kind-chained-visible-forall.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/StandaloneKindSignatures/standalone-kind-chained-visible-forall.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST xfail invisible forall body after visible forall in standalone kind signature is wrapped in extra parens during roundtrip -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RequiredTypeArguments #-}
+
+module StandaloneKindChainedVisibleForall where
+
+import Data.Kind (Type)
+
+type Family :: forall (name :: Name) -> forall (ks :: Params name). ParamsProxy name ks -> forall (args :: Args name ks) -> Exp (Res name ks args)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-instance-rhs-kind-annotation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/type-instance-rhs-kind-annotation.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST xfail kind annotation on type instance RHS gains extra parentheses during roundtrip -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+
+module TypeInstanceRhsKindAnnotation where
+
+import Data.Kind (Type)
+
+type instance Sing = SIndex as a :: Index as a -> Type

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-synonym-operator-kinded-params.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/type-synonym-operator-kinded-params.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST xfail kind annotations on type synonym operator parameters are dropped during roundtrip -}
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+
+module TypeSynonymOperatorKindedParams where
+
+type (a :: k1) <= (b :: k2) = (a <=? b) ~ 'True


### PR DESCRIPTION
## Summary

Adds 5 new oracle xfail fixture files documenting known roundtrip gaps in the AIHC parser:

- **`ForeignFunctionInterface/ctype-newtype.hs`** — `{-# CTYPE "signed int" #-}` on a `newtype` declaration is silently dropped by AIHC, causing a fingerprint mismatch after roundtrip.
- **`ForeignFunctionInterface/ctype-data-two-strings.hs`** — `{-# CTYPE "termbox.h" "struct tb_cell" #-}` on a `data` declaration is similarly dropped.
- **`StandaloneKindSignatures/standalone-kind-chained-visible-forall.hs`** — A standalone kind signature with a visible `forall ... ->` followed by an invisible `forall ... .` gets an extra pair of parentheses injected around the inner forall body during roundtrip.
- **`TypeOperators/type-synonym-operator-kinded-params.hs`** — Kind annotations on type synonym operator parameters (`type (a :: k1) <= (b :: k2) = ...`) are dropped during roundtrip, losing `:: k1` and `:: k2`.
- **`TypeFamilies/type-instance-rhs-kind-annotation.hs`** — A kind annotation on the RHS of a `type instance` (`type instance Sing = expr :: kind`) gains extra parentheses after roundtrip.

## Progress counts

xfail: +5