### PR TITLE
fix(parser): filter stale Hackage packages

### DIFF
--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -144,6 +144,7 @@ executable aihc-dev
     prettyprinter,
     process >=1.6 && <1.8,
     text >=1.2.3 && <2.2,
+    time,
     yaml >=0.11 && <0.12,
 
   default-extensions: OverloadedStrings
@@ -212,6 +213,7 @@ test-suite spec
     tasty-hunit,
     tasty-quickcheck,
     text >=1.2.3 && <2.2,
+    time,
     yaml >=0.11 && <0.12,
 
   ghc-options: -Wall

--- a/tooling/aihc-dev/app/hackage-progress/HackageProgress/CLI.hs
+++ b/tooling/aihc-dev/app/hackage-progress/HackageProgress/CLI.hs
@@ -9,6 +9,8 @@ module HackageProgress.CLI
 where
 
 import Data.List (nub)
+import Data.Time.Calendar (Day)
+import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import Options.Applicative qualified as OA
 import StackageProgress.CLI qualified as StackageCLI
 
@@ -18,6 +20,7 @@ data Options = Options
     optJobs :: Maybe Int,
     optOffline :: Bool,
     optUpdateIndex :: Bool,
+    optUpdatedSince :: Maybe Day,
     optPrompt :: Bool,
     optPromptSeed :: Maybe Int,
     optPrintSucceeded :: Bool,
