### PR TITLE
fix(repl): load bundled Prelude by default

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -62,6 +62,7 @@ test-suite spec
   build-depends:
     aeson,
     aihc,
+    aihc-fc,
     aihc-hackage,
     aihc-resolve,
     base >=4.16 && <5,

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -13,14 +13,13 @@ module Aihc.Cli.Repl
   )
 where
 
-import Aihc.Cli.Install (defaultStoreRoot)
-import Aihc.Fc (DesugarResult (..), evalProgramBinding, renderProgram, renderValue)
-import Aihc.Fc.Desugar (desugarModuleWithTcResult)
-import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExpr)
+import Aihc.Fc (DesugarResult (..), FcProgram (..), desugarModuleWithBindings, evalProgramBinding, renderProgram, renderValue)
+import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExpr, parseModule)
 import Aihc.Parser.Shorthand (Shorthand (..))
 import Aihc.Parser.Syntax
   ( Decl (..),
     Expr,
+    ImportDecl (..),
     Match (..),
     MatchHeadForm (..),
     Module (..),
@@ -32,7 +31,7 @@ import Aihc.Parser.Syntax
     qualifyName,
     unqualifiedNameFromText,
   )
-import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
 import Aihc.Tc
   ( Pred (..),
     TcBindingResult (..),
@@ -46,6 +45,7 @@ import Aihc.Tc
     tcModuleDiagnostics,
     tcModuleSuccess,
     typecheckModuleWithEnv,
+    typecheckModulesWithEnv,
   )
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson ((.!=), (.:), (.:?))
@@ -56,17 +56,21 @@ import Data.Char (isSpace)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List (find, stripPrefix)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty)
 import Prettyprinter.Render.String (renderString)
 import System.Console.Haskeline qualified as Haskeline
-import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 import System.FilePath ((</>))
+import System.FilePath qualified as FilePath
 
 data ReplSession = ReplSession
   { replModuleExports :: !ModuleExports,
     replImportedTerms :: ![(Text, TypeScheme)],
+    replDependencyProgram :: !FcProgram,
     replSettings :: !(IORef ReplSettings)
   }
 
@@ -122,14 +126,16 @@ runRepl maybeStoreRoot = do
 
 loadReplSession :: Maybe FilePath -> IO ReplSession
 loadReplSession maybeStoreRoot = do
-  storeRoot <- maybe defaultStoreRoot pure maybeStoreRoot
-  interfacePath <- findInstalledBaseInterface storeRoot
-  interface <- loadInterface interfacePath
+  baseContext <- loadAihcBaseContext
+  installedInterface <- loadExplicitStoreInterface maybeStoreRoot
   settingsRef <- newIORef defaultReplSettings
+  let installedExports = maybe Map.empty interfaceExports installedInterface
+      installedTerms = maybe [] interfaceImportedTerms installedInterface
   pure
     ReplSession
