### PR TITLE
fix: filter unsupported stackage build tools

### DIFF
--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -6,6 +6,7 @@ module HackageSupport
   ( downloadPackage,
     downloadPackageQuiet,
     downloadPackageQuietWithNetwork,
+    findPackageBuildToolDependencyNames,
     findTargetFilesFromCabal,
     FileInfo (..),
     readTextFileLenient,
@@ -27,6 +28,7 @@ import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
 import System.Directory (doesFileExist)
 import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, takeDirectory, (</>))
 
@@ -67,6 +69,18 @@ data FileInfo = FileInfo
 -- the string-typed results to the rich types used by @aihc-parser@.
 findTargetFilesFromCabal :: FilePath -> IO [FileInfo]
 findTargetFilesFromCabal extractedRoot = do
+  (gpd, cabalFile) <- parsePackageDescriptionFromRoot extractedRoot
+  rawFiles <- HC.collectComponentFiles gpd (takeDirectory cabalFile)
+  pure (map convertFileInfo rawFiles)
+
+-- | Find active build-tool dependency names from a package's @.cabal@ file.
+findPackageBuildToolDependencyNames :: FilePath -> IO [Text]
+findPackageBuildToolDependencyNames extractedRoot = do
+  (gpd, _) <- parsePackageDescriptionFromRoot extractedRoot
+  pure (HC.buildToolDependencyNames gpd)
+
+parsePackageDescriptionFromRoot :: FilePath -> IO (GenericPackageDescription, FilePath)
+parsePackageDescriptionFromRoot extractedRoot = do
   cabalFiles <- HU.findCabalFiles extractedRoot
   cabalFile <-
     case cabalFiles of
@@ -87,8 +101,7 @@ findTargetFilesFromCabal extractedRoot = do
           ( userError
               ("Failed to parse cabal file " ++ cabalFile ++ ": " ++ show errs)
           )
-  rawFiles <- HC.collectComponentFiles gpd (takeDirectory cabalFile)
-  pure (map convertFileInfo rawFiles)
+  pure (gpd, cabalFile)
 
 -- | Convert a string-typed 'HC.FileInfo' to the rich-typed local 'FileInfo'.
 convertFileInfo :: HC.FileInfo -> FileInfo

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -3,6 +3,7 @@ module StackageProgress.PackageRunner
   ( -- * Running packages
     runPackage,
     runPackageOrThrow,
+    packageDependsOnUnsupportedBuildTool,
 
     -- * Source size calculation
     totalSourceSize,
@@ -12,9 +13,11 @@ where
 import Aihc.Hackage.VersionResolver (getLatestVersion)
 import Control.Exception (IOException, SomeException, displayException, try)
 import Data.Maybe (isJust)
+import Data.Text (Text)
 import HackageSupport
   ( FileInfo (..),
     downloadPackageQuietWithNetwork,
+    findPackageBuildToolDependencyNames,
     findTargetFilesFromCabal,
   )
 import StackageProgress.CLI (Options (..))
@@ -31,6 +34,27 @@ import StackageProgress.Summary
     PackageSpec (..),
   )
 import System.Directory (getFileSize)
+
+unsupportedBuildToolNames :: [Text]
+unsupportedBuildToolNames = ["genprimopcode", "grimprimopcode"]
+
+-- | Return whether a package's active Cabal metadata requires an unsupported build tool.
+packageDependsOnUnsupportedBuildTool :: Options -> PackageSpec -> IO Bool
+packageDependsOnUnsupportedBuildTool opts spec = do
+  result <- try (packageDependsOnUnsupportedBuildToolOrThrow opts spec) :: IO (Either SomeException Bool)
+  pure $ case result of
+    Right depends -> depends
+    Left _ -> False
+
+packageDependsOnUnsupportedBuildToolOrThrow :: Options -> PackageSpec -> IO Bool
+packageDependsOnUnsupportedBuildToolOrThrow opts spec = do
+  versionResult <- resolveSpecVersion spec
+  case versionResult of
+    Left _ -> pure False
+    Right version -> do
+      srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) version
+      toolNames <- findPackageBuildToolDependencyNames srcDir
+      pure (any (`elem` unsupportedBuildToolNames) toolNames)
 
 -- | Process a package, catching any exceptions.
 runPackage :: Options -> PackageSpec -> IO PackageResult
