### PR TITLE
feat(fc): erase newtype runtime representations

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -169,7 +169,8 @@ compileWithDependencies dependencies parsed =
                        in compileProgramArtifacts program
 
 compileProgramArtifacts :: FcProgram -> Either CompileError CompileArtifacts
-compileProgramArtifacts core = do
+compileProgramArtifacts sourceCore = do
+  let core = Fc.lowerNewtypes sourceCore
   let grin = Grin.lowerProgram core
   assembly <- either (Left . CompileArm64Error) Right (compileProgram "main" grin)
   pure

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -869,6 +869,8 @@ test_compileExecutable =
         grin <- TIO.readFile (keptOutput <> ".grin")
         assertBool "core contains main" ("main" `T.isInfixOf` core)
         assertBool "GRIN contains main" ("main" `T.isInfixOf` grin)
+        assertBool "GRIN erases the IO constructor" (not ("constructor IO/" `T.isInfixOf` grin))
+        assertBool "GRIN erases the CInt constructor" (not ("constructor CInt/" `T.isInfixOf` grin))
         assertNativeOutput keptOutput
 
         runCompileWithEnvironment environment temporaryOptions

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -28,8 +28,7 @@ enum {
   AIHC_CONT_TOP = 3,
   AIHC_CONT_FINAL = 4,
   AIHC_CONT_FOREIGN_CINT = 5,
-  AIHC_CONT_FOREIGN_INT32 = 6,
-  AIHC_CONT_SELECT = 7,
+  AIHC_CONT_SELECT = 6,
 };
 
 enum {
@@ -45,8 +44,6 @@ typedef uintptr_t AihcSlot;
 typedef struct {
   void *function;
   uint64_t is_io;
-  uint64_t io_constructor;
-  uint64_t cint_constructor;
   uint64_t int32_constructor;
   uint64_t tuple_constructor;
 } AihcForeign;
@@ -92,7 +89,6 @@ typedef struct {
   AihcSlot *globals;
   AihcSlot *locals;
   void *exit_code;
-  uint64_t io_constructor;
   uint64_t tuple_constructor;
 } AihcMachine;
 
@@ -176,11 +172,10 @@ void aihc_set_cell(AihcValue *cell, AihcValue *value) {
   cell->fields[0] = (AihcSlot)value;
 }
 
-AihcMachine *aihc_machine_new(uint64_t global_count, uint64_t io_constructor,
+AihcMachine *aihc_machine_new(uint64_t global_count,
                               uint64_t tuple_constructor) {
   AihcMachine *machine = aihc_allocate(sizeof(*machine));
   machine->globals = aihc_allocate(sizeof(*machine->globals) * global_count);
-  machine->io_constructor = io_constructor;
   machine->tuple_constructor = tuple_constructor;
   return machine;
 }
@@ -249,9 +244,7 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
       for (uint64_t index = 0; index < applied->count; ++index) {
         action->fields[index] = applied->fields[index];
       }
-      AihcValue *io = aihc_constructor(descriptor->io_constructor, 1, 1);
-      io->fields[0] = (AihcSlot)action;
-      aihc_return_value(machine, (AihcSlot)io);
+      aihc_return_value(machine, (AihcSlot)action);
       return;
     }
     aihc_return_value(machine, (AihcSlot)applied);
@@ -316,12 +309,8 @@ static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
 }
 
 static void aihc_run_io(AihcMachine *machine, AihcValue *value) {
-  if (value->kind != AIHC_CONSTRUCTOR || value->info != machine->io_constructor ||
-      value->count != 1) {
-    aihc_fail("program result is not an IO value");
-  }
   aihc_push_special(machine, AIHC_CONT_FINAL);
-  aihc_apply_value(machine, (AihcValue *)value->fields[0], 0);
+  aihc_apply_value(machine, value, 0);
 }
 
 static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
@@ -361,19 +350,6 @@ static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
   }
   case AIHC_CONT_FOREIGN_CINT: {
     AihcForeign *descriptor = continuation->payload.foreign_call.descriptor;
-    AihcValue *cint = (AihcValue *)value;
-    if (cint->kind != AIHC_CONSTRUCTOR ||
-        cint->info != descriptor->cint_constructor || cint->count != 1) {
-      aihc_fail("foreign CInt argument has invalid outer constructor");
-    }
-    AihcContinuation *next =
-        aihc_push_special(machine, AIHC_CONT_FOREIGN_INT32);
-    next->payload.foreign_call = continuation->payload.foreign_call;
-    aihc_eval_value(machine, (AihcValue *)cint->fields[0], 1);
-    return;
-  }
-  case AIHC_CONT_FOREIGN_INT32: {
-    AihcForeign *descriptor = continuation->payload.foreign_call.descriptor;
     AihcValue *int32 = (AihcValue *)value;
     if (int32->kind != AIHC_CONSTRUCTOR ||
         int32->info != descriptor->int32_constructor || int32->count != 1) {
@@ -384,11 +360,9 @@ static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
     AihcValue *result_int32 =
         aihc_constructor(descriptor->int32_constructor, 1, 1);
     result_int32->fields[0] = (AihcSlot)(intptr_t)(int32_t)result;
-    AihcValue *cint = aihc_constructor(descriptor->cint_constructor, 1, 1);
-    cint->fields[0] = (AihcSlot)result_int32;
     AihcValue *tuple = aihc_constructor(descriptor->tuple_constructor, 2, 2);
     tuple->fields[0] = continuation->payload.foreign_call.state;
-    tuple->fields[1] = (AihcSlot)cint;
+    tuple->fields[1] = (AihcSlot)result_int32;
     aihc_return_value(machine, (AihcSlot)tuple);
     return;
   }

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -80,8 +80,7 @@ compileProgram entryName program = do
       "  stp x19, x20, [sp, #16]",
       "  stp x21, x22, [sp, #32]",
       immediate "x0" (length globalNames),
-      immediate "x1" ioConstructor,
-      immediate "x2" tupleConstructor,
+      immediate "x1" tupleConstructor,
       "  bl _aihc_machine_new",
       "  mov x22, x0"
     ]
@@ -112,7 +111,6 @@ compileProgram entryName program = do
     functionArities = Map.fromList [(grinFunctionName function, length (grinFunctionParameters function)) | function <- grinFunctions program]
     foreignLabels = Map.fromList [(grinForeignCallName foreignCall, foreignLabel index) | (index, foreignCall) <- zip [0 ..] (grinForeignCalls program)]
     compileEnv = CompileEnv constructorIds constructorArities globalSlots functionLabels functionArities foreignLabels
