### PR TITLE
fix(aihc-parser): publish library-only package

### DIFF
--- a/components/aihc-parser/CHANGELOG.md
+++ b/components/aihc-parser/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0.1] - 2026-05-28
+
+### Fixed
+
+- Removed internal progress executables from the published Cabal package so
+  Hackage lists `aihc-parser` as library-only.
+- Included parser fixture files in the source distribution so Hackage can run
+  the package test suite and report coverage.
+
 ## [1.0.0.0] - 2026-05-27
 
 ### Added

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -1,10 +1,14 @@
 cabal-version: 3.8
 name: aihc-parser
-version: 1.0.0.0
+version: 1.0.0.1
 build-type: Simple
 license: Unlicense
 license-file: LICENSE
 extra-doc-files: CHANGELOG.md
+extra-source-files:
+  test/Test/Fixtures/**/*.hs
+  test/Test/Fixtures/**/*.yaml
+
 author: David Himmelstrup
 maintainer: lemmih@gmail.com
 category: Development
@@ -242,77 +246,4 @@ test-suite spec
     -rtsopts
     -with-rtsopts=-N
 
-  default-language: GHC2021
-
-executable parser-progress
-  hs-source-dirs:
-    app/parser-progress
-
-  main-is: Main.hs
-  build-depends:
-    Cabal-syntax >=3.14 && <3.17,
-    Diff >=1.0 && <1.1,
-    aihc-cpp >=1.0 && <1.1,
-    aihc-hackage >=0.1 && <0.2,
-    aihc-parser >=1.0 && <1.1,
-    aihc-parser:parser-tooling-common,
-    base >=4.16 && <5,
-    bytestring >=0.10.8 && <0.13,
-    containers >=0.5 && <0.8,
-    deepseq >=1.4 && <1.6,
-    directory >=1.2.3 && <1.5,
-    filepath >=1.3.0.1 && <1.6,
-    ghc-lib-parser >=9.14.1 && <9.15,
-    prettyprinter >=1.7 && <1.8,
-    text >=1.2 && <2.2,
-
-  ghc-options: -Wall
-  default-language: GHC2021
-
-executable lexer-progress
-  hs-source-dirs:
-    app/lexer-progress
-
-  main-is: Main.hs
-  build-depends:
-    aeson >=2.0 && <2.3,
-    aihc-parser >=1.0 && <1.1,
-    aihc-parser:parser-tooling-common,
-    base >=4.16 && <5,
-    bytestring >=0.10.8 && <0.13,
-    containers >=0.5 && <0.8,
-    directory >=1.2.3 && <1.5,
-    filepath >=1.3.0.1 && <1.6,
-    text >=1.2 && <2.2,
-    yaml >=0.11 && <0.12,
-
-  ghc-options: -Wall
-  default-language: GHC2021
-
-executable extension-progress
-  hs-source-dirs:
-    app/extension-progress
-
-  main-is: Main.hs
-  build-depends:
-    Cabal-syntax >=3.14 && <3.17,
-    Diff >=1.0 && <1.1,
-    aeson >=2.0 && <2.3,
-    aihc-cpp >=1.0 && <1.1,
-    aihc-hackage >=0.1 && <0.2,
-    aihc-parser >=1.0 && <1.1,
-    aihc-parser:parser-tooling-common,
-    base >=4.16 && <5,
-    bytestring >=0.10.8 && <0.13,
-    containers >=0.5 && <0.8,
-    deepseq >=1.4 && <1.6,
-    directory >=1.2.3 && <1.5,
-    filepath >=1.3.0.1 && <1.6,
-    ghc-lib-parser >=9.14.1 && <9.15,
-    megaparsec >=9.0 && <10,
-    prettyprinter >=1.7 && <1.8,
-    text >=1.2 && <2.2,
-    yaml >=0.11 && <0.12,
-
-  ghc-options: -Wall
   default-language: GHC2021

--- a/components/aihc-parser/app/extension-progress/Main.hs
+++ b/components/aihc-parser/app/extension-progress/Main.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 
-import Aihc.Parser.Syntax qualified as Syntax
 import Data.List (sortOn)
 import Data.Map.Strict qualified as M
+import Data.Text (Text)
 import Data.Text qualified as T
 import ExtensionSupport
 import ParserGolden qualified as PG
@@ -103,7 +104,7 @@ convertGoldenStatus status =
 
 groupByExtension ::
   [(CaseMeta, Outcome, String)] ->
-  M.Map Syntax.Extension [(CaseMeta, Outcome, String)]
+  M.Map Text [(CaseMeta, Outcome, String)]
 groupByExtension =
   foldl' insertCase M.empty
   where
@@ -111,9 +112,9 @@ groupByExtension =
       foldl'
         (\m ext -> M.insertWith (<>) ext [caseOutcome] m)
         acc
-        [ext | Syntax.EnableExtension ext <- caseExtensions meta]
+        (caseEnabledExtensionNames meta)
 
