### PR TITLE
fix: install almost-fix

### DIFF
--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-monad-flipped-bind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-monad-flipped-bind.yaml
@@ -1,0 +1,21 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Control.Monad
+    import Data.Maybe
+
+    flipBool :: Bool -> Maybe Bool
+    flipBool False = Just True
+    flipBool True = Just False
+
+    answer :: Maybe Bool
+    answer = flipBool =<< Just False
+output: |
+  Just True
+expression: |
+  answer
+status: pass
+reason: Control.Monad exports flipped bind from aihc-base

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -1105,11 +1105,10 @@ registerClassDecl classDecl = do
         tciTyCon = TyCon className (length params),
         tciKind = classKind
       }
-  superPreds <- concat <$> traverse (mapM (surfacePredToPred paramTvEnv)) (maybeToList (classDeclContext classDecl))
-  concat <$> mapM (registerClassItem classPred superPreds paramTvEnv paramTyVars) (classDeclItems classDecl)
+  concat <$> mapM (registerClassItem classPred paramTvEnv paramTyVars) (classDeclItems classDecl)
 
-registerClassItem :: Pred -> [Pred] -> TvKindEnv -> [TyVarId] -> ClassDeclItem -> TcM [TcBindingResult]
-registerClassItem classPred superPreds classTvEnv classTyVars item =
+registerClassItem :: Pred -> TvKindEnv -> [TyVarId] -> ClassDeclItem -> TcM [TcBindingResult]
+registerClassItem classPred classTvEnv classTyVars item =
   case peelClassDeclItemAnn item of
     ClassItemTypeSig names ty -> do
       let (context, body) = splitContext ty
@@ -1120,7 +1119,7 @@ registerClassItem classPred superPreds classTvEnv classTyVars item =
       let tvEnv = classTvEnv <> Map.fromList (zip freeVars (zip extraTyVars extraKinds))
       methodBody <- checkSurfaceType tvEnv body KType
       contextPreds <- mapM (surfacePredToPred tvEnv) context
