### PR TITLE
fix(parser): reject malformed promoted quotes

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -17,14 +17,13 @@ import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
 import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser, typeSigDeclParser)
 import Aihc.Parser.Internal.Pattern (apatParser, caseAltPatternParser, patParser, patternParser)
-import Aihc.Parser.Internal.Type (typeAtomParser, typeIdentifierParser, typeParenOperatorParser, typeParser, typeSignatureParser)
+import Aihc.Parser.Internal.Type (typeAtomParser, typeParser, typeSignatureParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
 import Control.Monad (guard)
 import Data.Functor (($>))
 import Data.Text (Text)
-import Data.Text qualified as T
 import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
 
@@ -1229,66 +1228,36 @@ thNameQuoteExprParser = thValueNameQuoteParser <|> thTypeNameQuoteParser
 thValueNameQuoteParser :: TokParser Expr
 thValueNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkTHQuoteTick
-  ETHNameQuote <$> thValueNameQuoteBodyParser
+  body <- atomExprParser
+  guard (isTHValueNameQuoteBody body)
+  pure (ETHNameQuote body)
 
-thValueNameQuoteBodyParser :: TokParser Expr
-thValueNameQuoteBodyParser =
-  MP.try thValueNameQuoteListConstructorParser
-    <|> MP.try thValueNameQuoteTupleConstructorParser
-    <|> MP.try parenOperatorExprParser
-    <|> varExprParser
-
-thValueNameQuoteListConstructorParser :: TokParser Expr
-thValueNameQuoteListConstructorParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  expectedTok TkSpecialLBracket
-  expectedTok TkSpecialRBracket
-  pure (EList [])
-
-thValueNameQuoteTupleConstructorParser :: TokParser Expr
-thValueNameQuoteTupleConstructorParser = withSpanAnn (EAnn . mkAnnotation) $ do
-  (tupleFlavor, closeTok) <- tupleDelimsParser
-  mClosed <- MP.optional (expectedTok closeTok)
-  case mClosed of
-    Just () -> pure (ETuple tupleFlavor [])
-    Nothing -> do
-      expectedTok TkSpecialComma
-      moreCommas <- MP.many (expectedTok TkSpecialComma)
-      expectedTok closeTok
-      pure (ETuple tupleFlavor (replicate (2 + length moreCommas) Nothing))
+isTHValueNameQuoteBody :: Expr -> Bool
+isTHValueNameQuoteBody expr =
+  case peelExprAnn expr of
+    EVar {} -> True
+    EList [] -> True
+    ETuple _ elems -> all isTupleConstructorSlot elems
+    _ -> False
+  where
+    isTupleConstructorSlot Nothing = True
+    isTupleConstructorSlot Just {} = False
 
 thTypeNameQuoteParser :: TokParser Expr
 thTypeNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkTHTypeQuoteTick
-  ETHTypeNameQuote <$> thTypeNameQuoteBodyParser
+  body <- typeAtomParser
+  guard (isTHTypeNameQuoteBody body)
+  pure (ETHTypeNameQuote body)
 
-thTypeNameQuoteBodyParser :: TokParser Type
-thTypeNameQuoteBodyParser =
-  MP.try thTypeNameQuoteListConstructorParser
-    <|> MP.try thTypeNameQuoteTupleConstructorParser
-    <|> MP.try typeParenOperatorParser
-    <|> typeIdentifierParser
-
-thTypeNameQuoteListConstructorParser :: TokParser Type
-thTypeNameQuoteListConstructorParser = withSpanAnn (TAnn . mkAnnotation) $ do
-  expectedTok TkSpecialLBracket
-  expectedTok TkSpecialRBracket
-  pure (TBuiltinCon TBuiltinList)
-
-thTypeNameQuoteTupleConstructorParser :: TokParser Type
-thTypeNameQuoteTupleConstructorParser = withSpanAnn (TAnn . mkAnnotation) $ do
-  (tupleFlavor, closeTok) <- tupleDelimsParser
-  mClosed <- MP.optional (expectedTok closeTok)
-  case mClosed of
-    Just () -> pure (TTuple tupleFlavor Unpromoted [])
-    Nothing -> do
-      expectedTok TkSpecialComma
-      moreCommas <- MP.many (expectedTok TkSpecialComma)
-      expectedTok closeTok
-      case tupleFlavor of
-        Boxed -> pure (TBuiltinCon (TBuiltinTuple (2 + length moreCommas)))
-        Unboxed -> do
-          let tupleConName = "(#" <> T.replicate (1 + length moreCommas) "," <> "#)"
-          pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId tupleConName)) Unpromoted)
+isTHTypeNameQuoteBody :: Type -> Bool
+isTHTypeNameQuoteBody ty =
+  case peelTypeAnn ty of
+    TVar {} -> True
+    TCon {} -> True
+    TBuiltinCon {} -> True
+    TTuple _ _ [] -> True
+    _ -> False
 
 quasiQuoteExprParser :: TokParser Expr
 quasiQuoteExprParser =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -17,13 +17,14 @@ import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
 import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser, typeSigDeclParser)
 import Aihc.Parser.Internal.Pattern (apatParser, caseAltPatternParser, patParser, patternParser)
