### PR TITLE
feat(repl): add type command

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -40,6 +40,7 @@ import Aihc.Tc
     TyVarId (..),
     TypeScheme (..),
     Unique (..),
+    renderTcSignature,
     renderTcType,
     tcModuleBindings,
     tcModuleDiagnostics,
@@ -219,7 +220,7 @@ handleTypeCommand session expression =
   pure . ReplContinue . Just $
     case typecheckExpression session (T.pack expression) of
       Left err -> renderReplError err
-      Right checked -> expression <> " :: " <> renderReplType (checkedType checked)
+      Right checked -> renderTcSignature (T.pack expression) (checkedType checked)
 
 replCommandArgument :: String -> String -> Maybe String
 replCommandArgument command input =
@@ -228,19 +229,6 @@ replCommandArgument command input =
     Just rest@(first : _)
       | isSpace first -> Just (trim rest)
     _ -> Nothing
-
-renderReplType :: TcType -> String
-renderReplType =
-  T.unpack
-    . T.replace "∀" "forall"
-    . T.replace "⇒" "=>"
-    . T.replace "→" "->"
-    . T.pack
-    . renderTcType
-    . stripOuterForalls
-  where
-    stripOuterForalls (TcForAllTy _ body) = stripOuterForalls body
-    stripOuterForalls ty = ty
 
 handleSetCommand :: ReplSession -> String -> IO ReplStep
 handleSetCommand session rawCommand =

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -107,6 +107,13 @@ data ReplStep
   | ReplExit !(Maybe String)
   deriving (Eq, Show)
 
+data CheckedExpression = CheckedExpression
+  { checkedExpr :: !Expr,
+    checkedResolvedModule :: !Module,
+    checkedTcModule :: !Module,
+    checkedType :: !TcType
+  }
+
 runRepl :: Maybe FilePath -> IO ()
 runRepl maybeStoreRoot = do
   session <- loadReplSession maybeStoreRoot
@@ -151,6 +158,8 @@ handleReplInput session input =
         ":?" -> pure (ReplContinue (Just helpText))
         ":set" -> ReplContinue . Just . renderReplSettings <$> readIORef (replSettings session)
         _ | Just command <- stripPrefix ":set " trimmedInput -> handleSetCommand session command
+        _ | Just expression <- replCommandArgument ":type" trimmedInput -> handleTypeCommand session expression
+        _ | Just expression <- replCommandArgument ":t" trimmedInput -> handleTypeCommand session expression
         command@(':' : _) -> pure (ReplContinue (Just ("unknown command: " <> command)))
         _ -> do
           result <- evaluateExpression session (T.pack trimmedInput)
@@ -160,28 +169,12 @@ evaluateExpression :: ReplSession -> Text -> IO (Either ReplError Text)
 evaluateExpression session input = do
   settings <- readIORef (replSettings session)
   pure $ do
-    expr <-
-      case parseExpr defaultConfig {parserSourceName = "<repl>"} input of
-        ParseOk parsed -> Right parsed
-        ParseErr _ -> Left ReplParseError
-    let parsedModule = replModule expr
-        resolved = resolveWithDeps (replModuleExports session) [parsedModule]
-    case resolveErrors resolved of
-      [] -> pure ()
-      errors -> Left (ReplResolveError errors)
-    resolvedModule <-
-      case resolvedModules resolved of
-        [modu] -> Right modu
-        _ -> Left (ReplResolveError [ResolveNotImplemented "REPL resolver returned no module"])
-    let tcResult = typecheckModuleWithEnv (replImportedTerms session) resolvedModule
-    if tcModuleSuccess tcResult
-      then pure ()
-      else Left (ReplTypeError (map show (tcModuleDiagnostics tcResult)))
-    inferredType <-
-      case find ((== replBindingName) . tbName) (tcModuleBindings tcResult) of
-        Just binding -> Right (tbType binding)
-        Nothing -> Left (ReplTypeError ["missing inferred type for " <> T.unpack replBindingName])
-    let allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
+    checked <- typecheckExpression session input
+    let expr = checkedExpr checked
+        resolvedModule = checkedResolvedModule checked
+        tcResult = checkedTcModule checked
+        inferredType = checkedType checked
+        allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
         dsResult = desugarModuleWithBindings allBindings tcResult resolvedModule
     if dsSuccess dsResult
       then pure ()
@@ -189,6 +182,65 @@ evaluateExpression session input = do
     value <- mapLeft (ReplEvalError . show) (evalProgramBinding replBindingName (concatPrograms [replDependencyProgram session, dsProgram dsResult]))
     renderedValue <- mapLeft (ReplEvalError . show) (renderValue value)
     Right (renderEvaluation settings expr inferredType dsResult renderedValue)
