### PR TITLE
feat(arm64): compile Haskell source to native code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ result-*
 
 # Qwen Code
 .qwen/
+.aihc-cache/

--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -12,6 +12,7 @@ synopsis: Production command-line interface for the aihc compiler
 library
   exposed-modules:
     Aihc.Cli
+    Aihc.Cli.Compile
     Aihc.Cli.Install
     Aihc.Cli.Options
     Aihc.Cli.Repl
@@ -20,8 +21,10 @@ library
   build-depends:
     Cabal-syntax >=3.14 && <3.17,
     aeson >=2.0 && <2.3,
+    aihc-arm64,
     aihc-cpp,
     aihc-fc,
+    aihc-grin,
     aihc-hackage,
     aihc-parser,
     aihc-resolve,
@@ -34,6 +37,7 @@ library
     haskeline >=0.8 && <0.9,
     optparse-applicative >=0.16 && <0.19,
     prettyprinter,
+    process,
     text >=1.2.3 && <2.2,
 
   default-extensions: OverloadedStrings
@@ -71,6 +75,7 @@ test-suite spec
     directory,
     filepath,
     haskeline,
+    process,
     tasty,
     tasty-hunit,
     tasty-quickcheck,

--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -17,6 +17,9 @@ library
     Aihc.Cli.Options
     Aihc.Cli.Repl
 
+  other-modules:
+    Aihc.Cli.Compile.Dependencies
+
   hs-source-dirs: src
   build-depends:
     Cabal-syntax >=3.14 && <3.17,
@@ -80,6 +83,7 @@ test-suite spec
     tasty-hunit,
     tasty-quickcheck,
     text,
+    time,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/bin/aihc/src/Aihc/Cli.hs
+++ b/bin/aihc/src/Aihc/Cli.hs
@@ -4,6 +4,7 @@ module Aihc.Cli
   )
 where
 
+import Aihc.Cli.Compile (runCompile)
 import Aihc.Cli.Install (runInstall)
 import Aihc.Cli.Options (Command (..), ReplOptions (..), parseCommandIO)
 import Aihc.Cli.Repl (runRepl)
@@ -21,5 +22,6 @@ main = do
       exitFailure
 
 runCommand :: Command -> IO ()
+runCommand (CmdCompile opts) = runCompile opts
 runCommand (CmdInstall opts) = runInstall opts
 runCommand (CmdRepl opts) = runRepl (replStoreRoot opts)

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -37,7 +37,7 @@ import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
-import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithEnvAndInstances)
+import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithFullEnv)
 import Control.Exception (bracket)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -110,9 +110,10 @@ compileWithDependencies dependencies parsed =
   case resolveWithDeps (dependencyExports dependencies) [parsed] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
     ResolveResult {resolvedModules} ->
-      let checkedModules =
-            typecheckModulesWithEnvAndInstances
+      let (checkedModules, _, _) =
+            typecheckModulesWithFullEnv
               (dependencyTerms dependencies)
+              (dependencyTyCons dependencies)
               (dependencyInstances dependencies)
               resolvedModules
        in if not (all tcModuleSuccess checkedModules)

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Compile a standalone Haskell module through System FC and GRIN to a
+-- native Darwin AArch64 executable.
+module Aihc.Cli.Compile
+  ( CompileError (..),
+    compileOutputPath,
+    compileSourceToAssembly,
+    renderCompileError,
+    runCompile,
+  )
+where
+
+import Aihc.Arm64 (Arm64Error, compileProgram, runtimeSourcePath)
+import Aihc.Cli.Options (CompileOptions (..))
+import Aihc.Fc (DesugarResult (..), desugarModule)
+import Aihc.Grin (lowerProgram)
+import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
+import Aihc.Parser.Syntax (LanguageEdition (Haskell98Edition), effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
+import Aihc.Parser.Token (readModuleHeaderPragmas)
+import Control.Exception (bracket)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text.IO qualified as TIO
+import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.Exit (ExitCode (..))
+import System.FilePath (dropExtension, (</>))
+import System.IO (hClose, openTempFile)
+import System.Process (readProcessWithExitCode)
+
+data CompileError
+  = CompileParseError !String
+  | CompileFrontendError ![String]
+  | CompileArm64Error !Arm64Error
+  | CompileClangError !ExitCode !String
+  deriving (Eq, Show)
+
+runCompile :: CompileOptions -> IO ()
+runCompile options = do
+  source <- TIO.readFile (compileSourceFile options)
+  assembly <- either (ioError . userError . renderCompileError) pure (compileSourceToAssembly (compileSourceFile options) source)
+  let output = compileOutputPath options
+  if compileKeepAsm options
+    then do
+      let assemblyPath = output <> ".s"
+      TIO.writeFile assemblyPath assembly
+      assemble output assemblyPath
+    else withTemporaryDirectory "aihc-compile" $ \directory -> do
+      let assemblyPath = directory </> "program.s"
+      TIO.writeFile assemblyPath assembly
+      assemble output assemblyPath
+
+compileOutputPath :: CompileOptions -> FilePath
+compileOutputPath options =
+  fromMaybe defaultOutput (compileOutputFile options)
+  where
+    source = compileSourceFile options
+    withoutExtension = dropExtension source
+    defaultOutput
+      | withoutExtension == source = source <> ".out"
+      | otherwise = withoutExtension
+
+compileSourceToAssembly :: FilePath -> Text -> Either CompileError Text
+compileSourceToAssembly sourceName source = do
+  parsed <-
+    case parseModule config source of
+      ([], modu) -> Right modu
+      (errors, _) -> Left (CompileParseError (show errors))
+  let desugared = desugarModule parsed
+  if dsSuccess desugared
+    then either (Left . CompileArm64Error) Right (compileProgram "main" (lowerProgram (dsProgram desugared)))
+    else Left (CompileFrontendError (dsErrors desugared))
+  where
+    header = readModuleHeaderPragmas source
+    language = fromMaybe Haskell98Edition (headerLanguageEdition header)
+    config =
+      defaultConfig
+        { parserSourceName = sourceName,
+          parserExtensions = effectiveExtensions language (headerExtensionSettings header)
+        }
+
+renderCompileError :: CompileError -> String
+renderCompileError compileError =
+  case compileError of
+    CompileParseError err -> "parse error: " <> err
+    CompileFrontendError errors -> "frontend error: " <> unwords errors
+    CompileArm64Error err -> "ARM64 code generation error: " <> show err
+    CompileClangError exitCode err -> "clang failed (" <> show exitCode <> "): " <> err
+
+assemble :: FilePath -> FilePath -> IO ()
+assemble output assemblyPath = do
+  runtime <- runtimeSourcePath
+  (exitCode, _stdout, stderr) <-
+    readProcessWithExitCode
+      "clang"
+      ["-std=c11", "-Wall", "-Wextra", "-Werror", runtime, assemblyPath, "-o", output]
+      ""
+  case exitCode of
+    ExitSuccess -> pure ()
+    ExitFailure _ -> ioError (userError (renderCompileError (CompileClangError exitCode stderr)))
+
+withTemporaryDirectory :: String -> (FilePath -> IO value) -> IO value
+withTemporaryDirectory template = bracket acquire removeDirectoryRecursive
+  where
+    acquire = do
+      temporary <- getTemporaryDirectory
+      (path, handle) <- openTempFile temporary template
+      hClose handle
+      removeFile path
+      createDirectory path
+      pure path

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -8,8 +8,10 @@ module Aihc.Cli.Compile
     compileOutputPath,
     compileSourceToAssembly,
     compileSourceToAssemblyWithDependencies,
+    defaultCompileEnvironment,
     renderCompileError,
     runCompile,
+    runCompileWithEnvironment,
   )
 where
 
