### PR TITLE
feat(resolve): replace boot shims with pre-generated interfaces from GHC .hi files

### DIFF
--- a/components/aihc-resolve/aihc-resolve.cabal
+++ b/components/aihc-resolve/aihc-resolve.cabal
@@ -68,11 +68,14 @@ executable resolve-stackage-progress
   hs-source-dirs:
       app/resolve-stackage-progress
   main-is:          Main.hs
+  other-modules:
+      BootInterface
   build-depends:
       base >=4.16 && <5
     , aihc-resolve
     , aihc-parser
     , aihc-hackage
+    , aeson
     , text
     , containers
     , bytestring
@@ -82,6 +85,7 @@ executable resolve-stackage-progress
     , Cabal-syntax >= 3.14 && < 3.17
     , deepseq
     , aihc-cpp
+    , process
   ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language: GHC2021
 

--- a/components/aihc-resolve/app/resolve-stackage-progress/BootInterface.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/BootInterface.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Loading pre-generated boot package interfaces from JSON files.
+--
+-- Boot packages (ghc-prim, ghc-internal, ghc-bignum, base) use GHC-internal
+-- syntax that aihc-parser cannot handle. Instead of parsing them, we load
+-- pre-extracted interface files produced by @aihc-dev extract-resolve-iface@.
+--
+-- The JSON schema for a boot interface file is:
+--
+-- @
+-- { "package": "base-4.21.0.0"
+-- , "modules":
+--     [ { "module": "Data.List"
+--       , "terms": ["map", "filter", "foldl", ...]
+--       , "types": ["NonEmpty"]
+--       , "constructors": {"Maybe": ["Just", "Nothing"], ...}
+--       , "methods": {"Functor": ["fmap", "<$"], ...}
+--       }
+--     ]
+-- }
+-- @
+--
+-- Terms, types, constructors, and methods are all that the resolver needs:
+-- which names exist in which namespace for each module.
+module BootInterface
+  ( loadBootInterfaces,
+    bootPackageNames,
+  )
+where
+
+import Aihc.Parser.Syntax (NameType (..), mkQualifiedName, mkUnqualifiedName)
+import Aihc.Resolve (ModuleExports, ResolvedName (..), Scope (..))
+import Control.Exception (IOException, try)
+import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
+import Data.Aeson qualified as Aeson
+import Data.Char (isAlphaNum, isSpace, isUpper)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.IO (hPutStrLn, stderr)
+import System.Process (readProcess)
+
+-- | The set of packages that require pre-generated interfaces.
+-- These use GHC-internal syntax that cannot be parsed by aihc-parser.
+bootPackageNames :: Set Text
+bootPackageNames = Set.fromList ["ghc-prim", "ghc-internal", "ghc-bignum", "base"]
+
+-- | Load pre-generated boot interfaces, generating them on demand if not cached.
+--
+-- Returns a map from package name to its ModuleExports.
+-- Missing or broken interfaces are logged to stderr and treated as empty.
+loadBootInterfaces :: IO (Map Text ModuleExports)
+loadBootInterfaces = do
+  cacheDir <- getBootCacheDir
+  createDirectoryIfMissing True cacheDir
+  ghcVersion <- trim <$> readProcess "ghc" ["--numeric-version"] ""
+  let versionedDir = cacheDir </> ghcVersion
+  createDirectoryIfMissing True versionedDir
+  results <- mapM (loadOneBootPackage versionedDir) (Set.toList bootPackageNames)
+  pure (Map.fromList [(name, iface) | (name, Just iface) <- results])
+
+-- | Get the cache directory for boot interfaces.
+getBootCacheDir :: IO FilePath
+getBootCacheDir = do
+  mXdg <- lookupEnv "XDG_CACHE_HOME"
+  case mXdg of
+    Just dir -> pure (dir </> "aihc-resolve" </> "boot-interfaces")
+    Nothing -> do
+      home <- lookupEnv "HOME"
+      case home of
+        Just h -> pure (h </> ".cache" </> "aihc-resolve" </> "boot-interfaces")
+        Nothing -> pure (".cache" </> "aihc-resolve" </> "boot-interfaces")
+
+-- | Load a single boot package's interface, generating if needed.
+loadOneBootPackage :: FilePath -> Text -> IO (Text, Maybe ModuleExports)
+loadOneBootPackage cacheDir pkgName = do
+  let path = cacheDir </> T.unpack pkgName <> ".json"
+  exists <- doesFileExist path
+  if exists
+    then loadFromFile pkgName path
+    else do
+      generated <- generateBootInterface pkgName path
+      if generated
+        then loadFromFile pkgName path
+        else pure (pkgName, Nothing)
+
+-- | Load a boot interface from a JSON file.
+loadFromFile :: Text -> FilePath -> IO (Text, Maybe ModuleExports)
+loadFromFile pkgName path = do
+  result <- Aeson.eitherDecodeFileStrict' path
+  case result of
+    Left err -> do
+      hPutStrLn stderr ("Warning: failed to decode boot interface for " <> T.unpack pkgName <> ": " <> err)
+      pure (pkgName, Nothing)
+    Right bootIface -> pure (pkgName, Just (bootIfaceToModuleExports bootIface))
+
+-- | Generate a boot interface by running aihc-dev extract-resolve-iface.
+generateBootInterface :: Text -> FilePath -> IO Bool
+generateBootInterface pkgName outputPath = do
+  hPutStrLn stderr ("Generating boot interface for " <> T.unpack pkgName <> "...")
+  result <-
+    try $
+      readProcess
+        "cabal"
+        ["run", "-v0", "aihc-dev", "--", "extract-resolve-iface", "--package", T.unpack pkgName, "--output", outputPath]
+        ""
+  case result of
+    Left (e :: IOException) -> do
+      hPutStrLn stderr ("Warning: failed to generate boot interface for " <> T.unpack pkgName <> ": " <> show e)
+      pure False
+    Right _ -> do
+      hPutStrLn stderr ("  Generated: " <> outputPath)
+      pure True
+
+-- | JSON representation of a boot package interface.
+data BootPackageInterface = BootPackageInterface
+  { _bpiPackage :: Text,
+    bpiModules :: [BootModuleInterface]
+  }
+
+instance FromJSON BootPackageInterface where
+  parseJSON = withObject "BootPackageInterface" $ \o ->
+    BootPackageInterface
+      <$> o .: "package"
+      <*> o .: "modules"
+
+-- | JSON representation of a single module's interface.
+data BootModuleInterface = BootModuleInterface
+  { bmiModule :: Text,
+    bmiTerms :: [Text],
+    bmiTypes :: [Text],
+    bmiConstructors :: Map Text [Text],
+    bmiMethods :: Map Text [Text]
+  }
+
+instance FromJSON BootModuleInterface where
+  parseJSON = withObject "BootModuleInterface" $ \o ->
+    BootModuleInterface
+      <$> o .: "module"
+      <*> (fromMaybe [] <$> o .:? "terms")
+      <*> (fromMaybe [] <$> o .:? "types")
+      <*> (fromMaybe Map.empty <$> o .:? "constructors")
+      <*> (fromMaybe Map.empty <$> o .:? "methods")
+
+-- | Convert a boot package interface to the resolver's ModuleExports format.
+bootIfaceToModuleExports :: BootPackageInterface -> ModuleExports
+bootIfaceToModuleExports bpi =
+  Map.fromList
+    [(bmiModule bmi, bootModuleToScope bmi) | bmi <- bpiModules bpi]
+
+-- | Convert a single module interface to a Scope.
+bootModuleToScope :: BootModuleInterface -> Scope
+bootModuleToScope bmi =
+  Scope
+    { scopeTerms = Map.fromList termEntries,
+      scopeTypes = Map.fromList typeEntries,
+      scopeQualifiedModules = Map.empty
+    }
+  where
+    modName = bmiModule bmi
+
+    termEntries =
+      [(n, resolve modName n) | n <- bmiTerms bmi]
+        ++ [ (n, resolve modName n)
+           | (_, ctors) <- Map.toList (bmiConstructors bmi),
+             n <- ctors
+           ]
+        ++ [ (n, resolve modName n)
+           | (_, meths) <- Map.toList (bmiMethods bmi),
+             n <- meths
+           ]
+
+    typeEntries =
+      [(n, resolve modName n) | n <- bmiTypes bmi]
+        ++ [(className, resolve modName className) | className <- Map.keys (bmiMethods bmi)]
+
+    resolve :: Text -> Text -> ResolvedName
+    resolve qual n =
+      ResolvedTopLevel (mkQualifiedName (mkUnqualifiedName (inferNameType n) n) (Just qual))
+
+-- | Infer the NameType from a name's lexical form.
+inferNameType :: Text -> NameType
+inferNameType n = case T.uncons n of
+  Nothing -> NameConId
+  Just (c, _)
+    | c == ':' -> NameConSym
+    | not (isAlphaNum c) && c /= '_' && c /= '\'' -> NameVarSym
+    | isUpper c -> NameConId
+    | otherwise -> NameVarId
+
+-- | Strip leading and trailing whitespace.
+trim :: String -> String
+trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace

