### PR TITLE
fix(resolve): reassociate expression operators by fixity

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -401,6 +401,7 @@ interfaceModuleScope modu =
       scopeConstructors = interfaceModuleConstructors modu,
       scopeRecordFields = interfaceModuleRecordFields modu,
       scopeMethods = interfaceModuleMethods modu,
+      scopeFixities = Map.empty,
       scopeQualifiedModules = Map.empty
     }
 
@@ -556,7 +557,7 @@ parsePredJson =
       other -> fail ("unknown predicate tag: " <> T.unpack other)
 
 emptyScope :: Scope
-emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
+emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
 
 mapLeft :: (a -> b) -> Either a c -> Either b c
 mapLeft f value =

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -49,6 +49,7 @@ test-suite spec
     aeson,
     aihc-fc,
     aihc-parser,
+    aihc-resolve,
     aihc-tc,
     base >=4.16 && <5,
     bytestring,

--- a/components/aihc-fc/common/FcEvalGolden.hs
+++ b/components/aihc-fc/common/FcEvalGolden.hs
@@ -33,6 +33,7 @@ import Aihc.Parser.Syntax
     mkUnqualifiedName,
     parseExtensionName,
   )
+import Aihc.Resolve (ResolveResult (..), collectModuleExports, resolveWithDeps)
 import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), TcType (..), TyCon (..))
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
@@ -141,46 +142,60 @@ evaluateFcEvalCase tc =
   case parseInputs tc of
     Left errMsg -> classifyFailure tc errMsg
     Right (modules, expr) ->
-      let evalModule = combineModules modules expr
-          result = desugarModuleWithTcResult (syntheticTcResult evalModule) evalModule
-       in if dsSuccess result
-            then case evalProgramBinding evalBindingName (dsProgram result) >>= renderRawValue of
-              Right actual -> classifySuccess tc (T.unpack actual)
-              Left err -> classifyFailure tc ("eval error: " <> show err)
-            else classifyFailure tc ("desugar error: " <> unlines (dsErrors result))
+      let (depModules, evalModule) = combineModules modules expr
+          depExports = collectModuleExports depModules
+          resolved = resolveWithDeps depExports [evalModule]
+       in case resolved of
+            ResolveResult {resolvedModules = [resolvedModule], resolveErrors = []} ->
+              let result = desugarModuleWithTcResult (syntheticTcResult resolvedModule) resolvedModule
+               in if dsSuccess result
+                    then case evalProgramBinding evalBindingName (dsProgram result) >>= renderRawValue of
+                      Right actual -> classifySuccess tc (T.unpack actual)
+                      Left err -> classifyFailure tc ("eval error: " <> show err)
+                    else classifyFailure tc ("desugar error: " <> unlines (dsErrors result))
+            ResolveResult {resolveErrors} ->
+              classifyFailure tc ("resolve error: " <> show resolveErrors)
 
 parseInputs :: FcEvalCase -> Either String ([Module], Expr)
 parseInputs tc = do
-  modules <- mapM parseOneModule (evalCaseModules tc)
+  modules <- mapM (parseOneModuleWithExtensions (evalCaseExtensions tc)) (evalCaseModules tc)
   expr <- parseOneExpr (evalCaseExpression tc)
   pure (modules, expr)
   where
+    parseOneExpr input =
+      case parseExpr (config (evalCasePath tc <> ":expression")) input of
+        ParseOk expr -> Right expr
+        ParseErr err -> Left ("parse expression error: " <> show err)
     config source =
       defaultConfig
         { parserSourceName = source,
           parserExtensions = evalCaseExtensions tc
         }
-    parseOneModule input =
-      let cfg = config (T.unpack (T.takeWhile (/= '\n') input))
-          (errs, ast) = parseModule cfg input
-       in if null errs
-            then Right ast
-            else Left ("parse module error: " <> show errs)
-    parseOneExpr input =
-      case parseExpr (config (evalCasePath tc <> ":expression")) input of
-        ParseOk expr -> Right expr
-        ParseErr err -> Left ("parse expression error: " <> show err)
 
-combineModules :: [Module] -> Expr -> Module
+parseOneModuleWithExtensions :: [Extension] -> Text -> Either String Module
+parseOneModuleWithExtensions extensions input =
+  parseOneModule (T.unpack (T.takeWhile (/= '\n') input)) extensions input
+
+parseOneModule :: FilePath -> [Extension] -> Text -> Either String Module
+parseOneModule sourceName extensions input =
+  let cfg =
+        defaultConfig
+          { parserSourceName = sourceName,
+            parserExtensions = extensions
+          }
+      (errs, ast) = parseModule cfg input
+   in if null errs
+        then Right ast
+        else Left ("parse module error: " <> show errs)
+
+combineModules :: [Module] -> Expr -> ([Module], Module)
 combineModules modules expr =
   case modules of
