### PR TITLE
feat(cli): compile libraries incrementally

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -16,7 +16,7 @@ module Aihc.Cli.Compile
   )
 where
 
-import Aihc.Arm64 (Arm64Error, buildLinkLayout, compileProgram, compileProgramWithDependencies, extendLinkLayout, runtimeSourcePath, validateProgramPrimitives)
+import Aihc.Arm64 (Arm64Error, buildLinkLayout, compileProgram, compileProgramWithDependencies, extendLinkLayout, runtimeSourcePath, targetTriple, validateProgramPrimitives)
 import Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
@@ -340,7 +340,7 @@ assemble output assemblyPath archives = do
   (exitCode, _stdout, stderr) <-
     readProcessWithExitCode
       "clang"
-      (["-std=c11", "-Wall", "-Wextra", "-Werror", runtime, assemblyPath] <> archives <> ["-o", output])
+      (["--target=" <> targetTriple, "-std=c11", "-Wall", "-Wextra", "-Werror", runtime, assemblyPath] <> archives <> ["-o", output])
       ""
   case exitCode of
     ExitSuccess -> pure ()

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -16,10 +16,11 @@ module Aihc.Cli.Compile
   )
 where
 
-import Aihc.Arm64 (Arm64Error, compileProgram, runtimeSourcePath)
+import Aihc.Arm64 (Arm64Error, buildLinkLayout, compileProgram, compileProgramWithDependencies, extendLinkLayout, runtimeSourcePath, validateProgramPrimitives)
 import Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
+    DependencyUnit (..),
     buildDependencies,
   )
 import Aihc.Cli.Options (CompileOptions (..))
@@ -66,7 +67,8 @@ data CompileError
 data CompileArtifacts = CompileArtifacts
   { compiledCore :: !Text,
     compiledGrin :: !Text,
-    compiledAssembly :: !Text
+    compiledAssembly :: !Text,
+    compiledArchives :: ![FilePath]
   }
 
 runCompile :: CompileOptions -> IO ()
@@ -77,7 +79,7 @@ runCompile options = do
 runCompileWithEnvironment :: CompileEnvironment -> CompileOptions -> IO ()
 runCompileWithEnvironment environment options = do
   source <- TIO.readFile (compileSourceFile options)
-  artifactsResult <- compileSourceToArtifactsWithDependencies environment (compileSourceFile options) source
+  artifactsResult <- compileSourceToArtifactsWithDependencies (compileWholeProgram options) environment (compileSourceFile options) source
   artifacts <- either (ioError . userError . renderCompileError) pure artifactsResult
   let output = compileOutputPath options
   writeIntermediateArtifacts output options artifacts
@@ -85,11 +87,11 @@ runCompileWithEnvironment environment options = do
     then do
       let assemblyPath = output <> ".s"
       TIO.writeFile assemblyPath (compiledAssembly artifacts)
-      assemble output assemblyPath
+      assemble output assemblyPath (compiledArchives artifacts)
     else withTemporaryDirectory "aihc-compile" $ \directory -> do
       let assemblyPath = directory </> "program.s"
       TIO.writeFile assemblyPath (compiledAssembly artifacts)
-      assemble output assemblyPath
+      assemble output assemblyPath (compiledArchives artifacts)
 
 writeIntermediateArtifacts :: FilePath -> CompileOptions -> CompileArtifacts -> IO ()
 writeIntermediateArtifacts output options artifacts = do
@@ -126,26 +128,26 @@ compileSourceToAssembly sourceName source = do
 
 compileSourceToAssemblyWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToAssemblyWithDependencies environment sourceName source =
-  fmap (fmap compiledAssembly) (compileSourceToArtifactsWithDependencies environment sourceName source)
+  fmap (fmap compiledAssembly) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
 -- | Compile source and its dependencies to the optimized, combined System FC
 -- program rendered by @--keep-core@.
 compileSourceToCoreWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToCoreWithDependencies environment sourceName source =
-  fmap (fmap compiledCore) (compileSourceToArtifactsWithDependencies environment sourceName source)
+  fmap (fmap compiledCore) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
-compileSourceToArtifactsWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
-compileSourceToArtifactsWithDependencies environment sourceName source =
+compileSourceToArtifactsWithDependencies :: Bool -> CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
+compileSourceToArtifactsWithDependencies wholeProgram environment sourceName source =
   case parseCompileModule sourceName source of
     Left err -> pure (Left err)
     Right parsed -> do
-      dependencies <- buildDependencies environment (ImplicitPrelude `elem` sourceExtensions source) parsed
+      dependencies <- buildDependencies environment (ImplicitPrelude `elem` sourceExtensions source) (not wholeProgram) parsed
       pure $ do
         artifact <- either (Left . CompileDependencyError) Right dependencies
-        compileWithDependencies artifact parsed
+        compileWithDependencies wholeProgram artifact parsed
 
-compileWithDependencies :: DependencyArtifact -> Module -> Either CompileError CompileArtifacts
-compileWithDependencies dependencies parsed =
+compileWithDependencies :: Bool -> DependencyArtifact -> Module -> Either CompileError CompileArtifacts
+compileWithDependencies wholeProgram dependencies parsed =
   case resolveWithDeps (dependencyExports dependencies) [parsed] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
     ResolveResult {resolvedModules} ->
@@ -166,7 +168,33 @@ compileWithDependencies dependencies parsed =
                       let mainProgram = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                           freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainProgram) (dependencyProgram dependencies)
                           program = eliminateDeadCode "main" (appendPrograms freshDependencies mainProgram)
-                       in compileProgramArtifacts program
+                       in if wholeProgram
+                            then compileProgramArtifacts program
+                            else compileIncrementalArtifacts dependencies mainProgram program
+
+compileIncrementalArtifacts :: DependencyArtifact -> FcProgram -> FcProgram -> Either CompileError CompileArtifacts
+compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
+  let dependencyCorePrograms = map dependencyUnitProgram (dependencyUnits dependencies)
+      separatelyLowered = Grin.lowerPrograms (dependencyCorePrograms <> [mainCore])
+      dependencyGrinPrograms = take (length dependencyCorePrograms) separatelyLowered
+      mainGrin = last separatelyLowered
+      dependencyLayout = buildLinkLayout dependencyGrinPrograms
+      mainCore = eliminateDeadCode "main" unoptimizedMain
+      layout = extendLinkLayout dependencyLayout mainGrin
+      combinedGrin = Grin.lowerProgram combinedCore
+  either (Left . CompileArm64Error) Right (validateProgramPrimitives combinedGrin)
+  assembly <-
+    either
+      (Left . CompileArm64Error)
+      Right
+      (compileProgramWithDependencies layout (dependencyInitializerSymbols dependencies) "main" mainGrin)
+  pure
+    CompileArtifacts
+      { compiledCore = renderCore combinedCore,
+        compiledGrin = renderGrin combinedGrin,
+        compiledAssembly = assembly,
+        compiledArchives = dependencyArchivePaths dependencies
+      }
 
 compileProgramArtifacts :: FcProgram -> Either CompileError CompileArtifacts
 compileProgramArtifacts core = do
