### PR TITLE
docs: update test authoring skill

### DIFF
--- a/.agents/skills/aihc-test-authoring/SKILL.md
+++ b/.agents/skills/aihc-test-authoring/SKILL.md
@@ -13,7 +13,8 @@ Use this skill to decide which AIHC test framework matches a change, then load t
 2. Choose the narrowest test that proves the behavior.
 3. Read the matching component reference before creating or changing fixtures.
 4. Add a minimal regression case plus nearby corner cases when the behavior has boundaries.
-5. Run the narrow component test first, then the repository check required by `AGENTS.md` before commit.
+5. If the expected output should be derived from the current implementation, use `cabal run -v0 aihc-dev -- update-goldens` as described in `references/validation.md`.
+6. Run the narrow component test first, then the repository check required by `AGENTS.md` before commit.
 
 ## Which Test To Use
 

--- a/.agents/skills/aihc-test-authoring/references/aihc-fc.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-fc.md
@@ -40,6 +40,7 @@ Fixture shape:
 
 ```yaml
 extensions: []
+dependencies: []
 modules:
   - |
     module Test where
@@ -51,7 +52,13 @@ status: pass
 reason: renders evaluated list literals in raw constructor form
 ```
 
-Required keys: `extensions`, `modules`, `expression`, `output`, `status`. The fixture must define at least one module. The runner parses modules and expression, synthesizes an `__aihc_eval__` binding, desugars with synthetic type-checker output, evaluates that binding, and compares rendered raw value.
+Required keys: `extensions`, `modules`, `expression`, `output`, `status`. `dependencies` is optional and defaults to `[]`, but include it explicitly when the fixture relies on shared library modules.
+
+Use `dependencies: [aihc-base]` when an eval fixture depends on `Prelude` names or modules from `core-libs/aihc-base` instead of defining all dependencies inline in `modules`. The runner loads `aihc-base` from `core-libs/aihc-base` by default. Set `AIHC_BASE_SRC` only when local development, CI, or branch testing needs the fixture runner to use a modified or alternate `aihc-base` checkout; the value must be the package root whose `src` tree should replace the default `core-libs/aihc-base`. Dependency loading starts from `Prelude` plus the fixture modules' imports and follows imports transitively. Unknown dependency names fail the fixture.
+
+Keep self-contained eval fixtures dependency-free: define helper functions and operators in `modules` when the behavior under test is local FC evaluation rather than integration with `aihc-base`.
+
+The runner parses modules and expression, synthesizes an `__aihc_eval__` binding in the last fixture module, resolves dependency modules before fixture modules, desugars with synthetic type-checker output, evaluates that binding, and compares rendered raw value.
 
 ## Validation
 
@@ -60,3 +67,12 @@ Run:
 ```bash
 cabal test -v0 aihc-fc:spec --test-options="--hide-successes"
 ```
+
+To refresh expected `expected` or `output` fields from the current implementation, run the shared updater from the repository root:
+
+```bash
+cabal run -v0 aihc-dev -- update-goldens --dry-run
+cabal run -v0 aihc-dev -- update-goldens
+```
+
+Always rerun the FC suite afterwards. For eval fixtures with `dependencies`, treat the FC suite as the authority because it loads dependency modules through the eval fixture runner. The updater may skip dependency-backed eval fixtures when its inline-module path cannot resolve `Prelude` or `aihc-base` names, or when parsing, resolving, desugaring, or evaluating the fixture fails while computing a replacement `output`. These skips are distinct from the `fail` and `xfail` status skips described in `validation.md`; keep the fixture unchanged and use the FC suite failure output to decide whether the expected value should change.

--- a/.agents/skills/aihc-test-authoring/references/validation.md
+++ b/.agents/skills/aihc-test-authoring/references/validation.md
@@ -16,6 +16,21 @@ Use narrow commands while developing, then run the mandatory checks before commi
 - FC golden/eval: `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
 - CPP oracle/unit suite: `cabal test -v0 aihc-cpp:spec --test-options="--hide-successes"`
 
+## Updating Golden Outputs
+
+Use the golden updater when a fixture's expected output should be regenerated from the current implementation instead of hand-written:
+
+```bash
+cabal run -v0 aihc-dev -- update-goldens --dry-run
+cabal run -v0 aihc-dev -- update-goldens
+```
+
+Run it from the repository root. Use `--root <dir>` only when invoking it from another working directory. The updater scans parser AST goldens, lexer goldens, parser error messages, resolver goldens, TC goldens, FC goldens, FC eval outputs, formatter goldens, and parser CLI goldens. It updates generated expectation fields such as `ast`, `tokens`, `expected`, `output`, and `annotated` only for `pass` and `xpass` fixtures; `fail` and `xfail` cases are skipped because their expected output is not the current success contract.
+
+After running without `--dry-run`, inspect the diff before accepting it. A changed golden is evidence that behavior changed, not evidence that the new behavior is correct. Keep intentional fixture metadata (`status`, `reason`, extension lists, dependencies, module sources, and expression sources) under review.
+
+Use `--external-formatters` only when intentionally refreshing formatter goldens for external tools that are installed locally. Otherwise the updater refreshes the in-repo formatter outputs and skips external formatter outputs.
+
 ## Pre-Commit
 
 Before every commit:


### PR DESCRIPTION
## Summary

- Documented when and how to refresh generated golden fixture expectations with `cabal run -v0 aihc-dev -- update-goldens`.
- Added FC eval fixture guidance for the new `dependencies` field, including `dependencies: [aihc-base]`, `AIHC_BASE_SRC`, and dependency-backed updater skip behavior.
- Linked the top-level `aihc-test-authoring` workflow to the shared golden updater instructions.

## Progress counts

No progress counts changed; this is skill documentation only.

## Validation

- `cabal run -v0 aihc-dev -- update-goldens --dry-run` scanned 503 fixtures, updated 0, and skipped the expected dependency-backed FC eval fixtures.
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` returned no findings on the final diff.
