### PR TITLE
refactor(tc): return diagnostics as module annotations

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -57,14 +57,15 @@ import Aihc.Tc
   ( Pred (..),
     TcBindingResult (..),
     TcDiagnostic (..),
-    TcModuleResult (..),
     TcSeverity (..),
     TcType (..),
     TyCon (..),
     TyVarId (..),
     Unique (..),
     renderTcType,
-    tcmBindings,
+    tcModuleBindings,
+    tcModuleDiagnostics,
+    tcModuleSuccess,
     typecheckModule,
   )
 import Control.Applicative ((<|>))
@@ -978,12 +979,12 @@ typecheckInterfaceModules modules = do
   completedModules <- newIORef []
   result <- timeout typecheckPhaseTimeoutMicros (go currentModule completedModules [] modules)
   case result of
-    Just tcModules -> pure (tcModules, concatMap tcModuleDiagnostics tcModules)
+    Just tcModules -> pure (tcModules, concatMap tcModuleDiagnosticValues tcModules)
     Nothing -> do
       acc <- readIORef completedModules
       current <- readIORef currentModule
       let tcModules = reverse acc
-      pure (tcModules, concatMap tcModuleDiagnostics tcModules <> [typecheckTimeoutDiagnostic current])
+      pure (tcModules, concatMap tcModuleDiagnosticValues tcModules <> [typecheckTimeoutDiagnostic current])
   where
     go _current _completed acc [] =
       pure (reverse acc)
@@ -1207,21 +1208,21 @@ moduleExportsValue exports =
   | (moduleNameText, scope) <- Map.toAscList exports
   ]
 
-tcModuleValue :: Module -> TcModuleResult -> Aeson.Value
+tcModuleValue :: Module -> Module -> Aeson.Value
 tcModuleValue modu result =
   object
     [ "module" .= moduleDisplayName modu,
-      "success" .= tcmSuccess result,
-      "bindings" .= map tcBindingValue (tcmBindings result),
-      "diagnostics" .= map (tcDiagnosticValue (moduleDisplayName modu)) (tcmDiagnostics result)
+      "success" .= tcModuleSuccess result,
+      "bindings" .= map tcBindingValue (tcModuleBindings result),
+      "diagnostics" .= map (tcDiagnosticValue (moduleDisplayName modu)) (tcModuleDiagnostics result)
     ]
 
-tcModuleDiagnostics :: Aeson.Value -> [Aeson.Value]
-tcModuleDiagnostics (Aeson.Object obj) =
+tcModuleDiagnosticValues :: Aeson.Value -> [Aeson.Value]
+tcModuleDiagnosticValues (Aeson.Object obj) =
   case KeyMap.lookup "diagnostics" obj of
     Just (Aeson.Array arr) -> foldr (:) [] arr
     _ -> []
-tcModuleDiagnostics _ = []
+tcModuleDiagnosticValues _ = []
 
 tcBindingValue :: TcBindingResult -> Aeson.Value
 tcBindingValue binding =
@@ -1306,7 +1307,7 @@ uniqueValue (Unique unique) = unique
 tcDiagnosticValue :: Text -> TcDiagnostic -> Aeson.Value
 tcDiagnosticValue moduleName diag =
   object
-    [ "span" .= sourceSpanValue (diagLoc diag),
+    [ "span" .= sourceSpanValue (fromMaybe NoSourceSpan (diagLoc diag)),
       "severity" .= tcSeverityText (diagSeverity diag),
       "module" .= moduleName,
       "message" .= show (diagKind diag)

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -36,14 +36,15 @@ import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), Resol
 import Aihc.Tc
   ( Pred (..),
     TcBindingResult (..),
-    TcModuleResult (..),
     TcType (..),
     TyCon (..),
     TyVarId (..),
     TypeScheme (..),
     Unique (..),
     renderTcType,
-    tcmBindings,
+    tcModuleBindings,
+    tcModuleDiagnostics,
+    tcModuleSuccess,
     typecheckModuleWithEnv,
   )
 import Control.Monad.IO.Class (liftIO)
@@ -166,11 +167,11 @@ evaluateExpression session input = do
         [modu] -> Right modu
         _ -> Left (ReplResolveError [ResolveNotImplemented "REPL resolver returned no module"])
     let tcResult = typecheckModuleWithEnv (replImportedTerms session) resolvedModule
-    if tcmSuccess tcResult
+    if tcModuleSuccess tcResult
       then pure ()
-      else Left (ReplTypeError (map show (tcmDiagnostics tcResult)))
+      else Left (ReplTypeError (map show (tcModuleDiagnostics tcResult)))
     inferredType <-
-      case find ((== replBindingName) . tbName) (tcmBindings tcResult) of
+      case find ((== replBindingName) . tbName) (tcModuleBindings tcResult) of
         Just binding -> Right (tbType binding)
         Nothing -> Left (ReplTypeError ["missing inferred type for " <> T.unpack replBindingName])
     let dsResult = desugarModuleWithTcResult tcResult resolvedModule

--- a/components/aihc-fc/common/FcEvalGolden.hs
+++ b/components/aihc-fc/common/FcEvalGolden.hs
@@ -33,7 +33,7 @@ import Aihc.Parser.Syntax
     parseExtensionName,
   )
 import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
