### PR TITLE
fix(parser): tighten tuple type shorthand

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Shorthand.hs
@@ -656,10 +656,7 @@ docType ty =
         <+> parens (docType rhs)
     TFun arrowKind a b -> "TFun" <+> hsep (docFunctionTypeFields arrowKind a b)
     TTuple tupleFlavor promoted elems ->
-      "TTuple"
-        <+> pretty (show tupleFlavor)
-        <+> pretty (show promoted)
-        <+> brackets (hsep (punctuate comma (map docType elems)))
+      "TTuple" <+> hsep (docTypeTupleFields tupleFlavor promoted elems)
     TUnboxedSum elems ->
       "TUnboxedSum"
         <+> brackets (hsep (punctuate comma (map docType elems)))
@@ -692,6 +689,20 @@ docTypeListFields :: TypePromotion -> [Type] -> [Doc ann]
 docTypeListFields promoted elems =
   promotedFields <> [brackets (hsep (punctuate comma (map docType elems)))]
   where
+    promotedFields =
+      case promoted of
+        Unpromoted -> []
+        Promoted -> ["Promoted"]
+
+docTypeTupleFields :: TupleFlavor -> TypePromotion -> [Type] -> [Doc ann]
+docTypeTupleFields tupleFlavor promoted elems =
+  flavorFields <> promotedFields <> [brackets (hsep (punctuate comma (map docType elems)))]
+  where
+    flavorFields =
+      case tupleFlavor of
+        Boxed -> []
+        _ -> [pretty (show tupleFlavor)]
+
     promotedFields =
       case promoted of
         Unpromoted -> []

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/do-if-then-else-let-layout.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/do-if-then-else-let-layout.yaml
@@ -12,5 +12,5 @@ input: |
       else do
       return 0
 ast: |-
-  Module {ModuleHead {"DoAndIfThenElseLetLayout"}, [DoAndIfThenElse], [DeclTypeSig ["withLet"] (TApp (TCon "IO") (TTuple Boxed Unpromoted [])), DeclValue (PatternBind (PVar "withLet") (EDo [DoExpr (EIf (EVar "True") (EDo [DoLetDecls [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger)), DeclValue (PatternBind (PVar "y") (EInt 2 TInteger))], DoExpr (EApp (EVar "return") (EParen (EInfix (EVar "x") "+" (EVar "y"))))]) (EDo [DoExpr (EApp (EVar "return") (EInt 0 TInteger))]))]))]}
+  Module {ModuleHead {"DoAndIfThenElseLetLayout"}, [DoAndIfThenElse], [DeclTypeSig ["withLet"] (TApp (TCon "IO") (TTuple [])), DeclValue (PatternBind (PVar "withLet") (EDo [DoExpr (EIf (EVar "True") (EDo [DoLetDecls [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger)), DeclValue (PatternBind (PVar "y") (EInt 2 TInteger))], DoExpr (EApp (EVar "return") (EParen (EInfix (EVar "x") "+" (EVar "y"))))]) (EDo [DoExpr (EApp (EVar "return") (EInt 0 TInteger))]))]))]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/instance-promoted-unit-infix-head.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/instance-promoted-unit-infix-head.yaml
@@ -7,5 +7,5 @@ input: |
   class Infix a b
   instance '() `Infix` ()
 ast: |-
