### PR TITLE
fix(parser): avoid spurious parens in roundtrip output

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -499,8 +499,8 @@ guardExprNeedsParens arrow = \case
   ELambdaPats {} -> True
   EProc {} -> True
   EApp _ arg | isBlockExpr arg -> guardExprNeedsParens arrow arg
-  expr -> case arrow of
-    GuardArrow -> endsWithTypeSig expr
+  _ -> case arrow of
+    GuardArrow -> False
     GuardEquals -> False
 
 -- ---------------------------------------------------------------------------
@@ -559,12 +559,22 @@ addPatternBindLhsParens pat rhs =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternBindLhsParens sub rhs)
     -- Bare @name :: ty = rhs@ is valid declaration syntax and is handled by a
-    -- dedicated decl parser path. Other typed patterns must stay grouped so the
-    -- parser does not reinterpret them as signatures.
+    -- dedicated decl parser path. Nullary constructors must stay grouped so the
+    -- parser does not reinterpret them as variable signatures, but composite
+    -- patterns such as @[x] :: [T] = rhs@ round-trip without an outer pattern
+    -- paren.
     PTypeSig inner@(PVar name) ty ->
       wrapPat (isSymbolicUName name) (PTypeSig (addPatternAtomParens inner) (addTypeParens ty))
-    PTypeSig {} -> wrapPat True (addPatternParens pat)
+    PTypeSig inner ty ->
+      wrapPat
+        (typedPatternBindLhsNeedsParens inner)
+        (PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty))
     _ -> addPatternParens pat
+
+typedPatternBindLhsNeedsParens :: Pattern -> Bool
+typedPatternBindLhsNeedsParens (PAnn _ sub) = typedPatternBindLhsNeedsParens sub
+typedPatternBindLhsNeedsParens PCon {} = True
+typedPatternBindLhsNeedsParens _ = False
 
 addMatchParens :: UnqualifiedName -> Match -> Match
 addMatchParens name match =
@@ -1142,21 +1152,10 @@ addDoStmtParens stmt =
     DoExpr e -> DoExpr (wrapExpr (letExprNeedsDoStmtParens e) (addExprParens e))
     DoRecStmt stmts -> DoRecStmt (map addDoStmtParens stmts)
   where
-    letExprNeedsDoStmtParens (ELetDecls decls@(_ : _) _) =
-      not (all isBareDoLetExprDecl decls)
+    letExprNeedsDoStmtParens (ELetDecls (_ : _) _) = False
     letExprNeedsDoStmtParens (ELetDecls [] _) = True
     letExprNeedsDoStmtParens (EAnn _ inner) = letExprNeedsDoStmtParens inner
     letExprNeedsDoStmtParens _ = False
-
-    isBareDoLetExprDecl (DeclAnn _ inner) = isBareDoLetExprDecl inner
-    isBareDoLetExprDecl (DeclValue (PatternBind NoMultiplicityTag _ (UnguardedRhs _ _ Nothing))) = True
-    isBareDoLetExprDecl (DeclValue (FunctionBind _ matches)) = all hasPlainMatchRhs matches
-    isBareDoLetExprDecl _ = False
-
-    hasPlainMatchRhs match =
-      case matchRhs match of
-        UnguardedRhs _ _ Nothing -> True
-        _ -> False
 
 addCompStmtParens :: CompStmt -> CompStmt
 addCompStmtParens stmt =
@@ -1222,7 +1221,11 @@ addArithSeqParens seqInfo =
     ArithSeqFromThenTo fromE thenE toE -> ArithSeqFromThenTo (addExprGuardedParens fromE) (addExprGuardedParens thenE) (addExprParens toE)
 
 addExprGuardedParens :: Expr -> Expr
-addExprGuardedParens = addExprParensIn CtxGuarded
+addExprGuardedParens expr =
+  case peelExprAnn expr of
+    EIf {} -> addExprParens expr
+    EMultiWayIf {} -> addExprParens expr
+    _ -> addExprParensIn CtxGuarded expr
 
 -- ---------------------------------------------------------------------------
 -- Types

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/cabal-dollar-do-let-in.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/cabal-dollar-do-let-in.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST pass -}
+module CabalDollarDoLetIn where
+
+f neededLibWays =
+  run
+    $ do
+      let
+          neededLibWaysSet = fromList neededLibWays
+          useDynamicToo = static `member` neededLibWaysSet && dynamic `member` neededLibWaysSet
+          orderedBuilds
+            | useDynamicToo = [buildStaticAndDynamicToo]
+            | otherwise = build <$> neededLibWays
+          buildStaticAndDynamicToo = run dynamic
+       in sequence_ orderedBuilds

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hpdf-typed-pattern-let-in-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/hpdf-typed-pattern-let-in-do.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+module HpdfTypedPatternLetInDo where
+
+f xs = do
+  let [a, b] :: [Double] = xs
+      total = a + b
+   in pure total

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/pantry-local-signature-let-in-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/pantry-local-signature-let-in-do.hs
@@ -1,0 +1,18 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+module PantryLocalSignatureLetInDo where
+
+f x = do
+  let
+      err = Left x
+
+      test :: Eq a => Maybe a -> a -> Bool
+      test (Just y) z = y == z
+      test Nothing _ = True
+
+      tests =
+        [ test (Just x) x
+        , test Nothing x
+        ]
+
+   in if and tests then Right x else err

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/shake-pattern-guard-type-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/shake-pattern-guard-type-signature.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE GHC2021 #-}
+module ShakePatternGuardTypeSignature where
+
+f e =
+  case () of
+    _
+      | Nothing <- fromException e :: Maybe ShakeException
+      , Just x <- fromException e ->
+          x
+    _ -> e

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/srtree-if-arithmetic-sequence-bound.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/srtree-if-arithmetic-sequence-bound.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module SrtreeIfArithmeticSequenceBound where
+
+f maxSize =
+  randomFrom [if maxSize > 4 then 4 else 1 .. maxSize]


### PR DESCRIPTION
## Summary
- Avoid adding retained GHC parens for typed guard expressions, non-empty `let ... in ...` do statements, and `if` arithmetic sequence bounds.
- Preserve required parens for typed nullary constructor pattern bindings while allowing composite typed pattern bindings like `[a, b] :: [T]`.
- Add Hackage oracle regressions for HPDF, pantry, srtree, shake, and Cabal.

## Progress counts
- HPDF: roundtrip fails 1 -> 0 (38/38 files pass).
- pantry: roundtrip fails 1 -> 0 (17/17 files pass).
- srtree: roundtrip fails 2 -> 0 (37/37 files pass).
- shake: roundtrip fails 1 -> 0 (75/75 files pass).
- Cabal: roundtrip fails 1 -> 0 (150/150 files pass).

## Validation
- `just fmt`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern Hackage --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern properties --hide-successes --quickcheck-tests 1000"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester HPDF`
- `cabal run exe:aihc-dev -v0 -- hackage-tester pantry`
- `cabal run exe:aihc-dev -v0 -- hackage-tester srtree`
- `cabal run exe:aihc-dev -v0 -- hackage-tester shake`
- `cabal run exe:aihc-dev -v0 -- hackage-tester Cabal`
- `just check`

## Pre-PR review
- `coderabbit review --prompt-only` completed. It flagged semantic concerns in parser-only oracle fixtures (partial pattern, missing imports, unreachable Shake guards, and parenthesizing the srtree `if` bound). These are intentionally not changed because the fixtures must preserve the exact parse/roundtrip shapes from the packages and oracle fixtures are not typechecked or evaluated.