### PR TITLE
docs(aihc-parser): rewrite README for general use

### DIFF
--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -29,8 +29,8 @@ without reaching into GHC internals.
 ## What It Supports
 
 `aihc-parser` tracks GHC's parser behavior across Haskell2010 and modern
-Haskell. The test suite checks both whether syntax is accepted and whether the
-parsed result agrees with GHC after pretty-printing and reparsing.
+Haskell. The test suite checks both whether syntax is accepted and whether
+`aihc-parser` builds the same AST that GHC does.
 
 For the current support overview, see
 [aihc-parser-supported-extensions.md](../../docs/aihc-parser-supported-extensions.md).
@@ -44,46 +44,22 @@ For the current support overview, see
   sometimes accept programs that GHC rejects.
 - It is slower than GHC's parser.
 
-The compatibility target is still GHC: accepting less than GHC is a bug;
-accepting more than GHC is currently a known caveat.
+The compatibility target is still GHC: accepting less syntax than GHC is a bug,
+and accepting more syntax than GHC is also a bug. The latter is listed as a
+caveat because it is difficult to test exhaustively, and there are likely still
+bugs of that kind.
 
 ## What Gets Tested
 
 The parser is tested with golden examples, GHC oracle checks, package fixtures,
 and generated syntax. The main properties are:
 
-- GHC compatibility: syntax accepted by GHC should parse with `aihc-parser`.
-- Pretty-print + parse roundtrip: parsed syntax should pretty-print to Haskell
-  that parses again.
-- GHC AST fingerprint preservation: parser output should pretty-print into
-  source that GHC reads as the same AST shape.
+- Roundtripping: parsed syntax should pretty-print to Haskell that parses back
+  into the same `aihc-parser` AST.
+- GHC compatibility: test cases are parsed with both `aihc-parser` and
+  `ghc-lib-parser`; the `aihc-parser` AST is converted into GHC's AST and
+  checked for exact equality with `ghc-lib-parser`'s result.
 - Totality: parser, parenthesization, shorthand rendering, and pretty-printing
   should not throw exceptions on generated inputs.
 - Parentheses stability: required parentheses should be inserted consistently,
   and running the parenthesization pass again should not keep changing the tree.
-- Haskell2010 coverage: the Haskell2010 syntax corpus is expected to pass at
-  100%.
-
-## Tests
-
-From the repository root:
-
-```bash
-cabal test -v0 all --test-options=--hide-successes
-```
-
-For the full local check used before commits:
-
-```bash
-just check
-```
-
-## Contributing Syntax Cases
-
-If you find a GHC-compatible program that `aihc-parser` rejects, please turn it
-into a regression test. The most useful reports include the source snippet, the
-required parser flags, whether GHC accepts it, and the `aihc-parser` error
-message or roundtrip mismatch.
-
-The project is test-first. A compatibility bug is only fixed once the test suite
-can keep it fixed :)

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -1,133 +1,89 @@
-# Haskell Parser
+# aihc-parser
 
-This component contains a from-scratch Haskell parser plus oracle-backed tests.
+`aihc-parser` is a Haskell parser written in Haskell. It parses modules,
+declarations, expressions, patterns, and types into a Haskell AST, and it can
+pretty-print that AST back to source code.
 
-## Haskell2010 Coverage Tracking
+The goal is simple: accept the same Haskell that GHC accepts. The parser is
+intended to be 100% compatible with GHC, and there are currently no known
+compatibility bugs. If you find one, that is a bug worth reporting.
 
-The test suite includes a manifest-driven Haskell2010 syntax corpus under:
-- `test/Test/Fixtures/haskell2010/manifest.tsv`
+## A Quick Taste
 
-Each case is marked with one expected status:
-- `pass`: parser is expected to accept the case
-- `xfail`: known unimplemented syntax; parser is expected to reject it for now
+```console
+% echo 'main = putStrLn "hello world"' | aihc-dev parser
+Module {[DeclValue (PatternBind (PVar "main") (EApp (EVar "putStrLn") (EString "hello world")))]}
+```
 