@@ -53,32 +77,11 @@ runPackage opts spec = do
 -- | Process a package, potentially throwing exceptions.
 runPackageOrThrow :: Options -> PackageSpec -> IO PackageResult
 runPackageOrThrow opts spec = do
-  versionResult <- resolveVersion
+  versionResult <- resolveSpecVersion spec
   case versionResult of
-    Left errResult -> pure errResult
+    Left err -> pure (versionFailure err)
     Right version -> runWithVersion version
   where
-    resolveVersion :: IO (Either PackageResult String)
-    resolveVersion =
-      if pkgVersion spec == "installed"
-        then do
-          latestResult <- getLatestVersion Nothing (pkgName spec)
-          pure $ case latestResult of
-            Left err ->
-              Left
-                PackageResult
-                  { package = spec,
-                    packageOursOk = False,
-                    packageHseOk = False,
-                    packageGhcOk = False,
-                    packageReason = "failed to resolve latest version for installed package: " ++ err,
-                    packageGhcError = Nothing,
-                    packageSourceSize = 0,
-                    packageFileErrors = []
-                  }
-            Right ver -> Right ver
-        else pure (Right (pkgVersion spec))
-
     runWithVersion :: String -> IO PackageResult
     runWithVersion version = do
       srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) version
@@ -138,6 +141,25 @@ runPackageOrThrow opts spec = do
                     packageSourceSize = totalSize,
                     packageFileErrors = errors
                   }
+
+    versionFailure :: String -> PackageResult
+    versionFailure err =
+      PackageResult
+        { package = spec,
+          packageOursOk = False,
+          packageHseOk = False,
+          packageGhcOk = False,
+          packageReason = "failed to resolve latest version for installed package: " ++ err,
+          packageGhcError = Nothing,
+          packageSourceSize = 0,
+          packageFileErrors = []
+        }
+
+resolveSpecVersion :: PackageSpec -> IO (Either String String)
+resolveSpecVersion spec =
+  if pkgVersion spec == "installed"
+    then getLatestVersion Nothing (pkgName spec)
+    else pure (Right (pkgVersion spec))
 
 -- | Calculate total source size for a list of files.
 totalSourceSize :: [FileInfo] -> IO Integer

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -36,7 +36,7 @@ import StackageProgress.Summary
 import System.Directory (getFileSize)
 
 unsupportedBuildToolNames :: [Text]
-unsupportedBuildToolNames = ["genprimopcode", "grimprimopcode"]
+unsupportedBuildToolNames = ["genprimopcode"]
 
 -- | Return whether a package's active Cabal metadata requires an unsupported build tool.
 packageDependsOnUnsupportedBuildTool :: Options -> PackageSpec -> IO Bool

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
@@ -6,7 +6,7 @@ module StackageProgress.Run (run) where
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
-import Control.Monad (forM_, replicateM_, when)
+import Control.Monad (forM_, replicateM_, unless, when)
 import Data.List (sortBy)
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
@@ -17,7 +17,7 @@ import StackageProgress.CLI
     Parser (..),
     summaryOptionsFromOptions,
   )
