### PR TITLE
feat(parser): add ghc parser compat library

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
   bin/aihc
   components/aihc-cpp
   components/aihc-parser
+  components/aihc-parser-compat
   components/aihc-resolve
   components/aihc-tc
   components/aihc-fc

--- a/components/aihc-parser-compat/LICENSE
+++ b/components/aihc-parser-compat/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/components/aihc-parser-compat/aihc-parser-compat.cabal
+++ b/components/aihc-parser-compat/aihc-parser-compat.cabal
@@ -1,0 +1,66 @@
+cabal-version: 3.8
+name: aihc-parser-compat
+version: 0.1.0.0
+build-type: Simple
+license: Unlicense
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Compilers
+synopsis: Compatibility conversion from aihc-parser ASTs to ghc-lib-parser ASTs
+
+library
+  exposed-modules:
+    Aihc.Parser.Compat
+
+  other-modules:
+    Aihc.Parser.Compat.Internal.Convert
+    Aihc.Parser.Compat.Internal.Ghc
+
+  hs-source-dirs: src
+  build-depends:
+    aihc-parser,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    ghc-lib-parser,
+    prettyprinter,
+    text >=1.2,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+    src
+
+  main-is: Spec.hs
+  other-modules:
+    Aihc.Parser.Compat
+    Aihc.Parser.Compat.Internal.Convert
+    Aihc.Parser.Compat.Internal.Ghc
+    Test.Compat.Expr
+
+  build-depends:
+    QuickCheck,
+    aihc-parser,
+    aihc-parser:parser-test-support,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    ghc-lib-parser,
+    prettyprinter,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text >=1.2,
+
+  ghc-options:
+    -Wall
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+  default-language: GHC2021

--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat.hs
@@ -1,0 +1,16 @@
+module Aihc.Parser.Compat
+  ( toGhcHsExpr,
+  )
+where
+
+import Aihc.Parser.Compat.Internal.Convert qualified as Convert
+import Aihc.Parser.Syntax (Expr)
+import GHC.Hs (GhcPs)
+import Language.Haskell.Syntax.Expr (HsExpr)
+
+-- | Convert an aihc-parser expression into the matching ghc-lib-parser AST.
+--
+-- All locations and exact-print comments in the result are empty/default GHC
+-- values.
+toGhcHsExpr :: Expr -> HsExpr GhcPs
+toGhcHsExpr = Convert.toGhcHsExpr