-Runtime outcomes are reported as:
-- `PASS`: expected `pass`, oracle accepts source, and `parse -> pretty` preserves GHC AST
-- `XFAIL`: expected `xfail`, case still fails oracle and/or round-trip checks
-- `XPASS`: expected `xfail`, case now passes both oracle and round-trip checks
-- `FAIL`: regression or invalid case/manifest (for example oracle rejects a `pass` case)
+It understands modern GHC syntax too:
 
-Current progress baseline:
-<!-- AUTO-GENERATED: START haskell2010-progress -->
-- `1202/1202` implemented (`100.00%` complete)
-<!-- AUTO-GENERATED: END haskell2010-progress -->
+```console
+% echo 'x = (.f.g)' | aihc-dev parser -XOverloadedRecordDot
+Module {[DeclValue (PatternBind (PVar "x") (EParen (EGetFieldProjection ["f", "g"])))]}
+```
 
-## Extension Coverage Tracking
+Use it when you want a regular library API for source inspection,
+syntax-aware rewriting, Haskell syntax experiments, or compiler-adjacent tools
+without reaching into GHC internals.
 
-Tracked extensions are listed in:
-- `test/Test/Fixtures/extensions.tsv`
+## What It Supports
 
-Each extension can provide a manifest at:
-- `test/Test/Fixtures/<Extension>/manifest.tsv`
+`aihc-parser` tracks GHC's parser behavior across Haskell2010 and modern
+Haskell. The test suite checks both whether syntax is accepted and whether the
+parsed result agrees with GHC after pretty-printing and reparsing.
 
-Current extension baseline:
-<!-- AUTO-GENERATED: START extension-progress -->
-- Total tracked extensions: `86`
-- Supported: `86`
-- In Progress: `0`
-<!-- AUTO-GENERATED: END extension-progress -->
+For the current support overview, see
+[aihc-parser-supported-extensions.md](../../docs/aihc-parser-supported-extensions.md).
 
-Generated report:
-- `../../docs/aihc-parser-supported-extensions.md`
+## Caveats
 
-## Commands
+`aihc-parser` is ready to try, but it is still young:
 
-Run full tests:
+- It is not battle-tested in the way GHC's parser is.
+- It is more lenient than GHC in some places. In other words, `aihc-parser` can
+  sometimes accept programs that GHC rejects.
+- It is slower than GHC's parser.
+
+The compatibility target is still GHC: accepting less than GHC is a bug;
+accepting more than GHC is currently a known caveat.
+
+## What Gets Tested
+
+The parser is tested with golden examples, GHC oracle checks, package fixtures,
+and generated syntax. The main properties are:
+
+- GHC compatibility: syntax accepted by GHC should parse with `aihc-parser`.
+- Pretty-print + parse roundtrip: parsed syntax should pretty-print to Haskell
+  that parses again.
+- GHC AST fingerprint preservation: parser output should pretty-print into
+  source that GHC reads as the same AST shape.
+- Totality: parser, parenthesization, shorthand rendering, and pretty-printing
+  should not throw exceptions on generated inputs.
+- Parentheses stability: required parentheses should be inserted consistently,
+  and running the parenthesization pass again should not keep changing the tree.
+- Haskell2010 coverage: the Haskell2010 syntax corpus is expected to pass at
+  100%.
+
+## Tests
+
+From the repository root:
 
 ```bash
-nix run .#parser-test
+cabal test -v0 all --test-options=--hide-successes
 ```
 
-Run progress summary:
+For the full local check used before commits:
 
 ```bash
-nix run .#parser-progress
+just check
 ```
 
-Run extension support summary:
+## Contributing Syntax Cases
 
-```bash
-nix run .#parser-extension-progress
-```
+If you find a GHC-compatible program that `aihc-parser` rejects, please turn it
+into a regression test. The most useful reports include the source snippet, the
+required parser flags, whether GHC accepts it, and the `aihc-parser` error
+message or roundtrip mismatch.
 
