### PR TITLE
fix(parser): parenthesize TH splices before record dot

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -150,10 +150,13 @@ endsWithTypeSig = \case
 
 -- | Check whether an expression needs parenthesization before a record dot.
 -- Qualified variables (e.g., @A.x@), TH name quotes (@''C@, @'x@),
--- numeric literals, MagicHash literals, and identifiers ending in @#@ all
+-- TH splices (@$x@, @$$x@), numeric literals, MagicHash literals, and
+-- identifiers ending in @#@ all
 -- need parens to prevent ambiguity:
 -- - Qualified names: @A.x.field@ looks like the qualified name @A.x.field@
 -- - TH quotes: @''C.field@ looks like quoting the qualified name @C.field@
+-- - TH splices: @$x.field@ and @$$x.field@ parse as a splice followed by an
+--   unexpected @.@
 -- - Integers: @0xd9.field@ gets lexed as float @0xd9.d@ followed by @MQDc@
 -- - Floats: @1.0.field@ gets lexed as @1.0@ followed by @.field@
 -- - MagicHash: @'c'#.field@ or @x#.field@ — the @#.@ merges into an operator
@@ -164,6 +167,8 @@ needsParensBeforeDot = \case
   -- TH name quotes: 'x.field would be 'x.field (quoting qualified name)
   ETHNameQuote {} -> True
   ETHTypeNameQuote {} -> True
+  ETHSplice {} -> True
+  ETHTypedSplice {} -> True
   -- Numeric literals: digits followed by .field is ambiguous with float syntax
   EInt {} -> True
   EFloat {} -> True

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -131,6 +131,7 @@ buildTests = do
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
             testCase "pretty-prints negated open-ended expressions inside left sections" test_prettyNegatedOpenEndedSectionLhs,
             testCase "pretty-prints negated open-ended type signature bodies" test_prettyNegatedOpenEndedTypeSigBody,
+            testCase "pretty-prints record-dot TH splice bases" test_prettyRecordDotTHSpliceBase,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
             localOption (QC.QuickCheckTests 2000) $
@@ -796,6 +797,23 @@ test_prettyNegatedOpenEndedTypeSigBody = do
       assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
     ParseErr bundle ->
       assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
+
+test_prettyRecordDotTHSpliceBase :: Assertion
+test_prettyRecordDotTHSpliceBase = do
+  let config = defaultConfig {parserExtensions = [TemplateHaskell, MagicHash, OverloadedRecordDot]}
+      spliceName = qualifyName Nothing (mkUnqualifiedName NameVarId "q#")
+      fieldName = qualifyName Nothing (mkUnqualifiedName NameVarId "j7Msfc")
+      assertRoundTrips expectedRendered expr = do
+        let parenthesized = addExprParens expr
+            rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty parenthesized))
+        assertEqual "rendered expression" expectedRendered rendered
+        case parseExpr config rendered of
+          ParseOk reparsed ->
+            assertEqual "reparsed expression" (stripAnnotations parenthesized) (stripAnnotations reparsed)
+          ParseErr bundle ->
+            assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
+  assertRoundTrips "($q#).j7Msfc" (EGetField (ETHSplice (EVar spliceName)) fieldName)
+  assertRoundTrips "($$q#).j7Msfc" (EGetField (ETHTypedSplice (EVar spliceName)) fieldName)
 
 test_roundtripDiffIsMinimal :: Assertion
 test_roundtripDiffIsMinimal =


### PR DESCRIPTION
## Summary
- parenthesize Template Haskell splice expressions before `OverloadedRecordDot` field access so pretty-printed modules remain valid GHC syntax
- add a focused regression test covering both untyped and typed splice bases such as `($q#).field` and `($$q#).field`
- verified the original replay case now passes, along with `just check`

## Progress
- parser progress: no user-facing progress counters changed