### PR TITLE
test: add generic-lens-core promoted error message list oracle fixtures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-cons.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-cons.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail Promoted list element boundaries break after infix ErrorMessage operators -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+module M where
+
+type M1 = '[ 'Text "alpha" ':<>: 'Text "beta", 'Text "gamma" ]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-singleton.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-singleton.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail Promoted list elements containing infix ErrorMessage operators are not parenthesized in pretty-printed output -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+module M where
+
+type M1 = '[ 'Text "alpha" ':<>: 'Text "beta" ]


### PR DESCRIPTION
## Summary
Add two minimal oracle fixtures reproducing parser roundtrip failures observed on `generic-lens-core` via `hackage-tester` for promoted type-level error message expressions in type lists.

## Details
- `generic-lens-core-promoted-error-message-list-singleton.hs`
  - Reproduces a parse error on `]` with a singleton promoted list containing an infix promoted `ErrorMessage` operator.
  - `type M1 = '[ 'Text "alpha" ':<>: 'Text "beta" ]`

- `generic-lens-core-promoted-error-message-list-cons.hs`
  - Reproduces a parse error on `,` when such an infix element is followed by another list element.
  - `type M1 = '[ 'Text "alpha" ':<>: 'Text "beta", 'Text "gamma" ]`

These fixtures codify the known parser issue so it is tracked in oracle coverage and can be targeted by future parser fixes.
