### PR TITLE
fix(parser): parse builtin type constructors

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -336,10 +336,15 @@ typeParenOperatorParser = withSpanAnn (TAnn . mkAnnotation) $ do
       TkQConSym modQual sym -> Just (mkName (Just modQual) NameConSym sym)
       -- Handle reserved operators that can be used as type constructors
       TkReservedRightArrow -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym "->"))
+      TkReservedColon -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym ":"))
       -- Note: ~ is now lexed as TkVarSym "~" so TkVarSym case handles it
       _ -> Nothing
   expectedTok TkSpecialRParen
-  pure (TCon op Unpromoted)
+  pure $
+    case (nameQualifier op, nameType op, nameText op) of
+      (Nothing, NameVarSym, "->") -> TBuiltinCon TBuiltinArrow
+      (Nothing, NameConSym, ":") -> TBuiltinCon TBuiltinCons
+      _ -> TCon op Unpromoted
 
 typeQuasiQuoteParser :: TokParser Type
 typeQuasiQuoteParser =
@@ -372,7 +377,7 @@ typeListParser = withSpanAnn (TAnn . mkAnnotation) $ do
   expectedTok TkSpecialLBracket
   mClosed <- MP.optional (expectedTok TkSpecialRBracket)
   case mClosed of
-    Just () -> pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "[]")) Unpromoted)
+    Just () -> pure (TBuiltinCon TBuiltinList)
     Nothing -> do
       elems <- typeParser `MP.sepBy1` expectedTok TkSpecialComma
       expectedTok TkSpecialRBracket
@@ -392,11 +397,11 @@ typeParenOrTupleParser = withSpanAnn (TAnn . mkAnnotation) $ do
       moreCommas <- MP.many (expectedTok TkSpecialComma)
       expectedTok closeTok
       let arity = 2 + length moreCommas
-          tupleConName =
-            case tupleFlavor of
-              Boxed -> "(" <> T.replicate (arity - 1) "," <> ")"
-              Unboxed -> "(#" <> T.replicate (arity - 1) "," <> "#)"
-      pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId tupleConName)) Unpromoted)
+      case tupleFlavor of
+        Boxed -> pure (TBuiltinCon (TBuiltinTuple arity))
+        Unboxed -> do
+          let tupleConName = "(#" <> T.replicate (arity - 1) "," <> "#)"
+          pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId tupleConName)) Unpromoted)
 
     parenthesizedTypeOrTupleParser tupleFlavor closeTok = do
       first <- typeParser

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -471,6 +471,7 @@ needsTypeParens ctx ty =
       case ty of
         TVar {} -> False
         TCon {} -> False
+        TBuiltinCon {} -> False
         TImplicitParam {} -> False
         TTypeLit {} -> False
         TStar {} -> False
@@ -733,6 +734,8 @@ bangTypeNeedsPrefixParens TStar = True
 bangTypeNeedsPrefixParens (TCon name promoted)
   | promoted == Promoted = True
   | otherwise = isSymbolicName name
+bangTypeNeedsPrefixParens (TBuiltinCon TBuiltinCons) = True
+bangTypeNeedsPrefixParens (TBuiltinCon _) = False
 bangTypeNeedsPrefixParens TImplicitParam {} = True
 bangTypeNeedsPrefixParens TSplice {} = True
 -- Compound types: the first rendered character comes from the head/lhs.
@@ -785,6 +788,7 @@ infixConOperandNeedsParens (TTuple Boxed _ _) = False
 infixConOperandNeedsParens (TTuple Unboxed _ _) = False
 infixConOperandNeedsParens (TUnboxedSum {}) = True
 infixConOperandNeedsParens (TList _ []) = True
+infixConOperandNeedsParens (TBuiltinCon TBuiltinList) = True
 infixConOperandNeedsParens (TInfix {}) = True
 -- Application head determines what the parser sees first.
 infixConOperandNeedsParens (TApp f _) = infixConOperandNeedsParens f
@@ -1274,6 +1278,7 @@ addTypeParensShared ctx prec ty =
         TCon name promoted
           | isSymbolicName name, promoted /= Promoted -> TCon name promoted
           | otherwise -> TCon name promoted
+        TBuiltinCon {} -> ty
         TImplicitParam name inner -> TImplicitParam name (addImplicitParamBodyParens inner)
         TTypeLit {} -> ty
         TStar {} -> ty

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -436,6 +436,7 @@ prettyType ty =
             | T.any (== '\'') rendered = "' "
             | otherwise = "'"
        in if promoted == Promoted then promoteTick <> base else base
+    TBuiltinCon con -> prettyTypeBuiltinCon con
     TImplicitParam name inner -> pretty name <+> "::" <+> prettyType inner
     TTypeLit lit -> prettyTypeLiteral lit
     TStar -> "*"
@@ -485,6 +486,14 @@ prettyArrowKind :: ArrowKind -> Doc ann
 prettyArrowKind ArrowUnrestricted = "->"
 prettyArrowKind ArrowLinear = "%1" <+> "->"
 prettyArrowKind (ArrowExplicit ty) = "%" <> prettyType ty <+> "->"
+
+prettyTypeBuiltinCon :: TypeBuiltinCon -> Doc ann
+prettyTypeBuiltinCon con =
+  case con of
+    TBuiltinTuple arity -> parens (pretty (T.replicate (max 0 (arity - 1)) ","))
+    TBuiltinArrow -> "(->)"
+    TBuiltinList -> "[]"
+    TBuiltinCons -> "(:)"
 
 prettyContext :: [Type] -> Doc ann
 prettyContext constraints =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -610,6 +610,7 @@ docType ty =
       if promoted == Promoted
         then "TConPromoted" <+> docName name
         else "TCon" <+> docName name
