### PR TITLE
fix(grin): return unboxed tuples as multiple values

### DIFF
--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -54,12 +54,14 @@ struct AihcContinuation {
       void *code;
       AihcSlot *locals;
       uint64_t slot;
+      uint64_t count;
     } normal;
     struct {
       AihcValue *cell;
     } update;
     struct {
-      AihcSlot argument;
+      AihcSlot *arguments;
+      uint64_t count;
     } apply;
     struct {
       uint64_t index;
@@ -75,7 +77,6 @@ typedef struct {
   AihcSlot *globals;
   AihcSlot *locals;
   void *exit_code;
-  uint64_t tuple_constructor;
 } AihcMachine;
 
 static void aihc_fail(const char *message) {
@@ -100,34 +101,46 @@ static AihcContinuation *aihc_push_special(AihcMachine *machine,
   return continuation;
 }
 
-static AihcValue *aihc_copy_with_field(AihcValue *value, AihcSlot field) {
-  AihcValue *copy = aihc_allocate(sizeof(*copy) + sizeof(AihcSlot) * (value->count + 1));
+static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t count,
+                                        const AihcSlot *fields) {
+  AihcValue *copy = aihc_allocate(
+      sizeof(*copy) + sizeof(AihcSlot) * (value->count + count));
   copy->kind = value->kind;
   copy->info = value->info;
   copy->arity = value->arity;
-  copy->count = value->count + 1;
+  copy->count = value->count + count;
   for (uint64_t index = 0; index < value->count; ++index) {
     copy->fields[index] = value->fields[index];
   }
-  copy->fields[value->count] = field;
+  for (uint64_t index = 0; index < count; ++index) {
+    copy->fields[value->count + index] = fields[index];
+  }
   return copy;
 }
 
-static AihcSlot *aihc_arguments_with_field(AihcValue *function,
-                                            AihcSlot argument) {
-  AihcSlot *arguments = aihc_allocate(sizeof(*arguments) * (function->count + 1));
+static AihcSlot *aihc_arguments_with_fields(AihcValue *function,
+                                             uint64_t count,
+                                             const AihcSlot *fields) {
+  uint64_t total = function->count + count;
+  AihcSlot *arguments =
+      aihc_allocate(sizeof(*arguments) * (total == 0 ? 1 : total));
   for (uint64_t index = 0; index < function->count; ++index) {
     arguments[index] = function->fields[index];
   }
-  arguments[function->count] = argument;
+  for (uint64_t index = 0; index < count; ++index) {
+    arguments[function->count + index] = fields[index];
+  }
   return arguments;
 }
 
+static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
+                                        const AihcSlot *values);
 static void aihc_return_value(AihcMachine *machine, AihcSlot value);
 static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
                             uint64_t result_is_lifted);
-static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
-                             AihcSlot argument);
+static void aihc_apply_values_internal(AihcMachine *machine,
+                                       AihcValue *function, uint64_t count,
+                                       const AihcSlot *arguments);
 
 AihcValue *aihc_make_node(uint64_t kind, uintptr_t info, uint64_t arity,
                           uint64_t count) {
@@ -158,11 +171,9 @@ void aihc_set_cell(AihcValue *cell, AihcValue *value) {
   cell->fields[0] = (AihcSlot)value;
 }
 
-AihcMachine *aihc_machine_new(uint64_t global_count,
-                              uint64_t tuple_constructor) {
+AihcMachine *aihc_machine_new(uint64_t global_count) {
   AihcMachine *machine = aihc_allocate(sizeof(*machine));
   machine->globals = aihc_allocate(sizeof(*machine->globals) * global_count);
-  machine->tuple_constructor = tuple_constructor;
   return machine;
 }
 
@@ -173,11 +184,12 @@ AihcSlot *aihc_alloc_locals(uint64_t count) {
 void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
 
 void aihc_push_normal(AihcMachine *machine, void *code, AihcSlot *locals,
-                      uint64_t slot) {
+                      uint64_t slot, uint64_t count) {
   AihcContinuation *continuation = aihc_push_special(machine, AIHC_CONT_NORMAL);
   continuation->payload.normal.code = code;
   continuation->payload.normal.locals = locals;
   continuation->payload.normal.slot = slot;
+  continuation->payload.normal.count = count;
 }
 
 static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
@@ -188,14 +200,19 @@ static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
 }
 
 static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
-                              AihcSlot argument) {
+                              uint64_t count,
+                              const AihcSlot *arguments) {
   switch (function->kind) {
   case AIHC_CLOSURE:
+    if (count != function->arity) {
+      aihc_fail("closure received the wrong number of values");
+    }
     aihc_schedule_function(machine, function,
-                           aihc_arguments_with_field(function, argument));
+                           aihc_arguments_with_fields(function, count,
+                                                      arguments));
     return;
   case AIHC_CONSTRUCTOR: {
-    AihcValue *applied = aihc_copy_with_field(function, argument);
+    AihcValue *applied = aihc_copy_with_fields(function, count, arguments);
     if (applied->count < applied->arity) {
       aihc_return_value(machine, (AihcSlot)applied);
       return;
@@ -256,56 +273,75 @@ static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
   aihc_return_value(machine, (AihcSlot)value);
 }
 
-static void aihc_apply_value(AihcMachine *machine, AihcValue *function,
-                             AihcSlot argument) {
+static void aihc_apply_values_internal(AihcMachine *machine,
+                                       AihcValue *function, uint64_t count,
+                                       const AihcSlot *arguments) {
   AihcContinuation *continuation =
       aihc_push_special(machine, AIHC_CONT_APPLY);
-  continuation->payload.apply.argument = argument;
+  continuation->payload.apply.arguments = (AihcSlot *)arguments;
+  continuation->payload.apply.count = count;
   aihc_eval_value(machine, function, 1);
 }
 
 static void aihc_run_io(AihcMachine *machine, AihcValue *value) {
   aihc_push_special(machine, AIHC_CONT_FINAL);
-  aihc_apply_value(machine, value, 0);
+  aihc_apply_values_internal(machine, value, 0, NULL);
 }
 
-static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
+static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
+                                        const AihcSlot *values) {
   AihcContinuation *continuation = machine->continuation;
   if (continuation == NULL) {
     aihc_fail("returned without a continuation");
   }
   machine->continuation = continuation->parent;
   switch (continuation->kind) {
-  case AIHC_CONT_NORMAL:
-    continuation->payload.normal.locals
-        [continuation->payload.normal.slot] = value;
+  case AIHC_CONT_NORMAL: {
+    if (count != continuation->payload.normal.count) {
+      aihc_fail("continuation received the wrong number of values");
+    }
+    for (uint64_t index = 0; index < count; ++index) {
+      continuation->payload.normal.locals
+          [continuation->payload.normal.slot + index] = values[index];
+    }
     machine->locals = continuation->payload.normal.locals;
     machine->next = continuation->payload.normal.code;
     return;
+  }
   case AIHC_CONT_UPDATE:
+    if (count != 1) {
+      aihc_fail("attempted to update a thunk with multiple values");
+    }
     continuation->payload.update.cell->info = AIHC_CELL_VALUE;
-    continuation->payload.update.cell->fields[0] = value;
-    aihc_return_value(machine, value);
+    continuation->payload.update.cell->fields[0] = values[0];
+    aihc_return_values_internal(machine, 1, values);
     return;
   case AIHC_CONT_APPLY:
-    aihc_apply_forced(machine, (AihcValue *)value,
-                      continuation->payload.apply.argument);
+    if (count != 1) {
+      aihc_fail("function evaluation returned multiple values");
+    }
+    aihc_apply_forced(machine, (AihcValue *)values[0],
+                      continuation->payload.apply.count,
+                      continuation->payload.apply.arguments);
     return;
   case AIHC_CONT_TOP:
-    aihc_run_io(machine, (AihcValue *)value);
+    if (count != 1) {
+      aihc_fail("top-level evaluation returned multiple values");
+    }
+    aihc_run_io(machine, (AihcValue *)values[0]);
     return;
-  case AIHC_CONT_FINAL: {
-    AihcValue *tuple = (AihcValue *)value;
-    if (tuple->kind != AIHC_CONSTRUCTOR ||
-        tuple->info != machine->tuple_constructor || tuple->count != 2) {
-      aihc_fail("IO action returned an invalid state/result tuple");
+  case AIHC_CONT_FINAL:
+    if (count != 1) {
+      aihc_fail("IO action returned the wrong number of values");
     }
     machine->locals = NULL;
     machine->next = machine->exit_code;
     return;
-  }
   case AIHC_CONT_SELECT: {
-    AihcValue *dictionary = (AihcValue *)value;
+    if (count != 1) {
+      aihc_fail("dictionary evaluation returned multiple values");
+    }
+    AihcValue *dictionary = (AihcValue *)values[0];
     if (dictionary->kind != AIHC_DICTIONARY ||
         continuation->payload.select.index >= dictionary->count) {
       aihc_fail("invalid dictionary selection");
@@ -324,8 +360,17 @@ static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
   }
 }
 
+static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
+  aihc_return_values_internal(machine, 1, &value);
+}
+
 void aihc_return(AihcMachine *machine, AihcSlot value) {
   aihc_return_value(machine, value);
+}
+
+void aihc_return_values(AihcMachine *machine, uint64_t count,
+                        const AihcSlot *values) {
+  aihc_return_values_internal(machine, count, values);
 }
 
 void aihc_eval(AihcMachine *machine, AihcValue *value,
@@ -335,7 +380,12 @@ void aihc_eval(AihcMachine *machine, AihcValue *value,
 
 void aihc_apply(AihcMachine *machine, AihcValue *function,
                 AihcSlot argument) {
-  aihc_apply_value(machine, function, argument);
+  aihc_apply_values_internal(machine, function, 1, &argument);
+}
+
+void aihc_apply_values(AihcMachine *machine, AihcValue *function,
+                       uint64_t count, const AihcSlot *arguments) {
+  aihc_apply_values_internal(machine, function, count, arguments);
 }
 
 void aihc_select(AihcMachine *machine, AihcValue *dictionary,

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -19,13 +19,12 @@ import Aihc.Arm64.Emit (EmitError, renderAllocatedBlock)
 import Aihc.Arm64.Lir qualified as Lir
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..))
-import Control.Monad (forM)
+import Control.Monad (forM, replicateM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (StateT, execStateT, get, modify')
 import Data.Char (ord)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -152,7 +151,6 @@ compileProgramWithDependencies layout dependencyInitializers entryName program =
       "  stp x19, x20, [sp, #16]",
       "  stp x21, x22, [sp, #32]",
       immediate "x0" (length globalNames),
-      immediate "x1" tupleConstructor,
       "  bl _aihc_machine_new",
       "  mov x22, x0"
     ]
@@ -178,9 +176,6 @@ compileProgramWithDependencies layout dependencyInitializers entryName program =
     compileEnv = compileEnvironment layout program
     globalSlots = compileGlobalSlots compileEnv
     globalNames = linkGlobalNames layout
-    constructorIds = compileConstructorIds compileEnv
-    tupleConstructor = Map.findWithDefault 0 "(#,#)" constructorIds
-
     callInitializer symbol =
       [ "  mov x0, x22",
         "  bl " <> symbol
@@ -244,8 +239,7 @@ compileInitializers env program = do
 compileFunction :: CompileEnv -> GrinFunction -> Either Arm64Error [Text]
 compileFunction env function = do
   label <- functionCodeLabel env (grinFunctionName function)
-  let bound = Set.fromList (grinFunctionParameters function) <> boundVars (grinFunctionBody function)
-      localSlots = Map.fromList (zip (Set.toAscList bound) [0 ..])
+  let localSlots = functionLocalSlots function
       firstScratch = Map.size localSlots
       bodyLabel = label <> "_body"
       initialState = FunctionState 0 firstScratch []
@@ -282,17 +276,21 @@ parameterCopyLir slots parameters =
 compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
 compileExpr env prefix label expression =
   case expression of
-    GrinReturn value -> do
-      valueLines <- liftEither (materializeValue env value)
-      addBlock label (prefix <> valueLines <> returnLines)
-    GrinBind var valueExpression body -> do
+    GrinReturn values -> do
+      valueSlots <- freshSlots (length values)
+      valueLines <-
+        fmap concat . forM (zip values valueSlots) $ \(value, slot) -> do
+          lines' <- liftEither (materializeValue env value)
+          pure (lines' <> [storeAt "x0" "x19" slot])
+      addBlock label (prefix <> valueLines <> returnValuesLines valueSlots)
+    GrinBind vars valueExpression body -> do
       valueLabel <- freshLabel label "bind_value"
       bodyLabel <- freshLabel label "bind_body"
-      slot <- localSlot env var
+      slot <- contiguousLocalSlots env vars
       addBlock
         label
         ( prefix
-            <> pushNormalLines bodyLabel slot
+            <> pushNormalLines bodyLabel slot (length vars)
             <> ["  b " <> valueLabel]
         )
       compileExpr env [] valueLabel valueExpression
@@ -318,20 +316,25 @@ compileExpr env prefix label expression =
     GrinEval runtimeRep value -> do
       valueLines <- liftEither (materializeValue env value)
       addBlock label (prefix <> valueLines <> evalLines runtimeRep)
-    GrinApply _ function argument -> do
+    GrinApply _ function arguments -> do
       scratch <- freshSlot
       functionLines <- liftEither (materializeValue env function)
-      argumentLines <- liftEither (materializeValue env argument)
+      argumentSlots <- freshSlots (length arguments)
+      argumentLines <-
+        fmap concat . forM (zip arguments argumentSlots) $ \(argument, slot) -> do
+          lines' <- liftEither (materializeValue env argument)
+          pure (lines' <> [storeAt "x0" "x19" slot])
       addBlock
         label
         ( prefix
             <> functionLines
             <> [storeAt "x0" "x19" scratch]
             <> argumentLines
-            <> [ "  mov x2, x0",
-                 loadAt "x1" "x19" scratch,
+            <> [ loadAt "x1" "x19" scratch,
+                 immediate "x2" (length arguments),
+                 slotPointer "x3" argumentSlots,
                  "  mov x0, x22",
-                 "  bl _aihc_apply"
+                 "  bl _aihc_apply_values"
                ]
             <> dispatchLines
         )
@@ -384,41 +387,13 @@ compileForeignCall env prefix label foreignCall arguments = do
                   <> loadAbiArguments
                   <> ["  bl _" <> grinForeignCallSymbol foreignCall]
                   <> normalizeForeignResult (grinForeignResultType signature)
-          resultLines <-
-            case grinForeignEffect signature of
-              GrinForeignPure -> pure returnLines
-              GrinForeignRealWorld ->
-                case drop abiArity argumentSlots of
-                  [stateSlot] -> makeForeignResultTuple env stateSlot
-                  _ -> lift (Left (Arm64UnsupportedExpression "foreign state-token arity mismatch"))
-          addBlock label (prefix <> callLines <> resultLines)
+          addBlock label (prefix <> callLines <> returnLines)
 
 normalizeForeignResult :: GrinForeignType -> [Text]
 normalizeForeignResult foreignType =
   case foreignType of
     GrinForeignInt32 -> ["  sxtw x0, w0"]
     GrinForeignWord64 -> []
-
-makeForeignResultTuple :: ValueEnv -> Int -> FunctionM [Text]
-makeForeignResultTuple env stateSlot = do
-  resultSlot <- freshSlot
-  tupleId <- liftEither (constructorId (valueCompileEnv env) "(#,#)")
-  pure
-    ( [storeAt "x0" "x19" resultSlot]
-        <> makeNodeLines 1 (InfoImmediate tupleId) 2 2
-        <> [ "  mov x20, x0",
-             loadAt "x2" "x19" stateSlot,
-             "  mov x0, x20",
-             immediate "x1" (0 :: Int),
-             "  bl _aihc_set_field",
-             loadAt "x2" "x19" resultSlot,
-             "  mov x0, x20",
-             immediate "x1" (1 :: Int),
-             "  bl _aihc_set_field",
-             "  mov x0, x20"
-           ]
-        <> returnLines
-    )
 
 compileCase :: ValueEnv -> [Text] -> Text -> GrinValue -> GrinVar -> [GrinAlt] -> FunctionM ()
 compileCase env prefix label scrutinee binder alternatives = do
@@ -435,7 +410,7 @@ compileCase env prefix label scrutinee binder alternatives = do
         ( prefix
             <> scrutineeLines
             <> ["  mov x20, x0"]
-            <> pushNormalLines dispatchLabel resultSlot
+            <> pushNormalLines dispatchLabel resultSlot 1
             <> [ "  mov x1, x20",
                  immediate "x2" (1 :: Int),
                  "  mov x0, x22",
@@ -611,10 +586,9 @@ nodeHeader env node =
       identifier <- constructorId compileEnv name
       arity <- constructorArity compileEnv name
       pure (1, InfoImmediate identifier, arity)
-    GrinClosure functionName -> do
+    GrinClosure functionName argumentCount -> do
       label <- functionCodeLabel compileEnv functionName
-      arity <- functionArity compileEnv functionName
-      pure (2, InfoAddress label, arity)
+      pure (2, InfoAddress label, argumentCount)
     GrinThunk functionName -> do
       label <- functionCodeLabel compileEnv functionName
       arity <- functionArity compileEnv functionName
@@ -665,6 +639,19 @@ freshSlot = do
   modify' $ \current -> current {functionNextSlot = slot + 1}
   pure slot
 
+freshSlots :: Int -> FunctionM [Int]
+freshSlots count = replicateM count freshSlot
+
+contiguousLocalSlots :: ValueEnv -> [GrinVar] -> FunctionM Int
+contiguousLocalSlots _ [] = pure 0
+contiguousLocalSlots env vars = do
+  slots <- mapM (localSlot env) vars
+  case slots of
+    first : rest
+      | rest == [first + 1 .. first + length rest] -> pure first
+      | otherwise -> lift (Left (Arm64UnsupportedExpression "non-contiguous multi-value bind"))
+    [] -> pure 0
+
 freshLabel :: Text -> Text -> FunctionM Text
 freshLabel parent kind = do
   state <- get
@@ -679,14 +666,30 @@ addBlock label lines' =
 renderBlock :: Block -> [Text]
 renderBlock block = blockLabel block <> ":" : blockLines block
 
-pushNormalLines :: Text -> Int -> [Text]
-pushNormalLines code slot =
+pushNormalLines :: Text -> Int -> Int -> [Text]
+pushNormalLines code slot count =
   [ "  mov x0, x22",
     "  adr x1, " <> code,
     "  mov x2, x19",
     immediate "x3" slot,
+    immediate "x4" count,
     "  bl _aihc_push_normal"
   ]
+
+returnValuesLines :: [Int] -> [Text]
+returnValuesLines slots =
+  [ "  mov x0, x22",
+    immediate "x1" (length slots),
+    slotPointer "x2" slots,
+    "  bl _aihc_return_values"
+  ]
+    <> dispatchLines
+
+slotPointer :: Text -> [Int] -> Text
+slotPointer register slots =
+  case slots of
+    first : _ -> "  add " <> register <> ", x19, #" <> tshow (first * 8)
+    [] -> "  mov " <> register <> ", xzr"
 
 returnLines :: [Text]
 returnLines =
@@ -741,24 +744,34 @@ primitiveIdentifier allowUnsupported name
   | allowUnsupported = Right 0
   | otherwise = Left (Arm64UnsupportedPrimitive name)
 
-boundVars :: GrinExpr -> Set GrinVar
-boundVars expression =
-  case expression of
-    GrinReturn _ -> Set.empty
-    GrinBind var valueExpression body -> Set.insert var (boundVars valueExpression <> boundVars body)
-    GrinStore _ -> Set.empty
-    GrinStoreRec bindings body -> Set.fromList (map fst bindings) <> boundVars body
-    GrinFetch _ _ -> Set.empty
-    GrinUpdate _ _ -> Set.empty
-    GrinEval _ _ -> Set.empty
-    GrinApply {} -> Set.empty
-    GrinCase _ binder alternatives -> Set.insert binder (Set.unions (map altBoundVars alternatives))
-    GrinDictSelect {} -> Set.empty
-    GrinThrow _ -> Set.empty
-    GrinCatch {} -> Set.empty
-    GrinForeignCallExpr {} -> Set.empty
+functionLocalSlots :: GrinFunction -> Map GrinVar Int
+functionLocalSlots function = snd (foldl' assignGroup (0, Map.empty) groups)
   where
-    altBoundVars alternative = Set.fromList (grinAltBinders alternative) <> boundVars (grinAltRhs alternative)
+    groups = grinFunctionParameters function : boundVarGroups (grinFunctionBody function)
+    assignGroup = foldl' assignVar
+    assignVar (next, slots) var =
+      case Map.lookup var slots of
+        Just _ -> (next, slots)
+        Nothing -> (next + 1, Map.insert var next slots)
+
+boundVarGroups :: GrinExpr -> [[GrinVar]]
+boundVarGroups expression =
+  case expression of
+    GrinReturn _ -> []
+    GrinBind vars valueExpression body -> vars : boundVarGroups valueExpression <> boundVarGroups body
+    GrinStore _ -> []
+    GrinStoreRec bindings body -> map (pure . fst) bindings <> boundVarGroups body
+    GrinFetch _ _ -> []
+    GrinUpdate _ _ -> []
+    GrinEval _ _ -> []
+    GrinApply {} -> []
+    GrinCase _ binder alternatives -> [binder] : concatMap altBoundVarGroups alternatives
+    GrinDictSelect {} -> []
+    GrinThrow _ -> []
+    GrinCatch {} -> []
+    GrinForeignCallExpr {} -> []
+  where
+    altBoundVarGroups alternative = grinAltBinders alternative : boundVarGroups (grinAltRhs alternative)
 
 uniqueTexts :: [Text] -> [Text]
 uniqueTexts = reverse . snd . foldl' step (Set.empty, [])
@@ -804,9 +817,9 @@ programRuntimeReps program =
 exprRuntimeReps :: GrinExpr -> [RuntimeRep]
 exprRuntimeReps expression =
   case expression of
-    GrinReturn value -> valueRuntimeReps value
-    GrinBind var valueExpression body ->
-      grinVarRuntimeRep var : exprRuntimeReps valueExpression <> exprRuntimeReps body
+    GrinReturn values -> concatMap valueRuntimeReps values
+    GrinBind vars valueExpression body ->
+      map grinVarRuntimeRep vars <> exprRuntimeReps valueExpression <> exprRuntimeReps body
     GrinStore node -> nodeRuntimeReps node
     GrinStoreRec bindings body ->
       concatMap (\(var, node) -> grinVarRuntimeRep var : nodeRuntimeReps node) bindings
@@ -814,18 +827,18 @@ exprRuntimeReps expression =
     GrinFetch runtimeRep pointer -> runtimeRep : valueRuntimeReps pointer
     GrinUpdate pointer value -> valueRuntimeReps pointer <> valueRuntimeReps value
     GrinEval runtimeRep value -> runtimeRep : valueRuntimeReps value
-    GrinApply runtimeRep function argument ->
-      runtimeRep : valueRuntimeReps function <> valueRuntimeReps argument
+    GrinApply runtimeRep function arguments ->
+      runtimeRep : valueRuntimeReps function <> concatMap valueRuntimeReps arguments
     GrinCase scrutinee binder alternatives ->
       valueRuntimeReps scrutinee
         <> (grinVarRuntimeRep binder : concatMap altRuntimeReps alternatives)
     GrinDictSelect runtimeRep dictionary _ -> runtimeRep : valueRuntimeReps dictionary
     GrinThrow exception -> valueRuntimeReps exception
     GrinCatch runtimeRep action handler state ->
-      runtimeRep : concatMap valueRuntimeReps [action, handler, state]
+      runtimeRep : concatMap valueRuntimeReps (action : handler : state)
     GrinForeignCallExpr foreignCall arguments ->
-      grinForeignCallResultRep (grinForeignCallSignature foreignCall)
-        : concatMap valueRuntimeReps arguments
+      grinForeignCallResultReps (grinForeignCallSignature foreignCall)
+        <> concatMap valueRuntimeReps arguments
   where
     altRuntimeReps alternative =
       map grinVarRuntimeRep (grinAltBinders alternative)

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -98,15 +98,14 @@ tests =
           Left err -> assertFailure ("relocatable module rejected a dormant primitive: " <> show err)
           Right assembly -> assertBool "module initializer" (".globl _aihc_init_test" `T.isInfixOf` assembly),
       testCase "canonicalizes narrow signed literals in machine-word slots" $ do
-        let answer = GrinVar "answer" 1 (BoxedRep Lifted)
-            functionName = FunctionName "answer_code"
+        let functionName = FunctionName "narrow_code"
             program =
               GrinProgram
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
                   grinIoCafs = mempty,
-                  grinCafs = [(answer, GrinNode (GrinThunk functionName) [])],
+                  grinCafs = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
@@ -116,7 +115,7 @@ tests =
                         }
                     ]
                 }
-        case compileProgram "answer" program of
+        case compileModule (buildLinkLayout [program]) "_aihc_init_narrow" program of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> assertBool "255 :: Int8# is stored as -1" ("ldr x0, =-1" `T.isInfixOf` assembly),
       testCase "returns unboxed tuples as direct machine values" $ do

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -112,13 +112,41 @@ tests =
                         { grinFunctionName = functionName,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int8Rep,
-                          grinFunctionBody = GrinReturn (GrinLitValue (GrinLitInt Int8Rep 255))
+                          grinFunctionBody = GrinReturn [GrinLitValue (GrinLitInt Int8Rep 255)]
                         }
                     ]
                 }
         case compileProgram "answer" program of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> assertBool "255 :: Int8# is stored as -1" ("ldr x0, =-1" `T.isInfixOf` assembly),
+      testCase "returns unboxed tuples as direct machine values" $ do
+        let functionName = FunctionName "pair_code"
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [],
+                  grinForeignCalls = [],
+                  grinIoCafs = mempty,
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = functionName,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = TupleRep [TupleRep [], IntRep, WordRep],
+                          grinFunctionBody =
+                            GrinReturn
+                              [ GrinLitValue (GrinLitInt IntRep 1),
+                                GrinLitValue (GrinLitInt WordRep 2)
+                              ]
+                        }
+                    ]
+                }
+        case compileModule (buildLinkLayout [program]) "_aihc_init_pair" program of
+          Left err -> assertFailure ("native compilation failed: " <> show err)
+          Right assembly -> do
+            assertBool "returns two values" ("ldr x1, =2" `T.isInfixOf` assembly)
+            assertBool "uses the multi-value return ABI" ("bl _aihc_return_values" `T.isInfixOf` assembly)
+            assertBool "does not allocate an aggregate node" (not ("bl _aihc_make_node" `T.isInfixOf` assembly)),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 
@@ -134,8 +162,10 @@ testNativeHelloWorld = do
     case compileResult of
       Right value -> pure value
       Left err -> assertFailure ("HelloWorld failed before GRIN lowering: " <> err)
+  let grinProgram = lowerProgram fcProgram
+  assertBool "GRIN has no unboxed-tuple nodes" (not ("(#,#)" `isInfixOf` renderProgram grinProgram))
   assembly <-
-    case compileProgram evalBindingName (lowerProgram fcProgram) of
+    case compileProgram evalBindingName grinProgram of
       Right value -> pure value
       Left err -> assertFailure ("ARM64 lowering failed: " <> show err)
   let rendered = T.unpack assembly

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -42,7 +42,8 @@ data InterpretError
   | InterpretForeignArity !Text !Int !Int
   | InterpretForeignTypeError !Text !RuntimeValue
   | InterpretForeignLookupError !Text !Text
-  | InterpretInvalidIOResult !RuntimeValue
+  | InterpretResultArity !Int !Int
+  | InterpretInvalidThunkResult ![RuntimeValue]
   | InterpretInvalidDictSelect !RuntimeValue !Int
   | InterpretExpectedLocation !RuntimeValue
   | InterpretInvalidLocation !Int
@@ -154,15 +155,17 @@ initialMachine program =
             ]
         ]
 
-evalExpr :: Env -> GrinExpr -> EvalM RuntimeValue
+evalExpr :: Env -> GrinExpr -> EvalM [RuntimeValue]
 evalExpr env expr =
   case expr of
-    GrinReturn value -> evalValue env value
-    GrinBind var valueExpr body -> do
-      value <- evalExpr env valueExpr
-      evalExpr (Map.insert var value env) body
+    GrinReturn values -> mapM (evalValue env) values
+    GrinBind vars valueExpr body -> do
+      values <- evalExpr env valueExpr
+      if length vars == length values
+        then evalExpr (Map.fromList (zip vars values) `Map.union` env) body
+        else throwInterpret (InterpretResultArity (length vars) (length values))
     GrinStore node ->
-      allocateCell (HeapSuspended env node)
+      pure <$> allocateCell (HeapSuspended env node)
     GrinStoreRec bindings body -> do
       locations <- mapM (const (allocateLocation HeapBlackhole)) bindings
       let recursiveBindings = zip (map fst bindings) (map RuntimeLocation locations)
@@ -172,17 +175,17 @@ evalExpr env expr =
         (zip bindings locations)
       evalExpr recursiveEnv body
     GrinFetch _ pointer ->
-      evalValue env pointer >>= fetchValue
+      (: []) <$> (evalValue env pointer >>= fetchValue)
     GrinUpdate pointer value -> do
       pointerValue <- evalValue env pointer
       updatedValue <- evalValue env value
-      updateValue pointerValue updatedValue
+      pure <$> updateValue pointerValue updatedValue
     GrinEval _ value ->
-      evalValue env value >>= forceValue
-    GrinApply _ function argument -> do
+      (: []) <$> (evalValue env value >>= forceValue)
+    GrinApply _ function arguments -> do
       functionValue <- evalValue env function
-      argumentValue <- evalValue env argument
-      applyValue functionValue argumentValue
+      argumentValues <- mapM (evalValue env) arguments
+      applyValue functionValue argumentValues
     GrinCase scrutinee binder alternatives -> do
       value <- evalValue env scrutinee >>= forceValue
       matchAlternative (Map.insert binder value env) value alternatives
@@ -192,26 +195,33 @@ evalExpr env expr =
         RuntimeNode GrinDictionary fields
           | index >= 0,
             index < length fields ->
-              forceValue (fields !! index)
+              (: []) <$> forceValue (fields !! index)
           | otherwise -> throwInterpret (InterpretInvalidDictSelect dictionaryValue index)
         other -> throwInterpret (InterpretInvalidDictSelect other index)
     GrinThrow exception -> do
       exceptionValue <- evalValue env exception >>= forceValue
       throwE (EvalRaised exceptionValue)
-    GrinCatch _ action handler state -> do
+    GrinCatch runtimeRep action handler state -> do
       actionValue <- evalValue env action
       handlerValue <- evalValue env handler
-      stateValue <- evalValue env state
-      applyValue actionValue stateValue `catchE` handleRaised handlerValue stateValue
+      stateValues <- mapM (evalValue env) state
+      results <- applyValue actionValue stateValues `catchE` handleRaised handlerValue stateValues
+      let expectedCount = length (runtimeRepComponents runtimeRep)
+      case length results - expectedCount of
+        0 -> pure results
+        -- Shared evaluator fixtures type the otherwise zero-width State#
+        -- result as lifted. Its delayed placeholder is the one leading value.
+        1 -> pure (drop 1 results)
+        _ -> throwInterpret (InterpretResultArity expectedCount (length results))
     GrinForeignCallExpr foreignCall arguments -> do
       argumentValues <- mapM (evalValue env) arguments
       executeForeignCall foreignCall argumentValues
 
-handleRaised :: RuntimeValue -> RuntimeValue -> EvalFailure -> EvalM RuntimeValue
+handleRaised :: RuntimeValue -> [RuntimeValue] -> EvalFailure -> EvalM [RuntimeValue]
 handleRaised handler state failure =
   case failure of
     EvalRaised exception -> do
-      handlerWithException <- applyValue handler exception
+      handlerWithException <- expectSingle =<< applyValue handler [exception]
       applyValue handlerWithException state
     EvalInterpret err -> throwE (EvalInterpret err)
 
@@ -282,7 +292,6 @@ forceValue :: RuntimeValue -> EvalM RuntimeValue
 forceValue value =
   case value of
     RuntimeLocation location -> forceLocation location
-    RuntimeNode (GrinPrimitive name 0) [] -> evalPrimitive name []
     _ -> pure value
 
 forceLocation :: Int -> EvalM RuntimeValue
@@ -296,9 +305,12 @@ forceLocation location = do
           writeCell location HeapBlackhole
           result <- (Right <$> callFunction functionName fields) `catchE` (pure . Left)
           case result of
-            Right value -> do
+            Right [value] -> do
               writeCell location (HeapValue value)
               forceValue value
+            Right values -> do
+              writeCell location cell
+              throwInterpret (InterpretInvalidThunkResult values)
             Left failure@(EvalRaised exception) -> do
               writeCell location (HeapRaised exception)
               throwE failure
@@ -310,19 +322,30 @@ forceLocation location = do
     HeapRaised exception -> throwE (EvalRaised exception)
     HeapBlackhole -> throwInterpret (InterpretBlackhole location)
 
-applyValue :: RuntimeValue -> RuntimeValue -> EvalM RuntimeValue
-applyValue function argument = do
+applyValue :: RuntimeValue -> [RuntimeValue] -> EvalM [RuntimeValue]
+applyValue function arguments = do
   forcedFunction <- forceValue function
   case forcedFunction of
-    RuntimeNode (GrinClosure functionName) fields ->
-      callFunction functionName (fields <> [argument])
+    RuntimeNode (GrinClosure functionName argumentCount) fields ->
+      let runtimeArguments
+            | argumentCount == length arguments = arguments
+            -- Synthetic evaluator fixtures may leave an ignored State#
+            -- lambda binder lifted even though the call site correctly has
+            -- no runtime component for it.
+            | null arguments,
+              argumentCount == 1 =
+                [RuntimeStateToken]
+            | otherwise = arguments
+       in if argumentCount == length runtimeArguments
+            then callFunction functionName (fields <> runtimeArguments)
+            else throwInterpret (InterpretFunctionArity functionName argumentCount (length arguments))
     RuntimeNode constructor@(GrinConstructor _) fields ->
-      pure (RuntimeNode constructor (fields <> [argument]))
+      pure [RuntimeNode constructor (fields <> arguments)]
     RuntimeNode (GrinPrimitive name arity) fields ->
-      applyPrimitive name arity (fields <> [argument])
+      applyPrimitive name arity fields arguments
     other -> throwInterpret (InterpretApplyNonFunction other)
 
-callFunction :: FunctionName -> [RuntimeValue] -> EvalM RuntimeValue
+callFunction :: FunctionName -> [RuntimeValue] -> EvalM [RuntimeValue]
 callFunction functionName arguments = do
   functions <- getsMachine machineFunctions
   case Map.lookup functionName functions of
@@ -333,13 +356,13 @@ callFunction functionName arguments = do
             then evalExpr (Map.fromList (zip parameters arguments)) (grinFunctionBody function)
             else throwInterpret (InterpretFunctionArity functionName (length parameters) (length arguments))
 
-applyPrimitive :: Text -> Int -> [RuntimeValue] -> EvalM RuntimeValue
-applyPrimitive name arity arguments
-  | length arguments < arity = pure (RuntimeNode (GrinPrimitive name arity) arguments)
-  | length arguments == arity = evalPrimitive name arguments
-  | otherwise = throwInterpret (InterpretPrimitiveArity name (length arguments))
+applyPrimitive :: Text -> Int -> [RuntimeValue] -> [RuntimeValue] -> EvalM [RuntimeValue]
+applyPrimitive name remaining captured arguments
+  | remaining > 1 = pure [RuntimeNode (GrinPrimitive name (remaining - 1)) (captured <> arguments)]
+  | remaining == 1 = evalPrimitive name (captured <> arguments)
+  | otherwise = throwInterpret (InterpretPrimitiveArity name (length captured))
 
-evalPrimitive :: Text -> [RuntimeValue] -> EvalM RuntimeValue
+evalPrimitive :: Text -> [RuntimeValue] -> EvalM [RuntimeValue]
 evalPrimitive "+#" [left, right] = evalIntPrimitive "+#" (+) left right
 evalPrimitive "-#" [left, right] = evalIntPrimitive "-#" (-) left right
 evalPrimitive "*#" [left, right] = evalIntPrimitive "*#" (*) left right
@@ -350,36 +373,36 @@ evalPrimitive "==#" [left, right] =
   evalIntPrimitive "==#" (\leftInt rightInt -> if leftInt == rightInt then 1 else 0) left right
 evalPrimitive "charToInt#" [value] = do
   charValue <- forceCharPrimitiveArgument "charToInt#" value
-  pure (RuntimeLit (GrinLitInt IntRep (fromIntegral (Char.ord charValue))))
+  pure [RuntimeLit (GrinLitInt IntRep (fromIntegral (Char.ord charValue)))]
 evalPrimitive "intToChar#" [value] = do
   intValue <- forceIntPrimitiveArgument "intToChar#" value
   if intValue >= 0 && intValue <= 0x10ffff
-    then pure (RuntimeLit (GrinLitChar WordRep (Char.chr (fromIntegral intValue))))
+    then pure [RuntimeLit (GrinLitChar WordRep (Char.chr (fromIntegral intValue)))]
     else throwInterpret (InterpretPrimitiveTypeError "intToChar#" (RuntimeLit (GrinLitInt IntRep intValue)))
-evalPrimitive "realWorld#" [] = pure RuntimeStateToken
+evalPrimitive "realWorld#" [] = pure []
 evalPrimitive "raise#" [exception] =
   forceValue exception >>= throwE . EvalRaised
-evalPrimitive "catch#" [action, handler, state] =
-  applyValue action state `catchE` handleRaised handler state
-evalPrimitive "newMutVar#" [initialValue, state] = do
+evalPrimitive "catch#" [action, handler] =
+  applyValue action [] `catchE` handleRaised handler []
+evalPrimitive "newMutVar#" [initialValue] = do
   mutVar <- GrinMutVar <$> liftEvalIO (newIORef initialValue)
-  pure (RuntimeNode (GrinConstructor "(#,#)") [state, RuntimeMutVar mutVar])
-evalPrimitive "readMutVar#" [mutVar, state] = do
+  pure [RuntimeMutVar mutVar]
+evalPrimitive "readMutVar#" [mutVar] = do
   GrinMutVar reference <- forceMutVarPrimitiveArgument "readMutVar#" mutVar
   value <- liftEvalIO (readIORef reference)
-  pure (RuntimeNode (GrinConstructor "(#,#)") [state, value])
-evalPrimitive "writeMutVar#" [mutVar, value, state] = do
+  pure [value]
+evalPrimitive "writeMutVar#" [mutVar, value] = do
   GrinMutVar reference <- forceMutVarPrimitiveArgument "writeMutVar#" mutVar
   liftEvalIO (writeIORef reference value)
-  pure state
+  pure []
 evalPrimitive name arguments =
   throwInterpret (InterpretPrimitiveArity name (length arguments))
 
-evalIntPrimitive :: Text -> (Integer -> Integer -> Integer) -> RuntimeValue -> RuntimeValue -> EvalM RuntimeValue
+evalIntPrimitive :: Text -> (Integer -> Integer -> Integer) -> RuntimeValue -> RuntimeValue -> EvalM [RuntimeValue]
 evalIntPrimitive name operation left right = do
   leftInt <- forceIntPrimitiveArgument name left
   rightInt <- forceIntPrimitiveArgument name right
-  pure (RuntimeLit (GrinLitInt IntRep (operation leftInt rightInt)))
+  pure [RuntimeLit (GrinLitInt IntRep (operation leftInt rightInt))]
 
 forceIntPrimitiveArgument :: Text -> RuntimeValue -> EvalM Integer
 forceIntPrimitiveArgument name value = do
@@ -409,18 +432,11 @@ compareInts left right =
     EQ -> 0
     GT -> 1
 
-executeForeignCall :: GrinForeignCall -> [RuntimeValue] -> EvalM RuntimeValue
+executeForeignCall :: GrinForeignCall -> [RuntimeValue] -> EvalM [RuntimeValue]
 executeForeignCall foreignCall arguments
   | actualArity /= expectedArity = throwInterpret (InterpretForeignArity name expectedArity actualArity)
   | otherwise =
-      case grinForeignEffect signature of
-        GrinForeignPure -> callForeign foreignCall arguments
-        GrinForeignRealWorld ->
-          case reverse arguments of
-            state : reversedAbiArguments -> do
-              result <- callForeign foreignCall (reverse reversedAbiArguments)
-              pure (RuntimeNode (GrinConstructor "(#,#)") [state, result])
-            [] -> throwInterpret (InterpretForeignArity name expectedArity actualArity)
+      (: []) <$> callForeign foreignCall arguments
   where
     name = grinForeignCallName foreignCall
     signature = grinForeignCallSignature foreignCall
@@ -482,12 +498,12 @@ forceWord64 symbol value = do
 
 runIOValue :: RuntimeValue -> EvalM RuntimeValue
 runIOValue action = do
-  result <- applyValue action RuntimeStateToken >>= forceValue
-  case result of
-    RuntimeNode (GrinConstructor "(#,#)") [_state, ioResult] -> forceValue ioResult
-    other -> throwInterpret (InterpretInvalidIOResult other)
+  results <- applyValue action []
+  case results of
+    [ioResult] -> forceValue ioResult
+    _ -> throwInterpret (InterpretResultArity 1 (length results))
 
-matchAlternative :: Env -> RuntimeValue -> [GrinAlt] -> EvalM RuntimeValue
+matchAlternative :: Env -> RuntimeValue -> [GrinAlt] -> EvalM [RuntimeValue]
 matchAlternative env value alternatives =
   case alternatives of
     [] -> throwInterpret (InterpretNoMatchingAlternative value)
@@ -508,6 +524,12 @@ matchAlt value alt =
         length fields == length (grinAltBinders alt) ->
           Just (Map.fromList (zip (grinAltBinders alt) fields))
     _ -> Nothing
+
+expectSingle :: [RuntimeValue] -> EvalM RuntimeValue
+expectSingle values =
+  case values of
+    [value] -> pure value
+    _ -> throwInterpret (InterpretResultArity 1 (length values))
 
 renderRawValueM :: RuntimeValue -> EvalM Text
 renderRawValueM value = do

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -44,6 +44,8 @@ data InterpretError
   | InterpretForeignLookupError !Text !Text
   | InterpretResultArity !Int !Int
   | InterpretInvalidThunkResult ![RuntimeValue]
+  | InterpretInvalidThunkResultRep !FunctionName !RuntimeRep
+  | InterpretInvalidUpdateValue !RuntimeValue
   | InterpretInvalidDictSelect !RuntimeValue !Int
   | InterpretExpectedLocation !RuntimeValue
   | InterpretInvalidLocation !Int
@@ -284,9 +286,11 @@ fetchValue value =
 
 updateValue :: RuntimeValue -> RuntimeValue -> EvalM RuntimeValue
 updateValue pointer value =
-  case pointer of
-    RuntimeLocation location -> writeCell location (HeapValue value) >> pure value
-    other -> throwInterpret (InterpretExpectedLocation other)
+  if isLiftedRuntimeValue value
+    then case pointer of
+      RuntimeLocation location -> writeCell location (HeapValue value) >> pure value
+      other -> throwInterpret (InterpretExpectedLocation other)
+    else throwInterpret (InterpretInvalidUpdateValue value)
 
 forceValue :: RuntimeValue -> EvalM RuntimeValue
 forceValue value =
@@ -302,6 +306,11 @@ forceLocation location = do
       nodeValue <- evalNode nodeEnv node
       case nodeValue of
         RuntimeNode (GrinThunk functionName) fields -> do
+          function <- lookupFunction functionName
+          let resultRep = grinFunctionResultRep function
+          if isLiftedRuntimeRep resultRep
+            then pure ()
+            else throwInterpret (InterpretInvalidThunkResultRep functionName resultRep)
           writeCell location HeapBlackhole
           result <- (Right <$> callFunction functionName fields) `catchE` (pure . Left)
           case result of
@@ -347,14 +356,27 @@ applyValue function arguments = do
 
 callFunction :: FunctionName -> [RuntimeValue] -> EvalM [RuntimeValue]
 callFunction functionName arguments = do
+  function <- lookupFunction functionName
+  let parameters = grinFunctionParameters function
+  if length parameters == length arguments
+    then evalExpr (Map.fromList (zip parameters arguments)) (grinFunctionBody function)
+    else throwInterpret (InterpretFunctionArity functionName (length parameters) (length arguments))
+
+lookupFunction :: FunctionName -> EvalM GrinFunction
+lookupFunction functionName = do
   functions <- getsMachine machineFunctions
   case Map.lookup functionName functions of
     Nothing -> throwInterpret (InterpretUnknownFunction functionName)
-    Just function ->
-      let parameters = grinFunctionParameters function
-       in if length parameters == length arguments
-            then evalExpr (Map.fromList (zip parameters arguments)) (grinFunctionBody function)
-            else throwInterpret (InterpretFunctionArity functionName (length parameters) (length arguments))
+    Just function -> pure function
+
+isLiftedRuntimeValue :: RuntimeValue -> Bool
+isLiftedRuntimeValue value =
+  case value of
+    RuntimeLit literal -> isLiftedRuntimeRep (grinValueRuntimeRep (GrinLitValue literal))
+    RuntimeNode {} -> True
+    RuntimeLocation {} -> True
+    RuntimeMutVar {} -> False
+    RuntimeStateToken -> False
 
 applyPrimitive :: Text -> Int -> [RuntimeValue] -> [RuntimeValue] -> EvalM [RuntimeValue]
 applyPrimitive name remaining captured arguments

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -22,6 +22,7 @@ data GrinLintError
   | GrinLintUnknownFunction !FunctionName
   | GrinLintFunctionArity !FunctionName !Int !Int
   | GrinLintRepresentationMismatch !String !RuntimeRep !RuntimeRep
+  | GrinLintResultLayout !String ![RuntimeRep] ![RuntimeRep]
   | GrinLintEvalNonLifted !RuntimeRep
   | GrinLintForeignArity !Text !Int !Int
   | GrinLintUnknownForeignCall !Text
@@ -83,20 +84,21 @@ lintFunction env function =
   where
     bound = Set.fromList (grinFunctionParameters function) <> lintGlobalVars env
     resultErrors =
-      case exprRuntimeRep (grinFunctionBody function) of
+      case exprRuntimeReps (grinFunctionBody function) of
         Just actual
-          | actual /= grinFunctionResultRep function ->
-              [GrinLintRepresentationMismatch "function result" (grinFunctionResultRep function) actual]
+          | actual /= expected ->
+              [GrinLintResultLayout "function result" expected actual]
         _ -> []
+    expected = runtimeRepComponents (grinFunctionResultRep function)
 
 lintExpr :: LintEnv -> Set GrinVar -> GrinExpr -> [GrinLintError]
 lintExpr env bound expr =
   case expr of
-    GrinReturn value -> lintValue env bound value
-    GrinBind var valueExpr body ->
-      bindRepresentationErrors var valueExpr
+    GrinReturn values -> concatMap (lintValue env bound) values
+    GrinBind vars valueExpr body ->
+      bindRepresentationErrors vars valueExpr
         <> lintExpr env bound valueExpr
-        <> lintExpr env (Set.insert var bound) body
+        <> lintExpr env (Set.fromList vars <> bound) body
     GrinStore node -> lintNode env bound node
     GrinStoreRec bindings body ->
       let recursiveBound = Set.fromList (map fst bindings) <> bound
@@ -107,7 +109,7 @@ lintExpr env bound expr =
     GrinEval _ value ->
       [GrinLintEvalNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, runtimeRep /= liftedRuntimeRep]
         <> lintValue env bound value
-    GrinApply _ function argument -> lintValue env bound function <> lintValue env bound argument
+    GrinApply _ function arguments -> lintValue env bound function <> concatMap (lintValue env bound) arguments
     GrinCase scrutinee binder alternatives ->
       lintValue env bound scrutinee
         <> concatMap (lintAlt env (Set.insert binder bound)) alternatives
@@ -116,7 +118,7 @@ lintExpr env bound expr =
     GrinCatch _ action handler state ->
       lintValue env bound action
         <> lintValue env bound handler
-        <> lintValue env bound state
+        <> concatMap (lintValue env bound) state
     GrinForeignCallExpr foreignCall arguments ->
       let expectedReps = grinForeignOperandReps (grinForeignCallSignature foreignCall)
           actualReps = map grinValueRuntimeRep arguments
@@ -136,12 +138,14 @@ lintExpr env bound expr =
                ]
             <> concatMap (lintValue env bound) arguments
   where
-    bindRepresentationErrors var valueExpr =
-      case exprRuntimeRep valueExpr of
+    bindRepresentationErrors vars valueExpr =
+      case exprRuntimeReps valueExpr of
         Just actual
-          | actual /= grinVarRuntimeRep var ->
-              [GrinLintRepresentationMismatch "bind" (grinVarRuntimeRep var) actual]
+          | actual /= expected ->
+              [GrinLintResultLayout "bind" expected actual]
         _ -> []
+      where
+        expected = map grinVarRuntimeRep vars
 
 lintAlt :: LintEnv -> Set GrinVar -> GrinAlt -> [GrinLintError]
 lintAlt env bound alt =
@@ -179,7 +183,7 @@ lintNodeFunction :: LintEnv -> GrinNode -> [GrinLintError]
 lintNodeFunction env node =
   case grinNodeTag node of
     GrinThunk functionName -> checkFunctionArity functionName fieldCount
-    GrinClosure functionName -> checkFunctionArity functionName (fieldCount + 1)
+    GrinClosure functionName argumentCount -> checkClosureArity functionName argumentCount
     _ -> []
   where
     fieldCount = length (grinNodeFields node)
@@ -189,6 +193,8 @@ lintNodeFunction env node =
         Just expected
           | expected == actual -> []
           | otherwise -> [GrinLintFunctionArity functionName expected actual]
+    checkClosureArity functionName argumentCount =
+      checkFunctionArity functionName (fieldCount + argumentCount)
 
 duplicates :: (Ord a) => [a] -> [a]
 duplicates = go Set.empty Set.empty
@@ -198,23 +204,23 @@ duplicates = go Set.empty Set.empty
       | value `Set.member` seen = go seen (Set.insert value repeated) rest
       | otherwise = go (Set.insert value seen) repeated rest
 
-exprRuntimeRep :: GrinExpr -> Maybe RuntimeRep
-exprRuntimeRep expr =
+exprRuntimeReps :: GrinExpr -> Maybe [RuntimeRep]
+exprRuntimeReps expr =
   case expr of
-    GrinReturn value -> Just (grinValueRuntimeRep value)
-    GrinBind _ _ body -> exprRuntimeRep body
-    GrinStore {} -> Just liftedRuntimeRep
-    GrinStoreRec _ body -> exprRuntimeRep body
-    GrinFetch runtimeRep _ -> Just runtimeRep
-    GrinUpdate _ value -> Just (grinValueRuntimeRep value)
-    GrinEval runtimeRep _ -> Just runtimeRep
-    GrinApply runtimeRep _ _ -> Just runtimeRep
+    GrinReturn values -> Just (map grinValueRuntimeRep values)
+    GrinBind _ _ body -> exprRuntimeReps body
+    GrinStore {} -> Just [liftedRuntimeRep]
+    GrinStoreRec _ body -> exprRuntimeReps body
+    GrinFetch runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
+    GrinUpdate _ value -> Just [grinValueRuntimeRep value]
+    GrinEval runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
+    GrinApply runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinCase _ _ alternatives ->
       case alternatives of
-        first : _ -> exprRuntimeRep (grinAltRhs first)
+        first : _ -> exprRuntimeReps (grinAltRhs first)
         [] -> Nothing
-    GrinDictSelect runtimeRep _ _ -> Just runtimeRep
+    GrinDictSelect runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinThrow {} -> Nothing
-    GrinCatch runtimeRep _ _ _ -> Just runtimeRep
+    GrinCatch runtimeRep _ _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinForeignCallExpr foreignCall _ ->
-      Just (grinForeignCallResultRep (grinForeignCallSignature foreignCall))
+      Just (grinForeignCallResultReps (grinForeignCallSignature foreignCall))

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -21,9 +21,11 @@ data GrinLintError
   | GrinLintUnboundVariable !GrinVar
   | GrinLintUnknownFunction !FunctionName
   | GrinLintFunctionArity !FunctionName !Int !Int
+  | GrinLintThunkResult !FunctionName !RuntimeRep
   | GrinLintRepresentationMismatch !String !RuntimeRep !RuntimeRep
   | GrinLintResultLayout !String ![RuntimeRep] ![RuntimeRep]
   | GrinLintEvalNonLifted !RuntimeRep
+  | GrinLintUpdateNonLifted !RuntimeRep
   | GrinLintForeignArity !Text !Int !Int
   | GrinLintUnknownForeignCall !Text
   | GrinLintForeignCallDescriptorMismatch !Text
@@ -32,6 +34,7 @@ data GrinLintError
 
 data LintEnv = LintEnv
   { lintFunctionArities :: !(Map FunctionName Int),
+    lintFunctionResults :: !(Map FunctionName RuntimeRep),
     lintGlobalVars :: !(Set GrinVar),
     lintGlobalNames :: !(Set Text),
     lintConstructorLayouts :: !(Map Text [RuntimeRep]),
@@ -58,6 +61,7 @@ lintProgram program =
               [ (grinFunctionName function, length (grinFunctionParameters function))
               | function <- functions
               ],
+          lintFunctionResults = Map.fromList [(grinFunctionName function, grinFunctionResultRep function) | function <- functions],
           lintGlobalVars = Set.fromList cafVars,
           lintGlobalNames =
             Set.fromList
@@ -105,7 +109,10 @@ lintExpr env bound expr =
        in concatMap (lintNode env recursiveBound . snd) bindings
             <> lintExpr env recursiveBound body
     GrinFetch _ pointer -> lintValue env bound pointer
-    GrinUpdate pointer value -> lintValue env bound pointer <> lintValue env bound value
+    GrinUpdate pointer value ->
+      [GrinLintUpdateNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, not (isLiftedRuntimeRep runtimeRep)]
+        <> lintValue env bound pointer
+        <> lintValue env bound value
     GrinEval _ value ->
       [GrinLintEvalNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, runtimeRep /= liftedRuntimeRep]
         <> lintValue env bound value
@@ -182,7 +189,7 @@ lintConstructorFields env node =
 lintNodeFunction :: LintEnv -> GrinNode -> [GrinLintError]
 lintNodeFunction env node =
   case grinNodeTag node of
-    GrinThunk functionName -> checkFunctionArity functionName fieldCount
+    GrinThunk functionName -> checkFunctionArity functionName fieldCount <> checkThunkResult functionName
     GrinClosure functionName argumentCount -> checkClosureArity functionName argumentCount
     _ -> []
   where
@@ -195,6 +202,11 @@ lintNodeFunction env node =
           | otherwise -> [GrinLintFunctionArity functionName expected actual]
     checkClosureArity functionName argumentCount =
       checkFunctionArity functionName (fieldCount + argumentCount)
+    checkThunkResult functionName =
+      case Map.lookup functionName (lintFunctionResults env) of
+        Just runtimeRep
+          | not (isLiftedRuntimeRep runtimeRep) -> [GrinLintThunkResult functionName runtimeRep]
+        _ -> []
 
 duplicates :: (Ord a) => [a] -> [a]
 duplicates = go Set.empty Set.empty

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Lowering from non-strict System FC to strict, runtime-explicit GRIN.
@@ -12,7 +13,7 @@ import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types
-  ( RuntimeRep,
+  ( RuntimeRep (..),
     TcType (..),
     Unique (..),
     liftedRuntimeRep,
@@ -20,8 +21,8 @@ import Aihc.Tc.Types
     tyConArity,
     tyConName,
   )
-import Control.Monad (filterM)
 import Control.Monad.Trans.State.Strict (State, gets, modify', runState)
+import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -35,7 +36,7 @@ data LowerState = LowerState
     lowerPrimitiveNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
-    lowerLocalVars :: !(Set (Text, Unique))
+    lowerLocalVars :: !(Map (Text, Unique) [GrinVar])
   }
 
 type LowerM = State LowerState
@@ -126,7 +127,7 @@ lowerProgramWithEnvironment environment program =
           lowerPrimitiveNames = programEnvironmentPrimitives environment,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
-          lowerLocalVars = Set.empty
+          lowerLocalVars = Map.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
     tops = mconcat topParts
@@ -135,7 +136,7 @@ lowerTopBind :: FcTopBind -> LowerM LoweredTop
 lowerTopBind topBind =
   case topBind of
     FcData _ _ constructors ->
-      pure mempty {loweredConstructors = [(name, map typeRuntimeRep fields) | (name, fields) <- constructors]}
+      pure mempty {loweredConstructors = [(name, concatMap (runtimeRepComponents . typeRuntimeRep) fields) | (name, fields) <- constructors]}
     FcNewtype {} ->
       pure mempty
     FcPrimitive var arity ->
@@ -165,31 +166,44 @@ lowerExpr :: FcExpr -> LowerM GrinExpr
 lowerExpr expr = do
   primitiveNames <- gets lowerPrimitiveNames
   localVars <- gets lowerLocalVars
-  case primitiveApplication primitiveNames localVars expr of
+  case primitiveApplication primitiveNames (Map.keysSet localVars) expr of
     Just ("raise#", [exception]) ->
-      lowerStrict "exception" exception (pure . GrinThrow)
-    Just ("catch#", [action, handler, state]) ->
-      lowerArgument action $ \actionValue ->
-        lowerArgument handler $ \handlerValue ->
-          lowerArgument state $ \stateValue ->
-            pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue stateValue)
+      lowerSingleStrict "exception" exception (pure . GrinThrow)
+    Just ("catch#", [action, handler, _state]) ->
+      lowerSingleArgument action $ \actionValue ->
+        lowerSingleArgument handler $ \handlerValue ->
+          pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue [])
     _ -> lowerOrdinaryExpr expr
 
 lowerOrdinaryExpr :: FcExpr -> LowerM GrinExpr
 lowerOrdinaryExpr expr =
+  case unboxedTupleArguments expr of
+    Just arguments ->
+      lowerArgumentMany arguments (pure . GrinReturn)
+    Nothing -> lowerNonTupleExpr expr
+
+lowerNonTupleExpr :: FcExpr -> LowerM GrinExpr
+lowerNonTupleExpr expr =
   case expr of
     FcVar var ->
       do
-        direct <- lowerDirectValue expr
+        direct <- lowerDirectValues expr
         case direct of
-          Just value -> pure (GrinReturn value)
+          Just values -> pure (GrinReturn values)
           Nothing -> do
             isGlobal <- isGlobalVar var
+            runtimeVar <-
+              if isGlobal
+                then pure (lowerGlobalVar var)
+                else do
+                  localValues <- lookupLocalVars var
+                  case localValues of
+                    [localVar] -> pure localVar
+                    _ -> error "GRIN lowering expected one lifted local"
             let resultRep = typeRuntimeRep (varType var)
-                runtimeVar = if isGlobal then lowerGlobalVar var else lowerVar var
             pure (GrinEval resultRep (GrinVarValue runtimeVar))
     FcLit literal ->
-      pure (GrinReturn (GrinLitValue (lowerLiteral literal)))
+      pure (GrinReturn [GrinLitValue (lowerLiteral literal)])
     FcApp function argument ->
       lowerApplication function argument
     FcDictApp function argument ->
@@ -204,16 +218,14 @@ lowerOrdinaryExpr expr =
       lowerLambda var body
     FcDict fields ->
       lowerArgumentMany fields $ \values ->
-        pure (GrinReturn (GrinNodeValue (GrinNode GrinDictionary values)))
+        pure (GrinReturn [GrinNodeValue (GrinNode GrinDictionary values)])
     FcDictSelect dictionary index ->
-      lowerStrict "dictionary" dictionary $ \value ->
+      lowerSingleStrict "dictionary" dictionary $ \value ->
         pure (GrinDictSelect liftedRuntimeRep value index)
     FcLet bind body ->
       lowerLet bind body
     FcCase scrutinee binder alternatives ->
-      lowerStrict "scrutinee" scrutinee $ \value -> do
-        loweredAlternatives <- mapM (lowerAlt binder) alternatives
-        pure (GrinCase value (lowerVar binder) loweredAlternatives)
+      lowerCase scrutinee binder alternatives
     FcCast inner _ ->
       lowerExpr inner
     FcCallForeign foreignCall arguments ->
@@ -222,58 +234,109 @@ lowerOrdinaryExpr expr =
 
 lowerApplication :: FcExpr -> FcExpr -> LowerM GrinExpr
 lowerApplication function argument =
-  lowerStrict "function" function $ \functionValue ->
-    lowerArgument argument $ \argumentValue ->
-      pure (GrinApply (applicationResultRep function) functionValue argumentValue)
+  lowerSingleStrict "function" function $ \functionValue ->
+    lowerArgument argument $ \argumentValues ->
+      pure (GrinApply (applicationResultRep function) functionValue argumentValues)
+
+lowerCase :: FcExpr -> Var -> [FcAlt] -> LowerM GrinExpr
+lowerCase scrutinee binder alternatives =
+  case (runtimeRepComponents scrutineeRep, scrutineeRep, alternatives) of
+    ([], _, [alternative]) -> do
+      rhs <-
+        withBindings
+          ((binder, []) : [(fieldBinder, []) | fieldBinder <- altBinders alternative])
+          (lowerExpr (altRhs alternative))
+      scrutineeExpr <- lowerExpr scrutinee
+      pure (GrinBind [] scrutineeExpr rhs)
+    (_, TupleRep _, [alternative])
+      | DataAlt constructor <- altCon alternative,
+        isUnboxedTupleConstructor constructor ->
+          lowerUnboxedTupleCase scrutinee binder alternative
+    _ ->
+      lowerSingleStrict "scrutinee" scrutinee $ \value -> do
+        caseVars <- binderVars binder
+        caseVar <-
+          case caseVars of
+            [var] -> pure var
+            _ -> error "GRIN lowering expected one ordinary case binder"
+        loweredAlternatives <- mapM (lowerAlt (binder, [caseVar])) alternatives
+        pure (GrinCase value caseVar loweredAlternatives)
+  where
+    scrutineeRep = exprRuntimeRep scrutinee
+
+lowerUnboxedTupleCase :: FcExpr -> Var -> FcAlt -> LowerM GrinExpr
+lowerUnboxedTupleCase scrutinee binder alternative = do
+  resultVars <- freshVars "tuple" (exprRuntimeRep scrutinee)
+  let fieldBinders = altBinders alternative
+      fieldWidths = map (length . runtimeRepComponents . typeRuntimeRep . varType) fieldBinders
+      fieldGroups = splitWidths fieldWidths resultVars
+  if sum fieldWidths /= length resultVars
+    then error "GRIN lowering found inconsistent unboxed-tuple case fields"
+    else do
+      rhs <-
+        withBindings
+          ((binder, resultVars) : zip fieldBinders fieldGroups)
+          (lowerExpr (altRhs alternative))
+      scrutineeExpr <- lowerExpr scrutinee
+      pure (GrinBind resultVars scrutineeExpr rhs)
+
+splitWidths :: [Int] -> [value] -> [[value]]
+splitWidths widths values =
+  case widths of
+    [] -> []
+    width : rest ->
+      let (field, remaining) = splitAt width values
+       in field : splitWidths rest remaining
 
 lowerLambda :: Var -> FcExpr -> LowerM GrinExpr
 lowerLambda binder body = do
   captures <- capturesFor (FcLam binder body)
   functionName <- freshFunction "closure"
-  loweredBody <- withLocalVars [binder] (lowerExpr body)
+  (parameters, loweredBody) <- withFreshLocalVars [binder] $ \groups -> do
+    body' <- lowerExpr body
+    pure (concat groups, body')
   emitFunction
     GrinFunction
       { grinFunctionName = functionName,
-        grinFunctionParameters = captures <> [lowerVar binder],
+        grinFunctionParameters = captures <> parameters,
         grinFunctionResultRep = exprRuntimeRep body,
         grinFunctionBody = loweredBody
       }
   pure
-    ( GrinReturn
-        ( GrinNodeValue
-            (GrinNode (GrinClosure functionName) (map GrinVarValue captures))
-        )
-    )
+    (GrinReturn [GrinNodeValue (GrinNode (GrinClosure functionName (length parameters)) (map GrinVarValue captures))])
 
 lowerLet :: FcBind -> FcExpr -> LowerM GrinExpr
 lowerLet bind body =
   case bind of
     FcNonRec var rhs -> do
-      loweredBody <- withLocalVars [var] (lowerExpr body)
+      (vars, loweredBody) <- withFreshLocalVars [var] $ \groups -> do
+        body' <- lowerExpr body
+        pure (concat groups, body')
       if typeRuntimeRep (varType var) == liftedRuntimeRep
         then do
           node <- makeThunk rhs
-          pure (GrinBind (lowerVar var) (GrinStore node) loweredBody)
+          pure (GrinBind vars (GrinStore node) loweredBody)
         else do
           loweredRhs <- lowerExpr rhs
-          pure (GrinBind (lowerVar var) loweredRhs loweredBody)
+          pure (GrinBind vars loweredRhs loweredBody)
     FcRec bindings -> do
-      withLocalVars (map fst bindings) $ do
-        nodes <- mapM lowerBinding bindings
+      withFreshLocalVars (map fst bindings) $ \groups -> do
+        nodes <- mapM (makeThunk . snd) bindings
         loweredBody <- lowerExpr body
-        pure (GrinStoreRec nodes loweredBody)
-  where
-    lowerBinding (var, rhs) = do
-      node <- makeThunk rhs
-      pure (lowerVar var, node)
+        let vars = concat groups
+        if length vars == length nodes
+          then pure (GrinStoreRec (zip vars nodes) loweredBody)
+          else error "GRIN lowering expected lifted recursive bindings"
 
-lowerAlt :: Var -> FcAlt -> LowerM GrinAlt
-lowerAlt caseBinder alt = do
-  rhs <- withLocalVars (caseBinder : altBinders alt) (lowerExpr (altRhs alt))
+lowerAlt :: (Var, [GrinVar]) -> FcAlt -> LowerM GrinAlt
+lowerAlt caseBinding alt = do
+  (binders, rhs) <- withBindings [caseBinding] $ withFreshLocalVars (altBinders alt) $ \groups -> do
+    rhs' <- lowerExpr (altRhs alt)
+    pure (concat groups, rhs')
   pure
     GrinAlt
       { grinAltCon = lowerAltCon (altCon alt),
-        grinAltBinders = map lowerVar (altBinders alt),
+        grinAltBinders = binders,
         grinAltRhs = rhs
       }
 
@@ -291,50 +354,82 @@ makeThunk expr = do
       }
   pure (GrinNode (GrinThunk functionName) (map GrinVarValue captures))
 
-lowerStrict :: Text -> FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerStrict :: Text -> FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerStrict hint expr continuation = do
-  direct <- lowerDirectValue expr
+  direct <- lowerDirectValues expr
   case direct of
-    Just value -> continuation value
+    Just values -> continuation values
     Nothing -> do
-      valueVar <- freshVar hint (exprRuntimeRep expr)
+      valueVars <- freshVars hint (exprRuntimeRep expr)
       valueExpr <- lowerExpr expr
-      rest <- continuation (GrinVarValue valueVar)
-      pure (GrinBind valueVar valueExpr rest)
+      rest <- continuation (map GrinVarValue valueVars)
+      pure (GrinBind valueVars valueExpr rest)
 
-lowerDelayed :: FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerSingleStrict :: Text -> FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerSingleStrict hint expr continuation =
+  lowerStrict hint expr $ \case
+    [value] -> continuation value
+    _ -> error ("GRIN lowering expected one value for " <> T.unpack hint)
+
+lowerDelayed :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerDelayed expr continuation = do
   pointerVar <- freshVar "thunk" liftedRuntimeRep
   node <- makeThunk expr
-  rest <- continuation (GrinVarValue pointerVar)
-  pure (GrinBind pointerVar (GrinStore node) rest)
+  rest <- continuation [GrinVarValue pointerVar]
+  pure (GrinBind [pointerVar] (GrinStore node) rest)
 
-lowerArgument :: FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerArgument :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerArgument expr continuation = do
-  direct <- lowerDirectValue expr
+  direct <- lowerDirectValues expr
   case direct of
-    Just value -> continuation value
+    Just values -> continuation values
     Nothing
       | exprRuntimeRep expr == liftedRuntimeRep -> lowerDelayed expr continuation
       | otherwise -> lowerStrict "argument" expr continuation
+
+lowerSingleArgument :: FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerSingleArgument expr continuation =
+  lowerArgument expr $ \case
+    [value] -> continuation value
+    _ -> error "GRIN lowering expected one argument value"
 
 lowerArgumentMany :: [FcExpr] -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerArgumentMany expressions continuation =
   case expressions of
     [] -> continuation []
     first : rest ->
-      lowerArgument first $ \firstValue ->
+      lowerArgument first $ \firstValues ->
         lowerArgumentMany rest $ \restValues ->
-          continuation (firstValue : restValues)
+          continuation (firstValues <> restValues)
 
 lowerStrictMany :: [FcExpr] -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerStrictMany expressions continuation =
   case expressions of
     [] -> continuation []
     first : rest ->
-      lowerStrict "foreign_argument" first $ \firstValue ->
+      lowerStrict "foreign_argument" first $ \firstValues ->
         lowerStrictMany rest $ \restValues ->
-          continuation (firstValue : restValues)
+          continuation (firstValues <> restValues)
+
+freshVars :: Text -> RuntimeRep -> LowerM [GrinVar]
+freshVars hint = mapM (freshVar hint) . runtimeRepComponents
+
+unboxedTupleArguments :: FcExpr -> Maybe [FcExpr]
+unboxedTupleArguments expr =
+  case collectApplications expr of
+    (FcVar constructor, arguments)
+      | isUnboxedTupleConstructor (varName constructor) ->
+          case exprRuntimeRep expr of
+            TupleRep fieldReps
+              | length arguments == length fieldReps -> Just arguments
+            _ -> Nothing
+    _ -> Nothing
+
+isUnboxedTupleConstructor :: Text -> Bool
+isUnboxedTupleConstructor name =
+  case T.stripPrefix "(#" name >>= T.stripSuffix "#)" of
+    Just punctuation -> T.all (== ',') punctuation
+    Nothing -> False
 
 freshVar :: Text -> RuntimeRep -> LowerM GrinVar
 freshVar hint runtimeRep = do
@@ -412,59 +507,88 @@ freeVarsAlt :: FcAlt -> Set Var
 freeVarsAlt alt =
   freeVars (altRhs alt) `Set.difference` Set.fromList (altBinders alt)
 
-lowerVar :: Var -> GrinVar
-lowerVar var = GrinVar (varName var) (sourceUnique var) (typeRuntimeRep (varType var))
-
 lowerGlobalVar :: Var -> GrinVar
 lowerGlobalVar var = GrinVar (varName var) (sourceUnique var) liftedRuntimeRep
 
 capturesFor :: FcExpr -> LowerM [GrinVar]
-capturesFor expr = do
-  vars <- filterM (fmap not . isGlobalVar) (Set.toAscList (freeVars expr))
-  pure (map lowerVar vars)
+capturesFor expr =
+  fmap concat . mapM captureVars $ Set.toAscList (freeVars expr)
+  where
+    captureVars var = do
+      global <- isGlobalVar var
+      if global then pure [] else lookupLocalVars var
 
 isGlobalVar :: Var -> LowerM Bool
 isGlobalVar var = do
   localVars <- gets lowerLocalVars
   globalNames <- gets lowerGlobalNames
-  pure (varKey var `Set.notMember` localVars && varName var `Set.member` globalNames)
+  pure
+    ( varKey var `Map.notMember` localVars
+        && (varName var `Set.member` globalNames || isUnboxedTupleConstructor (varName var))
+    )
 
 -- | Values that are already in runtime normal form can be embedded directly
 -- in the surrounding GRIN operation. Constructor, primitive, and foreign
 -- globals are initialized as runtime nodes; unlike CAFs, they have no thunk to
 -- enter. Unboxed locals and literals are direct machine values as well.
-lowerDirectValue :: FcExpr -> LowerM (Maybe GrinValue)
-lowerDirectValue expr =
+lowerDirectValues :: FcExpr -> LowerM (Maybe [GrinValue])
+lowerDirectValues expr =
   case expr of
     FcVar var -> do
       isGlobal <- isGlobalVar var
       isWhnfGlobal <- isWhnfGlobalVar var
       let runtimeRep = typeRuntimeRep (varType var)
-      pure $
-        if isWhnfGlobal
-          then Just (GrinVarValue (lowerGlobalVar var))
-          else
-            if not isGlobal && runtimeRep /= liftedRuntimeRep
-              then Just (GrinVarValue (lowerVar var))
-              else Nothing
-    FcLit literal -> pure (Just (GrinLitValue (lowerLiteral literal)))
-    FcTyApp inner _ -> lowerDirectValue inner
-    FcCast inner _ -> lowerDirectValue inner
+      if null (runtimeRepComponents runtimeRep)
+        then pure (Just [])
+        else
+          if isWhnfGlobal
+            then pure (Just [GrinVarValue (lowerGlobalVar var)])
+            else
+              if not isGlobal && runtimeRep /= liftedRuntimeRep
+                then Just . map GrinVarValue <$> lookupLocalVars var
+                else pure Nothing
+    FcLit literal -> pure (Just [GrinLitValue (lowerLiteral literal)])
+    FcTyApp inner _ -> lowerDirectValues inner
+    FcCast inner _ -> lowerDirectValues inner
     _ -> pure Nothing
 
 isWhnfGlobalVar :: Var -> LowerM Bool
 isWhnfGlobalVar var = do
   localVars <- gets lowerLocalVars
   whnfGlobalNames <- gets lowerWhnfGlobalNames
-  pure (varKey var `Set.notMember` localVars && varName var `Set.member` whnfGlobalNames)
+  pure (varKey var `Map.notMember` localVars && varName var `Set.member` whnfGlobalNames)
 
-withLocalVars :: [Var] -> LowerM a -> LowerM a
-withLocalVars vars action = do
+withFreshLocalVars :: [Var] -> ([[GrinVar]] -> LowerM a) -> LowerM a
+withFreshLocalVars vars action = do
+  groups <- mapM binderVars vars
+  withBindings (zip vars groups) (action groups)
+
+withBindings :: [(Var, [GrinVar])] -> LowerM a -> LowerM a
+withBindings bindings action = do
   previous <- gets lowerLocalVars
-  modify' $ \state -> state {lowerLocalVars = Set.fromList (map varKey vars) <> previous}
+  let locals = Map.fromList [(varKey var, values) | (var, values) <- bindings]
+  modify' $ \state -> state {lowerLocalVars = locals <> previous}
   result <- action
   modify' $ \state -> state {lowerLocalVars = previous}
   pure result
+
+binderVars :: Var -> LowerM [GrinVar]
+binderVars var =
+  case runtimeRepComponents (typeRuntimeRep (varType var)) of
+    [] -> pure []
+    [runtimeRep] -> pure [GrinVar (varName var) (sourceUnique var) runtimeRep]
+    runtimeReps ->
+      sequence
+        [ freshVar (varName var <> "_" <> T.pack (show index)) runtimeRep
+        | (index, runtimeRep) <- zip [0 :: Int ..] runtimeReps
+        ]
+
+lookupLocalVars :: Var -> LowerM [GrinVar]
+lookupLocalVars var = do
+  locals <- gets lowerLocalVars
+  case Map.lookup (varKey var) locals of
+    Just values -> pure values
+    Nothing -> error ("GRIN lowering lost local binding for " <> T.unpack (varName var))
 
 varKey :: Var -> (Text, Unique)
 varKey var = (varName var, varUnique var)

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -341,18 +341,23 @@ lowerAlt caseBinding alt = do
       }
 
 makeThunk :: FcExpr -> LowerM GrinNode
-makeThunk expr = do
-  captures <- capturesFor expr
-  functionName <- freshFunction "thunk"
-  body <- lowerExpr expr
-  emitFunction
-    GrinFunction
-      { grinFunctionName = functionName,
-        grinFunctionParameters = captures,
-        grinFunctionResultRep = exprRuntimeRep expr,
-        grinFunctionBody = body
-      }
-  pure (GrinNode (GrinThunk functionName) (map GrinVarValue captures))
+makeThunk expr
+  | not (isLiftedRuntimeRep runtimeRep) =
+      error ("GRIN lowering cannot suspend an expression with runtime representation " <> show runtimeRep)
+  | otherwise = do
+      captures <- capturesFor expr
+      functionName <- freshFunction "thunk"
+      body <- lowerExpr expr
+      emitFunction
+        GrinFunction
+          { grinFunctionName = functionName,
+            grinFunctionParameters = captures,
+            grinFunctionResultRep = runtimeRep,
+            grinFunctionBody = body
+          }
+      pure (GrinNode (GrinThunk functionName) (map GrinVarValue captures))
+  where
+    runtimeRep = exprRuntimeRep expr
 
 lowerStrict :: Text -> FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerStrict hint expr continuation = do

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -61,10 +61,10 @@ renderExpr = renderExprIndented 0
 renderExprIndented :: Int -> GrinExpr -> String
 renderExprIndented indentation expr =
   case expr of
-    GrinReturn value -> indent indentation <> "return " <> renderValue value
-    GrinBind var valueExpr body ->
+    GrinReturn values -> indent indentation <> "return" <> renderValues values
+    GrinBind vars valueExpr body ->
       indent indentation
-        <> renderVar var
+        <> renderBinders vars
         <> " <-\n"
         <> renderExprIndented (indentation + 2) valueExpr
         <> "\n"
@@ -86,14 +86,13 @@ renderExprIndented indentation expr =
       indent indentation <> "update " <> renderValue pointer <> " " <> renderValue value
     GrinEval runtimeRep value ->
       indent indentation <> "eval @" <> show runtimeRep <> " " <> renderValue value
-    GrinApply runtimeRep function argument ->
+    GrinApply runtimeRep function arguments ->
       indent indentation
         <> "apply @"
         <> show runtimeRep
         <> " "
         <> renderValue function
-        <> " "
-        <> renderValue argument
+        <> renderValues arguments
     GrinCase scrutinee binder alternatives ->
       indent indentation
         <> "case "
@@ -116,12 +115,22 @@ renderExprIndented indentation expr =
         <> "catch @"
         <> show runtimeRep
         <> " "
-        <> unwords (map renderValue [action, handler, state])
+        <> unwords (map renderValue [action, handler])
+        <> renderValues state
     GrinForeignCallExpr foreignCall arguments ->
       indent indentation
         <> "foreign-call "
         <> T.unpack (grinForeignCallName foreignCall)
         <> concatMap ((" " <>) . renderValue) arguments
+
+renderValues :: [GrinValue] -> String
+renderValues = concatMap ((" " <>) . renderValue)
+
+renderBinders :: [GrinVar] -> String
+renderBinders vars =
+  case vars of
+    [] -> "()"
+    _ -> intercalate ", " (map renderVar vars)
 
 renderAlt :: Int -> GrinAlt -> String
 renderAlt indentation alt =
@@ -156,7 +165,8 @@ renderNodeTag :: GrinNodeTag -> String
 renderNodeTag nodeTag =
   case nodeTag of
     GrinConstructor name -> "C" <> T.unpack name
-    GrinClosure functionName -> "P" <> T.unpack (unFunctionName functionName)
+    GrinClosure functionName argumentCount ->
+      "P" <> T.unpack (unFunctionName functionName) <> "/" <> show argumentCount
     GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
     GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
     GrinDictionary -> "Dict"

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -21,8 +21,9 @@ module Aihc.Grin.Syntax
     GrinForeignSignature (..),
     GrinForeignEffect (..),
     GrinForeignType (..),
+    runtimeRepComponents,
     grinForeignOperandReps,
-    grinForeignCallResultRep,
+    grinForeignCallResultReps,
     grinValueRuntimeRep,
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
@@ -82,21 +83,22 @@ instance Ord GrinVar where
       (grinVarName left, grinVarUnique left)
       (grinVarName right, grinVarUnique right)
 
--- | Strict expressions. Every constructor except 'GrinStoreRec' produces one
--- value; 'GrinBind' names that value for the following expression.
+-- | Strict expressions return zero or more register values. 'GrinBind' names
+-- those values for the following expression. In particular, an unboxed tuple
+-- is represented by its flattened components, never by a heap node.
 data GrinExpr
-  = GrinReturn !GrinValue
-  | GrinBind !GrinVar !GrinExpr !GrinExpr
+  = GrinReturn ![GrinValue]
+  | GrinBind ![GrinVar] !GrinExpr !GrinExpr
   | GrinStore !GrinNode
   | GrinStoreRec ![(GrinVar, GrinNode)] !GrinExpr
   | GrinFetch !RuntimeRep !GrinValue
   | GrinUpdate !GrinValue !GrinValue
   | GrinEval !RuntimeRep !GrinValue
-  | GrinApply !RuntimeRep !GrinValue !GrinValue
+  | GrinApply !RuntimeRep !GrinValue ![GrinValue]
   | GrinCase !GrinValue !GrinVar ![GrinAlt]
   | GrinDictSelect !RuntimeRep !GrinValue !Int
   | GrinThrow !GrinValue
-  | GrinCatch !RuntimeRep !GrinValue !GrinValue !GrinValue
+  | GrinCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
   | -- | A saturated call whose operands are already strict primitive values.
     GrinForeignCallExpr !GrinForeignCall ![GrinValue]
   deriving (Eq, Show)
@@ -116,7 +118,7 @@ data GrinNode = GrinNode
 
 data GrinNodeTag
   = GrinConstructor !Text
-  | GrinClosure !FunctionName
+  | GrinClosure !FunctionName !Int
   | GrinThunk !FunctionName
   | GrinPrimitive !Text !Int
   | GrinDictionary
@@ -155,14 +157,20 @@ grinValueRuntimeRep value =
 isLiftedRuntimeRep :: RuntimeRep -> Bool
 isLiftedRuntimeRep runtimeRep = runtimeRep == liftedRuntimeRep
 
--- | Runtime reps currently carried as one pointer-sized heap reference by
--- GRIN/native codegen. Tuple and sum reps are strict, but their aggregate
--- payload is pointer-backed until the native ABI grows multi-value returns.
+-- | Flatten a source runtime representation into the values carried by GRIN's
+-- calling convention. Tuple components compose recursively, and zero-width
+-- tuples such as @State# RealWorld@ occupy no runtime slot.
+runtimeRepComponents :: RuntimeRep -> [RuntimeRep]
+runtimeRepComponents runtimeRep =
+  case runtimeRep of
+    TupleRep fieldReps -> concatMap runtimeRepComponents fieldReps
+    _ -> [runtimeRep]
+
+-- | Runtime reps carried in one pointer-sized slot.
 isPointerRuntimeRep :: RuntimeRep -> Bool
 isPointerRuntimeRep runtimeRep =
   case runtimeRep of
     BoxedRep {} -> True
-    TupleRep {} -> True
     SumRep {} -> True
     _ -> False
 
@@ -176,8 +184,7 @@ builtinConstructors =
     ("[]", 0),
     (":", 2),
     ("()", 0),
-    ("(,)", 2),
-    ("(#,#)", 2)
+    ("(,)", 2)
   ]
 
 data GrinForeignCall = GrinForeignCall
@@ -207,16 +214,10 @@ data GrinForeignType
 grinForeignOperandReps :: GrinForeignSignature -> [RuntimeRep]
 grinForeignOperandReps signature =
   map foreignTypeRuntimeRep (grinForeignArgumentTypes signature)
-    <> case grinForeignEffect signature of
-      GrinForeignPure -> []
-      GrinForeignRealWorld -> [TupleRep []]
 
-grinForeignCallResultRep :: GrinForeignSignature -> RuntimeRep
-grinForeignCallResultRep signature =
-  case grinForeignEffect signature of
-    GrinForeignPure -> foreignTypeRuntimeRep (grinForeignResultType signature)
-    GrinForeignRealWorld ->
-      TupleRep [TupleRep [], foreignTypeRuntimeRep (grinForeignResultType signature)]
+grinForeignCallResultReps :: GrinForeignSignature -> [RuntimeRep]
+grinForeignCallResultReps signature =
+  [foreignTypeRuntimeRep (grinForeignResultType signature)]
 
 foreignTypeRuntimeRep :: GrinForeignType -> RuntimeRep
 foreignTypeRuntimeRep foreignType =

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -119,7 +119,9 @@ data GrinNode = GrinNode
 data GrinNodeTag
   = GrinConstructor !Text
   | GrinClosure !FunctionName !Int
-  | GrinThunk !FunctionName
+  | -- | A suspended computation. Its target function must return exactly
+    -- @BoxedRep Lifted@; unlifted computations are always evaluated strictly.
+    GrinThunk !FunctionName
   | GrinPrimitive !Text !Int
   | GrinDictionary
   deriving (Eq, Show)

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -7,12 +7,16 @@ module Test.Grin.Suite
   )
 where
 
+import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Syntax
 import Aihc.Grin
-import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
+import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), Unique (..), runtimeRepOfType)
 import Aihc.Testing.EvalFixture qualified as EvalGolden
