### PR TITLE
fix(install): model library-only dependency outcomes

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -20,9 +20,11 @@ module Aihc.Cli.Install
     checkPackagePlanWithCache,
     defaultStoreRoot,
     dryRunInstallScaffold,
+    installFailureIsForPackage,
     lookupPackagePlanSourceFileCount,
     newPackageCheckCache,
     newPackagePlanCache,
+    packagePlanFailureIsForPackage,
     renderInstallFailure,
     renderInstallFailureWithOptions,
     runInstall,
@@ -82,7 +84,7 @@ import Aihc.Tc
   )
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar)
-import Control.Exception (SomeException, evaluate, mask, throwIO, try)
+import Control.Exception (AsyncException, Exception (..), SomeException, evaluate, fromException, mask, throwIO, try)
 import Control.Monad (when)
 import Data.Aeson (ToJSON (..), object, (.:), (.=))
 import Data.Aeson qualified as Aeson
@@ -210,6 +212,14 @@ data SourceAnalysisMode
   = AllowSourceWrites
   | AvoidSourceWrites
   deriving (Eq)
+
+data PackagePlanFailure = PackagePlanFailure !PackageSpec !SomeException
+
+instance Show PackagePlanFailure where
+  show (PackagePlanFailure _ cause) = displayException cause
+
+instance Exception PackagePlanFailure where
+  displayException (PackagePlanFailure _ cause) = displayException cause
 
 data CoreProvider = CoreProvider
   { coreProviderName :: !String,
@@ -384,29 +394,34 @@ buildDryRunPackagePlanWithResolver resolver storeRoot spec = do
 buildPackagePlanRecursive :: PackagePlanCache -> SourceAnalysisMode -> DependencyResolver -> FilePath -> [PackageSpec] -> PackageSpec -> IO (ResolvedDependency, PackagePlan)
 buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
   | packageSpecIdentity spec `elem` map packageSpecIdentity stack =
-      ioError (userError ("Cyclic dependency while installing " <> formatPackage spec))
+      withPackagePlanFailure cycleSpec $
+        ioError (userError ("Cyclic dependency while installing " <> formatPackage spec))
   | otherwise = buildPackagePlanCached cache mode spec build
   where
     spec = canonicalPackageSpec rawSpec
-    build = do
-      sourcePath <- sourcePathForSpec resolver spec
-      analysis <- analyzeSourceWith mode sourcePath
-      recordPackagePlanSourceFileCount cache mode spec (sourceFileCount analysis)
-      dependencySpecs <- mapM resolveDependencySpec (sourceDependencyNames analysis)
-      dependencyPlans <- mapM (buildPackagePlanRecursive cache mode resolver storeRoot (spec : stack)) dependencySpecs
-      let plan =
-            buildPackagePlanFromAnalysis
-              storeRoot
-              spec
-              sourcePath
-              (map fst dependencyPlans)
-              (map snd dependencyPlans)
-              analysis
-      pure (resolvedDependencyFromPlan plan, plan)
+    cycleSpec = spec {pkgVersion = "cyclic-dependency"}
+    build =
+      withPackagePlanFailure spec $ do
+        sourcePath <- sourcePathForSpec resolver spec
+        analysis <- analyzeSourceWith mode sourcePath
+        recordPackagePlanSourceFileCount cache mode spec (sourceFileCount analysis)
+        dependencySpecs <- mapM resolveDependencySpec (sourceDependencyNames analysis)
+        dependencyPlans <- mapM (buildPackagePlanRecursive cache mode resolver storeRoot (spec : stack)) dependencySpecs
+        let plan =
+              buildPackagePlanFromAnalysis
+                storeRoot
+                spec
+                sourcePath
+                (map fst dependencyPlans)
+                (map snd dependencyPlans)
+                analysis
+        pure (resolvedDependencyFromPlan plan, plan)
 
     resolveDependencySpec dependencyName = do
-      version <- resolveVersionForDependency dependencyName
+      version <- withPackagePlanFailure unresolvedSpec (resolveVersionForDependency dependencyName)
       pure (canonicalPackageSpec (PackageSpec dependencyName version))
+      where
+        unresolvedSpec = PackageSpec dependencyName "unresolved"
 
     resolveVersionForDependency dependencyName =
       case lookupCoreProvider dependencyName of
@@ -437,6 +452,29 @@ recordPackagePlanSourceFileCount :: PackagePlanCache -> SourceAnalysisMode -> Pa
 recordPackagePlanSourceFileCount cache mode spec count =
   modifyMVar_ (packagePlanSourceFileCounts cache) $ \counts ->
     pure (Map.insert (mode == AvoidSourceWrites, pkgName spec, pkgVersion spec) count counts)
+
+withPackagePlanFailure :: PackageSpec -> IO a -> IO a
+withPackagePlanFailure spec action = do
+  result <- try action
+  case result of
+    Right value -> pure value
+    Left (err :: SomeException) ->
+      case fromException err of
+        Just (_ :: PackagePlanFailure) -> throwIO err
+        Nothing ->
+          case fromException err of
+            Just (_ :: AsyncException) -> throwIO err
+            Nothing -> throwIO (PackagePlanFailure spec err)
+
+packagePlanFailureIsForPackage :: PackageSpec -> SomeException -> Bool
+packagePlanFailureIsForPackage rawSpec err =
+  case fromException err of
+    Just (PackagePlanFailure failedSpec _) -> packageSpecIdentity failedSpec == packageSpecIdentity (canonicalPackageSpec rawSpec)
+    Nothing -> True
+
+installFailureIsForPackage :: PackageSpec -> InstallFailure -> Bool
+installFailureIsForPackage rawSpec (InstallInterfaceFailure failedSpec _) =
+  packageSpecIdentity failedSpec == packageSpecIdentity (canonicalPackageSpec rawSpec)
 
 sourcePathForSpec :: DependencyResolver -> PackageSpec -> IO FilePath
 sourcePathForSpec resolver spec =

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -437,6 +437,7 @@ lookupCoreProvider name =
     "aihc-prim" -> Just aihcPrimProvider
     "ghc-internal" -> Just aihcInternalProvider
     "aihc-internal" -> Just aihcInternalProvider
+    "system-cxx-std-lib" -> Just systemCxxStdLibProvider
     _ -> Nothing
 
 canonicalPackageSpec :: PackageSpec -> PackageSpec
@@ -467,6 +468,14 @@ aihcInternalProvider =
     { coreProviderName = "aihc-internal",
       coreProviderVersion = "9.1204.0",
       coreProviderSourceRel = "core-libs" </> "aihc-internal"
+    }
+
+systemCxxStdLibProvider :: CoreProvider
+systemCxxStdLibProvider =
+  CoreProvider
+    { coreProviderName = "system-cxx-std-lib",
+      coreProviderVersion = "1.0",
+      coreProviderSourceRel = "core-libs" </> "system-cxx-std-lib"
     }
 
 coreProviderSourcePath :: CoreProvider -> IO FilePath

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -24,7 +24,7 @@ module Aihc.Cli.Install
     lookupPackagePlanSourceFileCount,
     newPackageCheckCache,
     newPackagePlanCache,
-    packagePlanFailureIsForPackage,
+    packagePlanFailureShouldBeReportedForPackage,
     renderInstallFailure,
     renderInstallFailureWithOptions,
     runInstall,
@@ -213,13 +213,18 @@ data SourceAnalysisMode
   | AvoidSourceWrites
   deriving (Eq)
 
-data PackagePlanFailure = PackagePlanFailure !PackageSpec !SomeException
+data PackagePlanFailureDisposition
+  = ReportPackagePlanFailure
+  | SkipPackagePlanFailure
+  deriving (Eq)
+
+data PackagePlanFailure = PackagePlanFailure !PackagePlanFailureDisposition !PackageSpec !SomeException
 
 instance Show PackagePlanFailure where
-  show (PackagePlanFailure _ cause) = displayException cause
+  show (PackagePlanFailure _ _ cause) = displayException cause
 
 instance Exception PackagePlanFailure where
-  displayException (PackagePlanFailure _ cause) = displayException cause
+  displayException (PackagePlanFailure _ _ cause) = displayException cause
 
 data CoreProvider = CoreProvider
   { coreProviderName :: !String,
@@ -394,7 +399,7 @@ buildDryRunPackagePlanWithResolver resolver storeRoot spec = do
 buildPackagePlanRecursive :: PackagePlanCache -> SourceAnalysisMode -> DependencyResolver -> FilePath -> [PackageSpec] -> PackageSpec -> IO (ResolvedDependency, PackagePlan)
 buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
   | packageSpecIdentity spec `elem` map packageSpecIdentity stack =
-      withPackagePlanFailure cycleSpec $
+      withSkippedPackagePlanFailure cycleSpec $
         ioError (userError ("Cyclic dependency while installing " <> formatPackage spec))
   | otherwise = buildPackagePlanCached cache mode spec build
   where
@@ -418,7 +423,7 @@ buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
         pure (resolvedDependencyFromPlan plan, plan)
 
     resolveDependencySpec dependencyName = do
-      version <- withPackagePlanFailure unresolvedSpec (resolveVersionForDependency dependencyName)
+      version <- withSkippedPackagePlanFailure unresolvedSpec (resolveVersionForDependency dependencyName)
       pure (canonicalPackageSpec (PackageSpec dependencyName version))
       where
         unresolvedSpec = PackageSpec dependencyName "unresolved"
@@ -454,7 +459,13 @@ recordPackagePlanSourceFileCount cache mode spec count =
     pure (Map.insert (mode == AvoidSourceWrites, pkgName spec, pkgVersion spec) count counts)
 
 withPackagePlanFailure :: PackageSpec -> IO a -> IO a
-withPackagePlanFailure spec action = do
+withPackagePlanFailure = withPackagePlanFailureDisposition ReportPackagePlanFailure
+
+withSkippedPackagePlanFailure :: PackageSpec -> IO a -> IO a
+withSkippedPackagePlanFailure = withPackagePlanFailureDisposition SkipPackagePlanFailure
+
+withPackagePlanFailureDisposition :: PackagePlanFailureDisposition -> PackageSpec -> IO a -> IO a
+withPackagePlanFailureDisposition disposition spec action = do
   result <- try action
   case result of
     Right value -> pure value
@@ -464,12 +475,14 @@ withPackagePlanFailure spec action = do
         Nothing ->
           case fromException err of
             Just (_ :: AsyncException) -> throwIO err
-            Nothing -> throwIO (PackagePlanFailure spec err)
+            Nothing -> throwIO (PackagePlanFailure disposition spec err)
 
-packagePlanFailureIsForPackage :: PackageSpec -> SomeException -> Bool
-packagePlanFailureIsForPackage rawSpec err =
+packagePlanFailureShouldBeReportedForPackage :: PackageSpec -> SomeException -> Bool
+packagePlanFailureShouldBeReportedForPackage rawSpec err =
   case fromException err of
-    Just (PackagePlanFailure failedSpec _) -> packageSpecIdentity failedSpec == packageSpecIdentity (canonicalPackageSpec rawSpec)
+    Just (PackagePlanFailure disposition failedSpec _) ->
+      disposition == ReportPackagePlanFailure
+        && packageSpecIdentity failedSpec == packageSpecIdentity (canonicalPackageSpec rawSpec)
     Nothing -> True
 
 installFailureIsForPackage :: PackageSpec -> InstallFailure -> Bool
@@ -480,7 +493,7 @@ sourcePathForSpec :: DependencyResolver -> PackageSpec -> IO FilePath
 sourcePathForSpec resolver spec =
   case lookupCoreProvider (pkgName spec) of
     Just provider -> coreProviderSourcePath provider
-    Nothing -> resolverSourcePath resolver spec
+    Nothing -> withSkippedPackagePlanFailure spec (resolverSourcePath resolver spec)
 
 lookupCoreProvider :: String -> Maybe CoreProvider
 lookupCoreProvider name =

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -20,6 +20,7 @@ module Aihc.Cli.Install
     checkPackagePlanWithCache,
     defaultStoreRoot,
     dryRunInstallScaffold,
+    lookupPackagePlanSourceFileCount,
     newPackageCheckCache,
     newPackagePlanCache,
     renderInstallFailure,
@@ -80,7 +81,7 @@ import Aihc.Tc
     typecheckModulesWithEnv,
   )
 import Control.Applicative ((<|>))
-import Control.Concurrent.MVar (MVar, modifyMVar, newEmptyMVar, newMVar, putMVar, readMVar)
+import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar)
 import Control.Exception (SomeException, evaluate, mask, throwIO, try)
 import Control.Monad (when)
 import Data.Aeson (ToJSON (..), object, (.:), (.=))
