### PR TITLE
fix(parser): avoid spurious parens in arrow and multiway contexts

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -297,6 +297,7 @@ needsExprParens ctx expr =
         -- correctly re-parsed as `(-x) + 1`.
         ENegate inner -> isOpenEnded inner
         ECase {} -> False
+        EMultiWayIf {} -> False
         _ -> isOpenEnded expr
     CtxAppFun ->
       case expr of
@@ -1106,7 +1107,7 @@ addExprParensPrec prec expr =
     ETuple tupleFlavor values -> ETuple tupleFlavor (map (fmap addExprParens) values)
     EUnboxedSum altIdx arity inner -> EUnboxedSum altIdx arity (addExprParens inner)
     EProc pat body ->
-      wrapExpr (prec > 0) (EProc (addArrowBndrPatternParens pat) (addCmdParens body))
+      wrapExpr (prec > 0) (EProc (addArrowBndrPatternParens pat) (addCmdParensIn CtxCmdTop body))
     EPragma pragma inner ->
       -- EPragma is transparent w.r.t. precedence: wrapping decisions are made
       -- by the outer context via needsExprParens, not by a self-prec check.
@@ -1650,12 +1651,19 @@ addPatternAtomStrictParens pat =
 -- Arrow commands
 -- ---------------------------------------------------------------------------
 
+data CmdCtx
+  = CtxCmdTop
+  | CtxCmdDoStmt
+
 addCmdParens :: Cmd -> Cmd
-addCmdParens cmd =
+addCmdParens = addCmdParensIn CtxCmdTop
+
+addCmdParensIn :: CmdCtx -> Cmd -> Cmd
+addCmdParensIn ctx cmd =
   case cmd of
-    CmdAnn ann inner -> CmdAnn ann (addCmdParens inner)
+    CmdAnn ann inner -> CmdAnn ann (addCmdParensIn ctx inner)
     CmdArrApp lhs appTy rhs ->
-      CmdArrApp (addCmdArrAppLhsParens lhs) appTy (addCmdArrAppRhsParens rhs)
+      CmdArrApp (addCmdArrAppLhsParens lhs) appTy (addCmdArrAppRhsParens ctx rhs)
     CmdInfix l op r ->
       CmdInfix (wrapCmdInfixLhs (addCmdParens l)) op (wrapCmdInfixRhs (addCmdParens r))
     CmdDo stmts ->
@@ -1717,17 +1725,22 @@ endsWithCmdLayoutBlock = \case
   EApp _ arg -> endsWithCmdLayoutBlock arg
   _ -> False
 
-addCmdArrAppRhsParens :: Expr -> Expr
-addCmdArrAppRhsParens rhs =
-  wrapExpr (endsWithTypeSig rhs) (addExprParens rhs)
+addCmdArrAppRhsParens :: CmdCtx -> Expr -> Expr
+addCmdArrAppRhsParens ctx rhs =
+  wrapExpr (cmdTopNeedsRhsParens && endsWithTypeSig rhs) (addExprParens rhs)
+  where
+    cmdTopNeedsRhsParens =
+      case ctx of
+        CtxCmdTop -> True
+        CtxCmdDoStmt -> False
 
 addCmdDoStmtParens :: DoStmt Cmd -> DoStmt Cmd
 addCmdDoStmtParens stmt =
   case stmt of
     DoAnn ann inner -> DoAnn ann (addCmdDoStmtParens inner)
-    DoBind pat cmd' -> DoBind (addPatternParens pat) (addCmdParens cmd')
+    DoBind pat cmd' -> DoBind (addPatternParens pat) (addCmdParensIn CtxCmdDoStmt cmd')
     DoLetDecls decls -> DoLetDecls (map addDeclParens decls)
-    DoExpr cmd' -> DoExpr (wrapCmd (isLetCmd cmd') (addCmdParens cmd'))
+    DoExpr cmd' -> DoExpr (wrapCmd (isLetCmd cmd') (addCmdParensIn CtxCmdDoStmt cmd'))
     DoRecStmt stmts -> DoRecStmt (map addCmdDoStmtParens stmts)
   where
     isLetCmd CmdLet {} = True

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1044,9 +1044,9 @@ test_prettyMultiWayIfInfixLhs = do
       expected =
         T.intercalate
           "\n"
-          [ "(if | True",
-            "     ->",
-            "      ())",
+          [ "if | True",
+            "    ->",
+            "     ()",
             " `a` 'x'"
           ]
       rendered = renderStrict (layoutPretty defaultLayoutOptions (pretty expr))

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/arrow-rhs-typesig.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/arrow-rhs-typesig.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE Arrows #-}
+module M where
+
+import Control.Arrow
+
+f = proc string -> do
+  count <- sumC -< 1 :: Integer
+  returnA -< count

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/multiway-if-infix-rhs.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/multiway-if-infix-rhs.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MultiWayIf #-}
+module M where
+
+actorVulnerable condAnyHarmfulFoeAdj condCanMelee condManyThreatAdj condSupport1 condSolo condInMelee heavilyDistressed fleeingMakesSense =
+  return $!
+    fleeingMakesSense
+      && if | condAnyHarmfulFoeAdj ->
+              not condCanMelee || condManyThreatAdj && not condSupport1 && not condSolo
+            | condInMelee -> False
+            | heavilyDistressed -> True
+            | otherwise -> False
+      && condCanFlee


### PR DESCRIPTION
## Summary
- Avoid adding RHS type-signature parentheses for arrow applications inside command do-statements, while preserving grouping for top-level proc command contexts.
- Allow multi-way if expressions to remain bare as infix left operands when GHC round-trips them without an HsPar.
- Add Parens oracle regressions for essence-of-live-coding and LambdaHack failures.

## Progress counts
- Parser oracle Parens pass fixtures: +2 pass cases.
- Hackage regressions resolved: 2/2 packages now report 0 roundtrip failures.

## Validation
- cabal test -v0 aihc-parser:spec --test-options="--pattern Parens"
- cabal run exe:aihc-dev -v0 -- hackage-tester essence-of-live-coding
- cabal run exe:aihc-dev -v0 -- hackage-tester LambdaHack
- just fmt
- just check
- coderabbit review --prompt-only: no findings