### PR TITLE
feat(cps): formalize Loom continuation IR

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -26,6 +26,7 @@ library
     aeson >=2.0 && <2.3,
     aihc-arm64,
     aihc-cpp,
+    aihc-cps,
     aihc-fc,
     aihc-grin,
     aihc-hackage,

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -6,6 +6,7 @@ module Aihc.Cli.Compile
   ( CompileEnvironment (..),
     CompileError (..),
     compileOutputPath,
+    compileSourceToCpsWithDependencies,
     compileSourceToCoreWithDependencies,
     compileSourceToAssembly,
     compileSourceToAssemblyWithDependencies,
@@ -24,6 +25,7 @@ import Aihc.Cli.Compile.Dependencies
     buildDependencies,
   )
 import Aihc.Cli.Options (CompileOptions (..))
+import Aihc.Cps qualified as Cps
 import Aihc.Fc
   ( DesugarResult (..),
     FcAlt (..),
@@ -59,6 +61,7 @@ data CompileError
   = CompileParseError !String
   | CompileFrontendError ![String]
   | CompileDependencyError !String
+  | CompileCpsError ![Cps.LoomLintError]
   | CompileArm64Error !Arm64Error
   | CompileClangError !ExitCode !String
   deriving (Eq, Show)
@@ -66,6 +69,7 @@ data CompileError
 data CompileArtifacts = CompileArtifacts
   { compiledCore :: !Text,
     compiledGrin :: !Text,
+    compiledCpsIr :: !Text,
     compiledAssembly :: !Text,
     compiledArchives :: ![FilePath]
   }
@@ -98,6 +102,8 @@ writeIntermediateArtifacts output options artifacts = do
     TIO.writeFile (output <> ".core") (compiledCore artifacts)
   when (compileKeepGrin options) $
     TIO.writeFile (output <> ".grin") (compiledGrin artifacts)
+  when (compileKeepCpsIr options) $
+    TIO.writeFile (output <> ".cps") (compiledCpsIr artifacts)
 
 -- | The project-local core libraries and shared compiled-library cache used by
 -- the command-line compiler.
@@ -134,6 +140,12 @@ compileSourceToAssemblyWithDependencies environment sourceName source =
 compileSourceToCoreWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToCoreWithDependencies environment sourceName source =
   fmap (fmap compiledCore) (compileSourceToArtifactsWithDependencies False environment sourceName source)
+
+-- | Compile source and its dependencies to the explicit continuation-passing
+-- program rendered by @--keep-cps-ir@.
+compileSourceToCpsWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
+compileSourceToCpsWithDependencies environment sourceName source =
+  fmap (fmap compiledCpsIr) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
 compileSourceToArtifactsWithDependencies :: Bool -> CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
 compileSourceToArtifactsWithDependencies wholeProgram environment sourceName source =
@@ -182,7 +194,9 @@ compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
       layout = extendLinkLayout dependencyLayout mainGrin
       linkedCore = Fc.lowerNewtypes combinedCore
       combinedGrin = Grin.lowerProgram linkedCore
+      cps = Cps.lowerProgram combinedGrin
   either (Left . CompileArm64Error) Right (validateProgramPrimitives combinedGrin)
+  validateCps cps
   assembly <-
     either
       (Left . CompileArm64Error)
@@ -192,6 +206,7 @@ compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
     CompileArtifacts
       { compiledCore = renderCore linkedCore,
         compiledGrin = renderGrin combinedGrin,
+        compiledCpsIr = renderCps cps,
         compiledAssembly = assembly,
         compiledArchives = dependencyArchivePaths dependencies
       }
@@ -200,11 +215,14 @@ compileProgramArtifacts :: FcProgram -> Either CompileError CompileArtifacts
 compileProgramArtifacts sourceCore = do
   let core = Fc.lowerNewtypes sourceCore
   let grin = Grin.lowerProgram core
+  let cps = Cps.lowerProgram grin
+  validateCps cps
   assembly <- either (Left . CompileArm64Error) Right (compileProgram "main" grin)
   pure
     CompileArtifacts
       { compiledCore = renderCore core,
         compiledGrin = renderGrin grin,
+        compiledCpsIr = renderCps cps,
         compiledAssembly = assembly,
         compiledArchives = []
       }
@@ -214,6 +232,15 @@ renderCore = withFinalNewline . Fc.renderProgram
 
 renderGrin :: Grin.GrinProgram -> Text
 renderGrin = withFinalNewline . Grin.renderProgram
+
+renderCps :: Cps.LoomProgram -> Text
+renderCps = withFinalNewline . Cps.renderProgram
+
+validateCps :: Cps.LoomProgram -> Either CompileError ()
+validateCps program =
+  case Cps.lintProgram program of
+    [] -> Right ()
+    errors -> Left (CompileCpsError errors)
 
 withFinalNewline :: String -> Text
 withFinalNewline rendered = T.pack rendered <> "\n"
@@ -331,6 +358,7 @@ renderCompileError compileError =
     CompileParseError err -> "parse error: " <> err
     CompileFrontendError errors -> "frontend error: " <> unwords errors
     CompileDependencyError err -> "dependency error: " <> err
+    CompileCpsError errors -> "Loom IR error: " <> show errors
     CompileArm64Error err -> "ARM64 code generation error: " <> show err
     CompileClangError exitCode err -> "clang failed (" <> show exitCode <> "): " <> err
 

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -23,6 +23,7 @@ data CompileOptions = CompileOptions
     compileOutputFile :: !(Maybe FilePath),
     compileKeepCore :: !Bool,
     compileKeepGrin :: !Bool,
+    compileKeepCpsIr :: !Bool,
     compileKeepAsm :: !Bool,
     compileWholeProgram :: !Bool
   }
