### PR TITLE
fix(parser-hackage-progress): filter custom preprocessors

### DIFF
--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -7,6 +7,7 @@ module HackageSupport
     downloadPackageQuiet,
     downloadPackageQuietWithNetwork,
     findPackageBuildToolDependencyNames,
+    findPackageUsesCustomPreprocessor,
     findTargetFilesFromCabal,
     FileInfo (..),
     readTextFileLenient,
@@ -78,6 +79,12 @@ findPackageBuildToolDependencyNames :: FilePath -> IO [Text]
 findPackageBuildToolDependencyNames extractedRoot = do
   (gpd, _) <- parsePackageDescriptionFromRoot extractedRoot
   pure (HC.buildToolDependencyNames gpd)
+
+-- | Find whether active package metadata requests a custom GHC preprocessor.
+findPackageUsesCustomPreprocessor :: FilePath -> IO Bool
+findPackageUsesCustomPreprocessor extractedRoot = do
+  (gpd, _) <- parsePackageDescriptionFromRoot extractedRoot
+  pure (HC.packageUsesCustomPreprocessor gpd)
 
 parsePackageDescriptionFromRoot :: FilePath -> IO (GenericPackageDescription, FilePath)
 parsePackageDescriptionFromRoot extractedRoot = do

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -10,6 +10,8 @@ module StackageProgress.PackageRunner
     runPackage,
     runPackageOrThrow,
     packageDependsOnUnsupportedBuildTool,
+    packageUsesUnsupportedMetadata,
+    packageUsesCustomPreprocessor,
 
     -- * Source size calculation
     totalSourceSize,
@@ -18,12 +20,13 @@ where
 
 import Aihc.Hackage.VersionResolver (getLatestVersion)
 import Control.Exception (IOException, SomeException, displayException, try)
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import HackageSupport
   ( FileInfo (..),
     downloadPackageQuietWithNetwork,
     findPackageBuildToolDependencyNames,
+    findPackageUsesCustomPreprocessor,
     findTargetFilesFromCabal,
   )
 import StackageProgress.CLI (Options (..))
@@ -67,6 +70,23 @@ packageRunOptionsFromStackageOptions opts =
 unsupportedBuildToolNames :: [Text]
 unsupportedBuildToolNames = ["genprimopcode"]
 
+-- | Return whether a package's active Cabal metadata uses any unsupported package-level feature.
+packageUsesUnsupportedMetadata :: PackageRunOptions -> PackageSpec -> IO Bool
+packageUsesUnsupportedMetadata opts spec = do
+  result <- try (packageUsesUnsupportedMetadataOrThrow opts spec) :: IO (Either SomeException Bool)
+  pure $ case result of
+    Right unsupported -> unsupported
+    Left _ -> False
+
+packageUsesUnsupportedMetadataOrThrow :: PackageRunOptions -> PackageSpec -> IO Bool
+packageUsesUnsupportedMetadataOrThrow opts spec = do
+  fromMaybe False <$> withResolvedPackage opts spec checkPackage
+  where
+    checkPackage srcDir = do
+      toolNames <- findPackageBuildToolDependencyNames srcDir
+      usesCustomPreprocessor <- findPackageUsesCustomPreprocessor srcDir
+      pure (usesCustomPreprocessor || any (`elem` unsupportedBuildToolNames) toolNames)
+
 -- | Return whether a package's active Cabal metadata requires an unsupported build tool.
 packageDependsOnUnsupportedBuildTool :: PackageRunOptions -> PackageSpec -> IO Bool
 packageDependsOnUnsupportedBuildTool opts spec = do
@@ -77,13 +97,32 @@ packageDependsOnUnsupportedBuildTool opts spec = do
 
 packageDependsOnUnsupportedBuildToolOrThrow :: PackageRunOptions -> PackageSpec -> IO Bool
 packageDependsOnUnsupportedBuildToolOrThrow opts spec = do
-  versionResult <- resolveSpecVersion spec
-  case versionResult of
-    Left _ -> pure False
-    Right version -> do
-      srcDir <- downloadPackageQuietWithNetwork (not (runOptOffline opts)) (pkgName spec) version
+  fromMaybe False <$> withResolvedPackage opts spec checkPackage
+  where
+    checkPackage srcDir = do
       toolNames <- findPackageBuildToolDependencyNames srcDir
       pure (any (`elem` unsupportedBuildToolNames) toolNames)
