### PR TITLE
ci: update nix-s3-cache-action to v1.0.3

### DIFF
--- a/.github/actions/setup-nix-ci/action.yml
+++ b/.github/actions/setup-nix-ci/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
     - name: Configure Cloudflare R2 cache
-      uses: lemmih/nix-s3-cache-action@29264f2f7ee0569b80a4c91ef27734c92ac69026 # v1.0.2
+      uses: lemmih/nix-s3-cache-action@1f2ffc8b285edc2e86487dc37679220ba33dbff3 # v1.0.3
       with:
         s3-endpoint: ${{ inputs.r2-account-id }}.r2.cloudflarestorage.com
         bucket: nix-cache


### PR DESCRIPTION
## Summary

- Updates the shared Nix CI setup action to use `lemmih/nix-s3-cache-action` `v1.0.3`.
- Keeps the action pinned to the immutable release commit `1f2ffc8b285edc2e86487dc37679220ba33dbff3`.

## Impact

CI jobs using `.github/actions/setup-nix-ci` will pick up the latest cache action release while retaining SHA-pinned supply-chain behavior.

## Progress Counts

- No compiler progress counts changed.
- README progress tables were not updated.

## Validation

- `just fmt`
- `just check`
