### PR TITLE
feat(base): implement Data.Enum

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -21,6 +21,7 @@ import Aihc.Parser.Syntax
     TupleFlavor (..),
     UnqualifiedName (..),
   )
+import Aihc.Parser.Syntax qualified as Surface
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -46,9 +47,17 @@ dsPatternPure PWildcard =
   (DefaultAlt, [])
 dsPatternPure (PAnn _ann inner) = dsPatternPure inner
 dsPatternPure (PParen inner) = dsPatternPure inner
-dsPatternPure (PLit _lit) =
-  (DefaultAlt, [])
+dsPatternPure (PLit lit) =
+  (dsLiteralAlt lit, [])
 dsPatternPure _ = (DefaultAlt, [])
+
+dsLiteralAlt :: Surface.Literal -> FcAltCon
+dsLiteralAlt lit =
+  case lit of
+    Surface.LitInt n _ _ -> LitAlt (LitInt n)
+    Surface.LitChar c _ -> LitAlt (LitChar c)
+    Surface.LitAnn _ inner -> dsLiteralAlt inner
+    _ -> DefaultAlt
 
 -- | Extract a name from a sub-pattern.
 subPatName :: Pattern -> Text

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/data-enum-bool.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/data-enum-bool.yaml
@@ -1,0 +1,31 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Enum (Bounded (..), Enum (..))
+
+    bounded :: (Bool, Bool)
+    bounded = (minBound, maxBound)
+
+    conversions :: ((Bool, Bool), (Int, Int))
+    conversions = ((toEnum 0, toEnum 1), (fromEnum False, fromEnum True))
+
+    successors :: (Bool, Bool)
+    successors = (succ False, pred True)
+
+    ranges :: (([Bool], [Bool]), (([Bool], [Bool]), [Bool]))
+    ranges =
+      ( (enumFrom False, enumFrom True),
+        ( (enumFromTo False True, enumFromThenTo False True True),
+          enumFromThenTo True False False
+        )
+      )
+output: |
+  (((False,True),((False,True),(0,1))),((True,False),(((: False (: True [])),(: True [])),(((: False (: True [])),(: False (: True []))),(: True (: False []))))))
+expression: |
+  ((bounded, conversions), (successors, ranges))
+status: pass
+reason: evaluates Data.Enum and Data.Bounded Bool behavior from aihc-base

--- a/core-libs/aihc-base/src/Data/Bounded.hs
+++ b/core-libs/aihc-base/src/Data/Bounded.hs
@@ -1,1 +1,6 @@
-module Data.Bounded () where
+module Data.Bounded
+  ( Bounded (..),
+  )
+where
+
+import GHC.Enum (Bounded (..))

--- a/core-libs/aihc-base/src/Data/Enum.hs
+++ b/core-libs/aihc-base/src/Data/Enum.hs
@@ -1,1 +1,7 @@
-module Data.Enum () where
+module Data.Enum
+  ( Enum (..),
+    Bounded (..),
+  )
+where
+
+import GHC.Enum (Bounded (..), Enum (..))

--- a/core-libs/aihc-base/src/Data/Int.hs
+++ b/core-libs/aihc-base/src/Data/Int.hs
@@ -1,1 +1,6 @@
-module Data.Int () where
+module Data.Int
+  ( Int,
+  )
+where
+
+import GHC.Int (Int)