+    TBuiltinCon con -> "TBuiltinCon" <+> pretty (show con)
     TImplicitParam name inner -> "TImplicitParam" <+> docText name <+> parens (docType inner)
     TTypeLit lit -> "TTypeLit" <+> docTypeLiteral lit
     TStar -> "TStar"

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -91,6 +91,7 @@ module Aihc.Parser.Syntax
     FloatType (..),
     NumericType (..),
     TypeLiteral (..),
+    TypeBuiltinCon (..),
     TypePromotion (..),
     ForallVis (..),
     ForallTelescope (..),
@@ -1178,6 +1179,7 @@ data Type
   = TAnn Annotation Type
   | TVar UnqualifiedName
   | TCon Name TypePromotion
+  | TBuiltinCon TypeBuiltinCon
   | TImplicitParam Text Type
   | TTypeLit TypeLiteral
   | TStar
@@ -1197,6 +1199,13 @@ data Type
   | -- \$typ or $(typ) (TH type splice)
     -- \_ (wildcard type, used in type family instance patterns)
     TWildcard
+  deriving (Data, Eq, Show, Generic, NFData)
+
+data TypeBuiltinCon
+  = TBuiltinTuple Int
+  | TBuiltinArrow
+  | TBuiltinList
+  | TBuiltinCons
   deriving (Data, Eq, Show, Generic, NFData)
 
 getTypeSourceSpan :: Type -> SourceSpan

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/data-con-infix-tuple-constructor-application.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/data-con-infix-tuple-constructor-application.yaml
@@ -2,5 +2,5 @@ extensions: []
 input: |
   data A b = (,) Int Int `Infix` b
 ast: |
-  Module {decls = [DeclData (DataDecl {name = "A", params = [TyVarBinder {name = "b"}], constructors = [InfixCon {op = "Infix", lhs = BangType {type = TApp (TApp (TCon "(,)") (TCon "Int")) (TCon "Int")}, rhs = BangType {type = TVar "b"}}]})]}
+  Module {decls = [DeclData (DataDecl {name = "A", params = [TyVarBinder {name = "b"}], constructors = [InfixCon {op = "Infix", lhs = BangType {type = TApp (TApp (TBuiltinCon TBuiltinTuple 2) (TCon "Int")) (TCon "Int")}, rhs = BangType {type = TVar "b"}}]})]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/builtin-cons-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/builtin-cons-type.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+module BuiltinConsType where
+
+x :: (:)
+x = undefined

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -162,7 +162,7 @@ genTypeNameQuoteType :: Gen Type
 genTypeNameQuoteType =
   oneof
     [ TCon <$> genConName <*> pure Unpromoted,
-      pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId "[]")) Unpromoted),
+      pure (TBuiltinCon TBuiltinList),
       pure (TTuple Boxed Unpromoted []),
       pure (TTuple Unboxed Unpromoted [])
     ]

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -40,6 +40,7 @@ genType = scale (`div` 2) $ do
         [ TVar <$> genTypeVarName,
           (`TCon` Unpromoted) <$> genConName,
           (`TCon` Promoted) <$> genConName,
+          TBuiltinCon <$> genTypeBuiltinCon,
           TTypeLit <$> genTypeLiteral,
           pure TStar,
           pure TWildcard,
@@ -54,6 +55,7 @@ genType = scale (`div` 2) $ do
         [ TVar <$> genTypeVarName,
           (`TCon` Unpromoted) <$> genConName,
           (`TCon` Promoted) <$> genConName,
+          TBuiltinCon <$> genTypeBuiltinCon,
           TTypeLit <$> genTypeLiteral,
           pure TStar,
           pure TWildcard,
@@ -285,6 +287,16 @@ genTypeLiteral =
         pure (TypeLitChar c (T.pack (show c)))
     ]
 
+genTypeBuiltinCon :: Gen TypeBuiltinCon
+genTypeBuiltinCon =
+  elements
+    [ TBuiltinTuple 2,
+      TBuiltinTuple 3,
+      TBuiltinArrow,
+      TBuiltinList,
+      TBuiltinCons
+    ]
+
 genSymbolText :: Gen Text
 genSymbolText = do
   len <- chooseInt (0, 8)
@@ -301,6 +313,8 @@ shrinkType ty =
       [ TCon shrunk promoted
       | shrunk <- shrinkName name
       ]
+    TBuiltinCon {} ->
+      []
     TImplicitParam name inner ->
       [inner]
         <> [TImplicitParam name' inner | name' <- shrinkImplicitParamName name]


### PR DESCRIPTION
## Summary

- Add a dedicated `TBuiltinCon` AST node for builtin type constructor references.
- Parse `(,)`, `(->)`, `[]`, and `(:)` into builtin constructor forms instead of plain `TCon` names.
- Add oracle coverage for `(:)` in type signatures and update affected golden/property fixtures.

## Root Cause

The parser had special syntax paths for tuple, arrow, and list type constructors, but those paths lowered constructor references to ordinary names. The reserved `:` token also was not accepted by the parenthesized type-operator parser, so `(:)` was rejected even though GHC accepts it with `DataKinds`.

## Progress Counts

- Parser oracle fixtures: +1 passing DataKinds regression (`builtin-cons-type.hs`).
- Full local suite: 1643 parser tests passed in the final `just check` run.
- README progress counts were not updated; they are maintained by cron.

## Validation

- `just fmt`
- `just check`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern builtin-cons-type --hide-successes"`

## Review

- `coderabbit review --prompt-only` was attempted, but CodeRabbit rejected the run because the account is over its hourly cap.
