### PR TITLE
fix(parser): preserve do let-in layout

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1362,25 +1362,8 @@ prettyDoStmt stmt =
     DoAnn _ inner -> prettyDoStmt inner
     DoBind pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     DoLetDecls decls -> prettyLetDecls decls
-    DoExpr expr
-      | Just (decls, body) <- peelLetExpr expr ->
-          prettyLetExprExplicit decls body
     DoExpr expr -> prettyExprAtStatementStart expr
     DoRecStmt stmts -> "rec" <> prettyDoLayout prettyDoStmt stmts
-
-prettyLetExprExplicit :: [Decl] -> Expr -> Doc ann
-prettyLetExprExplicit decls body =
-  "let" <+> spacedBraces (hsep (punctuate semi (concatMap prettyDeclLines decls))) <+> "in" <+> prettyExpr body
-
-peelLetExpr :: Expr -> Maybe ([Decl], Expr)
-peelLetExpr expr =
-  case expr of
-    EAnn _ sub -> peelLetExpr sub
-    ELetDecls decls body -> Just (decls, body)
-    EParen inner
-      | Just _ <- peelLetExpr inner ->
-          Nothing
-    _ -> Nothing
 
 prettyExprAtStatementStart :: Expr -> Doc ann
 prettyExprAtStatementStart expr =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-let-in-multiline-bindings.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/do-let-in-multiline-bindings.hs
@@ -1,0 +1,15 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Haskell2010 #-}
+
+module DoLetInMultilineBindings where
+
+f x = do
+  let a =
+        case x of
+          True -> 1
+          False -> 2
+      b =
+        case x of
+          True -> 3
+          False -> 4
+    in if x then a else b


### PR DESCRIPTION
## Summary

- stop special-casing `let ... in ...` expressions in `do` statements as explicit-brace lets
- add an oracle regression for a `do` expression containing a `let ... in ...` with multiple multiline local bindings

## Investigation

`select-rpms` parsed successfully, but the pretty-printer rendered a `do` statement expression as `let { pkgmgr = case ... ; com = case ... } in ...`. Because the local bindings themselves contained implicit-layout `case` expressions, GHC interpreted the generated semicolon in the nested layout context and rejected the rendered module at `com =`.

Rendering the expression with the normal implicit `let ... in ...` layout preserves GHC's AST fingerprint and avoids the invalid nested-layout boundary.

## Progress Counts

- `select-rpms-0.3.1`: 0% -> 100% parser hackage-tester success
- Roundtrip failures: 1 -> 0

## Validation

- `cabal run exe:aihc-dev -v0 -- hackage-tester select-rpms`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern do-let-in-multiline-bindings"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` ran; fixture type-consistency feedback was addressed