--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
@@ -1,0 +1,685 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.Parser.Compat.Internal.Convert
+  ( toGhcHsExpr,
+    toGhcLHsExpr,
+  )
+where
+
+import Aihc.Parser.Syntax qualified as A
+import Data.ByteString.Char8 qualified as BS
+import Data.Char (isDigit)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Text qualified as T
+import GHC.Builtin.Types (nilDataCon, tupleDataCon, tupleTyCon, unrestrictedFunTyConName)
+import GHC.Data.FastString (mkFastString)
+import GHC.Hs
+import GHC.Types.Basic
+import GHC.Types.Name.Occurrence (mkDataOcc, mkVarOcc)
+import GHC.Types.Name.Reader (RdrName, getRdrName, mkRdrQual, mkRdrUnqual)
+import GHC.Types.SourceText
+import GHC.Types.SrcLoc (GenLocated (..), noSrcSpan, unLoc)
+import Language.Haskell.Syntax.Basic (FieldLabelString (..), LexicalFixity (..))
+import Language.Haskell.Syntax.Specificity (Specificity (..))
+
+toGhcHsExpr :: A.Expr -> HsExpr GhcPs
+toGhcHsExpr expr =
+  case A.peelExprAnn expr of
+    A.EAnn _ inner -> toGhcHsExpr inner
+    A.EVar name -> HsVar noExtField (lA (toRdrName name))
+    A.ETypeSyntax _ ty -> HsEmbTy noAnn (toWcType ty)
+    A.EInt value numeric raw -> integerExpr value numeric raw
+    A.EFloat value floatTy raw -> floatExpr value floatTy raw
+    A.EChar value _ -> HsLit noExtField (HsChar NoSourceText value)
+    A.ECharHash value _ -> HsLit noExtField (HsCharPrim NoSourceText value)
+    A.EString value _ -> HsLit noExtField (HsString NoSourceText (mkFastString (T.unpack value)))
+    A.EStringHash value _ -> HsLit noExtField (HsStringPrim NoSourceText (BS.pack (T.unpack value)))
+    A.EOverloadedLabel value _ -> HsOverLabel NoSourceText (mkFastString (T.unpack value))
+    A.EQuasiQuote quoter body -> HsUntypedSplice noExtField (HsQuasiQuote noExtField (lA (toRdrName (A.nameFromText quoter))) (lA (mkFastString (T.unpack body))))
+    A.EIf cond yes no -> HsIf noAnn (toGhcLHsExpr cond) (toGhcLHsExpr yes) (toGhcLHsExpr no)
+    A.EMultiWayIf rhss -> HsMultiIf noAnn (nonEmpty (map toGRHS rhss))
+    A.ELambdaPats pats body -> HsLam noAnn LamSingle (matchGroup (LamAlt LamSingle) [match (LamAlt LamSingle) pats (A.UnguardedRhs [] body Nothing)])
+    A.ELambdaCase alts -> HsLam noAnn LamCase (matchGroup (LamAlt LamCase) (map (caseAltMatchWith (LamAlt LamCase)) alts))
+    A.ELambdaCases alts -> HsLam noAnn LamCases (matchGroup (LamAlt LamCases) (map (lambdaCasesAltMatchWith (LamAlt LamCases)) alts))
+    A.EInfix lhs op rhs -> OpApp noExtField (toGhcLHsExpr lhs) (operatorExpr op) (toGhcLHsExpr rhs)
+    A.ENegate inner -> NegApp noAnn (toGhcLHsExpr inner) noSyntaxExpr
+    A.ESectionL lhs op -> SectionL noExtField (toGhcLHsExpr lhs) (operatorExpr op)
+    A.ESectionR op rhs -> SectionR noExtField (operatorExpr op) (toGhcLHsExpr rhs)
+    A.ELetDecls decls body -> HsLet noAnn (localBinds decls) (toGhcLHsExpr body)
+    A.ECase scrut alts -> HsCase noAnn (toGhcLHsExpr scrut) (matchGroup CaseAlt (map caseAltMatch alts))
+    A.EDo stmts flavor -> HsDo noAnn (doFlavor flavor) (lA (doStmts stmts))
+    A.EListComp body stmts -> HsDo noAnn ListComp (lA (compStmts body stmts))
+    A.EListCompParallel body stmtss -> HsDo noAnn ListComp (lA (parCompStmts body stmtss))
+    A.EArithSeq seq' -> ArithSeq noAnn Nothing (arithSeqInfo seq')
+    A.ERecordCon con fields wildcard -> RecordCon recordAnn (lA (toRdrName con)) (recordBinds fields wildcard)
+    A.ERecordUpd target fields | Just con <- recordConTarget target -> RecordCon recordAnn (lA con) (recordBinds fields False)
+    A.ERecordUpd target fields -> RecordUpd recordAnn (toGhcLHsExpr target) (RegularRecUpdFields noExtField (map recordUpdField fields))
+    A.EGetField base field -> HsGetField noExtField (toGhcLHsExpr base) (lA (dotField field))
+    A.EGetFieldProjection fields -> HsProjection noAnn (nonEmpty (map dotField fields))
+    A.ETypeSig inner ty -> ExprWithTySig noAnn (toGhcLHsExpr inner) (toSigWcType ty)
+    A.EParen inner
+      | A.EGetFieldProjection {} <- A.peelExprAnn inner -> toGhcHsExpr inner
+      | otherwise -> HsPar parAnn (toGhcLHsExpr inner)
+    A.EList [] -> HsVar noExtField (lA (getRdrName nilDataCon))
+    A.EList elems -> ExplicitList noAnn (map toGhcLHsExpr elems)
+    A.ETuple flavor elems -> tupleExpr flavor elems
+    A.EUnboxedSum altIdx arity inner -> ExplicitSum noAnn (altIdx + 1) arity (toGhcLHsExpr inner)
+    A.ETypeApp inner ty -> HsAppType noAnn (toGhcLHsExpr inner) (toWcType ty)
+    A.EApp fun arg -> HsApp noExtField (toGhcLHsExpr fun) (toGhcLHsExpr arg)
+    A.ETHExpQuote body -> HsUntypedBracket noExtField (ExpBr noAnn (toGhcLHsExpr body))
+    A.ETHTypedQuote body -> HsTypedBracket noAnn (toGhcLHsExpr body)
+    A.ETHDeclQuote decls -> HsUntypedBracket noExtField (DecBrL noAnn (map toLHsDecl decls))
+    A.ETHTypeQuote ty -> HsUntypedBracket noExtField (TypBr noAnn (toLHsType ty))
+    A.ETHPatQuote pat -> HsUntypedBracket noExtField (PatBr noAnn (toLPat pat))
+    A.ETHNameQuote quoted -> HsUntypedBracket noExtField (VarBr noAnn True (quotedExprName quoted))
+    A.ETHTypeNameQuote ty -> HsUntypedBracket noExtField (VarBr noAnn False (quotedTypeName ty))
+    A.ETHSplice body -> HsUntypedSplice noExtField (HsUntypedSpliceExpr noAnn (toGhcLHsExpr body))
+    A.ETHTypedSplice body -> HsTypedSplice noExtField (HsTypedSpliceExpr noAnn (toGhcLHsExpr body))
+    A.EProc pat cmd -> HsProc noAnn (toLPat pat) (lA (HsCmdTop noExtField (toLHsCmd cmd)))
+    A.EPragma _ inner -> toGhcHsExpr inner
+
+toGhcLHsExpr :: A.Expr -> LHsExpr GhcPs
+toGhcLHsExpr = lA . toGhcHsExpr
+
+integerExpr :: Integer -> A.NumericType -> T.Text -> HsExpr GhcPs
+integerExpr value numeric raw =
+  case numeric of
+    A.TInteger -> HsOverLit noExtField (mkHsIntegral (IL (sourceText raw) False value))
+    A.TIntHash -> HsLit noExtField (HsIntPrim NoSourceText value)
+    A.TWordHash -> HsLit noExtField (HsWordPrim NoSourceText value)
+    A.TInt8Hash -> HsLit noExtField (HsInt8Prim NoSourceText value)
+    A.TInt16Hash -> HsLit noExtField (HsInt16Prim NoSourceText value)
+    A.TInt32Hash -> HsLit noExtField (HsInt32Prim NoSourceText value)
+    A.TInt64Hash -> HsLit noExtField (HsInt64Prim NoSourceText value)
+    A.TWord8Hash -> HsLit noExtField (HsWord8Prim NoSourceText value)
+    A.TWord16Hash -> HsLit noExtField (HsWord16Prim NoSourceText value)
+    A.TWord32Hash -> HsLit noExtField (HsWord32Prim NoSourceText value)
+    A.TWord64Hash -> HsLit noExtField (HsWord64Prim NoSourceText value)
+
+floatExpr :: Rational -> A.FloatType -> T.Text -> HsExpr GhcPs
+floatExpr value floatTy raw =
+  let lit = fractionalLit value raw
+   in case floatTy of
+        A.TFractional -> HsOverLit noExtField (mkHsFractional lit)
+        A.TFloatHash -> HsLit noExtField (HsFloatPrim noExtField lit)
+        A.TDoubleHash -> HsLit noExtField (HsDoublePrim noExtField lit)
+
+fractionalLit :: Rational -> T.Text -> FractionalLit
+fractionalLit value raw =
+  FL (sourceText raw) False significand' exponent' Base10
+  where
+    exponent' = fractionalExponent raw
+    significand' = value / (10 ^^ exponent')
+
+fractionalExponent :: T.Text -> Integer
+fractionalExponent raw =
+  explicitExponent - fromIntegral fractionalDigits
+  where
+    token = filter (/= '_') (T.unpack raw)
+    tokenSignificand = takeWhile (\c -> c /= 'e' && c /= 'E' && c /= '#') token
+    exponentText =
+      case dropWhile (\c -> c /= 'e' && c /= 'E') token of
+        [] -> ""
+        (_ : rest) -> takeWhile exponentChar rest
+    explicitExponent =
+      case reads exponentText of
+        [(value, "")] -> value
+        _ -> 0
+    fractionalDigits =
+      case dropWhile (/= '.') tokenSignificand of
+        [] -> 0
+        (_ : rest) -> length (takeWhile isDigit rest)
+    exponentChar c = c == '+' || c == '-' || isDigit c
+
+tupleExpr :: A.TupleFlavor -> [Maybe A.Expr] -> HsExpr GhcPs
+tupleExpr flavor elems =
+  case elems of
+    [] -> HsVar noExtField (lA (getRdrName (tupleDataCon (boxity flavor) 0)))
+    _
+      | all nullary elems -> HsVar noExtField (lA (getRdrName (tupleDataCon (boxity flavor) (length elems))))
+      | otherwise -> ExplicitTuple tupleAnn (map tupArg elems) (boxity flavor)
+
+tupArg :: Maybe A.Expr -> HsTupArg GhcPs
+tupArg =
+  maybe (Missing noAnn) (Present noExtField . toGhcLHsExpr)
+
+nullary :: Maybe a -> Bool
+nullary Nothing = True
+nullary Just {} = False
+
+operatorExpr :: A.Name -> LHsExpr GhcPs
+operatorExpr = lA . HsVar noExtField . lA . toRdrName
+
+recordBinds :: [A.RecordField A.Expr] -> Bool -> HsRecordBinds GhcPs
+recordBinds fields wildcard =
+  HsRecFields noExtField (map recordField fields) (if wildcard then Just (lA (RecFieldsDotDot 0)) else Nothing)
+
+recordField :: A.RecordField A.Expr -> LHsRecField GhcPs (LHsExpr GhcPs)
+recordField (A.RecordField name value pun) =
+  lA (HsFieldBind (Just noAnn) (lA (fieldOcc name)) (toGhcLHsExpr value) pun)
+
+recordUpdField :: A.RecordField A.Expr -> LHsRecUpdField GhcPs GhcPs
+recordUpdField (A.RecordField name value pun) =
+  lA (HsFieldBind (Just noAnn) (lA (fieldOcc name)) (toGhcLHsExpr value) pun)
+
+recordConTarget :: A.Expr -> Maybe RdrName
+recordConTarget expr =
+  case A.peelExprAnn expr of
+    A.EAnn _ inner -> recordConTarget inner
+    A.EVar name
+      | isConName name -> Just (toRdrName name)
+      | otherwise -> Nothing
+    A.EList [] -> Just (getRdrName nilDataCon)
+    A.ETuple flavor [] -> Just (getRdrName (tupleDataCon (boxity flavor) 0))
+    A.ETuple flavor elems | all nullary elems -> Just (getRdrName (tupleDataCon (boxity flavor) (length elems)))
+    _ -> Nothing
+
+isConName :: A.Name -> Bool
+isConName name =
+  case A.nameType name of
+    A.NameConId -> True
+    A.NameConSym -> True
+    _ -> False
+
+fieldOcc :: A.Name -> FieldOcc GhcPs
+fieldOcc name = FieldOcc noExtField (lA (toRdrName name))
+
+dotField :: A.Name -> DotFieldOcc GhcPs
+dotField name = DotFieldOcc noAnn (lA (FieldLabelString (mkFastString (T.unpack (A.nameText name)))))
+
+doFlavor :: A.DoFlavor -> HsDoFlavour
+doFlavor flavor =
+  case flavor of
+    A.DoPlain -> DoExpr Nothing
+    A.DoMdo -> MDoExpr Nothing
+    A.DoQualified modName -> DoExpr (Just (mkModuleName (T.unpack modName)))
+    A.DoQualifiedMdo modName -> MDoExpr (Just (mkModuleName (T.unpack modName)))
+
+doStmts :: [A.DoStmt A.Expr] -> [ExprLStmt GhcPs]
+doStmts [] = []
+doStmts [A.DoExpr expr] = [lA (LastStmt noExtField (toGhcLHsExpr expr) Nothing noSyntaxExpr)]
+doStmts (stmt : rest) = toDoStmt stmt : doStmts rest
+
+toDoStmt :: A.DoStmt A.Expr -> ExprLStmt GhcPs
+toDoStmt stmt =
+  lA $
+    case A.peelDoStmtAnn stmt of
+      A.DoAnn _ inner -> unLoc (toDoStmt inner)
+      A.DoBind pat body -> BindStmt noAnn (toLPat pat) (toGhcLHsExpr body)
+      A.DoLetDecls decls -> LetStmt noAnn (localBinds decls)
+      A.DoExpr body -> BodyStmt noExtField (toGhcLHsExpr body) noSyntaxExpr noSyntaxExpr
+      A.DoRecStmt stmts ->
+        RecStmt
+          noAnn
+          (lA (map toDoStmt stmts))
+          []
+          []
+          noSyntaxExpr
+          noSyntaxExpr
+          noSyntaxExpr
+
+compStmts :: A.Expr -> [A.CompStmt] -> [ExprLStmt GhcPs]
+compStmts body stmts = compQualStmts stmts <> [lA (LastStmt noExtField (toGhcLHsExpr body) Nothing noSyntaxExpr)]
+
+parCompStmts :: A.Expr -> [[A.CompStmt]] -> [ExprLStmt GhcPs]
+parCompStmts body branches =
+  [ lA $
+      ParStmt
+        noExtField
+        (nonEmpty (map parBlock branches))
+        parsedNoExpr
+        noSyntaxExpr,
+    lA (LastStmt noExtField (toGhcLHsExpr body) Nothing noSyntaxExpr)
+  ]
+
+parBlock :: [A.CompStmt] -> ParStmtBlock GhcPs GhcPs
+parBlock stmts = ParStmtBlock noExtField (compQualStmts stmts) [] noSyntaxExpr
+
+parsedNoExpr :: HsExpr GhcPs
+parsedNoExpr = HsLit noExtField (HsString (SourceText "noExpr") (mkFastString "noExpr"))
+
+compQualStmts :: [A.CompStmt] -> [ExprLStmt GhcPs]
+compQualStmts = foldl step []
+  where
+    step acc stmt =
+      case toCompStmt acc stmt of
+        (converted, True) -> [converted]
+        (converted, False) -> acc <> [converted]
+
+toCompStmt :: [ExprLStmt GhcPs] -> A.CompStmt -> (ExprLStmt GhcPs, Bool)
+toCompStmt previous stmt =
+  let transformed stmt' = (lA stmt', True)
+      plain stmt' = (lA stmt', False)
+   in case A.peelCompStmtAnn stmt of
+        A.CompAnn _ inner -> toCompStmt previous inner
+        A.CompGen pat expr -> plain (BindStmt noAnn (toLPat pat) (toGhcLHsExpr expr))
+        A.CompGuard expr -> plain (BodyStmt noExtField (toGhcLHsExpr expr) noSyntaxExpr noSyntaxExpr)
+        A.CompLetDecls decls -> plain (LetStmt noAnn (localBinds decls))
+        A.CompThen expr -> transformed (transStmt ThenForm previous expr Nothing)
+        A.CompThenBy usingExpr byExpr -> transformed (transStmt ThenForm previous usingExpr (Just byExpr))
+        A.CompGroupUsing expr -> transformed (transStmt GroupForm previous expr Nothing)
+        A.CompGroupByUsing byExpr usingExpr -> transformed (transStmt GroupForm previous usingExpr (Just byExpr))
+
+transStmt :: TransForm -> [ExprLStmt GhcPs] -> A.Expr -> Maybe A.Expr -> StmtLR GhcPs GhcPs (LHsExpr GhcPs)
+transStmt form previous usingExpr byExpr =
+  TransStmt noAnn form previous [] (toGhcLHsExpr usingExpr) (toGhcLHsExpr <$> byExpr) noSyntaxExpr noSyntaxExpr parsedNoExpr
+
+arithSeqInfo :: A.ArithSeq -> ArithSeqInfo GhcPs
+arithSeqInfo seq' =
+  case A.peelArithSeqAnn seq' of
+    A.ArithSeqAnn _ inner -> arithSeqInfo inner
+    A.ArithSeqFrom from -> From (toGhcLHsExpr from)
+    A.ArithSeqFromThen from next -> FromThen (toGhcLHsExpr from) (toGhcLHsExpr next)
+    A.ArithSeqFromTo from to -> FromTo (toGhcLHsExpr from) (toGhcLHsExpr to)
+    A.ArithSeqFromThenTo from next to -> FromThenTo (toGhcLHsExpr from) (toGhcLHsExpr next) (toGhcLHsExpr to)
+
+toLPat :: A.Pattern -> LPat GhcPs
+toLPat = lA . toPat
+
+toPat :: A.Pattern -> Pat GhcPs
+toPat pat =
+  case A.peelPatternAnn pat of
+    A.PAnn _ inner -> toPat inner
+    A.PVar name -> VarPat noExtField (lA (toRdrName (A.qualifyName Nothing name)))
+    A.PTypeBinder _ -> WildPat noExtField
+    A.PTypeSyntax _ ty -> EmbTyPat noAnn (HsTP noExtField (toLHsType ty))
+    A.PWildcard -> WildPat noExtField
+    A.PLit lit -> litPat lit
+    A.PQuasiQuote quoter body -> SplicePat noExtField (HsQuasiQuote noExtField (lA (toRdrName (A.nameFromText quoter))) (lA (mkFastString (T.unpack body))))
+    A.PTuple flavor [] -> ConPat conPatAnn (lA (getRdrName (tupleDataCon (boxity flavor) 0))) (PrefixCon [])
+    A.PTuple flavor pats -> TuplePat tupleAnn (map toLPat pats) (boxity flavor)
+    A.PUnboxedSum altIdx arity inner -> SumPat noAnn (toLPat inner) (altIdx + 1) arity
+    A.PList [] -> ConPat conPatAnn (lA (getRdrName nilDataCon)) (PrefixCon [])
+    A.PList pats -> ListPat noAnn (map toLPat pats)
+    A.PCon con [] pats -> ConPat conPatAnn (lA (toRdrName con)) (PrefixCon (map toLPat pats))
+    A.PCon con _ pats -> ConPat conPatAnn (lA (toRdrName con)) (PrefixCon (map toLPat pats))
+    A.PInfix lhs op rhs -> ConPat conPatAnn (lA (toRdrName op)) (InfixCon (toLPat lhs) (toLPat rhs))
+    A.PView expr inner -> ViewPat noAnn (toGhcLHsExpr expr) (toLPat inner)
+    A.PAs name inner -> AsPat noAnn (lA (toRdrName (A.qualifyName Nothing name))) (toLPat inner)
+    A.PStrict inner -> BangPat noAnn (toLPat inner)
+    A.PIrrefutable inner -> LazyPat noAnn (toLPat inner)
+    A.PNegLit lit -> negLitPat lit
+    A.PParen inner -> ParPat parAnn (toLPat inner)
+    A.PRecord con fields wildcard ->
+      ConPat conPatAnn (lA (toRdrName con)) (RecCon (HsRecFields noExtField (map patRecordField fields) (if wildcard then Just (lA (RecFieldsDotDot 0)) else Nothing)))
+    A.PTypeSig inner ty -> SigPat noAnn (toLPat inner) (HsPS noAnn (toLHsType ty))
+    A.PSplice expr -> SplicePat noExtField (HsUntypedSpliceExpr noAnn (toGhcLHsExpr expr))
+
+litPat :: A.Literal -> Pat GhcPs
+litPat lit =
+  case A.peelLiteralAnn lit of
+    A.LitAnn _ inner -> litPat inner
+    A.LitInt value numeric raw -> numLitPat value numeric raw
+    A.LitFloat value floatTy raw -> floatLitPat value floatTy raw
+    A.LitChar value _ -> LitPat noExtField (HsChar NoSourceText value)
+    A.LitCharHash value _ -> LitPat noExtField (HsCharPrim NoSourceText value)
+    A.LitString value _ -> LitPat noExtField (HsString NoSourceText (mkFastString (T.unpack value)))
+    A.LitStringHash value _ -> LitPat noExtField (HsStringPrim NoSourceText (BS.pack (T.unpack value)))
+
+negLitPat :: A.Literal -> Pat GhcPs
+negLitPat lit =
+  case A.peelLiteralAnn lit of
+    A.LitInt value A.TInteger raw -> NPat noAnn (lA (mkHsIntegral (IL (sourceText raw) False value))) (Just noSyntaxExpr) noSyntaxExpr
+    A.LitFloat value A.TFractional raw -> NPat noAnn (lA (mkHsFractional (fractionalLit value raw))) (Just noSyntaxExpr) noSyntaxExpr
+    other -> litPat other
+
+numLitPat :: Integer -> A.NumericType -> T.Text -> Pat GhcPs
+numLitPat value numeric raw =
+  case numeric of
+    A.TInteger -> NPat noAnn (lA (mkHsIntegral (IL (sourceText raw) False value))) Nothing noSyntaxExpr
+    _ -> case integerExpr value numeric raw of
+      HsLit _ lit -> LitPat noExtField lit
+      _ -> NPat noAnn (lA (mkHsIntegral (mkIntegralLit value))) Nothing noSyntaxExpr
+
+floatLitPat :: Rational -> A.FloatType -> T.Text -> Pat GhcPs
+floatLitPat value floatTy raw =
+  case floatExpr value floatTy raw of
+    HsLit _ lit -> LitPat noExtField lit
+    _ -> NPat noAnn (lA (mkHsFractional (fractionalLit value raw))) Nothing noSyntaxExpr
+
+patRecordField :: A.RecordField A.Pattern -> LHsRecField GhcPs (LPat GhcPs)
+patRecordField (A.RecordField name value pun) =
+  lA (HsFieldBind (Just noAnn) (lA (fieldOcc name)) (toLPat value) pun)
+
+toLHsType :: A.Type -> LHsType GhcPs
+toLHsType = lA . toHsType
+
+toHsType :: A.Type -> HsType GhcPs
+toHsType ty =
+  case A.peelTypeAnn ty of
+    A.TAnn _ inner -> toHsType inner
+    A.TVar name -> HsTyVar noAnn NotPromoted (lA (toRdrName (A.qualifyName Nothing name)))
+    A.TCon name promotion -> HsTyVar noAnn (promotionFlag promotion) (lA (toRdrName name))
+    A.TBuiltinCon builtin -> builtinType builtin
+    A.TImplicitParam name inner -> HsIParamTy noAnn (lA (HsIPName (mkFastString (T.unpack (T.dropWhile (== '?') name))))) (toLHsType inner)
+    A.TTypeLit lit -> HsTyLit noExtField (typeLit lit)
+    A.TStar -> HsStarTy noExtField False
+    A.TQuasiQuote quoter body -> HsSpliceTy noExtField (HsQuasiQuote noExtField (lA (toRdrName (A.nameFromText quoter))) (lA (mkFastString (T.unpack body))))
+    A.TForall telescope body -> HsForAllTy noExtField (forallTele telescope) (toLHsType body)
+    A.TApp fun arg -> HsAppTy noExtField (toLHsType fun) (toLHsType arg)
+    A.TTypeApp fun arg -> HsAppKindTy noAnn (toLHsType fun) (toLHsType arg)
+    A.TInfix lhs op promotion rhs -> HsOpTy noExtField (promotionFlag promotion) (toLHsType lhs) (lA (toRdrName op)) (toLHsType rhs)
+    A.TFun arrow lhs rhs -> HsFunTy noExtField (multAnn arrow) (toLHsType lhs) (toLHsType rhs)
+    A.TTuple flavor promotion elems ->
+      case promotion of
+        A.Promoted -> HsExplicitTupleTy (noAnn, noAnn, noAnn) IsPromoted (map toLHsType elems)
+        A.Unpromoted -> HsTupleTy noAnn (tupleSort flavor) (map toLHsType elems)
+    A.TUnboxedSum elems -> HsSumTy noAnn (map toLHsType elems)
+    A.TList promotion elems ->
+      case promotion of
+        A.Promoted -> HsExplicitListTy (noAnn, noAnn, noAnn) IsPromoted (map toLHsType elems)
+        A.Unpromoted | [elemTy] <- elems -> HsListTy noAnn (toLHsType elemTy)
+        A.Unpromoted -> HsExplicitListTy (noAnn, noAnn, noAnn) NotPromoted (map toLHsType elems)
+    A.TParen inner -> HsParTy parAnn (toLHsType inner)
+    A.TKindSig inner kind -> HsKindSig noAnn (toLHsType inner) (toLHsType kind)
+    A.TContext context body -> HsQualTy noExtField (lA (map toLHsType context)) (toLHsType body)
+    A.TSplice expr -> HsSpliceTy noExtField (HsUntypedSpliceExpr noAnn (toGhcLHsExpr expr))
+    A.TWildcard -> HsWildCardTy noAnn
+
+builtinType :: A.TypeBuiltinCon -> HsType GhcPs
+builtinType builtin =
+  case builtin of
+    A.TBuiltinTuple arity -> HsTyVar noAnn NotPromoted (lA (getRdrName (tupleDataCon Boxed arity)))
+    A.TBuiltinArrow -> HsTyVar noAnn NotPromoted (lA (getRdrName unrestrictedFunTyConName))
+    A.TBuiltinList -> HsTyVar noAnn NotPromoted (lA (getRdrName nilDataCon))
+    A.TBuiltinCons -> HsTyVar noAnn NotPromoted (lA (mkRdrUnqual (mkDataOcc ":")))
+
+typeLit :: A.TypeLiteral -> HsTyLit GhcPs
+typeLit lit =
+  case lit of
+    A.TypeLitInteger value _ -> HsNumTy NoSourceText value
+    A.TypeLitSymbol value _ -> HsStrTy NoSourceText (mkFastString (T.unpack value))
+    A.TypeLitChar value _ -> HsCharTy NoSourceText value
+
+toWcType :: A.Type -> LHsWcType GhcPs
+toWcType ty = HsWC noExtField (toLHsType ty)
+
+toSigWcType :: A.Type -> LHsSigWcType GhcPs
+toSigWcType ty =
+  case A.peelTypeAnn ty of
+    A.TAnn _ inner -> toSigWcType inner
+    A.TForall (A.ForallTelescope A.ForallInvisible binders) body ->
+      HsWC noExtField (lA (HsSig noExtField (HsOuterExplicit noAnn (map toInvisibleTyVarBndr binders)) (toLHsType body)))
+    _ ->
+      HsWC noExtField (lA (HsSig noExtField (HsOuterImplicit noExtField) (toLHsType ty)))
+
+forallTele :: A.ForallTelescope -> HsForAllTelescope GhcPs
+forallTele (A.ForallTelescope visibility binders) =
+  case visibility of
+    A.ForallVisible -> HsForAllVis noAnn (map (toTyVarBndr ()) binders)
+    A.ForallInvisible -> HsForAllInvis noAnn (map toInvisibleTyVarBndr binders)
+
+toInvisibleTyVarBndr :: A.TyVarBinder -> LHsTyVarBndr Specificity GhcPs
+toInvisibleTyVarBndr binder =
+  toTyVarBndr specificity binder
+  where
+    specificity =
+      case A.tyVarBinderSpecificity binder of
+        A.TyVarBInferred -> InferredSpec
+        A.TyVarBSpecified -> SpecifiedSpec
+
+toTyVarBndr :: flag -> A.TyVarBinder -> LHsTyVarBndr flag GhcPs
+toTyVarBndr flag binder =
+  lA (HsTvb noAnn flag (HsBndrVar noExtField (lA (mkRdrUnqual (mkVarOcc (T.unpack (A.tyVarBinderName binder)))))) kind)
+  where
+    kind = maybe (HsBndrNoKind noExtField) (HsBndrKind noExtField . toLHsType) (A.tyVarBinderKind binder)
+
+multAnn :: A.ArrowKind -> HsMultAnn GhcPs
+multAnn arrow =
+  case arrow of
+    A.ArrowUnrestricted -> HsUnannotated EpPatBind
+    A.ArrowLinear -> HsLinearAnn noAnn
+    A.ArrowExplicit ty -> HsExplicitMult (noAnn, EpPatBind) (toLHsType ty)
+
+localBinds :: [A.Decl] -> HsLocalBinds GhcPs
+localBinds decls =
+  let (binds, sigs) = foldMap declBindSig decls
+   in if null binds && null sigs
+        then EmptyLocalBinds noExtField
+        else HsValBinds noAnn (ValBinds NoAnnSortKey binds sigs)
+
+whereBinds :: Maybe [A.Decl] -> HsLocalBinds GhcPs
+whereBinds Nothing = EmptyLocalBinds noExtField
+whereBinds (Just decls) =
+  let (binds, sigs) = foldMap declBindSig decls
+   in HsValBinds noAnn (ValBinds NoAnnSortKey binds sigs)
+
+declBindSig :: A.Decl -> ([LHsBind GhcPs], [LSig GhcPs])
+declBindSig decl =
+  case A.peelDeclAnn decl of
+    A.DeclAnn _ inner -> declBindSig inner
+    A.DeclValue value -> ([lA (valueBind value)], [])
+    A.DeclTypeSig names ty -> ([], [lA (TypeSig noAnn (map (lA . toRdrName . A.qualifyName Nothing) names) (toSigWcType ty))])
+    A.DeclSplice expr -> ([lA (PatBind noExtField (lA (SplicePat noExtField (HsUntypedSpliceExpr noAnn (toGhcLHsExpr expr)))) (HsUnannotated EpPatBind) (grhss (A.UnguardedRhs [] (A.EVar "undefined") Nothing)))], [])
+    _ -> ([], [])
+
+valueBind :: A.ValueDecl -> HsBind GhcPs
+valueBind value =
+  case value of
+    A.FunctionBind name matches ->
+      FunBind noExtField (lA funName) (matchGroup (FunRhs (lA funName) Prefix NoSrcStrict noAnn) (map (functionMatch name) matches))
+      where
+        funName = toRdrName (A.qualifyName Nothing name)
+    A.PatternBind A.NoMultiplicityTag (A.PVar name) rhs ->
+      FunBind noExtField (lA funName) (matchGroup (FunRhs (lA funName) Prefix NoSrcStrict noAnn) [match (FunRhs (lA funName) Prefix NoSrcStrict noAnn) [] rhs])
+      where
+        funName = toRdrName (A.qualifyName Nothing name)
+    A.PatternBind A.NoMultiplicityTag pat rhs
+      | Just name <- strictVarPatName pat ->
+          let funName = toRdrName (A.qualifyName Nothing name)
+           in FunBind noExtField (lA funName) (matchGroup (FunRhs (lA funName) Prefix SrcStrict noAnn) [match (FunRhs (lA funName) Prefix SrcStrict noAnn) [] rhs])
+    A.PatternBind multiplicity pat rhs ->
+      PatBind noExtField (toLPat pat) (patMult multiplicity) (grhss rhs)
+
+strictVarPatName :: A.Pattern -> Maybe A.UnqualifiedName
+strictVarPatName pat =
+  case A.peelPatternAnn pat of
+    A.PAnn _ inner -> strictVarPatName inner
+    A.PStrict inner ->
+      case A.peelPatternAnn inner of
+        A.PAnn _ inner' -> strictVarPatName (A.PStrict inner')
+        A.PVar name -> Just name
+        _ -> Nothing
+    _ -> Nothing
+
+functionMatch :: A.BinderName -> A.Match -> Match GhcPs (LHsExpr GhcPs)
+functionMatch name (A.Match _ headForm pats rhs) =
+  Match noExtField FunRhs {mc_fun = lA (toRdrName (A.qualifyName Nothing name)), mc_fixity = fixity, mc_strictness = NoSrcStrict, mc_an = noAnn} (lA (map toLPat pats)) (grhss rhs)
+  where
+    fixity =
+      case headForm of
+        A.MatchHeadPrefix -> Prefix
+        A.MatchHeadInfix -> Infix
+
+caseAltMatch :: A.CaseAlt A.Expr -> Match GhcPs (LHsExpr GhcPs)
+caseAltMatch = caseAltMatchWith CaseAlt
+
+caseAltMatchWith :: HsMatchContext (LIdP GhcPs) -> A.CaseAlt A.Expr -> Match GhcPs (LHsExpr GhcPs)
+caseAltMatchWith context (A.CaseAlt _ pat rhs) = match context [pat] rhs
+
+lambdaCasesAltMatchWith :: HsMatchContext (LIdP GhcPs) -> A.LambdaCaseAlt -> Match GhcPs (LHsExpr GhcPs)
+lambdaCasesAltMatchWith context (A.LambdaCaseAlt _ pats rhs) = match context pats rhs
+
+match :: HsMatchContext (LIdP GhcPs) -> [A.Pattern] -> A.Rhs A.Expr -> Match GhcPs (LHsExpr GhcPs)
+match context pats rhs =
+  Match noExtField context (lA (map toLPat pats)) (grhss rhs)
+
+matchGroup :: HsMatchContext (LIdP GhcPs) -> [Match GhcPs (LHsExpr GhcPs)] -> MatchGroup GhcPs (LHsExpr GhcPs)
+matchGroup _ matches =
+  MG FromSource (lA (map lA matches))
+
+grhss :: A.Rhs A.Expr -> GRHSs GhcPs (LHsExpr GhcPs)
+grhss rhs =
+  case rhs of
+    A.UnguardedRhs _ body whereDecls ->
+      GRHSs emptyComments (lA (GRHS noAnn [] (toGhcLHsExpr body)) :| []) (whereBinds whereDecls)
+    A.GuardedRhss _ rhss whereDecls ->
+      GRHSs emptyComments (nonEmpty (map toGRHS rhss)) (whereBinds whereDecls)
+
+toGRHS :: A.GuardedRhs A.Expr -> LGRHS GhcPs (LHsExpr GhcPs)
+toGRHS (A.GuardedRhs _ guards body) =
+  lA (GRHS noAnn (map guardStmt guards) (toGhcLHsExpr body))
+
+guardStmt :: A.GuardQualifier -> GuardLStmt GhcPs
+guardStmt guard =
+  lA $
+    case A.peelGuardQualifierAnn guard of
+      A.GuardAnn _ inner -> unLoc (guardStmt inner)
+      A.GuardExpr expr -> BodyStmt noExtField (toGhcLHsExpr expr) noSyntaxExpr noSyntaxExpr
+      A.GuardPat pat expr -> BindStmt noAnn (toLPat pat) (toGhcLHsExpr expr)
+      A.GuardLet decls -> LetStmt noAnn (localBinds decls)
+
+patMult :: A.MultiplicityTag -> HsMultAnn GhcPs
+patMult tag =
+  case tag of
+    A.NoMultiplicityTag -> HsUnannotated EpPatBind
+    A.LinearMultiplicityTag -> HsLinearAnn noAnn
+    A.ExplicitMultiplicityTag ty -> HsExplicitMult (noAnn, EpPatBind) (toLHsType ty)
+
+toLHsDecl :: A.Decl -> LHsDecl GhcPs
+toLHsDecl decl =
+  case declBindSig decl of
+    (bind : _, _) -> lA (ValD noExtField (unLoc bind))
+    (_, sig : _) -> lA (SigD noExtField (unLoc sig))
+    _ -> lA (SpliceD noExtField (SpliceDecl noExtField (lA (HsUntypedSpliceExpr noAnn (toGhcLHsExpr (A.EVar "unsupportedDecl")))) DollarSplice))
+
+toLHsCmd :: A.Cmd -> LHsCmd GhcPs
+toLHsCmd = lA . toHsCmd
+
+toHsCmd :: A.Cmd -> HsCmd GhcPs
+toHsCmd cmd =
+  case A.peelCmdAnn cmd of
+    A.CmdAnn _ inner -> toHsCmd inner
+    A.CmdArrApp lhs appTy rhs -> HsCmdArrApp (NormalSyntax, EpaSpan noSrcSpan) (toGhcLHsExpr lhs) (toGhcLHsExpr rhs) (arrAppType appTy) True
+    A.CmdInfix lhs op rhs -> HsCmdArrForm noAnn (operatorExpr op) Infix [cmdTop lhs, cmdTop rhs]
+    A.CmdDo stmts -> HsCmdDo noAnn (lA (cmdDoStmts stmts))
+    A.CmdIf cond yes no -> HsCmdIf noAnn noSyntaxExpr (toGhcLHsExpr cond) (toLHsCmd yes) (toLHsCmd no)
+    A.CmdCase scrut alts -> HsCmdCase noAnn (toGhcLHsExpr scrut) (cmdMatchGroup CaseAlt (map cmdCaseAltMatch alts))
+    A.CmdLet decls body -> HsCmdLet noAnn (localBinds decls) (toLHsCmd body)
+    A.CmdLam pats body -> HsCmdLam noAnn LamSingle (cmdMatchGroup (LamAlt LamSingle) [cmdMatch (LamAlt LamSingle) pats (A.UnguardedRhs [] body Nothing)])
+    A.CmdApp fun arg -> HsCmdApp noExtField (toLHsCmd fun) (toGhcLHsExpr arg)
+    A.CmdPar inner -> HsCmdPar parAnn (toLHsCmd inner)
+
+cmdTop :: A.Cmd -> LHsCmdTop GhcPs
+cmdTop cmd = lA (HsCmdTop noExtField (toLHsCmd cmd))
+
+arrAppType :: A.ArrAppType -> HsArrAppType
+arrAppType appTy =
+  case appTy of
+    A.HsFirstOrderApp -> HsFirstOrderApp
+    A.HsHigherOrderApp -> HsHigherOrderApp
+
+cmdDoStmts :: [A.DoStmt A.Cmd] -> [CmdLStmt GhcPs]
+cmdDoStmts [] = []
+cmdDoStmts [A.DoExpr cmd] = [lA (LastStmt noExtField (toLHsCmd cmd) Nothing noSyntaxExpr)]
+cmdDoStmts (stmt : rest) = toCmdDoStmt stmt : cmdDoStmts rest
+
+toCmdDoStmt :: A.DoStmt A.Cmd -> CmdLStmt GhcPs
+toCmdDoStmt stmt =
+  lA $
+    case A.peelDoStmtAnn stmt of
+      A.DoAnn _ inner -> unLoc (toCmdDoStmt inner)
+      A.DoBind pat body -> BindStmt noAnn (toLPat pat) (toLHsCmd body)
+      A.DoLetDecls decls -> LetStmt noAnn (localBinds decls)
+      A.DoExpr body -> BodyStmt noExtField (toLHsCmd body) noSyntaxExpr noSyntaxExpr
+      A.DoRecStmt stmts ->
+        RecStmt
+          noAnn
+          (lA (map toCmdDoStmt stmts))
+          []
+          []
+          noSyntaxExpr
+          noSyntaxExpr
+          noSyntaxExpr
+
+cmdCaseAltMatch :: A.CaseAlt A.Cmd -> Match GhcPs (LHsCmd GhcPs)
+cmdCaseAltMatch (A.CaseAlt _ pat rhs) = cmdMatch CaseAlt [pat] rhs
+
+cmdMatch :: HsMatchContext (LIdP GhcPs) -> [A.Pattern] -> A.Rhs A.Cmd -> Match GhcPs (LHsCmd GhcPs)
+cmdMatch context pats rhs =
+  Match noExtField context (lA (map toLPat pats)) (cmdGrhss rhs)
+
+cmdMatchGroup :: HsMatchContext (LIdP GhcPs) -> [Match GhcPs (LHsCmd GhcPs)] -> MatchGroup GhcPs (LHsCmd GhcPs)
+cmdMatchGroup _ matches =
+  MG FromSource (lA (map lA matches))
+
+cmdGrhss :: A.Rhs A.Cmd -> GRHSs GhcPs (LHsCmd GhcPs)
+cmdGrhss rhs =
+  case rhs of
+    A.UnguardedRhs _ body whereDecls ->
+      GRHSs emptyComments (lA (GRHS noAnn [] (toLHsCmd body)) :| []) (whereBinds whereDecls)
+    A.GuardedRhss _ rhss whereDecls ->
+      GRHSs emptyComments (nonEmpty (map cmdGRHS rhss)) (whereBinds whereDecls)
+
+cmdGRHS :: A.GuardedRhs A.Cmd -> LGRHS GhcPs (LHsCmd GhcPs)
+cmdGRHS (A.GuardedRhs _ guards body) =
+  lA (GRHS noAnn (map guardStmt guards) (toLHsCmd body))
+
+quotedExprName :: A.Expr -> LIdP GhcPs
+quotedExprName expr =
+  case A.peelExprAnn expr of
+    A.EVar name -> lA (toRdrName name)
+    A.EList [] -> lA (getRdrName nilDataCon)
+    A.ETuple flavor elems -> lA (getRdrName (tupleDataCon (boxity flavor) (length elems)))
+    _ -> lA (mkRdrUnqual (mkVarOcc "unsupportedQuote"))
+
+quotedTypeName :: A.Type -> LIdP GhcPs
+quotedTypeName ty =
+  case A.peelTypeAnn ty of
+    A.TCon name _ -> lA (toRdrName name)
+    A.TBuiltinCon A.TBuiltinList -> lA (getRdrName nilDataCon)
+    A.TTuple flavor _ elems -> lA (getRdrName (tupleTyCon (boxity flavor) (length elems)))
+    _ -> lA (mkRdrUnqual (mkDataOcc "UnsupportedQuote"))
+
+toRdrName :: A.Name -> RdrName
+toRdrName name =
+  let occ = case A.nameType name of
+        A.NameVarId -> mkVarOcc
+        A.NameVarSym -> mkVarOcc
+        A.NameConId -> mkDataOcc
+        A.NameConSym -> mkDataOcc
+      local = occ (T.unpack (A.nameText name))
+   in case A.nameQualifier name of
+        Nothing -> mkRdrUnqual local
+        Just qualifier -> mkRdrQual (mkModuleName (T.unpack qualifier)) local
+
+boxity :: A.TupleFlavor -> Boxity
+boxity flavor =
+  case flavor of
+    A.Boxed -> Boxed
+    A.Unboxed -> Unboxed
+
+tupleSort :: A.TupleFlavor -> HsTupleSort
+tupleSort flavor =
+  case flavor of
+    A.Boxed -> HsBoxedOrConstraintTuple
+    A.Unboxed -> HsUnboxedTuple
+
+promotionFlag :: A.TypePromotion -> PromotionFlag
+promotionFlag promotion =
+  case promotion of
+    A.Unpromoted -> NotPromoted
+    A.Promoted -> IsPromoted
+
+sourceText :: T.Text -> SourceText
+sourceText = SourceText . mkFastString . T.unpack
+
+lA :: (HasAnnotation e) => a -> GenLocated e a
+lA = noLocA
+
+recordAnn :: (Maybe (EpToken "{"), Maybe (EpToken "}"))
+recordAnn = (Just noAnn, Just noAnn)
+
+conPatAnn :: (Maybe (EpToken "{"), Maybe (EpToken "}"))
+conPatAnn = (Nothing, Nothing)
+
+parAnn :: (EpToken "(", EpToken ")")
+parAnn = (noAnn, noAnn)
+
+tupleAnn :: (EpaLocation, EpaLocation)
+tupleAnn = (EpaSpan noSrcSpan, EpaSpan noSrcSpan)
+
+nonEmpty :: [a] -> NonEmpty a
+nonEmpty [] = error "aihc-parser-compat: expected a non-empty list"
+nonEmpty (x : xs) = x :| xs