+import Control.Monad (forM_)
 import Data.List (isInfixOf)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import Data.Text qualified as T
 import GrinGolden qualified
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
@@ -30,7 +34,23 @@ grinUnitTests =
         assertBool "contains explicit application" ("apply " `isInfixOf` rendered),
       testCase "interpreter implements fetch and update" $ do
         result <- interpretProgramBinding "answer" heapProgram
-        assertEqual "result" (Right "2") result,
+        assertEqual "result" (Right "Box 2") result,
+      testCase "interpreter rejects unlifted thunk results" $ do
+        result <- interpretProgramBinding "bad" (unliftedHeapProgram IntRep)
+        assertEqual "result" (Left (InterpretInvalidThunkResultRep unliftedThunkFunction IntRep)) result,
+      testCase "interpreter rejects unlifted heap updates" $ do
+        result <- interpretProgramBinding "answer" invalidUpdateProgram
+        assertEqual "result" (Left (InterpretInvalidUpdateValue (RuntimeLit (GrinLitInt IntRep 2)))) result,
+      testCase "lint rejects unlifted thunk results and heap updates" $
+        forM_ unliftedRuntimeReps $ \runtimeRep ->
+          let errors = lintProgram (unliftedHeapProgram runtimeRep)
+           in do
+                assertBool
+                  ("accepted thunk returning " <> show runtimeRep)
+                  (GrinLintThunkResult unliftedThunkFunction runtimeRep `elem` errors)
+                assertBool
+                  ("accepted heap update with " <> show runtimeRep)
+                  (GrinLintUpdateNonLifted runtimeRep `elem` errors),
       testCase "lint rejects constructor field representation mismatches" $ do
         let program = heapProgram {grinConstructors = [("Box", [WordRep])]}
         assertBool
