### PR TITLE
fix(tc): track provenance for unification diagnostics

### DIFF
--- a/components/aihc-tc/common/TcAnnotatedRender.hs
+++ b/components/aihc-tc/common/TcAnnotatedRender.hs
@@ -46,7 +46,7 @@ import Aihc.Tc.Annotations
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
   )
-import Aihc.Tc.Constraint (CtOrigin (..))
+import Aihc.Tc.Constraint (CtOrigin (..), EqProvenance (..), TypeOrigin (..), TypeRole (..), TypeTrace (..))
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Evidence (Coercion (..), EvTerm (..), EvVar (..))
 import Aihc.Tc.Types (Kind (..), Pred (..), TyCon (..), Unique (..))
@@ -86,24 +86,50 @@ collectTcLabels result =
 
 diagnosticLabels :: [TcDiagnostic] -> [TcLabel]
 diagnosticLabels =
-  mapMaybe diagnosticLabel
+  concatMap diagnosticLabelsFor
 
-diagnosticLabel :: TcDiagnostic -> Maybe TcLabel
-diagnosticLabel diagnostic =
+diagnosticLabelsFor :: TcDiagnostic -> [TcLabel]
+diagnosticLabelsFor diagnostic =
   case diagnosticSpan diagnostic of
-    NoSourceSpan -> Nothing
-    sp -> Just (sourceLabel sp (renderDiagnostic diagnostic))
+    NoSourceSpan -> []
+    sp -> sourceLabel sp (renderDiagnostic diagnostic) : diagnosticRelatedLabels diagnostic
+
+diagnosticRelatedLabels :: TcDiagnostic -> [TcLabel]
+diagnosticRelatedLabels diagnostic =
+  case diagKind diagnostic of
+    UnificationError _ _ _ (Just provenance) ->
+      mapMaybe (typeOriginNote "note" Nothing) (eqContextOrigins provenance)
+    _ -> []
+  where
+    typeOriginNote prefix maybeTy origin =
+      case origin of
+        TypeSignatureOrigin name sp ->
+          Just $
+            sourceLabel sp $
+              prefix
+                <> ": type signature for "
+                <> T.unpack name
+                <> " provides expected type"
+                <> maybe "" ((" " <>) . renderTcType) maybeTy
+        ConstraintTypeOrigin ctOrigin ->
+          case originSpan (Just ctOrigin) of
+            NoSourceSpan -> Nothing
+            sp -> Just (sourceLabel sp (prefix <> ": related type information came from " <> renderOrigin ctOrigin))
+        _ -> Nothing
 
 diagnosticSpan :: TcDiagnostic -> SourceSpan
 diagnosticSpan diagnostic =
   case diagLoc diagnostic of
-    NoSourceSpan -> originSpan (diagnosticOrigin diagnostic)
+    NoSourceSpan ->
+      case diagKind diagnostic of
+        UnificationError _ _ _ (Just provenance) -> eqPrimarySpan provenance
+        _ -> originSpan (diagnosticOrigin diagnostic)
     sp -> sp
 
 diagnosticOrigin :: TcDiagnostic -> Maybe CtOrigin
 diagnosticOrigin diagnostic =
   case diagKind diagnostic of
-    UnificationError _ _ origin -> Just origin
+    UnificationError _ _ origin _ -> Just origin
     UnsolvedWanted _ origin -> Just origin
     _ -> Nothing
 
@@ -119,6 +145,19 @@ originSpan origin =
     Just (UnifyOrigin sp) -> sp
     _ -> NoSourceSpan
 
+renderOrigin :: CtOrigin -> String
+renderOrigin origin =
+  case origin of
+    OccurrenceOf name -> "the occurrence of " <> T.unpack name
+    AppOrigin {} -> "an application"
+    LambdaOrigin {} -> "a lambda expression"
+    LetOrigin {} -> "a let binding"
+    LitOrigin {} -> "a literal"
+    SigOrigin {} -> "a type signature"
+    CaseBranchOrigin {} -> "a case branch"
+    InstOrigin name -> "the instance " <> T.unpack name
+    UnifyOrigin {} -> "a unification constraint"
+
 renderDiagnostic :: TcDiagnostic -> String
 renderDiagnostic diagnostic =
   severityPrefix (diagSeverity diagnostic) <> ": " <> renderDiagnosticKind (diagKind diagnostic)
@@ -130,8 +169,12 @@ severityPrefix TcWarning = "warning"
 renderDiagnosticKind :: TcErrorKind -> String
 renderDiagnosticKind kind =
   case kind of
-    UnificationError left right _ ->
-      "couldn't match " <> renderTcType left <> " with " <> renderTcType right
+    UnificationError left right _ maybeProvenance ->
+      case maybeProvenance of
+        Just provenance ->
+          renderTypeMismatch provenance
+        Nothing ->
+          "couldn't match " <> renderTcType left <> " with " <> renderTcType right
     OccursCheckError unique ty ->
       "occurs check failed: " <> renderUnique unique <> " occurs in " <> renderTcType ty
     UnboundVariable name ->
