### PR TITLE
fix(tc): support as-patterns

### DIFF
--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -21,6 +21,7 @@ library
     Aihc.Tc.Generate.Bind
     Aihc.Tc.Generate.Decl
     Aihc.Tc.Generate.Expr
+    Aihc.Tc.Generate.Pattern
     Aihc.Tc.Instantiate
     Aihc.Tc.Kind
     Aihc.Tc.Monad

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Bind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Bind.hs
@@ -33,13 +33,14 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Generalize (generalizeIgnoring)
+import Aihc.Tc.Generate.Pattern
 import Aihc.Tc.Instantiate qualified
 import Aihc.Tc.Kind (sigToScheme)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)
-import Control.Monad (foldM, zipWithM)
+import Control.Monad (foldM)
 import Data.List (nub, (\\))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -221,12 +222,11 @@ tcMatches inferExpr matches@(m0 : _) = do
 tcMatchEquation :: InferExpr -> [TcType] -> TcType -> Match -> TcM [Ct]
 tcMatchEquation inferExpr argTys resTy match = do
   let pats = matchPats match
-      bindings = concatMap extractPatternBindings (zip pats argTys)
-  patCts <- concat <$> zipWithM (inferPatternConstraints NoSourceSpan) pats argTys
-  (rhsTy, rhsCts) <- withPatternBindings bindings (inferRhsWithLocals inferExpr (matchRhs match))
+  patCheck <- checkPatterns NoSourceSpan (zip pats argTys)
+  (rhsTy, rhsCts) <- withPatternBindings (pcBindings patCheck) (inferRhsWithLocals inferExpr (matchRhs match))
   ev <- freshEvVar
   let resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin NoSourceSpan) NoSourceSpan
-  pure (patCts ++ rhsCts ++ [resCt])
+  pure (pcWantedCts patCheck ++ rhsCts ++ [resCt])
 
 unifyMatchRhs :: InferExpr -> TcType -> Match -> TcM [Ct]
 unifyMatchRhs inferExpr expectedTy match = do
@@ -234,25 +234,6 @@ unifyMatchRhs inferExpr expectedTy match = do
   ev <- freshEvVar
   let eqCt = mkWantedCt (EqPred rhsTy expectedTy) ev (AppOrigin NoSourceSpan) NoSourceSpan
   pure (rhsCts ++ [eqCt])
-
-inferPatternConstraints :: SourceSpan -> Pattern -> TcType -> TcM [Ct]
-inferPatternConstraints sp pat scrutTy =
-  case pat of
-    PCon name _typeArgs _subPats -> do
-      let conName = nameToText name
-      mBinder <- lookupTerm conName
-      case mBinder of
-        Just (TcIdBinder _ scheme _) -> do
-          (conTy, _preds) <- Aihc.Tc.Instantiate.instantiate scheme
-          let conResTy = resultType conTy
-          ev <- freshEvVar
-          pure [mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp]
-        _ -> pure []
-    PAnn _ann inner -> inferPatternConstraints sp inner scrutTy
-    PParen inner -> inferPatternConstraints sp inner scrutTy
-    PStrict inner -> inferPatternConstraints sp inner scrutTy
-    PIrrefutable inner -> inferPatternConstraints sp inner scrutTy
-    _ -> pure []
 
 shouldGeneralizeLocal :: Set.Set Text -> [Decl] -> TcM Bool
 shouldGeneralizeLocal binderSet decls = do
@@ -352,43 +333,6 @@ patternBinderName (PVar n) = Just (renderBinderName n, unqualifiedNameText n)
 patternBinderName (PParen inner) = patternBinderName inner
 patternBinderName (PAnn _ inner) = patternBinderName inner
 patternBinderName _ = Nothing
