### PR TITLE
fix(parser): normalize symbolic variable patterns in prefix position

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -750,16 +750,9 @@ functionBinderNameParser =
 functionBindValue :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs Expr -> ValueDecl
 functionBindValue _headForm name [] rhs =
   -- Zero-argument bindings (e.g. @x = 5@, @x | g = 5@) are pattern bindings,
-  -- not function bindings.  'FunctionBind' is reserved for declarations with
-  -- at least one argument pattern.  Symbolic operators are wrapped in 'PParen'
-  -- to preserve the @(.>.) = expr@ surface syntax; the parser consumed the
-  -- parens as part of the function binder, so we must restore them.
-  PatternBind NoMultiplicityTag (varPat name) rhs
-  where
-    varPat n
-      | unqualifiedNameType n == NameVarSym || unqualifiedNameType n == NameConSym =
-          PParen (PVar n)
-      | otherwise = PVar n
+  -- not function bindings. 'FunctionBind' is reserved for declarations with
+  -- at least one argument pattern.
+  PatternBind NoMultiplicityTag (PVar name) rhs
 functionBindValue headForm name pats rhs =
   FunctionBind
     name

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -334,10 +334,10 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
         Just mkView -> pure mkView
         Nothing -> tupleOrParenPatternParser tupleFlavor closeTok
   where
-    -- When a bare operator like :+ appears directly inside parens, the parens
-    -- serve as prefix notation (e.g. (:+)), not grouping. prettyPrefixName
-    -- already adds parens when printing symbolic names, so wrapping with PParen
-    -- would produce double parens.
+    -- When a bare operator like + or :+ appears directly inside parens, the
+    -- parens serve as prefix notation (e.g. (+), (:+)), not grouping.
+    -- prettyPrefixName already adds parens when printing symbolic names, so
+    -- wrapping with PParen would produce double parens.
     --
     -- However, when the inner pattern came from expression reclassification
     -- (e.g. ((:+)) where the expression parser already consumed the inner
@@ -349,6 +349,10 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
     --   False -> parens are grouping, wrap with PParen
     parenOrSymConParser isBareOperator inner = do
       case peelPatternAnn inner of
+        PVar name
+          | isBareOperator,
+            unqualifiedNameType name == NameVarSym ->
+              pure inner
         PCon con [] []
           | isBareOperator,
             nameType con == NameConSym -> do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1451,8 +1451,6 @@ addFunctionHeadPatternAtomParens :: Pattern -> Pattern
 addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
-    PVar name
-      | unqualifiedNameType name == NameVarSym -> wrapPat True (addPatternParens pat)
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSyntax {} -> wrapPat True (addPatternParens pat)
     PCon _ typeArgs args
@@ -1465,8 +1463,6 @@ addInfixFunctionHeadPatternAtomParens :: Pattern -> Pattern
 addInfixFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addInfixFunctionHeadPatternAtomParens sub)
-    PVar name
-      | unqualifiedNameType name == NameVarSym -> wrapPat True (addPatternParens pat)
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSig {} -> wrapPat True (addPatternParens pat)
     PInfix {} -> wrapPat True (addPatternParens pat)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1451,6 +1451,8 @@ addFunctionHeadPatternAtomParens :: Pattern -> Pattern
 addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
+    PVar name
+      | unqualifiedNameType name == NameVarSym -> wrapPat True (addPatternParens pat)
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSyntax {} -> wrapPat True (addPatternParens pat)
     PCon _ typeArgs args
@@ -1463,6 +1465,8 @@ addInfixFunctionHeadPatternAtomParens :: Pattern -> Pattern
 addInfixFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addInfixFunctionHeadPatternAtomParens sub)
+    PVar name
+      | unqualifiedNameType name == NameVarSym -> wrapPat True (addPatternParens pat)
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSig {} -> wrapPat True (addPatternParens pat)
     PInfix {} -> wrapPat True (addPatternParens pat)

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -486,7 +486,7 @@ prettyPattern :: Pattern -> Doc ann
 prettyPattern pat =
   case pat of
     PAnn _ sub -> prettyPattern sub
-    PVar name -> pretty name
+    PVar name -> prettyBinderUName name
     PTypeBinder binder -> prettyTyVarBinder binder
     PTypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
     PTypeSyntax TypeSyntaxInTerm ty -> prettyType ty

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/fixity-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/fixity-operator.yaml
@@ -5,5 +5,5 @@ input: |
   (<++>) :: [a] -> [a] -> [a]
   (<++>) = (++ )
 ast: |
-  Module {name = "D9", decls = [DeclFixity {assoc = InfixR, prec = 5, ops = ["<++>"]}, DeclTypeSig {names = ["<++>"], type = TFun ArrowUnrestricted (TList [TVar "a"]) (TFun ArrowUnrestricted (TList [TVar "a"]) (TList [TVar "a"]))}, DeclValue (PatternBind NoMultiplicityTag PParen (PVar "<++>") UnguardedRhs (EVar "++"))]}
+  Module {name = "D9", decls = [DeclFixity {assoc = InfixR, prec = 5, ops = ["<++>"]}, DeclTypeSig {names = ["<++>"], type = TFun ArrowUnrestricted (TList [TVar "a"]) (TFun ArrowUnrestricted (TList [TVar "a"]) (TList [TVar "a"]))}, DeclValue (PatternBind NoMultiplicityTag PVar "<++>" UnguardedRhs (EVar "++"))]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/pattern/paren-varsym-single.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pattern/paren-varsym-single.yaml
@@ -1,0 +1,5 @@
+extensions: []
+input: |
+  (+)
+ast: PVar "+"
+status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/pattern-bindings.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/pattern-bindings.yaml
@@ -14,8 +14,10 @@ expected:
     - "2:13-2:14 f => (value) Local 0 f"
     - "2:16-2:17 g => (value) Local 1 g"
     - "2:18-2:19 x => (value) Local 2 x"
+    - "3:1-3:3 .* => (value) Main..*"
     - "3:8-3:11 . => (value) Main.."
     - "3:14-3:17 . => (value) Main.."
+    - "4:1-4:4 .** => (value) Main..**"
     - "4:9-4:12 . => (value) Main.."
     - "4:15-4:19 .* => (value) Main..*"
 annotated:
@@ -30,10 +32,12 @@ annotated:
     │└─ v 0
     └─ v Main
     (.*) = (.) . (.)
-           │     └─ v Main
-           └─ v Main
+    │      │     └─ v Main
+    │      └─ v Main
+    └─ v Main
     (.**) = (.) . (.*)
-            │     └─ v Main
-            └─ v Main
+    │       │     └─ v Main
+    │       └─ v Main
+    └─ v Main
 status: pass
 reason: ""


### PR DESCRIPTION
## Summary
- normalize parenthesized symbolic variable patterns like `(+)` to `PVar "+"` instead of keeping a redundant `PParen`
- restore required parens for symbolic variable patterns in function-head pretty-printing so parser and roundtrip behavior stay consistent
- add a golden parser fixture covering the bare symbolic variable pattern case

## Validation
- ran `just fmt`
- ran `just check`
- verified `echo \"fn (+) = (+)\" | cabal run -v0 exe:aihc-parser -- -XUnboxedTuples -XTemplateHaskell` now produces `pats = [PVar "+"]`

## Progress
- parser-golden progress counts unchanged
- oracle progress counts unchanged