@@ -142,6 +185,37 @@ renderDiagnosticKind kind =
       "unsolved constraint " <> renderPred pred'
     OtherError message ->
       message
+
+renderTypeMismatch :: EqProvenance -> String
+renderTypeMismatch provenance =
+  typeRoleNoun (typeTraceRole actual)
+    <> " has type "
+    <> renderTcType (typeTraceType actual)
+    <> ", but expected "
+    <> renderTcType (typeTraceType expected)
+    <> renderExpectedOrigin (typeTraceOrigin expected)
+  where
+    actual = eqActualTrace provenance
+    expected = eqExpectedTrace provenance
+
+renderExpectedOrigin :: TypeOrigin -> String
+renderExpectedOrigin origin =
+  case origin of
+    ListElementTypeOrigin _ ->
+      " from an earlier list element"
+    TypeSignatureOrigin name _ ->
+      " from the type signature for " <> T.unpack name
+    ConstraintTypeOrigin ctOrigin ->
+      " from " <> renderOrigin ctOrigin
+    _ -> ""
+
+typeRoleNoun :: TypeRole -> String
+typeRoleNoun role =
+  case role of
+    ActualType -> "expression"
+    ExpectedType -> "expected type"
+    RequiredType -> "required type"
+    InferredType -> "inferred type"
 
 renderKind :: Kind -> String
 renderKind kind =

--- a/components/aihc-tc/src/Aihc/Tc/Constraint.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Constraint.hs
@@ -8,10 +8,17 @@ module Aihc.Tc.Constraint
 
     -- * Constraint origins
     CtOrigin (..),
+    CtProvenance (..),
+    EqProvenance (..),
+    TypeOrigin (..),
+    TypeRole (..),
+    TypeTrace (..),
 
     -- * Constraints
     Ct (..),
     mkWantedCt,
+    mkWantedEqCt,
+    ctEqProvenance,
 
     -- * Implications
     Implication (..),
@@ -49,12 +56,53 @@ data CtOrigin
   | UnifyOrigin !SourceSpan
   deriving (Eq, Show)
 
+-- | The diagnostic role a type played in an equality.
+data TypeRole
+  = ActualType
+  | ExpectedType
+  | RequiredType
+  | InferredType
+  deriving (Eq, Show)
+
+-- | Where one side of a type constraint came from.
+data TypeOrigin
+  = UnknownTypeOrigin
+  | ExpressionTypeOrigin !SourceSpan
+  | ListElementTypeOrigin !SourceSpan
+  | TypeSignatureOrigin !Text !SourceSpan
+  | ConstraintTypeOrigin !CtOrigin
+  deriving (Eq, Show)
+
+-- | A type plus the diagnostic role and source of that type information.
+data TypeTrace = TypeTrace
+  { typeTraceType :: !TcType,
+    typeTraceRole :: !TypeRole,
+    typeTraceOrigin :: !TypeOrigin
+  }
+  deriving (Eq, Show)
+
+-- | Expected-vs-actual provenance for an equality constraint.
+data EqProvenance = EqProvenance
+  { eqActualTrace :: !TypeTrace,
+    eqExpectedTrace :: !TypeTrace,
+    eqContextOrigins :: ![TypeOrigin],
+    eqPrimarySpan :: !SourceSpan
+  }
+  deriving (Eq, Show)
+
+-- | Diagnostic provenance carried by a constraint.
+data CtProvenance
+  = FromCtOrigin !CtOrigin
+  | FromEqProvenance !EqProvenance
+  deriving (Eq, Show)
+
 -- | A constraint to be solved.
 data Ct = Ct
   { ctPred :: !Pred,
     ctFlavor :: !CtFlavor,
     ctEvVar :: !EvVar,
     ctOrigin :: !CtOrigin,
+    ctProvenance :: !CtProvenance,
     ctLoc :: !SourceSpan
   }
   deriving (Show)
@@ -67,8 +115,36 @@ mkWantedCt p ev orig loc =
       ctFlavor = Wanted,
       ctEvVar = ev,
       ctOrigin = orig,
+      ctProvenance = FromCtOrigin orig,
       ctLoc = loc
     }
+
+-- | Create a wanted equality constraint with expected-vs-actual diagnostic
+-- provenance. The solver may reorient or decompose the predicate, but the
+-- provenance keeps the source-facing roles stable for error reporting.
+mkWantedEqCt :: TypeTrace -> TypeTrace -> EvVar -> CtOrigin -> SourceSpan -> Ct
+mkWantedEqCt actual expected ev orig loc =
+  Ct
+    { ctPred = EqPred (typeTraceType actual) (typeTraceType expected),
+      ctFlavor = Wanted,
+      ctEvVar = ev,
+      ctOrigin = orig,
+      ctProvenance =
+        FromEqProvenance
+          EqProvenance
+            { eqActualTrace = actual,
+              eqExpectedTrace = expected,
+              eqContextOrigins = [],
+              eqPrimarySpan = loc
+            },
+      ctLoc = loc
+    }
+
+ctEqProvenance :: Ct -> Maybe EqProvenance
+ctEqProvenance ct =
+  case ctProvenance ct of
+    FromEqProvenance provenance -> Just provenance
+    FromCtOrigin {} -> Nothing
 
 -- | An implication constraint.
 --