@@ -174,12 +202,20 @@ compileProgramArtifacts core = do
   assembly <- either (Left . CompileArm64Error) Right (compileProgram "main" grin)
   pure
     CompileArtifacts
-      { compiledCore = withFinalNewline (Fc.renderProgram core),
-        compiledGrin = withFinalNewline (Grin.renderProgram grin),
-        compiledAssembly = assembly
+      { compiledCore = renderCore core,
+        compiledGrin = renderGrin grin,
+        compiledAssembly = assembly,
+        compiledArchives = []
       }
-  where
-    withFinalNewline rendered = T.pack rendered <> "\n"
+
+renderCore :: FcProgram -> Text
+renderCore = withFinalNewline . Fc.renderProgram
+
+renderGrin :: Grin.GrinProgram -> Text
+renderGrin = withFinalNewline . Grin.renderProgram
+
+withFinalNewline :: String -> Text
+withFinalNewline rendered = T.pack rendered <> "\n"
 
 appendPrograms :: FcProgram -> FcProgram -> FcProgram
 appendPrograms (FcProgram left) (FcProgram right) = FcProgram (left <> right)
@@ -296,13 +332,13 @@ renderCompileError compileError =
     CompileArm64Error err -> "ARM64 code generation error: " <> show err
     CompileClangError exitCode err -> "clang failed (" <> show exitCode <> "): " <> err
 
-assemble :: FilePath -> FilePath -> IO ()
-assemble output assemblyPath = do
+assemble :: FilePath -> FilePath -> [FilePath] -> IO ()
+assemble output assemblyPath archives = do
   runtime <- runtimeSourcePath
   (exitCode, _stdout, stderr) <-
     readProcessWithExitCode
       "clang"
-      ["-std=c11", "-Wall", "-Wextra", "-Werror", runtime, assemblyPath, "-o", output]
+      (["-std=c11", "-Wall", "-Wextra", "-Werror", runtime, assemblyPath] <> archives <> ["-o", output])
       ""
   case exitCode of
     ExitSuccess -> pure ()

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -12,7 +12,7 @@ module Aihc.Cli.Compile.Dependencies
   )
 where
 
-import Aihc.Arm64 (LinkLayout, buildLinkLayout, compileModule)
+import Aihc.Arm64 (LinkLayout, buildLinkLayout, compileModule, targetTriple)
 import Aihc.Fc (DesugarResult (..), FcProgram (..), desugarModuleWithBindings)
 import Aihc.Grin qualified as Grin
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
@@ -400,7 +400,7 @@ buildObject layout unit = do
             let assemblyPath = temporary </> "module.s"
                 objectPath = temporary </> "module.o"
             TIO.writeFile assemblyPath assembly
-            (exitCode, _stdout, stderr) <- readProcessWithExitCode "clang" ["-c", assemblyPath, "-o", objectPath] ""
+            (exitCode, _stdout, stderr) <- readProcessWithExitCode "clang" ["--target=" <> targetTriple, "-c", assemblyPath, "-o", objectPath] ""
             case exitCode of
               ExitSuccess -> renameFile objectPath destination >> pure (Right ())
               ExitFailure _ -> pure (Left ("failed to assemble dependency module " <> T.unpack (dependencyUnitModule (nativeDependencyUnit unit)) <> ": " <> stderr))

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -2,14 +2,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Core-library discovery and content-addressed compilation for @aihc compile@.
+-- Each closure cache contains the frontend interface, one native object per
+-- loaded module, and one static archive per contributing library.
 module Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
+    DependencyUnit (..),
     buildDependencies,
   )
 where
 
+import Aihc.Arm64 (LinkLayout, buildLinkLayout, compileModule)
 import Aihc.Fc (DesugarResult (..), FcProgram (..), desugarModuleWithBindings)
+import Aihc.Grin qualified as Grin
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax
   ( ImportDecl (importDeclModule),
@@ -21,6 +26,7 @@ import Aihc.Parser.Syntax
     effectiveExtensions,
     headerExtensionSettings,
     headerLanguageEdition,
+    moduleName,
   )
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve
@@ -43,7 +49,7 @@ import Aihc.Tc
     tcModuleSuccess,
     typecheckModulesWithFullEnv,
   )
-import Control.Exception (bracketOnError)
+import Control.Exception (bracket, bracketOnError)
 import Control.Monad (filterM, foldM)
 import Data.Bits (xor)
 import Data.ByteString qualified as BS
@@ -63,17 +69,21 @@ import System.Directory
     doesDirectoryExist,
     doesFileExist,
     listDirectory,
+    removeDirectoryRecursive,
     removeFile,
     renameFile,
   )
+import System.Exit (ExitCode (..))
 import System.FilePath
   ( dropExtension,
     makeRelative,
     splitDirectories,
+    takeDirectory,
     takeExtension,
     (</>),
   )
 import System.IO (hClose, hPutStr, openTempFile)
+import System.Process (readProcessWithExitCode)
 import Text.Read (readMaybe)
 
 data CompileEnvironment = CompileEnvironment
@@ -88,8 +98,18 @@ data DependencyArtifact = DependencyArtifact
     dependencyTyCons :: ![TyConInfo],
     dependencyBindings :: ![TcBindingResult],
     dependencyInstances :: ![InstanceInfo],
-    dependencyProgram :: !FcProgram
+    dependencyProgram :: !FcProgram,
+    dependencyUnits :: ![DependencyUnit],
+    dependencyInitializerSymbols :: ![Text],
+    dependencyArchivePaths :: ![FilePath]
   }
