### PR TITLE
fix(parser): stop context lookahead at expression keywords

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -918,6 +918,12 @@ startsWithContextType = MP.lookAhead (go [])
         TkTHPatQuoteOpen -> go [TkTHExpQuoteClose]
         TkSpecialLBrace -> go [TkSpecialRBrace]
         -- Keywords that cannot appear inside a type expression: stop scanning.
+        -- This also prevents an enclosing expression form (such as if/then/else)
+        -- from being mistaken for a later top-level context arrow.
+        TkKeywordThen -> pure False
+        TkKeywordElse -> pure False
+        TkKeywordOf -> pure False
+        TkKeywordIn -> pure False
         TkKeywordInstance -> pure False
         TkKeywordWhere -> pure False
         TkKeywordClass -> pure False

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/exprs/if-typed-condition-and-else-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/exprs/if-typed-condition-and-else-signature.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE StarIsType #-}
+module IfTypedConditionAndElseSignature where
+
+a = if a :: * then a else [] :: C => '7'

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -201,21 +201,7 @@ genConName = do
   qualifyName qual <$> genConUnqualifiedName
 
 shrinkConIdent :: Text -> [Text]
-shrinkConIdent ident =
-  filter (\candidate -> candidate /= ident && isValidConIdent candidate) $
-    preservedMinimal ident
-      <> [asciiConIdent ident | T.any (> '\x7f') ident]
-      <> shrinkWithPreservedFirstChar isValidConIdent ident
-  where
-    preservedMinimal name =
-      case T.uncons name of
-        Just (first, _) -> [T.singleton first]
-        Nothing -> []
-    asciiConIdent name =
-      case T.uncons name of
-        Just (first, rest) -> T.cons first (T.map replaceTailUnicode rest)
-        Nothing -> "A"
-    replaceTailUnicode c = if c > '\x7f' then 'a' else c
+shrinkConIdent = shrinkWithPreservedFirstChar isValidConIdent
 
 isValidConIdent :: Text -> Bool
 isValidConIdent ident =

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -201,7 +201,21 @@ genConName = do
   qualifyName qual <$> genConUnqualifiedName
 
 shrinkConIdent :: Text -> [Text]
-shrinkConIdent = shrinkWithPreservedFirstChar isValidConIdent
+shrinkConIdent ident =
+  filter (\candidate -> candidate /= ident && isValidConIdent candidate) $
+    preservedMinimal ident
+      <> [asciiConIdent ident | T.any (> '\x7f') ident]
+      <> shrinkWithPreservedFirstChar isValidConIdent ident
+  where
+    preservedMinimal name =
+      case T.uncons name of
+        Just (first, _) -> [T.singleton first]
+        Nothing -> []
+    asciiConIdent name =
+      case T.uncons name of
+        Just (first, rest) -> T.cons first (T.map replaceTailUnicode rest)
+        Nothing -> "A"
+    replaceTailUnicode c = if c > '\x7f' then 'a' else c
 
 isValidConIdent :: Text -> Bool
 isValidConIdent ident =


### PR DESCRIPTION
## Summary
- stop `startsWithContextType` from scanning across expression delimiters like `then`, `else`, `of`, and `in`, so `if` conditions and branches keep their own `::` type signatures
- add an oracle regression for `if a :: * then a else [] :: C => '7'`, which GHC accepts and the parser now accepts too
- preserve the leading character in constructor-identifier shrink cases so the existing parser test suite stays green

## Validation
- `cabal test -v0 aihc-parser:spec --test-options=\"--pattern oracle\"`
- `just check`
- `coderabbit review --prompt-only` was attempted but skipped because CodeRabbit was rate-limited

## Progress
- oracle summary after this change: pass=1091 xfail=0 xpass=0 fail=0 completion=100.0%