-import StackageProgress.PackageRunner (runPackage)
+import StackageProgress.PackageRunner (packageDependsOnUnsupportedBuildTool, runPackage)
 import StackageProgress.Snapshot (loadStackageSnapshotWithMode)
 import StackageProgress.Summary
   ( FailedPackage (..),
@@ -53,8 +53,9 @@ run opts = do
         exitFailure
       Right specs -> pure specs
 
-  let total = length packages
   jobs <- maybe getNumProcessors pure (optJobs opts)
+  filteredPackages <- filterUnsupportedBuildToolPackages opts jobs packages
+  let total = length filteredPackages
   isStdoutTerminal <- hIsTerminalDevice stdout
   let showProgress = isStdoutTerminal && not (optPrompt opts)
   when showProgress (putProgressLine (ProgressState 0 0 total))
@@ -66,7 +67,7 @@ run opts = do
     foldConcurrentlyChunksWithProgress
       jobs
       (runPackage opts)
-      packages
+      filteredPackages
       total
       showProgress
       (summaryOptionsFromOptions opts)
@@ -136,6 +137,27 @@ run opts = do
       failed
 
   if successOursN == total then exitSuccess else exitFailure
+
+filterUnsupportedBuildToolPackages :: Options -> Int -> [PackageSpec] -> IO [PackageSpec]
+filterUnsupportedBuildToolPackages opts n packages = do
+  queue <- newChan
+  forM_ (zip [0 :: Int ..] packages) (writeChan queue . Just)
+  replicateM_ workerCount (writeChan queue Nothing)
+  keptVar <- newMVar []
+  let worker = do
+        next <- readChan queue
+        case next of
+          Nothing -> pure ()
+          Just (ix, spec) -> do
+            unsupported <- packageDependsOnUnsupportedBuildTool opts spec
+            unless unsupported $
+              modifyMVar_ keptVar (pure . ((ix, spec) :))
+            worker
+  replicateConcurrently_ workerCount worker
+  kept <- readMVar keptVar
+  pure (map snd (sortBy (\a b -> compare (fst a) (fst b)) kept))
+  where
+    workerCount = max 1 n
 
 foldConcurrentlyChunksWithProgress ::
   Int ->

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
@@ -3,6 +3,7 @@
 
 module StackageProgress.Run (run) where
 
+import Aihc.Hackage.Types (PackageSpec)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -13,6 +13,9 @@ module Aihc.Hackage.Cabal
     collectCondTreeData,
     collectMergedBuildInfo,
 
+    -- * Build tool dependency extraction
+    buildToolDependencyNames,
+
     -- * Extension / language extraction
     extractExtensions,
     extractLanguage,
@@ -37,11 +40,17 @@ import Distribution.PackageDescription
     Library,
     PackageDescription,
     autogenModules,
+    benchmarkBuildInfo,
     buildInfo,
+    buildToolDepends,
+    buildTools,
     buildable,
+    condBenchmarks,
     condExecutables,
+    condForeignLibs,
     condLibrary,
     condSubLibraries,
+    condTestSuites,
     cppOptions,
     defaultExtensions,
     defaultLanguage,
@@ -56,6 +65,7 @@ import Distribution.PackageDescription
     otherModules,
     package,
     packageDescription,
+    testBuildInfo,
   )
 import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Build.PathsModule (generatePathsModule)
@@ -84,12 +94,15 @@ import Distribution.Types.CondTree
 import Distribution.Types.Condition (Condition (..))
 import Distribution.Types.ConfVar (ConfVar (..))
 import Distribution.Types.Dependency (depPkgName)
+import Distribution.Types.ExeDependency (ExeDependency (..))
+import Distribution.Types.ForeignLib (foreignLibBuildInfo)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription, genPackageFlags)
+import Distribution.Types.LegacyExeDependency (LegacyExeDependency (..))
 import Distribution.Types.LibraryName (LibraryName (..))
 import Distribution.Types.LocalBuildInfo (LocalBuildInfo (..))
 import Distribution.Types.MungedPackageName (MungedPackageName (..))
 import Distribution.Types.UnitId (mkUnitId)
-import Distribution.Types.UnqualComponentName (UnqualComponentName)
+import Distribution.Types.UnqualComponentName (UnqualComponentName, unUnqualComponentName)
 import Distribution.Utils.Path (getSymbolicPath)
 import Distribution.Version (mkVersion, withinRange)
 import System.Directory (createDirectoryIfMissing)
@@ -178,6 +191,38 @@ executableFilesFor pkgDescr evalCond packageRoot exeName tree = do
 
 libraryComponentName :: LibraryName -> ComponentName
 libraryComponentName = CLibName
