### PR TITLE
feat(grin): store saturated constructors directly

### DIFF
--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -161,7 +161,8 @@ void aihc_set_cell(AihcValue *cell, AihcValue *value) {
   if (cell->kind != AIHC_CELL) {
     aihc_fail("attempted to initialize a non-cell");
   }
-  cell->info = AIHC_CELL_SUSPENDED;
+  cell->info =
+      value->kind == AIHC_THUNK ? AIHC_CELL_SUSPENDED : AIHC_CELL_VALUE;
   cell->fields[0] = (AihcSlot)value;
 }
 

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -186,8 +186,11 @@ evalExpr env expr =
       if length vars == length values
         then evalExpr (Map.fromList (zip vars values) `Map.union` env) body
         else throwInterpret (InterpretResultArity (length vars) (length values))
-    GrinStore node ->
-      pure <$> allocateCell (HeapSuspended env node)
+    GrinStore node@GrinNode {grinNodeTag} ->
+      pure
+        <$> case grinNodeTag of
+          GrinThunk {} -> allocateCell (HeapSuspended env node)
+          _ -> evalNode env node >>= allocateCell . HeapValue
     GrinStoreRec bindings body -> do
       locations <- mapM (const (allocateLocation HeapBlackhole)) bindings
       let recursiveBindings = zip (map fst bindings) (map RuntimeLocation locations)

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -71,7 +71,7 @@ instance Show GrinMutVar where
 type Env = Map GrinVar RuntimeValue
 
 data HeapCell
-  = HeapSuspended !Env !GrinNode
+  = HeapSuspended !FunctionName ![RuntimeValue]
   | HeapValue !RuntimeValue
   | HeapRaised !RuntimeValue
   | HeapBlackhole
@@ -137,7 +137,7 @@ initialMachine program =
       machineGlobals = globals,
       machineHeap =
         IntMap.fromList