@@ -114,6 +115,10 @@ compileOptionsParser =
     <*> OA.switch
       ( OA.long "keep-grin"
           <> OA.help "Keep the generated GRIN as OUTPUT.grin"
+      )
+    <*> OA.switch
+      ( OA.long "keep-cps-ir"
+          <> OA.help "Keep the generated Loom CPS IR as OUTPUT.cps"
       )
     <*> OA.switch
       ( OA.long "keep-asm"

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -8,6 +8,7 @@ import Aihc.Cli.Compile
     compileOutputPath,
     compileSourceToAssemblyWithDependencies,
     compileSourceToCoreWithDependencies,
+    compileSourceToCpsWithDependencies,
     defaultCompileEnvironment,
     runCompileWithEnvironment,
   )
@@ -77,31 +78,36 @@ main =
         [ testCase "parses compile source" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False False)))
               (parseCommandPure ["compile", "Main.hs"]),
           testCase "parses compile output and keep-asm" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False True False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False False True False)))
               (parseCommandPure ["compile", "Main.hs", "-o", "hello", "--keep-asm"]),
           testCase "parses keep-core" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False False False)))
               (parseCommandPure ["compile", "Main.hs", "--keep-core"]),
           testCase "parses keep-grin" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False False False)))
               (parseCommandPure ["compile", "Main.hs", "--keep-grin"]),
+          testCase "parses keep-cps-ir" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False True False False)))
+              (parseCommandPure ["compile", "Main.hs", "--keep-cps-ir"]),
           testCase "parses whole-program compatibility mode" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False True)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False True)))
               (parseCommandPure ["compile", "Main.hs", "--whole-program"]),
           testCase "derives safe default compile output paths" $ do
-            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False False))
-            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False False)),
+            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False False False))
+            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False False False)),
           testCase "parses install package" $
             assertEqual
               "command"
@@ -150,6 +156,7 @@ main =
                   assertBool "dependency initializer call" ("bl _aihc_init_" `T.isInfixOf` assembly)
                   assertBool "Haskell tail transfer" ("br x9" `T.isInfixOf` assembly),
           testCase "assembles an executable and honors keep-output flags" test_compileExecutable,
+          testCase "renders explicit Loom continuations" test_compileCps,
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
           testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
@@ -863,18 +870,22 @@ test_compileExecutable =
           keptOutput = root </> "kept"
           temporaryOutput = root </> "temporary"
           environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-          keptOptions = CompileOptions sourcePath (Just keptOutput) True True True False
-          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False False False True
+          keptOptions = CompileOptions sourcePath (Just keptOutput) True True True True False
+          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False False False False True
       withCurrentDirectory repositoryRoot $ do
         runCompileWithEnvironment environment keptOptions
         assertFileExists keptOutput
         assertFileExists (keptOutput <> ".core")
         assertFileExists (keptOutput <> ".grin")
+        assertFileExists (keptOutput <> ".cps")
         assertFileExists (keptOutput <> ".s")
         core <- TIO.readFile (keptOutput <> ".core")
         grin <- TIO.readFile (keptOutput <> ".grin")
+        cps <- TIO.readFile (keptOutput <> ".cps")
         assertBool "core contains main" ("main" `T.isInfixOf` core)
         assertBool "GRIN contains main" ("main" `T.isInfixOf` grin)
+        assertBool "CPS artifact is Loom IR" ("loom-ir 1" `T.isInfixOf` cps)
+        assertBool "CPS artifact contains explicit return continuations" (" return return%0 :: cont[" `T.isInfixOf` cps)
         assertBool "GRIN erases the IO constructor" (not ("constructor IO/" `T.isInfixOf` grin))
         assertBool "GRIN erases the CInt constructor" (not ("constructor CInt/" `T.isInfixOf` grin))
         assertNativeOutput keptOutput
@@ -883,8 +894,21 @@ test_compileExecutable =
         assertFileExists temporaryOutput
         assertFileDoesNotExist (temporaryOutput <> ".core")
         assertFileDoesNotExist (temporaryOutput <> ".grin")
+        assertFileDoesNotExist (temporaryOutput <> ".cps")
         assertFileDoesNotExist (temporaryOutput <> ".s")
         assertNativeOutput temporaryOutput
+
+test_compileCps :: Assertion
+test_compileCps =
+  withTempDir "aihc-compile-cps" $ \root -> do
+    let environment = CompileEnvironment (root </> "missing-core-libs") (root </> "cache")
+    result <- compileSourceToCpsWithDependencies environment "Main.hs" noImplicitDependencySource
+    case result of
+      Left err -> assertFailure ("expected CPS lowering to succeed, got: " <> show err)
+      Right cps -> do
+        assertBool "versioned Loom header" ("loom-ir 1" `T.isInfixOf` cps)
+        assertBool "explicit function return continuation" (" return return%0 :: cont[" `T.isInfixOf` cps)
+        assertBool "explicit operation transfer" (" -> k%" `T.isInfixOf` cps)
 
 test_compileDefaultEnvironment :: Assertion
 test_compileDefaultEnvironment =

--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
   components/aihc-tc
   components/aihc-fc
   components/aihc-grin
+  components/aihc-cps
   components/aihc-arm64
   bin/aihc-fmt
   tooling/aihc-hackage

--- a/components/aihc-cps/LICENSE
+++ b/components/aihc-cps/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/components/aihc-cps/aihc-cps.cabal
+++ b/components/aihc-cps/aihc-cps.cabal
@@ -1,0 +1,47 @@
+cabal-version: 3.8
+name: aihc-cps
+version: 0.1.0.0
+build-type: Simple
+license: Unlicense
+license-file: LICENSE
+author: David Himmelstrup
+maintainer: lemmih@gmail.com
+category: Development
+synopsis: Loom continuation-passing intermediate representation for AIHC
+
+library
+  exposed-modules:
+    Aihc.Cps
+    Aihc.Cps.Lint
+    Aihc.Cps.Lower
+    Aihc.Cps.Pretty
+    Aihc.Cps.Syntax
+
+  hs-source-dirs: src
+  build-depends:
+    aihc-grin,
+    aihc-tc,
+    base >=4.16 && <5,
+    containers,
+    text >=1.2,
+    transformers,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
+  build-depends:
+    aihc-cps,
+    aihc-grin,
+    aihc-tc,
+    base >=4.16 && <5,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+
+  ghc-options: -Wall
+  default-language: GHC2021

