### PR TITLE
fix(parser): cover generated pragma and type expressions

### DIFF
--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
@@ -77,10 +77,25 @@ toGhcHsExpr expr =
     A.ETHSplice body -> HsUntypedSplice noExtField (HsUntypedSpliceExpr noAnn (toGhcLHsExpr body))
     A.ETHTypedSplice body -> HsTypedSplice noExtField (HsTypedSpliceExpr noAnn (toGhcLHsExpr body))
     A.EProc pat cmd -> HsProc noAnn (toLPat pat) (lA (HsCmdTop noExtField (toLHsCmd cmd)))
-    A.EPragma _ inner -> toGhcHsExpr inner
+    A.EPragma pragma inner -> pragmaExpr pragma inner
 
 toGhcLHsExpr :: A.Expr -> LHsExpr GhcPs
 toGhcLHsExpr = lA . toGhcHsExpr
+
+pragmaExpr :: A.Pragma -> A.Expr -> HsExpr GhcPs
+pragmaExpr pragma inner =
+  case A.pragmaType pragma of
+    A.PragmaSCC label ->
+      HsPragE noExtField (HsPragSCC noAnn (stringLiteral label)) (toGhcLHsExpr inner)
+    _ -> toGhcHsExpr inner
+
+stringLiteral :: T.Text -> StringLiteral
+stringLiteral label =
+  StringLiteral
+    { sl_st = NoSourceText,
+      sl_fs = mkFastString (T.unpack label),
+      sl_tc = Nothing
+    }
 
 integerExpr :: Integer -> A.NumericType -> T.Text -> HsExpr GhcPs
 integerExpr value numeric raw =

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -368,7 +368,7 @@ addSectionLhsParens expr =
   where
     addSectionInfixRhsParens rhs =
       case peelExprAnn rhs of
-        EInfix {} -> addSectionLhsParens rhs
+        EInfix {} -> wrapExpr True (addSectionLhsParens rhs)
         _ | isOpenEnded rhs -> wrapExpr True (addExprParens rhs)
         _ -> addExprParensIn (CtxInfixRhs False) rhs
 
@@ -1331,7 +1331,13 @@ addNestedInfixRhsLhsParens lhs
 absorbsFollowingInfix :: Expr -> Bool
 absorbsFollowingInfix = \case
   EAnn _ sub -> absorbsFollowingInfix sub
+  EIf {} -> True
+  ELambdaPats {} -> True
+  ELambdaCase {} -> True
+  ELambdaCases {} -> True
+  ELetDecls {} -> True
   EProc {} -> True
+  EInfix _ _ rhs -> absorbsFollowingInfix rhs
   _ -> False
 
 startsWithMultiWayIf :: Expr -> Bool
@@ -1590,13 +1596,17 @@ addPatternViewInnerParens pat =
 
 addViewExprParens :: Expr -> Expr
 addViewExprParens expr =
-  if endsWithTypeSig expr || isProcExpr expr
+  if endsWithTypeSig expr || isProcExpr expr || isTypeSyntaxExpr expr
     then wrapExpr True (addExprParens expr)
     else addExprParens expr
   where
     isProcExpr e =
       case peelExprAnn e of
         EProc {} -> True
+        _ -> False
+    isTypeSyntaxExpr e =
+      case peelExprAnn e of
+        ETypeSyntax {} -> True
         _ -> False
 
 addPatternAtomParens :: Pattern -> Pattern

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -12,7 +12,7 @@ import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax
 import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
 import Data.Char (ord)
-import Data.Data (dataTypeConstrs, dataTypeOf, showConstr, toConstr)
+import Data.Data (Data, dataTypeConstrs, dataTypeOf, gmapQl, isAlgType, showConstr, toConstr)
 import Data.Maybe (isNothing)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -258,6 +258,8 @@ buildTests = do
             testCase "generated variable symbols reject reserved spellings" test_generatedVariableSymbolsRejectReservedSpellings,
             testCase "generated operators reject arrow tail spellings" test_generatedOperatorsRejectArrowTailSpellings,
             testCase "generated expressions can include mdo" test_generatedExpressionsCanIncludeMdo,
+            testCase "generated expressions can include SCC pragmas" test_generatedExpressionsCanIncludeSccPragmas,
+            testCase "generated expressions can include explicit type syntax" test_generatedExpressionsCanIncludeExplicitTypeSyntax,
             testCase "pretty-prints case expressions with implicit layout" test_prettyCaseExpressionUsesImplicitLayout,
             testCase "pretty-prints let expressions with implicit layout" test_prettyLetExpressionUsesImplicitLayout,
             testCase "pretty-prints negated layout-ending list-comprehension bodies" test_prettyNegatedLayoutEndingListCompBody,
@@ -272,6 +274,8 @@ buildTests = do
             testCase "pretty-prints instance declarations with implicit layout" test_prettyInstanceDeclarationUsesImplicitLayout,
             testCase "pretty-prints TH splices before record dots with parentheses" test_prettySpliceRecordDotBase,
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
+            testCase "pretty-prints nested infix RHS expressions inside sections" test_prettyNestedInfixRhsInsideSection,
+            testCase "pretty-prints infix RHS open-ended expressions before following infix operators" test_prettyInfixRhsOpenEndedBeforeFollowingInfix,
             testCase "pretty-prints reserved at right sections" test_prettyReservedAtRightSection,
             testCase "pretty-prints layout-ending operands inside left sections" test_prettyLayoutEndingOperandInsideLeftSection,
             testCase "pretty-prints type applications after layout-ending functions" test_prettyTypeAppAfterLayoutEndingFunction,