-import Aihc.Tc (TcBindingResult, TcModuleResult (..), tcmBindings, typecheckModulesWithEnv)
+import Aihc.Tc (TcBindingResult, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithEnv)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
@@ -157,7 +157,7 @@ evaluateFcEvalCase tc =
              in case resolved of
                   ResolveResult {resolvedModules, resolveErrors = []} ->
                     let tcResults = typecheckModulesWithEnv [] resolvedModules
-                     in if all tcmSuccess tcResults
+                     in if all tcModuleSuccess tcResults
                           then
                             let allBindings = moduleGroupBindings tcResults
                                 results = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
@@ -234,16 +234,16 @@ evalDecl expr =
           }
       ]
 
-renderTcErrors :: [TcModuleResult] -> String
+renderTcErrors :: [Module] -> String
 renderTcErrors results =
-  let rendered = unlines [show diagnostic | result <- results, diagnostic <- tcmDiagnostics result]
+  let rendered = unlines [show diagnostic | result <- results, diagnostic <- tcModuleDiagnostics result]
    in if null (trim rendered)
         then "type checker failed without diagnostics"
         else rendered
 
-moduleGroupBindings :: [TcModuleResult] -> [TcBindingResult]
+moduleGroupBindings :: [Module] -> [TcBindingResult]
 moduleGroupBindings =
-  concatMap tcmBindings
+  concatMap tcModuleBindings
 
 concatPrograms :: [FcProgram] -> FcProgram
 concatPrograms programs =

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -22,9 +22,9 @@ import Aihc.Parser
     defaultConfig,
     parseModule,
   )
-import Aihc.Parser.Syntax (Extension, parseExtensionName)
+import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
 import Aihc.Resolve (ResolveResult (..), resolve)
-import Aihc.Tc (TcBindingResult, TcModuleResult (..), tcmBindings, typecheck)
+import Aihc.Tc (TcBindingResult, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheck)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
@@ -137,7 +137,7 @@ evaluateFcCase tc =
           case resolve modules of
             ResolveResult {resolvedModules, resolveErrors = []} ->
               let tcResults = typecheck resolvedModules
-               in if all tcmSuccess tcResults
+               in if all tcModuleSuccess tcResults
                     then
                       let allBindings = moduleGroupBindings tcResults
                           results = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
@@ -163,13 +163,13 @@ evaluateFcCase tc =
     renderErrors results =
       unlines [err | r <- results, err <- dsErrors r]
 
-moduleGroupBindings :: [TcModuleResult] -> [TcBindingResult]
+moduleGroupBindings :: [Module] -> [TcBindingResult]
 moduleGroupBindings =
-  concatMap tcmBindings
+  concatMap tcModuleBindings
 
-renderTcErrors :: [TcModuleResult] -> String
+renderTcErrors :: [Module] -> String
 renderTcErrors results =
-  unlines [show d | r <- results, d <- tcmDiagnostics r]
+  unlines [show d | r <- results, d <- tcModuleDiagnostics r]
 
 classifySuccess :: FcCase -> String -> (Outcome, String)
 classifySuccess tc actual =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -36,7 +36,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameText,
   )
 import Aihc.Resolve (ResolveResult (..), resolve)
