### PR TITLE
fix(nix): use ghc 9.12 for haskell tooling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,16 +30,17 @@
       inherit (coverage) mkCoverageReport;
     };
     mkApps = import ./scripts/nix/apps.nix {
-      inherit (core) projectHsPackages;
+      inherit (core) toolHsPackages;
       inherit (haskell) mkHsPkgs;
       inherit (coverage) mkCoverageReport;
     };
     mkChecks = import ./scripts/nix/checks.nix {
-      inherit (core) projectHsPackages;
+      inherit (core) toolHsPackages;
       inherit sources;
       inherit (haskell) mkHsPkgsForChecks;
     };
     mkDevShells = import ./scripts/nix/dev-shells.nix {
+      inherit (core) toolHsPackages;
       inherit (haskell) mkHsPkgs;
     };
   in {

--- a/scripts/nix/apps.nix
+++ b/scripts/nix/apps.nix
@@ -1,9 +1,10 @@
 {
-  projectHsPackages,
+  toolHsPackages,
   mkHsPkgs,
   mkCoverageReport,
 }: pkgs: let
   hsPkgs = mkHsPkgs pkgs;
+  toolHsPkgs = toolHsPackages pkgs;
   parserProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "parser-progress";
   lexerProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "lexer-progress";
   extensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "extension-progress";
@@ -30,10 +31,10 @@
     meta.description = "aihc app: ${name}";
   };
 
-  mkApp = name: text: mkAppWithInputs name [pkgs.bash pkgs.cabal-install hsPkgs.ghc] text;
+  mkApp = name: text: mkAppWithInputs name [pkgs.bash toolHsPkgs.cabal-install hsPkgs.ghc] text;
 
   mkFmtApp = name: text:
-    mkAppWithInputs name [pkgs.bash pkgs.git pkgs.findutils pkgs.alejandra (projectHsPackages pkgs).ormolu] text;
+    mkAppWithInputs name [pkgs.bash pkgs.git pkgs.findutils pkgs.alejandra toolHsPkgs.ormolu] text;
 
   mkReportsApp = name: text: {
     type = "app";

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -1,9 +1,10 @@
 {
-  projectHsPackages,
+  toolHsPackages,
   sources,
   mkHsPkgsForChecks,
 }: pkgs: let
   hsPkgs = mkHsPkgsForChecks pkgs;
+  toolHsPkgs = toolHsPackages pkgs;
 
   addHiddenSuccesses = old: {
     # Hide passing tests so failures are visible in Nix's truncated output.
@@ -44,17 +45,17 @@
     alejandra --check .
   '';
 
-  haskellLint = mkSourceCheck "aihc-haskell-lint" (sources.haskellSrc pkgs) [pkgs.hlint pkgs.findutils] ''
+  haskellLint = mkSourceCheck "aihc-haskell-lint" (sources.haskellSrc pkgs) [toolHsPkgs.hlint pkgs.findutils] ''
     find . -type f -name '*.hs' -print0 \
       | xargs -0 -r hlint
   '';
 
-  haskellFormat = mkSourceCheck "aihc-haskell-format" (sources.haskellSrc pkgs) [pkgs.ormolu pkgs.findutils] ''
+  haskellFormat = mkSourceCheck "aihc-haskell-format" (sources.haskellSrc pkgs) [toolHsPkgs.ormolu pkgs.findutils] ''
     find . -type f -name '*.hs' -print0 \
       | xargs -0 -r ormolu --mode check
   '';
 
-  cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.haskellSrc pkgs) [pkgs.haskellPackages.cabal-gild pkgs.findutils] ''
+  cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.haskellSrc pkgs) [toolHsPkgs.cabal-gild pkgs.findutils] ''
     failed=0
     while IFS= read -r -d "" file; do
       cabal-gild --mode check --input "$file" || failed=1