-    ioConstructor = Map.findWithDefault 0 "IO" constructorIds
     tupleConstructor = Map.findWithDefault 0 "(#,#)" constructorIds
 
 compileInitializers :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
@@ -570,13 +568,11 @@ foreignDescriptors env program =
   where
     renderForeign foreignCall = do
       label <- foreignDescriptorLabel env foreignCall
-      (ioId, cintId, int32Id, tupleId) <- foreignConstructorIds env
+      (int32Id, tupleId) <- foreignConstructorIds env
       pure
         [ label <> ":",
           "  .quad _" <> grinForeignCallSymbol foreignCall,
           "  .quad " <> if isIo then "1" else "0",
-          "  .quad " <> tshow ioId,
-          "  .quad " <> tshow cintId,
           "  .quad " <> tshow int32Id,
           "  .quad " <> tshow tupleId
         ]
@@ -587,12 +583,10 @@ foreignDescriptors env program =
             GrinForeignIO _ -> True
             GrinForeignPure _ -> False
 
-foreignConstructorIds :: CompileEnv -> Either Arm64Error (Int, Int, Int, Int)
+foreignConstructorIds :: CompileEnv -> Either Arm64Error (Int, Int)
 foreignConstructorIds env =
-  (,,,)
-    <$> constructorId env "IO"
-    <*> constructorId env "CInt"
-    <*> constructorId env "I32#"
+  (,)
+    <$> constructorId env "I32#"
     <*> constructorId env "(#,#)"
 
 globalSlot :: CompileEnv -> Text -> Either Arm64Error Int

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -74,6 +74,7 @@ tests =
                 { grinConstructors = [("Box", [runtimeRep])],
                   grinPrimitives = [],
                   grinForeignCalls = [],
+                  grinIoCafs = mempty,
                   grinCafs = [],
                   grinFunctions = []
                 }
@@ -89,6 +90,7 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
+                  grinIoCafs = mempty,
                   grinCafs = [(answer, GrinNode (GrinThunk functionName) [])],
                   grinFunctions =
                     [ GrinFunction

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -18,6 +18,7 @@ library
     Aihc.Fc.Desugar.Match
     Aihc.Fc.Eval
     Aihc.Fc.Lint
+    Aihc.Fc.Newtype
     Aihc.Fc.Pretty
     Aihc.Fc.Subst
     Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -27,6 +27,7 @@ module Aihc.Fc
 
     -- * Optimization
     eliminateDeadCode,
+    lowerNewtypes,
 
     -- * Lint
     lintProgram,
@@ -47,5 +48,6 @@ import Aihc.Fc.DeadCode (eliminateDeadCode)
 import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)
+import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Pretty (renderExpr, renderProgram, renderTopBind, renderType)
 import Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -79,7 +79,7 @@ keepTopBind :: Map Text (Int, References) -> Map Text (Int, References) -> Set T
 keepTopBind valueDefinitions typeDefinitions values types index topBind =
   case topBind of
     FcData name _ _ -> selectedType name
-    FcNewtype name _ _ _ -> selectedType name
+    FcNewtype declaration -> selectedType (fcNewtypeName declaration)
     _ -> any selectedValue [varName var | (var, _) <- valueDefinitionsOf topBind]
   where
     selectedValue name = name `Set.member` values && fmap fst (Map.lookup name valueDefinitions) == Just index
@@ -98,14 +98,19 @@ typeDefinitionsOf :: FcTopBind -> [(Text, References)]
 typeDefinitionsOf topBind =
   case topBind of
     FcData name _ constructors -> [(name, foldMap (foldMap referencesType . snd) constructors)]
-    FcNewtype name _ _ fieldType -> [(name, referencesType fieldType)]
+    FcNewtype declaration ->
+      [ ( fcNewtypeName declaration,
+          referencesType (fcNewtypeRepresentation declaration)
+            <> referencesType (fcNewtypeResult declaration)
+        )
+      ]
     _ -> []
 
 typeConstructorsOf :: FcTopBind -> [(Text, [Text])]
 typeConstructorsOf topBind =
   case topBind of
     FcData name _ constructors -> [(name, map fst constructors)]
-    FcNewtype name _ constructor _ -> [(name, [constructor])]
+    FcNewtype declaration -> [(fcNewtypeName declaration, [fcNewtypeConstructor declaration])]
     _ -> []
 
 bindersOf :: FcBind -> [Var]

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -15,6 +15,7 @@ where
 
 import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsMatches, dsMatchesWithGivenDicts, freshUnique, freshVar, lookupType)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
+import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
@@ -100,7 +101,7 @@ desugarModuleWithBindings bindings tcResult _m =
                 }
             Right (binds, _) ->
               DesugarResult
-                { dsProgram = FcProgram binds,
+                { dsProgram = lowerNewtypes (FcProgram binds),
                   dsSuccess = True,
                   dsErrors = []
                 }
@@ -161,19 +162,34 @@ dsDataDeclM dd = do
   cons <- mapM dsDataConM (dataDeclConstructors dd)
   pure (FcData tyName [] cons)
 
--- | Preserve newtype declarations as distinct FC bindings so backends may
--- erase their representation while the evaluator can still model source-level
--- construction and pattern matching.
+-- | Retain the nominal declaration and its representation type as an FC axiom.
+-- 'lowerNewtypes' turns all term-level construction and matching into casts.
 dsNewtypeDeclM :: NewtypeDecl -> DsM FcTopBind
 dsNewtypeDeclM nd = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead nd))
   case newtypeDeclConstructor nd of
     Nothing -> desugarBug ("newtype " <> T.unpack tyName <> " has no constructor")
     Just con -> do
-      (conName, fields) <- dsDataConM con
-      case fields of
-        [fieldTy] -> pure (FcNewtype tyName [] conName fieldTy)
+      let (conName, arity) = dsDataConPure con
+      conTy <- lookupType conName
+      case (arity, dropForAlls conTy) of
+        (1, TcFunTy fieldTy resultTy@(TcTyCon resultTyCon resultArgs))
+          | tyConName resultTyCon == tyName,
+            Just tyVars <- traverse asTyVar resultArgs ->
+              pure
+                ( FcNewtype
+                    FcNewtypeDecl
+                      { fcNewtypeName = tyName,
+                        fcNewtypeTyVars = tyVars,
+                        fcNewtypeConstructor = conName,
+                        fcNewtypeRepresentation = fieldTy,
+                        fcNewtypeResult = resultTy
+                      }
+                )
         _ -> desugarBug ("newtype constructor " <> T.unpack conName <> " does not have exactly one field")
