### PR TITLE
fix(parser): preserve nested multi-way if infix roundtrips

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -63,6 +63,19 @@ prettyRawText raw
   | T.isInfixOf "\n" raw = nesting $ \level -> nest (negate level) (pretty raw)
   | otherwise = pretty raw
 
+startsWithMultiWayIf :: Expr -> Bool
+startsWithMultiWayIf expr =
+  case expr of
+    EAnn _ sub -> startsWithMultiWayIf sub
+    EInfix lhs _ _ -> startsWithMultiWayIf lhs
+    EApp fn _ -> startsWithMultiWayIf fn
+    ERecordUpd base _ -> startsWithMultiWayIf base
+    EGetField base _ -> startsWithMultiWayIf base
+    ETypeSig inner _ -> startsWithMultiWayIf inner
+    ETypeApp fn _ -> startsWithMultiWayIf fn
+    EMultiWayIf {} -> True
+    _ -> False
+
 -- | Pretty instance for Module - renders to valid Haskell source code.
 instance Pretty Module where
   pretty = prettyModuleDoc . addModuleParens
@@ -1160,7 +1173,7 @@ prettyExpr expr =
     ELambdaCases alts ->
       "\\" <> "cases" <> prettyCaseLayout (map prettyLambdaCaseAlt alts)
     EInfix lhs op rhs ->
-      prettyExpr lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs
+      (if startsWithMultiWayIf lhs then align else id) (prettyExpr lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs)
     ENegate inner -> "-" <> prettyExpr inner
     ESectionL lhs op ->
       prettyExpr lhs <> hardline <> " " <> prettyNameInfixOp op
@@ -1390,7 +1403,8 @@ prettyExprAtStatementStart expr =
     EOverloadedLabel _ raw -> pretty raw
     EApp {} -> prettyAppWith prettyExprAtStatementStart expr
     ETypeApp fn ty -> prettyExprAtStatementStart fn <> hardline <> " " <> prettyTypeAppArg ty
-    EInfix lhs op rhs -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs
+    EInfix lhs op rhs ->
+      (if startsWithMultiWayIf lhs then align else id) (prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op <+> prettyExpr rhs)
     ESectionL lhs op -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op
     ETypeSig inner ty -> prettyExprAtStatementStart inner <> hardline <> " " <> "::" <+> prettyType ty
     ERecordUpd base fields ->

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1045,51 +1045,17 @@ test_prettyMultiWayIfInfixLhs = do
 test_prettyMultiWayIfInfixLhsInDecl :: Assertion
 test_prettyMultiWayIfInfixLhsInDecl = do
   let config = defaultConfig {parserExtensions = [MultiWayIf, OverloadedLabels]}
-      decl =
-        DeclValue
-          ( PatternBind
-              NoMultiplicityTag
-              (PVar (mkUnqualifiedName NameVarId "a"))
-              ( UnguardedRhs
-                  []
-                  ( EList
-                      [ EInfix
-                          ( EMultiWayIf
-                              [ GuardedRhs
-                                  { guardedRhsAnns = [],
-                                    guardedRhsGuards =
-                                      [ GuardLet
-                                          [ DeclValue
-                                              ( PatternBind
-                                                  NoMultiplicityTag
-                                                  (PVar (mkUnqualifiedName NameVarSym "+"))
-                                                  (UnguardedRhs [] (EOverloadedLabel "a" "#a") Nothing)
-                                              )
-                                          ]
-                                      ],
-                                    guardedRhsBody = ETuple Boxed []
-                                  }
-                              ]
-                          )
-                          (qualifyName Nothing (mkUnqualifiedName NameVarId "a"))
-                          (ETuple Boxed [])
-                      ]
-                  )
-                  Nothing
-              )
-          )
-      expected =
-        T.intercalate
-          "\n"
-          [ "a =",
-            "  [if | let",
-            "        (+) =",
-            "           #a",
-            "       ->",
-            "        ()",
-            "    `a` ()]"
-          ]
-  assertDeclPrettyRoundTrip config decl expected
+      source =
+        """
+        a =
+          [if | let
+                (+) =
+                   #a
+               ->
+                ()
+              `a` ()]
+        """
+  assertParsedStrippedDeclShapeRoundTrip config source
 
 test_prettyMultiWayIfInfixLhsInsideUnboxedTuple :: Assertion
 test_prettyMultiWayIfInfixLhsInsideUnboxedTuple = do

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -265,6 +265,7 @@ buildTests = do
             testCase "pretty-prints negated layout-ending list-comprehension bodies" test_prettyNegatedLayoutEndingListCompBody,
             testCase "pretty-prints layout let guards in multi-way if" test_prettyLayoutLetGuardInMultiWayIf,
             testCase "pretty-prints multi-way if left operands using layout" test_prettyMultiWayIfInfixLhs,
