### PR TITLE
fix(parser): parenthesize typed pattern guards before arrows

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -504,7 +504,22 @@ guardExprNeedsParensWith typeSigNeedsParens arrow = \case
       GuardArrow -> typeSigNeedsParens ty
       GuardEquals -> False
   EApp _ arg | isBlockExpr arg -> guardExprNeedsParensWith typeSigNeedsParens arrow arg
-  _ -> False
+  expr ->
+    case arrow of
+      GuardArrow -> trailingTypeSigNeedsParens typeSigNeedsParens expr
+      GuardEquals -> False
+
+trailingTypeSigNeedsParens :: (Type -> Bool) -> Expr -> Bool
+trailingTypeSigNeedsParens typeSigNeedsParens expr =
+  case expr of
+    EAnn _ sub -> trailingTypeSigNeedsParens typeSigNeedsParens sub
+    ETypeSig _ ty -> typeSigNeedsParens ty
+    ELetDecls _ body -> trailingTypeSigNeedsParens typeSigNeedsParens body
+    ELambdaPats _ body -> trailingTypeSigNeedsParens typeSigNeedsParens body
+    EInfix _ _ rhs -> trailingTypeSigNeedsParens typeSigNeedsParens rhs
+    EApp _ arg -> trailingTypeSigNeedsParens typeSigNeedsParens arg
+    EIf _ _ no -> trailingTypeSigNeedsParens typeSigNeedsParens no
+    _ -> False
 
 typeHasFunctionArrow :: Type -> Bool
 typeHasFunctionArrow ty =
@@ -625,25 +640,35 @@ addRhsParens rhs =
 addGuardedRhsParens :: GuardArrow -> GuardedRhs Expr -> GuardedRhs Expr
 addGuardedRhsParens arrow grhs =
   grhs
-    { guardedRhsGuards = map (addGuardQualifierParens arrow) (guardedRhsGuards grhs),
+    { guardedRhsGuards = addGuardQualifiersParens arrow (guardedRhsGuards grhs),
       guardedRhsBody = addExprParens (guardedRhsBody grhs)
     }
 
-addGuardQualifierParens :: GuardArrow -> GuardQualifier -> GuardQualifier
-addGuardQualifierParens arrow qual =
+addGuardQualifiersParens :: GuardArrow -> [GuardQualifier] -> [GuardQualifier]
+addGuardQualifiersParens arrow quals =
+  case quals of
+    [] -> []
+    [qual] -> [addGuardQualifierParens arrow True qual]
+    qual : rest -> addGuardQualifierParens arrow False qual : addGuardQualifiersParens arrow rest
+
+addGuardQualifierParens :: GuardArrow -> Bool -> GuardQualifier -> GuardQualifier
+addGuardQualifierParens arrow isLast qual =
   case qual of
-    GuardAnn ann inner -> GuardAnn ann (addGuardQualifierParens arrow inner)
+    GuardAnn ann inner -> GuardAnn ann (addGuardQualifierParens arrow isLast inner)
     GuardExpr expr -> GuardExpr (addGuardExprParens arrow expr)
-    GuardPat pat expr -> GuardPat (addPatternParens pat) (addPatternGuardExprParens arrow expr)
+    GuardPat pat expr -> GuardPat (addPatternParens pat) (addPatternGuardExprParens arrow isLast expr)
     GuardLet decls -> GuardLet (map addDeclParens decls)
 
 addGuardExprParens :: GuardArrow -> Expr -> Expr
 addGuardExprParens arrow expr =
   wrapExpr (guardExprNeedsParensWith (const True) arrow expr) (addExprParens expr)
 
-addPatternGuardExprParens :: GuardArrow -> Expr -> Expr
-addPatternGuardExprParens arrow expr =
-  wrapExpr (guardExprNeedsParensWith typeHasFunctionArrow arrow expr) (addExprParens expr)
+addPatternGuardExprParens :: GuardArrow -> Bool -> Expr -> Expr
+addPatternGuardExprParens arrow isLast expr =
+  let typeSigNeedsParens
+        | isLast = const True
+        | otherwise = typeHasFunctionArrow
+   in wrapExpr (guardExprNeedsParensWith typeSigNeedsParens arrow expr) (addExprParens expr)
 
 addPatSynDeclParens :: PatSynDecl -> PatSynDecl
 addPatSynDeclParens ps =
@@ -1697,6 +1722,6 @@ addCmdCaseAltRhsParens rhs =
 addCmdGuardedRhsParens :: GuardedRhs Cmd -> GuardedRhs Cmd
 addCmdGuardedRhsParens grhs =
   grhs
-    { guardedRhsGuards = map (addGuardQualifierParens GuardArrow) (guardedRhsGuards grhs),
+    { guardedRhsGuards = addGuardQualifiersParens GuardArrow (guardedRhsGuards grhs),
       guardedRhsBody = addCmdParens (guardedRhsBody grhs)
     }

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/pattern-guard-type-signature-unboxed-sum.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/pattern-guard-type-signature-unboxed-sum.hs
@@ -1,0 +1,14 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE UnboxedSums #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module PatternGuardTypeSignatureUnboxedSum where
+
+(#
+      |
+      | []
+      |  #) =
+   if | (# #) <- (() :: (# (# [a||] | C #) | * #))
+        -> 0


### PR DESCRIPTION
## Summary

- parenthesize final pattern-guard generator expressions when a trailing type signature would otherwise run into a `->` guard arrow
- detect trailing type signatures nested at the right edge of guard expressions, such as `if ... else expr :: ty`
- add an oracle fixture for the GHC-valid parenthesized multi-way-if pattern guard with an unboxed-sum type signature

## Root Cause

The generated source was invalid Haskell. A pattern-guard generator RHS with a type signature cannot be left bare immediately before the guard arrow:

```haskell
(# | | [] | #) =
  if | (# #) <- ()
      :: (# (# [a||] | C #) | * #)
      -> 0
```

GHC accepts the expression only when the typed generator RHS is parenthesized:

```haskell
(# | | [] | #) =
  if | (# #) <- (() :: (# (# [a||] | C #) | * #))
      -> 0
```

So the fix is in the paren insertion pass: make the pretty-printer emit the parenthesized form in final guard-qualifier positions before `->`, while preserving existing behavior for earlier comma-separated qualifiers. The regression coverage is an oracle test so GHC remains the validity source of truth.

## Progress Counts

- Parser oracle fixtures: +1 pass fixture
- README progress counts: not updated; cron owns README updates

## Validation

- `aihc-dev snippet` rejects the unparenthesized invalid form with both GHC and aihc-parser
- `aihc-dev snippet` accepts the parenthesized valid form
- `cabal test -v0 aihc-parser:spec --test-options="--pattern /MultiWayIf\\/pattern-guard-type-signature-unboxed-sum/ --hide-successes"`
- `just replay "(SMGen 8893423991518077705 5640530345107170961,93)"`
- `just replay "(SMGen 4594955960740638986 12388071746710069441,98)"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern /Hackage\\/shake-pattern-guard-type-signature/ --hide-successes"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
