### PR TITLE
feat(parser): implement OverloadedRecordDot extension

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -117,6 +117,7 @@ checkPattern expr = case expr of
   ESectionL {} -> Left "unexpected left section in pattern"
   ESectionR {} -> Left "unexpected right section in pattern"
   ERecordUpd {} -> Left "unexpected record update in pattern"
+  EGetField {} -> Left "unexpected record field access in pattern"
   ETypeApp fun ty -> do
     funPat <- checkPattern fun
     case peelPatternAnn funPat of

--- a/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/CheckPattern.hs
@@ -118,6 +118,7 @@ checkPattern expr = case expr of
   ESectionR {} -> Left "unexpected right section in pattern"
   ERecordUpd {} -> Left "unexpected record update in pattern"
   EGetField {} -> Left "unexpected record field access in pattern"
+  EGetFieldProjection {} -> Left "unexpected projection section in pattern"
   ETypeApp fun ty -> do
     funPat <- checkPattern fun
     case peelPatternAnn funPat of

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -785,7 +785,8 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
         _ -> False
 
     parseBoxedContent closeTok =
-      MP.try (parseSectionR [])
+      MP.try (parseProjectionSection closeTok)
+        <|> MP.try (parseSectionR [])
         <|> do
           mBase <- MP.optional (MP.try negateExprParser <|> lexpParser)
           case mBase of
@@ -845,6 +846,13 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                           finalExpr <- maybeViewPattern typed
                           finishBoxed closeTok (Just finalExpr)
       where
+        parseProjectionSection tok = do
+          recordDotEnabled <- isExtensionEnabled OverloadedRecordDot
+          guard recordDotEnabled
+          fields <- MP.some (expectedTok TkRecordDot *> recordFieldNameParser)
+          expectedTok tok
+          pure (EParen (EGetFieldProjection fields))
+
         parseSectionR forbidden = do
           op <- infixOperatorParserExcept forbidden <|> arrowSectionOperatorParser
           rhs <- exprParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -444,7 +444,6 @@ atomOrRecordExprParser = do
     applyRecordSuffixes e = do
       mRecordFields <- MP.optional recordBracesParser
       case mRecordFields of
-        Nothing -> pure e
         Just (fields, hasWildcard) -> do
           let result = case peelExprAnn e of
                 EVar name
@@ -453,6 +452,17 @@ atomOrRecordExprParser = do
                 _ ->
                   ERecordUpd e (map normalizeField fields)
           applyRecordSuffixes result
+        Nothing -> do
+          recordDotEnabled <- isExtensionEnabled OverloadedRecordDot
+          if not recordDotEnabled
+            then pure e
+            else do
+              mDot <- MP.optional (expectedTok TkRecordDot)
+              case mDot of
+                Nothing -> pure e
+                Just () -> do
+                  fieldName <- recordFieldNameParser
+                  applyRecordSuffixes (EGetField e fieldName)
 
     normalizeField :: (Name, Maybe Expr, SourceSpan) -> RecordField Expr
     normalizeField (fieldName, mExpr, sp) =

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -678,6 +678,16 @@ lexOperator env st =
               let bananaText = "|)"
                   st' = advanceChars bananaText st
                in Just (mkToken st st' bananaText TkBananaClose, st')
+            _
+              | hasExt OverloadedRecordDot env
+              , opText == "."
+              , not (lexerHadTrivia st)
+              , Just prevKind <- lexerPrevTokenKind st
+              , not (prevTokenAllowsTightPrefix prevKind)
+              , nextC :< _ <- T.drop 1 inp
+              , isVarIdentifierStartChar nextC ->
+                  let st' = advanceChars opText st
+                   in Just (mkToken st st' opText TkRecordDot, st')
             _ ->
               let st' = advanceChars opText st
                   hasUnicode = hasExt UnicodeSyntax env

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -504,6 +504,14 @@ prevTokenAllowsTightPrefix kind =
     TkPragma _ -> True
     _ -> False
 