-    [] -> emptyEvalModule expr
-    firstModule : _ ->
-      firstModule
-        { moduleLanguagePragmas = concatMap moduleLanguagePragmas modules,
-          moduleImports = concatMap moduleImports modules,
-          moduleDecls = concatMap moduleDecls modules <> [evalDecl expr]
-        }
+    [] -> ([], emptyEvalModule expr)
+    _ ->
+      let depModules = init modules
+          evalModule = last modules
+       in (depModules, evalModule {moduleDecls = moduleDecls evalModule <> [evalDecl expr]})
 
 emptyEvalModule :: Expr -> Module
 emptyEvalModule expr =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -26,6 +26,7 @@ import Aihc.Parser.Syntax
     Name (..),
     Pattern (..),
     Rhs (..),
+    TupleFlavor (..),
     UnqualifiedName (..),
     ValueDecl (..),
     peelDeclAnn,
@@ -251,6 +252,8 @@ dsExpr (EInfix lhs op rhs) =
   dsExpr (EApp (EApp (EVar op) lhs) rhs)
 dsExpr (EList elems) =
   foldr consList nilList <$> mapM dsExpr elems
+dsExpr (ETuple Boxed elems) =
+  dsTuple elems
 dsExpr (EParen inner) = dsExpr inner
 dsExpr (EAnn _ann inner) = dsExpr inner
 dsExpr (EIf cond thenE elseE) = do
@@ -370,6 +373,24 @@ dsLocalGroup var group =
 dsStringLiteral :: Text -> DsM FcExpr
 dsStringLiteral text =
   pure (T.foldr consChar nilList text)
+
+dsTuple :: [Maybe Expr] -> DsM FcExpr
+dsTuple elems = do
+  elems' <- mapM dsMaybeTupleElem elems
+  pure (foldl' FcApp (tupleConExpr (length elems')) elems')
+
+dsMaybeTupleElem :: Maybe Expr -> DsM FcExpr
+dsMaybeTupleElem (Just expr) = dsExpr expr
+dsMaybeTupleElem Nothing = do
+  v <- freshVar "_tuple_section" unknownTy
+  pure (FcVar v)
+
+tupleConExpr :: Int -> FcExpr
+tupleConExpr arity =
+  FcVar (Var (tupleConName arity) (Unique (-20 - arity)) unknownTy)
+
+tupleConName :: Int -> Text
+tupleConName arity = "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
 
 consChar :: Char -> FcExpr -> FcExpr
 consChar char =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -59,6 +59,7 @@ primitiveEnv =
   Map.fromList
     [ ("[]", VConstructor "[]" []),
       (":", VConstructor ":" []),
+      ("(,)", VConstructor "(,)" []),
       ("++", VPrim "++" 2 [])
     ]
 
@@ -224,6 +225,9 @@ renderRawValue value = do
   case forced of
     VLit lit -> pure (renderLiteral lit)
     VConstructor name [] -> pure name
+    VConstructor name args | isTupleConstructor name (length args) -> do
+      renderedArgs <- mapM renderRawArg args
+      pure ("(" <> T.intercalate "," renderedArgs <> ")")
     VConstructor name args -> do
       renderedArgs <- mapM renderRawArg args
       pure (T.unwords (name : renderedArgs))
@@ -237,5 +241,10 @@ renderRawArg value = do
   rendered <- renderRawValue forced
   pure $
     case forced of
+      VConstructor name args | isTupleConstructor name (length args) -> rendered
       VConstructor _ (_ : _) -> "(" <> rendered <> ")"
       _ -> rendered
+
+isTupleConstructor :: Text -> Int -> Bool
+isTupleConstructor name arity =
+  arity >= 2 && name == "(" <> T.replicate (arity - 1) "," <> ")"

--- a/components/aihc-fc/test/Test/Fixtures/eval/infix-precedence-both-sides.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/infix-precedence-both-sides.yaml
@@ -1,0 +1,14 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    a + b = (a,b)
+    a * b = (a,b)
+    infixl 6 +
+    infixl 7 *
+output: |
+  (('a','b'),('c','d'))
+expression: |
+  'a' * 'b' + 'c' * 'd'
+status: pass
+reason: groups higher-precedence operators on both sides of a lower-precedence operator

--- a/components/aihc-fc/test/Test/Fixtures/eval/infix-precedence-right.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/infix-precedence-right.yaml
@@ -1,0 +1,14 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    a + b = (a,b)
+    a * b = (a,b)
+    infixl 6 +
+    infixl 7 *
+output: |
+  ('a',('b','c'))
+expression: |
+  'a' + 'b' * 'c'
+status: pass
+reason: groups higher-precedence right operand before lower-precedence operator

