### PR TITLE
fix(parser): preserve non-final block arguments

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -964,8 +964,9 @@ addAppsChainPrec prec expr =
       nArgs = length args
       args' =
         [ let isLast = i == nArgs - 1
+              canStayBare = isBlockExpr a && (isLast || not (isOpenEnded a))
               ctx
-                | isLast, isBlockExpr a = CtxAppArgNoParens
+                | canStayBare = CtxAppArgNoParens
                 | isLast = CtxAppArg
                 | isGreedyExpr a = CtxAppArgGreedy
                 | otherwise = CtxAppArg

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -264,6 +264,7 @@ needsExprParens ctx expr =
       False
     CtxAppArgGreedy ->
       case expr of
+        _ | isBracedExpr expr -> False
         EPragma {} -> True
         _ -> isGreedyExpr expr
     CtxTypeSigBody ->
@@ -288,7 +289,9 @@ exprCtxPrec ctx expr =
     CtxAppFun -> 2
     CtxAppArg -> 3
     CtxAppArgNoParens -> 0
-    CtxAppArgGreedy -> 3
+    CtxAppArgGreedy
+      | isBracedExpr expr -> 0
+      | otherwise -> 3
     CtxTypeSigBody -> 1
     CtxGuarded -> 0
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/nonfinal-case-block-arg.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/nonfinal-case-block-arg.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE BlockArguments #-}
+module M where
+
+x = finally
+  case a of
+    True -> b
+    False -> c
+  do
+    d


### PR DESCRIPTION
## Summary
- preserve bare non-final block arguments in application chains when `BlockArguments` already makes them self-delimiting
- add an oracle regression for `finally` applied to a `case` block followed by a `do` block
- progress: oracle pass count 1074 -> 1075, fail count 1 -> 0 for this regression

## Validation
- `cabal test -v0 aihc-parser:spec --test-options=\"--pattern nonfinal-case-block-arg\"`
- `just fmt`
- `just check`

## Notes
- `coderabbit review --prompt-only` was skipped because the service was rate-limited/offline