+  where
+    asTyVar (TcTyVar tyVar) = Just tyVar
+    asTyVar _ = Nothing
 
 dsForeignImport :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
 dsForeignImport tcAnn foreignDecl

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -95,8 +95,8 @@ dsDataConPure (PrefixCon _docs _ctx conName args) =
   (unqualifiedNameText conName, length args)
 dsDataConPure (InfixCon _docs _ctx _lhs conName _rhs) =
   (unqualifiedNameText conName, 2)
-dsDataConPure (RecordCon _docs _ctx conName _fields) =
-  (unqualifiedNameText conName, 0)
+dsDataConPure (RecordCon _docs _ctx conName fields) =
+  (unqualifiedNameText conName, length fields)
 dsDataConPure (GadtCon {}) = ("<gadt>", 0)
 dsDataConPure (TupleCon _docs _ctx flavor fields) =
   (tupleConText flavor (length fields), length fields)

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -11,8 +11,9 @@ module Aihc.Fc.Eval
   )
 where
 
+import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Syntax
-import Aihc.Tc.Types (RuntimeRep (..))
+import Aihc.Tc.Types (RuntimeRep (..), TcType (..), TyCon (..))
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (zipWithM, (<=<))
 import Control.Monad.Trans.Class (lift)
@@ -69,11 +70,23 @@ type Env = Map Text Value
 type EvalM = ExceptT EvalError IO
 
 evalProgramBinding :: Text -> FcProgram -> IO (Either EvalError Value)
-evalProgramBinding name program = runExceptT $
+evalProgramBinding name sourceProgram = runExceptT $
   case Map.lookup name env of
-    Just value -> forceValue value >>= runIOValue
+    Just value -> do
+      forced <- forceValue value
+      if name `Map.member` ioBindings
+        then runIOValue forced
+        else pure forced
     Nothing -> throwE (EvalMissingBinding name)
   where
+    program = lowerNewtypes sourceProgram
+    ioBindings =
+      Map.fromList
+        [ (varName var, ())
+        | FcTopBind bind <- fcTopBinds program,
+          var <- bindersOf bind,
+          isIOType (varType var)
+        ]
     env = foreignTopEnv `Map.union` primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
     foreignTopEnv = Map.fromList (concatMap foreignTopBindingValues (fcTopBinds program))
     primitiveTopEnv = Map.fromList (concatMap primitiveTopBindingValues (fcTopBinds program))
@@ -92,8 +105,8 @@ evalProgramBinding name program = runExceptT $
       [(varName var, VThunk env expr) | (var, expr) <- bindings]
     topBindingValues (FcData _ _ constructors) =
       [(conName, VConstructor conName []) | (conName, _) <- constructors]
-    topBindingValues (FcNewtype _ _ conName _) =
-      [(conName, VConstructor conName [])]
+    topBindingValues FcNewtype {} =
+      []
     topBindingValues FcPrimitive {} =
       []
     topBindingValues FcForeignImport {} =
@@ -166,14 +179,11 @@ forceValue value =
     _ -> pure value
 
 runIOValue :: Value -> EvalM Value
-runIOValue value =
-  case value of
-    VConstructor "IO" [action] -> do
-      result <- applyValue action VStateToken >>= forceValue
-      case result of
-        VConstructor "(#,#)" [_state, ioResult] -> forceValue ioResult
-        other -> throwE (EvalInvalidIOResult other)
-    _ -> pure value
+runIOValue action = do
+  result <- applyValue action VStateToken >>= forceValue
+  case result of
+    VConstructor "(#,#)" [_state, ioResult] -> forceValue ioResult
+    other -> throwE (EvalInvalidIOResult other)
 
 applyValue :: Value -> Value -> EvalM Value
 applyValue value arg = do
@@ -286,7 +296,7 @@ completeForeignCall :: FcForeignCall -> [Value] -> EvalM Value
 completeForeignCall foreignCall args =
   case fcForeignResult (fcForeignCallSignature foreignCall) of
     FcForeignPure _ -> callForeign foreignCall args
-    FcForeignIO _ -> pure (VConstructor "IO" [VForeignIOAction foreignCall args])
+    FcForeignIO _ -> pure (VForeignIOAction foreignCall args)
 
 callForeign :: FcForeignCall -> [Value] -> EvalM Value
 callForeign foreignCall args = do
@@ -329,22 +339,32 @@ forceCInt :: Text -> Value -> EvalM Integer
 forceCInt symbol value = do
   forced <- forceValue value
   case forced of
-    VConstructor "CInt" [int32] -> forceInt32 int32
+    VConstructor "I32#" [literal] -> forceInt32 literal
     other -> throwE (EvalForeignTypeError symbol other)
   where
-    forceInt32 int32 = do
-      forcedInt32 <- forceValue int32
-      case forcedInt32 of
-        VConstructor "I32#" [literal] -> do
-          forcedLiteral <- forceValue literal
-          case forcedLiteral of
-            VLit (LitInt _ intValue) -> pure intValue
-            other -> throwE (EvalForeignTypeError symbol other)
+    forceInt32 literal = do
+      forcedLiteral <- forceValue literal
+      case forcedLiteral of
+        VLit (LitInt _ intValue) -> pure intValue
         other -> throwE (EvalForeignTypeError symbol other)
 
 cIntValue :: Integer -> Value
 cIntValue value =
-  VConstructor "CInt" [VConstructor "I32#" [VLit (LitInt Int32Rep value)]]
+  VConstructor "I32#" [VLit (LitInt Int32Rep value)]
+
+bindersOf :: FcBind -> [Var]
+bindersOf bind =
+  case bind of
+    FcNonRec var _ -> [var]
+    FcRec bindings -> map fst bindings
+
+isIOType :: TcType -> Bool
+isIOType ty =
+  case ty of
+    TcTyCon (TyCon "IO" 1) [_] -> True
+    TcForAllTy _ body -> isIOType body
+    TcQualTy _ body -> isIOType body
+    _ -> False
 
 forceCharPrimitiveArg :: Text -> Value -> EvalM Char
 forceCharPrimitiveArg name value = do

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -57,7 +57,9 @@ data LintEnv = LintEnv
     -- | Type variables in scope.
     leTyVars :: !(Set TyVarId),
     -- | Known data constructors: name -> (type var params, field types, result type).
