### PR TITLE
chore: format cabal files with cabal-gild

### DIFF
--- a/components/aihc-cpp/aihc-cpp.cabal
+++ b/components/aihc-cpp/aihc-cpp.cabal
@@ -1,70 +1,78 @@
-cabal-version:      3.8
-name:               aihc-cpp
-version:            0.1.0.0
-build-type:         Simple
-license:            Unlicense
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Compilers
-synopsis:           Pure Haskell C preprocessor for aihc
+cabal-version: 3.8
+name: aihc-cpp
+version: 0.1.0.0
+build-type: Simple
+license: Unlicense
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: Pure Haskell C preprocessor for aihc
 
 library
   exposed-modules:
-      Aihc.Cpp
+    Aihc.Cpp
+
   other-modules:
-      Aihc.Cpp.Types
-      Aihc.Cpp.Parser
-      Aihc.Cpp.Evaluator
-      Aihc.Cpp.Scanner
-      Aihc.Cpp.Cursor
-  hs-source-dirs:   src
+    Aihc.Cpp.Cursor
+    Aihc.Cpp.Evaluator
+    Aihc.Cpp.Parser
+    Aihc.Cpp.Scanner
+    Aihc.Cpp.Types
+
+  hs-source-dirs: src
   build-depends:
-      base >=4.16 && <5
-    , bytestring
-    , text >=1.2
-    , containers
-    , filepath
-    , deepseq
-  ghc-options:        -Wall
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    filepath,
+    text >=1.2,
+
+  ghc-options: -Wall
   default-language: Haskell2010
 
 test-suite spec
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
   other-modules:
-      Test.Progress
+    Test.Progress
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-cpp
-    , bytestring
-    , cpphs
-    , text
-    , containers
-    , directory
-    , filepath
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-  ghc-options:        -Wall
+    aihc-cpp,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    cpphs,
+    directory,
+    filepath,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+
+  ghc-options: -Wall
   default-language: Haskell2010
 
 executable cpp-progress
   hs-source-dirs:
-      app/cpp-progress
-    , test
-  main-is:          Main.hs
+    app/cpp-progress
+    test
+
+  main-is: Main.hs
   other-modules:
-      Test.Progress
+    Test.Progress
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-cpp
-    , bytestring
-    , cpphs
-    , text
-    , containers
-    , directory
-    , filepath
-  ghc-options:        -Wall
+    aihc-cpp,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    cpphs,
+    directory,
+    filepath,
+    text,
+
+  ghc-options: -Wall
   default-language: Haskell2010

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -1,58 +1,68 @@
-cabal-version:      3.8
-name:               aihc-fc
-version:            0.1.0.0
-build-type:         Simple
-license:            NONE
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Compilers
-synopsis:           System FC core language with desugaring and lint
+cabal-version: 3.8
+name: aihc-fc
+version: 0.1.0.0
+build-type: Simple
+license: NONE
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: System FC core language with desugaring and lint
 
 library
   exposed-modules:
-      Aihc.Fc
-    , Aihc.Fc.Syntax
-    , Aihc.Fc.Pretty
-    , Aihc.Fc.Subst
-    , Aihc.Fc.Lint
-    , Aihc.Fc.Desugar
-    , Aihc.Fc.Desugar.Expr
-    , Aihc.Fc.Desugar.Match
-  hs-source-dirs:   src
+    Aihc.Fc
+    Aihc.Fc.Desugar
+    Aihc.Fc.Desugar.Expr
+    Aihc.Fc.Desugar.Match
+    Aihc.Fc.Lint
+    Aihc.Fc.Pretty
+    Aihc.Fc.Subst
+    Aihc.Fc.Syntax
+
+  hs-source-dirs: src
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , aihc-tc
-    , text >=1.2
-    , containers
-    , transformers
-  ghc-options:        -Wall
+    aihc-parser,
+    aihc-tc,
+    base >=4.16 && <5,
+    containers,
+    text >=1.2,
+    transformers,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 test-suite spec
-  type:             exitcode-stdio-1.0
+  type: exitcode-stdio-1.0
   hs-source-dirs:
-      test
-    , common
-  main-is:          Spec.hs
+    test
+    common
+
+  main-is: Spec.hs
   other-modules:
-      FcGolden
-    , Test.Fc.Suite
+    FcGolden
+    Test.Fc.Suite
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-fc
-    , aihc-parser
-    , aihc-tc
-    , text
-    , containers
-    , directory
-    , filepath
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , aeson
-    , bytestring
-    , yaml
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    aeson,
+    aihc-fc,
+    aihc-parser,
+    aihc-tc,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    yaml,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: GHC2021

--- a/components/aihc-parser-cli/aihc-parser-cli.cabal
+++ b/components/aihc-parser-cli/aihc-parser-cli.cabal
@@ -1,89 +1,104 @@
-cabal-version:      3.8
-name:               aihc-parser-cli
-version:            0.1.0.0
-build-type:         Simple
-license:            MIT
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Compilers
-synopsis:           CLI interface for aihc-parser and aihc-lexer
+cabal-version: 3.8
+name: aihc-parser-cli
+version: 0.1.0.0
+build-type: Simple
+license: MIT
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: CLI interface for aihc-parser and aihc-lexer
 
 library
   exposed-modules:
-      Aihc.Parser.CLI.Parser
-    , Aihc.Parser.CLI.Bench
-    , Aihc.Parser.Run
-    , Aihc.Parser.Bench.CLI
-    , Aihc.Parser.Bench.Parsers
-    , Aihc.Parser.Bench.Tarball
-    , Aihc.Parser.Bench.Benchmark
-    , Aihc.Parser.Bench.Metrics
-  hs-source-dirs:   src
+    Aihc.Parser.Bench.Benchmark
+    Aihc.Parser.Bench.CLI
+    Aihc.Parser.Bench.Metrics
+    Aihc.Parser.Bench.Parsers
+    Aihc.Parser.Bench.Tarball
+    Aihc.Parser.CLI.Bench
+    Aihc.Parser.CLI.Parser
+    Aihc.Parser.Run
+
+  hs-source-dirs: src
   build-depends:
-      base >=4.16 && <5
-    , aihc-cpp
-    , aihc-hackage
-    , aihc-parser
-    , text >=1.2
-    , optparse-applicative
-    , prettyprinter
     -- Dependencies for bench modules:
-    , aeson
-    , bytestring
-    , Cabal-syntax >= 3.14 && < 3.17
-    , containers
-    , deepseq
-    , directory
-    , filepath
-    , ghc-lib-parser
-    , haskell-src-exts
-    , http-client
-    , http-client-tls
-    , tar
-    , time
-    , zlib
-  ghc-options:        -Wall
+    Cabal-syntax >=3.14 && <3.17,
+    aeson,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    ghc-lib-parser,
+    haskell-src-exts,
+    http-client,
+    http-client-tls,
+    optparse-applicative,
+    prettyprinter,
+    tar,
+    text >=1.2,
+    time,
+    zlib,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable aihc-parser
-  hs-source-dirs:     app/aihc-parser
-  main-is:            Main.hs
+  hs-source-dirs: app/aihc-parser
+  main-is: Main.hs
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser-cli
-  ghc-options:        -Wall
-  default-language:   Haskell2010
+    aihc-parser-cli,
+    base >=4.16 && <5,
+
+  ghc-options: -Wall
+  default-language: Haskell2010
 
 executable aihc-parser-bench
-  hs-source-dirs:     app/aihc-parser-bench
-  main-is:            Main.hs
+  hs-source-dirs: app/aihc-parser-bench
+  main-is: Main.hs
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser-cli
-  ghc-options:        -Wall -rtsopts "-with-rtsopts=-T"
-  default-language:   Haskell2010
+    aihc-parser-cli,
+    base >=4.16 && <5,
+
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-T
+
+  default-language: Haskell2010
 
 test-suite spec
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
   other-modules:
-      CLIGolden
-    , Test.CLI.Suite
+    CLIGolden
+    Test.CLI.Suite
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , aihc-parser-cli
-    , text
-    , aeson
-    , bytestring
-    , containers
-    , directory
-    , filepath
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , yaml
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    aeson,
+    aihc-parser,
+    aihc-parser-cli,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    yaml,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: Haskell2010

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -1,311 +1,347 @@
-cabal-version:      3.8
-name:               aihc-parser
-version:            0.1.0.0
-build-type:         Simple
-license:            MIT
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Compilers
-synopsis:           From-scratch Haskell parser with differential tests
+cabal-version: 3.8
+name: aihc-parser
+version: 0.1.0.0
+build-type: Simple
+license: MIT
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: From-scratch Haskell parser with differential tests
 
 library
   exposed-modules:
-       Aihc.Parser
-     , Aihc.Parser.Syntax
-     , Aihc.Parser.Lex
-     , Aihc.Parser.Shorthand
-     , Aihc.Parser.Parens
+    Aihc.Parser
+    Aihc.Parser.Lex
+    Aihc.Parser.Parens
+    Aihc.Parser.Shorthand
+    Aihc.Parser.Syntax
+
   other-modules:
-       Aihc.Parser.Pretty
-     , Aihc.Parser.Types
-    , Aihc.Parser.Lex.Header
-    , Aihc.Parser.Lex.Layout
-    , Aihc.Parser.Lex.Numbers
-    , Aihc.Parser.Lex.Pragmas
-    , Aihc.Parser.Lex.Quoted
-    , Aihc.Parser.Lex.Trivia
-    , Aihc.Parser.Lex.Types
-    , Aihc.Parser.Internal.CheckPattern
-    , Aihc.Parser.Internal.Cmd
-    , Aihc.Parser.Internal.Common
-    , Aihc.Parser.Internal.Expr
-    , Aihc.Parser.Internal.Decl
-    , Aihc.Parser.Internal.Import
-    , Aihc.Parser.Internal.Module
-    , Aihc.Parser.Internal.Pattern
-    , Aihc.Parser.Internal.Type
-    , Aihc.Parser.Internal.FromTokens
-  hs-source-dirs:   src
+    Aihc.Parser.Internal.CheckPattern
+    Aihc.Parser.Internal.Cmd
+    Aihc.Parser.Internal.Common
+    Aihc.Parser.Internal.Decl
+    Aihc.Parser.Internal.Expr
+    Aihc.Parser.Internal.FromTokens
+    Aihc.Parser.Internal.Import
+    Aihc.Parser.Internal.Module
+    Aihc.Parser.Internal.Pattern
+    Aihc.Parser.Internal.Type
+    Aihc.Parser.Lex.Header
+    Aihc.Parser.Lex.Layout
+    Aihc.Parser.Lex.Numbers
+    Aihc.Parser.Lex.Pragmas
+    Aihc.Parser.Lex.Quoted
+    Aihc.Parser.Lex.Trivia
+    Aihc.Parser.Lex.Types
+    Aihc.Parser.Pretty
+    Aihc.Parser.Types
+
+  hs-source-dirs: src
   build-depends:
-      base >=4.16 && <5
-    , text >=1.2
-    , containers
-    , bytestring
-    , deepseq
-    , megaparsec
-    , prettyprinter
-  ghc-options:        -Wall
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    megaparsec,
+    prettyprinter,
+    text >=1.2,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 test-suite spec
-  type:             exitcode-stdio-1.0
+  type: exitcode-stdio-1.0
   hs-source-dirs:
-      test
-    , app/stackage-progress
-    , common
-    , src
-  main-is:          Spec.hs
+    test
+    app/stackage-progress
+    common
+    src
+
+  main-is: Spec.hs
   other-modules:
-      Aihc.Parser
-    , Aihc.Parser.Syntax
-    , Aihc.Parser.Lex
-    , Aihc.Parser.Shorthand
-    , Aihc.Parser.Parens
-    , Aihc.Parser.Pretty
-    , Aihc.Parser.Types
-    , Aihc.Parser.Lex.Header
-    , Aihc.Parser.Lex.Layout
-    , Aihc.Parser.Lex.Numbers
-    , Aihc.Parser.Lex.Pragmas
-    , Aihc.Parser.Lex.Quoted
-    , Aihc.Parser.Lex.Trivia
-    , Aihc.Parser.Lex.Types
-    , Aihc.Parser.Internal.CheckPattern
-    , Aihc.Parser.Internal.Cmd
-    , Aihc.Parser.Internal.Common
-    , Aihc.Parser.Internal.Expr
-    , Aihc.Parser.Internal.Decl
-    , Aihc.Parser.Internal.Import
-    , Aihc.Parser.Internal.Module
-    , Aihc.Parser.Internal.Pattern
-    , Aihc.Parser.Internal.Type
-    , Aihc.Parser.Internal.FromTokens
-    , CppSupport
-    , ExtensionSupport
-    , GhcOracle
-    , HackageSupport
-    , HackageTester.CLI
-    , HackageTester.Model
-    , HseExtensions
-    , LexerGolden
-    , ParserErrorGolden
-    , ParserGolden
-    , ParserValidation
-    , ShrinkUtils
-    , StackageProgress.CLI
-    , StackageProgress.FileChecker
-    , StackageProgress.Summary
-    , StackageProgress.FileCheckerTiming
-    , Test.ErrorMessages.Suite
-    , Test.Oracle.Suite
-    , Test.Performance.Suite
-    , Test.ExtensionMapping.Suite
-    , Test.HackageTester.Suite
-    , Test.Lexer.Suite
-    , Test.Properties.Arb.Decl
-    , Test.Properties.Arb.Expr
-    , Test.Properties.Arb.Utils
-    , Test.Properties.Arb.Identifiers
-    , Test.Properties.Arb.Module
-    , Test.Properties.Arb.Pattern
-    , Test.Properties.Arb.Type
-    , Test.Properties.Coverage
-    , Test.Properties.DeclRoundTrip
-    , Test.Properties.ExprHelpers
-    , Test.Properties.ExprRoundTrip
-    , Test.Properties.Identifiers
-    , Test.Properties.ModuleRoundTrip
-    , Test.Properties.NoExceptions
-    , Test.Properties.PatternRoundTrip
-    , Test.Properties.TypeRoundTrip
-    , Test.Parser.Suite
-    , Test.StackageProgress.FileCheckerTiming
-    , Test.StackageProgress.FileChecker
-    , Test.StackageProgress.Summary
+    Aihc.Parser
+    Aihc.Parser.Internal.CheckPattern
+    Aihc.Parser.Internal.Cmd
+    Aihc.Parser.Internal.Common
+    Aihc.Parser.Internal.Decl
+    Aihc.Parser.Internal.Expr
+    Aihc.Parser.Internal.FromTokens
+    Aihc.Parser.Internal.Import
+    Aihc.Parser.Internal.Module
+    Aihc.Parser.Internal.Pattern
+    Aihc.Parser.Internal.Type
+    Aihc.Parser.Lex
+    Aihc.Parser.Lex.Header
+    Aihc.Parser.Lex.Layout
+    Aihc.Parser.Lex.Numbers
+    Aihc.Parser.Lex.Pragmas
+    Aihc.Parser.Lex.Quoted
+    Aihc.Parser.Lex.Trivia
+    Aihc.Parser.Lex.Types
+    Aihc.Parser.Parens
+    Aihc.Parser.Pretty
+    Aihc.Parser.Shorthand
+    Aihc.Parser.Syntax
+    Aihc.Parser.Types
+    CppSupport
+    ExtensionSupport
+    GhcOracle
+    HackageSupport
+    HackageTester.CLI
+    HackageTester.Model
+    HseExtensions
+    LexerGolden
+    ParserErrorGolden
+    ParserGolden
+    ParserValidation
+    ShrinkUtils
+    StackageProgress.CLI
+    StackageProgress.FileChecker
+    StackageProgress.FileCheckerTiming
+    StackageProgress.Summary
+    Test.ErrorMessages.Suite
+    Test.ExtensionMapping.Suite
+    Test.HackageTester.Suite
+    Test.Lexer.Suite
+    Test.Oracle.Suite
+    Test.Parser.Suite
+    Test.Performance.Suite
+    Test.Properties.Arb.Decl
+    Test.Properties.Arb.Expr
+    Test.Properties.Arb.Identifiers
+    Test.Properties.Arb.Module
+    Test.Properties.Arb.Pattern
+    Test.Properties.Arb.Type
+    Test.Properties.Arb.Utils
+    Test.Properties.Coverage
+    Test.Properties.DeclRoundTrip
+    Test.Properties.ExprHelpers
+    Test.Properties.ExprRoundTrip
+    Test.Properties.Identifiers
+    Test.Properties.ModuleRoundTrip
+    Test.Properties.NoExceptions
+    Test.Properties.PatternRoundTrip
+    Test.Properties.TypeRoundTrip
+    Test.StackageProgress.FileChecker
+    Test.StackageProgress.FileCheckerTiming
+    Test.StackageProgress.Summary
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-cpp
-    , aihc-hackage
-    , Diff
-    , megaparsec
-    , text
-    , containers
-    , directory
-    , filepath
-    , deepseq
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck >= 0.11.1 && < 0.12
-    , QuickCheck
-    , ghc-lib-parser
-    , Cabal-syntax >= 3.14 && < 3.17
-    , haskell-src-exts
-    , aeson
-    , bytestring
-    , prettyprinter
-    , process
-    , yaml
-    , optparse-applicative
-    , template-haskell
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    Cabal-syntax >=3.14 && <3.17,
+    Diff,
+    QuickCheck,
+    aeson,
+    aihc-cpp,
+    aihc-hackage,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    ghc-lib-parser,
+    haskell-src-exts,
+    megaparsec,
+    optparse-applicative,
+    prettyprinter,
+    process,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck >=0.11.1 && <0.12,
+    template-haskell,
+    text,
+    yaml,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: GHC2021
 
 executable parser-progress
   hs-source-dirs:
-      app/parser-progress
-    , common
-  main-is:          Main.hs
+    app/parser-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      CppSupport
-    , ExtensionSupport
-    , ParserValidation
-    , GhcOracle
+    CppSupport
+    ExtensionSupport
+    GhcOracle
+    ParserValidation
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , aihc-cpp
-    , aihc-hackage
-    , Diff
-    , deepseq
-    , bytestring
-    , text
-    , containers
-    , directory
-    , filepath
-    , ghc-lib-parser
-    , Cabal-syntax >= 3.14 && < 3.17
-    , prettyprinter
-  ghc-options:        -Wall
+    Cabal-syntax >=3.14 && <3.17,
+    Diff,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    ghc-lib-parser,
+    prettyprinter,
+    text,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable lexer-progress
   hs-source-dirs:
-      app/lexer-progress
-    , common
-  main-is:          Main.hs
+    app/lexer-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      LexerGolden
+    LexerGolden
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , text
-    , bytestring
-    , containers
-    , directory
-    , filepath
-    , aeson
-    , yaml
-  ghc-options:        -Wall
+    aeson,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    text,
+    yaml,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable extension-progress
   hs-source-dirs:
-      app/extension-progress
-    , common
-  main-is:          Main.hs
+    app/extension-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      CppSupport
-    , ExtensionSupport
-    , ParserValidation
-    , GhcOracle
-    , ParserGolden
+    CppSupport
+    ExtensionSupport
+    GhcOracle
+    ParserGolden
+    ParserValidation
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , aihc-cpp
-    , aihc-hackage
-    , Diff
-    , deepseq
-    , text
-    , containers
-    , directory
-    , filepath
-    , ghc-lib-parser
-    , Cabal-syntax >= 3.14 && < 3.17
-    , megaparsec
-    , prettyprinter
-    , yaml
-    , aeson
-    , bytestring
-  ghc-options:        -Wall
+    Cabal-syntax >=3.14 && <3.17,
+    Diff,
+    aeson,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    ghc-lib-parser,
+    megaparsec,
+    prettyprinter,
+    text,
+    yaml,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable hackage-tester
   hs-source-dirs:
-      app/hackage-tester
-    , common
-  main-is:          Main.hs
+    app/hackage-tester
+    common
+
+  main-is: Main.hs
   other-modules:
-      ConcurrentProgress
-    , CppSupport
-    , GhcOracle
-    , HackageSupport
-    , HackageTester.CLI
-    , HackageTester.Model
-    , HseExtensions
-    , ParserValidation
-    , ShrinkUtils
+    ConcurrentProgress
+    CppSupport
+    GhcOracle
+    HackageSupport
+    HackageTester.CLI
+    HackageTester.Model
+    HseExtensions
+    ParserValidation
+    ShrinkUtils
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , aihc-cpp
-    , aihc-hackage
-    , Diff
-    , text
-    , containers
-    , deepseq
-    , directory
-    , filepath
-    , ghc-lib-parser
-    , Cabal-syntax >= 3.14 && < 3.17
-    , bytestring
-    , async
-    , aeson
-    , http-client
-    , http-client-tls
-    , optparse-applicative
-    , haskell-src-exts
-    , prettyprinter
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    Cabal-syntax >=3.14 && <3.17,
+    Diff,
+    aeson,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    async,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    ghc-lib-parser,
+    haskell-src-exts,
+    http-client,
+    http-client-tls,
+    optparse-applicative,
+    prettyprinter,
+    text,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: GHC2021
 
 executable stackage-progress
   hs-source-dirs:
-      app/stackage-progress
-    , common
-  main-is:          Main.hs
+    app/stackage-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      ConcurrentProgress
-    , CppSupport
-    , GhcOracle
-    , HackageSupport
-    , HseExtensions
-    , ParserValidation
-    , ShrinkUtils
-    , StackageProgress.CLI
-    , StackageProgress.FileChecker
-    , StackageProgress.FileCheckerTiming
-    , StackageProgress.PackageRunner
-    , StackageProgress.Snapshot
-    , StackageProgress.Summary
+    ConcurrentProgress
+    CppSupport
+    GhcOracle
+    HackageSupport
+    HseExtensions
+    ParserValidation
+    ShrinkUtils
+    StackageProgress.CLI
+    StackageProgress.FileChecker
+    StackageProgress.FileCheckerTiming
+    StackageProgress.PackageRunner
+    StackageProgress.Snapshot
+    StackageProgress.Summary
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , aihc-cpp
-    , aihc-hackage
-    , Diff
-    , text
-    , containers
-    , deepseq
-    , directory
-    , filepath
-    , ghc-lib-parser
-    , async
-    , Cabal-syntax >= 3.14 && < 3.17
-    , bytestring
-    , haskell-src-exts
-    , optparse-applicative
-    , prettyprinter
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    Cabal-syntax >=3.14 && <3.17,
+    Diff,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    async,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    ghc-lib-parser,
+    haskell-src-exts,
+    optparse-applicative,
+    prettyprinter,
+    text,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: GHC2021

--- a/components/aihc-resolve/aihc-resolve.cabal
+++ b/components/aihc-resolve/aihc-resolve.cabal
@@ -1,116 +1,140 @@
-cabal-version:      3.8
-name:               aihc-resolve
-version:            0.1.0.0
-build-type:         Simple
-license:            NONE
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Compilers
-synopsis:           Name resolution for parsed Haskell modules
+cabal-version: 3.8
+name: aihc-resolve
+version: 0.1.0.0
+build-type: Simple
+license: NONE
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: Name resolution for parsed Haskell modules
 
 library
   exposed-modules:
-      Aihc.Resolve
-    , Aihc.Resolve.Types
-  hs-source-dirs:   src
+    Aihc.Resolve
+    Aihc.Resolve.Types
+
+  hs-source-dirs: src
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , text >=1.2
-    , containers
-  ghc-options:        -Wall
+    aihc-parser,
+    base >=4.16 && <5,
+    containers,
+    text >=1.2,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable resolve-progress
   hs-source-dirs:
-      app/resolve-progress
-    , common
-  main-is:          Main.hs
+    app/resolve-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      ResolverGolden
+    ResolverGolden
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-resolve
-    , aihc-parser
-    , text
-    , containers
-    , directory
-    , filepath
-    , aeson
-    , bytestring
-    , yaml
-  ghc-options:        -Wall
+    aeson,
+    aihc-parser,
+    aihc-resolve,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    text,
+    yaml,
+
+  ghc-options: -Wall
   default-language: Haskell2010
 
 executable resolve-extension-progress
   hs-source-dirs:
-      app/resolve-extension-progress
-    , common
-  main-is:          Main.hs
+    app/resolve-extension-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      ResolverGolden
+    ResolverGolden
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-resolve
-    , aihc-parser
-    , text
-    , containers
-    , directory
-    , filepath
-    , aeson
-    , bytestring
-    , yaml
-  ghc-options:        -Wall
+    aeson,
+    aihc-parser,
+    aihc-resolve,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    text,
+    yaml,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable resolve-stackage-progress
   hs-source-dirs:
-      app/resolve-stackage-progress
-  main-is:          Main.hs
+    app/resolve-stackage-progress
+
+  main-is: Main.hs
   other-modules:
-      BootInterface
+    BootInterface
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-resolve
-    , aihc-parser
-    , aihc-hackage
-    , aeson
-    , text
-    , containers
-    , bytestring
-    , directory
-    , filepath
-    , async
-    , Cabal-syntax >= 3.14 && < 3.17
-    , deepseq
-    , aihc-cpp
-    , process
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    Cabal-syntax >=3.14 && <3.17,
+    aeson,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    aihc-resolve,
+    async,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    deepseq,
+    directory,
+    filepath,
+    process,
+    text,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: GHC2021
 
 test-suite spec
-  type:             exitcode-stdio-1.0
+  type: exitcode-stdio-1.0
   hs-source-dirs:
-      test
-    , common
-  main-is:          Spec.hs
+    test
+    common
+
+  main-is: Spec.hs
   other-modules:
-      ResolverGolden
-    , Test.Resolver.Suite
+    ResolverGolden
+    Test.Resolver.Suite
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-resolve
-    , aihc-parser
-    , text
-    , containers
-    , directory
-    , filepath
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , aeson
-    , bytestring
-    , yaml
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    aeson,
+    aihc-parser,
+    aihc-resolve,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    yaml,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: Haskell2010

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -1,111 +1,127 @@
-cabal-version:      3.8
-name:               aihc-tc
-version:            0.1.0.0
-build-type:         Simple
-license:            NONE
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Compilers
-synopsis:           OutsideIn(X) type checker for parsed Haskell modules
+cabal-version: 3.8
+name: aihc-tc
+version: 0.1.0.0
+build-type: Simple
+license: NONE
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: OutsideIn(X) type checker for parsed Haskell modules
 
 library
   exposed-modules:
-      Aihc.Tc
-    , Aihc.Tc.Types
-    , Aihc.Tc.Evidence
-    , Aihc.Tc.Constraint
-    , Aihc.Tc.Monad
-    , Aihc.Tc.Env
-    , Aihc.Tc.Annotations
-    , Aihc.Tc.Generate.Expr
-    , Aihc.Tc.Generate.Decl
-    , Aihc.Tc.Solve
-    , Aihc.Tc.Solve.Worklist
-    , Aihc.Tc.Solve.InertSet
-    , Aihc.Tc.Solve.Canonicalize
-    , Aihc.Tc.Solve.Equality
-    , Aihc.Tc.Solve.Dict
-    , Aihc.Tc.Unify
-    , Aihc.Tc.Zonk
-    , Aihc.Tc.Instantiate
-    , Aihc.Tc.Generalize
-    , Aihc.Tc.Error
-  hs-source-dirs:   src
+    Aihc.Tc
+    Aihc.Tc.Annotations
+    Aihc.Tc.Constraint
+    Aihc.Tc.Env
+    Aihc.Tc.Error
+    Aihc.Tc.Evidence
+    Aihc.Tc.Generalize
+    Aihc.Tc.Generate.Decl
+    Aihc.Tc.Generate.Expr
+    Aihc.Tc.Instantiate
+    Aihc.Tc.Monad
+    Aihc.Tc.Solve
+    Aihc.Tc.Solve.Canonicalize
+    Aihc.Tc.Solve.Dict
+    Aihc.Tc.Solve.Equality
+    Aihc.Tc.Solve.InertSet
+    Aihc.Tc.Solve.Worklist
+    Aihc.Tc.Types
+    Aihc.Tc.Unify
+    Aihc.Tc.Zonk
+
+  hs-source-dirs: src
   build-depends:
-      base >=4.16 && <5
-    , aihc-parser
-    , text >=1.2
-    , containers
-    , transformers
-  ghc-options:        -Wall
+    aihc-parser,
+    base >=4.16 && <5,
+    containers,
+    text >=1.2,
+    transformers,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 test-suite spec
-  type:             exitcode-stdio-1.0
+  type: exitcode-stdio-1.0
   hs-source-dirs:
-      test
-    , common
-  main-is:          Spec.hs
+    test
+    common
+
+  main-is: Spec.hs
   other-modules:
-      TcGolden
-    , Test.Tc.Suite
-    , Test.Tc.Properties
+    TcGolden
+    Test.Tc.Properties
+    Test.Tc.Suite
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-tc
-    , aihc-parser
-    , text
-    , containers
-    , directory
-    , filepath
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , aeson
-    , bytestring
-    , yaml
-  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+    aeson,
+    aihc-parser,
+    aihc-tc,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    yaml,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
   default-language: GHC2021
 
 executable tc-progress
   hs-source-dirs:
-      app/tc-progress
-    , common
-  main-is:          Main.hs
+    app/tc-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      TcGolden
+    TcGolden
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-tc
-    , aihc-parser
-    , text
-    , containers
-    , directory
-    , filepath
-    , yaml
-    , aeson
-    , bytestring
-  ghc-options:        -Wall
+    aeson,
+    aihc-parser,
+    aihc-tc,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    text,
+    yaml,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable tc-extension-progress
   hs-source-dirs:
-      app/tc-extension-progress
-    , common
-  main-is:          Main.hs
+    app/tc-extension-progress
+    common
+
+  main-is: Main.hs
   other-modules:
-      TcGolden
+    TcGolden
+
   build-depends:
-      base >=4.16 && <5
-    , aihc-tc
-    , aihc-parser
-    , text
-    , containers
-    , directory
-    , filepath
-    , yaml
-    , aeson
-    , bytestring
-  ghc-options:        -Wall
+    aeson,
+    aihc-parser,
+    aihc-tc,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    text,
+    yaml,
+
+  ghc-options: -Wall
   default-language: GHC2021

--- a/justfile
+++ b/justfile
@@ -14,9 +14,9 @@ replay ARGUMENT:
 qc:
   while true; do cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000" || break; done
 
-# Auto-format Nix files and Haskell files (excludes dist-newstyle, result, .git; Haskell excludes test fixtures)
+# Auto-format Nix, Cabal, and Haskell files (excludes dist-newstyle, result, .git; Haskell excludes test fixtures)
 fmt:
-  nix develop --quiet --command bash -c 'find . -name "*.nix" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0 | xargs -0 -r alejandra; ormolu --mode inplace $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'find . -name "*.nix" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0 | xargs -0 -r alejandra; while IFS= read -r -d "" file; do cabal-gild --mode format --io "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); ormolu --mode inplace $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
 
 # Apply HLint hints in place via apply-refact (HLint --refactor accepts one file at a time; same file set as fmt/check)
 hlint-refactor:
@@ -30,6 +30,7 @@ hlint-refactor:
 
 # Run full CI check: format, lint, then tests (warnings are errors only here, not in plain `cabal` / `just test`)
 check:
+  nix develop --quiet --command bash -c 'while IFS= read -r -d "" file; do cabal-gild --mode check --input "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0)'
   nix develop --quiet --command bash -c 'ormolu --mode check $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   nix develop --quiet --command bash -c 'hlint $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ hlint-refactor:
 
 # Run full CI check: format, lint, then tests (warnings are errors only here, not in plain `cabal` / `just test`)
 check:
-  nix develop --quiet --command bash -c 'while IFS= read -r -d "" file; do cabal-gild --mode check --input "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0)'
+  nix develop --quiet --command bash -c 'failed=0; while IFS= read -r -d "" file; do cabal-gild --mode check --input "$file" || failed=1; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); exit "$failed"'
   nix develop --quiet --command bash -c 'ormolu --mode check $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   nix develop --quiet --command bash -c 'hlint $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -53,9 +53,11 @@
   '';
 
   cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.haskellSrc pkgs) [pkgs.haskellPackages.cabal-gild pkgs.findutils] ''
-    while IFS= read -r -d '\0' file; do
-      cabal-gild --mode check --input "$file"
+    failed=0
+    while IFS= read -r -d "" file; do
+      cabal-gild --mode check --input "$file" || failed=1
     done < <(find . -type f -name '*.cabal' -print0)
+    test "$failed" -eq 0
   '';
 
   parserProgressStrict = mkProgressCheck "aihc-parser-progress-strict" (sources.parserSrc pkgs) hsPkgs.aihc-parser ''

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -52,6 +52,12 @@
       | xargs -0 -r ormolu --mode check
   '';
 
+  cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.haskellSrc pkgs) [pkgs.haskellPackages.cabal-gild pkgs.findutils] ''
+    while IFS= read -r -d '\0' file; do
+      cabal-gild --mode check --input "$file"
+    done < <(find . -type f -name '*.cabal' -print0)
+  '';
+
   parserProgressStrict = mkProgressCheck "aihc-parser-progress-strict" (sources.parserSrc pkgs) hsPkgs.aihc-parser ''
     parser-progress --strict
   '';