-      let preds = classPred : superPreds <> contextPreds
+      let preds = classPred : contextPreds
           scheme = ForAll (classTyVars <> extraTyVars) preds methodBody
           declaredTy = schemeToType scheme
       mapM

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -16,6 +16,8 @@ import Aihc.Parser.Syntax
   ( Annotation,
     CaseAlt (..),
     CompStmt (..),
+    DoFlavor (..),
+    DoStmt (..),
     Expr (..),
     LambdaCaseAlt (..),
     Name (..),
@@ -101,6 +103,8 @@ inferExprAt ambient expr = case expr of
     inferList (exprSpan expr `orSourceSpan` ambient) elems
   EListComp body quals ->
     inferListComp (exprSpan expr `orSourceSpan` ambient) body quals
+  EDo stmts flavor ->
+    inferDo (exprSpan expr `orSourceSpan` ambient) flavor stmts
   other -> do
     emitError (exprSpan expr `orSourceSpan` ambient) (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
     ty <- freshMetaTv
@@ -513,6 +517,104 @@ inferListComp sp body quals = do
       emitError qualSp (OtherError ("unsupported list comprehension qualifier in TC MVP: " ++ take 50 (show qual)))
       inferCompQuals ambient rest action
 
+inferDo :: SourceSpan -> DoFlavor -> [DoStmt Expr] -> TcM (Expr, TcType, [Ct])
+inferDo sp flavor stmts =
+  case flavor of
+    DoPlain -> do
+      (stmts', resultTy, cts) <- inferDoStmts sp stmts
+      let pending = pendingAnnotation resultTy [] [] []
+      pure (annotatePendingExprAt sp pending (EDo stmts' flavor), resultTy, cts)
+    _ -> do
+      emitError sp (OtherError ("unsupported do flavor in TC MVP: " ++ show flavor))
+      resultTy <- freshMetaTv
+      pure (EDo stmts flavor, resultTy, [])
+
+inferDoStmts :: SourceSpan -> [DoStmt Expr] -> TcM ([DoStmt Expr], TcType, [Ct])
+inferDoStmts sp stmts =
+  case stmts of
+    [] -> do
+      emitError sp (OtherError "empty do block in TC MVP")
+      resultTy <- freshMetaTv
+      pure ([], resultTy, [])
+    [stmt] -> inferLastDoStmt sp stmt
+    stmt : rest -> inferDoStmt sp stmt rest
+
+inferLastDoStmt :: SourceSpan -> DoStmt Expr -> TcM ([DoStmt Expr], TcType, [Ct])
+inferLastDoStmt ambient stmt =
+  case stmt of
+    DoAnn ann inner -> do
+      (stmts', resultTy, cts) <- inferLastDoStmt (doStmtSpan stmt `orSourceSpan` ambient) inner
+      case stmts' of
+        [inner'] -> pure ([DoAnn ann inner'], resultTy, cts)
+        _ -> pure (stmts', resultTy, cts)
+    DoExpr body -> do
+      (body', bodyTy, cts) <- inferExprAt ambient body
+      pure ([DoExpr body'], bodyTy, cts)
+    _ -> do
+      emitError ambient (OtherError "the last statement in a do block must be an expression")
+      resultTy <- freshMetaTv
+      pure ([stmt], resultTy, [])
+
+inferDoStmt :: SourceSpan -> DoStmt Expr -> [DoStmt Expr] -> TcM ([DoStmt Expr], TcType, [Ct])
+inferDoStmt ambient stmt rest =
+  case stmt of
+    DoAnn ann inner -> do
+      (stmts', resultTy, cts) <- inferDoStmt (doStmtSpan stmt `orSourceSpan` ambient) inner rest
+      case stmts' of
+        inner' : rest' -> pure (DoAnn ann inner' : rest', resultTy, cts)
+        [] -> pure ([], resultTy, cts)
+    DoBind pat action -> do
+      monadTy <- freshMetaTv
+      itemTy <- freshMetaTv
+      resultItemTy <- freshMetaTv
+      (action', actionTy, actionCts) <- inferExprAt ambient action
+      patCheck <- checkPattern ambient pat itemTy
+      (rest', resultTy, restCts) <-
+        withPatternBindings (pcBindings patCheck) (inferDoStmts ambient rest)
+      actionEq <- wantedDoEq ambient actionTy (TcAppTy monadTy itemTy)
+      resultEq <- wantedDoEq ambient resultTy (TcAppTy monadTy resultItemTy)
+      monadCt <- wantedMonad ambient monadTy
+      let pat' = annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)
+      pure
+        ( DoBind pat' action' : rest',
+          resultTy,
+          actionCts <> pcWantedCts patCheck <> restCts <> [actionEq, resultEq, monadCt]
+        )
+    DoExpr action -> do
+      monadTy <- freshMetaTv
+      itemTy <- freshMetaTv
+      resultItemTy <- freshMetaTv
+      (action', actionTy, actionCts) <- inferExprAt ambient action
+      (rest', resultTy, restCts) <- inferDoStmts ambient rest
+      actionEq <- wantedDoEq ambient actionTy (TcAppTy monadTy itemTy)
+      resultEq <- wantedDoEq ambient resultTy (TcAppTy monadTy resultItemTy)
+      monadCt <- wantedMonad ambient monadTy
+      pure
+        ( DoExpr action' : rest',
+          resultTy,
+          actionCts <> restCts <> [actionEq, resultEq, monadCt]
+        )
+    DoLetDecls decls -> do
+      (decls', rest', resultTy, cts) <-
+        inferLocalDecls inferExpr decls $ do
+          (rest', resultTy, restCts) <- inferDoStmts ambient rest
+          pure (rest', resultTy, restCts)
+      pure (DoLetDecls decls' : rest', resultTy, cts)
+    DoRecStmt _ -> do
+      emitError ambient (OtherError "recursive do statements are unsupported in TC MVP")
+      (rest', resultTy, cts) <- inferDoStmts ambient rest
+      pure (stmt : rest', resultTy, cts)
+
+wantedDoEq :: SourceSpan -> TcType -> TcType -> TcM Ct
+wantedDoEq sp actual expected = do
+  ev <- freshEvVar
+  pure (mkWantedCt (EqPred actual expected) ev (AppOrigin sp) sp)
+
+wantedMonad :: SourceSpan -> TcType -> TcM Ct
+wantedMonad sp monadTy = do
+  ev <- freshEvVar
+  pure (mkWantedCt (ClassPred "Monad" [monadTy]) ev (AppOrigin sp) sp)
+
 orSourceSpan :: SourceSpan -> SourceSpan -> SourceSpan
 orSourceSpan NoSourceSpan fallback = fallback
 orSourceSpan sp _ = sp
@@ -521,6 +623,12 @@ compStmtSpan :: CompStmt -> SourceSpan
 compStmtSpan compStmt =
   case compStmt of
     CompAnn ann _ -> fromMaybe NoSourceSpan (fromAnnotation @SourceSpan ann)
+    _ -> NoSourceSpan
+
+doStmtSpan :: DoStmt body -> SourceSpan
+doStmtSpan stmt =
+  case stmt of
+    DoAnn ann _ -> fromMaybe NoSourceSpan (fromAnnotation @SourceSpan ann)
     _ -> NoSourceSpan
 
 rhsExprSpan :: Rhs Expr -> SourceSpan

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -343,7 +343,7 @@ classPredicateArgKinds className argCount = do
   mInfo <- lookupTyCon className
   case mInfo of
     Just info -> takeClassArgKinds argCount <$> defaultKindMetas (tciKind info)
-    Nothing -> pure (replicate argCount KType)
+    Nothing -> mapM (const freshKindMeta) [1 .. argCount]
 
 takeClassArgKinds :: Int -> Kind -> [Kind]
 takeClassArgKinds n kind

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
@@ -63,6 +63,11 @@ solveEq ct t1 t2 = case (t1, t2) of
   (TcTyCon tc args, TcAppTy f a)
     | not (null args) ->
         solveDecomposed ct t1 [(TcTyCon tc (init args), f), (last args, a)]
+  -- Same type-application shape. This is also needed when solving wanted
+  -- equalities inside an implication, where canonicalization does not first
+  -- decompose the application for us.
+  (TcAppTy f1 a1, TcAppTy f2 a2) ->
+    solveDecomposed ct t1 [(f1, f2), (a1, a2)]
   -- Incompatible types.
   _ -> pure (EqError ct)
 

--- a/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
@@ -1,0 +1,59 @@
+annotated:
+- |-
+  {-# LANGUAGE KindSignatures #-}
+  module Test where
+
+  data Type
+       └─ type: *
+  data Bool = False | True
+       │      │       └─ type: Bool
+       │      └─ type: Bool
+       └─ type: *
+
+  class Applicative (m :: Type -> Type) where
+  └─ class methods: pure ∷ ∀ m a. (Applicative m) ⇒ a → m a
+    pure :: a -> m a
+
+  class Applicative m => Monad (m :: Type -> Type) where
+  └─ class methods: =<< ∷ ∀ m a b. (Monad m) ⇒ (a → m b) → m a → m b, return ∷ ∀ m a. (Monad m) ⇒ a → m a
+    (=<<) :: (a -> m b) -> m a -> m b
+    return :: a -> m a
+
+  almostFixM :: Monad m => m Bool -> (a -> m a) -> a -> m a
+  almostFixM p f x = do
+  │          │ │ │   └─ type: m a
+  │          │ │ └─ type: a
+  │          │ └─ type: a → m a
+  │          └─ type: m Bool
+  └─ type: ∀ m a. (Monad m) ⇒ m Bool → (a → m a) → a → m a
+    p' <- p
+    └─ type: Bool
+    if p' then almostFixM p f =<< f x
+               │              └─ type: (a → m a) → m a → m a; type-args: m, a, a; evidence: given Monad m
+               └─ type: m Bool → (a → m a) → a → m a; type-args: m, a; evidence: given Monad m
+          else return x
+               └─ type: a → m a; type-args: m, a; evidence: given Monad m
+extensions:
+- KindSignatures
+modules:
+- |
+  {-# LANGUAGE KindSignatures #-}
+  module Test where
+
+  data Type
+  data Bool = False | True
+
+  class Applicative (m :: Type -> Type) where
+    pure :: a -> m a
+
+  class Applicative m => Monad (m :: Type -> Type) where
+    (=<<) :: (a -> m b) -> m a -> m b
+    return :: a -> m a
+
+  almostFixM :: Monad m => m Bool -> (a -> m a) -> a -> m a
+  almostFixM p f x = do
+    p' <- p
+    if p' then almostFixM p f =<< f x
+          else return x
+reason: ordinary do notation preserves the monad constructor across bind statements
+status: pass

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -28,7 +28,7 @@ import Aihc.Parser.Syntax
     mkAnnotation,
     stripAnnotations,
   )
-import Aihc.Resolve (ResolveResult (..), resolve)
+import Aihc.Resolve (ResolveResult (..), extractInterface, resolve, resolveWithDeps)
 import Aihc.Tc
 import Aihc.Tc.Annotations (PendingTcAnnotation, TcClassAnnotation (..), TcClassMethodAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..), pendingAnnotation)
 import Aihc.Tc.Evidence (EvTerm (..))
@@ -217,7 +217,18 @@ kindTests =
                 \data M a = J a | N\n\
                 \fn :: M Int\n\
                 \fn = N\n"
-      assertBool "module should typecheck" (tcModuleSuccess result)
+      assertBool "module should typecheck" (tcModuleSuccess result),
+    testCase "infers the kind of an imported class parameter" $ do
+      let baseResult = resolve [parseOnly "module Base (Monad) where\nclass Monad m where\n"]
+          depExports = extractInterface baseResult
+          target = parseOnly "module Test where\nimport Base\nliftedId :: Monad m => m a -> m a\nliftedId x = x\n"
+          resolved = resolveWithDeps depExports [target]
+      case resolved of
+        ResolveResult {resolvedModules = [modu], resolveErrors = []} -> do
+          let result = typecheckModule modu
+          assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
+        ResolveResult {resolveErrors} ->
+          assertFailure ("Resolve error in imported-class kind test: " <> show resolveErrors)
   ]
   where
     isKindMismatch diag =
@@ -333,12 +344,16 @@ annotationModule =
 
 parseM :: Text -> Module
 parseM input =
+  case resolve [parseOnly input] of
+    ResolveResult {resolvedModules = [resolved], resolveErrors = []} -> resolved
+    ResolveResult {resolveErrors} -> error ("Resolve error in test: " ++ show resolveErrors)
+
+parseOnly :: Text -> Module
+parseOnly input =
   let config = defaultConfig {parserSourceName = "<test>"}
       (errs, modu) = parseModule config input
    in if null errs
-        then case resolve [modu] of
-          ResolveResult {resolvedModules = [resolved], resolveErrors = []} -> resolved
-          ResolveResult {resolveErrors} -> error ("Resolve error in test: " ++ show resolveErrors)
+        then modu
         else error ("Parse error in test: " ++ show errs)
 
 evidenceDictNames :: Module -> [Text]

--- a/core-libs/aihc-base/src/Control/Monad.hs
+++ b/core-libs/aihc-base/src/Control/Monad.hs
@@ -1,6 +1,7 @@
 module Control.Monad
   ( Monad (..),
+    (=<<),
   )
 where
 
-import Prelude (Monad (..))
+import Prelude (Monad (..), (=<<))

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -17,6 +17,7 @@ module Prelude
     String,
     (&&),
     (++),
+    (=<<),
     (/=),
     (==),
     id,
@@ -140,6 +141,11 @@ class (Applicative m) => Monad (m :: Type -> Type) where
   return :: a -> m a
 
 infixl 1 >>=, >>
+
+(=<<) :: (Monad m) => (a -> m b) -> m a -> m b
+f =<< mx = mx >>= f
+
+infixr 1 =<<
 
 instance Monad List where
   xs >>= k = bindList xs k


### PR DESCRIPTION
## Summary

- export a real `=<<` definition from `Prelude` and `Control.Monad`
- type-check ordinary `do` blocks while preserving a single monad constructor across statements
- infer missing imported class parameter kinds instead of defaulting them to `Type`
- keep class method schemes constrained by their class dictionary rather than duplicating superclass constraints
- decompose type applications while solving equalities inside implications

## Root cause

Installed interfaces provide imported term schemes but not the type-constructor kind environment. This made `Monad m` default `m` to kind `Type`, even when `m Bool` required `Type -> Type`. Ordinary `do` expressions were also unsupported by constraint generation. Once `=<<` was exposed, duplicated `Applicative` constraints in imported `Monad` method schemes revealed a further evidence failure.

## Progress counts

- aihc-tc unit tests: +1
- aihc-tc annotated fixtures: +1
- aihc-fc eval fixtures: +1
- README progress counts unchanged (cron-managed)

## Validation

- `cabal run -v0 aihc -- install almost-fix`
- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
