### PR TITLE
feat(runtime): add minimal green-thread scheduler

### DIFF
--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -1,6 +1,11 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 enum {
   AIHC_LITERAL_INT = 0,
@@ -34,10 +39,27 @@ enum {
 
 enum {
   AIHC_PRIM_REAL_WORLD = 1,
+  AIHC_PRIM_FORK = 2,
+  AIHC_PRIM_YIELD = 3,
+  AIHC_PRIM_NEW_MVAR = 4,
+  AIHC_PRIM_TAKE_MVAR = 5,
+  AIHC_PRIM_PUT_MVAR = 6,
+  AIHC_PRIM_DELAY = 7,
+};
+
+enum {
+  AIHC_FIBER_RUNNING = 0,
+  AIHC_FIBER_RUNNABLE = 1,
+  AIHC_FIBER_BLOCKED_TAKE = 2,
+  AIHC_FIBER_BLOCKED_PUT = 3,
+  AIHC_FIBER_SLEEPING = 4,
+  AIHC_FIBER_DEAD = 5,
 };
 
 typedef struct AihcValue AihcValue;
 typedef struct AihcContinuation AihcContinuation;
+typedef struct AihcFiber AihcFiber;
+typedef struct AihcMVar AihcMVar;
 /* Every runtime location is one machine word. Static RuntimeRep metadata says
  * whether that word is a heap pointer or an unboxed payload. */
 typedef uintptr_t AihcSlot;
@@ -86,6 +108,47 @@ struct AihcContinuation {
 };
 
 typedef struct {
+  uint64_t serial;
+} AihcThreadId;
+
+struct AihcFiber {
+  void *next;
+  AihcSlot *args;
+  AihcContinuation *continuation;
+  AihcSlot *locals;
+
+  uint64_t state;
+  bool is_main;
+  bool bootstrap;
+  bool has_pending_result;
+  AihcValue *bootstrap_action;
+  AihcSlot bootstrap_state;
+  AihcSlot pending_result;
+
+  AihcFiber *run_next;
+  AihcFiber *wait_next;
+  AihcFiber *timer_next;
+
+  AihcMVar *blocked_mvar;
+  AihcSlot blocked_state;
+  AihcSlot blocked_value;
+  uint64_t deadline_ns;
+  uint64_t timer_sequence;
+};
+
+typedef struct {
+  AihcFiber *head;
+  AihcFiber *tail;
+} AihcFiberQueue;
+
+struct AihcMVar {
+  bool full;
+  AihcSlot value;
+  AihcFiberQueue takers;
+  AihcFiberQueue putters;
+};
+
+typedef struct {
   void *next;
   AihcSlot *args;
   AihcContinuation *continuation;
@@ -94,6 +157,12 @@ typedef struct {
   void *exit_code;
   uint64_t io_constructor;
   uint64_t tuple_constructor;
+  AihcFiber *current_fiber;
+  AihcFiber *main_fiber;
+  AihcFiberQueue runnable;
+  AihcFiber *timers;
+  uint64_t next_thread_id;
+  uint64_t next_timer_sequence;
 } AihcMachine;
 
 static void aihc_fail(const char *message) {
@@ -146,6 +215,9 @@ static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
                             uint64_t result_is_lifted);
 static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
                              AihcSlot argument);
+static void aihc_schedule_next(AihcMachine *machine);
+static void aihc_execute_primitive(AihcMachine *machine,
+                                   AihcValue *primitive);
 
 AihcValue *aihc_make_node(uint64_t kind, uintptr_t info, uint64_t arity,
                           uint64_t count) {
@@ -182,6 +254,12 @@ AihcMachine *aihc_machine_new(uint64_t global_count, uint64_t io_constructor,
   machine->globals = aihc_allocate(sizeof(*machine->globals) * global_count);
   machine->io_constructor = io_constructor;
   machine->tuple_constructor = tuple_constructor;
+  machine->next_thread_id = 1;
+  AihcFiber *main_fiber = aihc_allocate(sizeof(*main_fiber));
+  main_fiber->state = AIHC_FIBER_RUNNING;
+  main_fiber->is_main = true;
+  machine->current_fiber = main_fiber;
+  machine->main_fiber = main_fiber;
   return machine;
 }
 
@@ -209,6 +287,173 @@ static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
 static AihcValue *aihc_constructor(uint64_t constructor, uint64_t arity,
                                    uint64_t count) {
   return aihc_make_node(AIHC_CONSTRUCTOR, constructor, arity, count);
+}
+
+static AihcValue *aihc_tuple2(AihcMachine *machine, AihcSlot first,
+                              AihcSlot second) {
+  AihcValue *tuple = aihc_constructor(machine->tuple_constructor, 2, 2);
+  tuple->fields[0] = first;
+  tuple->fields[1] = second;
+  return tuple;
+}
+
+static void aihc_run_queue_push(AihcFiberQueue *queue, AihcFiber *fiber) {
+  fiber->run_next = NULL;
+  if (queue->tail == NULL) {
+    queue->head = fiber;
+    queue->tail = fiber;
+  } else {
+    queue->tail->run_next = fiber;
+    queue->tail = fiber;
+  }
+}
+
+static AihcFiber *aihc_run_queue_pop(AihcFiberQueue *queue) {
+  AihcFiber *fiber = queue->head;
+  if (fiber == NULL) {
+    return NULL;
+  }
+  queue->head = fiber->run_next;
+  if (queue->head == NULL) {
+    queue->tail = NULL;
+  }
+  fiber->run_next = NULL;
+  return fiber;
+}
+
+static void aihc_wait_queue_push(AihcFiberQueue *queue, AihcFiber *fiber) {
+  fiber->wait_next = NULL;
+  if (queue->tail == NULL) {
+    queue->head = fiber;
+    queue->tail = fiber;
+  } else {
+    queue->tail->wait_next = fiber;
+    queue->tail = fiber;
+  }
+}
+
+static AihcFiber *aihc_wait_queue_pop(AihcFiberQueue *queue) {
+  AihcFiber *fiber = queue->head;
+  if (fiber == NULL) {
+    return NULL;
+  }
+  queue->head = fiber->wait_next;
+  if (queue->head == NULL) {
+    queue->tail = NULL;
+  }
+  fiber->wait_next = NULL;
+  return fiber;
+}
+
+static void aihc_save_current_fiber(AihcMachine *machine) {
+  AihcFiber *fiber = machine->current_fiber;
+  fiber->next = machine->next;
+  fiber->args = machine->args;
+  fiber->continuation = machine->continuation;
+  fiber->locals = machine->locals;
+}
+
+static void aihc_load_fiber(AihcMachine *machine, AihcFiber *fiber) {
+  machine->current_fiber = fiber;
+  machine->next = fiber->next;
+  machine->args = fiber->args;
+  machine->continuation = fiber->continuation;
+  machine->locals = fiber->locals;
+  fiber->state = AIHC_FIBER_RUNNING;
+}
+
+static void aihc_enqueue_fiber(AihcMachine *machine, AihcFiber *fiber) {
+  fiber->state = AIHC_FIBER_RUNNABLE;
+  aihc_run_queue_push(&machine->runnable, fiber);
+}
+
+static void aihc_wake_fiber(AihcMachine *machine, AihcFiber *fiber,
+                            AihcSlot result) {
+  fiber->has_pending_result = true;
+  fiber->pending_result = result;
+  fiber->blocked_mvar = NULL;
+  aihc_enqueue_fiber(machine, fiber);
+}
+
+static uint64_t aihc_monotonic_ns(void) {
+  struct timespec now;
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+    aihc_fail("could not read monotonic clock");
+  }
+  return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+}
+
+static void aihc_wait_until_ns(uint64_t deadline) {
+  for (;;) {
+    uint64_t now = aihc_monotonic_ns();
+    if (now >= deadline) {
+      return;
+    }
+    uint64_t remaining = deadline - now;
+    struct timespec sleep_time = {
+        .tv_sec = (time_t)(remaining / UINT64_C(1000000000)),
+        .tv_nsec = (long)(remaining % UINT64_C(1000000000)),
+    };
+    if (nanosleep(&sleep_time, NULL) == 0) {
+      return;
+    }
+    if (errno != EINTR) {
+      aihc_fail("timer wait failed");
+    }
+  }
+}
+
+static void aihc_insert_timer(AihcMachine *machine, AihcFiber *fiber) {
+  AihcFiber **cursor = &machine->timers;
+  while (*cursor != NULL &&
+         ((*cursor)->deadline_ns < fiber->deadline_ns ||
+          ((*cursor)->deadline_ns == fiber->deadline_ns &&
+           (*cursor)->timer_sequence < fiber->timer_sequence))) {
+    cursor = &(*cursor)->timer_next;
+  }
+  fiber->timer_next = *cursor;
+  *cursor = fiber;
+}
+
+static void aihc_drain_timers(AihcMachine *machine) {
+  uint64_t now = aihc_monotonic_ns();
+  while (machine->timers != NULL && machine->timers->deadline_ns <= now) {
+    AihcFiber *fiber = machine->timers;
+    machine->timers = fiber->timer_next;
+    fiber->timer_next = NULL;
+    aihc_enqueue_fiber(machine, fiber);
+  }
+}
+
+static void aihc_schedule_next(AihcMachine *machine) {
+  aihc_save_current_fiber(machine);
+  for (;;) {
+    aihc_drain_timers(machine);
+    AihcFiber *next = aihc_run_queue_pop(&machine->runnable);
+    if (next != NULL) {
+      aihc_load_fiber(machine, next);
+      if (next->bootstrap) {
+        next->bootstrap = false;
+        aihc_push_special(machine, AIHC_CONT_FINAL);
+        aihc_apply_value(machine, next->bootstrap_action,
+                         next->bootstrap_state);
+      } else if (next->has_pending_result) {
+        next->has_pending_result = false;
+        aihc_return_value(machine, next->pending_result);
+      }
+      return;
+    }
+    if (machine->timers != NULL) {
+      aihc_wait_until_ns(machine->timers->deadline_ns);
+      continue;
+    }
+    if (machine->main_fiber->state == AIHC_FIBER_DEAD) {
+      machine->locals = NULL;
+      machine->next = machine->exit_code;
+      return;
+    }
+    aihc_fail("deadlock: no runnable green threads or timers");
+  }
 }
 
 static void aihc_complete_foreign(AihcMachine *machine, AihcValue *foreign,
@@ -252,6 +497,10 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
       AihcValue *io = aihc_constructor(descriptor->io_constructor, 1, 1);
       io->fields[0] = (AihcSlot)action;
       aihc_return_value(machine, (AihcSlot)io);
+      return;
+    }
+    if (applied->kind == AIHC_PRIMITIVE) {
+      aihc_execute_primitive(machine, applied);
       return;
     }
     aihc_return_value(machine, (AihcSlot)applied);
@@ -355,8 +604,14 @@ static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
         tuple->info != machine->tuple_constructor || tuple->count != 2) {
       aihc_fail("IO action returned an invalid state/result tuple");
     }
-    machine->locals = NULL;
-    machine->next = machine->exit_code;
+    AihcFiber *fiber = machine->current_fiber;
+    fiber->state = AIHC_FIBER_DEAD;
+    if (fiber->is_main) {
+      machine->locals = NULL;
+      machine->next = machine->exit_code;
+    } else {
+      aihc_schedule_next(machine);
+    }
     return;
   }
   case AIHC_CONT_FOREIGN_CINT: {
@@ -433,6 +688,142 @@ void aihc_select(AihcMachine *machine, AihcValue *dictionary,
   continuation->payload.select.index = index;
   continuation->payload.select.result_is_lifted = result_is_lifted;
   aihc_eval_value(machine, dictionary, 1);
+}
+
+void aihc_prim_fork(AihcMachine *machine, AihcValue *action,
+                    AihcSlot state) {
+  AihcFiber *child = aihc_allocate(sizeof(*child));
+  AihcThreadId *thread_id = aihc_allocate(sizeof(*thread_id));
+  thread_id->serial = machine->next_thread_id++;
+  child->bootstrap = true;
+  child->bootstrap_action = action;
+  child->bootstrap_state = state;
+  aihc_enqueue_fiber(machine, child);
+  aihc_return_value(
+      machine,
+      (AihcSlot)aihc_tuple2(machine, state, (AihcSlot)thread_id));
+}
+
+void aihc_prim_yield(AihcMachine *machine, AihcSlot state) {
+  aihc_return_value(machine, state);
+  aihc_enqueue_fiber(machine, machine->current_fiber);
+  aihc_schedule_next(machine);
+}
+
+void aihc_prim_new_mvar(AihcMachine *machine, AihcSlot state) {
+  AihcMVar *mvar = aihc_allocate(sizeof(*mvar));
+  aihc_return_value(
+      machine, (AihcSlot)aihc_tuple2(machine, state, (AihcSlot)mvar));
+}
+
+void aihc_prim_take_mvar(AihcMachine *machine, AihcMVar *mvar,
+                         AihcSlot state) {
+  if (mvar == NULL) {
+    aihc_fail("takeMVar# received a null MVar");
+  }
+  if (!mvar->full) {
+    AihcFiber *fiber = machine->current_fiber;
+    fiber->state = AIHC_FIBER_BLOCKED_TAKE;
+    fiber->blocked_mvar = mvar;
+    fiber->blocked_state = state;
+    aihc_wait_queue_push(&mvar->takers, fiber);
+    aihc_schedule_next(machine);
+    return;
+  }
+
+  AihcSlot value = mvar->value;
+  AihcFiber *putter = aihc_wait_queue_pop(&mvar->putters);
+  if (putter == NULL) {
+    mvar->full = false;
+    mvar->value = 0;
+  } else {
+    mvar->value = putter->blocked_value;
+    aihc_wake_fiber(machine, putter, putter->blocked_state);
+  }
+  aihc_return_value(machine,
+                    (AihcSlot)aihc_tuple2(machine, state, value));
+}
+
+void aihc_prim_put_mvar(AihcMachine *machine, AihcMVar *mvar,
+                        AihcSlot value, AihcSlot state) {
+  if (mvar == NULL) {
+    aihc_fail("putMVar# received a null MVar");
+  }
+  AihcFiber *taker = aihc_wait_queue_pop(&mvar->takers);
+  if (taker != NULL) {
+    AihcValue *result = aihc_tuple2(machine, taker->blocked_state, value);
+    aihc_wake_fiber(machine, taker, (AihcSlot)result);
+    aihc_return_value(machine, state);
+    return;
+  }
+  if (!mvar->full) {
+    mvar->full = true;
+    mvar->value = value;
+    aihc_return_value(machine, state);
+    return;
+  }
+
+  AihcFiber *fiber = machine->current_fiber;
+  fiber->state = AIHC_FIBER_BLOCKED_PUT;
+  fiber->blocked_mvar = mvar;
+  fiber->blocked_state = state;
+  fiber->blocked_value = value;
+  aihc_wait_queue_push(&mvar->putters, fiber);
+  aihc_schedule_next(machine);
+}
+
+void aihc_prim_delay(AihcMachine *machine, intptr_t microseconds,
+                     AihcSlot state) {
+  if (microseconds <= 0) {
+    aihc_return_value(machine, state);
+    return;
+  }
+  uint64_t duration;
+  if ((uint64_t)microseconds > UINT64_MAX / UINT64_C(1000)) {
+    duration = UINT64_MAX;
+  } else {
+    duration = (uint64_t)microseconds * UINT64_C(1000);
+  }
+  uint64_t now = aihc_monotonic_ns();
+  uint64_t deadline = duration > UINT64_MAX - now ? UINT64_MAX : now + duration;
+  AihcFiber *fiber = machine->current_fiber;
+  fiber->state = AIHC_FIBER_SLEEPING;
+  fiber->has_pending_result = true;
+  fiber->pending_result = state;
+  fiber->deadline_ns = deadline;
+  fiber->timer_sequence = machine->next_timer_sequence++;
+  aihc_insert_timer(machine, fiber);
+  aihc_schedule_next(machine);
+}
+
+static void aihc_execute_primitive(AihcMachine *machine,
+                                   AihcValue *primitive) {
+  switch (primitive->info) {
+  case AIHC_PRIM_FORK:
+    aihc_prim_fork(machine, (AihcValue *)primitive->fields[0],
+                   primitive->fields[1]);
+    return;
+  case AIHC_PRIM_YIELD:
+    aihc_prim_yield(machine, primitive->fields[0]);
+    return;
+  case AIHC_PRIM_NEW_MVAR:
+    aihc_prim_new_mvar(machine, primitive->fields[0]);
+    return;
+  case AIHC_PRIM_TAKE_MVAR:
+    aihc_prim_take_mvar(machine, (AihcMVar *)primitive->fields[0],
+                        primitive->fields[1]);
+    return;
+  case AIHC_PRIM_PUT_MVAR:
+    aihc_prim_put_mvar(machine, (AihcMVar *)primitive->fields[0],
+                       primitive->fields[1], primitive->fields[2]);
+    return;
+  case AIHC_PRIM_DELAY:
+    aihc_prim_delay(machine, (intptr_t)primitive->fields[0],
+                    primitive->fields[1]);
+    return;
+  default:
+    aihc_fail("unsupported saturated primitive");
+  }
 }
 
 void aihc_start(AihcMachine *machine, AihcValue *root, void *exit_code) {

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -12,6 +12,7 @@ where
 import Aihc.Arm64.Emit (EmitError, renderAllocatedBlock)
 import Aihc.Arm64.Lir qualified as Lir
 import Aihc.Grin.Syntax
+import Aihc.Tc.Prim (PrimOp (..), primOpArity, primOpName)
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM)
 import Control.Monad.Trans.Class (lift)
@@ -121,10 +122,10 @@ compileInitializers env program = do
     slot <- globalSlot env name
     constructor <- constructorId env name
     pure $ makeNodeLines 1 (InfoImmediate constructor) arity 0 <> storeGlobal slot
-  primitiveLines <- fmap concat . forM (grinPrimitives program) $ \(var, arity) -> do
+  primitiveLines <- fmap concat . forM (grinPrimitives program) $ \(var, primOp) -> do
     slot <- globalSlot env (grinVarName var)
-    primitive <- primitiveId (grinVarName var)
-    pure $ makeNodeLines 4 (InfoImmediate primitive) arity 0 <> storeGlobal slot
+    primitive <- primitiveId primOp
+    pure $ makeNodeLines 4 (InfoImmediate primitive) (primOpArity primOp) 0 <> storeGlobal slot
   foreignLines <- fmap concat . forM (grinForeignCalls program) $ \foreignCall -> do
     slot <- globalSlot env (grinForeignCallName foreignCall)
     label <- foreignDescriptorLabel env foreignCall
@@ -260,8 +261,38 @@ compileExpr env prefix label expression =
         )
     GrinThrow {} -> unsupportedExpression "throw"
     GrinCatch {} -> unsupportedExpression "catch"
