### PR TITLE
refactor(fc): represent dictionaries as ordinary data

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -325,8 +325,8 @@ shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBi
         FcLam var body -> FcLam (shiftVar var) (shiftExpr body)
         FcTyLam tyVar body -> FcTyLam tyVar (shiftExpr body)
         FcDictLam var body -> FcDictLam (shiftVar var) (shiftExpr body)
-        FcDict fields -> FcDict (map shiftExpr fields)
-        FcDictSelect dictionary index -> FcDictSelect (shiftExpr dictionary) index
+        FcDict constructor fields -> FcDict constructor (map shiftExpr fields)
+        FcDictSelect constructor dictionary index -> FcDictSelect constructor (shiftExpr dictionary) index
         FcLet bind body -> FcLet (shiftBind bind) (shiftExpr body)
         FcCase scrutinee binder alternatives ->
           FcCase (shiftExpr scrutinee) (shiftVar binder) (map shiftAlt alternatives)
@@ -368,8 +368,8 @@ exprVars expression =
     FcLam var body -> var : exprVars body
     FcTyLam _ body -> exprVars body
     FcDictLam var body -> var : exprVars body
-    FcDict fields -> concatMap exprVars fields
-    FcDictSelect dictionary _ -> exprVars dictionary
+    FcDict _ fields -> concatMap exprVars fields
+    FcDictSelect _ dictionary _ -> exprVars dictionary
     FcLet bind body -> bindVarsDeep bind <> exprVars body
     FcCase scrutinee binder alternatives -> exprVars scrutinee <> (binder : concatMap altVars alternatives)
     FcCast inner _ -> exprVars inner

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -320,13 +320,9 @@ shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBi
         FcVar var -> FcVar (shiftVar var)
         FcLit {} -> expression
         FcApp function argument -> FcApp (shiftExpr function) (shiftExpr argument)
-        FcDictApp function argument -> FcDictApp (shiftExpr function) (shiftExpr argument)
         FcTyApp inner ty -> FcTyApp (shiftExpr inner) ty
         FcLam var body -> FcLam (shiftVar var) (shiftExpr body)
         FcTyLam tyVar body -> FcTyLam tyVar (shiftExpr body)
-        FcDictLam var body -> FcDictLam (shiftVar var) (shiftExpr body)
-        FcDict constructor fields -> FcDict constructor (map shiftExpr fields)
-        FcDictSelect constructor dictionary index -> FcDictSelect constructor (shiftExpr dictionary) index
         FcLet bind body -> FcLet (shiftBind bind) (shiftExpr body)
         FcCase scrutinee binder alternatives ->
           FcCase (shiftExpr scrutinee) (shiftVar binder) (map shiftAlt alternatives)
@@ -363,13 +359,9 @@ exprVars expression =
     FcVar var -> [var]
     FcLit {} -> []
     FcApp function argument -> exprVars function <> exprVars argument
-    FcDictApp function argument -> exprVars function <> exprVars argument
     FcTyApp inner _ -> exprVars inner
     FcLam var body -> var : exprVars body
     FcTyLam _ body -> exprVars body
-    FcDictLam var body -> var : exprVars body
-    FcDict _ fields -> concatMap exprVars fields
-    FcDictSelect _ dictionary _ -> exprVars dictionary
     FcLet bind body -> bindVarsDeep bind <> exprVars body
     FcCase scrutinee binder alternatives -> exprVars scrutinee <> (binder : concatMap altVars alternatives)
     FcCast inner _ -> exprVars inner

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -712,7 +712,9 @@ test_checksCastStyleDependencyId =
 
     result <- expectInstallSuccess (writeInstallScaffold plan)
     fcJson <- BL8.readFile (resultFcPath result)
-    assertBool "FC artifact applies imported id" ("{id @a}" `isInfixOf` BL8.unpack fcJson)
+    let renderedFc = BL8.unpack fcJson
+    assertBool "FC artifact constructs an ordinary Cast dictionary" ("$Dict$Cast @a @a" `isInfixOf` renderedFc)
+    assertBool "FC artifact applies imported id" ("id @a" `isInfixOf` renderedFc)
 
 test_checksConstraintKindedMultiParameterClasses :: Assertion
 test_checksConstraintKindedMultiParameterClasses =

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -157,13 +157,6 @@ void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field) {
   value->fields[index] = field;
 }
 
-AihcSlot aihc_project(AihcValue *object, uint64_t index) {
-  if (object->kind != AIHC_CONSTRUCTOR || index >= object->count) {
-    aihc_fail("invalid constructor projection");
-  }
-  return object->fields[index];
-}
-
 void aihc_set_cell(AihcValue *cell, AihcValue *value) {
   if (cell->kind != AIHC_CELL) {
     aihc_fail("attempted to initialize a non-cell");

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -8,9 +8,8 @@ enum {
   AIHC_CLOSURE = 2,
   AIHC_THUNK = 3,
   AIHC_PRIMITIVE = 4,
-  AIHC_DICTIONARY = 7,
-  AIHC_CELL = 8,
-  AIHC_STATE_TOKEN = 9,
+  AIHC_CELL = 5,
+  AIHC_STATE_TOKEN = 6,
 };
 
 enum {
@@ -25,7 +24,6 @@ enum {
   AIHC_CONT_APPLY = 2,
   AIHC_CONT_TOP = 3,
   AIHC_CONT_FINAL = 4,
-  AIHC_CONT_SELECT = 5,
 };
 
 enum {
@@ -63,10 +61,6 @@ struct AihcContinuation {
       AihcSlot *arguments;
       uint64_t count;
     } apply;
-    struct {
-      uint64_t index;
-      uint64_t result_is_lifted;
-    } select;
   } payload;
 };
 
@@ -161,6 +155,13 @@ void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field) {
     aihc_fail("field index out of bounds");
   }
   value->fields[index] = field;
+}
+
+AihcSlot aihc_project(AihcValue *object, uint64_t index) {
+  if (object->kind != AIHC_CONSTRUCTOR || index >= object->count) {
+    aihc_fail("invalid constructor projection");
+  }
+  return object->fields[index];
 }
 
 void aihc_set_cell(AihcValue *cell, AihcValue *value) {
@@ -337,24 +338,6 @@ static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
     machine->locals = NULL;
     machine->next = machine->exit_code;
     return;
-  case AIHC_CONT_SELECT: {
-    if (count != 1) {
-      aihc_fail("dictionary evaluation returned multiple values");
-    }
-    AihcValue *dictionary = (AihcValue *)values[0];
-    if (dictionary->kind != AIHC_DICTIONARY ||
-        continuation->payload.select.index >= dictionary->count) {
-      aihc_fail("invalid dictionary selection");
-    }
-    AihcSlot selected =
-        dictionary->fields[continuation->payload.select.index];
-    if (continuation->payload.select.result_is_lifted) {
-      aihc_eval_value(machine, (AihcValue *)selected, 1);
-    } else {
-      aihc_return_value(machine, selected);
-    }
-    return;
-  }
   default:
     aihc_fail("unknown continuation kind");
   }
@@ -386,15 +369,6 @@ void aihc_apply(AihcMachine *machine, AihcValue *function,
 void aihc_apply_values(AihcMachine *machine, AihcValue *function,
                        uint64_t count, const AihcSlot *arguments) {
   aihc_apply_values_internal(machine, function, count, arguments);
-}
-
-void aihc_select(AihcMachine *machine, AihcValue *dictionary,
-                 uint64_t index, uint64_t result_is_lifted) {
-  AihcContinuation *continuation =
-      aihc_push_special(machine, AIHC_CONT_SELECT);
-  continuation->payload.select.index = index;
-  continuation->payload.select.result_is_lifted = result_is_lifted;
-  aihc_eval_value(machine, dictionary, 1);
 }
 
 void aihc_start(AihcMachine *machine, AihcValue *root, void *exit_code) {

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -374,19 +374,16 @@ compileExpr env prefix label expression =
         )
     GrinCase scrutinee binder alternatives ->
       compileCase env prefix label scrutinee binder alternatives
-    GrinDictSelect runtimeRep dictionary index -> do
-      dictionaryLines <- liftEither (materializeValue env dictionary)
+    GrinProject _ object index -> do
+      objectLines <- liftEither (materializeValue env object)
       addBlock
         label
         ( prefix
-            <> dictionaryLines
-            <> [ "  mov x1, x0",
-                 immediate "x2" index,
-                 immediate "x3" (fromEnum (isLiftedRuntimeRep runtimeRep)),
-                 "  mov x0, x22",
-                 "  bl _aihc_select"
+            <> objectLines
+            <> [ immediate "x1" index,
+                 "  bl _aihc_project"
                ]
-            <> dispatchLines
+            <> returnLines
         )
     GrinThrow {} -> unsupportedExpression "throw"
     GrinCatch {} -> unsupportedExpression "catch"
@@ -630,7 +627,6 @@ nodeHeader env node =
     GrinPrimitive name arity -> do
       identifier <- primitiveId compileEnv name
       pure (4, InfoImmediate identifier, arity)
-    GrinDictionary -> pure (7, InfoImmediate 0, length (grinNodeFields node))
   where
     compileEnv = valueCompileEnv env
 
@@ -800,7 +796,7 @@ boundVarGroups expression =
     GrinEval _ _ -> []
     GrinApply {} -> []
     GrinCase _ binder alternatives -> [binder] : concatMap altBoundVarGroups alternatives
-    GrinDictSelect {} -> []
+    GrinProject {} -> []
     GrinThrow _ -> []
     GrinCatch {} -> []
     GrinForeignCallExpr {} -> []
@@ -868,7 +864,7 @@ exprRuntimeReps expression =
     GrinCase scrutinee binder alternatives ->
       valueRuntimeReps scrutinee
         <> (grinVarRuntimeRep binder : concatMap altRuntimeReps alternatives)
-    GrinDictSelect runtimeRep dictionary _ -> runtimeRep : valueRuntimeReps dictionary
+    GrinProject runtimeRep object _ -> runtimeRep : valueRuntimeReps object
     GrinThrow exception -> valueRuntimeReps exception
     GrinCatch runtimeRep action handler state ->
       runtimeRep : concatMap valueRuntimeReps (action : handler : state)

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -374,17 +374,6 @@ compileExpr env prefix label expression =
         )
     GrinCase scrutinee binder alternatives ->
       compileCase env prefix label scrutinee binder alternatives
-    GrinProject _ object index -> do
-      objectLines <- liftEither (materializeValue env object)
-      addBlock
-        label
-        ( prefix
-            <> objectLines
-            <> [ immediate "x1" index,
-                 "  bl _aihc_project"
-               ]
-            <> returnLines
-        )
     GrinThrow {} -> unsupportedExpression "throw"
     GrinCatch {} -> unsupportedExpression "catch"
     GrinForeignCallExpr foreignCall arguments ->
@@ -796,7 +785,6 @@ boundVarGroups expression =
     GrinEval _ _ -> []
     GrinApply {} -> []
     GrinCase _ binder alternatives -> [binder] : concatMap altBoundVarGroups alternatives
-    GrinProject {} -> []
     GrinThrow _ -> []
     GrinCatch {} -> []
     GrinForeignCallExpr {} -> []
@@ -864,7 +852,6 @@ exprRuntimeReps expression =
     GrinCase scrutinee binder alternatives ->
       valueRuntimeReps scrutinee
         <> (grinVarRuntimeRep binder : concatMap altRuntimeReps alternatives)
-    GrinProject runtimeRep object _ -> runtimeRep : valueRuntimeReps object
     GrinThrow exception -> valueRuntimeReps exception
     GrinCatch runtimeRep action handler state ->
       runtimeRep : concatMap valueRuntimeReps (action : handler : state)

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -146,6 +146,30 @@ tests =
             assertBool "returns two values" ("ldr x1, =2" `T.isInfixOf` assembly)
             assertBool "uses the multi-value return ABI" ("bl _aihc_return_values" `T.isInfixOf` assembly)
             assertBool "does not allocate an aggregate node" (not ("bl _aihc_make_node" `T.isInfixOf` assembly)),
+      testCase "compiles ordinary constructor projection" $ do
+        let object = GrinVar "object" 1 (BoxedRep Lifted)
+            functionName = FunctionName "project_code"
+            program =
+              GrinProgram
+                { grinConstructors = [("Pair", [IntRep, IntRep])],
+                  grinPrimitives = [],
+                  grinForeignCalls = [],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = functionName,
+                          grinFunctionParameters = [object],
+                          grinFunctionResultRep = IntRep,
+                          grinFunctionBody = GrinProject IntRep (GrinVarValue object) 1
+                        }
+                    ]
+                }
+        case compileModule (buildLinkLayout [program]) "_aihc_init_project" program of
+          Left err -> assertFailure ("native projection compilation failed: " <> show err)
+          Right assembly -> do
+            assertBool "uses the general projection helper" ("bl _aihc_project" `T.isInfixOf` assembly)
+            assertBool "has no dictionary selector" (not ("_aihc_select" `T.isInfixOf` assembly)),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -146,30 +146,6 @@ tests =
             assertBool "returns two values" ("ldr x1, =2" `T.isInfixOf` assembly)
             assertBool "uses the multi-value return ABI" ("bl _aihc_return_values" `T.isInfixOf` assembly)
             assertBool "does not allocate an aggregate node" (not ("bl _aihc_make_node" `T.isInfixOf` assembly)),
-      testCase "compiles ordinary constructor projection" $ do
-        let object = GrinVar "object" 1 (BoxedRep Lifted)
-            functionName = FunctionName "project_code"
-            program =
-              GrinProgram
-                { grinConstructors = [("Pair", [IntRep, IntRep])],
-                  grinPrimitives = [],
-                  grinForeignCalls = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
-                  grinFunctions =
-                    [ GrinFunction
-                        { grinFunctionName = functionName,
-                          grinFunctionParameters = [object],
-                          grinFunctionResultRep = IntRep,
-                          grinFunctionBody = GrinProject IntRep (GrinVarValue object) 1
-                        }
-                    ]
-                }
-        case compileModule (buildLinkLayout [program]) "_aihc_init_project" program of
-          Left err -> assertFailure ("native projection compilation failed: " <> show err)
-          Right assembly -> do
-            assertBool "uses the general projection helper" ("bl _aihc_project" `T.isInfixOf` assembly)
-            assertBool "has no dictionary selector" (not ("_aihc_select" `T.isInfixOf` assembly)),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -186,8 +186,12 @@ referencesExpr bound expression =
     FcLam var body -> referencesVarType var <> referencesExpr (Set.insert var bound) body
     FcTyLam _ body -> referencesExpr bound body
     FcDictLam var body -> referencesVarType var <> referencesExpr (Set.insert var bound) body
