### PR TITLE
feat(aihc-dev): report snippet check statuses

### DIFF
--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat.hs
@@ -1,12 +1,31 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Aihc.Parser.Compat
   ( toGhcHsDecl,
     toGhcHsExpr,
+    toGhcHsModuleDecls,
+    dumpGhcAst,
+    renderGhcAst,
+    sameGhcAst,
   )
 where
 
 import Aihc.Parser.Compat.Internal.Convert qualified as Convert
-import Aihc.Parser.Syntax (Decl, Expr)
-import GHC.Hs (GhcPs)
+import Aihc.Parser.Compat.Internal.Ghc (normalizeGhcAst)
+import Aihc.Parser.Syntax (Decl, Expr, Module, moduleDecls)
+import Data.ByteString (ByteString)
+import Data.Data (Data (..), cast, gmapQ, showConstr, toConstr)
+import Data.List (isPrefixOf)
+import Data.Proxy (Proxy (..))
+import Data.Text (Text)
+import GHC.Data.FastString (FastString)
+import GHC.Hs (GhcPs, HsLocalBindsLR (..), HsValBindsLR (..), LHsCmd, LHsExpr, StmtLR (..))
+import GHC.Types.Name.Reader (RdrName, rdrNameOcc)
+import GHC.Utils.Outputable (Outputable, ppr, showSDocUnsafe)
+import Language.Haskell.Syntax.Basic (FieldLabelString)
 import Language.Haskell.Syntax.Decls (HsDecl)
 import Language.Haskell.Syntax.Expr (HsExpr)
 
@@ -23,3 +42,196 @@ toGhcHsDecl = Convert.toGhcHsDecl
 -- values.
 toGhcHsExpr :: Expr -> HsExpr GhcPs
 toGhcHsExpr = Convert.toGhcHsExpr
