### PR TITLE
feat(dev): add targeted package resolver

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -28,6 +28,7 @@ where
 import Aihc.Parser.Syntax
   ( Annotation,
     BangType (..),
+    BinderHead,
     ClassDecl (..),
     ClassDeclItem (..),
     DataConDecl (..),
@@ -129,6 +130,8 @@ rhsSpan rhs =
 data Scope = Scope
   { scopeTerms :: Map.Map Text ResolvedName,
     scopeTypes :: Map.Map Text ResolvedName,
+    scopeConstructors :: Map.Map Text [Text],
+    scopeMethods :: Map.Map Text [Text],
     scopeQualifiedModules :: Map.Map Text Scope
   }
 
@@ -574,7 +577,7 @@ declSignatureScope decl signatureScopes =
 bindPatterns :: Scope -> SourceSpan -> Int -> [Pattern] -> (Int, Scope, [Pattern])
 bindPatterns typeScope ambient nextLocal pats =
   let (nextLocal', scopedEntries, pats') = foldl' step (nextLocal, [], []) pats
-   in (nextLocal', Scope (Map.fromList scopedEntries) Map.empty Map.empty, reverse pats')
+   in (nextLocal', Scope (Map.fromList scopedEntries) Map.empty Map.empty Map.empty Map.empty, reverse pats')
   where
     step (currentId, entries, acc) pat =
       let (nextId, scope, pat') = bindPattern typeScope ambient currentId pat
@@ -589,13 +592,13 @@ bindPattern typeScope lastSeen nextLocal pat =
       let sp = peelPatternSpan lastSeen pat
           resolvedName = ResolvedLocal nextLocal name
           annotation = ResolutionAnnotation sp (renderUnqualifiedName name) ResolutionNamespaceTerm resolvedName
-       in (nextLocal + 1, Scope (Map.singleton (renderUnqualifiedName name) resolvedName) Map.empty Map.empty, annotatePattern annotation (PVar name))
+       in (nextLocal + 1, Scope (Map.singleton (renderUnqualifiedName name) resolvedName) Map.empty Map.empty Map.empty Map.empty, annotatePattern annotation (PVar name))
     PTypeBinder binder ->
       let scoped = unionScope emptyScope typeScope
           binderName = mkUnqualifiedName NameVarId (tyVarBinderName binder)
           resolvedName = ResolvedLocal nextLocal binderName
           binder' = binder {tyVarBinderKind = fmap (resolveTypeAt scoped NoSourceSpan) (tyVarBinderKind binder)}
-          binderScope = Scope Map.empty (Map.singleton (tyVarBinderName binder) resolvedName) Map.empty
+          binderScope = Scope Map.empty (Map.singleton (tyVarBinderName binder) resolvedName) Map.empty Map.empty Map.empty
        in (nextLocal + 1, binderScope, PTypeBinder binder')
     PTypeSyntax form ty ->
       let here = peelPatternSpan lastSeen pat
@@ -628,7 +631,7 @@ bindPattern typeScope lastSeen nextLocal pat =
           aliasAnnotation =
             ResolutionAnnotation (spanStartNameSpan here aliasKey) aliasKey ResolutionNamespaceTerm aliasResolved
           (nextLocal', innerScope, inner') = bindPattern typeScope here (nextLocal + 1) inner
-          aliasScope = Scope (Map.singleton aliasKey aliasResolved) Map.empty Map.empty
+          aliasScope = Scope (Map.singleton aliasKey aliasResolved) Map.empty Map.empty Map.empty Map.empty
        in (nextLocal', unionScope innerScope aliasScope, annotatePattern aliasAnnotation (PAs alias inner'))
     PStrict inner ->
       let here = peelPatternSpan lastSeen pat
@@ -652,7 +655,7 @@ bindPattern typeScope lastSeen nextLocal pat =
               )
               (nextLocal, [], [])
               fields
-       in (nextLocal', Scope (Map.fromList entries) Map.empty Map.empty, PRecord name (reverse fields') wildcard)
+       in (nextLocal', Scope (Map.fromList entries) Map.empty Map.empty Map.empty Map.empty, PRecord name (reverse fields') wildcard)
     PTypeSig inner ty ->
       let here = peelPatternSpan lastSeen pat
           (nextLocal', scope, inner') = bindPattern typeScope here nextLocal inner
@@ -966,32 +969,57 @@ topLevelScope modu =
     moduleKeyText = moduleKey modu
     qualify = ResolvedTopLevel . (`mkQualifiedName` Just moduleKeyText)
     addDecl scope decl =
