### PR TITLE
refactor(cli): compile module SCCs incrementally

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -7,6 +7,7 @@ module Aihc.Cli.Compile
     CompileError (..),
     compileOutputPath,
     compileSourceToCoreWithDependencies,
+    compileSourceToGrinWithDependencies,
     compileSourceToAssembly,
     compileSourceToAssemblyWithDependencies,
     defaultCompileEnvironment,
@@ -129,11 +130,18 @@ compileSourceToAssemblyWithDependencies :: CompileEnvironment -> FilePath -> Tex
 compileSourceToAssemblyWithDependencies environment sourceName source =
   fmap (fmap compiledAssembly) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
--- | Compile source and its dependencies to the optimized, combined System FC
--- program rendered by @--keep-core@.
+-- | Compile source to the incremental System FC program rendered by
+-- @--keep-core@. Dependency declarations participate in cross-unit lowering,
+-- but their implementations remain in their separately compiled artifacts.
 compileSourceToCoreWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToCoreWithDependencies environment sourceName source =
   fmap (fmap compiledCore) (compileSourceToArtifactsWithDependencies False environment sourceName source)
+
+-- | Compile source and its dependencies to the incremental GRIN program
+-- rendered by @--keep-grin@.
+compileSourceToGrinWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
+compileSourceToGrinWithDependencies environment sourceName source =
+  fmap (fmap compiledGrin) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
 compileSourceToArtifactsWithDependencies :: Bool -> CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
 compileSourceToArtifactsWithDependencies wholeProgram environment sourceName source =
@@ -174,15 +182,18 @@ compileWithDependencies wholeProgram dependencies parsed =
 compileIncrementalArtifacts :: DependencyArtifact -> FcProgram -> FcProgram -> Either CompileError CompileArtifacts
 compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
   let dependencyCorePrograms = map dependencyUnitProgram (dependencyUnits dependencies)
-      separatelyLowered = Grin.lowerPrograms (dependencyCorePrograms <> [mainCore])
+      sourcePrograms = dependencyCorePrograms <> [sourceMainCore]
+      normalizedCorePrograms = Fc.lowerNewtypesPrograms sourcePrograms
+      separatelyLowered = Grin.lowerPrograms normalizedCorePrograms
       dependencyGrinPrograms = take (length dependencyCorePrograms) separatelyLowered
+      incrementalCore = last normalizedCorePrograms
       mainGrin = last separatelyLowered
       dependencyLayout = buildLinkLayout dependencyGrinPrograms
-      mainCore = eliminateDeadCode "main" unoptimizedMain
+      sourceMainCore = eliminateDeadCode "main" unoptimizedMain
       layout = extendLinkLayout dependencyLayout mainGrin
       linkedCore = Fc.lowerNewtypes combinedCore
-      combinedGrin = Grin.lowerProgram linkedCore
-  either (Left . CompileArm64Error) Right (validateProgramPrimitives combinedGrin)
+      linkedGrin = Grin.lowerProgram linkedCore
+  either (Left . CompileArm64Error) Right (validateProgramPrimitives linkedGrin)
   assembly <-
     either
       (Left . CompileArm64Error)
@@ -190,8 +201,8 @@ compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
       (compileProgramWithDependencies layout (dependencyInitializerSymbols dependencies) "main" mainGrin)
   pure
     CompileArtifacts
-      { compiledCore = renderCore linkedCore,
-        compiledGrin = renderGrin combinedGrin,
+      { compiledCore = renderCore incrementalCore,
+        compiledGrin = renderGrin mainGrin,
         compiledAssembly = assembly,
         compiledArchives = dependencyArchivePaths dependencies
       }

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -8,6 +8,7 @@ module Aihc.Cli.Compile
     compileOutputPath,
     compileSourceToCoreWithDependencies,
     compileSourceToGrinWithDependencies,
+    compileSourceToWholeCoreWithDependencies,
     compileSourceToAssembly,
     compileSourceToAssemblyWithDependencies,
     defaultCompileEnvironment,
@@ -69,6 +70,19 @@ data CompileArtifacts = CompileArtifacts
     compiledGrin :: !Text,
     compiledAssembly :: !Text,
     compiledArchives :: ![FilePath]
+  }
+
+-- | The Core and GRIN produced for one independently compiled module.
+data IncrementalUnit = IncrementalUnit
+  { incrementalUnitCore :: !FcProgram,
+    incrementalUnitGrin :: !Grin.GrinProgram
+  }
+
+-- | Per-module compiler output. Whole-program compilation is derived from
+-- this structure; it is never an alternative frontend or lowering path.
+data IncrementalCompilation = IncrementalCompilation
+  { incrementalDependencyUnits :: ![IncrementalUnit],
+    incrementalMainUnit :: !IncrementalUnit
   }
 
 runCompile :: CompileOptions -> IO ()
@@ -143,6 +157,13 @@ compileSourceToGrinWithDependencies :: CompileEnvironment -> FilePath -> Text ->
 compileSourceToGrinWithDependencies environment sourceName source =
   fmap (fmap compiledGrin) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
+-- | Compile source incrementally, then merge the resulting Core units and run
+-- whole-program dead-code elimination. This is the Core rendered by
+-- @--whole-program --keep-core@.
+compileSourceToWholeCoreWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
+compileSourceToWholeCoreWithDependencies environment sourceName source =
+  fmap (fmap compiledCore) (compileSourceToArtifactsWithDependencies True environment sourceName source)
+
 compileSourceToArtifactsWithDependencies :: Bool -> CompileEnvironment -> FilePath -> Text -> IO (Either CompileError CompileArtifacts)
 compileSourceToArtifactsWithDependencies wholeProgram environment sourceName source =
   case parseCompileModule sourceName source of
@@ -173,26 +194,62 @@ compileWithDependencies wholeProgram dependencies parsed =
                     then Left (CompileFrontendError (concatMap dsErrors desugared))
                     else
                       let mainProgram = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
-                          freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainProgram) (dependencyProgram dependencies)
-                          program = eliminateDeadCode "main" (appendPrograms freshDependencies mainProgram)
-                       in if wholeProgram
-                            then compileProgramArtifacts program
-                            else compileIncrementalArtifacts dependencies mainProgram program
+                       in do
+                            incremental <- compileIncrementally dependencies mainProgram
+                            if wholeProgram
+                              then compileWholeProgramArtifacts incremental
+                              else compileIncrementalArtifacts dependencies incremental
 
-compileIncrementalArtifacts :: DependencyArtifact -> FcProgram -> FcProgram -> Either CompileError CompileArtifacts
-compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
-  let dependencyCorePrograms = map dependencyUnitProgram (dependencyUnits dependencies)
-      sourcePrograms = dependencyCorePrograms <> [sourceMainCore]
-      normalizedCorePrograms = Fc.lowerNewtypesPrograms sourcePrograms
-      separatelyLowered = Grin.lowerPrograms normalizedCorePrograms
-      dependencyGrinPrograms = take (length dependencyCorePrograms) separatelyLowered
-      incrementalCore = last normalizedCorePrograms
-      mainGrin = last separatelyLowered
+-- | Compile every module to its own normalized Core and GRIN unit before any
+-- optional whole-program transformation is considered.
+compileIncrementally :: DependencyArtifact -> FcProgram -> Either CompileError IncrementalCompilation
+compileIncrementally dependencies unoptimizedMain =
+  case splitLast incrementalUnits of
+    Nothing -> Left (CompileFrontendError ["incremental compilation produced no main unit"])
+    Just (dependencyUnits', mainUnit) ->
+      Right
+        IncrementalCompilation
+          { incrementalDependencyUnits = dependencyUnits',
+            incrementalMainUnit = mainUnit
+          }
+  where
+    dependencyCorePrograms = map dependencyUnitProgram (dependencyUnits dependencies)
+    mainCore = eliminateDeadCode "main" unoptimizedMain
+    sourceCorePrograms = dependencyCorePrograms <> [mainCore]
+    normalizedCorePrograms = Fc.lowerNewtypesPrograms sourceCorePrograms
+    grinPrograms = Grin.lowerPrograms sourceCorePrograms
+    incrementalUnits = zipWith IncrementalUnit normalizedCorePrograms grinPrograms
+
+-- | Link already-incremental Core units for whole-program analysis. Unique
+-- namespaces are separated only while constructing the merged view.
+mergeIncrementalCore :: IncrementalCompilation -> FcProgram
+mergeIncrementalCore compilation =
+  appendPrograms freshDependencies mainCore
+  where
+    dependencyCore = concatPrograms (map incrementalUnitCore (incrementalDependencyUnits compilation))
+    mainCore = incrementalUnitCore (incrementalMainUnit compilation)
+    freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainCore) dependencyCore
+
+reachableLinkedCore :: IncrementalCompilation -> FcProgram
+reachableLinkedCore = eliminateDeadCode "main" . mergeIncrementalCore
+
+-- | The optional whole-program phase consumes incremental Core; it does not
+-- rerun the frontend or bypass per-module GRIN lowering.
+compileWholeProgramArtifacts :: IncrementalCompilation -> Either CompileError CompileArtifacts
+compileWholeProgramArtifacts = compileProgramArtifacts . reachableLinkedCore
+
+compileIncrementalArtifacts :: DependencyArtifact -> IncrementalCompilation -> Either CompileError CompileArtifacts
+compileIncrementalArtifacts dependencies compilation = do
+  let dependencyGrinPrograms = map incrementalUnitGrin (incrementalDependencyUnits compilation)
+      mainUnit = incrementalMainUnit compilation
+      mainCore = incrementalUnitCore mainUnit
+      mainGrin = incrementalUnitGrin mainUnit
       dependencyLayout = buildLinkLayout dependencyGrinPrograms
-      sourceMainCore = eliminateDeadCode "main" unoptimizedMain
       layout = extendLinkLayout dependencyLayout mainGrin
-      linkedCore = Fc.lowerNewtypes combinedCore
-      linkedGrin = Grin.lowerProgram linkedCore
+      -- Native dependency objects may contain dormant primitive declarations.
+      -- Validate only the linked reachable view, without using that merged
+      -- program as the output of incremental compilation.
+      linkedGrin = Grin.lowerProgram (reachableLinkedCore compilation)
   either (Left . CompileArm64Error) Right (validateProgramPrimitives linkedGrin)
   assembly <-
     either
@@ -201,7 +258,7 @@ compileIncrementalArtifacts dependencies unoptimizedMain combinedCore = do
       (compileProgramWithDependencies layout (dependencyInitializerSymbols dependencies) "main" mainGrin)
   pure
     CompileArtifacts
