### PR TITLE
test: add oracle xfail fixtures for parenthesized roundtrip regressions

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/lambda-case-application-with-guards.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/lambda-case-application-with-guards.hs
@@ -1,0 +1,21 @@
+{- ORACLE_TEST xfail shellify parse/pretty mismatch for \case in applicative chain -}
+{-# LANGUAGE LambdaCase #-}
+
+module LambdaCaseInfixApplication where
+
+parseCommandLineOptions originalParsedOptions =
+  if _packages transformedOptions == mempty then
+    Left noPackagesError
+  else
+    Right transformedOptions
+  where transformedOptions =
+          (Options <$> __command
+           <*> \case
+             f | __withFlake f -> Flake
+               | (hasShellArg . __shellPackages) f -> Flake
+             _ | otherwise -> Traditional
+           <*> __prioritiseLocalPinnedSystem) originalParsedOptions
+        hasShellArg (Just ("shell":_)) = True
+        hasShellArg _ = False
+
+data Mode = Flake | Traditional

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/log-base-modify-seq-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/log-base-modify-seq-parens.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST xfail log-base-style section-appends keep rhs grouped when parenthesized by parser -}
+{-# LANGUAGE OverloadedStrings #-}
+
+module MonoidAppendParen where
+
+appendToRef ref msg' = ref (<> msg' <> "\n")

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/monad-metrics-section-operator-paren.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/monad-metrics-section-operator-paren.hs
@@ -1,0 +1,4 @@
+{- ORACLE_TEST xfail monad-metrics-style section application emits extra parens around rhs precedence -}
+module ParenSectionExponent where
+
+nsToUs = (/ 10^(3 :: Int))


### PR DESCRIPTION
## Summary
Add three new oracle xfail fixtures that isolate parenthesization-related roundtrip mismatches found while running `hackage-tester`:

- `monad-metrics-section-operator-paren.hs` (Parens): captures missing parentheses around left section exponent application (`(/ 10^(3 :: Int))`).
- `lambda-case-application-with-guards.hs` (LambdaCase): captures `\case` in infix-application context being parenthesized by pretty-print (`(<*> \case ...)`).
- `log-base-modify-seq-parens.hs` (Parens): captures right-associative append-section argument requiring extra parenthesis (`(<> msg' <> "\n")`).

These files are intentionally minimal and focused to guard against regressions in oracle roundtrip behavior without affecting parser feature coverage elsewhere.