@@ -248,9 +249,10 @@ newtype PackageCheckCache
       (MVar (Map.Map String (MVar (Either SomeException (Either InstallFailure PreparedInstall)))))
 
 -- | Concurrent plan cache. A cache belongs to one resolver and store root.
-newtype PackagePlanCache
-  = PackagePlanCache
-      (MVar (Map.Map (Bool, String, String) (MVar (Either SomeException (ResolvedDependency, PackagePlan)))))
+data PackagePlanCache = PackagePlanCache
+  { packagePlanEntries :: !(MVar (Map.Map (Bool, String, String) (MVar (Either SomeException (ResolvedDependency, PackagePlan))))),
+    packagePlanSourceFileCounts :: !(MVar (Map.Map (Bool, String, String) Int))
+  }
 
 instance ToJSON ArtifactManifest where
   toJSON manifest =
@@ -360,7 +362,14 @@ buildPackagePlanWithResolver resolver storeRoot spec = do
   buildPackagePlanWithResolverCached cache resolver storeRoot spec
 
 newPackagePlanCache :: IO PackagePlanCache
-newPackagePlanCache = PackagePlanCache <$> newMVar Map.empty
+newPackagePlanCache = PackagePlanCache <$> newMVar Map.empty <*> newMVar Map.empty
+
+lookupPackagePlanSourceFileCount :: PackagePlanCache -> PackageSpec -> IO (Maybe Int)
+lookupPackagePlanSourceFileCount cache rawSpec = do
+  counts <- readMVar (packagePlanSourceFileCounts cache)
+  pure (Map.lookup (False, pkgName spec, pkgVersion spec) counts)
+  where
+    spec = canonicalPackageSpec rawSpec
 
 -- | Build a package plan while sharing dependency work with other roots.
 buildPackagePlanWithResolverCached :: PackagePlanCache -> DependencyResolver -> FilePath -> PackageSpec -> IO PackagePlan