+
+data DependencyUnit = DependencyUnit
+  { dependencyUnitLibrary :: !Text,
+    dependencyUnitModule :: !Text,
+    dependencyUnitProgram :: !FcProgram
+  }
+  deriving (Eq, Show, Read)
 
 data StoredDependencyArtifact = StoredDependencyArtifact
   { storedSchemaVersion :: !Int,
@@ -98,7 +118,7 @@ data StoredDependencyArtifact = StoredDependencyArtifact
     storedTyCons :: ![TyConInfo],
     storedBindings :: ![TcBindingResult],
     storedInstances :: ![InstanceInfo],
-    storedProgram :: !FcProgram
+    storedUnits :: ![DependencyUnit]
   }
   deriving (Show, Read)
 
@@ -134,10 +154,10 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 3
+cacheSchemaVersion = 4
 
-buildDependencies :: CompileEnvironment -> Bool -> Module -> IO (Either String DependencyArtifact)
-buildDependencies environment usesImplicitPrelude mainModule = do
+buildDependencies :: CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
+buildDependencies environment usesImplicitPrelude buildNative mainModule = do
   let importedRoots = map importDeclModule (moduleImports mainModule)
       defaultRoots = if usesImplicitPrelude then ["GHC.Prim", "Prelude"] else []
       initialRoots = sort (Set.toList (Set.fromList (defaultRoots <> importedRoots)))
@@ -159,14 +179,25 @@ buildDependencies environment usesImplicitPrelude mainModule = do
                   cachePath = cacheDirectory </> closureHash <> ".cache"
               cached <- readCache cachePath
               case cached of
-                Just artifact -> pure (Right artifact)
+                Just artifact
+                  | buildNative -> finishArtifact cacheDirectory closureHash artifact
+                  | otherwise -> pure (Right artifact)
                 Nothing ->
                   case compileLoadedModules loaded of
                     Left err -> pure (Left err)
                     Right artifact -> do
                       createDirectoryIfMissing True cacheDirectory
                       writeCache cacheDirectory cachePath artifact
-                      pure (Right artifact)
+                      if buildNative
+                        then finishArtifact cacheDirectory closureHash artifact
+                        else pure (Right artifact)
+
+finishArtifact :: FilePath -> FilePath -> DependencyArtifact -> IO (Either String DependencyArtifact)
+finishArtifact cacheDirectory closureHash artifact = do
+  native <- buildNativeArtifacts (cacheDirectory </> closureHash) (dependencyUnits artifact)
+  pure $
+    (\(initializers, archives) -> artifact {dependencyInitializerSymbols = initializers, dependencyArchivePaths = archives})
+      <$> native
 
 emptyDependencyArtifact :: DependencyArtifact
 emptyDependencyArtifact =
@@ -176,7 +207,10 @@ emptyDependencyArtifact =
       dependencyTyCons = [],
       dependencyBindings = [],
       dependencyInstances = [],
-      dependencyProgram = FcProgram []
+      dependencyProgram = FcProgram [],
+      dependencyUnits = [],
+      dependencyInitializerSymbols = [],
+      dependencyArchivePaths = []
     }
 
 -- aihc-base is defined in terms of the compiler-owned GHC.Prim interface even
@@ -213,12 +247,12 @@ discoverModules root = do
 
     insertModule sourceRoot library index path =
       let relative = dropExtension (makeRelative sourceRoot path)
-          moduleName = T.intercalate "." (map T.pack (splitDirectories relative))
-       in case Map.lookup moduleName index of
-            Nothing -> Right (Map.insert moduleName (ModuleSource library path) index)
+          discoveredModuleName = T.intercalate "." (map T.pack (splitDirectories relative))
+       in case Map.lookup discoveredModuleName index of
+            Nothing -> Right (Map.insert discoveredModuleName (ModuleSource library path) index)
             Just previous
               | libraryPriority library < libraryPriority (moduleSourceLibrary previous) ->
-                  Right (Map.insert moduleName (ModuleSource library path) index)
+                  Right (Map.insert discoveredModuleName (ModuleSource library path) index)
               | otherwise -> Right index
 
     libraryPriority "aihc-prim" = 0 :: Int
@@ -288,13 +322,111 @@ compileLoadedModules loaded =
                             dependencyTyCons = tyCons,
                             dependencyBindings = bindings,
                             dependencyInstances = instances,
-                            dependencyProgram = concatPrograms (map dsProgram desugared)
+                            dependencyProgram = concatPrograms (map dsProgram desugared),
+                            dependencyUnits = zipWith makeUnit loaded desugared,
+                            dependencyInitializerSymbols = [],
+                            dependencyArchivePaths = []
                           }
   where
     modules = map loadedModule loaded
