### PR TITLE
fix(parser): preserve top-level splice continuations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -169,8 +169,10 @@ prettyImportLevel level =
 -- | Pretty-print a top-level declaration splice.
 -- The expression is printed as-is; explicit TH splices appear as @$expr@ or
 -- @$(expr)@ through the normal 'ETHSplice' pretty-printer.
+-- Nested continuation lines keep infix operators from starting in top-level
+-- layout column one, where GHC can read them as a new declaration.
 prettyDeclSpliceExpr :: Expr -> Doc ann
-prettyDeclSpliceExpr = prettyExpr
+prettyDeclSpliceExpr = nest 2 . prettyExpr
 
 prettyQuotedText :: Text -> Doc ann
 prettyQuotedText txt = "\"" <> pretty txt <> "\""

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/top-level-infix-splices.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/top-level-infix-splices.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+
+$(fmap concat $ mapM deriveOnce [1..7])
+concat <$> uncurry mkMap `mapM` [ (i, n) | n <- [2 .. 10], i <- [0 .. n - 1] ]


### PR DESCRIPTION
## Summary

- Fix top-level declaration splice pretty-printing so multiline infix continuations are nested instead of starting in layout column one.
- Add a TemplateHaskell oracle regression covering the explicit splice and implicit top-level splice from the report.

## Root Cause

Top-level declaration splices reused the ordinary expression renderer at column one. When an infix expression broke across lines, the operator could be printed at the top-level layout column, and GHC could parse it as a new declaration or reject the roundtripped module.

## Validation

- `printf ... | cabal run -v0 exe:aihc-dev -- snippet`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern top-level-infix-splices"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`

## Progress Counts

- Parser oracle fixtures: +1 TemplateHaskell pass case.

## CodeRabbit

- Skipped one finding suggesting wrapping the implicit top-level splice in `$()`: GHC accepts the bare expression as an implicit declaration splice under `TemplateHaskell`, and the new oracle/snippet checks cover that behavior.
