### PR TITLE
docs: add AIHC test authoring skill

### DIFF
--- a/.agents/skills/aihc-test-authoring/SKILL.md
+++ b/.agents/skills/aihc-test-authoring/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: aihc-test-authoring
+description: Choose, author, and validate tests for the AIHC repository. Use when Codex needs to add or update tests in components/aihc-cpp, components/aihc-parser, components/aihc-resolve, components/aihc-tc, components/aihc-fc, or related compatibility/property suites, including unit tests, golden YAML fixtures, oracle fixtures, lexer fixtures, error-message fixtures, eval fixtures, and QuickCheck properties.
+---
+
+# AIHC Test Authoring
+
+Use this skill to decide which AIHC test framework matches a change, then load the relevant reference file before editing tests.
+
+## Workflow
+
+1. Identify the component touched by the change.
+2. Choose the narrowest test that proves the behavior.
+3. Read the matching component reference before creating or changing fixtures.
+4. Add a minimal regression case plus nearby corner cases when the behavior has boundaries.
+5. Run the narrow component test first, then the repository check required by `AGENTS.md` before commit.
+
+## Which Test To Use
+
+- Use a unit test when the behavior depends on a specific internal API, failure mode, edge case, or invariant that an oracle cannot express reliably.
+- Use a golden fixture when the important contract is the component's rendered output: parsed AST shorthand, resolver annotations, inferred types, System FC output, lexer token kinds, or diagnostics.
+- Use an oracle fixture when there is an external source of truth. Parser oracle tests compare with GHC and round-trip/fingerprint validation; CPP progress tests compare with `cpphs`.
+- Use an equivalent parser fixture when several source spellings should normalize to the same parsed tree after annotation stripping and paren normalization.
+- Use a QuickCheck property when the requirement is broad, algebraic, or generative: round trips, idempotency, no exceptions, shrinking, coverage, or compatibility over generated syntax.
+- Use an `xfail` fixture only to record a known gap while preventing silent regressions. Always include a concrete reason, and expect unexpected passes to fail CI until the fixture is promoted. Use `xpass` only in fixture formats that explicitly support it.
+
+Prefer a single focused fixture over a large scenario unless the behavior only appears through cross-module interaction.
+
+## Component References
+
+- `aihc-cpp`: read `references/aihc-cpp.md` for `cpphs` progress fixtures and preprocessor unit tests.
+- `aihc-parser`: read `references/aihc-parser.md` for parser golden, equivalent, lexer golden, error-message, oracle, unit, performance, and property tests.
+- `aihc-resolve`: read `references/aihc-resolve.md` for resolver golden fixtures and unit tests.
+- `aihc-tc`: read `references/aihc-tc.md` for type-checker golden fixtures, unit tests, and properties.
+- `aihc-fc`: read `references/aihc-fc.md` for FC golden fixtures, eval fixtures, and unit tests.
+- Shared commands and status semantics: read `references/validation.md`.
+
+## Ground Rules
+
+- Keep fixture names descriptive and scoped to the behavior, not the implementation detail that happens to expose it.
+- Put parser oracle fixtures under the feature directory that describes the language construct, not under a bug bucket, unless the existing suite has a more precise local convention.
+- Preserve the repository status model: `PASS`, `XFAIL`, `FAIL`, `XPASS`. Any `FAIL` or unexpected `XPASS` blocks merge.
+- Do not update repository READMEs for progress counts. PR descriptions may mention count changes, but README progress is cron-managed.
+- Never run `cabal test` in parallel in this repository.

--- a/.agents/skills/aihc-test-authoring/agents/openai.yaml
+++ b/.agents/skills/aihc-test-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AIHC Test Authoring"
+  short_description: "Choose and author AIHC repository tests"
+  default_prompt: "Use $aihc-test-authoring to add the right tests for this AIHC change."

