### PR TITLE
fix(parser): accept unicode identifier continuations

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -1012,7 +1012,7 @@ isVarIdentifierStartChar :: Char -> Bool
 isVarIdentifierStartChar c = c == '_' || isAsciiLower c || isUniSmall c
 
 isIdentTail :: Char -> Bool
-isIdentTail c = isIdentStart c || isIdentNumber c || c == '\''
+isIdentTail c = isIdentStart c || isIdentContinue c || c == '\''
 
 isConIdStart :: Char -> Bool
 isConIdStart c = isAsciiUpper c || isUniLarge c
@@ -1031,6 +1031,14 @@ isIdentNumber c =
   isDigit c
     || generalCategory c == DecimalNumber
     || generalCategory c == OtherNumber
+
+isIdentContinue :: Char -> Bool
+isIdentContinue c =
+  case generalCategory c of
+    LetterNumber -> True
+    ModifierLetter -> True
+    NonSpacingMark -> True
+    _ -> isIdentNumber c
 
 startsWithSymOp :: Text -> Bool
 startsWithSymOp t =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -763,7 +763,7 @@ inferNameType localName
         _ -> NameConId
 
 isIdentChar :: Char -> Bool
-isIdentChar c = isIdentifierStartChar c || isIdentifierNumberChar c || c == '\''
+isIdentChar c = isIdentifierStartChar c || isIdentifierContinueChar c || c == '\''
 
 isIdentifierStartChar :: Char -> Bool
 isIdentifierStartChar c = c == '_' || generalCategory c == LowercaseLetter || isConIdentifierStartChar c
@@ -777,6 +777,14 @@ isIdentifierNumberChar c =
     DecimalNumber -> True
     OtherNumber -> True
     _ -> False
+
+isIdentifierContinueChar :: Char -> Bool
+isIdentifierContinueChar c =
+  case generalCategory c of
+    LetterNumber -> True
+    ModifierLetter -> True
+    NonSpacingMark -> True
+    _ -> isIdentifierNumberChar c
 
 isOperatorLikeText :: Text -> Bool
 isOperatorLikeText op =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -219,6 +219,7 @@ buildTests = do
             testCase "shrunk let expressions do not cycle through simple lets" test_shrunkLetExpressionsDoNotCycleThroughSimpleLets,
             testCase "shrunk wildcard let expressions do not cycle through simple lets" test_shrunkWildcardLetExpressionsDoNotCycleThroughSimpleLets,
             testCase "generated identifiers accept unicode variable characters" test_generatedIdentifiersAcceptUnicodeVariableCharacters,
+            testCase "lexes unicode identifier continuation characters" test_unicodeIdentifierContinuationCharactersLex,
             testCase "generated identifiers accept MagicHash suffixes" test_generatedIdentifiersAcceptMagicHashSuffixes,
             testCase "generated constructor identifiers accept unicode uppercase and number tails" test_generatedConstructorIdentifiersAcceptUnicodeCharacters,
             testCase "data CTYPE pragmas round-trip" test_dataDeclCTypePragmaRoundTrips,
@@ -759,6 +760,21 @@ test_generatedIdentifiersAcceptUnicodeVariableCharacters = do
     isValidGeneratedIdent "a\x03b1\x00b2"
   assertBool "unicode lowercase letters should be accepted at the start of generated identifiers" $
     isValidGeneratedIdent "\x03bbx"
+
+test_unicodeIdentifierContinuationCharactersLex :: Assertion
+test_unicodeIdentifierContinuationCharactersLex =
+  mapM_
+    assertVarId
+    [ "\x03b1\x209b", -- modifier letter: alpha + subscript s
+      "a\x0301", -- non-spacing mark: a + combining acute
+      "a\x2160" -- letter number: a + roman numeral one
+    ]
+  where
+    assertVarId ident =
+      case lexTokens ident of
+        [LexToken {lexTokenKind = TkVarId actual}, LexToken {lexTokenKind = TkEOF}]
+          | actual == ident -> pure ()
+        other -> assertFailure ("expected variable identifier " <> T.unpack ident <> ", got: " <> show other)
 
 test_generatedIdentifiersAcceptMagicHashSuffixes :: Assertion
 test_generatedIdentifiersAcceptMagicHashSuffixes = do

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-identifier-continuation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-identifier-continuation.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeOperators #-}
+
+module UnicodeIdentifierContinuation where
+
+data ((s :: αₛ -> αₛ -> *) :×: (t :: αₜ -> αₜ -> *)) :: (αₛ, αₜ) -> (αₛ, αₜ) -> * where
+  (:×:) :: s aₛ bₛ -> t aₜ bₜ -> (s :×: t) '(aₛ, aₜ) '(bₛ, bₜ)

--- a/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Identifiers.hs
@@ -78,8 +78,11 @@ varIdentStartChars = filter isValidGeneratedIdentStartChar allChars
 conIdentStartChars :: [Char]
 conIdentStartChars = filter isValidConIdentStartChar allChars
 
