### PR TITLE
fix(cli): pretty-print install errors

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -123,6 +123,7 @@ import System.Exit (exitFailure)
 import System.FilePath (makeRelative, normalise, splitDirectories, takeDirectory, takeExtension, (</>))
 import System.IO (hPutStrLn, stderr)
 import System.Timeout (timeout)
+import Text.Read (readMaybe)
 
 data PackagePlan = PackagePlan
   { planPackageKey :: !PackageVariantKey,
@@ -764,7 +765,7 @@ blockingInterfaceFailures result =
 
 renderInstallFailure :: InstallFailure -> String
 renderInstallFailure =
-  renderInstallFailureWith False InstallErrorsJson
+  renderInstallFailureWith False InstallErrorsHuman
 
 renderInstallFailureWithOptions :: InstallOptions -> InstallFailure -> String
 renderInstallFailureWithOptions opts =
@@ -824,8 +825,31 @@ renderHumanDiagnostic phase diagnostic =
       case diagnosticModule diagnostic of
         Just moduleName -> "[" <> moduleName <> "] "
         Nothing -> ""
-    severityText = fromMaybe (T.pack phase) (stringField "severity" diagnostic)
-    messageText = fromMaybe (diagnosticSummary diagnostic) (stringField "message" diagnostic)
+    severityText = fromMaybe "error" (stringField "severity" diagnostic)
+    messageText = renderHumanDiagnosticMessage phase diagnostic
+
+renderHumanDiagnosticMessage :: String -> Aeson.Value -> Text
+renderHumanDiagnosticMessage phase diagnostic
+  | phase == "rename",
+    Just message <- stringField "message" diagnostic,
+    Just name <- stringField "name" diagnostic,
+    Just namespace <- stringField "namespace" diagnostic =
+      renderResolveMessage message name namespace
+  | otherwise = fromMaybe (diagnosticSummary diagnostic) (stringField "message" diagnostic)
+
+renderResolveMessage :: Text -> Text -> Text -> Text
+renderResolveMessage message name namespace
+  | message == "unbound" = "unbound " <> renderNamespace namespace <> " name ‘" <> name <> "’"
+  | message == "not found" = renderNamespace namespace <> " ‘" <> name <> "’ not found"
+  | otherwise = message <> ": " <> renderNamespace namespace <> " name ‘" <> name <> "’"
+
+renderNamespace :: Text -> Text
+renderNamespace namespace =
+  case namespace of
+    "ResolutionNamespaceTerm" -> "term"
+    "ResolutionNamespaceType" -> "type"
+    "ResolutionNamespaceModule" -> "module"
+    _ -> namespace
 
 renderHumanDiagnosticExcerpt :: Aeson.Value -> [String]
 renderHumanDiagnosticExcerpt diagnostic =
@@ -1016,7 +1040,9 @@ diagnosticSummary :: Aeson.Value -> Text
 diagnosticSummary =
   TE.decodeUtf8 . BL.toStrict . Aeson.encode
 
-addTcModuleDiagnosticSourceLines :: Map.Map FilePath [Text] -> Aeson.Value -> Aeson.Value
+type DiagnosticSourceMap = Map.Map FilePath (Map.Map Int Text)
+
+addTcModuleDiagnosticSourceLines :: DiagnosticSourceMap -> Aeson.Value -> Aeson.Value
 addTcModuleDiagnosticSourceLines sourceLinesByFile value =
   case value of
     Aeson.Object obj ->
@@ -1030,7 +1056,7 @@ addTcModuleDiagnosticSourceLines sourceLinesByFile value =
         _ -> value
     _ -> value
 
-addDiagnosticSourceLines :: Map.Map FilePath [Text] -> Aeson.Value -> Aeson.Value
+addDiagnosticSourceLines :: DiagnosticSourceMap -> Aeson.Value -> Aeson.Value
 addDiagnosticSourceLines sourceLinesByFile diagnostic =
   case (diagnostic, diagnosticFile diagnostic, diagnosticLineRange diagnostic) of
     (Aeson.Object obj, Just file, Just (startLine, endLine)) ->
@@ -1044,7 +1070,7 @@ addDiagnosticSourceLines sourceLinesByFile diagnostic =
         Nothing -> diagnostic
     _ -> diagnostic
 
-lookupSourceLines :: Text -> Map.Map FilePath [Text] -> Maybe [Text]
+lookupSourceLines :: Text -> DiagnosticSourceMap -> Maybe (Map.Map Int Text)
 lookupSourceLines file sourceLinesByFile =
   Map.lookup (T.unpack file) sourceLinesByFile
     <|> lookupNormalized
@@ -1071,13 +1097,13 @@ diagnosticLineRange diagnostic =
       line <- intField "line" diagnostic
       pure (line, line)
 
-sourceLineExcerpt :: [Text] -> Int -> Int -> [Aeson.Value]
+sourceLineExcerpt :: Map.Map Int Text -> Int -> Int -> [Aeson.Value]
 sourceLineExcerpt sourceLines startLine endLine =
   [ object
       [ "line" .= lineNumber,
         "text" .= lineText
       ]
-  | (lineNumber, lineText) <- zip [1 :: Int ..] sourceLines,
+  | (lineNumber, lineText) <- Map.toAscList sourceLines,
     lineNumber >= startLine,
     lineNumber <= endLine
   ]
@@ -1140,7 +1166,7 @@ generatePackageInterface depExports importedTerms importedBindings plan = do
   files <- collectPlanFiles plan
   parsedFiles <- mapM (parseInterfaceFile (planSourcePath plan)) files
   let parsedModules = [modu | ParsedFileOk _ modu _ _ <- parsedFiles]
-      sourceLinesByFile = Map.fromList (map parsedFileSourceLines parsedFiles)
+      sourceLinesByFile = Map.unionsWith Map.union (map parsedFileSourceLines parsedFiles)
       enrichDiagnostics = map (addDiagnosticSourceLines sourceLinesByFile)
       parseDiagnostics = enrichDiagnostics (concatMap parsedFileParseDiagnostics parsedFiles)
       cppDiagnostics = enrichDiagnostics (concatMap parsedFileCppDiagnostics parsedFiles)
@@ -1249,14 +1275,14 @@ typecheckTimeoutDiagnostic modu =
         ]
 
 data ParsedInterfaceFile
