### PR TITLE
fix(aihc-cpp): publish library-only package

### DIFF
--- a/components/aihc-cpp/CHANGELOG.md
+++ b/components/aihc-cpp/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0.2] - 2026-05-27
+
+### Fixed
+
+- Removed the internal `cpp-progress` executable from the published Cabal
+  package so Hackage lists `aihc-cpp` as library-only.
+- Included the CPP progress fixtures in the source distribution so Hackage can
+  run the package test suite and report coverage.
+
 ## [1.0.0.1] - 2026-05-27
 
 ### Fixed

--- a/components/aihc-cpp/aihc-cpp.cabal
+++ b/components/aihc-cpp/aihc-cpp.cabal
@@ -1,10 +1,15 @@
 cabal-version: 3.8
 name: aihc-cpp
-version: 1.0.0.1
+version: 1.0.0.2
 build-type: Simple
 license: Unlicense
 license-file: LICENSE
 extra-doc-files: CHANGELOG.md
+extra-source-files:
+  test/Test/Fixtures/progress/*.hs
+  test/Test/Fixtures/progress/*.tsv
+  test/Test/Fixtures/progress/includes/*.inc
+
 author: David Himmelstrup
 maintainer: lemmih@gmail.com
 category: Development
@@ -63,29 +68,6 @@ test-suite spec
     tasty >=1.5 && <1.6,
     tasty-hunit >=0.10 && <0.11,
     tasty-quickcheck >=0.11.1 && <0.12,
-    text >=1.2 && <2.2,
-
-  ghc-options: -Wall
-  default-language: Haskell2010
-
-executable cpp-progress
-  scope: private
-  hs-source-dirs:
-    app/cpp-progress
-    test
-
-  main-is: Main.hs
-  other-modules:
-    Test.Progress
-
-  build-depends:
-    aihc-cpp >=1.0 && <1.1,
-    base >=4.16 && <5,
-    bytestring >=0.10.8 && <0.13,
-    containers >=0.5 && <0.8,
-    cpphs >=1.20 && <1.21,
-    directory >=1.2.3 && <1.5,
-    filepath >=1.3.0.1 && <1.6,
     text >=1.2 && <2.2,
 
   ghc-options: -Wall

--- a/scripts/nix/apps.nix
+++ b/scripts/nix/apps.nix
@@ -7,13 +7,16 @@
   parserProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "parser-progress";
   lexerProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "lexer-progress";
   extensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "extension-progress";
-  cppProgressExe = pkgs.lib.getExe' hsPkgs.aihc-cpp "cpp-progress";
   resolveProgressExe = pkgs.lib.getExe' hsPkgs.aihc-resolve "resolve-progress";
   resolveExtensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-resolve "resolve-extension-progress";
   tcProgressExe = pkgs.lib.getExe' hsPkgs.aihc-tc "tc-progress";
   tcExtensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-tc "tc-extension-progress";
   aihcDevExe = pkgs.lib.getExe' hsPkgs.aihc-dev "aihc-dev";
   aihcExe = pkgs.lib.getExe' hsPkgs.aihc "aihc";
+  cppProgressEnv = hsPkgs.ghcWithPackages (p: [
+    p.aihc-cpp
+    p.cpphs
+  ]);
 
   repoRootGuard = ''
     test -d components/aihc-parser || {
@@ -46,6 +49,14 @@
 
   mkComponentApp = name: component: text:
     mkApp name ''
+      set -euo pipefail
+      ${repoRootGuard}
+      cd ${component}
+      ${text}
+    '';
+
+  mkComponentAppWithInputs = name: runtimeInputs: component: text:
+    mkAppWithInputs name runtimeInputs ''
       set -euo pipefail
       ${repoRootGuard}
       cd ${component}
@@ -162,12 +173,12 @@ in {
     cabal test --test-show-details=direct
   '';
 
-  cpp-progress = mkComponentApp "cpp-progress" "components/aihc-cpp" ''
-    ${cppProgressExe} "$@"
+  cpp-progress = mkComponentAppWithInputs "cpp-progress" [pkgs.bash cppProgressEnv] "components/aihc-cpp" ''
+    runghc -package-env - -itest app/cpp-progress/Main.hs "$@"
   '';
 
-  cpp-progress-strict = mkComponentApp "cpp-progress-strict" "components/aihc-cpp" ''
-    ${cppProgressExe} --strict "$@"
+  cpp-progress-strict = mkComponentAppWithInputs "cpp-progress-strict" [pkgs.bash cppProgressEnv] "components/aihc-cpp" ''
+    runghc -package-env - -itest app/cpp-progress/Main.hs --strict "$@"
   '';
 
   resolve-progress = mkComponentApp "resolve-progress" "components/aihc-resolve" ''

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -44,6 +44,11 @@
   mkProgressCheck = name: src: package: command:
     mkSourceCheck name src [package] command;
 
+  cppProgressEnv = hsPkgs.ghcWithPackages (p: [
+    p.aihc-cpp
+    p.cpphs
+  ]);
+
   parserTests = mkPackageTest hsPkgs.aihc-parser;
   cppTests = mkPackageTest hsPkgs.aihc-cpp;
   fcTests = mkFcPackageTest hsPkgs.aihc-fc;
@@ -91,8 +96,8 @@
     extension-progress --strict
   '';
 
-  cppProgressStrict = mkProgressCheck "aihc-cpp-progress-strict" (sources.cppSrc pkgs) hsPkgs.aihc-cpp ''
-    cpp-progress --strict
+  cppProgressStrict = mkSourceCheck "aihc-cpp-progress-strict" (sources.cppSrc pkgs) [cppProgressEnv] ''
+    runghc -package-env - -itest app/cpp-progress/Main.hs --strict
   '';
 
   cppDoctest =

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -19,10 +19,6 @@
     };
     aihc-cpp = {
       src = sources.cppSrc;
-      configureFlags = [
-        "--libexecdir=${builtins.placeholder "out"}/bin"
-        "--libexecsubdir="
-      ];
       disableProfiling = false;
       optimizeForChecks = false;
       supportsDocs = true;
@@ -165,21 +161,12 @@ in rec {
         })
       else drv;
 
-    applyConfigureFlags = flags: drv:
-      if flags == []
-      then drv
-      else
-        hsLib.overrideCabal drv (old: {
-          configureFlags = (old.configureFlags or []) ++ flags;
-        });
-
     mkComponent = final: name: spec: let
       baseDrv = final.callCabal2nix name (spec.src pkgs) {};
-      configureFlagsAdjusted = applyConfigureFlags (spec.configureFlags or []) baseDrv;
       profilingAdjusted =
         if spec.disableProfiling
-        then hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling configureFlagsAdjusted)
-        else configureFlagsAdjusted;
+        then hsLib.disableExecutableProfiling (hsLib.disableLibraryProfiling baseDrv)
+        else baseDrv;
       optimizationAdjusted =
         if disableOptimization && spec.optimizeForChecks
         then hsLib.disableOptimization profilingAdjusted


### PR DESCRIPTION
## Summary

- Bump `aihc-cpp` to `1.0.0.2` for a corrective Hackage release.
- Remove the `cpp-progress` executable stanza from the published Cabal package so Hackage classifies `aihc-cpp` as library-only.
- Add the CPP progress fixture files to `extra-source-files` so Hackage can run the test suite from the source distribution and produce coverage.
- Keep the internal `cpp-progress` Nix apps/checks by running the tool source with `runghc` in a Nix GHC package environment.

## Root cause

Hackage still marks packages with `scope: private` executable stanzas as programs. The `1.0.0.1` upload is immutable, so the published package needs a new release with no executable stanza at all. Hackage test failures were also likely caused by the source distribution missing the non-module progress fixtures.

## Progress

- CPP progress: 46/46

## Validation

- `cabal check`
- `cabal sdist`
- unpacked `aihc-cpp-1.0.0.2` sdist: `cabal test -v0 all --test-options=--hide-successes`
- `nix run .#cpp-progress-strict`
- `nix build .#checks.aarch64-darwin.cpp-progress-strict -L`
- `just fmt`
- `just check`
- `nix flake check -L`
