### PR TITLE
fix(parser): handle sbv package parse regressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -354,6 +354,7 @@ operatorNameParser =
       TkConSym op -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym op))
       TkQVarSym modName op -> Just (mkName (Just modName) NameVarSym op)
       TkQConSym modName op -> Just (mkName (Just modName) NameConSym op)
+      TkReservedAt -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym "@"))
       _ -> Nothing
 
 operatorUnqualifiedNameParser :: TokParser UnqualifiedName
@@ -370,6 +371,7 @@ operatorUnqualifiedNameParser =
       TkReservedDotDot -> Just (mkUnqualifiedName NameVarSym "..")
       TkReservedDoubleColon -> Just (mkUnqualifiedName NameVarSym "::")
       TkReservedColon -> Just (mkUnqualifiedName NameConSym ":")
+      TkReservedAt -> Just (mkUnqualifiedName NameVarSym "@")
       _ -> Nothing
 
 -- | Parse an infix operator name (varop) for function definitions.

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -745,6 +745,7 @@ functionBinderNameParser =
       tokenSatisfy "variable operator" $ \tok ->
         case lexTokenKind tok of
           TkVarSym ident -> Just (mkUnqualifiedName NameVarSym ident)
+          TkReservedAt -> Just (mkUnqualifiedName NameVarSym "@")
           _ -> Nothing
 
 functionBindValue :: MatchHeadForm -> UnqualifiedName -> [Pattern] -> Rhs Expr -> ValueDecl

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -565,6 +565,7 @@ operatorExprNameParser =
       TkConSym sym -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym sym))
       TkQVarSym modName sym -> Just (mkName (Just modName) NameVarSym sym)
       TkQConSym modName sym -> Just (mkName (Just modName) NameConSym sym)
+      TkReservedAt -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym "@"))
       TkMinusOperator -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym "-"))
       TkReservedColon -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym ":"))
       TkReservedDoubleColon -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym "::"))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -13,7 +13,7 @@ where
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (atomExprParser, exprParser, exprParserWithTypeSigParser)
-import Aihc.Parser.Internal.Type (typeInfixParser, typeParser)
+import Aihc.Parser.Internal.Type (typeParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenText)
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
@@ -316,7 +316,7 @@ subpatternWithBareViewParser = do
 
 viewPatternExprParser :: TokParser Expr
 viewPatternExprParser =
-  exprParserWithTypeSigParser typeInfixParser
+  exprParserWithTypeSigParser typeParser
 
 parenOrTuplePatternParser :: TokParser Pattern
 parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
@@ -410,6 +410,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
         TkConSym {} -> operatorOrExprPatternParser
         TkQConSym {} -> operatorOrExprPatternParser
         TkReservedColon -> operatorOrExprPatternParser
+        TkReservedAt -> operatorOrExprPatternParser
         _ -> do
           isAs <- startsWithAsPattern
           if isAs
@@ -442,6 +443,7 @@ parenOrTuplePatternParser = withSpanAnn (PAnn . mkAnnotation) $ do
             TkConSym op -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym op)) [] [])
             TkQConSym modName op -> pure (PCon (mkName (Just modName) NameConSym op) [] [])
             TkReservedColon -> pure (PCon (qualifyName Nothing (mkUnqualifiedName NameConSym ":")) [] [])
+            TkReservedAt -> pure (PVar (mkUnqualifiedName NameVarSym "@"))
             _ ->
               MP.customFailure
                 UnexpectedTokenExpecting

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -501,6 +501,7 @@ prevTokenAllowsTightPrefix kind =
     TkReservedDoubleColon -> True
     TkReservedPipe -> True
     TkReservedBackslash -> True
+    TkTypeApp -> True
     TkPragma _ -> True
     _ -> False
 
@@ -531,6 +532,7 @@ lexTypeApplication :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 lexTypeApplication _env st =
   case lexerInput st of
     '@' :< rest
+      | startsWithSplice rest -> Just (emitToken st "@" TkTypeApp)
       | not (startsWithSymOp rest) ->
           -- GHC lexes visible type application syntax based on layout, not on
           -- whether TypeApplications is enabled. Extension validity is checked
@@ -554,6 +556,15 @@ lexTypeApplication _env st =
           | c == '_' -> True
           | c == '\'' -> True
           | c == '"' -> True
+        _ -> False
+    startsWithSplice t =
+      case t of
+        '$' :< ('$' :< rest) -> canStartSpliceAtomT rest
+        '$' :< rest -> canStartSpliceAtomT rest
+        _ -> False
+    canStartSpliceAtomT t =
+      case t of
+        c :< _ -> isIdentStart c || c == '('
         _ -> False
 
 lexOverloadedLabel :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
@@ -964,7 +975,7 @@ takeQuoter input =
         _ -> (T.take n input, chars)
 
 isIdentStart :: Char -> Bool