--- a/components/aihc-tc/src/Aihc/Tc/Error.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Error.hs
@@ -7,7 +7,7 @@ module Aihc.Tc.Error
 where
 
 import Aihc.Parser.Syntax (SourceSpan)
-import Aihc.Tc.Constraint (CtOrigin)
+import Aihc.Tc.Constraint (CtOrigin, EqProvenance)
 import Aihc.Tc.Types
 
 -- | A diagnostic produced by the type checker.
@@ -27,7 +27,7 @@ data TcSeverity
 -- | Kinds of type checking errors.
 data TcErrorKind
   = -- | Could not unify two types.
-    UnificationError !TcType !TcType !CtOrigin
+    UnificationError !TcType !TcType !CtOrigin !(Maybe EqProvenance)
   | -- | Occurs check failure (infinite type).
     OccursCheckError !Unique !TcType
   | -- | Unbound variable.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -112,6 +112,20 @@ data TcBindingResult = TcBindingResult
   }
   deriving (Show)
 
+data UserSig = UserSig
+  { userSigName :: !Text,
+    userSigType :: !Type,
+    userSigSpan :: !SourceSpan
+  }
+  deriving (Show)
+
+data CheckedSig = CheckedSig
+  { checkedSigName :: !Text,
+    checkedSigScheme :: !TypeScheme,
+    checkedSigSpan :: !SourceSpan
+  }
+  deriving (Show)
+
 moduleBindings :: Module -> [TcBindingResult]
 moduleBindings modu =
   concatMap declBindings (moduleDecls modu)
@@ -231,8 +245,8 @@ tcModule m = do
   --          and report their types.
   mapM_ registerDecl (moduleDecls m)
   -- Phase 2: collect type signatures and convert them to schemes.
-  let rawSigs = collectRawSigs (moduleDecls m)
-  schemes <- traverse sigToScheme rawSigs
+  let rawSigs = collectUserSigs (moduleDecls m)
+  schemes <- traverse checkUserSig rawSigs
   -- Phase 3: group and type-check value bindings using signatures.
   let grouped = sortDeclGroups (groupValueDecls (moduleDecls m))
   valueResults <- concat <$> mapM (tcDeclGroup schemes) grouped
@@ -958,16 +972,33 @@ boolTy :: TcType
 boolTy = TcTyCon (TyCon "Bool" 0) []
 
 -- | Collect type signatures from a list of declarations.
-collectRawSigs :: [Decl] -> Map Text Type
-collectRawSigs decls = Map.fromList $ concatMap extractSig decls
+collectUserSigs :: [Decl] -> Map Text UserSig
+collectUserSigs decls = Map.fromList $ concatMap (extractSig NoSourceSpan) decls
   where
-    extractSig (DeclTypeSig names ty) =
-      [(unqualifiedNameText n, ty) | n <- names]
-    extractSig (DeclForeign foreignDecl)
+    extractSig ambient (DeclTypeSig names ty) =
+      [ (name, UserSig name ty sigSp)
+      | n <- names,
+        let name = unqualifiedNameText n,
+        let sigSp = ambient `orSourceSpan` unqualifiedNameSpan n `orSourceSpan` typeSpan ty
+      ]
+    extractSig ambient (DeclForeign foreignDecl)
       | isForeignImport foreignDecl =
-          [(unqualifiedNameText (foreignName foreignDecl), foreignType foreignDecl)]
-    extractSig (DeclAnn _ inner) = extractSig inner
-    extractSig _ = []
+          let name = unqualifiedNameText (foreignName foreignDecl)
+              sigSp = ambient `orSourceSpan` unqualifiedNameSpan (foreignName foreignDecl) `orSourceSpan` typeSpan (foreignType foreignDecl)
+           in [(name, UserSig name (foreignType foreignDecl) sigSp)]
+    extractSig ambient (DeclAnn ann inner) =
+      extractSig (fromMaybe ambient (fromAnnotation @SourceSpan ann)) inner
+    extractSig _ _ = []
+
+checkUserSig :: UserSig -> TcM CheckedSig
+checkUserSig userSig = do
+  scheme <- sigToScheme (userSigType userSig)
+  pure
+    CheckedSig
+      { checkedSigName = userSigName userSig,
+        checkedSigScheme = scheme,
+        checkedSigSpan = userSigSpan userSig
+      }
 
 listType :: TcType -> TcType
 listType ty = TcTyCon (TyCon "[]" 1) [ty]
