### PR TITLE
feat(fmt): add aihc-fmt MVP

### DIFF
--- a/bin/aihc-fmt/aihc-fmt.cabal
+++ b/bin/aihc-fmt/aihc-fmt.cabal
@@ -1,0 +1,71 @@
+cabal-version: 3.8
+name: aihc-fmt
+version: 0.1.0.0
+build-type: Simple
+license: MIT
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Development
+synopsis: Haskell formatter based on aihc-parser
+
+library
+  exposed-modules:
+    Aihc.Fmt
+    Aihc.Fmt.CLI
+    Aihc.Fmt.Comment
+
+  hs-source-dirs: src
+  build-depends:
+    aihc-parser,
+    base >=4.16 && <5,
+    containers,
+    optparse-applicative >=0.16 && <0.19,
+    prettyprinter,
+    process,
+    text >=1.2,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
+executable aihc-fmt
+  hs-source-dirs: app/aihc-fmt
+  main-is: Main.hs
+  build-depends:
+    aihc-fmt,
+    base >=4.16 && <5,
+    text,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules:
+    Test.Fmt.CLI
+    Test.Fmt.Golden
+
+  build-depends:
+    aeson,
+    aihc-fmt,
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    process,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    yaml,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+  default-language: GHC2021

--- a/bin/aihc-fmt/app/aihc-fmt/Main.hs
+++ b/bin/aihc-fmt/app/aihc-fmt/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Aihc.Fmt.CLI qualified as CLI
+
+main :: IO ()
+main = CLI.main

