### PR TITLE
docs: update aihc test authoring skill

### DIFF
--- a/.agents/skills/aihc-test-authoring/SKILL.md
+++ b/.agents/skills/aihc-test-authoring/SKILL.md
@@ -32,7 +32,7 @@ Prefer a single focused fixture over a large scenario unless the behavior only a
 - `aihc-cpp`: read `references/aihc-cpp.md` for `cpphs` progress fixtures and preprocessor unit tests.
 - `aihc-parser`: read `references/aihc-parser.md` for parser golden, equivalent, lexer golden, error-message, oracle, unit, performance, and property tests.
 - `aihc-resolve`: read `references/aihc-resolve.md` for resolver golden fixtures and unit tests.
-- `aihc-tc`: read `references/aihc-tc.md` for type-checker golden fixtures, unit tests, and properties.
+- `aihc-tc`: read `references/aihc-tc.md` for type-checker annotated golden fixtures, unit tests, and properties.
 - `aihc-fc`: read `references/aihc-fc.md` for FC golden fixtures, eval fixtures, and unit tests.
 - Shared commands and status semantics: read `references/validation.md`.
 

--- a/.agents/skills/aihc-test-authoring/references/aihc-tc.md
+++ b/.agents/skills/aihc-test-authoring/references/aihc-tc.md
@@ -1,16 +1,18 @@
 # aihc-tc Tests
 
-Use `aihc-tc` tests for type inference, type-checker diagnostics, unification, zonking, constraints, and solver behavior.
+Use `aihc-tc` tests for type inference, type-checker diagnostics, AST annotations, unification, zonking, constraints, and solver behavior.
 
 ## Choose The Test
 
-- Use golden fixtures when the contract is the inferred binding types for one or more modules, or a known type-check failure.
-- Use unit tests when the behavior is an internal operation such as unification, constraint solving, environment handling, or diagnostic construction.
+- Use annotated golden fixtures when the user-visible contract is the type-checker overlay for one or more modules: inferred binding types, expression annotations, kind annotations, evidence annotations, or rendered type diagnostics.
+- Use unit tests when the behavior is an internal operation or precise API invariant such as unification, constraint solving, environment handling, diagnostic construction, annotation structure, or a focused expression/module result.
 - Use QuickCheck properties for algebraic type-checker invariants. Existing examples live in `components/aihc-tc/test/Test/Tc/Properties.hs`.
 
-## Golden Fixtures
+Prefer annotated golden fixtures for source-level behavior because they exercise parse, resolve, type-check, and rendering in the same path used by downstream FC tests. Prefer unit tests for assertions that need direct access to `TcType`, `TcDiagnostic`, evidence terms, or helper APIs.
 
-Root: `components/aihc-tc/test/Test/Fixtures/golden`.
+## Annotated Golden Fixtures
+
+Root: `components/aihc-tc/test/Test/Fixtures/annotated`.
 
 Fixture shape:
 
@@ -20,21 +22,46 @@ modules:
   - |
     module Test where
     id x = x
-expected:
-  - "id :: forall a. a -> a"
+annotated:
+  - |-
+    module Test where
+    id x = x
+    │  └─ x ∷ a
+    └─ id ∷ ∀ a. a → a
 status: pass
 reason: ""
 ```
 
-Required keys: `extensions`, `modules`, `status`. `expected` may be a string, list of strings, or object keyed by module name. The runner parses each module, runs `typecheckModule`, and compares rendered binding types.
+Required keys: `extensions`, `modules`, `annotated`, `status`. `reason` is optional except where noted below. `modules` and `annotated` are lists of strings; each `annotated` entry is the rendered overlay for the corresponding module source.
 
-Statuses: `pass`, `fail`, `xfail`, `xpass`. Use `fail` when the expected behavior is rejection and rendered diagnostics are not the contract. Use `xfail` for known gaps; include a reason.
+Supported statuses are `pass`, `xfail`, and `xpass`. There is no `fail` status for TC annotated fixtures. Use `pass` for current expected output. Use `xfail` for a known gap and include a concrete `reason`; an `xfail` whose output starts matching becomes an `XPASS` and fails the suite. Use `xpass` only as strict tracking for a known bug that currently matches the annotated output; include `reason`.
+
+The runner:
+
+1. Parses each module with the fixture extensions.
+2. Resolves the parsed modules with `aihc-resolve`.
+3. Runs `typecheck` over the resolved module list.
+4. Renders source overlays with `renderAnnotatedTcResults`.
+5. Compares trimmed overlays with the `annotated` list.
+
+Type errors are part of the overlay contract when type checking still returns a rendered module. Parse or resolve failures are failures for `pass`, tolerated for `xfail`, and failures for `xpass`.
+
+Regenerate `annotated` from the current implementation only when the changed output is intentional:
+
+```bash
+cabal run -v0 aihc-dev -- update-goldens --dry-run
+cabal run -v0 aihc-dev -- update-goldens
+```
+
+The updater scans `components/aihc-tc/test/Test/Fixtures/annotated` and updates `annotated` only for `pass` and `xpass` fixtures. It skips `xfail` fixtures and fixtures that cannot parse, resolve, type-check, or render a successful output.
 
 ## Unit And Property Tests
 
 Add tests under `components/aihc-tc/test/Test/Tc/Suite.hs` for focused examples. Add properties to `Test/Tc/Properties.hs` and keep them in the `properties` group.
 
-Prefer properties for invariants such as idempotency, reflexivity, or stability under zonking/substitution. Prefer golden fixtures for user-visible inference examples.
+Current unit groups live under `tc-unit` and include literals, application, case, if-then-else, lambda, variables, kinds, annotations, and error-cases. Keep new unit tests in the nearest existing group, or add a narrowly named group when the behavior does not fit.
+
+Prefer properties for invariants such as idempotency, reflexivity, or stability under zonking/substitution. Prefer annotated golden fixtures for user-visible inference and diagnostic examples.
 
 ## Validation
 
@@ -42,4 +69,7 @@ Run:
 
 ```bash
 cabal test -v0 aihc-tc:spec --test-options="--hide-successes"
