### PR TITLE
feat(fc): eliminate unreachable core declarations

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -6,6 +6,7 @@ module Aihc.Cli.Compile
   ( CompileEnvironment (..),
     CompileError (..),
     compileOutputPath,
+    compileSourceToCoreWithDependencies,
     compileSourceToAssembly,
     compileSourceToAssemblyWithDependencies,
     defaultCompileEnvironment,
@@ -33,6 +34,7 @@ import Aihc.Fc
     Var (..),
     desugarModule,
     desugarModuleWithBindings,
+    eliminateDeadCode,
   )
 import Aihc.Fc qualified as Fc
 import Aihc.Grin qualified as Grin
@@ -43,10 +45,7 @@ import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
 import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithFullEnv)
 import Control.Exception (bracket)
 import Control.Monad (when)
-import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
-import Data.Set (Set)
-import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -129,6 +128,12 @@ compileSourceToAssemblyWithDependencies :: CompileEnvironment -> FilePath -> Tex
 compileSourceToAssemblyWithDependencies environment sourceName source =
   fmap (fmap compiledAssembly) (compileSourceToArtifactsWithDependencies environment sourceName source)
 
+-- | Compile source and its dependencies to the optimized, combined System FC
+-- program rendered by @--keep-core@.
+compileSourceToCoreWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
+compileSourceToCoreWithDependencies environment sourceName source =
+  fmap (fmap compiledCore) (compileSourceToArtifactsWithDependencies environment sourceName source)
+
 compileSourceToArtifactsWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
 compileSourceToArtifactsWithDependencies environment sourceName source =
   case parseCompileModule sourceName source of
@@ -160,7 +165,7 @@ compileWithDependencies dependencies parsed =
                     else
                       let mainProgram = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                           freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainProgram) (dependencyProgram dependencies)
-                          program = retainReachableTopBinds "main" (appendPrograms freshDependencies mainProgram)
+                          program = eliminateDeadCode "main" (appendPrograms freshDependencies mainProgram)
                        in compileProgramArtifacts program
 
 compileProgramArtifacts :: FcProgram -> Either CompileError CompileArtifacts
@@ -263,69 +268,6 @@ exprVars expression =
     FcCast inner _ -> exprVars inner
   where
     altVars alternative = altBinders alternative <> exprVars (altRhs alternative)
-
--- Native linking starts from @main@. Keeping unreachable dependency bindings
--- would force the backend to implement primitives that the executable never
--- calls and would initialize dead closures at startup.
-retainReachableTopBinds :: Text -> FcProgram -> FcProgram
-retainReachableTopBinds entry (FcProgram topBinds) =
-  FcProgram [topBind | (index, topBind) <- indexedTopBinds, keepTopBind index topBind]
-  where
-    indexedTopBinds = zip [0 :: Int ..] topBinds
-    definitions = Map.fromList [(varName var, expressions) | topBind <- topBinds, (var, expressions) <- topBindDefinitions topBind]
-    selectedDefinitions = Map.fromList [(varName var, index) | (index, topBind) <- indexedTopBinds, var <- topBindVars topBind]
-    reachable = closeReachable (Set.singleton entry)
-
-    closeReachable names =
-      let referenced = Set.unions [foldMap referencedNames (Map.findWithDefault [] name definitions) | name <- Set.toList names]
-          names' = names <> Set.filter (`Map.member` definitions) referenced
-       in if names' == names then names else closeReachable names'
-
-    keepTopBind index topBind =
-      case topBind of
-        FcData {} -> True
-        FcNewtype {} -> True
-        _ -> any (isSelectedReachable index) (topBindVars topBind)
-
-    isSelectedReachable index var =
-      varName var `Set.member` reachable
-        && Map.lookup (varName var) selectedDefinitions == Just index
-
-topBindDefinitions :: FcTopBind -> [(Var, [FcExpr])]
-topBindDefinitions topBind =
-  case topBind of
-    FcPrimitive var _ -> [(var, [])]
-    FcForeignImport foreignCall -> [(fcForeignCallVar foreignCall, [])]
-    FcTopBind (FcNonRec var expression) -> [(var, [expression])]
-    FcTopBind (FcRec bindings) -> [(var, map snd bindings) | (var, _) <- bindings]
-    FcData {} -> []
-    FcNewtype {} -> []
-
-topBindVars :: FcTopBind -> [Var]
-topBindVars = map fst . topBindDefinitions
-
-referencedNames :: FcExpr -> Set Text
-referencedNames expression =
-  case expression of
-    FcVar var -> Set.singleton (varName var)
-    FcLit _ -> Set.empty
-    FcApp function argument -> referencedNames function <> referencedNames argument
-    FcDictApp function argument -> referencedNames function <> referencedNames argument
-    FcTyApp inner _ -> referencedNames inner
-    FcLam _ body -> referencedNames body
-    FcTyLam _ body -> referencedNames body
-    FcDictLam _ body -> referencedNames body
-    FcDict fields -> foldMap referencedNames fields
-    FcDictSelect dictionary _ -> referencedNames dictionary
-    FcLet bind body -> referencedBindNames bind <> referencedNames body
-    FcCase scrutinee _ alternatives -> referencedNames scrutinee <> foldMap (referencedNames . altRhs) alternatives
-    FcCast inner _ -> referencedNames inner
-
-referencedBindNames :: FcBind -> Set Text
-referencedBindNames bind =
-  case bind of
-    FcNonRec _ expression -> referencedNames expression
-    FcRec bindings -> foldMap (referencedNames . snd) bindings
 
 parseCompileModule :: FilePath -> Text -> Either CompileError Module
 parseCompileModule sourceName source =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -7,6 +7,7 @@ import Aihc.Cli.Compile
     CompileError,
     compileOutputPath,
     compileSourceToAssemblyWithDependencies,
