### PR TITLE
fix(fc): typecheck eval fixtures with real tc

### DIFF
--- a/components/aihc-fc/common/FcEvalGolden.hs
+++ b/components/aihc-fc/common/FcEvalGolden.hs
@@ -27,15 +27,13 @@ import Aihc.Parser.Syntax
     MatchHeadForm (..),
     Module (..),
     NameType (..),
-    Pattern (..),
     Rhs (..),
-    UnqualifiedName (..),
     ValueDecl (..),
     mkUnqualifiedName,
     parseExtensionName,
   )
 import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
-import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), TcType (..), TyCon (..))
+import Aihc.Tc (TcModuleResult (..), typecheckModulesWithEnv)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
@@ -158,12 +156,16 @@ evaluateFcEvalCase tc =
             let resolved = resolveWithDeps mempty (deps <> evalModules)
              in case resolved of
                   ResolveResult {resolvedModules, resolveErrors = []} ->
-                    let results = map desugarResolvedModule resolvedModules
-                     in if all dsSuccess results
-                          then case evalProgramBinding evalBindingName (concatPrograms (map dsProgram results)) >>= renderRawValue of
-                            Right actual -> classifySuccess tc (T.unpack actual)
-                            Left err -> classifyFailure tc ("eval error: " <> show err)
-                          else classifyFailure tc ("desugar error: " <> unlines (concatMap dsErrors results))
+                    let tcResults = typecheckModulesWithEnv [] resolvedModules
+                     in if all tcmSuccess tcResults
+                          then
+                            let results = zipWith desugarModuleWithTcResult tcResults resolvedModules
+                             in if all dsSuccess results
+                                  then case evalProgramBinding evalBindingName (concatPrograms (map dsProgram results)) >>= renderRawValue of
+                                    Right actual -> classifySuccess tc (T.unpack actual)
+                                    Left err -> classifyFailure tc ("eval error: " <> show err)
+                                  else classifyFailure tc ("desugar error: " <> unlines (concatMap dsErrors results))
+                          else classifyFailure tc ("typecheck error: " <> renderTcErrors tcResults)
                   ResolveResult {resolveErrors} ->
                     classifyFailure tc ("resolve error: " <> show resolveErrors)
 
@@ -231,27 +233,12 @@ evalDecl expr =
           }
       ]
 
-syntheticTcResult :: Module -> TcModuleResult
-syntheticTcResult modu =
-  TcModuleResult
-    { tcmBindings = concatMap bindingTypes (moduleDecls modu),
-      tcmDiagnostics = [],
-      tcmSuccess = True
-    }
-
-bindingTypes :: Decl -> [TcBindingResult]
-bindingTypes decl =
-  case decl of
-    DeclAnn _ inner -> bindingTypes inner
-    DeclValue (FunctionBind name matches) ->
-      [TcBindingResult (unqualifiedNameText name) (functionType (matchArity matches))]
-    DeclValue (PatternBind _ pat _) ->
-      [TcBindingResult name unknownTy | Just name <- [barePatternName pat]]
-    _ -> []
-
-desugarResolvedModule :: Module -> DesugarResult
-desugarResolvedModule modu =
-  desugarModuleWithTcResult (syntheticTcResult modu) modu
+renderTcErrors :: [TcModuleResult] -> String
+renderTcErrors results =
+  let rendered = unlines [show diagnostic | result <- results, diagnostic <- tcmDiagnostics result]
+   in if null (trim rendered)
+        then "type checker failed without diagnostics"
+        else rendered
 
 concatPrograms :: [FcProgram] -> FcProgram
 concatPrograms programs =
@@ -338,25 +325,6 @@ findModulePathInDependencies ((_dependency, root) : rest) moduleName = do
 moduleNamePath :: Text -> FilePath
 moduleNamePath moduleName =
   joinPath (map T.unpack (T.splitOn "." moduleName)) <> ".hs"
