### PR TITLE
perf(parser): outperform ghc-lib-parser

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,7 +20,7 @@ Parser input is preprocessed with `aihc-cpp` before measurement. GHC is the base
 | Parser | Relative Speed |
 | --- | ---: |
 | GHC (`ghc-lib-parser`) | `1.00x` |
-| AIHC | `0.84x` |
+| AIHC | `1.01x` |
 
 ## CPP Performance
 

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Common.hs
@@ -76,7 +76,7 @@ where
 
 import Aihc.Parser.Lex (LayoutState (..), LexToken (..), LexTokenKind (..), closeImplicitLayoutContext)
 import Aihc.Parser.Syntax
-import Aihc.Parser.Types (ParserErrorComponent (..), TokStream (..), mkFoundToken)
+import Aihc.Parser.Types (ParserErrorComponent (..), TokStream (..), mkFoundToken, tokStreamExtensionSet)
 import Control.Monad (guard)
 import Data.Char (isUpper)
 import Data.Functor (($>))
@@ -481,7 +481,7 @@ withSpan parser = do
 inputStartSpan :: TokStream -> SourceSpan
 inputStartSpan ts
   | tokStreamEOFEmitted ts = noSourceSpan
-  | tok : _ <- layoutBuffer (tokStreamLayoutState ts) = lexTokenSpan tok
+  | tok : _ <- tokStreamBuffer ts = lexTokenSpan tok
   | rawTok : _ <- tokStreamRawTokens ts = lexTokenSpan rawTok
   | otherwise = noSourceSpan
 {-# INLINE inputStartSpan #-}
@@ -855,7 +855,8 @@ isConstructorIdentifier txt =
 
 isExtensionEnabled :: Extension -> TokParser Bool
 isExtensionEnabled ext =
-  memberExtension ext . tokStreamExtensionSet . MP.stateInput <$> MP.getParserState
+  memberExtension ext . tokStreamExtensionSet <$> MP.getInput
+{-# INLINE isExtensionEnabled #-}
 
 -- | Check whether any Template Haskell extension is enabled (quotes or full TH).
 thAnyEnabled :: TokParser Bool
@@ -902,7 +903,19 @@ closeImplicitLayout = do
   case closeImplicitLayoutContext (tokStreamLayoutState ts) of
     Nothing -> pure False
     Just laySt' -> do
-      MP.updateParserState (\s -> s {MP.stateInput = (MP.stateInput s) {tokStreamLayoutState = laySt'}})
+      let inserted = layoutBuffer laySt'
+          laySt'' = laySt' {layoutBuffer = []}
+      MP.updateParserState
+        ( \s ->
+            let input = MP.stateInput s
+             in s
+                  { MP.stateInput =
+                      input
+                        { tokStreamLayoutState = laySt'',
+                          tokStreamBuffer = inserted <> tokStreamBuffer input
+                        }
+                  }
+        )
       pure True
 
 -- | Like Megaparsec's 'MP.sepEndBy' but implements the parse-error rule for

--- a/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex/Types.hs
@@ -219,6 +219,7 @@ newtype LexerEnv = LexerEnv
 
 hasExt :: Extension -> LexerEnv -> Bool
 hasExt ext env = memberExtension ext (lexerExtensions env)
+{-# INLINE hasExt #-}
 
 data LexerState = LexerState
   { lexerInput :: !Text,

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -165,6 +165,7 @@ import Data.Char (GeneralCategory (..), generalCategory)
 import Data.Data (Constr, Data (..), DataType, Fixity (Prefix), mkConstr, mkDataType)
 import Data.Dynamic (Dynamic, Typeable, fromDynamic, toDyn)
 import Data.List (sort)
+import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String (IsString (..))
@@ -343,7 +344,7 @@ data ExtensionSet = ExtensionSet !Word64 !Word64 !Word64
   deriving anyclass (NFData)
 
 mkExtensionSet :: [Extension] -> ExtensionSet
-mkExtensionSet = foldl' insertExtension (ExtensionSet 0 0 0)
+mkExtensionSet = List.foldl' insertExtension (ExtensionSet 0 0 0)
   where
     insertExtension (ExtensionSet low middle high) ext =
       case fromEnum ext `quotRem` 64 of

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -160,11 +160,10 @@ module Aihc.Parser.Syntax
 where
 
 import Control.DeepSeq (NFData (..))
+import Data.Bits (setBit, testBit)
 import Data.Char (GeneralCategory (..), generalCategory)
 import Data.Data (Constr, Data (..), DataType, Fixity (Prefix), mkConstr, mkDataType)
 import Data.Dynamic (Dynamic, Typeable, fromDynamic, toDyn)
-import Data.IntSet (IntSet)
-import Data.IntSet qualified as IntSet
 import Data.List (sort)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -172,6 +171,7 @@ import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Typeable (cast)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 
 -- | A @LANGUAGE@ pragma name.
@@ -338,17 +338,28 @@ data Extension
   | XmlSyntax
   deriving (Data, Eq, Ord, Show, Read, Enum, Bounded, Generic, NFData)
 
-newtype ExtensionSet = ExtensionSet IntSet
+data ExtensionSet = ExtensionSet !Word64 !Word64 !Word64
   deriving stock (Eq, Show, Generic)
   deriving anyclass (NFData)
 
 mkExtensionSet :: [Extension] -> ExtensionSet
-mkExtensionSet =
-  ExtensionSet . IntSet.fromList . map fromEnum
+mkExtensionSet = foldl' insertExtension (ExtensionSet 0 0 0)
+  where
+    insertExtension (ExtensionSet low middle high) ext =
+      case fromEnum ext `quotRem` 64 of
+        (0, bit) -> ExtensionSet (setBit low bit) middle high
+        (1, bit) -> ExtensionSet low (setBit middle bit) high
+        (2, bit) -> ExtensionSet low middle (setBit high bit)
+        _ -> error "mkExtensionSet: extension enum exceeds bitset capacity"
 
 memberExtension :: Extension -> ExtensionSet -> Bool
-memberExtension ext (ExtensionSet exts) =
-  IntSet.member (fromEnum ext) exts
+memberExtension ext (ExtensionSet low middle high) =
+  case fromEnum ext `quotRem` 64 of
+    (0, bit) -> testBit low bit
+    (1, bit) -> testBit middle bit
+    (2, bit) -> testBit high bit
+    _ -> False
+{-# INLINE memberExtension #-}
 
 -- | A single @LANGUAGE@ pragma entry.
 -- Examples: @EnableExtension LambdaCase@ for @{-# LANGUAGE LambdaCase #-}@ and

--- a/components/aihc-parser/src/Aihc/Parser/Types.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Types.hs
@@ -81,14 +81,15 @@ mkFoundToken tok =
 data TokStream = TokStream
   { -- | Shared lazy list of raw tokens (never re-scanned on backtrack).
     tokStreamRawTokens :: [LexToken],
-    -- | Layout engine state (context stack, pending layout, buffer).
+    -- | Layout engine state (context stack and pending layout).
     tokStreamLayoutState :: LayoutState,
+    -- | Tokens ready for the parser, including virtual layout tokens.
+    tokStreamBuffer :: [LexToken],
     -- | Hidden pragmas that appeared before the next source token.
     -- Parsers may inspect these explicitly, but they never participate in the
     -- ordinary token stream.
     tokStreamPendingPragmas :: [Pragma],
     tokStreamPrevToken :: Maybe LexToken,
-    tokStreamExtensions :: [Extension],
     tokStreamExtensionSet :: ExtensionSet,
     -- | Whether this stream has already emitted TkEOF.
     -- After EOF is emitted, 'take1_' returns Nothing.
@@ -119,8 +120,8 @@ instance Show TokStream where
       <> show (length (tokStreamPendingPragmas ts))
       <> ", prevToken = "
       <> show (tokStreamPrevToken ts)
-      <> ", extensions = "
-      <> show (tokStreamExtensions ts)
+      <> ", extensionSet = "
+      <> show (tokStreamExtensionSet ts)
       <> " }"
 
 -- Manual NFData instance — don't force the lazy raw token list.
@@ -128,9 +129,8 @@ instance NFData TokStream where
   rnf ts =
     rnf (tokStreamPendingPragmas ts) `seq`
       rnf (tokStreamPrevToken ts) `seq`
-        rnf (tokStreamExtensions ts) `seq`
-          rnf (tokStreamExtensionSet ts) `seq`
-            rnf (tokStreamEOFEmitted ts)
+        rnf (tokStreamExtensionSet ts) `seq`
+          rnf (tokStreamEOFEmitted ts)
 
 -- | Create a TokStream for parsing expressions/declarations (no module layout).
 mkTokStream :: FilePath -> [Extension] -> Text -> TokStream
@@ -140,9 +140,9 @@ mkTokStream sourceName exts input =
         TokStream
           { tokStreamRawTokens = scanAllTokens env lexSt,
             tokStreamLayoutState = mkInitialLayoutState False exts,
+            tokStreamBuffer = [],
             tokStreamPendingPragmas = [],
             tokStreamPrevToken = Nothing,
-            tokStreamExtensions = exts,
             tokStreamExtensionSet = mkExtensionSet exts,
             tokStreamEOFEmitted = False
           }
@@ -156,9 +156,9 @@ mkTokStreamModule sourceName baseExts input =
         TokStream
           { tokStreamRawTokens = scanAllTokens env lexSt,
             tokStreamLayoutState = mkInitialLayoutState True effectiveExts,
+            tokStreamBuffer = [],
             tokStreamPendingPragmas = [],
             tokStreamPrevToken = Nothing,
-            tokStreamExtensions = effectiveExts,
             tokStreamExtensionSet = mkExtensionSet effectiveExts,
             tokStreamEOFEmitted = False
           }
@@ -174,58 +174,62 @@ mkTokStreamFromTokens toks =
    in normalizeTokStream
         TokStream
           { tokStreamRawTokens = scanAllTokens env lexSt,
-            tokStreamLayoutState =
-              (mkInitialLayoutState False [])
-                { layoutBuffer = toks
-                },
+            tokStreamLayoutState = mkInitialLayoutState False [],
+            tokStreamBuffer = toks,
             tokStreamPendingPragmas = [],
             tokStreamPrevToken = Nothing,
-            tokStreamExtensions = [],
             tokStreamExtensionSet = mkExtensionSet [],
             tokStreamEOFEmitted = False
           }
 
-pragmaFromToken :: LexToken -> Maybe Pragma
-pragmaFromToken tok =
-  case lexTokenKind tok of
-    TkPragma pragma' -> Just pragma'
-    _ -> Nothing
-
-isHiddenToken :: LexToken -> Bool
-isHiddenToken tok =
-  case lexTokenKind tok of
-    TkPragma _ -> True
-    TkLineComment -> True
-    TkBlockComment -> True
-    _ -> False
-
 normalizeTokStream :: TokStream -> TokStream
 normalizeTokStream ts0
   | tokStreamEOFEmitted ts0 = ts0
-  | otherwise = go ts0
+  | otherwise =
+      normalizeTokStreamParts
+        (tokStreamRawTokens ts0)
+        (tokStreamLayoutState ts0)
+        (tokStreamBuffer ts0)
+        (tokStreamPendingPragmas ts0)
+        (tokStreamPrevToken ts0)
+        (tokStreamExtensionSet ts0)
+        False
+
+-- | Advance through layout and hidden tokens until the stream is ready for
+-- 'stepOne'. Keeping the stream fields separate lets a token step normalize
+-- its successor without first allocating an intermediate 'TokStream'.
+normalizeTokStreamParts :: [LexToken] -> LayoutState -> [LexToken] -> [Pragma] -> Maybe LexToken -> ExtensionSet -> Bool -> TokStream
+normalizeTokStreamParts rawTokens layoutState buffer pendingPragmas prevToken extensionSet eofEmitted
+  | eofEmitted = finish rawTokens layoutState buffer pendingPragmas
+  | otherwise = go rawTokens layoutState buffer pendingPragmas
   where
-    go ts =
-      case layoutBuffer (tokStreamLayoutState ts) of
-        tok : rest
-          | Just pragma' <- pragmaFromToken tok ->
-              go
-                ts
-                  { tokStreamLayoutState = (tokStreamLayoutState ts) {layoutBuffer = rest},
-                    tokStreamPendingPragmas = tokStreamPendingPragmas ts <> [pragma']
-                  }
-          | isHiddenToken tok ->
-              go
-                ts
-                  { tokStreamLayoutState = (tokStreamLayoutState ts) {layoutBuffer = rest}
-                  }
-          | otherwise -> ts
+    finish rawTokens' layoutState' buffer' pendingPragmas' =
+      TokStream
+        { tokStreamRawTokens = rawTokens',
+          tokStreamLayoutState = layoutState',
+          tokStreamBuffer = buffer',
+          tokStreamPendingPragmas = pendingPragmas',
+          tokStreamPrevToken = prevToken,
+          tokStreamExtensionSet = extensionSet,
+          tokStreamEOFEmitted = eofEmitted
+        }
+
+    go rawTokens' layoutState' buffer' pendingPragmas' =
+      case buffer' of
+        tok : rest ->
+          case lexTokenKind tok of
+            TkPragma pragma' ->
+              go rawTokens' layoutState' rest (pendingPragmas' <> [pragma'])
+            TkLineComment -> go rawTokens' layoutState' rest pendingPragmas'
+            TkBlockComment -> go rawTokens' layoutState' rest pendingPragmas'
+            _ -> finish rawTokens' layoutState' buffer' pendingPragmas'
         [] ->
-          case tokStreamRawTokens ts of
-            [] -> ts
+          case rawTokens' of
+            [] -> finish [] layoutState' [] pendingPragmas'
             rawTok : rawRest ->
-              let (allToks, laySt') = layoutTransition (tokStreamLayoutState ts) rawTok
-                  laySt'' = laySt' {layoutBuffer = allToks}
-               in go ts {tokStreamRawTokens = rawRest, tokStreamLayoutState = laySt''}
+              let (allToks, laySt') = layoutTransition layoutState' rawTok
+               in go rawRest laySt' allToks pendingPragmas'
+{-# INLINE normalizeTokStreamParts #-}
 
 -- | Step one token from the stream. This is the core primitive used by all
 -- Stream methods.
@@ -244,29 +248,33 @@ stepOne :: TokStream -> Maybe (LexToken, TokStream)
 stepOne ts
   | tokStreamEOFEmitted ts = Nothing
   | otherwise =
-      let ts0 = normalizeTokStream ts
-          laySt = tokStreamLayoutState ts0
-       in case layoutBuffer laySt of
-            -- Drain buffered tokens first (virtual braces/semicolons)
-            tok : rest ->
-              let isEOF = lexTokenKind tok == TkEOF
-                  pendingPragmas =
-                    case lexTokenOrigin tok of
-                      InsertedLayout -> tokStreamPendingPragmas ts0
-                      FromSource
-                        | lexTokenKind tok == TkSpecialSemicolon -> tokStreamPendingPragmas ts0
-                        | otherwise -> []
-                  ts' =
-                    ts0
-                      { tokStreamLayoutState = laySt {layoutBuffer = rest},
-                        tokStreamPendingPragmas = pendingPragmas,
-                        tokStreamPrevToken = Just tok,
-                        tokStreamEOFEmitted = isEOF
-                      }
-               in Just
-                    (tok, normalizeTokStream ts')
-            [] ->
-              Nothing
+      case tokStreamBuffer ts of
+        -- Drain buffered tokens first (virtual braces/semicolons)
+        tok : rest ->
+          let kind = lexTokenKind tok
+              isEOF = case kind of
+                TkEOF -> True
+                _ -> False
+              pendingPragmas =
+                case lexTokenOrigin tok of
+                  InsertedLayout -> tokStreamPendingPragmas ts
+                  FromSource
+                    | TkSpecialSemicolon <- kind -> tokStreamPendingPragmas ts
+                    | otherwise -> []
+           in Just
+                ( tok,
+                  normalizeTokStreamParts
+                    (tokStreamRawTokens ts)
+                    (tokStreamLayoutState ts)
+                    rest
+                    pendingPragmas
+                    (Just tok)
+                    (tokStreamExtensionSet ts)
+                    isEOF
+                )
+        [] ->
+          Nothing
+{-# INLINE stepOne #-}
 
 instance Stream TokStream where
   type Token TokStream = LexToken


### PR DESCRIPTION
## Summary

- reduce token-stream allocation by separating the ready-token buffer from the larger layout state
- normalize successor streams without constructing an intermediate `TokStream`
- replace extension `IntSet` lookups with a compact fixed bitset and inline hot membership checks
- update the published parser benchmark

## Why

Profiling showed that token-stream normalization, `stepOne`, layout-buffer updates, and extension membership dominated AIHC parser time and allocation. The previous representation copied the full layout state while advancing each token and performed tree-based extension lookups in hot lexer and parser paths.

## Impact

The public parser API and parse behavior are unchanged. Backtracking still restores the shared lazy raw-token list and layout state, while the internal ready-token buffer is updated independently.

## Progress

- Parser performance: **0.84x -> 1.01x** relative to `ghc-lib-parser`
- Corpus: 3,412 packages, 55,616 Haskell files, 394.3 MB
- README progress counts are intentionally unchanged; generated README updates remain owned by the cron workflow

## Validation

- two consecutive full offline benchmark reports measured AIHC at `1.01x`
- `just fmt`
- `just check`
  - Ormolu and Cabal formatting
  - HLint
  - all component tests under `-Werror`
  - 1,860 parser tests
  - QuickCheck suites with 1,000 cases

