### PR TITLE
fix(aihc-dev): resolve re-exported interface types

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Find more information here:
 | TypeCheck Stackage | <!-- AUTO-GENERATED: START tc-stackage-progress --> `115/3427` (`3.36%`) ○○○○○ <!-- AUTO-GENERATED: END tc-stackage-progress -->             |
 | Resolve Stackage   | <!-- AUTO-GENERATED: START resolve-stackage-progress --> `201/3427` (`5.87%`) ○○○○○ <!-- AUTO-GENERATED: END resolve-stackage-progress -->  |
 | Parser Stackage    | <!-- AUTO-GENERATED: START parser-stackage-progress --> `2937/2937` (`100.00%`) ●●●●● <!-- AUTO-GENERATED: END parser-stackage-progress --> |
-| aihc-prim / ghc-prim | <!-- AUTO-GENERATED: START ghc-prim-progress --> `35/1276` (`2.74%`) ○○○○○ <!-- AUTO-GENERATED: END ghc-prim-progress -->                    |
-| aihc-base / base   | <!-- AUTO-GENERATED: START base-progress --> `6/9356` (`0.06%`) ○○○○○ <!-- AUTO-GENERATED: END base-progress -->                             |
+| aihc-prim / ghc-prim | <!-- AUTO-GENERATED: START ghc-prim-progress --> `35/3425` (`1.02%`) ○○○○○ <!-- AUTO-GENERATED: END ghc-prim-progress -->                    |
+| aihc-base / base   | <!-- AUTO-GENERATED: START base-progress --> `35/10055` (`0.35%`) ○○○○○ <!-- AUTO-GENERATED: END base-progress -->                             |
 | &nbsp; | &nbsp; |
 | TypeCheck Tests    | <!-- AUTO-GENERATED: START tc-progress --> `29/39` (`74.35%`) ●●●○○ <!-- AUTO-GENERATED: END tc-progress -->                                |
 | Resolve Tests      | <!-- AUTO-GENERATED: START resolve-progress --> `32/33` (`96.96%`) ●●●●○ <!-- AUTO-GENERATED: END resolve-progress -->                      |

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi.hs
@@ -61,7 +61,13 @@ import Distribution.ModuleName qualified as CabalModuleName
 import Distribution.PackageDescription (GenericPackageDescription, condLibrary, exposedModules)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Types.CondTree (CondTree (condTreeData))
-import GHC (Ghc)
+import GHC (Ghc, lookupName)
+import GHC.Core.ConLike (ConLike (..), conLikeName)
+import GHC.Core.DataCon (dataConName)
+import GHC.Core.DataCon qualified as DataCon
+import GHC.Core.PatSyn (patSynName, pprPatSynType)
+import GHC.Core.TyCo.Ppr (pprSigmaType, pprType)
+import GHC.Core.TyCon (isAlgTyCon, tyConDataCons, tyConName, tyConResKind)
 import GHC.Iface.Syntax
   ( IfaceClassBody (..),
     IfaceClassOp (..),
@@ -71,8 +77,10 @@ import GHC.Iface.Syntax
   )
 import GHC.Iface.Type (IfaceTyConBinder, IfaceType, ShowForAllFlag (..), pprIfaceSigmaType, pprIfaceType)
 import GHC.Types.Avail (AvailInfo (..))
+import GHC.Types.Id (idType)
 import GHC.Types.Name (Name, getOccString, nameModule_maybe)
 import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Types.TyThing (TyThing (..))
 import GHC.Unit.Module (moduleNameString)
 import GHC.Unit.Module.ModIface (ModIface, mi_decls, mi_exports, mi_fixities)
 import GHC.Unit.Types (moduleName, moduleUnit, unitString)
@@ -199,7 +207,7 @@ extractSingleModule readIface cacheRef importDir modName = do
   if exists
     then do
       iface <- liftIO $ readIface hiPath