-
-matchArity :: [Match] -> Int
-matchArity [] = 0
-matchArity (match : _) = length (matchPats match)
-
-functionType :: Int -> TcType
-functionType arity =
-  foldr TcFunTy unknownTy (replicate arity unknownTy)
-
-unknownTy :: TcType
-unknownTy = TcTyCon (TyCon "?" 0) []
-
-barePatternName :: Pattern -> Maybe Text
-barePatternName pat =
-  case pat of
-    PVar name -> Just (unqualifiedNameText name)
-    PAnn _ inner -> barePatternName inner
-    PParen inner -> barePatternName inner
-    _ -> Nothing
 
 classifySuccess :: FcEvalCase -> String -> (Outcome, String)
 classifySuccess tc actual =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -58,10 +58,10 @@ desugarModuleWithTcResult tcResult m =
       DesugarResult
         { dsProgram = FcProgram [],
           dsSuccess = False,
-          dsErrors = map showBinding (tcmBindings tcResult)
+          dsErrors = showTcFailure tcResult
         }
     else
-      let typeEnv = Map.fromList [(tbName b, tbType b) | b <- tcmBindings tcResult]
+      let typeEnv = Map.fromList (concatMap bindingTypeEntries (tcmBindings tcResult))
           binds = evalState (dsModule m) (DsState 1000 typeEnv Map.empty)
        in DesugarResult
             { dsProgram = FcProgram binds,
@@ -71,7 +71,17 @@ desugarModuleWithTcResult tcResult m =
 
 -- | Format a binding result for error messages.
 showBinding :: TcBindingResult -> String
-showBinding b = T.unpack (tbName b) ++ " :: " ++ renderTcType (tbType b)
+showBinding b = T.unpack (tbDisplayName b) ++ " :: " ++ renderTcType (tbType b)
+
+showTcFailure :: TcModuleResult -> [String]
+showTcFailure tcResult =
+  case map show (tcmDiagnostics tcResult) of
+    [] -> map showBinding (tcmBindings tcResult)
+    diagnostics -> diagnostics
+
+bindingTypeEntries :: TcBindingResult -> [(Text, TcType)]
+bindingTypeEntries b =
+  [(tbName b, tbType b)]
 
 -- | Desugar a module's declarations.
 dsModule :: Module -> DsM [FcTopBind]

--- a/components/aihc-fc/test/Test/Fixtures/eval/typecheck-rejects-bad-binding.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/typecheck-rejects-bad-binding.yaml
@@ -1,0 +1,13 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = False | True
+    bad :: () -> ()
+    bad _ = True
+output: |
+  True
+expression: |
+  bad
+status: fail
+reason: FC eval fixtures must reject modules that real type checking rejects

--- a/components/aihc-tc/common/TcGolden.hs
+++ b/components/aihc-tc/common/TcGolden.hs
@@ -22,7 +22,7 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax (Extension, parseExtensionName)
-import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), renderTcType, typecheckModule)
+import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), renderTcType, typecheck)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -146,7 +146,7 @@ evaluateTcCase tc =
    in case sequence parsedModules of
         Left errMsg -> classifyFailure tc ("parse error: " <> errMsg)
         Right modules ->
-          let results = map typecheckModule modules
+          let results = typecheck modules
            in if all tcmSuccess results
                 then classifySuccess tc (renderResults results)
                 else classifyFailure tc (renderDiags results)
@@ -163,7 +163,7 @@ evaluateTcCase tc =
             else Left (show errs)
     renderResults results =
       let bindings = concatMap tcmBindings results
-       in unlines [T.unpack (tbName b) <> " :: " <> renderTcType (tbType b) | b <- bindings]
+       in unlines [T.unpack (tbDisplayName b) <> " :: " <> renderTcType (tbType b) | b <- bindings]
     renderDiags results =
       unlines [show d | r <- results, d <- tcmDiagnostics r]
 

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -16,6 +16,7 @@ module Aihc.Tc
     typecheckExpr,
     typecheckModule,
     typecheckModuleWithEnv,
+    typecheckModulesWithEnv,
 
     -- * Result types
     TcResult (..),
@@ -114,21 +115,22 @@ typecheckModule =
 -- | Type-check a single module with preloaded top-level term bindings.
 typecheckModuleWithEnv :: [(Text, TypeScheme)] -> Module -> TcModuleResult
 typecheckModuleWithEnv importedTerms m =
-  case runTcM tcEnv initState (tcModule m) of
-    Left _abort ->
+  case typecheckModulesWithEnv importedTerms [m] of
+    [result] -> result
+    _ ->
       TcModuleResult
         { tcmBindings = [],
           tcmDiagnostics = [],
           tcmSuccess = False
         }
