### PR TITLE
feat(fc): evaluate CInt ccall imports

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -189,20 +189,26 @@ handleReplInput session input =
 evaluateExpression :: ReplSession -> Text -> IO (Either ReplError Text)
 evaluateExpression session input = do
   settings <- readIORef (replSettings session)
-  pure $ do
-    checked <- typecheckExpression session input
-    let expr = checkedExpr checked
-        resolvedModule = checkedResolvedModule checked
-        tcResult = checkedTcModule checked
-        inferredType = checkedType checked
-        allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
-        dsResult = desugarModuleWithBindings allBindings tcResult resolvedModule
-    if dsSuccess dsResult
-      then pure ()
-      else Left (ReplDesugarError (dsErrors dsResult))
-    value <- mapLeft (ReplEvalError . show) (evalProgramBinding replBindingName (concatPrograms [replDependencyProgram session, dsProgram dsResult]))
-    renderedValue <- mapLeft (ReplEvalError . show) (renderValue value)
-    Right (renderEvaluation settings expr inferredType dsResult renderedValue)
+  case typecheckExpression session input of
+    Left err -> pure (Left err)
+    Right checked -> do
+      let expr = checkedExpr checked
+          resolvedModule = checkedResolvedModule checked
+          tcResult = checkedTcModule checked
+          inferredType = checkedType checked
+          allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
+          dsResult = desugarModuleWithBindings allBindings tcResult resolvedModule
+      if not (dsSuccess dsResult)
+        then pure (Left (ReplDesugarError (dsErrors dsResult)))
+        else do
+          valueResult <- evalProgramBinding replBindingName (concatPrograms [replDependencyProgram session, dsProgram dsResult])
+          case mapLeft (ReplEvalError . show) valueResult of
+            Left err -> pure (Left err)
+            Right value -> do
+              renderedResult <- renderValue value
+              pure $ do
+                renderedValue <- mapLeft (ReplEvalError . show) renderedResult
+                Right (renderEvaluation settings expr inferredType dsResult renderedValue)
 
 typecheckExpression :: ReplSession -> Text -> Either ReplError CheckedExpression
 typecheckExpression session input = do

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -30,6 +30,7 @@ library
     containers,
     text >=1.2,
     transformers,
+    unix,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/components/aihc-fc/common/FcEvalGolden.hs
+++ b/components/aihc-fc/common/FcEvalGolden.hs
@@ -149,26 +149,32 @@ evaluateFcEvalCase tc =
     Right (modules, expr) -> do
       let evalModules = combineModules modules expr
       dependencyModules <- loadDependencyModules tc evalModules
-      pure $
-        case dependencyModules of
-          Left errMsg -> classifyFailure tc errMsg
-          Right deps ->
-            let resolved = resolveWithDeps mempty (deps <> evalModules)
-             in case resolved of
-                  ResolveResult {resolvedModules, resolveErrors = []} ->
-                    let tcResults = typecheckModulesWithEnv [] resolvedModules
-                     in if all tcModuleSuccess tcResults
-                          then
-                            let allBindings = moduleGroupBindings tcResults
-                                results = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
-                             in if all dsSuccess results
-                                  then case evalProgramBinding evalBindingName (concatPrograms (map dsProgram results)) >>= renderRawValue of
-                                    Right actual -> classifySuccess tc (T.unpack actual)
-                                    Left err -> classifyFailure tc ("eval error: " <> show err)
-                                  else classifyFailure tc ("desugar error: " <> unlines (concatMap dsErrors results))
-                          else classifyFailure tc ("typecheck error: " <> renderTcErrors tcResults)
-                  ResolveResult {resolveErrors} ->
-                    classifyFailure tc ("resolve error: " <> show resolveErrors)
+      case dependencyModules of
+        Left errMsg -> pure (classifyFailure tc errMsg)
+        Right deps ->
+          let resolved = resolveWithDeps mempty (deps <> evalModules)
+           in case resolved of
+                ResolveResult {resolvedModules, resolveErrors = []} ->
+                  let tcResults = typecheckModulesWithEnv [] resolvedModules
+                   in if all tcModuleSuccess tcResults
+                        then do
+                          let allBindings = moduleGroupBindings tcResults
+                              results = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
+                          if all dsSuccess results
+                            then do
+                              evalResult <- evalProgramBinding evalBindingName (concatPrograms (map dsProgram results))
+                              case evalResult of
+                                Left err -> pure (classifyFailure tc ("eval error: " <> show err))
+                                Right value -> do
+                                  renderResult <- renderRawValue value
+                                  pure $
+                                    case renderResult of
+                                      Right actual -> classifySuccess tc (T.unpack actual)
+                                      Left err -> classifyFailure tc ("eval error: " <> show err)
+                            else pure (classifyFailure tc ("desugar error: " <> unlines (concatMap dsErrors results)))
+                        else pure (classifyFailure tc ("typecheck error: " <> renderTcErrors tcResults))
+                ResolveResult {resolveErrors} ->
+                  pure (classifyFailure tc ("resolve error: " <> show resolveErrors))
 
 parseInputs :: FcEvalCase -> Either String ([Module], Expr)
 parseInputs tc = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -25,11 +25,14 @@ import Aihc.Parser.Syntax
     Expr,
     ForeignDecl (..),
     ForeignDirection (..),
