### PR TITLE
feat(cli): keep core and GRIN compile output

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -34,18 +34,21 @@ import Aihc.Fc
     desugarModule,
     desugarModuleWithBindings,
   )
-import Aihc.Grin (lowerProgram)
+import Aihc.Fc qualified as Fc
+import Aihc.Grin qualified as Grin
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
 import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithFullEnv)
 import Control.Exception (bracket)
+import Control.Monad (when)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import System.Directory (XdgDirectory (XdgCache), createDirectory, getCurrentDirectory, getTemporaryDirectory, getXdgDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
@@ -61,6 +64,12 @@ data CompileError
   | CompileClangError !ExitCode !String
   deriving (Eq, Show)
 
+data CompileArtifacts = CompileArtifacts
+  { compiledCore :: !Text,
+    compiledGrin :: !Text,
+    compiledAssembly :: !Text
+  }
+
 runCompile :: CompileOptions -> IO ()
 runCompile options = do
   environment <- defaultCompileEnvironment
@@ -69,18 +78,26 @@ runCompile options = do
 runCompileWithEnvironment :: CompileEnvironment -> CompileOptions -> IO ()
 runCompileWithEnvironment environment options = do
   source <- TIO.readFile (compileSourceFile options)
-  assemblyResult <- compileSourceToAssemblyWithDependencies environment (compileSourceFile options) source
-  assembly <- either (ioError . userError . renderCompileError) pure assemblyResult
+  artifactsResult <- compileSourceToArtifactsWithDependencies environment (compileSourceFile options) source
+  artifacts <- either (ioError . userError . renderCompileError) pure artifactsResult
   let output = compileOutputPath options
+  writeIntermediateArtifacts output options artifacts
   if compileKeepAsm options
     then do
       let assemblyPath = output <> ".s"
-      TIO.writeFile assemblyPath assembly
+      TIO.writeFile assemblyPath (compiledAssembly artifacts)
       assemble output assemblyPath
     else withTemporaryDirectory "aihc-compile" $ \directory -> do
       let assemblyPath = directory </> "program.s"
-      TIO.writeFile assemblyPath assembly
+      TIO.writeFile assemblyPath (compiledAssembly artifacts)
       assemble output assemblyPath
+
+writeIntermediateArtifacts :: FilePath -> CompileOptions -> CompileArtifacts -> IO ()
+writeIntermediateArtifacts output options artifacts = do
+  when (compileKeepCore options) $
+    TIO.writeFile (output <> ".core") (compiledCore artifacts)
+  when (compileKeepGrin options) $
+    TIO.writeFile (output <> ".grin") (compiledGrin artifacts)
 
 -- | The project-local core libraries and shared compiled-library cache used by
 -- the command-line compiler.
@@ -105,11 +122,15 @@ compileSourceToAssembly sourceName source = do
   parsed <- parseCompileModule sourceName source
   let desugared = desugarModule parsed
   if dsSuccess desugared
-    then either (Left . CompileArm64Error) Right (compileProgram "main" (lowerProgram (dsProgram desugared)))
+    then compiledAssembly <$> compileProgramArtifacts (dsProgram desugared)
     else Left (CompileFrontendError (dsErrors desugared))
 
 compileSourceToAssemblyWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToAssemblyWithDependencies environment sourceName source =
+  fmap (fmap compiledAssembly) (compileSourceToArtifactsWithDependencies environment sourceName source)
+
+compileSourceToArtifactsWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
+compileSourceToArtifactsWithDependencies environment sourceName source =
   case parseCompileModule sourceName source of
     Left err -> pure (Left err)
     Right parsed -> do
@@ -118,7 +139,7 @@ compileSourceToAssemblyWithDependencies environment sourceName source =
         artifact <- either (Left . CompileDependencyError) Right dependencies
         compileWithDependencies artifact parsed
 
-compileWithDependencies :: DependencyArtifact -> Module -> Either CompileError Text
+compileWithDependencies :: DependencyArtifact -> Module -> Either CompileError CompileArtifacts
 compileWithDependencies dependencies parsed =
   case resolveWithDeps (dependencyExports dependencies) [parsed] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
@@ -140,7 +161,20 @@ compileWithDependencies dependencies parsed =
                       let mainProgram = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                           freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainProgram) (dependencyProgram dependencies)
                           program = retainReachableTopBinds "main" (appendPrograms freshDependencies mainProgram)
