### PR TITLE
test(resolve): add xfail for class-method import scope

### DIFF
--- a/.codex/skills/aihc-resolve-test-cases/SKILL.md
+++ b/.codex/skills/aihc-resolve-test-cases/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: aihc-resolve-test-cases
+description: Use for creating, updating, and validating `aihc-resolve` golden fixtures for parser and scope behavior regressions.
+---
+
+# AIHC Resolve Test Cases
+
+## Use case
+
+Use this skill when you need to add or repair fixtures for `components/aihc-resolve/test/Test/Fixtures/golden/`.
+
+## Quick workflow
+
+1. Read `references/aihc-resolve-golden.md`.
+2. Create a minimal failing snippet in `modules` and classify it as `pass`, `xfail`, or `xpass`.
+3. Ensure required keys are present in the YAML fixture (`extensions`, `modules`, `status`, and `annotated`).
+4. Keep scope as small as possible and prefer one issue per fixture.
+5. Run the focused test target when available.
+
+## Common validation points
+
+- Use `status: xfail` for known parser/resolve gaps.
+- Keep `annotated` present as a list; for `xfail` it may be `[]`.
+- For `pass` and `xpass`, include both `expected` and `annotated`.
+- For class-related regressions, include the declaration module and a second module that exercises the lookup behavior.
+- If uncertain about fixture validity, run the fixture loader through resolver tests and confirm it parses before expecting semantics.
+
+## Minimal fixture shape
+
+```yaml
+extensions: []
+modules:
+  - |
+    module Main where
+    x = 1
+annotated: []
+status: xfail
+reason: "Short explanation of the known gap."
+```
+
+## References
+
+- [`/Users/lemmih/.codex/skills/aihc-resolve-test-cases/references/aihc-resolve-golden.md`](references/aihc-resolve-golden.md)

--- a/.codex/skills/aihc-resolve-test-cases/agents/openai.yaml
+++ b/.codex/skills/aihc-resolve-test-cases/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AIHC Resolve Test Cases"
+  short_description: "Author and review aihc-resolve golden fixtures"
+  default_prompt: "Use $aihc-resolve-test-cases to author or fix aihc-resolve fixture cases."

--- a/.codex/skills/aihc-resolve-test-cases/references/aihc-resolve-golden.md
+++ b/.codex/skills/aihc-resolve-test-cases/references/aihc-resolve-golden.md
@@ -1,0 +1,42 @@
+# AIHC Resolve Golden Fixtures
+
+Resolver fixtures live at:
+`components/aihc-resolve/test/Test/Fixtures/golden/*.yaml`
+
+Loader format:
+
+- `extensions`: list of parser extensions
+- `modules`: list of module source strings (parsed as separate modules)
+- `status`: `pass`, `xpass`, or `xfail`
+- `expected`: required for `pass` and `xpass`
+- `annotated`: required key for all statuses (can be `[]` for `xfail`)
+- `reason`: required for `xfail`
+
+Status behavior:
+
+- `pass`: output must match `expected` and `annotated`.
+- `xpass`: treated like strict `pass` but known to still fail CI intentionally.
+- `xfail`: must fail; if it unexpectedly passes, status becomes `xpass` and the suite flags regression.
+
+Useful pattern for class/import regressions:
+
+1. One module defines a class or type with minimal members.
+2. Second module imports and uses the target name directly.
+3. Keep other declarations minimal to avoid parser/lexer noise.
+
+Example import-member failure shape:
+
+```haskell
+module ClassMod where
+class Box a where
+  pick :: a -> a
+
+module Main where
+import ClassMod (Box (pick))
+f = pick
+```
+
+Recommended quick check:
+
+- Run resolver tests filtered to this fixture and ensure the fixture loads and gets categorized as expected.
+- If it fails to load before execution, fix schema keys first (most often missing `expected`/`annotated`).

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-method-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-method-import.yaml
@@ -9,5 +9,6 @@ modules:
     import ClassMod (Box (pick))
 
     f = pick
+annotated: []
 status: xfail
 reason: "Class member imports do not currently preserve method names in the term scope, so imported members like `pick` become Unbound."

--- a/components/aihc-resolve/test/Test/Fixtures/golden/class-method-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/class-method-import.yaml
@@ -1,0 +1,13 @@
+extensions: []
+modules:
+  - |
+    module ClassMod where
+    class Box a where
+      pick :: a -> a
+  - |
+    module Main where
+    import ClassMod (Box (pick))
+
+    f = pick
+status: xfail
+reason: "Class member imports do not currently preserve method names in the term scope, so imported members like `pick` become Unbound."


### PR DESCRIPTION
## Summary
- Add a minimal `resolver` golden `xfail` fixture for class-member imports being unresolved.
- Add a reusable Codex skill for authoring `aihc-resolve` golden fixtures.

## Root cause
- `aihc-resolve` does not preserve class methods in the effective imported term scope when using explicit class-member imports.
- `import ClassMod (Box (pick))` can expose `pick` as an imported member, but resolver filtering drops it for term lookup, producing `ResolveResolutionError "unbound"`.

## Changes
### Resolver test case
- Added `components/aihc-resolve/test/Test/Fixtures/golden/class-method-import.yaml`.
- `annotated` is explicitly provided so fixture schema validates (`annotated` is required for all statuses).
- Keeps the case `xfail` with rationale.

### Skill contribution
- Added ` .codex/skills/aihc-resolve-test-cases/` with:
  - `SKILL.md`
  - `agents/openai.yaml`
  - `references/aihc-resolve-golden.md`

This gives a reusable workflow for creating and validating future `aihc-resolve` fixture cases.
