### PR TITLE
fix(tc): report smallest stackage failures

### DIFF
--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -7,14 +7,17 @@ module TcStackageProgress
     PackageCounts (..),
     optionsParser,
     processLayers,
+    smallestFailingPackages,
     summarizePackageStatuses,
     typecheckOnePackage,
     run,
   )
 where
 
+import Aihc.Hackage.Cabal qualified as HC
 import Aihc.Hackage.Stackage (loadStackageSnapshot)
 import Aihc.Hackage.Types (PackageSpec (..))
+import Aihc.Hackage.Util (readTextFileLenient)
 import Aihc.Parser.Syntax (Module)
 import Aihc.Resolve (ModuleExports, ResolveResult (..), extractInterface, resolveWithDeps)
 import Aihc.Tc (tcModuleDiagnostics, tcModuleSuccess, typecheck)
@@ -33,6 +36,7 @@ import Data.Text qualified as T
 import GHC.Conc (getNumProcessors)
 import Options.Applicative qualified as OA
 import ResolveStackageProgress qualified as RSP
+import System.Directory (doesFileExist)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hIsTerminalDevice, hPutStrLn, stderr, stdout)
 
@@ -197,11 +201,34 @@ renderTcDiagnostics :: [Module] -> String
 renderTcDiagnostics results =
   unlines [show diag | result <- results, diag <- tcModuleDiagnostics result]
 
-reportResults :: Int -> Map Text RSP.PackageStatus -> IO ()
-reportResults topN results = do
+smallestFailingPackages ::
+  Int ->
+  Map Text RSP.PackageInfo ->
+  Map Text RSP.PackageStatus ->
+  IO [(Text, Int, String)]
+smallestFailingPackages topN infos results = do
+  sizes <- traverse packageLineCount infos
+  let failed =
+        [ (pkg, Map.findWithDefault 0 pkg sizes, msg)
+        | (pkg, RSP.PkgFailed msg) <- Map.toList results
+        ]
+  pure (take topN (sortOn (\(pkg, lineCount, msg) -> (lineCount, pkg, msg)) failed))
+
+packageLineCount :: RSP.PackageInfo -> IO Int
+packageLineCount info =
+  sum <$> mapM fileLineCount (RSP.piFiles info)
+
+fileLineCount :: HC.FileInfo -> IO Int
+fileLineCount fileInfo = do
+  let path = HC.fileInfoPath fileInfo
+  exists <- doesFileExist path
+  if exists
+    then length . T.lines <$> readTextFileLenient path
+    else pure 0
+
+reportResults :: Int -> Map Text RSP.PackageInfo -> Map Text RSP.PackageStatus -> IO ()
+reportResults topN infos results = do
   let counts = summarizePackageStatuses results
-      allList = Map.toList results
-      failed = [(pkg, msg) | (pkg, RSP.PkgFailed msg) <- allList]
   putStrLn ""
   putStrLn "Type checker results:"
   putStrLn $ "  Typechecked: " ++ show (countTypechecked counts) ++ " / " ++ show (countTotal counts) ++ " (" ++ show (pct (countTypechecked counts) (countTotal counts)) ++ "%)"
@@ -210,13 +237,13 @@ reportResults topN results = do
   let n = min topN (countFailed counts)
   Control.Monad.when (n > 0) $ do
     putStrLn ""
-    putStrLn $ "Top " ++ show n ++ " failing packages:"
-    let sorted = take n (sortOn (length . snd) failed)
+    putStrLn $ "Smallest " ++ show n ++ " failing packages:"
+    sorted <- smallestFailingPackages n infos results
     mapM_ printFailure sorted
   if countTypechecked counts == countTotal counts then exitSuccess else exitFailure
   where
-    printFailure (pkg, msg) = do
-      putStrLn $ "  " ++ T.unpack pkg ++ ":"
+    printFailure (pkg, lineCount, msg) = do
+      putStrLn $ "  " ++ T.unpack pkg ++ " (" ++ show lineCount ++ " lines):"
       mapM_ (\l -> putStrLn ("    " ++ l)) (take 5 (lines msg))
 
 pct :: Int -> Int -> Int
@@ -275,7 +302,7 @@ run opts0 = do
 
   results <- processLayers opts bootExports layers infos depGraph bootResults
 