@@ -382,6 +391,7 @@ buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
     build = do
       sourcePath <- sourcePathForSpec resolver spec
       analysis <- analyzeSourceWith mode sourcePath
+      recordPackagePlanSourceFileCount cache mode spec (sourceFileCount analysis)
       dependencySpecs <- mapM resolveDependencySpec (sourceDependencyNames analysis)
       dependencyPlans <- mapM (buildPackagePlanRecursive cache mode resolver storeRoot (spec : stack)) dependencySpecs
       let plan =
@@ -404,7 +414,7 @@ buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
         Nothing -> resolverResolveVersion resolver dependencyName
 
 buildPackagePlanCached :: PackagePlanCache -> SourceAnalysisMode -> PackageSpec -> IO (ResolvedDependency, PackagePlan) -> IO (ResolvedDependency, PackagePlan)
-buildPackagePlanCached (PackagePlanCache entries) mode spec action = mask $ \restore -> do
+buildPackagePlanCached cache mode spec action = mask $ \restore -> do
   resultVar <- newEmptyMVar
   (isOwner, sharedResult) <-
     modifyMVar entries $ \current ->
@@ -420,7 +430,13 @@ buildPackagePlanCached (PackagePlanCache entries) mode spec action = mask $ \res
       result <- readMVar sharedResult
       either throwIO pure result
   where
+    entries = packagePlanEntries cache
     cacheKey = (mode == AvoidSourceWrites, pkgName spec, pkgVersion spec)
+
+recordPackagePlanSourceFileCount :: PackagePlanCache -> SourceAnalysisMode -> PackageSpec -> Int -> IO ()
+recordPackagePlanSourceFileCount cache mode spec count =
+  modifyMVar_ (packagePlanSourceFileCounts cache) $ \counts ->
+    pure (Map.insert (mode == AvoidSourceWrites, pkgName spec, pkgVersion spec) count counts)
 
 sourcePathForSpec :: DependencyResolver -> PackageSpec -> IO FilePath
 sourcePathForSpec resolver spec =

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -102,7 +102,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Data.Word (Word64)
-import Distribution.PackageDescription (buildInfo, buildable, condExecutables, condLibrary, condSubLibraries, genPackageFlags, libBuildInfo)
+import Distribution.Package qualified as CabalPackage
+import Distribution.PackageDescription (buildable, condLibrary, condSubLibraries, genPackageFlags, libBuildInfo, package, packageDescription)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Types.Flag (flagDefault, flagName, unFlagName)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
@@ -566,7 +567,7 @@ analyzeSourceWith mode sourcePath = do
 analyzeSourceFileCount :: SourceAnalysisMode -> GenericPackageDescription -> FilePath -> IO Int
 analyzeSourceFileCount mode gpd sourcePath =
   case mode of
-    AllowSourceWrites -> length <$> HackageCabal.collectComponentFiles gpd sourcePath
+    AllowSourceWrites -> length <$> HackageCabal.collectLibraryFiles gpd sourcePath
     AvoidSourceWrites -> pure 0
 
 writeInstallScaffold :: PackagePlan -> IO (Either InstallFailure InstallResult)
@@ -1192,7 +1193,7 @@ collectPlanFiles plan = do
     case runParseResult (parseGenericPackageDescription cabalBytes) of
       (_, Right parsed) -> pure parsed
       (_, Left (_, errs)) -> ioError (userError ("Failed to parse " <> planCabalFile plan <> ": " <> show errs))
-  HackageCabal.collectComponentFiles gpd (planSourcePath plan)
+  HackageCabal.collectLibraryFiles gpd (planSourcePath plan)
 
 parseInterfaceFile :: FilePath -> HackageCabal.FileInfo -> IO ParsedInterfaceFile
 parseInterfaceFile packageRoot fileInfo = do
@@ -1609,23 +1610,20 @@ packageFlagAssignments gpd =
 
 packageDependencyNames :: GenericPackageDescription -> [String]
 packageDependencyNames gpd =
-  sort . nub . map T.unpack $
-    concatMap libraryDependencies libraryTrees
-      <> concatMap (executableDependencies . snd) (condExecutables gpd)
+  (sort . nub . map T.unpack)
+    ( concatMap
+        (filter (/= currentPackageName) . libraryDependencies)
+        libraryTrees
+    )
   where
     evalCond = HackageCabal.conditionEvaluator gpd
+    currentPackageName = T.pack . CabalPackage.unPackageName . CabalPackage.packageName . package $ packageDescription gpd
     libraryTrees =
       maybe [] pure (condLibrary gpd)
         <> map snd (condSubLibraries gpd)
 
     libraryDependencies tree =
       let build = HackageCabal.collectMergedBuildInfo evalCond libBuildInfo tree
-       in if buildable build
-            then HackageCabal.extractDependencies build
-            else []
-
-    executableDependencies tree =
-      let build = HackageCabal.collectMergedBuildInfo evalCond buildInfo tree
        in if buildable build
             then HackageCabal.extractDependencies build
             else []

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -21,7 +21,7 @@ module Aihc.Cli.Install
     defaultStoreRoot,
     dryRunInstallScaffold,
     installFailureIsForPackage,
-    lookupPackagePlanSourceFileCount,
+    lookupPackagePlanSourceLineCount,
     newPackageCheckCache,
     newPackagePlanCache,
     packagePlanFailureShouldBeReportedForPackage,
@@ -204,6 +204,7 @@ data SourceAnalysis = SourceAnalysis
     sourceSetupFile :: !(Maybe FilePath),
     sourceSetupBytes :: !BS.ByteString,
     sourceFileCount :: !Int,
+    sourceLineCount :: !Int,
     sourceFlagAssignments :: ![(String, Bool)],
     sourceDependencyNames :: ![String]
   }
@@ -266,7 +267,7 @@ newtype PackageCheckCache
 -- | Concurrent plan cache. A cache belongs to one resolver and store root.
 data PackagePlanCache = PackagePlanCache
   { packagePlanEntries :: !(MVar (Map.Map (Bool, String, String) (MVar (Either SomeException (ResolvedDependency, PackagePlan))))),
-    packagePlanSourceFileCounts :: !(MVar (Map.Map (Bool, String, String) Int))
+    packagePlanSourceLineCounts :: !(MVar (Map.Map (Bool, String, String) Int))
   }
 
 instance ToJSON ArtifactManifest where
@@ -379,9 +380,9 @@ buildPackagePlanWithResolver resolver storeRoot spec = do
 newPackagePlanCache :: IO PackagePlanCache
 newPackagePlanCache = PackagePlanCache <$> newMVar Map.empty <*> newMVar Map.empty
 
