### PR TITLE
test(oracle): add regression xfail cases for parenthesization roundtrip mismatches

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/force-layout-parenthesized-lens-op-arg.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/force-layout-parenthesized-lens-op-arg.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Guard roundtrip due to extra parentheses around operator argument -}
+module ForceLayoutParenthesizedLensArg where
+
+stepPos p = pos %~ (.+^ p ^. vel) $ p
+

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/friendly-time-append-seconds-lambda.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/friendly-time-append-seconds-lambda.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Guard roundtrip due to parenthesized section on string concat rhs -}
+module FriendlyTimeAppendSecondsLambda where
+
+secondsAgo = \f -> (++ " seconds" ++ dir f)
+

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ratio-int-parenthesized-compare.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ratio-int-parenthesized-compare.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST xfail Guard roundtrip due to unnecessary parentheses in rhs of <= -}
+module RatioIntParenthesizedCompare where
+
+enumFromTo n m = takeWhile (<= m + 1 / 2) (enumFrom n)
+


### PR DESCRIPTION
## Summary
- Add minimal oracle xfail fixtures for packages that currently fail roundtrip by adding spurious parentheses:
  - ratio-int-parenthesized-compare
  - force-layout-parenthesized-lens-op-arg
  - friendly-time-append-seconds-lambda

## Why
These packages fail oracle roundtrip because parser output adds unnecessary parentheses in precedence-sensitive expressions. The fixtures encode the exact minimal trigger shapes as `xfail` cases to prevent regressions.

## Notes
- Files are intentionally minimal and scoped to one expression each in `components/aihc-parser/test/Test/Fixtures/oracle/Hackage`.
- Please run the existing oracle suite before merging.