-  = ParsedFileOk !FilePath !Module ![Text] ![Aeson.Value]
-  | ParsedFileFailed !FilePath ![Text] ![Aeson.Value] ![Aeson.Value]
+  = ParsedFileOk !FilePath !Module !DiagnosticSourceMap ![Aeson.Value]
+  | ParsedFileFailed !FilePath !DiagnosticSourceMap ![Aeson.Value] ![Aeson.Value]
 
-parsedFileSourceLines :: ParsedInterfaceFile -> (FilePath, [Text])
+parsedFileSourceLines :: ParsedInterfaceFile -> DiagnosticSourceMap
 parsedFileSourceLines parsed =
   case parsed of
-    ParsedFileOk path _ sourceLines _ -> (path, sourceLines)
-    ParsedFileFailed path sourceLines _ _ -> (path, sourceLines)
+    ParsedFileOk _ _ sourceLines _ -> sourceLines
+    ParsedFileFailed _ sourceLines _ _ -> sourceLines
 
 parsedFileParseDiagnostics :: ParsedInterfaceFile -> [Aeson.Value]
 parsedFileParseDiagnostics parsed =
@@ -1299,7 +1325,7 @@ parseInterfaceFile packageRoot fileInfo = do
       cfg = defaultConfig {parserSourceName = path, parserExtensions = extensions}
       (parseErrs, modu) = parseModule cfg source
       parseDiagnostics = map (parseDiagnosticValue path) parseErrs
-      sourceLines = T.lines source
+      sourceLines = diagnosticSourceMap path source
   pure $
     if null parseErrs
       then ParsedFileOk path modu sourceLines cppDiagnostics
@@ -1314,6 +1340,38 @@ parseInterfaceFile packageRoot fileInfo = do
       case setting of
         EnableExtension CPP -> True
         _ -> False
