### PR TITLE
refactor(parser): share report grammar helpers

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -41,6 +41,8 @@ module Aihc.Parser.Internal.Common
     contextItemParserWith,
     contextItemsParserWith,
     contextParserWith,
+    typedSignaturePrefixParser,
+    typedBindingOrSignatureParser,
     functionHeadParserWith,
     functionHeadParserWithBinder,
     functionBindValue,
@@ -680,6 +682,32 @@ contextItemsParserWith typeParser typeAtomParser =
 
 contextParserWith :: TokParser Type -> TokParser Type -> TokParser [Type]
 contextParserWith = contextItemsParserWith
+
+-- | Parse the shared @vars :: type@ prefix used by type signatures and typed
+-- bindings.
+typedSignaturePrefixParser :: TokParser ty -> TokParser ([UnqualifiedName], ty)
+typedSignaturePrefixParser typeParser = do
+  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
+  expectedTok TkReservedDoubleColon
+  ty <- typeParser
+  pure (names, ty)
+
+-- | Parse either a plain type signature or a typed binding that must be
+-- reinterpreted when followed by @=@ or guarded RHS syntax.
+typedBindingOrSignatureParser ::
+  TokParser ty ->
+  ([UnqualifiedName] -> ty -> a) ->
+  (UnqualifiedName -> ty -> TokParser a) ->
+  String ->
+  TokParser a
+typedBindingOrSignatureParser typeParser signatureCtor bindingCtor singleBinderMsg = do
+  (names, ty) <- typedSignaturePrefixParser typeParser
+  nextKind <- lexTokenKind <$> lookAhead anySingle
+  if nextKind == TkReservedEquals || nextKind == TkReservedPipe
+    then case names of
+      [name] -> bindingCtor name ty
+      _ -> fail singleBinderMsg
+    else pure (signatureCtor names ty)
 
 functionHeadParserWith :: TokParser Pattern -> TokParser Pattern -> TokParser (MatchHeadForm, UnqualifiedName, [Pattern])
 functionHeadParserWith = functionHeadParserWithBinder functionBinderNameParser infixOperatorNameParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -35,6 +35,10 @@ instanceOverlapPragmaParser =
 anyPragmaParser :: String -> TokParser Pragma
 anyPragmaParser expectedLabel = hiddenPragma expectedLabel Just
 
+-- | Report core:
+--
+-- > decl -> gendecl
+-- >      | (funlhs | pat) rhs
 declParser :: TokParser Decl
 declParser = pragmaDeclParser <|> ordinaryDeclParser
 