-    Right (bindings, st) ->
-      let diags = reverse (tcsDiagnostics st)
-          hasErrors = any isError diags
-       in TcModuleResult
-            { tcmBindings = bindings,
-              tcmDiagnostics = diags,
-              tcmSuccess = not hasErrors
-            }
+
+-- | Type-check modules in order while sharing the accumulated top-level
+-- environment. This is intentionally pragmatic: callers that have already
+-- resolved a dependency-ordered module list can feed it here so later modules
+-- see earlier data constructors and value bindings.
+typecheckModulesWithEnv :: [(Text, TypeScheme)] -> [Module] -> [TcModuleResult]
+typecheckModulesWithEnv importedTerms =
+  go initState
   where
     initState =
       initTcState
@@ -139,6 +141,40 @@ typecheckModuleWithEnv importedTerms m =
               ]
               <> tcsGlobalTerms initTcState
         }
+
+    go _ [] = []
+    go st (m : ms) =
+      let (result, st') = typecheckModuleWithState st m
+       in result : go st' ms
+
+typecheckModuleWithState :: TcState -> Module -> (TcModuleResult, TcState)
+typecheckModuleWithState st m =
+  case runTcM tcEnv (st {tcsDiagnostics = []}) (tcModule m) of
+    Left _abort ->
+      ( TcModuleResult
+          { tcmBindings = [],
+            tcmDiagnostics = [],
+            tcmSuccess = False
+          },
+        st
+      )
+    Right (bindings, st') ->
+      let diags = reverse (tcsDiagnostics st')
+          hasErrors = any isError diags
+          result =
+            TcModuleResult
+              { tcmBindings = bindings,
+                tcmDiagnostics = diags,
+                tcmSuccess = not hasErrors
+              }
+          nextState =
+            st'
+              { tcsDiagnostics = [],
+                tcsMetaSolutions = Map.empty,
+                tcsEvBinds = Map.empty
+              }
+       in (result, nextState)
+  where
     tcEnv =
       emptyTcEnv
         { tcEnvMonoLocalBinds = MonoLocalBinds `elem` enabledExtensions,
@@ -151,4 +187,4 @@ typecheckModuleWithEnv importedTerms m =
 
 -- | Type-check a list of modules.
 typecheck :: [Module] -> [TcModuleResult]
-typecheck = map typecheckModule
+typecheck = typecheckModulesWithEnv []

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -33,6 +33,7 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     TupleFlavor (..),
     Type (..),
+    TypeBuiltinCon (..),
     UnqualifiedName (..),
     ValueDecl (..),
     binderHeadName,
@@ -42,10 +43,11 @@ import Aihc.Parser.Syntax
     gadtBodyResultType,
     peelDeclAnn,
     peelTypeHead,
+    tyVarBinderKind,
     tyVarBinderName,
   )
 import Aihc.Tc.Constraint
-import Aihc.Tc.Generalize (generalize)
+import Aihc.Tc.Generalize (generalizeIgnoring)
 import Aihc.Tc.Generate.Bind (inferRhsWithLocals)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Instantiate qualified
@@ -77,7 +79,11 @@ peelDeclSpan ambient _ = ambient
 
 -- | Result of type-checking a single binding.
 data TcBindingResult = TcBindingResult
-  { tbName :: !Text,
+  { -- | Canonical binder identity. Symbolic binders are stored without
+    -- prefix-position parentheses, e.g. @++@ rather than @(++)@.
+    tbName :: !Text,
+    -- | Human-facing rendering for diagnostics and golden output.
+    tbDisplayName :: !Text,
     tbType :: !TcType
   }
   deriving (Show)
@@ -116,13 +122,22 @@ freeTypeVars = nub . go
   where
     go (TVar name) = [unqualifiedNameText name]
     go (TApp f a) = go f ++ go a
+    go (TTypeApp f a) = go f ++ go a
+    go (TInfix lhs _ _ rhs) = go lhs ++ go rhs
     go (TFun _ a b) = go a ++ go b
+    go (TTuple _ _ args) = concatMap go args
+    go (TUnboxedSum args) = concatMap go args
+    go (TList _ args) = concatMap go args
     go (TParen inner) = go inner
     go (TAnn _ inner) = go inner
-    go (TContext _preds inner) = go inner
+    go (TKindSig inner kindTy) = go inner ++ go kindTy
+    go (TImplicitParam _ inner) = go inner
+    go (TContext preds inner) = concatMap go preds ++ go inner
     go (TForall telescope inner) =
-      go inner \\ map tyVarBinderName (forallTelescopeBinders telescope)
+      (concatMap binderKindVars (forallTelescopeBinders telescope) ++ go inner)
+        \\ map tyVarBinderName (forallTelescopeBinders telescope)
     go _ = []
+    binderKindVars binder = maybe [] go (tyVarBinderKind binder)
 
 -- | Convert a surface type to a TcType, using a map from variable names to
 -- TyVarIds for any type variables in scope.
@@ -135,6 +150,14 @@ convertSurfaceType tvMap ty = case peeledTy of
           Nothing -> TcTyCon (TyCon n 0) []
   TCon name _ ->
     namedTypeCon (nameText name)
+  TBuiltinCon TBuiltinList ->
+    TcTyCon (TyCon "[]" 1) []
+  TBuiltinCon TBuiltinCons ->
+    TcTyCon (TyCon ":" 2) []
+  TBuiltinCon (TBuiltinTuple arity) ->
+    TcTyCon (TyCon ("(" <> mconcat (replicate (arity - 1) ",") <> ")") arity) []
+  TBuiltinCon TBuiltinArrow ->
+    TcTyCon (TyCon "(->)" 2) []
   TApp {} ->
     -- Collect the full application chain to get the arity right.
     let (headTy, args) = collectTApps peeledTy
@@ -142,7 +165,7 @@ convertSurfaceType tvMap ty = case peeledTy of
         arity = length args
      in case peelTypeHead headTy of
           TCon name _ ->
-            TcTyCon (TyCon (nameText name) arity) convertedArgs
+            TcTyCon (TyCon (canonicalTypeConName arity (nameText name)) arity) convertedArgs
           TVar name ->
             let n = unqualifiedNameText name
              in case Map.lookup n tvMap of
@@ -175,7 +198,12 @@ collectTApps ty = go ty []
 
 namedTypeCon :: Text -> TcType
 namedTypeCon "String" = listType (TcTyCon (TyCon "Char" 0) [])
+namedTypeCon "List" = TcTyCon (TyCon "[]" 1) []
 namedTypeCon name = TcTyCon (TyCon name 0) []
+
+canonicalTypeConName :: Int -> Text -> Text
+canonicalTypeConName 1 "List" = "[]"
+canonicalTypeConName _ name = name
 
 listType :: TcType -> TcType
 listType ty = TcTyCon (TyCon "[]" 1) [ty]
@@ -386,18 +414,20 @@ tcFunctionWithSig displayName name scheme matches = do
   -- Report the declared scheme as the binding's type.
   let declaredTy = schemeToType scheme
   zonkedTy <- zonkType declaredTy
-  pure [TcBindingResult displayName zonkedTy]
+  pure [TcBindingResult name displayName zonkedTy]
 
 -- | Type-check a function without a type signature (infer).
 tcFunctionInfer :: Text -> Text -> [Match] -> TcM [TcBindingResult]
 tcFunctionInfer displayName name matches = do
+  placeholderTy <- freshMetaTv
+  extendTermEnvPermanent name (TcMonoIdBinder name placeholderTy)
   (ty, cts, impls) <- tcMatches matches
   _ <- solveWithImpls cts impls
-  scheme <- generalize ty []
+  scheme <- generalizeIgnoring [name] ty []
   let schemeTy = schemeToType scheme
   zonkedTy <- zonkType schemeTy
   extendTermEnvPermanent name (TcIdBinder name scheme Closed)
-  pure [TcBindingResult displayName zonkedTy]
+  pure [TcBindingResult name displayName zonkedTy]
 
 -- | Register a declaration in the environment (data types, etc.).
 -- Returns binding results for the declared names.
@@ -422,7 +452,7 @@ registerForeignPrimImport foreignDecl = do
       declaredTy = schemeToType scheme
   extendTermEnvPermanent name (TcIdBinder name scheme Closed)
   zonkedTy <- zonkType declaredTy
-  pure [TcBindingResult displayName zonkedTy]
+  pure [TcBindingResult name displayName zonkedTy]
 
 -- | Register a data declaration's type constructor and data constructors.
 --
@@ -436,13 +466,17 @@ registerDataDecl dd = do
       params = binderHeadParams (dataDeclHead dd)
       arity = length params
       starKind = TcTyCon (TyCon "*" 0) []
-      tyConResult = TcBindingResult tyName starKind
+      tyConResult = TcBindingResult tyName tyName starKind
   -- Create TyVarIds for the type parameters.
   paramVarIds <- mapM (freshSkolemTv . tyVarBinderName) params
   let paramMap = Map.fromList (zip (map tyVarBinderName params) paramVarIds)
-      tc = TyCon tyName arity
+      tc = dataDeclTyCon tyName arity
   conResults <- mapM (registerDataCon tc paramMap paramVarIds) (dataDeclConstructors dd)
   pure (tyConResult : conResults)
+
+dataDeclTyCon :: Text -> Int -> TyCon
+dataDeclTyCon "List" 1 = TyCon "[]" 1
+dataDeclTyCon name arity = TyCon name arity
 
 -- | Register a single data constructor as a polymorphic binding.
 -- Returns the binding result for the constructor.
@@ -483,8 +517,9 @@ registerDataCon tc paramMap paramVarIds con = case con of
           case names of
             (n : _) -> do
               zonkedTy <- zonkType conTy
-              pure (TcBindingResult (unqualifiedNameText n) zonkedTy)
-            [] -> pure (TcBindingResult "<gadt>" gadtResTy)
+              let name = unqualifiedNameText n
+               in pure (TcBindingResult name name zonkedTy)
+            [] -> pure (TcBindingResult "<gadt>" "<gadt>" gadtResTy)
   where
     resTy = TcTyCon tc (map TcTyVar paramVarIds)
     conScheme argTys = ForAll paramVarIds [] (foldr TcFunTy resTy argTys)
@@ -494,7 +529,7 @@ registerDataCon tc paramMap paramVarIds con = case con of
           scheme = conScheme argTys
       extendTermEnvPermanent name (TcIdBinder name scheme Closed)
       zonkedTy <- zonkType conTy
-      pure (TcBindingResult name zonkedTy)
+      pure (TcBindingResult name name zonkedTy)
 
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
@@ -549,7 +584,7 @@ tcValueDecl (PatternBind _ pat rhs) = case patternBinderName pat of
   Nothing -> do
     ty <- tcRhs rhs
     zonkedTy <- zonkType ty
-    pure [TcBindingResult "<pattern>" zonkedTy]
+    pure [TcBindingResult "<pattern>" "<pattern>" zonkedTy]
 
 -- | Extract the binder name from a pattern binding's LHS, if it is a bare
 -- variable pattern.  Returns @(displayName, envName)@ for simple variable

--- a/components/aihc-tc/test/Test/Fixtures/golden/list-signature-polymorphic.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/list-signature-polymorphic.yaml
@@ -1,0 +1,11 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    (++) :: [a] -> [a] -> [a]
+    [] ++ bs = bs
+    (a:as) ++ bs = a : (as ++ bs)
+expected:
+  - "(++) :: forall a. [a] -> [a] -> [a]"
+status: pass
+reason: polymorphic list signatures quantify variables inside list types

--- a/components/aihc-tc/test/Test/Fixtures/golden/prelude-list-core-lib.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/golden/prelude-list-core-lib.yaml
@@ -1,0 +1,16 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data List a = [] | a : [a]
+    infixr 5 :
+    (++) :: [a] -> [a] -> [a]
+    (++) [] ys = ys
+    (++) (x : xs) ys = x : (xs ++ ys)
+expected:
+  - "List :: *"
+  - "[] :: [a]"
+  - ": :: a -> [a] -> [a]"
+  - "(++) :: forall a. [a] -> [a] -> [a]"
+status: pass
+reason: Prelude-style List declarations share the builtin list type used by list syntax

--- a/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
@@ -10,7 +10,7 @@ where
 
 import Aihc.Cpp (Result (..))
 import Aihc.Dev.Parser.Run qualified as ParserRun
-import Aihc.Fc (DesugarResult (..), desugarModule, desugarModuleWithTcResult, evalProgramBinding, renderProgram, renderRawValue)
+import Aihc.Fc (DesugarResult (..), FcProgram (..), desugarModule, desugarModuleWithTcResult, evalProgramBinding, renderProgram, renderRawValue)
 import Aihc.Fmt (defaultFormatOptions, formatErrorMessage, formatExtensions, formatText)
 import Aihc.Parser
   ( ParseResult (..),
@@ -29,15 +29,14 @@ import Aihc.Parser.Syntax
     Expr,
     Extension,
     ExtensionSetting,
+    ImportDecl (..),
     LanguageEdition (Haskell2010Edition),
     Match (..),
     MatchHeadForm (..),
     Module (..),
     NameType (..),
-    Pattern (..),
     Pragma (..),
     Rhs (..),
-    UnqualifiedName (..),
     ValueDecl (..),
     editionFromExtensionSettings,
     effectiveExtensions,
@@ -45,8 +44,8 @@ import Aihc.Parser.Syntax
     parseExtensionName,
     parseExtensionSettingName,
   )
-import Aihc.Resolve (ResolveResult (..), collectModuleExports, renderAnnotatedResolveResult, renderResolveResult, resolve, resolveWithDeps)
-import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), TcType (..), TyCon (..), renderTcType, typecheckModule)
+import Aihc.Resolve (ResolveResult (..), renderAnnotatedResolveResult, renderResolveResult, resolve, resolveWithDeps)
+import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), renderTcType, typecheck, typecheckModulesWithEnv)
 import Control.Exception (IOException, bracket, catch)
 import Control.Monad (foldM, forM, forM_, unless)
 import CppSupport (cppEnabledInSource, preprocessForParserWithoutIncludes)
