### PR TITLE
refactor(resolve): unify binding group resolution

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -671,13 +671,16 @@ data Name = Name
     -- | Whether this is a variable, constructor, or operator
     nameType :: NameType,
     -- | The local name (e.g., @\"map\"@, @\".+.\"@)
-    nameText :: Text
+    nameText :: Text,
+    -- | Metadata attached to this name occurrence.
+    nameAnns :: [Annotation]
   }
   deriving (Eq, Show, Generic, NFData, Data)
 
 data UnqualifiedName = UnqualifiedName
   { unqualifiedNameType :: NameType,
-    unqualifiedNameText :: Text
+    unqualifiedNameText :: Text,
+    unqualifiedNameAnns :: [Annotation]
   }
   deriving (Eq, Show, Generic, NFData, Data)
 
@@ -694,18 +697,18 @@ data NameType
   deriving (Eq, Show, Generic, NFData, Enum, Bounded, Data)
 
 mkName :: Maybe Text -> NameType -> Text -> Name
-mkName = Name
+mkName qualifier ty txt = Name qualifier ty txt []
 
 mkQualifiedName :: UnqualifiedName -> Maybe Text -> Name
 mkQualifiedName name qualifier =
-  Name qualifier (unqualifiedNameType name) (unqualifiedNameText name)
+  Name qualifier (unqualifiedNameType name) (unqualifiedNameText name) (unqualifiedNameAnns name)
 
 qualifyName :: Maybe Text -> UnqualifiedName -> Name
 qualifyName qualifier name =
-  Name qualifier (unqualifiedNameType name) (unqualifiedNameText name)
+  Name qualifier (unqualifiedNameType name) (unqualifiedNameText name) (unqualifiedNameAnns name)
 
 mkUnqualifiedName :: NameType -> Text -> UnqualifiedName
-mkUnqualifiedName = UnqualifiedName
+mkUnqualifiedName ty txt = UnqualifiedName ty txt []
 
 renderName :: Name -> Text
 renderName name =
@@ -725,7 +728,7 @@ instance IsString UnqualifiedName where
 nameFromText :: Text -> Name
 nameFromText txt =
   let (qualifier, localName) = splitQualifiedIdentifierText txt
-   in Name qualifier (inferNameType localName) localName
+   in Name qualifier (inferNameType localName) localName []
   where
     splitQualifiedIdentifierText fullName =
       case T.splitOn "." fullName of
@@ -750,7 +753,7 @@ nameFromText txt =
             Nothing -> False
 
 unqualifiedNameFromText :: Text -> UnqualifiedName
-unqualifiedNameFromText txt = UnqualifiedName (inferNameType txt) txt
+unqualifiedNameFromText txt = UnqualifiedName (inferNameType txt) txt []
 
 inferNameType :: Text -> NameType
 inferNameType localName
@@ -1802,6 +1805,8 @@ stripAnnotations x = applyStrip (gmapT stripAnnotations x)
         `extT` sClassDeclItem
         `extT` sInstanceDeclItem
         `extT` sCmd
+        `extT` sName
+        `extT` sUnqualifiedName
         `extT` sExportSpec
         `extT` sImportItem
         `extT` sAnnotations
@@ -1862,6 +1867,12 @@ stripAnnotations x = applyStrip (gmapT stripAnnotations x)
     sCmd :: Cmd -> Cmd
     sCmd (CmdAnn _ c) = c
     sCmd c = c
+
+    sName :: Name -> Name
+    sName name = name {nameAnns = []}
+
+    sUnqualifiedName :: UnqualifiedName -> UnqualifiedName
+    sUnqualifiedName name = name {unqualifiedNameAnns = []}
 
     sExportSpec :: ExportSpec -> ExportSpec
     sExportSpec (ExportAnn _ e) = e

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -94,6 +94,8 @@ ownResolveErrors node =
   declResolutionErrors (cast node)
     <> classDeclItemResolutionErrors (cast node)
     <> importResolutionErrors (cast node)
+    <> nameResolutionErrors (cast node)
+    <> unqualifiedNameResolutionErrors (cast node)
     <> patternResolutionErrors (cast node)
     <> typeResolutionErrors (cast node)
     <> exprResolutionErrors (cast node)
@@ -114,6 +116,18 @@ importResolutionErrors :: Maybe ImportDecl -> [ResolveError]
 importResolutionErrors maybeImport =
   case maybeImport of
     Just importDecl -> mapMaybe annotationResolveError (mapMaybe fromAnnotation (importDeclAnns importDecl))
+    _ -> []
+
+nameResolutionErrors :: Maybe Name -> [ResolveError]
+nameResolutionErrors maybeName =
+  case maybeName of
+    Just name -> mapMaybe annotationResolveError (mapMaybe fromAnnotation (nameAnns name))
+    _ -> []
+
+unqualifiedNameResolutionErrors :: Maybe UnqualifiedName -> [ResolveError]
+unqualifiedNameResolutionErrors maybeName =
+  case maybeName of
+    Just name -> mapMaybe annotationResolveError (mapMaybe fromAnnotation (unqualifiedNameAnns name))
     _ -> []
 
 patternResolutionErrors :: Maybe Pattern -> [ResolveError]
@@ -255,66 +269,64 @@ missingImportedName item namespace itemName candidates
   where
     rendered = renderUnqualifiedName itemName
 
-type BindingAnnotation = Scope -> Decl -> Maybe ResolutionAnnotation
+type TermDefinition = UnqualifiedName -> Maybe ResolvedName
 
 resolveTopLevelDecls :: Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
-resolveTopLevelDecls _ [] = pure []
-resolveTopLevelDecls signatureScopes (decl : rest) = do
-  (signatureScopes', decl') <- resolveBindingDecl (flip topLevelBinderAnnotation) signatureScopes decl
-  decls' <- resolveTopLevelDecls signatureScopes' rest
-  pure (decl' : decls')
+resolveTopLevelDecls signatureScopes decls = do
+  scope <- currentScope
+  resolveBindingGroup (topLevelTermDefinition scope) signatureScopes decls
 
-resolveBindingGroup :: BindingAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
+resolveBindingGroup :: TermDefinition -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
 resolveBindingGroup _ _ [] = pure []
-resolveBindingGroup bindingAnnotation signatureScopes (decl : rest) = do
-  (signatureScopes', decl') <- resolveBindingDecl bindingAnnotation signatureScopes decl
-  decls' <- resolveBindingGroup bindingAnnotation signatureScopes' rest
+resolveBindingGroup termDefinition signatureScopes (decl : rest) = do
+  (signatureScopes', decl') <- resolveBindingDecl termDefinition signatureScopes decl
+  decls' <- resolveBindingGroup termDefinition signatureScopes' rest
   pure (decl' : decls')
 
-resolveBindingDecl :: BindingAnnotation -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveBindingDecl bindingAnnotation signatureScopes decl = do
+resolveBindingDecl :: TermDefinition -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
+resolveBindingDecl termDefinition signatureScopes decl = do
   scope <- currentScope
   let scoped = maybe scope (`unionScope` scope) (declSignatureScope decl signatureScopes)
