### PR TITLE
fix(aihc-cpp): hide internal progress executable

### DIFF
--- a/components/aihc-cpp/CHANGELOG.md
+++ b/components/aihc-cpp/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0.1] - 2026-05-27
+
+### Fixed
+
+- Marked the internal `cpp-progress` executable as private so Hackage lists
+  `aihc-cpp` as a library-only package.
+
 ## [1.0.0.0] - 2026-05-27
 
 ### Added

--- a/components/aihc-cpp/aihc-cpp.cabal
+++ b/components/aihc-cpp/aihc-cpp.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: aihc-cpp
-version: 1.0.0.0
+version: 1.0.0.1
 build-type: Simple
 license: Unlicense
 license-file: LICENSE
@@ -69,6 +69,7 @@ test-suite spec
   default-language: Haskell2010
 
 executable cpp-progress
+  scope: private
   hs-source-dirs:
     app/cpp-progress
     test

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -19,6 +19,10 @@
     };
     aihc-cpp = {
       src = sources.cppSrc;
+      configureFlags = [
+        "--libexecdir=${builtins.placeholder "out"}/bin"
+        "--libexecsubdir="
+      ];
       disableProfiling = false;
       optimizeForChecks = false;
       supportsDocs = true;
@@ -161,12 +165,21 @@ in rec {
         })
       else drv;
 
+    applyConfigureFlags = flags: drv:
+      if flags == []
+      then drv
+      else
+        hsLib.overrideCabal drv (old: {
+          configureFlags = (old.configureFlags or []) ++ flags;
+        });
+
     mkComponent = final: name: spec: let
       baseDrv = final.callCabal2nix name (spec.src pkgs) {};
+      configureFlagsAdjusted = applyConfigureFlags (spec.configureFlags or []) baseDrv;
       profilingAdjusted =
         if spec.disableProfiling
-        then hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling baseDrv)
-        else baseDrv;
+        then hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling configureFlagsAdjusted)
+        else configureFlagsAdjusted;
       optimizationAdjusted =
         if disableOptimization && spec.optimizeForChecks
         then hsLib.disableOptimization profilingAdjusted


### PR DESCRIPTION
## Summary

- Bump `aihc-cpp` to `1.0.0.1` for the Hackage metadata fix release.
- Mark the internal `cpp-progress` executable with `scope: private` so Hackage presents `aihc-cpp` as a library-only package.
- Configure the Nix-built `aihc-cpp` package to install private executables into `$out/bin`, keeping `pkgs.lib.getExe'` and PATH-based progress checks working.
- Add the `1.0.0.1` changelog entry.

## Progress Counts

- `aihc-cpp` cpphs oracle progress remains `46/46`; this PR does not change implementation coverage.

## Validation

- `cabal check`
- `just fmt`
- `just check`
- `nix build .#checks.aarch64-darwin.cpp-progress-strict -L`
- `nix run .#cpp-progress-strict -- --help`
- `nix flake check -L`