--- a/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
+++ b/components/aihc-resolve/app/resolve-stackage-progress/Main.hs
@@ -22,17 +22,15 @@ import Aihc.Parser.Syntax
     LanguageEdition (..),
     Module,
     ModuleHeaderPragmas (..),
-    NameType (..),
     SourceSpan (..),
     effectiveExtensions,
     headerExtensionSettings,
     headerLanguageEdition,
-    mkQualifiedName,
-    mkUnqualifiedName,
     parseExtensionSettingName,
     parseLanguageEdition,
   )
-import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), extractInterface, resolveWithDeps)
+import BootInterface (bootPackageNames, loadBootInterfaces)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (modifyMVar, modifyMVar_, newMVar, readMVar)
@@ -40,7 +38,7 @@ import Control.Exception (SomeException, displayException, evaluate, try)
 import Control.Monad (mplus)
 import Control.Monad qualified
 import Data.ByteString qualified as BS
-import Data.Char (isAlphaNum, isUpper, toLower)
+import Data.Char (toLower)
 import Data.List (nub, partition, sortOn)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -506,156 +504,6 @@ putProgressLine done total = do
   hFlush stdout
 
 -- ---------------------------------------------------------------------------
--- Boot package shims
--- ---------------------------------------------------------------------------
-
--- | Build a ResolvedTopLevel name for a boot shim entry.
-bootResolve :: Text -> Text -> ResolvedName
-bootResolve modName n =
-  ResolvedTopLevel (mkQualifiedName (mkUnqualifiedName nt n) (Just modName))
-  where
-    nt = case T.uncons n of
-      Nothing -> NameConId
-      Just (c, _)
-        | c == ':' -> NameConSym
-        | not (isAlphaNum c) && c /= '_' && c /= '\'' -> NameVarSym
-        | isUpper c -> NameConId
-        | otherwise -> NameVarId
-
-bootScope :: Text -> [Text] -> [Text] -> Scope
-bootScope modName termNames typeNames =
-  Scope
-    { scopeTerms = Map.fromList [(n, bootResolve modName n) | n <- termNames],
-      scopeTypes = Map.fromList [(n, bootResolve modName n) | n <- typeNames],
-      scopeQualifiedModules = Map.empty
-    }
-
-bootPackageExports :: Text -> ModuleExports
-bootPackageExports pkg = case pkg of
-  "ghc-prim" -> ghcPrimExports
-  "integer-gmp" -> integerExports
-  "integer-simple" -> integerExports
-  "ghc-bignum" -> integerExports
-  _ -> Map.empty
-
--- ---------------------------------------------------------------------------
--- Boot shims for common non-base packages
--- ---------------------------------------------------------------------------
-
-ghcPrimExports :: ModuleExports
-ghcPrimExports =
-  Map.fromList
-    [ ("GHC.Prim", ghcPrimScope),
-      ("GHC.Prim.Ext", ghcPrimExtScope)
-    ]
-
-ghcPrimScope :: Scope
-ghcPrimScope =
-  bootScope
-    "GHC.Prim"
-    [ "seq#",
-      "void#",
-      "realWorld#",
-      "coerce#",
-      "negateInt#",
-      "negateWord#",
-      "not#",
-      "narrow8Int#",
-      "narrow16Int#",
-      "narrow32Int#",
-      "narrow8Word#",
-      "narrow16Word#",
-      "narrow32Word#"
-    ]
-    [ "Int#",
-      "Word#",
-      "Char#",
-      "Float#",
-      "Double#",
-      "Addr#",
-      "State#",
-      "RealWorld",
-      "MutVar#",
-      "MutableByteArray#",
-      "ByteArray#",
-      "Array#",
-      "MutableArray#",
-      "SmallArray#",
-      "SmallMutableArray#",
-      "StablePtr#",
-      "StableName#",
-      "MVar#",
-      "TVar#",
-      "BCO#",
-      "ThreadId#",
-      "Weak#",
-      "Proxy#"
-    ]
-
-ghcPrimExtScope :: Scope
-ghcPrimExtScope =
-  bootScope
-    "GHC.Prim.Ext"
-    []
-    []
-
-integerExports :: ModuleExports
-integerExports =
-  Map.fromList
-    [ ("GHC.Integer", integerScope),
-      ("GHC.Integer.Type", integerScope),
-      ("GHC.Num.Integer", integerScope),
-      ("GHC.Num.Natural", naturalScope),
-      ("GHC.Natural", naturalScope),
-      ("Numeric.Natural", naturalScope)
-    ]
-
-integerScope :: Scope
-integerScope =
-  bootScope
-    "GHC.Integer"
-    [ "smallInteger",
-      "wordToInteger",
-      "integerToWord",
-      "integerToInt",
-      "integerToWord64",
-      "integerToInt64",
-      "word64ToInteger",
-      "int64ToInteger",
-      "plusInteger",
-      "minusInteger",
-      "timesInteger",
-      "negateInteger",
-      "absInteger",
-      "signumInteger",
-      "divModInteger",
-      "quotRemInteger",
-      "quotInteger",
-      "remInteger",
-      "divInteger",
-      "modInteger",
-      "gcdInteger",
-      "lcmInteger",
-      "andInteger",
-      "orInteger",
-      "xorInteger",
-      "complementInteger",
-      "shiftLInteger",
-      "shiftRInteger",
-      "testBitInteger",
-      "popCountInteger",
-      "bitInteger"
-    ]
-    ["Integer"]
-
-naturalScope :: Scope
-naturalScope =
-  bootScope
-    "Numeric.Natural"
-    []
-    ["Natural"]
-
--- ---------------------------------------------------------------------------
 -- main
 -- ---------------------------------------------------------------------------
 
