### PR TITLE
fix(install): use AIHC core library stand-ins

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -34,8 +34,9 @@ import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax
   ( Extension (..),
     ExtensionSetting (..),
+    ImportDecl (..),
     LanguageEdition (..),
-    Module,
+    Module (..),
     SourceSpan (..),
     effectiveExtensions,
     headerExtensionSettings,
@@ -61,12 +62,13 @@ import Aihc.Tc
     TcType (..),
     TyCon (..),
     TyVarId (..),
+    TypeScheme (..),
     Unique (..),
     renderTcType,
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleSuccess,
-    typecheckModule,
+    typecheckModulesWithEnv,
   )
 import Control.Applicative ((<|>))
 import Control.Exception (evaluate)
@@ -85,6 +87,7 @@ import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (nub, sort, sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -209,7 +212,8 @@ data InterfaceBuildResult = InterfaceBuildResult
     interfaceCppDiagnostics :: ![Aeson.Value],
     interfaceResolveDiagnostics :: ![Aeson.Value],
     interfaceTcDiagnostics :: ![Aeson.Value],
-    interfaceTcModules :: ![Aeson.Value]
+    interfaceTcModules :: ![Aeson.Value],
+    interfaceImportedTerms :: ![(Text, TypeScheme)]
   }
 
 data PreparedInstall = PreparedInstall
@@ -367,6 +371,7 @@ sourcePathForSpec resolver spec =
 lookupCoreProvider :: String -> Maybe CoreProvider
 lookupCoreProvider name =
   case name of
+    "base" -> Just aihcBaseProvider
     "aihc-base" -> Just aihcBaseProvider
     "ghc-prim" -> Just aihcPrimProvider
     "aihc-prim" -> Just aihcPrimProvider
@@ -527,7 +532,8 @@ prepareInstallScaffoldRecursive plan = do
       let preparedDependencyPairs = rights dependencyResults
           depExports = foldl' Map.union Map.empty (map fst preparedDependencyPairs)
           preparedDependencies = map snd preparedDependencyPairs
-      interfaceResult <- generatePackageInterface depExports plan
+          importedTerms = concatMap (interfaceImportedTerms . preparedInterface) preparedDependencies
+      interfaceResult <- generatePackageInterface depExports importedTerms plan
       pure $
         case blockingInterfaceFailures interfaceResult of
           [] ->
@@ -946,8 +952,8 @@ fcPlaceholder plan =
       "contains" .= (["system-fc"] :: [String])
     ]
 
-generatePackageInterface :: ModuleExports -> PackagePlan -> IO InterfaceBuildResult
-generatePackageInterface depExports plan = do
+generatePackageInterface :: ModuleExports -> [(Text, TypeScheme)] -> PackagePlan -> IO InterfaceBuildResult
+generatePackageInterface depExports importedTerms plan = do
   files <- collectPlanFiles plan
   parsedFiles <- mapM (parseInterfaceFile (planSourcePath plan)) files
   let parsedModules = [modu | ParsedFileOk _ modu _ _ <- parsedFiles]
@@ -957,7 +963,7 @@ generatePackageInterface depExports plan = do
       cppDiagnostics = enrichDiagnostics (concatMap parsedFileCppDiagnostics parsedFiles)
       resolveResult = resolveWithDeps depExports parsedModules
       ownExports = extractInterface resolveResult
-  (tcModules, tcDiagnostics) <- typecheckInterfaceModules (resolvedModules resolveResult)
+  (tcModules, tcDiagnostics, ownTerms) <- typecheckInterfaceModules importedTerms (resolvedModules resolveResult)
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
@@ -970,34 +976,69 @@ generatePackageInterface depExports plan = do
         interfaceCppDiagnostics = cppDiagnostics,
         interfaceResolveDiagnostics = resolveDiagnostics,
         interfaceTcDiagnostics = enrichedTcDiagnostics,