@@ -109,6 +115,7 @@ in {
   nix-format = nixFormat;
   haskell-lint = haskellLint;
   haskell-format = haskellFormat;
+  cabal-format = cabalFormat;
 
   all-tests = pkgs.linkFarm "aihc-all-tests" [
     {
@@ -174,6 +181,10 @@ in {
     {
       name = "haskell-format";
       path = haskellFormat;
+    }
+    {
+      name = "cabal-format";
+      path = cabalFormat;
     }
   ];
 }

--- a/scripts/nix/dev-shells.nix
+++ b/scripts/nix/dev-shells.nix
@@ -6,6 +6,7 @@ in {
       hsPkgs.ghc
       pkgs.cabal-install
       pkgs.ormolu
+      pkgs.haskellPackages.cabal-gild
       pkgs.alejandra
       pkgs.hlint
     ];

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -1,94 +1,105 @@
-cabal-version:      3.8
-name:               aihc-dev
-version:            0.1.0.0
-build-type:         Simple
-license:            MIT
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Development
-synopsis:           Developer tools for the aihc compiler
+cabal-version: 3.8
+name: aihc-dev
+version: 0.1.0.0
+build-type: Simple
+license: MIT
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Development
+synopsis: Developer tools for the aihc compiler
 
 library extract-hi
-  hs-source-dirs:   src
+  hs-source-dirs: src
   exposed-modules:
-      Aihc.Dev.ExtractHi
-    , Aihc.Dev.ExtractHi.Types
-    , Aihc.Dev.ExtractHi.ToResolveIface
+    Aihc.Dev.ExtractHi
+    Aihc.Dev.ExtractHi.ToResolveIface
+    Aihc.Dev.ExtractHi.Types
+
   other-modules:
-      Aihc.Dev.ExtractHi.GhcSession
+    Aihc.Dev.ExtractHi.GhcSession
+
   build-depends:
-      base >= 4.16 && < 5
-    , aeson >= 2.0 && < 2.3
-    , bytestring >= 0.10.8 && < 0.13
-    , containers >= 0.5 && < 0.8
-    , directory >= 1.2.3 && < 1.5
-    , filepath >= 1.3.0.1 && < 1.6
-    , ghc >= 9.12 && < 9.13
-    , process >= 1.6 && < 1.8
-    , text >= 1.2.3 && < 2.2
+    aeson >=2.0 && <2.3,
+    base >=4.16 && <5,
+    bytestring >=0.10.8 && <0.13,
+    containers >=0.5 && <0.8,
+    directory >=1.2.3 && <1.5,
+    filepath >=1.3.0.1 && <1.6,
+    ghc >=9.12 && <9.13,
+    process >=1.6 && <1.8,
+    text >=1.2.3 && <2.2,
+
   default-extensions: OverloadedStrings
-  ghc-options:        -Wall
+  ghc-options: -Wall
   default-language: GHC2021
 
 library snippet
   hs-source-dirs:
-      src
-    , ../../components/aihc-parser/common
+    src
+    ../../components/aihc-parser/common
+
   other-modules:
-      CppSupport
-    , GhcOracle
-    , ParserValidation
+    CppSupport
+    GhcOracle
+    ParserValidation
+
   exposed-modules:
-      Aihc.Dev.Snippet
+    Aihc.Dev.Snippet
+
   build-depends:
-      base >= 4.16 && < 5
-    , aihc-cpp
-    , aihc-parser
-    , aihc-hackage
-    , bytestring >= 0.10.8 && < 0.13
-    , Diff
-    , deepseq
-    , filepath >= 1.3.0.1 && < 1.6
-    , ghc-lib-parser
-    , prettyprinter
-    , text >= 1.2.3 && < 2.2
+    Diff,
+    aihc-cpp,
+    aihc-hackage,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring >=0.10.8 && <0.13,
+    deepseq,
+    filepath >=1.3.0.1 && <1.6,
+    ghc-lib-parser,
+    prettyprinter,
+    text >=1.2.3 && <2.2,
+
   default-extensions: OverloadedStrings
-  ghc-options:        -Wall
+  ghc-options: -Wall
   default-language: GHC2021
 
 executable aihc-dev
-  main-is:          Main.hs
+  main-is: Main.hs
   hs-source-dirs:
-      exe
+    exe
+
   build-depends:
-      base >= 4.16 && < 5
-    , aeson >= 2.0 && < 2.3
-    , aeson-pretty >= 0.8 && < 0.9
-    , aihc-parser
-    , aihc-dev:extract-hi
-    , aihc-dev:snippet
-    , bytestring >= 0.10.8 && < 0.13
-    , directory >= 1.2.3 && < 1.5
-    , filepath >= 1.3.0.1 && < 1.6
-    , optparse-applicative >= 0.16 && < 0.19
-    , yaml >= 0.11 && < 0.12
+    aeson >=2.0 && <2.3,
+    aeson-pretty >=0.8 && <0.9,
+    aihc-dev:extract-hi,
+    aihc-dev:snippet,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring >=0.10.8 && <0.13,
+    directory >=1.2.3 && <1.5,
+    filepath >=1.3.0.1 && <1.6,
+    optparse-applicative >=0.16 && <0.19,
+    yaml >=0.11 && <0.12,
+
   default-extensions: OverloadedStrings
-  ghc-options:        -Wall
+  ghc-options: -Wall
   default-language: GHC2021
 
 test-suite spec
-  type:             exitcode-stdio-1.0
+  type: exitcode-stdio-1.0
   hs-source-dirs:
-      test
-  main-is:          Spec.hs
+    test
+
+  main-is: Spec.hs
   build-depends:
-      base >= 4.16 && < 5
-    , aihc-parser
-    , aihc-dev:snippet
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , text >= 1.2.3 && < 2.2
-  ghc-options:        -Wall
+    aihc-dev:snippet,
+    aihc-parser,
+    base >=4.16 && <5,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text >=1.2.3 && <2.2,
+
+  ghc-options: -Wall
   default-language: GHC2021

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -1,50 +1,53 @@
-cabal-version:      3.8
-name:               aihc-hackage
-version:            0.1.0.0
-build-type:         Simple
-license:            MIT
-license-file:       LICENSE
-author:             David Himmelstrup
-maintainer:         lemmih@gmail.com
-category:           Development
-synopsis:           Shared Hackage/Stackage download and cabal-file utilities
+cabal-version: 3.8
+name: aihc-hackage
+version: 0.1.0.0
+build-type: Simple
+license: MIT
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Development
+synopsis: Shared Hackage/Stackage download and cabal-file utilities
 
 library
   exposed-modules:
-      Aihc.Hackage.Types
-    , Aihc.Hackage.Cache
-    , Aihc.Hackage.Cpp
-    , Aihc.Hackage.Download
-    , Aihc.Hackage.Stackage
-    , Aihc.Hackage.Cabal
-    , Aihc.Hackage.Util
-    , Aihc.Hackage.VersionResolver
-  hs-source-dirs:   src
+    Aihc.Hackage.Cabal
+    Aihc.Hackage.Cache
+    Aihc.Hackage.Cpp
+    Aihc.Hackage.Download
+    Aihc.Hackage.Stackage
+    Aihc.Hackage.Types
+    Aihc.Hackage.Util
+    Aihc.Hackage.VersionResolver
+
+  hs-source-dirs: src
   build-depends:
-      base >= 4.16 && < 5
-    , bytestring >= 0.10.8 && < 0.13
-    , Cabal-syntax >= 3.14 && < 3.17
-    , containers >= 0.5 && < 0.8
-    , directory >= 1.2.3 && < 1.5
-    , filepath >= 1.3.0.1 && < 1.6
-    , http-client >= 0.5 && < 0.8
-    , http-client-tls >= 0.2 && < 0.4
-    , http-types >= 0.9 && < 0.13
-    , tar >= 0.5 && < 0.7
-    , text >= 1.2.3 && < 2.2
-    , zlib >= 0.5.4 && < 0.8
-  ghc-options:        -Wall
+    Cabal-syntax >=3.14 && <3.17,
+    base >=4.16 && <5,
+    bytestring >=0.10.8 && <0.13,
+    containers >=0.5 && <0.8,
+    directory >=1.2.3 && <1.5,
+    filepath >=1.3.0.1 && <1.6,
+    http-client >=0.5 && <0.8,
+    http-client-tls >=0.2 && <0.4,
+    http-types >=0.9 && <0.13,
+    tar >=0.5 && <0.7,
+    text >=1.2.3 && <2.2,
+    zlib >=0.5.4 && <0.8,
+
+  ghc-options: -Wall
   default-language: GHC2021
 
 test-suite spec
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
   build-depends:
-      base >= 4.16 && < 5
-    , aihc-hackage
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-  ghc-options:        -Wall
+    aihc-hackage,
+    base >=4.16 && <5,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+
+  ghc-options: -Wall
   default-language: GHC2021


### PR DESCRIPTION
## Summary
- add `cabal-gild` to the default dev shell and use it in `just fmt`/`just check` to format and verify all `.cabal` files via nix-provided tooling
- add a dedicated `cabal-format` flake check so `nix flake check` verifies cabal formatting alongside existing nix and Haskell checks
- reformat the repository's `.cabal` files with `cabal-gild` and harden the per-file check loops so all files are checked before failing

## Validation
- `just fmt`
- `just check`
- `nix flake check`

## Progress Counts
- No progress counts changed.