-      { compiledCore = renderCore incrementalCore,
+      { compiledCore = renderCore mainCore,
         compiledGrin = renderGrin mainGrin,
         compiledAssembly = assembly,
         compiledArchives = dependencyArchivePaths dependencies
@@ -231,6 +288,15 @@ withFinalNewline rendered = T.pack rendered <> "\n"
 
 appendPrograms :: FcProgram -> FcProgram -> FcProgram
 appendPrograms (FcProgram left) (FcProgram right) = FcProgram (left <> right)
+
+concatPrograms :: [FcProgram] -> FcProgram
+concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
+
+splitLast :: [value] -> Maybe ([value], value)
+splitLast values =
+  case reverse values of
+    [] -> Nothing
+    final : preceding -> Just (reverse preceding, final)
 
 maximumProgramUnique :: FcProgram -> Int
 maximumProgramUnique = maximum . (0 :) . map varUniqueInt . programVars

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -18,7 +18,7 @@ module Aihc.Cli.Compile
   )
 where
 
-import Aihc.Arm64 (Arm64Error, buildLinkLayout, compileProgram, compileProgramWithDependencies, extendLinkLayout, runtimeSourcePath, targetTriple, validateProgramPrimitives)
+import Aihc.Arm64 (Arm64Error, buildLinkLayoutFromInterfaces, compileProgram, compileProgramWithDependencies, extendLinkLayout, runtimeSourcePath, targetTriple, validatePrimitiveNames)
 import Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
@@ -37,6 +37,8 @@ import Aihc.Fc
     desugarModule,
     desugarModuleWithBindings,
     eliminateDeadCode,
+    extractReachabilityInterface,
+    reachablePrimitiveNames,
   )
 import Aihc.Fc qualified as Fc
 import Aihc.Grin qualified as Grin
@@ -48,6 +50,7 @@ import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSucc
 import Control.Exception (bracket)
 import Control.Monad (when)
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -72,13 +75,13 @@ data CompileArtifacts = CompileArtifacts
     compiledArchives :: ![FilePath]
   }
 
--- | The Core and GRIN produced for one independently compiled module.
+-- | The Core and GRIN produced for one independently compiled module SCC.
 data IncrementalUnit = IncrementalUnit
   { incrementalUnitCore :: !FcProgram,
     incrementalUnitGrin :: !Grin.GrinProgram
   }
 
--- | Per-module compiler output. Whole-program compilation is derived from
+-- | Per-SCC compiler output. Whole-program compilation is derived from
 -- this structure; it is never an alternative frontend or lowering path.
 data IncrementalCompilation = IncrementalCompilation
   { incrementalDependencyUnits :: ![IncrementalUnit],
@@ -200,25 +203,21 @@ compileWithDependencies wholeProgram dependencies parsed =
                               then compileWholeProgramArtifacts incremental
                               else compileIncrementalArtifacts dependencies incremental
 
--- | Compile every module to its own normalized Core and GRIN unit before any
+-- | Compile every module SCC to its own normalized Core and GRIN unit before any
 -- optional whole-program transformation is considered.
 compileIncrementally :: DependencyArtifact -> FcProgram -> Either CompileError IncrementalCompilation
 compileIncrementally dependencies unoptimizedMain =
-  case splitLast incrementalUnits of
-    Nothing -> Left (CompileFrontendError ["incremental compilation produced no main unit"])
-    Just (dependencyUnits', mainUnit) ->
-      Right
-        IncrementalCompilation
-          { incrementalDependencyUnits = dependencyUnits',
-            incrementalMainUnit = mainUnit
-          }
+  Right
+    IncrementalCompilation
+      { incrementalDependencyUnits =
+          [ IncrementalUnit (dependencyUnitProgram unit) (dependencyUnitGrin unit)
+          | unit <- dependencyUnits dependencies
+          ],
+        incrementalMainUnit = IncrementalUnit mainCore mainGrin
+      }
   where
-    dependencyCorePrograms = map dependencyUnitProgram (dependencyUnits dependencies)
-    mainCore = eliminateDeadCode "main" unoptimizedMain
-    sourceCorePrograms = dependencyCorePrograms <> [mainCore]
-    normalizedCorePrograms = Fc.lowerNewtypesPrograms sourceCorePrograms
-    grinPrograms = Grin.lowerPrograms sourceCorePrograms
-    incrementalUnits = zipWith IncrementalUnit normalizedCorePrograms grinPrograms
+    mainCore = Fc.lowerNewtypesWithInterface (dependencyNewtypeInterface dependencies) (eliminateDeadCode "main" unoptimizedMain)
+    mainGrin = Grin.lowerProgramWithInterface (dependencyGrinInterface dependencies) mainCore
 
 -- | Link already-incremental Core units for whole-program analysis. Unique
 -- namespaces are separated only while constructing the merged view.
@@ -226,31 +225,34 @@ mergeIncrementalCore :: IncrementalCompilation -> FcProgram
 mergeIncrementalCore compilation =
   appendPrograms freshDependencies mainCore
   where
-    dependencyCore = concatPrograms (map incrementalUnitCore (incrementalDependencyUnits compilation))
     mainCore = incrementalUnitCore (incrementalMainUnit compilation)
-    freshDependencies = shiftProgramVars (1 + maximumProgramUnique mainCore) dependencyCore
+    freshDependencies = freshenPrograms (1 + maximumProgramUnique mainCore) (map incrementalUnitCore (incrementalDependencyUnits compilation))
+
+freshenPrograms :: Int -> [FcProgram] -> FcProgram
+freshenPrograms _ [] = FcProgram []
+freshenPrograms nextUnique (program : programs) =
+  appendPrograms shifted (freshenPrograms (1 + maximumProgramUnique shifted) programs)
+  where
+    shifted = shiftProgramVars nextUnique program
 
 reachableLinkedCore :: IncrementalCompilation -> FcProgram
 reachableLinkedCore = eliminateDeadCode "main" . mergeIncrementalCore
 
 -- | The optional whole-program phase consumes incremental Core; it does not
--- rerun the frontend or bypass per-module GRIN lowering.
+-- rerun the frontend or bypass per-SCC GRIN lowering.
 compileWholeProgramArtifacts :: IncrementalCompilation -> Either CompileError CompileArtifacts
 compileWholeProgramArtifacts = compileProgramArtifacts . reachableLinkedCore
 
 compileIncrementalArtifacts :: DependencyArtifact -> IncrementalCompilation -> Either CompileError CompileArtifacts
 compileIncrementalArtifacts dependencies compilation = do
-  let dependencyGrinPrograms = map incrementalUnitGrin (incrementalDependencyUnits compilation)
-      mainUnit = incrementalMainUnit compilation
+  let mainUnit = incrementalMainUnit compilation
       mainCore = incrementalUnitCore mainUnit
       mainGrin = incrementalUnitGrin mainUnit
-      dependencyLayout = buildLinkLayout dependencyGrinPrograms
+      dependencyLayout = buildLinkLayoutFromInterfaces (dependencyLinkInterfaces dependencies)
       layout = extendLinkLayout dependencyLayout mainGrin
-      -- Native dependency objects may contain dormant primitive declarations.
-      -- Validate only the linked reachable view, without using that merged
-      -- program as the output of incremental compilation.
-      linkedGrin = Grin.lowerProgram (reachableLinkedCore compilation)
-  either (Left . CompileArm64Error) Right (validateProgramPrimitives linkedGrin)
+      reachability = dependencyReachabilityInterface dependencies <> extractReachabilityInterface mainCore
+      primitives = Set.toAscList (reachablePrimitiveNames "main" reachability)
+  either (Left . CompileArm64Error) Right (validatePrimitiveNames primitives)
   assembly <-
     either
       (Left . CompileArm64Error)
@@ -288,15 +290,6 @@ withFinalNewline rendered = T.pack rendered <> "\n"
 
 appendPrograms :: FcProgram -> FcProgram -> FcProgram
 appendPrograms (FcProgram left) (FcProgram right) = FcProgram (left <> right)
-
-concatPrograms :: [FcProgram] -> FcProgram
-concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
-
-splitLast :: [value] -> Maybe ([value], value)
-splitLast values =
-  case reverse values of
-    [] -> Nothing
-    final : preceding -> Just (reverse preceding, final)
 
 maximumProgramUnique :: FcProgram -> Int
 maximumProgramUnique = maximum . (0 :) . map varUniqueInt . programVars

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -98,7 +98,6 @@ data DependencyArtifact = DependencyArtifact
     dependencyTyCons :: ![TyConInfo],
     dependencyBindings :: ![TcBindingResult],
     dependencyInstances :: ![InstanceInfo],
-    dependencyProgram :: !FcProgram,
     dependencyUnits :: ![DependencyUnit],
     dependencyInitializerSymbols :: ![Text],
     dependencyArchivePaths :: ![FilePath]
@@ -207,7 +206,6 @@ emptyDependencyArtifact =
       dependencyTyCons = [],
       dependencyBindings = [],
       dependencyInstances = [],
-      dependencyProgram = FcProgram [],
       dependencyUnits = [],
       dependencyInitializerSymbols = [],
       dependencyArchivePaths = []
@@ -322,7 +320,6 @@ compileLoadedModules loaded =
                             dependencyTyCons = tyCons,
                             dependencyBindings = bindings,
                             dependencyInstances = instances,
-                            dependencyProgram = concatPrograms (map dsProgram desugared),
                             dependencyUnits = zipWith makeUnit loaded desugared,
                             dependencyInitializerSymbols = [],
                             dependencyArchivePaths = []
@@ -335,9 +332,6 @@ compileLoadedModules loaded =
           dependencyUnitModule = fromMaybe "Main" (moduleName (loadedModule loadedModule')),
           dependencyUnitProgram = dsProgram desugared
         }
-
-concatPrograms :: [FcProgram] -> FcProgram
-concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
 
 buildNativeArtifacts :: FilePath -> [DependencyUnit] -> IO (Either String ([Text], [FilePath]))
 buildNativeArtifacts artifactRoot units = do
@@ -528,7 +522,6 @@ fromStoredArtifact stored =
       dependencyTyCons = storedTyCons stored,
       dependencyBindings = storedBindings stored,
       dependencyInstances = storedInstances stored,
-      dependencyProgram = concatPrograms (map dependencyUnitProgram (storedUnits stored)),
       dependencyUnits = storedUnits stored,
       dependencyInitializerSymbols = [],
       dependencyArchivePaths = []

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Core-library discovery and content-addressed compilation for @aihc compile@.
--- Each closure cache contains the frontend interface, one native object per
--- loaded module, and one static archive per contributing library.
+-- Each closure cache contains the frontend interfaces and one Core, GRIN, and
+-- native object artifact per strongly connected module component.
 module Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
@@ -12,8 +12,8 @@ module Aihc.Cli.Compile.Dependencies
   )
 where
 
-import Aihc.Arm64 (LinkLayout, buildLinkLayout, compileModule, targetTriple)
-import Aihc.Fc (DesugarResult (..), FcProgram (..), desugarModuleWithBindings)
+import Aihc.Arm64 (LinkInterface, LinkLayout, buildLinkLayoutFromInterfaces, compileModule, extractLinkInterface, targetTriple)
+import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface)
 import Aihc.Grin qualified as Grin
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax
@@ -35,7 +35,7 @@ import Aihc.Resolve
     ResolveResult (..),
     ResolvedName (..),
     Scope (..),
-    extractInterface,
+    extractInterfaceWithDeps,
     resolveWithDeps,
   )
 import Aihc.Tc
