### PR TITLE
fix: filter Haskell98 package progress targets

### DIFF
--- a/components/aihc-parser/common/HackageSupport.hs
+++ b/components/aihc-parser/common/HackageSupport.hs
@@ -7,6 +7,7 @@ module HackageSupport
     downloadPackageQuiet,
     downloadPackageQuietWithNetwork,
     findPackageBuildToolDependencyNames,
+    findPackageDefaultsToHaskell98,
     findTargetFilesFromCabal,
     FileInfo (..),
     readTextFileLenient,
@@ -78,6 +79,12 @@ findPackageBuildToolDependencyNames :: FilePath -> IO [Text]
 findPackageBuildToolDependencyNames extractedRoot = do
   (gpd, _) <- parsePackageDescriptionFromRoot extractedRoot
   pure (HC.buildToolDependencyNames gpd)
+
+-- | Return whether any active library or executable defaults to Haskell98.
+findPackageDefaultsToHaskell98 :: FilePath -> IO Bool
+findPackageDefaultsToHaskell98 extractedRoot = do
+  (gpd, _) <- parsePackageDescriptionFromRoot extractedRoot
+  pure (HC.packageDefaultsToHaskell98 gpd)
 
 parsePackageDescriptionFromRoot :: FilePath -> IO (GenericPackageDescription, FilePath)
 parsePackageDescriptionFromRoot extractedRoot = do

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/PackageRunner.hs
@@ -10,6 +10,7 @@ module StackageProgress.PackageRunner
     runPackage,
     runPackageOrThrow,
     packageDependsOnUnsupportedBuildTool,
+    packageUsesUnsupportedDefaultLanguage,
 
     -- * Source size calculation
     totalSourceSize,
@@ -24,6 +25,7 @@ import HackageSupport
   ( FileInfo (..),
     downloadPackageQuietWithNetwork,
     findPackageBuildToolDependencyNames,
+    findPackageDefaultsToHaskell98,
     findTargetFilesFromCabal,
   )
 import StackageProgress.CLI (Options (..))
@@ -66,6 +68,23 @@ packageRunOptionsFromStackageOptions opts =
 
 unsupportedBuildToolNames :: [Text]
 unsupportedBuildToolNames = ["genprimopcode"]
+
+-- | Return whether a package uses a default language edition unsupported by AIHC.
+packageUsesUnsupportedDefaultLanguage :: PackageRunOptions -> PackageSpec -> IO Bool
+packageUsesUnsupportedDefaultLanguage opts spec = do
+  result <- try (packageUsesUnsupportedDefaultLanguageOrThrow opts spec) :: IO (Either SomeException Bool)
+  pure $ case result of
+    Right usesUnsupportedLanguage -> usesUnsupportedLanguage
+    Left _ -> False
+
+packageUsesUnsupportedDefaultLanguageOrThrow :: PackageRunOptions -> PackageSpec -> IO Bool
+packageUsesUnsupportedDefaultLanguageOrThrow opts spec = do
+  versionResult <- resolveSpecVersion spec
+  case versionResult of
+    Left _ -> pure False
+    Right version -> do
+      srcDir <- downloadPackageQuietWithNetwork (not (runOptOffline opts)) (pkgName spec) version
+      findPackageDefaultsToHaskell98 srcDir
 
 -- | Return whether a package's active Cabal metadata requires an unsupported build tool.
 packageDependsOnUnsupportedBuildTool :: PackageRunOptions -> PackageSpec -> IO Bool

--- a/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/stackage-progress/StackageProgress/Run.hs
@@ -22,6 +22,7 @@ import StackageProgress.PackageRunner
   ( PackageRunOptions,
     packageDependsOnUnsupportedBuildTool,
     packageRunOptionsFromStackageOptions,
+    packageUsesUnsupportedDefaultLanguage,
     runPackage,
   )
 import StackageProgress.Snapshot (loadStackageSnapshotWithMode)
