### PR TITLE
fix(parser): stabilize 10k coverage roundtrips

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1770,7 +1770,7 @@ addViewExprParensWith :: Bool -> Expr -> Expr
 addViewExprParensWith allowLayoutTypeSig expr =
   if viewExprNeedsParens expr
     then wrapExpr True (addExprParens expr)
-    else addExprParens expr
+    else addViewExprInnerParens expr
   where
     viewExprNeedsParens e =
       isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
@@ -1782,6 +1782,19 @@ addViewExprParensWith allowLayoutTypeSig expr =
       case peelExprAnn e of
         ETypeSyntax {} -> True
         _ -> False
+
+    addViewExprInnerParens e =
+      case peelExprAnn e of
+        EIf cond yes no ->
+          EIf
+            (addExprParens cond)
+            (addViewExprIfBranchParens yes)
+            (addViewExprIfBranchParens no)
+        _ -> addExprParens e
+
+    addViewExprIfBranchParens branch =
+      let branch' = addExprParens branch
+       in wrapExpr (trailingTypeSigNeedsParens typeHasFunctionArrow branch') branch'
 
     isBareViewExprBlock e =
       case peelExprAnn e of

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1270,11 +1270,25 @@ addCaseAltPatternParens pat = addPatternParens pat
 
 addLambdaCaseAltParens :: LambdaCaseAlt -> LambdaCaseAlt
 addLambdaCaseAltParens (LambdaCaseAlt sp pats rhs) =
-  let pats' = case pats of
-        [] -> []
-        [_] -> map addFunctionHeadPatternAtomParens pats
-        _ -> map addPatternAtomParens pats
+  let pats' =
+        case pats of
+          [] -> []
+          [_] -> map addLambdaCasePatternAtomParens pats
+          _ -> map addPatternAtomParens pats
    in LambdaCaseAlt sp pats' (addCaseAltRhsParens rhs)
+
+addLambdaCasePatternAtomParens :: Pattern -> Pattern
+addLambdaCasePatternAtomParens pat =
+  case peelPatternAnn pat of
+    PView viewExpr inner
+      | isInfixViewExpr viewExpr ->
+          wrapPat True (PView (wrapExpr True (addExprParens viewExpr)) (addPatternViewInnerParens inner))
+    _ -> addFunctionHeadPatternAtomParens pat
+  where
+    isInfixViewExpr expr =
+      case peelExprAnn expr of
+        EInfix {} -> True
+        _ -> False
 
 addCaseAltRhsParens :: Rhs Expr -> Rhs Expr
 addCaseAltRhsParens rhs =
@@ -1424,13 +1438,13 @@ addTypeTopLevelParens :: Type -> Type
 addTypeTopLevelParens (TAnn ann sub) = TAnn ann (addTypeTopLevelParens sub)
 addTypeTopLevelParens (TImplicitParam name inner) =
   TImplicitParam name (addImplicitParamBodyParens inner)
-addTypeTopLevelParens (TKindSig ty kind) = TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addTypeTopLevelParens kind)
+addTypeTopLevelParens (TKindSig ty kind) = TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxKindSig 0 kind)
 addTypeTopLevelParens (TForall telescope inner) =
   TForall
     (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
     (addTypeTopLevelParens inner)
 addTypeTopLevelParens (TContext constraints inner) =
-  TContext (map addContextConstraintDelimitedParens constraints) (addContextBodyParens inner)
+  TContext (map addContextConstraintDelimitedParens constraints) (addPlainContextBodyParens inner)
 addTypeTopLevelParens (TParen inner) =
   TParen (addTypeTopLevelParens inner)
 addTypeTopLevelParens ty = addSignatureTypeParens ty
@@ -1483,11 +1497,14 @@ addSignatureTypeParensShared ctx prec ty =
         -- through roundtrips. The pretty-printer relies on the TParen wrapper
         -- to produce the required parentheses.
         TKindSig ty' kind ->
-          wrapTy True (TKindSig (atom 0 ty') (atom 0 kind))
+          wrapTy (kindSigNeedsOuterParens ctx) (TKindSig (atom 0 ty') (addSignatureTypeParensShared CtxKindSig 0 kind))
         TContext constraints inner ->
-          wrapTy (prec > 0) (TContext (addContextConstraints constraints) (atom 0 inner))
+          wrapTy (prec > 0) (TContext (addContextConstraints constraints) (addSignatureContextBodyParens inner))
         TSplice body -> TSplice (addSpliceBodyParens body)
         TWildcard {} -> ty
+  where
+    kindSigNeedsOuterParens CtxKindSig = False
+    kindSigNeedsOuterParens _ = True
 
 addArrowKindParens :: ArrowKind -> ArrowKind
 addArrowKindParens ArrowUnrestricted = ArrowUnrestricted
@@ -1498,12 +1515,10 @@ addTyVarBinderParens :: TyVarBinder -> TyVarBinder
 addTyVarBinderParens tvb =
   tvb {tyVarBinderKind = fmap addSignatureTypeParens (tyVarBinderKind tvb)}
 
--- | Process the body of a TForall. The forall body is parsed by
--- 'contextOrFunTypeParser' (not 'typeParser'), so a bare nested TForall
--- would fail to parse and must be wrapped in TParen.
+-- | Process the body of a TForall in signature-style positions.
+-- Bare outer kind signatures still need wrapping there.
 addForallBodyParens :: Type -> Type
 addForallBodyParens (TAnn ann sub) = TAnn ann (addForallBodyParens sub)
-addForallBodyParens ty@(TForall {}) = addSignatureTypeParensShared CtxTypeAtom 0 ty
 addForallBodyParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
 
 -- | Process the body of a TImplicitParam.
@@ -1513,25 +1528,31 @@ addImplicitParamBodyParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
 
 -- | Process the body to the right of a constraint arrow in a top-level type
 -- RHS. A kind signature is already delimited there in cases like
--- @type X = C => T :: K@, but TH splices still need grouping because
--- @type X = C => $x :: K@ is rejected at the @::@ by GHC.
-addContextBodyParens :: Type -> Type
-addContextBodyParens (TAnn ann sub) = TAnn ann (addContextBodyParens sub)
-addContextBodyParens ty =
+-- @type X = C => T :: K@, including TH splices such as @type X = C => $x :: K@,
+-- so no extra wrapper is needed around the outer kind signature itself.
+addPlainContextBodyParens :: Type -> Type
+addPlainContextBodyParens (TAnn ann sub) = TAnn ann (addPlainContextBodyParens sub)
+addPlainContextBodyParens ty =
+  case ty of
+    TKindSig ty' kind ->
+      TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxKindSig 0 kind)
+    TForall telescope inner ->
+      TForall
+        (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
+        (addTypeTopLevelParens inner)
+    TContext constraints inner ->
+      TContext (addContextConstraints constraints) (addPlainContextBodyParens inner)
+    _ -> addSignatureTypeParensShared CtxTypeAtom 0 ty
+
+addSignatureContextBodyParens :: Type -> Type
+addSignatureContextBodyParens (TAnn ann sub) = TAnn ann (addSignatureContextBodyParens sub)
+addSignatureContextBodyParens ty =
   case ty of
     TKindSig ty' kind ->
       wrapTy
-        (startsWithTypeSplice ty')
-        (TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxTypeAtom 0 kind))
+        True
+        (TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxKindSig 0 kind))
     _ -> addSignatureTypeParensShared CtxTypeAtom 0 ty
-
-startsWithTypeSplice :: Type -> Bool
-startsWithTypeSplice (TAnn _ sub) = startsWithTypeSplice sub
-startsWithTypeSplice (TParen _) = False
-startsWithTypeSplice TSplice {} = True
-startsWithTypeSplice (TApp f _) = startsWithTypeSplice f
-startsWithTypeSplice (TTypeApp f _) = startsWithTypeSplice f
-startsWithTypeSplice _ = False
 
 -- | Process a type inside explicit delimiters (TParen, TTuple, etc.).
 -- TKindSig does not need wrapping here because the enclosing delimiter
@@ -1544,7 +1565,7 @@ addTypeDelimitedParens (TAnn ann sub) = TAnn ann (addTypeDelimitedParens sub)
 addTypeDelimitedParens (TImplicitParam name inner) =
   TImplicitParam name (addImplicitParamBodyParens inner)
 addTypeDelimitedParens (TKindSig ty kind) =
-  TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxTypeAtom 0 kind)
+  TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxKindSig 0 kind)
 addTypeDelimitedParens (TForall telescope inner) =
   TForall
     (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
@@ -1572,7 +1593,7 @@ addTypeDelimitedParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
 addTypeInExplicitParenParens :: Type -> Type
 addTypeInExplicitParenParens (TAnn ann sub) = TAnn ann (addTypeInExplicitParenParens sub)
 addTypeInExplicitParenParens (TKindSig ty kind) =
-  TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxTypeAtom 0 kind)
+  TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty) (addSignatureTypeParensShared CtxKindSig 0 kind)
 addTypeInExplicitParenParens ty = addSignatureTypeParensShared CtxTypeAtom 0 ty
 
 addContextConstraintDelimitedParens :: Type -> Type
@@ -1609,13 +1630,21 @@ addContextConstraintMulti ty =
   case ty of
     TAnn ann sub ->
       TAnn ann (addContextConstraintMulti sub)
+    TImplicitParam name inner ->
+      TImplicitParam name (addImplicitParamBodyParens inner)
+    TInfix lhs op promoted rhs ->
+      TInfix (addTypeIn CtxTypeAppFun lhs) op promoted (addContextConstraintDelimitedParens rhs)
+    TApp f x ->
+      TApp (addTypeIn CtxTypeAppFun f) (addContextConstraintDelimitedParens x)
+    TTypeApp f x ->
+      TTypeApp (addTypeIn CtxTypeAppFun f) (addTypeIn CtxTypeDelimitedAppVisibleArg x)
     TKindSig ty' kind ->
       -- In multi-constraint context, TKindSig doesn't need wrapping
-      TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxTypeAtom 0 kind)
+      TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxKindSig 0 kind)
     TParen inner@(TKindSig {}) ->
       -- Strip TParen around TKindSig in multi-constraint context
       addContextConstraintMulti inner
