### PR TITLE
test(parser): add xfail oracle tests for TemplateHaskell dollar parens

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-instance-dollar.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-instance-dollar.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Parens.addModuleParens changes the parsed snippet -}
+{-# LANGUAGE TemplateHaskell #-}
+module M where
+
+x = [d| instance X $a |]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-proxy-dollar.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-proxy-dollar.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Parens.addModuleParens changes the parsed snippet -}
+{-# LANGUAGE TemplateHaskell #-}
+module M where
+
+x = [| Proxy :: Proxy $a |]


### PR DESCRIPTION
## Summary
- Add xfail oracle test for `instance X $a` in TH splices (`th-instance-dollar.hs`)
- Add xfail oracle test for `Proxy :: Proxy $a` in TH splices (`th-proxy-dollar.hs`)
- Both tests document `Parens.addModuleParens` incorrectly adding parens around `$a`

## Progress
- Oracle test count: +2 xfail