@@ -53,7 +73,7 @@ grinUnitTests =
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
         assertBool "contains a direct foreign call" ("foreign-call $ffi$abs" `isInfixOf` rendered)
-        assertBool "does not apply a foreign function value" (not ("apply " `isInfixOf` rendered)),
+        assertBool "does not apply a foreign function value" (not ("apply @Int32Rep $ffi$abs" `isInfixOf` rendered)),
       testCase "lint rejects undersaturated foreign calls" $ do
         let program = lowerProgram undersaturatedForeignProgram
         assertBool
@@ -114,15 +134,59 @@ mkEvalFixtureTest evalCase = testCase (EvalGolden.evalCaseId evalCase) $ do
 
 evaluateGrinProgram :: Text -> FcProgram -> IO (Either String Text)
 evaluateGrinProgram name fcProgram = do
-  let program = lowerProgram fcProgram
-  case lintProgram program of
-    [] -> do
-      result <- interpretProgramBinding name program
-      pure $
-        case result of
-          Left err -> Left (show err)
-          Right value -> Right value
-    lintErrors -> pure (Left ("GRIN lint error: " <> show lintErrors))
+  case prepareEvalProgram name (lowerNewtypes fcProgram) of
+    Left err -> pure (Left err)
+    Right (preparedProgram, unwrapResult) -> do
+      let program = lowerProgram preparedProgram
+      case lintProgram program of
+        [] -> do
+          result <- interpretProgramBinding name program
+          pure $
+            case result of
+              Left err -> Left (show err)
+              Right value -> Right (unwrapResult value)
+        lintErrors -> pure (Left ("GRIN lint error: " <> show lintErrors))
+
+prepareEvalProgram :: Text -> FcProgram -> Either String (FcProgram, Text -> Text)
+prepareEvalProgram name program@(FcProgram topBinds) =
+  case break isEvalBinding topBinds of
+    (_, []) -> Left ("missing evaluation binding " <> T.unpack name)
+    (_, FcTopBind (FcRec _) : _) -> Left "recursive evaluation binding is unsupported"
+    (before, FcTopBind (FcNonRec var rhs) : after) -> do
+      runtimeRep <- runtimeRepOfType (varType var)
+      if runtimeRep == BoxedRep Lifted
+        then Right (program, id)
+        else do
+          let componentCount = length (runtimeRepComponents runtimeRep)
+              constructorName = evalResultConstructor componentCount
+              wrapperType = TcTyCon (TyCon "__AihcEvalResultType" 0) []
+              constructorVar = Var constructorName (Unique (-1000000)) (TcFunTy (varType var) wrapperType)
+              wrappedVar = var {varType = wrapperType}
+              declaration = FcData "__AihcEvalResultType" [] [(constructorName, [varType var])]
+              wrappedBinding = FcTopBind (FcNonRec wrappedVar (FcApp (FcVar constructorVar) rhs))
+          Right
+            ( FcProgram (declaration : before <> (wrappedBinding : after)),
+              unwrapEvalResult componentCount constructorName
+            )
+    (_, _ : _) -> Left "invalid evaluation binding"
+  where
+    isEvalBinding topBind =
+      case topBind of
+        FcTopBind (FcNonRec var _) -> varName var == name
+        FcTopBind (FcRec bindings) -> any ((== name) . varName . fst) bindings
+        _ -> False
+
+evalResultConstructor :: Int -> Text
+evalResultConstructor componentCount
+  | componentCount == 0 = "()"
+  | componentCount == 1 = "__AihcEvalResult"
+  | otherwise = "(" <> T.replicate (componentCount - 1) "," <> ")"
+
+unwrapEvalResult :: Int -> Text -> Text -> Text
+unwrapEvalResult componentCount constructorName rendered
+  | componentCount == 0 = "<state>"
+  | componentCount == 1 = fromMaybe rendered (T.stripPrefix (constructorName <> " ") rendered)
+  | otherwise = rendered
 
 applicationProgram :: FcProgram
 applicationProgram =
