### PR TITLE
fix(parser): preserve transform-list-comp terminators after negation

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -600,10 +600,14 @@ contextItemParserWith typeParser typeAtomParser =
       rest <- MP.many constraintTypeAppArgParser
       pure (foldl applyConstraintAppArg first rest)
     constraintTypeAppArgParser =
-      (Left <$> MP.try (expectedTok TkTypeApp *> typeAtomParser))
-        <|> (Right <$> typeAtomParser)
+      (Left <$> MP.try (expectedTok TkTypeApp *> (typeAtomParser >>= rejectBareConstraintImplicitParam)))
+        <|> (Right <$> (typeAtomParser >>= rejectBareConstraintImplicitParam))
     applyConstraintAppArg fn (Left ty) = TTypeApp fn ty
     applyConstraintAppArg fn (Right ty) = TApp fn ty
+    rejectBareConstraintImplicitParam ty =
+      case peelTypeAnn ty of
+        TImplicitParam {} -> fail "implicit parameter type must be parenthesized"
+        _ -> pure ty
     -- \| Parse a type expression that can appear as a kind annotation.
     -- Handles function types (e.g., Type -> Constraint) and type application,
     -- but NOT context types (C a => ...) to avoid parsing cycles.

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -1068,10 +1068,21 @@ compTransformExprWithoutTypeSigParser = exprInfixChainParser compTransformLexpPa
 -- | TransformListComp still uses the report @lexp@ layering; only its atom
 -- parser changes.
 compTransformLexpParser :: TokParser Expr
-compTransformLexpParser = lexpBaseParser compTransformAppExprParser
+compTransformLexpParser =
+  lexpBlockParser
+    <|> MP.try compTransformNegateExprParser
+    <|> compTransformAppExprParser
 
 compTransformAppExprParser :: TokParser Expr
 compTransformAppExprParser = appExprParserWith compTransformAtomOrRecordExprParser
+
+compTransformNegateExprParser :: TokParser Expr
+compTransformNegateExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+  _ <- minusTokenValueParser
+  ENegate <$> compTransformNegateOperandParser
+
+compTransformNegateOperandParser :: TokParser Expr
+compTransformNegateOperandParser = reportLexpParser compTransformAppExprParser
 
 -- | Like 'atomOrRecordExprParser' but rejects bare 'by' and 'using' identifiers.
 -- These are treated as contextual keywords in TransformListComp context.

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -275,6 +275,7 @@ buildTests = do
             testCase "rejects bare kind signatures in signature type applications" test_signatureTypeParserRejectsAppArgBareKindSignature,
             testCase "parses parenthesized kind signatures in signature type applications" test_signatureTypeParserParsesAppArgParenthesizedKindSignature,
             testCase "rejects bare kind signatures in signature implicit parameter bodies" test_signatureTypeParserRejectsImplicitParamBareKindSignature,
+            testCase "rejects bare implicit parameter type arguments in contexts" test_typeParserRejectsBareImplicitParamContextAppArg,
             testCase "rejects bare kind signatures in value signatures" test_declParserRejectsBareKindSignature,
             testCase "parses bare kind signatures as types" test_typeParserParsesBareKindSignature,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
@@ -1540,6 +1541,14 @@ test_signatureTypeParserRejectsImplicitParamBareKindSignature :: Assertion
 test_signatureTypeParserRejectsImplicitParamBareKindSignature = do
   let config = defaultConfig {parserExtensions = requiredExtensions}
   case parseSignatureType config "?a :: _ :: _" of
+    ParseErr {} -> pure ()
+    ParseOk ty ->
+      assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations ty)))
+
+test_typeParserRejectsBareImplicitParamContextAppArg :: Assertion
+test_typeParserRejectsBareImplicitParamContextAppArg = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseType config "_ => (_, (:+) ?a :: _) => _" of
     ParseErr {} -> pure ()
     ParseOk ty ->
       assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations ty)))

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -247,6 +247,7 @@ buildTests = do
             testCase "pretty-prints nested infix RHS expressions inside sections" test_prettyNestedInfixRhsInsideSection,
             testCase "pretty-prints right sections with bare infix operands" test_prettyRightSectionInfixOperand,
             testCase "pretty-prints infix RHS open-ended expressions before following infix operators" test_prettyInfixRhsOpenEndedBeforeFollowingInfix,
+            testCase "parenthesizes transform-list-comp group-by infix RHS before using" test_transformListCompGroupByInfixRhsParens,
             testCase "parenthesizes lambda RHS before following infix operators" test_lambdaInfixRhsBeforeFollowingInfixParens,
             testCase "parenthesizes if RHS before following infix operators" test_ifInfixRhsBeforeFollowingInfixParens,
             testCase "parenthesizes infix RHS operands inside left sections" test_infixRhsInsideLeftSectionParens,
@@ -1575,6 +1576,12 @@ test_shrunkDoExpressionsKeepFinalExpression = do
        in assertEqual "invalid do-statement shrinks" [] invalidShrinks
     ParseErr bundle ->
       assertFailure ("expected parse success for " <> T.unpack source <> "\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_transformListCompGroupByInfixRhsParens :: Assertion
+test_transformListCompGroupByInfixRhsParens = do
+  let config = defaultConfig {parserExtensions = [TransformListComp]}
+      source = "_ = [[] | then group by ([] `a` - []) using []]"
+  assertParsedStrippedDeclShapeRoundTrip config source
 
 testDoStmtsEndInExpr :: [DoStmt Expr] -> Bool
 testDoStmtsEndInExpr stmts =


### PR DESCRIPTION
## Summary

- fix `TransformListComp` negation so `group by` expressions still stop at `using` and `by`
- reject bare implicit-parameter type arguments inside context applications so minimal-parens no longer relies on a parser false positive
- add focused parser regressions for both shrunk QuickCheck counterexamples

## Root Cause

- the transform-list-comprehension parser reused the generic negation parser, which reads negation operands with the normal application parser
- that let `using` and `by` be consumed as ordinary identifiers after prefix `-`, so GHC accepted `then group by [] 0a0 - [] using []` while `aihc-parser` rejected it
- separately, the special constraint application parser accepted bare implicit-parameter types as application arguments inside contexts
- that made `_ => (_, (:+) ?a :: _) => _` parse in `aihc-parser` even though GHC rejects it, which broke the minimal-parens property

## Validation

- `cabal test -v0 aihc-parser:spec --test-options='-p "/properties/&&/generated decl AST pretty-printer round-trip/" --quickcheck-replay="(SMGen 9279819758741723949 8751027274297275769,88)" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='-p "/parser/&&/parenthesizes transform-list-comp group-by infix RHS before using/" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='-p "/properties/&&/properties.type paren insertion is minimal/" --quickcheck-replay="(SMGen 9051391809336705882 418800532916807023,35)" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='-p "/parser/&&/rejects bare implicit parameter type arguments in contexts/" --hide-successes'`
- `just fmt`
- `just check`

## Review

- `coderabbit review --prompt-only` could not be run locally because the `coderabbit` command is not installed in this environment
