### PR TITLE
feat(grin): reify continuations as CPS-GRIN

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -7,6 +7,7 @@ module Aihc.Cli.Compile
     CompileError (..),
     compileOutputPath,
     compileSourceToCoreWithDependencies,
+    compileSourceToCpsGrinWithDependencies,
     compileSourceToGrinWithDependencies,
     compileSourceToWholeCoreWithDependencies,
     compileSourceToAssembly,
@@ -64,6 +65,7 @@ data CompileError
   = CompileParseError !String
   | CompileFrontendError ![String]
   | CompileDependencyError !String
+  | CompileCpsGrinError !Grin.CpsGrinError
   | CompileArm64Error !Arm64Error
   | CompileClangError !ExitCode !String
   deriving (Eq, Show)
@@ -71,6 +73,7 @@ data CompileError
 data CompileArtifacts = CompileArtifacts
   { compiledCore :: !Text,
     compiledGrin :: !Text,
+    compiledCpsGrin :: !Text,
     compiledAssembly :: !Text,
     compiledArchives :: ![FilePath]
   }
@@ -78,7 +81,8 @@ data CompileArtifacts = CompileArtifacts
 -- | The Core and GRIN produced for one independently compiled module SCC.
 data IncrementalUnit = IncrementalUnit
   { incrementalUnitCore :: !FcProgram,
-    incrementalUnitGrin :: !Grin.GrinProgram
+    incrementalUnitGrin :: !Grin.GrinProgram,
+    incrementalUnitCpsGrin :: !Grin.CpsGrinProgram
   }
 
 -- | Per-SCC compiler output. Whole-program compilation is derived from
@@ -114,8 +118,9 @@ writeIntermediateArtifacts :: FilePath -> CompileOptions -> CompileArtifacts -> 
 writeIntermediateArtifacts output options artifacts = do
   when (compileKeepCore options) $
     TIO.writeFile (output <> ".core") (compiledCore artifacts)
-  when (compileKeepGrin options) $
+  when (compileKeepGrin options) $ do
     TIO.writeFile (output <> ".grin") (compiledGrin artifacts)
+    TIO.writeFile (output <> ".cps.grin") (compiledCpsGrin artifacts)
 
 -- | The project-local core libraries and shared compiled-library cache used by
 -- the command-line compiler.
@@ -159,6 +164,12 @@ compileSourceToCoreWithDependencies environment sourceName source =
 compileSourceToGrinWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToGrinWithDependencies environment sourceName source =
   fmap (fmap compiledGrin) (compileSourceToArtifactsWithDependencies False environment sourceName source)
+
+-- | Compile source to the continuation-reified GRIN consumed by native
+-- backends and rendered as @.cps.grin@ by @--keep-grin@.
+compileSourceToCpsGrinWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
+compileSourceToCpsGrinWithDependencies environment sourceName source =
+  fmap (fmap compiledCpsGrin) (compileSourceToArtifactsWithDependencies False environment sourceName source)
 
 -- | Compile source incrementally, then merge the resulting Core units and run
 -- whole-program dead-code elimination. This is the Core rendered by
@@ -207,14 +218,16 @@ compileWithDependencies wholeProgram dependencies parsed =
 -- optional whole-program transformation is considered.
 compileIncrementally :: DependencyArtifact -> FcProgram -> Either CompileError IncrementalCompilation
 compileIncrementally dependencies unoptimizedMain =
-  Right
-    IncrementalCompilation
-      { incrementalDependencyUnits =
-          [ IncrementalUnit (dependencyUnitProgram unit) (dependencyUnitGrin unit)
-          | unit <- dependencyUnits dependencies
-          ],
-        incrementalMainUnit = IncrementalUnit mainCore mainGrin
-      }
+  do
+    mainCpsGrin <- either (Left . CompileCpsGrinError) Right (Grin.toCpsGrin mainGrin)
+    pure
+      IncrementalCompilation
+        { incrementalDependencyUnits =
+            [ IncrementalUnit (dependencyUnitProgram unit) (dependencyUnitGrin unit) (dependencyUnitCpsGrin unit)
+            | unit <- dependencyUnits dependencies
+            ],
+          incrementalMainUnit = IncrementalUnit mainCore mainGrin mainCpsGrin
+        }
   where
     mainCore = Fc.lowerNewtypesWithInterface (dependencyNewtypeInterface dependencies) (eliminateDeadCode "main" unoptimizedMain)
     mainGrin = Grin.lowerProgramWithInterface (dependencyGrinInterface dependencies) mainCore
@@ -248,6 +261,7 @@ compileIncrementalArtifacts dependencies compilation = do
   let mainUnit = incrementalMainUnit compilation
       mainCore = incrementalUnitCore mainUnit
       mainGrin = incrementalUnitGrin mainUnit
+      mainCpsGrin = incrementalUnitCpsGrin mainUnit
       dependencyLayout = buildLinkLayoutFromInterfaces (dependencyLinkInterfaces dependencies)
       layout = extendLinkLayout dependencyLayout mainGrin
       reachability = dependencyReachabilityInterface dependencies <> extractReachabilityInterface mainCore
@@ -257,11 +271,12 @@ compileIncrementalArtifacts dependencies compilation = do
     either
       (Left . CompileArm64Error)
       Right
