### PR TITLE
feat: generate Cabal Paths modules

### DIFF
--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -121,18 +121,24 @@ test-suite spec
     StackageProgress.CLI
     StackageProgress.FileChecker
     StackageProgress.FileCheckerTiming
+    Test.ResolveStackageProgress.PathsModule
     Test.StackageProgress.FileChecker
     Test.StackageProgress.FileCheckerTiming
 
   build-depends:
+    aeson >=2.0 && <2.3,
     aihc-cpp,
     aihc-dev:snippet,
     aihc-hackage,
     aihc-parser,
     aihc-parser:parser-tooling-common,
+    aihc-resolve,
     base >=4.16 && <5,
+    bytestring,
+    containers,
     deepseq,
     directory,
+    filepath,
     haskell-src-exts,
     optparse-applicative >=0.16 && <0.19,
     tasty,

--- a/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
@@ -213,11 +213,11 @@ hasFailedDep completed depGraph pkg =
     isFailure PkgSkipped = True
     isFailure _ = False
 
-gatherDepExports :: Text -> Map Text PackageStatus -> Map Text [Text] -> ModuleExports
-gatherDepExports pkg completed depGraph =
+gatherDepExports :: ModuleExports -> Text -> Map Text PackageStatus -> Map Text [Text] -> ModuleExports
+gatherDepExports ambientExports pkg completed depGraph =
   foldl'
     Map.union
-    Map.empty
+    ambientExports
     [ iface
     | dep <- Map.findWithDefault [] pkg depGraph,
       Just (PkgSuccess iface) <- [Map.lookup dep completed]
@@ -225,12 +225,13 @@ gatherDepExports pkg completed depGraph =
 
 processLayer ::
   Options ->
+  ModuleExports ->
   [Text] ->
   Map Text PackageInfo ->
   Map Text PackageStatus ->
   Map Text [Text] ->
   IO (Map Text PackageStatus)
-processLayer opts layer infos completed depGraph = do
+processLayer opts ambientExports layer infos completed depGraph = do
   let (toSkip, toProcess) = partition (hasFailedDep completed depGraph) layer
   let withSkips = foldl' (\m p -> Map.insert p PkgSkipped m) completed toSkip
   if null toProcess
@@ -247,7 +248,7 @@ processLayer opts layer infos completed depGraph = do
               Nothing -> pure ()
               Just pkg -> do
                 current <- readMVar resultVar
-                let depExports = gatherDepExports pkg current depGraph
+                let depExports = gatherDepExports ambientExports pkg current depGraph
                     info = Map.findWithDefault (PackageInfo "" [] []) pkg infos
                 status <- resolveOnePackage (optOffline opts) pkg info depExports
                 modifyMVar_ resultVar (pure . Map.insert pkg status)
@@ -257,16 +258,17 @@ processLayer opts layer infos completed depGraph = do
 
 processLayers ::
   Options ->
+  ModuleExports ->
   [[Text]] ->
   Map Text PackageInfo ->
   Map Text [Text] ->
   Map Text PackageStatus ->
   IO (Map Text PackageStatus)
-processLayers opts layers infos depGraph = go layers
+processLayers opts ambientExports layers infos depGraph = go layers
   where
     go [] acc = pure acc
     go (layer : rest) acc = do
-      acc' <- processLayer opts layer infos acc depGraph
+      acc' <- processLayer opts ambientExports layer infos acc depGraph
       go rest acc'
 
 -- ---------------------------------------------------------------------------
@@ -540,6 +542,7 @@ run opts0 = do
   -- Load pre-generated boot interfaces (generates on demand if not cached)
   putStrLn "Loading boot interfaces..."
   bootIfaceMap <- loadBootInterfaces
+  let bootExports = foldl' Map.union Map.empty (Map.elems bootIfaceMap)
   let bootResults =
         Map.fromList
           [ (T.pack (pkgName p), PkgSuccess (Map.findWithDefault Map.empty (T.pack (pkgName p)) bootIfaceMap))
@@ -567,7 +570,7 @@ run opts0 = do
     then pure ()
     else hPutStrLn stderr ("Warning: " ++ show (Set.size cyclePkgs) ++ " packages in dep cycles, resolving without dep interfaces")
 
-  results <- processLayers opts layers infos depGraph bootResults
+  results <- processLayers opts bootExports layers infos depGraph bootResults
 
   reportResults (optTopFailures opts) results
 

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -10,6 +10,7 @@ import Aihc.Dev.Snippet
     renderSnippetReport,
   )
 import Aihc.Parser.Syntax (Extension (TypeApplications), ExtensionSetting (..))
+import Test.ResolveStackageProgress.PathsModule (resolveStackagePathsModuleTests)
 import Test.StackageProgress.FileChecker (stackageProgressFileCheckerTests)
 import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimingTests)
 import Test.Tasty (defaultMain, testGroup)