-lookupPackagePlanSourceFileCount :: PackagePlanCache -> PackageSpec -> IO (Maybe Int)
-lookupPackagePlanSourceFileCount cache rawSpec = do
-  counts <- readMVar (packagePlanSourceFileCounts cache)
+lookupPackagePlanSourceLineCount :: PackagePlanCache -> PackageSpec -> IO (Maybe Int)
+lookupPackagePlanSourceLineCount cache rawSpec = do
+  counts <- readMVar (packagePlanSourceLineCounts cache)
   pure (Map.lookup (False, pkgName spec, pkgVersion spec) counts)
   where
     spec = canonicalPackageSpec rawSpec
@@ -409,7 +410,7 @@ buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
       withPackagePlanFailure spec $ do
         sourcePath <- sourcePathForSpec resolver spec
         analysis <- analyzeSourceWith mode sourcePath
-        recordPackagePlanSourceFileCount cache mode spec (sourceFileCount analysis)
+        recordPackagePlanSourceLineCount cache mode spec (sourceLineCount analysis)
         dependencySpecs <- mapM resolveDependencySpec (sourceDependencyNames analysis)
         dependencyPlans <- mapM (buildPackagePlanRecursive cache mode resolver storeRoot (spec : stack)) dependencySpecs
         let plan =
@@ -453,9 +454,9 @@ buildPackagePlanCached cache mode spec action = mask $ \restore -> do
     entries = packagePlanEntries cache
     cacheKey = (mode == AvoidSourceWrites, pkgName spec, pkgVersion spec)
 
-recordPackagePlanSourceFileCount :: PackagePlanCache -> SourceAnalysisMode -> PackageSpec -> Int -> IO ()
-recordPackagePlanSourceFileCount cache mode spec count =
-  modifyMVar_ (packagePlanSourceFileCounts cache) $ \counts ->
+recordPackagePlanSourceLineCount :: PackagePlanCache -> SourceAnalysisMode -> PackageSpec -> Int -> IO ()
+recordPackagePlanSourceLineCount cache mode spec count =
+  modifyMVar_ (packagePlanSourceLineCounts cache) $ \counts ->
     pure (Map.insert (mode == AvoidSourceWrites, pkgName spec, pkgVersion spec) count counts)
 
 withPackagePlanFailure :: PackageSpec -> IO a -> IO a
@@ -626,7 +627,7 @@ analyzeSourceWith mode sourcePath = do
     case runParseResult (parseGenericPackageDescription cabalBytes) of
       (_, Right parsed) -> pure parsed
       (_, Left (_, errs)) -> ioError (userError ("Failed to parse " <> cabalFile <> ": " <> show errs))
-  sourceFileCount <- analyzeSourceFileCount mode gpd sourcePath
+  (sourceFileCount, sourceLineCount) <- analyzeSourceMetrics mode gpd sourcePath
   setupFile <- findSetupFile sourcePath
   setupBytes <- maybe (pure BS.empty) BS.readFile setupFile
   pure
@@ -636,15 +637,22 @@ analyzeSourceWith mode sourcePath = do
         sourceSetupFile = setupFile,
         sourceSetupBytes = setupBytes,
         sourceFileCount = sourceFileCount,
+        sourceLineCount = sourceLineCount,
         sourceFlagAssignments = packageFlagAssignments gpd,
         sourceDependencyNames = packageDependencyNames gpd
       }
 
-analyzeSourceFileCount :: SourceAnalysisMode -> GenericPackageDescription -> FilePath -> IO Int
-analyzeSourceFileCount mode gpd sourcePath =
+analyzeSourceMetrics :: SourceAnalysisMode -> GenericPackageDescription -> FilePath -> IO (Int, Int)
+analyzeSourceMetrics mode gpd sourcePath =
   case mode of
-    AllowSourceWrites -> length <$> HackageCabal.collectLibraryFiles gpd sourcePath
-    AvoidSourceWrites -> pure 0
+    AllowSourceWrites -> do
+      files <- HackageCabal.collectLibraryFiles gpd sourcePath
+      lineCount <- sum <$> mapM fileLineCount files
+      pure (length files, lineCount)
+    AvoidSourceWrites -> pure (0, 0)
+  where
+    fileLineCount fileInfo =
+      length . T.lines <$> HackageUtil.readTextFileLenient (HackageCabal.fileInfoPath fileInfo)
 
 writeInstallScaffold :: PackagePlan -> IO (Either InstallFailure InstallResult)
 writeInstallScaffold plan = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -172,6 +172,7 @@ main =
           testCase "uses local provider for base dependencies" test_usesLocalProviderForBase,
           testCase "uses local provider for ghc-prim dependencies" test_usesLocalProviderForGhcPrim,
           testCase "uses local provider for ghc-internal dependencies" test_usesLocalProviderForGhcInternal,
+          testCase "uses virtual provider for system-cxx-std-lib dependencies" test_usesVirtualProviderForSystemCxxStdLib,
           testCase "manifest records core provider dependency names" test_manifestRecordsCoreProviderDependencyNames,
           testCase "installs resolved base dependency closure" test_installsResolvedBaseDependencyClosure,
           testCase "dry run writes no scaffold artifacts" test_dryRunWritesNoScaffoldArtifacts,
@@ -605,6 +606,20 @@ test_usesLocalProviderForGhcInternal =
         (PackageSpec "demo" "0.1.0.0")
     assertDependencySpec plan (PackageSpec "aihc-internal" "9.1204.0")
 
+test_usesVirtualProviderForSystemCxxStdLib :: Assertion
+test_usesVirtualProviderForSystemCxxStdLib =
+  withCoreDependencyFixture "system-cxx-std-lib" $ \sourceRoot storeRoot -> do
+    plan <-
+      buildPackagePlanWithResolver
+        (fixtureDependencyResolver sourceRoot [])
+        storeRoot
+        (PackageSpec "demo" "0.1.0.0")
+    assertDependencySpec plan (PackageSpec "system-cxx-std-lib" "1.0")
+    dependencyPlan <- findPlanByName "system-cxx-std-lib" (planDependencyPlans plan)
+    assertEqual "virtual package source file count" 0 (planSourceFileCount dependencyPlan)
+    _ <- expectInstallSuccess (checkPackagePlan plan)
+    pure ()
+
 test_manifestRecordsCoreProviderDependencyNames :: Assertion
 test_manifestRecordsCoreProviderDependencyNames =
   withCoreDependencyFixture "ghc-prim" $ \sourceRoot storeRoot -> do
@@ -807,6 +822,10 @@ createCoreProviderFixtures root = do
     "aihc-internal"
     "9.1204.0"
     "GHC.Internal.Base"
+  createVirtualCoreProviderPackage
+    (root </> "core-libs" </> "system-cxx-std-lib")
+    "system-cxx-std-lib"
+    "1.0"
 
 createCoreProviderPackage :: FilePath -> String -> String -> String -> IO ()
 createCoreProviderPackage sourceRoot name version moduleName = do
@@ -818,6 +837,23 @@ createCoreProviderPackage sourceRoot name version moduleName = do
   where
     dotToSlash '.' = '/'
     dotToSlash c = c
