### PR TITLE
feat: add parser hackage progress command

### DIFF
--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -101,12 +101,15 @@ executable aihc-dev
   main-is: Main.hs
   hs-source-dirs:
     exe
+    app/hackage-progress
     app/stackage-progress
     app/resolve-stackage-progress
 
   other-modules:
     Aihc.Dev.HackageTester.Run
     BootInterface
+    HackageProgress.CLI
+    HackageProgress.Run
     ResolvePackage
     ResolveStackageProgress
     StackageProgress.CLI
@@ -156,17 +159,23 @@ test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:
     test
+    app/hackage-progress
     app/stackage-progress
     app/resolve-stackage-progress
 
   main-is: Spec.hs
   other-modules:
     BootInterface
+    HackageProgress.CLI
+    HackageProgress.Run
     ResolvePackage
     ResolveStackageProgress
     StackageProgress.CLI
     StackageProgress.FileChecker
     StackageProgress.FileCheckerTiming
+    StackageProgress.PackageRunner
+    StackageProgress.Run
+    StackageProgress.Snapshot
     Test.ExtractHiCompare
     Test.ParserCLI.Golden
     Test.ParserCLI.Suite

--- a/tooling/aihc-dev/app/hackage-progress/HackageProgress/CLI.hs
+++ b/tooling/aihc-dev/app/hackage-progress/HackageProgress/CLI.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | CLI option parsing for hackage-progress using optparse-applicative.
+module HackageProgress.CLI
+  ( Options (..),
+    optionsParser,
+    toStackageOptions,
+  )
+where
+
+import Data.List (nub)
+import Options.Applicative qualified as OA
+import StackageProgress.CLI qualified as StackageCLI
+
+-- | Command-line options for hackage-progress.
+data Options = Options
+  { optParsers :: [StackageCLI.Parser],
+    optJobs :: Maybe Int,
+    optOffline :: Bool,
+    optUpdateIndex :: Bool,
+    optPrompt :: Bool,
+    optPromptSeed :: Maybe Int,
+    optPrintSucceeded :: Bool,
+    optPrintFailedTable :: Bool,
+    optGhcErrorsFile :: Maybe FilePath,
+    optGhcErrorsLimit :: Int,
+    optVerbose :: Bool
+  }
+  deriving (Eq, Show)
+
+optionsParser :: OA.Parser Options
+optionsParser =
+  Options
+    <$> parserOption
+    <*> OA.optional
+      ( OA.option
+          positiveIntReader
+          ( OA.long "jobs"
+              <> OA.metavar "N"
+              <> OA.help "Number of packages to process concurrently (default: CPU cores)"
+          )
+      )
+    <*> OA.switch
+      ( OA.long "offline"
+          <> OA.help "Use only cached index and packages, don't download"
+      )
+    <*> OA.switch
+      ( OA.long "update-index"
+          <> OA.help "Fetch and cache a fresh Hackage index before testing"
+      )
+    <*> OA.switch
+      ( OA.long "prompt"
+          <> OA.help "Generate a prompt for a random failing package"
+      )
+    <*> OA.optional
+      ( OA.option
+          OA.auto
+          ( OA.long "prompt-seed"
+              <> OA.metavar "N"
+              <> OA.help "Seed for selecting random failing package"
+          )
+      )
+    <*> OA.switch
+      ( OA.long "print-succeeded"
+          <> OA.help "Print list of succeeded packages"
+      )
+    <*> OA.switch
+      ( OA.long "print-failed-table"
+          <> OA.help "Print table of failed packages with sizes"
+      )
+    <*> OA.optional
+      ( OA.strOption
+          ( OA.long "ghc-errors-file"
+              <> OA.metavar "PATH"
+              <> OA.help "Write GHC errors to file"
+          )
+      )
+    <*> OA.option
+      positiveIntReader
+      ( OA.long "ghc-errors-limit"
+          <> OA.metavar "N"
+          <> OA.value 100
+          <> OA.showDefault
+          <> OA.help "Maximum number of GHC errors to store"
+      )
+    <*> OA.switch
+      ( OA.long "verbose"
+          <> OA.help "Print verbose progress information"
+      )
+
+toStackageOptions :: Options -> StackageCLI.Options
+toStackageOptions opts =
+  StackageCLI.Options
+    { StackageCLI.optSnapshot = "hackage",
+      StackageCLI.optParsers = optParsers opts,
+      StackageCLI.optJobs = optJobs opts,
+      StackageCLI.optOffline = optOffline opts,
+      StackageCLI.optPrompt = optPrompt opts,
+      StackageCLI.optPromptSeed = optPromptSeed opts,
+      StackageCLI.optPrintSucceeded = optPrintSucceeded opts,
+      StackageCLI.optPrintFailedTable = optPrintFailedTable opts,
+      StackageCLI.optGhcErrorsFile = optGhcErrorsFile opts,
+      StackageCLI.optGhcErrorsLimit = optGhcErrorsLimit opts,
+      StackageCLI.optVerbose = optVerbose opts
+    }
+
+parserOption :: OA.Parser [StackageCLI.Parser]
+parserOption =
+  OA.option
+    parseParsers
+    ( OA.long "parsers"
+        <> OA.metavar "PARSERS"
+        <> OA.value [StackageCLI.ParserAihc]
+        <> OA.help "Comma-separated list of parsers: aihc,hse,ghc"
+    )
+
+parseParsers :: OA.ReadM [StackageCLI.Parser]
+parseParsers = OA.eitherReader $ \raw -> do
+  parsers <- mapM parseParser (splitComma raw)
+  let uniq = nub parsers
+  if null uniq
+    then Left "--parsers cannot be empty"
+    else Right uniq
+
+parseParser :: String -> Either String StackageCLI.Parser
+parseParser raw =
+  case trim raw of
+    "aihc" -> Right StackageCLI.ParserAihc
+    "hse" -> Right StackageCLI.ParserHse
+    "ghc" -> Right StackageCLI.ParserGhc
+    other -> Left ("Unknown parser: " ++ other)
+
+splitComma :: String -> [String]
+splitComma s =
+  case break (== ',') s of
+    (chunk, []) -> [chunk]
+    (chunk, _ : rest) -> chunk : splitComma rest
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace
+  where
+    isSpace c = c == ' ' || c == '\t' || c == '\n' || c == '\r'
+    dropWhileEnd p = reverse . dropWhile p . reverse
+
+positiveIntReader :: OA.ReadM Int
+positiveIntReader = OA.eitherReader $ \raw ->
+  case reads raw of
+    [(n, "")] | n > 0 -> Right n
+    _ -> Left "must be a positive integer"

