### PR TITLE
fix(repl): enforce concrete constraints

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -33,19 +33,24 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
 import Aihc.Tc
-  ( Pred (..),
+  ( InstanceInfo,
+    Pred (..),
     TcBindingResult (..),
+    TcDiagnostic (..),
+    TcErrorKind (..),
     TcType (..),
     TyCon (..),
     TyVarId (..),
     TypeScheme (..),
     Unique (..),
+    renderPred,
     renderTcSignature,
     renderTcType,
     tcModuleBindings,
     tcModuleDiagnostics,
+    tcModuleInstances,
     tcModuleSuccess,
-    typecheckModuleWithEnv,
+    typecheckModuleWithEnvAndInstances,
     typecheckModulesWithEnv,
   )
 import Control.Monad.IO.Class (liftIO)
@@ -72,6 +77,7 @@ import System.FilePath qualified as FilePath
 data ReplSession = ReplSession
   { replModuleExports :: !ModuleExports,
     replImportedTerms :: ![(Text, TypeScheme)],
+    replImportedInstances :: ![InstanceInfo],
     replDependencyProgram :: !FcProgram,
     replSettings :: !(IORef ReplSettings)
   }
@@ -144,6 +150,7 @@ loadReplSession maybeStoreRoot = do
     ReplSession
       { replModuleExports = replBaseExports baseContext `Map.union` ensurePreludeMvpScope installedExports,
         replImportedTerms = mergeImportedTerms (replBaseImportedTerms baseContext) (ensurePreludeMvpTerms installedTerms),
+        replImportedInstances = replBaseImportedInstances baseContext,
         replDependencyProgram = replBaseProgram baseContext,
         replSettings = settingsRef
       }
@@ -199,10 +206,10 @@ typecheckExpression session input = do
     case resolvedModules resolved of
       [modu] -> Right modu
       _ -> Left (ReplResolveError [ResolveNotImplemented "REPL resolver returned no module"])
-  let tcResult = typecheckModuleWithEnv (replImportedTerms session) resolvedModule
+  let tcResult = typecheckModuleWithEnvAndInstances (replImportedTerms session) (replImportedInstances session) resolvedModule
   if tcModuleSuccess tcResult
     then pure ()
-    else Left (ReplTypeError (map show (tcModuleDiagnostics tcResult)))
+    else Left (ReplTypeError (map renderReplTcDiagnostic (tcModuleDiagnostics tcResult)))
   inferredType <-
     case find ((== replBindingName) . tbName) (tcModuleBindings tcResult) of
       Just binding -> Right (tbType binding)
@@ -345,6 +352,13 @@ renderReplError err =
     ReplEvalError message ->
       "eval error: " <> message
 
+renderReplTcDiagnostic :: TcDiagnostic -> String
+renderReplTcDiagnostic diagnostic =
+  case diagKind diagnostic of
+    UnsolvedWanted pred' _ ->
+      "no instance for " <> renderPred pred'
+    other -> show other
+
 helpText :: String
 helpText =
   unlines
@@ -368,6 +382,7 @@ data Interface = Interface
 data ReplBaseContext = ReplBaseContext
   { replBaseExports :: !ModuleExports,
     replBaseImportedTerms :: ![(Text, TypeScheme)],
+    replBaseImportedInstances :: ![InstanceInfo],
     replBaseProgram :: !FcProgram
   }
 
@@ -394,6 +409,7 @@ buildBaseContext modules =
                 ReplBaseContext
                   { replBaseExports = extractInterface resolved,
                     replBaseImportedTerms = map bindingImportedTerm allBindings,
+                    replBaseImportedInstances = concatMap tcModuleInstances tcResults,
                     replBaseProgram = concatPrograms (map dsProgram dsResults)
                   }
             else ioError (userError ("repl error: could not desugar bundled aihc-base Prelude: " <> unwords (concatMap dsErrors dsResults)))

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -114,6 +114,16 @@ main =
             assertEqual "short command" (ReplContinue (Just "not ∷ Bool → Bool")) shortStep
             polymorphicStep <- handleReplInput session ":t \\x -> x"
             assertEqual "polymorphic expression" (ReplContinue (Just "\\x -> x ∷ ∀ a. a → a")) polymorphicStep,
+          testCase "solves and normalizes type command constraints" $ do
+            session <- loadReplSession Nothing
+            operatorStep <- handleReplInput session ":t (+)"
+            assertEqual "operator" (ReplContinue (Just "(+) ∷ ∀ a. (Num a) ⇒ a → a → a")) operatorStep
+            partialStep <- handleReplInput session ":t (+) 1"
+            assertEqual "polymorphic partial application" (ReplContinue (Just "(+) 1 ∷ ∀ a. (Num a) ⇒ a → a")) partialStep
+            intStep <- handleReplInput session ":t (+) (1::Int)"
+            assertEqual "concrete instance" (ReplContinue (Just "(+) (1::Int) ∷ Int → Int")) intStep
+            boolStep <- handleReplInput session ":t (+) (1::Bool)"
+            assertEqual "missing concrete instance" (ReplContinue (Just "type error: no instance for Num Bool")) boolStep,
           testCase "evaluates string expressions through the pipeline" $ do
             session <- testReplSession
             step <- handleReplInput session "\"hello world\""
@@ -211,6 +221,7 @@ testReplSession = do
     ReplSession
       { replModuleExports = Map.empty,
         replImportedTerms = [],
+        replImportedInstances = [],
         replDependencyProgram = FcProgram [],
         replSettings = settingsRef
       }

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -18,7 +18,9 @@ module Aihc.Tc
     typecheckExpr,
     typecheckModule,
     typecheckModuleWithEnv,
+    typecheckModuleWithEnvAndInstances,
     typecheckModulesWithEnv,
+    typecheckModulesWithEnvAndInstances,
 
     -- * Result types
     TcResult (..),
@@ -27,6 +29,7 @@ module Aihc.Tc
     -- * Module result projections
     tcModuleBindings,
     tcModuleDiagnostics,
+    tcModuleInstances,
     tcModuleSuccess,
 
     -- * Re-exports for convenience
@@ -36,13 +39,15 @@ module Aihc.Tc
     TyVarId (..),
     TypeScheme (..),
     Pred (..),
+    InstanceInfo (..),
     Unique (..),
     TcAnnotation (..),
     TcDiagnostic (..),
     TcErrorKind (..),
     TcSeverity (..),
-    renderTcType,
+    renderPred,
     renderTcSignature,
+    renderTcType,
   )
 where
 