@@ -1141,21 +1172,21 @@ patternBinders pat =
     _ -> []
 
 -- | Type-check a declaration group.
-tcDeclGroup :: Map Text TypeScheme -> DeclGroup -> TcM [TcBindingResult]
+tcDeclGroup :: Map Text CheckedSig -> DeclGroup -> TcM [TcBindingResult]
 tcDeclGroup sigs (SingleDecl d) =
   case peelDeclAnn d of
     DeclValue (PatternBind _ pat rhs)
       | Just (displayName, name) <- patternBinderName pat,
-        Just scheme <- Map.lookup name sigs ->
-          tcFunctionWithSig displayName name scheme [zeroArgMatch (patternSpan pat `orSourceSpan` peelDeclSpan NoSourceSpan d) rhs]
+        Just sig <- Map.lookup name sigs ->
+          tcFunctionWithSig displayName name sig [zeroArgMatch (patternSpan pat `orSourceSpan` peelDeclSpan NoSourceSpan d) rhs]
     _ -> tcDecl d
 tcDeclGroup sigs (MergedFunctionBind _sp binder matches) = do
   let name = unqualifiedNameText binder
       displayName = renderBinderName binder
   case Map.lookup name sigs of
-    Just scheme -> do
+    Just sig -> do
       -- Use the declared type signature for checking.
-      tcFunctionWithSig displayName name scheme matches
+      tcFunctionWithSig displayName name sig matches
     Nothing -> do
       -- No signature: infer the type.
       tcFunctionInfer displayName name matches
@@ -1164,8 +1195,9 @@ tcDeclGroup sigs (MergedFunctionBind _sp binder matches) = do
 -- The signature's type variables are opened as rigid skolems so that
 -- the body is checked against them. GADT patterns generate implication
 -- constraints using the signature's skolems as given equalities.
-tcFunctionWithSig :: Text -> Text -> TypeScheme -> [Match] -> TcM [TcBindingResult]
-tcFunctionWithSig displayName name scheme matches = do
+tcFunctionWithSig :: Text -> Text -> CheckedSig -> [Match] -> TcM [TcBindingResult]
+tcFunctionWithSig displayName name sig matches = do
+  let scheme = checkedSigScheme sig
   ((), failed) <-
     withErrorTracking $ do
       extendTermEnvPermanent name (TcIdBinder name scheme Closed)
@@ -1176,7 +1208,7 @@ tcFunctionWithSig displayName name scheme matches = do
             [] -> 0
           (argTys, resTy) = splitFunTy sigTy nArgs
       -- Check each equation against the signature types.
-      results <- mapM (tcMatchEquation argTys resTy) matches
+      results <- mapM (tcMatchEquation (Just (TypeSignatureOrigin (checkedSigName sig) (checkedSigSpan sig))) argTys resTy) matches
       let (ctsList, implsList) = unzip results
           allCts = concat ctsList
           allImpls = concat implsList
@@ -1499,6 +1531,32 @@ patternSpan pat =
     PIrrefutable inner -> patternSpan inner
     _ -> NoSourceSpan
 
+typeSpan :: Type -> SourceSpan
+typeSpan ty =
+  case ty of
+    TAnn ann inner ->
+      fromMaybe (typeSpan inner) (fromAnnotation @SourceSpan ann)
+    TParen inner -> typeSpan inner
+    TForall _ inner -> typeSpan inner
+    TContext _ inner -> typeSpan inner
+    TKindSig inner _ -> typeSpan inner
+    _ -> NoSourceSpan
+
+rhsExprSpan :: Rhs Expr -> SourceSpan
+rhsExprSpan rhs =
+  case rhs of
+    UnguardedRhs anns expr _ -> exprSpan expr `orSourceSpan` sourceSpanFromAnns anns
+    GuardedRhss anns _ _ -> sourceSpanFromAnns anns
+
+exprSpan :: Expr -> SourceSpan
+exprSpan expr =
+  case expr of
+    EAnn ann inner ->
+      fromMaybe (exprSpan inner) (fromAnnotation @SourceSpan ann)
+    EParen inner -> exprSpan inner
+    ETypeSig inner _ -> exprSpan inner
+    _ -> NoSourceSpan
+
 -- | Convert a type scheme to a displayable type.
 schemeToType :: TypeScheme -> TcType
 schemeToType (ForAll [] [] ty) = ty
@@ -1528,7 +1586,7 @@ tcMatches matches@(m0 : _) = do
       argTys <- mapM (const freshMetaTv) [1 .. nArgs]
       resTy <- freshMetaTv
       -- Process each equation.
-      results <- mapM (tcMatchEquation argTys resTy) matches
+      results <- mapM (tcMatchEquation Nothing argTys resTy) matches
       let (ctsList, implsList) = unzip results
           allCts = concat ctsList
           allImpls = concat implsList