--- a/components/aihc-cps/src/Aihc/Cps.hs
+++ b/components/aihc-cps/src/Aihc/Cps.hs
@@ -1,0 +1,14 @@
+-- | Loom, AIHC's explicit continuation-passing intermediate representation.
+module Aihc.Cps
+  ( module Aihc.Cps.Syntax,
+    LoomLintError (..),
+    lintProgram,
+    lowerProgram,
+    renderProgram,
+  )
+where
+
+import Aihc.Cps.Lint (LoomLintError (..), lintProgram)
+import Aihc.Cps.Lower (lowerProgram)
+import Aihc.Cps.Pretty (renderProgram)
+import Aihc.Cps.Syntax

--- a/components/aihc-cps/src/Aihc/Cps/Lint.hs
+++ b/components/aihc-cps/src/Aihc/Cps/Lint.hs
@@ -1,0 +1,80 @@
+-- | Structural and calling-convention validation for Loom programs.
+module Aihc.Cps.Lint
+  ( LoomLintError (..),
+    lintProgram,
+  )
+where
+
+import Aihc.Cps.Syntax
+import Aihc.Grin.Syntax (grinValueRuntimeRep, grinVarRuntimeRep)
+import Aihc.Tc.Types (RuntimeRep)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+
+data LoomLintError
+  = LoomLintDuplicateContinuation !LoomContVar
+  | LoomLintUnboundContinuation !LoomContVar
+  | LoomLintContinuationSignature !LoomContVar ![RuntimeRep] ![RuntimeRep]
+  | LoomLintContinuationParameters !LoomContVar ![RuntimeRep] ![RuntimeRep]
+  | LoomLintContinuationArguments !LoomContVar ![RuntimeRep] ![RuntimeRep]
+  | LoomLintOperationContinuation !LoomContVar ![RuntimeRep] ![RuntimeRep]
+  deriving (Eq, Show)
+
+type ContEnv = Map LoomContVar [RuntimeRep]
+
+lintProgram :: LoomProgram -> [LoomLintError]
+lintProgram = concatMap lintFunction . loomFunctions
+
+lintFunction :: LoomFunction -> [LoomLintError]
+lintFunction function =
+  lintTerm
+    (Map.singleton returnContinuation (loomContRuntimeReps returnContinuation))
+    (loomFunctionBody function)
+  where
+    returnContinuation = loomFunctionReturn function
+
+lintTerm :: ContEnv -> LoomTerm -> [LoomLintError]
+lintTerm env term =
+  case term of
+    LoomLetCont continuation body ->
+      declarationErrors
+        <> lintTerm env (loomContinuationBody continuation)
+        <> lintTerm extendedEnv body
+      where
+        continuationName = loomContinuationName continuation
+        parameterReps = map grinVarRuntimeRep (loomContinuationParameters continuation)
+        signature = loomContRuntimeReps continuationName
+        declarationErrors =
+          [LoomLintDuplicateContinuation continuationName | Map.member continuationName env]
+            <> [ LoomLintContinuationParameters continuationName signature parameterReps
+               | signature /= parameterReps
+               ]
+        extendedEnv = Map.insert continuationName signature env
+    LoomInvoke operation continuation ->
+      lintContinuation env continuation
+        <> case loomOperationResultReps operation of
+          Just resultReps
+            | resultReps /= loomContRuntimeReps continuation ->
+                [LoomLintOperationContinuation continuation (loomContRuntimeReps continuation) resultReps]
+          _ -> []
+    LoomContinue continuation arguments ->
+      lintContinuation env continuation
+        <> [ LoomLintContinuationArguments continuation expected actual
+           | expected /= actual
+           ]
+      where
+        expected = loomContRuntimeReps continuation
+        actual = map grinValueRuntimeRep arguments
+    LoomCase _ _ alternatives -> concatMap (lintTerm env . loomAltBody) alternatives
+    LoomStoreRec _ body -> lintTerm env body
+
+lintContinuation :: ContEnv -> LoomContVar -> [LoomLintError]
+lintContinuation env continuation =
+  case Map.lookup continuation env of
+    Nothing -> [LoomLintUnboundContinuation continuation]
+    Just declaredSignature
+      | declaredSignature /= actualSignature ->
+          [LoomLintContinuationSignature continuation declaredSignature actualSignature]
+      | otherwise -> []
+  where
+    actualSignature = loomContRuntimeReps continuation

