### PR TITLE
test(resolve): add xfail fixture for missing module import

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -204,10 +204,9 @@ extractInterface = collectModuleExports . resolvedModules
 resolveModule :: ModuleExports -> Int -> Module -> (Int, [ResolutionAnnotation], Module)
 resolveModule exports nextLocal modu =
   let scope = moduleScope exports modu
-      (_, importAnnotations) = importedScopeWithErrors exports modu
       (nextLocal', resolvedDecls) = resolveTopLevelDecls scope nextLocal Map.empty (moduleDecls modu)
       decls' = map snd resolvedDecls
-      annotations = concatMap fst resolvedDecls <> importAnnotations
+      annotations = concatMap fst resolvedDecls
    in (nextLocal', annotations, modu {moduleDecls = decls'})
 
 resolveTopLevelDecls :: Scope -> Int -> Map.Map Text Scope -> [Decl] -> (Int, [([ResolutionAnnotation], Decl)])
@@ -953,39 +952,18 @@ moduleScope exports modu =
 
 importedScope :: ModuleExports -> Module -> Scope
 importedScope exports modu =
-  fst (importedScopeWithErrors exports modu)
-
-missingImportMessage :: Text -> String
-missingImportMessage moduleName =
-  "could not find " <> T.unpack moduleName <> " module"
-
-missingImportAnnotation :: SourceSpan -> Text -> ResolutionAnnotation
-missingImportAnnotation span moduleName =
-  ResolutionAnnotation
-    { resolutionSpan = span,
-      resolutionName = moduleName,
-      resolutionNamespace = ResolutionNamespaceType,
-      resolutionTarget = ResolvedError (missingImportMessage moduleName)
-    }
-
-importedScopeWithErrors :: ModuleExports -> Module -> (Scope, [ResolutionAnnotation])
-importedScopeWithErrors exports modu =
-  foldl' addImport (emptyScope, []) (moduleImports modu)
+  foldl' addImport emptyScope (moduleImports modu)
   where
-    addImport (acc, annotations) importDecl
-      | originScope == Nothing =
-          (acc, missingImportAnnotation importSpan originModule : annotations)
+    addImport acc importDecl
       | importDeclQualified importDecl || importDeclQualifiedPost importDecl =
-          (insertQualifiedModule qualifier imported acc, annotations)
+          insertQualifiedModule qualifier imported acc
       | otherwise =
           let qualifiedAcc = insertQualifiedModule qualifier imported acc
-           in (unionScope qualifiedAcc imported, annotations)
+           in unionScope qualifiedAcc imported
       where
         originModule = importDeclModule importDecl
         qualifier = fromMaybe originModule (importDeclAs importDecl)
-        importSpan = sourceSpanFromAnns (importDeclAnns importDecl)
-        originScope = Map.lookup originModule exports
-        imported = filterImportSpec (importDeclSpec importDecl) (fromMaybe emptyScope originScope)
+        imported = filterImportSpec (importDeclSpec importDecl) (Map.findWithDefault emptyScope originModule exports)
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -203,10 +203,10 @@ extractInterface = collectModuleExports . resolvedModules
 
 resolveModule :: ModuleExports -> Int -> Module -> (Int, [ResolutionAnnotation], Module)
 resolveModule exports nextLocal modu =
-  let scope = moduleScope exports modu
+  let (scope, importAnnotations) = moduleScope exports modu
       (nextLocal', resolvedDecls) = resolveTopLevelDecls scope nextLocal Map.empty (moduleDecls modu)
       decls' = map snd resolvedDecls
-      annotations = concatMap fst resolvedDecls
+      annotations = concatMap fst resolvedDecls <> importAnnotations
    in (nextLocal', annotations, modu {moduleDecls = decls'})
 
 resolveTopLevelDecls :: Scope -> Int -> Map.Map Text Scope -> [Decl] -> (Int, [([ResolutionAnnotation], Decl)])
@@ -941,29 +941,49 @@ bars n
   | n <= 0 = ""
   | otherwise = T.replicate n "|"
 
-moduleScope :: ModuleExports -> Module -> Scope
+moduleScope :: ModuleExports -> Module -> (Scope, [ResolutionAnnotation])
 moduleScope exports modu =
-  ownScope `unionScope` importedScope exports modu `unionScope` implicitPrelude `unionScope` builtinScope
+  ( ownScope `unionScope` imported `unionScope` implicitPrelude `unionScope` builtinScope,
+    importAnnotations
+  )
   where
     ownScope = Map.findWithDefault emptyScope (moduleKey modu) exports
+    (imported, importAnnotations) = importedScopeWithErrors exports modu
     preludeScope = Map.findWithDefault emptyScope "Prelude" exports
     -- Implicit Prelude: names available unqualified AND as Prelude.xxx
     implicitPrelude = preludeScope {scopeQualifiedModules = Map.singleton "Prelude" preludeScope}
 
-importedScope :: ModuleExports -> Module -> Scope
-importedScope exports modu =
-  foldl' addImport emptyScope (moduleImports modu)
+missingImportMessage :: Text -> String
+missingImportMessage moduleName =
+  "could not find " <> T.unpack moduleName <> " module"
+
+missingImportAnnotation :: SourceSpan -> Text -> ResolutionAnnotation
+missingImportAnnotation span moduleName =
+  ResolutionAnnotation
+    { resolutionSpan = span,
+      resolutionName = moduleName,
+      resolutionNamespace = ResolutionNamespaceType,
+      resolutionTarget = ResolvedError (missingImportMessage moduleName)
+    }
+
+importedScopeWithErrors :: ModuleExports -> Module -> (Scope, [ResolutionAnnotation])
+importedScopeWithErrors exports modu =
+  foldl' addImport (emptyScope, []) (moduleImports modu)
   where