-    FcDict fields -> foldMap (referencesExpr bound) fields
-    FcDictSelect dictionary _ -> referencesExpr bound dictionary
+    FcDict constructor fields ->
+      mempty {referencedValues = Set.singleton constructor}
+        <> foldMap (referencesExpr bound) fields
+    FcDictSelect constructor dictionary _ ->
+      mempty {referencedValues = Set.singleton constructor}
+        <> referencesExpr bound dictionary
     FcLet bind body -> referencesLet bound bind body
     FcCase scrutinee binder alternatives ->
       referencesExpr bound scrutinee

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -181,17 +181,9 @@ referencesExpr bound expression =
       | otherwise -> mempty {referencedValues = Set.singleton (varName var)} <> referencesVarType var
     FcLit literal -> foldMap referencesType (literalType literal)
     FcApp function argument -> referencesExpr bound function <> referencesExpr bound argument
-    FcDictApp function argument -> referencesExpr bound function <> referencesExpr bound argument
     FcTyApp inner ty -> referencesExpr bound inner <> referencesType ty
     FcLam var body -> referencesVarType var <> referencesExpr (Set.insert var bound) body
     FcTyLam _ body -> referencesExpr bound body
-    FcDictLam var body -> referencesVarType var <> referencesExpr (Set.insert var bound) body
-    FcDict constructor fields ->
-      mempty {referencedValues = Set.singleton constructor}
-        <> foldMap (referencesExpr bound) fields
-    FcDictSelect constructor dictionary _ ->
-      mempty {referencedValues = Set.singleton constructor}
-        <> referencesExpr bound dictionary
     FcLet bind body -> referencesLet bound bind body
     FcCase scrutinee binder alternatives ->
       referencesExpr bound scrutinee

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -37,9 +37,11 @@ import Aihc.Parser.Syntax
     NewtypeDecl (..),
     Pattern (..),
     Rhs,
+    TyVarBinder (..),
     UnqualifiedName (..),
     ValueDecl (..),
     binderHeadName,
+    binderHeadParams,
     fromAnnotation,
     peelDeclAnn,
     unqualifiedNameText,
@@ -47,6 +49,7 @@ import Aihc.Parser.Syntax
 import Aihc.Resolve (ResolveResult (..), resolve)
 import Aihc.Tc (TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
+import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, zipWithM)
@@ -103,10 +106,80 @@ desugarModuleWithBindings bindings tcResult _m =
                 }
             Right (binds, _) ->
               DesugarResult
