### PR TITLE
fix(parser): preserve promoted list syntax in pretty-printer

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -390,6 +390,17 @@ typeFamilyInfixAppView ty =
 
 -- | Pretty-print a type. The AST is assumed to already have TParen nodes
 -- in the correct positions (inserted by 'addTypeParens').
+-- | Check if a type, when pretty-printed, would start with a
+-- promotion tick.  This is used to decide whether a promoted list or
+-- tuple needs a space after the opening tick to avoid lexer confusion
+-- (e.g.  ''[ '[' ... ]'' is invalid, whereas ''[ '[ ... ]'' is valid).
+startsWithTick :: Type -> Bool
+startsWithTick (TAnn _ sub) = startsWithTick sub
+startsWithTick (TList Promoted _) = True
+startsWithTick (TCon _ Promoted) = True
+startsWithTick (TTuple _ Promoted _) = True
+startsWithTick _ = False
+
 prettyType :: Type -> Doc ann
 prettyType ty =
   case ty of
@@ -400,7 +411,7 @@ prettyType ty =
           base
             | isSymbolicTypeName name = parens (pretty rendered)
             | otherwise = pretty rendered
-       in if promoted == Promoted then "' " <> base else base
+       in if promoted == Promoted then "'" <> base else base
     TImplicitParam name inner -> pretty name <+> "::" <+> prettyType inner
     TTypeLit lit -> prettyTypeLiteral lit
     TStar -> "*"
@@ -422,13 +433,21 @@ prettyType ty =
     TFun arrowKind a b ->
       prettyType a <+> prettyArrowKind arrowKind <+> prettyType b
     TTuple tupleFlavor promoted elems ->
-      let tupleDoc = prettyTupleBody tupleFlavor (hsep (punctuate comma (map prettyType elems)))
-       in if promoted == Promoted then "'" <> tupleDoc else tupleDoc
+      let elemsDoc = hsep (punctuate comma (map prettyType elems))
+          tupleDoc = prettyTupleBody tupleFlavor elemsDoc
+       in case (promoted, elems) of
+            (Promoted, h : _) | startsWithTick h -> "' " <> tupleDoc
+            (Promoted, _) -> "'" <> tupleDoc
+            _ -> tupleDoc
     TUnboxedSum elems ->
       hsep ["(#", hsep (punctuate " |" (map prettyType elems)), "#)"]
     TList promoted elems ->
-      let listDoc = brackets (hsep (punctuate comma (map prettyType elems)))
-       in if promoted == Promoted then "'" <> listDoc else listDoc
+      let elemsDoc = hsep (punctuate comma (map prettyType elems))
+          listDoc = brackets elemsDoc
+       in case (promoted, elems) of
+            (Promoted, h : _) | startsWithTick h -> "' " <> listDoc
+            (Promoted, _) -> "'" <> listDoc
+            _ -> listDoc
     TKindSig ty' kind ->
       prettyType ty' <+> "::" <+> prettyType kind
     TContext constraints inner ->

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/tao-example-promoted-lists-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/tao-example-promoted-lists-roundtrip.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TaoExamplePromotedListsRoundtrip where
+
+import Data.Proxy (Proxy(Proxy))
+
+type OneToFour = '[1, 2, 3, 4]
+type Empty = '[]
+
+unitTests :: Proxy ('[ '[1, 2, 3], '[4] ])
+unitTests = Proxy :: Proxy ('[ '[1, 2, 3], '[4] ])


### PR DESCRIPTION
## Summary
- Fix pretty-printer emitting invalid promoted list syntax (`' []` instead of `'[]`, missing space before nested promoted elements)
- Introduce `startsWithTick` helper to detect promoted types that need a space after the opening tick
- Add regression oracle test covering the tao-example nested promoted list pattern

## Details
The pretty-printer was emitting `' []` for `type Empty = '[]` (with a spurious space) and `'['[1,2],'[3]]` for nested promoted lists where GHC requires `'[ '[1,2], '[3]]` (space after the outer tick when the first element is also promoted).

The fix:
1. Removed the spurious space in the `TCon` case (`"' " <> base` → `"'" <> base`)
2. Added `startsWithTick` to detect promoted `TList`/`TCon`/`TTuple` nodes
3. Modified `TList` and `TTuple` cases to emit `"' "` instead of `"'"` when the first element is promoted

## Test results
- `just check` passes (ormolu + hlint + full test suite)
- Regression test `tao-example-promoted-lists-roundtrip.hs` passes