@@ -163,15 +227,20 @@ unboxedApplicationProgram =
 shadowingProgram :: FcProgram
 shadowingProgram =
   FcProgram
-    [ FcTopBind
+    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+      FcTopBind
         ( FcNonRec
             answerVar
-            (FcApp (FcLam localAnswerVar (FcVar localAnswerVar)) (FcLit (LitInt IntRep 42)))
+            ( FcApp
+                (FcVar boxConstructorVar)
+                (FcApp (FcLam localAnswerVar (FcVar localAnswerVar)) (FcLit (LitInt IntRep 42)))
+            )
         )
     ]
   where
-    answerVar = Var "answer" (Unique 1) intTy
+    answerVar = Var "answer" (Unique 1) boxedIntTy
     localAnswerVar = Var "answer" (Unique 2) intTy
+    boxConstructorVar = Var "BoxedInt" (Unique 3) (TcFunTy intTy boxedIntTy)
 
 cafReferenceProgram :: FcProgram
 cafReferenceProgram =
@@ -192,14 +261,15 @@ cafReferenceProgram =
 exceptionProgram :: FcProgram
 exceptionProgram =
   FcProgram
-    [ FcPrimitive raiseVar 1,
+    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+      FcPrimitive raiseVar 1,
       FcPrimitive catchVar 3,
-      FcTopBind (FcNonRec answerVar caughtExpression)
+      FcTopBind (FcNonRec answerVar (FcApp (FcVar boxConstructorVar) caughtExpression))
     ]
   where
     raiseVar = Var "raise#" (Unique 1) (TcFunTy intTy intTy)
     catchVar = Var "catch#" (Unique 2) (TcFunTy actionTy (TcFunTy handlerTy (TcFunTy intTy intTy)))
