### PR TITLE
fix: handle pragma once and do-let roundtrips

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp.hs
@@ -74,6 +74,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -470,6 +471,8 @@ handleDirective ctx st directive =
         else continueBlank ctx st
     DirLine n mPath ->
       handleLineDirective ctx st n mPath
+    DirPragmaOnce ->
+      handlePragmaOnceDirective ctx st
     DirUnsupported name ->
       addDiagnosticWhenActive ctx Warning ("unsupported directive: " <> name) st
 
@@ -492,6 +495,12 @@ addDiagnosticWhenActive :: LineContext -> Severity -> Text -> EngineState -> Ste
 addDiagnosticWhenActive ctx severity message st =
   if currentActive (lcStack ctx)
     then continueBlank ctx (addDiag severity message (lcFilePath ctx) (lcLineNo ctx) st)
+    else continueBlank ctx st
+
+handlePragmaOnceDirective :: LineContext -> EngineState -> Step
+handlePragmaOnceDirective ctx st =
+  if currentActive (lcStack ctx)
+    then continueBlank ctx (st {stPragmaOnceFiles = S.insert (lcFilePath ctx) (stPragmaOnceFiles st)})
     else continueBlank ctx st
 
 pushConditionalFrame :: LineContext -> EngineState -> Bool -> Step
@@ -545,9 +554,14 @@ handleElseDirective ctx st =
 handleIncludeDirective :: LineContext -> EngineState -> IncludeKind -> Text -> Step
 handleIncludeDirective ctx st kind includeTarget
   | not (currentActive (lcStack ctx)) = continueBlank ctx st
+  | S.member includeFilePath (stPragmaOnceFiles st) = continueBlank ctx st
   | otherwise = NeedInclude includeReq nextStep
   where
     includePathText = T.unpack includeTarget