-      let (termNames, typeNames) = declExportedNames decl
+      let DeclExports termNames typeNames constructors methods = declExportedNames decl
           scope' = foldl' (\acc name -> insertTerm (renderUnqualifiedName name) (qualify name) acc) scope termNames
-       in foldl' (\acc name -> insertType (renderUnqualifiedName name) (qualify name) acc) scope' typeNames
+          scope'' = foldl' (\acc name -> insertType (renderUnqualifiedName name) (qualify name) acc) scope' typeNames
+          scope''' = scope'' {scopeConstructors = constructors `Map.union` scopeConstructors scope''}
+       in scope''' {scopeMethods = methods `Map.union` scopeMethods scope'''}
 
-declExportedNames :: Decl -> ([UnqualifiedName], [UnqualifiedName])
+data DeclExports = DeclExports [UnqualifiedName] [UnqualifiedName] (Map.Map Text [Text]) (Map.Map Text [Text])
+
+declExportedNames :: Decl -> DeclExports
 declExportedNames decl =
   case decl of
     DeclAnn _ inner -> declExportedNames inner
     DeclValue valueDecl ->
       case valueDecl of
-        FunctionBind name _ -> ([name], [])
+        FunctionBind name _ -> DeclExports [name] [] Map.empty Map.empty
         PatternBind _ pat _ ->
-          (map snd (collectPatVarBinders NoSourceSpan pat), [])
-    DeclTypeSig names _ -> (names, [])
+          DeclExports (map snd (collectPatVarBinders NoSourceSpan pat)) [] Map.empty Map.empty
+    DeclTypeSig names _ -> DeclExports names [] Map.empty Map.empty
     DeclClass classDecl ->
-      ( classDeclMethodNames (classDeclItems classDecl),
-        [binderHeadName (classDeclHead classDecl)]
-      )
-    DeclTypeData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [binderHeadName (dataDeclHead dataDecl)])
-    DeclData dataDecl -> (dataDeclConstructorNames (dataDeclConstructors dataDecl), [binderHeadName (dataDeclHead dataDecl)])
+      let className = binderHeadName (classDeclHead classDecl)
+          methodNames = classDeclMethodNames (classDeclItems classDecl)
+       in DeclExports
+            methodNames
+            [className]
+            Map.empty
+            (Map.singleton (renderUnqualifiedName className) (map renderUnqualifiedName methodNames))
+    DeclTypeData dataDecl ->
+      dataDeclExports (dataDeclHead dataDecl) (dataDeclConstructors dataDecl)
+    DeclData dataDecl ->
+      dataDeclExports (dataDeclHead dataDecl) (dataDeclConstructors dataDecl)
     DeclNewtype newtypeDecl ->
-      ( maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl),
-        [binderHeadName (newtypeDeclHead newtypeDecl)]
-      )
-    DeclTypeSyn typeSynDecl -> ([], [binderHeadName (typeSynHead typeSynDecl)])
-    _ -> ([], [])
+      let typeName = binderHeadName (newtypeDeclHead newtypeDecl)
+          termNames = maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl)
+          constructorNames = maybe [] dataConDeclConstructorNames (newtypeDeclConstructor newtypeDecl)
+       in DeclExports termNames [typeName] (constructorMap typeName constructorNames) Map.empty
+    DeclTypeSyn typeSynDecl -> DeclExports [] [binderHeadName (typeSynHead typeSynDecl)] Map.empty Map.empty
+    _ -> DeclExports [] [] Map.empty Map.empty
+
+dataDeclExports :: BinderHead UnqualifiedName -> [DataConDecl] -> DeclExports
+dataDeclExports headBinder constructors =
+  let typeName = binderHeadName headBinder
+   in DeclExports
+        (dataDeclConstructorNames constructors)
+        [typeName]
+        (constructorMap typeName (concatMap dataConDeclConstructorNames constructors))
+        Map.empty
+
+constructorMap :: UnqualifiedName -> [UnqualifiedName] -> Map.Map Text [Text]
+constructorMap typeName constructors
+  | null constructors = Map.empty
+  | otherwise = Map.singleton (renderUnqualifiedName typeName) (map renderUnqualifiedName constructors)
 
 classDeclMethodNames :: [ClassDeclItem] -> [UnqualifiedName]
 classDeclMethodNames = concatMap go
@@ -1013,6 +1041,20 @@ dataConDeclNames dataConDecl =
           InfixCon _ _ _ name _ -> [name]
           RecordCon _ _ name fields -> name : concatMap fieldNames fields
           GadtCon _ _ names (GadtRecordBody fields _) -> names <> concatMap fieldNames fields
+          GadtCon _ _ names _ -> names
+          TupleCon _ _ flavor fields -> [tupleConName flavor (length fields)]
+          UnboxedSumCon _ _ pos arity _ -> [unboxedSumConName pos arity]
+          ListCon {} -> [listConName]
+   in go dataConDecl
+
+dataConDeclConstructorNames :: DataConDecl -> [UnqualifiedName]
+dataConDeclConstructorNames dataConDecl =
+  let go d =
+        case d of
+          DataConAnn _ inner -> go inner
+          PrefixCon _ _ name _ -> [name]
+          InfixCon _ _ _ name _ -> [name]
+          RecordCon _ _ name _ -> [name]
           GadtCon _ _ names _ -> names
           TupleCon _ _ flavor fields -> [tupleConName flavor (length fields)]
           UnboxedSumCon _ _ pos arity _ -> [unboxedSumConName pos arity]
@@ -1081,6 +1123,8 @@ filterImportSpec maybeSpec scope =
                   then scopeTerms scope
                   else Map.filterWithKey (\n _ -> n `elem` allowed) (scopeTerms scope),
               scopeTypes = Map.filterWithKey (\n _ -> n `elem` allowed) (scopeTypes scope),
+              scopeConstructors = Map.filterWithKey (\n _ -> n `elem` allowed) (scopeConstructors scope),
+              scopeMethods = Map.filterWithKey (\n _ -> n `elem` allowed) (scopeMethods scope),
               scopeQualifiedModules = scopeQualifiedModules scope
             }
     Just ImportSpec {importSpecHiding = True, importSpecItems} ->
@@ -1134,7 +1178,7 @@ moduleKey :: Module -> Text
 moduleKey modu = fromMaybe (T.pack "Main") (moduleName modu)
 
 emptyScope :: Scope
-emptyScope = Scope Map.empty Map.empty Map.empty
+emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty
 
 -- | Scope containing all wired-in Haskell built-ins that have no defining
 -- source module but act like regular names during name resolution.
@@ -1158,6 +1202,8 @@ builtinScope =
   Scope
     { scopeTerms = Map.fromList (map mkBuiltinTerm builtinTermNames),
       scopeTypes = Map.fromList (map mkBuiltinType builtinTypeNames),
+      scopeConstructors = Map.empty,
+      scopeMethods = Map.empty,
       scopeQualifiedModules = Map.empty
     }
   where
@@ -1213,6 +1259,8 @@ unionScope left right =
   Scope
     { scopeTerms = scopeTerms left `Map.union` scopeTerms right,
       scopeTypes = scopeTypes left `Map.union` scopeTypes right,
+      scopeConstructors = scopeConstructors left `Map.union` scopeConstructors right,
+      scopeMethods = scopeMethods left `Map.union` scopeMethods right,
       scopeQualifiedModules = scopeQualifiedModules left `Map.union` scopeQualifiedModules right
     }
 
@@ -1245,6 +1293,8 @@ filterScopeByNames keep scope =
   Scope
     { scopeTerms = Map.filterWithKey (\name _ -> keep name) (scopeTerms scope),
       scopeTypes = Map.filterWithKey (\name _ -> keep name) (scopeTypes scope),
+      scopeConstructors = Map.filterWithKey (\name _ -> keep name) (scopeConstructors scope),
+      scopeMethods = Map.filterWithKey (\name _ -> keep name) (scopeMethods scope),
       scopeQualifiedModules = scopeQualifiedModules scope
     }
 

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -67,6 +67,7 @@ executable aihc-dev
   other-modules:
     Aihc.Dev.HackageTester.Run
     BootInterface
+    ResolvePackage
     ResolveStackageProgress
     StackageProgress.CLI
     StackageProgress.FileChecker
@@ -115,24 +116,32 @@ test-suite spec
   hs-source-dirs:
     test
     app/stackage-progress
+    app/resolve-stackage-progress
 
   main-is: Spec.hs
   other-modules:
+    BootInterface
+    ResolvePackage
+    ResolveStackageProgress
     StackageProgress.CLI
     StackageProgress.FileChecker
     StackageProgress.FileCheckerTiming
+    Test.ResolvePackage
     Test.ResolveStackageProgress.PathsModule
     Test.StackageProgress.FileChecker
     Test.StackageProgress.FileCheckerTiming
 
   build-depends:
+    Cabal-syntax >=3.14 && <3.17,
     aeson >=2.0 && <2.3,
+    aeson-pretty >=0.8 && <0.9,
     aihc-cpp,
     aihc-dev:snippet,
     aihc-hackage,
     aihc-parser,
     aihc-parser:parser-tooling-common,
     aihc-resolve,
+    async,
     base >=4.16 && <5,
     bytestring,
     containers,
@@ -141,10 +150,12 @@ test-suite spec
     filepath,
     haskell-src-exts,
     optparse-applicative >=0.16 && <0.19,
+    process >=1.6 && <1.8,
     tasty,
     tasty-hunit,
     tasty-quickcheck,
     text >=1.2.3 && <2.2,
+    yaml >=0.11 && <0.12,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
@@ -163,6 +163,8 @@ bootModuleToScope bmi =
   Scope
     { scopeTerms = Map.fromList termEntries,
       scopeTypes = Map.fromList typeEntries,
+      scopeConstructors = bmiConstructors bmi,
+      scopeMethods = bmiMethods bmi,
       scopeQualifiedModules = Map.empty
     }
   where

--- a/tooling/aihc-dev/app/resolve-stackage-progress/ResolvePackage.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/ResolvePackage.hs
@@ -1,0 +1,290 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ResolvePackage
+  ( InterfaceFormat (..),
+    Options (..),
+    ResolveModuleIface (..),
+    ResolvePackageIface (..),
+    dependencyClosure,
+    formatDependencyFailure,
+    interfaceFromExports,
+    optionsParser,
+    renderInterfaceJSON,
+    renderInterfaceYAML,
+    run,
+    targetLayers,
+  )
+where
+
+import Aihc.Hackage.Stackage (loadStackageSnapshot)
+import Aihc.Hackage.Types (PackageSpec (..))
+import Aihc.Resolve (ModuleExports, Scope (..))
+import BootInterface (bootPackageNames, loadBootInterfaces)
+import Control.Exception (SomeException, try)
+import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.ByteString.Lazy qualified as BL
+import Data.List (find, sort)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Yaml qualified as Yaml
+import Options.Applicative qualified as OA
+import ResolveStackageProgress
+  ( PackageInfo (..),
+    PackageStatus (..),
+    collectPackageInfo,
+    kahnLayers,
+    processLayers,
+  )
+import ResolveStackageProgress qualified as RSP
+import System.Exit (exitFailure)
+import System.IO (hPrint, hPutStrLn, stderr)
+
+data InterfaceFormat = InterfaceYAML | InterfaceJSON
+  deriving (Eq, Show)
+
+data Options = Options
+  { optPackage :: String,
+    optSnapshot :: String,
+    optOffline :: Bool,
+    optFormat :: InterfaceFormat
+  }
+
+optionsParser :: OA.Parser Options
+optionsParser =
+  Options
+    <$> OA.strArgument
+      ( OA.metavar "PACKAGE"
+          <> OA.help "Package name from the selected Stackage snapshot"
+      )
+    <*> OA.strOption
+      ( OA.long "snapshot"
+          <> OA.metavar "SNAPSHOT"
+          <> OA.value "lts-24.33"
+          <> OA.showDefault
+          <> OA.help "Stackage snapshot to resolve"
+      )
+    <*> OA.switch
+      ( OA.long "offline"
+          <> OA.help "Use only cached packages, don't download"
+      )
+    <*> OA.option
+      parseFormat
+      ( OA.long "format"
+          <> OA.metavar "yaml|json"
+          <> OA.value InterfaceYAML
+          <> OA.showDefaultWith renderFormat
+          <> OA.help "Interface output format"
+      )
+
+parseFormat :: OA.ReadM InterfaceFormat
+parseFormat =
+  OA.eitherReader $ \case
+    "yaml" -> Right InterfaceYAML
+    "json" -> Right InterfaceJSON
+    _ -> Left "expected yaml or json"
+
+renderFormat :: InterfaceFormat -> String
+renderFormat InterfaceYAML = "yaml"
+renderFormat InterfaceJSON = "json"
+
+data ResolvePackageIface = ResolvePackageIface
+  { rpiPackage :: Text,
+    rpiModules :: [ResolveModuleIface]
+  }
+  deriving (Eq, Show)
+
+instance ToJSON ResolvePackageIface where
+  toJSON rpi =
+    object
+      [ "package" .= rpiPackage rpi,
+        "modules" .= rpiModules rpi
+      ]
+
+data ResolveModuleIface = ResolveModuleIface
+  { rmiModule :: Text,
+    rmiTerms :: [Text],
+    rmiTypes :: [Text],
+    rmiConstructors :: Map Text [Text],
+    rmiMethods :: Map Text [Text]
+  }
+  deriving (Eq, Show)
+
+instance ToJSON ResolveModuleIface where
+  toJSON rmi =
+    object
+      [ "module" .= rmiModule rmi,
+        "terms" .= rmiTerms rmi,
+        "types" .= rmiTypes rmi,
+        "constructors" .= rmiConstructors rmi,
+        "methods" .= rmiMethods rmi
+      ]
+
+interfaceFromExports :: Text -> ModuleExports -> ResolvePackageIface
+interfaceFromExports pkg iface =
+  ResolvePackageIface
+    { rpiPackage = pkg,
+      rpiModules = map (uncurry moduleIfaceFromScope) (Map.toAscList iface)
+    }
+
+moduleIfaceFromScope :: Text -> Scope -> ResolveModuleIface
+moduleIfaceFromScope modName scope =
+  ResolveModuleIface
+    { rmiModule = modName,
+      rmiTerms = sort (Map.keys (scopeTerms scope)),
+      rmiTypes = sort (Map.keys (scopeTypes scope)),
+      rmiConstructors = fmap sort (scopeConstructors scope),
+      rmiMethods = fmap sort (scopeMethods scope)
+    }
+
+renderInterfaceJSON :: ResolvePackageIface -> BL.ByteString
+renderInterfaceJSON = encodePretty
+
+renderInterfaceYAML :: ResolvePackageIface -> BL.ByteString
+renderInterfaceYAML = BL.fromStrict . Yaml.encode
+
+dependencyClosure :: Text -> Map Text [Text] -> Set Text
+dependencyClosure target depGraph = go Set.empty [target]
+  where
+    go seen [] = seen
+    go seen (pkg : rest)
+      | pkg `Set.member` seen = go seen rest
+      | otherwise =
+          let deps = Map.findWithDefault [] pkg depGraph
+           in go (Set.insert pkg seen) (deps ++ rest)
+
+targetLayers :: Text -> Map Text [Text] -> [[Text]]
+targetLayers target depGraph =
+  let closure = dependencyClosure target depGraph
+      subGraph =
+        Map.fromSet
+          (\pkg -> filter (`Set.member` closure) (Map.findWithDefault [] pkg depGraph))
+          closure
+   in kahnLayers subGraph
+
+formatDependencyFailure :: Text -> Map Text [Text] -> Map Text PackageStatus -> String
+formatDependencyFailure target depGraph results =
+  let closure = Set.delete target (dependencyClosure target depGraph)
+      failed =
+        [ (pkg, msg)
+        | pkg <- Set.toAscList closure,
+          Just (PkgFailed msg) <- [Map.lookup pkg results]
+        ]
+      skipped =
+        [ pkg
+        | pkg <- Set.toAscList closure,
+          Just PkgSkipped <- [Map.lookup pkg results]
+        ]
+      renderFailed (pkg, msg) =
+        "  " ++ T.unpack pkg ++ ":\n" ++ unlines ["    " ++ line | line <- take 5 (lines msg)]
+      failedBlock = concatMap renderFailed failed
+      skippedBlock =
+        if null skipped
+          then ""
+          else "Skipped because dependencies failed: " ++ T.unpack (T.intercalate ", " skipped) ++ "\n"
+   in "Could not resolve " ++ T.unpack target ++ " because dependencies failed.\n" ++ failedBlock ++ skippedBlock
+
+run :: Options -> IO ()
+run opts = do
+  snapshotResult <- loadStackageSnapshot Nothing (optSnapshot opts) (optOffline opts)
+  packages <- case snapshotResult of
+    Left err -> hPutStrLn stderr ("Failed to load snapshot: " ++ err) >> exitFailure
+    Right pkgs -> pure pkgs
+
+  let target = T.pack (optPackage opts)
+      snapshotNames = Set.fromList (map (T.pack . pkgName) packages)
+  case find ((== optPackage opts) . pkgName) packages of
+    Nothing -> do
+      hPutStrLn stderr ("Package not found in " ++ optSnapshot opts ++ ": " ++ optPackage opts)
+      exitFailure
+    Just targetSpec
+      | target `Set.member` bootPackageNames -> resolveBootTarget opts target
+      | otherwise -> resolveSourceTarget opts target targetSpec packages snapshotNames
+
+resolveBootTarget :: Options -> Text -> IO ()
+resolveBootTarget opts target = do
+  bootIfaceMap <- loadBootInterfaces
+  case Map.lookup target bootIfaceMap of
+    Nothing -> hPutStrLn stderr ("Boot interface not found for " ++ T.unpack target) >> exitFailure
+    Just iface -> writeInterface opts (interfaceFromExports target iface)
+
+resolveSourceTarget :: Options -> Text -> PackageSpec -> [PackageSpec] -> Set Text -> IO ()
+resolveSourceTarget opts target targetSpec packages snapshotNames = do
+  targetInfoResult <- try (collectPackageInfo (optOffline opts) targetSpec snapshotNames)
+  (targetName, targetInfo) <- case targetInfoResult of
+    Left (e :: SomeException) -> hPrint stderr e >> exitFailure
+    Right r -> pure r
+  let firstDepGraph = Map.singleton targetName (piSnapshotDeps targetInfo)
+      initialClosure = dependencyClosure target firstDepGraph
+      packageMap = Map.fromList [(T.pack (pkgName spec), spec) | spec <- packages]
+  infos <- collectClosureInfos opts packageMap snapshotNames (Map.singleton targetName targetInfo) initialClosure
+  let depGraph = Map.fromList [(name, piSnapshotDeps info) | (name, info) <- Map.toList infos]
+      closure = dependencyClosure target depGraph
+      missing = Set.toList (Set.difference closure (Map.keysSet infos `Set.union` bootPackageNames))
+  if null missing
+    then pure ()
+    else do
+      hPutStrLn stderr ("Missing package info for: " ++ T.unpack (T.intercalate ", " missing))
+      exitFailure
+
+  bootIfaceMap <- loadBootInterfaces
+  let bootExports = foldl' Map.union Map.empty (Map.elems bootIfaceMap)
+      sourceClosure = Set.difference closure bootPackageNames
+      sourceInfos = Map.restrictKeys infos sourceClosure
+      sourceDepGraph = Map.map (filter (`Set.member` sourceClosure)) (Map.restrictKeys depGraph sourceClosure)
+      layers = targetLayers target sourceDepGraph
+      bootResults =
+        Map.fromList
+          [(pkg, PkgSuccess iface) | (pkg, iface) <- Map.toList bootIfaceMap, pkg `Set.member` closure]
+  results <- processLayers progressOptions bootExports layers sourceInfos sourceDepGraph bootResults
+  case Map.lookup target results of
+    Just (PkgSuccess iface) -> writeInterface opts (interfaceFromExports target iface)
+    Just (PkgFailed msg) -> hPutStrLn stderr msg >> exitFailure
+    Just PkgSkipped -> hPutStrLn stderr (formatDependencyFailure target depGraph results) >> exitFailure
+    Nothing -> hPutStrLn stderr ("No result produced for " ++ T.unpack target) >> exitFailure
+  where
+    progressOptions =
+      RSP.Options
+        { RSP.optSnapshot = optSnapshot opts,
+          RSP.optJobs = 1,
+          RSP.optOffline = optOffline opts,
+          RSP.optTopFailures = 10
+        }
+
+collectClosureInfos ::
+  Options ->
+  Map Text PackageSpec ->
+  Set Text ->
+  Map Text PackageInfo ->
+  Set Text ->
+  IO (Map Text PackageInfo)
+collectClosureInfos opts packageMap snapshotNames = go
+  where
+    go infos wanted =
+      let sourceWanted = Set.difference wanted bootPackageNames
+          missing = Set.difference sourceWanted (Map.keysSet infos)
+       in if Set.null missing
+            then pure infos
+            else do
+              newInfos <- mapM collectOne (Set.toList missing)
+              let infos' = foldl' (\acc (name, info) -> Map.insert name info acc) infos newInfos
+                  depGraph = Map.fromList [(name, piSnapshotDeps info) | (name, info) <- Map.toList infos']
+                  wanted' = foldl' Set.union wanted [dependencyClosure name depGraph | name <- Map.keys infos']
+              go infos' wanted'
+    collectOne name =
+      case Map.lookup name packageMap of
+        Nothing -> pure (name, PackageInfo "" [] [])
+        Just spec -> collectPackageInfo (optOffline opts) spec snapshotNames
+
+writeInterface :: Options -> ResolvePackageIface -> IO ()
+writeInterface opts iface =
+  BL.putStr $
+    case optFormat opts of
+      InterfaceYAML -> renderInterfaceYAML iface
+      InterfaceJSON -> renderInterfaceJSON iface

--- a/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
@@ -4,7 +4,15 @@
 
 module ResolveStackageProgress
   ( Options (..),
+    PackageInfo (..),
+    PackageStatus (..),
+    collectPackageInfo,
+    gatherDepExports,
+    kahnLayers,
     optionsParser,
+    phase1Parallel,
+    processLayers,
+    resolveOnePackage,
     run,
   )
 where

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -11,6 +11,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Yaml qualified as Yaml
 import HackageTester.CLI qualified as HackageTesterCLI
 import Options.Applicative
+import ResolvePackage qualified as RP
 import ResolveStackageProgress qualified as RSP
 import StackageProgress.CLI qualified as ParserStackageProgressCLI
 import StackageProgress.Run qualified as ParserStackageProgressRun
@@ -36,6 +37,7 @@ data Command
   | Snippet SnippetOpts
   | HackageTester HackageTesterCLI.Options
   | ParserStackageProgress ParserStackageProgressCLI.Options
+  | ResolvePackage RP.Options
   | ResolveStackageProgress RSP.Options
 
 data ExtractHiOpts = ExtractHiOpts
@@ -83,6 +85,12 @@ commandParser =
           ( info
               (ParserStackageProgress <$> ParserStackageProgressCLI.optionsParser <**> helper)
               (progDesc "Test parser on Stackage snapshot packages")
+          )
+        <> command
+          "resolve"
+          ( info
+              (ResolvePackage <$> RP.optionsParser <**> helper)
+              (progDesc "Resolve names in a Stackage package and print its resolver interface")
           )
         <> command
           "resolve-stackage-progress"
@@ -160,5 +168,7 @@ runCommand (HackageTester opts) =
   HackageTesterRun.run opts
 runCommand (ParserStackageProgress opts) =
   ParserStackageProgressRun.run opts
+runCommand (ResolvePackage opts) =
+  RP.run opts
 runCommand (ResolveStackageProgress opts) =
   RSP.run opts

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -10,6 +10,7 @@ import Aihc.Dev.Snippet
     renderSnippetReport,
   )
 import Aihc.Parser.Syntax (Extension (TypeApplications), ExtensionSetting (..))
+import Test.ResolvePackage (resolvePackageTests)
 import Test.ResolveStackageProgress.PathsModule (resolveStackagePathsModuleTests)
 import Test.StackageProgress.FileChecker (stackageProgressFileCheckerTests)
 import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimingTests)
@@ -39,6 +40,7 @@ main =
       testCase "parses -X extension arguments" $ do
         assertEqual "extension" (Right (EnableExtension TypeApplications)) (parseExtensionSettingArg "TypeApplications"),
       QC.testProperty "dummy quickcheck property" prop_dummy,
+      resolvePackageTests,
       resolveStackagePathsModuleTests,
       stackageProgressFileCheckerTests,
       stackageProgressFileCheckerTimingTests

--- a/tooling/aihc-dev/test/Test/ResolvePackage.hs
+++ b/tooling/aihc-dev/test/Test/ResolvePackage.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.ResolvePackage
+  ( resolvePackageTests,
+  )
+where
+
+import Aihc.Parser.Syntax (NameType (..), mkQualifiedName, mkUnqualifiedName)
+import Aihc.Resolve (ResolvedName (..), Scope (..))
+import Data.ByteString.Lazy.Char8 qualified as BL8
+import Data.List (isInfixOf)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import ResolvePackage
+  ( ResolveModuleIface (..),
+    ResolvePackageIface (..),
+    dependencyClosure,
+    formatDependencyFailure,
+    interfaceFromExports,
+    renderInterfaceJSON,
+    targetLayers,
+  )
+import ResolveStackageProgress (PackageStatus (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+resolvePackageTests :: TestTree
+resolvePackageTests =
+  testGroup
+    "resolve package"
+    [ testCase "selects transitive dependency closure" test_dependencyClosure,
+      testCase "orders only target dependency layers" test_targetLayers,
+      testCase "renders stable sorted interface JSON" test_renderInterfaceJSON,
+      testCase "formats dependency failures separately from target failures" test_formatDependencyFailure
+    ]
+
+test_dependencyClosure :: IO ()
+test_dependencyClosure = do
+  let graph =
+        Map.fromList
+          [ ("target", ["a", "b"]),
+            ("a", ["base"]),
+            ("b", ["a"]),
+            ("base", []),
+            ("unrelated", ["base"])
+          ]
+  assertEqual
+    "closure"
+    (Set.fromList ["target", "a", "b", "base"])
+    (dependencyClosure "target" graph)
+
+test_targetLayers :: IO ()
+test_targetLayers = do
+  let graph =
+        Map.fromList
+          [ ("target", ["a", "b"]),
+            ("a", ["base"]),
+            ("b", ["a"]),
+            ("base", []),
+            ("unrelated", [])
+          ]
+  assertEqual
+    "target layers"
+    [["base"], ["a"], ["b"], ["target"]]
+    (targetLayers "target" graph)
+
+test_renderInterfaceJSON :: IO ()
+test_renderInterfaceJSON = do
+  let iface =
+        interfaceFromExports
+          "demo"
+          ( Map.fromList
+              [ ("Z", mkScope ["zterm"] ["Zed"]),
+                ("A", (mkScope ["beta", "alpha"] ["Thing"]) {scopeConstructors = Map.singleton "Thing" ["MkThing"], scopeMethods = Map.singleton "Classy" ["method"]})
+              ]
+          )
+      rendered = BL8.unpack (renderInterfaceJSON iface)
+  assertEqual
+    "structured interface"
+    ( ResolvePackageIface
+        "demo"
+        [ ResolveModuleIface "A" ["alpha", "beta"] ["Thing"] (Map.singleton "Thing" ["MkThing"]) (Map.singleton "Classy" ["method"]),
+          ResolveModuleIface "Z" ["zterm"] ["Zed"] Map.empty Map.empty
+        ]
+    )
+    iface
+  assertBool "JSON includes constructors" ("\"MkThing\"" `isInfixOf` rendered)
+  assertBool "JSON includes methods" ("\"method\"" `isInfixOf` rendered)
+  assertBool "JSON includes first sorted module" ("\"module\": \"A\"" `isInfixOf` rendered)
+  assertBool "JSON includes sorted terms" ("\"alpha\"" `isInfixOf` rendered && "\"beta\"" `isInfixOf` rendered)
+
+test_formatDependencyFailure :: IO ()
+test_formatDependencyFailure = do
+  let graph =
+        Map.fromList
+          [ ("target", ["dep", "other"]),
+            ("dep", []),
+            ("other", ["dep"])
+          ]
+      results =
+        Map.fromList
+          [ ("dep", PkgFailed "dep failed\nextra detail\nmore detail\nmore detail\nmore detail\nhidden"),
+            ("other", PkgSkipped),
+            ("target", PkgSkipped)
+          ]
+      rendered = formatDependencyFailure "target" graph results
+  assertBool "mentions dependency failure" ("dep failed" `isInfixOf` rendered)
+  assertBool "mentions skipped dependency" ("Skipped because dependencies failed: other" `isInfixOf` rendered)
+  assertBool "does not report target as dependency" (not ("target:" `isInfixOf` rendered))
+
+mkScope :: [Text] -> [Text] -> Scope
+mkScope terms types =
+  Scope
+    { scopeTerms = Map.fromList [(name, resolve name) | name <- terms],
+      scopeTypes = Map.fromList [(name, resolve name) | name <- types],
+      scopeConstructors = Map.empty,
+      scopeMethods = Map.empty,
+      scopeQualifiedModules = Map.empty
+    }
+  where
+    resolve name =
+      ResolvedTopLevel (mkQualifiedName (mkUnqualifiedName NameVarId name) (Just "M"))

--- a/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
+++ b/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
@@ -112,6 +112,8 @@ mkScope moduleName terms types =
   Scope
     { scopeTerms = Map.fromList [(name, resolve name) | name <- terms],
       scopeTypes = Map.fromList [(name, resolve name) | name <- types],
+      scopeConstructors = Map.empty,
+      scopeMethods = Map.empty,
       scopeQualifiedModules = Map.empty
     }
   where


### PR DESCRIPTION
## Summary

- Add `aihc-dev resolve PACKAGE` for focused resolver debugging against a selected Stackage snapshot.
- Resolve the requested package dependency closure, then print only the target package resolver interface as YAML or JSON.
- Preserve constructor and class-method groupings in resolver `Scope` so interfaces include `terms`, `types`, `constructors`, and `methods`.

## Validation

- `cabal run -v0 exe:aihc-dev -- resolve base --offline --format json`
- `cabal test -v0 all --test-options=--hide-successes`
- `just fmt`
- `just check`

## Progress Counts

- No README progress counts updated; this adds a debugging command and interface metadata, not a resolver coverage fix.

## Pre-PR Review

- `coderabbit review --prompt-only` was attempted but skipped because the CodeRabbit account is currently over its review cap.
