### PR TITLE
feat(base): add Bool module

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -12,18 +12,22 @@ module Aihc.Fc.Desugar
   )
 where
 
-import Aihc.Fc.Desugar.Expr (DsM, DsState (..), dsMatches, freshUnique, lookupType)
+import Aihc.Fc.Desugar.Expr (DsM, DsState (..), dsMatches, dsRhs, freshUnique, lookupType)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
   ( DataDecl (..),
     Decl (..),
+    Expr,
     Match (..),
     Module (..),
+    Pattern (..),
+    Rhs,
     UnqualifiedName (..),
     ValueDecl (..),
     binderHeadName,
     peelDeclAnn,
+    unqualifiedNameText,
   )
 import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), renderTcType, typecheckModule)
 import Aihc.Tc.Types (TcType (..), TyCon (..))
@@ -93,21 +97,30 @@ dsDataDeclM dd = do
       cons = map (\c -> let (n, arity) = dsDataConPure c in (n, replicate arity (TcTyCon (TyCon "?" 0) []))) (dataDeclConstructors dd)
   pure (FcData tyName [] cons)
 
--- | A group of function bind declarations (possibly multi-equation).
-data DeclGroup = DeclGroup
-  { dgName :: !Text,
-    dgMatches :: ![Match]
-  }
+-- | A group of top-level value declarations.
+data DeclGroup
+  = DeclFunction !Text ![Match]
+  | DeclPattern !Text !(Rhs Expr)
 
--- | Group consecutive FunctionBind declarations with the same name.
+dgName :: DeclGroup -> Text
+dgName group =
+  case group of
+    DeclFunction name _ -> name
+    DeclPattern name _ -> name
+
+-- | Group consecutive FunctionBind declarations with the same name and keep
+-- simple top-level pattern binds.
 groupFunctionBinds :: [Decl] -> [DeclGroup]
 groupFunctionBinds [] = []
 groupFunctionBinds (d : ds) = case extractFunBind d of
   Just (name, matches) ->
     let (sameNameDecls, rest) = span (hasSameName name) ds
         allMatches = matches ++ concatMap (maybe [] snd . extractFunBind) sameNameDecls
-     in DeclGroup name allMatches : groupFunctionBinds rest
-  Nothing -> groupFunctionBinds ds
+     in DeclFunction name allMatches : groupFunctionBinds rest
+  Nothing ->
+    case extractPatternBind d of
+      Just group -> group : groupFunctionBinds ds
+      Nothing -> groupFunctionBinds ds
 
 -- | Extract function bind info from a declaration.
 extractFunBind :: Decl -> Maybe (Text, [Match])
@@ -122,11 +135,29 @@ hasSameName name d = case extractFunBind d of
   Just (n, _) -> n == name
   Nothing -> False
 
+extractPatternBind :: Decl -> Maybe DeclGroup
+extractPatternBind decl =
+  case peelDeclAnn decl of
+    DeclValue (PatternBind _ pat rhs) ->
+      DeclPattern <$> barePatternName pat <*> pure rhs
+    _ -> Nothing
+
+barePatternName :: Pattern -> Maybe Text
+barePatternName pat =
+  case pat of
+    PVar name -> Just (unqualifiedNameText name)
+    PAnn _ inner -> barePatternName inner
+    PParen inner -> barePatternName inner
+    _ -> Nothing
+
 -- | Desugar a function binding group.
 dsGroup :: DeclGroup -> DsM FcTopBind
 dsGroup grp = do
   ty <- lookupType (dgName grp)
   u <- freshUnique
   let var = Var (dgName grp) u ty