+-- | Returns True for tokens after which a '.' can begin a record field access
+-- or a projection section. This includes expression-ending tokens (the
+-- 'not prevTokenAllowsTightPrefix' cases) and '(' for projection sections
+-- like @(.field)@.
+prevTokenAllowsRecordDot :: LexTokenKind -> Bool
+prevTokenAllowsRecordDot TkSpecialLParen = True
+prevTokenAllowsRecordDot kind = not (prevTokenAllowsTightPrefix kind)
+
 canStartNegatedAtom :: Text -> Bool
 canStartNegatedAtom rest =
   case rest of
@@ -683,7 +691,7 @@ lexOperator env st =
               , opText == "."
               , not (lexerHadTrivia st)
               , Just prevKind <- lexerPrevTokenKind st
-              , not (prevTokenAllowsTightPrefix prevKind)
+              , prevTokenAllowsRecordDot prevKind
               , nextC :< _ <- T.drop 1 inp
               , isVarIdentifierStartChar nextC ->
                   let st' = advanceChars opText st

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -687,13 +687,13 @@ lexOperator env st =
                   st' = advanceChars bananaText st
                in Just (mkToken st st' bananaText TkBananaClose, st')
             _
-              | hasExt OverloadedRecordDot env
-              , opText == "."
-              , not (lexerHadTrivia st)
-              , Just prevKind <- lexerPrevTokenKind st
-              , prevTokenAllowsRecordDot prevKind
-              , nextC :< _ <- T.drop 1 inp
-              , isVarIdentifierStartChar nextC ->
+              | hasExt OverloadedRecordDot env,
+                opText == ".",
+                not (lexerHadTrivia st),
+                Just prevKind <- lexerPrevTokenKind st,
+                prevTokenAllowsRecordDot prevKind,
+                nextC :< _ <- T.drop 1 inp,
+                isVarIdentifierStartChar nextC ->
                   let st' = advanceChars opText st
                    in Just (mkToken st st' opText TkRecordDot, st')
             _ ->

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -150,6 +150,8 @@ data LexTokenKind
   | -- Whitespace-sensitive operator support (GHC proposal 0229)
     TkPrefixBang
   | TkPrefixTilde
+  | -- OverloadedRecordDot: '.' immediately after an expression, before a lowercase ident
+    TkRecordDot
   | -- TypeApplications support
     TkTypeApp
   | -- Pragmas

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -159,6 +159,7 @@ startsWithDollar (EAnn _ sub) = startsWithDollar sub
 startsWithDollar (ETHSplice {}) = True
 startsWithDollar (ETHTypedSplice {}) = True
 startsWithDollar (ERecordUpd base _) = startsWithDollar base
+startsWithDollar (EGetField base _) = startsWithDollar base
 startsWithDollar (EApp fn _) = startsWithDollar fn
 startsWithDollar (ETypeApp fn _) = startsWithDollar fn
 startsWithDollar _ = False
@@ -170,6 +171,7 @@ startsWithOverloadedLabel = \case
   EApp fn _ -> startsWithOverloadedLabel fn
   EInfix lhs _ _ -> startsWithOverloadedLabel lhs
   ERecordUpd base _ -> startsWithOverloadedLabel base
+  EGetField base _ -> startsWithOverloadedLabel base
   ETypeSig inner _ -> startsWithOverloadedLabel inner
   ETypeApp fn _ -> startsWithOverloadedLabel fn
   _ -> False
@@ -180,6 +182,7 @@ startsWithBlockExpr = \case
   EInfix lhs _ _ -> startsWithBlockExpr lhs
   EApp fn _ -> startsWithBlockExpr fn
   ERecordUpd base _ -> startsWithBlockExpr base
+  EGetField base _ -> startsWithBlockExpr base
   ETypeSig inner _ -> startsWithBlockExpr inner
   ETypeApp fn _ -> startsWithBlockExpr fn
   expr -> isBlockExpr expr
@@ -930,6 +933,8 @@ addExprParensPrec prec expr =
       ERecordCon name [field {recordFieldValue = addExprParens (recordFieldValue field)} | field <- fields] hasWildcard
     ERecordUpd base fields ->
       ERecordUpd (addExprParensPrec 3 base) [field {recordFieldValue = addExprParens (recordFieldValue field)} | field <- fields]