@@ -746,6 +750,25 @@ test_generatedExpressionsCanIncludeMdo =
     isMdo (EDo _ DoMdo) = True
     isMdo _ = False
 
+test_generatedExpressionsCanIncludeSccPragmas :: Assertion
+test_generatedExpressionsCanIncludeSccPragmas =
+  let samples = QGen.unGen (QC.vectorOf 4000 (QC.resize 5 (QC.arbitrary :: QC.Gen Expr))) (QRandom.mkQCGen 738) 5
+   in assertBool "expected expression generator to include at least one SCC pragma expression" $
+        any (Set.member "EPragma" . usedCtors) samples
+
+test_generatedExpressionsCanIncludeExplicitTypeSyntax :: Assertion
+test_generatedExpressionsCanIncludeExplicitTypeSyntax =
+  let samples = QGen.unGen (QC.vectorOf 4000 (QC.resize 5 (QC.arbitrary :: QC.Gen Expr))) (QRandom.mkQCGen 739) 5
+   in assertBool "expected expression generator to include at least one explicit type syntax expression" $
+        any (Set.member "ETypeSyntax" . usedCtors) samples
+
+usedCtors :: (Data a) => a -> Set.Set String
+usedCtors x =
+  let here
+        | isAlgType (dataTypeOf x) = Set.singleton (showConstr (toConstr x))
+        | otherwise = Set.empty
+   in here <> gmapQl (<>) Set.empty usedCtors x
+
 test_alternateCharLiteralSpellingsLexLikeGhc :: Assertion
 test_alternateCharLiteralSpellingsLexLikeGhc =
   mapM_ assertCharLiteralLexesLikeGhc finiteAlternateCharLiteralSpellings
@@ -1168,6 +1191,28 @@ test_prettyInfixRhsOpenEndedInsideSection = do
         ((\\case {  })
          `a` (\\ 0 -> ' ')
          `a`)
+        """
+  assertParsedStrippedExprShapeRoundTrip config source
+
+test_prettyNestedInfixRhsInsideSection :: Assertion
+test_prettyNestedInfixRhsInsideSection = do
+  let source =
+        """
+        ([]
+         + (""
+            `a` ())
+         +)
+        """
+  assertParsedStrippedExprShapeRoundTrip defaultConfig source
+
+test_prettyInfixRhsOpenEndedBeforeFollowingInfix :: Assertion
+test_prettyInfixRhsOpenEndedBeforeFollowingInfix = do
+  let config = defaultConfig {parserExtensions = [TemplateHaskell, QuasiQuotes]}
+      source =
+        """
+        [t| () |]
+         + (if [t| _ |] then [] else [])
+         `a` 0
         """
   assertParsedStrippedExprShapeRoundTrip config source
 

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -5,6 +5,7 @@ module Test.Properties.Arb.Expr
   ( genExpr,
     genRhs,
     mkIntExpr,
+    mkStringExpr,
     shrinkExpr,
     shrinkGuardQualifier,
   )
@@ -72,8 +73,10 @@ genExpr = scale (`div` 2) $ do
         ERecordUpd <$> genExpr <*> genRecordFieldsWith,
         ETypeSig <$> genExpr <*> genType,
         ETypeApp <$> genExpr <*> genType,
+        EParen . ETypeSyntax TypeSyntaxExplicitNamespace <$> genTypeSyntaxType,
         EParen <$> genExpr,
         EProc <$> genPattern <*> genCmdWith,
+        EParen <$> (EPragma <$> genSccPragma <*> genPragmaExpr),
         -- OverloadedRecordDot
         EGetField <$> genExpr <*> genRecordFieldName,
         EGetFieldProjection <$> smallList1 genRecordFieldName,
@@ -118,6 +121,21 @@ genOverloadedLabel :: Gen Expr
 genOverloadedLabel = do
   labelName <- suchThat genVarId (not . T.isSuffixOf "#")
   pure (EOverloadedLabel labelName ("#" <> labelName))
+
+genSccPragma :: Gen Pragma
+genSccPragma = do
+  sccLabel <- suchThat genVarId (not . T.isSuffixOf "#")
+  pure Pragma {pragmaType = PragmaSCC sccLabel, pragmaRawText = ""}
+
+genPragmaExpr :: Gen Expr
+genPragmaExpr = EVar <$> genVarName
+
+genTypeSyntaxType :: Gen Type
+genTypeSyntaxType =
+  oneof
+    [ TVar . mkUnqualifiedName NameVarId <$> genVarId,
+      (`TCon` Unpromoted) <$> genConName
+    ]
 
 -- | Generate a quasi-quote name, excluding TH bracket names (e, d, p, t) which
 -- would collide with Template Haskell bracket syntax ([e|...|], [d|...|], etc.).


### PR DESCRIPTION
## Summary
- generate covered SCC pragma and explicit type-syntax expression cases without producing invalid arbitrary AST contexts
- preserve SCC pragmas in parser-compat conversion
- tighten paren insertion for nested/open-ended infix RHS cases and type-syntax view expressions
- add regression tests for generator coverage and infix RHS grouping

## Progress counts
- aihc-parser spec count increased from 1709 to 1713 tests (+4). README progress counts were not updated.

## Validation
- `cabal test all -v0 --test-options="--quickcheck-tests=50000"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` was attempted but hung without findings/output, so it was skipped as unavailable.