### PR TITLE
fix(parser): preserve multi-way if infix lhs grouping

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1057,7 +1057,7 @@ addExprParensPrec prec expr =
       wrapExpr
         (prec > 1)
         ( EInfix
-            (addExprParensIn CtxInfixLhs lhs)
+            (addTopLevelInfixLhsParens prec lhs)
             op
             (addExprParensIn (CtxInfixRhs (prec == 1)) rhs)
         )
@@ -1279,6 +1279,26 @@ addExprGuardedParens expr =
     EIf {} -> addExprParens expr
     EMultiWayIf {} -> addExprParens expr
     _ -> addExprParensIn CtxGuarded expr
+
+-- | A top-level infix expression whose left operand starts with layout-sensitive
+-- syntax like @if |@ needs that operand grouped; otherwise the operator can be
+-- reparsed into the layout block's trailing body.
+addTopLevelInfixLhsParens :: Int -> Expr -> Expr
+addTopLevelInfixLhsParens prec lhs
+  | prec == 0 && startsWithMultiWayIf lhs = wrapExpr True (addExprParens lhs)
+  | otherwise = addExprParensIn CtxInfixLhs lhs
+
+startsWithMultiWayIf :: Expr -> Bool
+startsWithMultiWayIf = \case
+  EAnn _ sub -> startsWithMultiWayIf sub
+  EInfix lhs _ _ -> startsWithMultiWayIf lhs
+  EApp fn _ -> startsWithMultiWayIf fn
+  ERecordUpd base _ -> startsWithMultiWayIf base
+  EGetField base _ -> startsWithMultiWayIf base
+  ETypeSig inner _ -> startsWithMultiWayIf inner
+  ETypeApp fn _ -> startsWithMultiWayIf fn
+  EMultiWayIf {} -> True
+  _ -> False
 
 -- ---------------------------------------------------------------------------
 -- Types

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -281,6 +281,7 @@ buildTests = do
             testCase "pretty-prints negated layout-ending list-comprehension bodies" test_prettyNegatedLayoutEndingListCompBody,
             testCase "pretty-prints layout let guards in multi-way if" test_prettyLayoutLetGuardInMultiWayIf,
             testCase "pretty-prints multi-way if left operands with parentheses" test_prettyMultiWayIfInfixLhs,
+            testCase "pretty-prints multi-way if left operands inside unboxed sums with parentheses" test_prettyMultiWayIfInfixLhsInsideUnboxedSum,
             testCase "pretty-prints where clauses with implicit layout" test_prettyWhereClauseUsesImplicitLayout,
             testCase "pretty-prints GADT constructors with implicit layout" test_prettyGadtConstructorsUseImplicitLayout,
             testCase "pretty-prints lambda-case expressions with implicit layout" test_prettyLambdaCaseExpressionUsesImplicitLayout,
@@ -986,6 +987,25 @@ test_prettyMultiWayIfInfixLhs = do
          `a` 'x'
         """
   assertParsedStrippedExprShapeRoundTrip config source
+
+test_prettyMultiWayIfInfixLhsInsideUnboxedSum :: Assertion
+test_prettyMultiWayIfInfixLhsInsideUnboxedSum = do
+  let config = defaultConfig {parserExtensions = [UnboxedSums, MultiWayIf]}
+      source =
+        """
+        (# ((if | let {  }
+                 ->
+                  0)
+             `a` ()) | #)
+        """
+  case parseExpr config source of
+    ParseOk expr -> do
+      let stripped = stripParens expr
+          rendered = renderPretty stripped
+      assertBool "expected rendered expression to preserve grouped multi-way if lhs" ("(# (if" `T.isInfixOf` rendered)
+      assertExprRenderingRoundTrip config stripped rendered
+    ParseErr bundle ->
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
 
 test_prettyWhereClauseUsesImplicitLayout :: Assertion
 test_prettyWhereClauseUsesImplicitLayout = do

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -998,14 +998,7 @@ test_prettyMultiWayIfInfixLhsInsideUnboxedSum = do
                   0)
              `a` ()) | #)
         """
-  case parseExpr config source of
-    ParseOk expr -> do
-      let stripped = stripParens expr
-          rendered = renderPretty stripped
-      assertBool "expected rendered expression to preserve grouped multi-way if lhs" ("(# (if" `T.isInfixOf` rendered)
-      assertExprRenderingRoundTrip config stripped rendered
-    ParseErr bundle ->
-      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+  assertParsedStrippedExprShapeRoundTrip config source
 
 test_prettyWhereClauseUsesImplicitLayout :: Assertion
 test_prettyWhereClauseUsesImplicitLayout = do


### PR DESCRIPTION
## Summary
- parenthesize top-level infix left operands that start with a multi-way if so pretty-printing preserves the original parse
- add a parser regression that checks grouped multi-way-if rendering inside an unboxed sum slot
- verified with the reported QuickCheck replay, targeted parser/oracle checks, `just fmt`, `just check`, and a clean `coderabbit review --prompt-only`