### PR TITLE
test(parser): improve round-trip shrinker

### DIFF
--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -1002,18 +1002,20 @@ shrinkValueDecl :: ValueDecl -> [ValueDecl]
 shrinkValueDecl vd =
   case vd of
     PatternBind multTag pat rhs ->
-      [PatternBind multTag pat rhs' | rhs' <- shrinkRhs rhs]
+      [PatternBind multTag simpleVarPattern rhs | not (isSimpleVarPattern pat)]
+        <> [PatternBind multTag pat rhs' | rhs' <- shrinkRhs rhs]
         <> [PatternBind multTag pat' rhs | pat' <- shrinkPattern pat]
     FunctionBind name matches ->
-      -- Shrink multiple matches to a single match
-      [FunctionBind name [m {matchAnns = []}] | length matches > 1, m <- matches]
+      [ PatternBind NoMultiplicityTag (PVar name) (matchRhs match)
+      | match <- matches
+      ]
+        <>
+        -- Shrink multiple matches to a single match
+        [FunctionBind name [m {matchAnns = []}] | length matches > 1, m <- matches]
         -- Shrink the list of matches
         <> [FunctionBind name ms' | ms' <- shrinkList shrinkMatch matches, not (null ms')]
         -- Shrink the function name
         <> [FunctionBind name' matches | name' <- shrinkBinderName name]
-        <> [ PatternBind NoMultiplicityTag (PVar name) (matchRhs match)
-           | match <- matches
-           ]
 
 -- | Shrink an individual match clause.
 shrinkMatch :: Match -> [Match]
@@ -1033,14 +1035,13 @@ shrinkRhs :: Rhs Expr -> [Rhs Expr]
 shrinkRhs rhs =
   case rhs of
     UnguardedRhs _ expr mWhere ->
-      -- Drop the where clause first (big win)
-      [UnguardedRhs [] expr Nothing | isJust mWhere]
+      -- Hoist failing where-bound RHSs before shrinking the surrounding layout.
+      whereValueRhss (fromMaybe [] mWhere)
+        <> [UnguardedRhs [] expr Nothing | isJust mWhere]
         -- Shrink the expression
         <> [UnguardedRhs [] expr' mWhere | expr' <- shrinkExpr expr]
         -- Shrink the where clause
         <> [UnguardedRhs [] expr (Just ds') | Just ds <- [mWhere], ds' <- shrinkWhereDecls ds]
-        -- Place where with let
-        <> [rhs' | DeclValue (PatternBind _mult _pat rhs') <- fromMaybe [] mWhere]
     GuardedRhss _ grhss mWhere ->
       -- Collapse to unguarded keeping the where clause (try both with and without)
       [UnguardedRhs [] (guardedRhsBody firstGrhs) mWhere | firstGrhs : _ <- [grhss]]
@@ -1052,10 +1053,28 @@ shrinkRhs rhs =
         -- Shrink the where clause
         <> [GuardedRhss [] grhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkWhereDecls ds]
 
+isSimpleVarPattern :: Pattern -> Bool
+isSimpleVarPattern pat =
+  case pat of
+    PVar name -> unqualifiedNameType name == NameVarId && unqualifiedNameText name == "a"
+    _ -> False
+
+simpleVarPattern :: Pattern
+simpleVarPattern = PVar (mkUnqualifiedName NameVarId "a")
+
 -- | Shrink a where-clause declaration list (keep at least one decl).
 shrinkWhereDecls :: [Decl] -> [[Decl]]
 shrinkWhereDecls ds =
   [ds' | ds' <- shrinkList shrinkDecl ds, not (null ds')]
+
+whereValueRhss :: [Decl] -> [Rhs Expr]
+whereValueRhss decls =
+  [ rhs
+  | DeclValue valueDecl <- decls,
+    rhs <- case valueDecl of
+      PatternBind _ _ patternRhs -> [patternRhs]
+      FunctionBind _ matches -> map matchRhs matches
+  ]
 
 -- | Shrink a guarded RHS: shrink the body and the guards.
 shrinkGuardedRhs :: GuardedRhs Expr -> [GuardedRhs Expr]

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -456,8 +456,10 @@ shrinkExpr expr =
         <> [EApp fn arg' | arg' <- shrinkExpr arg]
     EInfix lhs op rhs ->
       [lhs, rhs]
-        <> [EInfix lhs' op rhs | lhs' <- shrinkExpr lhs]
+        <> [EInfix lhs simpleVarName rhs | op /= simpleVarName]
+        <> [EInfix simpleVarExpr op rhs | not (isSimpleVarExpr lhs)]
         <> [EInfix lhs op rhs' | rhs' <- shrinkExpr rhs]
+        <> [EInfix lhs' op rhs | lhs' <- shrinkExpr lhs]
         <> [EInfix lhs op' rhs | op' <- shrinkName op]
     ENegate inner -> inner : [ENegate inner' | inner' <- shrinkExpr inner]
     ESectionL inner op ->
@@ -491,11 +493,15 @@ shrinkExpr expr =
       [body | LambdaCaseAlt {lambdaCaseAltRhs = UnguardedRhs _ body _} <- alts]
         <> [ELambdaCases alts' | alts' <- shrinkLambdaCaseAlts alts, not (null alts')]
     ELetDecls decls body ->
-      body
-        : [ELetDecls decls body' | body' <- shrinkExpr body]
-          <> [ELetDecls decls' body | decls' <- shrinkDecls decls, not (null decls')]
+      [ELetDecls [simpleLetDecl] simpleUnitExpr | decls /= [simpleLetDecl] || body /= simpleUnitExpr]
+        <> ( body
+               : [ELetDecls decls body' | body' <- shrinkExpr body]
+                 <> [ELetDecls decls' body | decls' <- shrinkDecls decls, not (null decls')]
+           )
     EDo stmts flavor ->
-      [EDo stmts' flavor | stmts' <- shrinkDoStmts stmts, not (null stmts')]
+      [body | [DoExpr body] <- [stmts]]
+        <> [EDo stmts flavor' | flavor' <- shrinkDoFlavor flavor]
+        <> [EDo stmts' flavor | stmts' <- shrinkDoStmts stmts, not (null stmts')]
     EListComp body stmts ->
       body
         : [EListComp body' stmts | body' <- shrinkExpr body]
@@ -513,7 +519,8 @@ shrinkExpr expr =
     EArithSeq seq' ->
       [EArithSeq seq'' | seq'' <- shrinkArithSeq seq']
     ERecordCon con fields _ ->
-      [ERecordCon con' fields False | con' <- shrinkName con]
+      [simpleVarExpr]
+        <> [ERecordCon con' fields False | con' <- shrinkName con]
         <> [ERecordCon con fields' False | fields' <- shrinkRecordFields fields]
     ERecordUpd target fields ->
       target
@@ -657,14 +664,15 @@ shrinkLetDecl decl =
       [DeclValue (PatternBind multTag pat rhs') | rhs' <- shrinkLetRhs rhs]
         <> [DeclValue (PatternBind multTag pat' rhs) | pat' <- shrinkPattern pat]
     DeclValue (FunctionBind name matches) ->
-      -- Shrink multiple matches to a single match
-      [DeclValue (FunctionBind name [m {matchAnns = []}]) | length matches > 1, m <- matches]
+      [ DeclValue (PatternBind NoMultiplicityTag (PVar name) (matchRhs match))
+      | match <- matches
+      ]
+        <>
+        -- Shrink multiple matches to a single match
+        [DeclValue (FunctionBind name [m {matchAnns = []}]) | length matches > 1, m <- matches]
         -- Shrink individual matches
         <> [DeclValue (FunctionBind name ms') | ms' <- shrinkList shrinkLetMatch matches, not (null ms')]
         <> [DeclValue (FunctionBind name' matches) | name' <- shrinkUnqualifiedName name]
-        <> [ DeclValue (PatternBind NoMultiplicityTag (PVar name) (matchRhs match))
-           | match <- matches
-           ]
     DeclTypeSig names ty ->
       [DeclTypeSig names ty' | ty' <- shrinkType ty]
     _ -> []
@@ -680,7 +688,8 @@ shrinkLetRhs :: Rhs Expr -> [Rhs Expr]
 shrinkLetRhs rhs =
   case rhs of
     UnguardedRhs _ expr mWhere ->
-      [UnguardedRhs [] expr Nothing | isJust mWhere]
+      [rhs' | ds <- maybe [] pure mWhere, rhs' <- whereValueRhss ds]
+        <> [UnguardedRhs [] expr Nothing | isJust mWhere]
         <> [UnguardedRhs [] expr' mWhere | expr' <- shrinkExpr expr]
         <> [UnguardedRhs [] expr (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
     GuardedRhss _ rhss mWhere ->
@@ -703,11 +712,28 @@ shrinkCmdRhs rhs =
         <> [GuardedRhss [] rhss' mWhere | rhss' <- shrinkList shrinkCmdGuardedRhs rhss, not (null rhss')]
         <> [GuardedRhss [] rhss (Just ds') | Just ds <- [mWhere], ds' <- shrinkDecls ds, not (null ds')]
 
+whereValueRhss :: [Decl] -> [Rhs Expr]
+whereValueRhss decls =
+  [ rhs
+  | DeclValue valueDecl <- decls,
+    rhs <- case valueDecl of
+      PatternBind _ _ patternRhs -> [patternRhs]
+      FunctionBind _ matches -> map matchRhs matches
+  ]
+
 shrinkDoStmts :: [DoStmt Expr] -> [[DoStmt Expr]]
 shrinkDoStmts stmts =
   case stmts of
     [_] -> [] -- Can't shrink a single-element do block
     _ -> shrinkList shrinkDoStmt stmts
+
+shrinkDoFlavor :: DoFlavor -> [DoFlavor]
+shrinkDoFlavor flavor =
+  case flavor of
+    DoPlain -> []
+    DoMdo -> [DoPlain]
+    DoQualified _ -> [DoPlain]
+    DoQualifiedMdo name -> [DoPlain, DoMdo, DoQualified name]
 
 shrinkDoStmt :: DoStmt Expr -> [DoStmt Expr]
 shrinkDoStmt stmt =
@@ -786,3 +812,27 @@ shrinkRecordField field =
 instance Arbitrary Expr where
   arbitrary = resize 5 genExpr
   shrink = shrinkExpr
+
+simpleVarExpr :: Expr
+simpleVarExpr = EVar simpleVarName
+
+simpleVarName :: Name
+simpleVarName = qualifyName Nothing (mkUnqualifiedName NameVarId "a")
+
+isSimpleVarExpr :: Expr -> Bool
+isSimpleVarExpr expr =
+  case expr of
+    EVar name -> name == simpleVarName
+    _ -> False
+
+simpleUnitExpr :: Expr
+simpleUnitExpr = ETuple Boxed []
+
+simpleLetDecl :: Decl
+simpleLetDecl =
+  DeclValue
+    ( PatternBind
+        NoMultiplicityTag
+        (PVar (mkUnqualifiedName NameVarId "a"))
+        (UnguardedRhs [] simpleUnitExpr Nothing)
+    )

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -33,10 +33,13 @@ instance Arbitrary Module where
         }
 
   shrink modu =
-    [ modu {moduleDecls = shrunk}
-    | shrunk <- shrinkList shrink (moduleDecls modu),
-      not (null shrunk)
-    ]
+    [modu {moduleHead = Nothing} | Just _ <- [moduleHead modu]]
+      <> [modu {moduleImports = []} | not (null (moduleImports modu))]
+      <> [modu {moduleDecls = []} | not (null (moduleDecls modu))]
+      <> [ modu {moduleDecls = shrunk}
+         | shrunk <- shrinkList shrink (moduleDecls modu),
+           not (null shrunk)
+         ]
       <> [ modu {moduleImports = shrunk}
          | shrunk <- shrinkList shrinkImportDecl (moduleImports modu)
          ]


### PR DESCRIPTION
## Summary

- improve the parser property shrinkers so layout-sensitive infix/let failures shrink to the essential shape
- add direct simplifications for infix operators, record constructors, let declarations, single-expression do blocks, and module/import/declaration scaffolding
- hoist where-bound RHS failures earlier so unrelated surrounding declarations do not block shrinking

## Shrunk replay

The seed now shrinks to:

```haskell
a =
  a
   `a` let
         a =
           ()
         in ()
   `a` ()
```

## Progress counts

- Parser progress counts: unchanged; shrinker-only test infrastructure change.

## Validation

- `just fmt`
- `just replay "(SMGen 1032413213704102056 16511923372048548133,85)"` fails after 13 shrinks with the minimized case above
- `coderabbit review --prompt-only` found one module-declaration shrinker fast-path issue; addressed
- `just check`