-  body <- dsMatches ty (dgMatches grp)
+  body <-
+    case grp of
+      DeclFunction _ matches -> dsMatches ty matches
+      DeclPattern _ rhs -> dsRhs rhs
   pure (FcTopBind (FcNonRec var body))

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -8,6 +8,7 @@
 module Aihc.Fc.Desugar.Expr
   ( dsExpr,
     dsMatches,
+    dsRhs,
     DsM,
     DsState (..),
     freshUnique,

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -49,7 +49,8 @@ evalProgramBinding name program =
       [(varName var, VThunk env expr)]
     topBindingValues (FcTopBind (FcRec bindings)) =
       [(varName var, VThunk env expr) | (var, expr) <- bindings]
-    topBindingValues FcData {} = []
+    topBindingValues (FcData _ _ constructors) =
+      [(conName, VConstructor conName []) | (conName, _) <- constructors]
 
 evalExpr :: FcExpr -> Either EvalError Value
 evalExpr = evalWithEnv primitiveEnv

--- a/components/aihc-fc/test/Test/Fixtures/eval/bool-and.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/bool-and.yaml
@@ -1,0 +1,12 @@
+extensions: []
+dependencies: [aihc-base]
+modules:
+  - |
+    module Test where
+    loop = loop
+output: |
+  (((False,False),(False,True)),False)
+expression: |
+  (((False && False, False && True), (True && False, True && True)), False && loop)
+status: pass
+reason: evaluates Prelude Bool conjunction truth table and left short-circuiting from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/eval/bool-constructors.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/bool-constructors.yaml
@@ -1,0 +1,11 @@
+extensions: []
+dependencies: [aihc-base]
+modules:
+  - |
+    module Test where
+output: |
+  (False,True)
+expression: |
+  (False, True)
+status: pass
+reason: evaluates Prelude Bool data constructors from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/eval/bool-not.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/bool-not.yaml
@@ -1,0 +1,11 @@
+extensions: []
+dependencies: [aihc-base]
+modules:
+  - |
+    module Test where
+output: |
+  (True,False)
+expression: |
+  (not False, not True)
+status: pass
+reason: evaluates Prelude Bool negation from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/eval/bool-or.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/bool-or.yaml
@@ -1,0 +1,12 @@
+extensions: []
+dependencies: [aihc-base]
+modules:
+  - |
+    module Test where
+    loop = loop
+output: |
+  (((False,True),(True,True)),True)
+expression: |
+  (((False || False, False || True), (True || False, True || True)), True || loop)
+status: pass
+reason: evaluates Prelude Bool disjunction truth table and left short-circuiting from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/eval/bool-otherwise.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/bool-otherwise.yaml
@@ -1,0 +1,11 @@
+extensions: []
+dependencies: [aihc-base]
+modules:
+  - |
+    module Test where
+output: |
+  True
+expression: |
+  otherwise
+status: pass
+reason: evaluates Prelude otherwise as True from aihc-base

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/data-bool-core-lib.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/data-bool-core-lib.yaml
@@ -1,0 +1,34 @@
+extensions: []
+input: |
+  module Data.Bool
+    ( Bool (False, True),
+      (&&),
+      not,
+      otherwise,
+      (||),
+    )
+  where
+
+  data Bool = False | True
+
+  infixr 3 &&
+
+  (&&) :: Bool -> Bool -> Bool
+  False && _ = False
+  True && x = x
+
+  not :: Bool -> Bool
+  not False = True
+  not True = False
+
+  otherwise :: Bool
+  otherwise = True
+
+  infixr 2 ||
+
+  (||) :: Bool -> Bool -> Bool
+  False || x = x
+  True || _ = True
+ast: |-
+  Module {ModuleHead {"Data.Bool", [ExportWith{"Bool", [IEBundledMember{"False"}, IEBundledMember{"True"}]}, ExportVar{"&&"}, ExportVar{"not"}, ExportVar{"otherwise"}, ExportVar{"||"}]}, [DeclData (DataDecl {Prefix "Bool", [PrefixCon {UnqualifiedName {"False"}}, PrefixCon {UnqualifiedName {"True"}}]}), DeclFixity InfixR Nothing 3 [UnqualifiedName {"&&"}], DeclTypeSig ["&&"] (TFun (TCon "Bool") (TFun (TCon "Bool") (TCon "Bool"))), DeclValue (FunctionBind "&&" [Match {MatchHeadInfix, [PCon "False" [], PWildcard], EVar "False"}]), DeclValue (FunctionBind "&&" [Match {MatchHeadInfix, [PCon "True" [], PVar "x"], EVar "x"}]), DeclTypeSig ["not"] (TFun (TCon "Bool") (TCon "Bool")), DeclValue (FunctionBind "not" [Match {MatchHeadPrefix, [PCon "False" []], EVar "True"}]), DeclValue (FunctionBind "not" [Match {MatchHeadPrefix, [PCon "True" []], EVar "False"}]), DeclTypeSig ["otherwise"] (TCon "Bool"), DeclValue (PatternBind (PVar "otherwise") (EVar "True")), DeclFixity InfixR Nothing 2 [UnqualifiedName {"||"}], DeclTypeSig ["||"] (TFun (TCon "Bool") (TFun (TCon "Bool") (TCon "Bool"))), DeclValue (FunctionBind "||" [Match {MatchHeadInfix, [PCon "False" [], PVar "x"], EVar "x"}]), DeclValue (FunctionBind "||" [Match {MatchHeadInfix, [PCon "True" [], PWildcard], EVar "True"}])]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/prelude-bool-reexports.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/prelude-bool-reexports.yaml
@@ -1,0 +1,31 @@
+extensions: []
+input: |
+  module Prelude
+    ( Bool (..),
+      Char,
+      List (..),
+      String,
+      (&&),
+      (++),
+      not,
+      otherwise,
+      (||),
+    )
+  where
+
+  import Data.Bool (Bool (..), not, otherwise, (&&), (||))
+
+  data Char
+
+  data List a = [] | a : [a]
+
+  infixr 5 :
+
+  type String = [Char]
+
+  (++) :: [a] -> [a] -> [a]
+  (++) [] ys = ys
+  (++) (x : xs) ys = x : (xs ++ ys)
+ast: |-
+  Module {ModuleHead {"Prelude", [ExportAll{"Bool"}, ExportAbs{"Char"}, ExportAll{"List"}, ExportAbs{"String"}, ExportVar{"&&"}, ExportVar{"++"}, ExportVar{"not"}, ExportVar{"otherwise"}, ExportVar{"||"}]}, [ImportDecl {"Data.Bool", ImportSpec {[ImportItemAll{UnqualifiedName {"Bool"}}, ImportItemVar{UnqualifiedName {"not"}}, ImportItemVar{UnqualifiedName {"otherwise"}}, ImportItemVar{UnqualifiedName {"&&"}}, ImportItemVar{UnqualifiedName {"||"}}]}}], [DeclData (DataDecl {Prefix "Char"}), DeclData (DataDecl {Prefix "List" [TyVarBinder {"a"}], [ListCon {}, InfixCon {BangType {TVar "a"}, UnqualifiedName {":"}, BangType {TList [TVar "a"]}}]}), DeclFixity InfixR Nothing 5 [UnqualifiedName {":"}], DeclTypeSyn (TypeSynDecl {Prefix "String", TList [TCon "Char"]}), DeclTypeSig ["++"] (TFun (TList [TVar "a"]) (TFun (TList [TVar "a"]) (TList [TVar "a"]))), DeclValue (FunctionBind "++" [Match {MatchHeadPrefix, [PList [], PVar "ys"], EVar "ys"}]), DeclValue (FunctionBind "++" [Match {MatchHeadPrefix, [PParen (PInfix (PVar "x") ":" (PVar "xs")), PVar "ys"], EInfix (EVar "x") ":" (EParen (EInfix (EVar "xs") "++" (EVar "ys")))}])]}
+status: pass

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -32,6 +32,7 @@ import Aihc.Parser.Syntax
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
+    ExportSpec (..),
     FieldDecl (..),
     FixityAssoc (..),
     GadtBody (..),
@@ -53,6 +54,7 @@ import Aihc.Parser.Syntax
     ValueDecl (..),
     binderHeadName,
     mkUnqualifiedName,
+    moduleExports,
     moduleName,
     peelPatternAnn,
     qualifyName,
@@ -87,9 +89,65 @@ type ModuleExports = Map.Map Text Scope
 collectModuleExports :: [Module] -> ModuleExports
 collectModuleExports modules =
   Map.fromList
-    [ (moduleKey modu, topLevelScope modu)
+    [ (moduleKey modu, topLevelScope modu `unionScope` reExportedScope rawExports modu)
     | modu <- modules
     ]
+  where
+    rawExports =
+      Map.fromList
+        [ (moduleKey modu, topLevelScope modu)
+        | modu <- modules
+        ]
+
+reExportedScope :: ModuleExports -> Module -> Scope
+reExportedScope rawExports modu =
+  case moduleExports modu of
+    Nothing -> emptyScope
+    Just specs -> foldl' unionScope emptyScope (map exportSpecScope specs)
+  where
+    availableScope = importedScope rawExports modu
+
+    exportSpecScope spec =
+      case spec of
+        ExportAnn _ inner -> exportSpecScope inner
+        ExportModule _ exportModuleName -> Map.findWithDefault emptyScope exportModuleName rawExports
+        ExportVar _ _ name -> selectTerm (nameText name) availableScope
+        ExportAbs _ _ name -> selectType (nameText name) availableScope
+        ExportAll _ _ name -> selectTypeWithMembers (nameText name) availableScope (allTypeMembers (nameText name) availableScope)
+        ExportWith _ _ name members -> selectTypeWithMembers (nameText name) availableScope (map exportBundledMemberName members)
+        ExportWithAll _ _ name _ members ->
+          selectTypeWithMembers (nameText name) availableScope (map exportBundledMemberName members <> allTypeMembers (nameText name) availableScope)
+
+selectTerm :: Text -> Scope -> Scope
+selectTerm name scope =
+  emptyScope
+    { scopeTerms = Map.filterWithKey (\n _ -> n == name) (scopeTerms scope),
+      scopeFixities = Map.filterWithKey (\n _ -> n == name) (scopeFixities scope)
+    }
+
+selectType :: Text -> Scope -> Scope
+selectType name scope =
+  emptyScope
+    { scopeTypes = Map.filterWithKey (\n _ -> n == name) (scopeTypes scope)
+    }
+
+selectTypeWithMembers :: Text -> Scope -> [Text] -> Scope
+selectTypeWithMembers name scope members =
+  selectType name scope
+    `unionScope` emptyScope
+      { scopeTerms = Map.filterWithKey (\n _ -> n `elem` members) (scopeTerms scope),
+        scopeConstructors = Map.filterWithKey (\n _ -> n == name) (scopeConstructors scope),
+        scopeRecordFields = Map.filterWithKey (\n _ -> n `elem` members) (scopeRecordFields scope),
+        scopeMethods = Map.filterWithKey (\n _ -> n == name) (scopeMethods scope),
+        scopeFixities = Map.filterWithKey (\n _ -> n `elem` members) (scopeFixities scope)
+      }
+
+allTypeMembers :: Text -> Scope -> [Text]
+allTypeMembers name scope =
+  fromMaybe [] (Map.lookup name (scopeConstructors scope) <> Map.lookup name (scopeMethods scope))
+
+exportBundledMemberName :: IEBundledMember -> Text
+exportBundledMemberName = nameText . ieBundledMemberName
 
 topLevelScope :: Module -> Scope
 topLevelScope modu =

--- a/components/aihc-resolve/test/Test/Fixtures/golden/prelude-reexports-imported-bool.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/prelude-reexports-imported-bool.yaml
@@ -1,0 +1,103 @@
+extensions: []
+modules:
+  - |
+    module Data.Bool
+      ( Bool (False, True),
+        not,
+        (&&),
+      )
+    where
+
+    data Bool = False | True
+    not False = True
+    not True = False
+    False && _ = False
+    True && x = x
+  - |
+    module Prelude
+      ( Bool (..),
+        not,
+        (&&),
+      )
+    where
+
+    import Data.Bool (Bool (..), not, (&&))
+    p = not True
+  - |
+    module Main where
+    x = (not False, True && False)
+expected: |
+  Data.Bool:
+    8:6-8:10 Bool => (type) Data.Bool.Bool
+    8:13-8:18 False => (value) Data.Bool.False
+    8:21-8:25 True => (value) Data.Bool.True
+    9:1-9:4 not => (value) Data.Bool.not
+    9:13-9:17 True => (value) Data.Bool.True
+    10:1-10:4 not => (value) Data.Bool.not
+    10:12-10:17 False => (value) Data.Bool.False
+    11:1-11:3 && => (value) Data.Bool.&&
+    11:14-11:19 False => (value) Data.Bool.False
+    12:1-12:3 && => (value) Data.Bool.&&
+    12:9-12:10 x => (value) Local 0 x
+    12:13-12:14 x => (value) Local 0 x
+  Main:
+    2:1-2:2 x => (value) Main.x
+    2:5-2:7 && => (value) Data.Bool.&&
+    2:6-2:9 not => (value) Data.Bool.not
+    2:10-2:15 False => (value) Data.Bool.False
+    2:17-2:21 True => (value) Data.Bool.True
+    2:25-2:30 False => (value) Data.Bool.False
+  Prelude:
+    9:1-9:2 p => (value) Prelude.p
+    9:5-9:8 not => (value) Data.Bool.not
+    9:9-9:13 True => (value) Data.Bool.True
+annotated:
+  - |
+    module Data.Bool
+      ( Bool (False, True),
+        not,
+        (&&),
+      )
+    where
+
+    data Bool = False | True
+         │      │       └─ v Data.Bool
+         │      └─ v Data.Bool
+         └─ t Data.Bool
+    not False = True
+    │           └─ v Data.Bool
+    └─ v Data.Bool
+    not True = False
+    │          └─ v Data.Bool
+    └─ v Data.Bool
+    False && _ = False
+    │            └─ v Data.Bool
+    └─ v Data.Bool
+    True && x = x
+    │       │   └─ v 0
+    │       └─ v 0
+    └─ v Data.Bool
+  - |
+    module Main where
+    x = (not False, True && False)
+    │   ││   │      │       └─ v Data.Bool
+    │   ││   │      └─ v Data.Bool
+    │   ││   └─ v Data.Bool
+    │   │└─ v Data.Bool
+    │   └─ v Data.Bool
+    └─ v Main
+  - |
+    module Prelude
+      ( Bool (..),
+        not,
+        (&&),
+      )
+    where
+
+    import Data.Bool (Bool (..), not, (&&))
+    p = not True
+    │   │   └─ v Data.Bool
+    │   └─ v Data.Bool
+    └─ v Prelude
+status: pass
+reason: re-exports imported Bool names through Prelude

--- a/components/aihc-tc/test/Test/Fixtures/golden/bool-module-core-lib.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/bool-module-core-lib.yaml
@@ -1,0 +1,28 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = False | True
+    infixr 3 &&
+    (&&) :: Bool -> Bool -> Bool
+    False && _ = False
+    True && x = x
+    not :: Bool -> Bool
+    not False = True
+    not True = False
+    otherwise :: Bool
+    otherwise = True
+    infixr 2 ||
+    (||) :: Bool -> Bool -> Bool
+    False || x = x
+    True || _ = True
+expected:
+  - "Bool :: *"
+  - "False :: Bool"
+  - "True :: Bool"
+  - "(||) :: Bool -> Bool -> Bool"
+  - "otherwise :: Bool"
+  - "not :: Bool -> Bool"
+  - "(&&) :: Bool -> Bool -> Bool"
+status: pass
+reason: types the Bool API exported by Data.Bool

--- a/core-libs/aihc-base/src/Data/Bool.hs
+++ b/core-libs/aihc-base/src/Data/Bool.hs
@@ -1,1 +1,29 @@
-module Data.Bool () where
+module Data.Bool
+  ( Bool (False, True),
+    (&&),
+    not,
+    otherwise,
+    (||),
+  )
+where
+
+data Bool = False | True
+
+infixr 3 &&
+
+(&&) :: Bool -> Bool -> Bool
+False && _ = False
+True && x = x
+
+not :: Bool -> Bool
+not False = True
+not True = False
+
+otherwise :: Bool
+otherwise = True
+
+infixr 2 ||
+
+(||) :: Bool -> Bool -> Bool
+False || x = x
+True || _ = True

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -1,10 +1,17 @@
 module Prelude
-  ( Char,
+  ( Bool (..),
+    Char,
     List (..),
     String,
+    (&&),
     (++),
+    not,
+    otherwise,
+    (||),
   )
 where
+
+import Data.Bool (Bool (..), not, otherwise, (&&), (||))
 
 data Char
 


### PR DESCRIPTION
## Summary

- implement `Data.Bool` with `Bool`, `(&&)`, `not`, `otherwise`, and `(||)`
- re-export the Bool API from `Prelude`
- add parser golden coverage for the Bool module and Prelude re-export surface
- add resolver coverage for Prelude re-exporting imported Bool names
- add type-checker golden coverage for the Bool API
- add FC eval coverage for Bool constructors, `not`, `otherwise`, `(&&)`, `(||)`, and short-circuiting
- make those FC eval fixtures depend on `aihc-base` and use the definitions through implicit `Prelude`
- teach resolver export collection to include explicitly re-exported imported names while preserving existing own-declaration scope behavior
- teach FC eval/desugaring enough declared-constructor and top-level pattern-bind support for those eval fixtures

## Progress counts

- Parser golden fixtures: +2
- Resolver golden fixtures: +1
- Type-checker golden fixtures: +1
- FC eval fixtures: +5

## Validation

- `cabal test -v0 aihc-resolve:spec --test-options="--pattern prelude-reexports-imported-bool --hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--pattern bool --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern core-lib --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern prelude-bool-reexports --hide-successes"`
- `cabal test -v0 aihc-tc:spec --test-options="--pattern bool-module-core-lib --hide-successes"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` found one fixture import-order mismatch in an earlier revision; fixed. A later run completed with no findings; the latest attempted run was rate-limited.