@@ -47,6 +50,14 @@ optionsParser =
     <*> OA.switch
       ( OA.long "update-index"
           <> OA.help "Fetch and cache a fresh Hackage index before testing"
+      )
+    <*> OA.optional
+      ( OA.option
+          dayReader
+          ( OA.long "updated-since"
+              <> OA.metavar "YYYY-MM-DD"
+              <> OA.help "Only test packages whose latest Hackage upload is on or after this date (default: five years ago)"
+          )
       )
     <*> OA.switch
       ( OA.long "prompt"
@@ -147,3 +158,10 @@ positiveIntReader = OA.eitherReader $ \raw ->
   case reads raw of
     [(n, "")] | n > 0 -> Right n
     _ -> Left "must be a positive integer"
+
+dayReader :: OA.ReadM Day
+dayReader =
+  OA.eitherReader $ \raw ->
+    case parseTimeM True defaultTimeLocale "%F" raw of
+      Just day -> Right day
+      Nothing -> Left "must be a date in YYYY-MM-DD format"

--- a/tooling/aihc-dev/app/hackage-progress/HackageProgress/Run.hs
+++ b/tooling/aihc-dev/app/hackage-progress/HackageProgress/Run.hs
@@ -2,9 +2,13 @@ module HackageProgress.Run (run) where
 
 import Aihc.Hackage.Index
   ( HackageIndexMode (..),
-    loadHackageIndex,
+    loadHackageIndexUpdatedSince,
   )
 import Control.Monad (when)
+import Data.Int (Int64)
+import Data.Time.Calendar (Day, addGregorianYearsClip)
+import Data.Time.Clock (UTCTime (..), getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import HackageProgress.CLI (Options (..), toStackageOptions)
 import StackageProgress.Run qualified as StackageProgressRun
 import System.Exit (exitFailure)
@@ -16,7 +20,8 @@ run opts = do
     hPutStrLn stderr "Cannot combine --offline with --update-index."
     exitFailure
 
-  indexResult <- loadHackageIndex Nothing (hackageIndexMode opts)
+  cutoff <- cutoffUnixTime opts
+  indexResult <- loadHackageIndexUpdatedSince Nothing (hackageIndexMode opts) cutoff
   packages <-
     case indexResult of
       Left err -> do
@@ -31,3 +36,15 @@ hackageIndexMode opts
   | optUpdateIndex opts = UpdateHackageIndex
   | optOffline opts = OfflineHackageIndex
   | otherwise = UseCachedHackageIndex
+
+cutoffUnixTime :: Options -> IO Int64
+cutoffUnixTime opts =
+  dayToUnixTime <$> maybe fiveYearsAgo pure (optUpdatedSince opts)
+
+fiveYearsAgo :: IO Day
+fiveYearsAgo =
+  addGregorianYearsClip (-5) . utctDay <$> getCurrentTime
+
+dayToUnixTime :: Day -> Int64
+dayToUnixTime day =
+  floor (utcTimeToPOSIXSeconds (UTCTime day 0))

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Index.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Index.hs
@@ -4,16 +4,20 @@
 module Aihc.Hackage.Index
   ( HackageIndexMode (..),
     loadHackageIndex,
+    loadHackageIndexUpdatedSince,
     parseHackageIndex,
+    parseHackageIndexUpdatedSince,
   )
 where
 
 import Aihc.Hackage.Cache (hackageIndexCacheFile)
 import Aihc.Hackage.Types (PackageSpec (..))
 import Codec.Archive.Tar qualified as Tar
+import Codec.Archive.Tar.Entry qualified as Tar
 import Codec.Compression.GZip qualified as GZip
 import Control.Exception (SomeException, displayException, try)
 import Data.ByteString.Lazy qualified as LBS
+import Data.Int (Int64)
 import Data.List (isSuffixOf)
 import Data.Map.Strict qualified as Map
 import Distribution.Parsec (simpleParsec)
@@ -38,22 +42,30 @@ data HackageIndexMode
 -- If no cache exists, the index is fetched unless 'OfflineHackageIndex' is
 -- requested.
 loadHackageIndex :: Maybe Manager -> HackageIndexMode -> IO (Either String [PackageSpec])
-loadHackageIndex mManager mode = do
+loadHackageIndex mManager mode =
+  fmap (>>= parseHackageIndex) (loadHackageIndexBytes mManager mode)
+
+-- | Load Hackage's package index, keeping only packages whose latest version
+-- was uploaded at or after the given Unix timestamp.
+loadHackageIndexUpdatedSince :: Maybe Manager -> HackageIndexMode -> Int64 -> IO (Either String [PackageSpec])
+loadHackageIndexUpdatedSince mManager mode cutoff =
+  fmap (>>= parseHackageIndexUpdatedSince cutoff) (loadHackageIndexBytes mManager mode)
+
+loadHackageIndexBytes :: Maybe Manager -> HackageIndexMode -> IO (Either String LBS.ByteString)
+loadHackageIndexBytes mManager mode = do
   cacheFile <- hackageIndexCacheFile
   hasCache <- doesFileExist cacheFile
-  indexBytes <-
-    case (mode, hasCache) of
-      (OfflineHackageIndex, False) ->
-        pure (Left "Hackage index missing from cache in offline mode")
-      (UseCachedHackageIndex, True) ->
-        Right <$> LBS.readFile cacheFile
-      (OfflineHackageIndex, True) ->
-        Right <$> LBS.readFile cacheFile
-      (UpdateHackageIndex, _) ->
-        fetchAndCache cacheFile
-      (UseCachedHackageIndex, False) ->
-        fetchAndCache cacheFile
-  pure (indexBytes >>= parseHackageIndex)
+  case (mode, hasCache) of
+    (OfflineHackageIndex, False) ->
+      pure (Left "Hackage index missing from cache in offline mode")
+    (UseCachedHackageIndex, True) ->
+      Right <$> LBS.readFile cacheFile
+    (OfflineHackageIndex, True) ->
+      Right <$> LBS.readFile cacheFile
+    (UpdateHackageIndex, _) ->
+      fetchAndCache cacheFile
+    (UseCachedHackageIndex, False) ->
+      fetchAndCache cacheFile
   where
     fetchAndCache cacheFile = do
       manager <- maybe (newManager tlsManagerSettings) pure mManager
@@ -66,7 +78,17 @@ loadHackageIndex mManager mode = do
 
 -- | Parse a compressed Hackage @01-index.tar.gz@ into latest package versions.
 parseHackageIndex :: LBS.ByteString -> Either String [PackageSpec]
-parseHackageIndex bytes =
+parseHackageIndex =
+  parseHackageIndexWith (const True)
+
+-- | Parse a compressed Hackage @01-index.tar.gz@ into latest package versions
+-- whose latest package entry was uploaded at or after the given Unix timestamp.
+parseHackageIndexUpdatedSince :: Int64 -> LBS.ByteString -> Either String [PackageSpec]
+parseHackageIndexUpdatedSince cutoff =
+  parseHackageIndexWith (\(_, uploadedAt) -> uploadedAt >= cutoff)
+
+parseHackageIndexWith :: ((Version, Int64) -> Bool) -> LBS.ByteString -> Either String [PackageSpec]
+parseHackageIndexWith keep bytes =
   case collectEntries Map.empty (Tar.read (GZip.decompress bytes)) of
     Left err -> Left err
     Right packages
@@ -74,13 +96,18 @@ parseHackageIndex bytes =
       | otherwise ->
           Right
             [ PackageSpec name (prettyShow version)
-            | (name, version) <- Map.toAscList packages
+            | (name, (version, uploadedAt)) <- Map.toAscList packages,
+              keep (version, uploadedAt)
             ]
   where
     collectEntry packages entry =
       case packageVersionFromEntryPath (Tar.entryPath entry) of
         Nothing -> packages
-        Just (name, version) -> Map.insertWith max name version packages
+        Just (name, version) ->
+          Map.insertWith newerVersion name (version, Tar.entryTime entry) packages
+
+    newerVersion new old =
+      if fst new > fst old then new else old
 
     collectEntries packages (Tar.Next entry rest) =
       collectEntries (collectEntry packages entry) rest

--- a/tooling/aihc-hackage/test/Spec.hs
+++ b/tooling/aihc-hackage/test/Spec.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Aihc.Hackage.Cabal qualified as HC
-import Aihc.Hackage.Index (parseHackageIndex)
+import Aihc.Hackage.Index (parseHackageIndex, parseHackageIndexUpdatedSince)
 import Aihc.Hackage.Stackage (parseSnapshotConstraints)
 import Aihc.Hackage.Types (PackageSpec (..))
 import Codec.Archive.Tar qualified as Tar
@@ -45,6 +45,11 @@ main =
             [ PackageSpec "alpha" "1.2.0",
               PackageSpec "beta" "0.1"
             ],
+      testCase "filters Hackage index packages by latest upload time" $ do
+        parseHackageIndexUpdatedSince 100 testHackageIndex
+          @?= Right
+            [ PackageSpec "alpha" "1.2.0"
+            ],
       testCase "generates Cabal Paths module as a normal source file" test_generatesPathsModule,
       testCase "collects exposed modules from active conditional library branches" test_collectsConditionalExposedModules,
       testCase "extracts active build tool dependency names" test_extractsBuildToolDependencyNames,
@@ -69,20 +74,23 @@ testHackageIndex :: LBS.ByteString
 testHackageIndex =
   GZip.compress $
     Tar.write
-      [ cabalEntry "alpha/1.0.0/alpha.cabal",
-        cabalEntry "alpha/1.2.0/alpha.cabal",
-        cabalEntry "alpha/1.1.0/alpha.cabal",
-        cabalEntry "beta/0.1/beta.cabal",
+      [ cabalEntryAt "alpha/1.0.0/alpha.cabal" 20,
+        cabalEntryAt "alpha/1.2.0/alpha.cabal" 100,
+        cabalEntryAt "alpha/1.1.0/alpha.cabal" 200,
+        cabalEntryAt "beta/0.1/beta.cabal" 99,
         cabalEntry "beta/0.2/not-beta.cabal",
         cabalEntry "preferred-versions"
       ]
   where
     cabalEntry path =
+      cabalEntryAt path 0
+
+    cabalEntryAt path uploadedAt =
       case Tar.toTarPath False path of
         Left err -> error ("invalid test tar path: " <> show err)
         Right tarPath ->
           let contents = LBS.fromStrict (BSC.pack "name: ignored\n")
-           in Tar.simpleEntry tarPath (Tar.NormalFile contents (LBS.length contents))
+           in (Tar.simpleEntry tarPath (Tar.NormalFile contents (LBS.length contents))) {Tar.entryTime = uploadedAt}
 
 test_generatesPathsModule :: Assertion
 test_generatesPathsModule =


### PR DESCRIPTION
## Summary

- filter parser-hackage-progress to packages whose latest Hackage index entry was uploaded within the last five years
- add timestamp-aware Hackage index parsing while preserving the existing unfiltered API
- cover upload-time filtering in the aihc-hackage test suite

## Impact

This keeps parser progress runs focused on packages that still parse with modern GHC-era syntax, avoiding stale Hackage packages whose latest releases are older than the five-year window.

Progress counts are intentionally not hard-coded in docs; the filtered package set is computed from the Hackage index at runtime.

## Validation

- `cabal test -v0 aihc-hackage:spec --test-options=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
