### PR TITLE
test: add oracle xfail fixtures for hackage parenthesization regressions

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/enumset-sizeof-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/enumset-sizeof-xfail.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail enumset: parser requires parenthesized right side of `< sizeOf x * 8` expression -}
+module EnumsetTakeWhileSizeOfXFail where
+
+f x = takeWhile (< sizeOf x * 8)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indents-expected-message-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indents-expected-message-xfail.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail indents: parser adds parentheses around the concatenation expression for message in the parser expectation operator -}
+module IndentsExpectedMessageXFail where
+
+f ref pos =
+  (<?> prettyIndentation ref ++ " (started at line " ++ prettyLine ref ++ ")")
+    (unexpected pos)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/splitmix-distributions-negation-parens-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/splitmix-distributions-negation-parens-xfail.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST xfail splitmix-distributions: parser inserts extra parentheses in mixed negation and exponentiation expressions -}
+module SplitmixDistributionsNegationParensXFail where
+
+zipfLike a u =
+  let xInt = floor (u ** (- 1 / (a - 1)))
+   in xInt
+
+weibullLike a b x =
+  return $ (- 1 / a * log (1 - x)) ** 1 / b


### PR DESCRIPTION
## Summary
- Add three Hackage-focused oracle fixtures marked `xfail` to capture parenthesization roundtrip regressions.
- Each fixture is intentionally minimal and targets one package-level failure:
  - `enumset` (`takeWhile (< sizeOf x * 8)`).
  - `indents` (`(<? ... ++ ...)` message expression with string concatenation).
  - `splitmix-distributions` (zipf / weibull negation + exponentiation parenthesization).

## Notes
- Fixtures are added under `components/aihc-parser/test/Test/Fixtures/oracle/Hackage`.
- No parser code changes in this PR; this is regression coverage only.
