### PR TITLE
fix(parser): omit safe roundtrip parentheses

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1142,23 +1142,21 @@ addDoStmtParens stmt =
     DoExpr e -> DoExpr (wrapExpr (letExprNeedsDoStmtParens e) (addExprParens e))
     DoRecStmt stmts -> DoRecStmt (map addDoStmtParens stmts)
   where
-    letExprNeedsDoStmtParens (ELetDecls decls@(_ : _) body)
-      | all isSimpleLetDecl decls = False
-      | otherwise = not (isInfixExpr body)
+    letExprNeedsDoStmtParens (ELetDecls decls@(_ : _) _) =
+      not (all isBareDoLetExprDecl decls)
     letExprNeedsDoStmtParens (ELetDecls [] _) = True
     letExprNeedsDoStmtParens (EAnn _ inner) = letExprNeedsDoStmtParens inner
     letExprNeedsDoStmtParens _ = False
 
-    isSimpleLetDecl (DeclAnn _ inner) = isSimpleLetDecl inner
-    isSimpleLetDecl (DeclValue (PatternBind NoMultiplicityTag pat (UnguardedRhs _ _ Nothing))) =
-      case peelPatternAnn pat of
-        PVar _ -> True
-        _ -> False
-    isSimpleLetDecl _ = False
+    isBareDoLetExprDecl (DeclAnn _ inner) = isBareDoLetExprDecl inner
+    isBareDoLetExprDecl (DeclValue (PatternBind NoMultiplicityTag _ (UnguardedRhs _ _ Nothing))) = True
+    isBareDoLetExprDecl (DeclValue (FunctionBind _ matches)) = all hasPlainMatchRhs matches
+    isBareDoLetExprDecl _ = False
 
-    isInfixExpr EInfix {} = True
-    isInfixExpr (EAnn _ inner) = isInfixExpr inner
-    isInfixExpr _ = False
+    hasPlainMatchRhs match =
+      case matchRhs match of
+        UnguardedRhs _ _ Nothing -> True
+        _ -> False
 
 addCompStmtParens :: CompStmt -> CompStmt
 addCompStmtParens stmt =
@@ -1237,6 +1235,14 @@ addTypeParens = addTypeParensShared CtxTypeAtom 0
 addTypeTopLevelParens :: Type -> Type
 addTypeTopLevelParens (TAnn ann sub) = TAnn ann (addTypeTopLevelParens sub)
 addTypeTopLevelParens (TKindSig ty kind) = TKindSig (addTypeParensShared CtxTypeAtom 0 ty) (addTypeParensShared CtxTypeAtom 0 kind)