--- a/tooling/aihc-dev/app/hackage-progress/HackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/hackage-progress/HackageProgress/Run.hs
@@ -1,0 +1,33 @@
+module HackageProgress.Run (run) where
+
+import Aihc.Hackage.Index
+  ( HackageIndexMode (..),
+    loadHackageIndex,
+  )
+import Control.Monad (when)
+import HackageProgress.CLI (Options (..), toStackageOptions)
+import StackageProgress.Run qualified as StackageProgressRun
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+
+run :: Options -> IO ()
+run opts = do
+  when (optOffline opts && optUpdateIndex opts) $ do
+    hPutStrLn stderr "Cannot combine --offline with --update-index."
+    exitFailure
+
+  indexResult <- loadHackageIndex Nothing (hackageIndexMode opts)
+  packages <-
+    case indexResult of
+      Left err -> do
+        hPutStrLn stderr ("Failed to load Hackage index: " ++ err)
+        exitFailure
+      Right specs -> pure specs
+
+  StackageProgressRun.runPackages (toStackageOptions opts) packages
+
+hackageIndexMode :: Options -> HackageIndexMode
+hackageIndexMode opts
+  | optUpdateIndex opts = UpdateHackageIndex
+  | optOffline opts = OfflineHackageIndex
+  | otherwise = UseCachedHackageIndex

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -1,6 +1,12 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Package-level processing for Stackage packages.
 module StackageProgress.PackageRunner