@@ -71,9 +76,10 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
-import Aihc.Tc.Annotations (TcAnnotation (..), renderTcSignature, renderTcType)
+import Aihc.Tc.Annotations (TcAnnotation (..), renderPred, renderTcSignature, renderTcType)
+import Aihc.Tc.Env (InstanceInfo (..))
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
-import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, tcModule)
+import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleInstances, tcModule)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
@@ -138,6 +144,11 @@ tcModuleBindings :: Module -> [TcBindingResult]
 tcModuleBindings =
   moduleBindings
 
+-- | Class instances recovered from a type-checked module's annotations.
+tcModuleInstances :: Module -> [InstanceInfo]
+tcModuleInstances =
+  moduleInstances
+
 -- | Diagnostics recovered from type-checker annotations in a module.
 tcModuleDiagnostics :: Module -> [TcDiagnostic]
 tcModuleDiagnostics =
@@ -158,8 +169,13 @@ typecheckModule =
 
 -- | Type-check a single module with preloaded top-level term bindings.
 typecheckModuleWithEnv :: [(Text, TypeScheme)] -> Module -> Module
-typecheckModuleWithEnv importedTerms m =
-  case typecheckModulesWithEnv importedTerms [m] of
+typecheckModuleWithEnv importedTerms =
+  typecheckModuleWithEnvAndInstances importedTerms []
+
+-- | Type-check a single module with preloaded terms and class instances.
+typecheckModuleWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> Module -> Module
+typecheckModuleWithEnvAndInstances importedTerms importedInstances m =
+  case typecheckModulesWithEnvAndInstances importedTerms importedInstances [m] of
     [result] -> result
     _ ->
       annotateModuleDiagnostics [internalAbortDiagnostic "type checker returned unexpected module count"] m
