### PR TITLE
feat(parser): emit comment tokens

### DIFF
--- a/bin/aihc-fmt/src/Aihc/Fmt/Comment.hs
+++ b/bin/aihc-fmt/src/Aihc/Fmt/Comment.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 
 module Aihc.Fmt.Comment
   ( CommentKind (..),
@@ -10,11 +9,14 @@ module Aihc.Fmt.Comment
   )
 where
 
+import Aihc.Parser.Lex
+  ( LexToken (..),
+    LexTokenKind (..),
+    TokenOrigin (..),
+    lexModuleTokensWithSourceNameAndExtensions,
+  )
 import Aihc.Parser.Syntax (SourceSpan (..))
-import Data.Char (GeneralCategory (..), generalCategory, isAlphaNum, isSpace)
-import Data.Text (Text, pattern Empty, pattern (:<))
-import Data.Text qualified as T
-import Data.Text.Encoding qualified as TE
+import Data.Text (Text)
 
 data CommentKind
   = LineComment
@@ -43,189 +45,56 @@ formatCommentScanError err =
     UnterminatedCharLiteral sp -> "unterminated character literal at " <> formatSpan sp
 
 collectComments :: FilePath -> Text -> Either CommentScanError [SourceComment]
-collectComments sourceName input = go initialState []
+collectComments sourceName input = go Nothing [] tokens
   where
-    initialState =
-      ScanState
-        { scanInput = input,
-          scanLine = 1,
-          scanCol = 1,
-          scanOffset = 0,
-          scanLineHasCode = False
-        }
+    tokens = lexModuleTokensWithSourceNameAndExtensions sourceName [] input
 
-    go st acc =
-      case scanInput st of
-        Empty -> Right (reverse acc)
-        chars
-          | Just st' <- consumeWhitespace st ->
-              go st' acc
-          | "{-#" `T.isPrefixOf` chars,
-            Just st' <- consumePragma st ->
-              go st' acc
-          | "{-" `T.isPrefixOf` chars ->
-              case consumeNestedBlockComment sourceName st of
-                Left err -> Left err
-                Right (comment, st') -> go st' (comment : acc)
-          | Just rest <- T.stripPrefix "--" chars,
-            isLineCommentRest rest ->
-              let (comment, st') = consumeLineComment sourceName st
-               in go st' (comment : acc)
-          | "\"" `T.isPrefixOf` chars ->
-              case consumeQuoted sourceName '"' UnterminatedStringLiteral st of
-                Left err -> Left err
-                Right st' -> go (markCode st') acc
-          | "'" `T.isPrefixOf` chars ->
-              case consumeQuoted sourceName '\'' UnterminatedCharLiteral st of
-                Left err -> Left err
-                Right st' -> go (markCode st') acc
+    go _lineHasCode acc [] = Right (reverse acc)
+    go lineHasCode acc (tok : rest) =
+      case lexTokenKind tok of
+        TkLineComment ->
+          let comment = mkComment lineHasCode LineComment tok
+           in go lineHasCode (comment : acc) rest
+        TkBlockComment ->
+          let comment = mkComment lineHasCode BlockComment tok
+           in go lineHasCode (comment : acc) rest
+        TkError "unterminated block comment" ->
+          Left (UnterminatedBlockComment (lexTokenSpan tok))
+        _
+          | tokenCountsAsCode tok ->
+              go (sourceSpanEndLineMaybe (lexTokenSpan tok)) acc rest
           | otherwise ->
-              go (markCode (advanceOne st)) acc
+              go lineHasCode acc rest
 