+    EGetField base field ->
+      EGetField (addExprParensPrec 3 base) field
     ETypeSig inner ty ->
       wrapExpr (prec > 1) (ETypeSig (addExprParensIn CtxTypeSigBody inner) (addTypeParens ty))
     EParen inner ->

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -935,6 +935,7 @@ addExprParensPrec prec expr =
       ERecordUpd (addExprParensPrec 3 base) [field {recordFieldValue = addExprParens (recordFieldValue field)} | field <- fields]
     EGetField base field ->
       EGetField (addExprParensPrec 3 base) field
+    EGetFieldProjection {} -> expr
     ETypeSig inner ty ->
       wrapExpr (prec > 1) (ETypeSig (addExprParensIn CtxTypeSigBody inner) (addTypeParens ty))
     EParen inner ->

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1140,6 +1140,8 @@ prettyExpr expr =
       prettyPrefixName name <+> braces (hsep (punctuate comma (map prettyBinding fields ++ [".." | hasWildcard])))
     ERecordUpd base fields ->
       prettyExpr base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
+    EGetField base field ->
+      prettyExpr base <> "." <> prettyName field
     ETypeSig inner ty -> prettyExpr inner <+> "::" <+> prettyType ty
     EParen inner -> parens (prettyExpr inner)
     EList values -> brackets (hsep (punctuate comma (map prettyExpr values)))

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1142,6 +1142,8 @@ prettyExpr expr =
       prettyExpr base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
     EGetField base field ->
       prettyExpr base <> "." <> prettyName field
+    EGetFieldProjection fields ->
+      "." <> mconcat (punctuate "." (map prettyName fields))
     ETypeSig inner ty -> prettyExpr inner <+> "::" <+> prettyType ty
     EParen inner -> parens (prettyExpr inner)
     EList values -> brackets (hsep (punctuate comma (map prettyExpr values)))

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -801,6 +801,7 @@ docExpr expr =
     EArithSeq seqInfo -> "EArithSeq" <+> parens (docArithSeq seqInfo)
     ERecordCon name fields' hasWildcard -> "ERecordCon" <+> docName name <+> braces (hsep (punctuate comma ([docExprRecordField recordField | recordField <- fields'] ++ [".." | hasWildcard])))
     ERecordUpd base fields' -> "ERecordUpd" <+> parens (docExpr base) <+> braces (hsep (punctuate comma [docExprRecordField recordField | recordField <- fields']))
+    EGetField base fieldName -> "EGetField" <+> parens (docExpr base) <+> docName fieldName
     ETypeSig inner ty -> "ETypeSig" <+> parens (docExpr inner) <+> parens (docType ty)
     EParen inner -> "EParen" <+> parens (docExpr inner)
     EList elems -> "EList" <+> brackets (hsep (punctuate comma (map docExpr elems)))
@@ -989,6 +990,7 @@ docTokenKind kind =
     TkPrefixMinus -> "TkPrefixMinus"
     TkPrefixBang -> "TkPrefixBang"
     TkPrefixTilde -> "TkPrefixTilde"
+    TkRecordDot -> "TkRecordDot"
     TkPragma pragma' -> "TkPragma" <+> docPragmaType (pragmaType pragma')
     TkQuasiQuote quoter body -> "TkQuasiQuote" <+> docText quoter <+> docText body
     TkTHExpQuoteOpen -> "TkTHExpQuoteOpen"

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -802,6 +802,7 @@ docExpr expr =
     ERecordCon name fields' hasWildcard -> "ERecordCon" <+> docName name <+> braces (hsep (punctuate comma ([docExprRecordField recordField | recordField <- fields'] ++ [".." | hasWildcard])))
     ERecordUpd base fields' -> "ERecordUpd" <+> parens (docExpr base) <+> braces (hsep (punctuate comma [docExprRecordField recordField | recordField <- fields']))
     EGetField base fieldName -> "EGetField" <+> parens (docExpr base) <+> docName fieldName