-        interfaceTcModules = enrichedTcModules
+        interfaceTcModules = enrichedTcModules,
+        interfaceImportedTerms = ownTerms
       }
 
-typecheckInterfaceModules :: [Module] -> IO ([Aeson.Value], [Aeson.Value])
-typecheckInterfaceModules modules = do
-  currentModule <- newIORef Nothing
-  completedModules <- newIORef []
-  result <- timeout typecheckPhaseTimeoutMicros (go currentModule completedModules [] modules)
+typecheckInterfaceModules :: [(Text, TypeScheme)] -> [Module] -> IO ([Aeson.Value], [Aeson.Value], [(Text, TypeScheme)])
+typecheckInterfaceModules importedTerms modules = do
+  currentModule <- newIORef (listToMaybe sortedModules)
+  result <- timeout typecheckPhaseTimeoutMicros (go currentModule)
   case result of
-    Just tcModules -> pure (tcModules, concatMap tcModuleDiagnosticValues tcModules)
+    Just (tcModules, ownTerms) -> pure (tcModules, concatMap tcModuleDiagnosticValues tcModules, ownTerms)
     Nothing -> do
-      acc <- readIORef completedModules
       current <- readIORef currentModule
-      let tcModules = reverse acc
-      pure (tcModules, concatMap tcModuleDiagnosticValues tcModules <> [typecheckTimeoutDiagnostic current])
+      pure ([], [typecheckTimeoutDiagnostic current], [])
   where
-    go _current _completed acc [] =
-      pure (reverse acc)
-    go current completed acc (modu : rest) = do
-      writeIORef current (Just modu)
-      tcModule <- evaluate (forceJsonValue (typecheckInterfaceModule modu))
-      let acc' = tcModule : acc
-      writeIORef completed acc'
-      go current completed acc' rest
+    sortedModules = sortModulesByImports modules
+    go current = do
+      mapM_ (writeIORef current . Just) sortedModules
+      let checkedModules = typecheckModulesWithEnv importedTerms sortedModules
+          tcModules = zipWith tcModuleValue sortedModules checkedModules
+          ownTerms = concatMap moduleImportedTerms checkedModules
+      _ <- evaluate (forceJsonValue (Aeson.toJSON tcModules))
+      length (show ownTerms) `seq` pure (tcModules, ownTerms)
 