-
-extractPatternBindings :: (Pattern, TcType) -> [(Text, TcType)]
-extractPatternBindings (pat, ty) =
-  case pat of
-    PVar uname -> [(unqualifiedNameText uname, ty)]
-    PAnn _ann inner -> extractPatternBindings (inner, ty)
-    PParen inner -> extractPatternBindings (inner, ty)
-    PWildcard {} -> []
-    PLit {} -> []
-    PNegLit {} -> []
-    PAs name inner -> (unqualifiedNameText name, ty) : extractPatternBindings (inner, ty)
-    PStrict inner -> extractPatternBindings (inner, ty)
-    PIrrefutable inner -> extractPatternBindings (inner, ty)
-    PCon _name _typeArgs subPats ->
-      concatMap (\p -> extractPatternBindings (p, ty)) subPats
-    PInfix lhs op rhs
-      | nameText op == ":" ->
-          let elemTy = listElementType ty
-           in extractPatternBindings (lhs, elemTy) ++ extractPatternBindings (rhs, ty)
-      | otherwise ->
-          extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)
-    _ -> []
-
-withPatternBindings :: [(Text, TcType)] -> TcM a -> TcM a
-withPatternBindings [] action = action
-withPatternBindings ((name, ty) : rest) action =
-  extendTermEnv name (TcMonoIdBinder name ty) (withPatternBindings rest action)
-
-listElementType :: TcType -> TcType
-listElementType ty =
-  case ty of
-    TcTyCon (TyCon "[]" 1) [elemTy] -> elemTy
-    _ -> ty
-
-resultType :: TcType -> TcType
-resultType (TcFunTy _ res) = resultType res
-resultType ty = ty
 
 renderBinderName :: UnqualifiedName -> Text
 renderBinderName uname =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -70,6 +70,7 @@ import Aihc.Tc.Evidence (Coercion (..), EvTerm (..))
 import Aihc.Tc.Generalize (generalizeIgnoring)
 import Aihc.Tc.Generate.Bind (inferLocalDeclBinders, inferRhsWithLocals)
 import Aihc.Tc.Generate.Expr (inferExpr)
+import Aihc.Tc.Generate.Pattern
 import Aihc.Tc.Instantiate qualified
 import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkSurfaceType, convertSurfaceType, defaultKindMetas, freeTypeVars, freshKindMeta, kindToTcType, makeParamEnv, sigToScheme, surfacePredToPred, tyConKindFromParams)
 import Aihc.Tc.Monad
@@ -1092,17 +1093,17 @@ freeVarsRhs rhs =
 freeVarsExpr :: Expr -> [Text]
 freeVarsExpr expr =
   case expr of
-    EVar name -> [patNameToText name]
+    EVar name -> [nameToText name]
     EAnn _ inner -> freeVarsExpr inner
     EIf cond trueBranch falseBranch ->
       freeVarsExpr cond ++ freeVarsExpr trueBranch ++ freeVarsExpr falseBranch
     ELambdaPats pats body ->
       freeVarsExpr body \\ concatMap patternBinders pats
     EInfix lhs op rhs ->
-      patNameToText op : freeVarsExpr lhs ++ freeVarsExpr rhs
+      nameToText op : freeVarsExpr lhs ++ freeVarsExpr rhs
     ENegate inner -> freeVarsExpr inner
-    ESectionL inner op -> patNameToText op : freeVarsExpr inner
-    ESectionR op inner -> patNameToText op : freeVarsExpr inner
+    ESectionL inner op -> nameToText op : freeVarsExpr inner
+    ESectionR op inner -> nameToText op : freeVarsExpr inner
     ELetDecls decls body ->
       let localBinders = concatMap declBinders decls
        in (concatMap freeVarsDecl decls ++ freeVarsExpr body) \\ localBinders
@@ -1541,17 +1542,14 @@ tcMatchEquation :: [TcType] -> TcType -> Match -> TcM ([Ct], [Implication])
 tcMatchEquation argTys resTy match = do
   let pats = matchPats match
       sp = sourceSpanFromAnns (matchAnns match)
