### PR TITLE
fix(parser): space promoted infix list elements

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -419,6 +419,7 @@ startsWithTick (TList Promoted _) = True
 startsWithTick (TCon _ Promoted) = True
 startsWithTick (TTuple _ Promoted _) = True
 startsWithTick (TApp f _) = startsWithTick f
+startsWithTick (TInfix lhs _ _ _) = startsWithTick lhs
 startsWithTick _ = False
 
 prettyType :: Type -> Doc ann

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -117,6 +117,7 @@ buildTests = do
             testCase "generated constructor identifiers accept unicode uppercase and number tails" test_generatedConstructorIdentifiersAcceptUnicodeCharacters,
             testCase "data declaration result kinds parenthesize contexts" test_dataDeclResultKindContextRoundTrips,
             testCase "promoted qualified constructors avoid char literal ambiguity" test_promotedQualifiedConstructorAvoidsCharLiteralAmbiguity,
+            testCase "promoted lists space infix elements starting with ticks" test_promotedListSpacesInfixElementsStartingWithTicks,
             testCase "boxed tuple infix constructor operands stay bare" test_boxedTupleInfixConOperandStaysBare,
             testCase "unboxed tuple infix constructor operands stay bare" test_unboxedTupleInfixConOperandStaysBare,
             testCase "data CTYPE pragmas round-trip" test_dataDeclCTypePragmaRoundTrips,
@@ -451,6 +452,36 @@ test_promotedQualifiedConstructorAvoidsCharLiteralAmbiguity = do
       expected = stripAnnotations (addDeclParens decl)
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty (addDeclParens decl)))
   assertEqual "pretty-printed declaration" "type (:+) :: ' A'.B.C" rendered
+  case parseDecl defaultConfig rendered of
+    ParseOk parsed -> assertEqual "round-tripped declaration" expected (stripAnnotations parsed)
+    ParseErr err -> assertFailure ("expected parse success for " <> T.unpack rendered <> "\n" <> MPE.errorBundlePretty err)
+
+test_promotedListSpacesInfixElementsStartingWithTicks :: Assertion
+test_promotedListSpacesInfixElementsStartingWithTicks = do
+  let textType lit =
+        TApp
+          (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "Text")) Promoted)
+          (TTypeLit (TypeLitSymbol lit (T.pack (show (T.unpack lit)))))
+      messageType =
+        TInfix
+          (textType "alpha")
+          (qualifyName Nothing (mkUnqualifiedName NameConSym ":<>:"))
+          Promoted
+          (textType "beta")
+      decl =
+        DeclTypeSyn
+          TypeSynDecl
+            { typeSynHead = PrefixBinderHead (mkUnqualifiedName NameConId "M1") [],
+              typeSynBody =
+                TList
+                  Promoted
+                  [ messageType,
+                    textType "gamma"
+                  ]
+            }
+      expected = stripAnnotations (addDeclParens decl)
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty (addDeclParens decl)))
+  assertEqual "pretty-printed declaration" "type M1 = ' ['Text \"alpha\" ':<>: 'Text \"beta\", 'Text \"gamma\"]" rendered
   case parseDecl defaultConfig rendered of
     ParseOk parsed -> assertEqual "round-tripped declaration" expected (stripAnnotations parsed)
     ParseErr err -> assertFailure ("expected parse success for " <> T.unpack rendered <> "\n" <> MPE.errorBundlePretty err)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-cons.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-cons.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Promoted list element boundaries break after infix ErrorMessage operators -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 module M where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-singleton.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/generic-lens-core-promoted-error-message-list-singleton.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail Promoted list elements containing infix ErrorMessage operators are not parenthesized in pretty-printed output -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 module M where


### PR DESCRIPTION
## Summary
- Fix promoted list/tuple tick disambiguation when the first element is an infix type whose left operand starts with a promotion tick.
- Convert the two generic-lens-core Hackage oracle fixtures from xfail to pass.
- Add a direct pretty-print roundtrip regression test for promoted lists containing infix ErrorMessage-style operators.

## Root cause
The pretty-printer decides whether promoted list and tuple syntax needs a space after the outer promotion tick with `startsWithTick`. That predicate looked through type applications, promoted constructors, promoted lists, and promoted tuples, but not through `TInfix`. For a type like `['Text "alpha" ':<>: 'Text "beta"]`, the AST element is `TInfix (TApp (TCon ... Promoted) ...) ...`, so the predicate returned false and rendered `'['Text ...]`. GHC then rejected the roundtripped module at the comma or closing bracket because the token boundary was ambiguous.

I considered parenthesizing every infix type inside promoted list elements, or adding a special delimited-list element context in `Parens`. Those are heavier and change more pretty output than needed. The selected fix teaches `startsWithTick` to inspect the left edge of infix types, which matches the actual lexical hazard and generalizes to any infix type whose left operand starts with a tick.

## Testing
- `cabal test -v0 aihc-parser:spec --test-options="--pattern promoted"`
- `just fmt`
- `just check`

## Progress counts
- Oracle fixtures: pass=1092, xfail=2, total=1094

## Notes
- `coderabbit review --prompt-only` was attempted after local checks, but CodeRabbit was rate-limited for the organization, so this PR proceeds per the repo guidance.
- No follow-up refactors are needed for this fix.