+addTypeTopLevelParens (TForall telescope inner) =
+  TForall
+    (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
+    (addTypeTopLevelParens inner)
+addTypeTopLevelParens (TContext constraints inner) =
+  TContext (addContextConstraints constraints) (addContextBodyParens inner)
+addTypeTopLevelParens (TParen inner) =
+  TParen (addTypeTopLevelParens inner)
 addTypeTopLevelParens ty = addTypeParens ty
 
 addTypeIn :: TypeCtx -> Type -> Type
@@ -1333,6 +1339,28 @@ addImplicitParamBodyParens (TAnn ann sub) = TAnn ann (addImplicitParamBodyParens
 addImplicitParamBodyParens ty@(TContext {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
 addImplicitParamBodyParens ty@(TForall {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
 addImplicitParamBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
+
+-- | Process the body to the right of a constraint arrow in a top-level type
+-- RHS. A kind signature is already delimited there in cases like
+-- @type X = C => T :: K@, but TH splices still need grouping because
+-- @type X = C => $x :: K@ is rejected at the @::@ by GHC.
+addContextBodyParens :: Type -> Type
+addContextBodyParens (TAnn ann sub) = TAnn ann (addContextBodyParens sub)
+addContextBodyParens ty =
+  case ty of
+    TKindSig ty' kind ->
+      wrapTy
+        (startsWithTypeSplice ty')
+        (TKindSig (addTypeParensShared CtxTypeAtom 0 ty') (addTypeParensShared CtxTypeAtom 0 kind))
+    _ -> addTypeParensShared CtxTypeAtom 0 ty
+
+startsWithTypeSplice :: Type -> Bool
+startsWithTypeSplice (TAnn _ sub) = startsWithTypeSplice sub
+startsWithTypeSplice (TParen _) = False
+startsWithTypeSplice TSplice {} = True
+startsWithTypeSplice (TApp f _) = startsWithTypeSplice f
+startsWithTypeSplice (TTypeApp f _) = startsWithTypeSplice f
+startsWithTypeSplice _ = False
 
 -- | Process a type inside explicit delimiters (TParen, TTuple, etc.).
 -- TKindSig does not need wrapping here because the enclosing delimiter

--- a/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-kind-signature-rhs-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/ConstraintPolymorphism/constraint-kind-signature-rhs-roundtrip.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+
+module ConstraintKindSignatureRhsRoundtrip where
+
+import Data.Coerce (Coercible)
+import Data.Kind (Constraint)
+
+type Coercible2 f = (forall a b c d. (Coercible a b, Coercible c d) => Coercible (f a c) (f b d) :: Constraint)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/let-expression-do-statement-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DoAndIfThenElse/let-expression-do-statement-roundtrip.hs
@@ -1,0 +1,20 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Haskell2010 #-}
+
+module LetExpressionDoStatementRoundtrip where
+
+withLocalFunction :: IO ()
+withLocalFunction = do
+  let
+    loop n =
+      if n <= 0
+        then return ()
+        else loop (n - 1)
+   in loop 2
+
+withLocalPattern :: IO ()
+withLocalPattern = do
+  let
+    (x, y) = (1 :: Int, 2 :: Int)
+    total = x + y
+   in print total


### PR DESCRIPTION
## Summary

- Omit do-statement parentheses for ordinary non-empty let-in expressions that parse safely at statement start.
- Preserve grouping for unsafe let-in statements and TH-splice kind signatures where GHC still requires parentheses.
- Add oracle regression fixtures for let-in do statements and constraint kind signatures.

## Progress counts

- slave-thread: roundtrip fails 1 -> 0
- primitive-extras: roundtrip fails 4 -> 0
- cauldron: roundtrip fails 1 -> 0
- postgresql-syntax: roundtrip fails 1 -> 0
- wai-extra: roundtrip fails 1 -> 0
- monoidal-functors: roundtrip fails 1 -> 0

## Validation

- cabal test -v0 aihc-parser:spec --test-option=--hide-successes --test-option=--pattern --test-option=let-expression-do-statement-roundtrip
- cabal test -v0 aihc-parser:spec --test-option=--hide-successes --test-option=--pattern --test-option=constraint-kind-signature-rhs-roundtrip
- cabal test -v0 aihc-parser:spec --test-option=--hide-successes --test-option="--quickcheck-replay=(SMGen 1204200824570753086 4656083141901399313,99)"
- cabal test -v0 aihc-parser:spec --test-option=--hide-successes --test-option="--quickcheck-replay=(SMGen 11942231415213355709 5256299785787143309,70)"
- cabal run exe:aihc-dev -v0 -- hackage-tester slave-thread
- cabal run exe:aihc-dev -v0 -- hackage-tester primitive-extras
- cabal run exe:aihc-dev -v0 -- hackage-tester cauldron
- cabal run exe:aihc-dev -v0 -- hackage-tester postgresql-syntax
- cabal run exe:aihc-dev -v0 -- hackage-tester wai-extra
- cabal run exe:aihc-dev -v0 -- hackage-tester monoidal-functors
- just fmt
- just check

CodeRabbit review was skipped because the service reported the organization hourly cap.
