### PR TITLE
test(fc): add YAML evaluation fixtures

### DIFF
--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -41,6 +41,7 @@ test-suite spec
 
   main-is: Spec.hs
   other-modules:
+    FcEvalGolden
     FcGolden
     Test.Fc.Suite
 

--- a/components/aihc-fc/common/FcEvalGolden.hs
+++ b/components/aihc-fc/common/FcEvalGolden.hs
@@ -1,0 +1,317 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Golden test infrastructure for System FC evaluation fixtures.
+module FcEvalGolden
+  ( Outcome (..),
+    FcEvalCase (..),
+    evalFixtureRoot,
+    loadFcEvalCases,
+    evaluateFcEvalCase,
+  )
+where
+
+import Aihc.Fc (DesugarResult (..), desugarModuleWithTcResult, evalProgramBinding, renderRawValue)
+import Aihc.Parser
+  ( ParseResult (..),
+    ParserConfig (..),
+    defaultConfig,
+    parseExpr,
+    parseModule,
+  )
+import Aihc.Parser.Syntax
+  ( Decl (..),
+    Expr,
+    Extension,
+    Match (..),
+    MatchHeadForm (..),
+    Module (..),
+    NameType (..),
+    Pattern (..),
+    Rhs (..),
+    UnqualifiedName (..),
+    ValueDecl (..),
+    mkUnqualifiedName,
+    parseExtensionName,
+  )
+import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), TcType (..), TyCon (..))
+import Data.Aeson ((.!=), (.:), (.:?))
+import Data.Aeson.Types (parseEither, withArray, withObject)
+import Data.Char (isSpace, toLower)
+import Data.List (dropWhileEnd, sort)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Yaml qualified as Y
+import System.Directory (doesDirectoryExist, listDirectory)
+import System.FilePath (takeDirectory, takeExtension, (</>))
+
+data ExpectedStatus
+  = StatusPass
+  | StatusFail
+  | StatusXPass
+  | StatusXFail
+  deriving (Eq, Show)
+
+data Outcome
+  = OutcomePass
+  | OutcomeXFail
+  | OutcomeXPass
+  | OutcomeFail
+  deriving (Eq, Show)
+
+data FcEvalCase = FcEvalCase
+  { evalCaseId :: !String,
+    evalCaseCategory :: !String,
+    evalCasePath :: !FilePath,
+    evalCaseExtensions :: ![Extension],
+    evalCaseModules :: ![Text],
+    evalCaseExpression :: !Text,
+    evalCaseOutput :: !String,
+    evalCaseStatus :: !ExpectedStatus,
+    evalCaseReason :: !String
+  }
+  deriving (Eq, Show)
+
+evalFixtureRoot :: FilePath
+evalFixtureRoot = "test/Test/Fixtures/eval"
+
+evalBindingName :: Text
+evalBindingName = "__aihc_eval__"
+
+loadFcEvalCases :: IO [FcEvalCase]
+loadFcEvalCases = do
+  exists <- doesDirectoryExist evalFixtureRoot
+  if not exists
+    then pure []
+    else do
+      paths <- listFixtureFiles evalFixtureRoot
+      mapM loadFcEvalCase paths
+
+loadFcEvalCase :: FilePath -> IO FcEvalCase
+loadFcEvalCase path = do
+  raw <- Y.decodeFileEither path
+  case raw of
+    Left err -> fail ("Invalid YAML eval fixture " <> path <> ": " <> Y.prettyPrintParseException err)
+    Right value -> case parseFcEvalFixture path value of
+      Left e -> fail e
+      Right c -> pure c
+
+parseFcEvalFixture :: FilePath -> Y.Value -> Either String FcEvalCase
+parseFcEvalFixture path value = do
+  (extNames, modules, expression, output, statusText, reasonText) <-
+    parseEither
+      ( withObject "fc eval fixture" $ \obj -> do
+          exts <- obj .: "extensions"
+          mods <- obj .: "modules" >>= parseModules
+          expr <- obj .: "expression"
+          expected <- obj .: "output"
+          status <- obj .: "status"
+          reason <- obj .:? "reason" .!= ""
+          pure (exts, mods, expr, expected, status, reason)
+      )
+      value
+  if null modules
+    then Left ("Eval fixture must define at least one module in " <> path)
+    else do
+      exts <- validateExtensions path extNames
+      status <- parseStatus path statusText
+      let relPath = dropRootPrefix path
+          category = categoryFromPath relPath
+      pure
+        FcEvalCase
+          { evalCaseId = relPath,
+            evalCaseCategory = category,
+            evalCasePath = relPath,
+            evalCaseExtensions = exts,
+            evalCaseModules = modules,
+            evalCaseExpression = expression,
+            evalCaseOutput = trim (T.unpack output),
+            evalCaseStatus = status,
+            evalCaseReason = trim (T.unpack reasonText)
+          }
+
+parseModules :: Y.Value -> Y.Parser [Text]
+parseModules = withArray "modules" $ \arr ->
+  mapM parseModuleEntry (foldr (:) [] arr)
+  where
+    parseModuleEntry (Y.String t) = pure t
+    parseModuleEntry _ = fail "each module must be a string"
+
+evaluateFcEvalCase :: FcEvalCase -> (Outcome, String)
+evaluateFcEvalCase tc =
+  case parseInputs tc of
+    Left errMsg -> classifyFailure tc errMsg
+    Right (modules, expr) ->
+      let evalModule = combineModules modules expr
+          result = desugarModuleWithTcResult (syntheticTcResult evalModule) evalModule
+       in if dsSuccess result
+            then case evalProgramBinding evalBindingName (dsProgram result) >>= renderRawValue of
+              Right actual -> classifySuccess tc (T.unpack actual)
+              Left err -> classifyFailure tc ("eval error: " <> show err)
+            else classifyFailure tc ("desugar error: " <> unlines (dsErrors result))
+
+parseInputs :: FcEvalCase -> Either String ([Module], Expr)
+parseInputs tc = do
+  modules <- mapM parseOneModule (evalCaseModules tc)
+  expr <- parseOneExpr (evalCaseExpression tc)
+  pure (modules, expr)
+  where
+    config source =
+      defaultConfig
+        { parserSourceName = source,
+          parserExtensions = evalCaseExtensions tc
+        }
+    parseOneModule input =
+      let cfg = config (T.unpack (T.takeWhile (/= '\n') input))
+          (errs, ast) = parseModule cfg input
+       in if null errs
+            then Right ast
+            else Left ("parse module error: " <> show errs)
+    parseOneExpr input =
+      case parseExpr (config (evalCasePath tc <> ":expression")) input of
+        ParseOk expr -> Right expr
+        ParseErr err -> Left ("parse expression error: " <> show err)
+
+combineModules :: [Module] -> Expr -> Module
+combineModules modules expr =
+  case modules of
+    [] -> emptyEvalModule expr
+    firstModule : _ ->
+      firstModule
+        { moduleLanguagePragmas = concatMap moduleLanguagePragmas modules,
+          moduleImports = concatMap moduleImports modules,
+          moduleDecls = concatMap moduleDecls modules <> [evalDecl expr]
+        }
+
+emptyEvalModule :: Expr -> Module
+emptyEvalModule expr =
+  Module
+    { moduleAnns = [],
+      moduleHead = Nothing,
+      moduleLanguagePragmas = [],
+      moduleImports = [],
+      moduleDecls = [evalDecl expr]
+    }
+
+evalDecl :: Expr -> Decl
+evalDecl expr =
+  DeclValue $
+    FunctionBind
+      (mkUnqualifiedName NameVarId evalBindingName)
+      [ Match
+          { matchAnns = [],
+            matchHeadForm = MatchHeadPrefix,
+            matchPats = [],
+            matchRhs = UnguardedRhs [] expr Nothing
+          }
+      ]
+
+syntheticTcResult :: Module -> TcModuleResult
+syntheticTcResult modu =
+  TcModuleResult
+    { tcmBindings = concatMap bindingTypes (moduleDecls modu),
+      tcmDiagnostics = [],
+      tcmSuccess = True
+    }
+
+bindingTypes :: Decl -> [TcBindingResult]
+bindingTypes decl =
+  case decl of
+    DeclAnn _ inner -> bindingTypes inner
+    DeclValue (FunctionBind name matches) ->
+      [TcBindingResult (unqualifiedNameText name) (functionType (matchArity matches))]
+    DeclValue (PatternBind _ pat _) ->
+      [TcBindingResult name unknownTy | Just name <- [barePatternName pat]]
+    _ -> []
+
+matchArity :: [Match] -> Int
+matchArity [] = 0
+matchArity (match : _) = length (matchPats match)
+
+functionType :: Int -> TcType
+functionType arity =
+  foldr TcFunTy unknownTy (replicate arity unknownTy)
+
+unknownTy :: TcType
+unknownTy = TcTyCon (TyCon "?" 0) []
+
+barePatternName :: Pattern -> Maybe Text
+barePatternName pat =
+  case pat of
+    PVar name -> Just (unqualifiedNameText name)
+    PAnn _ inner -> barePatternName inner
+    PParen inner -> barePatternName inner
+    _ -> Nothing
+
+classifySuccess :: FcEvalCase -> String -> (Outcome, String)
+classifySuccess tc actual =
+  case evalCaseStatus tc of
+    StatusPass
+      | trim actual == trim (evalCaseOutput tc) -> (OutcomePass, "")
+      | otherwise ->
+          ( OutcomeFail,
+            "output mismatch\nexpected:\n" <> evalCaseOutput tc <> "\nactual:\n" <> trim actual
+          )
+    StatusFail ->
+      (OutcomeFail, "expected failure but evaluation succeeded")
+    StatusXFail
+      | trim actual == trim (evalCaseOutput tc) -> (OutcomeXPass, "")
+      | otherwise -> (OutcomeXFail, "")
+    StatusXPass
+      | trim actual == trim (evalCaseOutput tc) -> (OutcomeXPass, "known bug still passes")
+      | otherwise ->
+          (OutcomeFail, "expected xpass output match but got: " <> trim actual)
+
+classifyFailure :: FcEvalCase -> String -> (Outcome, String)
+classifyFailure tc errDetails =
+  case evalCaseStatus tc of
+    StatusPass -> (OutcomeFail, "expected success, got error: " <> errDetails)
+    StatusFail -> (OutcomePass, "")
+    StatusXFail -> (OutcomeXFail, "")
+    StatusXPass -> (OutcomeFail, "expected xpass, got error: " <> errDetails)
+
+listFixtureFiles :: FilePath -> IO [FilePath]
+listFixtureFiles dir = do
+  entries <- sort <$> listDirectory dir
+  concat
+    <$> mapM
+      ( \entry -> do
+          let path = dir </> entry
+          isDir <- doesDirectoryExist path
+          if isDir
+            then listFixtureFiles path
+            else
+              if takeExtension path `elem` [".yaml", ".yml"]
+                then pure [path]
+                else pure []
+      )
+      entries
+
+validateExtensions :: FilePath -> [Text] -> Either String [Extension]
+validateExtensions path = traverse parseOne
+  where
+    parseOne raw =
+      case parseExtensionName raw of
+        Just ext -> Right ext
+        Nothing -> Left ("Unknown extension " <> show raw <> " in " <> path)
+
+parseStatus :: FilePath -> Text -> Either String ExpectedStatus
+parseStatus path raw =
+  case map toLower (trim (T.unpack raw)) of
+    "pass" -> Right StatusPass
+    "fail" -> Right StatusFail
+    "xpass" -> Right StatusXPass
+    "xfail" -> Right StatusXFail
+    _ -> Left ("Invalid status in " <> path <> ": " <> T.unpack raw)
+
+dropRootPrefix :: FilePath -> FilePath
+dropRootPrefix path =
+  maybe path T.unpack (T.stripPrefix (T.pack (evalFixtureRoot <> "/")) (T.pack path))
+
+categoryFromPath :: FilePath -> String
+categoryFromPath path =
+  case takeDirectory path of
+    "." -> "eval"
+    dir -> dir
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -21,6 +21,7 @@ module Aihc.Fc
     evalProgramBinding,
     evalExpr,
     renderValue,