@@ -47,16 +47,17 @@ import Aihc.Tc
     tcModuleDiagnostics,
     tcModuleInstances,
     tcModuleSuccess,
-    typecheckModulesWithFullEnv,
+    typecheckModuleSccWithFullEnv,
   )
 import Control.Exception (bracket, bracketOnError)
 import Control.Monad (filterM, foldM)
 import Data.Bits (xor)
 import Data.ByteString qualified as BS
+import Data.Graph (SCC (..), stronglyConnComp)
 import Data.List (sort)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -98,15 +99,24 @@ data DependencyArtifact = DependencyArtifact
     dependencyTyCons :: ![TyConInfo],
     dependencyBindings :: ![TcBindingResult],
     dependencyInstances :: ![InstanceInfo],
+    dependencyNewtypeInterface :: !NewtypeInterface,
+    dependencyGrinInterface :: !Grin.GrinInterface,
+    dependencyReachabilityInterface :: !ReachabilityInterface,
+    dependencyLinkInterfaces :: ![LinkInterface],
     dependencyUnits :: ![DependencyUnit],
     dependencyInitializerSymbols :: ![Text],
     dependencyArchivePaths :: ![FilePath]
   }
 
 data DependencyUnit = DependencyUnit
-  { dependencyUnitLibrary :: !Text,
-    dependencyUnitModule :: !Text,
-    dependencyUnitProgram :: !FcProgram
+  { dependencyUnitLibraries :: ![Text],
+    dependencyUnitModules :: ![Text],
+    dependencyUnitProgram :: !FcProgram,
+    dependencyUnitGrin :: !Grin.GrinProgram,
+    dependencyUnitNewtypeInterface :: !NewtypeInterface,
+    dependencyUnitGrinInterface :: !Grin.GrinInterface,
+    dependencyUnitReachabilityInterface :: !ReachabilityInterface,
+    dependencyUnitLinkInterface :: !LinkInterface
   }
   deriving (Eq, Show, Read)
 
@@ -153,7 +163,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 4
+cacheSchemaVersion = 5
 
 buildDependencies :: CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies environment usesImplicitPrelude buildNative mainModule = do
@@ -206,6 +216,10 @@ emptyDependencyArtifact =
       dependencyTyCons = [],
       dependencyBindings = [],
       dependencyInstances = [],
+      dependencyNewtypeInterface = mempty,
+      dependencyGrinInterface = mempty,
+      dependencyReachabilityInterface = mempty,
+      dependencyLinkInterfaces = [],
       dependencyUnits = [],
       dependencyInitializerSymbols = [],
       dependencyArchivePaths = []
@@ -299,47 +313,111 @@ parserConfig sourceName source =
     language = fromMaybe Haskell98Edition (headerLanguageEdition header)
 
 compileLoadedModules :: [LoadedModule] -> Either String DependencyArtifact
-compileLoadedModules loaded =
-  case resolveWithDeps Map.empty modules of
-    ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("core library resolve error: " <> show errors)
-    resolved@ResolveResult {resolvedModules} ->
-      let (checkedModules, termSchemes, tyCons) = typecheckModulesWithFullEnv [] [] [] resolvedModules
-       in if not (all tcModuleSuccess checkedModules)
-            then Left ("core library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
-            else
-              let bindings = concatMap tcModuleBindings checkedModules
-                  instances = concatMap tcModuleInstances checkedModules
-                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
-               in if not (all dsSuccess desugared)
-                    then Left ("core library desugar error: " <> unlines (concatMap dsErrors desugared))
-                    else
-                      Right
-                        DependencyArtifact
-                          { dependencyExports = extractInterface resolved,
-                            dependencyTerms = termSchemes,
-                            dependencyTyCons = tyCons,
-                            dependencyBindings = bindings,
-                            dependencyInstances = instances,
-                            dependencyUnits = zipWith makeUnit loaded desugared,
-                            dependencyInitializerSymbols = [],
-                            dependencyArchivePaths = []
-                          }
+compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedModuleSccs loaded)
   where
-    modules = map loadedModule loaded
-    makeUnit loadedModule' desugared =
-      DependencyUnit
-        { dependencyUnitLibrary = loadedLibrary loadedModule',
-          dependencyUnitModule = fromMaybe "Main" (moduleName (loadedModule loadedModule')),
-          dependencyUnitProgram = dsProgram desugared
+    initialState = CompileState Map.empty [] [] [] [] mempty mempty mempty [] []
+
+    compileScc state members =
+      case resolveWithDeps (compileStateExports state) (map loadedModule members) of
+        ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("core library resolve error: " <> show errors)
+        resolved@ResolveResult {resolvedModules} ->
+          let (checkedModules, termSchemes, tyCons) =
+                typecheckModuleSccWithFullEnv
+                  (compileStateTerms state)
+                  (compileStateTyCons state)
+                  (compileStateInstances state)
+                  resolvedModules
+           in if not (all tcModuleSuccess checkedModules)
+                then Left ("core library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
+                else
+                  let localBindings = concatMap tcModuleBindings checkedModules
+                      bindings = compileStateBindings state <> localBindings
+                      localInstances = concatMap tcModuleInstances checkedModules
+                      desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
+                   in if not (all dsSuccess desugared)
+                        then Left ("core library desugar error: " <> unlines (concatMap dsErrors desugared))
+                        else
+                          let sourceCore = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
+                              core = lowerNewtypesWithInterface (compileStateNewtypes state) sourceCore
+                              newtypes = extractNewtypeInterface core
+                              grinInterface = Grin.extractGrinInterface core
+                              reachabilityInterface = extractReachabilityInterface core
+                              grin = Grin.lowerProgramWithInterface (compileStateGrin state) core
+                              linkInterface = extractLinkInterface grin
+                              unit =
+                                DependencyUnit
+                                  { dependencyUnitLibraries = sort (Set.toList (Set.fromList (map loadedLibrary members))),
+                                    dependencyUnitModules = sort (map loadedModuleName members),
+                                    dependencyUnitProgram = core,
+                                    dependencyUnitGrin = grin,
+                                    dependencyUnitNewtypeInterface = newtypes,
+                                    dependencyUnitGrinInterface = grinInterface,
+                                    dependencyUnitReachabilityInterface = reachabilityInterface,
+                                    dependencyUnitLinkInterface = linkInterface
+                                  }
+                           in Right
+                                CompileState
+                                  { compileStateExports = compileStateExports state <> extractInterfaceWithDeps (compileStateExports state) resolved,
+                                    compileStateTerms = termSchemes,
+                                    compileStateTyCons = tyCons,
+                                    compileStateBindings = bindings,
+                                    compileStateInstances = compileStateInstances state <> localInstances,
+                                    compileStateNewtypes = compileStateNewtypes state <> newtypes,
+                                    compileStateGrin = compileStateGrin state <> grinInterface,
+                                    compileStateReachability = compileStateReachability state <> reachabilityInterface,
+                                    compileStateLinks = compileStateLinks state <> [linkInterface],
+                                    compileStateUnits = compileStateUnits state <> [unit]
+                                  }
+
+    finish state =
+      DependencyArtifact
+        { dependencyExports = compileStateExports state,
+          dependencyTerms = compileStateTerms state,
+          dependencyTyCons = compileStateTyCons state,
+          dependencyBindings = compileStateBindings state,
+          dependencyInstances = compileStateInstances state,
+          dependencyNewtypeInterface = compileStateNewtypes state,
+          dependencyGrinInterface = compileStateGrin state,
+          dependencyReachabilityInterface = compileStateReachability state,
+          dependencyLinkInterfaces = compileStateLinks state,
+          dependencyUnits = compileStateUnits state,
+          dependencyInitializerSymbols = [],
+          dependencyArchivePaths = []
         }
+
+data CompileState = CompileState
+  { compileStateExports :: !ModuleExports,
+    compileStateTerms :: ![(Text, TypeScheme)],
+    compileStateTyCons :: ![TyConInfo],
+    compileStateBindings :: ![TcBindingResult],
+    compileStateInstances :: ![InstanceInfo],
+    compileStateNewtypes :: !NewtypeInterface,
+    compileStateGrin :: !Grin.GrinInterface,
+    compileStateReachability :: !ReachabilityInterface,
+    compileStateLinks :: ![LinkInterface],
+    compileStateUnits :: ![DependencyUnit]
+  }
+
+loadedModuleSccs :: [LoadedModule] -> [[LoadedModule]]
+loadedModuleSccs = map flatten . stronglyConnComp . map graphNode
+  where
+    graphNode loaded =
+      ( loaded,
+        loadedModuleName loaded,
+        map importDeclModule (moduleImports (loadedModule loaded))
+      )
+    flatten (AcyclicSCC member) = [member]
+    flatten (CyclicSCC members) = members
+
+loadedModuleName :: LoadedModule -> Text
+loadedModuleName = fromMaybe "Main" . moduleName . loadedModule
 
 buildNativeArtifacts :: FilePath -> [DependencyUnit] -> IO (Either String ([Text], [FilePath]))
 buildNativeArtifacts artifactRoot units = do
-  let programs = Grin.lowerPrograms (map dependencyUnitProgram units)
-      layout = buildLinkLayout programs
+  let layout = buildLinkLayoutFromInterfaces (map dependencyUnitLinkInterface units)
       objectRoot = artifactRoot </> "objects"
       archiveRoot = artifactRoot </> "archives"
-      nativeUnits = zipWith (nativeUnit objectRoot) units programs
+      nativeUnits = map (nativeUnit objectRoot) units
   objectResults <- mapM (buildObject layout) nativeUnits
   case sequence objectResults of
     Left err -> pure (Left err)
@@ -347,7 +425,7 @@ buildNativeArtifacts artifactRoot units = do
       createDirectoryIfMissing True archiveRoot
       let archiveMembers =
             foldl'
-              (\archives unit -> Map.insertWith (flip (<>)) (dependencyUnitLibrary (nativeDependencyUnit unit)) [nativeObjectPath unit] archives)
+              (\archives unit -> Map.insertWith (flip (<>)) (nativeUnitLibrary unit) [nativeObjectPath unit] archives)
               Map.empty
               nativeUnits
       archives <- mapM (buildArchive archiveRoot) (Map.toAscList archiveMembers)
@@ -362,16 +440,24 @@ data NativeUnit = NativeUnit
     nativeObjectPath :: !FilePath
   }
 
-nativeUnit :: FilePath -> DependencyUnit -> Grin.GrinProgram -> NativeUnit
-nativeUnit objectRoot unit program =
+nativeUnit :: FilePath -> DependencyUnit -> NativeUnit
+nativeUnit objectRoot unit =
   NativeUnit
     { nativeDependencyUnit = unit,
-      nativeProgram = program,
+      nativeProgram = dependencyUnitGrin unit,
       nativeInitializerSymbol = initializer,
-      nativeObjectPath = objectRoot </> T.unpack (dependencyUnitLibrary unit) </> T.unpack (dependencyUnitModule unit) <> ".o"
+      nativeObjectPath = objectRoot </> T.unpack library </> T.unpack unitName <> ".o"
     }
   where
-    initializer = "_aihc_init_" <> symbolHex (dependencyUnitLibrary unit <> "\0" <> dependencyUnitModule unit)
+    library = dependencyUnitPrimaryLibrary unit
+    unitName = T.intercalate "+" (dependencyUnitModules unit)
+    initializer = "_aihc_init_" <> symbolHex (library <> "\0" <> T.intercalate "\0" (dependencyUnitModules unit))
+
+nativeUnitLibrary :: NativeUnit -> Text
+nativeUnitLibrary = dependencyUnitPrimaryLibrary . nativeDependencyUnit
+
+dependencyUnitPrimaryLibrary :: DependencyUnit -> Text
+dependencyUnitPrimaryLibrary unit = fromMaybe "dependencies" (listToMaybe (dependencyUnitLibraries unit))
 
 symbolHex :: Text -> Text
 symbolHex = T.concat . map renderByte . BS.unpack . Text.encodeUtf8
@@ -387,7 +473,7 @@ buildObject layout unit = do
     then pure (Right ())
     else do
       case compileModule layout (nativeInitializerSymbol unit) (nativeProgram unit) of
-        Left err -> pure (Left ("ARM64 dependency code generation failed for " <> T.unpack (dependencyUnitModule (nativeDependencyUnit unit)) <> ": " <> show err))
+        Left err -> pure (Left ("ARM64 dependency code generation failed for " <> dependencyUnitLabel (nativeDependencyUnit unit) <> ": " <> show err))
         Right assembly -> do
           createDirectoryIfMissing True directory
           withTemporaryDirectory directory "module-build" $ \temporary -> do
@@ -397,7 +483,10 @@ buildObject layout unit = do
             (exitCode, _stdout, stderr) <- readProcessWithExitCode "clang" ["--target=" <> targetTriple, "-c", assemblyPath, "-o", objectPath] ""
             case exitCode of
               ExitSuccess -> renameFile objectPath destination >> pure (Right ())
-              ExitFailure _ -> pure (Left ("failed to assemble dependency module " <> T.unpack (dependencyUnitModule (nativeDependencyUnit unit)) <> ": " <> stderr))
+              ExitFailure _ -> pure (Left ("failed to assemble dependency unit " <> dependencyUnitLabel (nativeDependencyUnit unit) <> ": " <> stderr))
+
+dependencyUnitLabel :: DependencyUnit -> String
+dependencyUnitLabel = T.unpack . T.intercalate "," . dependencyUnitModules
 
 buildArchive :: FilePath -> (Text, [FilePath]) -> IO (Either String FilePath)
 buildArchive archiveRoot (library, objects) = do
@@ -522,10 +611,16 @@ fromStoredArtifact stored =
       dependencyTyCons = storedTyCons stored,
       dependencyBindings = storedBindings stored,
       dependencyInstances = storedInstances stored,
+      dependencyNewtypeInterface = foldMap dependencyUnitNewtypeInterface units,
+      dependencyGrinInterface = foldMap dependencyUnitGrinInterface units,
+      dependencyReachabilityInterface = foldMap dependencyUnitReachabilityInterface units,
+      dependencyLinkInterfaces = map dependencyUnitLinkInterface units,
       dependencyUnits = storedUnits stored,
       dependencyInitializerSymbols = [],
       dependencyArchivePaths = []
     }
+  where
+    units = storedUnits stored
 
 toStoredExports :: ModuleExports -> StoredModuleExports
 toStoredExports = StoredModuleExports . map (fmap toStoredScope) . Map.toAscList

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -121,7 +121,7 @@ compileOptionsParser =
       )
     <*> OA.switch
       ( OA.long "whole-program"
-          <> OA.help "Compile the program and all libraries as one assembly unit instead of linking cached library objects"
+          <> OA.help "After incremental module compilation, merge Core units for whole-program DCE and code generation"
       )
 
 replOptionsParser :: OA.Parser ReplOptions

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -9,6 +9,7 @@ import Aihc.Cli.Compile
     compileSourceToAssemblyWithDependencies,
     compileSourceToCoreWithDependencies,
     compileSourceToGrinWithDependencies,
+    compileSourceToWholeCoreWithDependencies,
     defaultCompileEnvironment,
     runCompileWithEnvironment,
   )
@@ -974,12 +975,15 @@ test_compileExplicitCoreImport =
       )
     core <- expectCompileArtifact =<< compileSourceToCoreWithDependencies environment "Main.hs" importedSource
     grin <- expectCompileArtifact =<< compileSourceToGrinWithDependencies environment "Main.hs" importedSource