--- a/components/aihc-fc/test/Test/Fixtures/eval/infixl-same-precedence.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/infixl-same-precedence.yaml
@@ -1,0 +1,12 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    a * b = (a,b)
+    infixl 7 *
+output: |
+  (('a','b'),'c')
+expression: |
+  'a' * 'b' * 'c'
+status: pass
+reason: keeps same-precedence left-associative operators grouped to the left

--- a/components/aihc-fc/test/Test/Fixtures/eval/infixr-same-precedence.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/infixr-same-precedence.yaml
@@ -1,0 +1,12 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    a + b = (a,b)
+    infixr 5 +
+output: |
+  ('a',('b','c'))
+expression: |
+  'a' + 'b' + 'c'
+status: pass
+reason: reassociates same-precedence right-associative operators to the right

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-cons-right-assoc.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-cons-right-assoc.yaml
@@ -1,0 +1,14 @@
+extensions: []
+modules:
+  - |
+    module Prelude where
+    data List a = [] | a : [a]
+    infixr 5 :
+  - |
+    module Test where
+output: |
+  : 'a' (: 'b' (: 'c' []))
+expression: |
+  'a' : 'b' : 'c' : []
+status: pass
+reason: reassociates list cons to the right after name resolution

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -11,6 +11,7 @@ module Aihc.Resolve
     resolve,
     resolveWithDeps,
     extractInterface,
+    OperatorFixity (..),
     Scope (..),
     ModuleExports,
     collectModuleExports,
@@ -38,6 +39,7 @@ import Aihc.Parser.Syntax
     DoStmt (..),
     Expr (..),
     FieldDecl (..),
+    FixityAssoc (..),
     ForallTelescope (..),
     GadtBody (..),
     GuardQualifier (..),
@@ -80,7 +82,7 @@ import Control.Monad (foldM, mapAndUnzipM)
 import Data.Data (Data, cast, gmapQ)
 import Data.List (find, mapAccumL)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 
 resolve :: [Module] -> ResolveResult
@@ -346,7 +348,7 @@ resolveDeclCore termDefinition decl =
       DeclClass <$> resolveClassDecl classDecl
     DeclDefault tys ->
       DeclDefault <$> mapM resolveType tys
