### PR TITLE
feat(tc): track stackage progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Find more information here:
 
 | Name               | Progress                                                                                                                             |
 | ------------------ | -----------------------------------------------------------------------------------------------------------------------------------: |
-| TypeCheck Stackage | `0/3390` (`0.00%`) ○○○○○                                                                                                              |
+| TypeCheck Stackage | <!-- AUTO-GENERATED: START tc-stackage-progress --> `0/3390` (`0.00%`) ○○○○○ <!-- AUTO-GENERATED: END tc-stackage-progress -->             |
 | Resolve Stackage   | <!-- AUTO-GENERATED: START resolve-stackage-progress --> `218/3427` (`6.36%`) ○○○○○ <!-- AUTO-GENERATED: END resolve-stackage-progress -->  |
 | Parser Stackage    | <!-- AUTO-GENERATED: START parser-stackage-progress --> `2937/2937` (`100.00%`) ●●●●● <!-- AUTO-GENERATED: END parser-stackage-progress --> |
 | &nbsp; | &nbsp; |

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -48,6 +48,7 @@ tc_cmd="${TC_PROGRESS_CMD:-nix run .#tc-progress}"
 tc_extension_markdown_cmd="${TC_EXTENSION_PROGRESS_CMD:-nix run .#tc-extension-progress}"
 stackage_cmd="${PARSER_STACKAGE_PROGRESS_CMD:-nix run .#aihc-dev -- parser-stackage-progress --snapshot lts-24.33 --jobs 1}"
 resolve_stackage_cmd="${RESOLVE_STACKAGE_PROGRESS_CMD:-nix run .#aihc-dev -- resolve-stackage-progress --snapshot lts-24.33}"
+tc_stackage_cmd="${TC_STACKAGE_PROGRESS_CMD:-nix run .#aihc-dev -- tc-stackage-progress --snapshot lts-24.33}"
 line_counts_cmd="${LINE_COUNTS_CMD:-nix run .#line-counts}"
 
 tmpdir="$(mktemp -d)"
@@ -67,6 +68,7 @@ tc_out="$tmpdir/tc-progress.txt"
 tc_extension_out="$tmpdir/tc-extension-progress.md"
 stackage_out="$tmpdir/stackage-progress.txt"
 resolve_stackage_out="$tmpdir/resolve-stackage-progress.txt"
+tc_stackage_out="$tmpdir/tc-stackage-progress.txt"
 line_counts_out="$tmpdir/line-counts.txt"
 
 run_cmd "$parser_cmd" >"$parser_out"
@@ -80,6 +82,7 @@ run_cmd "$tc_cmd" >"$tc_out"
 run_cmd "$tc_extension_markdown_cmd" | sed -n '/^# Type Checker Extension Support Status/,$p' >"$tc_extension_out"
 run_cmd "$stackage_cmd" >"$stackage_out" || true
 run_cmd "$resolve_stackage_cmd" >"$resolve_stackage_out" || true
