### PR TITLE
fix(parser): preserve tuple multi-way if infix roundtrips

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -288,6 +288,7 @@ needsExprParens ctx expr =
     CtxInfixLhs ->
       case expr of
         ETypeSig {} -> True
+        EMultiWayIf {} -> False
         -- ENegate needs parenthesization when its inner expression is
         -- open-ended (e.g. ends with a `let` body).  Without parens, the
         -- parser re-reads `- f let {} in x \`op\` y` as
@@ -297,7 +298,6 @@ needsExprParens ctx expr =
         -- correctly re-parsed as `(-x) + 1`.
         ENegate inner -> isOpenEnded inner
         ECase {} -> False
-        EMultiWayIf {} -> False
         _ -> isOpenEnded expr
     CtxAppFun ->
       case expr of
@@ -1104,7 +1104,7 @@ addExprParensPrec prec expr =
         EGetFieldProjection {} -> addExprParens inner
         _ -> EParen (addExprParens inner)
     EList values -> EList (map addExprParens values)
-    ETuple tupleFlavor values -> ETuple tupleFlavor (map (fmap addExprParens) values)
+    ETuple tupleFlavor values -> ETuple tupleFlavor (map (fmap addTupleElemParens) values)
     EUnboxedSum altIdx arity inner ->
       let inner' = addExprParens inner
        in EUnboxedSum altIdx arity (wrapExpr (startsWithMultiWayIf inner') inner')
@@ -1348,6 +1348,13 @@ startsWithMultiWayIf = \case
   ETypeApp fn _ -> startsWithMultiWayIf fn
   EMultiWayIf {} -> True
   _ -> False
+
+addTupleElemParens :: Expr -> Expr
+addTupleElemParens expr =
+  let expr' = addExprParens expr
+   in case peelExprAnn expr' of
+        EInfix lhs _ _ | startsWithMultiWayIf lhs -> wrapExpr True expr'
+        _ -> expr'
 
 -- ---------------------------------------------------------------------------
 -- Types

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -265,6 +265,7 @@ buildTests = do
             testCase "pretty-prints negated layout-ending list-comprehension bodies" test_prettyNegatedLayoutEndingListCompBody,
             testCase "pretty-prints layout let guards in multi-way if" test_prettyLayoutLetGuardInMultiWayIf,
             testCase "pretty-prints multi-way if left operands using layout" test_prettyMultiWayIfInfixLhs,
+            testCase "pretty-prints multi-way if left operands inside unboxed tuples with parentheses" test_prettyMultiWayIfInfixLhsInsideUnboxedTuple,
             testCase "pretty-prints multi-way if left operands inside unboxed sums with parentheses" test_prettyMultiWayIfInfixLhsInsideUnboxedSum,
             testCase "pretty-prints where clauses with implicit layout" test_prettyWhereClauseUsesImplicitLayout,
             testCase "pretty-prints GADT constructors with implicit layout" test_prettyGadtConstructorsUseImplicitLayout,
@@ -1037,6 +1038,19 @@ test_prettyMultiWayIfInfixLhs = do
             ->
              ()
          `a` 'x'
+        """
+  assertParsedStrippedExprShapeRoundTrip config source
+
+test_prettyMultiWayIfInfixLhsInsideUnboxedTuple :: Assertion
+test_prettyMultiWayIfInfixLhsInsideUnboxedTuple = do
+  let config = defaultConfig {parserExtensions = [UnboxedTuples, MultiWayIf, OverloadedLabels]}
+      source =
+        """
+        (# ((if | let {  }
+                 ->
+                  #foo)
+            `a` [880
+                 | 48.7]) #)
         """
   assertParsedStrippedExprShapeRoundTrip config source
 


### PR DESCRIPTION
## Summary
- parenthesize tuple elements whose infix left operand starts with a multi-way if so pretty-printed tuple roundtrips keep the original AST
- add a parser regression for an unboxed tuple case matching the failing QuickCheck shape
- validated the original replay seed, targeted multi-way-if regressions, `just fmt`, `just check`, and CodeRabbit prompt-only review with no findings