-                { dsProgram = lowerNewtypes (FcProgram binds),
+                { dsProgram = lowerConstraintProgram (lowerNewtypes (FcProgram binds)),
                   dsSuccess = True,
                   dsErrors = []
                 }
+
+-- | Type-class evidence is ordinary term-level data in FC. Replace qualified
+-- source types with explicit dictionary arrows after desugaring has consumed
+-- their predicate structure.
+lowerConstraintProgram :: FcProgram -> FcProgram
+lowerConstraintProgram (FcProgram topBinds) =
+  FcProgram (map lowerTopBind topBinds)
+  where
+    lowerTopBind topBind =
+      case topBind of
+        FcData name tyVars constructors ->
+          FcData name tyVars [(constructor, map lowerConstraintType fields) | (constructor, fields) <- constructors]
+        FcNewtype declaration ->
+          FcNewtype
+            declaration
+              { fcNewtypeRepresentation = lowerConstraintType (fcNewtypeRepresentation declaration),
+                fcNewtypeResult = lowerConstraintType (fcNewtypeResult declaration)
+              }
+        FcPrimitive var arity -> FcPrimitive (lowerVar var) arity
+        FcForeignImport foreignCall -> FcForeignImport foreignCall
+        FcTopBind bind -> FcTopBind (lowerBind bind)
+
+    lowerBind bind =
+      case bind of
+        FcNonRec var expression -> FcNonRec (lowerVar var) (lowerExpr expression)
+        FcRec bindings -> FcRec [(lowerVar var, lowerExpr expression) | (var, expression) <- bindings]
+
+    lowerExpr expression =
+      case expression of
+        FcVar var -> FcVar (lowerVar var)
+        FcLit {} -> expression
+        FcApp function argument -> FcApp (lowerExpr function) (lowerExpr argument)
+        FcTyApp function ty -> FcTyApp (lowerExpr function) (lowerConstraintType ty)
+        FcLam var body -> FcLam (lowerVar var) (lowerExpr body)
+        FcTyLam tyVar body -> FcTyLam tyVar (lowerExpr body)
+        FcLet bind body -> FcLet (lowerBind bind) (lowerExpr body)
+        FcCase scrutinee binder alternatives ->
+          FcCase (lowerExpr scrutinee) (lowerVar binder) (map lowerAlt alternatives)
+        FcCast inner coercion -> FcCast (lowerExpr inner) (lowerCoercion coercion)
+        FcCallForeign foreignCall arguments -> FcCallForeign foreignCall (map lowerExpr arguments)
+
+    lowerAlt alternative =
+      alternative
+        { altBinders = map lowerVar (altBinders alternative),
+          altRhs = lowerExpr (altRhs alternative)
+        }
+
+    lowerVar var = var {varType = lowerConstraintType (varType var)}
+
+lowerConstraintType :: TcType -> TcType
+lowerConstraintType ty =
+  case ty of
+    TcTyVar {} -> ty
+    TcMetaTv {} -> ty
+    TcTyCon tyCon arguments -> TcTyCon tyCon (map lowerConstraintType arguments)
+    TcFunTy argument result -> TcFunTy (lowerConstraintType argument) (lowerConstraintType result)
+    TcForAllTy tyVar body -> TcForAllTy tyVar (lowerConstraintType body)
+    TcQualTy predicates body ->
+      foldr (TcFunTy . lowerConstraintType . predType) (lowerConstraintType body) predicates
+    TcAppTy function argument -> TcAppTy (lowerConstraintType function) (lowerConstraintType argument)
+
+lowerCoercion :: Coercion -> Coercion
+lowerCoercion coercion =
+  case coercion of
+    CoVar {} -> coercion
+    Refl ty -> Refl (lowerConstraintType ty)
+    Sym inner -> Sym (lowerCoercion inner)
+    Trans left right -> Trans (lowerCoercion left) (lowerCoercion right)
+    TyConAppCo tyCon coercions -> TyConAppCo tyCon (map lowerCoercion coercions)
+    AxiomInstCo name types -> AxiomInstCo name (map lowerConstraintType types)
 
 -- | Format a binding result for error messages.
 showBinding :: TcBindingResult -> String
@@ -537,29 +610,45 @@ dataConFieldTypes name arity ty =
 
 dsClassDeclM :: ClassDecl -> TcClassAnnotation -> DsM [FcTopBind]
 dsClassDeclM classDecl classAnn = do
-  selectors <- mapM (dsClassSelector dictionaryConstructor) methods
+  (classTyVars, fieldTypes) <-
+    case methods of
+      [] -> do
+        tyVars <- mapM freshClassTyVar (binderHeadParams (classDeclHead classDecl))
+        pure (tyVars, [])
+      _ -> classDictionaryLayout className (map tcClassMethodType methods)
+  selectors <- mapM (dsClassSelector dictionaryConstructor classTyVars fieldTypes) methods
+  let dictionaryDeclaration = FcData className classTyVars [(dictionaryConstructor, fieldTypes)]
   pure (dictionaryDeclaration : selectors)
   where
     className = unqualifiedNameText (binderHeadName (classDeclHead classDecl))
     methods = tcClassMethods classAnn
     dictionaryConstructor = fcDictionaryConstructorName className
-    dictionaryDeclaration =
-      FcData
-        (fcDictionaryTypeName className)
-        []
-        [(dictionaryConstructor, map tcClassMethodType methods)]
+    freshClassTyVar binder = TyVarId (tyVarBinderName binder) <$> freshUnique
 
-dsClassSelector :: Text -> TcClassMethodAnnotation -> DsM FcTopBind
-dsClassSelector dictionaryConstructor methodAnn = do
+dsClassSelector :: Text -> [TyVarId] -> [TcType] -> TcClassMethodAnnotation -> DsM FcTopBind
+dsClassSelector dictionaryConstructor classTyVars fieldTypes methodAnn = do
   methodUnique <- freshUnique
   dictVars <- zipWithM mkSelectorDict [0 :: Int ..] dictPreds
-  classDictVar <-
+  classDictionaryVar <-
     case dictVars of
       dictVar : _ -> pure dictVar
       [] -> freshVar "$d" (tcClassMethodDictType methodAnn)
-  let methodVar = Var (tcClassMethodName methodAnn) methodUnique (tcClassMethodType methodAnn)
-      selected = FcDictSelect dictionaryConstructor (FcVar classDictVar) (tcClassMethodIndex methodAnn)
-      body = foldr FcTyLam (foldr FcDictLam selected dictVars) (tcClassMethodTyVars methodAnn)
+  caseBinder <- freshVar "$dict" (varType classDictionaryVar)
+  fieldBinders <- zipWithM (\index -> freshVar ("$method" <> T.pack (show index))) [0 :: Int ..] fieldTypes
+  selectedField <-
+    case drop (tcClassMethodIndex methodAnn) fieldBinders of
+      selected : _ -> pure selected
+      [] -> desugarBug ("invalid class method index for " <> T.unpack (tcClassMethodName methodAnn))
+  let extraTyVars = filter (`notElem` classTyVars) (tcClassMethodTyVars methodAnn)
+      extraDictVars = drop 1 dictVars
+      selected =
+        foldl
+          FcApp
+          (foldl FcTyApp (FcVar selectedField) (map TcTyVar extraTyVars))
+          (map FcVar extraDictVars)
+      selection = FcCase (FcVar classDictionaryVar) caseBinder [FcAlt (DataAlt dictionaryConstructor) fieldBinders selected]
+      methodVar = Var (tcClassMethodName methodAnn) methodUnique (tcClassMethodType methodAnn)
+      body = foldr FcTyLam (foldr FcLam selection dictVars) (tcClassMethodTyVars methodAnn)
   pure (FcTopBind (FcNonRec methodVar body))
   where
     (_tyVars, afterForAlls) = peelForAlls (tcClassMethodType methodAnn)
@@ -594,13 +683,28 @@ dsInstanceDict :: TcInstanceAnnotation -> InstanceDecl -> DsM FcTopBind
 dsInstanceDict instAnn instanceDecl = do
   let methods = Map.fromListWith combineMethods (instanceMethodGroups instanceDecl)
   contextDicts <- zipWithM mkContextDict [0 :: Int ..] (tcInstanceContextDicts instAnn)
-  fields <- mapM (dsInstanceMethod contextDicts methods) (tcInstanceMethodOrder instAnn)
+  let methodOrder = tcInstanceMethodOrder instAnn
+  fields <- mapM (dsInstanceMethod contextDicts methods) methodOrder
   dictVar <- freshVar (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)
-  dictionaryConstructor <-
+  className <-
     case dictionaryClassName (tcInstanceDictType instAnn) of
-      Just className -> pure (fcDictionaryConstructorName className)
+      Just name -> pure name
       Nothing -> desugarBug ("cannot determine class for instance dictionary " <> T.unpack (tcInstanceDictName instAnn))
-  let dictBody = foldr FcTyLam (foldr (FcDictLam . classDictVar) (FcDict dictionaryConstructor fields) contextDicts) (tcInstanceTyVars instAnn)
+  methodTypes <- mapM lookupType methodOrder
+  (classTyVars, fieldTypes) <-
+    case methodTypes of
+      [] -> do
+        tyVars <- mapM (\index -> TyVarId ("a" <> T.pack (show index)) <$> freshUnique) [0 .. length (tcInstanceHeadTypes instAnn) - 1]
+        pure (tyVars, [])
+      _ -> classDictionaryLayout className methodTypes
+  constructorUnique <- freshUnique
+  let dictionaryConstructor = fcDictionaryConstructorName className
+      dictionaryType = TcTyCon (TyCon className (length classTyVars)) (map TcTyVar classTyVars)
+      constructorType = foldr TcForAllTy (foldr TcFunTy dictionaryType fieldTypes) classTyVars
+      constructorVar = Var dictionaryConstructor constructorUnique constructorType
+      constructor = foldl FcTyApp (FcVar constructorVar) (tcInstanceHeadTypes instAnn)
+      dictionary = foldl FcApp constructor fields
+      dictBody = foldr FcTyLam (foldr (FcLam . classDictVar) dictionary contextDicts) (tcInstanceTyVars instAnn)
   pure (FcTopBind (FcNonRec dictVar dictBody))
   where
     combineMethods (newTy, newMatches) (_oldTy, oldMatches) = (newTy, oldMatches <> newMatches)
@@ -612,6 +716,51 @@ dictionaryClassName ty =
     TcQualTy _ body -> dictionaryClassName body
     TcTyCon (TyCon className _) _ -> Just className
     _ -> Nothing
+
+classDictionaryLayout :: Text -> [TcType] -> DsM ([TyVarId], [TcType])
+classDictionaryLayout className methodTypes = do
+  classTyVars <-
+    case methodTypes of
+      firstMethod : _ -> classTypeVariables className firstMethod
+      [] -> pure []
+  fieldTypes <- mapM (classMethodFieldType className classTyVars) methodTypes
+  pure (classTyVars, fieldTypes)
+
+classTypeVariables :: Text -> TcType -> DsM [TyVarId]
+classTypeVariables className methodType =
+  case [args | ClassPred predicateClass args <- predicates, predicateClass == className] of
+    args : _ ->
+      case traverse asTyVar args of
+        Just tyVars -> pure tyVars
+        Nothing -> desugarBug ("class predicate has non-variable parameters for " <> T.unpack className)
+    [] -> desugarBug ("class method lacks its class predicate for " <> T.unpack className)
+  where
+    (_, afterForAlls) = peelForAlls methodType
+    (predicates, _) = peelQuals afterForAlls
+    asTyVar (TcTyVar tyVar) = Just tyVar
+    asTyVar _ = Nothing
+
+classMethodFieldType :: Text -> [TyVarId] -> TcType -> DsM TcType
+classMethodFieldType className classTyVars methodType = do
+  remainingPredicates <-
+    case removeClassPredicate predicates of
+      Just result -> pure result
+      Nothing -> desugarBug ("class method lacks its class predicate for " <> T.unpack className)
+  let extraTyVars = filter (`notElem` classTyVars) methodTyVars
+      qualifiedBody =
+        if null remainingPredicates
+          then body
+          else TcQualTy remainingPredicates body
+  pure (foldr TcForAllTy qualifiedBody extraTyVars)
+  where
+    (methodTyVars, afterForAlls) = peelForAlls methodType
+    (predicates, body) = peelQuals afterForAlls
+    removeClassPredicate [] = Nothing
+    removeClassPredicate (predicate : rest) =
+      case predicate of
+        ClassPred predicateClass _
+          | predicateClass == className -> Just rest
+        _ -> (predicate :) <$> removeClassPredicate rest
 
 mkContextDict :: Int -> TcDictBinderAnnotation -> DsM ClassDict
 mkContextDict ix dictAnn = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -20,6 +20,7 @@ import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
   ( CallConv (..),
+    ClassDecl (..),
     DataConDecl,
     DataDecl (..),
     Decl (..),
@@ -154,8 +155,8 @@ dsDecl (DeclAnn ann inner)
       dsForeignImport tcAnn (Just foreignAnn) foreignDecl
 dsDecl (DeclAnn ann (DeclForeign foreignDecl))
   | Just tcAnn <- fromAnnotation ann = dsForeignImport tcAnn Nothing foreignDecl
-dsDecl (DeclAnn ann (DeclClass _classDecl))
-  | Just classAnn <- fromAnnotation ann = dsClassDeclM classAnn
+dsDecl (DeclAnn ann (DeclClass classDecl))
+  | Just classAnn <- fromAnnotation ann = dsClassDeclM classDecl classAnn
 dsDecl (DeclAnn _ inner) = dsDecl inner
 dsDecl DeclClass {} = desugarBug "missing type-checker annotation for class declaration"
 dsDecl _ = pure []
@@ -534,12 +535,22 @@ dataConFieldTypes name arity (TcFunTy arg rest) =
 dataConFieldTypes name arity ty =
   desugarBug ("missing field type information for data constructor " <> T.unpack name <> ": expected " <> show arity <> " more field(s) in " <> show ty)
 
-dsClassDeclM :: TcClassAnnotation -> DsM [FcTopBind]
-dsClassDeclM classAnn =
-  mapM dsClassSelector (tcClassMethods classAnn)
+dsClassDeclM :: ClassDecl -> TcClassAnnotation -> DsM [FcTopBind]
+dsClassDeclM classDecl classAnn = do
+  selectors <- mapM (dsClassSelector dictionaryConstructor) methods
+  pure (dictionaryDeclaration : selectors)
+  where
+    className = unqualifiedNameText (binderHeadName (classDeclHead classDecl))
+    methods = tcClassMethods classAnn
+    dictionaryConstructor = fcDictionaryConstructorName className
+    dictionaryDeclaration =
+      FcData
+        (fcDictionaryTypeName className)
+        []
+        [(dictionaryConstructor, map tcClassMethodType methods)]
 
-dsClassSelector :: TcClassMethodAnnotation -> DsM FcTopBind
-dsClassSelector methodAnn = do
+dsClassSelector :: Text -> TcClassMethodAnnotation -> DsM FcTopBind
+dsClassSelector dictionaryConstructor methodAnn = do
   methodUnique <- freshUnique
   dictVars <- zipWithM mkSelectorDict [0 :: Int ..] dictPreds
   classDictVar <-
@@ -547,7 +558,7 @@ dsClassSelector methodAnn = do
       dictVar : _ -> pure dictVar
       [] -> freshVar "$d" (tcClassMethodDictType methodAnn)
   let methodVar = Var (tcClassMethodName methodAnn) methodUnique (tcClassMethodType methodAnn)
-      selected = FcDictSelect (FcVar classDictVar) (tcClassMethodIndex methodAnn)
+      selected = FcDictSelect dictionaryConstructor (FcVar classDictVar) (tcClassMethodIndex methodAnn)
       body = foldr FcTyLam (foldr FcDictLam selected dictVars) (tcClassMethodTyVars methodAnn)
   pure (FcTopBind (FcNonRec methodVar body))
   where
@@ -585,10 +596,22 @@ dsInstanceDict instAnn instanceDecl = do
   contextDicts <- zipWithM mkContextDict [0 :: Int ..] (tcInstanceContextDicts instAnn)
   fields <- mapM (dsInstanceMethod contextDicts methods) (tcInstanceMethodOrder instAnn)
   dictVar <- freshVar (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)
-  let dictBody = foldr FcTyLam (foldr (FcDictLam . classDictVar) (FcDict fields) contextDicts) (tcInstanceTyVars instAnn)
+  dictionaryConstructor <-
+    case dictionaryClassName (tcInstanceDictType instAnn) of
+      Just className -> pure (fcDictionaryConstructorName className)
+      Nothing -> desugarBug ("cannot determine class for instance dictionary " <> T.unpack (tcInstanceDictName instAnn))
+  let dictBody = foldr FcTyLam (foldr (FcDictLam . classDictVar) (FcDict dictionaryConstructor fields) contextDicts) (tcInstanceTyVars instAnn)
   pure (FcTopBind (FcNonRec dictVar dictBody))
   where
     combineMethods (newTy, newMatches) (_oldTy, oldMatches) = (newTy, oldMatches <> newMatches)
+
+dictionaryClassName :: TcType -> Maybe Text
+dictionaryClassName ty =
+  case ty of
+    TcForAllTy _ body -> dictionaryClassName body
+    TcQualTy _ body -> dictionaryClassName body
+    TcTyCon (TyCon className _) _ -> Just className
+    _ -> Nothing
 
 mkContextDict :: Int -> TcDictBinderAnnotation -> DsM ClassDict
 mkContextDict ix dictAnn = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1159,20 +1159,44 @@ dsEvidence evidence =
         Nothing ->
           desugarBug ("missing local dictionary for " <> T.unpack (dictKey className args))
     EvGiven EqPred {} ->
-      pure (FcDict [])
+      pure (FcDict "()" [])
     EvDict dictName typeArgs contextEvidence -> do
       dictTy <- lookupType dictName
       contextDicts <- mapM dsEvidence contextEvidence
       let dictExpr = List.foldl' FcTyApp (FcVar (Var dictName (Unique (-199)) dictTy)) typeArgs
       pure (List.foldl' FcDictApp dictExpr contextDicts)
     EvCoercion {} ->
-      pure (FcDict [])
-    EvSuperClass dict index ->
-      (`FcDictSelect` index) <$> dsEvidence dict
+      pure (FcDict "()" [])
+    EvSuperClass dict index -> do
+      constructor <- evidenceDictionaryConstructor dict
+      FcDictSelect constructor <$> dsEvidence dict <*> pure index
     EvCast dict _co ->
       dsEvidence dict
     EvVarTerm {} ->
       desugarBug "unresolved evidence variable in type-checker annotation"
+
+evidenceDictionaryConstructor :: EvTerm -> DsM Text
+evidenceDictionaryConstructor evidence =
+  case evidence of
+    EvGiven (ClassPred className _) -> pure (fcDictionaryConstructorName className)
+    EvGiven EqPred {} -> pure "()"
+    EvDict dictName _ _ -> do
+      dictTy <- lookupType dictName
+      case dictionaryClassName dictTy of
+        Just className -> pure (fcDictionaryConstructorName className)
+        Nothing -> desugarBug ("cannot determine dictionary class from " <> T.unpack dictName <> " :: " <> show dictTy)
+    EvCoercion {} -> pure "()"
+    EvCast dict _ -> evidenceDictionaryConstructor dict
+    EvSuperClass {} -> desugarBug "nested superclass evidence lacks result class metadata"
+    EvVarTerm {} -> desugarBug "unresolved evidence variable has no dictionary constructor"
+
+dictionaryClassName :: TcType -> Maybe Text
+dictionaryClassName ty =
+  case ty of
+    TcForAllTy _ body -> dictionaryClassName body
+    TcQualTy _ body -> dictionaryClassName body
+    TcTyCon (TyCon className _) _ -> Just className
+    _ -> Nothing
 
 exprAnnotationType :: Expr -> Maybe TcType
 exprAnnotationType expr =
@@ -1305,7 +1329,7 @@ fcExprTypeM expr =
     FcLam var body -> TcFunTy (varType var) <$> fcExprTypeM body
     FcTyLam tv body -> TcForAllTy tv <$> fcExprTypeM body
     FcDictLam var body -> TcFunTy (varType var) <$> fcExprTypeM body
-    FcDict _fields -> pure (TcTyCon (TyCon "Dict" 0) [])
+    FcDict _ _fields -> pure (TcTyCon (TyCon "Dict" 0) [])
     FcDictSelect {} -> desugarBug "dictionary selection lacks field type annotation while desugaring"
     FcLet _bind body -> fcExprTypeM body
     FcCase _scrut _binder alts ->

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -177,7 +177,7 @@ dsMatchesWithDictSource givenDicts abstractDicts ty matches = case matches of
             dicts <- dictionariesFor dictPreds
             body <- withDicts dicts (dsRhs (matchRhs m0))
             let dictLamExpr
-                  | abstractDicts = foldr (FcDictLam . classDictVar) body dicts
+                  | abstractDicts = foldr (FcLam . classDictVar) body dicts
                   | otherwise = body
             pure (foldr FcTyLam dictLamExpr tyLams)
           else do
@@ -189,7 +189,7 @@ dsMatchesWithDictSource givenDicts abstractDicts ty matches = case matches of
             body <- withDicts dicts (buildCaseChain argVars resTy matches)
             let lamExpr = foldr FcLam body argVars
                 dictLamExpr
-                  | abstractDicts = foldr (FcDictLam . classDictVar) lamExpr dicts
+                  | abstractDicts = foldr (FcLam . classDictVar) lamExpr dicts
                   | otherwise = lamExpr
             pure (foldr FcTyLam dictLamExpr tyLams)
   where
@@ -224,9 +224,6 @@ peelForAlls ty = ([], ty)
 peelQuals :: TcType -> ([Pred], TcType)
 peelQuals (TcQualTy preds body) = (preds, body)
 peelQuals ty = ([], ty)
-
-qualifiedBody :: TcType -> TcType
-qualifiedBody ty = snd (peelQuals (snd (peelForAlls ty)))
 
 predType :: Pred -> TcType
 predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
@@ -518,7 +515,7 @@ dsAnnotatedVar tcAnn name _expr = do
       v <- freshVar n ty
       let typedExpr = List.foldl' FcTyApp (FcVar v) (tcAnnTypeArgs tcAnn)
       dicts <- mapM dsEvidence (tcAnnEvidenceTerms tcAnn)
-      pure (List.foldl' FcDictApp typedExpr dicts)
+      pure (List.foldl' FcApp typedExpr dicts)
 
 dsAnnotatedExpr :: TcAnnotation -> Expr -> DsM FcExpr
 dsAnnotatedExpr tcAnn inner =
@@ -1159,44 +1156,24 @@ dsEvidence evidence =
         Nothing ->
           desugarBug ("missing local dictionary for " <> T.unpack (dictKey className args))
     EvGiven EqPred {} ->
-      pure (FcDict "()" [])
+      pure unitConstructor
     EvDict dictName typeArgs contextEvidence -> do
       dictTy <- lookupType dictName
       contextDicts <- mapM dsEvidence contextEvidence
       let dictExpr = List.foldl' FcTyApp (FcVar (Var dictName (Unique (-199)) dictTy)) typeArgs
-      pure (List.foldl' FcDictApp dictExpr contextDicts)
+      pure (List.foldl' FcApp dictExpr contextDicts)
     EvCoercion {} ->
-      pure (FcDict "()" [])
-    EvSuperClass dict index -> do
-      constructor <- evidenceDictionaryConstructor dict
-      FcDictSelect constructor <$> dsEvidence dict <*> pure index
+      pure unitConstructor
+    EvSuperClass {} ->
+      desugarBug "superclass evidence is not supported by the type checker"
     EvCast dict _co ->
       dsEvidence dict
     EvVarTerm {} ->
       desugarBug "unresolved evidence variable in type-checker annotation"
 
-evidenceDictionaryConstructor :: EvTerm -> DsM Text
-evidenceDictionaryConstructor evidence =
-  case evidence of
-    EvGiven (ClassPred className _) -> pure (fcDictionaryConstructorName className)
-    EvGiven EqPred {} -> pure "()"
-    EvDict dictName _ _ -> do
-      dictTy <- lookupType dictName
-      case dictionaryClassName dictTy of
-        Just className -> pure (fcDictionaryConstructorName className)
-        Nothing -> desugarBug ("cannot determine dictionary class from " <> T.unpack dictName <> " :: " <> show dictTy)
-    EvCoercion {} -> pure "()"
-    EvCast dict _ -> evidenceDictionaryConstructor dict
-    EvSuperClass {} -> desugarBug "nested superclass evidence lacks result class metadata"
-    EvVarTerm {} -> desugarBug "unresolved evidence variable has no dictionary constructor"
-
-dictionaryClassName :: TcType -> Maybe Text
-dictionaryClassName ty =
-  case ty of
-    TcForAllTy _ body -> dictionaryClassName body
-    TcQualTy _ body -> dictionaryClassName body
-    TcTyCon (TyCon className _) _ -> Just className
-    _ -> Nothing
+unitConstructor :: FcExpr
+unitConstructor =
+  FcVar (Var "()" (Unique (-13)) (TcTyCon (TyCon "()" 0) []))
 
 exprAnnotationType :: Expr -> Maybe TcType
 exprAnnotationType expr =
@@ -1311,16 +1288,11 @@ fcExprTypeM expr =
         Just ty -> pure ty
         Nothing -> desugarBug ("literal has invalid runtime representation: " <> show lit)
     FcApp fun _arg -> do
-      funTy <- qualifiedBody <$> fcExprTypeM fun
-      case funTy of
-        TcFunTy _argTy resTy -> pure resTy
-        _ -> desugarBug ("application to non-function type while desugaring: " <> show funTy)
-    FcDictApp fun _dict -> do
       funTy <- fcExprTypeM fun
       case funTy of
         TcQualTy (_pred : preds) body -> pure (if null preds then body else TcQualTy preds body)
         TcFunTy _argTy resTy -> pure resTy
-        _ -> desugarBug ("dictionary application to non-qualified type while desugaring: " <> show funTy)
+        _ -> desugarBug ("application to non-function type while desugaring: " <> show funTy)
     FcTyApp fun ty -> do
       funTy <- fcExprTypeM fun
       case funTy of
@@ -1328,9 +1300,6 @@ fcExprTypeM expr =
         _ -> desugarBug ("type application to non-forall type while desugaring: " <> show funTy)
     FcLam var body -> TcFunTy (varType var) <$> fcExprTypeM body
     FcTyLam tv body -> TcForAllTy tv <$> fcExprTypeM body
-    FcDictLam var body -> TcFunTy (varType var) <$> fcExprTypeM body
-    FcDict _ _fields -> pure (TcTyCon (TyCon "Dict" 0) [])
-    FcDictSelect {} -> desugarBug "dictionary selection lacks field type annotation while desugaring"
     FcLet _bind body -> fcExprTypeM body
     FcCase _scrut _binder alts ->
       case alts of

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -49,7 +49,7 @@ data Value
   = VLit Literal
   | VClosure Env Var FcExpr
   | VConstructor Text [Value]
-  | VDict [Value]
+  | VDict Text [Value]
   | VPrim Text Int [Value]
   | VMutVar EvalMutVar
   | VStateToken
@@ -143,13 +143,14 @@ evalWithEnv env expr =
       evalWithEnv env body
     FcDictLam var body ->
       pure (VClosure env var body)
-    FcDict fields ->
-      pure (VDict (map (VThunk env) fields))
-    FcDictSelect dict index -> do
+    FcDict constructor fields ->
+      pure (VDict constructor (map (VThunk env) fields))
+    FcDictSelect expectedConstructor dict index -> do
       dictValue <- evalWithEnv env dict >>= forceValue
       case dictValue of
-        VDict fields
-          | index >= 0,
+        VDict actualConstructor fields
+          | actualConstructor == expectedConstructor,
+            index >= 0,
             index < length fields ->
               forceValue (fields !! index)
           | otherwise -> throwE (EvalInvalidDictSelect dictValue index)

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -41,7 +41,6 @@ data EvalError
   | EvalForeignTypeError Text Value
   | EvalForeignLookupError Text Text
   | EvalInvalidIOResult Value
-  | EvalInvalidDictSelect Value Int
   | EvalRaisedException Value
   deriving (Eq, Show)
 
@@ -49,7 +48,6 @@ data Value
   = VLit Literal
   | VClosure Env Var FcExpr
   | VConstructor Text [Value]
-  | VDict Text [Value]
   | VPrim Text Int [Value]
   | VMutVar EvalMutVar
   | VStateToken
@@ -132,29 +130,12 @@ evalWithEnv env expr =
     FcApp fun arg -> do
       funValue <- evalWithEnv env fun
       applyValue funValue (VThunk env arg)
-    FcDictApp fun arg -> do
-      funValue <- evalWithEnv env fun
-      applyValue funValue (VThunk env arg)
     FcTyApp inner _ ->
       evalWithEnv env inner
     FcLam var body ->
       pure (VClosure env var body)
     FcTyLam _ body ->
       evalWithEnv env body
-    FcDictLam var body ->
-      pure (VClosure env var body)
-    FcDict constructor fields ->
-      pure (VDict constructor (map (VThunk env) fields))
-    FcDictSelect expectedConstructor dict index -> do
-      dictValue <- evalWithEnv env dict >>= forceValue
-      case dictValue of
-        VDict actualConstructor fields
-          | actualConstructor == expectedConstructor,
-            index >= 0,
-            index < length fields ->
-              forceValue (fields !! index)
-          | otherwise -> throwE (EvalInvalidDictSelect dictValue index)
-        _ -> throwE (EvalApplyNonFunction dictValue)
     FcLet bind body ->
       evalWithEnv (extendBind env bind) body
     FcCase scrut _ alts -> do
@@ -427,7 +408,6 @@ renderForcedValue value =
     VConstructor name args -> do
       renderedArgs <- mapM (renderValueM <=< forceValue) args
       pure (T.unwords (name : renderedArgs))
-    VDict {} -> pure "<dictionary>"
     VClosure {} -> pure "<function>"
     VPrim {} -> pure "<function>"
     VMutVar {} -> pure "<mutvar>"
@@ -499,7 +479,6 @@ renderRawValueM value = do
     VConstructor name args -> do
       renderedArgs <- mapM renderRawArg args
       pure (T.unwords (name : renderedArgs))
-    VDict {} -> pure "<dictionary>"
     VClosure {} -> pure "<function>"
     VPrim {} -> pure "<function>"
     VMutVar {} -> pure "<mutvar>"

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -161,10 +161,10 @@ lintExpr env (FcDictLam v body) = do
   let env' = extendTermEnv v env
   bodyTy <- lintExpr env' body
   Right (TcFunTy (varType v) bodyTy)
-lintExpr env (FcDict fields) = do
+lintExpr env (FcDict _ fields) = do
   mapM_ (lintExpr env) fields
   Right (TcTyCon (TyCon "Dict" 0) [])
-lintExpr env (FcDictSelect dict index) = do
+lintExpr env (FcDictSelect _ dict index) = do
   _ <- lintExpr env dict
   Left (LintFailure ("dictionary selection lacks field type annotation: " ++ show index))
 lintExpr env (FcLet bind body) = do

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -85,6 +85,16 @@ lintProgram env0 prog = go envWithDeclarations (fcTopBinds prog)
 
     registerDeclaration (FcNewtype declaration) env =
       env {leNewtypes = Map.insert (fcNewtypeName declaration) declaration (leNewtypes env)}
+    registerDeclaration (FcData typeName tyVars constructors) env =
+      env
+        { leDataCons =
+            foldr
+              (\(constructor, fields) -> Map.insert constructor (tyVars, fields, resultType))
+              (leDataCons env)
+              constructors
+        }
+      where
+        resultType = TcTyCon (TyCon typeName (length tyVars)) (map TcTyVar tyVars)
     registerDeclaration (FcForeignImport foreignCall) env =
       env {leForeignCalls = Map.insert (fcForeignCallName foreignCall) foreignCall (leForeignCalls env)}
     registerDeclaration _ env = env
@@ -129,7 +139,12 @@ lintExpr :: LintEnv -> FcExpr -> Either LintError TcType
 lintExpr env (FcVar v) =
   case Map.lookup (varUnique v) (leTerms env) of
     Just ty -> Right ty
-    Nothing -> Left (UnboundVar (varName v) (varUnique v))
+    Nothing ->
+      case Map.lookup (varName v) (leDataCons env) of
+        Just (tyVars, fields, resultType)
+          | typesEqual (varType v) (foldr TcForAllTy (foldr TcFunTy resultType fields) tyVars) -> Right (varType v)
+          | otherwise -> Left (TypeMismatch "constructor occurrence" (foldr TcForAllTy (foldr TcFunTy resultType fields) tyVars) (varType v))
+        Nothing -> Left (UnboundVar (varName v) (varUnique v))
 lintExpr _ (FcLit lit) =
   case literalType lit of
     Just ty -> Right ty
@@ -142,7 +157,6 @@ lintExpr env (FcApp f a) = do
       | typesEqual argTy aTy -> Right resTy
       | otherwise -> Left (TypeMismatch "application argument" argTy aTy)
     _ -> Left (LintFailure ("application to non-function type: " ++ show fTy))
-lintExpr env (FcDictApp f a) = lintExpr env (FcApp f a)
 lintExpr env (FcTyApp e ty) = do
   eTy <- lintExpr env e
   case eTy of
@@ -157,16 +171,6 @@ lintExpr env (FcTyLam tv body) = do
   let env' = env {leTyVars = Set.insert tv (leTyVars env)}
   bodyTy <- lintExpr env' body
   Right (TcForAllTy tv bodyTy)
-lintExpr env (FcDictLam v body) = do
-  let env' = extendTermEnv v env
-  bodyTy <- lintExpr env' body
-  Right (TcFunTy (varType v) bodyTy)
-lintExpr env (FcDict _ fields) = do
-  mapM_ (lintExpr env) fields
-  Right (TcTyCon (TyCon "Dict" 0) [])
-lintExpr env (FcDictSelect _ dict index) = do
-  _ <- lintExpr env dict
-  Left (LintFailure ("dictionary selection lacks field type annotation: " ++ show index))
 lintExpr env (FcLet bind body) = do
   let (errs, env') = lintBind env bind
   case errs of

--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -97,8 +97,8 @@ lowerExpr env expr =
     FcLam var body -> FcLam var <$> lowerExpr env body
     FcTyLam tyVar body -> FcTyLam tyVar <$> lowerExpr env body
     FcDictLam var body -> FcDictLam var <$> lowerExpr env body
-    FcDict fields -> FcDict <$> mapM (lowerExpr env) fields
-    FcDictSelect dictionary index -> (`FcDictSelect` index) <$> lowerExpr env dictionary
+    FcDict constructor fields -> FcDict constructor <$> mapM (lowerExpr env) fields
+    FcDictSelect constructor dictionary index -> FcDictSelect constructor <$> lowerExpr env dictionary <*> pure index
     FcLet bind body -> FcLet <$> lowerBind env bind <*> lowerExpr env body
     FcCase scrutinee binder alternatives -> lowerCase env scrutinee binder alternatives
     FcCast inner coercion -> (`FcCast` coercion) <$> lowerExpr env inner
@@ -223,8 +223,8 @@ exprUniques expression =
     FcLam var body -> varUniques var <> exprUniques body
     FcTyLam _ body -> exprUniques body
     FcDictLam var body -> varUniques var <> exprUniques body
-    FcDict fields -> concatMap exprUniques fields
-    FcDictSelect dictionary _ -> exprUniques dictionary
+    FcDict _ fields -> concatMap exprUniques fields
+    FcDictSelect _ dictionary _ -> exprUniques dictionary
     FcLet bind body -> bindUniques bind <> exprUniques body
     FcCase scrutinee binder alternatives ->
       exprUniques scrutinee <> varUniques binder <> concatMap altUniques alternatives

--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -89,16 +89,12 @@ lowerExpr env expr =
           argument' <- lowerExpr env argument
           pure (wrapNewtype declaration typeArgs argument')
         Nothing -> FcApp <$> lowerExpr env function <*> lowerExpr env argument
-    FcDictApp function argument -> FcDictApp <$> lowerExpr env function <*> lowerExpr env argument
     FcTyApp {} ->
       case newtypeConstructorSpine env expr of
         Just (declaration, typeArgs) -> lowerConstructorValue declaration typeArgs
         Nothing -> lowerTypeApplication env expr
     FcLam var body -> FcLam var <$> lowerExpr env body
     FcTyLam tyVar body -> FcTyLam tyVar <$> lowerExpr env body
-    FcDictLam var body -> FcDictLam var <$> lowerExpr env body
-    FcDict constructor fields -> FcDict constructor <$> mapM (lowerExpr env) fields
-    FcDictSelect constructor dictionary index -> FcDictSelect constructor <$> lowerExpr env dictionary <*> pure index
     FcLet bind body -> FcLet <$> lowerBind env bind <*> lowerExpr env body
     FcCase scrutinee binder alternatives -> lowerCase env scrutinee binder alternatives
     FcCast inner coercion -> (`FcCast` coercion) <$> lowerExpr env inner
@@ -218,13 +214,9 @@ exprUniques expression =
     FcVar var -> varUniques var
     FcLit {} -> []
     FcApp function argument -> exprUniques function <> exprUniques argument
-    FcDictApp function argument -> exprUniques function <> exprUniques argument
     FcTyApp inner _ -> exprUniques inner
     FcLam var body -> varUniques var <> exprUniques body
     FcTyLam _ body -> exprUniques body
-    FcDictLam var body -> varUniques var <> exprUniques body
-    FcDict _ fields -> concatMap exprUniques fields
-    FcDictSelect _ dictionary _ -> exprUniques dictionary
     FcLet bind body -> bindUniques bind <> exprUniques body
     FcCase scrutinee binder alternatives ->
       exprUniques scrutinee <> varUniques binder <> concatMap altUniques alternatives

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -121,9 +121,6 @@ renderExprPrec _ _ (FcLit lit) = renderLiteral lit
 renderExprPrec n parens (FcApp f a) =
   paren parens $
     renderExprPrec n False f ++ " " ++ renderExprPrec n True a
-renderExprPrec n parens (FcDictApp f a) =
-  paren parens $
-    renderExprPrec n False f ++ " $" ++ renderExprPrec n True a
 renderExprPrec n parens (FcTyApp e ty) =
   paren parens $
     renderExprPrec n False e ++ " @" ++ renderTypePrec True ty
@@ -141,17 +138,6 @@ renderExprPrec n parens (FcTyLam tv body) =
       ++ T.unpack (tvName tv)
       ++ ".\n"
       ++ renderExprIndented (n + 2) body
-renderExprPrec n parens (FcDictLam v body) =
-  paren parens $
-    "\\" ++ renderVar v ++ " : dict.\n" ++ renderExprIndented (n + 2) body
-renderExprPrec n parens (FcDict _ fields) =
-  paren parens $
-    "{"
-      ++ intercalate ", " (map (renderExprPrec n False) fields)
-      ++ "}"
-renderExprPrec n parens (FcDictSelect _ dict index) =
-  paren parens $
-    renderExprPrec n True dict ++ "." ++ show index
 renderExprPrec n parens (FcLet bind body) =
   paren parens $
     "let\n"

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -144,12 +144,12 @@ renderExprPrec n parens (FcTyLam tv body) =
 renderExprPrec n parens (FcDictLam v body) =
   paren parens $
     "\\" ++ renderVar v ++ " : dict.\n" ++ renderExprIndented (n + 2) body
-renderExprPrec n parens (FcDict fields) =
+renderExprPrec n parens (FcDict _ fields) =
   paren parens $
     "{"
       ++ intercalate ", " (map (renderExprPrec n False) fields)
       ++ "}"
-renderExprPrec n parens (FcDictSelect dict index) =
+renderExprPrec n parens (FcDictSelect _ dict index) =
   paren parens $
     renderExprPrec n True dict ++ "." ++ show index
 renderExprPrec n parens (FcLet bind body) =

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -31,7 +31,6 @@ module Aihc.Fc.Syntax
     fcForeignOperandTypes,
     fcForeignCallResultType,
     fcForeignCallType,
-    fcDictionaryTypeName,
     fcDictionaryConstructorName,
 
     -- * Case alternatives
@@ -152,11 +151,6 @@ statePrimRealWorldType :: TcType
 statePrimRealWorldType =
   TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
 
--- | Generated ordinary data declaration used to represent one class's
--- dictionaries after FC is lowered to a runtime language.
-fcDictionaryTypeName :: Text -> Text
-fcDictionaryTypeName className = "$DictType$" <> className
-
 fcDictionaryConstructorName :: Text -> Text
 fcDictionaryConstructorName className = "$Dict$" <> className
 
@@ -185,21 +179,12 @@ data FcExpr
     FcLit !Literal
   | -- | Term application.
     FcApp !FcExpr !FcExpr
-  | -- | Dictionary application (@e dict@), kept separate from ordinary
-    -- term application so the dictionary-passing phase is explicit.
-    FcDictApp !FcExpr !FcExpr
   | -- | Type application (@e \@\tau@).
     FcTyApp !FcExpr !TcType
   | -- | Term lambda (@\lambda x : \tau . e@).
     FcLam !Var !FcExpr
   | -- | Type lambda (@\Lambda a . e@).
     FcTyLam !TyVarId !FcExpr
-  | -- | Dictionary lambda.
-    FcDictLam !Var !FcExpr
-  | -- | Dictionary value: ordinary constructor name and method fields.
-    FcDict !Text ![FcExpr]
-  | -- | Dictionary field selection: ordinary constructor name, value, index.
-    FcDictSelect !Text !FcExpr !Int
   | -- | Let binding.
     FcLet !FcBind !FcExpr
   | -- | Case expression: scrutinee, case binder, alternatives.

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -31,6 +31,8 @@ module Aihc.Fc.Syntax
     fcForeignOperandTypes,
     fcForeignCallResultType,
     fcForeignCallType,
+    fcDictionaryTypeName,
+    fcDictionaryConstructorName,
 
     -- * Case alternatives
     FcAlt (..),
@@ -150,6 +152,14 @@ statePrimRealWorldType :: TcType
 statePrimRealWorldType =
   TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
 
+-- | Generated ordinary data declaration used to represent one class's
+-- dictionaries after FC is lowered to a runtime language.
+fcDictionaryTypeName :: Text -> Text
+fcDictionaryTypeName className = "$DictType$" <> className
+
+fcDictionaryConstructorName :: Text -> Text
+fcDictionaryConstructorName className = "$Dict$" <> className
+
 -- | A typed variable.
 data Var = Var
   { varName :: !Text,
@@ -186,10 +196,10 @@ data FcExpr
     FcTyLam !TyVarId !FcExpr
   | -- | Dictionary lambda.
     FcDictLam !Var !FcExpr
-  | -- | Dictionary value, represented as method fields.
-    FcDict ![FcExpr]
-  | -- | Dictionary field selection.
-    FcDictSelect !FcExpr !Int
+  | -- | Dictionary value: ordinary constructor name and method fields.
+    FcDict !Text ![FcExpr]
+  | -- | Dictionary field selection: ordinary constructor name, value, index.
+    FcDictSelect !Text !FcExpr !Int
   | -- | Let binding.
     FcLet !FcBind !FcExpr
   | -- | Case expression: scrutinee, case binder, alternatives.

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -103,6 +103,20 @@ fcOptimizationTests =
           "reachable program"
           (FcProgram [FcTopBind (FcNonRec mainVar (FcLam local (FcVar local)))])
           (eliminateDeadCode "main" program),
+      testCase "retains ordinary dictionary constructor declarations" $ do
+        let dictionaryTy = ty "$DictType$Test"
+            dictionaryData = FcData "$DictType$Test" [] [("$Dict$Test", [stringTy])]
+            mainBinding =
+              FcTopBind
+                ( FcNonRec
+                    (Var "main" (Unique 13) dictionaryTy)
+                    (FcDict "$Dict$Test" [FcLit (LitString "method")])
+                )
+            program = FcProgram [dictionaryData, mainBinding]
+        assertEqual
+          "reachable dictionary declaration"
+          program
+          (eliminateDeadCode "main" program),
       testCase "lowers newtype construction to a linted representational cast" $ do
         let metersTy = ty "Meters"
             intHashTy = ty "Int#"

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -104,19 +104,27 @@ fcOptimizationTests =
           (FcProgram [FcTopBind (FcNonRec mainVar (FcLam local (FcVar local)))])
           (eliminateDeadCode "main" program),
       testCase "retains ordinary dictionary constructor declarations" $ do
-        let dictionaryTy = ty "$DictType$Test"
-            dictionaryData = FcData "$DictType$Test" [] [("$Dict$Test", [stringTy])]
+        let dictionaryTy = ty "Test"
+            dictionaryData = FcData "Test" [] [("$Dict$Test", [stringTy])]
+            dictionaryConstructor = Var "$Dict$Test" (Unique 14) (TcFunTy stringTy dictionaryTy)
+            dictionaryBinder = Var "$dictionary" (Unique 15) dictionaryTy
+            methodBinder = Var "$method" (Unique 16) stringTy
             mainBinding =
               FcTopBind
                 ( FcNonRec
-                    (Var "main" (Unique 13) dictionaryTy)
-                    (FcDict "$Dict$Test" [FcLit (LitString "method")])
+                    (Var "main" (Unique 13) stringTy)
+                    ( Aihc.Fc.FcCase
+                        (FcApp (FcVar dictionaryConstructor) (FcLit (LitString "method")))
+                        dictionaryBinder
+                        [FcAlt (DataAlt "$Dict$Test") [methodBinder] (FcVar methodBinder)]
+                    )
                 )
             program = FcProgram [dictionaryData, mainBinding]
         assertEqual
           "reachable dictionary declaration"
           program
-          (eliminateDeadCode "main" program),
+          (eliminateDeadCode "main" program)
+        assertEqual "Core lint" [] (lintProgram emptyLintEnv program),
       testCase "lowers newtype construction to a linted representational cast" $ do
         let metersTy = ty "Meters"
             intHashTy = ty "Int#"

--- a/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
@@ -3,6 +3,9 @@ expected: |-
    = False
    | True
 
+  data $DictType$Eq
+   = $Dict$Eq (∀ a. (Eq a) ⇒ a → a → Bool)
+
   == : ∀ a. (Eq a) ⇒ a → a → Bool =
     Λa.
       \$d0 : dict.

--- a/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
@@ -3,33 +3,35 @@ expected: |-
    = False
    | True
 
-  data $DictType$Eq
-   = $Dict$Eq (∀ a. (Eq a) ⇒ a → a → Bool)
+  data Eq a
+   = $Dict$Eq (a → a → Bool)
 
-  == : ∀ a. (Eq a) ⇒ a → a → Bool =
+  == : ∀ a. (Eq a) → a → a → Bool =
     Λa.
-      \$d0 : dict.
-        $d0.0
+      λ$d0 : Eq a.
+        case $d0 as $dict : Eq a of
+          $Dict$Eq $method0 →
+            $method0
 
-  $fEqBool : () ⇒ Eq Bool =
-    {λx1002 : Bool.
-      λy1003 : Bool.
-        case x1002 as _scrut : Bool of
+  $fEqBool : Eq Bool =
+    $Dict$Eq @Bool (λx1004 : Bool.
+      λy1005 : Bool.
+        case x1004 as _scrut : Bool of
           False →
-            case y1003 as _scrut : Bool of
+            case y1005 as _scrut : Bool of
               False →
                 True
               True →
                 False
           True →
-            case y1003 as _scrut : Bool of
+            case y1005 as _scrut : Bool of
               False →
                 False
               True →
-                True}
+                True)
 
   eqBool : Bool → Bool → Bool =
-    == @Bool $$fEqBool
+    == @Bool $fEqBool
 extensions: []
 modules:
 - |

--- a/components/aihc-fc/test/Test/Fixtures/golden/dictionary-method-constraints.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/dictionary-method-constraints.yaml
@@ -1,0 +1,40 @@
+expected: |-
+  data Result
+   = Result
+
+  data Render a
+   = $Dict$Render (a → Result)
+
+  render : ∀ a. (Render a) → a → Result =
+    Λa.
+      λ$d0 : Render a.
+        case $d0 as $dict : Render a of
+          $Dict$Render $method0 →
+            $method0
+
+  data Convert a
+   = $Dict$Convert (∀ b. (Render b) → a → b → Result)
+
+  convert : ∀ a b. (Convert a) → (Render b) → a → b → Result =
+    Λa.
+      Λb.
+        λ$d0 : Convert a.
+          λ$d1 : Render b.
+            case $d0 as $dict : Convert a of
+              $Dict$Convert $method0 →
+                $method0 @b $d1
+extensions: []
+modules:
+- |
+  module Test where
+
+  data Result = Result
+
+  class Render a where
+    render :: a -> Result
+
+  class Convert a where
+    convert :: Render b => a -> b -> Result
+reason: class dictionaries store constrained polymorphic methods as ordinary function
+  fields
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
@@ -9,10 +9,16 @@ expected: |-
   data Integer
    = IS Int#
 
+  data $DictType$Eq
+   = $Dict$Eq (∀ a. (Eq a) ⇒ a → a → Bool)
+
   == : ∀ a. (Eq a) ⇒ a → a → Bool =
     Λa.
       \$d0 : dict.
         $d0.0
+
+  data $DictType$Num
+   = $Dict$Num (∀ a. (Num a) ⇒ Integer → a)
 
   fromInteger : ∀ a. (Num a) ⇒ Integer → a =
     Λa.
@@ -78,6 +84,5 @@ modules:
   caseInt :: ()
   caseInt = case (1 :: Int) of
     1 -> ()
-reason: desugars concrete integer literals and integer case scrutinees through
-  Prelude.fromInteger
+reason: desugars concrete integer literals and integer case scrutinees through Prelude.fromInteger
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
@@ -9,50 +9,54 @@ expected: |-
   data Integer
    = IS Int#
 
-  data $DictType$Eq
-   = $Dict$Eq (∀ a. (Eq a) ⇒ a → a → Bool)
+  data Eq a
+   = $Dict$Eq (a → a → Bool)
 
-  == : ∀ a. (Eq a) ⇒ a → a → Bool =
+  == : ∀ a. (Eq a) → a → a → Bool =
     Λa.
-      \$d0 : dict.
-        $d0.0
+      λ$d0 : Eq a.
+        case $d0 as $dict : Eq a of
+          $Dict$Eq $method0 →
+            $method0
 
-  data $DictType$Num
-   = $Dict$Num (∀ a. (Num a) ⇒ Integer → a)
+  data Num a
+   = $Dict$Num (Integer → a)
 
-  fromInteger : ∀ a. (Num a) ⇒ Integer → a =
+  fromInteger : ∀ a. (Num a) → Integer → a =
     Λa.
-      \$d0 : dict.
-        $d0.0
+      λ$d0 : Num a.
+        case $d0 as $dict : Num a of
+          $Dict$Num $method0 →
+            $method0
 
-  $fEqInt : () ⇒ Eq Int =
-    {λx1004 : Int.
-      λy1005 : Int.
-        case x1004 as _scrut : Int of
+  $fEqInt : Eq Int =
+    $Dict$Eq @Int (λx1008 : Int.
+      λy1009 : Int.
+        case x1008 as _scrut : Int of
           I x →
-            case y1005 as _scrut : Int of
+            case y1009 as _scrut : Int of
               I y →
-                True}
+                True)
 
-  $fNumInt : () ⇒ Num Int =
-    {λx1012 : Integer.
-      case x1012 as _scrut : Integer of
+  $fNumInt : Num Int =
+    $Dict$Num @Int (λx1017 : Integer.
+      case x1017 as _scrut : Integer of
         IS x →
-          I x}
+          I x)
 
-  $fNumInteger : () ⇒ Num Integer =
-    {λx1017 : Integer.
-      x1017}
+  $fNumInteger : Num Integer =
+    $Dict$Num @Integer (λx1023 : Integer.
+      x1023)
   asInt : Int =
-    fromInteger @Int $$fNumInt (IS 1)
+    fromInteger @Int $fNumInt (IS 1)
 
   asInteger : Integer =
-    fromInteger @Integer $$fNumInteger (IS 1)
+    fromInteger @Integer $fNumInteger (IS 1)
 
   caseInt : () =
-    case fromInteger @Int $$fNumInt (IS 1) as _case : Int of
+    case fromInteger @Int $fNumInt (IS 1) as _case : Int of
       _ _case_value →
-        case == @Int $$fEqInt _case_value (fromInteger @Int $$fNumInt (IS 1)) as _case_guard : Bool of
+        case == @Int $fEqInt _case_value (fromInteger @Int $fNumInt (IS 1)) as _case_guard : Bool of
           True →
             ()
           False →

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-prelude-frominteger.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-prelude-frominteger.yaml
@@ -2,17 +2,19 @@ expected: |-
   data Integer
    = IS Int#
 
-  data $DictType$Num
-   = $Dict$Num (∀ a. (Num a) ⇒ Integer → a)
+  data Num a
+   = $Dict$Num (Integer → a)
 
-  fromInteger : ∀ a. (Num a) ⇒ Integer → a =
+  fromInteger : ∀ a. (Num a) → Integer → a =
     Λa.
-      \$d0 : dict.
-        $d0.0
-  one : ∀ a. (Num a) ⇒ a =
+      λ$d0 : Num a.
+        case $d0 as $dict : Num a of
+          $Dict$Num $method0 →
+            $method0
+  one : ∀ a. (Num a) → a =
     Λa.
-      \$d0 : dict.
-        fromInteger @a $$d0 (IS 1)
+      λ$d0 : Num a.
+        fromInteger @a $d0 (IS 1)
 extensions:
 - MagicHash
 modules:

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-prelude-frominteger.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-prelude-frominteger.yaml
@@ -2,6 +2,9 @@ expected: |-
   data Integer
    = IS Int#
 
+  data $DictType$Num
+   = $Dict$Num (∀ a. (Num a) ⇒ Integer → a)
+
   fromInteger : ∀ a. (Num a) ⇒ Integer → a =
     Λa.
       \$d0 : dict.
@@ -21,6 +24,6 @@ modules:
 - |
   module Main where
   one = 1
-reason: desugars default integer literals through Prelude.fromInteger applied to
-  an Integer constructor value
+reason: desugars default integer literals through Prelude.fromInteger applied to an
+  Integer constructor value
 status: pass

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -46,7 +46,6 @@ data InterpretError
   | InterpretInvalidThunkResult ![RuntimeValue]
   | InterpretInvalidThunkResultRep !FunctionName !RuntimeRep
   | InterpretInvalidUpdateValue !RuntimeValue
-  | InterpretInvalidProject !RuntimeValue !Int
   | InterpretExpectedLocation !RuntimeValue
   | InterpretInvalidLocation !Int
   | InterpretBlackhole !Int
@@ -212,15 +211,6 @@ evalExpr env expr =
     GrinCase scrutinee binder alternatives -> do
       value <- evalValue env scrutinee >>= forceValue
       matchAlternative (Map.insert binder value env) value alternatives
-    GrinProject _ object index -> do
-      objectValue <- evalValue env object
-      case objectValue of
-        RuntimeNode (GrinConstructor _) fields
-          | index >= 0,
-            index < length fields ->
-              pure [fields !! index]
-          | otherwise -> throwInterpret (InterpretInvalidProject objectValue index)
-        other -> throwInterpret (InterpretInvalidProject other index)
     GrinThrow exception -> do
       exceptionValue <- evalValue env exception >>= forceValue
       throwE (EvalRaised exceptionValue)

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -46,7 +46,7 @@ data InterpretError
   | InterpretInvalidThunkResult ![RuntimeValue]
   | InterpretInvalidThunkResultRep !FunctionName !RuntimeRep
   | InterpretInvalidUpdateValue !RuntimeValue
-  | InterpretInvalidDictSelect !RuntimeValue !Int
+  | InterpretInvalidProject !RuntimeValue !Int
   | InterpretExpectedLocation !RuntimeValue
   | InterpretInvalidLocation !Int
   | InterpretBlackhole !Int
@@ -212,15 +212,15 @@ evalExpr env expr =
     GrinCase scrutinee binder alternatives -> do
       value <- evalValue env scrutinee >>= forceValue
       matchAlternative (Map.insert binder value env) value alternatives
-    GrinDictSelect _ dictionary index -> do
-      dictionaryValue <- evalValue env dictionary >>= forceValue
-      case dictionaryValue of
-        RuntimeNode GrinDictionary fields
+    GrinProject _ object index -> do
+      objectValue <- evalValue env object
+      case objectValue of
+        RuntimeNode (GrinConstructor _) fields
           | index >= 0,
             index < length fields ->
-              (: []) <$> forceValue (fields !! index)
-          | otherwise -> throwInterpret (InterpretInvalidDictSelect dictionaryValue index)
-        other -> throwInterpret (InterpretInvalidDictSelect other index)
+              pure [fields !! index]
+          | otherwise -> throwInterpret (InterpretInvalidProject objectValue index)
+        other -> throwInterpret (InterpretInvalidProject other index)
     GrinThrow exception -> do
       exceptionValue <- evalValue env exception >>= forceValue
       throwE (EvalRaised exceptionValue)
@@ -588,7 +588,6 @@ renderRawValueM value = do
     RuntimeNode (GrinConstructor name) arguments -> do
       renderedArguments <- mapM renderRawArgument arguments
       pure (T.unwords (name : renderedArguments))
-    RuntimeNode GrinDictionary _ -> pure "<dictionary>"
     RuntimeNode GrinClosure {} _ -> pure "<function>"
     RuntimeNode GrinPrimitive {} _ -> pure "<function>"
     RuntimeNode GrinThunk {} _ -> pure "<thunk>"

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -31,6 +31,9 @@ data GrinLintError
   | GrinLintUnknownForeignCall !Text
   | GrinLintForeignCallDescriptorMismatch !Text
   | GrinLintConstructorLayout !Text ![RuntimeRep] ![RuntimeRep]
+  | GrinLintInvalidProjectIndex !Int
+  | GrinLintProjectNonConstructor !GrinNodeTag
+  | GrinLintProjectNonAtomic !RuntimeRep
   deriving (Eq, Show)
 
 data LintEnv = LintEnv
@@ -134,7 +137,11 @@ lintExpr env bound expr =
     GrinCase scrutinee binder alternatives ->
       lintValue env bound scrutinee
         <> concatMap (lintAlt env (Set.insert binder bound)) alternatives
-    GrinDictSelect _ dictionary _ -> lintValue env bound dictionary
+    GrinProject runtimeRep object index ->
+      [GrinLintInvalidProjectIndex index | index < 0]
+        <> [GrinLintProjectNonAtomic runtimeRep | runtimeRepComponents runtimeRep /= [runtimeRep]]
+        <> lintProject runtimeRep object index
+        <> lintValue env bound object
     GrinThrow exception -> lintValue env bound exception
     GrinCatch _ action handler state ->
       lintValue env bound action
@@ -181,6 +188,23 @@ lintValue env bound value =
       | otherwise -> [GrinLintUnboundVariable var]
     GrinLitValue _ -> []
     GrinNodeValue node -> lintNode env bound node
+
+lintProject :: RuntimeRep -> GrinValue -> Int -> [GrinLintError]
+lintProject expected object index =
+  case object of
+    GrinNodeValue node ->
+      case grinNodeTag node of
+        GrinConstructor _
+          | index >= length fields -> [GrinLintInvalidProjectIndex index]
+          | index >= 0,
+            let actual = grinValueRuntimeRep (fields !! index),
+            expected /= actual ->
+              [GrinLintRepresentationMismatch "projection result" expected actual]
+          | otherwise -> []
+        tag -> [GrinLintProjectNonConstructor tag]
+      where
+        fields = grinNodeFields node
+    _ -> []
 
 lintNode :: LintEnv -> Set GrinVar -> GrinNode -> [GrinLintError]
 lintNode env bound node =
@@ -245,7 +269,7 @@ exprRuntimeReps expr =
       case alternatives of
         first : _ -> exprRuntimeReps (grinAltRhs first)
         [] -> Nothing
-    GrinDictSelect runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
+    GrinProject runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinThrow {} -> Nothing
     GrinCatch runtimeRep _ _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinForeignCallExpr foreignCall _ ->

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -31,9 +31,6 @@ data GrinLintError
   | GrinLintUnknownForeignCall !Text
   | GrinLintForeignCallDescriptorMismatch !Text
   | GrinLintConstructorLayout !Text ![RuntimeRep] ![RuntimeRep]
-  | GrinLintInvalidProjectIndex !Int
-  | GrinLintProjectNonConstructor !GrinNodeTag
-  | GrinLintProjectNonAtomic !RuntimeRep
   deriving (Eq, Show)
 
 data LintEnv = LintEnv
@@ -137,11 +134,6 @@ lintExpr env bound expr =
     GrinCase scrutinee binder alternatives ->
       lintValue env bound scrutinee
         <> concatMap (lintAlt env (Set.insert binder bound)) alternatives
-    GrinProject runtimeRep object index ->
-      [GrinLintInvalidProjectIndex index | index < 0]
-        <> [GrinLintProjectNonAtomic runtimeRep | runtimeRepComponents runtimeRep /= [runtimeRep]]
-        <> lintProject runtimeRep object index
-        <> lintValue env bound object
     GrinThrow exception -> lintValue env bound exception
     GrinCatch _ action handler state ->
       lintValue env bound action
@@ -188,23 +180,6 @@ lintValue env bound value =
       | otherwise -> [GrinLintUnboundVariable var]
     GrinLitValue _ -> []
     GrinNodeValue node -> lintNode env bound node
-
-lintProject :: RuntimeRep -> GrinValue -> Int -> [GrinLintError]
-lintProject expected object index =
-  case object of
-    GrinNodeValue node ->
-      case grinNodeTag node of
-        GrinConstructor _
-          | index >= length fields -> [GrinLintInvalidProjectIndex index]
-          | index >= 0,
-            let actual = grinValueRuntimeRep (fields !! index),
-            expected /= actual ->
-              [GrinLintRepresentationMismatch "projection result" expected actual]
-          | otherwise -> []
-        tag -> [GrinLintProjectNonConstructor tag]
-      where
-        fields = grinNodeFields node
-    _ -> []
 
 lintNode :: LintEnv -> Set GrinVar -> GrinNode -> [GrinLintError]
 lintNode env bound node =
@@ -269,7 +244,6 @@ exprRuntimeReps expr =
       case alternatives of
         first : _ -> exprRuntimeReps (grinAltRhs first)
         [] -> Nothing
-    GrinProject runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinThrow {} -> Nothing
     GrinCatch runtimeRep _ _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinForeignCallExpr foreignCall _ ->

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -36,7 +36,7 @@ data LowerState = LowerState
     lowerPrimitiveNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
-    lowerRecordArities :: !(Set Int),
+    lowerConstructorLayouts :: !(Map Text [RuntimeRep]),
     lowerLocalVars :: !(Map (Text, Unique) [GrinVar])
   }
 
@@ -108,30 +108,36 @@ extractGrinInterface program =
 -- The supplied program must already have completed its FC transformations.
 lowerProgramWithInterface :: GrinInterface -> FcProgram -> GrinProgram
 lowerProgramWithInterface imported program =
-  lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program)) program
+  lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program) program) program
 
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),
     programEnvironmentWhnfGlobals :: !(Set Text),
-    programEnvironmentPrimitives :: !(Set Text)
+    programEnvironmentPrimitives :: !(Set Text),
+    programEnvironmentConstructorLayouts :: !(Map Text [RuntimeRep])
   }
 
-programEnvironment :: GrinInterface -> ProgramEnvironment
-programEnvironment interface =
+programEnvironment :: GrinInterface -> FcProgram -> ProgramEnvironment
+programEnvironment interface program =
   ProgramEnvironment
     { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
       programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
-      programEnvironmentPrimitives = grinInterfacePrimitives interface
+      programEnvironmentPrimitives = grinInterfacePrimitives interface,
+      programEnvironmentConstructorLayouts =
+        Map.fromList (builtinConstructorLayouts <> programConstructorLayouts program)
     }
+
+programConstructorLayouts :: FcProgram -> [(Text, [RuntimeRep])]
+programConstructorLayouts program =
+  [ (name, concatMap (runtimeRepComponents . typeRuntimeRep) fields)
+  | FcData _ _ constructors <- fcTopBinds program,
+    (name, fields) <- constructors
+  ]
 
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
 lowerProgramWithEnvironment environment program =
   GrinProgram
-    { grinConstructors =
-        loweredConstructors tops
-          <> [ (recordConstructorName arity, replicate arity liftedRuntimeRep)
-             | arity <- Set.toAscList (lowerRecordArities finalState)
-             ],
+    { grinConstructors = loweredConstructors tops,
       grinPrimitives = loweredPrimitives tops,
       grinForeignCalls = loweredForeignCalls tops,
       grinWhnfGlobals = loweredWhnfGlobals tops,
@@ -147,7 +153,7 @@ lowerProgramWithEnvironment environment program =
           lowerPrimitiveNames = programEnvironmentPrimitives environment,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
-          lowerRecordArities = Set.empty,
+          lowerConstructorLayouts = programEnvironmentConstructorLayouts environment,
           lowerLocalVars = Map.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
@@ -257,27 +263,23 @@ lowerNonTupleExpr expr =
       lowerExpr body
     FcDictLam var body ->
       lowerLambda var body
-    FcDict fields -> do
-      let arity = length fields
-          fieldReps = map exprRuntimeRep fields
-      if all (== liftedRuntimeRep) fieldReps
-        then pure ()
-        else error ("GRIN lowering received a non-lifted dictionary layout: " <> show fieldReps)
-      registerRecordConstructor arity
-      lowerArgumentMany fields $ \values ->
-        if length values == arity
-          then pure (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor (recordConstructorName arity)) values)])
-          else error "GRIN lowering expected every dictionary field to occupy one runtime slot"
-    FcDictSelect dictionary index ->
-      lowerSingleStrict "record" dictionary $ \value ->
-        do
-          field <- freshVar "projected_field" liftedRuntimeRep
-          pure
-            ( GrinBind
-                [field]
-                (GrinProject liftedRuntimeRep value index)
-                (GrinEval liftedRuntimeRep (GrinVarValue field))
-            )
+    FcDict constructor fields ->
+      lowerArgumentMany fields $ \values -> do
+        expectedLayout <- lookupConstructorLayout constructor
+        let actualLayout = map grinValueRuntimeRep values
+        if actualLayout == expectedLayout
+          then pure (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor constructor) values)])
+          else
+            error
+              ( "GRIN lowering found constructor layout mismatch for "
+                  <> T.unpack constructor
+                  <> ": expected "
+                  <> show expectedLayout
+                  <> ", got "
+                  <> show actualLayout
+              )
+    FcDictSelect constructor dictionary index ->
+      lowerSingleStrict "dictionary" dictionary $ \value -> lowerConstructorField constructor value index
     FcLet bind body ->
       lowerLet bind body
     FcCase scrutinee binder alternatives ->
