### PR TITLE
fix(parser): preserve unicode star operator

### DIFF
--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Convert.hs
@@ -260,7 +260,7 @@ toGadtResultType details ty =
 isStarType :: A.Type -> Bool
 isStarType ty =
   case A.peelTypeAnn ty of
-    A.TStar -> True
+    A.TStar {} -> True
     _ -> False
 
 strictness :: A.BangType -> SrcStrictness
@@ -977,7 +977,7 @@ toHsType ty =
     A.TBuiltinCon builtin -> builtinType builtin
     A.TImplicitParam name inner -> HsIParamTy noAnn (lA (HsIPName (mkFastString (T.unpack (T.dropWhile (== '?') name))))) (toLHsType inner)
     A.TTypeLit lit -> HsTyLit noExtField (typeLit lit)
-    A.TStar -> HsStarTy noExtField False
+    A.TStar {} -> HsStarTy noExtField False
     A.TQuasiQuote quoter body -> HsSpliceTy noExtField (HsQuasiQuote noExtField (lA (toRdrName (A.nameFromText quoter))) (lA (mkFastString (T.unpack body))))
     A.TForall telescope body ->
       case splitTrailingKindSig body of
@@ -1033,7 +1033,7 @@ toLHsKindAppArg ty =
     -- kind argument.  For example, @f @*@ parses as an argument shaped like
     -- @HsParTy (HsStarTy ...)@, while ordinary @*@ in type position is just
     -- @HsStarTy@ under StarIsType.
-    A.TStar -> lA (HsParTy parAnn (toLHsType ty))
+    A.TStar {} -> lA (HsParTy parAnn (toLHsType ty))
     _ -> toLHsType ty
 
 toLHsPromotedCollectionElem :: A.Type -> LHsType GhcPs

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -315,10 +315,11 @@ typeParenOperatorParser :: TokParser Type
 typeParenOperatorParser = withSpanAnn (TAnn . mkAnnotation) $ do
   expectedTok TkSpecialLParen
   starIsType <- isExtensionEnabled StarIsType
+  unicodeSyntax <- isExtensionEnabled UnicodeSyntax
   op <- tokenSatisfy "type operator" $ \tok ->
     case lexTokenKind tok of
-      TkVarSym sym | not starIsType || sym /= "*" -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym sym))
-      TkConSym sym | not starIsType || sym /= "*" -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym sym))
+      TkVarSym sym | not (isStarTypeSymbol starIsType unicodeSyntax sym) -> Just (qualifyName Nothing (mkUnqualifiedName NameVarSym sym))
+      TkConSym sym | not (isStarTypeSymbol starIsType unicodeSyntax sym) -> Just (qualifyName Nothing (mkUnqualifiedName NameConSym sym))
       TkQVarSym modQual sym -> Just (mkName (Just modQual) NameVarSym sym)
       TkQConSym modQual sym -> Just (mkName (Just modQual) NameConSym sym)
       -- Handle reserved operators that can be used as type constructors
@@ -353,11 +354,20 @@ typeIdentifierParser = withSpanAnn (TAnn . mkAnnotation) $ do
 typeStarParser :: TokParser Type
 typeStarParser = withSpanAnn (TAnn . mkAnnotation) $ do
   starIsType <- isExtensionEnabled StarIsType
+  unicodeSyntax <- isExtensionEnabled UnicodeSyntax
   if starIsType
     then do
-      expectedTok (TkVarSym "*")
-      pure TStar
+      spelling <- tokenSatisfy "star kind" $ \tok ->
+        case lexTokenKind tok of
+          TkVarSym sym | isStarTypeSymbol starIsType unicodeSyntax sym -> Just (lexTokenText tok)
+          TkConSym sym | isStarTypeSymbol starIsType unicodeSyntax sym -> Just (lexTokenText tok)
+          _ -> Nothing
+      pure (TStar spelling)
     else MP.empty
