### PR TITLE
refactor(parser): remove source span accessors

### DIFF
--- a/bin/aihc-fmt/src/Aihc/Fmt.hs
+++ b/bin/aihc-fmt/src/Aihc/Fmt.hs
@@ -155,11 +155,19 @@ importSections modu =
 declSections :: Module -> [Section]
 declSections modu =
   [ Section
-      { sectionSpan = Just (getDeclSourceSpan decl),
+      { sectionSpan = declSpan decl,
         sectionLines = textLines (renderPretty decl)
       }
   | decl <- moduleDecls modu
   ]
+
+declSpan :: Decl -> Maybe SourceSpan
+declSpan (DeclAnn ann inner) =
+  case fromAnnotation ann of
+    Just NoSourceSpan -> declSpan inner
+    Just sp -> Just sp
+    Nothing -> declSpan inner
+declSpan _ = Nothing
 
 singletonSection :: Maybe SourceSpan -> Text -> [Section]
 singletonSection _ "" = []

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -677,15 +677,22 @@ contextItemsParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]
 contextItemsParserWith typeParser typeAtomParser =
   MP.try parenthesizedContextItemsParser <|> fmap pure (contextItemParserWith typeParser typeAtomParser)
   where
-    parenthesizedContextItemsParser = do
-      withSpanAnn annotateParenthesizedItems $ do
+    parenthesizedContextItemsParser =
+      MP.try parenthesizedSingletonContextItemParser <|> parenthesizedMultipleContextItemsParser
+    parenthesizedSingletonContextItemParser =
+      fmap pure . withSpanAnn (TAnn . mkAnnotation) $ do
         items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
         guardNotFollowedByConstraintInfixOp
         case items of
-          [] -> fail "empty constraint list in parens"
-          _ -> pure items
-    annotateParenthesizedItems span' [item] = [typeAnnSpan span' (TParen item)]
-    annotateParenthesizedItems _ items = items
+          [item] -> pure (TParen item)
+          _ -> MP.empty
+    parenthesizedMultipleContextItemsParser = do
+      items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
+      guardNotFollowedByConstraintInfixOp
+      case items of
+        [] -> fail "empty constraint list in parens"
+        [_] -> MP.empty
+        _ -> pure items
     guardNotFollowedByConstraintInfixOp = do
       isFollowed <-
         fmap (either (const False) (const True))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -678,13 +678,14 @@ contextItemsParserWith typeParser typeAtomParser =
   MP.try parenthesizedContextItemsParser <|> fmap pure (contextItemParserWith typeParser typeAtomParser)
   where
     parenthesizedContextItemsParser = do
-      withSpan $ do
+      withSpanAnn annotateParenthesizedItems $ do
         items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
         guardNotFollowedByConstraintInfixOp
         case items of
           [] -> fail "empty constraint list in parens"
-          [item] -> pure (\span' -> [typeAnnSpan span' (TParen item)])
-          _ -> pure (const items)
+          _ -> pure items
+    annotateParenthesizedItems span' [item] = [typeAnnSpan span' (TParen item)]
+    annotateParenthesizedItems _ items = items
     guardNotFollowedByConstraintInfixOp = do
       isFollowed <-
         fmap (either (const False) (const True))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -678,12 +678,13 @@ contextItemsParserWith typeParser typeAtomParser =
   MP.try parenthesizedContextItemsParser <|> fmap pure (contextItemParserWith typeParser typeAtomParser)
   where
     parenthesizedContextItemsParser = do
-      items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
-      guardNotFollowedByConstraintInfixOp
-      case items of
-        [] -> fail "empty constraint list in parens"
-        [item] -> pure [typeAnnSpan (getTypeSourceSpan item) (TParen item)]
-        _ -> pure items
+      withSpan $ do
+        items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
+        guardNotFollowedByConstraintInfixOp
+        case items of
+          [] -> fail "empty constraint list in parens"
+          [item] -> pure (\span' -> [typeAnnSpan span' (TParen item)])
+          _ -> pure (const items)
     guardNotFollowedByConstraintInfixOp = do
       isFollowed <-
         fmap (either (const False) (const True))

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -677,21 +677,12 @@ contextItemsParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]
 contextItemsParserWith typeParser typeAtomParser =
   MP.try parenthesizedContextItemsParser <|> fmap pure (contextItemParserWith typeParser typeAtomParser)
   where
