### PR TITLE
fix(parser): accept infix patterns in infix equations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -1526,7 +1526,9 @@ patternBindDeclParser = MP.try $ withSpanAnn (DeclAnn . mkAnnotation) $ do
 
 valueDeclParser :: TokParser Decl
 valueDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  (headForm, name, pats) <- functionHeadParserWith asOrAppPatternParser simplePatternParser
+  -- Infix equations can use full operand patterns on both sides of the varop,
+  -- e.g. @a :&: as == b :&: bs = ()@.
+  (headForm, name, pats) <- functionHeadParserWith patternParser simplePatternParser
   functionBindDecl headForm name pats <$> equationRhsParser
 
 -- ---------------------------------------------------------------------------

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternOperators/infix-function-equation-infix-pattern-operands.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternOperators/infix-function-equation-infix-pattern-operands.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+module InfixFunctionEquationInfixPatternOperands where
+
+data List a = Nil | a :&: List a
+
+a :&: as == b :&: bs = ()


### PR DESCRIPTION
## Summary
- parse full operand patterns on both sides of an infix function equation head so declarations like `a :&: as == b :&: bs = ()` are accepted
- add an oracle parser fixture covering the reported valid Haskell snippet as a regression test
- parser oracle progress: 2051/2051 -> 2052/2052 locally after adding the new passing case

## Verification
- `echo \"a :&: as == b :&: bs = ()\" | cabal run -v0 exe:aihc-parser -- --pretty`
- `just fmt`
- `just check`

## CodeRabbit
- Ran `coderabbit review --prompt-only`
- Ignored the suggestion to rename the fixture's `(==)` operator because the regression specifically exercises a valid top-level operator equation using `(==)`