### PR TITLE
fix(parser): parse infix function head operands correctly

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -12,7 +12,7 @@ where
 import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (equationRhsParser, exprParser)
 import Aihc.Parser.Internal.Import (warningPragmaParser)
-import Aihc.Parser.Internal.Pattern (appPatternParser, patternParser, simplePatternParser)
+import Aihc.Parser.Internal.Pattern (appPatternParser, asOrAppPatternParser, patternParser, simplePatternParser)
 import Aihc.Parser.Internal.Type (arrowKindParser, forallTelescopeParser, typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind, pattern TkVarFamily, pattern TkVarRole)
 import Aihc.Parser.Syntax
@@ -80,7 +80,11 @@ ordinaryDeclParser = do
         TkSpecialComma -> MP.try typeSigOrPatternTypeSigDeclParser <|> valueDecl
         TkReservedEquals -> valueDecl
         _ -> nonBareVarPatternBindDeclParser <|> valueDecl
-    _ -> MP.try typeSigOrPatternTypeSigDeclParser <|> patternBindDeclParser <|> valueDecl
+    _ ->
+      MP.try typeSigOrPatternTypeSigDeclParser
+        <|> MP.try valueDeclParser
+        <|> patternBindDeclParser
+        <|> (if exprFallback then exprDeclParser else MP.empty)
 
 -- | Like 'patternBindDeclParser' but rejects bare variable patterns.
 -- When the leading token is a variable identifier, a bare @x = 5@ must be
@@ -780,7 +784,7 @@ fixityItemParser ann ctor = withSpanAnn ann $ do
 
 valueItemParser :: (SourceSpan -> a -> a) -> (ValueDecl -> a) -> TokParser a
 valueItemParser ann ctor = withSpanAnn ann $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  (headForm, name, pats) <- functionHeadParserWith asOrAppPatternParser simplePatternParser
   ctor . functionBindValue headForm name pats <$> equationRhsParser
 
 foreignDeclParser :: TokParser Decl
@@ -1522,7 +1526,7 @@ patternBindDeclParser = MP.try $ withSpanAnn (DeclAnn . mkAnnotation) $ do
 
 valueDeclParser :: TokParser Decl
 valueDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  (headForm, name, pats) <- functionHeadParserWith asOrAppPatternParser simplePatternParser
   functionBindDecl headForm name pats <$> equationRhsParser
 
 -- ---------------------------------------------------------------------------

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -9,6 +9,7 @@ module Aihc.Parser.Internal.Expr
     -- Re-exports from Pattern
     simplePatternParser,
     appPatternParser,
+    asOrAppPatternParser,
     patternParser,
     -- Re-exports from Type
     typeParser,
@@ -31,7 +32,7 @@ import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
 import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser, typeSigDeclParser)
-import Aihc.Parser.Internal.Pattern (appPatternParser, patternParser, patternParserWithTypeSigParser, simplePatternParser)
+import Aihc.Parser.Internal.Pattern (appPatternParser, asOrAppPatternParser, patternParser, patternParserWithTypeSigParser, simplePatternParser)
 import Aihc.Parser.Internal.Type (typeAppParser, typeAtomParser, typeHeadInfixParser, typeInfixOperatorParser, typeInfixParser, typeParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
 import Aihc.Parser.Syntax
@@ -1160,7 +1161,7 @@ localTypeSigDeclsParser = do
 
 localFunctionDeclParser :: TokParser Decl
 localFunctionDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
+  (headForm, name, pats) <- functionHeadParserWith asOrAppPatternParser simplePatternParser
   functionBindDecl headForm name pats <$> equationRhsParser
 
 localPatternDeclParser :: TokParser Decl

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -5,6 +5,7 @@ module Aihc.Parser.Internal.Pattern
     patternParserWithTypeSigParser,
     simplePatternParser,
     appPatternParser,
+    asOrAppPatternParser,
     literalParser,
   )
 where

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1364,6 +1364,7 @@ addInfixFunctionHeadPatternAtomParens pat =
     PAnn ann sub -> PAnn ann (addInfixFunctionHeadPatternAtomParens sub)
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSig {} -> wrapPat True (addPatternParens pat)
+    PInfix {} -> wrapPat True (addPatternParens pat)
     _ -> addPatternParens pat
 
 -- | Add parens for the inner pattern of @, !, ~.

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1150,6 +1150,10 @@ prettyExpr expr =
       -- reads as TkSpecialUnboxedLParen when UnboxedTuples/UnboxedSums is on.
       -- A leading space produces "( # ...)" which is unambiguous.
       ESectionR op _ | T.isPrefixOf "#" (renderName op) -> parens (" " <> prettyExpr inner)
+      -- ESectionL with a '#'-ending op renders as "(x #)" which the lexer
+      -- reads as TkSpecialUnboxedRParen when UnboxedTuples/UnboxedSums is on.
+      -- A trailing space produces "(x # )" which is unambiguous.
+      ESectionL _ op | T.isSuffixOf "#" (renderName op) -> parens (prettyExpr inner <> " ")
       _ -> parens (prettyExpr inner)
     EList values -> brackets (hsep (punctuate comma (map prettyExpr values)))
     ETuple Unboxed [] -> "(# #)"


### PR DESCRIPTION
## What changed

- Parse infix function-head operands with the non-infix pattern level so declarations such as `(# #) × $splice = ...` are not consumed as one pattern before the function operator is recognized.
- Prefer value/function declarations before true pattern bindings for ambiguous non-identifier declaration starts, while preserving Template Haskell expression-splice fallback.
- Parenthesize nested infix patterns when they appear as operands in infix function heads.
- Print left sections whose operator ends in `#` with a disambiguating trailing space so `#)` is not lexed as an unboxed tuple/sum close token.

## Root cause

The declaration parser used the full pattern parser for infix function-head operands. That parser can consume an infix pattern, so the left operand could greedily absorb the intended function operator and right operand. The replay also exposed a pretty-printer ambiguity for `(x #)`, which collides with the unboxed close token when unboxed tuples or sums are enabled.

## Progress counts

- Parser property replay: 1 failing seed fixed.
- README progress counts: not updated, per repository workflow.

## Validation

- `just replay "(SMGen 10025426425224508413 16895402701791805917,97)"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
