### PR TITLE
fix(parser): cover all class declaration items in generators

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -269,7 +269,7 @@ needsExprParens ctx expr =
     CtxTypeSigBody ->
       case expr of
         ETypeSig {} -> True
-        ENegate inner -> isOpenEnded inner
+        ENegate inner -> isGreedyExpr inner || isOpenEnded inner || endsWithTypeSig inner
         ELambdaPats {} -> True
         ELambdaCases {} -> True
         _ -> isOpenEnded expr

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -825,7 +825,7 @@ prettyClassItem item =
         ( [prettyFixityAssoc assoc]
             <> maybe [] (pure . pretty . show) prec
             <> maybe [] (pure . prettyNamespace) mNamespace
-            <> map prettyInfixOp ops
+            <> punctuate comma (map prettyInfixOp ops)
         )
     ClassItemDefault valueDecl -> prettyValueDeclSingleLine valueDecl
     ClassItemTypeFamilyDecl tf -> prettyAssocTypeFamilyDecl tf
@@ -906,7 +906,7 @@ prettyInstanceItem item =
         ( [prettyFixityAssoc assoc]
             <> maybe [] (pure . pretty . show) prec
             <> maybe [] (pure . prettyNamespace) mNamespace
-            <> map prettyInfixOp ops
+            <> punctuate comma (map prettyInfixOp ops)
         )
     InstanceItemTypeFamilyInst tfi -> prettyInstTypeFamilyInst tfi
     InstanceItemDataFamilyInst dfi -> prettyInstDataFamilyInst dfi

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -11,7 +11,9 @@ import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (ord)
+import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
 import Data.Maybe (isNothing)
+import Data.Set qualified as Set
 import Data.Text qualified as T
 import Numeric (showHex, showOct)
 import ParserValidation (formatDiff, validateParser)
@@ -113,6 +115,7 @@ buildTests = do
             testCase "generated identifiers accept MagicHash suffixes" test_generatedIdentifiersAcceptMagicHashSuffixes,
             testCase "generated constructor identifiers accept unicode uppercase and number tails" test_generatedConstructorIdentifiersAcceptUnicodeCharacters,
             testCase "data declaration result kinds parenthesize contexts" test_dataDeclResultKindContextRoundTrips,
+            testCase "promoted qualified constructors avoid char literal ambiguity" test_promotedQualifiedConstructorAvoidsCharLiteralAmbiguity,
             testCase "boxed tuple infix constructor operands stay bare" test_boxedTupleInfixConOperandStaysBare,
             testCase "unboxed tuple infix constructor operands stay bare" test_unboxedTupleInfixConOperandStaysBare,
             testCase "data CTYPE pragmas round-trip" test_dataDeclCTypePragmaRoundTrips,
@@ -149,6 +152,7 @@ buildTests = do
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
               QC.testProperty "generated class declarations can include associated data family operators" prop_generatedClassDeclsCanIncludeAssociatedDataFamilyOperators,
               QC.testProperty "generated class items include explicit associated type family syntax" prop_generatedAssociatedTypeFamiliesCanUseExplicitFamilyKeyword,
+              QC.testProperty "generated class declarations cover all class item constructors" prop_generatedClassDeclsCoverAllClassItemConstructors,
               QC.testProperty "generated modules can include empty bundled imports" prop_generatedModulesCanIncludeEmptyBundledImports,
               QC.testProperty "generated type names can appear in empty bundled import syntax" prop_generatedTypeNamesSupportEmptyBundledImports,
               QC.testProperty "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
@@ -405,6 +409,17 @@ test_dataDeclResultKindContextRoundTrips = do
       expected = stripAnnotations (addDeclParens decl)
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty (addDeclParens decl)))
   assertEqual "pretty-printed declaration" "data 𐖈 :: C => C" rendered
