### PR TITLE
fix(parser): indent TH splice bodies

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -64,6 +64,9 @@ prettyRawText raw
   | T.isInfixOf "\n" raw = nesting $ \level -> nest (negate level) (pretty raw)
   | otherwise = pretty raw
 
+prettySpliceBody :: Expr -> Doc ann
+prettySpliceBody = nest 2 . prettyExpr
+
 -- | Pretty instance for Module - renders to valid Haskell source code.
 instance Pretty Module where
   pretty = prettyModuleDoc . addModuleParens
@@ -482,7 +485,7 @@ prettyType ty =
       case constraints of
         [] -> prettyType inner
         cs -> prettyContext cs <+> "=>" <+> prettyType inner
-    TSplice body -> "$" <> prettyExpr body
+    TSplice body -> "$" <> prettySpliceBody body
     TWildcard -> "_"
 
 prettyArrowKind :: ArrowKind -> Doc ann
@@ -552,7 +555,7 @@ prettyPattern pat =
               )
           )
     PTypeSig inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
-    PSplice body -> "$" <> prettyExpr body
+    PSplice body -> "$" <> prettySpliceBody body
 
 -- | Pretty print a pattern field binding.
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann
@@ -1150,8 +1153,8 @@ prettyExpr expr =
     ETHPatQuote pat -> "[p|" <+> prettyPattern pat <+> "|]"
     ETHNameQuote body -> "' " <> prettyExpr body
     ETHTypeNameQuote ty -> "'' " <> prettyType ty
-    ETHSplice body -> "$" <> prettyExpr body
-    ETHTypedSplice body -> "$$" <> prettyExpr body
+    ETHSplice body -> "$" <> prettySpliceBody body
+    ETHTypedSplice body -> "$$" <> prettySpliceBody body
     EIf cond yes no ->
       "if" <+> nest 2 (prettyExpr cond <+> "then" <+> prettyExpr yes <+> "else" <+> prettyExpr no)
     EMultiWayIf rhss ->

--- a/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_type_splice_decl_quote_infix_body.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/TemplateHaskell/th_type_splice_decl_quote_infix_body.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE TemplateHaskell #-}
+
+module TH_TypeSpliceDeclQuoteInfixBody where
+
+x = [d| instance Show $(return $ ConT name) where show _ = abbrev |]


### PR DESCRIPTION
## Summary
- Route type, pattern, expression, and typed expression TH splice rendering through a shared splice-body helper.
- When paren insertion has chosen `$(...)`, indent continuation lines inside the splice parentheses so infix operators in the body remain nested.
- Add a minimal oracle regression for a declaration quote containing `$(return $ ConT name)`.

## Root cause
`addSpliceBodyParens` correctly wrapped non-atomic splice bodies as `EParen`, but the pretty-printer rendered the parenthesized body without nesting its contents. For a body like `return $ ConT name`, the inner infix `$` could start at the surrounding layout column inside a declaration quote, and GHC rejected the roundtripped module.

## Progress counts
- Parser progress: +1 passing oracle fixture; local `parser-progress` reports `PASS 1185`, `TOTAL 1185`, `COMPLETE 100.0%`.

## Validation
- Reduced `aihc-dev snippet` case for `[d| instance Show $(return $ ConT name) ... |]`
- Original `units-2.4.1.5/Data/Metrology/TH.hs` repro via `aihc-dev snippet -XTemplateHaskell -XSafeHaskell -XCPP`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern th_type_splice_decl_quote_infix_body --hide-successes"`
- `just fmt`
- `just check`
- `cabal run -v0 exe:parser-progress` from `components/aihc-parser`

## CodeRabbit
- `coderabbit review --prompt-only` was attempted twice; the retry failed with `Rate limit exceeded`, so the review was skipped per repo guidance.