### PR TITLE
fix(parser): parenthesize multi-way if in infix and greedy contexts

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -110,6 +110,7 @@ isGreedyExpr = \case
   EAnn _ sub -> isGreedyExpr sub
   ECase {} -> True
   EIf {} -> True
+  EMultiWayIf {} -> True
   ELambdaPats {} -> True
   ELambdaCase {} -> True
   ELambdaCases {} -> True
@@ -130,7 +131,7 @@ isBracedExpr :: Expr -> Bool
 isBracedExpr = \case
   EAnn _ sub -> isBracedExpr sub
   ECase _ [] -> True
-  EMultiWayIf {} -> True
+  -- Multi-way if renders as layout-sensitive @if | ...@, not a braced form.
   EDo {} -> True
   ELambdaCase {} -> True
   ELambdaCases {} -> True
@@ -143,6 +144,7 @@ isOpenEnded = \case
   EAnn _ sub -> isOpenEnded sub
   ECase _ alts -> not (null alts)
   EIf {} -> True
+  EMultiWayIf {} -> True
   ELambdaPats {} -> True
   ELambdaCases {} -> True
   ELetDecls {} -> True

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -143,6 +143,7 @@ buildTests = do
             testCase "pretty-prints let expressions with implicit layout" test_prettyLetExpressionUsesImplicitLayout,
             testCase "pretty-prints negated layout-ending list-comprehension bodies" test_prettyNegatedLayoutEndingListCompBody,
             testCase "pretty-prints layout let guards in multi-way if" test_prettyLayoutLetGuardInMultiWayIf,
+            testCase "pretty-prints multi-way if left operands with parentheses" test_prettyMultiWayIfInfixLhs,
             testCase "pretty-prints where clauses with implicit layout" test_prettyWhereClauseUsesImplicitLayout,
             testCase "pretty-prints GADT constructors with implicit layout" test_prettyGadtConstructorsUseImplicitLayout,
             testCase "pretty-prints lambda-case expressions with implicit layout" test_prettyLambdaCaseExpressionUsesImplicitLayout,
@@ -988,6 +989,37 @@ test_prettyLayoutLetGuardInMultiWayIf = do
             "     case '5' of",
             "       (+) ->",
             "         0"
+          ]
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
+  assertEqual "pretty-printed expression" expected rendered
+  case parseExpr config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed expression to reparse, got:\n" <> MPE.errorBundlePretty bundle)
+
+test_prettyMultiWayIfInfixLhs :: Assertion
+test_prettyMultiWayIfInfixLhs = do
+  let config = defaultConfig {parserExtensions = [MultiWayIf]}
+      op = qualifyName Nothing (mkUnqualifiedName NameVarId "a")
+      expr =
+        EInfix
+          ( EMultiWayIf
+              [ GuardedRhs
+                  []
+                  [GuardExpr (EVar (qualifyName Nothing (mkUnqualifiedName NameConId "True")))]
+                  (ETuple Boxed [])
+              ]
+          )
+          op
+          (EChar 'x' "'x'")
+      expected =
+        T.intercalate
+          "\n"
+          [ "(if | True",
+            "     ->",
+            "      ())",
+            " `a` 'x'"
           ]
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))
   assertEqual "pretty-printed expression" expected rendered

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/left-infix-roundtrip.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultiWayIf/left-infix-roundtrip.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MultiWayIf #-}
+module MultiWayIfLeftInfixRoundtrip where
+
+f = (if | True -> ()) `a` 'x'


### PR DESCRIPTION
## Summary
- treat `EMultiWayIf` as layout-sensitive instead of braced in `Parens`, so multi-way if expressions are parenthesized in infix and other greedy contexts where `if | ...` would otherwise absorb trailing syntax
- add a focused pretty-print regression for a multi-way if used as an infix left operand and an oracle fixture covering the corresponding GHC-accepted roundtrip
- Parser oracle progress: pass 1120 -> 1121 (+1), xfail 0 -> 0, xpass 0 -> 0, fail 0 -> 0, completion 100.00% -> 100.00%

## Testing
- `just check`

## CodeRabbit
- Skipped the "undefined infix identifier `a`" finding for the oracle fixture: oracle cases validate parser/GHC AST roundtrips rather than name resolution, and `just check` passes the new fixture as-is.