### PR TITLE
fix(parser): handle hash-leading infix pretty-print break

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1141,10 +1141,10 @@ prettyExpr expr =
     ELambdaCases alts ->
       "\\" <> "cases" <> prettyCaseLayout (map prettyLambdaCaseAlt alts)
     EInfix lhs op rhs ->
-      prettyExpr lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs
+      prettyExpr lhs <> infixBreak op <> prettyNameInfixOp op <+> prettyExpr rhs
     ENegate inner -> "-" <> prettyExpr inner
     ESectionL lhs op ->
-      prettyExpr lhs <> hardline <> " " <> prettyNameInfixOp op
+      prettyExpr lhs <> infixBreak op <> prettyNameInfixOp op
     ESectionR op rhs -> prettyNameInfixOp op <+> prettyExpr rhs
     ELetDecls decls body ->
       case decls of
@@ -1372,8 +1372,8 @@ prettyExprAtStatementStart expr =
     EOverloadedLabel _ raw -> pretty raw
     EApp {} -> prettyAppWith prettyExprAtStatementStart expr
     ETypeApp fn ty -> prettyExprAtStatementStart fn <> hardline <> " " <> "@" <> prettyType ty
-    EInfix lhs op rhs -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs
-    ESectionL lhs op -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op
+    EInfix lhs op rhs -> prettyExprAtStatementStart lhs <> infixBreak op <> prettyNameInfixOp op <+> prettyExpr rhs
+    ESectionL lhs op -> prettyExprAtStatementStart lhs <> infixBreak op <> prettyNameInfixOp op
     ETypeSig inner ty -> prettyExprAtStatementStart inner <> hardline <> " " <> "::" <+> prettyType ty
     ERecordUpd base fields ->
       prettyExprAtStatementStart base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
@@ -1432,6 +1432,10 @@ prettyCmdAtStatementStart cmd =
     CmdApp c e ->
       prettyCmdAtStatementStart c <+> prettyExpr e
     _ -> prettyCmd cmd
+
+infixBreak :: Name -> Doc ann
+infixBreak op =
+  if isHashLeadingSymbolicName op then " " else hardline
 
 prettyCmdCaseAlt :: CaseAlt Cmd -> Doc ann
 prettyCmdCaseAlt = prettyCaseAltWith prettyCmd

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1435,7 +1435,9 @@ prettyCmdAtStatementStart cmd =
 
 infixBreak :: Name -> Doc ann
 infixBreak op =