@@ -42,11 +46,15 @@ ordinaryDeclParser :: TokParser Decl
 ordinaryDeclParser = do
   (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
   exprFallback <- exprDeclEnabled
+  typeSigPrefix <- startsWithTypeSig
   let tokKind = lexTokenKind tok
       nextTokKind = lexTokenKind nextTok
       valueDecl
         | exprFallback = MP.try valueDeclParser <|> exprDeclParser
         | otherwise = valueDeclParser
+      sigOrValueDecl
+        | typeSigPrefix = typeSigOrPatternTypeSigDeclParser
+        | otherwise = valueDecl
   case tokKind of
     TkKeywordData ->
       case nextTokKind of
@@ -74,12 +82,12 @@ ordinaryDeclParser = do
     TkKeywordPattern -> patternSynonymParser
     TkVarId {} ->
       case nextTokKind of
-        TkReservedDoubleColon -> MP.try typeSigOrPatternTypeSigDeclParser <|> valueDecl
-        TkSpecialComma -> MP.try typeSigOrPatternTypeSigDeclParser <|> valueDecl
+        TkReservedDoubleColon -> sigOrValueDecl
+        TkSpecialComma -> sigOrValueDecl
         TkReservedEquals -> valueDecl
         _ -> nonBareVarPatternBindDeclParser <|> valueDecl
     _ ->
-      MP.try typeSigOrPatternTypeSigDeclParser
+      (if typeSigPrefix then typeSigOrPatternTypeSigDeclParser else MP.empty)
         <|> MP.try valueDeclParser
         <|> patternBindDeclParser
         <|> (if exprFallback then exprDeclParser else MP.empty)
@@ -126,6 +134,8 @@ exprDeclParser = DeclSplice <$> exprParser
 -- then dispatches based on the next token:
 -- - @::@ → standalone kind signature (must have zero type parameters)
 -- - @=@ → type synonym
+--
+-- > topdecl -> 'type' simpletype '=' type
 typeDeclarationParser :: TokParser Decl
 typeDeclarationParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
@@ -517,11 +527,13 @@ instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $
 
 -- ---------------------------------------------------------------------------
 
+-- | Report core general declaration:
+--
+-- > gendecl -> vars '::' [context '=>'] type
 typeSigDeclParser :: TokParser Decl
-typeSigDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
-  expectedTok TkReservedDoubleColon
-  DeclTypeSig names <$> typeParser
+typeSigDeclParser =
+  withSpanAnn (DeclAnn . mkAnnotation) $
+    uncurry DeclTypeSig <$> typedSignaturePrefixParser typeParser
 
 -- | Parse a type signature or a pattern-typed equation.
 --
@@ -536,25 +548,26 @@ typeSigDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
 -- reinterpreted as a pattern-typed equation; otherwise a plain type signature
 -- is returned.
 typeSigOrPatternTypeSigDeclParser :: TokParser Decl
-typeSigOrPatternTypeSigDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
-  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
-  expectedTok TkReservedDoubleColon
-  ty <- typeParser
-  nextKind <- lexTokenKind <$> lookAhead anySingle
-  if nextKind == TkReservedEquals || nextKind == TkReservedPipe
-    then case names of
-      [name] -> do
-        rhs <- equationRhsParser
-        let pat = PTypeSig (PVar name) ty
-        pure (DeclValue (PatternBind NoMultiplicityTag pat rhs))
-      _ -> fail "typed pattern bindings with '=' require exactly one binder"
-    else pure (DeclTypeSig names ty)
+typeSigOrPatternTypeSigDeclParser =
+  withSpanAnn (DeclAnn . mkAnnotation) $
+    typedBindingOrSignatureParser
+      typeParser
+      DeclTypeSig
+      ( \name ty -> do
+          rhs <- equationRhsParser
+          let pat = PTypeSig (PVar name) ty
+          pure (DeclValue (PatternBind NoMultiplicityTag pat rhs))
+      )
+      "typed pattern bindings with '=' require exactly one binder"
 
 defaultDeclParser :: TokParser Decl
 defaultDeclParser = do
   expectedTok TkKeywordDefault
   DeclDefault <$> parens (typeParser `MP.sepEndBy` expectedTok TkSpecialComma)
 
+-- | Report core general declaration:
+--
+-- > gendecl -> fixity [integer] ops
 fixityDeclParser :: TokParser Decl
 fixityDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   (parsedAssoc, prec, mNamespace, ops) <- fixityDeclPartsParser
@@ -605,6 +618,9 @@ fixityOperatorParser =
       expectedTok TkSpecialBacktick
       pure op
 
+-- | Report core:
+--
+-- > topdecl -> 'class' [scontext '=>'] tycls tyvar ['where' cdecls]
 classDeclParser :: TokParser Decl
 classDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordClass
@@ -649,11 +665,16 @@ whereClauseItemsParser itemParser = do
   expectedTok TkKeywordWhere
   bracedSemiSep itemParser <|> plainSemiSep1 itemParser <|> pure []
 
+-- | Report core:
+--
+-- > cdecl -> gendecl
+-- >       | (funlhs | var) rhs
 classDeclItemParser :: TokParser ClassDeclItem
 classDeclItemParser =
   classPragmaItemParser
     <|> do
       (tok, nextTok) <- lookAhead ((,) <$> anySingle <*> anySingle)
+      typeSigPrefix <- startsWithTypeSig
       case lexTokenKind tok of
         TkKeywordInfix -> classFixityItemParser
         TkKeywordInfixl -> classFixityItemParser
@@ -663,7 +684,7 @@ classDeclItemParser =
         TkKeywordType
           | lexTokenKind nextTok == TkKeywordInstance -> classDefaultTypeInstParser
         TkKeywordType -> MP.try classTypeFamilyDeclParser <|> classDefaultTypeInstShorthandParser
-        _ -> MP.try classTypeSigItemParser <|> classDefaultItemParser
+        _ -> (if typeSigPrefix then classTypeSigItemParser else classDefaultItemParser)
 
 classPragmaItemParser :: TokParser ClassDeclItem
 classPragmaItemParser =
@@ -686,6 +707,9 @@ classFixityItemParser = fixityItemParser (ClassItemAnn . mkAnnotation) ClassItem
 classDefaultItemParser :: TokParser ClassDeclItem
 classDefaultItemParser = valueItemParser (ClassItemAnn . mkAnnotation) ClassItemDefault
 
+-- | Report core:
+--
+-- > topdecl -> 'instance' [scontext '=>'] qtycls inst ['where' idecls]
 instanceDeclParser :: TokParser Decl
 instanceDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordInstance
@@ -732,11 +756,16 @@ instanceWhereClauseParser = do
     <|> plainSemiSep1 instanceDeclItemParser
     <|> pure []
 
+-- | Report core:
+--
+-- > idecl -> (funlhs | var) rhs
+-- >       | empty
 instanceDeclItemParser :: TokParser InstanceDeclItem
 instanceDeclItemParser =
   instancePragmaItemParser
     <|> do
       tok <- lookAhead anySingle
+      typeSigPrefix <- startsWithTypeSig
       case lexTokenKind tok of
         TkKeywordInfix -> instanceFixityItemParser
         TkKeywordInfixl -> instanceFixityItemParser
@@ -744,7 +773,7 @@ instanceDeclItemParser =
         TkKeywordData -> instanceDataFamilyInstParser
         TkKeywordNewtype -> instanceNewtypeFamilyInstParser
         TkKeywordType -> instanceTypeFamilyInstParser
-        _ -> MP.try instanceTypeSigItemParser <|> instanceValueItemParser
+        _ -> (if typeSigPrefix then instanceTypeSigItemParser else instanceValueItemParser)
 
 instancePragmaItemParser :: TokParser InstanceDeclItem
 instancePragmaItemParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $ do
@@ -764,10 +793,7 @@ instanceValueItemParser = valueItemParser (InstanceItemAnn . mkAnnotation) Insta
 -- Shared class/instance item helpers
 
 typeSigItemParser :: (SourceSpan -> a -> a) -> ([UnqualifiedName] -> Type -> a) -> TokParser a
-typeSigItemParser ann ctor = withSpanAnn ann $ do
-  names <- binderNameParser `MP.sepBy1` expectedTok TkSpecialComma
-  expectedTok TkReservedDoubleColon
-  ctor names <$> typeParser
+typeSigItemParser ann ctor = withSpanAnn ann $ uncurry ctor <$> typedSignaturePrefixParser typeParser
 
 fixityItemParser :: (SourceSpan -> a -> a) -> (FixityAssoc -> Maybe IEEntityNamespace -> Maybe Int -> [UnqualifiedName] -> a) -> TokParser a
 fixityItemParser ann ctor = withSpanAnn ann $ do
@@ -847,6 +873,9 @@ gadtDataDeclParser = do
   derivingClauses <- MP.many derivingClauseParser
   pure (constructors, derivingClauses)
 
+-- | Report core:
+--
+-- > topdecl -> 'data' [context '=>'] simpletype ['=' constrs] [deriving]
 dataDeclParser :: TokParser Decl
 dataDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordData
@@ -1049,6 +1078,9 @@ unboxedConDeclParser forallVars context = do
               let arity = 1 + 1 + length trailingPipes
               pure $ \span' -> DataConAnn (mkAnnotation span') (UnboxedSumCon forallVars context 1 arity firstField)
 
