### PR TITLE
chore: add golden fixture updater

### DIFF
--- a/components/aihc-parser/common/ParserGolden.hs
+++ b/components/aihc-parser/common/ParserGolden.hs
@@ -10,8 +10,10 @@ module ParserGolden
     moduleFixtureRoot,
     patternFixtureRoot,
     loadExprCases,
+    loadImportCases,
     loadModuleCases,
     loadPatternCases,
+    loadPragmaCases,
     parseParserCaseText,
     evaluateExprCase,
     evaluateModuleCase,
@@ -88,17 +90,29 @@ exprFixtureRoot = fixtureRoot </> "expr"
 moduleFixtureRoot :: FilePath
 moduleFixtureRoot = fixtureRoot </> "module"
 
+importFixtureRoot :: FilePath
+importFixtureRoot = fixtureRoot </> "import"
+
 patternFixtureRoot :: FilePath
 patternFixtureRoot = fixtureRoot </> "pattern"
 
+pragmaFixtureRoot :: FilePath
+pragmaFixtureRoot = fixtureRoot </> "pragma"
+
 loadExprCases :: IO [ParserCase]
 loadExprCases = loadCases CaseExpr exprFixtureRoot
+
+loadImportCases :: IO [ParserCase]
+loadImportCases = loadCases CaseModule importFixtureRoot
 
 loadModuleCases :: IO [ParserCase]
 loadModuleCases = loadCases CaseModule moduleFixtureRoot
 
 loadPatternCases :: IO [ParserCase]
 loadPatternCases = loadCases CasePattern patternFixtureRoot
+
+loadPragmaCases :: IO [ParserCase]
+loadPragmaCases = loadCases CaseModule pragmaFixtureRoot
 
 loadCases :: CaseKind -> FilePath -> IO [ParserCase]
 loadCases kind root = do

--- a/components/aihc-parser/test/Test/Fixtures/golden/import/operator-import.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/import/operator-import.yaml
@@ -2,36 +2,6 @@ extensions:
   - TypeOperators
 input: |
   import Data.Type.Equality ((:~~:)(..))
-status: pass
 ast: |-