-  Module {ModuleHead {"M"}, [DataKinds, FlexibleInstances, TypeOperators], [DeclClass (ClassDecl {Prefix "Infix" [TyVarBinder {"a"}, TyVarBinder {"b"}]}), DeclInstance (InstanceDecl {TInfix (TTuple Boxed Promoted []) "Infix" (TTuple Boxed Unpromoted [])})]}
+  Module {ModuleHead {"M"}, [DataKinds, FlexibleInstances, TypeOperators], [DeclClass (ClassDecl {Prefix "Infix" [TyVarBinder {"a"}, TyVarBinder {"b"}]}), DeclInstance (InstanceDecl {TInfix (TTuple Promoted []) "Infix" (TTuple [])})]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/standalone-deriving-infix-paren-lhs.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/standalone-deriving-infix-paren-lhs.yaml
@@ -2,5 +2,5 @@ extensions: []
 input: |
   deriving instance ((C) '()) :+ ()
 ast: |-
-  Module {[DeclStandaloneDeriving (StandaloneDerivingDecl {TInfix (TParen (TApp (TParen (TCon "C")) (TTuple Boxed Promoted []))) ":+" (TTuple Boxed Unpromoted [])})]}
+  Module {[DeclStandaloneDeriving (StandaloneDerivingDecl {TInfix (TParen (TApp (TParen (TCon "C")) (TTuple Promoted []))) ":+" (TTuple [])})]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/type-family-instance-promoted-unit.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/type-family-instance-promoted-unit.yaml
@@ -6,5 +6,5 @@ input: |
   type family T a
   type instance T '() = ()
 ast: |-
-  Module {ModuleHead {"M"}, [DataKinds, TypeFamilies], [DeclTypeFamilyDecl (TypeFamilyDecl {TypeHeadPrefix, True, TCon "T", [TyVarBinder {"a"}]}), DeclTypeFamilyInst (TypeFamilyInst {TypeHeadPrefix, TApp (TCon "T") (TTuple Boxed Promoted []), TTuple Boxed Unpromoted []})]}
+  Module {ModuleHead {"M"}, [DataKinds, TypeFamilies], [DeclTypeFamilyDecl (TypeFamilyDecl {TypeHeadPrefix, True, TCon "T", [TyVarBinder {"a"}]}), DeclTypeFamilyInst (TypeFamilyInst {TypeHeadPrefix, TApp (TCon "T") (TTuple Promoted []), TTuple []})]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/type-synonym.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/type-synonym.yaml
@@ -3,5 +3,5 @@ input: |
   module D6 where
   type Pair a = (a, a)
 ast: |-
-  Module {ModuleHead {"D6"}, [DeclTypeSyn (TypeSynDecl {Prefix "Pair" [TyVarBinder {"a"}], TTuple Boxed Unpromoted [TVar "a", TVar "a"]})]}
+  Module {ModuleHead {"D6"}, [DeclTypeSyn (TypeSynDecl {Prefix "Pair" [TyVarBinder {"a"}], TTuple [TVar "a", TVar "a"]})]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/type-tuple-shorthand-defaults.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/type-tuple-shorthand-defaults.yaml
@@ -1,0 +1,11 @@
+extensions: [DataKinds, UnboxedTuples]
+input: |
+  {-# LANGUAGE DataKinds #-}
+  {-# LANGUAGE UnboxedTuples #-}
+  module M where
+  x :: IO ()
+  y :: IO '()
+  z :: IO '(# #)
+ast: |-
+  Module {ModuleHead {"M"}, [DataKinds, UnboxedTuples], [DeclTypeSig ["x"] (TApp (TCon "IO") (TTuple [])), DeclTypeSig ["y"] (TApp (TCon "IO") (TTuple Promoted [])), DeclTypeSig ["z"] (TApp (TCon "IO") (TTuple Unboxed Promoted []))]}
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/golden/module/unboxed-tuples-basic.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/module/unboxed-tuples-basic.yaml
@@ -7,5 +7,5 @@ input: |
   h :: (# Int, Int #) -> (# Int, Int #)
   h t = t
 ast: |-
-  Module {ModuleHead {"UnboxedTuplesBasic"}, [UnboxedTuples], [DeclValue (PatternBind (PVar "x") (ETuple Unboxed [EInt 1 TInteger, EInt 2 TInteger])), DeclValue (FunctionBind "f" [Match {MatchHeadPrefix, [PTuple Unboxed [PVar "a", PVar "b"]], EVar "a"}]), DeclTypeSig ["h"] (TFun (TTuple Unboxed Unpromoted [TCon "Int", TCon "Int"]) (TTuple Unboxed Unpromoted [TCon "Int", TCon "Int"])), DeclValue (FunctionBind "h" [Match {MatchHeadPrefix, [PVar "t"], EVar "t"}])]}
+  Module {ModuleHead {"UnboxedTuplesBasic"}, [UnboxedTuples], [DeclValue (PatternBind (PVar "x") (ETuple Unboxed [EInt 1 TInteger, EInt 2 TInteger])), DeclValue (FunctionBind "f" [Match {MatchHeadPrefix, [PTuple Unboxed [PVar "a", PVar "b"]], EVar "a"}]), DeclTypeSig ["h"] (TFun (TTuple Unboxed [TCon "Int", TCon "Int"]) (TTuple Unboxed [TCon "Int", TCon "Int"])), DeclValue (FunctionBind "h" [Match {MatchHeadPrefix, [PVar "t"], EVar "t"}])]}
 status: pass


### PR DESCRIPTION
## Summary
- omit default `Boxed` and `Unpromoted` fields from `TTuple` shorthand output
- update parser golden snapshots to the tighter tuple rendering
- add a focused module golden fixture for `IO ()`, `IO '()`, and `IO '(# #)`\n\n## Progress counts\n- Parser golden module fixtures: +1 pass fixture\n\n## Validation\n- `cabal test -v0 aihc-parser:spec --test-options="--pattern type-tuple-shorthand-defaults --hide-successes"`\n- `echo 'x :: IO ()' | cabal run -v0 exe:aihc-dev -- parser`\n- `echo "x :: IO '()" | cabal run -v0 exe:aihc-dev -- parser`\n- `echo "x :: IO '(# #)" | cabal run -v0 exe:aihc-dev -- parser -XUnboxedTuples`\n- `just fmt`\n- `just check`