+-- | Report core:
+--
+-- > topdecl -> 'newtype' [context '=>'] simpletype '=' newconstr [deriving]
 newtypeDeclParser :: TokParser Decl
 newtypeDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   expectedTok TkKeywordNewtype
@@ -1162,6 +1194,8 @@ declContextParser = contextParserWith typeParser typeAtomParser
 -- | Parse a type/class declaration head, parameterised by the infix operator parser.
 -- Handles prefix (@T a b@), infix (@a op b@), parenthesised-infix (@(a op b) c@),
 -- and parenthesised-prefix (@(T a b) c@) forms.
+--
+-- > simpletype -> tycon tyvar_1 ... tyvar_k
 declHeadParserWith :: TokParser UnqualifiedName -> TokParser (BinderHead UnqualifiedName)
 declHeadParserWith opParser =
   MP.try parenthesizedInfixDeclHeadParser
@@ -1211,46 +1245,9 @@ typeSynonymOperatorParser =
       pure op
 
 typeFamilyHeadParser :: TokParser (TypeHeadForm, Type, [TyVarBinder])
-typeFamilyHeadParser =
-  MP.try parenthesizedInfixHeadParser
-    <|> MP.try infixHeadParser
-    <|> prefixHeadParser
-  where
-    prefixHeadParser = do
-      headType <- withSpan $ do
-        name <-
-          constructorNameParser
-            <|> (qualifyName Nothing <$> parens operatorUnqualifiedNameParser)
-        pure (\span' -> typeAnnSpan span' (TCon name Unpromoted))
-      params <- MP.many declTypeParamParser
-      pure (TypeHeadPrefix, headType, params)
-
-    infixHeadParser = do
-      lhs <- declTypeParamParser
-      op <- typeFamilyOperatorParser
-      rhs <- declTypeParamParser
-      let lhsType =
-            TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
-          rhsType =
-            TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs))
-      headType <- withSpan $ do
-        pure $ \span' -> typeAnnSpan span' (TInfix lhsType op Unpromoted rhsType)
-      pure (TypeHeadInfix, headType, [lhs, rhs])
-
-    parenthesizedInfixHeadParser = do
-      expectedTok TkSpecialLParen
-      lhs <- declTypeParamParser
-      op <- typeFamilyOperatorParser
-      rhs <- declTypeParamParser
-      expectedTok TkSpecialRParen
-      tailParams <- MP.many declTypeParamParser
-      let lhsType =
-            TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
-          rhsType =
-            TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs))
-      headType <- withSpan $ do
-        pure $ \span' -> typeAnnSpan span' (TInfix lhsType op Unpromoted rhsType)
-      pure (TypeHeadInfix, headType, [lhs, rhs] <> tailParams)
+typeFamilyHeadParser = withSpan $ do
+  binderHead <- declHeadParserWith (nameToUnqualified <$> typeFamilyOperatorParser)
+  pure (`binderHeadToTypeFamilyHead` binderHead)
 
 -- | Parse an operator for type family declarations.
 -- Unlike 'constructorOperatorParser', this accepts both constructor symbols (@:+:@)