+    GrinScheduler _ schedulerOp arguments ->
+      compileScheduler env prefix label schedulerOp arguments
   where
     unsupportedExpression name = lift (Left (Arm64UnsupportedExpression name))
+
+compileScheduler :: ValueEnv -> [Text] -> Text -> SchedulerPrimOp -> [GrinValue] -> FunctionM ()
+compileScheduler env prefix label schedulerOp arguments = do
+  slots <- mapM (const freshSlot) arguments
+  argumentLines <-
+    fmap concat . forM (zip arguments slots) $ \(argument, slot) -> do
+      valueLines <- liftEither (materializeValue env argument)
+      pure (valueLines <> [storeAt "x0" "x19" slot])
+  let registerLines =
+        [ loadAt ("x" <> tshow register) "x19" slot
+        | (register, slot) <- zip [1 :: Int ..] slots
+        ]
+      symbol =
+        case schedulerOp of
+          SchedulerFork -> "_aihc_prim_fork"
+          SchedulerYield -> "_aihc_prim_yield"
+          SchedulerNewMVar -> "_aihc_prim_new_mvar"
+          SchedulerTakeMVar -> "_aihc_prim_take_mvar"
+          SchedulerPutMVar -> "_aihc_prim_put_mvar"
+          SchedulerDelay -> "_aihc_prim_delay"
+  addBlock
+    label
+    ( prefix
+        <> argumentLines
+        <> registerLines
+        <> ["  mov x0, x22", "  bl " <> symbol]
+        <> dispatchLines
+    )
 
 compileCase :: ValueEnv -> [Text] -> Text -> GrinValue -> GrinVar -> [GrinAlt] -> FunctionM ()
 compileCase env prefix label scrutinee binder alternatives = do
@@ -462,9 +493,9 @@ nodeHeader env node =
       label <- functionCodeLabel compileEnv functionName
       arity <- functionArity compileEnv functionName
       pure (3, InfoAddress label, arity)
