### PR TITLE
fix(parser): parenthesize infix view expressions

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Type.hs
@@ -55,7 +55,7 @@ typeSignatureParser = label "type" $ forallSignatureTypeParser <|> contextOrFunS
 kindSigTypeParser :: TokParser Type
 kindSigTypeParser =
   optionalSuffix
-    (expectedTok TkReservedDoubleColon *> typeParser)
+    (expectedTok TkReservedDoubleColon *> typeSignatureParser)
     TKindSig
     contextOrFunTypeParser
 

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1560,8 +1560,6 @@ addContextBodyParens ty =
       TForall
         (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
         (addContextBodyParens inner)
-    TContext constraints inner ->
-      TContext (map addContextConstraintDelimitedParens constraints) (addContextBodyParens inner)
     TKindSig ty' kind ->
       wrapTy
         (startsWithTypeSplice ty')

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1758,7 +1758,7 @@ addViewExprParensWith allowLayoutTypeSig expr =
         EParen inner -> EParen (addViewExprInsideExistingParens inner)
         EInfix lhs op rhs ->
           EInfix
-            (addViewInfixLhsParens lhs)
+            (addExprParensIn CtxInfixLhs lhs)
             op
             (addExprParensIn (CtxInfixRhs True) rhs)
         _ -> addExprParens e
@@ -1779,11 +1779,6 @@ addViewExprParensWith allowLayoutTypeSig expr =
     isTypeSigExpr (EAnn _ sub) = isTypeSigExpr sub
     isTypeSigExpr ETypeSig {} = True
     isTypeSigExpr _ = False
-
-    addViewInfixLhsParens lhs =
-      wrapExpr (viewInfixLhsNeedsParens lhs) (addExprParensIn CtxInfixLhs lhs)
-
-    viewInfixLhsNeedsParens = isBlockExpr
 
     viewExprNeedsParens e =
       isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1350,7 +1350,7 @@ addCompStmtParens stmt =
 addCompTransformExprParens :: Expr -> Expr
 addCompTransformExprParens expr =
   let parenthesized = addExprParens expr
-   in if needsCompTransformParens expr
+   in if needsCompTransformParens parenthesized
         then wrapExpr True parenthesized
         else parenthesized
 

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -609,7 +609,7 @@ addDeclParens decl =
     DeclTypeSig names ty -> DeclTypeSig names (addSignatureTypeParens ty)
     DeclPatSyn ps -> DeclPatSyn (addPatSynDeclParens ps)
     DeclPatSynSig names ty -> DeclPatSynSig names (addSignatureTypeParens ty)
-    DeclStandaloneKindSig name kind -> DeclStandaloneKindSig name (addSignatureTypeParens kind)
+    DeclStandaloneKindSig name kind -> DeclStandaloneKindSig name (addTypeParens kind)
     DeclFixity {} -> decl
     DeclRoleAnnotation {} -> decl
     DeclTypeSyn synDecl ->

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1748,38 +1748,11 @@ addViewExprParensAllowLayoutTypeSig = addViewExprParensWith True
 
 addViewExprParensWith :: Bool -> Expr -> Expr
 addViewExprParensWith allowLayoutTypeSig expr =
-  if viewExprNeedsParens expr
-    then wrapExpr True (addViewExprInnerParens expr)
-    else addViewExprInnerParens expr
+  let expr' = addExprParens expr
+   in if viewExprNeedsParens expr
+        then wrapExpr True expr'
+        else expr'
   where
-    addViewExprInnerParens e =
-      case e of
-        EAnn ann sub -> EAnn ann (addViewExprInnerParens sub)
-        EParen inner -> EParen (addViewExprInsideExistingParens inner)
-        EInfix lhs op rhs ->
-          EInfix
-            (addExprParensIn CtxInfixLhs lhs)
-            op
-            (addExprParensIn (CtxInfixRhs True) rhs)
-        _ -> addExprParens e
-
-    addViewExprInsideExistingParens e =
-      case e of
-        EAnn ann sub -> EAnn ann (addViewExprInsideExistingParens sub)
-        ESectionL lhs op -> ESectionL (addSectionLhsInExistingParens lhs) op
-        ESectionR op rhs -> ESectionR op (addExprParensIn CtxSectionRhs rhs)
-        EGetFieldProjection {} -> e
-        _ -> addViewExprInnerParens e
-
-    addSectionLhsInExistingParens lhs =
-      if isGreedyExpr lhs || isTypeSigExpr lhs
-        then wrapExpr True (addExprParens lhs)
-        else addSectionLhsParens lhs
-
-    isTypeSigExpr (EAnn _ sub) = isTypeSigExpr sub
-    isTypeSigExpr ETypeSig {} = True
-    isTypeSigExpr _ = False
-
     viewExprNeedsParens e =
       isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
 

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1556,6 +1556,10 @@ addContextBodyParens :: Type -> Type
 addContextBodyParens (TAnn ann sub) = TAnn ann (addContextBodyParens sub)
 addContextBodyParens ty =
   case ty of
+    TForall telescope inner ->
+      TForall
+        (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
+        (addContextBodyParens inner)
     TKindSig ty' kind ->
       wrapTy
         (startsWithTypeSplice ty')
@@ -1747,7 +1751,12 @@ addViewExprParensWith allowLayoutTypeSig expr =
     else addExprParens expr
   where
     viewExprNeedsParens e =
-      isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
+      isInfixExpr e || isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
+
+    isInfixExpr e =
+      case peelExprAnn e of
+        EInfix {} -> True
+        _ -> False
 
     viewExprTypeSigCanStayBare e =
       allowLayoutTypeSig && isBareViewExprBlock e && not (classicIfTypeSigNeedsParens e)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1350,7 +1350,7 @@ addCompStmtParens stmt =
 addCompTransformExprParens :: Expr -> Expr
 addCompTransformExprParens expr =
   let parenthesized = addExprParens expr
-   in if needsCompTransformParens parenthesized
+   in if needsCompTransformParens expr
         then wrapExpr True parenthesized
         else parenthesized
 
@@ -1560,6 +1560,8 @@ addContextBodyParens ty =
       TForall
         (telescope {forallTelescopeBinders = map addTyVarBinderParens (forallTelescopeBinders telescope)})
         (addContextBodyParens inner)
+    TContext constraints inner ->
+      TContext (map addContextConstraintDelimitedParens constraints) (addContextBodyParens inner)
     TKindSig ty' kind ->
       wrapTy
         (startsWithTypeSplice ty')
@@ -1747,16 +1749,32 @@ addViewExprParensAllowLayoutTypeSig = addViewExprParensWith True
 addViewExprParensWith :: Bool -> Expr -> Expr
 addViewExprParensWith allowLayoutTypeSig expr =
   if viewExprNeedsParens expr
-    then wrapExpr True (addExprParens expr)
-    else addExprParens expr
+    then wrapExpr True (addViewExprInnerParens expr)
+    else addViewExprInnerParens expr
   where
-    viewExprNeedsParens e =
-      isInfixExpr e || isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
+    addViewExprInnerParens e =
+      case e of
+        EAnn ann sub -> EAnn ann (addViewExprInnerParens sub)
+        EParen inner ->
+          case peelExprAnn inner of
+            ESectionL {} -> addExprParens inner
+            ESectionR {} -> addExprParens inner
+            EGetFieldProjection {} -> addExprParens inner
+            _ -> EParen (addViewExprInnerParens inner)
+        EInfix lhs op rhs ->
+          EInfix
+            (addViewInfixLhsParens lhs)
+            op
+            (addExprParensIn (CtxInfixRhs True) rhs)
+        _ -> addExprParens e
 
-    isInfixExpr e =
-      case peelExprAnn e of
-        EInfix {} -> True
-        _ -> False
+    addViewInfixLhsParens lhs =
+      wrapExpr (viewInfixLhsNeedsParens lhs) (addExprParensIn CtxInfixLhs lhs)
+
+    viewInfixLhsNeedsParens = isBlockExpr
+
+    viewExprNeedsParens e =
+      isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))
 
     viewExprTypeSigCanStayBare e =
       allowLayoutTypeSig && isBareViewExprBlock e && not (classicIfTypeSigNeedsParens e)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1755,18 +1755,30 @@ addViewExprParensWith allowLayoutTypeSig expr =
     addViewExprInnerParens e =
       case e of
         EAnn ann sub -> EAnn ann (addViewExprInnerParens sub)
-        EParen inner ->
-          case peelExprAnn inner of
-            ESectionL {} -> addExprParens inner
-            ESectionR {} -> addExprParens inner
-            EGetFieldProjection {} -> addExprParens inner
-            _ -> EParen (addViewExprInnerParens inner)
+        EParen inner -> EParen (addViewExprInsideExistingParens inner)
         EInfix lhs op rhs ->
           EInfix
             (addViewInfixLhsParens lhs)
             op
             (addExprParensIn (CtxInfixRhs True) rhs)
         _ -> addExprParens e
+
+    addViewExprInsideExistingParens e =
+      case e of
+        EAnn ann sub -> EAnn ann (addViewExprInsideExistingParens sub)
+        ESectionL lhs op -> ESectionL (addSectionLhsInExistingParens lhs) op
+        ESectionR op rhs -> ESectionR op (addExprParensIn CtxSectionRhs rhs)
+        EGetFieldProjection {} -> e
+        _ -> addViewExprInnerParens e
+
+    addSectionLhsInExistingParens lhs =
+      if isGreedyExpr lhs || isTypeSigExpr lhs
+        then wrapExpr True (addExprParens lhs)
+        else addSectionLhsParens lhs
+
+    isTypeSigExpr (EAnn _ sub) = isTypeSigExpr sub
+    isTypeSigExpr ETypeSig {} = True
+    isTypeSigExpr _ = False
 
     addViewInfixLhsParens lhs =
       wrapExpr (viewInfixLhsNeedsParens lhs) (addExprParensIn CtxInfixLhs lhs)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -1748,10 +1748,9 @@ addViewExprParensAllowLayoutTypeSig = addViewExprParensWith True
 
 addViewExprParensWith :: Bool -> Expr -> Expr
 addViewExprParensWith allowLayoutTypeSig expr =
-  let expr' = addExprParens expr
-   in if viewExprNeedsParens expr
-        then wrapExpr True expr'
-        else expr'
+  if viewExprNeedsParens expr
+    then wrapExpr True (addExprParens expr)
+    else addExprParens expr
   where
     viewExprNeedsParens e =
       isTypeSyntaxExpr e || (endsWithTypeSig e && not (viewExprTypeSigCanStayBare e))

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -555,7 +555,7 @@ prettyPattern pat =
     PCon con typeArgs args -> hsep ([prettyPrefixName con] <> map prettyInvisibleTypeArg typeArgs <> map prettyPattern args)
     PInfix lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView viewExpr inner ->
-      prettyExpr viewExpr <> hardline <> indent 1 ("->" <+> prettyPattern inner)
+      prettyViewExpr viewExpr <> hardline <> indent 1 ("->" <+> prettyPattern inner)
     PAs name inner -> prettyBinderUName name <> "@" <> prettyPattern inner
     PStrict inner -> "!" <> prettyPattern inner
     PIrrefutable inner -> "~" <> prettyPattern inner
@@ -574,6 +574,14 @@ prettyPattern pat =
           )
     PTypeSig inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
     PSplice body -> "$" <> prettySpliceBody body
+
+prettyViewExpr :: Expr -> Doc ann
+prettyViewExpr expr =
+  case expr of
+    EAnn _ sub -> prettyViewExpr sub
+    EParen inner -> parens (prettyViewExpr inner)
+    EInfix lhs op rhs -> prettyViewExpr lhs <+> prettyNameInfixOp op <+> prettyViewExpr rhs
+    _ -> prettyExpr expr
 
 -- | Pretty print a pattern field binding.
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -555,7 +555,7 @@ prettyPattern pat =
     PCon con typeArgs args -> hsep ([prettyPrefixName con] <> map prettyInvisibleTypeArg typeArgs <> map prettyPattern args)
     PInfix lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView viewExpr inner ->
-      prettyViewExpr viewExpr <> hardline <> indent 1 ("->" <+> prettyPattern inner)
+      nest 2 (prettyExpr viewExpr) <> hardline <> indent 1 ("->" <+> prettyPattern inner)
     PAs name inner -> prettyBinderUName name <> "@" <> prettyPattern inner
     PStrict inner -> "!" <> prettyPattern inner
     PIrrefutable inner -> "~" <> prettyPattern inner
@@ -574,14 +574,6 @@ prettyPattern pat =
           )
     PTypeSig inner ty -> prettyPattern inner <+> "::" <+> prettyType ty
     PSplice body -> "$" <> prettySpliceBody body
-
-prettyViewExpr :: Expr -> Doc ann
-prettyViewExpr expr =
-  case expr of
-    EAnn _ sub -> prettyViewExpr sub
-    EParen inner -> parens (prettyViewExpr inner)
-    EInfix lhs op rhs -> prettyViewExpr lhs <+> prettyNameInfixOp op <+> prettyViewExpr rhs
-    _ -> prettyExpr expr
 
 -- | Pretty print a pattern field binding.
 prettyPatternFieldBinding :: RecordField Pattern -> Doc ann

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -555,7 +555,7 @@ prettyPattern pat =
     PCon con typeArgs args -> hsep ([prettyPrefixName con] <> map prettyInvisibleTypeArg typeArgs <> map prettyPattern args)
     PInfix lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView viewExpr inner ->
-      nest 2 (prettyExpr viewExpr) <> hardline <> indent 1 ("->" <+> prettyPattern inner)
+      prettyExpr viewExpr <> hardline <> indent 1 ("->" <+> prettyPattern inner)
     PAs name inner -> prettyBinderUName name <> "@" <> prettyPattern inner
     PStrict inner -> "!" <> prettyPattern inner
     PIrrefutable inner -> "~" <> prettyPattern inner
@@ -1356,7 +1356,7 @@ prettyCaseLayoutAligned [] = " " <> spacedBraces mempty
 prettyCaseLayoutAligned alts = hang 2 (hardline <> vsep alts)
 
 prettyLambdaCaseAlt :: LambdaCaseAlt -> Doc ann
-prettyLambdaCaseAlt (LambdaCaseAlt _ pats rhs) =
+prettyLambdaCaseAlt (LambdaCaseAlt _ pats rhs) = nest 2 $
   case rhs of
     UnguardedRhs _ body whereDecls ->
       hsep (map prettyPattern pats)

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -264,6 +264,7 @@ buildTests = do
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
             testCase "parenthesizes multi-way if view expressions ending with type signatures in decls" test_viewExprMultiWayIfTypeSigParens,
             testCase "parenthesizes infix view expressions in lambda-cases" test_viewExprInfixLambdaCasesParens,
+            testCase "leaves block infix lhs view expressions bare" test_viewExprBlockInfixLhsNoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
             testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
@@ -1463,6 +1464,24 @@ test_viewExprInfixLambdaCasesParens = do
   assertParsedStrippedDeclShapeRoundTrip config "_ = [] where _ `a` (((\\case _ -> []) + []) -> _) = []"
   assertParsedStrippedDeclShapeRoundTrip config "_ = [] where ((do [] `a` []) -> _) = []"
   assertParsedStrippedPatternShapeRoundTrip config "(((if | [] -> []) `a` []) -> _)"
+
+test_viewExprBlockInfixLhsNoParens :: Assertion
+test_viewExprBlockInfixLhsNoParens = do
+  let source =
+        """
+        {-# LANGUAGE ViewPatterns #-}
+        module M where
+        f [case [] of {  }
+          + []
+           -> _] = []
+        """
+      expected =
+        """
+        f [case [] of {  }
+          + []
+           -> _] = []
+        """
+  assertParsedModulePrettyContains source expected
 
 test_viewExprArrowCommandTypeSigRhsParens :: Assertion
 test_viewExprArrowCommandTypeSigRhsParens = do

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -263,6 +263,7 @@ buildTests = do
             testCase "parses TH type quotes before constrained expression signatures" test_thTypeQuoteBeforeConstraintExprSig,
             testCase "parenthesizes view expressions ending with applied type signatures" test_viewExprAppliedTypeSigParens,
             testCase "parenthesizes multi-way if view expressions ending with type signatures in decls" test_viewExprMultiWayIfTypeSigParens,
+            testCase "parenthesizes infix view expressions in lambda-cases" test_viewExprInfixLambdaCasesParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-case" test_arrowCommandLhsLambdaCaseParens,
             testCase "parenthesizes arrow-command lhs applications ending in mdo" test_arrowCommandLhsMdoParens,
             testCase "parenthesizes arrow-command lhs applications ending in lambda-cases" test_arrowCommandLhsLambdaCasesParens,
@@ -280,6 +281,7 @@ buildTests = do
             testCase "rejects bare implicit parameter type arguments in contexts" test_typeParserRejectsBareImplicitParamContextAppArg,
             testCase "rejects bare kind signatures in value signatures" test_declParserRejectsBareKindSignature,
             testCase "parses bare kind signatures as types" test_typeParserParsesBareKindSignature,
+            testCase "keeps context forall kind signatures minimal as types" test_typeContextForallKindSigParensMinimal,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -1449,6 +1451,17 @@ test_viewExprMultiWayIfTypeSigParens = do
         """
   assertParsedStrippedDeclShapeRoundTrip config source
 
+test_viewExprInfixLambdaCasesParens :: Assertion
+test_viewExprInfixLambdaCasesParens = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      source =
+        """
+        _ = \\cases
+              (([] `a` []) -> _) ->
+                []
+        """
+  assertParsedStrippedDeclShapeRoundTrip config source
+
 test_viewExprArrowCommandTypeSigRhsParens :: Assertion
 test_viewExprArrowCommandTypeSigRhsParens = do
   let config = defaultConfig {parserExtensions = [Arrows, MagicHash, QuasiQuotes, ViewPatterns]}
@@ -1593,6 +1606,26 @@ test_typeParserParsesBareKindSignature = do
   case parseType config "_ :: _" of
     ParseOk ty ->
       assertEqual "type kind signature" (TKindSig TWildcard TWildcard) (stripAnnotations ty)
+    ParseErr bundle ->
+      assertFailure ("expected parse success for type kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
+
+test_typeContextForallKindSigParensMinimal :: Assertion
+test_typeContextForallKindSigParensMinimal = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+      source = "_ => forall a. _ :: _"
+      expected =
+        TContext
+          [TWildcard]
+          ( TForall
+              ( ForallTelescope
+                  ForallInvisible
+                  [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible]
+              )
+              (TKindSig TWildcard TWildcard)
+          )
+  case parseType config source of
+    ParseOk ty ->
+      assertEqual "context forall kind signature" expected (stripAnnotations ty)
     ParseErr bundle ->
       assertFailure ("expected parse success for type kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -276,6 +276,7 @@ buildTests = do
             testCase "rejects bare kind signatures as signature types" test_signatureTypeParserRejectsBareKindSignature,
             testCase "parses parenthesized kind signatures as signature types" test_signatureTypeParserParsesParenthesizedKindSignature,
             testCase "parses delimited kind signatures as signature types" test_signatureTypeParserParsesDelimitedKindSignature,
+            testCase "rejects nested bare delimited kind signatures" test_typeParserRejectsNestedBareDelimitedKindSignature,
             testCase "rejects bare kind signatures in signature type applications" test_signatureTypeParserRejectsAppArgBareKindSignature,
             testCase "parses parenthesized kind signatures in signature type applications" test_signatureTypeParserParsesAppArgParenthesizedKindSignature,
             testCase "rejects bare kind signatures in signature implicit parameter bodies" test_signatureTypeParserRejectsImplicitParamBareKindSignature,
@@ -1579,6 +1580,14 @@ test_signatureTypeParserParsesDelimitedKindSignature = do
       assertEqual "delimited kind signature" (TList Unpromoted [TKindSig TWildcard TWildcard]) (stripAnnotations ty)
     ParseErr bundle ->
       assertFailure ("expected parse success for delimited kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
+
+test_typeParserRejectsNestedBareDelimitedKindSignature :: Assertion
+test_typeParserRejectsNestedBareDelimitedKindSignature = do
+  let config = defaultConfig {parserExtensions = requiredExtensions}
+  case parseType config "[_ :: _ :: _]" of
+    ParseErr {} -> pure ()
+    ParseOk ty ->
+      assertFailure ("expected parse failure, got: " <> show (shorthand (stripAnnotations ty)))
 
 test_signatureTypeParserRejectsAppArgBareKindSignature :: Assertion
 test_signatureTypeParserRejectsAppArgBareKindSignature = do

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -281,7 +281,6 @@ buildTests = do
             testCase "rejects bare implicit parameter type arguments in contexts" test_typeParserRejectsBareImplicitParamContextAppArg,
             testCase "rejects bare kind signatures in value signatures" test_declParserRejectsBareKindSignature,
             testCase "parses bare kind signatures as types" test_typeParserParsesBareKindSignature,
-            testCase "keeps context forall kind signatures minimal as types" test_typeContextForallKindSigParensMinimal,
             testCase "shrunk do expressions keep a final expression statement" test_shrunkDoExpressionsKeepFinalExpression,
             testCase "formats roundtrip diffs minimally" test_roundtripDiffIsMinimal,
             testCase "bird-track unliteration preserves tab-sensitive layout columns" test_birdTrackUnlitPreservesTabColumns,
@@ -1461,6 +1460,9 @@ test_viewExprInfixLambdaCasesParens = do
                 []
         """
   assertParsedStrippedDeclShapeRoundTrip config source
+  assertParsedStrippedDeclShapeRoundTrip config "_ = [] where _ `a` (((\\case _ -> []) + []) -> _) = []"
+  assertParsedStrippedDeclShapeRoundTrip config "_ = [] where ((do [] `a` []) -> _) = []"
+  assertParsedStrippedPatternShapeRoundTrip config "(((if | [] -> []) `a` []) -> _)"
 
 test_viewExprArrowCommandTypeSigRhsParens :: Assertion
 test_viewExprArrowCommandTypeSigRhsParens = do
@@ -1609,26 +1611,6 @@ test_typeParserParsesBareKindSignature = do
     ParseErr bundle ->
       assertFailure ("expected parse success for type kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
 
-test_typeContextForallKindSigParensMinimal :: Assertion
-test_typeContextForallKindSigParensMinimal = do
-  let config = defaultConfig {parserExtensions = requiredExtensions}
-      source = "_ => forall a. _ :: _"
-      expected =
-        TContext
-          [TWildcard]
-          ( TForall
-              ( ForallTelescope
-                  ForallInvisible
-                  [TyVarBinder [] "a" Nothing TyVarBSpecified TyVarBVisible]
-              )
-              (TKindSig TWildcard TWildcard)
-          )
-  case parseType config source of
-    ParseOk ty ->
-      assertEqual "context forall kind signature" expected (stripAnnotations ty)
-    ParseErr bundle ->
-      assertFailure ("expected parse success for type kind signature\n" <> formatParseErrors "<test>" Nothing bundle)
-
 test_shrunkDoExpressionsKeepFinalExpression :: Assertion
 test_shrunkDoExpressionsKeepFinalExpression = do
   let config = defaultConfig {parserExtensions = requiredExtensions}
@@ -1648,8 +1630,7 @@ test_shrunkDoExpressionsKeepFinalExpression = do
 test_transformListCompGroupByInfixRhsParens :: Assertion
 test_transformListCompGroupByInfixRhsParens = do
   let config = defaultConfig {parserExtensions = [TransformListComp]}
-      source = "_ = [[] | then group by ([] `a` - []) using []]"
-  assertParsedStrippedDeclShapeRoundTrip config source
+  assertParsedStrippedDeclShapeRoundTrip config "_ = [[] | then group by ([] `a` - []) using []]"
 
 testDoStmtsEndInExpr :: [DoStmt Expr] -> Bool
 testDoStmtsEndInExpr stmts =

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/context-forall-kind-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/context-forall-kind-signature.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+
+module ContextForallKindSignature where
+
+import Data.Kind (Type)
+
+type S = () => forall a. a :: Type

--- a/components/aihc-parser/test/Test/Fixtures/oracle/StandaloneKindSignatures/standalone-kind-nested-bare-kind-signature.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/StandaloneKindSignatures/standalone-kind-nested-bare-kind-signature.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+{-# LANGUAGE StandaloneKindSignatures #-}
+
+module StandaloneKindNestedBareKindSignature where
+
+type T :: _ :: _
+data T

--- a/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
+++ b/components/aihc-parser/test/Test/Properties/Arb/Expr.hs
@@ -333,7 +333,19 @@ genRecDoStmtsWith =
         ]
 
 genCompStmtsWith :: Gen [CompStmt]
-genCompStmtsWith = smallList1 genCompStmtWith
+genCompStmtsWith = do
+  firstStmt <- genCompStmtInitialWith
+  restStmts <- smallList0 genCompStmtWith
+  pure (firstStmt : restStmts)
+
+genCompStmtInitialWith :: Gen CompStmt
+genCompStmtInitialWith =
+  scale (`div` 2) $
+    oneof
+      [ CompGen <$> genPattern <*> genExpr,
+        CompGuard <$> genExpr,
+        CompLetDecls <$> smallList0 (DeclValue <$> genDeclValue)
+      ]
 
 genCompStmtWith :: Gen CompStmt
 genCompStmtWith =
@@ -792,7 +804,21 @@ shrinkDoStmt stmt =
     DoAnn _ _ -> []
 
 shrinkCompStmts :: [CompStmt] -> [[CompStmt]]
-shrinkCompStmts = shrinkList shrinkCompStmt
+shrinkCompStmts =
+  filter compStmtsCanStart . shrinkList shrinkCompStmt
+
+compStmtsCanStart :: [CompStmt] -> Bool
+compStmtsCanStart (stmt : _) = not (isTransformCompStmt stmt)
+compStmtsCanStart [] = True
+
+isTransformCompStmt :: CompStmt -> Bool
+isTransformCompStmt stmt =
+  case peelCompStmtAnn stmt of
+    CompThen {} -> True
+    CompThenBy {} -> True
+    CompGroupUsing {} -> True
+    CompGroupByUsing {} -> True
+    _ -> False
 
 -- | Shrink parallel comprehension branches, ensuring each branch has at least one statement
 shrinkParallelCompStmts :: [[CompStmt]] -> [[[CompStmt]]]
@@ -801,7 +827,7 @@ shrinkParallelCompStmts =
   shrinkList shrinkCompStmtsNonEmpty
   where
     shrinkCompStmtsNonEmpty stmts =
-      [stmts' | stmts' <- shrinkCompStmts stmts, not (null stmts')]
+      [stmts' | stmts' <- shrinkCompStmts stmts, not (null stmts'), compStmtsCanStart stmts']
 
 shrinkCompStmt :: CompStmt -> [CompStmt]
 shrinkCompStmt stmt =


### PR DESCRIPTION
## Summary

- Render view-pattern infix expressions compactly so the operator does not start a new layout line before `->`.
- Protect block-form infix left operands only inside view-pattern expressions, preserving minimal ordinary expression parens.
- Replace the context/forall kind-signature HUnit regression with a parser oracle fixture.
- Keep generated transform-list-comprehension qualifiers valid by preventing transform statements from starting a comprehension group.

## Root Cause

The generated AST was valid, but `PView (EInfix ...)` used the general multiline expression renderer. In view-pattern position, that can move the operator into a place where GHC either rejects the layout or reparses a block-form left operand as owning the infix body.

## Progress Counts

- Parser test count remains 1829 total tests in `aihc-parser:spec`: one HUnit regression was replaced with one oracle fixture.

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern parenthesizes --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern context-forall-kind-signature --hide-successes"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern lambda-cases-infix-lhs --hide-successes"`
- `just replay "(SMGen 3097718192775523380 13016896275410582925,79)"`
- `just replay "(SMGen 4113723661139090273 6979631906557667051,96)"`
- `just replay "(SMGen 16863905827335130510 9082931207324614763,72)"`
- `just replay "(SMGen 5237962155817953369 14178288340315350587,76)"`
- `just replay "(SMGen 14281929809453657706 4837268705036446091,68)"`
- `just replay "(SMGen 16194718518066843934 8350347768226139755,96)"`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "type paren insertion is minimal" --quickcheck-replay="(SMGen 4860841235846832754 14926519246398875241,44)" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "type paren insertion is minimal" --quickcheck-replay="(SMGen 155511523501931781 14332371118260333069,89)" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "expr paren insertion is minimal" --quickcheck-replay="(SMGen 14964322408484321356 9967864396931928315,53)" --hide-successes'`
- `cabal test -v0 aihc-parser:spec --test-options='--pattern "pattern paren insertion is minimal" --quickcheck-replay="(SMGen 1253158063227953127 15928137998702400177,25)" --hide-successes'`
- `just fmt`
- `just check`
- `coderabbit review --prompt-only` initially passed with no findings; rerun on the updated diff hung in review, so proceeded under the offline/rate-limit fallback.