--- a/components/aihc-cps/src/Aihc/Cps/Lower.hs
+++ b/components/aihc-cps/src/Aihc/Cps/Lower.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Convert strict GRIN sequencing into explicit Loom continuations.
+module Aihc.Cps.Lower
+  ( lowerProgram,
+  )
+where
+
+import Aihc.Cps.Syntax
+import Aihc.Grin.Syntax
+import Control.Monad.Trans.State.Strict (State, evalState, get, put)
+
+lowerProgram :: GrinProgram -> LoomProgram
+lowerProgram program =
+  LoomProgram
+    { loomConstructors = grinConstructors program,
+      loomPrimitives = grinPrimitives program,
+      loomForeignCalls = grinForeignCalls program,
+      loomWhnfGlobals = grinWhnfGlobals program,
+      loomCafs = grinCafs program,
+      loomFunctions = map lowerFunction (grinFunctions program)
+    }
+
+lowerFunction :: GrinFunction -> LoomFunction
+lowerFunction function =
+  LoomFunction
+    { loomFunctionName = grinFunctionName function,
+      loomFunctionParameters = grinFunctionParameters function,
+      loomFunctionReturn = returnContinuation,
+      loomFunctionBody = evalState (lowerExpr returnContinuation (grinFunctionBody function)) 1
+    }
+  where
+    returnContinuation = LoomContVar "return" 0 (runtimeRepComponents (grinFunctionResultRep function))
+
+lowerExpr :: LoomContVar -> GrinExpr -> State Int LoomTerm
+lowerExpr successor expression =
+  case expression of
+    GrinReturn values -> pure (LoomContinue successor values)
+    GrinBind parameters valueExpression body -> do
+      continuationName <- freshContinuation parameters
+      continuationBody <- lowerExpr successor body
+      valueTerm <- lowerExpr continuationName valueExpression
+      pure
+        ( LoomLetCont
+            LoomContinuation
+              { loomContinuationName = continuationName,
+                loomContinuationParameters = parameters,
+                loomContinuationBody = continuationBody
+              }
+            valueTerm
+        )
+    GrinStore node -> pure (LoomInvoke (LoomStore node) successor)
+    GrinStoreRec bindings body -> LoomStoreRec bindings <$> lowerExpr successor body
+    GrinFetch runtimeRep pointer -> pure (LoomInvoke (LoomFetch runtimeRep pointer) successor)
+    GrinUpdate pointer value -> pure (LoomInvoke (LoomUpdate pointer value) successor)
+    GrinEval runtimeRep value -> pure (LoomInvoke (LoomEval runtimeRep value) successor)
+    GrinApply runtimeRep function arguments -> pure (LoomInvoke (LoomApply runtimeRep function arguments) successor)
+    GrinCase scrutinee binder alternatives ->
+      LoomCase scrutinee binder <$> mapM (lowerAlt successor) alternatives
+    GrinDictSelect runtimeRep dictionary index -> pure (LoomInvoke (LoomDictSelect runtimeRep dictionary index) successor)
+    GrinThrow exception -> pure (LoomInvoke (LoomThrow exception) successor)
+    GrinCatch runtimeRep action handler state -> pure (LoomInvoke (LoomCatch runtimeRep action handler state) successor)
+    GrinForeignCallExpr foreignCall arguments -> pure (LoomInvoke (LoomForeignCall foreignCall arguments) successor)
+
+lowerAlt :: LoomContVar -> GrinAlt -> State Int LoomAlt
+lowerAlt successor alternative =
+  LoomAlt
+    (grinAltCon alternative)
+    (grinAltBinders alternative)
+    <$> lowerExpr successor (grinAltRhs alternative)
+
+freshContinuation :: [GrinVar] -> State Int LoomContVar
+freshContinuation parameters = do
+  unique <- get
+  put (unique + 1)
+  pure (LoomContVar "k" unique (map grinVarRuntimeRep parameters))