-    GrinPrimitive name arity -> do
-      identifier <- primitiveId name
-      pure (4, InfoImmediate identifier, arity)
+    GrinPrimitive primOp -> do
+      identifier <- primitiveId primOp
+      pure (4, InfoImmediate identifier, primOpArity primOp)
     GrinForeign foreignCall -> do
       label <- foreignDescriptorLabel compileEnv foreignCall
       let arity = length (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
@@ -622,10 +653,17 @@ foreignDescriptorLabel env foreignCall =
     Right
     (Map.lookup (grinForeignCallName foreignCall) (compileForeignLabels env))
 
-primitiveId :: Text -> Either Arm64Error Int
-primitiveId name
-  | name == "realWorld#" = Right 1
-  | otherwise = Left (Arm64UnsupportedPrimitive name)
+primitiveId :: PrimOp -> Either Arm64Error Int
+primitiveId primOp =
+  case primOp of
+    PrimRealWorld -> Right 1
+    PrimFork -> Right 2
+    PrimYield -> Right 3
+    PrimNewMVar -> Right 4
+    PrimTakeMVar -> Right 5
+    PrimPutMVar -> Right 6
+    PrimDelay -> Right 7
+    _ -> Left (Arm64UnsupportedPrimitive (primOpName primOp))
 
 boundVars :: GrinExpr -> Set GrinVar
 boundVars expression =
@@ -642,6 +680,7 @@ boundVars expression =
     GrinDictSelect {} -> Set.empty
     GrinThrow _ -> Set.empty
     GrinCatch {} -> Set.empty
+    GrinScheduler {} -> Set.empty
   where
     altBoundVars alternative = Set.fromList (grinAltBinders alternative) <> boundVars (grinAltRhs alternative)
 
@@ -708,6 +747,8 @@ exprRuntimeReps expression =
     GrinThrow exception -> valueRuntimeReps exception
     GrinCatch runtimeRep action handler state ->
       runtimeRep : concatMap valueRuntimeReps [action, handler, state]
+    GrinScheduler runtimeRep _ arguments ->
+      runtimeRep : concatMap valueRuntimeReps arguments
   where
     altRuntimeReps alternative =
       map grinVarRuntimeRep (grinAltBinders alternative)

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -102,6 +102,32 @@ tests =
         case compileProgram "answer" program of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> assertBool "255 :: Int8# is stored as -1" ("ldr x0, =-1" `T.isInfixOf` assembly),
+      testCase "lowers scheduler operations to the stable RTS ABI" $ do
+        let answer = GrinVar "answer" 20 (BoxedRep Lifted)
+            entryFunction = FunctionName "entry_code"
+            schedulerFunction = FunctionName "scheduler_code"
+            state = GrinVar "state" 21 (TupleRep [])
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [],
+                  grinForeignCalls = [],
+                  grinCafs = [(answer, GrinNode (GrinThunk entryFunction) [])],
+                  grinFunctions =
+                    [ GrinFunction entryFunction [] IntRep (GrinReturn (GrinLitValue (GrinLitInt IntRep 0))),
+                      GrinFunction
+                        schedulerFunction
+                        [state]
+                        (TupleRep [])
+                        (GrinScheduler (TupleRep []) SchedulerYield [GrinVarValue state])
+                    ]
+                }
+        case compileProgram "answer" program of
+          Left err -> assertFailure ("native scheduler compilation failed: " <> show err)
+          Right assembly ->
+            assertBool
+              "calls yield RTS entry"
+              ("bl _aihc_prim_yield" `T.isInfixOf` assembly),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -45,6 +45,7 @@ import Aihc.Parser.Syntax
 import Aihc.Resolve (ResolveResult (..), resolve)
 import Aihc.Tc (TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
+import Aihc.Tc.Prim (PrimOp (..), primOpArity, primOpFromName)
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.State.Strict (runStateT)
@@ -189,9 +190,9 @@ dsForeignPrim :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
 dsForeignPrim tcAnn foreignDecl = do
   let name = unqualifiedNameText (foreignName foreignDecl)
       ty = tcAnnType tcAnn
-  arity <- validatePrimitiveImport name ty
+  primOp <- validatePrimitiveImport name ty
   unique <- freshUnique
-  pure (FcPrimitive (Var name unique ty) arity)
+  pure (FcPrimitive (Var name unique ty) primOp)
 
 dsForeignCcall :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
 dsForeignCcall tcAnn foreignDecl = do
@@ -242,15 +243,18 @@ marshalForeignType (TcTyCon (TyCon "CInt" 0) []) = pure FcForeignCInt
 marshalForeignType ty =
   desugarBug ("unsupported foreign import value type: " <> show ty)
 
-validatePrimitiveImport :: Text -> TcType -> DsM Int
+validatePrimitiveImport :: Text -> TcType -> DsM PrimOp
 validatePrimitiveImport name ty =
-  case Map.lookup name primitiveImportSpecs of
-    Nothing ->
+  case (primOpFromName name, Map.lookup name primitiveImportSpecs) of
+    (Nothing, _) ->
       desugarBug ("unknown foreign import prim: " <> T.unpack name)
-    Just spec
-      | primitiveSpecAccepts spec ty -> pure (primitiveSpecArity spec)
+    (Just primOp, Just spec)
+      | primitiveSpecArity spec /= primOpArity primOp ->
+          desugarBug ("internal arity mismatch for foreign import prim " <> T.unpack name)
+      | primitiveSpecAccepts spec ty -> pure primOp
       | otherwise ->
           desugarBug ("incorrect type for foreign import prim " <> T.unpack name)
+    (Just _, Nothing) -> desugarBug ("missing type specification for foreign import prim: " <> T.unpack name)
 
 data PrimitiveSpec = PrimitiveSpec
   { primitiveSpecArity :: !Int,
@@ -273,7 +277,13 @@ primitiveImportSpecs =
       ("catch#", PrimitiveSpec 3 isCatchPrimType),
       ("newMutVar#", PrimitiveSpec 2 isNewMutVarPrimType),
       ("readMutVar#", PrimitiveSpec 2 isReadMutVarPrimType),
-      ("writeMutVar#", PrimitiveSpec 3 isWriteMutVarPrimType)
+      ("writeMutVar#", PrimitiveSpec 3 isWriteMutVarPrimType),
+      ("fork#", PrimitiveSpec 2 isForkPrimType),
+      ("yield#", PrimitiveSpec 1 (typesEqual (TcFunTy statePrimRealWorldTy statePrimRealWorldTy))),
+      ("newMVar#", PrimitiveSpec 1 isNewMVarPrimType),
+      ("takeMVar#", PrimitiveSpec 2 isTakeMVarPrimType),
+      ("putMVar#", PrimitiveSpec 3 isPutMVarPrimType),
+      ("delay#", PrimitiveSpec 2 isDelayPrimType)
     ]
 
 intBinaryPrim :: PrimitiveSpec
@@ -366,6 +376,69 @@ isWriteMutVarPrimType ty =
         _ -> False
     _ -> False
 
+isForkPrimType :: TcType -> Bool
+isForkPrimType ty =
+  case collectForAlls ty of
+    ([resultVar], TcFunTy actionTy (TcFunTy stateTy resultTy)) ->
+      typesEqual statePrimRealWorldTy stateTy
+        && typesEqual
+          (TcFunTy statePrimRealWorldTy (unboxedTupleTy [statePrimRealWorldTy, TcTyVar resultVar]))
+          actionTy
+        && typesEqual
+          (unboxedTupleTy [statePrimRealWorldTy, threadIdPrimTy])
+          resultTy
+    _ -> False
+
+isNewMVarPrimType :: TcType -> Bool
+isNewMVarPrimType ty =
+  case collectForAlls ty of
+    (quantified, TcFunTy stateTy resultTy) ->
+      case stateDomain stateTy of
+        Just domainVar ->
+          case [valueVar | valueVar <- quantified, valueVar /= domainVar] of
+            [valueVar] ->
+              hasExactlyTyVars quantified [domainVar, valueVar]
+                && typesEqual
+                  (unboxedTupleTy [stateTy, mVarPrimTy domainVar (TcTyVar valueVar)])
+                  resultTy
+            _ -> False
+        Nothing -> False
+    _ -> False
+
+isTakeMVarPrimType :: TcType -> Bool
+isTakeMVarPrimType ty =
+  case collectForAlls ty of
+    (quantified, TcFunTy mVarTy (TcFunTy stateTy resultTy)) ->
+      case (mVarArgs mVarTy, stateDomain stateTy) of
+        (Just (domainVar, valueTy@(TcTyVar valueVar)), Just stateDomainVar) ->
+          domainVar == stateDomainVar
+            && hasExactlyTyVars quantified [domainVar, valueVar]
+            && typesEqual (unboxedTupleTy [stateTy, valueTy]) resultTy
+        _ -> False
+    _ -> False
+
+isPutMVarPrimType :: TcType -> Bool
+isPutMVarPrimType ty =
+  case collectForAlls ty of
+    (quantified, TcFunTy mVarTy (TcFunTy valueTy (TcFunTy stateTy resultTy))) ->
+      case (mVarArgs mVarTy, stateDomain stateTy) of
+        (Just (domainVar, mVarValueTy@(TcTyVar valueVar)), Just stateDomainVar) ->
+          domainVar == stateDomainVar
+            && hasExactlyTyVars quantified [domainVar, valueVar]
+            && typesEqual mVarValueTy valueTy
+            && typesEqual stateTy resultTy
+        _ -> False
+    _ -> False
+
+isDelayPrimType :: TcType -> Bool
+isDelayPrimType ty =
+  case collectForAlls ty of
+    ([domainVar], TcFunTy durationTy (TcFunTy stateTy resultTy)) ->
+      typesEqual intHashTy durationTy
+        && stateDomain stateTy == Just domainVar
+        && typesEqual stateTy resultTy
+    _ -> False
+
 stateDomain :: TcType -> Maybe TyVarId
 stateDomain (TcTyCon (TyCon "State#" 1) [TcTyVar domainVar]) = Just domainVar
 stateDomain _ = Nothing
@@ -378,6 +451,18 @@ mutVarArgs _ = Nothing
 mutVarPrimTy :: TyVarId -> TcType -> TcType
 mutVarPrimTy domainVar valueTy =
   TcTyCon (TyCon "MutVar#" 2) [TcTyVar domainVar, valueTy]
+
+mVarArgs :: TcType -> Maybe (TyVarId, TcType)
+mVarArgs (TcTyCon (TyCon "MVar#" 2) [TcTyVar domainVar, valueTy]) =
+  Just (domainVar, valueTy)
+mVarArgs _ = Nothing
+
+mVarPrimTy :: TyVarId -> TcType -> TcType
+mVarPrimTy domainVar valueTy =
+  TcTyCon (TyCon "MVar#" 2) [TcTyVar domainVar, valueTy]
+
+threadIdPrimTy :: TcType
+threadIdPrimTy = TcTyCon (TyCon "ThreadId#" 0) []
 
 hasExactlyTyVars :: [TyVarId] -> [TyVarId] -> Bool
 hasExactlyTyVars actual expected =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -12,6 +12,7 @@ module Aihc.Fc.Eval
 where
 
 import Aihc.Fc.Syntax
+import Aihc.Tc.Prim (primOpArity, primOpName)
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (zipWithM, (<=<))
@@ -82,8 +83,8 @@ evalProgramBinding name program = runExceptT $
       [(varName (fcForeignCallVar foreignCall), VForeign foreignCall [])]
     foreignTopBindingValues _ =
       []
-    primitiveTopBindingValues (FcPrimitive var arity) =
-      [(varName var, VPrim (varName var) arity [])]
+    primitiveTopBindingValues (FcPrimitive var primOp) =
+      [(varName var, VPrim (primOpName primOp) (primOpArity primOp) [])]
     primitiveTopBindingValues _ =
       []
     topBindingValues (FcTopBind (FcNonRec var expr)) =

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -19,6 +19,7 @@ module Aihc.Fc.Pretty
 where
 
 import Aihc.Fc.Syntax
+import Aihc.Tc.Prim (primOpArity)
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..))
 import Data.List (intercalate)
 import Data.Text (Text)
@@ -53,11 +54,11 @@ renderTopBind (FcNewtype tyName tyVars conName fieldTy) =
     ++ T.unpack conName
     ++ " "
     ++ renderTypePrec True fieldTy
-renderTopBind (FcPrimitive var arity) =
+renderTopBind (FcPrimitive var primOp) =
   "foreign prim "
     ++ renderVar var
     ++ "/"
-    ++ show arity
+    ++ show (primOpArity primOp)
     ++ " : "
     ++ renderType (varType var)
 renderTopBind (FcForeignImport foreignCall) =

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -40,6 +40,7 @@ module Aihc.Fc.Syntax
 where
 
 import Aihc.Tc.Evidence (Coercion)
