### PR TITLE
test(resolve): add xfail fixture for named pattern-synonym unbound name

### DIFF
--- a/components/aihc-resolve/test/Test/Fixtures/golden/named-pattern-synonym-use.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/named-pattern-synonym-use.yaml
@@ -1,0 +1,22 @@
+extensions: []
+modules:
+  - |
+    {-# LANGUAGE PatternSynonyms #-}
+    module Main where
+    data F a = ArgF a
+    pattern Arg a = ArgF a
+    newtype Param p = Param p
+    param _ a = Param (Arg a)
+expected:
+  Main:
+    - "3:6-3:7 F => (type) Main.F"
+    - "3:10-3:14 ArgF => (value) Main.ArgF"
+    - "5:10-5:15 Param => (type) Main.Param"
+    - "5:18-5:23 Param => (value) Main.Param"
+    - "6:1-6:6 param => (value) Main.param"
+    - "6:9-6:10 a => (value) Local 0 a"
+    - "6:13-6:18 Param => (value) Main.Param"
+    - "6:20-6:23 Arg => (value) Error unbound"
+    - "6:24-6:25 a => (value) Local 0 a"
+status: xfail
+reason: "Pattern synonyms are not inserted into term scope in aihc-resolve. This module is equivalent to `named`'s internal helper usage and reproduces the unresolved `Arg` name at `param _ a = Param (Arg a)`."

--- a/components/aihc-resolve/test/Test/Fixtures/golden/named-pattern-synonym-use.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/named-pattern-synonym-use.yaml
@@ -18,5 +18,6 @@ expected:
     - "6:13-6:18 Param => (value) Main.Param"
     - "6:20-6:23 Arg => (value) Error unbound"
     - "6:24-6:25 a => (value) Local 0 a"
+annotated: []
 status: xfail
 reason: "Pattern synonyms are not inserted into term scope in aihc-resolve. This module is equivalent to `named`'s internal helper usage and reproduces the unresolved `Arg` name at `param _ a = Param (Arg a)`."


### PR DESCRIPTION
## Summary
- Add a new `aihc-resolve` xfail fixture (`components/aihc-resolve/test/Test/Fixtures/golden/named-pattern-synonym-use.yaml`) reproducing the name-resolution failure on `Named/Internal.hs` where `param _ a = Param (Arg a)` reports `Arg` as unbound.

## Root cause
Resolver currently does not insert pattern-synonym declarations into top-level term exports (`declExportedNames` / related declaration handling in `Aihc.Resolve`), so names introduced by `pattern` declarations are absent from module scope. In the `Named` package case, `Arg` is resolved as a term but isn't in `scopeTerms`, so downstream use resolves to `Error unbound`.

## Notes
This is an `xfail` regression fixture to lock the behavior and prevent accidental unintentional changes before implementing proper pattern-synonym support in the resolver.
