### PR TITLE
feat(grin): lower known code entries directly

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -163,7 +163,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 5
+cacheSchemaVersion = 6
 
 buildDependencies :: CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies environment usesImplicitPrelude buildNative mainModule = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -882,6 +882,10 @@ test_compileExecutable =
         assertBool "GRIN contains main" ("main" `T.isInfixOf` grin)
         assertBool "GRIN erases the IO constructor" (not ("constructor IO/" `T.isInfixOf` grin))
         assertBool "GRIN erases the CInt constructor" (not ("constructor CInt/" `T.isInfixOf` grin))
+        assertBool "GRIN does not allocate putchar globally" (not ("global putchar" `T.isInfixOf` grin || "caf putchar" `T.isInfixOf` grin))
+        assertBool "GRIN does not allocate char globally" (not ("global char" `T.isInfixOf` grin || "caf char" `T.isInfixOf` grin))
+        assertBool "GRIN uses direct known calls" ("call @BoxedRep Lifted $entry$>>" `T.isInfixOf` grin)
+        assertBool "GRIN leaves forcing to case and apply" (not ("eval @" `T.isInfixOf` grin))
         assertNativeOutput keptOutput
 
         runCompileWithEnvironment environment temporaryOptions

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -78,6 +78,10 @@ static void aihc_fail(const char *message) {
   abort();
 }
 