+    wholeCore <- expectCompileArtifact =<< compileSourceToWholeCoreWithDependencies environment "Main.hs" importedSource
     assertBool "dependency reference remains in incremental Core" ("identity" `T.isInfixOf` core)
     assertBool "dependency reference remains in incremental GRIN" ("identity" `T.isInfixOf` grin)
     assertBool "dependency Core implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` core))
     assertBool "dependency GRIN implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` grin))
+    assertBool "whole-program Core merges reachable dependency implementations" ("dependencyImplementation" `T.isInfixOf` wholeCore)
     assertBool "unreachable dependency function is excluded from Core" (not ("unreachableDependencyFunction" `T.isInfixOf` core))
     assertBool "unreachable dependency type is excluded from Core" (not ("UnreachableDependencyConstructor" `T.isInfixOf` core))
+    assertBool "whole-program DCE excludes unreachable dependency functions" (not ("unreachableDependencyFunction" `T.isInfixOf` wholeCore))
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
     compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
 

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -8,6 +8,7 @@ import Aihc.Cli.Compile
     compileOutputPath,
     compileSourceToAssemblyWithDependencies,
     compileSourceToCoreWithDependencies,
+    compileSourceToGrinWithDependencies,
     defaultCompileEnvironment,
     runCompileWithEnvironment,
   )
@@ -153,7 +154,7 @@ main =
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
           testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
-          testCase "builds explicit core imports under NoImplicitPrelude" test_compileExplicitCoreImport
+          testCase "builds explicit incremental imports under NoImplicitPrelude" test_compileExplicitCoreImport
         ],
       testGroup
         "repl"
@@ -967,13 +968,18 @@ test_compileExplicitCoreImport =
             "module Demo (identity) where",
             "data UnreachableDependencyType = UnreachableDependencyConstructor",
             "unreachableDependencyFunction = UnreachableDependencyConstructor",
-            "identity x = x"
+            "dependencyImplementation x = x",
+            "identity x = dependencyImplementation x"
           ]
       )
-    core <- expectCompileCore =<< compileSourceToCoreWithDependencies environment "Main.hs" importedSource
-    assertBool "reachable dependency function is retained" ("identity" `T.isInfixOf` core)
-    assertBool "unreachable dependency function is eliminated" (not ("unreachableDependencyFunction" `T.isInfixOf` core))
-    assertBool "unreachable dependency type is eliminated" (not ("UnreachableDependencyConstructor" `T.isInfixOf` core))
+    core <- expectCompileArtifact =<< compileSourceToCoreWithDependencies environment "Main.hs" importedSource
+    grin <- expectCompileArtifact =<< compileSourceToGrinWithDependencies environment "Main.hs" importedSource
+    assertBool "dependency reference remains in incremental Core" ("identity" `T.isInfixOf` core)
+    assertBool "dependency reference remains in incremental GRIN" ("identity" `T.isInfixOf` grin)
+    assertBool "dependency Core implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` core))
+    assertBool "dependency GRIN implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` grin))
+    assertBool "unreachable dependency function is excluded from Core" (not ("unreachableDependencyFunction" `T.isInfixOf` core))
+    assertBool "unreachable dependency type is excluded from Core" (not ("UnreachableDependencyConstructor" `T.isInfixOf` core))
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
     compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
 
@@ -983,8 +989,8 @@ expectCompileSuccess result =
     Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
     Right assembly -> assertBool "native entry" (".globl _main" `T.isInfixOf` assembly)
 
-expectCompileCore :: Either CompileError T.Text -> IO T.Text
-expectCompileCore result =
+expectCompileArtifact :: Either CompileError T.Text -> IO T.Text
+expectCompileArtifact result =
   case result of
     Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
     Right core -> pure core

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -155,7 +155,8 @@ main =
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
           testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
-          testCase "builds explicit incremental imports under NoImplicitPrelude" test_compileExplicitCoreImport
+          testCase "builds explicit incremental imports under NoImplicitPrelude" test_compileExplicitCoreImport,
+          testCase "compiles mutually recursive modules as one SCC unit" test_compileMutuallyRecursiveModules
         ],
       testGroup
         "repl"
@@ -986,6 +987,44 @@ test_compileExplicitCoreImport =
     assertBool "whole-program DCE excludes unreachable dependency functions" (not ("unreachableDependencyFunction" `T.isInfixOf` wholeCore))
     expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
     compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
