### PR TITLE
test: add common parser error-message fixtures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/arrow-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/arrow-pattern.yaml
@@ -1,0 +1,15 @@
+src: |
+  {-# LANGUAGE Arrows #-}
+  f (y -< x) = 5
+ghc: |
+  test.hs:2:4: error: [GHC-98980]
+      Command syntax in pattern: y -< x
+    |
+  2 | f (y -< x) = 5
+    |    ^^^^^^
+aihc: |
+  test.hs:2:6:
+  2 | f (y -< x) = 5
+    |      ^^
+  unexpected -<
+  expecting constructor operator, operator '::', symbol ')', symbol ',', or symbol '`'

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/arrow-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/arrow-pattern.yaml
@@ -2,11 +2,7 @@ src: |
   {-# LANGUAGE Arrows #-}
   f (y -< x) = 5
 ghc: |
-  test.hs:2:4: error: [GHC-98980]
-      Command syntax in pattern: y -< x
-    |
-  2 | f (y -< x) = 5
-    |    ^^^^^^
+  test.hs:2:4: error: [GHC-98980] Command syntax in pattern: y -< x
 aihc: |
   test.hs:2:6:
   2 | f (y -< x) = 5

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/lambda-in-case-branch.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/lambda-in-case-branch.yaml
@@ -3,11 +3,7 @@ src: |
     case x of
       \a -> a
 ghc: |
-  test.hs:3:5: error: [GHC-00482]
-      Illegal lambda-syntax in pattern
-  |
-  3 |     \a -> a
-    |     ^^^^^^^
+  test.hs:3:5: error: [GHC-00482] Illegal lambda-syntax in pattern
 aihc: |
   test.hs:3:5:
   3 |     \a -> a

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/lambda-in-case-branch.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/lambda-in-case-branch.yaml
@@ -1,0 +1,16 @@
+src: |
+  f x =
+    case x of
+      \a -> a
+ghc: |
+  test.hs:3:5: error: [GHC-00482]
+      Illegal lambda-syntax in pattern
+  |
+  3 |     \a -> a
+    |     ^^^^^^^
+aihc: |
+  test.hs:3:5:
+  3 |     \a -> a
+    |     ^
+  unexpected \
+  expecting end of input

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/let-expression-in-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/let-expression-in-pattern.yaml
@@ -1,0 +1,20 @@
+src: |
+  f n (let exp = x^2 in exp n) = True
+ghc: |
+  test.hs:1:6: error: [GHC-78892]
+      (let ... in ...)-syntax in pattern
+  |
+  1 | f n (let exp = x^2 in exp n) = True
+    |      ^^^^^^^^^^^^^^^^^^^^^^
+aihc: |
+  test.hs:1:6:
+  1 | f n (let exp = x^2 in exp n) = True
+    |      ^^^
+  unexpected 'let'
+  expecting pattern
+
+  test.hs:1:28:
+  1 | f n (let exp = x^2 in exp n) = True
+    |                            ^
+  unexpected )
+  expecting end of input

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/let-expression-in-pattern.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/let-expression-in-pattern.yaml
@@ -1,11 +1,7 @@
 src: |
   f n (let exp = x^2 in exp n) = True
 ghc: |
-  test.hs:1:6: error: [GHC-78892]
-      (let ... in ...)-syntax in pattern
-  |
-  1 | f n (let exp = x^2 in exp n) = True
-    |      ^^^^^^^^^^^^^^^^^^^^^^
+  test.hs:1:6: error: [GHC-78892] (let ... in ...)-syntax in pattern
 aihc: |
   test.hs:1:6:
   1 | f n (let exp = x^2 in exp n) = True

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/list-pattern-in-equation.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/list-pattern-in-equation.yaml
@@ -4,9 +4,6 @@ src: |
 ghc: |
   test.hs:1:3: error: [GHC-04584]
       Expression syntax in pattern: [1 .. 10]
-  |
-  1 | f [1..10] = 0
-    |   ^^^^^^^
 aihc: |
   test.hs:1:5:
   1 | f [1..10] = 0

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/list-pattern-in-equation.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/list-pattern-in-equation.yaml
@@ -1,0 +1,15 @@
+src: |
+  f [1..10] = 0
+  f _ = 1
+ghc: |
+  test.hs:1:3: error: [GHC-04584]
+      Expression syntax in pattern: [1 .. 10]
+  |
+  1 | f [1..10] = 0
+    |   ^^^^^^^
+aihc: |
+  test.hs:1:5:
+  1 | f [1..10] = 0
+    |     ^^
+  unexpected ..
+  expecting constructor operator, operator '::', symbol ',', symbol ']', or symbol '`'

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/nested-case-in-equation.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/nested-case-in-equation.yaml
@@ -3,11 +3,7 @@ src: |
     case y of
       _ -> 1
 ghc: |
-  test.hs:2:3: error: [GHC-53786]
-      (case ... of ...)-syntax in pattern
-  |
-  2 |   case y of
-    |   ^^^^^^^^^^^
+  test.hs:2:3: error: [GHC-53786] (case ... of ...)-syntax in pattern
 aihc: |
   test.hs:2:3:
   2 |   case y of

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/nested-case-in-equation.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/nested-case-in-equation.yaml
@@ -1,0 +1,16 @@
+src: |
+  f x y = case x of
+    case y of
+      _ -> 1
+ghc: |
+  test.hs:2:3: error: [GHC-53786]
+      (case ... of ...)-syntax in pattern
+  |
+  2 |   case y of
+    |   ^^^^^^^^^^^
+aihc: |
+  test.hs:2:3:
+  2 |   case y of
+    |   ^^^^
+  unexpected case
+  expecting end of input

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-as-non-constructor.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-as-non-constructor.yaml
@@ -1,11 +1,7 @@
 src: |
   f x@(just a) = ()
 ghc: |
-  test.hs:1:6: error: [GHC-07626]
-      Parse error in pattern: just
-  |
-  1 | f x@(just a) = ()
-    |      ^^^^^^
+  test.hs:1:6: error: [GHC-07626] Parse error in pattern: just
 aihc: |
   test.hs:1:11:
   1 | f x@(just a) = ()

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-as-non-constructor.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-as-non-constructor.yaml
@@ -1,0 +1,14 @@
+src: |
+  f x@(just a) = ()
+ghc: |
+  test.hs:1:6: error: [GHC-07626]
+      Parse error in pattern: just
+  |
+  1 | f x@(just a) = ()
+    |      ^^^^^^
+aihc: |
+  test.hs:1:11:
+  1 | f x@(just a) = ()
+    |           ^
+  unexpected a
+  expecting constructor operator, operator '::', symbol ')', symbol ',', or symbol '`'

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-list-vs-recursive-function.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-list-vs-recursive-function.yaml
@@ -1,11 +1,7 @@
 src: |
   f n (sq n) = True
 ghc: |
-  test.hs:1:6: error: [GHC-07626]
-      Parse error in pattern: sq
-  |
-  1 | f n (sq n) = True
-    |      ^^^^
+  test.hs:1:6: error: [GHC-07626] Parse error in pattern: sq
 aihc: |
   test.hs:1:9:
   1 | f n (sq n) = True

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-list-vs-recursive-function.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/pattern-list-vs-recursive-function.yaml
@@ -1,0 +1,14 @@
+src: |
+  f n (sq n) = True
+ghc: |
+  test.hs:1:6: error: [GHC-07626]
+      Parse error in pattern: sq
+  |
+  1 | f n (sq n) = True
+    |      ^^^^
+aihc: |
+  test.hs:1:9:
+  1 | f n (sq n) = True
+    |         ^
+  unexpected n
+  expecting constructor operator, operator '::', symbol ')', symbol ',', or symbol '`'

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/record-update-with-wildcard.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/record-update-with-wildcard.yaml
@@ -3,9 +3,6 @@ src: |
 ghc: |
   test.hs:1:17: error: [GHC-70712]
       You cannot use `..' in a record update
-  |
-  1 | y = x {field=8, ..}
-    |                 ^^
 aihc: |
   test.hs:1:17:
   1 | y = x {field=8, ..}

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/record-update-with-wildcard.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/record-update-with-wildcard.yaml
@@ -1,0 +1,21 @@
+src: |
+  y = x {field=8, ..}
+ghc: |
+  test.hs:1:17: error: [GHC-70712]
+      You cannot use `..' in a record update
+  |
+  1 | y = x {field=8, ..}
+    |                 ^^
+aihc: |
+  test.hs:1:17:
+  1 | y = x {field=8, ..}
+    |                 ^^
+  unexpected '..'
+  expecting expression
+  context: while parsing equation right-hand side
+
+  test.hs:1:19:
+  1 | y = x {field=8, ..}
+    |                   ^
+  unexpected }
+  expecting end of input

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/tuple-or-pattern-merge.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/tuple-or-pattern-merge.yaml
@@ -5,11 +5,7 @@ src: |
       | a > b     = merge as (b:bs) (a:rest)
       | otherwise = merge (a:as) bs (b:rest)
 ghc: |