+    makeUnit loadedModule' desugared =
+      DependencyUnit
+        { dependencyUnitLibrary = loadedLibrary loadedModule',
+          dependencyUnitModule = fromMaybe "Main" (moduleName (loadedModule loadedModule')),
+          dependencyUnitProgram = dsProgram desugared
+        }
 
 concatPrograms :: [FcProgram] -> FcProgram
 concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
+
+buildNativeArtifacts :: FilePath -> [DependencyUnit] -> IO (Either String ([Text], [FilePath]))
+buildNativeArtifacts artifactRoot units = do
+  let programs = Grin.lowerPrograms (map dependencyUnitProgram units)
+      layout = buildLinkLayout programs
+      objectRoot = artifactRoot </> "objects"
+      archiveRoot = artifactRoot </> "archives"
+      nativeUnits = zipWith (nativeUnit objectRoot) units programs
+  objectResults <- mapM (buildObject layout) nativeUnits
+  case sequence objectResults of
+    Left err -> pure (Left err)
+    Right _ -> do
+      createDirectoryIfMissing True archiveRoot
+      let archiveMembers =
+            foldl'
+              (\archives unit -> Map.insertWith (flip (<>)) (dependencyUnitLibrary (nativeDependencyUnit unit)) [nativeObjectPath unit] archives)
+              Map.empty
+              nativeUnits
+      archives <- mapM (buildArchive archiveRoot) (Map.toAscList archiveMembers)
+      pure $ do
+        archivePaths <- sequence archives
+        Right (map nativeInitializerSymbol nativeUnits, archivePaths)
+
+data NativeUnit = NativeUnit
+  { nativeDependencyUnit :: !DependencyUnit,
+    nativeProgram :: !Grin.GrinProgram,
+    nativeInitializerSymbol :: !Text,
+    nativeObjectPath :: !FilePath
+  }
+
+nativeUnit :: FilePath -> DependencyUnit -> Grin.GrinProgram -> NativeUnit
+nativeUnit objectRoot unit program =
+  NativeUnit
+    { nativeDependencyUnit = unit,
+      nativeProgram = program,
+      nativeInitializerSymbol = initializer,
+      nativeObjectPath = objectRoot </> T.unpack (dependencyUnitLibrary unit) </> T.unpack (dependencyUnitModule unit) <> ".o"
+    }
+  where
+    initializer = "_aihc_init_" <> symbolHex (dependencyUnitLibrary unit <> "\0" <> dependencyUnitModule unit)
+
+symbolHex :: Text -> Text
+symbolHex = T.concat . map renderByte . BS.unpack . Text.encodeUtf8
+  where
+    renderByte byte = T.pack (padLeft 2 '0' (showHex byte ""))
+
+buildObject :: LinkLayout -> NativeUnit -> IO (Either String ())
+buildObject layout unit = do
+  let destination = nativeObjectPath unit
+      directory = takeDirectory destination
+  exists <- doesFileExist destination
+  if exists
+    then pure (Right ())
+    else do
+      case compileModule layout (nativeInitializerSymbol unit) (nativeProgram unit) of
+        Left err -> pure (Left ("ARM64 dependency code generation failed for " <> T.unpack (dependencyUnitModule (nativeDependencyUnit unit)) <> ": " <> show err))
+        Right assembly -> do
+          createDirectoryIfMissing True directory
+          withTemporaryDirectory directory "module-build" $ \temporary -> do
+            let assemblyPath = temporary </> "module.s"
+                objectPath = temporary </> "module.o"
+            TIO.writeFile assemblyPath assembly
+            (exitCode, _stdout, stderr) <- readProcessWithExitCode "clang" ["-c", assemblyPath, "-o", objectPath] ""
+            case exitCode of
+              ExitSuccess -> renameFile objectPath destination >> pure (Right ())
+              ExitFailure _ -> pure (Left ("failed to assemble dependency module " <> T.unpack (dependencyUnitModule (nativeDependencyUnit unit)) <> ": " <> stderr))
+
+buildArchive :: FilePath -> (Text, [FilePath]) -> IO (Either String FilePath)
+buildArchive archiveRoot (library, objects) = do
+  let destination = archiveRoot </> "lib" <> T.unpack library <> ".a"
+  exists <- doesFileExist destination
+  if exists
+    then pure (Right destination)
+    else withTemporaryDirectory archiveRoot "archive-build" $ \temporary -> do
+      let archivePath = temporary </> "library.a"
+      (exitCode, _stdout, stderr) <- readProcessWithExitCode "ar" (["rcs", archivePath] <> objects) ""
+      case exitCode of
+        ExitSuccess -> renameFile archivePath destination >> pure (Right destination)
+        ExitFailure _ -> pure (Left ("failed to archive dependency library " <> T.unpack library <> ": " <> stderr))
+
+withTemporaryDirectory :: FilePath -> String -> (FilePath -> IO value) -> IO value
+withTemporaryDirectory parent template = bracket acquire removeDirectoryRecursive
+  where
+    acquire = do
+      (path, handle) <- openTempFile parent template
+      hClose handle
+      removeFile path
+      createDirectoryIfMissing True path
+      pure path
 
 dependencyGraphHash :: FilePath -> [LoadedModule] -> IO String
 dependencyGraphHash root loaded = do
@@ -385,7 +517,7 @@ toStoredArtifact artifact =
       storedTyCons = dependencyTyCons artifact,
       storedBindings = dependencyBindings artifact,
       storedInstances = dependencyInstances artifact,
-      storedProgram = dependencyProgram artifact
+      storedUnits = dependencyUnits artifact
     }
 
 fromStoredArtifact :: StoredDependencyArtifact -> DependencyArtifact
@@ -396,7 +528,10 @@ fromStoredArtifact stored =
       dependencyTyCons = storedTyCons stored,
       dependencyBindings = storedBindings stored,
       dependencyInstances = storedInstances stored,
-      dependencyProgram = storedProgram stored
+      dependencyProgram = concatPrograms (map dependencyUnitProgram (storedUnits stored)),
+      dependencyUnits = storedUnits stored,
+      dependencyInitializerSymbols = [],
+      dependencyArchivePaths = []
     }
 
 toStoredExports :: ModuleExports -> StoredModuleExports

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -23,7 +23,8 @@ data CompileOptions = CompileOptions
     compileOutputFile :: !(Maybe FilePath),
     compileKeepCore :: !Bool,
     compileKeepGrin :: !Bool,
-    compileKeepAsm :: !Bool
+    compileKeepAsm :: !Bool,
+    compileWholeProgram :: !Bool
   }
   deriving (Eq, Show)
 
@@ -117,6 +118,10 @@ compileOptionsParser =
     <*> OA.switch
       ( OA.long "keep-asm"
           <> OA.help "Keep the generated assembly as OUTPUT.s"
+      )
+    <*> OA.switch
+      ( OA.long "whole-program"
+          <> OA.help "Compile the program and all libraries as one assembly unit instead of linking cached library objects"
       )
 
 replOptionsParser :: OA.Parser ReplOptions

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -33,7 +33,7 @@ import Aihc.Fc (FcProgram (..))
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Resolve (Scope (..))
 import Control.Exception (bracket)
-import Control.Monad (when)
+import Control.Monad (when, (>=>))
 import Data.Aeson (object, (.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy.Char8 qualified as BL8
@@ -77,26 +77,31 @@ main =
         [ testCase "parses compile source" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False)))
               (parseCommandPure ["compile", "Main.hs"]),
           testCase "parses compile output and keep-asm" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False True)))
+              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False True False)))
               (parseCommandPure ["compile", "Main.hs", "-o", "hello", "--keep-asm"]),
           testCase "parses keep-core" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False False)))
               (parseCommandPure ["compile", "Main.hs", "--keep-core"]),
           testCase "parses keep-grin" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False False)))
               (parseCommandPure ["compile", "Main.hs", "--keep-grin"]),
+          testCase "parses whole-program compatibility mode" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False True)))
+              (parseCommandPure ["compile", "Main.hs", "--whole-program"]),
           testCase "derives safe default compile output paths" $ do
-            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False))
-            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False)),
+            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False False))
+            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False False)),
           testCase "parses install package" $
             assertEqual
               "command"