-  Module
-    { moduleSpan = SourceSpan 1 1 1 43
-    , moduleHeader = Nothing
-    , modulePragmas = []
-    , moduleImports =
-        [ ImportDecl
-            { importDeclSpan = SourceSpan 1 1 1 43
-            , importDeclLevel = Nothing
-            , importDeclPackage = Nothing
-            , importDeclQualified = False
-            , importDeclQualifiedPost = False
-            , importDeclModule = "Data.Type.Equality"
-            , importDeclAs = Nothing
-            , importDeclSpec =
-                Just
-                  ( ImportSpec
-                      { importSpecSpan = SourceSpan 1 27 1 43
-                      , importSpecHiding = False
-                      , importSpecItems =
-                          [ ImportItemAll
-                              { importItemSpan = SourceSpan 1 28 1 42
-                              , importItemNamespace = Nothing
-                              , importItemName = ":~~:"
-                              }
-                          ]
-                      }
-                  )
-            }
-        ]
-    , moduleDecls = []
-    }
+  Module {[ImportDecl {"Data.Type.Equality", ImportSpec {[ImportItemAll{UnqualifiedName {":~~:"}}]}}]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/pragma/language-leading-comma.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pragma/language-leading-comma.yaml
@@ -9,5 +9,5 @@ input: |
   module Demo where
   x = 1
 ast: |-
-  Module {name = "Demo", languagePragmas = [EnableExtension DataKinds, EnableExtension DeriveGeneric, EnableExtension DeriveDataTypeable, EnableExtension OverloadedStrings], decls = [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
+  Module {ModuleHead {"Demo"}, [DataKinds, DeriveGeneric, DeriveDataTypeable, OverloadedStrings], [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/pragma/language-multiple-multiline.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pragma/language-multiple-multiline.yaml
@@ -6,5 +6,5 @@ input: |
   module Demo where
   x = 1
 ast: |-
-  Module {name = "Demo", languagePragmas = [EnableExtension BangPatterns, EnableExtension GADTs, EnableExtension ScopedTypeVariables], decls = [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
+  Module {ModuleHead {"Demo"}, [BangPatterns, GADTs, ScopedTypeVariables], [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
 status: pass

--- a/components/aihc-parser/test/Test/Parser/Suite.hs
+++ b/components/aihc-parser/test/Test/Parser/Suite.hs
@@ -28,25 +28,33 @@ parserGoldenTests = do
 parserGoldenGroup :: IO TestTree
 parserGoldenGroup = do
   exprCases <- PG.loadExprCases
+  importCases <- PG.loadImportCases
   moduleCases <- PG.loadModuleCases
   patternCases <- PG.loadPatternCases
+  pragmaCases <- PG.loadPragmaCases
 
   exprChecks <- mapM mkExprCaseTest exprCases
+  importChecks <- mapM mkModuleCaseTest importCases
   moduleChecks <- mapM mkModuleCaseTest moduleCases
   patternChecks <- mapM mkPatternCaseTest patternCases
+  pragmaChecks <- mapM mkModuleCaseTest pragmaCases
 
   exprSummary <- mkSummaryTest "expr" PG.evaluateExprCase exprCases
+  importSummary <- mkSummaryTest "import" PG.evaluateModuleCase importCases
   moduleSummary <- mkSummaryTest "module" PG.evaluateModuleCase moduleCases
   patternSummary <- mkSummaryTest "pattern" PG.evaluatePatternCase patternCases
-  combinedSummary <- mkCombinedSummary exprCases moduleCases patternCases
+  pragmaSummary <- mkSummaryTest "pragma" PG.evaluateModuleCase pragmaCases
+  combinedSummary <- mkCombinedSummary exprCases importCases moduleCases patternCases pragmaCases
 
   pure
     ( testGroup
         "parser-golden"
         [ fixtureValidationTests,
           testGroup "expr" (exprChecks <> [exprSummary]),
+          testGroup "import" (importChecks <> [importSummary]),
           testGroup "module" (moduleChecks <> [moduleSummary]),
           testGroup "pattern" (patternChecks <> [patternSummary]),
+          testGroup "pragma" (pragmaChecks <> [pragmaSummary]),
           combinedSummary
         ]
     )
@@ -108,12 +116,14 @@ mkSummaryTest label evaluateCase cases = do
   let outcomes = map (evaluate evaluateCase) cases
   pure $ testCase (label <> " summary") (assertNoRegressions label outcomes)
 
-mkCombinedSummary :: [PG.ParserCase] -> [PG.ParserCase] -> [PG.ParserCase] -> IO TestTree
-mkCombinedSummary exprCases moduleCases patternCases = do
+mkCombinedSummary :: [PG.ParserCase] -> [PG.ParserCase] -> [PG.ParserCase] -> [PG.ParserCase] -> [PG.ParserCase] -> IO TestTree
+mkCombinedSummary exprCases importCases moduleCases patternCases pragmaCases = do
   let exprOutcomes = map (evaluate PG.evaluateExprCase) exprCases
+      importOutcomes = map (evaluate PG.evaluateModuleCase) importCases
       moduleOutcomes = map (evaluate PG.evaluateModuleCase) moduleCases
       patternOutcomes = map (evaluate PG.evaluatePatternCase) patternCases
-      outcomes = exprOutcomes <> moduleOutcomes <> patternOutcomes
+      pragmaOutcomes = map (evaluate PG.evaluateModuleCase) pragmaCases
+      outcomes = exprOutcomes <> importOutcomes <> moduleOutcomes <> patternOutcomes <> pragmaOutcomes
   pure $ testCase "summary" (assertNoRegressions "parser golden" outcomes)
 
 assertExprCase :: PG.ParserCase -> Assertion
@@ -329,9 +339,11 @@ fixtureValidationTests =
               other -> assertFailure ("expected xfail outcome with details, got: " <> show other),
       testCase "only YAML fixtures are loaded" $ do
         exprCases <- PG.loadExprCases
+        importCases <- PG.loadImportCases
         moduleCases <- PG.loadModuleCases
         patternCases <- PG.loadPatternCases
-        let cases = exprCases <> moduleCases <> patternCases
+        pragmaCases <- PG.loadPragmaCases
+        let cases = exprCases <> importCases <> moduleCases <> patternCases <> pragmaCases
         mapM_
           ( \meta ->
               unless (takeExtension (PG.casePath meta) `elem` [".yaml", ".yml"]) $

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -97,6 +97,40 @@ library parser-tools
   ghc-options: -Wall
   default-language: GHC2021
 
+library golden-tools
+  hs-source-dirs: src
+  exposed-modules:
+    Aihc.Dev.Golden.Update
+
+  other-modules:
+    Aihc.Dev.Parser.Run
+
+  build-depends:
+    aeson >=2.0 && <2.3,
+    aihc-cpp,
+    aihc-dev:parser-tools,
+    aihc-fc,
+    aihc-fmt,
+    aihc-parser,
+    aihc-parser:parser-tooling-common,
+    aihc-resolve,
+    aihc-tc,
+    base >=4.16 && <5,
+    bytestring >=0.10.8 && <0.13,
+    containers >=0.5 && <0.8,
+    directory >=1.2.3 && <1.5,
+    filepath >=1.3.0.1 && <1.6,
+    optparse-applicative >=0.16 && <0.19,
+    prettyprinter,
+    process >=1.6 && <1.8,
+    scientific,
+    text >=1.2.3 && <2.2,
+    yaml >=0.11 && <0.12,
+
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall
+  default-language: GHC2021
+
 executable aihc-dev
   main-is: Main.hs
   hs-source-dirs:
@@ -125,6 +159,7 @@ executable aihc-dev
     aeson-pretty >=0.8 && <0.9,
     aihc-cpp,
     aihc-dev:extract-hi,
+    aihc-dev:golden-tools,
     aihc-dev:parser-tools,
     aihc-dev:snippet,
     aihc-hackage,
@@ -178,6 +213,7 @@ test-suite spec
     StackageProgress.Run
     StackageProgress.Snapshot
     Test.ExtractHiCompare
+    Test.GoldenUpdate
     Test.ParserCLI.Golden
     Test.ParserCLI.Suite
     Test.ResolvePackage
@@ -191,6 +227,7 @@ test-suite spec
     aeson-pretty >=0.8 && <0.9,
     aihc-cpp,
     aihc-dev:extract-hi,
+    aihc-dev:golden-tools,
     aihc-dev:parser-tools,
     aihc-dev:snippet,
     aihc-hackage,

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Aihc.Dev.ExtractHi (extractPackage)
 import Aihc.Dev.ExtractHi.Compare (comparePackageSubset, renderInterfaceMismatch)
 import Aihc.Dev.ExtractHi.ToResolveIface (toResolveIface)
+import Aihc.Dev.Golden.Update qualified as GoldenUpdate
 import Aihc.Dev.HackageTester.Run qualified as HackageTesterRun
 import Aihc.Dev.Parser.Bench.CLI qualified as ParserBenchCLI
 import Aihc.Dev.Parser.Bench.Run qualified as ParserBenchRun
@@ -51,6 +52,7 @@ data Command
   | ParserHackageProgress ParserHackageProgressCLI.Options
   | ResolvePackage RP.Options
   | ResolveStackageProgress RSP.Options
+  | UpdateGoldens GoldenUpdate.Options
 
 data ExtractHiOpts = ExtractHiOpts
   { ehPackage :: String,
@@ -138,6 +140,12 @@ commandParser =
           ( info
               (ResolveStackageProgress <$> RSP.optionsParser <**> helper)
               (progDesc "Test name resolver on Stackage snapshot packages")
+          )
+        <> command
+          "update-goldens"
+          ( info
+              (UpdateGoldens <$> GoldenUpdate.optionsParser <**> helper)
+              (progDesc "Refresh golden fixture outputs from the current implementation")
           )
     )
 
@@ -242,3 +250,5 @@ runCommand (ResolvePackage opts) =
   RP.run opts
 runCommand (ResolveStackageProgress opts) =
   RSP.run opts
+runCommand (UpdateGoldens opts) =
+  GoldenUpdate.run opts

--- a/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
@@ -1,0 +1,866 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aihc.Dev.Golden.Update
+  ( Options (..),
+    optionsParser,
+    run,
+    replaceYamlValueAt,
+  )
+where
+
+import Aihc.Cpp (Result (..))
+import Aihc.Dev.Parser.Run qualified as ParserRun
+import Aihc.Fc (DesugarResult (..), desugarModule, desugarModuleWithTcResult, evalProgramBinding, renderProgram, renderRawValue)
+import Aihc.Fmt (defaultFormatOptions, formatErrorMessage, formatExtensions, formatText)
+import Aihc.Parser
+  ( ParseResult (..),
+    ParserConfig (..),
+    defaultConfig,
+    formatParseErrorBundle,
+    formatParseErrors,
+    parseExpr,
+    parseModule,
+    parsePattern,
+  )
+import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexModuleTokensWithExtensions, lexTokensWithExtensions)
+import Aihc.Parser.Shorthand (Shorthand (..))
+import Aihc.Parser.Syntax
+  ( Decl (..),
+    Expr,
+    Extension,
+    ExtensionSetting,
+    LanguageEdition (Haskell2010Edition),
+    Match (..),
+    MatchHeadForm (..),
+    Module (..),
+    NameType (..),
+    Pattern (..),
+    Pragma (..),
+    Rhs (..),
+    UnqualifiedName (..),
+    ValueDecl (..),
+    editionFromExtensionSettings,
+    effectiveExtensions,
+    mkUnqualifiedName,
+    parseExtensionName,
+    parseExtensionSettingName,
+  )
+import Aihc.Resolve (ResolveResult (..), collectModuleExports, renderAnnotatedResolveResult, renderResolveResult, resolve, resolveWithDeps)
+import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), TcType (..), TyCon (..), renderTcType, typecheckModule)
+import Control.Exception (IOException, bracket, catch)
+import Control.Monad (foldM, forM, forM_, unless)
+import CppSupport (cppEnabledInSource, preprocessForParserWithoutIncludes)
+import Data.Aeson (Value (..), toJSON)
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Types (parseEither, withArray)
+import Data.Bifunctor (first)
+import Data.ByteString qualified as BS
+import Data.Char (isSpace, toLower)
+import Data.List (dropWhileEnd, sort, sortOn)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Ratio (denominator, numerator)
+import Data.Scientific (toBoundedInteger)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
+import GhcOracle (oracleModuleAstFingerprint)
+import LexerGolden qualified as LG
+import Options.Applicative hiding (value)
+import Options.Applicative qualified as OA
+import ParserErrorGolden qualified as PEG
+import ParserGolden qualified as PG
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, findExecutable, getTemporaryDirectory, listDirectory, removeFile)
+import System.Exit (ExitCode (..))
+import System.FilePath (makeRelative, normalise, takeDirectory, takeExtension, (</>))
+import System.IO (Handle, hClose, openTempFile)
+import System.Process (readProcessWithExitCode)
+
+data Options = Options
+  { optRoot :: !FilePath,
+    optDryRun :: !Bool,
+    optExternalFormatters :: !Bool
+  }
+  deriving (Eq, Show)
+
+data Summary = Summary
+  { summaryScanned :: !Int,
+    summaryUpdated :: !Int,
+    summarySkipped :: ![(FilePath, String)]
+  }
+  deriving (Eq, Show)
+
+emptySummary :: Summary
+emptySummary = Summary 0 0 []
+
+data FixtureUpdate
+  = FixtureUnchanged
+  | FixtureUpdated Value
+  | FixtureSkipped String
+
+optionsParser :: Parser Options
+optionsParser =
+  Options
+    <$> strOption
+      ( long "root"
+          <> metavar "DIR"
+          <> OA.value "."
+          <> showDefault
+          <> help "Repository root containing components/, tooling/, and bin/"
+      )
+    <*> switch
+      ( long "dry-run"
+          <> help "Report fixtures that would change without writing files"
+      )
+    <*> switch
+      ( long "external-formatters"
+          <> help "Also refresh formatter goldens for installed external tools"
+      )
+
+run :: Options -> IO ()
+run opts = do
+  summaries <-
+    sequence
+      [ updateParserGoldens opts,
+        updateLexerGoldens opts,
+        updateParserErrorGoldens opts,
+        updateResolverGoldens opts,
+        updateTcGoldens opts,
+        updateFcGoldens opts,
+        updateFcEvalGoldens opts,
+        updateFormatterGoldens opts,
+        updateParserCliGoldens opts
+      ]
+  let total = foldl mergeSummary emptySummary summaries
+  putStrLn $
+    "golden fixtures: scanned "
+      <> show (summaryScanned total)
+      <> ", updated "
+      <> show (summaryUpdated total)
+      <> skippedSuffix total
+  unless (null (summarySkipped total)) $
+    forM_ (summarySkipped total) $ \(path, reason) ->
+      putStrLn ("skipped " <> path <> ": " <> reason)
+  where
+    skippedSuffix summary =
+      case summarySkipped summary of
+        [] -> ""
+        skipped -> ", skipped " <> show (length skipped)
+
+mergeSummary :: Summary -> Summary -> Summary
+mergeSummary left right =
+  Summary
+    { summaryScanned = summaryScanned left + summaryScanned right,
+      summaryUpdated = summaryUpdated left + summaryUpdated right,
+      summarySkipped = summarySkipped left <> summarySkipped right
+    }
+
+updateParserGoldens :: Options -> IO Summary
+updateParserGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-parser/test/Test/Fixtures/golden") $ \path value -> do
+    let rel = makeRelative (optRoot opts </> "components/aihc-parser/test/Test/Fixtures/golden") path
+    case parserKindFromPath rel of
+      Nothing -> pure (FixtureSkipped "not an expr/module/pattern parser golden")
+      Just kind ->
+        case PG.parseParserCaseText kind rel (decodeFixtureValue value) of
+          Left err -> pure (FixtureSkipped err)
+          Right meta ->
+            case parserActualAst meta of
+              Left err -> pure (skipForStatus (textField "status" value) err)
+              Right actual
+                | trim actual == trim (PG.caseAst meta) -> pure FixtureUnchanged
+                | not (shouldUpdateOutput value) -> pure FixtureUnchanged
+                | otherwise -> pure (setValueAt ["ast"] (String (T.pack actual)) value)
+
+parserKindFromPath :: FilePath -> Maybe PG.CaseKind
+parserKindFromPath path =
+  case takeWhile (/= '/') path of
+    "expr" -> Just PG.CaseExpr
+    "import" -> Just PG.CaseModule
+    "module" -> Just PG.CaseModule
+    "pattern" -> Just PG.CasePattern
+    "pragma" -> Just PG.CaseModule
+    _ -> Nothing
+
+parserActualAst :: PG.ParserCase -> Either String String
+parserActualAst meta =
+  case PG.caseKind meta of
+    PG.CaseExpr ->
+      case parseExpr (parserConfig (PG.casePath meta) (PG.caseExtensions meta)) (PG.caseInput meta) of
+        ParseOk ast -> Right (show (shorthand ast))
+        ParseErr err -> Left (formatParseErrorBundle (PG.casePath meta) (Just (PG.caseInput meta)) err)
+    PG.CaseModule ->
+      let (errs, ast) = parseModule (parserConfig (PG.casePath meta) (PG.caseExtensions meta)) (PG.caseInput meta)
+       in if null errs
+            then Right (show (shorthand ast))
+            else Left (formatParseErrors (PG.casePath meta) (Just (PG.caseInput meta)) errs)
+    PG.CasePattern ->
+      case parsePattern (parserConfig (PG.casePath meta) (PG.caseExtensions meta)) (PG.caseInput meta) of
+        ParseOk ast -> Right (show (shorthand ast))
+        ParseErr err -> Left (formatParseErrorBundle (PG.casePath meta) (Just (PG.caseInput meta)) err)
+
+parserConfig :: FilePath -> [ExtensionSetting] -> ParserConfig
+parserConfig sourceName exts =
+  let edition = fromMaybe Haskell2010Edition (editionFromExtensionSettings exts)
+   in defaultConfig
+        { parserSourceName = sourceName,
+          parserExtensions = effectiveExtensions edition exts
+        }
+
+updateLexerGoldens :: Options -> IO Summary
+updateLexerGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-parser/test/Test/Fixtures/lexer") $ \path value -> do
+    let root = optRoot opts </> "components/aihc-parser/test/Test/Fixtures/lexer"
+        rel = makeRelative root path
+    case LG.parseLexerCaseText rel (decodeFixtureValue value) of
+      Left err -> pure (FixtureSkipped err)
+      Right meta ->
+        let actual = actualLexerTokens meta
+            expected = map normalizeTokenKind (LG.caseTokens meta)
+         in if actual == expected || not (shouldUpdateOutput value)
+              then pure FixtureUnchanged
+              else pure (setValueAt ["tokens"] (toJSON (map renderTokenKind actual)) value)
+
+actualLexerTokens :: LG.LexerCase -> [LexTokenKind]
+actualLexerTokens meta =
+  let tokens =
+        if LG.caseIsModule meta
+          then lexModuleTokensWithExtensions (LG.caseExtensions meta) (LG.caseInput meta)
+          else lexTokensWithExtensions (LG.caseExtensions meta) (LG.caseInput meta)
+   in map (normalizeTokenKind . lexTokenKind) tokens
+
+normalizeTokenKind :: LexTokenKind -> LexTokenKind
+normalizeTokenKind (TkPragma pragma) = TkPragma (pragma {pragmaRawText = ""})
+normalizeTokenKind tok = tok
+
+renderTokenKind :: LexTokenKind -> Text
+renderTokenKind (TkFloat value floatType) =
+  "TkFloat " <> T.pack (renderRational value) <> " " <> T.pack (show floatType)
+renderTokenKind tok = T.pack (show tok)
+
+renderRational :: Rational -> String
+renderRational value =
+  let sign = if value < 0 then "-" else ""
+      n = abs (numerator value)
+      d = denominator value
+   in case decimalScale d of
+        Nothing -> show value
+        Just scale ->
+          let scaled = n * (10 ^ scale) `div` d
+              raw = show scaled
+              padded = replicate (scale + 1 - length raw) '0' <> raw
+              splitAt' = length padded - scale
+              (whole, frac0) = splitAt splitAt' padded
+              frac = dropWhileEnd (== '0') frac0
+           in sign <> if null frac then whole else whole <> "." <> frac
+
+decimalScale :: Integer -> Maybe Int
+decimalScale = go 0
+  where
+    go scale 1 = Just scale
+    go scale n
+      | even n = go (scale + 1) (n `div` 2)
+      | n `mod` 5 == 0 = go (scale + 1) (n `div` 5)
+      | otherwise = Nothing
+
+updateParserErrorGoldens :: Options -> IO Summary
+updateParserErrorGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-parser/test/Test/Fixtures/error-messages") $ \path value -> do
+    let root = optRoot opts </> "components/aihc-parser/test/Test/Fixtures/error-messages"
+        rel = makeRelative root path
+    case PEG.parseErrorMessageCaseText rel (decodeFixtureValue value) of
+      Left err -> pure (FixtureSkipped err)
+      Right meta ->
+        case parserErrorActual meta of
+          Left err -> pure (FixtureSkipped err)
+          Right (actualGhc, actualAihc) ->
+            pure $
+              applyFieldUpdates
+                [ (["ghc"], String actualGhc, actualGhc /= PEG.caseExpectedGhc meta),
+                  (["aihc"], String actualAihc, actualAihc /= PEG.caseExpectedAihc meta)
+                ]
+                value
+
+parserErrorActual :: PEG.ErrorMessageCase -> Either String (Text, Text)
+parserErrorActual meta = do
+  ghcText <-
+    case oracleModuleAstFingerprint "test.hs" Haskell2010Edition [] (PEG.caseSource meta) of
+      Right {} -> Left "GHC accepted the source"
+      Left err -> Right (normalizeErrorText err)
+  aihcText <- renderAihcErrorMessage (PEG.caseSource meta)
+  Right (ghcText, aihcText)
+
+renderAihcErrorMessage :: Text -> Either String Text
+renderAihcErrorMessage source =
+  let preprocessed =
+        if cppEnabledInSource source
+          then resultOutput (preprocessForParserWithoutIncludes "test.hs" [] source)
+          else source
+      (errs, _) = parseModule defaultConfig {parserSourceName = "test.hs"} preprocessed
+   in case errs of
+        [] -> Left "AIHC accepted the source"
+        _ -> Right (normalizeErrorText (T.pack (formatParseErrors "test.hs" (Just preprocessed) errs)))
+
+normalizeErrorText :: Text -> Text
+normalizeErrorText =
+  T.intercalate "\n" . map T.stripEnd . T.lines . T.dropWhileEnd (`elem` ['\n', '\r']) . T.replace "\r\n" "\n"
+
+updateResolverGoldens :: Options -> IO Summary
+updateResolverGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-resolve/test/Test/Fixtures/golden") $ \_ value ->
+    if not (shouldUpdateOutput value)
+      then pure FixtureUnchanged
+      else case resolverActual value of
+        Left err -> pure (FixtureSkipped err)
+        Right (actualExpected, actualAnnotated) -> do
+          let expected = parseExpectedField "expected" value
+              annotated = parseTextArrayField "annotated" value
+          pure $
+            applyFieldUpdates
+              [ (["expected"], String (T.pack actualExpected), either (const True) ((/= trim actualExpected) . trim . T.unpack) expected),
+                (["annotated"], toJSON (map T.pack actualAnnotated), either (const True) ((/= map trim actualAnnotated) . map (trim . T.unpack)) annotated)
+              ]
+              value
+
+resolverActual :: Value -> Either String (String, [String])
+resolverActual value = do
+  exts <- parseExtensions value
+  modules <- parseTextArrayField "modules" value
+  parsed <- traverse (parseModuleText exts) modules
+  let result = resolve parsed
+  Right (renderResolveResult result, renderAnnotatedResolveResult modules result)
+
+updateTcGoldens :: Options -> IO Summary
+updateTcGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-tc/test/Test/Fixtures/golden") $ \_ value ->
+    if not (shouldUpdateOutput value)
+      then pure FixtureUnchanged
+      else case tcActual value of
+        Left err -> pure (skipForStatus (textField "status" value) err)
+        Right actual -> updateExpectedText value actual
+
+tcActual :: Value -> Either String String
+tcActual value = do
+  exts <- parseExtensions value
+  modules <- parseTextArrayField "modules" value
+  parsed <- traverse (parseModuleText exts) modules
+  let results = map typecheckModule parsed
+  if all tcmSuccess results
+    then Right (trim (unlines [T.unpack (tbName b) <> " :: " <> renderTcType (tbType b) | r <- results, b <- tcmBindings r]))
+    else Left (unlines [show d | r <- results, d <- tcmDiagnostics r])
+
+updateFcGoldens :: Options -> IO Summary
+updateFcGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-fc/test/Test/Fixtures/golden") $ \_ value ->
+    if not (shouldUpdateOutput value)
+      then pure FixtureUnchanged
+      else case fcActual value of
+        Left err -> pure (skipForStatus (textField "status" value) err)
+        Right actual -> updateExpectedText value actual
+
+fcActual :: Value -> Either String String
+fcActual value = do
+  exts <- parseExtensions value
+  modules <- parseTextArrayField "modules" value
+  parsed <- traverse (parseModuleText exts) modules
+  let results = map desugarModule parsed
+  if all dsSuccess results
+    then Right (trim (unlines (map (renderProgram . dsProgram) results)))
+    else Left (unlines [err | r <- results, err <- dsErrors r])
+
+updateFcEvalGoldens :: Options -> IO Summary
+updateFcEvalGoldens opts =
+  updateYamlTree opts (optRoot opts </> "components/aihc-fc/test/Test/Fixtures/eval") $ \_ value ->
+    if not (shouldUpdateOutput value)
+      then pure FixtureUnchanged
+      else case fcEvalActual value of
+        Left err -> pure (skipForStatus (textField "status" value) err)
+        Right actual -> do
+          let expected = T.unpack <$> textField "output" value
+          pure $
+            if either (const True) ((/= trim actual) . trim) expected
+              then setValueAt ["output"] (String (T.pack actual)) value
+              else FixtureUnchanged
+
+fcEvalActual :: Value -> Either String String
+fcEvalActual value = do
+  exts <- parseExtensions value
+  moduleTexts <- parseTextArrayField "modules" value
+  exprText <- textField "expression" value
+  parsedModules <- traverse (parseModuleText exts) moduleTexts
+  expr <- parseExprText exts exprText
+  let (depModules, evalModule) = combineEvalModules parsedModules expr
+      depExports = collectModuleExports depModules
+  case resolveWithDeps depExports [evalModule] of
+    ResolveResult {resolvedModules = [resolvedModule], resolveErrors = []} ->
+      let result = desugarModuleWithTcResult (syntheticTcResult resolvedModule) resolvedModule
+       in if dsSuccess result
+            then first (("eval error: " <>) . show) (T.unpack <$> (evalProgramBinding evalBindingName (dsProgram result) >>= renderRawValue))
+            else Left ("desugar error: " <> unlines (dsErrors result))
+    ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+
+evalBindingName :: Text
+evalBindingName = "__aihc_eval__"
+
+combineEvalModules :: [Module] -> Expr -> ([Module], Module)
+combineEvalModules modules expr =
+  case modules of
+    [] -> ([], emptyEvalModule expr)
+    _ ->
+      let depModules = init modules
+          evalModule = last modules
+       in (depModules, evalModule {moduleDecls = moduleDecls evalModule <> [evalDecl expr]})
+
+emptyEvalModule :: Expr -> Module
+emptyEvalModule expr =
+  Module
+    { moduleAnns = [],
+      moduleHead = Nothing,
+      moduleLanguagePragmas = [],
+      moduleImports = [],
+      moduleDecls = [evalDecl expr]
+    }
+
+evalDecl :: Expr -> Decl
+evalDecl expr =
+  DeclValue $
+    FunctionBind
+      (mkUnqualifiedName NameVarId evalBindingName)
+      [ Match
+          { matchAnns = [],
+            matchHeadForm = MatchHeadPrefix,
+            matchPats = [],
+            matchRhs = UnguardedRhs [] expr Nothing
+          }
+      ]
+
+syntheticTcResult :: Module -> TcModuleResult
+syntheticTcResult modu =
+  TcModuleResult
+    { tcmBindings = concatMap bindingTypes (moduleDecls modu),
+      tcmDiagnostics = [],
+      tcmSuccess = True
+    }
+
+bindingTypes :: Decl -> [TcBindingResult]
+bindingTypes decl =
+  case decl of
+    DeclAnn _ inner -> bindingTypes inner
+    DeclValue (FunctionBind name matches) ->
+      [TcBindingResult (unqualifiedNameText name) (functionType (matchArity matches))]
+    DeclValue (PatternBind _ pat _) ->
+      [TcBindingResult name unknownTy | Just name <- [barePatternName pat]]
+    _ -> []
+
+matchArity :: [Match] -> Int
+matchArity [] = 0
+matchArity (match : _) = length (matchPats match)
+
+functionType :: Int -> TcType
+functionType arity =
+  foldr TcFunTy unknownTy (replicate arity unknownTy)
+
+unknownTy :: TcType
+unknownTy = TcTyCon (TyCon "?" 0) []
+
+barePatternName :: Pattern -> Maybe Text
+barePatternName pat =
+  case pat of
+    PVar name -> Just (unqualifiedNameText name)
+    PAnn _ inner -> barePatternName inner
+    PParen inner -> barePatternName inner
+    _ -> Nothing
+
+updateFormatterGoldens :: Options -> IO Summary
+updateFormatterGoldens opts =
+  updateYamlTree opts (optRoot opts </> "bin/aihc-fmt/test/Test/Fixtures/fmt") $ \_ value -> do
+    result <- formatterActuals opts value
+    case result of
+      Left err -> pure (FixtureSkipped err)
+      Right actuals -> do
+        let updates =
+              [ (["formatters", name, "output"], String output, formatterOutputDiffers name output value && formatterShouldUpdate name value)
+              | (name, output) <- actuals
+              ]
+        pure (applyFieldUpdates updates value)
+
+formatterActuals :: Options -> Value -> IO (Either String [(Text, Text)])
+formatterActuals opts value = do
+  case (,,) <$> parseExtensionSettings value <*> textField "input" value <*> (objectKeys =<< objectField "formatters" value) of
+    Left err -> pure (Left err)
+    Right (exts, input, formatterNames) -> do
+      let wanted name = name == "aihc-fmt" || optExternalFormatters opts
+      results <-
+        traverse
+          ( \name ->
+              if wanted name
+                then formatterActual name exts input
+                else pure (Right Nothing)
+          )
+          formatterNames
+      pure (catMaybesEither <$> sequence results)
+
+formatterActual :: Text -> [ExtensionSetting] -> Text -> IO (Either String (Maybe (Text, Text)))
+formatterActual "aihc-fmt" exts input =
+  case formatText defaultFormatOptions {formatExtensions = exts} "<fixture>" input of
+    Left err -> pure (Left (T.unpack (formatErrorMessage err)))
+    Right output -> pure (Right (Just ("aihc-fmt", output)))
+formatterActual name _ input =
+  Right <$> runExternalFormatter name input
+
+updateParserCliGoldens :: Options -> IO Summary
+updateParserCliGoldens opts =
+  updateYamlTree opts (optRoot opts </> "tooling/aihc-dev/test/Test/Fixtures/cli") $ \_ value ->
+    if not (shouldUpdateOutput value)
+      then pure FixtureUnchanged
+      else case cliActual value of
+        Left err -> pure (FixtureSkipped err)
+        Right (actualOutput, actualExit) ->
+          pure $
+            applyFieldUpdates
+              [ (["output"], String actualOutput, either (const True) ((/= actualOutput) . T.stripEnd) (textField "output" value)),
+                (["exit_code"], toJSON actualExit, either (const True) (/= actualExit) (intField "exit_code" 0 value))
+              ]
+              value
+
+cliActual :: Value -> Either String (Text, Int)
+cliActual value = do
+  args <- map T.unpack <$> optionalTextArrayField "args" value
+  input <- textField "input" value
+  includes <- parseIncludes value
+  let result = ParserRun.runCLI includes args input
+      output = T.stripEnd (ParserRun.cliStdout result <> ParserRun.cliStderr result)
+  Right (output, exitCodeToInt (ParserRun.cliExitCode result))
+
+parseIncludes :: Value -> Either String (Map FilePath Text)
+parseIncludes value =
+  case optionalObjectField "includes" value of
+    Left err -> Left err
+    Right Nothing -> Right M.empty
+    Right (Just obj) ->
+      traverseTextObject obj
+        >>= Right . M.fromList . map (\(path, source) -> (normalise (T.unpack path), source))
+
+exitCodeToInt :: ExitCode -> Int
+exitCodeToInt ExitSuccess = 0
+exitCodeToInt (ExitFailure n) = n
+
+-- Shared fixture traversal
+
+updateYamlTree :: Options -> FilePath -> (FilePath -> Value -> IO FixtureUpdate) -> IO Summary
+updateYamlTree opts root updater = do
+  paths <- listYamlFiles root
+  foldM step emptySummary paths
+  where
+    step summary path = do
+      valueResult <- readYamlValue path
+      result <-
+        case valueResult of
+          Left err -> pure (FixtureSkipped err)
+          Right value -> updater path value
+      case result of
+        FixtureUnchanged -> pure summary {summaryScanned = summaryScanned summary + 1}
+        FixtureSkipped reason ->
+          pure
+            summary
+              { summaryScanned = summaryScanned summary + 1,
+                summarySkipped = summarySkipped summary <> [(path, reason)]
+              }
+        FixtureUpdated value -> do
+          if optDryRun opts
+            then putStrLn ("would update " <> path)
+            else writeYamlValue path value
+          pure
+            summary
+              { summaryScanned = summaryScanned summary + 1,
+                summaryUpdated = summaryUpdated summary + 1
+              }
+
+listYamlFiles :: FilePath -> IO [FilePath]
+listYamlFiles root = do
+  exists <- doesDirectoryExist root
+  if not exists
+    then pure []
+    else do
+      entries <- sort <$> listDirectory root
+      fmap concat $
+        forM entries $ \entry -> do
+          let path = root </> entry
+          isDir <- doesDirectoryExist path
+          if isDir
+            then listYamlFiles path
+            else pure [path | yamlExtension path]
+
+yamlExtension :: FilePath -> Bool
+yamlExtension path =
+  case map toLower (takeExtension path) of
+    ".yaml" -> True
+    ".yml" -> True
+    _ -> False
+
+readYamlValue :: FilePath -> IO (Either String Value)
+readYamlValue path = do
+  bytes <- BS.readFile path
+  pure $
+    first Y.prettyPrintParseException $
+      Y.decodeEither' bytes
+
+writeYamlValue :: FilePath -> Value -> IO ()
+writeYamlValue path value = do
+  createDirectoryIfMissing True (takeDirectory path)
+  BS.writeFile path (Y.encode value)
+
+decodeFixtureValue :: Value -> Text
+decodeFixtureValue =
+  TE.decodeUtf8Lenient . Y.encode
+
+-- YAML editing
+
+replaceYamlValueAt :: [Text] -> Value -> Value -> Either String Value
+replaceYamlValueAt [] replacement _ = Right replacement
+replaceYamlValueAt (key : rest) replacement (Object obj) = do
+  current <-
+    maybe (Left ("missing key: " <> T.unpack key)) Right $
+      KeyMap.lookup (Key.fromText key) obj
+  updated <- replaceYamlValueAt rest replacement current
+  Right (Object (KeyMap.insert (Key.fromText key) updated obj))
+replaceYamlValueAt (key : _) _ _ =
+  Left ("cannot descend into non-object at key: " <> T.unpack key)
+
+setValueAt :: [Text] -> Value -> Value -> FixtureUpdate
+setValueAt path replacement value =
+  case replaceYamlValueAt path replacement value of
+    Left err -> FixtureSkipped err
+    Right updated
+      | updated == value -> FixtureUnchanged
+      | otherwise -> FixtureUpdated updated
+
+applyFieldUpdates :: [([Text], Value, Bool)] -> Value -> FixtureUpdate
+applyFieldUpdates updates value =
+  let wanted = [(path, replacement) | (path, replacement, changed) <- updates, changed]
+   in case foldM (\v (path, replacement) -> replaceYamlValueAt path replacement v) value wanted of
+        Left err -> FixtureSkipped err
+        Right updated
+          | updated == value -> FixtureUnchanged
+          | otherwise -> FixtureUpdated updated
+
+updateExpectedText :: Value -> String -> IO FixtureUpdate
+updateExpectedText value actual = do
+  let expected = parseExpectedField "expected" value
+  pure $
+    if either (const True) ((/= trim actual) . trim . T.unpack) expected
+      then setValueAt ["expected"] (String (T.pack actual)) value
+      else FixtureUnchanged
+
+-- YAML parsing helpers
+
+objectField :: Text -> Value -> Either String (KeyMap.KeyMap Value)
+objectField field (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Just (Object nested) -> Right nested
+    Just _ -> Left (T.unpack field <> " must be an object")
+    Nothing -> Left ("missing " <> T.unpack field)
+objectField field _ = Left (T.unpack field <> " must be read from an object")
+
+optionalObjectField :: Text -> Value -> Either String (Maybe (KeyMap.KeyMap Value))
+optionalObjectField field (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Nothing -> Right Nothing
+    Just (Object nested) -> Right (Just nested)
+    Just _ -> Left (T.unpack field <> " must be an object")
+optionalObjectField field _ = Left (T.unpack field <> " must be read from an object")
+
+textField :: Text -> Value -> Either String Text
+textField field (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Just (String txt) -> Right txt
+    Just _ -> Left (T.unpack field <> " must be a string")
+    Nothing -> Left ("missing " <> T.unpack field)
+textField field _ = Left (T.unpack field <> " must be read from an object")
+
+statusText :: Value -> Text
+statusText value =
+  either (const "") (T.toLower . T.strip) (textField "status" value)
+
+shouldUpdateOutput :: Value -> Bool
+shouldUpdateOutput value =
+  statusText value `elem` ["pass", "xpass"]
+
+intField :: Text -> Int -> Value -> Either String Int
+intField field defaultValue (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Nothing -> Right defaultValue
+    Just (Number n) ->
+      maybe (Left (T.unpack field <> " is not a bounded integer")) Right (toBoundedInteger n)
+    Just _ -> Left (T.unpack field <> " must be a number")
+intField field _ _ = Left (T.unpack field <> " must be read from an object")
+
+parseTextArrayField :: Text -> Value -> Either String [Text]
+parseTextArrayField field (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Just value -> parseTextArray field value
+    Nothing -> Left ("missing " <> T.unpack field)
+parseTextArrayField field _ = Left (T.unpack field <> " must be read from an object")
+
+optionalTextArrayField :: Text -> Value -> Either String [Text]
+optionalTextArrayField field (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Nothing -> Right []
+    Just value -> parseTextArray field value
+optionalTextArrayField field _ = Left (T.unpack field <> " must be read from an object")
+
+parseTextArray :: Text -> Value -> Either String [Text]
+parseTextArray field =
+  parseEither $
+    withArray (T.unpack field) $ \arr ->
+      traverse parseEntry (foldr (:) [] arr)
+  where
+    parseEntry (String txt) = pure txt
+    parseEntry _ = fail (T.unpack field <> " entries must be strings")
+
+parseExpectedField :: Text -> Value -> Either String Text
+parseExpectedField field (Object obj) =
+  case KeyMap.lookup (Key.fromText field) obj of
+    Just value -> parseExpectedValue value
+    Nothing -> Right ""
+parseExpectedField field _ = Left (T.unpack field <> " must be read from an object")
+
+parseExpectedValue :: Value -> Either String Text
+parseExpectedValue (String txt) = Right txt
+parseExpectedValue (Array arr) =
+  T.intercalate "\n" <$> traverse parseLine (foldr (:) [] arr)
+  where
+    parseLine (String txt) = Right txt
+    parseLine _ = Left "expected array entries must be strings"
+parseExpectedValue (Object obj) =
+  T.intercalate "\n" <$> traverse parseModuleExpected (sortOn (Key.toText . fst) (KeyMap.toList obj))
+  where
+    parseModuleExpected (moduleName, value) = do
+      lines' <- parseModuleLines value
+      Right (Key.toText moduleName <> ":\n" <> T.intercalate "\n" (map ("  " <>) lines'))
+    parseModuleLines (String txt) = Right [txt]
+    parseModuleLines (Array arr) = traverse parseLine (foldr (:) [] arr)
+    parseModuleLines _ = Left "expected object values must be strings or arrays"
+    parseLine (String txt) = Right txt
+    parseLine _ = Left "expected array entries must be strings"
+parseExpectedValue _ = Left "expected must be a string, array, or object"
+
+parseExtensions :: Value -> Either String [Extension]
+parseExtensions value = do
+  names <- optionalTextArrayField "extensions" value
+  forM names $ \name ->
+    maybe (Left ("unknown extension: " <> T.unpack name)) Right (parseExtensionName name)
+
+parseExtensionSettings :: Value -> Either String [ExtensionSetting]
+parseExtensionSettings value = do
+  names <- optionalTextArrayField "extensions" value
+  forM names $ \name ->
+    maybe (Left ("unknown extension setting: " <> T.unpack name)) Right (parseExtensionSettingName name)
+
+objectKeys :: KeyMap.KeyMap Value -> Either String [Text]
+objectKeys = Right . map Key.toText . KeyMap.keys
+
+traverseTextObject :: KeyMap.KeyMap Value -> Either String [(Text, Text)]
+traverseTextObject obj =
+  forM (KeyMap.toList obj) $ \(key, value) ->
+    case value of
+      String txt -> Right (Key.toText key, txt)
+      _ -> Left ("object value for " <> T.unpack (Key.toText key) <> " must be a string")
+
+formatterOutputDiffers :: Text -> Text -> Value -> Bool
+formatterOutputDiffers formatterName actual (Object obj) =
+  case KeyMap.lookup "formatters" obj of
+    Just (Object formatters) ->
+      case KeyMap.lookup (Key.fromText formatterName) formatters of
+        Just (Object formatter) ->
+          case KeyMap.lookup "output" formatter of
+            Just (String expected) -> expected /= actual
+            _ -> True
+        _ -> True
+    _ -> True
+formatterOutputDiffers _ _ _ = True
+
+formatterShouldUpdate :: Text -> Value -> Bool
+formatterShouldUpdate formatterName (Object obj) =
+  case KeyMap.lookup "formatters" obj of
+    Just (Object formatters) ->
+      case KeyMap.lookup (Key.fromText formatterName) formatters of
+        Just formatter -> shouldUpdateOutput formatter
+        _ -> False
+    _ -> False
+formatterShouldUpdate _ _ = False
+
+parseModuleText :: [Extension] -> Text -> Either String Module
+parseModuleText exts input =
+  let sourceName = T.unpack (T.takeWhile (/= '\n') input)
+      (errs, ast) =
+        parseModule
+          defaultConfig
+            { parserSourceName = sourceName,
+              parserExtensions = exts
+            }
+          input
+   in if null errs
+        then Right ast
+        else Left (formatParseErrors sourceName (Just input) errs)
+
+parseExprText :: [Extension] -> Text -> Either String Expr
+parseExprText exts input =
+  case parseExpr defaultConfig {parserSourceName = "<expression>", parserExtensions = exts} input of
+    ParseOk expr -> Right expr
+    ParseErr err -> Left (formatParseErrorBundle "<expression>" (Just input) err)
+
+skipForStatus :: Either String Text -> String -> FixtureUpdate
+skipForStatus status err =
+  case T.toLower . T.strip <$> status of
+    Right "pass" -> FixtureSkipped err
+    _ -> FixtureUnchanged
+
+catMaybesEither :: [Maybe a] -> [a]
+catMaybesEither = catMaybes
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace
+
+-- External formatter support is intentionally isolated because missing tools
+-- should never make the all-golden updater fail. The public flag opts into it.
+runExternalFormatter :: Text -> Text -> IO (Maybe (Text, Text))
+runExternalFormatter name input = do
+  mExe <- findExecutable (T.unpack name)
+  case mExe of
+    Nothing -> pure Nothing
+    Just exe ->
+      bracket
+        acquireTempFile
+        releaseTempFile
+        ( \(tmpPath, handle) -> do
+            TIO.hPutStr handle input
+            hClose handle
+            (exitCode, stdout, _stderr) <- readProcessWithExitCode exe [tmpPath] ""
+            formattedFile <- TIO.readFile tmpPath
+            let actual =
+                  if null stdout
+                    then formattedFile
+                    else T.pack stdout
+            pure $
+              case exitCode of
+                ExitSuccess -> Just (name, actual)
+                ExitFailure _ -> Nothing
+        )
+
+acquireTempFile :: IO (FilePath, Handle)
+acquireTempFile = do
+  tmpDir <- getTemporaryDirectory
+  openTempFile tmpDir "aihc-golden-format.hs"
+
+releaseTempFile :: (FilePath, Handle) -> IO ()
+releaseTempFile (tmpPath, handle) = do
+  hClose handle `catch` ignoreIOException
+  removeFile tmpPath `catch` ignoreIOException
+
+ignoreIOException :: IOException -> IO ()
+ignoreIOException _ = pure ()

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -11,6 +11,7 @@ import Aihc.Dev.Snippet
   )
 import Aihc.Parser.Syntax (Extension (TypeApplications), ExtensionSetting (..))
 import Test.ExtractHiCompare (extractHiCompareTests)
+import Test.GoldenUpdate (goldenUpdateTests)
 import Test.ParserCLI.Suite (cliTests)
 import Test.ResolvePackage (resolvePackageTests)
 import Test.ResolveStackageProgress.PathsModule (resolveStackagePathsModuleTests)
@@ -45,6 +46,7 @@ main = do
       QC.testProperty "dummy quickcheck property" prop_dummy,
       extractHiCompareTests,
       resolvePackageTests,
+      goldenUpdateTests,
       resolveStackagePathsModuleTests,
       stackageProgressFileCheckerTests,
       stackageProgressFileCheckerTimingTests,

--- a/tooling/aihc-dev/test/Test/Fixtures/cli/cpp/include-resolved.yaml
+++ b/tooling/aihc-dev/test/Test/Fixtures/cli/cpp/include-resolved.yaml
@@ -7,7 +7,8 @@ includes:
     #define FOO 42
 output: |
   #line 1 "<stdin>"
-  #line 1 "header.h"
+  #line 1 "./header.h"
+
 
   #line 2 "<stdin>"
   main = 42

--- a/tooling/aihc-dev/test/Test/Fixtures/cli/cpp/missing-include.yaml
+++ b/tooling/aihc-dev/test/Test/Fixtures/cli/cpp/missing-include.yaml
@@ -3,8 +3,8 @@ input: |
   main = undefined
 args: ["--cpp"]
 output: |
-  <stdin>:1: error: missing include: missing.h
   #line 1 "<stdin>"
   main = undefined
+  <stdin>:1: error: missing include: missing.h
 exit_code: 1
 status: pass

--- a/tooling/aihc-dev/test/Test/GoldenUpdate.hs
+++ b/tooling/aihc-dev/test/Test/GoldenUpdate.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.GoldenUpdate
+  ( goldenUpdateTests,
+  )
+where
+
+import Aihc.Dev.Golden.Update (replaceYamlValueAt)
+import Data.Aeson (Value (..), object, (.=))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+goldenUpdateTests :: TestTree
+goldenUpdateTests =
+  testGroup
+    "golden-update"
+    [ testCase "replaces nested YAML values without dropping siblings" $ do
+        let input =
+              object
+                [ "formatters"
+                    .= object
+                      [ "aihc-fmt"
+                          .= object
+                            [ "status" .= String "pass",
+                              "output" .= String "old"
+                            ],
+                        "ormolu"
+                          .= object
+                            [ "status" .= String "pass",
+                              "output" .= String "kept"
+                            ]
+                      ]
+                ]
+            expected =
+              object
+                [ "formatters"
+                    .= object
+                      [ "aihc-fmt"
+                          .= object
+                            [ "status" .= String "pass",
+                              "output" .= String "new"
+                            ],
+                        "ormolu"
+                          .= object
+                            [ "status" .= String "pass",
+                              "output" .= String "kept"
+                            ]
+                      ]
+                ]
+        assertEqual
+          "updated object"
+          (Right expected)
+          (replaceYamlValueAt ["formatters", "aihc-fmt", "output"] (String "new") input),
+      testCase "rejects missing YAML paths" $ do
+        let input = object ["output" .= String "old"]
+        assertBool
+          "missing path is rejected"
+          ( case replaceYamlValueAt ["formatters", "aihc-fmt", "output"] (String "new") input of
+              Left _ -> True
+              Right _ -> False
+          )
+    ]

--- a/tooling/aihc-dev/test/Test/ParserCLI/Golden.hs
+++ b/tooling/aihc-dev/test/Test/ParserCLI/Golden.hs
@@ -13,6 +13,7 @@ module Test.ParserCLI.Golden
     Outcome (..),
     CLICase (..),
     fixtureRoot,
+    loadCppCLICases,
     loadLexerCLICases,
     loadParserCLICases,
     parseCLICaseText,
@@ -69,8 +70,14 @@ fixtureRoot = "test/Test/Fixtures/cli"
 lexerFixtureRoot :: FilePath
 lexerFixtureRoot = fixtureRoot </> "lexer"
 
+cppFixtureRoot :: FilePath
+cppFixtureRoot = fixtureRoot </> "cpp"
+
 parserFixtureRoot :: FilePath
 parserFixtureRoot = fixtureRoot </> "parser"
+
+loadCppCLICases :: IO [CLICase]
+loadCppCLICases = loadCases cppFixtureRoot
 
 loadLexerCLICases :: IO [CLICase]
 loadLexerCLICases = loadCases lexerFixtureRoot

--- a/tooling/aihc-dev/test/Test/ParserCLI/Suite.hs
+++ b/tooling/aihc-dev/test/Test/ParserCLI/Suite.hs
@@ -18,17 +18,20 @@ import Test.Tasty.HUnit (assertFailure, testCase)
 cliTests :: IO TestTree
 cliTests = do
   -- Load golden test fixtures
+  cppCases <- CG.loadCppCLICases
   lexerCases <- CG.loadLexerCLICases
   parserCases <- CG.loadParserCLICases
 
   -- Build test trees (both use the unified aihc-parser CLI)
-  let lexerTests = mkCLIGoldenTests lexerCases
+  let cppTests = mkCLIGoldenTests cppCases
+      lexerTests = mkCLIGoldenTests lexerCases
       parserTests = mkCLIGoldenTests parserCases
 
   pure $
     testGroup
       "CLI"
-      [ testGroup "lexer (--lex)" lexerTests,
+      [ testGroup "cpp" cppTests,
+        testGroup "lexer (--lex)" lexerTests,
         testGroup "parser" parserTests
       ]
 


### PR DESCRIPTION
## Summary
- Add `aihc-dev update-goldens` with `--dry-run`, `--root`, and optional external formatter refresh support.
- Refresh current pass golden outputs found by the updater: 5 fixture files updated out of 493 scanned; xfail outputs are intentionally left unchanged.
- Add focused coverage for nested YAML field replacement.

## Validation
- `cabal run -v0 exe:aihc-dev -- update-goldens --dry-run` (0 pending updates)
- `cabal test -v0 aihc-parser:spec --test-options='--pattern parser-golden --hide-successes'`
- `cabal test -v0 aihc-resolve:spec --test-options='--pattern resolver-golden --hide-successes'`
- `cabal test -v0 aihc-tc:spec --test-options='--hide-successes'`
- `cabal test -v0 aihc-dev:spec --test-options='--pattern golden-update --hide-successes'`
- `cabal test -v0 aihc-dev:spec --test-options='--pattern CLI --hide-successes'`
- `just fmt`
- `just check`

## Pre-PR Review
- `coderabbit review --prompt-only` was attempted, but CodeRabbit returned a usage-credit rate limit before producing a review.