+
+diagnosticSourceMap :: FilePath -> Text -> DiagnosticSourceMap
+diagnosticSourceMap initialFile =
+  third . foldl' step (initialFile, 1, Map.empty) . T.lines
+  where
+    third (_, _, value) = value
+    step (currentFile, currentLine, sourceMap) line =
+      case parseLineDirective line of
+        Just (nextLine, nextFile) -> (fromMaybe currentFile nextFile, nextLine, sourceMap)
+        Nothing ->
+          ( currentFile,
+            currentLine + 1,
+            Map.insertWith Map.union currentFile (Map.singleton currentLine line) sourceMap
+          )
+
+parseLineDirective :: Text -> Maybe (Int, Maybe FilePath)
+parseLineDirective line = do
+  afterHash <- T.stripPrefix "#" line
+  let directive = T.stripStart afterHash
+      afterLine = fromMaybe directive (T.stripPrefix "line" directive)
+      (lineNumberText, rest) = T.span (`elem` ['0' .. '9']) (T.stripStart afterLine)
+  lineNumber <- readMaybe (T.unpack lineNumberText)
+  pure (lineNumber, directiveFile rest)
+  where
+    directiveFile rest =
+      case T.breakOn "\"" rest of
+        (_, quoted)
+          | Just afterQuote <- T.stripPrefix "\"" quoted,
+            let (file, closingQuote) = T.breakOn "\"" afterQuote,
+            not (T.null closingQuote) ->
+              Just (T.unpack file)
+        _ -> Nothing
 
 preprocessInterfaceSource :: FilePath -> HackageCabal.FileInfo -> Text -> IO (Text, [Aeson.Value])
 preprocessInterfaceSource packageRoot fileInfo source = do

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -118,15 +118,15 @@ installOptionsParser =
       ( OA.long "first-error-module"
           <> OA.help "Only print diagnostics from the module or file that produced the first install error"
       )
-    <*> humanErrorFormatParser
+    <*> errorFormatParser
 
-humanErrorFormatParser :: OA.Parser InstallErrorFormat
-humanErrorFormatParser =
+errorFormatParser :: OA.Parser InstallErrorFormat
+errorFormatParser =
   flagFromSwitch
     <$> OA.switch
-      ( OA.long "human-errors"
-          <> OA.help "Print install interface diagnostics in a human-readable format instead of JSON"
+      ( OA.long "json-errors"
+          <> OA.help "Print install interface diagnostics as JSON instead of human-readable text"
       )
   where
-    flagFromSwitch True = InstallErrorsHuman
-    flagFromSwitch False = InstallErrorsJson
+    flagFromSwitch True = InstallErrorsJson
+    flagFromSwitch False = InstallErrorsHuman

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -56,28 +56,28 @@ main =
         [ testCase "parses install package" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False False InstallErrorsJson)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False False InstallErrorsHuman)))
               (parseCommandPure ["install", "text"]),
           testCase "parses install version" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" (Just "2.1") Nothing False False False InstallErrorsJson)))
+              (Right (CmdInstall (InstallOptions "text" (Just "2.1") Nothing False False False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--version", "2.1"]),
           testCase "parses install offline and store" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") True False False InstallErrorsJson)))
+              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") True False False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--offline", "--store", "/tmp/aihc-store"]),
           testCase "parses install dry run" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False True False InstallErrorsJson)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False True False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--dry-run"]),
-          testCase "parses first error module and human errors" $
+          testCase "parses first error module and JSON errors" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False True InstallErrorsHuman)))
-              (parseCommandPure ["install", "text", "--first-error-module", "--human-errors"]),
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False True InstallErrorsJson)))
+              (parseCommandPure ["install", "text", "--first-error-module", "--json-errors"]),
           testCase "rejects explicit dependency variants" $
             assertLeftContains "dependency" (parseCommandPure ["install", "a", "--dependency", "b=1.0.0:abcdef"]),
           testCase "parses repl" $
@@ -203,10 +203,12 @@ main =
           testCase "writes dependency scaffold artifacts first" test_writeInstallScaffoldWritesDependencies,
           testCase "reports parse errors and writes no artifacts" test_reportsParseErrorsAndWritesNoArtifacts,
           testCase "reports rename errors and writes no artifacts" test_reportsRenameErrorsAndWritesNoArtifacts,
+          testCase "renders preprocessed source for rename errors" test_rendersPreprocessedSourceForRenameErrors,
           testCase "reports type-check errors and writes no artifacts" test_reportsTypeCheckErrorsAndWritesNoArtifacts,
           testCase "reports desugar errors and writes no artifacts" test_reportsDesugarErrorsAndWritesNoArtifacts,
           testCase "limits rendered install errors to first module" test_limitsRenderedInstallErrorsToFirstModule,
           testCase "renders human install errors" test_rendersHumanInstallErrors,
