### PR TITLE
test(parser): add pragma corner fixtures

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/golden/module/pragma/empty-pragma.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/pragma/empty-pragma.yaml
@@ -1,0 +1,8 @@
+extensions: []
+input: |
+  {-##-}
+  module EmptyPragma where
+  x = 1
+ast: |-
+  Module {ModuleHead {"EmptyPragma"}, [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/pragma/language-no-cpp.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/pragma/language-no-cpp.yaml
@@ -1,0 +1,8 @@
+extensions: []
+input: |
+  {-# LANGUAGE NoCPP #-}
+  module LanguageNoCPP where
+  x = 1
+ast: |-
+  Module {ModuleHead {"LanguageNoCPP"}, [DisableExtension CPP], [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/pragma/options-glasgow-exts-magic-hash.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/pragma/options-glasgow-exts-magic-hash.yaml
@@ -1,0 +1,8 @@
+extensions: []
+input: |
+  {-# OPTIONS -fglasgow-exts #-}
+  module OptionsGlasgowExtsMagicHash where
+  x# = 42#
+ast: |-
+  Module {ModuleHead {"OptionsGlasgowExtsMagicHash"}, [ConstrainedClassMethods, DeriveDataTypeable, DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, EmptyDataDecls, ExistentialQuantification, ExplicitNamespaces, FlexibleContexts, FlexibleInstances, ForeignFunctionInterface, FunctionalDependencies, GeneralizedNewtypeDeriving, ImplicitParams, InterruptibleFFI, KindSignatures, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, ParallelListComp, PatternGuards, PostfixOperators, RankNTypes, RecursiveDo, ScopedTypeVariables, StandaloneDeriving, TypeOperators, TypeSynonymInstances, UnboxedTuples, UnicodeSyntax, UnliftedFFITypes], [DeclValue (PatternBind (PVar "x#") (EInt 42 TIntHash))]}
+status: pass


### PR DESCRIPTION
## Summary

- Add active module golden fixtures for empty pragma syntax (`{-##-}`), `OPTIONS -fglasgow-exts`, and `LANGUAGE NoCPP`.
- Pin `OPTIONS -fglasgow-exts` as enabling `MagicHash` by parsing hash-suffixed identifiers and literals without an explicit `LANGUAGE MagicHash`.
- Pin extension negation as `DisableExtension CPP` in the shorthand AST.

## Progress counts

- Parser golden module fixtures: +3 pass cases.
- README progress counts were not updated; they are cron-managed.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern empty-pragma --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern language-no-cpp --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern options-glasgow-exts-magic-hash --hide-successes"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
