### PR TITLE
test(parser): add equivalence fixtures

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -64,6 +64,7 @@ library parser-tooling-common
     HackageTester.Model
     HseExtensions
     LexerGolden
+    ParserEquivalent
     ParserErrorGolden
     ParserGolden
     ParserValidation
@@ -138,6 +139,7 @@ test-suite spec
     HackageTester.Model
     HseExtensions
     LexerGolden
+    ParserEquivalent
     ParserErrorGolden
     ParserGolden
     ParserValidation

--- a/components/aihc-parser/app/parser-progress/Main.hs
+++ b/components/aihc-parser/app/parser-progress/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import ExtensionSupport
+import ParserEquivalent qualified as PE
 import System.Environment (getArgs)
 import System.Exit (exitFailure, exitSuccess)
 
@@ -12,7 +13,9 @@ main = do
   let strict = "--strict" `elem` args
 
   cases <- loadOracleCases
-  outcomes <- mapM evaluateCaseFromFile cases
+  oracleOutcomes <- mapM evaluateCaseFromFile cases
+  equivalentOutcomes <- loadEquivalentOutcomes
+  let outcomes = oracleOutcomes <> equivalentOutcomes
 
   let passN = countOutcome OutcomePass outcomes
       xfailN = countOutcome OutcomeXFail outcomes
@@ -69,3 +72,42 @@ printXPass (meta, details) =
         <> "] "
         <> details
     )
+
+loadEquivalentOutcomes :: IO [(CaseMeta, Outcome, String)]
+loadEquivalentOutcomes = do
+  exprCases <- PE.loadExprCases
+  moduleCases <- PE.loadModuleCases
+  declCases <- PE.loadDeclCases
+  patternCases <- PE.loadPatternCases
+  pure
+    ( map (evaluateEquivalentCase PE.evaluateExprCase) exprCases
+        <> map (evaluateEquivalentCase PE.evaluateModuleCase) moduleCases
+        <> map (evaluateEquivalentCase PE.evaluateDeclCase) declCases
+        <> map (evaluateEquivalentCase PE.evaluatePatternCase) patternCases
+    )
+
+evaluateEquivalentCase :: (PE.EquivalentCase -> (PE.Outcome, String)) -> PE.EquivalentCase -> (CaseMeta, Outcome, String)
+evaluateEquivalentCase evaluateCase equivalentCase =
+  let (outcome, details) = evaluateCase equivalentCase
+   in (equivalentCaseMeta equivalentCase, convertEquivalentOutcome outcome, details)
+
+equivalentCaseMeta :: PE.EquivalentCase -> CaseMeta
+equivalentCaseMeta equivalentCase =
+  CaseMeta
+    { caseId = "equivalent/" <> PE.caseId equivalentCase,
+      caseCategory = "equivalent/" <> PE.caseCategory equivalentCase,
+      casePath = PE.casePath equivalentCase,
+      caseExpected = convertEquivalentStatus (PE.caseStatus equivalentCase),
+      caseReason = PE.caseReason equivalentCase,
+      caseExtensions = PE.caseExtensions equivalentCase
+    }
+
+convertEquivalentStatus :: PE.ExpectedStatus -> Expected
+convertEquivalentStatus PE.StatusXFail = ExpectXFail
+convertEquivalentStatus _ = ExpectPass
+
+convertEquivalentOutcome :: PE.Outcome -> Outcome
+convertEquivalentOutcome PE.OutcomePass = OutcomePass
+convertEquivalentOutcome PE.OutcomeXFail = OutcomeXFail
+convertEquivalentOutcome PE.OutcomeXPass = OutcomeXPass
+convertEquivalentOutcome PE.OutcomeFail = OutcomeFail

