### PR TITLE
chore(aihc-parser): simplify package synopsis

### DIFF
--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -12,7 +12,7 @@ extra-source-files:
 author: David Himmelstrup
 maintainer: lemmih@gmail.com
 category: Development
-synopsis: From-scratch Haskell parser with differential tests
+synopsis: Haskell parser
 description:
   A from-scratch Haskell parser with lexer, syntax tree, and pretty-printer.
   The package is validated with golden tests and oracle-backed differential


### PR DESCRIPTION
## Summary

- Shorten the `aihc-parser` package synopsis to `Haskell parser`.

## Impact

- Package metadata now uses a concise synopsis while leaving the fuller description intact.

## Progress counts

- No progress counts changed.

## Validation

- `just fmt`
- `just check`