@@ -64,7 +65,7 @@ runPackages :: Options -> [PackageSpec] -> IO ()
 runPackages opts packages = do
   jobs <- maybe getNumProcessors pure (optJobs opts)
   let packageRunOpts = packageRunOptionsFromStackageOptions opts
-  filteredPackages <- filterUnsupportedBuildToolPackages packageRunOpts jobs packages
+  filteredPackages <- filterUnsupportedPackages packageRunOpts jobs packages
   let total = length filteredPackages
   isStdoutTerminal <- hIsTerminalDevice stdout
   let showProgress = isStdoutTerminal && not (optPrompt opts)
@@ -148,8 +149,8 @@ runPackages opts packages = do
 
   if successOursN == total then exitSuccess else exitFailure
 
-filterUnsupportedBuildToolPackages :: PackageRunOptions -> Int -> [PackageSpec] -> IO [PackageSpec]
-filterUnsupportedBuildToolPackages opts n packages = do
+filterUnsupportedPackages :: PackageRunOptions -> Int -> [PackageSpec] -> IO [PackageSpec]
+filterUnsupportedPackages opts n packages = do
   queue <- newChan
   forM_ (zip [0 :: Int ..] packages) (writeChan queue . Just)
   replicateM_ workerCount (writeChan queue Nothing)
@@ -159,7 +160,9 @@ filterUnsupportedBuildToolPackages opts n packages = do
         case next of
           Nothing -> pure ()
           Just (ix, spec) -> do
-            unsupported <- packageDependsOnUnsupportedBuildTool opts spec
+            unsupportedBuildTool <- packageDependsOnUnsupportedBuildTool opts spec
+            unsupportedLanguage <- packageUsesUnsupportedDefaultLanguage opts spec
+            let unsupported = unsupportedBuildTool || unsupportedLanguage
             unless unsupported $
               modifyMVar_ keptVar (pure . ((ix, spec) :))
             worker

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -20,6 +20,7 @@ module Aihc.Hackage.Cabal
     extractExtensions,
     extractLanguage,
     extractDependencies,
+    packageDefaultsToHaskell98,
   )
 where
 
@@ -197,6 +198,29 @@ buildToolDependencyNames :: GenericPackageDescription -> [Text]
 buildToolDependencyNames gpd =
   nub $
     concatMap buildInfoToolNames (activeComponentBuildInfos gpd)
+
+-- | Return whether any active source component uses Cabal's Haskell98 default.
+--
+-- Cabal treats a missing @default-language@ as Haskell98. AIHC does not support
+-- Haskell98 as a package language target, so progress tooling filters these
+-- packages before parsing their files.
+packageDefaultsToHaskell98 :: GenericPackageDescription -> Bool
+packageDefaultsToHaskell98 =
+  any buildInfoDefaultsToHaskell98 . activeSourceComponentBuildInfos
+
+buildInfoDefaultsToHaskell98 :: BuildInfo -> Bool
+buildInfoDefaultsToHaskell98 bi =
+  case defaultLanguage bi of
+    Nothing -> True
+    Just lang -> prettyShow lang == "Haskell98"
+
+activeSourceComponentBuildInfos :: GenericPackageDescription -> [BuildInfo]
+activeSourceComponentBuildInfos gpd =
+  let evalCond = conditionEvaluator gpd
+      merged = collectMergedBuildInfo evalCond
+   in maybe [] (pure . merged libBuildInfo) (condLibrary gpd)
+        <> map (merged libBuildInfo . snd) (condSubLibraries gpd)
+        <> map (merged buildInfo . snd) (condExecutables gpd)
 
 activeComponentBuildInfos :: GenericPackageDescription -> [BuildInfo]
 activeComponentBuildInfos gpd =

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -48,6 +48,8 @@ main =
       testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
       testCase "collects exposed modules from active conditional library branches" test_collectsConditionalExposedModules,
       testCase "extracts active build tool dependency names" test_extractsBuildToolDependencyNames,
+      testCase "detects packages that default to Haskell98" test_detectsHaskell98DefaultLanguage,
+      testCase "ignores inactive Haskell98 default-language branches" test_ignoresInactiveHaskell98DefaultLanguage,
       QC.testProperty "dummy quickcheck property" prop_dummy
     ]
 