+    ForeignEntitySpec (..),
+    ForeignSafety (..),
     InstanceDecl (..),
     InstanceDeclItem (..),
     Match (..),
     MatchHeadForm (..),
     Module (..),
+    NewtypeDecl (..),
     Pattern (..),
     Rhs,
     UnqualifiedName (..),
@@ -142,8 +145,9 @@ dsModule m = do
 -- | Desugar a single declaration (data types only; values handled by groups).
 dsDecl :: Decl -> DsM [FcTopBind]
 dsDecl (DeclData dd) = (: []) <$> dsDataDeclM dd
+dsDecl (DeclNewtype nd) = (: []) <$> dsNewtypeDeclM nd
 dsDecl (DeclAnn ann (DeclForeign foreignDecl))
-  | Just tcAnn <- fromAnnotation ann = (: []) <$> dsForeignPrim tcAnn foreignDecl
+  | Just tcAnn <- fromAnnotation ann = (: []) <$> dsForeignImport tcAnn foreignDecl
 dsDecl (DeclAnn ann (DeclClass _classDecl))
   | Just classAnn <- fromAnnotation ann = dsClassDeclM classAnn
 dsDecl (DeclAnn _ inner) = dsDecl inner
@@ -157,16 +161,73 @@ dsDataDeclM dd = do
   cons <- mapM dsDataConM (dataDeclConstructors dd)
   pure (FcData tyName [] cons)
 
+-- | Preserve newtype declarations as distinct FC bindings so backends may
+-- erase their representation while the evaluator can still model source-level
+-- construction and pattern matching.
+dsNewtypeDeclM :: NewtypeDecl -> DsM FcTopBind
+dsNewtypeDeclM nd = do
+  let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead nd))
+  case newtypeDeclConstructor nd of
+    Nothing -> desugarBug ("newtype " <> T.unpack tyName <> " has no constructor")
+    Just con -> do
+      (conName, fields) <- dsDataConM con
+      case fields of
+        [fieldTy] -> pure (FcNewtype tyName [] conName fieldTy)
+        _ -> desugarBug ("newtype constructor " <> T.unpack conName <> " does not have exactly one field")
+
+dsForeignImport :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
+dsForeignImport tcAnn foreignDecl
+  | foreignDirection foreignDecl /= ForeignImport =
+      desugarBug "unsupported foreign export after type checking"
+  | otherwise =
+      case foreignCallConv foreignDecl of
+        CPrim -> dsForeignPrim tcAnn foreignDecl
+        CCall -> dsForeignCcall tcAnn foreignDecl
+        callConv -> desugarBug ("unsupported foreign calling convention after type checking: " <> show callConv)
+
 dsForeignPrim :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
-dsForeignPrim tcAnn foreignDecl
-  | foreignDirection foreignDecl /= ForeignImport || foreignCallConv foreignDecl /= CPrim =
-      desugarBug "unsupported non-prim foreign declaration after type checking"
-  | otherwise = do
-      let name = unqualifiedNameText (foreignName foreignDecl)
-          ty = tcAnnType tcAnn
-      arity <- validatePrimitiveImport name ty
-      unique <- freshUnique
-      pure (FcPrimitive (Var name unique ty) arity)
+dsForeignPrim tcAnn foreignDecl = do
+  let name = unqualifiedNameText (foreignName foreignDecl)
+      ty = tcAnnType tcAnn
+  arity <- validatePrimitiveImport name ty
+  unique <- freshUnique
+  pure (FcPrimitive (Var name unique ty) arity)
+
+dsForeignCcall :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
+dsForeignCcall tcAnn foreignDecl = do
+  if foreignSafety foreignDecl == Just Unsafe
+    then pure ()
+    else desugarBug "only unsafe foreign imports are supported"
+  symbol <-
+    case foreignEntity foreignDecl of
+      ForeignEntityNamed name -> pure name
+      ForeignEntityStatic (Just name) -> pure name
+      ForeignEntityOmitted -> pure (unqualifiedNameText (foreignName foreignDecl))
+      _ -> desugarBug "only statically named foreign imports are supported"
+  let name = unqualifiedNameText (foreignName foreignDecl)
+      ty = tcAnnType tcAnn
+  abi <- foreignCallAbi ty
+  unique <- freshUnique
+  pure
+    ( FcForeignImport
+        FcForeignCall
+          { fcForeignCallVar = Var name unique ty,
+            fcForeignCallSymbol = symbol,
+            fcForeignCallAbi = abi
+          }
+    )
+
+foreignCallAbi :: TcType -> DsM FcForeignCallAbi
+foreignCallAbi (TcFunTy argument result)
+  | isCIntTy argument,
+    isCIntTy result =
+      pure FcCIntToCInt
+foreignCallAbi ty =
+  desugarBug ("unsupported foreign import type: " <> show ty)
+
+isCIntTy :: TcType -> Bool
+isCIntTy (TcTyCon (TyCon "CInt" 0) []) = True
+isCIntTy _ = False
 
 validatePrimitiveImport :: Text -> TcType -> DsM Int
 validatePrimitiveImport name ty =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Small evaluator for the System FC subset used by the REPL MVP.
