### PR TITLE
fix(parser): preserve type-level string gaps

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -497,7 +497,7 @@ prettyTypeLiteral :: TypeLiteral -> Doc ann
 prettyTypeLiteral lit =
   case lit of
     TypeLitInteger _ repr -> pretty repr
-    TypeLitSymbol _ repr -> pretty repr
+    TypeLitSymbol _ repr -> prettyRawText repr
     TypeLitChar _ repr -> pretty repr
 
 -- | Pretty-print a pattern. The AST is assumed to already have PParen nodes

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/string-gap-type-error-indentation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/string-gap-type-error-indentation.hs
@@ -1,0 +1,17 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module StringGapTypeErrorIndentation where
+
+import Data.Kind (Constraint)
+import GHC.TypeLits (ErrorMessage (Text), TypeError)
+
+type family UrlAlphabet k :: Constraint where
+  UrlAlphabet 'True = ()
+  UrlAlphabet _ = TypeError
+    ( 'Text "Cannot prove base64 value is encoded using the url-safe \
+            \alphabet. Please re-encode using the url-safe encoders, or use \
+            \a lenient decoder for the url-safe alphabet instead."
+    )


### PR DESCRIPTION
## Summary
- Preserve raw source text when pretty-printing type-level string literals.
- Add an oracle regression for string-gap indentation inside `TypeError ('Text ...)`.

## Progress counts
- Parser oracle fixtures: +1 pass (`MultilineStrings/string-gap-type-error-indentation`).

## Verification
- `cabal test -v0 aihc-parser:spec --test-options="--pattern string-gap-type-error-indentation"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester base64`
- `just fmt`
- `just check`

## Pre-PR review
- `coderabbit review --prompt-only` was attempted but CodeRabbit was rate-limited by the account hourly cap.
