### PR TITLE
feat: add aihc-dev tool with extract-hi subcommand

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,5 +6,6 @@ packages:
   components/aihc-tc
   components/aihc-fc
   tooling/aihc-hackage
+  tooling/aihc-dev
 
 tests: True

--- a/tooling/aihc-dev/LICENSE
+++ b/tooling/aihc-dev/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -1,0 +1,33 @@
+cabal-version:      3.8
+name:               aihc-dev
+version:            0.1.0.0
+build-type:         Simple
+license:            MIT
+license-file:       LICENSE
+author:             David Himmelstrup
+maintainer:         lemmih@gmail.com
+category:           Development
+synopsis:           Developer tools for the aihc compiler
+
+executable aihc-dev
+  main-is:          Main.hs
+  hs-source-dirs:   exe src
+  other-modules:
+      Aihc.Dev.ExtractHi
+    , Aihc.Dev.ExtractHi.Types
+    , Aihc.Dev.ExtractHi.GhcSession
+  build-depends:
+      base >= 4.16 && < 5
+    , aeson >= 2.0 && < 2.3
+    , bytestring >= 0.10.8 && < 0.13
+    , containers >= 0.5 && < 0.8
+    , directory >= 1.2.3 && < 1.5
+    , filepath >= 1.3.0.1 && < 1.6
+    , ghc >= 9.12 && < 9.13
+    , optparse-applicative >= 0.16 && < 0.19
+    , process >= 1.6 && < 1.8
+    , text >= 1.2.3 && < 2.2
+    , yaml >= 0.11 && < 0.12
+  default-extensions: OverloadedStrings
+  ghc-options:        -Wall
+  default-language: GHC2021

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -1,0 +1,63 @@
+module Main (main) where
+
+import Aihc.Dev.ExtractHi (extractPackage)
+import Data.Aeson (encode)
+import Data.ByteString.Lazy qualified as BL
+import Data.Yaml qualified as Yaml
+import Options.Applicative
+
+main :: IO ()
+main = do
+  cmd <- execParser opts
+  runCommand cmd
+  where
+    opts =
+      info
+        (commandParser <**> helper)
+        ( fullDesc
+            <> header "aihc-dev - developer tools for the aihc compiler"
+        )
+
+-- | Top-level command type. New subcommands are added here.
+newtype Command
+  = ExtractHi ExtractHiOpts
+
+data ExtractHiOpts = ExtractHiOpts
+  { ehPackage :: String,
+    ehFormat :: OutputFormat
+  }
+
+data OutputFormat = YAML | JSON
+  deriving (Show)
+
+commandParser :: Parser Command
+commandParser =
+  subparser
+    ( command
+        "extract-hi"
+        ( info
+            (ExtractHi <$> extractHiParser <**> helper)
+            (progDesc "Extract scoping and typing information from .hi interface files")
+        )
+    )
+
+extractHiParser :: Parser ExtractHiOpts
+extractHiParser =
+  ExtractHiOpts
+    <$> strArgument
+      ( metavar "PACKAGE"
+          <> help "Package name to extract (e.g. 'base', 'containers')"
+      )
+    <*> flag
+      YAML
+      JSON
+      ( long "json"
+          <> help "Output JSON instead of YAML"
+      )
+
+runCommand :: Command -> IO ()
+runCommand (ExtractHi opts) = do
+  pkg <- extractPackage (ehPackage opts)
+  case ehFormat opts of
+    YAML -> BL.putStr (BL.fromStrict (Yaml.encode pkg))
+    JSON -> BL.putStr (encode pkg)

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
@@ -1,0 +1,438 @@
+-- | Extract scoping and typing information from GHC .hi interface files.
+--
+-- Given a package name, this module locates the package via @ghc-pkg@,
+-- reads every exposed module's .hi file using the GHC API, and produces
+-- a structured 'PackageInterface' suitable for YAML serialization.
+--
+-- Handles re-export facades (e.g. @base@ re-exporting from @ghc-internal@)
+-- by following exported names to their defining modules.
+module Aihc.Dev.ExtractHi
+  ( extractPackage,
+  )
+where
+
+import Aihc.Dev.ExtractHi.GhcSession (withReadIface)
+import Aihc.Dev.ExtractHi.Types
+import Control.Exception (IOException, catch)
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC (Ghc)
+import GHC.Iface.Syntax
+  ( IfaceClassBody (..),
+    IfaceClassOp (..),
+    IfaceConDecl (..),
+    IfaceConDecls (..),
+    IfaceDecl (..),
+  )
+import GHC.Iface.Type (IfaceTyConBinder, IfaceType, ShowForAllFlag (..), pprIfaceSigmaType, pprIfaceType)
+import GHC.Types.Avail (AvailInfo (..))
+import GHC.Types.Name (Name, getOccString, nameModule_maybe)
+import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Unit.Module (moduleNameString)
+import GHC.Unit.Module.ModIface (ModIface, mi_decls, mi_exports, mi_fixities)
+import GHC.Unit.Types (moduleName, moduleUnit, unitString)
+import GHC.Utils.Outputable (showSDocUnsafe)
+import Language.Haskell.Syntax.Basic qualified as GHC
+import System.Directory (doesFileExist)
+import System.FilePath ((<.>), (</>))
+import System.Process (readProcess)
+
+-- | Cached module data: declarations and fixities from a single .hi file.
+data CachedModule = CachedModule
+  { cmDecls :: Map String IfaceDecl,
+    cmFixities :: Map String GHC.Fixity
+  }
+
+-- | Extract the full interface for a locally installed package.
+extractPackage :: String -> IO PackageInterface
+extractPackage pkgName = do
+  (pkgId, importDir, exposedMods) <- queryPackage pkgName
+  withReadIface $ \readIface -> do
+    cacheRef <- liftIO $ newIORef (Map.empty :: Map (String, String) CachedModule)
+    modules <- mapM (extractSingleModule readIface cacheRef importDir) exposedMods
+    pure
+      PackageInterface
+        { piPackage = T.pack pkgId,
+          piModules = modules
+        }
+
+-- | Load a remote module's data into the cache, returning the cached data.
+loadModule ::
+  (FilePath -> IO ModIface) ->
+  IORef (Map (String, String) CachedModule) ->
+  String ->
+  String ->
+  IO CachedModule
+loadModule readIface cacheRef unit modName = do
+  cache <- readIORef cacheRef
+  let key = (unit, modName)
+  case Map.lookup key cache of
+    Just cm -> pure cm
+    Nothing -> do
+      mImportDir <- queryImportDir unit
+      cm <- case mImportDir of
+        Nothing -> pure emptyCachedModule
+        Just importDir -> do
+          let hiPath = importDir </> map dotToSlash modName <.> "hi"
+          exists <- doesFileExist hiPath
+          if exists
+            then do
+              iface <- readIface hiPath
+              let ds = map snd (mi_decls iface)
+                  decls = Map.fromList [(getOccString (ifName d), d) | d <- ds]
+                  fixs = Map.fromList [(occNameString occ, f) | (occ, f) <- mi_fixities iface]
+              pure CachedModule {cmDecls = decls, cmFixities = fixs}
+            else pure emptyCachedModule
+      modifyIORef' cacheRef (Map.insert key cm)
+      pure cm
+
+emptyCachedModule :: CachedModule
+emptyCachedModule = CachedModule Map.empty Map.empty
+
+-- | Look up a declaration by following a Name to its defining module.
+lookupDecl ::
+  (FilePath -> IO ModIface) ->
+  IORef (Map (String, String) CachedModule) ->
+  Name ->
+  IO (Maybe IfaceDecl)
+lookupDecl readIface cacheRef name = case nameModule_maybe name of
+  Nothing -> pure Nothing
+  Just m -> do
+    let unit = unitString (moduleUnit m)
+        modName = moduleNameString (moduleName m)
+    cm <- loadModule readIface cacheRef unit modName
+    pure (Map.lookup (getOccString name) (cmDecls cm))
+
+-- | Look up a fixity by following a Name to its defining module.
+lookupFixity ::
+  (FilePath -> IO ModIface) ->
+  IORef (Map (String, String) CachedModule) ->
+  Name ->
+  IO (Maybe GHC.Fixity)
+lookupFixity readIface cacheRef name = case nameModule_maybe name of
+  Nothing -> pure Nothing
+  Just m -> do
+    let unit = unitString (moduleUnit m)
+        modName = moduleNameString (moduleName m)
+    cm <- loadModule readIface cacheRef unit modName
+    pure (Map.lookup (getOccString name) (cmFixities cm))
+
+-- | Extract interface information from a single module.
+extractSingleModule ::
+  (FilePath -> IO ModIface) ->
+  IORef (Map (String, String) CachedModule) ->
+  FilePath ->
+  String ->
+  Ghc ModuleInterface
+extractSingleModule readIface cacheRef importDir modName = do
+  let hiPath = importDir </> map dotToSlash modName <.> "hi"
+  exists <- liftIO $ doesFileExist hiPath
+  if exists
+    then do
+      iface <- liftIO $ readIface hiPath
+      liftIO $ ifaceToModule readIface cacheRef modName iface
+    else pure emptyModule
+  where
+    emptyModule =
+      ModuleInterface
+        { miModule = T.pack modName,
+          miTypes = [],
+          miValues = [],
+          miClasses = [],
+          miFixities = []
+        }
+
+-- | Convert a 'ModIface' to our output representation.
+ifaceToModule ::
+  (FilePath -> IO ModIface) ->
+  IORef (Map (String, String) CachedModule) ->
+  String ->
+  ModIface ->
+  IO ModuleInterface
+ifaceToModule readIface cacheRef modName iface = do
+  let exports = mi_exports iface
+      localFixities = mi_fixities iface
+      localDecls = map snd (mi_decls iface)
+      localDeclMap = Map.fromList [(getOccString (ifName d), d) | d <- localDecls]
+      localFixMap = Map.fromList [(occNameString occ, f) | (occ, f) <- localFixities]
+
+  -- Classify exports
+  (types, values, classes) <- classifyExports exports localDeclMap (lookupDecl readIface cacheRef)
+
+  -- Collect fixities: local ones first, then look up re-exported names
+  let allExportedNames = concatMap availNames exports
+  remoteFixities <- collectFixities readIface cacheRef localFixMap allExportedNames
+
+  pure
+    ModuleInterface
+      { miModule = T.pack modName,
+        miTypes = types,
+        miValues = values,
+        miClasses = classes,
+        miFixities = remoteFixities
+      }
+
+-- | Get all names from an AvailInfo.
+availNames :: AvailInfo -> [Name]
+availNames (Avail n) = [n]
+availNames (AvailTC _ subs) = subs
+
+-- | Collect fixities for all exported names.
+--
+-- First checks local fixities, then follows re-exports to defining modules.
+-- Only includes names that actually have a non-default fixity.
+collectFixities ::
+  (FilePath -> IO ModIface) ->
+  IORef (Map (String, String) CachedModule) ->
+  Map String GHC.Fixity ->
+  [Name] ->
+  IO [FixityInfo]
+collectFixities readIface cacheRef localFixMap names = do
+  results <- mapM lookupOne names
+  pure (concat results)
+  where
+    lookupOne name = do
+      let occStr = getOccString name
+      case Map.lookup occStr localFixMap of
+        Just fix -> pure [toFixityInfo occStr fix]
+        Nothing -> do
+          mFix <- lookupFixity readIface cacheRef name
+          case mFix of
+            Just fix -> pure [toFixityInfo occStr fix]
+            Nothing -> pure []
+
+    toFixityInfo nameStr (GHC.Fixity prec dir) =
+      FixityInfo
+        { fiName = T.pack nameStr,
+          fiDirection = convertDir dir,
+          fiPrecedence = prec
+        }
+
+    convertDir GHC.InfixL = InfixL
+    convertDir GHC.InfixR = InfixR
+    convertDir GHC.InfixN = InfixN
+
+-- | Classify exports into types, values, and classes.
+classifyExports ::
+  [AvailInfo] ->
+  Map String IfaceDecl ->
+  (Name -> IO (Maybe IfaceDecl)) ->
+  IO ([ExportedType], [ExportedValue], [ExportedClass])
+classifyExports avails localDeclMap cachedLookup = do
+  results <- mapM (classifySingle localDeclMap cachedLookup) avails
+  let (ts, vs, cs) = foldr merge ([], [], []) results
+  pure (ts, vs, cs)
+  where
+    merge (t, v, c) (ts, vs, cs) = (t ++ ts, v ++ vs, c ++ cs)
+
+-- | Classify a single AvailInfo.
+classifySingle ::
+  Map String IfaceDecl ->
+  (Name -> IO (Maybe IfaceDecl)) ->
+  AvailInfo ->
+  IO ([ExportedType], [ExportedValue], [ExportedClass])
+classifySingle localDeclMap cachedLookup avail = case avail of
+  Avail name -> do
+    let nameStr = getOccString name
+    mDecl <- resolveDecl localDeclMap cachedLookup nameStr name
+    case mDecl of
+      Just decl -> pure ([], [extractValue decl], [])
+      Nothing ->
+        pure
+          ( [],
+            [ ExportedValue
+                { evName = T.pack nameStr,
+                  evType = "<unresolved>"
+                }
+            ],
+            []
+          )
+  AvailTC name subs -> do
+    let nameStr = getOccString name
+        subNames = map getOccString subs
+    mDecl <- resolveDecl localDeclMap cachedLookup nameStr name
+    case mDecl of
+      Just decl@IfaceClass {} ->
+        pure ([], [], [extractClass decl subNames])
+      Just decl@IfaceData {} ->
+        pure ([extractDataType decl subNames], [], [])
+      Just decl@IfaceSynonym {} ->
+        pure ([extractSynonym decl], [], [])
+      Just decl@IfaceFamily {} ->
+        pure ([extractFamily decl], [], [])
+      _ ->
+        pure
+          ( [ ExportedType
+                { etName = T.pack nameStr,
+                  etKind = "<unresolved>",
+                  etConstructors = map T.pack (filter (/= nameStr) subNames)
+                }
+            ],
+            [],
+            []
+          )
+
+-- | Resolve a declaration: check local first, then follow re-exports.
+resolveDecl ::
+  Map String IfaceDecl ->
+  (Name -> IO (Maybe IfaceDecl)) ->
+  String ->
+  Name ->
+  IO (Maybe IfaceDecl)
+resolveDecl localDeclMap cachedLookup nameStr name =
+  case Map.lookup nameStr localDeclMap of
+    Just decl -> pure (Just decl)
+    Nothing -> cachedLookup name
+
+-- | Extract value/function information from an IfaceId declaration.
+extractValue :: IfaceDecl -> ExportedValue
+extractValue decl = case decl of
+  IfaceId {ifName, ifType} ->
+    ExportedValue
+      { evName = T.pack (getOccString ifName),
+        evType = renderType ifType
+      }
+  other ->
+    ExportedValue
+      { evName = T.pack (getOccString (ifName other)),
+        evType = "<unexpected-decl-kind>"
+      }
+
+-- | Extract data type information.
+extractDataType :: IfaceDecl -> [String] -> ExportedType
+extractDataType decl subNames = case decl of
+  IfaceData {ifName, ifBinders, ifResKind, ifCons} ->
+    let parentName = getOccString ifName
+        ctors = case ifCons of
+          IfAbstractTyCon -> []
+          IfDataTyCon _ cs -> map (T.pack . getOccString . ifConName) cs
+          IfNewTyCon c -> [T.pack (getOccString (ifConName c))]
+        ctorStrings = map T.unpack ctors
+        extraSubs =
+          [ T.pack s
+          | s <- subNames,
+            s /= parentName,
+            s `notElem` ctorStrings
+          ]
+     in ExportedType
+          { etName = T.pack parentName,
+            etKind = renderKind ifBinders ifResKind,
+            etConstructors = ctors ++ extraSubs
+          }
+  other ->
+    ExportedType
+      { etName = T.pack (getOccString (ifName other)),
+        etKind = "<unexpected>",
+        etConstructors = []
+      }
+
+-- | Extract type synonym information.
+extractSynonym :: IfaceDecl -> ExportedType
+extractSynonym decl = case decl of
+  IfaceSynonym {ifName, ifBinders, ifResKind} ->
+    ExportedType
+      { etName = T.pack (getOccString ifName),
+        etKind = renderKind ifBinders ifResKind,
+        etConstructors = []
+      }
+  other ->
+    ExportedType
+      { etName = T.pack (getOccString (ifName other)),
+        etKind = "<unexpected>",
+        etConstructors = []
+      }
+
+-- | Extract type family information.
+extractFamily :: IfaceDecl -> ExportedType
+extractFamily decl = case decl of
+  IfaceFamily {ifName, ifBinders, ifResKind} ->
+    ExportedType
+      { etName = T.pack (getOccString ifName),
+        etKind = renderKind ifBinders ifResKind,
+        etConstructors = []
+      }
+  other ->
+    ExportedType
+      { etName = T.pack (getOccString (ifName other)),
+        etKind = "<unexpected>",
+        etConstructors = []
+      }
+
+-- | Extract class information.
+extractClass :: IfaceDecl -> [String] -> ExportedClass
+extractClass decl _subNames = case decl of
+  IfaceClass {ifName, ifBody} ->
+    let methods = case ifBody of
+          IfAbstractClass -> []
+          IfConcreteClass {ifSigs} ->
+            [extractClassOp op | op <- ifSigs]
+     in ExportedClass
+          { ecName = T.pack (getOccString ifName),
+            ecMethods = methods
+          }
+  other ->
+    ExportedClass
+      { ecName = T.pack (getOccString (ifName other)),
+        ecMethods = []
+      }
+
+-- | Extract a class method from its IfaceClassOp.
+extractClassOp :: IfaceClassOp -> ClassMethod
+extractClassOp (IfaceClassOp name ty _defMeth) =
+  ClassMethod
+    { cmName = T.pack (getOccString name),
+      cmType = renderType ty
+    }
+
+-- | Render an IfaceType to a human-readable string.
+renderType :: IfaceType -> Text
+renderType ty = T.pack (showSDocUnsafe (pprIfaceSigmaType ShowForAllWhen ty))
+
+-- | Render a kind from binders and result kind.
+renderKind :: [IfaceTyConBinder] -> IfaceType -> Text
+renderKind _binders resKind =
+  T.pack (showSDocUnsafe (pprIfaceType resKind))
+
+-- | Query @ghc-pkg@ for package information.
+--
+-- Returns (package-id, import-dir, [exposed-module-names]).
+queryPackage :: String -> IO (String, FilePath, [String])
+queryPackage pkgName = do
+  pkgId <- trim <$> readProcess "ghc-pkg" ["field", pkgName, "id", "--simple-output"] ""
+  importDir <- trim <$> readProcess "ghc-pkg" ["field", pkgName, "import-dirs", "--simple-output"] ""
+  exposedModsRaw <- readProcess "ghc-pkg" ["field", pkgName, "exposed-modules", "--simple-output"] ""
+  let exposedMods = map stripComma (words exposedModsRaw)
+  pure (pkgId, importDir, exposedMods)
+
+-- | Query @ghc-pkg@ for a package's import directory by unit id.
+queryImportDir :: String -> IO (Maybe FilePath)
+queryImportDir unitId = do
+  result <- tryReadProcess "ghc-pkg" ["field", unitId, "import-dirs", "--simple-output"]
+  case result of
+    Just dir -> pure (Just (trim dir))
+    Nothing -> pure Nothing
+
+-- | Try to run a process, returning Nothing on failure.
+tryReadProcess :: FilePath -> [String] -> IO (Maybe String)
+tryReadProcess prog args =
+  (Just <$> readProcess prog args "")
+    `catch` (\(_ :: IOException) -> pure Nothing)
+
+-- | Strip trailing commas from ghc-pkg output tokens.
+stripComma :: String -> String
+stripComma s = case reverse s of
+  ',' : rest -> reverse rest
+  _ -> s
+
+trim :: String -> String
+trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+  where
+    isSpace c = c == ' ' || c == '\n' || c == '\r' || c == '\t'
+
+dotToSlash :: Char -> Char
+dotToSlash '.' = '/'
+dotToSlash c = c

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/GhcSession.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/GhcSession.hs
@@ -1,0 +1,52 @@
+-- | GHC session initialization for reading .hi interface files.
+--
+-- Provides a minimal GHC session sufficient to deserialize .hi files
+-- using 'GHC.Iface.Binary.readBinIface'. This avoids the overhead of
+-- a full GHC compilation session while still providing the 'NameCache'
+-- and 'Profile' required for deserialization.
+module Aihc.Dev.ExtractHi.GhcSession
+  ( withReadIface,
+  )
+where
+
+import GHC (Ghc, getSession, runGhc, setSessionDynFlags)
+import GHC.Driver.Env.Types (HscEnv (..))
+import GHC.Driver.Monad (getSessionDynFlags)
+import GHC.Driver.Session (DynFlags (..))
+import GHC.Iface.Binary (CheckHiWay (..), TraceBinIFace (..), readBinIface)
+import GHC.Platform.Profile (Profile (..))
+import GHC.Platform.Ways qualified as Ways
+import GHC.Unit.Module.ModIface (ModIface)
+import System.Process (readProcess)
+
+-- | Run an action with a function that reads .hi files.
+--
+-- Initializes a GHC session to obtain the 'NameCache' and host 'Profile',
+-- then provides a reader function to the callback. The reader can be called
+-- repeatedly to deserialize multiple .hi files within the same session.
+withReadIface :: (ReadIface -> Ghc a) -> IO a
+withReadIface action = do
+  libDir <- getGhcLibDir
+  runGhc (Just libDir) $ do
+    dflags <- getSessionDynFlags
+    _ <- setSessionDynFlags dflags
+    env <- getSession
+    let profile =
+          Profile
+            { profilePlatform = targetPlatform (hsc_dflags env),
+              profileWays = Ways.hostFullWays
+            }
+        nc = hsc_NC env
+        reader = readBinIface profile nc IgnoreHiWay QuietBinIFace
+    action reader
+
+-- | A function that reads a .hi file into a 'ModIface'.
+type ReadIface = FilePath -> IO ModIface
+
+-- | Discover the GHC library directory by calling @ghc --print-libdir@.
+getGhcLibDir :: IO FilePath
+getGhcLibDir = do
+  raw <- readProcess "ghc" ["--print-libdir"] ""
+  pure (trimTrailingNewline raw)
+  where
+    trimTrailingNewline = reverse . dropWhile (== '\n') . reverse

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Types.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Types.hs
@@ -1,0 +1,132 @@
+-- | Data types representing extracted interface information, serializable to YAML.
+module Aihc.Dev.ExtractHi.Types
+  ( PackageInterface (..),
+    ModuleInterface (..),
+    ExportedType (..),
+    ExportedValue (..),
+    ExportedClass (..),
+    ClassMethod (..),
+    FixityInfo (..),
+    FixityDirection (..),
+  )
+where
+
+import Data.Aeson (ToJSON (..), Value (..), object, (.=))
+import Data.Text (Text)
+
+-- | Complete interface for a package: all exposed modules.
+data PackageInterface = PackageInterface
+  { piPackage :: Text,
+    piModules :: [ModuleInterface]
+  }
+  deriving (Show)
+
+instance ToJSON PackageInterface where
+  toJSON pi' =
+    object
+      [ "package" .= piPackage pi',
+        "modules" .= piModules pi'
+      ]
+
+-- | Interface for a single module.
+data ModuleInterface = ModuleInterface
+  { miModule :: Text,
+    miTypes :: [ExportedType],
+    miValues :: [ExportedValue],
+    miClasses :: [ExportedClass],
+    miFixities :: [FixityInfo]
+  }
+  deriving (Show)
+
+instance ToJSON ModuleInterface where
+  toJSON mi =
+    object
+      [ "module" .= miModule mi,
+        "types" .= miTypes mi,
+        "values" .= miValues mi,
+        "classes" .= miClasses mi,
+        "fixities" .= miFixities mi
+      ]
+
+-- | An exported type or data declaration.
+data ExportedType = ExportedType
+  { etName :: Text,
+    etKind :: Text,
+    etConstructors :: [Text]
+  }
+  deriving (Show)
+
+instance ToJSON ExportedType where
+  toJSON et =
+    object
+      [ "name" .= etName et,
+        "kind" .= etKind et,
+        "constructors" .= etConstructors et
+      ]
+
+-- | An exported value (function or variable).
+data ExportedValue = ExportedValue
+  { evName :: Text,
+    evType :: Text
+  }
+  deriving (Show)
+
+instance ToJSON ExportedValue where
+  toJSON ev =
+    object
+      [ "name" .= evName ev,
+        "type" .= evType ev
+      ]
+
+-- | An exported type class.
+data ExportedClass = ExportedClass
+  { ecName :: Text,
+    ecMethods :: [ClassMethod]
+  }
+  deriving (Show)
+
+instance ToJSON ExportedClass where
+  toJSON ec =
+    object
+      [ "name" .= ecName ec,
+        "methods" .= ecMethods ec
+      ]
+
+-- | A method within a type class.
+data ClassMethod = ClassMethod
+  { cmName :: Text,
+    cmType :: Text
+  }
+  deriving (Show)
+
+instance ToJSON ClassMethod where
+  toJSON cm =
+    object
+      [ "name" .= cmName cm,
+        "type" .= cmType cm
+      ]
+
+-- | Fixity declaration for an operator.
+data FixityInfo = FixityInfo
+  { fiName :: Text,
+    fiDirection :: FixityDirection,
+    fiPrecedence :: Int
+  }
+  deriving (Show)
+
+instance ToJSON FixityInfo where
+  toJSON fi =
+    object
+      [ "name" .= fiName fi,
+        "direction" .= fiDirection fi,
+        "precedence" .= fiPrecedence fi
+      ]
+
+-- | Direction of a fixity declaration.
+data FixityDirection = InfixL | InfixR | InfixN
+  deriving (Show)
+
+instance ToJSON FixityDirection where
+  toJSON InfixL = String "infixl"
+  toJSON InfixR = String "infixr"
+  toJSON InfixN = String "infix"