@@ -63,6 +62,7 @@ import Data.Map.Strict qualified as M
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Ratio (denominator, numerator)
 import Data.Scientific (toBoundedInteger)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -74,9 +74,9 @@ import Options.Applicative hiding (value)
 import Options.Applicative qualified as OA
 import ParserErrorGolden qualified as PEG
 import ParserGolden qualified as PG
-import System.Directory (createDirectoryIfMissing, doesDirectoryExist, findExecutable, getTemporaryDirectory, listDirectory, removeFile)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, findExecutable, getTemporaryDirectory, listDirectory, removeFile)
 import System.Exit (ExitCode (..))
-import System.FilePath (makeRelative, normalise, takeDirectory, takeExtension, (</>))
+import System.FilePath (joinPath, makeRelative, normalise, takeDirectory, takeExtension, (</>))
 import System.IO (Handle, hClose, openTempFile)
 import System.Process (readProcessWithExitCode)
 
@@ -348,9 +348,9 @@ tcActual value = do
   exts <- parseExtensions value
   modules <- parseTextArrayField "modules" value
   parsed <- traverse (parseModuleText exts) modules
-  let results = map typecheckModule parsed
+  let results = typecheck parsed
   if all tcmSuccess results
-    then Right (trim (unlines [T.unpack (tbName b) <> " :: " <> renderTcType (tbType b) | r <- results, b <- tcmBindings r]))
+    then Right (trim (unlines [T.unpack (tbDisplayName b) <> " :: " <> renderTcType (tbType b) | r <- results, b <- tcmBindings r]))
     else Left (unlines [show d | r <- results, d <- tcmDiagnostics r])
 
 updateFcGoldens :: Options -> IO Summary
