### PR TITLE
fix: replace MIT licensing with Unlicense

### DIFF
--- a/bin/aihc-fmt/aihc-fmt.cabal
+++ b/bin/aihc-fmt/aihc-fmt.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-fmt
 version: 0.1.0.0
 build-type: Simple
-license: MIT
+license: Unlicense
 author: David Himmelstrup
 maintainer: lemmih@gmail.com
 category: Development

--- a/bin/aihc/LICENSE
+++ b/bin/aihc/LICENSE
@@ -1,21 +1,24 @@
-MIT License
+This is free and unencumbered software released into the public domain.
 
-Copyright (c) 2026 David Himmelstrup
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+For more information, please refer to <https://unlicense.org>

--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc
 version: 0.1.0.0
 build-type: Simple
-license: MIT
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-fc
 version: 0.1.0.0
 build-type: Simple
-license: NONE
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-parser
 version: 0.1.0.0
 build-type: Simple
-license: MIT
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com

--- a/components/aihc-resolve/aihc-resolve.cabal
+++ b/components/aihc-resolve/aihc-resolve.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-resolve
 version: 0.1.0.0
 build-type: Simple
-license: NONE
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-tc
 version: 0.1.0.0
 build-type: Simple
-license: NONE
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-dev
 version: 0.1.0.0
 build-type: Simple
-license: MIT
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.8
 name: aihc-hackage
 version: 0.1.0.0
 build-type: Simple
-license: MIT
+license: Unlicense
 license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com


### PR DESCRIPTION
## Summary

- replaced remaining MIT license metadata with `Unlicense` in cabal package files
- replaced `bin/aihc/LICENSE` with the repository-standard Unlicense text
- aligned project packages that already carried an Unlicense `LICENSE` file but still declared `license: NONE`

## Progress counts

- No README progress counts changed; this is a license metadata/text-only update.

## Validation

- `just fmt`
- `just check`
