### PR TITLE
test(parser): remove non-parser extension coverage

### DIFF
--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1334,8 +1334,7 @@ test_prettyNestedInfixRhsInsideSection = do
 
 test_prettyRightSectionInfixOperand :: Assertion
 test_prettyRightSectionInfixOperand = do
-  let config = defaultConfig {parserExtensions = [OverloadedStrings]}
-      sources =
+  let sources =
         [ "(/ 10 ^ (3 :: Int))",
           "(<> msg <> \"\\n\")",
           "(++ \" seconds\" ++ dir f)",
@@ -1344,7 +1343,7 @@ test_prettyRightSectionInfixOperand = do
           "(.+^ p ^. vel)",
           "(<?> prettyIndentation ref ++ \" (started at line \" ++ prettyLine ref ++ \")\")"
         ]
-  mapM_ (assertParsedStrippedExprShapeRoundTrip config) sources
+  mapM_ (assertParsedStrippedExprShapeRoundTrip defaultConfig) sources
 
 test_prettyInfixRhsOpenEndedBeforeFollowingInfix :: Assertion
 test_prettyInfixRhsOpenEndedBeforeFollowingInfix = do

--- a/components/aihc-parser/test/Test/Fixtures/golden/pragma/language-leading-comma.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/golden/pragma/language-leading-comma.yaml
@@ -4,10 +4,9 @@ input: |
       DataKinds
     , DeriveGeneric
     , DeriveDataTypeable
-    , OverloadedStrings
     #-}
   module Demo where
   x = 1
 ast: |-
-  Module {ModuleHead {"Demo"}, [DataKinds, DeriveGeneric, DeriveDataTypeable, OverloadedStrings], [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
+  Module {ModuleHead {"Demo"}, [DataKinds, DeriveGeneric, DeriveDataTypeable], [DeclValue (PatternBind (PVar "x") (EInt 1 TInteger))]}
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/pragma/language-leading-comma.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/pragma/language-leading-comma.yaml
@@ -4,9 +4,8 @@ input: |
       DataKinds
     , DeriveGeneric
     , DeriveDataTypeable
-    , OverloadedStrings
     #-}
 tokens:
-  - 'TkPragma (PragmaLanguage [EnableExtension DataKinds, EnableExtension DeriveGeneric, EnableExtension DeriveDataTypeable, EnableExtension OverloadedStrings])'
+  - 'TkPragma (PragmaLanguage [EnableExtension DataKinds, EnableExtension DeriveGeneric, EnableExtension DeriveDataTypeable])'
   - 'TkEOF'
 status: pass

--- a/components/aihc-parser/test/Test/Fixtures/oracle/FlexibleInstances/instance-unit.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/FlexibleInstances/instance-unit.hs
@@ -1,5 +1,5 @@
 {- ORACLE_TEST pass -}
-{-# LANGUAGE KindSignatures, FlexibleInstances, MultiParamTypeClasses, FlexibleContexts, TypeSynonymInstances #-}
+{-# LANGUAGE KindSignatures, FlexibleInstances, MultiParamTypeClasses, FlexibleContexts #-}
 module InstanceUnit where
 
 class Unit x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/string-gap-type-error-indentation.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/MultilineStrings/string-gap-type-error-indentation.hs
@@ -1,7 +1,6 @@
 {- ORACLE_TEST pass -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module StringGapTypeErrorIndentation where
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Parens/log-base-modify-seq-parens.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Parens/log-base-modify-seq-parens.hs
@@ -1,5 +1,4 @@
 {- ORACLE_TEST pass -}
-{-# LANGUAGE OverloadedStrings #-}
 
 module MonoidAppendParen where
 

--- a/docs/aihc-parser-supported-extensions.md
+++ b/docs/aihc-parser-supported-extensions.md
@@ -2,8 +2,8 @@
 
 ## Summary
 
-- Total Extensions: 86
-- Supported: 86
+- Total Extensions: 83
+- Supported: 83
 - In Progress: 0
 
 ## Extension Status
@@ -17,7 +17,7 @@
 | CApiFFI                   |   🟢    | 4/4           |
 | ConstraintKinds           |   🟢    | 8/8           |
 | CPP                       |   🟢    | 8/8           |
-| DataKinds                 |   🟢    | 64/64         |
+| DataKinds                 |   🟢    | 65/65         |
 | DefaultSignatures         |   🟢    | 4/4           |
 | DerivingStrategies        |   🟢    | 8/8           |
 | DerivingVia               |   🟢    | 7/7           |
@@ -60,7 +60,6 @@
 | OverlappingInstances      |   🟢    | 1/1           |
 | OverloadedLabels          |   🟢    | 6/6           |
 | OverloadedRecordDot       |   🟢    | 8/8           |
-| OverloadedStrings         |   🟢    | 1/1           |
 | PackageImports            |   🟢    | 6/6           |
 | ParallelListComp          |   🟢    | 3/3           |
 | PartialTypeSignatures     |   🟢    | 21/21         |
@@ -90,10 +89,8 @@
 | TypeFamilies              |   🟢    | 61/61         |
 | TypeFamilyDependencies    |   🟢    | 4/4           |
 | TypeOperators             |   🟢    | 71/71         |
-| TypeSynonymInstances      |   🟢    | 1/1           |
 | UnboxedSums               |   🟢    | 13/13         |
-| UnboxedTuples             |   🟢    | 21/21         |
-| UndecidableInstances      |   🟢    | 1/1           |
+| UnboxedTuples             |   🟢    | 22/22         |
 | UnicodeSyntax             |   🟢    | 21/21         |
 | ViewPatterns              |   🟢    | 26/26         |
 


### PR DESCRIPTION
## Summary

- remove parser fixture usage of `OverloadedStrings`, `TypeSynonymInstances`, and `UndecidableInstances` where those extensions were explicitly enabled but not needed for parsing
- preserve the existing `-fglasgow-exts` OPTIONS pragma fixture for MagicHash coverage
- regenerate `docs/aihc-parser-supported-extensions.md` so the non-parser rows are no longer counted

## Progress Counts

- Parser extension report: `86` total / `86` supported -> `83` total / `83` supported

## Validation

- `cabal test -v0 aihc-parser:spec --test-options="--pattern parser --hide-successes"`
- `just fmt`
- `just check`