+import Aihc.Tc.Prim (PrimOp)
 import Aihc.Tc.Types
   ( RuntimeRep (..),
     TcType (..),
@@ -66,7 +67,7 @@ data FcTopBind
     -- single constructor.
     FcNewtype !Text ![TyVarId] !Text !TcType
   | -- | A primitive imported by @foreign import prim@.
-    FcPrimitive !Var !Int
+    FcPrimitive !Var !PrimOp
   | -- | A C function imported by @foreign import ccall@.
     FcForeignImport !FcForeignCall
   | -- | Value binding.

--- a/components/aihc-fc/test/Test/Fixtures/golden/scheduler-primitives.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/scheduler-primitives.yaml
@@ -1,0 +1,45 @@
+expected: |-
+  data State#
+
+  data RealWorld
+
+  data MVar#
+
+  data ThreadId#
+
+  foreign prim fork#/2 : ∀ a. ((State# RealWorld) → (#,#) (State# RealWorld) a) → (State# RealWorld) → (#,#) (State# RealWorld) ThreadId#
+
+  foreign prim yield#/1 : (State# RealWorld) → State# RealWorld
+
+  foreign prim newMVar#/1 : ∀ d a. (State# d) → (#,#) (State# d) (MVar# d a)
+
+  foreign prim takeMVar#/2 : ∀ d a. (MVar# d a) → (State# d) → (#,#) (State# d) a
+
+  foreign prim putMVar#/3 : ∀ d a. (MVar# d a) → a → (State# d) → State# d
+
+  foreign prim delay#/2 : ∀ d. Int# → (State# d) → State# d
+extensions:
+- EmptyDataDecls
+- GHCForeignImportPrim
+- MagicHash
+- UnboxedTuples
+modules:
+- |
+  module Test where
+
+  data State# s
+  data RealWorld
+  data MVar# d a
+  data ThreadId#
+
+  foreign import prim fork# ::
+    (State# RealWorld -> (# State# RealWorld, a #)) ->
+    State# RealWorld ->
+    (# State# RealWorld, ThreadId# #)
+  foreign import prim yield# :: State# RealWorld -> State# RealWorld
+  foreign import prim newMVar# :: State# d -> (# State# d, MVar# d a #)
+  foreign import prim takeMVar# :: MVar# d a -> State# d -> (# State# d, a #)
+  foreign import prim putMVar# :: MVar# d a -> a -> State# d -> State# d
+  foreign import prim delay# :: Int# -> State# d -> State# d
+reason: validates and preserves the exact scheduler primitive schemes
+status: pass

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -12,6 +12,7 @@ synopsis: Strict graph-reduction intermediate language for AIHC
 library
   exposed-modules:
     Aihc.Grin
+    Aihc.Grin.Cps
     Aihc.Grin.Interpret
     Aihc.Grin.Lint
     Aihc.Grin.Lower

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -1,6 +1,7 @@
 -- | AIHC's strict Graph Reduction Intermediate Notation dialect.
 module Aihc.Grin
   ( module Aihc.Grin.Syntax,
+    module Aihc.Grin.Cps,
     lowerProgram,
     lintProgram,
     GrinLintError (..),
@@ -12,6 +13,7 @@ module Aihc.Grin
   )
 where
 
+import Aihc.Grin.Cps
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
 import Aihc.Grin.Lower (lowerProgram)

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -1,0 +1,105 @@
+-- | Explicit continuation form for runtime-explicit GRIN.
+--
+-- The transformation removes 'GrinBind' from the control spine. Every
+-- operation receives its success continuation, including scheduler
+-- operations that may either complete immediately or suspend the fiber.
+module Aihc.Grin.Cps
+  ( CpsExpr (..),
+    CpsContinuation (..),
+    CpsOperation (..),
+    CpsAlt (..),
+    cpsExpr,
+    schedulerContinuations,
+  )
+where
+
+import Aihc.Grin.Syntax
+import Aihc.Tc.Types (RuntimeRep)
+
+data CpsExpr
+  = CpsContinue !CpsContinuation !GrinValue
+  | CpsOperation !CpsOperation !CpsContinuation
+  | CpsStoreRec ![(GrinVar, GrinNode)] !CpsExpr
+  | CpsCase !GrinValue !GrinVar ![CpsAlt]
+  deriving (Eq, Show)
+
+data CpsContinuation
+  = CpsReturn
+  | CpsBind !GrinVar !CpsExpr
+  deriving (Eq, Show)
+
+data CpsOperation
+  = CpsStore !GrinNode
+  | CpsFetch !RuntimeRep !GrinValue
+  | CpsUpdate !GrinValue !GrinValue
+  | CpsEval !RuntimeRep !GrinValue
+  | CpsApply !RuntimeRep !GrinValue !GrinValue
+  | CpsDictSelect !RuntimeRep !GrinValue !Int
+  | CpsThrow !GrinValue
+  | CpsCatch !RuntimeRep !GrinValue !GrinValue !GrinValue
+  | CpsScheduler !RuntimeRep !SchedulerPrimOp ![GrinValue]
+  deriving (Eq, Show)
+
+data CpsAlt = CpsAlt
+  { cpsAltCon :: !GrinAltCon,
+    cpsAltBinders :: ![GrinVar],
+    cpsAltRhs :: !CpsExpr
+  }
+  deriving (Eq, Show)
+
+cpsExpr :: GrinExpr -> CpsExpr
+cpsExpr expression = transform expression CpsReturn
+
+transform :: GrinExpr -> CpsContinuation -> CpsExpr
+transform expression continuation =
+  case expression of
+    GrinReturn value -> CpsContinue continuation value
+    GrinBind binder valueExpression body ->
+      transform valueExpression (CpsBind binder (transform body continuation))
+    GrinStore node -> CpsOperation (CpsStore node) continuation
+    GrinStoreRec bindings body -> CpsStoreRec bindings (transform body continuation)
+    GrinFetch runtimeRep pointer -> CpsOperation (CpsFetch runtimeRep pointer) continuation
+    GrinUpdate pointer value -> CpsOperation (CpsUpdate pointer value) continuation
+    GrinEval runtimeRep value -> CpsOperation (CpsEval runtimeRep value) continuation
+    GrinApply runtimeRep function argument ->
+      CpsOperation (CpsApply runtimeRep function argument) continuation
+    GrinCase scrutinee binder alternatives ->
+      CpsCase scrutinee binder (map (transformAlt continuation) alternatives)
+    GrinDictSelect runtimeRep dictionary index ->
+      CpsOperation (CpsDictSelect runtimeRep dictionary index) continuation
+    GrinThrow exception -> CpsOperation (CpsThrow exception) continuation
+    GrinCatch runtimeRep action handler state ->
+      CpsOperation (CpsCatch runtimeRep action handler state) continuation
+    GrinScheduler runtimeRep schedulerOp arguments ->
+      CpsOperation (CpsScheduler runtimeRep schedulerOp arguments) continuation
+
+transformAlt :: CpsContinuation -> GrinAlt -> CpsAlt
+transformAlt continuation alternative =
+  CpsAlt
+    { cpsAltCon = grinAltCon alternative,
+      cpsAltBinders = grinAltBinders alternative,
+      cpsAltRhs = transform (grinAltRhs alternative) continuation
+    }
+
+-- | Collect scheduler operations together with the continuation saved when
+-- the operation suspends. This is useful to validate backend lowering and GC
+-- root metadata.
+schedulerContinuations :: CpsExpr -> [(SchedulerPrimOp, CpsContinuation)]
+schedulerContinuations expression =
+  case expression of
+    CpsContinue continuation _ -> continuationSchedulers continuation
+    CpsOperation operation continuation ->
+      operationScheduler operation continuation <> continuationSchedulers continuation
+    CpsStoreRec _ body -> schedulerContinuations body
+    CpsCase _ _ alternatives -> concatMap (schedulerContinuations . cpsAltRhs) alternatives
+  where
+    operationScheduler operation continuation =
+      case operation of
+        CpsScheduler _ schedulerOp _ -> [(schedulerOp, continuation)]
+        _ -> []
+
+continuationSchedulers :: CpsContinuation -> [(SchedulerPrimOp, CpsContinuation)]
+continuationSchedulers continuation =
+  case continuation of
+    CpsReturn -> []
+    CpsBind _ body -> schedulerContinuations body

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Reference interpreter for strict GRIN programs.
@@ -8,24 +9,31 @@ module Aihc.Grin.Interpret
   )
 where
 
+import Aihc.Grin.Cps
 import Aihc.Grin.Syntax
+import Aihc.Tc.Prim (PrimOp, primOpArity, primOpName)
 import Aihc.Tc.Types (RuntimeRep (..))
+import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
 import Control.Monad.Trans.State.Strict (StateT, gets, modify', runStateT)
 import Data.Char qualified as Char
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
+import Data.List (insertBy)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Sequence (Seq (..), (|>))
+import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
 import Foreign.LibFFI (Arg, argCInt, callFFI, retCInt)
 import Foreign.Ptr (FunPtr)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
 data InterpretError
@@ -45,6 +53,7 @@ data InterpretError
   | InterpretExpectedLocation !RuntimeValue
   | InterpretInvalidLocation !Int
   | InterpretBlackhole !Int
+  | InterpretDeadlock
   | InterpretRaisedException !Text
   deriving (Eq, Show)
 
@@ -53,6 +62,8 @@ data RuntimeValue
   | RuntimeNode !GrinNodeTag ![RuntimeValue]
   | RuntimeLocation !Int
   | RuntimeMutVar !GrinMutVar
+  | RuntimeMVar !Int
+  | RuntimeThreadId !Int
   | RuntimeStateToken
   deriving (Eq, Show)
 
@@ -77,30 +88,87 @@ data Machine = Machine
     machineFunctions :: !(Map FunctionName GrinFunction),
     machineGlobals :: !(Map Text RuntimeValue),
     machineHeap :: !(IntMap HeapCell),
-    machineNextLocation :: !Int
+    machineNextLocation :: !Int,
+    machineRunnable :: !(Seq (SchedulerM ())),
+    machineMVars :: !(IntMap MVarState),
+    machineNextMVar :: !Int,
+    machineNextThreadId :: !Int,
+    machineTimers :: ![Timer],
+    machineNextTimerSequence :: !Word64,
+    machineResult :: !(Maybe (Either EvalFailure Text))
   }
 
 data EvalFailure
   = EvalInterpret !InterpretError
   | EvalRaised !RuntimeValue
 
-type EvalM = ExceptT EvalFailure (StateT Machine IO)
+type SchedulerM = StateT Machine IO
+
+newtype EvalM a = EvalM
+  { runEvalM :: (Either EvalFailure a -> SchedulerM ()) -> SchedulerM ()
+  }
+
+instance Functor EvalM where
+  fmap function action =
+    EvalM $ \continuation ->
+      runEvalM action $ \case
+        Left failure -> continuation (Left failure)
+        Right value -> continuation (Right (function value))
+
+instance Applicative EvalM where
+  pure value = EvalM (\continuation -> continuation (Right value))
+  function <*> argument = do
+    applied <- function
+    applied <$> argument
+
+instance Monad EvalM where
+  action >>= next =
+    EvalM $ \continuation ->
+      runEvalM action $ \case
+        Left failure -> continuation (Left failure)
+        Right value -> runEvalM (next value) continuation
+
+instance MonadFail EvalM where
+  fail message = error ("GRIN interpreter invariant failed: " <> message)
+
+data MVarState = MVarState
+  { mvarValue :: !(Maybe RuntimeValue),
+    mvarTakers :: !(Seq Taker),
+    mvarPutters :: !(Seq Putter)
+  }
+
+data Taker
+  = Taker
+      !RuntimeValue
+      !(Either EvalFailure RuntimeValue -> SchedulerM ())
+
+data Putter
+  = Putter
+      !RuntimeValue
+      !RuntimeValue
+      !(Either EvalFailure RuntimeValue -> SchedulerM ())
+
+data Timer = Timer
+  { timerDeadline :: !Word64,
+    timerSequence :: !Word64,
+    timerAction :: !(SchedulerM ())
+  }
 
 -- | Interpret and render a named top-level binding using the raw constructor
 -- representation shared by the compiler pipeline evaluation fixtures.
 interpretProgramBinding :: Text -> GrinProgram -> IO (Either InterpretError Text)
 interpretProgramBinding name program = do
   let machine = initialMachine program
-  (result, finalMachine) <- runStateT (runExceptT action) machine
-  case result of
-    Right rendered -> pure (Right rendered)
-    Left (EvalInterpret err) -> pure (Left err)
-    Left (EvalRaised exception) -> do
-      (renderResult, _) <- runStateT (runExceptT (renderRawValueM exception)) finalMachine
-      pure $
-        case renderResult of
-          Right rendered -> Left (InterpretRaisedException rendered)
-          Left _ -> Left (InterpretRaisedException (T.pack (show exception)))
+  (_, finalMachine) <-
+    runStateT
+      (enqueueAction (runEvalM action finishMain) >> runScheduler)
+      machine
+  case machineResult finalMachine of
+    Just (Right rendered) -> pure (Right rendered)
+    Just (Left (EvalInterpret err)) -> pure (Left err)
+    Just (Left (EvalRaised exception)) ->
+      pure (Left (InterpretRaisedException (T.pack (show exception))))
+    Nothing -> pure (Left InterpretDeadlock)
   where
     action = do
       globals <- getsMachine machineGlobals
@@ -109,6 +177,7 @@ interpretProgramBinding name program = do
           Just binding -> pure binding
           Nothing -> throwInterpret (InterpretMissingBinding name)
       forceValue value >>= runIOValue >>= renderRawValueM
+    finishMain result = modify' (\machine -> machine {machineResult = Just result})
 
 initialMachine :: GrinProgram -> Machine
 initialMachine program =
@@ -125,7 +194,14 @@ initialMachine program =
           [ (location, HeapSuspended cafEnv node)
           | ((_, node), location) <- zip cafs [0 ..]
           ],
-      machineNextLocation = length cafs
+      machineNextLocation = length cafs,
+      machineRunnable = Seq.empty,
+      machineMVars = IntMap.empty,
+      machineNextMVar = 0,
+      machineNextThreadId = 1,
+      machineTimers = [],
+      machineNextTimerSequence = 0,
+      machineResult = Nothing
     }
   where
     cafs = grinCafs program
@@ -142,8 +218,8 @@ initialMachine program =
             | foreignCall <- grinForeignCalls program
             ],
           Map.fromList
-            [ (grinVarName var, RuntimeNode (GrinPrimitive (grinVarName var) arity) [])
-            | (var, arity) <- grinPrimitives program
+            [ (grinVarName var, RuntimeNode (GrinPrimitive primOp) [])
+            | (var, primOp) <- grinPrimitives program
             ],
           Map.fromList
             [ (constructor, RuntimeNode (GrinConstructor constructor) [])
@@ -151,39 +227,107 @@ initialMachine program =
             ]
         ]
 