@@ -170,6 +186,11 @@ typecheckModuleWithEnv importedTerms m =
 -- see earlier data constructors and value bindings.
 typecheckModulesWithEnv :: [(Text, TypeScheme)] -> [Module] -> [Module]
 typecheckModulesWithEnv importedTerms =
+  typecheckModulesWithEnvAndInstances importedTerms []
+
+-- | Type-check modules in order with preloaded terms and class instances.
+typecheckModulesWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> [Module] -> [Module]
+typecheckModulesWithEnvAndInstances importedTerms importedInstances =
   go initState
   where
     initState =
@@ -179,7 +200,8 @@ typecheckModulesWithEnv importedTerms =
               [ (name, TcIdBinder scheme Closed)
               | (name, scheme) <- importedTerms
               ]
-              <> tcsGlobalTerms initTcState
+              <> tcsGlobalTerms initTcState,
+          tcsInstances = importedInstances
         }
 
     go _ [] = []

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -28,6 +28,7 @@ module Aihc.Tc.Annotations
     pendingAnnotation,
 
     -- * Pretty-printing
+    renderPred,
     renderTcType,
     renderTcSignature,
   )
@@ -142,6 +143,15 @@ pendingAnnotation = PendingTcAnnotation
 -- | Render a binder and its 'TcType' as a human-readable signature.
 renderTcSignature :: Text -> TcType -> String
 renderTcSignature name ty = T.unpack name ++ " ∷ " ++ renderTcType ty
+
+-- | Render a class or equality predicate as source-like text.
+renderPred :: Pred -> String
+renderPred pred' =
+  case pred' of
+    ClassPred className args ->
+      renderTcType (TcTyCon (TyCon className (length args)) args)
+    EqPred left right ->
+      renderTcType left ++ " ~ " ++ renderTcType right
 
 -- | Render a 'TcType' as a human-readable string.
 --

--- a/components/aihc-tc/src/Aihc/Tc/Generalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generalize.hs
@@ -8,6 +8,7 @@ module Aihc.Tc.Generalize
     generalizeIgnoring,
     generalizeAndCommit,
     generalizeAndCommitIgnoring,
+    predMetaVars,
   )
 where
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -9,6 +9,7 @@
 module Aihc.Tc.Generate.Decl
   ( tcModule,
     moduleBindings,
+    moduleInstances,
     TcBindingResult (..),
   )
 where
@@ -66,9 +67,10 @@ import Aihc.Tc.Annotations
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (InstanceInfo (..), TyConInfo (..))
+import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Finalize (finalizeModuleTc)
-import Aihc.Tc.Generalize (generalizeAndCommitIgnoring)
+import Aihc.Tc.Generalize (generalizeAndCommitIgnoring, predMetaVars)
 import Aihc.Tc.Generate.Bind (inferRhsWithLocals)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Generate.Pattern
@@ -80,9 +82,9 @@ import Aihc.Tc.Solve.Dict (solveDictWithGivens)
 import Aihc.Tc.Solve.InertSet (InertSet (..))
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)
-import Control.Monad (foldM, forM_, zipWithM)
+import Control.Monad (foldM, forM_, when, zipWithM)
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (mapAccumL, nub, (\\))
+import Data.List (mapAccumL, nub, nubBy, partition, (\\))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
@@ -130,6 +132,38 @@ data CheckedSig = CheckedSig
 moduleBindings :: Module -> [TcBindingResult]
 moduleBindings modu =
   concatMap declBindings (moduleDecls modu)
