### PR TITLE
fix(parser): preserve pending pragmas across explicit-brace semicolons

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -264,7 +264,9 @@ stepOne ts
                   pendingPragmas =
                     case lexTokenOrigin tok of
                       InsertedLayout -> tokStreamPendingPragmas ts0
-                      FromSource -> []
+                      FromSource
+                        | lexTokenKind tok == TkSpecialSemicolon -> tokStreamPendingPragmas ts0
+                        | otherwise -> []
                   ts' =
                     ts0
                       { tokStreamLayoutState = laySt {layoutBuffer = rest},

--- a/components/aihc-parser/test/Test/Fixtures/oracle/pragma/InlinePragmasAfterBindingInInstance.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/pragma/InlinePragmasAfterBindingInInstance.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST pass -}
+module InlinePragmasAfterBindingInInstance where
+
+import Foreign.Storable (Storable (..))
+import Foreign.Ptr (castPtr)
+
+newtype LE16 = LE16 {fromLE16 :: Int}
+
+instance Storable LE16 where
+  { sizeOf _ = sizeOf (undefined :: Int);
+    {-# INLINE sizeOf #-};
+    alignment _ = alignment (undefined :: Int);
+    {-# INLINE alignment #-};
+  }


### PR DESCRIPTION
## Summary

- In explicit-brace `where` blocks, `INLINE` pragmas appearing *after* a binding (as generated by CPP macros like in the `btrfs` package) were silently dropped during parse → pretty-print roundtrips
- Root cause: `skipSemicolons` consumed the `;` following the pragma — a `FromSource` token — which cleared `pendingPragmas` before `instancePragmaItemParser` could find it
- Fix: treat `FromSource` `;` the same as `InsertedLayout` tokens when deciding whether to preserve `pendingPragmas` in `stepOne`

## Test plan

- [x] `cabal run exe:hackage-tester -v0 -- btrfs` now reports 100% success (was 67% with 1 roundtrip failure)
- [x] New oracle test `InlinePragmasAfterBindingInInstance.hs` covers explicit-brace INLINE-after-binding pattern
- [x] `just check` passes all 1575 tests