-evalExpr :: Env -> GrinExpr -> EvalM RuntimeValue
-evalExpr env expr =
-  case expr of
-    GrinReturn value -> evalValue env value
-    GrinBind var valueExpr body -> do
-      value <- evalExpr env valueExpr
-      evalExpr (Map.insert var value env) body
-    GrinStore node ->
-      allocateCell (HeapSuspended env node)
-    GrinStoreRec bindings body -> do
+enqueueAction :: SchedulerM () -> SchedulerM ()
+enqueueAction action =
+  modify' (\machine -> machine {machineRunnable = machineRunnable machine |> action})
+
+runScheduler :: SchedulerM ()
+runScheduler = do
+  completed <- gets machineResult
+  case completed of
+    Just _ -> pure ()
+    Nothing -> do
+      now <- lift getMonotonicTimeNSec
+      drainDueTimers now
+      runnable <- gets machineRunnable
+      case Seq.viewl runnable of
+        action Seq.:< rest -> do
+          modify' (\machine -> machine {machineRunnable = rest})
+          action
+          runScheduler
+        Seq.EmptyL -> do
+          timers <- gets machineTimers
+          case timers of
+            [] ->
+              modify'
+                ( \machine ->
+                    machine
+                      { machineResult = Just (Left (EvalInterpret InterpretDeadlock))
+                      }
+                )
+            Timer deadline _ _ : _ -> do
+              waitForDeadline now deadline
+              runScheduler
+
+drainDueTimers :: Word64 -> SchedulerM ()
+drainDueTimers now = do
+  timers <- gets machineTimers
+  let (due, pending) = span ((<= now) . timerDeadline) timers
+  modify'
+    ( \machine ->
+        machine
+          { machineTimers = pending,
+            machineRunnable = foldl (|>) (machineRunnable machine) (map timerAction due)
+          }
+    )
+
+waitForDeadline :: Word64 -> Word64 -> SchedulerM ()
+waitForDeadline now deadline
+  | deadline <= now = pure ()
+  | otherwise =
+      lift (threadDelay (fromIntegral (min (fromIntegral (maxBound :: Int)) microseconds)))
+  where
+    nanoseconds = deadline - now
+    microseconds = max 1 ((nanoseconds + 999) `div` 1000)
+
+insertTimer :: Timer -> [Timer] -> [Timer]
+insertTimer = insertBy compareTimer
+  where
+    compareTimer left right =
+      compare
+        (timerDeadline left, timerSequence left)
+        (timerDeadline right, timerSequence right)
+
+evalCpsExpr :: Env -> CpsExpr -> EvalM RuntimeValue
+evalCpsExpr env expression =
+  case expression of
+    CpsContinue continuation value ->
+      evalValue env value >>= continueCps env continuation
+    CpsOperation operation continuation ->
+      evalCpsOperation env operation >>= continueCps env continuation
+    CpsStoreRec bindings body -> do
       locations <- mapM (const (allocateLocation HeapBlackhole)) bindings
       let recursiveBindings = zip (map fst bindings) (map RuntimeLocation locations)
           recursiveEnv = Map.fromList recursiveBindings `Map.union` env
       mapM_
         (\((_, node), location) -> writeCell location (HeapSuspended recursiveEnv node))
         (zip bindings locations)
-      evalExpr recursiveEnv body
-    GrinFetch _ pointer ->
-      evalValue env pointer >>= fetchValue
-    GrinUpdate pointer value -> do
+      evalCpsExpr recursiveEnv body
+    CpsCase scrutinee binder alternatives -> do
+      value <- evalValue env scrutinee >>= forceValue
+      matchCpsAlternative (Map.insert binder value env) value alternatives
+
+continueCps :: Env -> CpsContinuation -> RuntimeValue -> EvalM RuntimeValue
+continueCps env continuation value =
+  case continuation of
+    CpsReturn -> pure value
+    CpsBind binder body -> evalCpsExpr (Map.insert binder value env) body
+
+evalCpsOperation :: Env -> CpsOperation -> EvalM RuntimeValue
+evalCpsOperation env operation =
+  case operation of
+    CpsStore node -> allocateCell (HeapSuspended env node)
+    CpsFetch _ pointer -> evalValue env pointer >>= fetchValue
+    CpsUpdate pointer value -> do
       pointerValue <- evalValue env pointer
       updatedValue <- evalValue env value
       updateValue pointerValue updatedValue
-    GrinEval _ value ->
-      evalValue env value >>= forceValue
-    GrinApply _ function argument -> do
+    CpsEval _ value -> evalValue env value >>= forceValue
+    CpsApply _ function argument -> do
       functionValue <- evalValue env function
       argumentValue <- evalValue env argument
       applyValue functionValue argumentValue
-    GrinCase scrutinee binder alternatives -> do
-      value <- evalValue env scrutinee >>= forceValue
-      matchAlternative (Map.insert binder value env) value alternatives
-    GrinDictSelect _ dictionary index -> do
+    CpsDictSelect _ dictionary index -> do
       dictionaryValue <- evalValue env dictionary >>= forceValue
       case dictionaryValue of
         RuntimeNode GrinDictionary fields
@@ -192,14 +336,17 @@ evalExpr env expr =
               forceValue (fields !! index)
           | otherwise -> throwInterpret (InterpretInvalidDictSelect dictionaryValue index)
         other -> throwInterpret (InterpretInvalidDictSelect other index)
-    GrinThrow exception -> do
+    CpsThrow exception -> do
       exceptionValue <- evalValue env exception >>= forceValue
       throwE (EvalRaised exceptionValue)
-    GrinCatch _ action handler state -> do
+    CpsCatch _ action handler state -> do
       actionValue <- evalValue env action
       handlerValue <- evalValue env handler
       stateValue <- evalValue env state
       applyValue actionValue stateValue `catchE` handleRaised handlerValue stateValue
+    CpsScheduler _ schedulerOp arguments -> do
+      argumentValues <- mapM (evalValue env) arguments
+      evalScheduler schedulerOp argumentValues
 
 handleRaised :: RuntimeValue -> RuntimeValue -> EvalFailure -> EvalM RuntimeValue
 handleRaised handler state failure =
@@ -208,6 +355,135 @@ handleRaised handler state failure =
       handlerWithException <- applyValue handler exception
       applyValue handlerWithException state
     EvalInterpret err -> throwE (EvalInterpret err)
+
+evalScheduler :: SchedulerPrimOp -> [RuntimeValue] -> EvalM RuntimeValue
+evalScheduler SchedulerFork [action, state] =
+  EvalM $ \parentContinuation -> do
+    threadId <- gets machineNextThreadId
+    modify' (\machine -> machine {machineNextThreadId = threadId + 1})
+    enqueueAction
+      ( runEvalM
+          (applyValue action state)
+          (const (pure ()))
+      )
+    parentContinuation
+      ( Right
+          ( RuntimeNode
+              (GrinConstructor "(#,#)")
+              [state, RuntimeThreadId threadId]
+          )
+      )
+evalScheduler SchedulerYield [state] =
+  EvalM $ \continuation -> enqueueAction (continuation (Right state))
+evalScheduler SchedulerNewMVar [state] =
+  EvalM $ \continuation -> do
+    identifier <- gets machineNextMVar
+    modify'
+      ( \machine ->
+          machine
+            { machineMVars =
+                IntMap.insert identifier emptyMVarState (machineMVars machine),
+              machineNextMVar = identifier + 1
+            }
+      )
+    continuation
+      ( Right
+          ( RuntimeNode
+              (GrinConstructor "(#,#)")
+              [state, RuntimeMVar identifier]
+          )
+      )
+evalScheduler SchedulerTakeMVar [RuntimeMVar identifier, state] =
+  EvalM $ \continuation -> do
+    mvar <- lookupMVar identifier
+    case mvarValue mvar of
+      Nothing ->
+        updateMVar
+          identifier
+          mvar {mvarTakers = mvarTakers mvar |> Taker state continuation}
+      Just value ->
+        case Seq.viewl (mvarPutters mvar) of
+          Putter nextValue putterState resumePutter Seq.:< remainingPutters -> do
+            updateMVar
+              identifier
+              mvar
+                { mvarValue = Just nextValue,
+                  mvarPutters = remainingPutters
+                }
+            enqueueAction (resumePutter (Right putterState))
+            continuation (Right (stateValueTuple state value))
+          Seq.EmptyL -> do
+            updateMVar identifier mvar {mvarValue = Nothing}
+            continuation (Right (stateValueTuple state value))
+evalScheduler SchedulerPutMVar [RuntimeMVar identifier, value, state] =
+  EvalM $ \continuation -> do
+    mvar <- lookupMVar identifier
+    case Seq.viewl (mvarTakers mvar) of
+      Taker takerStateValue resumeTaker Seq.:< remainingTakers -> do
+        updateMVar identifier mvar {mvarTakers = remainingTakers}
+        enqueueAction (resumeTaker (Right (stateValueTuple takerStateValue value)))
+        continuation (Right state)
+      Seq.EmptyL ->
+        case mvarValue mvar of
+          Nothing -> do
+            updateMVar identifier mvar {mvarValue = Just value}
+            continuation (Right state)
+          Just _ ->
+            updateMVar
+              identifier
+              mvar {mvarPutters = mvarPutters mvar |> Putter value state continuation}
+evalScheduler SchedulerDelay [RuntimeLit (GrinLitInt _ microseconds), state]
+  | microseconds <= 0 = pure state
+  | otherwise =
+      EvalM $ \continuation -> do
+        now <- lift getMonotonicTimeNSec
+        sequenceNumber <- gets machineNextTimerSequence
+        let duration = saturatingMicrosecondsToNanoseconds microseconds
+            deadline = saturatingAdd now duration
+            timer = Timer deadline sequenceNumber (continuation (Right state))
+        modify'
+          ( \machine ->
+              machine
+                { machineTimers = insertTimer timer (machineTimers machine),
+                  machineNextTimerSequence = sequenceNumber + 1
+                }
+          )
+evalScheduler schedulerOp arguments =
+  throwInterpret
+    ( InterpretPrimitiveArity
+        (T.pack (show schedulerOp))
+        (length arguments)
+    )
+
+emptyMVarState :: MVarState
+emptyMVarState = MVarState Nothing Seq.empty Seq.empty
+
+lookupMVar :: Int -> SchedulerM MVarState
+lookupMVar identifier = do
+  mvars <- gets machineMVars
+  case IntMap.lookup identifier mvars of
+    Just mvar -> pure mvar
+    Nothing -> error ("GRIN scheduler referenced unknown MVar " <> show identifier)
+
+updateMVar :: Int -> MVarState -> SchedulerM ()
+updateMVar identifier mvar =
+  modify'
+    ( \machine ->
+        machine {machineMVars = IntMap.insert identifier mvar (machineMVars machine)}
+    )
+
+stateValueTuple :: RuntimeValue -> RuntimeValue -> RuntimeValue
+stateValueTuple state value =
+  RuntimeNode (GrinConstructor "(#,#)") [state, value]
+
+saturatingMicrosecondsToNanoseconds :: Integer -> Word64
+saturatingMicrosecondsToNanoseconds microseconds =
+  fromInteger (min (toInteger (maxBound :: Word64)) (microseconds * 1000))
+
+saturatingAdd :: Word64 -> Word64 -> Word64
+saturatingAdd left right
+  | maxBound - left < right = maxBound
+  | otherwise = left + right
 
 evalValue :: Env -> GrinValue -> EvalM RuntimeValue
 evalValue env value =
@@ -279,7 +555,8 @@ forceValue value =
     RuntimeNode (GrinForeign foreignCall) []
       | null (grinForeignArgumentTypes (grinForeignCallSignature foreignCall)) ->
           completeForeignCall foreignCall []
-    RuntimeNode (GrinPrimitive name 0) [] -> evalPrimitive name []
+    RuntimeNode (GrinPrimitive primOp) []
+      | primOpArity primOp == 0 -> evalPrimitive (primOpName primOp) []
     _ -> pure value
 
 forceLocation :: Int -> EvalM RuntimeValue
@@ -315,8 +592,8 @@ applyValue function argument = do
       callFunction functionName (fields <> [argument])
     RuntimeNode constructor@(GrinConstructor _) fields ->
       pure (RuntimeNode constructor (fields <> [argument]))
-    RuntimeNode (GrinPrimitive name arity) fields ->
-      applyPrimitive name arity (fields <> [argument])
+    RuntimeNode (GrinPrimitive primOp) fields ->
+      applyPrimitive primOp (fields <> [argument])
     RuntimeNode (GrinForeign foreignCall) fields ->
       applyForeign foreignCall (fields <> [argument])
     RuntimeNode (GrinForeignIOAction foreignCall) fields -> do
@@ -332,14 +609,17 @@ callFunction functionName arguments = do
     Just function ->
       let parameters = grinFunctionParameters function
        in if length parameters == length arguments
-            then evalExpr (Map.fromList (zip parameters arguments)) (grinFunctionBody function)
+            then evalCpsExpr (Map.fromList (zip parameters arguments)) (cpsExpr (grinFunctionBody function))
             else throwInterpret (InterpretFunctionArity functionName (length parameters) (length arguments))
 
-applyPrimitive :: Text -> Int -> [RuntimeValue] -> EvalM RuntimeValue
-applyPrimitive name arity arguments
-  | length arguments < arity = pure (RuntimeNode (GrinPrimitive name arity) arguments)
+applyPrimitive :: PrimOp -> [RuntimeValue] -> EvalM RuntimeValue
+applyPrimitive primOp arguments
+  | length arguments < arity = pure (RuntimeNode (GrinPrimitive primOp) arguments)
   | length arguments == arity = evalPrimitive name arguments
   | otherwise = throwInterpret (InterpretPrimitiveArity name (length arguments))