@@ -673,18 +521,24 @@ main = do
 
   let total = length packages
       snapshotNames = Set.fromList (map (T.pack . pkgName) packages)
-      -- GHC boot packages use CPP and internal syntax our parser can't handle.
-      -- Pre-stub them as successful with hand-written export shims.
-      (bootPkgs, regularPkgs) = partition (\p -> pkgVersion p == "installed") packages
-      bootResults =
+      -- Partition into boot packages (pre-generated interfaces) and regular packages.
+      -- Boot packages: those in bootPackageNames that use GHC-internal syntax.
+      -- Other "installed" packages (e.g. text, parsec) are resolved from source.
+      (bootPkgs, regularPkgs) = partition isBootPkg packages
+      isBootPkg p = T.pack (pkgName p) `Set.member` bootPackageNames
+
+  -- Load pre-generated boot interfaces (generates on demand if not cached)
+  putStrLn "Loading boot interfaces..."
+  bootIfaceMap <- loadBootInterfaces
+  let bootResults =
         Map.fromList
-          [ (T.pack (pkgName p), PkgSuccess (bootPackageExports (T.pack (pkgName p))))
+          [ (T.pack (pkgName p), PkgSuccess (Map.findWithDefault Map.empty (T.pack (pkgName p)) bootIfaceMap))
           | p <- bootPkgs
           ]
 
   isStdoutTerminal <- hIsTerminalDevice stdout
   putStrLn $ "Resolving " ++ optSnapshot opts ++ " (" ++ show total ++ " packages, " ++ show jobs ++ " jobs)..."
-  putStrLn $ "  " ++ show (length bootPkgs) ++ " GHC boot packages stubbed, " ++ show (length regularPkgs) ++ " to download"
+  putStrLn $ "  " ++ show (length bootPkgs) ++ " boot packages (pre-generated), " ++ show (length regularPkgs) ++ " to resolve from source"
   putStrLn "Phase 1: downloading packages and collecting dependency info..."
 
   infos <- phase1Parallel opts regularPkgs snapshotNames isStdoutTerminal (length regularPkgs)

--- a/justfile
+++ b/justfile
@@ -33,3 +33,16 @@ check:
   nix develop --quiet --command bash -c 'ormolu --mode check $(find components -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   nix develop --quiet --command bash -c 'hlint $(find components -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'
+
+# Generate boot package interfaces for the resolver (requires GHC dev env)
+gen-boot-ifaces:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  GHC_VERSION=$(ghc --numeric-version)
+  CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/aihc-resolve/boot-interfaces/$GHC_VERSION"
+  mkdir -p "$CACHE_DIR"
+  for pkg in ghc-prim ghc-internal ghc-bignum base; do
+    echo "Extracting interface for $pkg..."
+    cabal run -v0 aihc-dev -- extract-resolve-iface --package "$pkg" --output "$CACHE_DIR/$pkg.json"
+  done
+  echo "Boot interfaces generated in $CACHE_DIR"

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -16,9 +16,11 @@ executable aihc-dev
       Aihc.Dev.ExtractHi
     , Aihc.Dev.ExtractHi.Types
     , Aihc.Dev.ExtractHi.GhcSession
+    , Aihc.Dev.ExtractHi.ToResolveIface
   build-depends:
       base >= 4.16 && < 5
     , aeson >= 2.0 && < 2.3
+    , aeson-pretty >= 0.8 && < 0.9
     , bytestring >= 0.10.8 && < 0.13
     , containers >= 0.5 && < 0.8
     , directory >= 1.2.3 && < 1.5

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -1,10 +1,14 @@
 module Main (main) where
 
 import Aihc.Dev.ExtractHi (extractPackage)
+import Aihc.Dev.ExtractHi.ToResolveIface (toResolveIface)
 import Data.Aeson (encode)
+import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString.Lazy qualified as BL
 import Data.Yaml qualified as Yaml
 import Options.Applicative
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory)
 
 main :: IO ()
 main = do
@@ -19,12 +23,18 @@ main = do
         )
 
 -- | Top-level command type. New subcommands are added here.
