### PR TITLE
fix(parser): reject bare proc command arrow lhs

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Cmd.hs
@@ -7,7 +7,7 @@ where
 
 import Aihc.Parser.Internal.CheckPattern (checkPattern)
 import Aihc.Parser.Internal.Common
-import {-# SOURCE #-} Aihc.Parser.Internal.Expr (atomExprParser, caseRhsParserWithBodyParser, exprParser, parseLetDeclsParser, parseLetDeclsStmtParser)
+import {-# SOURCE #-} Aihc.Parser.Internal.Expr (atomExprParser, caseRhsParserWithBodyParser, cmdArrAppLhsParser, exprParser, parseLetDeclsParser, parseLetDeclsStmtParser)
 import Aihc.Parser.Internal.Pattern (apatParser, caseAltPatternParser, patternParser)
 import Aihc.Parser.Lex (LexTokenKind (..), lexTokenKind)
 import Aihc.Parser.Syntax
@@ -66,7 +66,7 @@ cmd10Parser = do
 
 cmdArrAppParser :: TokParser Cmd
 cmdArrAppParser = do
-  expr <- exprParser
+  expr <- cmdArrAppLhsParser
   (appType, rhs) <- cmdArrTailParser
   pure (CmdArrApp expr appType rhs)
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs
@@ -4,6 +4,7 @@
 module Aihc.Parser.Internal.Expr
   ( exprParser,
     atomExprParser,
+    cmdArrAppLhsParser,
     lexpParser,
     equationRhsParser,
     caseRhsParserWithBodyParser,
@@ -81,6 +82,26 @@ exprCoreParserWithTypeSigParser typeSigParser = do
     (expectedTok TkReservedDoubleColon *> typeSigParser)
     ETypeSig
     exprCoreParserWithoutTypeSig
+
+-- | Parse the command-arrow LHS nonterminal from GHC's @exp_gen(infixexp)@
+-- grammar:
+--
+-- @
+-- exp : infixexp -< exp
+--     | infixexp -<< exp
+-- @
+--
+-- AIHC parses commands directly rather than through GHC's expression-command
+-- disambiguation, so this context removes the bare @proc@ atom. A parenthesized
+-- @proc@ expression still parses through the ordinary parenthesized atom rule.
+cmdArrAppLhsParser :: TokParser Expr
+cmdArrAppLhsParser =
+  exprInfixChainParser (lexpParserWith CmdArrAppLhsAtom)
+
+data AtomContext
+  = NormalExprAtom
+  | CmdArrAppLhsAtom
+  deriving (Eq)
 
 -- | The operator name used to represent @->@ in view-pattern expressions.
 viewPatArrowName :: Name
@@ -263,15 +284,18 @@ exprInfixChainParser lexp = do
 --
 -- Extensions add more block-like forms at this grammar level.
 lexpParser :: TokParser Expr
-lexpParser = do
+lexpParser = lexpParserWith NormalExprAtom
+
+lexpParserWith :: AtomContext -> TokParser Expr
+lexpParserWith atomContext = do
   mSCC <- optionalHiddenPragma getSCCPragma
   case mSCC of
-    Just sccPragma -> EPragma sccPragma <$> lexpParser
-    Nothing -> lexpBaseParser appExprParser
+    Just sccPragma -> EPragma sccPragma <$> lexpParserWith atomContext
+    Nothing -> lexpBaseParserWith atomContext (appExprParserWith (atomOrRecordExprParserWith atomContext))
 
-lexpBaseParser :: TokParser Expr -> TokParser Expr
-lexpBaseParser appParser =
-  lexpBlockParser
+lexpBaseParserWith :: AtomContext -> TokParser Expr -> TokParser Expr
+lexpBaseParserWith atomContext appParser =
+  lexpBlockParserWith atomContext
     <|> MP.try negateExprParser
     <|> appParser
 
@@ -293,7 +317,10 @@ reportLexpParser appParser =
 --
 -- GHC extensions extend this set with @mdo@, qualified @do@, and @proc@.
 lexpBlockParser :: TokParser Expr
-lexpBlockParser =
+lexpBlockParser = lexpBlockParserWith NormalExprAtom
+
+lexpBlockParserWith :: AtomContext -> TokParser Expr
+lexpBlockParserWith atomContext =
   doExprParser
     <|> mdoExprParser
     <|> qualifiedDoExprParser
@@ -301,8 +328,12 @@ lexpBlockParser =
     <|> ifExprParser
     <|> caseExprParser
     <|> letExprParser
-    <|> procExprParser
+    <|> procBlockParser
     <|> lambdaExprParser
+  where
+    procBlockParser
+      | atomContext == NormalExprAtom = procExprParser
+      | otherwise = MP.empty
 
 getSCCPragma :: Pragma -> Maybe Pragma
 getSCCPragma p = case pragmaType p of
@@ -403,12 +434,15 @@ appExprParserWith atomParser = withSpanAnn (EAnn . mkAnnotation) $ do
 -- namespace expressions stay in 'atomExprParser'; they can be record-update
 -- bases only after parentheses make them an @aexp@.
 atomOrRecordExprParser :: TokParser Expr
-atomOrRecordExprParser =
-  recordExprParser <|> atomExprParser
+atomOrRecordExprParser = atomOrRecordExprParserWith NormalExprAtom
+
+atomOrRecordExprParserWith :: AtomContext -> TokParser Expr
+atomOrRecordExprParserWith atomContext =
+  recordExprParser <|> atomExprParserWith atomContext
   where
     recordExprParser :: TokParser Expr
     recordExprParser = do
-      base <- recordBaseAtomExprParser
+      base <- recordBaseAtomExprParserWith atomContext
       applyRecordSuffixes base
 
     applyRecordSuffixes :: Expr -> TokParser Expr
@@ -480,14 +514,14 @@ recordFieldBindingParser = withSpan $ do
 -- >      | '(' qop infixexp ')'
 -- >      | qcon '{' fbind_1 ',' ... ',' fbind_n '}'
 -- >      | aexp<qcon> '{' fbind_1 ',' ... ',' fbind_n '}'
-recordBaseAtomExprParser :: TokParser Expr
-recordBaseAtomExprParser = do
+recordBaseAtomExprParserWith :: AtomContext -> TokParser Expr
+recordBaseAtomExprParserWith atomContext = do
   thAny <- thAnyEnabled
   tok <- lookAhead anySingle
   case lexTokenKind tok of
     TkImplicitParam {} -> implicitParamExprParser
     _ ->
-      MP.try prefixNegateAtomExprParser
+      MP.try (prefixNegateAtomExprParserWith atomContext)
         <|> MP.try parenOperatorExprParser
         <|> (if thAny then thQuoteExprParser else MP.empty)
         <|> (if thAny then thNameQuoteExprParser else MP.empty)
@@ -511,7 +545,10 @@ recordBaseAtomExprParser = do
 -- This variant also admits extension-only atoms such as block arguments and
 -- explicit namespace syntax when the corresponding extensions are enabled.
 atomExprParser :: TokParser Expr
-atomExprParser = do
+atomExprParser = atomExprParserWith NormalExprAtom
+
+atomExprParserWith :: AtomContext -> TokParser Expr
+atomExprParserWith atomContext = do
   blockArgsEnabled <- isExtensionEnabled BlockArguments
   thAny <- thAnyEnabled
   explicitNamespacesEnabled <- isExtensionEnabled ExplicitNamespaces
@@ -529,9 +566,9 @@ atomExprParser = do
     TkQualifiedMdo {} | blockArgsEnabled -> qualifiedMdoExprParser
     TkKeywordCase | blockArgsEnabled -> caseExprParser
     TkKeywordIf | blockArgsEnabled -> ifExprParser
-    TkKeywordProc | blockArgsEnabled -> procExprParser
+    TkKeywordProc | blockArgsEnabled && atomContext == NormalExprAtom -> procExprParser
     _ ->
-      MP.try prefixNegateAtomExprParser
+      MP.try (prefixNegateAtomExprParserWith atomContext)
         <|> MP.try parenOperatorExprParser
         <|> (if thAny then thQuoteExprParser else MP.empty)
         <|> (if thAny then thNameQuoteExprParser else MP.empty)
@@ -553,10 +590,10 @@ explicitTypeExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
   expectedTok TkKeywordType
   ETypeSyntax TypeSyntaxExplicitNamespace <$> typeParser
 
-prefixNegateAtomExprParser :: TokParser Expr
-prefixNegateAtomExprParser = withSpanAnn (EAnn . mkAnnotation) $ do
+prefixNegateAtomExprParserWith :: AtomContext -> TokParser Expr
+prefixNegateAtomExprParserWith atomContext = withSpanAnn (EAnn . mkAnnotation) $ do
   prefixMinusTokenParser
-  ENegate <$> atomExprParser
+  ENegate <$> atomExprParserWith atomContext
 
 negateExprParser :: TokParser Expr
 negateExprParser = withSpanAnn (EAnn . mkAnnotation) $ do

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs-boot
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Expr.hs-boot
@@ -14,6 +14,7 @@ import Aihc.Parser.Syntax (Decl, Expr, Rhs)
 -- | Parse a full expression
 exprParser :: TokParser Expr
 atomExprParser :: TokParser Expr
+cmdArrAppLhsParser :: TokParser Expr
 lexpParser :: TokParser Expr
 
 -- | Parse the right-hand side of an equation (guarded or unguarded)

--- a/components/aihc-parser/src/Aihc/Parser/Parens.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Parens.hs
@@ -2087,7 +2087,14 @@ addCmdParensIn ctx cmd =
 
 addCmdArrAppLhsParens :: Expr -> Expr
 addCmdArrAppLhsParens lhs =
-  wrapExpr (startsWithBlockExpr lhs || isOpenEnded lhs || endsWithTypeSig lhs || endsWithCmdLayoutTail lhs) (addExprParensPrec 1 lhs)
+  wrapExpr (cmdArrAppLhsNeedsParens lhs) (addExprParensPrec 1 lhs)
+
+cmdArrAppLhsNeedsParens :: Expr -> Bool
+cmdArrAppLhsNeedsParens expr =
+  startsWithBlockExpr expr
+    || isOpenEnded expr
+    || endsWithTypeSig expr
+    || endsWithCmdLayoutTail expr
 
 -- | Arrow tails are parsed outside the expression grammar, so a command lhs that
 -- ends in a layout block needs explicit grouping even when the same expression

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/arrow-proc-lhs-needs-parens.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/arrow-proc-lhs-needs-parens.yaml
@@ -1,0 +1,6 @@
+extensions: [Arrows, ViewPatterns, BlockArguments]
+input: |
+  module M where
+  f [proc _ -> proc _ -> [] -< [] -<< [] -> _] = ()
+status: fail
+reason: bare proc command lhs must be parenthesized before -<<


### PR DESCRIPTION
## Summary
- Confirmed GHC rejects the unparenthesized nested proc view-pattern spelling; the parentheses are required.
- Replaced the parser-side guard with a dedicated command-arrow LHS nonterminal based on GHC's `exp_gen(infixexp)` arrow-tail grammar.
- Kept `Parens` using the same grouping rule for printing, and added a parser golden failure fixture for the bare proc LHS before `-<<`.

## Tests
- `just replay "(SMGen 4531439526276601647 16272872206368985039,68)"`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern arrow-proc-lhs-needs-parens --hide-successes"`
- `aihc-dev snippet` for the unparenthesized case: GHC parse failure, AIHC parse failure.
- `aihc-dev snippet` for the parenthesized case: GHC OK, AIHC OK, AST match OK, minimal parentheses OK.
- `just fmt`
- `just check`

## Progress
- Parser progress: PASS 1202, XFAIL 0, XPASS 0, FAIL 0, TOTAL 1202, COMPLETE 100.0%.
- Net change: +1 parser golden fixture; READMEs not updated.