### PR TITLE
fix: support installing lawful

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -210,6 +210,7 @@ main =
           testCase "does not install dependencies when root package fails" test_failedRootDoesNotInstallDependencies,
           testCase "type-checks references to dependency bindings" test_typeChecksReferencesToDependencyBindings,
           testCase "checks cast-style instance methods using dependency id" test_checksCastStyleDependencyId,
+          testCase "checks constraint-kinded multi-parameter classes" test_checksConstraintKindedMultiParameterClasses,
           testCase "checks packages without writing install artifacts" test_checkPackagePlanWritesNoArtifacts,
           testCase "uses local provider for base dependencies" test_usesLocalProviderForBase,
           testCase "uses local provider for ghc-prim dependencies" test_usesLocalProviderForGhcPrim,
@@ -616,6 +617,31 @@ test_checksCastStyleDependencyId =
     result <- expectInstallSuccess (writeInstallScaffold plan)
     fcJson <- BL8.readFile (resultFcPath result)
     assertBool "FC artifact applies imported id" ("{id @a}" `isInfixOf` BL8.unpack fcJson)
+
+test_checksConstraintKindedMultiParameterClasses :: Assertion
+test_checksConstraintKindedMultiParameterClasses =
+  withTempDir "aihc-cli" $ \root -> do
+    let sourceRoot = root </> "source"
+        storeRoot = root </> "store"
+        source =
+          unlines
+            [ "{-# LANGUAGE ConstraintKinds #-}",
+              "{-# LANGUAGE MultiParamTypeClasses #-}",
+              "{-# LANGUAGE NoImplicitPrelude #-}",
+              "{-# LANGUAGE UndecidableSuperClasses #-}",
+              "module Demo where",
+              "class Eq a",
+              "class c t => Lawful c t",
+              "data Bool = False | True",
+              "instance Eq Bool",
+              "instance Lawful Eq Bool"
+            ]
+    createFixturePackageWithSource sourceRoot "demo" "0.1.0.0" "Demo" [] source
+    createDirectoryIfMissing True storeRoot
+    plan <- buildPackagePlanWithResolver (fixtureDependencyResolver sourceRoot []) storeRoot (PackageSpec "demo" "0.1.0.0")
+
+    _ <- expectInstallSuccess (writeInstallScaffold plan)
+    pure ()
 
 test_checkPackagePlanWritesNoArtifacts :: Assertion
 test_checkPackagePlanWritesNoArtifacts =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -189,6 +189,7 @@ primitiveImportSpecs =
     [ ("+#", intBinaryPrim),
       ("-#", intBinaryPrim),
       ("*#", intBinaryPrim),
+      ("compareInt#", intBinaryPrim),
       ("<#", intBinaryPrim),
       ("==#", intBinaryPrim),
       ("raise#", PrimitiveSpec 1 isRaisePrimType),

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -149,6 +149,8 @@ evalPrimitive "-#" [left, right] =
   evalIntPrim "-#" (-) left right
 evalPrimitive "*#" [left, right] =
   evalIntPrim "*#" (*) left right
+evalPrimitive "compareInt#" [left, right] =
+  evalIntPrim "compareInt#" compareInts left right
 evalPrimitive "<#" [left, right] =
   evalIntPrim "<#" (\leftInt rightInt -> if leftInt < rightInt then 1 else 0) left right
 evalPrimitive "==#" [left, right] =
@@ -163,6 +165,13 @@ evalPrimitive "catch#" [action, handler, state] =
     result -> result
 evalPrimitive name args =
   Left (EvalPrimitiveArity name (length args))
+
+compareInts :: Integer -> Integer -> Integer
+compareInts left right =
+  case compare left right of
+    LT -> -1
+    EQ -> 0
+    GT -> 1
 
 evalIntPrim :: Text -> (Integer -> Integer -> Integer) -> Value -> Value -> Either EvalError Value
 evalIntPrim name op left right = do

--- a/components/aihc-fc/test/Test/Fixtures/eval/aihc-prim-compare-int.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/aihc-prim-compare-int.yaml
@@ -1,0 +1,25 @@
+dependencies:
+  - aihc-base
+  - aihc-prim
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    import GHC.Prim (compareInt#)
+
+    data Result = Pass | Fail
+output: |
+  Pass
+expression: |
+  case compareInt# 1# 2# of
+    -1# ->
+      case compareInt# 2# 2# of
+        0# ->
+          case compareInt# 3# 2# of
+            1# -> Pass
+            _ -> Fail
+        _ -> Fail
+    _ -> Fail
+status: pass
+reason: compareInt# imported from aihc-prim returns negative, zero, and positive ordering tags

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-ord.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/prelude-ord.yaml
@@ -1,0 +1,38 @@
+dependencies:
+  - aihc-base
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+    import Data.Ord (comparing)
+    import GHC.Int (Int(I#))
+    import GHC.Internal.Integer (Integer(IS))
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : xs) = allTrue xs
+    allTrue (False : _) = False
+output: |
+  True
+expression: |
+  allTrue
+    [ False < True,
+      True > False,
+      False <= False,
+      True >= True,
+      compare True False == GT,
+      comparing not False True == GT,
+      I# 1# < I# 2#,
+      compare (IS 2#) (IS 2#) == EQ,
+      [False, True] < [True],
+      [False] < [False, True],
+      Nothing < Just False,
+      Left True < Right False,
+      LT < EQ,
+      max False True == True,
+      min (I# 2#) (I# 1#) == I# 1#,
+      max (Just False) (Just True) == Just True
+    ]
+status: pass
+reason: Prelude Ord methods implement structural ordering for all supported types

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -80,6 +80,7 @@ data Scope = Scope
     scopeFixities :: Map.Map Text OperatorFixity,
     scopeQualifiedModules :: Map.Map Text Scope
   }
+  deriving (Eq)
 
 data OperatorFixity = OperatorFixity
   { operatorFixityAssoc :: !FixityAssoc,
@@ -90,30 +91,34 @@ data OperatorFixity = OperatorFixity
 type ModuleExports = Map.Map Text Scope
 
 collectModuleExports :: [Module] -> ModuleExports
-collectModuleExports modules =
-  Map.fromList
-    [ (moduleKey modu, exportedScope rawExports modu)
-    | modu <- modules
-    ]
+collectModuleExports modules = closeExports initialExports
   where
-    rawExports =
+    initialExports =
       Map.fromList
-        [ (moduleKey modu, topLevelScope modu)
+        [ (moduleKey modu, emptyScope)
         | modu <- modules
         ]
 
+    closeExports exports =
+      let exports' =
+            Map.fromList
+              [ (moduleKey modu, exportedScope exports modu)
+              | modu <- modules
+              ]
+       in if exports' == exports then exports else closeExports exports'
+
 exportedScope :: ModuleExports -> Module -> Scope
-exportedScope rawExports modu =
+exportedScope exports modu =
   case moduleExports modu of
     Nothing -> topLevelScope modu
     Just specs -> List.foldl' unionScope emptyScope (map exportSpecScope specs)
   where
-    availableScope = topLevelScope modu `unionScope` importedScope rawExports modu
+    availableScope = topLevelScope modu `unionScope` importedScope exports modu
 
     exportSpecScope spec =
       case spec of
         ExportAnn _ inner -> exportSpecScope inner
-        ExportModule _ exportModuleName -> Map.findWithDefault emptyScope exportModuleName rawExports
+        ExportModule _ exportModuleName -> Map.findWithDefault emptyScope exportModuleName exports
         ExportVar _ _ name -> selectTerm (nameText name) availableScope
         ExportAbs _ _ name -> selectType (nameText name) availableScope
         ExportAll _ _ name -> selectTypeWithMembers (nameText name) availableScope (allTypeMembers (nameText name) availableScope)

--- a/components/aihc-resolve/test/Test/Fixtures/golden/transitive-type-reexport.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/transitive-type-reexport.yaml
@@ -1,0 +1,36 @@
+annotated:
+- |-
+  module Internal (Integer) where
+  data Integer = IS
+       │         └─ v Internal
+       └─ t Internal
+- |-
+  module Main where
+  value :: Integer
+  │        └─ t Internal
+  └─ v Main
+  value = value
+  │       └─ v Main
+  └─ v Main
+- |-
+  module Prelude (Integer) where
+  import Public (Integer)
+- |-
+  module Public (Integer) where
+  import Internal (Integer)
+extensions: []
+modules:
+- |
+  module Internal (Integer) where
+  data Integer = IS
+- |
+  module Public (Integer) where
+  import Internal (Integer)
+- |
+  module Prelude (Integer) where
+  import Public (Integer)
+- |
+  module Main where
+  value :: Integer
+  value = value
+status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -1155,6 +1155,7 @@ registerClassDecl classDecl = do
       paramKinds = map paramKind paramInfos
       paramTvEnv = Map.fromList [(paramName param, (paramTyVar param, paramKind param)) | param <- paramInfos]
       classPred = ClassPred className (map TcTyVar paramTyVars)
+  mapM_ (\superclass -> checkSurfaceType paramTvEnv superclass KConstraint) (fromMaybe [] (classDeclContext classDecl))
   classKind <- defaultKindMetas (foldr KFun KConstraint paramKinds)
   extendTyConEnvPermanent
     className

--- a/core-libs/aihc-base/src/Data/Ord.hs
+++ b/core-libs/aihc-base/src/Data/Ord.hs
@@ -1,1 +1,11 @@
-module Data.Ord () where
+module Data.Ord
+  ( Ord (..),
+    Ordering (..),
+    comparing,
+  )
+where
+
+import Prelude (Ord (..), Ordering (..))
+
+comparing :: (Ord a) => (b -> a) -> b -> b -> Ordering
+comparing projection x y = compare (projection x) (projection y)

--- a/core-libs/aihc-base/src/GHC/Internal/Integer.hs
+++ b/core-libs/aihc-base/src/GHC/Internal/Integer.hs
@@ -2,11 +2,17 @@
 
 module GHC.Internal.Integer
   ( Integer (..),
+    eqInteger#,
   )
 where
+
+foreign import prim (==#) :: Int# -> Int# -> Int#
 
 -- Temporary representation: this is a boxed wrapper around machine-sized
 -- Int#, not arbitrary precision. Integer needs to become a real
 -- arbitrary-precision type once aihc-base has the runtime and primitive
 -- support for that representation.
 data Integer = IS Int#
+
+eqInteger# :: Integer -> Integer -> Int#
+eqInteger# (IS x) (IS y) = (==#) x y

--- a/core-libs/aihc-base/src/GHC/Internal/Integer.hs
+++ b/core-libs/aihc-base/src/GHC/Internal/Integer.hs
@@ -2,17 +2,23 @@
 
 module GHC.Internal.Integer
   ( Integer (..),
+    compareInteger#,
     eqInteger#,
   )
 where
 
 foreign import prim (==#) :: Int# -> Int# -> Int#
 
+foreign import prim compareInt# :: Int# -> Int# -> Int#
+
 -- Temporary representation: this is a boxed wrapper around machine-sized
 -- Int#, not arbitrary precision. Integer needs to become a real
 -- arbitrary-precision type once aihc-base has the runtime and primitive
 -- support for that representation.
 data Integer = IS Int#
+
+compareInteger# :: Integer -> Integer -> Int#
+compareInteger# (IS x) (IS y) = compareInt# x y
 
 eqInteger# :: Integer -> Integer -> Int#
 eqInteger# (IS x) (IS y) = (==#) x y

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -14,7 +14,8 @@ module Prelude
     Maybe (..),
     Monad (..),
     Num (..),
-    Ord,
+    Ord (..),
+    Ordering (..),
     String,
     (&&),
     (++),
@@ -32,10 +33,12 @@ import Data.Bool (Bool (..), not, otherwise, (&&), (||))
 import Data.Kind (Type)
 import GHC.Int (Int (..))
 import GHC.Integer (Integer)
-import GHC.Internal.Integer (eqInteger#)
+import GHC.Internal.Integer (compareInteger#, eqInteger#)
 import GHC.Num (Num (..))
 
 foreign import prim (==#) :: Int# -> Int# -> Int#
+
+foreign import prim compareInt# :: Int# -> Int# -> Int#
 
 data Char
 
@@ -51,6 +54,8 @@ id x = x
 data Maybe a = Nothing | Just a
 
 data Either a b = Left a | Right b
+
+data Ordering = LT | EQ | GT
 
 class Eq a where
   (==) :: a -> a -> Bool
@@ -106,19 +111,173 @@ instance (Eq a, Eq b) => Eq (Either a b) where
 
   x /= y = not (x == y)
 
-class (Eq a) => Ord a
+instance Eq Ordering where
+  LT == LT = True
+  EQ == EQ = True
+  GT == GT = True
+  _ == _ = False
 
-instance Ord Bool
+  x /= y = not (x == y)
 
-instance Ord Int
+class (Eq a) => Ord a where
+  compare :: a -> a -> Ordering
+  (<) :: a -> a -> Bool
+  (<=) :: a -> a -> Bool
+  (>) :: a -> a -> Bool
+  (>=) :: a -> a -> Bool
+  max :: a -> a -> a
+  min :: a -> a -> a
 
-instance Ord Integer
+infix 4 <, <=, >, >=
 
-instance (Ord a) => Ord [a]
+instance Ord Bool where
+  compare = compareBool
+  x < y = lessBy compareBool x y
+  x <= y = lessOrEqualBy compareBool x y
+  x > y = greaterBy compareBool x y
+  x >= y = greaterOrEqualBy compareBool x y
+  max = maxBy compareBool
+  min = minBy compareBool
 
-instance (Ord a) => Ord (Maybe a)
+instance Ord Int where
+  compare = compareInt
+  x < y = lessBy compareInt x y
+  x <= y = lessOrEqualBy compareInt x y
+  x > y = greaterBy compareInt x y
+  x >= y = greaterOrEqualBy compareInt x y
+  max = maxBy compareInt
+  min = minBy compareInt
 
-instance (Ord a, Ord b) => Ord (Either a b)
+instance Ord Integer where
+  compare = compareInteger
+  x < y = lessBy compareInteger x y
+  x <= y = lessOrEqualBy compareInteger x y
+  x > y = greaterBy compareInteger x y
+  x >= y = greaterOrEqualBy compareInteger x y
+  max = maxBy compareInteger
+  min = minBy compareInteger
+
+instance (Ord a) => Ord [a] where
+  compare = compareList
+  xs < ys = lessBy compareList xs ys
+  xs <= ys = lessOrEqualBy compareList xs ys
+  xs > ys = greaterBy compareList xs ys
+  xs >= ys = greaterOrEqualBy compareList xs ys
+  max = maxBy compareList
+  min = minBy compareList
+
+instance (Ord a) => Ord (Maybe a) where
+  compare = compareMaybe
+  x < y = lessBy compareMaybe x y
+  x <= y = lessOrEqualBy compareMaybe x y
+  x > y = greaterBy compareMaybe x y
+  x >= y = greaterOrEqualBy compareMaybe x y
+  max = maxBy compareMaybe
+  min = minBy compareMaybe
+
+instance (Ord a, Ord b) => Ord (Either a b) where
+  compare = compareEither
+  x < y = lessBy compareEither x y
+  x <= y = lessOrEqualBy compareEither x y
+  x > y = greaterBy compareEither x y
+  x >= y = greaterOrEqualBy compareEither x y
+  max = maxBy compareEither
+  min = minBy compareEither
+
+instance Ord Ordering where
+  compare = compareOrdering
+  x < y = lessBy compareOrdering x y
+  x <= y = lessOrEqualBy compareOrdering x y
+  x > y = greaterBy compareOrdering x y
+  x >= y = greaterOrEqualBy compareOrdering x y
+  max = maxBy compareOrdering
+  min = minBy compareOrdering
+
+compareBool :: Bool -> Bool -> Ordering
+compareBool False False = EQ
+compareBool False True = LT
+compareBool True False = GT
+compareBool True True = EQ
+
+compareInt :: Int -> Int -> Ordering
+compareInt (I# x) (I# y) = orderingFromInt# (compareInt# x y)
+
+compareInteger :: Integer -> Integer -> Ordering
+compareInteger x y = orderingFromInt# (compareInteger# x y)
+
+compareList :: (Ord a) => [a] -> [a] -> Ordering
+compareList [] [] = EQ
+compareList [] (_ : _) = LT
+compareList (_ : _) [] = GT
+compareList (x : xs) (y : ys) =
+  case compare x y of
+    LT -> LT
+    EQ -> compareList xs ys
+    GT -> GT
+
+compareMaybe :: (Ord a) => Maybe a -> Maybe a -> Ordering
+compareMaybe Nothing Nothing = EQ
+compareMaybe Nothing (Just _) = LT
+compareMaybe (Just _) Nothing = GT
+compareMaybe (Just x) (Just y) = compare x y
+
+compareEither :: (Ord a, Ord b) => Either a b -> Either a b -> Ordering
+compareEither (Left x) (Left y) = compare x y
+compareEither (Left _) (Right _) = LT
+compareEither (Right _) (Left _) = GT
+compareEither (Right x) (Right y) = compare x y
+
+compareOrdering :: Ordering -> Ordering -> Ordering
+compareOrdering LT LT = EQ
+compareOrdering LT _ = LT
+compareOrdering EQ LT = GT
+compareOrdering EQ EQ = EQ
+compareOrdering EQ GT = LT
+compareOrdering GT GT = EQ
+compareOrdering GT _ = GT
+
+orderingFromInt# :: Int# -> Ordering
+orderingFromInt# value =
+  case value of
+    0# -> EQ
+    1# -> GT
+    _ -> LT
+
+lessBy :: (a -> a -> Ordering) -> a -> a -> Bool
+lessBy cmp x y =
+  case cmp x y of
+    LT -> True
+    _ -> False
+
+lessOrEqualBy :: (a -> a -> Ordering) -> a -> a -> Bool
+lessOrEqualBy cmp x y =
+  case cmp x y of
+    GT -> False
+    _ -> True
+
+greaterBy :: (a -> a -> Ordering) -> a -> a -> Bool
+greaterBy cmp x y =
+  case cmp x y of
+    GT -> True
+    _ -> False
+
+greaterOrEqualBy :: (a -> a -> Ordering) -> a -> a -> Bool
+greaterOrEqualBy cmp x y =
+  case cmp x y of
+    LT -> False
+    _ -> True
+
+maxBy :: (a -> a -> Ordering) -> a -> a -> a
+maxBy cmp x y =
+  case cmp x y of
+    GT -> x
+    _ -> y
+
+minBy :: (a -> a -> Ordering) -> a -> a -> a
+minBy cmp x y =
+  case cmp x y of
+    GT -> y
+    _ -> x
 
 (++) :: [a] -> [a] -> [a]
 (++) [] ys = ys

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -14,6 +14,7 @@ module Prelude
     Maybe (..),
     Monad (..),
     Num (..),
+    Ord,
     String,
     (&&),
     (++),
@@ -31,6 +32,7 @@ import Data.Bool (Bool (..), not, otherwise, (&&), (||))
 import Data.Kind (Type)
 import GHC.Int (Int (..))
 import GHC.Integer (Integer)
+import GHC.Internal.Integer (eqInteger#)
 import GHC.Num (Num (..))
 
 foreign import prim (==#) :: Int# -> Int# -> Int#
@@ -72,6 +74,14 @@ instance Eq Int where
 
   x /= y = not (x == y)
 
+instance Eq Integer where
+  x == y =
+    case eqInteger# x y of
+      0# -> False
+      _ -> True
+
+  x /= y = not (x == y)
+
 instance (Eq a) => Eq [a] where
   [] == [] = True
   [] == (_ : _) = False
@@ -79,6 +89,36 @@ instance (Eq a) => Eq [a] where
   (x : xs) == (y : ys) = x == y && xs == ys
 
   xs /= ys = not (xs == ys)
+
+instance (Eq a) => Eq (Maybe a) where
+  Nothing == Nothing = True
+  Nothing == Just _ = False
+  Just _ == Nothing = False
+  Just x == Just y = x == y
+
+  x /= y = not (x == y)
+
+instance (Eq a, Eq b) => Eq (Either a b) where
+  Left x == Left y = x == y
+  Left _ == Right _ = False
+  Right _ == Left _ = False
+  Right x == Right y = x == y
+
+  x /= y = not (x == y)
+
+class (Eq a) => Ord a
+
+instance Ord Bool
+
+instance Ord Int
+
+instance Ord Integer
+
+instance (Ord a) => Ord [a]
+
+instance (Ord a) => Ord (Maybe a)
+
+instance (Ord a, Ord b) => Ord (Either a b)
 
 (++) :: [a] -> [a] -> [a]
 (++) [] ys = ys

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -4,6 +4,7 @@
 
 module GHC.Prim
   ( catch#,
+    compareInt#,
     raise#,
     State#,
     RealWorld,
@@ -18,6 +19,8 @@ data State# s
 data RealWorld
 
 foreign import prim raise# :: a -> b
+
+foreign import prim compareInt# :: Int# -> Int# -> Int#
 
 foreign import prim
   catch# ::


### PR DESCRIPTION
## Summary

- add `compareInt#`, a three-way `Int#` comparison primitive exposed by `GHC.Prim`
- implement the full `Ord` method surface and structural instances required by `lawful`
- expose `Ordering` and implement `Data.Ord.comparing`
- preserve transitive imported type re-exports so `Prelude` exposes `Integer`
- infer class-parameter kinds from superclass constraints before defaulting them
- cover transitive type re-exports and constraint-kinded multi-parameter classes

## Validation

- `cabal run -v0 aihc -- install lawful`
- `just fmt`
- `just check`

## Progress counts

- resolver golden fixtures: +1 passing fixture
- installer integration tests: +1 passing test
- FC evaluation fixtures: +2 passing fixtures
- README progress counts unchanged (managed by cron)