+    compileSourceToCoreWithDependencies,
     defaultCompileEnvironment,
     runCompileWithEnvironment,
   )
@@ -946,8 +947,18 @@ test_compileExplicitCoreImport =
       coreRoot
       "demo"
       "Demo"
-      "{-# LANGUAGE NoImplicitPrelude #-}\nmodule Demo (identity) where\nidentity x = x\n"
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
+      ( unlines
+          [ "{-# LANGUAGE NoImplicitPrelude #-}",
+            "module Demo (identity) where",
+            "data UnreachableDependencyType = UnreachableDependencyConstructor",
+            "unreachableDependencyFunction = UnreachableDependencyConstructor",
+            "identity x = x"
+          ]
+      )
+    core <- expectCompileCore =<< compileSourceToCoreWithDependencies environment "Main.hs" importedSource
+    assertBool "reachable dependency function is retained" ("identity" `T.isInfixOf` core)
+    assertBool "unreachable dependency function is eliminated" (not ("unreachableDependencyFunction" `T.isInfixOf` core))
+    assertBool "unreachable dependency type is eliminated" (not ("UnreachableDependencyConstructor" `T.isInfixOf` core))
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
     compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
 
@@ -956,6 +967,12 @@ expectCompileSuccess result =
   case result of
     Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
     Right assembly -> assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
+
+expectCompileCore :: Either CompileError T.Text -> IO T.Text
+expectCompileCore result =
+  case result of
+    Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
+    Right core -> pure core
 
 implicitDependencySource :: T.Text
 implicitDependencySource =

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -12,6 +12,7 @@ synopsis: System FC core language with desugaring and lint
 library
   exposed-modules:
     Aihc.Fc
+    Aihc.Fc.DeadCode
     Aihc.Fc.Desugar
     Aihc.Fc.Desugar.Expr
     Aihc.Fc.Desugar.Match

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -25,6 +25,9 @@ module Aihc.Fc
     EvalError (..),
     Value (..),
 
+    -- * Optimization
+    eliminateDeadCode,
+
     -- * Lint
     lintProgram,
     lintExpr,
@@ -40,6 +43,7 @@ module Aihc.Fc
   )
 where
 
+import Aihc.Fc.DeadCode (eliminateDeadCode)
 import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -1,0 +1,209 @@