-    leDataCons :: !(Map Text ([TyVarId], [TcType], TcType))
+    leDataCons :: !(Map Text ([TyVarId], [TcType], TcType)),
+    -- | Representational equality axioms introduced by newtypes.
+    leNewtypes :: !(Map Text FcNewtypeDecl)
   }
   deriving (Show)
 
@@ -67,13 +69,20 @@ emptyLintEnv =
   LintEnv
     { leTerms = Map.empty,
       leTyVars = Set.empty,
-      leDataCons = Map.empty
+      leDataCons = Map.empty,
+      leNewtypes = Map.empty
     }
 
 -- | Lint an entire program.
 lintProgram :: LintEnv -> FcProgram -> [LintError]
-lintProgram env0 prog = go env0 (fcTopBinds prog)
+lintProgram env0 prog = go envWithNewtypes (fcTopBinds prog)
   where
+    envWithNewtypes = foldr registerNewtype env0 (fcTopBinds prog)
+
+    registerNewtype (FcNewtype declaration) env =
+      env {leNewtypes = Map.insert (fcNewtypeName declaration) declaration (leNewtypes env)}
+    registerNewtype _ env = env
+
     go _ [] = []
     go env (FcData {} : rest) =
       -- Data declarations don't need expression-level linting.
@@ -167,7 +176,7 @@ lintExpr env (FcCase scrut _binder alts) = do
       Right resTy
 lintExpr env (FcCast e co) = do
   eTy <- lintExpr env e
-  let (coFrom, coTo) = coercionEndpoints co
+  (coFrom, coTo) <- coercionEndpoints env co
   if typesEqual eTy coFrom
     then Right coTo
     else Left (TypeMismatch "cast source" coFrom eTy)
@@ -189,19 +198,34 @@ lintAltWithExpected env resTy alt = do
 --
 -- For the MVP, this is minimal. A full implementation would recursively
 -- compute the proved equality.
-coercionEndpoints :: Coercion -> (TcType, TcType)
-coercionEndpoints (Refl ty) = (ty, ty)
-coercionEndpoints (Sym co) = let (a, b) = coercionEndpoints co in (b, a)
-coercionEndpoints (Trans co1 co2) =
-  let (a, _) = coercionEndpoints co1
-      (_, c) = coercionEndpoints co2
-   in (a, c)
-coercionEndpoints (CoVar _) = (TcMetaTv (Unique (-1)), TcMetaTv (Unique (-1)))
-coercionEndpoints (TyConAppCo tc coercions) =
-  let pairs = map coercionEndpoints coercions
-   in (TcTyCon tc (map fst pairs), TcTyCon tc (map snd pairs))
-coercionEndpoints (AxiomInstCo _ _) =
-  (TcMetaTv (Unique (-1)), TcMetaTv (Unique (-1)))
+coercionEndpoints :: LintEnv -> Coercion -> Either LintError (TcType, TcType)
+coercionEndpoints _ (Refl ty) = Right (ty, ty)
+coercionEndpoints env (Sym co) = do
+  (from, to) <- coercionEndpoints env co
+  Right (to, from)
+coercionEndpoints env (Trans co1 co2) = do
+  (from, middleLeft) <- coercionEndpoints env co1
+  (middleRight, to) <- coercionEndpoints env co2
+  if typesEqual middleLeft middleRight
+    then Right (from, to)
+    else Left (TypeMismatch "coercion transitivity" middleLeft middleRight)
+coercionEndpoints _ (CoVar _) =
+  Right (TcMetaTv (Unique (-1)), TcMetaTv (Unique (-1)))
+coercionEndpoints env (TyConAppCo tc coercions) = do
+  pairs <- mapM (coercionEndpoints env) coercions
+  Right (TcTyCon tc (map fst pairs), TcTyCon tc (map snd pairs))
+coercionEndpoints env (AxiomInstCo name typeArgs) =
+  case Map.lookup name (leNewtypes env) of
+    Nothing -> Left (LintFailure ("unknown newtype axiom: " ++ show name))
+    Just declaration
+      | length typeArgs /= length (fcNewtypeTyVars declaration) ->
+          Left (LintFailure ("newtype axiom arity mismatch: " ++ show name))
+      | otherwise ->
+          let substitution = Map.fromList (zip (fcNewtypeTyVars declaration) typeArgs)
+           in Right
+                ( substType substitution (fcNewtypeResult declaration),
+                  substType substitution (fcNewtypeRepresentation declaration)
+                )
 
 -- | Extend the term environment with a variable.
 extendTermEnv :: Var -> LintEnv -> LintEnv

