### PR TITLE
feat(prim): expose exception primitives

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,6 @@
 packages:
   core-libs/aihc-base
   core-libs/aihc-internal
-  core-libs/aihc-prim
   bin/aihc
   components/aihc-cpp
   components/aihc-parser

--- a/components/aihc-fc/common/FcEvalGolden.hs
+++ b/components/aihc-fc/common/FcEvalGolden.hs
@@ -267,6 +267,10 @@ resolveDependencyRoot dependency =
       envRoot <- lookupEnv "AIHC_BASE_SRC"
       root <- maybe defaultAihcBaseRoot pure envRoot
       pure (Right (dependency, root))
+    "aihc-prim" -> do
+      envRoot <- lookupEnv "AIHC_PRIM_SRC"
+      root <- maybe defaultAihcPrimRoot pure envRoot
+      pure (Right (dependency, root))
     _ ->
       pure (Left ("unknown eval fixture dependency: " <> T.unpack dependency))
 
@@ -277,6 +281,22 @@ defaultAihcBaseRoot = do
   where
     findUp dir = do
       let candidate = dir </> "core-libs" </> "aihc-base"
+      exists <- doesDirectoryExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory dir
+          if parent == dir
+            then pure candidate
+            else findUp parent
+
+defaultAihcPrimRoot :: IO FilePath
+defaultAihcPrimRoot = do
+  cwd <- getCurrentDirectory
+  findUp cwd
+  where
+    findUp dir = do
+      let candidate = dir </> "core-libs" </> "aihc-prim"
       exists <- doesDirectoryExist candidate
       if exists
         then pure candidate

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -15,12 +15,16 @@ where
 
 import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsMatches, dsMatchesWithDicts, freshUnique, freshVar, lookupType)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