+  where
+    name = primOpName primOp
+    arity = primOpArity primOp
 
 evalPrimitive :: Text -> [RuntimeValue] -> EvalM RuntimeValue
 evalPrimitive "+#" [left, right] = evalIntPrimitive "+#" (+) left right
@@ -500,26 +780,26 @@ runIOValue value =
         other -> throwInterpret (InterpretInvalidIOResult other)
     _ -> pure value
 
-matchAlternative :: Env -> RuntimeValue -> [GrinAlt] -> EvalM RuntimeValue
-matchAlternative env value alternatives =
+matchCpsAlternative :: Env -> RuntimeValue -> [CpsAlt] -> EvalM RuntimeValue
+matchCpsAlternative env value alternatives =
   case alternatives of
     [] -> throwInterpret (InterpretNoMatchingAlternative value)
     alt : rest ->
-      case matchAlt value alt of
-        Just bindings -> evalExpr (bindings `Map.union` env) (grinAltRhs alt)
-        Nothing -> matchAlternative env value rest
+      case matchCpsAlt value alt of
+        Just bindings -> evalCpsExpr (bindings `Map.union` env) (cpsAltRhs alt)
+        Nothing -> matchCpsAlternative env value rest
 
-matchAlt :: RuntimeValue -> GrinAlt -> Maybe Env
-matchAlt value alt =
-  case (grinAltCon alt, value) of
+matchCpsAlt :: RuntimeValue -> CpsAlt -> Maybe Env
+matchCpsAlt value alt =
+  case (cpsAltCon alt, value) of
     (GrinDefaultAlt, _) ->
-      Just (Map.fromList [(var, value) | var <- grinAltBinders alt])
+      Just (Map.fromList [(var, value) | var <- cpsAltBinders alt])
     (GrinLitAlt expected, RuntimeLit actual)
       | expected == actual -> Just Map.empty
     (GrinDataAlt expected, RuntimeNode (GrinConstructor actual) fields)
       | expected == actual,
-        length fields == length (grinAltBinders alt) ->
-          Just (Map.fromList (zip (grinAltBinders alt) fields))
+        length fields == length (cpsAltBinders alt) ->
+          Just (Map.fromList (zip (cpsAltBinders alt) fields))
     _ -> Nothing
 
 renderRawValueM :: RuntimeValue -> EvalM Text
@@ -538,12 +818,14 @@ renderRawValueM value = do
       pure (T.unwords (name : renderedArguments))
     RuntimeNode GrinDictionary _ -> pure "<dictionary>"
     RuntimeNode GrinClosure {} _ -> pure "<function>"
-    RuntimeNode GrinPrimitive {} _ -> pure "<function>"
+    RuntimeNode (GrinPrimitive _) _ -> pure "<function>"
     RuntimeNode GrinForeign {} _ -> pure "<function>"
     RuntimeNode GrinForeignIOAction {} _ -> pure "<io action>"
     RuntimeNode GrinThunk {} _ -> pure "<thunk>"
     RuntimeLocation _ -> renderRawValueM forced
     RuntimeMutVar {} -> pure "<mutvar>"
+    RuntimeMVar {} -> pure "<mvar>"
+    RuntimeThreadId identifier -> pure ("<thread " <> T.pack (show identifier) <> ">")
     RuntimeStateToken -> pure "<state>"
 
 renderRawArgument :: RuntimeValue -> EvalM Text
@@ -582,11 +864,24 @@ isTupleConstructor name arity =
 throwInterpret :: InterpretError -> EvalM value
 throwInterpret = throwE . EvalInterpret
 
+throwE :: EvalFailure -> EvalM value
+throwE failure = EvalM (\continuation -> continuation (Left failure))
+
+catchE :: EvalM value -> (EvalFailure -> EvalM value) -> EvalM value
+catchE action handler =
+  EvalM $ \continuation ->
+    runEvalM action $ \case
+      Left failure -> runEvalM (handler failure) continuation
+      Right value -> continuation (Right value)
+
 liftEvalIO :: IO value -> EvalM value
-liftEvalIO = lift . lift
+liftEvalIO action =
+  EvalM $ \continuation -> lift action >>= continuation . Right
 
 getsMachine :: (Machine -> value) -> EvalM value
-getsMachine = lift . gets
+getsMachine project =
+  EvalM $ \continuation -> gets project >>= continuation . Right
 
 modifyMachine :: (Machine -> Machine) -> EvalM ()
-modifyMachine = lift . modify'
+modifyMachine update =
+  EvalM $ \continuation -> modify' update >> continuation (Right ())

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -24,6 +24,7 @@ data GrinLintError
   | GrinLintRepresentationMismatch !String !RuntimeRep !RuntimeRep
   | GrinLintEvalNonLifted !RuntimeRep
   | GrinLintConstructorLayout !Text ![RuntimeRep] ![RuntimeRep]
+  | GrinLintSchedulerArity !SchedulerPrimOp !Int !Int
   deriving (Eq, Show)
 
 data LintEnv = LintEnv
@@ -113,6 +114,12 @@ lintExpr env bound expr =
       lintValue env bound action
         <> lintValue env bound handler
         <> lintValue env bound state
+    GrinScheduler _ schedulerOp arguments ->
+      let expected = schedulerArity schedulerOp
+       in [ GrinLintSchedulerArity schedulerOp expected (length arguments)
+          | length arguments /= expected
+          ]
+            <> concatMap (lintValue env bound) arguments
   where
     bindRepresentationErrors var valueExpr =
       case exprRuntimeRep valueExpr of
@@ -194,3 +201,14 @@ exprRuntimeRep expr =
     GrinDictSelect runtimeRep _ _ -> Just runtimeRep
     GrinThrow {} -> Nothing
     GrinCatch runtimeRep _ _ _ -> Just runtimeRep