-      (compileProgramWithDependencies layout (dependencyInitializerSymbols dependencies) "main" mainGrin)
+      (compileProgramWithDependencies layout (dependencyInitializerSymbols dependencies) "main" mainCpsGrin)
   pure
     CompileArtifacts
       { compiledCore = renderCore mainCore,
         compiledGrin = renderGrin mainGrin,
+        compiledCpsGrin = renderCpsGrin mainCpsGrin,
         compiledAssembly = assembly,
         compiledArchives = dependencyArchivePaths dependencies
       }
@@ -270,11 +285,13 @@ compileProgramArtifacts :: FcProgram -> Either CompileError CompileArtifacts
 compileProgramArtifacts sourceCore = do
   let core = Fc.lowerNewtypes sourceCore
   let grin = Grin.lowerProgram core
-  assembly <- either (Left . CompileArm64Error) Right (compileProgram "main" grin)
+  cpsGrin <- either (Left . CompileCpsGrinError) Right (Grin.toCpsGrin grin)
+  assembly <- either (Left . CompileArm64Error) Right (compileProgram "main" cpsGrin)
   pure
     CompileArtifacts
       { compiledCore = renderCore core,
         compiledGrin = renderGrin grin,
+        compiledCpsGrin = renderCpsGrin cpsGrin,
         compiledAssembly = assembly,
         compiledArchives = []
       }
@@ -284,6 +301,9 @@ renderCore = withFinalNewline . Fc.renderProgram
 
 renderGrin :: Grin.GrinProgram -> Text
 renderGrin = withFinalNewline . Grin.renderProgram
+
+renderCpsGrin :: Grin.CpsGrinProgram -> Text
+renderCpsGrin = renderGrin . Grin.cpsGrinProgram
 
 withFinalNewline :: String -> Text
 withFinalNewline rendered = T.pack rendered <> "\n"
@@ -393,6 +413,7 @@ renderCompileError compileError =
     CompileParseError err -> "parse error: " <> err
     CompileFrontendError errors -> "frontend error: " <> unwords errors
     CompileDependencyError err -> "dependency error: " <> err
+    CompileCpsGrinError err -> "CPS-GRIN error: " <> show err
     CompileArm64Error err -> "ARM64 code generation error: " <> show err
     CompileClangError exitCode err -> "clang failed (" <> show exitCode <> "): " <> err
 

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -113,6 +113,7 @@ data DependencyUnit = DependencyUnit
     dependencyUnitModules :: ![Text],
     dependencyUnitProgram :: !FcProgram,
     dependencyUnitGrin :: !Grin.GrinProgram,
+    dependencyUnitCpsGrin :: !Grin.CpsGrinProgram,
     dependencyUnitNewtypeInterface :: !NewtypeInterface,
     dependencyUnitGrinInterface :: !Grin.GrinInterface,
     dependencyUnitReachabilityInterface :: !ReachabilityInterface,
@@ -163,7 +164,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 5
+cacheSchemaVersion = 6
 
 buildDependencies :: CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies environment usesImplicitPrelude buildNative mainModule = do
@@ -344,30 +345,34 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                               reachabilityInterface = extractReachabilityInterface core
                               grin = Grin.lowerProgramWithInterface (compileStateGrin state) core
                               linkInterface = extractLinkInterface grin
-                              unit =
-                                DependencyUnit
-                                  { dependencyUnitLibraries = sort (Set.toList (Set.fromList (map loadedLibrary members))),
-                                    dependencyUnitModules = sort (map loadedModuleName members),
-                                    dependencyUnitProgram = core,
-                                    dependencyUnitGrin = grin,
-                                    dependencyUnitNewtypeInterface = newtypes,
-                                    dependencyUnitGrinInterface = grinInterface,
-                                    dependencyUnitReachabilityInterface = reachabilityInterface,
-                                    dependencyUnitLinkInterface = linkInterface
-                                  }
-                           in Right
-                                CompileState
-                                  { compileStateExports = compileStateExports state <> extractInterfaceWithDeps (compileStateExports state) resolved,
-                                    compileStateTerms = termSchemes,
-                                    compileStateTyCons = tyCons,
-                                    compileStateBindings = bindings,
-                                    compileStateInstances = compileStateInstances state <> localInstances,
-                                    compileStateNewtypes = compileStateNewtypes state <> newtypes,
-                                    compileStateGrin = compileStateGrin state <> grinInterface,
-                                    compileStateReachability = compileStateReachability state <> reachabilityInterface,
-                                    compileStateLinks = compileStateLinks state <> [linkInterface],
-                                    compileStateUnits = compileStateUnits state <> [unit]
-                                  }
+                           in case Grin.toCpsGrin grin of
+                                Left err -> Left ("core library CPS-GRIN error: " <> show err)
+                                Right cpsGrin ->
+                                  let unit =
+                                        DependencyUnit
+                                          { dependencyUnitLibraries = sort (Set.toList (Set.fromList (map loadedLibrary members))),
+                                            dependencyUnitModules = sort (map loadedModuleName members),
+                                            dependencyUnitProgram = core,
+                                            dependencyUnitGrin = grin,
+                                            dependencyUnitCpsGrin = cpsGrin,
+                                            dependencyUnitNewtypeInterface = newtypes,
+                                            dependencyUnitGrinInterface = grinInterface,
+                                            dependencyUnitReachabilityInterface = reachabilityInterface,
+                                            dependencyUnitLinkInterface = linkInterface
+                                          }
+                                   in Right
+                                        CompileState
+                                          { compileStateExports = compileStateExports state <> extractInterfaceWithDeps (compileStateExports state) resolved,
+                                            compileStateTerms = termSchemes,
+                                            compileStateTyCons = tyCons,
+                                            compileStateBindings = bindings,
+                                            compileStateInstances = compileStateInstances state <> localInstances,
+                                            compileStateNewtypes = compileStateNewtypes state <> newtypes,
+                                            compileStateGrin = compileStateGrin state <> grinInterface,
+                                            compileStateReachability = compileStateReachability state <> reachabilityInterface,
+                                            compileStateLinks = compileStateLinks state <> [linkInterface],
+                                            compileStateUnits = compileStateUnits state <> [unit]
+                                          }
 
     finish state =
       DependencyArtifact
