### PR TITLE
fix(parser): allow percent operator in infix section parsing

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -1032,6 +1032,9 @@ infixOperatorParserExcept forbidden =
           TkConSym op ->
             let name = qualifyName Nothing (mkUnqualifiedName NameConSym op)
              in if allowed name then Just name else Nothing
+          TkPrefixPercent ->
+            let name = qualifyName Nothing (mkUnqualifiedName NameVarSym "%")
+             in if allowed name then Just name else Nothing
           TkQVarSym modName op ->
             let name = mkName (Just modName) NameVarSym op
              in if allowed name then Just name else Nothing

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/graphviz-percent-section.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/graphviz-percent-section.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+module A where
+
+f = (%1)


### PR DESCRIPTION
## Why
Graphviz currently fails in Hackage oracle checks with a parse error on `Data/GraphViz/Parsing.hs` for a section expression `f = (%1)`. `GHC` accepts the file, but AIHC rejects it.

## Why now
The failure comes from the parser treating `%` as `TkPrefixPercent` in a prefix-operator section context. `%` was accepted by the lexer but `infixOperatorParserExcept` only recognized `TkVarSym`/`TkConSym` (plus a few reserved/builtin forms), so sections like `(%1)`/`(-1)` with percent were rejected.

## Fix
- Allow `TkPrefixPercent` in `symbolicOperatorParser` and normalize it to the operator name `%`.
- Add a minimal oracle fixture reproducing the graphviz case:
  `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/graphviz-percent-section.hs`
  - content: `f = (%1)` with `ORACLE_TEST pass` annotation.

## Verification
- Ran parser regression check with this fixture through `aihc-parser`/`aihc-dev` and confirmed the case is now accepted as parse-valid.
- This is intentionally a minimal regression to lock in the parser behavior.