@@ -141,6 +143,20 @@ test_extractsBuildToolDependencyNames = do
     (sort ["alex", "genprimopcode"])
     (sort (map T.unpack (HC.buildToolDependencyNames gpd)))
 
+test_detectsHaskell98DefaultLanguage :: Assertion
+test_detectsHaskell98DefaultLanguage = do
+  explicit <- parseTestCabal haskell98DefaultLanguageCabal
+  missing <- parseTestCabal missingDefaultLanguageCabal
+  supported <- parseTestCabal haskell2010DefaultLanguageCabal
+  assertBool "explicit Haskell98 default-language is unsupported" (HC.packageDefaultsToHaskell98 explicit)
+  assertBool "missing default-language falls back to Haskell98" (HC.packageDefaultsToHaskell98 missing)
+  assertBool "Haskell2010 default-language is supported" (not (HC.packageDefaultsToHaskell98 supported))
+
+test_ignoresInactiveHaskell98DefaultLanguage :: Assertion
+test_ignoresInactiveHaskell98DefaultLanguage = do
+  gpd <- parseTestCabal inactiveHaskell98DefaultLanguageCabal
+  assertBool "inactive Haskell98 branch should not filter the package" (not (HC.packageDefaultsToHaskell98 gpd))
+
 parseTestCabal :: String -> IO GenericPackageDescription
 parseTestCabal source =
   case snd (runParseResult (parseGenericPackageDescription (BSC.pack source))) of
@@ -211,6 +227,63 @@ buildToolDependsCabal =
       "  default-language: Haskell2010",
       "  if flag(generated)",
       "    build-tool-depends: inactive-tool:inactive-tool >= 0"
+    ]
+
+haskell98DefaultLanguageCabal :: String
+haskell98DefaultLanguageCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: haskell98-language",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: Haskell98Language",
+      "  hs-source-dirs: src",
+      "  default-language: Haskell98"
+    ]
+
+missingDefaultLanguageCabal :: String
+missingDefaultLanguageCabal =
+  unlines
+    [ "cabal-version: 1.10",
+      "name: missing-language",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: MissingLanguage",
+      "  hs-source-dirs: src"
+    ]
+
+haskell2010DefaultLanguageCabal :: String
+haskell2010DefaultLanguageCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: haskell2010-language",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: Haskell2010Language",
+      "  hs-source-dirs: src",
+      "  default-language: Haskell2010"
+    ]
+
+inactiveHaskell98DefaultLanguageCabal :: String
+inactiveHaskell98DefaultLanguageCabal =
+  unlines
+    [ "cabal-version: 2.4",
+      "name: inactive-haskell98-language",
+      "version: 0.1.0.0",
+      "",
+      "flag legacy",
+      "  default: False",
+      "  manual: True",
+      "",
+      "library",
+      "  exposed-modules: InactiveHaskell98Language",
+      "  hs-source-dirs: src",
+      "  default-language: Haskell2010",
+      "  if flag(legacy)",
+      "    default-language: Haskell98"
     ]
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a


### PR DESCRIPTION
## Summary

- Treat active library/executable components with explicit `default-language: Haskell98` as unsupported progress targets.
- Treat missing `default-language` as Cabal's Haskell98 default and filter those packages before parsing.
- Add Cabal metadata regression coverage for explicit, implicit, supported, and inactive conditional language cases.

## Progress counts

`parser-hackage-progress` now excludes Haskell98-default packages from its denominator. README progress counts were not updated; they are cron-managed.

## Validation

- `cabal test -v0 aihc-hackage:spec --test-options="--pattern Haskell98"`
- `cabal test -v0 aihc-dev:spec --test-options="--pattern=dummy"`
- `just fmt`
- `cabal test -v0 aihc-hackage:spec --test-options=--hide-successes`
- `just check`

## Pre-PR review

- `coderabbit review --prompt-only` was attempted and skipped because CodeRabbit reported exhausted usage credits/rate limiting.