-  test.hs:3:1: error: [GHC-07626]
-      Parse error in pattern: merge
-  |
-  3 | merge a:as (b:bs) rest
-    | ^^^^^^^
+  test.hs:3:1: error: [GHC-07626] Parse error in pattern: merge
 aihc: |
   test.hs:3:8:
   3 | merge a:as (b:bs) rest

--- a/components/aihc-parser/test/Test/Fixtures/error-messages/module/tuple-or-pattern-merge.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/error-messages/module/tuple-or-pattern-merge.yaml
@@ -1,0 +1,18 @@
+src: |
+  merge [] bs rest = bs ++ rest
+  merge as [] rest = as ++ rest
+  merge a:as (b:bs) rest
+      | a > b     = merge as (b:bs) (a:rest)
+      | otherwise = merge (a:as) bs (b:rest)
+ghc: |
+  test.hs:3:1: error: [GHC-07626]
+      Parse error in pattern: merge
+  |
+  3 | merge a:as (b:bs) rest
+    | ^^^^^^^
+aihc: |
+  test.hs:3:8:
+  3 | merge a:as (b:bs) rest
+    |        ^
+  unexpected ':'
+  expecting = or guarded right-hand side


### PR DESCRIPTION
## Summary
- Add parser error-message golden fixtures for common syntax mistakes in function equations and patterns.
- Include expected `ghc` and `aihc` diagnostics for future regression tracking.
- Cases added:
  - tuple-or-pattern-merge
  - lambda-in-case-branch
  - list-pattern-in-equation
  - nested-case-in-equation
  - record-update-with-wildcard
  - let-expression-in-pattern
  - pattern-list-vs-recursive-function
  - arrow-pattern

## Verification
- Added fixture files under `components/aihc-parser/test/Test/Fixtures/error-messages/module`.
- No test suite run in this change set.