-    parenthesizedContextItemsParser =
-      MP.try parenthesizedSingletonContextItemParser <|> parenthesizedMultipleContextItemsParser
-    parenthesizedSingletonContextItemParser =
-      fmap pure . withSpanAnn (TAnn . mkAnnotation) $ do
-        items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
-        guardNotFollowedByConstraintInfixOp
-        case items of
-          [item] -> pure (TParen item)
-          _ -> MP.empty
-    parenthesizedMultipleContextItemsParser = do
+    parenthesizedContextItemsParser = do
       items <- parens (contextItemParserWith typeParser typeAtomParser `MP.sepEndBy` expectedTok TkSpecialComma)
       guardNotFollowedByConstraintInfixOp
       case items of
         [] -> fail "empty constraint list in parens"
-        [_] -> MP.empty
+        [item] -> pure [typeAnnSpan NoSourceSpan (TParen item)]
         _ -> pure items
     guardNotFollowedByConstraintInfixOp = do
       isFollowed <-

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -83,18 +83,21 @@ conOperatorParser =
 appPatternParser :: TokParser Pattern
 appPatternParser =
   negativeLiteralPatternParser <|> do
-    first <- patternAtomParser
-    if isPatternAppHead first
-      then foldl buildPatternApp first <$> MP.many patternAtomParser
-      else pure first
+    withSpan $ do
+      first <- patternAtomParser
+      if isPatternAppHead first
+        then do
+          args <- MP.many patternAtomParser
+          case args of
+            [] -> pure (const first)
+            _ -> pure (\span' -> PAnn (mkAnnotation span') (foldl buildPatternApp first args))
+        else pure (const first)
 
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =
   case peelPatternAnn lhs of
     PCon name typeArgs args ->
-      PAnn
-        (mkAnnotation (mergeSourceSpans (getPatternSourceSpan lhs) (getPatternSourceSpan rhs)))
-        (PCon name typeArgs (args <> [rhs]))
+      PCon name typeArgs (args <> [rhs])
     _ -> lhs
 
 -- | Parse an atomic pattern (@apat@ in the Haskell Report).

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -84,22 +84,13 @@ appPatternParser :: TokParser Pattern
 appPatternParser =
   negativeLiteralPatternParser
     <|> withSpanAnn
-      annotateAppPattern
+      (PAnn . mkAnnotation)
       ( do
           first <- patternAtomParser
           if isPatternAppHead first
-            then do
-              args <- MP.many patternAtomParser
-              case args of
-                [] -> pure first
-                _ -> pure (foldl buildPatternApp first args)
+            then foldl buildPatternApp first <$> MP.many patternAtomParser
             else pure first
       )