+run_cmd "$tc_stackage_cmd" >"$tc_stackage_out" || true
 run_cmd "$line_counts_cmd" >"$line_counts_out"
 
 parse_progress() {
@@ -197,6 +200,23 @@ parse_resolve_stackage_progress() {
   ' "$infile"
 }
 
+parse_tc_stackage_progress() {
+	local infile="$1"
+	awk '
+    /^  Typechecked:[[:space:]]+/ {
+      implemented = $2 + 0
+      total = $4 + 0
+    }
+    END {
+      if (total == "" || total <= 0) {
+        exit 2
+      }
+      complete = (implemented * 100.0) / total
+      printf "%d\n%d\n%.2f\n", implemented, total, complete
+    }
+  ' "$infile"
+}
+
 progress_circles() {
 	local complete="$1"
 	awk -v complete="$complete" '
@@ -301,6 +321,14 @@ resolve_stackage_implemented="${resolve_stackage_vals[0]}"
 resolve_stackage_total="${resolve_stackage_vals[1]}"
 resolve_stackage_complete="${resolve_stackage_vals[2]}"
 
+tc_stackage_vals=($(parse_tc_stackage_progress "$tc_stackage_out")) || {
+	echo "update-generated-content.sh: could not parse tc-stackage-progress output (expected '  Typechecked: N / M' line on stdout)." >&2
+	exit 2
+}
+tc_stackage_implemented="${tc_stackage_vals[0]}"
+tc_stackage_total="${tc_stackage_vals[1]}"
+tc_stackage_complete="${tc_stackage_vals[2]}"
+
 parser_total_tests=$((parser_total + ext_test_total))
 parser_passing_tests=$((parser_implemented + ext_implemented))
 parser_total_complete="$(awk -v passing="$parser_passing_tests" -v total="$parser_total_tests" 'BEGIN { if (total <= 0) { printf "0.00" } else { printf "%.2f", (passing * 100.0) / total } }')"
@@ -308,6 +336,7 @@ parser_total_circles="$(progress_circles "$parser_total_complete")"
 cpp_circles="$(progress_circles "$cpp_complete")"
 stackage_circles="$(progress_circles "$stackage_complete")"
 resolve_stackage_circles="$(progress_circles "$resolve_stackage_complete")"
+tc_stackage_circles="$(progress_circles "$tc_stackage_complete")"
 lexer_circles="$(progress_circles "$lexer_complete")"
 resolve_circles="$(progress_circles "$resolve_complete")"
 tc_circles="$(progress_circles "$tc_complete")"
@@ -326,6 +355,10 @@ EOF2
 
 cat >"$tmpdir/readme-root-resolve-stackage.txt" <<EOF2
 \`${resolve_stackage_implemented}/${resolve_stackage_total}\` (\`${resolve_stackage_complete}%\`) ${resolve_stackage_circles}
+EOF2
+
+cat >"$tmpdir/readme-root-tc-stackage.txt" <<EOF2
+\`${tc_stackage_implemented}/${tc_stackage_total}\` (\`${tc_stackage_complete}%\`) ${tc_stackage_circles}
 EOF2
 
 cat >"$tmpdir/readme-root-lexer.txt" <<EOF2
@@ -470,6 +503,7 @@ replace_marker_inline README.md "parser-progress" "$tmpdir/readme-root-parser.tx
 replace_marker_inline README.md "lexer-progress" "$tmpdir/readme-root-lexer.txt"
 replace_marker_inline README.md "parser-stackage-progress" "$tmpdir/readme-root-stackage.txt"
 replace_marker_inline README.md "resolve-stackage-progress" "$tmpdir/readme-root-resolve-stackage.txt"
+replace_marker_inline README.md "tc-stackage-progress" "$tmpdir/readme-root-tc-stackage.txt"
 replace_marker_inline README.md "cpp-progress" "$tmpdir/readme-root-cpp.txt"
 replace_marker_inline README.md "resolve-progress" "$tmpdir/readme-root-resolve.txt"
 replace_marker_inline README.md "tc-progress" "$tmpdir/readme-root-tc.txt"

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -143,6 +143,7 @@ executable aihc-dev
     app/hackage-progress
     app/stackage-progress
     app/resolve-stackage-progress
+    app/tc-stackage-progress
 
   other-modules:
     Aihc.Dev.HackageTester.Run
@@ -157,6 +158,7 @@ executable aihc-dev
     StackageProgress.PackageRunner
     StackageProgress.Run
     StackageProgress.Snapshot
+    TcStackageProgress
 
   build-depends:
     Cabal-syntax >=3.14 && <3.17,
@@ -171,6 +173,7 @@ executable aihc-dev
     aihc-parser,
     aihc-parser-tooling-common,
     aihc-resolve,
+    aihc-tc,
     async,
     base >=4.16 && <5,
     bytestring >=0.10.8 && <0.13,
@@ -203,6 +206,7 @@ test-suite spec
     app/hackage-progress
     app/stackage-progress
     app/resolve-stackage-progress
+    app/tc-stackage-progress
 
   main-is: Spec.hs
   other-modules:
@@ -217,6 +221,7 @@ test-suite spec
     StackageProgress.PackageRunner
     StackageProgress.Run
     StackageProgress.Snapshot
+    TcStackageProgress
     Test.ExtractHiCompare
     Test.GoldenUpdate
     Test.ParserCLI.Golden
@@ -225,6 +230,7 @@ test-suite spec
     Test.ResolveStackageProgress.PathsModule
     Test.StackageProgress.FileChecker
     Test.StackageProgress.FileCheckerTiming
+    Test.TcStackageProgress
 
   build-depends:
     Cabal-syntax >=3.14 && <3.17,
@@ -241,6 +247,7 @@ test-suite spec
     aihc-parser-tooling-common,
     aihc-prim,
     aihc-resolve,
+    aihc-tc,
     async,
     base >=4.16 && <5,
     bytestring,

--- a/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
@@ -10,8 +10,10 @@ module ResolveStackageProgress
     gatherDepExports,
     kahnLayers,
     optionsParser,
+    parseFileInfo,
     phase1Parallel,
     processLayers,
+    renderResolveError,
     resolveOnePackage,
     run,
   )

--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -1,0 +1,288 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module TcStackageProgress
+  ( Options (..),
+    PackageCounts (..),
+    optionsParser,
+    processLayers,
+    summarizePackageStatuses,
+    typecheckOnePackage,
+    run,
+  )
+where
+
+import Aihc.Hackage.Stackage (loadStackageSnapshot)
+import Aihc.Hackage.Types (PackageSpec (..))
+import Aihc.Resolve (ModuleExports, ResolveResult (..), extractInterface, resolveWithDeps)
+import Aihc.Tc (TcModuleResult (..), typecheck)
+import BootInterface (bootPackageNames, loadBootInterfaces)
+import Control.Concurrent.Async (replicateConcurrently_)
+import Control.Concurrent.Chan (newChan, readChan, writeChan)
+import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
+import Control.Exception (SomeException, displayException, evaluate, try)
+import Control.Monad qualified
+import Data.List (partition, sortOn)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Conc (getNumProcessors)
+import Options.Applicative qualified as OA
+import ResolveStackageProgress qualified as RSP
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hIsTerminalDevice, hPutStrLn, stderr, stdout)
+
+data Options = Options
+  { optSnapshot :: String,
+    optJobs :: Int,
+    optOffline :: Bool,
+    optTopFailures :: Int
+  }
+
+optionsParser :: OA.Parser Options
+optionsParser =
+  Options
+    <$> OA.strOption
+      ( OA.long "snapshot"
+          <> OA.metavar "SNAPSHOT"
+          <> OA.value "lts-24.33"
+          <> OA.showDefault
+          <> OA.help "Stackage snapshot to type-check"
+      )
+    <*> OA.option
+      OA.auto
+      ( OA.long "jobs"
+          <> OA.metavar "N"
+          <> OA.value 0
+          <> OA.help "Number of parallel jobs (default: CPU cores)"
+      )
+    <*> OA.switch
+      ( OA.long "offline"
+          <> OA.help "Use only cached packages, don't download"
+      )
+    <*> OA.option
+      OA.auto
+      ( OA.long "top"
+          <> OA.metavar "N"
+          <> OA.value 10
+          <> OA.showDefault
+          <> OA.help "Number of top failing packages to display"
+      )
+
+data PackageCounts = PackageCounts
+  { countTypechecked :: !Int,
+    countFailed :: !Int,
+    countSkipped :: !Int,
+    countTotal :: !Int
+  }
+  deriving (Eq, Show)
+
+summarizePackageStatuses :: Map Text RSP.PackageStatus -> PackageCounts
+summarizePackageStatuses results =
+  PackageCounts
+    { countTypechecked = length [() | RSP.PkgSuccess _ <- statuses],
+      countFailed = length [() | RSP.PkgFailed _ <- statuses],
+      countSkipped = length [() | RSP.PkgSkipped <- statuses],
+      countTotal = length statuses
+    }
+  where
+    statuses = Map.elems results
+
+hasFailedDep :: Map Text RSP.PackageStatus -> Map Text [Text] -> Text -> Bool
+hasFailedDep completed depGraph pkg =
+  any isFailure [Map.findWithDefault RSP.PkgSkipped dep completed | dep <- deps]
+  where
+    deps = Map.findWithDefault [] pkg depGraph
+    isFailure (RSP.PkgFailed _) = True
+    isFailure RSP.PkgSkipped = True
+    isFailure _ = False
+
+gatherDepExports :: ModuleExports -> Text -> Map Text RSP.PackageStatus -> Map Text [Text] -> ModuleExports
+gatherDepExports ambientExports pkg completed depGraph =
+  foldl'
+    Map.union
+    ambientExports
+    [ iface
+    | dep <- Map.findWithDefault [] pkg depGraph,
+      Just (RSP.PkgSuccess iface) <- [Map.lookup dep completed]
+    ]
+
+processLayer ::
+  Options ->
+  ModuleExports ->
+  [Text] ->
+  Map Text RSP.PackageInfo ->
+  Map Text RSP.PackageStatus ->
+  Map Text [Text] ->
+  IO (Map Text RSP.PackageStatus)
+processLayer opts ambientExports layer infos completed depGraph = do
+  let (toSkip, toProcess) = partition (hasFailedDep completed depGraph) layer
+      withSkips = foldl' (\m p -> Map.insert p RSP.PkgSkipped m) completed toSkip
+  if null toProcess
+    then pure withSkips
+    else do
+      let workerCount = max 1 (min (optJobs opts) (length toProcess))
+      queue <- newChan
+      mapM_ (writeChan queue . Just) toProcess
+      replicateM_ workerCount (writeChan queue Nothing)
+      resultVar <- newMVar withSkips
+      let worker = do
+            next <- readChan queue
+            case next of
+              Nothing -> pure ()
+              Just pkg -> do
+                current <- readMVar resultVar
+                let depExports = gatherDepExports ambientExports pkg current depGraph
+                    info = Map.findWithDefault (RSP.PackageInfo "" [] []) pkg infos
+                status <- typecheckOnePackage (optOffline opts) pkg info depExports
+                modifyMVar_ resultVar (pure . Map.insert pkg status)
+                worker
+      replicateConcurrently_ workerCount worker
+      readMVar resultVar
+
+processLayers ::
+  Options ->
+  ModuleExports ->
+  [[Text]] ->
+  Map Text RSP.PackageInfo ->
+  Map Text [Text] ->
+  Map Text RSP.PackageStatus ->
+  IO (Map Text RSP.PackageStatus)
+processLayers opts ambientExports layers infos depGraph = go layers
+  where
+    go [] acc = pure acc
+    go (layer : rest) acc = do
+      acc' <- processLayer opts ambientExports layer infos acc depGraph
+      go rest acc'
+
+typecheckOnePackage :: Bool -> Text -> RSP.PackageInfo -> ModuleExports -> IO RSP.PackageStatus
+typecheckOnePackage offline pkg info depExports = do
+  result <- try (typecheckOnePackageOrThrow offline pkg info depExports)
+  pure $ case result of
+    Left (e :: SomeException) -> RSP.PkgFailed (displayException e)
+    Right status -> status
+
+typecheckOnePackageOrThrow :: Bool -> Text -> RSP.PackageInfo -> ModuleExports -> IO RSP.PackageStatus
+typecheckOnePackageOrThrow _offline _pkg info depExports = do
+  let rawFiles = RSP.piFiles info
+  if null rawFiles
+    then pure (RSP.PkgSuccess depExports)
+    else do
+      parseResults <- mapM (RSP.parseFileInfo (RSP.piSrcDir info)) rawFiles
+      let (errs, pairs) = partitionEithers parseResults
+      case errs of
+        (e : _) -> pure (RSP.PkgFailed e)
+        [] -> do
+          let modules = map fst pairs
+              srcTexts = Map.fromList [(path, src) | (_, (path, src)) <- pairs]
+              resolveResult = resolveWithDeps depExports modules
+              !annCount = sum (map (length . snd) (resolvedAnnotations resolveResult))
+          _ <- evaluate annCount
+          case resolveErrors resolveResult of
+            [] -> typecheckResolvedPackage resolveResult
+            resolveErrs -> pure (RSP.PkgFailed (unlines (map (RSP.renderResolveError srcTexts) resolveErrs)))
+
+typecheckResolvedPackage :: ResolveResult -> IO RSP.PackageStatus
+typecheckResolvedPackage resolveResult = do
+  let results = typecheck (resolvedModules resolveResult)
+      !diagCount = sum (map (length . tcmDiagnostics) results)
+  _ <- evaluate diagCount
+  if all tcmSuccess results
+    then pure (RSP.PkgSuccess (extractInterface resolveResult))
+    else pure (RSP.PkgFailed (renderTcDiagnostics results))
+
+renderTcDiagnostics :: [TcModuleResult] -> String
+renderTcDiagnostics results =
+  unlines [show diag | result <- results, diag <- tcmDiagnostics result]
+
+reportResults :: Int -> Map Text RSP.PackageStatus -> IO ()
+reportResults topN results = do
+  let counts = summarizePackageStatuses results
+      allList = Map.toList results
+      failed = [(pkg, msg) | (pkg, RSP.PkgFailed msg) <- allList]
+  putStrLn ""
+  putStrLn "Type checker results:"
+  putStrLn $ "  Typechecked: " ++ show (countTypechecked counts) ++ " / " ++ show (countTotal counts) ++ " (" ++ show (pct (countTypechecked counts) (countTotal counts)) ++ "%)"
+  putStrLn $ "  Failed:      " ++ show (countFailed counts) ++ " (parse, resolver, or type-checker errors)"
+  putStrLn $ "  Skipped:     " ++ show (countSkipped counts) ++ " (dep had failure)"
+  let n = min topN (countFailed counts)
+  Control.Monad.when (n > 0) $ do
+    putStrLn ""
+    putStrLn $ "Top " ++ show n ++ " failing packages:"
+    let sorted = take n (sortOn (length . snd) failed)
+    mapM_ printFailure sorted
+  if countTypechecked counts == countTotal counts then exitSuccess else exitFailure
+  where
+    printFailure (pkg, msg) = do
+      putStrLn $ "  " ++ T.unpack pkg ++ ":"
+      mapM_ (\l -> putStrLn ("    " ++ l)) (take 5 (lines msg))
+
+pct :: Int -> Int -> Int
+pct _ 0 = 100
+pct n total = (n * 100) `div` total
+
+run :: Options -> IO ()
+run opts0 = do
+  jobs <- if optJobs opts0 == 0 then getNumProcessors else pure (optJobs opts0)
+  let opts = opts0 {optJobs = jobs}
+
+  snapshotResult <- loadStackageSnapshot Nothing (optSnapshot opts) (optOffline opts)
+  packages <- case snapshotResult of
+    Left err -> hPutStrLn stderr ("Failed to load snapshot: " ++ err) >> exitFailure
+    Right pkgs -> pure pkgs
+
+  let total = length packages
+      snapshotNames = Set.fromList (map (T.pack . pkgName) packages)
+      (bootPkgs, regularPkgs) = partition isBootPkg packages
+      isBootPkg p = T.pack (pkgName p) `Set.member` bootPackageNames
+      progressOptions =
+        RSP.Options
+          { RSP.optSnapshot = optSnapshot opts,
+            RSP.optJobs = optJobs opts,
+            RSP.optOffline = optOffline opts,
+            RSP.optTopFailures = optTopFailures opts
+          }
+
+  putStrLn "Loading boot interfaces..."
+  bootIfaceMap <- loadBootInterfaces
+  let bootExports = foldl' Map.union Map.empty (Map.elems bootIfaceMap)
+      bootResults =
+        Map.fromList
+          [ (T.pack (pkgName p), RSP.PkgSuccess (Map.findWithDefault Map.empty (T.pack (pkgName p)) bootIfaceMap))
+          | p <- bootPkgs
+          ]
+
+  isStdoutTerminal <- hIsTerminalDevice stdout
+  putStrLn $ "Type-checking " ++ optSnapshot opts ++ " (" ++ show total ++ " packages, " ++ show jobs ++ " jobs)..."
+  putStrLn $ "  " ++ show (length bootPkgs) ++ " boot packages (pre-generated), " ++ show (length regularPkgs) ++ " to type-check from source"
+  putStrLn "Phase 1: downloading packages and collecting dependency info..."
+
+  infos <- RSP.phase1Parallel progressOptions regularPkgs snapshotNames isStdoutTerminal (length regularPkgs)
+
+  putStrLn "\nPhase 2: parsing, resolving, and type-checking packages in dependency order..."
+
+  let depGraph =
+        Map.fromList
+          [(name, RSP.piSnapshotDeps info) | (name, info) <- Map.toList infos]
+      layers = RSP.kahnLayers depGraph
+      coveredPkgs = Set.fromList (concat layers)
+      cyclePkgs = Set.difference (Set.fromList (map (T.pack . pkgName) regularPkgs)) coveredPkgs
+  if Set.null cyclePkgs
+    then pure ()
+    else hPutStrLn stderr ("Warning: " ++ show (Set.size cyclePkgs) ++ " packages in dep cycles, type-checking without dep interfaces")
+
+  results <- processLayers opts bootExports layers infos depGraph bootResults
+
+  reportResults (optTopFailures opts) results
+
+partitionEithers :: [Either a b] -> ([a], [b])
+partitionEithers [] = ([], [])
+partitionEithers (Left a : rest) = let (as, bs) = partitionEithers rest in (a : as, bs)
+partitionEithers (Right b : rest) = let (as, bs) = partitionEithers rest in (as, b : bs)
+
+replicateM_ :: Int -> IO () -> IO ()
+replicateM_ 0 _ = pure ()
+replicateM_ n action = action >> replicateM_ (n - 1) action

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -26,6 +26,7 @@ import StackageProgress.Run qualified as ParserStackageProgressRun
 import System.Directory (createDirectoryIfMissing)
 import System.Exit (exitFailure)
 import System.FilePath (takeDirectory)
+import TcStackageProgress qualified as TSP
 
 main :: IO ()
 main = do
@@ -52,6 +53,7 @@ data Command
   | ParserHackageProgress ParserHackageProgressCLI.Options
   | ResolvePackage RP.Options
   | ResolveStackageProgress RSP.Options
+  | TcStackageProgress TSP.Options
   | UpdateGoldens GoldenUpdate.Options
 
 data ExtractHiOpts = ExtractHiOpts
@@ -140,6 +142,12 @@ commandParser =
           ( info
               (ResolveStackageProgress <$> RSP.optionsParser <**> helper)
               (progDesc "Test name resolver on Stackage snapshot packages")
+          )
+        <> command
+          "tc-stackage-progress"
+          ( info
+              (TcStackageProgress <$> TSP.optionsParser <**> helper)
+              (progDesc "Test type checker on Stackage snapshot packages")
           )
         <> command
           "update-goldens"
@@ -250,5 +258,7 @@ runCommand (ResolvePackage opts) =
   RP.run opts
 runCommand (ResolveStackageProgress opts) =
   RSP.run opts
+runCommand (TcStackageProgress opts) =
+  TSP.run opts
 runCommand (UpdateGoldens opts) =
   GoldenUpdate.run opts

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -21,6 +21,7 @@ import Test.StackageProgress.FileCheckerTiming (stackageProgressFileCheckerTimin
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 import Test.Tasty.QuickCheck qualified as QC
+import Test.TcStackageProgress (tcStackageProgressTests)
 
 main :: IO ()
 main = do
@@ -76,6 +77,7 @@ main = do
       resolveStackagePathsModuleTests,
       stackageProgressFileCheckerTests,
       stackageProgressFileCheckerTimingTests,
+      tcStackageProgressTests,
       cliTestsTree
     ]
 

--- a/tooling/aihc-dev/test/Test/TcStackageProgress.hs
+++ b/tooling/aihc-dev/test/Test/TcStackageProgress.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.TcStackageProgress
+  ( tcStackageProgressTests,
+  )
+where
+
+import Data.Map.Strict qualified as Map
+import ResolveStackageProgress (PackageStatus (..))
+import TcStackageProgress (PackageCounts (..), summarizePackageStatuses)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+tcStackageProgressTests :: TestTree
+tcStackageProgressTests =
+  testGroup
+    "tc stackage progress"
+    [ testCase "counts typechecked, failed, and skipped packages" test_countsPackageStatuses
+    ]
+
+test_countsPackageStatuses :: IO ()
+test_countsPackageStatuses = do
+  let statuses =
+        Map.fromList
+          [ ("base", PkgSuccess Map.empty),
+            ("containers", PkgFailed "type error"),
+            ("text", PkgSkipped)
+          ]
+  assertEqual
+    "counts"
+    PackageCounts
+      { countTypechecked = 1,
+        countFailed = 1,
+        countSkipped = 1,
+        countTotal = 3
+      }
+    (summarizePackageStatuses statuses)


### PR DESCRIPTION
## Summary
- add `aihc-dev tc-stackage-progress` to process Stackage packages through parse, name resolution, and `aihc-tc`
- wire the root README TypeCheck Stackage row into generated report updates
- add an `aihc-dev` unit test for type-checker Stackage package status summaries

## Progress counts
- TypeCheck Stackage remains `0/3390` in the README placeholder; the row is now auto-generated from `tc-stackage-progress` during report generation.

## Validation
- `cabal test -v0 aihc-dev:spec --test-options=--hide-successes`
- mocked `scripts/update-generated-content.sh --check` for parser/resolve/tc Stackage output
- `just fmt`
- `just check`