### PR TITLE
refactor(ffi): make foreign calls saturated

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -29,7 +29,6 @@ import Aihc.Fc
     FcAlt (..),
     FcBind (..),
     FcExpr (..),
-    FcForeignCall (..),
     FcProgram (..),
     FcTopBind (..),
     Var (..),
@@ -238,8 +237,7 @@ shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBi
         FcData {} -> topBind
         FcNewtype {} -> topBind
         FcPrimitive var arity -> FcPrimitive (shiftVar var) arity
-        FcForeignImport foreignCall ->
-          FcForeignImport foreignCall {fcForeignCallVar = shiftVar (fcForeignCallVar foreignCall)}
+        FcForeignImport {} -> topBind
         FcTopBind bind -> FcTopBind (shiftBind bind)
 
     shiftBind bind =
@@ -263,6 +261,7 @@ shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBi
         FcCase scrutinee binder alternatives ->
           FcCase (shiftExpr scrutinee) (shiftVar binder) (map shiftAlt alternatives)
         FcCast inner coercion -> FcCast (shiftExpr inner) coercion
+        FcCallForeign foreignCall arguments -> FcCallForeign foreignCall (map shiftExpr arguments)
 
     shiftAlt alternative =
       alternative
@@ -279,7 +278,7 @@ topBindVarsDeep topBind =
     FcData {} -> []
     FcNewtype {} -> []
     FcPrimitive var _ -> [var]
-    FcForeignImport foreignCall -> [fcForeignCallVar foreignCall]
+    FcForeignImport {} -> []
     FcTopBind bind -> bindVarsDeep bind
 
 bindVarsDeep :: FcBind -> [Var]
@@ -304,6 +303,7 @@ exprVars expression =
     FcLet bind body -> bindVarsDeep bind <> exprVars body
     FcCase scrutinee binder alternatives -> exprVars scrutinee <> (binder : concatMap altVars alternatives)
     FcCast inner _ -> exprVars inner
+    FcCallForeign _ arguments -> concatMap exprVars arguments
   where
     altVars alternative = altBinders alternative <> exprVars (altRhs alternative)
 

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -8,8 +8,6 @@ enum {
   AIHC_CLOSURE = 2,
   AIHC_THUNK = 3,
   AIHC_PRIMITIVE = 4,
-  AIHC_FOREIGN = 5,
-  AIHC_FOREIGN_IO = 6,
   AIHC_DICTIONARY = 7,
   AIHC_CELL = 8,
   AIHC_STATE_TOKEN = 9,
@@ -27,8 +25,7 @@ enum {
   AIHC_CONT_APPLY = 2,
   AIHC_CONT_TOP = 3,
   AIHC_CONT_FINAL = 4,
-  AIHC_CONT_FOREIGN_CINT = 5,
-  AIHC_CONT_SELECT = 6,
+  AIHC_CONT_SELECT = 5,
 };
 
 enum {
@@ -40,13 +37,6 @@ typedef struct AihcContinuation AihcContinuation;
 /* Every runtime location is one machine word. Static RuntimeRep metadata says
  * whether that word is a heap pointer or an unboxed payload. */
 typedef uintptr_t AihcSlot;
-
-typedef struct {
-  void *function;
-  uint64_t is_io;
-  uint64_t int32_constructor;
-  uint64_t tuple_constructor;
-} AihcForeign;
 
 struct AihcValue {
   uint64_t kind;
@@ -71,10 +61,6 @@ struct AihcContinuation {
     struct {
       AihcSlot argument;
     } apply;
-    struct {
-      AihcSlot state;
-      AihcForeign *descriptor;
-    } foreign_call;
     struct {
       uint64_t index;
       uint64_t result_is_lifted;
@@ -201,21 +187,6 @@ static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
   machine->locals = NULL;
 }
 
-static AihcValue *aihc_constructor(uint64_t constructor, uint64_t arity,
-                                   uint64_t count) {
-  return aihc_make_node(AIHC_CONSTRUCTOR, constructor, arity, count);
-}
-
-static void aihc_complete_foreign(AihcMachine *machine, AihcValue *foreign,
-                                  AihcSlot state) {
-  AihcContinuation *continuation =
-      aihc_push_special(machine, AIHC_CONT_FOREIGN_CINT);
-  continuation->payload.foreign_call.state = state;
-  continuation->payload.foreign_call.descriptor =
-      (AihcForeign *)foreign->info;
-  aihc_eval_value(machine, (AihcValue *)foreign->fields[0], 1);
-}
-
 static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
                               AihcSlot argument) {
   switch (function->kind) {
@@ -223,8 +194,7 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
     aihc_schedule_function(machine, function,
                            aihc_arguments_with_field(function, argument));
     return;
-  case AIHC_CONSTRUCTOR:
-  case AIHC_FOREIGN: {
+  case AIHC_CONSTRUCTOR: {
     AihcValue *applied = aihc_copy_with_field(function, argument);
     if (applied->count < applied->arity) {
       aihc_return_value(machine, (AihcSlot)applied);
@@ -233,27 +203,11 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
     if (applied->count > applied->arity) {
       aihc_fail("overapplication is not implemented");
     }
-    if (applied->kind == AIHC_FOREIGN) {
-      AihcForeign *descriptor = (AihcForeign *)applied->info;
-      if (!descriptor->is_io) {
-        aihc_fail("pure foreign calls are not implemented");
-      }
-      AihcValue *action = aihc_make_node(AIHC_FOREIGN_IO, applied->info,
-                                         applied->arity, applied->count);
-      for (uint64_t index = 0; index < applied->count; ++index) {
-        action->fields[index] = applied->fields[index];
-      }
-      aihc_return_value(machine, (AihcSlot)action);
-      return;
-    }
     aihc_return_value(machine, (AihcSlot)applied);
     return;
   }
   case AIHC_PRIMITIVE:
     aihc_fail("primitive is not implemented by the native runtime");
-    return;
-  case AIHC_FOREIGN_IO:
-    aihc_complete_foreign(machine, function, argument);
     return;
   default:
     aihc_fail("attempted to apply a non-function value");
@@ -348,24 +302,6 @@ static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
     }
     machine->locals = NULL;
     machine->next = machine->exit_code;
-    return;
-  }
-  case AIHC_CONT_FOREIGN_CINT: {
-    AihcForeign *descriptor = continuation->payload.foreign_call.descriptor;
-    AihcValue *int32 = (AihcValue *)value;
-    if (int32->kind != AIHC_CONSTRUCTOR ||
-        int32->info != descriptor->int32_constructor || int32->count != 1) {
-      aihc_fail("foreign CInt argument has invalid Int32 constructor");
-    }
-    int argument = (int)(int32_t)(uint32_t)int32->fields[0];
-    int result = ((int (*)(int))descriptor->function)(argument);
-    AihcValue *result_int32 =
-        aihc_constructor(descriptor->int32_constructor, 1, 1);
-    result_int32->fields[0] = (AihcSlot)(intptr_t)(int32_t)result;
-    AihcValue *tuple = aihc_constructor(descriptor->tuple_constructor, 2, 2);
-    tuple->fields[0] = continuation->payload.foreign_call.state;
-    tuple->fields[1] = (AihcSlot)result_int32;
-    aihc_return_value(machine, (AihcSlot)tuple);
     return;
   }
   case AIHC_CONT_SELECT: {

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -48,7 +48,6 @@ data CompileEnv = CompileEnv
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
     compileFunctionArities :: !(Map FunctionName Int),
-    compileForeignLabels :: !(Map Text Text),
     compileAllowUnsupportedPrimitives :: !Bool
   }
 
@@ -105,14 +104,13 @@ extendLinkLayout layout program =
     }
 
 -- | Compile a library module to relocatable assembly. The exported initializer
--- installs the module's primitive, foreign, and CAF globals into the shared
+-- installs the module's primitive and CAF globals into the shared
 -- machine table. Constructors are installed once by the executable entry unit.
 compileModule :: LinkLayout -> Text -> GrinProgram -> Either Arm64Error Text
 compileModule layout initializerSymbol program = do
   mapM_ validateRuntimeRep (programRuntimeReps program)
   initLines <- compileInitializers compileEnv program
   functions <- mapM (compileFunction compileEnv) (grinFunctions program)
-  descriptors <- foreignDescriptors compileEnv program
   pure . T.unlines $
     [ ".section __TEXT,__text,regular,pure_instructions",
       ".p2align 2",
@@ -131,7 +129,6 @@ compileModule layout initializerSymbol program = do
            "  ret"
          ]
       <> concat functions
-      <> descriptors
   where
     compileEnv = (compileEnvironment layout program) {compileAllowUnsupportedPrimitives = True}
 
@@ -145,7 +142,6 @@ compileProgramWithDependencies layout dependencyInitializers entryName program =
   constructorLines <- compileConstructorInitializers compileEnv
   initLines <- compileInitializers compileEnv program
   functions <- mapM (compileFunction compileEnv) (grinFunctions program)
-  descriptors <- foreignDescriptors compileEnv program
   pure . T.unlines $
     [ ".section __TEXT,__text,regular,pure_instructions",
       ".p2align 2",
@@ -178,7 +174,6 @@ compileProgramWithDependencies layout dependencyInitializers entryName program =
            "  ret"
          ]
       <> concat functions
-      <> descriptors
   where
     compileEnv = compileEnvironment layout program
     globalSlots = compileGlobalSlots compileEnv
@@ -202,7 +197,6 @@ programGlobalNames :: GrinProgram -> [Text]
 programGlobalNames program =
   map fst (programConstructorArities program)
     <> map (grinVarName . fst) (grinPrimitives program)
-    <> map grinForeignCallName (grinForeignCalls program)
     <> map (grinVarName . fst) (grinCafs program)
 
 compileEnvironment :: LinkLayout -> GrinProgram -> CompileEnv
@@ -213,7 +207,6 @@ compileEnvironment layout program =
       compileGlobalSlots = Map.fromList (zip (linkGlobalNames layout) [0 ..]),
       compileFunctionLabels = Map.fromList [(grinFunctionName function, functionLabel index) | (index, function) <- zip [0 ..] (grinFunctions program)],
       compileFunctionArities = Map.fromList [(grinFunctionName function, length (grinFunctionParameters function)) | function <- grinFunctions program],
-      compileForeignLabels = Map.fromList [(grinForeignCallName foreignCall, foreignLabel index) | (index, foreignCall) <- zip [0 ..] (grinForeignCalls program)],
       compileAllowUnsupportedPrimitives = False
     }
   where
@@ -232,11 +225,6 @@ compileInitializers env program = do
     slot <- globalSlot env (grinVarName var)
     primitive <- primitiveId env (grinVarName var)
     pure $ makeNodeLines 4 (InfoImmediate primitive) arity 0 <> storeGlobal slot
-  foreignLines <- fmap concat . forM (grinForeignCalls program) $ \foreignCall -> do
-    slot <- globalSlot env (grinForeignCallName foreignCall)
-    label <- foreignDescriptorLabel env foreignCall
-    let arity = length (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
-    pure $ makeNodeLines 5 (InfoAddress label) arity 0 <> storeGlobal slot
   cafCellLines <- fmap concat . forM (grinCafs program) $ \(var, _) -> do
     slot <- globalSlot env (grinVarName var)
     pure (["  bl _aihc_make_cell"] <> storeGlobal slot)
@@ -251,7 +239,7 @@ compileInitializers env program = do
              "  mov x1, x20",
              "  bl _aihc_set_cell"
            ]
-  pure (primitiveLines <> foreignLines <> cafCellLines <> cafValueLines)
+  pure (primitiveLines <> cafCellLines <> cafValueLines)
 
 compileFunction :: CompileEnv -> GrinFunction -> Either Arm64Error [Text]
 compileFunction env function = do
@@ -365,8 +353,72 @@ compileExpr env prefix label expression =
         )
     GrinThrow {} -> unsupportedExpression "throw"
     GrinCatch {} -> unsupportedExpression "catch"
+    GrinForeignCallExpr foreignCall arguments ->
+      compileForeignCall env prefix label foreignCall arguments
   where
     unsupportedExpression name = lift (Left (Arm64UnsupportedExpression name))
+
+compileForeignCall :: ValueEnv -> [Text] -> Text -> GrinForeignCall -> [GrinValue] -> FunctionM ()
+compileForeignCall env prefix label foreignCall arguments = do
+  let signature = grinForeignCallSignature foreignCall
+      abiArity = length (grinForeignArgumentTypes signature)
+      expectedArity = length (grinForeignOperandReps signature)
+  if length arguments /= expectedArity
+    then lift (Left (Arm64UnsupportedExpression "foreign call arity mismatch"))
+    else
+      if abiArity > 8
+        then lift (Left (Arm64UnsupportedExpression "foreign calls with more than eight arguments"))
+        else do
+          argumentSlots <- mapM (const freshSlot) arguments
+          argumentLines <-
+            fmap concat . forM (zip arguments argumentSlots) $ \(argument, slot) -> do
+              valueLines <- liftEither (materializeValue env argument)
+              pure (valueLines <> [storeAt "x0" "x19" slot])
+          let abiSlots = take abiArity argumentSlots
+              loadAbiArguments =
+                [ loadAt ("x" <> tshow index) "x19" slot
+                | (index, slot) <- zip [0 :: Int ..] abiSlots
+                ]
+              callLines =
+                argumentLines
+                  <> loadAbiArguments
+                  <> ["  bl _" <> grinForeignCallSymbol foreignCall]
+                  <> normalizeForeignResult (grinForeignResultType signature)
+          resultLines <-
+            case grinForeignEffect signature of
+              GrinForeignPure -> pure returnLines
+              GrinForeignRealWorld ->
+                case drop abiArity argumentSlots of
+                  [stateSlot] -> makeForeignResultTuple env stateSlot
+                  _ -> lift (Left (Arm64UnsupportedExpression "foreign state-token arity mismatch"))
+          addBlock label (prefix <> callLines <> resultLines)
+
+normalizeForeignResult :: GrinForeignType -> [Text]
+normalizeForeignResult foreignType =
+  case foreignType of
+    GrinForeignInt32 -> ["  sxtw x0, w0"]
+    GrinForeignWord64 -> []
+
+makeForeignResultTuple :: ValueEnv -> Int -> FunctionM [Text]
+makeForeignResultTuple env stateSlot = do
+  resultSlot <- freshSlot
+  tupleId <- liftEither (constructorId (valueCompileEnv env) "(#,#)")
+  pure
+    ( [storeAt "x0" "x19" resultSlot]
+        <> makeNodeLines 1 (InfoImmediate tupleId) 2 2
+        <> [ "  mov x20, x0",
+             loadAt "x2" "x19" stateSlot,
+             "  mov x0, x20",
+             immediate "x1" (0 :: Int),
+             "  bl _aihc_set_field",
+             loadAt "x2" "x19" resultSlot,
+             "  mov x0, x20",
+             immediate "x1" (1 :: Int),
+             "  bl _aihc_set_field",
+             "  mov x0, x20"
+           ]
+        <> returnLines
+    )
 
 compileCase :: ValueEnv -> [Text] -> Text -> GrinValue -> GrinVar -> [GrinAlt] -> FunctionM ()
 compileCase env prefix label scrutinee binder alternatives = do
@@ -570,11 +622,6 @@ nodeHeader env node =
     GrinPrimitive name arity -> do
       identifier <- primitiveId compileEnv name
       pure (4, InfoImmediate identifier, arity)
-    GrinForeign foreignCall -> do
-      label <- foreignDescriptorLabel compileEnv foreignCall
-      let arity = length (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
-      pure (5, InfoAddress label, arity)
-    GrinForeignIOAction _ -> Left (Arm64UnsupportedValue "source foreign IO action node")
     GrinDictionary -> pure (7, InfoImmediate 0, length (grinNodeFields node))
   where
     compileEnv = valueCompileEnv env
@@ -665,37 +712,6 @@ dispatchLines =
     "  br x9"
   ]
 
-foreignDescriptors :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
-foreignDescriptors env program =
-  case grinForeignCalls program of
-    [] -> pure []
-    foreignCalls -> do
-      rendered <- fmap concat (mapM renderForeign foreignCalls)
-      pure ([".section __DATA,__data", ".p2align 3"] <> rendered)
-  where
-    renderForeign foreignCall = do
-      label <- foreignDescriptorLabel env foreignCall
-      (int32Id, tupleId) <- foreignConstructorIds env
-      pure
-        [ label <> ":",
-          "  .quad _" <> grinForeignCallSymbol foreignCall,
-          "  .quad " <> if isIo then "1" else "0",
-          "  .quad " <> tshow int32Id,
-          "  .quad " <> tshow tupleId
-        ]
-      where
-        signature = grinForeignCallSignature foreignCall
-        isIo =
-          case grinForeignResult signature of
-            GrinForeignIO _ -> True
-            GrinForeignPure _ -> False
-
-foreignConstructorIds :: CompileEnv -> Either Arm64Error (Int, Int)
-foreignConstructorIds env =
-  (,)
-    <$> constructorId env "I32#"
-    <*> constructorId env "(#,#)"
-
 globalSlot :: CompileEnv -> Text -> Either Arm64Error Int
 globalSlot env name =
   maybe (Left (Arm64MissingGlobal name)) Right (Map.lookup name (compileGlobalSlots env))
@@ -715,13 +731,6 @@ functionCodeLabel env name =
 functionArity :: CompileEnv -> FunctionName -> Either Arm64Error Int
 functionArity env name =
   maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionArities env))
