### PR TITLE
ci: require GHC compatibility checks

### DIFF
--- a/.github/rulesets/main-pr-squash-only.json
+++ b/.github/rulesets/main-pr-squash-only.json
@@ -29,7 +29,11 @@
       "type": "required_status_checks",
       "parameters": {
         "contexts": [
-          "flake-check"
+          "flake-check",
+          "Build components with GHC 9.8.4",
+          "Build components with GHC 9.10.3",
+          "Build components with GHC 9.12.4",
+          "Build components with GHC 9.14.1"
         ],
         "strict": false
       }


### PR DESCRIPTION
## Summary

- Require the new GHC Compatibility matrix jobs in the checked-in main branch ruleset.
- Applied the live GitHub repository ruleset with `gh api` so `main` now requires `flake-check` plus GHC 9.8.4, 9.10.3, 9.12.4, and 9.14.1 compatibility checks.

## Progress Counts

- Unchanged; this PR does not affect generated progress counts.

## Validation

- `just fmt`
- `just check`
- `gh api repos/{owner}/{repo}/rulesets/13527763` verified the live required status check contexts.