@@ -514,14 +516,47 @@ emitFunction :: GrinFunction -> LowerM ()
 emitFunction function =
   modify' $ \state -> state {lowerFunctionsRev = function : lowerFunctionsRev state}
 
--- | FC dictionaries are homogeneous lifted records once type-class meaning is
--- erased. Equal layouts share an ordinary generated constructor.
-registerRecordConstructor :: Int -> LowerM ()
-registerRecordConstructor arity =
-  modify' $ \state -> state {lowerRecordArities = Set.insert arity (lowerRecordArities state)}
+lookupConstructorLayout :: Text -> LowerM [RuntimeRep]
+lookupConstructorLayout constructor = do
+  layouts <- gets lowerConstructorLayouts
+  case Map.lookup constructor layouts of
+    Just layout -> pure layout
+    Nothing -> error ("GRIN lowering could not find constructor layout for " <> T.unpack constructor)
 
-recordConstructorName :: Int -> Text
-recordConstructorName arity = "$grin_record_" <> T.pack (show arity)
+-- | Select a field by destructuring an ordinary constructor node. Dictionary
+-- access needs no GRIN or runtime-system operation beyond the normal case and
+-- evaluation forms used for every other lazy constructor field.
+lowerConstructorField :: Text -> GrinValue -> Int -> LowerM GrinExpr
+lowerConstructorField constructor nodeValue index = do
+  layout <- lookupConstructorLayout constructor
+  if index < 0 || index >= length layout
+    then
+      error
+        ( "GRIN lowering received an invalid field index "
+            <> show index
+            <> " for constructor "
+            <> T.unpack constructor
+        )
+    else do
+      nodeVar <- freshVar "dictionary" liftedRuntimeRep
+      fieldVars <- mapM (freshVar "dictionary_field") layout
+      let selectedVar = fieldVars !! index
+          selectedRep = layout !! index
+          selectedExpr =
+            if isLiftedRuntimeRep selectedRep
+              then GrinEval selectedRep (GrinVarValue selectedVar)
+              else GrinReturn [GrinVarValue selectedVar]
+      pure
+        ( GrinCase
+            nodeValue
+            nodeVar
+            [ GrinAlt
+                { grinAltCon = GrinDataAlt constructor,
+                  grinAltBinders = fieldVars,
+                  grinAltRhs = selectedExpr
+                }
+            ]
+        )
 
 primitiveApplication :: Set Text -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
 primitiveApplication primitiveNames localVars expr =
