### PR TITLE
fix(reports): provide ghc to generated reports app

### DIFF
--- a/scripts/nix/apps.nix
+++ b/scripts/nix/apps.nix
@@ -139,7 +139,7 @@ in {
     ${extensionProgressExe} "$@"
   '';
 
-  aihc-dev = mkAppWithInputs "aihc-dev" [pkgs.bash] ''
+  aihc-dev = mkAppWithInputs "aihc-dev" [pkgs.bash hsPkgs.ghc] ''
     exec ${aihcDevExe} "$@"
   '';
 

--- a/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
@@ -43,7 +43,7 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import System.Directory (createDirectoryIfMissing, doesFileExist)
-import System.Environment (lookupEnv)
+import System.Environment (getExecutablePath, lookupEnv)
 import System.FilePath ((</>))
 import System.IO (hPutStrLn, stderr)
 import System.Process (readProcess)
@@ -106,11 +106,12 @@ loadFromFile pkgName path = do
 generateBootInterface :: Text -> FilePath -> IO Bool
 generateBootInterface pkgName outputPath = do
   hPutStrLn stderr ("Generating boot interface for " <> T.unpack pkgName <> "...")
+  aihcDevExe <- getExecutablePath
   result <-
     try $
       readProcess
-        "cabal"
-        ["run", "-v0", "aihc-dev", "--", "extract-resolve-iface", "--package", T.unpack pkgName, "--output", outputPath]
+        aihcDevExe
+        ["extract-resolve-iface", "--package", T.unpack pkgName, "--output", outputPath]
         ""
   case result of
     Left (e :: IOException) -> do


### PR DESCRIPTION
## Summary
- add the project GHC to the `aihc-dev` Nix app runtime so scheduled generated reports can find `ghc`/`ghc-pkg`
- generate boot resolver interfaces by re-running the current `aihc-dev` executable instead of shelling through `cabal run`

## Progress counts
- No generated progress counts changed.

## Verification
- `just fmt`
- `XDG_CACHE_HOME=... nix run .#aihc-dev -- extract-resolve-iface --package ghc-prim --output ...`
- boot-interface probe generated fresh `base`, `ghc-bignum`, `ghc-internal`, and `ghc-prim` interfaces before timing out ahead of the full Stackage sweep
- `cabal test -v0 aihc-dev:spec --test-options=--hide-successes`
- `just check`

CodeRabbit review was attempted but skipped because the account hit the review cap.
