### PR TITLE
fix(parser): align multiline case scrutinees

### DIFF
--- a/components/aihc-parser/src/Aihc/Parser/Pretty.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Pretty.hs
@@ -1339,7 +1339,7 @@ prettyGuardQualifiersLayout qualifiers =
 prettyCaseExpr :: ([Doc ann] -> Doc ann) -> Expr -> [CaseAlt Expr] -> Doc ann
 prettyCaseExpr layout scrutinee alts =
   "case"
-    <+> prettyExpr scrutinee
+    <+> align (prettyExpr scrutinee)
     <+> "of"
     <> layout (map prettyCaseAlt alts)
 

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/boltzmann-samplers-infix-case-scrutinee.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Hackage/boltzmann-samplers-infix-case-scrutinee.hs
@@ -1,0 +1,15 @@
+{- ORACLE_TEST pass -}
+module M where
+
+infixl 9 #!
+
+(#!) = undefined
+
+data A = SomeData B
+
+data B = AlgRep Int | Other
+
+phi xedni i = case xedni #! i of
+  SomeData a -> case a of
+    AlgRep _ -> \_ _ -> 0
+    Other -> \x _ -> x


### PR DESCRIPTION
## Summary

- align multiline `case` scrutinees beneath the text following `case`
- keep infix scrutinee continuation lines inside the scrutinee layout block
- add an oracle regression derived from `boltzmann-samplers`

## Root cause

The pretty-printer rendered an infix `case` scrutinee with its continuation operator at column 2 and the case alternatives at column 3. GHC treated the first alternative as a continuation of the scrutinee and rejected its `->` during round-trip validation.

## Impact

The Parser Stackage result advances from `2937/2938` to `2938/2938` packages. README progress counts are intentionally left to the generated-report workflow.

## Validation

- `cabal run -v0 exe:aihc-dev -- snippet components/aihc-parser/test/Test/Fixtures/oracle/Hackage/boltzmann-samplers-infix-case-scrutinee.hs`
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle --hide-successes"` (1,204 tests passed)
- `cabal run -v0 exe:aihc-dev -- hackage-tester boltzmann-samplers` (7/7 files, 100%)
- `just fmt`
- `just check`