@@ -12,11 +13,20 @@ module Aihc.Fc.Eval
 where
 
 import Aihc.Fc.Syntax
+import Control.Exception (SomeException, displayException, try)
 import Control.Monad ((<=<))
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
+import Foreign.C.Types (CInt (..))
+import Foreign.Ptr (FunPtr)
+import System.Posix.DynamicLinker (DL (Default), dlsym)
+
+foreign import ccall unsafe "dynamic"
+  callCIntToCInt :: FunPtr (CInt -> CInt) -> CInt -> CInt
 
 data EvalError
   = EvalUnboundVariable Text
@@ -25,6 +35,8 @@ data EvalError
   | EvalNoMatchingAlternative Value
   | EvalPrimitiveArity Text Int
   | EvalPrimitiveTypeError Text Value
+  | EvalForeignTypeError Text Value
+  | EvalForeignLookupError Text Text
   | EvalInvalidDictSelect Value Int
   | EvalRaisedException Value
   deriving (Eq, Show)
@@ -35,20 +47,28 @@ data Value
   | VConstructor Text [Value]
   | VDict [Value]
   | VPrim Text Int [Value]
+  | VForeign FcForeignCall [Value]
   | VThunk Env FcExpr
   deriving (Eq, Show)
 
 type Env = Map Text Value
 
-evalProgramBinding :: Text -> FcProgram -> Either EvalError Value
-evalProgramBinding name program =
+type EvalM = ExceptT EvalError IO
+
+evalProgramBinding :: Text -> FcProgram -> IO (Either EvalError Value)
+evalProgramBinding name program = runExceptT $
   case Map.lookup name env of
     Just value -> forceValue value
-    Nothing -> Left (EvalMissingBinding name)
+    Nothing -> throwE (EvalMissingBinding name)
   where
-    env = primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
+    env = foreignTopEnv `Map.union` primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
+    foreignTopEnv = Map.fromList (concatMap foreignTopBindingValues (fcTopBinds program))
     primitiveTopEnv = Map.fromList (concatMap primitiveTopBindingValues (fcTopBinds program))
     topEnv = Map.fromList (concatMap topBindingValues (fcTopBinds program))
+    foreignTopBindingValues (FcForeignImport foreignCall) =
+      [(varName (fcForeignCallVar foreignCall), VForeign foreignCall [])]
+    foreignTopBindingValues _ =
+      []
     primitiveTopBindingValues (FcPrimitive var arity) =
       [(varName var, VPrim (varName var) arity [])]
     primitiveTopBindingValues _ =
@@ -59,11 +79,15 @@ evalProgramBinding name program =
       [(varName var, VThunk env expr) | (var, expr) <- bindings]
     topBindingValues (FcData _ _ constructors) =
       [(conName, VConstructor conName []) | (conName, _) <- constructors]
+    topBindingValues (FcNewtype _ _ conName _) =
+      [(conName, VConstructor conName [])]
     topBindingValues FcPrimitive {} =
       []
+    topBindingValues FcForeignImport {} =
+      []
 
-evalExpr :: FcExpr -> Either EvalError Value
-evalExpr = evalWithEnv builtinConstructorEnv
+evalExpr :: FcExpr -> IO (Either EvalError Value)
+evalExpr = runExceptT . evalWithEnv builtinConstructorEnv
 
 builtinConstructorEnv :: Env
 builtinConstructorEnv =
@@ -75,15 +99,15 @@ builtinConstructorEnv =
       ("(#,#)", VConstructor "(#,#)" [])
     ]
 
-evalWithEnv :: Env -> FcExpr -> Either EvalError Value
+evalWithEnv :: Env -> FcExpr -> EvalM Value
 evalWithEnv env expr =
   case expr of
     FcVar var ->
       case Map.lookup (varName var) env of
         Just value -> forceValue value