+void aihc_unsupported_primitive(void) {
+  aihc_fail("primitive is not implemented by the native runtime");
+}
+
 static void *aihc_allocate(size_t bytes) {
   void *pointer = calloc(1, bytes);
   if (pointer == NULL) {
@@ -199,7 +203,13 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
                               const AihcSlot *arguments) {
   switch (function->kind) {
   case AIHC_CLOSURE:
-    if (count != function->arity) {
+    if (count < function->arity) {
+      AihcValue *applied = aihc_copy_with_fields(function, count, arguments);
+      applied->arity -= count;
+      aihc_return_value(machine, (AihcSlot)applied);
+      return;
+    }
+    if (count > function->arity) {
       aihc_fail("closure received the wrong number of values");
     }
     aihc_schedule_function(machine, function,

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -33,6 +33,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Numeric (showHex)
 
 data Arm64Error
   = Arm64MissingEntry !Text
@@ -214,13 +215,12 @@ emptyLinkLayout :: LinkLayout
 emptyLinkLayout =
   LinkLayout
     { linkConstructors = builtinConstructors,
-      linkGlobalNames = map fst builtinConstructors
+      linkGlobalNames = [name | (name, arity) <- builtinConstructors, arity == 0]
     }
 
 programGlobalNames :: GrinProgram -> [Text]
 programGlobalNames program =
-  map fst (programConstructorArities program)
-    <> map (grinVarName . fst) (grinPrimitives program)
+  [name | (name, arity) <- programConstructorArities program, arity == 0]
     <> map (grinVarName . fst) (grinWhnfGlobals program)
     <> map (grinVarName . fst) (grinCafs program)
 
@@ -230,8 +230,24 @@ compileEnvironment layout program =
     { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
       compileConstructorArities = Map.fromList constructors,
       compileGlobalSlots = Map.fromList (zip (linkGlobalNames layout) [0 ..]),
-      compileFunctionLabels = Map.fromList [(grinFunctionName function, functionLabel index) | (index, function) <- zip [0 ..] (grinFunctions program)],
-      compileFunctionArities = Map.fromList [(grinFunctionName function, length (grinFunctionParameters function)) | function <- grinFunctions program],
+      compileFunctionLabels =
+        Map.fromList
+          ( [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
+            | info <- grinExternalFunctions program
+            ]
+              <> [ (grinFunctionName function, localFunctionLabel index function)
+                 | (index, function) <- zip [0 ..] (grinFunctions program)
+                 ]
+          ),
+      compileFunctionArities =
+        Map.fromList
+          ( [ (grinCodeFunctionName info, length (concat (grinCodeParameterLayouts info)))
+            | info <- grinExternalFunctions program
+            ]
+              <> [ (grinFunctionName function, length (grinFunctionParameters function))
+                 | function <- grinFunctions program
+                 ]
+          ),
       compileAllowUnsupportedPrimitives = False
     }
   where
@@ -239,17 +255,18 @@ compileEnvironment layout program =
 
 compileConstructorInitializers :: CompileEnv -> Either Arm64Error [Text]
 compileConstructorInitializers env =
-  fmap concat . forM (Map.toAscList (compileConstructorIds env)) $ \(name, constructor) -> do
+  fmap concat . forM nullaryConstructors $ \(name, constructor) -> do
     slot <- globalSlot env name
-    arity <- constructorArity env name
-    pure $ makeNodeLines 1 (InfoImmediate constructor) arity 0 <> storeGlobal slot
+    pure $ makeNodeLines 1 (InfoImmediate constructor) 0 0 <> storeGlobal slot
+  where
+    nullaryConstructors =
+      [ (name, constructor)
+      | (name, constructor) <- Map.toAscList (compileConstructorIds env),
+        Map.lookup name (compileConstructorArities env) == Just 0
+      ]
 
 compileInitializers :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
 compileInitializers env program = do
-  primitiveLines <- fmap concat . forM (grinPrimitives program) $ \(var, arity) -> do
-    slot <- globalSlot env (grinVarName var)
-    primitive <- primitiveId env (grinVarName var)
-    pure $ makeNodeLines 4 (InfoImmediate primitive) arity 0 <> storeGlobal slot
   whnfGlobalLines <- fmap concat . forM (grinWhnfGlobals program) $ \(var, node) -> do
     slot <- globalSlot env (grinVarName var)
     nodeLines <- materializeNode (ValueEnv env Map.empty) node
@@ -268,7 +285,7 @@ compileInitializers env program = do
              "  mov x1, x20",
              "  bl _aihc_set_cell"
            ]
-  pure (primitiveLines <> cafCellLines <> whnfGlobalLines <> cafValueLines)
+  pure (cafCellLines <> whnfGlobalLines <> cafValueLines)
 
 compileFunction :: CompileEnv -> GrinFunction -> Either Arm64Error [Text]
 compileFunction env function = do
@@ -284,17 +301,24 @@ compileFunction env function = do
     either (Left . Arm64EmitError) Right (renderAllocatedBlock spillBase (parameterCopyLir localSlots (grinFunctionParameters function)))
   let slotCount = max 1 (spillBase + spillCount)
       entry =
-        [ label <> ":",
-          immediate "x0" slotCount,
-          "  bl _aihc_alloc_locals",
-          "  mov x19, x0",
-          "  str x19, [x22, #32]",
-          "  ldr x8, [x22, #8]"
-        ]
+        exportLines function label
+          <> [ label <> ":",
+               immediate "x0" slotCount,
+               "  bl _aihc_alloc_locals",
+               "  mov x19, x0",
+               "  str x19, [x22, #32]",
+               "  ldr x8, [x22, #8]"
+             ]
           <> parameterCopies
           <> ["  b " <> bodyLabel]
       blocks = concatMap renderBlock (reverse (functionBlocksRev finalState))
   pure (entry <> blocks)
+
+exportLines :: GrinFunction -> Text -> [Text]
+exportLines function label =
+  case grinFunctionLinkName function of
+    Just _ -> [".globl " <> label]
+    Nothing -> []
 
 parameterCopyLir :: Map GrinVar Int -> [GrinVar] -> [Lir.Instruction]
 parameterCopyLir slots parameters =
@@ -350,6 +374,27 @@ compileExpr env prefix label expression =
     GrinEval runtimeRep value -> do
       valueLines <- liftEither (materializeValue env value)
       addBlock label (prefix <> valueLines <> evalLines runtimeRep)
+    GrinCall _ functionName arguments -> do
+      target <- liftEither (functionCodeLabel (valueCompileEnv env) functionName)
+      argumentSlots <- freshSlots (length arguments)
+      argumentLines <-
+        fmap concat . forM (zip arguments argumentSlots) $ \(argument, slot) -> do
+          lines' <- liftEither (materializeValue env argument)
+          pure (lines' <> [storeAt "x0" "x19" slot])
+      addBlock
+        label
+        ( prefix
+            <> argumentLines
+            <> [slotPointer "x8" argumentSlots, "  str x8, [x22, #8]", "  b " <> target]
+        )
+    GrinPrimitiveCall runtimeRep name arguments
+      | name == "realWorld#",
+        null arguments,
+        null (runtimeRepComponents runtimeRep) ->
+          addBlock label (prefix <> returnValuesLines [])
+      | compileAllowUnsupportedPrimitives (valueCompileEnv env) ->
+          addBlock label (prefix <> ["  bl _aihc_unsupported_primitive", "  b " <> label])
+      | otherwise -> unsupportedExpression ("primitive call " <> name)
     GrinApply _ function arguments -> do
       scratch <- freshSlot
       functionLines <- liftEither (materializeValue env function)
@@ -783,6 +828,8 @@ boundVarGroups expression =
     GrinFetch _ _ -> []
     GrinUpdate _ _ -> []
     GrinEval _ _ -> []
+    GrinCall {} -> []
+    GrinPrimitiveCall {} -> []
     GrinApply {} -> []
     GrinCase _ binder alternatives -> [binder] : concatMap altBoundVarGroups alternatives
     GrinThrow _ -> []
@@ -847,6 +894,10 @@ exprRuntimeReps expression =
     GrinFetch runtimeRep pointer -> runtimeRep : valueRuntimeReps pointer
     GrinUpdate pointer value -> valueRuntimeReps pointer <> valueRuntimeReps value
     GrinEval runtimeRep value -> runtimeRep : valueRuntimeReps value
+    GrinCall runtimeRep _ arguments ->
+      runtimeRep : concatMap valueRuntimeReps arguments
+    GrinPrimitiveCall runtimeRep _ arguments ->
+      runtimeRep : concatMap valueRuntimeReps arguments
     GrinApply runtimeRep function arguments ->
       runtimeRep : valueRuntimeReps function <> concatMap valueRuntimeReps arguments
     GrinCase scrutinee binder alternatives ->
@@ -875,6 +926,18 @@ nodeRuntimeReps node = concatMap valueRuntimeReps (grinNodeFields node)
 
 functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index
+
+localFunctionLabel :: Int -> GrinFunction -> Text
+localFunctionLabel index function =
+  case grinFunctionLinkName function of
+    Just name -> linkedFunctionLabel name
+    Nothing -> functionLabel index
+
+linkedFunctionLabel :: Text -> Text
+linkedFunctionLabel name =
+  "_aihc_entry_" <> T.concatMap encode name
+  where
+    encode character = T.pack (showHex (ord character) "_")
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot =

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -74,6 +74,8 @@ tests =
                 { grinConstructors = [("Box", [runtimeRep])],
                   grinPrimitives = [],
                   grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
                   grinWhnfGlobals = [],
                   grinCafs = [],
                   grinFunctions = []
@@ -89,6 +91,8 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(primitive, 2)],
                   grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
                   grinWhnfGlobals = [],
                   grinCafs = [],
                   grinFunctions = []
@@ -104,11 +108,14 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
                   grinWhnfGlobals = [],
                   grinCafs = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
+                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int8Rep,
                           grinFunctionBody = GrinReturn [GrinLitValue (GrinLitInt Int8Rep 255)]
@@ -125,11 +132,14 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
                   grinWhnfGlobals = [],
                   grinCafs = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
+                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [TupleRep [], IntRep, WordRep],
                           grinFunctionBody =
@@ -146,6 +156,41 @@ tests =
             assertBool "returns two values" ("ldr x1, =2" `T.isInfixOf` assembly)
             assertBool "uses the multi-value return ABI" ("bl _aihc_return_values" `T.isInfixOf` assembly)
             assertBool "does not allocate an aggregate node" (not ("bl _aihc_make_node" `T.isInfixOf` assembly)),
+      testCase "exports stable entries and branches directly to dependency code" $ do
+        let identityName = FunctionName "$entry$identity"
+            callerName = FunctionName "$entry$caller"
+            argument = GrinVar "argument" 1 (BoxedRep Lifted)
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [],
+                  grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions =
+                    [ GrinCodeInfo
+                        { grinCodeSourceName = "identity",
+                          grinCodeFunctionName = identityName,
+                          grinCodeParameterLayouts = [[BoxedRep Lifted]],
+                          grinCodeResultRep = BoxedRep Lifted
+                        }
+                    ],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = callerName,
+                          grinFunctionLinkName = Just "caller",
+                          grinFunctionParameters = [argument],
+                          grinFunctionResultRep = BoxedRep Lifted,
+                          grinFunctionBody = GrinCall (BoxedRep Lifted) identityName [GrinVarValue argument]
+                        }
+                    ]
+                }
+        case compileModule (buildLinkLayout [program]) "_aihc_init_direct_call" program of
+          Left err -> assertFailure ("native compilation failed: " <> show err)
+          Right assembly -> do
+            assertBool "exports caller entry" (".globl _aihc_entry_63_61_6c_6c_65_72_" `T.isInfixOf` assembly)
+            assertBool "branches to dependency entry" ("b _aihc_entry_69_64_65_6e_74_69_74_79_" `T.isInfixOf` assembly),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -158,12 +158,9 @@ initialMachine program =
         [ Map.fromList [(grinVarName var, value) | (var, value) <- cafLocations],
           staticGlobals,
           Map.fromList
-            [ (grinVarName var, RuntimeNode (GrinPrimitive (grinVarName var) arity) [])
-            | (var, arity) <- grinPrimitives program
-            ],
-          Map.fromList
             [ (constructor, RuntimeNode (GrinConstructor constructor) [])
-            | constructor <- map fst builtinConstructors <> map fst (grinConstructors program)
+            | (constructor, arity) <- builtinConstructors <> [(name, length fields) | (name, fields) <- grinConstructors program],
+              arity == 0
             ]
         ]
     staticNode (GrinNode tag fields) = RuntimeNode tag (map staticValue fields)
@@ -202,6 +199,10 @@ evalExpr env expr =
       pure <$> updateValue pointerValue updatedValue
     GrinEval _ value ->
       (: []) <$> (materializeValue env value >>= forceValue)
+    GrinCall _ functionName arguments ->
+      callFunction functionName =<< mapM (materializeValue env) arguments
+    GrinPrimitiveCall _ name arguments ->
+      evalPrimitive name =<< mapM (materializeValue env) arguments
     GrinApply _ function arguments -> do
       functionValue <- materializeValue env function
       argumentValues <- mapM (materializeValue env) arguments
@@ -359,9 +360,15 @@ applyValue function arguments = do
               argumentCount == 1 =
                 [RuntimeStateToken]
             | otherwise = arguments
-       in if argumentCount == length runtimeArguments
-            then callFunction functionName (fields <> runtimeArguments)
-            else throwInterpret (InterpretFunctionArity functionName argumentCount (length arguments))
+       in case compare (length runtimeArguments) argumentCount of
+            LT ->
+              pure
+                [ RuntimeNode
+                    (GrinClosure functionName (argumentCount - length runtimeArguments))
+                    (fields <> runtimeArguments)
+                ]
+            EQ -> callFunction functionName (fields <> runtimeArguments)
+            GT -> throwInterpret (InterpretFunctionArity functionName argumentCount (length arguments))
     RuntimeNode constructor@(GrinConstructor _) fields ->
       pure [RuntimeNode constructor (fields <> arguments)]
     RuntimeNode (GrinPrimitive name arity) fields ->

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -21,6 +21,7 @@ data GrinLintError
   | GrinLintDuplicateCaf !GrinVar
   | GrinLintUnboundVariable !GrinVar
   | GrinLintUnknownFunction !FunctionName
+  | GrinLintUnknownPrimitive !Text
   | GrinLintFunctionArity !FunctionName !Int !Int
   | GrinLintThunkResult !FunctionName !RuntimeRep
   | GrinLintRepresentationMismatch !String !RuntimeRep !RuntimeRep
@@ -36,6 +37,7 @@ data GrinLintError
 data LintEnv = LintEnv
   { lintFunctionArities :: !(Map FunctionName Int),
     lintFunctionResults :: !(Map FunctionName RuntimeRep),
+    lintPrimitiveArities :: !(Map Text Int),
     lintGlobalVars :: !(Set GrinVar),
     lintGlobalNames :: !(Set Text),
     lintConstructorLayouts :: !(Map Text [RuntimeRep]),
@@ -64,16 +66,25 @@ lintProgram program =
       LintEnv
         { lintFunctionArities =
             Map.fromList
-              [ (grinFunctionName function, length (grinFunctionParameters function))
-              | function <- functions
-              ],
-          lintFunctionResults = Map.fromList [(grinFunctionName function, grinFunctionResultRep function) | function <- functions],
+              ( [ (grinFunctionName function, length (grinFunctionParameters function))
+                | function <- functions
+                ]
+                  <> [ (grinCodeFunctionName info, length (concat (grinCodeParameterLayouts info)))
+                     | info <- grinExternalFunctions program
+                     ]
+              ),
+          lintFunctionResults =
+            Map.fromList
+              ( [(grinFunctionName function, grinFunctionResultRep function) | function <- functions]
+                  <> [(grinCodeFunctionName info, grinCodeResultRep info) | info <- grinExternalFunctions program]
+              ),
+          lintPrimitiveArities = Map.fromList [(grinVarName var, arity) | (var, arity) <- grinPrimitives program],
           lintGlobalVars = Set.fromList (globalVars <> cafVars),
           lintGlobalNames =
             Set.fromList
-              ( map fst builtinConstructors
-                  <> map fst (grinConstructors program)
-                  <> map (grinVarName . fst) (grinPrimitives program)
+              ( [name | (name, arity) <- builtinConstructors, arity == 0]
+                  <> [name | (name, fields) <- grinConstructors program, null fields]
+                  <> grinExternalGlobals program
                   <> map grinVarName globalVars
                   <> map grinVarName cafVars
               ),
@@ -130,6 +141,11 @@ lintExpr env bound expr =
     GrinEval _ value ->
       [GrinLintEvalNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, runtimeRep /= liftedRuntimeRep]
         <> lintValue env bound value
+    GrinCall runtimeRep functionName arguments ->
+      lintKnownCall env bound runtimeRep functionName arguments
+    GrinPrimitiveCall _ name arguments ->
+      [GrinLintUnknownPrimitive name | name `Map.notMember` lintPrimitiveArities env]
+        <> concatMap (lintValue env bound) arguments
     GrinApply _ function arguments -> lintValue env bound function <> concatMap (lintValue env bound) arguments
     GrinCase scrutinee binder alternatives ->
       lintValue env bound scrutinee
@@ -157,15 +173,27 @@ lintExpr env bound expr =
                  expected /= actual
                ]
             <> concatMap (lintValue env bound) arguments
+
+lintKnownCall :: LintEnv -> Set GrinVar -> RuntimeRep -> FunctionName -> [GrinValue] -> [GrinLintError]
+lintKnownCall env bound _runtimeRep functionName arguments =
+  functionErrors <> concatMap (lintValue env bound) arguments
   where
-    bindRepresentationErrors vars valueExpr =
-      case exprRuntimeReps valueExpr of
-        Just actual
-          | actual /= expected ->
-              [GrinLintResultLayout "bind" expected actual]
-        _ -> []
-      where
-        expected = map grinVarRuntimeRep vars
+    functionErrors =
+      case Map.lookup functionName (lintFunctionArities env) of
+        Nothing -> [GrinLintUnknownFunction functionName]
+        Just expected
+          | expected /= length arguments -> [GrinLintFunctionArity functionName expected (length arguments)]
+        Just _ -> []
+
+bindRepresentationErrors :: [GrinVar] -> GrinExpr -> [GrinLintError]
+bindRepresentationErrors vars valueExpr =
+  case exprRuntimeReps valueExpr of
+    Just actual
+      | actual /= expected ->
+          [GrinLintResultLayout "bind" expected actual]
+    _ -> []
+  where
+    expected = map grinVarRuntimeRep vars
 
 lintAlt :: LintEnv -> Set GrinVar -> GrinAlt -> [GrinLintError]
 lintAlt env bound alt =
@@ -193,7 +221,8 @@ lintConstructorFields env node =
     GrinConstructor name ->
       case Map.lookup name (lintConstructorLayouts env) of
         Just expected
-          | expected /= actual -> [GrinLintConstructorLayout name expected actual]
+          | actual /= take (length actual) expected || length actual > length expected ->
+              [GrinLintConstructorLayout name expected actual]
         _ -> []
     _ -> []
   where
@@ -239,6 +268,8 @@ exprRuntimeReps expr =
     GrinFetch runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
     GrinUpdate _ value -> Just [grinValueRuntimeRep value]
     GrinEval runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
+    GrinCall runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
+    GrinPrimitiveCall runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinApply runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinCase _ _ alternatives ->
       case alternatives of

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -34,7 +34,12 @@ data LowerState = LowerState
     lowerNextFunction :: !Int,
     lowerFunctionsRev :: ![GrinFunction],
     lowerConstructorArities :: !(Map Text Int),
-    lowerPrimitiveNames :: !(Set Text),
+    lowerPrimitiveArities :: !(Map Text Int),
+    lowerCodeInfos :: !(Map Text GrinCodeInfo),
+    lowerLocalCodeNames :: !(Set Text),
+    lowerReferencedExternalCodeNames :: !(Set Text),
+    lowerLocalGlobalNames :: !(Set Text),
+    lowerReferencedExternalGlobalNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
     lowerLocalVars :: !(Map (Text, Unique) [GrinVar])
@@ -78,7 +83,8 @@ data GrinInterface = GrinInterface
   { grinInterfaceGlobals :: !(Set Text),
     grinInterfaceWhnfGlobals :: !(Set Text),
     grinInterfaceConstructorArities :: !(Map Text Int),
-    grinInterfacePrimitives :: !(Set Text)
+    grinInterfacePrimitiveArities :: !(Map Text Int),
+    grinInterfaceCodeInfos :: !(Map Text GrinCodeInfo)
   }
   deriving (Eq, Show, Read)
 
@@ -88,11 +94,12 @@ instance Semigroup GrinInterface where
       { grinInterfaceGlobals = grinInterfaceGlobals left <> grinInterfaceGlobals right,
         grinInterfaceWhnfGlobals = grinInterfaceWhnfGlobals left <> grinInterfaceWhnfGlobals right,
         grinInterfaceConstructorArities = grinInterfaceConstructorArities left <> grinInterfaceConstructorArities right,
-        grinInterfacePrimitives = grinInterfacePrimitives left <> grinInterfacePrimitives right
+        grinInterfacePrimitiveArities = grinInterfacePrimitiveArities left <> grinInterfacePrimitiveArities right,
+        grinInterfaceCodeInfos = grinInterfaceCodeInfos left <> grinInterfaceCodeInfos right
       }
 
 instance Monoid GrinInterface where
-  mempty = GrinInterface Set.empty Set.empty Map.empty Set.empty
+  mempty = GrinInterface Set.empty Set.empty Map.empty Map.empty Map.empty
 
 extractGrinInterface :: FcProgram -> GrinInterface
 extractGrinInterface program =
@@ -100,11 +107,12 @@ extractGrinInterface program =
     { grinInterfaceGlobals = Set.fromList (programGlobalNames program),
       grinInterfaceWhnfGlobals = Set.fromList (programWhnfGlobalNames program),
       grinInterfaceConstructorArities = Map.fromList (programConstructors program),
-      grinInterfacePrimitives =
-        Set.fromList
-          [ varName var
-          | FcPrimitive var _ <- fcTopBinds program
-          ]
+      grinInterfacePrimitiveArities =
+        Map.fromList
+          [ (varName var, arity)
+          | FcPrimitive var arity <- fcTopBinds program
+          ],
+      grinInterfaceCodeInfos = Map.fromList (programCodeInfos program)
     }
 
 -- | Lower one SCC using only the exported runtime facts of predecessor SCCs.
@@ -117,7 +125,8 @@ data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),
     programEnvironmentWhnfGlobals :: !(Set Text),
     programEnvironmentConstructorArities :: !(Map Text Int),
-    programEnvironmentPrimitives :: !(Set Text)
+    programEnvironmentPrimitiveArities :: !(Map Text Int),
+    programEnvironmentCodeInfos :: !(Map Text GrinCodeInfo)
   }
 
 programEnvironment :: GrinInterface -> ProgramEnvironment
@@ -126,7 +135,8 @@ programEnvironment interface =
     { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
       programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
       programEnvironmentConstructorArities = Map.fromList builtinConstructors <> grinInterfaceConstructorArities interface,
-      programEnvironmentPrimitives = grinInterfacePrimitives interface
+      programEnvironmentPrimitiveArities = grinInterfacePrimitiveArities interface,
+      programEnvironmentCodeInfos = grinInterfaceCodeInfos interface
     }
 
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
@@ -135,6 +145,8 @@ lowerProgramWithEnvironment environment program =
     { grinConstructors = loweredConstructors tops,
       grinPrimitives = loweredPrimitives tops,
       grinForeignCalls = loweredForeignCalls tops,
+      grinExternalGlobals = Set.toAscList (lowerReferencedExternalGlobalNames finalState),
+      grinExternalFunctions = externalCodeInfos,
       grinWhnfGlobals = loweredWhnfGlobals tops,
       grinCafs = loweredCafs tops,
       grinFunctions = reverse (lowerFunctionsRev finalState)
@@ -146,13 +158,24 @@ lowerProgramWithEnvironment environment program =
           lowerNextFunction = 0,
           lowerFunctionsRev = [],
           lowerConstructorArities = programEnvironmentConstructorArities environment,
-          lowerPrimitiveNames = programEnvironmentPrimitives environment,
+          lowerPrimitiveArities = programEnvironmentPrimitiveArities environment,
+          lowerCodeInfos = programEnvironmentCodeInfos environment,
+          lowerLocalCodeNames = localCodeNames,
+          lowerReferencedExternalCodeNames = Set.empty,
+          lowerLocalGlobalNames = Set.fromList (programGlobalNames program),
+          lowerReferencedExternalGlobalNames = Set.empty,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
           lowerLocalVars = Map.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
     tops = mconcat topParts
+    localCodeNames = Map.keysSet (Map.fromList (programCodeInfos program))
+    externalCodeInfos =
+      [ info
+      | (name, info) <- Map.toAscList (programEnvironmentCodeInfos environment),
+        name `Set.member` lowerReferencedExternalCodeNames finalState
+      ]
 
 lowerTopBind :: FcTopBind -> LowerM LoweredTop
 lowerTopBind topBind =
@@ -175,14 +198,18 @@ lowerTopValueBind bind =
       mconcat <$> mapM (uncurry lowerBinding) bindings
   where
     lowerBinding var expr = do
-      topVar <- freshTopVar var
       if isDirectFunction expr
         then do
-          node <- makeGlobalFunction expr
-          pure mempty {loweredWhnfGlobals = [(topVar, node)]}
+          emitTopFunction var expr
+          pure mempty
         else do
-          node <- makeThunk expr
-          pure mempty {loweredCafs = [(topVar, node)]}
+          staticNode <- lowerStaticNode expr
+          topVar <- freshTopVar var
+          case staticNode of
+            Just node -> pure mempty {loweredWhnfGlobals = [(topVar, node)]}
+            Nothing -> do
+              node <- makeThunk expr
+              pure mempty {loweredCafs = [(topVar, node)]}
 
 -- | A top-level RHS is already a function value exactly when reaching its
 -- first runtime construct requires only erasing type abstraction or casts.
@@ -196,31 +223,44 @@ isDirectFunction expr =
     FcCast inner _ -> isDirectFunction inner
     _ -> False
 
-makeGlobalFunction :: FcExpr -> LowerM GrinNode
-makeGlobalFunction expr = do
-  lowered <- lowerExpr expr
-  case lowered of
-    GrinReturn [GrinNodeValue node@GrinNode {grinNodeTag = GrinClosure {}}] -> pure node
-    _ -> error "GRIN lowering expected a direct top-level function closure"
+emitTopFunction :: Var -> FcExpr -> LowerM ()
+emitTopFunction var expr = do
+  let (binders, body) = collectLeadingLambdas expr
+      functionName = topFunctionName var
+  (parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
+    body' <- lowerExpr body
+    pure (concat groups, body')
+  emitFunction
+    GrinFunction
+      { grinFunctionName = functionName,
+        grinFunctionLinkName = Just (varName var),
+        grinFunctionParameters = parameters,
+        grinFunctionResultRep = exprRuntimeRep body,
+        grinFunctionBody = loweredBody
+      }
 
 lowerExpr :: FcExpr -> LowerM GrinExpr
 lowerExpr expr = do
   constructorArities <- gets lowerConstructorArities
-  primitiveNames <- gets lowerPrimitiveNames
+  primitiveArities <- gets lowerPrimitiveArities
   localVars <- gets lowerLocalVars
-  case saturatedConstructorApplication constructorArities (Map.keysSet localVars) expr of
+  case constructorApplication constructorArities (Map.keysSet localVars) expr of
     Just (constructor, arguments) ->
       lowerArgumentMany arguments $ \values ->
-        pure (GrinStore (GrinNode (GrinConstructor constructor) values))
+        pure (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor constructor) values)])
     Nothing ->
-      case primitiveApplication primitiveNames (Map.keysSet localVars) expr of
+      case primitiveApplication primitiveArities (Map.keysSet localVars) expr of
         Just ("raise#", [exception]) ->
-          lowerSingleStrict "exception" exception (pure . GrinThrow)
+          lowerSingleOperand "exception" exception (pure . GrinThrow)
         Just ("catch#", [action, handler, _state]) ->
           lowerSingleArgument action $ \actionValue ->
             lowerSingleArgument handler $ \handlerValue ->
               pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue [])
-        _ -> lowerOrdinaryExpr expr
+        Just (name, arguments) ->
+          case Map.lookup name primitiveArities of
+            Just arity -> lowerPrimitiveApplication expr name arity arguments
+            Nothing -> error "GRIN lowering lost primitive arity"
+        Nothing -> lowerOrdinaryExpr expr
 
 lowerOrdinaryExpr :: FcExpr -> LowerM GrinExpr
 lowerOrdinaryExpr expr =
@@ -234,25 +274,21 @@ lowerNonTupleExpr expr =
   case expr of
     FcVar var ->
       do
-        direct <- lowerDirectValues expr
-        case direct of
-          Just values -> pure (GrinReturn values)
+        codeInfo <- lookupCodeInfo var
+        case codeInfo of
+          Just info -> pure (GrinReturn [knownFunctionValue info 0 []])
           Nothing -> do
-            isGlobal <- isGlobalVar var
-            runtimeVar <-
-              if isGlobal
-                then pure (lowerGlobalVar var)
-                else do
-                  localValues <- lookupLocalVars var
-                  case localValues of
-                    [localVar] -> pure localVar
-                    _ -> error "GRIN lowering expected one lifted local"
-            let resultRep = typeRuntimeRep (varType var)
-            pure (GrinEval resultRep (GrinVarValue runtimeVar))
+            direct <- lowerDirectValues expr
+            case direct of
+              Just values -> pure (GrinReturn values)
+              Nothing -> do
+                runtimeVar <- lookupRuntimeVar var
+                let resultRep = typeRuntimeRep (varType var)
+                pure (GrinEval resultRep (GrinVarValue runtimeVar))
     FcLit literal ->
       pure (GrinReturn [GrinLitValue (lowerLiteral literal)])
-    FcApp function argument ->
-      lowerApplication function argument
+    FcApp {} ->
+      lowerApplication expr
     FcTyApp inner _ ->
       lowerExpr inner
     FcLam var body ->
@@ -269,11 +305,126 @@ lowerNonTupleExpr expr =
       lowerStrictMany arguments $ \values ->
         pure (GrinForeignCallExpr (lowerForeignCall foreignCall) values)
 
-lowerApplication :: FcExpr -> FcExpr -> LowerM GrinExpr
-lowerApplication function argument =
-  lowerSingleStrict "function" function $ \functionValue ->
-    lowerArgument argument $ \argumentValues ->
-      pure (GrinApply (applicationResultRep function) functionValue argumentValues)
+lowerApplication :: FcExpr -> LowerM GrinExpr
+lowerApplication expr =
+  case collectApplications expr of
+    (FcVar var, arguments) -> do
+      codeInfo <- lookupCodeInfo var
+      case codeInfo of
+        Just info -> lowerKnownApplication expr info arguments
+        Nothing -> lowerUnknownApplication expr
+    _ -> lowerUnknownApplication expr
+
+lowerKnownApplication :: FcExpr -> GrinCodeInfo -> [FcExpr] -> LowerM GrinExpr
+lowerKnownApplication originalExpr info arguments =
+  case compare suppliedArity termArity of
+    LT ->
+      lowerArgumentMany arguments $ \values ->
+        pure (GrinReturn [knownFunctionValue info suppliedArity values])
+    EQ ->
+      lowerArgumentMany arguments $ \values ->
+        pure (GrinCall (exprRuntimeRep appliedExpr) (grinCodeFunctionName info) values)
+    GT -> do
+      let (saturatedArguments, extraArguments) = splitAt termArity arguments
+          saturatedExpr = dropLastTermApplications (suppliedArity - termArity) originalExpr
+          saturatedRep = exprRuntimeRep saturatedExpr
+      lowerArgumentMany saturatedArguments $ \values -> do
+        resultVars <- freshVars "call" saturatedRep
+        case resultVars of
+          [resultVar] -> do
+            rest <- lowerRemainingApplications saturatedExpr (GrinVarValue resultVar) extraArguments
+            pure
+              ( GrinBind
+                  resultVars
+                  (GrinCall saturatedRep (grinCodeFunctionName info) values)
+                  rest
+              )
+          _ -> error "GRIN lowering expected an overapplied function call to return one function value"
+  where
+    suppliedArity = length arguments
+    termArity = length (grinCodeParameterLayouts info)
+    appliedExpr = originalExpr
+
+lowerPrimitiveApplication :: FcExpr -> Text -> Int -> [FcExpr] -> LowerM GrinExpr
+lowerPrimitiveApplication originalExpr name arity arguments =
+  case compare suppliedArity arity of
+    LT ->
+      lowerArgumentMany arguments $ \values ->
+        pure
+          ( GrinReturn
+              [ GrinNodeValue
+                  (GrinNode (GrinPrimitive name (arity - suppliedArity)) values)
+              ]
+          )
+    EQ ->
+      lowerArgumentMany arguments $ \values ->
+        pure (GrinPrimitiveCall (exprRuntimeRep originalExpr) name values)
+    GT -> do
+      let (saturatedArguments, extraArguments) = splitAt arity arguments
+          saturatedExpr = dropLastTermApplications (suppliedArity - arity) originalExpr
+          saturatedRep = exprRuntimeRep saturatedExpr
+      lowerArgumentMany saturatedArguments $ \values -> do
+        resultVars <- freshVars "primitive" saturatedRep
+        case resultVars of
+          [resultVar] -> do
+            rest <- lowerRemainingApplications saturatedExpr (GrinVarValue resultVar) extraArguments
+            pure
+              ( GrinBind
+                  resultVars
+                  (GrinPrimitiveCall saturatedRep name values)
+                  rest
+              )
+          _ -> error "GRIN lowering expected an overapplied primitive to return one function value"
+  where
+    suppliedArity = length arguments
+
+dropLastTermApplications :: Int -> FcExpr -> FcExpr
+dropLastTermApplications count expr
+  | count <= 0 = expr
+  | otherwise =
+      case expr of
+        FcApp function _ -> dropLastTermApplications (count - 1) function
+        FcTyApp inner ty -> FcTyApp (dropLastTermApplications count inner) ty
+        FcCast inner coercion -> FcCast (dropLastTermApplications count inner) coercion
+        _ -> error "GRIN lowering could not split an overapplication"
+
+lowerRemainingApplications :: FcExpr -> GrinValue -> [FcExpr] -> LowerM GrinExpr
+lowerRemainingApplications functionExpr functionValue arguments =
+  case arguments of
+    [] -> pure (GrinReturn [functionValue])
+    argument : rest -> do
+      let appliedExpr = FcApp functionExpr argument
+          resultRep = exprRuntimeRep appliedExpr
+      lowerArgument argument $ \argumentValues ->
+        if null rest
+          then pure (GrinApply resultRep functionValue argumentValues)
+          else do
+            resultVars <- freshVars "function" resultRep
+            case resultVars of
+              [resultVar] -> do
+                body <- lowerRemainingApplications appliedExpr (GrinVarValue resultVar) rest
+                pure (GrinBind resultVars (GrinApply resultRep functionValue argumentValues) body)
+              _ -> error "GRIN lowering expected an intermediate application to return one function value"
+
+lowerUnknownApplication :: FcExpr -> LowerM GrinExpr
+lowerUnknownApplication expr =
+  case expr of
+    FcApp function argument ->
+      lowerSingleOperand "function" function $ \functionValue ->
+        lowerArgument argument $ \argumentValues ->
+          pure (GrinApply (applicationResultRep function) functionValue argumentValues)
+    _ -> error "GRIN lowering expected an application"
+
+knownFunctionValue :: GrinCodeInfo -> Int -> [GrinValue] -> GrinValue
+knownFunctionValue info suppliedTermArity fields =
+  GrinNodeValue
+    ( GrinNode
+        (GrinClosure (grinCodeFunctionName info) remainingRuntimeArity)
+        fields
+    )
+  where
+    remainingRuntimeArity =
+      length (concat (drop suppliedTermArity (grinCodeParameterLayouts info)))
 
 lowerCase :: FcExpr -> Var -> [FcAlt] -> LowerM GrinExpr
 lowerCase scrutinee binder alternatives =
@@ -290,7 +441,7 @@ lowerCase scrutinee binder alternatives =
         isUnboxedTupleConstructor constructor ->
           lowerUnboxedTupleCase scrutinee binder alternative
     _ ->
-      lowerSingleStrict "scrutinee" scrutinee $ \value -> do
+      lowerSingleOperand "scrutinee" scrutinee $ \value -> do
         caseVars <- binderVars binder
         caseVar <-
           case caseVars of
@@ -326,39 +477,63 @@ splitWidths widths values =
        in field : splitWidths rest remaining
 
 lowerLambda :: Var -> FcExpr -> LowerM GrinExpr
-lowerLambda binder body = do
-  captures <- capturesFor (FcLam binder body)
+lowerLambda binder body =
+  GrinReturn . pure . GrinNodeValue <$> makeClosureNode (FcLam binder body)
+
+makeClosureNode :: FcExpr -> LowerM GrinNode
+makeClosureNode expr = do
+  let (binders, lambdaBody) = collectLeadingLambdas expr
+  captures <- capturesFor expr
   functionName <- freshFunction "closure"
-  (parameters, loweredBody) <- withFreshLocalVars [binder] $ \groups -> do
-    body' <- lowerExpr body
+  (parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
+    body' <- lowerExpr lambdaBody
     pure (concat groups, body')
   emitFunction
     GrinFunction
       { grinFunctionName = functionName,
+        grinFunctionLinkName = Nothing,
         grinFunctionParameters = captures <> parameters,
-        grinFunctionResultRep = exprRuntimeRep body,
+        grinFunctionResultRep = exprRuntimeRep lambdaBody,
         grinFunctionBody = loweredBody
       }
-  pure
-    (GrinReturn [GrinNodeValue (GrinNode (GrinClosure functionName (length parameters)) (map GrinVarValue captures))])
+  pure (GrinNode (GrinClosure functionName (length parameters)) (map GrinVarValue captures))
 
 lowerLet :: FcBind -> FcExpr -> LowerM GrinExpr
 lowerLet bind body =
   case bind of
-    FcNonRec var rhs -> do
-      (vars, loweredBody) <- withFreshLocalVars [var] $ \groups -> do
-        body' <- lowerExpr body
-        pure (concat groups, body')
-      if typeRuntimeRep (varType var) == liftedRuntimeRep
-        then do
-          node <- makeThunk rhs
-          pure (GrinBind vars (GrinStore node) loweredBody)
-        else do
+    FcNonRec var rhs
+      | typeRuntimeRep (varType var) == liftedRuntimeRep -> do
+          alias <- lookupAliasVars rhs
+          case alias of
+            Just values -> withBindings [(var, values)] (lowerExpr body)
+            Nothing -> do
+              rhsIsWhnf <- isWhnfExpr rhs
+              (vars, loweredBody) <- withFreshLocalVars [var] $ \groups -> do
+                body' <- lowerExpr body
+                pure (concat groups, body')
+              if rhsIsWhnf
+                then do
+                  loweredRhs <- lowerExpr rhs
+                  pure (GrinBind vars loweredRhs loweredBody)
+                else do
+                  node <- makeThunk rhs
+                  pure (GrinBind vars (GrinStore node) loweredBody)
+      | otherwise -> do
+          (vars, loweredBody) <- withFreshLocalVars [var] $ \groups -> do
+            body' <- lowerExpr body
+            pure (concat groups, body')
           loweredRhs <- lowerExpr rhs
           pure (GrinBind vars loweredRhs loweredBody)
     FcRec bindings -> do
       withFreshLocalVars (map fst bindings) $ \groups -> do
-        nodes <- mapM (makeThunk . snd) bindings
+        nodes <-
+          mapM
+            ( \(_, rhs) ->
+                if isDirectFunction rhs
+                  then makeClosureNode rhs
+                  else makeThunk rhs
+            )
+            bindings
         loweredBody <- lowerExpr body
         let vars = concat groups
         if length vars == length nodes
@@ -388,6 +563,7 @@ makeThunk expr
       emitFunction
         GrinFunction
           { grinFunctionName = functionName,
+            grinFunctionLinkName = Nothing,
             grinFunctionParameters = captures,
             grinFunctionResultRep = runtimeRep,
             grinFunctionBody = body
@@ -395,6 +571,40 @@ makeThunk expr
       pure (GrinNode (GrinThunk functionName) (map GrinVarValue captures))
   where
     runtimeRep = exprRuntimeRep expr
+
+lowerStaticNode :: FcExpr -> LowerM (Maybe GrinNode)
+lowerStaticNode expr = do
+  constructorArities <- gets lowerConstructorArities
+  localVars <- gets lowerLocalVars
+  case constructorApplication constructorArities (Map.keysSet localVars) expr of
+    Just (constructor, arguments) -> do
+      values <- mapM lowerStaticValues arguments
+      pure (GrinNode (GrinConstructor constructor) . concat <$> sequence values)
+    Nothing -> pure Nothing
+
+lowerStaticValues :: FcExpr -> LowerM (Maybe [GrinValue])
+lowerStaticValues expr =
+  case expr of
+    FcLit literal -> pure (Just [GrinLitValue (lowerLiteral literal)])
+    FcVar var
+      | null (runtimeRepComponents (typeRuntimeRep (varType var))) -> pure (Just [])
+      | otherwise -> do
+          constructorArity <- lookupConstructorArity var
+          isWhnfGlobal <- isWhnfGlobalVar var
+          localGlobalNames <- gets lowerLocalGlobalNames
+          case constructorArity of
+            Just 0 -> do
+              noteExternalGlobalReference var
+              pure (Just [GrinVarValue (lowerGlobalVar var)])
+            _
+              | isWhnfGlobal,
+                varName var `Set.notMember` localGlobalNames -> do
+                  noteExternalGlobalReference var
+                  pure (Just [GrinVarValue (lowerGlobalVar var)])
+              | otherwise -> pure Nothing
+    FcTyApp inner _ -> lowerStaticValues inner
+    FcCast inner _ -> lowerStaticValues inner
+    _ -> pure Nothing
 
 lowerStrict :: Text -> FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerStrict hint expr continuation = do
@@ -407,27 +617,64 @@ lowerStrict hint expr continuation = do
       rest <- continuation (map GrinVarValue valueVars)
       pure (GrinBind valueVars valueExpr rest)
 
-lowerSingleStrict :: Text -> FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
-lowerSingleStrict hint expr continuation =
-  lowerStrict hint expr $ \case
+-- | Lower an operand for an operation that performs its own forcing. Variables
+-- are passed as their existing lazy pointers; non-atomic computations are
+-- evaluated only far enough to produce the operand supplied to the operation.
+lowerOperand :: Text -> FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerOperand hint expr continuation = do
+  direct <- lowerLazyDirectValues expr
+  case direct of
+    Just values -> continuation values
+    Nothing -> do
+      valueVars <- freshVars hint (exprRuntimeRep expr)
+      valueExpr <- lowerExpr expr
+      rest <- continuation (map GrinVarValue valueVars)
+      pure (GrinBind valueVars valueExpr rest)
+
+lowerSingleOperand :: Text -> FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerSingleOperand hint expr continuation =
+  lowerOperand hint expr $ \case
     [value] -> continuation value
-    _ -> error ("GRIN lowering expected one value for " <> T.unpack hint)
+    _ -> error ("GRIN lowering expected one operand for " <> T.unpack hint)
 
 lowerDelayed :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerDelayed expr continuation = do
-  pointerVar <- freshVar "thunk" liftedRuntimeRep
-  node <- makeThunk expr
-  rest <- continuation [GrinVarValue pointerVar]
-  pure (GrinBind [pointerVar] (GrinStore node) rest)
+  knownCall <- knownSaturatedApplication expr
+  case knownCall of
+    Just (info, arguments) ->
+      lowerArgumentMany arguments $ \values ->
+        storeDelayedNode (GrinNode (GrinThunk (grinCodeFunctionName info)) values)
+    Nothing -> makeThunk expr >>= storeDelayedNode
+  where
+    storeDelayedNode node = do
+      pointerVar <- freshVar "thunk" liftedRuntimeRep
+      rest <- continuation [GrinVarValue pointerVar]
+      pure (GrinBind [pointerVar] (GrinStore node) rest)
 
 lowerArgument :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerArgument expr continuation = do
-  direct <- lowerDirectValues expr
+  direct <- lowerLazyDirectValues expr
   case direct of
-    Just values -> continuation values
-    Nothing
-      | exprRuntimeRep expr == liftedRuntimeRep -> lowerDelayed expr continuation
-      | otherwise -> lowerStrict "argument" expr continuation
+    Just values -> atomizeNodeValues values continuation
+    Nothing -> do
+      whnf <- isWhnfExpr expr
+      if whnf
+        then lowerOperand "argument" expr continuation
+        else
+          if exprRuntimeRep expr == liftedRuntimeRep
+            then lowerDelayed expr continuation
+            else lowerStrict "argument" expr continuation
+
+atomizeNodeValues :: [GrinValue] -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
+atomizeNodeValues values continuation
+  | any isNodeValue values = do
+      vars <- mapM (freshVar "value" . grinValueRuntimeRep) values
+      rest <- continuation (map GrinVarValue vars)
+      pure (GrinBind vars (GrinReturn values) rest)
+  | otherwise = continuation values
+  where
+    isNodeValue GrinNodeValue {} = True
+    isNodeValue _ = False
 
 lowerSingleArgument :: FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerSingleArgument expr continuation =
@@ -495,23 +742,23 @@ emitFunction :: GrinFunction -> LowerM ()
 emitFunction function =
   modify' $ \state -> state {lowerFunctionsRev = function : lowerFunctionsRev state}
 
-primitiveApplication :: Set Text -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
-primitiveApplication primitiveNames localVars expr =
+primitiveApplication :: Map Text Int -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
+primitiveApplication primitiveArities localVars expr =
   case collectApplications expr of
     (FcVar var, arguments)
       | varKey var `Set.notMember` localVars,
-        varName var `Set.member` primitiveNames ->
+        varName var `Map.member` primitiveArities ->
           Just (varName var, arguments)
     _ -> Nothing
 
-saturatedConstructorApplication :: Map Text Int -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
-saturatedConstructorApplication constructorArities localVars expr =
+constructorApplication :: Map Text Int -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
+constructorApplication constructorArities localVars expr =
   case collectApplications expr of
     (FcVar var, arguments)
       | varKey var `Set.notMember` localVars,
         Just arity <- Map.lookup (varName var) constructorArities,
         arity > 0,
-        length arguments == arity ->
+        length arguments <= arity ->
           Just (varName var, arguments)
     _ -> Nothing
 
@@ -561,8 +808,16 @@ capturesFor expr =
   fmap concat . mapM captureVars $ Set.toAscList (freeVars expr)
   where
     captureVars var = do
-      global <- isGlobalVar var
-      if global then pure [] else lookupLocalVars var
+      codeInfo <- lookupCodeInfo var
+      case codeInfo of
+        Just _ -> pure []
+        Nothing -> do
+          primitiveArity <- lookupPrimitiveArity var
+          case primitiveArity of
+            Just _ -> pure []
+            Nothing -> do
+              global <- isGlobalVar var
+              if global then pure [] else lookupLocalVars var
 
 isGlobalVar :: Var -> LowerM Bool
 isGlobalVar var = do
@@ -574,29 +829,189 @@ isGlobalVar var = do
     )
 
 -- | Values that are already in runtime normal form can be embedded directly
--- in the surrounding GRIN operation. Constructor, primitive, and foreign
--- globals are initialized as runtime nodes; unlike CAFs, they have no thunk to
--- enter. Unboxed locals and literals are direct machine values as well.
+-- in the surrounding GRIN operation. Constructors and primitives with positive
+-- arity are node literals rather than allocated globals. Unboxed locals and
+-- literals are direct machine values as well.
 lowerDirectValues :: FcExpr -> LowerM (Maybe [GrinValue])
 lowerDirectValues expr =
   case expr of
     FcVar var -> do
       isGlobal <- isGlobalVar var
       isWhnfGlobal <- isWhnfGlobalVar var
+      constructorArity <- lookupConstructorArity var
+      primitiveArity <- lookupPrimitiveArity var
       let runtimeRep = typeRuntimeRep (varType var)
-      if null (runtimeRepComponents runtimeRep)
-        then pure (Just [])
-        else
-          if isWhnfGlobal
-            then pure (Just [GrinVarValue (lowerGlobalVar var)])
-            else
-              if not isGlobal && runtimeRep /= liftedRuntimeRep
-                then Just . map GrinVarValue <$> lookupLocalVars var
-                else pure Nothing
+      case (constructorArity, primitiveArity) of
+        _ | null (runtimeRepComponents runtimeRep) -> pure (Just [])
+        (Just arity, _)
+          | arity > 0 ->
+              pure (Just [GrinNodeValue (GrinNode (GrinConstructor (varName var)) [])])
+        (_, Just arity)
+          | arity > 0 ->
+              pure (Just [GrinNodeValue (GrinNode (GrinPrimitive (varName var) arity) [])])
+        _
+          | isWhnfGlobal -> do
+              noteExternalGlobalReference var
+              pure (Just [GrinVarValue (lowerGlobalVar var)])
+          | not isGlobal && runtimeRep /= liftedRuntimeRep ->
+              Just . map GrinVarValue <$> lookupLocalVars var
+          | otherwise -> pure Nothing
     FcLit literal -> pure (Just [GrinLitValue (lowerLiteral literal)])
     FcTyApp inner _ -> lowerDirectValues inner
     FcCast inner _ -> lowerDirectValues inner
     _ -> pure Nothing
+
+-- | Values suitable for a non-strict position. Unlike 'lowerDirectValues', a
+-- lifted variable is returned as its existing pointer without being forced or
+-- wrapped in another thunk.
+lowerLazyDirectValues :: FcExpr -> LowerM (Maybe [GrinValue])
+lowerLazyDirectValues expr =
+  case expr of
+    FcVar var -> do
+      codeInfo <- lookupCodeInfo var
+      case codeInfo of
+        Just info -> pure (Just [knownFunctionValue info 0 []])
+        Nothing -> do
+          constructorArity <- lookupConstructorArity var
+          primitiveArity <- lookupPrimitiveArity var
+          case (constructorArity, primitiveArity) of
+            (Just arity, _)
+              | arity > 0 ->
+                  pure (Just [GrinNodeValue (GrinNode (GrinConstructor (varName var)) [])])
+            (_, Just arity)
+              | arity > 0 ->
+                  pure (Just [GrinNodeValue (GrinNode (GrinPrimitive (varName var) arity) [])])
+            _ -> Just . map GrinVarValue <$> lookupRuntimeVars var
+    FcLit literal -> pure (Just [GrinLitValue (lowerLiteral literal)])
+    FcTyApp inner _ -> lowerLazyDirectValues inner
+    FcCast inner _ -> lowerLazyDirectValues inner
+    _ -> pure Nothing
+
+lookupRuntimeVars :: Var -> LowerM [GrinVar]
+lookupRuntimeVars var = do
+  let runtimeReps = runtimeRepComponents (typeRuntimeRep (varType var))
+  if null runtimeReps
+    then pure []
+    else do
+      global <- isGlobalVar var
+      if global
+        then case runtimeReps of
+          [_] -> do
+            noteExternalGlobalReference var
+            pure [lowerGlobalVar var]
+          _ -> error "GRIN lowering found a global with a multi-value runtime representation"
+        else lookupLocalVars var
+
+lookupRuntimeVar :: Var -> LowerM GrinVar
+lookupRuntimeVar var =
+  lookupRuntimeVars var >>= \case
+    [runtimeVar] -> pure runtimeVar
+    _ -> error "GRIN lowering expected one lifted runtime variable"
+
+noteExternalGlobalReference :: Var -> LowerM ()
+noteExternalGlobalReference var = do
+  localGlobalNames <- gets lowerLocalGlobalNames
+  if varName var `Set.member` localGlobalNames
+    then pure ()
+    else modify' $ \state ->
+      state
+        { lowerReferencedExternalGlobalNames =
+            Set.insert (varName var) (lowerReferencedExternalGlobalNames state)
+        }
+
+lookupAliasVars :: FcExpr -> LowerM (Maybe [GrinVar])
+lookupAliasVars expr =
+  case expr of
+    FcVar var -> do
+      codeInfo <- lookupCodeInfo var
+      case codeInfo of
+        Just _ -> pure Nothing
+        Nothing -> Just <$> lookupRuntimeVars var
+    FcTyApp inner _ -> lookupAliasVars inner
+    FcCast inner _ -> lookupAliasVars inner
+    _ -> pure Nothing
+
+lookupCodeInfo :: Var -> LowerM (Maybe GrinCodeInfo)
+lookupCodeInfo var = do
+  locals <- gets lowerLocalVars
+  codeInfos <- gets lowerCodeInfos
+  localCodeNames <- gets lowerLocalCodeNames
+  if varKey var `Map.member` locals
+    then pure Nothing
+    else case Map.lookup (varName var) codeInfos of
+      Nothing -> pure Nothing
+      Just info -> do
+        if varName var `Set.member` localCodeNames
+          then pure ()
+          else modify' $ \state ->
+            state
+              { lowerReferencedExternalCodeNames =
+                  Set.insert (varName var) (lowerReferencedExternalCodeNames state)
+              }
+        pure (Just info)
+
+lookupConstructorArity :: Var -> LowerM (Maybe Int)
+lookupConstructorArity var = do
+  locals <- gets lowerLocalVars
+  constructorArities <- gets lowerConstructorArities
+  pure
+    ( if varKey var `Map.member` locals
+        then Nothing
+        else Map.lookup (varName var) constructorArities
+    )
+
+lookupPrimitiveArity :: Var -> LowerM (Maybe Int)
+lookupPrimitiveArity var = do
+  locals <- gets lowerLocalVars
+  primitiveArities <- gets lowerPrimitiveArities
+  pure
+    ( if varKey var `Map.member` locals
+        then Nothing
+        else Map.lookup (varName var) primitiveArities
+    )
+
+knownSaturatedApplication :: FcExpr -> LowerM (Maybe (GrinCodeInfo, [FcExpr]))
+knownSaturatedApplication expr =
+  case collectApplications expr of
+    (FcVar var, arguments) -> do
+      codeInfo <- lookupCodeInfo var
+      pure $ do
+        info <- codeInfo
+        if length arguments == length (grinCodeParameterLayouts info)
+          then Just (info, arguments)
+          else Nothing
+    _ -> pure Nothing
+
+isWhnfExpr :: FcExpr -> LowerM Bool
+isWhnfExpr expr =
+  case expr of
+    FcLam {} -> pure True
+    FcTyLam _ body -> isWhnfExpr body
+    FcCast inner _ -> isWhnfExpr inner
+    FcLit literal -> pure (isLiftedRuntimeRep (literalRuntimeRep literal))
+    FcVar var -> do
+      codeInfo <- lookupCodeInfo var
+      primitiveArity <- lookupPrimitiveArity var
+      constructorArity <- lookupConstructorArity var
+      pure
+        ( case codeInfo of
+            Just _ -> True
+            Nothing -> maybe False (> 0) primitiveArity || maybe False (> 0) constructorArity
+        )
+    FcApp {} -> do
+      constructorArities <- gets lowerConstructorArities
+      localVars <- gets lowerLocalVars
+      case constructorApplication constructorArities (Map.keysSet localVars) expr of
+        Just _ -> pure True
+        Nothing ->
+          case collectApplications expr of
+            (FcVar var, arguments) -> do
+              codeInfo <- lookupCodeInfo var
+              pure $ case codeInfo of
+                Just info -> length arguments < length (grinCodeParameterLayouts info)
+                Nothing -> False
+            _ -> pure False
+    _ -> pure False
 
 isWhnfGlobalVar :: Var -> LowerM Bool
 isWhnfGlobalVar var = do
@@ -755,9 +1170,13 @@ programGlobalNames program = concatMap topGlobalNames (fcTopBinds program)
       case topBind of
         FcData _ _ constructors -> map fst constructors
         FcNewtype {} -> []
-        FcPrimitive var _ -> [varName var]
+        FcPrimitive {} -> []
         FcForeignImport {} -> []
-        FcTopBind bind -> map (varName . fst) (topBindings bind)
+        FcTopBind bind ->
+          [ varName var
+          | (var, expr) <- topBindings bind,
+            not (isDirectFunction expr)
+          ]
     topBindings bind =
       case bind of
         FcNonRec var expr -> [(var, expr)]
@@ -773,21 +1192,78 @@ programConstructors program =
 programWhnfGlobalNames :: FcProgram -> [Text]
 programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds program)
   where
+    constructorArities = Map.fromList (builtinConstructors <> programConstructors program)
     topWhnfGlobalNames topBind =
       case topBind of
         FcData _ _ constructors -> map fst constructors
         FcNewtype {} -> []
-        FcPrimitive var _ -> [varName var]
+        FcPrimitive {} -> []
         FcForeignImport {} -> []
         FcTopBind bind ->
           [ varName var
           | (var, expr) <- topBindings bind,
-            isDirectFunction expr
+            isStaticWhnf constructorArities expr
           ]
     topBindings bind =
       case bind of
         FcNonRec var expr -> [(var, expr)]
         FcRec bindings -> bindings
+
+programCodeInfos :: FcProgram -> [(Text, GrinCodeInfo)]
+programCodeInfos program =
+  [ (varName var, codeInfoFor var expr)
+  | FcTopBind bind <- fcTopBinds program,
+    (var, expr) <- topBindings bind,
+    isDirectFunction expr
+  ]
+  where
+    topBindings bind =
+      case bind of
+        FcNonRec var expr -> [(var, expr)]
+        FcRec bindings -> bindings
+
+codeInfoFor :: Var -> FcExpr -> GrinCodeInfo
+codeInfoFor var expr =
+  GrinCodeInfo
+    { grinCodeSourceName = varName var,
+      grinCodeFunctionName = topFunctionName var,
+      grinCodeParameterLayouts =
+        [ runtimeRepComponents (typeRuntimeRep (varType binder))
+        | binder <- binders
+        ],
+      grinCodeResultRep = exprRuntimeRep body
+    }
+  where
+    (binders, body) = collectLeadingLambdas expr
+
+topFunctionName :: Var -> FunctionName
+topFunctionName var = FunctionName ("$entry$" <> varName var)
+
+collectLeadingLambdas :: FcExpr -> ([Var], FcExpr)
+collectLeadingLambdas expr =
+  case expr of
+    FcLam binder body ->
+      let (binders, result) = collectLeadingLambdas body
+       in (binder : binders, result)
+    FcTyLam _ body -> collectLeadingLambdas body
+    FcCast inner _ -> collectLeadingLambdas inner
+    _ -> ([], expr)
+
+isStaticWhnf :: Map Text Int -> FcExpr -> Bool
+isStaticWhnf constructorArities expr =
+  case constructorApplication constructorArities Set.empty expr of
+    Just (_, arguments) -> all isStaticArgument arguments
+    Nothing -> False
+  where
+    isStaticArgument argument =
+      case argument of
+        FcLit {} -> True
+        FcVar var ->
+          null (runtimeRepComponents (typeRuntimeRep (varType var)))
+            || Map.lookup (varName var) constructorArities == Just 0
+        FcTyApp inner _ -> isStaticArgument inner
+        FcCast inner _ -> isStaticArgument inner
+        _ -> False
 
 topVars :: FcTopBind -> [Var]
 topVars topBind =

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -17,10 +17,21 @@ renderProgram program =
     ( map renderConstructor (grinConstructors program)
         <> map renderPrimitive (grinPrimitives program)
         <> map renderForeign (grinForeignCalls program)
+        <> map (("external global " <>) . T.unpack) (grinExternalGlobals program)
+        <> map renderExternalFunction (grinExternalFunctions program)
         <> map renderGlobal (grinWhnfGlobals program)
         <> map renderCaf (grinCafs program)
         <> map renderFunction (grinFunctions program)
     )
+
+renderExternalFunction :: GrinCodeInfo -> String
+renderExternalFunction info =
+  "external "
+    <> T.unpack (grinCodeSourceName info)
+    <> "/"
+    <> show (length (grinCodeParameterLayouts info))
+    <> " = "
+    <> T.unpack (unFunctionName (grinCodeFunctionName info))
 
 renderConstructor :: (T.Text, [RuntimeRep]) -> String
 renderConstructor (name, fieldReps) =
@@ -91,6 +102,20 @@ renderExprIndented indentation expr =
       indent indentation <> "update " <> renderValue pointer <> " " <> renderValue value
     GrinEval runtimeRep value ->
       indent indentation <> "eval @" <> show runtimeRep <> " " <> renderValue value
+    GrinCall runtimeRep functionName arguments ->
+      indent indentation
+        <> "call @"
+        <> show runtimeRep
+        <> " "
+        <> T.unpack (unFunctionName functionName)
+        <> renderValues arguments
+    GrinPrimitiveCall runtimeRep name arguments ->
+      indent indentation
+        <> "primitive-call @"
+        <> show runtimeRep
+        <> " "
+        <> T.unpack name
+        <> renderValues arguments
     GrinApply runtimeRep function arguments ->
       indent indentation
         <> "apply @"

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -7,6 +7,7 @@
 -- nodes and the explicit 'GrinEval' and 'GrinApply' operations.
 module Aihc.Grin.Syntax
   ( GrinProgram (..),
+    GrinCodeInfo (..),
     GrinFunction (..),
     FunctionName (..),
     GrinVar (..),
@@ -39,6 +40,11 @@ data GrinProgram = GrinProgram
   { grinConstructors :: ![(Text, [RuntimeRep])],
     grinPrimitives :: ![(GrinVar, Int)],
     grinForeignCalls :: ![GrinForeignCall],
+    -- | Global slots supplied by dependency units and referenced by this unit.
+    grinExternalGlobals :: ![Text],
+    -- | Code entries supplied by other compilation units. Unlike runtime
+    -- globals, these names never occupy global-table slots.
+    grinExternalFunctions :: ![GrinCodeInfo],
     -- | Top-level values that are already in weak-head normal form. These are
     -- initialized directly rather than represented by updateable CAF cells.
     grinWhnfGlobals :: ![(GrinVar, GrinNode)],
@@ -47,10 +53,23 @@ data GrinProgram = GrinProgram
   }
   deriving (Eq, Show, Read)
 
+-- | Runtime calling information exported for a top-level code binding.
+-- Parameter layouts retain source-argument boundaries because a Core term
+-- argument such as @State# RealWorld@ may contribute no runtime values.
+data GrinCodeInfo = GrinCodeInfo
+  { grinCodeSourceName :: !Text,
+    grinCodeFunctionName :: !FunctionName,
+    grinCodeParameterLayouts :: ![[RuntimeRep]],
+    grinCodeResultRep :: !RuntimeRep
+  }
+  deriving (Eq, Show, Read)
+
 -- | A first-order code definition. Closures and thunks refer to functions by
 -- name and carry their environment as node fields.
 data GrinFunction = GrinFunction
   { grinFunctionName :: !FunctionName,
+    -- | Source-level name when this entry is link-visible to other units.
+    grinFunctionLinkName :: !(Maybe Text),
     grinFunctionParameters :: ![GrinVar],
     grinFunctionResultRep :: !RuntimeRep,
     grinFunctionBody :: !GrinExpr
@@ -93,6 +112,10 @@ data GrinExpr
   | GrinFetch !RuntimeRep !GrinValue
   | GrinUpdate !GrinValue !GrinValue
   | GrinEval !RuntimeRep !GrinValue
+  | -- | A saturated call to a statically known code entry.
+    GrinCall !RuntimeRep !FunctionName ![GrinValue]
+  | -- | A saturated call to a statically known primitive entry.
+    GrinPrimitiveCall !RuntimeRep !Text ![GrinValue]
   | GrinApply !RuntimeRep !GrinValue ![GrinValue]
   | GrinCase !GrinValue !GrinVar ![GrinAlt]
   | GrinThrow !GrinValue

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -25,12 +25,11 @@ grinUnitTests :: TestTree
 grinUnitTests =
   testGroup
     "GRIN"
-    [ testCase "FC lowering makes laziness and application explicit" $ do
+    [ testCase "FC lowering passes known WHNF arguments without thunk cells" $ do
         let program = lowerProgram applicationProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "contains an allocated thunk" ("store " `isInfixOf` rendered)
-        assertBool "contains explicit evaluation" ("eval " `isInfixOf` rendered)
+        assertBool "does not allocate a constructor argument thunk" (not ("store " `isInfixOf` rendered))
         assertBool "contains explicit application" ("apply " `isInfixOf` rendered),
       testCase "interpreter implements fetch and update" $ do
         result <- interpretProgramBinding "answer" heapProgram
@@ -68,14 +67,20 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "records IntRep" ("IntRep" `isInfixOf` rendered)
         assertBool "does not allocate an argument thunk" (not ("store (F$grin_thunk" `isInfixOf` rendered)),
-      testCase "FC lowering stores saturated constructor applications directly" $ do
+      testCase "FC lowering calls saturated primitives without global slots" $ do
+        let program = lowerProgram primitiveCallProgram
+            rendered = renderProgram program
+        assertEqual "lint" [] (lintProgram program)
+        assertBool "contains a direct primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered)
+        assertBool "primitive is not global" (not ("global +#" `isInfixOf` rendered)),
+      testCase "FC lowering returns saturated constructor nodes without update cells" $ do
         let program = lowerProgram saturatedConstructorProgram
         assertEqual "lint" [] (lintProgram program)
         case grinFunctions program of
           [function] ->
             assertEqual
               "constructor body"
-              (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
+              (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)])])
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
       testCase "FC lowering emits saturated strict foreign calls" $ do
@@ -100,11 +105,36 @@ grinUnitTests =
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
         assertBool "CAF reference is evaluated" ("eval @BoxedRep Lifted source%" `isInfixOf` rendered),
+      testCase "FC lowering initializes static constructor values without CAF cells" $ do
+        let program = lowerProgram staticConstructorProgram
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual "static globals" ["source"] (map (grinVarName . fst) (grinWhnfGlobals program))
+        assertEqual "no CAFs" [] (grinCafs program),
       testCase "FC lowering only makes computed function values CAFs" $ do
         let program = lowerProgram functionClassificationProgram
         assertEqual "lint" [] (lintProgram program)
-        assertEqual "direct function globals" ["direct"] (map (grinVarName . fst) (grinWhnfGlobals program))
+        assertEqual "direct functions are not globals" [] (map (grinVarName . fst) (grinWhnfGlobals program))
         assertEqual "computed function CAFs" ["computed"] (map (grinVarName . fst) (grinCafs program)),
+      testCase "FC lowering flattens top-level lambdas into one exported entry" $ do
+        let program = lowerProgram functionClassificationProgram
+            exported = [function | function <- grinFunctions program, grinFunctionLinkName function == Just "direct"]
+        case exported of
+          [function] -> assertEqual "runtime parameters" 2 (length (grinFunctionParameters function))
+          _ -> assertFailure ("expected one exported direct entry, got " <> show (length exported)),
+      testCase "recursive function bindings store closures without thunk wrappers" $ do
+        let program = lowerProgram recursiveFunctionProgram
+            recursiveNodes =
+              [ node
+              | function <- grinFunctions program,
+                GrinStoreRec bindings _ <- [grinFunctionBody function],
+                (_, node) <- bindings
+              ]
+        assertEqual "lint" [] (lintProgram program)
+        case recursiveNodes of
+          [GrinNode GrinClosure {} _] -> pure ()
+          nodes -> assertFailure ("expected one recursive closure node, got " <> show nodes)
+        result <- interpretProgramBinding "answer" program
+        assertEqual "result" (Right "<function>") result,
       testCase "FC dictionaries lower to ordinary constructor nodes and cases" $ do
         let program = lowerProgram dictionaryProgram
             rendered = renderProgram program
@@ -113,7 +143,7 @@ grinUnitTests =
           "dictionary constructor has an ordinary declared layout"
           [("Box", [IntRep]), ("$Dict$Test", [BoxedRep Lifted, BoxedRep Lifted])]
           (grinConstructors program)
-        assertBool ("direct dictionary constructor store:\n" <> rendered) ("store (C$Dict$Test" `isInfixOf` rendered)
+        assertBool ("direct dictionary constructor return:\n" <> rendered) ("return (C$Dict$Test" `isInfixOf` rendered)
         assertBool "ordinary dictionary case" ("$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
         assertBool "no tuple encoding" (not ("C(,)" `isInfixOf` rendered || "C()" `isInfixOf` rendered))
         assertBool "no projection operation" (not ("project " `isInfixOf` rendered))
@@ -126,6 +156,16 @@ grinUnitTests =
                 parameters = concatMap grinFunctionParameters (grinFunctions consumer)
             assertBool "dependency CAF remains global" (all ((/= "source") . grinVarName) parameters)
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
+      testCase "separate FC units call dependency code entries directly" $ do
+        case separateFunctionPrograms of
+          [providerCore, consumerCore] -> do
+            let consumer = lowerProgramWithInterface (extractGrinInterface providerCore) consumerCore
+                rendered = renderProgram consumer
+            assertEqual "lint" [] (lintProgram consumer)
+            assertEqual "external code" ["identity"] (map grinCodeSourceName (grinExternalFunctions consumer))
+            assertBool "direct dependency call" ("call @BoxedRep Lifted $entry$identity" `isInfixOf` rendered)
+            assertBool "dependency function has no global slot" (not ("global identity" `isInfixOf` rendered))
+          programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
       testCase "separate FC units store saturated dependency constructors directly" $ do
         case separateConstructorPrograms of
           [providerCore, consumerCore] -> do
@@ -134,7 +174,7 @@ grinUnitTests =
               [function] ->
                 assertEqual
                   "constructor body"
-                  (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 72 Int32Rep)]))
+                  (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 72 Int32Rep)])])
                   (grinFunctionBody function)
               functions -> assertFailure ("expected one constructor function, got " <> show (length functions))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