--- a/.agents/skills/aihc-test-authoring/references/aihc-cpp.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-cpp.md
@@ -1,0 +1,45 @@
+# aihc-cpp Tests
+
+Use `aihc-cpp` tests for preprocessor behavior in `components/aihc-cpp`.
+
+## Choose The Test
+
+- Use progress fixtures for behavior that should match `cpphs` output.
+- Use unit tests in `components/aihc-cpp/test/Spec.hs` when `cpphs` is not the right authority, when `cpphs` is imperfect, or when the behavior is an internal API/invariant such as include continuations, configured predefined macros, or diagnostics.
+- Use `xfail` progress rows for known `cpphs` mismatches that should remain visible.
+
+## Progress Fixtures
+
+Files live in `components/aihc-cpp/test/Test/Fixtures/progress`.
+
+Create a `.hs` source file, then add a tab-separated row to `manifest.tsv`:
+
+```text
+id<TAB>category<TAB>path<TAB>expected<TAB>reason
+```
+
+Columns:
+
+- `id`: unique test id, usually filename without `.hs`.
+- `category`: grouping such as `macro`, `conditionals`, `diagnostics`, `include`, `lexing`, or `pkg`.
+- `path`: fixture path relative to `test/Test/Fixtures/progress`.
+- `expected`: `pass` or `xfail`.
+- `reason`: required for `xfail`; optional for `pass`.
+
+The runner preprocesses the fixture with AIHC and with `cpphs`, normalizes `#line` locations into located records, and compares the results.
+
+Includes are resolved relative to the current source/include directory. Put include files under `test/Test/Fixtures/progress/includes` or next to the fixture if that matches the scenario.
+
+## Unit Tests
+
+Add focused `tasty-hunit` tests in `components/aihc-cpp/test/Spec.hs` when the assertion needs exact `Result`, `Step`, diagnostics, include continuation behavior, macro configuration, or output independent from `cpphs`.
+
+Keep unit tests short: build an input `ByteString`, run `preprocess defaultConfig{...}`, drive `NeedInclude` when needed, and assert on `resultOutput` or diagnostics.
+
+## Validation
+
+Run:
+
+```bash
+cabal test -v0 aihc-cpp:spec --test-options="--hide-successes"
+```

--- a/.agents/skills/aihc-test-authoring/references/aihc-fc.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-fc.md
@@ -1,0 +1,62 @@
+# aihc-fc Tests
+
+Use `aihc-fc` tests for System FC desugaring, pretty-printed FC output, evaluator behavior, and focused FC unit tests.
+
+## Choose The Test
+
+- Use FC golden fixtures when parsed source should desugar to precise pretty-printed FC.
+- Use FC eval fixtures when the behavior is runtime evaluation of an expression or module binding.
+- Use unit tests in `components/aihc-fc/test/Test/Fc/Suite.hs` when the assertion is small and direct, such as evaluator primitives or helper functions.
+
+## Golden Fixtures
+
+Root: `components/aihc-fc/test/Test/Fixtures/golden`.
+
+Fixture shape:
+
+```yaml
+extensions: []
+modules:
+  - |
+    module Test where
+    id x = x
+expected: |
+  <rendered FC program>
+status: pass
+reason: ""
+```
+
+Required keys: `extensions`, `modules`, `status`. `expected` may be a string or list of strings. The runner parses each module, desugars it, renders the FC program, trims both sides, and compares.
+
+Statuses: `pass`, `fail`, `xfail`, `xpass`. Use `fail` when desugaring should fail. Use `xfail` only for a known gap and include `reason`.
+
+Copy expected FC from the renderer when possible. The pretty-printer may use symbols or formatting that are hard to reproduce by hand; exact output is the contract.
+
+## Eval Fixtures
+
+Root: `components/aihc-fc/test/Test/Fixtures/eval`.
+
+Fixture shape:
+
+```yaml
+extensions: []
+modules:
+  - |
+    module Test where
+output: |
+  : 'x' []
+expression: |
+  ['x']
+status: pass
+reason: renders evaluated list literals in raw constructor form
+```
+
+Required keys: `extensions`, `modules`, `expression`, `output`, `status`. The fixture must define at least one module. The runner parses modules and expression, synthesizes an `__aihc_eval__` binding, desugars with synthetic type-checker output, evaluates that binding, and compares rendered raw value.
+
+## Validation
+
+Run:
+
+```bash
+cabal test -v0 aihc-fc:spec --test-options="--hide-successes"
+```

