### PR TITLE
fix: include conditional exposed modules

### DIFF
--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -138,9 +138,9 @@ dedupeFiles (f : fs) = f : dedupeFiles (filter (\x -> fileInfoPath x /= fileInfo
 
 libraryFilesFor :: PackageDescription -> (Condition ConfVar -> Bool) -> FilePath -> LibraryName -> CondTree ConfVar c Library -> IO [FileInfo]
 libraryFilesFor pkgDescr evalCond packageRoot libName tree = do
-  let library = condTreeData tree
+  let libraries = collectCondTreeData evalCond tree
       build = collectMergedBuildInfo evalCond libBuildInfo tree
-      moduleNames = exposedModules library <> otherModules build <> autogenModules build
+      moduleNames = nub (concatMap exposedModules libraries <> otherModules build <> autogenModules build)
       exts = extractExtensions build
       cppOpts = cppOptions build
       includeSearchDirs = extractIncludeDirs packageRoot build

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -33,6 +33,7 @@ main =
               PackageSpec "custom-package" "installed"
             ],
       testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
+      testCase "collects exposed modules from active conditional library branches" test_collectsConditionalExposedModules,
       QC.testProperty "dummy quickcheck property" prop_dummy
     ]
 
@@ -79,6 +80,26 @@ test_generatesPathsModule =
       [info] -> assertEqual "expected generated module to depend on base" [T.pack "base"] (HC.fileInfoDependencies info)
       _ -> assertFailure "expected exactly one FileInfo for generated Paths module"
 
+test_collectsConditionalExposedModules :: Assertion
+test_collectsConditionalExposedModules =
+  withTempDir "aihc-hackage-conditional-exposed" $ \root -> do
+    let cabalFile = root </> "conditional-exposed.cabal"
+        srcDir = root </> "src" </> "Control" </> "Category"
+        sourceFile = srcDir </> "Unicode.hs"
+    createDirectoryIfMissing True srcDir
+    writeFile cabalFile conditionalExposedCabal
+    writeFile sourceFile "module Control.Category.Unicode where\n"
+
+    cabalBytes <- BS.readFile cabalFile
+    gpd <-
+      case snd (runParseResult (parseGenericPackageDescription cabalBytes)) of
+        Right parsed -> pure parsed
+        Left (_, errs) -> assertFailure ("failed to parse test cabal file: " <> show errs)
+
+    files <- HC.collectComponentFiles gpd root
+    let paths = map HC.fileInfoPath files
+    assertBool "expected conditionally exposed module to be selected" (any ("src/Control/Category/Unicode.hs" `isSuffixOf`) paths)
+
 pathsDemoCabal :: String
 pathsDemoCabal =
   unlines
@@ -101,6 +122,27 @@ pathsUserSource =
       "pathsVersion = version",
       "pathsDataDir = getDataDir",
       "pathsDataFileName = getDataFileName"
+    ]
+
+conditionalExposedCabal :: String
+conditionalExposedCabal =
+  unlines
+    [ "cabal-version: 3.0",
+      "name: conditional-exposed",
+      "version: 0.1.0.0",
+      "",
+      "flag old-base",
+      "  default: False",
+      "  manual: True",
+      "",
+      "library",
+      "  hs-source-dirs: src",
+      "  default-language: Haskell2010",
+      "  if flag(old-base)",
+      "    build-depends: base >= 3.0 && < 3.0.3.1",
+      "  else",
+      "    exposed-modules: Control.Category.Unicode",
+      "    build-depends: base >= 3.0.3.1 && < 5"
     ]
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a


### PR DESCRIPTION
## Summary
- collect exposed modules from active Cabal library branches instead of only the root library stanza
- add a regression shaped like base-unicode-symbols, where `old-base` is false by default and `Control.Category.Unicode` is exposed in the active `else` branch

## Root Cause
`collectComponentFiles` merged active `BuildInfo` branches, but library module discovery read `exposedModules` only from `condTreeData`. Modules declared inside active conditional branches were therefore omitted from package resolution.

## Progress Counts
- Resolver progress counts: unchanged by this PR.

## Validation
- `cabal test -v0 aihc-hackage:spec --test-options="--pattern conditional"`
- `cabal run -v0 exe:aihc-dev -- resolve base-unicode-symbols`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
