### PR TITLE
feat: add README progress circles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Find more information here:
 
 | Name               | Progress                                                                                                                             |
 | ------------------ | -----------------------------------------------------------------------------------------------------------------------------------: |
-| TypeCheck Stackage | `0/3390` (`0.00%`)                                                                                                                   |
-| Resolve Stackage   | <!-- AUTO-GENERATED: START resolve-stackage-progress --> `330/3427` (`9.63%`) <!-- AUTO-GENERATED: END resolve-stackage-progress -->  |
-| Parser Stackage    | <!-- AUTO-GENERATED: START parser-stackage-progress --> `3330/3427` (`97.17%`) <!-- AUTO-GENERATED: END parser-stackage-progress --> |
-| TypeCheck Tests    | <!-- AUTO-GENERATED: START tc-progress --> `12/29` (`41.37%`) <!-- AUTO-GENERATED: END tc-progress -->                                |
-| Resolve Tests      | <!-- AUTO-GENERATED: START resolve-progress --> `19/21` (`90.47%`) <!-- AUTO-GENERATED: END resolve-progress -->                      |
-| Parser Tests       | <!-- AUTO-GENERATED: START parser-progress --> `2065/2069` (`99.81%`) <!-- AUTO-GENERATED: END parser-progress -->                     |
-| Lexer Tests        | <!-- AUTO-GENERATED: START lexer-progress --> `102/102` (`100.00%`) <!-- AUTO-GENERATED: END lexer-progress -->                        |
-| CPP Tests          | <!-- AUTO-GENERATED: START cpp-progress --> `43/43` (`100.00%`) <!-- AUTO-GENERATED: END cpp-progress -->                            |
+| TypeCheck Stackage | `0/3390` (`0.00%`) ○○○○○                                                                                                              |
+| Resolve Stackage   | <!-- AUTO-GENERATED: START resolve-stackage-progress --> `330/3427` (`9.63%`) ○○○○○ <!-- AUTO-GENERATED: END resolve-stackage-progress -->  |
+| Parser Stackage    | <!-- AUTO-GENERATED: START parser-stackage-progress --> `3330/3427` (`97.17%`) ●●●●○ <!-- AUTO-GENERATED: END parser-stackage-progress --> |
+| TypeCheck Tests    | <!-- AUTO-GENERATED: START tc-progress --> `12/29` (`41.37%`) ●●○○○ <!-- AUTO-GENERATED: END tc-progress -->                                |
+| Resolve Tests      | <!-- AUTO-GENERATED: START resolve-progress --> `19/21` (`90.47%`) ●●●●○ <!-- AUTO-GENERATED: END resolve-progress -->                      |
+| Parser Tests       | <!-- AUTO-GENERATED: START parser-progress --> `2072/2076` (`99.81%`) ●●●●○ <!-- AUTO-GENERATED: END parser-progress -->                     |
+| Lexer Tests        | <!-- AUTO-GENERATED: START lexer-progress --> `102/102` (`100.00%`) ●●●●● <!-- AUTO-GENERATED: END lexer-progress -->                        |
+| CPP Tests          | <!-- AUTO-GENERATED: START cpp-progress --> `43/43` (`100.00%`) ●●●●● <!-- AUTO-GENERATED: END cpp-progress -->                            |
 
 ## Lines of code
 
@@ -34,11 +34,11 @@ Find more information here:
 |-----------------|--------|---------|---------|
 | aihc-cpp        |   1701 |     688 |    2389 |
 | aihc-fc         |    887 |     262 |    1149 |
-| aihc-parser     |  12558 |   16300 |   28858 |
+| aihc-parser     |  12523 |   15030 |   27553 |
 | aihc-parser-cli |   1970 |     430 |    2400 |
-| aihc-resolve    |   1420 |    1814 |    3234 |
+| aihc-resolve    |   1392 |    1183 |    2575 |
 | aihc-tc         |   1853 |    1004 |    2857 |