--- a/components/aihc-cps/src/Aihc/Cps/Pretty.hs
+++ b/components/aihc-cps/src/Aihc/Cps/Pretty.hs
@@ -1,0 +1,196 @@
+-- | Stable, human-readable rendering of Loom IR.
+module Aihc.Cps.Pretty
+  ( renderProgram,
+  )
+where
+
+import Aihc.Cps.Syntax
+import Aihc.Grin.Syntax
+import Aihc.Tc.Types (RuntimeRep)
+import Data.List (intercalate)
+import Data.Text qualified as T
+
+renderProgram :: LoomProgram -> String
+renderProgram program =
+  intercalate
+    "\n\n"
+    ( ["loom-ir 1"]
+        <> map renderConstructor (loomConstructors program)
+        <> map renderPrimitive (loomPrimitives program)
+        <> map renderForeign (loomForeignCalls program)
+        <> map renderGlobal (loomWhnfGlobals program)
+        <> map renderCaf (loomCafs program)
+        <> map renderFunction (loomFunctions program)
+    )
+
+renderConstructor :: (T.Text, [RuntimeRep]) -> String
+renderConstructor (name, fieldReps) =
+  "constructor "
+    <> T.unpack name
+    <> "/"
+    <> show (length fieldReps)
+    <> " ["
+    <> intercalate ", " (map show fieldReps)
+    <> "]"
+
+renderPrimitive :: (GrinVar, Int) -> String
+renderPrimitive (var, arity) =
+  "primitive " <> renderVar var <> "/" <> show arity
+
+renderForeign :: GrinForeignCall -> String
+renderForeign foreignCall =
+  "foreign \""
+    <> T.unpack (grinForeignCallSymbol foreignCall)
+    <> "\" "
+    <> T.unpack (grinForeignCallName foreignCall)
+
+renderGlobal :: (GrinVar, GrinNode) -> String
+renderGlobal (var, node) =
+  "global " <> renderVar var <> " = " <> renderNode node
+
+renderCaf :: (GrinVar, GrinNode) -> String
+renderCaf (var, node) =
+  "caf " <> renderVar var <> " = " <> renderNode node
+
+renderFunction :: LoomFunction -> String
+renderFunction function =
+  "code "
+    <> T.unpack (unFunctionName (loomFunctionName function))
+    <> concatMap ((" " <>) . renderVar) (loomFunctionParameters function)
+    <> " return "
+    <> renderContVar (loomFunctionReturn function)
+    <> " =\n"
+    <> renderTerm 2 (loomFunctionBody function)
+
+renderTerm :: Int -> LoomTerm -> String
+renderTerm indentation term =
+  case term of
+    LoomLetCont continuation body ->
+      indent indentation
+        <> "letcont "
+        <> renderContVar (loomContinuationName continuation)
+        <> concatMap ((" " <>) . renderVar) (loomContinuationParameters continuation)
+        <> " =\n"
+        <> renderTerm (indentation + 2) (loomContinuationBody continuation)
+        <> "\n"
+        <> indent indentation
+        <> "in\n"
+        <> renderTerm (indentation + 2) body
+    LoomInvoke operation continuation ->
+      indent indentation <> renderOperation operation <> " -> " <> renderContVar continuation
+    LoomContinue continuation values ->
+      indent indentation
+        <> "continue "
+        <> renderContVar continuation
+        <> concatMap ((" " <>) . renderValue) values
+    LoomCase scrutinee binder alternatives ->
+      indent indentation
+        <> "case "
+        <> renderValue scrutinee
+        <> " as "
+        <> renderVar binder
+        <> " of\n"
+        <> intercalate "\n" (map (renderAlt (indentation + 2)) alternatives)
+    LoomStoreRec bindings body ->
+      indent indentation
+        <> "store-rec\n"
+        <> intercalate
+          "\n"
+          [indent (indentation + 2) <> renderVar var <> " = " <> renderNode node | (var, node) <- bindings]
+        <> "\n"
+        <> indent indentation
+        <> "in\n"
+        <> renderTerm (indentation + 2) body
+
+renderOperation :: LoomOperation -> String
+renderOperation operation =
+  case operation of
+    LoomStore node -> "store " <> renderNode node
+    LoomFetch runtimeRep pointer -> "fetch @" <> show runtimeRep <> " " <> renderValue pointer
+    LoomUpdate pointer value -> "update " <> renderValue pointer <> " " <> renderValue value
+    LoomEval runtimeRep value -> "eval @" <> show runtimeRep <> " " <> renderValue value
+    LoomApply runtimeRep function arguments ->
+      "apply @"
+        <> show runtimeRep
+        <> " "
+        <> renderValue function
+        <> concatMap ((" " <>) . renderValue) arguments
+    LoomDictSelect runtimeRep dictionary index ->
+      "select @" <> show runtimeRep <> " " <> renderValue dictionary <> " " <> show index
+    LoomThrow exception -> "throw " <> renderValue exception
+    LoomCatch runtimeRep action handler state ->
+      "catch @"
+        <> show runtimeRep
+        <> " "
+        <> unwords (map renderValue [action, handler])
+        <> concatMap ((" " <>) . renderValue) state
+    LoomForeignCall foreignCall arguments ->
+      "foreign-call "
+        <> T.unpack (grinForeignCallName foreignCall)
+        <> concatMap ((" " <>) . renderValue) arguments
+
+renderAlt :: Int -> LoomAlt -> String
+renderAlt indentation alternative =
+  indent indentation
+    <> renderAltCon (loomAltCon alternative)
+    <> concatMap ((" " <>) . renderVar) (loomAltBinders alternative)
+    <> " ->\n"
+    <> renderTerm (indentation + 2) (loomAltBody alternative)
+
+renderAltCon :: GrinAltCon -> String
+renderAltCon alternative =
+  case alternative of
+    GrinDataAlt name -> T.unpack name
+    GrinLitAlt literal -> renderLiteral literal
+    GrinDefaultAlt -> "_"
+
+renderValue :: GrinValue -> String
+renderValue value =
+  case value of
+    GrinVarValue var -> renderVar var
+    GrinLitValue literal -> renderLiteral literal
+    GrinNodeValue node -> renderNode node
+
+renderNode :: GrinNode -> String
+renderNode node =
+  "("
+    <> renderNodeTag (grinNodeTag node)
+    <> concatMap ((" " <>) . renderValue) (grinNodeFields node)
+    <> ")"
+
+renderNodeTag :: GrinNodeTag -> String
+renderNodeTag nodeTag =
+  case nodeTag of
+    GrinConstructor name -> "C" <> T.unpack name
+    GrinClosure functionName argumentCount ->
+      "P" <> T.unpack (unFunctionName functionName) <> "/" <> show argumentCount
+    GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
+    GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
+    GrinDictionary -> "Dict"
+
+renderLiteral :: GrinLiteral -> String
+renderLiteral literal =
+  case literal of
+    GrinLitInt _ value -> show value
+    GrinLitChar _ value -> show value
+    GrinLitString value -> show (T.unpack value)
+
+renderVar :: GrinVar -> String
+renderVar var =
+  T.unpack (grinVarName var)
+    <> "%"
+    <> show (grinVarUnique var)
+    <> " :: "
+    <> show (grinVarRuntimeRep var)
+
+renderContVar :: LoomContVar -> String
+renderContVar continuation =
+  T.unpack (loomContName continuation)
+    <> "%"
+    <> show (loomContUnique continuation)
+    <> " :: cont["
+    <> intercalate ", " (map show (loomContRuntimeReps continuation))
+    <> "]"
+
+indent :: Int -> String
+indent count = replicate count ' '