-          [ (location, HeapSuspended cafEnv node)
+          [ (location, storedCell (staticNode node))
           | ((_, node), location) <- zip cafs [0 ..]
           ],
       machineNextLocation = length cafs
@@ -148,7 +148,6 @@ initialMachine program =
       [ (var, RuntimeLocation location)
       | ((var, _), location) <- zip cafs [0 ..]
       ]
-    cafEnv = Map.fromList cafLocations
     staticGlobals =
       Map.fromList
         [ (grinVarName var, staticNode node)
@@ -180,47 +179,43 @@ initialMachine program =
 evalExpr :: Env -> GrinExpr -> EvalM [RuntimeValue]
 evalExpr env expr =
   case expr of
-    GrinReturn values -> mapM (evalValue env) values
+    GrinReturn values -> mapM (materializeValue env) values
     GrinBind vars valueExpr body -> do
       values <- evalExpr env valueExpr
       if length vars == length values
         then evalExpr (Map.fromList (zip vars values) `Map.union` env) body
         else throwInterpret (InterpretResultArity (length vars) (length values))
-    GrinStore node@GrinNode {grinNodeTag} ->
-      pure
-        <$> case grinNodeTag of
-          GrinThunk {} -> allocateCell (HeapSuspended env node)
-          _ -> evalNode env node >>= allocateCell . HeapValue
+    GrinStore node ->
+      pure <$> (materializeNode env node >>= allocateCell . storedCell)
     GrinStoreRec bindings body -> do
       locations <- mapM (const (allocateLocation HeapBlackhole)) bindings
       let recursiveBindings = zip (map fst bindings) (map RuntimeLocation locations)
           recursiveEnv = Map.fromList recursiveBindings `Map.union` env
-      mapM_
-        (\((_, node), location) -> writeCell location (HeapSuspended recursiveEnv node))
-        (zip bindings locations)
+      runtimeNodes <- mapM (materializeNode recursiveEnv . snd) bindings
+      mapM_ (uncurry writeCell) (zip locations (map storedCell runtimeNodes))
       evalExpr recursiveEnv body
     GrinFetch _ pointer ->
-      (: []) <$> (evalValue env pointer >>= fetchValue)
+      (: []) <$> (materializeValue env pointer >>= fetchValue)
     GrinUpdate pointer value -> do
-      pointerValue <- evalValue env pointer
-      updatedValue <- evalValue env value
+      pointerValue <- materializeValue env pointer
+      updatedValue <- materializeValue env value
       pure <$> updateValue pointerValue updatedValue
     GrinEval _ value ->
-      (: []) <$> (evalValue env value >>= forceValue)
+      (: []) <$> (materializeValue env value >>= forceValue)
     GrinApply _ function arguments -> do
-      functionValue <- evalValue env function
-      argumentValues <- mapM (evalValue env) arguments
+      functionValue <- materializeValue env function
+      argumentValues <- mapM (materializeValue env) arguments
       applyValue functionValue argumentValues
     GrinCase scrutinee binder alternatives -> do
-      value <- evalValue env scrutinee >>= forceValue
+      value <- materializeValue env scrutinee >>= forceValue
       matchAlternative (Map.insert binder value env) value alternatives
     GrinThrow exception -> do
-      exceptionValue <- evalValue env exception >>= forceValue
+      exceptionValue <- materializeValue env exception >>= forceValue
       throwE (EvalRaised exceptionValue)
     GrinCatch runtimeRep action handler state -> do
-      actionValue <- evalValue env action
-      handlerValue <- evalValue env handler
-      stateValues <- mapM (evalValue env) state
+      actionValue <- materializeValue env action
+      handlerValue <- materializeValue env handler
+      stateValues <- mapM (materializeValue env) state
       results <- applyValue actionValue stateValues `catchE` handleRaised handlerValue stateValues
       let expectedCount = length (runtimeRepComponents runtimeRep)
       case length results - expectedCount of
@@ -230,7 +225,7 @@ evalExpr env expr =
         1 -> pure (drop 1 results)
         _ -> throwInterpret (InterpretResultArity expectedCount (length results))
     GrinForeignCallExpr foreignCall arguments -> do
-      argumentValues <- mapM (evalValue env) arguments
+      argumentValues <- mapM (materializeValue env) arguments
       executeForeignCall foreignCall argumentValues
 
 handleRaised :: RuntimeValue -> [RuntimeValue] -> EvalFailure -> EvalM [RuntimeValue]
@@ -241,8 +236,11 @@ handleRaised handler state failure =
       applyValue handlerWithException state
     EvalInterpret err -> throwE (EvalInterpret err)
 
-evalValue :: Env -> GrinValue -> EvalM RuntimeValue
-evalValue env value =
+-- | Resolve an atomic GRIN value into its runtime representation. This only
+-- captures variables and constructs nodes; it never forces a heap location or
+-- enters a thunk.
+materializeValue :: Env -> GrinValue -> EvalM RuntimeValue
+materializeValue env value =
   case value of
     GrinVarValue var ->
       case Map.lookup var env of
@@ -253,11 +251,17 @@ evalValue env value =
             Just runtimeValue -> pure runtimeValue
             Nothing -> throwInterpret (InterpretUnboundVariable var)
     GrinLitValue literal -> pure (RuntimeLit literal)
-    GrinNodeValue node -> evalNode env node
+    GrinNodeValue node -> materializeNode env node
 
-evalNode :: Env -> GrinNode -> EvalM RuntimeValue
-evalNode env node =
-  RuntimeNode (grinNodeTag node) <$> mapM (evalValue env) (grinNodeFields node)
+materializeNode :: Env -> GrinNode -> EvalM RuntimeValue
+materializeNode env node =
+  RuntimeNode (grinNodeTag node) <$> mapM (materializeValue env) (grinNodeFields node)
+
+storedCell :: RuntimeValue -> HeapCell
+storedCell value =
+  case value of
+    RuntimeNode (GrinThunk functionName) fields -> HeapSuspended functionName fields
+    _ -> HeapValue value
 
 allocateCell :: HeapCell -> EvalM RuntimeValue
 allocateCell cell = RuntimeLocation <$> allocateLocation cell
@@ -292,7 +296,7 @@ fetchValue value =
     RuntimeLocation location -> do
       cell <- readCell location
       case cell of
-        HeapSuspended nodeEnv node -> evalNode nodeEnv node
+        HeapSuspended functionName fields -> pure (RuntimeNode (GrinThunk functionName) fields)
         HeapValue result -> pure result
         HeapRaised exception -> throwE (EvalRaised exception)
         HeapBlackhole -> throwInterpret (InterpretBlackhole location)
@@ -316,31 +320,27 @@ forceLocation :: Int -> EvalM RuntimeValue
 forceLocation location = do
   cell <- readCell location
   case cell of
-    HeapSuspended nodeEnv node -> do
-      nodeValue <- evalNode nodeEnv node
-      case nodeValue of
-        RuntimeNode (GrinThunk functionName) fields -> do
-          function <- lookupFunction functionName
-          let resultRep = grinFunctionResultRep function
-          if isLiftedRuntimeRep resultRep
-            then pure ()
-            else throwInterpret (InterpretInvalidThunkResultRep functionName resultRep)
-          writeCell location HeapBlackhole
-          result <- (Right <$> callFunction functionName fields) `catchE` (pure . Left)
-          case result of
-            Right [value] -> do
-              writeCell location (HeapValue value)
-              forceValue value
-            Right values -> do
-              writeCell location cell
-              throwInterpret (InterpretInvalidThunkResult values)
-            Left failure@(EvalRaised exception) -> do
-              writeCell location (HeapRaised exception)
-              throwE failure
-            Left failure@(EvalInterpret _) -> do
-              writeCell location cell
-              throwE failure
-        other -> pure other
+    HeapSuspended functionName fields -> do
+      function <- lookupFunction functionName
+      let resultRep = grinFunctionResultRep function
+      if isLiftedRuntimeRep resultRep
+        then pure ()
+        else throwInterpret (InterpretInvalidThunkResultRep functionName resultRep)
+      writeCell location HeapBlackhole
+      result <- (Right <$> callFunction functionName fields) `catchE` (pure . Left)
+      case result of
+        Right [value] -> do
+          writeCell location (HeapValue value)
+          forceValue value
+        Right values -> do
+          writeCell location cell
+          throwInterpret (InterpretInvalidThunkResult values)
+        Left failure@(EvalRaised exception) -> do
+          writeCell location (HeapRaised exception)
+          throwE failure
+        Left failure@(EvalInterpret _) -> do
+          writeCell location cell
+          throwE failure
     HeapValue result -> forceValue result
     HeapRaised exception -> throwE (EvalRaised exception)
     HeapBlackhole -> throwInterpret (InterpretBlackhole location)

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -33,6 +33,7 @@ data LowerState = LowerState
   { lowerNextUnique :: !Int,
     lowerNextFunction :: !Int,
     lowerFunctionsRev :: ![GrinFunction],
+    lowerConstructorArities :: !(Map Text Int),
     lowerPrimitiveNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
@@ -71,11 +72,12 @@ lowerProgram sourceProgram = lowerProgramWithInterface mempty program
     program = lowerNewtypes sourceProgram
 
 -- | Runtime facts exported by one compiled unit. Lowering consumers need to
--- know which external names are globals, already in WHNF, or primitives, but
--- never need the defining FC expressions.
+-- know which external names are globals, already in WHNF, constructors, or
+-- primitives, but never need the defining FC expressions.
 data GrinInterface = GrinInterface
   { grinInterfaceGlobals :: !(Set Text),
     grinInterfaceWhnfGlobals :: !(Set Text),
+    grinInterfaceConstructorArities :: !(Map Text Int),
     grinInterfacePrimitives :: !(Set Text)
   }
   deriving (Eq, Show, Read)
@@ -85,17 +87,19 @@ instance Semigroup GrinInterface where
     GrinInterface
       { grinInterfaceGlobals = grinInterfaceGlobals left <> grinInterfaceGlobals right,
         grinInterfaceWhnfGlobals = grinInterfaceWhnfGlobals left <> grinInterfaceWhnfGlobals right,
+        grinInterfaceConstructorArities = grinInterfaceConstructorArities left <> grinInterfaceConstructorArities right,
         grinInterfacePrimitives = grinInterfacePrimitives left <> grinInterfacePrimitives right
       }
 
 instance Monoid GrinInterface where
-  mempty = GrinInterface Set.empty Set.empty Set.empty
+  mempty = GrinInterface Set.empty Set.empty Map.empty Set.empty
 
 extractGrinInterface :: FcProgram -> GrinInterface
 extractGrinInterface program =
   GrinInterface
     { grinInterfaceGlobals = Set.fromList (programGlobalNames program),
       grinInterfaceWhnfGlobals = Set.fromList (programWhnfGlobalNames program),
+      grinInterfaceConstructorArities = Map.fromList (programConstructors program),
       grinInterfacePrimitives =
         Set.fromList
           [ varName var
@@ -112,6 +116,7 @@ lowerProgramWithInterface imported program =
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),
     programEnvironmentWhnfGlobals :: !(Set Text),
+    programEnvironmentConstructorArities :: !(Map Text Int),
     programEnvironmentPrimitives :: !(Set Text)
   }
 
@@ -120,6 +125,7 @@ programEnvironment interface =
   ProgramEnvironment
     { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
       programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
+      programEnvironmentConstructorArities = Map.fromList builtinConstructors <> grinInterfaceConstructorArities interface,
       programEnvironmentPrimitives = grinInterfacePrimitives interface
     }
 
@@ -139,6 +145,7 @@ lowerProgramWithEnvironment environment program =
         { lowerNextUnique = maximum (0 : map sourceUnique (programVars program)) + 1,
           lowerNextFunction = 0,
           lowerFunctionsRev = [],
+          lowerConstructorArities = programEnvironmentConstructorArities environment,
           lowerPrimitiveNames = programEnvironmentPrimitives environment,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
@@ -198,16 +205,22 @@ makeGlobalFunction expr = do
 
 lowerExpr :: FcExpr -> LowerM GrinExpr
 lowerExpr expr = do
+  constructorArities <- gets lowerConstructorArities
   primitiveNames <- gets lowerPrimitiveNames
   localVars <- gets lowerLocalVars
-  case primitiveApplication primitiveNames (Map.keysSet localVars) expr of
-    Just ("raise#", [exception]) ->
-      lowerSingleStrict "exception" exception (pure . GrinThrow)
-    Just ("catch#", [action, handler, _state]) ->
-      lowerSingleArgument action $ \actionValue ->
-        lowerSingleArgument handler $ \handlerValue ->
-          pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue [])
-    _ -> lowerOrdinaryExpr expr
+  case saturatedConstructorApplication constructorArities (Map.keysSet localVars) expr of
+    Just (constructor, arguments) ->
+      lowerArgumentMany arguments $ \values ->
+        pure (GrinStore (GrinNode (GrinConstructor constructor) values))
+    Nothing ->
+      case primitiveApplication primitiveNames (Map.keysSet localVars) expr of
+        Just ("raise#", [exception]) ->
+          lowerSingleStrict "exception" exception (pure . GrinThrow)
+        Just ("catch#", [action, handler, _state]) ->
+          lowerSingleArgument action $ \actionValue ->
+            lowerSingleArgument handler $ \handlerValue ->
+              pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue [])
+        _ -> lowerOrdinaryExpr expr
 
 lowerOrdinaryExpr :: FcExpr -> LowerM GrinExpr
 lowerOrdinaryExpr expr =
@@ -491,6 +504,17 @@ primitiveApplication primitiveNames localVars expr =
           Just (varName var, arguments)
     _ -> Nothing
 
+saturatedConstructorApplication :: Map Text Int -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
+saturatedConstructorApplication constructorArities localVars expr =
+  case collectApplications expr of
+    (FcVar var, arguments)
+      | varKey var `Set.notMember` localVars,
+        Just arity <- Map.lookup (varName var) constructorArities,
+        arity > 0,
+        length arguments == arity ->
+          Just (varName var, arguments)
+    _ -> Nothing
+
 collectApplications :: FcExpr -> (FcExpr, [FcExpr])
 collectApplications expr =
   case expr of
@@ -738,6 +762,13 @@ programGlobalNames program = concatMap topGlobalNames (fcTopBinds program)
       case bind of
         FcNonRec var expr -> [(var, expr)]
         FcRec bindings -> bindings
+
+programConstructors :: FcProgram -> [(Text, Int)]
+programConstructors program =
+  [ (name, length fields)
+  | FcData _ _ constructors <- fcTopBinds program,
+    (name, fields) <- constructors
+  ]
 
 programWhnfGlobalNames :: FcProgram -> [Text]
 programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds program)

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -67,7 +67,17 @@ grinUnitTests =
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
         assertBool "records IntRep" ("IntRep" `isInfixOf` rendered)
-        assertBool "does not allocate an argument thunk" (not ("store " `isInfixOf` rendered)),
+        assertBool "does not allocate an argument thunk" (not ("store (F$grin_thunk" `isInfixOf` rendered)),
+      testCase "FC lowering stores saturated constructor applications directly" $ do
+        let program = lowerProgram saturatedConstructorProgram
+        assertEqual "lint" [] (lintProgram program)
+        case grinFunctions program of
+          [function] ->
+            assertEqual
+              "constructor body"
+              (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
+              (grinFunctionBody function)
+          functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
       testCase "FC lowering emits saturated strict foreign calls" $ do
         let program = lowerProgram foreignProgram
             rendered = renderProgram program
@@ -103,7 +113,7 @@ grinUnitTests =
           "dictionary constructor has an ordinary declared layout"
           [("Box", [IntRep]), ("$Dict$Test", [BoxedRep Lifted, BoxedRep Lifted])]
           (grinConstructors program)
-        assertBool ("ordinary dictionary constructor application:\n" <> rendered) ("$Dict$Test" `isInfixOf` rendered && "apply " `isInfixOf` rendered)
+        assertBool ("direct dictionary constructor store:\n" <> rendered) ("store (C$Dict$Test" `isInfixOf` rendered)
         assertBool "ordinary dictionary case" ("$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
         assertBool "no tuple encoding" (not ("C(,)" `isInfixOf` rendered || "C()" `isInfixOf` rendered))
         assertBool "no projection operation" (not ("project " `isInfixOf` rendered))
@@ -115,6 +125,18 @@ grinUnitTests =
             let consumer = lowerProgramWithInterface (extractGrinInterface providerCore) consumerCore
                 parameters = concatMap grinFunctionParameters (grinFunctions consumer)
             assertBool "dependency CAF remains global" (all ((/= "source") . grinVarName) parameters)
+          programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
+      testCase "separate FC units store saturated dependency constructors directly" $ do
+        case separateConstructorPrograms of
+          [providerCore, consumerCore] -> do
+            let consumer = lowerProgramWithInterface (extractGrinInterface providerCore) consumerCore
+            case grinFunctions consumer of
+              [function] ->
+                assertEqual
+                  "constructor body"
+                  (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 72 Int32Rep)]))
+                  (grinFunctionBody function)
+              functions -> assertFailure ("expected one constructor function, got " <> show (length functions))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
       testCase "separate FC units erase dependency newtypes" $ do
         case separateNewtypePrograms of
