### PR TITLE
fix(parser): normalize ParseErr and add doctests

### DIFF
--- a/components/aihc-parser-compat/test/Test/Compat/Decl.hs
+++ b/components/aihc-parser-compat/test/Test/Compat/Decl.hs
@@ -83,7 +83,7 @@ example label source =
   testCase label $ do
     aihcDecl <-
       case Aihc.parseDecl compatParserConfig source of
-        Aihc.ParseErr err -> assertFailure (Aihc.formatParseErrorBundle "<compat-test>" (Just source) err)
+        Aihc.ParseErr err -> assertFailure (Aihc.formatParseErrors "<compat-test>" (Just source) err)
         Aihc.ParseOk decl -> pure decl
     ghcDecl <-
       case parseGhcLocatedDecl compatGhcExtensions source of

--- a/components/aihc-parser-compat/test/Test/Compat/Expr.hs
+++ b/components/aihc-parser-compat/test/Test/Compat/Expr.hs
@@ -109,7 +109,7 @@ repeatedInfixParser = do
   let source = "1 + 2 + 3"
   aihcExpr <-
     case Aihc.parseExpr Aihc.defaultConfig source of
-      Aihc.ParseErr err -> assertFailure (Aihc.formatParseErrorBundle "<compat-test>" (Just source) err)
+      Aihc.ParseErr err -> assertFailure (Aihc.formatParseErrors "<compat-test>" (Just source) err)
       Aihc.ParseOk expr -> pure expr
   ghcExpr <-
     case parseGhcLocatedExpr compatGhcExtensions source of

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -23,6 +23,7 @@ library
     Aihc.Parser.Internal.Cmd
     Aihc.Parser.Internal.Common
     Aihc.Parser.Internal.Decl
+    Aihc.Parser.Internal.Errors
     Aihc.Parser.Internal.Expr
     Aihc.Parser.Internal.FromTokens
     Aihc.Parser.Internal.Import
@@ -134,6 +135,7 @@ test-suite spec
     Aihc.Parser.Internal.Cmd
     Aihc.Parser.Internal.Common
     Aihc.Parser.Internal.Decl
+    Aihc.Parser.Internal.Errors
     Aihc.Parser.Internal.Expr
     Aihc.Parser.Internal.FromTokens
     Aihc.Parser.Internal.Import