@@ -1289,6 +1286,24 @@ classHeadParser = declHeadParserWith (nameToUnqualified <$> typeFamilyOperatorPa
 
 nameToUnqualified :: Name -> UnqualifiedName
 nameToUnqualified name = mkUnqualifiedName (nameType name) (nameText name)
+
+binderHeadToTypeFamilyHead :: SourceSpan -> BinderHead UnqualifiedName -> (TypeHeadForm, Type, [TyVarBinder])
+binderHeadToTypeFamilyHead span' binderHead =
+  case binderHead of
+    PrefixBinderHead name params ->
+      ( TypeHeadPrefix,
+        typeAnnSpan span' (TCon (qualifyName Nothing name) Unpromoted),
+        params
+      )
+    InfixBinderHead lhs op rhs tailParams ->
+      ( TypeHeadInfix,
+        typeAnnSpan span' (TInfix lhsType opName Unpromoted rhsType),
+        [lhs, rhs] <> tailParams
+      )
+      where
+        lhsType = TVar (mkUnqualifiedName NameVarId (tyVarBinderName lhs))
+        rhsType = TVar (mkUnqualifiedName NameVarId (tyVarBinderName rhs))
+        opName = qualifyName Nothing op
 
 explicitForallBinderParser :: TokParser TyVarBinder
 explicitForallBinderParser =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -15,7 +15,7 @@ where
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Cmd (cmdParser)
 import Aihc.Parser.Internal.Common
-import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser, typeSigDeclParser)
+import Aihc.Parser.Internal.Decl (declParser, fixityDeclParser, pragmaDeclParser)
 import Aihc.Parser.Internal.Pattern (apatParser, caseAltPatternParser, patParser, patternParser)
 import Aihc.Parser.Internal.Type (typeAtomParser, typeParser, typeSignatureParser)
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokenKind, lexTokenSpan, lexTokenText)
@@ -45,6 +45,9 @@ exprOrPatternBindParser exprP rhsP bindCtor exprCtor = do
       bindCtor pat <$> rhsP
     Nothing -> pure (exprCtor expr)
 
+-- | Report core:
+--
+-- > exp -> infixexp ['::' type]
 exprParser :: TokParser Expr
 exprParser =
   exprParserWithTypeSigParser typeSignatureParser
@@ -61,20 +64,16 @@ exprCoreParserWithoutTypeSig = do
     Just sccPragma -> EPragma sccPragma <$> exprCoreParserWithoutTypeSig
     Nothing -> exprCoreParserWithoutTypeSigBody
 
+-- | Report core:
+--
+-- > infixexp -> lexp qop infixexp
+-- >          | '-' infixexp
+-- >          | lexp
+--
+-- Extensions reuse the same infix chain shape by swapping the @lexp@
+-- parser that supplies operands.
 exprCoreParserWithoutTypeSigBody :: TokParser Expr