@@ -1537,8 +1595,8 @@ tcMatches matches@(m0 : _) = do
 
 -- | Type-check a single match equation against expected arg/result types.
 -- Returns flat wanted constraints and implication constraints.
-tcMatchEquation :: [TcType] -> TcType -> Match -> TcM ([Ct], [Implication])
-tcMatchEquation argTys resTy match = do
+tcMatchEquation :: Maybe TypeOrigin -> [TcType] -> TcType -> Match -> TcM ([Ct], [Implication])
+tcMatchEquation expectedOrigin argTys resTy match = do
   let pats = matchPats match
       sp = sourceSpanFromAnns (matchAnns match)
   -- Bind pattern variables with their corresponding arg types.
@@ -1550,7 +1608,22 @@ tcMatchEquation argTys resTy match = do
   (rhsTy, rhsCts) <- withPatBindings bindings (inferRhsExpr (matchRhs match))
   -- RHS type must match the expected result type.
   ev <- freshEvVar
-  let resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
+  let rhsSp = rhsExprSpan (matchRhs match) `orSourceSpan` sp
+      resCt =
+        mkWantedEqCt
+          TypeTrace
+            { typeTraceType = rhsTy,
+              typeTraceRole = ActualType,
+              typeTraceOrigin = ExpressionTypeOrigin rhsSp
+            }
+          TypeTrace
+            { typeTraceType = resTy,
+              typeTraceRole = ExpectedType,
+              typeTraceOrigin = fromMaybe (ConstraintTypeOrigin (AppOrigin sp)) expectedOrigin
+            }
+          ev
+          (AppOrigin rhsSp)
+          rhsSp
   let bodyWanteds = wantedPatCts ++ rhsCts ++ [resCt]
   if null givenCts
     then -- No GADT givens: emit everything as flat wanteds.
@@ -1600,6 +1673,7 @@ inferPatConstraints sp pat scrutTy = case pat of
                       ctFlavor = Given,
                       ctEvVar = ev,
                       ctOrigin = AppOrigin sp,
+                      ctProvenance = FromCtOrigin (AppOrigin sp),
                       ctLoc = sp
                     }
             pure [([], [givenCt])]
@@ -1620,7 +1694,22 @@ unifyMatchRhs expectedTy match = do
   (rhsTy, rhsCts) <- inferRhsExpr (matchRhs match)
   ev <- freshEvVar
   let sp = sourceSpanFromAnns (matchAnns match)
-  let eqCt = mkWantedCt (EqPred rhsTy expectedTy) ev (AppOrigin sp) sp
+      rhsSp = rhsExprSpan (matchRhs match) `orSourceSpan` sp
+      eqCt =
+        mkWantedEqCt
+          TypeTrace
+            { typeTraceType = rhsTy,
+              typeTraceRole = ActualType,
+              typeTraceOrigin = ExpressionTypeOrigin rhsSp
+            }
+          TypeTrace
+            { typeTraceType = expectedTy,
+              typeTraceRole = ExpectedType,
+              typeTraceOrigin = ConstraintTypeOrigin (AppOrigin sp)
+            }
+          ev
+          (AppOrigin rhsSp)
+          rhsSp
   pure (rhsCts ++ [eqCt])
 
 -- | Convert a Name to Text for lookup.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -43,9 +43,12 @@ import Data.Text qualified as T
 --
 -- Returns the inferred type and a list of wanted constraints.
 inferExpr :: Expr -> TcM (TcType, [Ct])
-inferExpr expr = case expr of
+inferExpr = inferExprAt NoSourceSpan
+
+inferExprAt :: SourceSpan -> Expr -> TcM (TcType, [Ct])
+inferExprAt ambient expr = case expr of
   -- Variables: look up in environment, instantiate if polymorphic.
-  EVar name -> inferVar NoSourceSpan (nameToText name)
+  EVar name -> inferVar (exprSpan expr `orSourceSpan` ambient) (nameToText name)
   -- Boxed integer literals are monomorphic Int for the MVP. MagicHash
   -- literals keep their primitive, unboxed type.
   EInt _ numericType _ -> pure (numericLiteralType numericType, [])
@@ -58,45 +61,45 @@ inferExpr expr = case expr of
   -- primitive String type constructor.
   EString _ _ -> pure (stringTyCon, [])
   -- Lambda: \x -> body
-  ELambdaPats pats body -> inferLambda NoSourceSpan pats body
+  ELambdaPats pats body -> inferLambda (exprSpan expr `orSourceSpan` ambient) pats body
   -- Lambda case: \case { pat -> body; ... }
-  ELambdaCase alts -> inferLambdaCase NoSourceSpan alts
+  ELambdaCase alts -> inferLambdaCase (exprSpan expr `orSourceSpan` ambient) alts
   -- Multi-argument lambda cases: \cases { p1 p2 -> body; ... }
-  ELambdaCases alts -> inferLambdaCases NoSourceSpan alts
+  ELambdaCases alts -> inferLambdaCases (exprSpan expr `orSourceSpan` ambient) alts
   -- Application: f x
