### PR TITLE
fix(parser): handle view-pattern QC regressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1614,18 +1614,20 @@ addViewExprParensWith allowLayoutTypeSig expr =
       isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
 
     viewExprTypeSigCanStayBare e =
-      allowLayoutTypeSig
-        && case peelExprAnn e of
-          ECase {} -> True
-          EDo {} -> True
-          EMultiWayIf {} -> True
-          ELambdaCase {} -> True
-          ELambdaCases {} -> True
-          _ -> False
+      allowLayoutTypeSig && isBareViewExprBlock e
 
     isTypeSyntaxExpr e =
       case peelExprAnn e of
         ETypeSyntax {} -> True
+        _ -> False
+
+    isBareViewExprBlock e =
+      case peelExprAnn e of
+        ECase {} -> True
+        EIf {} -> True
+        EMultiWayIf {} -> True
+        ELambdaCase {} -> True
+        ELambdaCases {} -> True
         _ -> False
 
 addPatternAtomParens :: Pattern -> Pattern

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1205,7 +1205,7 @@ prettyExpr expr =
     EGetFieldProjection fields ->
       "." <> mconcat (punctuate "." (map prettyName fields))
     ETypeSig inner ty ->
-      prettyExpr inner <> hardline <> "::" <+> prettyType ty
+      align (prettyExpr inner <> hardline <> "::" <+> prettyType ty)
     EParen inner -> case inner of
       ECase scrutinee alts ->
         parens (prettyCaseExpr prettyCaseLayoutAligned scrutinee alts)
@@ -1402,7 +1402,7 @@ prettyExprAtStatementStart expr =
     ETypeApp fn ty -> prettyExprAtStatementStart fn <> hardline <> " " <> prettyTypeAppArg ty
     EInfix lhs op rhs -> prettyExprAtStatementStart lhs <> hardline <> prettyNameInfixOp op <+> prettyExpr rhs
     ESectionL lhs op -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op
-    ETypeSig inner ty -> prettyExprAtStatementStart inner <> hardline <> "::" <+> prettyType ty
+    ETypeSig inner ty -> prettyExprAtStatementStart inner <> hardline <> indent 2 ("::" <+> prettyType ty)
     ERecordUpd base fields ->
       prettyExprAtStatementStart base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
     EGetField base field ->

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -30,6 +30,7 @@ import Test.Oracle.Suite (oracleTests)
 import Test.Parser.Suite (parserGoldenTests)
 import Test.Performance.Suite (parserPerformanceTests)
 import Test.Properties.Arb.Decl (genDeclClass, genDeclDataFamilyInst, shrinkDecl)