-      liftIO $ ifaceToModule readIface cacheRef modName iface
+      ifaceToModule readIface cacheRef modName iface
     else
       pure
         ModuleInterface
@@ -216,7 +224,7 @@ ifaceToModule ::
   IORef (Map (String, String) CachedModule) ->
   String ->
   ModIface ->
-  IO ModuleInterface
+  Ghc ModuleInterface
 ifaceToModule readIface cacheRef modName iface = do
   let exports = mi_exports iface
       localFixities = mi_fixities iface
@@ -225,11 +233,11 @@ ifaceToModule readIface cacheRef modName iface = do
       localFixMap = Map.fromList [(occNameString occ, f) | (occ, f) <- localFixities]
 
   -- Classify exports
-  (types, values, classes) <- classifyExports exports localDeclMap (lookupDecl readIface cacheRef)
+  (types, values, classes) <- classifyExports (T.pack modName) exports localDeclMap (lookupDecl readIface cacheRef)
 
   -- Collect fixities: local ones first, then look up re-exported names
   let allExportedNames = concatMap availNames exports
-  remoteFixities <- collectFixities readIface cacheRef localFixMap allExportedNames
+  remoteFixities <- liftIO $ collectFixities readIface cacheRef localFixMap allExportedNames
 
   pure
     ModuleInterface
@@ -282,12 +290,13 @@ collectFixities readIface cacheRef localFixMap names = do
 
 -- | Classify exports into types, values, and classes.
 classifyExports ::
+  Text ->
   [AvailInfo] ->
   Map String IfaceDecl ->
   (Name -> IO (Maybe IfaceDecl)) ->
-  IO ([ExportedType], [ExportedValue], [ExportedClass])
-classifyExports avails localDeclMap cachedLookup = do
-  results <- mapM (classifySingle localDeclMap cachedLookup) avails
+  Ghc ([ExportedType], [ExportedValue], [ExportedClass])
+classifyExports modName avails localDeclMap cachedLookup = do
+  results <- mapM (classifySingle modName localDeclMap cachedLookup) avails
   let (ts, vs, cs) = foldr merge ([], [], []) results
   pure (ts, vs, cs)
   where
@@ -295,30 +304,36 @@ classifyExports avails localDeclMap cachedLookup = do
 
 -- | Classify a single AvailInfo.
 classifySingle ::
+  Text ->
   Map String IfaceDecl ->
   (Name -> IO (Maybe IfaceDecl)) ->
   AvailInfo ->
-  IO ([ExportedType], [ExportedValue], [ExportedClass])
-classifySingle localDeclMap cachedLookup avail = case avail of
+  Ghc ([ExportedType], [ExportedValue], [ExportedClass])
+classifySingle modName localDeclMap cachedLookup avail = case avail of
   Avail name -> do
     let nameStr = getOccString name
-    mDecl <- resolveDecl localDeclMap cachedLookup nameStr name
+    mDecl <- liftIO $ resolveDecl localDeclMap cachedLookup nameStr name
     case mDecl of
-      Just decl -> pure ([], [extractValue decl], [])
-      Nothing ->
-        pure
-          ( [],
-            [ ExportedValue
-                { evName = T.pack nameStr,
-                  evType = "<unresolved>"
-                }
-            ],
-            []
-          )
+      Just decl
+        | Just value <- extractValue decl ->
+            pure ([], [value], [])
+      Just IfaceData {} ->
+        pure ([], [], [])
+      Just IfaceSynonym {} ->
+        pure ([], [], [])
+      Just IfaceFamily {} ->
+        pure ([], [], [])
+      Just IfaceClass {} ->
+        pure ([], [], [])
+      _ -> do
+        mValue <- extractValueFromName name
+        case mValue of
+          Just value -> pure ([], [value], [])
+          Nothing -> unresolvedExport modName "value" nameStr
   AvailTC name subs -> do
     let nameStr = getOccString name
         subNames = map getOccString subs