@@ -80,8 +81,8 @@
 
   cppDoctest =
     mkSourceCheck "aihc-cpp-doctest" (sources.cppSrc pkgs) [
-      (projectHsPackages pkgs).doctest
-      (projectHsPackages pkgs).ghc
+      toolHsPkgs.doctest
+      hsPkgs.ghc
       hsPkgs.aihc-cpp
     ] ''
       # Run doctest on the Aihc.Cpp module.

--- a/scripts/nix/core.nix
+++ b/scripts/nix/core.nix
@@ -5,11 +5,32 @@
     "x86_64-darwin"
     "aarch64-darwin"
   ];
-in {
+in rec {
   inherit systems;
 
   forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f (import nixpkgs {inherit system;}));
 
-  # GHC / Stackage package set for Nix-built Haskell derivations (matches nixpkgs haskell.packages.ghc9124).
-  projectHsPackages = pkgs: pkgs.haskell.packages.ghc9124;
+  # GHC / Stackage package set for Nix-built Haskell derivations.
+  # Keep build-time Haskell dependencies in the same GHC 9.12 package set
+  # instead of falling back to nixpkgs' default haskellPackages alias.
+  toolHsPackages = pkgs: let
+    hsPkgs = pkgs.haskell.packages.ghc9124.override {
+      buildHaskellPackages = hsPkgs;
+      overrides = _final: prev: {
+        mkDerivation = args:
+          prev.mkDerivation
+          (args
+            // {
+              enableLibraryProfiling = false;
+              enableExecutableProfiling = false;
+            });
+        # The upstream Unix socket test can exceed Darwin's socket path limit
+        # under Nix's build directory.
+        network = pkgs.haskell.lib.dontCheck prev.network;
+      };
+    };
+  in
+    hsPkgs;
+
+  projectHsPackages = toolHsPackages;
 }

--- a/scripts/nix/dev-shells.nix
+++ b/scripts/nix/dev-shells.nix
@@ -1,14 +1,18 @@
-{mkHsPkgs}: pkgs: let
+{
+  toolHsPackages,
+  mkHsPkgs,
+}: pkgs: let
   hsPkgs = mkHsPkgs pkgs;