-        Nothing -> Left (EvalUnboundVariable (varName var))
+        Nothing -> throwE (EvalUnboundVariable (varName var))
     FcLit lit ->
-      Right (VLit lit)
+      pure (VLit lit)
     FcApp fun arg -> do
       funValue <- evalWithEnv env fun
       applyValue funValue (VThunk env arg)
@@ -93,13 +117,13 @@ evalWithEnv env expr =
     FcTyApp inner _ ->
       evalWithEnv env inner
     FcLam var body ->
-      Right (VClosure env var body)
+      pure (VClosure env var body)
     FcTyLam _ body ->
       evalWithEnv env body
     FcDictLam var body ->
-      Right (VClosure env var body)
+      pure (VClosure env var body)
     FcDict fields ->
-      VDict <$> mapM (pure . VThunk env) fields
+      pure (VDict (map (VThunk env) fields))
     FcDictSelect dict index -> do
       dictValue <- evalWithEnv env dict >>= forceValue
       case dictValue of
@@ -107,8 +131,8 @@ evalWithEnv env expr =
           | index >= 0,
             index < length fields ->
               forceValue (fields !! index)
-          | otherwise -> Left (EvalInvalidDictSelect dictValue index)
-        _ -> Left (EvalApplyNonFunction dictValue)
+          | otherwise -> throwE (EvalInvalidDictSelect dictValue index)
+        _ -> throwE (EvalApplyNonFunction dictValue)
     FcLet bind body ->
       evalWithEnv (extendBind env bind) body
     FcCase scrut _ alts -> do
@@ -117,32 +141,34 @@ evalWithEnv env expr =
     FcCast inner _ ->
       evalWithEnv env inner
 
-forceValue :: Value -> Either EvalError Value
+forceValue :: Value -> EvalM Value
 forceValue value =
   case value of
     VThunk env expr -> evalWithEnv env expr
-    _ -> Right value
+    _ -> pure value
 
-applyValue :: Value -> Value -> Either EvalError Value
+applyValue :: Value -> Value -> EvalM Value
 applyValue value arg = do
   forced <- forceValue value
   case forced of
     VClosure closureEnv var body ->
       evalWithEnv (Map.insert (varName var) arg closureEnv) body
     VConstructor name args ->
-      Right (VConstructor name (args <> [arg]))
+      pure (VConstructor name (args <> [arg]))
     VPrim name arity args ->
       applyPrimitive name arity (args <> [arg])
+    VForeign foreignCall args ->
+      applyForeign foreignCall (args <> [arg])
     _ ->
-      Left (EvalApplyNonFunction forced)
+      throwE (EvalApplyNonFunction forced)
 
-applyPrimitive :: Text -> Int -> [Value] -> Either EvalError Value
+applyPrimitive :: Text -> Int -> [Value] -> EvalM Value
 applyPrimitive name arity args
-  | length args < arity = Right (VPrim name arity args)
+  | length args < arity = pure (VPrim name arity args)
   | length args == arity = evalPrimitive name args
-  | otherwise = Left (EvalPrimitiveArity name (length args))
+  | otherwise = throwE (EvalPrimitiveArity name (length args))
 
-evalPrimitive :: Text -> [Value] -> Either EvalError Value
+evalPrimitive :: Text -> [Value] -> EvalM Value
 evalPrimitive "+#" [left, right] =
   evalIntPrim "+#" (+) left right
 evalPrimitive "-#" [left, right] =
@@ -156,15 +182,16 @@ evalPrimitive "<#" [left, right] =
 evalPrimitive "==#" [left, right] =
   evalIntPrim "==#" (\leftInt rightInt -> if leftInt == rightInt then 1 else 0) left right
 evalPrimitive "raise#" [exception] =
-  Left . EvalRaisedException =<< forceValue exception
+  throwE . EvalRaisedException =<< forceValue exception
 evalPrimitive "catch#" [action, handler, state] =
-  case applyValue action state of
-    Left (EvalRaisedException exception) -> do
+  applyValue action state `catchE` handleRaised
+  where
+    handleRaised (EvalRaisedException exception) = do
       handlerWithException <- applyValue handler exception
       applyValue handlerWithException state
-    result -> result
+    handleRaised err = throwE err
 evalPrimitive name args =
-  Left (EvalPrimitiveArity name (length args))
+  throwE (EvalPrimitiveArity name (length args))
 
 compareInts :: Integer -> Integer -> Integer
 compareInts left right =
@@ -173,18 +200,66 @@ compareInts left right =
     EQ -> 0
     GT -> 1
 
-evalIntPrim :: Text -> (Integer -> Integer -> Integer) -> Value -> Value -> Either EvalError Value
+evalIntPrim :: Text -> (Integer -> Integer -> Integer) -> Value -> Value -> EvalM Value
 evalIntPrim name op left right = do
   leftInt <- forceIntPrimitiveArg name left
   rightInt <- forceIntPrimitiveArg name right
   pure (VLit (LitInt (op leftInt rightInt)))
 