+
+isStarTypeSymbol :: Bool -> Bool -> T.Text -> Bool
+isStarTypeSymbol starIsType unicodeSyntax sym =
+  starIsType && (sym == "*" || (unicodeSyntax && sym == "★"))
 
 typeListParser :: TokParser Type
 typeListParser = withSpanAnn (TAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -742,7 +742,6 @@ unicodeOpTokenKind hasArrows txt firstChar
   | txt == "→" = TkReservedRightArrow
   | txt == "←" = TkReservedLeftArrow
   | txt == "∀" = TkKeywordForall
-  | txt == "★" = TkVarSym "*"
   | txt == "⤙" = if hasArrows then TkArrowTail else TkVarSym "-<"
   | txt == "⤚" = if hasArrows then TkArrowTailReverse else TkVarSym ">-"
   | txt == "⤛" = if hasArrows then TkDoubleArrowTail else TkVarSym "-<<"

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -743,7 +743,7 @@ addBangTypeParens bt =
 bangTypeNeedsPrefixParens :: Type -> Bool
 bangTypeNeedsPrefixParens (TAnn _ sub) = bangTypeNeedsPrefixParens sub
 bangTypeNeedsPrefixParens (TParen _) = False
-bangTypeNeedsPrefixParens TStar = True
+bangTypeNeedsPrefixParens TStar {} = True
 bangTypeNeedsPrefixParens (TCon _ Promoted) = True
 bangTypeNeedsPrefixParens (TBuiltinCon TBuiltinCons) = True
 bangTypeNeedsPrefixParens (TBuiltinCon _) = False

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -445,7 +445,7 @@ prettyType ty =
     TBuiltinCon con -> prettyTypeBuiltinCon con
     TImplicitParam name inner -> pretty name <+> "::" <+> prettyType inner
     TTypeLit lit -> prettyTypeLiteral lit
-    TStar -> "*"
+    TStar spelling -> pretty spelling
     TQuasiQuote quoter body -> prettyQuasiQuote quoter body
     TForall telescope inner ->
       prettyForallTelescope telescope <+> prettyType inner

--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -637,7 +637,7 @@ docType ty =
     TBuiltinCon con -> "TBuiltinCon" <+> pretty (show con)
     TImplicitParam name inner -> "TImplicitParam" <+> docText name <+> parens (docType inner)
     TTypeLit lit -> "TTypeLit" <+> docTypeLiteral lit
-    TStar -> "TStar"
+    TStar {} -> "TStar"
     TQuasiQuote quoter body -> "TQuasiQuote" <+> docText quoter <+> docText body
     TForall telescope inner ->
       case forallTelescopeVisibility telescope of

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -1124,7 +1124,7 @@ data Type
   | TBuiltinCon TypeBuiltinCon
   | TImplicitParam Text Type
   | TTypeLit TypeLiteral
-  | TStar
+  | TStar Text
   | TQuasiQuote Text Text
   | TForall ForallTelescope Type
   | TApp Type Type

--- a/components/aihc-parser/test/Test/Fixtures/lexer/unicode-syntax/star.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/unicode-syntax/star.yaml
@@ -2,6 +2,6 @@ extensions:
   - UnicodeSyntax
 input: "★"
 tokens:
-  - 'TkVarSym "*"'
+  - 'TkVarSym "★"'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-star-expression-operator.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-star-expression-operator.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeStarExpressionOperator where
+
+infixl 7 ★
+
+(★) ∷ Int → Int → Int
+(★) = (*)
+
+value ∷ Int
+value = 2 ★ 3

--- a/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-star-type.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/UnicodeSyntax/unicode-star-type.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE StarIsType #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeStarType where
+
+type StarKind = ★

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -634,7 +634,7 @@ genInstanceHeadType = suchThat (scale (min 4) genType) isValidInstanceHeadType
 isValidInstanceHeadType :: Type -> Bool
 isValidInstanceHeadType ty =
   case ty of
-    TStar -> False
+    TStar {} -> False
     TForall {} -> False
     TContext {} -> False
     TImplicitParam {} -> False
@@ -648,7 +648,7 @@ isInfixInstanceHeadType ty =
     TVar {} -> True
     TCon {} -> True
     TTypeLit {} -> True
-    TStar -> True
+    TStar {} -> True
     TTuple {} -> True
     TList {} -> True
     TApp fn arg -> isInfixInstanceHeadType fn && isInfixInstanceHeadType arg
@@ -866,7 +866,7 @@ genFamilyLhsArg :: Gen Type
 genFamilyLhsArg = suchThat (scale (min 4) genType) (not . isStarType)
 
 isStarType :: Type -> Bool
-isStarType TStar = True
+isStarType TStar {} = True
 isStarType _ = False
 
 genDeclPragma :: Gen Decl

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -43,7 +43,7 @@ genType = scale (`div` 2) $ do
           (`TCon` Promoted) <$> genConName,
           TBuiltinCon <$> genTypeBuiltinCon,
           TTypeLit <$> genTypeLiteral,
-          pure TStar,
+          pure (TStar "*"),
           pure TWildcard,
           TQuasiQuote <$> genQuoterName <*> genQuasiBody,
           TTuple Boxed Unpromoted <$> elements [[], [TVar "a", TCon (qualifyName Nothing (mkUnqualifiedName NameConId "B")) Unpromoted]],
@@ -58,7 +58,7 @@ genType = scale (`div` 2) $ do
           (`TCon` Promoted) <$> genConName,
           TBuiltinCon <$> genTypeBuiltinCon,
           TTypeLit <$> genTypeLiteral,
-          pure TStar,
+          pure (TStar "*"),
           pure TWildcard,
           TQuasiQuote <$> genQuoterName <*> genQuasiBody,
           TForall <$> genForallTelescope <*> genType,
@@ -185,7 +185,7 @@ genPromotedElem =
     [ TVar <$> genTypeVarName,
       (`TCon` Unpromoted) <$> genConName,
       genPromotedSafeTypeLiteral,
-      pure TStar
+      pure (TStar "*")
     ]
 
 -- | Generate type literals safe for use in promoted contexts (no char literals).
@@ -207,7 +207,7 @@ genSimpleTypeAtom =
     [ TVar <$> genTypeVarName,
       (`TCon` Unpromoted) <$> genConName,
       TTypeLit <$> genTypeLiteral,
-      pure TStar,
+      pure (TStar "*"),
       pure TWildcard,
       TQuasiQuote <$> genQuoterName <*> genQuasiBody,
       TTuple Boxed Unpromoted <$> genTypeTupleElems,
@@ -323,7 +323,7 @@ shrinkType ty =
           <> [TImplicitParam name inner' | inner' <- shrinkType inner]
       TTypeLit {} ->
         []
-      TStar ->
+      TStar {} ->
         []
       TQuasiQuote quoter body ->
         [TQuasiQuote q body | q <- shrinkIdent quoter]

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -931,7 +931,7 @@ resolveType ty =
     TImplicitParam name inner ->
       TImplicitParam name <$> resolveType inner
     TTypeLit {} -> pure ty
-    TStar -> pure ty
+    TStar {} -> pure ty
     TForall telescope inner -> do
       (binderScope, binders') <- withLocalSupply 0 (bindTyVarBinders (forallTelescopeBinders telescope))
       inner' <- extendScope binderScope (resolveType inner)


### PR DESCRIPTION
## Summary
- Preserve `★` as a distinct Unicode operator token instead of normalizing it to `*` in the lexer.
- Parse `★` as `TStar` only in UnicodeSyntax type-star contexts, and carry the original star spelling through `TStar` so roundtrips preserve `*` vs `★`.
- Add oracle coverage for Unicode star as an expression operator and as a type star.

## Progress Counts
- Parser oracle fixtures: +2 pass cases.

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern lexer-golden --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern unicode-star --hide-successes"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester dozenal`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (applied the relevant parser suggestion; skipped unrelated local skill-doc suggestions)