@@ -435,7 +440,7 @@ buildNativeArtifacts artifactRoot units = do
 
 data NativeUnit = NativeUnit
   { nativeDependencyUnit :: !DependencyUnit,
-    nativeProgram :: !Grin.GrinProgram,
+    nativeProgram :: !Grin.CpsGrinProgram,
     nativeInitializerSymbol :: !Text,
     nativeObjectPath :: !FilePath
   }
@@ -444,7 +449,7 @@ nativeUnit :: FilePath -> DependencyUnit -> NativeUnit
 nativeUnit objectRoot unit =
   NativeUnit
     { nativeDependencyUnit = unit,
-      nativeProgram = dependencyUnitGrin unit,
+      nativeProgram = dependencyUnitCpsGrin unit,
       nativeInitializerSymbol = initializer,
       nativeObjectPath = objectRoot </> T.unpack library </> T.unpack unitName <> ".o"
     }

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -8,6 +8,7 @@ import Aihc.Cli.Compile
     compileOutputPath,
     compileSourceToAssemblyWithDependencies,
     compileSourceToCoreWithDependencies,
+    compileSourceToCpsGrinWithDependencies,
     compileSourceToGrinWithDependencies,
     compileSourceToWholeCoreWithDependencies,
     defaultCompileEnvironment,
@@ -875,11 +876,14 @@ test_compileExecutable =
         assertFileExists keptOutput
         assertFileExists (keptOutput <> ".core")
         assertFileExists (keptOutput <> ".grin")
+        assertFileExists (keptOutput <> ".cps.grin")
         assertFileExists (keptOutput <> ".s")
         core <- TIO.readFile (keptOutput <> ".core")
         grin <- TIO.readFile (keptOutput <> ".grin")
+        cpsGrin <- TIO.readFile (keptOutput <> ".cps.grin")
         assertBool "core contains main" ("main" `T.isInfixOf` core)
         assertBool "GRIN contains main" ("main" `T.isInfixOf` grin)
+        assertBool "CPS-GRIN contains allocated continuations" ("store (P$cps$" `T.isInfixOf` cpsGrin)
         assertBool "GRIN erases the IO constructor" (not ("constructor IO/" `T.isInfixOf` grin))
         assertBool "GRIN erases the CInt constructor" (not ("constructor CInt/" `T.isInfixOf` grin))
         assertNativeOutput keptOutput
@@ -888,6 +892,7 @@ test_compileExecutable =
         assertFileExists temporaryOutput
         assertFileDoesNotExist (temporaryOutput <> ".core")
         assertFileDoesNotExist (temporaryOutput <> ".grin")
+        assertFileDoesNotExist (temporaryOutput <> ".cps.grin")
         assertFileDoesNotExist (temporaryOutput <> ".s")
         assertNativeOutput temporaryOutput
 
@@ -978,9 +983,12 @@ test_compileExplicitCoreImport =
       )
     core <- expectCompileArtifact =<< compileSourceToCoreWithDependencies environment "Main.hs" importedSource
     grin <- expectCompileArtifact =<< compileSourceToGrinWithDependencies environment "Main.hs" importedSource
+    cpsGrin <- expectCompileArtifact =<< compileSourceToCpsGrinWithDependencies environment "Main.hs" importedSource
     wholeCore <- expectCompileArtifact =<< compileSourceToWholeCoreWithDependencies environment "Main.hs" importedSource
     assertBool "dependency reference remains in incremental Core" ("identity" `T.isInfixOf` core)
     assertBool "dependency reference remains in incremental GRIN" ("identity" `T.isInfixOf` grin)
+    assertBool "CPS-GRIN allocates ordinary continuation closures" ("store (P$cps$" `T.isInfixOf` cpsGrin)
+    assertBool "CPS-GRIN invokes ordinary continuation closures" ("apply @" `T.isInfixOf` cpsGrin)
     assertBool "dependency Core implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` core))
     assertBool "dependency GRIN implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` grin))
     assertBool "whole-program Core merges reachable dependency implementations" ("dependencyImplementation" `T.isInfixOf` wholeCore)

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -22,6 +22,7 @@ where
 
 import Aihc.Arm64.Emit (EmitError, renderAllocatedBlock)
 import Aihc.Arm64.Lir qualified as Lir
+import Aihc.Grin.Cps (CpsGrinProgram, cpsGrinProgram)
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM, replicateM)
@@ -91,9 +92,11 @@ data ValueEnv = ValueEnv
     valueLocalSlots :: !(Map GrinVar Int)
   }
 