-    mDecl <- resolveDecl localDeclMap cachedLookup nameStr name
+    mDecl <- liftIO $ resolveDecl localDeclMap cachedLookup nameStr name
     case mDecl of
       Just decl@IfaceClass {} ->
         pure ([], [], [extractClass decl subNames])
@@ -328,17 +343,15 @@ classifySingle localDeclMap cachedLookup avail = case avail of
         pure ([extractSynonym decl], [], [])
       Just decl@IfaceFamily {} ->
         pure ([extractFamily decl], [], [])
-      _ ->
-        pure
-          ( [ ExportedType
-                { etName = T.pack nameStr,
-                  etKind = "<unresolved>",
-                  etConstructors = map T.pack (filter (/= nameStr) subNames)
-                }
-            ],
-            [],
-            []
-          )
+      _ -> do
+        mType <- extractTypeFromName name subNames
+        case mType of
+          Just typ -> pure ([typ], [], [])
+          Nothing -> unresolvedExport modName "type" nameStr
+
+unresolvedExport :: Text -> String -> String -> Ghc a
+unresolvedExport modName exportKind name =
+  liftIO $ ioError (userError ("could not resolve " <> exportKind <> " export " <> T.unpack modName <> "." <> name))
 
 -- | Resolve a declaration: check local first, then follow re-exports.
 resolveDecl ::
@@ -353,18 +366,66 @@ resolveDecl localDeclMap cachedLookup nameStr name =
     Nothing -> cachedLookup name
 
 -- | Extract value/function information from an IfaceId declaration.
-extractValue :: IfaceDecl -> ExportedValue
+extractValue :: IfaceDecl -> Maybe ExportedValue
 extractValue decl = case decl of
   IfaceId {ifName, ifType} ->
-    ExportedValue
-      { evName = T.pack (getOccString ifName),
-        evType = renderType ifType
-      }
-  other ->
-    ExportedValue
-      { evName = T.pack (getOccString (ifName other)),
-        evType = "<unexpected-decl-kind>"
-      }
+    Just
+      ExportedValue
+        { evName = T.pack (getOccString ifName),
+          evType = renderType ifType
+        }
+  _ -> Nothing
+
+extractValueFromName :: Name -> Ghc (Maybe ExportedValue)
+extractValueFromName name = do
+  mThing <- lookupName name
+  pure $
+    case mThing of
+      Just (AnId identifier) ->
+        Just
+          ExportedValue
+            { evName = T.pack (getOccString name),
+              evType = T.pack (showSDocUnsafe (pprSigmaType (idType identifier)))
+            }
+      Just (AConLike conLike@(RealDataCon dataCon)) ->
+        Just
+          ExportedValue
+            { evName = T.pack (getOccString (conLikeName conLike)),
+              evType = T.pack (showSDocUnsafe (pprSigmaType (DataCon.dataConRepType dataCon)))
+            }
+      Just (AConLike (PatSynCon patSyn)) ->
+        Just
+          ExportedValue
+            { evName = T.pack (getOccString (patSynName patSyn)),
+              evType = T.pack (showSDocUnsafe (pprPatSynType patSyn))
+            }
+      _ -> Nothing
+
+extractTypeFromName :: Name -> [String] -> Ghc (Maybe ExportedType)
+extractTypeFromName name subNames = do
+  mThing <- lookupName name
+  pure $
+    case mThing of
+      Just (ATyCon tyCon) ->
+        let parentName = getOccString (tyConName tyCon)
+            ctorNames =
+              if isAlgTyCon tyCon
+                then map (T.pack . getOccString . dataConName) (tyConDataCons tyCon)
+                else []
+            ctorStrings = map T.unpack ctorNames
+            extraSubs =
+              [ T.pack subName
+              | subName <- subNames,
+                subName /= parentName,
+                subName `notElem` ctorStrings
+              ]
+         in Just
+              ExportedType
+                { etName = T.pack parentName,
+                  etKind = T.pack (showSDocUnsafe (pprType (tyConResKind tyCon))),
+                  etConstructors = ctorNames ++ extraSubs
+                }
+      _ -> Nothing
 
 -- | Extract data type information.
 extractDataType :: IfaceDecl -> [String] -> ExportedType