+
+createVirtualCoreProviderPackage :: FilePath -> String -> String -> IO ()
+createVirtualCoreProviderPackage sourceRoot name version = do
+  createDirectoryIfMissing True sourceRoot
+  writeFile
+    (sourceRoot </> name <> ".cabal")
+    ( unlines
+        [ "cabal-version: 3.8",
+          "name: " <> name,
+          "version: " <> version,
+          "build-type: Simple",
+          "license: NONE",
+          "",
+          "library",
+          "  default-language: GHC2021"
+        ]
+    )
 
 fixtureCabal :: String -> String -> String -> [String] -> [String] -> String
 fixtureCabal name version moduleName otherModules dependencies =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -156,6 +156,7 @@ main =
         "install"
         [ testCase "builds stable store paths" test_stableStorePath,
           testCase "recursive dependencies affect store paths" test_recursiveDependenciesAffectStorePaths,
+          testCase "plans library components without executables" test_plansLibraryComponentsWithoutExecutables,
           testCase "writes scaffold artifacts" test_writeInstallScaffold,
           testCase "writes dependency scaffold artifacts first" test_writeInstallScaffoldWritesDependencies,
           testCase "reports parse errors and writes no artifacts" test_reportsParseErrorsAndWritesNoArtifacts,
@@ -277,6 +278,33 @@ test_recursiveDependenciesAffectStorePaths =
         storeRoot
         (PackageSpec "demo" "0.1.0.0")
     assertBool "dependency variant should change store path" (planStorePath plan1 /= planStorePath plan2)
+
+test_plansLibraryComponentsWithoutExecutables :: Assertion
+test_plansLibraryComponentsWithoutExecutables =
+  withTempDir "aihc-cli" $ \root -> do
+    let sourceRoot = root </> "source"
+        depRoot = root </> "dep"
+        storeRoot = root </> "store"
+    createDirectoryIfMissing True (sourceRoot </> "src")
+    createDirectoryIfMissing True (sourceRoot </> "internal" </> "Demo")
+    createDirectoryIfMissing True (sourceRoot </> "app")
+    createDirectoryIfMissing True storeRoot
+    writeFile (sourceRoot </> "demo.cabal") libraryOnlyInstallCabal
+    writeFile (sourceRoot </> "src" </> "Demo.hs") "module Demo where\nimport Demo.Internal\nimport Dep\nx = depId internalValue\n"
+    writeFile (sourceRoot </> "internal" </> "Demo" </> "Internal.hs") "module Demo.Internal where\ninternalValue = ()\n"
+    writeFile (sourceRoot </> "app" </> "Main.hs") "module Main where\nthis executable is intentionally invalid\n"
+    createFixturePackageWithSource depRoot "dep" "1.0.0" "Dep" [] "module Dep where\ndepId x = x\n"
+
+    plan <-
+      buildPackagePlanWithResolver
+        (fixtureDependencyResolver sourceRoot [("dep", "1.0.0", depRoot)])
+        storeRoot
+        (PackageSpec "demo" "0.1.0.0")
+
+    assertEqual "library source file count" 2 (planSourceFileCount plan)
+    assertEqual "external library dependencies" ["dep"] [pkgName (packageKeySpec (planPackageKey dependencyPlan)) | dependencyPlan <- planDependencyPlans plan]
+    _ <- expectInstallSuccess (checkPackagePlan plan)
+    pure ()
 
 test_writeInstallScaffold :: Assertion
 test_writeInstallScaffold =
@@ -817,6 +845,31 @@ demoCabal =
       "  exposed-modules: Demo",
       "  hs-source-dirs: src",
       "  build-depends: base >=4 && <5",
+      "  default-language: Haskell2010"
+    ]
+
+libraryOnlyInstallCabal :: String
+libraryOnlyInstallCabal =
+  unlines
+    [ "cabal-version: 3.0",
+      "name: demo",
+      "version: 0.1.0.0",
+      "",
+      "library demo-internal",
+      "  exposed-modules: Demo.Internal",
+      "  hs-source-dirs: internal",
+      "  default-language: Haskell2010",
+      "",
+      "library",
+      "  exposed-modules: Demo",
+      "  hs-source-dirs: src",
+      "  build-depends: demo-internal, dep",
+      "  default-language: Haskell2010",
+      "",
+      "executable demo-cli",
+      "  main-is: Main.hs",
+      "  hs-source-dirs: app",
+      "  build-depends: demo, executable-only-dependency",
       "  default-language: Haskell2010"
     ]
 

--- a/core-libs/system-cxx-std-lib/system-cxx-std-lib.cabal
+++ b/core-libs/system-cxx-std-lib/system-cxx-std-lib.cabal
@@ -1,0 +1,9 @@
+cabal-version: 3.8
+name: system-cxx-std-lib
+version: 1.0
+build-type: Simple
+license: NONE
+synopsis: Virtual package representing the C++ standard library
+
+library
+  default-language: GHC2021

--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -5,6 +5,7 @@ module TcStackageProgress
   ( Options (..),
     PackageCounts (..),
     optionsParser,
+    checkOnePackage,
     smallestFailingPackages,
     summarizePackageStatuses,
     run,
@@ -19,6 +20,7 @@ import Aihc.Cli.Install
     buildPackagePlanWithResolverCached,
     checkPackagePlanWithCache,
     defaultStoreRoot,
+    lookupPackagePlanSourceFileCount,
     newPackageCheckCache,
     newPackagePlanCache,
     renderInstallFailure,
@@ -37,6 +39,7 @@ import Control.Monad qualified
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Conc (getNumProcessors)
@@ -194,10 +197,12 @@ checkOnePackage planCache checkCache resolver storeRoot spec = do
     plan <- buildPackagePlanWithResolverCached planCache resolver storeRoot spec
     checkResult <- checkPackagePlanWithCache checkCache plan
     pure (plan, checkResult)
-  pure $ case result of
-    Left (err :: SomeException) -> (RSP.PkgFailed (displayException err), 0)
-    Right (plan, Left failure) -> (RSP.PkgFailed (renderInstallFailure failure), planSourceFileCount plan)
-    Right (plan, Right _) -> (RSP.PkgSuccess Map.empty, planSourceFileCount plan)
+  case result of
+    Left (err :: SomeException) -> do
+      sourceFileCount <- fromMaybe 0 <$> lookupPackagePlanSourceFileCount planCache spec
+      pure (RSP.PkgFailed (displayException err), sourceFileCount)
+    Right (plan, Left failure) -> pure (RSP.PkgFailed (renderInstallFailure failure), planSourceFileCount plan)
+    Right (plan, Right _) -> pure (RSP.PkgSuccess Map.empty, planSourceFileCount plan)
 
 reportResults :: Int -> Map Text (RSP.PackageStatus, Int) -> IO ()
 reportResults topN resultsWithSizes = do

--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -25,7 +25,7 @@ import Aihc.Cli.Install
     lookupPackagePlanSourceFileCount,
     newPackageCheckCache,
     newPackagePlanCache,
-    packagePlanFailureIsForPackage,
+    packagePlanFailureShouldBeReportedForPackage,
     renderInstallFailure,
   )
 import Aihc.Hackage.Cabal qualified as HC