-compileProgram :: Text -> GrinProgram -> Either Arm64Error Text
-compileProgram entryName program =
-  compileProgramWithDependencies (buildLinkLayout [program]) [] entryName program
+compileProgram :: Text -> CpsGrinProgram -> Either Arm64Error Text
+compileProgram entryName cpsProgram =
+  compileProgramWithDependencies (buildLinkLayout [program]) [] entryName cpsProgram
+  where
+    program = cpsGrinProgram cpsProgram
 
 -- | Reject primitives that reachable native code would not execute correctly.
 -- Relocatable library objects may carry dormant primitive declarations, but
@@ -134,8 +137,8 @@ extendLinkLayoutWithInterface layout interface =
 -- | Compile a library SCC to relocatable assembly. The exported initializer
 -- installs the unit's primitive, static, and CAF globals into the shared
 -- machine table. Constructors are installed once by the executable entry unit.
-compileModule :: LinkLayout -> Text -> GrinProgram -> Either Arm64Error Text
-compileModule layout initializerSymbol program = do
+compileModule :: LinkLayout -> Text -> CpsGrinProgram -> Either Arm64Error Text
+compileModule layout initializerSymbol cpsProgram = do
   mapM_ validateRuntimeRep (programRuntimeReps program)
   initLines <- compileInitializers compileEnv program
   functions <- mapM (compileFunction compileEnv) (grinFunctions program)
@@ -158,13 +161,14 @@ compileModule layout initializerSymbol program = do
          ]
       <> concat functions
   where
+    program = cpsGrinProgram cpsProgram
     compileEnv = (compileEnvironment layout program) {compileAllowUnsupportedPrimitives = True}
 
 -- | Compile the user program entry unit against cached dependency modules.
 -- Dependency initializers are called after constructors are installed and
 -- before the user module's own globals are initialized.
-compileProgramWithDependencies :: LinkLayout -> [Text] -> Text -> GrinProgram -> Either Arm64Error Text
-compileProgramWithDependencies layout dependencyInitializers entryName program = do
+compileProgramWithDependencies :: LinkLayout -> [Text] -> Text -> CpsGrinProgram -> Either Arm64Error Text
+compileProgramWithDependencies layout dependencyInitializers entryName cpsProgram = do
   mapM_ validateRuntimeRep (programRuntimeReps program)
   rootSlot <- maybe (Left (Arm64MissingEntry entryName)) Right (Map.lookup entryName globalSlots)
   constructorLines <- compileConstructorInitializers compileEnv
@@ -202,6 +206,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName program =
          ]
       <> concat functions
   where
+    program = cpsGrinProgram cpsProgram
     compileEnv = compileEnvironment layout program
     globalSlots = compileGlobalSlots compileEnv
     globalNames = linkGlobalNames layout

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -81,7 +81,7 @@ tests =
         assertEqual
           "native representation diagnostic"
           (Left (Arm64UnsupportedRuntimeRep runtimeRep))
-          (compileProgram "missing" program),
+          (compileProgram "missing" (expectCpsGrin program)),
       testCase "keeps unsupported dormant primitives out of linked programs" $ do
         let primitive = GrinVar "+#" 1 (BoxedRep Lifted)
             program =
@@ -94,7 +94,7 @@ tests =
                   grinFunctions = []
                 }
         assertEqual "linked primitive validation" (Left (Arm64UnsupportedPrimitive "+#")) (validateProgramPrimitives program)
-        case compileModule (buildLinkLayout [program]) "_aihc_init_test" program of
+        case compileModule (buildLinkLayout [program]) "_aihc_init_test" (expectCpsGrin program) of
           Left err -> assertFailure ("relocatable module rejected a dormant primitive: " <> show err)
           Right assembly -> assertBool "module initializer" (".globl _aihc_init_test" `T.isInfixOf` assembly),
       testCase "canonicalizes narrow signed literals in machine-word slots" $ do
@@ -115,7 +115,7 @@ tests =
                         }
                     ]
                 }
-        case compileModule (buildLinkLayout [program]) "_aihc_init_narrow" program of
+        case compileModule (buildLinkLayout [program]) "_aihc_init_narrow" (expectCpsGrin program) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> assertBool "255 :: Int8# is stored as -1" ("ldr x0, =-1" `T.isInfixOf` assembly),
       testCase "returns unboxed tuples as direct machine values" $ do
@@ -140,7 +140,7 @@ tests =
                         }
                     ]
                 }
-        case compileModule (buildLinkLayout [program]) "_aihc_init_pair" program of
+        case compileModule (buildLinkLayout [program]) "_aihc_init_pair" (expectCpsGrin program) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> do
             assertBool "returns two values" ("ldr x1, =2" `T.isInfixOf` assembly)
@@ -164,7 +164,7 @@ testNativeHelloWorld = do
   let grinProgram = lowerProgram fcProgram
   assertBool "GRIN has no unboxed-tuple nodes" (not ("(#,#)" `isInfixOf` renderProgram grinProgram))
   assembly <-
-    case compileProgram evalBindingName grinProgram of
+    case compileProgram evalBindingName (expectCpsGrin grinProgram) of
       Right value -> pure value
       Left err -> assertFailure ("ARM64 lowering failed: " <> show err)
   let rendered = T.unpack assembly
