### PR TITLE
fix(parser): parenthesize arrow command lhs ending in mdo

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1714,6 +1714,7 @@ addCmdArrAppLhsParens lhs =
 endsWithCmdLayoutTail :: Expr -> Bool
 endsWithCmdLayoutTail = \case
   EAnn _ sub -> endsWithCmdLayoutTail sub
+  expr | endsWithCmdLayoutBlock expr -> True
   EInfix _ _ rhs -> endsWithCmdLayoutTail rhs
   ENegate inner -> endsWithCmdLayoutTail inner
   EPragma _ inner -> endsWithCmdLayoutTail inner

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -302,6 +302,7 @@ buildTests = do
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
             testCase "parenthesizes multi-way if view expressions ending with type signatures in decls" test_viewExprMultiWayIfTypeSigParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
+            testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
@@ -1285,6 +1286,18 @@ test_arrowCommandLhsLambdaCaseParens = do
             \\case
               C ->
                 []) -< ()
+        """
+  assertParsedStrippedDeclShapeRoundTrip config source
+
+test_arrowCommandLhsMdoParens :: Assertion
+test_arrowCommandLhsMdoParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      source =
+        """
+        (:+) =
+          proc a -> (()
+            + mdo
+                "nerEAot"#) -< ()
         """
   assertParsedStrippedDeclShapeRoundTrip config source
 


### PR DESCRIPTION
## Summary
- parenthesize arrow command left-hand expressions when they end in a layout block directly, not only through application tails
- add a regression for the shrunk `proc ... -<` case where an infix lhs ended with `mdo`, which previously pretty-printed to invalid syntax
- local checks: `just replay \"(SMGen 6767792275444457985 90098704222595619,88)\"`, `just fmt`, `just check`, `coderabbit review --prompt-only` (no findings)