+
+-- | Recover instance-environment entries from finalized module annotations.
+moduleInstances :: Module -> [InstanceInfo]
+moduleInstances modu =
+  concatMap declInstances (moduleDecls modu)
+
+declInstances :: Decl -> [InstanceInfo]
+declInstances decl =
+  case decl of
+    DeclAnn ann inner ->
+      annotationInstances ann inner <> declInstances inner
+    _ -> []
+
+annotationInstances :: Annotation -> Decl -> [InstanceInfo]
+annotationInstances ann decl =
+  case (fromAnnotation ann, peelDeclAnn decl) of
+    (Just instAnn, DeclInstance instanceDecl)
+      | Just className <- instanceHeadName (instanceDeclHead instanceDecl) ->
+          [ InstanceInfo
+              { iiClassName = nameText className,
+                iiDictName = tcInstanceDictName instAnn,
+                iiDictType = tcInstanceDictType instAnn,
+                iiTyVars = tcInstanceTyVars instAnn,
+                iiContext = map dictBinderPred (tcInstanceContextDicts instAnn),
+                iiHead = tcInstanceHeadTypes instAnn
+              }
+          ]
+    _ -> []
+
+dictBinderPred :: TcDictBinderAnnotation -> Pred
+dictBinderPred dictBinder =
+  ClassPred (tcDictBinderClassName dictBinder) (tcDictBinderArgs dictBinder)
 
 declBindings :: Decl -> [TcBindingResult]
 declBindings decl =
@@ -1055,10 +1089,35 @@ tcFunctionInfer displayName name matches = do
 
 generalizableResidualPreds :: SolveResult -> TcM [Pred]
 generalizableResidualPreds solveResult = do
-  let residualCts = srResidual solveResult <> inertDicts (srInerts solveResult)
+  residualCts <- mapM zonkCtPred (srResidual solveResult <> inertDicts (srInerts solveResult))
+  let uniqueResidualCts = nubBy sameCtPred residualCts
+      (polymorphicCts, concreteCts) = partition (predicateCanGeneralize . ctPred) uniqueResidualCts
+  -- Every occurrence still needs evidence, even when equal predicates share
+  -- one constraint in the generalized type.
   forM_ residualCts $ \ct ->
-    bindEvidence (ctEvVar ct) (EvGiven (ctPred ct))
-  pure (map ctPred residualCts)
+    when (predicateCanGeneralize (ctPred ct)) $
+      bindEvidence (ctEvVar ct) (EvGiven (ctPred ct))
+  -- A fully concrete residual cannot be discharged by a caller-supplied
+  -- dictionary, so reject it at the originating expression.
+  forM_ concreteCts $ \ct ->
+    emitError (ctLoc ct) (UnsolvedWanted (ctPred ct) (ctOrigin ct))
+  pure (map ctPred polymorphicCts)
+  where
+    zonkCtPred ct = do
+      pred' <- zonkPred (ctPred ct)
+      pure (ct {ctPred = pred'})
+
+    sameCtPred left right = ctPred left == ctPred right
+
+predicateCanGeneralize :: Pred -> Bool
+predicateCanGeneralize =
+  not . null . predMetaVars
+
+zonkPred :: Pred -> TcM Pred
+zonkPred pred' =
+  case pred' of
+    ClassPred className args -> ClassPred className <$> mapM zonkType args
+    EqPred left right -> EqPred <$> zonkType left <*> zonkType right
 
 -- | Register a declaration in the environment (data types, etc.).
 -- Returns binding results for the declared names.


### PR DESCRIPTION
## Summary

- carry type-checked dependency instance facts into REPL expression checking
- deduplicate equivalent residual predicates while preserving evidence for every occurrence
- discharge concrete constraints through known instances and reject unresolved concrete predicates
- render missing-instance diagnostics for `:type`

## Root cause

The REPL imported Prelude term schemes but discarded the Prelude instance environment. As a result, both `Num Int` and `Num Bool` remained residual constraints, and repeated uses of the same predicate were generalized independently.

## Impact

`:t (+) 1` now reports one `Num a` constraint, `:t (+) (1::Int)` simplifies to `Int → Int`, and `:t (+) (1::Bool)` reports `no instance for Num Bool`.

## Progress counts

- AIHC CLI tests: 46 → 47 (+1 regression test)
- README progress counts unchanged (cron-managed)

## Verification

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