-  where
-    annotateAppPattern span' pat =
-      case peelPatternAnn pat of
-        PCon _ _ (_ : _) -> PAnn (mkAnnotation span') pat
-        _ -> pat
 
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -82,16 +82,24 @@ conOperatorParser =
 -- @Con (-0)@ — the @-@ is not valid inside an @apat@.
 appPatternParser :: TokParser Pattern
 appPatternParser =
-  negativeLiteralPatternParser <|> do
-    withSpan $ do
-      first <- patternAtomParser
-      if isPatternAppHead first
-        then do
-          args <- MP.many patternAtomParser
-          case args of
-            [] -> pure (const first)
-            _ -> pure (\span' -> PAnn (mkAnnotation span') (foldl buildPatternApp first args))
-        else pure (const first)
+  negativeLiteralPatternParser
+    <|> withSpanAnn
+      annotateAppPattern
+      ( do
+          first <- patternAtomParser
+          if isPatternAppHead first
+            then do
+              args <- MP.many patternAtomParser
+              case args of
+                [] -> pure first
+                _ -> pure (foldl buildPatternApp first args)
+            else pure first
+      )
+  where
+    annotateAppPattern span' pat =
+      case peelPatternAnn pat of
+        PCon _ _ (_ : _) -> PAnn (mkAnnotation span') pat
+        _ -> pat
 
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -82,21 +82,19 @@ conOperatorParser =
 -- @Con (-0)@ — the @-@ is not valid inside an @apat@.
 appPatternParser :: TokParser Pattern
 appPatternParser =
-  negativeLiteralPatternParser
-    <|> withSpanAnn
-      (PAnn . mkAnnotation)
-      ( do
-          first <- patternAtomParser
-          if isPatternAppHead first
-            then foldl buildPatternApp first <$> MP.many patternAtomParser
-            else pure first
-      )
+  negativeLiteralPatternParser <|> do
+    first <- patternAtomParser
+    if isPatternAppHead first
+      then foldl buildPatternApp first <$> MP.many patternAtomParser
+      else pure first
 
 buildPatternApp :: Pattern -> Pattern -> Pattern
 buildPatternApp lhs rhs =
   case peelPatternAnn lhs of
     PCon name typeArgs args ->
-      PCon name typeArgs (args <> [rhs])
+      PAnn
+        (mkAnnotation NoSourceSpan)
+        (PCon name typeArgs (args <> [rhs]))
     _ -> lhs
 
 -- | Parse an atomic pattern (@apat@ in the Haskell Report).

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 --
@@ -154,21 +153,6 @@ module Aihc.Parser.Syntax
     literalAnnSpan,
     peelLiteralAnn,
     typeAnnSpan,
-    getArithSeqSourceSpan,
-    getClassDeclItemSourceSpan,
-    getCmdSourceSpan,
-    getCompStmtSourceSpan,
-    getDataConDeclSourceSpan,
-    getDeclSourceSpan,
-    getDoStmtSourceSpan,
-    getExportSpecSourceSpan,
-    getExprSourceSpan,
-    getGuardQualifierSourceSpan,
-    getImportItemSourceSpan,
-    getInstanceDeclItemSourceSpan,
-    getLiteralSourceSpan,
-    getPatternSourceSpan,
-    getTypeSourceSpan,
   )
 where
 
@@ -895,14 +879,6 @@ data ExportSpec
   | ExportAnn Annotation ExportSpec
   deriving (Data, Eq, Show, Generic, NFData)
 