+    GrinScheduler runtimeRep _ _ -> Just runtimeRep
+
+schedulerArity :: SchedulerPrimOp -> Int
+schedulerArity schedulerOp =
+  case schedulerOp of
+    SchedulerFork -> 2
+    SchedulerYield -> 1
+    SchedulerNewMVar -> 1
+    SchedulerTakeMVar -> 2
+    SchedulerPutMVar -> 3
+    SchedulerDelay -> 2

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -9,6 +9,7 @@ where
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Syntax
+import Aihc.Tc.Prim (PrimOp, primOpArity, primOpName, schedulerPrimOp)
 import Aihc.Tc.Types
   ( RuntimeRep,
     TcType (..),
@@ -28,7 +29,7 @@ data LowerState = LowerState
   { lowerNextUnique :: !Int,
     lowerNextFunction :: !Int,
     lowerFunctionsRev :: ![GrinFunction],
-    lowerPrimitiveNames :: !(Set Text),
+    lowerPrimitiveOps :: !(Map.Map Text PrimOp),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
     lowerLocalVars :: !(Set (Text, Unique))
@@ -38,7 +39,7 @@ type LowerM = State LowerState
 
 data LoweredTop = LoweredTop
   { loweredConstructors :: ![(Text, [RuntimeRep])],
-    loweredPrimitives :: ![(GrinVar, Int)],
+    loweredPrimitives :: ![(GrinVar, PrimOp)],
     loweredForeignCalls :: ![GrinForeignCall],
     loweredCafs :: ![(GrinVar, GrinNode)]
   }
@@ -73,10 +74,10 @@ lowerProgram program =
         { lowerNextUnique = maximum (0 : map sourceUnique (programVars program)) + 1,
           lowerNextFunction = 0,
           lowerFunctionsRev = [],
-          lowerPrimitiveNames =
-            Set.fromList
-              [ varName var
-              | FcPrimitive var _ <- fcTopBinds program
+          lowerPrimitiveOps =
+            Map.fromList
+              [ (varName var, primOp)
+              | FcPrimitive var primOp <- fcTopBinds program
               ],
           lowerGlobalNames = Set.fromList (map fst builtinConstructors <> programGlobalNames program),
           lowerWhnfGlobalNames = Set.fromList (map fst builtinConstructors <> programWhnfGlobalNames program),
@@ -92,8 +93,8 @@ lowerTopBind topBind =
       pure mempty {loweredConstructors = [(name, map typeRuntimeRep fields) | (name, fields) <- constructors]}
     FcNewtype _ _ constructor field ->
       pure mempty {loweredConstructors = [(constructor, [typeRuntimeRep field])]}
-    FcPrimitive var arity ->
-      pure mempty {loweredPrimitives = [(lowerGlobalVar var, arity)]}
+    FcPrimitive var primOp ->
+      pure mempty {loweredPrimitives = [(lowerGlobalVar var, primOp)]}
     FcForeignImport foreignCall ->
       pure mempty {loweredForeignCalls = [lowerForeignCall foreignCall]}
     FcTopBind bind -> do
@@ -117,17 +118,25 @@ lowerCafBind bind =
 
 lowerExpr :: FcExpr -> LowerM GrinExpr
 lowerExpr expr = do
-  primitiveNames <- gets lowerPrimitiveNames
+  primitiveOps <- gets lowerPrimitiveOps
   localVars <- gets lowerLocalVars
-  case primitiveApplication primitiveNames localVars expr of
-    Just ("raise#", [exception]) ->
-      lowerStrict "exception" exception (pure . GrinThrow)
-    Just ("catch#", [action, handler, state]) ->
+  case primitiveApplication primitiveOps localVars expr of
+    Just (primOp, [exception])
+      | primOpNameIs "raise#" primOp ->
+          lowerStrict "exception" exception (pure . GrinThrow)
+    Just (primOp, [action, handler, state]) | primOpNameIs "catch#" primOp ->
       lowerArgument action $ \actionValue ->
         lowerArgument handler $ \handlerValue ->
           lowerArgument state $ \stateValue ->
             pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue stateValue)
+    Just (primOp, arguments)
+      | length arguments == primOpArity primOp,
+        Just schedulerOp <- schedulerPrimOp primOp ->
+          lowerArgumentMany arguments $ \values ->
+            pure (GrinScheduler (exprRuntimeRep expr) schedulerOp values)
     _ -> lowerOrdinaryExpr expr
+  where
+    primOpNameIs expected primOp = primOpName primOp == expected
 
 lowerOrdinaryExpr :: FcExpr -> LowerM GrinExpr
 lowerOrdinaryExpr expr =
@@ -300,13 +309,13 @@ emitFunction :: GrinFunction -> LowerM ()
 emitFunction function =
   modify' $ \state -> state {lowerFunctionsRev = function : lowerFunctionsRev state}
 
-primitiveApplication :: Set Text -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
-primitiveApplication primitiveNames localVars expr =
+primitiveApplication :: Map.Map Text PrimOp -> Set (Text, Unique) -> FcExpr -> Maybe (PrimOp, [FcExpr])
+primitiveApplication primitiveOps localVars expr =
   case collectApplications expr of
     (FcVar var, arguments)
       | varKey var `Set.notMember` localVars,
-        varName var `Set.member` primitiveNames ->
-          Just (varName var, arguments)
+        Just primOp <- Map.lookup (varName var) primitiveOps ->
+          Just (primOp, arguments)
     _ -> Nothing
 
 collectApplications :: FcExpr -> (FcExpr, [FcExpr])

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -6,6 +6,7 @@ module Aihc.Grin.Pretty
 where
 
 import Aihc.Grin.Syntax
+import Aihc.Tc.Prim (PrimOp, primOpArity, primOpName)
 import Aihc.Tc.Types (RuntimeRep)
 import Data.List (intercalate)
 import Data.Text qualified as T
@@ -31,9 +32,9 @@ renderConstructor (name, fieldReps) =
     <> intercalate ", " (map show fieldReps)
     <> "]"
 
-renderPrimitive :: (GrinVar, Int) -> String
-renderPrimitive (var, arity) =
-  "primitive " <> renderVar var <> "/" <> show arity
+renderPrimitive :: (GrinVar, PrimOp) -> String
+renderPrimitive (var, primOp) =
+  "primitive " <> renderVar var <> "/" <> show (primOpArity primOp)
 
 renderForeign :: GrinForeignCall -> String
 renderForeign foreignCall =
@@ -117,6 +118,13 @@ renderExprIndented indentation expr =
         <> show runtimeRep
         <> " "
         <> unwords (map renderValue [action, handler, state])
+    GrinScheduler runtimeRep schedulerOp arguments ->
+      indent indentation
+        <> "scheduler @"
+        <> show runtimeRep
+        <> " "
+        <> show schedulerOp
+        <> concatMap ((" " <>) . renderValue) arguments
 
 renderAlt :: Int -> GrinAlt -> String
 renderAlt indentation alt =
@@ -153,7 +161,7 @@ renderNodeTag nodeTag =
     GrinConstructor name -> "C" <> T.unpack name
     GrinClosure functionName -> "P" <> T.unpack (unFunctionName functionName)
     GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
-    GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
+    GrinPrimitive primOp -> "Prim[" <> T.unpack (primOpName primOp) <> "/" <> show (primOpArity primOp) <> "]"
     GrinForeign foreignCall -> "Foreign[" <> T.unpack (grinForeignCallName foreignCall) <> "]"
     GrinForeignIOAction foreignCall -> "ForeignIO[" <> T.unpack (grinForeignCallName foreignCall) <> "]"
     GrinDictionary -> "Dict"

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -21,6 +21,7 @@ module Aihc.Grin.Syntax
     GrinForeignSignature (..),
     GrinForeignResult (..),
     GrinForeignType (..),
+    SchedulerPrimOp (..),
     grinValueRuntimeRep,
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
@@ -28,13 +29,14 @@ module Aihc.Grin.Syntax
   )
 where
 
+import Aihc.Tc.Prim (PrimOp, SchedulerPrimOp (..))
 import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
 import Data.Text (Text)
 
 -- | A whole GRIN program.
 data GrinProgram = GrinProgram
   { grinConstructors :: ![(Text, [RuntimeRep])],
-    grinPrimitives :: ![(GrinVar, Int)],
+    grinPrimitives :: ![(GrinVar, PrimOp)],
     grinForeignCalls :: ![GrinForeignCall],
     grinCafs :: ![(GrinVar, GrinNode)],
     grinFunctions :: ![GrinFunction]
@@ -91,6 +93,7 @@ data GrinExpr
   | GrinDictSelect !RuntimeRep !GrinValue !Int
   | GrinThrow !GrinValue
   | GrinCatch !RuntimeRep !GrinValue !GrinValue !GrinValue
+  | GrinScheduler !RuntimeRep !SchedulerPrimOp ![GrinValue]
   deriving (Eq, Show)
 
 -- | Atomic operands in the strict language.
@@ -110,7 +113,7 @@ data GrinNodeTag
   = GrinConstructor !Text
   | GrinClosure !FunctionName
   | GrinThunk !FunctionName
-  | GrinPrimitive !Text !Int
+  | GrinPrimitive !PrimOp
   | GrinForeign !GrinForeignCall
   | GrinForeignIOAction !GrinForeignCall
   | GrinDictionary

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -9,7 +9,7 @@ where
 
 import Aihc.Fc.Syntax
 import Aihc.Grin
-import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
+import Aihc.Tc (Levity (..), PrimOp (..), RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Data.List (isInfixOf)
 import Data.Text (Text)
@@ -58,7 +58,20 @@ grinUnitTests =
         let program = lowerProgram cafReferenceProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "CAF reference is evaluated" ("eval @BoxedRep Lifted source%" `isInfixOf` rendered)
+        assertBool "CAF reference is evaluated" ("eval @BoxedRep Lifted source%" `isInfixOf` rendered),
+      testCase "cooperative scheduler forks and transfers through an MVar" $ do
+        assertEqual "lint" [] (lintProgram schedulerProgram)
+        result <- interpretProgramBinding "answer" schedulerProgram
+        assertEqual "result" (Right "42") result,
+      testCase "timer suspension resumes its CPS continuation" $ do
+        assertEqual "lint" [] (lintProgram timerProgram)
+        result <- interpretProgramBinding "answer" timerProgram
+        assertEqual "result" (Right "7") result,
+      testCase "CPS exposes the continuation saved by scheduler operations" $ do
+        let schedulerPoints = schedulerContinuations (cpsExpr schedulerActionBody)
+        case schedulerPoints of
+          (SchedulerNewMVar, CpsBind {}) : _ -> pure ()
+          other -> assertFailure ("expected newMVar scheduler continuation, got " <> show other)
     ]
 
 grinGoldenTests :: IO TestTree
@@ -168,8 +181,8 @@ cafReferenceProgram =
 exceptionProgram :: FcProgram
 exceptionProgram =
   FcProgram
-    [ FcPrimitive raiseVar 1,
-      FcPrimitive catchVar 3,
+    [ FcPrimitive raiseVar PrimRaise,
+      FcPrimitive catchVar PrimCatch,
       FcTopBind (FcNonRec answerVar caughtExpression)
     ]
   where
@@ -224,3 +237,118 @@ intTy = TcTyCon (TyCon "Int#" 0) []
 
 boxedIntTy :: TcType
 boxedIntTy = TcTyCon (TyCon "Int" 0) []
+
+schedulerProgram :: GrinProgram
+schedulerProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinCafs = [(answer, GrinNode (GrinThunk mainFunction) [])],
+      grinFunctions =
+        [ GrinFunction mainFunction [] liftedRep mainBody,
+          GrinFunction actionFunction [initialState] ioResultRep schedulerActionBody,
+          GrinFunction childFunction [childMVar, childState] liftedRep childBody
+        ]
+    }
+  where
+    answer = GrinVar "answer" 100 liftedRep
+    mainFunction = FunctionName "scheduler_main"
+    actionFunction = FunctionName "scheduler_action"
+    childFunction = FunctionName "scheduler_child"
+    initialState = GrinVar "initialState" 101 stateRep
+    childMVar = GrinVar "childMVar" 102 unliftedPointerRep
+    childState = GrinVar "childState" 103 stateRep
+    mainBody =
+      GrinReturn
+        ( GrinNodeValue
+            (GrinNode (GrinConstructor "IO") [GrinNodeValue (GrinNode (GrinClosure actionFunction) [])])
+        )
+    childBody =
+      GrinBind childNextState (GrinScheduler stateRep SchedulerPutMVar [GrinVarValue childMVar, intValue 42, GrinVarValue childState]) $
+        GrinReturn (stateValueResult (GrinVarValue childNextState) unitValue)
+    childNextState = GrinVar "childNextState" 104 stateRep
+
+schedulerActionBody :: GrinExpr
+schedulerActionBody =
+  GrinBind allocatedTuple (GrinScheduler mvarResultRep SchedulerNewMVar [GrinVarValue initialState]) $
+    GrinCase
+      (GrinVarValue allocatedTuple)
+      allocatedCaseBinder
+      [ GrinAlt (GrinDataAlt "(#,#)") [allocatedState, mvar] $
+          GrinBind forkedTuple (GrinScheduler forkResultRep SchedulerFork [childClosure mvar, GrinVarValue allocatedState]) $
+            GrinCase
+              (GrinVarValue forkedTuple)
+              forkedCaseBinder
+              [ GrinAlt (GrinDataAlt "(#,#)") [forkedState, threadId] $
+                  GrinScheduler ioResultRep SchedulerTakeMVar [GrinVarValue mvar, GrinVarValue forkedState]
+              ]
+      ]
+  where
+    initialState = GrinVar "initialState" 101 stateRep
+    allocatedTuple = GrinVar "allocatedTuple" 105 mvarResultRep
+    allocatedCaseBinder = GrinVar "allocatedCase" 106 mvarResultRep
+    allocatedState = GrinVar "allocatedState" 107 stateRep
+    mvar = GrinVar "mvar" 108 unliftedPointerRep
+    forkedTuple = GrinVar "forkedTuple" 109 forkResultRep
+    forkedCaseBinder = GrinVar "forkedCase" 110 forkResultRep
+    forkedState = GrinVar "forkedState" 111 stateRep
+    threadId = GrinVar "threadId" 112 unliftedPointerRep
+    childClosure capturedMVar =
+      GrinNodeValue
+        (GrinNode (GrinClosure (FunctionName "scheduler_child")) [GrinVarValue capturedMVar])
+
+timerProgram :: GrinProgram
+timerProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinCafs = [(answer, GrinNode (GrinThunk mainFunction) [])],
+      grinFunctions =
+        [ GrinFunction mainFunction [] liftedRep mainBody,
+          GrinFunction actionFunction [initialState] liftedRep actionBody
+        ]
+    }
+  where
+    answer = GrinVar "answer" 120 liftedRep
+    mainFunction = FunctionName "timer_main"
+    actionFunction = FunctionName "timer_action"
+    initialState = GrinVar "initialState" 121 stateRep
+    delayedState = GrinVar "delayedState" 122 stateRep
+    mainBody =
+      GrinReturn
+        ( GrinNodeValue
+            (GrinNode (GrinConstructor "IO") [GrinNodeValue (GrinNode (GrinClosure actionFunction) [])])
+        )
+    actionBody =
+      GrinBind delayedState (GrinScheduler stateRep SchedulerDelay [intValue 1, GrinVarValue initialState]) $
+        GrinReturn (stateValueResult (GrinVarValue delayedState) (intValue 7))
+
+stateValueResult :: GrinValue -> GrinValue -> GrinValue
+stateValueResult state value =
+  GrinNodeValue (GrinNode (GrinConstructor "(#,#)") [state, value])
+
+intValue :: Integer -> GrinValue
+intValue = GrinLitValue . GrinLitInt IntRep
+
+unitValue :: GrinValue
+unitValue = GrinNodeValue (GrinNode (GrinConstructor "()") [])
+
+liftedRep :: RuntimeRep
+liftedRep = BoxedRep Lifted
+
+unliftedPointerRep :: RuntimeRep
+unliftedPointerRep = BoxedRep Unlifted
+
+stateRep :: RuntimeRep
+stateRep = TupleRep []
+
+mvarResultRep :: RuntimeRep
+mvarResultRep = TupleRep [stateRep, unliftedPointerRep]
+
+forkResultRep :: RuntimeRep
+forkResultRep = TupleRep [stateRep, unliftedPointerRep]
+
+ioResultRep :: RuntimeRep
+ioResultRep = TupleRep [stateRep, IntRep]

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -26,6 +26,7 @@ library
     Aihc.Tc.Instantiate
     Aihc.Tc.Kind
     Aihc.Tc.Monad
+    Aihc.Tc.Prim
     Aihc.Tc.Solve
     Aihc.Tc.Solve.Canonicalize
     Aihc.Tc.Solve.Dict

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -55,6 +55,12 @@ module Aihc.Tc
     runtimeRepOfType,
     isLiftedType,
     isUnliftedType,
+    PrimOp (..),
+    SchedulerPrimOp (..),
+    primOpArity,
+    primOpFromName,
+    primOpName,
+    schedulerPrimOp,
     TcAnnotation (..),
     TcDiagnostic (..),
     TcErrorKind (..),
@@ -96,6 +102,7 @@ import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleInstances, tcModule)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Monad
+import Aihc.Tc.Prim
 import Aihc.Tc.Solve (solveConstraints)
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (zonkType)

--- a/components/aihc-tc/src/Aihc/Tc/Prim.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Prim.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Stable identities for runtime primitives.
+--
+-- Textual foreign-import names are resolved to these identities before
+-- runtime-explicit lowering.  Backends must dispatch on 'PrimOp', not on
+-- source text.
+module Aihc.Tc.Prim
+  ( PrimOp (..),
+    primOpArity,
+    primOpFromName,
+    primOpName,
+    SchedulerPrimOp (..),
+    schedulerPrimOp,
+  )
+where
+
+import Data.Text (Text)
+
+data PrimOp
+  = PrimIntAdd
+  | PrimIntSubtract
+  | PrimIntMultiply
+  | PrimCompareInt
+  | PrimIntLessThan
+  | PrimIntEqual
+  | PrimCharToInt
+  | PrimIntToChar
+  | PrimRaise
+  | PrimRealWorld
+  | PrimCatch
+  | PrimNewMutVar
+  | PrimReadMutVar
+  | PrimWriteMutVar
+  | PrimFork
+  | PrimYield
+  | PrimNewMVar
+  | PrimTakeMVar
+  | PrimPutMVar
+  | PrimDelay
+  deriving (Bounded, Enum, Eq, Ord, Read, Show)
+
+data SchedulerPrimOp
+  = SchedulerFork
+  | SchedulerYield
+  | SchedulerNewMVar
+  | SchedulerTakeMVar
+  | SchedulerPutMVar
+  | SchedulerDelay
+  deriving (Eq, Ord, Read, Show)
+
+primOpName :: PrimOp -> Text
+primOpName primOp =
+  case primOp of
+    PrimIntAdd -> "+#"
+    PrimIntSubtract -> "-#"
+    PrimIntMultiply -> "*#"
+    PrimCompareInt -> "compareInt#"
+    PrimIntLessThan -> "<#"
+    PrimIntEqual -> "==#"
+    PrimCharToInt -> "charToInt#"
+    PrimIntToChar -> "intToChar#"
+    PrimRaise -> "raise#"
+    PrimRealWorld -> "realWorld#"
+    PrimCatch -> "catch#"
+    PrimNewMutVar -> "newMutVar#"
+    PrimReadMutVar -> "readMutVar#"
+    PrimWriteMutVar -> "writeMutVar#"
+    PrimFork -> "fork#"
+    PrimYield -> "yield#"
+    PrimNewMVar -> "newMVar#"
+    PrimTakeMVar -> "takeMVar#"
+    PrimPutMVar -> "putMVar#"
+    PrimDelay -> "delay#"
+
+primOpFromName :: Text -> Maybe PrimOp
+primOpFromName name =
+  lookup name [(primOpName primOp, primOp) | primOp <- [minBound .. maxBound]]
+
+primOpArity :: PrimOp -> Int
+primOpArity primOp =
+  case primOp of
+    PrimRealWorld -> 0
+    PrimCharToInt -> 1
+    PrimIntToChar -> 1
+    PrimRaise -> 1
+    PrimYield -> 1
+    PrimNewMVar -> 1
+    PrimIntAdd -> 2
+    PrimIntSubtract -> 2
+    PrimIntMultiply -> 2
+    PrimCompareInt -> 2
+    PrimIntLessThan -> 2
+    PrimIntEqual -> 2
+    PrimNewMutVar -> 2
+    PrimReadMutVar -> 2
+    PrimFork -> 2
+    PrimTakeMVar -> 2
+    PrimDelay -> 2
+    PrimCatch -> 3
+    PrimWriteMutVar -> 3
+    PrimPutMVar -> 3
+
+schedulerPrimOp :: PrimOp -> Maybe SchedulerPrimOp
+schedulerPrimOp primOp =
+  case primOp of
+    PrimFork -> Just SchedulerFork
+    PrimYield -> Just SchedulerYield
+    PrimNewMVar -> Just SchedulerNewMVar
+    PrimTakeMVar -> Just SchedulerTakeMVar
+    PrimPutMVar -> Just SchedulerPutMVar
+    PrimDelay -> Just SchedulerDelay
+    _ -> Nothing

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -261,6 +261,8 @@ fixedTyConKind name =
   case name of
     "State#" -> Just (KFun liftedTypeKind (KTYPE (TupleRep [])))
     "MutVar#" -> Just (KFun liftedTypeKind (KFun liftedTypeKind (KTYPE (BoxedRep Unlifted))))
+    "MVar#" -> Just (KFun liftedTypeKind (KFun liftedTypeKind (KTYPE (BoxedRep Unlifted))))
+    "ThreadId#" -> Just (KTYPE (BoxedRep Unlifted))
     _
       | Just runtimeRep <- primitiveRuntimeRep name -> Just (KTYPE runtimeRep)
       | isPromotedRuntimeRep name -> Just KRuntimeRep

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -225,6 +225,16 @@ kindTests =
           ("Double#", DoubleRep),
           ("Char#", WordRep)
         ],
