### PR TITLE
fix(pretty): handle '#'-starting VarSym in parenthesized contexts

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -747,9 +747,7 @@ prettyRecordFields fields =
     )
   where
     prettyFieldName :: UnqualifiedName -> Doc ann
-    prettyFieldName name
-      | isSymbolicUName name = parens (pretty name)
-      | otherwise = pretty name
+    prettyFieldName = prettyFunctionBinder
 
 dataConQualifierPrefix :: [TyVarBinder] -> [Type] -> [Doc ann]
 dataConQualifierPrefix forallVars constraints = forallTyVarBinderPrefix forallVars <> contextPrefix constraints
@@ -1059,9 +1057,7 @@ prettyExpr expr =
   case expr of
     EApp fn arg -> prettyExpr fn <+> prettyExpr arg
     ETypeApp fn ty -> prettyExpr fn <+> "@" <> prettyType ty
-    EVar name
-      | isSymbolicName name -> parens (pretty (renderName name))
-      | otherwise -> pretty name
+    EVar name -> prettyName name
     ETypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
     ETypeSyntax TypeSyntaxInTerm ty -> prettyType ty
     EInt _ _ repr -> pretty repr
@@ -1149,7 +1145,12 @@ prettyExpr expr =
     EGetFieldProjection fields ->
       "." <> mconcat (punctuate "." (map prettyName fields))
     ETypeSig inner ty -> prettyExpr inner <+> "::" <+> prettyType ty
-    EParen inner -> parens (prettyExpr inner)
+    EParen inner -> case inner of
+      -- ESectionR with a '#'-starting op renders as "(# ...)" which the lexer
+      -- reads as TkSpecialUnboxedLParen when UnboxedTuples/UnboxedSums is on.
+      -- A leading space produces "( # ...)" which is unambiguous.
+      ESectionR op _ | T.isPrefixOf "#" (renderName op) -> parens (" " <> prettyExpr inner)
+      _ -> parens (prettyExpr inner)
     EList values -> brackets (hsep (punctuate comma (map prettyExpr values)))
     ETuple Unboxed [] -> "(# #)"
     ETuple tupleFlavor values ->

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -83,10 +83,9 @@ symbolChars :: [Char]
 symbolChars = filter isValidSymbolChar allChars
 
 -- Symbols starting with ':' are constructors, symbols starting with '|' collide
--- with guard/alternative syntax in expression positions, and symbols ending
--- with '#' clash with overloaded labels.
+-- with guard/alternative syntax in expression positions.
 varSymStartChars :: [Char]
-varSymStartChars = filter (\c -> c /= ':' && c /= '|' && c /= '#') symbolChars
+varSymStartChars = filter (\c -> c /= ':' && c /= '|') symbolChars
 
 reservedOperators :: Set.Set Text
 reservedOperators =
@@ -254,7 +253,17 @@ isValidGeneratedVarSym op =
         && T.all isValidSymbolChar rest
         && op `Set.notMember` reservedOperators
         && not (isDashRun op)
+        && not (isOverloadedLabelPrefix op)
     Nothing -> False
+
+-- | '#' followed by an identifier-start char is an overloaded label, not a symbol.
+isOverloadedLabelPrefix :: Text -> Bool
+isOverloadedLabelPrefix op =
+  case T.uncons op of
+    Just ('#', rest) -> case T.uncons rest of
+      Just (c, _) -> isValidGeneratedIdentStartChar c || isValidConIdentStartChar c
+      Nothing -> False
+    _ -> False
 
 -------------------------------------------------------------------------------
 -- Module qualifiers


### PR DESCRIPTION
## Summary

- Enables `#`-starting operator symbols in the `genVarSym` arbitrary generator (previously excluded via `varSymStartChars`)
- Adds `isOverloadedLabelPrefix` guard to `isValidGeneratedVarSym` to reject `#` followed by an identifier-start char (which would be parsed as an overloaded label)
- Fixes three pretty-printer sites where `(#sym)` output conflicts with the lexer's `TkSpecialUnboxedLParen` token (`(#`) when UnboxedTuples/UnboxedSums is enabled:
  - **`EVar`**: delegate to `prettyName` instead of duplicating inline parens logic (already `#`-aware)
  - **Record field names** (`prettyFieldName`): delegate to `prettyFunctionBinder` instead of bare `parens (pretty name)`
  - **`EParen (ESectionR op _)`**: add a leading space when `op` starts with `#`, producing `( # ...)` instead of `(# ...)`

## Test plan

- [ ] All three failure seeds replay cleanly:
  - `(SMGen 13916308209988964807 6407662837100918567,36)` — `#`-starting field name
  - `(SMGen 16966065901365732745 2538038076162669883,32)` — `DeclSplice (EVar "#")`
  - `(SMGen 15456260616995084025 4156860675046091907,73)` — `ESectionR "#"` inside where clause
- [ ] Full property test suite passes