### PR DESCRIPTION
## Summary

- Adds `tooling/aihc-dev`, a developer tooling package with a subcommand architecture designed for future expansion.
- Implements `extract-hi` subcommand that extracts scoping and typing information from GHC's `.hi` interface files for locally installed packages.
- Uses the GHC API (`readBinIface`) to deserialize `.hi` files, producing structured YAML/JSON output.

## What it extracts

For each exposed module in a package:
- **Types** — name, kind, constructors
- **Values** — name, type signature (human-readable, via `pprIfaceSigmaType`)
- **Classes** — name, method signatures
- **Fixities** — name, direction (infixl/infixr/infix), precedence

## Re-export handling

Handles facade packages (e.g. `base` re-exporting from `ghc-internal`) by following exported names to their defining modules via `nameModule_maybe`, caching loaded `.hi` files for efficiency.

## Usage

```
aihc-dev extract-hi base          # YAML output
aihc-dev extract-hi base --json   # JSON output
```

## Design

- Subcommand-based CLI (optparse-applicative) — easy to add new commands later.
- GHC API approach chosen over `--show-iface` text parsing (structured, typed access) or GHCi `:browse` (too slow, incomplete).
- Not added to the Nix check pipeline since it depends on the `ghc` library package (only needed as a dev tool, not CI-critical).