@@ -173,6 +173,12 @@ testNativeHelloWorld = do
   assertBool "emits unboxed literals as raw words" (not ("_aihc_make_literal" `isInfixOf` rendered))
   when (arch == "aarch64" && os == "darwin") $
     runHelloWorldAssembly assembly
+
+expectCpsGrin :: GrinProgram -> CpsGrinProgram
+expectCpsGrin program =
+  case toCpsGrin program of
+    Right cpsProgram -> cpsProgram
+    Left err -> error ("test GRIN failed CPS conversion: " <> show err)
 
 runHelloWorldAssembly :: T.Text -> IO ()
 runHelloWorldAssembly assembly =

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -12,6 +12,7 @@ synopsis: Strict graph-reduction intermediate language for AIHC
 library
   exposed-modules:
     Aihc.Grin
+    Aihc.Grin.Cps
     Aihc.Grin.Interpret
     Aihc.Grin.Lint
     Aihc.Grin.Lower

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -1,6 +1,10 @@
 -- | AIHC's strict Graph Reduction Intermediate Notation dialect.
 module Aihc.Grin
   ( module Aihc.Grin.Syntax,
+    CpsGrinProgram,
+    CpsGrinError (..),
+    cpsGrinProgram,
+    toCpsGrin,
     lowerProgram,
     GrinInterface,
     extractGrinInterface,
@@ -16,6 +20,7 @@ module Aihc.Grin
   )
 where
 