-isIdentStart c = isAsciiUpper c || isAsciiLower c || c == '_' || isUniSmall c || isUniLarge c
+isIdentStart c = isAsciiUpper c || isAsciiLower c || c == '_' || isUniSmall c || isUniLarge c || isUniOtherLetter c
 
 isVarIdentifierStartChar :: Char -> Bool
 isVarIdentifierStartChar c = c == '_' || isAsciiLower c || isUniSmall c
@@ -976,10 +987,13 @@ isConIdStart :: Char -> Bool
 isConIdStart c = isAsciiUpper c || isUniLarge c
 
 isUniSmall :: Char -> Bool
-isUniSmall c = not (isAscii c) && generalCategory c == LowercaseLetter
+isUniSmall c = not (isAscii c) && generalCategory c `elem` [LowercaseLetter, OtherLetter]
 
 isUniLarge :: Char -> Bool
 isUniLarge c = not (isAscii c) && generalCategory c `elem` [UppercaseLetter, TitlecaseLetter]
+
+isUniOtherLetter :: Char -> Bool
+isUniOtherLetter c = not (isAscii c) && generalCategory c == OtherLetter
 
 isIdentNumber :: Char -> Bool
 isIdentNumber c =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -752,6 +752,7 @@ infixConOperandNeedsParens (TList _ []) = True
 infixConOperandNeedsParens (TInfix {}) = True
 -- Application head determines what the parser sees first.
 infixConOperandNeedsParens (TApp f _) = infixConOperandNeedsParens f
+infixConOperandNeedsParens (TTypeApp _ TSplice {}) = True
 infixConOperandNeedsParens (TTypeApp f _) = infixConOperandNeedsParens f
 infixConOperandNeedsParens _ = False
 

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -548,7 +548,8 @@ addPatternBindLhsParens pat rhs =
     -- Bare @name :: ty = rhs@ is valid declaration syntax and is handled by a
     -- dedicated decl parser path. Other typed patterns must stay grouped so the
     -- parser does not reinterpret them as signatures.
-    PTypeSig inner@(PVar {}) ty -> PTypeSig (addPatternAtomParens inner) (addTypeParens ty)
+    PTypeSig inner@(PVar name) ty ->
+      wrapPat (isSymbolicUName name) (PTypeSig (addPatternAtomParens inner) (addTypeParens ty))
     PTypeSig {} -> wrapPat True (addPatternParens pat)
     _ -> addPatternParens pat
 
@@ -1499,7 +1500,7 @@ addFunctionHeadPatternAtomParens pat =
     PCon _ typeArgs args
       | not (null typeArgs) || not (null args) -> wrapPat True (addPatternParens pat)
     PTypeSig inner@(PVar {}) ty ->
-      PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty)
+      wrapPat True (PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty))
     PTypeSig {} -> wrapPat True (addPatternParens pat)
     PAs {} -> addPatternParens pat
     PRecord {} -> addPatternParens pat

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -436,9 +436,11 @@ needsTypeParens ctx ty =
         -- TStar renders as @*@ which merges with the preceding @\@@ in TTypeApp
         -- to form a single operator token @\@*@.
         TStar {} -> True
-        -- TSplice renders as @$name@ or @$(expr)@; the @$@ merges with the
-        -- preceding @\@@ in TTypeApp to form a single operator token @\@$@.
-        TSplice {} -> True
+        -- TSplice renders as @$name@ or @$(expr)@. Parenthesizing this form in
+        -- type-application argument positions changes the pretty output from
+        -- @$expr@ to @(@$expr)@ and can trigger avoidable roundtrip mismatches
+        -- in instance heads.
+        TSplice {} -> False
         -- TImplicitParam parses greedily: as a TApp argument ?x :: T -> U absorbs
         -- the surrounding -> U into the implicit param type.
         TImplicitParam {} -> True
@@ -1490,10 +1492,15 @@ addFunctionHeadPatternAtomParens :: Pattern -> Pattern
 addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
+    PParen (PTypeSig inner@(PVar {}) ty) ->
+      PParen (PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty))
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSyntax {} -> wrapPat True (addPatternParens pat)
     PCon _ typeArgs args
       | not (null typeArgs) || not (null args) -> wrapPat True (addPatternParens pat)
+    PTypeSig inner@(PVar {}) ty ->
+      PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty)
+    PTypeSig {} -> wrapPat True (addPatternParens pat)
     PAs {} -> addPatternParens pat
     PRecord {} -> addPatternParens pat
     _ -> addPatternAtomParens pat

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -578,7 +578,7 @@ test_generatedConstructorSymbolsRejectReservedSpellings =
 test_generatedVariableSymbolsRejectReservedSpellings :: Assertion
 test_generatedVariableSymbolsRejectReservedSpellings =
   assertBool "reserved variable symbol spellings and dash runs must be rejected" $
