### PR TITLE
fix(parser): preserve star type application syntax

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -112,8 +112,8 @@ lexModuleTokensWithSourceNameAndExtensions :: FilePath -> [Extension] -> Text ->
 lexModuleTokensWithSourceNameAndExtensions sourceName baseExts input =
   lexChunksWithExtensions True sourceName effectiveExts [input]
   where
-    headerExts = enabledExtensionsFromSettings (readModuleHeaderExtensionsFromChunks [input])
-    effectiveExts = baseExts <> [ext | ext <- headerExts, ext `notElem` baseExts]
+    headerSettings = readModuleHeaderExtensionsFromChunks [input]
+    effectiveExts = applyImpliedExtensions (foldr applyExtensionSetting baseExts headerSettings)
 
 lexTokensFromChunksWithExtensions :: [Extension] -> [Text] -> [LexToken]
 lexTokensFromChunksWithExtensions = lexChunksWithExtensions False "<input>"

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -399,6 +399,7 @@ data TypeCtx
   = CtxTypeFunArg
   | CtxTypeAppFun
   | CtxTypeAppArg
+  | CtxTypeAppVisibleArg
   | CtxTypeFamilyOperand
   | CtxTypeAtom
   | CtxKindSig
@@ -433,8 +434,20 @@ needsTypeParens ctx ty =
         TFun {} -> True
         TContext {} -> True
         TInfix {} -> True
-        -- TStar renders as @*@ which merges with the preceding @\@@ in TTypeApp
-        -- to form a single operator token @\@*@.
+        TSplice {} -> False
+        TImplicitParam {} -> True
+        _ -> False
+    CtxTypeAppVisibleArg ->
+      case ty of
+        TQuasiQuote {} -> False
+        TApp {} -> True
+        TTypeApp {} -> True
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        TInfix {} -> True
+        -- TStar renders as @*@, which merges with the preceding @\@@ in
+        -- visible type application to form a single operator token @\@*@.
         TStar {} -> True
         -- TSplice renders as @$name@ or @$(expr)@. Parenthesizing this form in
         -- type-application argument positions changes the pretty output from
@@ -945,7 +958,7 @@ addExprParensPrec prec expr =
     EApp {} -> addAppsChainPrec prec expr
     ETypeApp fn ty ->
       let fn' = wrapExpr (isGreedyExpr fn) (addExprParensIn CtxAppFun fn)
-       in wrapExpr (prec > 2) (ETypeApp fn' (addTypeIn CtxTypeAppArg ty))
+       in wrapExpr (prec > 2) (ETypeApp fn' (addTypeIn CtxTypeAppVisibleArg ty))
     ETypeSyntax form ty -> wrapExpr (prec > 2) (ETypeSyntax form (addTypeParens ty))
     EVar {} -> expr
     EInt {} -> expr
@@ -1253,7 +1266,7 @@ addTypeParensShared ctx prec ty =
         TApp f x ->
           wrapTy (prec > 2) (TApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeAppArg x))
         TTypeApp f x ->
-          wrapTy (prec > 2) (TTypeApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeAppArg x))
+          wrapTy (prec > 2) (TTypeApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeAppVisibleArg x))
         TFun arrowKind a b ->
           wrapTy (prec > 0) (TFun (addArrowKindParens arrowKind) (addTypeIn CtxTypeFunArg a) (atom 0 b))
         TTuple tupleFlavor promoted elems ->

--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -24,14 +24,13 @@ import Aihc.Parser.Lex
     LexTokenKind (..),
     Pragma,
     TokenOrigin (..),
-    enabledExtensionsFromSettings,
     layoutTransition,
     mkInitialLayoutState,
     mkInitialLexerState,
     readModuleHeaderExtensionsFromChunks,
     scanAllTokens,
   )
-import Aihc.Parser.Syntax (Extension, SourceSpan (..))
+import Aihc.Parser.Syntax (Extension, SourceSpan (..), applyExtensionSetting, applyImpliedExtensions)
 import Control.DeepSeq (NFData (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
@@ -188,8 +187,8 @@ mkTokStreamModule sourceName baseExts input =
             tokStreamEOFEmitted = False
           }
   where
-    headerExts = enabledExtensionsFromSettings (readModuleHeaderExtensionsFromChunks [input])
-    effectiveExts = baseExts <> [ext | ext <- headerExts, ext `notElem` baseExts]
+    headerSettings = readModuleHeaderExtensionsFromChunks [input]
+    effectiveExts = applyImpliedExtensions (foldr applyExtensionSetting baseExts headerSettings)
 
 -- | Create a TokStream from pre-lexed tokens (for testing/compatibility).
 -- Layout tokens must already be inserted in the token list.

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeApplications/visible-type-application-star-is-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeApplications/visible-type-application-star-is-type.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+
+data Proxy (a :: *) = Proxy
+
+x :: Proxy (*)
+x = Proxy @(*)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/star-is-type-application-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TypeOperators/star-is-type-application-signature.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+
+data Proxy a = Proxy
+
+mulProxy :: Proxy a -> Proxy b -> Proxy (a * b)
+mulProxy _ _ = Proxy


### PR DESCRIPTION
## Summary
- keep `StarIsType` parsing semantics intact: `a * b` remains ordinary type application of `(*)`
- render ordinary type application to `TStar` as `a * b`, while still rendering visible type application as `@(*)` so it does not lex as `@*`
- apply module header extension settings consistently so disabling pragmas can remove default extensions during module lexing/parsing
- add oracle regressions for both `Proxy (a * b)` under `GHC2021` and `Proxy @(*)`

## Progress counts
- Oracle fixtures: +2 pass cases
  - `TypeOperators/star-is-type-application-signature`
  - `TypeApplications/visible-type-application-star-is-type`

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern star-is-type-application-signature"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern visible-type-application-star-is-type"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern type-family-infix-star-equation"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester reflection`
- `just fmt`
- `just check`

CodeRabbit review was skipped because the service reported the account hourly cap was reached.