@@ -142,6 +147,7 @@ main =
                 Left err -> assertFailure ("expected compile success, got: " <> show err)
                 Right assembly -> do
                   assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
+                  assertBool "dependency initializer call" ("bl _aihc_init_" `T.isInfixOf` assembly)
                   assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
           testCase "assembles an executable and honors keep-output flags" test_compileExecutable,
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
@@ -857,8 +863,8 @@ test_compileExecutable =
           keptOutput = root </> "kept"
           temporaryOutput = root </> "temporary"
           environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-          keptOptions = CompileOptions sourcePath (Just keptOutput) True True True
-          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False False False
+          keptOptions = CompileOptions sourcePath (Just keptOutput) True True True False
+          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False False False True
       withCurrentDirectory repositoryRoot $ do
         runCompileWithEnvironment environment keptOptions
         assertFileExists keptOutput
@@ -908,7 +914,8 @@ test_compileImplicitCoreDependencies =
         environment = CompileEnvironment coreRoot cacheRoot
         implicitSource = implicitDependencySource
     createCompileLibrary coreRoot "aihc-prim" "GHC.Prim" "module GHC.Prim where\n"
-    createCompileLibrary coreRoot "aihc-base" "Prelude" "module Prelude where\nid x = x\n"
+    createCompileLibrary coreRoot "aihc-base" "BaseSupport" "module BaseSupport where\nsupport x = x\n"
+    createCompileLibrary coreRoot "aihc-base" "Prelude" "module Prelude where\nimport BaseSupport\nid x = support x\n"
     writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 1\n"
 
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
@@ -917,11 +924,17 @@ test_compileImplicitCoreDependencies =
     cachePath <- case cacheFiles of
       [path] -> pure path
       paths -> assertFailure ("expected one cache file, got " <> show paths)
+    objectFiles <- compileCacheArtifacts ".o" cacheRoot
+    archiveFiles <- compileCacheArtifacts ".a" cacheRoot
+    assertEqual "one object per dependency module" 3 (length objectFiles)
+    assertEqual "one archive per dependency library" 2 (length archiveFiles)
 
     let oldTimestamp = UTCTime (fromGregorian 2000 1 1) 0
     setModificationTime cachePath oldTimestamp
+    mapM_ (`setModificationTime` oldTimestamp) (objectFiles <> archiveFiles)
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
     getModificationTime cachePath >>= assertEqual "cache hit preserves artifact" oldTimestamp
+    mapM_ (getModificationTime >=> assertEqual "cache hit preserves native artifact" oldTimestamp) (objectFiles <> archiveFiles)
 
     writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 2\n"
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
@@ -1010,7 +1023,10 @@ createCompileLibrary coreRoot library moduleName source = do
     dotToSlash char = char
 
 compileCacheFiles :: FilePath -> IO [FilePath]
-compileCacheFiles root = do
+compileCacheFiles = compileCacheArtifacts ".cache"
+
+compileCacheArtifacts :: String -> FilePath -> IO [FilePath]
+compileCacheArtifacts extension root = do
   exists <- doesDirectoryExist root
   if not exists
     then pure []
@@ -1022,8 +1038,8 @@ compileCacheFiles root = do
       let path = root </> entry
       isDirectory <- doesDirectoryExist path
       if isDirectory
-        then compileCacheFiles path
-        else pure [path | ".cache" `isSuffixOf` path]
+        then compileCacheArtifacts extension path
+        else pure [path | extension `isSuffixOf` path]
 
 assertNativeOutput :: FilePath -> Assertion
 assertNativeOutput executable = do

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -229,7 +229,6 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
                            aihc_arguments_with_field(function, argument));
     return;
   case AIHC_CONSTRUCTOR:
-  case AIHC_PRIMITIVE:
   case AIHC_FOREIGN: {
     AihcValue *applied = aihc_copy_with_field(function, argument);
     if (applied->count < applied->arity) {
@@ -257,6 +256,9 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
     aihc_return_value(machine, (AihcSlot)applied);
     return;
   }
+  case AIHC_PRIMITIVE:
+    aihc_fail("primitive is not implemented by the native runtime");
+    return;
   case AIHC_FOREIGN_IO:
     aihc_complete_foreign(machine, function, argument);
     return;

--- a/components/aihc-arm64/src/Aihc/Arm64.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64.hs
@@ -1,12 +1,27 @@
 -- | Native AArch64 code generation for runtime-explicit GRIN.
 module Aihc.Arm64
   ( Arm64Error (..),
+    LinkLayout,
+    buildLinkLayout,
+    compileModule,
     compileProgram,
+    compileProgramWithDependencies,
+    extendLinkLayout,
     runtimeSourcePath,
+    validateProgramPrimitives,
   )
 where
 
-import Aihc.Arm64.Codegen (Arm64Error (..), compileProgram)
+import Aihc.Arm64.Codegen
+  ( Arm64Error (..),
+    LinkLayout,
+    buildLinkLayout,
+    compileModule,
+    compileProgram,
+    compileProgramWithDependencies,
+    extendLinkLayout,
+    validateProgramPrimitives,
+  )
 import Paths_aihc_arm64 (getDataFileName)
 
 -- | Locate the C runtime used by generated assembly.

--- a/components/aihc-arm64/src/Aihc/Arm64.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64.hs
@@ -8,6 +8,7 @@ module Aihc.Arm64
     compileProgramWithDependencies,
     extendLinkLayout,
     runtimeSourcePath,
+    targetTriple,
     validateProgramPrimitives,
   )
 where
@@ -27,3 +28,7 @@ import Paths_aihc_arm64 (getDataFileName)
 -- | Locate the C runtime used by generated assembly.
 runtimeSourcePath :: IO FilePath
 runtimeSourcePath = getDataFileName "runtime/aihc_runtime.c"
+
+-- | LLVM target triple for the assembly emitted by this backend.
+targetTriple :: String
+targetTriple = "arm64-apple-darwin"

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -5,7 +5,13 @@
 -- for the C runtime and foreign functions.
 module Aihc.Arm64.Codegen
   ( Arm64Error (..),
+    LinkLayout,
+    buildLinkLayout,
+    compileModule,
     compileProgram,
+    compileProgramWithDependencies,
+    extendLinkLayout,
+    validateProgramPrimitives,
   )
 where
 