+    renderRawValue,
     EvalError (..),
     Value (..),
 
@@ -39,7 +40,7 @@ module Aihc.Fc
 where
 
 import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithTcResult)
-import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderValue)
+import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)
 import Aihc.Fc.Pretty (renderExpr, renderProgram, renderTopBind, renderType)
 import Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -7,6 +7,7 @@ module Aihc.Fc.Eval
     evalProgramBinding,
     evalExpr,
     renderValue,
+    renderRawValue,
   )
 where
 
@@ -216,3 +217,25 @@ renderLiteral lit =
     LitInt i -> T.pack (show i)
     LitChar c -> T.pack (show c)
     LitString s -> T.pack (show (T.unpack s))
+
+renderRawValue :: Value -> Either EvalError Text
+renderRawValue value = do
+  forced <- forceValue value
+  case forced of
+    VLit lit -> pure (renderLiteral lit)
+    VConstructor name [] -> pure name
+    VConstructor name args -> do
+      renderedArgs <- mapM renderRawArg args
+      pure (T.unwords (name : renderedArgs))
+    VClosure {} -> pure "<function>"
+    VPrim {} -> pure "<function>"
+    VThunk {} -> renderRawValue forced
+
+renderRawArg :: Value -> Either EvalError Text
+renderRawArg value = do
+  forced <- forceValue value
+  rendered <- renderRawValue forced
+  pure $
+    case forced of
+      VConstructor _ (_ : _) -> "(" <> rendered <> ")"
+      _ -> rendered

