### PR TITLE
fix(parser): parenthesize typed multi-way if view expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -160,6 +160,10 @@ endsWithTypeSig = \case
   ETypeSig {} -> True
   ELetDecls _ body -> endsWithTypeSig body
   ELambdaPats _ body -> endsWithTypeSig body
+  EMultiWayIf rhss ->
+    case reverse rhss of
+      grhs : _ -> endsWithTypeSig (guardedRhsBody grhs)
+      [] -> False
   EInfix _ _ rhs -> endsWithTypeSig rhs
   EApp _ arg -> endsWithTypeSig arg
   EIf _ _ no -> endsWithTypeSig no

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -175,6 +175,7 @@ buildTests = do
             testCase "pretty-prints symbolic deriving classes as prefix constructors" test_prettySymbolicDerivingClass,
             testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
+            testCase "parenthesizes multi-way if view expressions ending with type signatures in decls" test_viewExprMultiWayIfTypeSigParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
@@ -1559,6 +1560,52 @@ test_viewExprAppliedTypeSigParens = do
       assertEqual "reparsed pattern" (stripAnnotations parenthesized) (stripAnnotations reparsed)
     ParseErr bundle ->
       assertFailure ("expected pretty-printed pattern to reparse, got:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_viewExprMultiWayIfTypeSigParens :: Assertion
+test_viewExprMultiWayIfTypeSigParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      decl =
+        DeclValue
+          ( PatternBind
+              NoMultiplicityTag
+              ( PUnboxedSum
+                  0
+                  3
+                  ( PView
+                      ( EMultiWayIf
+                          [ GuardedRhs
+                              []
+                              [GuardLet []]
+                              (ETypeSig (EChar 'G' "'G'") TStar)
+                          ]
+                      )
+                      (PLit (LitInt 0 TInteger "0"))
+                  )
+              )
+              (UnguardedRhs [] (EArithSeq (ArithSeqFrom (ELambdaCases []))) Nothing)
+          )
+      parenthesized = addDeclParens decl
+      rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty parenthesized))
+  assertEqual
+    "rendered decl"
+    ( T.intercalate
+        "\n"
+        [ "(# (if | let {  }",
+          "        ->",
+          "         'G'",
+          "          :: *)",
+          "      -> 0",
+          "     | ",
+          "     |  #) =",
+          "  [(\\cases {  }) ..]"
+        ]
+    )
+    rendered
+  case parseDecl config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed decl" (stripAnnotations parenthesized) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected pretty-printed decl to reparse, got:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
 
 test_viewExprArrowCommandTypeSigRhsParens :: Assertion
 test_viewExprArrowCommandTypeSigRhsParens = do


### PR DESCRIPTION
## Summary
- treat `EMultiWayIf` as ending in a type signature when its final guarded body does, so `addViewExprParens` wraps view expressions that would otherwise print invalid declaration syntax
- add a declaration-level regression covering an unboxed-sum view pattern with a typed multi-way `if`, matching the QuickCheck replay that was failing
- verified with the failing QuickCheck replay, `just fmt`, `just check`, and a clean CodeRabbit prompt-only review