--- a/components/aihc-parser/common/ParserEquivalent.hs
+++ b/components/aihc-parser/common/ParserEquivalent.hs
@@ -1,0 +1,380 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ParserEquivalent
+  ( CaseKind (..),
+    ExpectedStatus (..),
+    Outcome (..),
+    EquivalentCase (..),
+    fixtureRoot,
+    exprFixtureRoot,
+    moduleFixtureRoot,
+    declFixtureRoot,
+    patternFixtureRoot,
+    loadExprCases,
+    loadModuleCases,
+    loadDeclCases,
+    loadPatternCases,
+    parseEquivalentCaseText,
+    evaluateExprCase,
+    evaluateModuleCase,
+    evaluateDeclCase,
+    evaluatePatternCase,
+    progressSummary,
+  )
+where
+
+import Aihc.Parser
+  ( ParseResult (..),
+    ParserConfig (..),
+    defaultConfig,
+    formatParseErrorBundle,
+    formatParseErrors,
+    parseDecl,
+    parseExpr,
+    parseModule,
+    parsePattern,
+  )
+import Aihc.Parser.Shorthand (Shorthand (..))
+import Aihc.Parser.Syntax
+  ( Decl,
+    Expr (..),
+    ExtensionSetting,
+    LanguageEdition (Haskell2010Edition),
+    Module,
+    Pattern (..),
+    editionFromExtensionSettings,
+    effectiveExtensions,
+    parseExtensionSettingName,
+    stripAnnotations,
+  )
+import Data.Aeson ((.!=), (.:), (.:?))
+import Data.Aeson.Types (parseEither, withObject)
+import Data.Char (isSpace, toLower)
+import Data.Data (Data (..))
+import Data.List (dropWhileEnd, sort, stripPrefix)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
+import ParserValidation (stripParens)
+import System.Directory (doesDirectoryExist, listDirectory)
+import System.FilePath (addTrailingPathSeparator, normalise, takeDirectory, takeExtension, (</>))
+
+data CaseKind = CaseExpr | CaseModule | CaseDecl | CasePattern deriving (Eq, Show)
+
+data ExpectedStatus
+  = StatusPass
+  | StatusFail
+  | StatusXFail
+  deriving (Eq, Show)
+
+data Outcome
+  = OutcomePass
+  | OutcomeXFail
+  | OutcomeXPass
+  | OutcomeFail
+  deriving (Eq, Show)
+
+data EquivalentCase = EquivalentCase
+  { caseKind :: !CaseKind,
+    caseId :: !String,
+    caseCategory :: !String,
+    casePath :: !FilePath,
+    caseExtensions :: ![ExtensionSetting],
+    caseInputs :: ![Text],
+    caseStatus :: !ExpectedStatus,
+    caseReason :: !String
+  }
+  deriving (Eq, Show)
+
+fixtureRoot :: FilePath
+fixtureRoot = "test/Test/Fixtures/equivalent"
+
+exprFixtureRoot :: FilePath
+exprFixtureRoot = fixtureRoot </> "expr"
+
+moduleFixtureRoot :: FilePath
+moduleFixtureRoot = fixtureRoot </> "module"
+
+declFixtureRoot :: FilePath
+declFixtureRoot = fixtureRoot </> "decl"
+
+patternFixtureRoot :: FilePath
+patternFixtureRoot = fixtureRoot </> "pattern"
+
+loadExprCases :: IO [EquivalentCase]
+loadExprCases = loadCases CaseExpr exprFixtureRoot
+
+loadModuleCases :: IO [EquivalentCase]
+loadModuleCases = loadCases CaseModule moduleFixtureRoot
+
+loadDeclCases :: IO [EquivalentCase]
+loadDeclCases = loadCases CaseDecl declFixtureRoot
+
+loadPatternCases :: IO [EquivalentCase]
+loadPatternCases = loadCases CasePattern patternFixtureRoot
+
+loadCases :: CaseKind -> FilePath -> IO [EquivalentCase]
+loadCases kind root = do
+  exists <- doesDirectoryExist root
+  if not exists
+    then pure []
+    else do
+      paths <- listFixtureFiles root
+      mapM (loadEquivalentCase kind) paths
+
+loadEquivalentCase :: CaseKind -> FilePath -> IO EquivalentCase
+loadEquivalentCase kind path = do
+  source <- TIO.readFile path
+  case parseEquivalentCaseText kind path source of
+    Left err -> fail err
+    Right parsed -> pure parsed
+
+parseEquivalentCaseText :: CaseKind -> FilePath -> Text -> Either String EquivalentCase
+parseEquivalentCaseText kind path source = do
+  value <-
+    case Y.decodeEither' (encodeUtf8 source) of
+      Left err -> Left ("Invalid YAML equivalence fixture " <> path <> ": " <> Y.prettyPrintParseException err)
+      Right parsed -> Right parsed
+  (extNames, inputTexts, statusText, reasonText) <- parseYamlFixture path value
+  exts <- validateExtensions path extNames
+  inputs <- validateInputs path inputTexts
+  status <- parseStatus path statusText
+  reason <- validateReason path status (T.unpack reasonText)
+  let relPath = dropRootPrefix path
+      category = categoryFromPath relPath
+  pure
+    EquivalentCase
+      { caseKind = kind,
+        caseId = relPath,
+        caseCategory = category,
+        casePath = relPath,
+        caseExtensions = exts,
+        caseInputs = inputs,
+        caseStatus = status,
+        caseReason = reason
+      }
+
+parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [Text], Text, Text)
+parseYamlFixture path value =
+  case parseEither
+    ( withObject "parser equivalence fixture" $ \obj -> do
+        exts <- obj .: "extensions"
+        inputs <- obj .: "equivalent"
+        statusText <- obj .: "status"
+        reasonText <- obj .:? "reason" .!= ""
+        pure (exts, inputs, statusText, reasonText)
+    )
+    value of
+    Left err -> Left ("Invalid parser equivalence fixture schema in " <> path <> ": " <> err)
+    Right parsed -> Right parsed
+
+evaluateExprCase :: EquivalentCase -> (Outcome, String)
+evaluateExprCase meta = evaluateEquivalentCase meta parseExprValue
+
+evaluateModuleCase :: EquivalentCase -> (Outcome, String)
+evaluateModuleCase meta = evaluateEquivalentCase meta parseModuleValue
+
+evaluateDeclCase :: EquivalentCase -> (Outcome, String)
+evaluateDeclCase meta = evaluateEquivalentCase meta parseDeclValue
+
+evaluatePatternCase :: EquivalentCase -> (Outcome, String)
+evaluatePatternCase meta = evaluateEquivalentCase meta parsePatternValue
+
+evaluateEquivalentCase ::
+  (Eq a, Data a, Shorthand a) =>
+  EquivalentCase ->
+  (ParserConfig -> Text -> Either String a) ->
+  (Outcome, String)
+evaluateEquivalentCase meta parseValue =
+  case traverse parseOne (zip [(1 :: Int) ..] (caseInputs meta)) of
+    Left err -> classifyFailure meta err
+    Right parsed -> classifyEquivalence meta parsed
+  where
+    config = parserConfig meta
+    parseOne (ix, inputText) =
+      case parseValue config inputText of
+        Left err -> Left ("input #" <> show ix <> " failed to parse: " <> err)
+        Right ast -> Right (ix, normalize ast)
+
+parseExprValue :: ParserConfig -> Text -> Either String Expr
+parseExprValue config source =
+  case parseExpr config source of
+    ParseOk ast -> Right ast
+    ParseErr err -> Left (formatParseErrorBundle (parserSourceName config) (Just source) err)
+
+parseModuleValue :: ParserConfig -> Text -> Either String Module
+parseModuleValue config source =
+  case parseModule config source of
+    ([], ast) -> Right ast
+    (errs, _) -> Left (formatParseErrors (parserSourceName config) (Just source) errs)
+
+parseDeclValue :: ParserConfig -> Text -> Either String Decl
+parseDeclValue config source =
+  case parseDecl config source of
+    ParseOk ast -> Right ast
+    ParseErr err -> Left (formatParseErrorBundle (parserSourceName config) (Just source) err)
+
+parsePatternValue :: ParserConfig -> Text -> Either String Pattern
+parsePatternValue config source =
+  case parsePattern config source of
+    ParseOk ast -> Right ast
+    ParseErr err -> Left (formatParseErrorBundle (parserSourceName config) (Just source) err)
+
+classifyEquivalence :: (Eq a, Shorthand a) => EquivalentCase -> [(Int, a)] -> (Outcome, String)
+classifyEquivalence meta parsed =
+  case findMismatch parsed of
+    Nothing -> classifyEquivalent meta
+    Just (expected, actual) -> classifyDifferent meta expected actual
+
+findMismatch :: (Eq a) => [(Int, a)] -> Maybe ((Int, a), (Int, a))
+findMismatch [] = Nothing
+findMismatch [_] = Nothing
+findMismatch (expected : rest) =
+  case filter ((/= snd expected) . snd) rest of
+    [] -> Nothing
+    actual : _ -> Just (expected, actual)
+
+classifyEquivalent :: EquivalentCase -> (Outcome, String)
+classifyEquivalent meta =
+  case caseStatus meta of
+    StatusPass -> (OutcomePass, "")
+    StatusFail ->
+      ( OutcomeFail,
+        "expected non-equivalent inputs but normalized ASTs matched"
+      )
+    StatusXFail ->
+      ( OutcomeXPass,
+        "expected xfail (known failing bug), but inputs now normalize to equivalent ASTs"
+      )
+
+classifyDifferent :: (Shorthand a) => EquivalentCase -> (Int, a) -> (Int, a) -> (Outcome, String)
+classifyDifferent meta expected actual =
+  case caseStatus meta of
+    StatusPass ->
+      ( OutcomeFail,
+        equivalenceMismatchDetails expected actual
+      )
+    StatusFail -> (OutcomePass, "")
+    StatusXFail ->
+      ( OutcomeXFail,
+        "known bug still present: " <> equivalenceMismatchDetails expected actual
+      )
+
+classifyFailure :: EquivalentCase -> String -> (Outcome, String)
+classifyFailure meta errDetails =
+  case caseStatus meta of
+    StatusPass ->
+      ( OutcomeFail,
+        "expected parse success, got parse error: " <> errDetails
+      )
+    -- StatusFail means the inputs should parse successfully but normalize to
+    -- different ASTs; parse errors indicate a malformed equivalence fixture.
+    StatusFail ->
+      ( OutcomeFail,
+        "expected parse success for non-equivalent inputs, got parse error: " <> errDetails
+      )
+    StatusXFail ->
+      ( OutcomeXFail,
+        "known bug still present: " <> errDetails
+      )
+
+equivalenceMismatchDetails :: (Shorthand a) => (Int, a) -> (Int, a) -> String
+equivalenceMismatchDetails (expectedIx, expected) (actualIx, actual) =
+  "normalized AST mismatch between input #"
+    <> show expectedIx
+    <> " and input #"
+    <> show actualIx
+    <> " (expected shorthand="
+    <> show (shorthand expected)
+    <> ", actual shorthand="
+    <> show (shorthand actual)
+    <> ")"
+
+normalize :: (Data a) => a -> a
+normalize = stripParens . stripAnnotations
+
+parserConfig :: EquivalentCase -> ParserConfig
+parserConfig meta =
+  defaultConfig
+    { parserSourceName = casePath meta,
+      parserExtensions = effectiveExtensions edition (caseExtensions meta)
+    }
+  where
+    edition = fromMaybe Haskell2010Edition (editionFromExtensionSettings (caseExtensions meta))
+
+progressSummary :: [(EquivalentCase, Outcome, String)] -> (Int, Int, Int, Int)
+progressSummary outcomes =
+  ( count OutcomePass,
+    count OutcomeXFail,
+    count OutcomeXPass,
+    count OutcomeFail
+  )
+  where
+    count wanted = length [() | (_, out, _) <- outcomes, out == wanted]
+
+listFixtureFiles :: FilePath -> IO [FilePath]
+listFixtureFiles dir = do
+  entries <- sort <$> listDirectory dir
+  concat
+    <$> mapM
+      ( \entry -> do
+          let path = dir </> entry
+          isDir <- doesDirectoryExist path
+          if isDir
+            then listFixtureFiles path
+            else
+              if takeExtension path `elem` [".yaml", ".yml"]
+                then pure [path]
+                else pure []
+      )
+      entries
+
+validateExtensions :: FilePath -> [Text] -> Either String [ExtensionSetting]
+validateExtensions path = traverse parseOne
+  where
+    parseOne raw =
+      case parseExtensionSettingName raw of
+        Just setting -> Right setting
+        Nothing -> Left ("Unknown parser extension " <> show raw <> " in " <> path)
+
+validateInputs :: FilePath -> [Text] -> Either String [Text]
+validateInputs path inputs =
+  case inputs of
+    [] -> Left ("[equivalent] must contain at least two inputs in " <> path)
+    [_] -> Left ("[equivalent] must contain at least two inputs in " <> path)
+    _ -> Right inputs
+
+parseStatus :: FilePath -> Text -> Either String ExpectedStatus
+parseStatus path raw =
+  case map toLower (trim (T.unpack raw)) of
+    "pass" -> Right StatusPass
+    "fail" -> Right StatusFail
+    "xfail" -> Right StatusXFail
+    "xpass" -> Left ("xpass is not allowed in " <> path <> ": use xfail instead")
+    _ -> Left ("Invalid [status] in " <> path <> ": " <> T.unpack raw)
+
+validateReason :: FilePath -> ExpectedStatus -> String -> Either String String
+validateReason path status reason =
+  let trimmed = trim reason
+   in case status of
+        StatusXFail | null trimmed -> Left ("[reason] is required for xfail status in " <> path)
+        _ -> Right trimmed
+
+dropRootPrefix :: FilePath -> FilePath
+dropRootPrefix path =
+  fromMaybe path (stripPrefix prefix normalizedPath)
+  where
+    prefix = addTrailingPathSeparator (normalise fixtureRoot)
+    normalizedPath = normalise path
+
+categoryFromPath :: FilePath -> String
+categoryFromPath path =
+  case takeDirectory path of
+    "." -> "equivalent"
+    dir -> dir
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/components/aihc-parser/common/ParserValidation.hs
+++ b/components/aihc-parser/common/ParserValidation.hs
@@ -5,6 +5,7 @@ module ParserValidation
   ( ValidationErrorKind (..),
     ValidationError (..),
     formatDiff,
+    stripParens,
     validateParser,
   )
 where
