### PR TITLE
feat(fmt): compact safe pretty-printer layouts

### DIFF
--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/compact-safe-separators.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/compact-safe-separators.yaml
@@ -7,15 +7,19 @@ formatters:
       module Main where
       xs = [1, 2, 3]
       f = case True of {
-              True -> 1;
-              False | otherwise
-                     -> 0 }
+        True -> 1;
+        False | otherwise
+         -> 0 }
       g = \case {
-              True -> 1;
-              False | otherwise
-                     -> 0 }
+        True -> 1;
+        False | otherwise
+         -> 0 }
+      h = case True of {
+        True -> do {
+            pure
+              1 } }
       q = [d|
-            x = 1 |]
+        x = 1 |]
       empty = [d| |]
     status: pass
 input: |
@@ -23,5 +27,6 @@ input: |
   xs=[1,2,3]
   f = case True of { True -> 1; False | otherwise -> 0 }
   g = \case { True -> 1; False | otherwise -> 0 }
+  h = case True of { True -> do { pure 1 } }
   q = [d| x=1 |]
   empty = [d| |]

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/compact-safe-separators.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/compact-safe-separators.yaml
@@ -1,0 +1,27 @@
+extensions:
+- LambdaCase
+- TemplateHaskell
+formatters:
+  aihc-fmt:
+    output: |
+      module Main where
+      xs = [1, 2, 3]
+      f = case True of {
+              True -> 1;
+              False | otherwise
+                     -> 0 }
+      g = \case {
+              True -> 1;
+              False | otherwise
+                     -> 0 }
+      q = [d|
+            x = 1 |]
+      empty = [d| |]
+    status: pass
+input: |
+  module Main where
+  xs=[1,2,3]
+  f = case True of { True -> 1; False | otherwise -> 0 }
+  g = \case { True -> 1; False | otherwise -> 0 }
+  q = [d| x=1 |]
+  empty = [d| |]

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/explicit-layout.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/explicit-layout.yaml
@@ -4,21 +4,21 @@ formatters:
     output: |
       module Main where {
       main = do {
-              x <- pure
-                  1;
-              y <- pure
-                  2;
-              pure
-                  y };
+        x <- pure
+          1;
+        y <- pure
+          2;
+        pure
+          y };
       f v = case v of {
-              True -> 1;
-              False -> 0 };
+        True -> 1;
+        False -> 0 };
       g = let { a = 1;
               b = 2 }
             in a;
       h x = x
-          where {
-            y = 1 } }
+        where {
+          y = 1 } }
     status: pass
 input: |
   module Main where { main = do { x <- pure 1; y <- pure 2; pure y }; f v = case v of { True -> 1; False -> 0 }; g = let { a = 1; b = 2 } in a; h x = x where { y = 1 } }

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/explicit-layout.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/explicit-layout.yaml
@@ -1,9 +1,6 @@
 extensions: []
-input: |
-  module Main where { main = do { x <- pure 1; y <- pure 2; pure y }; f v = case v of { True -> 1; False -> 0 }; g = let { a = 1; b = 2 } in a; h x = x where { y = 1 } }
 formatters:
   aihc-fmt:
-    status: pass
     output: |
       module Main where {
       main = do {
@@ -14,13 +11,14 @@ formatters:
               pure
                   y };
       f v = case v of {
-              True ->
-                  1;
-              False ->
-                  0 };
+              True -> 1;
+              False -> 0 };
       g = let { a = 1;
               b = 2 }
             in a;
       h x = x
           where {
             y = 1 } }
+    status: pass
+input: |
+  module Main where { main = do { x <- pure 1; y <- pure 2; pure y }; f v = case v of { True -> 1; False -> 0 }; g = let { a = 1; b = 2 } in a; h x = x where { y = 1 } }

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/top-level-decls.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/basic/top-level-decls.yaml
@@ -1,36 +1,36 @@
 extensions: []
-input: |
-  module Main where
-  f x=x+1
-  g y = f y
 formatters:
   aihc-fmt:
-    status: pass
     output: |
       module Main where
       f x = x
-            + 1
+       + 1
       g y = f
-              y
-  ormolu:
+        y
     status: pass
-    output: |
-      module Main where
-
-      f x = x + 1
-
-      g y = f y
   hindent:
-    status: pass
     output: |
       module Main where
 
       f x = x + 1
 
       g y = f y
-  stylish-haskell:
     status: pass
+  ormolu:
+    output: |
+      module Main where
+
+      f x = x + 1
+
+      g y = f y
+    status: pass
+  stylish-haskell:
     output: |
       module Main where
       f x=x+1
       g y = f y
+    status: pass
+input: |
+  module Main where
+  f x=x+1
+  g y = f y