--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Ghc.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Ghc.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Aihc.Parser.Compat.Internal.Ghc
+  ( compatGhcExtensions,
+    normalizeGhcAst,
+    parseCompatLocatedExpr,
+    parseCompatExpr,
+    parseGhcLocatedExpr,
+    unsafeParseCompatExpr,
+    unsafeParseCompatLocatedExpr,
+  )
+where
+
+import Aihc.Parser.Syntax qualified as Syntax
+import Control.Exception (SomeException, catch, displayException, evaluate)
+import Data.Data (Data (..), Typeable, cast)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Data.EnumSet qualified as EnumSet
+import GHC.Data.FastString (mkFastString)
+import GHC.Data.StringBuffer (stringToStringBuffer)
+import GHC.Hs (GhcPs, LHsExpr)
+import GHC.LanguageExtensions.Type qualified as GHC
+import GHC.Parser (parseExpression)
+import GHC.Parser.Annotation
+  ( EpAnnComments,
+    EpaLocation,
+    emptyComments,
+    noAnnSrcSpan,
+  )
+import GHC.Parser.Lexer
+  ( PState,
+    ParseResult (..),
+    Token (..),
+    getPsErrorMessages,
+    initParserState,
+    lexer,
+    mkParserOpts,
+    unP,
+  )
+import GHC.Parser.PostProcess (ECP (..), runPV)
+import GHC.Types.Error (NoDiagnosticOpts (NoDiagnosticOpts), errorsFound)
+import GHC.Types.SrcLoc
+  ( EpaLocation' (..),
+    GenLocated (..),
+    NoCommentsLocation,
+    SrcSpan,
+    mkRealSrcLoc,
+    noSrcSpan,
+    unLoc,
+  )
+import GHC.Utils.Error (emptyDiagOpts, pprMessages)
+import GHC.Utils.Outputable (showSDocUnsafe)
+import Language.Haskell.Syntax.Expr (HsExpr)
+import System.IO.Unsafe (unsafePerformIO)
+
+compatGhcExtensions :: [GHC.Extension]
+compatGhcExtensions =
+  mapMaybe toGhcExtension compatAihcExtensions
+
+compatAihcExtensions :: [Syntax.Extension]
+compatAihcExtensions =
+  Syntax.effectiveExtensions Syntax.GHC2024Edition $
+    map
+      Syntax.EnableExtension
+      [ Syntax.Arrows,
+        Syntax.BlockArguments,
+        Syntax.CApiFFI,
+        Syntax.ExplicitNamespaces,
+        Syntax.ImplicitParams,
+        Syntax.LambdaCase,
+        Syntax.LinearTypes,
+        Syntax.MagicHash,
+        Syntax.MultiWayIf,
+        Syntax.OverloadedLabels,
+        Syntax.OverloadedRecordDot,
+        Syntax.ParallelListComp,
+        Syntax.PatternSynonyms,
+        Syntax.QualifiedDo,
+        Syntax.QuasiQuotes,
+        Syntax.RecursiveDo,
+        Syntax.RequiredTypeArguments,
+        Syntax.TemplateHaskell,
+        Syntax.TransformListComp,
+        Syntax.TupleSections,
+        Syntax.TypeAbstractions,
+        Syntax.TypeApplications,
+        Syntax.UnboxedSums,
+        Syntax.UnboxedTuples,
+        Syntax.UnicodeSyntax,
+        Syntax.ViewPatterns
+      ]
+
+parseCompatExpr :: Text -> Either Text (HsExpr GhcPs)
+parseCompatExpr source = unLoc <$> parseCompatLocatedExpr source
+
+parseCompatLocatedExpr :: Text -> Either Text (LHsExpr GhcPs)
+parseCompatLocatedExpr source =
+  case parseGhcLocatedExpr compatGhcExtensions source of
+    Left err -> Left err
+    Right expr -> Right (normalizeGhcAst expr)
+
+unsafeParseCompatExpr :: Text -> HsExpr GhcPs
+unsafeParseCompatExpr source = unLoc (unsafeParseCompatLocatedExpr source)
+
+unsafeParseCompatLocatedExpr :: Text -> LHsExpr GhcPs
+unsafeParseCompatLocatedExpr source =
+  case parseCompatLocatedExpr source of
+    Left err -> error ("ghc-lib-parser failed to parse converted expression:\n" <> T.unpack err <> "\nsource:\n" <> T.unpack source)
+    Right expr -> expr
+
+parseGhcLocatedExpr :: [GHC.Extension] -> Text -> Either Text (LHsExpr GhcPs)
+parseGhcLocatedExpr exts input =
+  let opts = mkParserOpts (EnumSet.fromList exts) emptyDiagOpts False False False True
+      buffer = stringToStringBuffer (T.unpack input)
+      start = mkRealSrcLoc (mkFastString "<aihc-parser-compat>") 1 1
+   in case catchPureExceptionText $ case unP parseExpression (initParserState opts buffer start) of
+        POk st ecp ->
+          case unP (runPV (unECP ecp)) st of
+            POk st' (expr :: LHsExpr GhcPs) ->
+              if parserStateHasErrors st'
+                then Left (renderParserErrors st')
+                else case firstSignificantToken st' of
+                  Right tok ->
+                    case unLoc tok of
+                      ITeof -> Right expr
+                      _ -> Left ("GHC parser accepted expression prefix but left trailing token: " <> T.pack (show tok))
+                  Left lexErr -> Left ("GHC lexer failed while checking for trailing tokens: " <> lexErr)
+            PFailed st' -> Left (renderParserErrors st')
+        PFailed st -> Left (renderParserErrors st) of
+        Left err -> Left ("GHC parser exception: " <> err)
+        Right result -> result
+
+firstSignificantToken :: PState -> Either Text (GenLocated SrcSpan Token)
+firstSignificantToken = firstSignificantTokenWithFuel 10000
+
+firstSignificantTokenWithFuel :: Int -> PState -> Either Text (GenLocated SrcSpan Token)
+firstSignificantTokenWithFuel fuel st
+  | fuel <= 0 = Left "GHC lexer exceeded trailing-token scan limit"
+  | otherwise =
+      case unP (lexer False pure) st of
+        POk st' tok
+          | isIgnorableToken (unLoc tok) -> firstSignificantTokenWithFuel (fuel - 1) st'
+          | otherwise -> Right tok
+        PFailed st' -> Left (renderParserErrors st')
+
+renderParserErrors :: PState -> Text
+renderParserErrors st =
+  T.pack (showSDocUnsafe (pprMessages NoDiagnosticOpts (getPsErrorMessages st)))
+
+parserStateHasErrors :: PState -> Bool
+parserStateHasErrors st = errorsFound (getPsErrorMessages st)
+
+isIgnorableToken :: Token -> Bool
+isIgnorableToken tok =
+  case tok of
+    ITlineComment {} -> True
+    ITblockComment {} -> True
+    _ -> False
+
+catchPureExceptionText :: a -> Either Text a
+catchPureExceptionText value =
+  unsafePerformIO $ do
+    (Right <$> evaluate value)
+      `catch` \(err :: SomeException) ->
+        pure (Left (T.pack (displayException err)))
+{-# NOINLINE catchPureExceptionText #-}
+
+-- This only catches exceptions raised while evaluating the parser's outer
+-- result constructor.  Nested lazy exceptions are still surfaced by callers.
+
+normalizeGhcAst :: (Data a) => a -> a
+normalizeGhcAst =
+  everywhere
+    ( id
+        `extT` emptySrcSpan
+        `extT` emptyEpaLocation
+        `extT` emptyNoCommentsLocation
+        `extT` emptyEpAnnComments
+    )
+
+emptySrcSpan :: SrcSpan -> SrcSpan
+emptySrcSpan _ = noSrcSpan
+
+emptyEpaLocation :: EpaLocation -> EpaLocation
+emptyEpaLocation _ = noAnnSrcSpan noSrcSpan
+
+emptyNoCommentsLocation :: NoCommentsLocation -> NoCommentsLocation
+emptyNoCommentsLocation _ = EpaSpan noSrcSpan
+
+emptyEpAnnComments :: EpAnnComments -> EpAnnComments
+emptyEpAnnComments _ = emptyComments
+
+everywhere :: (forall a. (Data a) => a -> a) -> forall a. (Data a) => a -> a
+everywhere f = go
+  where
+    go :: (Data a) => a -> a
+    go = f . gmapT go
+
+extT :: forall a b. (Typeable a, Typeable b) => (a -> a) -> (b -> b) -> a -> a
+extT f g x =
+  case cast x of
+    Just y -> fromMaybe (f x) (cast (g y))
+    Nothing -> f x
+
+toGhcExtension :: Syntax.Extension -> Maybe GHC.Extension
+toGhcExtension ext =
+  case ext of
+    Syntax.NondecreasingIndentation ->
+      lookupAny ["NondecreasingIndentation", "AlternativeLayoutRule", "AlternativeLayoutRuleTransitional", "RelaxedLayout"]
+    _ ->
+      lookupAny [toGhcExtensionName ext]
+  where
+    ghcExtensions = [(show ghcExt, ghcExt) | ghcExt <- [minBound .. maxBound]]
+
+    lookupAny [] = Nothing
+    lookupAny (name : names) =
+      case lookup name ghcExtensions of
+        Just ghcExt -> Just ghcExt
+        Nothing -> lookupAny names
+
+    toGhcExtensionName Syntax.CPP = "Cpp"
+    toGhcExtensionName Syntax.GeneralizedNewtypeDeriving = "GeneralisedNewtypeDeriving"
+    toGhcExtensionName Syntax.SafeHaskell = "Safe"
+    toGhcExtensionName Syntax.Trustworthy = "Trustworthy"
+    toGhcExtensionName Syntax.UnsafeHaskell = "Unsafe"
+    toGhcExtensionName Syntax.Rank2Types = "RankNTypes"
+    toGhcExtensionName Syntax.PolymorphicComponents = "RankNTypes"
+    toGhcExtensionName other = T.unpack (Syntax.extensionName other)

--- a/components/aihc-parser-compat/test/Spec.hs
+++ b/components/aihc-parser-compat/test/Spec.hs
@@ -1,0 +1,11 @@
+module Main (main) where
+
+import Test.Compat.Expr (exprCompatTests)
+import Test.Tasty
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "aihc-parser-compat"
+      [exprCompatTests]

--- a/components/aihc-parser-compat/test/Test/Compat/Expr.hs
+++ b/components/aihc-parser-compat/test/Test/Compat/Expr.hs
@@ -1,0 +1,629 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Compat.Expr
+  ( exprCompatTests,
+  )
+where
+
+import Aihc.Parser qualified as Aihc
+import Aihc.Parser.Compat (toGhcHsExpr)
+import Aihc.Parser.Compat.Internal.Ghc
+  ( compatGhcExtensions,
+    normalizeGhcAst,
+    parseGhcLocatedExpr,
+  )
+import Aihc.Parser.Parens (addExprParens)
+import Aihc.Parser.Pretty ()
+import Aihc.Parser.Syntax hiding (Match, RecordCon)
+import Data.ByteString (ByteString)
+import Data.Data (Data, gmapQ, showConstr, toConstr)
+import Data.List (isPrefixOf)
+import Data.List.NonEmpty qualified as NE
+import Data.Proxy (Proxy (..))
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Typeable (cast)
+import GHC.Data.FastString (FastString)
+import GHC.Hs
+  ( ArithSeqInfo (..),
+    DotFieldOcc (..),
+    FieldOcc (..),
+    GRHS (..),
+    GRHSs (..),
+    GhcPs,
+    HsCmd (..),
+    HsCmdTop (..),
+    HsExpr (..),
+    HsFieldBind (..),
+    HsLocalBindsLR (..),
+    HsQuote (..),
+    HsRecFields (..),
+    HsTupArg (..),
+    HsTypedSplice (..),
+    HsUntypedSplice (..),
+    HsValBindsLR (..),
+    LGRHS,
+    LHsCmd,
+    LHsCmdTop,
+    LHsExpr,
+    LHsRecUpdFields (..),
+    LMatch,
+    Match (..),
+    MatchGroup (..),
+    ParStmtBlock (..),
+    StmtLR (..),
+  )
+import GHC.Types.Name.Reader (RdrName, rdrNameOcc)
+import GHC.Types.SrcLoc (GenLocated, unLoc)
+import GHC.Utils.Outputable (Outputable, ppr, showSDocUnsafe)
+import Language.Haskell.Syntax.Basic (FieldLabelString)
+import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
+import Prettyprinter.Render.Text (renderStrict)
+import Test.Properties.Arb.Expr ()
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck qualified as QC
+
+exprCompatTests :: TestTree
+exprCompatTests =
+  testGroup
+    "expr"
+    [ testGroup
+        "examples"
+        [ example "variable" (EVar "x"),
+          example "integer" (EInt 42 TInteger "42"),
+          example "empty list" (EList []),
+          example "unit tuple" (ETuple Boxed []),
+          example "unboxed unit tuple" (ETuple Unboxed []),
+          example "tuple section" (ETuple Boxed [Just (EVar "x"), Nothing]),
+          example "unboxed sum" (EUnboxedSum 1 3 (EVar "x")),
+          example "infix application" (EInfix (EVar "x") "+" (EVar "y")),
+          example "left section" (ESectionL (EVar "x") "+"),
+          example "right section" (ESectionR "+" (EVar "x")),
+          example "lambda" (ELambdaPats [PVar "x"] (EVar "x")),
+          example "lambda-case" (ELambdaCase [CaseAlt [] (PVar "x") (UnguardedRhs [] (EVar "x") Nothing)]),
+          example "do" (EDo [DoExpr (EVar "x")] DoPlain),
+          example "mdo" (EDo [DoExpr (EVar "x")] DoMdo),
+          example "qualified do" (EDo [DoExpr (EVar "x")] (DoQualified "M")),
+          example "record construction" (ERecordCon "C" [RecordField "x" (EVar "y") False] False),
+          example "record update" (ERecordUpd (EVar "r") [RecordField "x" (EVar "y") False]),
+          example "type application" (ETypeApp (EVar "f") (TCon "Int" Unpromoted)),
+          example "type signature" (ETypeSig (EVar "x") (TCon "Int" Unpromoted)),
+          example "TH expression quote" (ETHExpQuote (EVar "x")),
+          example "TH splice" (ETHSplice (EParen (EVar "x"))),
+          example "record dot" (EGetField (EVar "r") "x"),
+          example "record projection" (EGetFieldProjection ["x", "y"]),
+          testCase "repeated infix application matches GHC" repeatedInfixParser
+        ],
+      QC.testProperty "generated expr converts to normalized GHC parsed AST" prop_exprCompat
+    ]
+
+repeatedInfixParser :: Assertion
+repeatedInfixParser = do
+  let source = "1 + 2 + 3"
+  aihcExpr <-
+    case Aihc.parseExpr Aihc.defaultConfig source of
+      Aihc.ParseErr err -> assertFailure (Aihc.formatParseErrorBundle "<compat-test>" (Just source) err)
+      Aihc.ParseOk expr -> pure expr
+  ghcExpr <-
+    case parseGhcLocatedExpr compatGhcExtensions source of
+      Left err -> assertFailure (T.unpack err)
+      Right expr -> pure (normalizeGhcAst (unLoc expr))
+  let convertedExpr = toGhcHsExpr aihcExpr
+  assertBool
+    ("expected: " <> renderGhc ghcExpr <> "\nactual: " <> renderGhc convertedExpr)
+    (eqHsExprIgnoringAnnotations ghcExpr convertedExpr)
+
+prop_exprCompat :: Expr -> QC.Property
+prop_exprCompat expr =
+  let parenthesized = addExprParens expr
+      source = renderExpr parenthesized
+   in QC.counterexample (T.unpack source) $
+        case parseGhcLocatedExpr compatGhcExtensions source of
+          Left err -> QC.counterexample (T.unpack err) False
+          Right parsed ->
+            let expected = normalizeGhcAst (unLoc parsed)
+                actual = toGhcHsExpr parenthesized
+             in QC.counterexample (exprMismatch expected actual) $
+                  eqHsExprIgnoringAnnotations expected actual
+
+example :: TestName -> Expr -> TestTree
+example label expr =
+  testCase label $ do
+    let parenthesized = addExprParens expr
+        source = renderExpr parenthesized
+    case parseGhcLocatedExpr compatGhcExtensions source of
+      Left err -> assertFailure (T.unpack err <> "\nsource:\n" <> T.unpack source)
+      Right parsed -> do
+        let expected = normalizeGhcAst (unLoc parsed)
+            actual = toGhcHsExpr parenthesized
+        assertBool (T.unpack source <> "\n" <> exprMismatch expected actual) $
+          eqHsExprIgnoringAnnotations expected actual
+
+renderExpr :: Expr -> Text
+renderExpr = renderStrict . layoutPretty defaultLayoutOptions . pretty
+
+exprMismatch :: HsExpr GhcPs -> HsExpr GhcPs -> String
+exprMismatch expected actual =
+  unlines
+    [ "expected pretty: " <> renderGhc expected,
+      "actual pretty: " <> renderGhc actual,
+      "expected comparison tree:",
+      comparisonDump expected,
+      "actual comparison tree:",
+      comparisonDump actual
+    ]
+
+eqHsExprIgnoringAnnotations :: HsExpr GhcPs -> HsExpr GhcPs -> Bool
+eqHsExprIgnoringAnnotations left right =
+  case (left, right) of
+    (HsVar _ a, HsVar _ b) -> sameStructural (unLoc a) (unLoc b)
+    (HsOverLabel _ a, HsOverLabel _ b) -> a == b
+    (HsIPVar _ a, HsIPVar _ b) -> a == b
+    (HsOverLit _ a, HsOverLit _ b) -> sameStructural a b
+    (HsLit _ a, HsLit _ b) -> sameStructural a b
+    (HsLam _ variantA matchesA, HsLam _ variantB matchesB) ->
+      variantA == variantB && eqMatchGroup matchesA matchesB
+    (HsApp _ funA argA, HsApp _ funB argB) ->
+      eqLocatedHsExpr funA funB && eqLocatedHsExpr argA argB
+    (HsAppType _ funA tyA, HsAppType _ funB tyB) ->
+      eqLocatedHsExpr funA funB && sameStructural tyA tyB
+    (OpApp _ lhsA opA rhsA, OpApp _ lhsB opB rhsB) ->
+      eqLocatedHsExpr lhsA lhsB && eqLocatedHsExpr opA opB && eqLocatedHsExpr rhsA rhsB
+    (NegApp _ exprA syntaxA, NegApp _ exprB syntaxB) ->
+      eqLocatedHsExpr exprA exprB && sameStructural syntaxA syntaxB
+    (HsPar _ exprA, HsPar _ exprB) ->
+      eqLocatedHsExpr exprA exprB
+    (HsPar _ exprA, exprB) ->
+      eqHsExprIgnoringAnnotations (unLoc exprA) exprB
+    (exprA, HsPar _ exprB) ->
+      eqHsExprIgnoringAnnotations exprA (unLoc exprB)
+    (SectionL _ exprA opA, SectionL _ exprB opB) ->
+      eqLocatedHsExpr exprA exprB && eqLocatedHsExpr opA opB
+    (SectionR _ opA exprA, SectionR _ opB exprB) ->
+      eqLocatedHsExpr opA opB && eqLocatedHsExpr exprA exprB
+    (ExplicitTuple _ argsA boxityA, ExplicitTuple _ argsB boxityB) ->
+      boxityA == boxityB && eqList eqHsTupArg argsA argsB
+    (ExplicitSum _ tagA arityA exprA, ExplicitSum _ tagB arityB exprB) ->
+      tagA == tagB && arityA == arityB && eqLocatedHsExpr exprA exprB
+    (HsCase _ scrutA matchesA, HsCase _ scrutB matchesB) ->
+      eqLocatedHsExpr scrutA scrutB && eqMatchGroup matchesA matchesB
+    (HsIf _ condA yesA noA, HsIf _ condB yesB noB) ->
+      eqLocatedHsExpr condA condB && eqLocatedHsExpr yesA yesB && eqLocatedHsExpr noA noB
+    (HsMultiIf _ rhssA, HsMultiIf _ rhssB) ->
+      eqNonEmpty eqLocatedGRHS rhssA rhssB
+    (HsLet _ bindsA exprA, HsLet _ bindsB exprB) ->
+      eqLocalBinds bindsA bindsB && eqLocatedHsExpr exprA exprB
+    (HsDo _ flavorA stmtsA, HsDo _ flavorB stmtsB) ->
+      flavorA == flavorB && eqList eqLocatedStmt (unLoc stmtsA) (unLoc stmtsB)
+    (ExplicitList _ exprsA, ExplicitList _ exprsB) ->
+      eqList eqLocatedHsExpr exprsA exprsB
+    (RecordCon {rcon_con = conA, rcon_flds = fieldsA}, RecordCon {rcon_con = conB, rcon_flds = fieldsB}) ->
+      sameStructural (unLoc conA) (unLoc conB) && eqHsRecFields fieldsA fieldsB
+    (RecordUpd {rupd_expr = exprA, rupd_flds = fieldsA}, RecordUpd {rupd_expr = exprB, rupd_flds = fieldsB}) ->
+      eqLocatedHsExpr exprA exprB && eqHsRecUpdFields fieldsA fieldsB
+    (HsGetField {gf_expr = exprA, gf_field = fieldA}, HsGetField {gf_expr = exprB, gf_field = fieldB}) ->
+      eqLocatedHsExpr exprA exprB && eqDotFieldOcc (unLoc fieldA) (unLoc fieldB)
+    (HsProjection {proj_flds = fieldsA}, HsProjection {proj_flds = fieldsB}) ->
+      eqList eqDotFieldOcc (NE.toList fieldsA) (NE.toList fieldsB)
+    (ExprWithTySig _ exprA tyA, ExprWithTySig _ exprB tyB) ->
+      eqLocatedHsExpr exprA exprB && sameStructural tyA tyB
+    (ArithSeq _ witnessA seqA, ArithSeq _ witnessB seqB) ->
+      sameStructural witnessA witnessB && eqArithSeqInfo seqA seqB
+    (HsTypedBracket _ exprA, HsTypedBracket _ exprB) ->
+      eqLocatedHsExpr exprA exprB
+    (HsUntypedBracket _ quoteA, HsUntypedBracket _ quoteB) ->
+      eqHsQuote quoteA quoteB
+    (HsTypedSplice _ spliceA, HsTypedSplice _ spliceB) ->
+      eqHsTypedSplice spliceA spliceB
+    (HsUntypedSplice _ spliceA, HsUntypedSplice _ spliceB) ->
+      eqHsUntypedSplice spliceA spliceB
+    (HsProc _ patA cmdA, HsProc _ patB cmdB) ->
+      sameStructural patA patB && eqLocatedHsCmdTop cmdA cmdB
+    (HsStatic _ exprA, HsStatic _ exprB) ->
+      eqLocatedHsExpr exprA exprB
+    (HsPragE _ pragA exprA, HsPragE _ pragB exprB) ->
+      sameStructural pragA pragB && eqLocatedHsExpr exprA exprB
+    (HsEmbTy _ tyA, HsEmbTy _ tyB) ->
+      sameStructural tyA tyB
+    (HsHole a, HsHole b) ->
+      sameConstructor a b
+    (HsForAll _ telescopeA exprA, HsForAll _ telescopeB exprB) ->
+      sameStructural telescopeA telescopeB && eqLocatedHsExpr exprA exprB
+    (HsQual _ contextA exprA, HsQual _ contextB exprB) ->
+      eqList eqLocatedHsExpr (unLoc contextA) (unLoc contextB) && eqLocatedHsExpr exprA exprB
+    (HsFunArr _ multA argA resA, HsFunArr _ multB argB resB) ->
+      sameStructural multA multB && eqLocatedHsExpr argA argB && eqLocatedHsExpr resA resB
+    _ -> False
+
+eqLocatedHsExpr :: LHsExpr GhcPs -> LHsExpr GhcPs -> Bool
+eqLocatedHsExpr left right = eqHsExprIgnoringAnnotations (unLoc left) (unLoc right)
+
+eqHsTupArg :: HsTupArg GhcPs -> HsTupArg GhcPs -> Bool
+eqHsTupArg left right =
+  case (left, right) of
+    (Present _ exprA, Present _ exprB) -> eqLocatedHsExpr exprA exprB
+    (Missing _, Missing _) -> True
+    _ -> False
+
+eqMatchGroup :: MatchGroup GhcPs (LHsExpr GhcPs) -> MatchGroup GhcPs (LHsExpr GhcPs) -> Bool
+eqMatchGroup left right =
+  case (left, right) of
+    (MG _ matchesA, MG _ matchesB) -> eqList eqLocatedMatch (unLoc matchesA) (unLoc matchesB)
+
+eqLocatedMatch :: LMatch GhcPs (LHsExpr GhcPs) -> LMatch GhcPs (LHsExpr GhcPs) -> Bool
+eqLocatedMatch left right =
+  case (unLoc left, unLoc right) of
+    (Match _ contextA patsA grhssA, Match _ contextB patsB grhssB) ->
+      sameStructural contextA contextB && sameStructural patsA patsB && eqGRHSs grhssA grhssB
+
+eqGRHSs :: GRHSs GhcPs (LHsExpr GhcPs) -> GRHSs GhcPs (LHsExpr GhcPs) -> Bool
+eqGRHSs left right =
+  case (left, right) of
+    (GRHSs _ grhssA bindsA, GRHSs _ grhssB bindsB) ->
+      eqNonEmpty eqLocatedGRHS grhssA grhssB && eqLocalBinds bindsA bindsB
+
+eqLocatedGRHS :: LGRHS GhcPs (LHsExpr GhcPs) -> LGRHS GhcPs (LHsExpr GhcPs) -> Bool
+eqLocatedGRHS left right =
+  case (unLoc left, unLoc right) of
+    (GRHS _ guardsA bodyA, GRHS _ guardsB bodyB) ->
+      eqList eqLocatedStmt guardsA guardsB && eqLocatedHsExpr bodyA bodyB
+
+eqLocatedStmt :: GenLocated location (StmtLR GhcPs GhcPs (LHsExpr GhcPs)) -> GenLocated location' (StmtLR GhcPs GhcPs (LHsExpr GhcPs)) -> Bool
+eqLocatedStmt left right =
+  case (unLoc left, unLoc right) of
+    (LastStmt _ bodyA _ _, LastStmt _ bodyB _ _) ->
+      eqLocatedHsExpr bodyA bodyB
+    (LastStmt _ bodyA _ _, BodyStmt _ bodyB _ _) ->
+      eqLocatedHsExpr bodyA bodyB
+    (BodyStmt _ bodyA _ _, LastStmt _ bodyB _ _) ->
+      eqLocatedHsExpr bodyA bodyB
+    (BindStmt _ patA bodyA, BindStmt _ patB bodyB) ->
+      sameStructural patA patB && eqLocatedHsExpr bodyA bodyB
+    (BodyStmt _ bodyA _ _, BodyStmt _ bodyB _ _) ->
+      eqLocatedHsExpr bodyA bodyB
+    (LetStmt _ bindsA, LetStmt _ bindsB) ->
+      eqLocalBinds bindsA bindsB
+    (ParStmt _ blocksA _ _, ParStmt _ blocksB _ _) ->
+      eqNonEmpty eqParStmtBlock blocksA blocksB
+    (TransStmt {trS_form = formA, trS_using = usingA, trS_by = byA}, TransStmt {trS_form = formB, trS_using = usingB, trS_by = byB}) ->
+      sameConstructor formA formB && eqLocatedHsExpr usingA usingB && eqMaybe eqLocatedHsExpr byA byB
+    (RecStmt {recS_stmts = stmtsA}, RecStmt {recS_stmts = stmtsB}) ->
+      eqList eqLocatedStmt (unLoc stmtsA) (unLoc stmtsB)
+    _ -> False
+
+eqLocatedHsCmdTop :: LHsCmdTop GhcPs -> LHsCmdTop GhcPs -> Bool
+eqLocatedHsCmdTop left right =
+  case (unLoc left, unLoc right) of
+    (HsCmdTop _ cmdA, HsCmdTop _ cmdB) -> eqLocatedHsCmd cmdA cmdB
+
+eqLocatedHsCmd :: LHsCmd GhcPs -> LHsCmd GhcPs -> Bool
+eqLocatedHsCmd left right =
+  eqHsCmdIgnoringAnnotations (unLoc left) (unLoc right)
+
+eqHsCmdIgnoringAnnotations :: HsCmd GhcPs -> HsCmd GhcPs -> Bool
+eqHsCmdIgnoringAnnotations left right =
+  case (left, right) of
+    (HsCmdArrApp _ lhsA rhsA appTyA _, HsCmdArrApp _ lhsB rhsB appTyB _) ->
+      eqLocatedHsExpr lhsA lhsB && eqLocatedHsExpr rhsA rhsB && sameConstructor appTyA appTyB
+    (HsCmdArrForm _ opA fixityA argsA, HsCmdArrForm _ opB fixityB argsB) ->
+      eqLocatedHsExpr opA opB && fixityA == fixityB && eqList eqLocatedHsCmdTop argsA argsB
+    (HsCmdApp _ funA argA, HsCmdApp _ funB argB) ->
+      eqLocatedHsCmd funA funB && eqLocatedHsExpr argA argB
+    (HsCmdLam _ variantA matchesA, HsCmdLam _ variantB matchesB) ->
+      variantA == variantB && sameStructural matchesA matchesB
+    (HsCmdPar _ cmdA, HsCmdPar _ cmdB) ->
+      eqLocatedHsCmd cmdA cmdB
+    (HsCmdCase _ scrutA matchesA, HsCmdCase _ scrutB matchesB) ->
+      eqLocatedHsExpr scrutA scrutB && sameStructural matchesA matchesB
+    (HsCmdIf _ _ condA yesA noA, HsCmdIf _ _ condB yesB noB) ->
+      eqLocatedHsExpr condA condB && eqLocatedHsCmd yesA yesB && eqLocatedHsCmd noA noB
+    (HsCmdLet _ bindsA cmdA, HsCmdLet _ bindsB cmdB) ->
+      eqLocalBinds bindsA bindsB && eqLocatedHsCmd cmdA cmdB
+    (HsCmdDo _ stmtsA, HsCmdDo _ stmtsB) ->
+      eqList eqLocatedCmdStmt (unLoc stmtsA) (unLoc stmtsB)
+    _ -> False
+
+eqLocatedCmdStmt :: GenLocated location (StmtLR GhcPs GhcPs (LHsCmd GhcPs)) -> GenLocated location' (StmtLR GhcPs GhcPs (LHsCmd GhcPs)) -> Bool
+eqLocatedCmdStmt left right =
+  case (unLoc left, unLoc right) of
+    (LastStmt _ bodyA _ _, LastStmt _ bodyB _ _) ->
+      eqLocatedHsCmd bodyA bodyB
+    (LastStmt _ bodyA _ _, BodyStmt _ bodyB _ _) ->
+      eqLocatedHsCmd bodyA bodyB
+    (BodyStmt _ bodyA _ _, LastStmt _ bodyB _ _) ->
+      eqLocatedHsCmd bodyA bodyB
+    (BindStmt _ patA bodyA, BindStmt _ patB bodyB) ->
+      sameStructural patA patB && eqLocatedHsCmd bodyA bodyB
+    (BodyStmt _ bodyA _ _, BodyStmt _ bodyB _ _) ->
+      eqLocatedHsCmd bodyA bodyB
+    (LetStmt _ bindsA, LetStmt _ bindsB) ->
+      eqLocalBinds bindsA bindsB
+    (RecStmt {recS_stmts = stmtsA}, RecStmt {recS_stmts = stmtsB}) ->
+      eqList eqLocatedCmdStmt (unLoc stmtsA) (unLoc stmtsB)
+    _ -> False
+
+eqParStmtBlock :: ParStmtBlock GhcPs GhcPs -> ParStmtBlock GhcPs GhcPs -> Bool
+eqParStmtBlock (ParStmtBlock _ stmtsA _ _) (ParStmtBlock _ stmtsB _ _) =
+  eqList eqLocatedStmt stmtsA stmtsB
+
+eqMaybe :: (a -> b -> Bool) -> Maybe a -> Maybe b -> Bool
+eqMaybe eq left right =
+  case (left, right) of
+    (Nothing, Nothing) -> True
+    (Just a, Just b) -> eq a b
+    _ -> False
+
+eqLocalBinds :: HsLocalBindsLR GhcPs GhcPs -> HsLocalBindsLR GhcPs GhcPs -> Bool
+eqLocalBinds left right =
+  sameStructural left right || bothEmpty left right
+  where
+    bothEmpty left' right' = emptyLocalBindsLike left' && emptyLocalBindsLike right'
+
+eqHsRecFields :: HsRecFields GhcPs (LHsExpr GhcPs) -> HsRecFields GhcPs (LHsExpr GhcPs) -> Bool
+eqHsRecFields left right =
+  case (left, right) of
+    (HsRecFields _ fieldsA dotdotA, HsRecFields _ fieldsB dotdotB) ->
+      eqList eqLocatedFieldBind fieldsA fieldsB && sameConstructor dotdotA dotdotB
+
+eqHsRecUpdFields :: LHsRecUpdFields GhcPs -> LHsRecUpdFields GhcPs -> Bool
+eqHsRecUpdFields left right =
+  case (left, right) of
+    (RegularRecUpdFields _ fieldsA, RegularRecUpdFields _ fieldsB) ->
+      eqList eqLocatedFieldBind fieldsA fieldsB
+    (OverloadedRecUpdFields _ fieldsA, OverloadedRecUpdFields _ fieldsB) ->
+      eqList eqLocatedFieldBind fieldsA fieldsB
+    (RegularRecUpdFields _ [], OverloadedRecUpdFields _ []) ->
+      True
+    (OverloadedRecUpdFields _ [], RegularRecUpdFields _ []) ->
+      True
+    _ -> False
+
+eqDotFieldOcc :: DotFieldOcc GhcPs -> DotFieldOcc GhcPs -> Bool
+eqDotFieldOcc (DotFieldOcc _ labelA) (DotFieldOcc _ labelB) =
+  unLoc labelA == unLoc labelB
+
+eqLocatedFieldBind :: (Data lhs) => GenLocated location (HsFieldBind lhs (LHsExpr GhcPs)) -> GenLocated location (HsFieldBind lhs (LHsExpr GhcPs)) -> Bool
+eqLocatedFieldBind left right =
+  let HsFieldBind _ lhsA rhsA punA = unLoc left
+      HsFieldBind _ lhsB rhsB punB = unLoc right
+   in sameFieldLhs lhsA lhsB && eqLocatedHsExpr rhsA rhsB && punA == punB
+
+sameFieldLhs :: (Data a, Data b) => a -> b -> Bool
+sameFieldLhs left right =
+  case (cast left, cast right) of
+    (Just (FieldOcc _ labelA :: FieldOcc GhcPs), Just (FieldOcc _ labelB :: FieldOcc GhcPs)) ->
+      sameStructural (unLoc labelA) (unLoc labelB)
+    _ -> sameStructural left right
+
+eqArithSeqInfo :: ArithSeqInfo GhcPs -> ArithSeqInfo GhcPs -> Bool
+eqArithSeqInfo left right =
+  case (left, right) of
+    (From fromA, From fromB) ->
+      eqLocatedHsExpr fromA fromB
+    (FromThen fromA thenA, FromThen fromB thenB) ->
+      eqLocatedHsExpr fromA fromB && eqLocatedHsExpr thenA thenB
+    (FromTo fromA toA, FromTo fromB toB) ->
+      eqLocatedHsExpr fromA fromB && eqLocatedHsExpr toA toB
+    (FromThenTo fromA thenA toA, FromThenTo fromB thenB toB) ->
+      eqLocatedHsExpr fromA fromB && eqLocatedHsExpr thenA thenB && eqLocatedHsExpr toA toB
+    _ -> False
+
+eqHsQuote :: HsQuote GhcPs -> HsQuote GhcPs -> Bool
+eqHsQuote left right =
+  case (left, right) of
+    (ExpBr _ exprA, ExpBr _ exprB) -> eqLocatedHsExpr exprA exprB
+    (PatBr _ patA, PatBr _ patB) -> sameStructural patA patB
+    (DecBrL _ declsA, DecBrL _ declsB) -> sameStructural declsA declsB
+    (DecBrG _ groupA, DecBrG _ groupB) -> sameStructural groupA groupB
+    (TypBr _ tyA, TypBr _ tyB) -> sameStructural tyA tyB
+    (VarBr _ namespaceA nameA, VarBr _ namespaceB nameB) -> namespaceA == namespaceB && sameStructural nameA nameB
+    _ -> False
+
+eqHsTypedSplice :: HsTypedSplice GhcPs -> HsTypedSplice GhcPs -> Bool
+eqHsTypedSplice left right =
+  case (left, right) of
+    (HsTypedSpliceExpr _ exprA, HsTypedSpliceExpr _ exprB) -> eqLocatedHsExpr exprA exprB
+
+eqHsUntypedSplice :: HsUntypedSplice GhcPs -> HsUntypedSplice GhcPs -> Bool
+eqHsUntypedSplice left right =
+  case (left, right) of
+    (HsUntypedSpliceExpr _ exprA, HsUntypedSpliceExpr _ exprB) -> eqLocatedHsExpr exprA exprB
+    (HsQuasiQuote _ quoterA bodyA, HsQuasiQuote _ quoterB bodyB) -> sameStructural quoterA quoterB && sameStructural bodyA bodyB
+    _ -> False
+
+eqList :: (a -> b -> Bool) -> [a] -> [b] -> Bool
+eqList eq left right =
+  length left == length right && and (zipWith eq left right)
+
+eqNonEmpty :: (a -> b -> Bool) -> NE.NonEmpty a -> NE.NonEmpty b -> Bool
+eqNonEmpty eq left right =
+  eqList eq (NE.toList left) (NE.toList right)
+
+sameConstructor :: (Data a, Data b) => a -> b -> Bool
+sameConstructor left right =
+  showConstr (toConstr (normalizeGhcAst left)) == showConstr (toConstr (normalizeGhcAst right))
+
+data SomeData = forall a. (Data a) => SomeData a
+
+sameStructural :: (Data a, Data b) => a -> b -> Bool
+sameStructural left right =
+  structuralEq (normalizeGhcAst left) (normalizeGhcAst right)
+
+structuralEq :: (Data a, Data b) => a -> b -> Bool
+structuralEq left right =
+  primitiveEq left right
+    || emptyLocalBindsEq left right
+    || stmtEq left right
+    || (isIgnoredAnnotationPayload left && isIgnoredAnnotationPayload right)
+    || ( sameCon
+           && case (conName, leftChildren, rightChildren) of
+             ("L", [_, leftPayload], [_, rightPayload]) -> structuralEqSome leftPayload rightPayload
+             _ -> eqList structuralEqSome leftChildren rightChildren
+       )
+  where
+    conName = showConstr (toConstr left)
+    sameCon = conName == showConstr (toConstr right)
+    leftChildren = gmapQ SomeData left
+    rightChildren = gmapQ SomeData right
+
+emptyLocalBindsEq :: (Data a, Data b) => a -> b -> Bool
+emptyLocalBindsEq left right =
+  case (cast left, cast right) of
+    (Just (left' :: HsLocalBindsLR GhcPs GhcPs), Just (right' :: HsLocalBindsLR GhcPs GhcPs)) ->
+      emptyLocalBindsLike left' && emptyLocalBindsLike right'
+    _ -> False
+
+stmtEq :: (Data a, Data b) => a -> b -> Bool
+stmtEq left right =
+  exprStmtEq || cmdStmtEq
+  where
+    exprStmtEq =
+      case (cast left, cast right) of
+        (Just (left' :: StmtLR GhcPs GhcPs (LHsExpr GhcPs)), Just (right' :: StmtLR GhcPs GhcPs (LHsExpr GhcPs))) ->
+          eqStmtBodies eqLocatedHsExpr left' right'
+        _ -> False
+    cmdStmtEq =
+      case (cast left, cast right) of
+        (Just (left' :: StmtLR GhcPs GhcPs (LHsCmd GhcPs)), Just (right' :: StmtLR GhcPs GhcPs (LHsCmd GhcPs))) ->
+          eqStmtBodies eqLocatedHsCmd left' right'
+        _ -> False
+
+eqStmtBodies :: (body -> body -> Bool) -> StmtLR GhcPs GhcPs body -> StmtLR GhcPs GhcPs body -> Bool
+eqStmtBodies eqBody left right =
+  case (left, right) of
+    (LastStmt _ bodyA _ _, LastStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    (LastStmt _ bodyA _ _, BodyStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    (BodyStmt _ bodyA _ _, LastStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    (BodyStmt _ bodyA _ _, BodyStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    _ -> False
+
+emptyLocalBindsLike :: HsLocalBindsLR GhcPs GhcPs -> Bool
+emptyLocalBindsLike binds =
+  case binds of
+    EmptyLocalBinds _ -> True
+    HsValBinds _ (ValBinds _ [] []) -> True
+    _ -> False
+
+isIgnoredAnnotationPayload :: (Data a) => a -> Bool
+isIgnoredAnnotationPayload value =
+  case (showConstr (toConstr value), gmapQ SomeData value) of
+    (name, _) | isIgnoredAnnotationCon name -> True
+    ("Nothing", []) -> True
+    ("Just", [payload]) -> isIgnoredAnnotationSome payload
+    ("[]", []) -> True
+    (":", [headPayload, tailPayload]) -> isIgnoredAnnotationSome headPayload && isIgnoredAnnotationSome tailPayload
+    ("(,)", payloads) -> all isIgnoredAnnotationSome payloads
+    _ -> False
+
+isIgnoredAnnotationCon :: String -> Bool
+isIgnoredAnnotationCon name =
+  any (`isPrefixOf` name) ["Ann", "Ep", "Epa", "NameAnn", "NoEp"]
+    || name
+      `elem` [ "Anchor",
+               "NameSquare",
+               "NameParens",
+               "NameBackquotes",
+               "NoComments",
+               "NormalSyntax",
+               "UnicodeSyntax",
+               "NoSourceText",
+               "SourceText"
+             ]
+
+structuralEqSome :: SomeData -> SomeData -> Bool
+structuralEqSome (SomeData left) (SomeData right) =
+  structuralEq left right
+
+isIgnoredAnnotationSome :: SomeData -> Bool
+isIgnoredAnnotationSome (SomeData value) =
+  isIgnoredAnnotationPayload value
+
+primitiveEq :: (Data a, Data b) => a -> b -> Bool
+primitiveEq left right =
+  primRdrName
+    || prim (Proxy @Bool)
+    || prim (Proxy @Char)
+    || prim (Proxy @Int)
+    || prim (Proxy @Integer)
+    || prim (Proxy @Rational)
+    || prim (Proxy @String)
+    || prim (Proxy @Text)
+    || prim (Proxy @ByteString)
+    || prim (Proxy @FastString)
+    || prim (Proxy @FieldLabelString)
+  where
+    primRdrName =
+      case (cast left, cast right) of
+        (Just (left' :: RdrName), Just (right' :: RdrName)) -> rdrNameOcc left' == rdrNameOcc right'
+        _ -> False
+
+    prim :: forall c. (Eq c, Data c) => Proxy c -> Bool
+    prim _ =
+      case (cast left, cast right) of
+        (Just (left' :: c), Just (right' :: c)) -> left' == right'
+        _ -> False
+
+comparisonDump :: (Data a) => a -> String
+comparisonDump = unlines . dumpLines 0 . normalizeGhcAst
+
+dumpLines :: (Data a) => Int -> a -> [String]
+dumpLines depth value =
+  let conName = showConstr (toConstr value)
+      children = gmapQ SomeData value
+   in if isIgnoredDumpPayload value
+        then []
+        else case (primitiveValue value, conName, children) of
+          (Just leaf, _, _) -> [indent depth <> leaf]
+          (_, "L", [_, payload]) -> dumpSome depth payload
+          _ ->
+            let childLines = concatMap (dumpSome (depth + 1)) children
+             in if null childLines
+                  then [indent depth <> conName]
+                  else (indent depth <> conName) : childLines
+
+dumpSome :: Int -> SomeData -> [String]
+dumpSome depth (SomeData value) =
+  dumpLines depth value
+
+isIgnoredDumpPayload :: (Data a) => a -> Bool
+isIgnoredDumpPayload value =
+  isIgnoredAnnotationPayload value
+    || showConstr (toConstr value)
+      `elem` [ "NoExtField",
+               "NoExtCon",
+               "NoAnnSortKey"
+             ]
+
+primitiveValue :: (Data a) => a -> Maybe String
+primitiveValue value =
+  prim (Proxy @Bool)
+    <> prim (Proxy @Char)
+    <> prim (Proxy @Int)
+    <> prim (Proxy @Integer)
+    <> prim (Proxy @Rational)
+    <> prim (Proxy @String)
+    <> prim (Proxy @Text)
+    <> prim (Proxy @ByteString)
+    <> prim (Proxy @FastString)
+    <> primRdrName
+  where
+    primRdrName =
+      case cast value of
+        Just (value' :: RdrName) -> Just (renderGhc (rdrNameOcc value'))
+        Nothing -> Nothing
+
+    prim :: forall c. (Show c, Data c) => Proxy c -> Maybe String
+    prim _ =
+      case cast value of
+        Just (value' :: c) -> Just (show value')
+        Nothing -> Nothing
+
+indent :: Int -> String
+indent depth = replicate (depth * 2) ' '
+
+renderGhc :: (Outputable a) => a -> String
+renderGhc = showSDocUnsafe . ppr

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -14,6 +14,7 @@ library
     Aihc.Parser
     Aihc.Parser.Lex
     Aihc.Parser.Parens
+    Aihc.Parser.Pretty
     Aihc.Parser.Shorthand
     Aihc.Parser.Syntax
 
@@ -35,7 +36,6 @@ library
     Aihc.Parser.Lex.Quoted
     Aihc.Parser.Lex.Trivia
     Aihc.Parser.Lex.Types
-    Aihc.Parser.Pretty
     Aihc.Parser.Types
 
   hs-source-dirs: src
@@ -93,6 +93,28 @@ library parser-tooling-common
     prettyprinter,
     text >=1.2.3 && <2.2,
     yaml,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
+library parser-test-support
+  visibility: public
+  hs-source-dirs: test
+  exposed-modules:
+    Test.Properties.Arb.Decl
+    Test.Properties.Arb.Expr
+    Test.Properties.Arb.Identifiers
+    Test.Properties.Arb.Module
+    Test.Properties.Arb.Pattern
+    Test.Properties.Arb.Type
+    Test.Properties.Arb.Utils
+
+  build-depends:
+    QuickCheck,
+    aihc-parser,
+    base >=4.16 && <5,
+    containers,
+    text,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -63,6 +63,7 @@ module Aihc.Parser.Internal.Common
     isConLikeNameType,
     liftCheck,
     infixOperatorParserExcept,
+    foldInfixL,
     foldInfixR,
   )
 where
@@ -1036,14 +1037,20 @@ infixOperatorParserExcept forbidden =
       expectedTok TkSpecialBacktick
       if allowed op then pure op else fail "forbidden infix operator"
 
+-- | Build a left-associated infix chain from a left operand and a list
+-- of @(operator, operand)@ pairs.  Given @lhs@ and
+-- @[(op1, a), (op2, b), (op3, c)]@ this produces
+-- @((lhs \`op1\` a) \`op2\` b) \`op3\` c@.
+--
+-- This matches GHC's parsed expression AST before any later fixity
+-- reassociation pass has run.
+foldInfixL :: (a -> (op, a) -> a) -> a -> [(op, a)] -> a
+foldInfixL = foldl
+
 -- | Build a right-associated infix chain from a left operand and a list
 -- of @(operator, operand)@ pairs.  Given @lhs@ and
 -- @[(op1, a), (op2, b), (op3, c)]@ this produces
 -- @lhs \`op1\` (a \`op2\` (b \`op3\` c))@.
---
--- Right-association is the correct default when no fixity information is
--- available: the end-user of the library is responsible for
--- re-associating the tree according to operator precedence.
 foldInfixR :: (a -> (op, a) -> a) -> a -> [(op, a)] -> a
 foldInfixR _ lhs [] = lhs
 foldInfixR build lhs ((op, rhs) : rest) =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -93,7 +93,7 @@ exprCoreParserWithoutTypeSigBody forbiddenInfix = do
     _ -> infixExprParserExcept forbiddenInfix
   rest <- MP.many ((,) <$> infixOperatorParserExcept forbiddenInfix <*> region "after infix operator" lexpParser)
   afterArrow <- MP.optional arrowTailParser
-  let withInfix = foldInfixR buildInfix base rest
+  let withInfix = foldInfixL buildInfix base rest
   pure $ case afterArrow of
     Just (op, rhs) -> EInfix withInfix op rhs
     Nothing -> withInfix
@@ -334,7 +334,7 @@ infixExprParserWith lexp forbidden = do
           <$> infixOperatorParserExcept forbidden
           <*> region "after infix operator" lexp
       )
-  pure (foldInfixR buildInfix lhs rest)
+  pure (foldInfixL buildInfix lhs rest)
 
 -- | Parse an lexp (left-expression) - includes do, if, case, let, lambda, and fexp.
 lexpParser :: TokParser Expr
@@ -750,7 +750,7 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                   <*> region "after infix operator" lexpParser
               )
           )
-      let withInfix = foldInfixR buildInfix negBase rest
+      let withInfix = foldInfixL buildInfix negBase rest
       mTypeSig <- MP.optional (expectedTok TkReservedDoubleColon *> typeParser)
       let typed = case mTypeSig of
             Just ty -> ETypeSig withInfix ty
@@ -824,7 +824,7 @@ parenExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
                                   <*> region "after infix operator" lexpParser
                               )
                           )
-                      let fullInfix = foldInfixR buildInfix base ((op, rhs) : more)
+                      let fullInfix = foldInfixL buildInfix base ((op, rhs) : more)
                       mTrailingOp <- MP.optional (infixOperatorParserExcept [])
                       case mTrailingOp of
                         Just trailOp -> do
@@ -1061,7 +1061,7 @@ compTransformExprWithoutTypeSigParser = do
     TkReservedBackslash -> lambdaExprParser
     _ -> compTransformInfixExprParser
   rest <- MP.many ((,) <$> infixOperatorParserExcept [] <*> compTransformLexpParser)
-  pure (foldInfixR buildInfix base rest)
+  pure (foldInfixL buildInfix base rest)
 
 compTransformLexpParser :: TokParser Expr
 compTransformLexpParser = lexpBaseParser compTransformAppExprParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -35,7 +35,7 @@ infixPatternParser :: TokParser Pattern
 infixPatternParser = do
   lhs <- asOrAppPatternParser
   rest <- MP.many ((,) <$> conOperatorParser <*> asOrAppPatternParser)
-  pure (foldInfixR buildInfixPattern lhs rest)
+  pure (foldInfixL buildInfixPattern lhs rest)
 
 -- | Parse either an as-pattern (name@atom) or an application pattern.
 -- As-patterns bind tighter than infix but looser than application,

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -272,10 +272,10 @@ needsExprParens ctx expr =
   case ctx of
     CtxInfixRhs _protectOpenEnded ->
       case expr of
-        -- EInfix on the RHS does NOT need parenthesization: the parser
-        -- builds right-associated chains, so nested infix on the RHS is
-        -- the natural nesting direction.  Printing without parens
-        -- produces the same text as the original source.
+        -- The expression parser builds left-associated chains, so a nested
+        -- infix expression on the RHS only appears when the source had
+        -- explicit parentheses.
+        EInfix {} -> True
         ETypeSig {} -> True
         -- ENegate does NOT need parenthesization in infix RHS position.
         -- GHC already rejects `x + - 1` (precedence >= 6) at parse time,
@@ -286,11 +286,6 @@ needsExprParens ctx expr =
         _ -> False
     CtxInfixLhs ->
       case expr of
-        -- EInfix on the LHS needs parenthesization: the parser builds
-        -- right-associated chains, so a nested EInfix on the LHS can only
-        -- appear when the source had explicit parentheses.  Without the
-        -- wrapping, the re-parsed tree would right-associate differently.
-        EInfix {} -> True
         ETypeSig {} -> True
         -- ENegate needs parenthesization when its inner expression is
         -- open-ended (e.g. ends with a `let` body).  Without parens, the
@@ -456,11 +451,9 @@ needsTypeParens ctx ty =
         -- TStar renders as @*@, which merges with the preceding @\@@ in
         -- visible type application to form a single operator token @\@*@.
         TStar {} -> True
-        -- TSplice renders as @$name@ or @$(expr)@. Parenthesizing this form in
-        -- type-application argument positions changes the pretty output from
-        -- @$expr@ to @(@$expr)@ and can trigger avoidable roundtrip mismatches
-        -- in instance heads.
-        TSplice {} -> False
+        -- TSplice renders with a leading '$', which merges with the preceding
+        -- visible type-application '@' into an operator token.
+        TSplice {} -> True
         -- TImplicitParam parses greedily: as a TApp argument ?x :: T -> U absorbs
         -- the surrounding -> U into the implicit param type.
         TImplicitParam {} -> True
@@ -1004,6 +997,8 @@ addExprParens :: Expr -> Expr
 addExprParens = addExprParensPrec 0
 
 addExprParensIn :: ExprCtx -> Expr -> Expr
+addExprParensIn ctx@(CtxInfixRhs protectOpenEnded) expr@EInfix {} =
+  wrapExpr (needsExprParens ctx expr) (addInfixRhsParens protectOpenEnded expr)
 addExprParensIn ctx expr =
   wrapExpr (needsExprParens ctx expr) (addExprParensPrec (exprCtxPrec ctx expr) expr)
 
@@ -1285,8 +1280,35 @@ addExprGuardedParens expr =
 -- reparsed into the layout block's trailing body.
 addTopLevelInfixLhsParens :: Int -> Expr -> Expr
 addTopLevelInfixLhsParens prec lhs
-  | prec == 0 && startsWithMultiWayIf lhs = wrapExpr True (addExprParens lhs)
-  | otherwise = addExprParensIn CtxInfixLhs lhs
+  | prec /= 1 && startsWithMultiWayIf lhs = wrapExpr True (addExprParens lhs)
+  | otherwise = addInfixLhsParens lhs
+
+addInfixLhsParens :: Expr -> Expr
+addInfixLhsParens expr =
+  case expr of
+    EAnn ann sub -> EAnn ann (addInfixLhsParens sub)
+    EInfix lhs op rhs ->
+      EInfix
+        (addInfixLhsParens lhs)
+        op
+        (addExprParensIn (CtxInfixRhs True) rhs)
+    _ -> addExprParensIn CtxInfixLhs expr
+
+addInfixRhsParens :: Bool -> Expr -> Expr
+addInfixRhsParens protectOpenEnded expr =
+  case expr of
+    EAnn ann sub -> EAnn ann (addInfixRhsParens protectOpenEnded sub)
+    EInfix lhs op rhs ->
+      EInfix
+        (addNestedInfixRhsLhsParens lhs)
+        op
+        (addExprParensIn (CtxInfixRhs protectOpenEnded) rhs)
+    _ -> addExprParensPrec (exprCtxPrec (CtxInfixRhs protectOpenEnded) expr) expr
+
+addNestedInfixRhsLhsParens :: Expr -> Expr
+addNestedInfixRhsLhsParens lhs
+  | startsWithMultiWayIf lhs = wrapExpr True (addExprParens lhs)
+  | otherwise = addInfixLhsParens lhs
 
 startsWithMultiWayIf :: Expr -> Bool
 startsWithMultiWayIf = \case
@@ -1553,11 +1575,6 @@ addViewExprParens expr =
         EProc {} -> True
         _ -> False
 
--- | Check if an operator is the cons operator ':'.
-isConsOperator :: Name -> Bool
-isConsOperator name =
-  renderName name == ":"
-
 addPatternAtomParens :: Pattern -> Pattern
 addPatternAtomParens pat =
   case pat of
@@ -1580,11 +1597,7 @@ addPatternAtomParens pat =
     PSplice {} -> addPatternParens pat
     PRecord {} -> addPatternParens pat
     PCon _ [] [] -> addPatternParens pat
-    PInfix _ op _
-      | isConsOperator op ->
-          -- Cons operator (:) is right-associative, so nested cons patterns
-          -- don't need parentheses: x1:x2:xs parses as x1:(x2:xs)
-          addPatternParens pat
+    PInfix {} -> wrapPat True (addPatternParens pat)
     _ -> wrapPat True (addPatternParens pat)
 
 -- | Add parens for a pattern in infix-pattern operand position.
@@ -1598,17 +1611,18 @@ addPatternInfixOperandParens pat =
     PAnn ann sub -> PAnn ann (addPatternInfixOperandParens sub)
     PNegLit _ -> addPatternParens pat
     PCon {} -> addPatternParens pat
+    PInfix {} -> addPatternParens pat
     _ -> addPatternAtomParens pat
 
 -- | Add parens for the right operand of a 'PInfix' pattern.
--- Infix patterns in Haskell are right-recursive (@infixpat -> pat10 conop infixpat@),
--- so a nested 'PInfix' on the RHS is the natural parse and does not need wrapping.
+-- The parser builds left-associated chains, so a nested 'PInfix' on the RHS
+-- needs explicit grouping.
 addPatternInfixRhsOperandParens :: Pattern -> Pattern
 addPatternInfixRhsOperandParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addPatternInfixRhsOperandParens sub)
     PCon {} -> addPatternParens pat
-    PInfix {} -> addPatternParens pat
+    PInfix {} -> wrapPat True (addPatternParens pat)
     _ -> addPatternAtomParens pat
 
 -- | Add parens for a pattern in arrow binder position (lambda/proc).

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -454,7 +454,7 @@ prettyType ty =
     TApp f x ->
       prettyType f <+> prettyType x
     TTypeApp f x ->
-      prettyType f <+> "@" <> prettyType x
+      prettyType f <+> prettyTypeAppArg x
     TFun arrowKind a b ->
       prettyType a <+> prettyArrowKind arrowKind <+> prettyType b
     TTuple tupleFlavor promoted elems ->
@@ -707,7 +707,19 @@ prettyForallTelescope telescope =
       ForallVisible -> " ->"
 
 prettyInvisibleTypeArg :: Type -> Doc ann
-prettyInvisibleTypeArg ty = "@" <> prettyType ty
+prettyInvisibleTypeArg = prettyTypeAppArg
+
+prettyTypeAppArg :: Type -> Doc ann
+prettyTypeAppArg ty
+  | typeStartsWithSplice ty = "@" <> parens (prettyType ty)
+  | otherwise = "@" <> prettyType ty
+
+typeStartsWithSplice :: Type -> Bool
+typeStartsWithSplice ty =
+  case ty of
+    TAnn _ sub -> typeStartsWithSplice sub
+    TSplice {} -> True
+    _ -> False
 
 prettyDataCon :: DataConDecl -> Doc ann
 prettyDataCon ctor =
@@ -1116,7 +1128,7 @@ prettyExpr expr =
   case expr of
     EApp {} -> prettyApp expr
     ETypeApp fn ty ->
-      prettyExpr fn <> hardline <> " " <> "@" <> prettyType ty
+      prettyExpr fn <> hardline <> " " <> prettyTypeAppArg ty
     EVar name -> prettyName name
     ETypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
     ETypeSyntax TypeSyntaxInTerm ty -> prettyType ty
@@ -1377,7 +1389,7 @@ prettyExprAtStatementStart expr =
     EAnn _ sub -> prettyExprAtStatementStart sub
     EOverloadedLabel _ raw -> pretty raw
     EApp {} -> prettyAppWith prettyExprAtStatementStart expr
-    ETypeApp fn ty -> prettyExprAtStatementStart fn <> hardline <> " " <> "@" <> prettyType ty
+    ETypeApp fn ty -> prettyExprAtStatementStart fn <> hardline <> " " <> prettyTypeAppArg ty
     EInfix lhs op rhs -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs
     ESectionL lhs op -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op
     ETypeSig inner ty -> prettyExprAtStatementStart inner <> hardline <> " " <> "::" <+> prettyType ty


### PR DESCRIPTION
## Summary

- Add new `aihc-parser-compat` component package.
- Expose `toGhcHsExpr :: Expr -> HsExpr GhcPs` for converting parser expressions into normalized ghc-lib-parser ASTs.
- Reuse existing parser generators through a public `aihc-parser:parser-test-support` sublibrary.
- Add focused examples and a QuickCheck property comparing normalized structural GHC AST fingerprints.

## Progress counts

- Unchanged. This PR does not update parser progress counts or generated READMEs.

## Validation

- `cabal test -v0 aihc-parser-compat:spec --test-options=--hide-successes`
- `cabal test -v0 all --test-options=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` findings reviewed; valid findings fixed, one `mkParserOpts` signature finding skipped as not applicable to the ghc-lib-parser version in this repo.
