### PR TITLE
fix(resolve): report missing import items

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -39,6 +39,7 @@ import Aihc.Parser.Syntax
     GadtBody (..),
     GuardQualifier (..),
     GuardedRhs (..),
+    IEBundledMember (..),
     ImportDecl (..),
     ImportItem (..),
     ImportLevel (..),
@@ -59,6 +60,7 @@ import Aihc.Parser.Syntax
     ValueDecl (..),
     binderHeadName,
     fromAnnotation,
+    getImportItemSourceSpan,
     mkAnnotation,
     mkQualifiedName,
     mkUnqualifiedName,
@@ -69,9 +71,10 @@ import Aihc.Parser.Syntax
     renderUnqualifiedName,
   )
 import Aihc.Resolve.Types
+import Control.Applicative ((<|>))
 import Data.Bifunctor
 import Data.Data (Data, cast, gmapQ)
-import Data.List (mapAccumL)
+import Data.List (find, mapAccumL)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
@@ -155,7 +158,7 @@ declResolutionErrors maybeDecl =
 importResolutionErrors :: Maybe ImportDecl -> [ResolveError]
 importResolutionErrors maybeImport =
   case maybeImport of
-    Just (ImportResolution resolution) -> maybeToList (annotationResolveError resolution)
+    Just importDecl -> mapMaybe annotationResolveError (mapMaybe fromAnnotation (importDeclAnns importDecl))
     _ -> []
 
 patternResolutionErrors :: Maybe Pattern -> [ResolveError]
@@ -225,7 +228,8 @@ resolveModuleImports exports =
   map resolveModuleImport
   where
     resolveModuleImport importDecl
-      | Map.member (importDeclModule importDecl) exports = importDecl
+      | Just originScope <- Map.lookup (importDeclModule importDecl) exports =
+          annotateImportErrors (missingImportItemAnnotations originScope importDecl) importDecl
       | otherwise = annotateImport (missingModuleImportAnnotation importDecl) importDecl
 
 missingModuleImportAnnotation :: ImportDecl -> ResolutionAnnotation
@@ -236,6 +240,75 @@ missingModuleImportAnnotation importDecl =
         importedModule
         ResolutionNamespaceModule
         (ResolvedError "not found")
+
+missingImportItemAnnotations :: Scope -> ImportDecl -> [ResolutionAnnotation]
+missingImportItemAnnotations originScope importDecl =
+  case importDeclSpec importDecl of
+    Just ImportSpec {importSpecHiding = False, importSpecItems} ->
+      mapMaybe (missingImportItemAnnotation originScope) importSpecItems
+    _ -> []
+
+missingImportItemAnnotation :: Scope -> ImportItem -> Maybe ResolutionAnnotation
+missingImportItemAnnotation originScope item =
+  go item
+  where
+    go current =
+      case current of
+        ImportAnn _ sub -> go sub
+        ImportItemVar _ itemName ->
+          missingImportedName item ResolutionNamespaceTerm itemName (scopeTerms originScope)
+        ImportItemAbs _ itemName ->
+          missingImportedName item ResolutionNamespaceType itemName (scopeTypes originScope)
+        ImportItemAll _ itemName ->
+          missingImportedName item ResolutionNamespaceType itemName (scopeTypes originScope)
+        ImportItemWith _ itemName members ->
+          missingImportedName item ResolutionNamespaceType itemName (scopeTypes originScope)
+            <|> missingImportMemberAnnotation originScope item members
+        ImportItemAllWith _ itemName _ members ->
+          missingImportedName item ResolutionNamespaceType itemName (scopeTypes originScope)
+            <|> missingImportMemberAnnotation originScope item members
+
+missingImportMemberAnnotation :: Scope -> ImportItem -> [IEBundledMember] -> Maybe ResolutionAnnotation
+missingImportMemberAnnotation originScope item members =
+  missingMemberAnnotation <$> find missingMember members
+  where
+    missingMember member = Map.notMember (nameText (ieBundledMemberName member)) (scopeTerms originScope)
+    missingMemberAnnotation member =
+      let memberName = nameText (ieBundledMemberName member)
+       in ResolutionAnnotation
+            (importMemberNameSpan (getImportItemSourceSpan item) memberName)
+            memberName
+            ResolutionNamespaceTerm
+            (ResolvedError "not exported")
+
+missingImportedName :: ImportItem -> ResolutionNamespace -> UnqualifiedName -> Map.Map Text ResolvedName -> Maybe ResolutionAnnotation
+missingImportedName item namespace itemName candidates
+  | Map.member rendered candidates = Nothing
+  | otherwise =
+      Just
+        ( ResolutionAnnotation
+            (spanStartNameSpan (getImportItemSourceSpan item) rendered)
+            rendered
+            namespace
+            (ResolvedError "not exported")
+        )
+  where
+    rendered = renderUnqualifiedName itemName
+
+importMemberNameSpan :: SourceSpan -> Text -> SourceSpan
+importMemberNameSpan itemSpan memberName =
+  case itemSpan of
+    SourceSpan sourceName startLine startCol endLine endCol startOffset endOffset ->
+      let width = T.length memberName
+       in SourceSpan
+            sourceName
+            startLine
+            (max startCol (endCol - width - 1))
+            endLine
+            endCol
+            startOffset
+            endOffset
+    NoSourceSpan -> NoSourceSpan
 
 resolveTopLevelDecls :: Scope -> Int -> Map.Map Text Scope -> [Decl] -> (Int, [([ResolutionAnnotation], Decl)])
 resolveTopLevelDecls _ nextLocal _ [] = (nextLocal, [])