--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Representation-correct lowering of @newtype@ constructors and patterns.
+--
+-- Newtypes remain nominally distinct in FC types, with 'FcNewtypeDecl'
+-- providing their representational equality axiom. Their term constructors
+-- and patterns are casts and lazy bindings; they never denote heap nodes.
+module Aihc.Fc.Newtype
+  ( lowerNewtypes,
+  )
+where
+
+import Aihc.Fc.Subst (substType)
+import Aihc.Fc.Syntax
+import Aihc.Tc.Evidence (Coercion (..))
+import Aihc.Tc.Types (TcType (..), TyCon (..), Unique (..))
+import Control.Monad.Trans.State.Strict (State, evalState, state)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+newtype NewtypeEnv = NewtypeEnv
+  { newtypesByConstructor :: Map Text FcNewtypeDecl
+  }
+
+type LowerM = State Int
+
+-- | Replace every known newtype construction and match with a coercion cast.
+-- Running this more than once is harmless, which lets callers normalize both
+-- individual modules and a later combined cross-module program.
+lowerNewtypes :: FcProgram -> FcProgram
+lowerNewtypes program@(FcProgram topBinds) =
+  FcProgram (evalState (mapM (lowerTopBind env) topBinds) (nextUnique program))
+  where
+    env =
+      NewtypeEnv
+        { newtypesByConstructor =
+            Map.fromList
+              [ (fcNewtypeConstructor declaration, declaration)
+              | FcNewtype declaration <- topBinds
+              ]
+        }
+
+lowerTopBind :: NewtypeEnv -> FcTopBind -> LowerM FcTopBind
+lowerTopBind env topBind =
+  case topBind of
+    FcTopBind bind -> FcTopBind <$> lowerBind env bind
+    _ -> pure topBind
+
+lowerBind :: NewtypeEnv -> FcBind -> LowerM FcBind
+lowerBind env bind =
+  case bind of
+    FcNonRec var rhs -> FcNonRec var <$> lowerExpr env rhs
+    FcRec bindings -> FcRec <$> mapM (traverse (lowerExpr env)) bindings
+
+lowerExpr :: NewtypeEnv -> FcExpr -> LowerM FcExpr
+lowerExpr env expr =
+  case expr of
+    FcVar var ->
+      case Map.lookup (varName var) (newtypesByConstructor env) of
+        Just declaration -> lowerConstructorValue declaration []
+        Nothing -> pure expr
+    FcLit {} -> pure expr
+    FcApp function argument ->
+      case newtypeConstructorSpine env function of
+        Just (declaration, typeArgs) -> do
+          argument' <- lowerExpr env argument
+          pure (wrapNewtype declaration typeArgs argument')
+        Nothing -> FcApp <$> lowerExpr env function <*> lowerExpr env argument
+    FcDictApp function argument -> FcDictApp <$> lowerExpr env function <*> lowerExpr env argument
+    FcTyApp {} ->
+      case newtypeConstructorSpine env expr of
+        Just (declaration, typeArgs) -> lowerConstructorValue declaration typeArgs
+        Nothing -> lowerTypeApplication env expr
+    FcLam var body -> FcLam var <$> lowerExpr env body
+    FcTyLam tyVar body -> FcTyLam tyVar <$> lowerExpr env body
+    FcDictLam var body -> FcDictLam var <$> lowerExpr env body
+    FcDict fields -> FcDict <$> mapM (lowerExpr env) fields
+    FcDictSelect dictionary index -> (`FcDictSelect` index) <$> lowerExpr env dictionary
+    FcLet bind body -> FcLet <$> lowerBind env bind <*> lowerExpr env body
+    FcCase scrutinee binder alternatives -> lowerCase env scrutinee binder alternatives
+    FcCast inner coercion -> (`FcCast` coercion) <$> lowerExpr env inner
+
+lowerTypeApplication :: NewtypeEnv -> FcExpr -> LowerM FcExpr
+lowerTypeApplication env expression =
+  case expression of
+    FcTyApp function ty -> (`FcTyApp` ty) <$> lowerExpr env function
+    _ -> lowerExpr env expression
+
+lowerConstructorValue :: FcNewtypeDecl -> [TcType] -> LowerM FcExpr
+lowerConstructorValue declaration typeArgs = do
+  binder <- freshVar "$newtype" (instantiateRepresentation declaration typeArgs)
+  pure (FcLam binder (wrapNewtype declaration typeArgs (FcVar binder)))
+
+lowerCase :: NewtypeEnv -> FcExpr -> Var -> [FcAlt] -> LowerM FcExpr
+lowerCase env scrutinee binder alternatives =
+  case firstNewtypeAlternative env alternatives of
+    Just (declaration, fieldBinder, rhs) -> do
+      scrutinee' <- lowerExpr env scrutinee
+      rhs' <- lowerExpr env rhs
+      let typeArgs = newtypeArguments declaration (varType binder)
+          representation = unwrapNewtype declaration typeArgs (FcVar binder)
+      pure
+        ( FcLet
+            (FcNonRec binder scrutinee')
+            (FcLet (FcNonRec fieldBinder representation) rhs')
+        )
+    Nothing -> do
+      scrutinee' <- lowerExpr env scrutinee
+      alternatives' <- mapM (lowerAlt env) alternatives
+      pure (FcCase scrutinee' binder alternatives')
+
+lowerAlt :: NewtypeEnv -> FcAlt -> LowerM FcAlt
+lowerAlt env alternative = do
+  rhs <- lowerExpr env (altRhs alternative)
+  pure alternative {altRhs = rhs}
+
+firstNewtypeAlternative :: NewtypeEnv -> [FcAlt] -> Maybe (FcNewtypeDecl, Var, FcExpr)
+firstNewtypeAlternative env alternatives =
+  case [ (declaration, fieldBinder, altRhs alternative)
+       | alternative <- alternatives,
+         DataAlt constructor <- [altCon alternative],
+         Just declaration <- [Map.lookup constructor (newtypesByConstructor env)],
+         [fieldBinder] <- [altBinders alternative]
+       ] of
+    match : _ -> Just match
+    [] -> Nothing
+
+newtypeConstructorSpine :: NewtypeEnv -> FcExpr -> Maybe (FcNewtypeDecl, [TcType])
+newtypeConstructorSpine env = go []
+  where
+    go typeArgs expression =
+      case expression of
+        FcTyApp inner ty -> go (ty : typeArgs) inner
+        FcVar var -> (,typeArgs) <$> Map.lookup (varName var) (newtypesByConstructor env)
+        _ -> Nothing
+
+wrapNewtype :: FcNewtypeDecl -> [TcType] -> FcExpr -> FcExpr
+wrapNewtype declaration typeArgs expression =
+  FcCast expression (Sym (newtypeAxiom declaration typeArgs))
+
+unwrapNewtype :: FcNewtypeDecl -> [TcType] -> FcExpr -> FcExpr
+unwrapNewtype declaration typeArgs expression =
+  FcCast expression (newtypeAxiom declaration typeArgs)
+
+newtypeAxiom :: FcNewtypeDecl -> [TcType] -> Coercion
+newtypeAxiom declaration typeArgs =
+  AxiomInstCo (fcNewtypeName declaration) (completeTypeArgs declaration typeArgs)
+
+instantiateRepresentation :: FcNewtypeDecl -> [TcType] -> TcType
+instantiateRepresentation declaration typeArgs =
+  substType
+    (Map.fromList (zip (fcNewtypeTyVars declaration) (completeTypeArgs declaration typeArgs)))
+    (fcNewtypeRepresentation declaration)
+
+newtypeArguments :: FcNewtypeDecl -> TcType -> [TcType]
+newtypeArguments declaration ty =
+  case ty of
+    TcTyCon (TyCon name _) arguments
+      | name == fcNewtypeName declaration -> arguments
+    _ -> []
+
+completeTypeArgs :: FcNewtypeDecl -> [TcType] -> [TcType]
+completeTypeArgs declaration typeArgs
+  | length typeArgs <= length tyVars =
+      typeArgs <> map TcTyVar (drop (length typeArgs) tyVars)
+  | otherwise = typeArgs
+  where
+    tyVars = fcNewtypeTyVars declaration
+
+freshVar :: Text -> TcType -> LowerM Var
+freshVar name ty =
+  state $ \unique -> (Var name (Unique unique) ty, unique + 1)
+
+nextUnique :: FcProgram -> Int
+nextUnique (FcProgram topBinds) = maximum (0 : concatMap topBindUniques topBinds) + 1
+
+topBindUniques :: FcTopBind -> [Int]
+topBindUniques topBind =
+  case topBind of
+    FcPrimitive var _ -> varUniques var
+    FcForeignImport foreignCall -> varUniques (fcForeignCallVar foreignCall)
+    FcTopBind bind -> bindUniques bind
+    _ -> []
+
+bindUniques :: FcBind -> [Int]
+bindUniques bind =
+  case bind of
+    FcNonRec var rhs -> varUniques var <> exprUniques rhs
+    FcRec bindings -> concatMap (\(var, rhs) -> varUniques var <> exprUniques rhs) bindings
+
+exprUniques :: FcExpr -> [Int]
+exprUniques expression =
+  case expression of
+    FcVar var -> varUniques var
+    FcLit {} -> []
+    FcApp function argument -> exprUniques function <> exprUniques argument
+    FcDictApp function argument -> exprUniques function <> exprUniques argument
+    FcTyApp inner _ -> exprUniques inner
+    FcLam var body -> varUniques var <> exprUniques body
+    FcTyLam _ body -> exprUniques body
+    FcDictLam var body -> varUniques var <> exprUniques body
+    FcDict fields -> concatMap exprUniques fields
+    FcDictSelect dictionary _ -> exprUniques dictionary
+    FcLet bind body -> bindUniques bind <> exprUniques body
+    FcCase scrutinee binder alternatives ->
+      exprUniques scrutinee <> varUniques binder <> concatMap altUniques alternatives
+    FcCast inner _ -> exprUniques inner
+
+altUniques :: FcAlt -> [Int]
+altUniques alternative = concatMap varUniques (altBinders alternative) <> exprUniques (altRhs alternative)
+
+varUniques :: Var -> [Int]
+varUniques var =
+  case varUnique var of
+    Unique unique -> [unique]

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -45,14 +45,14 @@ renderTopBind (FcData tyName tyVars cons) =
     ++ T.unpack tyName
     ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
     ++ renderDataCons cons
-renderTopBind (FcNewtype tyName tyVars conName fieldTy) =
+renderTopBind (FcNewtype declaration) =
   "newtype "
-    ++ T.unpack tyName
-    ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
+    ++ T.unpack (fcNewtypeName declaration)
+    ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) (fcNewtypeTyVars declaration)
     ++ " = "
-    ++ T.unpack conName
+    ++ T.unpack (fcNewtypeConstructor declaration)
     ++ " "
-    ++ renderTypePrec True fieldTy
+    ++ renderTypePrec True (fcNewtypeRepresentation declaration)
 renderTopBind (FcPrimitive var arity) =
   "foreign prim "
     ++ renderVar var

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -22,6 +22,7 @@ module Aihc.Fc.Syntax
     -- * Bindings
     FcBind (..),
     FcTopBind (..),
+    FcNewtypeDecl (..),
     FcProgram (..),
     FcForeignCall (..),
     FcForeignSignature (..),
@@ -62,15 +63,27 @@ data FcTopBind
   = -- | Data type declaration: type name, type variable parameters,
     -- list of (constructor name, field types).
     FcData !Text ![TyVarId] ![(Text, [TcType])]
-  | -- | Newtype declaration: type name, type variable parameters, and its
-    -- single constructor.
-    FcNewtype !Text ![TyVarId] !Text !TcType
+  | -- | A nominal type with a representational equality axiom.
+    FcNewtype !FcNewtypeDecl
   | -- | A primitive imported by @foreign import prim@.
     FcPrimitive !Var !Int
   | -- | A C function imported by @foreign import ccall@.
     FcForeignImport !FcForeignCall
   | -- | Value binding.
     FcTopBind !FcBind
+  deriving (Eq, Show, Read)
+
+-- | The type-level information retained for a @newtype@ after its constructor
+-- and pattern matches have been lowered to representational casts.
+--
+-- This declaration is proof metadata, not a runtime constructor declaration.
+data FcNewtypeDecl = FcNewtypeDecl
+  { fcNewtypeName :: !Text,
+    fcNewtypeTyVars :: ![TyVarId],
+    fcNewtypeConstructor :: !Text,
+    fcNewtypeRepresentation :: !TcType,
+    fcNewtypeResult :: !TcType
+  }
   deriving (Eq, Show, Read)
 
 -- | A statically named C function resolved by the evaluator or a code generator.

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -101,7 +101,30 @@ fcOptimizationTests =
         assertEqual
           "reachable program"
           (FcProgram [FcTopBind (FcNonRec mainVar (FcLam local (FcVar local)))])
-          (eliminateDeadCode "main" program)
+          (eliminateDeadCode "main" program),
+      testCase "lowers newtype construction to a linted representational cast" $ do
+        let metersTy = ty "Meters"
+            intHashTy = ty "Int#"
+            declaration =
+              FcNewtypeDecl
+                { fcNewtypeName = "Meters",
+                  fcNewtypeTyVars = [],
+                  fcNewtypeConstructor = "Meters",
+                  fcNewtypeRepresentation = intHashTy,
+                  fcNewtypeResult = metersTy
+                }
+            constructor = Var "Meters" (Unique 20) (TcFunTy intHashTy metersTy)
+            value = Var "value" (Unique 21) metersTy
+            source =
+              FcProgram
+                [ FcNewtype declaration,
+                  FcTopBind (FcNonRec value (FcApp (FcVar constructor) (FcLit (LitInt IntRep 42))))
+                ]
+            lowered = lowerNewtypes source
+        assertEqual "idempotent lowering" lowered (lowerNewtypes lowered)
+        assertEqual "Core lint" [] (lintProgram emptyLintEnv lowered)
+        result <- evalProgramBinding "value" lowered >>= renderEvalResult
+        assertEqual "runtime representation" (Right "42") result
     ]
 
 fcEvalFixtureTests :: IO TestTree

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -21,6 +21,7 @@ import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Foreign.C.Types (CInt (..))
@@ -108,7 +109,12 @@ interpretProgramBinding name program = do
         case Map.lookup name globals of
           Just binding -> pure binding
           Nothing -> throwInterpret (InterpretMissingBinding name)
-      forceValue value >>= runIOValue >>= renderRawValueM
+      forced <- forceValue value
+      result <-
+        if name `Set.member` grinIoCafs program
+          then runIOValue forced
+          else pure forced
+      renderRawValueM result
 
 initialMachine :: GrinProgram -> Machine
 initialMachine program =
@@ -426,7 +432,7 @@ completeForeignCall foreignCall arguments =
   case grinForeignResult (grinForeignCallSignature foreignCall) of
     GrinForeignPure _ -> callForeign foreignCall arguments
     GrinForeignIO _ ->
-      pure (RuntimeNode (GrinConstructor "IO") [RuntimeNode (GrinForeignIOAction foreignCall) arguments])
+      pure (RuntimeNode (GrinForeignIOAction foreignCall) arguments)
 
 callForeign :: GrinForeignCall -> [RuntimeValue] -> EvalM RuntimeValue
 callForeign foreignCall arguments = do
@@ -471,34 +477,27 @@ forceCInt :: Text -> RuntimeValue -> EvalM Integer
 forceCInt symbol value = do
   forced <- forceValue value
   case forced of
-    RuntimeNode (GrinConstructor "CInt") [int32] -> forceInt32 int32
+    RuntimeNode (GrinConstructor "I32#") [literal] -> forceInt32 literal
     other -> throwInterpret (InterpretForeignTypeError symbol other)
   where
-    forceInt32 int32 = do
-      forcedInt32 <- forceValue int32
-      case forcedInt32 of
-        RuntimeNode (GrinConstructor "I32#") [literal] -> do
-          forcedLiteral <- forceValue literal
-          case forcedLiteral of
-            RuntimeLit (GrinLitInt _ intValue) -> pure intValue
-            other -> throwInterpret (InterpretForeignTypeError symbol other)
+    forceInt32 literal = do
+      forcedLiteral <- forceValue literal
+      case forcedLiteral of
+        RuntimeLit (GrinLitInt _ intValue) -> pure intValue
         other -> throwInterpret (InterpretForeignTypeError symbol other)
 
 cIntValue :: Integer -> RuntimeValue
 cIntValue value =
   RuntimeNode
-    (GrinConstructor "CInt")
-    [RuntimeNode (GrinConstructor "I32#") [RuntimeLit (GrinLitInt Int32Rep value)]]
+    (GrinConstructor "I32#")
+    [RuntimeLit (GrinLitInt Int32Rep value)]
 
 runIOValue :: RuntimeValue -> EvalM RuntimeValue
-runIOValue value =
-  case value of
-    RuntimeNode (GrinConstructor "IO") [action] -> do
-      result <- applyValue action RuntimeStateToken >>= forceValue
-      case result of
-        RuntimeNode (GrinConstructor "(#,#)") [_state, ioResult] -> forceValue ioResult
-        other -> throwInterpret (InterpretInvalidIOResult other)
-    _ -> pure value
+runIOValue action = do
+  result <- applyValue action RuntimeStateToken >>= forceValue
+  case result of
+    RuntimeNode (GrinConstructor "(#,#)") [_state, ioResult] -> forceValue ioResult
+    other -> throwInterpret (InterpretInvalidIOResult other)
 
 matchAlternative :: Env -> RuntimeValue -> [GrinAlt] -> EvalM RuntimeValue
 matchAlternative env value alternatives =

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -6,6 +6,7 @@ module Aihc.Grin.Lower
   )
 where
 
