### PR TITLE
fix(parser): parenthesize negated typed view expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -131,6 +131,7 @@ endsWithTypeSig = \case
     case reverse rhss of
       grhs : _ -> endsWithTypeSig (guardedRhsBody grhs)
       [] -> False
+  ENegate inner -> endsWithTypeSig inner
   EInfix _ _ rhs -> endsWithTypeSig rhs
   EApp _ arg -> endsWithTypeSig arg
   EIf _ _ no -> endsWithTypeSig no

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -266,6 +266,7 @@ buildTests = do
             testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
+            testCase "parenthesizes negated typed view expressions" test_viewExprNegatedTypeSigParens,
             testCase "pretty-prints typed view expressions without invalid layout" test_typedViewExprPrettyLayout,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
@@ -1444,6 +1445,20 @@ test_viewExprArrowCommandTypeSigRhsParens = do
          -> C {})
         """
   assertParsedStrippedPatternShapeRoundTrip config source
+
+test_viewExprNegatedTypeSigParens :: Assertion
+test_viewExprNegatedTypeSigParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      source =
+        """
+        _ = []
+            where
+              ((- \\ _ -> []
+                    :: _
+                 -> _)
+               -> _) + _ = []
+        """
+  assertParsedStrippedDeclShapeRoundTrip config source
 
 test_typedViewExprPrettyLayout :: Assertion
 test_typedViewExprPrettyLayout = do


### PR DESCRIPTION
## What changed

- Teach parser paren insertion that a negated expression still ends with a type signature when its operand does.
- Add a regression for the shrunk view-pattern/function-head case from the QuickCheck replay.

## Why

The pretty-printer emitted a view pattern where `- \ _ -> [] :: _ -> _` was left bare before the view-pattern arrow. GHC then interpreted the lambda syntax as pattern syntax and rejected the generated module.

## Impact

Generated module pretty-printer round trips now keep the negated typed view expression grouped so the rendered source reparses.

## Progress counts

- No README progress counts changed.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern \"parenthesizes negated typed view expressions\" --hide-successes"`
- `just replay "(SMGen 5158514384494255530 10491715187793599811,64)"`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
