### PR TITLE
fix(cpp): preserve indented hash operators

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp/Parser.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Parser.hs
@@ -73,7 +73,7 @@ parseDirectiveBody body =
           "line" -> parseLineDirective rest
           "warning" -> Just (DirWarning rest)
           "error" -> Just (DirError rest)
-          _ -> Just (DirUnsupported name)
+          _ -> Nothing
 
 parseLineDirective :: Text -> Maybe Directive
 parseLineDirective body =

--- a/components/aihc-cpp/test/Test/Fixtures/progress/indented-hash-operator.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/indented-hash-operator.hs
@@ -1,0 +1,2 @@
+f = (d
+    # reflectY)

--- a/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -25,6 +25,7 @@ function-macro-guard-patterns	macro	function-macro-guard-patterns.hs	pass
 line-directive-file-and-number	diagnostics	line-directive-file-and-number.hs	pass
 line-directive-number-only	diagnostics	line-directive-number-only.hs	pass
 language-pragma-closing-line	lexing	language-pragma-closing-line.hs	pass
+indented-hash-operator	lexing	indented-hash-operator.hs	pass
 macro-in-comment	lexing	macro-in-comment.hs	pass
 macro-in-inline-block-comment	lexing	macro-in-inline-block-comment.hs	pass
 macro-in-line-comment	lexing	macro-in-line-comment.hs	pass


### PR DESCRIPTION
## Summary

- Preserve unknown indented `# name` lines as source instead of treating them as unsupported CPP directives.
- Add a cpp oracle regression for an indented `#` operator continuation, matching cpphs/GHC CPP behavior.

## Root Cause

`aihc-cpp` parsed any leading-whitespace `# identifier` line with an unrecognized name as `DirUnsupported`, which blanked the line and emitted a warning. That incorrectly consumed Haskell source such as `    # reflectY)` after pretty-printing.

## Progress

- aihc-cpp progress: PASS 44, XFAIL 0, XPASS 0, FAIL 0, TOTAL 44, COMPLETE 100.0%.

## Validation

- `cabal test -v0 aihc-cpp:spec --test-options="--pattern indented-hash-operator"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