@@ -485,7 +546,7 @@ extractSourceModule srcRoot modPath = do
       modName = T.pack (map pathSepToDot modPath)
   exists <- doesFileExist sourcePath
   if not exists
-    then pure (emptySourceModule modName)
+    then ioError (userError ("source module " <> T.unpack modName <> " not found at " <> sourcePath))
     else do
       source <- TE.decodeUtf8 <$> BS.readFile sourcePath
       let (errs, parsed) =
@@ -493,29 +554,31 @@ extractSourceModule srcRoot modPath = do
               (defaultConfig {parserSourceName = sourcePath})
               source
       if null errs
-        then pure (sourceModuleInterface modName parsed)
-        else pure (emptySourceModule modName)
+        then sourceModuleInterface modName parsed
+        else ioError (userError ("source module " <> T.unpack modName <> " parse failed: " <> show errs))
 
-emptySourceModule :: Text -> ModuleInterface
-emptySourceModule modName =
-  ModuleInterface
-    { miModule = modName,
-      miTypes = [],
-      miValues = [],
-      miClasses = [],
-      miFixities = []
-    }
-
-sourceModuleInterface :: Text -> Module -> ModuleInterface
+sourceModuleInterface :: Text -> Module -> IO ModuleInterface
 sourceModuleInterface fallbackName modu =
-  applySourceExports modu $
-    ModuleInterface
-      { miModule = fromMaybe fallbackName (Syntax.moduleName modu),
-        miTypes = sourceTypes kindSigs decls,
-        miValues = sourceValues decls,
-        miClasses = sourceClasses decls,
-        miFixities = sourceFixities decls
-      }
+  let iface =
+        applySourceExports modu $
+          ModuleInterface
+            { miModule = fromMaybe fallbackName (Syntax.moduleName modu),
+              miTypes = sourceTypes kindSigs decls,
+              miValues = sourceValues decls,
+              miClasses = sourceClasses decls,
+              miFixities = sourceFixities decls
+            }
+   in case missingExportedValueSignatures modu decls iface of
+        [] -> pure iface
+        missing ->
+          ioError
+            ( userError
+                ( "source module "
+                    <> T.unpack (miModule iface)
+                    <> " has exported value(s) without type signatures: "
+                    <> T.unpack (T.intercalate ", " missing)
+                )
+            )
   where
     decls = map peelDeclAnn (moduleDecls modu)
     kindSigs = Map.fromList [(renderUnqualifiedName name, renderSourceType kind) | DeclStandaloneKindSig name kind <- decls]
@@ -523,16 +586,30 @@ sourceModuleInterface fallbackName modu =
 sourceValues :: [Decl] -> [ExportedValue]
 sourceValues decls =
   Map.elems $