-Strict mode (non-zero exit on regressions or `XPASS`):
-
-```bash
-nix run .#parser-progress-strict
-```
-
-Extension strict mode (non-zero exit on regressions or `XPASS`):
-
-```bash
-nix run .#parser-extension-progress-strict
-```
-
-## Extension Support
-
-Beyond Haskell2010, we track support for various Haskell language extensions. Each extension has its own test directory under:
-- `test/Test/Fixtures/<ExtensionName>/manifest.tsv`
-
-### Generating Extension Status Report
-
-```bash
-nix run .#parser-extension-progress -- --markdown \
-  | sed -n '/^# Haskell Parser Extension Support Status/,$p'
-```
-
-This generates a markdown report showing:
-- Total extensions tracked
-- Supported extensions (all tests passing)
-- Partial support (some tests passing)
-- Haskell2010 baseline
-
-### Adding a New Extension
-
-1. Create a new directory: `test/Test/Fixtures/<ExtensionName>/`
-2. Add test files (valid Haskell source with the extension enabled)
-3. Create `manifest.tsv` with test cases in the same format as Haskell2010
-
-The manifest format:
-```
-<test-id>	<category>	<path/to/file.hs>	<pass|xfail>	<reason>
-```
-
-Example:
-```
-list-comp-parallel-1	expressions	list-comp.hs	pass	parallel list comprehension
-```
-
-### NIX Commands
-
-- `nix run .#parser-extension-progress -- --markdown | sed -n '/^# Haskell Parser Extension Support Status/,$p'` - Generate clean markdown report to stdout
-- `nix build .#extension-report` - Build report to result/ directory
-- `nix flake check` - Includes extension report as part of CI checks
-
-## Hackage Testing
-
-To validate the parser against real-world Haskell packages from Hackage:
-
-```bash
-nix run .#aihc-dev -- hackage-tester <package-name>
-```
-
-Example:
-```bash
-nix run .#aihc-dev -- hackage-tester transformers
-```
-
-The tool:
-- Downloads and caches packages locally in `~/.cache/aihc/hackage/`
-- Runs the in-repo CPP preprocessor before parsing (with best-effort include resolution)
-- Parses Cabal-declared library and executable source files
-- Reports parse errors and roundtrip failures
-- Shows success rate for the package
+The project is test-first. A compatibility bug is only fixed once the test suite
+can keep it fixed :)

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -1,12 +1,11 @@
 # aihc-parser
 
-`aihc-parser` is a Haskell parser written in Haskell. It parses modules,
-declarations, expressions, patterns, and types into a Haskell AST, and it can
-pretty-print that AST back to source code.
+`aihc-parser` is a Haskell parser library. It parses modules, declarations,
+expressions, patterns, and types into an AST, and can pretty-print that AST
+back to source code.
 
-The goal is simple: accept the same Haskell that GHC accepts. The parser is
-intended to be 100% compatible with GHC, and there are currently no known
-compatibility bugs. If you find one, that is a bug worth reporting.
+Its goal is to accept exactly the same Haskell as GHC. There are currently no
+known compatibility bugs; if you find one, please report it.
 
 ## A Quick Taste
 
