### PR TITLE
fix(fc): desugar do notation through bind

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -27,6 +27,7 @@ import Aihc.Parser.Syntax
   ( CaseAlt (..),
     CompStmt (..),
     Decl (..),
+    DoStmt (..),
     Expr (..),
     LambdaCaseAlt (..),
     Match (..),
@@ -42,6 +43,7 @@ import Aihc.Parser.Syntax
     mkName,
     peelCompStmtAnn,
     peelDeclAnn,
+    peelDoStmtAnn,
     peelLiteralAnn,
     peelPatternAnn,
     qualifyName,
@@ -471,6 +473,7 @@ dsAnnotatedExpr tcAnn inner =
     ELetDecls decls body -> dsLetDecls decls (dsExpr body)
     EList elems -> dsList tcAnn elems
     EListComp body quals -> dsListComp tcAnn body quals
+    EDo stmts Surface.DoPlain -> dsDo stmts
     ETuple flavor elems -> dsTuple flavor tcAnn elems
     ELambdaPats pats body -> dsLambda pats body
     ELambdaCase alts -> dsLambdaCase alts
@@ -479,6 +482,70 @@ dsAnnotatedExpr tcAnn inner =
     EInfix lhs op rhs -> dsInfix lhs op rhs
     ECase scrut alts -> dsCase scrut alts
     _ -> desugarBug ("unsupported annotated expression form after type checking: " <> take 80 (show inner))
+
+dsDo :: [DoStmt Expr] -> DsM FcExpr
+dsDo stmts =
+  case stmts of
+    [] -> desugarBug "cannot desugar an empty do block"
+    [stmt] ->
+      case peelDoStmtAnn stmt of
+        DoExpr body -> dsExpr body
+        other -> desugarBug ("unsupported final do statement after type checking: " <> take 80 (show other))
+    stmt : rest ->
+      case peelDoStmtAnn stmt of
+        DoLetDecls decls -> dsLetDecls decls (dsDo rest)
+        DoBind pat action -> dsDoBind stmt action (dsDoPatternContinuation pat rest)
+        DoExpr action -> dsDoBind stmt action (dsDoDiscardContinuation stmt rest)
+        other -> desugarBug ("unsupported do statement after type checking: " <> take 80 (show other))
+
+dsDoBind :: DoStmt Expr -> Expr -> DsM FcExpr -> DsM FcExpr
+dsDoBind stmt action continuation = do
+  (tcAnn, resolution) <- requiredDoBindOccurrence stmt
+  bind <- dsAnnotatedVar tcAnn (resolvedAnnotationName resolution) (EVar (resolvedAnnotationName resolution))
+  action' <- dsExpr action
+  FcApp (FcApp bind action') <$> continuation
+
+dsDoPatternContinuation :: Pattern -> [DoStmt Expr] -> DsM FcExpr
+dsDoPatternContinuation pat rest = do
+  argTy <- lambdaPatternTypeRequired pat
+  arg <- freshInternalVar "_do" argTy
+  body <-
+    case directPatternBindings pat arg of
+      Just bindings -> withLocals bindings (dsDo rest)
+      Nothing -> do
+        failure <- noPatternMatch [arg]
+        dsMatchPattern arg pat (dsDo rest) failure
+  pure (FcLam arg body)
+
+dsDoDiscardContinuation :: DoStmt Expr -> [DoStmt Expr] -> DsM FcExpr
+dsDoDiscardContinuation stmt rest = do
+  (tcAnn, _) <- requiredDoBindOccurrence stmt
+  argTy <- doBindArgumentType tcAnn
+  arg <- freshInternalVar "_do" argTy
+  FcLam arg <$> dsDo rest
+
+doBindArgumentType :: TcAnnotation -> DsM TcType
+doBindArgumentType tcAnn =
+  case tcAnnType tcAnn of
+    TcFunTy _ (TcFunTy (TcFunTy argTy _) _) -> pure argTy
+    ty -> desugarBug ("unexpected >>= type while desugaring do notation: " <> show ty)
+
+requiredDoBindOccurrence :: DoStmt Expr -> DsM (TcAnnotation, ResolutionAnnotation)
+requiredDoBindOccurrence stmt =
+  case doBindOccurrence stmt of
+    Just occurrence -> pure occurrence
+    Nothing -> desugarBug ("missing >>= occurrence annotation while desugaring do notation: " <> take 80 (show stmt))
+
+doBindOccurrence :: DoStmt Expr -> Maybe (TcAnnotation, ResolutionAnnotation)
+doBindOccurrence = go Nothing Nothing
+  where
+    go maybeTc maybeResolution stmt =
+      case stmt of
+        DoAnn ann inner ->
+          let maybeTc' = (fromAnnotation ann :: Maybe TcAnnotation) <|> maybeTc
+              maybeResolution' = (fromAnnotation ann :: Maybe ResolutionAnnotation) <|> maybeResolution
+           in go maybeTc' maybeResolution' inner
+        _ -> (,) <$> maybeTc <*> maybeResolution
 
 dsOverloadedIntegerLiteral :: TcAnnotation -> ResolutionAnnotation -> Integer -> DsM FcExpr
 dsOverloadedIntegerLiteral tcAnn resolution value = do

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-do-notation.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-do-notation.yaml
@@ -1,0 +1,28 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    runMaybe :: Maybe Bool -> Maybe Bool
+    runMaybe value = do
+      result <- value
+      Just result
+
+    discardMaybe :: Maybe Bool
+    discardMaybe = do
+      Just False
+      Just True
+
+    letMaybe :: Maybe Bool
+    letMaybe = do
+      let result = True
+      Just result
+
+output: |
+  (((Just True),(Just True)),(Just True))
+expression: |
+  ((runMaybe (Just True), discardMaybe), letMaybe)
+status: pass
+reason: desugars do action statements through Prelude >>= while preserving let statements

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -801,25 +801,27 @@ resolveDoStmts stmts = do
         case stmts' of
           [] -> pure (scope, [])
           stmt : rest -> do
-            (scope', stmt') <- resolveDoStmt stmt
+            (scope', stmt') <- resolveDoStmt (null rest) stmt
             (scope'', rest') <- go scope' rest
             pure (scope'', stmt' : rest')
 
-resolveDoStmt :: DoStmt Expr -> ResolveM (Scope, DoStmt Expr)
-resolveDoStmt stmt =
+resolveDoStmt :: Bool -> DoStmt Expr -> ResolveM (Scope, DoStmt Expr)
+resolveDoStmt isLast stmt =
   case stmt of
     DoAnn ann inner -> do
-      (scope', inner') <- withPushedSpan ann (resolveDoStmt inner)
+      (scope', inner') <- withPushedSpan ann (resolveDoStmt isLast inner)
       pure (scope', DoAnn ann inner')
     DoExpr body -> do
       scope <- currentScope
       body' <- resolveExpr body
-      pure (scope, DoExpr body')
+      stmt' <- annotateDoBind isLast (DoExpr body')
+      pure (scope, stmt')
     DoBind pat body -> do
       scope <- currentScope
       body' <- resolveExpr body
       (patScope, pat') <- bindPattern pat
-      pure (unionScope patScope scope, DoBind pat' body')
+      stmt' <- annotateDoBind isLast (DoBind pat' body')
+      pure (unionScope patScope scope, stmt')
     DoLetDecls decls -> do
       scope <- currentScope
       (binderAnnotations, localScope) <- allocateLocalDeclBinders decls
@@ -829,6 +831,14 @@ resolveDoStmt stmt =
       scope <- currentScope
       (_, stmts') <- resolveDoStmts stmts
       pure (scope, DoRecStmt stmts')
+
+annotateDoBind :: Bool -> DoStmt Expr -> ResolveM (DoStmt Expr)
+annotateDoBind isLast stmt
+  | isLast = pure stmt
+  | otherwise = do
+      sp <- currentSpan
+      bindAnn <- syntaxTermAnnotation sp ">>="
+      pure (DoAnn (mkAnnotation bindAnn) stmt)
 
 resolveArithSeq :: ArithSeq -> ResolveM ArithSeq
 resolveArithSeq arithSeq =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -222,6 +222,11 @@ isFromIntegerResolution resolution =
   resolutionNamespace resolution == ResolutionNamespaceTerm
     && resolutionName resolution == "fromInteger"
 
+isDoBindResolution :: ResolutionAnnotation -> Bool
+isDoBindResolution resolution =
+  resolutionNamespace resolution == ResolutionNamespaceTerm
+    && resolutionName resolution == ">>="
+
 annotatePendingExpr :: PendingTcAnnotation -> Expr -> Expr
 annotatePendingExpr ann =
   EAnn (mkAnnotation ann)
@@ -558,6 +563,10 @@ inferLastDoStmt ambient stmt =
 inferDoStmt :: SourceSpan -> DoStmt Expr -> [DoStmt Expr] -> TcM ([DoStmt Expr], TcType, [Ct])
 inferDoStmt ambient stmt rest =
   case stmt of
+    DoAnn ann inner
+      | Just resolution <- fromAnnotation @ResolutionAnnotation ann,
+        isDoBindResolution resolution ->
+          inferResolvedDoStmt ambient ann resolution inner rest
     DoAnn ann inner -> do
       (stmts', resultTy, cts) <- inferDoStmt (doStmtSpan stmt `orSourceSpan` ambient) inner rest
       case stmts' of
@@ -604,6 +613,50 @@ inferDoStmt ambient stmt rest =
       emitError ambient (OtherError "recursive do statements are unsupported in TC MVP")
       (rest', resultTy, cts) <- inferDoStmts ambient rest
       pure (stmt : rest', resultTy, cts)
+
+inferResolvedDoStmt :: SourceSpan -> Annotation -> ResolutionAnnotation -> DoStmt Expr -> [DoStmt Expr] -> TcM ([DoStmt Expr], TcType, [Ct])
+inferResolvedDoStmt ambient resolutionAnn resolution stmt rest =
+  case stmt of
+    DoBind pat action -> do
+      itemTy <- freshMetaTv
+      (action', actionTy, actionCts) <- inferExprAt ambient action
+      patCheck <- checkPattern ambient pat itemTy
+      (rest', resultTy, restCts) <-
+        withPatternBindings (pcBindings patCheck) (inferDoStmts ambient rest)
+      (pending, methodCts) <- inferDoBindMethod ambient resolution actionTy itemTy resultTy
+      let pat' = annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)
+          stmt' = DoAnn (mkAnnotation pending) (DoAnn resolutionAnn (DoBind pat' action'))
+      pure (stmt' : rest', resultTy, actionCts <> pcWantedCts patCheck <> restCts <> methodCts)
+    DoExpr action -> do
+      itemTy <- freshMetaTv
+      (action', actionTy, actionCts) <- inferExprAt ambient action
+      (rest', resultTy, restCts) <- inferDoStmts ambient rest
+      (pending, methodCts) <- inferDoBindMethod ambient resolution actionTy itemTy resultTy
+      let stmt' = DoAnn (mkAnnotation pending) (DoAnn resolutionAnn (DoExpr action'))
+      pure (stmt' : rest', resultTy, actionCts <> restCts <> methodCts)
+    _ -> do
+      emitError ambient (OtherError "internal do-bind annotation on a non-action statement")
+      inferDoStmt ambient stmt rest
+
+inferDoBindMethod :: SourceSpan -> ResolutionAnnotation -> TcType -> TcType -> TcType -> TcM (PendingTcAnnotation, [Ct])
+inferDoBindMethod sp resolution actionTy itemTy resultTy = do
+  mBinder <- lookupResolvedTerm ">>=" (resolutionTarget resolution)
+  case mBinder of
+    Just (TcIdBinder scheme _) -> do
+      inst <- instantiateWithArgs scheme
+      methodCts <- mapM (predToCt sp ">>=") (instPreds inst)
+      ev <- freshEvVar
+      let expectedTy = TcFunTy actionTy (TcFunTy (TcFunTy itemTy resultTy) resultTy)
+          methodEq = mkWantedCt (EqPred (instType inst) expectedTy) ev (OccurrenceOf ">>=") sp
+          pending = pendingAnnotation (instType inst) (instTypeArgs inst) (map ctEvVar methodCts) []
+      pure (pending, methodCts <> [methodEq])
+    Just (TcMonoIdBinder ty) -> do
+      ev <- freshEvVar
+      let expectedTy = TcFunTy actionTy (TcFunTy (TcFunTy itemTy resultTy) resultTy)
+          methodEq = mkWantedCt (EqPred ty expectedTy) ev (OccurrenceOf ">>=") sp
+      pure (pendingAnnotation ty [] [] [], [methodEq])
+    Nothing ->
+      abortTc ("resolved >>= missing from type environment: " <> show (resolutionTarget resolution))
 
 wantedDoEq :: SourceSpan -> TcType -> TcType -> TcM Ct
 wantedDoEq sp actual expected = do

--- a/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
@@ -1,6 +1,6 @@
 annotated:
 - |-
-  {-# LANGUAGE KindSignatures #-}
+  {-# LANGUAGE KindSignatures, RebindableSyntax #-}
   module Test where
 
   data Type
@@ -15,7 +15,8 @@ annotated:
     pure :: a -> m a
 
   class Applicative m => Monad (m :: Type -> Type) where
-  └─ class methods: =<< ∷ ∀ m a b. (Monad m) ⇒ (a → m b) → m a → m b, return ∷ ∀ m a. (Monad m) ⇒ a → m a
+  └─ class methods: >>= ∷ ∀ m a b. (Monad m) ⇒ m a → (a → m b) → m b, =<< ∷ ∀ m a b. (Monad m) ⇒ (a → m b) → m a → m b, return ∷ ∀ m a. (Monad m) ⇒ a → m a
+    (>>=) :: m a -> (a -> m b) -> m b
     (=<<) :: (a -> m b) -> m a -> m b
     return :: a -> m a
 
@@ -28,6 +29,7 @@ annotated:
   └─ type: ∀ m a. (Monad m) ⇒ m Bool → (a → m a) → a → m a
     p' <- p
     └─ type: Bool
+    └─ type: m Bool → (Bool → m a) → m a; type-args: m, Bool, a; evidence: given Monad m
     if p' then almostFixM p f =<< f x
                │              └─ type: (a → m a) → m a → m a; type-args: m, a, a; evidence: given Monad m
                └─ type: m Bool → (a → m a) → a → m a; type-args: m, a; evidence: given Monad m
@@ -35,9 +37,10 @@ annotated:
                └─ type: a → m a; type-args: m, a; evidence: given Monad m
 extensions:
 - KindSignatures
+- RebindableSyntax
 modules:
 - |
-  {-# LANGUAGE KindSignatures #-}
+  {-# LANGUAGE KindSignatures, RebindableSyntax #-}
   module Test where
 
   data Type
@@ -47,6 +50,7 @@ modules:
     pure :: a -> m a
 
   class Applicative m => Monad (m :: Type -> Type) where
+    (>>=) :: m a -> (a -> m b) -> m b
     (=<<) :: (a -> m b) -> m a -> m b
     return :: a -> m a
 
@@ -55,5 +59,5 @@ modules:
     p' <- p
     if p' then almostFixM p f =<< f x
           else return x
-reason: ordinary do notation preserves the monad constructor across bind statements
+reason: do notation records the instantiated >>= method and preserves the monad constructor
 status: pass


### PR DESCRIPTION
## Summary

- resolve the implicit `(>>=)` occurrence used by each non-final do action
- instantiate and solve its type arguments and `Monad` evidence in `aihc-tc`
- lower plain do blocks in `aihc-fc` to nested Prelude bind applications, including pattern, discarded-action, and let statements
- add type-checker annotation coverage and an end-to-end Maybe evaluation fixture

## Root cause

Type checking preserved annotated `EDo` nodes, but the annotation did not carry the resolved and instantiated bind method needed downstream, and `aihc-fc` had no `EDo` lowering case. As a result, packages such as `almost-fix-0.0.2` reached the generic unsupported-expression error during interface compilation.

## Impact

`aihc install almost-fix` now compiles the package interface and emits its System FC artifact. Ordinary do notation uses the Prelude `(>>=)` occurrence and its solved dictionary evidence.

## Progress counts

- FC evaluation/spec cases: 71 -> 72
- TC annotated cases: unchanged at 84

## Validation

- `cabal test -v0 aihc-tc:spec --test-options='--pattern do-notation-monad.yaml --hide-successes'`
- `cabal test -v0 aihc-fc:spec --test-options='--pattern prelude-do-notation --hide-successes'`
- `cabal run -v0 aihc -- install almost-fix`
- `just fmt`
- `just check`
