### PR TITLE
fix(cpp): ignore string delimiters in macro args

### DIFF
--- a/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
+++ b/components/aihc-cpp/src/Aihc/Cpp/Evaluator.hs
@@ -112,19 +112,35 @@ countExtraLinesConsumed st txt moreLines = scanForFunctionMacro False False Fals
               seekOpenParen (T.dropWhile isSpace nextLine) (extraLines + 1)
 
     findClosingParen :: Int -> Text -> Int -> Maybe Int
-    findClosingParen depth remaining extraLines =
-      case T.uncons remaining of
-        Nothing ->
-          -- Need more lines
-          case drop extraLines moreLines of
-            [] -> Nothing -- No more lines, unclosed call
-            (nextLine : _) ->
-              findClosingParen depth (T.cons '\n' nextLine) (extraLines + 1)
-        Just (ch, rest)
-          | ch == '(' -> findClosingParen (depth + 1) rest extraLines
-          | ch == ')' && depth > 0 -> findClosingParen (depth - 1) rest extraLines
-          | ch == ')' -> Just extraLines
-          | otherwise -> findClosingParen depth rest extraLines
+    findClosingParen = goClosing False False False
+      where
+        goClosing :: Bool -> Bool -> Bool -> Int -> Text -> Int -> Maybe Int
+        goClosing inString inChar escaped depth remaining extraLines =
+          case T.uncons remaining of
+            Nothing ->
+              -- Need more lines
+              case drop extraLines moreLines of
+                [] -> Nothing -- No more lines, unclosed call
+                (nextLine : _) ->
+                  goClosing inString inChar escaped depth (T.cons '\n' nextLine) (extraLines + 1)
+            Just (ch, rest)
+              | inString ->
+                  let escaped' = ch == '\\' && not escaped
+                      inString' = not (ch == '"' && not escaped)
+                   in goClosing inString' False escaped' depth rest extraLines
+              | inChar ->
+                  let escaped' = ch == '\\' && not escaped
+                      inChar' = not (ch == '\'' && not escaped)
+                   in goClosing False inChar' escaped' depth rest extraLines
+              | startsHsBlockComment remaining ->
+                  let (_, afterComment) = consumeHsBlockComment remaining
+                   in goClosing False False False depth afterComment extraLines
+              | ch == '"' -> goClosing True False False depth rest extraLines
+              | ch == '\'' -> goClosing False True False depth rest extraLines
+              | ch == '(' -> goClosing False False False (depth + 1) rest extraLines
+              | ch == ')' && depth > 0 -> goClosing False False False (depth - 1) rest extraLines
+              | ch == ')' -> Just extraLines
+              | otherwise -> goClosing False False False depth rest extraLines
 
 -- | Blue-paint macro expansion engine. Uses a suppression set (@painted@)
 -- to prevent infinite recursion instead of iterating to a fixpoint.
@@ -252,20 +268,32 @@ commentBody commentText =
 parseCallArgs :: Text -> Maybe ([Text], Text)
 parseCallArgs input = do
   ('(', rest) <- T.uncons (T.dropWhile isSpace input)
-  parseArgs 0 [] mempty rest
+  parseArgs False False False 0 [] mempty rest
 
-parseArgs :: Int -> [Text] -> TB.Builder -> Text -> Maybe ([Text], Text)
-parseArgs depth argsRev current remaining =
+parseArgs :: Bool -> Bool -> Bool -> Int -> [Text] -> TB.Builder -> Text -> Maybe ([Text], Text)
+parseArgs inString inChar escaped depth argsRev current remaining =
   case T.uncons remaining of
     Nothing -> Nothing
     Just (ch, rest)
+      | inString ->
+          let escaped' = ch == '\\' && not escaped
+              inString' = not (ch == '"' && not escaped)
+           in parseArgs inString' False escaped' depth argsRev (current <> TB.singleton ch) rest
+      | inChar ->
+          let escaped' = ch == '\\' && not escaped
+              inChar' = not (ch == '\'' && not escaped)
+           in parseArgs False inChar' escaped' depth argsRev (current <> TB.singleton ch) rest
       | startsHsBlockComment remaining ->
           let (commentText, afterComment) = consumeHsBlockComment remaining
-           in parseArgs depth argsRev (current <> TB.fromText commentText) afterComment
+           in parseArgs False False False depth argsRev (current <> TB.fromText commentText) afterComment
+      | ch == '"' ->
+          parseArgs True False False depth argsRev (current <> TB.singleton ch) rest
+      | ch == '\'' ->
+          parseArgs False True False depth argsRev (current <> TB.singleton ch) rest
       | ch == '(' ->