@@ -377,43 +377,119 @@ updateFcEvalGoldens opts =
   updateYamlTree opts (optRoot opts </> "components/aihc-fc/test/Test/Fixtures/eval") $ \_ value ->
     if not (shouldUpdateOutput value)
       then pure FixtureUnchanged
-      else case fcEvalActual value of
-        Left err -> pure (skipForStatus (textField "status" value) err)
-        Right actual -> do
-          let expected = T.unpack <$> textField "output" value
-          pure $
-            if either (const True) ((/= trim actual) . trim) expected
-              then setValueAt ["output"] (String (T.pack actual)) value
-              else FixtureUnchanged
+      else do
+        actualResult <- fcEvalActual opts value
+        case actualResult of
+          Left err -> pure (skipForStatus (textField "status" value) err)
+          Right actual -> do
+            let expected = T.unpack <$> textField "output" value
+            pure $
+              if either (const True) ((/= trim actual) . trim) expected
+                then setValueAt ["output"] (String (T.pack actual)) value
+                else FixtureUnchanged
 
-fcEvalActual :: Value -> Either String String
-fcEvalActual value = do
+fcEvalActual :: Options -> Value -> IO (Either String String)
+fcEvalActual opts value =
+  case parseEvalInput value of
+    Left err -> pure (Left err)
+    Right (dependencies, evalModules) -> do
+      dependencyModules <- loadFcEvalDependencyModules opts dependencies evalModules
+      pure $ do
+        deps <- dependencyModules
+        case resolveWithDeps mempty (deps <> evalModules) of
+          ResolveResult {resolvedModules, resolveErrors = []} ->
+            let tcResults = typecheckModulesWithEnv [] resolvedModules
+             in if all tcmSuccess tcResults
+                  then
+                    let dsResults = zipWith desugarModuleWithTcResult tcResults resolvedModules
+                     in if all dsSuccess dsResults
+                          then first (("eval error: " <>) . show) (T.unpack <$> (evalProgramBinding evalBindingName (concatPrograms (map dsProgram dsResults)) >>= renderRawValue))
+                          else Left ("desugar error: " <> unlines (concatMap dsErrors dsResults))
+                  else Left ("typecheck error: " <> renderTcErrors tcResults)
+          ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+
+parseEvalInput :: Value -> Either String ([Text], [Module])
+parseEvalInput value = do
   exts <- parseExtensions value