--- a/components/aihc-fc/test/Spec.hs
+++ b/components/aihc-fc/test/Spec.hs
@@ -1,17 +1,19 @@
 module Main (main) where
 
-import Test.Fc.Suite (fcEvalTests, fcGoldenTests)
+import Test.Fc.Suite (fcEvalFixtureTests, fcEvalTests, fcGoldenTests)
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.QuickCheck qualified as QC
 
 main :: IO ()
 main = do
   golden <- fcGoldenTests
+  evalFixtures <- fcEvalFixtureTests
   defaultMain
     ( testGroup
         "aihc-fc"
         [ golden,
           fcEvalTests,
+          evalFixtures,
           QC.testProperty "dummy quickcheck property" prop_dummy
         ]
     )

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -4,12 +4,14 @@
 module Test.Fc.Suite
   ( fcGoldenTests,
     fcEvalTests,
+    fcEvalFixtureTests,
   )
 where
 
 import Aihc.Fc
 import Aihc.Tc (TcType (..), TyCon (..), Unique (..))
 import Data.Text (Text)
+import FcEvalGolden qualified as EvalGolden
 import FcGolden
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
@@ -50,8 +52,28 @@ fcEvalTests =
                 [ FcTopBind
                     (FcNonRec (var "answer" stringTy) (FcLit (LitString "top")))
                 ]