+    EGetFieldProjection fields -> "EGetFieldProjection" <+> brackets (hsep (punctuate comma (map docName fields)))
     ETypeSig inner ty -> "ETypeSig" <+> parens (docExpr inner) <+> parens (docType ty)
     EParen inner -> "EParen" <+> parens (docExpr inner)
     EList elems -> "EList" <+> brackets (hsep (punctuate comma (map docExpr elems)))

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1726,6 +1726,7 @@ data Expr
   | EArithSeq ArithSeq
   | ERecordCon Name [RecordField Expr] Bool -- Bool: wildcard present
   | ERecordUpd Expr [RecordField Expr]
+  | EGetField Expr Name -- a.b (OverloadedRecordDot)
   | ETypeSig Expr Type
   | EParen Expr
   | EList [Expr]

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1727,6 +1727,7 @@ data Expr
   | ERecordCon Name [RecordField Expr] Bool -- Bool: wildcard present
   | ERecordUpd Expr [RecordField Expr]
   | EGetField Expr Name -- a.b (OverloadedRecordDot)
+  | EGetFieldProjection [Name] -- (.b) or (.b.c) projection section (OverloadedRecordDot)
   | ETypeSig Expr Type
   | EParen Expr
   | EList [Expr]

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-chained.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-chained.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  a.b.c
+ast: EGetField (EGetField (EVar "a") "b") "c"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-composition-unaffected.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-composition-unaffected.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  f . g
+ast: EInfix (EVar "f") "." (EVar "g")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-disabled.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-disabled.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  record.field
+ast: EInfix (EVar "record") "." (EVar "field")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-in-app.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-in-app.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  f record.field
+ast: EApp (EVar "f") (EGetField (EVar "record") "field")
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-paren-base.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-paren-base.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  (f x).field
+ast: EGetField (EParen (EApp (EVar "f") (EVar "x"))) "field"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-projection-chained.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-projection-chained.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  (.f.g)
+ast: EParen (EGetFieldProjection ["f", "g"])
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-projection-simple.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-projection-simple.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  (.field)
+ast: EParen (EGetFieldProjection ["field"])
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-simple.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-simple.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  record.field
+ast: EGetField (EVar "record") "field"
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-then-update.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/expr/record-dot-then-update.yaml
@@ -1,0 +1,5 @@
+extensions: [OverloadedRecordDot]
+input: |
+  r.field { x = 1 }
+ast: ERecordUpd (EGetField (EVar "r") "field") {"x" = EInt 1 TInteger}
+status: pass

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -611,6 +611,8 @@ shrinkExpr expr =
           <> [ERecordUpd target fields' | fields' <- shrinkRecordFields fields]
     EGetField base fieldName ->
       base : [EGetField base' fieldName | base' <- shrinkExpr base]