-  ( -- * Running packages
+  ( -- * Options
+    PackageRunOptions (..),
+    packageRunOptionsFromStackageOptions,
+
+    -- * Running packages
     runPackage,
     runPackageOrThrow,
     packageDependsOnUnsupportedBuildTool,
@@ -21,6 +27,7 @@ import HackageSupport
     findTargetFilesFromCabal,
   )
 import StackageProgress.CLI (Options (..))
+import StackageProgress.CLI qualified as StackageCLI
 import StackageProgress.FileChecker
   ( FileCheckOptions (..),
     PackageFileSummary (..),
@@ -35,29 +42,51 @@ import StackageProgress.Summary
   )
 import System.Directory (getFileSize)
 
+-- | Package-level runner options shared by Stackage and Hackage progress tools.
+data PackageRunOptions = PackageRunOptions
+  { runOptParsers :: ![StackageCLI.Parser],
+    runOptOffline :: !Bool,
+    runOptPrompt :: !Bool,
+    runOptPrintFailedTable :: !Bool,
+    runOptGhcErrorsFile :: !(Maybe FilePath),
+    runOptVerbose :: !Bool
+  }
+  deriving (Eq, Show)
+
+packageRunOptionsFromStackageOptions :: Options -> PackageRunOptions
+packageRunOptionsFromStackageOptions opts =
+  PackageRunOptions
+    { runOptParsers = optParsers opts,
+      runOptOffline = optOffline opts,
+      runOptPrompt = optPrompt opts,
+      runOptPrintFailedTable = optPrintFailedTable opts,
+      runOptGhcErrorsFile = optGhcErrorsFile opts,
+      runOptVerbose = optVerbose opts
+    }
+
 unsupportedBuildToolNames :: [Text]
 unsupportedBuildToolNames = ["genprimopcode"]
 
 -- | Return whether a package's active Cabal metadata requires an unsupported build tool.
-packageDependsOnUnsupportedBuildTool :: Options -> PackageSpec -> IO Bool
+packageDependsOnUnsupportedBuildTool :: PackageRunOptions -> PackageSpec -> IO Bool
 packageDependsOnUnsupportedBuildTool opts spec = do
   result <- try (packageDependsOnUnsupportedBuildToolOrThrow opts spec) :: IO (Either SomeException Bool)
   pure $ case result of
     Right depends -> depends
     Left _ -> False
 
-packageDependsOnUnsupportedBuildToolOrThrow :: Options -> PackageSpec -> IO Bool
+packageDependsOnUnsupportedBuildToolOrThrow :: PackageRunOptions -> PackageSpec -> IO Bool
 packageDependsOnUnsupportedBuildToolOrThrow opts spec = do
   versionResult <- resolveSpecVersion spec
   case versionResult of
     Left _ -> pure False
     Right version -> do
-      srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) version
+      srcDir <- downloadPackageQuietWithNetwork (not (runOptOffline opts)) (pkgName spec) version
       toolNames <- findPackageBuildToolDependencyNames srcDir
       pure (any (`elem` unsupportedBuildToolNames) toolNames)
 
 -- | Process a package, catching any exceptions.
-runPackage :: Options -> PackageSpec -> IO PackageResult
+runPackage :: PackageRunOptions -> PackageSpec -> IO PackageResult
 runPackage opts spec = do
   result <- try (runPackageOrThrow opts spec)
   pure $ case result of
@@ -75,7 +104,7 @@ runPackage opts spec = do
     Right pkgResult -> pkgResult
 
 -- | Process a package, potentially throwing exceptions.
-runPackageOrThrow :: Options -> PackageSpec -> IO PackageResult
+runPackageOrThrow :: PackageRunOptions -> PackageSpec -> IO PackageResult
 runPackageOrThrow opts spec = do
   versionResult <- resolveSpecVersion spec
   case versionResult of
