### PR TITLE
test(parser): add xfail oracle tests for unimplemented features

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/MagicHash/infix-operator-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MagicHash/infix-operator-layout.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST xfail infix operator with magic hash in layout context not yet supported -}
+{-# LANGUAGE MagicHash #-}
+
+module MagicHashOperatorLayout where
+
+fn = val
+  #! val

--- a/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/foldable-ranger-overlappable.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/OverlappingInstances/foldable-ranger-overlappable.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST xfail instance with OVERLAPPABLE pragma, type operators in constraint, and lambda case not yet supported -}
+{-# LANGUAGE OverlappingInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeOperators #-}
+
+module OverlappingInstanceRangeR where
+
+data RangeR a b = NilR | (RangeR a b) :++ b
+
+instance {-# OVERLAPPABLE #-}
+        Foldable (RangeR 0 (m - 1)) => Foldable (RangeR 0 m) where
+        foldr (-<) z = \case NilR -> z; xs :++ x -> foldr (-<) (x -< z) xs

--- a/components/aihc-parser/test/Test/Fixtures/oracle/SourceImports/source-qualified-import.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/SourceImports/source-qualified-import.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail SOURCE pragma with qualified import not yet supported -}
+{-# LANGUAGE ImportQualifiedPost #-}
+
+module SourceImportQualified where
+
+import {-# SOURCE #-} qualified Test.ChasingBottoms.IsBottom as B

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/unpos-promoted-tuple.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeFamilies/unpos-promoted-tuple.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST xfail closed type family with promoted tuple patterns and polymorphic kind variables not yet supported -}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+
+module UnPosPromotedTuple where
+
+type family UnPos (x :: k1) :: k2 where
+  UnPos ('Pos x) = x
+  UnPos '( 'Pos x, 'Pos y) = '(x, y)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedSums/newtype-maybe-hash-unboxed-sum.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedSums/newtype-maybe-hash-unboxed-sum.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST xfail pretty-print yields ambiguous output -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UnboxedSums #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ExplicitForAll #-}
+
+module NewtypeMaybeHashUnboxedSum where
+
+newtype Maybe# :: forall (r :: RuntimeRep). TYPE r -> TYPE ('SumRep '[ 'TupleRep '[], r]) where
+  Maybe# :: forall (r :: RuntimeRep) (a :: TYPE r). (# (# #) | a #) -> Maybe# @r a

--- a/components/aihc-parser/test/Test/Fixtures/oracle/pragma/scc-expression.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/pragma/scc-expression.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail SCC pragma in expression context not yet supported -}
+
+module SCCPragmaExpression where
+
+mapL f lx = cachedLatch ({-# SCC mapL #-} f <$> getValueL lx)


### PR DESCRIPTION
## Summary
- Add 6 xfail oracle test files for aihc-parser covering unimplemented features
- Tests cover: unboxed sums with newtype, promoted tuple patterns in type families, SOURCE pragma with qualified imports, OVERLAPPABLE instances with type operators, magic hash infix operators in layout, and SCC pragmas in expressions

## Progress
New xfail oracle tests: +6