-forceIntPrimitiveArg :: Text -> Value -> Either EvalError Integer
+forceIntPrimitiveArg :: Text -> Value -> EvalM Integer
 forceIntPrimitiveArg name value = do
   forced <- forceValue value
   case forced of
     VLit (LitInt intValue) -> pure intValue
-    other -> Left (EvalPrimitiveTypeError name other)
+    other -> throwE (EvalPrimitiveTypeError name other)
+
+applyForeign :: FcForeignCall -> [Value] -> EvalM Value
+applyForeign foreignCall args =
+  case (fcForeignCallAbi foreignCall, args) of
+    (FcCIntToCInt, []) -> pure (VForeign foreignCall [])
+    (FcCIntToCInt, [argument]) -> evalCIntToCInt foreignCall argument
+    _ -> throwE (EvalPrimitiveArity (varName (fcForeignCallVar foreignCall)) (length args))
+
+evalCIntToCInt :: FcForeignCall -> Value -> EvalM Value
+evalCIntToCInt foreignCall argument = do
+  argumentValue <- forceCInt (fcForeignCallSymbol foreignCall) argument
+  lookupResult <-
+    lift
+      ( try (dlsym Default (T.unpack (fcForeignCallSymbol foreignCall))) ::
+          IO (Either SomeException (FunPtr (CInt -> CInt)))
+      )
+  functionPointer <-
+    case lookupResult of
+      Left err ->
+        throwE
+          ( EvalForeignLookupError
+              (fcForeignCallSymbol foreignCall)
+              (T.pack (displayException err))
+          )
+      Right pointer -> pure pointer
+  let CInt result = callCIntToCInt functionPointer (CInt (fromInteger argumentValue))
+  pure (cIntValue (toInteger result))
+
+forceCInt :: Text -> Value -> EvalM Integer
+forceCInt symbol value = do
+  forced <- forceValue value
+  case forced of
+    VConstructor "CInt" [int32] -> forceInt32 int32
+    other -> throwE (EvalForeignTypeError symbol other)
+  where
+    forceInt32 int32 = do
+      forcedInt32 <- forceValue int32
+      case forcedInt32 of
+        VConstructor "I32#" [literal] -> do
+          forcedLiteral <- forceValue literal
+          case forcedLiteral of
+            VLit (LitInt intValue) -> pure intValue
+            other -> throwE (EvalForeignTypeError symbol other)
+        other -> throwE (EvalForeignTypeError symbol other)
+
+cIntValue :: Integer -> Value
+cIntValue value =
+  VConstructor "CInt" [VConstructor "I32#" [VLit (LitInt value)]]
 
 extendBind :: Env -> FcBind -> Env
 extendBind env bind =
@@ -197,11 +272,11 @@ extendBind env bind =
         recEnv = foldr insertBinding env bindings
         insertBinding (var, expr) = Map.insert (varName var) (VThunk recEnv expr)
 
-matchAlternative :: Env -> Value -> [FcAlt] -> Either EvalError Value
+matchAlternative :: Env -> Value -> [FcAlt] -> EvalM Value
 matchAlternative env value =
   go
   where
-    go [] = Left (EvalNoMatchingAlternative value)
+    go [] = throwE (EvalNoMatchingAlternative value)
     go (alt : rest) =
       case matchAlt value alt of
         Just bindings -> evalWithEnv (bindings <> env) (altRhs alt)
@@ -222,50 +297,68 @@ matchAlt value alt =
     _ ->
       Nothing
 
-renderValue :: Value -> Either EvalError Text
-renderValue value = do
+renderValue :: Value -> IO (Either EvalError Text)
+renderValue = runExceptT . renderValueM
+
+renderValueM :: Value -> EvalM Text
+renderValueM value = do
   forced <- forceValue value
-  case collectString forced of
+  stringValue <- collectString forced
+  case stringValue of
     Just text -> pure (T.pack (show (T.unpack text)))
     Nothing -> renderForcedValue forced
 
-renderForcedValue :: Value -> Either EvalError Text
+renderForcedValue :: Value -> EvalM Text
 renderForcedValue value =
   case value of
     VLit lit -> pure (renderLiteral lit)
     VConstructor name [] -> pure name
-    VConstructor ":" _ | Just elems <- collectList value -> do
-      renderedElems <- mapM (renderValue <=< forceValue) elems
-      pure ("[" <> T.intercalate ", " renderedElems <> "]")
+    VConstructor ":" _ -> do
+      listValue <- collectList value
+      case listValue of
+        Just elems -> do
+          renderedElems <- mapM (renderValueM <=< forceValue) elems
+          pure ("[" <> T.intercalate ", " renderedElems <> "]")
+        Nothing -> renderConstructor value
     VConstructor name args -> do