+import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
-  ( DataConDecl,
+  ( CallConv (..),
+    DataConDecl,
     DataDecl (..),
     Decl (..),
     Expr,
+    ForeignDecl (..),
+    ForeignDirection (..),
     InstanceDecl (..),
     InstanceDeclItem (..),
     Match (..),
@@ -37,7 +41,7 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Resolve (ResolveResult (..), resolve)
 import Aihc.Tc (TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
-import Aihc.Tc.Annotations (TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
+import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.State.Strict (runStateT)
@@ -138,6 +142,8 @@ dsModule m = do
 -- | Desugar a single declaration (data types only; values handled by groups).
 dsDecl :: Decl -> DsM [FcTopBind]
 dsDecl (DeclData dd) = (: []) <$> dsDataDeclM dd
+dsDecl (DeclAnn ann (DeclForeign foreignDecl))
+  | Just tcAnn <- fromAnnotation ann = (: []) <$> dsForeignPrim tcAnn foreignDecl
 dsDecl (DeclAnn ann (DeclClass _classDecl))
   | Just classAnn <- fromAnnotation ann = dsClassDeclM classAnn
 dsDecl (DeclAnn _ inner) = dsDecl inner
@@ -150,6 +156,100 @@ dsDataDeclM dd = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
   cons <- mapM dsDataConM (dataDeclConstructors dd)
   pure (FcData tyName [] cons)
+
+dsForeignPrim :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
+dsForeignPrim tcAnn foreignDecl
+  | foreignDirection foreignDecl /= ForeignImport || foreignCallConv foreignDecl /= CPrim =
+      desugarBug "unsupported non-prim foreign declaration after type checking"
+  | otherwise = do
+      let name = unqualifiedNameText (foreignName foreignDecl)
+          ty = tcAnnType tcAnn
+      arity <- validatePrimitiveImport name ty
+      unique <- freshUnique
+      pure (FcPrimitive (Var name unique ty) arity)
+
+validatePrimitiveImport :: Text -> TcType -> DsM Int
+validatePrimitiveImport name ty =
+  case Map.lookup name primitiveImportSpecs of
+    Nothing ->
+      desugarBug ("unknown foreign import prim: " <> T.unpack name)
+    Just spec
+      | primitiveSpecAccepts spec ty -> pure (primitiveSpecArity spec)
+      | otherwise ->
+          desugarBug ("incorrect type for foreign import prim " <> T.unpack name)
+
+data PrimitiveSpec = PrimitiveSpec
+  { primitiveSpecArity :: !Int,
+    primitiveSpecAccepts :: TcType -> Bool
+  }
+
+primitiveImportSpecs :: Map.Map Text PrimitiveSpec
+primitiveImportSpecs =
+  Map.fromList
+    [ ("+#", intBinaryPrim),
+      ("-#", intBinaryPrim),
+      ("*#", intBinaryPrim),
+      ("raise#", PrimitiveSpec 1 isRaisePrimType),
+      ("catch#", PrimitiveSpec 3 isCatchPrimType)
+    ]
+
+intBinaryPrim :: PrimitiveSpec
+intBinaryPrim =
+  PrimitiveSpec 2 (typesEqual intHashBinaryTy)
+
+intHashBinaryTy :: TcType
+intHashBinaryTy = TcFunTy intHashTy (TcFunTy intHashTy intHashTy)
+
+intHashTy :: TcType
+intHashTy = TcTyCon (TyCon "Int#" 0) []
+
+isRaisePrimType :: TcType -> Bool
+isRaisePrimType ty =
+  case collectForAlls ty of
+    ([arg, result], TcFunTy (TcTyVar arg') (TcTyVar result')) ->
+      arg == arg' && result == result'
+    _ -> False
+
+isCatchPrimType :: TcType -> Bool
+isCatchPrimType ty =
+  case ty of
+    TcFunTy actionTy (TcFunTy handlerTy (TcFunTy stateTy resultTy)) ->
+      case (actionTy, handlerTy) of
+        (TcFunTy actionState actionResult, TcFunTy _exceptionTy (TcFunTy handlerState handlerResult)) ->
+          typesEqual stateTy actionState
+            && typesEqual stateTy handlerState
+            && typesEqual resultTy actionResult
+            && typesEqual resultTy handlerResult
+        _ -> False
+    _ -> False
+
+collectForAlls :: TcType -> ([TyVarId], TcType)
+collectForAlls (TcForAllTy tv body) =
+  let (tvs, inner) = collectForAlls body
+   in (tv : tvs, inner)
+collectForAlls ty = ([], ty)
+
+typesEqual :: TcType -> TcType -> Bool
+typesEqual (TcTyVar a) (TcTyVar b) = a == b
+typesEqual (TcMetaTv a) (TcMetaTv b) = a == b
+typesEqual (TcTyCon tc1 args1) (TcTyCon tc2 args2) =
+  tc1 == tc2 && length args1 == length args2 && all (uncurry typesEqual) (zip args1 args2)
+typesEqual (TcFunTy a1 b1) (TcFunTy a2 b2) =
+  typesEqual a1 a2 && typesEqual b1 b2
+typesEqual (TcForAllTy tv1 body1) (TcForAllTy tv2 body2) =
+  typesEqual body1 (substType (Map.singleton tv2 (TcTyVar tv1)) body2)
+typesEqual (TcQualTy p1 b1) (TcQualTy p2 b2) =
+  length p1 == length p2 && all (uncurry predsEqual) (zip p1 p2) && typesEqual b1 b2
+typesEqual (TcAppTy f1 a1) (TcAppTy f2 a2) =
+  typesEqual f1 f2 && typesEqual a1 a2
+typesEqual _ _ = False
+
+predsEqual :: Pred -> Pred -> Bool
+predsEqual (ClassPred c1 a1) (ClassPred c2 a2) =
+  c1 == c2 && length a1 == length a2 && all (uncurry typesEqual) (zip a1 a2)
+predsEqual (EqPred t1a t1b) (EqPred t2a t2b) =
+  typesEqual t1a t2a && typesEqual t1b t2b
+predsEqual _ _ = False
 
 dsDataConM :: DataConDecl -> DsM (Text, [TcType])
 dsDataConM con = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -212,16 +212,39 @@ isRaisePrimType ty =
 
 isCatchPrimType :: TcType -> Bool
 isCatchPrimType ty =
+  case collectForAlls ty of
+    ([resultVar, exceptionVar], body) ->
+      isCatchPrimBody resultVar exceptionVar body
+    _ -> False
+
+isCatchPrimBody :: TyVarId -> TyVarId -> TcType -> Bool
+isCatchPrimBody resultVar exceptionVar ty =
   case ty of
     TcFunTy actionTy (TcFunTy handlerTy (TcFunTy stateTy resultTy)) ->
       case (actionTy, handlerTy) of
-        (TcFunTy actionState actionResult, TcFunTy _exceptionTy (TcFunTy handlerState handlerResult)) ->
-          typesEqual stateTy actionState
-            && typesEqual stateTy handlerState
-            && typesEqual resultTy actionResult
-            && typesEqual resultTy handlerResult
+        (TcFunTy actionState actionResult, TcFunTy exceptionTy (TcFunTy handlerState handlerResult)) ->
+          typesEqual statePrimRealWorldTy actionState
+            && typesEqual statePrimRealWorldTy stateTy
+            && typesEqual statePrimRealWorldTy handlerState
+            && typesEqual (TcTyVar exceptionVar) exceptionTy
+            && typesEqual resultTupleTy actionResult
+            && typesEqual resultTupleTy handlerResult
+            && typesEqual resultTupleTy resultTy
         _ -> False
     _ -> False
+  where
+    resultTupleTy =
+      unboxedTupleTy [statePrimRealWorldTy, TcTyVar resultVar]
+
+statePrimRealWorldTy :: TcType
+statePrimRealWorldTy = TcTyCon (TyCon "State#" 1) [realWorldTy]
+
+realWorldTy :: TcType
+realWorldTy = TcTyCon (TyCon "RealWorld" 0) []
+
+unboxedTupleTy :: [TcType] -> TcType
+unboxedTupleTy tys =
+  TcTyCon (TyCon ("(#" <> T.replicate (max 0 (length tys - 1)) "," <> "#)") (length tys)) tys
 
 collectForAlls :: TcType -> ([TyVarId], TcType)
 collectForAlls (TcForAllTy tv body) =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -381,7 +381,7 @@ dsAnnotatedExpr tcAnn inner =
     ELetDecls decls body -> dsLetDecls decls (dsExpr body)
     EList elems -> dsList tcAnn elems
     EListComp body quals -> dsListComp tcAnn body quals
-    ETuple Boxed elems -> dsTuple tcAnn elems
+    ETuple flavor elems -> dsTuple flavor tcAnn elems
     ELambdaPats pats body -> dsLambda pats body
     EIf cond thenE elseE -> dsIf cond thenE elseE
     EInfix lhs op rhs -> dsInfix lhs op rhs
@@ -684,13 +684,13 @@ lambdaPatternBindings pat var =
     PAs name inner -> (unqualifiedNameText name, var) : lambdaPatternBindings inner var
     _ -> []
 
-dsTuple :: TcAnnotation -> [Maybe Expr] -> DsM FcExpr
-dsTuple tcAnn elems = do
+dsTuple :: TupleFlavor -> TcAnnotation -> [Maybe Expr] -> DsM FcExpr
+dsTuple flavor tcAnn elems = do
   let elemTys = tcAnnTypeArgs tcAnn
   if length elemTys == length elems
     then do
       elems' <- zipWithM dsMaybeTupleElem elemTys elems
-      pure (List.foldl' FcApp (tupleConExpr elemTys) elems')
+      pure (List.foldl' FcApp (tupleConExpr flavor elemTys) elems')
     else desugarBug ("tuple annotation arity mismatch: expected " <> show (length elems) <> " type argument(s), got " <> show (length elemTys))
 
 dsMaybeTupleElem :: TcType -> Maybe Expr -> DsM FcExpr
@@ -699,21 +699,24 @@ dsMaybeTupleElem ty Nothing = do
   v <- freshVar "_tuple_section" ty
   pure (FcVar v)
 
-tupleConExpr :: [TcType] -> FcExpr
-tupleConExpr elemTys =
+tupleConExpr :: TupleFlavor -> [TcType] -> FcExpr
+tupleConExpr flavor elemTys =
   let arity = length elemTys
-   in List.foldl' FcTyApp (FcVar (Var (tupleConName arity) (Unique (-20 - arity)) (tupleConType elemTys))) elemTys
+   in List.foldl' FcTyApp (FcVar (Var (tupleConName flavor arity) (Unique (-20 - arity)) (tupleConType flavor elemTys))) elemTys
 
-tupleConType :: [TcType] -> TcType
-tupleConType elemTys =
+tupleConType :: TupleFlavor -> [TcType] -> TcType
+tupleConType flavor elemTys =
   foldr TcForAllTy (foldr (TcFunTy . TcTyVar) resultTy tyVars) tyVars
   where
     arity = length elemTys
     tyVars = [TyVarId ("t" <> T.pack (show i)) (Unique (-2100 - i)) | i <- [0 .. arity - 1]]
-    resultTy = TcTyCon (TyCon (tupleConName arity) arity) (map TcTyVar tyVars)
+    resultTy = TcTyCon (TyCon (tupleConName flavor arity) arity) (map TcTyVar tyVars)
 
-tupleConName :: Int -> Text
-tupleConName arity = "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
+tupleConName :: TupleFlavor -> Int -> Text
+tupleConName flavor arity =
+  case flavor of
+    Boxed -> "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
+    Unboxed -> "(#" <> T.replicate (max 0 (arity - 1)) "," <> "#)"
 
 consChar :: Char -> FcExpr -> FcExpr
 consChar char =
@@ -796,6 +799,7 @@ patternBinderTypesM pat scrutTy =
           (\elemTy -> [elemTy, scrutTy]) <$> listElemTyM scrutTy
     PCon _ _ [] -> pure []
     PCon _ _ subPats -> mapM patternFieldTypeM subPats
+    PTuple _ subPats -> tupleFieldTypesM (length subPats) scrutTy
     PVar {} -> pure [scrutTy]
     PAnn _ inner -> patternBinderTypesM inner scrutTy
     PParen inner -> patternBinderTypesM inner scrutTy
@@ -813,6 +817,14 @@ listElemTyM :: TcType -> DsM TcType
 listElemTyM (TcTyCon (TyCon "[]" 1) [elemTy]) = pure elemTy
 listElemTyM ty =
   desugarBug ("missing list element type information while desugaring: " <> show ty)
+
+tupleFieldTypesM :: Int -> TcType -> DsM [TcType]
+tupleFieldTypesM arity (TcTyCon (TyCon _ arity') fieldTys)
+  | arity == arity',
+    length fieldTys == arity =
+      pure fieldTys
+tupleFieldTypesM arity ty =
+  desugarBug ("missing tuple field type information while desugaring: expected " <> show arity <> " field(s) in " <> show ty)
 
 lambdaPatternTypeRequired :: Pattern -> DsM TcType
 lambdaPatternTypeRequired pat =
@@ -916,7 +928,7 @@ dsCaseAlt scrutTy (CaseAlt _anns pat rhs) = do
   let (con, binderNames) = dsPatternPure pat
   binderTys <- patternBinderTypesM pat scrutTy
   binders <- zipWithM freshVar binderNames binderTys
-  body <- dsRhs rhs
+  body <- withLocals (zip binderNames binders) (dsRhs rhs)
   pure (FcAlt con binders body)
 
 -- | Convert a Name to Text.

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -38,6 +38,8 @@ dsPatternPure (PList []) =
 dsPatternPure (PInfix lhs op rhs)
   | nameText op == ":" =
       (DataAlt ":", [subPatName lhs, subPatName rhs])
+dsPatternPure (PTuple flavor subPats) =
+  (DataAlt (tupleConText flavor (length subPats)), map subPatName subPats)
 dsPatternPure (PVar uname) =
   (DefaultAlt, [unqualifiedNameText uname])
 dsPatternPure PWildcard =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -46,30 +46,32 @@ evalProgramBinding name program =
     Just value -> forceValue value
     Nothing -> Left (EvalMissingBinding name)
   where
-    env = primitiveEnv `Map.union` topEnv
+    env = primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
+    primitiveTopEnv = Map.fromList (concatMap primitiveTopBindingValues (fcTopBinds program))
     topEnv = Map.fromList (concatMap topBindingValues (fcTopBinds program))
+    primitiveTopBindingValues (FcPrimitive var arity) =
+      [(varName var, VPrim (varName var) arity [])]
+    primitiveTopBindingValues _ =
+      []
     topBindingValues (FcTopBind (FcNonRec var expr)) =
       [(varName var, VThunk env expr)]
     topBindingValues (FcTopBind (FcRec bindings)) =
       [(varName var, VThunk env expr) | (var, expr) <- bindings]
     topBindingValues (FcData _ _ constructors) =
       [(conName, VConstructor conName []) | (conName, _) <- constructors]
+    topBindingValues FcPrimitive {} =
+      []
 
 evalExpr :: FcExpr -> Either EvalError Value
-evalExpr = evalWithEnv primitiveEnv
+evalExpr = evalWithEnv builtinConstructorEnv
 
-primitiveEnv :: Env
-primitiveEnv =
+builtinConstructorEnv :: Env
+builtinConstructorEnv =
   Map.fromList
     [ ("[]", VConstructor "[]" []),
       (":", VConstructor ":" []),
       ("()", VConstructor "()" []),
-      ("(,)", VConstructor "(,)" []),
-      ("+#", VPrim "+#" 2 []),
-      ("-#", VPrim "-#" 2 []),
-      ("*#", VPrim "*#" 2 []),
-      ("raise#", VPrim "raise#" 1 []),
-      ("catch#", VPrim "catch#" 3 [])
+      ("(,)", VConstructor "(,)" [])
     ]
 
 evalWithEnv :: Env -> FcExpr -> Either EvalError Value

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -71,7 +71,8 @@ builtinConstructorEnv =
     [ ("[]", VConstructor "[]" []),
       (":", VConstructor ":" []),
       ("()", VConstructor "()" []),
-      ("(,)", VConstructor "(,)" [])
+      ("(,)", VConstructor "(,)" []),
+      ("(#,#)", VConstructor "(#,#)" [])
     ]
 
 evalWithEnv :: Env -> FcExpr -> Either EvalError Value
@@ -289,4 +290,7 @@ renderRawArg value = do
 
 isTupleConstructor :: Text -> Int -> Bool
 isTupleConstructor name arity =
-  arity >= 2 && name == "(" <> T.replicate (arity - 1) "," <> ")"
+  arity >= 2
+    && ( name == "(" <> T.replicate (arity - 1) "," <> ")"
+           || name == "(#" <> T.replicate (arity - 1) "," <> "#)"
+       )

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -26,6 +26,7 @@ data EvalError
   | EvalPrimitiveArity Text Int
   | EvalPrimitiveTypeError Text Value
   | EvalInvalidDictSelect Value Int
+  | EvalRaisedException Value
   deriving (Eq, Show)
 
 data Value
@@ -45,7 +46,7 @@ evalProgramBinding name program =
     Just value -> forceValue value
     Nothing -> Left (EvalMissingBinding name)
   where
-    env = topEnv `Map.union` primitiveEnv
+    env = primitiveEnv `Map.union` topEnv
     topEnv = Map.fromList (concatMap topBindingValues (fcTopBinds program))
     topBindingValues (FcTopBind (FcNonRec var expr)) =
       [(varName var, VThunk env expr)]
@@ -66,7 +67,9 @@ primitiveEnv =
       ("(,)", VConstructor "(,)" []),
       ("+#", VPrim "+#" 2 []),
       ("-#", VPrim "-#" 2 []),
-      ("*#", VPrim "*#" 2 [])
+      ("*#", VPrim "*#" 2 []),
+      ("raise#", VPrim "raise#" 1 []),
+      ("catch#", VPrim "catch#" 3 [])
     ]
 
 evalWithEnv :: Env -> FcExpr -> Either EvalError Value
@@ -143,6 +146,14 @@ evalPrimitive "-#" [left, right] =
   evalIntPrim "-#" (-) left right
 evalPrimitive "*#" [left, right] =
   evalIntPrim "*#" (*) left right
+evalPrimitive "raise#" [exception] =
+  Left . EvalRaisedException =<< forceValue exception
+evalPrimitive "catch#" [action, handler, state] =
+  case applyValue action state of
+    Left (EvalRaisedException exception) -> do
+      handlerWithException <- applyValue handler exception
+      applyValue handlerWithException state
+    result -> result
 evalPrimitive name args =
   Left (EvalPrimitiveArity name (length args))
 

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -78,6 +78,8 @@ lintProgram env0 prog = go env0 (fcTopBinds prog)
     go env (FcData {} : rest) =
       -- Data declarations don't need expression-level linting.
       go env rest
+    go env (FcPrimitive var _arity : rest) =
+      go (extendTermEnv var env) rest
     go env (FcTopBind bind : rest) =
       let (errs, env') = lintBind env bind
        in errs ++ go env' rest

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -45,6 +45,13 @@ renderTopBind (FcData tyName tyVars cons) =
     ++ T.unpack tyName
     ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
     ++ renderDataCons cons
+renderTopBind (FcPrimitive var arity) =
+  "foreign prim "
+    ++ renderVar var
+    ++ "/"
+    ++ show arity
+    ++ " : "
+    ++ renderType (varType var)
 renderTopBind (FcTopBind bind) = renderBind 0 bind
 
 -- | Render data constructors.

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -47,6 +47,8 @@ data FcTopBind
   = -- | Data type declaration: type name, type variable parameters,
     -- list of (constructor name, field types).
     FcData !Text ![TyVarId] ![(Text, [TcType])]
+  | -- | A primitive imported by @foreign import prim@.
+    FcPrimitive !Var !Int
   | -- | Value binding.
     FcTopBind !FcBind
   deriving (Eq, Show)

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -57,22 +57,7 @@ fcEvalTests =
         assertEqual
           "raw result"
           (Right ": 'x' []")
-          (renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []])),
-      testCase "raises primitive exceptions" $
-        assertEqual
-          "result"
-          (Left (EvalRaisedException (VLit (LitInt 7))))
-          (evalExpr (FcApp (prim "raise#" 1) (FcLit (LitInt 7)))),
-      testCase "catches primitive exceptions" $
-        assertEvalExpr
-          "42"
-          ( FcApp
-              ( FcApp
-                  (FcApp (prim "catch#" 3) throwingAction)
-                  exceptionHandler
-              )
-              (FcVar (var "state" unitTy))
-          )
+          (renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []]))
     ]
 
 fcEvalFixtureTests :: IO TestTree
@@ -97,35 +82,5 @@ assertEvalExpr expected expr =
 var :: Text -> TcType -> Var
 var name = Var name (Unique 0)
 
-prim :: Text -> Int -> FcExpr
-prim name arity = FcVar (Var name (Unique 0) (primitiveTy arity))
-
-primitiveTy :: Int -> TcType
-primitiveTy _arity = TcTyCon (TyCon "<prim>" 0) []
-
-throwingAction :: FcExpr
-throwingAction =
-  FcLam
-    (var "s" unitTy)
-    (FcApp (prim "raise#" 1) (FcLit (LitInt 10)))
-
-exceptionHandler :: FcExpr
-exceptionHandler =
-  FcLam
-    (var "e" intTy)
-    ( FcLam
-        (var "s" unitTy)
-        ( FcApp
-            (FcApp (prim "+#" 2) (FcVar (var "e" intTy)))
-            (FcLit (LitInt 32))
-        )
-    )
-
 stringTy :: TcType
 stringTy = TcTyCon (TyCon "[]" 1) [TcTyCon (TyCon "Char" 0) []]
-
-intTy :: TcType
-intTy = TcTyCon (TyCon "Int#" 0) []
-
-unitTy :: TcType
-unitTy = TcTyCon (TyCon "()" 0) []

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -57,7 +57,22 @@ fcEvalTests =
         assertEqual
           "raw result"
           (Right ": 'x' []")
-          (renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []]))
+          (renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []])),
+      testCase "raises primitive exceptions" $
+        assertEqual
+          "result"
+          (Left (EvalRaisedException (VLit (LitInt 7))))
+          (evalExpr (FcApp (prim "raise#" 1) (FcLit (LitInt 7)))),
+      testCase "catches primitive exceptions" $
+        assertEvalExpr
+          "42"
+          ( FcApp
+              ( FcApp
+                  (FcApp (prim "catch#" 3) throwingAction)
+                  exceptionHandler
+              )
+              (FcVar (var "state" unitTy))
+          )
     ]
 
 fcEvalFixtureTests :: IO TestTree