@@ -1205,6 +1278,10 @@ annotateType annotation = TAnn (mkAnnotation annotation)
 annotateImport :: ResolutionAnnotation -> ImportDecl -> ImportDecl
 annotateImport annotation importDecl =
   importDecl {importDeclAnns = mkAnnotation annotation : importDeclAnns importDecl}
+
+annotateImportErrors :: [ResolutionAnnotation] -> ImportDecl -> ImportDecl
+annotateImportErrors annotations importDecl =
+  importDecl {importDeclAnns = map mkAnnotation annotations <> importDeclAnns importDecl}
 
 importModuleNameSpan :: ImportDecl -> SourceSpan
 importModuleNameSpan importDecl =

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -95,7 +95,10 @@ pattern ImportResolution :: ResolutionAnnotation -> ImportDecl
 pattern ImportResolution resolution <- (importResolutionAnnotation -> Just resolution)
 
 importResolutionAnnotation :: ImportDecl -> Maybe ResolutionAnnotation
-importResolutionAnnotation = listToMaybe . mapMaybe fromAnnotation . importDeclAnns
+importResolutionAnnotation = listToMaybe . importResolutionAnnotations
+
+importResolutionAnnotations :: ImportDecl -> [ResolutionAnnotation]
+importResolutionAnnotations = mapMaybe fromAnnotation . importDeclAnns
 
 renderResolveResult :: ResolveResult -> String
 renderResolveResult result =
@@ -179,7 +182,7 @@ declResolution maybeDecl =
 importResolution :: Maybe ImportDecl -> [ResolutionAnnotation]
 importResolution maybeImport =
   case maybeImport of
-    Just (ImportResolution resolution) -> [resolution]
+    Just importDecl -> importResolutionAnnotations importDecl
     _ -> []
 
 patternResolution :: Maybe Pattern -> [ResolutionAnnotation]

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-constructor.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-constructor.yaml
@@ -7,6 +7,26 @@ modules:
     module Main where
     import ValidModule (FoundType(MissingConstructor))
     x = MissingConstructor
-status: xfail
-reason: "Imports with explicit constructors do not validate constructor availability; missing constructors are not rejected on the import."
-annotated: []
+status: pass
+reason: ""
+expected:
+  Main:
+    - "2:31-2:50 MissingConstructor => (value) Error not exported"
+    - "3:1-3:2 x => (value) Main.x"
+    - "3:5-3:23 MissingConstructor => (value) Error unbound"
+  ValidModule:
+    - "2:6-2:15 FoundType => (type) ValidModule.FoundType"
+    - "2:18-2:34 FoundConstructor => (value) ValidModule.FoundConstructor"
+annotated:
+  - |
+    module Main where
+    import ValidModule (FoundType(MissingConstructor))
+                                  └─ v Error not exported
+    x = MissingConstructor
+    │   └─ v Error unbound
+    └─ v Main
+  - |
+    module ValidModule where
+    data FoundType = FoundConstructor
+         │           └─ v ValidModule
+         └─ t ValidModule

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type-wildcard.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type-wildcard.yaml
@@ -8,6 +8,29 @@ modules:
     import ValidModule (MissingType(..))
     x :: MissingType
     x = 1