-data ScanState = ScanState
-  { scanInput :: !Text,
-    scanLine :: !Int,
-    scanCol :: !Int,
-    scanOffset :: !Int,
-    scanLineHasCode :: !Bool
-  }
-  deriving (Eq, Show)
-
-consumeWhitespace :: ScanState -> Maybe ScanState
-consumeWhitespace st =
-  case scanInput st of
-    c :< _
-      | isSpace c ->
-          Just (advanceOne st)
-    _ -> Nothing
-
-consumePragma :: ScanState -> Maybe ScanState
-consumePragma st =
-  let (prefix, suffix) = T.breakOn "#-}" (scanInput st)
-   in if T.null suffix
-        then Nothing
-        else Just (advanceText (prefix <> "#-}") st)
-
-consumeLineComment :: FilePath -> ScanState -> (SourceComment, ScanState)
-consumeLineComment sourceName st =
-  let (raw, rest) = T.break (== '\n') (scanInput st)
-      st' = advanceText raw st
-      span' = mkScanSpan sourceName st st'
-      comment =
-        SourceComment
-          { commentSpan = span',
-            commentText = raw,
-            commentKind = LineComment,
-            commentHasCodeBefore = scanLineHasCode st
-          }
-   in (comment, st' {scanInput = rest})
-
-consumeNestedBlockComment :: FilePath -> ScanState -> Either CommentScanError (SourceComment, ScanState)
-consumeNestedBlockComment sourceName st =
-  case scanBlock 0 0 (scanInput st) of
-    Nothing -> Left (UnterminatedBlockComment (mkPointSpan sourceName st))
-    Just len ->
-      let raw = T.take len (scanInput st)
-          st' = advanceText raw st
-          comment =
-            SourceComment
-              { commentSpan = mkScanSpan sourceName st st',
-                commentText = raw,
-                commentKind = BlockComment,
-                commentHasCodeBefore = scanLineHasCode st
-              }
-       in Right (comment, st')
-  where
-    scanBlock :: Int -> Int -> Text -> Maybe Int
-    scanBlock depth n input =
-      case T.uncons input of
-        Nothing -> Nothing
-        Just (c, rest1) ->
-          case T.uncons rest1 of
-            Just (c2, rest2)
-              | c == '{' && c2 == '-' ->
-                  scanBlock (depth + 1) (n + 2) rest2
-              | c == '-' && c2 == '}' ->
-                  if depth == 1
-                    then Just (n + 2)
-                    else scanBlock (depth - 1) (n + 2) rest2
-            _ -> scanBlock depth (n + 1) rest1
-
-consumeQuoted ::
-  FilePath ->
-  Char ->
-  (SourceSpan -> CommentScanError) ->
-  ScanState ->
-  Either CommentScanError ScanState
-consumeQuoted sourceName quote mkErr st =
-  go False (advanceOne st)
-  where
-    go escaped current =
-      case scanInput current of
-        Empty -> Left (mkErr (mkPointSpan sourceName st))
-        c :< _
-          | escaped -> go False (advanceOne current)
-          | c == '\\',
-            quote == '"',
-            Just afterGap <- consumeStringGap (advanceOne current) ->
-              go False afterGap
-          | c == '\\' -> go True (advanceOne current)
-          | c == quote -> Right (advanceOne current)
-          | c == '\n' -> Left (mkErr (mkPointSpan sourceName st))
-          | otherwise -> go False (advanceOne current)
-
-consumeStringGap :: ScanState -> Maybe ScanState
-consumeStringGap = go False False
-  where
-    go seenWhitespace seenNewline st =
-      case scanInput st of
-        c :< _
-          | c == '\\' && seenWhitespace && seenNewline -> Just (advanceOne st)
-          | isSpace c -> go True (seenNewline || c == '\n') (advanceOne st)
-        _ -> Nothing
-
-advanceOne :: ScanState -> ScanState
-advanceOne st =
-  case T.uncons (scanInput st) of
-    Nothing -> st
-    Just (c, rest) ->
-      let bytes = byteLength (T.singleton c)
-       in if c == '\n'
-            then
-              st
-                { scanInput = rest,
-                  scanLine = scanLine st + 1,
-                  scanCol = 1,
-                  scanOffset = scanOffset st + bytes,
-                  scanLineHasCode = False
-                }
-            else
-              st
-                { scanInput = rest,
-                  scanCol = scanCol st + 1,
-                  scanOffset = scanOffset st + bytes
-                }
-
-advanceText :: Text -> ScanState -> ScanState
-advanceText txt st = T.foldl' (\acc _ -> advanceOne acc) st txt
-
-markCode :: ScanState -> ScanState
-markCode st = st {scanLineHasCode = True}
-
-mkScanSpan :: FilePath -> ScanState -> ScanState -> SourceSpan
-mkScanSpan sourceName start end =
-  SourceSpan
-    { sourceSpanSourceName = sourceName,
-      sourceSpanStartLine = scanLine start,
-      sourceSpanStartCol = scanCol start,
-      sourceSpanEndLine = scanLine end,
-      sourceSpanEndCol = scanCol end,
-      sourceSpanStartOffset = scanOffset start,
-      sourceSpanEndOffset = scanOffset end
+mkComment :: Maybe Int -> CommentKind -> LexToken -> SourceComment
+mkComment lineHasCode kind tok =
+  SourceComment
+    { commentSpan = lexTokenSpan tok,
+      commentText = lexTokenText tok,
+      commentKind = kind,
+      commentHasCodeBefore = lineHasCode == sourceSpanStartLineMaybe (lexTokenSpan tok)
     }
 
-mkPointSpan :: FilePath -> ScanState -> SourceSpan
-mkPointSpan sourceName st = mkScanSpan sourceName st st
+tokenCountsAsCode :: LexToken -> Bool
+tokenCountsAsCode tok =
+  case (lexTokenOrigin tok, lexTokenKind tok) of
+    (FromSource, TkPragma _) -> False
+    (FromSource, TkEOF) -> False
+    (FromSource, TkError _) -> False
+    (FromSource, _) -> True
+    (InsertedLayout, _) -> False
+
+sourceSpanStartLineMaybe :: SourceSpan -> Maybe Int
+sourceSpanStartLineMaybe sp =
+  case sp of
+    SourceSpan {sourceSpanStartLine = line} -> Just line
+    NoSourceSpan -> Nothing
+
+sourceSpanEndLineMaybe :: SourceSpan -> Maybe Int
+sourceSpanEndLineMaybe sp =
+  case sp of
+    SourceSpan {sourceSpanEndLine = line} -> Just line
+    NoSourceSpan -> Nothing
 
 formatSpan :: SourceSpan -> String
 formatSpan sp =
@@ -233,29 +102,3 @@ formatSpan sp =
     NoSourceSpan -> "<unknown>"
     SourceSpan {sourceSpanSourceName, sourceSpanStartLine, sourceSpanStartCol} ->
       sourceSpanSourceName <> ":" <> show sourceSpanStartLine <> ":" <> show sourceSpanStartCol
-
-byteLength :: Text -> Int
-byteLength = T.length . TE.decodeLatin1 . TE.encodeUtf8
-
-isLineCommentRest :: Text -> Bool
-isLineCommentRest rest =
-  case T.dropWhile (== '-') rest of
-    Empty -> True
-    c :< _ -> not (isSymbolicOpChar c)
-
-isSymbolicOpChar :: Char -> Bool
-isSymbolicOpChar c =
-  c `elem` ("!#$%&*+./<=>?@\\^|-~:" :: String)
-    || (not (isAlphaNum c) && not (isSpace c) && isSymbolicCategory (generalCategory c))
-
-isSymbolicCategory :: GeneralCategory -> Bool
-isSymbolicCategory category =
-  case category of
-    MathSymbol -> True
-    CurrencySymbol -> True
-    ModifierSymbol -> True
-    OtherSymbol -> True
-    DashPunctuation -> True
-    OtherPunctuation -> True
-    ConnectorPunctuation -> True
-    _ -> False

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/comment-looking-literals.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/comment-looking-literals.yaml
@@ -1,0 +1,14 @@
+extensions: []
+input: |
+  module Main where
+  x = "-- not a comment {- nope -}"
+  c = '-'
+formatters:
+  aihc-fmt:
+    status: pass
+    output: |
+      module Main where
+      x =
+        "-- not a comment {- nope -}"
+      c =
+        '-'

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -69,8 +69,8 @@ import Aihc.Parser.Lex.Quoted
     scanQuoted,
   )
 import Aihc.Parser.Lex.Trivia
-  ( consumeBlockCommentOrError,
-    consumeLineComment,
+  ( consumeBlockCommentTokenOrError,
+    consumeLineCommentToken,
     isHaskellWhitespace,
     isLineComment,
     tryConsumeControlPragma,
@@ -144,14 +144,12 @@ scanTokens :: LexerEnv -> LexerState -> [LexToken]
 scanTokens env st0 =
   case skipTrivia st0 of
     SkipToken tok st ->
-      let st' = st {lexerPrevTokenKind = Just (lexTokenKind tok), lexerHadTrivia = False}
-       in tok : scanTokens env st'
+      tok : scanTokens env (recordScannedToken tok st)
     SkipDone st
       | T.null (lexerInput st) -> [eofToken st]
       | otherwise ->
           let (tok, st') = nextToken env st
-              st'' = st' {lexerPrevTokenKind = Just (lexTokenKind tok), lexerHadTrivia = False}
-           in tok : scanTokens env st''
+           in tok : scanTokens env (recordScannedToken tok st')
 
 data SkipResult = SkipDone !LexerState | SkipToken !LexToken !LexerState
 
@@ -171,7 +169,8 @@ skipTrivia = go
             _
               | Just rest <- T.stripPrefix "--" inp,
                 isLineComment rest ->
-                  go (markHadTrivia (consumeLineComment st))
+                  let (tok, st') = consumeLineCommentToken st
+                   in SkipToken tok (markHadTrivia st')
             -- Check {-# before {- so control pragmas are handled first and
             -- block comment handler does not eat pragma tokens.
             _
@@ -181,8 +180,8 @@ skipTrivia = go
                     Just (Just tok, st') -> SkipToken tok (markHadTrivia st')
                     Nothing -> SkipDone st -- not a control pragma; let nextToken handle it
               | "{-" `T.isPrefixOf` inp ->
-                  case consumeBlockCommentOrError st of
-                    Right st' -> go (markHadTrivia st')
+                  case consumeBlockCommentTokenOrError st of
+                    Right (tok, st') -> SkipToken tok (markHadTrivia st')
                     Left (tok, st') -> SkipToken tok (markHadTrivia st')
             _ ->
               case tryConsumeLineDirective st of
@@ -192,6 +191,18 @@ skipTrivia = go
 
 markHadTrivia :: LexerState -> LexerState
 markHadTrivia st = st {lexerHadTrivia = True}
+
+isCommentTokenKind :: LexTokenKind -> Bool
+isCommentTokenKind kind =
+  case kind of
+    TkLineComment -> True
+    TkBlockComment -> True
+    _ -> False
+
+recordScannedToken :: LexToken -> LexerState -> LexerState
+recordScannedToken tok st
+  | isCommentTokenKind (lexTokenKind tok) = st {lexerHadTrivia = True}
+  | otherwise = st {lexerPrevTokenKind = Just (lexTokenKind tok), lexerHadTrivia = False}
 
 -- | Lex a regular pragma token ({-# ... #-}).
 -- Control pragmas (LINE, COLUMN) are handled in 'skipTrivia' and never reach here.
@@ -254,8 +265,7 @@ scanOneToken :: LexerEnv -> LexerState -> Maybe (LexToken, LexerState)
 scanOneToken env st0 =
   case skipTrivia st0 of
     SkipToken tok st ->
-      let st' = st {lexerPrevTokenKind = Just (lexTokenKind tok), lexerHadTrivia = False}
-       in Just (tok, st')
+      Just (tok, recordScannedToken tok st)
     SkipDone st
       | T.null (lexerInput st) ->
           case lexerPrevTokenKind st of
@@ -266,8 +276,7 @@ scanOneToken env st0 =
                in Just (tok, st')
       | otherwise ->
           let (tok, st') = nextToken env st
-              st'' = st' {lexerPrevTokenKind = Just (lexTokenKind tok), lexerHadTrivia = False}
-           in Just (tok, st'')
+           in Just (tok, recordScannedToken tok st')
 
 scanAllTokens :: LexerEnv -> LexerState -> [LexToken]
 scanAllTokens env st =

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Header.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Header.hs
@@ -18,6 +18,8 @@ readModuleHeaderExtensionsFromTokens = go
         LexToken {lexTokenKind = TkPragma Pragma {pragmaType = PragmaWarning _}} : rest -> go rest
         LexToken {lexTokenKind = TkPragma Pragma {pragmaType = PragmaDeprecated _}} : rest -> go rest
         LexToken {lexTokenKind = TkPragma Pragma {pragmaType = PragmaUnknown _}} : rest -> go rest
+        LexToken {lexTokenKind = TkLineComment} : rest -> go rest
+        LexToken {lexTokenKind = TkBlockComment} : rest -> go rest
         LexToken {lexTokenKind = TkError _} : _ -> []
         _ -> []
 

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Layout.hs
@@ -44,6 +44,8 @@ noteModuleLayoutBeforeToken st tok =
     ModuleLayoutSeekStart ->
       case lexTokenKind tok of
         TkPragma _ -> st
+        TkLineComment -> st
+        TkBlockComment -> st
         TkKeywordModule -> st {layoutModuleMode = ModuleLayoutAwaitWhere}
         _ -> st {layoutModuleMode = ModuleLayoutDone, layoutPendingLayout = Just (PendingImplicitLayout LayoutOrdinary)}
     _ -> st
@@ -389,6 +391,8 @@ isBOL _ = lexTokenAtLineStart
 layoutTransition :: LayoutState -> LexToken -> ([LexToken], LayoutState)
 layoutTransition st tok =
   case lexTokenKind tok of
+    TkLineComment -> ([tok], st)
+    TkBlockComment -> ([tok], st)
     TkEOF ->
       let eofAnchor = fromMaybe (lexTokenSpan tok) (layoutPrevTokenEndSpan st)
           (moduleInserted, stAfterModule) = finalizeModuleLayoutAtEOF st eofAnchor

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Trivia.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Aihc.Parser.Lex.Trivia
-  ( consumeBlockCommentOrError,
-    consumeLineComment,
+  ( consumeBlockCommentTokenOrError,
+    consumeLineCommentToken,
     isHaskellWhitespace,
     isLineComment,
     tryConsumeControlPragma,
@@ -77,29 +77,31 @@ tryConsumeControlPragma st =
            in Just (Just (mkToken st st' consumedT (TkError msg)), st')
         Nothing -> Nothing
 
-consumeLineComment :: LexerState -> LexerState
-consumeLineComment st =
+consumeLineCommentToken :: LexerState -> (LexToken, LexerState)
+consumeLineCommentToken st =
   let inp = lexerInput st
       rest = T.drop 2 inp
       consumed = "--" <> T.takeWhile (/= '\n') rest
-   in advanceChars consumed st
+      st' = advanceChars consumed st
+   in (mkToken st st' consumed TkLineComment, st')
 
-consumeBlockComment :: LexerState -> Maybe LexerState
-consumeBlockComment st =
+consumeBlockCommentToken :: LexerState -> Maybe (LexToken, LexerState)
+consumeBlockCommentToken st =
   case scanNestedBlockComment 1 (T.drop 2 (lexerInput st)) of
     Just consumedTail ->
       let consumed = "{-" <> consumedTail
           st' = advanceChars consumed st
-       in Just $
+          st'' =
             if T.any (== '\n') consumed
               then st'
               else st' {lexerAtLineStart = lexerAtLineStart st}
+       in Just (mkToken st st'' consumed TkBlockComment, st'')
     Nothing -> Nothing
 
-consumeBlockCommentOrError :: LexerState -> Either (LexToken, LexerState) LexerState
-consumeBlockCommentOrError st =
-  case consumeBlockComment st of
-    Just st' -> Right st'
+consumeBlockCommentTokenOrError :: LexerState -> Either (LexToken, LexerState) (LexToken, LexerState)
+consumeBlockCommentTokenOrError st =
+  case consumeBlockCommentToken st of
+    Just result -> Right result
     Nothing ->
       let consumed = lexerInput st
           st' = advanceChars consumed st

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -171,6 +171,8 @@ data LexTokenKind
   | TkTHTypedSplice
   | -- Other
     TkQuasiQuote Text Text
+  | TkLineComment
+  | TkBlockComment
   | TkError Text
   | TkEOF
   deriving (Eq, Ord, Show, Read, Generic, NFData)

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -1060,6 +1060,8 @@ docTokenKind kind =
     TkRecordDot -> "TkRecordDot"
     TkPragma pragma' -> "TkPragma" <+> docPragmaType (pragmaType pragma')
     TkQuasiQuote quoter body -> "TkQuasiQuote" <+> docText quoter <+> docText body
+    TkLineComment -> "TkLineComment"
+    TkBlockComment -> "TkBlockComment"
     TkTHExpQuoteOpen -> "TkTHExpQuoteOpen"
     TkTHExpQuoteClose -> "TkTHExpQuoteClose"
     TkTHTypedQuoteOpen -> "TkTHTypedQuoteOpen"

--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -214,6 +214,14 @@ pragmaFromToken tok =
     TkPragma pragma' -> Just pragma'
     _ -> Nothing
 
+isHiddenToken :: LexToken -> Bool
+isHiddenToken tok =
+  case lexTokenKind tok of
+    TkPragma _ -> True
+    TkLineComment -> True
+    TkBlockComment -> True
+    _ -> False
+
 normalizeTokStream :: TokStream -> TokStream
 normalizeTokStream ts0
   | tokStreamEOFEmitted ts0 = ts0
@@ -227,6 +235,11 @@ normalizeTokStream ts0
                 ts
                   { tokStreamLayoutState = (tokStreamLayoutState ts) {layoutBuffer = rest},
                     tokStreamPendingPragmas = tokStreamPendingPragmas ts <> [pragma']
+                  }
+          | isHiddenToken tok ->
+              go
+                ts
+                  { tokStreamLayoutState = (tokStreamLayoutState ts) {layoutBuffer = rest}
                   }
           | otherwise -> ts
         [] ->

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -110,6 +110,9 @@ buildTests = do
             testCase "sets lexTokenAtLineStart correctly" test_tokenAtLineStartWithoutDirective,
             testCase "hash line directive sets lexTokenAtLineStart" test_hashLineDirectiveSetsAtLineStart,
             testCase "hash line directive preserves layout" test_hashLineDirectivePreservesLayout,
+            testCase "comments are ignored in module headers" test_commentsIgnoredInModuleHeaders,
+            testCase "comments are ignored by layout" test_commentsIgnoredByLayout,
+            testCase "comments preserve trivia for negative literals" test_commentsPreserveTriviaForNegativeLiterals,
             testCase "indented hash-line is operator, not directive" test_indentedHashLineIsOperator,
             testCase "can lex lazily from chunks" test_lexerChunkLaziness,
             testCase "lexes alternate valid character literal spellings" test_alternateCharLiteralSpellingsLexLikeGhc,
@@ -359,6 +362,45 @@ test_hashLineDirectivePreservesLayout =
    in do
         assertBool ("expected no parse errors, got: " <> show errs) (null errs)
         assertEqual "expected two declarations" 2 (length (moduleDecls modu))
+
+test_commentsIgnoredInModuleHeaders :: Assertion
+test_commentsIgnoredInModuleHeaders =
+  let source =
+        T.unlines
+          [ "{-# LANGUAGE OverloadedLabels #-}",
+            "-- comment between pragma and module header",
+            "module Test where",
+            "x = #foo"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        assertEqual "expected one declaration" 1 (length (moduleDecls modu))
+
+test_commentsIgnoredByLayout :: Assertion
+test_commentsIgnoredByLayout =
+  let source =
+        T.unlines
+          [ "module Test where",
+            "main = do",
+            "  -- comment inside layout block",
+            "  pure ()",
+            "  pure ()"
+          ]
+      (errs, modu) = parseModule defaultConfig source
+   in do
+        assertBool ("expected no parse errors, got: " <> show errs) (null errs)
+        assertEqual "expected one declaration" 1 (length (moduleDecls modu))
+
+test_commentsPreserveTriviaForNegativeLiterals :: Assertion
+test_commentsPreserveTriviaForNegativeLiterals =
+  case lexTokensWithExtensions [NegativeLiterals] "x -- comment\n-1" of
+    [ LexToken {lexTokenKind = TkVarId "x"},
+      LexToken {lexTokenKind = TkLineComment},
+      LexToken {lexTokenKind = TkInteger (-1) TInteger},
+      LexToken {lexTokenKind = TkEOF}
+      ] -> pure ()
+    other -> assertFailure ("expected comment trivia before negative literal, got: " <> show other)
 
 test_indentedHashLineIsOperator :: Assertion
 test_indentedHashLineIsOperator =

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/comment-between-identifiers.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/comment-between-identifiers.yaml
@@ -4,6 +4,7 @@ input: |
   y
 tokens:
   - 'TkVarId "x"'
+  - 'TkLineComment'
   - 'TkVarId "y"'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-backtick-operator.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-backtick-operator.yaml
@@ -1,5 +1,6 @@
 extensions: []
 input: "--`"
 tokens:
+  - 'TkLineComment'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-foo-comment.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/dash-dash-foo-comment.yaml
@@ -1,5 +1,6 @@
 extensions: []
 input: "--foo"
 tokens:
+  - 'TkLineComment'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/nested-block-comment.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/nested-block-comment.yaml
@@ -1,0 +1,6 @@
+extensions: []
+input: "{- outer {- inner -} outer -}"
+tokens:
+  - 'TkBlockComment'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/quadruple-dash-comment.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/quadruple-dash-comment.yaml
@@ -1,5 +1,6 @@
 extensions: []
 input: "----"
 tokens:
+  - 'TkLineComment'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/simple-line-comment.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/simple-line-comment.yaml
@@ -1,5 +1,6 @@
 extensions: []
 input: "-- simple comment"
 tokens:
+  - 'TkLineComment'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/comments/triple-dash-comment.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/comments/triple-dash-comment.yaml
@@ -1,5 +1,6 @@
 extensions: []
 input: "---"
 tokens:
+  - 'TkLineComment'
   - 'TkEOF'
 status: pass


### PR DESCRIPTION
## Summary

- emit `TkLineComment` and `TkBlockComment` from the parser lexer while preserving parser/layout behavior by hiding comment tokens from the Megaparsec stream
- replace `aihc-fmt`'s hand-written comment scanner with lexer-backed comment collection
- add lexer, parser, and formatter coverage for comment tokens, ignored comments, nested block comments, and comment-looking text inside literals

## Impact

The parser lexer is now the source of truth for source comments. Existing parser behavior remains unchanged: comments still behave as trivia for prefix decisions, layout insertion, module-header extension discovery, and parsing.

## Progress counts

- Lexer golden fixtures: +1 pass fixture for nested block comments; existing comment fixtures now expect comment tokens.
- Formatter golden fixtures: +1 pass fixture for comment-looking literals.
- READMEs were not updated; cron owns those generated progress summaries.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern lexer"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern comments"`
- `cabal test -v0 aihc-fmt:spec --test-options=--hide-successes`
- `cabal test -v0 all --test-options=--hide-successes`
- `just fmt`
- `just check`
- `git diff --check`

## Pre-PR review

`coderabbit review --prompt-only` was attempted but skipped because the account is over the hourly review cap.
