### PR TITLE
fix(parser): indent pattern synonym pretty output

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -306,13 +306,14 @@ prettyMultiplicityTag (ExplicitMultiplicityTag ty) = "%" <> prettyType ty <+> me
 -- | Pretty-print a pattern synonym declaration.
 prettyPatSynDecl :: PatSynDecl -> Doc ann
 prettyPatSynDecl ps =
-  hsep
-    ( ["pattern"]
-        <> prettyPatSynLhs (patSynDeclName ps) (patSynDeclArgs ps)
-        <> [dirArrow (patSynDeclDir ps)]
-        <> [prettyPattern (patSynDeclPat ps)]
-        <> prettyPatSynWhere (patSynDeclName ps) (patSynDeclDir ps)
-    )
+  hang 2 $
+    hsep
+      ( ["pattern"]
+          <> prettyPatSynLhs (patSynDeclName ps) (patSynDeclArgs ps)
+          <> [dirArrow (patSynDeclDir ps)]
+          <> [prettyPattern (patSynDeclPat ps)]
+          <> prettyPatSynWhere (patSynDeclName ps) (patSynDeclDir ps)
+      )
   where
     dirArrow PatSynBidirectional = "="
     dirArrow PatSynUnidirectional = "<-"

--- a/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-explicit-where-view-pattern-layout.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/PatternSynonyms/pattern-synonyms-explicit-where-view-pattern-layout.hs
@@ -1,0 +1,9 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module PatternSynonymsExplicitWhereViewPatternLayout where
+
+pattern P r <- (T ((2 / pi *) -> r))
+  where
+    P r = T $ r * pi / 2


### PR DESCRIPTION
## Summary
- Indent pretty-printed pattern synonym declarations with a hanging layout so wrapped RHS/view-pattern lines remain nested under the declaration.
- Add an oracle regression fixture for the manifolds-core explicit pattern synonym layout failure.

## Root cause
Pattern synonym declarations were rendered as a flat `hsep`. If the RHS pattern contained hardline breaks, continuation lines could begin at column 1; GHC then parsed an operator such as `/` as an invalid top-level token.

## Progress counts
- Parser progress: +1 passing oracle fixture; local `parser-progress` reports `PASS 1184`, `TOTAL 1184`, `COMPLETE 100.0%`.

## Validation
- Reduced snippet via `aihc-dev snippet`
- Original `manifolds-core-0.6.1.1/Math/Manifold/Core/Types.hs` repro via `aihc-dev snippet -XTemplateHaskell`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern pattern-synonyms-explicit-where-view-pattern-layout --hide-successes"`
- `just fmt`
- `just check`
- `cabal run -v0 exe:parser-progress` from `components/aihc-parser`
- `coderabbit review --prompt-only` (no findings)