### PR TITLE
feat(aihc-dev): add core library compatibility stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Find more information here:
 | TypeCheck Stackage | <!-- AUTO-GENERATED: START tc-stackage-progress --> `116/3427` (`3.38%`) ○○○○○ <!-- AUTO-GENERATED: END tc-stackage-progress -->             |
 | Resolve Stackage   | <!-- AUTO-GENERATED: START resolve-stackage-progress --> `240/3427` (`7.00%`) ○○○○○ <!-- AUTO-GENERATED: END resolve-stackage-progress -->  |
 | Parser Stackage    | <!-- AUTO-GENERATED: START parser-stackage-progress --> `2937/2937` (`100.00%`) ●●●●● <!-- AUTO-GENERATED: END parser-stackage-progress --> |
+| ghc-prim / aihc-prim | <!-- AUTO-GENERATED: START ghc-prim-progress --> `0/1276` (`0.00%`) ○○○○○ <!-- AUTO-GENERATED: END ghc-prim-progress -->                    |
+| base / aihc-base   | <!-- AUTO-GENERATED: START base-progress --> `2/9355` (`0.02%`) ○○○○○ <!-- AUTO-GENERATED: END base-progress -->                             |
 | &nbsp; | &nbsp; |
 | TypeCheck Tests    | <!-- AUTO-GENERATED: START tc-progress --> `29/39` (`74.35%`) ●●●○○ <!-- AUTO-GENERATED: END tc-progress -->                                |
 | Resolve Tests      | <!-- AUTO-GENERATED: START resolve-progress --> `31/32` (`96.87%`) ●●●●○ <!-- AUTO-GENERATED: END resolve-progress -->                      |

--- a/scripts/update-generated-content.sh
+++ b/scripts/update-generated-content.sh
@@ -47,6 +47,7 @@ resolve_extension_markdown_cmd="${RESOLVE_EXTENSION_PROGRESS_CMD:-nix run .#reso
 stackage_cmd="${PARSER_STACKAGE_PROGRESS_CMD:-nix run .#aihc-dev -- parser-stackage-progress --snapshot lts-24.33 --jobs 1}"
 resolve_stackage_cmd="${RESOLVE_STACKAGE_PROGRESS_CMD:-nix run .#aihc-dev -- resolve-stackage-progress --snapshot lts-24.33}"
 tc_stackage_cmd="${TC_STACKAGE_PROGRESS_CMD:-nix run .#aihc-dev -- tc-stackage-progress --snapshot lts-24.33}"
+core_libs_progress_cmd="${CORE_LIBS_PROGRESS_CMD:-nix run .#aihc-dev -- core-libs-progress}"
 line_counts_cmd="${LINE_COUNTS_CMD:-nix run .#line-counts}"
 
 tmpdir="$(mktemp -d)"
@@ -65,6 +66,7 @@ resolve_extension_out="$tmpdir/resolve-extension-progress.md"
 stackage_out="$tmpdir/stackage-progress.txt"
 resolve_stackage_out="$tmpdir/resolve-stackage-progress.txt"
 tc_stackage_out="$tmpdir/tc-stackage-progress.txt"
+core_libs_progress_out="$tmpdir/core-libs-progress.txt"
 line_counts_out="$tmpdir/line-counts.txt"
 
 run_cmd "$parser_cmd" >"$parser_out"
@@ -77,6 +79,7 @@ run_cmd "$resolve_extension_markdown_cmd" | sed -n '/^# Name Resolver Extension 
 run_cmd "$stackage_cmd" >"$stackage_out" || true
 run_cmd "$resolve_stackage_cmd" >"$resolve_stackage_out" || true
 run_cmd "$tc_stackage_cmd" >"$tc_stackage_out" || true