-exprCoreParserWithoutTypeSigBody = do
-  base <-
-    doExprParser
-      <|> mdoExprParser
-      <|> qualifiedDoExprParser
-      <|> qualifiedMdoExprParser
-      <|> ifExprParser
-      <|> letExprParser
-      <|> procExprParser
-      <|> lambdaExprParser
-      <|> infixExprParser
-  rest <- MP.many ((,) <$> infixOperatorParser <*> region "after infix operator" lexpParser)
-  pure (foldInfixL buildInfix base rest)
+exprCoreParserWithoutTypeSigBody = exprInfixChainParser lexpParser
 
 exprCoreParserWithTypeSigParser :: TokParser Type -> TokParser Expr
 exprCoreParserWithTypeSigParser typeSigParser = do
@@ -240,12 +239,11 @@ doRecStmtParser = withSpanAnn (DoAnn . mkAnnotation) $ do
   expectedTok TkKeywordRec
   DoRecStmt <$> bracedSemiSep1 doStmtParser
 
-infixExprParser :: TokParser Expr
-infixExprParser = infixExprParserWith lexpParser
-
-infixExprParserWith :: TokParser Expr -> TokParser Expr
-infixExprParserWith lexp = do
-  lhs <- MP.try negateExprParser <|> lexp
+-- | Shared infix-chain parser used by the report core and contextual
+-- expression variants such as TransformListComp.
+exprInfixChainParser :: TokParser Expr -> TokParser Expr
+exprInfixChainParser lexp = do
+  lhs <- lexp
   rest <-
     MP.many
       ( (,)
@@ -254,7 +252,16 @@ infixExprParserWith lexp = do
       )
   pure (foldInfixL buildInfix lhs rest)
 
--- | Parse an lexp (left-expression) - includes do, if, case, let, lambda, and fexp.
+-- | Report core:
+--
+-- > lexp -> '\\' apat_1 ... apat_n '->' exp
+-- >      | 'let' decls 'in' exp
+-- >      | 'if' exp [';'] 'then' exp [';'] 'else' exp
+-- >      | 'case' exp 'of' '{' alts '}'
+-- >      | 'do' '{' stmts '}'
+-- >      | fexp
+--
+-- Extensions add more block-like forms at this grammar level.
 lexpParser :: TokParser Expr
 lexpParser = do
   mSCC <- optionalHiddenPragma getSCCPragma
@@ -276,6 +283,15 @@ reportLexpParser appParser =
   lexpBlockParser
     <|> appParser
 
+-- | Report core block forms:
+--
+-- > lexp -> '\\' apat_1 ... apat_n '->' exp
+-- >      | 'let' decls 'in' exp
+-- >      | 'if' exp [';'] 'then' exp [';'] 'else' exp
+-- >      | 'case' exp 'of' '{' alts '}'
+-- >      | 'do' '{' stmts '}'
+--
+-- GHC extensions extend this set with @mdo@, qualified @do@, and @proc@.
 lexpBlockParser :: TokParser Expr
 lexpBlockParser =
   doExprParser
@@ -338,9 +354,14 @@ overloadedLabelExprParser =
       TkOverloadedLabel lbl repr -> Just (EOverloadedLabel lbl repr)
       _ -> Nothing
 
+-- | Report core:
+--
+-- > fexp -> [fexp] aexp
 appExprParser :: TokParser Expr
 appExprParser = appExprParserWith atomOrRecordExprParser
 
+-- | Shared application parser used by the report core and contextual
+-- variants.  The caller chooses the @aexp@-like atom parser.
 appExprParserWith :: TokParser Expr -> TokParser Expr
 appExprParserWith atomParser = withSpanAnn (EAnn . mkAnnotation) $ do
   first <- atomParser
@@ -446,6 +467,19 @@ recordFieldBindingParser = withSpan $ do
 
 -- | Parse the expression forms that correspond to the report's @aexp@
 -- production and can therefore be record construction/update bases.
+--
+-- > aexp -> qvar
+-- >      | gcon
+-- >      | literal
+-- >      | '(' exp ')'
+-- >      | '(' exp_1 ',' ... ',' exp_k ')'
+-- >      | '[' exp_1 ',' ... ',' exp_k ']'
+-- >      | '[' exp_1 [',' exp_2] '..' [exp_3] ']'
+-- >      | '[' exp '|' qual_1 ',' ... ',' qual_n ']'
+-- >      | '(' infixexp qop ')'
+-- >      | '(' qop infixexp ')'
+-- >      | qcon '{' fbind_1 ',' ... ',' fbind_n '}'
+-- >      | aexp<qcon> '{' fbind_1 ',' ... ',' fbind_n '}'
 recordBaseAtomExprParser :: TokParser Expr
 recordBaseAtomExprParser = do
   thAny <- thAnyEnabled