@@ -84,14 +113,14 @@ runPackageOrThrow opts spec = do
   where
     runWithVersion :: String -> IO PackageResult
     runWithVersion version = do
-      srcDir <- downloadPackageQuietWithNetwork (not (optOffline opts)) (pkgName spec) version
+      srcDir <- downloadPackageQuietWithNetwork (not (runOptOffline opts)) (pkgName spec) version
       files <- findTargetFilesFromCabal srcDir
-      totalSize <- if optPrintFailedTable opts then totalSourceSize files else pure 0
+      totalSize <- if runOptPrintFailedTable opts then totalSourceSize files else pure 0
       let checkOpts =
             FileCheckOptions
-              { fileCheckKeepFirstFailure = optPrompt opts || isJust (optGhcErrorsFile opts),
-                fileCheckKeepFileErrors = optPrintFailedTable opts,
-                fileCheckKeepGhcError = isJust (optGhcErrorsFile opts)
+              { fileCheckKeepFirstFailure = runOptPrompt opts || isJust (runOptGhcErrorsFile opts),
+                fileCheckKeepFileErrors = runOptPrintFailedTable opts,
+                fileCheckKeepGhcError = isJust (runOptGhcErrorsFile opts)
               }
       if null files
         then
@@ -107,7 +136,7 @@ runPackageOrThrow opts spec = do
                 packageFileErrors = []
               }
         else do
-          fileSummary <- foldFilesForPackage checkOpts (optParsers opts) (optVerbose opts) srcDir emptyFileSummary files
+          fileSummary <- foldFilesForPackage checkOpts (runOptParsers opts) (runOptVerbose opts) srcDir emptyFileSummary files
           let hseOk = packageFileHseOk fileSummary
               ghcOk = packageFileGhcOk fileSummary
               ghcError = packageFileGhcError fileSummary

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module StackageProgress.Run (run) where
+module StackageProgress.Run (run, runPackages) where
 
 import Aihc.Hackage.Types (PackageSpec)
 import Control.Concurrent.Async (replicateConcurrently_)
@@ -18,7 +18,12 @@ import StackageProgress.CLI
     Parser (..),
     summaryOptionsFromOptions,
   )
