### PR TITLE
fix(parser): parenthesize applied view type signatures

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -152,6 +152,7 @@ endsWithTypeSig = \case
   ELetDecls _ body -> endsWithTypeSig body
   ELambdaPats _ body -> endsWithTypeSig body
   EInfix _ _ rhs -> endsWithTypeSig rhs
+  EApp _ arg -> endsWithTypeSig arg
   EIf _ _ no -> endsWithTypeSig no
   _ -> False
 
@@ -293,6 +294,7 @@ needsExprParens ctx expr =
         _ -> False
     CtxAppArg ->
       case expr of
+        _ | endsWithTypeSig expr -> True
         _ | isBlockExpr expr -> False
         -- A pragma as a function argument needs parens: `fn {-# P #-} x` is
         -- ambiguous; `fn ({-# P #-} x)` is unambiguous.
@@ -1036,7 +1038,7 @@ addAppsChainPrec prec expr =
       nArgs = length args
       args' =
         [ let isLast = i == nArgs - 1
-              canStayBare = isBlockExpr a && (isLast || not (isOpenEnded a))
+              canStayBare = isBlockExpr a && not (endsWithTypeSig a) && (isLast || not (isOpenEnded a))
               ctx
                 | canStayBare = CtxAppArgNoParens
                 | isLast = CtxAppArg

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -6,7 +6,7 @@ module Main (main) where
 import Aihc.Cpp (resultOutput)
 import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
-import Aihc.Parser.Parens (addDeclParens, addExprParens)
+import Aihc.Parser.Parens (addDeclParens, addExprParens, addPatternParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
@@ -134,6 +134,7 @@ buildTests = do
             testCase "pretty-prints record-dot TH splice bases" test_prettyRecordDotTHSpliceBase,
             testCase "pretty-prints symbolic deriving classes as prefix constructors" test_prettySymbolicDerivingClass,
             testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
+            testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
             localOption (QC.QuickCheckTests 2000) $
@@ -857,6 +858,31 @@ test_thTypeQuoteBeforeConstraintExprSig = do
     ParseOk _ -> pure ()
     ParseErr bundle ->
       assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> MPE.errorBundlePretty bundle)
+
+test_viewExprAppliedTypeSigParens :: Assertion
+test_viewExprAppliedTypeSigParens = do
+  let config = defaultConfig {parserExtensions = [BlockArguments, DataKinds, ViewPatterns]}
+      varA = qualifyName Nothing (mkUnqualifiedName NameVarId "a")
+      conC = qualifyName Nothing (mkUnqualifiedName NameConId "C")
+      pat =
+        PView
+          ( EApp
+              (EList [])
+              ( EIf
+                  (EVar varA)
+                  (EVar varA)
+                  (ETypeSig (EList []) (TFun ArrowUnrestricted (TCon conC Promoted) (TCon conC Unpromoted)))
+              )
+          )
+          (PCon conC [] [])
+      parenthesized = addPatternParens pat
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty parenthesized))
+  assertEqual "rendered pattern" "(([] (if a then a else [] :: 'C -> C)) -> C)" rendered
+  case parsePattern config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed pattern" (stripAnnotations parenthesized) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed pattern to reparse, got:\n" <> MPE.errorBundlePretty bundle)
 
 test_roundtripDiffIsMinimal :: Assertion
 test_roundtripDiffIsMinimal =


### PR DESCRIPTION
## Summary
- detect application expressions whose rendered form ends in a type signature
- parenthesize block application arguments ending in type signatures so view-pattern parsing keeps the signature on the argument
- add a regression test for the minimized view-pattern case

## Progress counts
- No README progress counts changed; this parser pretty-printer fix does not affect progress fixtures.

## Checks
- just replay "(SMGen 2557039091854712494 5226721794849871027,45)"
- cabal test -v0 aihc-parser:spec --test-options='--pattern "/parenthesizes view expressions ending with applied type signatures/" --hide-successes'
- just fmt
- just check
- coderabbit review --prompt-only: no findings