@@ -42,8 +48,19 @@ data CompileEnv = CompileEnv
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
     compileFunctionArities :: !(Map FunctionName Int),
-    compileForeignLabels :: !(Map Text Text)
+    compileForeignLabels :: !(Map Text Text),
+    compileAllowUnsupportedPrimitives :: !Bool
   }
+
+-- | The process-wide constructor tags and global table slots shared by all
+-- native compilation units in one executable. Extending a dependency layout
+-- appends user-program entries, so cached dependency objects keep the same
+-- assignments regardless of the program that links them.
+data LinkLayout = LinkLayout
+  { linkConstructors :: ![(Text, Int)],
+    linkGlobalNames :: ![Text]
+  }
+  deriving (Eq, Show)
 
 data Block = Block
   { blockLabel :: !Text,
@@ -64,9 +81,68 @@ data ValueEnv = ValueEnv
   }
 
 compileProgram :: Text -> GrinProgram -> Either Arm64Error Text
-compileProgram entryName program = do
+compileProgram entryName program =
+  compileProgramWithDependencies (buildLinkLayout [program]) [] entryName program
+
+-- | Reject primitives that reachable native code would not execute correctly.
+-- Relocatable library objects may carry dormant primitive declarations, but
+-- the linked program is checked after whole-program dead-code elimination.
+validateProgramPrimitives :: GrinProgram -> Either Arm64Error ()
+validateProgramPrimitives program =
+  mapM_ (primitiveIdentifier False . grinVarName . fst) (grinPrimitives program)
+
+-- | Build the stable layout for a dependency closure in dependency order.
+buildLinkLayout :: [GrinProgram] -> LinkLayout
+buildLinkLayout = foldl extendLinkLayout emptyLinkLayout
+
+-- | Append a compilation unit to an existing layout without renumbering any
+-- existing constructor or global.
+extendLinkLayout :: LinkLayout -> GrinProgram -> LinkLayout
+extendLinkLayout layout program =
+  LinkLayout
+    { linkConstructors = uniqueByName (linkConstructors layout <> programConstructorArities program),
+      linkGlobalNames = uniqueTexts (linkGlobalNames layout <> programGlobalNames program)
+    }
+
+-- | Compile a library module to relocatable assembly. The exported initializer
+-- installs the module's primitive, foreign, and CAF globals into the shared
+-- machine table. Constructors are installed once by the executable entry unit.
+compileModule :: LinkLayout -> Text -> GrinProgram -> Either Arm64Error Text
+compileModule layout initializerSymbol program = do
+  mapM_ validateRuntimeRep (programRuntimeReps program)
+  initLines <- compileInitializers compileEnv program
+  functions <- mapM (compileFunction compileEnv) (grinFunctions program)
+  descriptors <- foreignDescriptors compileEnv program
+  pure . T.unlines $
+    [ ".section __TEXT,__text,regular,pure_instructions",
+      ".p2align 2",
+      ".globl " <> initializerSymbol,
+      initializerSymbol <> ":",
+      "  stp x29, x30, [sp, #-48]!",
+      "  mov x29, sp",
+      "  stp x19, x20, [sp, #16]",
+      "  stp x21, x22, [sp, #32]",
+      "  mov x22, x0"
+    ]
+      <> initLines
+      <> [ "  ldp x21, x22, [sp, #32]",
+           "  ldp x19, x20, [sp, #16]",
+           "  ldp x29, x30, [sp], #48",
+           "  ret"
+         ]
+      <> concat functions
+      <> descriptors
+  where
+    compileEnv = (compileEnvironment layout program) {compileAllowUnsupportedPrimitives = True}
+
+-- | Compile the user program entry unit against cached dependency modules.
+-- Dependency initializers are called after constructors are installed and
+-- before the user module's own globals are initialized.
+compileProgramWithDependencies :: LinkLayout -> [Text] -> Text -> GrinProgram -> Either Arm64Error Text
+compileProgramWithDependencies layout dependencyInitializers entryName program = do
   mapM_ validateRuntimeRep (programRuntimeReps program)
   rootSlot <- maybe (Left (Arm64MissingEntry entryName)) Right (Map.lookup entryName globalSlots)
+  constructorLines <- compileConstructorInitializers compileEnv
   initLines <- compileInitializers compileEnv program
   functions <- mapM (compileFunction compileEnv) (grinFunctions program)
   descriptors <- foreignDescriptors compileEnv program
@@ -85,6 +161,8 @@ compileProgram entryName program = do
       "  bl _aihc_machine_new",
       "  mov x22, x0"
     ]