--- a/components/aihc-cps/src/Aihc/Cps/Syntax.hs
+++ b/components/aihc-cps/src/Aihc/Cps/Syntax.hs
@@ -1,0 +1,129 @@
+-- | The formal syntax of AIHC's continuation-passing IR, Loom.
+--
+-- Loom sits immediately after GRIN. Its terms obey this grammar:
+--
+-- @
+-- term ::= letcont continuation in term
+--        | invoke operation -> continuation
+--        | continue continuation values
+--        | case value as variable of alternatives
+--        | store-rec bindings in term
+-- @
+--
+-- There is deliberately no implicit return or fall-through term. A function
+-- receives its caller's continuation as an explicit parameter, while local
+-- continuations are introduced by 'LoomLetCont'. Every path therefore ends in
+-- either 'LoomContinue' or an operation with an explicit successor.
+module Aihc.Cps.Syntax
+  ( LoomProgram (..),
+    LoomFunction (..),
+    LoomContVar (..),
+    LoomContinuation (..),
+    LoomTerm (..),
+    LoomOperation (..),
+    LoomAlt (..),
+    loomOperationResultReps,
+  )
+where
+
+import Aihc.Grin.Syntax
+import Aihc.Tc.Types (RuntimeRep, liftedRuntimeRep)
+import Data.Text (Text)
+
+-- | A whole Loom program. Heap-layout declarations remain identical to GRIN;
+-- only executable function bodies change representation.
+data LoomProgram = LoomProgram
+  { loomConstructors :: ![(Text, [RuntimeRep])],
+    loomPrimitives :: ![(GrinVar, Int)],
+    loomForeignCalls :: ![GrinForeignCall],
+    loomWhnfGlobals :: ![(GrinVar, GrinNode)],
+    loomCafs :: ![(GrinVar, GrinNode)],
+    loomFunctions :: ![LoomFunction]
+  }
+  deriving (Eq, Show)
+
+-- | First-order code with an explicit return-continuation parameter.
+data LoomFunction = LoomFunction
+  { loomFunctionName :: !FunctionName,
+    loomFunctionParameters :: ![GrinVar],
+    loomFunctionReturn :: !LoomContVar,
+    loomFunctionBody :: !LoomTerm
+  }
+  deriving (Eq, Show)
+
+-- | A continuation variable and the flattened runtime layout of its arguments.
+-- The text and unique form its identity; the layout is its checked signature.
+data LoomContVar = LoomContVar
+  { loomContName :: !Text,
+    loomContUnique :: !Int,
+    loomContRuntimeReps :: ![RuntimeRep]
+  }
+  deriving (Show)
+
+instance Eq LoomContVar where
+  left == right =
+    loomContName left == loomContName right
+      && loomContUnique left == loomContUnique right
+
+instance Ord LoomContVar where
+  compare left right =
+    compare
+      (loomContName left, loomContUnique left)
+      (loomContName right, loomContUnique right)
+
+-- | A lexically scoped continuation. Free data and continuation variables in
+-- its body are captured lexically; a later closure-conversion pass may make
+-- those captures explicit.
+data LoomContinuation = LoomContinuation
+  { loomContinuationName :: !LoomContVar,
+    loomContinuationParameters :: ![GrinVar],
+    loomContinuationBody :: !LoomTerm
+  }
+  deriving (Eq, Show)
+
+-- | CPS control terms. Constructors that contain another term bind lexical
+-- structure; the other constructors transfer control and cannot fall through.
+data LoomTerm
+  = LoomLetCont !LoomContinuation !LoomTerm
+  | LoomInvoke !LoomOperation !LoomContVar
+  | LoomContinue !LoomContVar ![GrinValue]
+  | LoomCase !GrinValue !GrinVar ![LoomAlt]
+  | LoomStoreRec ![(GrinVar, GrinNode)] !LoomTerm
+  deriving (Eq, Show)
+
+-- | A primitive operation with no implicit successor. Its result is delivered
+-- to the continuation named by the surrounding 'LoomInvoke'.
+data LoomOperation
+  = LoomStore !GrinNode
+  | LoomFetch !RuntimeRep !GrinValue
+  | LoomUpdate !GrinValue !GrinValue
+  | LoomEval !RuntimeRep !GrinValue
+  | LoomApply !RuntimeRep !GrinValue ![GrinValue]
+  | LoomDictSelect !RuntimeRep !GrinValue !Int
+  | LoomThrow !GrinValue
+  | LoomCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
+  | LoomForeignCall !GrinForeignCall ![GrinValue]
+  deriving (Eq, Show)
+
+data LoomAlt = LoomAlt
+  { loomAltCon :: !GrinAltCon,
+    loomAltBinders :: ![GrinVar],
+    loomAltBody :: !LoomTerm
+  }
+  deriving (Eq, Show)
+
+-- | The register layout delivered by an operation. 'LoomThrow' never returns,
+-- so it is compatible with a successor of any signature.
+loomOperationResultReps :: LoomOperation -> Maybe [RuntimeRep]
+loomOperationResultReps operation =
+  case operation of
+    LoomStore {} -> Just [liftedRuntimeRep]
+    LoomFetch runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
+    LoomUpdate _ value -> Just [grinValueRuntimeRep value]
+    LoomEval runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
+    LoomApply runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
+    LoomDictSelect runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
+    LoomThrow {} -> Nothing
+    LoomCatch runtimeRep _ _ _ -> Just (runtimeRepComponents runtimeRep)
+    LoomForeignCall foreignCall _ ->
+      Just (grinForeignCallResultReps (grinForeignCallSignature foreignCall))