-import Aihc.Tc (TcBindingResult (..), TcModuleResult (..), renderTcSignature, tcmBindings, typecheckModule)
+import Aihc.Tc (TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
 import Aihc.Tc.Annotations (TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Control.Monad (zipWithM)
@@ -69,13 +69,13 @@ desugarModule m =
 -- | Desugar a module using a type-checking result already computed by
 -- the caller. This is useful for clients such as the REPL that preload
 -- imported bindings into the type-checker environment.
-desugarModuleWithTcResult :: TcModuleResult -> Module -> DesugarResult
+desugarModuleWithTcResult :: Module -> Module -> DesugarResult
 desugarModuleWithTcResult tcResult =
-  desugarModuleWithBindings (tcmBindings tcResult) tcResult
+  desugarModuleWithBindings (tcModuleBindings tcResult) tcResult
 
-desugarModuleWithBindings :: [TcBindingResult] -> TcModuleResult -> Module -> DesugarResult
+desugarModuleWithBindings :: [TcBindingResult] -> Module -> Module -> DesugarResult
 desugarModuleWithBindings bindings tcResult _m =
-  if not (tcmSuccess tcResult)
+  if not (tcModuleSuccess tcResult)
     then
       DesugarResult
         { dsProgram = FcProgram [],
@@ -84,7 +84,7 @@ desugarModuleWithBindings bindings tcResult _m =
         }
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
-       in case runStateT (dsModule (tcmModule tcResult)) (DsState 1000 typeEnv Map.empty Map.empty) of
+       in case runStateT (dsModule tcResult) (DsState 1000 typeEnv Map.empty Map.empty) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram [],
@@ -102,10 +102,10 @@ desugarModuleWithBindings bindings tcResult _m =
 showBinding :: TcBindingResult -> String
 showBinding b = renderTcSignature (tbDisplayName b) (tbType b)
 
-showTcFailure :: TcModuleResult -> [String]
+showTcFailure :: Module -> [String]
 showTcFailure tcResult =
-  case map show (tcmDiagnostics tcResult) of
-    [] -> map showBinding (tcmBindings tcResult)
+  case map show (tcModuleDiagnostics tcResult) of
+    [] -> map showBinding (tcModuleBindings tcResult)
     diagnostics -> diagnostics
 
 bindingTypeEntries :: TcBindingResult -> [(Text, TcType)]

--- a/components/aihc-tc/common/TcAnnotatedRender.hs
+++ b/components/aihc-tc/common/TcAnnotatedRender.hs
@@ -38,7 +38,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     moduleName,
   )
-import Aihc.Tc (TcModuleResult (..), TcType (..), renderTcSignature, renderTcType)
+import Aihc.Tc (TcType (..), renderTcSignature, renderTcType, tcModuleDiagnostics)
 import Aihc.Tc.Annotations
   ( TcAnnotation (..),
     TcClassAnnotation (..),
@@ -57,9 +57,9 @@ import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-renderAnnotatedTcResults :: [Text] -> [TcModuleResult] -> [String]
+renderAnnotatedTcResults :: [Text] -> [Module] -> [String]
 renderAnnotatedTcResults sources results =
-  map renderOne (sortOn (moduleDisplayName . tcmModule . snd) (zip sources results))
+  map renderOne (sortOn (moduleDisplayName . snd) (zip sources results))
   where
     renderOne (source, result) =
       renderAnnotatedSource source (collectTcLabels result)
@@ -76,13 +76,13 @@ data TcLabel = TcLabel
 sourceLabel :: SourceSpan -> String -> TcLabel
 sourceLabel = TcLabel
 
-collectTcLabels :: TcModuleResult -> [TcLabel]
+collectTcLabels :: Module -> [TcLabel]
 collectTcLabels result =
   sortOn labelKey $
     -- The annotated AST is the source of truth: it preserves source placement
     -- and distinct binders that a flat binding table can conflate.
-    concatMap (declLabels Nothing) (moduleDecls (tcmModule result))
-      <> diagnosticLabels (tcmDiagnostics result)
+    concatMap (declLabels Nothing) (moduleDecls result)
+      <> diagnosticLabels (tcModuleDiagnostics result)
 
 diagnosticLabels :: [TcDiagnostic] -> [TcLabel]
 diagnosticLabels =
@@ -120,11 +120,11 @@ diagnosticRelatedLabels diagnostic =
 diagnosticSpan :: TcDiagnostic -> SourceSpan
 diagnosticSpan diagnostic =
   case diagLoc diagnostic of
-    NoSourceSpan ->
+    Nothing ->
       case diagKind diagnostic of
         UnificationError _ _ _ (Just provenance) -> eqPrimarySpan provenance
         _ -> originSpan (diagnosticOrigin diagnostic)
-    sp -> sp
+    Just sp -> sp
 
 diagnosticOrigin :: TcDiagnostic -> Maybe CtOrigin
 diagnosticOrigin diagnostic =

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -20,9 +20,12 @@ module Aihc.Tc
 
     -- * Result types
     TcResult (..),
-    TcModuleResult (..),
     TcBindingResult (..),
-    tcmBindings,
+
+    -- * Module result projections
+    tcModuleBindings,
+    tcModuleDiagnostics,
+    tcModuleSuccess,
 
     -- * Re-exports for convenience
     TcType (..),
@@ -41,7 +44,7 @@ module Aihc.Tc
   )
 where
 
-import Aihc.Parser.Syntax (Expr, Extension (..), Module (..), applyExtensionSetting, applyImpliedExtensions)
+import Aihc.Parser.Syntax (Expr, Extension (..), Module (..), applyExtensionSetting, applyImpliedExtensions, fromAnnotation, mkAnnotation)
 import Aihc.Tc.Annotations (TcAnnotation (..), renderTcSignature, renderTcType)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, tcModule)