+cabal test -v0 aihc-tc:spec --test-options="--pattern tc-annotated-golden --hide-successes"
+cabal test -v0 aihc-tc:spec --test-options="--pattern tc-unit --hide-successes"
+cabal test -v0 aihc-tc:spec --test-options="--pattern properties --hide-successes"
 ```

--- a/.agents/skills/aihc-test-authoring/references/validation.md
+++ b/.agents/skills/aihc-test-authoring/references/validation.md
@@ -12,7 +12,7 @@ Use narrow commands while developing, then run the mandatory checks before commi
 - Parser properties: `cabal test -v0 aihc-parser:spec --test-options="--pattern properties --quickcheck-tests 1000 --hide-successes"`
 - Deep parser fuzzing: `cabal test -v0 aihc-parser:spec --test-options="--pattern properties --quickcheck-tests 10000"`
 - Resolve golden: `cabal test -v0 aihc-resolve:spec --test-options="--pattern resolver-golden --hide-successes"`
-- Type checker golden/properties: `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
+- Type checker annotated golden/unit/properties: `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
 - FC golden/eval: `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
 - CPP oracle/unit suite: `cabal test -v0 aihc-cpp:spec --test-options="--hide-successes"`
 
@@ -25,7 +25,7 @@ cabal run -v0 aihc-dev -- update-goldens --dry-run
 cabal run -v0 aihc-dev -- update-goldens
 ```
 
-Run it from the repository root. Use `--root <dir>` only when invoking it from another working directory. The updater scans parser AST goldens, lexer goldens, parser error messages, resolver goldens, TC goldens, TC annotated goldens, FC goldens, FC eval outputs, formatter goldens, and parser CLI goldens. It updates generated expectation fields such as `ast`, `tokens`, `expected`, `output`, and `annotated` only for `pass` and `xpass` fixtures; `fail` and `xfail` cases are skipped because their expected output is not the current success contract.
+Run it from the repository root. Use `--root <dir>` only when invoking it from another working directory. The updater scans parser AST goldens, lexer goldens, parser error messages, resolver goldens, TC annotated goldens, FC goldens, FC eval outputs, formatter goldens, and parser CLI goldens. It updates generated expectation fields such as `ast`, `tokens`, `expected`, `output`, and `annotated` only for `pass` and `xpass` fixtures; `fail` and `xfail` cases are skipped because their expected output is not the current success contract.
 
 After running without `--dry-run`, inspect the diff before accepting it. A changed golden is evidence that behavior changed, not evidence that the new behavior is correct. Keep intentional fixture metadata (`status`, `reason`, extension lists, dependencies, module sources, and expression sources) under review.
 
@@ -43,7 +43,7 @@ Do not commit if `just check` fails. Fix formatting, lint, or test failures firs
 ## Status Semantics
 
 - `pass`: expected to pass now.
-- `fail`: expected to fail now; supported by parser golden, TC golden, and FC golden where the loader accepts it.
+- `fail`: expected to fail now; supported by parser golden, FC golden, and FC eval fixtures where the loader accepts it. TC annotated fixtures do not accept `fail`.
 - `xfail`: known gap; the test is expected not to satisfy the success contract yet and must include `reason`.
 - `xpass`: known bug that currently passes unexpectedly; treat as strict tracking and include `reason`. Not every fixture format accepts `xpass` (`aihc-parser` parser golden and equivalent fixtures reject it).
 


### PR DESCRIPTION
## Summary

- Update the `aihc-test-authoring` skill to describe the current `aihc-tc` annotated golden fixture framework.
- Correct shared validation guidance for TC annotated goldens and accepted status semantics.
- Remove stale references to nonexistent TC signature golden fixtures.

## Progress counts

- Unchanged. This is a documentation-only skill update; no README/progress fixture counts were updated.

## Validation

- `just fmt`
- `just check`