-                       in either (Left . CompileArm64Error) Right (compileProgram "main" (lowerProgram program))
+                       in compileProgramArtifacts program
+
+compileProgramArtifacts :: FcProgram -> Either CompileError CompileArtifacts
+compileProgramArtifacts core = do
+  let grin = Grin.lowerProgram core
+  assembly <- either (Left . CompileArm64Error) Right (compileProgram "main" grin)
+  pure
+    CompileArtifacts
+      { compiledCore = withFinalNewline (Fc.renderProgram core),
+        compiledGrin = withFinalNewline (Grin.renderProgram grin),
+        compiledAssembly = assembly
+      }
+  where
+    withFinalNewline rendered = T.pack rendered <> "\n"
 
 appendPrograms :: FcProgram -> FcProgram -> FcProgram
 appendPrograms (FcProgram left) (FcProgram right) = FcProgram (left <> right)

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -21,6 +21,8 @@ data Command
 data CompileOptions = CompileOptions
   { compileSourceFile :: !FilePath,
     compileOutputFile :: !(Maybe FilePath),
+    compileKeepCore :: !Bool,
+    compileKeepGrin :: !Bool,
     compileKeepAsm :: !Bool
   }
   deriving (Eq, Show)
@@ -103,6 +105,14 @@ compileOptionsParser =
               <> OA.metavar "FILE"
               <> OA.help "Write the executable to FILE (default: SOURCE without its extension)"
           )
+      )
+    <*> OA.switch
+      ( OA.long "keep-core"
+          <> OA.help "Keep the generated System FC core as OUTPUT.core"
+      )
+    <*> OA.switch
+      ( OA.long "keep-grin"
+          <> OA.help "Keep the generated GRIN as OUTPUT.grin"
       )
     <*> OA.switch
       ( OA.long "keep-asm"

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -76,16 +76,26 @@ main =
         [ testCase "parses compile source" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False)))
               (parseCommandPure ["compile", "Main.hs"]),
           testCase "parses compile output and keep-asm" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") True)))
+              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False True)))
               (parseCommandPure ["compile", "Main.hs", "-o", "hello", "--keep-asm"]),
+          testCase "parses keep-core" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False)))
+              (parseCommandPure ["compile", "Main.hs", "--keep-core"]),
+          testCase "parses keep-grin" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False)))
+              (parseCommandPure ["compile", "Main.hs", "--keep-grin"]),
           testCase "derives safe default compile output paths" $ do
-            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False))
-            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False)),
+            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False))
+            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False)),
           testCase "parses install package" $
             assertEqual
               "command"
@@ -132,7 +142,7 @@ main =
                 Right assembly -> do
                   assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
                   assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
-          testCase "assembles an executable and honors keep-asm" test_compileExecutable,
+          testCase "assembles an executable and honors keep-output flags" test_compileExecutable,
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
           testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
@@ -846,16 +856,24 @@ test_compileExecutable =
           keptOutput = root </> "kept"
           temporaryOutput = root </> "temporary"
           environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-          keptOptions = CompileOptions sourcePath (Just keptOutput) True
-          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False
+          keptOptions = CompileOptions sourcePath (Just keptOutput) True True True
+          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False False False
       withCurrentDirectory repositoryRoot $ do
         runCompileWithEnvironment environment keptOptions
         assertFileExists keptOutput
+        assertFileExists (keptOutput <> ".core")
+        assertFileExists (keptOutput <> ".grin")
         assertFileExists (keptOutput <> ".s")
+        core <- TIO.readFile (keptOutput <> ".core")
+        grin <- TIO.readFile (keptOutput <> ".grin")
+        assertBool "core contains main" ("main" `T.isInfixOf` core)
+        assertBool "GRIN contains main" ("main" `T.isInfixOf` grin)
         assertNativeOutput keptOutput
 
         runCompileWithEnvironment environment temporaryOptions
         assertFileExists temporaryOutput
+        assertFileDoesNotExist (temporaryOutput <> ".core")
+        assertFileDoesNotExist (temporaryOutput <> ".grin")
         assertFileDoesNotExist (temporaryOutput <> ".s")
         assertNativeOutput temporaryOutput
 


### PR DESCRIPTION
## Summary

- add `--keep-core` and `--keep-grin` flags to `aihc compile`
- write the final linked and reachability-pruned System FC and GRIN programs to `OUTPUT.core` and `OUTPUT.grin`
- preserve the existing temporary-output behavior when the new flags are omitted
- cover each keep-output flag independently and verify the native compile path writes the requested artifacts

## Impact

Compiler users can inspect the exact System FC and GRIN programs passed to downstream native code generation without changing the executable output path or retaining every intermediate by default.

## Progress counts

- `aihc:spec`: 62 -> 64 tests (+2 CLI flag regression tests)
- fixture status counts unchanged; README progress files were not modified

## Validation

- `cabal test -v0 aihc:spec --test-options="--pattern compile --hide-successes"`
- `just fmt`
- `just check`