+
+-- | Return whether a package's active Cabal metadata requests a custom GHC preprocessor.
+packageUsesCustomPreprocessor :: PackageRunOptions -> PackageSpec -> IO Bool
+packageUsesCustomPreprocessor opts spec = do
+  result <- try (packageUsesCustomPreprocessorOrThrow opts spec) :: IO (Either SomeException Bool)
+  pure $ case result of
+    Right usesPreprocessor -> usesPreprocessor
+    Left _ -> False
+
+packageUsesCustomPreprocessorOrThrow :: PackageRunOptions -> PackageSpec -> IO Bool
+packageUsesCustomPreprocessorOrThrow opts spec = do
+  fromMaybe False <$> withResolvedPackage opts spec findPackageUsesCustomPreprocessor
+
+withResolvedPackage :: PackageRunOptions -> PackageSpec -> (FilePath -> IO a) -> IO (Maybe a)
+withResolvedPackage opts spec action = do
+  versionResult <- resolveSpecVersion spec
+  case versionResult of
+    Left _ -> pure Nothing
+    Right version -> do
+      srcDir <- downloadPackageQuietWithNetwork (not (runOptOffline opts)) (pkgName spec) version
+      Just <$> action srcDir
 
 -- | Process a package, catching any exceptions.
 runPackage :: PackageRunOptions -> PackageSpec -> IO PackageResult

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
@@ -20,8 +20,8 @@ import StackageProgress.CLI
   )
 import StackageProgress.PackageRunner
   ( PackageRunOptions,
-    packageDependsOnUnsupportedBuildTool,
     packageRunOptionsFromStackageOptions,
+    packageUsesUnsupportedMetadata,
     runPackage,
   )
 import StackageProgress.Snapshot (loadStackageSnapshotWithMode)
@@ -64,7 +64,7 @@ runPackages :: Options -> [PackageSpec] -> IO ()
 runPackages opts packages = do
   jobs <- maybe getNumProcessors pure (optJobs opts)
   let packageRunOpts = packageRunOptionsFromStackageOptions opts
-  filteredPackages <- filterUnsupportedBuildToolPackages packageRunOpts jobs packages
+  filteredPackages <- filterUnsupportedPackages packageRunOpts jobs packages
   let total = length filteredPackages
   isStdoutTerminal <- hIsTerminalDevice stdout
   let showProgress = isStdoutTerminal && not (optPrompt opts)
@@ -148,8 +148,8 @@ runPackages opts packages = do
 
   if successOursN == total then exitSuccess else exitFailure
 
-filterUnsupportedBuildToolPackages :: PackageRunOptions -> Int -> [PackageSpec] -> IO [PackageSpec]
-filterUnsupportedBuildToolPackages opts n packages = do
+filterUnsupportedPackages :: PackageRunOptions -> Int -> [PackageSpec] -> IO [PackageSpec]
+filterUnsupportedPackages opts n packages = do
   queue <- newChan
   forM_ (zip [0 :: Int ..] packages) (writeChan queue . Just)
   replicateM_ workerCount (writeChan queue Nothing)
@@ -159,7 +159,7 @@ filterUnsupportedBuildToolPackages opts n packages = do
         case next of
           Nothing -> pure ()
           Just (ix, spec) -> do
-            unsupported <- packageDependsOnUnsupportedBuildTool opts spec
+            unsupported <- packageUsesUnsupportedMetadata opts spec
             unless unsupported $
               modifyMVar_ keptVar (pure . ((ix, spec) :))
             worker

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -15,6 +15,7 @@ module Aihc.Hackage.Cabal
 
     -- * Build tool dependency extraction
     buildToolDependencyNames,
+    packageUsesCustomPreprocessor,
 
     -- * Extension / language extraction
     extractExtensions,
@@ -24,13 +25,14 @@ module Aihc.Hackage.Cabal
 where
 
 import Aihc.Hackage.Util (existingPaths, moduleFilesForBuildInfo, sourceDirs)
-import Data.List (nub)
+import Data.List (isPrefixOf, nub)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Version qualified as DV
 import Distribution.Compat.Graph qualified as Graph
 import Distribution.Compiler (CompilerFlavor (..), CompilerId (..))
+import Distribution.Compiler qualified as Compiler
 import Distribution.ModuleName qualified as ModuleName
 import Distribution.Package (packageName, unPackageName)
 import Distribution.PackageDescription
@@ -62,6 +64,7 @@ import Distribution.PackageDescription
     libBuildInfo,
     modulePath,
     oldExtensions,
+    options,
     otherModules,
     package,
     packageDescription,
@@ -198,6 +201,11 @@ buildToolDependencyNames gpd =
   nub $
     concatMap buildInfoToolNames (activeComponentBuildInfos gpd)
 
+-- | Return whether any active component requests a custom GHC preprocessor.
+packageUsesCustomPreprocessor :: GenericPackageDescription -> Bool
+packageUsesCustomPreprocessor gpd =
+  any buildInfoUsesCustomPreprocessor (activeComponentBuildInfos gpd)
+
 activeComponentBuildInfos :: GenericPackageDescription -> [BuildInfo]
 activeComponentBuildInfos gpd =
   let evalCond = conditionEvaluator gpd