-    DeclFixity {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclFixity {} -> pure decl
     DeclRoleAnnotation {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclPragma {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclPatSyn {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
@@ -503,14 +505,14 @@ resolveExpr expr =
       ELambdaCase <$> mapM resolveCaseAlt alts
     ELambdaCases alts ->
       ELambdaCases <$> mapM resolveLambdaCaseAlt alts
-    EInfix left op right ->
-      EInfix <$> resolveExpr left <*> pure op <*> resolveExpr right
+    EInfix {} ->
+      resolveInfixExpr expr
     ENegate inner ->
       ENegate <$> resolveExpr inner
     ESectionL inner op ->
-      ESectionL <$> resolveExpr inner <*> pure op
+      ESectionL <$> resolveExpr inner <*> resolveTermUseAtName op
     ESectionR op inner ->
-      ESectionR op <$> resolveExpr inner
+      ESectionR <$> resolveTermUseAtName op <*> resolveExpr inner
     ELetDecls decls body -> do
       (binderAnnotations, localScope) <- allocateLocalDeclBinders decls
       decls' <- extendScope localScope (resolveBoundDecls binderAnnotations Map.empty decls)
@@ -670,7 +672,7 @@ bindPattern pat =
       let binderName = mkUnqualifiedName NameVarId (tyVarBinderName binder)
       resolvedName <- freshLocal binderName
       binder' <- traverseTyVarBinderKind binder
-      let binderScope = Scope Map.empty (Map.singleton (tyVarBinderName binder) resolvedName) Map.empty Map.empty Map.empty Map.empty
+      let binderScope = Scope Map.empty (Map.singleton (tyVarBinderName binder) resolvedName) Map.empty Map.empty Map.empty Map.empty Map.empty
       pure (binderScope, PTypeBinder binder')
     PTypeSyntax form ty -> do
       ty' <- resolveType ty
@@ -724,7 +726,7 @@ bindPattern pat =
           )
           fields
       wildcardEntries <- bindRecordWildcardFields name fields wildcard
-      let wildcardScope = Scope (Map.fromList wildcardEntries) Map.empty Map.empty Map.empty Map.empty Map.empty
+      let wildcardScope = Scope (Map.fromList wildcardEntries) Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
       pure (foldr unionScope wildcardScope fieldScopes, PRecord name fields' wildcard)
     PTypeSig inner ty -> do
       (scope, inner') <- bindPattern inner
@@ -744,7 +746,7 @@ bindPattern pat =
 
 termScope :: Text -> ResolvedName -> Scope
 termScope key resolvedName =
-  Scope (Map.singleton key resolvedName) Map.empty Map.empty Map.empty Map.empty Map.empty
+  Scope (Map.singleton key resolvedName) Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
 
 resolvePatternDefinition :: TermDefinition -> Pattern -> ResolveM Pattern
 resolvePatternDefinition termDefinition pat =
@@ -1077,6 +1079,102 @@ resolveTermUse name = do
   sp <- currentSpan
   scope <- currentScope
   pure (resolveNameTo sp ResolutionNamespaceTerm (resolveTermName scope name) name)
+
+resolveTermUseAtName :: Name -> ResolveM Name
+resolveTermUseAtName name = do
+  sp <- currentSpan
+  scope <- currentScope
+  pure (resolveNameTo (spanStartNameSpan sp (nameText name)) ResolutionNamespaceTerm (resolveTermName scope name) name)
+
+data ResolvedInfixOp = ResolvedInfixOp
+  { resolvedInfixName :: !Name,
+    resolvedInfixFixity :: !OperatorFixity
+  }
+
+resolveInfixExpr :: Expr -> ResolveM Expr
+resolveInfixExpr expr = do
+  let (operands, names) = flattenInfixExpr expr
+  operands' <- mapM resolveExpr operands
+  names' <- mapM resolveTermUseAtName names
+  let fallbackExpr = buildLeftInfixExpr expr operands' names'
+  reassociateResolvedInfixExpr operands' names' fallbackExpr
+
+reassociateResolvedInfixExpr :: [Expr] -> [Name] -> Expr -> ResolveM Expr
+reassociateResolvedInfixExpr operands names fallbackExpr = do
+  scope <- currentScope
+  sp <- currentSpan
+  let ops = [ResolvedInfixOp name (resolveFixityName scope name) | name <- names]
+  case ambiguousInfixOp ops of
+    Just op ->
+      pure $
+        annotateExpr
+          ( ResolutionAnnotation
+              (spanStartNameSpan sp (nameText (resolvedInfixName op)))
+              (nameText (resolvedInfixName op))
+              ResolutionNamespaceTerm
+              (ResolvedError "ambiguous fixity")
+          )
+          fallbackExpr
+    Nothing ->
+      pure (rebuildInfixExpr fallbackExpr operands ops)
+
+buildLeftInfixExpr :: Expr -> [Expr] -> [Name] -> Expr
+buildLeftInfixExpr fallbackExpr [] _ = fallbackExpr
+buildLeftInfixExpr _ (operand : operands) ops =
+  foldl' (\left (op, right) -> EInfix left op right) operand (zip ops operands)
+
+flattenInfixExpr :: Expr -> ([Expr], [Name])
+flattenInfixExpr expr =
+  case expr of
+    EInfix left op right ->
+      let (operands, ops) = flattenInfixExpr left
+       in (operands <> [right], ops <> [op])
+    _ -> ([expr], [])
+
+ambiguousInfixOp :: [ResolvedInfixOp] -> Maybe ResolvedInfixOp
+ambiguousInfixOp ops =
+  listToMaybe
+    [ right
+    | (leftIndex, left) <- indexed,
+      let leftPrec = infixPrecedence left,
+      (rightIndex, right) <- drop (leftIndex + 1) indexed,
+      infixPrecedence right == leftPrec,
+      all ((> leftPrec) . infixPrecedence) [between | (index, between) <- indexed, index > leftIndex, index < rightIndex],
+      incompatibleSamePrecedence left right
+    ]
+  where
+    indexed = zip [0 :: Int ..] ops
+
+incompatibleSamePrecedence :: ResolvedInfixOp -> ResolvedInfixOp -> Bool
+incompatibleSamePrecedence left right =
+  infixAssoc left /= infixAssoc right || infixAssoc left == Infix || infixAssoc right == Infix
+
+infixAssoc :: ResolvedInfixOp -> FixityAssoc
+infixAssoc = operatorFixityAssoc . resolvedInfixFixity
+
+infixPrecedence :: ResolvedInfixOp -> Int
+infixPrecedence = operatorFixityPrecedence . resolvedInfixFixity
+
+rebuildInfixExpr :: Expr -> [Expr] -> [ResolvedInfixOp] -> Expr
+rebuildInfixExpr fallbackExpr [] _ = fallbackExpr
+rebuildInfixExpr _ (operand : operands) ops =
+  let (expr, _, _) = parseInfixExpr 0 operand operands ops
+   in expr
+
+parseInfixExpr :: Int -> Expr -> [Expr] -> [ResolvedInfixOp] -> (Expr, [Expr], [ResolvedInfixOp])
+parseInfixExpr minPrec lhs operands ops =
+  case ops of
+    op : restOps
+      | infixPrecedence op >= minPrec,
+        rhsOperand : restOperands <- operands ->
+          let nextMinPrec =
+                case infixAssoc op of
+                  InfixR -> infixPrecedence op
+                  Infix -> infixPrecedence op + 1
+                  InfixL -> infixPrecedence op + 1
+              (rhs, operands', ops') = parseInfixExpr nextMinPrec rhsOperand restOperands restOps
+           in parseInfixExpr minPrec (EInfix lhs (resolvedInfixName op) rhs) operands' ops'
+    _ -> (lhs, operands, ops)
 
 resolveTypeUse :: Name -> ResolveM Name
 resolveTypeUse name = do

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -2,6 +2,7 @@
 
 module Aihc.Resolve.Scope
   ( Scope (..),
+    OperatorFixity (..),
     ModuleExports,
     collectModuleExports,
     moduleScope,
@@ -12,8 +13,10 @@ module Aihc.Resolve.Scope
     insertType,
     lookupTerm,
     lookupType,
+    lookupFixity,
     resolveTermName,
     resolveTypeName,
+    resolveFixityName,
     collectPatVarBinders,
     tupleConName,
     unboxedSumConName,
@@ -30,8 +33,10 @@ import Aihc.Parser.Syntax
     DataDecl (..),
     Decl (..),
     FieldDecl (..),
+    FixityAssoc (..),
     GadtBody (..),
     IEBundledMember (..),
+    IEEntityNamespace (..),
     ImportDecl (..),
     ImportItem (..),
     ImportSpec (..),
@@ -67,8 +72,15 @@ data Scope = Scope
     scopeConstructors :: Map.Map Text [Text],
     scopeRecordFields :: Map.Map Text [Text],
     scopeMethods :: Map.Map Text [Text],
+    scopeFixities :: Map.Map Text OperatorFixity,
     scopeQualifiedModules :: Map.Map Text Scope
   }
+
+data OperatorFixity = OperatorFixity
+  { operatorFixityAssoc :: !FixityAssoc,
+    operatorFixityPrecedence :: !Int
+  }
+  deriving (Eq, Show)
 
 type ModuleExports = Map.Map Text Scope
 
@@ -86,14 +98,15 @@ topLevelScope modu =
     moduleKeyText = moduleKey modu
     qualify = ResolvedTopLevel . qualifyName (Just moduleKeyText)
     addDecl scope decl =
-      let DeclExports termNames typeNames constructors recordFields methods = declExportedNames decl
+      let DeclExports termNames typeNames constructors recordFields methods fixities = declExportedNames decl
           scope' = foldl' (\acc name -> insertTerm (renderUnqualifiedName name) (qualify name) acc) scope termNames
           scope'' = foldl' (\acc name -> insertType (renderUnqualifiedName name) (qualify name) acc) scope' typeNames
           scope''' = scope'' {scopeConstructors = constructors `Map.union` scopeConstructors scope''}
           scope'''' = scope''' {scopeRecordFields = recordFields `Map.union` scopeRecordFields scope'''}
-       in scope'''' {scopeMethods = methods `Map.union` scopeMethods scope''''}
+          scope''''' = scope'''' {scopeMethods = methods `Map.union` scopeMethods scope''''}
+       in scope''''' {scopeFixities = fixities `Map.union` scopeFixities scope'''''}
 
-data DeclExports = DeclExports [UnqualifiedName] [UnqualifiedName] (Map.Map Text [Text]) (Map.Map Text [Text]) (Map.Map Text [Text])
+data DeclExports = DeclExports [UnqualifiedName] [UnqualifiedName] (Map.Map Text [Text]) (Map.Map Text [Text]) (Map.Map Text [Text]) (Map.Map Text OperatorFixity)
 
 declExportedNames :: Decl -> DeclExports
 declExportedNames decl =
@@ -101,10 +114,20 @@ declExportedNames decl =
     DeclAnn _ inner -> declExportedNames inner
     DeclValue valueDecl ->
       case valueDecl of
-        FunctionBind name _ -> DeclExports [name] [] Map.empty Map.empty Map.empty
+        FunctionBind name _ -> DeclExports [name] [] Map.empty Map.empty Map.empty Map.empty
         PatternBind _ pat _ ->
-          DeclExports (map snd (collectPatVarBinders NoSourceSpan pat)) [] Map.empty Map.empty Map.empty
-    DeclTypeSig names _ -> DeclExports names [] Map.empty Map.empty Map.empty
+          DeclExports (map snd (collectPatVarBinders NoSourceSpan pat)) [] Map.empty Map.empty Map.empty Map.empty
+    DeclTypeSig names _ -> DeclExports names [] Map.empty Map.empty Map.empty Map.empty
+    DeclFixity assoc mNamespace mPrec ops
+      | mNamespace /= Just IEEntityNamespaceType ->
+          DeclExports
+            []
+            []
+            Map.empty
+            Map.empty
+            Map.empty
+            (Map.fromList [(renderUnqualifiedName op, OperatorFixity assoc (fromMaybe 9 mPrec)) | op <- ops])
+      | otherwise -> DeclExports [] [] Map.empty Map.empty Map.empty Map.empty
     DeclClass classDecl ->
       let className = binderHeadName (classDeclHead classDecl)
           methodNames = classDeclMethodNames (classDeclItems classDecl)
@@ -114,6 +137,7 @@ declExportedNames decl =
             Map.empty
             Map.empty
             (Map.singleton (renderUnqualifiedName className) (map renderUnqualifiedName methodNames))
+            Map.empty
     DeclTypeData dataDecl ->
       dataDeclExports (dataDeclHead dataDecl) (dataDeclConstructors dataDecl)
     DeclData dataDecl ->
@@ -122,9 +146,9 @@ declExportedNames decl =
       let typeName = binderHeadName (newtypeDeclHead newtypeDecl)
           termNames = maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl)
           constructorNames = maybe [] dataConDeclConstructorNames (newtypeDeclConstructor newtypeDecl)
-       in DeclExports termNames [typeName] (constructorMap typeName constructorNames) (maybe Map.empty (recordFieldMap . (: [])) (newtypeDeclConstructor newtypeDecl)) Map.empty
-    DeclTypeSyn typeSynDecl -> DeclExports [] [binderHeadName (typeSynHead typeSynDecl)] Map.empty Map.empty Map.empty
-    _ -> DeclExports [] [] Map.empty Map.empty Map.empty
+       in DeclExports termNames [typeName] (constructorMap typeName constructorNames) (maybe Map.empty (recordFieldMap . (: [])) (newtypeDeclConstructor newtypeDecl)) Map.empty Map.empty
+    DeclTypeSyn typeSynDecl -> DeclExports [] [binderHeadName (typeSynHead typeSynDecl)] Map.empty Map.empty Map.empty Map.empty
+    _ -> DeclExports [] [] Map.empty Map.empty Map.empty Map.empty
 
 dataDeclExports :: BinderHead UnqualifiedName -> [DataConDecl] -> DeclExports
 dataDeclExports headBinder constructors =
@@ -134,6 +158,7 @@ dataDeclExports headBinder constructors =
         [typeName]
         (constructorMap typeName (concatMap dataConDeclConstructorNames constructors))
         (recordFieldMap constructors)
+        Map.empty
         Map.empty
 
 constructorMap :: UnqualifiedName -> [UnqualifiedName] -> Map.Map Text [Text]
@@ -258,6 +283,7 @@ filterImportSpec maybeSpec scope =
               scopeConstructors = Map.filterWithKey (\n _ -> n `elem` allowedTypes) (scopeConstructors scope),
               scopeRecordFields = Map.filterWithKey (\n _ -> n `elem` allowedTerms) (scopeRecordFields scope),
               scopeMethods = Map.filterWithKey (\n _ -> n `elem` allowedTypes) (scopeMethods scope),
+              scopeFixities = Map.filterWithKey (\n _ -> n `elem` allowedTerms) (scopeFixities scope),
               scopeQualifiedModules = scopeQualifiedModules scope
             }
     Just ImportSpec {importSpecHiding = True, importSpecItems} ->
@@ -325,7 +351,7 @@ moduleKey :: Module -> Text
 moduleKey modu = fromMaybe (T.pack "Main") (moduleName modu)
 
 emptyScope :: Scope
-emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
+emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
 
 -- | Scope containing all wired-in Haskell built-ins that have no defining
 -- source module but act like regular names during name resolution.
@@ -352,6 +378,7 @@ builtinScope =
       scopeConstructors = Map.empty,
       scopeRecordFields = Map.empty,
       scopeMethods = Map.empty,
+      scopeFixities = Map.empty,
       scopeQualifiedModules = Map.empty
     }
   where
@@ -410,6 +437,7 @@ unionScope left right =
       scopeConstructors = scopeConstructors left `Map.union` scopeConstructors right,
       scopeRecordFields = scopeRecordFields left `Map.union` scopeRecordFields right,
       scopeMethods = scopeMethods left `Map.union` scopeMethods right,
+      scopeFixities = scopeFixities left `Map.union` scopeFixities right,
       scopeQualifiedModules = scopeQualifiedModules left `Map.union` scopeQualifiedModules right
     }
 
@@ -437,6 +465,13 @@ lookupType name scope =
     name
     (scopeTypes scope)
 
+lookupFixity :: Text -> Scope -> OperatorFixity
+lookupFixity name scope =
+  Map.findWithDefault defaultOperatorFixity name (scopeFixities scope)
+
+defaultOperatorFixity :: OperatorFixity
+defaultOperatorFixity = OperatorFixity InfixL 9
+
 filterScopeByNames :: (Text -> Bool) -> Scope -> Scope
 filterScopeByNames keep scope =
   Scope
@@ -445,8 +480,19 @@ filterScopeByNames keep scope =
       scopeConstructors = Map.filterWithKey (\name _ -> keep name) (scopeConstructors scope),
       scopeRecordFields = Map.filterWithKey (\name _ -> keep name) (scopeRecordFields scope),
       scopeMethods = Map.filterWithKey (\name _ -> keep name) (scopeMethods scope),
+      scopeFixities = Map.filterWithKey (\name _ -> keep name) (scopeFixities scope),
       scopeQualifiedModules = scopeQualifiedModules scope
     }
+
+resolveFixityName :: Scope -> Name -> OperatorFixity
+resolveFixityName scope name =
+  case nameQualifier name of
+    Just qualifier ->
+      case Map.lookup qualifier (scopeQualifiedModules scope) of
+        Nothing -> defaultOperatorFixity
+        Just qualifiedScope -> lookupFixity (nameText name) qualifiedScope
+    Nothing ->
+      lookupFixity (nameText name) scope
 
 collectPatVarBinders :: SourceSpan -> Pattern -> [(SourceSpan, UnqualifiedName)]
 collectPatVarBinders ambient pat =

--- a/components/aihc-resolve/test/Test/Fixtures/golden/constructor-pattern.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/constructor-pattern.yaml
@@ -23,6 +23,7 @@ expected:
     - "5:1-5:8 sumTree => (value) Main.sumTree"
     - "5:15-5:16 l => (value) Local 1 l"
     - "5:17-5:18 r => (value) Local 2 r"
+    - "5:20-5:21 + => (value) Error unbound"
     - "5:22-5:29 sumTree => (value) Main.sumTree"
     - "5:30-5:31 l => (value) Local 1 l"
     - "5:34-5:41 sumTree => (value) Main.sumTree"
@@ -42,10 +43,11 @@ annotated:
     └─ v Main     │    └─ v 0
                   └─ v 0
     sumTree (Node l r) = sumTree l + sumTree r
-    └─ v Main     │ │    │       │   │       └─ v 2
-                  │ │    │       │   └─ v Main
-                  │ │    │       └─ v 1
-                  │ │    └─ v Main
+    └─ v Main     │ │  │ │       │   │       └─ v 2
+                  │ │  │ │       │   └─ v Main
+                  │ │  │ │       └─ v 1
+                  │ │  │ └─ v Main
+                  │ │  └─ v Error unbound
                   │ └─ v 2
                   └─ v 1
 status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/infix-ambiguous-same-precedence.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/infix-ambiguous-same-precedence.yaml
@@ -1,0 +1,33 @@
+extensions: []
+modules:
+  - |
+    module Main where
+    infix 5 +++
+    (+++) x y = x
+    bad = 'a' +++ 'b' +++ 'c'
+expected:
+  Main:
+    - "3:1-3:4 +++ => (value) Main.+++"
+    - "3:7-3:8 x => (value) Local 0 x"
+    - "3:9-3:10 y => (value) Local 1 y"
+    - "3:13-3:14 x => (value) Local 0 x"
+    - "4:1-4:4 bad => (value) Main.bad"
+    - "4:5-4:8 +++ => (value) Error ambiguous fixity"
+    - "4:5-4:8 +++ => (value) Main.+++"
+    - "4:5-4:8 +++ => (value) Main.+++"
+annotated:
+  - |
+    module Main where
+    infix 5 +++
+    (+++) x y = x
+    │     │ │   └─ v 0
+    │     │ └─ v 1
+    │     └─ v 0
+    └─ v Main
+    bad = 'a' +++ 'b' +++ 'c'
+    │   └─ v Main
+    │   └─ v Main
+    │   └─ v Error ambiguous fixity
+    └─ v Main
+status: pass
+reason: reports ambiguous same-precedence non-associative operators

--- a/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
@@ -1,0 +1,33 @@
+extensions: []
+modules:
+  - |
+    module Prelude where
+    data List a = [] | a : [a]
+    infixr 5 :
+  - |
+    module Main where
+    xs = 'a' : 'b' : 'c' : []
+expected:
+  Main:
+    - "2:1-2:3 xs => (value) Main.xs"
+    - "2:4-2:5 : => (value) Prelude.:"
+    - "2:4-2:5 : => (value) Prelude.:"
+    - "2:4-2:5 : => (value) Prelude.:"
+  Prelude:
+    - "2:6-2:10 List => (type) Prelude.List"
+    - "2:20-2:21 : => (value) Prelude.:"
+annotated:
+  - |
+    module Main where
+    xs = 'a' : 'b' : 'c' : []
+    │  └─ v Prelude
+    │  └─ v Prelude
+    │  └─ v Prelude
+    └─ v Main
+  - |
+    module Prelude where
+    data List a = [] | a : [a]
+         └─ t Prelude  └─ v Prelude
+    infixr 5 :
+status: pass
+reason: reassociates list cons to the right using Prelude fixity

--- a/components/aihc-resolve/test/Test/Fixtures/golden/pattern-bindings.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/pattern-bindings.yaml
@@ -15,9 +15,11 @@ expected:
     - "2:16-2:17 g => (value) Local 1 g"
     - "2:18-2:19 x => (value) Local 2 x"
     - "3:1-3:3 .* => (value) Main..*"
+    - "3:6-3:7 . => (value) Main.."
     - "3:8-3:11 . => (value) Main.."
     - "3:14-3:17 . => (value) Main.."
     - "4:1-4:4 .** => (value) Main..**"
+    - "4:7-4:8 . => (value) Main.."
     - "4:9-4:12 . => (value) Main.."
     - "4:15-4:19 .* => (value) Main..*"
 annotated:
@@ -32,12 +34,14 @@ annotated:
     │└─ v 0
     └─ v Main
     (.*) = (.) . (.)
-    │      │     └─ v Main
-    │      └─ v Main
+    │    │ │     └─ v Main
+    │    │ └─ v Main
+    │    └─ v Main
     └─ v Main
     (.**) = (.) . (.*)
-    │       │     └─ v Main
-    │       └─ v Main
+    │     │ │     └─ v Main
+    │     │ └─ v Main
+    │     └─ v Main
     └─ v Main
 status: pass
 reason: ""

--- a/components/aihc-resolve/test/Test/Fixtures/golden/qualified-import-with-alias.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/qualified-import-with-alias.yaml
@@ -14,6 +14,7 @@ expected:
     - "3:1-3:11 maxRetries => (value) Data.Config.maxRetries"
   Main:
     - "3:1-3:10 useConfig => (value) Main.useConfig"
+    - "3:11-3:12 + => (value) Error unbound"
     - "3:13-3:33 defaultConfig => (value) Data.Config.defaultConfig"
     - "3:36-3:53 maxRetries => (value) Data.Config.maxRetries"
 annotated:
@@ -27,5 +28,6 @@ annotated:
     module Main where
     import qualified Data.Config as Config
     useConfig = Config.defaultConfig + Config.maxRetries
-    └─ v Main   └─ v Data.Config       └─ v Data.Config
+    └─ v Main │ └─ v Data.Config       └─ v Data.Config
+              └─ v Error unbound
 status: pass

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -1,11 +1,16 @@
 module Prelude
   ( Char,
+    List (..),
     String,
     (++),
   )
 where
 
 data Char
+
+data List a = [] | a : [a]
+
+infixr 5 :
 
 type String = [Char]
 

--- a/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
@@ -166,6 +166,7 @@ bootModuleToScope bmi =
       scopeConstructors = bmiConstructors bmi,
       scopeRecordFields = Map.empty,
       scopeMethods = bmiMethods bmi,
+      scopeFixities = Map.empty,
       scopeQualifiedModules = Map.empty
     }
   where

