### PR TITLE
fix(parser): preserve section operand roundtrips

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -263,6 +263,7 @@ data ExprCtx
   | CtxAppArg
   | CtxAppArgNoParens
   | CtxAppArgGreedy
+  | CtxSectionRhs
   | CtxTypeSigBody
   | CtxGuarded
 
@@ -319,6 +320,10 @@ needsExprParens ctx expr =
         _ | isBracedExpr expr -> False
         EPragma {} -> True
         _ -> isGreedyExpr expr
+    CtxSectionRhs ->
+      case expr of
+        ETypeSig {} -> True
+        _ -> False
     CtxTypeSigBody ->
       case expr of
         ETypeSig {} -> True
@@ -348,6 +353,7 @@ exprCtxPrec ctx expr =
       | isBlockExpr expr -> 0
       | isBracedExpr expr -> 0
       | otherwise -> 3
+    CtxSectionRhs -> 0
     CtxTypeSigBody -> 1
     CtxGuarded -> 0
 
@@ -1068,10 +1074,9 @@ addExprParensPrec prec expr =
               else addSectionLhsParens lhs
        in EParen (ESectionL lhs' op)
     ESectionR op rhs ->
-      -- The RHS operand is parsed as an infix RHS, so low-precedence forms
-      -- such as type signatures need their own parentheses:
-      -- @(`op` (x :: T))@, not @(`op` x :: T)@.
-      EParen (ESectionR op (addExprParensIn (CtxInfixRhs False) rhs))
+      -- Right sections accept ordinary expressions as operands. Only explicit
+      -- type signatures need extra grouping to avoid @(`op` x :: T)@.
+      EParen (ESectionR op (addExprParensIn CtxSectionRhs rhs))
     ELetDecls decls body ->
       wrapExpr (prec > 0) (ELetDecls (map addDeclParens decls) (addExprParens body))
     ECase scrutinee alts ->
@@ -1329,8 +1334,6 @@ absorbsFollowingInfix = \case
   EAnn _ sub -> absorbsFollowingInfix sub
   EIf {} -> True
   ELambdaPats {} -> True
-  ELambdaCase {} -> True
-  ELambdaCases {} -> True
   ELetDecls {} -> True
   EProc {} -> True
   EApp _ arg | isBlockExpr arg -> absorbsFollowingInfix arg

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -271,11 +271,13 @@ buildTests = do
             testCase "pretty-prints GADT constructors with implicit layout" test_prettyGadtConstructorsUseImplicitLayout,
             testCase "pretty-prints lambda-case expressions with implicit layout" test_prettyLambdaCaseExpressionUsesImplicitLayout,
             testCase "pretty-prints lambda-cases expressions with implicit layout" test_prettyLambdaCasesExpressionUsesImplicitLayout,
+            testCase "pretty-prints lambda-case applicative chains without extra parens" test_prettyLambdaCaseApplicativeChain,
             testCase "pretty-prints class declarations with implicit layout" test_prettyClassDeclarationUsesImplicitLayout,
             testCase "pretty-prints instance declarations with implicit layout" test_prettyInstanceDeclarationUsesImplicitLayout,
             testCase "pretty-prints TH splices before record dots with parentheses" test_prettySpliceRecordDotBase,
             testCase "pretty-prints infix RHS open-ended expressions inside sections" test_prettyInfixRhsOpenEndedInsideSection,
             testCase "pretty-prints nested infix RHS expressions inside sections" test_prettyNestedInfixRhsInsideSection,
+            testCase "pretty-prints right sections with bare infix operands" test_prettyRightSectionInfixOperand,
             testCase "pretty-prints infix RHS open-ended expressions before following infix operators" test_prettyInfixRhsOpenEndedBeforeFollowingInfix,
             testCase "parenthesizes lambda RHS before following infix operators" test_lambdaInfixRhsBeforeFollowingInfixParens,
             testCase "parenthesizes if RHS before following infix operators" test_ifInfixRhsBeforeFollowingInfixParens,
@@ -1165,6 +1167,21 @@ test_prettyLambdaCasesExpressionUsesImplicitLayout = do
         """
   assertParsedDeclPrettyRoundTrip config declSource declExpected
 
+test_prettyLambdaCaseApplicativeChain :: Assertion
+test_prettyLambdaCaseApplicativeChain = do
+  let config = defaultConfig {parserExtensions = [LambdaCase]}
+      source =
+        T.unlines
+          [ "f originalParsedOptions =",
+            "  (Options <$> __command",
+            "   <*> \\case",
+            "         f | __withFlake f -> Flake",
+            "         _ | otherwise -> Traditional",
+            "   <*> __prioritiseLocalPinnedSystem)",
+            "    originalParsedOptions"
+          ]
+  assertParsedStrippedDeclShapeRoundTrip config source
+
 test_prettyClassDeclarationUsesImplicitLayout :: Assertion
 test_prettyClassDeclarationUsesImplicitLayout = do
   let source = "class C a where { f :: a -> Int; f x = case x of { 0 -> 1; _ -> 2 }; g = 3 }"
@@ -1221,6 +1238,20 @@ test_prettyNestedInfixRhsInsideSection = do
          +)
         """
   assertParsedStrippedExprShapeRoundTrip defaultConfig source
+
+test_prettyRightSectionInfixOperand :: Assertion
+test_prettyRightSectionInfixOperand = do
+  let config = defaultConfig {parserExtensions = [OverloadedStrings]}
+      sources =
+        [ "(/ 10 ^ (3 :: Int))",
+          "(<> msg <> \"\\n\")",
+          "(++ \" seconds\" ++ dir f)",
+          "(< sizeOf x * 8)",
+          "(<= m + 1 / 2)",
+          "(.+^ p ^. vel)",
+          "(<?> prettyIndentation ref ++ \" (started at line \" ++ prettyLine ref ++ \")\")"
+        ]
+  mapM_ (assertParsedStrippedExprShapeRoundTrip config) sources
 
 test_prettyInfixRhsOpenEndedBeforeFollowingInfix :: Assertion
 test_prettyInfixRhsOpenEndedBeforeFollowingInfix = do

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/enumset-sizeof-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/enumset-sizeof-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail enumset: parser requires parenthesized right side of `< sizeOf x * 8` expression -}
+{- ORACLE_TEST pass -}
 module EnumsetTakeWhileSizeOfXFail where
 
 f x = takeWhile (< sizeOf x * 8)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/enumset-sizeof.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/enumset-sizeof.hs
