### PR TITLE
fix(parser): parenthesize negated section operands

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -302,6 +302,9 @@ addSectionLhsParens expr =
         (addExprParensIn CtxInfixLhs lhs)
         op
         (addSectionInfixRhsParens rhs)
+    ENegate inner
+      | isGreedyExpr inner || isOpenEnded inner ->
+          wrapExpr True (addExprParens expr)
     _ -> addExprParensPrec 1 expr
   where
     addSectionInfixRhsParens rhs =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -129,6 +129,7 @@ buildTests = do
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
+            testCase "pretty-prints negated open-ended expressions inside left sections" test_prettyNegatedOpenEndedSectionLhs,
             testCase "pretty-prints negated open-ended type signature bodies" test_prettyNegatedOpenEndedTypeSigBody,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -749,6 +750,26 @@ test_prettyInfixRhsOpenEndedInsideSection = do
           )
           op
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+  case parseExpr config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
+
+test_prettyNegatedOpenEndedSectionLhs :: Assertion
+test_prettyNegatedOpenEndedSectionLhs = do
+  let config = defaultConfig {parserExtensions = [BlockArguments]}
+      op = qualifyName Nothing (mkUnqualifiedName NameVarId "a")
+      expr =
+        ESectionL
+          ( ENegate
+              ( EApp
+                  (EString "" "\"\"")
+                  (EIf (EChar 'N' "'N'") (ETuple Boxed []) (ETuple Boxed []))
+              )
+          )
+          op
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty (addExprParens expr)))
   case parseExpr config rendered of
     ParseOk reparsed ->
       assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)


### PR DESCRIPTION
## Summary
- Parenthesize negated left-section operands when their inner expression is greedy/open-ended, preventing BlockArguments forms from absorbing the section operator.
- Add a regression test for a negated function application with an `if` argument inside a left section.

## Progress counts
- Unchanged; this is a parser pretty-printing bug fix and does not update generated README progress tables.

## Verification
- `cabal test -v0 aihc-parser:spec --test-options="--pattern negated --hide-successes"`
- `just replay "(SMGen 10593124702832386191 5719428628938908275,96)"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)