-
-foreignDescriptorLabel :: CompileEnv -> GrinForeignCall -> Either Arm64Error Text
-foreignDescriptorLabel env foreignCall =
-  maybe
-    (Left (Arm64MissingGlobal (grinForeignCallName foreignCall)))
-    Right
-    (Map.lookup (grinForeignCallName foreignCall) (compileForeignLabels env))
 
 primitiveId :: CompileEnv -> Text -> Either Arm64Error Int
 primitiveId env = primitiveIdentifier (compileAllowUnsupportedPrimitives env)
@@ -747,6 +756,7 @@ boundVars expression =
     GrinDictSelect {} -> Set.empty
     GrinThrow _ -> Set.empty
     GrinCatch {} -> Set.empty
+    GrinForeignCallExpr {} -> Set.empty
   where
     altBoundVars alternative = Set.fromList (grinAltBinders alternative) <> boundVars (grinAltRhs alternative)
 
@@ -813,6 +823,9 @@ exprRuntimeReps expression =
     GrinThrow exception -> valueRuntimeReps exception
     GrinCatch runtimeRep action handler state ->
       runtimeRep : concatMap valueRuntimeReps [action, handler, state]
+    GrinForeignCallExpr foreignCall arguments ->
+      grinForeignCallResultRep (grinForeignCallSignature foreignCall)
+        : concatMap valueRuntimeReps arguments
   where
     altRuntimeReps alternative =
       map grinVarRuntimeRep (grinAltBinders alternative)
@@ -830,9 +843,6 @@ nodeRuntimeReps node = concatMap valueRuntimeReps (grinNodeFields node)
 
 functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index
-
-foreignLabel :: Int -> Text
-foreignLabel index = ".Laihc_foreign_" <> tshow index
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot =

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -39,9 +39,9 @@ eliminateDeadCode entry (FcProgram topBinds) =
     indexedTopBinds = zip [0 :: Int ..] topBinds
     valueDefinitions =
       Map.fromList