@@ -204,7 +204,7 @@ checkOnePackage planCache checkCache resolver storeRoot spec = do
     Left (err :: SomeException) -> do
       sourceFileCount <- fromMaybe 0 <$> lookupPackagePlanSourceFileCount planCache spec
       let status =
-            if packagePlanFailureIsForPackage spec err
+            if packagePlanFailureShouldBeReportedForPackage spec err
               then RSP.PkgFailed (displayException err)
               else RSP.PkgSkipped
       pure (status, sourceFileCount)

--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -22,7 +22,7 @@ import Aihc.Cli.Install
     checkPackagePlanWithCache,
     defaultStoreRoot,
     installFailureIsForPackage,
-    lookupPackagePlanSourceFileCount,
+    lookupPackagePlanSourceLineCount,
     newPackageCheckCache,
     newPackagePlanCache,
     packagePlanFailureShouldBeReportedForPackage,
@@ -200,22 +200,22 @@ checkOnePackage planCache checkCache resolver storeRoot spec = do
     plan <- buildPackagePlanWithResolverCached planCache resolver storeRoot spec
     checkResult <- checkPackagePlanWithCache checkCache plan
     pure (plan, checkResult)
+  lineCount <- fromMaybe 0 <$> lookupPackagePlanSourceLineCount planCache spec
   case result of
     Left (err :: SomeException) -> do
-      sourceFileCount <- fromMaybe 0 <$> lookupPackagePlanSourceFileCount planCache spec
       let status =
             if packagePlanFailureShouldBeReportedForPackage spec err
               then RSP.PkgFailed (displayException err)
               else RSP.PkgSkipped
-      pure (status, sourceFileCount)
+      pure (status, lineCount)
     Right (plan, Left failure) ->
       let rootSpec = packageKeySpec (planPackageKey plan)
           status =
             if installFailureIsForPackage rootSpec failure
               then RSP.PkgFailed (renderInstallFailure failure)
               else RSP.PkgSkipped
-       in pure (status, planSourceFileCount plan)
-    Right (plan, Right _) -> pure (RSP.PkgSuccess Map.empty, planSourceFileCount plan)
+       in pure (status, lineCount)
+    Right (_, Right _) -> pure (RSP.PkgSuccess Map.empty, lineCount)
 
 reportResults :: Int -> Map Text (RSP.PackageStatus, Int) -> IO ()
 reportResults topN resultsWithSizes = do
@@ -238,7 +238,7 @@ reportResults topN resultsWithSizes = do
   if countTypechecked counts == countTotal counts then exitSuccess else exitFailure
   where
     printFailure (pkg, lineCount, msg) = do
-      putStrLn $ "  " ++ T.unpack pkg ++ " (" ++ show lineCount ++ " files):"
+      putStrLn $ "  " ++ T.unpack pkg ++ " (" ++ show lineCount ++ " lines):"
       mapM_ (\line -> putStrLn ("    " ++ line)) (take 5 (lines msg))
 
 pct :: Int -> Int -> Int

--- a/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
+++ b/tooling/aihc-dev/app/tc-stackage-progress/TcStackageProgress.hs
@@ -17,12 +17,15 @@ import Aihc.Cli.Install
     PackageCheckCache,
     PackagePlan (..),
     PackagePlanCache,
+    PackageVariantKey (..),
     buildPackagePlanWithResolverCached,
     checkPackagePlanWithCache,
     defaultStoreRoot,
+    installFailureIsForPackage,
     lookupPackagePlanSourceFileCount,
     newPackageCheckCache,
     newPackagePlanCache,
+    packagePlanFailureIsForPackage,
     renderInstallFailure,
   )
 import Aihc.Hackage.Cabal qualified as HC
@@ -200,8 +203,18 @@ checkOnePackage planCache checkCache resolver storeRoot spec = do
   case result of
     Left (err :: SomeException) -> do
       sourceFileCount <- fromMaybe 0 <$> lookupPackagePlanSourceFileCount planCache spec
-      pure (RSP.PkgFailed (displayException err), sourceFileCount)
-    Right (plan, Left failure) -> pure (RSP.PkgFailed (renderInstallFailure failure), planSourceFileCount plan)
+      let status =
+            if packagePlanFailureIsForPackage spec err
+              then RSP.PkgFailed (displayException err)
+              else RSP.PkgSkipped
+      pure (status, sourceFileCount)
+    Right (plan, Left failure) ->
+      let rootSpec = packageKeySpec (planPackageKey plan)
+          status =
+            if installFailureIsForPackage rootSpec failure
+              then RSP.PkgFailed (renderInstallFailure failure)
+              else RSP.PkgSkipped
+       in pure (status, planSourceFileCount plan)
     Right (plan, Right _) -> pure (RSP.PkgSuccess Map.empty, planSourceFileCount plan)
 
 reportResults :: Int -> Map Text (RSP.PackageStatus, Int) -> IO ()
@@ -212,7 +225,7 @@ reportResults topN resultsWithSizes = do
   putStrLn "Type checker results:"
   putStrLn $ "  Typechecked: " ++ show (countTypechecked counts) ++ " / " ++ show (countTotal counts) ++ " (" ++ show (pct (countTypechecked counts) (countTotal counts)) ++ "%)"
   putStrLn $ "  Failed:      " ++ show (countFailed counts) ++ " (parse, scope, type-check, or desugar errors)"