-    answerVar = Var "answer" (Unique 3) intTy
+    answerVar = Var "answer" (Unique 3) boxedIntTy
     actionState = Var "actionState" (Unique 4) intTy
     exception = Var "exception" (Unique 5) intTy
     handlerState = Var "handlerState" (Unique 6) intTy
@@ -207,6 +277,7 @@ exceptionProgram =
     handlerTy = TcFunTy intTy (TcFunTy intTy intTy)
     action = FcLam actionState (FcApp (FcVar raiseVar) (FcLit (LitInt IntRep 10)))
     handler = FcLam exception (FcLam handlerState (FcVar exception))
+    boxConstructorVar = Var "BoxedInt" (Unique 7) (TcFunTy intTy boxedIntTy)
     caughtExpression =
       FcApp
         (FcApp (FcApp (FcVar catchVar) action) handler)
@@ -228,12 +299,12 @@ heapProgram =
         [ GrinFunction
             { grinFunctionName = functionName,
               grinFunctionParameters = [],
-              grinFunctionResultRep = IntRep,
+              grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
                 GrinBind [pointer] (GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])) $
                   GrinBind [fetched] (GrinFetch (BoxedRep Lifted) (GrinVarValue pointer)) $
-                    GrinBind [updated] (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt IntRep 2))) $
-                      GrinEval IntRep (GrinVarValue pointer)
+                    GrinBind [updated] (GrinUpdate (GrinVarValue pointer) updatedBox) $
+                      GrinEval (BoxedRep Lifted) (GrinVarValue pointer)
             }
         ]
     }