+  case parseDecl defaultConfig rendered of
+    ParseOk parsed -> assertEqual "round-tripped declaration" expected (stripAnnotations parsed)
+    ParseErr err -> assertFailure ("expected parse success for " <> T.unpack rendered <> "\n" <> MPE.errorBundlePretty err)
+
+test_promotedQualifiedConstructorAvoidsCharLiteralAmbiguity :: Assertion
+test_promotedQualifiedConstructorAvoidsCharLiteralAmbiguity = do
+  let promotedName = mkName (Just "A'.B") NameConId "C"
+      decl = DeclStandaloneKindSig (mkUnqualifiedName NameConSym ":+") (TCon promotedName Promoted)
+      expected = stripAnnotations (addDeclParens decl)
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty (addDeclParens decl)))
+  assertEqual "pretty-printed declaration" "type (:+) :: ' A'.B.C" rendered
   case parseDecl defaultConfig rendered of
     ParseOk parsed -> assertEqual "round-tripped declaration" expected (stripAnnotations parsed)
     ParseErr err -> assertFailure ("expected parse success for " <> T.unpack rendered <> "\n" <> MPE.errorBundlePretty err)
@@ -953,6 +968,31 @@ prop_generatedAssociatedTypeFamiliesCanUseExplicitFamilyKeyword =
             <> show (length matching)
         )
         (not (null matching))
+
+prop_generatedClassDeclsCoverAllClassItemConstructors :: Property
+prop_generatedClassDeclsCoverAllClassItemConstructors =
+  let samples = sampleGen 6000 genDeclClass
+      seen =
+        Set.fromList
+          [ showConstr (toConstr item)
+          | DeclClass ClassDecl {classDeclItems} <- samples,
+            item <- map peelClassDeclItemAnn classDeclItems
+          ]
+      expected =
+        Set.fromList
+          [ ctor
+          | ctor <- map showConstr (dataTypeConstrs (dataTypeOf (undefined :: ClassDeclItem))),
+            ctor /= "ClassItemAnn"
+          ]
+      missing = Set.toList (expected Set.\\ seen)
+   in counterexample
+        ( "expected generated class declarations to cover all class item constructors; missing "
+            <> show missing
+            <> ", sampled "
+            <> show (length samples)
+            <> " declarations"
+        )
+        (Set.null (expected Set.\\ seen))
 
 prop_generatedModulesCanIncludeEmptyBundledImports :: Property
 prop_generatedModulesCanIncludeEmptyBundledImports =

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -408,16 +408,36 @@ genClassDeclItems params =
   smallList0 $
     oneof
       [ genClassTypeSigItem,
+        genClassDefaultSigItem,
+        genClassFixityItem,
+        genClassDefaultItem,
         genClassAssociatedTypeDeclItem,
         genClassAssociatedDataDeclItem params,
-        ClassItemTypeFamilyDecl <$> genAssociatedTypeFamilyDecl,
-        ClassItemDefaultTypeInst <$> genAssociatedTypeDefaultInst
+        ClassItemDefaultTypeInst <$> genAssociatedTypeDefaultInst,
+        genClassPragmaItem,
+        genAnnotatedClassDeclItem params
       ]
 
 genClassTypeSigItem :: Gen ClassDeclItem
 genClassTypeSigItem = do
   name <- genVarUnqualifiedName
   ClassItemTypeSig [name] <$> genType
+
+genClassDefaultSigItem :: Gen ClassDeclItem
+genClassDefaultSigItem = do
+  name <- genVarUnqualifiedName
+  ClassItemDefaultSig name <$> genType
+
+genClassFixityItem :: Gen ClassDeclItem
+genClassFixityItem = do
+  assoc <- elements [Infix, InfixL, InfixR]
+  prec <- elements [Nothing, Just 0, Just 6, Just 9]
+  namespace <- elements [Nothing, Just IEEntityNamespaceType, Just IEEntityNamespaceData]
+  ops <- smallList1 genVarUnqualifiedName
+  pure (ClassItemFixity assoc namespace prec ops)
+
+genClassDefaultItem :: Gen ClassDeclItem
+genClassDefaultItem = ClassItemDefault <$> genFunctionValueDecl
 
 genClassAssociatedTypeDeclItem :: Gen ClassDeclItem
 genClassAssociatedTypeDeclItem = do
@@ -433,6 +453,25 @@ genClassAssociatedDataDeclItem :: [TyVarBinder] -> Gen ClassDeclItem
 genClassAssociatedDataDeclItem params = do
   df <- genAssociatedDataFamilyDecl params
   pure $ ClassItemDataFamilyDecl df