-  EApp fun arg -> inferApp NoSourceSpan fun arg
+  EApp fun arg -> inferApp (exprSpan expr `orSourceSpan` ambient) fun arg
   -- Infix application: a `op` b
-  EInfix lhs op rhs -> inferExpr (EApp (EApp (EVar op) lhs) rhs)
+  EInfix lhs op rhs -> inferExprAt (exprSpan expr `orSourceSpan` ambient) (EApp (EApp (EVar op) lhs) rhs)
   -- If-then-else
-  EIf cond thenE elseE -> inferIf NoSourceSpan cond thenE elseE
+  EIf cond thenE elseE -> inferIf (exprSpan expr `orSourceSpan` ambient) cond thenE elseE
   -- Case expression
-  ECase scrutinee alts -> inferCase NoSourceSpan scrutinee alts
+  ECase scrutinee alts -> inferCase (exprSpan expr `orSourceSpan` ambient) scrutinee alts
   -- Let expression
   ELetDecls decls body ->
     inferLocalDecls inferExpr decls (inferExpr body)
   -- Parenthesized expression
-  EParen inner -> inferExpr inner
+  EParen inner -> inferExprAt (exprSpan expr `orSourceSpan` ambient) inner
   -- Type signature: (e :: T)
   ETypeSig inner _ty -> do
     -- MVP: just infer the inner expression.
     -- Full version would check against the given type.
-    inferExpr inner
+    inferExprAt (exprSpan expr `orSourceSpan` ambient) inner
   -- Negation
   ENegate inner -> do
     (innerTy, cs) <- inferExpr inner
     -- For MVP, just return the inner type.
     pure (innerTy, cs)
   -- Annotated expression (from other passes, e.g. resolve).
-  EAnn _ann inner -> inferExpr inner
+  EAnn ann inner -> inferExprAt (fromMaybe ambient (fromAnnotation @SourceSpan ann)) inner
   -- Tuple
-  ETuple _flavor elems -> inferTuple NoSourceSpan elems
+  ETuple _flavor elems -> inferTuple (exprSpan expr `orSourceSpan` ambient) elems
   -- List
-  EList elems -> inferList NoSourceSpan elems
+  EList elems -> inferList (exprSpan expr `orSourceSpan` ambient) elems
   -- List comprehension
-  EListComp body quals -> inferListComp NoSourceSpan body quals
+  EListComp body quals -> inferListComp (exprSpan expr `orSourceSpan` ambient) body quals
   -- Unsupported expression forms for MVP.
   other -> do