-newtype Command
+data Command
   = ExtractHi ExtractHiOpts
+  | ExtractResolveIface ExtractResolveIfaceOpts
 
 data ExtractHiOpts = ExtractHiOpts
   { ehPackage :: String,
     ehFormat :: OutputFormat
+  }
+
+data ExtractResolveIfaceOpts = ExtractResolveIfaceOpts
+  { eriPackage :: String,
+    eriOutput :: FilePath
   }
 
 data OutputFormat = YAML | JSON
@@ -39,6 +49,12 @@ commandParser =
             (ExtractHi <$> extractHiParser <**> helper)
             (progDesc "Extract scoping and typing information from .hi interface files")
         )
+        <> command
+          "extract-resolve-iface"
+          ( info
+              (ExtractResolveIface <$> extractResolveIfaceParser <**> helper)
+              (progDesc "Extract minimal resolver interface (names only) from .hi files")
+          )
     )
 
 extractHiParser :: Parser ExtractHiOpts
@@ -55,9 +71,29 @@ extractHiParser =
           <> help "Output JSON instead of YAML"
       )
 
+extractResolveIfaceParser :: Parser ExtractResolveIfaceOpts
+extractResolveIfaceParser =
+  ExtractResolveIfaceOpts
+    <$> strOption
+      ( long "package"
+          <> metavar "PACKAGE"
+          <> help "Package name to extract (e.g. 'base', 'ghc-prim')"
+      )
+    <*> strOption
+      ( long "output"
+          <> metavar "FILE"
+          <> help "Output file path for the JSON interface"
+      )
+
 runCommand :: Command -> IO ()
 runCommand (ExtractHi opts) = do
   pkg <- extractPackage (ehPackage opts)
   case ehFormat opts of
     YAML -> BL.putStr (BL.fromStrict (Yaml.encode pkg))
     JSON -> BL.putStr (encode pkg)