+-- | Whole-program dead-code elimination for System FC.
+module Aihc.Fc.DeadCode
+  ( eliminateDeadCode,
+  )
+where
+
+import Aihc.Fc.Syntax
+import Aihc.Tc.Evidence (Coercion (..))
+import Aihc.Tc.Types (Pred (..), TcType (..), tyConName)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+
+data References = References
+  { referencedValues :: !(Set Text),
+    referencedTypes :: !(Set Text)
+  }
+
+instance Semigroup References where
+  References leftValues leftTypes <> References rightValues rightTypes =
+    References (leftValues <> rightValues) (leftTypes <> rightTypes)
+
+instance Monoid References where
+  mempty = References Set.empty Set.empty
+
+-- | Retain only the value and type declarations transitively reachable from
+-- the named entry point. The input is expected to be the combined program so
+-- references can cross module and package boundaries.
+eliminateDeadCode :: Text -> FcProgram -> FcProgram
+eliminateDeadCode entry (FcProgram topBinds) =
+  FcProgram
+    [ topBind
+    | (index, topBind) <- indexedTopBinds,
+      keepTopBind valueDefinitions typeDefinitions reachableValues reachableTypes index topBind
+    ]
+  where
+    indexedTopBinds = zip [0 :: Int ..] topBinds
+    valueDefinitions =
+      Map.fromList
+        [ (varName var, (index, references))
+        | (index, topBind) <- indexedTopBinds,
+          (var, references) <- valueDefinitionsOf topBind
+        ]
+    typeDefinitions =
+      Map.fromList
+        [ (name, (index, references))
+        | (index, topBind) <- indexedTopBinds,
+          (name, references) <- typeDefinitionsOf topBind
+        ]
+    constructorOwners =
+      Map.fromList
+        [ (constructor, name)
+        | topBind <- topBinds,
+          (name, constructors) <- typeConstructorsOf topBind,
+          constructor <- constructors
+        ]
+    (reachableValues, reachableTypes) = closeReachable valueDefinitions typeDefinitions constructorOwners (Set.singleton entry) Set.empty
+
+closeReachable :: Map Text (Int, References) -> Map Text (Int, References) -> Map Text Text -> Set Text -> Set Text -> (Set Text, Set Text)
+closeReachable valueDefinitions typeDefinitions constructorOwners values types =
+  let references =
+        foldMap (definitionReferences valueDefinitions) values
+          <> foldMap (definitionReferences typeDefinitions) types
+      values' = values <> referencedValues references
+      types' =
+        types
+          <> referencedTypes references
+          <> Set.fromList [owner | value <- Set.toList values', Just owner <- [Map.lookup value constructorOwners]]
+   in if values' == values && types' == types
+        then (values, types)
+        else closeReachable valueDefinitions typeDefinitions constructorOwners values' types'
+
+definitionReferences :: Map Text (Int, References) -> Text -> References
+definitionReferences definitions name = maybe mempty snd (Map.lookup name definitions)
+
+keepTopBind :: Map Text (Int, References) -> Map Text (Int, References) -> Set Text -> Set Text -> Int -> FcTopBind -> Bool
+keepTopBind valueDefinitions typeDefinitions values types index topBind =
+  case topBind of
+    FcData name _ _ -> selectedType name
+    FcNewtype name _ _ _ -> selectedType name
+    _ -> any selectedValue [varName var | (var, _) <- valueDefinitionsOf topBind]
+  where
+    selectedValue name = name `Set.member` values && fmap fst (Map.lookup name valueDefinitions) == Just index
+    selectedType name = name `Set.member` types && fmap fst (Map.lookup name typeDefinitions) == Just index
+
+valueDefinitionsOf :: FcTopBind -> [(Var, References)]
+valueDefinitionsOf topBind =
+  case topBind of
+    FcPrimitive var _ -> [(var, referencesVarType var)]
+    FcForeignImport foreignCall -> [(fcForeignCallVar foreignCall, referencesVarType (fcForeignCallVar foreignCall))]
+    FcTopBind bind -> [(var, referencesTopLevelBind bind) | var <- bindersOf bind]
+    FcData {} -> []
+    FcNewtype {} -> []
+
+typeDefinitionsOf :: FcTopBind -> [(Text, References)]
+typeDefinitionsOf topBind =
+  case topBind of
+    FcData name _ constructors -> [(name, foldMap (foldMap referencesType . snd) constructors)]
+    FcNewtype name _ _ fieldType -> [(name, referencesType fieldType)]
+    _ -> []
+
+typeConstructorsOf :: FcTopBind -> [(Text, [Text])]
+typeConstructorsOf topBind =
+  case topBind of
+    FcData name _ constructors -> [(name, map fst constructors)]
+    FcNewtype name _ constructor _ -> [(name, [constructor])]
+    _ -> []
+
+bindersOf :: FcBind -> [Var]
+bindersOf bind =
+  case bind of
+    FcNonRec var _ -> [var]
+    FcRec bindings -> map fst bindings
+
+referencesTopLevelBind :: FcBind -> References
+referencesTopLevelBind bind =
+  case bind of
+    FcNonRec var expression -> referencesVarType var <> referencesExpr Set.empty expression
+    FcRec bindings ->
+      let binders = Set.fromList (map fst bindings)
+       in foldMap (\(var, expression) -> referencesVarType var <> referencesExpr binders expression) bindings
+
+referencesExpr :: Set Var -> FcExpr -> References
+referencesExpr bound expression =
+  case expression of
+    FcVar var
+      | var `Set.member` bound -> referencesVarType var
+      | otherwise -> mempty {referencedValues = Set.singleton (varName var)} <> referencesVarType var
+    FcLit literal -> foldMap referencesType (literalType literal)
+    FcApp function argument -> referencesExpr bound function <> referencesExpr bound argument
+    FcDictApp function argument -> referencesExpr bound function <> referencesExpr bound argument
+    FcTyApp inner ty -> referencesExpr bound inner <> referencesType ty
+    FcLam var body -> referencesVarType var <> referencesExpr (Set.insert var bound) body
+    FcTyLam _ body -> referencesExpr bound body
+    FcDictLam var body -> referencesVarType var <> referencesExpr (Set.insert var bound) body
+    FcDict fields -> foldMap (referencesExpr bound) fields
+    FcDictSelect dictionary _ -> referencesExpr bound dictionary
+    FcLet bind body -> referencesLet bound bind body
+    FcCase scrutinee binder alternatives ->
+      referencesExpr bound scrutinee
+        <> referencesVarType binder
+        <> foldMap (referencesAlt (Set.insert binder bound)) alternatives
+    FcCast inner coercion -> referencesExpr bound inner <> referencesCoercion coercion
+
+referencesLet :: Set Var -> FcBind -> FcExpr -> References
+referencesLet bound bind body =
+  case bind of
+    FcNonRec var rhs ->
+      referencesVarType var
+        <> referencesExpr bound rhs
+        <> referencesExpr (Set.insert var bound) body
+    FcRec bindings ->
+      let binders = Set.fromList (map fst bindings)
+          innerBound = bound <> binders
+       in foldMap (\(var, rhs) -> referencesVarType var <> referencesExpr innerBound rhs) bindings
+            <> referencesExpr innerBound body
+
+referencesAlt :: Set Var -> FcAlt -> References
+referencesAlt bound alternative =
+  referencesAltCon (altCon alternative)
+    <> foldMap referencesVarType (altBinders alternative)
+    <> referencesExpr (bound <> Set.fromList (altBinders alternative)) (altRhs alternative)
+
+referencesAltCon :: FcAltCon -> References
+referencesAltCon altCon =
+  case altCon of
+    DataAlt constructor -> mempty {referencedValues = Set.singleton constructor}
+    LitAlt literal -> foldMap referencesType (literalType literal)
+    DefaultAlt -> mempty
+
+referencesVarType :: Var -> References
+referencesVarType = referencesType . varType
+
+referencesType :: TcType -> References
+referencesType ty =
+  case ty of
+    TcTyVar {} -> mempty
+    TcMetaTv {} -> mempty
+    TcTyCon tyCon arguments ->
+      mempty {referencedTypes = Set.singleton (tyConName tyCon)}
+        <> foldMap referencesType arguments
+    TcFunTy argument result -> referencesType argument <> referencesType result
+    TcForAllTy _ body -> referencesType body
+    TcQualTy predicates body -> foldMap referencesPred predicates <> referencesType body
+    TcAppTy function argument -> referencesType function <> referencesType argument
+
+referencesPred :: Pred -> References
+referencesPred predicate =
+  case predicate of
+    ClassPred name arguments ->
+      mempty {referencedTypes = Set.singleton name}
+        <> foldMap referencesType arguments
+    EqPred left right -> referencesType left <> referencesType right
+
+referencesCoercion :: Coercion -> References
+referencesCoercion coercion =
+  case coercion of
+    CoVar {} -> mempty
+    Refl ty -> referencesType ty
+    Sym inner -> referencesCoercion inner
+    Trans left right -> referencesCoercion left <> referencesCoercion right
+    TyConAppCo tyCon coercions ->
+      mempty {referencedTypes = Set.singleton (tyConName tyCon)}
+        <> foldMap referencesCoercion coercions
+    AxiomInstCo name types ->
+      mempty {referencedTypes = Set.singleton name}
+        <> foldMap referencesType types

--- a/components/aihc-fc/test/Spec.hs
+++ b/components/aihc-fc/test/Spec.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Test.Fc.Suite (fcEvalFixtureTests, fcEvalTests, fcGoldenTests)
+import Test.Fc.Suite (fcEvalFixtureTests, fcEvalTests, fcGoldenTests, fcOptimizationTests)
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.QuickCheck qualified as QC
 
@@ -13,6 +13,7 @@ main = do
         "aihc-fc"
         [ golden,
           fcEvalTests,
+          fcOptimizationTests,
           evalFixtures,
           QC.testProperty "dummy quickcheck property" prop_dummy
         ]

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -5,6 +5,7 @@ module Test.Fc.Suite
   ( fcGoldenTests,
     fcEvalTests,
     fcEvalFixtureTests,
+    fcOptimizationTests,
   )
 where
 
@@ -65,6 +66,44 @@ fcEvalTests =
           result
     ]
 