+
+test_compileMutuallyRecursiveModules :: Assertion
+test_compileMutuallyRecursiveModules =
+  withTempDir "aihc-compile-module-scc" $ \root -> do
+    let coreRoot = root </> "core-libs"
+        cacheRoot = root </> "cache"
+        environment = CompileEnvironment coreRoot cacheRoot
+        source = T.replace "module Main where\n" "module Main where\n\nimport Cycle.A (Token)\n" noImplicitDependencySource
+    createCompileLibrary
+      coreRoot
+      "cycle"
+      "Cycle.A"
+      ( unlines
+          [ "{-# LANGUAGE NoImplicitPrelude #-}",
+            "module Cycle.A (Token, a) where",
+            "import Cycle.B (b)",
+            "data Token = Token",
+            "a :: Token -> Token",
+            "a = b"
+          ]
+      )
+    createCompileLibrary
+      coreRoot
+      "cycle"
+      "Cycle.B"
+      ( unlines
+          [ "{-# LANGUAGE NoImplicitPrelude #-}",
+            "module Cycle.B (b) where",
+            "import Cycle.A (Token, a)",
+            "b :: Token -> Token",
+            "b value = value",
+            "back :: Token -> Token",
+            "back = a"
+          ]
+      )
+    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" source
+    objectFiles <- compileCacheArtifacts ".o" cacheRoot
+    assertEqual "one object for the two-module SCC" 1 (length objectFiles)
 
 expectCompileSuccess :: Either CompileError T.Text -> Assertion
 expectCompileSuccess result =

--- a/components/aihc-arm64/src/Aihc/Arm64.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64.hs
@@ -2,25 +2,35 @@
 module Aihc.Arm64
   ( Arm64Error (..),
     LinkLayout,
+    LinkInterface,
     buildLinkLayout,
+    buildLinkLayoutFromInterfaces,
     compileModule,
     compileProgram,
     compileProgramWithDependencies,
     extendLinkLayout,
+    extendLinkLayoutWithInterface,
+    extractLinkInterface,
     runtimeSourcePath,
     targetTriple,
     validateProgramPrimitives,
+    validatePrimitiveNames,
   )
 where
 
 import Aihc.Arm64.Codegen
   ( Arm64Error (..),
+    LinkInterface,
     LinkLayout,
     buildLinkLayout,
+    buildLinkLayoutFromInterfaces,
     compileModule,
     compileProgram,
     compileProgramWithDependencies,
     extendLinkLayout,
+    extendLinkLayoutWithInterface,
+    extractLinkInterface,
+    validatePrimitiveNames,
     validateProgramPrimitives,
   )
 import Paths_aihc_arm64 (getDataFileName)

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -6,12 +6,17 @@
 module Aihc.Arm64.Codegen
   ( Arm64Error (..),
     LinkLayout,
+    LinkInterface,
     buildLinkLayout,
+    buildLinkLayoutFromInterfaces,
     compileModule,
     compileProgram,
     compileProgramWithDependencies,
     extendLinkLayout,
+    extendLinkLayoutWithInterface,
+    extractLinkInterface,
     validateProgramPrimitives,
+    validatePrimitiveNames,
   )
 where
 
@@ -60,6 +65,14 @@ data LinkLayout = LinkLayout
   }
   deriving (Eq, Show)
 
+-- | Constructor and global-table metadata exported by a native compilation
+-- unit. Code generation for another unit never needs its GRIN bodies.
+data LinkInterface = LinkInterface
+  { linkInterfaceConstructors :: ![(Text, Int)],
+    linkInterfaceGlobalNames :: ![Text]
+  }
+  deriving (Eq, Show, Read)
+
 data Block = Block
   { blockLabel :: !Text,
     blockLines :: ![Text]
@@ -87,23 +100,39 @@ compileProgram entryName program =
 -- the linked program is checked after whole-program dead-code elimination.
 validateProgramPrimitives :: GrinProgram -> Either Arm64Error ()
 validateProgramPrimitives program =
-  mapM_ (primitiveIdentifier False . grinVarName . fst) (grinPrimitives program)
+  validatePrimitiveNames (map (grinVarName . fst) (grinPrimitives program))
+
+validatePrimitiveNames :: [Text] -> Either Arm64Error ()
+validatePrimitiveNames = mapM_ (primitiveIdentifier False)
 
 -- | Build the stable layout for a dependency closure in dependency order.
 buildLinkLayout :: [GrinProgram] -> LinkLayout
-buildLinkLayout = foldl extendLinkLayout emptyLinkLayout
+buildLinkLayout = buildLinkLayoutFromInterfaces . map extractLinkInterface
+
+buildLinkLayoutFromInterfaces :: [LinkInterface] -> LinkLayout
+buildLinkLayoutFromInterfaces = foldl extendLinkLayoutWithInterface emptyLinkLayout
+
+extractLinkInterface :: GrinProgram -> LinkInterface
+extractLinkInterface program =
+  LinkInterface
+    { linkInterfaceConstructors = programConstructorArities program,
+      linkInterfaceGlobalNames = programGlobalNames program
+    }
 
 -- | Append a compilation unit to an existing layout without renumbering any
 -- existing constructor or global.
 extendLinkLayout :: LinkLayout -> GrinProgram -> LinkLayout
-extendLinkLayout layout program =
+extendLinkLayout layout = extendLinkLayoutWithInterface layout . extractLinkInterface
+
+extendLinkLayoutWithInterface :: LinkLayout -> LinkInterface -> LinkLayout
+extendLinkLayoutWithInterface layout interface =
   LinkLayout
-    { linkConstructors = uniqueByName (linkConstructors layout <> programConstructorArities program),
-      linkGlobalNames = uniqueTexts (linkGlobalNames layout <> programGlobalNames program)
+    { linkConstructors = uniqueByName (linkConstructors layout <> linkInterfaceConstructors interface),
+      linkGlobalNames = uniqueTexts (linkGlobalNames layout <> linkInterfaceGlobalNames interface)
     }
 
--- | Compile a library module to relocatable assembly. The exported initializer
--- initializer installs the module's primitive, static, and CAF globals into the shared
+-- | Compile a library SCC to relocatable assembly. The exported initializer
+-- installs the unit's primitive, static, and CAF globals into the shared
 -- machine table. Constructors are installed once by the executable entry unit.
 compileModule :: LinkLayout -> Text -> GrinProgram -> Either Arm64Error Text
 compileModule layout initializerSymbol program = do

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -27,8 +27,13 @@ module Aihc.Fc
 
     -- * Optimization
     eliminateDeadCode,
+    ReachabilityInterface,
+    extractReachabilityInterface,
+    reachablePrimitiveNames,
     lowerNewtypes,
-    lowerNewtypesPrograms,
+    NewtypeInterface,
+    extractNewtypeInterface,
+    lowerNewtypesWithInterface,
 
     -- * Lint
     lintProgram,
@@ -45,10 +50,10 @@ module Aihc.Fc
   )
 where
 
-import Aihc.Fc.DeadCode (eliminateDeadCode)
+import Aihc.Fc.DeadCode (ReachabilityInterface, eliminateDeadCode, extractReachabilityInterface, reachablePrimitiveNames)
 import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)
-import Aihc.Fc.Newtype (lowerNewtypes, lowerNewtypesPrograms)
+import Aihc.Fc.Newtype (NewtypeInterface, extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
 import Aihc.Fc.Pretty (renderExpr, renderProgram, renderTopBind, renderType)
 import Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -28,6 +28,7 @@ module Aihc.Fc
     -- * Optimization
     eliminateDeadCode,
     lowerNewtypes,
+    lowerNewtypesPrograms,
 
     -- * Lint
     lintProgram,
@@ -48,6 +49,6 @@ import Aihc.Fc.DeadCode (eliminateDeadCode)
 import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)
-import Aihc.Fc.Newtype (lowerNewtypes)
+import Aihc.Fc.Newtype (lowerNewtypes, lowerNewtypesPrograms)
 import Aihc.Fc.Pretty (renderExpr, renderProgram, renderTopBind, renderType)
 import Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -1,6 +1,9 @@
 -- | Whole-program dead-code elimination for System FC.
 module Aihc.Fc.DeadCode