-      { replModuleExports = ensurePreludeMvpScope (interfaceExports interface),
-        replImportedTerms = ensurePreludeMvpTerms (interfaceImportedTerms interface),
+      { replModuleExports = replBaseExports baseContext `Map.union` ensurePreludeMvpScope installedExports,
+        replImportedTerms = mergeImportedTerms (replBaseImportedTerms baseContext) (ensurePreludeMvpTerms installedTerms),
+        replDependencyProgram = replBaseProgram baseContext,
         replSettings = settingsRef
       }
 
@@ -174,11 +180,12 @@ evaluateExpression session input = do
       case find ((== replBindingName) . tbName) (tcModuleBindings tcResult) of
         Just binding -> Right (tbType binding)
         Nothing -> Left (ReplTypeError ["missing inferred type for " <> T.unpack replBindingName])
-    let dsResult = desugarModuleWithTcResult tcResult resolvedModule
+    let allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
+        dsResult = desugarModuleWithBindings allBindings tcResult resolvedModule
     if dsSuccess dsResult
       then pure ()
       else Left (ReplDesugarError (dsErrors dsResult))
-    value <- mapLeft (ReplEvalError . show) (evalProgramBinding replBindingName (dsProgram dsResult))
+    value <- mapLeft (ReplEvalError . show) (evalProgramBinding replBindingName (concatPrograms [replDependencyProgram session, dsProgram dsResult]))
     renderedValue <- mapLeft (ReplEvalError . show) (renderValue value)
     Right (renderEvaluation settings expr inferredType dsResult renderedValue)
 
@@ -315,6 +322,145 @@ data Interface = Interface
   { interfaceExports :: ModuleExports,
     interfaceImportedTerms :: [(Text, TypeScheme)]
   }
+
+data ReplBaseContext = ReplBaseContext
+  { replBaseExports :: !ModuleExports,
+    replBaseImportedTerms :: ![(Text, TypeScheme)],
+    replBaseProgram :: !FcProgram
+  }
+
+loadAihcBaseContext :: IO ReplBaseContext
+loadAihcBaseContext = do
+  root <- defaultAihcBaseRoot
+  modulesResult <- loadTransitiveModules [("aihc-base", root)] (Set.singleton "Prelude")
+  case modulesResult of
+    Left err -> ioError (userError ("repl error: could not load bundled aihc-base Prelude: " <> err))
+    Right modules -> buildBaseContext modules
+
+buildBaseContext :: [Module] -> IO ReplBaseContext
+buildBaseContext modules =
+  case resolveWithDeps Map.empty modules of
+    resolved@ResolveResult {resolveErrors = [], resolvedModules} -> do
+      let tcResults = typecheckModulesWithEnv [] resolvedModules
+      if all tcModuleSuccess tcResults
+        then do
+          let allBindings = concatMap tcModuleBindings tcResults
+              dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
+          if all dsSuccess dsResults
+            then
+              pure
+                ReplBaseContext
+                  { replBaseExports = extractInterface resolved,
+                    replBaseImportedTerms = map bindingImportedTerm allBindings,
+                    replBaseProgram = concatPrograms (map dsProgram dsResults)
+                  }
+            else ioError (userError ("repl error: could not desugar bundled aihc-base Prelude: " <> unwords (concatMap dsErrors dsResults)))
+        else ioError (userError ("repl error: could not type-check bundled aihc-base Prelude: " <> unwords (concatMap (map show . tcModuleDiagnostics) tcResults)))
+    ResolveResult {resolveErrors} ->
+      ioError (userError ("repl error: could not resolve bundled aihc-base Prelude: " <> show resolveErrors))
+
+bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
+bindingImportedTerm binding =
+  (tbName binding, tcTypeScheme (tbType binding))
+
+mergeImportedTerms :: [(Text, TypeScheme)] -> [(Text, TypeScheme)] -> [(Text, TypeScheme)]
+mergeImportedTerms preferred fallback =
+  Map.toList (Map.fromList fallback <> Map.fromList preferred)
+
+importedTermBindings :: [(Text, TypeScheme)] -> [TcBindingResult]
+importedTermBindings terms =
+  [ TcBindingResult
+      { tbName = name,
+        tbDisplayName = name,
+        tbType = instantiateSchemeBody scheme
+      }
+  | (name, scheme) <- terms
+  ]
+
+instantiateSchemeBody :: TypeScheme -> TcType
+instantiateSchemeBody (ForAll tvs preds body) =
+  foldr TcForAllTy (qualify preds body) tvs
+  where
+    qualify [] ty = ty
+    qualify constraints ty = TcQualTy constraints ty
+
+concatPrograms :: [FcProgram] -> FcProgram
+concatPrograms programs =
+  FcProgram (concatMap fcTopBinds programs)
+
+loadExplicitStoreInterface :: Maybe FilePath -> IO (Maybe Interface)
+loadExplicitStoreInterface Nothing = pure Nothing
+loadExplicitStoreInterface (Just storeRoot) = do
+  interfacePath <- findInstalledBaseInterface storeRoot
+  Just <$> loadInterface interfacePath
+
+defaultAihcBaseRoot :: IO FilePath
+defaultAihcBaseRoot = do
+  cwd <- getCurrentDirectory
+  findUp cwd
+  where
+    findUp dir = do
+      let candidate = dir </> "core-libs" </> "aihc-base"
+      exists <- doesDirectoryExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = FilePath.takeDirectory dir
+          if parent == dir
+            then pure candidate
+            else findUp parent
+
+loadTransitiveModules :: [(Text, FilePath)] -> Set.Set Text -> IO (Either String [Module])
+loadTransitiveModules packageRoots initialModules =
+  go Set.empty [] (Set.toAscList initialModules)
+  where
+    go _ loaded [] =
+      pure (Right loaded)
+    go seen loaded (moduleName : pending)
+      | moduleName `Set.member` seen =
+          go seen loaded pending
+      | otherwise = do
+          maybePath <- findModulePathInDependencies packageRoots moduleName
+          case maybePath of
+            Nothing -> do
+              let dependencyNames = T.intercalate ", " (map fst packageRoots)
+              pure (Left ("dependency module " <> T.unpack moduleName <> " not found in dependencies: " <> T.unpack dependencyNames))
+            Just path -> do
+              source <- TIO.readFile path
+              case parseOneModule path source of
+                Left errMsg -> pure (Left ("dependency module " <> T.unpack moduleName <> " parse error: " <> errMsg))
+                Right modu -> do
+                  let seen' = Set.insert moduleName seen
+                      newImports = Set.toAscList (importedModuleNames [modu] `Set.difference` seen')
+                  go seen' (modu : loaded) (pending <> newImports)
+
+findModulePathInDependencies :: [(Text, FilePath)] -> Text -> IO (Maybe FilePath)
+findModulePathInDependencies [] _ = pure Nothing
+findModulePathInDependencies ((_dependency, root) : rest) moduleName = do
+  let path = root </> "src" </> moduleNamePath moduleName
+  exists <- doesFileExist path
+  if exists
+    then pure (Just path)
+    else findModulePathInDependencies rest moduleName
+
+moduleNamePath :: Text -> FilePath
+moduleNamePath moduleName =
+  FilePath.joinPath (map T.unpack (T.splitOn "." moduleName)) <> ".hs"
+
+parseOneModule :: FilePath -> Text -> Either String Module
+parseOneModule sourceName input =
+  let cfg =
+        defaultConfig
+          { parserSourceName = sourceName
+          }
+      (errs, ast) = parseModule cfg input
+   in if null errs
+        then Right ast
+        else Left ("parse module error: " <> show errs)
+
+importedModuleNames :: [Module] -> Set.Set Text
+importedModuleNames modules =
+  Set.fromList [importDeclModule importDecl | modu <- modules, importDecl <- moduleImports modu]
 
 data InterfaceModule = InterfaceModule
   { interfaceModuleName :: !Text,
@@ -453,7 +599,7 @@ instance Aeson.FromJSON StoreCandidate where
 
 isBaseManifest :: StoreCandidate -> Bool
 isBaseManifest candidate =
-  candidatePackageName candidate == "base"
+  candidatePackageName candidate `elem` ["aihc-base", "base"]
 
 ensurePreludeMvpScope :: ModuleExports -> ModuleExports
 ensurePreludeMvpScope exports =

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -64,6 +64,7 @@ import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty)
 import Prettyprinter.Render.String (renderString)
 import System.Console.Haskeline qualified as Haskeline
 import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
+import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 import System.FilePath qualified as FilePath
 
@@ -396,8 +397,16 @@ loadExplicitStoreInterface (Just storeRoot) = do
 
 defaultAihcBaseRoot :: IO FilePath
 defaultAihcBaseRoot = do
-  cwd <- getCurrentDirectory
-  findUp cwd
+  baseOverride <- lookupEnv "AIHC_BASE_SRC"
+  case baseOverride of
+    Just root -> pure root
+    Nothing -> do
+      coreLibsOverride <- lookupEnv "AIHC_CORE_LIBS_ROOT"
+      case coreLibsOverride of
+        Just root -> pure (root </> "core-libs" </> "aihc-base")
+        Nothing -> do
+          cwd <- getCurrentDirectory
+          findUp cwd
   where
     findUp dir = do
       let candidate = dir </> "core-libs" </> "aihc-base"

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -19,6 +19,7 @@ import Aihc.Cli.Install
   )
 import Aihc.Cli.Options (Command (..), InstallErrorFormat (..), InstallOptions (..), ReplOptions (..), parseCommandPure)
 import Aihc.Cli.Repl (ReplError (..), ReplSession (..), ReplStep (..), defaultReplSettings, evaluateExpression, handleReplInput, loadReplSession)
+import Aihc.Fc (FcProgram (..))
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Resolve (Scope (..))
 import Control.Exception (bracket)
@@ -144,6 +145,10 @@ main =
                 assertBool ("expected system-fc output, got:\n" <> T.unpack output) ("system-fc:\n__aihc_repl_it : [Char] =" `T.isInfixOf` output)
                 assertBool ("expected desugared char list, got:\n" <> T.unpack output) (not ("LitString" `T.isInfixOf` output))
               Left err -> assertFailure ("expected success, got " <> show err),
+          testCase "loads bundled aihc-base Prelude by default" $ do
+            session <- loadReplSession Nothing
+            result <- evaluateExpression session "otherwise"
+            assertEqual "result" (Right "True") result,
           testCase "loads installed base interface for Prelude MVP scope" test_loadsInstalledBaseInterfaceForRepl
         ],
       testGroup