+runCommand (ExtractResolveIface opts) = do
+  pkg <- extractPackage (eriPackage opts)
+  let resolveIface = toResolveIface pkg
+      outputPath = eriOutput opts
+  createDirectoryIfMissing True (takeDirectory outputPath)
+  BL.writeFile outputPath (encodePretty resolveIface)

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/ToResolveIface.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/ToResolveIface.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Convert a 'PackageInterface' (rich GHC .hi extraction) to the minimal
+-- JSON format needed by the aihc-resolve name resolver.
+--
+-- The resolver only needs to know which names exist in each module and
+-- namespace (terms vs types). It does not need type signatures, kinds,
+-- or other rich information.
+--
+-- Output JSON schema:
+--
+-- @
+-- { "package": "base-4.21.0.0"
+-- , "modules":
+--     [ { "module": "Data.List"
+--       , "terms": ["map", "filter", ...]
+--       , "types": ["NonEmpty", ...]
+--       , "constructors": {"Maybe": ["Just", "Nothing"], ...}
+--       , "methods": {"Functor": ["fmap", "<$"], ...}
+--       }
+--     ]
+-- }
+-- @
+module Aihc.Dev.ExtractHi.ToResolveIface
+  ( toResolveIface,
+    ResolvePackageIface (..),
+    ResolveModuleIface (..),
+  )
+where
+
+import Aihc.Dev.ExtractHi.Types
+import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+-- | Minimal package interface for the resolver.
+data ResolvePackageIface = ResolvePackageIface
+  { rpiPackage :: Text,
+    rpiModules :: [ResolveModuleIface]
+  }
+  deriving (Show)
+
+instance ToJSON ResolvePackageIface where
+  toJSON rpi =
+    object
+      [ "package" .= rpiPackage rpi,
+        "modules" .= rpiModules rpi
+      ]
+
+-- | Minimal module interface for the resolver.
+data ResolveModuleIface = ResolveModuleIface
+  { rmiModule :: Text,
+    rmiTerms :: [Text],
+    rmiTypes :: [Text],
+    rmiConstructors :: Map Text [Text],
+    rmiMethods :: Map Text [Text]
+  }
+  deriving (Show)
+
+instance ToJSON ResolveModuleIface where
+  toJSON rmi =
+    object
+      [ "module" .= rmiModule rmi,
+        "terms" .= rmiTerms rmi,
+        "types" .= rmiTypes rmi,
+        "constructors" .= rmiConstructors rmi,
+        "methods" .= rmiMethods rmi
+      ]
+
+-- | Convert a rich PackageInterface to the minimal resolver format.
+toResolveIface :: PackageInterface -> ResolvePackageIface
+toResolveIface pi' =
+  ResolvePackageIface
+    { rpiPackage = piPackage pi',
+      rpiModules = map convertModule (piModules pi')
+    }
+
+-- | Convert a single module interface.
+convertModule :: ModuleInterface -> ResolveModuleIface
+convertModule mi =
+  ResolveModuleIface
+    { rmiModule = miModule mi,
+      rmiTerms = plainValues,
+      rmiTypes = typeNames,
+      rmiConstructors = constructorMap,
+      rmiMethods = methodMap
+    }
+  where
+    -- Plain values: functions and variables (not constructors or methods)
+    plainValues = map evName (miValues mi)
+
+    -- Type names: data types, type synonyms, type families
+    typeNames = map etName (miTypes mi)
+
+    -- Constructors grouped by their parent type
+    constructorMap =
+      Map.fromList
+        [ (etName et, etConstructors et)
+        | et <- miTypes mi,
+          not (null (etConstructors et))
+        ]
+
+    -- Methods grouped by their parent class
+    methodMap =
+      Map.fromList
+        [ (ecName ec, map cmName (ecMethods ec))
+        | ec <- miClasses mi,
+          not (null (ecMethods ec))
+        ]


### PR DESCRIPTION
## Summary

- Replace hand-written boot package shims (~30 names covering only `ghc-prim` and `integer` packages) with complete interfaces extracted from GHC's compiled `.hi` files (thousands of names across hundreds of modules for `base`, `ghc-internal`, `ghc-prim`, `ghc-bignum`)
- Add `extract-resolve-iface` subcommand to `aihc-dev` that converts rich `.hi` data into the minimal JSON format the resolver needs (just name existence per namespace)
- Boot interfaces are generated on demand and cached at `~/.cache/aihc-resolve/boot-interfaces/<ghc-version>/`
- Only true boot packages (`ghc-prim`, `ghc-internal`, `ghc-bignum`, `base`) use pre-generated interfaces; other `"installed"` packages like `text` and `parsec` are now resolved from Hackage source like regular packages

## Motivation

The previous approach provided a tiny, manually-curated set of names for boot packages. This caused cascading resolution failures: any package importing a name from `base` that wasn't in the shim would fail. With complete boot interfaces, the resolver now only fails on genuine implementation gaps rather than missing boot data.

## Architecture

```
aihc-dev extract-resolve-iface --package base --output base.json
    │
    ├── Reads GHC .hi files via GHC API
    ├── Classifies exports (types/values/classes/constructors/methods)
    └── Outputs minimal JSON: { modules: [{ module, terms, types, constructors, methods }] }

resolve-stackage-progress (at startup)
    │
    ├── Checks cache: ~/.cache/aihc-resolve/boot-interfaces/<ghc-ver>/<pkg>.json
    ├── If missing: shells out to `cabal run aihc-dev -- extract-resolve-iface ...`
    └── Converts JSON → ModuleExports (Map Text Scope) for resolver consumption
```

## Testing

- `just check` passes (ormolu + hlint + full test suite with -Werror)
- Manually verified: `extract-resolve-iface` produces correct output for `ghc-prim` (7 modules), `ghc-internal` (217 modules), and `base` (246 modules)