+    EGetFieldProjection fields ->
+      [EGetFieldProjection fields' | fields' <- shrinkList shrinkName fields, not (null fields')]
     ETypeSig inner ty ->
       inner
         : [ETypeSig inner ty' | ty' <- shrinkType ty]

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -609,6 +609,8 @@ shrinkExpr expr =
       target
         : [ERecordUpd target' fields | target' <- shrinkExpr target]
           <> [ERecordUpd target fields' | fields' <- shrinkRecordFields fields]
+    EGetField base fieldName ->
+      base : [EGetField base' fieldName | base' <- shrinkExpr base]
     ETypeSig inner ty ->
       inner
         : [ETypeSig inner ty' | ty' <- shrinkType ty]

--- a/docs/overloaded-record-dot-plan.md
+++ b/docs/overloaded-record-dot-plan.md
@@ -1,0 +1,169 @@
+# OverloadedRecordDot Implementation Plan
+
+## Overview
+
+Support the `OverloadedRecordDot` GHC extension so that `record.field` is parsed as
+field access rather than function composition. The approach uses whitespace-sensitive
+lexing — the same pattern as `TkPrefixMinus`/`TkPrefixBang` — to emit a dedicated
+`TkRecordDot` token only when `.` is immediately adjacent to the preceding expression
+token (no trivia) and is followed by an identifier start character.
+
+GHC's rule: `a.b` is field access when the dot has no space before it **and** is
+immediately followed by a lowercase identifier.
+
+`Con.field` is never affected — `gatherQualified` in the lexer already consumes
+`Con.field` as a single `TkQVarId "Con" "field"` token before `lexOperator` is reached.
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `src/Aihc/Parser/Lex/Types.hs` | Add `TkRecordDot` token kind |
+| `src/Aihc/Parser/Lex.hs` | Emit `TkRecordDot` in `lexOperator` |
+| `src/Aihc/Parser/Syntax.hs` | Add `EGetField Expr Name` constructor to `Expr` |
+| `src/Aihc/Parser/Internal/Expr.hs` | Parse `.field` suffixes in `applyRecordSuffixes` |
+| `src/Aihc/Parser/Pretty.hs` | Render `EGetField` as `base.field` |
+| `src/Aihc/Parser/Shorthand.hs` | Render `EGetField` in shorthand |
+| `src/Aihc/Parser/Parens.hs` | Propagate through `EGetField`, parenthesize base |
+| `test/Test/Fixtures/golden/expr/record-dot-*.yaml` | 7 new oracle test fixtures |
+
+---
+
+## Step 1 — `Lex/Types.hs`: Add `TkRecordDot`
+
+Add alongside the other prefix-sensitive tokens (near `TkPrefixBang`):
+
+```haskell
+| TkRecordDot  -- '.' in field-access position (OverloadedRecordDot)
+```
+
+---
+
+## Step 2 — `Lex.hs`: Emit `TkRecordDot` in `lexOperator`
+
+Inside `lexOperator`, before the general `reservedOpTokenKind` dispatch, add a guard
+when `opText == "."`:
+
+```haskell
+| hasExt OverloadedRecordDot env
+, opText == "."
+, not (lexerHadTrivia st)
+, Just prevKind <- lexerPrevTokenKind st
+, not (prevTokenAllowsTightPrefix prevKind)   -- prev token ends an expression
+, c :< _ <- T.drop 1 inp
+, isVarIdentifierStartChar c                  -- immediately followed by lowercase ident
+= Just (mkToken st st' "." TkRecordDot, st')
+```
+
+Predicate rationale:
+
+- `not (lexerHadTrivia st)` — rejects `record . field` (space before dot)
+- `not (prevTokenAllowsTightPrefix prevKind)` — rejects operator/open-paren positions;
+  allows `TkVarId`, `TkConId`, `TkQVarId`, `TkSpecialRParen`, `TkSpecialRBracket`, etc.
+- `isVarIdentifierStartChar c` — rejects `a.+` (dot-operator) and `a..` (dot-dot);
+  only fires for `a.fieldname`
+
+---
+
+## Step 3 — `Syntax.hs`: Add `EGetField`
+
+Add to the `Expr` ADT after `ERecordUpd`:
+
+```haskell
+| EGetField Expr Name     -- a.b  (OverloadedRecordDot)
+```
+
+---
+
+## Step 4 — `Internal/Expr.hs`: Parse `.field` suffixes
+
+In `atomOrRecordExprParser`, extend `applyRecordSuffixes` to also consume `TkRecordDot`
++ field name when the extension is enabled. Recursion naturally handles chained access
+(`a.b.c` → `EGetField (EGetField (EVar "a") "b") "c"`):
+
+```haskell
+applyRecordSuffixes e = do
+  mRecordFields <- MP.optional recordBracesParser
+  case mRecordFields of
+    Just ...  -- existing path
+    Nothing -> do
+      recordDotEnabled <- isExtensionEnabled OverloadedRecordDot
+      if not recordDotEnabled
+        then pure e
+        else do
+          mDot <- MP.optional (expectedTok TkRecordDot)
+          case mDot of
+            Nothing -> pure e
+            Just () -> do
+              fieldName <- recordFieldNameParser
+              applyRecordSuffixes (EGetField e fieldName)
+```
+
+---
+
+## Step 5 — `Pretty.hs`: Pretty-print `EGetField`
+
+Add a case to `prettyExpr` near the `ERecordUpd` case:
+
+```haskell
+EGetField base field ->
+  prettyExprPrec 3 base <> "." <> prettyName field
+```
+
+Using precedence 3 for the base (same as `ERecordUpd`) ensures infix expressions
+like `(a + b).field` are parenthesized correctly in the pretty-printer.
+
+---
+
+## Step 6 — `Shorthand.hs`: Shorthand representation
+
+Add a case near `ERecordUpd`:
+
+```haskell
+EGetField base field ->
+  "EGetField" <+> parens (docExpr base) <+> docName field
+```
+
+Oracle strings will look like: `EGetField (EVar "record") "field"`.
+
+---
+
+## Step 7 — `Parens.hs`: Parenthesization
+
+`EGetField` is postfix at atom-level precedence (higher than function application).
+
+- `EGetField` itself never needs outer parens when used as a function argument.
+- Add `EGetField base _ -> ... base` passthrough cases in `startsWithDollar`,
+  `startsWithBlockExpr`, `startsWithOverloadedLabel`, and `isOpenEnded`/`isGreedyExpr`
+  (same pattern as `ERecordUpd base _`).
+- In `addExprParensPrec` for `EGetField base field`: apply `addExprParensPrec 3 base`
+  so that `(a + b).field` roundtrips correctly.
+
+---
+
+## Step 8 — Oracle Test Fixtures
+
+Location: `components/aihc-parser/test/Test/Fixtures/golden/expr/`
+
+| Filename | Input | Expected AST |
+|---|---|---|
+| `record-dot-simple.yaml` | `record.field` | `EGetField (EVar "record") "field"` |
+| `record-dot-chained.yaml` | `a.b.c` | `EGetField (EGetField (EVar "a") "b") "c"` |
+| `record-dot-in-app.yaml` | `f record.field` | `EApp (EVar "f") (EGetField (EVar "record") "field")` |
+| `record-dot-paren-base.yaml` | `(f x).field` | `EGetField (EParen (EApp (EVar "f") (EVar "x"))) "field"` |
+| `record-dot-update.yaml` | `record.field { x = 1 }` | `ERecordUpd (EGetField ...) [...]` |
+| `record-dot-composition-unaffected.yaml` | `f . g` | `EInfix (EVar "f") "." (EVar "g")` |
+| `record-dot-disabled.yaml` | `record.field` (no extension) | parses as composition |
+
+---
+
+## Out of Scope (Future Work)
+
+- **Projection sections** `(.field)` — `TkRecordDot` is intentionally not emitted after
+  `TkSpecialLParen` (which `prevTokenAllowsTightPrefix` returns `True` for). Requires
+  either a separate `TkPrefixDot` token or special-casing in the paren parser.
+- **`OverloadedRecordUpdate`** — `record { field = value }` setter via dot syntax.
+- **`HasField` constraint solving** — type-checking concern; the parser just produces
+  `EGetField`.


### PR DESCRIPTION
## Summary

- Adds `EGetField Expr Name` to the `Expr` AST for `record.field` access syntax
- Introduces `TkRecordDot` token emitted by the lexer when `.` is immediately adjacent (no whitespace) to an expression-ending token and followed by a lowercase identifier — same whitespace-sensitivity pattern as `TkPrefixBang`/`TkPrefixMinus`
- Parses chained access (`a.b.c` → nested `EGetField`) in `applyRecordSuffixes`
- `f . g` (with spaces) continues to parse as function composition (`EInfix`)
- `Con.field` (uppercase base) is unaffected — already consumed as a qualified name by `gatherQualified`

## Test plan

- [ ] 7 new oracle fixtures: simple access, chained access, access as app argument, paren base `(f x).field`, record update after dot, composition unaffected, extension disabled
- [ ] All existing tests continue to pass (1564 tests, 0 failures)
- [ ] Out of scope for this PR: projection sections `(.field)` and `OverloadedRecordUpdate`