### PR TITLE
feat(aihc-base): add functor applicative and monad

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -172,10 +172,34 @@ dsClassDeclM classAnn =
 dsClassSelector :: TcClassMethodAnnotation -> DsM FcTopBind
 dsClassSelector methodAnn = do
   methodUnique <- freshUnique
-  dictVar <- freshVar "$d" (tcClassMethodDictType methodAnn)
+  dictVars <- zipWithM mkSelectorDict [0 :: Int ..] dictPreds
+  classDictVar <-
+    case dictVars of
+      dictVar : _ -> pure dictVar
+      [] -> freshVar "$d" (tcClassMethodDictType methodAnn)
   let methodVar = Var (tcClassMethodName methodAnn) methodUnique (tcClassMethodType methodAnn)
-      body = foldr FcTyLam (FcDictLam dictVar (FcDictSelect (FcVar dictVar) (tcClassMethodIndex methodAnn))) (tcClassMethodTyVars methodAnn)
+      selected = FcDictSelect (FcVar classDictVar) (tcClassMethodIndex methodAnn)
+      body = foldr FcTyLam (foldr FcDictLam selected dictVars) (tcClassMethodTyVars methodAnn)
   pure (FcTopBind (FcNonRec methodVar body))
+  where
+    (_tyVars, afterForAlls) = peelForAlls (tcClassMethodType methodAnn)
+    (dictPreds, _bodyTy) = peelQuals afterForAlls
+    mkSelectorDict ix pred' =
+      freshVar ("$d" <> T.pack (show ix)) (predType pred')
+
+peelForAlls :: TcType -> ([TyVarId], TcType)
+peelForAlls (TcForAllTy tv rest) =
+  let (tvs, inner) = peelForAlls rest
+   in (tv : tvs, inner)
+peelForAlls ty = ([], ty)
+
+peelQuals :: TcType -> ([Pred], TcType)
+peelQuals (TcQualTy preds body) = (preds, body)
+peelQuals ty = ([], ty)
+
+predType :: Pred -> TcType
+predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
+predType (EqPred left right) = TcTyCon (TyCon "~" 2) [left, right]
 
 dsInstanceDecl :: Decl -> DsM [FcTopBind]
 dsInstanceDecl decl =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -49,7 +49,7 @@ import Control.Monad.Trans.State.Strict (StateT, get, modify')
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -163,7 +163,7 @@ dsMatchesWithDicts abstractDicts ty matches = case matches of
                 (dictPreds, innerTy) = peelQuals afterForAlls
                 (argTys, resTy) = peelFunTys nArgs innerTy
             dicts <- mapM mkClassDict (zip [0 :: Int ..] dictPreds)
-            argVars <- mapM (\(i, argTy) -> freshVar (argName i) argTy) (zip [0 :: Int ..] argTys)
+            argVars <- mapM (\(i, argTy) -> freshInternalVar (argName i) argTy) (zip [0 :: Int ..] argTys)
             body <- withDicts dicts (buildCaseChain argVars resTy matches)
             let lamExpr = foldr FcLam body argVars
                 dictLamExpr
@@ -662,7 +662,7 @@ directPatternBindings pat var =
 dsLambda :: [Pattern] -> Expr -> DsM FcExpr
 dsLambda pats body = do
   argTys <- mapM lambdaPatternTypeRequired pats
-  vars <- zipWithM freshVar (map lambdaArgName pats) argTys
+  vars <- zipWithM freshInternalVar (map lambdaArgName pats) argTys
   body' <- withLocals (concat (zipWith lambdaPatternBindings pats vars)) (dsExpr body)
   pure (foldr FcLam body' vars)
 
@@ -795,7 +795,9 @@ patternBinderTypesM pat scrutTy =
       | nameText op == ":" ->
           (\elemTy -> [elemTy, scrutTy]) <$> listElemTyM scrutTy
     PCon _ _ [] -> pure []
-    PCon _ _ subPats -> mapM patternFieldTypeM subPats
+    PCon name _ subPats -> do
+      fallbackTys <- constructorFieldTypesM name (length subPats)
+      zipWithM patternFieldTypeM subPats fallbackTys
     PVar {} -> pure [scrutTy]
     PAnn _ inner -> patternBinderTypesM inner scrutTy
     PParen inner -> patternBinderTypesM inner scrutTy
@@ -806,8 +808,24 @@ patternBinderTypesM pat scrutTy =
     missingPatternTypes =
       desugarBug ("missing pattern binder type information while desugaring: " <> take 80 (show pat))
 
-    patternFieldTypeM subPat =
-      maybe missingPatternTypes pure (patternBinderAnnotationType subPat <|> patternAnnotationType subPat)
+    patternFieldTypeM subPat fallbackTy =
+      pure (fromMaybe fallbackTy (patternBinderAnnotationType subPat <|> patternAnnotationType subPat))
+
+constructorFieldTypesM :: Name -> Int -> DsM [TcType]
+constructorFieldTypesM name arity = do
+  ty <- lookupTypeName name
+  takeConstructorFields (nameToText name) arity (dropForAlls ty)
+
+takeConstructorFields :: Text -> Int -> TcType -> DsM [TcType]
+takeConstructorFields _ 0 _ = pure []
+takeConstructorFields name arity (TcFunTy arg rest) =
+  (arg :) <$> takeConstructorFields name (arity - 1) rest
+takeConstructorFields name arity ty =
+  desugarBug ("missing field type information for constructor pattern " <> T.unpack name <> ": expected " <> show arity <> " more field(s) in " <> show ty)
+
+dropForAlls :: TcType -> TcType
+dropForAlls (TcForAllTy _ body) = dropForAlls body
+dropForAlls ty = ty
 
 listElemTyM :: TcType -> DsM TcType
 listElemTyM (TcTyCon (TyCon "[]" 1) [elemTy]) = pure elemTy
@@ -916,7 +934,7 @@ dsCaseAlt scrutTy (CaseAlt _anns pat rhs) = do
   let (con, binderNames) = dsPatternPure pat
   binderTys <- patternBinderTypesM pat scrutTy
   binders <- zipWithM freshVar binderNames binderTys
-  body <- dsRhs rhs
+  body <- withLocals (zip binderNames binders) (dsRhs rhs)
   pure (FcAlt con binders body)
 
 -- | Convert a Name to Text.

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -184,7 +184,7 @@ matchAlt :: Value -> FcAlt -> Maybe Env
 matchAlt value alt =
   case (altCon alt, value) of
     (DefaultAlt, _) ->
-      Just Map.empty
+      Just (Map.fromList [(varName var, value) | var <- altBinders alt])
     (LitAlt expected, VLit actual)
       | expected == actual ->
           Just Map.empty

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-applicative-maybe-either-list.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-applicative-maybe-either-list.yaml
@@ -1,0 +1,41 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Control.Applicative
+    import Data.Either
+    import Data.Maybe
+
+    flipBool :: Bool -> Bool
+    flipBool False = True
+    flipBool True = False
+
+    maybePure :: Maybe Bool
+    maybePure = pure True
+
+    maybeApply :: Maybe Bool
+    maybeApply = Just flipBool <*> Just False
+
+    maybeEmpty :: Maybe Bool
+    maybeEmpty = Nothing <*> Just False
+
+    eitherPure :: Either Bool Bool
+    eitherPure = pure True
+
+    eitherApply :: Either Bool Bool
+    eitherApply = Right flipBool <*> Right False
+
+    eitherLeftFunction :: Either Bool Bool
+    eitherLeftFunction = Left False <*> Right True
+
+    listApply :: [Bool]
+    listApply = [flipBool] <*> [False, True]
+
+output: |
+  ((((Just True),(Just True)),Nothing),((((Right True),(Right True)),(Left False)),(: True (: False []))))
+expression: |
+  (((maybePure, maybeApply), maybeEmpty), (((eitherPure, eitherApply), eitherLeftFunction), listApply))
+status: pass
+reason: evaluates Prelude Applicative instances for Maybe, Either, and lists from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-functor-maybe-either-list.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-functor-maybe-either-list.yaml
@@ -1,0 +1,34 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Data.Either
+    import Data.Functor
+    import Data.Maybe
+
+    flipBool :: Bool -> Bool
+    flipBool False = True
+    flipBool True = False
+
+    mapMaybeJust :: Maybe Bool
+    mapMaybeJust = fmap flipBool (Just True)
+
+    mapMaybeNothing :: Maybe Bool
+    mapMaybeNothing = fmap flipBool Nothing
+
+    mapListBool :: [Bool]
+    mapListBool = fmap flipBool [False, True]
+
+    mapEitherLeft :: Either Bool Bool
+    mapEitherLeft = fmap flipBool (Left True)
+
+    mapEitherRight :: Either Bool Bool
+    mapEitherRight = fmap flipBool (Right True)
+output: |
+  ((((Just False),Nothing),(: True (: False []))),((Left True),(Right False)))
+expression: |
+  (((mapMaybeJust, mapMaybeNothing), mapListBool), (mapEitherLeft, mapEitherRight))
+status: pass
+reason: evaluates Prelude Functor instances for Maybe, Either, and lists from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-monad-maybe-either-list.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-monad-maybe-either-list.yaml
@@ -1,0 +1,52 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Control.Monad
+    import Data.Either
+    import Data.Maybe
+
+    keepTrue :: Bool -> Maybe Bool
+    keepTrue True = Just True
+    keepTrue False = Nothing
+
+    maybeBindJust :: Maybe Bool
+    maybeBindJust = Just True >>= keepTrue
+
+    maybeBindNothing :: Maybe Bool
+    maybeBindNothing = Nothing >>= keepTrue
+
+    maybeReturn :: Maybe Bool
+    maybeReturn = return False
+
+    maybeThen :: Maybe Bool
+    maybeThen = Just True >> Just False
+
+    eitherStep :: Bool -> Either Bool Bool
+    eitherStep True = Right False
+    eitherStep False = Left True
+
+    eitherBindRight :: Either Bool Bool
+    eitherBindRight = Right True >>= eitherStep
+
+    eitherBindLeft :: Either Bool Bool
+    eitherBindLeft = Left False >>= eitherStep
+
+    eitherThen :: Either Bool Bool
+    eitherThen = Right True >> Right False
+
+    expand :: Bool -> [Bool]
+    expand False = [False]
+    expand True = [True, False]
+
+    listBind :: [Bool]
+    listBind = [False, True] >>= expand
+
+output: |
+  ((((Just True),Nothing),((Just False),(Just False))),(((Right False),(Left False)),((Right False),(: False (: True (: False []))))))
+expression: |
+  (((maybeBindJust, maybeBindNothing), (maybeReturn, maybeThen)), ((eitherBindRight, eitherBindLeft), (eitherThen, listBind)))
+status: pass
+reason: evaluates Prelude Monad instances for Maybe, Either, and lists from aihc-base

--- a/components/aihc-fc/test/Test/Fixtures/golden/bool-id-not.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/bool-id-not.yaml
@@ -1,27 +1,27 @@
-extensions: []
-modules:
-  - |
-    module Test where
-    data Bool = True | False
-    id x = x
-    not True = False
-    not False = True
-expected: |
+expected: |-
   data Bool
    = True
    | False
 
   id : ∀ a. a → a =
     Λa.
-      λx : a.
-        x
+      λx1001 : a.
+        x1001
 
   not : Bool → Bool =
-    λx : Bool.
-      case x as _scrut : Bool of
+    λx1003 : Bool.
+      case x1003 as _scrut : Bool of
         True →
           False
         False →
           True
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = True | False
+  id x = x
+  not True = False
+  not False = True
+reason: 'MVP: data Bool + id + not desugared to System FC'
 status: pass
-reason: "MVP: data Bool + id + not desugared to System FC"

--- a/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
@@ -1,42 +1,25 @@
-extensions: []
-modules:
-  - |
-    module Test where
-    data Bool = False | True
-
-    class Eq a where
-      (==) :: a -> a -> Bool
-
-    instance Eq Bool where
-      False == False = True
-      False == True = False
-      True == False = False
-      True == True = True
-
-    eqBool :: Bool -> Bool -> Bool
-    eqBool = (==)
-expected: |
+expected: |-
   data Bool
    = False
    | True
 
   == : ∀ a. (Eq a) ⇒ a → a → Bool =
     Λa.
-      \$d : dict.
-        $d.0
+      \$d0 : dict.
+        $d0.0
 
   $fEqBool : () ⇒ Eq Bool =
-    {λx : Bool.
-      λy : Bool.
-        case x as _scrut : Bool of
+    {λx1002 : Bool.
+      λy1003 : Bool.
+        case x1002 as _scrut : Bool of
           False →
-            case y as _scrut : Bool of
+            case y1003 as _scrut : Bool of
               False →
                 True
               True →
                 False
           True →
-            case y as _scrut : Bool of
+            case y1003 as _scrut : Bool of
               False →
                 False
               True →
@@ -44,5 +27,22 @@ expected: |
 
   eqBool : Bool → Bool → Bool =
     == @Bool $$fEqBool
-status: pass
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = False | True
+
+  class Eq a where
+    (==) :: a -> a -> Bool
+
+  instance Eq Bool where
+    False == False = True
+    False == True = False
+    True == False = False
+    True == True = True
+
+  eqBool :: Bool -> Bool -> Bool
+  eqBool = (==)
 reason: reifies both type arguments and dictionaries for class method occurrences
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/lambda-annotation.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/lambda-annotation.yaml
@@ -1,18 +1,18 @@
-extensions: []
-modules:
-  - |
-    module Test where
-    data Bool = True | False
-
-    idBool :: Bool -> Bool
-    idBool = \x -> x
-expected: |
+expected: |-
   data Bool
    = True
    | False
 
   idBool : Bool → Bool =
-    λx : Bool.
-      x
-status: pass
+    λx1001 : Bool.
+      x1001
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = True | False
+
+  idBool :: Bool -> Bool
+  idBool = \x -> x
 reason: desugars lambda binder types from type-checker annotations
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/lambda-polymorphic-identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/lambda-polymorphic-identity.yaml
@@ -1,12 +1,12 @@
-extensions: []
-modules:
-  - |
-    module Test where
-    id = \x -> x
-expected: |
+expected: |-
   id : ∀ a. a → a =
     Λa.
-      λx : a.
-        x
-status: pass
+      λx1001 : a.
+        x1001
+extensions: []
+modules:
+- |
+  module Test where
+  id = \x -> x
 reason: desugars inferred polymorphic lambda binder types from type-checker annotations
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/list-comprehension-direct-recursion.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/list-comprehension-direct-recursion.yaml
@@ -5,8 +5,8 @@ expected: |-
 
   select : ∀ a. (a → Bool) → [a] → [a] =
     Λa.
-      λx : a → Bool.
-        λy : [a].
+      λx1001 : a → Bool.
+        λy1002 : [a].
           let
             rec
               $lc1003 : [a] → [a] =
@@ -15,13 +15,13 @@ expected: |-
                     [] →
                       [] @a
                     : _lc_head1005 _lc_tail1006 →
-                      case x _lc_head1005 as _lc_guard1008 : Bool of
+                      case x1001 _lc_head1005 as _lc_guard1008 : Bool of
                         True →
                           : @a _lc_head1005 ($lc1003 _lc_tail1006)
                         False →
                           $lc1003 _lc_tail1006
           in
-            $lc1003 y
+            $lc1003 y1002
 extensions: []
 modules:
 - |

--- a/components/aihc-fc/test/Test/Fixtures/golden/type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/type-application.yaml
@@ -1,24 +1,24 @@
-extensions: []
-modules:
-  - |
-    module Test where
-    data Bool = True | False
-
-    id x = x
-
-    true :: Bool
-    true = id True
-expected: |
+expected: |-
   data Bool
    = True
    | False
 
   id : ∀ a. a → a =
     Λa.
-      λx : a.
-        x
+      λx1001 : a.
+        x1001
 
   true : Bool =
     id @Bool True
-status: pass
+extensions: []
+modules:
+- |
+  module Test where
+  data Bool = True | False
+
+  id x = x
+
+  true :: Bool
+  true = id True
 reason: reifies type arguments when desugaring polymorphic variable occurrences
+status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -71,7 +71,7 @@ import Aihc.Tc.Generate.Bind (inferRhsWithLocals)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Generate.Pattern
 import Aihc.Tc.Instantiate qualified
-import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkSurfaceType, convertSurfaceType, defaultKindMetas, freeTypeVars, freshKindMeta, kindToTcType, makeParamEnv, sigToScheme, surfacePredToPred, tyConKindFromParams)
+import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkSurfaceType, classPredicateArgKinds, defaultKindMetas, freeTypeVars, freshKindMeta, kindToTcType, makeParamEnv, sigToScheme, surfacePredToPred, tyConKindFromParams)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints, solveWithImpls)
 import Aihc.Tc.Solve.Dict (solveDictWithGivens)
@@ -420,7 +420,7 @@ annotateInstanceDeclTc classMethods instanceDecl =
       tvIds <- mapM freshSkolemTv freeVars
       let tvMap = Map.fromList (zip freeVars tvIds)
           classNameText = nameText className
-      headTys <- mapM (convertSurfaceType tvMap) headArgTypes
+      headTys <- checkInstanceHeadTypes classNameText tvMap headArgTypes
       let dictName = instanceDictName classNameText headTys
       context <- mapM (surfacePredToPred (simpleTvKindEnv tvMap)) (instanceDeclContext instanceDecl)
       let contextDicts = map predDictBinder context
@@ -461,12 +461,12 @@ tcInstanceDeclBodies (DeclInstance instanceDecl) =
   case (instanceHeadName (instanceDeclHead instanceDecl), instanceHeadTypes (instanceDeclHead instanceDecl)) of
     (_, []) -> pure (DeclInstance instanceDecl)
     (Nothing, _) -> pure (DeclInstance instanceDecl)
-    (Just _, headArgTypes) -> do
+    (Just className, headArgTypes) -> do
       let explicitTyVars = map tyVarBinderName (instanceDeclForall instanceDecl)
           freeVars = nub (explicitTyVars <> concatMap freeTypeVars (instanceDeclContext instanceDecl <> headArgTypes))
       tvIds <- mapM freshSkolemTv freeVars
       let tvMap = Map.fromList (zip freeVars tvIds)
-      headTys <- mapM (convertSurfaceType tvMap) headArgTypes
+      headTys <- checkInstanceHeadTypes (nameText className) tvMap headArgTypes
       givens <- mapM (surfacePredToPred (simpleTvKindEnv tvMap)) (instanceDeclContext instanceDecl)
       items <- mapM (tcInstanceItemBody givens headTys) (instanceDeclItems instanceDecl)
       pure (DeclInstance (instanceDecl {instanceDeclItems = items}))
@@ -660,6 +660,11 @@ splitContext ty = ([], ty)
 
 simpleTvKindEnv :: Map Text TyVarId -> TvKindEnv
 simpleTvKindEnv = Map.map (,KType)
+
+checkInstanceHeadTypes :: Text -> Map Text TyVarId -> [Type] -> TcM [TcType]
+checkInstanceHeadTypes className tvMap headArgTypes = do
+  argKinds <- classPredicateArgKinds className (length headArgTypes)
+  zipWithM (checkSurfaceType (simpleTvKindEnv tvMap)) headArgTypes argKinds
 
 -- | Instantiate a type scheme with fresh skolems for type-checking while
 -- preserving the scheme predicates as scoped givens for the checked body.
@@ -1114,7 +1119,7 @@ registerInstanceDecl instanceDecl =
       tvIds <- mapM freshSkolemTv freeVars
       let tvMap = Map.fromList (zip freeVars tvIds)
           classNameText = nameText className
-      headTys <- mapM (convertSurfaceType tvMap) headArgs
+      headTys <- checkInstanceHeadTypes classNameText tvMap headArgs
       let dictName = instanceDictName classNameText headTys
       context <- mapM (surfacePredToPred (simpleTvKindEnv tvMap)) (instanceDeclContext instanceDecl)
       let dictTy = foldr TcForAllTy (TcQualTy context (predType (ClassPred classNameText headTys))) tvIds

--- a/components/aihc-tc/src/Aihc/Tc/Instantiate.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Instantiate.hs
@@ -67,7 +67,10 @@ applySubst subst = go
        in TcForAllTy tv (applySubst subst' body)
     go (TcQualTy preds body) =
       TcQualTy (map (substPred subst) preds) (go body)
-    go (TcAppTy f a) = TcAppTy (go f) (go a)
+    go (TcAppTy f a) = applyType (go f) (go a)
+
+    applyType (TcTyCon tc args) arg = TcTyCon tc (args <> [arg])
+    applyType f arg = TcAppTy f arg
 
 -- | Apply a substitution to a predicate.
 substPred :: Map.Map Unique TcType -> Pred -> Pred

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -11,6 +11,7 @@ module Aihc.Tc.Kind
     freeTypeVars,
     freshKindMeta,
     kindToTcType,
+    classPredicateArgKinds,
     makeParamEnv,
     sigToScheme,
     surfacePredToPred,
@@ -41,6 +42,7 @@ import Aihc.Tc.Env (TyConInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
+import Control.Monad (zipWithM)
 import Data.List (nub, (\\))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -327,11 +329,29 @@ surfacePredToPred :: TvKindEnv -> Type -> TcM Pred
 surfacePredToPred tvEnv ty =
   case instanceHeadName ty of
     Just className -> do
-      args <- mapM (\arg -> checkSurfaceType tvEnv arg KType) (instanceHeadTypes ty)
+      let classNameText = nameText className
+          headArgs = instanceHeadTypes ty
+      argKinds <- classPredicateArgKinds classNameText (length headArgs)
+      args <- zipWithM (checkSurfaceType tvEnv) headArgs argKinds
       pure (ClassPred (nameText className) args)
     Nothing -> do
       emitError NoSourceSpan (OtherError ("invalid class predicate: " <> show ty))
       pure (ClassPred "<invalid-predicate>" [])
+
+classPredicateArgKinds :: Text -> Int -> TcM [Kind]
+classPredicateArgKinds className argCount = do
+  mInfo <- lookupTyCon className
+  case mInfo of
+    Just info -> takeClassArgKinds argCount <$> defaultKindMetas (tciKind info)
+    Nothing -> pure (replicate argCount KType)
+
+takeClassArgKinds :: Int -> Kind -> [Kind]
+takeClassArgKinds n kind
+  | n <= 0 = []
+  | otherwise =
+      case kind of
+        KFun arg rest -> arg : takeClassArgKinds (n - 1) rest
+        _ -> replicate n KType
 
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Canonicalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Canonicalize.hs
@@ -52,6 +52,19 @@ canonEq ct t1 t2 = case (t1, t2) of
       [ ct {ctPred = EqPred a1 a2},
         ct {ctPred = EqPred b1 b2}
       ]
+  -- Decompose an applied type constructor variable against a saturated tycon.
+  (TcAppTy f a, TcTyCon tc args)
+    | not (null args) ->
+        CanonEqs
+          [ ct {ctPred = EqPred f (TcTyCon tc (init args))},
+            ct {ctPred = EqPred a (last args)}
+          ]
+  (TcTyCon tc args, TcAppTy f a)
+    | not (null args) ->
+        CanonEqs
+          [ ct {ctPred = EqPred (TcTyCon tc (init args)) f},
+            ct {ctPred = EqPred (last args) a}
+          ]
   -- Decompose type application.
   (TcAppTy f1 a1, TcAppTy f2 a2) ->
     CanonEqs

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
@@ -56,6 +56,13 @@ solveEq ct t1 t2 = case (t1, t2) of
   -- Same function type shape: decompose.
   (TcFunTy a1 b1, TcFunTy a2 b2) ->
     solveDecomposed ct t1 [(a1, a2), (b1, b2)]
+  -- Applied type constructor variable against a saturated tycon.
+  (TcAppTy f a, TcTyCon tc args)
+    | not (null args) ->
+        solveDecomposed ct t1 [(f, TcTyCon tc (init args)), (a, last args)]
+  (TcTyCon tc args, TcAppTy f a)
+    | not (null args) ->
+        solveDecomposed ct t1 [(TcTyCon tc (init args), f), (last args, a)]
   -- Incompatible types.
   _ -> pure (EqError ct)
 

--- a/components/aihc-tc/src/Aihc/Tc/Unify.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Unify.hs
@@ -45,6 +45,16 @@ unifyTypes (TcFunTy a1 b1) (TcFunTy a2 b2) = do
   r1 <- unifyTypes a1 a2
   r2 <- unifyTypes b1 b2
   pure $ r1 >> r2
+unifyTypes (TcAppTy f a) (TcTyCon tc args)
+  | not (null args) = do
+      r1 <- unifyTypes f (TcTyCon tc (init args))
+      r2 <- unifyTypes a (last args)
+      pure $ r1 >> r2
+unifyTypes (TcTyCon tc args) (TcAppTy f a)
+  | not (null args) = do
+      r1 <- unifyTypes (TcTyCon tc (init args)) f
+      r2 <- unifyTypes (last args) a
+      pure $ r1 >> r2
 unifyTypes (TcAppTy f1 a1) (TcAppTy f2 a2) = do
   r1 <- unifyTypes f1 f2
   r2 <- unifyTypes a1 a2

--- a/core-libs/aihc-base/src/Control/Applicative.hs
+++ b/core-libs/aihc-base/src/Control/Applicative.hs
@@ -1,1 +1,6 @@
-module Control.Applicative () where
+module Control.Applicative
+  ( Applicative (..),
+  )
+where
+
+import Prelude (Applicative (..))

--- a/core-libs/aihc-base/src/Control/Monad.hs
+++ b/core-libs/aihc-base/src/Control/Monad.hs
@@ -1,1 +1,6 @@
-module Control.Monad () where
+module Control.Monad
+  ( Monad (..),
+  )
+where
+
+import Prelude (Monad (..))

--- a/core-libs/aihc-base/src/Data/Either.hs
+++ b/core-libs/aihc-base/src/Data/Either.hs
@@ -1,1 +1,6 @@
-module Data.Either () where
+module Data.Either
+  ( Either (..),
+  )
+where
+
+import Prelude (Either (..))

--- a/core-libs/aihc-base/src/Data/Functor.hs
+++ b/core-libs/aihc-base/src/Data/Functor.hs
@@ -1,1 +1,6 @@
-module Data.Functor () where
+module Data.Functor
+  ( Functor (..),
+  )
+where
+
+import Prelude (Functor (..))

--- a/core-libs/aihc-base/src/Data/Kind.hs
+++ b/core-libs/aihc-base/src/Data/Kind.hs
@@ -1,1 +1,6 @@
-module Data.Kind () where
+module Data.Kind
+  ( Type,
+  )
+where
+
+data Type

--- a/core-libs/aihc-base/src/Data/Maybe.hs
+++ b/core-libs/aihc-base/src/Data/Maybe.hs
@@ -1,1 +1,6 @@
-module Data.Maybe () where
+module Data.Maybe
+  ( Maybe (..),
+  )
+where
+
+import Prelude (Maybe (..))

--- a/core-libs/aihc-base/src/GHC/Maybe.hs
+++ b/core-libs/aihc-base/src/GHC/Maybe.hs
@@ -1,1 +1,6 @@
-module GHC.Maybe () where
+module GHC.Maybe
+  ( Maybe (..),
+  )
+where
+
+import Prelude (Maybe (..))

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -1,8 +1,15 @@
+{-# LANGUAGE KindSignatures #-}
+
 module Prelude
-  ( Bool (..),
+  ( Applicative (..),
+    Bool (..),
     Char,
+    Either (..),
     Eq (..),
+    Functor (..),
     List (..),
+    Maybe (..),
+    Monad (..),
     String,
     (&&),
     (++),
@@ -15,6 +22,7 @@ module Prelude
 where
 
 import Data.Bool (Bool (..), not, otherwise, (&&), (||))
+import Data.Kind (Type)
 
 data Char
 
@@ -23,6 +31,10 @@ data List a = [] | a : [a]
 infixr 5 :
 
 type String = [Char]
+
+data Maybe a = Nothing | Just a
+
+data Either a b = Left a | Right b
 
 class Eq a where
   (==) :: a -> a -> Bool
@@ -49,3 +61,108 @@ instance (Eq a) => Eq [a] where
 (++) :: [a] -> [a] -> [a]
 (++) [] ys = ys
 (++) (x : xs) ys = x : (xs ++ ys)
+
+class Functor (f :: Type -> Type) where
+  fmap :: (a -> b) -> f a -> f b
+
+instance Functor List where
+  fmap = fmapList
+
+instance Functor Maybe where
+  fmap f mx =
+    case mx of
+      Nothing -> Nothing
+      Just x -> Just (f x)
+
+instance Functor (Either e) where
+  fmap f mx =
+    case mx of
+      Left e -> Left e
+      Right x -> Right (f x)
+
+class (Functor f) => Applicative (f :: Type -> Type) where
+  pure :: a -> f a
+  (<*>) :: f (a -> b) -> f a -> f b
+
+infixl 4 <*>
+
+instance Applicative List where
+  pure x = [x]
+
+  fs <*> xs = applyList fs xs
+
+instance Applicative Maybe where
+  pure = Just
+
+  mf <*> mx =
+    case mf of
+      Nothing -> Nothing
+      Just f ->
+        case mx of
+          Nothing -> Nothing
+          Just x -> Just (f x)
+
+instance Applicative (Either e) where
+  pure = Right
+
+  mf <*> mx =
+    case mf of
+      Left e -> Left e
+      Right f ->
+        case mx of
+          Left e -> Left e
+          Right x -> Right (f x)
+
+class (Applicative m) => Monad (m :: Type -> Type) where
+  (>>=) :: m a -> (a -> m b) -> m b
+  (>>) :: m a -> m b -> m b
+  return :: a -> m a
+
+infixl 1 >>=, >>
+
+instance Monad List where
+  xs >>= k = bindList xs k
+
+  xs >> ys = thenList xs ys
+  return x = [x]
+
+instance Monad Maybe where
+  mx >>= k = bindMaybe mx k
+
+  mx >> my =
+    case mx of
+      Nothing -> Nothing
+      Just _ -> my
+  return = Just
+
+instance Monad (Either e) where
+  mx >>= k =
+    case mx of
+      Left e -> Left e
+      Right x -> k x
+
+  mx >> my =
+    case mx of
+      Left e -> Left e
+      Right _ -> my
+  return = Right
+
+fmapList :: (a -> b) -> [a] -> [b]
+fmapList _ [] = []
+fmapList f (x : xs) = f x : fmapList f xs
+
+applyList :: [a -> b] -> [a] -> [b]
+applyList [] _ = []
+applyList (f : fs) xs = fmapList f xs ++ applyList fs xs
+
+bindList :: [a] -> (a -> [b]) -> [b]
+bindList [] _ = []
+bindList (x : xs) k = k x ++ bindList xs k
+
+bindMaybe :: Maybe a -> (a -> Maybe b) -> Maybe b
+bindMaybe Nothing _ = Nothing
+bindMaybe (Just x) k = k x
+
+thenList :: [a] -> [b] -> [b]
+thenList [] _ = []
+thenList (_ : xs) ys = ys ++ thenList xs ys


### PR DESCRIPTION
## Summary

- Add `Functor`, `Applicative`, and `Monad` classes to `aihc-base`, with instances for lists, `Maybe`, and `Either`.
- Add minimal `Maybe`, `Either`, and `Data.Kind.Type` surface plus compatibility re-export modules.
- Extend TC/FC support needed for higher-kinded class heads and the resulting dictionary/eval behavior.
- Add `aihc-fc` eval fixtures covering Functor, Applicative, and Monad behavior from `aihc-base`.

## Progress counts

- No README progress-count files were updated; those remain cron-managed.
- Added three dependency-backed `aihc-fc` eval fixtures under `components/aihc-fc/test/Test/Fixtures/eval/base/`.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `cabal run -v0 aihc-dev -- update-goldens`
- `just fmt`
- `just check`

## Merge

- Merged `origin/main` into this branch after the feature commit and reran `just fmt` plus `just check` on the merge result.