-  reportResults (optTopFailures opts) results
+  reportResults (optTopFailures opts) infos results
 
 partitionEithers :: [Either a b] -> ([a], [b])
 partitionEithers [] = ([], [])

--- a/tooling/aihc-dev/test/Test/TcStackageProgress.hs
+++ b/tooling/aihc-dev/test/Test/TcStackageProgress.hs
@@ -5,9 +5,15 @@ module Test.TcStackageProgress
   )
 where
 
+import Aihc.Hackage.Cabal (FileInfo (..))
+import Control.Exception (bracket)
 import Data.Map.Strict qualified as Map
 import ResolveStackageProgress (PackageStatus (..))
-import TcStackageProgress (PackageCounts (..), summarizePackageStatuses)
+import ResolveStackageProgress qualified as RSP
+import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
+import TcStackageProgress (PackageCounts (..), smallestFailingPackages, summarizePackageStatuses)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, testCase)
 
@@ -15,7 +21,8 @@ tcStackageProgressTests :: TestTree
 tcStackageProgressTests =
   testGroup
     "tc stackage progress"
-    [ testCase "counts typechecked, failed, and skipped packages" test_countsPackageStatuses
+    [ testCase "counts typechecked, failed, and skipped packages" test_countsPackageStatuses,
+      testCase "selects the smallest failing packages before applying the top limit" test_smallestFailingPackages
     ]
 
 test_countsPackageStatuses :: IO ()
@@ -35,3 +42,60 @@ test_countsPackageStatuses = do
         countTotal = 3
       }
     (summarizePackageStatuses statuses)
+
+test_smallestFailingPackages :: IO ()
+test_smallestFailingPackages =
+  withTempDir "tc-stackage-progress" $ \dir -> do
+    let tinyFile = dir </> "Tiny.hs"
+        mediumFile = dir </> "Medium.hs"
+        largeFile = dir </> "Large.hs"
+    writeFile tinyFile "module Tiny where\n"
+    writeFile mediumFile "module Medium where\nx = 1\n"
+    writeFile largeFile "module Large where\nx = 1\ny = 2\nz = 3\n"
+    let infos =
+          Map.fromList
+            [ ("large", packageInfo [largeFile]),
+              ("medium", packageInfo [mediumFile]),
+              ("tiny", packageInfo [tinyFile])
+            ]
+        statuses =
+          Map.fromList
+            [ ("large", PkgFailed "large error"),
+              ("medium", PkgFailed "medium error"),
+              ("tiny", PkgFailed "tiny error")
+            ]
+    assertEqual
+      "smallest failures"
+      [("tiny", 1, "tiny error"), ("medium", 2, "medium error")]
+      =<< smallestFailingPackages 2 infos statuses
+
+packageInfo :: [FilePath] -> RSP.PackageInfo
+packageInfo paths =
+  RSP.PackageInfo
+    { RSP.piSrcDir = "",
+      RSP.piFiles = map fileInfo paths,
+      RSP.piSnapshotDeps = []
+    }
+
+fileInfo :: FilePath -> FileInfo
+fileInfo path =
+  FileInfo
+    { fileInfoPath = path,
+      fileInfoExtensions = [],
+      fileInfoCppOptions = [],
+      fileInfoIncludeDirs = [],
+      fileInfoLanguage = Nothing,
+      fileInfoDependencies = []
+    }
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+  tempRoot <- getTemporaryDirectory
+  (tempFile, tempHandle) <- openTempFile tempRoot (prefix ++ "-XXXXXX")
+  hClose tempHandle
+  removeFile tempFile
+  createDirectory tempFile
+  bracket
+    (pure tempFile)
+    removeDirectoryRecursive
+    action


### PR DESCRIPTION
## Summary

- Sort `tc-stackage-progress` failures by package source line count before applying `--top`.
- Print the selected failing package line counts in the report.
- Add a focused `aihc-dev` regression test for smallest-failure selection.

## Impact

This makes `cabal run aihc-dev -- tc-stackage-progress --top N` surface the smallest failing packages first, which should make incremental type-checker progress easier to target.

Progress counts were not updated; README progress is maintained by the cron workflow.

## Validation

- `cabal test -v0 aihc-dev:spec --test-options="--pattern smallest"`
- `just fmt`
- `just check`