+
+-- | Collect package and executable names referenced by active build-tool fields.
+buildToolDependencyNames :: GenericPackageDescription -> [Text]
+buildToolDependencyNames gpd =
+  nub $
+    concatMap buildInfoToolNames (activeComponentBuildInfos gpd)
+
+activeComponentBuildInfos :: GenericPackageDescription -> [BuildInfo]
+activeComponentBuildInfos gpd =
+  let evalCond = conditionEvaluator gpd
+      merged = collectMergedBuildInfo evalCond
+   in maybe [] (pure . merged libBuildInfo) (condLibrary gpd)
+        <> map (merged libBuildInfo . snd) (condSubLibraries gpd)
+        <> map (merged foreignLibBuildInfo . snd) (condForeignLibs gpd)
+        <> map (merged buildInfo . snd) (condExecutables gpd)
+        <> map (merged testBuildInfo . snd) (condTestSuites gpd)
+        <> map (merged benchmarkBuildInfo . snd) (condBenchmarks gpd)
+
+buildInfoToolNames :: BuildInfo -> [Text]
+buildInfoToolNames bi =
+  concatMap exeDependencyNames (buildToolDepends bi)
+    <> concatMap legacyExeDependencyNames (buildTools bi)
+
+exeDependencyNames :: ExeDependency -> [Text]
+exeDependencyNames (ExeDependency pkgName exeName _) =
+  [ T.pack (unPackageName pkgName),
+    T.pack (unUnqualComponentName exeName)
+  ]
+
+legacyExeDependencyNames :: LegacyExeDependency -> [Text]
+legacyExeDependencyNames (LegacyExeDependency toolName _) =
+  [T.pack toolName]
 
 generatedPathsFileInfo :: FilePath -> FileInfo
 generatedPathsFileInfo path =

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -5,9 +5,11 @@ import Aihc.Hackage.Stackage (parseSnapshotConstraints)
 import Aihc.Hackage.Types (PackageSpec (..))
 import Control.Exception (bracket)
 import Data.ByteString qualified as BS
-import Data.List (isInfixOf, isSuffixOf)
+import Data.ByteString.Char8 qualified as BSC
+import Data.List (isInfixOf, isSuffixOf, sort)
 import Data.Text qualified as T
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
 import System.Directory (createDirectory, createDirectoryIfMissing, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.FilePath ((</>))
 import System.IO (hClose, openTempFile)
@@ -34,6 +36,7 @@ main =
             ],
       testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
       testCase "collects exposed modules from active conditional library branches" test_collectsConditionalExposedModules,
+      testCase "extracts active build tool dependency names" test_extractsBuildToolDependencyNames,
       QC.testProperty "dummy quickcheck property" prop_dummy
     ]
 
@@ -100,6 +103,20 @@ test_collectsConditionalExposedModules =
     let paths = map HC.fileInfoPath files
     assertBool "expected conditionally exposed module to be selected" (any ("src/Control/Category/Unicode.hs" `isSuffixOf`) paths)
 
+test_extractsBuildToolDependencyNames :: Assertion
+test_extractsBuildToolDependencyNames = do
+  gpd <- parseTestCabal buildToolDependsCabal
+  assertEqual
+    "expected active modern and legacy build tools"
+    (sort ["alex", "genprimopcode"])
+    (sort (map T.unpack (HC.buildToolDependencyNames gpd)))
+
+parseTestCabal :: String -> IO GenericPackageDescription
+parseTestCabal source =
+  case snd (runParseResult (parseGenericPackageDescription (BSC.pack source))) of
+    Right parsed -> pure parsed
+    Left (_, errs) -> assertFailure ("failed to parse test cabal file: " <> show errs)
+
 pathsDemoCabal :: String
 pathsDemoCabal =
   unlines
@@ -143,6 +160,27 @@ conditionalExposedCabal =
       "  else",
       "    exposed-modules: Control.Category.Unicode",
       "    build-depends: base >= 3.0.3.1 && < 5"
+    ]
+
+buildToolDependsCabal :: String
+buildToolDependsCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: build-tool-demo",
+      "version: 0.1.0.0",
+      "",
+      "flag generated",
+      "  default: False",
+      "  manual: True",
+      "",
+      "library",
+      "  exposed-modules: BuildToolDemo",
+      "  hs-source-dirs: src",
+      "  build-tool-depends: genprimopcode:genprimopcode >= 0",
+      "  build-tools: alex >= 3",
+      "  default-language: Haskell2010",
+      "  if flag(generated)",
+      "    build-tool-depends: inactive-tool:inactive-tool >= 0"
     ]
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a


### PR DESCRIPTION
## Summary

- add Cabal metadata extraction for active build-tool dependencies
- filter parser-stackage-progress packages whose active build tools include genprimopcode (and the misspelled grimprimopcode guard)
- keep unsupported build-tool packages out of the progress denominator before parsing starts

## Progress counts

- Not regenerated in this PR. The next parser-stackage-progress run will exclude packages that require the unsupported genprimopcode build tool from both numerator and denominator instead of attempting to parse them.

## Validation

- just fmt
- just check
- coderabbit review --prompt-only: no findings