-      renderedArgs <- mapM (renderValue <=< forceValue) args
+      renderedArgs <- mapM (renderValueM <=< forceValue) args
       pure (T.unwords (name : renderedArgs))
     VDict {} -> pure "<dictionary>"
     VClosure {} -> pure "<function>"
     VPrim {} -> pure "<function>"
-    VThunk {} -> renderValue value
-
-collectString :: Value -> Maybe Text
-collectString value = do
-  values <- collectList value
-  chars <- traverse charValue values
-  pure (T.pack chars)
+    VForeign {} -> pure "<function>"
+    VThunk {} -> renderValueM value
   where
-    charValue item =
-      case item of
-        VLit (LitChar c) -> Just c
-        VThunk {} -> either (const Nothing) charValue (forceValue item)
-        _ -> Nothing
+    renderConstructor (VConstructor name args) = do
+      renderedArgs <- mapM (renderValueM <=< forceValue) args
+      pure (T.unwords (name : renderedArgs))
+    renderConstructor other = renderForcedValue other
 
-collectList :: Value -> Maybe [Value]
-collectList value =
-  case value of
-    VConstructor "[]" [] -> Just []
+collectString :: Value -> EvalM (Maybe Text)
+collectString value = do
+  listValue <- collectList value
+  case listValue of
+    Nothing -> pure Nothing
+    Just values -> do
+      chars <- traverse charValue values
+      pure (T.pack <$> sequence chars)
+  where
+    charValue item = do
+      forced <- forceValue item
+      pure $
+        case forced of
+          VLit (LitChar c) -> Just c
+          _ -> Nothing
+
+collectList :: Value -> EvalM (Maybe [Value])
+collectList value = do
+  forced <- forceValue value
+  case forced of
+    VConstructor "[]" [] -> pure (Just [])
     VConstructor ":" [headValue, tailValue] -> do
-      tailValue' <- either (const Nothing) Just (forceValue tailValue)
-      (headValue :) <$> collectList tailValue'
-    VThunk {} -> either (const Nothing) collectList (forceValue value)
-    _ -> Nothing
+      tailValues <- collectList tailValue
+      pure ((headValue :) <$> tailValues)
+    _ -> pure Nothing
 
 renderLiteral :: Literal -> Text
 renderLiteral lit =
@@ -274,8 +367,11 @@ renderLiteral lit =
     LitChar c -> T.pack (show c)
     LitString s -> T.pack (show (T.unpack s))
 
-renderRawValue :: Value -> Either EvalError Text
-renderRawValue value = do
+renderRawValue :: Value -> IO (Either EvalError Text)
+renderRawValue = runExceptT . renderRawValueM
+
+renderRawValueM :: Value -> EvalM Text
+renderRawValueM value = do
   forced <- forceValue value
   case forced of
     VLit lit -> pure (renderLiteral lit)
@@ -289,12 +385,13 @@ renderRawValue value = do
     VDict {} -> pure "<dictionary>"
     VClosure {} -> pure "<function>"
     VPrim {} -> pure "<function>"
-    VThunk {} -> renderRawValue forced
+    VForeign {} -> pure "<function>"
+    VThunk {} -> renderRawValueM forced
 
-renderRawArg :: Value -> Either EvalError Text
+renderRawArg :: Value -> EvalM Text
 renderRawArg value = do
   forced <- forceValue value
-  rendered <- renderRawValue forced
+  rendered <- renderRawValueM forced
   pure $
     case forced of
       VConstructor name args | isTupleConstructor name (length args) -> rendered

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -78,8 +78,13 @@ lintProgram env0 prog = go env0 (fcTopBinds prog)
     go env (FcData {} : rest) =
       -- Data declarations don't need expression-level linting.
       go env rest
+    go env (FcNewtype {} : rest) =
+      -- Newtype declarations don't need expression-level linting.
+      go env rest
     go env (FcPrimitive var _arity : rest) =
       go (extendTermEnv var env) rest