@@ -524,6 +546,42 @@ foreignBoxConstructorVar = Var "BoxedInt32" (Unique 51) (TcFunTy int32Ty boxedIn
 
 int32Ty :: TcType
 int32Ty = TcTyCon (TyCon "Int32#" 0) []
+
+saturatedConstructorProgram :: FcProgram
+saturatedConstructorProgram =
+  FcProgram
+    [ FcData "Int32" [] [("I32#", [int32Ty])],
+      FcTopBind
+        ( FcNonRec
+            int32WrapperVar
+            (FcLam int32ArgumentVar (FcApp (FcVar int32ConstructorVar) (FcVar int32ArgumentVar)))
+        )
+    ]
+  where
+    int32WrapperVar = Var "wrapInt32" (Unique 60) (TcFunTy int32Ty boxedInt32Ty)
+    int32ConstructorVar = Var "I32#" (Unique 61) (TcFunTy int32Ty boxedInt32Ty)
+
+boxedInt32Ty :: TcType
+boxedInt32Ty = TcTyCon (TyCon "Int32" 0) []
+
+int32ArgumentVar :: Var
+int32ArgumentVar = Var "value" (Unique 62) int32Ty
+
+separateConstructorPrograms :: [FcProgram]
+separateConstructorPrograms =
+  [ FcProgram [FcData "Int32" [] [("I32#", [int32Ty])]],
+    FcProgram
+      [ FcTopBind
+          ( FcNonRec
+              wrapperVar
+              (FcLam argumentVar (FcApp (FcVar constructorVar) (FcVar argumentVar)))
+          )
+      ]
+  ]
+  where
+    wrapperVar = Var "wrapInt32" (Unique 70) (TcFunTy int32Ty boxedInt32Ty)
+    constructorVar = Var "I32#" (Unique 71) (TcFunTy int32Ty boxedInt32Ty)
+    argumentVar = Var "value" (Unique 72) int32Ty
 
 separatePrograms :: [FcProgram]
 separatePrograms =

--- a/test/Test/Fixtures/grin/boxed-int-field.yaml
+++ b/test/Test/Fixtures/grin/boxed-int-field.yaml
@@ -4,7 +4,7 @@ expected: |-
   caf value%1002 :: BoxedRep Lifted = (F$grin_thunk_0)
 
   $grin_thunk_0 -> BoxedRep Lifted =
-    apply @BoxedRep Lifted Box%1001 :: BoxedRep Lifted 42
+    store (CBox 42)
 extensions:
 - MagicHash
 reason: preserves lifted constructor storage and the IntRep field representation

--- a/test/Test/Fixtures/grin/narrow-integer-fields.yaml
+++ b/test/Test/Fixtures/grin/narrow-integer-fields.yaml
@@ -4,9 +4,7 @@ expected: |-
   caf value%1002 :: BoxedRep Lifted = (F$grin_thunk_0)
 
   $grin_thunk_0 -> BoxedRep Lifted =
-    $grin_function_1003%1003 :: BoxedRep Lifted <-
-      apply @BoxedRep Lifted Narrow%1001 :: BoxedRep Lifted 123
-    apply @BoxedRep Lifted $grin_function_1003%1003 :: BoxedRep Lifted 456
+    store (CNarrow 123 456)
 extensions:
 - MagicHash
 - ExtendedLiterals

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -4,7 +4,7 @@ expected: |-
   caf value%1003 :: BoxedRep Lifted = (F$grin_thunk_0)
 
   $grin_thunk_0 -> BoxedRep Lifted =
-    apply @BoxedRep Lifted IS%1002 :: BoxedRep Lifted 42
+    store (CIS 42)
 extensions:
   - MagicHash
 reason: erases newtype constructors and casts before producing runtime GRIN

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -8,7 +8,7 @@ expected: |-
       $grin_tuple_1007%1007 :: IntRep, $grin_tuple_1008%1008 :: WordRep <-
         return 1 2
       return $grin_tuple_1007%1007 :: IntRep
-    apply @BoxedRep Lifted Box%1001 :: BoxedRep Lifted $grin_argument_1006%1006 :: IntRep
+    store (CBox $grin_argument_1006%1006 :: IntRep)
 extensions:
 - MagicHash
 - UnboxedTuples

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -10,7 +10,7 @@ expected: |-
       $grin_tuple_1009%1009 :: IntRep <-
         return 42
       return $grin_tuple_1009%1009 :: IntRep
-    apply @BoxedRep Lifted Box%1002 :: BoxedRep Lifted $grin_argument_1008%1008 :: IntRep
+    store (CBox $grin_argument_1008%1008 :: IntRep)
 extensions:
 - EmptyDataDecls
 - MagicHash


### PR DESCRIPTION
## Summary

- lower saturated constructor applications directly to `GrinStore` constructor nodes instead of generic `GrinApply`
- carry constructor arities through `GrinInterface`, so dependency constructors receive the same direct lowering
- initialize stored non-thunk nodes as heap values in both the GRIN interpreter and native runtime
- refresh GRIN goldens to record the simpler generated form

## Why

Constructor applications currently flow through the general apply machinery even when the constructor is statically known and saturated. For example, `I32# value` becomes an `apply` against the global constructor. The lowering already has all information needed to allocate the final node directly, so emitting `Store (I32 value)` at that point is simpler and avoids unnecessary runtime application dispatch.

Partial constructor applications remain on the generic apply path, and lifted fields retain their existing delayed/thunked behavior.

## Root cause

The GRIN lowering environment tracked constructors only as WHNF globals. It did not retain constructor arities, so lowering could not distinguish a saturated constructor application from an ordinary function application. The native cell initializer also classified every stored node as suspended, which was incompatible with directly stored constructor nodes.

## Validation

- `just fmt`
- `just check`
- focused `aihc-grin:spec`: all 97 tests passed
- compiled `examples/hello-world/Main.hs` with `--keep-grin`; generated code contains `store (CI32# x1015%1015 :: Int32Rep)`
- ran the compiled hello-world executable; output is `Hello, world!`

## Progress counts

- GRIN spec: 95 → 97 tests (+2 focused structural tests)
- repository READMEs intentionally unchanged; generated progress reports remain cron-managed