+      <> constructorLines
+      <> concatMap callInitializer dependencyInitializers
       <> initLines
       <> [ "  ldr x9, [x22, #24]",
            loadAt "x1" "x9" rootSlot,
@@ -103,27 +181,58 @@ compileProgram entryName program = do
       <> concat functions
       <> descriptors
   where
-    constructors = uniqueByName (builtinConstructors <> programConstructorArities program)
-    constructorIds = Map.fromList (zip (map fst constructors) [1 ..])
-    constructorArities = Map.fromList constructors
-    globalNames = uniqueTexts (map fst constructors <> map (grinVarName . fst) (grinPrimitives program) <> map grinForeignCallName (grinForeignCalls program) <> map (grinVarName . fst) (grinCafs program))
-    globalSlots = Map.fromList (zip globalNames [0 ..])
-    functionLabels = Map.fromList [(grinFunctionName function, functionLabel index) | (index, function) <- zip [0 ..] (grinFunctions program)]
-    functionArities = Map.fromList [(grinFunctionName function, length (grinFunctionParameters function)) | function <- grinFunctions program]
-    foreignLabels = Map.fromList [(grinForeignCallName foreignCall, foreignLabel index) | (index, foreignCall) <- zip [0 ..] (grinForeignCalls program)]
-    compileEnv = CompileEnv constructorIds constructorArities globalSlots functionLabels functionArities foreignLabels
+    compileEnv = compileEnvironment layout program
+    globalSlots = compileGlobalSlots compileEnv
+    globalNames = linkGlobalNames layout
+    constructorIds = compileConstructorIds compileEnv
     ioConstructor = Map.findWithDefault 0 "IO" constructorIds
     tupleConstructor = Map.findWithDefault 0 "(#,#)" constructorIds
 
+    callInitializer symbol =
+      [ "  mov x0, x22",
+        "  bl " <> symbol
+      ]
+
+emptyLinkLayout :: LinkLayout
+emptyLinkLayout =
+  LinkLayout
+    { linkConstructors = builtinConstructors,
+      linkGlobalNames = map fst builtinConstructors
+    }
+
+programGlobalNames :: GrinProgram -> [Text]
+programGlobalNames program =
+  map fst (programConstructorArities program)
+    <> map (grinVarName . fst) (grinPrimitives program)
+    <> map grinForeignCallName (grinForeignCalls program)
+    <> map (grinVarName . fst) (grinCafs program)
+
+compileEnvironment :: LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironment layout program =
+  CompileEnv
+    { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
+      compileConstructorArities = Map.fromList constructors,
+      compileGlobalSlots = Map.fromList (zip (linkGlobalNames layout) [0 ..]),
+      compileFunctionLabels = Map.fromList [(grinFunctionName function, functionLabel index) | (index, function) <- zip [0 ..] (grinFunctions program)],
+      compileFunctionArities = Map.fromList [(grinFunctionName function, length (grinFunctionParameters function)) | function <- grinFunctions program],
+      compileForeignLabels = Map.fromList [(grinForeignCallName foreignCall, foreignLabel index) | (index, foreignCall) <- zip [0 ..] (grinForeignCalls program)],
+      compileAllowUnsupportedPrimitives = False
+    }
+  where
+    constructors = linkConstructors layout
+
+compileConstructorInitializers :: CompileEnv -> Either Arm64Error [Text]
+compileConstructorInitializers env =
+  fmap concat . forM (Map.toAscList (compileConstructorIds env)) $ \(name, constructor) -> do
+    slot <- globalSlot env name
+    arity <- constructorArity env name
+    pure $ makeNodeLines 1 (InfoImmediate constructor) arity 0 <> storeGlobal slot
+
 compileInitializers :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
 compileInitializers env program = do
-  constructorLines <- fmap concat . forM constructors $ \(name, arity) -> do
-    slot <- globalSlot env name
-    constructor <- constructorId env name
-    pure $ makeNodeLines 1 (InfoImmediate constructor) arity 0 <> storeGlobal slot
   primitiveLines <- fmap concat . forM (grinPrimitives program) $ \(var, arity) -> do
     slot <- globalSlot env (grinVarName var)
-    primitive <- primitiveId (grinVarName var)
+    primitive <- primitiveId env (grinVarName var)
     pure $ makeNodeLines 4 (InfoImmediate primitive) arity 0 <> storeGlobal slot
   foreignLines <- fmap concat . forM (grinForeignCalls program) $ \foreignCall -> do
     slot <- globalSlot env (grinForeignCallName foreignCall)
@@ -144,9 +253,7 @@ compileInitializers env program = do
              "  mov x1, x20",
              "  bl _aihc_set_cell"
            ]
-  pure (constructorLines <> primitiveLines <> foreignLines <> cafCellLines <> cafValueLines)
-  where
-    constructors = uniqueByName (builtinConstructors <> programConstructorArities program)
+  pure (primitiveLines <> foreignLines <> cafCellLines <> cafValueLines)
 
 compileFunction :: CompileEnv -> GrinFunction -> Either Arm64Error [Text]
 compileFunction env function = do
@@ -463,7 +570,7 @@ nodeHeader env node =
       arity <- functionArity compileEnv functionName
       pure (3, InfoAddress label, arity)
     GrinPrimitive name arity -> do
-      identifier <- primitiveId name
+      identifier <- primitiveId compileEnv name
       pure (4, InfoImmediate identifier, arity)
     GrinForeign foreignCall -> do
       label <- foreignDescriptorLabel compileEnv foreignCall
@@ -622,9 +729,13 @@ foreignDescriptorLabel env foreignCall =
     Right
     (Map.lookup (grinForeignCallName foreignCall) (compileForeignLabels env))
 
-primitiveId :: Text -> Either Arm64Error Int
-primitiveId name
+primitiveId :: CompileEnv -> Text -> Either Arm64Error Int
+primitiveId env = primitiveIdentifier (compileAllowUnsupportedPrimitives env)
+
+primitiveIdentifier :: Bool -> Text -> Either Arm64Error Int
+primitiveIdentifier allowUnsupported name
   | name == "realWorld#" = Right 1
+  | allowUnsupported = Right 0
   | otherwise = Left (Arm64UnsupportedPrimitive name)
 
 boundVars :: GrinExpr -> Set GrinVar

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -5,7 +5,7 @@ module Test.Arm64.Suite
   )
 where
 
-import Aihc.Arm64 (Arm64Error (..), compileProgram, runtimeSourcePath)
+import Aihc.Arm64 (Arm64Error (..), buildLinkLayout, compileModule, compileProgram, runtimeSourcePath, validateProgramPrimitives)
 import Aihc.Arm64.Emit (renderAllocatedBlock)
 import Aihc.Arm64.Lir
 import Aihc.Arm64.RegisterAllocate
@@ -81,6 +81,20 @@ tests =
           "native representation diagnostic"
           (Left (Arm64UnsupportedRuntimeRep runtimeRep))
           (compileProgram "missing" program),