+  dependencies <- optionalTextArrayField "dependencies" value
   moduleTexts <- parseTextArrayField "modules" value
   exprText <- textField "expression" value
   parsedModules <- traverse (parseModuleText exts) moduleTexts
   expr <- parseExprText exts exprText
-  let (depModules, evalModule) = combineEvalModules parsedModules expr
-      depExports = collectModuleExports depModules
-  case resolveWithDeps depExports [evalModule] of
-    ResolveResult {resolvedModules = [resolvedModule], resolveErrors = []} ->
-      let result = desugarModuleWithTcResult (syntheticTcResult resolvedModule) resolvedModule
-       in if dsSuccess result
-            then first (("eval error: " <>) . show) (T.unpack <$> (evalProgramBinding evalBindingName (dsProgram result) >>= renderRawValue))
-            else Left ("desugar error: " <> unlines (dsErrors result))
-    ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+  pure (dependencies, combineEvalModules parsedModules expr)
 
 evalBindingName :: Text
 evalBindingName = "__aihc_eval__"
 
-combineEvalModules :: [Module] -> Expr -> ([Module], Module)
+combineEvalModules :: [Module] -> Expr -> [Module]
 combineEvalModules modules expr =
   case modules of
-    [] -> ([], emptyEvalModule expr)
+    [] -> [emptyEvalModule expr]
     _ ->
       let depModules = init modules
           evalModule = last modules