@@ -1,4 +1,4 @@
 {- ORACLE_TEST pass -}
-module EnumsetTakeWhileSizeOfXFail where
+module EnumsetTakeWhileSizeOf where
 
 f x = takeWhile (< sizeOf x * 8)

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/force-layout-parenthesized-lens-op-arg.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/force-layout-parenthesized-lens-op-arg.hs
@@ -1,5 +1,4 @@
-{- ORACLE_TEST xfail Guard roundtrip due to extra parentheses around operator argument -}
+{- ORACLE_TEST pass -}
 module ForceLayoutParenthesizedLensArg where
 
 stepPos p = pos %~ (.+^ p ^. vel) $ p
-

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/friendly-time-append-seconds-lambda.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/friendly-time-append-seconds-lambda.hs
@@ -1,5 +1,4 @@
-{- ORACLE_TEST xfail Guard roundtrip due to parenthesized section on string concat rhs -}
+{- ORACLE_TEST pass -}
 module FriendlyTimeAppendSecondsLambda where
 
 secondsAgo = \f -> (++ " seconds" ++ dir f)
-

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indents-expected-message-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indents-expected-message-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail indents: parser adds parentheses around the concatenation expression for message in the parser expectation operator -}
+{- ORACLE_TEST pass -}
 module IndentsExpectedMessageXFail where
 
 f ref pos =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indents-expected-message.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/indents-expected-message.hs
@@ -1,5 +1,5 @@
 {- ORACLE_TEST pass -}
-module IndentsExpectedMessageXFail where
+module IndentsExpectedMessage where
 
 f ref pos =
   (<?> prettyIndentation ref ++ " (started at line " ++ prettyLine ref ++ ")")

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ratio-int-parenthesized-compare.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/ratio-int-parenthesized-compare.hs
@@ -1,5 +1,4 @@
-{- ORACLE_TEST xfail Guard roundtrip due to unnecessary parentheses in rhs of <= -}
+{- ORACLE_TEST pass -}
 module RatioIntParenthesizedCompare where
 
 enumFromTo n m = takeWhile (<= m + 1 / 2) (enumFrom n)
-

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/splitmix-distributions-negation-parens-xfail.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/splitmix-distributions-negation-parens-xfail.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail splitmix-distributions: parser inserts extra parentheses in mixed negation and exponentiation expressions -}
+{- ORACLE_TEST pass -}
 module SplitmixDistributionsNegationParensXFail where
 
 zipfLike a u =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/splitmix-distributions-negation-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/splitmix-distributions-negation-parens.hs
@@ -1,5 +1,5 @@
 {- ORACLE_TEST pass -}
-module SplitmixDistributionsNegationParensXFail where
+module SplitmixDistributionsNegationParens where
 
 zipfLike a u =
   let xInt = floor (u ** (- 1 / (a - 1)))

--- a/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/lambda-case-application-with-guards.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/LambdaCase/lambda-case-application-with-guards.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail shellify parse/pretty mismatch for \case in applicative chain -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE LambdaCase #-}
 
 module LambdaCaseInfixApplication where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/log-base-modify-seq-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/log-base-modify-seq-parens.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail log-base-style section-appends keep rhs grouped when parenthesized by parser -}
+{- ORACLE_TEST pass -}
 {-# LANGUAGE OverloadedStrings #-}
 
 module MonoidAppendParen where

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/monad-metrics-section-operator-paren.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/monad-metrics-section-operator-paren.hs
@@ -1,4 +1,4 @@
-{- ORACLE_TEST xfail monad-metrics-style section application emits extra parens around rhs precedence -}
+{- ORACLE_TEST pass -}
 module ParenSectionExponent where
 
 nsToUs = (/ 10^(3 :: Int))


### PR DESCRIPTION
## Summary
- replace the infix-RHS reuse in `Aihc.Parser.Parens` with a dedicated right-section operand rule, and stop treating `\\case`/`\\cases` as needing follow-on infix protection in applicative chains
- add focused parser regressions for bare infix operands inside right sections and lambda-case applicative chains, and promote the 9 former oracle `xfail` fixtures to passing coverage
- rename the remaining historical `*-xfail` Hackage fixtures that now pass so the oracle corpus matches current status

## Progress
- Parser progress: 1128 pass / 9 xfail / 0 xpass / 0 fail -> 1137 pass / 0 xfail / 0 xpass / 0 fail

## Validation
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "pretty-prints right sections with bare infix operands"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "pretty-prints lambda-case applicative chains without extra parens"'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern oracle'`
- `just fmt`
- `just check`

## CodeRabbit
- Renamed the three remaining pass fixtures that still carried `xfail` in their filenames and module names.
- Ignored the `sizeOf` import suggestion because oracle fixtures are parser/oracle syntax inputs, not typechecked modules.