@@ -38,6 +39,7 @@ main =
       testCase "parses -X extension arguments" $ do
         assertEqual "extension" (Right (EnableExtension TypeApplications)) (parseExtensionSettingArg "TypeApplications"),
       QC.testProperty "dummy quickcheck property" prop_dummy,
+      resolveStackagePathsModuleTests,
       stackageProgressFileCheckerTests,
       stackageProgressFileCheckerTimingTests
     ]

--- a/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
+++ b/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.ResolveStackageProgress.PathsModule
+  ( resolveStackagePathsModuleTests,
+  )
+where
+
+import Aihc.Cpp (Result (..))
+import Aihc.Parser (ParserConfig (..), defaultConfig, formatParseErrors, parseModule)
+import Aihc.Parser.Syntax
+  ( LanguageEdition (..),
+    NameType (..),
+    headerExtensionSettings,
+    headerLanguageEdition,
+    mkQualifiedName,
+    mkUnqualifiedName,
+  )
+import Aihc.Parser.Syntax qualified as Syntax
+import Aihc.Resolve (ModuleExports, ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
+import Control.Exception (bracket)
+import CppSupport (moduleHeaderPragmas, preprocessForParserIfEnabled)
+import Data.Aeson (Value, encode, object, (.=))
+import Data.ByteString.Lazy qualified as BL
+import Data.Char (isAlphaNum, isUpper)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import HackageSupport
+  ( FileInfo (..),
+    findTargetFilesFromCabal,
+    readTextFileLenient,
+    resolveIncludeBestEffort,
+  )
+import System.Directory (createDirectory, createDirectoryIfMissing, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
+
+resolveStackagePathsModuleTests :: TestTree
+resolveStackagePathsModuleTests =
+  testGroup
+    "resolve stackage generated Paths modules"
+    [ testCase "extracts an interface for a no-dependency package using Paths_pkg" test_extractsInterfaceForGeneratedPathsPackage
+    ]
+
+test_extractsInterfaceForGeneratedPathsPackage :: Assertion
+test_extractsInterfaceForGeneratedPathsPackage =
+  withTempDir "aihc-dev-paths" $ \root -> do
+    let cabalFile = root </> "paths-demo.cabal"
+        srcDir = root </> "src"
+        sourceFile = srcDir </> "PathsUser.hs"
+        ifaceFile = root </> "interface.json"
+    createDirectoryIfMissing True srcDir
+    writeFile cabalFile pathsDemoCabal
+    writeFile sourceFile pathsUserSource
+
+    files <- findTargetFilesFromCabal root
+    modules <- mapM (parseFileInfo root) files
+    let result = resolveWithDeps baseExports modules
+    assertEqual "expected generated Paths package to resolve cleanly" [] (resolveErrors result)
+
+    let iface = extractInterface result
+    BL.writeFile ifaceFile (encode (interfaceJson iface))
+    written <- BL.readFile ifaceFile
+    assertBool "expected interface JSON to be written" (not (BL.null written))
+
+    assertBool "expected user module in interface" (Map.member "PathsUser" iface)
+    case Map.lookup "Paths_paths_demo" iface of
+      Nothing -> assertFailure "expected generated Paths module in interface"
+      Just pathsScope -> do
+        assertBool "expected version export" (Map.member "version" (scopeTerms pathsScope))
+        assertBool "expected getDataDir export" (Map.member "getDataDir" (scopeTerms pathsScope))
+        assertBool "expected getDataFileName export" (Map.member "getDataFileName" (scopeTerms pathsScope))
+
+parseFileInfo :: FilePath -> FileInfo -> IO Syntax.Module
+parseFileInfo packageRoot info = do
+  let file = fileInfoPath info
+  source <- readTextFileLenient file
+  Result {resultOutput = source'} <-
+    preprocessForParserIfEnabled
+      (fileInfoExtensions info)
+      (fileInfoCppOptions info)
+      file
+      (fileInfoDependencies info)
+      (resolveIncludeBestEffort packageRoot (fileInfoIncludeDirs info) file)
+      source
+  let headerPragmas = moduleHeaderPragmas source'
+      defaultEdition = fromMaybe Haskell98Edition (fileInfoLanguage info)
+      edition = fromMaybe defaultEdition (headerLanguageEdition headerPragmas)
+      extensionSettings = fileInfoExtensions info ++ headerExtensionSettings headerPragmas
+      effectiveExts = Syntax.effectiveExtensions edition extensionSettings
+      config = defaultConfig {parserSourceName = file, parserExtensions = effectiveExts}
+      (errs, modu) = parseModule config source'
+  if null errs
+    then pure modu
+    else assertFailure (formatParseErrors file (Just source') errs)
+
+baseExports :: ModuleExports
+baseExports =
+  Map.fromList
+    [ ("Prelude", mkScope "Prelude" ["return", "++", "==", "otherwise"] ["IO", "FilePath", "String", "Char", "Bool"]),
+      ("Control.Exception", mkScope "Control.Exception" ["catch"] ["IOException"]),
+      ("Data.List", mkScope "Data.List" ["last"] []),
+      ("Data.Version", mkScope "Data.Version" ["Version"] ["Version"]),
+      ("System.Environment", mkScope "System.Environment" ["getEnv"] [])
+    ]
+
+mkScope :: Text -> [Text] -> [Text] -> Scope
+mkScope moduleName terms types =
+  Scope
+    { scopeTerms = Map.fromList [(name, resolve name) | name <- terms],
+      scopeTypes = Map.fromList [(name, resolve name) | name <- types],
+      scopeQualifiedModules = Map.empty
+    }
+  where
+    resolve name =
+      ResolvedTopLevel (mkQualifiedName (mkUnqualifiedName (inferNameType name) name) (Just moduleName))
+
+inferNameType :: Text -> NameType
+inferNameType name =
+  case T.uncons name of
+    Nothing -> NameVarId
+    Just (c, _)
+      | c == ':' -> NameConSym
+      | not (isAlphaNum c) && c /= '_' && c /= '\'' -> NameVarSym
+      | isUpper c -> NameConId
+      | otherwise -> NameVarId
+
+interfaceJson :: ModuleExports -> Value
+interfaceJson iface =
+  object
+    [ "modules"
+        .= [ object
+               [ "module" .= moduleName,
+                 "terms" .= Map.keys (scopeTerms scope),
+                 "types" .= Map.keys (scopeTypes scope)
+               ]
+           | (moduleName, scope) <- Map.toList iface
+           ]
+    ]
+
+pathsDemoCabal :: String
+pathsDemoCabal =
+  unlines
+    [ "cabal-version: 3.0",
+      "name: paths-demo",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: PathsUser",
+      "  autogen-modules: Paths_paths_demo",
+      "  hs-source-dirs: src",
+      "  default-language: Haskell2010"
+    ]
+
+pathsUserSource :: String
+pathsUserSource =
+  unlines
+    [ "module PathsUser where",
+      "import Paths_paths_demo (version, getDataDir, getDataFileName)",
+      "pathsVersion = version",
+      "pathsDataDir = getDataDir",
+      "pathsDataFileName = getDataFileName"
+    ]
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+  tempRoot <- getTemporaryDirectory
+  (tempFile, tempHandle) <- openTempFile tempRoot (prefix ++ "-XXXXXX")
+  hClose tempHandle
+  removeFile tempFile
+  createDirectory tempFile
+  bracket
+    (pure tempFile)
+    removeDirectoryRecursive
+    action

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -22,6 +22,7 @@ library
 
   hs-source-dirs: src
   build-depends:
+    Cabal >=3.14 && <3.17,
     Cabal-syntax >=3.14 && <3.17,
     base >=4.16 && <5,
     bytestring >=0.10.8 && <0.13,
@@ -43,11 +44,16 @@ test-suite spec
   hs-source-dirs: test
   main-is: Spec.hs
   build-depends:
+    Cabal-syntax >=3.14 && <3.17,
     aihc-hackage,
     base >=4.16 && <5,
+    bytestring,
+    directory,
+    filepath,
     tasty,
     tasty-hunit,
     tasty-quickcheck,
+    text,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- | Cabal-file parsing utilities: condition evaluation, component file discovery.
 module Aihc.Hackage.Cabal
   ( -- * File info
@@ -24,13 +26,16 @@ import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Version qualified as DV
-import Distribution.Compiler (CompilerFlavor (..))
-import Distribution.Package (unPackageName)
+import Distribution.Compat.Graph qualified as Graph
+import Distribution.Compiler (CompilerFlavor (..), CompilerId (..))
+import Distribution.ModuleName qualified as ModuleName
+import Distribution.Package (packageName, unPackageName)
 import Distribution.PackageDescription
   ( BuildInfo,
     Executable,
     FlagName,
     Library,
+    PackageDescription,
     autogenModules,
     buildInfo,
     buildable,
@@ -49,10 +54,29 @@ import Distribution.PackageDescription
     modulePath,
     oldExtensions,
     otherModules,
+    package,
+    packageDescription,
   )
 import Distribution.Pretty (prettyShow)
-import Distribution.System (buildArch, buildOS)
+import Distribution.Simple.Build.PathsModule (generatePathsModule)
+import Distribution.Simple.BuildPaths (autogenPathsModuleName)
+import Distribution.Simple.Compiler
+  ( AbiTag (..),
+    Compiler (..),
+    DebugInfoLevel (..),
+    OptimisationLevel (..),
+    PackageDBX (..),
+    ProfDetailLevel (..),
+  )
+import Distribution.Simple.InstallDirs (defaultInstallDirs)
+import Distribution.Simple.Program.Db (emptyProgramDb)
+import Distribution.Simple.Setup (defaultConfigFlags)
+import Distribution.System (buildArch, buildOS, buildPlatform)
 import Distribution.Types.BuildInfo (targetBuildDepends)
+import Distribution.Types.ComponentId (mkComponentId)
+import Distribution.Types.ComponentLocalBuildInfo (ComponentLocalBuildInfo (..))
+import Distribution.Types.ComponentName (ComponentName (..), componentNameString, pattern CBenchName, pattern CExeName, pattern CFLibName, pattern CTestName)
+import Distribution.Types.ComponentRequestedSpec (ComponentRequestedSpec (..))
 import Distribution.Types.CondTree
   ( CondBranch (CondBranch),
     CondTree (condTreeComponents, condTreeData),
@@ -61,9 +85,15 @@ import Distribution.Types.Condition (Condition (..))
 import Distribution.Types.ConfVar (ConfVar (..))
 import Distribution.Types.Dependency (depPkgName)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription, genPackageFlags)
+import Distribution.Types.LibraryName (LibraryName (..))
+import Distribution.Types.LocalBuildInfo (LocalBuildInfo (..))
+import Distribution.Types.MungedPackageName (MungedPackageName (..))
+import Distribution.Types.UnitId (mkUnitId)
+import Distribution.Types.UnqualComponentName (UnqualComponentName)
 import Distribution.Utils.Path (getSymbolicPath)
 import Distribution.Version (mkVersion, withinRange)
-import System.FilePath ((</>))
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory, (<.>), (</>))
 import System.Info (compilerName, compilerVersion)
 
 -- | Information about a Haskell source file discovered via a @.cabal@ file.
@@ -89,21 +119,25 @@ data FileInfo = FileInfo
 collectComponentFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
 collectComponentFiles gpd packageRoot = do
   let evalCond = conditionEvaluator gpd
-      libraryTrees = maybe [] pure (condLibrary gpd) <> map snd (condSubLibraries gpd)
-      executableTrees = map snd (condExecutables gpd)
+      pkgDescr = packageDescription gpd
+      libraryTrees = maybe [] (pure . (LMainLibName,)) (condLibrary gpd) <> map (first LSubLibName) (condSubLibraries gpd)
+      executableTrees = condExecutables gpd
 
-  libraryFiles <- fmap concat (mapM (libraryFilesFor evalCond packageRoot) libraryTrees)
-  executableFiles <- fmap concat (mapM (executableFilesFor evalCond packageRoot) executableTrees)
+  libraryFiles <- fmap concat (mapM (uncurry (libraryFilesFor pkgDescr evalCond packageRoot)) libraryTrees)
+  executableFiles <- fmap concat (mapM (uncurry (executableFilesFor pkgDescr evalCond packageRoot)) executableTrees)
 
   let allFiles = libraryFiles <> executableFiles
   pure (dedupeFiles allFiles)
+
+first :: (a -> c) -> (a, b) -> (c, b)
+first f (a, b) = (f a, b)
 
 dedupeFiles :: [FileInfo] -> [FileInfo]
 dedupeFiles [] = []
 dedupeFiles (f : fs) = f : dedupeFiles (filter (\x -> fileInfoPath x /= fileInfoPath f) fs)
 
-libraryFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Library -> IO [FileInfo]
-libraryFilesFor evalCond packageRoot tree = do
+libraryFilesFor :: PackageDescription -> (Condition ConfVar -> Bool) -> FilePath -> LibraryName -> CondTree ConfVar c Library -> IO [FileInfo]
+libraryFilesFor pkgDescr evalCond packageRoot libName tree = do
   let library = condTreeData tree
       build = collectMergedBuildInfo evalCond libBuildInfo tree
       moduleNames = exposedModules library <> otherModules build <> autogenModules build
@@ -116,10 +150,13 @@ libraryFilesFor evalCond packageRoot tree = do
     then pure []
     else do
       paths <- moduleFilesForBuildInfo packageRoot build moduleNames
-      pure [FileInfo path exts cppOpts includeSearchDirs lang deps | path <- paths]
+      generatedPaths <- generatedPathsFiles packageRoot pkgDescr (libraryComponentName libName) moduleNames
+      pure $
+        [FileInfo path exts cppOpts includeSearchDirs lang deps | path <- paths]
+          <> [generatedPathsFileInfo path | path <- generatedPaths]
 
-executableFilesFor :: (Condition ConfVar -> Bool) -> FilePath -> CondTree ConfVar c Executable -> IO [FileInfo]
-executableFilesFor evalCond packageRoot tree = do
+executableFilesFor :: PackageDescription -> (Condition ConfVar -> Bool) -> FilePath -> UnqualComponentName -> CondTree ConfVar c Executable -> IO [FileInfo]
+executableFilesFor pkgDescr evalCond packageRoot exeName tree = do
   let executable = condTreeData tree
       build = collectMergedBuildInfo evalCond buildInfo tree
       moduleNames = otherModules build <> exeModules executable <> autogenModules build
@@ -134,7 +171,161 @@ executableFilesFor evalCond packageRoot tree = do
     else do
       moduleFiles <- moduleFilesForBuildInfo packageRoot build moduleNames
       mainFiles <- existingPaths [dir </> mainPath | dir <- sourceDirs packageRoot build]
-      pure [FileInfo path exts cppOpts includeSearchDirs lang deps | path <- moduleFiles <> mainFiles]
+      generatedPaths <- generatedPathsFiles packageRoot pkgDescr (CExeName exeName) moduleNames
+      pure $
+        [FileInfo path exts cppOpts includeSearchDirs lang deps | path <- moduleFiles <> mainFiles]
+          <> [generatedPathsFileInfo path | path <- generatedPaths]
+
+libraryComponentName :: LibraryName -> ComponentName
+libraryComponentName = CLibName
+
+generatedPathsFileInfo :: FilePath -> FileInfo
+generatedPathsFileInfo path =
+  FileInfo
+    { fileInfoPath = path,
+      fileInfoExtensions = [],
+      fileInfoCppOptions = [],
+      fileInfoIncludeDirs = [],
+      fileInfoLanguage = Nothing,
+      fileInfoDependencies = [T.pack "base"]
+    }
+
+generatedPathsFiles :: FilePath -> PackageDescription -> ComponentName -> [ModuleName.ModuleName] -> IO [FilePath]
+generatedPathsFiles packageRoot pkgDescr componentName moduleNames
+  | autogenPathsModuleName pkgDescr `notElem` moduleNames = pure []
+  | otherwise = do
+      let path = generatedPathsModulePath packageRoot pkgDescr
+      createDirectoryIfMissing True (takeDirectory path)
+      lbi <- syntheticLocalBuildInfo pkgDescr
+      let clbi = syntheticComponentLocalBuildInfo pkgDescr componentName
+      writeFile path (generatePathsModule pkgDescr lbi clbi)
+      pure [path]
+
+generatedPathsModulePath :: FilePath -> PackageDescription -> FilePath
+generatedPathsModulePath packageRoot pkgDescr =
+  packageRoot </> ".aihc-autogen" </> ModuleName.toFilePath (autogenPathsModuleName pkgDescr) <.> "hs"
+
+syntheticLocalBuildInfo :: PackageDescription -> IO LocalBuildInfo
+syntheticLocalBuildInfo pkgDescr = do
+  dirs <- defaultInstallDirs GHC False False
+  let comp =
+        Compiler
+          (CompilerId GHC (mkVersion (DV.versionBranch compilerVersion)))
+          NoAbiTag
+          [CompilerId GHC (mkVersion (DV.versionBranch compilerVersion))]
+          []
+          []
+          Map.empty
+  pure $
+    LocalBuildInfo
+      { configFlags = defaultConfigFlags emptyProgramDb,
+        flagAssignment = mempty,
+        componentEnabledSpec = ComponentRequestedSpec False False,
+        extraConfigArgs = [],
+        installDirTemplates = dirs,
+        compiler = comp,
+        hostPlatform = buildPlatform,
+        pkgDescrFile = Nothing,
+        componentGraph = Graph.empty,
+        componentNameMap = Map.empty,
+        promisedPkgs = Map.empty,
+        installedPkgs = mempty,
+        localPkgDescr = pkgDescr,
+        withPrograms = emptyProgramDb,
+        withPackageDB = [GlobalPackageDB],
+        withVanillaLib = True,
+        withProfLib = False,
+        withProfLibShared = False,
+        withSharedLib = False,
+        withStaticLib = False,
+        withDynExe = False,
+        withFullyStaticExe = False,
+        withProfExe = False,
+        withProfLibDetail = ProfDetailNone,
+        withProfExeDetail = ProfDetailNone,
+        withOptimization = NoOptimisation,
+        withDebugInfo = NoDebugInfo,
+        withGHCiLib = False,
+        splitSections = False,
+        splitObjs = False,
+        stripExes = False,
+        stripLibs = False,
+        exeCoverage = False,
+        libCoverage = False,
+        extraCoverageFor = [],
+        relocatable = False
+      }
+
+syntheticComponentLocalBuildInfo :: PackageDescription -> ComponentName -> ComponentLocalBuildInfo
+syntheticComponentLocalBuildInfo pkgDescr componentName =
+  case componentName of
+    CLibName libName ->
+      LibComponentLocalBuildInfo
+        { componentLocalName = componentName,
+          componentComponentId = componentId,
+          componentUnitId = unitId,
+          componentIsIndefinite_ = False,
+          componentInstantiatedWith = [],
+          componentPackageDeps = [],
+          componentIncludes = [],
+          componentExeDeps = [],
+          componentInternalDeps = [],
+          componentCompatPackageKey = unitIdText,
+          componentCompatPackageName = MungedPackageName (packageName pkgDescr) libName,
+          componentExposedModules = [],
+          componentIsPublic = True
+        }
+    CExeName _ ->
+      ExeComponentLocalBuildInfo
+        { componentLocalName = componentName,
+          componentComponentId = componentId,
+          componentUnitId = unitId,
+          componentPackageDeps = [],
+          componentIncludes = [],
+          componentExeDeps = [],
+          componentInternalDeps = []
+        }
+    CTestName _ ->
+      TestComponentLocalBuildInfo
+        { componentLocalName = componentName,
+          componentComponentId = componentId,
+          componentUnitId = unitId,
+          componentPackageDeps = [],
+          componentIncludes = [],
+          componentExeDeps = [],
+          componentInternalDeps = []
+        }
+    CBenchName _ ->
+      BenchComponentLocalBuildInfo
+        { componentLocalName = componentName,
+          componentComponentId = componentId,
+          componentUnitId = unitId,
+          componentPackageDeps = [],
+          componentIncludes = [],
+          componentExeDeps = [],
+          componentInternalDeps = []
+        }
+    CFLibName _ ->
+      FLibComponentLocalBuildInfo
+        { componentLocalName = componentName,
+          componentComponentId = componentId,
+          componentUnitId = unitId,
+          componentPackageDeps = [],
+          componentIncludes = [],
+          componentExeDeps = [],
+          componentInternalDeps = []
+        }
+  where
+    unitIdText = prettyShow (package pkgDescr) <> componentSuffix componentName
+    componentId = mkComponentId unitIdText
+    unitId = mkUnitId unitIdText
+
+componentSuffix :: ComponentName -> String
+componentSuffix componentName =
+  case componentName of
+    CLibName LMainLibName -> ""
+    CLibName (LSubLibName name) -> "-lib-" <> prettyShow name
+    CNotLibName _ -> "-exe-" <> maybe "unnamed" prettyShow (componentNameString componentName)
 
 -- | Evaluate cabal conditions using the host compiler and default flag values.
 conditionEvaluator :: GenericPackageDescription -> Condition ConfVar -> Bool

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -1,9 +1,18 @@
 module Main (main) where
 
+import Aihc.Hackage.Cabal qualified as HC
 import Aihc.Hackage.Stackage (parseSnapshotConstraints)
 import Aihc.Hackage.Types (PackageSpec (..))
+import Control.Exception (bracket)
+import Data.ByteString qualified as BS
+import Data.List (isInfixOf, isSuffixOf)
+import Data.Text qualified as T
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import System.Directory (createDirectory, createDirectoryIfMissing, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Test.Tasty.QuickCheck qualified as QC
 
 main :: IO ()
@@ -23,6 +32,7 @@ main =
             [ PackageSpec "ghc-prim" "installed",
               PackageSpec "custom-package" "installed"
             ],
+      testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
       QC.testProperty "dummy quickcheck property" prop_dummy
     ]
 
@@ -36,3 +46,71 @@ actual @?= expected =
   if actual == expected
     then pure ()
     else assertFailure ("expected: " <> show expected <> "\n but got: " <> show actual)
+
+test_generatesPathsModule :: Assertion
+test_generatesPathsModule =
+  withTempDir "aihc-hackage-paths" $ \root -> do
+    let cabalFile = root </> "paths-demo.cabal"
+        srcDir = root </> "src"
+        sourceFile = srcDir </> "PathsUser.hs"
+    createDirectoryIfMissing True srcDir
+    writeFile cabalFile pathsDemoCabal
+    writeFile sourceFile pathsUserSource
+
+    cabalBytes <- BS.readFile cabalFile
+    gpd <-
+      case snd (runParseResult (parseGenericPackageDescription cabalBytes)) of
+        Right parsed -> pure parsed
+        Left (_, errs) -> assertFailure ("failed to parse test cabal file: " <> show errs)
+
+    files <- HC.collectComponentFiles gpd root
+    let paths = map HC.fileInfoPath files
+        generated = root </> ".aihc-autogen" </> "Paths_paths_demo.hs"
+    assertBool "expected package source module to be selected" (any ("src/PathsUser.hs" `isSuffixOf`) paths)
+    assertBool "expected generated Paths module to be selected" (generated `elem` paths)
+
+    generatedSource <- readFile generated
+    assertBool "expected Cabal module header" ("module Paths_paths_demo" `isInfixOf` generatedSource)
+    assertBool "expected version export" ("version :: Version" `isInfixOf` generatedSource)
+    assertBool "expected getDataDir export" ("getDataDir" `isInfixOf` generatedSource)
+    assertBool "expected getDataFileName export" ("getDataFileName :: FilePath -> IO FilePath" `isInfixOf` generatedSource)
+
+    case filter ((== generated) . HC.fileInfoPath) files of
+      [info] -> assertEqual "expected generated module to depend on base" [T.pack "base"] (HC.fileInfoDependencies info)
+      _ -> assertFailure "expected exactly one FileInfo for generated Paths module"
+
+pathsDemoCabal :: String
+pathsDemoCabal =
+  unlines
+    [ "cabal-version: 3.0",
+      "name: paths-demo",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: PathsUser",
+      "  autogen-modules: Paths_paths_demo",
+      "  hs-source-dirs: src",
+      "  default-language: Haskell2010"
+    ]
+
+pathsUserSource :: String
+pathsUserSource =
+  unlines
+    [ "module PathsUser where",
+      "import Paths_paths_demo (version, getDataDir, getDataFileName)",
+      "pathsVersion = version",
+      "pathsDataDir = getDataDir",
+      "pathsDataFileName = getDataFileName"
+    ]
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+  tempRoot <- getTemporaryDirectory
+  (tempFile, tempHandle) <- openTempFile tempRoot (prefix ++ "-XXXXXX")
+  hClose tempHandle
+  removeFile tempFile
+  createDirectory tempFile
+  bracket
+    (pure tempFile)
+    removeDirectoryRecursive
+    action


### PR DESCRIPTION
## Summary

- Generate Cabal `Paths_{pkg}` modules through Cabal’s `generatePathsModule` during shared Cabal component discovery.
- Materialize generated modules under `.aihc-autogen` so parser and resolver Stackage progress tools see them as normal source files.
- Merge boot interfaces into every resolve-stackage package resolution, so generated Cabal modules can resolve their `base` imports even when a package has no declared dependencies.
- Add regression tests for no-dependency Cabal packages that import their generated `Paths_{pkg}` module and produce resolver interfaces.

## Progress counts

- README progress counts were not updated in this PR.
- Expected impact: packages using `Paths_{pkg}` should become parseable/resolvable once the scheduled progress-count workflow reruns.

## Validation

- `cabal test -v0 aihc-hackage:spec --test-options="--pattern Paths"`
- `cabal test -v0 aihc-dev:spec --test-options="--pattern generated"`
- `just fmt`
- `just check`

## CodeRabbit

- `coderabbit review --prompt-only` completed once and reported two Cabal constructor maintainability findings; both were fixed.
- A final rerun after the fixes was skipped because CodeRabbit hit the hourly usage cap.