+
+-- | Convert every declaration in an aihc-parser module into ghc-lib-parser AST
+-- declarations.
+--
+-- Module headers and imports are intentionally outside the current
+-- compatibility conversion surface.
+toGhcHsModuleDecls :: Module -> [HsDecl GhcPs]
+toGhcHsModuleDecls = map toGhcHsDecl . moduleDecls
+
+-- | Compare GHC AST values after normalizing locations and exact-print
+-- annotations.
+sameGhcAst :: (Data a, Data b) => a -> b -> Bool
+sameGhcAst left right =
+  structuralEq (normalizeGhcAst left) (normalizeGhcAst right)
+
+data SomeData = forall a. (Data a) => SomeData a
+
+structuralEq :: (Data a, Data b) => a -> b -> Bool
+structuralEq left right =
+  primitiveEq left right
+    || emptyLocalBindsEq left right
+    || stmtEq left right
+    || (isIgnoredAnnotationPayload left && isIgnoredAnnotationPayload right)
+    || ( sameCon
+           && case (conName, leftChildren, rightChildren) of
+             ("L", [_, leftPayload], [_, rightPayload]) -> structuralEqSome leftPayload rightPayload
+             _ -> length leftChildren == length rightChildren && and (zipWith structuralEqSome leftChildren rightChildren)
+       )
+  where
+    conName = showConstr (toConstr left)
+    sameCon = conName == showConstr (toConstr right)
+    leftChildren = gmapQ SomeData left
+    rightChildren = gmapQ SomeData right
+
+structuralEqSome :: SomeData -> SomeData -> Bool
+structuralEqSome (SomeData left) (SomeData right) =
+  structuralEq left right
+
+emptyLocalBindsEq :: (Data a, Data b) => a -> b -> Bool
+emptyLocalBindsEq left right =
+  case (cast left, cast right) of
+    (Just (left' :: HsLocalBindsLR GhcPs GhcPs), Just (right' :: HsLocalBindsLR GhcPs GhcPs)) ->
+      emptyLocalBindsLike left' && emptyLocalBindsLike right'
+    _ -> False
+
+stmtEq :: (Data a, Data b) => a -> b -> Bool
+stmtEq left right =
+  exprStmtEq || cmdStmtEq
+  where
+    exprStmtEq =
+      case (cast left, cast right) of
+        (Just (left' :: StmtLR GhcPs GhcPs (LHsExpr GhcPs)), Just (right' :: StmtLR GhcPs GhcPs (LHsExpr GhcPs))) ->
+          eqStmtBodies structuralEq left' right'
+        _ -> False
+    cmdStmtEq =
+      case (cast left, cast right) of
+        (Just (left' :: StmtLR GhcPs GhcPs (LHsCmd GhcPs)), Just (right' :: StmtLR GhcPs GhcPs (LHsCmd GhcPs))) ->
+          eqStmtBodies structuralEq left' right'
+        _ -> False
+
+eqStmtBodies :: (body -> body -> Bool) -> StmtLR GhcPs GhcPs body -> StmtLR GhcPs GhcPs body -> Bool
+eqStmtBodies eqBody left right =
+  case (left, right) of
+    (LastStmt _ bodyA _ _, LastStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    (LastStmt _ bodyA _ _, BodyStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    (BodyStmt _ bodyA _ _, LastStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    (BodyStmt _ bodyA _ _, BodyStmt _ bodyB _ _) -> eqBody bodyA bodyB
+    _ -> False
+
+emptyLocalBindsLike :: HsLocalBindsLR GhcPs GhcPs -> Bool
+emptyLocalBindsLike binds =
+  case binds of
+    EmptyLocalBinds _ -> True
+    HsValBinds _ (ValBinds _ [] []) -> True
+    _ -> False
+
+isIgnoredAnnotationPayload :: (Data a) => a -> Bool
+isIgnoredAnnotationPayload value =
+  case (showConstr (toConstr value), gmapQ SomeData value) of
+    (name, _) | isIgnoredAnnotationCon name -> True
+    ("Nothing", []) -> True
+    ("Just", [payload]) -> isIgnoredAnnotationSome payload
+    ("[]", []) -> True
+    (":", [headPayload, tailPayload]) -> isIgnoredAnnotationSome headPayload && isIgnoredAnnotationSome tailPayload
+    ("(,)", payloads) -> all isIgnoredAnnotationSome payloads
+    _ -> False
+
+isIgnoredAnnotationCon :: String -> Bool
+isIgnoredAnnotationCon name =
+  any (`isPrefixOf` name) ["Ann", "Ep", "Epa", "NameAnn", "NoEp"]
+    || name
+      `elem` [ "Anchor",
+               "NameSquare",
+               "NameParens",
+               "NameBackquotes",
+               "NoComments",
+               "NormalSyntax",
+               "UnicodeSyntax",
+               "NoSourceText",
+               "SourceText"
+             ]
+
+isIgnoredAnnotationSome :: SomeData -> Bool
+isIgnoredAnnotationSome (SomeData value) =
+  isIgnoredAnnotationPayload value
+
+primitiveEq :: (Data a, Data b) => a -> b -> Bool
+primitiveEq left right =
+  primRdrName
+    || prim (Proxy @Bool)
+    || prim (Proxy @Char)
+    || prim (Proxy @Int)
+    || prim (Proxy @Integer)
+    || prim (Proxy @Rational)
+    || prim (Proxy @String)
+    || prim (Proxy @Text)
+    || prim (Proxy @ByteString)
+    || prim (Proxy @FastString)
+    || prim (Proxy @FieldLabelString)
+  where
+    primRdrName =
+      case (cast left, cast right) of
+        (Just (left' :: RdrName), Just (right' :: RdrName)) -> rdrNameOcc left' == rdrNameOcc right'
+        _ -> False
+
+    prim :: forall c. (Eq c, Data c) => Proxy c -> Bool
+    prim _ =
+      case (cast left, cast right) of
+        (Just (left' :: c), Just (right' :: c)) -> left' == right'
+        _ -> False
+
+-- | Render a normalized comparison tree for diagnostics.
+dumpGhcAst :: (Data a) => a -> String
+dumpGhcAst = unlines . dumpLines 0 . normalizeGhcAst
+
+dumpLines :: (Data a) => Int -> a -> [String]
+dumpLines depth value =
+  let conName = showConstr (toConstr value)
+      children = gmapQ SomeData value
+   in if isIgnoredDumpPayload value
+        then []
+        else case (primitiveValue value, conName, children) of
+          (Just leaf, _, _) -> [indent depth <> leaf]
+          (_, "L", [_, payload]) -> dumpSome depth payload
+          _ ->
+            let childLines = concatMap (dumpSome (depth + 1)) children
+             in if null childLines
+                  then [indent depth <> conName]
+                  else (indent depth <> conName) : childLines
+
+dumpSome :: Int -> SomeData -> [String]
+dumpSome depth (SomeData value) =
+  dumpLines depth value
+
+isIgnoredDumpPayload :: (Data a) => a -> Bool
+isIgnoredDumpPayload value =
+  isIgnoredAnnotationPayload value
+    || showConstr (toConstr value)
+      `elem` [ "NoExtField",
+               "NoExtCon",
+               "NoAnnSortKey"
+             ]
+
+primitiveValue :: (Data a) => a -> Maybe String
+primitiveValue value =
+  prim (Proxy @Bool)
+    <> prim (Proxy @Char)
+    <> prim (Proxy @Int)
+    <> prim (Proxy @Integer)
+    <> prim (Proxy @Rational)
+    <> prim (Proxy @String)
+    <> prim (Proxy @Text)
+    <> prim (Proxy @ByteString)
+    <> prim (Proxy @FastString)
+    <> primRdrName
+  where
+    primRdrName =
+      case cast value of
+        Just (value' :: RdrName) -> Just (renderGhcAst (rdrNameOcc value'))
+        Nothing -> Nothing
+
+    prim :: forall c. (Show c, Data c) => Proxy c -> Maybe String
+    prim _ =
+      case cast value of
+        Just (value' :: c) -> Just (show value')
+        Nothing -> Nothing
+
+indent :: Int -> String
+indent depth = replicate (depth * 2) ' '
+
+-- | Render a GHC AST value with GHC's pretty-printer.
+renderGhcAst :: (Outputable a) => a -> String
+renderGhcAst = showSDocUnsafe . ppr

--- a/components/aihc-parser/common/GhcOracle.hs
+++ b/components/aihc-parser/common/GhcOracle.hs
@@ -4,6 +4,7 @@
 module GhcOracle
   ( oracleModuleAstFingerprint,
     oracleModuleAstFingerprintNoCPP,
+    parseWithGhcWithExtensions,
     toGhcExtension,
     fromGhcExtension,
   )

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1560,6 +1560,8 @@ addContextBodyParens ty =
       wrapTy
         (startsWithTypeSplice ty')
         (TKindSig (addSignatureTypeParensShared CtxTypeAtom 0 ty') (addSignatureTypeParensShared CtxTypeAtom 0 kind))
+    TContext constraints inner ->
+      TContext (map addContextConstraintDelimitedParens constraints) (addContextBodyParens inner)
     _ -> addSignatureTypeParensShared CtxTypeAtom 0 ty
 
 startsWithTypeSplice :: Type -> Bool

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -7,7 +7,7 @@ module Main (main) where
 import Aihc.Cpp (resultOutput)
 import Aihc.Parser
 import Aihc.Parser.Lex (LexToken (..), LexTokenKind (..), lexTokens, lexTokensFromChunks, lexTokensWithExtensions)
-import Aihc.Parser.Parens (addExprParens)
+import Aihc.Parser.Parens (addExprParens, addTypeParens)
 import Aihc.Parser.Pretty ()
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
@@ -280,6 +280,7 @@ buildTests = do
             testCase "rejects bare implicit parameter type arguments in contexts" test_typeParserRejectsBareImplicitParamContextAppArg,
             testCase "rejects bare kind signatures in value signatures" test_declParserRejectsBareKindSignature,
             testCase "parses bare kind signatures as types" test_typeParserParsesBareKindSignature,
+            testCase "keeps nested context kind signatures minimal" test_typeParensNestedContextKindSignatureIsMinimal,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -1595,6 +1596,11 @@ test_typeParserParsesBareKindSignature = do
       assertEqual "type kind signature" (TKindSig TWildcard TWildcard) (stripAnnotations ty)
     ParseErr bundle ->
       assertFailure ("expected parse success for type kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
+
+test_typeParensNestedContextKindSignatureIsMinimal :: Assertion
+test_typeParensNestedContextKindSignatureIsMinimal = do
+  let ty = TContext [TWildcard] (TContext [TWildcard] (TKindSig TWildcard TWildcard))
+  assertEqual "nested context body" ty (addTypeParens ty)
 
 test_shrunkDoExpressionsKeepFinalExpression :: Assertion
 test_shrunkDoExpressionsKeepFinalExpression = do

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -10,6 +10,13 @@
       supportsDocs = true;
       supportsCoverage = true;
     };
+    aihc-parser-compat = {
+      src = sources.parserCompatSrc;
+      disableProfiling = true;
+      optimizeForChecks = true;
+      supportsDocs = false;
+      supportsCoverage = false;
+    };
     aihc-cpp = {
       src = sources.cppSrc;
       disableProfiling = false;

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -21,6 +21,11 @@ in rec {
     ".json"
   ];
 
+  parserCompatSrc = mkComponentSrc "/components/aihc-parser-compat" [
+    ".hs"
+    ".cabal"
+  ];
+
   cppSrc = mkComponentSrc "/components/aihc-cpp" [
     ".hs"
     ".cabal"

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -46,6 +46,7 @@ library snippet
     aihc-hackage,
     aihc-parser,
     aihc-parser:parser-tooling-common,
+    aihc-parser-compat,
     base >=4.16 && <5,
     bytestring >=0.10.8 && <0.13,
     deepseq,

--- a/tooling/aihc-dev/src/Aihc/Dev/Snippet.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Snippet.hs
@@ -3,12 +3,15 @@
 module Aihc.Dev.Snippet
   ( SnippetOpts (..),
     SnippetReport (..),
+    ReportLine (..),
+    ReportTone (..),
     ParseComparison (..),
     parseExtensionSettingArg,
     runSnippet,
     analyzeSnippet,
     buildSnippetReport,
     renderSnippetReport,
+    renderSnippetReportColored,
   )
 where
 
@@ -39,6 +42,7 @@ import ParserValidation (ValidationError (..), formatDiff, validateParser)
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import System.Exit (exitFailure)
+import System.IO (hIsTerminalDevice, stdout)
 
 data SnippetOpts = SnippetOpts
   { snippetExtensions :: [ExtensionSetting],
@@ -52,8 +56,19 @@ data ParseComparison
   | BothAccept
   deriving (Eq, Show)
 
+data ReportTone
+  = ReportBug
+  | ReportNonBug
+  deriving (Eq, Show)
+
+data ReportLine = ReportLine
+  { reportLineTone :: ReportTone,
+    reportLineText :: String
+  }
+  deriving (Eq, Show)
+
 data SnippetReport = SnippetReport
-  { reportStatusLines :: [String],
+  { reportStatusLines :: [ReportLine],
     reportHasFailure :: Bool
   }
   deriving (Eq, Show)
@@ -63,7 +78,8 @@ runSnippet opts = do
   let sourceTag = fromMaybe "<stdin>" (snippetFile opts)
   source <- maybe TIO.getContents TIO.readFile (snippetFile opts)
   let report = analyzeSnippet sourceTag (snippetExtensions opts) source
-  putStr (renderSnippetReport report)
+  useColor <- hIsTerminalDevice stdout
+  putStr (renderSnippetReportColored useColor report)
   Control.Monad.when (reportHasFailure report) exitFailure
 
 parseExtensionSettingArg :: String -> Either String ExtensionSetting
@@ -87,22 +103,44 @@ analyzeSnippet sourceTag cliExtensions source =
         case comparison of
           BothAccept -> fmap validationErrorMessage (validateParser sourceTag edition extensionSettings source')
           _ -> Nothing
-      parensDiff = parserModule >>= parsedSnippetParensDiff source
+      parensDiff =
+        case comparison of
+          BothAccept -> parserModule >>= parsedSnippetParensDiff source
+          _ -> Nothing
    in buildSnippetReport comparison validationFailure parensDiff
 
 buildSnippetReport :: ParseComparison -> Maybe String -> Maybe String -> SnippetReport
 buildSnippetReport comparison validationFailure parensDiff =
   let statusLines =
         comparisonLines comparison
-          ++ maybe [] pure validationFailure
-          ++ maybe [] pure parensDiff
+          ++ roundtripLines comparison validationFailure
+          ++ parensLines comparison parensDiff
       hasFailure = comparison /= BothAccept || isJust validationFailure || isJust parensDiff
    in SnippetReport statusLines hasFailure
 
 renderSnippetReport :: SnippetReport -> String
-renderSnippetReport report =
-  intercalate "\n" (map (dropWhileEnd (== '\n')) (reportStatusLines report))
+renderSnippetReport = renderSnippetReportColored False
+
+renderSnippetReportColored :: Bool -> SnippetReport -> String
+renderSnippetReportColored useColor report =
+  intercalate "\n" (map (renderReportLine useColor) (reportStatusLines report))
     <> if null (reportStatusLines report) then "" else "\n"
+
+renderReportLine :: Bool -> ReportLine -> String
+renderReportLine useColor line =
+  let text = dropWhileEnd (== '\n') (reportLineText line)
+   in if useColor
+        then colorForTone (reportLineTone line) <> text <> ansiReset
+        else text
+
+colorForTone :: ReportTone -> String
+colorForTone tone =
+  case tone of
+    ReportBug -> "\ESC[31m"
+    ReportNonBug -> "\ESC[32m"
+
+ansiReset :: String
+ansiReset = "\ESC[0m"
 
 compareParseResults :: Bool -> Maybe Module -> ParseComparison
 compareParseResults ghcAccepts parserModule =
@@ -112,16 +150,47 @@ compareParseResults ghcAccepts parserModule =
     (True, Nothing) -> GhcAcceptsAihcRejects
     (True, Just _) -> BothAccept
 
-comparisonLines :: ParseComparison -> [String]
+comparisonLines :: ParseComparison -> [ReportLine]
 comparisonLines comparison =
   case comparison of
     BothReject ->
-      ["Snippet fails to parse with both GHC and aihc-parser."]
+      [ nonBugLine "GHC Parses: Parse failure",
+        nonBugLine "AIHC Parses: Parse failure (Expected)"
+      ]
     GhcRejectsAihcAccepts ->
-      ["Bug found: code rejected by GHC but parsed by aihc-parser."]
+      [ nonBugLine "GHC Parses: Parse failure",
+        bugLine "AIHC Parses: OK (Bug: GHC/AIHC mismatch)"
+      ]
     GhcAcceptsAihcRejects ->
-      ["Bug found: code rejected by aihc-parser but parsed by GHC."]
-    BothAccept -> []
+      [ nonBugLine "GHC Parses: OK",
+        bugLine "AIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)"
+      ]
+    BothAccept ->
+      [ nonBugLine "GHC Parses: OK",
+        nonBugLine "AIHC Parses: OK"
+      ]
+
+roundtripLines :: ParseComparison -> Maybe String -> [ReportLine]
+roundtripLines comparison validationFailure =
+  case (comparison, validationFailure) of
+    (BothAccept, Nothing) -> []
+    (BothAccept, Just message) -> [bugLine ("Roundtrip: Bug found:\n" <> message)]
+    (_, _) -> []
+
+parensLines :: ParseComparison -> Maybe String -> [ReportLine]
+parensLines comparison parensDiff =
+  case comparison of
+    BothAccept ->
+      case parensDiff of
+        Nothing -> [nonBugLine "Minimal Parentheses: OK"]
+        Just message -> [bugLine ("Minimal Parentheses: " <> message)]
+    _ -> [nonBugLine "Minimal Parentheses: Skipped"]
+
+bugLine :: String -> ReportLine
+bugLine = ReportLine ReportBug
+
+nonBugLine :: String -> ReportLine
+nonBugLine = ReportLine ReportNonBug
 
 parseWithAihc :: FilePath -> LanguageEdition -> [ExtensionSetting] -> Text -> Maybe Module
 parseWithAihc sourceTag edition extensionSettings source =
@@ -146,7 +215,7 @@ parsedSnippetParensDiff source modu =
 
 formatParensDiff :: Text -> Text -> String
 formatParensDiff before after =
-  let header = "Bug found: Parens.addModuleParens changes the parsed snippet."
+  let header = "Bug found:"
    in case formatDiff before after of
         Nothing -> header
         Just diffChunk ->

--- a/tooling/aihc-dev/src/Aihc/Dev/Snippet.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Snippet.hs
@@ -17,6 +17,7 @@ where
 
 import Aihc.Cpp (resultOutput)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
+import Aihc.Parser.Compat (dumpGhcAst, sameGhcAst, toGhcHsModuleDecls)
 import Aihc.Parser.Lex (readModuleHeaderPragmas)
 import Aihc.Parser.Parens (addModuleParens)
 import Aihc.Parser.Syntax
@@ -33,11 +34,14 @@ import Aihc.Parser.Syntax
 import Control.Monad
 import CppSupport (preprocessForParserWithoutIncludesIfEnabled)
 import Data.List (dropWhileEnd, intercalate)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
-import GhcOracle (oracleModuleAstFingerprint)
+import GHC.Hs (GhcPs, HsModule (..))
+import GHC.Types.SrcLoc (unLoc)
+import GhcOracle (parseWithGhcWithExtensions, toGhcExtension)
+import Language.Haskell.Syntax.Decls (HsDecl)
 import ParserValidation (ValidationError (..), formatDiff, validateParser)
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
@@ -96,9 +100,13 @@ analyzeSnippet sourceTag cliExtensions source =
       defaultEdition = fromMaybe Haskell2010Edition (editionFromExtensionSettings cliExtensions)
       edition = fromMaybe defaultEdition (headerLanguageEdition headerPragmas)
       extensionSettings = cliExtensions ++ headerExtensionSettings headerPragmas
-      ghcAccepts = either (const False) (const True) (oracleModuleAstFingerprint sourceTag edition extensionSettings source)
+      ghcModule = parseWithGhc sourceTag edition extensionSettings source'
       parserModule = parseWithAihc sourceTag edition extensionSettings source'
-      comparison = compareParseResults ghcAccepts parserModule
+      comparison = compareParseResults (either (const False) (const True) ghcModule) parserModule
+      ghcAstFailure =
+        case (comparison, ghcModule, parserModule) of
+          (BothAccept, Right ghcModule', Just parserModule') -> compareSnippetGhcAst parserModule' ghcModule'
+          _ -> Nothing
       validationFailure =
         case comparison of
           BothAccept -> fmap validationErrorMessage (validateParser sourceTag edition extensionSettings source')
@@ -107,15 +115,16 @@ analyzeSnippet sourceTag cliExtensions source =
         case comparison of
           BothAccept -> parserModule >>= parsedSnippetParensDiff source
           _ -> Nothing
-   in buildSnippetReport comparison validationFailure parensDiff
+   in buildSnippetReport comparison ghcAstFailure validationFailure parensDiff
 
-buildSnippetReport :: ParseComparison -> Maybe String -> Maybe String -> SnippetReport
-buildSnippetReport comparison validationFailure parensDiff =
+buildSnippetReport :: ParseComparison -> Maybe String -> Maybe String -> Maybe String -> SnippetReport
+buildSnippetReport comparison ghcAstFailure validationFailure parensDiff =
   let statusLines =
         comparisonLines comparison
+          ++ ghcAstLines comparison ghcAstFailure
           ++ roundtripLines comparison validationFailure
           ++ parensLines comparison parensDiff
-      hasFailure = comparison /= BothAccept || isJust validationFailure || isJust parensDiff
+      hasFailure = comparison /= BothAccept || isJust ghcAstFailure || isJust validationFailure || isJust parensDiff
    in SnippetReport statusLines hasFailure
 
 renderSnippetReport :: SnippetReport -> String
@@ -177,6 +186,15 @@ roundtripLines comparison validationFailure =
     (BothAccept, Just message) -> [bugLine ("Roundtrip: Bug found:\n" <> message)]
     (_, _) -> []
 
+ghcAstLines :: ParseComparison -> Maybe String -> [ReportLine]
+ghcAstLines comparison ghcAstFailure =
+  case comparison of
+    BothAccept ->
+      case ghcAstFailure of
+        Nothing -> [nonBugLine "GHC AST Match: OK"]
+        Just message -> [bugLine ("GHC AST Match: " <> message)]
+    _ -> [nonBugLine "GHC AST Match: Skipped"]
+
 parensLines :: ParseComparison -> Maybe String -> [ReportLine]
 parensLines comparison parensDiff =
   case comparison of
@@ -192,6 +210,11 @@ bugLine = ReportLine ReportBug
 nonBugLine :: String -> ReportLine
 nonBugLine = ReportLine ReportNonBug
 
+parseWithGhc :: FilePath -> LanguageEdition -> [ExtensionSetting] -> Text -> Either Text (HsModule GhcPs)
+parseWithGhc sourceTag edition extensionSettings source =
+  let ghcExtensions = mapMaybe toGhcExtension (effectiveExtensions edition extensionSettings)
+   in parseWithGhcWithExtensions sourceTag ghcExtensions source
+
 parseWithAihc :: FilePath -> LanguageEdition -> [ExtensionSetting] -> Text -> Maybe Module
 parseWithAihc sourceTag edition extensionSettings source =
   let config =
@@ -203,6 +226,45 @@ parseWithAihc sourceTag edition extensionSettings source =
    in case errs of
         [] -> Just modu
         _ -> Nothing
+
+compareSnippetGhcAst :: Module -> HsModule GhcPs -> Maybe String
+compareSnippetGhcAst parserModule ghcModule =
+  let expectedDecls = map unLoc (hsmodDecls ghcModule)
+      actualDecls = toGhcHsModuleDecls parserModule
+   in compareGhcDecls expectedDecls actualDecls
+
+compareGhcDecls :: [HsDecl GhcPs] -> [HsDecl GhcPs] -> Maybe String
+compareGhcDecls expectedDecls actualDecls
+  | length expectedDecls /= length actualDecls =
+      Just
+        ( intercalate
+            "\n"
+            [ "Bug found:",
+              "Declaration count mismatch: GHC parsed "
+                <> show (length expectedDecls)
+                <> ", AIHC converted "
+                <> show (length actualDecls)
+                <> "."
+            ]
+        )
+  | otherwise = firstMismatch (zip3 [1 :: Int ..] expectedDecls actualDecls)
+  where
+    firstMismatch [] = Nothing
+    firstMismatch ((index, expected, actual) : rest)
+      | sameGhcAst expected actual = firstMismatch rest
+      | otherwise = Just (formatGhcAstMismatch index expected actual)
+
+formatGhcAstMismatch :: Int -> HsDecl GhcPs -> HsDecl GhcPs -> String
+formatGhcAstMismatch index expected actual =
+  intercalate
+    "\n"
+    [ "Bug found:",
+      "Declaration " <> show index <> " differs after converting the AIHC AST to GHC AST.",
+      "GHC parser AST:",
+      dropWhileEnd (== '\n') (dumpGhcAst expected),
+      "Converted AIHC AST:",
+      dropWhileEnd (== '\n') (dumpGhcAst actual)
+    ]
 
 parsedSnippetParensDiff :: Text -> Module -> Maybe String
 parsedSnippetParensDiff source modu =

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -27,38 +27,45 @@ main = do
   cliTestsTree <- cliTests
   defaultMain . testGroup "aihc-dev" $
     [ testCase "reports both parsers rejecting a snippet" $ do
-        let report = buildSnippetReport BothReject Nothing Nothing
+        let report = buildSnippetReport BothReject Nothing Nothing Nothing
         assertEqual
           "message"
-          "GHC Parses: Parse failure\nAIHC Parses: Parse failure (Expected)\nMinimal Parentheses: Skipped\n"
+          "GHC Parses: Parse failure\nAIHC Parses: Parse failure (Expected)\nGHC AST Match: Skipped\nMinimal Parentheses: Skipped\n"
           (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "reports parser mismatch when aihc rejects valid GHC snippet" $ do
-        let report = buildSnippetReport GhcAcceptsAihcRejects Nothing Nothing
+        let report = buildSnippetReport GhcAcceptsAihcRejects Nothing Nothing Nothing
         assertEqual
           "message"
-          "GHC Parses: OK\nAIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)\nMinimal Parentheses: Skipped\n"
+          "GHC Parses: OK\nAIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)\nGHC AST Match: Skipped\nMinimal Parentheses: Skipped\n"
+          (renderSnippetReport report)
+        assertBool "failure" (reportHasFailure report),
+      testCase "includes GHC AST conversion mismatch" $ do
+        let report = buildSnippetReport BothAccept (Just "Bug found:\nDeclaration 1 differs") Nothing Nothing
+        assertEqual
+          "message"
+          "GHC Parses: OK\nAIHC Parses: OK\nGHC AST Match: Bug found:\nDeclaration 1 differs\nMinimal Parentheses: OK\n"
           (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "includes roundtrip failures" $ do
-        let report = buildSnippetReport BothAccept (Just "Roundtrip mismatch") Nothing
+        let report = buildSnippetReport BothAccept Nothing (Just "Roundtrip mismatch") Nothing
         assertEqual
           "message"
-          "GHC Parses: OK\nAIHC Parses: OK\nRoundtrip: Bug found:\nRoundtrip mismatch\nMinimal Parentheses: OK\n"
+          "GHC Parses: OK\nAIHC Parses: OK\nGHC AST Match: OK\nRoundtrip: Bug found:\nRoundtrip mismatch\nMinimal Parentheses: OK\n"
           (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "includes parens diff" $ do
-        let report = buildSnippetReport BothAccept Nothing (Just "Bug found:\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n")
+        let report = buildSnippetReport BothAccept Nothing Nothing (Just "Bug found:\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n")
         assertEqual
           "message"
-          "GHC Parses: OK\nAIHC Parses: OK\nMinimal Parentheses: Bug found:\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n"
+          "GHC Parses: OK\nAIHC Parses: OK\nGHC AST Match: OK\nMinimal Parentheses: Bug found:\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n"
           (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "colors status lines when requested" $ do
-        let report = buildSnippetReport GhcAcceptsAihcRejects Nothing Nothing
+        let report = buildSnippetReport GhcAcceptsAihcRejects Nothing Nothing Nothing
         assertEqual
           "message"
-          "\ESC[32mGHC Parses: OK\ESC[0m\n\ESC[31mAIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)\ESC[0m\n\ESC[32mMinimal Parentheses: Skipped\ESC[0m\n"
+          "\ESC[32mGHC Parses: OK\ESC[0m\n\ESC[31mAIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)\ESC[0m\n\ESC[32mGHC AST Match: Skipped\ESC[0m\n\ESC[32mMinimal Parentheses: Skipped\ESC[0m\n"
           (renderSnippetReportColored True report),
       testCase "parses -X extension arguments" $ do
         assertEqual "extension" (Right (EnableExtension TypeApplications)) (parseExtensionSettingArg "TypeApplications"),

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -8,6 +8,7 @@ import Aihc.Dev.Snippet
     buildSnippetReport,
     parseExtensionSettingArg,
     renderSnippetReport,
+    renderSnippetReportColored,
   )
 import Aihc.Parser.Syntax (Extension (TypeApplications), ExtensionSetting (..))
 import Test.ExtractHiCompare (extractHiCompareTests)
@@ -27,20 +28,38 @@ main = do
   defaultMain . testGroup "aihc-dev" $
     [ testCase "reports both parsers rejecting a snippet" $ do
         let report = buildSnippetReport BothReject Nothing Nothing
-        assertEqual "message" "Snippet fails to parse with both GHC and aihc-parser.\n" (renderSnippetReport report)
+        assertEqual
+          "message"
+          "GHC Parses: Parse failure\nAIHC Parses: Parse failure (Expected)\nMinimal Parentheses: Skipped\n"
+          (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "reports parser mismatch when aihc rejects valid GHC snippet" $ do
         let report = buildSnippetReport GhcAcceptsAihcRejects Nothing Nothing
-        assertEqual "message" "Bug found: code rejected by aihc-parser but parsed by GHC.\n" (renderSnippetReport report)
+        assertEqual
+          "message"
+          "GHC Parses: OK\nAIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)\nMinimal Parentheses: Skipped\n"
+          (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "includes roundtrip failures" $ do
         let report = buildSnippetReport BothAccept (Just "Roundtrip mismatch") Nothing
-        assertEqual "message" "Roundtrip mismatch\n" (renderSnippetReport report)
+        assertEqual
+          "message"
+          "GHC Parses: OK\nAIHC Parses: OK\nRoundtrip: Bug found:\nRoundtrip mismatch\nMinimal Parentheses: OK\n"
+          (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
       testCase "includes parens diff" $ do
-        let report = buildSnippetReport BothAccept Nothing (Just "Bug found: Parens.addModuleParens changes the parsed snippet.\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n")
-        assertEqual "message" "Bug found: Parens.addModuleParens changes the parsed snippet.\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n" (renderSnippetReport report)
+        let report = buildSnippetReport BothAccept Nothing (Just "Bug found:\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n")
+        assertEqual
+          "message"
+          "GHC Parses: OK\nAIHC Parses: OK\nMinimal Parentheses: Bug found:\nChanged section:\n@@ line 1 @@\n- a\n+ (a)\n"
+          (renderSnippetReport report)
         assertBool "failure" (reportHasFailure report),
+      testCase "colors status lines when requested" $ do
+        let report = buildSnippetReport GhcAcceptsAihcRejects Nothing Nothing
+        assertEqual
+          "message"
+          "\ESC[32mGHC Parses: OK\ESC[0m\n\ESC[31mAIHC Parses: Parse failure (Bug: GHC/AIHC mismatch)\ESC[0m\n\ESC[32mMinimal Parentheses: Skipped\ESC[0m\n"
+          (renderSnippetReportColored True report),
       testCase "parses -X extension arguments" $ do
         assertEqual "extension" (Right (EnableExtension TypeApplications)) (parseExtensionSettingArg "TypeApplications"),
       QC.testProperty "dummy quickcheck property" prop_dummy,


### PR DESCRIPTION
## Summary
- print explicit GHC, AIHC, GHC AST compatibility, and minimal-parentheses status lines from `aihc-dev snippet`
- color bug statuses red and non-bug statuses green when stdout is a TTY
- run the GHC AST compatibility check only after both GHC and AIHC parse successfully
- fix a nested context kind-signature minimal-parens regression found during `just check`
- wire `aihc-parser-compat` into the Nix Haskell package set for `aihc-dev`

## Progress counts
- No parser progress-count README changes.

## Validation
- `cabal test -v0 aihc-parser-compat:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-dev:spec --test-options="--hide-successes"`
- direct `aihc-dev snippet` smoke tests for valid and invalid snippets
- `nix eval .#checks.aarch64-darwin.dev-tests.drvPath`
- `nix eval .#checks.aarch64-linux.dev-tests.drvPath` progressed past the original missing `aihc-parser-compat` argument, then stopped locally because this host cannot build Linux derivations
- `cabal test -v0 aihc-parser:spec --test-option=-p --test-option="/properties.type paren insertion is minimal/" --test-option="--quickcheck-replay=(SMGen 3308977147141028364 4091988692405098507,95)" --test-option=--hide-successes`
- `cabal test -v0 aihc-parser:spec --test-option=-p --test-option="/properties.generated module AST pretty-printer round-trip/" --test-option="--quickcheck-replay=(SMGen 5268000609495650324 3847546382480660913,40)" --test-option=--hide-successes`
- `cabal test -v0 aihc-parser:spec --test-option=-p --test-option="/properties.generated module AST validator/" --test-option="--quickcheck-replay=(SMGen 16720880900485738593 17930195457442276063,34)" --test-option=--hide-successes`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` (no findings before PR creation)