@@ -471,6 +505,11 @@ recordBaseAtomExprParser = do
         <|> varExprParser
 
 -- | Parse an atom without record construction/update syntax.
+--
+-- > aexp -> qvar | gcon | literal | '(' exp ')' | ...
+--
+-- This variant also admits extension-only atoms such as block arguments and
+-- explicit namespace syntax when the corresponding extensions are enabled.
 atomExprParser :: TokParser Expr
 atomExprParser = do
   blockArgsEnabled <- isExtensionEnabled BlockArguments
@@ -576,6 +615,11 @@ operatorExprNameParser =
 rhsParser :: TokParser (Rhs Expr)
 rhsParser = label "right-hand side" (caseRhsParserWithBodyParser exprParser)
 
+-- | Report core:
+--
+-- > rhs   -> '=' exp ['where' decls]
+-- >       | gdrhs ['where' decls]
+-- > gdrhs -> guards '=' exp [gdrhs]
 equationRhsParser :: TokParser (Rhs Expr)
 equationRhsParser = label "equation right-hand side" (rhsParserWithBodyParser RhsArrowEquation exprParser)
 
@@ -639,6 +683,10 @@ guardedRhsParserWithBodyParser arrowKind bodyParser = withSpan $ do
 
 -- | Parse a guard qualifier. The 'RhsArrowKind' controls whether guard
 -- expressions may carry a bare top-level type signature before the RHS arrow.
+--
+-- > guard -> pat '<-' infixexp
+-- >       | 'let' decls
+-- >       | infixexp
 guardQualifierParser :: RhsArrowKind -> TokParser GuardQualifier
 guardQualifierParser arrowKind = do
   tok <- lookAhead anySingle
@@ -1011,26 +1059,16 @@ compTransformExprParser =
       compTransformExprWithoutTypeSigParser
 
 -- | Parse the core of a TransformListComp expression (without type signature suffix).
+--
+-- This reuses the normal @infixexp@ ladder, but with an @aexp@ parser that
+-- treats bare @by@ and @using@ as terminators rather than variable atoms.
 compTransformExprWithoutTypeSigParser :: TokParser Expr
-compTransformExprWithoutTypeSigParser = do
-  base <-
-    doExprParser
-      <|> mdoExprParser
-      <|> qualifiedDoExprParser
-      <|> qualifiedMdoExprParser
-      <|> ifExprParser
-      <|> letExprParser
-      <|> procExprParser
-      <|> lambdaExprParser
-      <|> compTransformInfixExprParser
-  rest <- MP.many ((,) <$> infixOperatorParser <*> compTransformLexpParser)
-  pure (foldInfixL buildInfix base rest)
+compTransformExprWithoutTypeSigParser = exprInfixChainParser compTransformLexpParser
 
+-- | TransformListComp still uses the report @lexp@ layering; only its atom
+-- parser changes.
 compTransformLexpParser :: TokParser Expr
 compTransformLexpParser = lexpBaseParser compTransformAppExprParser
-
-compTransformInfixExprParser :: TokParser Expr
-compTransformInfixExprParser = infixExprParserWith compTransformLexpParser
 
 compTransformAppExprParser :: TokParser Expr
 compTransformAppExprParser = appExprParserWith compTransformAtomOrRecordExprParser
@@ -1061,6 +1099,9 @@ compLetStmtParser :: TokParser CompStmt
 compLetStmtParser = withSpanAnn (CompAnn . mkAnnotation) $ do
   CompLetDecls <$> parseLetDeclsStmtParser
 
+-- | Report core:
+--
+-- > lexp -> '\\' apat_1 ... apat_n '->' exp
 lambdaExprParser :: TokParser Expr
 lambdaExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkReservedBackslash
@@ -1085,6 +1126,9 @@ lambdaExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
     bracedCaseAlts = bracedSemiSep caseAltParser
     bracedLambdaCaseAlts = bracedSemiSep lambdaCaseAltParser
 
+-- | Report core:
+--
+-- > lexp -> 'let' decls 'in' exp
 letExprParser :: TokParser Expr
 letExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   decls <- parseLetDeclsParser
@@ -1096,32 +1140,32 @@ whereClauseParser = do
   expectedTok TkKeywordWhere
   bracedDeclsMaybeEmpty
 
+-- | Report core local declarations:
+--
+-- > decl -> gendecl
+-- >      | (funlhs | pat) rhs
 localDeclsParser :: TokParser Decl
-localDeclsParser =
+localDeclsParser = do
+  typeSigPrefix <- startsWithTypeSig
   pragmaDeclParser
     <|> implicitParamDeclParser
     <|> fixityDeclParser