-getExportSpecSourceSpan :: ExportSpec -> SourceSpan
-getExportSpecSourceSpan spec =
-  case spec of
-    ExportAnn ann sub
-      | Just srcSpan <- fromAnnotation ann -> srcSpan
-      | otherwise -> getExportSpecSourceSpan sub
-    _ -> NoSourceSpan
-
 data ImportDecl = ImportDecl
   { importDeclAnns :: [Annotation],
     importDeclLevel :: Maybe ImportLevel,
@@ -938,14 +914,6 @@ data ImportItem
   | ImportAnn Annotation ImportItem
   deriving (Data, Eq, Show, Generic, NFData)
 
-getImportItemSourceSpan :: ImportItem -> SourceSpan
-getImportItemSourceSpan item =
-  case item of
-    ImportAnn ann sub
-      | Just srcSpan <- fromAnnotation ann -> srcSpan
-      | otherwise -> getImportItemSourceSpan sub
-    _ -> NoSourceSpan
-
 data Decl
   = DeclAnn Annotation Decl
   | DeclValue ValueDecl
@@ -973,14 +941,6 @@ data Decl
   | -- pragma declaration (e.g. {-# INLINE f #-}, {-# SPECIALIZE ... #-})
     DeclPragma Pragma
   deriving (Data, Eq, Show, Generic, NFData)
-
-getDeclSourceSpan :: Decl -> SourceSpan
-getDeclSourceSpan decl =
-  case decl of
-    DeclAnn ann sub
-      | Just srcSpan <- fromAnnotation ann -> srcSpan
-      | otherwise -> getDeclSourceSpan sub
-    _ -> NoSourceSpan
 
 -- | Peel nested 'DeclAnn' wrappers.
 peelDeclAnn :: Decl -> Decl
@@ -1066,14 +1026,6 @@ peelGuardQualifierAnn :: GuardQualifier -> GuardQualifier
 peelGuardQualifierAnn (GuardAnn _ inner) = peelGuardQualifierAnn inner
 peelGuardQualifierAnn q = q
 
-getGuardQualifierSourceSpan :: GuardQualifier -> SourceSpan
-getGuardQualifierSourceSpan qualifier =
-  case qualifier of
-    GuardAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getGuardQualifierSourceSpan sub
-    _ -> NoSourceSpan
-
 data Literal
   = LitAnn Annotation Literal
   | LitInt Integer NumericType Text
@@ -1083,14 +1035,6 @@ data Literal
   | LitString Text Text
   | LitStringHash Text Text
   deriving (Data, Eq, Show, Generic, NFData)
-
-getLiteralSourceSpan :: Literal -> SourceSpan
-getLiteralSourceSpan literal =
-  case literal of
-    LitAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getLiteralSourceSpan sub
-    _ -> NoSourceSpan
 
 literalAnnSpan :: SourceSpan -> Literal -> Literal
 literalAnnSpan sp = LitAnn (mkAnnotation sp)
@@ -1135,14 +1079,6 @@ data Pattern
   | PSplice Expr
   -- \$pat or $(pat) (TH pattern splice)
   deriving (Data, Eq, Show, Generic, NFData)
-
-getPatternSourceSpan :: Pattern -> SourceSpan
-getPatternSourceSpan pat =
-  case pat of
-    PAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getPatternSourceSpan sub
-    _ -> NoSourceSpan
 
 -- | Peel nested 'PAnn' wrappers.
 peelPatternAnn :: Pattern -> Pattern
@@ -1207,14 +1143,6 @@ data TypeBuiltinCon
   | TBuiltinList
   | TBuiltinCons
   deriving (Data, Eq, Show, Generic, NFData)
-
-getTypeSourceSpan :: Type -> SourceSpan
-getTypeSourceSpan ty =
-  case ty of
-    TAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getTypeSourceSpan sub
-    _ -> NoSourceSpan
 
 typeAnnSpan :: SourceSpan -> Type -> Type
 typeAnnSpan sp = TAnn (mkAnnotation sp)
@@ -1507,14 +1435,6 @@ gadtBodyResultType body =
     GadtPrefixBody _ ty -> ty
     GadtRecordBody _ ty -> ty
 
-getDataConDeclSourceSpan :: DataConDecl -> SourceSpan
-getDataConDeclSourceSpan dataConDecl =
-  case dataConDecl of
-    DataConAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getDataConDeclSourceSpan sub
-    _ -> NoSourceSpan
-
 data BangType = BangType
   { bangAnns :: [Annotation],
     bangPragmas :: [Pragma],
@@ -1584,14 +1504,6 @@ data ClassDeclItem
     ClassItemPragma Pragma
   deriving (Data, Eq, Show, Generic, NFData)
 
-getClassDeclItemSourceSpan :: ClassDeclItem -> SourceSpan
-getClassDeclItemSourceSpan classDeclItem =
-  case classDeclItem of
-    ClassItemAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getClassDeclItemSourceSpan sub
-    _ -> NoSourceSpan
-
 peelClassDeclItemAnn :: ClassDeclItem -> ClassDeclItem
 peelClassDeclItemAnn (ClassItemAnn _ inner) = peelClassDeclItemAnn inner
 peelClassDeclItemAnn item = item
@@ -1628,14 +1540,6 @@ data InstanceDeclItem
 peelInstanceDeclItemAnn :: InstanceDeclItem -> InstanceDeclItem
 peelInstanceDeclItemAnn (InstanceItemAnn _ inner) = peelInstanceDeclItemAnn inner
 peelInstanceDeclItemAnn item = item
-
-getInstanceDeclItemSourceSpan :: InstanceDeclItem -> SourceSpan
-getInstanceDeclItemSourceSpan instanceDeclItem =
-  case instanceDeclItem of
-    InstanceItemAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getInstanceDeclItemSourceSpan sub
-    _ -> NoSourceSpan
 
 data FixityAssoc
   = Infix
@@ -1762,14 +1666,6 @@ data Expr
   | EPragma Pragma Expr
   deriving (Data, Eq, Show, Generic, NFData)
 
-getExprSourceSpan :: Expr -> SourceSpan
-getExprSourceSpan expr =
-  case expr of
-    EAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getExprSourceSpan sub
-    _ -> NoSourceSpan
-
 -- | Peel nested 'EAnn' layers (e.g. span-only dynamic annotations).
 peelExprAnn :: Expr -> Expr
 peelExprAnn (EAnn _ x) = peelExprAnn x
@@ -1813,14 +1709,6 @@ peelDoStmtAnn :: DoStmt body -> DoStmt body
 peelDoStmtAnn (DoAnn _ inner) = peelDoStmtAnn inner
 peelDoStmtAnn s = s
 
-getDoStmtSourceSpan :: DoStmt body -> SourceSpan
-getDoStmtSourceSpan doStmt =
-  case doStmt of
-    DoAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getDoStmtSourceSpan sub
-    _ -> NoSourceSpan
-
 -- | Arrow command type (used inside 'proc' expressions).
 -- Commands mirror expressions but live in a separate namespace so the
 -- pretty-printer knows not to parenthesise @do { … }@ as an infix LHS.
@@ -1855,14 +1743,6 @@ peelCmdAnn c = c
 data ArrAppType = HsFirstOrderApp | HsHigherOrderApp
   deriving (Data, Eq, Show, Generic, NFData)
 
-getCmdSourceSpan :: Cmd -> SourceSpan
-getCmdSourceSpan cmd =
-  case cmd of
-    CmdAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getCmdSourceSpan sub
-    _ -> NoSourceSpan
-
 data CompStmt
   = -- | Metadata for the whole comprehension statement (typically a 'SourceSpan' via 'mkAnnotation').
     CompAnn Annotation CompStmt
@@ -1883,14 +1763,6 @@ peelCompStmtAnn :: CompStmt -> CompStmt
 peelCompStmtAnn (CompAnn _ inner) = peelCompStmtAnn inner
 peelCompStmtAnn s = s
 
-getCompStmtSourceSpan :: CompStmt -> SourceSpan
-getCompStmtSourceSpan compStmt =
-  case compStmt of
-    CompAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getCompStmtSourceSpan sub
-    _ -> NoSourceSpan
-
 data ArithSeq
   = -- | Metadata for the whole arithmetic sequence (typically a 'SourceSpan' via 'mkAnnotation').
     ArithSeqAnn Annotation ArithSeq
@@ -1903,14 +1775,6 @@ data ArithSeq
 peelArithSeqAnn :: ArithSeq -> ArithSeq
 peelArithSeqAnn (ArithSeqAnn _ inner) = peelArithSeqAnn inner
 peelArithSeqAnn s = s
-
-getArithSeqSourceSpan :: ArithSeq -> SourceSpan
-getArithSeqSourceSpan arithSeq =
-  case arithSeq of
-    ArithSeqAnn ann sub
-      | Just srcSpan <- fromAnnotation @SourceSpan ann -> srcSpan
-      | otherwise -> getArithSeqSourceSpan sub
-    _ -> NoSourceSpan
 
 -- | Recursively strip all annotations from an AST value.
 --

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -62,7 +62,6 @@ import Aihc.Parser.Syntax
     ValueDecl (..),
     binderHeadName,
     fromAnnotation,
-    getImportItemSourceSpan,
     mkAnnotation,
     mkQualifiedName,
     mkUnqualifiedName,
@@ -122,6 +121,10 @@ peelGuardQualifierSpan ambient _ = ambient
 peelDataConSpan :: SourceSpan -> DataConDecl -> SourceSpan
 peelDataConSpan ambient (DataConAnn ann inner) = peelDataConSpan (pushSpanFromAnn ambient ann) inner
 peelDataConSpan ambient _ = ambient
+
+peelImportItemSpan :: SourceSpan -> ImportItem -> SourceSpan
+peelImportItemSpan ambient (ImportAnn ann inner) = peelImportItemSpan (pushSpanFromAnn ambient ann) inner
+peelImportItemSpan ambient _ = ambient
 
 rhsSpan :: Rhs body -> SourceSpan
 rhsSpan rhs =
@@ -289,7 +292,7 @@ missingImportMemberAnnotation originScope item members =
     missingMemberAnnotation member =
       let memberName = nameText (ieBundledMemberName member)
        in ResolutionAnnotation
-            (importMemberNameSpan (getImportItemSourceSpan item) memberName)
+            (importMemberNameSpan (peelImportItemSpan NoSourceSpan item) memberName)
             memberName
             ResolutionNamespaceTerm
             (ResolvedError "not exported")
@@ -300,7 +303,7 @@ missingImportedName item namespace itemName candidates
   | otherwise =
       Just
         ( ResolutionAnnotation
-            (spanStartNameSpan (getImportItemSourceSpan item) rendered)
+            (spanStartNameSpan (peelImportItemSpan NoSourceSpan item) rendered)
             rendered
             namespace
             (ResolvedError "not exported")

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -35,7 +35,6 @@ import Aihc.Parser.Syntax
     binderHeadParams,
     fromAnnotation,
     gadtBodyResultType,
-    getDeclSourceSpan,
     peelDeclAnn,
     peelTypeHead,
     tyVarBinderName,
@@ -52,7 +51,7 @@ import Control.Monad (zipWithM)
 import Data.List (nub)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 
 -- | Merge concrete source spans embedded in a list of annotations.
@@ -61,6 +60,11 @@ sourceSpanFromAnns anns =
   case mapMaybe (fromAnnotation @SourceSpan) anns of
     [] -> NoSourceSpan
     s : _ -> s
+
+peelDeclSpan :: SourceSpan -> Decl -> SourceSpan
+peelDeclSpan ambient (DeclAnn ann inner) =
+  peelDeclSpan (fromMaybe ambient (fromAnnotation @SourceSpan ann)) inner
+peelDeclSpan ambient _ = ambient
 
 -- | Result of type-checking a single binding.
 data TcBindingResult = TcBindingResult
@@ -199,7 +203,7 @@ extractFunctionBind :: Decl -> Maybe (SourceSpan, UnqualifiedName, [Match])
 extractFunctionBind decl =
   case peelDeclAnn decl of
     DeclValue (FunctionBind name matches) ->
-      let sp = getDeclSourceSpan decl
+      let sp = peelDeclSpan NoSourceSpan decl
        in Just (sp, name, matches)
     _ -> Nothing
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -26,14 +26,13 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     UnqualifiedName (..),
     fromAnnotation,
-    getExprSourceSpan,
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Instantiate (instantiate)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -43,7 +42,7 @@ import Data.Text qualified as T
 inferExpr :: Expr -> TcM (TcType, [Ct])
 inferExpr expr = case expr of
   -- Variables: look up in environment, instantiate if polymorphic.
-  EVar name -> inferVar (getExprSourceSpan expr) (nameToText name)
+  EVar name -> inferVar (exprSpan expr) (nameToText name)
   -- Integer literals: monomorphic Int for MVP.
   -- (Full version would use Num constraint.)
   EInt {} -> pure (intTyCon, [])
@@ -54,17 +53,17 @@ inferExpr expr = case expr of
   -- String literals.
   EString _ _ -> pure (stringTyCon, [])
   -- Lambda: \x -> body
-  ELambdaPats pats body -> inferLambda (getExprSourceSpan expr) pats body
+  ELambdaPats pats body -> inferLambda (exprSpan expr) pats body
   -- Lambda case: \case { pat -> body; ... }
-  ELambdaCase alts -> inferLambdaCase (getExprSourceSpan expr) alts
+  ELambdaCase alts -> inferLambdaCase (exprSpan expr) alts
   -- Multi-argument lambda cases: \cases { p1 p2 -> body; ... }
-  ELambdaCases alts -> inferLambdaCases (getExprSourceSpan expr) alts
+  ELambdaCases alts -> inferLambdaCases (exprSpan expr) alts
   -- Application: f x
-  EApp fun arg -> inferApp (getExprSourceSpan expr) fun arg
+  EApp fun arg -> inferApp (exprSpan expr) fun arg
   -- If-then-else
-  EIf cond thenE elseE -> inferIf (getExprSourceSpan expr) cond thenE elseE
+  EIf cond thenE elseE -> inferIf (exprSpan expr) cond thenE elseE
   -- Case expression
-  ECase scrutinee alts -> inferCase (getExprSourceSpan expr) scrutinee alts
+  ECase scrutinee alts -> inferCase (exprSpan expr) scrutinee alts
   -- Let expression
   ELetDecls _decls body -> do
     -- MVP: infer body only (let bindings not yet processed).
@@ -85,15 +84,21 @@ inferExpr expr = case expr of
   -- Annotated expression (from other passes, e.g. resolve).
   EAnn _ann inner -> inferExpr inner
   -- Tuple
-  ETuple _flavor elems -> inferTuple (getExprSourceSpan expr) elems
+  ETuple _flavor elems -> inferTuple (exprSpan expr) elems
   -- List
-  EList elems -> inferList (getExprSourceSpan expr) elems
+  EList elems -> inferList (exprSpan expr) elems
   -- Unsupported expression forms for MVP.
   other -> do
-    let sp = getExprSourceSpan other
+    let sp = exprSpan other
     emitError sp (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
     ty <- freshMetaTv
     pure (ty, [])
+
+exprSpan :: Expr -> SourceSpan
+exprSpan = go NoSourceSpan
+  where
+    go ambient (EAnn ann inner) = go (fromMaybe ambient (fromAnnotation @SourceSpan ann)) inner
+    go ambient _ = ambient
 
 -- | Infer the type of a variable reference.
 inferVar :: SourceSpan -> Text -> TcM (TcType, [Ct])

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -32,7 +32,7 @@ import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Instantiate (instantiate)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -42,7 +42,7 @@ import Data.Text qualified as T
 inferExpr :: Expr -> TcM (TcType, [Ct])
 inferExpr expr = case expr of
   -- Variables: look up in environment, instantiate if polymorphic.
-  EVar name -> inferVar (exprSpan expr) (nameToText name)
+  EVar name -> inferVar NoSourceSpan (nameToText name)
   -- Integer literals: monomorphic Int for MVP.
   -- (Full version would use Num constraint.)
   EInt {} -> pure (intTyCon, [])
@@ -53,17 +53,17 @@ inferExpr expr = case expr of
   -- String literals.
   EString _ _ -> pure (stringTyCon, [])
   -- Lambda: \x -> body
-  ELambdaPats pats body -> inferLambda (exprSpan expr) pats body
+  ELambdaPats pats body -> inferLambda NoSourceSpan pats body
   -- Lambda case: \case { pat -> body; ... }
-  ELambdaCase alts -> inferLambdaCase (exprSpan expr) alts
+  ELambdaCase alts -> inferLambdaCase NoSourceSpan alts
   -- Multi-argument lambda cases: \cases { p1 p2 -> body; ... }
-  ELambdaCases alts -> inferLambdaCases (exprSpan expr) alts
+  ELambdaCases alts -> inferLambdaCases NoSourceSpan alts
   -- Application: f x
-  EApp fun arg -> inferApp (exprSpan expr) fun arg
+  EApp fun arg -> inferApp NoSourceSpan fun arg
   -- If-then-else
-  EIf cond thenE elseE -> inferIf (exprSpan expr) cond thenE elseE
+  EIf cond thenE elseE -> inferIf NoSourceSpan cond thenE elseE
   -- Case expression
-  ECase scrutinee alts -> inferCase (exprSpan expr) scrutinee alts
+  ECase scrutinee alts -> inferCase NoSourceSpan scrutinee alts
   -- Let expression
   ELetDecls _decls body -> do
     -- MVP: infer body only (let bindings not yet processed).
@@ -84,21 +84,14 @@ inferExpr expr = case expr of
   -- Annotated expression (from other passes, e.g. resolve).
   EAnn _ann inner -> inferExpr inner
   -- Tuple
-  ETuple _flavor elems -> inferTuple (exprSpan expr) elems
+  ETuple _flavor elems -> inferTuple NoSourceSpan elems
   -- List
-  EList elems -> inferList (exprSpan expr) elems
+  EList elems -> inferList NoSourceSpan elems
   -- Unsupported expression forms for MVP.
   other -> do
-    let sp = exprSpan other
-    emitError sp (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
+    emitError NoSourceSpan (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
     ty <- freshMetaTv
     pure (ty, [])
-
-exprSpan :: Expr -> SourceSpan
-exprSpan = go NoSourceSpan
-  where
-    go ambient (EAnn ann inner) = go (fromMaybe ambient (fromAnnotation @SourceSpan ann)) inner
-    go ambient _ = ambient
 
 -- | Infer the type of a variable reference.
 inferVar :: SourceSpan -> Text -> TcM (TcType, [Ct])


### PR DESCRIPTION
## Summary

- Removed all exported `get*SourceSpan` helpers from `Aihc.Parser.Syntax`.
- Replaced parser call-sites with parse-time span capture.
- Updated formatter, resolver, and typechecker call-sites to peel source spans from annotations locally where they still need fallback locations.

## Progress counts

- `get*SourceSpan` helpers removed: 15
- Remaining repo-wide matches for `get[A-Za-z0-9_]*SourceSpan`: 0

## Validation

- `just fmt`
- `just check`
- `cabal test -v0 all --test-options=--hide-successes`
- `cabal test -v0 all --ghc-options=-Werror --test-options=--hide-successes`

## Notes

- `coderabbit review --prompt-only` was attempted but skipped because the account is over the hourly review cap.