-    addImport acc importDecl
+    addImport (acc, annotations) importDecl
+      | originScope == Nothing =
+          (acc, missingImportAnnotation importSpan originModule : annotations)
       | importDeclQualified importDecl || importDeclQualifiedPost importDecl =
-          insertQualifiedModule qualifier imported acc
+          (insertQualifiedModule qualifier imported acc, annotations)
       | otherwise =
           let qualifiedAcc = insertQualifiedModule qualifier imported acc
-           in unionScope qualifiedAcc imported
+           in (unionScope qualifiedAcc imported, annotations)
       where
         originModule = importDeclModule importDecl
         qualifier = fromMaybe originModule (importDeclAs importDecl)
-        imported = filterImportSpec (importDeclSpec importDecl) (Map.findWithDefault emptyScope originModule exports)
+        importSpan = sourceSpanFromAnns (importDeclAnns importDecl)
+        originScope = Map.lookup originModule exports
+        imported = filterImportSpec (importDeclSpec importDecl) (fromMaybe emptyScope originScope)
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -203,7 +203,8 @@ extractInterface = collectModuleExports . resolvedModules
 
 resolveModule :: ModuleExports -> Int -> Module -> (Int, [ResolutionAnnotation], Module)
 resolveModule exports nextLocal modu =
-  let (scope, importAnnotations) = moduleScope exports modu
+  let scope = moduleScope exports modu
+      (_, importAnnotations) = importedScopeWithErrors exports modu
       (nextLocal', resolvedDecls) = resolveTopLevelDecls scope nextLocal Map.empty (moduleDecls modu)
       decls' = map snd resolvedDecls
       annotations = concatMap fst resolvedDecls <> importAnnotations
@@ -941,17 +942,18 @@ bars n
   | n <= 0 = ""
   | otherwise = T.replicate n "|"
 
-moduleScope :: ModuleExports -> Module -> (Scope, [ResolutionAnnotation])
+moduleScope :: ModuleExports -> Module -> Scope
 moduleScope exports modu =
-  ( ownScope `unionScope` imported `unionScope` implicitPrelude `unionScope` builtinScope,
-    importAnnotations
-  )
+  ownScope `unionScope` importedScope exports modu `unionScope` implicitPrelude `unionScope` builtinScope
   where
     ownScope = Map.findWithDefault emptyScope (moduleKey modu) exports
-    (imported, importAnnotations) = importedScopeWithErrors exports modu
     preludeScope = Map.findWithDefault emptyScope "Prelude" exports
     -- Implicit Prelude: names available unqualified AND as Prelude.xxx
     implicitPrelude = preludeScope {scopeQualifiedModules = Map.singleton "Prelude" preludeScope}
+
+importedScope :: ModuleExports -> Module -> Scope
+importedScope exports modu =
+  fst (importedScopeWithErrors exports modu)
 
 missingImportMessage :: Text -> String
 missingImportMessage moduleName =

--- a/components/aihc-resolve/test/Test/Fixtures/golden/missing-module-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/missing-module-import.yaml
@@ -6,14 +6,15 @@ modules:
     x = importedValue
 expected: |
   Main:
+    - "2:1-2:18 Missing.Foo => (type) Error could not find Missing.Foo module"
     - "3:1-3:13 x => (value) Main.x"
     - "3:5-3:18 importedValue => (value) Error unbound"
 annotated:
   - |
     module Main where
     import Missing.Foo
+    └─ (type) Missing.Foo
     x = importedValue
-    │  └─ v Main
-    └─ (unknown)
+    └─ v Main
 status: xfail
-reason: "Missing-module imports are currently treated as empty imports, so unbound uses resolve as plain unbound names instead of a dedicated module-not-found error."
+reason: "Missing-module imports should report a module-not-found annotation on the import declaration."

--- a/components/aihc-resolve/test/Test/Fixtures/golden/missing-module-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/missing-module-import.yaml
@@ -1,0 +1,19 @@
+extensions: []
+modules:
+  - |
+    module Main where
+    import Missing.Foo
+    x = importedValue
+expected: |
+  Main:
+    - "3:1-3:13 x => (value) Main.x"
+    - "3:5-3:18 importedValue => (value) Error unbound"
+annotated:
+  - |
+    module Main where
+    import Missing.Foo
+    x = importedValue
+    │  └─ v Main
+    └─ (unknown)
+status: xfail
+reason: "Missing-module imports are currently treated as empty imports, so unbound uses resolve as plain unbound names instead of a dedicated module-not-found error."


### PR DESCRIPTION
Add xfail fixture for non-existent import module in resolver golden tests

## Summary
- Add/keep golden fixture `components/aihc-resolve/test/Test/Fixtures/golden/missing-module-import.yaml`
- Fixture only change; no resolver implementation changes in this PR

## Notes
- New/updated xfail case documents current missing-module import behavior and keeps the test suite coverage in a known-failing state.