-    <|> MP.try localTypeSigDeclsParser
+    <|> (if typeSigPrefix then localTypeSigDeclsParser else MP.empty)
     <|> MP.try localFunctionDeclParser
     <|> localPatternDeclParser
 
 localTypeSigDeclsParser :: TokParser Decl
-localTypeSigDeclsParser = do
-  sig <- typeSigDeclParser
-  let (names, ty) =
-        case peelDeclAnn sig of
-          DeclTypeSig sigNames sigTy -> (sigNames, sigTy)
-          _ -> error "typeSigDeclParser must produce DeclTypeSig"
-  nextKind <- lexTokenKind <$> lookAhead anySingle
-  if nextKind == TkReservedEquals || nextKind == TkReservedPipe
-    then case names of
-      [name] -> do
-        rhs <- equationRhsParser
-        let pat = PTypeSig (PVar name) ty
-        pure (DeclValue (PatternBind NoMultiplicityTag pat rhs))
-      _ ->
-        fail "local typed bindings with '=' or guards require exactly one binder"
-    else pure sig
+localTypeSigDeclsParser =
+  withSpanAnn (DeclAnn . mkAnnotation) $
+    typedBindingOrSignatureParser
+      typeParser
+      DeclTypeSig
+      ( \name ty -> do
+          rhs <- equationRhsParser
+          let pat = PTypeSig (PVar name) ty
+          pure (DeclValue (PatternBind NoMultiplicityTag pat rhs))
+      )
+      "local typed bindings with '=' or guards require exactly one binder"
 
 localFunctionDeclParser :: TokParser Decl
 localFunctionDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Pattern.hs
@@ -21,6 +21,10 @@ import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
 import Text.Megaparsec (anySingle, lookAhead, (<|>))
 import Text.Megaparsec qualified as MP
 
+-- | Report core:
+--
+-- > pat -> lpat qconop pat
+-- >     | lpat
 patternParser :: TokParser Pattern
 patternParser = patternParserWithTypeSigParser typeParser
 
@@ -39,6 +43,8 @@ patternParserWithTypeSigParser typeSigParser =
 -- rhs@ is accepted because the signature is parenthesized into an atomic
 -- pattern.  Use the report @pat@ level here so the outer @::@ is left for the
 -- case RHS parser, which then rejects it.
+-- | Case alternatives intentionally use the report @pat@ level rather than
+-- the outer typed-pattern wrapper.
 caseAltPatternParser :: TokParser Pattern
 caseAltPatternParser = patParser
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -40,12 +40,18 @@ thSpliceTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
     bareSpliceBody = withSpanAnn (EAnn . mkAnnotation) $ do
       EVar <$> identifierNameParser
 
+-- | Report core plus outer extension forms:
+--
+-- > type -> btype ['->' type]
 typeParser :: TokParser Type
 typeParser = label "type" $ forallTypeParser <|> kindSigTypeParser
 
+-- | Type syntax accepted after expression signatures. This keeps the same
+-- report core while allowing outer @forall@ and context forms.
 typeSignatureParser :: TokParser Type
 typeSignatureParser = label "type" $ forallSignatureTypeParser <|> contextOrFunSignatureTypeParser
 
+-- | Extension form wrapping the report core with a kind annotation.
 kindSigTypeParser :: TokParser Type
 kindSigTypeParser =
   optionalSuffix
@@ -53,6 +59,9 @@ kindSigTypeParser =
     TKindSig
     contextOrFunTypeParser
 
+-- | Extension form:
+--
+-- > forall a_1 ... a_n . type
 forallSignatureTypeParser :: TokParser Type
 forallSignatureTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
   telescope <- forallTelescopeParser
@@ -64,29 +73,30 @@ contextOrFunSignatureTypeParser = do
   if isContextType then contextSignatureTypeParser else typeFunSignatureParser
 
 contextSignatureTypeParser :: TokParser Type
-contextSignatureTypeParser = do
-  constraints <- contextItemsParserWith typeSignatureParser typeAtomParser
-  expectedTok TkReservedDoubleArrow
-  TContext constraints <$> typeSignatureParser
+contextSignatureTypeParser = contextTypeParserWith typeSignatureParser
 
+-- | Report core plus extension infix-type support:
+--
+-- > type -> btype ['->' type]
 typeFunSignatureParser :: TokParser Type
