### PR TITLE
feat(aihc-base): implement Data.Either helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Find more information here:
 | Resolve Stackage   | <!-- AUTO-GENERATED: START resolve-stackage-progress --> `201/3427` (`5.87%`) ○○○○○ <!-- AUTO-GENERATED: END resolve-stackage-progress -->  |
 | Parser Stackage    | <!-- AUTO-GENERATED: START parser-stackage-progress --> `2937/2937` (`100.00%`) ●●●●● <!-- AUTO-GENERATED: END parser-stackage-progress --> |
 | aihc-prim / ghc-prim | <!-- AUTO-GENERATED: START ghc-prim-progress --> `35/3425` (`1.02%`) ○○○○○ <!-- AUTO-GENERATED: END ghc-prim-progress -->                    |
-| aihc-base / base   | <!-- AUTO-GENERATED: START base-progress --> `35/10055` (`0.35%`) ○○○○○ <!-- AUTO-GENERATED: END base-progress -->                             |
+| aihc-base / base   | <!-- AUTO-GENERATED: START base-progress --> `43/10055` (`0.43%`) ○○○○○ <!-- AUTO-GENERATED: END base-progress -->                             |
 | &nbsp; | &nbsp; |
 | TypeCheck Tests    | <!-- AUTO-GENERATED: START tc-progress --> `29/39` (`74.35%`) ●●●○○ <!-- AUTO-GENERATED: END tc-progress -->                                |
 | Resolve Tests      | <!-- AUTO-GENERATED: START resolve-progress --> `32/33` (`96.96%`) ●●●●○ <!-- AUTO-GENERATED: END resolve-progress -->                      |

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/data-either-functions.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/data-either-functions.yaml
@@ -1,0 +1,52 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Data.Either
+
+    leftValue :: Either Bool Bool
+    leftValue = Left True
+
+    rightValue :: Either Bool Bool
+    rightValue = Right True
+
+    chooseLeft :: Bool
+    chooseLeft = either not not (Left False)
+
+    chooseRight :: Bool
+    chooseRight = either not not (Right True)
+
+    defaultLeft :: Bool
+    defaultLeft = fromLeft False rightValue
+
+    presentLeft :: Bool
+    presentLeft = fromLeft False leftValue
+
+    defaultRight :: Bool
+    defaultRight = fromRight False leftValue
+
+    presentRight :: Bool
+    presentRight = fromRight False rightValue
+
+    leftFlags :: (Bool, Bool)
+    leftFlags = (isLeft leftValue, isLeft rightValue)
+
+    rightFlags :: (Bool, Bool)
+    rightFlags = (isRight leftValue, isRight rightValue)
+
+    leftValues :: [Bool]
+    leftValues = lefts [Left True, Right False, Left False]
+
+    rightValues :: [Bool]
+    rightValues = rights [Left True, Right False, Right True]
+
+    partitioned :: ([Bool], [Bool])
+    partitioned = partitionEithers [Left True, Right False, Left False, Right True]
+output: |
+  ((((True,False),(False,True)),((False,True),((True,False),(False,True)))),(((: True (: False [])),(: False (: True []))),((: True (: False [])),(: False (: True [])))))
+expression: |
+  ((((chooseLeft, chooseRight), (defaultLeft, presentLeft)), ((defaultRight, presentRight), (leftFlags, rightFlags))), ((leftValues, rightValues), partitioned))
+status: pass
+reason: evaluates Data.Either helpers from aihc-base with Left, Right, and list order cases

--- a/core-libs/aihc-base/src/Data/Either.hs
+++ b/core-libs/aihc-base/src/Data/Either.hs
@@ -1,6 +1,75 @@
 module Data.Either
   ( Either (..),
+    either,
+    fromLeft,
+    fromRight,
+    isLeft,
+    isRight,
+    lefts,
+    rights,
+    partitionEithers,
   )
 where
 
-import Prelude (Either (..))
+import Prelude (Bool (..), Either (..))
+
+either :: (a -> c) -> (b -> c) -> Either a b -> c
+either f g value =
+  case value of
+    Left x -> f x
+    Right y -> g y
+
+fromLeft :: a -> Either a b -> a
+fromLeft fallback value =
+  case value of
+    Left x -> x
+    Right _ -> fallback
+
+fromRight :: b -> Either a b -> b
+fromRight fallback value =
+  case value of
+    Left _ -> fallback
+    Right y -> y
+
+isLeft :: Either a b -> Bool
+isLeft value =
+  case value of
+    Left _ -> True
+    Right _ -> False
+
+isRight :: Either a b -> Bool
+isRight value =
+  case value of
+    Left _ -> False
+    Right _ -> True
+
+lefts :: [Either a b] -> [a]
+lefts values =
+  case values of
+    [] -> []
+    value : xs ->
+      case value of
+        Left x -> x : lefts xs
+        Right _ -> lefts xs
+
+rights :: [Either a b] -> [b]
+rights values =
+  case values of
+    [] -> []
+    value : xs ->
+      case value of
+        Left _ -> rights xs
+        Right y -> y : rights xs
+
+partitionEithers :: [Either a b] -> ([a], [b])
+partitionEithers values =
+  case values of
+    [] -> ([], [])
+    value : xs ->
+      case value of
+        Left x ->
+          case partitionEithers xs of
+            (ls, rs) -> (x : ls, rs)
+        Right y ->
+          case partitionEithers xs of
+            (ls, rs) -> (ls, y : rs)


### PR DESCRIPTION
## Summary
- implement the base-compatible Data.Either helper exports in aihc-base
- add an aihc-fc eval fixture covering either, fromLeft, fromRight, isLeft, isRight, lefts, rights, and partitionEithers
- update README core-libs progress counts

## Progress counts
- core-libs progress now reports: GHC_PRIM 35/3425 (1.02%), BASE 43/10055 (0.43%)

## Tests
- cabal test -v0 aihc-fc:spec --test-options="--hide-successes"
- cabal run -v0 exe:aihc-dev -- core-libs-progress
- just fmt
- just check