-mkExtensionResult :: (Syntax.Extension, [(CaseMeta, Outcome, String)]) -> ExtensionResult
+mkExtensionResult :: (Text, [(CaseMeta, Outcome, String)]) -> ExtensionResult
 mkExtensionResult (name, outcomes) =
   let passN = countOutcome OutcomePass outcomes
       xfailN = countOutcome OutcomeXFail outcomes
@@ -124,7 +125,7 @@ mkExtensionResult (name, outcomes) =
         | failN == 0 && xfailN == 0 && xpassN == 0 = Supported
         | otherwise = InProgress
    in ExtensionResult
-        { erName = T.unpack (Syntax.extensionName name),
+        { erName = T.unpack name,
           erStatus = status,
           erPassN = passN,
           erXFailN = xfailN,

--- a/components/aihc-parser/app/parser-progress/Main.hs
+++ b/components/aihc-parser/app/parser-progress/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where

--- a/components/aihc-parser/common/ExtensionSupport.hs
+++ b/components/aihc-parser/common/ExtensionSupport.hs
@@ -6,6 +6,7 @@ module ExtensionSupport
     CaseMeta (..),
     oracleFixtureRoot,
     caseSourcePath,
+    caseEnabledExtensionNames,
     loadOracleCases,
     classifyOutcome,
     finalizeOutcome,
@@ -46,6 +47,10 @@ oracleFixtureRoot = "test/Test/Fixtures/oracle"
 
 caseSourcePath :: CaseMeta -> FilePath
 caseSourcePath meta = oracleFixtureRoot </> casePath meta
+
+caseEnabledExtensionNames :: CaseMeta -> [Text]
+caseEnabledExtensionNames meta =
+  [Syntax.extensionName ext | Syntax.EnableExtension ext <- caseExtensions meta]
 
 loadOracleCases :: IO [CaseMeta]
 loadOracleCases = do

--- a/scripts/nix/apps.nix
+++ b/scripts/nix/apps.nix
@@ -4,9 +4,6 @@
   mkCoverageReport,
 }: pkgs: let
   hsPkgs = mkHsPkgs pkgs;
-  parserProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "parser-progress";
-  lexerProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "lexer-progress";
-  extensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-parser "extension-progress";
   resolveProgressExe = pkgs.lib.getExe' hsPkgs.aihc-resolve "resolve-progress";
   resolveExtensionProgressExe = pkgs.lib.getExe' hsPkgs.aihc-resolve "resolve-extension-progress";
   tcProgressExe = pkgs.lib.getExe' hsPkgs.aihc-tc "tc-progress";
@@ -17,6 +14,17 @@
     p.aihc-cpp
     p.cpphs
   ]);