+      testCase "keeps unsupported dormant primitives out of linked programs" $ do
+        let primitive = GrinVar "+#" 1 (BoxedRep Lifted)
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [(primitive, 2)],
+                  grinForeignCalls = [],
+                  grinCafs = [],
+                  grinFunctions = []
+                }
+        assertEqual "linked primitive validation" (Left (Arm64UnsupportedPrimitive "+#")) (validateProgramPrimitives program)
+        case compileModule (buildLinkLayout [program]) "_aihc_init_test" program of
+          Left err -> assertFailure ("relocatable module rejected a dormant primitive: " <> show err)
+          Right assembly -> assertBool "module initializer" (".globl _aihc_init_test" `T.isInfixOf` assembly),
       testCase "canonicalizes narrow signed literals in machine-word slots" $ do
         let answer = GrinVar "answer" 1 (BoxedRep Lifted)
             functionName = FunctionName "answer_code"

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -2,6 +2,7 @@
 module Aihc.Grin
   ( module Aihc.Grin.Syntax,
     lowerProgram,
+    lowerPrograms,
     lintProgram,
     GrinLintError (..),
     renderProgram,
@@ -14,6 +15,6 @@ where
 
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
-import Aihc.Grin.Lower (lowerProgram)
+import Aihc.Grin.Lower (lowerProgram, lowerPrograms)
 import Aihc.Grin.Pretty (renderExpr, renderProgram)
 import Aihc.Grin.Syntax

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -3,6 +3,7 @@
 -- | Lowering from non-strict System FC to strict, runtime-explicit GRIN.
 module Aihc.Grin.Lower
   ( lowerProgram,
+    lowerPrograms,
   )
 where
 
@@ -59,7 +60,38 @@ instance Monoid LoweredTop where
 -- representations, closure-convert lambdas and thunks, and make evaluation,
 -- application, allocation, and exception control explicit.
 lowerProgram :: FcProgram -> GrinProgram
-lowerProgram program =
+lowerProgram program = lowerProgramWithEnvironment (programEnvironment [program]) program
+
+-- | Lower separately compiled FC units with the complete set of global names
+-- supplied by the compilation closure. A unit may refer to a constructor,
+-- primitive, foreign import, or CAF defined in another unit, but generated
+-- functions and local variables remain private to that unit.
+lowerPrograms :: [FcProgram] -> [GrinProgram]
+lowerPrograms programs = map (lowerProgramWithEnvironment environment) programs
+  where
+    environment = programEnvironment programs
+
+data ProgramEnvironment = ProgramEnvironment
+  { programEnvironmentGlobals :: !(Set Text),
+    programEnvironmentWhnfGlobals :: !(Set Text),
+    programEnvironmentPrimitives :: !(Set Text)
+  }
+
+programEnvironment :: [FcProgram] -> ProgramEnvironment
+programEnvironment programs =
+  ProgramEnvironment
+    { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors <> concatMap programGlobalNames programs),
+      programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors <> concatMap programWhnfGlobalNames programs),
+      programEnvironmentPrimitives =
+        Set.fromList
+          [ varName var
+          | program <- programs,
+            FcPrimitive var _ <- fcTopBinds program
+          ]
+    }
+
+lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
+lowerProgramWithEnvironment environment program =
   GrinProgram
     { grinConstructors = loweredConstructors tops,
       grinPrimitives = loweredPrimitives tops,
@@ -73,13 +105,9 @@ lowerProgram program =
         { lowerNextUnique = maximum (0 : map sourceUnique (programVars program)) + 1,
           lowerNextFunction = 0,
           lowerFunctionsRev = [],
-          lowerPrimitiveNames =
-            Set.fromList
-              [ varName var
-              | FcPrimitive var _ <- fcTopBinds program
-              ],
-          lowerGlobalNames = Set.fromList (map fst builtinConstructors <> programGlobalNames program),
-          lowerWhnfGlobalNames = Set.fromList (map fst builtinConstructors <> programWhnfGlobalNames program),
+          lowerPrimitiveNames = programEnvironmentPrimitives environment,
+          lowerGlobalNames = programEnvironmentGlobals environment,
+          lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
           lowerLocalVars = Set.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -58,7 +58,13 @@ grinUnitTests =
         let program = lowerProgram cafReferenceProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "CAF reference is evaluated" ("eval @BoxedRep Lifted source%" `isInfixOf` rendered)
+        assertBool "CAF reference is evaluated" ("eval @BoxedRep Lifted source%" `isInfixOf` rendered),
+      testCase "separate FC units do not capture dependency globals" $ do
+        case lowerPrograms separatePrograms of
+          [_provider, consumer] -> do
+            let parameters = concatMap grinFunctionParameters (grinFunctions consumer)
+            assertBool "dependency CAF remains global" (all ((/= "source") . grinVarName) parameters)
+          programs -> assertFailure ("expected two separately lowered programs, got " <> show (length programs))
     ]
 
 grinGoldenTests :: IO TestTree
@@ -224,3 +230,13 @@ intTy = TcTyCon (TyCon "Int#" 0) []
 
 boxedIntTy :: TcType
 boxedIntTy = TcTyCon (TyCon "Int" 0) []
+
+separatePrograms :: [FcProgram]
+separatePrograms =
+  [ FcProgram [FcTopBind (FcNonRec sourceVar (FcLit (LitString "provider")))],
+    FcProgram [FcTopBind (FcNonRec answerVar (FcLam argumentVar (FcVar sourceVar)))]
+  ]
+  where
+    sourceVar = Var "source" (Unique 30) boxedIntTy
+    answerVar = Var "answer" (Unique 31) (TcFunTy boxedIntTy boxedIntTy)
+    argumentVar = Var "argument" (Unique 32) boxedIntTy

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -41,6 +41,7 @@
           old:
             addHiddenSuccesses old
             // {
+              testToolDepends = (old.testToolDepends or []) ++ [pkgs.llvmPackages.clang];
               preCheck =
                 (old.preCheck or "")
                 + ''


### PR DESCRIPTION
## Summary

- make dependency-aware native compilation emit one cached object per loaded library module
- group cached module objects into one static archive per contributing library and link those archives into the user executable
- add relocatable ARM64 module initializers backed by a stable dependency link layout for constructor tags and global slots
- lower separate FC units with the full dependency global environment so cross-module CAFs are not captured as locals
- keep the previous combined pipeline behind `aihc compile --whole-program`

## Implementation notes

The executable entry unit allocates the shared runtime global table, installs constructors once, invokes dependency module initializers in dependency order, initializes the user module, and enters `main`. Dependency layouts are extended rather than renumbered when the user unit is added, which keeps cached objects independent of the user program.

Library objects may contain dormant primitive declarations that the native runtime does not yet implement. After whole-program dead-code elimination, the linked program's reachable primitive set is still validated strictly, preserving the previous compile-time failure behavior.

The dependency cache schema now stores per-module FC units without duplicating the combined FC program. Native artifacts live beside that interface cache: module `.o` files under an `objects` tree and library `.a` files under an `archives` tree. Existing artifacts are reused without regenerating assembly or rebuilding archives.

## User impact

Incremental library compilation is now the default for `aihc compile`. Repeated builds with the same dependency closure reuse cached library object files and archives. `--keep-core`, `--keep-grin`, and `--keep-asm` continue to work; `--whole-program` restores the former single-assembly-unit behavior when needed.

## Validation

- `just fmt`
- `just check`
- native executable regression runs both incremental and whole-program modes on Darwin AArch64
- cache regression verifies three dependency modules produce three object files, two libraries produce two archives, and cache hits preserve interface/object/archive timestamps

## Progress counts

Unchanged. No parser, compatibility, or generated README progress counts are affected.