@@ -45,7 +47,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
-import System.Directory (createDirectory, getCurrentDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.Directory (XdgDirectory (XdgCache), createDirectory, getCurrentDirectory, getTemporaryDirectory, getXdgDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
 import System.FilePath (dropExtension, (</>))
 import System.IO (hClose, openTempFile)
@@ -61,9 +63,12 @@ data CompileError
 
 runCompile :: CompileOptions -> IO ()
 runCompile options = do
+  environment <- defaultCompileEnvironment
+  runCompileWithEnvironment environment options
+
+runCompileWithEnvironment :: CompileEnvironment -> CompileOptions -> IO ()
+runCompileWithEnvironment environment options = do
   source <- TIO.readFile (compileSourceFile options)
-  cwd <- getCurrentDirectory
-  let environment = CompileEnvironment (cwd </> "core-libs") (cwd </> ".aihc-cache" </> "libraries")
   assemblyResult <- compileSourceToAssemblyWithDependencies environment (compileSourceFile options) source
   assembly <- either (ioError . userError . renderCompileError) pure assemblyResult
   let output = compileOutputPath options
@@ -76,6 +81,14 @@ runCompile options = do
       let assemblyPath = directory </> "program.s"
       TIO.writeFile assemblyPath assembly
       assemble output assemblyPath
+
+-- | The project-local core libraries and shared compiled-library cache used by
+-- the command-line compiler.
+defaultCompileEnvironment :: IO CompileEnvironment
+defaultCompileEnvironment = do
+  cwd <- getCurrentDirectory
+  cacheDirectory <- getXdgDirectory XdgCache "aihc"
+  pure (CompileEnvironment (cwd </> "core-libs") (cacheDirectory </> "libraries"))
 
 compileOutputPath :: CompileOptions -> FilePath
 compileOutputPath options =

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -3,26 +3,49 @@
 -- | Compile a standalone Haskell module through System FC and GRIN to a
 -- native Darwin AArch64 executable.
 module Aihc.Cli.Compile
-  ( CompileError (..),
+  ( CompileEnvironment (..),
+    CompileError (..),
     compileOutputPath,
     compileSourceToAssembly,
+    compileSourceToAssemblyWithDependencies,
     renderCompileError,
     runCompile,
   )
 where
 
 import Aihc.Arm64 (Arm64Error, compileProgram, runtimeSourcePath)
+import Aihc.Cli.Compile.Dependencies
+  ( CompileEnvironment (..),
+    DependencyArtifact (..),
+    buildDependencies,
+  )
 import Aihc.Cli.Options (CompileOptions (..))
-import Aihc.Fc (DesugarResult (..), desugarModule)
+import Aihc.Fc
+  ( DesugarResult (..),
+    FcAlt (..),
+    FcBind (..),
+    FcExpr (..),
+    FcForeignCall (..),
+    FcProgram (..),
+    FcTopBind (..),
+    Var (..),
+    desugarModule,
+    desugarModuleWithBindings,
+  )
 import Aihc.Grin (lowerProgram)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
-import Aihc.Parser.Syntax (LanguageEdition (Haskell98Edition), effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
+import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
 import Aihc.Parser.Token (readModuleHeaderPragmas)
+import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
+import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithEnvAndInstances)
 import Control.Exception (bracket)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
-import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.Directory (createDirectory, getCurrentDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
 import System.FilePath (dropExtension, (</>))
 import System.IO (hClose, openTempFile)
@@ -31,6 +54,7 @@ import System.Process (readProcessWithExitCode)
 data CompileError
   = CompileParseError !String
   | CompileFrontendError ![String]
+  | CompileDependencyError !String
   | CompileArm64Error !Arm64Error
   | CompileClangError !ExitCode !String
   deriving (Eq, Show)
@@ -38,7 +62,10 @@ data CompileError
 runCompile :: CompileOptions -> IO ()
 runCompile options = do
   source <- TIO.readFile (compileSourceFile options)
-  assembly <- either (ioError . userError . renderCompileError) pure (compileSourceToAssembly (compileSourceFile options) source)
+  cwd <- getCurrentDirectory
+  let environment = CompileEnvironment (cwd </> "core-libs") (cwd </> ".aihc-cache" </> "libraries")
+  assemblyResult <- compileSourceToAssemblyWithDependencies environment (compileSourceFile options) source
+  assembly <- either (ioError . userError . renderCompileError) pure assemblyResult
   let output = compileOutputPath options
   if compileKeepAsm options
     then do
@@ -62,28 +89,220 @@ compileOutputPath options =
 
 compileSourceToAssembly :: FilePath -> Text -> Either CompileError Text
 compileSourceToAssembly sourceName source = do
-  parsed <-
-    case parseModule config source of
-      ([], modu) -> Right modu
-      (errors, _) -> Left (CompileParseError (show errors))
+  parsed <- parseCompileModule sourceName source
   let desugared = desugarModule parsed
   if dsSuccess desugared
     then either (Left . CompileArm64Error) Right (compileProgram "main" (lowerProgram (dsProgram desugared)))
     else Left (CompileFrontendError (dsErrors desugared))
+
+compileSourceToAssemblyWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
+compileSourceToAssemblyWithDependencies environment sourceName source =
+  case parseCompileModule sourceName source of
+    Left err -> pure (Left err)
+    Right parsed -> do
+      dependencies <- buildDependencies environment (ImplicitPrelude `elem` sourceExtensions source) parsed
+      pure $ do
+        artifact <- either (Left . CompileDependencyError) Right dependencies
+        compileWithDependencies artifact parsed
+
+compileWithDependencies :: DependencyArtifact -> Module -> Either CompileError Text
+compileWithDependencies dependencies parsed =
+  case resolveWithDeps (dependencyExports dependencies) [parsed] of
+    ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
+    ResolveResult {resolvedModules} ->
+      let checkedModules =
+            typecheckModulesWithEnvAndInstances
+              (dependencyTerms dependencies)
+              (dependencyInstances dependencies)
+              resolvedModules
+       in if not (all tcModuleSuccess checkedModules)
+            then Left (CompileFrontendError ["typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules)])
+            else
+              let bindings = dependencyBindings dependencies <> concatMap tcModuleBindings checkedModules
+                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
+               in if not (all dsSuccess desugared)
+                    then Left (CompileFrontendError (concatMap dsErrors desugared))
+                    else
+                      let mainProgram = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
+                          freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainProgram) (dependencyProgram dependencies)
+                          program = retainReachableTopBinds "main" (appendPrograms freshDependencies mainProgram)
+                       in either (Left . CompileArm64Error) Right (compileProgram "main" (lowerProgram program))
+
+appendPrograms :: FcProgram -> FcProgram -> FcProgram
+appendPrograms (FcProgram left) (FcProgram right) = FcProgram (left <> right)
+
+maximumProgramUnique :: FcProgram -> Int
+maximumProgramUnique = maximum . (0 :) . map varUniqueInt . programVars
+
+varUniqueInt :: Var -> Int
+varUniqueInt Var {varUnique = Unique unique} = unique
+
+shiftProgramVars :: Int -> FcProgram -> FcProgram
+shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBinds)
   where
-    header = readModuleHeaderPragmas source
-    language = fromMaybe Haskell98Edition (headerLanguageEdition header)
+    shiftVar var@Var {varUnique = Unique unique} = var {varUnique = Unique (unique + offset)}
+
+    shiftTopBind topBind =
+      case topBind of
+        FcData {} -> topBind
+        FcNewtype {} -> topBind
+        FcPrimitive var arity -> FcPrimitive (shiftVar var) arity
+        FcForeignImport foreignCall ->
+          FcForeignImport foreignCall {fcForeignCallVar = shiftVar (fcForeignCallVar foreignCall)}
+        FcTopBind bind -> FcTopBind (shiftBind bind)
+
+    shiftBind bind =
+      case bind of
+        FcNonRec var expression -> FcNonRec (shiftVar var) (shiftExpr expression)
+        FcRec bindings -> FcRec [(shiftVar var, shiftExpr expression) | (var, expression) <- bindings]
+
+    shiftExpr expression =
+      case expression of
+        FcVar var -> FcVar (shiftVar var)
+        FcLit {} -> expression
+        FcApp function argument -> FcApp (shiftExpr function) (shiftExpr argument)
+        FcDictApp function argument -> FcDictApp (shiftExpr function) (shiftExpr argument)
+        FcTyApp inner ty -> FcTyApp (shiftExpr inner) ty
+        FcLam var body -> FcLam (shiftVar var) (shiftExpr body)
+        FcTyLam tyVar body -> FcTyLam tyVar (shiftExpr body)
+        FcDictLam var body -> FcDictLam (shiftVar var) (shiftExpr body)
+        FcDict fields -> FcDict (map shiftExpr fields)
+        FcDictSelect dictionary index -> FcDictSelect (shiftExpr dictionary) index
+        FcLet bind body -> FcLet (shiftBind bind) (shiftExpr body)
+        FcCase scrutinee binder alternatives ->
+          FcCase (shiftExpr scrutinee) (shiftVar binder) (map shiftAlt alternatives)
+        FcCast inner coercion -> FcCast (shiftExpr inner) coercion
+
+    shiftAlt alternative =
+      alternative
+        { altBinders = map shiftVar (altBinders alternative),
+          altRhs = shiftExpr (altRhs alternative)
+        }
+
+programVars :: FcProgram -> [Var]
+programVars (FcProgram topBinds) = concatMap topBindVarsDeep topBinds
+
+topBindVarsDeep :: FcTopBind -> [Var]
+topBindVarsDeep topBind =
+  case topBind of
+    FcData {} -> []
+    FcNewtype {} -> []
+    FcPrimitive var _ -> [var]
+    FcForeignImport foreignCall -> [fcForeignCallVar foreignCall]
+    FcTopBind bind -> bindVarsDeep bind
+
+bindVarsDeep :: FcBind -> [Var]
+bindVarsDeep bind =
+  case bind of
+    FcNonRec var expression -> var : exprVars expression
+    FcRec bindings -> concat [var : exprVars expression | (var, expression) <- bindings]
+
+exprVars :: FcExpr -> [Var]
+exprVars expression =
+  case expression of
+    FcVar var -> [var]
+    FcLit {} -> []
+    FcApp function argument -> exprVars function <> exprVars argument
+    FcDictApp function argument -> exprVars function <> exprVars argument
+    FcTyApp inner _ -> exprVars inner
+    FcLam var body -> var : exprVars body
+    FcTyLam _ body -> exprVars body
+    FcDictLam var body -> var : exprVars body
+    FcDict fields -> concatMap exprVars fields
+    FcDictSelect dictionary _ -> exprVars dictionary
+    FcLet bind body -> bindVarsDeep bind <> exprVars body
+    FcCase scrutinee binder alternatives -> exprVars scrutinee <> (binder : concatMap altVars alternatives)
+    FcCast inner _ -> exprVars inner
+  where
+    altVars alternative = altBinders alternative <> exprVars (altRhs alternative)
+
+-- Native linking starts from @main@. Keeping unreachable dependency bindings
+-- would force the backend to implement primitives that the executable never
+-- calls and would initialize dead closures at startup.
+retainReachableTopBinds :: Text -> FcProgram -> FcProgram
+retainReachableTopBinds entry (FcProgram topBinds) =
+  FcProgram [topBind | (index, topBind) <- indexedTopBinds, keepTopBind index topBind]
+  where
+    indexedTopBinds = zip [0 :: Int ..] topBinds
+    definitions = Map.fromList [(varName var, expressions) | topBind <- topBinds, (var, expressions) <- topBindDefinitions topBind]
+    selectedDefinitions = Map.fromList [(varName var, index) | (index, topBind) <- indexedTopBinds, var <- topBindVars topBind]
+    reachable = closeReachable (Set.singleton entry)
+
+    closeReachable names =
+      let referenced = Set.unions [foldMap referencedNames (Map.findWithDefault [] name definitions) | name <- Set.toList names]
+          names' = names <> Set.filter (`Map.member` definitions) referenced
+       in if names' == names then names else closeReachable names'
+
+    keepTopBind index topBind =
+      case topBind of
+        FcData {} -> True
+        FcNewtype {} -> True
+        _ -> any (isSelectedReachable index) (topBindVars topBind)
+
+    isSelectedReachable index var =
+      varName var `Set.member` reachable
+        && Map.lookup (varName var) selectedDefinitions == Just index
+
+topBindDefinitions :: FcTopBind -> [(Var, [FcExpr])]
+topBindDefinitions topBind =
+  case topBind of
+    FcPrimitive var _ -> [(var, [])]
+    FcForeignImport foreignCall -> [(fcForeignCallVar foreignCall, [])]
+    FcTopBind (FcNonRec var expression) -> [(var, [expression])]
+    FcTopBind (FcRec bindings) -> [(var, map snd bindings) | (var, _) <- bindings]
+    FcData {} -> []
+    FcNewtype {} -> []
+
+topBindVars :: FcTopBind -> [Var]
+topBindVars = map fst . topBindDefinitions
+
+referencedNames :: FcExpr -> Set Text
+referencedNames expression =
+  case expression of
+    FcVar var -> Set.singleton (varName var)
+    FcLit _ -> Set.empty
+    FcApp function argument -> referencedNames function <> referencedNames argument
+    FcDictApp function argument -> referencedNames function <> referencedNames argument
+    FcTyApp inner _ -> referencedNames inner
+    FcLam _ body -> referencedNames body
+    FcTyLam _ body -> referencedNames body
+    FcDictLam _ body -> referencedNames body
+    FcDict fields -> foldMap referencedNames fields
+    FcDictSelect dictionary _ -> referencedNames dictionary
+    FcLet bind body -> referencedBindNames bind <> referencedNames body
+    FcCase scrutinee _ alternatives -> referencedNames scrutinee <> foldMap (referencedNames . altRhs) alternatives
+    FcCast inner _ -> referencedNames inner
+
+referencedBindNames :: FcBind -> Set Text
+referencedBindNames bind =
+  case bind of
+    FcNonRec _ expression -> referencedNames expression
+    FcRec bindings -> foldMap (referencedNames . snd) bindings
+
+parseCompileModule :: FilePath -> Text -> Either CompileError Module
+parseCompileModule sourceName source =
+  case parseModule config source of
+    ([], modu) -> Right modu
+    (errors, _) -> Left (CompileParseError (show errors))
+  where
     config =
       defaultConfig
         { parserSourceName = sourceName,
-          parserExtensions = effectiveExtensions language (headerExtensionSettings header)
+          parserExtensions = sourceExtensions source
         }
+
+sourceExtensions :: Text -> [Extension]
+sourceExtensions source = effectiveExtensions language (headerExtensionSettings header)
+  where
+    header = readModuleHeaderPragmas source
+    language = fromMaybe Haskell98Edition (headerLanguageEdition header)
 
 renderCompileError :: CompileError -> String
 renderCompileError compileError =
   case compileError of
     CompileParseError err -> "parse error: " <> err
     CompileFrontendError errors -> "frontend error: " <> unwords errors
+    CompileDependencyError err -> "dependency error: " <> err
     CompileArm64Error err -> "ARM64 code generation error: " <> show err
     CompileClangError exitCode err -> "clang failed (" <> show exitCode <> "): " <> err
 

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -35,14 +35,13 @@ import Aihc.Resolve
 import Aihc.Tc
   ( InstanceInfo,
     TcBindingResult (..),
-    TcType (..),
-    TyVarId,
+    TyConInfo,
     TypeScheme (..),
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleInstances,
     tcModuleSuccess,
-    typecheckModulesWithEnv,
+    typecheckModulesWithFullEnv,
   )
 import Control.Exception (bracketOnError)
 import Control.Monad (filterM, foldM)
@@ -86,6 +85,7 @@ data CompileEnvironment = CompileEnvironment
 data DependencyArtifact = DependencyArtifact
   { dependencyExports :: !ModuleExports,
     dependencyTerms :: ![(Text, TypeScheme)],
+    dependencyTyCons :: ![TyConInfo],
     dependencyBindings :: ![TcBindingResult],
     dependencyInstances :: ![InstanceInfo],
     dependencyProgram :: !FcProgram
@@ -95,6 +95,7 @@ data StoredDependencyArtifact = StoredDependencyArtifact
   { storedSchemaVersion :: !Int,
     storedExports :: !StoredModuleExports,
     storedTerms :: ![(Text, TypeScheme)],
+    storedTyCons :: ![TyConInfo],
     storedBindings :: ![TcBindingResult],
     storedInstances :: ![InstanceInfo],
     storedProgram :: !FcProgram
@@ -133,7 +134,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 1
+cacheSchemaVersion = 3
 
 buildDependencies :: CompileEnvironment -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies environment usesImplicitPrelude mainModule = do
@@ -172,6 +173,7 @@ emptyDependencyArtifact =
   DependencyArtifact
     { dependencyExports = Map.empty,
       dependencyTerms = [],
+      dependencyTyCons = [],
       dependencyBindings = [],
       dependencyInstances = [],
       dependencyProgram = FcProgram []
@@ -269,7 +271,7 @@ compileLoadedModules loaded =
   case resolveWithDeps Map.empty modules of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("core library resolve error: " <> show errors)
     resolved@ResolveResult {resolvedModules} ->
-      let checkedModules = typecheckModulesWithEnv [] resolvedModules
+      let (checkedModules, termSchemes, tyCons) = typecheckModulesWithFullEnv [] [] [] resolvedModules
        in if not (all tcModuleSuccess checkedModules)
             then Left ("core library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
             else
@@ -282,28 +284,14 @@ compileLoadedModules loaded =
                       Right
                         DependencyArtifact
                           { dependencyExports = extractInterface resolved,
-                            dependencyTerms = map bindingImportedTerm bindings,
+                            dependencyTerms = termSchemes,
+                            dependencyTyCons = tyCons,
                             dependencyBindings = bindings,
                             dependencyInstances = instances,
                             dependencyProgram = concatPrograms (map dsProgram desugared)
                           }
   where
     modules = map loadedModule loaded
-
-bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
-bindingImportedTerm binding = (tbName binding, tcTypeScheme (tbType binding))
-
-tcTypeScheme :: TcType -> TypeScheme
-tcTypeScheme ty =
-  case collectForAlls ty of
-    (tvs, TcQualTy preds body) -> ForAll tvs preds body
-    (tvs, body) -> ForAll tvs [] body
-
-collectForAlls :: TcType -> ([TyVarId], TcType)
-collectForAlls (TcForAllTy tv body) =
-  let (tvs, inner) = collectForAlls body
-   in (tv : tvs, inner)
-collectForAlls ty = ([], ty)
 
 concatPrograms :: [FcProgram] -> FcProgram
 concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
@@ -394,6 +382,7 @@ toStoredArtifact artifact =
     { storedSchemaVersion = cacheSchemaVersion,
       storedExports = toStoredExports (dependencyExports artifact),
       storedTerms = dependencyTerms artifact,
+      storedTyCons = dependencyTyCons artifact,
       storedBindings = dependencyBindings artifact,
       storedInstances = dependencyInstances artifact,
       storedProgram = dependencyProgram artifact
@@ -404,6 +393,7 @@ fromStoredArtifact stored =
   DependencyArtifact
     { dependencyExports = fromStoredExports (storedExports stored),
       dependencyTerms = storedTerms stored,
+      dependencyTyCons = storedTyCons stored,
       dependencyBindings = storedBindings stored,
       dependencyInstances = storedInstances stored,
       dependencyProgram = storedProgram stored

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -1,0 +1,456 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Core-library discovery and content-addressed compilation for @aihc compile@.
+module Aihc.Cli.Compile.Dependencies
+  ( CompileEnvironment (..),
+    DependencyArtifact (..),
+    buildDependencies,
+  )
+where
+
+import Aihc.Fc (DesugarResult (..), FcProgram (..), desugarModuleWithBindings)
+import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
+import Aihc.Parser.Syntax
+  ( ImportDecl (importDeclModule),
+    LanguageEdition (Haskell98Edition),
+    Module (..),
+    Name (..),
+    NameType,
+    UnqualifiedName (..),
+    effectiveExtensions,
+    headerExtensionSettings,
+    headerLanguageEdition,
+  )
+import Aihc.Parser.Token (readModuleHeaderPragmas)
+import Aihc.Resolve
+  ( ModuleExports,
+    OperatorFixity,
+    ResolveResult (..),
+    ResolvedName (..),
+    Scope (..),
+    extractInterface,
+    resolveWithDeps,
+  )
+import Aihc.Tc
+  ( InstanceInfo,
+    TcBindingResult (..),
+    TcType (..),
+    TyVarId,
+    TypeScheme (..),
+    tcModuleBindings,
+    tcModuleDiagnostics,
+    tcModuleInstances,
+    tcModuleSuccess,
+    typecheckModulesWithEnv,
+  )
+import Control.Exception (bracketOnError)
+import Control.Monad (filterM, foldM)
+import Data.Bits (xor)
+import Data.ByteString qualified as BS
+import Data.List (sort)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as Text
+import Data.Text.IO qualified as TIO
+import Data.Word (Word64)
+import Numeric (showHex)
+import System.Directory
+  ( createDirectoryIfMissing,
+    doesDirectoryExist,
+    doesFileExist,
+    listDirectory,
+    removeFile,
+    renameFile,
+  )
+import System.FilePath
+  ( dropExtension,
+    makeRelative,
+    splitDirectories,
+    takeExtension,
+    (</>),
+  )
+import System.IO (hClose, hPutStr, openTempFile)
+import Text.Read (readMaybe)
+
+data CompileEnvironment = CompileEnvironment
+  { compileCoreLibraryRoot :: !FilePath,
+    compileCacheRoot :: !FilePath
+  }
+  deriving (Eq, Show)
+
+data DependencyArtifact = DependencyArtifact
+  { dependencyExports :: !ModuleExports,
+    dependencyTerms :: ![(Text, TypeScheme)],
+    dependencyBindings :: ![TcBindingResult],
+    dependencyInstances :: ![InstanceInfo],
+    dependencyProgram :: !FcProgram
+  }
+
+data StoredDependencyArtifact = StoredDependencyArtifact
+  { storedSchemaVersion :: !Int,
+    storedExports :: !StoredModuleExports,
+    storedTerms :: ![(Text, TypeScheme)],
+    storedBindings :: ![TcBindingResult],
+    storedInstances :: ![InstanceInfo],
+    storedProgram :: !FcProgram
+  }
+  deriving (Show, Read)
+
+newtype StoredModuleExports = StoredModuleExports [(Text, StoredScope)]
+  deriving (Show, Read)
+
+data StoredScope = StoredScope
+  { storedScopeTerms :: ![(Text, StoredResolvedName)],
+    storedScopeTypes :: ![(Text, StoredResolvedName)],
+    storedScopeConstructors :: ![(Text, [Text])],
+    storedScopeRecordFields :: ![(Text, [Text])],
+    storedScopeMethods :: ![(Text, [Text])],
+    storedScopeFixities :: ![(Text, OperatorFixity)],
+    storedScopeQualifiedModules :: ![(Text, StoredScope)]
+  }
+  deriving (Show, Read)
+
+data StoredResolvedName
+  = StoredTopLevel !(Maybe Text) !NameType !Text
+  | StoredLocal !Int !NameType !Text
+  | StoredBuiltin !Text
+  | StoredError !String
+  deriving (Show, Read)
+
+data ModuleSource = ModuleSource
+  { moduleSourceLibrary :: !Text,
+    moduleSourcePath :: !FilePath
+  }
+
+data LoadedModule = LoadedModule
+  { loadedLibrary :: !Text,
+    loadedModule :: !Module
+  }
+
+cacheSchemaVersion :: Int
+cacheSchemaVersion = 1
+
+buildDependencies :: CompileEnvironment -> Bool -> Module -> IO (Either String DependencyArtifact)
+buildDependencies environment usesImplicitPrelude mainModule = do
+  let importedRoots = map importDeclModule (moduleImports mainModule)
+      defaultRoots = if usesImplicitPrelude then ["GHC.Prim", "Prelude"] else []
+      initialRoots = sort (Set.toList (Set.fromList (defaultRoots <> importedRoots)))
+  if null initialRoots
+    then pure (Right emptyDependencyArtifact)
+    else do
+      indexResult <- discoverModules (compileCoreLibraryRoot environment)
+      case indexResult of
+        Left err -> pure (Left err)
+        Right moduleIndex -> do
+          let roots = addLibraryRoots moduleIndex initialRoots
+          closureResult <- loadModuleClosure moduleIndex roots
+          case closureResult of
+            Left err -> pure (Left err)
+            Right loaded -> do
+              graphHash <- dependencyGraphHash (compileCoreLibraryRoot environment) loaded
+              let closureHash = stableHash (map (Text.encodeUtf8 . frameText) roots)
+                  cacheDirectory = compileCacheRoot environment </> graphHash
+                  cachePath = cacheDirectory </> closureHash <> ".cache"
+              cached <- readCache cachePath
+              case cached of
+                Just artifact -> pure (Right artifact)
+                Nothing ->
+                  case compileLoadedModules loaded of
+                    Left err -> pure (Left err)
+                    Right artifact -> do
+                      createDirectoryIfMissing True cacheDirectory
+                      writeCache cacheDirectory cachePath artifact
+                      pure (Right artifact)
+
+emptyDependencyArtifact :: DependencyArtifact
+emptyDependencyArtifact =
+  DependencyArtifact
+    { dependencyExports = Map.empty,
+      dependencyTerms = [],
+      dependencyBindings = [],
+      dependencyInstances = [],
+      dependencyProgram = FcProgram []
+    }
+
+-- aihc-base is defined in terms of the compiler-owned GHC.Prim interface even
+-- when a selected base module does not import it directly.
+addLibraryRoots :: Map Text ModuleSource -> [Text] -> [Text]
+addLibraryRoots moduleIndex roots
+  | any isBaseModule roots = sort (Set.toList (Set.insert "GHC.Prim" (Set.fromList roots)))
+  | otherwise = roots
+  where
+    isBaseModule name =
+      case Map.lookup name moduleIndex of
+        Just ModuleSource {moduleSourceLibrary = "aihc-base"} -> True
+        _ -> False
+
+discoverModules :: FilePath -> IO (Either String (Map Text ModuleSource))
+discoverModules root = do
+  exists <- doesDirectoryExist root
+  if not exists
+    then pure (Left ("core library directory does not exist: " <> root))
+    else do
+      entries <- sort <$> listDirectory root
+      libraries <- filterM (doesDirectoryExist . (root </>)) entries
+      foldM addLibrary (Right Map.empty) libraries
+  where
+    addLibrary (Left err) _ = pure (Left err)
+    addLibrary (Right index) library = do
+      let sourceRoot = root </> library </> "src"
+      sourceRootExists <- doesDirectoryExist sourceRoot
+      if not sourceRootExists
+        then pure (Right index)
+        else do
+          files <- listFilesRecursively sourceRoot
+          pure (foldM (insertModule sourceRoot (T.pack library)) index (filter ((== ".hs") . takeExtension) files))
+
+    insertModule sourceRoot library index path =
+      let relative = dropExtension (makeRelative sourceRoot path)
+          moduleName = T.intercalate "." (map T.pack (splitDirectories relative))
+       in case Map.lookup moduleName index of
+            Nothing -> Right (Map.insert moduleName (ModuleSource library path) index)
+            Just previous
+              | libraryPriority library < libraryPriority (moduleSourceLibrary previous) ->
+                  Right (Map.insert moduleName (ModuleSource library path) index)
+              | otherwise -> Right index
+
+    libraryPriority "aihc-prim" = 0 :: Int
+    libraryPriority "aihc-base" = 1
+    libraryPriority "aihc-internal" = 3
+    libraryPriority _ = 2
+
+loadModuleClosure :: Map Text ModuleSource -> [Text] -> IO (Either String [LoadedModule])
+loadModuleClosure index roots = fmap (fmap snd) (go Set.empty [] roots)
+  where
+    go seen loaded [] = pure (Right (seen, loaded))
+    go seen loaded (name : remaining)
+      | name `Set.member` seen = go seen loaded remaining
+      | otherwise =
+          case Map.lookup name index of
+            Nothing -> pure (Left ("core module not found in ./core-libs: " <> T.unpack name))
+            Just source -> do
+              parsed <- parseModuleFile source
+              case parsed of
+                Left err -> pure (Left err)
+                Right modu -> do
+                  let seen' = Set.insert name seen
+                      imports = map importDeclModule (moduleImports modu)
+                  dependencies <- go seen' loaded imports
+                  case dependencies of
+                    Left err -> pure (Left err)
+                    Right (seen'', loaded') ->
+                      go seen'' (loaded' <> [LoadedModule (moduleSourceLibrary source) modu]) remaining
+
+parseModuleFile :: ModuleSource -> IO (Either String Module)
+parseModuleFile ModuleSource {moduleSourcePath} = do
+  source <- TIO.readFile moduleSourcePath
+  pure $
+    case parseModule (parserConfig moduleSourcePath source) source of
+      ([], modu) -> Right modu
+      (errors, _) -> Left ("failed to parse core module " <> moduleSourcePath <> ": " <> show errors)
+
+parserConfig :: FilePath -> Text -> ParserConfig
+parserConfig sourceName source =
+  defaultConfig
+    { parserSourceName = sourceName,
+      parserExtensions = effectiveExtensions language (headerExtensionSettings header)
+    }
+  where
+    header = readModuleHeaderPragmas source
+    language = fromMaybe Haskell98Edition (headerLanguageEdition header)
+
+compileLoadedModules :: [LoadedModule] -> Either String DependencyArtifact
+compileLoadedModules loaded =
+  case resolveWithDeps Map.empty modules of
+    ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("core library resolve error: " <> show errors)
+    resolved@ResolveResult {resolvedModules} ->
+      let checkedModules = typecheckModulesWithEnv [] resolvedModules
+       in if not (all tcModuleSuccess checkedModules)
+            then Left ("core library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
+            else
+              let bindings = concatMap tcModuleBindings checkedModules
+                  instances = concatMap tcModuleInstances checkedModules
+                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
+               in if not (all dsSuccess desugared)
+                    then Left ("core library desugar error: " <> unlines (concatMap dsErrors desugared))
+                    else
+                      Right
+                        DependencyArtifact
+                          { dependencyExports = extractInterface resolved,
+                            dependencyTerms = map bindingImportedTerm bindings,
+                            dependencyBindings = bindings,
+                            dependencyInstances = instances,
+                            dependencyProgram = concatPrograms (map dsProgram desugared)
+                          }
+  where
+    modules = map loadedModule loaded
+
+bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
+bindingImportedTerm binding = (tbName binding, tcTypeScheme (tbType binding))
+
+tcTypeScheme :: TcType -> TypeScheme
+tcTypeScheme ty =
+  case collectForAlls ty of
+    (tvs, TcQualTy preds body) -> ForAll tvs preds body
+    (tvs, body) -> ForAll tvs [] body
+
+collectForAlls :: TcType -> ([TyVarId], TcType)
+collectForAlls (TcForAllTy tv body) =
+  let (tvs, inner) = collectForAlls body
+   in (tv : tvs, inner)
+collectForAlls ty = ([], ty)
+
+concatPrograms :: [FcProgram] -> FcProgram
+concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
+
+dependencyGraphHash :: FilePath -> [LoadedModule] -> IO String
+dependencyGraphHash root loaded = do
+  let libraries = sort (Set.toList (Set.fromList (map (T.unpack . loadedLibrary) loaded)))
+  chunks <- concat <$> mapM libraryChunks libraries
+  pure (stableHash (Text.encodeUtf8 (frameText (T.pack (show cacheSchemaVersion))) : chunks))
+  where
+    libraryChunks library = do
+      let libraryRoot = root </> library
+      exists <- doesDirectoryExist libraryRoot
+      if not exists
+        then pure [Text.encodeUtf8 (frameText (T.pack library))]
+        else do
+          files <- sort <$> listFilesRecursively libraryRoot
+          fmap concat . mapM (fileChunks libraryRoot) $ files
+
+    fileChunks libraryRoot path = do
+      bytes <- BS.readFile path
+      pure
+        [ Text.encodeUtf8 (frameText (T.pack (makeRelative root libraryRoot))),
+          Text.encodeUtf8 (frameText (T.pack (makeRelative libraryRoot path))),
+          Text.encodeUtf8 (frameText (T.pack (show (BS.length bytes)))),
+          bytes
+        ]
+
+listFilesRecursively :: FilePath -> IO [FilePath]
+listFilesRecursively root = do
+  entries <- sort <$> listDirectory root
+  fmap concat . mapM visit $ entries
+  where
+    visit name = do
+      let path = root </> name
+      directory <- doesDirectoryExist path
+      if directory
+        then listFilesRecursively path
+        else do
+          file <- doesFileExist path
+          pure [path | file]
+
+frameText :: Text -> Text
+frameText value = T.pack (show (T.length value)) <> ":" <> value
+
+stableHash :: [BS.ByteString] -> String
+stableHash chunks = padLeft 16 '0' (showHex digest "")
+  where
+    digest = foldl' hashChunk fnvOffset chunks
+    hashChunk = BS.foldl' (\hash byte -> (hash `xor` fromIntegral byte) * fnvPrime)
+
+fnvOffset :: Word64
+fnvOffset = 14695981039346656037
+
+fnvPrime :: Word64
+fnvPrime = 1099511628211
+
+padLeft :: Int -> Char -> String -> String
+padLeft width char value = replicate (max 0 (width - length value)) char <> value
+
+readCache :: FilePath -> IO (Maybe DependencyArtifact)
+readCache path = do
+  exists <- doesFileExist path
+  if not exists
+    then pure Nothing
+    else do
+      contents <- readFile path
+      pure $ do
+        stored <- readMaybe contents
+        if storedSchemaVersion stored == cacheSchemaVersion
+          then Just (fromStoredArtifact stored)
+          else Nothing
+
+writeCache :: FilePath -> FilePath -> DependencyArtifact -> IO ()
+writeCache directory destination artifact =
+  bracketOnError
+    (openTempFile directory "dependency.cache.tmp")
+    (\(path, handle) -> hClose handle >> removeFile path)
+    ( \(path, handle) -> do
+        hPutStr handle (show (toStoredArtifact artifact))
+        hClose handle
+        renameFile path destination
+    )
+
+toStoredArtifact :: DependencyArtifact -> StoredDependencyArtifact
+toStoredArtifact artifact =
+  StoredDependencyArtifact
+    { storedSchemaVersion = cacheSchemaVersion,
+      storedExports = toStoredExports (dependencyExports artifact),
+      storedTerms = dependencyTerms artifact,
+      storedBindings = dependencyBindings artifact,
+      storedInstances = dependencyInstances artifact,
+      storedProgram = dependencyProgram artifact
+    }
+
+fromStoredArtifact :: StoredDependencyArtifact -> DependencyArtifact
+fromStoredArtifact stored =
+  DependencyArtifact
+    { dependencyExports = fromStoredExports (storedExports stored),
+      dependencyTerms = storedTerms stored,
+      dependencyBindings = storedBindings stored,
+      dependencyInstances = storedInstances stored,
+      dependencyProgram = storedProgram stored
+    }
+
+toStoredExports :: ModuleExports -> StoredModuleExports
+toStoredExports = StoredModuleExports . map (fmap toStoredScope) . Map.toAscList
+
+fromStoredExports :: StoredModuleExports -> ModuleExports
+fromStoredExports (StoredModuleExports exports) = Map.fromList (map (fmap fromStoredScope) exports)
+
+toStoredScope :: Scope -> StoredScope
+toStoredScope scope =
+  StoredScope
+    { storedScopeTerms = map (fmap toStoredResolvedName) (Map.toAscList (scopeTerms scope)),
+      storedScopeTypes = map (fmap toStoredResolvedName) (Map.toAscList (scopeTypes scope)),
+      storedScopeConstructors = Map.toAscList (scopeConstructors scope),
+      storedScopeRecordFields = Map.toAscList (scopeRecordFields scope),
+      storedScopeMethods = Map.toAscList (scopeMethods scope),
+      storedScopeFixities = Map.toAscList (scopeFixities scope),
+      storedScopeQualifiedModules = map (fmap toStoredScope) (Map.toAscList (scopeQualifiedModules scope))
+    }
+
+fromStoredScope :: StoredScope -> Scope
+fromStoredScope scope =
+  Scope
+    { scopeTerms = Map.fromList (map (fmap fromStoredResolvedName) (storedScopeTerms scope)),
+      scopeTypes = Map.fromList (map (fmap fromStoredResolvedName) (storedScopeTypes scope)),
+      scopeConstructors = Map.fromList (storedScopeConstructors scope),
+      scopeRecordFields = Map.fromList (storedScopeRecordFields scope),
+      scopeMethods = Map.fromList (storedScopeMethods scope),
+      scopeFixities = Map.fromList (storedScopeFixities scope),
+      scopeQualifiedModules = Map.fromList (map (fmap fromStoredScope) (storedScopeQualifiedModules scope))
+    }
+
+toStoredResolvedName :: ResolvedName -> StoredResolvedName
+toStoredResolvedName resolved =
+  case resolved of
+    ResolvedTopLevel Name {nameQualifier, nameType, nameText} -> StoredTopLevel nameQualifier nameType nameText
+    ResolvedLocal unique UnqualifiedName {unqualifiedNameType, unqualifiedNameText} -> StoredLocal unique unqualifiedNameType unqualifiedNameText
+    ResolvedBuiltin name -> StoredBuiltin name
+    ResolvedError err -> StoredError err
+
+fromStoredResolvedName :: StoredResolvedName -> ResolvedName
+fromStoredResolvedName stored =
+  case stored of
+    StoredTopLevel qualifier nameType name -> ResolvedTopLevel (Name qualifier nameType name [])
+    StoredLocal unique nameType name -> ResolvedLocal unique (UnqualifiedName nameType name [])
+    StoredBuiltin name -> ResolvedBuiltin name
+    StoredError err -> ResolvedError err

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -1,5 +1,6 @@
 module Aihc.Cli.Options
   ( Command (..),
+    CompileOptions (..),
     InstallErrorFormat (..),
     InstallOptions (..),
     ReplOptions (..),
@@ -12,8 +13,16 @@ where
 import Options.Applicative qualified as OA
 
 data Command
-  = CmdInstall !InstallOptions
+  = CmdCompile !CompileOptions
+  | CmdInstall !InstallOptions
   | CmdRepl !ReplOptions
+  deriving (Eq, Show)
+
+data CompileOptions = CompileOptions
+  { compileSourceFile :: !FilePath,
+    compileOutputFile :: !(Maybe FilePath),
+    compileKeepAsm :: !Bool
+  }
   deriving (Eq, Show)
 
 newtype ReplOptions = ReplOptions
@@ -61,11 +70,17 @@ commandParser :: OA.Parser Command
 commandParser =
   OA.subparser
     ( OA.command
-        "install"
+        "compile"
         ( OA.info
-            (CmdInstall <$> installOptionsParser OA.<**> OA.helper)
-            (OA.progDesc "Install a Hackage package into the aihc store scaffold")
+            (CmdCompile <$> compileOptionsParser OA.<**> OA.helper)
+            (OA.progDesc "Compile a Haskell source file to a native ARM64 executable")
         )
+        <> OA.command
+          "install"
+          ( OA.info
+              (CmdInstall <$> installOptionsParser OA.<**> OA.helper)
+              (OA.progDesc "Install a Hackage package into the aihc store scaffold")
+          )
         <> OA.command
           "repl"
           ( OA.info
@@ -73,6 +88,26 @@ commandParser =
               (OA.progDesc "Start the aihc expression REPL")
           )
     )
+
+compileOptionsParser :: OA.Parser CompileOptions
+compileOptionsParser =
+  CompileOptions
+    <$> OA.strArgument
+      ( OA.metavar "SOURCE"
+          <> OA.help "Haskell source file containing the main binding"
+      )
+    <*> OA.optional
+      ( OA.strOption
+          ( OA.short 'o'
+              <> OA.long "output"
+              <> OA.metavar "FILE"
+              <> OA.help "Write the executable to FILE (default: SOURCE without its extension)"
+          )
+      )
+    <*> OA.switch
+      ( OA.long "keep-asm"
+          <> OA.help "Keep the generated assembly as OUTPUT.s"
+      )
 
 replOptionsParser :: OA.Parser ReplOptions
 replOptionsParser =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -33,12 +33,14 @@ import Data.IORef (newIORef)
 import Data.List (isInfixOf, isPrefixOf, isSuffixOf, sort)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import System.Console.Haskeline qualified as Haskeline
 import System.Directory
   ( createDirectory,
     createDirectoryIfMissing,
     doesDirectoryExist,
     doesFileExist,
+    getCurrentDirectory,
     getTemporaryDirectory,
     removeDirectoryRecursive,
     removeFile,
@@ -106,7 +108,9 @@ main =
       testGroup
         "compile"
         [ testCase "lowers a standalone main module to ARM64 assembly" $ do
-            case compileSourceToAssembly "Main.hs" compileFixtureSource of
+            sourcePath <- helloWorldExamplePath
+            source <- TIO.readFile sourcePath
+            case compileSourceToAssembly sourcePath source of
               Left err -> assertFailure ("expected compile success, got: " <> show err)
               Right assembly -> do
                 assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
@@ -816,13 +820,11 @@ test_compileExecutable :: Assertion
 test_compileExecutable =
   when (arch == "aarch64" && os == "darwin") $
     withTempDir "aihc-compile" $ \root -> do
-      let sourcePath = root </> "Main.hs"
-          keptOutput = root </> "kept"
+      sourcePath <- helloWorldExamplePath
+      let keptOutput = root </> "kept"
           temporaryOutput = root </> "temporary"
           keptOptions = CompileOptions sourcePath (Just keptOutput) True
           temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False
-      writeFile sourcePath (T.unpack compileFixtureSource)
-
       runCompile keptOptions
       assertFileExists keptOutput
       assertFileExists (keptOutput <> ".s")
@@ -837,30 +839,22 @@ assertNativeOutput :: FilePath -> Assertion
 assertNativeOutput executable = do
   (exitCode, stdout, stderr) <- readProcessWithExitCode executable [] ""
   assertEqual ("native stderr: " <> stderr) ExitSuccess exitCode
-  assertEqual "native stdout" "H" stdout
+  assertEqual "native stdout" "Hello, world!\n" stdout
 
-compileFixtureSource :: T.Text
-compileFixtureSource =
-  T.unlines
-    [ "{-# LANGUAGE ExtendedLiterals #-}",
-      "{-# LANGUAGE ForeignFunctionInterface #-}",
-      "{-# LANGUAGE GHCForeignImportPrim #-}",
-      "{-# LANGUAGE MagicHash #-}",
-      "{-# LANGUAGE NoImplicitPrelude #-}",
-      "{-# LANGUAGE UnboxedTuples #-}",
-      "module Main where",
-      "data State# s",
-      "data RealWorld",
-      "data Int32 = I32# Int32#",
-      "newtype CInt = CInt Int32",
-      "newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))",
-      "foreign import prim realWorld# :: State# RealWorld",
-      "foreign import ccall unsafe putchar :: CInt -> IO CInt",
-      "char :: Int32# -> CInt",
-      "char value = CInt (I32# value)",
-      "main :: IO CInt",
-      "main = putchar (char 72#Int32)"
-    ]
+helloWorldExamplePath :: IO FilePath
+helloWorldExamplePath = getCurrentDirectory >>= findFrom
+  where
+    relativePath = "examples" </> "hello-world" </> "Main.hs"
+    findFrom directory = do
+      let candidate = directory </> relativePath
+      exists <- doesFileExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory directory
+          if parent == directory
+            then assertFailure ("could not find " <> relativePath)
+            else findFrom parent
 
 assertFileExists :: FilePath -> Assertion
 assertFileExists path = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -2,6 +2,7 @@
 
 module Main (main) where
 
+import Aihc.Cli.Compile (compileOutputPath, compileSourceToAssembly, runCompile)
 import Aihc.Cli.Install
   ( DependencyResolver (..),
     InstallFailure (..),
@@ -18,12 +19,13 @@ import Aihc.Cli.Install
     renderInstallFailureWithOptions,
     writeInstallScaffold,
   )
-import Aihc.Cli.Options (Command (..), InstallErrorFormat (..), InstallOptions (..), ReplOptions (..), parseCommandPure)
+import Aihc.Cli.Options (Command (..), CompileOptions (..), InstallErrorFormat (..), InstallOptions (..), ReplOptions (..), parseCommandPure)
 import Aihc.Cli.Repl (ReplError (..), ReplSession (..), ReplStep (..), defaultReplSettings, evaluateExpression, handleReplInput, loadReplSession, replCompletion)
 import Aihc.Fc (FcProgram (..))
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Resolve (Scope (..))
 import Control.Exception (bracket)
+import Control.Monad (when)
 import Data.Aeson (object, (.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy.Char8 qualified as BL8
@@ -42,8 +44,11 @@ import System.Directory
     removeFile,
   )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory, takeFileName, (</>))
 import System.IO (hClose, openTempFile)
+import System.Info (arch, os)
+import System.Process (readProcessWithExitCode)
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Test.Tasty.QuickCheck qualified as QC
@@ -53,7 +58,20 @@ main =
   defaultMain . testGroup "aihc" $
     [ testGroup
         "cli"
-        [ testCase "parses install package" $
+        [ testCase "parses compile source" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False)))
+              (parseCommandPure ["compile", "Main.hs"]),
+          testCase "parses compile output and keep-asm" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") True)))
+              (parseCommandPure ["compile", "Main.hs", "-o", "hello", "--keep-asm"]),
+          testCase "derives safe default compile output paths" $ do
+            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False))
+            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False)),
+          testCase "parses install package" $
             assertEqual
               "command"
               (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False False InstallErrorsHuman)))
@@ -84,6 +102,16 @@ main =
             assertEqual "command" (Right (CmdRepl (ReplOptions Nothing))) (parseCommandPure ["repl"]),
           testCase "parses repl store" $
             assertEqual "command" (Right (CmdRepl (ReplOptions (Just "/tmp/aihc-store")))) (parseCommandPure ["repl", "--store", "/tmp/aihc-store"])
+        ],
+      testGroup
+        "compile"
+        [ testCase "lowers a standalone main module to ARM64 assembly" $ do
+            case compileSourceToAssembly "Main.hs" compileFixtureSource of
+              Left err -> assertFailure ("expected compile success, got: " <> show err)
+              Right assembly -> do
+                assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
+                assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
+          testCase "assembles an executable and honors keep-asm" test_compileExecutable
         ],
       testGroup
         "repl"
@@ -783,6 +811,56 @@ test_dryRunPlannerDoesNotGenerateSourceFiles =
 
     autogenExists <- doesDirectoryExist autogenDir
     assertBool ("expected dry-run planner not to create " <> autogenDir) (not autogenExists)
+
+test_compileExecutable :: Assertion
+test_compileExecutable =
+  when (arch == "aarch64" && os == "darwin") $
+    withTempDir "aihc-compile" $ \root -> do
+      let sourcePath = root </> "Main.hs"
+          keptOutput = root </> "kept"
+          temporaryOutput = root </> "temporary"
+          keptOptions = CompileOptions sourcePath (Just keptOutput) True
+          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False
+      writeFile sourcePath (T.unpack compileFixtureSource)
+
+      runCompile keptOptions
+      assertFileExists keptOutput
+      assertFileExists (keptOutput <> ".s")
+      assertNativeOutput keptOutput
+
+      runCompile temporaryOptions
+      assertFileExists temporaryOutput
+      assertFileDoesNotExist (temporaryOutput <> ".s")
+      assertNativeOutput temporaryOutput
+
+assertNativeOutput :: FilePath -> Assertion
+assertNativeOutput executable = do
+  (exitCode, stdout, stderr) <- readProcessWithExitCode executable [] ""
+  assertEqual ("native stderr: " <> stderr) ExitSuccess exitCode
+  assertEqual "native stdout" "H" stdout
+
+compileFixtureSource :: T.Text
+compileFixtureSource =
+  T.unlines
+    [ "{-# LANGUAGE ExtendedLiterals #-}",
+      "{-# LANGUAGE ForeignFunctionInterface #-}",
+      "{-# LANGUAGE GHCForeignImportPrim #-}",
+      "{-# LANGUAGE MagicHash #-}",
+      "{-# LANGUAGE NoImplicitPrelude #-}",
+      "{-# LANGUAGE UnboxedTuples #-}",
+      "module Main where",
+      "data State# s",
+      "data RealWorld",
+      "data Int32 = I32# Int32#",
+      "newtype CInt = CInt Int32",
+      "newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))",
+      "foreign import prim realWorld# :: State# RealWorld",
+      "foreign import ccall unsafe putchar :: CInt -> IO CInt",
+      "char :: Int32# -> CInt",
+      "char value = CInt (I32# value)",
+      "main :: IO CInt",
+      "main = putchar (char 72#Int32)"
+    ]
 
 assertFileExists :: FilePath -> Assertion
 assertFileExists path = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -7,7 +7,8 @@ import Aihc.Cli.Compile
     CompileError,
     compileOutputPath,
     compileSourceToAssemblyWithDependencies,
-    runCompile,
+    defaultCompileEnvironment,
+    runCompileWithEnvironment,
   )
 import Aihc.Cli.Install
   ( DependencyResolver (..),
@@ -132,6 +133,7 @@ main =
                   assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
                   assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
           testCase "assembles an executable and honors keep-asm" test_compileExecutable,
+          testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
           testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
           testCase "builds explicit core imports under NoImplicitPrelude" test_compileExplicitCoreImport
@@ -843,18 +845,40 @@ test_compileExecutable =
       let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
           keptOutput = root </> "kept"
           temporaryOutput = root </> "temporary"
+          environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
           keptOptions = CompileOptions sourcePath (Just keptOutput) True
           temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False
       withCurrentDirectory repositoryRoot $ do
-        runCompile keptOptions
+        runCompileWithEnvironment environment keptOptions
         assertFileExists keptOutput
         assertFileExists (keptOutput <> ".s")
         assertNativeOutput keptOutput
 
-        runCompile temporaryOptions
+        runCompileWithEnvironment environment temporaryOptions
         assertFileExists temporaryOutput
         assertFileDoesNotExist (temporaryOutput <> ".s")
         assertNativeOutput temporaryOutput
+
+test_compileDefaultEnvironment :: Assertion
+test_compileDefaultEnvironment =
+  withTempDir "aihc-compile-environment" $ \root -> do
+    let workingDirectory = root </> "project"
+        cacheHome = root </> "cache"
+    createDirectoryIfMissing True workingDirectory
+    bracket
+      (lookupEnv "XDG_CACHE_HOME")
+      restoreCacheHome
+      ( \_ -> do
+          setEnv "XDG_CACHE_HOME" cacheHome
+          withCurrentDirectory workingDirectory $ do
+            actualWorkingDirectory <- getCurrentDirectory
+            environment <- defaultCompileEnvironment
+            assertEqual "core libraries" (actualWorkingDirectory </> "core-libs") (compileCoreLibraryRoot environment)
+            assertEqual "compiled dependency cache" (cacheHome </> "aihc" </> "libraries") (compileCacheRoot environment)
+      )
+  where
+    restoreCacheHome Nothing = unsetEnv "XDG_CACHE_HOME"
+    restoreCacheHome (Just value) = setEnv "XDG_CACHE_HOME" value
 
 test_compileImplicitCoreDependencies :: Assertion
 test_compileImplicitCoreDependencies =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -2,7 +2,14 @@
 
 module Main (main) where
 
-import Aihc.Cli.Compile (compileOutputPath, compileSourceToAssembly, runCompile)
+import Aihc.Cli.Compile
+  ( CompileEnvironment (..),
+    CompileError,
+    compileOutputPath,
+    compileSourceToAssembly,
+    compileSourceToAssemblyWithDependencies,
+    runCompile,
+  )
 import Aihc.Cli.Install
   ( DependencyResolver (..),
     InstallFailure (..),
@@ -34,6 +41,8 @@ import Data.List (isInfixOf, isPrefixOf, isSuffixOf, sort)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime (..))
 import System.Console.Haskeline qualified as Haskeline
 import System.Directory
   ( createDirectory,
@@ -41,9 +50,12 @@ import System.Directory
     doesDirectoryExist,
     doesFileExist,
     getCurrentDirectory,
+    getModificationTime,
     getTemporaryDirectory,
+    listDirectory,
     removeDirectoryRecursive,
     removeFile,
+    setModificationTime,
   )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.Exit (ExitCode (..))
@@ -115,7 +127,10 @@ main =
               Right assembly -> do
                 assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
                 assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
-          testCase "assembles an executable and honors keep-asm" test_compileExecutable
+          testCase "assembles an executable and honors keep-asm" test_compileExecutable,
+          testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
+          testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
+          testCase "builds explicit core imports under NoImplicitPrelude" test_compileExplicitCoreImport
         ],
       testGroup
         "repl"
@@ -834,6 +849,96 @@ test_compileExecutable =
       assertFileExists temporaryOutput
       assertFileDoesNotExist (temporaryOutput <> ".s")
       assertNativeOutput temporaryOutput
+
+test_compileImplicitCoreDependencies :: Assertion
+test_compileImplicitCoreDependencies =
+  withTempDir "aihc-compile-dependencies" $ \root -> do
+    sourcePath <- helloWorldExamplePath
+    source <- TIO.readFile sourcePath
+    let coreRoot = root </> "core-libs"
+        cacheRoot = root </> "cache"
+        environment = CompileEnvironment coreRoot cacheRoot
+        implicitSource = T.replace "{-# LANGUAGE NoImplicitPrelude #-}\n" "" source
+    createCompileLibrary coreRoot "aihc-prim" "GHC.Prim" "module GHC.Prim where\n"
+    createCompileLibrary coreRoot "aihc-base" "Prelude" "module Prelude where\n"
+    writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 1\n"
+
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
+    cacheFiles <- compileCacheFiles cacheRoot
+    assertEqual "one dependency artifact" 1 (length cacheFiles)
+    cachePath <- case cacheFiles of
+      [path] -> pure path
+      paths -> assertFailure ("expected one cache file, got " <> show paths)
+
+    let oldTimestamp = UTCTime (fromGregorian 2000 1 1) 0
+    setModificationTime cachePath oldTimestamp
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
+    getModificationTime cachePath >>= assertEqual "cache hit preserves artifact" oldTimestamp
+
+    writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 2\n"
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
+    compileCacheFiles cacheRoot >>= assertEqual "unused library input changes the graph key" 2 . length
+
+test_compileNoImplicitPrelude :: Assertion
+test_compileNoImplicitPrelude =
+  withTempDir "aihc-compile-no-prelude" $ \root -> do
+    sourcePath <- helloWorldExamplePath
+    source <- TIO.readFile sourcePath
+    let environment = CompileEnvironment (root </> "missing-core-libs") (root </> "cache")
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath source
+    cacheExists <- doesDirectoryExist (compileCacheRoot environment)
+    assertBool "NoImplicitPrelude should not create a dependency cache" (not cacheExists)
+
+test_compileExplicitCoreImport :: Assertion
+test_compileExplicitCoreImport =
+  withTempDir "aihc-compile-explicit-dependency" $ \root -> do
+    sourcePath <- helloWorldExamplePath
+    source <- TIO.readFile sourcePath
+    let coreRoot = root </> "core-libs"
+        cacheRoot = root </> "cache"
+        environment = CompileEnvironment coreRoot cacheRoot
+        withImport = T.replace "module Main where\n" "module Main where\n\nimport Demo (identity)\n" source
+        importedSource = T.replace "putchar (char 72#Int32)" "putchar (identity (char 72#Int32))" withImport
+    createCompileLibrary
+      coreRoot
+      "demo"
+      "Demo"
+      "{-# LANGUAGE NoImplicitPrelude #-}\nmodule Demo (identity) where\nidentity x = x\n"
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath importedSource
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath importedSource
+    compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
+
+expectCompileSuccess :: Either CompileError T.Text -> Assertion
+expectCompileSuccess result =
+  case result of
+    Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
+    Right assembly -> assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
+
+createCompileLibrary :: FilePath -> FilePath -> FilePath -> String -> IO ()
+createCompileLibrary coreRoot library moduleName source = do
+  let sourcePath = coreRoot </> library </> "src" </> map dotToSlash moduleName <> ".hs"
+  createDirectoryIfMissing True (takeDirectory sourcePath)
+  writeFile (coreRoot </> library </> library <> ".cabal") ("name: " <> library <> "\n")
+  writeFile sourcePath source
+  where
+    dotToSlash '.' = '/'
+    dotToSlash char = char
+
+compileCacheFiles :: FilePath -> IO [FilePath]
+compileCacheFiles root = do
+  exists <- doesDirectoryExist root
+  if not exists
+    then pure []
+    else do
+      entries <- listDirectory root
+      concat <$> mapM visit entries
+  where
+    visit entry = do
+      let path = root </> entry
+      isDirectory <- doesDirectoryExist path
+      if isDirectory
+        then compileCacheFiles path
+        else pure [path | ".cache" `isSuffixOf` path]
 
 assertNativeOutput :: FilePath -> Assertion
 assertNativeOutput executable = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -6,7 +6,6 @@ import Aihc.Cli.Compile
   ( CompileEnvironment (..),
     CompileError,
     compileOutputPath,
-    compileSourceToAssembly,
     compileSourceToAssemblyWithDependencies,
     runCompile,
   )
@@ -56,6 +55,7 @@ import System.Directory
     removeDirectoryRecursive,
     removeFile,
     setModificationTime,
+    withCurrentDirectory,
   )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.Exit (ExitCode (..))
@@ -119,14 +119,18 @@ main =
         ],
       testGroup
         "compile"
-        [ testCase "lowers a standalone main module to ARM64 assembly" $ do
-            sourcePath <- helloWorldExamplePath
-            source <- TIO.readFile sourcePath
-            case compileSourceToAssembly sourcePath source of
-              Left err -> assertFailure ("expected compile success, got: " <> show err)
-              Right assembly -> do
-                assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
-                assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
+        [ testCase "lowers the aihc-base HelloWorld example to ARM64 assembly" $
+            withTempDir "aihc-compile-example" $ \root -> do
+              sourcePath <- helloWorldExamplePath
+              source <- TIO.readFile sourcePath
+              let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
+                  environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
+              result <- compileSourceToAssemblyWithDependencies environment sourcePath source
+              case result of
+                Left err -> assertFailure ("expected compile success, got: " <> show err)
+                Right assembly -> do
+                  assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
+                  assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
           testCase "assembles an executable and honors keep-asm" test_compileExecutable,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
           testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
@@ -836,31 +840,32 @@ test_compileExecutable =
   when (arch == "aarch64" && os == "darwin") $
     withTempDir "aihc-compile" $ \root -> do
       sourcePath <- helloWorldExamplePath
-      let keptOutput = root </> "kept"
+      let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
+          keptOutput = root </> "kept"
           temporaryOutput = root </> "temporary"
           keptOptions = CompileOptions sourcePath (Just keptOutput) True
           temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False
-      runCompile keptOptions
-      assertFileExists keptOutput
-      assertFileExists (keptOutput <> ".s")
-      assertNativeOutput keptOutput
+      withCurrentDirectory repositoryRoot $ do
+        runCompile keptOptions
+        assertFileExists keptOutput
+        assertFileExists (keptOutput <> ".s")
+        assertNativeOutput keptOutput
 
-      runCompile temporaryOptions
-      assertFileExists temporaryOutput
-      assertFileDoesNotExist (temporaryOutput <> ".s")
-      assertNativeOutput temporaryOutput
+        runCompile temporaryOptions
+        assertFileExists temporaryOutput
+        assertFileDoesNotExist (temporaryOutput <> ".s")
+        assertNativeOutput temporaryOutput
 
 test_compileImplicitCoreDependencies :: Assertion
 test_compileImplicitCoreDependencies =
   withTempDir "aihc-compile-dependencies" $ \root -> do
-    sourcePath <- helloWorldExamplePath
-    source <- TIO.readFile sourcePath
-    let coreRoot = root </> "core-libs"
+    let sourcePath = "Main.hs"
+        coreRoot = root </> "core-libs"
         cacheRoot = root </> "cache"
         environment = CompileEnvironment coreRoot cacheRoot
-        implicitSource = T.replace "{-# LANGUAGE NoImplicitPrelude #-}\n" "" source
+        implicitSource = implicitDependencySource
     createCompileLibrary coreRoot "aihc-prim" "GHC.Prim" "module GHC.Prim where\n"
-    createCompileLibrary coreRoot "aihc-base" "Prelude" "module Prelude where\n"
+    createCompileLibrary coreRoot "aihc-base" "Prelude" "module Prelude where\nid x = x\n"
     writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 1\n"
 
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
@@ -882,30 +887,26 @@ test_compileImplicitCoreDependencies =
 test_compileNoImplicitPrelude :: Assertion
 test_compileNoImplicitPrelude =
   withTempDir "aihc-compile-no-prelude" $ \root -> do
-    sourcePath <- helloWorldExamplePath
-    source <- TIO.readFile sourcePath
     let environment = CompileEnvironment (root </> "missing-core-libs") (root </> "cache")
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath source
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" noImplicitDependencySource
     cacheExists <- doesDirectoryExist (compileCacheRoot environment)
     assertBool "NoImplicitPrelude should not create a dependency cache" (not cacheExists)
 
 test_compileExplicitCoreImport :: Assertion
 test_compileExplicitCoreImport =
   withTempDir "aihc-compile-explicit-dependency" $ \root -> do
-    sourcePath <- helloWorldExamplePath
-    source <- TIO.readFile sourcePath
     let coreRoot = root </> "core-libs"
         cacheRoot = root </> "cache"
         environment = CompileEnvironment coreRoot cacheRoot
-        withImport = T.replace "module Main where\n" "module Main where\n\nimport Demo (identity)\n" source
+        withImport = T.replace "module Main where\n" "module Main where\n\nimport Demo (identity)\n" noImplicitDependencySource
         importedSource = T.replace "putchar (char 72#Int32)" "putchar (identity (char 72#Int32))" withImport
     createCompileLibrary
       coreRoot
       "demo"
       "Demo"
       "{-# LANGUAGE NoImplicitPrelude #-}\nmodule Demo (identity) where\nidentity x = x\n"
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath importedSource
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath importedSource
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
     compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
 
 expectCompileSuccess :: Either CompileError T.Text -> Assertion
@@ -913,6 +914,31 @@ expectCompileSuccess result =
   case result of
     Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
     Right assembly -> assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
+
+implicitDependencySource :: T.Text
+implicitDependencySource =
+  T.unlines
+    [ "{-# LANGUAGE ExtendedLiterals #-}",
+      "{-# LANGUAGE ForeignFunctionInterface #-}",
+      "{-# LANGUAGE MagicHash #-}",
+      "{-# LANGUAGE UnboxedTuples #-}",
+      "module Main where",
+      "data State# s",
+      "data RealWorld",
+      "data Int32 = I32# Int32#",
+      "newtype CInt = CInt Int32",
+      "newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))",
+      "foreign import ccall unsafe putchar :: CInt -> IO CInt",
+      "char value = CInt (I32# value)",
+      "main = id (putchar (char 72#Int32))"
+    ]
+
+noImplicitDependencySource :: T.Text
+noImplicitDependencySource =
+  T.replace
+    "main = id (putchar (char 72#Int32))"
+    "main = putchar (char 72#Int32)"
+    ("{-# LANGUAGE NoImplicitPrelude #-}\n" <> implicitDependencySource)
 
 createCompileLibrary :: FilePath -> FilePath -> FilePath -> String -> IO ()
 createCompileLibrary coreRoot library moduleName source = do

--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
   components/aihc-tc
   components/aihc-fc
   components/aihc-grin
+  components/aihc-arm64
   bin/aihc-fmt
   tooling/aihc-hackage
   tooling/aihc-testing

--- a/components/aihc-arm64/LICENSE
+++ b/components/aihc-arm64/LICENSE
@@ -1,0 +1,19 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/components/aihc-arm64/aihc-arm64.cabal
+++ b/components/aihc-arm64/aihc-arm64.cabal
@@ -1,0 +1,68 @@
+cabal-version: 3.8
+name: aihc-arm64
+version: 0.1.0.0
+build-type: Simple
+license: Unlicense
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Development
+synopsis: Native AArch64 backend for AIHC GRIN
+data-files:
+  runtime/aihc_runtime.c
+
+library
+  exposed-modules:
+    Aihc.Arm64
+    Aihc.Arm64.Codegen
+    Aihc.Arm64.Emit
+    Aihc.Arm64.Lir
+    Aihc.Arm64.RegisterAllocate
+
+  other-modules: Paths_aihc_arm64
+  autogen-modules: Paths_aihc_arm64
+  hs-source-dirs: src
+  build-depends:
+    aihc-grin,
+    base >=4.16 && <5,
+    containers,
+    text,
+    transformers,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+    ../../test/support
+
+  main-is: Spec.hs
+  other-modules:
+    Aihc.Testing.EvalFixture
+    Test.Arm64.Suite
+
+  build-depends:
+    aeson,
+    aihc-arm64,
+    aihc-fc,
+    aihc-grin,
+    aihc-parser,
+    aihc-resolve,
+    aihc-tc,
+    base >=4.16 && <5,
+    containers,
+    directory,
+    filepath,
+    libffi >=0.2 && <0.3,
+    process,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    unix,
+    yaml,
+
+  ghc-options: -Wall
+  default-language: GHC2021

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -42,7 +42,6 @@ typedef struct AihcContinuation AihcContinuation;
 
 typedef struct {
   void *function;
-  uint64_t arity;
   uint64_t is_io;
   uint64_t io_constructor;
   uint64_t cint_constructor;
@@ -65,7 +64,6 @@ struct AihcContinuation {
   AihcValue **locals;
   uint64_t slot;
   AihcValue *first;
-  AihcValue *second;
   uintptr_t info;
 };
 

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -1,0 +1,420 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+enum {
+  AIHC_LITERAL_INT = 0,
+  AIHC_CONSTRUCTOR = 1,
+  AIHC_CLOSURE = 2,
+  AIHC_THUNK = 3,
+  AIHC_PRIMITIVE = 4,
+  AIHC_FOREIGN = 5,
+  AIHC_FOREIGN_IO = 6,
+  AIHC_DICTIONARY = 7,
+  AIHC_CELL = 8,
+  AIHC_STATE_TOKEN = 9,
+};
+
+enum {
+  AIHC_CELL_SUSPENDED = 0,
+  AIHC_CELL_VALUE = 1,
+  AIHC_CELL_BLACKHOLE = 2,
+};
+
+enum {
+  AIHC_CONT_NORMAL = 0,
+  AIHC_CONT_UPDATE = 1,
+  AIHC_CONT_APPLY = 2,
+  AIHC_CONT_TOP = 3,
+  AIHC_CONT_FINAL = 4,
+  AIHC_CONT_FOREIGN_CINT = 5,
+  AIHC_CONT_FOREIGN_INT32 = 6,
+  AIHC_CONT_FOREIGN_LITERAL = 7,
+  AIHC_CONT_SELECT = 8,
+};
+
+enum {
+  AIHC_PRIM_REAL_WORLD = 1,
+};
+
+typedef struct AihcValue AihcValue;
+typedef struct AihcContinuation AihcContinuation;
+
+typedef struct {
+  void *function;
+  uint64_t arity;
+  uint64_t is_io;
+  uint64_t io_constructor;
+  uint64_t cint_constructor;
+  uint64_t int32_constructor;
+  uint64_t tuple_constructor;
+} AihcForeign;
+
+struct AihcValue {
+  uint64_t kind;
+  uintptr_t info;
+  uint64_t arity;
+  uint64_t count;
+  AihcValue *fields[];
+};
+
+struct AihcContinuation {
+  uint64_t kind;
+  AihcContinuation *parent;
+  void *code;
+  AihcValue **locals;
+  uint64_t slot;
+  AihcValue *first;
+  AihcValue *second;
+  uintptr_t info;
+};
+
+typedef struct {
+  void *next;
+  AihcValue **args;
+  AihcContinuation *continuation;
+  AihcValue **globals;
+  AihcValue **locals;
+  void *exit_code;
+  uint64_t io_constructor;
+  uint64_t tuple_constructor;
+  AihcValue *state_token;
+} AihcMachine;
+
+static void aihc_fail(const char *message) {
+  fprintf(stderr, "aihc runtime: %s\n", message);
+  abort();
+}
+
+static void *aihc_allocate(size_t bytes) {
+  void *pointer = calloc(1, bytes);
+  if (pointer == NULL) {
+    aihc_fail("out of memory");
+  }
+  return pointer;
+}
+
+static AihcContinuation *aihc_push_special(AihcMachine *machine,
+                                            uint64_t kind) {
+  AihcContinuation *continuation = aihc_allocate(sizeof(*continuation));
+  continuation->kind = kind;
+  continuation->parent = machine->continuation;
+  machine->continuation = continuation;
+  return continuation;
+}
+
+static AihcValue *aihc_copy_with_field(AihcValue *value, AihcValue *field) {
+  AihcValue *copy = aihc_allocate(sizeof(*copy) + sizeof(AihcValue *) * (value->count + 1));
+  copy->kind = value->kind;
+  copy->info = value->info;
+  copy->arity = value->arity;
+  copy->count = value->count + 1;
+  for (uint64_t index = 0; index < value->count; ++index) {
+    copy->fields[index] = value->fields[index];
+  }
+  copy->fields[value->count] = field;
+  return copy;
+}
+
+static AihcValue **aihc_arguments_with_field(AihcValue *function,
+                                              AihcValue *argument) {
+  AihcValue **arguments = aihc_allocate(sizeof(*arguments) * (function->count + 1));
+  for (uint64_t index = 0; index < function->count; ++index) {
+    arguments[index] = function->fields[index];
+  }
+  arguments[function->count] = argument;
+  return arguments;
+}
+
+static void aihc_return_value(AihcMachine *machine, AihcValue *value);
+static void aihc_eval_value(AihcMachine *machine, AihcValue *value);
+static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
+                             AihcValue *argument);
+
+AihcValue *aihc_make_node(uint64_t kind, uintptr_t info, uint64_t arity,
+                          uint64_t count) {
+  AihcValue *value = aihc_allocate(sizeof(*value) + sizeof(AihcValue *) * count);
+  value->kind = kind;
+  value->info = info;
+  value->arity = arity;
+  value->count = count;
+  return value;
+}
+
+AihcValue *aihc_make_literal(int64_t integer) {
+  return aihc_make_node(AIHC_LITERAL_INT, (uintptr_t)integer, 0, 0);
+}
+
+AihcValue *aihc_make_cell(void) {
+  return aihc_make_node(AIHC_CELL, AIHC_CELL_SUSPENDED, 1, 1);
+}
+
+void aihc_set_field(AihcValue *value, uint64_t index, AihcValue *field) {
+  if (index >= value->count) {
+    aihc_fail("field index out of bounds");
+  }
+  value->fields[index] = field;
+}
+
+void aihc_set_cell(AihcValue *cell, AihcValue *value) {
+  if (cell->kind != AIHC_CELL) {
+    aihc_fail("attempted to initialize a non-cell");
+  }
+  cell->info = AIHC_CELL_SUSPENDED;
+  cell->fields[0] = value;
+}
+
+AihcMachine *aihc_machine_new(uint64_t global_count, uint64_t io_constructor,
+                              uint64_t tuple_constructor) {
+  AihcMachine *machine = aihc_allocate(sizeof(*machine));
+  machine->globals = aihc_allocate(sizeof(*machine->globals) * global_count);
+  machine->io_constructor = io_constructor;
+  machine->tuple_constructor = tuple_constructor;
+  machine->state_token = aihc_make_node(AIHC_STATE_TOKEN, 0, 0, 0);
+  return machine;
+}
+
+AihcValue **aihc_alloc_locals(uint64_t count) {
+  return aihc_allocate(sizeof(AihcValue *) * (count == 0 ? 1 : count));
+}
+
+void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
+
+void aihc_push_normal(AihcMachine *machine, void *code, AihcValue **locals,
+                      uint64_t slot) {
+  AihcContinuation *continuation = aihc_push_special(machine, AIHC_CONT_NORMAL);
+  continuation->code = code;
+  continuation->locals = locals;
+  continuation->slot = slot;
+}
+
+static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
+                                   AihcValue **arguments) {
+  machine->next = (void *)function->info;
+  machine->args = arguments;
+  machine->locals = NULL;
+}
+
+static AihcValue *aihc_constructor(uint64_t constructor, uint64_t arity,
+                                   uint64_t count) {
+  return aihc_make_node(AIHC_CONSTRUCTOR, constructor, arity, count);
+}
+
+static void aihc_complete_foreign(AihcMachine *machine, AihcValue *foreign,
+                                  AihcValue *state) {
+  AihcContinuation *continuation =
+      aihc_push_special(machine, AIHC_CONT_FOREIGN_CINT);
+  continuation->first = state;
+  continuation->info = foreign->info;
+  aihc_eval_value(machine, foreign->fields[0]);
+}
+
+static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
+                              AihcValue *argument) {
+  switch (function->kind) {
+  case AIHC_CLOSURE:
+    aihc_schedule_function(machine, function,
+                           aihc_arguments_with_field(function, argument));
+    return;
+  case AIHC_CONSTRUCTOR:
+  case AIHC_PRIMITIVE:
+  case AIHC_FOREIGN: {
+    AihcValue *applied = aihc_copy_with_field(function, argument);
+    if (applied->count < applied->arity) {
+      aihc_return_value(machine, applied);
+      return;
+    }
+    if (applied->count > applied->arity) {
+      aihc_fail("overapplication is not implemented");
+    }
+    if (applied->kind == AIHC_FOREIGN) {
+      AihcForeign *descriptor = (AihcForeign *)applied->info;
+      if (!descriptor->is_io) {
+        aihc_fail("pure foreign calls are not implemented");
+      }
+      AihcValue *action = aihc_make_node(AIHC_FOREIGN_IO, applied->info,
+                                         applied->arity, applied->count);
+      for (uint64_t index = 0; index < applied->count; ++index) {
+        action->fields[index] = applied->fields[index];
+      }
+      AihcValue *io = aihc_constructor(descriptor->io_constructor, 1, 1);
+      io->fields[0] = action;
+      aihc_return_value(machine, io);
+      return;
+    }
+    aihc_return_value(machine, applied);
+    return;
+  }
+  case AIHC_FOREIGN_IO:
+    aihc_complete_foreign(machine, function, argument);
+    return;
+  default:
+    aihc_fail("attempted to apply a non-function value");
+  }
+}
+
+static void aihc_eval_value(AihcMachine *machine, AihcValue *value) {
+  if (value == NULL) {
+    aihc_fail("attempted to evaluate null");
+  }
+  if (value->kind == AIHC_CELL) {
+    switch (value->info) {
+    case AIHC_CELL_SUSPENDED: {
+      AihcValue *thunk = value->fields[0];
+      if (thunk == NULL || thunk->kind != AIHC_THUNK) {
+        aihc_fail("suspended cell does not contain a thunk");
+      }
+      value->info = AIHC_CELL_BLACKHOLE;
+      AihcContinuation *continuation =
+          aihc_push_special(machine, AIHC_CONT_UPDATE);
+      continuation->first = value;
+      aihc_schedule_function(machine, thunk, thunk->fields);
+      return;
+    }
+    case AIHC_CELL_VALUE:
+      aihc_eval_value(machine, value->fields[0]);
+      return;
+    case AIHC_CELL_BLACKHOLE:
+      aihc_fail("blackholed thunk re-entered");
+    default:
+      aihc_fail("unknown cell state");
+    }
+  }
+  if (value->kind == AIHC_PRIMITIVE && value->arity == 0) {
+    if (value->info == AIHC_PRIM_REAL_WORLD) {
+      aihc_return_value(machine, machine->state_token);
+      return;
+    }
+    aihc_fail("unknown zero-arity primitive");
+  }
+  aihc_return_value(machine, value);
+}
+
+static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
+                             AihcValue *argument) {
+  AihcContinuation *continuation =
+      aihc_push_special(machine, AIHC_CONT_APPLY);
+  continuation->first = argument;
+  aihc_eval_value(machine, function);
+}
+
+static void aihc_run_io(AihcMachine *machine, AihcValue *value) {
+  if (value->kind != AIHC_CONSTRUCTOR || value->info != machine->io_constructor ||
+      value->count != 1) {
+    aihc_fail("program result is not an IO value");
+  }
+  aihc_push_special(machine, AIHC_CONT_FINAL);
+  aihc_apply_value(machine, value->fields[0], machine->state_token);
+}
+
+static void aihc_return_value(AihcMachine *machine, AihcValue *value) {
+  AihcContinuation *continuation = machine->continuation;
+  if (continuation == NULL) {
+    aihc_fail("returned without a continuation");
+  }
+  machine->continuation = continuation->parent;
+  switch (continuation->kind) {
+  case AIHC_CONT_NORMAL:
+    continuation->locals[continuation->slot] = value;
+    machine->locals = continuation->locals;
+    machine->next = continuation->code;
+    return;
+  case AIHC_CONT_UPDATE:
+    continuation->first->info = AIHC_CELL_VALUE;
+    continuation->first->fields[0] = value;
+    aihc_return_value(machine, value);
+    return;
+  case AIHC_CONT_APPLY:
+    aihc_apply_forced(machine, value, continuation->first);
+    return;
+  case AIHC_CONT_TOP:
+    aihc_run_io(machine, value);
+    return;
+  case AIHC_CONT_FINAL:
+    if (value->kind != AIHC_CONSTRUCTOR ||
+        value->info != machine->tuple_constructor || value->count != 2) {
+      aihc_fail("IO action returned an invalid state/result tuple");
+    }
+    machine->locals = NULL;
+    machine->next = machine->exit_code;
+    return;
+  case AIHC_CONT_FOREIGN_CINT: {
+    AihcForeign *descriptor = (AihcForeign *)continuation->info;
+    if (value->kind != AIHC_CONSTRUCTOR ||
+        value->info != descriptor->cint_constructor || value->count != 1) {
+      aihc_fail("foreign CInt argument has invalid outer constructor");
+    }
+    AihcContinuation *next =
+        aihc_push_special(machine, AIHC_CONT_FOREIGN_INT32);
+    next->first = continuation->first;
+    next->info = continuation->info;
+    aihc_eval_value(machine, value->fields[0]);
+    return;
+  }
+  case AIHC_CONT_FOREIGN_INT32: {
+    AihcForeign *descriptor = (AihcForeign *)continuation->info;
+    if (value->kind != AIHC_CONSTRUCTOR ||
+        value->info != descriptor->int32_constructor || value->count != 1) {
+      aihc_fail("foreign CInt argument has invalid Int32 constructor");
+    }
+    AihcContinuation *next =
+        aihc_push_special(machine, AIHC_CONT_FOREIGN_LITERAL);
+    next->first = continuation->first;
+    next->info = continuation->info;
+    aihc_eval_value(machine, value->fields[0]);
+    return;
+  }
+  case AIHC_CONT_FOREIGN_LITERAL: {
+    AihcForeign *descriptor = (AihcForeign *)continuation->info;
+    if (value->kind != AIHC_LITERAL_INT) {
+      aihc_fail("foreign CInt argument is not an integer literal");
+    }
+    int result = ((int (*)(int))descriptor->function)((int)value->info);
+    AihcValue *literal = aihc_make_literal(result);
+    AihcValue *int32 = aihc_constructor(descriptor->int32_constructor, 1, 1);
+    int32->fields[0] = literal;
+    AihcValue *cint = aihc_constructor(descriptor->cint_constructor, 1, 1);
+    cint->fields[0] = int32;
+    AihcValue *tuple = aihc_constructor(descriptor->tuple_constructor, 2, 2);
+    tuple->fields[0] = continuation->first;
+    tuple->fields[1] = cint;
+    aihc_return_value(machine, tuple);
+    return;
+  }
+  case AIHC_CONT_SELECT:
+    if (value->kind != AIHC_DICTIONARY || continuation->slot >= value->count) {
+      aihc_fail("invalid dictionary selection");
+    }
+    aihc_eval_value(machine, value->fields[continuation->slot]);
+    return;
+  default:
+    aihc_fail("unknown continuation kind");
+  }
+}
+
+void aihc_return(AihcMachine *machine, AihcValue *value) {
+  aihc_return_value(machine, value);
+}
+
+void aihc_eval(AihcMachine *machine, AihcValue *value) {
+  aihc_eval_value(machine, value);
+}
+
+void aihc_apply(AihcMachine *machine, AihcValue *function,
+                AihcValue *argument) {
+  aihc_apply_value(machine, function, argument);
+}
+
+void aihc_select(AihcMachine *machine, AihcValue *dictionary,
+                 uint64_t index) {
+  AihcContinuation *continuation =
+      aihc_push_special(machine, AIHC_CONT_SELECT);
+  continuation->slot = index;
+  aihc_eval_value(machine, dictionary);
+}
+
+void aihc_start(AihcMachine *machine, AihcValue *root, void *exit_code) {
+  machine->exit_code = exit_code;
+  aihc_push_special(machine, AIHC_CONT_TOP);
+  aihc_eval_value(machine, root);
+}

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -60,11 +60,26 @@ struct AihcValue {
 struct AihcContinuation {
   uint64_t kind;
   AihcContinuation *parent;
-  void *code;
-  AihcValue **locals;
-  uint64_t slot;
-  AihcValue *first;
-  uintptr_t info;
+  union {
+    struct {
+      void *code;
+      AihcValue **locals;
+      uint64_t slot;
+    } normal;
+    struct {
+      AihcValue *cell;
+    } update;
+    struct {
+      AihcValue *argument;
+    } apply;
+    struct {
+      AihcValue *state;
+      AihcForeign *descriptor;
+    } foreign_call;
+    struct {
+      uint64_t index;
+    } select;
+  } payload;
 };
 
 typedef struct {
@@ -181,9 +196,9 @@ void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
 void aihc_push_normal(AihcMachine *machine, void *code, AihcValue **locals,
                       uint64_t slot) {
   AihcContinuation *continuation = aihc_push_special(machine, AIHC_CONT_NORMAL);
-  continuation->code = code;
-  continuation->locals = locals;
-  continuation->slot = slot;
+  continuation->payload.normal.code = code;
+  continuation->payload.normal.locals = locals;
+  continuation->payload.normal.slot = slot;
 }
 
 static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
@@ -202,8 +217,9 @@ static void aihc_complete_foreign(AihcMachine *machine, AihcValue *foreign,
                                   AihcValue *state) {
   AihcContinuation *continuation =
       aihc_push_special(machine, AIHC_CONT_FOREIGN_CINT);
-  continuation->first = state;
-  continuation->info = foreign->info;
+  continuation->payload.foreign_call.state = state;
+  continuation->payload.foreign_call.descriptor =
+      (AihcForeign *)foreign->info;
   aihc_eval_value(machine, foreign->fields[0]);
 }
 
@@ -265,7 +281,7 @@ static void aihc_eval_value(AihcMachine *machine, AihcValue *value) {
       value->info = AIHC_CELL_BLACKHOLE;
       AihcContinuation *continuation =
           aihc_push_special(machine, AIHC_CONT_UPDATE);
-      continuation->first = value;
+      continuation->payload.update.cell = value;
       aihc_schedule_function(machine, thunk, thunk->fields);
       return;
     }
@@ -292,7 +308,7 @@ static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
                              AihcValue *argument) {
   AihcContinuation *continuation =
       aihc_push_special(machine, AIHC_CONT_APPLY);
-  continuation->first = argument;
+  continuation->payload.apply.argument = argument;
   aihc_eval_value(machine, function);
 }
 
@@ -313,17 +329,18 @@ static void aihc_return_value(AihcMachine *machine, AihcValue *value) {
   machine->continuation = continuation->parent;
   switch (continuation->kind) {
   case AIHC_CONT_NORMAL:
-    continuation->locals[continuation->slot] = value;
-    machine->locals = continuation->locals;
-    machine->next = continuation->code;
+    continuation->payload.normal.locals
+        [continuation->payload.normal.slot] = value;
+    machine->locals = continuation->payload.normal.locals;
+    machine->next = continuation->payload.normal.code;
     return;
   case AIHC_CONT_UPDATE:
-    continuation->first->info = AIHC_CELL_VALUE;
-    continuation->first->fields[0] = value;
+    continuation->payload.update.cell->info = AIHC_CELL_VALUE;
+    continuation->payload.update.cell->fields[0] = value;
     aihc_return_value(machine, value);
     return;
   case AIHC_CONT_APPLY:
-    aihc_apply_forced(machine, value, continuation->first);
+    aihc_apply_forced(machine, value, continuation->payload.apply.argument);
     return;
   case AIHC_CONT_TOP:
     aihc_run_io(machine, value);
@@ -337,33 +354,31 @@ static void aihc_return_value(AihcMachine *machine, AihcValue *value) {
     machine->next = machine->exit_code;
     return;
   case AIHC_CONT_FOREIGN_CINT: {
-    AihcForeign *descriptor = (AihcForeign *)continuation->info;
+    AihcForeign *descriptor = continuation->payload.foreign_call.descriptor;
     if (value->kind != AIHC_CONSTRUCTOR ||
         value->info != descriptor->cint_constructor || value->count != 1) {
       aihc_fail("foreign CInt argument has invalid outer constructor");
     }
     AihcContinuation *next =
         aihc_push_special(machine, AIHC_CONT_FOREIGN_INT32);
-    next->first = continuation->first;
-    next->info = continuation->info;
+    next->payload.foreign_call = continuation->payload.foreign_call;
     aihc_eval_value(machine, value->fields[0]);
     return;
   }
   case AIHC_CONT_FOREIGN_INT32: {
-    AihcForeign *descriptor = (AihcForeign *)continuation->info;
+    AihcForeign *descriptor = continuation->payload.foreign_call.descriptor;
     if (value->kind != AIHC_CONSTRUCTOR ||
         value->info != descriptor->int32_constructor || value->count != 1) {
       aihc_fail("foreign CInt argument has invalid Int32 constructor");
     }
     AihcContinuation *next =
         aihc_push_special(machine, AIHC_CONT_FOREIGN_LITERAL);
-    next->first = continuation->first;
-    next->info = continuation->info;
+    next->payload.foreign_call = continuation->payload.foreign_call;
     aihc_eval_value(machine, value->fields[0]);
     return;
   }
   case AIHC_CONT_FOREIGN_LITERAL: {
-    AihcForeign *descriptor = (AihcForeign *)continuation->info;
+    AihcForeign *descriptor = continuation->payload.foreign_call.descriptor;
     if (value->kind != AIHC_LITERAL_INT) {
       aihc_fail("foreign CInt argument is not an integer literal");
     }
@@ -374,16 +389,18 @@ static void aihc_return_value(AihcMachine *machine, AihcValue *value) {
     AihcValue *cint = aihc_constructor(descriptor->cint_constructor, 1, 1);
     cint->fields[0] = int32;
     AihcValue *tuple = aihc_constructor(descriptor->tuple_constructor, 2, 2);
-    tuple->fields[0] = continuation->first;
+    tuple->fields[0] = continuation->payload.foreign_call.state;
     tuple->fields[1] = cint;
     aihc_return_value(machine, tuple);
     return;
   }
   case AIHC_CONT_SELECT:
-    if (value->kind != AIHC_DICTIONARY || continuation->slot >= value->count) {
+    if (value->kind != AIHC_DICTIONARY ||
+        continuation->payload.select.index >= value->count) {
       aihc_fail("invalid dictionary selection");
     }
-    aihc_eval_value(machine, value->fields[continuation->slot]);
+    aihc_eval_value(machine,
+                    value->fields[continuation->payload.select.index]);
     return;
   default:
     aihc_fail("unknown continuation kind");
@@ -407,7 +424,7 @@ void aihc_select(AihcMachine *machine, AihcValue *dictionary,
                  uint64_t index) {
   AihcContinuation *continuation =
       aihc_push_special(machine, AIHC_CONT_SELECT);
-  continuation->slot = index;
+  continuation->payload.select.index = index;
   aihc_eval_value(machine, dictionary);
 }
 

--- a/components/aihc-arm64/src/Aihc/Arm64.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64.hs
@@ -1,0 +1,14 @@
+-- | Native AArch64 code generation for runtime-explicit GRIN.
+module Aihc.Arm64
+  ( Arm64Error (..),
+    compileProgram,
+    runtimeSourcePath,
+  )
+where
+
+import Aihc.Arm64.Codegen (Arm64Error (..), compileProgram)
+import Paths_aihc_arm64 (getDataFileName)
+
+-- | Locate the C runtime used by generated assembly.
+runtimeSourcePath :: IO FilePath
+runtimeSourcePath = getDataFileName "runtime/aihc_runtime.c"

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -1,0 +1,657 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Lower runtime-explicit GRIN to textual AArch64 assembly for Darwin.
+-- Generated Haskell entries transfer only with branches; calls are reserved
+-- for the C runtime and foreign functions.
+module Aihc.Arm64.Codegen
+  ( Arm64Error (..),
+    compileProgram,
+  )
+where
+
+import Aihc.Arm64.Emit (EmitError, renderAllocatedBlock)
+import Aihc.Arm64.Lir qualified as Lir
+import Aihc.Grin.Syntax
+import Control.Monad (forM)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict (StateT, execStateT, get, modify')
+import Data.Char (ord)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+
+data Arm64Error
+  = Arm64MissingEntry !Text
+  | Arm64MissingGlobal !Text
+  | Arm64MissingFunction !FunctionName
+  | Arm64MissingConstructor !Text
+  | Arm64UnsupportedPrimitive !Text
+  | Arm64UnsupportedExpression !Text
+  | Arm64UnsupportedValue !Text
+  | Arm64EmitError !EmitError
+  deriving (Eq, Show)
+
+data CompileEnv = CompileEnv
+  { compileConstructorIds :: !(Map Text Int),
+    compileConstructorArities :: !(Map Text Int),
+    compileGlobalSlots :: !(Map Text Int),
+    compileFunctionLabels :: !(Map FunctionName Text),
+    compileFunctionArities :: !(Map FunctionName Int),
+    compileForeignLabels :: !(Map Text Text)
+  }
+
+data Block = Block
+  { blockLabel :: !Text,
+    blockLines :: ![Text]
+  }
+
+data FunctionState = FunctionState
+  { functionNextLabel :: !Int,
+    functionNextSlot :: !Int,
+    functionBlocksRev :: ![Block]
+  }
+
+type FunctionM = StateT FunctionState (Either Arm64Error)
+
+data ValueEnv = ValueEnv
+  { valueCompileEnv :: !CompileEnv,
+    valueLocalSlots :: !(Map GrinVar Int)
+  }
+
+compileProgram :: Text -> GrinProgram -> Either Arm64Error Text
+compileProgram entryName program = do
+  rootSlot <- maybe (Left (Arm64MissingEntry entryName)) Right (Map.lookup entryName globalSlots)
+  initLines <- compileInitializers compileEnv program
+  functions <- mapM (compileFunction compileEnv) (grinFunctions program)
+  descriptors <- foreignDescriptors compileEnv program
+  pure . T.unlines $
+    [ ".section __TEXT,__text,regular,pure_instructions",
+      ".p2align 2",
+      ".globl _main",
+      "_main:",
+      "  stp x29, x30, [sp, #-48]!",
+      "  mov x29, sp",
+      "  stp x19, x20, [sp, #16]",
+      "  stp x21, x22, [sp, #32]",
+      immediate "x0" (length globalNames),
+      immediate "x1" ioConstructor,
+      immediate "x2" tupleConstructor,
+      "  bl _aihc_machine_new",
+      "  mov x22, x0"
+    ]
+      <> initLines
+      <> [ "  ldr x9, [x22, #24]",
+           loadAt "x1" "x9" rootSlot,
+           "  mov x0, x22",
+           "  adr x2, .Laihc_exit",
+           "  bl _aihc_start"
+         ]
+      <> dispatchLines
+      <> [ ".Laihc_exit:",
+           "  mov w0, #0",
+           "  ldp x21, x22, [sp, #32]",
+           "  ldp x19, x20, [sp, #16]",
+           "  ldp x29, x30, [sp], #48",
+           "  ret"
+         ]
+      <> concat functions
+      <> descriptors
+  where
+    constructors = uniqueByName (builtinConstructors <> grinConstructors program)
+    constructorIds = Map.fromList (zip (map fst constructors) [1 ..])
+    constructorArities = Map.fromList constructors
+    globalNames = uniqueTexts (map fst constructors <> map (grinVarName . fst) (grinPrimitives program) <> map grinForeignCallName (grinForeignCalls program) <> map (grinVarName . fst) (grinCafs program))
+    globalSlots = Map.fromList (zip globalNames [0 ..])
+    functionLabels = Map.fromList [(grinFunctionName function, functionLabel index) | (index, function) <- zip [0 ..] (grinFunctions program)]
+    functionArities = Map.fromList [(grinFunctionName function, length (grinFunctionParameters function)) | function <- grinFunctions program]
+    foreignLabels = Map.fromList [(grinForeignCallName foreignCall, foreignLabel index) | (index, foreignCall) <- zip [0 ..] (grinForeignCalls program)]
+    compileEnv = CompileEnv constructorIds constructorArities globalSlots functionLabels functionArities foreignLabels
+    ioConstructor = Map.findWithDefault 0 "IO" constructorIds
+    tupleConstructor = Map.findWithDefault 0 "(#,#)" constructorIds
+
+compileInitializers :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
+compileInitializers env program = do
+  constructorLines <- fmap concat . forM constructors $ \(name, arity) -> do
+    slot <- globalSlot env name
+    constructor <- constructorId env name
+    pure $ makeNodeLines 1 (InfoImmediate constructor) arity 0 <> storeGlobal slot
+  primitiveLines <- fmap concat . forM (grinPrimitives program) $ \(var, arity) -> do
+    slot <- globalSlot env (grinVarName var)
+    primitive <- primitiveId (grinVarName var)
+    pure $ makeNodeLines 4 (InfoImmediate primitive) arity 0 <> storeGlobal slot
+  foreignLines <- fmap concat . forM (grinForeignCalls program) $ \foreignCall -> do
+    slot <- globalSlot env (grinForeignCallName foreignCall)
+    label <- foreignDescriptorLabel env foreignCall
+    let arity = length (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
+    pure $ makeNodeLines 5 (InfoAddress label) arity 0 <> storeGlobal slot
+  cafCellLines <- fmap concat . forM (grinCafs program) $ \(var, _) -> do
+    slot <- globalSlot env (grinVarName var)
+    pure (["  bl _aihc_make_cell"] <> storeGlobal slot)
+  cafValueLines <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
+    slot <- globalSlot env (grinVarName var)
+    nodeLines <- materializeNode (ValueEnv env Map.empty) node
+    pure $
+      nodeLines
+        <> [ "  mov x20, x0",
+             "  ldr x9, [x22, #24]",
+             loadAt "x0" "x9" slot,
+             "  mov x1, x20",
+             "  bl _aihc_set_cell"
+           ]
+  pure (constructorLines <> primitiveLines <> foreignLines <> cafCellLines <> cafValueLines)
+  where
+    constructors = uniqueByName (builtinConstructors <> grinConstructors program)
+
+compileFunction :: CompileEnv -> GrinFunction -> Either Arm64Error [Text]
+compileFunction env function = do
+  label <- functionCodeLabel env (grinFunctionName function)
+  let bound = Set.fromList (grinFunctionParameters function) <> boundVars (grinFunctionBody function)
+      localSlots = Map.fromList (zip (Set.toAscList bound) [0 ..])
+      firstScratch = Map.size localSlots
+      bodyLabel = label <> "_body"
+      initialState = FunctionState 0 firstScratch []
+      valueEnv = ValueEnv env localSlots
+  finalState <- execStateT (compileExpr valueEnv [] bodyLabel (grinFunctionBody function)) initialState
+  let spillBase = functionNextSlot finalState
+  (parameterCopies, spillCount) <-
+    either (Left . Arm64EmitError) Right (renderAllocatedBlock spillBase (parameterCopyLir localSlots (grinFunctionParameters function)))
+  let slotCount = max 1 (spillBase + spillCount)
+      entry =
+        [ label <> ":",
+          immediate "x0" slotCount,
+          "  bl _aihc_alloc_locals",
+          "  mov x19, x0",
+          "  str x19, [x22, #32]",
+          "  ldr x8, [x22, #8]"
+        ]
+          <> parameterCopies
+          <> ["  b " <> bodyLabel]
+      blocks = concatMap renderBlock (reverse (functionBlocksRev finalState))
+  pure (entry <> blocks)
+
+parameterCopyLir :: Map GrinVar Int -> [GrinVar] -> [Lir.Instruction]
+parameterCopyLir slots parameters =
+  concat
+    [ [ Lir.Load (Lir.Virtual register) (Lir.Physical Lir.X8) (argumentIndex * 8),
+        Lir.Store (Lir.Virtual register) (Lir.Physical Lir.X19) (slot * 8)
+      ]
+    | (argumentIndex, var) <- zip [0 :: Int ..] parameters,
+      let register = Lir.VirtualReg argumentIndex,
+      Just slot <- [Map.lookup var slots]
+    ]
+
+compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
+compileExpr env prefix label expression =
+  case expression of
+    GrinReturn value -> do
+      valueLines <- liftEither (materializeValue env value)
+      addBlock label (prefix <> valueLines <> returnLines)
+    GrinBind var valueExpression body -> do
+      valueLabel <- freshLabel label "bind_value"
+      bodyLabel <- freshLabel label "bind_body"
+      slot <- localSlot env var
+      addBlock
+        label
+        ( prefix
+            <> pushNormalLines bodyLabel slot
+            <> ["  b " <> valueLabel]
+        )
+      compileExpr env [] valueLabel valueExpression
+      compileExpr env [] bodyLabel body
+    GrinStore node -> do
+      nodeLines <- liftEither (materializeNode env node)
+      addBlock
+        label
+        ( prefix
+            <> nodeLines
+            <> [ "  mov x20, x0",
+                 "  bl _aihc_make_cell",
+                 "  mov x21, x0",
+                 "  mov x1, x20",
+                 "  bl _aihc_set_cell",
+                 "  mov x0, x21"
+               ]
+            <> returnLines
+        )
+    GrinStoreRec {} -> unsupportedExpression "recursive heap allocation"
+    GrinFetch {} -> unsupportedExpression "fetch"
+    GrinUpdate {} -> unsupportedExpression "update"
+    GrinEval value -> do
+      valueLines <- liftEither (materializeValue env value)
+      addBlock label (prefix <> valueLines <> evalLines)
+    GrinApply function argument -> do
+      scratch <- freshSlot
+      functionLines <- liftEither (materializeValue env function)
+      argumentLines <- liftEither (materializeValue env argument)
+      addBlock
+        label
+        ( prefix
+            <> functionLines
+            <> [storeAt "x0" "x19" scratch]
+            <> argumentLines
+            <> [ "  mov x2, x0",
+                 loadAt "x1" "x19" scratch,
+                 "  mov x0, x22",
+                 "  bl _aihc_apply"
+               ]
+            <> dispatchLines
+        )
+    GrinCase scrutinee binder alternatives ->
+      compileCase env prefix label scrutinee binder alternatives
+    GrinDictSelect dictionary index -> do
+      dictionaryLines <- liftEither (materializeValue env dictionary)
+      addBlock
+        label
+        ( prefix
+            <> dictionaryLines
+            <> [ "  mov x1, x0",
+                 immediate "x2" index,
+                 "  mov x0, x22",
+                 "  bl _aihc_select"
+               ]
+            <> dispatchLines
+        )
+    GrinThrow {} -> unsupportedExpression "throw"
+    GrinCatch {} -> unsupportedExpression "catch"
+  where
+    unsupportedExpression name = lift (Left (Arm64UnsupportedExpression name))
+
+compileCase :: ValueEnv -> [Text] -> Text -> GrinValue -> GrinVar -> [GrinAlt] -> FunctionM ()
+compileCase env prefix label scrutinee binder alternatives = do
+  resultSlot <- freshSlot
+  dispatchLabel <- freshLabel label "case_dispatch"
+  scrutineeLines <- liftEither (materializeValue env scrutinee)
+  addBlock
+    label
+    ( prefix
+        <> scrutineeLines
+        <> ["  mov x20, x0"]
+        <> pushNormalLines dispatchLabel resultSlot
+        <> [ "  mov x1, x20",
+             "  mov x0, x22",
+             "  bl _aihc_eval"
+           ]
+        <> dispatchLines
+    )
+  binderSlot <- localSlot env binder
+  alternativeTargets <- forM alternatives $ \alternative -> do
+    alternativeLabel <- freshLabel label "case_alt"
+    prefixLines <- alternativePrefix env resultSlot alternative
+    compileExpr env prefixLines alternativeLabel (grinAltRhs alternative)
+    pure (alternative, alternativeLabel)
+  checks <- caseChecks env resultSlot alternativeTargets
+  addBlock
+    dispatchLabel
+    ( [ loadAt "x9" "x19" resultSlot,
+        storeAt "x9" "x19" binderSlot
+      ]
+        <> checks
+    )
+
+alternativePrefix :: ValueEnv -> Int -> GrinAlt -> FunctionM [Text]
+alternativePrefix env resultSlot alternative =
+  case grinAltCon alternative of
+    GrinDataAlt _ ->
+      fmap concat . forM (zip [0 ..] (grinAltBinders alternative)) $ \(index, binder) -> do
+        slot <- localSlot env binder
+        pure
+          [ loadAt "x9" "x19" resultSlot,
+            loadByteOffset "x10" "x9" (32 + index * 8),
+            storeAt "x10" "x19" slot
+          ]
+    GrinLitAlt _ -> pure []
+    GrinDefaultAlt ->
+      fmap concat . forM (grinAltBinders alternative) $ \binder -> do
+        slot <- localSlot env binder
+        pure
+          [ loadAt "x9" "x19" resultSlot,
+            storeAt "x9" "x19" slot
+          ]
+
+caseChecks :: ValueEnv -> Int -> [(GrinAlt, Text)] -> FunctionM [Text]
+caseChecks env resultSlot targets = do
+  let nonDefault = [(alternative, label) | (alternative, label) <- targets, grinAltCon alternative /= GrinDefaultAlt]
+      defaultTarget = [label | (alternative, label) <- targets, grinAltCon alternative == GrinDefaultAlt]
+  checks <- fmap concat . forM nonDefault $ \(alternative, target) ->
+    case grinAltCon alternative of
+      GrinDataAlt name -> do
+        identifier <- liftEither (constructorId (valueCompileEnv env) name)
+        pure
+          [ loadAt "x9" "x19" resultSlot,
+            "  ldr x10, [x9, #0]",
+            "  cmp x10, #1",
+            "  b.ne 1f",
+            "  ldr x10, [x9, #8]",
+            "  cmp x10, #" <> tshow identifier,
+            "  b.eq " <> target,
+            "1:"
+          ]
+      GrinLitAlt literal ->
+        case literalInteger literal of
+          Just integer ->
+            pure
+              [ loadAt "x9" "x19" resultSlot,
+                "  ldr x10, [x9, #0]",
+                "  cmp x10, #0",
+                "  b.ne 1f",
+                "  ldr x10, [x9, #8]",
+                immediate "x11" integer,
+                "  cmp x10, x11",
+                "  b.eq " <> target,
+                "1:"
+              ]
+          Nothing -> lift (Left (Arm64UnsupportedValue "string case alternative"))
+      GrinDefaultAlt -> pure []
+  pure $
+    checks
+      <> case defaultTarget of
+        target : _ -> ["  b " <> target]
+        [] -> ["  bl _aihc_no_match", "  brk #0"]
+
+materializeValue :: ValueEnv -> GrinValue -> Either Arm64Error [Text]
+materializeValue env value =
+  case value of
+    GrinVarValue var -> loadVariable env var
+    GrinLitValue literal -> materializeLiteral literal
+    GrinNodeValue node -> materializeNode env node
+
+materializeLiteral :: GrinLiteral -> Either Arm64Error [Text]
+materializeLiteral literal =
+  case literalInteger literal of
+    Just integer -> Right [immediate "x0" integer, "  bl _aihc_make_literal"]
+    Nothing -> Left (Arm64UnsupportedValue "string literal")
+
+literalInteger :: GrinLiteral -> Maybe Integer
+literalInteger literal =
+  case literal of
+    GrinLitInt integer -> Just integer
+    GrinLitChar character -> Just (fromIntegral (ord character))
+    GrinLitString _ -> Nothing
+
+materializeNode :: ValueEnv -> GrinNode -> Either Arm64Error [Text]
+materializeNode env node = do
+  (kind, info, arity) <- nodeHeader env node
+  fieldLines <- fmap concat . forM (zip [0 :: Int ..] (grinNodeFields node)) $ \(index, field) -> do
+    unlessAtomic field
+    valueLines <- materializeValue env field
+    pure $
+      valueLines
+        <> [ "  mov x2, x0",
+             "  mov x0, x20",
+             immediate "x1" index,
+             "  bl _aihc_set_field"
+           ]
+  pure $
+    makeNodeLines kind info arity (length (grinNodeFields node))
+      <> ["  mov x20, x0"]
+      <> fieldLines
+      <> ["  mov x0, x20"]
+  where
+    unlessAtomic field =
+      case field of
+        GrinNodeValue {} -> Left (Arm64UnsupportedValue "nested node field")
+        _ -> Right ()
+
+nodeHeader :: ValueEnv -> GrinNode -> Either Arm64Error (Int, NodeInfo, Int)
+nodeHeader env node =
+  case grinNodeTag node of
+    GrinConstructor name -> do
+      identifier <- constructorId compileEnv name
+      arity <- constructorArity compileEnv name
+      pure (1, InfoImmediate identifier, arity)
+    GrinClosure functionName -> do
+      label <- functionCodeLabel compileEnv functionName
+      arity <- functionArity compileEnv functionName
+      pure (2, InfoAddress label, arity)
+    GrinThunk functionName -> do
+      label <- functionCodeLabel compileEnv functionName
+      arity <- functionArity compileEnv functionName
+      pure (3, InfoAddress label, arity)
+    GrinPrimitive name arity -> do
+      identifier <- primitiveId name
+      pure (4, InfoImmediate identifier, arity)
+    GrinForeign foreignCall -> do
+      label <- foreignDescriptorLabel compileEnv foreignCall
+      let arity = length (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
+      pure (5, InfoAddress label, arity)
+    GrinForeignIOAction _ -> Left (Arm64UnsupportedValue "source foreign IO action node")
+    GrinDictionary -> pure (7, InfoImmediate 0, length (grinNodeFields node))
+  where
+    compileEnv = valueCompileEnv env
+
+data NodeInfo
+  = InfoImmediate !Int
+  | InfoAddress !Text
+
+makeNodeLines :: Int -> NodeInfo -> Int -> Int -> [Text]
+makeNodeLines kind info arity count =
+  [ immediate "x0" kind,
+    infoLine info,
+    immediate "x2" arity,
+    immediate "x3" count,
+    "  bl _aihc_make_node"
+  ]
+  where
+    infoLine nodeInfo =
+      case nodeInfo of
+        InfoImmediate integer -> immediate "x1" integer
+        InfoAddress label -> address "x1" label
+
+loadVariable :: ValueEnv -> GrinVar -> Either Arm64Error [Text]
+loadVariable env var =
+  case Map.lookup var (valueLocalSlots env) of
+    Just slot -> Right [loadAt "x0" "x19" slot]
+    Nothing -> do
+      slot <- globalSlot (valueCompileEnv env) (grinVarName var)
+      pure ["  ldr x9, [x22, #24]", loadAt "x0" "x9" slot]
+
+localSlot :: ValueEnv -> GrinVar -> FunctionM Int
+localSlot env var =
+  case Map.lookup var (valueLocalSlots env) of
+    Just slot -> pure slot
+    Nothing -> lift (Left (Arm64UnsupportedExpression ("missing local slot for " <> grinVarName var)))
+
+freshSlot :: FunctionM Int
+freshSlot = do
+  state <- get
+  let slot = functionNextSlot state
+  modify' $ \current -> current {functionNextSlot = slot + 1}
+  pure slot
+
+freshLabel :: Text -> Text -> FunctionM Text
+freshLabel parent kind = do
+  state <- get
+  let identifier = functionNextLabel state
+  modify' $ \current -> current {functionNextLabel = identifier + 1}
+  pure (parent <> "_" <> kind <> "_" <> tshow identifier)
+
+addBlock :: Text -> [Text] -> FunctionM ()
+addBlock label lines' =
+  modify' $ \state -> state {functionBlocksRev = Block label lines' : functionBlocksRev state}
+
+renderBlock :: Block -> [Text]
+renderBlock block = blockLabel block <> ":" : blockLines block
+
+pushNormalLines :: Text -> Int -> [Text]
+pushNormalLines code slot =
+  [ "  mov x0, x22",
+    "  adr x1, " <> code,
+    "  mov x2, x19",
+    immediate "x3" slot,
+    "  bl _aihc_push_normal"
+  ]
+
+returnLines :: [Text]
+returnLines =
+  [ "  mov x1, x0",
+    "  mov x0, x22",
+    "  bl _aihc_return"
+  ]
+    <> dispatchLines
+
+evalLines :: [Text]
+evalLines =
+  [ "  mov x1, x0",
+    "  mov x0, x22",
+    "  bl _aihc_eval"
+  ]
+    <> dispatchLines
+
+dispatchLines :: [Text]
+dispatchLines =
+  [ "  ldr x19, [x22, #32]",
+    "  ldr x9, [x22, #0]",
+    "  br x9"
+  ]
+
+foreignDescriptors :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
+foreignDescriptors env program =
+  case grinForeignCalls program of
+    [] -> pure []
+    foreignCalls -> do
+      rendered <- fmap concat (mapM renderForeign foreignCalls)
+      pure ([".section __DATA,__data", ".p2align 3"] <> rendered)
+  where
+    renderForeign foreignCall = do
+      label <- foreignDescriptorLabel env foreignCall
+      (ioId, cintId, int32Id, tupleId) <- foreignConstructorIds env
+      pure
+        [ label <> ":",
+          "  .quad _" <> grinForeignCallSymbol foreignCall,
+          "  .quad " <> tshow (length (grinForeignArgumentTypes signature)),
+          "  .quad " <> if isIo then "1" else "0",
+          "  .quad " <> tshow ioId,
+          "  .quad " <> tshow cintId,
+          "  .quad " <> tshow int32Id,
+          "  .quad " <> tshow tupleId
+        ]
+      where
+        signature = grinForeignCallSignature foreignCall
+        isIo =
+          case grinForeignResult signature of
+            GrinForeignIO _ -> True
+            GrinForeignPure _ -> False
+
+foreignConstructorIds :: CompileEnv -> Either Arm64Error (Int, Int, Int, Int)
+foreignConstructorIds env =
+  (,,,)
+    <$> constructorId env "IO"
+    <*> constructorId env "CInt"
+    <*> constructorId env "I32#"
+    <*> constructorId env "(#,#)"
+
+globalSlot :: CompileEnv -> Text -> Either Arm64Error Int
+globalSlot env name =
+  maybe (Left (Arm64MissingGlobal name)) Right (Map.lookup name (compileGlobalSlots env))
+
+constructorId :: CompileEnv -> Text -> Either Arm64Error Int
+constructorId env name =
+  maybe (Left (Arm64MissingConstructor name)) Right (Map.lookup name (compileConstructorIds env))
+
+constructorArity :: CompileEnv -> Text -> Either Arm64Error Int
+constructorArity env name =
+  maybe (Left (Arm64MissingConstructor name)) Right (Map.lookup name (compileConstructorArities env))
+
+functionCodeLabel :: CompileEnv -> FunctionName -> Either Arm64Error Text
+functionCodeLabel env name =
+  maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionLabels env))
+
+functionArity :: CompileEnv -> FunctionName -> Either Arm64Error Int
+functionArity env name =
+  maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionArities env))
+
+foreignDescriptorLabel :: CompileEnv -> GrinForeignCall -> Either Arm64Error Text
+foreignDescriptorLabel env foreignCall =
+  maybe
+    (Left (Arm64MissingGlobal (grinForeignCallName foreignCall)))
+    Right
+    (Map.lookup (grinForeignCallName foreignCall) (compileForeignLabels env))
+
+primitiveId :: Text -> Either Arm64Error Int
+primitiveId name
+  | name == "realWorld#" = Right 1
+  | otherwise = Left (Arm64UnsupportedPrimitive name)
+
+boundVars :: GrinExpr -> Set GrinVar
+boundVars expression =
+  case expression of
+    GrinReturn _ -> Set.empty
+    GrinBind var valueExpression body -> Set.insert var (boundVars valueExpression <> boundVars body)
+    GrinStore _ -> Set.empty
+    GrinStoreRec bindings body -> Set.fromList (map fst bindings) <> boundVars body
+    GrinFetch _ -> Set.empty
+    GrinUpdate _ _ -> Set.empty
+    GrinEval _ -> Set.empty
+    GrinApply _ _ -> Set.empty
+    GrinCase _ binder alternatives -> Set.insert binder (Set.unions (map altBoundVars alternatives))
+    GrinDictSelect _ _ -> Set.empty
+    GrinThrow _ -> Set.empty
+    GrinCatch {} -> Set.empty
+  where
+    altBoundVars alternative = Set.fromList (grinAltBinders alternative) <> boundVars (grinAltRhs alternative)
+
+uniqueTexts :: [Text] -> [Text]
+uniqueTexts = reverse . snd . foldl' step (Set.empty, [])
+  where
+    step (seen, values) value
+      | value `Set.member` seen = (seen, values)
+      | otherwise = (Set.insert value seen, value : values)
+
+uniqueByName :: [(Text, Int)] -> [(Text, Int)]
+uniqueByName values =
+  [ (name, arity)
+  | name <- uniqueTexts (map fst values),
+    Just arity <- [lookup name values]
+  ]
+
+builtinConstructors :: [(Text, Int)]
+builtinConstructors =
+  [ ("C#", 1),
+    ("[]", 0),
+    (":", 2),
+    ("()", 0),
+    ("(,)", 2),
+    ("(#,#)", 2)
+  ]
+
+functionLabel :: Int -> Text
+functionLabel index = ".Laihc_function_" <> tshow index
+
+foreignLabel :: Int -> Text
+foreignLabel index = ".Laihc_foreign_" <> tshow index
+
+storeGlobal :: Int -> [Text]
+storeGlobal slot =
+  [ "  ldr x9, [x22, #24]",
+    storeAt "x0" "x9" slot
+  ]
+
+loadAt :: Text -> Text -> Int -> Text
+loadAt destination base slot = loadByteOffset destination base (slot * 8)
+
+storeAt :: Text -> Text -> Int -> Text
+storeAt source base slot = storeByteOffset source base (slot * 8)
+
+loadByteOffset :: Text -> Text -> Int -> Text
+loadByteOffset destination base offset =
+  "  ldr " <> destination <> ", [" <> base <> ", #" <> tshow offset <> "]"
+
+storeByteOffset :: Text -> Text -> Int -> Text
+storeByteOffset source base offset =
+  "  str " <> source <> ", [" <> base <> ", #" <> tshow offset <> "]"
+
+immediate :: (Show value) => Text -> value -> Text
+immediate register value = "  ldr " <> register <> ", =" <> T.pack (show value)
+
+address :: Text -> Text -> Text
+address register label =
+  "  adrp " <> register <> ", " <> label <> "@PAGE\n  add " <> register <> ", " <> register <> ", " <> label <> "@PAGEOFF"
+
+tshow :: (Show value) => value -> Text
+tshow = T.pack . show
+
+liftEither :: Either Arm64Error value -> FunctionM value
+liftEither = lift

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -521,7 +521,6 @@ foreignDescriptors env program =
       pure
         [ label <> ":",
           "  .quad _" <> grinForeignCallSymbol foreignCall,
-          "  .quad " <> tshow (length (grinForeignArgumentTypes signature)),
           "  .quad " <> if isIo then "1" else "0",
           "  .quad " <> tshow ioId,
           "  .quad " <> tshow cintId,

--- a/components/aihc-arm64/src/Aihc/Arm64/Emit.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Emit.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Render register-allocated AArch64 LIR. Spills are loaded from and stored
+-- into the current Haskell heap frame in @x19@.
+module Aihc.Arm64.Emit
+  ( EmitError (..),
+    renderAllocatedBlock,
+    renderPhysicalReg,
+  )
+where
+
+import Aihc.Arm64.Lir
+import Aihc.Arm64.RegisterAllocate
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+
+data EmitError
+  = EmitMissingAllocation !VirtualReg
+  | EmitTooManySpilledOperands !Instruction
+  deriving (Eq, Show)
+
+renderAllocatedBlock :: Int -> [Instruction] -> Either EmitError ([Text], Int)
+renderAllocatedBlock spillBase instructions = do
+  rendered <- mapM (renderInstruction spillBase allocation) instructions
+  pure (concat rendered, allocationSpillCount allocation)
+  where
+    allocation = allocateBlock instructions
+
+renderInstruction :: Int -> Allocation -> Instruction -> Either EmitError [Text]
+renderInstruction spillBase allocation instruction = do
+  let virtuals = Set.toAscList (instructionUses instruction <> instructionDefs instruction)
+      spilled =
+        [ register
+        | register <- virtuals,
+          Just InHeapSpill {} <- [Map.lookup register locations]
+        ]
+  scratchAssignments <-
+    if length spilled <= length spillScratchRegisters
+      then pure (Map.fromList (zip spilled spillScratchRegisters))
+      else Left (EmitTooManySpilledOperands instruction)
+  before <- fmap concat . mapM (loadSpill scratchAssignments) $ Set.toAscList (instructionUses instruction)
+  core <- renderCore (resolveRegister scratchAssignments) instruction
+  after <- fmap concat . mapM (storeSpill scratchAssignments) $ Set.toAscList (instructionDefs instruction)
+  pure (before <> [core] <> after)
+  where
+    locations = allocationLocations allocation
+    resolveRegister scratchAssignments register =
+      case register of
+        Physical physical -> Right physical
+        Virtual virtual ->
+          case Map.lookup virtual locations of
+            Just (InRegister physical) -> Right physical
+            Just InHeapSpill {} ->
+              maybe (Left (EmitMissingAllocation virtual)) Right (Map.lookup virtual scratchAssignments)
+            Nothing -> Left (EmitMissingAllocation virtual)
+    loadSpill scratchAssignments virtual =
+      case Map.lookup virtual locations of
+        Just (InHeapSpill slot) -> do
+          scratch <- maybe (Left (EmitMissingAllocation virtual)) Right (Map.lookup virtual scratchAssignments)
+          pure [heapLoad scratch (spillBase + slot)]
+        Just InRegister {} -> pure []
+        Nothing -> Left (EmitMissingAllocation virtual)
+    storeSpill scratchAssignments virtual =
+      case Map.lookup virtual locations of
+        Just (InHeapSpill slot) -> do
+          scratch <- maybe (Left (EmitMissingAllocation virtual)) Right (Map.lookup virtual scratchAssignments)
+          pure [heapStore scratch (spillBase + slot)]
+        Just InRegister {} -> pure []
+        Nothing -> Left (EmitMissingAllocation virtual)
+
+renderCore :: (Register -> Either EmitError PhysicalReg) -> Instruction -> Either EmitError Text
+renderCore resolve instruction =
+  case instruction of
+    Move destination source -> binary "mov" <$> resolve destination <*> resolve source
+    MoveImmediate destination integer -> do
+      destination' <- resolve destination
+      pure ("  ldr " <> renderPhysicalReg destination' <> ", =" <> tshow integer)
+    Load destination base offset -> do
+      destination' <- resolve destination
+      base' <- resolve base
+      pure (memory "ldr" destination' base' offset)
+    Store source base offset -> do
+      source' <- resolve source
+      base' <- resolve base
+      pure (memory "str" source' base' offset)
+    Add destination left right -> do
+      destination' <- resolve destination
+      left' <- resolve left
+      right' <- resolve right
+      pure (ternary "add" destination' left' right')
+    Compare left right -> binary "cmp" <$> resolve left <*> resolve right
+    CompareImmediate value integer -> do
+      value' <- resolve value
+      pure ("  cmp " <> renderPhysicalReg value' <> ", #" <> tshow integer)
+    LoadAddress destination label -> do
+      destination' <- resolve destination
+      let rendered = renderPhysicalReg destination'
+      pure ("  adrp " <> rendered <> ", " <> label <> "@PAGE\n  add " <> rendered <> ", " <> rendered <> ", " <> label <> "@PAGEOFF")
+    Call symbol -> pure ("  bl " <> symbol)
+
+binary :: Text -> PhysicalReg -> PhysicalReg -> Text
+binary opcode destination source =
+  "  " <> opcode <> " " <> renderPhysicalReg destination <> ", " <> renderPhysicalReg source
+
+ternary :: Text -> PhysicalReg -> PhysicalReg -> PhysicalReg -> Text
+ternary opcode destination left right =
+  "  " <> opcode <> " " <> renderPhysicalReg destination <> ", " <> renderPhysicalReg left <> ", " <> renderPhysicalReg right
+
+memory :: Text -> PhysicalReg -> PhysicalReg -> Int -> Text
+memory opcode value base offset =
+  "  " <> opcode <> " " <> renderPhysicalReg value <> ", [" <> renderPhysicalReg base <> ", #" <> tshow offset <> "]"
+
+heapLoad :: PhysicalReg -> Int -> Text
+heapLoad destination slot = memory "ldr" destination X19 (slot * 8)
+
+heapStore :: PhysicalReg -> Int -> Text
+heapStore source slot = memory "str" source X19 (slot * 8)
+
+spillScratchRegisters :: [PhysicalReg]
+spillScratchRegisters = [X8, X7, X6]
+
+renderPhysicalReg :: PhysicalReg -> Text
+renderPhysicalReg register =
+  case register of
+    X0 -> "x0"
+    X1 -> "x1"
+    X2 -> "x2"
+    X3 -> "x3"
+    X4 -> "x4"
+    X5 -> "x5"
+    X6 -> "x6"
+    X7 -> "x7"
+    X8 -> "x8"
+    X9 -> "x9"
+    X10 -> "x10"
+    X11 -> "x11"
+    X12 -> "x12"
+    X13 -> "x13"
+    X14 -> "x14"
+    X15 -> "x15"
+    X19 -> "x19"
+    X20 -> "x20"
+    X21 -> "x21"
+    X22 -> "x22"
+
+tshow :: (Show value) => value -> Text
+tshow = T.pack . show

--- a/components/aihc-arm64/src/Aihc/Arm64/Lir.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Lir.hs
@@ -1,0 +1,91 @@
+-- | Small AArch64-shaped low-level IR used immediately before register
+-- allocation. Blocks may contain virtual registers, but calls and control-flow
+-- edges are explicit.
+module Aihc.Arm64.Lir
+  ( VirtualReg (..),
+    Register (..),
+    PhysicalReg (..),
+    Instruction (..),
+    instructionDefs,
+    instructionUses,
+  )
+where
+
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+
+newtype VirtualReg = VirtualReg Int
+  deriving (Eq, Ord, Show)
+
+data PhysicalReg
+  = X0
+  | X1
+  | X2
+  | X3
+  | X4
+  | X5
+  | X6
+  | X7
+  | X8
+  | X9
+  | X10
+  | X11
+  | X12
+  | X13
+  | X14
+  | X15
+  | X19
+  | X20
+  | X21
+  | X22
+  deriving (Eq, Ord, Show, Enum, Bounded)
+
+data Register
+  = Virtual !VirtualReg
+  | Physical !PhysicalReg
+  deriving (Eq, Ord, Show)
+
+data Instruction
+  = Move !Register !Register
+  | MoveImmediate !Register !Integer
+  | Load !Register !Register !Int
+  | Store !Register !Register !Int
+  | Add !Register !Register !Register
+  | Compare !Register !Register
+  | CompareImmediate !Register !Integer
+  | LoadAddress !Register !Text
+  | Call !Text
+  deriving (Eq, Show)
+
+instructionDefs :: Instruction -> Set VirtualReg
+instructionDefs instruction =
+  case instruction of
+    Move destination _ -> virtual destination
+    MoveImmediate destination _ -> virtual destination
+    Load destination _ _ -> virtual destination
+    Store {} -> Set.empty
+    Add destination _ _ -> virtual destination
+    Compare {} -> Set.empty
+    CompareImmediate {} -> Set.empty
+    LoadAddress destination _ -> virtual destination
+    Call {} -> Set.empty
+
+instructionUses :: Instruction -> Set VirtualReg
+instructionUses instruction =
+  case instruction of
+    Move _ source -> virtual source
+    MoveImmediate {} -> Set.empty
+    Load _ base _ -> virtual base
+    Store source base _ -> virtual source <> virtual base
+    Add _ left right -> virtual left <> virtual right
+    Compare left right -> virtual left <> virtual right
+    CompareImmediate value _ -> virtual value
+    LoadAddress {} -> Set.empty
+    Call {} -> Set.empty
+
+virtual :: Register -> Set VirtualReg
+virtual register =
+  case register of
+    Virtual value -> Set.singleton value
+    Physical _ -> Set.empty

--- a/components/aihc-arm64/src/Aihc/Arm64/RegisterAllocate.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/RegisterAllocate.hs
@@ -1,0 +1,133 @@
+-- | Fast linear-scan allocation for straight-line AArch64 LIR blocks.
+--
+-- Haskell spill slots are abstract frame slots, never native-stack offsets.
+-- Code generation materializes them relative to the current heap frame.
+module Aihc.Arm64.RegisterAllocate
+  ( Location (..),
+    Allocation (..),
+    allocateBlock,
+    allocatableRegisters,
+  )
+where
+
+import Aihc.Arm64.Lir
+import Data.List (maximumBy, sortOn)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Ord (comparing)
+import Data.Set qualified as Set
+
+data Location
+  = InRegister !PhysicalReg
+  | InHeapSpill !Int
+  deriving (Eq, Show)
+
+data Allocation = Allocation
+  { allocationLocations :: !(Map VirtualReg Location),
+    allocationSpillCount :: !Int
+  }
+  deriving (Eq, Show)
+
+data Interval = Interval
+  { intervalRegister :: !VirtualReg,
+    intervalStart :: !Int,
+    intervalEnd :: !Int,
+    intervalCrossesCall :: !Bool
+  }
+  deriving (Eq, Show)
+
+data Active = Active
+  { activeInterval :: !Interval,
+    activePhysical :: !PhysicalReg
+  }
+
+data ScanState = ScanState
+  { scanActive :: ![Active],
+    scanLocations :: !(Map VirtualReg Location),
+    scanNextSpill :: !Int
+  }
+
+-- | Registers which are caller-clobbered by C and not reserved for the linker,
+-- platform, frame pointer, link register, or runtime state. Values live across
+-- a 'Call' are assigned heap spill slots instead.
+allocatableRegisters :: [PhysicalReg]
+allocatableRegisters = [X9, X10, X11, X12, X13, X14, X15]
+
+allocateBlock :: [Instruction] -> Allocation
+allocateBlock instructions =
+  Allocation
+    { allocationLocations = scanLocations finalState,
+      allocationSpillCount = scanNextSpill finalState
+    }
+  where
+    intervals = sortOn intervalStart (buildIntervals instructions)
+    finalState = foldl' allocateInterval initialState intervals
+    initialState = ScanState [] Map.empty 0
+
+allocateInterval :: ScanState -> Interval -> ScanState
+allocateInterval state interval =
+  if intervalCrossesCall interval
+    then assignSpill stateAfterExpiry interval
+    else case freeRegisters of
+      physical : _ ->
+        stateAfterExpiry
+          { scanActive = Active interval physical : scanActive stateAfterExpiry,
+            scanLocations = Map.insert (intervalRegister interval) (InRegister physical) (scanLocations stateAfterExpiry)
+          }
+      [] -> spillInterval stateAfterExpiry interval
+  where
+    (_, remaining) = span ((< intervalStart interval) . intervalEnd . activeInterval) (sortOn (intervalEnd . activeInterval) (scanActive state))
+    stateAfterExpiry = state {scanActive = remaining}
+    occupied = Set.fromList (map activePhysical remaining)
+    freeRegisters = filter (`Set.notMember` occupied) allocatableRegisters
+
+spillInterval :: ScanState -> Interval -> ScanState
+spillInterval state interval =
+  case scanActive state of
+    [] -> assignSpill state interval
+    active
+      | intervalEnd (activeInterval spillCandidate) > intervalEnd interval ->
+          let stateWithOldSpilled = assignSpill state (activeInterval spillCandidate)
+              activeWithoutCandidate = filter ((/= intervalRegister (activeInterval spillCandidate)) . intervalRegister . activeInterval) (scanActive stateWithOldSpilled)
+              physical = activePhysical spillCandidate
+           in stateWithOldSpilled
+                { scanActive = Active interval physical : activeWithoutCandidate,
+                  scanLocations = Map.insert (intervalRegister interval) (InRegister physical) (scanLocations stateWithOldSpilled)
+                }
+      | otherwise -> assignSpill state interval
+      where
+        spillCandidate = maximumBy (comparing (intervalEnd . activeInterval)) active
+
+assignSpill :: ScanState -> Interval -> ScanState
+assignSpill state interval =
+  state
+    { scanActive = filter ((/= intervalRegister interval) . intervalRegister . activeInterval) (scanActive state),
+      scanLocations = Map.insert (intervalRegister interval) (InHeapSpill spill) (scanLocations state),
+      scanNextSpill = spill + 1
+    }
+  where
+    spill = scanNextSpill state
+
+buildIntervals :: [Instruction] -> [Interval]
+buildIntervals instructions =
+  [ Interval register first lastPosition (any (\position -> first < position && position < lastPosition) callPositions)
+  | (register, (first, lastPosition)) <- Map.toList positions
+  ]
+  where
+    callPositions = [position | (position, Call {}) <- zip [0 ..] instructions]
+    positions =
+      foldl'
+        ( \accumulator (position, instruction) ->
+            foldl'
+              (recordPosition position)
+              accumulator
+              (Set.toList (instructionDefs instruction <> instructionUses instruction))
+        )
+        Map.empty
+        (zip [0 ..] instructions)
+    recordPosition position accumulator register =
+      Map.insertWith
+        (\(newFirst, newLast) (oldFirst, oldLast) -> (min newFirst oldFirst, max newLast oldLast))
+        register
+        (position, position)
+        accumulator

--- a/components/aihc-arm64/test/Spec.hs
+++ b/components/aihc-arm64/test/Spec.hs
@@ -1,0 +1,19 @@
+module Main (main) where
+
+import Test.Arm64.Suite (tests)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck qualified as QC
+
+main :: IO ()
+main =
+  defaultMain
+    ( testGroup
+        "aihc-arm64"
+        [ tests,
+          QC.testProperty "dummy quickcheck property" prop_dummy
+        ]
+    )
+
+-- | Keep the workspace-wide QuickCheck controls accepted by this suite.
+prop_dummy :: Bool -> Bool
+prop_dummy _ = True

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Arm64.Suite
+  ( tests,
+  )
+where
+
+import Aihc.Arm64 (compileProgram, runtimeSourcePath)
+import Aihc.Arm64.Emit (renderAllocatedBlock)
+import Aihc.Arm64.Lir
+import Aihc.Arm64.RegisterAllocate
+import Aihc.Grin (lowerProgram)
+import Aihc.Testing.EvalFixture (EvalCase (..), compileEvalCase, evalBindingName, loadEvalCases)
+import Control.Exception (bracket)
+import Control.Monad (when)
+import Data.List (find, isInfixOf)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.Exit (ExitCode (..))
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
+import System.Info (arch, os)
+import System.Process (readProcessWithExitCode)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "aihc-arm64"
+    [ testCase "linear scan reuses an expired register" $ do
+        let first = VirtualReg 0
+            second = VirtualReg 1
+            allocation =
+              allocateBlock
+                [ MoveImmediate (Virtual first) 1,
+                  Move (Physical X0) (Virtual first),
+                  MoveImmediate (Virtual second) 2,
+                  Move (Physical X1) (Virtual second)
+                ]
+        assertEqual
+          "locations"
+          (Map.fromList [(first, InRegister X9), (second, InRegister X9)])
+          (allocationLocations allocation),
+      testCase "linear scan spills into a heap-frame slot" $ do
+        let registers = map VirtualReg [0 .. 7]
+            definitions = [MoveImmediate (Virtual register) (fromIntegral index) | (index, register) <- zip [0 :: Int ..] registers]
+            uses = [Move (Physical X0) (Virtual register) | register <- registers]
+            instructions = definitions <> uses
+            allocation = allocateBlock instructions
+        assertEqual "one spill" 1 (allocationSpillCount allocation)
+        assertBool "heap spill assigned" (InHeapSpill 0 `elem` Map.elems (allocationLocations allocation))
+        case renderAllocatedBlock 10 instructions of
+          Left err -> assertFailure ("failed to emit allocated block: " <> show err)
+          Right (assembly, spillCount) -> do
+            assertEqual "emitted spill count" 1 spillCount
+            assertBool "spill stored in heap frame" ("  str x8, [x19, #80]" `elem` assembly)
+            assertBool "spill loaded from heap frame" ("  ldr x8, [x19, #80]" `elem` assembly),
+      testCase "linear scan spills values live across C calls" $ do
+        let register = VirtualReg 0
+            allocation =
+              allocateBlock
+                [ MoveImmediate (Virtual register) 1,
+                  Call "_external",
+                  Move (Physical X0) (Virtual register)
+                ]
+        assertEqual "call-spanning location" (Just (InHeapSpill 0)) (Map.lookup register (allocationLocations allocation)),
+      testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
+    ]
+
+testNativeHelloWorld :: IO ()
+testNativeHelloWorld = do
+  cases <- loadEvalCases
+  evalCase <-
+    case find ((== "native-hello-world.yaml") . evalCaseId) cases of
+      Just value -> pure value
+      Nothing -> assertFailure "native HelloWorld fixture is missing"
+  compileResult <- compileEvalCase evalCase
+  fcProgram <-
+    case compileResult of
+      Right value -> pure value
+      Left err -> assertFailure ("HelloWorld failed before GRIN lowering: " <> err)
+  assembly <-
+    case compileProgram evalBindingName (lowerProgram fcProgram) of
+      Right value -> pure value
+      Left err -> assertFailure ("ARM64 lowering failed: " <> show err)
+  let rendered = T.unpack assembly
+  assertBool "emits indirect Haskell tail transfers" ("br x9" `isInfixOf` rendered)
+  assertBool "never calls a generated Haskell entry" (not ("bl .Laihc_function_" `isInfixOf` rendered))
+  when (arch == "aarch64" && os == "darwin") $
+    runHelloWorldAssembly assembly
+
+runHelloWorldAssembly :: T.Text -> IO ()
+runHelloWorldAssembly assembly =
+  withTempDirectory "aihc-arm64-hello" $ \directory -> do
+    runtime <- runtimeSourcePath
+    let assemblyPath = directory </> "hello.s"
+        executablePath = directory </> "hello"
+    writeFile assemblyPath (T.unpack assembly)
+    (clangExit, _clangOut, clangErr) <-
+      readProcessWithExitCode "clang" ["-std=c11", "-Wall", "-Wextra", "-Werror", runtime, assemblyPath, "-o", executablePath] ""
+    case clangExit of
+      ExitSuccess -> pure ()
+      ExitFailure _ -> assertFailure ("clang failed to assemble HelloWorld:\n" <> clangErr)
+    (programExit, programOut, programErr) <- readProcessWithExitCode executablePath [] ""
+    assertEqual ("native stderr: " <> programErr) ExitSuccess programExit
+    assertEqual "native stdout" "Hello, world!\n" programOut
+
+withTempDirectory :: String -> (FilePath -> IO value) -> IO value
+withTempDirectory template = bracket acquire removeDirectoryRecursive
+  where
+    acquire = do
+      temporary <- getTemporaryDirectory
+      (path, handle) <- openTempFile temporary template
+      hClose handle
+      removeFile path
+      createDirectory path
+      pure path

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -44,7 +44,7 @@ newtype FcProgram = FcProgram
   { -- | Top-level bindings in dependency order.
     fcTopBinds :: [FcTopBind]
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A top-level binding.
 data FcTopBind
@@ -60,7 +60,7 @@ data FcTopBind
     FcForeignImport !FcForeignCall
   | -- | Value binding.
     FcTopBind !FcBind
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A statically named C function resolved by the evaluator or a code generator.
 data FcForeignCall = FcForeignCall
@@ -68,7 +68,7 @@ data FcForeignCall = FcForeignCall
     fcForeignCallSymbol :: !Text,
     fcForeignCallSignature :: !FcForeignSignature
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | The ABI-relevant part of a foreign import's type.
 --
@@ -78,18 +78,18 @@ data FcForeignSignature = FcForeignSignature
   { fcForeignArgumentTypes :: ![FcForeignType],
     fcForeignResult :: !FcForeignResult
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Whether a foreign call is pure or produces an 'IO' action.
 data FcForeignResult
   = FcForeignPure !FcForeignType
   | FcForeignIO !FcForeignType
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A value type with explicit host ABI marshalling support.
 data FcForeignType
   = FcForeignCInt
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A typed variable.
 data Var = Var
@@ -97,7 +97,7 @@ data Var = Var
     varUnique :: !Unique,
     varType :: !TcType
   }
-  deriving (Show)
+  deriving (Show, Read)
 
 -- Eq/Ord on Unique only, mirroring TyVarId.
 instance Eq Var where
@@ -137,7 +137,7 @@ data FcExpr
     FcCase !FcExpr !Var ![FcAlt]
   | -- | Cast: @e \triangleright \gamma@.
     FcCast !FcExpr !Coercion
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Binding group.
 data FcBind
@@ -145,7 +145,7 @@ data FcBind
     FcNonRec !Var !FcExpr
   | -- | Recursive binding group.
     FcRec ![(Var, FcExpr)]
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Case alternative.
 data FcAlt = FcAlt
@@ -156,7 +156,7 @@ data FcAlt = FcAlt
     -- | Right-hand side.
     altRhs :: !FcExpr
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Case alternative constructor.
 data FcAltCon
@@ -166,7 +166,7 @@ data FcAltCon
     LitAlt !Literal
   | -- | Default/wildcard.
     DefaultAlt
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Literal values.
 data Literal
@@ -174,4 +174,4 @@ data Literal
   | -- | An unboxed character literal, such as @'x'#@.
     LitChar !Char
   | LitString !Text
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)

--- a/components/aihc-parser/src/Aihc/Parser/Syntax.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Syntax.hs
@@ -739,7 +739,7 @@ data NameType
     NameVarSym
   | -- | Constructor operator (e.g., @:@, @:++@)
     NameConSym
-  deriving (Eq, Show, Generic, NFData, Enum, Bounded, Data)
+  deriving (Eq, Show, Read, Generic, NFData, Enum, Bounded, Data)
 
 mkName :: Maybe Text -> NameType -> Text -> Name
 mkName qualifier ty txt = Name qualifier ty txt []
@@ -1874,7 +1874,7 @@ data FixityAssoc
     InfixL
   | -- | @infixr@
     InfixR
-  deriving (Data, Eq, Show, Generic, NFData)
+  deriving (Data, Eq, Show, Read, Generic, NFData)
 
 -- | A foreign import or export declaration.
 -- Example: @foreign import ccall "puts" puts :: CString -> IO CInt@.

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -86,7 +86,7 @@ data OperatorFixity = OperatorFixity
   { operatorFixityAssoc :: !FixityAssoc,
     operatorFixityPrecedence :: !Int
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 type ModuleExports = Map.Map Text Scope
 

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -21,6 +21,7 @@ module Aihc.Tc
     typecheckModuleWithEnvAndInstances,
     typecheckModulesWithEnv,
     typecheckModulesWithEnvAndInstances,
+    typecheckModulesWithFullEnv,
 
     -- * Result types
     TcResult (..),
@@ -40,6 +41,7 @@ module Aihc.Tc
     TypeScheme (..),
     Pred (..),
     InstanceInfo (..),
+    TyConInfo (..),
     Unique (..),
     TcAnnotation (..),
     TcDiagnostic (..),
@@ -77,7 +79,7 @@ import Aihc.Parser.Syntax
     mkAnnotation,
   )
 import Aihc.Tc.Annotations (TcAnnotation (..), renderPred, renderTcSignature, renderTcType)
-import Aihc.Tc.Env (InstanceInfo (..))
+import Aihc.Tc.Env (InstanceInfo (..), TyConInfo (..))
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleInstances, tcModule)
 import Aihc.Tc.Generate.Expr (inferExpr)
@@ -191,7 +193,23 @@ typecheckModulesWithEnv importedTerms =
 -- | Type-check modules in order with preloaded terms and class instances.
 typecheckModulesWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> [Module] -> [Module]
 typecheckModulesWithEnvAndInstances importedTerms importedInstances =
-  go initState
+  firstOfThree . typecheckModulesWithFullEnv importedTerms [] importedInstances
+
+firstOfThree :: (a, b, c) -> a
+firstOfThree (first, _, _) = first
+
+-- | Type-check modules with a complete imported type-checker interface and
+-- return the accumulated term schemes and type constructors for downstream
+-- modules.
+typecheckModulesWithFullEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo])
+typecheckModulesWithFullEnv importedTerms importedTyCons importedInstances modules =
+  let (checkedModules, finalState) = go initState modules
+   in ( checkedModules,
+        [ (name, scheme)
+        | (name, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms finalState)
+        ],
+        Map.elems (tcsGlobalTyCons finalState)
+      )
   where
     initState =
       initTcState
@@ -201,13 +219,20 @@ typecheckModulesWithEnvAndInstances importedTerms importedInstances =
               | (name, scheme) <- importedTerms
               ]
               <> tcsGlobalTerms initTcState,
+          tcsGlobalTyCons =
+            Map.fromList
+              [ (tciName tyCon, tyCon)
+              | tyCon <- importedTyCons
+              ]
+              <> tcsGlobalTyCons initTcState,
           tcsInstances = importedInstances
         }
 
-    go _ [] = []
+    go st [] = ([], st)
     go st (m : ms) =
       let (result, st') = typecheckModuleWithState st m
-       in result : go st' ms
+          (results, finalState) = go st' ms
+       in (result : results, finalState)
 
 typecheckModuleWithState :: TcState -> Module -> (Module, TcState)
 typecheckModuleWithState st m =

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -52,7 +52,7 @@ data TyConInfo = TyConInfo
     tciTyCon :: !TyCon,
     tciKind :: !Kind
   }
-  deriving (Show)
+  deriving (Show, Read)
 
 -- | Information about a data constructor.
 --

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -99,4 +99,4 @@ data InstanceInfo = InstanceInfo
     -- | Instance head types.
     iiHead :: ![TcType]
   }
-  deriving (Show)
+  deriving (Show, Read)

--- a/components/aihc-tc/src/Aihc/Tc/Evidence.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Evidence.hs
@@ -21,7 +21,7 @@ import Data.Text (Text)
 
 -- | An evidence variable, uniquely identified.
 newtype EvVar = EvVar {evVarUnique :: Unique}
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | Evidence terms.
 --
@@ -41,14 +41,14 @@ data EvTerm
     EvSuperClass !EvTerm !Int
   | -- | Cast evidence through a coercion.
     EvCast !EvTerm !Coercion
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A binding of an evidence variable to its term.
 data EvBinding = EvBinding
   { evBindVar :: !EvVar,
     evBindTerm :: !EvTerm
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Coercions for type equality evidence.
 --
@@ -67,4 +67,4 @@ data Coercion
     TyConAppCo !TyCon ![Coercion]
   | -- | Type family / newtype axiom instantiation (future).
     AxiomInstCo !Text ![TcType]
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -113,7 +113,7 @@ data TcBindingResult = TcBindingResult
     tbDisplayName :: !Text,
     tbType :: !TcType
   }
-  deriving (Show)
+  deriving (Show, Read)
 
 data UserSig = UserSig
   { userSigName :: !Text,

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -39,7 +39,7 @@ import Data.Text qualified as T
 
 -- | Unique identifier for type variables and evidence variables.
 newtype Unique = Unique Int
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | A type variable identifier, carrying both a human-readable name and
 -- a unique tag for alpha-equivalence.
@@ -47,7 +47,7 @@ data TyVarId = TyVarId
   { tvName :: !Text,
     tvUnique :: !Unique
   }
-  deriving (Show)
+  deriving (Show, Read)
 
 instance Eq TyVarId where
   a == b = tvUnique a == tvUnique b
@@ -60,7 +60,7 @@ data TyCon = TyCon
   { tyConName :: !Text,
     tyConArity :: !Int
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | Kinds for the type language checked by @aihc-tc@.
 data Kind
@@ -68,7 +68,7 @@ data Kind
   | KConstraint
   | KFun !Kind !Kind
   | KMeta !Unique
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | Internal type representation.
 --
@@ -91,7 +91,7 @@ data TcType
     TcQualTy ![Pred] !TcType
   | -- | Unsaturated type application @f a@.
     TcAppTy !TcType !TcType
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Whether a type has an unlifted runtime representation in the subset of
 -- primitive types and runtime representations currently modeled by AIHC.
@@ -172,7 +172,7 @@ isUnliftedRuntimeRep rep =
 -- @ForAll [a, b] [Eq a] (a -> b -> Bool)@
 -- represents @forall a b. Eq a => a -> b -> Bool@.
 data TypeScheme = ForAll ![TyVarId] ![Pred] !TcType
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A predicate (primitive constraint).
 --
@@ -184,7 +184,7 @@ data Pred
     ClassPred !Text ![TcType]
   | -- | Type equality predicate, e.g. @a ~ Int@.
     EqPred !TcType !TcType
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | The nesting level of implication constraints.
 --

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -228,7 +228,25 @@ kindTests =
           let result = typecheckModule modu
           assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
         ResolveResult {resolveErrors} ->
-          assertFailure ("Resolve error in imported-class kind test: " <> show resolveErrors)
+          assertFailure ("Resolve error in imported-class kind test: " <> show resolveErrors),
+    testCase "uses imported type constructor arities" $ do
+      let baseResult = resolve [parseOnly "module Base (Box) where\ndata Box a = Box a\n"]
+          depExports = extractInterface baseResult
+      case baseResult of
+        ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
+          let (checkedBase, _, importedTyCons) = typecheckModulesWithFullEnv [] [] [] baseModules
+          assertBool "dependency should typecheck" (all tcModuleSuccess checkedBase)
+          let target = parseOnly "module Test where\nimport Base\ndata Unit = Unit\nkeep :: Box Unit -> Box Unit\nkeep x = x\n"
+          case resolveWithDeps depExports [target] of
+            ResolveResult {resolvedModules = targetModules, resolveErrors = []} -> do
+              let (checkedTarget, _, _) = typecheckModulesWithFullEnv [] importedTyCons [] targetModules
+              assertBool
+                ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedTarget))
+                (all tcModuleSuccess checkedTarget)
+            ResolveResult {resolveErrors} ->
+              assertFailure ("Resolve error in imported-type test: " <> show resolveErrors)
+        ResolveResult {resolveErrors} ->
+          assertFailure ("Resolve error in dependency-type test: " <> show resolveErrors)
   ]
   where
     isKindMismatch diag =

--- a/examples/hello-world/Main.hs
+++ b/examples/hello-world/Main.hs
@@ -1,43 +1,13 @@
 {-# LANGUAGE ExtendedLiterals #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE GHCForeignImportPrim #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 
 module Main where
 
-data State# s
-
-data RealWorld
-
-data Int32 = I32# Int32#
-
-newtype CInt = CInt Int32
-
-newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
-
-foreign import prim realWorld# :: State# RealWorld
+import Foreign.C.Types (CInt (..))
+import GHC.Int (Int32 (..))
 
 foreign import ccall unsafe putchar :: CInt -> IO CInt
-
-bind :: IO a -> (a -> IO b) -> IO b
-bind (IO action) next =
-  IO
-    ( \state ->
-        case action state of
-          (# nextState, value #) ->
-            case next value of
-              IO nextAction -> nextAction nextState
-    )
-
-thenIO :: IO a -> IO b -> IO b
-thenIO first second = bind first (\ignored -> second)
-
-infixr 1 >>
-
-(>>) :: IO a -> IO b -> IO b
-(>>) first second = thenIO first second
 
 char :: Int32# -> CInt
 char value = CInt (I32# value)

--- a/examples/hello-world/Main.hs
+++ b/examples/hello-world/Main.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ExtendedLiterals #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GHCForeignImportPrim #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Main where
+
+data State# s
+
+data RealWorld
+
+data Int32 = I32# Int32#
+
+newtype CInt = CInt Int32
+
+newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
+
+foreign import prim realWorld# :: State# RealWorld
+
+foreign import ccall unsafe putchar :: CInt -> IO CInt
+
+bind :: IO a -> (a -> IO b) -> IO b
+bind (IO action) next =
+  IO
+    ( \state ->
+        case action state of
+          (# nextState, value #) ->
+            case next value of
+              IO nextAction -> nextAction nextState
+    )
+
+thenIO :: IO a -> IO b -> IO b
+thenIO first second = bind first (\ignored -> second)
+
+infixr 1 >>
+
+(>>) :: IO a -> IO b -> IO b
+(>>) first second = thenIO first second
+
+char :: Int32# -> CInt
+char value = CInt (I32# value)
+
+main :: IO CInt
+main =
+  putchar (char 72#Int32)
+    >> putchar (char 101#Int32)
+    >> putchar (char 108#Int32)
+    >> putchar (char 108#Int32)
+    >> putchar (char 111#Int32)
+    >> putchar (char 44#Int32)
+    >> putchar (char 32#Int32)
+    >> putchar (char 119#Int32)
+    >> putchar (char 111#Int32)
+    >> putchar (char 114#Int32)
+    >> putchar (char 108#Int32)
+    >> putchar (char 100#Int32)
+    >> putchar (char 33#Int32)
+    >> putchar (char 10#Int32)

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -71,6 +71,7 @@
 
   parserTests = mkPackageTest hsPkgs.aihc-parser;
   cppTests = mkPackageTest hsPkgs.aihc-cpp;
+  arm64Tests = mkEvalPackageTest hsPkgs.aihc-arm64;
   fcTests = mkEvalPackageTest hsPkgs.aihc-fc;
   grinTests = mkEvalPackageTest hsPkgs.aihc-grin;
   resolveTests = mkPackageTest hsPkgs.aihc-resolve;
@@ -166,6 +167,7 @@
 in {
   parser-tests = parserTests;
   cpp-tests = cppTests;
+  arm64-tests = arm64Tests;
   fc-tests = fcTests;
   grin-tests = grinTests;
   resolve-tests = resolveTests;
@@ -195,6 +197,10 @@ in {
     {
       name = "cpp-tests";
       path = cppTests;
+    }
+    {
+      name = "arm64-tests";
+      path = arm64Tests;
     }
     {
       name = "fc-tests";

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -3,6 +3,17 @@
   sources,
 }: let
   componentSpecs = {
+    aihc-arm64 = {
+      src = sources.arm64Src;
+      cabal2nixOptions = {
+        extraCabal2nixOptions = "--subpath components/aihc-arm64";
+        srcModifier = src: src;
+      };
+      disableProfiling = true;
+      optimizeForChecks = true;
+      supportsDocs = false;
+      supportsCoverage = false;
+    };
     aihc-parser = {
       src = sources.parserSrc;
       disableProfiling = true;
@@ -120,6 +131,10 @@
     };
     aihc = {
       src = sources.aihcSrc;
+      cabal2nixOptions = {
+        extraCabal2nixOptions = "--subpath bin/aihc";
+        srcModifier = src: src;
+      };
       disableProfiling = true;
       optimizeForChecks = true;
       supportsDocs = false;

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -59,6 +59,14 @@ in rec {
     ".yml"
   ];
 
+  arm64Src = mkRootSubsetSrc ["components/aihc-arm64/" "test/support/"] [
+    ".hs"
+    ".cabal"
+    ".c"
+    ".yaml"
+    ".yml"
+  ];
+
   grinSrc = mkRootSubsetSrc ["components/aihc-grin/" "test/support/"] [
     ".hs"
     ".cabal"
@@ -155,7 +163,7 @@ in rec {
         type == "directory" || ((inToolingCommon || inResolveCommon) && matchesSourceSuffix);
     };
 
-  aihcSrc = mkComponentSrc "/bin/aihc" [
+  aihcSrc = mkRootSubsetSrc ["bin/aihc/" "core-libs/" "examples/hello-world/"] [
     ".hs"
     ".cabal"
   ];

--- a/test/Test/Fixtures/eval/native-hello-world.yaml
+++ b/test/Test/Fixtures/eval/native-hello-world.yaml
@@ -1,0 +1,58 @@
+extensions:
+  - ExtendedLiterals
+  - ForeignFunctionInterface
+  - GHCForeignImportPrim
+  - MagicHash
+  - UnboxedTuples
+modules:
+  - |
+    {-# LANGUAGE NoImplicitPrelude #-}
+
+    module Test where
+
+    data State# s
+    data RealWorld
+    data Int32 = I32# Int32#
+    newtype CInt = CInt Int32
+    newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
+
+    foreign import prim realWorld# :: State# RealWorld
+    foreign import ccall unsafe putchar :: CInt -> IO CInt
+
+    bind :: IO a -> (a -> IO b) -> IO b
+    bind (IO action) next =
+      IO (\state ->
+        case action state of
+          (# nextState, value #) ->
+            case next value of
+              IO nextAction -> nextAction nextState)
+
+    thenIO :: IO a -> IO b -> IO b
+    thenIO first second = bind first (\ignored -> second)
+
+    char :: Int32# -> CInt
+    char value = CInt (I32# value)
+
+    hello :: IO CInt
+    hello =
+      thenIO (putchar (char 72#Int32))
+        (thenIO (putchar (char 101#Int32))
+          (thenIO (putchar (char 108#Int32))
+            (thenIO (putchar (char 108#Int32))
+              (thenIO (putchar (char 111#Int32))
+                (thenIO (putchar (char 44#Int32))
+                  (thenIO (putchar (char 32#Int32))
+                    (thenIO (putchar (char 119#Int32))
+                      (thenIO (putchar (char 111#Int32))
+                        (thenIO (putchar (char 114#Int32))
+                          (thenIO (putchar (char 108#Int32))
+                            (thenIO (putchar (char 100#Int32))
+                              (thenIO (putchar (char 33#Int32))
+                                (putchar (char 10#Int32))))))))))))))
+stdout: |
+  Hello, world!
+output: |
+  CInt (I32# 10)
+expression: hello
+status: pass
+reason: compiles and executes a standalone HelloWorld IO program without depending on aihc-base


### PR DESCRIPTION
## Summary

- add an `aihc-arm64` component that lowers runtime-explicit GRIN to Darwin AArch64 assembly
- represent Haskell control flow as heap continuations and transfer between generated entries only with `b`/`br`
- add a linear-scan register allocator whose pressure and C-call spills live in heap frames rather than on the native stack
- add a C runtime for closure/thunk `eval` and `apply`, IO execution, constructor storage, and C ABI foreign calls
- compile, assemble, link, and execute a standalone HelloWorld fixture through parser, resolver, type checker, System FC, GRIN, and native ARM64
- add `aihc compile SOURCE [-o FILE] [--keep-asm]` to run that pipeline and invoke Clang, retaining `OUTPUT.s` on request
- add `examples/hello-world/Main.hs`, using implicit `Prelude`, `IO`, and `(>>)` from `aihc-base`, and compile that checked-in example directly in the CLI integration tests
- remove unused continuation and foreign-descriptor fields after auditing the runtime/codegen ABI
- represent continuation payloads as a tagged union with type-specific normal, update, apply, foreign-call, and dictionary-selection variants
- discover imported modules only in `./core-libs`, build `aihc-base` and `aihc-prim` implicitly unless `NoImplicitPrelude` is enabled, and restore compiled dependency interfaces/System FC from a content-addressed cache
- key dependency artifacts by every file in the participating library graph, freshen cached FC identities at link time, and remove unreachable dependency bindings before ARM64 lowering
- preserve imported polymorphic term schemes and type-constructor arities in cached type-checker interfaces
- register `aihc-arm64` in the Nix package set and run its eval suite from the flake's aggregate test check
- store compiled dependency artifacts in the shared XDG cache instead of creating a package cache in the working directory

## Milestone scope

This first native slice targets Darwin ARM64 and the GRIN operations needed by the standalone HelloWorld program. Recursive allocation, explicit fetch/update, exceptions, and garbage collection remain unsupported and fail during code generation rather than being silently miscompiled.

## Progress counts

- shared GRIN eval fixtures: 73 -> 74
- `aihc-arm64` tests: 0 -> 5
- `aihc-tc` tests: 85 -> 86
- `aihc` tests: 53 -> 62

## Validation

- `just fmt`
- `just check`
- native HelloWorld output: `Hello, world!\n`
- actual `aihc compile` invocation produced and ran a Mach-O ARM64 executable
- `aihc compile examples/hello-world/Main.hs` prints `Hello, world!\n`
- bundled C runtime compiled with Clang `-Wall -Wextra -Werror`
- implicit-Prelude HelloWorld compilation against the repository's real `aihc-base` and `aihc-prim`
- cache reuse and whole-library graph invalidation tests
- XDG cache-location regression coverage with isolated temporary caches for native integration tests
- `nix build .#checks.aarch64-darwin.arm64-tests --no-link`
- `nix build .#checks.aarch64-darwin.aihc-tests --no-link`