-import Aihc.Parser.Internal.Type (typeAtomParser, typeParser, typeSignatureParser)
+import Aihc.Parser.Internal.Type (typeAtomParser, typeIdentifierParser, typeParenOperatorParser, typeParser, typeSignatureParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
 import Control.Monad (guard)
 import Data.Functor (($>))
 import Data.Text (Text)
+import Data.Text qualified as T
 import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
 
@@ -1228,7 +1229,32 @@ thNameQuoteExprParser = thValueNameQuoteParser <|> thTypeNameQuoteParser
 thValueNameQuoteParser :: TokParser Expr
 thValueNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkTHQuoteTick
-  ETHNameQuote <$> atomExprParser
+  ETHNameQuote <$> thValueNameQuoteBodyParser
+
+thValueNameQuoteBodyParser :: TokParser Expr
+thValueNameQuoteBodyParser =
+  MP.try thValueNameQuoteListConstructorParser
+    <|> MP.try thValueNameQuoteTupleConstructorParser
+    <|> MP.try parenOperatorExprParser
+    <|> varExprParser
+
+thValueNameQuoteListConstructorParser :: TokParser Expr
+thValueNameQuoteListConstructorParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  expectedTok TkSpecialLBracket
+  expectedTok TkSpecialRBracket
+  pure (EList [])
+
+thValueNameQuoteTupleConstructorParser :: TokParser Expr
+thValueNameQuoteTupleConstructorParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  (tupleFlavor, closeTok) <- tupleDelimsParser
+  mClosed <- MP.optional (expectedTok closeTok)
+  case mClosed of
+    Just () -> pure (ETuple tupleFlavor [])
+    Nothing -> do
+      expectedTok TkSpecialComma
+      moreCommas <- MP.many (expectedTok TkSpecialComma)
+      expectedTok closeTok
+      pure (ETuple tupleFlavor (replicate (2 + length moreCommas) Nothing))
 
 thTypeNameQuoteParser :: TokParser Expr
 thTypeNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
@@ -1236,14 +1262,33 @@ thTypeNameQuoteParser = withSpanAnn (EAnn . mkAnnotation) $ do
   ETHTypeNameQuote <$> thTypeNameQuoteBodyParser
 
 thTypeNameQuoteBodyParser :: TokParser Type
-thTypeNameQuoteBodyParser = do
-  ty <- typeAtomParser
-  case peelTypeAnn ty of
-    TWildcard {} -> MP.empty
-    TTypeLit {} -> MP.empty
-    TQuasiQuote {} -> MP.empty
-    TSplice {} -> MP.empty
-    _ -> pure ty
+thTypeNameQuoteBodyParser =
+  MP.try thTypeNameQuoteListConstructorParser
+    <|> MP.try thTypeNameQuoteTupleConstructorParser
+    <|> MP.try typeParenOperatorParser
+    <|> typeIdentifierParser
+
+thTypeNameQuoteListConstructorParser :: TokParser Type
+thTypeNameQuoteListConstructorParser = withSpanAnn (TAnn . mkAnnotation) $ do
+  expectedTok TkSpecialLBracket
+  expectedTok TkSpecialRBracket
+  pure (TBuiltinCon TBuiltinList)
+
+thTypeNameQuoteTupleConstructorParser :: TokParser Type
+thTypeNameQuoteTupleConstructorParser = withSpanAnn (TAnn . mkAnnotation) $ do
+  (tupleFlavor, closeTok) <- tupleDelimsParser
+  mClosed <- MP.optional (expectedTok closeTok)
+  case mClosed of
+    Just () -> pure (TTuple tupleFlavor Unpromoted [])
+    Nothing -> do
+      expectedTok TkSpecialComma
+      moreCommas <- MP.many (expectedTok TkSpecialComma)
+      expectedTok closeTok
+      case tupleFlavor of
+        Boxed -> pure (TBuiltinCon (TBuiltinTuple (2 + length moreCommas)))
+        Unboxed -> do
+          let tupleConName = "(#" <> T.replicate (1 + length moreCommas) "," <> "#)"
+          pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId tupleConName)) Unpromoted)
 
 quasiQuoteExprParser :: TokParser Expr
 quasiQuoteExprParser =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -11,6 +11,8 @@ module Aihc.Parser.Internal.Type
     buildTypeApp,
     buildInfixType,
     typeAtomParser,