+
+typecheckExpression :: ReplSession -> Text -> Either ReplError CheckedExpression
+typecheckExpression session input = do
+  expr <-
+    case parseExpr defaultConfig {parserSourceName = "<repl>"} input of
+      ParseOk parsed -> Right parsed
+      ParseErr _ -> Left ReplParseError
+  let parsedModule = replModule expr
+      resolved = resolveWithDeps (replModuleExports session) [parsedModule]
+  case resolveErrors resolved of
+    [] -> pure ()
+    errors -> Left (ReplResolveError errors)
+  resolvedModule <-
+    case resolvedModules resolved of
+      [modu] -> Right modu
+      _ -> Left (ReplResolveError [ResolveNotImplemented "REPL resolver returned no module"])
+  let tcResult = typecheckModuleWithEnv (replImportedTerms session) resolvedModule
+  if tcModuleSuccess tcResult
+    then pure ()
+    else Left (ReplTypeError (map show (tcModuleDiagnostics tcResult)))
+  inferredType <-
+    case find ((== replBindingName) . tbName) (tcModuleBindings tcResult) of
+      Just binding -> Right (tbType binding)
+      Nothing -> Left (ReplTypeError ["missing inferred type for " <> T.unpack replBindingName])
+  Right
+    CheckedExpression
+      { checkedExpr = expr,
+        checkedResolvedModule = resolvedModule,
+        checkedTcModule = tcResult,
+        checkedType = inferredType
+      }
+
+handleTypeCommand :: ReplSession -> String -> IO ReplStep
+handleTypeCommand session expression =
+  pure . ReplContinue . Just $
+    case typecheckExpression session (T.pack expression) of
+      Left err -> renderReplError err
+      Right checked -> expression <> " :: " <> renderReplType (checkedType checked)
+
+replCommandArgument :: String -> String -> Maybe String
+replCommandArgument command input =
+  case stripPrefix command input of
+    Just "" -> Just ""
+    Just rest@(first : _)
+      | isSpace first -> Just (trim rest)
+    _ -> Nothing
+
+renderReplType :: TcType -> String
+renderReplType =
+  T.unpack
+    . T.replace "∀" "forall"
+    . T.replace "⇒" "=>"
+    . T.replace "→" "->"
+    . T.pack
+    . renderTcType
+    . stripOuterForalls
+  where
+    stripOuterForalls (TcForAllTy _ body) = stripOuterForalls body
+    stripOuterForalls ty = ty
 
 handleSetCommand :: ReplSession -> String -> IO ReplStep
 handleSetCommand session rawCommand =
@@ -310,7 +362,8 @@ helpText =
   unlines
     [ "Commands:",
       "  :quit, :q  Exit the REPL",
-      "  :help, :?  Show this help"
+      "  :help, :?  Show this help",
+      "  :type, :t  Show an expression's type"
     ]
 
 trim :: String -> String

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -104,8 +104,16 @@ main =
             assertEqual "step" (ReplContinue Nothing) step,
           testCase "reports unknown commands" $ do
             session <- testReplSession
-            step <- handleReplInput session ":type"
-            assertEqual "step" (ReplContinue (Just "unknown command: :type")) step,
+            step <- handleReplInput session ":unknown"
+            assertEqual "step" (ReplContinue (Just "unknown command: :unknown")) step,
+          testCase "reports expression types with long and short commands" $ do
+            session <- loadReplSession Nothing
+            longStep <- handleReplInput session ":type True"
+            assertEqual "long command" (ReplContinue (Just "True :: Bool")) longStep
+            shortStep <- handleReplInput session ":t not"
+            assertEqual "short command" (ReplContinue (Just "not :: Bool -> Bool")) shortStep
+            polymorphicStep <- handleReplInput session ":t \\x -> x"
+            assertEqual "polymorphic expression" (ReplContinue (Just "\\x -> x :: a -> a")) polymorphicStep,
           testCase "evaluates string expressions through the pipeline" $ do
             session <- testReplSession
             step <- handleReplInput session "\"hello world\""

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -109,11 +109,11 @@ main =
           testCase "reports expression types with long and short commands" $ do
             session <- loadReplSession Nothing
             longStep <- handleReplInput session ":type True"
-            assertEqual "long command" (ReplContinue (Just "True :: Bool")) longStep
+            assertEqual "long command" (ReplContinue (Just "True ∷ Bool")) longStep
             shortStep <- handleReplInput session ":t not"
-            assertEqual "short command" (ReplContinue (Just "not :: Bool -> Bool")) shortStep
+            assertEqual "short command" (ReplContinue (Just "not ∷ Bool → Bool")) shortStep
             polymorphicStep <- handleReplInput session ":t \\x -> x"
-            assertEqual "polymorphic expression" (ReplContinue (Just "\\x -> x :: a -> a")) polymorphicStep,
+            assertEqual "polymorphic expression" (ReplContinue (Just "\\x -> x ∷ ∀ a. a → a")) polymorphicStep,
           testCase "evaluates string expressions through the pipeline" $ do
             session <- testReplSession
             step <- handleReplInput session "\"hello world\""


### PR DESCRIPTION
## Summary

- add `:type` and `:t` REPL commands that parse, resolve, and type-check expressions without evaluating them
- render inferred signatures with AIHC's native Unicode type syntax, including `∷`, `→`, and `∀`
- document the commands in REPL help and cover constructors, functions, and polymorphic expressions

## Validation

- `just fmt`
- `just check`
- CLI smoke test for `:type True` and `:t not` with Unicode signatures

## Progress counts

- No language-progress fixture counts changed; one focused CLI regression test was added.