-         in assertEqual "result" (Right "\"top\"") (evalProgramBinding "answer" program >>= renderValue)
+         in assertEqual "result" (Right "\"top\"") (evalProgramBinding "answer" program >>= renderValue),
+      testCase "renders raw constructor values" $
+        assertEqual
+          "raw result"
+          (Right ": 'x' []")
+          (renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []]))
     ]
+
+fcEvalFixtureTests :: IO TestTree
+fcEvalFixtureTests = do
+  cases <- EvalGolden.loadFcEvalCases
+  let tests = map mkEvalFixtureTest cases
+  pure (testGroup "FC evaluation fixtures" tests)
+
+mkEvalFixtureTest :: EvalGolden.FcEvalCase -> TestTree
+mkEvalFixtureTest tc = testCase (EvalGolden.evalCaseId tc) $ do
+  let (outcome, details) = EvalGolden.evaluateFcEvalCase tc
+  case outcome of
+    EvalGolden.OutcomePass -> pure ()
+    EvalGolden.OutcomeXFail -> pure ()
+    EvalGolden.OutcomeXPass -> assertFailure ("unexpected pass (xpass): " <> details)
+    EvalGolden.OutcomeFail -> assertFailure details
 
 assertEvalExpr :: Text -> FcExpr -> IO ()
 assertEvalExpr expected expr =

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-append.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-append.yaml
@@ -1,0 +1,13 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    (++) :: [a] -> [a] -> [a]
+    [] ++ bs = bs
+    (a:as) ++ bs = a : (as ++ bs)
+output: |
+  : 'a' (: 'b' [])
+expression: |
+  ['a'] ++ ['b']
+status: pass
+reason: evaluates a module-defined list append operator

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-literal.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-literal.yaml
@@ -1,0 +1,10 @@
+extensions: []
+modules:
+  - |
+    module Test where
+output: |
+  : 'x' []
+expression: |
+  ['x']
+status: pass
+reason: renders evaluated list literals in raw constructor form

--- a/components/aihc-fc/test/Test/Fixtures/eval/module-binding.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/module-binding.yaml
@@ -1,0 +1,11 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    answer x = x
+output: |
+  'z'
+expression: |
+  answer 'z'
+status: pass
+reason: evaluates expressions that reference module bindings


### PR DESCRIPTION
## Summary

- add YAML-driven FC evaluation fixtures under `components/aihc-fc/test/Test/Fixtures/eval`
- add a fixture loader that parses block-scalar modules/expressions, appends a synthetic eval binding, desugars, evaluates, and compares raw FC constructor output
- expose `renderRawValue` for raw evaluated constructor rendering and cover it with HUnit

## Validation

- `cabal test -v0 aihc-fc:spec --test-options=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)

## Progress Counts

- No README progress counts updated; this change adds `aihc-fc` test infrastructure and fixtures rather than parser oracle/progress-count coverage.
