### PR TITLE
test(parser): add GHC layout oracle cases

### DIFF
--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout001-case-where.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout001-case-where.hs
@@ -1,0 +1,7 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout001.hs.
+module M where
+
+f = case () of
+  () -> ()
+  where x = x

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout002-if-then-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout002-if-then-do.hs
@@ -1,0 +1,5 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout002.hs.
+module M where
+
+f = if True then do undefined else undefined

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout003-list-comprehension-closes-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout003-list-comprehension-closes-do.hs
@@ -1,0 +1,12 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout003.hs.
+module M where
+
+-- The array package used to have things in this sort of pattern, where
+-- the "parse error" rule is needed to close the do block's layout
+
+f :: [IO ()]
+f = [do
+   undefined
+   undefined
+   | _ <- undefined]

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout004-pattern-guard-let.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout004-pattern-guard-let.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout004.hs.
+{-# LANGUAGE PatternGuards #-}
+
+module M where
+
+f | Just x <- undefined,
+    let y = x,
+    undefined x y
+  = ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout005-else-closes-do.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout005-else-closes-do.hs
@@ -1,0 +1,10 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout005.hs.
+module M where
+
+-- GHC's Lexer.x had a piece of code like this
+
+f = if True then do
+        case () of
+            () -> ()
+            else ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout006-guarded-do-let.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout006-guarded-do-let.hs
@@ -1,0 +1,13 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout006.hs.
+module M where
+
+-- GHC's GHC.Parser.PostProcess had a piece of code like this
+
+f :: IO ()
+f
+ | True = do
+ let x = ()
+     y = ()
+ return ()
+ | True = return ()

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout007-splice-closing-paren.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout007-splice-closing-paren.hs
@@ -1,0 +1,11 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout007.hs.
+{-# LANGUAGE TemplateHaskell #-}
+
+module M where
+
+-- The paren here closes the open-splice - it doesn't match an
+-- opening paren
+
+f :: IO ()
+f = do print $( [| 'a' |] )

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout008-do-mdo-rec.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout008-do-mdo-rec.hs
@@ -1,0 +1,22 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout008.hs.
+{-# LANGUAGE RecursiveDo, DoRec #-}
+{-# OPTIONS_GHC -fno-warn-deprecated-flags #-}
+
+module M where
+
+-- do, mdo and rec should all open layouts
+
+f :: IO ()
+f = do print 'a'
+       print 'b'
+
+g :: IO ()
+g = mdo print 'a'
+        print 'b'
+
+h :: IO ()
+h = do print 'a'
+       rec print 'b'
+           print 'c'
+       print 'd'

--- a/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout009-explicit-let-braces.hs
+++ b/components/aihc-parser/test/Test/Fixtures/oracle/Layout/ghc-layout009-explicit-let-braces.hs
@@ -1,0 +1,6 @@
+{- ORACLE_TEST pass -}
+-- From GHC testsuite/tests/layout/layout009.hs.
+module M where
+
+f :: Char
+f = let {x = 'a'} in x


### PR DESCRIPTION
## Summary

- add all nine Haskell sources from GHC's `testsuite/tests/layout` as parser oracle fixtures
- preserve the upstream layout-sensitive source and record its origin in each fixture
- cover case/where attachment, the parse-error layout rule, guarded RHSs, Template Haskell splice delimiters, `do`/`mdo`/`rec`, and explicit braces

Each fixture requires AIHC to accept the source and reproduce GHC's parsed AST fingerprint after paren insertion and pretty-printing. All nine sources already matched GHC, so no parser implementation changes were required.

## Progress

- oracle fixtures: 1,190 -> 1,199
- passing oracle fixtures: 1,190 -> 1,199
- xfail oracle fixtures: 0 -> 0
- completion: 100% -> 100%

## Validation

- ran `aihc-dev snippet` against each of the nine upstream sources; GHC parse, AIHC parse, and GHC AST match all passed
- `cabal test -v0 aihc-parser:spec --test-options="--pattern oracle --hide-successes"` (all 1,213 test nodes passed)
- `just fmt`
- `just check`