@@ -555,8 +590,8 @@ freeVars expr =
     FcLam var body -> Set.delete var (freeVars body)
     FcTyLam _ body -> freeVars body
     FcDictLam var body -> Set.delete var (freeVars body)
-    FcDict fields -> foldMap freeVars fields
-    FcDictSelect dictionary _ -> freeVars dictionary
+    FcDict _ fields -> foldMap freeVars fields
+    FcDictSelect _ dictionary _ -> freeVars dictionary
     FcLet bind body -> freeVarsBind bind body
     FcCase scrutinee binder alternatives ->
       freeVars scrutinee
@@ -839,8 +874,8 @@ exprVars expr =
     FcLam var body -> var : exprVars body
     FcTyLam _ body -> exprVars body
     FcDictLam var body -> var : exprVars body
-    FcDict fields -> concatMap exprVars fields
-    FcDictSelect dictionary _ -> exprVars dictionary
+    FcDict _ fields -> concatMap exprVars fields
+    FcDictSelect _ dictionary _ -> exprVars dictionary
     FcLet bind body -> bindVars bind <> exprVars body
     FcCase scrutinee binder alternatives ->
       exprVars scrutinee <> (binder : concatMap altVars alternatives)

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -36,7 +36,6 @@ data LowerState = LowerState
     lowerPrimitiveNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