@@ -241,8 +312,71 @@ heapProgram =
     answer = GrinVar "answer" 1 (BoxedRep Lifted)
     pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
     fetched = GrinVar "fetched" 3 (BoxedRep Lifted)
-    updated = GrinVar "updated" 4 IntRep
+    updated = GrinVar "updated" 4 (BoxedRep Lifted)
+    updatedBox = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)])
     functionName = FunctionName "answer_code"
+
+invalidUpdateProgram :: GrinProgram
+invalidUpdateProgram =
+  heapProgram
+    { grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = FunctionName "answer_code",
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind [pointer] (GrinStore initialBox) $
+                  GrinBind [updated] (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt IntRep 2))) $
+                    GrinReturn [updatedBox]
+            }
+        ]
+    }
+  where
+    pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
+    updated = GrinVar "updated" 3 IntRep
+    initialBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)]
+    updatedBox = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)])
+
+unliftedRuntimeReps :: [RuntimeRep]
+unliftedRuntimeReps =
+  [ IntRep,
+    WordRep,
+    BoxedRep Unlifted,
+    TupleRep [IntRep, WordRep],
+    TupleRep []
+  ]
+
+unliftedHeapProgram :: RuntimeRep -> GrinProgram
+unliftedHeapProgram runtimeRep =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinIoCafs = mempty,
+      grinCafs = [(GrinVar "bad" 1 (BoxedRep Lifted), GrinNode (GrinThunk unliftedThunkFunction) [GrinLitValue (GrinLitString "capture")])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = unliftedThunkFunction,
+              grinFunctionParameters = [pointer],
+              grinFunctionResultRep = runtimeRep,
+              grinFunctionBody =
+                GrinBind
+                  [updated]
+                  (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt runtimeRep 0)))
+                  ( GrinReturn
+                      [ GrinLitValue (GrinLitInt componentRep 0)
+                      | componentRep <- runtimeRepComponents runtimeRep
+                      ]
+                  )
+            }
+        ]
+    }
+  where
+    pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
+    updated = GrinVar "updated" 3 runtimeRep
+
+unliftedThunkFunction :: FunctionName
+unliftedThunkFunction = FunctionName "unlifted_thunk"
 
 intTy :: TcType
 intTy = TcTyCon (TyCon "Int#" 0) []
