### PR TITLE
ci: use pinned GitHub Ubuntu runner fallback

### DIFF
--- a/.github/workflows/generated-reports-update.yml
+++ b/.github/workflows/generated-reports-update.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           runner-label: ${{ vars.CI_SELF_HOSTED_RUNNER_LABEL != '' && vars.CI_SELF_HOSTED_RUNNER_LABEL || 'aihc-lima' }}
-          fallback-runner: ${{ vars.CI_HOSTED_FALLBACK_RUNNER != '' && vars.CI_HOSTED_FALLBACK_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          fallback-runner: ${{ vars.CI_HOSTED_FALLBACK_RUNNER != '' && vars.CI_HOSTED_FALLBACK_RUNNER || 'ubuntu-24.04' }}
           runner-token: ${{ secrets.SELF_HOSTED_RUNNER_ADMIN_TOKEN != '' && secrets.SELF_HOSTED_RUNNER_ADMIN_TOKEN || secrets.AUTOMATION_PR_TOKEN }}
           allow-self-hosted: true
 

--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           runner-label: ${{ vars.CI_SELF_HOSTED_RUNNER_LABEL != '' && vars.CI_SELF_HOSTED_RUNNER_LABEL || 'aihc-lima' }}
-          fallback-runner: ${{ vars.CI_HOSTED_FALLBACK_RUNNER != '' && vars.CI_HOSTED_FALLBACK_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          fallback-runner: ${{ vars.CI_HOSTED_FALLBACK_RUNNER != '' && vars.CI_HOSTED_FALLBACK_RUNNER || 'ubuntu-24.04' }}
           runner-token: ${{ secrets.SELF_HOSTED_RUNNER_ADMIN_TOKEN != '' && secrets.SELF_HOSTED_RUNNER_ADMIN_TOKEN || secrets.AUTOMATION_PR_TOKEN }}
           allow-self-hosted: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 


### PR DESCRIPTION
## Summary
- switch the fallback hosted runner in selected workflow jobs from blacksmith to GitHub-hosted ubuntu-24.04
- keeps self-hosted-first selection logic, only changes hosted fallback default

## Testing
- not run (workflow-only config change)