-  ( eliminateDeadCode,
+  ( ReachabilityInterface,
+    eliminateDeadCode,
+    extractReachabilityInterface,
+    reachablePrimitiveNames,
   )
 where
 
@@ -24,6 +27,49 @@ instance Semigroup References where
 
 instance Monoid References where
   mempty = References Set.empty Set.empty
+
+-- | Per-definition call edges and primitive declarations exported by one
+-- incremental unit. This is sufficient to validate the reachable primitive
+-- closure without reopening dependency bodies.
+data ReachabilityInterface = ReachabilityInterface
+  { reachabilityValueEdges :: !(Map Text (Set Text)),
+    reachabilityPrimitives :: !(Set Text)
+  }
+  deriving (Eq, Show, Read)
+
+instance Semigroup ReachabilityInterface where
+  left <> right =
+    ReachabilityInterface
+      { reachabilityValueEdges = reachabilityValueEdges left <> reachabilityValueEdges right,
+        reachabilityPrimitives = reachabilityPrimitives left <> reachabilityPrimitives right
+      }
+
+instance Monoid ReachabilityInterface where
+  mempty = ReachabilityInterface Map.empty Set.empty
+
+extractReachabilityInterface :: FcProgram -> ReachabilityInterface
+extractReachabilityInterface (FcProgram topBinds) =
+  ReachabilityInterface
+    { reachabilityValueEdges =
+        Map.fromList
+          [ (name, referencedValues references)
+          | topBind <- topBinds,
+            (name, references) <- valueDefinitionsOf topBind
+          ],
+      reachabilityPrimitives =
+        Set.fromList
+          [ varName var
+          | FcPrimitive var _ <- topBinds
+          ]
+    }
+
+reachablePrimitiveNames :: Text -> ReachabilityInterface -> Set Text
+reachablePrimitiveNames entry interface =
+  Set.intersection (close (Set.singleton entry)) (reachabilityPrimitives interface)
+  where
+    close values =
+      let values' = values <> foldMap (\name -> Map.findWithDefault Set.empty name (reachabilityValueEdges interface)) values
+       in if values' == values then values else close values'
 
 -- | Retain only the value and type declarations transitively reachable from
 -- the named entry point. The input is expected to be the combined program so

--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -6,8 +6,10 @@
 -- providing their representational equality axiom. Their term constructors
 -- and patterns are casts and lazy bindings; they never denote heap nodes.
 module Aihc.Fc.Newtype
-  ( lowerNewtypes,
-    lowerNewtypesPrograms,
+  ( NewtypeInterface,
+    extractNewtypeInterface,
+    lowerNewtypes,
+    lowerNewtypesWithInterface,
   )
 where
 
@@ -20,9 +22,18 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 
-newtype NewtypeEnv = NewtypeEnv
+newtype NewtypeInterface = NewtypeInterface
   { newtypesByConstructor :: Map Text FcNewtypeDecl
   }
+  deriving (Eq, Show, Read)
+
+instance Semigroup NewtypeInterface where
+  NewtypeInterface left <> NewtypeInterface right = NewtypeInterface (right <> left)
+
+instance Monoid NewtypeInterface where
+  mempty = NewtypeInterface Map.empty
+
+type NewtypeEnv = NewtypeInterface
 
 type LowerM = State Int
 
@@ -30,34 +41,27 @@ type LowerM = State Int
 -- Running this more than once is harmless, which lets callers normalize both
 -- individual modules and a later combined cross-module program.
 lowerNewtypes :: FcProgram -> FcProgram
-lowerNewtypes program@(FcProgram topBinds) =
+lowerNewtypes = lowerNewtypesWithInterface mempty
+
+-- | The representation information exported by one independently compiled
+-- unit. It contains declarations only; no term implementation crosses the
+-- incremental boundary.
+extractNewtypeInterface :: FcProgram -> NewtypeInterface
+extractNewtypeInterface (FcProgram topBinds) =
+  NewtypeInterface
+    ( Map.fromList
+        [ (fcNewtypeConstructor declaration, declaration)
+        | FcNewtype declaration <- topBinds
+        ]
+    )
+
+-- | Lower one compilation unit using declaration interfaces imported from
+-- already compiled units. Local declarations take precedence.
+lowerNewtypesWithInterface :: NewtypeInterface -> FcProgram -> FcProgram
+lowerNewtypesWithInterface imported program@(FcProgram topBinds) =
   FcProgram (evalState (mapM (lowerTopBind env) topBinds) (nextUnique program))
   where
-    env =
-      NewtypeEnv
-        { newtypesByConstructor =
-            Map.fromList
-              [ (fcNewtypeConstructor declaration, declaration)
-              | FcNewtype declaration <- topBinds
-              ]
-        }
-
--- | Lower newtypes across separately compiled units while preserving their
--- boundaries. Dependency declarations are available while rewriting every
--- unit, but dependency bindings do not become part of consumer units.
-lowerNewtypesPrograms :: [FcProgram] -> [FcProgram]
-lowerNewtypesPrograms sourcePrograms = splitPrograms sourcePrograms (lowerNewtypes (concatPrograms sourcePrograms))
-
-concatPrograms :: [FcProgram] -> FcProgram
-concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
-
-splitPrograms :: [FcProgram] -> FcProgram -> [FcProgram]
-splitPrograms sourcePrograms (FcProgram topBinds) = go sourcePrograms topBinds
-  where
-    go [] _ = []
-    go (FcProgram sourceTopBinds : rest) remaining =
-      let (unitTopBinds, remaining') = splitAt (length sourceTopBinds) remaining
-       in FcProgram unitTopBinds : go rest remaining'
+    env = imported <> extractNewtypeInterface program
 
 lowerTopBind :: NewtypeEnv -> FcTopBind -> LowerM FcTopBind
 lowerTopBind env topBind =

--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -7,6 +7,7 @@
 -- and patterns are casts and lazy bindings; they never denote heap nodes.
 module Aihc.Fc.Newtype
   ( lowerNewtypes,
+    lowerNewtypesPrograms,
   )
 where
 
@@ -40,6 +41,23 @@ lowerNewtypes program@(FcProgram topBinds) =
               | FcNewtype declaration <- topBinds
               ]
         }
+
+-- | Lower newtypes across separately compiled units while preserving their
+-- boundaries. Dependency declarations are available while rewriting every
+-- unit, but dependency bindings do not become part of consumer units.
+lowerNewtypesPrograms :: [FcProgram] -> [FcProgram]
+lowerNewtypesPrograms sourcePrograms = splitPrograms sourcePrograms (lowerNewtypes (concatPrograms sourcePrograms))
+
+concatPrograms :: [FcProgram] -> FcProgram
+concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
+
+splitPrograms :: [FcProgram] -> FcProgram -> [FcProgram]
+splitPrograms sourcePrograms (FcProgram topBinds) = go sourcePrograms topBinds
+  where
+    go [] _ = []
+    go (FcProgram sourceTopBinds : rest) remaining =
+      let (unitTopBinds, remaining') = splitAt (length sourceTopBinds) remaining
+       in FcProgram unitTopBinds : go rest remaining'
 
 lowerTopBind :: NewtypeEnv -> FcTopBind -> LowerM FcTopBind
 lowerTopBind env topBind =

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -144,9 +144,9 @@ fcOptimizationTests =
             consumer = FcProgram [FcTopBind (FcNonRec value (FcApp (FcVar constructor) literal))]
             loweredConsumer = FcProgram [FcTopBind (FcNonRec value (FcCast literal (Sym (AxiomInstCo "Wrapper" []))))]
         assertEqual
-          "separate programs"
-          [provider, loweredConsumer]
-          (lowerNewtypesPrograms [provider, consumer])
+          "consumer body"
+          loweredConsumer
+          (lowerNewtypesWithInterface (extractNewtypeInterface provider) consumer)
     ]
 
 fcEvalFixtureTests :: IO TestTree

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -11,6 +11,7 @@ where
 
 import Aihc.Fc
 import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
+import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Data.Text (Text)
 import FcGolden
@@ -124,7 +125,28 @@ fcOptimizationTests =
         assertEqual "idempotent lowering" lowered (lowerNewtypes lowered)
         assertEqual "Core lint" [] (lintProgram emptyLintEnv lowered)
         result <- evalProgramBinding "value" lowered >>= renderEvalResult
-        assertEqual "runtime representation" (Right "42") result
+        assertEqual "runtime representation" (Right "42") result,
+      testCase "lowers dependency newtypes without merging separate units" $ do
+        let wrapperTy = ty "Wrapper"
+            intHashTy = ty "Int#"
+            declaration =
+              FcNewtypeDecl
+                { fcNewtypeName = "Wrapper",
+                  fcNewtypeTyVars = [],
+                  fcNewtypeConstructor = "Wrap",
+                  fcNewtypeRepresentation = intHashTy,
+                  fcNewtypeResult = wrapperTy
+                }
+            constructor = Var "Wrap" (Unique 30) (TcFunTy intHashTy wrapperTy)
+            value = Var "value" (Unique 31) wrapperTy
+            literal = FcLit (LitInt IntRep 42)
+            provider = FcProgram [FcNewtype declaration]
+            consumer = FcProgram [FcTopBind (FcNonRec value (FcApp (FcVar constructor) literal))]
+            loweredConsumer = FcProgram [FcTopBind (FcNonRec value (FcCast literal (Sym (AxiomInstCo "Wrapper" []))))]
+        assertEqual
+          "separate programs"
+          [provider, loweredConsumer]
+          (lowerNewtypesPrograms [provider, consumer])
     ]
 
 fcEvalFixtureTests :: IO TestTree

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -2,7 +2,9 @@
 module Aihc.Grin
   ( module Aihc.Grin.Syntax,
     lowerProgram,
-    lowerPrograms,
+    GrinInterface,
+    extractGrinInterface,
+    lowerProgramWithInterface,
     lintProgram,
     GrinLintError (..),
     renderProgram,
@@ -16,6 +18,6 @@ where
 
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
-import Aihc.Grin.Lower (lowerProgram, lowerPrograms)
+import Aihc.Grin.Lower (GrinInterface, extractGrinInterface, lowerProgram, lowerProgramWithInterface)
 import Aihc.Grin.Pretty (renderExpr, renderProgram)
 import Aihc.Grin.Syntax

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -3,12 +3,14 @@
 
 -- | Lowering from non-strict System FC to strict, runtime-explicit GRIN.
 module Aihc.Grin.Lower
-  ( lowerProgram,
-    lowerPrograms,
+  ( GrinInterface,
+    extractGrinInterface,
+    lowerProgram,
+    lowerProgramWithInterface,
   )
 where
 
-import Aihc.Fc.Newtype (lowerNewtypes, lowerNewtypesPrograms)
+import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Syntax
@@ -64,19 +66,48 @@ instance Monoid LoweredTop where
 -- representations, closure-convert lambdas and thunks, and make evaluation,
 -- application, allocation, and exception control explicit.
 lowerProgram :: FcProgram -> GrinProgram
-lowerProgram sourceProgram = lowerProgramWithEnvironment (programEnvironment [program]) program
+lowerProgram sourceProgram = lowerProgramWithInterface mempty program
   where
     program = lowerNewtypes sourceProgram
 
--- | Lower separately compiled FC units with the complete set of global names
--- supplied by the compilation closure. A unit may refer to a constructor,
--- primitive, foreign import, or CAF defined in another unit, but generated
--- functions and local variables remain private to that unit.
-lowerPrograms :: [FcProgram] -> [GrinProgram]
-lowerPrograms sourcePrograms = map (lowerProgramWithEnvironment environment) programs
-  where
-    programs = lowerNewtypesPrograms sourcePrograms
-    environment = programEnvironment programs
+-- | Runtime facts exported by one compiled unit. Lowering consumers need to
+-- know which external names are globals, already in WHNF, or primitives, but
+-- never need the defining FC expressions.
+data GrinInterface = GrinInterface
+  { grinInterfaceGlobals :: !(Set Text),
+    grinInterfaceWhnfGlobals :: !(Set Text),
+    grinInterfacePrimitives :: !(Set Text)
+  }
+  deriving (Eq, Show, Read)
+
+instance Semigroup GrinInterface where
+  left <> right =
+    GrinInterface
+      { grinInterfaceGlobals = grinInterfaceGlobals left <> grinInterfaceGlobals right,
+        grinInterfaceWhnfGlobals = grinInterfaceWhnfGlobals left <> grinInterfaceWhnfGlobals right,
+        grinInterfacePrimitives = grinInterfacePrimitives left <> grinInterfacePrimitives right
+      }
+
+instance Monoid GrinInterface where
+  mempty = GrinInterface Set.empty Set.empty Set.empty
+
+extractGrinInterface :: FcProgram -> GrinInterface
+extractGrinInterface program =
+  GrinInterface
+    { grinInterfaceGlobals = Set.fromList (programGlobalNames program),
+      grinInterfaceWhnfGlobals = Set.fromList (programWhnfGlobalNames program),
+      grinInterfacePrimitives =
+        Set.fromList
+          [ varName var
+          | FcPrimitive var _ <- fcTopBinds program
+          ]
+    }
+
+-- | Lower one SCC using only the exported runtime facts of predecessor SCCs.
+-- The supplied program must already have completed its FC transformations.
+lowerProgramWithInterface :: GrinInterface -> FcProgram -> GrinProgram
+lowerProgramWithInterface imported program =
+  lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program)) program
 
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),
@@ -84,17 +115,12 @@ data ProgramEnvironment = ProgramEnvironment
     programEnvironmentPrimitives :: !(Set Text)
   }
 