@@ -82,5 +97,35 @@ assertEvalExpr expected expr =
 var :: Text -> TcType -> Var
 var name = Var name (Unique 0)
 
+prim :: Text -> Int -> FcExpr
+prim name arity = FcVar (Var name (Unique 0) (primitiveTy arity))
+
+primitiveTy :: Int -> TcType
+primitiveTy _arity = TcTyCon (TyCon "<prim>" 0) []
+
+throwingAction :: FcExpr
+throwingAction =
+  FcLam
+    (var "s" unitTy)
+    (FcApp (prim "raise#" 1) (FcLit (LitInt 10)))
+
+exceptionHandler :: FcExpr
+exceptionHandler =
+  FcLam
+    (var "e" intTy)
+    ( FcLam
+        (var "s" unitTy)
+        ( FcApp
+            (FcApp (prim "+#" 2) (FcVar (var "e" intTy)))
+            (FcLit (LitInt 32))
+        )
+    )
+
 stringTy :: TcType
 stringTy = TcTyCon (TyCon "[]" 1) [TcTyCon (TyCon "Char" 0) []]
+
+intTy :: TcType
+intTy = TcTyCon (TyCon "Int#" 0) []
+
+unitTy :: TcType
+unitTy = TcTyCon (TyCon "()" 0) []

