### PR TITLE
fix(parser): parenthesize layout-ending arrow-command lhs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1713,6 +1713,7 @@ endsWithCmdLayoutBlock = \case
   EAnn _ sub -> endsWithCmdLayoutBlock sub
   EDo {} -> True
   ELambdaCase {} -> True
+  ELambdaCases {} -> True
   EApp _ arg -> endsWithCmdLayoutBlock arg
   _ -> False
 

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1694,7 +1694,27 @@ addCmdParens cmd =
 
 addCmdArrAppLhsParens :: Expr -> Expr
 addCmdArrAppLhsParens lhs =
-  wrapExpr (startsWithBlockExpr lhs || isOpenEnded lhs || endsWithTypeSig lhs) (addExprParensPrec 1 lhs)
+  wrapExpr (startsWithBlockExpr lhs || isOpenEnded lhs || endsWithTypeSig lhs || endsWithCmdLayoutTail lhs) (addExprParensPrec 1 lhs)
+
+-- | Arrow tails are parsed outside the expression grammar, so a command lhs that
+-- ends in a layout block needs explicit grouping even when the same expression
+-- can stay bare before ordinary expression suffixes like @::@ or @\@-type apps.
+endsWithCmdLayoutTail :: Expr -> Bool
+endsWithCmdLayoutTail = \case
+  EAnn _ sub -> endsWithCmdLayoutTail sub
+  EInfix _ _ rhs -> endsWithCmdLayoutTail rhs
+  ENegate inner -> endsWithCmdLayoutTail inner
+  EPragma _ inner -> endsWithCmdLayoutTail inner
+  EApp _ arg -> endsWithCmdLayoutBlock arg
+  _ -> False
+
+endsWithCmdLayoutBlock :: Expr -> Bool
+endsWithCmdLayoutBlock = \case
+  EAnn _ sub -> endsWithCmdLayoutBlock sub
+  EDo {} -> True
+  ELambdaCase {} -> True
+  EApp _ arg -> endsWithCmdLayoutBlock arg
+  _ -> False
 
 addCmdArrAppRhsParens :: Expr -> Expr
 addCmdArrAppRhsParens rhs =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -163,6 +163,7 @@ buildTests = do
             testCase "pretty-prints symbolic deriving classes as prefix constructors" test_prettySymbolicDerivingClass,
             testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
+            testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -1554,6 +1555,54 @@ test_viewExprArrowCommandTypeSigRhsParens = do
       assertEqual "reparsed pattern" (stripAnnotations parenthesized) (stripAnnotations reparsed)
     ParseErr bundle ->
       assertFailure ("expected pretty-printed pattern to reparse, got:\n" <> MPE.errorBundlePretty bundle)
+
+test_arrowCommandLhsLambdaCaseParens :: Assertion
+test_arrowCommandLhsLambdaCaseParens = do
+  let config = defaultConfig {parserExtensions = [Arrows, BlockArguments, LambdaCase]}
+      decl =
+        DeclValue
+          ( PatternBind
+              NoMultiplicityTag
+              (PLit (LitInt 0 TInteger "0"))
+              ( UnguardedRhs
+                  []
+                  ( EProc
+                      (PVar (mkUnqualifiedName NameVarId "a"))
+                      ( CmdArrApp
+                          ( EApp
+                              (EList [])
+                              ( ELambdaCase
+                                  [ CaseAlt
+                                      []
+                                      (PCon (qualifyName Nothing (mkUnqualifiedName NameConId "C")) [] [])
+                                      (UnguardedRhs [] (EList []) Nothing)
+                                  ]
+                              )
+                          )
+                          HsFirstOrderApp
+                          (ETuple Boxed [])
+                      )
+                  )
+                  Nothing
+              )
+          )
+      parenthesized = addDeclParens decl
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty parenthesized))
+      expected =
+        T.intercalate
+          "\n"
+          [ "0 =",
+            "  proc a -> ([]",
+            "    \\case",
+            "      C ->",
+            "        []) -< ()"
+          ]
+  assertEqual "rendered declaration" expected rendered
+  case parseDecl config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed declaration" (stripAnnotations parenthesized) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed declaration to reparse, got:\n" <> MPE.errorBundlePretty bundle)
 
 test_roundtripDiffIsMinimal :: Assertion
 test_roundtripDiffIsMinimal =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -164,6 +164,7 @@ buildTests = do
             testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
+            testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -1594,6 +1595,54 @@ test_arrowCommandLhsLambdaCaseParens = do
           [ "0 =",
             "  proc a -> ([]",
             "    \\case",
+            "      C ->",
+            "        []) -< ()"
+          ]
+  assertEqual "rendered declaration" expected rendered
+  case parseDecl config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed declaration" (stripAnnotations parenthesized) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed declaration to reparse, got:\n" <> MPE.errorBundlePretty bundle)
+
+test_arrowCommandLhsLambdaCasesParens :: Assertion
+test_arrowCommandLhsLambdaCasesParens = do
+  let config = defaultConfig {parserExtensions = [Arrows, BlockArguments, LambdaCase]}
+      decl =
+        DeclValue
+          ( PatternBind
+              NoMultiplicityTag
+              (PLit (LitInt 0 TInteger "0"))
+              ( UnguardedRhs
+                  []
+                  ( EProc
+                      (PVar (mkUnqualifiedName NameVarId "a"))
+                      ( CmdArrApp
+                          ( EApp
+                              (EList [])
+                              ( ELambdaCases
+                                  [ LambdaCaseAlt
+                                      []
+                                      [PCon (qualifyName Nothing (mkUnqualifiedName NameConId "C")) [] []]
+                                      (UnguardedRhs [] (EList []) Nothing)
+                                  ]
+                              )
+                          )
+                          HsFirstOrderApp
+                          (ETuple Boxed [])
+                      )
+                  )
+                  Nothing
+              )
+          )
+      parenthesized = addDeclParens decl
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty parenthesized))
+      expected =
+        T.intercalate
+          "\n"
+          [ "0 =",
+            "  proc a -> ([]",
+            "    \\cases",
             "      C ->",
             "        []) -< ()"
           ]


### PR DESCRIPTION
## Summary
- parenthesize arrow-command left operands when an application ends in a layout-sensitive tail that would otherwise absorb `-<` or `-<<`
- cover both `\case` and `\cases` in the new command-lhs predicate, and add focused regressions for each shrunk `proc` round-trip shape
- Progress counts: unchanged; this fix tightens parser round-trip correctness without adding oracle or golden fixtures

## Testing
- `just replay "(SMGen 3462988847251563096 2673833702393577797,86)"`
- `just fmt`
- `just check`

## CodeRabbit
- `coderabbit review --prompt-only` (no findings after adding `\cases` coverage)