+import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Syntax
@@ -15,6 +16,8 @@ import Aihc.Tc.Types
     Unique (..),
     liftedRuntimeRep,
     runtimeRepOfType,
+    tyConArity,
+    tyConName,
   )
 import Control.Monad (filterM)
 import Control.Monad.Trans.State.Strict (State, gets, modify', runState)
@@ -59,15 +62,17 @@ instance Monoid LoweredTop where
 -- representations, closure-convert lambdas and thunks, and make evaluation,
 -- application, allocation, and exception control explicit.
 lowerProgram :: FcProgram -> GrinProgram
-lowerProgram program =
+lowerProgram sourceProgram =
   GrinProgram
     { grinConstructors = loweredConstructors tops,
       grinPrimitives = loweredPrimitives tops,
       grinForeignCalls = loweredForeignCalls tops,
+      grinIoCafs = programIoCafs program,
       grinCafs = loweredCafs tops,
       grinFunctions = reverse (lowerFunctionsRev finalState)
     }
   where
+    program = lowerNewtypes sourceProgram
     initialState =
       LowerState
         { lowerNextUnique = maximum (0 : map sourceUnique (programVars program)) + 1,
@@ -90,8 +95,8 @@ lowerTopBind topBind =
   case topBind of
     FcData _ _ constructors ->
       pure mempty {loweredConstructors = [(name, map typeRuntimeRep fields) | (name, fields) <- constructors]}
-    FcNewtype _ _ constructor field ->
-      pure mempty {loweredConstructors = [(constructor, [typeRuntimeRep field])]}
+    FcNewtype {} ->
+      pure mempty
     FcPrimitive var arity ->
       pure mempty {loweredPrimitives = [(lowerGlobalVar var, arity)]}
     FcForeignImport foreignCall ->
@@ -528,7 +533,7 @@ programGlobalNames program = concatMap topGlobalNames (fcTopBinds program)
     topGlobalNames topBind =
       case topBind of
         FcData _ _ constructors -> map fst constructors
-        FcNewtype _ _ constructor _ -> [constructor]
+        FcNewtype {} -> []
         FcPrimitive var _ -> [varName var]
         FcForeignImport foreignCall -> [varName (fcForeignCallVar foreignCall)]
         FcTopBind bind -> map (varName . fst) (topBindings bind)
@@ -543,10 +548,31 @@ programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds progra
     topWhnfGlobalNames topBind =
       case topBind of
         FcData _ _ constructors -> map fst constructors
-        FcNewtype _ _ constructor _ -> [constructor]
+        FcNewtype {} -> []
         FcPrimitive var _ -> [varName var]
         FcForeignImport foreignCall -> [varName (fcForeignCallVar foreignCall)]
         FcTopBind {} -> []
+
+programIoCafs :: FcProgram -> Set Text
+programIoCafs program =
+  Set.fromList
+    [ varName var
+    | FcTopBind bind <- fcTopBinds program,
+      var <- map fst (topBindings bind),
+      isIOType (varType var)
+    ]
+  where
+    topBindings bind =
+      case bind of
+        FcNonRec var rhs -> [(var, rhs)]
+        FcRec bindings -> bindings
+
+    isIOType ty =
+      case ty of
+        TcTyCon tyCon [_] | tyConName tyCon == "IO", tyConArity tyCon == 1 -> True
+        TcForAllTy _ body -> isIOType body
+        TcQualTy _ body -> isIOType body
+        _ -> False
 
 topVars :: FcTopBind -> [Var]
 topVars topBind =

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -29,6 +29,7 @@ module Aihc.Grin.Syntax
 where
 
 import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
+import Data.Set (Set)
 import Data.Text (Text)
 
 -- | A whole GRIN program.
@@ -36,6 +37,9 @@ data GrinProgram = GrinProgram
   { grinConstructors :: ![(Text, [RuntimeRep])],
     grinPrimitives :: ![(GrinVar, Int)],
     grinForeignCalls :: ![GrinForeignCall],
+    -- | CAF names whose source type is @IO a@ and must be entered with the
+    -- real-world state token by a top-level runner.
+    grinIoCafs :: !(Set Text),
     grinCafs :: ![(GrinVar, GrinNode)],
     grinFunctions :: ![GrinFunction]
   }

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -194,6 +194,7 @@ heapProgram =
     { grinConstructors = [("Box", [IntRep])],
       grinPrimitives = [],
       grinForeignCalls = [],
+      grinIoCafs = mempty,
       grinCafs =
         [ ( answer,
             GrinNode (GrinThunk functionName) []

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-abs.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-abs.yaml
@@ -13,7 +13,7 @@ modules:
 
     foreign import ccall unsafe "abs" c_abs :: CInt -> CInt
 output: |
-  CInt (I32# 42)
+  I32# 42
 expression: |
   c_abs (CInt (I32# (-42#Int32)))
 status: pass

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-putchar-do.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-putchar-do.yaml
@@ -19,7 +19,7 @@ modules:
       putchar second
 stdout: AB
 output: |
-  CInt (I32# 66)
+  I32# 66
 expression: |
   putTwo (CInt (I32# 65#Int32)) (CInt (I32# 66#Int32))
 status: pass

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-putchar.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-putchar.yaml
@@ -14,7 +14,7 @@ modules:
     foreign import ccall unsafe putchar :: CInt -> IO CInt
 stdout: A
 output: |
-  CInt (I32# 65)
+  I32# 65
 expression: |
   putchar (CInt (I32# 65#Int32))
 status: pass

--- a/test/Test/Fixtures/eval/native-hello-world.yaml
+++ b/test/Test/Fixtures/eval/native-hello-world.yaml
@@ -52,7 +52,7 @@ modules:
 stdout: |
   Hello, world!
 output: |
-  CInt (I32# 10)
+  I32# 10
 expression: hello
 status: pass
 reason: compiles and executes a standalone HelloWorld IO program without depending on aihc-base

--- a/test/Test/Fixtures/eval/newtype-higher-order-constructor.yaml
+++ b/test/Test/Fixtures/eval/newtype-higher-order-constructor.yaml
@@ -1,0 +1,19 @@
+extensions:
+  - MagicHash
+modules:
+  - |
+    {-# LANGUAGE NoImplicitPrelude #-}
+    module Test where
+
+    data Int = IS Int#
+    newtype Identity a = Identity a
+
+    apply f value = f value
+
+    result :: Identity Int
+    result = apply Identity (IS 42#)
+output: |
+  IS 42
+expression: result
+status: pass
+reason: treats a higher-order newtype constructor as a representational identity

--- a/test/Test/Fixtures/eval/newtype-pattern-is-lazy.yaml
+++ b/test/Test/Fixtures/eval/newtype-pattern-is-lazy.yaml
@@ -1,0 +1,25 @@
+dependencies:
+  - aihc-base
+  - aihc-prim
+extensions:
+  - MagicHash
+modules:
+  - |
+    {-# LANGUAGE NoImplicitPrelude #-}
+    module Test where
+
+    import GHC.Prim (raise#)
+
+    data Token = Token
+    newtype Action = Action Token
+
+    ignoreAction :: Action -> Token
+    ignoreAction (Action _) = Token
+
+    result :: Token
+    result = ignoreAction (raise# Token)
+output: |
+  Token
+expression: result
+status: pass
+reason: does not force a newtype scrutinee merely to match its nonexistent constructor tag

--- a/test/Test/Fixtures/eval/newtype-record-constructor.yaml
+++ b/test/Test/Fixtures/eval/newtype-record-constructor.yaml
@@ -1,0 +1,17 @@
+extensions:
+  - MagicHash
+modules:
+  - |
+    {-# LANGUAGE NoImplicitPrelude #-}
+    module Test where
+
+    data Int = IS Int#
+    newtype Wrapped = Wrapped { unwrap :: Int }
+
+    result :: Wrapped
+    result = Wrapped (IS 42#)
+output: |
+  IS 42
+expression: result
+status: pass
+reason: erases a record-style newtype constructor to its single field representation

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -1,0 +1,17 @@
+expected: |-
+  constructor IS/1 [IntRep]
+
+  caf value%1003 :: BoxedRep Lifted = (F$grin_thunk_0)
+
+  $grin_thunk_0 -> BoxedRep Lifted =
+    apply @BoxedRep Lifted IS%1002 :: BoxedRep Lifted 42
+extensions:
+  - MagicHash
+reason: erases newtype constructors and casts before producing runtime GRIN
+source: |
+  module Test where
+  data Int = IS Int#
+  newtype Identity a = Identity a
+  value :: Identity Int
+  value = Identity (IS 42#)
+status: pass


### PR DESCRIPTION
## Summary

- retain newtypes in System FC as nominal declarations with representational equality axioms, then lower constructor uses and patterns to casts and lazy bindings
- make the lowering idempotent so it handles both per-module declarations and imported newtypes after programs are combined
- remove newtype constructors from GRIN globals/layouts, carry only the IO-entry fact needed by evaluators, and run IO as its underlying state function
- remove the IO and CInt wrapper constructor IDs from the ARM64 FFI/runtime ABI so foreign values use their underlying representations
- support record-style newtype constructors and lint instantiated newtype coercion axioms

## Root cause

System FC modeled newtype constructors and patterns as ordinary data construction and case analysis. GRIN therefore faithfully allocated and inspected runtime nodes for nominal-only types such as IO and CInt. Besides the extra representation, an ordinary GRIN case forced a newtype scrutinee even though a newtype pattern has no runtime tag to inspect.

## Impact

Compiled GRIN no longer declares or applies IO, CInt, or other newtype runtime constructors. The hello-world program still compiles and runs natively, while its saved GRIN contains only the underlying I32# and state-function representations.

## Progress counts

- aihc-fc tests: 89 -> 93 (+4)
- aihc-grin tests: 81 -> 85 (+4)
- README progress counts are intentionally unchanged; the cron workflow owns them

## Validation

- `just fmt`
- `just check` after rebasing onto current `origin/main`
- explicit hello-world compile/run with saved Core, GRIN, and assembly; output: `Hello, world!`
