### PR TITLE
fix(parser): parenthesize typed record-field view expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1688,7 +1688,7 @@ addPatternParens pat =
     PNegLit lit -> PNegLit lit
     PParen inner -> PParen (addPatternInDelimited inner)
     PRecord con fields hasWildcard ->
-      PRecord con [field {recordFieldValue = addPatternInDelimited (recordFieldValue field)} | field <- fields] hasWildcard
+      PRecord con [field {recordFieldValue = addPatternInRecordField (recordFieldValue field)} | field <- fields] hasWildcard
     PTypeSig inner ty -> PTypeSig (addPatternInfixOperandParens inner) (addSignatureTypeParens ty)
     PSplice body -> PSplice (addSpliceBodyParens body)
 
@@ -1711,6 +1711,9 @@ addPatternInDelimitedWith allowLayoutTypeSig pat =
 
 addPatternInUnboxedSum :: Int -> Pattern -> Pattern
 addPatternInUnboxedSum altIdx = addPatternInDelimitedWith (altIdx > 0)
+
+addPatternInRecordField :: Pattern -> Pattern
+addPatternInRecordField = addPatternInDelimitedWith False
 
 -- | Template Haskell pattern quotes accept typed patterns only when they are
 -- parenthesized: @[p| (a :: T) |]@ parses, but @[p| a :: T |]@ does not.

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1750,7 +1750,7 @@ addViewExprParensWith allowLayoutTypeSig expr =
       isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
 
     viewExprTypeSigCanStayBare e =
-      allowLayoutTypeSig && isBareViewExprBlock e
+      allowLayoutTypeSig && isBareViewExprBlock e && not (classicIfTypeSigNeedsParens e)
 
     isTypeSyntaxExpr e =
       case peelExprAnn e of
@@ -1764,6 +1764,16 @@ addViewExprParensWith allowLayoutTypeSig expr =
         EMultiWayIf {} -> True
         ELambdaCase {} -> True
         ELambdaCases {} -> True
+        _ -> False
+
+    classicIfTypeSigNeedsParens e =
+      case peelExprAnn e of
+        EIf _ _ no -> elseBranchHasDirectTypeSig no
+        _ -> False
+
+    elseBranchHasDirectTypeSig branch =
+      case peelExprAnn branch of
+        ETypeSig {} -> True
         _ -> False
 
 addPatternAtomParens :: Pattern -> Pattern

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -269,6 +269,7 @@ buildTests = do
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "parenthesizes negated typed view expressions" test_viewExprNegatedTypeSigParens,
             testCase "pretty-prints typed view expressions without invalid layout" test_typedViewExprPrettyLayout,
+            testCase "parenthesizes typed record-field view expressions with layout blocks" test_recordFieldViewExprTypeSigParens,
             testCase "rejects bare kind signatures as signature types" test_signatureTypeParserRejectsBareKindSignature,
             testCase "parses parenthesized kind signatures as signature types" test_signatureTypeParserParsesParenthesizedKindSignature,
             testCase "parses delimited kind signatures as signature types" test_signatureTypeParserParsesDelimitedKindSignature,
@@ -1490,9 +1491,22 @@ test_typedViewExprPrettyLayout = do
     ((if | let _ = []
             ->
              []
-       :: _)
-     -> _)
+      :: _)
+    -> _)
     """
+
+test_recordFieldViewExprTypeSigParens :: Assertion
+test_recordFieldViewExprTypeSigParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      source =
+        """
+        _ = []
+            where
+              _ `a` (:+) {a = ((if [] then [] else []
+                               :: _)
+                              -> _)} = []
+        """
+  assertParsedStrippedDeclShapeRoundTrip config source
 
 test_signatureTypeParserRejectsBareKindSignature :: Assertion
 test_signatureTypeParserRejectsBareKindSignature = do

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -269,6 +269,7 @@ buildTests = do
             testCase "parenthesizes typed arrow-command RHS inside view expressions" test_viewExprArrowCommandTypeSigRhsParens,
             testCase "parenthesizes negated typed view expressions" test_viewExprNegatedTypeSigParens,
             testCase "pretty-prints typed view expressions without invalid layout" test_typedViewExprPrettyLayout,
+            testCase "parenthesizes typed classic-if tuple view expressions" test_tupleClassicIfViewExprTypeSigParens,
             testCase "parenthesizes typed record-field view expressions with layout blocks" test_recordFieldViewExprTypeSigParens,
             testCase "rejects bare kind signatures as signature types" test_signatureTypeParserRejectsBareKindSignature,
             testCase "parses parenthesized kind signatures as signature types" test_signatureTypeParserParsesParenthesizedKindSignature,
@@ -1488,11 +1489,22 @@ test_typedViewExprPrettyLayout = do
   assertParsedStrippedPatternShapeRoundTrip
     config
     """
-    ((if | let _ = []
-            ->
-             []
+     ((if | let _ = []
+             ->
+              []
       :: _)
     -> _)
+    """
+
+test_tupleClassicIfViewExprTypeSigParens :: Assertion
+test_tupleClassicIfViewExprTypeSigParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  assertParsedStrippedPatternShapeRoundTrip
+    config
+    """
+    (_, ((if [] then [] else []
+          :: _)
+         -> _))
     """
 
 test_recordFieldViewExprTypeSigParens :: Assertion


### PR DESCRIPTION
## Summary

- parenthesize classic `if` view expressions in delimited pattern contexts when the `else` branch is directly type-signed
- keep the existing bare-layout exception for other typed block view expressions, including the oracle-covered multi-way-if cases
- add focused regressions for tuple and record-field patterns around the shrunk QuickCheck failures

## Root Cause

- delimited pattern contexts intentionally allow some block expressions with trailing type signatures to stay bare inside view patterns
- that exception was too broad for classic `if ... then ... else ...` when the `else` branch itself carried the trailing type signature
- pretty-printing emitted `if ... then ... else [] :: _ -> _`, which parses as a typed `if` expression followed by an orphaned arrow instead of a view pattern
- the same underlying shape surfaced in both a tuple-element pattern and a record-field pattern

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern \"typed classic-if tuple view expressions\" --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern \"typed record-field view expressions with layout blocks\" --hide-successes"`
- `just replay "(SMGen 10284119303838573767 6713069793505343875,90)"`
- `just replay "(SMGen 660516189521374698 15036392352789198529,89)"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern \"view-pattern-multiway-if-type-signature\" --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern \"view-pattern-list-multiway-if-type-signature\" --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern \"view-pattern-if-multiway-if-type-signature\" --hide-successes"`
- `just fmt`
- `just check`

## Review

- `coderabbit review --prompt-only` could not be run locally because the `coderabbit` command is not installed in this environment