-    lowerConstructorLayouts :: !(Map Text [RuntimeRep]),
     lowerLocalVars :: !(Map (Text, Unique) [GrinVar])
   }
 
@@ -108,31 +107,21 @@ extractGrinInterface program =
 -- The supplied program must already have completed its FC transformations.
 lowerProgramWithInterface :: GrinInterface -> FcProgram -> GrinProgram
 lowerProgramWithInterface imported program =
-  lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program) program) program
+  lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program)) program
 
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),
     programEnvironmentWhnfGlobals :: !(Set Text),
-    programEnvironmentPrimitives :: !(Set Text),
-    programEnvironmentConstructorLayouts :: !(Map Text [RuntimeRep])
+    programEnvironmentPrimitives :: !(Set Text)
   }
 
-programEnvironment :: GrinInterface -> FcProgram -> ProgramEnvironment
-programEnvironment interface program =
+programEnvironment :: GrinInterface -> ProgramEnvironment
+programEnvironment interface =
   ProgramEnvironment
     { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
       programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
-      programEnvironmentPrimitives = grinInterfacePrimitives interface,
-      programEnvironmentConstructorLayouts =
-        Map.fromList (builtinConstructorLayouts <> programConstructorLayouts program)
+      programEnvironmentPrimitives = grinInterfacePrimitives interface
     }