@@ -50,8 +53,11 @@ import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)
+import Data.Data (Data, gmapQ)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (maybeToList)
 import Data.Text (Text)
+import Data.Typeable (cast)
 
 -- | Result of type checking.
 data TcResult = TcResult
@@ -98,44 +104,42 @@ typecheckExprM expr = do
   -- 3. Zonk the result type.
   zonkType ty
 
--- | Result of type-checking a module.
-data TcModuleResult = TcModuleResult
-  { -- | Module annotated with type-checker elaboration data.
-    tcmModule :: !Module,
-    -- | Diagnostics (errors and warnings) produced.
-    tcmDiagnostics :: ![TcDiagnostic],
-    -- | Whether type checking succeeded (no errors).
-    tcmSuccess :: !Bool
-  }
-  deriving (Show)
+-- | Top-level bindings recovered from a type-checked module's annotations.
+tcModuleBindings :: Module -> [TcBindingResult]
+tcModuleBindings =
+  moduleBindings
 
-tcmBindings :: TcModuleResult -> [TcBindingResult]
-tcmBindings =
-  moduleBindings . tcmModule
+-- | Diagnostics recovered from type-checker annotations in a module.
+tcModuleDiagnostics :: Module -> [TcDiagnostic]
+tcModuleDiagnostics =
+  collectTcDiagnostics
+
+-- | Whether an annotated module contains no type-checker errors.
+tcModuleSuccess :: Module -> Bool
+tcModuleSuccess =
+  not . any isError . tcModuleDiagnostics
+  where
+    isError diagnostic = diagSeverity diagnostic == TcError
 
 -- | Type-check a single module, processing data declarations and
 -- value bindings.
-typecheckModule :: Module -> TcModuleResult
+typecheckModule :: Module -> Module
 typecheckModule =
   typecheckModuleWithEnv []
 
 -- | Type-check a single module with preloaded top-level term bindings.
-typecheckModuleWithEnv :: [(Text, TypeScheme)] -> Module -> TcModuleResult
+typecheckModuleWithEnv :: [(Text, TypeScheme)] -> Module -> Module
 typecheckModuleWithEnv importedTerms m =
   case typecheckModulesWithEnv importedTerms [m] of
     [result] -> result
     _ ->
-      TcModuleResult
-        { tcmModule = m,
-          tcmDiagnostics = [],
-          tcmSuccess = False
-        }
+      annotateModuleDiagnostics [internalAbortDiagnostic "type checker returned unexpected module count"] m
 
 -- | Type-check modules in order while sharing the accumulated top-level
 -- environment. This is intentionally pragmatic: callers that have already
 -- resolved a dependency-ordered module list can feed it here so later modules
 -- see earlier data constructors and value bindings.
-typecheckModulesWithEnv :: [(Text, TypeScheme)] -> [Module] -> [TcModuleResult]
+typecheckModulesWithEnv :: [(Text, TypeScheme)] -> [Module] -> [Module]
 typecheckModulesWithEnv importedTerms =
   go initState
   where