@@ -22,9 +21,9 @@ It understands modern GHC syntax too:
 Module {[DeclValue (PatternBind (PVar "x") (EParen (EGetFieldProjection ["f", "g"])))]}
 ```
 
-Use it when you want a regular library API for source inspection,
-syntax-aware rewriting, Haskell syntax experiments, or compiler-adjacent tools
-without reaching into GHC internals.
+Use it for source inspection, syntax-aware rewriting, Haskell syntax
+experiments, or compiler-adjacent tools that want a regular library API instead
+of reaching into GHC internals.
 
 ## What It Supports
 
@@ -37,26 +36,23 @@ For the current support overview, see
 
 ## Caveats
 
-`aihc-parser` is ready to try, but it is still young:
+`aihc-parser` is ready to try, but it has not had anything like GHC's years of
+production exposure.
 
-- It is not battle-tested in the way GHC's parser is.
-- It is more lenient than GHC in some places. In other words, `aihc-parser` can
-  sometimes accept programs that GHC rejects.
-- It is slower than GHC's parser.
+The intended behavior is exact GHC compatibility. Rejecting code that GHC
+accepts is a bug. Accepting code that GHC rejects is also a bug, but that class
+of bug is harder to test exhaustively, so some cases almost certainly remain.
 
-The compatibility target is still GHC: accepting less syntax than GHC is a bug,
-and accepting more syntax than GHC is also a bug. The latter is listed as a
-caveat because it is difficult to test exhaustively, and there are likely still
-bugs of that kind.
+It is also slower than GHC's parser.
 
 ## What Gets Tested
 
-The parser is tested with golden examples, GHC oracle checks, package fixtures,
-and generated syntax. The main properties are:
+The test suite uses golden examples, GHC oracle checks, package fixtures, and
+generated syntax. The core properties are:
 
 - `parse ∘ pretty = id`: pretty-printed ASTs parse back to the same
   `aihc-parser` AST.
 - `to_ghc_ast ∘ parse = ghc_parse`: parsed ASTs convert to exactly the same
   GHC AST that `ghc-lib-parser` produces.
-- `parse`, `pretty`, `parens`, and shorthand rendering are total on generated
+- `parse`, `pretty`, `parens`, and shorthand rendering do not throw on generated
   inputs.

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -54,12 +54,10 @@ bugs of that kind.
 The parser is tested with golden examples, GHC oracle checks, package fixtures,
 and generated syntax. The main properties are:
 
-- Roundtripping: parsed syntax should pretty-print to Haskell that parses back
-  into the same `aihc-parser` AST.
-- GHC compatibility: test cases are parsed with both `aihc-parser` and
-  `ghc-lib-parser`; the `aihc-parser` AST is converted into GHC's AST and
-  checked for exact equality with `ghc-lib-parser`'s result.
-- Totality: parser, parenthesization, shorthand rendering, and pretty-printing
-  should not throw exceptions on generated inputs.
-- Parentheses stability: required parentheses should be inserted consistently,
-  and running the parenthesization pass again should not keep changing the tree.
+- `parse ∘ pretty = id`: pretty-printed ASTs parse back to the same
+  `aihc-parser` AST.
+- `to_ghc_ast ∘ parse = ghc_parse`: parsed ASTs convert to exactly the same
+  GHC AST that `ghc-lib-parser` produces.
+- `parens ∘ parens = parens`: inserting required parentheses is stable.
+- `parse`, `pretty`, `parens`, and shorthand rendering are total on generated
+  inputs.

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -27,9 +27,8 @@ of reaching into GHC internals.
 
 ## What It Supports
 
-`aihc-parser` tracks GHC's parser behavior across Haskell2010 and modern
-Haskell. The test suite checks both whether syntax is accepted and whether
-`aihc-parser` builds the same AST that GHC does.
+`aihc-parser` tracks GHC's parser behavior. The test suite checks both whether
+syntax is accepted and whether `aihc-parser` builds the same AST that GHC does.
 
 For the current support overview, see
 [aihc-parser-supported-extensions.md](../../docs/aihc-parser-supported-extensions.md).

--- a/components/aihc-parser/README.md
+++ b/components/aihc-parser/README.md
@@ -58,6 +58,5 @@ and generated syntax. The main properties are:
   `aihc-parser` AST.
 - `to_ghc_ast ∘ parse = ghc_parse`: parsed ASTs convert to exactly the same
   GHC AST that `ghc-lib-parser` produces.
-- `parens ∘ parens = parens`: inserting required parentheses is stable.
 - `parse`, `pretty`, `parens`, and shorthand rendering are total on generated
   inputs.

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -104,21 +104,6 @@ parse_progress() {
   ' "$infile"
 }
 
-parse_extension_summary() {
-	local infile="$1"
-	awk '
-    /^- Total Extensions:/ { total=$4 }
-    /^- Supported:/ { supported=$3 }
-    /^- In Progress:/ { in_progress=$4 }
-    END {
-      if (total == "" || supported == "" || in_progress == "") {
-        exit 2
-      }
-      printf "%d\n%d\n%d\n", total, supported, in_progress
-    }
-  ' "$infile"
-}
-
 parse_extension_progress() {
 	local infile="$1"
 	awk '
@@ -293,14 +278,6 @@ tc_total="${tc_vals[4]}"
 tc_implemented="${tc_vals[5]}"
 tc_complete="${tc_vals[6]}"
 
-ext_vals=($(parse_extension_summary "$extension_out")) || {
-	echo "update-generated-content.sh: could not parse extension markdown summary (expected Total Extensions, Supported, In Progress lines after --markdown)." >&2
-	exit 2
-}
-ext_total="${ext_vals[0]}"
-ext_supported="${ext_vals[1]}"
-ext_in_progress="${ext_vals[2]}"
-
 ext_progress_vals=($(parse_extension_progress "$extension_progress_out")) || {
 	echo "update-generated-content.sh: could not parse parser-extension-progress text (expected PASS=/XFAIL=/ lines)." >&2
 	exit 2
@@ -335,10 +312,6 @@ lexer_circles="$(progress_circles "$lexer_complete")"
 resolve_circles="$(progress_circles "$resolve_complete")"
 tc_circles="$(progress_circles "$tc_complete")"
 
-# extract extension name lists (alphabetically sorted, comma-separated) from the markdown table if present
-ext_supported_names="$(awk -F'|' 'BEGIN{names=""} /^\|/ { status=$3; name=$2; gsub(/^[ \t]+|[ \t]+$/, "", name); gsub(/^[ \t]+|[ \t]+$/, "", status); if (status == "Supported") { if (names=="") names=name; else names=names ", " name } } END{ print names }' "$extension_out")"
-ext_in_progress_names="$(awk -F'|' 'BEGIN{names=""} /^\|/ { status=$3; name=$2; gsub(/^[ \t]+|[ \t]+$/, "", name); gsub(/^[ \t]+|[ \t]+$/, "", status); if (status == "In Progress") { if (names=="") names=name; else names=names ", " name } } END{ print names }' "$extension_out")"
-
 cat >"$tmpdir/readme-root-parser.txt" <<EOF2
 \`${parser_passing_tests}/${parser_total_tests}\` (\`${parser_total_complete}%\`) ${parser_total_circles}
 EOF2
@@ -365,16 +338,6 @@ EOF2
 
 cat >"$tmpdir/readme-root-tc.txt" <<EOF2
 \`${tc_implemented}/${tc_total}\` (\`${tc_complete}%\`) ${tc_circles}
-EOF2
-
-cat >"$tmpdir/readme-parser-h2010.txt" <<EOF2
-- \`${parser_implemented}/${parser_total}\` implemented (\`${parser_complete}%\` complete)
-EOF2
-
-cat >"$tmpdir/readme-parser-extension.txt" <<EOF2
-- Total tracked extensions: \`${ext_total}\`
-- Supported: \`${ext_supported}\`
-- In Progress: \`${ext_in_progress}\`
 EOF2
 
 cat >"$tmpdir/readme-cpp.txt" <<EOF2
@@ -511,8 +474,6 @@ replace_marker_inline README.md "cpp-progress" "$tmpdir/readme-root-cpp.txt"
 replace_marker_inline README.md "resolve-progress" "$tmpdir/readme-root-resolve.txt"
 replace_marker_inline README.md "tc-progress" "$tmpdir/readme-root-tc.txt"
 replace_marker_block README.md "line-counts" "$line_counts_out"
-replace_marker_block components/aihc-parser/README.md "haskell2010-progress" "$tmpdir/readme-parser-h2010.txt"
-replace_marker_block components/aihc-parser/README.md "extension-progress" "$tmpdir/readme-parser-extension.txt"
 replace_marker_block components/aihc-cpp/README.md "cpp-progress" "$tmpdir/readme-cpp.txt"
 
 if [ "$mode" = "--check" ] && [ "$stale" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- Rewrite the aihc-parser README for general users.
- Replace the Haskell API demo with short `aihc-dev parser` examples.
- Remove duplicated generated progress/status blocks and link to the maintained extension support overview instead.

## Progress counts

- No parser implementation progress changed.
- README no longer duplicates generated support counts; it links to `docs/aihc-parser-supported-extensions.md` for the current overview.

## Validation

- `just fmt`
- `just check`