--- a/components/aihc-cps/test/Spec.hs
+++ b/components/aihc-cps/test/Spec.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Aihc.Cps
+import Aihc.Grin.Syntax
+import Aihc.Tc.Types (RuntimeRep (IntRep), liftedRuntimeRep)
+import Data.List (isInfixOf)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+import Test.Tasty.QuickCheck qualified as QC
+
+main :: IO ()
+main = defaultMain (testGroup "aihc-cps" tests)
+
+tests :: [TestTree]
+tests =
+  [ testCase "a GRIN bind becomes a named continuation" testBindLowering,
+    testCase "nested binds retain the enclosing continuation" testNestedBinds,
+    testCase "the linter rejects a continuation argument layout mismatch" testContinuationMismatch,
+    testCase "the renderer identifies Loom IR and explicit transfers" testRendering,
+    QC.testProperty "dummy quickcheck property" prop_dummy
+  ]
+
+-- | Keep the workspace-wide QuickCheck controls accepted by this suite.
+prop_dummy :: Bool -> Bool
+prop_dummy _ = True
+
+testBindLowering :: IO ()
+testBindLowering =
+  case loomFunctions (lowerProgram (singleFunctionProgram body)) of
+    [function] -> do
+      assertEqual "return continuation layout" [IntRep] (loomContRuntimeReps (loomFunctionReturn function))
+      case loomFunctionBody function of
+        LoomLetCont continuation (LoomInvoke (LoomEval IntRep _) target) -> do
+          assertEqual "operation target" (loomContinuationName continuation) target
+          assertEqual "continuation parameters" [result] (loomContinuationParameters continuation)
+          assertEqual
+            "continuation body"
+            (LoomContinue (loomFunctionReturn function) [GrinVarValue result])
+            (loomContinuationBody continuation)
+        actual -> fail ("unexpected lowering: " <> show actual)
+      assertEqual "lowered program lints" [] (lintProgram (lowerProgram (singleFunctionProgram body)))
+    actual -> fail ("expected one function, got: " <> show actual)
+  where
+    input = GrinVar "input" 1 liftedRuntimeRep
+    result = GrinVar "result" 2 IntRep
+    body = GrinBind [result] (GrinEval IntRep (GrinVarValue input)) (GrinReturn [GrinVarValue result])
+
+testNestedBinds :: IO ()
+testNestedBinds =
+  case loomFunctionBody (onlyFunction (lowerProgram (singleFunctionProgram body))) of
+    LoomLetCont outer (LoomInvoke _ outerTarget) -> do
+      assertEqual "first operation targets outer continuation" (loomContinuationName outer) outerTarget
+      case loomContinuationBody outer of
+        LoomLetCont inner (LoomInvoke _ innerTarget) -> do
+          assertEqual "second operation targets inner continuation" (loomContinuationName inner) innerTarget
+          assertEqual
+            "inner continuation returns to the function caller"
+            (LoomContinue returnContinuation [GrinVarValue second])
+            (loomContinuationBody inner)
+        actual -> fail ("expected nested continuation, got: " <> show actual)
+    actual -> fail ("expected outer continuation, got: " <> show actual)
+  where
+    first = GrinVar "first" 2 liftedRuntimeRep
+    second = GrinVar "second" 3 IntRep
+    pointer = GrinVar "pointer" 1 liftedRuntimeRep
+    body =
+      GrinBind
+        [first]
+        (GrinFetch liftedRuntimeRep (GrinVarValue pointer))
+        (GrinBind [second] (GrinEval IntRep (GrinVarValue first)) (GrinReturn [GrinVarValue second]))
+    function = onlyFunction (lowerProgram (singleFunctionProgram body))
+    returnContinuation = loomFunctionReturn function
+
+testContinuationMismatch :: IO ()
+testContinuationMismatch = do
+  let returnContinuation = LoomContVar "return" 0 [IntRep]
+      function =
+        LoomFunction
+          { loomFunctionName = FunctionName "main",
+            loomFunctionParameters = [],
+            loomFunctionReturn = returnContinuation,
+            loomFunctionBody = LoomContinue returnContinuation [GrinNodeValue (GrinNode (GrinConstructor "()") [])]
+          }
+      program = emptyLoomProgram {loomFunctions = [function]}
+  assertEqual
+    "mismatched value representation"
+    [LoomLintContinuationArguments returnContinuation [IntRep] [liftedRuntimeRep]]
+    (lintProgram program)
+
+testRendering :: IO ()
+testRendering = do
+  let rendered = renderProgram (lowerProgram (singleFunctionProgram body))
+  assertBool "versioned Loom header" ("loom-ir 1" `isInfixOf` rendered)
+  assertBool "explicit return continuation" ("return return%0" `isInfixOf` rendered)
+  assertBool "explicit operation transfer" ("eval @IntRep" `isInfixOf` rendered && " -> k%1" `isInfixOf` rendered)
+  where
+    input = GrinVar "input" 1 liftedRuntimeRep
+    result = GrinVar "result" 2 IntRep
+    body = GrinBind [result] (GrinEval IntRep (GrinVarValue input)) (GrinReturn [GrinVarValue result])
+
+singleFunctionProgram :: GrinExpr -> GrinProgram
+singleFunctionProgram body =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinWhnfGlobals = [],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = FunctionName "main",
+              grinFunctionParameters = [GrinVar "input" 1 liftedRuntimeRep],
+              grinFunctionResultRep = IntRep,
+              grinFunctionBody = body
+            }
+        ]
+    }
+
+emptyLoomProgram :: LoomProgram
+emptyLoomProgram =
+  LoomProgram
+    { loomConstructors = [],
+      loomPrimitives = [],
+      loomForeignCalls = [],
+      loomWhnfGlobals = [],
+      loomCafs = [],
+      loomFunctions = []
+    }
+
+onlyFunction :: LoomProgram -> LoomFunction
+onlyFunction program =
+  case loomFunctions program of
+    [function] -> function
+    actual -> error ("expected one function, got: " <> show actual)

--- a/docs/loom-ir.md
+++ b/docs/loom-ir.md
@@ -1,0 +1,110 @@
+# Loom IR
+
+Loom is AIHC's continuation-passing intermediate representation. It is named
+for the way control flow is woven from explicit continuations.
+
+Loom sits after strict GRIN and before backend-specific lowering:
+
+```text
+Haskell -> surface AST -> resolved AST -> typed AST -> System FC -> GRIN -> Loom -> backend IR
+```
+
+The native ARM64 backend still consumes GRIN while Loom is being introduced.
+The compiler nevertheless constructs and validates Loom on every compilation,
+so moving a backend across the boundary will not change the language exposed by
+the preceding stages.
+
+## Syntax
+
+A Loom program contains the same heap-layout declarations, globals, CAFs,
+primitive declarations, and foreign-call descriptors as its source GRIN
+program. Only function bodies change representation.
+
+```text
+function     ::= code f(value-parameters; return-continuation) = term
+
+term         ::= letcont continuation = term in term
+               | invoke operation -> continuation
+               | continue continuation values
+               | case value as variable of alternatives
+               | store-rec bindings in term
+
+continuation ::= k(value-parameters) = term
+alternative  ::= constructor value-parameters -> term
+               | literal -> term
+               | _ -> term
+```
+
+Every continuation carries the flattened `RuntimeRep` layout of the values it
+accepts. Function parameters remain ordinary GRIN register values. The return
+continuation is a distinct continuation parameter, not an ordinary heap value.
+
+`term` has no `return`, fall-through, or sequence constructor. `continue`
+transfers directly to a continuation, and `invoke` transfers the result of an
+operation to a continuation. Consequently every executable path names its next
+control destination.
+
+Local continuations are lexical. Their bodies may capture value variables and
+outer continuation variables. A future continuation-closure-conversion pass
+can make those captures explicit when required by a backend.
+
+## GRIN-to-Loom translation
+
+Write `C[e, k]` for lowering GRIN expression `e` with successor continuation
+`k`.
+
+```text
+C[return xs, k]             = continue k xs
+
+C[xs <- operation; body, k] =
+  letcont k1(xs) = C[body, k]
+  in invoke operation -> k1
+
+C[xs <- nested; body, k]    =
+  letcont k1(xs) = C[body, k]
+  in C[nested, k1]
+
+C[case x of alts, k]        = case x of map (C[alt, k]) alts
+
+C[store-rec bindings; e, k] = store-rec bindings in C[e, k]
+```
+
+Each function result `RuntimeRep` is flattened using the existing GRIN calling
+convention. That layout becomes the signature of the function's explicit
+return continuation. A GRIN bind's variables determine the signature of the
+local continuation introduced for its body.
+
+## Static invariants
+
+The Loom linter enforces:
+
+- every referenced continuation is lexically bound;
+- continuation identities cannot be redeclared in the same scope;
+- a local continuation's parameter layout equals its declared signature;
+- values passed by `continue` match the target continuation's signature; and
+- an operation's result layout matches its successor's signature.
+
+`throw` has no result layout because it never returns, so it may occur with any
+successor signature. This keeps exceptional control explicit without claiming
+that the successor is reachable.
+
+The Haskell data type enforces the remaining control-flow invariant: it is not
+possible to construct a Loom term that implicitly returns or falls through.
+
+## Runtime boundary
+
+Loom does not introduce scheduler requests such as `fork`, `yield`, or `delay`.
+Those facilities can be ordinary Loom code built around captured/resumable
+continuations. A later lowering may give a small set of continuation operations
+target-specific representations after control flow and roots are explicit.
+
+Runtime operations inherited from GRIN (`eval`, `apply`, `catch`, and similar
+operations) remain visible operations at this boundary. They are intentionally
+not part of Loom's control structure and can be replaced by ordinary Loom code
+in subsequent whole-program transformations.
+
+## Compiler artifact
+
+`aihc compile SOURCE --keep-cps-ir` writes the validated textual form to
+`OUTPUT.cps`. The file starts with `loom-ir 1`; this version identifies the
+debugging format and permits deliberate syntax changes later.

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -75,6 +75,7 @@
   arm64Tests = mkEvalPackageTest hsPkgs.aihc-arm64;
   fcTests = mkEvalPackageTest hsPkgs.aihc-fc;
   grinTests = mkEvalPackageTest hsPkgs.aihc-grin;
