### PR TITLE
fix(parser): avoid spurious let do parens

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1126,12 +1126,17 @@ addDoStmtParens stmt =
     DoAnn ann inner -> DoAnn ann (addDoStmtParens inner)
     DoBind pat e -> DoBind (addPatternParens pat) (addExprParens e)
     DoLetDecls decls -> DoLetDecls (map addDeclParens decls)
-    DoExpr e -> DoExpr (wrapExpr (isLetExpr e) (addExprParens e))
+    DoExpr e -> DoExpr (wrapExpr (letExprNeedsDoStmtParens e) (addExprParens e))
     DoRecStmt stmts -> DoRecStmt (map addDoStmtParens stmts)
   where
-    isLetExpr ELetDecls {} = True
-    isLetExpr (EAnn _ inner) = isLetExpr inner
-    isLetExpr _ = False
+    letExprNeedsDoStmtParens (ELetDecls (_ : _) body) = not (isInfixExpr body)
+    letExprNeedsDoStmtParens (ELetDecls [] _) = True
+    letExprNeedsDoStmtParens (EAnn _ inner) = letExprNeedsDoStmtParens inner
+    letExprNeedsDoStmtParens _ = False
+
+    isInfixExpr EInfix {} = True
+    isInfixExpr (EAnn _ inner) = isInfixExpr inner
+    isInfixExpr _ = False
 
 addCompStmtParens :: CompStmt -> CompStmt
 addCompStmtParens stmt =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1150,7 +1150,7 @@ prettyExpr expr =
     ELetDecls decls body ->
       case decls of
         [] -> prettyLetDecls decls <+> "in" <+> prettyExpr body
-        _ -> align (prettyLetDecls decls <> hardline <> "in" <+> prettyExpr body)
+        _ -> align (prettyLetDecls decls <> hardline <> indent 2 ("in" <+> prettyExpr body))
     ECase scrutinee alts ->
       prettyCaseExpr prettyCaseLayout scrutinee alts
     EDo stmts flavor ->

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -843,7 +843,7 @@ test_prettyCaseExpressionUsesImplicitLayout = do
 test_prettyLetExpressionUsesImplicitLayout :: Assertion
 test_prettyLetExpressionUsesImplicitLayout = do
   let source = "let { x = 10 } in x + x"
-      expected = T.intercalate "\n" ["let", "  x =", "    10", "in x", " + x"]
+      expected = T.intercalate "\n" ["let", "  x =", "    10", "  in x", "   + x"]
   case parseExpr defaultConfig source of
     ParseOk expr -> do
       let rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/csp-let-lhs-infix-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/csp-let-lhs-infix-roundtrip.hs
@@ -1,0 +1,15 @@
+{- ORACLE_TEST pass -}
+module CspLetLhsInfixRoundtrip where
+
+f dvcs' =
+  unsafePerformIO $
+    runAmb $ do
+      dvcs <- lift $ readIORef dvcs'
+      let
+        loop [] = return ()
+        loop (d : ds) =
+          do
+            dvcABinding d
+            filterM (liftM not . dvcIsBound) ds >>= loop
+       in filterM (liftM not . dvcIsBound) dvcs >>= loop
+      lift $ result dvcs


### PR DESCRIPTION
## Summary
- avoid adding an outer expression paren for non-empty `let ... in <infix>` do statements
- render non-empty `let` expressions with `in` indented under the let layout so the bare do-statement form remains GHC-parseable
- add an oracle regression fixture for the csp roundtrip failure

## Progress counts
- Oracle pass fixtures: +1 (`Hackage/csp-let-lhs-infix-roundtrip`)

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern csp-let-lhs-infix-roundtrip"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester csp`
- `just fmt`
- `just check`

## Pre-PR review
- `coderabbit review --prompt-only` was attempted, but CodeRabbit refused the review due to the hourly cap.