### PR TITLE
feat(fc): desugar baseline list comprehensions

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -24,6 +24,7 @@ import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
   ( CaseAlt (..),
+    CompStmt (..),
     Decl (..),
     Expr (..),
     Match (..),
@@ -34,6 +35,7 @@ import Aihc.Parser.Syntax
     UnqualifiedName (..),
     ValueDecl (..),
     fromAnnotation,
+    peelCompStmtAnn,
     peelDeclAnn,
     unqualifiedNameText,
   )
@@ -84,6 +86,11 @@ freshVar :: Text -> TcType -> DsM Var
 freshVar name ty = do
   u <- freshUnique
   pure (Var name u ty)
+
+freshInternalVar :: Text -> TcType -> DsM Var
+freshInternalVar prefix ty = do
+  u@(Unique unique) <- freshUnique
+  pure (Var (prefix <> T.pack (show unique)) u ty)
 
 desugarBug :: String -> DsM a
 desugarBug = lift . Left
@@ -335,6 +342,8 @@ dsExpr (EInfix lhs op rhs) =
   dsInfix lhs op rhs
 dsExpr EList {} =
   desugarBug "missing type-checker annotation for list literal"
+dsExpr EListComp {} =
+  desugarBug "missing type-checker annotation for list comprehension"
 dsExpr ETuple {} =
   desugarBug "missing type-checker annotation for tuple literal"
 dsExpr (EParen inner) = dsExpr inner
@@ -371,6 +380,7 @@ dsAnnotatedExpr tcAnn inner =
     EApp fun arg -> FcApp <$> dsExpr fun <*> dsExpr arg
     ELetDecls decls body -> dsLetDecls decls (dsExpr body)
     EList elems -> dsList tcAnn elems
+    EListComp body quals -> dsListComp tcAnn body quals
     ETuple Boxed elems -> dsTuple tcAnn elems
     ELambdaPats pats body -> dsLambda pats body
     EIf cond thenE elseE -> dsIf cond thenE elseE
@@ -544,6 +554,111 @@ dsList tcAnn elems =
     elemTys ->
       desugarBug ("list annotation arity mismatch: expected 1 type argument, got " <> show (length elemTys))
 