@@ -315,7 +355,10 @@ cafReferenceProgram =
       FcTopBind
         ( FcNonRec
             sourceVar
-            (FcApp (FcVar boxConstructorVar) (FcLit (LitInt IntRep 1)))
+            ( FcApp
+                (FcLam computedVar (FcVar computedVar))
+                (FcApp (FcVar boxConstructorVar) (FcLit (LitInt IntRep 1)))
+            )
         ),
       FcTopBind (FcNonRec answerVar (FcVar sourceVar))
     ]
@@ -323,6 +366,54 @@ cafReferenceProgram =
     sourceVar = Var "source" (Unique 20) boxedIntTy
     answerVar = Var "answer" (Unique 21) boxedIntTy
     boxConstructorVar = Var "BoxedInt" (Unique 22) (TcFunTy intTy boxedIntTy)
+    computedVar = Var "computed" (Unique 23) boxedIntTy
+
+staticConstructorProgram :: FcProgram
+staticConstructorProgram =
+  FcProgram
+    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+      FcTopBind
+        ( FcNonRec
+            sourceVar
+            (FcApp (FcVar boxConstructorVar) (FcLit (LitInt IntRep 1)))
+        )
+    ]
+  where
+    sourceVar = Var "source" (Unique 24) boxedIntTy
+    boxConstructorVar = Var "BoxedInt" (Unique 25) (TcFunTy intTy boxedIntTy)
+
+recursiveFunctionProgram :: FcProgram
+recursiveFunctionProgram =
+  FcProgram
+    [ FcTopBind
+        ( FcNonRec
+            answerVar
+            ( FcLet
+                (FcRec [(functionVar, FcLam argumentVar (FcVar argumentVar))])
+                (FcVar functionVar)
+            )
+        )
+    ]
+  where
+    functionTy = TcFunTy boxedIntTy boxedIntTy
+    answerVar = Var "answer" (Unique 26) functionTy
+    functionVar = Var "function" (Unique 27) functionTy
+    argumentVar = Var "argument" (Unique 28) boxedIntTy
+
+primitiveCallProgram :: FcProgram
+primitiveCallProgram =
+  FcProgram
+    [ FcPrimitive addVar 2,
+      FcTopBind
+        ( FcNonRec
+            addOneVar
+            (FcLam argumentVar (FcApp (FcApp (FcVar addVar) (FcVar argumentVar)) (FcLit (LitInt IntRep 1))))
+        )
+    ]
+  where
+    addVar = Var "+#" (Unique 29) (TcFunTy intTy (TcFunTy intTy intTy))
+    addOneVar = Var "addOne" (Unique 30) (TcFunTy intTy intTy)
+    argumentVar = Var "argument" (Unique 31) intTy
 
 functionClassificationProgram :: FcProgram
 functionClassificationProgram =