-  if isHashLeadingSymbolicName op then " " else hardline
+  if isHashLeadingSymbolicName op
+    then " "
+    else hardline <> " "
 
 prettyCmdCaseAlt :: CaseAlt Cmd -> Doc ann
 prettyCmdCaseAlt = prettyCaseAltWith prettyCmd

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-command-infix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-command-infix.hs
@@ -1,0 +1,11 @@
+{-# ORACLE_TEST pass -}
+{-# LANGUAGE Arrows #-}
+module DiagramsCanvasCommandHashInfix where
+
+import Control.Arrow
+
+expr' term = proc x -> do
+  returnA -< x
+  #> do
+    y <- term -< ()
+    expr' term -< x + y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-command-infix.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-command-infix.hs
@@ -1,4 +1,4 @@
-{-# ORACLE_TEST pass -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE Arrows #-}
 module DiagramsCanvasCommandHashInfix where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-infix-application.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-infix-application.hs
@@ -1,0 +1,22 @@
+{- ORACLE_TEST pass -}
+module DiagramsCanvasCanvas where
+
+infixl 0 #
+(#) :: a -> (a -> b) -> b
+(#) = flip id
+
+adjustDia :: Int -> Int -> Int -> Int -> Int
+adjustDia c opts d =
+  adjustDia2D
+    size
+    c
+    opts
+    (d
+     # reflectY)
+  where
+    size :: Int
+    size = 42
+    adjustDia2D :: Int -> Int -> Int -> Int -> Int
+    adjustDia2D s p q r = s + p + q + r
+    reflectY :: Int -> Int
+    reflectY = id

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -137,6 +137,10 @@ snippetParser =
               <> help "Snippet file to analyze (reads stdin if omitted)"
           )
       )
+    <*> switch
+      ( long "print-roundtripped"
+          <> help "Print the roundtripped module emitted by aihc-parser"
+      )
 
 parseExtensionSetting :: ReadM ExtensionSetting
 parseExtensionSetting =

--- a/tooling/aihc-dev/src/Aihc/Dev/Snippet.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Snippet.hs
@@ -42,7 +42,8 @@ import System.Exit (exitFailure)
 
 data SnippetOpts = SnippetOpts
   { snippetExtensions :: [ExtensionSetting],
-    snippetFile :: Maybe FilePath
+    snippetFile :: Maybe FilePath,
+    snippetPrintRoundtripped :: Bool
   }
 
 data ParseComparison
@@ -62,8 +63,14 @@ runSnippet :: SnippetOpts -> IO ()
 runSnippet opts = do
   let sourceTag = fromMaybe "<stdin>" (snippetFile opts)
   source <- maybe TIO.getContents TIO.readFile (snippetFile opts)
-  let report = analyzeSnippet sourceTag (snippetExtensions opts) source
+  let (report, roundtrippedSource) = analyzeSnippet sourceTag (snippetExtensions opts) source
   putStr (renderSnippetReport report)
+  when (snippetPrintRoundtripped opts) $
+    case roundtrippedSource of
+      Nothing -> pure ()
+      Just rendered -> do
+        putStrLn "\nRoundtripped module:"
+        TIO.putStrLn rendered
   Control.Monad.when (reportHasFailure report) exitFailure
 
 parseExtensionSettingArg :: String -> Either String ExtensionSetting
@@ -72,7 +79,7 @@ parseExtensionSettingArg raw =
     Just setting -> Right setting
     Nothing -> Left ("Unknown extension: " <> raw)
 
-analyzeSnippet :: FilePath -> [ExtensionSetting] -> Text -> SnippetReport
+analyzeSnippet :: FilePath -> [ExtensionSetting] -> Text -> (SnippetReport, Maybe Text)
 analyzeSnippet sourceTag cliExtensions source =
   let preprocessed = preprocessForParserWithoutIncludesIfEnabled cliExtensions [] sourceTag [] source
       source' = resultOutput preprocessed
@@ -88,7 +95,8 @@ analyzeSnippet sourceTag cliExtensions source =
           BothAccept -> fmap validationErrorMessage (validateParser sourceTag edition extensionSettings source')
           _ -> Nothing
       parensDiff = parserModule >>= parsedSnippetParensDiff source
-   in buildSnippetReport comparison validationFailure parensDiff
+      roundtrippedSource = fmap renderModule parserModule
+   in (buildSnippetReport comparison validationFailure parensDiff, roundtrippedSource)
 
 buildSnippetReport :: ParseComparison -> Maybe String -> Maybe String -> SnippetReport
 buildSnippetReport comparison validationFailure parensDiff =
@@ -134,6 +142,10 @@ parseWithAihc sourceTag edition extensionSettings source =
    in case errs of
         [] -> Just modu
         _ -> Nothing
+
+renderModule :: Module -> Text
+renderModule =
+  renderStrict . layoutPretty defaultLayoutOptions . pretty
 
 parsedSnippetParensDiff :: Text -> Module -> Maybe String
 parsedSnippetParensDiff source modu =


### PR DESCRIPTION
## Summary

- Keep the existing hash-leading infix multiline expression fix for `#` and related operators in `Aihc.Parser.Pretty`.
- Add an additional oracle fixture in `Hackage` for a command-level hash-leading infix operator in `proc`/`do` form.

## Why

- The original failure mode is triggered by layout-sensitive `#`-leading operators in command notation.
- `CmdInfix` must keep its line-oriented layout (`hardline`) for the operator break; collapsing it to a flat space for `#` in command contexts changes parse/parenthesization and produces a different GHC AST.
- The new fixture locks in the known-safe roundtrip behavior so future refactors do not reintroduce this class of regression.

## Validation

- `cabal run exe:aihc-dev -- hackage-tester diagrams-canvas`
- `cat components/aihc-parser/test/Test/Fixtures/oracle/Hackage/diagrams-canvas-hash-leading-command-infix.hs | cabal run exe:aihc-dev -- snippet -XArrows --print-roundtripped`