@@ -253,19 +387,21 @@ boxedIntTy = TcTyCon (TyCon "Int" 0) []
 foreignProgram :: FcProgram
 foreignProgram =
   FcProgram
-    [ FcForeignImport foreignCall,
+    [ FcData "BoxedInt32" [] [("BoxedInt32", [int32Ty])],
+      FcForeignImport foreignCall,
       FcTopBind
         ( FcNonRec
             foreignAnswerVar
-            (FcCallForeign foreignCall [FcLit (LitInt Int32Rep 42)])
+            (FcApp (FcVar foreignBoxConstructorVar) (FcCallForeign foreignCall [FcLit (LitInt Int32Rep 42)]))
         )
     ]
 
 undersaturatedForeignProgram :: FcProgram
 undersaturatedForeignProgram =
   FcProgram
-    [ FcForeignImport foreignCall,
-      FcTopBind (FcNonRec foreignAnswerVar (FcCallForeign foreignCall []))
+    [ FcData "BoxedInt32" [] [("BoxedInt32", [int32Ty])],
+      FcForeignImport foreignCall,
+      FcTopBind (FcNonRec foreignAnswerVar (FcApp (FcVar foreignBoxConstructorVar) (FcCallForeign foreignCall [])))
     ]
 
 foreignCall :: FcForeignCall
@@ -282,7 +418,13 @@ foreignCall =
     }
 
 foreignAnswerVar :: Var
-foreignAnswerVar = Var "answer" (Unique 50) (TcTyCon (TyCon "Int32#" 0) [])
+foreignAnswerVar = Var "answer" (Unique 50) boxedIntTy
+
+foreignBoxConstructorVar :: Var
+foreignBoxConstructorVar = Var "BoxedInt32" (Unique 51) (TcFunTy int32Ty boxedIntTy)
+
+int32Ty :: TcType
+int32Ty = TcTyCon (TyCon "Int32#" 0) []
 
 separatePrograms :: [FcProgram]
 separatePrograms =
@@ -297,7 +439,7 @@ separatePrograms =
 separateNewtypePrograms :: [FcProgram]
 separateNewtypePrograms =
   [ FcProgram [FcNewtype declaration],
-    FcProgram [FcTopBind (FcNonRec answerVar (FcApp (FcVar constructorVar) (FcLit (LitInt IntRep 42))))]
+    FcProgram [FcTopBind (FcNonRec answerVar (FcLam argumentVar (FcApp (FcVar constructorVar) (FcLit (LitInt IntRep 42)))))]
   ]
   where
     declaration =
@@ -310,4 +452,5 @@ separateNewtypePrograms =
         }
     wrapperTy = TcTyCon (TyCon "Wrapper" 0) []
     constructorVar = Var "Wrap" (Unique 40) (TcFunTy intTy wrapperTy)