+import Aihc.Grin.Cps (CpsGrinError (..), CpsGrinProgram, cpsGrinProgram, toCpsGrin)
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
 import Aihc.Grin.Lower (GrinInterface, extractGrinInterface, lowerProgram, lowerProgramWithInterface)

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Reify direct-style GRIN continuations as ordinary GRIN closures.
+--
+-- This pass deliberately keeps the GRIN syntax. Each source 'GrinBind' is
+-- rewritten so its body lives in a generated function. A closure for that
+-- function is allocated with 'GrinStore' and invoked with 'GrinApply' after
+-- the bound expression produces its values. The introduced administrative
+-- binds retain the current runtime-operation protocol; future suspension
+-- lowering can transfer ownership of the explicit closure instead of
+-- returning through them.
+module Aihc.Grin.Cps
+  ( CpsGrinProgram,
+    CpsGrinError (..),
+    cpsGrinProgram,
+    toCpsGrin,
+  )
+where
+
+import Aihc.Grin.Syntax
+import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict (StateT, get, modify', put, runStateT)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text qualified as T
+
+-- | A GRIN program known to have passed through continuation reification.
+-- Keeping the constructor private prevents accidentally applying the pass
+-- twice or sending direct-style GRIN to a backend that expects CPS-GRIN.
+newtype CpsGrinProgram = CpsGrinProgram
+  { cpsGrinProgram :: GrinProgram
+  }
+  deriving (Eq, Show, Read)
+
+-- | A violated precondition at the CPS boundary. Exception control must have
+-- been lowered to ordinary GRIN control flow before continuations are reified.
+data CpsGrinError
+  = CpsGrinUnexpectedThrow !FunctionName
+  | CpsGrinUnexpectedCatch !FunctionName
+  deriving (Eq, Show)
+
+data CpsState = CpsState
+  { cpsNextVarUnique :: !Int,
+    cpsNextContinuationUnique :: !Int,
+    cpsUsedFunctionNames :: !(Set FunctionName),
+    cpsGeneratedFunctionsRev :: ![GrinFunction]
+  }
+
+type CpsM = StateT CpsState (Either CpsGrinError)
+
+toCpsGrin :: GrinProgram -> Either CpsGrinError CpsGrinProgram
+toCpsGrin program = do
+  (functions, finalState) <- runStateT (mapM transformFunction sourceFunctions) initialState
+  pure . CpsGrinProgram $
+    program
+      { grinFunctions = functions <> reverse (cpsGeneratedFunctionsRev finalState)
+      }
+  where
+    sourceFunctions = grinFunctions program
+    initialState =
+      CpsState
+        { cpsNextVarUnique = 1 + maximumProgramVarUnique program,
+          cpsNextContinuationUnique = 0,
+          cpsUsedFunctionNames = Set.fromList (map grinFunctionName sourceFunctions),
+          cpsGeneratedFunctionsRev = []
+        }
+
+transformFunction :: GrinFunction -> CpsM GrinFunction
+transformFunction function = do
+  body <-
+    transformExpr
+      (grinFunctionName function)
+      (Set.fromList (grinFunctionParameters function))
+      (grinFunctionResultRep function)
+      (grinFunctionBody function)
+  pure function {grinFunctionBody = body}
+
+transformExpr :: FunctionName -> Set GrinVar -> RuntimeRep -> GrinExpr -> CpsM GrinExpr
+transformExpr parent bound resultRep expression =
+  case expression of
+    GrinReturn {} -> pure expression
+    GrinBind resultVars valueExpression body -> do
+      transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
+      transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
+      continuationName <- freshContinuationName parent
+      continuationVar <- freshContinuationVar
+      let captures = Set.toAscList (freeExprVars transformedBody `Set.intersection` bound)
+          continuationFunction =
+            GrinFunction
+              { grinFunctionName = continuationName,
+                grinFunctionParameters = captures <> resultVars,
+                grinFunctionResultRep = resultRep,
+                grinFunctionBody = transformedBody
+              }
+          continuationNode =
+            GrinNode
+              (GrinClosure continuationName (length resultVars))
+              (map GrinVarValue captures)
+          invokeContinuation =
+            GrinApply
+              resultRep
+              (GrinVarValue continuationVar)
+              (map GrinVarValue resultVars)
+      addGeneratedFunction continuationFunction
+      pure
+        ( GrinBind
+            [continuationVar]
+            (GrinStore continuationNode)
+            (GrinBind resultVars transformedValue invokeContinuation)
+        )
+    GrinStore {} -> pure expression
+    GrinStoreRec bindings body -> do
+      let recursiveVars = Set.fromList (map fst bindings)
+      GrinStoreRec bindings <$> transformExpr parent (bound <> recursiveVars) resultRep body
+    GrinFetch {} -> pure expression
+    GrinUpdate {} -> pure expression
+    GrinEval {} -> pure expression
+    GrinApply {} -> pure expression
+    GrinCase scrutinee binder alternatives ->
+      GrinCase scrutinee binder <$> mapM transformAlternative alternatives
+      where
+        transformAlternative alternative = do
+          let alternativeBound = bound <> Set.fromList (binder : grinAltBinders alternative)
+          rhs <- transformExpr parent alternativeBound resultRep (grinAltRhs alternative)
+          pure alternative {grinAltRhs = rhs}
+    GrinThrow {} -> lift (Left (CpsGrinUnexpectedThrow parent))
+    GrinCatch {} -> lift (Left (CpsGrinUnexpectedCatch parent))
+    GrinForeignCallExpr {} -> pure expression
+
+freshContinuationName :: FunctionName -> CpsM FunctionName
+freshContinuationName parent = do
+  state <- get
+  let unique = cpsNextContinuationUnique state
+      candidate =
+        FunctionName
+          ( "$cps$"
+              <> unFunctionName parent
+              <> "$"
+              <> T.pack (show unique)
+          )
+  put state {cpsNextContinuationUnique = unique + 1}
+  if candidate `Set.member` cpsUsedFunctionNames state
+    then freshContinuationName parent
+    else do
+      modify' $ \current -> current {cpsUsedFunctionNames = Set.insert candidate (cpsUsedFunctionNames current)}
+      pure candidate
+
+freshContinuationVar :: CpsM GrinVar
+freshContinuationVar = do
+  state <- get
+  let unique = cpsNextVarUnique state
+  put state {cpsNextVarUnique = unique + 1}
+  pure (GrinVar "$cps_continuation" unique liftedRuntimeRep)
+
+addGeneratedFunction :: GrinFunction -> CpsM ()
+addGeneratedFunction function =
+  modify' $ \state ->
+    state
+      { cpsGeneratedFunctionsRev = function : cpsGeneratedFunctionsRev state
+      }
+
+varsRuntimeRep :: [GrinVar] -> RuntimeRep
+varsRuntimeRep vars =
+  case map grinVarRuntimeRep vars of
+    [runtimeRep] -> runtimeRep
+    runtimeReps -> TupleRep runtimeReps
+
+freeExprVars :: GrinExpr -> Set GrinVar
+freeExprVars expression =
+  case expression of
+    GrinReturn values -> foldMap freeValueVars values
+    GrinBind vars valueExpression body ->
+      freeExprVars valueExpression
+        <> (freeExprVars body `Set.difference` Set.fromList vars)
+    GrinStore node -> freeNodeVars node
+    GrinStoreRec bindings body ->
+      (foldMap (freeNodeVars . snd) bindings <> freeExprVars body)
+        `Set.difference` Set.fromList (map fst bindings)
+    GrinFetch _ pointer -> freeValueVars pointer
+    GrinUpdate pointer value -> freeValueVars pointer <> freeValueVars value
+    GrinEval _ value -> freeValueVars value
+    GrinApply _ function arguments -> freeValueVars function <> foldMap freeValueVars arguments
+    GrinCase scrutinee binder alternatives ->
+      freeValueVars scrutinee
+        <> foldMap (freeAlternativeVars binder) alternatives
+    GrinThrow exception -> freeValueVars exception
+    GrinCatch _ action handler state ->
+      freeValueVars action <> freeValueVars handler <> foldMap freeValueVars state
+    GrinForeignCallExpr _ arguments -> foldMap freeValueVars arguments
+
+freeAlternativeVars :: GrinVar -> GrinAlt -> Set GrinVar
+freeAlternativeVars binder alternative =
+  freeExprVars (grinAltRhs alternative)
+    `Set.difference` Set.fromList (binder : grinAltBinders alternative)
+
+freeValueVars :: GrinValue -> Set GrinVar
+freeValueVars value =
+  case value of
+    GrinVarValue var -> Set.singleton var
+    GrinLitValue {} -> Set.empty
+    GrinNodeValue node -> freeNodeVars node
+
+freeNodeVars :: GrinNode -> Set GrinVar
+freeNodeVars = foldMap freeValueVars . grinNodeFields
+
+maximumProgramVarUnique :: GrinProgram -> Int
+maximumProgramVarUnique program =
+  maximum
+    ( 0
+        : map (grinVarUnique . fst) (grinPrimitives program)
+          <> concatMap bindingUniques (grinWhnfGlobals program)
+          <> concatMap bindingUniques (grinCafs program)
+          <> concatMap functionUniques (grinFunctions program)
+    )
+  where
+    bindingUniques (var, node) = grinVarUnique var : nodeUniques node
+    functionUniques function =
+      map grinVarUnique (grinFunctionParameters function)
+        <> exprUniques (grinFunctionBody function)
+
+exprUniques :: GrinExpr -> [Int]
+exprUniques expression =
+  case expression of
+    GrinReturn values -> concatMap valueUniques values
+    GrinBind vars valueExpression body ->
+      map grinVarUnique vars <> exprUniques valueExpression <> exprUniques body
+    GrinStore node -> nodeUniques node
+    GrinStoreRec bindings body ->
+      concatMap (\(var, node) -> grinVarUnique var : nodeUniques node) bindings
+        <> exprUniques body
+    GrinFetch _ pointer -> valueUniques pointer
+    GrinUpdate pointer value -> valueUniques pointer <> valueUniques value
+    GrinEval _ value -> valueUniques value
+    GrinApply _ function arguments -> valueUniques function <> concatMap valueUniques arguments
+    GrinCase scrutinee binder alternatives ->
+      valueUniques scrutinee
+        <> (grinVarUnique binder : concatMap alternativeUniques alternatives)
+    GrinThrow exception -> valueUniques exception
+    GrinCatch _ action handler state ->
+      valueUniques action <> valueUniques handler <> concatMap valueUniques state
+    GrinForeignCallExpr _ arguments -> concatMap valueUniques arguments
+
+alternativeUniques :: GrinAlt -> [Int]
+alternativeUniques alternative =
+  map grinVarUnique (grinAltBinders alternative)
+    <> exprUniques (grinAltRhs alternative)
+
+valueUniques :: GrinValue -> [Int]
+valueUniques value =
+  case value of
+    GrinVarValue var -> [grinVarUnique var]
+    GrinLitValue {} -> []
+    GrinNodeValue node -> nodeUniques node
+
+nodeUniques :: GrinNode -> [Int]
+nodeUniques = concatMap valueUniques . grinNodeFields

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -62,6 +62,28 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "contains explicit throw" ("throw " `isInfixOf` rendered)
         assertBool "contains explicit catch" ("catch " `isInfixOf` rendered),
+      testCase "CPS-GRIN allocates and applies ordinary continuation closures" $ do
+        cps <- expectCpsGrin heapProgram
+        let program = cpsGrinProgram cps
+            rendered = renderProgram program
+        assertEqual "transformed lint" [] (lintProgram program)
+        assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
+        assertBool "invokes a continuation closure" ("apply @BoxedRep Lifted $cps_continuation" `isInfixOf` rendered)
+        assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
+      testCase "CPS-GRIN preserves evaluation semantics" $ do
+        cps <- expectCpsGrin heapProgram
+        directResult <- interpretProgramBinding "answer" heapProgram
+        cpsResult <- interpretProgramBinding "answer" (cpsGrinProgram cps)
+        assertEqual "result" directResult cpsResult,
+      testCase "CPS-GRIN requires exception control to be eliminated" $ do
+        assertEqual
+          "throw"
+          (Left (CpsGrinUnexpectedThrow exceptionBoundaryFunction))
+          (toCpsGrin (exceptionBoundaryProgram (GrinThrow (GrinLitValue (GrinLitInt IntRep 1)))))
+        assertEqual
+          "catch"
+          (Left (CpsGrinUnexpectedCatch exceptionBoundaryFunction))
+          (toCpsGrin (exceptionBoundaryProgram (GrinCatch IntRep exceptionAction exceptionHandler []))),
       testCase "FC lowering evaluates Int# arguments without allocating thunks" $ do
         let program = lowerProgram unboxedApplicationProgram
             rendered = renderProgram program
@@ -149,6 +171,17 @@ grinUnitTests =
             assertBool "newtype constructor is erased across units" (not ("Wrap" `isInfixOf` renderProgram consumer))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs))
     ]