--- a/tooling/aihc-dev/test/Test/ResolvePackage.hs
+++ b/tooling/aihc-dev/test/Test/ResolvePackage.hs
@@ -117,6 +117,7 @@ mkScope terms types =
       scopeConstructors = Map.empty,
       scopeRecordFields = Map.empty,
       scopeMethods = Map.empty,
+      scopeFixities = Map.empty,
       scopeQualifiedModules = Map.empty
     }
   where

--- a/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
+++ b/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
@@ -115,6 +115,7 @@ mkScope moduleName terms types =
       scopeConstructors = Map.empty,
       scopeRecordFields = Map.empty,
       scopeMethods = Map.empty,
+      scopeFixities = Map.empty,
       scopeQualifiedModules = Map.empty
     }
   where


### PR DESCRIPTION
## Summary
- Add `List(..)` to the aihc-base Prelude with list constructors and `infixr 5 :`.
- Track expression operator fixities in `aihc-resolve`, resolve infix operator names, reassociate expression chains after name resolution, and report ambiguous same-precedence chains.
- Keep builtin resolver terms separate from source fixities: `:` remains a builtin term fallback, but its right-associative fixity is sourced from parsed Prelude exports.
- Run FC eval fixtures through name resolution; fixture modules before the last are treated as dependency modules, so installed tests do not depend on repo-relative source paths.
- Add tuple expression desugaring/evaluation support needed by fixity eval fixtures that return nested pairs.

## Progress Counts
- `aihc-resolve` golden fixtures: +2 (`list-cons-right-assoc`, `infix-ambiguous-same-precedence`).
- `aihc-fc` eval fixtures: +5 (`list-cons-right-assoc`, `infixr-same-precedence`, `infixl-same-precedence`, `infix-precedence-right`, `infix-precedence-both-sides`).

## CI Fix
- Removed the installed-test filesystem dependency on `../../core-libs/aihc-base/src/Prelude.hs`.
- The list-cons eval fixture now includes a parsed `Prelude` dependency module that defines `infixr 5 :`.

## CodeRabbit
- Latest `coderabbit review --prompt-only`: no findings.

## Validation
- `cabal test -v0 aihc-resolve:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
- `nix flake check`