--- a/components/aihc-parser/common/ParserEquivalent.hs
+++ b/components/aihc-parser/common/ParserEquivalent.hs
@@ -27,7 +27,6 @@ import Aihc.Parser
   ( ParseResult (..),
     ParserConfig (..),
     defaultConfig,
-    formatParseErrorBundle,
     formatParseErrors,
     parseDecl,
     parseExpr,
@@ -203,7 +202,7 @@ parseExprValue :: ParserConfig -> Text -> Either String Expr
 parseExprValue config source =
   case parseExpr config source of
     ParseOk ast -> Right ast
-    ParseErr err -> Left (formatParseErrorBundle (parserSourceName config) (Just source) err)
+    ParseErr err -> Left (formatParseErrors (parserSourceName config) (Just source) err)
 
 parseModuleValue :: ParserConfig -> Text -> Either String Module
 parseModuleValue config source =
@@ -215,13 +214,13 @@ parseDeclValue :: ParserConfig -> Text -> Either String Decl
 parseDeclValue config source =
   case parseDecl config source of
     ParseOk ast -> Right ast
-    ParseErr err -> Left (formatParseErrorBundle (parserSourceName config) (Just source) err)
+    ParseErr err -> Left (formatParseErrors (parserSourceName config) (Just source) err)
 
 parsePatternValue :: ParserConfig -> Text -> Either String Pattern
 parsePatternValue config source =
   case parsePattern config source of
     ParseOk ast -> Right ast
-    ParseErr err -> Left (formatParseErrorBundle (parserSourceName config) (Just source) err)
+    ParseErr err -> Left (formatParseErrors (parserSourceName config) (Just source) err)
 
 classifyEquivalence :: (Eq a, Shorthand a) => EquivalentCase -> [(Int, a)] -> (Outcome, String)
 classifyEquivalence meta parsed =

--- a/components/aihc-parser/common/ParserGolden.hs
+++ b/components/aihc-parser/common/ParserGolden.hs
@@ -26,7 +26,6 @@ import Aihc.Parser
   ( ParseResult (..),
     ParserConfig (..),
     defaultConfig,
-    formatParseErrorBundle,
     formatParseErrors,
     parseExpr,
     parseModule,
@@ -175,7 +174,7 @@ evaluateExprCase :: ParserCase -> (Outcome, String)
 evaluateExprCase meta =
   case parseExpr parserConfig (caseInput meta) of
     ParseOk ast -> classifySuccess meta (show (shorthand ast))
-    ParseErr err -> classifyFailure meta (formatParseErrorBundle (casePath meta) (Just (caseInput meta)) err)
+    ParseErr err -> classifyFailure meta (formatParseErrors (casePath meta) (Just (caseInput meta)) err)
   where
     edition = fromMaybe Haskell2010Edition (editionFromExtensionSettings (caseExtensions meta))
     parserConfig =
@@ -204,7 +203,7 @@ evaluatePatternCase :: ParserCase -> (Outcome, String)
 evaluatePatternCase meta =
   case parsePattern parserConfig (caseInput meta) of
     ParseOk ast -> classifySuccess meta (show (shorthand ast))
-    ParseErr err -> classifyFailure meta (formatParseErrorBundle (casePath meta) (Just (caseInput meta)) err)
+    ParseErr err -> classifyFailure meta (formatParseErrors (casePath meta) (Just (caseInput meta)) err)
   where
     edition = fromMaybe Haskell2010Edition (editionFromExtensionSettings (caseExtensions meta))
     parserConfig =

--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -34,33 +34,23 @@ where
 
 import Aihc.Parser.Internal.Common (drainParseErrors, eofTok)
 import Aihc.Parser.Internal.Decl (declParser)
+import Aihc.Parser.Internal.Errors (parseErrorBundleToSpannedText, parseErrorsToSpannedText)
 import Aihc.Parser.Internal.Expr (exprParser)
 import Aihc.Parser.Internal.Module (moduleParser)
 import Aihc.Parser.Internal.Pattern (patternParser)
 import Aihc.Parser.Internal.Type (typeParser, typeSignatureParser)
-import Aihc.Parser.Lex
-  ( LexToken (..),
-    TokenOrigin (..),
-  )
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Syntax (Decl, Expr, Module (..), Pattern, SourceSpan (..), Type, applyImpliedExtensions)
 import Aihc.Parser.Types
 import Data.ByteString qualified as BS
 import Data.List qualified as List
-import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe)
-import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Data.Word (Word8)
 import Prettyprinter (Doc, colon, defaultLayoutOptions, layoutPretty, pretty, vcat)
 import Prettyprinter.Render.String (renderString)
-import Prettyprinter.Render.Text qualified as RText
 import Text.Megaparsec (runParser)
-import Text.Megaparsec qualified as MP
-import Text.Megaparsec.Error (ErrorFancy (..), ErrorItem (..))
-import Text.Megaparsec.Error qualified as MPE
 
 -- $setup
 -- >>> :set -XOverloadedStrings
@@ -101,7 +91,7 @@ parseExpr :: ParserConfig -> Text -> ParseResult Expr
 parseExpr cfg input =
   let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (exprParser <* eofTok) (parserSourceName cfg) ts of
-        Left bundle -> ParseErr bundle
+        Left bundle -> ParseErr (parseErrorBundleToSpannedText bundle)
         Right expr -> ParseOk expr
 
 -- | Parse a Haskell pattern.
@@ -115,7 +105,7 @@ parsePattern :: ParserConfig -> Text -> ParseResult Pattern
 parsePattern cfg input =
   let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (patternParser <* eofTok) (parserSourceName cfg) ts of
-        Left bundle -> ParseErr bundle
+        Left bundle -> ParseErr (parseErrorBundleToSpannedText bundle)
         Right pat -> ParseOk pat
 
 -- | Parse a Haskell signature type.
@@ -129,7 +119,7 @@ parseSignatureType :: ParserConfig -> Text -> ParseResult Type
 parseSignatureType cfg input =
   let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (typeSignatureParser <* eofTok) (parserSourceName cfg) ts of
-        Left bundle -> ParseErr bundle
+        Left bundle -> ParseErr (parseErrorBundleToSpannedText bundle)
         Right ty -> ParseOk ty
 
 -- | Parse a Haskell type in the general declaration RHS context.
@@ -146,7 +136,7 @@ parseType :: ParserConfig -> Text -> ParseResult Type
 parseType cfg input =
   let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (typeParser <* eofTok) (parserSourceName cfg) ts of
-        Left bundle -> ParseErr bundle
+        Left bundle -> ParseErr (parseErrorBundleToSpannedText bundle)
         Right ty -> ParseOk ty
 
 -- | Parse a single Haskell declaration.
@@ -157,7 +147,7 @@ parseDecl :: ParserConfig -> Text -> ParseResult Decl
 parseDecl cfg input =
   let ts = mkTokStream (parserSourceName cfg) (applyImpliedExtensions (parserExtensions cfg)) input
    in case runParser (declParser <* eofTok) (parserSourceName cfg) ts of
-        Left bundle -> ParseErr bundle
+        Left bundle -> ParseErr (parseErrorBundleToSpannedText bundle)
         Right decl -> ParseOk decl
 
 -- | Parse a complete Haskell module.
@@ -183,7 +173,7 @@ parseModule cfg input =
         pure (errs, modu)
    in case runParser parser (parserSourceName cfg) ts of
         Left bundle ->
-          ( parseErrorsToSpannedText (NE.toList (MPE.bundleErrors bundle)),
+          ( parseErrorBundleToSpannedText bundle,
             Module
               { moduleAnns = [],
                 moduleHead = Nothing,
@@ -195,19 +185,10 @@ parseModule cfg input =
         Right (errs, modu) ->
           (parseErrorsToSpannedText errs, modu)
 
--- | Convert raw MegaParsec parse errors into @(SourceSpan, Text)@ pairs.
-parseErrorsToSpannedText :: [MPE.ParseError TokStream ParserErrorComponent] -> [(SourceSpan, Text)]
-parseErrorsToSpannedText errs =
-  [ (fromMaybe NoSourceSpan mSpan, RText.renderStrict (layoutPretty defaultLayoutOptions doc))
-  | err <- List.sortOn MP.errorOffset errs,
-    (mSpan, doc) <- renderParseErrors err
-  ]
-
--- | Pretty-print a Megaparsec parse error bundle using the same source-context
--- formatter as 'parseModule'.
-formatParseErrorBundle :: FilePath -> Maybe Text -> ParseErrorBundle -> String
-formatParseErrorBundle sourceName mSource bundle =
-  formatParseErrors sourceName mSource (parseErrorsToSpannedText (NE.toList (MPE.bundleErrors bundle)))
+-- | Pretty-print normalized parse errors, such as the payload carried by
+-- 'ParseErr'.
+formatParseErrorBundle :: FilePath -> Maybe Text -> [(SourceSpan, Text)] -> String
+formatParseErrorBundle = formatParseErrors
 
 -- | Pretty-print a list of spanned parse errors with source context.
 formatParseErrors :: FilePath -> Maybe Text -> [(SourceSpan, Text)] -> String
@@ -227,81 +208,6 @@ formatParseErrors sourceName mSource errs =
           )
           errs
    in List.intercalate "\n\n" blocks
-
--- | Turn a Megaparsec 'MPE.ParseError' into message blocks with optional spans.
---
--- * 'MPE.TrivialError': unexpected and expected items are rendered from token
---   text, with a span attached when the unexpected item is token content.
--- * 'MPE.FancyError': one block per fancy error. 'ErrorCustom' uses our
---   unexpected line, 'MPE.showErrorComponent', and context lines.
-renderParseErrors :: MPE.ParseError TokStream ParserErrorComponent -> [(Maybe SourceSpan, Doc ann)]
-renderParseErrors err =
-  case err of
-    MPE.TrivialError _ mUnexpected expected ->
-      let mSpan = trivialUnexpectedSpan mUnexpected
-       in [(mSpan, vcat (map pretty (renderTrivialError mUnexpected expected)))]
-    MPE.FancyError _ fancySet ->
-      map renderFancyError (Set.toAscList fancySet)
-  where
-    trivialUnexpectedSpan :: Maybe (ErrorItem LexToken) -> Maybe SourceSpan
-    trivialUnexpectedSpan mItem =
-      case mItem of
-        Just (Tokens ts) -> Just (lexTokenSpan (NE.head ts))
-        _ -> Nothing
-
-    renderFancyError :: ErrorFancy ParserErrorComponent -> (Maybe SourceSpan, Doc ann)
-    renderFancyError fancy =
-      case fancy of
-        ErrorCustom custom ->
-          ( customFoundSpan custom,
-            vcat (map pretty (customMessageLines custom))
-          )
-        ErrorFail message -> (Nothing, pretty message)
-        _ ->
-          ( Nothing,
-            pretty (show fancy)
-          )
-
-    customFoundSpan :: ParserErrorComponent -> Maybe SourceSpan
-    customFoundSpan (UnexpectedTokenExpecting (Just found) _ _) =
-      Just (foundTokenSpan found)
-    customFoundSpan _ = Nothing
-
-    customMessageLines :: ParserErrorComponent -> [String]
-    customMessageLines e@(UnexpectedTokenExpecting mFound _ contexts) =
-      [maybe "unexpected end of input" renderUnexpectedToken mFound, MPE.showErrorComponent e]
-        <> map (\context -> "context: " <> T.unpack context) contexts
-
-renderTrivialError :: Maybe (ErrorItem LexToken) -> Set.Set (ErrorItem LexToken) -> [String]
-renderTrivialError mUnexpected expected =
-  maybe [] (\item -> ["unexpected " <> renderErrorItem item]) mUnexpected
-    <> ["expecting " <> renderExpectedItems (Set.toAscList expected) | not (Set.null expected)]
-
-renderErrorItem :: ErrorItem LexToken -> String
-renderErrorItem item =
-  case item of
-    Tokens toks -> unwords (map (T.unpack . lexTokenText) (NE.toList toks))
-    Label label -> NE.toList label
-    EndOfInput -> "end of input"
-
-renderExpectedItems :: [ErrorItem LexToken] -> String
-renderExpectedItems items =
-  case map renderErrorItem items of
-    [] -> ""
-    [item] -> item
-    [itemA, itemB] -> itemA <> " or " <> itemB
-    rendered -> List.intercalate ", " (init rendered) <> ", or " <> last rendered
-
-renderUnexpectedToken :: FoundToken -> String
-renderUnexpectedToken found =
-  "unexpected " <> tokenDescriptor found
-
-tokenDescriptor :: FoundToken -> String
-tokenDescriptor found =
-  case foundTokenOrigin found of
-    InsertedLayout -> "end of input"
-    FromSource ->
-      "'" <> T.unpack (foundTokenText found) <> "'"
 
 -- renderSourceReference "<input>" "x = 1" (SourceSpan 1 5 1 6) = """
 -- <input>:1:5:

--- a/components/aihc-parser/src/Aihc/Parser.hs
+++ b/components/aihc-parser/src/Aihc/Parser.hs
@@ -19,8 +19,6 @@ module Aihc.Parser
 
     -- * Parse results
     ParseResult (..),
-    ParseErrorBundle,
-    formatParseErrorBundle,
     formatParseErrors,
 
     -- * Parsing expressions, patterns, types, and declarations
@@ -184,11 +182,6 @@ parseModule cfg input =
           )
         Right (errs, modu) ->
           (parseErrorsToSpannedText errs, modu)
-
--- | Pretty-print normalized parse errors, such as the payload carried by
--- 'ParseErr'.
-formatParseErrorBundle :: FilePath -> Maybe Text -> [(SourceSpan, Text)] -> String
-formatParseErrorBundle = formatParseErrors
 
 -- | Pretty-print a list of spanned parse errors with source context.
 formatParseErrors :: FilePath -> Maybe Text -> [(SourceSpan, Text)] -> String

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Errors.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Errors.hs
@@ -1,0 +1,100 @@
+module Aihc.Parser.Internal.Errors
+  ( parseErrorBundleToSpannedText,
+    parseErrorsToSpannedText,
+  )
+where
+
+import Aihc.Parser.Lex (LexToken (..), TokenOrigin (..))
+import Aihc.Parser.Syntax (SourceSpan (..))
+import Aihc.Parser.Types (FoundToken (..), ParseErrorBundle, ParserErrorComponent (..), TokStream)
+import Data.List qualified as List
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Prettyprinter (Doc, defaultLayoutOptions, layoutPretty, pretty, vcat)
+import Prettyprinter.Render.Text qualified as RText
+import Text.Megaparsec qualified as MP
+import Text.Megaparsec.Error (ErrorFancy (..), ErrorItem (..))
+import Text.Megaparsec.Error qualified as MPE
+
+parseErrorBundleToSpannedText :: ParseErrorBundle -> [(SourceSpan, Text)]
+parseErrorBundleToSpannedText bundle =
+  parseErrorsToSpannedText (NE.toList (MPE.bundleErrors bundle))
+
+parseErrorsToSpannedText :: [MPE.ParseError TokStream ParserErrorComponent] -> [(SourceSpan, Text)]
+parseErrorsToSpannedText errs =
+  [ (fromMaybe NoSourceSpan mSpan, RText.renderStrict (layoutPretty defaultLayoutOptions doc))
+  | err <- List.sortOn MP.errorOffset errs,
+    (mSpan, doc) <- renderParseErrors err
+  ]
+
+renderParseErrors :: MPE.ParseError TokStream ParserErrorComponent -> [(Maybe SourceSpan, Doc ann)]
+renderParseErrors err =
+  case err of
+    MPE.TrivialError _ mUnexpected expected ->
+      let mSpan = trivialUnexpectedSpan mUnexpected
+       in [(mSpan, vcat (map pretty (renderTrivialError mUnexpected expected)))]
+    MPE.FancyError _ fancySet ->
+      map renderFancyError (Set.toAscList fancySet)
+  where
+    trivialUnexpectedSpan :: Maybe (ErrorItem LexToken) -> Maybe SourceSpan
+    trivialUnexpectedSpan mItem =
+      case mItem of
+        Just (Tokens ts) -> Just (lexTokenSpan (NE.head ts))
+        _ -> Nothing
+
+    renderFancyError :: ErrorFancy ParserErrorComponent -> (Maybe SourceSpan, Doc ann)
+    renderFancyError fancy =
+      case fancy of
+        ErrorCustom custom ->
+          ( customFoundSpan custom,
+            vcat (map pretty (customMessageLines custom))
+          )
+        ErrorFail message -> (Nothing, pretty message)
+        _ ->
+          ( Nothing,
+            pretty (show fancy)
+          )
+
+    customFoundSpan :: ParserErrorComponent -> Maybe SourceSpan
+    customFoundSpan (UnexpectedTokenExpecting (Just found) _ _) =
+      Just (foundTokenSpan found)
+    customFoundSpan _ = Nothing
+
+    customMessageLines :: ParserErrorComponent -> [String]
+    customMessageLines e@(UnexpectedTokenExpecting mFound _ contexts) =
+      [maybe "unexpected end of input" renderUnexpectedToken mFound, MPE.showErrorComponent e]
+        <> map (\context -> "context: " <> T.unpack context) contexts
+
+renderTrivialError :: Maybe (ErrorItem LexToken) -> Set.Set (ErrorItem LexToken) -> [String]
+renderTrivialError mUnexpected expected =
+  maybe [] (\item -> ["unexpected " <> renderErrorItem item]) mUnexpected
+    <> ["expecting " <> renderExpectedItems (Set.toAscList expected) | not (Set.null expected)]
+
+renderErrorItem :: ErrorItem LexToken -> String
+renderErrorItem item =
+  case item of
+    Tokens toks -> unwords (map (T.unpack . lexTokenText) (NE.toList toks))
+    Label label -> NE.toList label
+    EndOfInput -> "end of input"
+
+renderExpectedItems :: [ErrorItem LexToken] -> String
+renderExpectedItems items =
+  case map renderErrorItem items of
+    [] -> ""
+    [item] -> item
+    [itemA, itemB] -> itemA <> " or " <> itemB
+    rendered -> List.intercalate ", " (init rendered) <> ", or " <> last rendered
+
+renderUnexpectedToken :: FoundToken -> String
+renderUnexpectedToken found =
+  "unexpected " <> tokenDescriptor found
+
+tokenDescriptor :: FoundToken -> String
+tokenDescriptor found =
+  case foundTokenOrigin found of
+    InsertedLayout -> "end of input"
+    FromSource ->
+      "'" <> T.unpack (foundTokenText found) <> "'"

--- a/components/aihc-parser/src/Aihc/Parser/Internal/FromTokens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/FromTokens.hs
@@ -24,6 +24,7 @@ where
 
 import Aihc.Parser.Internal.Common (TokParser, eofTok)
 import Aihc.Parser.Internal.Decl (declParser)
+import Aihc.Parser.Internal.Errors (parseErrorBundleToSpannedText)
 import Aihc.Parser.Internal.Expr (exprParser)
 import Aihc.Parser.Internal.Import (importDeclParser, moduleHeaderParser)
 import Aihc.Parser.Internal.Module (moduleParser)
@@ -37,7 +38,7 @@ import Text.Megaparsec (runParser)
 parseFromTokens :: TokParser a -> FilePath -> [LexToken] -> ParseResult a
 parseFromTokens parser sourceName toks =
   case runParser (parser <* eofTok) sourceName (mkTokStreamFromTokens toks) of
-    Left bundle -> ParseErr bundle
+    Left bundle -> ParseErr (parseErrorBundleToSpannedText bundle)
     Right parsed -> ParseOk parsed
 
 parseExprFromTokens :: FilePath -> [LexToken] -> ParseResult Expr

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -37,6 +37,11 @@ import Data.Char (isHexDigit)
 import Data.Maybe (isJust, isNothing)
 import Data.Text qualified as T
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Aihc.Parser.Shorthand (Shorthand(..))
+-- >>> import Aihc.Parser.Syntax
+
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
@@ -572,6 +577,13 @@ typeHasFunctionArrow ty =
 -- Module
 -- ---------------------------------------------------------------------------
 
+-- | Parenthesise an entire module.
+--
+-- >>> shorthand $ addModuleParens (Module [] Nothing [] [] [DeclTypeSig ["f"] (TKindSig TWildcard TWildcard)])
+-- Module {[DeclTypeSig ["f"] (TParen (TKindSig (TWildcard) (TWildcard)))]}
+--
+-- >>> shorthand $ addModuleParens (Module [] Nothing [] [] [DeclTypeSig ["f"] (TCon "Int" Unpromoted)])
+-- Module {[DeclTypeSig ["f"] (TCon "Int")]}
 addModuleParens :: Module -> Module
 addModuleParens modu =
   modu
@@ -582,6 +594,13 @@ addModuleParens modu =
 -- Declarations
 -- ---------------------------------------------------------------------------
 
+-- | Parenthesise a declaration.
+--
+-- >>> shorthand $ addDeclParens (DeclTypeSig ["f"] (TKindSig TWildcard TWildcard))
+-- DeclTypeSig ["f"] (TParen (TKindSig (TWildcard) (TWildcard)))
+--
+-- >>> shorthand $ addDeclParens (DeclTypeSig ["f"] (TCon "Int" Unpromoted))
+-- DeclTypeSig ["f"] (TCon "Int")
 addDeclParens :: Decl -> Decl
 addDeclParens decl =
   case decl of
@@ -1027,6 +1046,12 @@ addDataFamilyInstHeadParens followedByKindSig ty =
 -- ---------------------------------------------------------------------------
 
 -- | Add parentheses to an expression at all required positions.
+--
+-- >>> shorthand $ addExprParens (EApp (EVar "f") (EInfix (EVar "x") "+" (EVar "y")))
+-- EApp (EVar "f") (EParen (EInfix (EVar "x") "+" (EVar "y")))
+--
+-- >>> shorthand $ addExprParens (EApp (EVar "f") (EVar "x"))
+-- EApp (EVar "f") (EVar "x")
 addExprParens :: Expr -> Expr
 addExprParens = addExprParensPrec 0
 
@@ -1413,10 +1438,22 @@ absorbsFollowingInfix = \case
 -- ---------------------------------------------------------------------------
 
 -- | Add parentheses to a signature type at all required positions.
+--
+-- >>> shorthand $ addSignatureTypeParens (TKindSig TWildcard TWildcard)
+-- TParen (TKindSig (TWildcard) (TWildcard))
+--
+-- >>> shorthand $ addSignatureTypeParens (TFun ArrowUnrestricted (TCon "A" Unpromoted) (TCon "B" Unpromoted))
+-- TFun (TCon "A") (TCon "B")
 addSignatureTypeParens :: Type -> Type
 addSignatureTypeParens = addSignatureTypeParensShared CtxTypeAtom 0
 
 -- | Add parentheses to a plain type at all required positions.
+--
+-- >>> shorthand $ addTypeParens (TApp (TCon "Proxy" Unpromoted) (TFun ArrowUnrestricted (TCon "A" Unpromoted) (TCon "B" Unpromoted)))
+-- TApp (TCon "Proxy") (TParen (TFun (TCon "A") (TCon "B")))
+--
+-- >>> shorthand $ addTypeParens (TApp (TCon "Proxy" Unpromoted) (TCon "A" Unpromoted))
+-- TApp (TCon "Proxy") (TCon "A")
 addTypeParens :: Type -> Type
 addTypeParens = addTypeTopLevelParens
 
@@ -1622,6 +1659,12 @@ addContextConstraintMulti ty =
 -- ---------------------------------------------------------------------------
 
 -- | Add parentheses to a pattern at all required positions.
+--
+-- >>> shorthand $ addPatternParens (PAs "xs" (PNegLit (LitInt 1 TInteger "1")))
+-- PAs UnqualifiedName {"xs"} (PParen (PNegLit (LitInt 1 TInteger)))
+--
+-- >>> shorthand $ addPatternParens (PAs "xs" (PVar "x"))
+-- PAs UnqualifiedName {"xs"} (PVar "x")
 addPatternParens :: Pattern -> Pattern
 addPatternParens pat =
   case pat of

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -54,6 +54,14 @@ import Prettyprinter
     (<+>),
   )
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Aihc.Parser.Shorthand (Shorthand(..))
+-- >>> import Aihc.Parser.Syntax
+-- >>> import Prettyprinter (defaultLayoutOptions, layoutPretty)
+-- >>> import Prettyprinter.Render.String (renderString)
+-- >>> let renderDoc = renderString . layoutPretty defaultLayoutOptions
+
 -- | Wrap a document in braces with interior spaces: @{ content }@.
 -- Unlike 'braces' which produces @{content}@, this version avoids the
 -- @{-@ block-comment ambiguity that occurs when the content starts with a
@@ -417,6 +425,10 @@ typeFamilyInfixAppView ty =
 
 -- | Pretty-print a type. The AST is assumed to already have TParen nodes
 -- in the correct positions (inserted by 'addTypeParens').
+--
+-- >>> let ty = TApp (TCon "Proxy" Unpromoted) (TParen (TFun ArrowUnrestricted (TCon "A" Unpromoted) (TCon "B" Unpromoted))) in (renderDoc (prettyType ty), show (shorthand ty))
+-- ("Proxy (A -> B)","TApp (TCon \"Proxy\") (TParen (TFun (TCon \"A\") (TCon \"B\")))")
+--
 -- | Check if a type, when pretty-printed, would start with a
 -- promotion tick.  This is used to decide whether a promoted list or
 -- tuple needs a space after the opening tick to avoid lexer confusion
@@ -520,6 +532,9 @@ prettyTypeLiteral lit =
 
 -- | Pretty-print a pattern. The AST is assumed to already have PParen nodes
 -- in the correct positions (inserted by 'addPatternParens').
+--
+-- >>> let pat = PAs "xs" (PParen (PNegLit (LitInt 1 TInteger "1"))) in (renderDoc (prettyPattern pat), show (shorthand pat))
+-- ("xs@(-1)","PAs UnqualifiedName {\"xs\"} (PParen (PNegLit (LitInt 1 TInteger)))")
 prettyPattern :: Pattern -> Doc ann
 prettyPattern pat =
   case pat of
@@ -1133,6 +1148,9 @@ prettyConstructorUName name
 
 -- | Pretty-print an expression. The AST is assumed to already have EParen
 -- nodes in the correct positions (inserted by 'addExprParens').
+--
+-- >>> let expr = EApp (EVar "f") (EParen (EInfix (EVar "x") "+" (EVar "y"))) in (renderDoc (prettyExpr expr), show (shorthand expr))
+-- ("f\n  (x\n  + y)","EApp (EVar \"f\") (EParen (EInfix (EVar \"x\") \"+\" (EVar \"y\")))")
 prettyExpr :: Expr -> Doc ann
 prettyExpr expr =
   case expr of

--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -29,7 +29,7 @@ import Aihc.Parser.Lex
     readModuleHeaderExtensionsFromChunks,
     scanAllTokens,
   )
-import Aihc.Parser.Syntax (Extension, SourceSpan (..), applyExtensionSetting, applyImpliedExtensions)
+import Aihc.Parser.Syntax (Extension, SourceSpan, applyExtensionSetting, applyImpliedExtensions)
 import Control.DeepSeq (NFData (..))
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -38,7 +38,7 @@ import Text.Megaparsec qualified as MP
 import Text.Megaparsec.Error qualified as MPE
 import Text.Megaparsec.Stream (Stream (..))
 
--- | Parse error from token parser. Use 'formatParseErrorBundle' from "Parser" to render.
+-- | Raw Megaparsec parse error bundle for low-level parser entry points.
 type ParseErrorBundle = MPE.ParseErrorBundle TokStream ParserErrorComponent
 
 data FoundToken = FoundToken
@@ -308,10 +308,10 @@ data ParserConfig = ParserConfig
 
 data ParseResult a
   = ParseOk a
-  | ParseErr ParseErrorBundle
+  | ParseErr [(SourceSpan, Text)]
 
 instance (NFData a) => NFData (ParseResult a) where
   rnf parseResult =
     case parseResult of
       ParseOk parsed -> rnf parsed
-      ParseErr bundle -> rnf (show bundle)
+      ParseErr errs -> rnf errs

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -107,9 +107,9 @@ assertParsedStrippedExprShapeRoundTrip config source =
             ParseOk reparsed -> do
               assertEqualShorthand (T.unpack rendered) (stripAnnotations stripped) (stripAnnotations (stripParens reparsed))
             ParseErr bundle ->
-              assertFailure ("expected pretty-printed expression to reparse, got:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+              assertFailure ("expected pretty-printed expression to reparse, got:\n" <> formatParseErrors "<test>" Nothing bundle)
     ParseErr bundle ->
-      assertFailure ("expected parse success for:\n" <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for:\n" <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing bundle)
 
 assertParsedStrippedPatternShapeRoundTrip :: ParserConfig -> Text -> Assertion
 assertParsedStrippedPatternShapeRoundTrip config source =
@@ -121,9 +121,9 @@ assertParsedStrippedPatternShapeRoundTrip config source =
             ParseOk reparsed ->
               assertEqual "reparsed pattern" (stripAnnotations stripped) (stripAnnotations (stripParens reparsed))
             ParseErr bundle ->
-              assertFailure ("expected pretty-printed pattern to reparse:\n" <> T.unpack rendered <> "\ngot:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+              assertFailure ("expected pretty-printed pattern to reparse:\n" <> T.unpack rendered <> "\ngot:\n" <> formatParseErrors "<test>" Nothing bundle)
     ParseErr bundle ->
-      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing bundle)
 
 assertParsedStrippedDeclShapeRoundTrip :: ParserConfig -> Text -> Assertion
 assertParsedStrippedDeclShapeRoundTrip config source =
@@ -135,9 +135,9 @@ assertParsedStrippedDeclShapeRoundTrip config source =
             ParseOk reparsed ->
               assertEqual "reparsed declaration" (stripAnnotations stripped) (stripAnnotations (stripParens reparsed))
             ParseErr bundle ->
-              assertFailure ("expected pretty-printed declaration to reparse, got:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+              assertFailure ("expected pretty-printed declaration to reparse, got:\n" <> formatParseErrors "<test>" Nothing bundle)
     ParseErr bundle ->
-      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing bundle)
 
 assertParsedModulePrettyContains :: Text -> Text -> Assertion
 assertParsedModulePrettyContains source expected =
@@ -154,7 +154,7 @@ assertExprRenderingRoundTrip config expr rendered =
     ParseOk reparsed ->
       assertEqual "reparsed expression" (stripAnnotations (addExprParens expr)) (stripAnnotations reparsed)
     ParseErr bundle ->
-      assertFailure ("expected pretty-printed expression to reparse, got:\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected pretty-printed expression to reparse, got:\n" <> formatParseErrors "<test>" Nothing bundle)
 
 main :: IO ()
 main = buildTests >>= defaultMain
@@ -423,7 +423,7 @@ test_unicodeSymbolIsNotOverloadedLabel = do
   case parseDecl config source of
     ParseOk _ -> pure ()
     ParseErr bundle ->
-      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_stringGapBeforeClosingQuoteLexes :: Assertion
 test_stringGapBeforeClosingQuoteLexes = do
@@ -448,7 +448,7 @@ test_overloadedLabelPrettyPrintsWithDelimiterSpacing = do
   mapM_
     ( \source ->
         case parseExpr config source of
-          ParseErr err -> assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing err)
+          ParseErr err -> assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing err)
           ParseOk _ -> pure ()
     )
     rendered
@@ -1415,7 +1415,7 @@ test_thTypeQuoteBeforeConstraintExprSig = do
   case parseDecl config source of
     ParseOk _ -> pure ()
     ParseErr bundle ->
-      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_viewExprAppliedTypeSigParens :: Assertion
 test_viewExprAppliedTypeSigParens = do
@@ -1507,7 +1507,7 @@ test_signatureTypeParserParsesParenthesizedKindSignature = do
     ParseOk ty ->
       assertEqual "parenthesized kind signature" (TParen (TKindSig TWildcard TWildcard)) (stripAnnotations ty)
     ParseErr bundle ->
-      assertFailure ("expected parse success for parenthesized kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for parenthesized kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_signatureTypeParserParsesDelimitedKindSignature :: Assertion
 test_signatureTypeParserParsesDelimitedKindSignature = do
@@ -1516,7 +1516,7 @@ test_signatureTypeParserParsesDelimitedKindSignature = do
     ParseOk ty ->
       assertEqual "delimited kind signature" (TList Unpromoted [TKindSig TWildcard TWildcard]) (stripAnnotations ty)
     ParseErr bundle ->
-      assertFailure ("expected parse success for delimited kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for delimited kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_signatureTypeParserRejectsAppArgBareKindSignature :: Assertion
 test_signatureTypeParserRejectsAppArgBareKindSignature = do
@@ -1533,7 +1533,7 @@ test_signatureTypeParserParsesAppArgParenthesizedKindSignature = do
     ParseOk ty ->
       assertEqual "parenthesized app argument kind signature" (TApp TWildcard (TParen (TKindSig TWildcard TWildcard))) (stripAnnotations ty)
     ParseErr bundle ->
-      assertFailure ("expected parse success for parenthesized app argument kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for parenthesized app argument kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_signatureTypeParserRejectsImplicitParamBareKindSignature :: Assertion
 test_signatureTypeParserRejectsImplicitParamBareKindSignature = do
@@ -1558,7 +1558,7 @@ test_typeParserParsesBareKindSignature = do
     ParseOk ty ->
       assertEqual "type kind signature" (TKindSig TWildcard TWildcard) (stripAnnotations ty)
     ParseErr bundle ->
-      assertFailure ("expected parse success for type kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for type kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_shrunkDoExpressionsKeepFinalExpression :: Assertion
 test_shrunkDoExpressionsKeepFinalExpression = do
@@ -1574,7 +1574,7 @@ test_shrunkDoExpressionsKeepFinalExpression = do
       let invalidShrinks = [stmts | EDo stmts _ <- shrinkExpr expr, not (testDoStmtsEndInExpr stmts)]
        in assertEqual "invalid do-statement shrinks" [] invalidShrinks
     ParseErr bundle ->
-      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrors "<test>" Nothing bundle)
 
 testDoStmtsEndInExpr :: [DoStmt Expr] -> Bool
 testDoStmtsEndInExpr stmts =

--- a/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/DeclRoundTrip.hs
@@ -5,7 +5,7 @@ module Test.Properties.DeclRoundTrip
   )
 where
 
-import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, formatParseErrorBundle, parseDecl)
+import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, formatParseErrors, parseDecl)
 import Aihc.Parser.Parens (addDeclParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
@@ -38,7 +38,7 @@ prop_declPrettyRoundTrip decl =
             counterexample (T.unpack source) $
               case parseDecl declConfig source of
                 ParseErr err ->
-                  counterexample (formatParseErrorBundle (parserSourceName declConfig) (Just source) err) False
+                  counterexample (formatParseErrors (parserSourceName declConfig) (Just source) err) False
                 ParseOk parsed ->
                   let actual = stripAnnotations parsed
                    in counterexample ("expected:\n" <> show (shorthand expected) <> "\nactual:\n" <> show (shorthand actual)) (expected == actual)

--- a/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/ExprRoundTrip.hs
@@ -32,7 +32,7 @@ prop_exprPrettyRoundTrip expr =
         counterexample (T.unpack source) $
           case parseExpr exprConfig source of
             ParseErr err ->
-              counterexample (formatParseErrorBundle (parserSourceName exprConfig) (Just source) err) False
+              counterexample (formatParseErrors (parserSourceName exprConfig) (Just source) err) False
             ParseOk parsed ->
               let actual = stripAnnotations parsed
                in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)

--- a/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/PatternRoundTrip.hs
@@ -5,7 +5,7 @@ module Test.Properties.PatternRoundTrip
   )
 where
 
-import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, formatParseErrorBundle, parsePattern)
+import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, formatParseErrors, parsePattern)
 import Aihc.Parser.Parens (addPatternParens)
 import Aihc.Parser.Syntax
 import Data.Text qualified as T
@@ -31,7 +31,7 @@ prop_patternPrettyRoundTrip pat =
           counterexample (T.unpack source) $
             case parsePattern patternConfig source of
               ParseErr err ->
-                counterexample (formatParseErrorBundle (parserSourceName patternConfig) (Just source) err) False
+                counterexample (formatParseErrors (parserSourceName patternConfig) (Just source) err) False
               ParseOk parsed ->
                 let actual = stripAnnotations parsed
                  in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)

--- a/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
+++ b/components/aihc-parser/test/Test/Properties/TypeRoundTrip.hs
@@ -31,7 +31,7 @@ prop_typePrettyRoundTrip ty =
             counterexample (T.unpack source) $
               case parseType typeConfig source of
                 ParseErr err ->
-                  counterexample (formatParseErrorBundle (parserSourceName typeConfig) (Just source) err) False
+                  counterexample (formatParseErrors (parserSourceName typeConfig) (Just source) err) False
                 ParseOk parsed ->
                   let actual = stripAnnotations parsed
                    in counterexample ("expected: " <> show expected <> "\nactual: " <> show actual) (expected == actual)

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -116,6 +116,8 @@
       PKGDB=$(ghc --print-global-package-db)
       # Include all source files so imports between modules work.
       doctest -XGHC2021 -package-db="$PKGDB" -isrc \
+        src/Aihc/Parser/Parens.hs \
+        src/Aihc/Parser/Pretty.hs \
         src/Aihc/Parser/Shorthand.hs \
         src/Aihc/Parser.hs
     '';

--- a/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
@@ -16,7 +16,6 @@ import Aihc.Parser
   ( ParseResult (..),
     ParserConfig (..),
     defaultConfig,
-    formatParseErrorBundle,
     formatParseErrors,
     parseExpr,
     parseModule,
@@ -192,7 +191,7 @@ parserActualAst meta =
     PG.CaseExpr ->
       case parseExpr (parserConfig (PG.casePath meta) (PG.caseExtensions meta)) (PG.caseInput meta) of
         ParseOk ast -> Right (show (shorthand ast))
-        ParseErr err -> Left (formatParseErrorBundle (PG.casePath meta) (Just (PG.caseInput meta)) err)
+        ParseErr err -> Left (formatParseErrors (PG.casePath meta) (Just (PG.caseInput meta)) err)
     PG.CaseModule ->
       let (errs, ast) = parseModule (parserConfig (PG.casePath meta) (PG.caseExtensions meta)) (PG.caseInput meta)
        in if null errs
@@ -201,7 +200,7 @@ parserActualAst meta =
     PG.CasePattern ->
       case parsePattern (parserConfig (PG.casePath meta) (PG.caseExtensions meta)) (PG.caseInput meta) of
         ParseOk ast -> Right (show (shorthand ast))
-        ParseErr err -> Left (formatParseErrorBundle (PG.casePath meta) (Just (PG.caseInput meta)) err)
+        ParseErr err -> Left (formatParseErrors (PG.casePath meta) (Just (PG.caseInput meta)) err)
 
 parserConfig :: FilePath -> [ExtensionSetting] -> ParserConfig
 parserConfig sourceName exts =
@@ -862,7 +861,7 @@ parseExprText :: [Extension] -> Text -> Either String Expr
 parseExprText exts input =
   case parseExpr defaultConfig {parserSourceName = "<expression>", parserExtensions = exts} input of
     ParseOk expr -> Right expr
-    ParseErr err -> Left (formatParseErrorBundle "<expression>" (Just input) err)
+    ParseErr err -> Left (formatParseErrors "<expression>" (Just input) err)
 
 skipForStatus :: Either String Text -> String -> FixtureUpdate
 skipForStatus status err =


### PR DESCRIPTION
## Summary

- add doctest coverage for all exported `Aihc.Parser.Parens` entry points and for exported `Aihc.Parser.Pretty` helpers
- normalize `ParseErr` to carry `[(SourceSpan, Text)]` instead of raw Megaparsec bundles
- share parser error normalization across top-level and token-stream parser entry points
- extend the parser doctest Nix check to include `Parens.hs` and `Pretty.hs`

## Validation

- `just fmt`
- `just check`
- `nix build .#checks.aarch64-darwin.parser-doctest`

## Progress Counts

- No README progress counters changed