+    typeParenOperatorParser,
+    typeIdentifierParser,
     contextItemsParser,
     thSpliceTypeParser,
     arrowKindParser,
@@ -19,13 +21,12 @@ where
 
 import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (exprParser)
-import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
+import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
 import Aihc.Parser.Syntax
 import Data.Char (isLower)
 import Data.Functor (($>))
-import Data.Text (Text)
 import Data.Text qualified as T
-import Text.Megaparsec (anySingle, (<|>))
+import Text.Megaparsec ((<|>))
 import Text.Megaparsec qualified as MP
 
 -- | Parse a Template Haskell type splice: $typ or $(typ)
@@ -309,7 +310,7 @@ promotedTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
   -- Accept both TkVarSym "'" and TkTHQuoteTick for promoted types
   -- This handles ambiguity between TH value quotes and promoted types
   expectedTok (TkVarSym "'") <|> expectedTok TkTHQuoteTick
-  MP.try promotedStructuredTypeParser <|> promotedRawTypeParser
+  promotedStructuredTypeParser
 
 promotedStructuredTypeParser :: TokParser Type
 promotedStructuredTypeParser = do
@@ -319,38 +320,6 @@ promotedStructuredTypeParser = do
       <|> MP.try typeParenOperatorParser
       <|> typeIdentifierParser
   maybe (fail "promoted type") pure (markTypePromoted ty)
-
-promotedRawTypeParser :: TokParser Type
-promotedRawTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
-  suffix <- promotedBracketedSuffixParser <|> promotedParenthesizedSuffixParser
-  pure (TCon (qualifyName Nothing (mkUnqualifiedName NameConId suffix)) Promoted)
-
-promotedBracketedSuffixParser :: TokParser Text
-promotedBracketedSuffixParser = collectDelimitedRaw TkSpecialLBracket TkSpecialRBracket
-
-promotedParenthesizedSuffixParser :: TokParser Text
-promotedParenthesizedSuffixParser = collectDelimitedRaw TkSpecialLParen TkSpecialRParen
-
-collectDelimitedRaw :: LexTokenKind -> LexTokenKind -> TokParser Text
-collectDelimitedRaw openKind closeKind = do
-  openTxt <- tokenSatisfy ("opening delimiter " <> show openKind) $ \tok ->
-    if lexTokenKind tok == openKind then Just (lexTokenText tok) else Nothing
-  go 1 openTxt
-  where
-    go :: Int -> Text -> TokParser Text
-    go depth acc = do
-      tok <- anySingle
-      let kind = lexTokenKind tok
-          txt = lexTokenText tok
-          acc' = acc <> txt
-      case () of
-        _
-          | kind == openKind -> go (depth + 1) acc'
-          | kind == closeKind ->
-              if depth == 1
-                then pure acc'
-                else go (depth - 1) acc'
-          | otherwise -> go depth acc'
 
 typeParenOperatorParser :: TokParser Type
 typeParenOperatorParser = withSpanAnn (TAnn . mkAnnotation) $ do
@@ -468,7 +437,20 @@ markTypePromoted ty =
       | Just inner <- markTypePromoted sub ->
           Just (TAnn ann inner)
     TCon name _ -> Just (TCon name Promoted)