@@ -190,6 +195,7 @@ testReplSession = do
     ReplSession
       { replModuleExports = Map.empty,
         replImportedTerms = [],
+        replDependencyProgram = FcProgram [],
         replSettings = settingsRef
       }
 
@@ -205,7 +211,7 @@ test_loadsInstalledBaseInterfaceForRepl =
       manifestPath
       ( Aeson.encode
           ( object
-              [ "package" .= object ["name" .= ("base" :: String), "version" .= ("4.22.0.0" :: String)],
+              [ "package" .= object ["name" .= ("aihc-base" :: String), "version" .= ("4.21.2.0" :: String)],
                 "interfacePath" .= interfacePath
               ]
           )

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -32,6 +32,23 @@
       )
     );
 
+  mkAihcPackageTest = drv:
+    pkgs.haskell.lib.doCheck (
+      pkgs.haskell.lib.dontHaddock (
+        pkgs.haskell.lib.overrideCabal drv (
+          old:
+            addHiddenSuccesses old
+            // {
+              preCheck =
+                (old.preCheck or "")
+                + ''
+                  export AIHC_BASE_SRC=${sources.baseSrc pkgs}
+                '';
+            }
+        )
+      )
+    );
+
   mkSourceCheck = name: src: nativeBuildInputs: text:
     pkgs.runCommand name {
       inherit src nativeBuildInputs;
@@ -56,7 +73,7 @@
   tcTests = mkPackageTest hsPkgs.aihc-tc;
   testingTests = mkPackageTest hsPkgs.aihc-testing;
   devTests = mkPackageTest hsPkgs.aihc-dev;
-  aihcTests = mkPackageTest hsPkgs.aihc;
+  aihcTests = mkAihcPackageTest hsPkgs.aihc;
   fmtTests = mkPackageTest hsPkgs.aihc-fmt;
 
   nixLint = mkSourceCheck "aihc-nix-lint" (sources.nixSrc pkgs) [pkgs.statix] ''


### PR DESCRIPTION
## Summary

- Load the bundled `aihc-base` `Prelude` context when a REPL session starts, including resolver exports, imported type schemes, and System FC definitions.
- Evaluate REPL expressions against the cached dependency program plus the current synthetic REPL binding.
- Add regression coverage for `otherwise` resolving and evaluating in a default REPL session.

## Root Cause

The REPL was relying on an installed package interface and an MVP fallback scope. That could leave ordinary Prelude terms such as `otherwise` unavailable, and it did not carry real Prelude definitions into FC evaluation.

## Progress Counts

Unchanged. This PR does not update parser/resolver/type-checker fixture progress counts.

## Validation

- `cabal test -v0 aihc:spec --test-options="--pattern repl --hide-successes"`
- `printf 'otherwise\n:q\n' | cabal run -v0 aihc -- repl`
- `just fmt`
- `just check`