+import Test.Properties.Arb.Expr (shrinkExpr)
 import Test.Properties.Arb.Identifiers
   ( genConSym,
     genVarSym,
@@ -120,7 +121,7 @@ assertParsedStrippedPatternShapeRoundTrip config source =
             ParseOk reparsed ->
               assertEqual "reparsed pattern" (stripAnnotations stripped) (stripAnnotations (stripParens reparsed))
             ParseErr bundle ->
-              assertFailure ("expected pretty-printed pattern to reparse, got:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+              assertFailure ("expected pretty-printed pattern to reparse:\n" <> T.unpack rendered <> "\ngot:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
     ParseErr bundle ->
       assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
 
@@ -265,6 +266,8 @@ buildTests = do
             testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
+            testCase "pretty-prints typed view expressions without invalid layout" test_typedViewExprPrettyLayout,
+            testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
             localOption (QC.QuickCheckTests 2000) $
@@ -1441,6 +1444,56 @@ test_viewExprArrowCommandTypeSigRhsParens = do
          -> C {})
         """
   assertParsedStrippedPatternShapeRoundTrip config source
+
+test_typedViewExprPrettyLayout :: Assertion
+test_typedViewExprPrettyLayout = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  assertParsedStrippedExprShapeRoundTrip
+    config
+    """
+    do
+      (([]
+        :: _)
+       -> _) <- []
+      []
+    """
+  assertParsedStrippedPatternShapeRoundTrip
+    config
+    """
+    ((if | let _ = []
+            ->
+             []
+       :: _)
+     -> _)
+    """
+
+test_shrunkDoExpressionsKeepFinalExpression :: Assertion
+test_shrunkDoExpressionsKeepFinalExpression = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      source =
+        """
+        do
+          (([] :: _) -> _) <- []
+          []
+        """
+  case parseExpr config source of
+    ParseOk expr ->
+      let invalidShrinks = [stmts | EDo stmts _ <- shrinkExpr expr, not (testDoStmtsEndInExpr stmts)]
+       in assertEqual "invalid do-statement shrinks" [] invalidShrinks
+    ParseErr bundle ->
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+testDoStmtsEndInExpr :: [DoStmt Expr] -> Bool
+testDoStmtsEndInExpr stmts =
+  case reverse stmts of
+    stmt : _ -> testIsDoExprStmt stmt
+    [] -> False
+
+testIsDoExprStmt :: DoStmt Expr -> Bool
+testIsDoExprStmt stmt =
+  case peelDoStmtAnn stmt of
+    DoExpr {} -> True
+    _ -> False
 
 test_arrowCommandLhsLambdaCaseParens :: Assertion
 test_arrowCommandLhsLambdaCaseParens = do

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/view-pattern-if-multiway-if-type-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/view-pattern-if-multiway-if-type-signature.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE UnboxedSums #-}
+{-# LANGUAGE ViewPatterns #-}
+module M where
+
+x (#
+     | if [] then [] else if | []
+                                ->
+                                 []
+                                  :: _
+      -> _
+     |  #) = ()

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -753,8 +753,20 @@ whereValueRhss decls =
 shrinkDoStmts :: [DoStmt Expr] -> [[DoStmt Expr]]
 shrinkDoStmts stmts =
   case stmts of
-    [stmt] -> [[stmt'] | stmt' <- shrinkDoStmt stmt]
-    _ -> shrinkList shrinkDoStmt stmts
+    [stmt] -> [[stmt'] | stmt' <- shrinkDoStmt stmt, isDoExprStmt stmt']
+    _ -> [stmts' | stmts' <- shrinkList shrinkDoStmt stmts, doStmtsEndInExpr stmts']
+
+doStmtsEndInExpr :: [DoStmt Expr] -> Bool
+doStmtsEndInExpr stmts =
+  case reverse stmts of
+    stmt : _ -> isDoExprStmt stmt
+    [] -> False
+
+isDoExprStmt :: DoStmt Expr -> Bool
+isDoExprStmt stmt =
+  case peelDoStmtAnn stmt of
+    DoExpr {} -> True
+    _ -> False
 
 shrinkDoFlavor :: DoFlavor -> [DoFlavor]
 shrinkDoFlavor flavor =


### PR DESCRIPTION
## What changed

- Avoids adding view-expression parentheses for the reduced delimited `if ... else if | ... :: _` pattern case by tightening the existing bare-layout rule instead of adding a new paren path.
- Fixes expression type-signature layout so nested signatures align with the expression they annotate, while statement-start signatures remain indented inside `do` blocks.
- Keeps generated `do` expression shrinks valid by preserving the final expression statement invariant.
- Adds source-based parser unit regressions for required parens and an oracle fixture for the no-extra-parens case.

## Root cause

- The delimited view-pattern rule was too narrow about which layout expressions can remain bare, so it inserted an unnecessary `EParen` around the first counterexample.
- Expression type signatures were rendered with `::` at the surrounding layout column, which could make a view-pattern expression line up with the containing `do` statement and become invalid or parse as the wrong AST.
- The `EDo` shrinker used generic list shrinking, which could remove the required final `DoExpr` and produce invalid generated modules.

## Progress counts

- Parser unit tests: +2 focused source-based regressions.
- Parser oracle fixtures: +1 pass fixture.
- README progress counts unchanged; README updates are cron-managed.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern parser --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle --hide-successes"`
- `just replay "(SMGen 2086803663951877415 4296295014289719877,71)"`
- `just replay "(SMGen 5436112648842847755 2654321176732544493,91)"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