+dsListComp :: TcAnnotation -> Expr -> [CompStmt] -> DsM FcExpr
+dsListComp tcAnn body quals = do
+  elemTy <- listCompElemTy tcAnn
+  dsCompQuals elemTy body quals (nilList elemTy)
+
+listCompElemTy :: TcAnnotation -> DsM TcType
+listCompElemTy tcAnn =
+  case tcAnnTypeArgs tcAnn of
+    [elemTy] -> pure elemTy
+    [] -> listElemTyM (tcAnnType tcAnn)
+    elemTys ->
+      desugarBug ("list comprehension annotation arity mismatch: expected 1 type argument, got " <> show (length elemTys))
+
+dsCompQuals :: TcType -> Expr -> [CompStmt] -> FcExpr -> DsM FcExpr
+dsCompQuals elemTy body quals tailExpr =
+  case quals of
+    [] -> do
+      body' <- dsExpr body
+      pure (consList elemTy body' tailExpr)
+    qual : rest ->
+      case peelCompStmtAnn qual of
+        CompGen pat src -> dsCompGen elemTy body pat src rest tailExpr
+        CompGuard guard -> dsCompGuard elemTy body guard rest tailExpr
+        CompLetDecls decls -> dsLetDecls decls (dsCompQuals elemTy body rest tailExpr)
+        CompThen {} -> unsupportedCompQual qual
+        CompThenBy {} -> unsupportedCompQual qual
+        CompGroupUsing {} -> unsupportedCompQual qual
+        CompGroupByUsing {} -> unsupportedCompQual qual
+        CompAnn {} -> desugarBug "unreachable annotated list comprehension qualifier"
+
+unsupportedCompQual :: CompStmt -> DsM a
+unsupportedCompQual qual =
+  desugarBug ("unsupported list comprehension qualifier after type checking: " <> take 80 (show qual))
+
+dsCompGuard :: TcType -> Expr -> Expr -> [CompStmt] -> FcExpr -> DsM FcExpr
+dsCompGuard elemTy body guard rest tailExpr = do
+  guard' <- dsExpr guard
+  trueBranch <- dsCompQuals elemTy body rest tailExpr
+  binder <- freshInternalVar "_lc_guard" boolTy
+  pure
+    ( FcCase
+        guard'
+        binder
+        [ FcAlt (DataAlt "True") [] trueBranch,
+          FcAlt (DataAlt "False") [] tailExpr
+        ]
+    )
+
+dsCompGen :: TcType -> Expr -> Pattern -> Expr -> [CompStmt] -> FcExpr -> DsM FcExpr
+dsCompGen elemTy body pat src rest tailExpr = do
+  src' <- dsExpr src
+  srcListTy <- fcExprTypeM src'
+  srcElemTy <- listElemTyM srcListTy
+  worker <- freshInternalVar "$lc" (TcFunTy srcListTy (listType elemTy))
+  listVar <- freshInternalVar "_lc_list" srcListTy
+  headVar <- freshInternalVar "_lc_head" srcElemTy
+  restVar <- freshInternalVar "_lc_tail" srcListTy
+  caseBinder <- freshInternalVar "_lc_scrut" srcListTy
+  let recurTail = FcApp (FcVar worker) (FcVar restVar)
+  consRhs <- dsCompGenMatch elemTy body pat rest headVar recurTail
+  let workerBody =
+        FcLam listVar $
+          FcCase
+            (FcVar listVar)
+            caseBinder
+            [ FcAlt (DataAlt "[]") [] tailExpr,
+              FcAlt (DataAlt ":") [headVar, restVar] consRhs
+            ]
+  pure (FcLet (FcRec [(worker, workerBody)]) (FcApp (FcVar worker) src'))
+
+dsCompGenMatch :: TcType -> Expr -> Pattern -> [CompStmt] -> Var -> FcExpr -> DsM FcExpr
+dsCompGenMatch elemTy body pat rest headVar skipExpr =
+  case directPatternBindings pat headVar of
+    Just bindings ->
+      withLocals bindings (dsCompQuals elemTy body rest skipExpr)
+    Nothing -> do
+      let (con, binderNames) = dsPatternPure pat
+      case con of
+        DefaultAlt ->
+          desugarBug ("unsupported list comprehension generator pattern: " <> take 80 (show pat))
+        _ -> do
+          binderTys <- patternBinderTypesM pat (varType headVar)
+          binders <- zipWithM freshVar binderNames binderTys
+          matched <- withLocals (zip binderNames binders) (dsCompQuals elemTy body rest skipExpr)
+          caseBinder <- freshInternalVar "_lc_match" (varType headVar)
+          pure
+            ( FcCase
+                (FcVar headVar)
+                caseBinder
+                [ FcAlt con binders matched,
+                  FcAlt DefaultAlt [] skipExpr
+                ]
+            )
+
+directPatternBindings :: Pattern -> Var -> Maybe [(Text, Var)]
+directPatternBindings pat var =
+  case pat of
+    PVar name -> Just [(unqualifiedNameText name, var)]
+    PWildcard -> Just []
+    PAnn _ inner -> directPatternBindings inner var
+    PParen inner -> directPatternBindings inner var
+    PAs name inner -> ((unqualifiedNameText name, var) :) <$> directPatternBindings inner var
+    PStrict inner -> directPatternBindings inner var
+    _ -> Nothing
+
 dsLambda :: [Pattern] -> Expr -> DsM FcExpr
 dsLambda pats body = do
   argTys <- mapM lambdaPatternTypeRequired pats
@@ -680,7 +795,7 @@ patternBinderTypesM pat scrutTy =
       | nameText op == ":" ->
           (\elemTy -> [elemTy, scrutTy]) <$> listElemTyM scrutTy
     PCon _ _ [] -> pure []
-    PCon {} -> missingPatternTypes
+    PCon _ _ subPats -> mapM patternFieldTypeM subPats
     PVar {} -> pure [scrutTy]
     PAnn _ inner -> patternBinderTypesM inner scrutTy
     PParen inner -> patternBinderTypesM inner scrutTy
@@ -690,6 +805,9 @@ patternBinderTypesM pat scrutTy =
   where
     missingPatternTypes =
       desugarBug ("missing pattern binder type information while desugaring: " <> take 80 (show pat))
+
+    patternFieldTypeM subPat =
+      maybe missingPatternTypes pure (patternBinderAnnotationType subPat <|> patternAnnotationType subPat)
 
 listElemTyM :: TcType -> DsM TcType
 listElemTyM (TcTyCon (TyCon "[]" 1) [elemTy]) = pure elemTy

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-guard.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-guard.yaml
@@ -1,0 +1,13 @@
+dependencies: []
+expression: |
+  [x | x <- xs, x]
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+
+  xs = [False, True, False, True]
+output: ': True (: True [])'
+reason: evaluates a list comprehension boolean guard as element filtering
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-let.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-let.yaml
@@ -1,0 +1,17 @@
+dependencies: []
+expression: |
+  [y | x <- xs, let y = not x]
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+
+  not False = True
+  not True = False
+
+  xs = [False, True]
+output: ': True (: False [])'
+reason: evaluates a list comprehension let qualifier scoped over later qualifiers
+  and the body
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-map.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-map.yaml
@@ -1,0 +1,16 @@
+dependencies: []
+expression: |
+  [not x | x <- xs]
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+
+  not False = True
+  not True = False
+
+  xs = [False, True]
+output: ': True (: False [])'
+reason: evaluates a baseline list comprehension with one generator and mapped body
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-multiple-generators.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-multiple-generators.yaml
@@ -1,0 +1,14 @@
+dependencies: []
+expression: |
+  [(x, y) | x <- xs, y <- ys]
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+
+  xs = [False, True]
+  ys = [True, False]
+output: ': (False,True) (: (False,False) (: (True,True) (: (True,False) [])))'
+reason: evaluates multiple list comprehension generators in nested-loop order
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-refutable-pattern.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/list-comprehension-refutable-pattern.yaml
@@ -1,0 +1,14 @@
+dependencies: []
+expression: |
+  [x | Just x <- xs]
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+  data Maybe a = Nothing | Just a
+
+  xs = [Nothing, Just False, Just True, Nothing]
+output: ': False (: True [])'
+reason: evaluates refutable generator patterns by skipping non-matching elements
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/list-comprehension-direct-recursion.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/list-comprehension-direct-recursion.yaml
@@ -1,0 +1,33 @@
+expected: |-
+  data Bool
+   = False
+   | True
+
+  select : ∀ a. (a → Bool) → [a] → [a] =
+    Λa.
+      λx : a → Bool.
+        λy : [a].
+          let
+            rec
+              $lc1003 : [a] → [a] =
+                λ_lc_list1004 : [a].
+                  case _lc_list1004 as _lc_scrut1007 : [a] of
+                    [] →
+                      [] @a
+                    : _lc_head1005 _lc_tail1006 →
+                      case x _lc_head1005 as _lc_guard1008 : Bool of
+                        True →
+                          : @a _lc_head1005 ($lc1003 _lc_tail1006)
+                        False →
+                          $lc1003 _lc_tail1006
+          in
+            $lc1003 y
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+
+  select fn list = [x | x <- list, fn x]
+reason: desugars list comprehensions directly to recursive Core without Prelude helpers
+status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -379,7 +379,9 @@ inferList sp elems = case elems of
 inferListComp :: SourceSpan -> Expr -> [CompStmt] -> TcM (Expr, TcType, [Ct])
 inferListComp sp body quals = do
   (quals', body', bodyTy, cts) <- inferCompQuals sp quals (inferExpr body)
-  pure (EListComp body' quals', listType bodyTy, cts)
+  let resultTy = listType bodyTy
+      pending = pendingAnnotation resultTy [bodyTy] [] []
+  pure (annotatePendingExprAt sp pending (EListComp body' quals'), resultTy, cts)
   where
     listType elemTy = TcTyCon listTyCon' [elemTy]
     listTyCon' = TyCon {tyConName = "[]", tyConArity = 1}

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
@@ -6,7 +6,9 @@ annotated:
        │      └─ type: Bool
        └─ type: *
   filter f list = [ x | x <- list, f x ]
-  │      │ └─ type: [a] └─ type: a
+  │      │ │      │     └─ type: a
+  │      │ │      └─ type: [a]; type-args: a
+  │      │ └─ type: [a]
   │      └─ type: a → Bool
   └─ type: ∀ a. (a → Bool) → [a] → [a]
 extensions: []

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-let.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-let.yaml
@@ -2,7 +2,9 @@ annotated:
 - |-
   module Test where
   withLet list = [ y | x <- list, let y = x ]
-  │       └─ type: [a] └─ type: a     └─ type: a
+  │       │      │     └─ type: a     └─ type: a
+  │       │      └─ type: [a]; type-args: a
+  │       └─ type: [a]
   └─ type: ∀ a. [a] → [a]
 extensions: []
 modules:

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-multiple-generators.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-multiple-generators.yaml
@@ -2,9 +2,10 @@ annotated:
 - |-
   module Test where
   pairs xs ys = [ (x, y) | x <- xs, y <- ys ]
-  │     │  │      │        │        └─ type: b
-  │     │  │      │        └─ type: a
-  │     │  │      └─ type: (a, b); type-args: a, b
+  │     │  │    │ │        │        └─ type: b
+  │     │  │    │ │        └─ type: a
+  │     │  │    │ └─ type: (a, b); type-args: a, b
+  │     │  │    └─ type: [(a, b)]; type-args: (a, b)
   │     │  └─ type: [b]
   │     └─ type: [a]
   └─ type: ∀ a b. [a] → [b] → [(a, b)]

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension.yaml
@@ -2,7 +2,9 @@ annotated:
 - |-
   module Test where
   map f list = [ f x | x <- list ]
-  │   │ └─ type: [a]   └─ type: a
+  │   │ │      │       └─ type: a
+  │   │ │      └─ type: [b]; type-args: b
+  │   │ └─ type: [a]
   │   └─ type: a → b
   └─ type: ∀ a b. (a → b) → [a] → [b]
 extensions: []


### PR DESCRIPTION
## Summary

- Desugar baseline list comprehensions in `aihc-fc` directly to recursive System FC workers, list constructors, `case`, and local `let`.
- Add the list-comprehension result type annotation in `aihc-tc` so FC consumes upstream type information instead of inferring it locally.
- Add FC fixtures covering generator mapping, guards, let qualifiers, multiple generators, refutable pattern skipping, and the direct recursive Core shape.

## Progress counts

- FC golden fixtures: +1
- FC eval fixtures: +5
- TC annotated list-comprehension fixtures refreshed: 4

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `cabal run -v0 aihc-dev -- update-goldens --dry-run`
- `cabal run -v0 aihc-dev -- update-goldens`
- `just fmt`
- `just check`