@@ -410,6 +501,8 @@ heapProgram =
     { grinConstructors = [("Box", [IntRep])],
       grinPrimitives = [],
       grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
       grinWhnfGlobals = [],
       grinCafs =
         [ ( answer,
@@ -419,6 +512,7 @@ heapProgram =
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = functionName,
+              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
@@ -443,6 +537,7 @@ invalidUpdateProgram =
     { grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "answer_code",
+              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
@@ -473,11 +568,14 @@ unliftedHeapProgram runtimeRep =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
       grinWhnfGlobals = [],
       grinCafs = [(GrinVar "bad" 1 (BoxedRep Lifted), GrinNode (GrinThunk unliftedThunkFunction) [GrinLitValue (GrinLitString "capture")])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = unliftedThunkFunction,
+              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [pointer],
               grinFunctionResultRep = runtimeRep,
               grinFunctionBody =
@@ -592,6 +690,20 @@ separatePrograms =
     sourceVar = Var "source" (Unique 30) boxedIntTy
     answerVar = Var "answer" (Unique 31) (TcFunTy boxedIntTy boxedIntTy)
     argumentVar = Var "argument" (Unique 32) boxedIntTy
+
+separateFunctionPrograms :: [FcProgram]
+separateFunctionPrograms =
+  [ FcProgram
+      [ FcTopBind (FcNonRec sourceVar (FcLit (LitString "provider"))),
+        FcTopBind (FcNonRec identityVar (FcLam argumentVar (FcVar argumentVar)))
+      ],
+    FcProgram [FcTopBind (FcNonRec answerVar (FcApp (FcVar identityVar) (FcVar sourceVar)))]
+  ]
+  where
+    sourceVar = Var "source" (Unique 80) boxedIntTy
+    identityVar = Var "identity" (Unique 81) (TcFunTy boxedIntTy boxedIntTy)
+    argumentVar = Var "argument" (Unique 82) boxedIntTy
+    answerVar = Var "answer" (Unique 83) boxedIntTy
 
 separateNewtypePrograms :: [FcProgram]
 separateNewtypePrograms =

--- a/test/Test/Fixtures/grin/boxed-int-field.yaml
+++ b/test/Test/Fixtures/grin/boxed-int-field.yaml
@@ -1,13 +1,10 @@
 expected: |-
   constructor Box/1 [IntRep]
 
-  caf value%1002 :: BoxedRep Lifted = (F$grin_thunk_0)
-
-  $grin_thunk_0 -> BoxedRep Lifted =
-    store (CBox 42)
+  global value%1002 :: BoxedRep Lifted = (CBox 42)
 extensions:
 - MagicHash
-reason: preserves lifted constructor storage and the IntRep field representation
+reason: initializes a static lifted constructor directly and preserves its IntRep field representation
 source: |
   module Test where
   data Box = Box Int#

--- a/test/Test/Fixtures/grin/narrow-integer-fields.yaml
+++ b/test/Test/Fixtures/grin/narrow-integer-fields.yaml
@@ -1,14 +1,11 @@
 expected: |-
   constructor Narrow/2 [Int8Rep, Word16Rep]
 
-  caf value%1002 :: BoxedRep Lifted = (F$grin_thunk_0)
-
-  $grin_thunk_0 -> BoxedRep Lifted =
-    store (CNarrow 123 456)
+  global value%1002 :: BoxedRep Lifted = (CNarrow 123 456)
 extensions:
 - MagicHash
 - ExtendedLiterals
-reason: preserves distinct narrow signed and unsigned runtime representations
+reason: initializes a static constructor directly while preserving distinct narrow signed and unsigned runtime representations
 source: |
   module Test where
   data Narrow = Narrow Int8# Word16#

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -4,7 +4,7 @@ expected: |-
   caf value%1003 :: BoxedRep Lifted = (F$grin_thunk_0)
 
   $grin_thunk_0 -> BoxedRep Lifted =
-    store (CIS 42)
+    return (CIS 42)
 extensions:
   - MagicHash
 reason: erases newtype constructors and casts before producing runtime GRIN

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -8,7 +8,7 @@ expected: |-
       $grin_tuple_1007%1007 :: IntRep, $grin_tuple_1008%1008 :: WordRep <-
         return 1 2
       return $grin_tuple_1007%1007 :: IntRep
-    store (CBox $grin_argument_1006%1006 :: IntRep)
+    return (CBox $grin_argument_1006%1006 :: IntRep)
 extensions:
 - MagicHash
 - UnboxedTuples

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -10,7 +10,7 @@ expected: |-
       $grin_tuple_1009%1009 :: IntRep <-
         return 42
       return $grin_tuple_1009%1009 :: IntRep
-    store (CBox $grin_argument_1008%1008 :: IntRep)
+    return (CBox $grin_argument_1008%1008 :: IntRep)
 extensions:
 - EmptyDataDecls
 - MagicHash


### PR DESCRIPTION
## Summary

- export source arity and runtime-layout metadata through GRIN interfaces, emit stable link-visible code entries, and directly call known local/external functions
- reserve global slots for zero-arity runtime values: functions, positive-arity constructors, and primitives now become direct code or inline closure/node values
- lower saturated primitives and constructors directly, reuse known entries for suspended calls, preserve PAPs, and represent recursive functions as closures instead of thunk wrappers
- avoid redundant stores and evals for aliases, WHNF values, case/apply operands, and static constructor values
- extend lint, interpreter, AArch64 codegen/runtime, cache ABI, golden tests, and end-to-end native coverage for the new representation

## Generated GRIN progress

For `examples/hello-world/Main.hs` without an optimization pass:

| construct | before | after | change |
| --- | ---: | ---: | ---: |
| function globals | 2 | 0 | -2 |
| CAFs | 1 | 1 | unchanged |
| generated functions | 60 | 16 | -44 |
| `store` expressions | 58 | 40 | -18 |
| generic `apply` expressions | 67 | 26 | -41 |
| explicit `eval` expressions | 16 | 0 | -16 |
| direct known `call` expressions | 0 | 13 | +13 |

The remaining generic applies are calls through the method returned by the one-argument `(>>)` dictionary selector; removing those would require arity raising or specialization rather than smarter syntax-directed lowering.

## Validation

- `just fmt`
- `just check`
- clean-cache incremental native Hello World compile and execution