-typecheckInterfaceModule :: Module -> Aeson.Value
-typecheckInterfaceModule modu =
-  tcModuleValue modu (typecheckModule modu)
+sortModulesByImports :: [Module] -> [Module]
+sortModulesByImports modules = reverse sorted
+  where
+    modulesByName = Map.fromList [(name, modu) | modu <- modules, Just name <- [Syntax.moduleName modu]]
+    (_, sorted) = foldl' visitModule (Set.empty, []) modules
+
+    visitModule state@(seen, acc) modu =
+      case Syntax.moduleName modu of
+        Just name
+          | name `Set.member` seen -> state
+          | otherwise ->
+              let seen' = Set.insert name seen
+                  (seen'', acc') = foldl' visitImport (seen', acc) (moduleImports modu)
+               in (seen'', modu : acc')
+        Nothing -> (seen, modu : acc)
+
+    visitImport state importDecl =
+      case Map.lookup (importDeclModule importDecl) modulesByName of
+        Just importedModule -> visitModule state importedModule
+        Nothing -> state
+
+moduleImportedTerms :: Module -> [(Text, TypeScheme)]
+moduleImportedTerms =
+  map bindingImportedTerm . tcModuleBindings
+
+bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
+bindingImportedTerm binding =
+  (tbName binding, tcTypeScheme (tbType binding))
+
+tcTypeScheme :: TcType -> TypeScheme
+tcTypeScheme ty =
+  case collectForAlls ty of
+    (tvs, TcQualTy preds body) -> ForAll tvs preds body
+    (tvs, body) -> ForAll tvs [] body
+
+collectForAlls :: TcType -> ([TyVarId], TcType)
+collectForAlls (TcForAllTy tv body) =
+  let (tvs, inner) = collectForAlls body
+   in (tv : tvs, inner)
+collectForAlls ty = ([], ty)
 
 typecheckPhaseTimeoutMicros :: Int
 typecheckPhaseTimeoutMicros = 1000 * 1000

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -162,7 +162,8 @@ main =
           testCase "limits rendered install errors to first module" test_limitsRenderedInstallErrorsToFirstModule,
           testCase "renders human install errors" test_rendersHumanInstallErrors,
           testCase "does not install dependencies when root package fails" test_failedRootDoesNotInstallDependencies,
-          testCase "resolves base dependencies through resolver" test_resolvesBaseDependenciesThroughResolver,
+          testCase "type-checks references to dependency bindings" test_typeChecksReferencesToDependencyBindings,
+          testCase "uses local provider for base dependencies" test_usesLocalProviderForBase,
           testCase "uses local provider for ghc-prim dependencies" test_usesLocalProviderForGhcPrim,
           testCase "uses local provider for ghc-internal dependencies" test_usesLocalProviderForGhcInternal,
           testCase "manifest records core provider dependency names" test_manifestRecordsCoreProviderDependencyNames,
@@ -446,6 +447,24 @@ test_failedRootDoesNotInstallDependencies =
     assertFileDoesNotExist (planStorePath plan </> "manifest.json")
     assertFileDoesNotExist (planStorePath dependencyPlan </> "manifest.json")
 
+test_typeChecksReferencesToDependencyBindings :: Assertion
+test_typeChecksReferencesToDependencyBindings =
+  withTempDir "aihc-cli" $ \root -> do
+    let sourceRoot = root </> "source"
+        depRoot = root </> "dep"
+        storeRoot = root </> "store"
+    createFixturePackageWithSource sourceRoot "demo" "0.1.0.0" "Demo" ["dep >=1 && <2"] "module Demo where\nimport Dep\ny = depId ()\n"
+    createFixturePackageWithSource depRoot "dep" "1.0.0" "Dep" [] "module Dep where\ndepId :: a -> a\ndepId x = x\n"
+    createDirectoryIfMissing True storeRoot
+    plan <-
+      buildPackagePlanWithResolver
+        (fixtureDependencyResolver sourceRoot [("dep", "1.0.0", depRoot)])
+        storeRoot
+        (PackageSpec "demo" "0.1.0.0")
+
+    _ <- expectInstallSuccess (writeInstallScaffold plan)
+    assertFileExists (planStorePath plan </> "manifest.json")
+
 test_usesLocalProviderForGhcPrim :: Assertion
 test_usesLocalProviderForGhcPrim =
   withCoreDependencyFixture "ghc-prim" $ \sourceRoot storeRoot -> do
@@ -456,15 +475,15 @@ test_usesLocalProviderForGhcPrim =
         (PackageSpec "demo" "0.1.0.0")
     assertDependencySpec plan (PackageSpec "aihc-prim" "0.13.0")
 
-test_resolvesBaseDependenciesThroughResolver :: Assertion
-test_resolvesBaseDependenciesThroughResolver =
-  withBaseDependencyFixture $ \sourceRoot baseRoot storeRoot -> do
+test_usesLocalProviderForBase :: Assertion
+test_usesLocalProviderForBase =
+  withCoreDependencyFixture "base" $ \sourceRoot storeRoot -> do
     plan <-
       buildPackagePlanWithResolver
-        (fixtureDependencyResolver sourceRoot [("base", "4.22.0.0", baseRoot)])
+        (fixtureDependencyResolver sourceRoot [])
         storeRoot
         (PackageSpec "demo" "0.1.0.0")
-    assertDependencySpec plan (PackageSpec "base" "4.22.0.0")
+    assertDependencySpec plan (PackageSpec "aihc-base" "4.21.2.0")
 
 test_usesLocalProviderForGhcInternal :: Assertion
 test_usesLocalProviderForGhcInternal =
@@ -492,16 +511,16 @@ test_manifestRecordsCoreProviderDependencyNames =
 
 test_installsResolvedBaseDependencyClosure :: Assertion
 test_installsResolvedBaseDependencyClosure =
-  withBaseDependencyFixture $ \sourceRoot baseRoot storeRoot -> do
+  withCoreDependencyFixture "base" $ \sourceRoot storeRoot -> do
     plan <-
       buildPackagePlanWithResolver
-        (fixtureDependencyResolver sourceRoot [("base", "4.22.0.0", baseRoot)])
+        (fixtureDependencyResolver sourceRoot [])
         storeRoot
         (PackageSpec "demo" "0.1.0.0")
     _ <- expectInstallSuccess (writeInstallScaffold plan)
     let plans = flattenPackagePlans plan
         installedNames = sort [pkgName (packageKeySpec (planPackageKey item)) | item <- plans]
-    assertEqual "installed packages" ["base", "demo"] installedNames
+    assertEqual "installed packages" ["aihc-base", "demo"] installedNames
     mapM_ (assertFileExists . (</> "manifest.json") . planStorePath) plans
 
 test_dryRunWritesNoScaffoldArtifacts :: Assertion
@@ -599,17 +618,6 @@ withCoreDependencyFixture dependencyName action =
     createCoreProviderFixtures coreLibsRoot
     createDirectoryIfMissing True storeRoot
     withCoreLibsRoot coreLibsRoot (action sourceRoot storeRoot)
-
-withBaseDependencyFixture :: (FilePath -> FilePath -> FilePath -> IO a) -> IO a
-withBaseDependencyFixture action =
-  withTempDir "aihc-cli" $ \root -> do
-    let sourceRoot = root </> "source"
-        baseRoot = root </> "base"
-        storeRoot = root </> "store"
-    createFixturePackage sourceRoot "demo" "0.1.0.0" "Demo" ["base"]
-    createFixturePackage baseRoot "base" "4.22.0.0" "Base" []
-    createDirectoryIfMissing True storeRoot
-    action sourceRoot baseRoot storeRoot
 
 withCoreLibsRoot :: FilePath -> IO a -> IO a
 withCoreLibsRoot root action =

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-id.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-id.yaml
@@ -1,0 +1,12 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+output: |
+  True
+expression: |
+  id True
+status: pass
+reason: evaluates Prelude.id loaded from the aihc-base dependency

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -18,6 +18,7 @@ module Prelude
     (++),
     (/=),
     (==),
+    id,
     not,
     otherwise,
     (||),
@@ -37,6 +38,9 @@ data List a = [] | a : [a]
 infixr 5 :
 
 type String = [Char]
+
+id :: a -> a
+id x = x
 
 data Maybe a = Nothing | Just a
 


### PR DESCRIPTION
## Summary

- canonicalize upstream `base` dependencies to the bundled `aihc-base` provider, alongside the existing `ghc-prim` to `aihc-prim` substitution
- type-check package modules in import order and carry inferred dependency bindings into dependent package type checking
- add and export `Prelude.id` from `aihc-base`
- cover core-provider substitution, cross-package binding types, and evaluation of bundled `Prelude.id`

## Why

`aihc install cast` resolved and attempted to install GHC's `base`, which is not an AIHC-compatible source package. After substituting `aihc-base`, the installer also needed to preserve dependency binding types so `Pattern.Cast` could type-check its use of `Prelude.id`.

## Impact

`cabal run aihc -- install cast` now completes and writes the package manifest and interface artifacts. This adds one passing `aihc-fc` eval fixture; generated README progress counts are intentionally unchanged and remain cron-managed.

## Validation

- `cabal test -v0 aihc:spec --test-options="--pattern install --hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--pattern prelude-id --hide-successes"`
- `cabal run -v0 aihc -- install cast --store /tmp/aihc-cast-after`
- `just fmt`
- `just check`