+    go env (FcForeignImport foreignCall : rest) =
+      go (extendTermEnv (fcForeignCallVar foreignCall) env) rest
     go env (FcTopBind bind : rest) =
       let (errs, env') = lintBind env bind
        in errs ++ go env' rest

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -45,6 +45,14 @@ renderTopBind (FcData tyName tyVars cons) =
     ++ T.unpack tyName
     ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
     ++ renderDataCons cons
+renderTopBind (FcNewtype tyName tyVars conName fieldTy) =
+  "newtype "
+    ++ T.unpack tyName
+    ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
+    ++ " = "
+    ++ T.unpack conName
+    ++ " "
+    ++ renderTypePrec True fieldTy
 renderTopBind (FcPrimitive var arity) =
   "foreign prim "
     ++ renderVar var
@@ -52,6 +60,13 @@ renderTopBind (FcPrimitive var arity) =
     ++ show arity
     ++ " : "
     ++ renderType (varType var)
+renderTopBind (FcForeignImport foreignCall) =
+  "foreign ccall \""
+    ++ T.unpack (fcForeignCallSymbol foreignCall)
+    ++ "\" "
+    ++ renderVar (fcForeignCallVar foreignCall)
+    ++ " : "
+    ++ renderType (varType (fcForeignCallVar foreignCall))
 renderTopBind (FcTopBind bind) = renderBind 0 bind
 
 -- | Render data constructors.

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -21,6 +21,8 @@ module Aihc.Fc.Syntax
     FcBind (..),
     FcTopBind (..),
     FcProgram (..),
+    FcForeignCall (..),
+    FcForeignCallAbi (..),
 
     -- * Case alternatives
     FcAlt (..),
@@ -47,10 +49,32 @@ data FcTopBind
   = -- | Data type declaration: type name, type variable parameters,
     -- list of (constructor name, field types).
     FcData !Text ![TyVarId] ![(Text, [TcType])]
+  | -- | Newtype declaration: type name, type variable parameters, and its
+    -- single constructor.
+    FcNewtype !Text ![TyVarId] !Text !TcType
   | -- | A primitive imported by @foreign import prim@.
     FcPrimitive !Var !Int
+  | -- | A C function imported by @foreign import ccall@.
+    FcForeignImport !FcForeignCall
   | -- | Value binding.
     FcTopBind !FcBind
+  deriving (Eq, Show)
+
+-- | A statically named C function resolved by the evaluator or a code generator.
+data FcForeignCall = FcForeignCall
+  { fcForeignCallVar :: !Var,
+    fcForeignCallSymbol :: !Text,
+    fcForeignCallAbi :: !FcForeignCallAbi
+  }
+  deriving (Eq, Show)
+
+-- | Foreign ABI shapes supported by System FC lowering.
+--
+-- This is deliberately an algebraic type rather than an untyped arity. Each
+-- new shape must define its marshalling semantics before it can reach a
+-- backend or the interpreter.
+data FcForeignCallAbi
+  = FcCIntToCInt
   deriving (Eq, Show)
 
 -- | A typed variable.

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -52,12 +52,15 @@ fcEvalTests =
                 [ FcTopBind
                     (FcNonRec (var "answer" stringTy) (FcLit (LitString "top")))
                 ]
-         in assertEqual "result" (Right "\"top\"") (evalProgramBinding "answer" program >>= renderValue),
-      testCase "renders raw constructor values" $
+         in do
+              result <- evalProgramBinding "answer" program >>= renderEvalResult
+              assertEqual "result" (Right "\"top\"") result,
+      testCase "renders raw constructor values" $ do
+        result <- renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []])
         assertEqual
           "raw result"
           (Right ": 'x' []")
-          (renderRawValue (VConstructor ":" [VLit (LitChar 'x'), VConstructor "[]" []]))
+          result
     ]
 
 fcEvalFixtureTests :: IO TestTree
@@ -76,8 +79,15 @@ mkEvalFixtureTest tc = testCase (EvalGolden.evalCaseId tc) $ do
     EvalGolden.OutcomeFail -> assertFailure details
 
 assertEvalExpr :: Text -> FcExpr -> IO ()
-assertEvalExpr expected expr =
-  assertEqual "result" (Right expected) (evalExpr expr >>= renderValue)
+assertEvalExpr expected expr = do
+  result <- evalExpr expr >>= renderEvalResult
+  assertEqual "result" (Right expected) result
+
+renderEvalResult :: Either EvalError Value -> IO (Either EvalError Text)
+renderEvalResult result =
+  case result of
+    Left err -> pure (Left err)
+    Right value -> renderValue value
 
 var :: Text -> TcType -> Var
 var name = Var name (Unique 0)

