### PR TITLE
test: add xfail golden cases for missing explicit imports

### DIFF
--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-constructor.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-constructor.yaml
@@ -1,0 +1,12 @@
+extensions: []
+modules:
+  - |
+    module ValidModule where
+    data FoundType = FoundConstructor
+  - |
+    module Main where
+    import ValidModule (FoundType(MissingConstructor))
+    x = MissingConstructor
+status: xfail
+reason: "Imports with explicit constructors do not validate constructor availability; missing constructors are not rejected on the import."
+annotated: []

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type-wildcard.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type-wildcard.yaml
@@ -1,0 +1,13 @@
+extensions: []
+modules:
+  - |
+    module ValidModule where
+    data FoundType = FoundConstructor
+  - |
+    module Main where
+    import ValidModule (MissingType(..))
+    x :: MissingType
+    x = 1
+status: xfail
+reason: "Type wildcard imports of missing types are not explicitly reported; missing type names are only caught indirectly."
+annotated: []

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type.yaml
@@ -1,0 +1,13 @@
+extensions: []
+modules:
+  - |
+    module ValidModule where
+    data FoundType = FoundConstructor
+  - |
+    module Main where
+    import ValidModule (MissingType)
+    x :: MissingType
+    x = 1
+status: xfail
+reason: "Missing type imports are not diagnosed at import time, so the missing type only surfaces as downstream name resolution failures."
+annotated: []

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-value.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-value.yaml
@@ -1,0 +1,13 @@
+extensions: []
+modules:
+  - |
+    module ValidModule where
+    valid_fn :: Int
+    valid_fn = 1
+  - |
+    module Main where
+    import ValidModule (missing_fn)
+    x = missing_fn
+status: xfail
+reason: "Missing value imports are not detected as import-level errors when the imported name is absent."
+annotated: []


### PR DESCRIPTION
## Summary
- Add four resolver golden fixtures for explicit import list miss cases against an existing `ValidModule`:
  - `import ValidModule (missing_fn)`
  - `import ValidModule (MissingType)`
  - `import ValidModule (MissingType(..))`
  - `import ValidModule (FoundType(MissingConstructor))`
- Mark each as `status: xfail` with rationale since these are known gaps.

## Progress
- pass: 0
- xfail: 4
- xpass: 0
- fail: 0