-identTailChars :: [Char]
-identTailChars = filter isValidIdentTailChar allChars
+varIdentTailChars :: [Char]
+varIdentTailChars = filter isValidGeneratedIdentTailChar allChars
+
+conIdentTailChars :: [Char]
+conIdentTailChars = filter isValidConIdentTailChar allChars
 
 symbolChars :: [Char]
 symbolChars = filter isValidSymbolChar allChars
@@ -131,7 +134,7 @@ genVarId :: Gen Text
 genVarId = do
   first <- elements varIdentStartChars
   restLen <- chooseInt (0, 8)
-  rest <- vectorOf restLen (elements identTailChars)
+  rest <- vectorOf restLen (elements varIdentTailChars)
   hashCount <- chooseInt (0, 4)
   let candidate = T.pack (first : rest) <> T.replicate hashCount "#"
   if isValidGeneratedIdent candidate
@@ -142,7 +145,7 @@ genVarIdNoHash :: Gen Text
 genVarIdNoHash = do
   first <- elements varIdentStartChars
   restLen <- chooseInt (0, 8)
-  rest <- vectorOf restLen (elements identTailChars)
+  rest <- vectorOf restLen (elements varIdentTailChars)
   let candidate = T.pack (first : rest)
   if isValidGeneratedIdent candidate
     then pure candidate
@@ -172,7 +175,7 @@ isValidGeneratedIdent ident =
         Just (first, rest) ->
           baseIdent /= "_"
             && isValidGeneratedIdentStartChar first
-            && T.all isValidIdentTailChar rest
+            && T.all isValidGeneratedIdentTailChar rest
             && not (isReservedIdentifier allExtensions ident)
         Nothing -> False
     Nothing -> False
@@ -193,7 +196,7 @@ genConId :: Gen Text
 genConId = do
   first <- elements conIdentStartChars
   restLen <- chooseInt (0, 5)
-  rest <- vectorOf restLen (elements identTailChars)
+  rest <- vectorOf restLen (elements conIdentTailChars)
   hashCount <- chooseInt (0, 4)
   pure (T.pack (first : rest) <> T.replicate hashCount "#")
 
@@ -225,7 +228,7 @@ isValidConIdent ident =
       case T.uncons baseIdent of
         Just (first, rest) ->
           isValidConIdentStartChar first
-            && T.all isValidIdentTailChar rest
+            && T.all isValidConIdentTailChar rest
         Nothing -> False
     Nothing -> False
 
@@ -403,8 +406,26 @@ isValidIdentNumberChar c =
     OtherNumber -> True
     _ -> False
 
-isValidIdentTailChar :: Char -> Bool
-isValidIdentTailChar c = c == '\'' || isValidGeneratedIdentStartChar c || isValidConIdentStartChar c || isValidIdentNumberChar c
+isValidGeneratedIdentTailChar :: Char -> Bool
+isValidGeneratedIdentTailChar c = c == '\'' || isValidGeneratedIdentStartChar c || isValidConIdentStartChar c || isValidIdentContinueChar c
+
+isValidConIdentTailChar :: Char -> Bool
+isValidConIdentTailChar c = c == '\'' || isValidGeneratedIdentStartChar c || isValidConIdentStartChar c || isValidConIdentContinueChar c
+
+isValidIdentContinueChar :: Char -> Bool
+isValidIdentContinueChar c =
+  case generalCategory c of
+    LetterNumber -> True
+    ModifierLetter -> True
+    _ -> isValidIdentNumberChar c
+
+isValidConIdentContinueChar :: Char -> Bool
+isValidConIdentContinueChar c =
+  case generalCategory c of
+    DecimalNumber -> True
+    ModifierLetter -> True
+    NonSpacingMark -> True
+    _ -> False
 
 isValidSymbolChar :: Char -> Bool
 isValidSymbolChar c = c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String) || isValidUnicodeSymbolChar c && c /= '`'


### PR DESCRIPTION
## Summary

- Accept GHC-recognized Unicode identifier continuation categories needed for names like `αₛ`.
- Keep Syntax identifier splitting in step with the lexer continuation rules.
- Add lexer coverage and an oracle fixture based on the `product` package data declaration.
- Split variable and constructor identifier generator tail sets so fuzzed names stay inside GHC-safe contexts.

## Progress Counts

- `product-0.1.0.0` hackage-tester parse errors: 1 -> 0.
- `product-0.1.0.0` hackage-tester success rate: failing -> 100% (2 files, 0 GHC errors, 0 parse errors, 0 roundtrip failures).

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern=continuation --hide-successes"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester product`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only`

## CodeRabbit

- Skipped suggestion to add `SpacingCombiningMark` and `ConnectorPunctuation`: direct GHC checks reject both as identifier continuation characters for this target.