-        [ (varName var, (index, references))
+        [ (name, (index, references))
         | (index, topBind) <- indexedTopBinds,
-          (var, references) <- valueDefinitionsOf topBind
+          (name, references) <- valueDefinitionsOf topBind
         ]
     typeDefinitions =
       Map.fromList
@@ -80,17 +80,17 @@ keepTopBind valueDefinitions typeDefinitions values types index topBind =
   case topBind of
     FcData name _ _ -> selectedType name
     FcNewtype declaration -> selectedType (fcNewtypeName declaration)
-    _ -> any selectedValue [varName var | (var, _) <- valueDefinitionsOf topBind]
+    _ -> any selectedValue [name | (name, _) <- valueDefinitionsOf topBind]
   where
     selectedValue name = name `Set.member` values && fmap fst (Map.lookup name valueDefinitions) == Just index
     selectedType name = name `Set.member` types && fmap fst (Map.lookup name typeDefinitions) == Just index
 
-valueDefinitionsOf :: FcTopBind -> [(Var, References)]
+valueDefinitionsOf :: FcTopBind -> [(Text, References)]
 valueDefinitionsOf topBind =
   case topBind of
-    FcPrimitive var _ -> [(var, referencesVarType var)]
-    FcForeignImport foreignCall -> [(fcForeignCallVar foreignCall, referencesVarType (fcForeignCallVar foreignCall))]
-    FcTopBind bind -> [(var, referencesTopLevelBind bind) | var <- bindersOf bind]
+    FcPrimitive var _ -> [(varName var, referencesVarType var)]
+    FcForeignImport foreignCall -> [(fcForeignCallName foreignCall, mempty)]
+    FcTopBind bind -> [(varName var, referencesTopLevelBind bind) | var <- bindersOf bind]
     FcData {} -> []
     FcNewtype {} -> []
 
@@ -148,6 +148,9 @@ referencesExpr bound expression =
         <> referencesVarType binder
         <> foldMap (referencesAlt (Set.insert binder bound)) alternatives
     FcCast inner coercion -> referencesExpr bound inner <> referencesCoercion coercion
+    FcCallForeign foreignCall arguments ->
+      mempty {referencedValues = Set.singleton (fcForeignCallName foreignCall)}
+        <> foldMap (referencesExpr bound) arguments
 
 referencesLet :: Set Var -> FcBind -> FcExpr -> References
 referencesLet bound bind body =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -45,9 +45,10 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Resolve (ResolveResult (..), resolve)
 import Aihc.Tc (TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
-import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
+import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
-import Control.Monad (zipWithM)
+import Control.Applicative ((<|>))
+import Control.Monad (foldM, zipWithM)
 import Control.Monad.Trans.State.Strict (runStateT)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
@@ -147,8 +148,12 @@ dsModule m = do
 dsDecl :: Decl -> DsM [FcTopBind]
 dsDecl (DeclData dd) = (: []) <$> dsDataDeclM dd
 dsDecl (DeclNewtype nd) = (: []) <$> dsNewtypeDeclM nd
+dsDecl (DeclAnn ann inner)
+  | Just foreignAnn <- fromAnnotation ann,
+    Just (tcAnn, foreignDecl) <- annotatedForeignDecl inner =
+      dsForeignImport tcAnn (Just foreignAnn) foreignDecl
 dsDecl (DeclAnn ann (DeclForeign foreignDecl))
-  | Just tcAnn <- fromAnnotation ann = (: []) <$> dsForeignImport tcAnn foreignDecl
+  | Just tcAnn <- fromAnnotation ann = dsForeignImport tcAnn Nothing foreignDecl
 dsDecl (DeclAnn ann (DeclClass _classDecl))
   | Just classAnn <- fromAnnotation ann = dsClassDeclM classAnn
 dsDecl (DeclAnn _ inner) = dsDecl inner
@@ -191,14 +196,26 @@ dsNewtypeDeclM nd = do
     asTyVar (TcTyVar tyVar) = Just tyVar
     asTyVar _ = Nothing
 
-dsForeignImport :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
-dsForeignImport tcAnn foreignDecl
+annotatedForeignDecl :: Decl -> Maybe (TcAnnotation, ForeignDecl)
+annotatedForeignDecl = go Nothing
+  where
+    go maybeTc decl =
+      case decl of
+        DeclAnn ann inner -> go (fromAnnotation ann <|> maybeTc) inner
+        DeclForeign foreignDecl -> (,foreignDecl) <$> maybeTc
+        _ -> Nothing
+
+dsForeignImport :: TcAnnotation -> Maybe TcForeignImportAnnotation -> ForeignDecl -> DsM [FcTopBind]
+dsForeignImport tcAnn foreignPlan foreignDecl
   | foreignDirection foreignDecl /= ForeignImport =
       desugarBug "unsupported foreign export after type checking"
   | otherwise =
       case foreignCallConv foreignDecl of
-        CPrim -> dsForeignPrim tcAnn foreignDecl
-        CCall -> dsForeignCcall tcAnn foreignDecl
+        CPrim -> (: []) <$> dsForeignPrim tcAnn foreignDecl
+        CCall ->
+          case foreignPlan of
+            Just plan -> dsForeignCcall tcAnn plan foreignDecl
+            Nothing -> desugarBug "missing type-checker foreign import plan"
         callConv -> desugarBug ("unsupported foreign calling convention after type checking: " <> show callConv)
 
 dsForeignPrim :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
@@ -209,8 +226,8 @@ dsForeignPrim tcAnn foreignDecl = do
   unique <- freshUnique
   pure (FcPrimitive (Var name unique ty) arity)
 
-dsForeignCcall :: TcAnnotation -> ForeignDecl -> DsM FcTopBind
-dsForeignCcall tcAnn foreignDecl = do
+dsForeignCcall :: TcAnnotation -> TcForeignImportAnnotation -> ForeignDecl -> DsM [FcTopBind]
+dsForeignCcall tcAnn foreignPlan foreignDecl = do
   if foreignSafety foreignDecl == Just Unsafe
     then pure ()
     else desugarBug "only unsafe foreign imports are supported"
@@ -221,42 +238,108 @@ dsForeignCcall tcAnn foreignDecl = do
       ForeignEntityOmitted -> pure (unqualifiedNameText (foreignName foreignDecl))
       _ -> desugarBug "only statically named foreign imports are supported"
   let name = unqualifiedNameText (foreignName foreignDecl)
-      ty = tcAnnType tcAnn
-  signature <- foreignCallSignature ty
-  unique <- freshUnique
-  pure
-    ( FcForeignImport
+      wrapperType = tcAnnType tcAnn
+      signature =
+        FcForeignSignature
+          { fcForeignArgumentTypes = map (lowerForeignAbiType . tcForeignAbiType) (tcForeignArguments foreignPlan),
+            fcForeignResultType = lowerForeignAbiType (tcForeignAbiType (tcForeignResult foreignPlan)),
+            fcForeignEffect = lowerForeignEffect (tcForeignEffect foreignPlan)
+          }
+      foreignCall =
         FcForeignCall
-          { fcForeignCallVar = Var name unique ty,
+          { fcForeignCallName = "$ffi$" <> name,
             fcForeignCallSymbol = symbol,
             fcForeignCallSignature = signature
           }
-    )
-
-foreignCallSignature :: TcType -> DsM FcForeignSignature
-foreignCallSignature ty = do
-  let (arguments, result) = splitForeignFunctionType ty
-  argumentTypes <- traverse marshalForeignType arguments
-  resultType <-
-    case result of
-      TcTyCon (TyCon "IO" 1) [ioResult] -> FcForeignIO <$> marshalForeignType ioResult
-      _ -> FcForeignPure <$> marshalForeignType result
+  wrapperVar <- freshVar name wrapperType
+  argumentVars <-
+    mapM
+      (\(index, marshal) -> freshVar ("$ffi_arg_" <> T.pack (show index)) (tcForeignSourceType marshal))
+      (zip [0 :: Int ..] (tcForeignArguments foreignPlan))
+  wrapperBody <-
+    unboxForeignArguments (zip argumentVars (tcForeignArguments foreignPlan)) $ \arguments ->
+      case tcForeignEffect foreignPlan of
+        TcForeignPure ->
+          boxForeignValue (tcForeignResult foreignPlan) (FcCallForeign foreignCall arguments)
+        TcForeignRealWorld -> makeForeignIoWrapper foreignCall (tcForeignResult foreignPlan) arguments
   pure
-    FcForeignSignature
-      { fcForeignArgumentTypes = argumentTypes,
-        fcForeignResult = resultType
-      }
+    [ FcForeignImport foreignCall,
+      FcTopBind (FcNonRec wrapperVar (foldr FcLam wrapperBody argumentVars))
+    ]
 
-splitForeignFunctionType :: TcType -> ([TcType], TcType)
-splitForeignFunctionType (TcFunTy argument result) =
-  let (arguments, finalResult) = splitForeignFunctionType result
-   in (argument : arguments, finalResult)
-splitForeignFunctionType result = ([], result)
+lowerForeignAbiType :: TcForeignAbiType -> FcForeignType
+lowerForeignAbiType foreignType =
+  case foreignType of
+    TcForeignInt32 -> FcForeignInt32
+    TcForeignWord64 -> FcForeignWord64
 
-marshalForeignType :: TcType -> DsM FcForeignType
-marshalForeignType (TcTyCon (TyCon "CInt" 0) []) = pure FcForeignCInt
-marshalForeignType ty =
-  desugarBug ("unsupported foreign import value type: " <> show ty)
+lowerForeignEffect :: TcForeignEffect -> FcForeignEffect
+lowerForeignEffect effect =
+  case effect of
+    TcForeignPure -> FcForeignPure
+    TcForeignRealWorld -> FcForeignRealWorld
+
+unboxForeignArguments :: [(Var, TcForeignMarshal)] -> ([FcExpr] -> DsM FcExpr) -> DsM FcExpr
+unboxForeignArguments arguments continuation = go arguments []
+  where
+    go [] values = continuation (reverse values)
+    go ((var, marshal) : rest) values =
+      unboxForeignValue marshal (FcVar var) $ \value -> go rest (value : values)
+
+unboxForeignValue :: TcForeignMarshal -> FcExpr -> (FcExpr -> DsM FcExpr) -> DsM FcExpr
+unboxForeignValue marshal expression continuation =
+  go (tcForeignSourceType marshal) (tcForeignConstructors marshal) expression
+  where
+    go _ [] value = continuation value
+    go valueType (constructor : constructors) value = do
+      constructorType <- dropForAlls <$> lookupType constructor
+      fieldType <-
+        case constructorType of
+          TcFunTy field _ -> pure field
+          _ -> desugarBug ("foreign marshalling constructor is not unary: " <> T.unpack constructor)
+      caseBinder <- freshVar "$ffi_case" valueType
+      fieldBinder <- freshVar "$ffi_field" fieldType
+      rhs <- go fieldType constructors (FcVar fieldBinder)
+      pure
+        ( FcCase
+            value
+            caseBinder
+            [FcAlt (DataAlt constructor) [fieldBinder] rhs]
+        )
+
+boxForeignValue :: TcForeignMarshal -> FcExpr -> DsM FcExpr
+boxForeignValue marshal rawValue =
+  foldM applyConstructor rawValue (reverse (tcForeignConstructors marshal))
+  where
+    applyConstructor value constructor = do
+      constructorType <- lookupType constructor
+      constructorVar <- freshVar constructor constructorType
+      pure (FcApp (FcVar constructorVar) value)
+
+makeForeignIoWrapper :: FcForeignCall -> TcForeignMarshal -> [FcExpr] -> DsM FcExpr
+makeForeignIoWrapper foreignCall resultMarshal arguments = do
+  stateVar <- freshVar "$ffi_state" statePrimRealWorldTy
+  tupleBinder <- freshVar "$ffi_result" (fcForeignCallResultType (fcForeignCallSignature foreignCall))
+  nextStateVar <- freshVar "$ffi_next_state" statePrimRealWorldTy
+  rawResultVar <- freshVar "$ffi_raw_result" (tcForeignPrimitiveType resultMarshal)
+  boxedResult <- boxForeignValue resultMarshal (FcVar rawResultVar)
+  tupleConstructor <-
+    freshVar
+      "(#,#)"
+      (TcFunTy statePrimRealWorldTy (TcFunTy (tcForeignSourceType resultMarshal) (unboxedTupleTy [statePrimRealWorldTy, tcForeignSourceType resultMarshal])))
+  ioConstructorType <- lookupType "IO"
+  ioConstructor <- freshVar "IO" ioConstructorType
+  let resultTuple = FcApp (FcApp (FcVar tupleConstructor) (FcVar nextStateVar)) boxedResult
+      call = FcCallForeign foreignCall (arguments <> [FcVar stateVar])
+      stateAction =
+        FcLam
+          stateVar
+          ( FcCase
+              call
+              tupleBinder
+              [FcAlt (DataAlt "(#,#)") [nextStateVar, rawResultVar] resultTuple]
+          )
+  pure (FcApp (FcTyApp (FcVar ioConstructor) (tcForeignSourceType resultMarshal)) stateAction)
 
 validatePrimitiveImport :: Text -> TcType -> DsM Int
 validatePrimitiveImport name ty =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1313,6 +1313,8 @@ fcExprTypeM expr =
         [] -> desugarBug "case expression has no alternatives while desugaring"
         FcAlt _ _ body : _ -> fcExprTypeM body
     FcCast inner _co -> fcExprTypeM inner
+    FcCallForeign foreignCall _arguments ->
+      pure (fcForeignCallResultType (fcForeignCallSignature foreignCall))
 
 dictKey :: Text -> [TcType] -> Text
 dictKey className args = className <> ":" <> T.intercalate "," (map typeKey args)

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -15,7 +15,7 @@ import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Types (RuntimeRep (..), TcType (..), TyCon (..))
 import Control.Exception (SomeException, displayException, try)
-import Control.Monad (zipWithM, (<=<))
+import Control.Monad (zipWithM, (<=<), (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
 import Data.Char qualified as Char
@@ -24,8 +24,9 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
-import Foreign.LibFFI (Arg, argCInt, callFFI, retCInt)
+import Foreign.LibFFI (Arg, argCInt, argWord64, callFFI, retCInt, retWord64)
 import Foreign.Ptr (FunPtr)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
@@ -50,8 +51,6 @@ data Value
   | VConstructor Text [Value]
   | VDict [Value]
   | VPrim Text Int [Value]
-  | VForeign FcForeignCall [Value]
-  | VForeignIOAction FcForeignCall [Value]
   | VMutVar EvalMutVar
   | VStateToken
   | VThunk Env FcExpr
@@ -87,14 +86,9 @@ evalProgramBinding name sourceProgram = runExceptT $
           var <- bindersOf bind,
           isIOType (varType var)
         ]
-    env = foreignTopEnv `Map.union` primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
-    foreignTopEnv = Map.fromList (concatMap foreignTopBindingValues (fcTopBinds program))
+    env = primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
     primitiveTopEnv = Map.fromList (concatMap primitiveTopBindingValues (fcTopBinds program))
     topEnv = Map.fromList (concatMap topBindingValues (fcTopBinds program))
-    foreignTopBindingValues (FcForeignImport foreignCall) =
-      [(varName (fcForeignCallVar foreignCall), VForeign foreignCall [])]
-    foreignTopBindingValues _ =
-      []
     primitiveTopBindingValues (FcPrimitive var arity) =
       [(varName var, VPrim (varName var) arity [])]
     primitiveTopBindingValues _ =
@@ -167,14 +161,14 @@ evalWithEnv env expr =
       matchAlternative env value alts
     FcCast inner _ ->
       evalWithEnv env inner
+    FcCallForeign foreignCall arguments -> do
+      values <- mapM (evalWithEnv env >=> forceValue) arguments
+      executeForeignCall foreignCall values
 
 forceValue :: Value -> EvalM Value
 forceValue value =
   case value of
     VThunk env expr -> evalWithEnv env expr
-    VForeign foreignCall []
-      | null (fcForeignArgumentTypes (fcForeignCallSignature foreignCall)) ->
-          completeForeignCall foreignCall []
     VPrim name 0 [] -> evalPrimitive name []
     _ -> pure value
 
@@ -195,11 +189,6 @@ applyValue value arg = do
       pure (VConstructor name (args <> [arg]))
     VPrim name arity args ->
       applyPrimitive name arity (args <> [arg])
-    VForeign foreignCall args ->
-      applyForeign foreignCall (args <> [arg])
-    VForeignIOAction foreignCall args -> do
-      result <- callForeign foreignCall args
-      pure (VConstructor "(#,#)" [arg, result])
     _ ->
       throwE (EvalApplyNonFunction forced)
 
@@ -282,21 +271,23 @@ forceMutVarPrimitiveArg name value = do
     VMutVar mutVar -> pure mutVar
     other -> throwE (EvalPrimitiveTypeError name other)
 
-applyForeign :: FcForeignCall -> [Value] -> EvalM Value
-applyForeign foreignCall args
-  | actualArity < expectedArity = pure (VForeign foreignCall args)
-  | actualArity == expectedArity = completeForeignCall foreignCall args
-  | otherwise = throwE (EvalForeignArity name expectedArity actualArity)
+executeForeignCall :: FcForeignCall -> [Value] -> EvalM Value
+executeForeignCall foreignCall arguments
+  | actualArity /= expectedArity = throwE (EvalForeignArity name expectedArity actualArity)
+  | otherwise =
+      case fcForeignEffect signature of
+        FcForeignPure -> callForeign foreignCall arguments
+        FcForeignRealWorld ->
+          case reverse arguments of
+            state : reversedAbiArguments -> do
+              result <- callForeign foreignCall (reverse reversedAbiArguments)
+              pure (VConstructor "(#,#)" [state, result])
+            [] -> throwE (EvalForeignArity name expectedArity actualArity)
   where
-    name = varName (fcForeignCallVar foreignCall)
-    actualArity = length args
-    expectedArity = length (fcForeignArgumentTypes (fcForeignCallSignature foreignCall))
-
-completeForeignCall :: FcForeignCall -> [Value] -> EvalM Value
-completeForeignCall foreignCall args =
-  case fcForeignResult (fcForeignCallSignature foreignCall) of
-    FcForeignPure _ -> callForeign foreignCall args
-    FcForeignIO _ -> pure (VForeignIOAction foreignCall args)
+    name = fcForeignCallName foreignCall
+    signature = fcForeignCallSignature foreignCall
+    actualArity = length arguments
+    expectedArity = length (fcForeignOperandTypes signature)
 
 callForeign :: FcForeignCall -> [Value] -> EvalM Value
 callForeign foreignCall args = do
@@ -306,19 +297,21 @@ callForeign foreignCall args = do
       (fcForeignArgumentTypes (fcForeignCallSignature foreignCall))
       args
   functionPointer <- lookupForeignFunction foreignCall
-  case foreignResultType (fcForeignResult (fcForeignCallSignature foreignCall)) of
-    FcForeignCInt -> do
+  case fcForeignResultType (fcForeignCallSignature foreignCall) of
+    FcForeignInt32 -> do
       CInt result <- lift (callFFI functionPointer retCInt marshalledArgs)
-      pure (cIntValue (toInteger result))
-
-foreignResultType :: FcForeignResult -> FcForeignType
-foreignResultType (FcForeignPure resultType) = resultType
-foreignResultType (FcForeignIO resultType) = resultType
+      pure (VLit (LitInt Int32Rep (toInteger result)))
+    FcForeignWord64 -> do
+      result <- lift (callFFI functionPointer retWord64 marshalledArgs)
+      pure (VLit (LitInt Word64Rep (toInteger result)))
 
 marshalForeignArgument :: Text -> FcForeignType -> Value -> EvalM Arg
-marshalForeignArgument symbol FcForeignCInt argument = do
-  argumentValue <- forceCInt symbol argument
+marshalForeignArgument symbol FcForeignInt32 argument = do
+  argumentValue <- forceInt32 symbol argument
   pure (argCInt (CInt (fromInteger argumentValue)))
+marshalForeignArgument symbol FcForeignWord64 argument = do
+  argumentValue <- forceWord64 symbol argument
+  pure (argWord64 (fromInteger argumentValue :: Word64))
 
 lookupForeignFunction :: FcForeignCall -> EvalM (FunPtr ())
 lookupForeignFunction foreignCall = do
@@ -335,22 +328,19 @@ lookupForeignFunction foreignCall = do
 tryForeign :: IO a -> IO (Either SomeException a)
 tryForeign = try
 
-forceCInt :: Text -> Value -> EvalM Integer
-forceCInt symbol value = do
+forceInt32 :: Text -> Value -> EvalM Integer
+forceInt32 symbol value = do
   forced <- forceValue value
   case forced of
-    VConstructor "I32#" [literal] -> forceInt32 literal
+    VLit (LitInt Int32Rep intValue) -> pure intValue
     other -> throwE (EvalForeignTypeError symbol other)
-  where
-    forceInt32 literal = do
-      forcedLiteral <- forceValue literal
-      case forcedLiteral of
-        VLit (LitInt _ intValue) -> pure intValue
-        other -> throwE (EvalForeignTypeError symbol other)
 
-cIntValue :: Integer -> Value
-cIntValue value =
-  VConstructor "I32#" [VLit (LitInt Int32Rep value)]
+forceWord64 :: Text -> Value -> EvalM Integer
+forceWord64 symbol value = do
+  forced <- forceValue value
+  case forced of
+    VLit (LitInt Word64Rep intValue) -> pure intValue
+    other -> throwE (EvalForeignTypeError symbol other)
 
 bindersOf :: FcBind -> [Var]
 bindersOf bind =
@@ -439,8 +429,6 @@ renderForcedValue value =
     VDict {} -> pure "<dictionary>"
     VClosure {} -> pure "<function>"
     VPrim {} -> pure "<function>"
-    VForeign {} -> pure "<function>"
-    VForeignIOAction {} -> pure "<io action>"
     VMutVar {} -> pure "<mutvar>"
     VStateToken -> pure "<state>"
     VThunk {} -> renderValueM value
@@ -513,8 +501,6 @@ renderRawValueM value = do
     VDict {} -> pure "<dictionary>"
     VClosure {} -> pure "<function>"
     VPrim {} -> pure "<function>"
-    VForeign {} -> pure "<function>"
-    VForeignIOAction {} -> pure "<io action>"
     VMutVar {} -> pure "<mutvar>"
     VStateToken -> pure "<state>"
     VThunk {} -> renderRawValueM forced

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -48,6 +48,8 @@ data LintError
     InconsistentAlts !TcType !TcType
   | -- | General lint failure.
     LintFailure !String
+  | UnknownForeignCall !Text
+  | ForeignCallDescriptorMismatch !Text
   deriving (Eq, Show)
 
 -- | Lint environment.
@@ -59,7 +61,8 @@ data LintEnv = LintEnv
     -- | Known data constructors: name -> (type var params, field types, result type).
     leDataCons :: !(Map Text ([TyVarId], [TcType], TcType)),
     -- | Representational equality axioms introduced by newtypes.
-    leNewtypes :: !(Map Text FcNewtypeDecl)
+    leNewtypes :: !(Map Text FcNewtypeDecl),
+    leForeignCalls :: !(Map Text FcForeignCall)
   }
   deriving (Show)
 
@@ -70,18 +73,21 @@ emptyLintEnv =
     { leTerms = Map.empty,
       leTyVars = Set.empty,
       leDataCons = Map.empty,
-      leNewtypes = Map.empty
+      leNewtypes = Map.empty,
+      leForeignCalls = Map.empty
     }
 
 -- | Lint an entire program.
 lintProgram :: LintEnv -> FcProgram -> [LintError]
-lintProgram env0 prog = go envWithNewtypes (fcTopBinds prog)
+lintProgram env0 prog = go envWithDeclarations (fcTopBinds prog)
   where
-    envWithNewtypes = foldr registerNewtype env0 (fcTopBinds prog)
+    envWithDeclarations = foldr registerDeclaration env0 (fcTopBinds prog)
 
-    registerNewtype (FcNewtype declaration) env =
+    registerDeclaration (FcNewtype declaration) env =
       env {leNewtypes = Map.insert (fcNewtypeName declaration) declaration (leNewtypes env)}
-    registerNewtype _ env = env
+    registerDeclaration (FcForeignImport foreignCall) env =
+      env {leForeignCalls = Map.insert (fcForeignCallName foreignCall) foreignCall (leForeignCalls env)}
+    registerDeclaration _ env = env
 
     go _ [] = []
     go env (FcData {} : rest) =
@@ -92,8 +98,8 @@ lintProgram env0 prog = go envWithNewtypes (fcTopBinds prog)
       go env rest
     go env (FcPrimitive var _arity : rest) =
       go (extendTermEnv var env) rest
-    go env (FcForeignImport foreignCall : rest) =
-      go (extendTermEnv (fcForeignCallVar foreignCall) env) rest
+    go env (FcForeignImport _ : rest) =
+      go env rest
     go env (FcTopBind bind : rest) =
       let (errs, env') = lintBind env bind
        in errs ++ go env' rest
@@ -180,6 +186,23 @@ lintExpr env (FcCast e co) = do
   if typesEqual eTy coFrom
     then Right coTo
     else Left (TypeMismatch "cast source" coFrom eTy)
+lintExpr env (FcCallForeign foreignCall arguments) = do
+  case Map.lookup (fcForeignCallName foreignCall) (leForeignCalls env) of
+    Nothing -> Left (UnknownForeignCall (fcForeignCallName foreignCall))
+    Just declared
+      | declared /= foreignCall -> Left (ForeignCallDescriptorMismatch (fcForeignCallName foreignCall))
+      | otherwise -> Right ()
+  argumentTypes <- mapM (lintExpr env) arguments
+  let expectedTypes = fcForeignOperandTypes (fcForeignCallSignature foreignCall)
+  if length argumentTypes /= length expectedTypes
+    then Left (LintFailure ("foreign call arity mismatch for " ++ show (fcForeignCallName foreignCall)))
+    else do
+      mapM_ checkArgument (zip expectedTypes argumentTypes)
+      pure (fcForeignCallResultType (fcForeignCallSignature foreignCall))
+  where
+    checkArgument (expected, actual)
+      | typesEqual expected actual = Right ()
+      | otherwise = Left (TypeMismatch "foreign call argument" expected actual)
 
 -- | Lint a case alternative.
 lintAlt :: LintEnv -> FcAlt -> Either LintError TcType

--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -80,6 +80,7 @@ lowerExpr env expr =
     FcLet bind body -> FcLet <$> lowerBind env bind <*> lowerExpr env body
     FcCase scrutinee binder alternatives -> lowerCase env scrutinee binder alternatives
     FcCast inner coercion -> (`FcCast` coercion) <$> lowerExpr env inner
+    FcCallForeign foreignCall arguments -> FcCallForeign foreignCall <$> mapM (lowerExpr env) arguments
 
 lowerTypeApplication :: NewtypeEnv -> FcExpr -> LowerM FcExpr
 lowerTypeApplication env expression =
@@ -179,7 +180,7 @@ topBindUniques :: FcTopBind -> [Int]
 topBindUniques topBind =
   case topBind of
     FcPrimitive var _ -> varUniques var
-    FcForeignImport foreignCall -> varUniques (fcForeignCallVar foreignCall)
+    FcForeignImport {} -> []
     FcTopBind bind -> bindUniques bind
     _ -> []
 
@@ -206,6 +207,7 @@ exprUniques expression =
     FcCase scrutinee binder alternatives ->
       exprUniques scrutinee <> varUniques binder <> concatMap altUniques alternatives
     FcCast inner _ -> exprUniques inner
+    FcCallForeign _ arguments -> concatMap exprUniques arguments
 
 altUniques :: FcAlt -> [Int]
 altUniques alternative = concatMap varUniques (altBinders alternative) <> exprUniques (altRhs alternative)

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -64,9 +64,9 @@ renderTopBind (FcForeignImport foreignCall) =
   "foreign ccall \""
     ++ T.unpack (fcForeignCallSymbol foreignCall)
     ++ "\" "
-    ++ renderVar (fcForeignCallVar foreignCall)
+    ++ T.unpack (fcForeignCallName foreignCall)
     ++ " : "
-    ++ renderType (varType (fcForeignCallVar foreignCall))
+    ++ renderType (fcForeignCallType (fcForeignCallSignature foreignCall))
 renderTopBind (FcTopBind bind) = renderBind 0 bind
 
 -- | Render data constructors.
@@ -173,6 +173,11 @@ renderExprPrec n parens (FcCase scrut binder alts) =
 renderExprPrec n parens (FcCast e _co) =
   paren parens $
     renderExprPrec n True e ++ " " ++ [castChar] ++ " <co>"
+renderExprPrec n parens (FcCallForeign foreignCall arguments) =
+  paren parens $
+    "foreign-call "
+      ++ T.unpack (fcForeignCallName foreignCall)
+      ++ concatMap ((" " ++) . renderExprPrec n True) arguments
 
 -- | Render a case alternative.
 renderAlt :: Int -> FcAlt -> String

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -26,8 +26,11 @@ module Aihc.Fc.Syntax
     FcProgram (..),
     FcForeignCall (..),
     FcForeignSignature (..),
-    FcForeignResult (..),
+    FcForeignEffect (..),
     FcForeignType (..),
+    fcForeignOperandTypes,
+    fcForeignCallResultType,
+    fcForeignCallType,
 
     -- * Case alternatives
     FcAlt (..),
@@ -67,7 +70,8 @@ data FcTopBind
     FcNewtype !FcNewtypeDecl
   | -- | A primitive imported by @foreign import prim@.
     FcPrimitive !Var !Int
-  | -- | A C function imported by @foreign import ccall@.
+  | -- | A C symbol available to saturated 'FcCallForeign' expressions.  It
+    -- does not introduce a term variable.
     FcForeignImport !FcForeignCall
   | -- | Value binding.
     FcTopBind !FcBind
@@ -88,7 +92,7 @@ data FcNewtypeDecl = FcNewtypeDecl
 
 -- | A statically named C function resolved by the evaluator or a code generator.
 data FcForeignCall = FcForeignCall
-  { fcForeignCallVar :: !Var,
+  { fcForeignCallName :: !Text,
     fcForeignCallSymbol :: !Text,
     fcForeignCallSignature :: !FcForeignSignature
   }
@@ -100,20 +104,51 @@ data FcForeignCall = FcForeignCall
 -- does not require a constructor for every arity and result combination.
 data FcForeignSignature = FcForeignSignature
   { fcForeignArgumentTypes :: ![FcForeignType],
-    fcForeignResult :: !FcForeignResult
+    fcForeignResultType :: !FcForeignType,
+    fcForeignEffect :: !FcForeignEffect
   }
   deriving (Eq, Show, Read)
 
--- | Whether a foreign call is pure or produces an 'IO' action.
-data FcForeignResult
-  = FcForeignPure !FcForeignType
-  | FcForeignIO !FcForeignType
+data FcForeignEffect
+  = FcForeignPure
+  | FcForeignRealWorld
   deriving (Eq, Show, Read)
 
 -- | A value type with explicit host ABI marshalling support.
 data FcForeignType
-  = FcForeignCInt
+  = FcForeignInt32
+  | FcForeignWord64
   deriving (Eq, Show, Read)
+
+fcForeignOperandTypes :: FcForeignSignature -> [TcType]
+fcForeignOperandTypes signature =
+  map foreignPrimitiveType (fcForeignArgumentTypes signature)
+    <> case fcForeignEffect signature of
+      FcForeignPure -> []
+      FcForeignRealWorld -> [statePrimRealWorldType]
+
+fcForeignCallResultType :: FcForeignSignature -> TcType
+fcForeignCallResultType signature =
+  case fcForeignEffect signature of
+    FcForeignPure -> foreignPrimitiveType (fcForeignResultType signature)
+    FcForeignRealWorld ->
+      TcTyCon
+        (TyCon "(#,#)" 2)
+        [statePrimRealWorldType, foreignPrimitiveType (fcForeignResultType signature)]
+
+fcForeignCallType :: FcForeignSignature -> TcType
+fcForeignCallType signature =
+  foldr TcFunTy (fcForeignCallResultType signature) (fcForeignOperandTypes signature)
+
+foreignPrimitiveType :: FcForeignType -> TcType
+foreignPrimitiveType foreignType =
+  case foreignType of
+    FcForeignInt32 -> TcTyCon (TyCon "Int32#" 0) []
+    FcForeignWord64 -> TcTyCon (TyCon "Word64#" 0) []
+
+statePrimRealWorldType :: TcType
+statePrimRealWorldType =
+  TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
 
 -- | A typed variable.
 data Var = Var
@@ -161,6 +196,9 @@ data FcExpr
     FcCase !FcExpr !Var ![FcAlt]
   | -- | Cast: @e \triangleright \gamma@.
     FcCast !FcExpr !Coercion
+  | -- | A fully saturated foreign call.  Unlike a term application, this
+    -- node cannot represent a foreign function value or partial application.
+    FcCallForeign !FcForeignCall ![FcExpr]
   deriving (Eq, Show, Read)
 
 -- | Binding group.

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-primitive-wrapper.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-primitive-wrapper.yaml
@@ -1,0 +1,48 @@
+expected: |-
+  data State#
+
+  data RealWorld
+
+  data Int32
+   = I32# Int32#
+
+  newtype CInt = CInt Int32
+
+  newtype IO a = IO ((State# RealWorld) → (#,#) (State# RealWorld) a)
+
+  foreign ccall "putchar" $ffi$putchar : Int32# → (State# RealWorld) → (#,#) (State# RealWorld) Int32#
+
+  putchar : CInt → IO CInt =
+    λ$ffi_arg_0 : CInt.
+      let
+        $ffi_case : CInt =
+          $ffi_arg_0
+      in
+        let
+          $ffi_field : Int32 =
+            $ffi_case ▷ <co>
+        in
+          case $ffi_field as $ffi_case : Int32 of
+            I32# $ffi_field →
+              (λ$ffi_state : State# RealWorld.
+                case foreign-call $ffi$putchar $ffi_field $ffi_state as $ffi_result : (#,#) (State# RealWorld) Int32# of
+                  (#,#) $ffi_next_state $ffi_raw_result →
+                    (#,#) $ffi_next_state ((I32# $ffi_raw_result) ▷ <co>)) ▷ <co>
+extensions:
+- ForeignFunctionInterface
+- MagicHash
+- UnboxedTuples
+modules:
+- |
+  module Test where
+
+  data State# s
+  data RealWorld
+  data Int32 = I32# Int32#
+  newtype CInt = CInt Int32
+  newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
+
+  foreign import ccall unsafe putchar :: CInt -> IO CInt
+reason: ccall desugaring exposes only a saturated primitive operation beneath the
+  Haskell wrapper
+status: pass

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -24,8 +24,9 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
-import Foreign.LibFFI (Arg, argCInt, callFFI, retCInt)
+import Foreign.LibFFI (Arg, argCInt, argWord64, callFFI, retCInt, retWord64)
 import Foreign.Ptr (FunPtr)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
@@ -144,10 +145,6 @@ initialMachine program =
       Map.unions
         [ Map.fromList [(grinVarName var, value) | (var, value) <- cafLocations],
           Map.fromList
-            [ (grinForeignCallName foreignCall, RuntimeNode (GrinForeign foreignCall) [])
-            | foreignCall <- grinForeignCalls program
-            ],
-          Map.fromList
             [ (grinVarName var, RuntimeNode (GrinPrimitive (grinVarName var) arity) [])
             | (var, arity) <- grinPrimitives program
             ],
@@ -206,6 +203,9 @@ evalExpr env expr =
       handlerValue <- evalValue env handler
       stateValue <- evalValue env state
       applyValue actionValue stateValue `catchE` handleRaised handlerValue stateValue
+    GrinForeignCallExpr foreignCall arguments -> do
+      argumentValues <- mapM (evalValue env) arguments
+      executeForeignCall foreignCall argumentValues
 
 handleRaised :: RuntimeValue -> RuntimeValue -> EvalFailure -> EvalM RuntimeValue
 handleRaised handler state failure =
@@ -282,9 +282,6 @@ forceValue :: RuntimeValue -> EvalM RuntimeValue
 forceValue value =
   case value of
     RuntimeLocation location -> forceLocation location
-    RuntimeNode (GrinForeign foreignCall) []
-      | null (grinForeignArgumentTypes (grinForeignCallSignature foreignCall)) ->
-          completeForeignCall foreignCall []
     RuntimeNode (GrinPrimitive name 0) [] -> evalPrimitive name []
     _ -> pure value
 
@@ -323,11 +320,6 @@ applyValue function argument = do
       pure (RuntimeNode constructor (fields <> [argument]))
     RuntimeNode (GrinPrimitive name arity) fields ->
       applyPrimitive name arity (fields <> [argument])
-    RuntimeNode (GrinForeign foreignCall) fields ->
-      applyForeign foreignCall (fields <> [argument])
-    RuntimeNode (GrinForeignIOAction foreignCall) fields -> do
-      result <- callForeign foreignCall fields
-      pure (RuntimeNode (GrinConstructor "(#,#)") [argument, result])
     other -> throwInterpret (InterpretApplyNonFunction other)
 
 callFunction :: FunctionName -> [RuntimeValue] -> EvalM RuntimeValue
@@ -417,22 +409,23 @@ compareInts left right =
     EQ -> 0
     GT -> 1
 
-applyForeign :: GrinForeignCall -> [RuntimeValue] -> EvalM RuntimeValue
-applyForeign foreignCall arguments
-  | actualArity < expectedArity = pure (RuntimeNode (GrinForeign foreignCall) arguments)
-  | actualArity == expectedArity = completeForeignCall foreignCall arguments
-  | otherwise = throwInterpret (InterpretForeignArity name expectedArity actualArity)
+executeForeignCall :: GrinForeignCall -> [RuntimeValue] -> EvalM RuntimeValue
+executeForeignCall foreignCall arguments
+  | actualArity /= expectedArity = throwInterpret (InterpretForeignArity name expectedArity actualArity)
+  | otherwise =
+      case grinForeignEffect signature of
+        GrinForeignPure -> callForeign foreignCall arguments
+        GrinForeignRealWorld ->
+          case reverse arguments of
+            state : reversedAbiArguments -> do
+              result <- callForeign foreignCall (reverse reversedAbiArguments)
+              pure (RuntimeNode (GrinConstructor "(#,#)") [state, result])
+            [] -> throwInterpret (InterpretForeignArity name expectedArity actualArity)
   where
     name = grinForeignCallName foreignCall
+    signature = grinForeignCallSignature foreignCall
     actualArity = length arguments
-    expectedArity = length (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
-
-completeForeignCall :: GrinForeignCall -> [RuntimeValue] -> EvalM RuntimeValue
-completeForeignCall foreignCall arguments =
-  case grinForeignResult (grinForeignCallSignature foreignCall) of
-    GrinForeignPure _ -> callForeign foreignCall arguments
-    GrinForeignIO _ ->
-      pure (RuntimeNode (GrinForeignIOAction foreignCall) arguments)
+    expectedArity = length (grinForeignOperandReps signature)
 
 callForeign :: GrinForeignCall -> [RuntimeValue] -> EvalM RuntimeValue
 callForeign foreignCall arguments = do
@@ -442,21 +435,21 @@ callForeign foreignCall arguments = do
       (grinForeignArgumentTypes (grinForeignCallSignature foreignCall))
       arguments
   functionPointer <- lookupForeignFunction foreignCall
-  case foreignResultType (grinForeignResult (grinForeignCallSignature foreignCall)) of
-    GrinForeignCInt -> do
+  case grinForeignResultType (grinForeignCallSignature foreignCall) of
+    GrinForeignInt32 -> do
       CInt result <- liftEvalIO (callFFI functionPointer retCInt marshalledArguments)
-      pure (cIntValue (toInteger result))
-
-foreignResultType :: GrinForeignResult -> GrinForeignType
-foreignResultType result =
-  case result of
-    GrinForeignPure resultType -> resultType
-    GrinForeignIO resultType -> resultType
+      pure (RuntimeLit (GrinLitInt Int32Rep (toInteger result)))
+    GrinForeignWord64 -> do
+      result <- liftEvalIO (callFFI functionPointer retWord64 marshalledArguments)
+      pure (RuntimeLit (GrinLitInt Word64Rep (toInteger result)))
 
 marshalForeignArgument :: Text -> GrinForeignType -> RuntimeValue -> EvalM Arg
-marshalForeignArgument symbol GrinForeignCInt argument = do
-  argumentValue <- forceCInt symbol argument
+marshalForeignArgument symbol GrinForeignInt32 argument = do
+  argumentValue <- forceInt32 symbol argument
   pure (argCInt (CInt (fromInteger argumentValue)))
+marshalForeignArgument symbol GrinForeignWord64 argument = do
+  argumentValue <- forceWord64 symbol argument
+  pure (argWord64 (fromInteger argumentValue :: Word64))
 
 lookupForeignFunction :: GrinForeignCall -> EvalM (FunPtr ())
 lookupForeignFunction foreignCall = do
@@ -473,24 +466,19 @@ lookupForeignFunction foreignCall = do
 tryForeign :: IO value -> IO (Either SomeException value)
 tryForeign = try
 
-forceCInt :: Text -> RuntimeValue -> EvalM Integer
-forceCInt symbol value = do
+forceInt32 :: Text -> RuntimeValue -> EvalM Integer
+forceInt32 symbol value = do
   forced <- forceValue value
   case forced of
-    RuntimeNode (GrinConstructor "I32#") [literal] -> forceInt32 literal
+    RuntimeLit (GrinLitInt Int32Rep intValue) -> pure intValue
     other -> throwInterpret (InterpretForeignTypeError symbol other)
-  where
-    forceInt32 literal = do
-      forcedLiteral <- forceValue literal
-      case forcedLiteral of
-        RuntimeLit (GrinLitInt _ intValue) -> pure intValue
-        other -> throwInterpret (InterpretForeignTypeError symbol other)
 
-cIntValue :: Integer -> RuntimeValue
-cIntValue value =
-  RuntimeNode
-    (GrinConstructor "I32#")
-    [RuntimeLit (GrinLitInt Int32Rep value)]
+forceWord64 :: Text -> RuntimeValue -> EvalM Integer
+forceWord64 symbol value = do
+  forced <- forceValue value
+  case forced of
+    RuntimeLit (GrinLitInt Word64Rep intValue) -> pure intValue
+    other -> throwInterpret (InterpretForeignTypeError symbol other)
 
 runIOValue :: RuntimeValue -> EvalM RuntimeValue
 runIOValue action = do
@@ -538,8 +526,6 @@ renderRawValueM value = do
     RuntimeNode GrinDictionary _ -> pure "<dictionary>"
     RuntimeNode GrinClosure {} _ -> pure "<function>"
     RuntimeNode GrinPrimitive {} _ -> pure "<function>"
-    RuntimeNode GrinForeign {} _ -> pure "<function>"
-    RuntimeNode GrinForeignIOAction {} _ -> pure "<io action>"
     RuntimeNode GrinThunk {} _ -> pure "<thunk>"
     RuntimeLocation _ -> renderRawValueM forced
     RuntimeMutVar {} -> pure "<mutvar>"

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -23,6 +23,9 @@ data GrinLintError
   | GrinLintFunctionArity !FunctionName !Int !Int
   | GrinLintRepresentationMismatch !String !RuntimeRep !RuntimeRep
   | GrinLintEvalNonLifted !RuntimeRep
+  | GrinLintForeignArity !Text !Int !Int
+  | GrinLintUnknownForeignCall !Text
+  | GrinLintForeignCallDescriptorMismatch !Text
   | GrinLintConstructorLayout !Text ![RuntimeRep] ![RuntimeRep]
   deriving (Eq, Show)
 
@@ -30,7 +33,8 @@ data LintEnv = LintEnv
   { lintFunctionArities :: !(Map FunctionName Int),
     lintGlobalVars :: !(Set GrinVar),
     lintGlobalNames :: !(Set Text),
-    lintConstructorLayouts :: !(Map Text [RuntimeRep])
+    lintConstructorLayouts :: !(Map Text [RuntimeRep]),
+    lintForeignCalls :: !(Map Text GrinForeignCall)
   }
 
 lintProgram :: GrinProgram -> [GrinLintError]
@@ -59,10 +63,10 @@ lintProgram program =
               ( map fst builtinConstructors
                   <> map fst (grinConstructors program)
                   <> map (grinVarName . fst) (grinPrimitives program)
-                  <> map grinForeignCallName (grinForeignCalls program)
                   <> map grinVarName cafVars
               ),
-          lintConstructorLayouts = Map.fromList (grinConstructors program)
+          lintConstructorLayouts = Map.fromList (grinConstructors program),
+          lintForeignCalls = Map.fromList [(grinForeignCallName call, call) | call <- grinForeignCalls program]
         }
 
 lintCaf :: LintEnv -> (GrinVar, GrinNode) -> [GrinLintError]
@@ -113,6 +117,24 @@ lintExpr env bound expr =
       lintValue env bound action
         <> lintValue env bound handler
         <> lintValue env bound state
+    GrinForeignCallExpr foreignCall arguments ->
+      let expectedReps = grinForeignOperandReps (grinForeignCallSignature foreignCall)
+          actualReps = map grinValueRuntimeRep arguments
+          descriptorErrors =
+            case Map.lookup (grinForeignCallName foreignCall) (lintForeignCalls env) of
+              Nothing -> [GrinLintUnknownForeignCall (grinForeignCallName foreignCall)]
+              Just declared
+                | declared /= foreignCall -> [GrinLintForeignCallDescriptorMismatch (grinForeignCallName foreignCall)]
+                | otherwise -> []
+       in descriptorErrors
+            <> [ GrinLintForeignArity (grinForeignCallName foreignCall) (length expectedReps) (length actualReps)
+               | length expectedReps /= length actualReps
+               ]
+            <> [ GrinLintRepresentationMismatch "foreign call argument" expected actual
+               | (expected, actual) <- zip expectedReps actualReps,
+                 expected /= actual
+               ]
+            <> concatMap (lintValue env bound) arguments
   where
     bindRepresentationErrors var valueExpr =
       case exprRuntimeRep valueExpr of
@@ -194,3 +216,5 @@ exprRuntimeRep expr =
     GrinDictSelect runtimeRep _ _ -> Just runtimeRep
     GrinThrow {} -> Nothing
     GrinCatch runtimeRep _ _ _ -> Just runtimeRep
+    GrinForeignCallExpr foreignCall _ ->
+      Just (grinForeignCallResultRep (grinForeignCallSignature foreignCall))

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -216,6 +216,9 @@ lowerOrdinaryExpr expr =
         pure (GrinCase value (lowerVar binder) loweredAlternatives)
     FcCast inner _ ->
       lowerExpr inner
+    FcCallForeign foreignCall arguments ->
+      lowerStrictMany arguments $ \values ->
+        pure (GrinForeignCallExpr (lowerForeignCall foreignCall) values)
 
 lowerApplication :: FcExpr -> FcExpr -> LowerM GrinExpr
 lowerApplication function argument =
@@ -324,6 +327,15 @@ lowerArgumentMany expressions continuation =
         lowerArgumentMany rest $ \restValues ->
           continuation (firstValue : restValues)
 
+lowerStrictMany :: [FcExpr] -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerStrictMany expressions continuation =
+  case expressions of
+    [] -> continuation []
+    first : rest ->
+      lowerStrict "foreign_argument" first $ \firstValue ->
+        lowerStrictMany rest $ \restValues ->
+          continuation (firstValue : restValues)
+
 freshVar :: Text -> RuntimeRep -> LowerM GrinVar
 freshVar hint runtimeRep = do
   unique <- gets lowerNextUnique
@@ -385,6 +397,7 @@ freeVars expr =
       freeVars scrutinee
         <> Set.delete binder (foldMap freeVarsAlt alternatives)
     FcCast inner _ -> freeVars inner
+    FcCallForeign _ arguments -> foldMap freeVars arguments
 
 freeVarsBind :: FcBind -> FcExpr -> Set Var
 freeVarsBind bind body =
@@ -478,7 +491,7 @@ lowerAltCon altCon =
 lowerForeignCall :: FcForeignCall -> GrinForeignCall
 lowerForeignCall foreignCall =
   GrinForeignCall
-    { grinForeignCallName = varName (fcForeignCallVar foreignCall),
+    { grinForeignCallName = fcForeignCallName foreignCall,
       grinForeignCallSymbol = fcForeignCallSymbol foreignCall,
       grinForeignCallSignature = lowerForeignSignature (fcForeignCallSignature foreignCall)
     }
@@ -487,19 +500,21 @@ lowerForeignSignature :: FcForeignSignature -> GrinForeignSignature
 lowerForeignSignature signature =
   GrinForeignSignature
     { grinForeignArgumentTypes = map lowerForeignType (fcForeignArgumentTypes signature),
-      grinForeignResult = lowerForeignResult (fcForeignResult signature)
+      grinForeignResultType = lowerForeignType (fcForeignResultType signature),
+      grinForeignEffect = lowerForeignEffect (fcForeignEffect signature)
     }
 
-lowerForeignResult :: FcForeignResult -> GrinForeignResult
-lowerForeignResult result =
-  case result of
-    FcForeignPure foreignType -> GrinForeignPure (lowerForeignType foreignType)
-    FcForeignIO foreignType -> GrinForeignIO (lowerForeignType foreignType)
+lowerForeignEffect :: FcForeignEffect -> GrinForeignEffect
+lowerForeignEffect effect =
+  case effect of
+    FcForeignPure -> GrinForeignPure
+    FcForeignRealWorld -> GrinForeignRealWorld
 
 lowerForeignType :: FcForeignType -> GrinForeignType
 lowerForeignType foreignType =
   case foreignType of
-    FcForeignCInt -> GrinForeignCInt
+    FcForeignInt32 -> GrinForeignInt32
+    FcForeignWord64 -> GrinForeignWord64
 
 exprRuntimeRep :: FcExpr -> RuntimeRep
 exprRuntimeRep expr =
@@ -538,6 +553,8 @@ exprType expr =
         first : _ -> exprType (altRhs first)
         [] -> Nothing
     FcCast inner _ -> exprType inner
+    FcCallForeign foreignCall _arguments ->
+      Just (fcForeignCallResultType (fcForeignCallSignature foreignCall))
   where
     functionResultType functionType =
       case functionType of
@@ -576,7 +593,7 @@ programGlobalNames program = concatMap topGlobalNames (fcTopBinds program)
         FcData _ _ constructors -> map fst constructors
         FcNewtype {} -> []
         FcPrimitive var _ -> [varName var]
-        FcForeignImport foreignCall -> [varName (fcForeignCallVar foreignCall)]
+        FcForeignImport {} -> []
         FcTopBind bind -> map (varName . fst) (topBindings bind)
     topBindings bind =
       case bind of
@@ -591,7 +608,7 @@ programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds progra
         FcData _ _ constructors -> map fst constructors
         FcNewtype {} -> []
         FcPrimitive var _ -> [varName var]
-        FcForeignImport foreignCall -> [varName (fcForeignCallVar foreignCall)]
+        FcForeignImport {} -> []
         FcTopBind {} -> []
 
 programIoCafs :: FcProgram -> Set Text
@@ -621,7 +638,7 @@ topVars topBind =
     FcData {} -> []
     FcNewtype {} -> []
     FcPrimitive var _ -> [var]
-    FcForeignImport foreignCall -> [fcForeignCallVar foreignCall]
+    FcForeignImport {} -> []
     FcTopBind bind -> bindVars bind
 
 bindVars :: FcBind -> [Var]
@@ -647,6 +664,7 @@ exprVars expr =
     FcCase scrutinee binder alternatives ->
       exprVars scrutinee <> (binder : concatMap altVars alternatives)
     FcCast inner _ -> exprVars inner
+    FcCallForeign _ arguments -> concatMap exprVars arguments
 
 altVars :: FcAlt -> [Var]
 altVars alt = grinAltBinders' <> exprVars (altRhs alt)

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -117,6 +117,11 @@ renderExprIndented indentation expr =
         <> show runtimeRep
         <> " "
         <> unwords (map renderValue [action, handler, state])
+    GrinForeignCallExpr foreignCall arguments ->
+      indent indentation
+        <> "foreign-call "
+        <> T.unpack (grinForeignCallName foreignCall)
+        <> concatMap ((" " <>) . renderValue) arguments
 
 renderAlt :: Int -> GrinAlt -> String
 renderAlt indentation alt =
@@ -154,8 +159,6 @@ renderNodeTag nodeTag =
     GrinClosure functionName -> "P" <> T.unpack (unFunctionName functionName)
     GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
     GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
-    GrinForeign foreignCall -> "Foreign[" <> T.unpack (grinForeignCallName foreignCall) <> "]"
-    GrinForeignIOAction foreignCall -> "ForeignIO[" <> T.unpack (grinForeignCallName foreignCall) <> "]"
     GrinDictionary -> "Dict"
 
 renderLiteral :: GrinLiteral -> String

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -19,8 +19,10 @@ module Aihc.Grin.Syntax
     GrinLiteral (..),
     GrinForeignCall (..),
     GrinForeignSignature (..),
-    GrinForeignResult (..),
+    GrinForeignEffect (..),
     GrinForeignType (..),
+    grinForeignOperandReps,
+    grinForeignCallResultRep,
     grinValueRuntimeRep,
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
@@ -95,6 +97,8 @@ data GrinExpr
   | GrinDictSelect !RuntimeRep !GrinValue !Int
   | GrinThrow !GrinValue
   | GrinCatch !RuntimeRep !GrinValue !GrinValue !GrinValue
+  | -- | A saturated call whose operands are already strict primitive values.
+    GrinForeignCallExpr !GrinForeignCall ![GrinValue]
   deriving (Eq, Show)
 
 -- | Atomic operands in the strict language.
@@ -115,8 +119,6 @@ data GrinNodeTag
   | GrinClosure !FunctionName
   | GrinThunk !FunctionName
   | GrinPrimitive !Text !Int
-  | GrinForeign !GrinForeignCall
-  | GrinForeignIOAction !GrinForeignCall
   | GrinDictionary
   deriving (Eq, Show)
 
@@ -187,15 +189,37 @@ data GrinForeignCall = GrinForeignCall
 
 data GrinForeignSignature = GrinForeignSignature
   { grinForeignArgumentTypes :: ![GrinForeignType],
-    grinForeignResult :: !GrinForeignResult
+    grinForeignResultType :: !GrinForeignType,
+    grinForeignEffect :: !GrinForeignEffect
   }
   deriving (Eq, Show)
 
-data GrinForeignResult
-  = GrinForeignPure !GrinForeignType
-  | GrinForeignIO !GrinForeignType
+data GrinForeignEffect
+  = GrinForeignPure
+  | GrinForeignRealWorld
   deriving (Eq, Show)
 
 data GrinForeignType
-  = GrinForeignCInt
+  = GrinForeignInt32
+  | GrinForeignWord64
   deriving (Eq, Show)
+
+grinForeignOperandReps :: GrinForeignSignature -> [RuntimeRep]
+grinForeignOperandReps signature =
+  map foreignTypeRuntimeRep (grinForeignArgumentTypes signature)
+    <> case grinForeignEffect signature of
+      GrinForeignPure -> []
+      GrinForeignRealWorld -> [TupleRep []]
+
+grinForeignCallResultRep :: GrinForeignSignature -> RuntimeRep
+grinForeignCallResultRep signature =
+  case grinForeignEffect signature of
+    GrinForeignPure -> foreignTypeRuntimeRep (grinForeignResultType signature)
+    GrinForeignRealWorld ->
+      TupleRep [TupleRep [], foreignTypeRuntimeRep (grinForeignResultType signature)]
+
+foreignTypeRuntimeRep :: GrinForeignType -> RuntimeRep
+foreignTypeRuntimeRep foreignType =
+  case foreignType of
+    GrinForeignInt32 -> Int32Rep
+    GrinForeignWord64 -> Word64Rep

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -48,6 +48,17 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "records IntRep" ("IntRep" `isInfixOf` rendered)
         assertBool "does not allocate an argument thunk" (not ("store " `isInfixOf` rendered)),
+      testCase "FC lowering emits saturated strict foreign calls" $ do
+        let program = lowerProgram foreignProgram
+            rendered = renderProgram program
+        assertEqual "lint" [] (lintProgram program)
+        assertBool "contains a direct foreign call" ("foreign-call $ffi$abs" `isInfixOf` rendered)
+        assertBool "does not apply a foreign function value" (not ("apply " `isInfixOf` rendered)),
+      testCase "lint rejects undersaturated foreign calls" $ do
+        let program = lowerProgram undersaturatedForeignProgram
+        assertBool
+          "foreign arity mismatch"
+          (GrinLintForeignArity "$ffi$abs" 1 0 `elem` lintProgram program),
       testCase "FC lowering distinguishes shadowing locals from globals" $ do
         let program = lowerProgram shadowingProgram
             rendered = renderProgram program
@@ -238,6 +249,40 @@ intTy = TcTyCon (TyCon "Int#" 0) []
 
 boxedIntTy :: TcType
 boxedIntTy = TcTyCon (TyCon "Int" 0) []
+
+foreignProgram :: FcProgram
+foreignProgram =
+  FcProgram
+    [ FcForeignImport foreignCall,
+      FcTopBind
+        ( FcNonRec
+            foreignAnswerVar
+            (FcCallForeign foreignCall [FcLit (LitInt Int32Rep 42)])
+        )
+    ]
+
+undersaturatedForeignProgram :: FcProgram
+undersaturatedForeignProgram =
+  FcProgram
+    [ FcForeignImport foreignCall,
+      FcTopBind (FcNonRec foreignAnswerVar (FcCallForeign foreignCall []))
+    ]
+
+foreignCall :: FcForeignCall
+foreignCall =
+  FcForeignCall
+    { fcForeignCallName = "$ffi$abs",
+      fcForeignCallSymbol = "abs",
+      fcForeignCallSignature =
+        FcForeignSignature
+          { fcForeignArgumentTypes = [FcForeignInt32],
+            fcForeignResultType = FcForeignInt32,
+            fcForeignEffect = FcForeignPure
+          }
+    }
+
+foreignAnswerVar :: Var
+foreignAnswerVar = Var "answer" (Unique 50) (TcTyCon (TyCon "Int32#" 0) [])
 
 separatePrograms :: [FcProgram]
 separatePrograms =

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -9,6 +9,10 @@
 module Aihc.Tc.Annotations
   ( -- * Annotation type
     TcAnnotation (..),
+    TcForeignImportAnnotation (..),
+    TcForeignEffect (..),
+    TcForeignMarshal (..),
+    TcForeignAbiType (..),
     PendingTcAnnotation (..),
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
@@ -61,6 +65,41 @@ data TcAnnotation = TcAnnotation
     -- | Term argument types made explicit for lambda-like binders.
     tcAnnTermArgTypes :: ![TcType]
   }
+  deriving (Eq, Show)
+
+-- | The fully checked lowering plan for a foreign import.  Keeping this in
+-- the type-checker output prevents System FC desugaring from rediscovering
+-- Haskell FFI representation rules from constructor names.
+data TcForeignImportAnnotation = TcForeignImportAnnotation
+  { tcForeignArguments :: ![TcForeignMarshal],
+    tcForeignResult :: !TcForeignMarshal,
+    tcForeignEffect :: !TcForeignEffect
+  }
+  deriving (Eq, Show)
+
+-- | Whether a raw foreign call is pure or explicitly threads the real-world
+-- state token.
+data TcForeignEffect
+  = TcForeignPure
+  | TcForeignRealWorld
+  deriving (Eq, Show)
+
+-- | A source value's path to its primitive ABI representation.  Constructor
+-- names are ordered outermost to innermost; for example, a @CInt@ is lowered
+-- through @CInt@ and @I32#@ to @Int32#@.
+data TcForeignMarshal = TcForeignMarshal
+  { tcForeignSourceType :: !TcType,
+    tcForeignPrimitiveType :: !TcType,
+    tcForeignConstructors :: ![Text],
+    tcForeignAbiType :: !TcForeignAbiType
+  }
+  deriving (Eq, Show)
+
+-- | Primitive values understood by the C ABI bridge.  This is deliberately
+-- independent from lifted Haskell wrapper types.
+data TcForeignAbiType
+  = TcForeignInt32
+  | TcForeignWord64
   deriving (Eq, Show)
 
 -- | Type-checker annotation payload before constraint solving has finished.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -18,6 +18,7 @@ import Aihc.Parser.Syntax
   ( Annotation,
     BangType (..),
     BinderHead (..),
+    CallConv (..),
     CaseAlt (..),
     ClassDecl (..),
     ClassDeclItem (..),
@@ -61,6 +62,10 @@ import Aihc.Tc.Annotations
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
     TcDictBinderAnnotation (..),
+    TcForeignAbiType (..),
+    TcForeignEffect (..),
+    TcForeignImportAnnotation (..),
+    TcForeignMarshal (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
     annotateDecl,
@@ -484,7 +489,64 @@ dataConBindingType name = do
 annotateForeignDeclTc :: ForeignDecl -> TcM Decl
 annotateForeignDeclTc foreignDecl = do
   ty <- bindingType (unqualifiedNameText (foreignName foreignDecl))
-  pure (annotateDeclAt (unqualifiedNameSpan (foreignName foreignDecl)) (TcAnnotation ty [] [] []) (DeclForeign foreignDecl))
+  let sourceSpan = unqualifiedNameSpan (foreignName foreignDecl)
+      annotated = annotateDeclAt sourceSpan (TcAnnotation ty [] [] []) (DeclForeign foreignDecl)
+  case foreignCallConv foreignDecl of
+    CCall -> do
+      plan <- checkForeignImportType sourceSpan ty
+      pure (DeclAnn (mkAnnotation plan) annotated)
+    _ -> pure annotated
+
+checkForeignImportType :: SourceSpan -> TcType -> TcM TcForeignImportAnnotation
+checkForeignImportType sourceSpan ty = do
+  let (argumentTypes, resultType) = splitFunctionType ty
+      (effect, valueResultType) =
+        case resultType of
+          TcTyCon (TyCon "IO" 1) [ioResult] -> (TcForeignRealWorld, ioResult)
+          _ -> (TcForeignPure, resultType)
+  arguments <- mapM (checkForeignValueType sourceSpan) argumentTypes
+  result <- checkForeignValueType sourceSpan valueResultType
+  pure
+    TcForeignImportAnnotation
+      { tcForeignArguments = arguments,
+        tcForeignResult = result,
+        tcForeignEffect = effect
+      }
+
+splitFunctionType :: TcType -> ([TcType], TcType)
+splitFunctionType ty =
+  case ty of
+    TcFunTy argument result ->
+      let (arguments, finalResult) = splitFunctionType result
+       in (argument : arguments, finalResult)
+    _ -> ([], ty)
+
+checkForeignValueType :: SourceSpan -> TcType -> TcM TcForeignMarshal
+checkForeignValueType sourceSpan ty =
+  case ty of
+    TcTyCon (TyCon "CInt" 0) [] -> pure (int32Marshal ty ["CInt", "I32#"])
+    TcTyCon (TyCon "Int32" 0) [] -> pure (int32Marshal ty ["I32#"])
+    TcTyCon (TyCon "Int32#" 0) [] -> pure (int32Marshal ty [])
+    TcTyCon (TyCon "Word64" 0) [] -> pure (word64Marshal ty ["W64#"])
+    TcTyCon (TyCon "Word64#" 0) [] -> pure (word64Marshal ty [])
+    _ -> do
+      emitError sourceSpan (OtherError ("unsupported foreign import value type: " <> show ty))
+      pure (int32Marshal ty [])
+  where
+    int32Marshal sourceType constructors =
+      TcForeignMarshal
+        { tcForeignSourceType = sourceType,
+          tcForeignPrimitiveType = TcTyCon (TyCon "Int32#" 0) [],
+          tcForeignConstructors = constructors,
+          tcForeignAbiType = TcForeignInt32
+        }
+    word64Marshal sourceType constructors =
+      TcForeignMarshal
+        { tcForeignSourceType = sourceType,
+          tcForeignPrimitiveType = TcTyCon (TyCon "Word64#" 0) [],
+          tcForeignConstructors = constructors,
+          tcForeignAbiType = TcForeignWord64
+        }
 
 annotateDeclAt :: SourceSpan -> TcAnnotation -> Decl -> Decl
 annotateDeclAt NoSourceSpan tcAnn decl =


### PR DESCRIPTION
## Summary

- elaborate source FFI signatures in `aihc-tc` into primitive marshalling plans
- desugar each ccall into a normal Haskell wrapper around an explicit saturated System FC operation
- lower foreign calls to strict GRIN expressions instead of applicable heap nodes
- execute primitive ABI values directly in the FC/GRIN interpreters and ARM64 code generator
- remove the native runtime's curried foreign-function and deferred IO-action machinery

## Why

Foreign imports were represented as first-class high-level functions all the way through GRIN. That allowed partial application and forced GRIN/native runtime code to understand `CInt` boxing and `IO` construction. The new representation makes saturation and primitive argument representations structural invariants while threading `State# RealWorld` explicitly for effectful calls.

## Impact

Source declarations remain ordinary Haskell FFI declarations. Generated FC now exposes a primitive raw call plus a typed wrapper, and GRIN can only represent a foreign call with its complete strict operand list.

## Validation

- `just fmt`
- `just check`
- native hello-world compilation/execution
- existing libc `putchar` and `abs` shared eval fixtures

## Progress counts

- FC golden fixtures: +1
- GRIN unit tests: +2