-status: xfail
-reason: "Type wildcard imports of missing types are not explicitly reported; missing type names are only caught indirectly."
-annotated: []
+status: pass
+reason: ""
+expected:
+  Main:
+    - "2:21-2:32 MissingType => (type) Error not exported"
+    - "3:1-3:2 x => (value) Main.x"
+    - "3:6-3:17 MissingType => (type) Error unbound"
+    - "4:1-4:2 x => (value) Main.x"
+  ValidModule:
+    - "2:6-2:15 FoundType => (type) ValidModule.FoundType"
+    - "2:18-2:34 FoundConstructor => (value) ValidModule.FoundConstructor"
+annotated:
+  - |
+    module Main where
+    import ValidModule (MissingType(..))
+                        └─ t Error not exported
+    x :: MissingType
+    │    └─ t Error unbound
+    └─ v Main
+    x = 1
+    └─ v Main
+  - |
+    module ValidModule where
+    data FoundType = FoundConstructor
+         │           └─ v ValidModule
+         └─ t ValidModule

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-type.yaml
@@ -8,6 +8,29 @@ modules:
     import ValidModule (MissingType)
     x :: MissingType
     x = 1
-status: xfail
-reason: "Missing type imports are not diagnosed at import time, so the missing type only surfaces as downstream name resolution failures."
-annotated: []
+status: pass
+reason: ""
+expected:
+  Main:
+    - "2:21-2:32 MissingType => (type) Error not exported"
+    - "3:1-3:2 x => (value) Main.x"
+    - "3:6-3:17 MissingType => (type) Error unbound"
+    - "4:1-4:2 x => (value) Main.x"
+  ValidModule:
+    - "2:6-2:15 FoundType => (type) ValidModule.FoundType"
+    - "2:18-2:34 FoundConstructor => (value) ValidModule.FoundConstructor"
+annotated:
+  - |
+    module Main where
+    import ValidModule (MissingType)
+                        └─ t Error not exported
+    x :: MissingType
+    │    └─ t Error unbound
+    └─ v Main
+    x = 1
+    └─ v Main
+  - |
+    module ValidModule where
+    data FoundType = FoundConstructor
+         │           └─ v ValidModule
+         └─ t ValidModule

--- a/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-value.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/import-missing-value.yaml
@@ -8,6 +8,29 @@ modules:
     module Main where
     import ValidModule (missing_fn)
     x = missing_fn
-status: xfail
-reason: "Missing value imports are not detected as import-level errors when the imported name is absent."
-annotated: []
+status: pass
+reason: ""
+expected:
+  Main:
+    - "2:21-2:31 missing_fn => (value) Error not exported"
+    - "3:1-3:2 x => (value) Main.x"
+    - "3:5-3:15 missing_fn => (value) Error unbound"
+  ValidModule:
+    - "2:1-2:9 valid_fn => (value) ValidModule.valid_fn"
+    - "2:13-2:16 Int => (type) Error unbound"
+    - "3:1-3:9 valid_fn => (value) ValidModule.valid_fn"
+annotated:
+  - |
+    module Main where
+    import ValidModule (missing_fn)
+                        └─ v Error not exported
+    x = missing_fn
+    │   └─ v Error unbound
+    └─ v Main
+  - |
+    module ValidModule where
+    valid_fn :: Int
+    │           └─ t Error unbound
+    └─ v ValidModule
+    valid_fn = 1
+    └─ v ValidModule


### PR DESCRIPTION
## Summary

- Validate explicit non-hiding import lists against the origin module export scope.
- Emit import-level resolver errors for missing values, types, wildcard type imports, and bundled constructors.
- Promote four aihc-resolve golden fixtures from xfail to pass with annotated diagnostics.

## Progress

- Resolver golden progress: PASS 24, XFAIL 2, XPASS 0, FAIL 0, TOTAL 26, COMPLETE 92.3%.

## Validation

- cabal test -v0 aihc-resolve:spec --test-options="--pattern import-missing"
- just fmt
- just check
- coderabbit review --prompt-only skipped: hourly/usage cap blocked review startup.