+
+expectCpsGrin :: GrinProgram -> IO CpsGrinProgram
+expectCpsGrin program =
+  case toCpsGrin program of
+    Left err -> assertFailure ("expected CPS-GRIN conversion to succeed, got " <> show err)
+    Right cps -> pure cps
+
+continuationHasCaptures :: GrinFunction -> Bool
+continuationHasCaptures function =
+  "$cps$" `T.isInfixOf` unFunctionName (grinFunctionName function)
+    && length (grinFunctionParameters function) > 1
 
 grinGoldenTests :: IO TestTree
 grinGoldenTests =
@@ -436,6 +469,26 @@ heapProgram =
     updated = GrinVar "updated" 4 (BoxedRep Lifted)
     updatedBox = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)])
     functionName = FunctionName "answer_code"
+
+exceptionBoundaryProgram :: GrinExpr -> GrinProgram
+exceptionBoundaryProgram body =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinWhnfGlobals = [],
+      grinCafs = [],
+      grinFunctions = [GrinFunction exceptionBoundaryFunction [] IntRep body]
+    }
+
+exceptionBoundaryFunction :: FunctionName
+exceptionBoundaryFunction = FunctionName "exception_boundary"
+
+exceptionAction :: GrinValue
+exceptionAction = GrinNodeValue (GrinNode (GrinConstructor "Action") [])
+
+exceptionHandler :: GrinValue
+exceptionHandler = GrinNodeValue (GrinNode (GrinConstructor "Handler") [])
 
 invalidUpdateProgram :: GrinProgram
 invalidUpdateProgram =

