### PR TITLE
fix(parser): parse visible type applications before extension validation

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -415,16 +415,13 @@ appExprParser = appExprParserWith atomOrRecordExprParser
 
 appExprParserWith :: TokParser Expr -> TokParser Expr
 appExprParserWith atomParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  typeAppsEnabled <- isExtensionEnabled TypeApplications
   first <- atomParser
-  rest <- MP.many (appArg typeAppsEnabled)
+  rest <- MP.many appArg
   pure $
     foldl applyArg first rest
   where
-    appArg :: Bool -> TokParser (Either Type Expr)
-    appArg typeAppsEnabled
-      | typeAppsEnabled = (Left <$> typeAppArg) <|> (Right <$> atomParser)
-      | otherwise = Right <$> atomParser
+    appArg :: TokParser (Either Type Expr)
+    appArg = (Left <$> typeAppArg) <|> (Right <$> atomParser)
 
     typeAppArg :: TokParser Type
     typeAppArg = MP.try $ do

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -528,23 +528,21 @@ canStartNegatedAtom rest =
     _ -> False
 
 lexTypeApplication :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
-lexTypeApplication env st
-  | not (hasExt TypeApplications env) = Nothing
-  | otherwise =
-      case lexerInput st of
-        '@' :< rest
-          | not (startsWithSymOp rest) ->
-              -- GHC requires whitespace before @ in type applications.
-              -- Without whitespace, @ is the as-pattern operator (TkReservedAt).
-              -- With whitespace, it can be a type application (TkTypeApp).
-              if lexerHadTrivia st
-                then
-                  let kind
-                        | canStartTypeAtomT rest = TkTypeApp
-                        | otherwise = TkVarSym "@"
-                   in Just (emitToken st "@" kind)
-                else Just (emitToken st "@" TkReservedAt)
-        _ -> Nothing
+lexTypeApplication _env st =
+  case lexerInput st of
+    '@' :< rest
+      | not (startsWithSymOp rest) ->
+          -- GHC lexes visible type application syntax based on layout, not on
+          -- whether TypeApplications is enabled. Extension validity is checked
+          -- later, after parsing.
+          if lexerHadTrivia st
+            then
+              let kind
+                    | canStartTypeAtomT rest = TkTypeApp
+                    | otherwise = TkVarSym "@"
+               in Just (emitToken st "@" kind)
+            else Just (emitToken st "@" TkReservedAt)
+    _ -> Nothing
   where
     canStartTypeAtomT t =
       case t of

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/unboxed-tuple-visible-type-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnboxedTuples/unboxed-tuple-visible-type-application.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnboxedTuples #-}
+
+module UnboxedTupleVisibleTypeApplication where
+
+x = (, ) @(# * | 'C #)


### PR DESCRIPTION
## Summary
- parse visible type application syntax based on GHC's whitespace-sensitive tokenization rules instead of rejecting it before extension validation
- allow expression application parsing to consume visible type application arguments even when `TypeApplications` is not enabled, matching GHC's parse-then-validate behavior
- add an oracle regression for `x = (, ) @(# * | 'C #)` under `UnboxedTuples`

## Progress
- Oracle cases: 1027 -> 1028 pass
- XFAIL: 7 -> 7
- FAIL: 0 -> 0
- XPASS: 0 -> 0

## Checks
- `just fmt`
- `cabal test -v0 aihc-parser:spec --test-options=\"--pattern oracle\"`
- `just check`

## Review
- `coderabbit review --prompt-only` could not run due to CodeRabbit hourly rate limiting