+          testCase "renders JSON install errors on request" test_rendersJsonInstallErrors,
           testCase "does not install dependencies when root package fails" test_failedRootDoesNotInstallDependencies,
           testCase "type-checks references to dependency bindings" test_typeChecksReferencesToDependencyBindings,
           testCase "checks cast-style instance methods using dependency id" test_checksCastStyleDependencyId,
@@ -487,19 +489,40 @@ test_limitsRenderedInstallErrorsToFirstModule = do
 
 test_rendersHumanInstallErrors :: Assertion
 test_rendersHumanInstallErrors = do
-  let opts =
-        defaultInstallOptionsForTest
-          { installErrorFormat = InstallErrorsHuman
-          }
-      err = renderInstallFailureWithOptions opts syntheticInstallFailure
+  let err = renderInstallFailure syntheticInstallFailure
   assertBool ("error includes human location, got:\n" <> err) ("src/Demo.hs:2:3: error: [Demo] selected module failed" `isInfixOf` err)
   assertBool ("error includes source line, got:\n" <> err) ("  2 | x = selected + problem" `isInfixOf` err)
   assertBool ("error includes caret range, got:\n" <> err) ("    |   ^^^^^^^^" `isInfixOf` err)
   assertBool "error omits JSON object syntax" (not ("{\"" `isInfixOf` err))
 
+test_rendersJsonInstallErrors :: Assertion
+test_rendersJsonInstallErrors = do
+  let opts =
+        defaultInstallOptionsForTest
+          { installErrorFormat = InstallErrorsJson
+          }
+      err = renderInstallFailureWithOptions opts syntheticInstallFailure
+  assertBool ("error includes JSON diagnostic, got:\n" <> err) ("{\"message\":\"selected module failed\"" `isInfixOf` err)
+
+test_rendersPreprocessedSourceForRenameErrors :: Assertion
+test_rendersPreprocessedSourceForRenameErrors =
+  withTempDir "aihc-cli" $ \root -> do
+    let sourceRoot = root </> "source"
+        storeRoot = root </> "store"
+        source = "{-# LANGUAGE CPP #-}\nmodule Demo where\n#define MISSING missingAfterCpp\nx = MISSING\n"
+    createFixturePackageWithSource sourceRoot "demo" "0.1.0.0" "Demo" [] source
+    createDirectoryIfMissing True storeRoot
+    plan <- buildPackagePlanFromSource storeRoot (PackageSpec "demo" "0.1.0.0") sourceRoot
+
+    err <- renderInstallFailure <$> expectInstallFailure (writeInstallScaffold plan)
+    assertBool ("error explains the unbound name, got:\n" <> err) ("unbound term name ‘missingAfterCpp’" `isInfixOf` err)
+    assertBool ("error includes postprocessed source, got:\n" <> err) ("| x = missingAfterCpp" `isInfixOf` err)
+    assertBool ("error includes a caret, got:\n" <> err) ("^^^^^^^^^^^^^^^" `isInfixOf` err)
+    assertBool "error omits preprocessed macro use" (not ("| x = MISSING" `isInfixOf` err))
+
 defaultInstallOptionsForTest :: InstallOptions
 defaultInstallOptionsForTest =
-  InstallOptions "demo" Nothing Nothing False False False InstallErrorsJson
+  InstallOptions "demo" Nothing Nothing False False False InstallErrorsHuman
 
 syntheticInstallFailure :: InstallFailure
 syntheticInstallFailure =


### PR DESCRIPTION
## Summary

- make human-readable install diagnostics the default while preserving JSON output behind `--json-errors`
- render resolver errors with clear namespace-aware messages, source locations, source lines, and caret ranges
- build diagnostic excerpts from preprocessed source using CPP line directives so expanded text and logical locations stay aligned
- add end-to-end coverage for macro-expanded rename failures and explicit JSON output

## Root cause

The CLI already had a human renderer, but normal installs defaulted to raw JSON. Its source excerpts also indexed physical preprocessor output lines directly, even though parser spans follow `#line` directives, which could select the wrong source line after synthetic macro injection.

## Validation

- `cabal test -v0 aihc:spec --test-options=--hide-successes` (52 tests)
- `cabal run -v0 aihc -- install lawful` (verified human diagnostics and caret placement)
- `just fmt`
- `just check`

## Progress counts

- aihc CLI tests: 50 -> 52
- README progress files unchanged; they remain cron-managed.