@@ -154,26 +158,16 @@ typecheckModulesWithEnv importedTerms =
       let (result, st') = typecheckModuleWithState st m
        in result : go st' ms
 
-typecheckModuleWithState :: TcState -> Module -> (TcModuleResult, TcState)
+typecheckModuleWithState :: TcState -> Module -> (Module, TcState)
 typecheckModuleWithState st m =
   case runTcM tcEnv (st {tcsDiagnostics = []}) (tcModule m) of
-    Left _abort ->
-      ( TcModuleResult
-          { tcmModule = m,
-            tcmDiagnostics = [],
-            tcmSuccess = False
-          },
+    Left abort ->
+      ( annotateModuleDiagnostics [internalAbortDiagnostic (tcAbortMessage abort)] m,
         st
       )
     Right (annotatedModule, st') ->
       let diags = reverse (tcsDiagnostics st')
-          hasErrors = any isError diags
-          result =
-            TcModuleResult
-              { tcmModule = annotatedModule,
-                tcmDiagnostics = diags,
-                tcmSuccess = not hasErrors
-              }
+          result = annotateModuleDiagnostics diags annotatedModule
           nextState =
             st'
               { tcsDiagnostics = [],
@@ -191,8 +185,25 @@ typecheckModuleWithState st m =
     enabledExtensions =
       applyImpliedExtensions $
         foldr applyExtensionSetting [MonoLocalBinds, MonomorphismRestriction] (moduleLanguagePragmas m)
-    isError d = diagSeverity d == TcError
 
 -- | Type-check a list of modules.
-typecheck :: [Module] -> [TcModuleResult]
+typecheck :: [Module] -> [Module]
 typecheck = typecheckModulesWithEnv []
+
+annotateModuleDiagnostics :: [TcDiagnostic] -> Module -> Module
+annotateModuleDiagnostics diagnostics m =
+  m {moduleAnns = moduleAnns m <> map mkAnnotation diagnostics}
+
+collectTcDiagnostics :: (Data a) => a -> [TcDiagnostic]
+collectTcDiagnostics value =
+  case cast value of
+    Just ann -> maybeToList (fromAnnotation ann)
+    Nothing -> concat (gmapQ collectTcDiagnostics value)
+
+internalAbortDiagnostic :: String -> TcDiagnostic
+internalAbortDiagnostic msg =
+  TcDiagnostic
+    { diagLoc = Nothing,
+      diagSeverity = TcError,
+      diagKind = OtherError ("internal type checker abort: " <> msg)
+    }

--- a/components/aihc-tc/src/Aihc/Tc/Error.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Error.hs
@@ -11,8 +11,12 @@ import Aihc.Tc.Constraint (CtOrigin, EqProvenance)
 import Aihc.Tc.Types
 
 -- | A diagnostic produced by the type checker.
+--
+-- Source locations are display metadata, not the identity of the diagnostic.
+-- A diagnostic can be attached to an AST even when the input did not preserve
+-- source spans.
 data TcDiagnostic = TcDiagnostic
-  { diagLoc :: !SourceSpan,
+  { diagLoc :: !(Maybe SourceSpan),
     diagSeverity :: !TcSeverity,
     diagKind :: !TcErrorKind
   }

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -6,6 +6,7 @@ module Aihc.Tc.Monad
     TcM,
     runTcM,
     abortTc,
+    tcAbortMessage,
 
     -- * State
     TcState (..),
@@ -59,7 +60,7 @@ module Aihc.Tc.Monad
   )
 where
 
-import Aihc.Parser.Syntax (SourceSpan)
+import Aihc.Parser.Syntax (SourceSpan (..))
 import Aihc.Tc.Env (InstanceInfo, TyConInfo)
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
@@ -94,6 +95,9 @@ runTcM env st m = runStateT (runReaderT m env) st
 
 abortTc :: String -> TcM a
 abortTc msg = lift (lift (Left (TcAbort msg)))
+
+tcAbortMessage :: TcAbort -> String
+tcAbortMessage (TcAbort msg) = msg
 
 -- | The local typing environment (read-only within a scope).
 data TcEnv = TcEnv
@@ -315,10 +319,14 @@ emitError :: SourceSpan -> TcErrorKind -> TcM ()
 emitError loc kind =
   emitDiagnostic
     TcDiagnostic
-      { diagLoc = loc,
+      { diagLoc = diagnosticLoc loc,
         diagSeverity = TcError,
         diagKind = kind
       }
+
+diagnosticLoc :: SourceSpan -> Maybe SourceSpan
+diagnosticLoc NoSourceSpan = Nothing
+diagnosticLoc sp = Just sp
 
 -- | Get all diagnostics collected so far.
 getDiagnostics :: TcM [TcDiagnostic]

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -22,9 +22,11 @@ import Aihc.Parser.Syntax
     Name (..),
     Pattern (..),
     Rhs (..),
+    SourceSpan,
     ValueDecl (..),
     fromAnnotation,
     mkAnnotation,
+    stripAnnotations,
   )
 import Aihc.Resolve (ResolveResult (..), resolve)
 import Aihc.Tc
@@ -185,8 +187,8 @@ kindTests =
                 \data M a = J a | N\n\
                 \fn :: M\n\
                 \fn = fn\n"
-      assertBool "module should fail" (not (tcmSuccess result))
-      assertBool "should report a kind mismatch" (any isKindMismatch (tcmDiagnostics result)),
+      assertBool "module should fail" (not (tcModuleSuccess result))
+      assertBool "should report a kind mismatch" (any isKindMismatch (tcModuleDiagnostics result)),
     testCase "accepts saturated type constructor in signature" $ do
       let result =
             typecheckModule $
@@ -196,7 +198,7 @@ kindTests =
                 \data M a = J a | N\n\
                 \fn :: M Int\n\
                 \fn = N\n"
-      assertBool "module should typecheck" (tcmSuccess result)
+      assertBool "module should typecheck" (tcModuleSuccess result)
   ]
   where
     isKindMismatch diag =
@@ -208,20 +210,20 @@ annotationTests :: [TestTree]
 annotationTests =
   [ testCase "typeclass annotations select concrete dictionaries" $ do
       let result = typecheckModule annotationModule
-      assertBool "module should typecheck" (tcmSuccess result)
-      assertBool "Eq Bool evidence" ("$fEqBool" `elem` evidenceDictNames (tcmModule result))
-      assertBool "Eq [Bool] evidence" ("$fEqList" `elem` evidenceDictNames (tcmModule result))
-      assertBool "Default Bool evidence" ("$fDefaultBool" `elem` evidenceDictNames (tcmModule result))
-      assertBool "given Eq a evidence inside list instance" (hasGivenClass "Eq" (tcmModule result)),
+      assertBool "module should typecheck" (tcModuleSuccess result)
+      assertBool "Eq Bool evidence" ("$fEqBool" `elem` evidenceDictNames result)
+      assertBool "Eq [Bool] evidence" ("$fEqList" `elem` evidenceDictNames result)
+      assertBool "Default Bool evidence" ("$fDefaultBool" `elem` evidenceDictNames result)
+      assertBool "given Eq a evidence inside list instance" (hasGivenClass "Eq" result),
     testCase "class and instance annotations carry dictionary layout" $ do
       let result = typecheckModule annotationModule
-      assertBool "module should typecheck" (tcmSuccess result)
-      assertBool "Eq class methods annotated" (hasClassMethod "==" 0 (tcmModule result))
-      assertBool "Default class method annotated" (hasClassMethod "def" 0 (tcmModule result))
-      assertBool "Eq Bool instance annotated" (hasInstanceDict "$fEqBool" (tcmModule result))
-      assertBool "Eq list instance annotated" (hasInstanceDict "$fEqList" (tcmModule result))
-      assertBool "Default Bool instance annotated" (hasInstanceDict "$fDefaultBool" (tcmModule result))
-      assertBool "instance method types annotated" (hasInstanceMethod "==" (tcmModule result) && hasInstanceMethod "def" (tcmModule result)),
+      assertBool "module should typecheck" (tcModuleSuccess result)
+      assertBool "Eq class methods annotated" (hasClassMethod "==" 0 result)
+      assertBool "Default class method annotated" (hasClassMethod "def" 0 result)
+      assertBool "Eq Bool instance annotated" (hasInstanceDict "$fEqBool" result)
+      assertBool "Eq list instance annotated" (hasInstanceDict "$fEqList" result)
+      assertBool "Default Bool instance annotated" (hasInstanceDict "$fDefaultBool" result)
+      assertBool "instance method types annotated" (hasInstanceMethod "==" result && hasInstanceMethod "def" result),
     testCase "polymorphic occurrence type arguments are finalized" $ do
       let result =
             typecheckModule $
@@ -229,14 +231,37 @@ annotationTests =
                 "module Test where\n\
                 \f x = x\n\
                 \g y = f (f y)\n"
-          typeArgs = concatMap tcAnnTypeArgs (exprAnnotations (tcmModule result))
-      assertBool "module should typecheck" (tcmSuccess result)
+          typeArgs = concatMap tcAnnTypeArgs (exprAnnotations result)
+      assertBool "module should typecheck" (tcModuleSuccess result)
       assertBool "expected polymorphic occurrence type arguments" (not (null typeArgs))
       assertBool "type arguments should not leak unsolved metas" (not (any hasMetaTcType typeArgs)),
     testCase "module typechecking finalizes all pending annotations" $ do
       let result = typecheckModule annotationModule
-      assertBool "module should typecheck" (tcmSuccess result)
-      assertBool "pending annotations should not escape" (not (containsPendingTcAnnotation (tcmModule result))),
+      assertBool "module should typecheck" (tcModuleSuccess result)
+      assertBool "pending annotations should not escape" (not (containsPendingTcAnnotation result)),
+    testCase "module diagnostics are carried by module annotations" $ do
+      let result =
+            typecheckModule $
+              parseM
+                "module Test where\n\
+                \data M a = J a | N\n\
+                \fn :: M\n\
+                \fn = fn\n"
+      assertBool "module should fail" (not (tcModuleSuccess result))
+      assertBool "diagnostics should be attached to module annotations" (any isTcDiagnosticAnnotation (moduleAnns result)),
+    testCase "module diagnostics do not require source span annotations" $ do
+      let unspannedModule =
+            stripAnnotations $
+              parseM
+                "module Test where\n\
+                \data M a = J a | N\n\
+                \fn :: M\n\
+                \fn = fn\n"
+          result = typecheckModule unspannedModule
+      assertBool "input should not carry source span annotations" (not (containsSourceSpanAnnotation unspannedModule))
+      assertBool "module should fail" (not (tcModuleSuccess result))
+      assertBool "diagnostics should be attached to module annotations" (any isTcDiagnosticAnnotation (moduleAnns result))
+      assertBool "diagnostic location should be absent" (not (any hasDiagnosticLocation (tcModuleDiagnostics result))),
     testCase "finalization rewrites pending annotations in arbitrary syntax positions" $ do
       let pendingModule =
             withPendingGuardedRhsAnnotations $
@@ -386,6 +411,18 @@ containsPendingTcAnnotation =
 containsFinalTcAnnotation :: (Data a) => a -> Bool
 containsFinalTcAnnotation =
   containsParserAnnotation (isJust . fromAnnotation @TcAnnotation)
+
+containsSourceSpanAnnotation :: (Data a) => a -> Bool
+containsSourceSpanAnnotation =
+  containsParserAnnotation (isJust . fromAnnotation @SourceSpan)
+
+isTcDiagnosticAnnotation :: Annotation -> Bool
+isTcDiagnosticAnnotation =
+  isJust . fromAnnotation @TcDiagnostic
+
+hasDiagnosticLocation :: TcDiagnostic -> Bool
+hasDiagnosticLocation =
+  isJust . diagLoc
 
 containsParserAnnotation :: (Data a) => (Annotation -> Bool) -> a -> Bool
 containsParserAnnotation predicate value =

--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -15,8 +15,9 @@ where
 
 import Aihc.Hackage.Stackage (loadStackageSnapshot)
 import Aihc.Hackage.Types (PackageSpec (..))
+import Aihc.Parser.Syntax (Module)
 import Aihc.Resolve (ModuleExports, ResolveResult (..), extractInterface, resolveWithDeps)
-import Aihc.Tc (TcModuleResult (..), typecheck)
+import Aihc.Tc (tcModuleDiagnostics, tcModuleSuccess, typecheck)
 import BootInterface (bootPackageNames, loadBootInterfaces)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
@@ -186,15 +187,15 @@ typecheckOnePackageOrThrow _offline _pkg info depExports = do
 typecheckResolvedPackage :: ResolveResult -> IO RSP.PackageStatus
 typecheckResolvedPackage resolveResult = do
   let results = typecheck (resolvedModules resolveResult)
-      !diagCount = sum (map (length . tcmDiagnostics) results)
+      !diagCount = sum (map (length . tcModuleDiagnostics) results)
   _ <- evaluate diagCount
-  if all tcmSuccess results
+  if all tcModuleSuccess results
     then pure (RSP.PkgSuccess (extractInterface resolveResult))
     else pure (RSP.PkgFailed (renderTcDiagnostics results))
 
-renderTcDiagnostics :: [TcModuleResult] -> String
+renderTcDiagnostics :: [Module] -> String
 renderTcDiagnostics results =
-  unlines [show diag | result <- results, diag <- tcmDiagnostics result]
+  unlines [show diag | result <- results, diag <- tcModuleDiagnostics result]
 
 reportResults :: Int -> Map Text RSP.PackageStatus -> IO ()
 reportResults topN results = do

--- a/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
@@ -44,7 +44,7 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Parser.Token (LexToken (..), LexTokenKind (..), lexModuleTokensWithExtensions, lexTokensWithExtensions)
 import Aihc.Resolve (ResolveResult (..), resolve, resolveWithDeps)
-import Aihc.Tc (TcBindingResult, TcModuleResult (..), tcmBindings, typecheck, typecheckModulesWithEnv)
+import Aihc.Tc (TcBindingResult, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheck, typecheckModulesWithEnv)
 import Control.Exception (IOException, bracket, catch)
 import Control.Monad (foldM, forM, forM_, unless)
 import CppSupport (cppEnabledInSource, preprocessForParserWithoutIncludes)
@@ -354,9 +354,9 @@ tcAnnotatedActual value = do
   case resolve parsed of
     ResolveResult {resolvedModules, resolveErrors = []} ->
       let results = typecheck resolvedModules
-       in if all tcmSuccess results
+       in if all tcModuleSuccess results
             then Right (map trim (renderAnnotatedTcResults modules results))
-            else Left (unlines [show d | r <- results, d <- tcmDiagnostics r])
+            else Left (unlines [show d | r <- results, d <- tcModuleDiagnostics r])
     ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
 
 updateFcGoldens :: Options -> IO Summary
@@ -376,7 +376,7 @@ fcActual value = do
   case resolve parsed of
     ResolveResult {resolvedModules, resolveErrors = []} ->
       let tcResults = typecheck resolvedModules
-       in if all tcmSuccess tcResults
+       in if all tcModuleSuccess tcResults
             then
               let allBindings = moduleGroupBindings tcResults
                   dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
@@ -413,7 +413,7 @@ fcEvalActual opts value =
         case resolveWithDeps mempty (deps <> evalModules) of
           ResolveResult {resolvedModules, resolveErrors = []} ->
             let tcResults = typecheckModulesWithEnv [] resolvedModules
-             in if all tcmSuccess tcResults
+             in if all tcModuleSuccess tcResults
                   then
                     let allBindings = moduleGroupBindings tcResults
                         dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
@@ -533,16 +533,16 @@ concatPrograms :: [FcProgram] -> FcProgram
 concatPrograms programs =
   FcProgram (concatMap fcTopBinds programs)
 
-renderTcErrors :: [TcModuleResult] -> String
+renderTcErrors :: [Module] -> String
 renderTcErrors results =
-  let rendered = unlines [show diagnostic | result <- results, diagnostic <- tcmDiagnostics result]
+  let rendered = unlines [show diagnostic | result <- results, diagnostic <- tcModuleDiagnostics result]
    in if null (trim rendered)
         then "type checker failed without diagnostics"
         else rendered
 
-moduleGroupBindings :: [TcModuleResult] -> [TcBindingResult]
+moduleGroupBindings :: [Module] -> [TcBindingResult]
 moduleGroupBindings =
-  concatMap tcmBindings
+  concatMap tcModuleBindings
 
 updateFormatterGoldens :: Options -> IO Summary
 updateFormatterGoldens opts =


### PR DESCRIPTION
## Summary

- Make module type-checking return annotated `Module` values directly instead of `TcModuleResult` wrapper records.
- Attach type-checker diagnostics to `moduleAnns` and expose `tcModuleDiagnostics`, `tcModuleSuccess`, and `tcModuleBindings` as projections over the annotated module.
- Make `TcDiagnostic` source locations optional so diagnostics can exist even when the input AST has no source-span annotations.
- Update FC desugaring, CLI interface generation, REPL, golden update tooling, and progress tooling to consume annotated modules.

## Why

The type-checker output should have one authoritative shape: the annotated module. Diagnostics are part of type-checker output and should travel with that AST instead of living in a separate side channel. Source spans are useful display metadata, but they should not be required for diagnostics to exist.

## Progress Counts

- `aihc-tc:spec` unit coverage increased by one regression test for diagnostics on unspanned input modules.
- No README progress tables were updated.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--pattern tc-unit --hide-successes"`
- `just fmt`
- `just check`