+  toolHsPkgs = toolHsPackages pkgs;
 in {
   default = pkgs.mkShell {
     buildInputs = [
       hsPkgs.ghc
-      pkgs.cabal-install
-      pkgs.ormolu
-      pkgs.haskellPackages.cabal-gild
+      toolHsPkgs.cabal-install
+      toolHsPkgs.ormolu
+      toolHsPkgs.cabal-gild
       pkgs.alejandra
-      pkgs.hlint
+      toolHsPkgs.hlint
     ];
   };
 }

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -12,7 +12,7 @@
     };
     aihc-cpp = {
       src = sources.cppSrc;
-      disableProfiling = false;
+      disableProfiling = true;
       optimizeForChecks = false;
       supportsDocs = true;
       supportsCoverage = true;
@@ -105,7 +105,17 @@
     else drv;
 
   isOverridableHaskellDrv = pkgs: drv:
-    pkgs.lib.isDerivation drv && drv.isHaskellLibrary or false;
+    pkgs.lib.isDerivation drv && drv ? isHaskellLibrary;
+
+  disableProfiling = hsLib: drv:
+    hsLib.overrideCabal
+    (hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling drv))
+    (_old: {
+      # Nixpkgs' Haskell builder pulls HsColour into library builds when
+      # source hyperlinking is enabled. Disable it so the build-tool path does
+      # not reintroduce a profiled HsColour derivation.
+      hyperlinkSource = false;
+    });
 
   disableUpstreamChecks = pkgs: hsLib: localPackageNames: _final: prev:
     builtins.mapAttrs (
@@ -114,14 +124,15 @@
         then drv
         else
           hsLib.dontCheck
-          (hsLib.dontHaddock
-            (hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling drv)))
+          (hsLib.dontHaddock (disableProfiling hsLib drv))
     )
     prev;
 in rec {
   # Hackage dependencies whose build settings need manual adjustment.
-  hackageDepTestFixes = pkgs: _final: prev: {
-    network = pkgs.haskell.lib.dontCheck prev.network;
+  hackageDepTestFixes = _pkgs: hsLib: _final: prev: {
+    network =
+      hsLib.dontCheck
+      (hsLib.dontHaddock (disableProfiling hsLib prev.network));
   };
 
   mkHsPkgsVariant = pkgs: {
@@ -144,7 +155,7 @@ in rec {
       baseDrv = final.callCabal2nix name (spec.src pkgs) {};
       profilingAdjusted =
         if spec.disableProfiling
-        then hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling baseDrv)
+        then disableProfiling hsLib baseDrv
         else baseDrv;
       optimizationAdjusted =
         if disableOptimization && spec.optimizeForChecks
@@ -167,18 +178,21 @@ in rec {
       applyHaddockMode hsLib haddockMode checksAdjusted;
   in
     (projectHsPackages pkgs).override {
+      buildHaskellPackages = projectHsPackages pkgs;
       overrides = final: prev:
         disableUpstreamChecks pkgs hsLib localPackageNames final prev
-        // hackageDepTestFixes pkgs final prev
+        // hackageDepTestFixes pkgs hsLib final prev
         // {
           ghc-lib-parser = hsLib.dontCheck (hsLib.dontHaddock (
-            hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling
-              final.ghc-lib-parser_9_14_1_20251220)
+            disableProfiling hsLib final.ghc-lib-parser_9_14_1_20251220
+          ));
+          ghc-lib-parser-ex = hsLib.dontCheck (hsLib.dontHaddock (
+            disableProfiling hsLib final.ghc-lib-parser-ex_9_14_2_0
           ));
           aihc-hackage = hsLib.dontCheck (hsLib.dontHaddock (
-            hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling (
+            disableProfiling hsLib (
               final.callCabal2nix "aihc-hackage" (sources.hackageSrc pkgs) {}
-            ))
+            )
           ));
         }
         // builtins.mapAttrs (mkComponent final) componentSpecs;


### PR DESCRIPTION
## Summary

- Use an explicit `ghc9124` Haskell package set for Nix Haskell tooling instead of nixpkgs' default `haskellPackages`.
- Keep tool dependencies on the standard GHC 9.12 nixpkgs package set, while project packages can still apply AIHC-specific overlays.
- Disable Haskell library/executable profiling at the shared GHC 9.12 package-set level, and keep build-time Haskell dependencies on GHC 9.12 instead of falling back to GHC 9.10.

## Root cause

`pkgs.haskellPackages` currently resolves to GHC 9.10.3 in this nixpkgs input. Some tool and setup/build dependencies were still using that default set, and `buildHaskellPackages = pkgs.haskellPackages` allowed project builds to fall back to GHC 9.10 for build-time Haskell dependencies. That is why `nix flake check -L` could hit `ghc-9.10.3: unrecognised flag: -fobject-determinism` even though the project package set itself was intended to be GHC 9.12.

## Validation

- `just fmt`
- `just check`
- `nix flake check -L`
- Evaluated tool package set: `ghc = 9.12.4`, `hlint = 3.10`, `ormolu = 0.8.0.2`, `ghc-lib-parser = 9.12.3.20251228`.
- Evaluated project check package set: `ghc = 9.12.4`, `ghc-lib-parser = 9.14.1.20251220`, `ghc-lib-parser-ex = 9.14.2.0`.
- Checked `aihc-parser` build log: it uses `ghc-9.12.4`, passes `--disable-library-profiling --disable-profiling`, and contains no `p_o` or `ghc-9.10` matches.

Note: I attempted the requested empty-store verification, but this macOS Nix install rejects diverted local stores with `building using a diverted store is not supported on this platform`. The successful `nix flake check -L` run on the normal store rebuilt the affected Haskell dependencies and exposed the same compiler/tooling path.