--- a/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/nested-comment.yaml
+++ b/bin/aihc-fmt/test/Test/Fixtures/fmt/comments/nested-comment.yaml
@@ -1,37 +1,37 @@
 extensions: []
+formatters:
+  aihc-fmt:
+    output: |
+      module Main where
+      f = x {- nested -}
+        where
+          x = 1
+    status: pass
+  hindent:
+    output: |
+      module Main where
+
+      f = x {- nested -}
+        where
+          x = 1
+    status: pass
+  ormolu:
+    output: |
+      module Main where
+
+      f = x {- nested -}
+        where
+          x = 1
+    status: pass
+  stylish-haskell:
+    output: |
+      module Main where
+      f = x {- nested -}
+        where
+          x = 1
+    status: pass
 input: |
   module Main where
   f = x {- nested -}
     where
       x = 1
-formatters:
-  aihc-fmt:
-    status: pass
-    output: |
-      module Main where
-      f = x {- nested -}
-        where
-            x = 1
-  ormolu:
-    status: pass
-    output: |
-      module Main where
-
-      f = x {- nested -}
-        where
-          x = 1
-  hindent:
-    status: pass
-    output: |
-      module Main where
-
-      f = x {- nested -}
-        where
-          x = 1
-  stylish-haskell:
-    status: pass
-    output: |
-      module Main where
-      f = x {- nested -}
-        where
-          x = 1

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1142,7 +1142,7 @@ prettyConstructorUName name
 -- nodes in the correct positions (inserted by 'addExprParens').
 --
 -- >>> let expr = EApp (EVar "f") (EParen (EInfix (EVar "x") "+" (EVar "y"))) in (renderDoc (prettyExpr expr), show (shorthand expr))
--- ("f\n  (x\n  + y)","EApp (EVar \"f\") (EParen (EInfix (EVar \"x\") \"+\" (EVar \"y\")))")
+-- ("f\n  (x\n   + y)","EApp (EVar \"f\") (EParen (EInfix (EVar \"x\") \"+\" (EVar \"y\")))")
 prettyExpr :: Expr -> Doc ann
 prettyExpr expr =
   case expr of

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -401,18 +401,13 @@ prettyIndentedWhereClause Nothing = mempty
 prettyIndentedWhereClause whereDecls = hardline <> indent 2 (prettyWhereClauseBare whereDecls)
 
 prettyTHDeclQuote :: [Decl] -> Doc ann
-prettyTHDeclQuote [] =
-  hang 2 $
-    "[d|"
-      <> hardline
-      <> "|]"
+prettyTHDeclQuote [] = "[d| |]"
 prettyTHDeclQuote decls =
   hang 2 $
     "[d|"
       <> hardline
       <> vsep (concatMap prettyDeclLines decls)