-programEnvironment :: [FcProgram] -> ProgramEnvironment
-programEnvironment programs =
+programEnvironment :: GrinInterface -> ProgramEnvironment
+programEnvironment interface =
   ProgramEnvironment
-    { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors <> concatMap programGlobalNames programs),
-      programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors <> concatMap programWhnfGlobalNames programs),
-      programEnvironmentPrimitives =
-        Set.fromList
-          [ varName var
-          | program <- programs,
-            FcPrimitive var _ <- fcTopBinds program
-          ]
+    { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
+      programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
+      programEnvironmentPrimitives = grinInterfacePrimitives interface
     }
 
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -8,7 +8,7 @@ module Aihc.Grin.Lower
   )
 where
 
-import Aihc.Fc.Newtype (lowerNewtypes)
+import Aihc.Fc.Newtype (lowerNewtypes, lowerNewtypesPrograms)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Syntax
@@ -75,19 +75,8 @@ lowerProgram sourceProgram = lowerProgramWithEnvironment (programEnvironment [pr
 lowerPrograms :: [FcProgram] -> [GrinProgram]
 lowerPrograms sourcePrograms = map (lowerProgramWithEnvironment environment) programs
   where
-    programs = splitPrograms sourcePrograms (lowerNewtypes (concatPrograms sourcePrograms))
+    programs = lowerNewtypesPrograms sourcePrograms
     environment = programEnvironment programs
-
-concatPrograms :: [FcProgram] -> FcProgram
-concatPrograms programs = FcProgram (concatMap fcTopBinds programs)
-
-splitPrograms :: [FcProgram] -> FcProgram -> [FcProgram]
-splitPrograms sourcePrograms (FcProgram topBinds) = go sourcePrograms topBinds
-  where
-    go [] _ = []
-    go (FcProgram sourceTopBinds : rest) remaining =
-      let (unitTopBinds, remaining') = splitAt (length sourceTopBinds) remaining
-       in FcProgram unitTopBinds : go rest remaining'
 
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -45,7 +45,7 @@ data GrinProgram = GrinProgram
     grinCafs :: ![(GrinVar, GrinNode)],
     grinFunctions :: ![GrinFunction]
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | A first-order code definition. Closures and thunks refer to functions by
 -- name and carry their environment as node fields.
@@ -55,12 +55,12 @@ data GrinFunction = GrinFunction
     grinFunctionResultRep :: !RuntimeRep,
     grinFunctionBody :: !GrinExpr
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 newtype FunctionName = FunctionName
   { unFunctionName :: Text
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | GRIN erases source types but preserves the part of their kinds that
 -- determines the runtime ABI.
@@ -69,7 +69,7 @@ data GrinVar = GrinVar
     grinVarUnique :: !Int,
     grinVarRuntimeRep :: !RuntimeRep
   }
-  deriving (Show)
+  deriving (Show, Read)
 
 instance Eq GrinVar where
   left == right =
@@ -100,20 +100,20 @@ data GrinExpr
   | GrinCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
   | -- | A saturated call whose operands are already strict primitive values.
     GrinForeignCallExpr !GrinForeignCall ![GrinValue]
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 -- | Atomic operands in the strict language.
 data GrinValue
   = GrinVarValue !GrinVar
   | GrinLitValue !GrinLiteral
   | GrinNodeValue !GrinNode
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinNode = GrinNode
   { grinNodeTag :: !GrinNodeTag,
     grinNodeFields :: ![GrinValue]
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinNodeTag
   = GrinConstructor !Text
@@ -123,26 +123,26 @@ data GrinNodeTag
     GrinThunk !FunctionName
   | GrinPrimitive !Text !Int
   | GrinDictionary
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinAlt = GrinAlt
   { grinAltCon :: !GrinAltCon,
     grinAltBinders :: ![GrinVar],
     grinAltRhs :: !GrinExpr
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinAltCon
   = GrinDataAlt !Text
   | GrinLitAlt !GrinLiteral
   | GrinDefaultAlt
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinLiteral
   = GrinLitInt !RuntimeRep !Integer
   | GrinLitChar !RuntimeRep !Char
   | GrinLitString !Text
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 grinValueRuntimeRep :: GrinValue -> RuntimeRep
 grinValueRuntimeRep value =
@@ -193,24 +193,24 @@ data GrinForeignCall = GrinForeignCall
     grinForeignCallSymbol :: !Text,
     grinForeignCallSignature :: !GrinForeignSignature
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinForeignSignature = GrinForeignSignature
   { grinForeignArgumentTypes :: ![GrinForeignType],
     grinForeignResultType :: !GrinForeignType,
     grinForeignEffect :: !GrinForeignEffect
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinForeignEffect
   = GrinForeignPure
   | GrinForeignRealWorld
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 data GrinForeignType
   = GrinForeignInt32
   | GrinForeignWord64
-  deriving (Eq, Show)
+  deriving (Eq, Show, Read)
 
 grinForeignOperandReps :: GrinForeignSignature -> [RuntimeRep]
 grinForeignOperandReps signature =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -7,7 +7,7 @@ module Test.Grin.Suite
   )
 where
 
-import Aihc.Fc.Newtype (lowerNewtypes)
+import Aihc.Fc.Newtype (extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
 import Aihc.Fc.Syntax
 import Aihc.Grin
 import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), runtimeRepOfType)
@@ -96,18 +96,22 @@ grinUnitTests =
         assertEqual "direct function globals" ["direct"] (map (grinVarName . fst) (grinWhnfGlobals program))
         assertEqual "computed function CAFs" ["computed"] (map (grinVarName . fst) (grinCafs program)),
       testCase "separate FC units do not capture dependency globals" $ do
-        case lowerPrograms separatePrograms of
-          [_provider, consumer] -> do
-            let parameters = concatMap grinFunctionParameters (grinFunctions consumer)
+        case separatePrograms of
+          [providerCore, consumerCore] -> do
+            let consumer = lowerProgramWithInterface (extractGrinInterface providerCore) consumerCore
+                parameters = concatMap grinFunctionParameters (grinFunctions consumer)
             assertBool "dependency CAF remains global" (all ((/= "source") . grinVarName) parameters)
-          programs -> assertFailure ("expected two separately lowered programs, got " <> show (length programs)),
+          programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
       testCase "separate FC units erase dependency newtypes" $ do
-        case lowerPrograms separateNewtypePrograms of
-          [provider, consumer] -> do
+        case separateNewtypePrograms of
+          [providerCore, sourceConsumer] -> do
+            let consumerCore = lowerNewtypesWithInterface (extractNewtypeInterface providerCore) sourceConsumer
+                provider = lowerProgram providerCore
+                consumer = lowerProgramWithInterface (extractGrinInterface providerCore) consumerCore
             assertEqual "newtype declaration emits no constructor" [] (grinConstructors provider)
             assertEqual "consumer lint" [] (lintProgram consumer)
             assertBool "newtype constructor is erased across units" (not ("Wrap" `isInfixOf` renderProgram consumer))
-          programs -> assertFailure ("expected two separately lowered programs, got " <> show (length programs))
+          programs -> assertFailure ("expected two FC programs, got " <> show (length programs))
     ]
 
 grinGoldenTests :: IO TestTree

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -11,6 +11,7 @@ module Aihc.Resolve
     resolve,
     resolveWithDeps,
     extractInterface,
+    extractInterfaceWithDeps,
     OperatorFixity (..),
     Scope (..),
     ModuleExports,
@@ -199,6 +200,9 @@ resolveWithDeps depExports modules =
 
 extractInterface :: ResolveResult -> ModuleExports
 extractInterface = collectModuleExports . resolvedModules
+
+extractInterfaceWithDeps :: ModuleExports -> ResolveResult -> ModuleExports
+extractInterfaceWithDeps depExports = collectModuleExportsWithDeps depExports . resolvedModules
 
 resolveModule :: ModuleExports -> Int -> Module -> (Int, Module)
 resolveModule exports nextLocal modu =

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -5,6 +5,7 @@ module Aihc.Resolve.Scope
     OperatorFixity (..),
     ModuleExports,
     collectModuleExports,
+    collectModuleExportsWithDeps,
     moduleScope,
     moduleKey,
     emptyScope,
@@ -91,20 +92,26 @@ data OperatorFixity = OperatorFixity
 type ModuleExports = Map.Map Text Scope
 
 collectModuleExports :: [Module] -> ModuleExports
-collectModuleExports modules = closeExports initialExports
+collectModuleExports = collectModuleExportsWithDeps Map.empty
+
+-- | Extract interfaces for a compilation unit while allowing its explicit
+-- export lists to re-export names supplied by predecessor units.
+collectModuleExportsWithDeps :: ModuleExports -> [Module] -> ModuleExports
+collectModuleExportsWithDeps depExports modules = Map.restrictKeys (closeExports initialExports) moduleKeys
   where
-    initialExports =
+    moduleKeys = Map.keysSet localExports
+    localExports =
       Map.fromList
         [ (moduleKey modu, emptyScope)
         | modu <- modules
         ]
+    initialExports =
+      localExports `Map.union` depExports
 
     closeExports exports =
       let exports' =
-            Map.fromList
-              [ (moduleKey modu, exportedScope exports modu)
-              | modu <- modules
-              ]
+            Map.fromList [(moduleKey modu, exportedScope exports modu) | modu <- modules]
+              `Map.union` depExports
        in if exports' == exports then exports else closeExports exports'
 
 exportedScope :: ModuleExports -> Module -> Scope

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -22,6 +22,7 @@ module Aihc.Tc
     typecheckModulesWithEnv,
     typecheckModulesWithEnvAndInstances,
     typecheckModulesWithFullEnv,
+    typecheckModuleSccWithFullEnv,
 
     -- * Result types
     TcResult (..),
@@ -93,7 +94,7 @@ import Aihc.Parser.Syntax
 import Aihc.Tc.Annotations (TcAnnotation (..), renderPred, renderTcSignature, renderTcType)
 import Aihc.Tc.Env (InstanceInfo (..), TyConInfo (..))
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
-import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleInstances, tcModule)
+import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleInstances, tcModule, tcModuleScc)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
@@ -245,6 +246,88 @@ typecheckModulesWithFullEnv importedTerms importedTyCons importedInstances modul
       let (result, st') = typecheckModuleWithState st m
           (results, finalState) = go st' ms
        in (result : results, finalState)
+
+-- | Type-check the modules in one strongly connected import component as a
+-- single incremental unit. Only the supplied imported interface is visible;
+-- implementations from predecessor components are never consumed.
+typecheckModuleSccWithFullEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo])
+typecheckModuleSccWithFullEnv importedTerms importedTyCons importedInstances modules =
+  let initState = initialTcState importedTerms importedTyCons importedInstances
+      (checkedModules, finalState) = typecheckModuleSccWithState initState modules
+   in ( checkedModules,
+        [ (name, scheme)
+        | (name, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms finalState)
+        ],
+        Map.elems (tcsGlobalTyCons finalState)
+      )
+
+initialTcState :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> TcState
+initialTcState importedTerms importedTyCons importedInstances =
+  initTcState
+    { tcsGlobalTerms =
+        Map.fromList
+          [ (name, TcIdBinder scheme Closed)
+          | (name, scheme) <- importedTerms
+          ]
+          <> tcsGlobalTerms initTcState,
+      tcsGlobalTyCons =
+        Map.fromList
+          [ (tciName tyCon, tyCon)
+          | tyCon <- importedTyCons
+          ]
+          <> tcsGlobalTyCons initTcState,
+      tcsInstances = importedInstances
+    }
+
+typecheckModuleSccWithState :: TcState -> [Module] -> ([Module], TcState)
+typecheckModuleSccWithState st modules =
+  case runTcM tcEnv (st {tcsDiagnostics = []}) (tcModuleScc modules) of
+    Left abort ->
+      ( case modules of
+          [] -> []
+          first : rest -> annotateModuleDiagnostics [internalAbortDiagnostic (tcAbortMessage abort)] first : rest,
+        st
+      )
+    Right (annotatedModules, st') ->
+      let diags = reverse (tcsDiagnostics st')
+          results = attachSccDiagnostics diags annotatedModules
+          nextState =
+            st'
+              { tcsDiagnostics = [],
+                tcsMetaSolutions = Map.empty,
+                tcsKindSolutions = Map.empty,
+                tcsEvBinds = Map.empty
+              }
+       in (results, nextState)
+  where
+    tcEnv =
+      emptyTcEnv
+        { tcEnvMonoLocalBinds = any (elem MonoLocalBinds . moduleExtensions) modules,
+          tcEnvMonomorphismRestriction = any (elem MonomorphismRestriction . moduleExtensions) modules
+        }
+    moduleExtensions m =
+      applyImpliedExtensions $
+        foldr applyExtensionSetting [MonoLocalBinds, MonomorphismRestriction] (moduleLanguagePragmas m)
+
+attachSccDiagnostics :: [TcDiagnostic] -> [Module] -> [Module]
+attachSccDiagnostics diagnostics modules = foldl attachOne modules diagnostics
+  where
+    attachOne [] _ = []
+    attachOne current@(first : rest) diagnostic =
+      case diagLoc diagnostic of
+        Nothing -> annotateModuleDiagnostics [diagnostic] first : rest
+        Just span' ->
+          let sourceName = sourceSpanSourceName span'
+              matches m = sourceName `elem` moduleSourceNames m
+           in if any matches current
+                then map (\m -> if matches m then annotateModuleDiagnostics [diagnostic] m else m) current
+                else annotateModuleDiagnostics [internalAbortDiagnostic "SCC diagnostic source did not match a module"] first : rest
+
+moduleSourceNames :: Module -> [FilePath]
+moduleSourceNames modu =
+  case spanFromAnnotations (moduleAnns modu) of
+    SourceSpan {sourceSpanSourceName = sourceName} -> [sourceName]
+    NoSourceSpan -> []
 
 typecheckModuleWithState :: TcState -> Module -> (Module, TcState)
 typecheckModuleWithState st m =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -8,6 +8,7 @@
 -- Processes top-level data declarations and value bindings from a module.
 module Aihc.Tc.Generate.Decl
   ( tcModule,
+    tcModuleScc,
     moduleBindings,
     moduleInstances,
     TcBindingResult (..),
@@ -288,12 +289,40 @@ dataConBindingName name =
 -- needed by older callers.
 tcModule :: Module -> TcM Module
 tcModule m = do
+  modules <- tcModuleScc [m]
+  case modules of
+    [result] -> pure result
+    _ -> pure m
+
+-- | Type-check one strongly connected module component. Data declarations and
+-- explicit signatures are registered for the whole component before any
+-- value body is checked, allowing a module to refer back to a signed binding
+-- in another member of the same import cycle.
+tcModuleScc :: [Module] -> TcM [Module]
+tcModuleScc modules = do
   -- Phase 1: collect data declarations, register constructors,
   --          and report their types.
-  mapM_ registerDecl (moduleDecls m)
+  mapM_ registerDecl (concatMap moduleDecls modules)
   -- Phase 2: collect type signatures and convert them to schemes.
-  rawSigs <- collectUserSigs (moduleDecls m)
-  schemes <- traverse checkUserSig rawSigs
+  rawSigs <- mapM (collectUserSigs . moduleDecls) modules
+  schemes <- mapM (traverse checkUserSig) rawSigs
+  mapM_ registerCheckedSig (concatMap Map.elems schemes)
+  pending <- zipWithM tcModuleBody schemes modules
+  -- No module interface in the SCC may retain state-local kind metavariables.
+  defaultGlobalKindMetas
+  mapM finishPendingModule pending
+
+registerCheckedSig :: CheckedSig -> TcM ()
+registerCheckedSig sig =
+  extendTermEnvPermanent (checkedSigName sig) (TcIdBinder (checkedSigScheme sig) Closed)
+
+data PendingModule = PendingModule
+  { pendingSyntax :: !Module,
+    pendingValueResults :: ![TcBindingResult]
+  }
+
+tcModuleBody :: Map TcTermKey CheckedSig -> Module -> TcM PendingModule
+tcModuleBody schemes m = do
   -- Phase 3: group and type-check value bindings using signatures.
   let sourceGroups = zip [0 :: Int ..] (groupValueDecls (moduleDecls m))
   grouped <- sortDeclGroups sourceGroups
@@ -312,17 +341,18 @@ tcModule m = do
   -- and evidence records as ordinary expressions.
   instanceDecls <- mapM tcInstanceDeclBodies (moduleDecls valueAnnotatedModule)
   let pendingModule = valueAnnotatedModule {moduleDecls = instanceDecls}
-  -- A module interface must never retain state-local kind metavariables: the
-  -- kind solution map is deliberately cleared before the next module.
-  defaultGlobalKindMetas
   -- Phase 5: reject source top-level values whose finalized types are
   -- unlifted. Generated declarations without source spans are permitted so
   -- downstream passes can introduce internal unlifted bindings.
   checkTopLevelUnliftedBindings sourceGroups groupResults
+  pure (PendingModule pendingModule valueResults)
+
+finishPendingModule :: PendingModule -> TcM Module
+finishPendingModule pending = do
   -- Only bindings that checked without errors are eligible for value
   -- annotations. Failed bindings remain in the recovery environment, but
   -- they must not be rendered as successful inferred types.
-  annotatedModule <- annotateModuleTc (Set.fromList (map tbName valueResults)) pendingModule
+  annotatedModule <- annotateModuleTc (Set.fromList (map tbName (pendingValueResults pending))) (pendingSyntax pending)
   finalizeModuleTc annotatedModule
 
 defaultGlobalKindMetas :: TcM ()


### PR DESCRIPTION
## Summary

- make a strongly connected set of mutually recursive modules the atomic incremental compilation unit
- compile dependency SCCs in topological order and cache one normalized Core program, GRIN program, and native object per SCC
- pass only explicit interfaces between SCCs: resolver exports, type/kind/evidence facts, newtype declarations, GRIN global/WHNF/primitive facts, primitive reachability edges, and native link layout metadata
- pre-register declarations and explicit signatures across each SCC before checking member bodies
- preserve imported re-exports when extracting a downstream resolver interface
- keep normal `--keep-core` and `--keep-grin` artifacts limited to the main SCC
- retain whole-program compilation as an additional phase that merges already-compiled SCC Core programs and then runs whole-program DCE

## Architecture

Dependency discovery now condenses the import graph with `stronglyConnComp`. Each SCC is resolved, typechecked, desugared, newtype-lowered, GRIN-lowered, summarized, cached, and code-generated without reading implementation bodies from predecessor SCCs.

The interfaces are deliberately stage-specific:

- resolver: exported scopes, including imported re-exports
- typechecker/desugarer: term schemes, type constructors, instances, and binding names/types
- FC newtype lowering: newtype declarations only
- GRIN lowering: external global, WHNF-global, and primitive names only
- primitive validation: per-definition reachability edges and primitive declarations
- ARM64 layout: constructor arities and global names only

Mutually recursive modules are compiled together. Their data declarations and explicit signatures are installed for the complete SCC before value bodies are checked, so signed cross-module recursion is available in both directions.

## Whole-program compilation

Whole-program compilation is not a separate frontend path. The compiler always produces the per-SCC Core and GRIN structures first. When `--whole-program` is selected, a later phase freshens and merges the incremental Core units, performs global DCE, and lowers the reachable merged program.

## Impact

Incremental artifacts contain external dependency references but not dependency implementations. Dependency GRIN and native layout are now read from cached SCC artifacts/interfaces instead of being reconstructed from the complete dependency Core closure. Reachable primitive validation similarly traverses interface summaries and no longer creates a hidden whole-program GRIN value during incremental compilation.

## Progress counts

- CLI tests: 65 → 66
- Added one end-to-end regression proving a two-module import cycle compiles as one SCC/native object and supports signed cross-module references
- Updated FC and GRIN unit coverage to exercise explicit interface-driven lowering rather than closure-wide batch helpers
- README progress files: unchanged, as required

## Validation

- `just fmt`
- `just check` (2,526 tests passed)