+    includeFilePath =
+      case kind of
+        IncludeLocal -> takeDirectory (lcFilePath ctx) </> includePathText
+        IncludeSystem -> includePathText
     includeReq =
       IncludeRequest
         { includePath = includePathText,
@@ -561,11 +575,7 @@ handleIncludeDirective ctx st kind includeTarget
         ctx
         (addDiag Error ("missing include: " <> includeTarget) (lcFilePath ctx) (lcLineNo ctx) st)
     nextStep (Just includeBytes) =
-      let includeFilePath =
-            case kind of
-              IncludeLocal -> takeDirectory (lcFilePath ctx) </> includePathText
-              IncludeSystem -> includePathText
-          includeCursor = fromByteString includeBytes
+      let includeCursor = fromByteString includeBytes
           -- Include files treat trailing newlines as producing an extra
           -- empty line (matching splitOn "\n" semantics).
           includeHasTrailingNl = not (BS.null includeBytes) && BS.last includeBytes == 0x0A

--- a/components/aihc-cpp/src/Aihc/Cpp/Parser.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Parser.hs
@@ -34,6 +34,7 @@ data Directive
   | DirElse
   | DirEndIf
   | DirLine !Int !(Maybe FilePath)
+  | DirPragmaOnce
   | DirWarning !Text
   | DirError !Text
   | DirUnsupported !Text
@@ -71,6 +72,7 @@ parseDirectiveBody body =
           "else" -> Just DirElse
           "endif" -> Just DirEndIf
           "line" -> parseLineDirective rest
+          "pragma" -> parsePragma rest
           "warning" -> Just (DirWarning rest)
           "error" -> Just (DirError rest)
           _ -> Nothing
@@ -84,6 +86,12 @@ parseLineDirective body =
        in case parseQuotedText rest of
             Nothing -> Just (DirLine lineNumber Nothing)
             Just path -> Just (DirLine lineNumber (Just (T.unpack path)))
+
+parsePragma :: Text -> Maybe Directive
+parsePragma body =
+  case T.words body of
+    ["once"] -> Just DirPragmaOnce
+    _ -> Nothing
 
 parseDefine :: Text -> Maybe Directive
 parseDefine rest = do

--- a/components/aihc-cpp/src/Aihc/Cpp/Types.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Types.hs
@@ -27,6 +27,8 @@ import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import Data.Set (Set)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text.Lazy.Builder as TB
 import GHC.Generics (Generic)
@@ -136,6 +138,7 @@ data EngineState = EngineState
     stOutput :: !TB.Builder,
     stOutputLineCount :: {-# UNPACK #-} !Int,
     stDiagnosticsRev :: ![Diagnostic],
+    stPragmaOnceFiles :: !(Set FilePath),
     stSkippingDanglingElse :: !Bool,
     stHsBlockCommentDepth :: !Int,
     stCBlockCommentDepth :: !Int,
@@ -150,6 +153,7 @@ emptyState filePath =
       stOutput = mempty,
       stOutputLineCount = 0,
       stDiagnosticsRev = [],
+      stPragmaOnceFiles = S.empty,
       stSkippingDanglingElse = False,
       stHsBlockCommentDepth = 0,
       stCBlockCommentDepth = 0,

--- a/components/aihc-cpp/test/Spec.hs
+++ b/components/aihc-cpp/test/Spec.hs
@@ -20,6 +20,7 @@ main = do
         "cpp-oracle"
         ( checks
             <> [linePragmaTest, dateTimeTest, functionMacroArgumentTest, functionMacroUnclosedCallTest, definedConditionSpacingTest, tokenPastingTests, ccallLineCommentTest]
+            <> [pragmaOnceTest]
             <> [QC.testProperty "dummy quickcheck property" prop_dummy]
         )
     )
@@ -173,6 +174,20 @@ ccallLineCommentTest =
           then pure ()
           else assertFailure ("expected CCALL expansion with line comment, got: " <> show (resultOutput result))
       _ -> assertFailure "expected Done"
+
+pragmaOnceTest :: TestTree
+pragmaOnceTest =
+  testCase "#pragma once skips repeated includes" $
+    case preprocess defaultConfig {configInputFile = "root.hs"} (TE.encodeUtf8 "#include \"guarded.inc\"\n#include \"guarded.inc\"\nafter") of
+      NeedInclude _ k1 ->
+        case k1 (Just "#pragma once\ninside") of
+          NeedInclude {} -> assertFailure "second include should be skipped"
+          Done result -> do
+            let output = resultOutput result
+            if T.count "inside" output == 1 && "after\n" `T.isSuffixOf` output
+              then pure ()
+              else assertFailure ("expected guarded include once, got: " <> show output)
+      Done _ -> assertFailure "expected include continuation step"
 
 ccallLineCommentInput :: T.Text
 ccallLineCommentInput =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1126,12 +1126,19 @@ addDoStmtParens stmt =
     DoAnn ann inner -> DoAnn ann (addDoStmtParens inner)
     DoBind pat e -> DoBind (addPatternParens pat) (addExprParens e)
     DoLetDecls decls -> DoLetDecls (map addDeclParens decls)
-    DoExpr e -> DoExpr (wrapExpr (isLetExpr e) (addExprParens e))
+    DoExpr e -> DoExpr (wrapExpr (isComplexLetExpr e) (addExprParens e))
     DoRecStmt stmts -> DoRecStmt (map addDoStmtParens stmts)
   where
-    isLetExpr ELetDecls {} = True
-    isLetExpr (EAnn _ inner) = isLetExpr inner
-    isLetExpr _ = False
+    isComplexLetExpr (EAnn _ inner) = isComplexLetExpr inner
+    isComplexLetExpr (ELetDecls decls _) = not (all isSimpleLetDecl decls)
+    isComplexLetExpr _ = False
+
+    isSimpleLetDecl (DeclAnn _ inner) = isSimpleLetDecl inner
+    isSimpleLetDecl (DeclValue (PatternBind NoMultiplicityTag pat (UnguardedRhs _ _ Nothing))) =
+      case peelPatternAnn pat of
+        PVar _ -> True
+        _ -> False
+    isSimpleLetDecl _ = False
 
 addCompStmtParens :: CompStmt -> CompStmt
 addCompStmtParens stmt =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1362,9 +1362,25 @@ prettyDoStmt stmt =
     DoAnn _ inner -> prettyDoStmt inner
     DoBind pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     DoLetDecls decls -> prettyLetDecls decls
-    DoExpr expr@ELetDecls {} -> parens (prettyExpr expr)
+    DoExpr expr
+      | Just (decls, body) <- peelLetExpr expr ->
+          prettyLetExprExplicit decls body
     DoExpr expr -> prettyExprAtStatementStart expr
     DoRecStmt stmts -> "rec" <> prettyDoLayout prettyDoStmt stmts
+
+prettyLetExprExplicit :: [Decl] -> Expr -> Doc ann
+prettyLetExprExplicit decls body =
+  "let" <+> spacedBraces (hsep (punctuate semi (concatMap prettyDeclLines decls))) <+> "in" <+> prettyExpr body
+
+peelLetExpr :: Expr -> Maybe ([Decl], Expr)
+peelLetExpr expr =
+  case expr of
+    EAnn _ sub -> peelLetExpr sub
+    ELetDecls decls body -> Just (decls, body)
+    EParen inner
+      | Just _ <- peelLetExpr inner ->
+          Nothing
+    _ -> Nothing
 
 prettyExprAtStatementStart :: Expr -> Doc ann
 prettyExprAtStatementStart expr =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/do-let-in-expression-stmt.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/do-let-in-expression-stmt.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module DoLetInExpressionStmt where
+
+f m = do
+  let x = 1 in m x


### PR DESCRIPTION
## Summary

- Add `#pragma once` support to the CPP preprocessor and skip repeated includes before requesting include contents.
- Preserve do-expression `let ... in ...` roundtrips without adding an unnecessary `HsPar`, while keeping complex generated let statements on the existing parenthesized path.
- Add regression coverage for repeated pragma-once includes and the minimized do-let oracle case.

## Progress counts

- Parser oracle fixtures: +1 pass case (`Parens/do-let-in-expression-stmt`).
- CPP unit regressions: +1 pass case (`#pragma once skips repeated includes`).

## Validation

- `coderabbit review --prompt-only` (2 findings addressed)
- `just fmt`
- `just check`
- `cabal run exe:aihc-dev -v0 -- hackage-tester clash-lib` (111 files, 0 parse errors, 0 roundtrip failures)