-
-programConstructorLayouts :: FcProgram -> [(Text, [RuntimeRep])]
-programConstructorLayouts program =
-  [ (name, concatMap (runtimeRepComponents . typeRuntimeRep) fields)
-  | FcData _ _ constructors <- fcTopBinds program,
-    (name, fields) <- constructors
-  ]
 
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
 lowerProgramWithEnvironment environment program =
@@ -153,7 +142,6 @@ lowerProgramWithEnvironment environment program =
           lowerPrimitiveNames = programEnvironmentPrimitives environment,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
-          lowerConstructorLayouts = programEnvironmentConstructorLayouts environment,
           lowerLocalVars = Map.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
@@ -197,7 +185,6 @@ isDirectFunction :: FcExpr -> Bool
 isDirectFunction expr =
   case expr of
     FcLam {} -> True
-    FcDictLam {} -> True
     FcTyLam _ body -> isDirectFunction body
     FcCast inner _ -> isDirectFunction inner
     _ -> False
@@ -253,33 +240,12 @@ lowerNonTupleExpr expr =
       pure (GrinReturn [GrinLitValue (lowerLiteral literal)])
     FcApp function argument ->
       lowerApplication function argument
-    FcDictApp function argument ->
-      lowerApplication function argument
     FcTyApp inner _ ->
       lowerExpr inner
     FcLam var body ->
       lowerLambda var body
     FcTyLam _ body ->
       lowerExpr body
-    FcDictLam var body ->
-      lowerLambda var body
-    FcDict constructor fields ->
-      lowerArgumentMany fields $ \values -> do
-        expectedLayout <- lookupConstructorLayout constructor
-        let actualLayout = map grinValueRuntimeRep values
-        if actualLayout == expectedLayout
-          then pure (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor constructor) values)])
-          else
-            error
-              ( "GRIN lowering found constructor layout mismatch for "
-                  <> T.unpack constructor
-                  <> ": expected "
-                  <> show expectedLayout
-                  <> ", got "
-                  <> show actualLayout
-              )
-    FcDictSelect constructor dictionary index ->
-      lowerSingleStrict "dictionary" dictionary $ \value -> lowerConstructorField constructor value index
     FcLet bind body ->
       lowerLet bind body
     FcCase scrutinee binder alternatives ->
@@ -516,48 +482,6 @@ emitFunction :: GrinFunction -> LowerM ()
 emitFunction function =
   modify' $ \state -> state {lowerFunctionsRev = function : lowerFunctionsRev state}
 
-lookupConstructorLayout :: Text -> LowerM [RuntimeRep]
-lookupConstructorLayout constructor = do
-  layouts <- gets lowerConstructorLayouts
-  case Map.lookup constructor layouts of
-    Just layout -> pure layout
-    Nothing -> error ("GRIN lowering could not find constructor layout for " <> T.unpack constructor)
-
--- | Select a field by destructuring an ordinary constructor node. Dictionary
--- access needs no GRIN or runtime-system operation beyond the normal case and
--- evaluation forms used for every other lazy constructor field.
-lowerConstructorField :: Text -> GrinValue -> Int -> LowerM GrinExpr
-lowerConstructorField constructor nodeValue index = do
-  layout <- lookupConstructorLayout constructor
-  if index < 0 || index >= length layout
-    then
-      error
-        ( "GRIN lowering received an invalid field index "
-            <> show index
-            <> " for constructor "
-            <> T.unpack constructor
-        )
-    else do
-      nodeVar <- freshVar "dictionary" liftedRuntimeRep
-      fieldVars <- mapM (freshVar "dictionary_field") layout
-      let selectedVar = fieldVars !! index
-          selectedRep = layout !! index
-          selectedExpr =
-            if isLiftedRuntimeRep selectedRep
-              then GrinEval selectedRep (GrinVarValue selectedVar)
-              else GrinReturn [GrinVarValue selectedVar]
-      pure
-        ( GrinCase
-            nodeValue
-            nodeVar
-            [ GrinAlt
-                { grinAltCon = GrinDataAlt constructor,
-                  grinAltBinders = fieldVars,
-                  grinAltRhs = selectedExpr
-                }
-            ]
-        )
-
 primitiveApplication :: Set Text -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
 primitiveApplication primitiveNames localVars expr =
   case collectApplications expr of
@@ -573,9 +497,6 @@ collectApplications expr =
     FcApp function argument ->
       let (headExpr, arguments) = collectApplications function
        in (headExpr, arguments <> [argument])
-    FcDictApp function argument ->
-      let (headExpr, arguments) = collectApplications function
-       in (headExpr, arguments <> [argument])
     FcTyApp inner _ -> collectApplications inner
     _ -> (expr, [])
 
@@ -585,13 +506,9 @@ freeVars expr =
     FcVar var -> Set.singleton var
     FcLit _ -> Set.empty
     FcApp function argument -> freeVars function <> freeVars argument
-    FcDictApp function argument -> freeVars function <> freeVars argument
     FcTyApp inner _ -> freeVars inner
     FcLam var body -> Set.delete var (freeVars body)
     FcTyLam _ body -> freeVars body
-    FcDictLam var body -> Set.delete var (freeVars body)
-    FcDict _ fields -> foldMap freeVars fields
-    FcDictSelect _ dictionary _ -> freeVars dictionary
     FcLet bind body -> freeVarsBind bind body
     FcCase scrutinee binder alternatives ->
       freeVars scrutinee
@@ -751,9 +668,6 @@ exprRuntimeRep expr =
     FcLit literal -> literalRuntimeRep literal
     FcLam {} -> liftedRuntimeRep
     FcTyLam {} -> liftedRuntimeRep
-    FcDictLam {} -> liftedRuntimeRep
-    FcDict {} -> liftedRuntimeRep
-    FcDictSelect {} -> liftedRuntimeRep
     _ ->
       case exprType expr of
         Just ty -> typeRuntimeRep ty
@@ -765,7 +679,6 @@ exprType expr =
     FcVar var -> Just (varType var)
     FcLit literal -> literalType literal
     FcApp function _ -> functionResultType =<< exprType function
-    FcDictApp function _ -> functionResultType =<< exprType function
     FcTyApp function argument -> do
       functionType <- exprType function
       case functionType of
@@ -773,9 +686,6 @@ exprType expr =
         _ -> Just functionType
     FcLam var body -> TcFunTy (varType var) <$> exprType body
     FcTyLam tyVar body -> TcForAllTy tyVar <$> exprType body
-    FcDictLam var body -> TcFunTy (varType var) <$> exprType body
-    FcDict {} -> Nothing
-    FcDictSelect {} -> Nothing
     FcLet _ body -> exprType body
     FcCase _ _ alternatives ->
       case alternatives of
@@ -869,13 +779,9 @@ exprVars expr =
     FcVar var -> [var]
     FcLit _ -> []
     FcApp function argument -> exprVars function <> exprVars argument
-    FcDictApp function argument -> exprVars function <> exprVars argument
     FcTyApp inner _ -> exprVars inner
     FcLam var body -> var : exprVars body
     FcTyLam _ body -> exprVars body
-    FcDictLam var body -> var : exprVars body
-    FcDict _ fields -> concatMap exprVars fields
-    FcDictSelect _ dictionary _ -> exprVars dictionary
     FcLet bind body -> bindVars bind <> exprVars body
     FcCase scrutinee binder alternatives ->
       exprVars scrutinee <> (binder : concatMap altVars alternatives)

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -36,6 +36,7 @@ data LowerState = LowerState
     lowerPrimitiveNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
+    lowerRecordArities :: !(Set Int),
     lowerLocalVars :: !(Map (Text, Unique) [GrinVar])
   }
 
@@ -126,7 +127,11 @@ programEnvironment interface =
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
 lowerProgramWithEnvironment environment program =
   GrinProgram
-    { grinConstructors = loweredConstructors tops,
+    { grinConstructors =
+        loweredConstructors tops
+          <> [ (recordConstructorName arity, replicate arity liftedRuntimeRep)
+             | arity <- Set.toAscList (lowerRecordArities finalState)
+             ],
       grinPrimitives = loweredPrimitives tops,
       grinForeignCalls = loweredForeignCalls tops,
       grinWhnfGlobals = loweredWhnfGlobals tops,
@@ -142,6 +147,7 @@ lowerProgramWithEnvironment environment program =
           lowerPrimitiveNames = programEnvironmentPrimitives environment,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
+          lowerRecordArities = Set.empty,
           lowerLocalVars = Map.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
@@ -251,12 +257,27 @@ lowerNonTupleExpr expr =
       lowerExpr body
     FcDictLam var body ->
       lowerLambda var body
-    FcDict fields ->
+    FcDict fields -> do
+      let arity = length fields
+          fieldReps = map exprRuntimeRep fields
+      if all (== liftedRuntimeRep) fieldReps
+        then pure ()
+        else error ("GRIN lowering received a non-lifted dictionary layout: " <> show fieldReps)
+      registerRecordConstructor arity
       lowerArgumentMany fields $ \values ->
-        pure (GrinReturn [GrinNodeValue (GrinNode GrinDictionary values)])
+        if length values == arity
+          then pure (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor (recordConstructorName arity)) values)])
+          else error "GRIN lowering expected every dictionary field to occupy one runtime slot"
     FcDictSelect dictionary index ->
-      lowerSingleStrict "dictionary" dictionary $ \value ->
-        pure (GrinDictSelect liftedRuntimeRep value index)
+      lowerSingleStrict "record" dictionary $ \value ->
+        do
+          field <- freshVar "projected_field" liftedRuntimeRep
+          pure
+            ( GrinBind
+                [field]
+                (GrinProject liftedRuntimeRep value index)
+                (GrinEval liftedRuntimeRep (GrinVarValue field))
+            )
     FcLet bind body ->
       lowerLet bind body
     FcCase scrutinee binder alternatives ->
@@ -492,6 +513,15 @@ freshFunction kind = do
 emitFunction :: GrinFunction -> LowerM ()
 emitFunction function =
   modify' $ \state -> state {lowerFunctionsRev = function : lowerFunctionsRev state}
+
+-- | FC dictionaries are homogeneous lifted records once type-class meaning is
+-- erased. Equal layouts share an ordinary generated constructor.
+registerRecordConstructor :: Int -> LowerM ()
+registerRecordConstructor arity =
+  modify' $ \state -> state {lowerRecordArities = Set.insert arity (lowerRecordArities state)}
+
+recordConstructorName :: Int -> Text
+recordConstructorName arity = "$grin_record_" <> T.pack (show arity)
 
 primitiveApplication :: Set Text -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
 primitiveApplication primitiveNames localVars expr =

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -106,14 +106,6 @@ renderExprIndented indentation expr =
         <> renderVar binder
         <> " of\n"
         <> intercalate "\n" (map (renderAlt (indentation + 2)) alternatives)
-    GrinProject runtimeRep object index ->
-      indent indentation
-        <> "project @"
-        <> show runtimeRep
-        <> " "
-        <> renderValue object
-        <> " "
-        <> show index
     GrinThrow exception -> indent indentation <> "throw " <> renderValue exception
     GrinCatch runtimeRep action handler state ->
       indent indentation

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -106,12 +106,12 @@ renderExprIndented indentation expr =
         <> renderVar binder
         <> " of\n"
         <> intercalate "\n" (map (renderAlt (indentation + 2)) alternatives)
-    GrinDictSelect runtimeRep dictionary index ->
+    GrinProject runtimeRep object index ->
       indent indentation
-        <> "select @"
+        <> "project @"
         <> show runtimeRep
         <> " "
-        <> renderValue dictionary
+        <> renderValue object
         <> " "
         <> show index
     GrinThrow exception -> indent indentation <> "throw " <> renderValue exception
@@ -174,7 +174,6 @@ renderNodeTag nodeTag =
       "P" <> T.unpack (unFunctionName functionName) <> "/" <> show argumentCount
     GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
     GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
-    GrinDictionary -> "Dict"
 
 renderLiteral :: GrinLiteral -> String
 renderLiteral literal =

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -28,6 +28,7 @@ module Aihc.Grin.Syntax
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
     builtinConstructors,
+    builtinConstructorLayouts,
   )
 where
 
@@ -95,10 +96,6 @@ data GrinExpr
   | GrinEval !RuntimeRep !GrinValue
   | GrinApply !RuntimeRep !GrinValue ![GrinValue]
   | GrinCase !GrinValue !GrinVar ![GrinAlt]
-  | -- | Project one field from an ordinary constructor node. The node must
-    -- already be in weak-head normal form; evaluating the selected field is a
-    -- separate 'GrinEval'.
-    GrinProject !RuntimeRep !GrinValue !Int
   | GrinThrow !GrinValue
   | GrinCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
   | -- | A saturated call whose operands are already strict primitive values.
@@ -182,12 +179,15 @@ isPointerRuntimeRep runtimeRep =
 -- interpretation, linting, and native code generation agree on which global
 -- constructor values exist before the program starts.
 builtinConstructors :: [(Text, Int)]