-  putStrLn $ "  Skipped:     " ++ show (countSkipped counts)
+  putStrLn $ "  Skipped:     " ++ show (countSkipped counts) ++ " (dependency failed)"
   let failures =
         take topN . sortOn (\(pkg, lineCount, msg) -> (lineCount, pkg, msg)) $
           [ (pkg, lineCount, msg)

--- a/tooling/aihc-dev/test/Test/TcStackageProgress.hs
+++ b/tooling/aihc-dev/test/Test/TcStackageProgress.hs
@@ -89,9 +89,9 @@ test_skipsSourceDownloadFailure =
     planCache <- newPackagePlanCache
     checkCache <- newPackageCheckCache
 
-    (status, sourceFileCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
+    (status, lineCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
 
-    assertEqual "source file count" 0 sourceFileCount
+    assertEqual "source line count" 0 lineCount
     assertSkipped status
 
 test_skipsDependencyPlanningFailure :: IO ()
@@ -112,9 +112,9 @@ test_skipsDependencyPlanningFailure =
     planCache <- newPackagePlanCache
     checkCache <- newPackageCheckCache
 
-    (status, sourceFileCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
+    (status, lineCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
 
-    assertEqual "source file count" 1 sourceFileCount
+    assertEqual "source line count" 2 lineCount
     assertSkipped status
 
 test_skipsDependencyCheckFailure :: IO ()

--- a/tooling/aihc-dev/test/Test/TcStackageProgress.hs
+++ b/tooling/aihc-dev/test/Test/TcStackageProgress.hs
@@ -5,24 +5,28 @@ module Test.TcStackageProgress
   )
 where
 
+import Aihc.Cli.Install (DependencyResolver (..), newPackageCheckCache, newPackagePlanCache)
 import Aihc.Hackage.Cabal (FileInfo (..))
+import Aihc.Hackage.Types (PackageSpec (..))
 import Control.Exception (bracket)
+import Data.List (isInfixOf)
 import Data.Map.Strict qualified as Map
 import ResolveStackageProgress (PackageStatus (..))
 import ResolveStackageProgress qualified as RSP
-import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.Directory (createDirectory, createDirectoryIfMissing, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.FilePath ((</>))
 import System.IO (hClose, openTempFile)
-import TcStackageProgress (PackageCounts (..), smallestFailingPackages, summarizePackageStatuses)
+import TcStackageProgress (PackageCounts (..), checkOnePackage, smallestFailingPackages, summarizePackageStatuses)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertEqual, testCase)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 
 tcStackageProgressTests :: TestTree
 tcStackageProgressTests =
   testGroup
     "tc stackage progress"
     [ testCase "counts typechecked, failed, and skipped packages" test_countsPackageStatuses,
-      testCase "selects the smallest failing packages before applying the top limit" test_smallestFailingPackages
+      testCase "selects the smallest failing packages before applying the top limit" test_smallestFailingPackages,
+      testCase "keeps the source file count when dependency planning fails" test_keepsSourceFileCountOnPlanningFailure
     ]
 
 test_countsPackageStatuses :: IO ()
@@ -68,6 +72,45 @@ test_smallestFailingPackages =
       "smallest failures"
       [("tiny", 1, "tiny error"), ("medium", 2, "medium error")]
       =<< smallestFailingPackages 2 infos statuses
+
+test_keepsSourceFileCountOnPlanningFailure :: IO ()
+test_keepsSourceFileCountOnPlanningFailure =
+  withTempDir "tc-stackage-progress-planning-failure" $ \dir -> do
+    let sourceRoot = dir </> "source"
+        sourceDir = sourceRoot </> "src"
+        storeRoot = dir </> "store"
+        spec = PackageSpec "demo" "0.1.0.0"
+        resolver =
+          DependencyResolver
+            { resolverResolveVersion = \name -> fail ("missing dependency version for " <> name),
+              resolverSourcePath = const (pure sourceRoot)
+            }
+    createDirectoryIfMissing True sourceDir
+    writeFile (sourceRoot </> "demo.cabal") planningFailureCabal
+    writeFile (sourceDir </> "Demo.hs") "module Demo where\nx = ()\n"
+    planCache <- newPackagePlanCache
+    checkCache <- newPackageCheckCache
+
+    (status, sourceFileCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
+
+    assertEqual "source file count" 1 sourceFileCount
+    case status of
+      PkgFailed message -> assertBool "dependency failure is retained" ("missing dependency version" `isInfixOf` message)
+      _ -> fail "expected package failure"
+
+planningFailureCabal :: String
+planningFailureCabal =
+  unlines
+    [ "cabal-version: 3.0",
+      "name: demo",
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: Demo",
+      "  hs-source-dirs: src",
+      "  build-depends: missing-dependency",
+      "  default-language: Haskell2010"
+    ]
 
 packageInfo :: [FilePath] -> RSP.PackageInfo
 packageInfo paths =

--- a/tooling/aihc-dev/test/Test/TcStackageProgress.hs
+++ b/tooling/aihc-dev/test/Test/TcStackageProgress.hs
@@ -26,7 +26,9 @@ tcStackageProgressTests =
     "tc stackage progress"
     [ testCase "counts typechecked, failed, and skipped packages" test_countsPackageStatuses,
       testCase "selects the smallest failing packages before applying the top limit" test_smallestFailingPackages,
-      testCase "keeps the source file count when dependency planning fails" test_keepsSourceFileCountOnPlanningFailure
+      testCase "skips packages when dependency planning fails" test_skipsDependencyPlanningFailure,
+      testCase "skips packages when a dependency check fails" test_skipsDependencyCheckFailure,
+      testCase "reports failures originating in the root package" test_reportsRootPackageFailure
     ]
 
 test_countsPackageStatuses :: IO ()
@@ -73,8 +75,8 @@ test_smallestFailingPackages =
       [("tiny", 1, "tiny error"), ("medium", 2, "medium error")]
       =<< smallestFailingPackages 2 infos statuses
 
-test_keepsSourceFileCountOnPlanningFailure :: IO ()
-test_keepsSourceFileCountOnPlanningFailure =
+test_skipsDependencyPlanningFailure :: IO ()
+test_skipsDependencyPlanningFailure =
   withTempDir "tc-stackage-progress-planning-failure" $ \dir -> do
     let sourceRoot = dir </> "source"
         sourceDir = sourceRoot </> "src"
@@ -94,9 +96,75 @@ test_keepsSourceFileCountOnPlanningFailure =
     (status, sourceFileCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
 
     assertEqual "source file count" 1 sourceFileCount
+    assertSkipped status
+
+test_skipsDependencyCheckFailure :: IO ()
+test_skipsDependencyCheckFailure =
+  withTempDir "tc-stackage-progress-dependency-check-failure" $ \dir -> do
+    let sourceRoot = dir </> "source"
+        dependencyRoot = dir </> "dependency"
+        storeRoot = dir </> "store"
+        spec = PackageSpec "demo" "0.1.0.0"
+        resolver =
+          DependencyResolver
+            { resolverResolveVersion = const (pure "1.0.0"),
+              resolverSourcePath = \packageSpec ->
+                pure $ if pkgName packageSpec == "demo" then sourceRoot else dependencyRoot
+            }
+    createPackage sourceRoot "demo" "Demo" ["dependency"] "module Demo where\nx = ()\n"
+    createPackage dependencyRoot "dependency" "Dependency" [] "module Dependency where\nx =\n"
+    planCache <- newPackagePlanCache
+    checkCache <- newPackageCheckCache
+
+    (status, _) <- checkOnePackage planCache checkCache resolver storeRoot spec
+
+    assertSkipped status
+
+test_reportsRootPackageFailure :: IO ()
+test_reportsRootPackageFailure =
+  withTempDir "tc-stackage-progress-root-failure" $ \dir -> do
+    let sourceRoot = dir </> "source"
+        storeRoot = dir </> "store"
+        spec = PackageSpec "demo" "0.1.0.0"
+        resolver =
+          DependencyResolver
+            { resolverResolveVersion = \name -> fail ("unexpected dependency " <> name),
+              resolverSourcePath = const (pure sourceRoot)
+            }
+    createPackage sourceRoot "demo" "Demo" [] "module Demo where\nx =\n"
+    planCache <- newPackagePlanCache
+    checkCache <- newPackageCheckCache
+
+    (status, _) <- checkOnePackage planCache checkCache resolver storeRoot spec
+
     case status of
-      PkgFailed message -> assertBool "dependency failure is retained" ("missing dependency version" `isInfixOf` message)
-      _ -> fail "expected package failure"
+      PkgFailed message -> assertBool "root parse failure is retained" ("parse errors" `isInfixOf` message)
+      _ -> fail "expected root package failure"
+
+assertSkipped :: PackageStatus -> IO ()
+assertSkipped PkgSkipped = pure ()
+assertSkipped _ = fail "expected package to be skipped"
+
+createPackage :: FilePath -> String -> String -> [String] -> String -> IO ()
+createPackage root name moduleName dependencies source = do
+  let sourceDir = root </> "src"
+  createDirectoryIfMissing True sourceDir
+  writeFile (root </> name <> ".cabal") (packageCabal name moduleName dependencies)
+  writeFile (sourceDir </> moduleName <> ".hs") source
+
+packageCabal :: String -> String -> [String] -> String
+packageCabal name moduleName dependencies =
+  unlines $
+    [ "cabal-version: 3.0",
+      "name: " <> name,
+      "version: 0.1.0.0",
+      "",
+      "library",
+      "  exposed-modules: " <> moduleName,
+      "  hs-source-dirs: src"
+    ]
+      <> ["  build-depends: " <> dependency | dependency <- dependencies]
+      <> ["  default-language: Haskell2010"]
 
 planningFailureCabal :: String
 planningFailureCabal =

--- a/tooling/aihc-dev/test/Test/TcStackageProgress.hs
+++ b/tooling/aihc-dev/test/Test/TcStackageProgress.hs
@@ -26,6 +26,7 @@ tcStackageProgressTests =
     "tc stackage progress"
     [ testCase "counts typechecked, failed, and skipped packages" test_countsPackageStatuses,
       testCase "selects the smallest failing packages before applying the top limit" test_smallestFailingPackages,
+      testCase "skips packages when source download fails" test_skipsSourceDownloadFailure,
       testCase "skips packages when dependency planning fails" test_skipsDependencyPlanningFailure,
       testCase "skips packages when a dependency check fails" test_skipsDependencyCheckFailure,
       testCase "reports failures originating in the root package" test_reportsRootPackageFailure
@@ -74,6 +75,24 @@ test_smallestFailingPackages =
       "smallest failures"
       [("tiny", 1, "tiny error"), ("medium", 2, "medium error")]
       =<< smallestFailingPackages 2 infos statuses
+
+test_skipsSourceDownloadFailure :: IO ()
+test_skipsSourceDownloadFailure =
+  withTempDir "tc-stackage-progress-download-failure" $ \dir -> do
+    let storeRoot = dir </> "store"
+        spec = PackageSpec "demo" "0.1.0.0"
+        resolver =
+          DependencyResolver
+            { resolverResolveVersion = \name -> fail ("unexpected dependency " <> name),
+              resolverSourcePath = const (fail "download failed")
+            }
+    planCache <- newPackagePlanCache
+    checkCache <- newPackageCheckCache
+
+    (status, sourceFileCount) <- checkOnePackage planCache checkCache resolver storeRoot spec
+
+    assertEqual "source file count" 0 sourceFileCount
+    assertSkipped status
 
 test_skipsDependencyPlanningFailure :: IO ()
 test_skipsDependencyPlanningFailure =

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -7,6 +7,7 @@ module Aihc.Hackage.Cabal
 
     -- * Component file discovery
     collectComponentFiles,
+    collectLibraryFiles,
 
     -- * Condition evaluation
     conditionEvaluator,
@@ -135,16 +136,28 @@ data FileInfo = FileInfo
 -- component whose @buildable@ flag is true.
 collectComponentFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
 collectComponentFiles gpd packageRoot = do
+  libraryFiles <- collectLibraryFiles gpd packageRoot
+  executableFiles <- collectExecutableFiles gpd packageRoot
+  pure (dedupeFiles (libraryFiles <> executableFiles))
+
+-- | Collect source files from buildable library components only.
+collectLibraryFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
+collectLibraryFiles gpd packageRoot = do
   let evalCond = conditionEvaluator gpd
       pkgDescr = packageDescription gpd
       libraryTrees = maybe [] (pure . (LMainLibName,)) (condLibrary gpd) <> map (first LSubLibName) (condSubLibraries gpd)
-      executableTrees = condExecutables gpd
 
   libraryFiles <- fmap concat (mapM (uncurry (libraryFilesFor pkgDescr evalCond packageRoot)) libraryTrees)
-  executableFiles <- fmap concat (mapM (uncurry (executableFilesFor pkgDescr evalCond packageRoot)) executableTrees)
+  pure (dedupeFiles libraryFiles)
 
-  let allFiles = libraryFiles <> executableFiles
-  pure (dedupeFiles allFiles)
+collectExecutableFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
+collectExecutableFiles gpd packageRoot = do
+  let evalCond = conditionEvaluator gpd
+      pkgDescr = packageDescription gpd
+      executableTrees = condExecutables gpd
+
+  executableFiles <- fmap concat (mapM (uncurry (executableFilesFor pkgDescr evalCond packageRoot)) executableTrees)
+  pure (dedupeFiles executableFiles)
 
 first :: (a -> c) -> (a, b) -> (c, b)
 first f (a, b) = (f a, b)


### PR DESCRIPTION
## Summary

- add library-only Cabal source discovery for the install pipeline
- exclude executable dependencies and source files from package installation
- treat dependencies on the current package internal libraries as intra-package edges instead of recursive installs
- add an empty system-cxx-std-lib-1.0 core provider for the compiler virtual C++ standard-library dependency
- preserve root library source size when recursive dependency planning fails
- sort failing packages by total active library source lines instead of file count
- classify packages with failed dependencies or unavailable source downloads as skipped
- report only failures originating in downloaded root packages
- add regression coverage for library-only planning, virtual-package resolution, size reporting, dependency failures, download failures, and root failures

## Root cause

The installer flattened library and executable build-depends entries into one package-level dependency graph. Executables commonly depend on their package main library, and internal sublibrary dependencies are represented with the enclosing package name, so both forms became false recursive package dependencies.

The snapshot resolver also treated system-cxx-std-lib as a missing Stackage package even though it is a compiler-provided virtual package with no Haskell module surface.

Finally, tc-stackage-progress hardcoded source size to zero when dependency planning raised an exception, measured size only as a file count, and classified dependency or source-download failures as compiler failures of every affected root package.

## Impact

The install pipeline now plans, parses, resolves, type-checks, and desugars libraries only. Executables remain out of scope until binary installation is implemented. The virtual C++ standard-library dependency resolves locally without downloading or compiling source modules.

Stackage type-check progress for LTS 24.33 increases from **35 / 3427** to **102 / 3427**. The latest run reports **275 root failures** and **3050 skipped packages**. Propagated dependency errors and unavailable packages are absent from the failure list. The smallest failures are ranked by source lines: packcheck at 5 lines, type-equality at 7, and unidecode at 12. README progress counts are intentionally unchanged because they are cron-managed.

## Validation

- cabal test -v0 aihc:spec --test-options="--pattern library --hide-successes"
- cabal test -v0 aihc:spec --test-options="--pattern system-cxx-std-lib --hide-successes"
- cabal test -v0 aihc-dev:spec --test-options="--pattern stackage --hide-successes"
- just fmt
- just check
- cabal run -v0 aihc-dev -- tc-stackage-progress --jobs 10 --top 10