+            testCase "pretty-prints multi-way if left operands in declarations" test_prettyMultiWayIfInfixLhsInDecl,
             testCase "pretty-prints multi-way if left operands inside unboxed tuples with parentheses" test_prettyMultiWayIfInfixLhsInsideUnboxedTuple,
             testCase "pretty-prints multi-way if left operands inside unboxed sums with parentheses" test_prettyMultiWayIfInfixLhsInsideUnboxedSum,
             testCase "pretty-prints where clauses with implicit layout" test_prettyWhereClauseUsesImplicitLayout,
@@ -1040,6 +1041,55 @@ test_prettyMultiWayIfInfixLhs = do
          `a` 'x'
         """
   assertParsedStrippedExprShapeRoundTrip config source
+
+test_prettyMultiWayIfInfixLhsInDecl :: Assertion
+test_prettyMultiWayIfInfixLhsInDecl = do
+  let config = defaultConfig {parserExtensions = [MultiWayIf, OverloadedLabels]}
+      decl =
+        DeclValue
+          ( PatternBind
+              NoMultiplicityTag
+              (PVar (mkUnqualifiedName NameVarId "a"))
+              ( UnguardedRhs
+                  []
+                  ( EList
+                      [ EInfix
+                          ( EMultiWayIf
+                              [ GuardedRhs
+                                  { guardedRhsAnns = [],
+                                    guardedRhsGuards =
+                                      [ GuardLet
+                                          [ DeclValue
+                                              ( PatternBind
+                                                  NoMultiplicityTag
+                                                  (PVar (mkUnqualifiedName NameVarSym "+"))
+                                                  (UnguardedRhs [] (EOverloadedLabel "a" "#a") Nothing)
+                                              )
+                                          ]
+                                      ],
+                                    guardedRhsBody = ETuple Boxed []
+                                  }
+                              ]
+                          )
+                          (qualifyName Nothing (mkUnqualifiedName NameVarId "a"))
+                          (ETuple Boxed [])
+                      ]
+                  )
+                  Nothing
+              )
+          )
+      expected =
+        T.intercalate
+          "\n"
+          [ "a =",
+            "  [if | let",
+            "        (+) =",
+            "           #a",
+            "       ->",
+            "        ()",
+            "    `a` ()]"
+          ]
+  assertDeclPrettyRoundTrip config decl expected
 
 test_prettyMultiWayIfInfixLhsInsideUnboxedTuple :: Assertion
 test_prettyMultiWayIfInfixLhsInsideUnboxedTuple = do


### PR DESCRIPTION
## Summary
- fix pretty-printing of infix expressions whose left operand starts with a multi-way if so nested layout contexts reparse as the intended outer infix expression
- add a declaration-level regression test covering the original QuickCheck replay shape with a list element containing a multi-way if on the left of an infix operator
- verified with `just replay \"(SMGen 13587471787218946846 12109043036645283787,39)\"`, `just fmt`, `just check`, and CodeRabbit prompt-only review

## Validation
- `just replay "(SMGen 13587471787218946846 12109043036645283787,39)"`
- `just fmt`
- `just check`

## Progress
- oracle completion remains 99.11%: pass=1123 xfail=9 xpass=0 fail=0