+    testCase "scheduler handles have fixed unlifted pointer kinds" $ do
+      let unliftedHandleKind = KTYPE (BoxedRep Unlifted)
+      assertEqual
+        "ThreadId# kind"
+        unliftedHandleKind
+        (typeKind (TcTyCon (TyCon "ThreadId#" 0) []))
+      assertEqual
+        "MVar# kind"
+        (KFun liftedTypeKind (KFun liftedTypeKind unliftedHandleKind))
+        (tyConKind (TyCon "MVar#" 2)),
     testCase "records source-level constructor field representations" $ do
       let result =
             typecheckModule $

--- a/core-libs/aihc-base/src/Control/Concurrent.hs
+++ b/core-libs/aihc-base/src/Control/Concurrent.hs
@@ -1,1 +1,41 @@
-module Control.Concurrent () where
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Control.Concurrent
+  ( ThreadId,
+    forkIO,
+    threadDelay,
+    yield,
+  )
+where
+
+import GHC.IO (IO (..))
+import GHC.Int (Int (..))
+import GHC.Prim (ThreadId#, delay#, fork#, yield#)
+
+data ThreadId = ThreadId ThreadId#
+
+forkIO :: IO () -> IO ThreadId
+forkIO (IO action) =
+  IO
+    ( \state ->
+        case fork# action state of
+          (# nextState, threadId #) -> (# nextState, ThreadId threadId #)
+    )
+
+yield :: IO ()
+yield =
+  IO
+    ( \state ->
+        case yield# state of
+          nextState -> (# nextState, () #)
+    )
+
+threadDelay :: Int -> IO ()
+threadDelay (I# microseconds) =
+  IO
+    ( \state ->
+        case delay# microseconds state of
+          nextState -> (# nextState, () #)
+    )

--- a/core-libs/aihc-base/src/Control/Concurrent/MVar.hs
+++ b/core-libs/aihc-base/src/Control/Concurrent/MVar.hs
@@ -1,1 +1,10 @@
-module Control.Concurrent.MVar () where
+module Control.Concurrent.MVar
+  ( MVar,
+    newEmptyMVar,
+    newMVar,
+    putMVar,
+    takeMVar,
+  )
+where
+
+import GHC.MVar (MVar, newEmptyMVar, newMVar, putMVar, takeMVar)

--- a/core-libs/aihc-base/src/GHC/MVar.hs
+++ b/core-libs/aihc-base/src/GHC/MVar.hs
@@ -1,1 +1,46 @@
-module GHC.MVar () where
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module GHC.MVar
+  ( MVar,
+    newEmptyMVar,
+    newMVar,
+    putMVar,
+    takeMVar,
+  )
+where
+
+import GHC.IO (IO (..))
+import GHC.Prim (MVar#, RealWorld, newMVar#, putMVar#, takeMVar#)
+
+data MVar a = MVar (MVar# RealWorld a)
+
+newEmptyMVar :: IO (MVar a)
+newEmptyMVar =
+  IO
+    ( \state ->
+        case newMVar# state of
+          (# nextState, mvar #) -> (# nextState, MVar mvar #)
+    )
+
+newMVar :: a -> IO (MVar a)
+newMVar value =
+  IO
+    ( \state ->
+        case newMVar# state of
+          (# allocatedState, mvar #) ->
+            case putMVar# mvar value allocatedState of
+              nextState -> (# nextState, MVar mvar #)
+    )
+
+takeMVar :: MVar a -> IO a
+takeMVar (MVar mvar) = IO (takeMVar# mvar)
+
+putMVar :: MVar a -> a -> IO ()
+putMVar (MVar mvar) value =
+  IO
+    ( \state ->
+        case putMVar# mvar value state of
+          nextState -> (# nextState, () #)
+    )

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -5,15 +5,23 @@
 module GHC.Prim
   ( catch#,
     compareInt#,
+    delay#,
+    fork#,
+    MVar#,
     MutVar#,
+    newMVar#,
     newMutVar#,
+    putMVar#,
     raise#,
     realWorld#,
     readMutVar#,
     State#,
     RealWorld,
+    takeMVar#,
+    ThreadId#,
     TYPE,
     writeMutVar#,
+    yield#,
   )
 where
 
@@ -22,6 +30,10 @@ import GHC.Types (TYPE)
 data State# s
 
 data MutVar# d a
+
+data MVar# d a
+
+data ThreadId#
 
 data RealWorld
 
@@ -36,6 +48,22 @@ foreign import prim newMutVar# :: a -> State# d -> (# State# d, MutVar# d a #)
 foreign import prim readMutVar# :: MutVar# d a -> State# d -> (# State# d, a #)
 
 foreign import prim writeMutVar# :: MutVar# d a -> a -> State# d -> State# d
+
+foreign import prim
+  fork# ::
+    (State# RealWorld -> (# State# RealWorld, a #)) ->
+    State# RealWorld ->
+    (# State# RealWorld, ThreadId# #)
+
+foreign import prim yield# :: State# RealWorld -> State# RealWorld
+
+foreign import prim newMVar# :: State# d -> (# State# d, MVar# d a #)
+
+foreign import prim takeMVar# :: MVar# d a -> State# d -> (# State# d, a #)
+
+foreign import prim putMVar# :: MVar# d a -> a -> State# d -> State# d
+
+foreign import prim delay# :: Int# -> State# d -> State# d
 
 foreign import prim
   catch# ::

--- a/test/Test/Fixtures/eval/scheduler-api-loads.yaml
+++ b/test/Test/Fixtures/eval/scheduler-api-loads.yaml
@@ -1,0 +1,31 @@
+dependencies:
+  - aihc-base
+  - aihc-prim
+extensions: []
+modules:
+  - |
+    module Test where
+
+    import Control.Concurrent (ThreadId, forkIO, threadDelay, yield)
+    import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar, takeMVar)
+    import GHC.IO (IO)
+
+    schedulerEntry :: IO () -> IO ThreadId
+    schedulerEntry action = forkIO action
+
+    empty :: IO (MVar a)
+    empty = newEmptyMVar
+
+    full :: a -> IO (MVar a)
+    full value = newMVar value
+
+    transfer :: MVar a -> a -> IO a
+    transfer mvar value = putMVar mvar value >> takeMVar mvar
+
+    pause :: IO ()
+    pause = yield >> threadDelay 1
+output: |
+  <function>
+expression: schedulerEntry
+status: pass
+reason: typechecks and loads the minimal public green-thread, MVar, and timer API

--- a/test/Test/Fixtures/grin/scheduler-yield.yaml
+++ b/test/Test/Fixtures/grin/scheduler-yield.yaml
@@ -1,0 +1,26 @@
+expected: |-
+  primitive yield#%1000 :: BoxedRep Lifted/1
+
+  caf resume%1004 :: BoxedRep Lifted = (F$grin_thunk_0)
+
+  $grin_closure_1 x1002%1002 :: TupleRep [] -> TupleRep [] =
+    scheduler @TupleRep [] SchedulerYield x1002%1002 :: TupleRep []
+
+  $grin_thunk_0 -> BoxedRep Lifted =
+    return (P$grin_closure_1)
+extensions:
+- EmptyDataDecls
+- GHCForeignImportPrim
+- MagicHash
+reason: lowers a saturated scheduler primitive to an explicit suspension operation
+source: |
+  module Test where
+
+  data State# s
+  data RealWorld
+
+  foreign import prim yield# :: State# RealWorld -> State# RealWorld
+
+  resume :: State# RealWorld -> State# RealWorld
+  resume state = yield# state
+status: pass


### PR DESCRIPTION
## Summary

- add stable `PrimOp` identities and the exact `fork#`, `yield#`, MVar, and `delay#` primitive schemes
- lower saturated scheduler primitives to explicit GRIN operations and transform GRIN control flow into an explicit CPS form
- execute the CPS form with a single-capability cooperative reference scheduler using FIFO runnable and MVar queues plus monotonic timers
- add the matching ARM64 RTS ABI, per-fiber continuation state, green-thread switching, MVar handoff, and timer wakeups
- expose the minimal `Control.Concurrent` and `Control.Concurrent.MVar` APIs from `aihc-base`

## Semantics

The scheduler is deliberately minimal: one OS thread, cooperative green threads, FIFO scheduling, blocking `takeMVar#`/`putMVar#`, and relative monotonic timers. `fork#` queues the child while the parent continues. Main-thread completion ends the program; a blocked main thread with no runnable fibers or timers reports deadlock.

Scheduler operations carry explicit success continuations in CPS. The portable GRIN interpreter queues those continuations directly. The native runtime retains the existing heap continuation chain per fiber and switches only after generated code returns to the trampoline, so suspension does not retain the C stack.

## Progress counts

- FC golden fixtures: +1
- GRIN golden fixtures: +1
- shared evaluation fixtures: +1
- type-checker unit cases: +1
- GRIN unit cases: +3
- ARM64 unit cases: +1
- README progress counts: unchanged, as required

## Validation

- `just fmt`
- `just check` (all suites under `-Werror`, including 1,861 parser tests)
- `clang -std=c11 -Wall -Wextra -Werror -c components/aihc-arm64/runtime/aihc_runtime.c`