+    TBuiltinCon con -> Just (promoteBuiltinCon con)
     TList _ elems -> Just (TList Promoted elems)
     TTuple tupleFlavor _ elems -> Just (TTuple tupleFlavor Promoted elems)
     TTypeApp fn arg -> TTypeApp <$> markTypePromoted fn <*> pure arg
     _ -> Nothing
+
+promoteBuiltinCon :: TypeBuiltinCon -> Type
+promoteBuiltinCon con =
+  TCon
+    ( qualifyName Nothing $
+        case con of
+          TBuiltinTuple arity -> mkUnqualifiedName NameConId ("(" <> T.replicate (max 0 (arity - 1)) "," <> ")")
+          TBuiltinArrow -> mkUnqualifiedName NameVarSym "->"
+          TBuiltinList -> mkUnqualifiedName NameConId "[]"
+          TBuiltinCons -> mkUnqualifiedName NameConSym ":"
+    )
+    Promoted

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -11,8 +11,6 @@ module Aihc.Parser.Internal.Type
     buildTypeApp,
     buildInfixType,
     typeAtomParser,
-    typeParenOperatorParser,
-    typeIdentifierParser,
     contextItemsParser,
     thSpliceTypeParser,
     arrowKindParser,
@@ -310,15 +308,7 @@ promotedTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
   -- Accept both TkVarSym "'" and TkTHQuoteTick for promoted types
   -- This handles ambiguity between TH value quotes and promoted types
   expectedTok (TkVarSym "'") <|> expectedTok TkTHQuoteTick
-  promotedStructuredTypeParser
-
-promotedStructuredTypeParser :: TokParser Type
-promotedStructuredTypeParser = do
-  ty <-
-    MP.try typeListParser
-      <|> MP.try typeParenOrTupleParser
-      <|> MP.try typeParenOperatorParser
-      <|> typeIdentifierParser
+  ty <- typeAtomParser
   maybe (fail "promoted type") pure (markTypePromoted ty)
 
 typeParenOperatorParser :: TokParser Type

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1363,7 +1363,7 @@ test_parenthesesInsertion = do
           }
   assertParsedStrippedExprShapeRoundTrip config "- (- 10)"
   assertParsedStrippedExprShapeRoundTrip config "a + (b + c)"
-  assertParsedStrippedExprShapeRoundTrip config "(' (p#)).a"
+  assertParsedStrippedExprShapeRoundTrip config "(' (+)).a"
   assertParsedStrippedExprShapeRoundTrip config "(A.+).a"
   assertParsedStrippedExprShapeRoundTrip config "[t| (_ :: _) |]"
   assertParsedStrippedExprShapeRoundTrip config "[p| _ |] (proc _ -> () -<< a)"

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/promoted-parenthesized-qualified-name.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/promoted-parenthesized-qualified-name.yaml
@@ -1,0 +1,5 @@
+extensions: [DataKinds]
+input: |
+  type T = '(M.A)
+status: fail
+reason: GHC rejects parenthesized promoted constructor names

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/th-name-quote-tuple-expression.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/th-name-quote-tuple-expression.yaml
@@ -1,0 +1,5 @@
+extensions: [TemplateHaskell]
+input: |
+  x = '(A,B)
+status: fail
+reason: GHC rejects tuple expressions as Template Haskell name quote bodies


### PR DESCRIPTION
## Summary

- restrict Template Haskell name and type-name quotes to quoteable names and built-in constructors instead of arbitrary atoms
- remove the raw promoted-type delimiter collector and promote only structured parsed type forms
- add fail regressions for `x = '(A,B)` and parenthesized promoted qualified names

## Root Cause

The parser used broad atom/type parsers after quote tokens. That let TH name quotes accept tuple expressions and let promoted types fall back to a raw token collector that could manufacture constructor names like `(M.A)`.

## Progress Counts

- Parser golden fixtures: +2 fail regressions
- README progress tables: not updated, per repo workflow

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern golden --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern TemplateHaskell --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern DataKinds --hide-successes"`
- `printf '%s\n' "x = '(A,B)" | cabal run -v0 exe:aihc-dev -- snippet -XTemplateHaskell`
- `printf '%s\n' "type T = '(M.A)" | cabal run -v0 exe:aihc-dev -- snippet -XDataKinds`
- `cabal test -v0 aihc-parser:spec --test-options=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
