### PR TITLE
fix(parser): honor block comments in layout

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
@@ -87,7 +87,13 @@ consumeLineComment st =
 consumeBlockComment :: LexerState -> Maybe LexerState
 consumeBlockComment st =
   case scanNestedBlockComment 1 (T.drop 2 (lexerInput st)) of
-    Just consumedTail -> Just (advanceChars ("{-" <> consumedTail) st)
+    Just consumedTail ->
+      let consumed = "{-" <> consumedTail
+          st' = advanceChars consumed st
+       in Just $
+            if T.any (== '\n') consumed
+              then st'
+              else st' {lexerAtLineStart = lexerAtLineStart st}
     Nothing -> Nothing
 
 consumeBlockCommentOrError :: LexerState -> Either (LexToken, LexerState) LexerState

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/liquid-fixpoint-do-comment-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/liquid-fixpoint-do-comment-layout.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+module A where
+
+f = do {- a -} x
+       {- b -} y

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/liquid-fixpoint-do-multiline-comment-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/liquid-fixpoint-do-multiline-comment-layout.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+module A where
+
+fn = do   {-
+       -} hello
+          world


### PR DESCRIPTION
## Summary
- Preserve same-line block comment columns as layout anchors for the next source token.
- Add a minimal liquid-fixpoint oracle regression covering commented `do` statements.

## Progress counts
- Oracle fixtures: pass +1

## Validation
- `cabal run -v0 exe:aihc-dev -- snippet /Users/lemmih/.cache/aihc/hackage/liquid-fixpoint-8.10.7/src/Language/Fixpoint/Types/Visitor.hs`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern liquid-fixpoint-do-comment-layout"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester liquid-fixpoint`
- `just fmt`
- `just check`

CodeRabbit review was skipped because the service rejected the review at the hourly cap.