+  parserProgressEnv = hsPkgs.ghcWithPackages (p: [
+    p.aihc-parser
+  ]);
+  parserProgressRunghcSetup = ''
+    run_parser_progress() {
+      local parser_pkg tooling_pkg
+      parser_pkg="$(ghc-pkg describe aihc-parser | awk '/^id:/{gsub(/^id:[ \t]*/, ""); print; exit}')"
+      tooling_pkg="$(ghc-pkg describe z-aihc-parser-z-parser-tooling-common | awk '/^id:/{getline; gsub(/^[ \t]+/, ""); print; exit}')"
+      runghc -package-env - -XGHC2021 -package-id="$parser_pkg" -package-id="$tooling_pkg" "$@"
+    }
+  '';
 
   repoRootGuard = ''
     test -d components/aihc-parser || {
@@ -137,16 +145,19 @@ in {
     cabal test --test-show-details=direct
   '';
 
-  parser-progress = mkComponentApp "parser-progress" "components/aihc-parser" ''
-    ${parserProgressExe}
+  parser-progress = mkComponentAppWithInputs "parser-progress" [pkgs.bash parserProgressEnv] "components/aihc-parser" ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/parser-progress/Main.hs "$@"
   '';
 
-  lexer-progress = mkComponentApp "lexer-progress" "components/aihc-parser" ''
-    ${lexerProgressExe}
+  lexer-progress = mkComponentAppWithInputs "lexer-progress" [pkgs.bash parserProgressEnv] "components/aihc-parser" ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/lexer-progress/Main.hs "$@"
   '';
 
-  parser-extension-progress = mkComponentApp "parser-extension-progress" "components/aihc-parser" ''
-    ${extensionProgressExe} "$@"
+  parser-extension-progress = mkComponentAppWithInputs "parser-extension-progress" [pkgs.bash parserProgressEnv] "components/aihc-parser" ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/extension-progress/Main.hs "$@"
   '';
 
   aihc-dev = mkAppWithInputs "aihc-dev" [pkgs.bash hsPkgs.ghc] ''
@@ -157,16 +168,19 @@ in {
     exec ${aihcExe} "$@"
   '';
 
-  parser-progress-strict = mkComponentApp "parser-progress-strict" "components/aihc-parser" ''
-    ${parserProgressExe} --strict
+  parser-progress-strict = mkComponentAppWithInputs "parser-progress-strict" [pkgs.bash parserProgressEnv] "components/aihc-parser" ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/parser-progress/Main.hs --strict
   '';
 
-  lexer-progress-strict = mkComponentApp "lexer-progress-strict" "components/aihc-parser" ''
-    ${lexerProgressExe} --strict
+  lexer-progress-strict = mkComponentAppWithInputs "lexer-progress-strict" [pkgs.bash parserProgressEnv] "components/aihc-parser" ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/lexer-progress/Main.hs --strict
   '';
 
-  parser-extension-progress-strict = mkComponentApp "parser-extension-progress-strict" "components/aihc-parser" ''
-    ${extensionProgressExe} --strict "$@"
+  parser-extension-progress-strict = mkComponentAppWithInputs "parser-extension-progress-strict" [pkgs.bash parserProgressEnv] "components/aihc-parser" ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/extension-progress/Main.hs --strict "$@"
   '';
 
   cpp-test = mkComponentApp "cpp-test" "components/aihc-cpp" ''

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -41,13 +41,21 @@
       touch "$out"
     '';
 
-  mkProgressCheck = name: src: package: command:
-    mkSourceCheck name src [package] command;
-
   cppProgressEnv = hsPkgs.ghcWithPackages (p: [
     p.aihc-cpp
     p.cpphs
   ]);
+  parserProgressEnv = hsPkgs.ghcWithPackages (p: [
+    p.aihc-parser
+  ]);
+  parserProgressRunghcSetup = ''
+    run_parser_progress() {
+      local parser_pkg tooling_pkg
+      parser_pkg="$(ghc-pkg describe aihc-parser | awk '/^id:/{gsub(/^id:[ \t]*/, ""); print; exit}')"
+      tooling_pkg="$(ghc-pkg describe z-aihc-parser-z-parser-tooling-common | awk '/^id:/{getline; gsub(/^[ \t]+/, ""); print; exit}')"
+      runghc -package-env - -XGHC2021 -package-id="$parser_pkg" -package-id="$tooling_pkg" "$@"
+    }
+  '';
 
   parserTests = mkPackageTest hsPkgs.aihc-parser;
   cppTests = mkPackageTest hsPkgs.aihc-cpp;
@@ -84,16 +92,19 @@
     test "$failed" -eq 0
   '';
 
-  parserProgressStrict = mkProgressCheck "aihc-parser-progress-strict" (sources.parserSrc pkgs) hsPkgs.aihc-parser ''
-    parser-progress --strict
+  parserProgressStrict = mkSourceCheck "aihc-parser-progress-strict" (sources.parserSrc pkgs) [parserProgressEnv] ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/parser-progress/Main.hs --strict
   '';
 
-  lexerProgressStrict = mkProgressCheck "aihc-lexer-progress-strict" (sources.parserSrc pkgs) hsPkgs.aihc-parser ''
-    lexer-progress --strict
+  lexerProgressStrict = mkSourceCheck "aihc-lexer-progress-strict" (sources.parserSrc pkgs) [parserProgressEnv] ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/lexer-progress/Main.hs --strict
   '';
 
-  parserExtensionProgressStrict = mkProgressCheck "aihc-parser-extension-progress-strict" (sources.parserSrc pkgs) hsPkgs.aihc-parser ''
-    extension-progress --strict
+  parserExtensionProgressStrict = mkSourceCheck "aihc-parser-extension-progress-strict" (sources.parserSrc pkgs) [parserProgressEnv] ''
+    ${parserProgressRunghcSetup}
+    run_parser_progress app/extension-progress/Main.hs --strict
   '';
 
   cppProgressStrict = mkSourceCheck "aihc-cpp-progress-strict" (sources.cppSrc pkgs) [cppProgressEnv] ''


### PR DESCRIPTION
## Summary

- release `aihc-parser-1.0.0.1`
- remove the internal parser progress executables from the published Cabal file so Hackage lists the package as a library
- include all parser fixture `.hs` and `.yaml` files in the sdist so Hackage can run tests and report coverage
- keep the Nix progress apps/checks by running the internal scripts with `runghc` from the Nix-provided `ghcWithPackages` environment

## Progress counts

- Parser progress: 1202 / 1202 PASS, 0 XFAIL, 0 XPASS, 0 FAIL
- Lexer progress: 104 / 104 PASS, 0 XFAIL, 0 XPASS, 0 FAIL
- Parser extension support: 83 / 83 supported, 0 in progress

## Validation

- `just fmt`
- `cabal check` in `components/aihc-parser`
- `cabal sdist` in `components/aihc-parser`
- verified `dist-newstyle/sdist/aihc-parser-1.0.0.1.tar.gz` has 1602 fixture files, no `app/` files, and no executable stanzas
- unpacked the sdist and ran `cabal test -v0 aihc-parser:spec --test-options=--hide-successes` with local `aihc-cpp` and `aihc-hackage`: all 1858 tests passed
- `nix run .#parser-progress-strict`
- `nix run .#lexer-progress-strict`
- `nix run .#parser-extension-progress-strict`
- `just check`
- `nix flake check -L`

## Release note

The public `aihc-parser` library component does not depend on `aihc-hackage`, but the Hackage tester tooling/test components still do. The sdist test above wires in the local `tooling/aihc-hackage`; publishing or otherwise making `aihc-hackage` available is still required if Hackage is expected to run those test components from the public index.
