### PR TITLE
fix(parser): accept reserved @ right sections

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -854,10 +854,15 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
           pure (EParen (EGetFieldProjection fields))
 
         parseSectionR forbidden = do
-          op <- infixOperatorParserExcept forbidden <|> arrowSectionOperatorParser
+          op <- reservedAtSectionOperatorParser forbidden <|> infixOperatorParserExcept forbidden <|> arrowSectionOperatorParser
           rhs <- exprParser
           expectedTok closeTok
           pure (EParen (ESectionR op rhs))
+
+        reservedAtSectionOperatorParser forbidden = do
+          guard ("@" `notElem` forbidden)
+          expectedTok TkReservedAt
+          pure (qualifyName Nothing (mkUnqualifiedName NameVarSym "@"))
 
         arrowSectionOperatorParser =
           tokenSatisfy "operator" $ \tok ->

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -151,6 +151,7 @@ buildTests = do
             testCase "pretty-prints instance declarations with implicit layout" test_prettyInstanceDeclarationUsesImplicitLayout,
             testCase "pretty-prints TH splices before record dots with parentheses" test_prettySpliceRecordDotBase,
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
+            testCase "pretty-prints reserved at right sections" test_prettyReservedAtRightSection,
             testCase "pretty-prints layout-ending operands inside left sections" test_prettyLayoutEndingOperandInsideLeftSection,
             testCase "pretty-prints type applications after layout-ending functions" test_prettyTypeAppAfterLayoutEndingFunction,
             testCase "pretty-prints type signatures after layout-ending functions" test_prettyTypeSigAfterLayoutEndingFunction,
@@ -1229,6 +1230,17 @@ test_prettyInfixRhsOpenEndedInsideSection = do
           op
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
   case parseExpr config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed expression to reparse, got:\n" <> show bundle)
+
+test_prettyReservedAtRightSection :: Assertion
+test_prettyReservedAtRightSection = do
+  let expr = ESectionR (qualifyName Nothing (mkUnqualifiedName NameVarSym "@")) (ETuple Boxed [])
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+  assertEqual "pretty-printed expression" "(@ ())" rendered
+  case parseExpr defaultConfig rendered of
     ParseOk reparsed ->
       assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
     ParseErr bundle ->

--- a/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/paren-reserved-at-section.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/haskell2010/expressions/paren-reserved-at-section.hs
@@ -1,0 +1,8 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Haskell2010 #-}
+module ParenReservedAtSection where
+
+(@) :: a -> b -> a
+(@) x _ = x
+
+test = (@ ())


### PR DESCRIPTION
## Summary
- accept `TkReservedAt` in parenthesized right operator sections so pretty-printed `(@ ())` reparses correctly
- add a focused round-trip test and a Haskell2010 oracle fixture covering reserved `@` sections
- fix the QuickCheck module round-trip replay `(SMGen 15485976786952467329 2585152739752543271,72)` by closing the parser gap instead of changing generation

## Validation
- `just replay \"(SMGen 15485976786952467329 2585152739752543271,72)\"`
- `just fmt`
- `just check`

## Progress
- parser oracle pass count: +1 fixture (`haskell2010/expressions/paren-reserved-at-section`)