--- a/components/aihc-fc/test/Test/Fixtures/eval/foreign-ccall-libc-abs.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/foreign-ccall-libc-abs.yaml
@@ -1,0 +1,20 @@
+extensions:
+  - ExtendedLiterals
+  - ForeignFunctionInterface
+  - MagicHash
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Int (Int32 (..))
+    import Foreign.C.Types (CInt (..))
+
+    foreign import ccall unsafe "abs" c_abs :: CInt -> CInt
+output: |
+  CInt (I32# 42)
+expression: |
+  c_abs (CInt (I32# (-42#Int32)))
+status: pass
+reason: dynamically resolves and invokes libc abs through an unsafe ccall

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -485,6 +485,7 @@ builtinTypeNames =
     -- Unboxed primitive types (GHC.Prim / GHC.Types)
     "Int#",
     "Int8#",
+    "Int32#",
     "Word#",
     "Char#",
     "Float#",

--- a/core-libs/aihc-base/src/Data/Int.hs
+++ b/core-libs/aihc-base/src/Data/Int.hs
@@ -1,6 +1,7 @@
 module Data.Int
   ( Int,
+    Int32 (..),
   )
 where
 
-import GHC.Int (Int)
+import GHC.Int (Int, Int32 (..))

--- a/core-libs/aihc-base/src/Foreign/C/Types.hs
+++ b/core-libs/aihc-base/src/Foreign/C/Types.hs
@@ -1,1 +1,8 @@
-module Foreign.C.Types () where
+module Foreign.C.Types
+  ( CInt (..),
+  )
+where
+
+import Data.Int (Int32)
+
+newtype CInt = CInt Int32

--- a/core-libs/aihc-base/src/GHC/Int.hs
+++ b/core-libs/aihc-base/src/GHC/Int.hs
@@ -2,6 +2,7 @@
 
 module GHC.Int
   ( Int (..),
+    Int32 (..),
   )
 where
 
@@ -12,3 +13,5 @@ foreign import prim (-#) :: Int# -> Int# -> Int#
 foreign import prim (*#) :: Int# -> Int# -> Int#
 
 data Int = I# Int#
+
+data Int32 = I32# Int32#

--- a/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Golden/Update.hs
@@ -408,20 +408,27 @@ fcEvalActual opts value =
     Left err -> pure (Left err)
     Right (dependencies, evalModules) -> do
       dependencyModules <- loadFcEvalDependencyModules opts dependencies evalModules
-      pure $ do
-        deps <- dependencyModules
-        case resolveWithDeps mempty (deps <> evalModules) of
-          ResolveResult {resolvedModules, resolveErrors = []} ->
-            let tcResults = typecheckModulesWithEnv [] resolvedModules
-             in if all tcModuleSuccess tcResults
-                  then
-                    let allBindings = moduleGroupBindings tcResults
-                        dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
-                     in if all dsSuccess dsResults
-                          then first (("eval error: " <>) . show) (T.unpack <$> (evalProgramBinding evalBindingName (concatPrograms (map dsProgram dsResults)) >>= renderRawValue))
-                          else Left ("desugar error: " <> unlines (concatMap dsErrors dsResults))
-                  else Left ("typecheck error: " <> renderTcErrors tcResults)
-          ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+      case dependencyModules of
+        Left err -> pure (Left err)
+        Right deps ->
+          case resolveWithDeps mempty (deps <> evalModules) of
+            ResolveResult {resolvedModules, resolveErrors = []} ->
+              let tcResults = typecheckModulesWithEnv [] resolvedModules
+               in if all tcModuleSuccess tcResults
+                    then do
+                      let allBindings = moduleGroupBindings tcResults
+                          dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
+                      if all dsSuccess dsResults
+                        then do
+                          evalResult <- evalProgramBinding evalBindingName (concatPrograms (map dsProgram dsResults))
+                          case evalResult of
+                            Left err -> pure (Left ("eval error: " <> show err))
+                            Right evaluated -> do
+                              renderResult <- renderRawValue evaluated
+                              pure (first (("eval error: " <>) . show) (T.unpack <$> renderResult))
+                        else pure (Left ("desugar error: " <> unlines (concatMap dsErrors dsResults)))
+                    else pure (Left ("typecheck error: " <> renderTcErrors tcResults))
+            ResolveResult {resolveErrors} -> pure (Left ("resolve error: " <> show resolveErrors))
 
 parseEvalInput :: Value -> Either String ([Text], [Module])
 parseEvalInput value = do


### PR DESCRIPTION
## Summary

- define the minimal `Int32` and `CInt` core-library surface
- lower statically named `foreign import ccall unsafe` declarations with an explicit `CInt -> CInt` ABI into System FC
- make the FC evaluator effectful and dynamically resolve C symbols from the host process
- invoke libc `abs` through a typed dynamic-call wrapper
- preserve newtype declarations in FC so the evaluator can model source construction while future backends may erase the representation
- add an end-to-end evaluation fixture for `foreign import ccall unsafe "abs"`

## Impact

AIHC's interpreter can now evaluate its first libc FFI call. The FC representation records the foreign symbol and supported ABI independently of the host loader, leaving native and WASM/WASI backends free to implement their own linking strategy.

## Progress counts

- FC evaluation fixtures: +1 passing fixture
- README progress counts unchanged (managed by cron)

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--pattern foreign-ccall-libc-abs --hide-successes"`
- `just fmt`
- `just check`
  - formatting and HLint
  - all component tests under `-Werror`
  - all 75 FC tests
  - all 1,861 parser tests