-    not (any isValidGeneratedVarSym ["..", "=", "\\", "|", "|+", "<-", "->", "@", "~", "=>", "--", "---"])
+    not (any isValidGeneratedVarSym ["..", "=", "\\", "|", "|+", "<-", "->", "~", "=>", "--", "---"])
 
 test_generatedOperatorsRejectArrowTailSpellings :: Assertion
 test_generatedOperatorsRejectArrowTailSpellings =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-function-head-at-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-function-head-at-operator.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST pass -}
+f e (@) = do
+  undefined
+

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-function-head-type-sig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-function-head-type-sig.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST pass -}
+f (fn :: Int -> Int) = fn
+

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-gadt-record-at-field.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-gadt-record-at-field.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module S where
+
+data family C
+
+data instance C where
+  (:+) :: {(@) :: Int} -> C

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-template-splice-instance-head.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-template-splice-instance-head.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+module S where
+
+class C a
+
+instance C $(pure Int)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-typed-infix-app-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-typed-infix-app-roundtrip.hs
@@ -1,0 +1,3 @@
+{- ORACLE_TEST pass -}
+f = (fromBytes :: Int -> Int) 1 # other 2
+

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-unicode-varid-method.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-unicode-varid-method.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+module S where
+
+class C α where
+  ﬧ :: α -> α
+

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-instance-dollar.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-instance-dollar.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Parens.addModuleParens changes the parsed snippet -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TemplateHaskell #-}
 module M where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-proxy-dollar.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/th-proxy-dollar.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Parens.addModuleParens changes the parsed snippet -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE TemplateHaskell #-}
 module M where
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -267,14 +267,8 @@ isValidGeneratedVarSym op =
         && T.all isValidSymbolChar rest
         && op `Set.notMember` reservedOperators
         && not (isDashRun op)
-        && not (isTypeAppSplicePrefix op)
         && not (isOverloadedLabelPrefix op)
     Nothing -> False
-
--- | '@$' starts visible type application followed by a Template Haskell splice,
--- not an operator token.
-isTypeAppSplicePrefix :: Text -> Bool
-isTypeAppSplicePrefix = T.isPrefixOf "@$"
 
 -- | '#' followed by an identifier-start char is an overloaded label, not a symbol.
 isOverloadedLabelPrefix :: Text -> Bool

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -99,7 +99,6 @@ reservedOperators =
       "|",
       "<-",
       "->",
-      "@",
       "~",
       "=>",
       "-<",
@@ -268,8 +267,14 @@ isValidGeneratedVarSym op =
         && T.all isValidSymbolChar rest
         && op `Set.notMember` reservedOperators
         && not (isDashRun op)
+        && not (isTypeAppSplicePrefix op)
         && not (isOverloadedLabelPrefix op)
     Nothing -> False
+
+-- | '@$' starts visible type application followed by a Template Haskell splice,
+-- not an operator token.
+isTypeAppSplicePrefix :: Text -> Bool
+isTypeAppSplicePrefix = T.isPrefixOf "@$"
 
 -- | '#' followed by an identifier-start char is an overloaded label, not a symbol.
 isOverloadedLabelPrefix :: Text -> Bool


### PR DESCRIPTION
## Summary
- Fix parser rejection paths triggered by `sbv` package parsing where the lexer and declaration/pattern parsers treated specific tokens as non-operators.
- Add minimal oracle fixtures for the originally failing `sbv` cases.

## Why this failed
- `Lists.hs` used `f (@) = ...` in a function head; parser accepted type/application/sections differently and did not treat `@` as an operator in some function-head/expr paths.
- `ShefferStroke.hs` used a Unicode variable-method-like identifier (`ﬧ`) that was not accepted by identifier-start logic.
- The same underlying token/parenthesization gaps surfaced in function-head type signatures, template-splice instance heads, and parenthesization decisions around type application and splices.

## Changes
- `components/aihc-parser/src/Aihc/Parser/Internal/Common.hs`
- `components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs`
- `components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs`
- `components/aihc-parser/src/Aihc/Parser/Lex.hs`
- `components/aihc-parser/src/Aihc/Parser/Parens.hs`
- `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-function-head-at-operator.hs`
- `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-function-head-type-sig.hs`
- `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-template-splice-instance-head.hs`
- `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-typed-infix-app-roundtrip.hs`
- `components/aihc-parser/test/Test/Fixtures/oracle/Hackage/sbv-unicode-varid-method.hs`

## Validation
- `cabal run exe:aihc-dev -v0 -- hackage-tester sbv`

## Progress
- Parse errors: 2 -> 0
- Roundtrip fails: 4 -> 2
- Success rate: 93% -> 99%
