### PR TITLE
fix(parser): imply RankNTypes from PolymorphicComponents

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -599,6 +599,7 @@ impliedExtensions =
     (LinearTypes, [EnableExtension MonoLocalBinds]),
     (MonadComprehensions, [EnableExtension ParallelListComp]),
     (MultiParamTypeClasses, [EnableExtension ConstrainedClassMethods]),
+    (PolymorphicComponents, [EnableExtension RankNTypes]),
     (PolyKinds, [EnableExtension KindSignatures]),
     (QuantifiedConstraints, [EnableExtension ExplicitForAll]),
     (Rank2Types, [EnableExtension RankNTypes]),

--- a/components/aihc-parser/test/Test/HackageTester/Suite.hs
+++ b/components/aihc-parser/test/Test/HackageTester/Suite.hs
@@ -46,6 +46,7 @@ hackageTesterTests =
           testCase "accepts mixed-case LANGUAGE pragmas" test_oracleAcceptsMixedCaseLanguagePragma,
           testCase "accepts NondecreasingIndentation pragmas" test_oracleAcceptsNondecreasingIndentationPragma,
           testCase "applies implied extensions" test_oracleAppliesImpliedExtensions,
+          testCase "treats PolymorphicComponents as RankNTypes" test_oracleTreatsPolymorphicComponentsAsRankNTypes,
           testCase "defaults to Haskell2010 when language is omitted" test_oracleDefaultsToHaskell2010,
           testCase "uses Haskell2010 language defaults" test_oracleUsesHaskell2010Defaults,
           testCase "uses Haskell98 fallback defaults" test_oracleUsesHaskell98FallbackDefaults,
@@ -197,6 +198,21 @@ test_oracleAppliesImpliedExtensions =
           "module A where",
           "f :: forall a. a -> a",
           "f x = x"
+        ]
+
+test_oracleTreatsPolymorphicComponentsAsRankNTypes :: Assertion
+test_oracleTreatsPolymorphicComponentsAsRankNTypes =
+  case oracleModuleAstFingerprint "hackage-tester" Syntax.Haskell2010Edition [Syntax.EnableExtension Syntax.PolymorphicComponents] source of
+    Left err ->
+      assertBool
+        ("expected PolymorphicComponents to imply RankNTypes and ExplicitForAll, got: " <> T.unpack err)
+        False
+    Right {} -> pure ()
+  where
+    source =
+      T.unlines
+        [ "module A where",
+          "data R m = R { runR :: forall a. m a -> m a }"
         ]
 
 test_oracleDefaultsToHaskell2010 :: Assertion


### PR DESCRIPTION
## Summary

- Add the missing implied-extension edge from `PolymorphicComponents` to `RankNTypes`.
- Cover the Hackage tester oracle behavior with a regression case using an explicit `forall` record field.

## Root Cause

`parsec` enables `PolymorphicComponents` in its cabal file. The hackage tester computes the complete extension set before invoking the GHC oracle, but `PolymorphicComponents` was not expanded to `RankNTypes`, so `RankNTypes -> ExplicitForAll` was never reached. GHC then rejected `Text.Parsec.Token` with `Illegal symbol forall in type`.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern PolymorphicComponents"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester parsec --only-ghc-errors`
- `cabal run exe:aihc-dev -v0 -- hackage-tester parsec`
- `just fmt`
- `just check`