--- a/docs/cps-grin.md
+++ b/docs/cps-grin.md
@@ -1,0 +1,70 @@
+# CPS-GRIN
+
+AIHC represents continuations with ordinary GRIN values instead of adding a
+second intermediate language. The compilation pipeline is:
+
+```text
+Haskell -> System FC -> GRIN -> CPS-GRIN -> native backend
+```
+
+`CPS-GRIN` is GRIN satisfying an additional invariant. Every continuation
+which was the body of a source `GrinBind` has been closure-converted into a
+generated `GrinFunction`. The transformation stores a closure for that
+function with `GrinStore` and invokes it with `GrinApply` when the preceding
+expression produces its values.
+
+For example, the shape
+
+```text
+%x <- operation
+rest %captured %x
+```
+
+becomes the equivalent of
+
+```text
+%k <- store (P$cps$parent$0/1 %captured)
+%x <- operation
+apply %k %x
+
+$cps$parent$0 %captured %x =
+  rest %captured %x
+```
+
+The generated closure captures exactly the variables which are bound at the
+original bind and free in its body. Generated names and capture order are
+deterministic. The administrative binds needed to receive results from
+`GrinStore` and the preceding operation remain GRIN sequencing; they are not
+user continuations and are not recursively closure-converted.
+
+## Boundary and invariants
+
+`toCpsGrin` is the only constructor for `CpsGrinProgram`; its data constructor
+is private. Backends accept `CpsGrinProgram`, not `GrinProgram`, so normal API
+use cannot bypass the pass or accidentally apply it twice. Both the main unit
+and every cached dependency SCC cross this boundary before native code
+generation.
+
+Throw and catch nodes are rejected at this boundary. Exception control must be
+lowered to ordinary GRIN control flow before CPS conversion. This keeps
+CPS-GRIN's continuation model singular instead of retaining an implicit second
+exception continuation.
+
+The ordinary `.grin` artifact remains the direct-style input to the pass. When
+`--keep-grin` is used, AIHC also writes `.cps.grin`, the exact program consumed
+by the native backend.
+
+## Scheduler direction
+
+The pass does not implement suspension or scheduling. It establishes the
+representation needed to do that without scheduler-specific compiler
+primitives: a later lowering can detach the stored continuation closure at an
+asynchronous boundary, return it to ordinary scheduler code, and resume it by
+using the existing apply mechanism. Forking, queues, MVars, and timers can then
+be libraries built around ownership and resumption of this value rather than
+distinct control-flow nodes in the compiler IR.
+
+This first representation is intentionally allocation-heavy. Optimizations
+such as eliminating immediately applied continuations belong after the
+suspension semantics are established, where they can prove that a continuation
+does not escape.


### PR DESCRIPTION
## Summary

- add a CPS pass which keeps GRIN syntax and closure-converts every source `GrinBind` continuation into a generated GRIN function
- allocate continuation closures with `GrinStore`, capture their lexical environment, and invoke them through ordinary `GrinApply`
- make `CpsGrinProgram` a private-constructor boundary and require it at all ARM64 code-generation entry points
- route both the main unit and cached dependency SCCs through CPS-GRIN before native compilation
- write the direct `.grin` and backend-consumed `.cps.grin` artifacts together under `--keep-grin`
- document the CPS-GRIN invariant, exception-control precondition, and scheduler direction

## Why

PR #1300 introduced a second Loom IR whose structure largely duplicated GRIN. This replacement keeps continuations as ordinary GRIN heap values, so the compiler can reuse GRIN's closure, store, apply, lint, interpreter, pretty-printer, and backend machinery.

The backend API accepts only `CpsGrinProgram`, whose constructor is private. This makes CPS conversion an enforced compilation phase rather than an optional CLI rendering path. Dependency cache schema version 6 records both readable direct GRIN and CPS-GRIN, preventing cached modules from bypassing the phase.

The generated representation is intentionally allocation-heavy. Administrative binds which receive the results of `GrinStore` and the preceding operation remain as GRIN sequencing; the user continuation formerly represented by the bind body is the part reified as an ordinary closure. Escape analysis and immediately-applied-continuation elimination can follow after suspension semantics are defined.

Throw and catch remain an explicit precondition: they must be transformed into ordinary GRIN control flow before CPS conversion, and the pass reports either form if it crosses the boundary.

## Validation

- `just fmt`
- `just check`
- focused CPS-GRIN tests verify generated closure allocation/application and captured environments
- interpreter regression verifies direct GRIN and CPS-GRIN produce the same result
- boundary tests verify throw/catch rejection
- native Hello World and incremental dependency tests compile through the typed CPS boundary
- CLI artifact test verifies `--keep-grin` retains `.grin` and `.cps.grin`, while the default retains neither

## Progress counts

- GRIN spec: 97 → 100 tests (+3 CPS-GRIN tests)
- ARM64 spec: unchanged at 9 tests
- CLI spec: unchanged at 66 tests (artifact and incremental assertions extended)
- repository READMEs intentionally unchanged; generated progress reports remain cron-managed

Supersedes #1300.