--- a/.agents/skills/aihc-test-authoring/references/aihc-parser.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-parser.md
@@ -1,0 +1,133 @@
+# aihc-parser Tests
+
+Use `aihc-parser` tests for lexing, parsing, pretty-printing, error messages, GHC oracle compliance, compatibility, performance, and generative properties.
+
+## Choose The Test
+
+- Use parser golden fixtures when one source fragment should produce a precise shorthand AST or a precise parse failure.
+- Use equivalent fixtures when multiple spellings should parse to the same normalized tree.
+- Use lexer golden fixtures when tokenization, layout, pragma tokens, source directives, or extension-sensitive lexing is the contract.
+- Use error-message fixtures when both GHC rejection and AIHC diagnostic rendering matter.
+- Use oracle fixtures when GHC is the authority for accepting a full module and AIHC must also pass round-trip/fingerprint validation.
+- Use unit tests in `components/aihc-parser/test/Spec.hs` for small internal behaviors, pretty-printer expectations, regression checks around shrunk examples, and assertions that need custom setup.
+- Use QuickCheck properties under `components/aihc-parser/test/Test/Properties` for generators, round trips, paren insertion, no-exception guarantees, coverage, and idempotency.
+- Use parser-compat tests under `components/aihc-parser-compat/test` when AIHC syntax conversion to normalized GHC AST is the contract.
+
+## Parser Golden Fixtures
+
+Root: `components/aihc-parser/test/Test/Fixtures/golden`.
+
+Subdirectories select parser entry point:
+
+- `expr`: `parseExpr`
+- `module`: `parseModule`
+- `pattern`: `parsePattern`
+
+Fixture shape:
+
+```yaml
+extensions: []
+input: |
+  42
+ast: |-
+  EInt 42 TInteger
+status: pass
+reason: ""
+```
+
+Required keys: `extensions`, `input`, `status`. Supported statuses are `pass`, `fail`, and `xfail`; `xpass` is rejected. `pass` requires `ast`; `xfail` requires `reason`. `fail` means the parser should reject the input. The expected `ast` is `show (shorthand ast)`, so prefer generating it from the current parser rather than hand-formatting large trees.
+
+## Equivalent Fixtures
+
+Root: `components/aihc-parser/test/Test/Fixtures/equivalent`.
+
+Subdirectories select parser entry point: `expr`, `module`, `decl`, `pattern`.
+
+Fixture shape:
+
+```yaml
+extensions: []
+equivalent:
+  - a + b + c
+  - (a + b) + c
+status: pass
+reason: parser matches GHC's left-associated parsed infix tree
+```
+
+Use at least two inputs. Supported statuses are `pass`, `fail`, and `xfail`; `xpass` is rejected. The runner parses every input, strips annotations, normalizes parens, and compares the trees.
+
+## Lexer Golden Fixtures
+
+Root: `components/aihc-parser/test/Test/Fixtures/lexer`.
+
+Fixture shape:
+
+```yaml
+extensions: []
+input: |
+  x --> y
+tokens:
+  - 'TkVarId "x"'
+  - 'TkVarSym "-->"'
+  - 'TkVarId "y"'
+  - 'TkEOF'
+status: pass
+```
+
+Required keys: `extensions`, `input`, `tokens`, `status`. Supported statuses are `pass`, `xfail`, and `xpass`; `xfail` and `xpass` require `reason`. Fixtures whose relative path is under `module/` use `lexModuleTokensWithExtensions`; other lexer fixtures use `lexTokensWithExtensions`.
+
+Token strings are read as `LexTokenKind` constructors. `TkPragma` fixtures omit `pragmaRawText`; the runner normalizes it away.
+
+## Error-Message Fixtures
+
+Root: `components/aihc-parser/test/Test/Fixtures/error-messages`.
+
+Fixture shape:
+
+```yaml
+src: |
+  x =
+ghc: |
+  test.hs:2:1: error: [GHC-58481]
+      parse error (possibly incorrect indentation or mismatched brackets)
+aihc: |
+  test.hs:1:3:
+  1 | x =
+    |   ^
+  unexpected end of input
+  expecting expression
+```
+
+Allowed keys are exactly `src`, `ghc`, and `aihc`. The runner first verifies that GHC rejects the source with the expected normalized message, then checks AIHC's formatted parser errors.
+
+## Oracle Fixtures
+
+Root: `components/aihc-parser/test/Test/Fixtures/oracle`.
+
+Each fixture is a `.hs` file whose first non-space text is an oracle block:
+
+```haskell
+{- ORACLE_TEST pass -}
+{-# LANGUAGE BlockArguments #-}
+module BasicDo where
+
+f = id do
+  pure ()
+```
+
+Use `{- ORACLE_TEST xfail <reason> -}` for known gaps. The runner derives extensions from the module header, optionally preprocesses CPP-enabled sources, asks GHC for an AST fingerprint, then validates AIHC parsing and round-trip/fingerprint equality. `pass` therefore means more than "AIHC accepted the file".
+
+## Unit And Property Tests
+
+Add unit tests to `components/aihc-parser/test/Spec.hs` when a fixture cannot express the assertion or a reduced QuickCheck counterexample should be pinned directly.
+
+Add properties under `components/aihc-parser/test/Test/Properties`. Reuse existing arbitrary modules under `Test/Properties/Arb` and preserve the existing group names in `Spec.hs`, especially `properties` and `no exceptions`, so `just replay` and pattern filters keep working.
+
+## Useful Commands
+
+```bash
+cabal test -v0 aihc-parser:spec --test-options="--pattern parser --hide-successes"
+cabal test -v0 aihc-parser:spec --test-options="--pattern lexer-golden --hide-successes"
+cabal test -v0 aihc-parser:spec --test-options="--pattern oracle --hide-successes"
+cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000"
+```