-  -- Bind pattern variables with their corresponding arg types.
-  let bindings = concatMap extractPatternBindings (zip pats argTys)
-  -- Collect pattern constraints, separating GADT givens from regular wanteds.
-  (wantedPatCts, givenCts) <-
-    unzipPair . concat <$> zipWithM (inferPatConstraints sp) pats argTys
+  patCheck <- checkPatternsWithGivens sp (zip pats argTys)
   -- Infer the RHS under the extended environment.
-  (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
+  (rhsTy, rhsCts) <- withPatternBindings (pcBindings patCheck) (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.
   ev <- freshEvVar
   let resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
-  let bodyWanteds = wantedPatCts ++ rhsCts ++ [resCt]
+  let givenCts = pcGivenCts patCheck
+      bodyWanteds = pcWantedCts patCheck ++ rhsCts ++ [resCt]
   if null givenCts
     then -- No GADT givens: emit everything as flat wanteds.
       pure (bodyWanteds, [])
@@ -1569,51 +1567,6 @@ tcMatchEquation argTys resTy match = do
               }
       pure ([], [impl])
 
--- | Unzip a list of pairs of constraint lists.
-unzipPair :: [([Ct], [Ct])] -> ([Ct], [Ct])
-unzipPair pairs =
-  let (as, bs) = unzip pairs
-   in (concat as, concat bs)
-
--- | Infer constraints from a single pattern, separated into regular wanted
--- constraints (for non-GADT constructors) and given constraints (for GADT
--- constructors that refine the scrutinee's type parameters).
---
--- Returns @(wantedCts, givenCts)@.
-inferPatConstraints :: SourceSpan -> Pattern -> TcType -> TcM [([Ct], [Ct])]
-inferPatConstraints sp pat scrutTy = case pat of
-  PCon name _typeArgs _subPats -> do
-    let conName = patNameToText name
-    mBinder <- lookupTerm conName
-    case mBinder of
-      Just (TcIdBinder _ scheme _) -> do
-        (conTy, _preds) <- instantiateSch scheme
-        let conResTy = resultType conTy
-        ev <- freshEvVar
-        gadtCon <- isGadtCon conName
-        if gadtCon
-          then do
-            -- GADT constructor: emit the scrutinee equality as a GIVEN.
-            let givenCt =
-                  Ct
-                    { ctPred = EqPred scrutTy conResTy,
-                      ctFlavor = Given,
-                      ctEvVar = ev,
-                      ctOrigin = AppOrigin sp,
-                      ctLoc = sp
-                    }
-            pure [([], [givenCt])]
-          else do
-            -- Regular constructor: emit as a WANTED constraint.
-            let wantedCt = mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp
-            pure [([wantedCt], [])]
-      _ -> pure [([], [])]
-  PAnn _ann inner -> inferPatConstraints sp inner scrutTy
-  PParen inner -> inferPatConstraints sp inner scrutTy
-  PStrict inner -> inferPatConstraints sp inner scrutTy
-  PIrrefutable inner -> inferPatConstraints sp inner scrutTy
-  _ -> pure [([], [])]
-
 -- | Unify an additional match equation's RHS with the expected type.
 unifyMatchRhs :: TcType -> Match -> TcM [Ct]
 unifyMatchRhs expectedTy match = do
@@ -1622,55 +1575,6 @@ unifyMatchRhs expectedTy match = do
   let sp = sourceSpanFromAnns (matchAnns match)
   let eqCt = mkWantedCt (EqPred rhsTy expectedTy) ev (AppOrigin sp) sp
   pure (rhsCts ++ [eqCt])
-
--- | Convert a Name to Text for lookup.
-patNameToText :: Name -> Text
-patNameToText n = case nameQualifier n of
-  Nothing -> nameText n
-  Just q -> q <> "." <> nameText n
-
--- | Extract the result type from a (possibly nested) function type.
-resultType :: TcType -> TcType
-resultType (TcFunTy _ res) = resultType res
-resultType ty = ty
-
--- | Instantiate a type scheme (delegating to the Instantiate module).
-instantiateSch :: TypeScheme -> TcM (TcType, [Pred])
-instantiateSch = Aihc.Tc.Instantiate.instantiate
-
--- | Extract variable bindings from a pattern paired with its expected type.
-extractPatternBindings :: (Pattern, TcType) -> [(Text, TcType)]
-extractPatternBindings (pat, ty) = case pat of
-  PVar uname -> [(unqualifiedNameText uname, ty)]
-  PAnn _ann inner -> extractPatternBindings (inner, ty)
-  PParen inner -> extractPatternBindings (inner, ty)
-  PWildcard {} -> []
-  PLit {} -> []
-  PNegLit {} -> []
-  PAs name inner -> (unqualifiedNameText name, ty) : extractPatternBindings (inner, ty)
-  PStrict inner -> extractPatternBindings (inner, ty)
-  PIrrefutable inner -> extractPatternBindings (inner, ty)
-  PCon _name _typeArgs subPats ->
-    concatMap (\p -> extractPatternBindings (p, ty)) subPats
-  PInfix lhs op rhs
-    | nameText op == ":" ->
-        let elemTy = listElementType ty
-         in extractPatternBindings (lhs, elemTy) ++ extractPatternBindings (rhs, ty)
-    | otherwise ->
-        extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)
-  _ -> []
-
-listElementType :: TcType -> TcType
-listElementType ty =
-  case ty of
-    TcTyCon (TyCon "[]" 1) [elemTy] -> elemTy
-    _ -> ty
-
--- | Run a computation with pattern bindings in scope.
-withPatBindings :: [(Text, TcType)] -> TcM a -> TcM a
-withPatBindings [] m = m
-withPatBindings ((name, ty) : rest) m =
-  extendTermEnv name (TcMonoIdBinder name ty) (withPatBindings rest m)
 
 -- | Infer the type of a right-hand side expression.
 inferRhsExpr :: Rhs Expr -> TcM (TcType, [Ct])

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -26,12 +26,12 @@ import Aihc.Parser.Syntax
     Pattern (..),
     Rhs (..),
     SourceSpan (..),
-    UnqualifiedName (..),
     fromAnnotation,
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Generate.Bind (inferLocalDecls, inferRhsWithLocals)
+import Aihc.Tc.Generate.Pattern
 import Aihc.Tc.Instantiate (instantiate)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
@@ -125,15 +125,15 @@ predToCt sp name p = do
 
 -- | Infer the type of a lambda expression.
 inferLambda :: SourceSpan -> [Pattern] -> Expr -> TcM (TcType, [Ct])
-inferLambda _sp pats body = do
+inferLambda sp pats body = do
   -- Create a fresh meta-variable for each pattern and bind pattern
   -- variables into the environment.
   argTys <- mapM (const freshMetaTv) pats
-  let bindings = concatMap extractPatternBindings (zip pats argTys)
+  patCheck <- checkPatterns sp (zip pats argTys)
   -- Infer the body under the extended environment.
-  (bodyTy, bodyCts) <- withPatternBindings bindings (inferExpr body)
+  (bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferExpr body)
   let funTy = foldr TcFunTy bodyTy argTys
-  pure (funTy, bodyCts)
+  pure (funTy, pcWantedCts patCheck ++ bodyCts)
 
 -- | Infer the type of a lambda-case expression.
 --
@@ -177,58 +177,23 @@ inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
     inferAlt (CaseAlt altAnns pat rhs) = do
       let altSp = sourceSpanFromAnns altAnns
           branchSp = combineSourceSpan altSp sp
-      let bindings = extractPatternBindings (pat, scrutTy)
-      -- Emit constraint: pattern's constructor result type ~ scrutinee type.
-      patCts <- inferPatternConstraints branchSp scrutTy pat
+      patCheck <- checkPattern branchSp pat scrutTy
       -- Infer the RHS under the pattern bindings.
-      (rhsTy, rhsCts) <- withPatternBindings bindings (inferRhs rhs)
+      (rhsTy, rhsCts) <- withPatternBindings (pcBindings patCheck) (inferRhs rhs)
       -- RHS must match the expected result type.
       ev <- freshEvVar
       let rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (CaseBranchOrigin branchSp) branchSp
-      pure (patCts ++ rhsCts ++ [rhsCt])
+      pure (pcWantedCts patCheck ++ rhsCts ++ [rhsCt])
 
 inferLambdaCaseAlt :: SourceSpan -> [TcType] -> TcType -> LambdaCaseAlt -> TcM [Ct]
 inferLambdaCaseAlt sp argTys resTy alt = do
   let pats = lambdaCaseAltPats alt
       rhs = lambdaCaseAltRhs alt
-      bindings = concatMap extractPatternBindings (zip pats argTys)
-  patCts <- concat <$> sequence [inferPatternConstraints sp argTy pat | (pat, argTy) <- zip pats argTys]
-  (rhsTy, rhsCts) <- withPatternBindings bindings (inferRhs rhs)
+  patCheck <- checkPatterns sp (zip pats argTys)
+  (rhsTy, rhsCts) <- withPatternBindings (pcBindings patCheck) (inferRhs rhs)
   ev <- freshEvVar
   let rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
-  pure (patCts ++ rhsCts ++ [rhsCt])
-
--- | Infer constraints from a pattern.
---
--- For constructor patterns, we emit an equality between the constructor's
--- result type and the scrutinee type. For variable/wildcard/literal patterns,
--- no extra constraints are needed (the variable just gets the scrutinee type).
-inferPatternConstraints :: SourceSpan -> TcType -> Pattern -> TcM [Ct]
-inferPatternConstraints sp scrutTy pat = case pat of
-  PCon name _typeArgs _subPats -> do
-    -- Look up the constructor; if found, emit scrutTy ~ constructor result type.
-    let conName = nameToText name
-    mBinder <- lookupTerm conName
-    case mBinder of
-      Just (TcIdBinder _ scheme _) -> do
-        (conTy, _preds) <- instantiate scheme
-        -- For a nullary constructor (no args), conTy is the result type.
-        -- For a constructor with args, conTy is a function type whose
-        -- result is the data type. We need to extract the result type.
-        let conResTy = resultType conTy
-        ev <- freshEvVar
-        pure [mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp]
-      _ -> pure []
-  PAnn _ann inner -> inferPatternConstraints sp scrutTy inner
-  PParen inner -> inferPatternConstraints sp scrutTy inner
-  PStrict inner -> inferPatternConstraints sp scrutTy inner
-  PIrrefutable inner -> inferPatternConstraints sp scrutTy inner
-  _ -> pure []
-
--- | Extract the result type from a (possibly nested) function type.
-resultType :: TcType -> TcType
-resultType (TcFunTy _ res) = resultType res
-resultType ty = ty
+  pure (pcWantedCts patCheck ++ rhsCts ++ [rhsCt])
 
 sourceSpanFromAnns :: [Annotation] -> SourceSpan
 sourceSpanFromAnns anns =
@@ -326,13 +291,12 @@ inferListComp sp body quals = do
         CompGen pat src -> do
           elemTy <- freshMetaTv
           (srcTy, srcCts) <- inferExpr src
-          patCts <- inferPatternConstraints ambient elemTy pat
+          patCheck <- checkPattern ambient pat elemTy
           ev <- freshEvVar
           let srcSp = exprSpan src `orSourceSpan` ambient
               srcListCt = mkWantedCt (EqPred srcTy (listType elemTy)) ev (AppOrigin srcSp) srcSp
-              bindings = extractPatternBindings (pat, elemTy)
-          (bodyTy, bodyCts) <- withPatternBindings bindings (inferCompQuals ambient rest action)
-          pure (bodyTy, srcCts ++ patCts ++ [srcListCt] ++ bodyCts)
+          (bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferCompQuals ambient rest action)
+          pure (bodyTy, srcCts ++ pcWantedCts patCheck ++ [srcListCt] ++ bodyCts)
         CompGuard guard -> do
           (guardTy, guardCts) <- inferExpr guard
           ev <- freshEvVar
@@ -414,49 +378,3 @@ stringTyCon = TcTyCon (TyCon "[]" 1) [charTyCon]
 
 boolTyCon :: TcType
 boolTyCon = TcTyCon (TyCon "Bool" 0) []
-
--- | Extract variable bindings from a pattern paired with its expected type.
---
--- For a 'PVar', we bind the variable name to the given type.
--- For a 'PCon' (constructor pattern), we return bindings for sub-patterns
--- but assign fresh types to them (the constructor arg types are not yet
--- tracked in the MVP).
--- Other patterns are handled minimally for the MVP.
-extractPatternBindings :: (Pattern, TcType) -> [(Text, TcType)]
-extractPatternBindings (pat, ty) = case pat of
-  PVar uname -> [(unqualifiedNameText uname, ty)]
-  PAnn _ann inner -> extractPatternBindings (inner, ty)
-  PParen inner -> extractPatternBindings (inner, ty)
-  PWildcard {} -> []
-  PLit {} -> []
-  PNegLit {} -> []
-  PAs name inner -> (unqualifiedNameText name, ty) : extractPatternBindings (inner, ty)
-  PStrict inner -> extractPatternBindings (inner, ty)
-  PIrrefutable inner -> extractPatternBindings (inner, ty)
-  -- For constructor patterns like (True), (Just x), etc. the overall
-  -- pattern type doesn't directly give us the sub-pattern types. But
-  -- we can still extract the variable names for binding purposes.
-  PCon _name _typeArgs subPats ->
-    -- Each sub-pattern gets an unknown type (we'd need constructor info
-    -- to assign proper types). For the MVP, they're not needed since
-    -- constructor pattern matching in function heads is handled by tcMatches.
-    concatMap (\p -> extractPatternBindings (p, ty)) subPats
-  PInfix lhs op rhs
-    | nameText op == ":" ->
-        let elemTy = listElementType ty
-         in extractPatternBindings (lhs, elemTy) ++ extractPatternBindings (rhs, ty)
-    | otherwise ->
-        extractPatternBindings (lhs, ty) ++ extractPatternBindings (rhs, ty)
-  _ -> []
-
-listElementType :: TcType -> TcType
-listElementType ty =
-  case ty of
-    TcTyCon (TyCon "[]" 1) [elemTy] -> elemTy
-    _ -> ty
-
--- | Run a computation with pattern bindings in scope.
-withPatternBindings :: [(Text, TcType)] -> TcM a -> TcM a
-withPatternBindings [] m = m
-withPatternBindings ((name, ty) : rest) m =
-  extendTermEnv name (TcMonoIdBinder name ty) (withPatternBindings rest m)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Shared type-checking support for term patterns.
+module Aihc.Tc.Generate.Pattern
+  ( PatternCheck (..),
+    checkPattern,
+    checkPatterns,
+    checkPatternsWithGivens,
+    withPatternBindings,
+  )
+where
+
+import Aihc.Parser.Syntax
+  ( Name (..),
+    Pattern (..),
+    SourceSpan,
+    nameText,
+    unqualifiedNameText,
+  )
+import Aihc.Tc.Constraint
+import Aihc.Tc.Instantiate (instantiate)
+import Aihc.Tc.Monad
+import Aihc.Tc.Types
+import Data.Text (Text)
+
+data PatternCheck = PatternCheck
+  { pcBindings :: ![(Text, TcType)],
+    pcWantedCts :: ![Ct],
+    pcGivenCts :: ![Ct]
+  }
+  deriving (Show)
+
+instance Semigroup PatternCheck where
+  left <> right =
+    PatternCheck
+      { pcBindings = pcBindings left <> pcBindings right,
+        pcWantedCts = pcWantedCts left <> pcWantedCts right,
+        pcGivenCts = pcGivenCts left <> pcGivenCts right
+      }
+
+instance Monoid PatternCheck where
+  mempty = PatternCheck [] [] []
+
+data GadtHandling
+  = GadtAsWanted
+  | GadtAsGiven
+  deriving (Eq)
+
+checkPatterns :: SourceSpan -> [(Pattern, TcType)] -> TcM PatternCheck
+checkPatterns = checkPatternsWith GadtAsWanted
+
+checkPatternsWithGivens :: SourceSpan -> [(Pattern, TcType)] -> TcM PatternCheck
+checkPatternsWithGivens = checkPatternsWith GadtAsGiven
+
+checkPatternsWith :: GadtHandling -> SourceSpan -> [(Pattern, TcType)] -> TcM PatternCheck
+checkPatternsWith gadtHandling sp = fmap mconcat . mapM (uncurry (checkPatternWith gadtHandling sp))
+
+checkPattern :: SourceSpan -> Pattern -> TcType -> TcM PatternCheck
+checkPattern = checkPatternWith GadtAsWanted
+
+checkPatternWith :: GadtHandling -> SourceSpan -> Pattern -> TcType -> TcM PatternCheck
+checkPatternWith gadtHandling sp pat scrutTy =
+  case pat of
+    PVar name ->
+      pure mempty {pcBindings = [(unqualifiedNameText name, scrutTy)]}
+    PAnn _ann inner -> checkPatternWith gadtHandling sp inner scrutTy
+    PParen inner -> checkPatternWith gadtHandling sp inner scrutTy
+    PWildcard {} -> pure mempty
+    PLit {} -> pure mempty
+    PNegLit {} -> pure mempty
+    PAs name inner -> do
+      innerCheck <- checkPatternWith gadtHandling sp inner scrutTy
+      pure innerCheck {pcBindings = (unqualifiedNameText name, scrutTy) : pcBindings innerCheck}
+    PStrict inner -> checkPatternWith gadtHandling sp inner scrutTy
+    PIrrefutable inner -> checkPatternWith gadtHandling sp inner scrutTy
+    PCon name _typeArgs subPats ->
+      checkConPattern gadtHandling sp (patternNameText name) subPats scrutTy
+    PInfix lhs op rhs ->
+      checkConPattern gadtHandling sp (patternNameText op) [lhs, rhs] scrutTy
+    PList items -> do
+      elemTy <- freshMetaTv
+      let listTy = listType elemTy
+      eqCt <- wantedEq sp scrutTy listTy
+      itemChecks <- checkPatternsWith gadtHandling sp [(item, elemTy) | item <- items]
+      pure itemChecks {pcWantedCts = eqCt : pcWantedCts itemChecks}
+    _ -> pure mempty
+
+checkConPattern :: GadtHandling -> SourceSpan -> Text -> [Pattern] -> TcType -> TcM PatternCheck
+checkConPattern gadtHandling sp conName subPats scrutTy = do
+  mBinder <- lookupTerm conName
+  case mBinder of
+    Just (TcIdBinder _ scheme _) -> do
+      (conTy, _preds) <- instantiate scheme
+      (argTys, conResTy) <- splitConTy (length subPats) conTy
+      scrutCt <- constructorScrutineeCt gadtHandling sp conName scrutTy conResTy
+      subCheck <- checkPatternsWith gadtHandling sp (zip subPats argTys)
+      pure
+        subCheck
+          { pcWantedCts = fst scrutCt <> pcWantedCts subCheck,
+            pcGivenCts = snd scrutCt <> pcGivenCts subCheck
+          }
+    _ -> pure mempty
+
+constructorScrutineeCt :: GadtHandling -> SourceSpan -> Text -> TcType -> TcType -> TcM ([Ct], [Ct])
+constructorScrutineeCt gadtHandling sp conName scrutTy conResTy = do
+  ev <- freshEvVar
+  gadtCon <- isGadtCon conName
+  if gadtHandling == GadtAsGiven && gadtCon
+    then
+      pure
+        ( [],
+          [ Ct
+              { ctPred = EqPred scrutTy conResTy,
+                ctFlavor = Given,
+                ctEvVar = ev,
+                ctOrigin = AppOrigin sp,
+                ctLoc = sp
+              }
+          ]
+        )
+    else do
+      let wantedCt = mkWantedCt (EqPred scrutTy conResTy) ev (AppOrigin sp) sp
+      pure ([wantedCt], [])
+
+splitConTy :: Int -> TcType -> TcM ([TcType], TcType)
+splitConTy 0 ty = pure ([], ty)
+splitConTy n (TcFunTy arg rest) = do
+  (args, result) <- splitConTy (n - 1) rest
+  pure (arg : args, result)
+splitConTy n result = do
+  missingArgs <- mapM (const freshMetaTv) [1 .. n]
+  pure (missingArgs, result)
+
+wantedEq :: SourceSpan -> TcType -> TcType -> TcM Ct
+wantedEq sp left right = do
+  ev <- freshEvVar
+  pure (mkWantedCt (EqPred left right) ev (AppOrigin sp) sp)
+
+withPatternBindings :: [(Text, TcType)] -> TcM a -> TcM a
+withPatternBindings [] action = action
+withPatternBindings ((name, ty) : rest) action =
+  extendTermEnv name (TcMonoIdBinder name ty) (withPatternBindings rest action)
+
+listType :: TcType -> TcType
+listType elemTy = TcTyCon (TyCon "[]" 1) [elemTy]
+
+patternNameText :: Name -> Text
+patternNameText name =
+  case nameQualifier name of
+    Nothing -> nameText name
+    Just qualifier -> qualifier <> "." <> nameText name

--- a/components/aihc-tc/test/Test/Fixtures/annotated/as-pattern.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/as-pattern.yaml
@@ -2,9 +2,14 @@ extensions: []
 modules:
   - |
     module Test where
-    data Bool = True | False
     asPattern xs@(x:rest) = xs
-    (:) a b = a
-annotated: []
-status: xfail
-reason: "as-patterns not yet supported"
+annotated:
+  - |-
+    module Test where
+    asPattern xs@(x:rest) = xs
+    │         │   │ └─ rest ∷ [a]
+    │         │   └─ x ∷ a
+    │         └─ xs ∷ [a]
+    └─ asPattern ∷ ∀ a. [a] → [a]
+status: pass
+reason: ""

--- a/components/aihc-tc/test/Test/Fixtures/annotated/chained-as-pattern.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/chained-as-pattern.yaml
@@ -1,0 +1,16 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    fn a@b@c = (a,b,c)
+annotated:
+  - |-
+    module Test where
+    fn a@b@c = (a,b,c)
+    │  │ │ │   └─ type-args: a, a, a
+    │  │ │ └─ c ∷ a
+    │  │ └─ b ∷ a
+    │  └─ a ∷ a
+    └─ fn ∷ ∀ a. a → (a, a, a)
+status: pass
+reason: ""


### PR DESCRIPTION
## What changed

- Trimmed `components/aihc-tc/test/Test/Fixtures/annotated/as-pattern.yaml` so it no longer defines local `Bool` or `(:)` declarations.
- Promoted the as-pattern annotated fixture from `xfail` to `pass`.
- Added shared type-checker pattern generation in `Aihc.Tc.Generate.Pattern` and wired it through expression, local binding, and top-level declaration checking.
- As-pattern aliases now bind to the full scrutinee type while the inner pattern is recursively checked, so `xs@(x:rest)` infers `xs :: [a]`, `x :: a`, and `rest :: [a]`.

## Progress counts

- `aihc-tc` annotated fixtures: `as-pattern.yaml` moved from known failure to passing coverage (`xfail -1`, `pass +1`).

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`