-    answerVar = Var "answer" (Unique 41) wrapperTy
+    answerVar = Var "answer" (Unique 41) (TcFunTy boxedIntTy wrapperTy)
+    argumentVar = Var "argument" (Unique 42) boxedIntTy

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -230,9 +230,9 @@ heapProgram =
               grinFunctionParameters = [],
               grinFunctionResultRep = IntRep,
               grinFunctionBody =
-                GrinBind pointer (GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])) $
-                  GrinBind fetched (GrinFetch (BoxedRep Lifted) (GrinVarValue pointer)) $
-                    GrinBind updated (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt IntRep 2))) $
+                GrinBind [pointer] (GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])) $
+                  GrinBind [fetched] (GrinFetch (BoxedRep Lifted) (GrinVarValue pointer)) $
+                    GrinBind [updated] (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt IntRep 2))) $
                       GrinEval IntRep (GrinVarValue pointer)
             }
         ]

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -5,18 +5,14 @@ expected: |-
 
   $grin_thunk_0 -> BoxedRep Lifted =
     $grin_argument_1006%1006 :: IntRep <-
-      $grin_scrutinee_1007%1007 :: TupleRep [IntRep,WordRep] <-
-        $grin_function_1008%1008 :: BoxedRep Lifted <-
-          apply @BoxedRep Lifted (#,#)%-22 :: BoxedRep Lifted 1
-        apply @TupleRep [IntRep,WordRep] $grin_function_1008%1008 :: BoxedRep Lifted 2
-      case $grin_scrutinee_1007%1007 :: TupleRep [IntRep,WordRep] as _case%1002 :: TupleRep [IntRep,WordRep] of
-        (#,#) first%1003 :: IntRep _%1004 :: WordRep ->
-          return first%1003 :: IntRep
+      $grin_tuple_1007%1007 :: IntRep, $grin_tuple_1008%1008 :: WordRep <-
+        return 1 2
+      return $grin_tuple_1007%1007 :: IntRep
     apply @BoxedRep Lifted Box%1001 :: BoxedRep Lifted $grin_argument_1006%1006 :: IntRep
 extensions:
 - MagicHash
 - UnboxedTuples
-reason: preserves the aggregate TupleRep and its heterogeneous component representations
+reason: returns heterogeneous unboxed-tuple components directly without allocating or matching a node
 source: |
   module Test where
   data Box = Box Int#

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -1,0 +1,27 @@
+expected: |-
+  constructor Box/1 [IntRep]
+
+  primitive realWorld#%1000 :: BoxedRep Lifted/0
+
+  caf value%1007 :: BoxedRep Lifted = (F$grin_thunk_0)
+
+  $grin_thunk_0 -> BoxedRep Lifted =
+    $grin_argument_1008%1008 :: IntRep <-
+      $grin_tuple_1009%1009 :: IntRep <-
+        return 42
+      return $grin_tuple_1009%1009 :: IntRep
+    apply @BoxedRep Lifted Box%1002 :: BoxedRep Lifted $grin_argument_1008%1008 :: IntRep
+extensions:
+- EmptyDataDecls
+- MagicHash
+- UnboxedTuples
+reason: omits zero-width State# components from unboxed-tuple returns and binds
+source: |
+  module Test where
+  data State# s
+  data RealWorld
+  data Box = Box Int#
+  foreign import prim realWorld# :: State# RealWorld
+  value :: Box
+  value = Box (case (# realWorld#, 42# #) of (# _, answer #) -> answer)
+status: pass


### PR DESCRIPTION
## Summary

- lower unboxed tuples to direct zero-or-more GRIN values instead of allocating `(#,#)` nodes
- erase zero-width runtime components such as `State# RealWorld` from calls, returns, constructor layouts, and native code
- enforce that suspended computations return exactly `BoxedRep Lifted`; all unlifted computations remain strict
- extend the ARM64 continuation ABI to carry multiple return slots while rejecting multi-value thunk updates
- add GRIN structural/interpreter and ARM64 native regression coverage

## Root cause

GRIN represented every expression result and bind as exactly one value. That forced unboxed tuple construction through the ordinary heap-node path and kept zero-width tuple fields alive as runtime operands. Thunk validity was also inferred from calling conventions rather than checked from the target function's result representation, so a one-slot unlifted result such as `Int#` was not distinguished from a lifted pointer.

The new representation flattens `TupleRep` recursively at the FC-to-GRIN boundary. Ordinary lifted values remain single pointer values; unboxed tuples become multiple direct values; `TupleRep []` becomes no value at all. Thunk construction now accepts only `BoxedRep Lifted`, GRIN lint independently rejects unlifted thunk targets and heap updates, and the reference interpreter enforces the same invariant if lint is bypassed.

## Impact

A function returning `(# A, B #)` now returns two machine values directly. A function of shape `State# RealWorld -> (# State# RealWorld, Int# #)` has no runtime state argument and returns only the `Int#`. Computations returning `Int#`, `Word#`, unlifted boxed values, unboxed tuples, or zero-width values cannot be suspended or installed as thunk updates.

## Progress

- GRIN golden coverage: +1 zero-width fixture and updated direct multi-value tuple fixture
- `aihc-grin:spec`: 93 passing tests, including representation-wide thunk/update invariant checks
- `aihc-arm64:spec`: 9 passing tests, including native multi-value return coverage
- README progress counts unchanged; they are maintained by the scheduled workflow

## Validation

- `just fmt`
- `just check`
- regenerated and executed the hello-world native example; generated GRIN contains no `(#,#)` node