-| **Total**       |  20389 |   20498 |   40887 |
+| **Total**       |  20326 |   18597 |   38923 |
 ```
 <!-- AUTO-GENERATED: END line-counts -->
 

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -19,7 +19,7 @@ Runtime outcomes are reported as:
 
 Current progress baseline:
 <!-- AUTO-GENERATED: START haskell2010-progress -->
-- `1081/1083` implemented (`99.81%` complete)
+- `1082/1084` implemented (`99.81%` complete)
 <!-- AUTO-GENERATED: END haskell2010-progress -->
 
 ## Extension Coverage Tracking

--- a/docs/aihc-parser-supported-extensions.md
+++ b/docs/aihc-parser-supported-extensions.md
@@ -17,14 +17,14 @@
 | CApiFFI                   |   🟢    | 4/4           |
 | ConstraintKinds           |   🟢    | 7/7           |
 | CPP                       |   🟢    | 8/8           |
-| DataKinds                 |   🟢    | 55/55         |
+| DataKinds                 |   🟢    | 56/56         |
 | DefaultSignatures         |   🟢    | 4/4           |
 | DerivingStrategies        |   🟢    | 8/8           |
-| DerivingVia               |   🟢    | 6/6           |
+| DerivingVia               |   🟢    | 7/7           |
 | DoAndIfThenElse           |   🟢    | 15/15         |
 | EmptyCase                 |   🟢    | 4/4           |
 | EmptyDataDecls            |   🟢    | 8/8           |
-| EmptyDataDeriving         |   🟢    | 3/3           |
+| EmptyDataDeriving         |   🟢    | 4/4           |
 | ExistentialQuantification |   🟢    | 7/7           |
 | ExplicitForAll            |   🟢    | 25/25         |
 | ExplicitLevelImports      |   🟢    | 4/4           |
@@ -44,7 +44,7 @@
 | ImportQualifiedPost       |   🟢    | 5/5           |
 | InstanceSigs              |   🟢    | 5/5           |
 | InterruptibleFFI          |   🟢    | 1/1           |
-| KindSignatures            |   🟢    | 28/28         |
+| KindSignatures            |   🟢    | 29/29         |
 | LambdaCase                |   🟢    | 15/15         |
 | LinearTypes               |   🟢    | 14/14         |
 | MagicHash                 |   🟢    | 19/19         |
@@ -76,7 +76,7 @@
 | ScopedTypeVariables       |   🟢    | 18/18         |
 | StandaloneDeriving        |   🟢    | 18/18         |
 | StandaloneKindSignatures  |   🟢    | 11/11         |
-| StarIsType                |   🟢    | 2/2           |
+| StarIsType                |   🟢    | 3/3           |
 | TemplateHaskell           |   🟡    | 45/47         |
 | TemplateHaskellQuotes     |   🟢    | 13/13         |
 | TransformListComp         |   🟢    | 13/13         |
@@ -86,7 +86,7 @@
 | TypeData                  |   🟢    | 1/1           |
 | TypeFamilies              |   🟢    | 56/56         |
 | TypeFamilyDependencies    |   🟢    | 3/3           |
-| TypeOperators             |   🟢    | 66/66         |
+| TypeOperators             |   🟢    | 67/67         |
 | TypeSynonymInstances      |   🟢    | 1/1           |
 | UnboxedSums               |   🟢    | 8/8           |
 | UnboxedTuples             |   🟢    | 19/19         |

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -212,6 +212,27 @@ parse_resolve_stackage_progress() {
   ' "$infile"
 }
 
+progress_circles() {
+	local complete="$1"
+	awk -v complete="$complete" '
+    BEGIN {
+      filled = int(complete / 20)
+      if (filled < 0) {
+        filled = 0
+      } else if (filled > 5) {
+        filled = 5
+      }
+
+      for (i = 1; i <= filled; i++) {
+        printf "●"
+      }
+      for (i = filled + 1; i <= 5; i++) {
+        printf "○"
+      }
+    }
+  '
+}
+
 parser_vals=($(parse_progress "$parser_out")) || {
 	echo "update-generated-content.sh: could not parse parser-progress summary (expected PASS/XFAIL/XPASS/FAIL/TOTAL/COMPLETE on stdout)." >&2
 	exit 2
@@ -306,37 +327,44 @@ resolve_stackage_complete="${resolve_stackage_vals[2]}"
 parser_total_tests=$((parser_total + ext_test_total))
 parser_passing_tests=$((parser_implemented + ext_implemented))
 parser_total_complete="$(awk -v passing="$parser_passing_tests" -v total="$parser_total_tests" 'BEGIN { if (total <= 0) { printf "0.00" } else { printf "%.2f", (passing * 100.0) / total } }')"
+parser_total_circles="$(progress_circles "$parser_total_complete")"
+cpp_circles="$(progress_circles "$cpp_complete")"
+stackage_circles="$(progress_circles "$stackage_complete")"
+resolve_stackage_circles="$(progress_circles "$resolve_stackage_complete")"
+lexer_circles="$(progress_circles "$lexer_complete")"
+resolve_circles="$(progress_circles "$resolve_complete")"
+tc_circles="$(progress_circles "$tc_complete")"
 
 # extract extension name lists (alphabetically sorted, comma-separated) from the markdown table if present
 ext_supported_names="$(awk -F'|' 'BEGIN{names=""} /^\|/ { status=$3; name=$2; gsub(/^[ \t]+|[ \t]+$/, "", name); gsub(/^[ \t]+|[ \t]+$/, "", status); if (status == "Supported") { if (names=="") names=name; else names=names ", " name } } END{ print names }' "$extension_out")"
 ext_in_progress_names="$(awk -F'|' 'BEGIN{names=""} /^\|/ { status=$3; name=$2; gsub(/^[ \t]+|[ \t]+$/, "", name); gsub(/^[ \t]+|[ \t]+$/, "", status); if (status == "In Progress") { if (names=="") names=name; else names=names ", " name } } END{ print names }' "$extension_out")"
 
 cat >"$tmpdir/readme-root-parser.txt" <<EOF2
-\`${parser_passing_tests}/${parser_total_tests}\` (\`${parser_total_complete}%\`)
+\`${parser_passing_tests}/${parser_total_tests}\` (\`${parser_total_complete}%\`) ${parser_total_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-cpp.txt" <<EOF2
-\`${cpp_implemented}/${cpp_total}\` (\`${cpp_complete}%\`)
+\`${cpp_implemented}/${cpp_total}\` (\`${cpp_complete}%\`) ${cpp_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-stackage.txt" <<EOF2
-\`${stackage_implemented}/${stackage_total}\` (\`${stackage_complete}%\`)
+\`${stackage_implemented}/${stackage_total}\` (\`${stackage_complete}%\`) ${stackage_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-resolve-stackage.txt" <<EOF2
-\`${resolve_stackage_implemented}/${resolve_stackage_total}\` (\`${resolve_stackage_complete}%\`)
+\`${resolve_stackage_implemented}/${resolve_stackage_total}\` (\`${resolve_stackage_complete}%\`) ${resolve_stackage_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-lexer.txt" <<EOF2
-\`${lexer_implemented}/${lexer_total}\` (\`${lexer_complete}%\`)
+\`${lexer_implemented}/${lexer_total}\` (\`${lexer_complete}%\`) ${lexer_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-resolve.txt" <<EOF2
-\`${resolve_implemented}/${resolve_total}\` (\`${resolve_complete}%\`)
+\`${resolve_implemented}/${resolve_total}\` (\`${resolve_complete}%\`) ${resolve_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-tc.txt" <<EOF2
-\`${tc_implemented}/${tc_total}\` (\`${tc_complete}%\`)
+\`${tc_implemented}/${tc_total}\` (\`${tc_complete}%\`) ${tc_circles}
 EOF2
 
 cat >"$tmpdir/readme-parser-h2010.txt" <<EOF2


### PR DESCRIPTION
## Summary
- Add five-character Unicode progress circles to generated root README progress entries.
- Refresh generated progress artifacts so the README shows: TypeCheck Stackage 0/3390, Resolve Stackage 330/3427, Parser Stackage 3330/3427, TypeCheck Tests 12/29, Resolve Tests 19/21, Parser Tests 2072/2076, Lexer Tests 102/102, CPP Tests 43/43.
- Keep the static TypeCheck Stackage row visually consistent with the generated rows.

## Verification
- scripts/update-generated-content.sh --update
- scripts/update-generated-content.sh --check
- just fmt
- just check
- coderabbit review --prompt-only: no findings