-    Map.unionsWith
-      preferTypedValue
-      [ Map.fromList [(renderUnqualifiedName name, ExportedValue (renderUnqualifiedName name) (renderSourceType ty)) | DeclTypeSig names ty <- decls, name <- names],
-        Map.fromList [(name, ExportedValue name "<missing-source-signature>") | DeclValue valueDecl <- decls, name <- valueDeclNames valueDecl]
+    Map.fromList
+      [ (renderUnqualifiedName name, ExportedValue (renderUnqualifiedName name) (renderSourceType ty))
+      | DeclTypeSig names ty <- decls,
+        name <- names
       ]
 
-preferTypedValue :: ExportedValue -> ExportedValue -> ExportedValue
-preferTypedValue left right
-  | evType left == "<missing-source-signature>" = right
-  | otherwise = left
+missingExportedValueSignatures :: Module -> [Decl] -> ModuleInterface -> [Text]
+missingExportedValueSignatures modu decls iface =
+  [ name
+  | name <- candidateNames,
+    Map.notMember name typedValues
+  ]
+  where
+    typedValues = Map.fromList [(evName value, ()) | value <- miValues iface]
+    declaredValues =
+      Map.fromList [(name, ()) | DeclValue valueDecl <- decls, name <- valueDeclNames valueDecl]
+    candidateNames =
+      case moduleExports modu of
+        Nothing -> Map.keys declaredValues
+        Just specs ->
+          [ name
+          | name <- concatMap exportValueNames specs,
+            Map.member name declaredValues
+          ]
 
 valueDeclNames :: ValueDecl -> [Text]
 valueDeclNames valueDecl =
@@ -773,10 +850,12 @@ queryPackageMaybe pkgName = do
 -- | Query @ghc-pkg@ for a package's import directory by unit id.
 queryImportDir :: String -> IO (Maybe FilePath)
 queryImportDir unitId = do
-  result <- tryReadGhcPkg ["--ipid", "field", unitId, "import-dirs", "--simple-output"]
-  case result of
+  resultByUnitId <- tryReadGhcPkg ["--ipid", "field", unitId, "import-dirs", "--simple-output"]
+  case resultByUnitId of
     Just dir -> pure (Just (trim dir))
-    Nothing -> pure Nothing
+    Nothing -> do
+      resultByPackageId <- tryReadGhcPkg ["field", unitId, "import-dirs", "--simple-output"]
+      pure (trim <$> resultByPackageId)
 
 readGhcPkg :: [String] -> IO String
 readGhcPkg args = do

--- a/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Compare.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/ExtractHi/Compare.hs
@@ -148,8 +148,7 @@ compareTypes candidate oracle =
         Nothing -> [mismatch (basePath <> ":" <> etName typ) "type is not exported by oracle"]
         Just oracleType ->
           [ mismatch (basePath <> ":" <> etName typ <> ".kind") "type kind differs from oracle"
-          | etKind oracleType /= "<unresolved>",
-            etKind typ /= etKind oracleType
+          | etKind typ /= etKind oracleType
           ]
             <> [ mismatch (basePath <> ":" <> etName typ <> ".constructors") "constructors differ from oracle"
                | etConstructors typ /= etConstructors oracleType

--- a/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
+++ b/tooling/aihc-dev/test/Test/ExtractHiCompare.hs
@@ -14,7 +14,8 @@ import Aihc.Dev.ExtractHi.Compare
     renderCoreLibProgressReports,
   )
 import Aihc.Dev.ExtractHi.Types
-import Control.Exception (bracket)
+import Control.Exception (IOException, bracket, try)
+import Data.List qualified as List
 import Data.Text qualified as T
 import System.Directory (createDirectory, createDirectoryIfMissing, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.FilePath ((</>))
@@ -33,6 +34,8 @@ extractHiCompareTests =
         "core-libs-progress"
         [ testCase "counts matching exported interface facts" test_coreLibProgressCountsMatches,
           testCase "extracts source package exports" test_coreLibProgressExtractsSourcePackage,
+          testCase "rejects exported source values without signatures" test_coreLibProgressRejectsMissingSourceSignature,
+          testCase "resolves base re-exported value types" test_coreLibProgressResolvesReexportedTypes,
           testCase "counts missing candidate exports as failures" test_coreLibProgressCountsMissingExports,
           testCase "rejects changed value types and type kinds" test_coreLibProgressRejectsChangedSignatures,
           testCase "requires exports to come from the same module" test_coreLibProgressRequiresSameModule,
@@ -81,6 +84,37 @@ test_coreLibProgressExtractsSourcePackage =
         assertEqual "types" [ExportedType "Bool" "<unspecified-source-kind>" ["False", "True"]] (miTypes modIface)
         assertEqual "fixities" [FixityInfo "&&" InfixR 3] (miFixities modIface)
       _ -> assertFailure ("expected one source module, got " <> show (piModules iface))
+
+test_coreLibProgressRejectsMissingSourceSignature :: Assertion
+test_coreLibProgressRejectsMissingSourceSignature =
+  withTempDir "core-libs-progress-source-missing-signature" $ \root -> do
+    let srcDir = root </> "src" </> "Data"
+    createDirectoryIfMissing True srcDir
+    writeFile (root </> "demo-base.cabal") demoBaseCabal
+    writeFile (srcDir </> "Bool.hs") demoBoolMissingSignatureSource
+    result <- try (extractSourcePackage root "demo-base") :: IO (Either IOException PackageInterface)
+    case result of
+      Left err ->
+        assertBool "mentions missing type signature" ("without type signatures: not" `List.isInfixOf` show err)
+      Right iface ->
+        assertFailure ("expected missing source signature failure, got " <> show iface)
+
+test_coreLibProgressResolvesReexportedTypes :: Assertion
+test_coreLibProgressResolvesReexportedTypes = do
+  baseIface <- extractPackage "base"
+  dataEither <- findModule "Data.Either" baseIface
+  assertEqual
+    "Data.Either value types"
+    [ ExportedValue "either" "(a -> c) -> (b -> c) -> Either a b -> c",
+      ExportedValue "fromLeft" "a -> Either a b -> a",
+      ExportedValue "fromRight" "b -> Either a b -> b",
+      ExportedValue "isLeft" "Either a b -> Bool",
+      ExportedValue "isRight" "Either a b -> Bool",
+      ExportedValue "lefts" "[Either a b] -> [a]",
+      ExportedValue "partitionEithers" "[Either a b] -> ([a], [b])",
+      ExportedValue "rights" "[Either a b] -> [b]"
+    ]
+    (miValues dataEither)
 
 test_coreLibProgressCountsMissingExports :: Assertion
 test_coreLibProgressCountsMissingExports = do
@@ -186,6 +220,12 @@ fullModule name =
       miFixities = [FixityInfo "+" InfixL 6]
     }
 
+findModule :: T.Text -> PackageInterface -> IO ModuleInterface
+findModule name iface =
+  case List.find ((== name) . miModule) (piModules iface) of
+    Just modu -> pure modu
+    Nothing -> assertFailure ("module not found: " <> T.unpack name)
+
 demoBaseCabal :: String
 demoBaseCabal =
   unlines
@@ -216,6 +256,19 @@ demoBoolSource =
       "(&&) :: Bool -> Bool -> Bool",
       "False && _ = False",
       "True && x = x"
+    ]
+
+demoBoolMissingSignatureSource :: String
+demoBoolMissingSignatureSource =
+  unlines
+    [ "module Data.Bool",
+      "  ( Bool(False, True),",
+      "    not,",
+      "  )",
+      "where",
+      "data Bool = False | True",
+      "not False = True",
+      "not True = False"
     ]
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a


### PR DESCRIPTION
## Summary
- fail interface extraction instead of emitting unresolved placeholder data
- resolve re-exported values and types through GHC name lookup, including constructors and pattern synonyms
- reject incomplete source extraction for missing modules, parse errors, and exported values without type signatures

## Progress counts
- core-libs progress now reports: GHC_PRIM 35/3425 (1.02%), BASE 35/10055 (0.35%)

## Tests
- cabal test -v0 aihc-dev:spec --test-options="--pattern core-libs-progress --hide-successes"
- cabal test -v0 aihc-dev:spec --test-options="--hide-successes"
- cabal run -v0 exe:aihc-dev -- extract-hi base --json
- cabal run -v0 exe:aihc-dev -- core-libs-progress
- just fmt
- just check