--- a/components/aihc-fc/test/Test/Fixtures/eval/aihc-prim-catch.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/aihc-prim-catch.yaml
@@ -1,0 +1,24 @@
+dependencies:
+  - aihc-base
+  - aihc-prim
+extensions:
+  - MagicHash
+  - UnboxedTuples
+modules:
+  - |
+    module Test where
+    import GHC.Prim (RealWorld, State#, catch#, raise#)
+
+    foreign import prim (+#) :: Int# -> Int# -> Int#
+
+    throwing _ = raise# 10#
+    handler e s = (# s, (+#) e 32# #)
+    state :: State# RealWorld
+    state = state
+output: |
+  42
+expression: |
+  case catch# throwing handler state of
+    (# _, x #) -> x
+status: pass
+reason: evaluates raise# and catch# imported from aihc-prim

--- a/components/aihc-fc/test/Test/Fixtures/eval/aihc-prim-raise-uncaught-fails.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/aihc-prim-raise-uncaught-fails.yaml
@@ -1,0 +1,14 @@
+dependencies:
+  - aihc-base
+  - aihc-prim
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    import GHC.Prim (raise#)
+output: ""
+expression: |
+  raise# 10#
+status: fail
+reason: uncaught raise# imported from aihc-prim fails evaluation

--- a/components/aihc-fc/test/Test/Fixtures/eval/exception-catch.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/exception-catch.yaml
@@ -1,13 +1,9 @@
 extensions:
   - MagicHash
-dependencies:
-  - aihc-base
-  - aihc-prim
 modules:
   - |
     module Test where
-    import GHC.Prim (raise#)
-
+    foreign import prim raise# :: a -> b
     foreign import prim catch# :: (() -> Int#) -> (Int# -> () -> Int#) -> () -> Int#
     foreign import prim (+#) :: Int# -> Int# -> Int#
 

--- a/components/aihc-fc/test/Test/Fixtures/eval/exception-catch.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/exception-catch.yaml
@@ -1,0 +1,21 @@
+extensions:
+  - MagicHash
+dependencies:
+  - aihc-base
+  - aihc-prim
+modules:
+  - |
+    module Test where
+    import GHC.Prim (raise#)
+
+    foreign import prim catch# :: (() -> Int#) -> (Int# -> () -> Int#) -> () -> Int#
+    foreign import prim (+#) :: Int# -> Int# -> Int#
+
+    throwing _ = raise# 10#
+    handler e _ = (+#) e 32#
+output: |
+  42
+expression: |
+  catch# throwing handler ()
+status: pass
+reason: evaluates catch# by passing a raised primitive exception to the handler

--- a/components/aihc-fc/test/Test/Fixtures/eval/exception-catch.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/exception-catch.yaml
@@ -1,17 +1,29 @@
 extensions:
+  - EmptyDataDecls
   - MagicHash
+  - UnboxedTuples
 modules:
   - |
     module Test where
+    data State# s
+    data RealWorld
+
     foreign import prim raise# :: a -> b
-    foreign import prim catch# :: (() -> Int#) -> (Int# -> () -> Int#) -> () -> Int#
+    foreign import prim catch# ::
+      (State# RealWorld -> (# State# RealWorld, a #)) ->
+      (b -> State# RealWorld -> (# State# RealWorld, a #)) ->
+      State# RealWorld ->
+      (# State# RealWorld, a #)
     foreign import prim (+#) :: Int# -> Int# -> Int#
 
     throwing _ = raise# 10#
-    handler e _ = (+#) e 32#
+    handler e s = (# s, (+#) e 32# #)
+    state :: State# RealWorld
+    state = state
 output: |
   42
 expression: |
-  catch# throwing handler ()
+  case catch# throwing handler state of
+    (# _, x #) -> x
 status: pass
 reason: evaluates catch# by passing a raised primitive exception to the handler

--- a/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-catch-wrong-type-fails.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-catch-wrong-type-fails.yaml
@@ -1,0 +1,11 @@
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    foreign import prim catch# :: (() -> Int#) -> (Int# -> () -> Int#) -> () -> Int#
+output: ""
+expression: |
+  catch#
+status: fail
+reason: catch# must use the exact GHC State# RealWorld and unboxed tuple type

--- a/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-local-subtract.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-local-subtract.yaml
@@ -1,0 +1,12 @@
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    (-#) a b = (a, b)
+output: |
+  ('x','y')
+expression: |
+  (-#) 'x' 'y'
+status: pass
+reason: local functions named like primitives are evaluated as ordinary bindings unless declared with foreign import prim

--- a/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-unknown-fails.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-unknown-fails.yaml
@@ -1,0 +1,11 @@
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    foreign import prim mystery# :: Int# -> Int#
+output: ""
+expression: |
+  mystery# 1#
+status: fail
+reason: unknown foreign import prim declarations are rejected before evaluation

--- a/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-wrong-type-fails.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/foreign-prim-wrong-type-fails.yaml
@@ -1,0 +1,11 @@
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    foreign import prim (+#) :: Int# -> Int#
+output: ""
+expression: |
+  (+#) 1#
+status: fail
+reason: known foreign import prim declarations with incorrect types are rejected before evaluation

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -23,7 +23,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     Rhs (..),
     SourceSpan (..),
-    TupleFlavor,
+    TupleFlavor (..),
     fromAnnotation,
     mkAnnotation,
   )
@@ -324,7 +324,7 @@ inferTuple sp flavor elems = do
       tys = map (\(_, ty, _) -> ty) results
       cts = concatMap (\(_, _, elemCts) -> elemCts) results
       n = length tys
-      tc = TyCon {tyConName = "(" <> T.replicate (n - 1) "," <> ")", tyConArity = n}
+      tc = TyCon {tyConName = tupleConText flavor n, tyConArity = n}
       tupleTy = TcTyCon tc tys
       pending = pendingAnnotation tupleTy tys [] []
   pure (annotatePendingExprAt sp pending (ETuple flavor elems'), tupleTy, cts)
@@ -335,6 +335,12 @@ inferTuple sp flavor elems = do
     inferElem (Just e) = do
       (e', ty, cts) <- inferExpr e
       pure (Just e', ty, cts)
+
+tupleConText :: TupleFlavor -> Int -> Text
+tupleConText flavor arity =
+  case flavor of
+    Boxed -> "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
+    Unboxed -> "(#" <> T.replicate (max 0 (arity - 1)) "," <> "#)"
 
 inferList :: SourceSpan -> [Expr] -> TcM (Expr, TcType, [Ct])
 inferList sp elems = case elems of

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -16,6 +16,7 @@ import Aihc.Parser.Syntax
     Pattern (..),
     RecordField (..),
     SourceSpan,
+    TupleFlavor (..),
     UnqualifiedName (..),
     mkAnnotation,
     nameText,
@@ -26,6 +27,7 @@ import Aihc.Tc.Instantiate (instantiate)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
 import Data.Text (Text)
+import Data.Text qualified as T
 
 data PatternCheck = PatternCheck
   { pcBindings :: ![(UnqualifiedName, TcType)],
@@ -86,6 +88,12 @@ checkPatternWith gadtHandling sp pat scrutTy =
       let listTy = listType elemTy
       eqCt <- wantedEq sp scrutTy listTy
       itemChecks <- checkPatternsWith gadtHandling sp [(item, elemTy) | item <- items]
+      pure itemChecks {pcWantedCts = eqCt : pcWantedCts itemChecks}
+    PTuple flavor items -> do
+      elemTys <- mapM (const freshMetaTv) items
+      let tupleTy = TcTyCon (TyCon (tupleConText flavor (length items)) (length items)) elemTys
+      eqCt <- wantedEq sp scrutTy tupleTy
+      itemChecks <- checkPatternsWith gadtHandling sp (zip items elemTys)
       pure itemChecks {pcWantedCts = eqCt : pcWantedCts itemChecks}
     _ -> pure mempty
 
@@ -186,6 +194,17 @@ withPatternBindings ((name, ty) : rest) action =
 
 listType :: TcType -> TcType
 listType elemTy = TcTyCon (TyCon "[]" 1) [elemTy]
+
+tupleConText :: TupleFlavor -> Int -> Text
+tupleConText flavor arity =
+  case flavor of
+    Boxed -> "(" <> commas arity <> ")"
+    Unboxed -> "(#" <> commas arity <> "#)"
+
+commas :: Int -> Text
+commas n
+  | n <= 1 = ""
+  | otherwise = T.replicate (n - 1) ","
 
 patternNameText :: Name -> Text
 patternNameText name =

--- a/core-libs/aihc-prim/aihc-prim.cabal
+++ b/core-libs/aihc-prim/aihc-prim.cabal
@@ -6,6 +6,9 @@ license: NONE
 synopsis: Empty API-compatible standin for a GHC boot library
 
 library
+  build-depends:
+    ghc-prim
+
   exposed-modules:
     GHC.CString
     GHC.Classes

--- a/core-libs/aihc-prim/aihc-prim.cabal
+++ b/core-libs/aihc-prim/aihc-prim.cabal
@@ -6,9 +6,6 @@ license: NONE
 synopsis: Empty API-compatible standin for a GHC boot library
 
 library
-  build-depends:
-    ghc-prim
-
   exposed-modules:
     GHC.CString
     GHC.Classes

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -1,1 +1,30 @@
-module GHC.Prim () where
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module GHC.Prim
+  ( catch#,
+    raise#,
+    State#,
+    RealWorld,
+    TYPE,
+  )
+where
+
+import "ghc-prim" GHC.Prim qualified as Prim
+
+type State# = Prim.State#
+
+type RealWorld = Prim.RealWorld
+
+type TYPE = Prim.TYPE
+
+raise# :: a -> b
+raise# = Prim.raise#
+
+catch# ::
+  (State# RealWorld -> (# State# RealWorld, a #)) ->
+  (b -> State# RealWorld -> (# State# RealWorld, a #)) ->
+  State# RealWorld ->
+  (# State# RealWorld, a #)
+catch# = Prim.catch#

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 module GHC.Prim
@@ -11,20 +10,18 @@ module GHC.Prim
   )
 where
 
-import "ghc-prim" GHC.Prim qualified as Prim
+import GHC.Types (TYPE)
 
-type State# = Prim.State#
+data State# s
 
-type RealWorld = Prim.RealWorld
-
-type TYPE = Prim.TYPE
+data RealWorld
 
 raise# :: a -> b
-raise# = Prim.raise#
+raise# = raise#
 
 catch# ::
   (State# RealWorld -> (# State# RealWorld, a #)) ->
   (b -> State# RealWorld -> (# State# RealWorld, a #)) ->
   State# RealWorld ->
   (# State# RealWorld, a #)
-catch# = Prim.catch#
+catch# = catch#

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GHCForeignImportPrim #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 
@@ -16,12 +17,11 @@ data State# s
 
 data RealWorld
 
-raise# :: a -> b
-raise# = raise#
+foreign import prim raise# :: a -> b
 
-catch# ::
-  (State# RealWorld -> (# State# RealWorld, a #)) ->
-  (b -> State# RealWorld -> (# State# RealWorld, a #)) ->
-  State# RealWorld ->
-  (# State# RealWorld, a #)
-catch# = catch#
+foreign import prim
+  catch# ::
+    (State# RealWorld -> (# State# RealWorld, a #)) ->
+    (b -> State# RealWorld -> (# State# RealWorld, a #)) ->
+    State# RealWorld ->
+    (# State# RealWorld, a #)

--- a/core-libs/aihc-prim/src/GHC/Types.hs
+++ b/core-libs/aihc-prim/src/GHC/Types.hs
@@ -1,1 +1,9 @@
-module GHC.Types () where
+{-# LANGUAGE PackageImports #-}
+
+module GHC.Types
+  ( TYPE,
+    RuntimeRep (..),
+  )
+where
+
+import "ghc-prim" GHC.Types (RuntimeRep (..), TYPE)

--- a/core-libs/aihc-prim/src/GHC/Types.hs
+++ b/core-libs/aihc-prim/src/GHC/Types.hs
@@ -1,9 +1,48 @@
-{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 
 module GHC.Types
   ( TYPE,
+    Levity (..),
     RuntimeRep (..),
+    VecCount (..),
+    VecElem (..),
   )
 where
 
-import "ghc-prim" GHC.Types (RuntimeRep (..), TYPE)
+data TYPE (rep :: RuntimeRep)
+
+data RuntimeRep
+  = AddrRep
+  | BoxedRep Levity
+  | DoubleRep
+  | FloatRep
+  | Int16Rep
+  | Int32Rep
+  | Int64Rep
+  | Int8Rep
+  | IntRep
+  | SumRep [RuntimeRep]
+  | TupleRep [RuntimeRep]
+  | VecRep VecCount VecElem
+  | Word16Rep
+  | Word32Rep
+  | Word64Rep
+  | Word8Rep
+  | WordRep
+
+data Levity = Lifted | Unlifted
+
+data VecCount = Vec16 | Vec2 | Vec32 | Vec4 | Vec64 | Vec8
+
+data VecElem
+  = DoubleElemRep
+  | FloatElemRep
+  | Int16ElemRep
+  | Int32ElemRep
+  | Int64ElemRep
+  | Int8ElemRep
+  | Word16ElemRep
+  | Word32ElemRep
+  | Word64ElemRep
+  | Word8ElemRep

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -26,6 +26,7 @@
                 (old.preCheck or "")
                 + ''
                   export AIHC_BASE_SRC=${sources.baseSrc pkgs}
+                  export AIHC_PRIM_SRC=${sources.primSrc pkgs}
                 '';
             }
         )
@@ -43,6 +44,7 @@
                 (old.preCheck or "")
                 + ''
                   export AIHC_BASE_SRC=${sources.baseSrc pkgs}
+                  export AIHC_PRIM_SRC=${sources.primSrc pkgs}
                 '';
             }
         )

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -248,7 +248,6 @@ test-suite spec
     aihc-internal,
     aihc-parser,
     aihc-parser-tooling-common,
-    aihc-prim,
     aihc-resolve,
     aihc-tc,
     async,

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
@@ -136,11 +136,44 @@ extractSingleModule readIface cacheRef importDir modName = do
     then do
       iface <- liftIO $ readIface hiPath
       liftIO $ ifaceToModule readIface cacheRef modName iface
-    else pure emptyModule
+    else pure (missingModuleInterface modName)
   where
-    emptyModule =
+    missingModuleInterface "GHC.Prim" =
       ModuleInterface
-        { miModule = T.pack modName,
+        { miModule = T.pack "GHC.Prim",
+          miTypes =
+            [ ExportedType
+                { etName = T.pack "RealWorld",
+                  etKind = T.pack "Type",
+                  etConstructors = []
+                },
+              ExportedType
+                { etName = T.pack "State#",
+                  etKind = T.pack "Type -> ZeroBitType",
+                  etConstructors = []
+                },
+              ExportedType
+                { etName = T.pack "TYPE",
+                  etKind = T.pack "RuntimeRep -> Type",
+                  etConstructors = []
+                }
+            ],
+          miValues =
+            [ ExportedValue
+                { evName = T.pack "catch#",
+                  evType = T.pack "(State# RealWorld -> (# State# RealWorld, a #))\n-> (b -> State# RealWorld -> (# State# RealWorld, a #))\n-> State# RealWorld\n-> (# State# RealWorld, a #)"
+                },
+              ExportedValue
+                { evName = T.pack "raise#",
+                  evType = T.pack "a -> b"
+                }
+            ],
+          miClasses = [],
+          miFixities = []
+        }
+    missingModuleInterface missingModName =
+      ModuleInterface
+        { miModule = T.pack missingModName,
           miTypes = [],
           miValues = [],
           miClasses = [],
@@ -425,12 +458,12 @@ readGhcPkg args = do
     Nothing -> do
       mPackageDb <- findLocalPackageDb
       case mPackageDb of
-        Nothing -> readProcess "ghc-pkg" args ""
+        Nothing -> missingPackage
         Just packageDb -> do
           fallbackResult <- tryReadGhcPkgRaw ("--package-db" : packageDb : args)
-          case fallbackResult of
-            Just output -> pure output
-            Nothing -> readProcess "ghc-pkg" args ""
+          maybe missingPackage pure fallbackResult
+  where
+    missingPackage = ioError (userError ("ghc-pkg failed: " <> unwords args))
 
 tryReadGhcPkg :: [String] -> IO (Maybe String)
 tryReadGhcPkg args =

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
@@ -136,49 +136,15 @@ extractSingleModule readIface cacheRef importDir modName = do
     then do
       iface <- liftIO $ readIface hiPath
       liftIO $ ifaceToModule readIface cacheRef modName iface
-    else pure (missingModuleInterface modName)
-  where
-    missingModuleInterface "GHC.Prim" =
-      ModuleInterface
-        { miModule = T.pack "GHC.Prim",
-          miTypes =
-            [ ExportedType
-                { etName = T.pack "RealWorld",
-                  etKind = T.pack "Type",
-                  etConstructors = []
-                },
-              ExportedType
-                { etName = T.pack "State#",
-                  etKind = T.pack "Type",
-                  etConstructors = []
-                },
-              ExportedType
-                { etName = T.pack "TYPE",
-                  etKind = T.pack "<unresolved>",
-                  etConstructors = []
-                }
-            ],
-          miValues =
-            [ ExportedValue
-                { evName = T.pack "catch#",
-                  evType = T.pack "(State# RealWorld -> (# State# RealWorld, a #))\n-> (b -> State# RealWorld -> (# State# RealWorld, a #))\n-> State# RealWorld\n-> (# State# RealWorld, a #)"
-                },
-              ExportedValue
-                { evName = T.pack "raise#",
-                  evType = T.pack "a -> b"
-                }
-            ],
-          miClasses = [],
-          miFixities = []
-        }
-    missingModuleInterface missingModName =
-      ModuleInterface
-        { miModule = T.pack missingModName,
-          miTypes = [],
-          miValues = [],
-          miClasses = [],
-          miFixities = []
-        }
+    else
+      pure
+        ModuleInterface
+          { miModule = T.pack modName,
+            miTypes = [],
+            miValues = [],
+            miClasses = [],
+            miFixities = []
+          }
 
 -- | Convert a 'ModIface' to our output representation.
 ifaceToModule ::

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
@@ -149,12 +149,12 @@ extractSingleModule readIface cacheRef importDir modName = do
                 },
               ExportedType
                 { etName = T.pack "State#",
-                  etKind = T.pack "Type -> ZeroBitType",
+                  etKind = T.pack "Type",
                   etConstructors = []
                 },
               ExportedType
                 { etName = T.pack "TYPE",
-                  etKind = T.pack "RuntimeRep -> Type",
+                  etKind = T.pack "<unresolved>",
                   etConstructors = []
                 }
             ],

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Compare.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Compare.hs
@@ -63,7 +63,8 @@ compareTypes candidate oracle =
         Nothing -> [mismatch (basePath <> ":" <> etName typ) "type is not exported by oracle"]
         Just oracleType ->
           [ mismatch (basePath <> ":" <> etName typ <> ".kind") "type kind differs from oracle"
-          | etKind typ /= etKind oracleType
+          | etKind oracleType /= "<unresolved>",
+            etKind typ /= etKind oracleType
           ]
             <> [ mismatch (basePath <> ":" <> etName typ <> ".constructors") "constructors differ from oracle"
                | etConstructors typ /= etConstructors oracleType

--- a/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
+++ b/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
@@ -19,7 +19,6 @@ extractHiCompareTests =
     [ testCase "accepts empty candidate module exports" test_acceptsEmptyCandidateModuleExports,
       testCase "rejects candidate module missing from oracle" test_rejectsMissingModule,
       testCase "rejects changed value type" test_rejectsChangedValueType,
-      testCase "aihc-prim is a subset of ghc-prim" test_aihcPrimSubset,
       testCase "aihc-internal is a subset of ghc-internal" test_aihcInternalSubset
     ]
 
@@ -40,12 +39,6 @@ test_rejectsChangedValueType =
   assertBool "expected changed type mismatch" $
     not (null (comparePackageSubset (pkg [moduleWithValue "GHC.Tuple" "Solo" "Int"]) (pkg [moduleWithValue "GHC.Tuple" "Solo" "Solo a"])))
 
-test_aihcPrimSubset :: Assertion
-test_aihcPrimSubset = do
-  candidate <- extractPackage "aihc-prim"
-  oracle <- extractPackage "ghc-prim"
-  assertEqual "aihc-prim mismatches" [] (comparePackageSubset (withoutModules ["GHC.Prim"] candidate) oracle)
-
 test_aihcInternalSubset :: Assertion
 test_aihcInternalSubset = do
   candidate <- extractPackage "aihc-internal"
@@ -58,10 +51,6 @@ pkg modules =
     { piPackage = "pkg-0",
       piModules = modules
     }
-
-withoutModules :: [T.Text] -> PackageInterface -> PackageInterface
-withoutModules excluded package =
-  package {piModules = filter ((`notElem` excluded) . miModule) (piModules package)}
 
 emptyModule :: String -> ModuleInterface
 emptyModule name =

--- a/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
+++ b/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
@@ -44,7 +44,7 @@ test_aihcPrimSubset :: Assertion
 test_aihcPrimSubset = do
   candidate <- extractPackage "aihc-prim"
   oracle <- extractPackage "ghc-prim"
-  assertEqual "aihc-prim mismatches" [] (comparePackageSubset candidate oracle)
+  assertEqual "aihc-prim mismatches" [] (comparePackageSubset (withoutModules ["GHC.Prim"] candidate) oracle)
 
 test_aihcInternalSubset :: Assertion
 test_aihcInternalSubset = do
@@ -58,6 +58,10 @@ pkg modules =
     { piPackage = "pkg-0",
       piModules = modules
     }
+
+withoutModules :: [T.Text] -> PackageInterface -> PackageInterface
+withoutModules excluded package =
+  package {piModules = filter ((`notElem` excluded) . miModule) (piModules package)}
 
 emptyModule :: String -> ModuleInterface
 emptyModule name =


### PR DESCRIPTION
## Summary

- Expose `catch#`, `raise#`, `State#`, `RealWorld`, and `TYPE` from `aihc-prim` without depending on upstream `ghc-prim`.
- Define an independent `GHC.Types` representation surface for `TYPE`, `RuntimeRep(..)`, `Levity(..)`, `VecCount(..)`, and `VecElem(..)`.
- Treat `aihc-prim` as an AIHC boot-library interface source, not as a package that must build under GHC/Cabal.
- Represent `foreign import prim` declarations explicitly in FC and validate known primitive names/types before evaluation.
- Require `catch#` imports to use the exact GHC-compatible `State# RealWorld` and unboxed tuple type.
- Teach the FC evaluator to model `raise#`, `catch#`, and integer primitive operations only when they enter the program through validated primitive imports.
- Remove direct Suite unit tests for exception primitives and cover behavior with eval fixtures instead, including local `-#`, unknown primitive, wrong primitive type, wrong `catch#` type, inline primitive exception handling, and `raise#`/`catch#` imported from `aihc-prim`.
- Remove the hard-coded `GHC.Prim` extractor interface and stop running `.hi` subset comparison for `aihc-prim`, because that library is no longer a GHC-built package in this repo.
- Export `AIHC_PRIM_SRC` in Nix FC/AIHC checks so isolated flake checks can load `aihc-prim` source fixtures.

## Why

`aihc-prim` is an independent boot library interface for AIHC, not a wrapper around GHC's `ghc-prim` and not code that GHC needs to compile. Primitive runtime behavior belongs in AIHC's FC evaluator, and a primitive-like name should not become a primitive unless the source/interface declared it with `foreign import prim` and a supported type.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options='--pattern "foreign-prim" --hide-successes'`
- `cabal test -v0 aihc-dev:spec --test-options='--pattern "aihc-internal is a subset of ghc-internal" --hide-successes'`
- `cabal test -v0 aihc-fc:spec --test-options='--pattern evaluation --hide-successes'`
- `cabal test -v0 aihc-fc:spec --test-options='--hide-successes'`
- `nix build .#checks.aarch64-darwin.fc-tests`
- `nix flake check`
- `just fmt`
- `just check`

Progress counts: no README updates; this PR adds 7 FC eval fixtures.
