### PR TITLE
fix(parser): keep top-level declarations out of empty instance where blocks

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -92,9 +92,12 @@ openImplicitLayout kind st tok =
       openTok = virtualSymbolToken "{" (lexTokenSpan tok)
       closeTok = virtualSymbolToken "}" (lexTokenSpan tok)
       newContext = LayoutImplicit col kind
-      -- Under NondecreasingIndentation, a nested context at the same level
-      -- as its parent is allowed (produces normal layout, not empty {}).
-      opensEmpty = if layoutNondecreasingIndent st then col < parentIndent else col <= parentIndent
+      -- Under NondecreasingIndentation, same-column nesting is allowed for
+      -- ordinary statement layouts (not declaration where-blocks).
+      opensEmpty =
+        if layoutNondecreasingIndent st && kind /= LayoutWhereBlock
+          then col < parentIndent
+          else col <= parentIndent
    in if opensEmpty
         then ([openTok, closeTok], st {layoutPendingLayout = Nothing}, False)
         else
@@ -247,7 +250,7 @@ stepTokenContext st tok =
       | otherwise -> st
     TkKeywordLet -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutLetBlock)}
     TkKeywordRec -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
-    TkKeywordWhere -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
+    TkKeywordWhere -> st {layoutPendingLayout = Just (PendingImplicitLayout LayoutWhereBlock)}
     TkKeywordElse -> decrementAfterThenElseClassicIfDepth st
     TkKeywordIf -> st {layoutPendingLayout = Just PendingMaybeMultiWayIf}
     TkTHDeclQuoteOpen ->

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -236,6 +236,7 @@ data LayoutContext
 
 data ImplicitLayoutKind
   = LayoutOrdinary
+  | LayoutWhereBlock
   | LayoutLetBlock
   | LayoutMultiWayIf
   | LayoutAfterThenElse !Int -- do-block opened directly by a preceding 'then'/'else'; tracks nested classic ifs inside the block

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/alsa-core-empty-instance-where-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/alsa-core-empty-instance-where-layout.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+module Sound.ALSA.Exception where
+
+class Exception a
+
+data T = T
+
+instance Exception T where
+
+checkResult :: Integral a => String -> a -> IO a
+checkResult = undefined


### PR DESCRIPTION
## Summary
- Fix layout handling for `where`-introduced declaration blocks so empty instance bodies do not absorb following top-level declarations under `NondecreasingIndentation` defaults.
- Add an oracle regression fixture that reproduces the `alsa-core` empty `instance ... where` layout boundary.
- Verified with `just check` and `cabal run exe:hackage-tester -v0 -- alsa-core`.

## Progress
- pass=1
- xfail=0
- xpass=0
- fail=0

## Review
- `coderabbit review --prompt-only` was attempted but skipped because the service returned a rate-limit/add-on error.