-       in (depModules, evalModule {moduleDecls = moduleDecls evalModule <> [evalDecl expr]})
+       in depModules <> [evalModule {moduleDecls = moduleDecls evalModule <> [evalDecl expr]}]
+
+loadFcEvalDependencyModules :: Options -> [Text] -> [Module] -> IO (Either String [Module])
+loadFcEvalDependencyModules _ [] _ =
+  pure (Right [])
+loadFcEvalDependencyModules opts dependencies evalModules = do
+  roots <- traverse (resolveFcEvalDependencyRoot opts) dependencies
+  case sequence roots of
+    Left errMsg -> pure (Left errMsg)
+    Right packageRoots ->
+      loadTransitiveFcEvalModules packageRoots (initialFcEvalDependencyModules evalModules)
+
+resolveFcEvalDependencyRoot :: Options -> Text -> IO (Either String (Text, FilePath))
+resolveFcEvalDependencyRoot opts dependency =
+  case dependency of
+    "aihc-base" -> pure (Right (dependency, optRoot opts </> "core-libs" </> "aihc-base"))
+    _ -> pure (Left ("unknown eval fixture dependency: " <> T.unpack dependency))
+
+initialFcEvalDependencyModules :: [Module] -> Set.Set Text
+initialFcEvalDependencyModules modules =
+  Set.insert "Prelude" (importedFcEvalModuleNames modules)
+
+importedFcEvalModuleNames :: [Module] -> Set.Set Text
+importedFcEvalModuleNames modules =
+  Set.fromList [importDeclModule importDecl | modu <- modules, importDecl <- moduleImports modu]
+
+loadTransitiveFcEvalModules :: [(Text, FilePath)] -> Set.Set Text -> IO (Either String [Module])
+loadTransitiveFcEvalModules packageRoots initialModules =
+  go Set.empty [] (Set.toAscList initialModules)
+  where
+    go _ loaded [] =
+      pure (Right (reverse loaded))
+    go seen loaded (moduleName : pending)
+      | moduleName `Set.member` seen =
+          go seen loaded pending
+      | otherwise = do
+          maybePath <- findFcEvalModulePath packageRoots moduleName
+          case maybePath of
+            Nothing -> do
+              let dependencyNames = T.intercalate ", " (map fst packageRoots)
+              pure (Left ("dependency module " <> T.unpack moduleName <> " not found in dependencies: " <> T.unpack dependencyNames))
+            Just path -> do
+              source <- TIO.readFile path
+              case parseModuleText [] source of
+                Left errMsg -> pure (Left ("dependency module " <> T.unpack moduleName <> " parse error: " <> errMsg))
+                Right modu -> do
+                  let seen' = Set.insert moduleName seen
+                      newImports = Set.toAscList (importedFcEvalModuleNames [modu] `Set.difference` seen')
+                  go seen' (modu : loaded) (pending <> newImports)
+
+findFcEvalModulePath :: [(Text, FilePath)] -> Text -> IO (Maybe FilePath)
+findFcEvalModulePath [] _ = pure Nothing
+findFcEvalModulePath ((_dependency, root) : rest) moduleName = do
+  let path = root </> "src" </> fcEvalModuleNamePath moduleName
+  exists <- doesFileExist path
+  if exists
+    then pure (Just path)
+    else findFcEvalModulePath rest moduleName
+
+fcEvalModuleNamePath :: Text -> FilePath
+fcEvalModuleNamePath moduleName =
+  joinPath (map T.unpack (T.splitOn "." moduleName)) <> ".hs"
 
 emptyEvalModule :: Expr -> Module
 emptyEvalModule expr =
@@ -438,42 +514,16 @@ evalDecl expr =
           }
       ]
 