-      <> hardline
-      <> "|]"
+      <+> "|]"
 
 -- | Infix type-family heads use @l \`Op\` r@ with a 'NameConId' operator (e.g.
 -- @\`And\`@), so 'isSymbolicTypeName' is false; 'TypeHeadInfix' already marks
@@ -1268,7 +1263,7 @@ prettyCommaSeparated :: (a -> Doc ann) -> [a] -> Doc ann
 prettyCommaSeparated render items =
   case map render items of
     [] -> mempty
-    rendered -> hang 2 (vsep (punctuate comma rendered))
+    rendered -> hsep (punctuate comma rendered)
 
 prettyBarSeparated :: [Doc ann] -> Doc ann
 prettyBarSeparated items =
@@ -1294,13 +1289,11 @@ prettyCaseAltWith prettyBody (CaseAlt _ pat rhs) = nest 2 $
     UnguardedRhs _ body whereDecls ->
       prettyPattern pat
         <+> "->"
-        <> hardline
-        <> indent 2 (prettyBody body)
+        <+> prettyBody body
         <> prettyIndentedWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
       prettyPattern pat
-        <> hardline
-        <> indent 2 (vsep (map (prettyCaseGuardedRhsBlock prettyBody) grhss))
+        <+> align (vsep (map (prettyCaseGuardedRhsBlock prettyBody) grhss))
         <> prettyIndentedWhereClause whereDecls
 
 prettyCaseAlt :: CaseAlt Expr -> Doc ann
@@ -1315,8 +1308,7 @@ prettyGuardedRhsBodyBlock arrow grhs =
         <> hardline
         <> " "
         <> pretty arrow
-        <> hardline
-        <> indent 2 (prettyExpr body)
+        <+> prettyExpr body
 
 prettyCaseGuardedRhsBlock :: (body -> Doc ann) -> GuardedRhs body -> Doc ann
 prettyCaseGuardedRhsBlock prettyBody grhs =
@@ -1327,8 +1319,7 @@ prettyCaseGuardedRhsBlock prettyBody grhs =
         <> hardline
         <> " "
         <> "->"
-        <> hardline
-        <> indent 2 (prettyBody body)
+        <+> prettyBody body
 
 prettyMultiWayIfRhss :: [GuardedRhs Expr] -> Doc ann
 prettyMultiWayIfRhss rhss = vsep (map (prettyGuardedRhsBodyBlock "->") rhss)
@@ -1361,13 +1352,11 @@ prettyLambdaCaseAlt (LambdaCaseAlt _ pats rhs) = nest 2 $
     UnguardedRhs _ body whereDecls ->
       hsep (map prettyPattern pats)
         <+> "->"
-        <> hardline
-        <> indent 2 (prettyExpr body)
+        <+> prettyExpr body
         <> prettyIndentedWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
       hsep (map prettyPattern pats)
-        <> hardline
-        <> indent 2 (vsep (map (prettyCaseGuardedRhsBlock prettyExpr) grhss))
+        <+> align (vsep (map (prettyCaseGuardedRhsBlock prettyExpr) grhss))
         <> prettyIndentedWhereClause whereDecls
 
 prettyGuardQualifier :: GuardQualifier -> Doc ann
@@ -1511,8 +1500,7 @@ prettyGuardedRhsBlock grhs =
         <+> nest
           2
           ( prettyGuardQualifiersLayout guards
-              <> hardline
-              <> "="
+              <+> "="
               <+> nest 2 (prettyExpr body)
           )
 

--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -44,7 +44,6 @@ import Prettyprinter
     hang,
     hardline,
     hsep,
-    indent,
     nest,
     nesting,
     parens,
@@ -75,7 +74,7 @@ prettyRawText raw
   | otherwise = pretty raw
 
 prettySpliceBody :: Expr -> Doc ann
-prettySpliceBody = nest 2 . prettyExpr
+prettySpliceBody = prettyExpr
 
 -- | Pretty instance for Module - renders to valid Haskell source code.
 instance Pretty Module where
@@ -297,7 +296,7 @@ prettyRole role =
     RoleInfer -> "_"
 
 prettyValueDeclLines :: ValueDecl -> [Doc ann]
-prettyValueDeclLines valueDecl = map (nest 2) $
+prettyValueDeclLines valueDecl =
   case valueDecl of
     PatternBind multTag pat rhs -> [prettyMultiplicityTag multTag <> prettyPattern pat <+> prettyRhs rhs]
     FunctionBind name matches ->
@@ -319,14 +318,13 @@ prettyMultiplicityTag (ExplicitMultiplicityTag ty) = "%" <> prettyType ty <+> me
 -- | Pretty-print a pattern synonym declaration.
 prettyPatSynDecl :: PatSynDecl -> Doc ann
 prettyPatSynDecl ps =
-  hang 2 $
-    hsep
-      ( ["pattern"]
-          <> prettyPatSynLhs (patSynDeclName ps) (patSynDeclArgs ps)
-          <> [dirArrow (patSynDeclDir ps)]
-          <> [prettyPattern (patSynDeclPat ps)]
-          <> prettyPatSynWhere (patSynDeclName ps) (patSynDeclDir ps)
-      )
+  hsep
+    ( ["pattern"]
+        <> prettyPatSynLhs (patSynDeclName ps) (patSynDeclArgs ps)
+        <> [dirArrow (patSynDeclDir ps)]
+        <> [prettyPattern (patSynDeclPat ps)]
+        <> prettyPatSynWhere (patSynDeclName ps) (patSynDeclDir ps)
+    )
   where
     dirArrow PatSynBidirectional = "="
     dirArrow PatSynUnidirectional = "<-"
@@ -347,19 +345,23 @@ prettyPatSynWhere _ PatSynBidirectional = []
 prettyPatSynWhere _ PatSynUnidirectional = []
 prettyPatSynWhere _ (PatSynExplicitBidirectional []) = ["where", spacedBraces mempty]
 prettyPatSynWhere name (PatSynExplicitBidirectional matches) =
-  ["where" <> hardline <> indent 2 (vsep (map (prettyFunctionMatch name) matches))]
+  ["where" <> nest 2 (hardline <> vsep (map (prettyFunctionMatch name) matches))]
 
 prettyFunctionMatchLines :: UnqualifiedName -> Match -> [Doc ann]
 prettyFunctionMatchLines name match =
   case matchRhs match of
     UnguardedRhs {} -> [prettyFunctionMatch name match]
     GuardedRhss _ grhss mWhereDecls ->
-      prettyFunctionHead name (matchHeadForm match) (matchPats match)
-        : map
-          (indent 2)
-          ( map prettyGuardedRhsBlock grhss
-              <> [prettyWhereClauseBare mWhereDecls | isJust mWhereDecls]
-          )
+      [ prettyFunctionHead name (matchHeadForm match) (matchPats match)
+          <> nest
+            2
+            ( hardline
+                <> vsep
+                  ( map prettyGuardedRhsBlock grhss
+                      <> [prettyWhereClauseBare mWhereDecls | isJust mWhereDecls]
+                  )
+            )
+      ]
 
 prettyFunctionMatch :: UnqualifiedName -> Match -> Doc ann
 prettyFunctionMatch name match =
@@ -385,29 +387,27 @@ prettyRhs rhs =
   case rhs of
     UnguardedRhs _ body whereDecls ->
       "="
-        <+> nest 4 (prettyExpr body)
+        <+> prettyExpr body
         <> prettyIndentedWhereClause whereDecls
     GuardedRhss _ guards whereDecls ->
-      hardline <> indent 2 (prettyGuardedRhssBlock guards whereDecls)
+      nest 2 (hardline <> prettyGuardedRhssBlock guards whereDecls)
 
 prettyWhereClauseBare :: Maybe [Decl] -> Doc ann
 prettyWhereClauseBare Nothing = mempty
 prettyWhereClauseBare (Just []) = "where" <+> spacedBraces mempty
 prettyWhereClauseBare (Just decls) =
-  "where" <> hardline <> indent 2 (vsep (concatMap prettyDeclLines decls))
+  "where" <> nest 2 (hardline <> vsep (concatMap prettyDeclLines decls))
 
 prettyIndentedWhereClause :: Maybe [Decl] -> Doc ann
 prettyIndentedWhereClause Nothing = mempty
-prettyIndentedWhereClause whereDecls = hardline <> indent 2 (prettyWhereClauseBare whereDecls)
+prettyIndentedWhereClause whereDecls = nest 2 (hardline <> prettyWhereClauseBare whereDecls)
 
 prettyTHDeclQuote :: [Decl] -> Doc ann
 prettyTHDeclQuote [] = "[d| |]"
 prettyTHDeclQuote decls =
-  hang 2 $
-    "[d|"
-      <> hardline
-      <> vsep (concatMap prettyDeclLines decls)
-      <+> "|]"
+  "[d|"
+    <> nest 2 (hardline <> vsep (concatMap prettyDeclLines decls))
+    <+> "|]"
 
 -- | Infix type-family heads use @l \`Op\` r@ with a 'NameConId' operator (e.g.
 -- @\`And\`@), so 'isSymbolicTypeName' is false; 'TypeHeadInfix' already marks
@@ -550,7 +550,7 @@ prettyPattern pat =
     PCon con typeArgs args -> hsep ([prettyPrefixName con] <> map prettyInvisibleTypeArg typeArgs <> map prettyPattern args)
     PInfix lhs op rhs -> prettyPattern lhs <+> prettyNameInfixOp op <+> prettyPattern rhs
     PView viewExpr inner ->
-      prettyExpr viewExpr <> hardline <> indent 1 ("->" <+> prettyPattern inner)
+      prettyExpr viewExpr <> nest 1 (hardline <> "->" <+> prettyPattern inner)
     PAs name inner -> prettyBinderUName name <> "@" <> prettyPattern inner
     PStrict inner -> "!" <> prettyPattern inner
     PIrrefutable inner -> "~" <> prettyPattern inner
@@ -659,8 +659,7 @@ derivingParts = concatMap derivingPart
 prettyGadtConBlock :: [DataConDecl] -> [DerivingClause] -> Doc ann
 prettyGadtConBlock ctors derivingClauses =
   "where"
-    <> hardline
-    <> indent 2 (vsep (map prettyDataCon ctors <> derivingParts derivingClauses))
+    <> nest 2 (hardline <> vsep (map prettyDataCon ctors <> derivingParts derivingClauses))
 
 derivingPart :: DerivingClause -> [Doc ann]
 derivingPart (DerivingClause strategy classes) =
@@ -853,8 +852,7 @@ prettyClassDecl decl =
         items ->
           headDoc
             <+> "where"
-            <> hardline
-            <> indent 2 (vsep (concatMap prettyClassItemLines items))
+            <> nest 2 (hardline <> vsep (concatMap prettyClassItemLines items))
 
 prettyClassFundeps :: [FunctionalDependency] -> [Doc ann]
 prettyClassFundeps deps =
@@ -926,8 +924,7 @@ prettyInstanceDecl decl =
         items ->
           headDoc
             <+> "where"
-            <> hardline
-            <> indent 2 (vsep (concatMap prettyInstanceItemLines items))
+            <> nest 2 (hardline <> vsep (concatMap prettyInstanceItemLines items))
 
 prettyStandaloneDeriving :: StandaloneDerivingDecl -> Doc ann
 prettyStandaloneDeriving decl =
@@ -1151,7 +1148,7 @@ prettyExpr expr =
   case expr of
     EApp {} -> prettyApp expr
     ETypeApp fn ty ->
-      prettyExpr fn <> hardline <> " " <> prettyTypeAppArg ty
+      nest 2 (prettyExpr fn) <> nest 1 (hardline <> " " <> prettyTypeAppArg ty)
     EVar name -> prettyName name
     ETypeSyntax TypeSyntaxExplicitNamespace ty -> "type" <+> prettyType ty
     ETypeSyntax TypeSyntaxInTerm ty -> prettyType ty
@@ -1173,25 +1170,25 @@ prettyExpr expr =
     ETHSplice body -> "$" <> prettySpliceBody body
     ETHTypedSplice body -> "$$" <> prettySpliceBody body
     EIf cond yes no ->
-      "if" <+> nest 2 (prettyExpr cond <+> "then" <+> prettyExpr yes <+> "else" <+> prettyExpr no)
+      "if" <+> prettyExpr cond <+> "then" <+> prettyExpr yes <+> "else" <+> prettyExpr no
     EMultiWayIf rhss ->
-      "if" <+> hang 3 (prettyMultiWayIfRhss rhss)
+      "if" <+> align (prettyMultiWayIfRhss rhss)
     ELambdaPats pats body ->
-      "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> nest 2 (prettyExpr body)
+      "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyExpr body
     ELambdaCase alts ->
       "\\" <> "case" <> prettyCaseLayout (map prettyCaseAlt alts)
     ELambdaCases alts ->
       "\\" <> "cases" <> prettyCaseLayout (map prettyLambdaCaseAlt alts)
     EInfix lhs op rhs ->
-      prettyExpr lhs <> hardline <> prettyNameInfixOp op <+> prettyExpr rhs
+      nest 2 (prettyExpr lhs) <> nest 1 (hardline <> prettyNameInfixOp op <+> prettyExpr rhs)
     ENegate inner -> "-" <+> prettyExprAtStatementStart inner
     ESectionL lhs op ->
-      prettyExpr lhs <> hardline <> " " <> prettyNameInfixOp op
+      nest 2 (prettyExpr lhs) <> nest 1 (hardline <> " " <> prettyNameInfixOp op)
     ESectionR op rhs -> prettyNameInfixOp op <+> prettyExpr rhs
     ELetDecls decls body ->
       case decls of
         [] -> prettyLetDecls decls <+> "in" <+> prettyExpr body
-        _ -> align (prettyLetDecls decls <> hardline <> indent 2 ("in" <+> prettyExpr body))
+        _ -> align (prettyLetDecls decls <> nest 2 (hardline <> "in" <+> prettyExpr body))
     ECase scrutinee alts ->
       prettyCaseExpr prettyCaseLayout scrutinee alts
     EDo stmts flavor ->
@@ -1220,10 +1217,10 @@ prettyExpr expr =
     EGetFieldProjection fields ->
       "." <> mconcat (punctuate "." (map prettyName fields))
     ETypeSig inner ty ->
-      align (prettyExpr inner <> hardline <> "::" <+> prettyType ty)
+      nest 2 (prettyExpr inner) <> nest 1 (hardline <> "::" <+> prettyType ty)
     EParen inner -> case inner of
       ECase scrutinee alts ->
-        parens (prettyCaseExpr prettyCaseLayoutAligned scrutinee alts)
+        parens (prettyCaseExpr prettyCaseLayout scrutinee alts)
       -- ESectionR with a '#'-starting op renders as "(# ...)" which the lexer
       -- reads as TkSpecialUnboxedLParen when UnboxedTuples/UnboxedSums is on.
       -- A leading space produces "( # ...)" which is unambiguous.
@@ -1241,7 +1238,7 @@ prettyExpr expr =
       let slots = [if i == altIdx then prettyExpr inner else mempty | i <- [0 .. arity - 1]]
        in hsep ["(#", prettyBarSeparated slots, "#)"]
     EProc pat body ->
-      "proc" <+> prettyPattern pat <+> "->" <+> nest 2 (prettyCmd body)
+      "proc" <+> prettyPattern pat <+> "->" <+> prettyCmd body
     EPragma pragma inner ->
       prettyPragma pragma <+> prettyExpr inner
     EAnn _ sub -> prettyExpr sub
@@ -1252,7 +1249,7 @@ prettyApp = prettyAppWith prettyExpr
 prettyAppWith :: (Expr -> Doc ann) -> Expr -> Doc ann
 prettyAppWith prettyFn expr =
   let (fn, args) = flattenApps expr
-   in vsep (prettyFn fn : map (indent 2 . prettyExpr) args)
+   in prettyFn fn <> nest 2 (hardline <> vsep (map prettyExpr args))
   where
     flattenApps = go []
     go args (EAnn _ sub) = go args sub
@@ -1269,7 +1266,7 @@ prettyBarSeparated :: [Doc ann] -> Doc ann
 prettyBarSeparated items =
   case items of
     [] -> mempty
-    firstItem : restItems -> hang 2 (vsep (firstItem : map ("|" <+>) restItems))
+    firstItem : restItems -> hang 1 (vsep (firstItem : map ("|" <+>) restItems))
 
 prettyTupleBody :: TupleFlavor -> Doc ann -> Doc ann
 prettyTupleBody tupleFlavor inner =
@@ -1284,16 +1281,15 @@ prettyBinding field =
     else prettyName (recordFieldName field) <+> "=" <+> prettyExpr (recordFieldValue field)
 
 prettyCaseAltWith :: (body -> Doc ann) -> CaseAlt body -> Doc ann
-prettyCaseAltWith prettyBody (CaseAlt _ pat rhs) = nest 2 $
+prettyCaseAltWith prettyBody (CaseAlt _ pat rhs) =
   case rhs of
     UnguardedRhs _ body whereDecls ->
       prettyPattern pat
         <+> "->"
-        <+> prettyBody body
+        <+> nest 2 (prettyBody body)
         <> prettyIndentedWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
-      prettyPattern pat
-        <+> align (vsep (map (prettyCaseGuardedRhsBlock prettyBody) grhss))
+      prettyGuardedCaseAlt (prettyPattern pat) prettyBody grhss
         <> prettyIndentedWhereClause whereDecls
 
 prettyCaseAlt :: CaseAlt Expr -> Doc ann
@@ -1319,7 +1315,15 @@ prettyCaseGuardedRhsBlock prettyBody grhs =
         <> hardline
         <> " "
         <> "->"
-        <+> prettyBody body
+        <+> nest 2 (prettyBody body)
+
+prettyGuardedCaseAlt :: Doc ann -> (body -> Doc ann) -> [GuardedRhs body] -> Doc ann
+prettyGuardedCaseAlt headDoc prettyBody grhss =
+  case map (prettyCaseGuardedRhsBlock prettyBody) grhss of
+    [] -> headDoc
+    [firstGrhs] -> headDoc <+> firstGrhs
+    firstGrhs : restGrhss ->
+      headDoc <+> firstGrhs <> nest 2 (hardline <> vsep restGrhss)
 
 prettyMultiWayIfRhss :: [GuardedRhs Expr] -> Doc ann
 prettyMultiWayIfRhss rhss = vsep (map (prettyGuardedRhsBodyBlock "->") rhss)
@@ -1328,13 +1332,14 @@ prettyGuardQualifiersLayout :: [GuardQualifier] -> Doc ann
 prettyGuardQualifiersLayout qualifiers =
   case map prettyGuardQualifier qualifiers of
     [] -> mempty
+    [firstQualifier] -> firstQualifier
     firstQualifier : restQualifiers ->
-      vsep (firstQualifier : map (indent 2 . (comma <+>)) restQualifiers)
+      firstQualifier <> nest 2 (hardline <> vsep (map (comma <+>) restQualifiers))
 
 prettyCaseExpr :: ([Doc ann] -> Doc ann) -> Expr -> [CaseAlt Expr] -> Doc ann
 prettyCaseExpr layout scrutinee alts =
   "case"
-    <+> nest 2 (prettyExpr scrutinee)
+    <+> prettyExpr scrutinee
     <+> "of"
     <> layout (map prettyCaseAlt alts)
 
@@ -1342,21 +1347,16 @@ prettyCaseLayout :: [Doc ann] -> Doc ann
 prettyCaseLayout [] = " " <> spacedBraces mempty
 prettyCaseLayout alts = nest 2 (hardline <> vsep alts)
 
-prettyCaseLayoutAligned :: [Doc ann] -> Doc ann
-prettyCaseLayoutAligned [] = " " <> spacedBraces mempty
-prettyCaseLayoutAligned alts = hang 2 (hardline <> vsep alts)
-
 prettyLambdaCaseAlt :: LambdaCaseAlt -> Doc ann
-prettyLambdaCaseAlt (LambdaCaseAlt _ pats rhs) = nest 2 $
+prettyLambdaCaseAlt (LambdaCaseAlt _ pats rhs) =
   case rhs of
     UnguardedRhs _ body whereDecls ->
       hsep (map prettyPattern pats)
         <+> "->"
-        <+> prettyExpr body
+        <+> nest 2 (prettyExpr body)
         <> prettyIndentedWhereClause whereDecls
     GuardedRhss _ grhss whereDecls ->
-      hsep (map prettyPattern pats)
-        <+> align (vsep (map (prettyCaseGuardedRhsBlock prettyExpr) grhss))
+      prettyGuardedCaseAlt (hsep (map prettyPattern pats)) prettyExpr grhss
         <> prettyIndentedWhereClause whereDecls
 
 prettyGuardQualifier :: GuardQualifier -> Doc ann
@@ -1371,7 +1371,7 @@ prettyLetDecls :: [Decl] -> Doc ann
 prettyLetDecls decls
   | null decls = "let" <+> spacedBraces mempty
   | otherwise =
-      "let" <+> hang 0 (vsep (concatMap prettyDeclLines decls))
+      "let" <+> align (vsep (concatMap prettyDeclLines decls))
 
 prettyDoFlavor :: DoFlavor -> Doc ann
 prettyDoFlavor DoPlain = "do"
@@ -1395,10 +1395,10 @@ prettyDoStmt :: DoStmt Expr -> Doc ann
 prettyDoStmt stmt =
   case stmt of
     DoAnn _ inner -> prettyDoStmt inner
-    DoBind pat expr -> prettyPattern pat <+> "<-" <+> nest 2 (prettyExpr expr)
+    DoBind pat expr -> prettyPattern pat <+> "<-" <+> prettyExpr expr
     DoLetDecls decls -> prettyLetDecls decls
     --
-    DoExpr expr -> hang 2 (prettyExprAtStatementStart expr)
+    DoExpr expr -> prettyExprAtStatementStart expr
     DoRecStmt stmts -> "rec" <> nest 2 (prettyDoLayout prettyDoStmt stmts)
 
 -- prettyExprAtStatementStart is a hack to get overloaded labels to align. We always print a space before labels which messes things up.
@@ -1408,10 +1408,10 @@ prettyExprAtStatementStart expr =
     EAnn _ sub -> prettyExprAtStatementStart sub
     EOverloadedLabel _ raw -> pretty raw
     EApp {} -> prettyAppWith prettyExprAtStatementStart expr
-    ETypeApp fn ty -> prettyExprAtStatementStart fn <> hardline <> " " <> prettyTypeAppArg ty
-    EInfix lhs op rhs -> prettyExprAtStatementStart lhs <> hardline <> prettyNameInfixOp op <+> prettyExpr rhs
-    ESectionL lhs op -> prettyExprAtStatementStart lhs <> hardline <> " " <> prettyNameInfixOp op
-    ETypeSig inner ty -> prettyExprAtStatementStart inner <> hardline <> indent 2 ("::" <+> prettyType ty)
+    ETypeApp fn ty -> nest 2 (prettyExprAtStatementStart fn) <> nest 1 (hardline <> " " <> prettyTypeAppArg ty)
+    EInfix lhs op rhs -> nest 2 (prettyExprAtStatementStart lhs) <> nest 1 (hardline <> prettyNameInfixOp op <+> prettyExpr rhs)
+    ESectionL lhs op -> nest 2 (prettyExprAtStatementStart lhs) <> nest 1 (hardline <> " " <> prettyNameInfixOp op)
+    ETypeSig inner ty -> nest 2 (prettyExprAtStatementStart inner) <> nest 1 (hardline <> "::" <+> prettyType ty)
     ERecordUpd base fields ->
       prettyExprAtStatementStart base <+> braces (hsep (punctuate comma (map prettyBinding fields)))
     EGetField base field ->
@@ -1421,16 +1421,16 @@ prettyExprAtStatementStart expr =
 -- | Pretty-print an arrow command.
 prettyCmd :: Cmd -> Doc ann
 prettyCmd (CmdAnn _ inner) = prettyCmd inner
-prettyCmd cmd = nest 2 $
+prettyCmd cmd =
   case cmd of
     CmdArrApp lhs HsFirstOrderApp rhs ->
       prettyExpr lhs <+> "-<" <+> prettyExpr rhs
     CmdArrApp lhs HsHigherOrderApp rhs ->
       prettyExpr lhs <+> "-<<" <+> prettyExpr rhs
     CmdInfix l op r ->
-      prettyCmd l <> hardline <> " " <> prettyNameInfixOp op <+> prettyCmd r
+      nest 2 (prettyCmd l) <> nest 1 (hardline <> " " <> prettyNameInfixOp op <+> prettyCmd r)
     CmdDo stmts ->
-      "do" <> prettyDoLayout prettyCmdStmt stmts
+      "do" <> nest 2 (prettyDoLayout prettyCmdStmt stmts)
     CmdIf cond yes no ->
       "if" <+> prettyExpr cond <+> "then" <+> prettyCmd yes <+> "else" <+> prettyCmd no
     CmdCase scrut alts ->
@@ -1438,7 +1438,7 @@ prettyCmd cmd = nest 2 $
     CmdLet decls body ->
       case decls of
         [] -> prettyLetDecls decls <+> "in" <+> prettyCmd body
-        _ -> align (prettyLetDecls decls <> hardline <> "in" <+> prettyCmd body)
+        _ -> align (prettyLetDecls decls <> nest 2 (hardline <> "in" <+> prettyCmd body))
     CmdLam pats body ->
       "\\" <+> hsep (map prettyPattern pats) <+> "->" <+> prettyCmd body
     CmdApp c e ->
@@ -1457,7 +1457,7 @@ prettyCmdStmt stmt =
     DoRecStmt stmts -> "rec" <> nest 2 (prettyDoLayout prettyCmdStmt stmts)
 
 prettyCmdAtStatementStart :: Cmd -> Doc ann
-prettyCmdAtStatementStart cmd = nest 2 $
+prettyCmdAtStatementStart cmd =
   case cmd of
     CmdAnn _ inner -> prettyCmdAtStatementStart inner
     CmdArrApp lhs HsFirstOrderApp rhs ->
@@ -1465,7 +1465,7 @@ prettyCmdAtStatementStart cmd = nest 2 $
     CmdArrApp lhs HsHigherOrderApp rhs ->
       prettyExprAtStatementStart lhs <+> "-<<" <+> prettyExpr rhs
     CmdInfix l op r ->
-      prettyCmdAtStatementStart l <> hardline <> " " <> prettyNameInfixOp op <+> prettyCmd r
+      nest 2 (prettyCmdAtStatementStart l) <> nest 1 (hardline <> " " <> prettyNameInfixOp op <+> prettyCmd r)
     CmdApp c e ->
       prettyCmdAtStatementStart c <+> prettyExpr e
     _ -> prettyCmd cmd
@@ -1497,12 +1497,9 @@ prettyGuardedRhsBlock grhs =
   let guards = guardedRhsGuards grhs
       body = guardedRhsBody grhs
    in "|"
-        <+> nest
-          2
-          ( prettyGuardQualifiersLayout guards
-              <+> "="
-              <+> nest 2 (prettyExpr body)
-          )
+        <+> prettyGuardQualifiersLayout guards
+        <+> "="
+        <+> prettyExpr body
 
 prettyArithSeq :: ArithSeq -> Doc ann
 prettyArithSeq seqInfo =
@@ -1541,7 +1538,7 @@ prettyTypeFamilyDecl tf =
       ["=", prettyTyVarBinder result, "|", prettyTypeFamilyInjectivity injectivity]
     eqsPart Nothing = []
     eqsPart (Just []) = ["where", spacedBraces mempty]
-    eqsPart (Just eqs) = ["where" <> hardline <> indent 2 (vsep (map prettyTypeFamilyEq eqs))]
+    eqsPart (Just eqs) = ["where" <> nest 2 (hardline <> vsep (map prettyTypeFamilyEq eqs))]
 
 prettyTypeFamilyEq :: TypeFamilyEq -> Doc ann
 prettyTypeFamilyEq eq =

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -465,7 +465,7 @@ test_overloadedLabelPrettyPrintsWithDelimiterSpacing = do
           EParen (EOverloadedLabel "a" "#a")
         ]
       rendered = map (renderStrict . layoutPretty defaultLayoutOptions . pretty) exprs
-      expected = ["( #a,\n   )", "[ #a]", "( #a)"]
+      expected = ["( #a, )", "[ #a]", "( #a)"]
   assertEqual "pretty-printed forms" expected rendered
   mapM_
     ( \source ->

--- a/components/aihc-parser/test/Spec.hs
+++ b/components/aihc-parser/test/Spec.hs
@@ -1655,8 +1655,8 @@ test_viewExprBlockInfixLhsNoParens = do
       expected =
         """
         f [case [] of {  }
-          + []
-           -> _] = []
+         + []
+         -> _] = []
         """
   assertParsedModulePrettyContains source expected
 


### PR DESCRIPTION
## Summary

- compact comma-separated forms, case and lambda-case RHSs, guarded alternatives, and Template Haskell declaration quotes
- assign indentation to the construct that emits each newline instead of stacking declaration-, alternative-, and command-wide nesting
- prefer local `nest` scopes over eager `indent`, with one-column delimiter scopes where a token must dedent out of a block
- retain unconditional hard newlines where layout or block-argument parsing needs them
- add focused formatter coverage and update the overloaded-label tuple expectation

## Why

The pretty-printer used hard newlines and broad nesting more widely than the grammar requires. Removing all delimiters is unsafe: applications, infix expressions, type signatures, view arrows, comprehension bars, and related boundaries can be absorbed into a trailing `do`, `case`, `\case`, `\cases`, multi-way `if`, or type. Likewise, removing all nesting breaks Haskell layout, but applying it at every enclosing layer over-indents nested bodies. This change keeps only unambiguous separators and gives each multiline construct one local continuation scope.

## Validation

- `just fmt`
- `just check`
- `cabal test aihc-parser:spec -v0 --test-options="--pattern properties --quickcheck-tests 10000 --hide-successes"`

## Progress counts

Parser extension support counts are unchanged.