+  cpsTests = mkPackageTest hsPkgs.aihc-cps;
   resolveTests = mkPackageTest hsPkgs.aihc-resolve;
   tcTests = mkPackageTest hsPkgs.aihc-tc;
   testingTests = mkPackageTest hsPkgs.aihc-testing;
@@ -171,6 +172,7 @@ in {
   arm64-tests = arm64Tests;
   fc-tests = fcTests;
   grin-tests = grinTests;
+  cps-tests = cpsTests;
   resolve-tests = resolveTests;
   tc-tests = tcTests;
   testing-tests = testingTests;
@@ -210,6 +212,10 @@ in {
     {
       name = "grin-tests";
       path = grinTests;
+    }
+    {
+      name = "cps-tests";
+      path = cpsTests;
     }
     {
       name = "resolve-tests";

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -57,6 +57,13 @@
       supportsDocs = false;
       supportsCoverage = false;
     };
+    aihc-cps = {
+      src = sources.cpsSrc;
+      disableProfiling = true;
+      optimizeForChecks = true;
+      supportsDocs = false;
+      supportsCoverage = false;
+    };
     aihc-resolve = {
       src = sources.resolveSrc;
       disableProfiling = true;

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -72,6 +72,11 @@ in rec {
     ".cabal"
   ];
 
+  cpsSrc = mkComponentSrc "/components/aihc-cps" [
+    ".hs"
+    ".cabal"
+  ];
+
   evalFixturesSrc = mkComponentSrc "/test/Test/Fixtures/eval" [
     ".yaml"
     ".yml"


### PR DESCRIPTION
## Summary

- add `aihc-cps`, a standalone component defining Loom, AIHC's formal continuation-passing IR
- give every function an explicit return-continuation parameter and lower every GRIN bind to a lexically named continuation
- make every operation name its successor; Loom has no implicit return or fall-through term
- validate continuation scope, signatures, parameter layouts, argument layouts, and operation result layouts
- preserve dictionaries solely as ordinary constructor nodes and cases, matching the simplified FC/GRIN representation
- require exception control to be transformed before CPS conversion; Loom has no throw/catch operations and lowering rejects either GRIN form
- add a versioned renderer and `aihc compile --keep-cps-ir`, which writes validated Loom IR to `OUTPUT.cps`
- integrate the component with Cabal and Nix and document its grammar, translation, invariants, and pipeline position

## Design

Loom sits immediately after GRIN. `continue k values` transfers directly to a continuation, while `invoke operation -> k` delivers an operation's results to an explicit successor. Local continuations are lexical and may capture outer values and continuations; later closure conversion can make those captures concrete for a backend. Dictionaries need no Loom-specific syntax because they have already become ordinary data.

The compiler constructs and lints Loom for every independently compiled SCC. The main SCC is rendered by `--keep-cps-ir`, matching the incremental `--keep-grin` artifact model. Whole-program mode constructs Loom again after merging and optimizing Core. The ARM64 backend still consumes GRIN during this staged migration, so this PR establishes and exercises the IR boundary without coupling the initial formalization to a backend rewrite.

`GrinThrow` and `GrinCatch` are explicit boundary violations: conversion returns a function-qualified lowering error. This keeps exception lowering an earlier GRIN transformation and makes it impossible for backend-facing Loom passes to acquire exception primitives accidentally.

## Impact

The compiler now has a stable CPS representation on which continuation capture/resume, explicit stack construction, runtime-root discovery, and scheduler lowering can be expressed as subsequent transformations. Scheduler requests are not baked into the IR.

## Validation

- `just fmt`
- `just check`
- focused `aihc-cps:spec` lowering/lint/render tests
- platform-independent CLI compilation through validated Loom output
- native keep-artifact regression extended to cover `.cps`

## Progress counts

- new `aihc-cps:spec`: 8 passing tests
- `aihc:spec`: 66 -> 68 (+2)
- parser/CPP fixture progress counts: unchanged
- README progress counts: unchanged; the scheduled workflow owns them