-  (signatureScopes', decl') <- withScope scoped (resolveDeclWithSignatureScope signatureScopes decl)
-  let decl'' = maybe decl' (`annotateDecl` decl') (bindingAnnotation scope decl)
-  pure (signatureScopes', decl'')
+  withScope scoped (resolveDeclWithSignatureScope termDefinition signatureScopes decl)
 
-resolveDeclWithSignatureScope :: Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveDeclWithSignatureScope signatureScopes decl =
+resolveDeclWithSignatureScope :: TermDefinition -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
+resolveDeclWithSignatureScope termDefinition signatureScopes decl =
   case decl of
     DeclAnn ann inner ->
       withPushedSpan ann $ do
-        (signatureScopes', inner') <- resolveDeclWithSignatureScope signatureScopes inner
+        (signatureScopes', inner') <- resolveDeclWithSignatureScope termDefinition signatureScopes inner
         pure (signatureScopes', DeclAnn ann inner')
     DeclTypeSig names ty -> do
+      sp <- currentSpan
       (binderScope, ty') <- resolveTypeSignature ty
+      let names' = map (resolveTermDefinitionAt sp termDefinition) names
       let signatureScopes' =
             foldl'
               (\acc name -> Map.insert (renderUnqualifiedName name) binderScope acc)
               signatureScopes
               names
-      pure (signatureScopes', DeclTypeSig names ty')
+      pure (signatureScopes', DeclTypeSig names' ty')
     _ -> do
-      decl' <- resolveDecl decl
+      decl' <- resolveDecl termDefinition decl
       let signatureScopes' =
             case declBinderCandidate decl of
               Just (_, name) -> Map.delete (renderUnqualifiedName name) signatureScopes
               Nothing -> signatureScopes
       pure (signatureScopes', decl')
 
-resolveDecl :: Decl -> ResolveM Decl
-resolveDecl (DeclAnn ann inner) =
-  withPushedSpan ann (resolveDecl inner)
-resolveDecl decl =
-  resolveDeclCore decl
+resolveDecl :: TermDefinition -> Decl -> ResolveM Decl
+resolveDecl termDefinition (DeclAnn ann inner) =
+  withPushedSpan ann (resolveDecl termDefinition inner)
+resolveDecl termDefinition decl =
+  resolveDeclCore termDefinition decl
 
-resolveDeclCore :: Decl -> ResolveM Decl
-resolveDeclCore decl =
+resolveDeclCore :: TermDefinition -> Decl -> ResolveM Decl
+resolveDeclCore termDefinition decl =
   case decl of
     DeclAnn ann inner ->
-      withPushedSpan ann (resolveDeclCore inner)
+      withPushedSpan ann (resolveDeclCore termDefinition inner)
     DeclValue valueDecl ->
-      DeclValue <$> resolveValueDecl valueDecl
+      DeclValue <$> resolveValueDecl termDefinition valueDecl
     DeclTypeSig names ty -> do
       ty' <- resolveType ty
       pure (DeclTypeSig names ty')
@@ -346,26 +358,33 @@ resolveDeclCore decl =
     DeclTypeFamilyInst {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclDataFamilyInst {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
 
-resolveValueDecl :: ValueDecl -> ResolveM ValueDecl
-resolveValueDecl valueDecl =
+resolveValueDecl :: TermDefinition -> ValueDecl -> ResolveM ValueDecl
+resolveValueDecl termDefinition valueDecl =
   case valueDecl of
-    FunctionBind name matches ->
-      FunctionBind name <$> mapM resolveMatch matches
+    FunctionBind name matches -> do
+      sp <- currentSpan
+      let name' = resolveTermDefinitionAt sp termDefinition name
+      FunctionBind name' <$> mapM resolveMatch matches
     PatternBind multTag pat rhs ->
-      PatternBind multTag <$> resolvePatternSyntax pat <*> resolveRhs rhs
+      PatternBind multTag <$> resolvePatternDefinition termDefinition pat <*> resolveRhs rhs
 
 resolveClassDecl :: ClassDecl -> ResolveM ClassDecl
 resolveClassDecl classDecl = do
   scope <- currentScope
   declSpan <- currentSpan
+  let resolveHeadName name =
+        let rendered = renderUnqualifiedName name
+            span' = declKeywordNameSpan "class " declSpan rendered
+         in resolveUnqualifiedNameTo span' ResolutionNamespaceType (lookupType rendered scope) name
+      head' =
+        case classDeclHead classDecl of
+          PrefixBinderHead name params -> PrefixBinderHead (resolveHeadName name) params
+          InfixBinderHead lhs name rhs params -> InfixBinderHead lhs (resolveHeadName name) rhs params
   context' <- traverse (mapM resolveType) (classDeclContext classDecl)
   items' <- mapM resolveClassDeclItem (classDeclItems classDecl)
   pure
     classDecl
-      { classDeclHead =
-          annotateBinderHeadName
-            (classNameAnnotation scope declSpan)
-            (classDeclHead classDecl),
+      { classDeclHead = head',
         classDeclContext = context',
         classDeclItems = items'
       }
@@ -376,7 +395,9 @@ resolveClassDeclItem classDeclItem =
     ClassItemAnn ann inner -> ClassItemAnn ann <$> withPushedSpan ann (resolveClassDeclItem inner)
     ClassItemTypeSig names ty -> ClassItemTypeSig names <$> resolveType ty
     ClassItemDefaultSig name ty -> ClassItemDefaultSig name <$> resolveType ty
-    ClassItemDefault valueDecl -> ClassItemDefault <$> withLocalSupply 0 (resolveValueDecl valueDecl)
+    ClassItemDefault valueDecl -> do
+      scope <- currentScope
+      ClassItemDefault <$> withLocalSupply 0 (resolveValueDecl (topLevelTermDefinition scope) valueDecl)
     ClassItemFixity {} -> annotateUnhandledClassDeclItem <$> currentSpan <*> pure classDeclItem
     ClassItemPragma {} -> annotateUnhandledClassDeclItem <$> currentSpan <*> pure classDeclItem
     ClassItemTypeFamilyDecl {} -> annotateUnhandledClassDeclItem <$> currentSpan <*> pure classDeclItem
@@ -459,14 +480,8 @@ resolveExpr expr =
   case expr of
     EAnn ann inner ->
       withPushedSpan ann (resolveExpr inner)
-    EVar name -> do
-      sp <- currentSpan
-      scope <- currentScope
-      pure
-        ( annotateExpr
-            (ResolutionAnnotation sp (nameText name) ResolutionNamespaceTerm (resolveTermName scope name))
-            (EVar name)
-        )
+    EVar name ->
+      EVar <$> resolveTermUse name
     ETypeSyntax form ty -> ETypeSyntax form <$> resolveType ty
     EInt {} -> pure expr
     EFloat {} -> pure expr
@@ -624,9 +639,9 @@ resolveArithSeq arithSeq =
     ArithSeqFromThenTo from then' to ->
       ArithSeqFromThenTo <$> resolveExpr from <*> resolveExpr then' <*> resolveExpr to
 
-resolveBoundDecls :: Map.Map Text ResolutionAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
-resolveBoundDecls binderAnnotations =
-  resolveBindingGroup (\_ decl -> declBinderAnnotation decl binderAnnotations)
+resolveBoundDecls :: Map.Map Text ResolvedName -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
+resolveBoundDecls binderTargets =
+  resolveBindingGroup (\name -> Map.lookup (renderUnqualifiedName name) binderTargets)
 
 declSignatureScope :: Decl -> Map.Map Text Scope -> Maybe Scope
 declSignatureScope decl signatureScopes =
@@ -648,8 +663,8 @@ bindPattern pat =
       sp <- currentSpan
       resolvedName <- freshLocal name
       let key = renderUnqualifiedName name
-          annotation = ResolutionAnnotation sp (renderUnqualifiedName name) ResolutionNamespaceTerm resolvedName
-      pure (termScope key resolvedName, annotatePattern annotation (PVar name))
+          name' = resolveUnqualifiedNameTo sp ResolutionNamespaceTerm resolvedName name
+      pure (termScope key resolvedName, PVar name')
     PTypeBinder binder -> do
       let binderName = mkUnqualifiedName NameVarId (tyVarBinderName binder)
       resolvedName <- freshLocal binderName
@@ -686,11 +701,10 @@ bindPattern pat =
       here <- currentSpan
       let aliasKey = renderUnqualifiedName alias
       aliasResolved <- freshLocal alias
-      let aliasAnnotation =
-            ResolutionAnnotation (spanStartNameSpan here aliasKey) aliasKey ResolutionNamespaceTerm aliasResolved
+      let alias' = resolveUnqualifiedNameTo (spanStartNameSpan here aliasKey) ResolutionNamespaceTerm aliasResolved alias
           aliasScope = termScope aliasKey aliasResolved
       (innerScope, inner') <- bindPattern inner
-      pure (unionScope innerScope aliasScope, annotatePattern aliasAnnotation (PAs alias inner'))
+      pure (unionScope innerScope aliasScope, PAs alias' inner')
     PStrict inner -> do
       (scope, inner') <- bindPattern inner
       pure (scope, PStrict inner')
@@ -731,12 +745,14 @@ termScope :: Text -> ResolvedName -> Scope
 termScope key resolvedName =
   Scope (Map.singleton key resolvedName) Map.empty Map.empty Map.empty Map.empty Map.empty
 
-resolvePatternSyntax :: Pattern -> ResolveM Pattern
-resolvePatternSyntax pat =
+resolvePatternDefinition :: TermDefinition -> Pattern -> ResolveM Pattern
+resolvePatternDefinition termDefinition pat =
   case pat of
     PAnn ann inner ->
-      withPushedSpan ann (resolvePatternSyntax inner)
-    PVar {} -> pure pat
+      withPushedSpan ann (resolvePatternDefinition termDefinition inner)
+    PVar name -> do
+      sp <- currentSpan
+      pure (PVar (resolveTermDefinitionAt sp termDefinition name))
     PTypeBinder binder -> do
       kind' <- traverse resolveType (tyVarBinderKind binder)
       pure (PTypeBinder (binder {tyVarBinderKind = kind'}))
@@ -746,37 +762,38 @@ resolvePatternSyntax pat =
     PLit {} -> pure pat
     PQuasiQuote {} -> annotateUnhandledPattern <$> currentSpan <*> pure pat
     PTuple flavor pats ->
-      PTuple flavor <$> mapM resolvePatternSyntax pats
+      PTuple flavor <$> mapM (resolvePatternDefinition termDefinition) pats
     PUnboxedSum alt arity inner ->
-      PUnboxedSum alt arity <$> resolvePatternSyntax inner
+      PUnboxedSum alt arity <$> resolvePatternDefinition termDefinition inner
     PList pats ->
-      PList <$> mapM resolvePatternSyntax pats
+      PList <$> mapM (resolvePatternDefinition termDefinition) pats
     PCon name typeArgs pats ->
-      PCon name <$> mapM resolveType typeArgs <*> mapM resolvePatternSyntax pats
+      PCon name <$> mapM resolveType typeArgs <*> mapM (resolvePatternDefinition termDefinition) pats
     PInfix left name right ->
-      PInfix <$> resolvePatternSyntax left <*> pure name <*> resolvePatternSyntax right
+      PInfix <$> resolvePatternDefinition termDefinition left <*> pure name <*> resolvePatternDefinition termDefinition right
     PView expr inner ->
-      PView <$> withLocalSupply 0 (resolveExpr expr) <*> resolvePatternSyntax inner
-    PAs alias inner ->
-      PAs alias <$> resolvePatternSyntax inner
+      PView <$> withLocalSupply 0 (resolveExpr expr) <*> resolvePatternDefinition termDefinition inner
+    PAs alias inner -> do
+      sp <- currentSpan
+      PAs (resolveTermDefinitionAt sp termDefinition alias) <$> resolvePatternDefinition termDefinition inner
     PStrict inner ->
-      PStrict <$> resolvePatternSyntax inner
+      PStrict <$> resolvePatternDefinition termDefinition inner
     PIrrefutable inner ->
-      PIrrefutable <$> resolvePatternSyntax inner
+      PIrrefutable <$> resolvePatternDefinition termDefinition inner
     PNegLit {} -> pure pat
     PParen inner ->
-      PParen <$> resolvePatternSyntax inner
+      PParen <$> resolvePatternDefinition termDefinition inner
     PRecord name fields wildcard ->
       PRecord name
         <$> mapM
           ( \field -> do
-              value' <- resolvePatternSyntax (recordFieldValue field)
+              value' <- resolvePatternDefinition termDefinition (recordFieldValue field)
               pure field {recordFieldValue = value'}
           )
           fields
         <*> pure wildcard
     PTypeSig inner ty ->
-      PTypeSig <$> resolvePatternSyntax inner <*> resolveType ty
+      PTypeSig <$> resolvePatternDefinition termDefinition inner <*> resolveType ty
     PSplice expr ->
       PSplice <$> withLocalSupply 0 (resolveExpr expr)
 
@@ -802,34 +819,44 @@ resolveDataDecl :: Text -> DataDecl -> ResolveM DataDecl
 resolveDataDecl keyword dataDecl = do
   scope <- currentScope
   declSpan <- currentSpan
+  let resolveHeadName name =
+        let rendered = renderUnqualifiedName name
+            span' = declKeywordNameSpan keyword declSpan rendered
+         in resolveUnqualifiedNameTo span' ResolutionNamespaceType (lookupType rendered scope) name
+      head' =
+        case dataDeclHead dataDecl of
+          PrefixBinderHead name params -> PrefixBinderHead (resolveHeadName name) params
+          InfixBinderHead lhs name rhs params -> InfixBinderHead lhs (resolveHeadName name) rhs params
   context' <- mapM resolveType (dataDeclContext dataDecl)
   kind' <- traverse resolveType (dataDeclKind dataDecl)
   constructors' <- mapM resolveDataConDecl (dataDeclConstructors dataDecl)
   pure
     dataDecl
-      { dataDeclHead =
-          annotateBinderHeadName
-            (dataDeclNameAnnotation scope keyword declSpan)
-            (dataDeclHead dataDecl),
+      { dataDeclHead = head',
         dataDeclContext = context',
         dataDeclKind = kind',
-        dataDeclConstructors = map (annotateDataConDeclName scope) constructors'
+        dataDeclConstructors = map (resolveDataConDefinitions scope) constructors'
       }
 
 resolveNewtypeDecl :: NewtypeDecl -> ResolveM NewtypeDecl
 resolveNewtypeDecl newtypeDecl = do
   scope <- currentScope
   declSpan <- currentSpan
+  let resolveHeadName name =
+        let rendered = renderUnqualifiedName name
+            span' = declKeywordNameSpan "newtype " declSpan rendered
+         in resolveUnqualifiedNameTo span' ResolutionNamespaceType (lookupType rendered scope) name
+      head' =
+        case newtypeDeclHead newtypeDecl of
+          PrefixBinderHead name params -> PrefixBinderHead (resolveHeadName name) params
+          InfixBinderHead lhs name rhs params -> InfixBinderHead lhs (resolveHeadName name) rhs params
   kind' <- traverse resolveType (newtypeDeclKind newtypeDecl)
   constructor' <- traverse resolveDataConDecl (newtypeDeclConstructor newtypeDecl)
   pure
     newtypeDecl
-      { newtypeDeclHead =
-          annotateBinderHeadName
-            (newtypeDeclNameAnnotation scope declSpan)
-            (newtypeDeclHead newtypeDecl),
+      { newtypeDeclHead = head',
         newtypeDeclKind = kind',
-        newtypeDeclConstructor = annotateDataConDeclName scope <$> constructor'
+        newtypeDeclConstructor = resolveDataConDefinitions scope <$> constructor'
       }
 
 resolveDataConDecl :: DataConDecl -> ResolveM DataConDecl
@@ -880,19 +907,10 @@ resolveType :: Type -> ResolveM Type
 resolveType ty =
   case ty of
     TAnn ann inner -> withPushedSpan ann (resolveType inner)
-    TVar name -> do
-      sp <- currentSpan
-      scope <- currentScope
-      let resolvedTyVar = TVar name
-      pure (maybe resolvedTyVar (`annotateType` resolvedTyVar) (resolveScopedTypeVarAnnotation scope sp name))
-    TCon name promoted -> do
-      sp <- currentSpan
-      scope <- currentScope
-      pure
-        ( annotateType
-            (ResolutionAnnotation sp (nameText name) ResolutionNamespaceType (resolveTypeName scope name))
-            (TCon name promoted)
-        )
+    TVar name ->
+      TVar <$> resolveScopedTypeVariableUse name
+    TCon name promoted ->
+      TCon <$> resolveTypeUse name <*> pure promoted
     TBuiltinCon {} -> pure ty
     TImplicitParam name inner ->
       TImplicitParam name <$> resolveType inner
@@ -934,14 +952,6 @@ resolveArrowKind arrowKind =
     ArrowLinear -> pure arrowKind
     ArrowExplicit ty -> ArrowExplicit <$> resolveType ty
 
-resolveScopedTypeVarAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> Maybe ResolutionAnnotation
-resolveScopedTypeVarAnnotation scope span' name =
-  let rendered = renderUnqualifiedName name
-      resolved = lookupType rendered scope
-   in case resolved of
-        ResolvedError _ -> Nothing
-        _ -> Just (ResolutionAnnotation span' rendered ResolutionNamespaceType resolved)
-
 resolveTypeSignature :: Type -> ResolveM (Scope, Type)
 resolveTypeSignature ty =
   case ty of
@@ -970,16 +980,15 @@ bindTyVarBinders =
       kind' <- traverse resolveType (tyVarBinderKind binder)
       pure binder {tyVarBinderKind = kind'}
 
-allocateLocalDeclBinders :: [Decl] -> ResolveM (Map.Map Text ResolutionAnnotation, Scope)
+allocateLocalDeclBinders :: [Decl] -> ResolveM (Map.Map Text ResolvedName, Scope)
 allocateLocalDeclBinders =
   foldM step (Map.empty, emptyScope)
   where
     step acc decl = foldM addBinder acc (declBinderCandidates decl)
-    addBinder (annotations, scope) (span', name) = do
+    addBinder (targets, scope) (_, name) = do
       resolvedName <- freshLocal name
       let key = renderUnqualifiedName name
-          annotation = ResolutionAnnotation span' key ResolutionNamespaceTerm resolvedName
-      pure (Map.insert key annotation annotations, insertTerm key resolvedName scope)
+      pure (Map.insert key resolvedName targets, insertTerm key resolvedName scope)
 
 -- | Collect all term binders introduced by a declaration (handles tuple patterns etc.)
 declBinderCandidates :: Decl -> [(SourceSpan, UnqualifiedName)]
@@ -997,20 +1006,6 @@ declBinderCandidates decl =
         DeclTypeSig [name] _ ->
           [(spanStartNameSpan outerSp (renderUnqualifiedName name), name)]
         _ -> []
-
-declBinderAnnotation :: Decl -> Map.Map Text ResolutionAnnotation -> Maybe ResolutionAnnotation
-declBinderAnnotation decl binderAnnotations =
-  case declBinderCandidate decl of
-    Just (_, name) -> Map.lookup (renderUnqualifiedName name) binderAnnotations
-    Nothing -> Nothing
-
-topLevelBinderAnnotation :: Decl -> Scope -> Maybe ResolutionAnnotation
-topLevelBinderAnnotation decl scope =
-  case declBinderCandidate decl of
-    Just (span', name) ->
-      let rendered = renderUnqualifiedName name
-       in Just (ResolutionAnnotation span' rendered ResolutionNamespaceTerm (lookupTerm rendered scope))
-    Nothing -> Nothing
 
 declBinderCandidate :: Decl -> Maybe (SourceSpan, UnqualifiedName)
 declBinderCandidate decl =
@@ -1034,74 +1029,79 @@ declBinderCandidate decl =
           Just (spanStartNameSpan outerSp (renderUnqualifiedName name), name)
         _ -> Nothing
 
-annotateBinderHeadName :: (UnqualifiedName -> ResolutionAnnotation) -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
-annotateBinderHeadName annotationFor head' =
-  case head' of
-    PrefixBinderHead name params ->
-      PrefixBinderHead (annotateUnqualifiedName (annotationFor name) name) params
-    InfixBinderHead lhs name rhs params ->
-      InfixBinderHead lhs (annotateUnqualifiedName (annotationFor name) name) rhs params
+topLevelTermDefinition :: Scope -> TermDefinition
+topLevelTermDefinition scope name =
+  Just (lookupTerm (renderUnqualifiedName name) scope)
 
-annotateDataConDeclName :: Scope -> DataConDecl -> DataConDecl
-annotateDataConDeclName scope =
+resolveTermDefinitionAt :: SourceSpan -> TermDefinition -> UnqualifiedName -> UnqualifiedName
+resolveTermDefinitionAt span' termDefinition name =
+  case termDefinition name of
+    Just resolved ->
+      resolveUnqualifiedNameTo (spanStartNameSpan span' (renderUnqualifiedName name)) ResolutionNamespaceTerm resolved name
+    Nothing -> name
+
+resolveUnqualifiedNameTo :: SourceSpan -> ResolutionNamespace -> ResolvedName -> UnqualifiedName -> UnqualifiedName
+resolveUnqualifiedNameTo span' namespace resolved name =
+  name
+    { unqualifiedNameAnns =
+        mkAnnotation (ResolutionAnnotation span' (renderUnqualifiedName name) namespace resolved)
+          : unqualifiedNameAnns name
+    }
+
+resolveNameTo :: SourceSpan -> ResolutionNamespace -> ResolvedName -> Name -> Name
+resolveNameTo span' namespace resolved name =
+  name
+    { nameAnns =
+        mkAnnotation (ResolutionAnnotation span' (nameText name) namespace resolved)
+          : nameAnns name
+    }
+
+resolveTermUse :: Name -> ResolveM Name
+resolveTermUse name = do
+  sp <- currentSpan
+  scope <- currentScope
+  pure (resolveNameTo sp ResolutionNamespaceTerm (resolveTermName scope name) name)
+
+resolveTypeUse :: Name -> ResolveM Name
+resolveTypeUse name = do
+  sp <- currentSpan
+  scope <- currentScope
+  pure (resolveNameTo sp ResolutionNamespaceType (resolveTypeName scope name) name)
+
+resolveScopedTypeVariableUse :: UnqualifiedName -> ResolveM UnqualifiedName
+resolveScopedTypeVariableUse name = do
+  sp <- currentSpan
+  scope <- currentScope
+  let rendered = renderUnqualifiedName name
+      resolved = lookupType rendered scope
+  pure $
+    case resolved of
+      ResolvedError _ -> name
+      _ -> resolveUnqualifiedNameTo sp ResolutionNamespaceType resolved name
+
+resolveDataConDefinitions :: Scope -> DataConDecl -> DataConDecl
+resolveDataConDefinitions scope =
   go NoSourceSpan
   where
     go ambient current =
       case current of
         DataConAnn ann inner -> DataConAnn ann (go (pushSpanFromAnn ambient ann) inner)
         PrefixCon forallVars context name bangTypes ->
-          PrefixCon forallVars context (annotateTopLevelName ambient name) bangTypes
+          PrefixCon forallVars context (resolveConstructor ambient name) bangTypes
         RecordCon forallVars context name fields ->
-          RecordCon forallVars context (annotateTopLevelName ambient name) fields
+          RecordCon forallVars context (resolveConstructor ambient name) fields
         InfixCon forallVars context lhs name rhs ->
-          InfixCon forallVars context lhs (annotateTopLevelName ambient name) rhs
+          InfixCon forallVars context lhs (resolveConstructor ambient name) rhs
         GadtCon forallVars context names body ->
-          GadtCon forallVars context (map (annotateTopLevelName ambient) names) body
+          GadtCon forallVars context (map (resolveConstructor ambient) names) body
         TupleCon {} -> current
         UnboxedSumCon {} -> current
         ListCon {} -> current
 
-    annotateTopLevelName span' name =
-      annotateUnqualifiedName (topLevelNameAnnotation scope span' name) name
-
-annotateUnqualifiedName :: ResolutionAnnotation -> UnqualifiedName -> UnqualifiedName
-annotateUnqualifiedName annotation name =
-  name {unqualifiedNameAnns = mkAnnotation annotation : unqualifiedNameAnns name}
-
-classNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
-classNameAnnotation scope declSpan name =
-  ResolutionAnnotation
-    (declKeywordNameSpan "class " declSpan (renderUnqualifiedName name))
-    (renderUnqualifiedName name)
-    ResolutionNamespaceType
-    (resolveTopLevelType scope name)
-
-dataDeclNameAnnotation :: Scope -> Text -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
-dataDeclNameAnnotation scope keyword declSpan name =
-  ResolutionAnnotation
-    (declKeywordNameSpan keyword declSpan (renderUnqualifiedName name))
-    (renderUnqualifiedName name)
-    ResolutionNamespaceType
-    (resolveTopLevelType scope name)
-
-newtypeDeclNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
-newtypeDeclNameAnnotation scope declSpan name =
-  ResolutionAnnotation
-    (declKeywordNameSpan "newtype " declSpan (renderUnqualifiedName name))
-    (renderUnqualifiedName name)
-    ResolutionNamespaceType
-    (resolveTopLevelType scope name)
-
-resolveTopLevelType :: Scope -> UnqualifiedName -> ResolvedName
-resolveTopLevelType scope name = lookupType (renderUnqualifiedName name) scope
-
-resolveTopLevelTerm :: Scope -> UnqualifiedName -> ResolvedName
-resolveTopLevelTerm scope name = lookupTerm (renderUnqualifiedName name) scope
-
-topLevelNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
-topLevelNameAnnotation scope span' name =
-  ResolutionAnnotation
-    (spanStartNameSpan span' (renderUnqualifiedName name))
-    (renderUnqualifiedName name)
-    ResolutionNamespaceTerm
-    (resolveTopLevelTerm scope name)
+    resolveConstructor span' name =
+      let rendered = renderUnqualifiedName name
+       in resolveUnqualifiedNameTo
+            (spanStartNameSpan span' rendered)
+            ResolutionNamespaceTerm
+            (lookupTerm rendered scope)
+            name

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -254,50 +254,38 @@ missingImportedName item namespace itemName candidates
   where
     rendered = renderUnqualifiedName itemName
 
-data BindingGroupPolicy = BindingGroupPolicy
-  { bindingDeclAnnotation :: Scope -> Decl -> Maybe ResolutionAnnotation,
-    bindingExtraAnnotations :: Scope -> Decl -> [ResolutionAnnotation]
-  }
-
-topLevelBindingPolicy :: BindingGroupPolicy
-topLevelBindingPolicy =
-  BindingGroupPolicy
-    { bindingDeclAnnotation = flip topLevelBinderAnnotation,
-      bindingExtraAnnotations = flip topLevelDeclAnnotations
-    }
-
-localBindingPolicy :: Map.Map Text ResolutionAnnotation -> BindingGroupPolicy
-localBindingPolicy binderAnnotations =
-  BindingGroupPolicy
-    { bindingDeclAnnotation = \_ decl -> declBinderAnnotation decl binderAnnotations,
-      bindingExtraAnnotations = \_ _ -> []
-    }
+type BindingAnnotation = Scope -> Decl -> Maybe ResolutionAnnotation
 
 resolveTopLevelDecls :: Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
-resolveTopLevelDecls = resolveBindingGroup topLevelBindingPolicy
-
-resolveBindingGroup :: BindingGroupPolicy -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
-resolveBindingGroup _ _ [] = pure []
-resolveBindingGroup policy signatureScopes (decl : rest) = do
-  (signatureScopes', decl') <- resolveBindingDecl policy signatureScopes decl
-  decls' <- resolveBindingGroup policy signatureScopes' rest
+resolveTopLevelDecls _ [] = pure []
+resolveTopLevelDecls signatureScopes (decl : rest) = do
+  scope <- currentScope
+  emitAnnotations (topLevelIntroducedNameAnnotations scope decl)
+  (signatureScopes', decl') <- resolveBindingDecl (flip topLevelBinderAnnotation) signatureScopes decl
+  decls' <- resolveTopLevelDecls signatureScopes' rest
   pure (decl' : decls')
 
-resolveBindingDecl :: BindingGroupPolicy -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveBindingDecl policy signatureScopes decl = do
+resolveBindingGroup :: BindingAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
+resolveBindingGroup _ _ [] = pure []
+resolveBindingGroup bindingAnnotation signatureScopes (decl : rest) = do
+  (signatureScopes', decl') <- resolveBindingDecl bindingAnnotation signatureScopes decl
+  decls' <- resolveBindingGroup bindingAnnotation signatureScopes' rest
+  pure (decl' : decls')
+
+resolveBindingDecl :: BindingAnnotation -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
+resolveBindingDecl bindingAnnotation signatureScopes decl = do
   scope <- currentScope
   let scoped = maybe scope (`unionScope` scope) (declSignatureScope decl signatureScopes)
-  (signatureScopes', decl') <- withScope scoped (resolveDeclWithSignatureScope policy signatureScopes decl)
-  emitAnnotations (bindingExtraAnnotations policy scope decl)
-  let decl'' = maybe decl' (`annotateDecl` decl') (bindingDeclAnnotation policy scope decl)
+  (signatureScopes', decl') <- withScope scoped (resolveDeclWithSignatureScope signatureScopes decl)
+  let decl'' = maybe decl' (`annotateDecl` decl') (bindingAnnotation scope decl)
   pure (signatureScopes', decl'')
 
-resolveDeclWithSignatureScope :: BindingGroupPolicy -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveDeclWithSignatureScope policy signatureScopes decl =
+resolveDeclWithSignatureScope :: Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
+resolveDeclWithSignatureScope signatureScopes decl =
   case decl of
     DeclAnn ann inner ->
       withPushedSpan ann $ do
-        (signatureScopes', inner') <- resolveDeclWithSignatureScope policy signatureScopes inner
+        (signatureScopes', inner') <- resolveDeclWithSignatureScope signatureScopes inner
         pure (signatureScopes', DeclAnn ann inner')
     DeclTypeSig names ty -> do
       (binderScope, ty') <- resolveTypeSignature ty
@@ -635,7 +623,7 @@ resolveArithSeq arithSeq =
 
 resolveBoundDecls :: Map.Map Text ResolutionAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
 resolveBoundDecls binderAnnotations =
-  resolveBindingGroup (localBindingPolicy binderAnnotations)
+  resolveBindingGroup (\_ decl -> declBinderAnnotation decl binderAnnotations)
 
 declSignatureScope :: Decl -> Map.Map Text Scope -> Maybe Scope
 declSignatureScope decl signatureScopes =
@@ -1021,8 +1009,8 @@ declBinderCandidate decl =
           Just (spanStartNameSpan outerSp (renderUnqualifiedName name), name)
         _ -> Nothing
 
-topLevelDeclAnnotations :: Decl -> Scope -> [ResolutionAnnotation]
-topLevelDeclAnnotations decl scope =
+topLevelIntroducedNameAnnotations :: Scope -> Decl -> [ResolutionAnnotation]
+topLevelIntroducedNameAnnotations scope decl =
   case peelDeclSpan NoSourceSpan decl of
     (declSpan, DeclClass classDecl) -> [classAnnotation scope declSpan classDecl]
     (declSpan, DeclTypeData dataDecl) -> dataDeclAnnotations declSpan "type data " dataDecl

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -260,11 +260,9 @@ type BindingAnnotation = Scope -> Decl -> Maybe ResolutionAnnotation
 resolveTopLevelDecls :: Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
 resolveTopLevelDecls _ [] = pure []
 resolveTopLevelDecls signatureScopes (decl : rest) = do
-  scope <- currentScope
   (signatureScopes', decl') <- resolveBindingDecl (flip topLevelBinderAnnotation) signatureScopes decl
-  let decl'' = annotateTopLevelIntroducedNames scope decl'
   decls' <- resolveTopLevelDecls signatureScopes' rest
-  pure (decl'' : decls')
+  pure (decl' : decls')
 
 resolveBindingGroup :: BindingAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
 resolveBindingGroup _ _ [] = pure []
@@ -323,16 +321,14 @@ resolveDeclCore decl =
     DeclStandaloneKindSig {} ->
       annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclTypeData dataDecl ->
-      DeclTypeData <$> resolveDataDecl dataDecl
+      DeclTypeData <$> resolveDataDecl "type data " dataDecl
     DeclData dataDecl ->
-      DeclData <$> resolveDataDecl dataDecl
+      DeclData <$> resolveDataDecl "data " dataDecl
     DeclTypeSyn {} ->
       annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclSplice expr -> DeclSplice <$> resolveExpr expr
-    DeclNewtype newtypeDecl -> do
-      kind' <- traverse resolveType (newtypeDeclKind newtypeDecl)
-      constructor' <- traverse resolveDataConDecl (newtypeDeclConstructor newtypeDecl)
-      pure (DeclNewtype (newtypeDecl {newtypeDeclKind = kind', newtypeDeclConstructor = constructor'}))
+    DeclNewtype newtypeDecl ->
+      DeclNewtype <$> resolveNewtypeDecl newtypeDecl
     DeclClass classDecl ->
       DeclClass <$> resolveClassDecl classDecl
     DeclDefault tys ->
@@ -360,11 +356,17 @@ resolveValueDecl valueDecl =
 
 resolveClassDecl :: ClassDecl -> ResolveM ClassDecl
 resolveClassDecl classDecl = do
+  scope <- currentScope
+  declSpan <- currentSpan
   context' <- traverse (mapM resolveType) (classDeclContext classDecl)
   items' <- mapM resolveClassDeclItem (classDeclItems classDecl)
   pure
     classDecl
-      { classDeclContext = context',
+      { classDeclHead =
+          annotateBinderHeadName
+            (classNameAnnotation scope declSpan)
+            (classDeclHead classDecl),
+        classDeclContext = context',
         classDeclItems = items'
       }
 
@@ -796,16 +798,38 @@ bindRecordWildcardFields conName fields wildcard
       resolvedName <- freshLocal binder
       pure (fieldName, resolvedName)
 
-resolveDataDecl :: DataDecl -> ResolveM DataDecl
-resolveDataDecl dataDecl = do
+resolveDataDecl :: Text -> DataDecl -> ResolveM DataDecl
+resolveDataDecl keyword dataDecl = do
+  scope <- currentScope
+  declSpan <- currentSpan
   context' <- mapM resolveType (dataDeclContext dataDecl)
   kind' <- traverse resolveType (dataDeclKind dataDecl)
   constructors' <- mapM resolveDataConDecl (dataDeclConstructors dataDecl)
   pure
     dataDecl
-      { dataDeclContext = context',
+      { dataDeclHead =
+          annotateBinderHeadName
+            (dataDeclNameAnnotation scope keyword declSpan)
+            (dataDeclHead dataDecl),
+        dataDeclContext = context',
         dataDeclKind = kind',
-        dataDeclConstructors = constructors'
+        dataDeclConstructors = map (annotateDataConDeclName scope) constructors'
+      }
+
+resolveNewtypeDecl :: NewtypeDecl -> ResolveM NewtypeDecl
+resolveNewtypeDecl newtypeDecl = do
+  scope <- currentScope
+  declSpan <- currentSpan
+  kind' <- traverse resolveType (newtypeDeclKind newtypeDecl)
+  constructor' <- traverse resolveDataConDecl (newtypeDeclConstructor newtypeDecl)
+  pure
+    newtypeDecl
+      { newtypeDeclHead =
+          annotateBinderHeadName
+            (newtypeDeclNameAnnotation scope declSpan)
+            (newtypeDeclHead newtypeDecl),
+        newtypeDeclKind = kind',
+        newtypeDeclConstructor = annotateDataConDeclName scope <$> constructor'
       }
 
 resolveDataConDecl :: DataConDecl -> ResolveM DataConDecl
@@ -1010,52 +1034,6 @@ declBinderCandidate decl =
           Just (spanStartNameSpan outerSp (renderUnqualifiedName name), name)
         _ -> Nothing
 
-annotateTopLevelIntroducedNames :: Scope -> Decl -> Decl
-annotateTopLevelIntroducedNames scope =
-  go NoSourceSpan
-  where
-    go ambient current =
-      case current of
-        DeclAnn ann inner -> DeclAnn ann (go (pushSpanFromAnn ambient ann) inner)
-        DeclClass classDecl ->
-          DeclClass (annotateClassDeclName scope ambient classDecl)
-        DeclTypeData dataDecl ->
-          DeclTypeData (annotateDataDeclNames scope ambient "type data " dataDecl)
-        DeclData dataDecl ->
-          DeclData (annotateDataDeclNames scope ambient "data " dataDecl)
-        DeclNewtype newtypeDecl ->
-          DeclNewtype (annotateNewtypeDeclNames scope ambient newtypeDecl)
-        _ -> current
-
-annotateClassDeclName :: Scope -> SourceSpan -> ClassDecl -> ClassDecl
-annotateClassDeclName scope declSpan classDecl =
-  classDecl
-    { classDeclHead =
-        annotateBinderHeadName
-          (classNameAnnotation scope declSpan (classDeclHead classDecl))
-          (classDeclHead classDecl)
-    }
-
-annotateDataDeclNames :: Scope -> SourceSpan -> Text -> DataDecl -> DataDecl
-annotateDataDeclNames scope declSpan keyword dataDecl =
-  dataDecl
-    { dataDeclHead =
-        annotateBinderHeadName
-          (dataDeclNameAnnotation scope keyword declSpan (dataDeclHead dataDecl))
-          (dataDeclHead dataDecl),
-      dataDeclConstructors = map (annotateDataConDeclName scope) (dataDeclConstructors dataDecl)
-    }
-
-annotateNewtypeDeclNames :: Scope -> SourceSpan -> NewtypeDecl -> NewtypeDecl
-annotateNewtypeDeclNames scope declSpan newtypeDecl =
-  newtypeDecl
-    { newtypeDeclHead =
-        annotateBinderHeadName
-          (newtypeDeclNameAnnotation scope declSpan (newtypeDeclHead newtypeDecl))
-          (newtypeDeclHead newtypeDecl),
-      newtypeDeclConstructor = annotateDataConDeclName scope <$> newtypeDeclConstructor newtypeDecl
-    }
-
 annotateBinderHeadName :: (UnqualifiedName -> ResolutionAnnotation) -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName annotationFor head' =
   case head' of
@@ -1090,24 +1068,24 @@ annotateUnqualifiedName :: ResolutionAnnotation -> UnqualifiedName -> Unqualifie
 annotateUnqualifiedName annotation name =
   name {unqualifiedNameAnns = mkAnnotation annotation : unqualifiedNameAnns name}
 
-classNameAnnotation :: Scope -> SourceSpan -> BinderHead UnqualifiedName -> UnqualifiedName -> ResolutionAnnotation
-classNameAnnotation scope declSpan _ name =
+classNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
+classNameAnnotation scope declSpan name =
   ResolutionAnnotation
     (declKeywordNameSpan "class " declSpan (renderUnqualifiedName name))
     (renderUnqualifiedName name)
     ResolutionNamespaceType
     (resolveTopLevelType scope name)
 
-dataDeclNameAnnotation :: Scope -> Text -> SourceSpan -> BinderHead UnqualifiedName -> UnqualifiedName -> ResolutionAnnotation
-dataDeclNameAnnotation scope keyword declSpan _ name =
+dataDeclNameAnnotation :: Scope -> Text -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
+dataDeclNameAnnotation scope keyword declSpan name =
   ResolutionAnnotation
     (declKeywordNameSpan keyword declSpan (renderUnqualifiedName name))
     (renderUnqualifiedName name)
     ResolutionNamespaceType
     (resolveTopLevelType scope name)
 
-newtypeDeclNameAnnotation :: Scope -> SourceSpan -> BinderHead UnqualifiedName -> UnqualifiedName -> ResolutionAnnotation
-newtypeDeclNameAnnotation scope declSpan _ name =
+newtypeDeclNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
+newtypeDeclNameAnnotation scope declSpan name =
   ResolutionAnnotation
     (declKeywordNameSpan "newtype " declSpan (renderUnqualifiedName name))
     (renderUnqualifiedName name)

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -255,24 +255,21 @@ missingImportedName item namespace itemName candidates
     rendered = renderUnqualifiedName itemName
 
 data BindingGroupPolicy = BindingGroupPolicy
-  { bindingPreserveDeclAnn :: !Bool,
-    bindingDeclAnnotation :: Scope -> Decl -> Maybe ResolutionAnnotation,
+  { bindingDeclAnnotation :: Scope -> Decl -> Maybe ResolutionAnnotation,
     bindingExtraAnnotations :: Scope -> Decl -> [ResolutionAnnotation]
   }
 
 topLevelBindingPolicy :: BindingGroupPolicy
 topLevelBindingPolicy =
   BindingGroupPolicy
-    { bindingPreserveDeclAnn = True,
-      bindingDeclAnnotation = flip topLevelBinderAnnotation,
+    { bindingDeclAnnotation = flip topLevelBinderAnnotation,
       bindingExtraAnnotations = flip topLevelDeclAnnotations
     }
 
 localBindingPolicy :: Map.Map Text ResolutionAnnotation -> BindingGroupPolicy
 localBindingPolicy binderAnnotations =
   BindingGroupPolicy
-    { bindingPreserveDeclAnn = False,
-      bindingDeclAnnotation = \_ decl -> declBinderAnnotation decl binderAnnotations,
+    { bindingDeclAnnotation = \_ decl -> declBinderAnnotation decl binderAnnotations,
       bindingExtraAnnotations = \_ _ -> []
     }
 
@@ -298,11 +295,10 @@ resolveBindingDecl policy signatureScopes decl = do
 resolveDeclWithSignatureScope :: BindingGroupPolicy -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
 resolveDeclWithSignatureScope policy signatureScopes decl =
   case decl of
-    DeclAnn ann inner
-      | bindingPreserveDeclAnn policy ->
-          withPushedSpan ann $ do
-            (signatureScopes', inner') <- resolveDeclWithSignatureScope policy signatureScopes inner
-            pure (signatureScopes', DeclAnn ann inner')
+    DeclAnn ann inner ->
+      withPushedSpan ann $ do
+        (signatureScopes', inner') <- resolveDeclWithSignatureScope policy signatureScopes inner
+        pure (signatureScopes', DeclAnn ann inner')
     DeclTypeSig names ty -> do
       (binderScope, ty') <- resolveTypeSignature ty
       let signatureScopes' =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -28,6 +28,7 @@ import Aihc.Parser.Syntax
   ( ArithSeq (..),
     ArrowKind (..),
     BangType (..),
+    BinderHead (..),
     CaseAlt (..),
     ClassDecl (..),
     ClassDeclItem (..),
@@ -59,7 +60,6 @@ import Aihc.Parser.Syntax
     Type (..),
     UnqualifiedName,
     ValueDecl (..),
-    binderHeadName,
     fromAnnotation,
     mkAnnotation,
     mkUnqualifiedName,
@@ -68,6 +68,7 @@ import Aihc.Parser.Syntax
     recordFieldName,
     recordFieldValue,
     renderUnqualifiedName,
+    unqualifiedNameAnns,
   )
 import Aihc.Resolve.Monad
 import Aihc.Resolve.Scope
@@ -260,10 +261,10 @@ resolveTopLevelDecls :: Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
 resolveTopLevelDecls _ [] = pure []
 resolveTopLevelDecls signatureScopes (decl : rest) = do
   scope <- currentScope
-  emitAnnotations (topLevelIntroducedNameAnnotations scope decl)
   (signatureScopes', decl') <- resolveBindingDecl (flip topLevelBinderAnnotation) signatureScopes decl
+  let decl'' = annotateTopLevelIntroducedNames scope decl'
   decls' <- resolveTopLevelDecls signatureScopes' rest
-  pure (decl' : decls')
+  pure (decl'' : decls')
 
 resolveBindingGroup :: BindingAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
 resolveBindingGroup _ _ [] = pure []
@@ -1009,73 +1010,115 @@ declBinderCandidate decl =
           Just (spanStartNameSpan outerSp (renderUnqualifiedName name), name)
         _ -> Nothing
 
-topLevelIntroducedNameAnnotations :: Scope -> Decl -> [ResolutionAnnotation]
-topLevelIntroducedNameAnnotations scope decl =
-  case peelDeclSpan NoSourceSpan decl of
-    (declSpan, DeclClass classDecl) -> [classAnnotation scope declSpan classDecl]
-    (declSpan, DeclTypeData dataDecl) -> dataDeclAnnotations declSpan "type data " dataDecl
-    (declSpan, DeclData dataDecl) -> dataDeclAnnotations declSpan "data " dataDecl
-    (declSpan, DeclNewtype newtypeDecl) ->
-      let span' = declSpan
-          typeName = binderHeadName (newtypeDeclHead newtypeDecl)
-          typeAnnotation =
-            ResolutionAnnotation
-              (declKeywordNameSpan "newtype " span' (renderUnqualifiedName typeName))
-              (renderUnqualifiedName typeName)
-              ResolutionNamespaceType
-              (resolveTopLevelType scope typeName)
-          constructorAnnotations =
-            maybe [] (\ctor -> [dataConAnnotation scope ctor]) (newtypeDeclConstructor newtypeDecl)
-       in typeAnnotation : constructorAnnotations
-    _ -> []
+annotateTopLevelIntroducedNames :: Scope -> Decl -> Decl
+annotateTopLevelIntroducedNames scope =
+  go NoSourceSpan
   where
-    dataDeclAnnotations declSpan keyword dataDecl =
-      let span' = declSpan
-          typeName = binderHeadName (dataDeclHead dataDecl)
-          typeAnnotation =
-            ResolutionAnnotation
-              (declKeywordNameSpan keyword span' (renderUnqualifiedName typeName))
-              (renderUnqualifiedName typeName)
-              ResolutionNamespaceType
-              (resolveTopLevelType scope typeName)
-       in typeAnnotation : map (dataConAnnotation scope) (dataDeclConstructors dataDecl)
+    go ambient current =
+      case current of
+        DeclAnn ann inner -> DeclAnn ann (go (pushSpanFromAnn ambient ann) inner)
+        DeclClass classDecl ->
+          DeclClass (annotateClassDeclName scope ambient classDecl)
+        DeclTypeData dataDecl ->
+          DeclTypeData (annotateDataDeclNames scope ambient "type data " dataDecl)
+        DeclData dataDecl ->
+          DeclData (annotateDataDeclNames scope ambient "data " dataDecl)
+        DeclNewtype newtypeDecl ->
+          DeclNewtype (annotateNewtypeDeclNames scope ambient newtypeDecl)
+        _ -> current
 
-classAnnotation :: Scope -> SourceSpan -> ClassDecl -> ResolutionAnnotation
-classAnnotation scope declSpan classDecl =
-  let className = binderHeadName (classDeclHead classDecl)
-      span' = declSpan
-   in ResolutionAnnotation
-        (declKeywordNameSpan "class " span' (renderUnqualifiedName className))
-        (renderUnqualifiedName className)
-        ResolutionNamespaceType
-        (resolveTopLevelType scope className)
+annotateClassDeclName :: Scope -> SourceSpan -> ClassDecl -> ClassDecl
+annotateClassDeclName scope declSpan classDecl =
+  classDecl
+    { classDeclHead =
+        annotateBinderHeadName
+          (classNameAnnotation scope declSpan (classDeclHead classDecl))
+          (classDeclHead classDecl)
+    }
+
+annotateDataDeclNames :: Scope -> SourceSpan -> Text -> DataDecl -> DataDecl
+annotateDataDeclNames scope declSpan keyword dataDecl =
+  dataDecl
+    { dataDeclHead =
+        annotateBinderHeadName
+          (dataDeclNameAnnotation scope keyword declSpan (dataDeclHead dataDecl))
+          (dataDeclHead dataDecl),
+      dataDeclConstructors = map (annotateDataConDeclName scope) (dataDeclConstructors dataDecl)
+    }
+
+annotateNewtypeDeclNames :: Scope -> SourceSpan -> NewtypeDecl -> NewtypeDecl
+annotateNewtypeDeclNames scope declSpan newtypeDecl =
+  newtypeDecl
+    { newtypeDeclHead =
+        annotateBinderHeadName
+          (newtypeDeclNameAnnotation scope declSpan (newtypeDeclHead newtypeDecl))
+          (newtypeDeclHead newtypeDecl),
+      newtypeDeclConstructor = annotateDataConDeclName scope <$> newtypeDeclConstructor newtypeDecl
+    }
+
+annotateBinderHeadName :: (UnqualifiedName -> ResolutionAnnotation) -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
+annotateBinderHeadName annotationFor head' =
+  case head' of
+    PrefixBinderHead name params ->
+      PrefixBinderHead (annotateUnqualifiedName (annotationFor name) name) params
+    InfixBinderHead lhs name rhs params ->
+      InfixBinderHead lhs (annotateUnqualifiedName (annotationFor name) name) rhs params
+
+annotateDataConDeclName :: Scope -> DataConDecl -> DataConDecl
+annotateDataConDeclName scope =
+  go NoSourceSpan
+  where
+    go ambient current =
+      case current of
+        DataConAnn ann inner -> DataConAnn ann (go (pushSpanFromAnn ambient ann) inner)
+        PrefixCon forallVars context name bangTypes ->
+          PrefixCon forallVars context (annotateTopLevelName ambient name) bangTypes
+        RecordCon forallVars context name fields ->
+          RecordCon forallVars context (annotateTopLevelName ambient name) fields
+        InfixCon forallVars context lhs name rhs ->
+          InfixCon forallVars context lhs (annotateTopLevelName ambient name) rhs
+        GadtCon forallVars context names body ->
+          GadtCon forallVars context (map (annotateTopLevelName ambient) names) body
+        TupleCon {} -> current
+        UnboxedSumCon {} -> current
+        ListCon {} -> current
+
+    annotateTopLevelName span' name =
+      annotateUnqualifiedName (topLevelNameAnnotation scope span' name) name
+
+annotateUnqualifiedName :: ResolutionAnnotation -> UnqualifiedName -> UnqualifiedName
+annotateUnqualifiedName annotation name =
+  name {unqualifiedNameAnns = mkAnnotation annotation : unqualifiedNameAnns name}
+
+classNameAnnotation :: Scope -> SourceSpan -> BinderHead UnqualifiedName -> UnqualifiedName -> ResolutionAnnotation
+classNameAnnotation scope declSpan _ name =
+  ResolutionAnnotation
+    (declKeywordNameSpan "class " declSpan (renderUnqualifiedName name))
+    (renderUnqualifiedName name)
+    ResolutionNamespaceType
+    (resolveTopLevelType scope name)
+
+dataDeclNameAnnotation :: Scope -> Text -> SourceSpan -> BinderHead UnqualifiedName -> UnqualifiedName -> ResolutionAnnotation
+dataDeclNameAnnotation scope keyword declSpan _ name =
+  ResolutionAnnotation
+    (declKeywordNameSpan keyword declSpan (renderUnqualifiedName name))
+    (renderUnqualifiedName name)
+    ResolutionNamespaceType
+    (resolveTopLevelType scope name)
+
+newtypeDeclNameAnnotation :: Scope -> SourceSpan -> BinderHead UnqualifiedName -> UnqualifiedName -> ResolutionAnnotation
+newtypeDeclNameAnnotation scope declSpan _ name =
+  ResolutionAnnotation
+    (declKeywordNameSpan "newtype " declSpan (renderUnqualifiedName name))
+    (renderUnqualifiedName name)
+    ResolutionNamespaceType
+    (resolveTopLevelType scope name)
 
 resolveTopLevelType :: Scope -> UnqualifiedName -> ResolvedName
 resolveTopLevelType scope name = lookupType (renderUnqualifiedName name) scope
 
 resolveTopLevelTerm :: Scope -> UnqualifiedName -> ResolvedName
 resolveTopLevelTerm scope name = lookupTerm (renderUnqualifiedName name) scope
-
-dataConAnnotation :: Scope -> DataConDecl -> ResolutionAnnotation
-dataConAnnotation scope dataConDecl =
-  let span' = peelDataConSpan NoSourceSpan dataConDecl
-      go d =
-        case d of
-          DataConAnn _ inner -> go inner
-          PrefixCon _ _ name _ -> topLevelNameAnnotation scope span' name
-          RecordCon _ _ name _ -> topLevelNameAnnotation scope span' name
-          InfixCon _ _ _ name _ -> topLevelNameAnnotation scope span' name
-          GadtCon _ _ names _ ->
-            case names of
-              name : _ -> topLevelNameAnnotation scope span' name
-              [] -> ResolutionAnnotation NoSourceSpan "" ResolutionNamespaceTerm (ResolvedError "missing GADT constructor name")
-          TupleCon _ _ flavor fields ->
-            topLevelNameAnnotation scope span' (tupleConName flavor (length fields))
-          UnboxedSumCon _ _ pos arity _ ->
-            topLevelNameAnnotation scope span' (unboxedSumConName pos arity)
-          ListCon {} ->
-            topLevelNameAnnotation scope span' listConName
-   in go dataConDecl
 
 topLevelNameAnnotation :: Scope -> SourceSpan -> UnqualifiedName -> ResolutionAnnotation
 topLevelNameAnnotation scope span' name =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -254,29 +254,55 @@ missingImportedName item namespace itemName candidates
   where
     rendered = renderUnqualifiedName itemName
 
+data BindingGroupPolicy = BindingGroupPolicy
+  { bindingPreserveDeclAnn :: !Bool,
+    bindingDeclAnnotation :: Scope -> Decl -> Maybe ResolutionAnnotation,
+    bindingExtraAnnotations :: Scope -> Decl -> [ResolutionAnnotation]
+  }
+
+topLevelBindingPolicy :: BindingGroupPolicy
+topLevelBindingPolicy =
+  BindingGroupPolicy
+    { bindingPreserveDeclAnn = True,
+      bindingDeclAnnotation = flip topLevelBinderAnnotation,
+      bindingExtraAnnotations = flip topLevelDeclAnnotations
+    }
+
+localBindingPolicy :: Map.Map Text ResolutionAnnotation -> BindingGroupPolicy
+localBindingPolicy binderAnnotations =
+  BindingGroupPolicy
+    { bindingPreserveDeclAnn = False,
+      bindingDeclAnnotation = \_ decl -> declBinderAnnotation decl binderAnnotations,
+      bindingExtraAnnotations = \_ _ -> []
+    }
+
 resolveTopLevelDecls :: Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
-resolveTopLevelDecls _ [] = pure []
-resolveTopLevelDecls signatureScopes (decl : rest) = do
-  (signatureScopes', decl') <- resolveTopLevelDecl signatureScopes decl
-  decls' <- resolveTopLevelDecls signatureScopes' rest
+resolveTopLevelDecls = resolveBindingGroup topLevelBindingPolicy
+
+resolveBindingGroup :: BindingGroupPolicy -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
+resolveBindingGroup _ _ [] = pure []
+resolveBindingGroup policy signatureScopes (decl : rest) = do
+  (signatureScopes', decl') <- resolveBindingDecl policy signatureScopes decl
+  decls' <- resolveBindingGroup policy signatureScopes' rest
   pure (decl' : decls')
 
-resolveTopLevelDecl :: Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveTopLevelDecl signatureScopes decl = do
+resolveBindingDecl :: BindingGroupPolicy -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
+resolveBindingDecl policy signatureScopes decl = do
   scope <- currentScope
   let scoped = maybe scope (`unionScope` scope) (declSignatureScope decl signatureScopes)
-  (signatureScopes', decl') <- withScope scoped (resolveDeclWithSignatureScope signatureScopes decl)
-  emitAnnotations (topLevelDeclAnnotations decl scope)
-  let decl'' = maybe decl' (`annotateDecl` decl') (topLevelBinderAnnotation decl scope)
+  (signatureScopes', decl') <- withScope scoped (resolveDeclWithSignatureScope policy signatureScopes decl)
+  emitAnnotations (bindingExtraAnnotations policy scope decl)
+  let decl'' = maybe decl' (`annotateDecl` decl') (bindingDeclAnnotation policy scope decl)
   pure (signatureScopes', decl'')
 
-resolveDeclWithSignatureScope :: Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveDeclWithSignatureScope signatureScopes decl =
+resolveDeclWithSignatureScope :: BindingGroupPolicy -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
+resolveDeclWithSignatureScope policy signatureScopes decl =
   case decl of
-    DeclAnn ann inner ->
-      withPushedSpan ann $ do
-        (signatureScopes', inner') <- resolveDeclWithSignatureScope signatureScopes inner
-        pure (signatureScopes', DeclAnn ann inner')
+    DeclAnn ann inner
+      | bindingPreserveDeclAnn policy ->
+          withPushedSpan ann $ do
+            (signatureScopes', inner') <- resolveDeclWithSignatureScope policy signatureScopes inner
+            pure (signatureScopes', DeclAnn ann inner')
     DeclTypeSig names ty -> do
       (binderScope, ty') <- resolveTypeSignature ty
       let signatureScopes' =
@@ -611,40 +637,9 @@ resolveArithSeq arithSeq =
     ArithSeqFromThenTo from then' to ->
       ArithSeqFromThenTo <$> resolveExpr from <*> resolveExpr then' <*> resolveExpr to
 
-resolveBoundDecl :: Map.Map Text ResolutionAnnotation -> Decl -> ResolveM Decl
-resolveBoundDecl binderAnnotations decl = do
-  decl' <- resolveDecl decl
-  pure (maybe decl' (`annotateDecl` decl') (declBinderAnnotation decl binderAnnotations))
-
 resolveBoundDecls :: Map.Map Text ResolutionAnnotation -> Map.Map Text Scope -> [Decl] -> ResolveM [Decl]
-resolveBoundDecls _ _ [] = pure []
-resolveBoundDecls binderAnnotations signatureScopes (decl : rest) = do
-  scope <- currentScope
-  let scoped = maybe scope (`unionScope` scope) (declSignatureScope decl signatureScopes)
-  (signatureScopes', decl') <- withScope scoped (resolveBoundDeclWithSignatureScope binderAnnotations signatureScopes decl)
-  decls' <- resolveBoundDecls binderAnnotations signatureScopes' rest
-  pure (decl' : decls')
-
-resolveBoundDeclWithSignatureScope :: Map.Map Text ResolutionAnnotation -> Map.Map Text Scope -> Decl -> ResolveM (Map.Map Text Scope, Decl)
-resolveBoundDeclWithSignatureScope binderAnnotations signatureScopes decl =
-  case decl of
-    DeclTypeSig names ty -> do
-      (binderScope, ty') <- resolveTypeSignature ty
-      let signatureScopes' =
-            foldl'
-              (\acc name -> Map.insert (renderUnqualifiedName name) binderScope acc)
-              signatureScopes
-              names
-          resolvedDecl = DeclTypeSig names ty'
-          annotatedDecl = maybe resolvedDecl (`annotateDecl` resolvedDecl) (declBinderAnnotation decl binderAnnotations)
-      pure (signatureScopes', annotatedDecl)
-    _ -> do
-      decl' <- resolveBoundDecl binderAnnotations decl
-      let signatureScopes' =
-            case declBinderCandidate decl of
-              Just (_, name) -> Map.delete (renderUnqualifiedName name) signatureScopes
-              Nothing -> signatureScopes
-      pure (signatureScopes', decl')
+resolveBoundDecls binderAnnotations =
+  resolveBindingGroup (localBindingPolicy binderAnnotations)
 
 declSignatureScope :: Decl -> Map.Map Text Scope -> Maybe Scope
 declSignatureScope decl signatureScopes =

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -29,7 +29,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     SourceSpan (..),
     Type (..),
-    UnqualifiedName,
+    UnqualifiedName (..),
     fromAnnotation,
     moduleName,
     renderName,
@@ -171,6 +171,8 @@ ownAnnotation node =
   declResolution (cast node)
     <> classDeclItemResolution (cast node)
     <> importResolution (cast node)
+    <> nameResolution (cast node)
+    <> unqualifiedNameResolution (cast node)
     <> patternResolution (cast node)
     <> typeResolution (cast node)
     <> exprResolution (cast node)
@@ -191,6 +193,18 @@ importResolution :: Maybe ImportDecl -> [ResolutionAnnotation]
 importResolution maybeImport =
   case maybeImport of
     Just importDecl -> importResolutionAnnotations importDecl
+    _ -> []
+
+nameResolution :: Maybe Name -> [ResolutionAnnotation]
+nameResolution maybeName =
+  case maybeName of
+    Just name -> mapMaybe fromAnnotation (nameAnns name)
+    _ -> []
+
+unqualifiedNameResolution :: Maybe UnqualifiedName -> [ResolutionAnnotation]
+unqualifiedNameResolution maybeName =
+  case maybeName of
+    Just name -> mapMaybe fromAnnotation (unqualifiedNameAnns name)
     _ -> []
 
 patternResolution :: Maybe Pattern -> [ResolutionAnnotation]


### PR DESCRIPTION
## Summary

- Add `BindingGroupPolicy` to describe binder annotation and generated-annotation behavior.
- Route top-level and local declaration groups through one `resolveBindingGroup` traversal.
- Remove the separate local bound-declaration resolver while preserving existing top-level/local policy differences.
- Always preserve declaration annotations during binding resolution, removing the `bindingPreserveDeclAnn` policy switch.
- Replace the binding policy record with an explicit term-definition resolver.
- Add annotation lists to `Name` and `UnqualifiedName`, collect name-level resolution annotations, and resolve usage/definition annotations at the name occurrence rather than through declaration/type/expression/pattern wrappers.

## Progress counts

- Resolver support counts: unchanged; this is a behavior-preserving refactor and README progress files were not updated.

## Validation

- `cabal test -v0 aihc-resolve:spec --test-options="--pattern resolver-golden"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
