### PR TITLE
feat(parser): support JavaScript FFI imports

### DIFF
--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
@@ -593,6 +593,7 @@ callConv cc =
     A.StdCall -> StdCallConv
     A.CApi -> CApiConv
     A.CPrim -> PrimCallConv
+    A.JavaScript -> JavaScriptCallConv
 
 foreignSafety :: A.ForeignSafety -> Safety
 foreignSafety safety =

--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Ghc.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Ghc.hs
@@ -78,6 +78,7 @@ compatAihcExtensions =
         Syntax.CApiFFI,
         Syntax.ExplicitNamespaces,
         Syntax.ImplicitParams,
+        Syntax.JavaScriptFFI,
         Syntax.LambdaCase,
         Syntax.LinearTypes,
         Syntax.MagicHash,

--- a/components/aihc-parser-compat/test/Test/Compat/Decl.hs
+++ b/components/aihc-parser-compat/test/Test/Compat/Decl.hs
@@ -127,6 +127,7 @@ compatParserConfig =
           GADTs,
           ImplicitParams,
           InstanceSigs,
+          JavaScriptFFI,
           LambdaCase,
           LinearTypes,
           MagicHash,

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -814,6 +814,7 @@ callConvParser =
     <|> (varIdTok "stdcall" >> pure StdCall)
     <|> (varIdTok "capi" >> pure CApi)
     <|> (varIdTok "prim" >> pure CPrim)
+    <|> (varIdTok "javascript" >> pure JavaScript)
 
 foreignSafetyParser :: TokParser ForeignSafety
 foreignSafetyParser =

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1020,6 +1020,7 @@ prettyCallConv cc =
     StdCall -> "stdcall"
     CApi -> "capi"
     CPrim -> "prim"
+    JavaScript -> "javascript"
 
 prettySafety :: ForeignSafety -> Doc ann
 prettySafety safety =

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -598,6 +598,7 @@ docCallConv cc =
     StdCall -> "StdCall"
     CApi -> "CApi"
     CPrim -> "CPrim"
+    JavaScript -> "JavaScript"
 
 docForeignSafety :: ForeignSafety -> Doc ann
 docForeignSafety fs =

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1582,6 +1582,7 @@ data CallConv
   | StdCall
   | CApi
   | CPrim
+  | JavaScript
   deriving (Data, Eq, Show, Generic, NFData)
 
 data ForeignSafety

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/javascript-ffi-imports.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/javascript-ffi-imports.yaml
@@ -1,0 +1,11 @@
+extensions:
+  - JavaScriptFFI
+input: |
+  {-# LANGUAGE JavaScriptFFI #-}
+  module JavaScriptFFIImport where
+  foreign import javascript "((x,y) => { return x + y; })" js_add :: Int -> Int -> Int
+  foreign import javascript interruptible "((i,cont) => { return cont(i); })" js_cont :: Int -> IO Int
+  foreign import javascript unsafe "performance.now" js_now :: IO Double
+ast: |-
+  Module {ModuleHead {"JavaScriptFFIImport"}, [JavaScriptFFI], [DeclForeign (ForeignDecl {ForeignImport, JavaScript, ForeignEntityNamed "((x,y) => { return x + y; })", UnqualifiedName {"js_add"}, TFun (TCon "Int") (TFun (TCon "Int") (TCon "Int"))}), DeclForeign (ForeignDecl {ForeignImport, JavaScript, Interruptible, ForeignEntityNamed "((i,cont) => { return cont(i); })", UnqualifiedName {"js_cont"}, TFun (TCon "Int") (TApp (TCon "IO") (TCon "Int"))}), DeclForeign (ForeignDecl {ForeignImport, JavaScript, Unsafe, ForeignEntityNamed "performance.now", UnqualifiedName {"js_now"}, TApp (TCon "IO") (TCon "Double")})]}
+status: pass

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -668,7 +668,7 @@ genDeclSplice = do
 
 genDeclForeign :: Gen Decl
 genDeclForeign = do
-  callConv <- elements [CCall, StdCall, CApi]
+  callConv <- elements [CCall, StdCall, CApi, JavaScript]
   direction <- elements [ForeignImport, ForeignExport]
   -- Safety is only valid for imports, not exports
   safety <- case direction of

--- a/components/aihc-parser/test/Test/Properties/Arb/Utils.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Utils.hs
@@ -50,6 +50,7 @@ requiredExtensions = effectiveExtensions GHC2024Edition moduleExtensionSettings
           CApiFFI,
           ExplicitNamespaces,
           ImplicitParams,
+          JavaScriptFFI,
           LambdaCase,
           LinearTypes,
           MagicHash,


### PR DESCRIPTION
## Summary

- Add `javascript` as a foreign calling convention in the parser AST, parser, pretty-printer, and shorthand output.
- Map the new calling convention through `aihc-parser-compat` to GHC’s `JavaScriptCallConv`.
- Add parser golden coverage for `foreign import javascript`, including default safety, `interruptible`, and `unsafe` imports from the GHC JavaScript FFI docs.

## Progress

- Parser extension support: `85/85` -> `86/86` supported.
- `JavaScriptFFI`: `1/1` passing.
- Generated README/docs were not updated; they are maintained by the cron workflow.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern javascript-ffi-imports"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` skipped: CodeRabbit reported no remaining usage credits / rate limit exceeded.