--- a/.agents/skills/aihc-test-authoring/references/aihc-resolve.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-resolve.md
@@ -1,0 +1,45 @@
+# aihc-resolve Tests
+
+Use `aihc-resolve` tests for name-resolution behavior, scopes, imports, builtins, annotations, and diagnostics rendered by the resolver.
+
+## Choose The Test
+
+- Use golden fixtures for resolver output and annotated source output.
+- Use unit tests in `components/aihc-resolve/test/Test/Resolver/Suite.hs` only for resolver test harness behavior or assertions that cannot be represented as a source fixture.
+
+## Golden Fixtures
+
+Root: `components/aihc-resolve/test/Test/Fixtures/golden`.
+
+Fixture shape:
+
+```yaml
+extensions: []
+modules:
+  - |
+    module Main where
+    x = 1
+expected:
+  Main:
+    - "2:1-2:2 x => (value) Main.x"
+annotated:
+  - |
+    module Main where
+    x = 1
+status: pass
+```
+
+Required keys: `extensions`, `modules`, `annotated`, `status`. `pass` and `xpass` require `expected` and non-empty `annotated`. `xfail` and `xpass` require `reason`.
+`reason` is optional for `pass`.
+
+`modules` is a list because resolver behavior often needs multiple modules. Use one declaration module plus one use module for import/export regressions. The parser source name for each module is the first line up to newline, so include a normal `module X where` header.
+
+`expected` may be a string, a list of strings, or an object keyed by module name. `annotated` is always a list of source renderings.
+
+## Validation
+
+Run:
+
+```bash
+cabal test -v0 aihc-resolve:spec --test-options="--pattern resolver-golden --hide-successes"
+```