@@ -13,8 +14,11 @@ import Aihc.Parser (ParserConfig (..), defaultConfig, formatParseErrors, parseMo
 import Aihc.Parser.Syntax qualified as Syntax
 import Control.DeepSeq (NFData)
 import Data.Algorithm.Diff (PolyDiff (..), getDiff)
+import Data.Data (Data (..))
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Typeable (Typeable, cast)
 import GHC.Generics (Generic)
 import GhcOracle qualified
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
@@ -102,6 +106,31 @@ validateParser sourceTag edition extensionSettings source =
         { parserSourceName = sourceTag,
           parserExtensions = finalExts
         }
+
+stripParens :: (Data a) => a -> a
+stripParens x = applyStrip (gmapT stripParens x)
+  where
+    applyStrip :: (Data c) => c -> c
+    applyStrip =
+      id
+        `extT` stripExprParens
+        `extT` stripTypeParens
+        `extT` stripPatternParens
+
+    stripExprParens :: Syntax.Expr -> Syntax.Expr
+    stripExprParens (Syntax.EParen expr) = expr
+    stripExprParens expr = expr
+
+    stripTypeParens :: Syntax.Type -> Syntax.Type
+    stripTypeParens (Syntax.TParen typ) = typ
+    stripTypeParens typ = typ
+
+    stripPatternParens :: Syntax.Pattern -> Syntax.Pattern
+    stripPatternParens (Syntax.PParen pat) = pat
+    stripPatternParens pat = pat
+
+    extT :: (Typeable c, Typeable d) => (c -> c) -> (d -> d) -> c -> c
+    extT f g y = fromMaybe (f y) (cast . g =<< cast y)
 
 formatFingerprintMismatch :: Text -> Text -> String
 formatFingerprintMismatch sourceFp renderedFp =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -12,15 +12,13 @@ import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (ord)
-import Data.Data (Data (..), dataTypeConstrs, dataTypeOf, showConstr, toConstr)
-import Data.Dynamic (Typeable)
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
+import Data.Maybe (isNothing)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Typeable (cast)
 import Numeric (showHex, showOct)
-import ParserValidation (formatDiff, validateParser)
+import ParserValidation (formatDiff, stripParens, validateParser)
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.ErrorMessages.Suite (errorMessageTests)
@@ -82,31 +80,6 @@ sampleGen count gen = QGen.unGen (QC.vectorOf count gen) (QRandom.mkQCGen 202604
 
 renderPretty :: (Pretty a) => a -> Text
 renderPretty = renderStrict . layoutPretty defaultLayoutOptions . pretty
-
-stripParens :: (Data a) => a -> a
-stripParens x = applyStrip (gmapT stripParens x)
-  where
-    applyStrip :: (Data c) => c -> c
-    applyStrip =
-      id
-        `extT` stripExprParens
-        `extT` stripTypeParens
-        `extT` stripPatternParens
-
-    stripExprParens :: Expr -> Expr
-    stripExprParens (EParen expr) = expr
-    stripExprParens expr = expr
-
-    stripTypeParens :: Type -> Type
-    stripTypeParens (TParen typ) = typ
-    stripTypeParens typ = typ
-
-    stripPatternParens :: Pattern -> Pattern
-    stripPatternParens (PParen pat) = pat
-    stripPatternParens pat = pat
-
-    extT :: (Typeable c, Typeable d) => (c -> c) -> (d -> d) -> c -> c
-    extT f g y = fromMaybe (f y) (cast . g =<< cast y)
 
 assertParsedExprPrettyRoundTrip :: ParserConfig -> Text -> Text -> Assertion
 assertParsedExprPrettyRoundTrip config source expected =

--- a/components/aihc-parser/test/Test/Fixtures/equivalent/decl/paren-rhs.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/equivalent/decl/paren-rhs.yaml
@@ -1,0 +1,5 @@
+extensions: []
+equivalent:
+  - x = 10
+  - x = (10)
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/equivalent/expr/infix-left-assoc.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/equivalent/expr/infix-left-assoc.yaml
@@ -1,0 +1,6 @@
+extensions: []
+equivalent:
+  - a + b + c
+  - (a + b) + c
+status: xfail
+reason: parser currently preserves different infix grouping after stripping parens

--- a/components/aihc-parser/test/Test/Fixtures/equivalent/module/braced-decls.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/equivalent/module/braced-decls.yaml
@@ -1,0 +1,8 @@
+extensions: []
+equivalent:
+  - |
+    module X where
+    x = 10
+  - |
+    module X where { x = 10 }
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/equivalent/pattern/paren-con-arg.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/equivalent/pattern/paren-con-arg.yaml
@@ -1,0 +1,5 @@
+extensions: []
+equivalent:
+  - Just x
+  - Just (x)
+status: pass

--- a/components/aihc-parser/test/Test/Parser/Suite.hs
+++ b/components/aihc-parser/test/Test/Parser/Suite.hs
@@ -7,6 +7,7 @@ where
 
 import Control.Monad (unless, when)
 import Data.Text qualified as T
+import ParserEquivalent qualified as PE
 import ParserGolden qualified as PG
 import System.FilePath (takeExtension)
 import Test.Tasty (TestTree, testGroup)
@@ -14,6 +15,18 @@ import Test.Tasty.HUnit (Assertion, assertFailure, testCase, testCaseInfo)
 
 parserGoldenTests :: IO TestTree
 parserGoldenTests = do
+  goldenTests <- parserGoldenGroup
+  equivalentTests <- parserEquivalentGroup
+  pure
+    ( testGroup
+        "parser-fixtures"
+        [ goldenTests,
+          equivalentTests
+        ]
+    )
+
+parserGoldenGroup :: IO TestTree
+parserGoldenGroup = do
   exprCases <- PG.loadExprCases
   moduleCases <- PG.loadModuleCases
   patternCases <- PG.loadPatternCases
@@ -33,6 +46,36 @@ parserGoldenTests = do
         [ fixtureValidationTests,
           testGroup "expr" (exprChecks <> [exprSummary]),
           testGroup "module" (moduleChecks <> [moduleSummary]),
+          testGroup "pattern" (patternChecks <> [patternSummary]),
+          combinedSummary
+        ]
+    )
+
+parserEquivalentGroup :: IO TestTree
+parserEquivalentGroup = do
+  exprCases <- PE.loadExprCases
+  moduleCases <- PE.loadModuleCases
+  declCases <- PE.loadDeclCases
+  patternCases <- PE.loadPatternCases
+
+  exprChecks <- mapM mkEquivalentExprCaseTest exprCases
+  moduleChecks <- mapM mkEquivalentModuleCaseTest moduleCases
+  declChecks <- mapM mkEquivalentDeclCaseTest declCases
+  patternChecks <- mapM mkEquivalentPatternCaseTest patternCases
+
+  exprSummary <- mkEquivalentSummaryTest "expr" PE.evaluateExprCase exprCases
+  moduleSummary <- mkEquivalentSummaryTest "module" PE.evaluateModuleCase moduleCases
+  declSummary <- mkEquivalentSummaryTest "decl" PE.evaluateDeclCase declCases
+  patternSummary <- mkEquivalentSummaryTest "pattern" PE.evaluatePatternCase patternCases
+  combinedSummary <- mkEquivalentCombinedSummary exprCases moduleCases declCases patternCases
+
+  pure
+    ( testGroup
+        "parser-equivalent"
+        [ equivalenceFixtureValidationTests,
+          testGroup "expr" (exprChecks <> [exprSummary]),
+          testGroup "module" (moduleChecks <> [moduleSummary]),
+          testGroup "decl" (declChecks <> [declSummary]),
           testGroup "pattern" (patternChecks <> [patternSummary]),
           combinedSummary
         ]
@@ -82,6 +125,59 @@ assertModuleCase = assertCaseWith PG.evaluateModuleCase
 assertPatternCase :: PG.ParserCase -> Assertion
 assertPatternCase = assertCaseWith PG.evaluatePatternCase
 
+mkEquivalentExprCaseTest :: PE.EquivalentCase -> IO TestTree
+mkEquivalentExprCaseTest meta = pure $ case PE.caseStatus meta of
+  PE.StatusXFail -> testCaseInfo (PE.caseId meta) (equivalentXFailDetails (PE.evaluateExprCase meta) <* assertEquivalentExprCase meta)
+  _ -> testCase (PE.caseId meta) (assertEquivalentExprCase meta)
+
+mkEquivalentModuleCaseTest :: PE.EquivalentCase -> IO TestTree
+mkEquivalentModuleCaseTest meta = pure $ case PE.caseStatus meta of
+  PE.StatusXFail -> testCaseInfo (PE.caseId meta) (equivalentXFailDetails (PE.evaluateModuleCase meta) <* assertEquivalentModuleCase meta)
+  _ -> testCase (PE.caseId meta) (assertEquivalentModuleCase meta)
+
+mkEquivalentDeclCaseTest :: PE.EquivalentCase -> IO TestTree
+mkEquivalentDeclCaseTest meta = pure $ case PE.caseStatus meta of
+  PE.StatusXFail -> testCaseInfo (PE.caseId meta) (equivalentXFailDetails (PE.evaluateDeclCase meta) <* assertEquivalentDeclCase meta)
+  _ -> testCase (PE.caseId meta) (assertEquivalentDeclCase meta)
+
+mkEquivalentPatternCaseTest :: PE.EquivalentCase -> IO TestTree
+mkEquivalentPatternCaseTest meta = pure $ case PE.caseStatus meta of
+  PE.StatusXFail -> testCaseInfo (PE.caseId meta) (equivalentXFailDetails (PE.evaluatePatternCase meta) <* assertEquivalentPatternCase meta)
+  _ -> testCase (PE.caseId meta) (assertEquivalentPatternCase meta)
+
+equivalentXFailDetails :: (PE.Outcome, String) -> IO String
+equivalentXFailDetails (outcome, details) = do
+  case outcome of
+    PE.OutcomeXFail -> pure ()
+    _ -> assertFailure ("expected xfail outcome, got: " <> show outcome)
+  pure details
+
+mkEquivalentSummaryTest :: String -> (PE.EquivalentCase -> (PE.Outcome, String)) -> [PE.EquivalentCase] -> IO TestTree
+mkEquivalentSummaryTest label evaluateCase cases = do
+  let outcomes = map (evaluateEquivalent evaluateCase) cases
+  pure $ testCase (label <> " summary") (assertNoEquivalentRegressions label outcomes)
+
+mkEquivalentCombinedSummary :: [PE.EquivalentCase] -> [PE.EquivalentCase] -> [PE.EquivalentCase] -> [PE.EquivalentCase] -> IO TestTree
+mkEquivalentCombinedSummary exprCases moduleCases declCases patternCases = do
+  let exprOutcomes = map (evaluateEquivalent PE.evaluateExprCase) exprCases
+      moduleOutcomes = map (evaluateEquivalent PE.evaluateModuleCase) moduleCases
+      declOutcomes = map (evaluateEquivalent PE.evaluateDeclCase) declCases
+      patternOutcomes = map (evaluateEquivalent PE.evaluatePatternCase) patternCases
+      outcomes = exprOutcomes <> moduleOutcomes <> declOutcomes <> patternOutcomes
+  pure $ testCase "summary" (assertNoEquivalentRegressions "parser equivalence" outcomes)
+
+assertEquivalentExprCase :: PE.EquivalentCase -> Assertion
+assertEquivalentExprCase = assertEquivalentCaseWith PE.evaluateExprCase
+
+assertEquivalentModuleCase :: PE.EquivalentCase -> Assertion
+assertEquivalentModuleCase = assertEquivalentCaseWith PE.evaluateModuleCase
+
+assertEquivalentDeclCase :: PE.EquivalentCase -> Assertion
+assertEquivalentDeclCase = assertEquivalentCaseWith PE.evaluateDeclCase
+
+assertEquivalentPatternCase :: PE.EquivalentCase -> Assertion
+assertEquivalentPatternCase = assertEquivalentCaseWith PE.evaluatePatternCase
+
 assertCaseWith :: (PG.ParserCase -> (PG.Outcome, String)) -> PG.ParserCase -> Assertion
 assertCaseWith evaluateCase meta =
   case evaluateCase meta of
@@ -104,6 +200,33 @@ assertCaseWith evaluateCase meta =
             <> PG.caseId meta
             <> " reason="
             <> PG.caseReason meta
+            <> " details="
+            <> details
+        )
+    _ -> pure ()
+
+assertEquivalentCaseWith :: (PE.EquivalentCase -> (PE.Outcome, String)) -> PE.EquivalentCase -> Assertion
+assertEquivalentCaseWith evaluateCase meta =
+  case evaluateCase meta of
+    (PE.OutcomeFail, details) ->
+      assertFailure
+        ( "Regression in parser equivalence case "
+            <> PE.caseId meta
+            <> " ("
+            <> PE.caseCategory meta
+            <> ") expected "
+            <> show (PE.caseStatus meta)
+            <> " reason="
+            <> PE.caseReason meta
+            <> " details="
+            <> details
+        )
+    (PE.OutcomeXPass, details) ->
+      assertFailure
+        ( "Unexpected pass in xfail parser equivalence case "
+            <> PE.caseId meta
+            <> " reason="
+            <> PE.caseReason meta
             <> " details="
             <> details
         )
@@ -133,6 +256,33 @@ assertNoRegressions label outcomes = do
 
 evaluate :: (PG.ParserCase -> (PG.Outcome, String)) -> PG.ParserCase -> (PG.ParserCase, PG.Outcome, String)
 evaluate evaluateCase meta =
+  let (outcome, details) = evaluateCase meta
+   in (meta, outcome, details)
+
+assertNoEquivalentRegressions :: String -> [(PE.EquivalentCase, PE.Outcome, String)] -> Assertion
+assertNoEquivalentRegressions label outcomes = do
+  let (passN, xfailN, xpassN, failN) = PE.progressSummary outcomes
+      totalN = passN + xfailN + xpassN + failN
+      completion = pct passN totalN
+  when (failN > 0 || xpassN > 0) $
+    assertFailure
+      ( label
+          <> " regressions found. "
+          <> "pass="
+          <> show passN
+          <> " xfail="
+          <> show xfailN
+          <> " xpass="
+          <> show xpassN
+          <> " fail="
+          <> show failN
+          <> " completion="
+          <> show completion
+          <> "%"
+      )
+
+evaluateEquivalent :: (PE.EquivalentCase -> (PE.Outcome, String)) -> PE.EquivalentCase -> (PE.EquivalentCase, PE.Outcome, String)
+evaluateEquivalent evaluateCase meta =
   let (outcome, details) = evaluateCase meta
    in (meta, outcome, details)
 
@@ -232,4 +382,85 @@ validXPassFixture =
       "ast: EVar \"x\"",
       "status: xpass",
       "reason: known bug"
+    ]
+
+equivalenceFixtureValidationTests :: TestTree
+equivalenceFixtureValidationTests =
+  testGroup
+    "equivalence-fixture-parse"
+    [ testCase "rejects missing required keys" $
+        case PE.parseEquivalentCaseText PE.CaseExpr "missing.yaml" "extensions: []\n" of
+          Left _ -> pure ()
+          Right _ -> assertFailure "expected parse failure for missing required YAML keys",
+      testCase "requires two equivalent inputs" $
+        case PE.parseEquivalentCaseText PE.CaseExpr "one-input.yaml" validEquivalentSingleInput of
+          Left _ -> pure ()
+          Right _ -> assertFailure "expected parse failure for single equivalent input",
+      testCase "requires reason for xfail" $
+        case PE.parseEquivalentCaseText PE.CaseExpr "xfail.yaml" validEquivalentXFailMissingReason of
+          Left _ -> pure ()
+          Right _ -> assertFailure "expected parse failure when xfail reason is missing",
+      testCase "rejects xpass status" $
+        case PE.parseEquivalentCaseText PE.CaseExpr "xpass.yaml" validEquivalentXPassFixture of
+          Left _ -> pure ()
+          Right _ -> assertFailure "expected parse failure for xpass status",
+      testCase "accepts pass fixture" $
+        case PE.parseEquivalentCaseText PE.CaseExpr "pass.yaml" validEquivalentPassFixture of
+          Left err -> assertFailure ("expected parse success, got: " <> err)
+          Right parsed ->
+            if PE.caseStatus parsed == PE.StatusPass && length (PE.caseInputs parsed) == 2
+              then pure ()
+              else assertFailure "expected pass status with two inputs",
+      testCase "only YAML fixtures are loaded" $ do
+        exprCases <- PE.loadExprCases
+        moduleCases <- PE.loadModuleCases
+        declCases <- PE.loadDeclCases
+        patternCases <- PE.loadPatternCases
+        let cases = exprCases <> moduleCases <> declCases <> patternCases
+        mapM_
+          ( \meta ->
+              unless (takeExtension (PE.casePath meta) `elem` [".yaml", ".yml"]) $
+                assertFailure ("unexpected non-parser equivalence fixture loaded: " <> PE.casePath meta)
+          )
+          cases
+    ]
+
+validEquivalentSingleInput :: T.Text
+validEquivalentSingleInput =
+  T.unlines
+    [ "extensions: []",
+      "equivalent:",
+      "  - x",
+      "status: pass"
+    ]
+
+validEquivalentXFailMissingReason :: T.Text
+validEquivalentXFailMissingReason =
+  T.unlines
+    [ "extensions: []",
+      "equivalent:",
+      "  - x",
+      "  - (x)",
+      "status: xfail"
+    ]
+
+validEquivalentXPassFixture :: T.Text
+validEquivalentXPassFixture =
+  T.unlines
+    [ "extensions: []",
+      "equivalent:",
+      "  - x",
+      "  - (x)",
+      "status: xpass",
+      "reason: known bug"
+    ]
+
+validEquivalentPassFixture :: T.Text
+validEquivalentPassFixture =
+  T.unlines
+    [ "extensions: []",
+      "equivalent:",
+      "  - x",
+      "  - (x)",
+      "status: pass"
     ]


### PR DESCRIPTION
## Summary

- Add `ParserEquivalent`, a YAML fixture loader/evaluator for parser equivalence tests.
- Wire equivalence fixtures into the parser Tasty suite for module, decl, expr, and pattern cases.
- Include equivalence fixture outcomes in `parser-progress`.
- Seed each equivalence folder with fixtures, including the infix expression example as an expected failure that exposes current parser grouping behavior.

## Progress Counts

- Parser equivalence fixtures: pass=3, xfail=1, xpass=0, fail=0.
- `parser-progress`: PASS=1126, XFAIL=1, XPASS=0, FAIL=0, TOTAL=1127.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern parser-fixtures --hide-successes"`
- `(cd components/aihc-parser && cabal run -v0 exe:parser-progress)`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (findings addressed)