### PR TITLE
test(parser): check minimal type parentheses contexts

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -25,6 +25,7 @@ module Aihc.Parser
 
     -- * Parsing expressions, patterns, types, and declarations
     parseExpr,
+    parseSignatureType,
     parseType,
     parsePattern,
     parseDecl,
@@ -36,7 +37,7 @@ import Aihc.Parser.Internal.Decl (declParser)
 import Aihc.Parser.Internal.Expr (exprParser)
 import Aihc.Parser.Internal.Module (moduleParser)
 import Aihc.Parser.Internal.Pattern (patternParser)
-import Aihc.Parser.Internal.Type (typeParser)
+import Aihc.Parser.Internal.Type (typeParser, typeSignatureParser)
 import Aihc.Parser.Lex
   ( LexToken (..),
     TokenOrigin (..),
@@ -117,13 +118,30 @@ parsePattern cfg input =
         Left bundle -> ParseErr bundle
         Right pat -> ParseOk pat
 
--- | Parse a Haskell type.
+-- | Parse a Haskell signature type.
+--
+-- This is the context used by top-level type signatures. Unlike 'parseType',
+-- it rejects an unparenthesized outer kind signature:
+--
+-- >>> case parseSignatureType defaultConfig "_ :: _" of { ParseErr _ -> "error"; ParseOk _ -> "ok" }
+-- "error"
+parseSignatureType :: ParserConfig -> Text -> ParseResult Type
+parseSignatureType cfg input =
+  let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
+   in case runParser (typeSignatureParser <* eofTok) (parserSourceName cfg) ts of
+        Left bundle -> ParseErr bundle
+        Right ty -> ParseOk ty
+
+-- | Parse a Haskell type in the general declaration RHS context.
 --
 -- >>> shorthand $ parseType defaultConfig "Int -> Bool"
 -- ParseOk (TFun (TCon "Int") (TCon "Bool"))
 --
 -- >>> shorthand $ parseType defaultConfig "Maybe a"
 -- ParseOk (TApp (TCon "Maybe") (TVar "a"))
+--
+-- >>> shorthand $ parseType defaultConfig "_ :: _"
+-- ParseOk (TKindSig (TWildcard) (TWildcard))
 parseType :: ParserConfig -> Text -> ParseResult Type
 parseType cfg input =
   let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Decl.hs
@@ -13,7 +13,7 @@ import Aihc.Parser.Internal.Common
 import {-# SOURCE #-} Aihc.Parser.Internal.Expr (equationRhsParser, exprParser)
 import Aihc.Parser.Internal.Import (warningPragmaParser)
 import Aihc.Parser.Internal.Pattern (apatParser, lpatParser, patParser, patternParser)
-import Aihc.Parser.Internal.Type (arrowKindParser, forallTelescopeParser, typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser)
+import Aihc.Parser.Internal.Type (arrowKindParser, forallTelescopeParser, typeAppParser, typeAtomParser, typeInfixOperatorParser, typeInfixParser, typeParser, typeSignatureParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind, pattern TkVarFamily, pattern TkVarRole)
 import Aihc.Parser.Syntax
 import Aihc.Parser.Types (ParserErrorComponent (..), mkFoundToken)
@@ -533,7 +533,7 @@ instanceNewtypeFamilyInstParser = withSpanAnn (InstanceItemAnn . mkAnnotation) $
 typeSigDeclParser :: TokParser Decl
 typeSigDeclParser =
   withSpanAnn (DeclAnn . mkAnnotation) $
-    uncurry DeclTypeSig <$> typedSignaturePrefixParser typeParser
+    uncurry DeclTypeSig <$> typedSignaturePrefixParser typeSignatureParser
 
 -- | Parse a type signature or a pattern-typed equation.
 --
@@ -551,7 +551,7 @@ typeSigOrPatternTypeSigDeclParser :: TokParser Decl
 typeSigOrPatternTypeSigDeclParser =
   withSpanAnn (DeclAnn . mkAnnotation) $
     typedBindingOrSignatureParser
-      typeParser
+      typeSignatureParser
       DeclTypeSig
       ( \name ty -> do
           rhs <- equationRhsParser
@@ -699,7 +699,7 @@ classDefaultSigItemParser = withSpanAnn (ClassItemAnn . mkAnnotation) $ do
   expectedTok TkKeywordDefault
   name <- binderNameParser
   expectedTok TkReservedDoubleColon
-  ClassItemDefaultSig name <$> typeParser
+  ClassItemDefaultSig name <$> typeSignatureParser
 
 classFixityItemParser :: TokParser ClassDeclItem
 classFixityItemParser = fixityItemParser (ClassItemAnn . mkAnnotation) ClassItemFixity
@@ -793,7 +793,7 @@ instanceValueItemParser = valueItemParser (InstanceItemAnn . mkAnnotation) Insta
 -- Shared class/instance item helpers
 
 typeSigItemParser :: (SourceSpan -> a -> a) -> ([UnqualifiedName] -> Type -> a) -> TokParser a
-typeSigItemParser ann ctor = withSpanAnn ann $ uncurry ctor <$> typedSignaturePrefixParser typeParser
+typeSigItemParser ann ctor = withSpanAnn ann $ uncurry ctor <$> typedSignaturePrefixParser typeSignatureParser
 
 fixityItemParser :: (SourceSpan -> a -> a) -> (FixityAssoc -> Maybe IEEntityNamespace -> Maybe Int -> [UnqualifiedName] -> a) -> TokParser a
 fixityItemParser ann ctor = withSpanAnn ann $ do
@@ -817,7 +817,7 @@ foreignDeclParser = withSpanAnn (DeclAnn . mkAnnotation) $ do
   entity <- MP.optional foreignEntityParser
   name <- binderNameParser
   expectedTok TkReservedDoubleColon
-  ty <- typeParser
+  ty <- typeSignatureParser
   pure $
     DeclForeign
       ForeignDecl
@@ -1563,7 +1563,7 @@ patternSynonymSigDeclParser = do
   expectedTok TkKeywordPattern
   names <- patSynNameParser `MP.sepBy1` expectedTok TkSpecialComma
   expectedTok TkReservedDoubleColon
-  DeclPatSynSig names <$> typeParser
+  DeclPatSynSig names <$> typeSignatureParser
 
 patSynNameParser :: TokParser UnqualifiedName
 patSynNameParser =

--- a/components/aihc-parser/src/Aihc/Parser/Internal/FromTokens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/FromTokens.hs
@@ -13,6 +13,7 @@
 module Aihc.Parser.Internal.FromTokens
   ( parseExprFromTokens,
     parsePatternFromTokens,
+    parseSignatureTypeFromTokens,
     parseTypeFromTokens,
     parseModuleFromTokens,
     parseDeclFromTokens,
@@ -27,7 +28,7 @@ import Aihc.Parser.Internal.Expr (exprParser)
 import Aihc.Parser.Internal.Import (importDeclParser, moduleHeaderParser)
 import Aihc.Parser.Internal.Module (moduleParser)
 import Aihc.Parser.Internal.Pattern (patternParser)
-import Aihc.Parser.Internal.Type (typeParser)
+import Aihc.Parser.Internal.Type (typeParser, typeSignatureParser)
 import Aihc.Parser.Lex (LexToken)
 import Aihc.Parser.Syntax (Decl, Expr, ImportDecl, Module, ModuleHead, Pattern, Type)
 import Aihc.Parser.Types
@@ -44,6 +45,9 @@ parseExprFromTokens = parseFromTokens exprParser
 
 parsePatternFromTokens :: FilePath -> [LexToken] -> ParseResult Pattern
 parsePatternFromTokens = parseFromTokens patternParser
+
+parseSignatureTypeFromTokens :: FilePath -> [LexToken] -> ParseResult Type
+parseSignatureTypeFromTokens = parseFromTokens typeSignatureParser
 
 parseTypeFromTokens :: FilePath -> [LexToken] -> ParseResult Type
 parseTypeFromTokens = parseFromTokens typeParser

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -73,13 +73,21 @@ contextOrFunSignatureTypeParser = do
   if isContextType then contextSignatureTypeParser else typeFunSignatureParser
 
 contextSignatureTypeParser :: TokParser Type
-contextSignatureTypeParser = contextTypeParserWith typeSignatureParser
+contextSignatureTypeParser = do
+  constraints <- contextItemsParserWith typeSignatureParser typeSignatureContextAtomParser
+  expectedTok TkReservedDoubleArrow
+  TContext constraints <$> typeSignatureParser
 
 -- | Report core plus extension infix-type support:
 --
 -- > type -> btype ['->' type]
 typeFunSignatureParser :: TokParser Type
-typeFunSignatureParser = typeFunParserWith typeSignatureParser
+typeFunSignatureParser = do
+  lhs <- typeSignatureInfixParser
+  mArrow <- MP.optional arrowKindParser
+  case mArrow of
+    Nothing -> pure lhs
+    Just arrowKind -> TFun arrowKind lhs <$> typeSignatureParser
 
 contextOrFunTypeParser :: TokParser Type
 contextOrFunTypeParser = do
@@ -148,7 +156,7 @@ contextTypeParserWith rhsParser = do
 -- > type -> btype ['->' type]
 -- > btype -> [btype] atype
 typeFunParser :: TokParser Type
-typeFunParser = typeFunParserWith typeParser
+typeFunParser = typeFunParserWith typeSignatureParser
 
 typeFunParserWith :: TokParser Type -> TokParser Type
 typeFunParserWith rhsParser = do
@@ -196,8 +204,24 @@ multiplicityToArrowKind ty =
 typeInfixParser :: TokParser Type
 typeInfixParser = do
   lhs <- typeAppParser
-  rest <- MP.many ((,) <$> typeInfixOperatorParser <*> typeAppParser)
+  rest <- MP.many ((,) <$> typeInfixOperatorParser <*> typeInfixRhsParser)
   pure (foldInfixR buildInfixType lhs rest)
+
+typeInfixRhsParser :: TokParser Type
+typeInfixRhsParser = do
+  rhs <- typeAppParser
+  rejectBareTypeImplicitParam rhs
+
+typeSignatureInfixParser :: TokParser Type
+typeSignatureInfixParser = do
+  lhs <- typeSignatureAppParser
+  rest <- MP.many ((,) <$> typeInfixOperatorParser <*> typeSignatureInfixRhsParser)
+  pure (foldInfixR buildInfixType lhs rest)
+
+typeSignatureInfixRhsParser :: TokParser Type
+typeSignatureInfixRhsParser = do
+  rhs <- typeSignatureAppParser
+  rejectBareSignatureImplicitParam rhs
 
 -- | Parse a type head that may contain infix operators but NOT type applications.
 -- Used for type family heads like @type family l `And` r@ where the head is
@@ -276,16 +300,46 @@ typeAppParser = do
   rest <- MP.many typeAppArgParser
   pure (foldl applyTypeAppArg first rest)
 
+typeSignatureAppParser :: TokParser Type
+typeSignatureAppParser = do
+  first <- typeSignatureAtomParser
+  rest <- MP.many typeSignatureAppArgParser
+  pure (foldl applyTypeAppArg first rest)
+
 buildTypeApp :: Type -> Type -> Type
 buildTypeApp = TApp
 
 typeAppArgParser :: TokParser (Either Type Type)
-typeAppArgParser = (Left <$> MP.try invisibleTypeAppParser) <|> (Right <$> typeAtomParser)
+typeAppArgParser =
+  (Left <$> MP.try invisibleTypeAppParser)
+    <|> (Right <$> (typeAtomParser >>= rejectBareTypeImplicitParam))
 
 invisibleTypeAppParser :: TokParser Type
 invisibleTypeAppParser = do
   expectedTok TkTypeApp
-  typeAtomParser
+  typeAtomParser >>= rejectBareTypeImplicitParam
+
+typeSignatureAppArgParser :: TokParser (Either Type Type)
+typeSignatureAppArgParser =
+  (Left <$> MP.try invisibleSignatureTypeAppParser)
+    <|> (Right <$> (typeSignatureAtomParser >>= rejectBareSignatureImplicitParam))
+
+typeSignatureContextAtomParser :: TokParser Type
+typeSignatureContextAtomParser = typeSignatureAtomParser >>= rejectBareSignatureImplicitParam
+
+rejectBareSignatureImplicitParam :: Type -> TokParser Type
+rejectBareSignatureImplicitParam = rejectBareTypeImplicitParam
+
+rejectBareTypeImplicitParam :: Type -> TokParser Type
+rejectBareTypeImplicitParam ty =
+  case peelTypeAnn ty of
+    TImplicitParam {} -> fail "implicit parameter type must be parenthesized"
+    _ -> pure ty
+
+invisibleSignatureTypeAppParser :: TokParser Type
+invisibleSignatureTypeAppParser = do
+  expectedTok TkTypeApp
+  typeSignatureAtomParser >>= rejectBareSignatureImplicitParam
 
 applyTypeAppArg :: Type -> Either Type Type -> Type
 applyTypeAppArg fn (Left ty) = TTypeApp fn ty
@@ -317,12 +371,33 @@ typeAtomParser = do
     <|> typeWildcardParser
     <|> typeIdentifierParser
 
--- | Parse an implicit parameter type: @?name :: Type@
+typeSignatureAtomParser :: TokParser Type
+typeSignatureAtomParser = do
+  thAny <- thAnyEnabled
+  ipEnabled <- isExtensionEnabled ImplicitParams
+  MP.try promotedTypeParser
+    <|> typeLiteralTypeParser
+    <|> typeQuasiQuoteParser
+    <|> (if thAny then thSpliceTypeParser else MP.empty)
+    <|> (if ipEnabled then typeImplicitParamParser else MP.empty)
+    <|> typeListParser
+    <|> MP.try typeParenOperatorParser
+    <|> typeParenOrTupleParser
+    <|> typeStarParser
+    <|> typeWildcardParser
+    <|> typeIdentifierParser
+
+-- | Parse an implicit parameter type.
+--
+-- The body uses 'typeSignatureParser' so @?x :: (T :: K)@ is accepted
+-- through the parenthesized atom grammar, but @?x :: T :: K@ is left for an
+-- outer kind-signature parser in a plain type context and rejected in a
+-- signature context.
 typeImplicitParamParser :: TokParser Type
 typeImplicitParamParser = withSpanAnn (TAnn . mkAnnotation) $ do
   name <- implicitParamNameParser
   expectedTok TkReservedDoubleColon
-  TImplicitParam name <$> typeParser
+  TImplicitParam name <$> typeSignatureParser
 
 typeWildcardParser :: TokParser Type
 typeWildcardParser = withSpanAnn (TAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -19,12 +19,14 @@
 -- * 'addDeclParens'    — parenthesise a declaration
 -- * 'addExprParens'    — parenthesise an expression
 -- * 'addPatternParens' — parenthesise a pattern
--- * 'addTypeParens'    — parenthesise a type
+-- * 'addSignatureTypeParens' — parenthesise a signature type
+-- * 'addTypeParens'          — parenthesise a plain type
 module Aihc.Parser.Parens
   ( addModuleParens,
     addDeclParens,
     addExprParens,
     addPatternParens,
+    addSignatureTypeParens,
     addTypeParens,
   )
 where
@@ -390,9 +392,13 @@ addSectionLhsParens expr =
 
 data TypeCtx
   = CtxTypeFunArg
+  | CtxTypeInfixRhs
+  | CtxTypeDelimitedInfixRhs
   | CtxTypeAppFun
   | CtxTypeAppArg
+  | CtxTypeDelimitedAppArg
   | CtxTypeAppVisibleArg
+  | CtxTypeDelimitedAppVisibleArg
   | CtxTypeFamilyOperand
   | CtxTypeAtom
   | CtxKindSig
@@ -408,6 +414,20 @@ needsTypeParens ctx ty =
         TContext {} -> True
         -- TImplicitParam parses greedily: ?x :: T -> U absorbs -> U into the
         -- implicit param type, so TFun (TImplicitParam ..) .. needs parens.
+        TImplicitParam {} -> True
+        _ -> False
+    CtxTypeInfixRhs ->
+      case ty of
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        TImplicitParam {} -> True
+        _ -> False
+    CtxTypeDelimitedInfixRhs ->
+      case ty of
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
         TImplicitParam {} -> True
         _ -> False
     CtxTypeAppFun ->
@@ -427,8 +447,20 @@ needsTypeParens ctx ty =
         TFun {} -> True
         TContext {} -> True
         TInfix {} -> True
-        TSplice {} -> False
         TImplicitParam {} -> True
+        TSplice {} -> False
+        _ -> False
+    CtxTypeDelimitedAppArg ->
+      case ty of
+        TQuasiQuote {} -> False
+        TApp {} -> True
+        TTypeApp {} -> True
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        TInfix {} -> True
+        TImplicitParam {} -> True
+        TSplice {} -> False
         _ -> False
     CtxTypeAppVisibleArg ->
       case ty of
@@ -447,6 +479,19 @@ needsTypeParens ctx ty =
         TSplice {} -> True
         -- TImplicitParam parses greedily: as a TApp argument ?x :: T -> U absorbs
         -- the surrounding -> U into the implicit param type.
+        TImplicitParam {} -> True
+        _ -> False
+    CtxTypeDelimitedAppVisibleArg ->
+      case ty of
+        TQuasiQuote {} -> False
+        TApp {} -> True
+        TTypeApp {} -> True
+        TForall {} -> True
+        TFun {} -> True
+        TContext {} -> True
+        TInfix {} -> True
+        TStar {} -> True
+        TSplice {} -> True
         TImplicitParam {} -> True
         _ -> False
     CtxTypeFamilyOperand ->
@@ -541,21 +586,21 @@ addDeclParens decl =
   case decl of
     DeclAnn ann sub -> DeclAnn ann (addDeclParens sub)
     DeclValue vdecl -> DeclValue (addValueDeclParens vdecl)
-    DeclTypeSig names ty -> DeclTypeSig names (addTypeParens ty)
+    DeclTypeSig names ty -> DeclTypeSig names (addSignatureTypeParens ty)
     DeclPatSyn ps -> DeclPatSyn (addPatSynDeclParens ps)
-    DeclPatSynSig names ty -> DeclPatSynSig names (addTypeParens ty)
-    DeclStandaloneKindSig name kind -> DeclStandaloneKindSig name (addTypeParens kind)
+    DeclPatSynSig names ty -> DeclPatSynSig names (addSignatureTypeParens ty)
+    DeclStandaloneKindSig name kind -> DeclStandaloneKindSig name (addSignatureTypeParens kind)
     DeclFixity {} -> decl
     DeclRoleAnnotation {} -> decl
     DeclTypeSyn synDecl ->
-      DeclTypeSyn (synDecl {typeSynBody = addTypeTopLevelParens (typeSynBody synDecl)})
+      DeclTypeSyn (synDecl {typeSynBody = addTypeParens (typeSynBody synDecl)})
     DeclData dataDecl -> DeclData (addDataDeclParens dataDecl)
     DeclTypeData dataDecl -> DeclTypeData (addDataDeclParens dataDecl)
     DeclNewtype newtypeDecl -> DeclNewtype (addNewtypeDeclParens newtypeDecl)
     DeclClass classDecl -> DeclClass (addClassDeclParens classDecl)
     DeclInstance instanceDecl -> DeclInstance (addInstanceDeclParens instanceDecl)
     DeclStandaloneDeriving derivingDecl -> DeclStandaloneDeriving (addStandaloneDerivingParens derivingDecl)
-    DeclDefault tys -> DeclDefault (map addTypeParens tys)
+    DeclDefault tys -> DeclDefault (map addSignatureTypeParens tys)
     DeclForeign foreignDecl -> DeclForeign (addForeignDeclParens foreignDecl)
     DeclSplice body -> DeclSplice (addDeclSpliceParens body)
     DeclTypeFamilyDecl tf -> DeclTypeFamilyDecl (addTypeFamilyDeclParens tf)
@@ -580,7 +625,7 @@ addPatternBindLhsParens pat rhs =
     PTypeSig inner ty ->
       wrapPat
         (typedPatternBindLhsNeedsParens inner)
-        (PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty))
+        (PTypeSig (addPatternInfixOperandParens inner) (addSignatureTypeParens ty))
     _ -> addPatternParens pat
 
 typedPatternBindLhsNeedsParens :: Pattern -> Bool
@@ -672,7 +717,7 @@ addDataDeclParens decl =
   decl
     { dataDeclCTypePragma = fmap stripPragmaRawText (dataDeclCTypePragma decl),
       dataDeclContext = addContextConstraints (dataDeclContext decl),
-      dataDeclKind = fmap addTypeParens (dataDeclKind decl),
+      dataDeclKind = fmap addSignatureTypeParens (dataDeclKind decl),
       dataDeclConstructors = map addDataConDeclParens (dataDeclConstructors decl),
       dataDeclDeriving = map addDerivingClauseParens (dataDeclDeriving decl)
     }
@@ -682,7 +727,7 @@ addNewtypeDeclParens decl =
   decl
     { newtypeDeclCTypePragma = fmap stripPragmaRawText (newtypeDeclCTypePragma decl),
       newtypeDeclContext = addContextConstraints (newtypeDeclContext decl),
-      newtypeDeclKind = fmap addTypeParens (newtypeDeclKind decl),
+      newtypeDeclKind = fmap addSignatureTypeParens (newtypeDeclKind decl),
       newtypeDeclConstructor = fmap addDataConDeclParens (newtypeDeclConstructor decl),
       newtypeDeclDeriving = map addDerivingClauseParens (newtypeDeclDeriving decl)
     }
@@ -696,14 +741,14 @@ addDerivingClauseParens dc =
     { derivingClasses =
         case derivingClasses dc of
           Left name -> Left name
-          Right classes -> Right (map addTypeParens classes),
+          Right classes -> Right (map addSignatureTypeParens classes),
       derivingStrategy = fmap addDerivingStrategyParens (derivingStrategy dc)
     }
 
 addDerivingStrategyParens :: DerivingStrategy -> DerivingStrategy
 addDerivingStrategyParens strategy =
   case strategy of
-    DerivingVia ty -> DerivingVia (addTypeParens ty)
+    DerivingVia ty -> DerivingVia (addSignatureTypeParens ty)
     _ -> strategy
 
 addDataConDeclParens :: DataConDecl -> DataConDecl
@@ -815,7 +860,7 @@ prefixConBangTypeNeedsParens _ = False
 addRecordFieldDeclParens :: FieldDecl -> FieldDecl
 addRecordFieldDeclParens fd =
   fd
-    { fieldMultiplicity = fmap addTypeParens (fieldMultiplicity fd),
+    { fieldMultiplicity = fmap addSignatureTypeParens (fieldMultiplicity fd),
       fieldType = addRecordFieldBangTypeParens (fieldType fd)
     }
 
@@ -827,7 +872,7 @@ addRecordFieldBangTypeParens bt =
           ( (bangStrict bt || bangLazy bt)
               && bangTypeNeedsPrefixParens (bangType bt)
           )
-          (addTypeParens (bangType bt))
+          (addSignatureTypeParens (bangType bt))
     }
 
 addGadtBodyParens :: GadtBody -> GadtBody
@@ -841,7 +886,7 @@ addGadtBodyParens body =
       GadtPrefixBody (map (Data.Bifunctor.bimap addGadtBangTypeParens addArrowKindParens) args) (addTypeIn CtxTypeFunArg resultTy)
     GadtRecordBody fields resultTy ->
       -- Record GADT result type uses typeParser so any type is fine here.
-      GadtRecordBody (map addRecordFieldDeclParens fields) (addTypeParens resultTy)
+      GadtRecordBody (map addRecordFieldDeclParens fields) (addSignatureTypeParens resultTy)
 
 addGadtBangTypeParens :: BangType -> BangType
 addGadtBangTypeParens bt =
@@ -865,8 +910,8 @@ addClassItemParens :: ClassDeclItem -> ClassDeclItem
 addClassItemParens item =
   case item of
     ClassItemAnn ann sub -> ClassItemAnn ann (addClassItemParens sub)
-    ClassItemTypeSig names ty -> ClassItemTypeSig names (addTypeParens ty)
-    ClassItemDefaultSig name ty -> ClassItemDefaultSig name (addTypeParens ty)
+    ClassItemTypeSig names ty -> ClassItemTypeSig names (addSignatureTypeParens ty)
+    ClassItemDefaultSig name ty -> ClassItemDefaultSig name (addSignatureTypeParens ty)
     ClassItemFixity {} -> item
     ClassItemDefault vdecl -> ClassItemDefault (addValueDeclParens vdecl)
     ClassItemTypeFamilyDecl tf -> ClassItemTypeFamilyDecl (addTypeFamilyDeclParens tf)
@@ -878,7 +923,7 @@ addInstanceDeclParens :: InstanceDecl -> InstanceDecl
 addInstanceDeclParens decl =
   decl
     { instanceDeclContext = addContextConstraints (instanceDeclContext decl),
-      instanceDeclHead = addTypeParens (instanceDeclHead decl),
+      instanceDeclHead = addSignatureTypeParens (instanceDeclHead decl),
       instanceDeclItems = map addInstanceItemParens (instanceDeclItems decl)
     }
 
@@ -887,7 +932,7 @@ addInstanceItemParens item =
   case item of
     InstanceItemAnn ann inner -> InstanceItemAnn ann (addInstanceItemParens inner)
     InstanceItemBind vdecl -> InstanceItemBind (addValueDeclParens vdecl)
-    InstanceItemTypeSig names ty -> InstanceItemTypeSig names (addTypeParens ty)
+    InstanceItemTypeSig names ty -> InstanceItemTypeSig names (addSignatureTypeParens ty)
     InstanceItemFixity {} -> item
     InstanceItemTypeFamilyInst tfi -> InstanceItemTypeFamilyInst (addTypeFamilyInstParens tfi)
     InstanceItemDataFamilyInst dfi -> InstanceItemDataFamilyInst (addDataFamilyInstParens dfi)
@@ -898,20 +943,20 @@ addStandaloneDerivingParens decl =
   decl
     { standaloneDerivingStrategy = fmap addDerivingStrategyParens (standaloneDerivingStrategy decl),
       standaloneDerivingContext = addContextConstraints (standaloneDerivingContext decl),
-      standaloneDerivingHead = addTypeParens (standaloneDerivingHead decl)
+      standaloneDerivingHead = addSignatureTypeParens (standaloneDerivingHead decl)
     }
 
 addForeignDeclParens :: ForeignDecl -> ForeignDecl
 addForeignDeclParens decl =
   decl
-    { foreignType = addTypeParens (foreignType decl)
+    { foreignType = addSignatureTypeParens (foreignType decl)
     }
 
 addTypeFamilyDeclParens :: TypeFamilyDecl -> TypeFamilyDecl
 addTypeFamilyDeclParens tf =
   tf
     { typeFamilyDeclExplicitFamilyKeyword = typeFamilyDeclExplicitFamilyKeyword tf,
-      typeFamilyDeclHead = addTypeParens (typeFamilyDeclHead tf),
+      typeFamilyDeclHead = addSignatureTypeParens (typeFamilyDeclHead tf),
       typeFamilyDeclResultSig = fmap addTypeFamilyResultSigParens (typeFamilyDeclResultSig tf),
       typeFamilyDeclEquations = fmap (map addTypeFamilyEqParens) (typeFamilyDeclEquations tf)
     }
@@ -919,7 +964,7 @@ addTypeFamilyDeclParens tf =
 addTypeFamilyResultSigParens :: TypeFamilyResultSig -> TypeFamilyResultSig
 addTypeFamilyResultSigParens sig =
   case sig of
-    TypeFamilyKindSig kind -> TypeFamilyKindSig (addTypeParens kind)
+    TypeFamilyKindSig kind -> TypeFamilyKindSig (addSignatureTypeParens kind)
     TypeFamilyTyVarSig result -> TypeFamilyTyVarSig (addTyVarBinderParens result)
     TypeFamilyInjectiveSig result injectivity -> TypeFamilyInjectiveSig (addTyVarBinderParens result) injectivity
 
@@ -933,7 +978,7 @@ addTypeFamilyEqParens eq =
 addDataFamilyDeclParens :: DataFamilyDecl -> DataFamilyDecl
 addDataFamilyDeclParens df =
   df
-    { dataFamilyDeclKind = fmap addTypeParens (dataFamilyDeclKind df)
+    { dataFamilyDeclKind = fmap addSignatureTypeParens (dataFamilyDeclKind df)
     }
 
 addTypeFamilyInstParens :: TypeFamilyInst -> TypeFamilyInst
@@ -946,29 +991,35 @@ addTypeFamilyInstParens tfi =
 addTypeFamilyLhsParens :: TypeHeadForm -> Type -> Type
 addTypeFamilyLhsParens headForm ty =
   case headForm of
-    TypeHeadPrefix -> addTypeParens ty
+    TypeHeadPrefix -> addSignatureTypeParens ty
     TypeHeadInfix ->
       case peelTypeAnn ty of
         TApp l r ->
           case peelTypeAnn l of
             TApp op lhs ->
               TApp
-                (TApp (addTypeParens op) (addTypeIn CtxTypeFamilyOperand lhs))
+                (TApp (addSignatureTypeParens op) (addTypeIn CtxTypeFamilyOperand lhs))
                 (addTypeIn CtxTypeFamilyOperand r)
-            _ -> addTypeParens ty
-        _ -> addTypeParens ty
+            _ -> addSignatureTypeParens ty
+        _ -> addSignatureTypeParens ty
 
 addTypeFamilyRhsParens :: Type -> Type
-addTypeFamilyRhsParens = addTypeTopLevelParens
+addTypeFamilyRhsParens = addTypeParens
 
 addDataFamilyInstParens :: DataFamilyInst -> DataFamilyInst
 addDataFamilyInstParens dfi =
   dfi
-    { dataFamilyInstHead = addTypeParens (dataFamilyInstHead dfi),
-      dataFamilyInstKind = fmap addTypeParens (dataFamilyInstKind dfi),
+    { dataFamilyInstHead = addDataFamilyInstHeadParens (isJust (dataFamilyInstKind dfi)) (dataFamilyInstHead dfi),
+      dataFamilyInstKind = fmap addSignatureTypeParens (dataFamilyInstKind dfi),
       dataFamilyInstConstructors = map addDataConDeclParens (dataFamilyInstConstructors dfi),
       dataFamilyInstDeriving = map addDerivingClauseParens (dataFamilyInstDeriving dfi)
     }
+
+addDataFamilyInstHeadParens :: Bool -> Type -> Type
+addDataFamilyInstHeadParens followedByKindSig ty =
+  case (followedByKindSig, peelTypeAnn ty) of
+    (True, TImplicitParam {}) -> wrapTy True (addSignatureTypeParens ty)
+    _ -> addSignatureTypeParens ty
 
 -- ---------------------------------------------------------------------------
 -- Expressions
@@ -999,7 +1050,7 @@ addExprParensPrec prec expr =
     ETypeApp fn ty ->
       let fn' = wrapExpr (isGreedyExpr fn) (addExprParensIn CtxAppFun fn)
        in wrapExpr (prec > 2) (ETypeApp fn' (addTypeIn CtxTypeAppVisibleArg ty))
-    ETypeSyntax form ty -> wrapExpr (prec > 2) (ETypeSyntax form (addTypeParens ty))
+    ETypeSyntax form ty -> wrapExpr (prec > 2) (ETypeSyntax form (addSignatureTypeParens ty))
     EVar {} -> expr
     EInt {} -> expr
     EFloat {} -> expr
@@ -1012,10 +1063,10 @@ addExprParensPrec prec expr =
     ETHExpQuote body -> ETHExpQuote (addExprParens body)
     ETHTypedQuote body -> ETHTypedQuote (addExprParens body)
     ETHDeclQuote decls -> ETHDeclQuote (map addDeclParens decls)
-    ETHTypeQuote ty -> ETHTypeQuote (addTypeTopLevelParens ty)
+    ETHTypeQuote ty -> ETHTypeQuote (addTypeParens ty)
     ETHPatQuote pat -> ETHPatQuote (addTHPatQuoteParens pat)
     ETHNameQuote body -> ETHNameQuote (addExprParens body)
-    ETHTypeNameQuote ty -> ETHTypeNameQuote (addTypeParens ty)
+    ETHTypeNameQuote ty -> ETHTypeNameQuote (addSignatureTypeParens ty)
     ETHSplice body -> ETHSplice (addSpliceBodyParens body)
     ETHTypedSplice body -> ETHTypedSplice (addSpliceBodyParens body)
     EIf cond yes no ->
@@ -1074,7 +1125,7 @@ addExprParensPrec prec expr =
        in EGetField (wrapExpr (needsParensBeforeDotField base' field) base') field
     EGetFieldProjection {} -> EParen expr
     ETypeSig inner ty ->
-      wrapExpr (prec > 1) (ETypeSig (addTypeSigBodyParens inner) (addTypeParens ty))
+      wrapExpr (prec > 1) (ETypeSig (addTypeSigBodyParens inner) (addSignatureTypeParens ty))
     EParen inner ->
       -- If inner is a section or projection, addExprParens(inner) already produces EParen(section/projection).
       -- Delegating avoids double-wrapping and maintains idempotency.
@@ -1197,7 +1248,7 @@ addDelimitedExprParens :: Expr -> Expr
 addDelimitedExprParens expr =
   case expr of
     EAnn ann sub -> EAnn ann (addDelimitedExprParens sub)
-    ETypeSig inner ty -> ETypeSig (addDelimitedTypeSigBodyParens inner) (addTypeParens ty)
+    ETypeSig inner ty -> ETypeSig (addDelimitedTypeSigBodyParens inner) (addSignatureTypeParens ty)
     _ -> addExprParens expr
 
 addDelimitedTypeSigBodyParens :: Expr -> Expr
@@ -1245,7 +1296,7 @@ addDoExprParens :: Expr -> Expr
 addDoExprParens expr =
   case expr of
     EAnn ann sub -> EAnn ann (addDoExprParens sub)
-    ETypeSig inner ty -> ETypeSig (addDelimitedTypeSigBodyParens inner) (addTypeParens ty)
+    ETypeSig inner ty -> ETypeSig (addDelimitedTypeSigBodyParens inner) (addSignatureTypeParens ty)
     _ -> addExprParens expr
 
 addCompStmtParens :: CompStmt -> CompStmt
@@ -1360,32 +1411,38 @@ absorbsFollowingInfix = \case
 -- Types
 -- ---------------------------------------------------------------------------
 
--- | Add parentheses to a type at all required positions.
+-- | Add parentheses to a signature type at all required positions.
+addSignatureTypeParens :: Type -> Type
+addSignatureTypeParens = addSignatureTypeParensShared CtxTypeAtom 0
+
+-- | Add parentheses to a plain type at all required positions.
 addTypeParens :: Type -> Type
-addTypeParens = addTypeParensShared CtxTypeAtom 0
+addTypeParens = addTypeTopLevelParens
 
 addTypeTopLevelParens :: Type -> Type
 addTypeTopLevelParens (TAnn ann sub) = TAnn ann (addTypeTopLevelParens sub)
-addTypeTopLevelParens (TKindSig ty kind) = TKindSig (addTypeParensShared CtxTypeAtom 0 ty) (addTypeParensShared CtxTypeAtom 0 kind)
+addTypeTopLevelParens (TImplicitParam name inner) =
+  TImplicitParam name (addImplicitParamBodyParens inner)
+addTypeTopLevelParens (TKindSig ty kind) = TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addTypeTopLevelParens kind)
 addTypeTopLevelParens (TForall telescope inner) =
   TForall
     (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
     (addTypeTopLevelParens inner)
 addTypeTopLevelParens (TContext constraints inner) =
-  TContext (addContextConstraints constraints) (addContextBodyParens inner)
+  TContext (map addContextConstraintDelimitedParens constraints) (addContextBodyParens inner)
 addTypeTopLevelParens (TParen inner) =
   TParen (addTypeTopLevelParens inner)
-addTypeTopLevelParens ty = addTypeParens ty
+addTypeTopLevelParens ty = addSignatureTypeParens ty
 
 addTypeIn :: TypeCtx -> Type -> Type
 addTypeIn ctx ty =
-  wrapTy (needsTypeParens ctx ty) (addTypeParensShared ctx 0 ty)
+  wrapTy (needsTypeParens ctx ty) (addSignatureTypeParensShared ctx 0 ty)
 
-addTypeParensShared :: TypeCtx -> Int -> Type -> Type
-addTypeParensShared ctx prec ty =
-  let atom = addTypeParensShared CtxTypeAtom
+addSignatureTypeParensShared :: TypeCtx -> Int -> Type -> Type
+addSignatureTypeParensShared ctx prec ty =
+  let atom = addSignatureTypeParensShared CtxTypeAtom
    in case ty of
-        TAnn ann sub -> TAnn ann (addTypeParensShared ctx prec sub)
+        TAnn ann sub -> TAnn ann (addSignatureTypeParensShared ctx prec sub)
         TVar {} -> ty
         TCon name promoted -> TCon name promoted
         TBuiltinCon {} -> ty
@@ -1406,7 +1463,7 @@ addTypeParensShared ctx prec ty =
           -- Type operators are right-associative in GHC, so the RHS can contain
           -- nested TInfix without parens (a `op1` b `op2` c = a `op1` (b `op2` c)).
           -- The LHS needs parens for nested TInfix to prevent left-association.
-          wrapTy (prec > 0) (TInfix (addTypeIn CtxTypeAppFun lhs) op promoted (addTypeIn CtxTypeFunArg rhs))
+          wrapTy (prec > 0) (TInfix (addTypeIn CtxTypeAppFun lhs) op promoted (addTypeIn CtxTypeInfixRhs rhs))
         TApp f x ->
           wrapTy (prec > 2) (TApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeAppArg x))
         TTypeApp f x ->
@@ -1414,12 +1471,12 @@ addTypeParensShared ctx prec ty =
         TFun arrowKind a b ->
           wrapTy (prec > 0) (TFun (addArrowKindParens arrowKind) (addTypeIn CtxTypeFunArg a) (atom 0 b))
         TTuple tupleFlavor promoted elems ->
-          TTuple tupleFlavor promoted (map (atom 0) elems)
-        TUnboxedSum elems -> TUnboxedSum (map (atom 0) elems)
-        TList promoted elems -> TList promoted (map (atom 0) elems)
+          TTuple tupleFlavor promoted (map addSignatureTypeParensInner elems)
+        TUnboxedSum elems -> TUnboxedSum (map addSignatureTypeParensInner elems)
+        TList promoted elems -> TList promoted (map addSignatureTypeParensInner elems)
         -- Inside an explicit TParen, TKindSig does not need an additional
         -- TParen wrapper since the enclosing delimiter already provides it.
-        TParen inner -> TParen (addTypeParensInner inner)
+        TParen inner -> TParen (addTypeInExplicitParenParens inner)
         -- TKindSig always needs parens in most contexts. The parser absorbs
         -- (ty :: kind) as TKindSig directly, so the TParen is not preserved
         -- through roundtrips. The pretty-printer relies on the TParen wrapper
@@ -1434,35 +1491,24 @@ addTypeParensShared ctx prec ty =
 addArrowKindParens :: ArrowKind -> ArrowKind
 addArrowKindParens ArrowUnrestricted = ArrowUnrestricted
 addArrowKindParens ArrowLinear = ArrowLinear
-addArrowKindParens (ArrowExplicit ty) = ArrowExplicit (addTypeParens ty)
+addArrowKindParens (ArrowExplicit ty) = ArrowExplicit (addSignatureTypeParens ty)
 
 addTyVarBinderParens :: TyVarBinder -> TyVarBinder
 addTyVarBinderParens tvb =
-  tvb {tyVarBinderKind = fmap addTypeParens (tyVarBinderKind tvb)}
+  tvb {tyVarBinderKind = fmap addSignatureTypeParens (tyVarBinderKind tvb)}
 
 -- | Process the body of a TForall. The forall body is parsed by
 -- 'contextOrFunTypeParser' (not 'typeParser'), so a bare nested TForall
 -- would fail to parse and must be wrapped in TParen.
 addForallBodyParens :: Type -> Type
 addForallBodyParens (TAnn ann sub) = TAnn ann (addForallBodyParens sub)
-addForallBodyParens ty@(TForall {}) = addTypeParensShared CtxTypeAtom 0 ty
-addForallBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
+addForallBodyParens ty@(TForall {}) = addSignatureTypeParensShared CtxTypeAtom 0 ty
+addForallBodyParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
 
--- | Process the body of a TImplicitParam. Although 'typeImplicitParamParser'
--- uses 'typeParser' (which handles TContext), the 'startsWithContextType'
--- lookahead will mistake @?x :: C a => T@ for an outer context, consuming
--- the entire implicit param as a constraint item and then failing to find @=>@.
--- Wrap a bare TContext in TParen to prevent this misinterpretation.
---
--- Similarly, a bare TForall whose body contains a TContext produces a @=>@ that
--- is visible to 'startsWithContextType' (the forall binders are balanced braces,
--- but the body's @=>@ appears at top bracket depth after them). Wrapping TForall
--- in TParen hides the inner @=>@ behind a bracket pair.
+-- | Process the body of a TImplicitParam.
 addImplicitParamBodyParens :: Type -> Type
 addImplicitParamBodyParens (TAnn ann sub) = TAnn ann (addImplicitParamBodyParens sub)
-addImplicitParamBodyParens ty@(TContext {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
-addImplicitParamBodyParens ty@(TForall {}) = wrapTy True (addTypeParensShared CtxTypeAtom 0 ty)
-addImplicitParamBodyParens ty = addTypeParensShared CtxTypeAtom 0 ty
+addImplicitParamBodyParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
 
 -- | Process the body to the right of a constraint arrow in a top-level type
 -- RHS. A kind signature is already delimited there in cases like
@@ -1475,8 +1521,8 @@ addContextBodyParens ty =
     TKindSig ty' kind ->
       wrapTy
         (startsWithTypeSplice ty')
-        (TKindSig (addTypeParensShared CtxTypeAtom 0 ty') (addTypeParensShared CtxTypeAtom 0 kind))
-    _ -> addTypeParensShared CtxTypeAtom 0 ty
+        (TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxTypeAtom 0 kind))
+    _ -> addSignatureTypeParensShared CtxTypeAtom 0 ty
 
 startsWithTypeSplice :: Type -> Bool
 startsWithTypeSplice (TAnn _ sub) = startsWithTypeSplice sub
@@ -1489,13 +1535,56 @@ startsWithTypeSplice _ = False
 -- | Process a type inside explicit delimiters (TParen, TTuple, etc.).
 -- TKindSig does not need wrapping here because the enclosing delimiter
 -- already provides the necessary parenthesization.
-addTypeParensInner :: Type -> Type
-addTypeParensInner (TAnn _ sub) = addTypeParensInner sub
-addTypeParensInner ty =
-  case ty of
-    TKindSig ty' kind ->
-      TKindSig (addTypeParensShared CtxTypeAtom 0 ty') (addTypeParensShared CtxTypeAtom 0 kind)
-    _ -> addTypeParensShared CtxTypeAtom 0 ty
+addSignatureTypeParensInner :: Type -> Type
+addSignatureTypeParensInner = addTypeDelimitedParens
+
+addTypeDelimitedParens :: Type -> Type
+addTypeDelimitedParens (TAnn ann sub) = TAnn ann (addTypeDelimitedParens sub)
+addTypeDelimitedParens (TImplicitParam name inner) =
+  TImplicitParam name (addImplicitParamBodyParens inner)
+addTypeDelimitedParens (TKindSig ty kind) =
+  TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxTypeAtom 0 kind)
+addTypeDelimitedParens (TForall telescope inner) =
+  TForall
+    (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
+    (addTypeDelimitedParens inner)
+addTypeDelimitedParens (TContext constraints inner) =
+  TContext (map addContextConstraintDelimitedParens constraints) (addTypeDelimitedParens inner)
+addTypeDelimitedParens (TInfix lhs op promoted rhs) =
+  TInfix (addTypeIn CtxTypeAppFun lhs) op promoted (addTypeIn CtxTypeDelimitedInfixRhs rhs)
+addTypeDelimitedParens (TApp f x) =
+  TApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeDelimitedAppArg x)
+addTypeDelimitedParens (TTypeApp f x) =
+  TTypeApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeDelimitedAppVisibleArg x)
+addTypeDelimitedParens (TFun arrowKind a b) =
+  TFun (addArrowKindParens arrowKind) (addTypeIn CtxTypeFunArg a) (addSignatureTypeParensShared CtxTypeAtom 0 b)
+addTypeDelimitedParens (TTuple tupleFlavor promoted elems) =
+  TTuple tupleFlavor promoted (map addTypeDelimitedParens elems)
+addTypeDelimitedParens (TUnboxedSum elems) =
+  TUnboxedSum (map addTypeDelimitedParens elems)
+addTypeDelimitedParens (TList promoted elems) =
+  TList promoted (map addTypeDelimitedParens elems)
+addTypeDelimitedParens (TParen inner) =
+  TParen (addTypeInExplicitParenParens inner)
+addTypeDelimitedParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
+
+addTypeInExplicitParenParens :: Type -> Type
+addTypeInExplicitParenParens (TAnn ann sub) = TAnn ann (addTypeInExplicitParenParens sub)
+addTypeInExplicitParenParens (TKindSig ty kind) =
+  TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxTypeAtom 0 kind)
+addTypeInExplicitParenParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
+
+addContextConstraintDelimitedParens :: Type -> Type
+addContextConstraintDelimitedParens (TAnn ann sub) = TAnn ann (addContextConstraintDelimitedParens sub)
+addContextConstraintDelimitedParens (TImplicitParam name inner) =
+  TImplicitParam name (addImplicitParamBodyParens inner)
+addContextConstraintDelimitedParens (TInfix lhs op promoted rhs) =
+  TInfix (addTypeIn CtxTypeAppFun lhs) op promoted (addContextConstraintDelimitedParens rhs)
+addContextConstraintDelimitedParens (TApp f x) =
+  TApp (addTypeIn CtxTypeAppFun f) (addContextConstraintDelimitedParens x)
+addContextConstraintDelimitedParens (TTypeApp f x) =
+  TTypeApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeDelimitedAppVisibleArg x)
+addContextConstraintDelimitedParens ty = addTypeDelimitedParens ty
 
 -- | Process constraint types in a TContext.
 -- In multi-constraint contexts, TKindSig doesn't need individual parens
@@ -1509,7 +1598,7 @@ addContextConstraints constraints =
 -- | Add parens to a single constraint in a context.
 -- TKindSig needs wrapping here because there's no comma delimiter.
 addContextConstraintSingle :: Type -> Type
-addContextConstraintSingle = addTypeParens
+addContextConstraintSingle = addSignatureTypeParens
 
 -- | Add parens to a constraint in a multi-constraint context.
 -- TKindSig doesn't need extra wrapping because commas delimit.
@@ -1521,11 +1610,11 @@ addContextConstraintMulti ty =
       TAnn ann (addContextConstraintMulti sub)
     TKindSig ty' kind ->
       -- In multi-constraint context, TKindSig doesn't need wrapping
-      TKindSig (addTypeParensShared CtxTypeAtom 0 ty') (addTypeParensShared CtxTypeAtom 0 kind)
+      TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxTypeAtom 0 kind)
     TParen inner@(TKindSig {}) ->
       -- Strip TParen around TKindSig in multi-constraint context
       addContextConstraintMulti inner
-    _ -> addTypeParens ty
+    _ -> addSignatureTypeParens ty
 
 -- ---------------------------------------------------------------------------
 -- Patterns
@@ -1538,7 +1627,7 @@ addPatternParens pat =
     PAnn sp sub -> PAnn sp (addPatternParens sub)
     PVar {} -> pat
     PTypeBinder binder -> PTypeBinder (addTyVarBinderParens binder)
-    PTypeSyntax form ty -> PTypeSyntax form (addTypeParens ty)
+    PTypeSyntax form ty -> PTypeSyntax form (addSignatureTypeParens ty)
     PWildcard {} -> pat
     PLit lit -> PLit lit
     PQuasiQuote {} -> pat
@@ -1556,7 +1645,7 @@ addPatternParens pat =
     PParen inner -> PParen (addPatternInDelimited inner)
     PRecord con fields hasWildcard ->
       PRecord con [field {recordFieldValue = addPatternInDelimited (recordFieldValue field)} | field <- fields] hasWildcard
-    PTypeSig inner ty -> PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty)
+    PTypeSig inner ty -> PTypeSig (addPatternInfixOperandParens inner) (addSignatureTypeParens ty)
     PSplice body -> PSplice (addSpliceBodyParens body)
 
 -- | Add parens for a pattern inside a delimited context (tuples, lists, etc.).
@@ -1700,13 +1789,13 @@ addFunctionHeadPatternAtomParens pat =
   case pat of
     PAnn ann sub -> PAnn ann (addFunctionHeadPatternAtomParens sub)
     PParen (PTypeSig inner@(PVar {}) ty) ->
-      PParen (PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty))
+      PParen (PTypeSig (addPatternInfixOperandParens inner) (addSignatureTypeParens ty))
     PNegLit {} -> wrapPat True (addPatternParens pat)
     PTypeSyntax {} -> wrapPat True (addPatternParens pat)
     PCon _ typeArgs args
       | not (null typeArgs) || not (null args) -> wrapPat True (addPatternParens pat)
     PTypeSig inner@(PVar {}) ty ->
-      wrapPat True (PTypeSig (addPatternInfixOperandParens inner) (addTypeParens ty))
+      wrapPat True (PTypeSig (addPatternInfixOperandParens inner) (addSignatureTypeParens ty))
     PTypeSig {} -> wrapPat True (addPatternParens pat)
     PAs {} -> addPatternParens pat
     PRecord {} -> addPatternParens pat

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -17,13 +17,15 @@
 -- formatting, so the formatting code here does not need to worry about
 -- operator precedence or context-sensitive parenthesization.
 --
--- This module has an empty export list because it only provides typeclass
--- instances. Import it to bring the 'Pretty' instances into scope.
+-- Import this module to bring the 'Pretty' instances into scope. The exported
+-- helpers render AST nodes without first inserting additional parentheses,
+-- which is useful for tests that need to inspect parenthesization directly.
 --
 -- __Provided instances:__ 'Pretty' for 'Module', 'Expr', 'Pattern', 'Type'.
 module Aihc.Parser.Pretty
   ( prettyExpr,
     prettyPattern,
+    prettyType,
   )
 where
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -45,7 +45,7 @@ import Test.Properties.Arb.Pattern (shrinkPattern)
 import Test.Properties.Arb.Utils (requiredExtensions)
 import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
 import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip)
-import Test.Properties.MinimalParentheses (prop_minimalParenthesesExpr, prop_minimalParenthesesPattern)
+import Test.Properties.MinimalParentheses (prop_minimalParenthesesExpr, prop_minimalParenthesesPattern, prop_minimalParenthesesSignatureType, prop_minimalParenthesesType)
 import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip, prop_moduleValidator)
 import Test.Properties.NoExceptions
   ( prop_declParserArbitraryTokensNoExceptions,
@@ -267,6 +267,14 @@ buildTests = do
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "pretty-prints typed view expressions without invalid layout" test_typedViewExprPrettyLayout,
+            testCase "rejects bare kind signatures as signature types" test_signatureTypeParserRejectsBareKindSignature,
+            testCase "parses parenthesized kind signatures as signature types" test_signatureTypeParserParsesParenthesizedKindSignature,
+            testCase "parses delimited kind signatures as signature types" test_signatureTypeParserParsesDelimitedKindSignature,
+            testCase "rejects bare kind signatures in signature type applications" test_signatureTypeParserRejectsAppArgBareKindSignature,
+            testCase "parses parenthesized kind signatures in signature type applications" test_signatureTypeParserParsesAppArgParenthesizedKindSignature,
+            testCase "rejects bare kind signatures in signature implicit parameter bodies" test_signatureTypeParserRejectsImplicitParamBareKindSignature,
+            testCase "rejects bare kind signatures in value signatures" test_declParserRejectsBareKindSignature,
+            testCase "parses bare kind signatures as types" test_typeParserParsesBareKindSignature,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -287,6 +295,8 @@ buildTests = do
             "properties"
             [ QC.testProperty "expr paren insertion is minimal" prop_minimalParenthesesExpr,
               QC.testProperty "pattern paren insertion is minimal" prop_minimalParenthesesPattern,
+              QC.testProperty "signature type paren insertion is minimal" prop_minimalParenthesesSignatureType,
+              QC.testProperty "type paren insertion is minimal" prop_minimalParenthesesType,
               QC.testProperty "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
               QC.testProperty "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
               QC.testProperty "generated data family instances can include inline result kinds" prop_generatedDataFamilyInstancesCanIncludeInlineResultKinds,
@@ -1466,6 +1476,74 @@ test_typedViewExprPrettyLayout = do
        :: _)
      -> _)
     """
+
+test_signatureTypeParserRejectsBareKindSignature :: Assertion
+test_signatureTypeParserRejectsBareKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseSignatureType config "_ :: _" of
+    ParseErr {} -> pure ()
+    ParseOk ty ->
+      assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations ty)))
+
+test_signatureTypeParserParsesParenthesizedKindSignature :: Assertion
+test_signatureTypeParserParsesParenthesizedKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseSignatureType config "(_ :: _)" of
+    ParseOk ty ->
+      assertEqual "parenthesized kind signature" (TParen (TKindSig TWildcard TWildcard)) (stripAnnotations ty)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for parenthesized kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_signatureTypeParserParsesDelimitedKindSignature :: Assertion
+test_signatureTypeParserParsesDelimitedKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseSignatureType config "[_ :: _]" of
+    ParseOk ty ->
+      assertEqual "delimited kind signature" (TList Unpromoted [TKindSig TWildcard TWildcard]) (stripAnnotations ty)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for delimited kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_signatureTypeParserRejectsAppArgBareKindSignature :: Assertion
+test_signatureTypeParserRejectsAppArgBareKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseSignatureType config "_ _ :: _" of
+    ParseErr {} -> pure ()
+    ParseOk ty ->
+      assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations ty)))
+
+test_signatureTypeParserParsesAppArgParenthesizedKindSignature :: Assertion
+test_signatureTypeParserParsesAppArgParenthesizedKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseSignatureType config "_ (_ :: _)" of
+    ParseOk ty ->
+      assertEqual "parenthesized app argument kind signature" (TApp TWildcard (TParen (TKindSig TWildcard TWildcard))) (stripAnnotations ty)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for parenthesized app argument kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_signatureTypeParserRejectsImplicitParamBareKindSignature :: Assertion
+test_signatureTypeParserRejectsImplicitParamBareKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseSignatureType config "?a :: _ :: _" of
+    ParseErr {} -> pure ()
+    ParseOk ty ->
+      assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations ty)))
+
+test_declParserRejectsBareKindSignature :: Assertion
+test_declParserRejectsBareKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseDecl config "x :: _ :: _" of
+    ParseErr {} -> pure ()
+    ParseOk decl ->
+      assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations decl)))
+
+test_typeParserParsesBareKindSignature :: Assertion
+test_typeParserParsesBareKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseType config "_ :: _" of
+    ParseOk ty ->
+      assertEqual "type kind signature" (TKindSig TWildcard TWildcard) (stripAnnotations ty)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for type kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
 
 test_shrunkDoExpressionsKeepFinalExpression :: Assertion
 test_shrunkDoExpressionsKeepFinalExpression = do

--- a/components/aihc-parser/test/Test/Properties/MinimalParentheses.hs
+++ b/components/aihc-parser/test/Test/Properties/MinimalParentheses.hs
@@ -3,12 +3,14 @@
 module Test.Properties.MinimalParentheses
   ( prop_minimalParenthesesExpr,
     prop_minimalParenthesesPattern,
+    prop_minimalParenthesesType,
+    prop_minimalParenthesesSignatureType,
   )
 where
 
-import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExpr, parsePattern)
-import Aihc.Parser.Parens (addExprParens, addPatternParens)
-import Aihc.Parser.Pretty (prettyExpr, prettyPattern)
+import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExpr, parsePattern, parseSignatureType, parseType)
+import Aihc.Parser.Parens (addExprParens, addPatternParens, addSignatureTypeParens, addTypeParens)
+import Aihc.Parser.Pretty (prettyExpr, prettyPattern, prettyType)
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
 import Data.Text qualified as T
@@ -65,3 +67,45 @@ prop_minimalParenthesesPattern pat = do
     source = renderStrict (layoutPretty defaultLayoutOptions (prettyPattern noParens))
     isMinimal = parenthesized == noParens
     patternIsValid = case parsePattern config source of ParseOk parsed -> stripAnnotations parsed == stripAnnotations noParens; ParseErr {} -> False
+
+prop_minimalParenthesesSignatureType :: Type -> Property
+prop_minimalParenthesesSignatureType ty = do
+  counterexample
+    ( "Found smaller, valid signature type. "
+        ++ "Original:\n"
+        ++ show (shorthand parenthesized)
+        ++ "\n"
+        ++ T.unpack (renderStrict (layoutPretty defaultLayoutOptions (prettyType parenthesized)))
+        ++ "\nSmaller:\n"
+        ++ show (shorthand noParens)
+        ++ "\n"
+        ++ T.unpack (renderStrict (layoutPretty defaultLayoutOptions (prettyType noParens)))
+    )
+    (isMinimal || not typeIsValid)
+  where
+    noParens = stripParens ty
+    parenthesized = addSignatureTypeParens noParens
+    source = renderStrict (layoutPretty defaultLayoutOptions (prettyType noParens))
+    isMinimal = parenthesized == noParens
+    typeIsValid = case parseSignatureType config source of ParseOk parsed -> stripAnnotations parsed == stripAnnotations noParens; ParseErr {} -> False
+
+prop_minimalParenthesesType :: Type -> Property
+prop_minimalParenthesesType ty = do
+  counterexample
+    ( "Found smaller, valid type. "
+        ++ "Original:\n"
+        ++ show (shorthand parenthesized)
+        ++ "\n"
+        ++ T.unpack (renderStrict (layoutPretty defaultLayoutOptions (prettyType parenthesized)))
+        ++ "\nSmaller:\n"
+        ++ show (shorthand noParens)
+        ++ "\n"
+        ++ T.unpack (renderStrict (layoutPretty defaultLayoutOptions (prettyType noParens)))
+    )
+    (isMinimal || not typeIsValid)
+  where
+    noParens = stripParens ty
+    parenthesized = addTypeParens noParens
+    source = renderStrict (layoutPretty defaultLayoutOptions (prettyType noParens))
+    isMinimal = parenthesized == noParens
+    typeIsValid = case parseType config source of ParseOk parsed -> stripAnnotations parsed == stripAnnotations noParens; ParseErr {} -> False


### PR DESCRIPTION
## Summary

- add separate QuickCheck coverage for generic type parentheses and signature type parentheses
- align public parser entry point names with internal parsers: `parseType` uses `typeParser`, and `parseSignatureType` uses `typeSignatureParser`
- align paren entry point names with parser contexts: `addTypeParens` handles plain type contexts, and `addSignatureTypeParens` handles signature type contexts
- remove the redundant `typeStandaloneParser` alias and update token/test/property naming to signature-type terminology
- replace standalone-type validity filtering with grammar-level parsing: plain type RHSs accept raw outer kind signatures, while signature types reject them unless explicitly delimited
- keep implicit-parameter types from being accepted as bare app, visible-app, infix, and constraint operands where GHC requires parentheses
- use signature-specific type parsing for value, class, instance, foreign, and pattern-synonym signatures so declarations like `x :: _ :: _` are rejected like GHC
- expose raw `prettyType` for the minimal-parentheses properties

## Progress Counts

- Parser property checks: +2 (`type paren insertion is minimal`, `signature type paren insertion is minimal`)
- Parser regression tests: +8 kind-signature context checks
- Parser API entry points: +1 (`parseSignatureType`)
- Parens API entry points: +1 (`addSignatureTypeParens`)

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern kind --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern paren --hide-successes --quickcheck-tests 1000"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern generated --hide-successes --quickcheck-tests 1000"`
- `cabal test -v0 aihc-parser-compat:spec --test-options="--pattern generated --hide-successes --quickcheck-tests 1000"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