--- a/core-libs/aihc-base/src/GHC/Enum.hs
+++ b/core-libs/aihc-base/src/GHC/Enum.hs
@@ -1,1 +1,84 @@
-module GHC.Enum () where
+module GHC.Enum
+  ( Bounded (..),
+    Enum (..),
+    boundedEnumFrom,
+    boundedEnumFromThen,
+    fromEnumError,
+    predError,
+    succError,
+    toEnumError,
+  )
+where
+
+import Data.Bool (Bool (..))
+import GHC.Int (Int)
+
+class Bounded a where
+  minBound :: a
+  maxBound :: a
+
+class Enum a where
+  succ :: a -> a
+  pred :: a -> a
+  toEnum :: Int -> a
+  fromEnum :: a -> Int
+  enumFrom :: a -> [a]
+  enumFromThen :: a -> a -> [a]
+  enumFromTo :: a -> a -> [a]
+  enumFromThenTo :: a -> a -> a -> [a]
+
+boundedEnumFrom :: (Enum a, Bounded a) => a -> [a]
+boundedEnumFrom = boundedEnumFrom
+
+boundedEnumFromThen :: (Enum a, Bounded a) => a -> a -> [a]
+boundedEnumFromThen = boundedEnumFromThen
+
+toEnumError :: [Char] -> Int -> (a, a) -> b
+toEnumError = toEnumError
+
+fromEnumError :: [Char] -> a -> b
+fromEnumError = fromEnumError
+
+succError :: [Char] -> a
+succError = succError
+
+predError :: [Char] -> a
+predError = predError
+
+instance Bounded Bool where
+  minBound = False
+  maxBound = True
+
+instance Enum Bool where
+  succ False = True
+  succ True = succError "Prelude.Enum.Bool.succ"
+
+  pred True = False
+  pred False = predError "Prelude.Enum.Bool.pred"
+
+  toEnum 0 = False
+  toEnum 1 = True
+  toEnum n = toEnumError "Bool" n (False, True)
+
+  fromEnum False = 0
+  fromEnum True = 1
+
+  enumFrom False = [False, True]
+  enumFrom True = [True]
+
+  enumFromThen False True = [False, True]
+  enumFromThen True False = [True, False]
+  enumFromThen False False = [False]
+  enumFromThen True True = [True]
+
+  enumFromTo False False = [False]
+  enumFromTo False True = [False, True]
+  enumFromTo True True = [True]
+  enumFromTo True False = []
+
+  enumFromThenTo False True False = [False]
+  enumFromThenTo False True True = [False, True]
+  enumFromThenTo True False True = [True]
+  enumFromThenTo True False False = [True, False]
+  enumFromThenTo False False _ = [False]
+  enumFromThenTo True True _ = [True]

--- a/core-libs/aihc-base/src/GHC/Int.hs
+++ b/core-libs/aihc-base/src/GHC/Int.hs
@@ -1,1 +1,14 @@
-module GHC.Int () where
+{-# LANGUAGE MagicHash #-}
+
+module GHC.Int
+  ( Int (..),
+  )
+where
+
+foreign import prim (+#) :: Int# -> Int# -> Int#
+
+foreign import prim (-#) :: Int# -> Int# -> Int#
+
+foreign import prim (*#) :: Int# -> Int# -> Int#
+
+data Int = I# Int#

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -7,6 +7,7 @@ module Prelude
     Either (..),
     Eq (..),
     Functor (..),
+    Int,
     Integer,
     List (..),
     Maybe (..),
@@ -25,6 +26,7 @@ where
 
 import Data.Bool (Bool (..), not, otherwise, (&&), (||))
 import Data.Kind (Type)
+import GHC.Int (Int)
 import GHC.Integer (Integer)
 import GHC.Num (Num (..))
 


### PR DESCRIPTION
## Summary

- Implement `Data.Enum` and `Data.Bounded` as public facades over `GHC.Enum`.
- Add the initial `GHC.Enum` surface with `Bounded`, `Enum`, and concrete `Bool` instances.
- Add the boxed `Int` type surface needed by the `Enum` class without adding boxed `Int`/`Bool` primitive imports.
- Teach FC pattern desugaring to lower integer and character literal patterns to literal alternatives.
- Add an `aihc-fc` eval fixture covering `Data.Enum`/`Data.Bounded` Bool conversions, bounds, successors, and ranges.

## Progress Counts

- `aihc-dev core-libs-progress`: `BASE 7 9355 0.07`

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