--- a/bin/aihc-fmt/src/Aihc/Fmt.hs
+++ b/bin/aihc-fmt/src/Aihc/Fmt.hs
@@ -1,0 +1,256 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.Fmt
+  ( FormatOptions (..),
+    defaultFormatOptions,
+    FormatError (..),
+    formatErrorMessage,
+    formatText,
+  )
+where
+
+import Aihc.Fmt.Comment
+import Aihc.Parser
+  ( ParserConfig (..),
+    defaultConfig,
+    formatParseErrors,
+    parseModule,
+  )
+import Aihc.Parser.Lex
+  ( LexToken (..),
+    LexTokenKind (..),
+    lexModuleTokensWithSourceNameAndExtensions,
+    readModuleHeaderPragmas,
+  )
+import Aihc.Parser.Parens (addModuleParens)
+import Aihc.Parser.Syntax
+import Data.List (partition, unsnoc)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Prettyprinter (Pretty (pretty), defaultLayoutOptions, layoutPretty, (<+>))
+import Prettyprinter.Render.String (renderString)
+
+newtype FormatOptions = FormatOptions
+  { formatExtensions :: [ExtensionSetting]
+  }
+  deriving (Eq, Show)
+
+defaultFormatOptions :: FormatOptions
+defaultFormatOptions = FormatOptions {formatExtensions = []}
+
+data FormatError
+  = OriginalParseFailure !FilePath !Text
+  | FormattedParseFailure !FilePath !Text
+  | SemanticMismatch !FilePath !String
+  | CommentScanFailure !FilePath !CommentScanError
+  | IdempotenceFailure !FilePath !Text !Text
+  deriving (Eq, Show)
+
+formatText :: FormatOptions -> FilePath -> Text -> Either FormatError Text
+formatText opts sourceName input = do
+  formatted <- formatTextOnce opts sourceName input
+  formattedAgain <- formatTextOnce opts sourceName formatted
+  if formattedAgain == formatted
+    then Right formatted
+    else Left (IdempotenceFailure sourceName formatted formattedAgain)
+
+formatTextOnce :: FormatOptions -> FilePath -> Text -> Either FormatError Text
+formatTextOnce opts sourceName input = do
+  comments <- firstCommentError (collectComments sourceName input)
+  original <- parseInput OriginalParseFailure sourceName opts input
+  let rendered = renderModuleWithComments sourceName input original comments
+  reparsed <- parseInput FormattedParseFailure sourceName opts rendered
+  if normalizeModule original == normalizeModule reparsed
+    then Right rendered
+    else
+      Left
+        ( SemanticMismatch
+            sourceName
+            "formatted module reparsed to a different AST"
+        )
+  where
+    firstCommentError =
+      either (Left . CommentScanFailure sourceName) Right
+
+parseInput :: (FilePath -> Text -> FormatError) -> FilePath -> FormatOptions -> Text -> Either FormatError Module
+parseInput mkErr sourceName opts input =
+  let cfg = parserConfig sourceName opts input
+      (errs, modu) = parseModule cfg input
+   in if null errs
+        then Right modu
+        else Left (mkErr sourceName (T.pack (formatParseErrors sourceName (Just input) errs)))
+
+parserConfig :: FilePath -> FormatOptions -> Text -> ParserConfig
+parserConfig sourceName opts input =
+  defaultConfig
+    { parserSourceName = sourceName,
+      parserExtensions = finalExts
+    }
+  where
+    headerPragmas = readModuleHeaderPragmas input
+    defaultEdition = fromMaybe Haskell2010Edition (editionFromExtensionSettings (formatExtensions opts))
+    edition = fromMaybe defaultEdition (headerLanguageEdition headerPragmas)
+    finalExts = effectiveExtensions edition (formatExtensions opts <> headerExtensionSettings headerPragmas)
+
+normalizeModule :: Module -> Module
+normalizeModule = stripAnnotations . addModuleParens
+
+renderModuleWithComments :: FilePath -> Text -> Module -> [SourceComment] -> Text
+renderModuleWithComments sourceName input modu comments =
+  ensureTrailingNewline . T.unlines . placeComments comments $ sections
+  where
+    sections =
+      languagePragmaSections sourceName input
+        <> moduleHeadSections modu
+        <> importSections modu
+        <> declSections modu
+
+data Section = Section
+  { sectionSpan :: !(Maybe SourceSpan),
+    sectionLines :: ![Text]
+  }
+  deriving (Eq, Show)
+
+languagePragmaSections :: FilePath -> Text -> [Section]
+languagePragmaSections sourceName input =
+  case pragmaSpans of
+    [] -> []
+    spans ->
+      [ Section
+          { sectionSpan = Just (foldr1 mergeSourceSpans spans),
+            sectionLines = map renderLanguagePragma settings
+          }
+      ]
+  where
+    tokens = lexModuleTokensWithSourceNameAndExtensions sourceName [] input
+    pragmaSpans =
+      [ sp
+      | LexToken {lexTokenKind = TkPragma Pragma {pragmaType = PragmaLanguage {}}, lexTokenSpan = sp} <- tokens
+      ]
+    headerPragmas = readModuleHeaderPragmas input
+    settings = headerExtensionSettings headerPragmas
+
+renderLanguagePragma :: ExtensionSetting -> Text
+renderLanguagePragma ext =
+  T.pack . renderString . layoutPretty defaultLayoutOptions $
+    "{-# LANGUAGE" <+> pretty (extensionSettingName ext) <+> "#-}"
+
+moduleHeadSections :: Module -> [Section]
+moduleHeadSections modu =
+  case moduleHead modu of
+    Nothing -> []
+    Just head' ->
+      singletonSection (annListSpan (moduleHeadAnns head')) (renderOnlyHeader modu)
+
+importSections :: Module -> [Section]
+importSections modu =
+  [ Section
+      { sectionSpan = annListSpan (importDeclAnns importDecl),
+        sectionLines = textLines (renderModuleWithoutPreamble modu {moduleHead = Nothing, moduleImports = [importDecl], moduleDecls = []})
+      }
+  | importDecl <- moduleImports modu
+  ]
+
+declSections :: Module -> [Section]
+declSections modu =
+  [ Section
+      { sectionSpan = Just (getDeclSourceSpan decl),
+        sectionLines = textLines (renderPretty decl)
+      }
+  | decl <- moduleDecls modu
+  ]
+
+singletonSection :: Maybe SourceSpan -> Text -> [Section]
+singletonSection _ "" = []
+singletonSection sp txt = [Section sp (textLines txt)]
+
+renderOnlyHeader :: Module -> Text
+renderOnlyHeader modu =
+  renderModuleWithoutPreamble
+    modu
+      { moduleLanguagePragmas = [],
+        moduleImports = [],
+        moduleDecls = []
+      }
+
+renderModuleWithoutPreamble :: Module -> Text
+renderModuleWithoutPreamble modu =
+  renderPretty modu {moduleLanguagePragmas = []}
+
+renderPretty :: (Pretty a) => a -> Text
+renderPretty =
+  T.pack . renderString . layoutPretty defaultLayoutOptions . pretty
+
+textLines :: Text -> [Text]
+textLines txt = filter (not . T.null) (T.lines txt)
+
+annListSpan :: [Annotation] -> Maybe SourceSpan
+annListSpan = firstRealSpan . mapMaybe fromAnnotation
+
+firstRealSpan :: [SourceSpan] -> Maybe SourceSpan
+firstRealSpan spans =
+  case filter (/= NoSourceSpan) spans of
+    [] -> Nothing
+    sp : _ -> Just sp
+
+placeComments :: [SourceComment] -> [Section] -> [Text]
+placeComments comments [] =
+  concatMap renderStandaloneComment comments
+placeComments comments (section : rest) =
+  let (sameLine, notSameLine) = partition (commentFollowsSection section) comments
+      (before, after) = partition (commentPrecedesSection section) notSameLine
+      current = renderSection section before sameLine
+   in current <> placeComments after rest
+
+renderSection :: Section -> [SourceComment] -> [SourceComment] -> [Text]
+renderSection section leading trailing =
+  concatMap renderStandaloneComment leading
+    <> appendTrailingComments (sectionLines section) trailing
+
+appendTrailingComments :: [Text] -> [SourceComment] -> [Text]
+appendTrailingComments [] comments = concatMap renderStandaloneComment comments
+appendTrailingComments lines0 [] = lines0
+appendTrailingComments lines0 comments =
+  let rendered = T.intercalate " " (map commentText comments)
+   in case unsnoc lines0 of
+        Nothing -> concatMap renderStandaloneComment comments
+        Just (prefix, lastLine) -> prefix <> [lastLine <> " " <> rendered]
+
+renderStandaloneComment :: SourceComment -> [Text]
+renderStandaloneComment comment =
+  T.lines (commentText comment)
+
+commentPrecedesSection :: Section -> SourceComment -> Bool
+commentPrecedesSection section comment =
+  case sectionSpan section of
+    Nothing -> False
+    Just sp -> sourceSpanEndLine (commentSpan comment) < sourceSpanStartLine sp
+
+commentFollowsSection :: Section -> SourceComment -> Bool
+commentFollowsSection section comment =
+  case sectionSpan section of
+    Nothing -> False
+    Just sp ->
+      commentHasCodeBefore comment
+        && sourceSpanStartLine (commentSpan comment) == sourceSpanEndLine sp
+
+ensureTrailingNewline :: Text -> Text
+ensureTrailingNewline txt
+  | T.null txt = ""
+  | "\n" `T.isSuffixOf` txt = txt
+  | otherwise = txt <> "\n"
+
+formatErrorMessage :: FormatError -> Text
+formatErrorMessage err =
+  case err of
+    OriginalParseFailure sourceName msg ->
+      T.pack sourceName <> ": failed to parse input\n" <> msg
+    FormattedParseFailure sourceName msg ->
+      T.pack sourceName <> ": formatted output did not parse\n" <> msg
+    SemanticMismatch sourceName msg ->
+      T.pack sourceName <> ": semantic sanity check failed: " <> T.pack msg
+    CommentScanFailure sourceName scanErr ->
+      T.pack sourceName <> ": comment scan failed: " <> T.pack (formatCommentScanError scanErr)
+    IdempotenceFailure sourceName _ _ ->
+      T.pack sourceName <> ": idempotence sanity check failed"

--- a/bin/aihc-fmt/src/Aihc/Fmt/CLI.hs
+++ b/bin/aihc-fmt/src/Aihc/Fmt/CLI.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.Fmt.CLI
+  ( Mode (..),
+    Options (..),
+    CLIResult (..),
+    main,
+    runCLI,
+  )
+where
+
+import Aihc.Fmt
+import Aihc.Parser.Syntax (ExtensionSetting, parseExtensionSettingName)
+import Control.Exception (IOException, try)
+import Control.Monad (foldM)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Options.Applicative
+import System.Environment (getArgs)
+import System.Exit (ExitCode (..), exitWith)
+import System.IO qualified as IO
+
+data Mode
+  = ModeStdout
+  | ModeInplace
+  | ModeCheck
+  deriving (Eq, Show)
+
+data Options = Options
+  { optMode :: !Mode,
+    optExtensions :: ![ExtensionSetting],
+    optFiles :: ![FilePath]
+  }
+  deriving (Eq, Show)
+
+data CLIResult = CLIResult
+  { cliExitCode :: !ExitCode,
+    cliStdout :: !Text,
+    cliStderr :: !Text
+  }
+  deriving (Eq, Show)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  parsed <- parseArgs args
+  case parsed of
+    Left result -> finish result
+    Right opts -> do
+      stdin <-
+        if null (optFiles opts)
+          then TIO.getContents
+          else pure ""
+      result <- runCLI TIO.readFile TIO.writeFile opts stdin
+      finish result
+
+finish :: CLIResult -> IO ()
+finish result = do
+  TIO.putStr (cliStdout result)
+  TIO.hPutStr IO.stderr (cliStderr result)
+  exitWith (cliExitCode result)
+
+runCLI ::
+  (FilePath -> IO Text) ->
+  (FilePath -> Text -> IO ()) ->
+  Options ->
+  Text ->
+  IO CLIResult
+runCLI readFileText writeFileText opts stdin =
+  case optFiles opts of
+    [] -> runStdin opts stdin
+    files -> runFiles readFileText writeFileText opts files
+
+runStdin :: Options -> Text -> IO CLIResult
+runStdin opts stdin =
+  case formatText formatOpts "<stdin>" stdin of
+    Left err -> pure (CLIResult (ExitFailure 1) "" (formatErrorMessage err <> "\n"))
+    Right formatted ->
+      case optMode opts of
+        ModeStdout -> pure (CLIResult ExitSuccess formatted "")
+        ModeCheck ->
+          if formatted == stdin
+            then pure (CLIResult ExitSuccess "" "")
+            else pure (CLIResult (ExitFailure 1) "" "<stdin>: needs formatting\n")
+        ModeInplace ->
+          pure (CLIResult (ExitFailure 1) "" "aihc-fmt: --mode inplace requires file arguments\n")
+  where
+    formatOpts = FormatOptions {formatExtensions = optExtensions opts}
+
+runFiles ::
+  (FilePath -> IO Text) ->
+  (FilePath -> Text -> IO ()) ->
+  Options ->
+  [FilePath] ->
+  IO CLIResult
+runFiles readFileText writeFileText opts =
+  foldM
+    (runOneFile readFileText writeFileText opts)
+    (CLIResult ExitSuccess "" "")
+
+runOneFile ::
+  (FilePath -> IO Text) ->
+  (FilePath -> Text -> IO ()) ->
+  Options ->
+  CLIResult ->
+  FilePath ->
+  IO CLIResult
+runOneFile readFileText writeFileText opts acc path = do
+  eInput <- try (readFileText path)
+  case eInput of
+    Left err -> pure (appendIOException path err acc)
+    Right input -> do
+      let formatOpts = FormatOptions {formatExtensions = optExtensions opts}
+      case formatText formatOpts path input of
+        Left err ->
+          pure
+            acc
+              { cliExitCode = ExitFailure 1,
+                cliStderr = cliStderr acc <> formatErrorMessage err <> "\n"
+              }
+        Right formatted ->
+          case optMode opts of
+            ModeStdout ->
+              pure acc {cliStdout = cliStdout acc <> formatted}
+            ModeCheck ->
+              if formatted == input
+                then pure acc
+                else
+                  pure
+                    acc
+                      { cliExitCode = ExitFailure 1,
+                        cliStderr = cliStderr acc <> T.pack path <> ": needs formatting\n"
+                      }
+            ModeInplace ->
+              if formatted == input
+                then pure acc
+                else do
+                  eWrite <- try (writeFileText path formatted)
+                  case eWrite of
+                    Left err -> pure (appendIOException path err acc)
+                    Right () -> pure acc
+
+appendIOException :: FilePath -> IOException -> CLIResult -> CLIResult
+appendIOException path err acc =
+  acc
+    { cliExitCode = ExitFailure 1,
+      cliStderr = cliStderr acc <> T.pack path <> ": " <> T.pack (show err) <> "\n"
+    }
+
+parseArgs :: [String] -> IO (Either CLIResult Options)
+parseArgs args =
+  case execParserPure defaultPrefs optionsParser args of
+    Success opts -> pure (Right opts)
+    Failure failure ->
+      let (msg, exitCode) = renderFailure failure "aihc-fmt"
+          msgText = T.pack msg <> "\n"
+       in if exitCode == ExitSuccess
+            then pure (Left (CLIResult exitCode msgText ""))
+            else pure (Left (CLIResult exitCode "" msgText))
+    CompletionInvoked completion -> do
+      output <- execCompletion completion "aihc-fmt"
+      pure (Left (CLIResult ExitSuccess (T.pack output) ""))
+
+optionsParser :: ParserInfo Options
+optionsParser =
+  info
+    (optionsP <**> helper)
+    ( fullDesc
+        <> progDesc "Format Haskell source with aihc-parser"
+        <> header "aihc-fmt - Haskell formatter"
+    )
+
+optionsP :: Parser Options
+optionsP =
+  Options
+    <$> modeOption
+    <*> many extensionOption
+    <*> many (argument str (metavar "FILE"))
+
+modeOption :: Parser Mode
+modeOption =
+  option
+    parseMode
+    ( long "mode"
+        <> metavar "MODE"
+        <> value ModeStdout
+        <> showDefaultWith renderMode
+        <> help "Output mode: stdout, inplace, or check"
+    )
+
+parseMode :: ReadM Mode
+parseMode = eitherReader $ \raw ->
+  case raw of
+    "stdout" -> Right ModeStdout
+    "inplace" -> Right ModeInplace
+    "check" -> Right ModeCheck
+    _ -> Left ("unknown mode: " <> raw)
+
+renderMode :: Mode -> String
+renderMode mode =
+  case mode of
+    ModeStdout -> "stdout"
+    ModeInplace -> "inplace"
+    ModeCheck -> "check"
+
+extensionOption :: Parser ExtensionSetting
+extensionOption =
+  option
+    parseExtensionSetting
+    ( short 'X'
+        <> metavar "EXTENSION"
+        <> help "Enable a language extension"
+    )
+
+parseExtensionSetting :: ReadM ExtensionSetting
+parseExtensionSetting = eitherReader $ \raw ->
+  case parseExtensionSettingName (T.pack raw) of
+    Just setting -> Right setting
+    Nothing -> Left ("unknown extension: " <> raw)

--- a/bin/aihc-fmt/src/Aihc/Fmt/Comment.hs
+++ b/bin/aihc-fmt/src/Aihc/Fmt/Comment.hs
@@ -1,0 +1,261 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module Aihc.Fmt.Comment
+  ( CommentKind (..),
+    SourceComment (..),
+    CommentScanError (..),
+    collectComments,
+    formatCommentScanError,
+  )
+where
+
+import Aihc.Parser.Syntax (SourceSpan (..))
+import Data.Char (GeneralCategory (..), generalCategory, isAlphaNum, isSpace)
+import Data.Text (Text, pattern Empty, pattern (:<))
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+
+data CommentKind
+  = LineComment
+  | BlockComment
+  deriving (Eq, Ord, Show)
+
+data SourceComment = SourceComment
+  { commentSpan :: !SourceSpan,
+    commentText :: !Text,
+    commentKind :: !CommentKind,
+    commentHasCodeBefore :: !Bool
+  }
+  deriving (Eq, Ord, Show)
+
+data CommentScanError
+  = UnterminatedBlockComment !SourceSpan
+  | UnterminatedStringLiteral !SourceSpan
+  | UnterminatedCharLiteral !SourceSpan
+  deriving (Eq, Show)
+
+formatCommentScanError :: CommentScanError -> String
+formatCommentScanError err =
+  case err of
+    UnterminatedBlockComment sp -> "unterminated block comment at " <> formatSpan sp
+    UnterminatedStringLiteral sp -> "unterminated string literal at " <> formatSpan sp
+    UnterminatedCharLiteral sp -> "unterminated character literal at " <> formatSpan sp
+
+collectComments :: FilePath -> Text -> Either CommentScanError [SourceComment]
+collectComments sourceName input = go initialState []
+  where
+    initialState =
+      ScanState
+        { scanInput = input,
+          scanLine = 1,
+          scanCol = 1,
+          scanOffset = 0,
+          scanLineHasCode = False
+        }
+
+    go st acc =
+      case scanInput st of
+        Empty -> Right (reverse acc)
+        chars
+          | Just st' <- consumeWhitespace st ->
+              go st' acc
+          | "{-#" `T.isPrefixOf` chars,
+            Just st' <- consumePragma st ->
+              go st' acc
+          | "{-" `T.isPrefixOf` chars ->
+              case consumeNestedBlockComment sourceName st of
+                Left err -> Left err
+                Right (comment, st') -> go st' (comment : acc)
+          | Just rest <- T.stripPrefix "--" chars,
+            isLineCommentRest rest ->
+              let (comment, st') = consumeLineComment sourceName st
+               in go st' (comment : acc)
+          | "\"" `T.isPrefixOf` chars ->
+              case consumeQuoted sourceName '"' UnterminatedStringLiteral st of
+                Left err -> Left err
+                Right st' -> go (markCode st') acc
+          | "'" `T.isPrefixOf` chars ->
+              case consumeQuoted sourceName '\'' UnterminatedCharLiteral st of
+                Left err -> Left err
+                Right st' -> go (markCode st') acc
+          | otherwise ->
+              go (markCode (advanceOne st)) acc
+
+data ScanState = ScanState
+  { scanInput :: !Text,
+    scanLine :: !Int,
+    scanCol :: !Int,
+    scanOffset :: !Int,
+    scanLineHasCode :: !Bool
+  }
+  deriving (Eq, Show)
+
+consumeWhitespace :: ScanState -> Maybe ScanState
+consumeWhitespace st =
+  case scanInput st of
+    c :< _
+      | isSpace c ->
+          Just (advanceOne st)
+    _ -> Nothing
+
+consumePragma :: ScanState -> Maybe ScanState
+consumePragma st =
+  let (prefix, suffix) = T.breakOn "#-}" (scanInput st)
+   in if T.null suffix
+        then Nothing
+        else Just (advanceText (prefix <> "#-}") st)
+
+consumeLineComment :: FilePath -> ScanState -> (SourceComment, ScanState)
+consumeLineComment sourceName st =
+  let (raw, rest) = T.break (== '\n') (scanInput st)
+      st' = advanceText raw st
+      span' = mkScanSpan sourceName st st'
+      comment =
+        SourceComment
+          { commentSpan = span',
+            commentText = raw,
+            commentKind = LineComment,
+            commentHasCodeBefore = scanLineHasCode st
+          }
+   in (comment, st' {scanInput = rest})
+
+consumeNestedBlockComment :: FilePath -> ScanState -> Either CommentScanError (SourceComment, ScanState)
+consumeNestedBlockComment sourceName st =
+  case scanBlock 0 0 (scanInput st) of
+    Nothing -> Left (UnterminatedBlockComment (mkPointSpan sourceName st))
+    Just len ->
+      let raw = T.take len (scanInput st)
+          st' = advanceText raw st
+          comment =
+            SourceComment
+              { commentSpan = mkScanSpan sourceName st st',
+                commentText = raw,
+                commentKind = BlockComment,
+                commentHasCodeBefore = scanLineHasCode st
+              }
+       in Right (comment, st')
+  where
+    scanBlock :: Int -> Int -> Text -> Maybe Int
+    scanBlock depth n input =
+      case T.uncons input of
+        Nothing -> Nothing
+        Just (c, rest1) ->
+          case T.uncons rest1 of
+            Just (c2, rest2)
+              | c == '{' && c2 == '-' ->
+                  scanBlock (depth + 1) (n + 2) rest2
+              | c == '-' && c2 == '}' ->
+                  if depth == 1
+                    then Just (n + 2)
+                    else scanBlock (depth - 1) (n + 2) rest2
+            _ -> scanBlock depth (n + 1) rest1
+
+consumeQuoted ::
+  FilePath ->
+  Char ->
+  (SourceSpan -> CommentScanError) ->
+  ScanState ->
+  Either CommentScanError ScanState
+consumeQuoted sourceName quote mkErr st =
+  go False (advanceOne st)
+  where
+    go escaped current =
+      case scanInput current of
+        Empty -> Left (mkErr (mkPointSpan sourceName st))
+        c :< _
+          | escaped -> go False (advanceOne current)
+          | c == '\\',
+            quote == '"',
+            Just afterGap <- consumeStringGap (advanceOne current) ->
+              go False afterGap
+          | c == '\\' -> go True (advanceOne current)
+          | c == quote -> Right (advanceOne current)
+          | c == '\n' -> Left (mkErr (mkPointSpan sourceName st))
+          | otherwise -> go False (advanceOne current)
+
+consumeStringGap :: ScanState -> Maybe ScanState
+consumeStringGap = go False False
+  where
+    go seenWhitespace seenNewline st =
+      case scanInput st of
+        c :< _
+          | c == '\\' && seenWhitespace && seenNewline -> Just (advanceOne st)
+          | isSpace c -> go True (seenNewline || c == '\n') (advanceOne st)
+        _ -> Nothing
+
+advanceOne :: ScanState -> ScanState
+advanceOne st =
+  case T.uncons (scanInput st) of
+    Nothing -> st
+    Just (c, rest) ->
+      let bytes = byteLength (T.singleton c)
+       in if c == '\n'
+            then
+              st
+                { scanInput = rest,
+                  scanLine = scanLine st + 1,
+                  scanCol = 1,
+                  scanOffset = scanOffset st + bytes,
+                  scanLineHasCode = False
+                }
+            else
+              st
+                { scanInput = rest,
+                  scanCol = scanCol st + 1,
+                  scanOffset = scanOffset st + bytes
+                }
+
+advanceText :: Text -> ScanState -> ScanState
+advanceText txt st = T.foldl' (\acc _ -> advanceOne acc) st txt
+
+markCode :: ScanState -> ScanState
+markCode st = st {scanLineHasCode = True}
+
+mkScanSpan :: FilePath -> ScanState -> ScanState -> SourceSpan
+mkScanSpan sourceName start end =
+  SourceSpan
+    { sourceSpanSourceName = sourceName,
+      sourceSpanStartLine = scanLine start,
+      sourceSpanStartCol = scanCol start,
+      sourceSpanEndLine = scanLine end,
+      sourceSpanEndCol = scanCol end,
+      sourceSpanStartOffset = scanOffset start,
+      sourceSpanEndOffset = scanOffset end
+    }
+
+mkPointSpan :: FilePath -> ScanState -> SourceSpan
+mkPointSpan sourceName st = mkScanSpan sourceName st st
+
+formatSpan :: SourceSpan -> String
+formatSpan sp =
+  case sp of
+    NoSourceSpan -> "<unknown>"
+    SourceSpan {sourceSpanSourceName, sourceSpanStartLine, sourceSpanStartCol} ->
+      sourceSpanSourceName <> ":" <> show sourceSpanStartLine <> ":" <> show sourceSpanStartCol
+
+byteLength :: Text -> Int
+byteLength = T.length . TE.decodeLatin1 . TE.encodeUtf8
+
+isLineCommentRest :: Text -> Bool
+isLineCommentRest rest =
+  case T.dropWhile (== '-') rest of
+    Empty -> True
+    c :< _ -> not (isSymbolicOpChar c)
+
+isSymbolicOpChar :: Char -> Bool
+isSymbolicOpChar c =
+  c `elem` ("!#$%&*+./<=>?@\\^|-~:" :: String)
+    || (not (isAlphaNum c) && not (isSpace c) && isSymbolicCategory (generalCategory c))
+
+isSymbolicCategory :: GeneralCategory -> Bool
+isSymbolicCategory category =
+  case category of
+    MathSymbol -> True
+    CurrencySymbol -> True
+    ModifierSymbol -> True
+    OtherSymbol -> True
+    DashPunctuation -> True
+    OtherPunctuation -> True
+    ConnectorPunctuation -> True
+    _ -> False

--- a/bin/aihc-fmt/test/Spec.hs
+++ b/bin/aihc-fmt/test/Spec.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import Test.Fmt.CLI (cliTests)
+import Test.Fmt.Golden (goldenTests)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck qualified as QC
+
+main :: IO ()
+main = do
+  golden <- goldenTests
+  defaultMain $
+    testGroup
+      "aihc-fmt"
+      [ golden,
+        cliTests,
+        QC.testProperty "accepts shared QuickCheck options" prop_acceptsQuickCheckOptions
+      ]
+
+prop_acceptsQuickCheckOptions :: () -> Bool
+prop_acceptsQuickCheckOptions () = True

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/imports.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/imports.yaml
@@ -1,0 +1,47 @@
+extensions: []
+input: |
+  {-# LANGUAGE ImportQualifiedPost #-}
+  module Main where
+  import Data.Text qualified as T
+  import Data.Map (Map)
+  x=1
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      {-# LANGUAGE ImportQualifiedPost #-}
+      module Main where
+      import Data.Text qualified as T
+      import Data.Map (Map)
+      x =
+        1
+  ormolu:
+    status: pass
+    output: |
+      {-# LANGUAGE ImportQualifiedPost #-}
+
+      module Main where
+
+      import Data.Map (Map)
+      import Data.Text qualified as T
+
+      x = 1
+  hindent:
+    status: pass
+    output: |
+      {-# LANGUAGE ImportQualifiedPost #-}
+
+      module Main where
+
+      import Data.Map (Map)
+      import Data.Text qualified as T
+
+      x = 1
+  stylish-haskell:
+    status: pass
+    output: |
+      {-# LANGUAGE ImportQualifiedPost #-}
+      module Main where
+      import           Data.Map  (Map)
+      import qualified Data.Text as T
+      x=1

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/language-pragmas.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/language-pragmas.yaml
@@ -1,0 +1,35 @@
+extensions: []
+input: |
+  {-# LANGUAGE OverloadedStrings #-}
+  module Main where
+  name = "x"
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      {-# LANGUAGE OverloadedStrings #-}
+      module Main where
+      name =
+        "x"
+  ormolu:
+    status: pass
+    output: |
+      {-# LANGUAGE OverloadedStrings #-}
+
+      module Main where
+
+      name = "x"
+  hindent:
+    status: pass
+    output: |
+      {-# LANGUAGE OverloadedStrings #-}
+
+      module Main where
+
+      name = "x"
+  stylish-haskell:
+    status: pass
+    output: |
+      {-# LANGUAGE OverloadedStrings #-}
+      module Main where
+      name = "x"

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/simple-module.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/simple-module.yaml
@@ -1,0 +1,28 @@
+extensions: []
+input: |
+  module Main where
+  x=1
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      module Main where
+      x =
+        1
+  ormolu:
+    status: pass
+    output: |
+      module Main where
+
+      x = 1
+  hindent:
+    status: pass
+    output: |
+      module Main where
+
+      x = 1
+  stylish-haskell:
+    status: pass
+    output: |
+      module Main where
+      x=1

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/top-level-decls.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/top-level-decls.yaml
@@ -1,0 +1,38 @@
+extensions: []
+input: |
+  module Main where
+  f x=x+1
+  g y = f y
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      module Main where
+      f x =
+        x
+         + 1
+      g y =
+        f
+          y
+  ormolu:
+    status: pass
+    output: |
+      module Main where
+
+      f x = x + 1
+
+      g y = f y
+  hindent:
+    status: pass
+    output: |
+      module Main where
+
+      f x = x + 1
+
+      g y = f y
+  stylish-haskell:
+    status: pass
+    output: |
+      module Main where
+      f x=x+1
+      g y = f y

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/leading-top-level.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/leading-top-level.yaml
@@ -1,0 +1,33 @@
+extensions: []
+input: |
+  module Main where
+  -- leading
+  x=1
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      module Main where
+      -- leading
+      x =
+        1
+  ormolu:
+    status: pass
+    output: |
+      module Main where
+
+      -- leading
+      x = 1
+  hindent:
+    status: pass
+    output: |
+      module Main where
+
+      -- leading
+      x = 1
+  stylish-haskell:
+    status: pass
+    output: |
+      module Main where
+      -- leading
+      x=1

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/nested-comment.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/nested-comment.yaml
@@ -1,0 +1,40 @@
+extensions: []
+input: |
+  module Main where
+  f = x {- nested -}
+    where
+      x = 1
+formatters:
+  aihc-fmt:
+    status: xfail
+    reason: MVP only places comments near top-level sections; nested comments are preserved but not attached in place yet
+    output: |
+      module Main where
+      f =
+        x {- nested -}
+        where
+          x =
+            1
+  ormolu:
+    status: pass
+    output: |
+      module Main where
+
+      f = x {- nested -}
+        where
+          x = 1
+  hindent:
+    status: pass
+    output: |
+      module Main where
+
+      f = x {- nested -}
+        where
+          x = 1
+  stylish-haskell:
+    status: pass
+    output: |
+      module Main where
+      f = x {- nested -}
+        where
+          x = 1

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/same-line-trailing.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/same-line-trailing.yaml
@@ -1,0 +1,28 @@
+extensions: []
+input: |
+  module Main where
+  x=1 -- trailing
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      module Main where
+      x =
+        1 -- trailing
+  ormolu:
+    status: pass
+    output: |
+      module Main where
+
+      x = 1 -- trailing
+  hindent:
+    status: pass
+    output: |
+      module Main where
+
+      x = 1 -- trailing
+  stylish-haskell:
+    status: pass
+    output: |
+      module Main where
+      x=1 -- trailing

--- a/bin/aihc-fmt/test/Test/Fmt/CLI.hs
+++ b/bin/aihc-fmt/test/Test/Fmt/CLI.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Fmt.CLI
+  ( cliTests,
+  )
+where
+
+import Aihc.Fmt.CLI
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
+import System.Exit (ExitCode (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+cliTests :: TestTree
+cliTests =
+  testGroup
+    "cli"
+    [ testCase "formats stdin to stdout" test_stdinStdout,
+      testCase "check mode reports unformatted stdin" test_checkStdin,
+      testCase "inplace mode writes formatted files" test_inplace
+    ]
+
+test_stdinStdout :: IO ()
+test_stdinStdout = do
+  result <- runCLI missingReader missingWriter (Options ModeStdout [] []) "x=1\n"
+  assertEqual "exit" ExitSuccess (cliExitCode result)
+  assertEqual "stdout" "x =\n  1\n" (cliStdout result)
+  assertEqual "stderr" "" (cliStderr result)
+
+test_checkStdin :: IO ()
+test_checkStdin = do
+  result <- runCLI missingReader missingWriter (Options ModeCheck [] []) "x=1\n"
+  assertEqual "exit" (ExitFailure 1) (cliExitCode result)
+  assertEqual "stdout" "" (cliStdout result)
+  assertEqual "stderr" "<stdin>: needs formatting\n" (cliStderr result)
+
+test_inplace :: IO ()
+test_inplace = do
+  ref <- newIORef (M.singleton "Example.hs" "x=1\n")
+  let reader path = do
+        files <- readIORef ref
+        pure (files M.! path)
+      writer path contents = modifyIORef' ref (M.insert path contents)
+  result <- runCLI reader writer (Options ModeInplace [] ["Example.hs"]) ""
+  files <- readIORef ref
+  assertEqual "exit" ExitSuccess (cliExitCode result)
+  assertEqual "file" (Just "x =\n  1\n") (M.lookup "Example.hs" files)
+
+missingReader :: FilePath -> IO Text
+missingReader path = fail ("unexpected read: " <> path)
+
+missingWriter :: FilePath -> Text -> IO ()
+missingWriter path _ = fail ("unexpected write: " <> path)

--- a/bin/aihc-fmt/test/Test/Fmt/Golden.hs
+++ b/bin/aihc-fmt/test/Test/Fmt/Golden.hs
@@ -1,0 +1,263 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Fmt.Golden
+  ( goldenTests,
+  )
+where
+
+import Aihc.Fmt
+import Aihc.Parser.Syntax (ExtensionSetting, parseExtensionSettingName)
+import Control.Exception (IOException, bracket, catch)
+import Control.Monad (forM)
+import Data.Aeson (FromJSON, (.!=), (.:), (.:?))
+import Data.Aeson.Types (Parser, parseEither, withObject)
+import Data.Char (isSpace, toLower)
+import Data.Foldable (for_)
+import Data.List (dropWhileEnd, sort)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
+import System.Directory (doesDirectoryExist, findExecutable, getTemporaryDirectory, listDirectory, removeFile)
+import System.Exit (ExitCode (..))
+import System.FilePath (takeExtension, (</>))
+import System.IO (Handle, hClose, openTempFile)
+import System.Process (readProcessWithExitCode)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase, testCaseInfo)
+
+data ExpectedStatus
+  = StatusPass
+  | StatusXFail
+  deriving (Eq, Show)
+
+data FormatterExpectation = FormatterExpectation
+  { expectationStatus :: !ExpectedStatus,
+    expectationOutput :: !Text,
+    expectationReason :: !String
+  }
+  deriving (Eq, Show)
+
+data FormatterCase = FormatterCase
+  { caseId :: !String,
+    casePath :: !FilePath,
+    caseExtensions :: ![ExtensionSetting],
+    caseInput :: !Text,
+    caseFormatters :: !(Map Text FormatterExpectation)
+  }
+  deriving (Eq, Show)
+
+fixtureRoot :: FilePath
+fixtureRoot = "test/Test/Fixtures/fmt"
+
+goldenTests :: IO TestTree
+goldenTests = do
+  cases <- loadCases
+  aihcTests <- mapM mkAihcTest cases
+  externalTests <- mapM mkExternalTests cases
+  pure $
+    testGroup
+      "fmt-golden"
+      [ testGroup "aihc-fmt" aihcTests,
+        testGroup "external" (concat externalTests)
+      ]
+
+mkAihcTest :: FormatterCase -> IO TestTree
+mkAihcTest meta = pure $
+  case expectationFor "aihc-fmt" meta of
+    Nothing -> testCase (caseId meta) (assertFailure "missing aihc-fmt expectation")
+    Just expected ->
+      case expectationStatus expected of
+        StatusPass -> testCase (caseId meta) (assertAihcCase meta expected)
+        StatusXFail -> testCaseInfo (caseId meta) (xfailDetails (evaluateAihc meta expected))
+
+mkExternalTests :: FormatterCase -> IO [TestTree]
+mkExternalTests meta =
+  forM ["ormolu", "hindent", "stylish-haskell"] $ \name ->
+    case expectationFor name meta of
+      Nothing -> pure $ testCase (caseId meta <> "/" <> T.unpack name) (pure ())
+      Just expected ->
+        mkExternalTest name meta expected
+
+mkExternalTest :: Text -> FormatterCase -> FormatterExpectation -> IO TestTree
+mkExternalTest name meta expected = do
+  mExe <- findExecutable (T.unpack name)
+  case mExe of
+    Nothing ->
+      pure $
+        testCaseInfo
+          (caseId meta <> "/" <> T.unpack name)
+          (pure ("skipped: " <> T.unpack name <> " is not on PATH"))
+    Just exe ->
+      pure $
+        testCase (caseId meta <> "/" <> T.unpack name) $
+          assertExternalCase exe name meta expected
+
+assertAihcCase :: FormatterCase -> FormatterExpectation -> Assertion
+assertAihcCase meta expected =
+  for_ (evaluateAihc meta expected) assertFailure
+
+xfailDetails :: Maybe String -> IO String
+xfailDetails result =
+  case result of
+    Nothing -> assertFailure "expected xfail case to keep failing"
+    Just details -> pure details
+
+evaluateAihc :: FormatterCase -> FormatterExpectation -> Maybe String
+evaluateAihc meta expected =
+  case formatText opts (casePath meta) (caseInput meta) of
+    Left err ->
+      Just ("aihc-fmt failed: " <> T.unpack (formatErrorMessage err))
+    Right actual
+      | actual == expectationOutput expected -> Nothing
+      | expectationStatus expected == StatusXFail ->
+          Just ("known formatter gap: " <> expectationReason expected)
+      | otherwise ->
+          Just (mismatchDetails (expectationOutput expected) actual)
+  where
+    opts = defaultFormatOptions {formatExtensions = caseExtensions meta}
+
+assertExternalCase :: FilePath -> Text -> FormatterCase -> FormatterExpectation -> Assertion
+assertExternalCase exe name meta expected = do
+  (exitCode, stdout, stderr, formattedFile) <-
+    bracket
+      acquireTempFile
+      releaseTempFile
+      ( \(tmpPath, handle) -> do
+          TIO.hPutStr handle (caseInput meta)
+          hClose handle
+          (exitCode, stdout, stderr) <- readProcessWithExitCode exe [tmpPath] ""
+          formattedFile <- TIO.readFile tmpPath
+          pure (exitCode, stdout, stderr, formattedFile)
+      )
+  let actual =
+        if null stdout
+          then formattedFile
+          else T.pack stdout
+  case (exitCode, expectationStatus expected) of
+    (ExitSuccess, StatusPass)
+      | actual == expectationOutput expected -> pure ()
+      | otherwise -> assertFailure (mismatchDetails (expectationOutput expected) actual)
+    (ExitSuccess, StatusXFail)
+      | actual == expectationOutput expected ->
+          assertFailure ("expected " <> T.unpack name <> " xfail to keep failing")
+      | otherwise -> pure ()
+    (ExitFailure _, StatusXFail) -> pure ()
+    (ExitFailure _, StatusPass) ->
+      assertFailure (T.unpack name <> " failed:\n" <> stderr)
+
+acquireTempFile :: IO (FilePath, Handle)
+acquireTempFile = do
+  tmpDir <- getTemporaryDirectory
+  openTempFile tmpDir "aihc-fmt-fixture.hs"
+
+releaseTempFile :: (FilePath, Handle) -> IO ()
+releaseTempFile (tmpPath, handle) = do
+  hClose handle `catch` ignoreIOException
+  removeFile tmpPath `catch` ignoreIOException
+
+ignoreIOException :: IOException -> IO ()
+ignoreIOException _ = pure ()
+
+loadCases :: IO [FormatterCase]
+loadCases = do
+  paths <- listFixtureFiles fixtureRoot
+  mapM loadCase paths
+
+loadCase :: FilePath -> IO FormatterCase
+loadCase path = do
+  source <- TIO.readFile path
+  case parseCaseText path source of
+    Left err -> fail err
+    Right parsed -> pure parsed
+
+parseCaseText :: FilePath -> Text -> Either String FormatterCase
+parseCaseText path source = do
+  value <-
+    case Y.decodeEither' (encodeUtf8 source) of
+      Left err -> Left ("Invalid YAML fixture " <> path <> ": " <> Y.prettyPrintParseException err)
+      Right parsed -> Right parsed
+  (extNames, inputText, formatters) <-
+    case parseEither parseYaml value of
+      Left err -> Left ("Invalid formatter fixture schema in " <> path <> ": " <> err)
+      Right parsed -> Right parsed
+  exts <- traverse (parseExtension path) extNames
+  pure
+    FormatterCase
+      { caseId = dropRootPrefix path,
+        casePath = path,
+        caseExtensions = exts,
+        caseInput = inputText,
+        caseFormatters = formatters
+      }
+
+parseYaml :: Y.Value -> Parser ([Text], Text, Map Text FormatterExpectation)
+parseYaml =
+  withObject "formatter fixture" $ \obj ->
+    (,,)
+      <$> obj .: "extensions"
+      <*> obj .: "input"
+      <*> obj .: "formatters"
+
+instance FromJSON FormatterExpectation where
+  parseJSON =
+    withObject "formatter expectation" $ \obj -> do
+      rawStatus <- obj .: "status"
+      FormatterExpectation
+        <$> parseStatus rawStatus
+        <*> obj .: "output"
+        <*> obj .:? "reason" .!= ""
+
+parseStatus :: Text -> Y.Parser ExpectedStatus
+parseStatus raw =
+  case map toLower (trim (T.unpack raw)) of
+    "pass" -> pure StatusPass
+    "xfail" -> pure StatusXFail
+    _ -> fail ("invalid status: " <> T.unpack raw)
+
+parseExtension :: FilePath -> Text -> Either String ExtensionSetting
+parseExtension path raw =
+  case parseExtensionSettingName raw of
+    Just ext -> Right ext
+    Nothing -> Left ("Invalid extension in " <> path <> ": " <> T.unpack raw)
+
+expectationFor :: Text -> FormatterCase -> Maybe FormatterExpectation
+expectationFor name meta = M.lookup name (caseFormatters meta)
+
+listFixtureFiles :: FilePath -> IO [FilePath]
+listFixtureFiles dir = do
+  exists <- doesDirectoryExist dir
+  if not exists
+    then pure []
+    else do
+      entries <- sort <$> listDirectory dir
+      concat
+        <$> mapM
+          ( \entry -> do
+              let path = dir </> entry
+              isDir <- doesDirectoryExist path
+              if isDir
+                then listFixtureFiles path
+                else
+                  if takeExtension path `elem` [".yaml", ".yml"]
+                    then pure [path]
+                    else pure []
+          )
+          entries
+
+dropRootPrefix :: FilePath -> FilePath
+dropRootPrefix path =
+  maybe path T.unpack (T.stripPrefix (T.pack (fixtureRoot <> "/")) (T.pack path))
+
+mismatchDetails :: Text -> Text -> String
+mismatchDetails expected actual =
+  "output mismatch\nexpected:\n"
+    <> T.unpack expected
+    <> "\nactual:\n"
+    <> T.unpack actual
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
   components/aihc-resolve
   components/aihc-tc
   components/aihc-fc
+  bin/aihc-fmt
   tooling/aihc-hackage
   tooling/aihc-dev
 

--- a/docs/formatter-comment-attachment.md
+++ b/docs/formatter-comment-attachment.md
@@ -1,0 +1,97 @@
+# Formatter Comment Attachment
+
+This document records the comment-placement strategies used by current Haskell
+formatters and the tradeoffs for `aihc-fmt`.
+
+## Ormolu
+
+Ormolu extracts comments from GHC parser annotations into a `CommentStream`,
+then consumes that stream while rendering located AST nodes. The package
+description explicitly lists `Ormolu.Parser.CommentStream` and
+`Ormolu.Printer.Comments` as public implementation modules, and states core
+goals including GHC-parser-based parsing, idempotence, robustness, and comment
+preservation.
+
+The comment stream normalizes line and block comments, removes valid Haddock
+comments from the ordinary stream, handles stack script headers separately, and
+extracts pragmas with comments associated to the same pragma line. During
+printing, the `located` combinator is the main attachment point: it emits
+preceding comments, renders the AST node with an enclosing span, and then emits
+following comments. Following-comment attachment checks whether the comment is
+on the same line, continues a previous comment block, is the last element in an
+enclosing construct, and whether attaching it to the child would incorrectly
+steal it from the parent based on column distance.
+
+This design is high quality but depends heavily on a complete, precise span
+stream and on every printer path consistently entering located nodes.
+
+Sources:
+
+- [Ormolu package/docs](https://hackage.haskell.org/package/ormolu)
+- [Ormolu.Parser.CommentStream](https://raw.githubusercontent.com/tweag/ormolu/master/src/Ormolu/Parser/CommentStream.hs)
+- [Ormolu.Printer.Comments](https://raw.githubusercontent.com/tweag/ormolu/master/src/Ormolu/Printer/Comments.hs)
+- [Ormolu.Printer.Combinators](https://raw.githubusercontent.com/tweag/ormolu/master/src/Ormolu/Printer/Combinators.hs)
+
+## Hindent
+
+Hindent uses a relocation pass over GHC parser annotations. The pass starts from
+the parser's comment collection and rewrites AST annotations so comments are
+stored as prior or following comments on the nodes Hindent's printer expects.
+
+The relocation pass contains specialized rules for pragmas, comments before
+pragmas, export-list elements, class elements, case branches, do statements,
+top-level declarations, same-line comments, top-level `where` clauses, and
+remaining comments after nodes. It also scans annotations backwards for
+following comments so inner nodes do not necessarily consume comments that
+belong to enclosing syntax. This makes comment placement explicit and testable,
+but it is coupled to GHC annotation shapes and requires special cases for
+language constructs.
+
+Sources:
+
+- [Hindent package/docs](https://hackage.haskell.org/package/hindent)
+- [HIndent.ModulePreprocessing.CommentRelocation](https://raw.githubusercontent.com/mihaimaruseac/hindent/master/src/HIndent/ModulePreprocessing/CommentRelocation.hs)
+
+## Stylish Haskell
+
+Stylish Haskell is a line-editing pipeline over a parsed GHC AST. Each step
+receives the original lines and parsed module, then applies targeted textual
+edits. This means comments are often preserved naturally because untouched lines
+stay untouched.
+
+The tradeoff is that steps that replace whole blocks can lose comments inside
+those blocks. The import step explicitly notes that regrouping imports discards
+blank lines and comments inside the import section. The module helper also notes
+that merging imports loses the mapping between parser comments and import
+declarations, because GHC annotation comments are not already attached to the
+specific import nodes Stylish wants to manipulate.
+
+Stylish Haskell therefore avoids many whole-program comment-placement problems
+by editing only selected ranges, but that approach is a weaker fit for
+`aihc-fmt`, whose MVP is a whole-module pretty-printer with semantic
+round-trip checks.
+
+Sources:
+
+- [Stylish Haskell package/docs](https://hackage.haskell.org/package/stylish-haskell)
+- [Stylish Haskell run pipeline](https://raw.githubusercontent.com/haskell/stylish-haskell/master/lib/Language/Haskell/Stylish.hs)
+- [Stylish Haskell imports step](https://raw.githubusercontent.com/haskell/stylish-haskell/master/lib/Language/Haskell/Stylish/Step/Imports.hs)
+- [Stylish Haskell module helpers](https://raw.githubusercontent.com/haskell/stylish-haskell/master/lib/Language/Haskell/Stylish/Module.hs)
+
+## `aihc-fmt` MVP Direction
+
+The MVP follows the Ormolu/Hindent principle that formatted output must be
+reparsed and compared against the original AST before any output is printed or
+written. The initial comment model is intentionally narrower:
+
+- scan ordinary comments separately from the parser token stream;
+- preserve language pragmas, module headers, imports, and declarations as
+top-level render sections;
+- attach comments before the next top-level section when they precede it;
+- attach same-line comments to the section that ended on that line;
+- preserve unsupported nested comments in source order, with xfail fixtures
+documenting known placement gaps.
+
+The likely next step is to move from section-level placement to AST-node
+placement by extending parser annotations or adding a Hindent-style relocation
+pass over `aihc-parser` spans.

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ qc:
 
 # Auto-format Nix, Cabal, and Haskell files (excludes dist-newstyle, result, .git; Haskell excludes test fixtures)
 fmt:
-  nix develop --quiet --command bash -c 'find . -name "*.nix" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0 | xargs -0 -r alejandra; while IFS= read -r -d "" file; do cabal-gild --mode format --io "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); ormolu --mode inplace $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'find . -name "*.nix" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0 | xargs -0 -r alejandra; while IFS= read -r -d "" file; do cabal-gild --mode format --io "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); ormolu --mode inplace $(find components tooling bin -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
 
 # Apply HLint hints in place via apply-refact (HLint --refactor accepts one file at a time; same file set as fmt/check)
 hlint-refactor:
@@ -26,13 +26,13 @@ hlint-refactor:
     'set -euo pipefail
      while IFS= read -r -d "" f; do
        hlint --refactor --refactor-options="--inplace" "$f"
-     done < <(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*" -print0)'
+     done < <(find components tooling bin -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*" -print0)'
 
 # Run full CI check: format, lint, then tests (warnings are errors only here, not in plain `cabal` / `just test`)
 check:
   nix develop --quiet --command bash -c 'failed=0; while IFS= read -r -d "" file; do cabal-gild --mode check --input "$file" || failed=1; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); exit "$failed"'
-  nix develop --quiet --command bash -c 'ormolu --mode check $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
-  nix develop --quiet --command bash -c 'hlint -j $(find components tooling -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'ormolu --mode check $(find components tooling bin -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'hlint -j $(find components tooling bin -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'
 
 # Generate boot package interfaces for the resolver (requires GHC dev env)

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -34,6 +34,7 @@
   resolveTests = mkPackageTest hsPkgs.aihc-resolve;
   tcTests = mkPackageTest hsPkgs.aihc-tc;
   devTests = mkPackageTest hsPkgs.aihc-dev;
+  fmtTests = mkPackageTest hsPkgs.aihc-fmt;
 
   nixLint = mkSourceCheck "aihc-nix-lint" (sources.nixSrc pkgs) [pkgs.statix] ''
     statix check flake.nix
@@ -109,6 +110,7 @@ in {
   resolve-tests = resolveTests;
   tc-tests = tcTests;
   dev-tests = devTests;
+  fmt-tests = fmtTests;
   cpp-doctest = cppDoctest;
   parser-doctest = parserDoctest;
   parser-progress-strict = parserProgressStrict;
@@ -149,6 +151,10 @@ in {
     {
       name = "dev-tests";
       path = devTests;
+    }
+    {
+      name = "fmt-tests";
+      path = fmtTests;
     }
     {
       name = "cpp-doctest";

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -52,6 +52,13 @@
       supportsDocs = false;
       supportsCoverage = false;
     };
+    aihc-fmt = {
+      src = sources.fmtSrc;
+      disableProfiling = true;
+      optimizeForChecks = true;
+      supportsDocs = false;
+      supportsCoverage = false;
+    };
   };
 
   enableCoverageWithExport = hsLib: drv:

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -68,6 +68,13 @@ in rec {
     ".cabal"
   ];
 
+  fmtSrc = mkComponentSrc "/bin/aihc-fmt" [
+    ".hs"
+    ".cabal"
+    ".yaml"
+    ".yml"
+  ];
+
   # Filtered source for nix linting - only nix files.
   nixSrc = pkgs:
     pkgs.lib.cleanSourceWith {
@@ -78,7 +85,7 @@ in rec {
         type == "directory" || pkgs.lib.hasSuffix ".nix" baseName;
     };
 
-  # Filtered source for Haskell linting/formatting - .hs files and .cabal files in components and tooling.
+  # Filtered source for Haskell linting/formatting - .hs files and .cabal files in components, tooling, and bin.
   # (.cabal files needed for ormolu to detect language settings like GHC2021)
   haskellSrc = pkgs:
     pkgs.lib.cleanSourceWith {
@@ -91,8 +98,9 @@ in rec {
         isFixture = pkgs.lib.hasInfix "/test/Test/Fixtures/" pathStr;
         inComponents = pkgs.lib.hasInfix "/components/" pathStr;
         inTooling = pkgs.lib.hasInfix "/tooling/" pathStr;
+        inBin = pkgs.lib.hasInfix "/bin/" pathStr;
       in
-        type == "directory" || ((inComponents || inTooling) && (isCabal || (isHaskell && !isFixture)));
+        type == "directory" || ((inComponents || inTooling || inBin) && (isCabal || (isHaskell && !isFixture)));
     };
 
   # Filtered source for scripts - only shell scripts.


### PR DESCRIPTION
## Summary
- add a new `bin/aihc-fmt` Cabal package with library, executable, CLI, tests, and YAML formatter comparison fixtures
- implement conservative parse/format/reparse semantic checks plus idempotence checks before output
- add best-effort top-level and same-line comment preservation, with nested comment behavior captured as xfail
- document Ormolu, Hindent, and Stylish Haskell comment attachment strategies
- wire `bin/` into `just fmt`, `just check`, and Nix package/check source filters

## Progress counts
- Formatter packages: 0 -> 1
- Formatter golden fixtures: 0 -> 7
- aihc-fmt tests: 0 -> 32

## Validation
- `cabal test -v0 aihc-fmt:spec --test-options=--hide-successes`
- `cabal test -v0 all --test-options=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` ran; findings were addressed before the final push

Note: two intermediate `just check` attempts hit randomized existing parser QuickCheck property failures unrelated to this PR; subsequent full `just check` runs passed.
