### PR TITLE
fix(parser): handle TH type quotes before constrained signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -896,6 +896,7 @@ startsWithContextType = MP.lookAhead (go [])
       case lexTokenKind tok of
         TkEOF -> pure False
         TkReservedDoubleArrow -> pure True
+        TkReservedDoubleColon -> pure False
         TkReservedRightArrow -> pure False
         TkReservedEquals -> pure False
         TkSpecialComma -> pure False
@@ -905,9 +906,16 @@ startsWithContextType = MP.lookAhead (go [])
         TkSpecialUnboxedRParen -> pure False
         TkSpecialRBracket -> pure False
         TkSpecialRBrace -> pure False
+        TkTHExpQuoteClose -> pure False
+        TkTHTypedQuoteClose -> pure False
         TkSpecialLParen -> go [TkSpecialRParen]
         TkSpecialUnboxedLParen -> go [TkSpecialUnboxedRParen]
         TkSpecialLBracket -> go [TkSpecialRBracket]
+        TkTHExpQuoteOpen -> go [TkTHExpQuoteClose]
+        TkTHTypedQuoteOpen -> go [TkTHTypedQuoteClose]
+        TkTHDeclQuoteOpen -> go [TkTHExpQuoteClose]
+        TkTHTypeQuoteOpen -> go [TkTHExpQuoteClose]
+        TkTHPatQuoteOpen -> go [TkTHExpQuoteClose]
         TkSpecialLBrace -> go [TkSpecialRBrace]
         -- Keywords that cannot appear inside a type expression: stop scanning.
         TkKeywordInstance -> pure False
@@ -928,6 +936,11 @@ startsWithContextType = MP.lookAhead (go [])
         TkSpecialLParen -> go (TkSpecialRParen : stack)
         TkSpecialUnboxedLParen -> go (TkSpecialUnboxedRParen : stack)
         TkSpecialLBracket -> go (TkSpecialRBracket : stack)
+        TkTHExpQuoteOpen -> go (TkTHExpQuoteClose : stack)
+        TkTHTypedQuoteOpen -> go (TkTHTypedQuoteClose : stack)
+        TkTHDeclQuoteOpen -> go (TkTHExpQuoteClose : stack)
+        TkTHTypeQuoteOpen -> go (TkTHExpQuoteClose : stack)
+        TkTHPatQuoteOpen -> go (TkTHExpQuoteClose : stack)
         TkSpecialLBrace -> go (TkSpecialRBrace : stack)
         _ -> go stack
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -14,6 +14,7 @@ import Data.Char (ord)
 import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
 import Data.Maybe (isNothing)
 import Data.Set qualified as Set
+import Data.Text (Text)
 import Data.Text qualified as T
 import Numeric (showHex, showOct)
 import ParserValidation (formatDiff, validateParser)
@@ -132,6 +133,7 @@ buildTests = do
             testCase "pretty-prints negated open-ended expressions inside left sections" test_prettyNegatedOpenEndedSectionLhs,
             testCase "pretty-prints negated open-ended type signature bodies" test_prettyNegatedOpenEndedTypeSigBody,
             testCase "pretty-prints record-dot TH splice bases" test_prettyRecordDotTHSpliceBase,
+            testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
             localOption (QC.QuickCheckTests 2000) $
@@ -814,6 +816,16 @@ test_prettyRecordDotTHSpliceBase = do
             assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
   assertRoundTrips "($q#).j7Msfc" (EGetField (ETHSplice (EVar spliceName)) fieldName)
   assertRoundTrips "($$q#).j7Msfc" (EGetField (ETHTypedSplice (EVar spliceName)) fieldName)
+
+test_thTypeQuoteBeforeConstraintExprSig :: Assertion
+test_thTypeQuoteBeforeConstraintExprSig = do
+  let config = defaultConfig {parserExtensions = [TemplateHaskell, QuasiQuotes]}
+      source :: Text
+      source = "x = [t| C |] :: (:+) => ()"
+  case parseDecl config source of
+    ParseOk _ -> pure ()
+    ParseErr bundle ->
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> MPE.errorBundlePretty bundle)
 
 test_roundtripDiffIsMinimal :: Assertion
 test_roundtripDiffIsMinimal =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/type-quote-constrained-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/type-quote-constrained-signature.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TypeQuoteConstrainedSignature where
+
+x = [t| C |] :: (:+) => ()


### PR DESCRIPTION
## Summary
- fix `startsWithContextType` so Template Haskell quote brackets are treated as balanced delimiters and top-level `::` stops context probing instead of leaking to the outer `=>`
- add parser and oracle regressions for `x = [t| C |] :: (:+) => ()`
- Progress counts unchanged: pass=1590 xfail=0 xpass=0 fail=0

## Verification
- `printf '%s\n' 'x = [t| C |] :: (:+) => ()' | cabal run -v0 aihc-dev -- snippet -XTemplateHaskell -XQuasiQuotes -XTypeOperators`
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` could not run because the service reported an hourly cap / usage limit.