-typeFunSignatureParser = do
-  lhs <- typeInfixParser
-  mArrow <- MP.optional arrowKindParser
-  case mArrow of
-    Nothing -> pure lhs
-    Just arrowKind -> TFun arrowKind lhs <$> typeSignatureParser
+typeFunSignatureParser = typeFunParserWith typeSignatureParser
 
 contextOrFunTypeParser :: TokParser Type
 contextOrFunTypeParser = do
   isContextType <- startsWithContextType
   if isContextType then contextTypeParser else typeFunParser
 
+-- | Extension form:
+--
+-- > forall a_1 ... a_n . type
 forallTypeParser :: TokParser Type
 forallTypeParser = withSpanAnn (TAnn . mkAnnotation) $ do
   telescope <- forallTelescopeParser
   TForall telescope <$> typeParser
 
+-- | Extension form:
+--
+-- > forall -> 'forall' binder_1 ... binder_n ('.' | '->')
 forallTelescopeParser :: TokParser ForallTelescope
 forallTelescopeParser = do
   expectedTok TkKeywordForall
@@ -122,21 +132,31 @@ forallBinderParser =
           )
 
 contextTypeParser :: TokParser Type
-contextTypeParser = do
-  constraints <- contextItemsParser
-  expectedTok TkReservedDoubleArrow
-  TContext constraints <$> typeParser
+contextTypeParser = contextTypeParserWith typeParser
 
 contextItemsParser :: TokParser [Type]
 contextItemsParser = contextItemsParserWith typeParser typeAtomParser
 
+contextTypeParserWith :: TokParser Type -> TokParser Type
+contextTypeParserWith rhsParser = do
+  constraints <- contextItemsParserWith rhsParser typeAtomParser
+  expectedTok TkReservedDoubleArrow
+  TContext constraints <$> rhsParser
+
+-- | Report core plus extension infix-type support:
+--
+-- > type -> btype ['->' type]
+-- > btype -> [btype] atype
 typeFunParser :: TokParser Type
-typeFunParser = do
+typeFunParser = typeFunParserWith typeParser
+
+typeFunParserWith :: TokParser Type -> TokParser Type
+typeFunParserWith rhsParser = do
   lhs <- typeInfixParser
   mArrow <- MP.optional arrowKindParser
   case mArrow of
     Nothing -> pure lhs
-    Just arrowKind -> TFun arrowKind lhs <$> typeParser
+    Just arrowKind -> TFun arrowKind lhs <$> rhsParser
 
 -- | Parse an arrow annotation and consume the @->@ token.
 -- Handles @->@ (unrestricted), @⊸@ (linear), @%1 ->@ (linear), and @%m ->@
@@ -170,6 +190,9 @@ multiplicityToArrowKind ty =
     TTypeLit (TypeLitInteger 1 _) -> ArrowLinear
     _ -> ArrowExplicit ty
 
+-- | Extension layer over the report's @btype@ chain:
+--
+-- > btype -> [btype] atype
 typeInfixParser :: TokParser Type
 typeInfixParser = do
   lhs <- typeAppParser
@@ -244,6 +267,9 @@ typeInfixOperatorParser =
           TkQConSym modQual sym -> Just (mkName (Just modQual) NameConSym sym, Promoted)
           _ -> Nothing
 
+-- | Report core:
+--
+-- > btype -> [btype] atype
 typeAppParser :: TokParser Type
 typeAppParser = do
   first <- typeAtomParser
@@ -265,6 +291,16 @@ applyTypeAppArg :: Type -> Either Type Type -> Type
 applyTypeAppArg fn (Left ty) = TTypeApp fn ty
 applyTypeAppArg fn (Right ty) = TApp fn ty
 
+-- | Report core:
+--
+-- > atype -> gtycon
+-- >       | tyvar
+-- >       | '(' type_1 ',' ... ',' type_k ')'
+-- >       | '[' type ']'
+-- >       | '(' type ')'
+--
+-- This parser also admits extension atoms such as promoted types,
+-- quasi-quotes, splices, wildcards, and implicit-parameter types.
 typeAtomParser :: TokParser Type
 typeAtomParser = do
   thAny <- thAnyEnabled


### PR DESCRIPTION
## Summary
- factor shared parser helpers for typed signatures, typed bindings, and report-shaped expression/type grammar ladders to reduce duplicated parsing code
- reuse the shared helpers across expression, declaration, and type parsing, including declaration dispatch that now prefers non-consuming signature probes over speculative reparsing
- add BNF snippet comments to the core expression, pattern, type, and declaration parsers so the implementation is easier to compare against the Haskell report

## Validation
- just fmt
- just check

## Progress
- parser simplification work advanced by consolidating repeated report-grammar parsing paths and documenting their BNF anchors inline