+fcOptimizationTests :: TestTree
+fcOptimizationTests =
+  testGroup
+    "FC optimizations"
+    [ testCase "eliminates values and types unreachable from the entry point" $ do
+        let liveTy = ty "Live"
+            leafTy = ty "Leaf"
+            deadTy = ty "Dead"
+            mainVar = Var "main" (Unique 1) liveTy
+            helperVar = Var "helper" (Unique 2) liveTy
+            deadVar = Var "dead" (Unique 3) deadTy
+            liveData = FcData "Live" [] [("Live", [leafTy])]
+            leafData = FcData "Leaf" [] [("Leaf", [])]
+            deadData = FcData "Dead" [] [("Dead", [])]
+            helper = FcTopBind (FcNonRec helperVar (FcVar (Var "Live" (Unique 4) (TcFunTy leafTy liveTy))))
+            mainBinding = FcTopBind (FcNonRec mainVar (FcVar helperVar))
+            deadBinding = FcTopBind (FcNonRec deadVar (FcVar (Var "Dead" (Unique 5) deadTy)))
+            program = FcProgram [deadData, deadBinding, leafData, liveData, helper, mainBinding]
+        assertEqual
+          "reachable program"
+          (FcProgram [leafData, liveData, helper, mainBinding])
+          (eliminateDeadCode "main" program),
+      testCase "does not confuse a local binder with a top-level definition" $ do
+        let valueTy = ty "Value"
+            local = Var "shadowed" (Unique 10) valueTy
+            global = Var "shadowed" (Unique 11) valueTy
+            mainVar = Var "main" (Unique 12) (TcFunTy valueTy valueTy)
+            program =
+              FcProgram
+                [ FcTopBind (FcNonRec global (FcVar global)),
+                  FcTopBind (FcNonRec mainVar (FcLam local (FcVar local)))
+                ]
+        assertEqual
+          "reachable program"
+          (FcProgram [FcTopBind (FcNonRec mainVar (FcLam local (FcVar local)))])
+          (eliminateDeadCode "main" program)
+    ]
+
 fcEvalFixtureTests :: IO TestTree
 fcEvalFixtureTests = do
   cases <- EvalGolden.loadEvalCases
@@ -108,3 +147,6 @@ var name = Var name (Unique 0)
 
 stringTy :: TcType
 stringTy = TcTyCon (TyCon "[]" 1) [TcTyCon (TyCon "Char" 0) []]
+
+ty :: Text -> TcType
+ty name = TcTyCon (TyCon name 0) []


### PR DESCRIPTION
## Summary

- add a whole-program System FC dead-code pass that closes value and type reachability from an entry point
- run the pass from `aihc compile` after dependency and main Core programs are combined, rooted at `main`
- account for constructor ownership, type fields, signatures, predicates, coercions, and lexical scoping
- cover direct FC reachability, local shadowing, and dependency-aware compile output

## Progress counts

- Parser and extension progress counts are unchanged.

## Testing

- `just fmt`
- `just check`