### PR TITLE
feat(fc): evaluate visible type applications

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -433,6 +433,9 @@ dsExpr ETuple {} =
 dsExpr (EParen inner) = dsExpr inner
 dsExpr (EAnn _ann inner) = dsExpr inner
 dsExpr (ETypeSig inner _ty) = dsExpr inner
+-- The type checker records visible type arguments on the polymorphic
+-- occurrence, which 'dsAnnotatedVar' lowers to 'FcTyApp'.
+dsExpr (ETypeApp fun _ty) = dsExpr fun
 dsExpr (EIf cond thenE elseE) =
   dsIf cond thenE elseE
 dsExpr (ECase scrut alts) =

--- a/components/aihc-fc/test/Test/Fixtures/eval/base/num-int-visible-type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/eval/base/num-int-visible-type-application.yaml
@@ -1,0 +1,13 @@
+extensions:
+  - TypeApplications
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+output: |
+  I# 2
+expression: |
+  (+) @Int 1 1
+status: pass
+reason: visible type application selects the Num Int instance unambiguously

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -77,6 +77,8 @@ inferExprAt ambient expr = case expr of
     inferLambdaCases (exprSpan expr `orSourceSpan` ambient) alts
   EApp fun arg ->
     inferApp (exprSpan expr `orSourceSpan` ambient) fun arg
+  ETypeApp fun tyArg ->
+    inferTypeApp (exprSpan expr `orSourceSpan` ambient) fun tyArg
   EInfix lhs op rhs ->
     inferInfix (exprSpan expr `orSourceSpan` ambient) lhs op rhs
   EIf cond thenE elseE ->
@@ -378,6 +380,53 @@ inferApp sp fun arg = do
   ev <- freshEvVar
   let eqCt = mkWantedCt (EqPred funTy (TcFunTy argTy resTy)) ev (AppOrigin sp) sp
   pure (EApp fun' arg', resTy, funCts ++ argCts ++ [eqCt])
+
+inferTypeApp :: SourceSpan -> Expr -> Type -> TcM (Expr, TcType, [Ct])
+inferTypeApp sp fun tyArg = do
+  (fun', funTy, funCts) <- inferExpr fun
+  explicitTy <- checkSurfaceType Map.empty tyArg KType
+  case drop (visibleTypeApplicationCount fun) (pendingTypeArgs fun') of
+    inferredTy : _ -> do
+      ev <- freshEvVar
+      let origin = InstOrigin "visible type application"
+          eqCt =
+            mkWantedEqCt
+              TypeTrace
+                { typeTraceType = inferredTy,
+                  typeTraceRole = InferredType,
+                  typeTraceOrigin = ConstraintTypeOrigin origin
+                }
+              TypeTrace
+                { typeTraceType = explicitTy,
+                  typeTraceRole = RequiredType,
+                  typeTraceOrigin = ConstraintTypeOrigin origin
+                }
+              ev
+              origin
+              sp
+      pure (ETypeApp fun' tyArg, funTy, funCts <> [eqCt])
+    [] -> do
+      emitError sp (OtherError "visible type application requires a polymorphic expression")
+      pure (ETypeApp fun' tyArg, funTy, funCts)
+
+visibleTypeApplicationCount :: Expr -> Int
+visibleTypeApplicationCount expr =
+  case expr of
+    ETypeApp fun _ -> 1 + visibleTypeApplicationCount fun
+    EParen inner -> visibleTypeApplicationCount inner
+    EAnn _ inner -> visibleTypeApplicationCount inner
+    _ -> 0
+
+pendingTypeArgs :: Expr -> [TcType]
+pendingTypeArgs expr =
+  case expr of
+    EAnn ann inner ->
+      case fromAnnotation @PendingTcAnnotation ann of
+        Just pending -> pendingTcAnnTypeArgs pending
+        Nothing -> pendingTypeArgs inner
+    ETypeApp fun _ -> pendingTypeArgs fun
+    EParen inner -> pendingTypeArgs inner
+    _ -> []
 
 inferInfix :: SourceSpan -> Expr -> Name -> Expr -> TcM (Expr, TcType, [Ct])
 inferInfix sp lhs op rhs = do


### PR DESCRIPTION
## Summary

- add an `aihc-fc` eval fixture for `(+) @Int 1 1`
- teach `aihc-tc` to constrain visible type arguments against occurrence instantiations
- erase the surface type-application node in `aihc-fc` after its annotated occurrence lowers to `FcTyApp`

## Why

`ETypeApp` was parsed and resolved, but the type checker rejected it as an unsupported expression form. This prevented an explicit `@Int` from selecting the `Num Int` instance even though the expression is unambiguous.

## Impact

Visible type application now fixes the selected polymorphic occurrence type before class evidence is solved, so the FC evaluator produces `I# 2` for the requested expression.

## Progress

- `aihc-fc` test count: 75 -> 76
- README progress counts unchanged (cron-managed)

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--pattern num-int-visible-type-application --hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