-    emitError NoSourceSpan (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
+    emitError (exprSpan expr `orSourceSpan` ambient) (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
     ty <- freshMetaTv
     pure (ty, [])
 
@@ -172,7 +175,27 @@ inferLambdaCases sp alts = do
 -- Each alternative's pattern is checked against the scrutinee type,
 -- and each RHS must unify with the expected result type.
 inferCaseAlts :: SourceSpan -> TcType -> TcType -> [CaseAlt Expr] -> TcM [Ct]
-inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
+inferCaseAlts _sp _scrutTy _resTy [] = pure []
+inferCaseAlts sp scrutTy resTy (firstAlt : restAlts) = do
+  (firstBranchSp, firstRhsSp, firstRhsTy, firstCts) <- inferAlt firstAlt
+  resultEv <- freshEvVar
+  let resultCt =
+        mkWantedEqCt
+          TypeTrace
+            { typeTraceType = firstRhsTy,
+              typeTraceRole = ActualType,
+              typeTraceOrigin = ExpressionTypeOrigin firstRhsSp
+            }
+          TypeTrace
+            { typeTraceType = resTy,
+              typeTraceRole = ExpectedType,
+              typeTraceOrigin = ConstraintTypeOrigin (CaseBranchOrigin firstBranchSp)
+            }
+          resultEv
+          (CaseBranchOrigin firstRhsSp)
+          firstRhsSp
+  restCts <- concat <$> mapM (inferAltAgainst firstBranchSp firstRhsTy) restAlts
+  pure (firstCts ++ [resultCt] ++ restCts)
   where
     inferAlt (CaseAlt altAnns pat rhs) = do
       let altSp = sourceSpanFromAnns altAnns
@@ -182,10 +205,28 @@ inferCaseAlts sp scrutTy resTy alts = concat <$> mapM inferAlt alts
       patCts <- inferPatternConstraints branchSp scrutTy pat
       -- Infer the RHS under the pattern bindings.
       (rhsTy, rhsCts) <- withPatternBindings bindings (inferRhs rhs)
-      -- RHS must match the expected result type.
+      let rhsSp = rhsExprSpan rhs `orSourceSpan` branchSp
+      pure (branchSp, rhsSp, rhsTy, patCts ++ rhsCts)
+
+    inferAltAgainst expectedBranchSp expectedTy alt = do
+      (branchSp, rhsSp, rhsTy, cts) <- inferAlt alt
       ev <- freshEvVar
-      let rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (CaseBranchOrigin branchSp) branchSp
-      pure (patCts ++ rhsCts ++ [rhsCt])
+      let rhsCt =
+            mkWantedEqCt
+              TypeTrace
+                { typeTraceType = rhsTy,
+                  typeTraceRole = ActualType,
+                  typeTraceOrigin = ExpressionTypeOrigin rhsSp
+                }
+              TypeTrace
+                { typeTraceType = expectedTy,
+                  typeTraceRole = ExpectedType,
+                  typeTraceOrigin = ConstraintTypeOrigin (CaseBranchOrigin expectedBranchSp)
+                }
+              ev
+              (CaseBranchOrigin branchSp)
+              rhsSp
+      pure (cts ++ [rhsCt])
 
 inferLambdaCaseAlt :: SourceSpan -> [TcType] -> TcType -> LambdaCaseAlt -> TcM [Ct]
 inferLambdaCaseAlt sp argTys resTy alt = do
@@ -292,17 +333,35 @@ inferList sp elems = case elems of
     elemTy <- freshMetaTv
     pure (TcTyCon listTyCon' [elemTy], [])
   (e : es) -> do
+    let headSp = exprSpan e `orSourceSpan` sp
     (headTy, headCts) <- inferExpr e
-    results <- mapM inferExpr es
-    let tailCts = concatMap snd results
+    results <- mapM inferElem es
+    let tailCts = concatMap (\(_, elemCts, _) -> elemCts) results
     -- All elements must have the same type.
-    eqCts <- mapM (mkElemEq headTy) results
+    eqCts <- mapM (mkElemEq headSp headTy) results
     pure (TcTyCon listTyCon' [headTy], headCts ++ tailCts ++ eqCts)
   where
     listTyCon' = TyCon {tyConName = "[]", tyConArity = 1}
-    mkElemEq headTy (elemTy, _) = do
+    inferElem elemExpr = do
+      (elemTy, elemCts) <- inferExpr elemExpr
+      pure (elemTy, elemCts, exprSpan elemExpr `orSourceSpan` sp)
+    mkElemEq headSp headTy (elemTy, _, elemSp) = do
       ev <- freshEvVar
-      pure $ mkWantedCt (EqPred headTy elemTy) ev (AppOrigin sp) sp
+      pure $
+        mkWantedEqCt
+          TypeTrace
+            { typeTraceType = elemTy,
+              typeTraceRole = ActualType,
+              typeTraceOrigin = ExpressionTypeOrigin elemSp
+            }
+          TypeTrace
+            { typeTraceType = headTy,
+              typeTraceRole = ExpectedType,
+              typeTraceOrigin = ListElementTypeOrigin headSp
+            }
+          ev
+          (AppOrigin elemSp)
+          elemSp
 
 -- | Infer the type of a list comprehension.
 --
@@ -361,6 +420,12 @@ compStmtSpan compStmt =
   case compStmt of
     CompAnn ann _ -> fromMaybe NoSourceSpan (fromAnnotation @SourceSpan ann)
     _ -> NoSourceSpan
+
+rhsExprSpan :: Rhs Expr -> SourceSpan
+rhsExprSpan rhs =
+  case rhs of
+    UnguardedRhs anns expr _ -> exprSpan expr `orSourceSpan` sourceSpanFromAnns anns
+    GuardedRhss anns _ _ -> sourceSpanFromAnns anns
 
 exprSpan :: Expr -> SourceSpan
 exprSpan expr =

--- a/components/aihc-tc/src/Aihc/Tc/Solve.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve.hs
@@ -102,7 +102,7 @@ processEq wl ct = do
       -- Report the error.
       case ctPred errCt of
         EqPred t1 t2 ->
-          emitError (ctLoc errCt) (UnificationError t1 t2 (ctOrigin errCt))
+          emitError (ctLoc errCt) . UnificationError t1 t2 (ctOrigin errCt) =<< zonkCtEqProvenance errCt
         p ->
           emitError (ctLoc errCt) (UnsolvedWanted p (ctOrigin errCt))
       pure wl
@@ -173,10 +173,29 @@ solveWantedWithGivens givens ct = case ctPred ct of
       EqError errCt ->
         case ctPred errCt of
           EqPred et1 et2 ->
-            emitError (ctLoc errCt) (UnificationError et1 et2 (ctOrigin errCt))
+            emitError (ctLoc errCt) . UnificationError et1 et2 (ctOrigin errCt) =<< zonkCtEqProvenance errCt
           p ->
             emitError (ctLoc errCt) (UnsolvedWanted p (ctOrigin errCt))
   _ -> pure ()
+
+zonkCtEqProvenance :: Ct -> TcM (Maybe EqProvenance)
+zonkCtEqProvenance ct =
+  traverse zonkEqProvenance (ctEqProvenance ct)
+
+zonkEqProvenance :: EqProvenance -> TcM EqProvenance
+zonkEqProvenance provenance = do
+  actual <- zonkTypeTrace (eqActualTrace provenance)
+  expected <- zonkTypeTrace (eqExpectedTrace provenance)
+  pure
+    provenance
+      { eqActualTrace = actual,
+        eqExpectedTrace = expected
+      }
+
+zonkTypeTrace :: TypeTrace -> TcM TypeTrace
+zonkTypeTrace trace' = do
+  ty <- zonkType (typeTraceType trace')
+  pure (trace' {typeTraceType = ty})
 
 -- | Strict left fold in a monad.
 foldM :: (Monad m) => (a -> b -> m a) -> a -> [b] -> m a

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
@@ -30,7 +30,7 @@ solveEquality ct = case ctPred ct of
   EqPred t1 t2 -> do
     t1' <- zonkType t1
     t2' <- zonkType t2
-    solveEq ct t1' t2'
+    solveEq (ct {ctPred = EqPred t1' t2'}) t1' t2'
   _ -> pure (EqStuck ct)
 
 -- | Solve an equality between two zonked types.

--- a/components/aihc-tc/src/Aihc/Tc/Unify.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Unify.hs
@@ -24,9 +24,9 @@ unify loc origin t1 t2 = do
   result <- unifyTypes t1' t2'
   case result of
     Right () -> pure ()
+    Left (UnificationError left right _ provenance) ->
+      emitError loc (UnificationError left right origin provenance)
     Left err -> emitError loc err
-  where
-    _ = origin -- carried for future error-reporting enhancement
 
 -- | Attempt to unify two types, returning an error kind on failure.
 unifyTypes :: TcType -> TcType -> TcM (Either TcErrorKind ())
@@ -50,7 +50,7 @@ unifyTypes (TcAppTy f1 a1) (TcAppTy f2 a2) = do
   r2 <- unifyTypes a1 a2
   pure $ r1 >> r2
 unifyTypes t1 t2 =
-  pure $ Left $ UnificationError t1 t2 (UnifyOrigin NoSourceSpan)
+  pure $ Left $ UnificationError t1 t2 (UnifyOrigin NoSourceSpan) Nothing
 
 -- | Unify a meta-variable with a type, performing the occurs check.
 unifyMetaTv :: Unique -> TcType -> TcM (Either TcErrorKind ())

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-error-case-branches.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-error-case-branches.yaml
@@ -1,0 +1,21 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = True | False
+    val = case () of
+      () -> True
+      () -> ()
+annotated:
+  - |-
+    module Test where
+    data Bool = True | False
+         │      │      └─ False ∷ Bool
+         │      └─ True ∷ Bool
+         └─ Bool ∷ *
+    val = case () of
+      () -> True
+      () -> ()
+            └─ error: expression has type (), but expected Bool from a case branch
+status: pass
+reason: case branch result mismatches should explain where the expected type came from

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-error-list-elements.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-error-list-elements.yaml
@@ -1,0 +1,17 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = True | False
+    list = [True, ()]
+annotated:
+  - |-
+    module Test where
+    data Bool = True | False
+         │      │      └─ False ∷ Bool
+         │      └─ True ∷ Bool
+         └─ Bool ∷ *
+    list = [True, ()]
+                  └─ error: expression has type (), but expected Bool from an earlier list element
+status: pass
+reason: list element mismatches should explain where the expected element type came from

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-error-partial.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-error-partial.yaml
@@ -12,6 +12,6 @@ annotated:
     └─ y ∷ ()
     x :: ()
     x = []
-    └─ error: couldn't match [?1] with ()
+        └─ error: expression has type [?1], but expected () from the type signature for x
 status: pass
 reason: type errors should render alongside successful annotations


### PR DESCRIPTION
## What changed

- Added expected-vs-actual provenance to equality constraints so solver reorientation does not erase diagnostic roles.
- Preserved expression spans through TC expression inference and kept top-level type signature spans alongside checked schemes.
- Rendered unification diagnostics with expected-type provenance in the primary error message.
- Removed the separate expected-type note for type signatures; that provenance now stays with the error.
- Added case-branch result provenance so later mismatching branches can report that the expected type came from another case branch.
- Added list-element result provenance so later mismatching elements can report that the expected type came from an earlier list element.
- Updated `type-error-partial.yaml` and added `type-error-case-branches.yaml` and `type-error-list-elements.yaml`.

## Why

Unification errors were reduced to two final types and one origin. That made diagnostics choose coarse spans such as the whole binding and gave no explanation for where expected types came from.

## Progress counts

- TC annotated golden fixtures: +2 pass fixtures (`type-error-case-branches.yaml`, `type-error-list-elements.yaml`).
- No fixture status counts changed.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `cabal run -v0 aihc-dev -- update-goldens` (diagnostic pass fixtures were skipped by the updater, so affected annotated fixtures were kept in sync manually from rendered output)
- `just fmt`
- `just check`