--- a/.agents/skills/aihc-test-authoring/references/aihc-tc.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-tc.md
@@ -1,0 +1,45 @@
+# aihc-tc Tests
+
+Use `aihc-tc` tests for type inference, type-checker diagnostics, unification, zonking, constraints, and solver behavior.
+
+## Choose The Test
+
+- Use golden fixtures when the contract is the inferred binding types for one or more modules, or a known type-check failure.
+- Use unit tests when the behavior is an internal operation such as unification, constraint solving, environment handling, or diagnostic construction.
+- Use QuickCheck properties for algebraic type-checker invariants. Existing examples live in `components/aihc-tc/test/Test/Tc/Properties.hs`.
+
+## Golden Fixtures
+
+Root: `components/aihc-tc/test/Test/Fixtures/golden`.
+
+Fixture shape:
+
+```yaml
+extensions: []
+modules:
+  - |
+    module Test where
+    id x = x
+expected:
+  - "id :: forall a. a -> a"
+status: pass
+reason: ""
+```
+
+Required keys: `extensions`, `modules`, `status`. `expected` may be a string, list of strings, or object keyed by module name. The runner parses each module, runs `typecheckModule`, and compares rendered binding types.
+
+Statuses: `pass`, `fail`, `xfail`, `xpass`. Use `fail` when the expected behavior is rejection and rendered diagnostics are not the contract. Use `xfail` for known gaps; include a reason.
+
+## Unit And Property Tests
+
+Add tests under `components/aihc-tc/test/Test/Tc/Suite.hs` for focused examples. Add properties to `Test/Tc/Properties.hs` and keep them in the `properties` group.
+
+Prefer properties for invariants such as idempotency, reflexivity, or stability under zonking/substitution. Prefer golden fixtures for user-visible inference examples.
+
+## Validation
+
+Run:
+
+```bash
+cabal test -v0 aihc-tc:spec --test-options="--hide-successes"
+```

--- a/.agents/skills/aihc-test-authoring/references/validation.md
+++ b/.agents/skills/aihc-test-authoring/references/validation.md
@@ -1,0 +1,35 @@
+# Validation
+
+Use narrow commands while developing, then run the mandatory checks before committing.
+
+## Narrow Commands
+
+- All fast tests: `cabal test -v0 all --test-options=--hide-successes`
+- One test pattern: `cabal test -v0 <component>:spec --test-options="--pattern <pattern> --hide-successes"`
+- Parser golden/equivalent group: `cabal test -v0 aihc-parser:spec --test-options="--pattern parser --hide-successes"`
+- Parser oracle group: `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle --hide-successes"`
+- Parser lexer golden group: `cabal test -v0 aihc-parser:spec --test-options="--pattern lexer-golden --hide-successes"`
+- Parser properties: `cabal test -v0 aihc-parser:spec --test-options="--pattern properties --quickcheck-tests 1000 --hide-successes"`
+- Deep parser fuzzing: `cabal test -v0 aihc-parser:spec --test-options="--pattern properties --quickcheck-tests 10000"`
+- Resolve golden: `cabal test -v0 aihc-resolve:spec --test-options="--pattern resolver-golden --hide-successes"`
+- Type checker golden/properties: `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
+- FC golden/eval: `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
+- CPP oracle/unit suite: `cabal test -v0 aihc-cpp:spec --test-options="--hide-successes"`
+
+## Pre-Commit
+
+Before every commit:
+
+1. Run `just fmt`.
+2. Run `just check`.
+
+Do not commit if `just check` fails. Fix formatting, lint, or test failures first.
+
+## Status Semantics
+
+- `pass`: expected to pass now.
+- `fail`: expected to fail now; supported by parser golden, TC golden, and FC golden where the loader accepts it.
+- `xfail`: known gap; the test is expected not to satisfy the success contract yet and must include `reason`.
+- `xpass`: known bug that currently passes unexpectedly; treat as strict tracking and include `reason`. Not every fixture format accepts `xpass` (`aihc-parser` parser golden and equivalent fixtures reject it).
+
+When an `xfail` starts passing, promote it to `pass` and add the expected output if that fixture format requires one.


### PR DESCRIPTION
## Summary

- Add the `aihc-test-authoring` Codex skill for choosing and authoring tests across AIHC components.
- Add component-specific references for `aihc-cpp`, `aihc-parser`, `aihc-resolve`, `aihc-tc`, and `aihc-fc` fixture formats and test commands.
- Add shared validation guidance for narrow test commands, status semantics, and the mandatory pre-commit workflow.

## Progress counts

- No fixture progress counts changed.

## Validation

- `python3 /Users/lemmih/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/aihc-test-authoring`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` ran once and produced findings; valid findings were addressed. A follow-up run was skipped because CodeRabbit reported usage credits/rate limit exceeded.