@@ -223,6 +231,21 @@ exeDependencyNames (ExeDependency pkgName exeName _) =
 legacyExeDependencyNames :: LegacyExeDependency -> [Text]
 legacyExeDependencyNames (LegacyExeDependency toolName _) =
   [T.pack toolName]
+
+buildInfoUsesCustomPreprocessor :: BuildInfo -> Bool
+buildInfoUsesCustomPreprocessor bi =
+  ghcOptionsUseCustomPreprocessor (concat ghcOptions)
+  where
+    ghcOptions =
+      [ opts
+      | (GHC, opts) <- Compiler.perCompilerFlavorToList (options bi)
+      ]
+
+ghcOptionsUseCustomPreprocessor :: [String] -> Bool
+ghcOptionsUseCustomPreprocessor opts =
+  "-F" `elem` opts && any isPgmFOption opts
+  where
+    isPgmFOption opt = "-pgmF" `isPrefixOf` opt
 
 generatedPathsFileInfo :: FilePath -> FileInfo
 generatedPathsFileInfo path =

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -48,6 +48,7 @@ main =
       testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
       testCase "collects exposed modules from active conditional library branches" test_collectsConditionalExposedModules,
       testCase "extracts active build tool dependency names" test_extractsBuildToolDependencyNames,
+      testCase "detects active custom preprocessor options" test_detectsCustomPreprocessorOptions,
       QC.testProperty "dummy quickcheck property" prop_dummy
     ]
 
@@ -141,6 +142,15 @@ test_extractsBuildToolDependencyNames = do
     (sort ["alex", "genprimopcode"])
     (sort (map T.unpack (HC.buildToolDependencyNames gpd)))
 
+test_detectsCustomPreprocessorOptions :: Assertion
+test_detectsCustomPreprocessorOptions = do
+  hsp <- parseTestCabal customPreprocessorCabal
+  inactive <- parseTestCabal inactiveCustomPreprocessorCabal
+  pgmFOnly <- parseTestCabal pgmFWithoutFPreprocessorCabal
+  assertBool "expected -F with -pgmF to require filtering" (HC.packageUsesCustomPreprocessor hsp)
+  assertBool "expected inactive custom preprocessor options to be ignored" (not (HC.packageUsesCustomPreprocessor inactive))
+  assertBool "expected -pgmF without -F not to enable preprocessing" (not (HC.packageUsesCustomPreprocessor pgmFOnly))
+
 parseTestCabal :: String -> IO GenericPackageDescription
 parseTestCabal source =
   case snd (runParseResult (parseGenericPackageDescription (BSC.pack source))) of
@@ -211,6 +221,53 @@ buildToolDependsCabal =
       "  default-language: Haskell2010",
       "  if flag(generated)",
       "    build-tool-depends: inactive-tool:inactive-tool >= 0"
+    ]
+
+customPreprocessorCabal :: String
+customPreprocessorCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: custom-preprocessor-demo",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: CustomPreprocessorDemo",
+      "  ghc-options: -F -pgmFtrhsx -Wall",
+      "  build-depends: base",
+      "  default-language: Haskell2010"
+    ]
+
+inactiveCustomPreprocessorCabal :: String
+inactiveCustomPreprocessorCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: inactive-custom-preprocessor-demo",
+      "version: 0.1.0.0",
+      "",
+      "flag generated",
+      "  default: False",
+      "  manual: True",
+      "",
+      "library",
+      "  exposed-modules: InactiveCustomPreprocessorDemo",
+      "  build-depends: base",
+      "  default-language: Haskell2010",
+      "  if flag(generated)",
+      "    ghc-options: -F -pgmFtrhsx"
+    ]
+
+pgmFWithoutFPreprocessorCabal :: String
+pgmFWithoutFPreprocessorCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: pgmf-without-f-demo",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: PgmFWithoutFDemo",
+      "  ghc-options: -pgmFtrhsx -Wall",
+      "  build-depends: base",
+      "  default-language: Haskell2010"
     ]
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a


### PR DESCRIPTION
## Summary

- Detect active Cabal `ghc-options` that enable a custom preprocessor with `-F` plus `-pgmF...`.
- Filter packages with unsupported package metadata before `parser-hackage-progress` runs parser checks.
- Add regression coverage for active custom preprocessors, inactive conditional options, and `-pgmF` without `-F`.

## Progress counts

- Runtime progress denominators now exclude packages whose active Cabal metadata requests a custom preprocessor, such as `hsp-cgi`.
- No README progress tables were updated; those remain cron-managed.

## Validation

- `cabal test -v0 aihc-hackage:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-dev:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-hackage:spec aihc-dev:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`

## CodeRabbit

- `coderabbit review --prompt-only` completed once; the relevant `PackageRunner` refactor finding was fixed.
- A second run after the refactor was rate-limited due to usage credits, so it could not be completed.
- Other reported findings were unrelated `.agents` documentation issues and were left out of this scoped fix.