-syntheticTcResult :: Module -> TcModuleResult
-syntheticTcResult modu =
-  TcModuleResult
-    { tcmBindings = concatMap bindingTypes (moduleDecls modu),
-      tcmDiagnostics = [],
-      tcmSuccess = True
-    }
+concatPrograms :: [FcProgram] -> FcProgram
+concatPrograms programs =
+  FcProgram (concatMap fcTopBinds programs)
 
-bindingTypes :: Decl -> [TcBindingResult]
-bindingTypes decl =
-  case decl of
-    DeclAnn _ inner -> bindingTypes inner
-    DeclValue (FunctionBind name matches) ->
-      [TcBindingResult (unqualifiedNameText name) (functionType (matchArity matches))]
-    DeclValue (PatternBind _ pat _) ->
-      [TcBindingResult name unknownTy | Just name <- [barePatternName pat]]
-    _ -> []
-
-matchArity :: [Match] -> Int
-matchArity [] = 0
-matchArity (match : _) = length (matchPats match)
-
-functionType :: Int -> TcType
-functionType arity =
-  foldr TcFunTy unknownTy (replicate arity unknownTy)
-
-unknownTy :: TcType
-unknownTy = TcTyCon (TyCon "?" 0) []
-
-barePatternName :: Pattern -> Maybe Text
-barePatternName pat =
-  case pat of
-    PVar name -> Just (unqualifiedNameText name)
-    PAnn _ inner -> barePatternName inner
-    PParen inner -> barePatternName inner
-    _ -> Nothing
+renderTcErrors :: [TcModuleResult] -> String
+renderTcErrors results =
+  let rendered = unlines [show diagnostic | result <- results, diagnostic <- tcmDiagnostics result]
+   in if null (trim rendered)
+        then "type checker failed without diagnostics"
+        else rendered
 
 updateFormatterGoldens :: Options -> IO Summary
 updateFormatterGoldens opts =


### PR DESCRIPTION
## Summary

- replace FC eval fixture synthetic type-checker results with real shared `aihc-tc` module type-checking
- add a shared multi-module TC entry point and use it in TC goldens/updater paths
- fix TC support needed by current FC eval coverage: list-signature free variables, Prelude-style `List`, and self-recursive bindings
- improve desugar failure messages to surface TC diagnostics and add regression fixtures

## Progress Counts

- `aihc-tc` golden fixtures: +2 passing fixtures
- `aihc-fc` eval fixtures: +1 expected-failure fixture proving real TC rejection
- READMEs intentionally not updated; cron owns generated progress docs

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `cabal build -v0 exe:aihc-dev`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings)
