### PR TITLE
fix(parser): preserve promoted tuple char spacing

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -424,6 +424,7 @@ startsWithTick (TAnn _ sub) = startsWithTick sub
 startsWithTick (TList Promoted _) = True
 startsWithTick (TCon _ Promoted) = True
 startsWithTick (TTuple _ Promoted _) = True
+startsWithTick (TTypeLit (TypeLitChar _ _)) = True
 startsWithTick (TApp f _) = startsWithTick f
 startsWithTick (TInfix lhs _ _ _) = startsWithTick lhs
 startsWithTick _ = False

--- a/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/promoted-tuple-leading-char.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/promoted-tuple-leading-char.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module PromotedTupleLeadingChar where
+
+import GHC.TypeLits (Symbol)
+
+type family DropHash (value :: Maybe (Char, Symbol)) :: Symbol where
+  DropHash ('Just '( '#', rest)) = rest
+  DropHash 'Nothing = ""


### PR DESCRIPTION
## Summary
- Treat promoted character type literals as tick-leading when deciding whether promoted tuples/lists need a separating space.
- Add an oracle regression for a promoted tuple whose first element is a promoted character literal.

## Root Cause
The pretty-printer rendered `'( '#', rest)` as `'('#', rest)`. GHC then lexed the promoted tuple tick together with the promoted character literal and rejected the round-tripped module at the comma.

## Validation
- `cabal test -v0 aihc-parser:spec --test-options="--pattern promoted-tuple-leading-char --hide-successes"`
- `cabal run exe:aihc-dev -v0 -- hackage-tester typist`
- `just fmt`
- `just check`
- `nix develop --quiet --command bash -c 'ormolu --mode inplace components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/promoted-tuple-leading-char.hs && hlint components/aihc-parser/test/Test/Fixtures/oracle/DataKinds/promoted-tuple-leading-char.hs'`
- `coderabbit review --prompt-only` (reviewed; unrelated docs finding skipped, fixture formatting/lint finding verified)

## Progress Counts
- Parser oracle pass fixtures: +1