-          parseArgs (depth + 1) argsRev (current <> TB.singleton ch) rest
+          parseArgs False False False (depth + 1) argsRev (current <> TB.singleton ch) rest
       | ch == ')' && depth > 0 ->
-          parseArgs (depth - 1) argsRev (current <> TB.singleton ch) rest
+          parseArgs False False False (depth - 1) argsRev (current <> TB.singleton ch) rest
       | ch == ')' && depth == 0 ->
           let arg = trimSpacesText (builderToText current)
               argsRev' =
@@ -275,7 +303,7 @@ parseArgs depth argsRev current remaining =
            in Just (reverse argsRev', rest)
       | ch == ',' && depth == 0 ->
           let arg = trimSpacesText (builderToText current)
-           in parseArgs depth (arg : argsRev) mempty rest
+           in parseArgs False False False depth (arg : argsRev) mempty rest
       | ch == '-' && depth == 0,
         Just ('-', afterDash) <- T.uncons rest ->
           -- Haskell line comment inside arg list: close the arg, find ')' in comment
@@ -289,7 +317,7 @@ parseArgs depth argsRev current remaining =
                       argsRev' = if T.null arg && null argsRev then [""] else arg : argsRev
                    in Just (reverse argsRev', trailingWS <> commentPrefix <> afterClose)
       | otherwise ->
-          parseArgs depth argsRev (current <> TB.singleton ch) rest
+          parseArgs False False False depth argsRev (current <> TB.singleton ch) rest
 
 -- | Find the last ')' in text and split before it.
 findLastCloseParen :: Text -> Maybe (Text, Text)

--- a/components/aihc-cpp/test/Test/Fixtures/progress/macro-multiline-string-comma.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/macro-multiline-string-comma.hs
@@ -1,0 +1,8 @@
+#define DEBUG_TRACE(s) {- nothing -}
+
+happyDoAction i tk st =
+  DEBUG_TRACE("state: " ++ show st ++
+              ", token: " ++ show i ++
+              ", action: ")
+  case action of
+    Done -> done

--- a/components/aihc-cpp/test/Test/Fixtures/progress/macro-multiline-string-parens.hs
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/macro-multiline-string-parens.hs
@@ -1,0 +1,6 @@
+#define DEBUG_TRACE(s) {- nothing -}
+
+happySimulateReduce r st sts =
+  DEBUG_TRACE("simulate reduction of rule " ++ show r ++ ", (nested)")
+  let result = reduce r st sts
+  in result

--- a/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
+++ b/components/aihc-cpp/test/Test/Fixtures/progress/manifest.tsv
@@ -38,6 +38,8 @@ macro-expansion-not-in-string	macro	macro-expansion-not-in-string.hs	pass
 hpp-file-macro-string-pattern	macro	hpp-file-macro-string-pattern.hs	pass
 rules-pragma-cpp-branch	lexing	rules-pragma-cpp-branch.hs	pass
 macro-multiline-args	macro	macro-multiline-args.hs	pass
+macro-multiline-string-comma	macro	macro-multiline-string-comma.hs	pass
+macro-multiline-string-parens	macro	macro-multiline-string-parens.hs	pass
 stringify-paste-pair	macro	stringify-paste-pair.hs	pass
 macro-comment-replacement	macro	macro-comment-replacement.hs	pass
 thyme-lens-comment-paste	macro	thyme-lens-comment-paste.hs	pass


### PR DESCRIPTION
## What changed

- Made CPP function-macro argument scanning string- and char-literal aware, so commas and parentheses inside literals do not split arguments or terminate multiline calls.
- Added progress fixtures for Happy-style multiline DEBUG_TRACE calls with commas and parentheses inside string literals.

## Why

Happy-generated parsers use DEBUG_TRACE(s) with multiline string concatenation. Commas in those strings made AIHC treat DEBUG_TRACE as a multi-argument call, leaving the macro unexpanded and causing GHC to parse `DEBUG_TRACE (...) case/let/if` as invalid function application.

## Progress counts

- aihc-cpp progress fixtures: 44 pass -> 46 pass

## Validation

- `cabal test -v0 aihc-cpp:spec --test-options="--pattern macro-multiline-string"`
- `cabal test -v0 aihc-cpp:spec --test-options=--hide-successes`
- `cabal run exe:aihc-dev -v0 -- hackage-tester happy-lib`
- `just fmt`
- `just check`

## Pre-PR review

- `coderabbit review --prompt-only` was attempted, but CodeRabbit refused the review due to the hourly/usage cap.