+
+genClassPragmaItem :: Gen ClassDeclItem
+genClassPragmaItem = do
+  kind <- elements ["INLINE", "NOINLINE", "INLINABLE"]
+  ClassItemPragma . (\pt -> Pragma {pragmaType = pt, pragmaRawText = ""}) . PragmaInline kind <$> genVarId
+
+genAnnotatedClassDeclItem :: [TyVarBinder] -> Gen ClassDeclItem
+genAnnotatedClassDeclItem params =
+  ClassItemAnn (mkAnnotation noSourceSpan)
+    <$> oneof
+      [ genClassTypeSigItem,
+        genClassDefaultSigItem,
+        genClassFixityItem,
+        genClassDefaultItem,
+        genClassAssociatedTypeDeclItem,
+        genClassAssociatedDataDeclItem params,
+        ClassItemDefaultTypeInst <$> genAssociatedTypeDefaultInst,
+        genClassPragmaItem
+      ]
 
 genAssociatedTypeFamilyDecl :: Gen TypeFamilyDecl
 genAssociatedTypeFamilyDecl = do

--- a/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ModuleRoundTrip.hs
@@ -35,7 +35,7 @@ prop_modulePrettyRoundTrip modu =
 prop_moduleValidator :: Module -> Property
 prop_moduleValidator modu =
   let source = renderStrict (layoutPretty defaultLayoutOptions (pretty modu))
-      mbErr = validateParser "<quickcheck>" GHC2024Edition [] source
+      mbErr = validateParser "<quickcheck>" GHC2024Edition moduleExtensionSettings source
    in counterexample ("Original source:\n" <> T.unpack source) $
         case mbErr of
           Nothing -> property True
@@ -45,5 +45,30 @@ prop_moduleValidator modu =
 moduleConfig :: ParserConfig
 moduleConfig =
   defaultConfig
-    { parserExtensions = effectiveExtensions GHC2024Edition [EnableExtension BlockArguments, EnableExtension Arrows, EnableExtension UnboxedTuples, EnableExtension UnboxedSums, EnableExtension TemplateHaskell, EnableExtension UnicodeSyntax, EnableExtension QuasiQuotes, EnableExtension PatternSynonyms, EnableExtension MagicHash, EnableExtension OverloadedLabels, EnableExtension MultiWayIf, EnableExtension RecursiveDo, EnableExtension TypeApplications, EnableExtension TupleSections, EnableExtension CApiFFI, EnableExtension ImplicitParams, EnableExtension ExplicitNamespaces, EnableExtension TypeAbstractions, EnableExtension RequiredTypeArguments, EnableExtension ViewPatterns, EnableExtension LambdaCase]
+    { parserExtensions = effectiveExtensions GHC2024Edition moduleExtensionSettings
     }
+
+moduleExtensionSettings :: [ExtensionSetting]
+moduleExtensionSettings =
+  [ EnableExtension BlockArguments,
+    EnableExtension Arrows,
+    EnableExtension UnboxedTuples,
+    EnableExtension UnboxedSums,
+    EnableExtension TemplateHaskell,
+    EnableExtension UnicodeSyntax,
+    EnableExtension QuasiQuotes,
+    EnableExtension PatternSynonyms,
+    EnableExtension MagicHash,
+    EnableExtension OverloadedLabels,
+    EnableExtension MultiWayIf,
+    EnableExtension RecursiveDo,
+    EnableExtension TypeApplications,
+    EnableExtension TupleSections,
+    EnableExtension CApiFFI,
+    EnableExtension ImplicitParams,
+    EnableExtension ExplicitNamespaces,
+    EnableExtension TypeAbstractions,
+    EnableExtension RequiredTypeArguments,
+    EnableExtension ViewPatterns,
+    EnableExtension LambdaCase
+  ]


### PR DESCRIPTION
## Summary
- expand `genClassDeclItems` to cover every `ClassDeclItem` form, including default signatures, fixity items, method defaults, pragmas, and annotated class items
- fix class and instance pretty-printing for multi-operator fixity declarations and tighten expression parenthesization so negated typed expressions round-trip without regressing oracle output
- add regression coverage for promoted qualified constructors that could lex as char literals, add a class-item constructor coverage property, and align module validation with the generator's extension settings

## Validation
- ran `just fmt`
- ran `just check`
- ran `coderabbit review --prompt-only` and fixed the reported `ModuleRoundTrip` extension mismatch

## Progress
- oracle summary after changes: pass=1075 xfail=0 xpass=0 fail=0 completion=100.0%