### PR TITLE
fix(parser): preserve right-associated command infix chains

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1397,7 +1397,7 @@ addCmdParens cmd =
     CmdArrApp lhs appTy rhs ->
       CmdArrApp (addCmdArrAppLhsParens lhs) appTy (addExprParens rhs)
     CmdInfix l op r ->
-      CmdInfix (wrapCmdOperand (addCmdParens l)) op (wrapCmdOperand (addCmdParens r))
+      CmdInfix (wrapCmdInfixLhs (addCmdParens l)) op (wrapCmdInfixRhs (addCmdParens r))
     CmdDo stmts ->
       CmdDo (map addCmdDoStmtParens stmts)
     CmdIf cond yes no ->
@@ -1413,7 +1413,7 @@ addCmdParens cmd =
     CmdPar c ->
       CmdPar (addCmdParens c)
   where
-    wrapCmdOperand inner =
+    wrapCmdInfixLhs inner =
       case peelCmdAnn inner of
         CmdArrApp {} -> CmdPar inner
         CmdLet {} -> CmdPar inner
@@ -1421,6 +1421,15 @@ addCmdParens cmd =
         CmdCase {} -> CmdPar inner
         CmdLam {} -> CmdPar inner
         CmdInfix {} -> CmdPar inner
+        _ -> inner
+
+    wrapCmdInfixRhs inner =
+      case peelCmdAnn inner of
+        CmdArrApp {} -> CmdPar inner
+        CmdLet {} -> CmdPar inner
+        CmdIf {} -> CmdPar inner
+        CmdCase {} -> CmdPar inner
+        CmdLam {} -> CmdPar inner
         _ -> inner
 
 addCmdArrAppLhsParens :: Expr -> Expr

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/arrow-infix-chain-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/arrow-infix-chain-rhs.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Arrows #-}
+module M where
+
+import Control.Arrow
+
+f a b c = proc x -> (a -< x) <+> (b -< x) <+> (c -< x)


### PR DESCRIPTION
## What changed

- Keep nested `CmdInfix` nodes bare on the right-hand side during the parenthesization pass so right-associated command chains keep their original grouping.
- Still parenthesize the left-hand side of command infix chains when needed to preserve explicit left nesting.
- Add an oracle regression for a three-command infix chain inside a `proc` body.

## Root cause

`addCmdParens` wrapped both operands of `CmdInfix` with the same rule set. That was correct for the left operand, but too strong for the right operand because command infix parsing is naturally right-associated. Re-parenthesizing the right operand introduced a `CmdPar` node that changed the GHC AST fingerprint after pretty-print and reparse.

## Progress counts

- Hackage roundtrip regressions fixed in this PR: 1.
- README progress counts: not updated, per repository workflow.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern Parens"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (rate-limited; skipped per repository workflow)