-    _ -> addSignatureTypeParens ty
+    _ -> addTypeDelimitedParens ty
 
 -- ---------------------------------------------------------------------------
 -- Patterns

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -9,7 +9,6 @@ import Aihc.Parser
   ( ParseResult (..),
     ParserConfig (..),
     defaultConfig,
-    formatParseErrorBundle,
     formatParseErrors,
     parseDecl,
     parseExpr,
@@ -19,7 +18,7 @@ import Aihc.Parser
     parseType,
   )
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
-import Aihc.Parser.Parens (addExprParens, addSignatureTypeParens, addTypeParens)
+import Aihc.Parser.Parens (addDeclParens, addExprParens, addSignatureTypeParens, addTypeParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
@@ -275,6 +274,7 @@ buildTests = do
             testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
             testCase "parenthesizes multi-way if view expressions ending with type signatures in decls" test_viewExprMultiWayIfTypeSigParens,
+            testCase "parenthesizes if view expressions ending with type signatures in decls" test_viewExprIfTypeSigParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
             testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
@@ -1465,6 +1465,23 @@ test_viewExprMultiWayIfTypeSigParens = do
         """
   assertParsedStrippedDeclShapeRoundTrip config source
 
+test_viewExprIfTypeSigParens :: Assertion
+test_viewExprIfTypeSigParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      decl =
+        DeclValue
+          ( PatternBind
+              NoMultiplicityTag
+              (PParen (PView (EIf (EList []) (EList []) (ETypeSig (EList []) (TFun ArrowUnrestricted TWildcard TWildcard))) PWildcard))
+              (UnguardedRhs [] (EList []) Nothing)
+          )
+      rendered = renderPretty decl
+  case parseDecl config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed if view expression with typed else branch" (stripAnnotations (addDeclParens decl)) (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for if view expression with typed else branch\n" <> formatParseErrors "<test>" Nothing bundle)
+
 test_viewExprArrowCommandTypeSigRhsParens :: Assertion
 test_viewExprArrowCommandTypeSigRhsParens = do
   let config = defaultConfig {parserExtensions = [Arrows, MagicHash, QuasiQuotes, ViewPatterns]}
@@ -1611,7 +1628,7 @@ test_signatureTypeParensWrapsForallKindSignatures = do
     ParseOk reparsed ->
       assertEqual "reparsed signature forall kind signature" ty (stripAnnotations (stripParens reparsed))
     ParseErr bundle ->
-      assertFailure ("expected parse success for signature forall kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for signature forall kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_typeParensKeepsNestedKindSignaturesBare :: Assertion
 test_typeParensKeepsNestedKindSignaturesBare =
@@ -1632,7 +1649,7 @@ test_typeParensKeepsForallKindSignaturesBare = do
     ParseOk reparsed ->
       assertEqual "reparsed constrained forall kind signature" ty (stripAnnotations reparsed)
     ParseErr bundle ->
-      assertFailure ("expected parse success for constrained forall kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for constrained forall kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_typeParensKeepsSpliceKindSignaturesBare :: Assertion
 test_typeParensKeepsSpliceKindSignaturesBare = do
@@ -1644,7 +1661,7 @@ test_typeParensKeepsSpliceKindSignaturesBare = do
     ParseOk reparsed ->
       assertEqual "reparsed constrained splice kind signature" ty (stripAnnotations reparsed)
     ParseErr bundle ->
-      assertFailure ("expected parse success for constrained splice kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+      assertFailure ("expected parse success for constrained splice kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
 test_signatureTypeParensKeepsNestedKindSignaturesBare :: Assertion
 test_signatureTypeParensKeepsNestedKindSignaturesBare =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -7,7 +7,7 @@ module Main (main) where
 import Aihc.Cpp (resultOutput)
 import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
-import Aihc.Parser.Parens (addExprParens)
+import Aihc.Parser.Parens (addExprParens, addSignatureTypeParens, addTypeParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
@@ -265,6 +265,7 @@ buildTests = do
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
             testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
+            testCase "parenthesizes infix view expressions inside lambda-cases" test_lambdaCasesViewExprInfixParens,
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "parenthesizes negated typed view expressions" test_viewExprNegatedTypeSigParens,
             testCase "pretty-prints typed view expressions without invalid layout" test_typedViewExprPrettyLayout,
@@ -276,6 +277,11 @@ buildTests = do
             testCase "rejects bare kind signatures in signature implicit parameter bodies" test_signatureTypeParserRejectsImplicitParamBareKindSignature,
             testCase "rejects bare kind signatures in value signatures" test_declParserRejectsBareKindSignature,
             testCase "parses bare kind signatures as types" test_typeParserParsesBareKindSignature,
+            testCase "parenthesizes forall kind signatures as signature types" test_signatureTypeParensWrapsForallKindSignatures,
+            testCase "keeps nested kind signatures bare in type contexts" test_typeParensKeepsNestedKindSignaturesBare,
+            testCase "keeps forall kind signatures bare in type contexts" test_typeParensKeepsForallKindSignaturesBare,
+            testCase "keeps splice kind signatures bare in type contexts" test_typeParensKeepsSpliceKindSignaturesBare,
+            testCase "keeps nested kind signatures bare in signature tuples" test_signatureTypeParensKeepsNestedKindSignaturesBare,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -1456,6 +1462,19 @@ test_viewExprArrowCommandTypeSigRhsParens = do
         """
   assertParsedStrippedPatternShapeRoundTrip config source
 
+test_lambdaCasesViewExprInfixParens :: Assertion
+test_lambdaCasesViewExprInfixParens = do
+  let config = defaultConfig {parserExtensions = [LambdaCase, ViewPatterns]}
+      source =
+        """
+        _ = \\cases
+              (([]
+              `a` [])
+               -> _) ->
+                []
+        """
+  assertParsedStrippedDeclShapeRoundTrip config source
+
 test_viewExprNegatedTypeSigParens :: Assertion
 test_viewExprNegatedTypeSigParens = do
   let config = defaultConfig {parserExtensions = requiredExtensions}
@@ -1559,6 +1578,60 @@ test_typeParserParsesBareKindSignature = do
       assertEqual "type kind signature" (TKindSig TWildcard TWildcard) (stripAnnotations ty)
     ParseErr bundle ->
       assertFailure ("expected parse success for type kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_signatureTypeParensWrapsForallKindSignatures :: Assertion
+test_signatureTypeParensWrapsForallKindSignatures = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      ty = TForall (ForallTelescope ForallInvisible [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible]) (TKindSig TWildcard TWildcard)
+      rendered = renderPretty (addSignatureTypeParens ty)
+  assertEqual "signature forall kind signature rendering" "forall a. (_ :: _)" rendered
+  case parseSignatureType config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed signature forall kind signature" ty (stripAnnotations (stripParens reparsed))
+    ParseErr bundle ->
+      assertFailure ("expected parse success for signature forall kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_typeParensKeepsNestedKindSignaturesBare :: Assertion
+test_typeParensKeepsNestedKindSignaturesBare =
+  assertEqual
+    "nested kind signatures in contexts should not gain extra parens"
+    (TContext [TWildcard] (TContext [TWildcard] (TKindSig TWildcard TWildcard)))
+    ( addTypeParens
+        (TContext [TWildcard] (TContext [TWildcard] (TKindSig TWildcard TWildcard)))
+    )
+
+test_typeParensKeepsForallKindSignaturesBare :: Assertion
+test_typeParensKeepsForallKindSignaturesBare = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      ty = TContext [TWildcard] (TForall (ForallTelescope ForallInvisible [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible]) (TKindSig TWildcard TWildcard))
+      rendered = renderPretty (addTypeParens ty)
+  assertEqual "constrained forall kind signature rendering" "_ => forall a. _ :: _" rendered
+  case parseType config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed constrained forall kind signature" ty (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for constrained forall kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_typeParensKeepsSpliceKindSignaturesBare :: Assertion
+test_typeParensKeepsSpliceKindSignaturesBare = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      ty = TContext [TWildcard] (TKindSig (TSplice (EVar (qualifyName Nothing (mkUnqualifiedName NameVarId "a")))) TWildcard)
+      rendered = renderPretty (addTypeParens ty)
+  assertEqual "constrained splice kind signature rendering" "_ => $a :: _" rendered
+  case parseType config rendered of
+    ParseOk reparsed ->
+      assertEqual "reparsed constrained splice kind signature" ty (stripAnnotations reparsed)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for constrained splice kind signature\n" <> formatParseErrorBundle "<test>" Nothing bundle)
+
+test_signatureTypeParensKeepsNestedKindSignaturesBare :: Assertion
+test_signatureTypeParensKeepsNestedKindSignaturesBare =
+  assertEqual
+    "nested kind signatures in tuple elements should not gain extra parens"
+    (TTuple Boxed Unpromoted [TWildcard, TKindSig TWildcard (TKindSig TWildcard TWildcard)])
+    ( addSignatureTypeParens
+        (TTuple Boxed Unpromoted [TWildcard, TKindSig TWildcard (TKindSig TWildcard TWildcard)])
+    )
 
 test_shrunkDoExpressionsKeepFinalExpression :: Assertion
 test_shrunkDoExpressionsKeepFinalExpression = do

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -6,6 +6,18 @@ module Main (main) where
 
 import Aihc.Cpp (resultOutput)
 import Aihc.Parser
+  ( ParseResult (..),
+    ParserConfig (..),
+    defaultConfig,
+    formatParseErrorBundle,
+    formatParseErrors,
+    parseDecl,
+    parseExpr,
+    parseModule,
+    parsePattern,
+    parseSignatureType,
+    parseType,
+  )
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
 import Aihc.Parser.Parens (addExprParens, addSignatureTypeParens, addTypeParens)
 import Aihc.Parser.Pretty ()

--- a/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Decl.hs
@@ -860,7 +860,13 @@ genFamilyTypeApp = do
   pure (foldl TApp f args)
 
 genFamilyTypeAtom :: Gen Type
-genFamilyTypeAtom = genSimpleTypeWithoutFun
+genFamilyTypeAtom = suchThat genSimpleTypeWithoutFun isValidFamilyTypeAtom
+
+isValidFamilyTypeAtom :: Type -> Bool
+isValidFamilyTypeAtom ty =
+  case ty of
+    TWildcard -> False
+    _ -> True
 
 genFamilyLhsArg :: Gen Type
 genFamilyLhsArg = suchThat (scale (min 4) genType) (not . isStarType)
@@ -877,12 +883,69 @@ genDeclPragma = do
 genDeclPatSyn :: Gen Decl
 genDeclPatSyn = do
   synName <- genConUnqualifiedName
-  argName <- genVarId
-  conName <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConId
-  let args = PatSynPrefixArgs [argName]
-      pat = PCon conName [] [PVar (mkUnqualifiedName NameVarId argName)]
-  dir <- elements [PatSynBidirectional, PatSynUnidirectional]
+  args <- genPatSynArgs
+  pat <- genPatSynPattern args
+  dir <- genPatSynDir synName args pat
   pure $ DeclPatSyn (PatSynDecl synName args pat dir)
+
+genPatSynArgs :: Gen PatSynArgs
+genPatSynArgs =
+  oneof
+    [ PatSynPrefixArgs <$> smallList1 genVarId,
+      PatSynInfixArgs <$> genVarId <*> genVarId,
+      PatSynRecordArgs <$> smallList1 genVarId
+    ]
+
+genPatSynPattern :: PatSynArgs -> Gen Pattern
+genPatSynPattern args = do
+  conName <- qualifyName Nothing . mkUnqualifiedName NameConId <$> genConId
+  pure $ case args of
+    PatSynPrefixArgs names ->
+      PCon conName [] [PVar (mkUnqualifiedName NameVarId name) | name <- names]
+    PatSynInfixArgs lhs rhs ->
+      PInfix (PVar (mkUnqualifiedName NameVarId lhs)) conName (PVar (mkUnqualifiedName NameVarId rhs))
+    PatSynRecordArgs fields ->
+      PRecord
+        conName
+        [ RecordField
+            (qualifyName Nothing (mkUnqualifiedName NameVarId field))
+            (PVar (mkUnqualifiedName NameVarId field))
+            False
+        | field <- fields
+        ]
+        False
+
+genPatSynDir :: UnqualifiedName -> PatSynArgs -> Pattern -> Gen PatSynDir
+genPatSynDir synName args pat =
+  frequency
+    [ (2, elements [PatSynBidirectional, PatSynUnidirectional]),
+      (1, PatSynExplicitBidirectional <$> genPatSynMatches synName args pat)
+    ]
+
+genPatSynMatches :: UnqualifiedName -> PatSynArgs -> Pattern -> Gen [Match]
+genPatSynMatches _synName args _pat = do
+  rhs <- genRhs
+  pure
+    [ Match
+        { matchAnns = [],
+          matchHeadForm = patSynMatchHeadForm args,
+          matchPats = patSynMatchPats args,
+          matchRhs = rhs
+        }
+    ]
+
+patSynMatchHeadForm :: PatSynArgs -> MatchHeadForm
+patSynMatchHeadForm args =
+  case args of
+    PatSynInfixArgs {} -> MatchHeadInfix
+    _ -> MatchHeadPrefix
+
+patSynMatchPats :: PatSynArgs -> [Pattern]
+patSynMatchPats args =
+  case args of
+    PatSynPrefixArgs names -> [PVar (mkUnqualifiedName NameVarId name) | name <- names]
+    PatSynInfixArgs lhs rhs -> [PVar (mkUnqualifiedName NameVarId lhs), PVar (mkUnqualifiedName NameVarId rhs)]
+    PatSynRecordArgs fields -> [PVar (mkUnqualifiedName NameVarId field) | field <- fields]
 
 genDeclPatSynSig :: Gen Decl
 genDeclPatSynSig = DeclPatSynSig <$> smallList1 genConUnqualifiedName <*> genType
@@ -905,12 +968,26 @@ genDerivingClauses = smallList0 genDerivingClause
 genDerivingClause :: Gen DerivingClause
 genDerivingClause = do
   strategy <- optional genDerivingStrategy
-  classes <- oneof [Left <$> genSimpleConName, Right <$> smallList0 genType]
+  classes <- oneof [Left <$> genSimpleConName, Right <$> smallList0 genDerivingClauseType]
   pure $
     DerivingClause
       { derivingStrategy = strategy,
         derivingClasses = classes
       }
+
+genDerivingClauseType :: Gen Type
+genDerivingClauseType = suchThat genType isValidDerivingClauseType
+
+isValidDerivingClauseType :: Type -> Bool
+isValidDerivingClauseType ty =
+  case ty of
+    TStar {} -> False
+    TWildcard -> False
+    TForall {} -> False
+    TContext {} -> False
+    TImplicitParam {} -> False
+    TAnn _ inner -> isValidDerivingClauseType inner
+    _ -> True
 
 genDerivingStrategy :: Gen DerivingStrategy
 genDerivingStrategy =
@@ -1297,13 +1374,20 @@ shrinkTypeFamilyInst tfi =
 shrinkTypeFamilyInstLhs :: TypeHeadForm -> Type -> [Type]
 shrinkTypeFamilyInstLhs headForm lhs =
   case headForm of
-    TypeHeadPrefix -> shrinkType lhs
+    TypeHeadPrefix -> shrinkPrefixTypeFamilyInstLhs lhs
     TypeHeadInfix ->
       case lhs of
         TApp (TApp op lhsArg) rhsArg ->
           [TApp (TApp op lhsArg') rhsArg | lhsArg' <- shrinkType lhsArg]
             <> [TApp (TApp op lhsArg) rhsArg' | rhsArg' <- shrinkType rhsArg]
         _ -> []
+
+shrinkPrefixTypeFamilyInstLhs :: Type -> [Type]
+shrinkPrefixTypeFamilyInstLhs lhs =
+  case lhs of
+    TApp familyCon arg ->
+      [TApp familyCon arg' | arg' <- shrinkType arg]
+    _ -> []
 
 shrinkDataFamilyInst :: DataFamilyInst -> [DataFamilyInst]
 shrinkDataFamilyInst dfi =

--- a/components/aihc-parser/test/Test/Properties/Arb/Module.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Module.hs
@@ -22,12 +22,13 @@ instance Arbitrary Module where
     n <- chooseInt (0, 6)
     imports <- genImportDecls
     mHead <- genMaybeModuleHead
+    languagePragmas <- genModuleLanguagePragmas
     decls <- vectorOf n arbitrary
     pure $
       Module
         { moduleAnns = [],
           moduleHead = mHead,
-          moduleLanguagePragmas = [],
+          moduleLanguagePragmas = languagePragmas,
           moduleImports = imports,
           moduleDecls = decls
         }
@@ -43,9 +44,26 @@ instance Arbitrary Module where
       <> [ modu {moduleImports = shrunk}
          | shrunk <- shrinkList shrinkImportDecl (moduleImports modu)
          ]
+      <> [ modu {moduleLanguagePragmas = shrunk}
+         | shrunk <- shrinkList shrink (moduleLanguagePragmas modu)
+         ]
       <> [ modu {moduleHead = shrunk}
          | shrunk <- shrinkMaybeModuleHead (moduleHead modu)
          ]
+
+genModuleLanguagePragmas :: Gen [ExtensionSetting]
+genModuleLanguagePragmas = do
+  n <- chooseInt (0, 3)
+  vectorOf n arbitrary
+
+instance Arbitrary ExtensionSetting where
+  arbitrary = EnableExtension <$> elements coverageSafeExtensions
+
+  shrink _ = []
+
+coverageSafeExtensions :: [Extension]
+coverageSafeExtensions =
+  filter (`notElem` [AlternativeLayoutRule, LexicalNegation, NegativeLiterals, OverloadedRecordUpdate]) allKnownExtensions
 
 -- | Generate an optional module head.
 -- Most modules have explicit headers, but implicit modules (Nothing) are also valid.
@@ -232,8 +250,11 @@ instance Arbitrary ImportItem where
         [ImportItemAbs namespace name | not (null members)]
           <> [ImportItemWith namespace shrunk members | shrunk <- shrinkTypeName name]
           <> [ImportItemWith namespace name shrunk | shrunk <- shrinkList shrink members, not (null shrunk)]
-      ImportItemAllWith namespace name _wildcardIndex members ->
+      ImportItemAllWith namespace name wildcardIndex members ->
         [ImportItemWith namespace name members]
+          <> [ImportItemAllWith namespace shrunk wildcardIndex members | shrunk <- shrinkTypeName name]
+          <> [ImportItemAllWith namespace name shrunkIndex members | shrunkIndex <- shrinkWildcardIndex wildcardIndex members]
+          <> [ImportItemAllWith namespace name (min wildcardIndex (length shrunk)) shrunk | shrunk <- shrinkList shrink members, not (null shrunk)]
 
 instance Arbitrary IEBundledMember where
   arbitrary = do
@@ -295,6 +316,7 @@ instance Arbitrary ImportDecl where
   arbitrary = do
     modName <- genModuleName
     spec <- genMaybeImportSpec
+    asName <- genMaybeImportAs
     pure $
       ImportDecl
         { importDeclAnns = [],
@@ -305,7 +327,7 @@ instance Arbitrary ImportDecl where
           importDeclQualified = False,
           importDeclQualifiedPost = False,
           importDeclModule = modName,
-          importDeclAs = Nothing,
+          importDeclAs = asName,
           importDeclSpec = spec
         }
 
@@ -316,6 +338,9 @@ instance Arbitrary ImportDecl where
       <> [ decl {importDeclSpec = shrunk}
          | shrunk <- shrinkMaybeImportSpec (importDeclSpec decl)
          ]
+      <> [ decl {importDeclAs = shrunk}
+         | shrunk <- shrinkMaybeImportAs (importDeclAs decl)
+         ]
 
 genImportDecls :: Gen [ImportDecl]
 genImportDecls = do
@@ -324,6 +349,13 @@ genImportDecls = do
 
 shrinkImportDecl :: ImportDecl -> [ImportDecl]
 shrinkImportDecl = shrink
+
+genMaybeImportAs :: Gen (Maybe Text)
+genMaybeImportAs = frequency [(3, pure Nothing), (2, Just <$> genModuleName)]
+
+shrinkMaybeImportAs :: Maybe Text -> [Maybe Text]
+shrinkMaybeImportAs Nothing = []
+shrinkMaybeImportAs (Just alias) = Nothing : [Just shrunk | shrunk <- shrinkModuleName alias]
 
 genModuleName :: Gen Text
 genModuleName = do

--- a/components/aihc-parser/test/Test/Properties/Arb/Type.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Type.hs
@@ -334,11 +334,11 @@ shrinkType ty =
           <> [TForall telescope inner' | inner' <- shrinkType inner]
       TApp fn arg ->
         [fn, arg]
-          <> [TApp fn' arg | fn' <- shrinkType fn]
+          <> [TApp fn' arg | fn' <- shrinkType fn, isValidTypeAppFunction fn']
           <> [TApp fn arg' | arg' <- shrinkType arg]
       TTypeApp fn arg ->
         [fn, arg]
-          <> [TTypeApp fn' arg | fn' <- shrinkType fn]
+          <> [TTypeApp fn' arg | fn' <- shrinkType fn, isValidTypeAppFunction fn']
           <> [TTypeApp fn arg' | arg' <- shrinkType arg]
       TFun arrowKind lhs rhs ->
         [lhs, rhs]
@@ -371,6 +371,21 @@ shrinkType ty =
       TWildcard ->
         []
       TAnn _ sub -> shrinkType sub
+
+isValidTypeAppFunction :: Type -> Bool
+isValidTypeAppFunction ty =
+  case ty of
+    TAnn _ sub -> isValidTypeAppFunction sub
+    TVar {} -> True
+    TCon {} -> True
+    TBuiltinCon {} -> True
+    TApp fn _ -> isValidTypeAppFunction fn
+    TTypeApp fn _ -> isValidTypeAppFunction fn
+    TInfix {} -> True
+    TParen inner -> isValidTypeAppFunction inner
+    TKindSig inner _ -> isValidTypeAppFunction inner
+    TSplice {} -> True
+    _ -> False
 
 shrinkTyVarBinders :: [TyVarBinder] -> [[TyVarBinder]]
 shrinkTyVarBinders binders =

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -78,7 +78,7 @@
   enableCoverageWithExport = hsLib: drv:
     hsLib.overrideCabal drv (old: {
       configureFlags = (old.configureFlags or []) ++ ["--enable-coverage"];
-      testFlags = (old.testFlags or []) ++ ["--hide-successes"];
+      testFlags = (old.testFlags or []) ++ ["--hide-successes" "--quickcheck-tests=10000"];
       preCheck =
         (old.preCheck or "")
         + ''


### PR DESCRIPTION
## Summary

- stabilize `aihc-parser` 10k QuickCheck coverage runs by tightening generators and shrinkers for property-safe module and type shapes
- fix parser paren insertion for constrained kind signatures and lambda-case view-pattern infix expressions, with focused regressions
- move the 10k QuickCheck override into the Nix coverage path so normal test runs stay unchanged

## Validation

- `just fmt`
- `just check`
- `nix build .#coverage`

## Progress

- `aihc-parser` expression coverage: `89%`
- coverage build now completes successfully and writes `result/aihc-parser-html/hpc_index.html`