+run_cmd "$core_libs_progress_cmd" >"$core_libs_progress_out"
 run_cmd "$line_counts_cmd" >"$line_counts_out"
 
 parse_progress() {
@@ -211,6 +214,24 @@ parse_tc_stackage_progress() {
   ' "$infile"
 }
 
+parse_core_libs_progress() {
+	local infile="$1"
+	local key="$2"
+	awk -v key="$key" '
+    $1 == key {
+      implemented = $2 + 0
+      total = $3 + 0
+      complete = $4 + 0
+    }
+    END {
+      if (total == "" || total <= 0) {
+        exit 2
+      }
+      printf "%d\n%d\n%.2f\n", implemented, total, complete
+    }
+  ' "$infile"
+}
+
 progress_circles() {
 	local complete="$1"
 	awk -v complete="$complete" '
@@ -311,6 +332,22 @@ tc_stackage_implemented="${tc_stackage_vals[0]}"
 tc_stackage_total="${tc_stackage_vals[1]}"
 tc_stackage_complete="${tc_stackage_vals[2]}"
 
+ghc_prim_vals=($(parse_core_libs_progress "$core_libs_progress_out" "GHC_PRIM")) || {
+	echo "update-generated-content.sh: could not parse core-libs-progress output for GHC_PRIM (expected 'GHC_PRIM N M PCT' line on stdout)." >&2
+	exit 2
+}
+ghc_prim_implemented="${ghc_prim_vals[0]}"
+ghc_prim_total="${ghc_prim_vals[1]}"
+ghc_prim_complete="${ghc_prim_vals[2]}"
+
+base_vals=($(parse_core_libs_progress "$core_libs_progress_out" "BASE")) || {
+	echo "update-generated-content.sh: could not parse core-libs-progress output for BASE (expected 'BASE N M PCT' line on stdout)." >&2
+	exit 2
+}
+base_implemented="${base_vals[0]}"
+base_total="${base_vals[1]}"
+base_complete="${base_vals[2]}"
+
 parser_total_tests=$((parser_total + ext_test_total))
 parser_passing_tests=$((parser_implemented + ext_implemented))
 parser_total_complete="$(awk -v passing="$parser_passing_tests" -v total="$parser_total_tests" 'BEGIN { if (total <= 0) { printf "0.00" } else { printf "%.2f", (passing * 100.0) / total } }')"
@@ -321,6 +358,8 @@ resolve_stackage_circles="$(progress_circles "$resolve_stackage_complete")"
 tc_stackage_circles="$(progress_circles "$tc_stackage_complete")"
 lexer_circles="$(progress_circles "$lexer_complete")"
 resolve_circles="$(progress_circles "$resolve_complete")"
+ghc_prim_circles="$(progress_circles "$ghc_prim_complete")"
+base_circles="$(progress_circles "$base_complete")"
 
 cat >"$tmpdir/readme-root-parser.txt" <<EOF2
 \`${parser_passing_tests}/${parser_total_tests}\` (\`${parser_total_complete}%\`) ${parser_total_circles}
@@ -348,6 +387,14 @@ EOF2
 
 cat >"$tmpdir/readme-root-resolve.txt" <<EOF2
 \`${resolve_implemented}/${resolve_total}\` (\`${resolve_complete}%\`) ${resolve_circles}
+EOF2
+
+cat >"$tmpdir/readme-root-ghc-prim.txt" <<EOF2
+\`${ghc_prim_implemented}/${ghc_prim_total}\` (\`${ghc_prim_complete}%\`) ${ghc_prim_circles}
+EOF2
+
+cat >"$tmpdir/readme-root-base.txt" <<EOF2
+\`${base_implemented}/${base_total}\` (\`${base_complete}%\`) ${base_circles}
 EOF2
 
 cat >"$tmpdir/readme-cpp.txt" <<EOF2
@@ -474,6 +521,8 @@ replace_marker_inline README.md "resolve-stackage-progress" "$tmpdir/readme-root
 replace_marker_inline README.md "tc-stackage-progress" "$tmpdir/readme-root-tc-stackage.txt"
 replace_marker_inline README.md "cpp-progress" "$tmpdir/readme-root-cpp.txt"
 replace_marker_inline README.md "resolve-progress" "$tmpdir/readme-root-resolve.txt"
+replace_marker_inline README.md "ghc-prim-progress" "$tmpdir/readme-root-ghc-prim.txt"
+replace_marker_inline README.md "base-progress" "$tmpdir/readme-root-base.txt"
 replace_marker_block README.md "line-counts" "$line_counts_out"
 replace_marker_block components/aihc-cpp/README.md "cpp-progress" "$tmpdir/readme-cpp.txt"
 

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -21,13 +21,16 @@ library extract-hi
     Aihc.Dev.ExtractHi.GhcSession
 
   build-depends:
+    Cabal-syntax >=3.14 && <3.17,
     aeson >=2.0 && <2.3,
+    aihc-parser,
     base >=4.16 && <5,
     bytestring >=0.10.8 && <0.13,
     containers >=0.5 && <0.8,
     directory >=1.2.3 && <1.5,
     filepath >=1.3.0.1 && <1.6,
     ghc >=9.12 && <9.13,
+    prettyprinter,
     process >=1.6 && <1.8,
     text >=1.2.3 && <2.2,
 

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Aihc.Dev.ExtractHi (extractPackage)
-import Aihc.Dev.ExtractHi.Compare (comparePackageSubset, renderInterfaceMismatch)
+import Aihc.Dev.ExtractHi.Compare (comparePackageSubset, renderCoreLibProgressReports, renderInterfaceMismatch, runCoreLibProgressReports)
 import Aihc.Dev.ExtractHi.ToResolveIface (toResolveIface)
 import Aihc.Dev.Golden.Update qualified as GoldenUpdate
 import Aihc.Dev.HackageTester.Run qualified as HackageTesterRun
@@ -44,6 +44,7 @@ main = do
 data Command
   = ExtractHi ExtractHiOpts
   | CompareHiSubset CompareHiSubsetOpts
+  | CoreLibsProgress
   | ExtractResolveIface ExtractResolveIfaceOpts
   | Snippet SnippetOpts
   | Parser ParserRun.Options
@@ -88,6 +89,12 @@ commandParser =
           ( info
               (CompareHiSubset <$> compareHiSubsetParser <**> helper)
               (progDesc "Check that a candidate .hi interface is a subset of an oracle package")
+          )
+        <> command
+          "core-libs-progress"
+          ( info
+              (pure CoreLibsProgress <**> helper)
+              (progDesc "Report ghc-prim/base API coverage for aihc-prim/aihc-base")
           )
         <> command
           "extract-resolve-iface"
@@ -236,6 +243,8 @@ runCommand (CompareHiSubset opts) = do
     else do
       mapM_ (putStrLn . renderInterfaceMismatch) mismatches
       exitFailure
+runCommand CoreLibsProgress =
+  putStr . renderCoreLibProgressReports =<< runCoreLibProgressReports
 runCommand (ExtractResolveIface opts) = do
   pkg <- extractPackage (eriPackage opts)
   let resolveIface = toResolveIface pkg

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
@@ -8,18 +8,58 @@
 -- by following exported names to their defining modules.
 module Aihc.Dev.ExtractHi
   ( extractPackage,
+    extractPackageMaybe,
+    extractSourcePackage,
   )
 where
 
 import Aihc.Dev.ExtractHi.GhcSession (withReadIface)
 import Aihc.Dev.ExtractHi.Types
-import Control.Exception (IOException, catch)
+import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
+import Aihc.Parser.Pretty (prettyType)
+import Aihc.Parser.Syntax
+  ( BinderHead (..),
+    ClassDecl (..),
+    ClassDeclItem (..),
+    DataConDecl (..),
+    DataDecl (..),
+    Decl (..),
+    ExportSpec (..),
+    FieldDecl (..),
+    FixityAssoc,
+    GadtBody (..),
+    IEBundledMember (..),
+    IEEntityNamespace (..),
+    Module (..),
+    NewtypeDecl (..),
+    Pattern (..),
+    Type (..),
+    TypeFamilyDecl (..),
+    TypeFamilyResultSig (..),
+    TypeSynDecl (..),
+    UnqualifiedName,
+    ValueDecl (..),
+    moduleExports,
+    peelClassDeclItemAnn,
+    peelDataConAnn,
+    peelDeclAnn,
+    renderName,
+    renderUnqualifiedName,
+  )
+import Aihc.Parser.Syntax qualified as Syntax
 import Control.Monad.IO.Class (liftIO)
+import Data.ByteString qualified as BS
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Distribution.ModuleName qualified as CabalModuleName
+import Distribution.PackageDescription (GenericPackageDescription, condLibrary, exposedModules)
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Types.CondTree (CondTree (condTreeData))
 import GHC (Ghc)
 import GHC.Iface.Syntax
   ( IfaceClassBody (..),
@@ -37,9 +77,11 @@ import GHC.Unit.Module.ModIface (ModIface, mi_decls, mi_exports, mi_fixities)
 import GHC.Unit.Types (moduleName, moduleUnit, unitString)
 import GHC.Utils.Outputable (showSDocUnsafe)
 import Language.Haskell.Syntax.Basic qualified as GHC
-import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory)
+import Prettyprinter (defaultLayoutOptions, layoutPretty)
+import Prettyprinter.Render.String (renderString)
+import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 import System.Exit (ExitCode (..))
-import System.FilePath (takeDirectory, (<.>), (</>))
+import System.FilePath (takeDirectory, takeExtension, (<.>), (</>))
 import System.Process (readProcess, readProcessWithExitCode)
 
 -- | Cached module data: declarations and fixities from a single .hi file.
@@ -52,6 +94,27 @@ data CachedModule = CachedModule
 extractPackage :: String -> IO PackageInterface
 extractPackage pkgName = do
   (pkgId, importDir, exposedMods) <- queryPackage pkgName
+  extractPackageFromQuery pkgId importDir exposedMods
+
+extractPackageMaybe :: String -> IO (Maybe PackageInterface)
+extractPackageMaybe pkgName = do
+  mPackage <- queryPackageMaybe pkgName
+  case mPackage of
+    Nothing -> pure Nothing
+    Just (pkgId, importDir, exposedMods) -> Just <$> extractPackageFromQuery pkgId importDir exposedMods
+
+extractSourcePackage :: FilePath -> String -> IO PackageInterface
+extractSourcePackage root pkgName = do
+  exposedMods <- exposedSourceModules root
+  modules <- mapM (extractSourceModule (root </> "src")) exposedMods
+  pure
+    PackageInterface
+      { piPackage = T.pack pkgName,
+        piModules = modules
+      }
+
+extractPackageFromQuery :: String -> FilePath -> [String] -> IO PackageInterface
+extractPackageFromQuery pkgId importDir exposedMods =
   withReadIface $ \readIface -> do
     cacheRef <- liftIO $ newIORef (Map.empty :: Map (String, String) CachedModule)
     modules <- mapM (extractSingleModule readIface cacheRef importDir) exposedMods
@@ -398,6 +461,292 @@ renderKind :: [IfaceTyConBinder] -> IfaceType -> Text
 renderKind _binders resKind =
   T.pack (showSDocUnsafe (pprIfaceType resKind))
 
+exposedSourceModules :: FilePath -> IO [String]
+exposedSourceModules root = do
+  cabalFiles <- filter ((".cabal" ==) . takeExtension) <$> listDirectory root
+  case cabalFiles of
+    cabalFile : _ -> do
+      contents <- BS.readFile (root </> cabalFile)
+      case runParseResult (parseGenericPackageDescription contents) of
+        (_, Right gpd) -> pure (genericPackageExposedModules gpd)
+        (_, Left (_, errors)) -> ioError (userError ("could not parse " <> cabalFile <> ": " <> show errors))
+    [] -> ioError (userError ("no Cabal file found under " <> root))
+
+genericPackageExposedModules :: GenericPackageDescription -> [String]
+genericPackageExposedModules gpd =
+  [ CabalModuleName.toFilePath modName
+  | libTree <- maybe [] pure (condLibrary gpd),
+    modName <- exposedModules (condTreeData libTree)
+  ]
+
+extractSourceModule :: FilePath -> String -> IO ModuleInterface
+extractSourceModule srcRoot modPath = do
+  let sourcePath = srcRoot </> modPath <.> "hs"
+      modName = T.pack (map pathSepToDot modPath)
+  exists <- doesFileExist sourcePath
+  if not exists
+    then pure (emptySourceModule modName)
+    else do
+      source <- TE.decodeUtf8 <$> BS.readFile sourcePath
+      let (errs, parsed) =
+            parseModule
+              (defaultConfig {parserSourceName = sourcePath})
+              source
+      if null errs
+        then pure (sourceModuleInterface modName parsed)
+        else pure (emptySourceModule modName)
+
+emptySourceModule :: Text -> ModuleInterface
+emptySourceModule modName =
+  ModuleInterface
+    { miModule = modName,
+      miTypes = [],
+      miValues = [],
+      miClasses = [],
+      miFixities = []
+    }
+
+sourceModuleInterface :: Text -> Module -> ModuleInterface
+sourceModuleInterface fallbackName modu =
+  applySourceExports modu $
+    ModuleInterface
+      { miModule = fromMaybe fallbackName (Syntax.moduleName modu),
+        miTypes = sourceTypes kindSigs decls,
+        miValues = sourceValues decls,
+        miClasses = sourceClasses decls,
+        miFixities = sourceFixities decls
+      }
+  where
+    decls = map peelDeclAnn (moduleDecls modu)
+    kindSigs = Map.fromList [(renderUnqualifiedName name, renderSourceType kind) | DeclStandaloneKindSig name kind <- decls]
+
+sourceValues :: [Decl] -> [ExportedValue]
+sourceValues decls =
+  Map.elems $
+    Map.unionsWith
+      preferTypedValue
+      [ Map.fromList [(renderUnqualifiedName name, ExportedValue (renderUnqualifiedName name) (renderSourceType ty)) | DeclTypeSig names ty <- decls, name <- names],
+        Map.fromList [(name, ExportedValue name "<missing-source-signature>") | DeclValue valueDecl <- decls, name <- valueDeclNames valueDecl]
+      ]
+
+preferTypedValue :: ExportedValue -> ExportedValue -> ExportedValue
+preferTypedValue left right
+  | evType left == "<missing-source-signature>" = right
+  | otherwise = left
+
+valueDeclNames :: ValueDecl -> [Text]
+valueDeclNames valueDecl =
+  case valueDecl of
+    FunctionBind name _ -> [renderUnqualifiedName name]
+    PatternBind _ pat _ -> patternBinderNames pat
+
+patternBinderNames :: Pattern -> [Text]
+patternBinderNames pat =
+  case pat of
+    PAnn _ inner -> patternBinderNames inner
+    PVar name -> [renderUnqualifiedName name]
+    _ -> []
+
+sourceTypes :: Map Text Text -> [Decl] -> [ExportedType]
+sourceTypes kindSigs =
+  mapMaybe go
+  where
+    go decl =
+      case decl of
+        DeclTypeSyn syn ->
+          let name = binderHeadName (typeSynHead syn)
+           in Just (ExportedType name (sourceTypeKind kindSigs name Nothing) [])
+        DeclTypeData dataDecl -> Just (sourceDataType kindSigs dataDecl)
+        DeclData dataDecl -> Just (sourceDataType kindSigs dataDecl)
+        DeclNewtype newtypeDecl -> Just (sourceNewtype kindSigs newtypeDecl)
+        DeclTypeFamilyDecl familyDecl ->
+          let name = sourceTypeFamilyName familyDecl
+              kind = case typeFamilyDeclResultSig familyDecl of
+                Just (TypeFamilyKindSig ty) -> Just ty
+                _ -> Nothing
+           in Just (ExportedType name (sourceTypeKind kindSigs name kind) [])
+        _ -> Nothing
+
+sourceDataType :: Map Text Text -> DataDecl -> ExportedType
+sourceDataType kindSigs dataDecl =
+  ExportedType
+    { etName = name,
+      etKind = sourceTypeKind kindSigs name (dataDeclKind dataDecl),
+      etConstructors = concatMap dataConNames (dataDeclConstructors dataDecl)
+    }
+  where
+    name = binderHeadName (dataDeclHead dataDecl)
+
+sourceNewtype :: Map Text Text -> NewtypeDecl -> ExportedType
+sourceNewtype kindSigs newtypeDecl =
+  ExportedType
+    { etName = name,
+      etKind = sourceTypeKind kindSigs name (newtypeDeclKind newtypeDecl),
+      etConstructors = maybe [] dataConNames (newtypeDeclConstructor newtypeDecl)
+    }
+  where
+    name = binderHeadName (newtypeDeclHead newtypeDecl)
+
+sourceTypeKind :: Map Text Text -> Text -> Maybe Type -> Text
+sourceTypeKind kindSigs name inlineKind =
+  case inlineKind of
+    Just kind -> renderSourceType kind
+    Nothing -> Map.findWithDefault "<unspecified-source-kind>" name kindSigs
+
+sourceClasses :: [Decl] -> [ExportedClass]
+sourceClasses decls =
+  [ ExportedClass
+      { ecName = binderHeadName (classDeclHead classDecl),
+        ecMethods = sourceClassMethods classDecl
+      }
+  | DeclClass classDecl <- decls
+  ]
+
+sourceClassMethods :: ClassDecl -> [ClassMethod]
+sourceClassMethods classDecl =
+  [ ClassMethod (renderUnqualifiedName name) (renderSourceType ty)
+  | item <- map peelClassDeclItemAnn (classDeclItems classDecl),
+    ClassItemTypeSig names ty <- [item],
+    name <- names
+  ]
+
+sourceFixities :: [Decl] -> [FixityInfo]
+sourceFixities decls =
+  [ FixityInfo
+      { fiName = renderUnqualifiedName op,
+        fiDirection = sourceFixityDirection assoc,
+        fiPrecedence = fromMaybe 9 mPrec
+      }
+  | DeclFixity assoc _ mPrec ops <- decls,
+    op <- ops
+  ]
+
+sourceFixityDirection :: FixityAssoc -> FixityDirection
+sourceFixityDirection assoc =
+  case assoc of
+    Syntax.InfixL -> Aihc.Dev.ExtractHi.Types.InfixL
+    Syntax.InfixR -> Aihc.Dev.ExtractHi.Types.InfixR
+    Syntax.Infix -> Aihc.Dev.ExtractHi.Types.InfixN
+
+applySourceExports :: Module -> ModuleInterface -> ModuleInterface
+applySourceExports modu iface =
+  case moduleExports modu of
+    Nothing -> iface
+    Just specs ->
+      iface
+        { miValues = filter (exportedValue allowedValues) (miValues iface),
+          miTypes = mapMaybe (filterExportedType allowedTypes allowedConstructors) (miTypes iface),
+          miClasses = mapMaybe (filterExportedClass allowedTypes allowedMethods) (miClasses iface),
+          miFixities = filter (exportedFixity allowedValues allowedTypes) (miFixities iface)
+        }
+      where
+        allowedValues = Map.fromList [(name, ()) | name <- concatMap exportValueNames specs]
+        allowedTypes = Map.fromList [(name, exportMembers spec) | spec <- specs, name <- exportTypeNames spec]
+        allowedConstructors = Map.unionsWith (<>) [Map.singleton parent members | spec <- specs, (parent, members) <- exportTypeMemberNames spec]
+        allowedMethods = Map.unionsWith (<>) [Map.singleton parent members | spec <- specs, (parent, members) <- exportTypeMemberNames spec]
+
+exportedValue :: Map Text () -> ExportedValue -> Bool
+exportedValue allowed value =
+  Map.member (evName value) allowed
+
+filterExportedType :: Map Text (Maybe [Text]) -> Map Text [Text] -> ExportedType -> Maybe ExportedType
+filterExportedType allowedTypes allowedConstructors typ =
+  case Map.lookup (etName typ) allowedTypes of
+    Nothing -> Nothing
+    Just Nothing -> Just (typ {etConstructors = []})
+    Just (Just []) -> Just typ
+    Just (Just names) -> Just (typ {etConstructors = filter (`elem` names) (etConstructors typ)})
+  where
+    _ = allowedConstructors
+
+filterExportedClass :: Map Text (Maybe [Text]) -> Map Text [Text] -> ExportedClass -> Maybe ExportedClass
+filterExportedClass allowedTypes allowedMethods klass =
+  case Map.lookup (ecName klass) allowedTypes of
+    Nothing -> Nothing
+    Just Nothing -> Just (klass {ecMethods = []})
+    Just (Just []) -> Just klass
+    Just (Just names) -> Just (klass {ecMethods = filter ((`elem` names) . cmName) (ecMethods klass)})
+  where
+    _ = allowedMethods
+
+exportedFixity :: Map Text () -> Map Text (Maybe [Text]) -> FixityInfo -> Bool
+exportedFixity allowedValues allowedTypes fixity =
+  Map.member (fiName fixity) allowedValues || Map.member (fiName fixity) allowedTypes
+
+exportValueNames :: ExportSpec -> [Text]
+exportValueNames spec =
+  case spec of
+    ExportAnn _ inner -> exportValueNames inner
+    ExportVar _ namespace name | namespace /= Just IEEntityNamespaceType -> [renderName name]
+    _ -> []
+
+exportTypeNames :: ExportSpec -> [Text]
+exportTypeNames spec =
+  case spec of
+    ExportAnn _ inner -> exportTypeNames inner
+    ExportVar _ (Just IEEntityNamespaceType) name -> [renderName name]
+    ExportAbs _ _ name -> [renderName name]
+    ExportAll _ _ name -> [renderName name]
+    ExportWith _ _ name _ -> [renderName name]
+    ExportWithAll _ _ name _ _ -> [renderName name]
+    _ -> []
+
+exportTypeMemberNames :: ExportSpec -> [(Text, [Text])]
+exportTypeMemberNames spec =
+  case spec of
+    ExportAnn _ inner -> exportTypeMemberNames inner
+    ExportWith _ _ name members -> [(renderName name, map (renderName . ieBundledMemberName) members)]
+    ExportWithAll _ _ name _ members -> [(renderName name, map (renderName . ieBundledMemberName) members)]
+    _ -> []
+
+exportMembers :: ExportSpec -> Maybe [Text]
+exportMembers spec =
+  case spec of
+    ExportAnn _ inner -> exportMembers inner
+    ExportAbs {} -> Nothing
+    ExportAll {} -> Just []
+    ExportWith _ _ _ members -> Just (map (renderName . ieBundledMemberName) members)
+    ExportWithAll _ _ _ _ members -> Just (map (renderName . ieBundledMemberName) members)
+    _ -> Nothing
+
+binderHeadName :: BinderHead UnqualifiedName -> Text
+binderHeadName head' =
+  case head' of
+    PrefixBinderHead name _ -> renderUnqualifiedName name
+    InfixBinderHead _ name _ _ -> renderUnqualifiedName name
+
+sourceTypeFamilyName :: TypeFamilyDecl -> Text
+sourceTypeFamilyName familyDecl =
+  case typeFamilyDeclHead familyDecl of
+    TCon name _ -> renderName name
+    _ -> renderSourceType (typeFamilyDeclHead familyDecl)
+
+dataConNames :: DataConDecl -> [Text]
+dataConNames con =
+  case peelDataConAnn con of
+    PrefixCon _ _ name _ -> [renderUnqualifiedName name]
+    InfixCon _ _ _ name _ -> [renderUnqualifiedName name]
+    RecordCon _ _ name fields -> renderUnqualifiedName name : concatMap fieldDeclNames fields
+    GadtCon _ _ names body -> map renderUnqualifiedName names <> gadtBodyFieldNames body
+    TupleCon {} -> []
+    UnboxedSumCon {} -> []
+    ListCon {} -> ["[]"]
+    DataConAnn {} -> []
+
+gadtBodyFieldNames :: GadtBody -> [Text]
+gadtBodyFieldNames body =
+  case body of
+    GadtPrefixBody {} -> []
+    GadtRecordBody fields _ -> concatMap fieldDeclNames fields
+
+fieldDeclNames :: FieldDecl -> [Text]
+fieldDeclNames field =
+  map renderUnqualifiedName (fieldNames field)
+
+renderSourceType :: Type -> Text
+renderSourceType =
+  T.pack . renderString . layoutPretty defaultLayoutOptions . prettyType
+
 -- | Query @ghc-pkg@ for package information.
 --
 -- Returns (package-id, import-dir, [exposed-module-names]).
@@ -409,33 +758,43 @@ queryPackage pkgName = do
   let exposedMods = map stripComma (words exposedModsRaw)
   pure (pkgId, importDir, exposedMods)
 
+queryPackageMaybe :: String -> IO (Maybe (String, FilePath, [String]))
+queryPackageMaybe pkgName = do
+  mPkgId <- fmap trim <$> tryReadGhcPkg ["field", pkgName, "id", "--simple-output"]
+  mImportDir <- fmap trim <$> tryReadGhcPkg ["field", pkgName, "import-dirs", "--simple-output"]
+  mExposedModsRaw <- tryReadGhcPkg ["field", pkgName, "exposed-modules", "--simple-output"]
+  pure $ do
+    pkgId <- mPkgId
+    importDir <- mImportDir
+    exposedModsRaw <- mExposedModsRaw
+    let exposedMods = map stripComma (words exposedModsRaw)
+    pure (pkgId, importDir, exposedMods)
+
 -- | Query @ghc-pkg@ for a package's import directory by unit id.
 queryImportDir :: String -> IO (Maybe FilePath)
 queryImportDir unitId = do
-  result <- tryReadGhcPkg ["field", unitId, "import-dirs", "--simple-output"]
+  result <- tryReadGhcPkg ["--ipid", "field", unitId, "import-dirs", "--simple-output"]
   case result of
     Just dir -> pure (Just (trim dir))
     Nothing -> pure Nothing
 
 readGhcPkg :: [String] -> IO String
 readGhcPkg args = do
-  result <- tryReadGhcPkgRaw args
+  result <- tryReadGhcPkg args
   case result of
     Just output -> pure output
+    Nothing -> readProcess "ghc-pkg" args ""
+
+tryReadGhcPkg :: [String] -> IO (Maybe String)
+tryReadGhcPkg args = do
+  result <- tryReadGhcPkgRaw args
+  case result of
+    Just output -> pure (Just output)
     Nothing -> do
       mPackageDb <- findLocalPackageDb
       case mPackageDb of
-        Nothing -> readProcess "ghc-pkg" args ""
-        Just packageDb -> do
-          fallbackResult <- tryReadGhcPkgRaw ("--package-db" : packageDb : args)
-          case fallbackResult of
-            Just output -> pure output
-            Nothing -> readProcess "ghc-pkg" args ""
-
-tryReadGhcPkg :: [String] -> IO (Maybe String)
-tryReadGhcPkg args =
-  (Just <$> readGhcPkg args)
-    `catch` (\(_ :: IOException) -> pure Nothing)
+        Nothing -> pure Nothing
+        Just packageDb -> tryReadGhcPkgRaw ("--package-db" : packageDb : args)
 
 tryReadGhcPkgRaw :: [String] -> IO (Maybe String)
 tryReadGhcPkgRaw args = do
@@ -476,3 +835,7 @@ trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
 dotToSlash :: Char -> Char
 dotToSlash '.' = '/'
 dotToSlash c = c
+
+pathSepToDot :: Char -> Char
+pathSepToDot '/' = '.'
+pathSepToDot c = c

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Compare.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Compare.hs
@@ -3,22 +3,107 @@
 -- | Subset compatibility checks for interfaces extracted from @.hi@ files.
 module Aihc.Dev.ExtractHi.Compare
   ( InterfaceMismatch (..),
+    CompatibilityReport (..),
+    CoreLibProgressReport (..),
+    comparePackageCompatibility,
     comparePackageSubset,
+    compatibilityPercent,
+    coreLibProgressReports,
     renderInterfaceMismatch,
+    renderCoreLibProgressReport,
+    renderCoreLibProgressReports,
+    runCoreLibProgressReports,
   )
 where
 
+import Aihc.Dev.ExtractHi (extractPackage, extractSourcePackage)
 import Aihc.Dev.ExtractHi.Types
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
+import System.FilePath ((</>))
+import Text.Printf (printf)
 
 data InterfaceMismatch = InterfaceMismatch
   { mismatchPath :: !Text,
     mismatchMessage :: !Text
   }
   deriving (Eq, Show)
+
+data CompatibilityReport = CompatibilityReport
+  { crMatched :: !Int,
+    crTotal :: !Int,
+    crExtra :: !Int,
+    crMismatches :: ![InterfaceMismatch]
+  }
+  deriving (Eq, Show)
+
+data CoreLibProgressReport = CoreLibProgressReport
+  { clprProgressKey :: !String,
+    clprExtraKey :: !String,
+    clprReport :: !CompatibilityReport
+  }
+  deriving (Eq, Show)
+
+comparePackageCompatibility :: PackageInterface -> PackageInterface -> CompatibilityReport
+comparePackageCompatibility candidate oracle =
+  CompatibilityReport
+    { crMatched = matched,
+      crTotal = total,
+      crExtra = countExtraPackageItems candidate oracle,
+      crMismatches = mismatches
+    }
+  where
+    oracleItems = packageItems oracle
+    candidateItems = packageItems candidate
+    candidateMap = keyed itemKey candidateItems
+    results = map (compareCompatibilityItem candidateMap) oracleItems
+    matched = length (filter id (map fst results))
+    total = length oracleItems
+    mismatches = concatMap snd results
+
+compatibilityPercent :: CompatibilityReport -> Double
+compatibilityPercent report
+  | crTotal report <= 0 = 100
+  | otherwise = fromIntegral (crMatched report) * 100.0 / fromIntegral (crTotal report)
+
+coreLibProgressReports :: PackageInterface -> PackageInterface -> PackageInterface -> PackageInterface -> [CoreLibProgressReport]
+coreLibProgressReports aihcPrim ghcPrim aihcBase base =
+  [ CoreLibProgressReport
+      { clprProgressKey = "GHC_PRIM",
+        clprExtraKey = "ghc-prim",
+        clprReport = comparePackageCompatibility aihcPrim ghcPrim
+      },
+    CoreLibProgressReport
+      { clprProgressKey = "BASE",
+        clprExtraKey = "base",
+        clprReport = comparePackageCompatibility aihcBase base
+      }
+  ]
+
+runCoreLibProgressReports :: IO [CoreLibProgressReport]
+runCoreLibProgressReports = do
+  ghcPrim <- extractPackage "ghc-prim"
+  aihcPrim <- extractSourcePackage ("core-libs" </> "aihc-prim") "aihc-prim"
+  base <- extractPackage "base"
+  aihcBase <- extractSourcePackage ("core-libs" </> "aihc-base") "aihc-base"
+  pure (coreLibProgressReports aihcPrim ghcPrim aihcBase base)
+
+renderCoreLibProgressReports :: [CoreLibProgressReport] -> String
+renderCoreLibProgressReports reports =
+  unlines (map renderCoreLibProgressReport reports <> map renderExtraLine reports)
+
+renderCoreLibProgressReport :: CoreLibProgressReport -> String
+renderCoreLibProgressReport report =
+  printf
+    "%s %d %d %.2f"
+    (clprProgressKey report)
+    (crMatched stats)
+    (crTotal stats)
+    (compatibilityPercent stats)
+  where
+    stats = clprReport report
 
 comparePackageSubset :: PackageInterface -> PackageInterface -> [InterfaceMismatch]
 comparePackageSubset candidate oracle =
@@ -119,3 +204,98 @@ mismatch = InterfaceMismatch
 renderInterfaceMismatch :: InterfaceMismatch -> String
 renderInterfaceMismatch item =
   T.unpack (mismatchPath item <> ": " <> mismatchMessage item)
+
+renderExtraLine :: CoreLibProgressReport -> String
+renderExtraLine report =
+  printf "EXTRA %s %d" (clprExtraKey report) (crExtra (clprReport report))
+
+data InterfaceItem = InterfaceItem
+  { itemKey :: !Text,
+    itemPath :: !Text,
+    itemSignature :: !Text
+  }
+  deriving (Eq, Show)
+
+compareCompatibilityItem :: Map Text InterfaceItem -> InterfaceItem -> (Bool, [InterfaceMismatch])
+compareCompatibilityItem candidateItems oracleItem =
+  case Map.lookup (itemKey oracleItem) candidateItems of
+    Nothing -> (False, [mismatch (itemPath oracleItem) "export is missing from candidate"])
+    Just candidateItem
+      | itemSignature candidateItem /= itemSignature oracleItem ->
+          (False, [mismatch (itemPath oracleItem) "export signature differs from candidate"])
+      | otherwise -> (True, [])
+
+countExtraPackageItems :: PackageInterface -> PackageInterface -> Int
+countExtraPackageItems candidate oracle =
+  length
+    [ ()
+    | candidateItem <- packageItems candidate,
+      Map.notMember (itemKey candidateItem) oracleItems
+    ]
+  where
+    oracleItems = keyed itemKey (packageItems oracle)
+
+packageItems :: PackageInterface -> [InterfaceItem]
+packageItems pkg =
+  concatMap moduleItems (piModules pkg)
+
+moduleItems :: ModuleInterface -> [InterfaceItem]
+moduleItems iface =
+  concat
+    [ map (valueItem moduleName) (miValues iface),
+      concatMap (typeItems moduleName) (miTypes iface),
+      concatMap (classItems moduleName) (miClasses iface),
+      map (fixityItem moduleName) (miFixities iface)
+    ]
+  where
+    moduleName = miModule iface
+
+valueItem :: Text -> ExportedValue -> InterfaceItem
+valueItem moduleName value =
+  InterfaceItem
+    { itemKey = moduleName <> ".value:" <> evName value,
+      itemPath = moduleName <> ".value:" <> evName value,
+      itemSignature = evType value
+    }
+
+typeItems :: Text -> ExportedType -> [InterfaceItem]
+typeItems moduleName typ =
+  InterfaceItem
+    { itemKey = typeKey,
+      itemPath = typeKey,
+      itemSignature = etKind typ
+    }
+    : [ InterfaceItem
+          { itemKey = typeKey <> ".constructor:" <> ctor,
+            itemPath = typeKey <> ".constructor:" <> ctor,
+            itemSignature = ctor
+          }
+      | ctor <- etConstructors typ
+      ]
+  where
+    typeKey = moduleName <> ".type:" <> etName typ
+
+classItems :: Text -> ExportedClass -> [InterfaceItem]
+classItems moduleName klass =
+  InterfaceItem
+    { itemKey = classKey,
+      itemPath = classKey,
+      itemSignature = ecName klass
+    }
+    : [ InterfaceItem
+          { itemKey = classKey <> ".method:" <> cmName method,
+            itemPath = classKey <> ".method:" <> cmName method,
+            itemSignature = cmType method
+          }
+      | method <- ecMethods klass
+      ]
+  where
+    classKey = moduleName <> ".class:" <> ecName klass
+
+fixityItem :: Text -> FixityInfo -> InterfaceItem
+fixityItem moduleName fixity =
+  InterfaceItem
+    { itemKey = moduleName <> ".fixity:" <> fiName fixity,
+      itemPath = moduleName <> ".fixity:" <> fiName fixity,
+      itemSignature = T.pack (show fixity)
+    }

--- a/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
+++ b/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
@@ -5,12 +5,22 @@ module Test.ExtractHiCompare
   )
 where
 
-import Aihc.Dev.ExtractHi (extractPackage)
-import Aihc.Dev.ExtractHi.Compare (comparePackageSubset)
+import Aihc.Dev.ExtractHi (extractPackage, extractSourcePackage)
+import Aihc.Dev.ExtractHi.Compare
+  ( CompatibilityReport (..),
+    CoreLibProgressReport (..),
+    comparePackageCompatibility,
+    comparePackageSubset,
+    renderCoreLibProgressReports,
+  )
 import Aihc.Dev.ExtractHi.Types
+import Control.Exception (bracket)
 import Data.Text qualified as T
+import System.Directory (createDirectory, createDirectoryIfMissing, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, testCase)
+import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 
 extractHiCompareTests :: TestTree
 extractHiCompareTests =
@@ -19,6 +29,16 @@ extractHiCompareTests =
     [ testCase "accepts empty candidate module exports" test_acceptsEmptyCandidateModuleExports,
       testCase "rejects candidate module missing from oracle" test_rejectsMissingModule,
       testCase "rejects changed value type" test_rejectsChangedValueType,
+      testGroup
+        "core-libs-progress"
+        [ testCase "counts matching exported interface facts" test_coreLibProgressCountsMatches,
+          testCase "extracts source package exports" test_coreLibProgressExtractsSourcePackage,
+          testCase "counts missing candidate exports as failures" test_coreLibProgressCountsMissingExports,
+          testCase "rejects changed value types and type kinds" test_coreLibProgressRejectsChangedSignatures,
+          testCase "requires exports to come from the same module" test_coreLibProgressRequiresSameModule,
+          testCase "counts candidate-only exports separately" test_coreLibProgressCountsExtrasSeparately,
+          testCase "renders stable command output" test_coreLibProgressRendersStableOutput
+        ],
       testCase "aihc-prim is a subset of ghc-prim" test_aihcPrimSubset,
       testCase "aihc-internal is a subset of ghc-internal" test_aihcInternalSubset
     ]
@@ -39,6 +59,90 @@ test_rejectsChangedValueType :: Assertion
 test_rejectsChangedValueType =
   assertBool "expected changed type mismatch" $
     not (null (comparePackageSubset (pkg [moduleWithValue "GHC.Tuple" "Solo" "Int"]) (pkg [moduleWithValue "GHC.Tuple" "Solo" "Solo a"])))
+
+test_coreLibProgressCountsMatches :: Assertion
+test_coreLibProgressCountsMatches =
+  assertEqual
+    "report"
+    (CompatibilityReport 6 6 0 [])
+    (comparePackageCompatibility (pkg [fullModule "A"]) (pkg [fullModule "A"]))
+
+test_coreLibProgressExtractsSourcePackage :: Assertion
+test_coreLibProgressExtractsSourcePackage =
+  withTempDir "core-libs-progress-source" $ \root -> do
+    let srcDir = root </> "src" </> "Data"
+    createDirectoryIfMissing True srcDir
+    writeFile (root </> "demo-base.cabal") demoBaseCabal
+    writeFile (srcDir </> "Bool.hs") demoBoolSource
+    iface <- extractSourcePackage root "demo-base"
+    case piModules iface of
+      [modIface] -> do
+        assertEqual "module" "Data.Bool" (miModule modIface)
+        assertEqual "values" [ExportedValue "&&" "Bool -> Bool -> Bool", ExportedValue "not" "Bool -> Bool"] (miValues modIface)
+        assertEqual "types" [ExportedType "Bool" "<unspecified-source-kind>" ["False", "True"]] (miTypes modIface)
+        assertEqual "fixities" [FixityInfo "&&" InfixR 3] (miFixities modIface)
+      _ -> assertFailure ("expected one source module, got " <> show (piModules iface))
+
+test_coreLibProgressCountsMissingExports :: Assertion
+test_coreLibProgressCountsMissingExports = do
+  let report = comparePackageCompatibility (pkg [emptyModule "A"]) (pkg [moduleWithValue "A" "f" "Int"])
+  assertEqual "matched" 0 (crMatched report)
+  assertEqual "total" 1 (crTotal report)
+  assertEqual "extras" 0 (crExtra report)
+  assertEqual "mismatches" 1 (length (crMismatches report))
+
+test_coreLibProgressRejectsChangedSignatures :: Assertion
+test_coreLibProgressRejectsChangedSignatures = do
+  let candidate =
+        (emptyModule "A")
+          { miValues = [ExportedValue "f" "Bool"],
+            miTypes = [ExportedType "T" "Bool" []]
+          }
+      oracle =
+        (emptyModule "A")
+          { miValues = [ExportedValue "f" "Int"],
+            miTypes = [ExportedType "T" "Type" []]
+          }
+      report = comparePackageCompatibility (pkg [candidate]) (pkg [oracle])
+  assertEqual "matched" 0 (crMatched report)
+  assertEqual "total" 2 (crTotal report)
+  assertEqual "mismatches" 2 (length (crMismatches report))
+
+test_coreLibProgressRequiresSameModule :: Assertion
+test_coreLibProgressRequiresSameModule = do
+  let report =
+        comparePackageCompatibility
+          (pkg [moduleWithValue "B" "f" "Int"])
+          (pkg [moduleWithValue "A" "f" "Int"])
+  assertEqual "matched" 0 (crMatched report)
+  assertEqual "total" 1 (crTotal report)
+  assertEqual "extras" 1 (crExtra report)
+
+test_coreLibProgressCountsExtrasSeparately :: Assertion
+test_coreLibProgressCountsExtrasSeparately = do
+  let candidate =
+        (moduleWithValue "A" "f" "Int")
+          { miValues =
+              [ ExportedValue "f" "Int",
+                ExportedValue "extra" "Int"
+              ]
+          }
+      report = comparePackageCompatibility (pkg [candidate]) (pkg [moduleWithValue "A" "f" "Int"])
+  assertEqual "matched" 1 (crMatched report)
+  assertEqual "total" 1 (crTotal report)
+  assertEqual "extras" 1 (crExtra report)
+  assertEqual "mismatches" 0 (length (crMismatches report))
+
+test_coreLibProgressRendersStableOutput :: Assertion
+test_coreLibProgressRendersStableOutput =
+  assertEqual
+    "output"
+    "GHC_PRIM 1 4 25.00\nBASE 2 5 40.00\nEXTRA ghc-prim 2\nEXTRA base 3\n"
+    ( renderCoreLibProgressReports
+        [ CoreLibProgressReport "GHC_PRIM" "ghc-prim" (CompatibilityReport 1 4 2 []),
+          CoreLibProgressReport "BASE" "base" (CompatibilityReport 2 5 3 [])
+        ]
+    )
 
 test_aihcPrimSubset :: Assertion
 test_aihcPrimSubset = do
@@ -79,6 +183,59 @@ moduleWithValue moduleName valueName valueType =
             }
         ]
     }
+
+fullModule :: String -> ModuleInterface
+fullModule name =
+  (emptyModule name)
+    { miValues = [ExportedValue "f" "Int"],
+      miTypes = [ExportedType "T" "Type" ["MkT"]],
+      miClasses = [ExportedClass "C" [ClassMethod "method" "Int"]],
+      miFixities = [FixityInfo "+" InfixL 6]
+    }
+
+demoBaseCabal :: String
+demoBaseCabal =
+  unlines
+    [ "cabal-version: 3.8",
+      "name: demo-base",
+      "version: 0.1.0.0",
+      "build-type: Simple",
+      "library",
+      "  exposed-modules: Data.Bool",
+      "  hs-source-dirs: src",
+      "  default-language: GHC2021"
+    ]
+
+demoBoolSource :: String
+demoBoolSource =
+  unlines
+    [ "module Data.Bool",
+      "  ( Bool(False, True),",
+      "    not,",
+      "    (&&),",
+      "  )",
+      "where",
+      "data Bool = False | True",
+      "infixr 3 &&",
+      "not :: Bool -> Bool",
+      "not False = True",
+      "not True = False",
+      "(&&) :: Bool -> Bool -> Bool",
+      "False && _ = False",
+      "True && x = x"
+    ]
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+  tempRoot <- getTemporaryDirectory
+  (tempFile, tempHandle) <- openTempFile tempRoot (prefix ++ "-XXXXXX")
+  hClose tempHandle
+  removeFile tempFile
+  createDirectory tempFile
+  bracket
+    (pure tempFile)
+    removeDirectoryRecursive
+    action
 
 fromString :: String -> T.Text
 fromString = T.pack


### PR DESCRIPTION
## Summary

- Add an oracle-first core library compatibility report for `ghc-prim`/`aihc-prim` and `base`/`aihc-base`.
- Keep upstream packages read from GHC `.hi` interfaces, but extract the AIHC candidate surface from `core-libs` source so `aihc-base` and `aihc-prim` do not need to produce GHC-readable package interfaces.
- Add `aihc-dev core-libs-progress` and wire generated README progress rows through `scripts/update-generated-content.sh`.

## Current progress counts

- `ghc-prim / aihc-prim`: `0/1276 (0.00%)`, extras: `0`
- `base / aihc-base`: `2/9355 (0.02%)`, extras: `10`

## Validation

- `cabal test -v0 aihc-dev:spec --test-options="--pattern core-libs-progress --hide-successes"`
- `cabal run -v0 aihc-dev -- core-libs-progress`
- `bash scripts/update-generated-content.sh --check`
- `just fmt`
- `just check`
- `nix run .#aihc-dev -- core-libs-progress`
- `nix flake check`

## CI note

`nix flake check` passed locally on `aarch64-darwin`, including the `dev-tests` derivation that covers the new `aihc-dev` tests.