-builtinConstructors =
-  [ ("C#", 1),
-    ("[]", 0),
-    (":", 2),
-    ("()", 0),
-    ("(,)", 2)
+builtinConstructors = [(name, length layout) | (name, layout) <- builtinConstructorLayouts]
+
+builtinConstructorLayouts :: [(Text, [RuntimeRep])]
+builtinConstructorLayouts =
+  [ ("C#", [WordRep]),
+    ("[]", []),
+    (":", [liftedRuntimeRep, liftedRuntimeRep]),
+    ("()", []),
+    ("(,)", [liftedRuntimeRep, liftedRuntimeRep])
   ]
 
 data GrinForeignCall = GrinForeignCall

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -95,7 +95,10 @@ data GrinExpr
   | GrinEval !RuntimeRep !GrinValue
   | GrinApply !RuntimeRep !GrinValue ![GrinValue]
   | GrinCase !GrinValue !GrinVar ![GrinAlt]
-  | GrinDictSelect !RuntimeRep !GrinValue !Int
+  | -- | Project one field from an ordinary constructor node. The node must
+    -- already be in weak-head normal form; evaluating the selected field is a
+    -- separate 'GrinEval'.
+    GrinProject !RuntimeRep !GrinValue !Int
   | GrinThrow !GrinValue
   | GrinCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
   | -- | A saturated call whose operands are already strict primitive values.
@@ -122,7 +125,6 @@ data GrinNodeTag
     -- @BoxedRep Lifted@; unlifted computations are always evaluated strictly.
     GrinThunk !FunctionName
   | GrinPrimitive !Text !Int
-  | GrinDictionary
   deriving (Eq, Show, Read)
 
 data GrinAlt = GrinAlt

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -28,7 +28,6 @@ module Aihc.Grin.Syntax
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
     builtinConstructors,
-    builtinConstructorLayouts,
   )
 where
 
@@ -179,15 +178,12 @@ isPointerRuntimeRep runtimeRep =
 -- interpretation, linting, and native code generation agree on which global
 -- constructor values exist before the program starts.
 builtinConstructors :: [(Text, Int)]
-builtinConstructors = [(name, length layout) | (name, layout) <- builtinConstructorLayouts]
-
-builtinConstructorLayouts :: [(Text, [RuntimeRep])]
-builtinConstructorLayouts =
-  [ ("C#", [WordRep]),
-    ("[]", []),
-    (":", [liftedRuntimeRep, liftedRuntimeRep]),
-    ("()", []),
-    ("(,)", [liftedRuntimeRep, liftedRuntimeRep])
+builtinConstructors =
+  [ ("C#", 1),
+    ("[]", 0),
+    (":", 2),
+    ("()", 0),
+    ("(,)", 2)
   ]
 
 data GrinForeignCall = GrinForeignCall

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -56,6 +56,35 @@ grinUnitTests =
         assertBool
           "constructor layout mismatch"
           (GrinLintConstructorLayout "Box" [WordRep] [IntRep] `elem` lintProgram program),
+      testCase "lint rejects statically invalid constructor projections" $ do
+        let functionName = FunctionName "project_code"
+            nonConstructor = GrinNodeValue (GrinNode (GrinThunk functionName) [])
+            box = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])
+            projectProgram resultRep constructors object index =
+              GrinProgram
+                { grinConstructors = constructors,
+                  grinPrimitives = [],
+                  grinForeignCalls = [],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = functionName,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = resultRep,
+                          grinFunctionBody = GrinProject resultRep object index
+                        }
+                    ]
+                }
+        assertBool
+          "non-constructor projection"
+          (GrinLintProjectNonConstructor (GrinThunk functionName) `elem` lintProgram (projectProgram (BoxedRep Lifted) [] nonConstructor 0))
+        assertBool
+          "out-of-bounds projection"
+          (GrinLintInvalidProjectIndex 1 `elem` lintProgram (projectProgram IntRep [("Box", [IntRep])] box 1))
+        assertBool
+          "non-atomic projection result"
+          (GrinLintProjectNonAtomic (TupleRep [IntRep, WordRep]) `elem` lintProgram (projectProgram (TupleRep [IntRep, WordRep]) [("Box", [IntRep])] box 0)),
       testCase "FC lowering makes exception control explicit" $ do
         let program = lowerProgram exceptionProgram
             rendered = renderProgram program
@@ -95,6 +124,18 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertEqual "direct function globals" ["direct"] (map (grinVarName . fst) (grinWhnfGlobals program))
         assertEqual "computed function CAFs" ["computed"] (map (grinVarName . fst) (grinCafs program)),
+      testCase "FC dictionaries lower to ordinary constructor projection" $ do
+        let program = lowerProgram dictionaryProgram
+            rendered = renderProgram program
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual
+          "dictionary layout"
+          (Just [BoxedRep Lifted, BoxedRep Lifted])
+          (lookup "$grin_record_2" (grinConstructors program))
+        assertBool "ordinary constructor node" ("C$grin_record_2" `isInfixOf` rendered)
+        assertBool "ordinary field projection" ("project @BoxedRep Lifted" `isInfixOf` rendered)
+        result <- interpretProgramBinding "answer" program
+        assertEqual "selected field is evaluated" (Right "Box 2") result,
       testCase "separate FC units do not capture dependency globals" $ do
         case separatePrograms of
           [providerCore, consumerCore] -> do
@@ -316,6 +357,21 @@ functionClassificationProgram =
     computedArgumentVar = Var "argument" (Unique 35) boxedIntTy
     computedVar = Var "computed" (Unique 36) (TcFunTy boxedIntTy boxedIntTy)
     boxConstructorVar = Var "BoxedInt" (Unique 37) (TcFunTy intTy boxedIntTy)
+
+dictionaryProgram :: FcProgram
+dictionaryProgram =
+  FcProgram
+    [ FcData "Box" [] [("Box", [intTy])],
+      FcTopBind
+        ( FcNonRec
+            answerVar
+            (FcDictSelect (FcDict [boxed 1, boxed 2]) 1)
+        )
+    ]
+  where
+    answerVar = Var "answer" (Unique 40) boxedIntTy
+    boxConstructorVar = Var "Box" (Unique 41) (TcFunTy intTy boxedIntTy)
+    boxed value = FcApp (FcVar boxConstructorVar) (FcLit (LitInt IntRep value))
 
 exceptionProgram :: FcProgram
 exceptionProgram =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -56,35 +56,6 @@ grinUnitTests =
         assertBool
           "constructor layout mismatch"
           (GrinLintConstructorLayout "Box" [WordRep] [IntRep] `elem` lintProgram program),
-      testCase "lint rejects statically invalid constructor projections" $ do
-        let functionName = FunctionName "project_code"
-            nonConstructor = GrinNodeValue (GrinNode (GrinThunk functionName) [])
-            box = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])
-            projectProgram resultRep constructors object index =
-              GrinProgram
-                { grinConstructors = constructors,
-                  grinPrimitives = [],
-                  grinForeignCalls = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
-                  grinFunctions =
-                    [ GrinFunction
-                        { grinFunctionName = functionName,
-                          grinFunctionParameters = [],
-                          grinFunctionResultRep = resultRep,
-                          grinFunctionBody = GrinProject resultRep object index
-                        }
-                    ]
-                }
-        assertBool
-          "non-constructor projection"
-          (GrinLintProjectNonConstructor (GrinThunk functionName) `elem` lintProgram (projectProgram (BoxedRep Lifted) [] nonConstructor 0))
-        assertBool
-          "out-of-bounds projection"
-          (GrinLintInvalidProjectIndex 1 `elem` lintProgram (projectProgram IntRep [("Box", [IntRep])] box 1))
-        assertBool
-          "non-atomic projection result"
-          (GrinLintProjectNonAtomic (TupleRep [IntRep, WordRep]) `elem` lintProgram (projectProgram (TupleRep [IntRep, WordRep]) [("Box", [IntRep])] box 0)),
       testCase "FC lowering makes exception control explicit" $ do
         let program = lowerProgram exceptionProgram
             rendered = renderProgram program
@@ -124,16 +95,18 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertEqual "direct function globals" ["direct"] (map (grinVarName . fst) (grinWhnfGlobals program))
         assertEqual "computed function CAFs" ["computed"] (map (grinVarName . fst) (grinCafs program)),
-      testCase "FC dictionaries lower to ordinary constructor projection" $ do
+      testCase "FC dictionaries lower to ordinary constructor nodes and cases" $ do
         let program = lowerProgram dictionaryProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
         assertEqual
-          "dictionary layout"
-          (Just [BoxedRep Lifted, BoxedRep Lifted])
-          (lookup "$grin_record_2" (grinConstructors program))
-        assertBool "ordinary constructor node" ("C$grin_record_2" `isInfixOf` rendered)
-        assertBool "ordinary field projection" ("project @BoxedRep Lifted" `isInfixOf` rendered)
+          "dictionary constructor has an ordinary declared layout"
+          [("Box", [IntRep]), ("$Dict$Test", [BoxedRep Lifted, BoxedRep Lifted])]
+          (grinConstructors program)
+        assertBool "one ordinary dictionary node" ("C$Dict$Test" `isInfixOf` rendered)
+        assertBool "ordinary dictionary case" ("C$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
+        assertBool "no tuple encoding" (not ("C(,)" `isInfixOf` rendered || "C()" `isInfixOf` rendered))
+        assertBool "no projection operation" (not ("project " `isInfixOf` rendered))
         result <- interpretProgramBinding "answer" program
         assertEqual "selected field is evaluated" (Right "Box 2") result,
       testCase "separate FC units do not capture dependency globals" $ do
@@ -362,10 +335,11 @@ dictionaryProgram :: FcProgram
 dictionaryProgram =
   FcProgram
     [ FcData "Box" [] [("Box", [intTy])],
+      FcData "$DictType$Test" [] [("$Dict$Test", [boxedIntTy, boxedIntTy])],
       FcTopBind
         ( FcNonRec
             answerVar
-            (FcDictSelect (FcDict [boxed 1, boxed 2]) 1)
+            (FcDictSelect "$Dict$Test" (FcDict "$Dict$Test" [boxed 1, boxed 2]) 1)
         )
     ]
   where

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -103,8 +103,8 @@ grinUnitTests =
           "dictionary constructor has an ordinary declared layout"
           [("Box", [IntRep]), ("$Dict$Test", [BoxedRep Lifted, BoxedRep Lifted])]
           (grinConstructors program)
-        assertBool "one ordinary dictionary node" ("C$Dict$Test" `isInfixOf` rendered)
-        assertBool "ordinary dictionary case" ("C$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
+        assertBool ("ordinary dictionary constructor application:\n" <> rendered) ("$Dict$Test" `isInfixOf` rendered && "apply " `isInfixOf` rendered)
+        assertBool "ordinary dictionary case" ("$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
         assertBool "no tuple encoding" (not ("C(,)" `isInfixOf` rendered || "C()" `isInfixOf` rendered))
         assertBool "no projection operation" (not ("project " `isInfixOf` rendered))
         result <- interpretProgramBinding "answer" program
@@ -309,7 +309,7 @@ functionClassificationProgram =
       FcTopBind
         ( FcNonRec
             directVar
-            (FcTyLam typeVar (FcDictLam dictionaryVar (FcLam directArgumentVar (FcVar directArgumentVar))))
+            (FcTyLam typeVar (FcLam dictionaryVar (FcLam directArgumentVar (FcVar directArgumentVar))))
         ),
       FcTopBind
         ( FcNonRec
@@ -335,16 +335,26 @@ dictionaryProgram :: FcProgram
 dictionaryProgram =
   FcProgram
     [ FcData "Box" [] [("Box", [intTy])],
-      FcData "$DictType$Test" [] [("$Dict$Test", [boxedIntTy, boxedIntTy])],
+      FcData "Test" [] [("$Dict$Test", [boxedIntTy, boxedIntTy])],
       FcTopBind
         ( FcNonRec
             answerVar
-            (FcDictSelect "$Dict$Test" (FcDict "$Dict$Test" [boxed 1, boxed 2]) 1)
+            ( FcCase
+                dictionary
+                dictionaryBinder
+                [FcAlt (DataAlt "$Dict$Test") [firstMethod, secondMethod] (FcVar secondMethod)]
+            )
         )
     ]
   where
+    dictionaryTy = TcTyCon (TyCon "Test" 0) []
     answerVar = Var "answer" (Unique 40) boxedIntTy
     boxConstructorVar = Var "Box" (Unique 41) (TcFunTy intTy boxedIntTy)
+    dictionaryConstructorVar = Var "$Dict$Test" (Unique 42) (TcFunTy boxedIntTy (TcFunTy boxedIntTy dictionaryTy))
+    dictionaryBinder = Var "$dictionary" (Unique 43) dictionaryTy
+    firstMethod = Var "$method0" (Unique 44) boxedIntTy
+    secondMethod = Var "$method1" (Unique 45) boxedIntTy
+    dictionary = FcApp (FcApp (FcVar dictionaryConstructorVar) (boxed 1)) (boxed 2)
     boxed value = FcApp (FcVar boxConstructorVar) (FcLit (LitInt IntRep value))
 
 exceptionProgram :: FcProgram


### PR DESCRIPTION
## Summary

- represent each type-class dictionary as an ordinary parameterized FC data declaration with a class-specific constructor
- lower constraints to explicit ordinary function arrows at the TC-to-FC boundary
- generate method selectors as ordinary lambdas and constructor cases
- generate instance dictionaries as ordinary constructor applications, including polymorphic methods with additional constraints
- remove all special FC and GRIN dictionary terms, projection/record-arity lowering, dictionary node tags, and dictionary-specific ARM64 runtime support

## Why

Dictionaries are runtime objects, not a distinct GRIN or RTS concept. Keeping special dictionary applications, records, selectors, projections, layouts, and runtime continuations duplicated behavior already expressed by ordinary functions, constructors, and cases.

The Core representation now states the implementation directly. For example, `Eq a` becomes an ordinary `data Eq a = $Dict$Eq (...)`; `(==)` accepts an `Eq a` value and selects its method with a normal case; `$fEqBool` constructs that value with `$Dict$Eq @Bool`. GRIN receives only ordinary constructor nodes and case expressions. No tuple encoding or projection is involved.

## Impact

- FC consumers see explicit dictionary data types and ordinary term applications instead of `FcDict*` forms.
- GRIN, its interpreter/linter/pretty-printer, ARM64 code generation, and the RTS are entirely dictionary-oblivious.
- Dictionary constructors participate in the same linting, dead-code reachability, lowering, linking, evaluation, and case dispatch as every other data constructor.

## Progress counts

- FC spec: 95 → 97 tests
- GRIN spec: 94 → 95 tests
- ARM64 spec: unchanged at 9 tests
- FC golden fixtures: +1 PASS fixture for constrained polymorphic dictionary methods
- README progress counts: unchanged (cron-managed)

## Validation

- `cabal test -v0 aihc-fc:spec --test-options=--hide-successes` (97 passed)
- `cabal test -v0 aihc-grin:spec --test-options=--hide-successes` (95 passed)
- installed-module regression for a cast-style instance using an imported method
- `just fmt`
- `just check`