-import StackageProgress.PackageRunner (packageDependsOnUnsupportedBuildTool, runPackage)
+import StackageProgress.PackageRunner
+  ( PackageRunOptions,
+    packageDependsOnUnsupportedBuildTool,
+    packageRunOptionsFromStackageOptions,
+    runPackage,
+  )
 import StackageProgress.Snapshot (loadStackageSnapshotWithMode)
 import StackageProgress.Summary
   ( FailedPackage (..),
@@ -53,9 +58,13 @@ run opts = do
         hPutStrLn stderr ("Failed to load snapshot: " ++ err)
         exitFailure
       Right specs -> pure specs
+  runPackages opts packages
 
+runPackages :: Options -> [PackageSpec] -> IO ()
+runPackages opts packages = do
   jobs <- maybe getNumProcessors pure (optJobs opts)
-  filteredPackages <- filterUnsupportedBuildToolPackages opts jobs packages
+  let packageRunOpts = packageRunOptionsFromStackageOptions opts
+  filteredPackages <- filterUnsupportedBuildToolPackages packageRunOpts jobs packages
   let total = length filteredPackages
   isStdoutTerminal <- hIsTerminalDevice stdout
   let showProgress = isStdoutTerminal && not (optPrompt opts)
@@ -67,7 +76,7 @@ run opts = do
   (summary, promptCandidates) <-
     foldConcurrentlyChunksWithProgress
       jobs
-      (runPackage opts)
+      (runPackage packageRunOpts)
       filteredPackages
       total
       showProgress
@@ -139,7 +148,7 @@ run opts = do
 
   if successOursN == total then exitSuccess else exitFailure
 
-filterUnsupportedBuildToolPackages :: Options -> Int -> [PackageSpec] -> IO [PackageSpec]
+filterUnsupportedBuildToolPackages :: PackageRunOptions -> Int -> [PackageSpec] -> IO [PackageSpec]
 filterUnsupportedBuildToolPackages opts n packages = do
   queue <- newChan
   forM_ (zip [0 :: Int ..] packages) (writeChan queue . Just)

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -14,6 +14,8 @@ import Data.Aeson (encode)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString.Lazy qualified as BL
 import Data.Yaml qualified as Yaml
+import HackageProgress.CLI qualified as ParserHackageProgressCLI
+import HackageProgress.Run qualified as ParserHackageProgressRun
 import HackageTester.CLI qualified as HackageTesterCLI
 import Options.Applicative
 import ResolvePackage qualified as RP
@@ -46,6 +48,7 @@ data Command
   | ParserBench ParserBenchCLI.Options
   | HackageTester HackageTesterCLI.Options
   | ParserStackageProgress ParserStackageProgressCLI.Options
+  | ParserHackageProgress ParserHackageProgressCLI.Options
   | ResolvePackage RP.Options
   | ResolveStackageProgress RSP.Options
 
@@ -117,6 +120,12 @@ commandParser =
           ( info
               (ParserStackageProgress <$> ParserStackageProgressCLI.optionsParser <**> helper)
               (progDesc "Test parser on Stackage snapshot packages")
+          )
+        <> command
+          "parser-hackage-progress"
+          ( info
+              (ParserHackageProgress <$> ParserHackageProgressCLI.optionsParser <**> helper)
+              (progDesc "Test parser on all packages in Hackage")
           )
         <> command
           "resolve"
@@ -227,6 +236,8 @@ runCommand (HackageTester opts) =
   HackageTesterRun.run opts
 runCommand (ParserStackageProgress opts) =
   ParserStackageProgressRun.run opts
+runCommand (ParserHackageProgress opts) =
+  ParserHackageProgressRun.run opts
 runCommand (ResolvePackage opts) =
   RP.run opts
 runCommand (ResolveStackageProgress opts) =

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -15,6 +15,7 @@ library
     Aihc.Hackage.Cache
     Aihc.Hackage.Cpp
     Aihc.Hackage.Download
+    Aihc.Hackage.Index
     Aihc.Hackage.Stackage
     Aihc.Hackage.Types
     Aihc.Hackage.Util
@@ -50,10 +51,12 @@ test-suite spec
     bytestring,
     directory,
     filepath,
+    tar,
     tasty,
     tasty-hunit,
     tasty-quickcheck,
     text,
+    zlib,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cache.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cache.hs
@@ -1,6 +1,7 @@
 -- | XDG cache layout for downloaded Hackage packages and Stackage snapshots.
 module Aihc.Hackage.Cache
   ( getHackageCacheDir,
+    hackageIndexCacheFile,
     getStackageCacheDir,
     snapshotCacheFile,
     sanitizeName,
@@ -22,6 +23,15 @@ getHackageCacheDir :: IO FilePath
 getHackageCacheDir = do
   cacheBase <- getXdgDirectory XdgCache "aihc"
   pure (cacheBase </> "hackage")
+
+-- | Cache file for Hackage's package index.
+--
+-- @~\/.cache\/aihc\/hackage\/01-index.tar.gz@
+hackageIndexCacheFile :: IO FilePath
+hackageIndexCacheFile = do
+  dir <- getHackageCacheDir
+  createDirectoryIfMissing True dir
+  pure (dir </> "01-index.tar.gz")
 
 -- | XDG cache directory for Stackage snapshot data.
 --

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Index.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Index.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Hackage package index fetching and parsing.
+module Aihc.Hackage.Index
+  ( HackageIndexMode (..),
+    loadHackageIndex,
+    parseHackageIndex,
+  )
+where
+
+import Aihc.Hackage.Cache (hackageIndexCacheFile)
+import Aihc.Hackage.Types (PackageSpec (..))
+import Codec.Archive.Tar qualified as Tar
+import Codec.Compression.GZip qualified as GZip
+import Control.Exception (SomeException, displayException, try)
+import Data.ByteString.Lazy qualified as LBS
+import Data.List (isSuffixOf)
+import Data.Map.Strict qualified as Map
+import Distribution.Parsec (simpleParsec)
+import Distribution.Pretty (prettyShow)
+import Distribution.Types.Version (Version)
+import Network.HTTP.Client (Manager, httpLbs, newManager, parseRequest, responseBody, responseStatus)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Status (statusCode)
+import System.Directory (doesFileExist)
+import System.FilePath.Posix (splitDirectories)
+
+-- | Controls whether the cached index may be refreshed from Hackage.
+data HackageIndexMode
+  = UseCachedHackageIndex
+  | UpdateHackageIndex
+  | OfflineHackageIndex
+  deriving (Eq, Show)
+
+-- | Load Hackage's package index.
+--
+-- Existing cached data is reused unless 'UpdateHackageIndex' is requested.
+-- If no cache exists, the index is fetched unless 'OfflineHackageIndex' is
+-- requested.
+loadHackageIndex :: Maybe Manager -> HackageIndexMode -> IO (Either String [PackageSpec])
+loadHackageIndex mManager mode = do
+  cacheFile <- hackageIndexCacheFile
+  hasCache <- doesFileExist cacheFile
+  indexBytes <-
+    case (mode, hasCache) of
+      (OfflineHackageIndex, False) ->
+        pure (Left "Hackage index missing from cache in offline mode")
+      (UseCachedHackageIndex, True) ->
+        Right <$> LBS.readFile cacheFile
+      (OfflineHackageIndex, True) ->
+        Right <$> LBS.readFile cacheFile
+      (UpdateHackageIndex, _) ->
+        fetchAndCache cacheFile
+      (UseCachedHackageIndex, False) ->
+        fetchAndCache cacheFile
+  pure (indexBytes >>= parseHackageIndex)
+  where
+    fetchAndCache cacheFile = do
+      manager <- maybe (newManager tlsManagerSettings) pure mManager
+      fetched <- httpGetLBS manager "https://hackage.haskell.org/01-index.tar.gz"
+      case fetched of
+        Left err -> pure (Left err)
+        Right bytes -> do
+          LBS.writeFile cacheFile bytes
+          pure (Right bytes)
+
+-- | Parse a compressed Hackage @01-index.tar.gz@ into latest package versions.
+parseHackageIndex :: LBS.ByteString -> Either String [PackageSpec]
+parseHackageIndex bytes =
+  case collectEntries Map.empty (Tar.read (GZip.decompress bytes)) of
+    Left err -> Left err
+    Right packages
+      | Map.null packages -> Left "No package versions found in Hackage index"
+      | otherwise ->
+          Right
+            [ PackageSpec name (prettyShow version)
+            | (name, version) <- Map.toAscList packages
+            ]
+  where
+    collectEntry packages entry =
+      case packageVersionFromEntryPath (Tar.entryPath entry) of
+        Nothing -> packages
+        Just (name, version) -> Map.insertWith max name version packages
+
+    collectEntries packages (Tar.Next entry rest) =
+      collectEntries (collectEntry packages entry) rest
+    collectEntries packages Tar.Done = Right packages
+    collectEntries _ (Tar.Fail err) = Left (show err)
+
+packageVersionFromEntryPath :: FilePath -> Maybe (String, Version)
+packageVersionFromEntryPath path =
+  case splitDirectories path of
+    [name, rawVersion, cabalFile]
+      | cabalFile == name ++ ".cabal",
+        ".cabal" `isSuffixOf` cabalFile,
+        Just version <- simpleParsec rawVersion ->
+          Just (name, version)
+    _ -> Nothing
+
+httpGetLBS :: Manager -> String -> IO (Either String LBS.ByteString)
+httpGetLBS manager url = do
+  result <- try $ do
+    request <- parseRequest url
+    response <- httpLbs request manager
+    let status = statusCode (responseStatus response)
+    if status >= 200 && status < 300
+      then pure (Right (responseBody response))
+      else pure (Left ("HTTP " ++ show status ++ " for " ++ url))
+  case result of
+    Left (err :: SomeException) -> pure (Left (displayException err))
+    Right r -> pure r

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -1,11 +1,16 @@
 module Main (main) where
 
 import Aihc.Hackage.Cabal qualified as HC
+import Aihc.Hackage.Index (parseHackageIndex)
 import Aihc.Hackage.Stackage (parseSnapshotConstraints)
 import Aihc.Hackage.Types (PackageSpec (..))
+import Codec.Archive.Tar qualified as Tar
+import Codec.Archive.Tar.Entry qualified as Tar
+import Codec.Compression.GZip qualified as GZip
 import Control.Exception (bracket)
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BSC
+import Data.ByteString.Lazy qualified as LBS
 import Data.List (isInfixOf, isSuffixOf, sort)
 import Data.Text qualified as T
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
@@ -34,6 +39,12 @@ main =
             [ PackageSpec "ghc-prim" "installed",
               PackageSpec "custom-package" "installed"
             ],
+      testCase "parses latest package versions from Hackage index tarball" $ do
+        parseHackageIndex testHackageIndex
+          @?= Right
+            [ PackageSpec "alpha" "1.2.0",
+              PackageSpec "beta" "0.1"
+            ],
       testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
       testCase "collects exposed modules from active conditional library branches" test_collectsConditionalExposedModules,
       testCase "extracts active build tool dependency names" test_extractsBuildToolDependencyNames,
@@ -50,6 +61,25 @@ actual @?= expected =
   if actual == expected
     then pure ()
     else assertFailure ("expected: " <> show expected <> "\n but got: " <> show actual)
+
+testHackageIndex :: LBS.ByteString
+testHackageIndex =
+  GZip.compress $
+    Tar.write
+      [ cabalEntry "alpha/1.0.0/alpha.cabal",
+        cabalEntry "alpha/1.2.0/alpha.cabal",
+        cabalEntry "alpha/1.1.0/alpha.cabal",
+        cabalEntry "beta/0.1/beta.cabal",
+        cabalEntry "beta/0.2/not-beta.cabal",
+        cabalEntry "preferred-versions"
+      ]
+  where
+    cabalEntry path =
+      case Tar.toTarPath False path of
+        Left err -> error ("invalid test tar path: " <> show err)
+        Right tarPath ->
+          let contents = LBS.fromStrict (BSC.pack "name: ignored\n")
+           in Tar.simpleEntry tarPath (Tar.NormalFile contents (LBS.length contents))
 
 test_generatesPathsModule :: Assertion
 test_generatesPathsModule =


### PR DESCRIPTION
## Summary

- Add `aihc-dev parser-hackage-progress` to run the parser progress workflow over latest package versions from the Hackage index.
- Cache `01-index.tar.gz` under the existing AIHC Hackage cache and refresh it only when `--update-index` is passed.
- Share the existing Stackage package runner so parser/HSE/GHC comparison options, prompt generation, failed tables, and GHC error capture behave consistently.
- Add Hackage index parsing coverage for selecting the latest version per package.

## Progress Counts

- No README progress counts were regenerated in this PR.
- New command reports counts dynamically from the cached Hackage index; no Hackage baseline count is committed.

## CodeRabbit

- Fixed valid finding: `--ghc-errors-limit` on `parser-hackage-progress` now rejects non-positive values.
- Skipped false finding: `StackageProgress.CLI.Options` has no `optUpdateIndex`; Hackage index refresh is handled before converting to shared runner options.
- Skipped unrelated finding: existing README Parser Stackage count was pre-existing and not changed by this PR.

## Validation

- `cabal test -v0 aihc-hackage:spec --test-options=--hide-successes`
- `cabal build -v0 exe:aihc-dev`
- `cabal run -v0 exe:aihc-dev -- parser-hackage-progress --help`
- `cabal run -v0 exe:aihc-dev -- parser-hackage-progress --offline --update-index` (fails fast as expected)
- `cabal test -v0 aihc-dev:spec --test-options=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`
