### PR TITLE
fix(grin): make heap allocation explicit

### DIFF
--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -319,7 +319,10 @@ static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
     }
     continuation->payload.update.cell->info = AIHC_CELL_VALUE;
     continuation->payload.update.cell->fields[0] = values[0];
-    aihc_return_values_internal(machine, 1, values);
+    /* A stored constructor is itself represented by a value cell. Continue
+     * forcing the thunk result so the awaiting continuation receives the
+     * constructor node rather than that intermediate heap location. */
+    aihc_eval_value(machine, (AihcValue *)values[0], 1);
     return;
   case AIHC_CONT_APPLY:
     if (count != 1) {

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -339,7 +339,7 @@ parameterCopyLir slots parameters =
 compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
 compileExpr env prefix label expression =
   case expression of
-    GrinReturn values -> do
+    GrinConstant values -> do
       valueSlots <- freshSlots (length values)
       valueLines <-
         fmap concat . forM (zip values valueSlots) $ \(value, slot) -> do
@@ -576,7 +576,6 @@ materializeValue env value =
   case value of
     GrinVarValue var -> loadVariable env var
     GrinLitValue literal -> materializeLiteral literal
-    GrinNodeValue node -> materializeNode env node
 
 materializeLiteral :: GrinLiteral -> Either Arm64Error [Text]
 materializeLiteral literal =
@@ -629,7 +628,6 @@ materializeNode :: ValueEnv -> GrinNode -> Either Arm64Error [Text]
 materializeNode env node = do
   (kind, info, arity) <- nodeHeader env node
   fieldLines <- fmap concat . forM (zip [0 :: Int ..] (grinNodeFields node)) $ \(index, field) -> do
-    unlessAtomic field
     valueLines <- materializeValue env field
     pure $
       valueLines
@@ -643,11 +641,6 @@ materializeNode env node = do
       <> ["  mov x20, x0"]
       <> fieldLines
       <> ["  mov x0, x20"]
-  where
-    unlessAtomic field =
-      case field of
-        GrinNodeValue {} -> Left (Arm64UnsupportedValue "nested node field")
-        _ -> Right ()
 
 nodeHeader :: ValueEnv -> GrinNode -> Either Arm64Error (Int, NodeInfo, Int)
 nodeHeader env node =
@@ -826,7 +819,7 @@ functionLocalSlots function = snd (foldl' assignGroup (0, Map.empty) groups)
 boundVarGroups :: GrinExpr -> [[GrinVar]]
 boundVarGroups expression =
   case expression of
-    GrinReturn _ -> []
+    GrinConstant _ -> []
     GrinBind vars valueExpression body -> vars : boundVarGroups valueExpression <> boundVarGroups body
     GrinStore _ -> []
     GrinStoreRec bindings body -> map (pure . fst) bindings <> boundVarGroups body
@@ -889,7 +882,7 @@ programRuntimeReps program =
 exprRuntimeReps :: GrinExpr -> [RuntimeRep]
 exprRuntimeReps expression =
   case expression of
-    GrinReturn values -> concatMap valueRuntimeReps values
+    GrinConstant values -> concatMap valueRuntimeReps values
     GrinBind vars valueExpression body ->
       map grinVarRuntimeRep vars <> exprRuntimeReps valueExpression <> exprRuntimeReps body
     GrinStore node -> nodeRuntimeReps node
@@ -920,11 +913,7 @@ exprRuntimeReps expression =
         <> exprRuntimeReps (grinAltRhs alternative)
 
 valueRuntimeReps :: GrinValue -> [RuntimeRep]
-valueRuntimeReps value =
-  grinValueRuntimeRep value
-    : case value of
-      GrinNodeValue node -> nodeRuntimeReps node
-      _ -> []
+valueRuntimeReps value = [grinValueRuntimeRep value]
 
 nodeRuntimeReps :: GrinNode -> [RuntimeRep]
 nodeRuntimeReps node = concatMap valueRuntimeReps (grinNodeFields node)

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -118,7 +118,7 @@ tests =
                           grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int8Rep,
-                          grinFunctionBody = GrinReturn [GrinLitValue (GrinLitInt Int8Rep 255)]
+                          grinFunctionBody = GrinConstant [GrinLitValue (GrinLitInt Int8Rep 255)]
                         }
                     ]
                 }
@@ -143,7 +143,7 @@ tests =
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [TupleRep [], IntRep, WordRep],
                           grinFunctionBody =
-                            GrinReturn
+                            GrinConstant
                               [ GrinLitValue (GrinLitInt IntRep 1),
                                 GrinLitValue (GrinLitInt WordRep 2)
                               ]

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -79,7 +79,7 @@ transformFunction function = do
 transformExpr :: FunctionName -> Set GrinVar -> RuntimeRep -> GrinExpr -> CpsM GrinExpr
 transformExpr parent bound resultRep expression =
   case expression of
-    GrinReturn {} -> pure expression
+    GrinConstant {} -> pure expression
     GrinBind resultVars valueExpression body -> do
       transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
       transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
@@ -172,7 +172,7 @@ varsRuntimeRep vars =
 freeExprVars :: GrinExpr -> Set GrinVar
 freeExprVars expression =
   case expression of
-    GrinReturn values -> foldMap freeValueVars values
+    GrinConstant values -> foldMap freeValueVars values
     GrinBind vars valueExpression body ->
       freeExprVars valueExpression
         <> (freeExprVars body `Set.difference` Set.fromList vars)
@@ -204,7 +204,6 @@ freeValueVars value =
   case value of
     GrinVarValue var -> Set.singleton var
     GrinLitValue {} -> Set.empty
-    GrinNodeValue node -> freeNodeVars node
 
 freeNodeVars :: GrinNode -> Set GrinVar
 freeNodeVars = foldMap freeValueVars . grinNodeFields
@@ -227,7 +226,7 @@ maximumProgramVarUnique program =
 exprUniques :: GrinExpr -> [Int]
 exprUniques expression =
   case expression of
-    GrinReturn values -> concatMap valueUniques values
+    GrinConstant values -> concatMap valueUniques values
     GrinBind vars valueExpression body ->
       map grinVarUnique vars <> exprUniques valueExpression <> exprUniques body
     GrinStore node -> nodeUniques node
@@ -258,7 +257,6 @@ valueUniques value =
   case value of
     GrinVarValue var -> [grinVarUnique var]
     GrinLitValue {} -> []
-    GrinNodeValue node -> nodeUniques node
 
 nodeUniques :: GrinNode -> [Int]
 nodeUniques = concatMap valueUniques . grinNodeFields

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -171,12 +171,11 @@ initialMachine program =
             Just runtimeValue -> runtimeValue
             Nothing -> error ("GRIN interpreter found an unbound static global " <> T.unpack (grinVarName var))
         GrinLitValue literal -> RuntimeLit literal
-        GrinNodeValue node -> staticNode node
 
 evalExpr :: Env -> GrinExpr -> EvalM [RuntimeValue]
 evalExpr env expr =
   case expr of
-    GrinReturn values -> mapM (materializeValue env) values
+    GrinConstant values -> mapM (materializeValue env) values
     GrinBind vars valueExpr body -> do
       values <- evalExpr env valueExpr
       if length vars == length values
@@ -252,7 +251,6 @@ materializeValue env value =
             Just runtimeValue -> pure runtimeValue
             Nothing -> throwInterpret (InterpretUnboundVariable var)
     GrinLitValue literal -> pure (RuntimeLit literal)
-    GrinNodeValue node -> materializeNode env node
 
 materializeNode :: Env -> GrinNode -> EvalM RuntimeValue
 materializeNode env node =

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -123,7 +123,7 @@ lintFunction env function =
 lintExpr :: LintEnv -> Set GrinVar -> GrinExpr -> [GrinLintError]
 lintExpr env bound expr =
   case expr of
-    GrinReturn values -> concatMap (lintValue env bound) values
+    GrinConstant values -> concatMap (lintValue env bound) values
     GrinBind vars valueExpr body ->
       bindRepresentationErrors vars valueExpr
         <> lintExpr env bound valueExpr
@@ -207,7 +207,6 @@ lintValue env bound value =
       | grinVarName var `Set.member` lintGlobalNames env -> []
       | otherwise -> [GrinLintUnboundVariable var]
     GrinLitValue _ -> []
-    GrinNodeValue node -> lintNode env bound node
 
 lintNode :: LintEnv -> Set GrinVar -> GrinNode -> [GrinLintError]
 lintNode env bound node =
@@ -261,7 +260,7 @@ duplicates = go Set.empty Set.empty
 exprRuntimeReps :: GrinExpr -> Maybe [RuntimeRep]
 exprRuntimeReps expr =
   case expr of
-    GrinReturn values -> Just (map grinValueRuntimeRep values)
+    GrinConstant values -> Just (map grinValueRuntimeRep values)
     GrinBind _ _ body -> exprRuntimeReps body
     GrinStore {} -> Just [liftedRuntimeRep]
     GrinStoreRec _ body -> exprRuntimeReps body

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -333,12 +333,7 @@ lowerKnownApplication originalExpr info arguments =
         case resultVars of
           [resultVar] -> do
             rest <- lowerRemainingApplications saturatedExpr (GrinVarValue resultVar) extraArguments
-            pure
-              ( GrinBind
-                  resultVars
-                  (GrinCall saturatedRep (grinCodeFunctionName info) values)
-                  rest
-              )
+            pure (bindExpr resultVars (GrinCall saturatedRep (grinCodeFunctionName info) values) rest)
           _ -> error "GRIN lowering expected an overapplied function call to return one function value"
   where
     suppliedArity = length arguments
@@ -363,12 +358,7 @@ lowerPrimitiveApplication originalExpr name arity arguments =
         case resultVars of
           [resultVar] -> do
             rest <- lowerRemainingApplications saturatedExpr (GrinVarValue resultVar) extraArguments
-            pure
-              ( GrinBind
-                  resultVars
-                  (GrinPrimitiveCall saturatedRep name values)
-                  rest
-              )
+            pure (bindExpr resultVars (GrinPrimitiveCall saturatedRep name values) rest)
           _ -> error "GRIN lowering expected an overapplied primitive to return one function value"
   where
     suppliedArity = length arguments
@@ -398,7 +388,7 @@ lowerRemainingApplications functionExpr functionValue arguments =
             case resultVars of
               [resultVar] -> do
                 body <- lowerRemainingApplications appliedExpr (GrinVarValue resultVar) rest
-                pure (GrinBind resultVars (GrinApply resultRep functionValue argumentValues) body)
+                pure (bindExpr resultVars (GrinApply resultRep functionValue argumentValues) body)
               _ -> error "GRIN lowering expected an intermediate application to return one function value"
 
 lowerUnknownApplication :: FcExpr -> LowerM GrinExpr
@@ -427,7 +417,7 @@ lowerCase scrutinee binder alternatives =
           ((binder, []) : [(fieldBinder, []) | fieldBinder <- altBinders alternative])
           (lowerExpr (altRhs alternative))
       scrutineeExpr <- lowerExpr scrutinee
-      pure (GrinBind [] scrutineeExpr rhs)
+      pure (bindExpr [] scrutineeExpr rhs)
     (_, TupleRep _, [alternative])
       | DataAlt constructor <- altCon alternative,
         isUnboxedTupleConstructor constructor ->
@@ -458,7 +448,7 @@ lowerUnboxedTupleCase scrutinee binder alternative = do
           ((binder, resultVars) : zip fieldBinders fieldGroups)
           (lowerExpr (altRhs alternative))
       scrutineeExpr <- lowerExpr scrutinee
-      pure (GrinBind resultVars scrutineeExpr rhs)
+      pure (bindExpr resultVars scrutineeExpr rhs)
 
 splitWidths :: [Int] -> [value] -> [[value]]
 splitWidths widths values =
@@ -467,6 +457,15 @@ splitWidths widths values =
     width : rest ->
       let (field, remaining) = splitAt width values
        in field : splitWidths rest remaining
+
+-- | Sequence an expression only when its results are used by the body.
+-- Forwarding every bound result unchanged is exactly the value expression.
+bindExpr :: [GrinVar] -> GrinExpr -> GrinExpr -> GrinExpr
+bindExpr vars valueExpr body =
+  case body of
+    GrinConstant values
+      | values == map GrinVarValue vars -> valueExpr
+    _ -> GrinBind vars valueExpr body
 
 lowerLambda :: Var -> FcExpr -> LowerM GrinExpr
 lowerLambda binder body =
@@ -506,16 +505,16 @@ lowerLet bind body =
               if rhsIsWhnf
                 then do
                   loweredRhs <- lowerExpr rhs
-                  pure (GrinBind vars loweredRhs loweredBody)
+                  pure (bindExpr vars loweredRhs loweredBody)
                 else do
                   node <- makeThunk rhs
-                  pure (GrinBind vars (GrinStore node) loweredBody)
+                  pure (bindExpr vars (GrinStore node) loweredBody)
       | otherwise -> do
           (vars, loweredBody) <- withFreshLocalVars [var] $ \groups -> do
             body' <- lowerExpr body
             pure (concat groups, body')
           loweredRhs <- lowerExpr rhs
-          pure (GrinBind vars loweredRhs loweredBody)
+          pure (bindExpr vars loweredRhs loweredBody)
     FcRec bindings -> do
       withFreshLocalVars (map fst bindings) $ \groups -> do
         nodes <-
@@ -607,7 +606,7 @@ lowerStrict hint expr continuation = do
       valueVars <- freshVars hint (exprRuntimeRep expr)
       valueExpr <- lowerExpr expr
       rest <- continuation (map GrinVarValue valueVars)
-      pure (GrinBind valueVars valueExpr rest)
+      pure (bindExpr valueVars valueExpr rest)
 
 -- | Lower an operand for an operation that performs its own forcing. Variables
 -- are passed as their existing lazy pointers; non-atomic computations are
@@ -621,7 +620,7 @@ lowerOperand hint expr continuation = do
       valueVars <- freshVars hint (exprRuntimeRep expr)
       valueExpr <- lowerExpr expr
       rest <- continuation (map GrinVarValue valueVars)
-      pure (GrinBind valueVars valueExpr rest)
+      pure (bindExpr valueVars valueExpr rest)
 
 lowerSingleOperand :: Text -> FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerSingleOperand hint expr continuation =
@@ -641,7 +640,7 @@ lowerDelayed expr continuation = do
     storeDelayedNode node = do
       pointerVar <- freshVar "thunk" liftedRuntimeRep
       rest <- continuation [GrinVarValue pointerVar]
-      pure (GrinBind [pointerVar] (GrinStore node) rest)
+      pure (bindExpr [pointerVar] (GrinStore node) rest)
 
 lowerArgument :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerArgument expr continuation = do

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -247,7 +247,7 @@ lowerExpr expr = do
   case constructorApplication constructorArities (Map.keysSet localVars) expr of
     Just (constructor, arguments) ->
       lowerArgumentMany arguments $ \values ->
-        pure (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor constructor) values)])
+        pure (GrinStore (GrinNode (GrinConstructor constructor) values))
     Nothing ->
       case primitiveApplication primitiveArities (Map.keysSet localVars) expr of
         Just ("raise#", [exception]) ->
@@ -266,7 +266,7 @@ lowerOrdinaryExpr :: FcExpr -> LowerM GrinExpr
 lowerOrdinaryExpr expr =
   case unboxedTupleArguments expr of
     Just arguments ->
-      lowerArgumentMany arguments (pure . GrinReturn)
+      lowerArgumentMany arguments (pure . GrinConstant)
     Nothing -> lowerNonTupleExpr expr
 
 lowerNonTupleExpr :: FcExpr -> LowerM GrinExpr
@@ -276,17 +276,17 @@ lowerNonTupleExpr expr =
       do
         codeInfo <- lookupCodeInfo var
         case codeInfo of
-          Just info -> pure (GrinReturn [knownFunctionValue info 0 []])
+          Just info -> pure (GrinStore (knownFunctionNode info 0 []))
           Nothing -> do
             direct <- lowerDirectValues expr
             case direct of
-              Just values -> pure (GrinReturn values)
+              Just values -> pure (GrinConstant values)
               Nothing -> do
                 runtimeVar <- lookupRuntimeVar var
                 let resultRep = typeRuntimeRep (varType var)
                 pure (GrinEval resultRep (GrinVarValue runtimeVar))
     FcLit literal ->
-      pure (GrinReturn [GrinLitValue (lowerLiteral literal)])
+      pure (GrinConstant [GrinLitValue (lowerLiteral literal)])
     FcApp {} ->
       lowerApplication expr
     FcTyApp inner _ ->
@@ -320,7 +320,7 @@ lowerKnownApplication originalExpr info arguments =
   case compare suppliedArity termArity of
     LT ->
       lowerArgumentMany arguments $ \values ->
-        pure (GrinReturn [knownFunctionValue info suppliedArity values])
+        pure (GrinStore (knownFunctionNode info suppliedArity values))
     EQ ->
       lowerArgumentMany arguments $ \values ->
         pure (GrinCall (exprRuntimeRep appliedExpr) (grinCodeFunctionName info) values)
@@ -350,12 +350,7 @@ lowerPrimitiveApplication originalExpr name arity arguments =
   case compare suppliedArity arity of
     LT ->
       lowerArgumentMany arguments $ \values ->
-        pure
-          ( GrinReturn
-              [ GrinNodeValue
-                  (GrinNode (GrinPrimitive name (arity - suppliedArity)) values)
-              ]
-          )
+        pure (GrinStore (GrinNode (GrinPrimitive name (arity - suppliedArity)) values))
     EQ ->
       lowerArgumentMany arguments $ \values ->
         pure (GrinPrimitiveCall (exprRuntimeRep originalExpr) name values)
@@ -391,7 +386,7 @@ dropLastTermApplications count expr
 lowerRemainingApplications :: FcExpr -> GrinValue -> [FcExpr] -> LowerM GrinExpr
 lowerRemainingApplications functionExpr functionValue arguments =
   case arguments of
-    [] -> pure (GrinReturn [functionValue])
+    [] -> pure (GrinConstant [functionValue])
     argument : rest -> do
       let appliedExpr = FcApp functionExpr argument
           resultRep = exprRuntimeRep appliedExpr
@@ -415,13 +410,10 @@ lowerUnknownApplication expr =
           pure (GrinApply (applicationResultRep function) functionValue argumentValues)
     _ -> error "GRIN lowering expected an application"
 
-knownFunctionValue :: GrinCodeInfo -> Int -> [GrinValue] -> GrinValue
-knownFunctionValue info suppliedTermArity fields =
-  GrinNodeValue
-    ( GrinNode
-        (GrinClosure (grinCodeFunctionName info) remainingRuntimeArity)
-        fields
-    )
+knownFunctionNode :: GrinCodeInfo -> Int -> [GrinValue] -> GrinNode
+knownFunctionNode info suppliedTermArity =
+  GrinNode
+    (GrinClosure (grinCodeFunctionName info) remainingRuntimeArity)
   where
     remainingRuntimeArity =
       length (concat (drop suppliedTermArity (grinCodeParameterLayouts info)))
@@ -478,7 +470,7 @@ splitWidths widths values =
 
 lowerLambda :: Var -> FcExpr -> LowerM GrinExpr
 lowerLambda binder body =
-  GrinReturn . pure . GrinNodeValue <$> makeClosureNode (FcLam binder body)
+  GrinStore <$> makeClosureNode (FcLam binder body)
 
 makeClosureNode :: FcExpr -> LowerM GrinNode
 makeClosureNode expr = do
@@ -655,7 +647,7 @@ lowerArgument :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerArgument expr continuation = do
   direct <- lowerLazyDirectValues expr
   case direct of
-    Just values -> atomizeNodeValues values continuation
+    Just values -> continuation values
     Nothing -> do
       whnf <- isWhnfExpr expr
       if whnf
@@ -664,17 +656,6 @@ lowerArgument expr continuation = do
           if exprRuntimeRep expr == liftedRuntimeRep
             then lowerDelayed expr continuation
             else lowerStrict "argument" expr continuation
-
-atomizeNodeValues :: [GrinValue] -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
-atomizeNodeValues values continuation
-  | any isNodeValue values = do
-      vars <- mapM (freshVar "value" . grinValueRuntimeRep) values
-      rest <- continuation (map GrinVarValue vars)
-      pure (GrinBind vars (GrinReturn values) rest)
-  | otherwise = continuation values
-  where
-    isNodeValue GrinNodeValue {} = True
-    isNodeValue _ = False
 
 lowerSingleArgument :: FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerSingleArgument expr continuation =
@@ -828,10 +809,9 @@ isGlobalVar var = do
         && (varName var `Set.member` globalNames || isUnboxedTupleConstructor (varName var))
     )
 
--- | Values that are already in runtime normal form can be embedded directly
--- in the surrounding GRIN operation. Constructors and primitives with positive
--- arity are node literals rather than allocated globals. Unboxed locals and
--- literals are direct machine values as well.
+-- | Values that can be embedded directly in a non-allocating GRIN operation.
+-- Dynamic constructors, closures, and primitives are deliberately excluded:
+-- they must be introduced by 'GrinStore'.
 lowerDirectValues :: FcExpr -> LowerM (Maybe [GrinValue])
 lowerDirectValues expr =
   case expr of
@@ -844,11 +824,9 @@ lowerDirectValues expr =
       case (constructorArity, primitiveArity) of
         _ | null (runtimeRepComponents runtimeRep) -> pure (Just [])
         (Just arity, _)
-          | arity > 0 ->
-              pure (Just [GrinNodeValue (GrinNode (GrinConstructor (varName var)) [])])
+          | arity > 0 -> pure Nothing
         (_, Just arity)
-          | arity > 0 ->
-              pure (Just [GrinNodeValue (GrinNode (GrinPrimitive (varName var) arity) [])])
+          | arity > 0 -> pure Nothing
         _
           | isWhnfGlobal -> do
               noteExternalGlobalReference var
@@ -870,17 +848,15 @@ lowerLazyDirectValues expr =
     FcVar var -> do
       codeInfo <- lookupCodeInfo var
       case codeInfo of
-        Just info -> pure (Just [knownFunctionValue info 0 []])
+        Just _ -> pure Nothing
         Nothing -> do
           constructorArity <- lookupConstructorArity var
           primitiveArity <- lookupPrimitiveArity var
           case (constructorArity, primitiveArity) of
             (Just arity, _)
-              | arity > 0 ->
-                  pure (Just [GrinNodeValue (GrinNode (GrinConstructor (varName var)) [])])
+              | arity > 0 -> pure Nothing
             (_, Just arity)
-              | arity > 0 ->
-                  pure (Just [GrinNodeValue (GrinNode (GrinPrimitive (varName var) arity) [])])
+              | arity > 0 -> pure Nothing
             _ -> Just . map GrinVarValue <$> lookupRuntimeVars var
     FcLit literal -> pure (Just [GrinLitValue (lowerLiteral literal)])
     FcTyApp inner _ -> lowerLazyDirectValues inner

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -77,7 +77,7 @@ renderExpr = renderExprIndented 0
 renderExprIndented :: Int -> GrinExpr -> String
 renderExprIndented indentation expr =
   case expr of
-    GrinReturn values -> indent indentation <> "return" <> renderValues values
+    GrinConstant values -> indent indentation <> "constant" <> renderValues values
     GrinBind vars valueExpr body ->
       indent indentation
         <> renderBinders vars
@@ -174,7 +174,6 @@ renderValue value =
   case value of
     GrinVarValue var -> renderVar var
     GrinLitValue literal -> renderLiteral literal
-    GrinNodeValue node -> renderNode node
 
 renderNode :: GrinNode -> String
 renderNode node =

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -101,11 +101,13 @@ instance Ord GrinVar where
       (grinVarName left, grinVarUnique left)
       (grinVarName right, grinVarUnique right)
 
--- | Strict expressions return zero or more register values. 'GrinBind' names
--- those values for the following expression. In particular, an unboxed tuple
--- is represented by its flattened components, never by a heap node.
+-- | Strict expressions produce zero or more register values. 'GrinBind' names
+-- those values for the following expression. 'GrinConstant' can only forward
+-- atomic variables and literals; every dynamic node enters the heap explicitly
+-- through 'GrinStore' or 'GrinStoreRec'. In particular, an unboxed tuple is
+-- represented by its flattened components, never by a heap node.
 data GrinExpr
-  = GrinReturn ![GrinValue]
+  = GrinConstant ![GrinValue]
   | GrinBind ![GrinVar] !GrinExpr !GrinExpr
   | GrinStore !GrinNode
   | GrinStoreRec ![(GrinVar, GrinNode)] !GrinExpr
@@ -128,7 +130,6 @@ data GrinExpr
 data GrinValue
   = GrinVarValue !GrinVar
   | GrinLitValue !GrinLiteral
-  | GrinNodeValue !GrinNode
   deriving (Eq, Show, Read)
 
 data GrinNode = GrinNode
@@ -174,7 +175,6 @@ grinValueRuntimeRep value =
         GrinLitInt runtimeRep _ -> runtimeRep
         GrinLitChar runtimeRep _ -> runtimeRep
         GrinLitString {} -> liftedRuntimeRep
-    GrinNodeValue {} -> liftedRuntimeRep
 
 isLiftedRuntimeRep :: RuntimeRep -> Bool
 isLiftedRuntimeRep runtimeRep = runtimeRep == liftedRuntimeRep

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -29,7 +29,7 @@ grinUnitTests =
         let program = lowerProgram applicationProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "does not allocate a constructor argument thunk" (not ("store " `isInfixOf` rendered))
+        assertBool "does not allocate a constructor argument thunk" (not ("store (F$grin_thunk" `isInfixOf` rendered))
         assertBool "contains explicit application" ("apply " `isInfixOf` rendered),
       testCase "interpreter implements fetch and update" $ do
         result <- interpretProgramBinding "answer" heapProgram
@@ -95,14 +95,14 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "contains a direct primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered)
         assertBool "primitive is not global" (not ("global +#" `isInfixOf` rendered)),
-      testCase "FC lowering returns saturated constructor nodes without update cells" $ do
+      testCase "FC lowering stores saturated constructor nodes" $ do
         let program = lowerProgram saturatedConstructorProgram
         assertEqual "lint" [] (lintProgram program)
         case grinFunctions program of
           [function] ->
             assertEqual
               "constructor body"
-              (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)])])
+              (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
       testCase "FC lowering emits saturated strict foreign calls" $ do
@@ -120,7 +120,7 @@ grinUnitTests =
         let program = lowerProgram shadowingProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "raw local is returned directly" ("return answer%2 :: IntRep" `isInfixOf` rendered)
+        assertBool "raw local is emitted as a constant" ("constant answer%2 :: IntRep" `isInfixOf` rendered)
         assertBool "raw local is not treated as a global cell" (not ("eval @IntRep answer%2" `isInfixOf` rendered)),
       testCase "FC lowering still evaluates CAF references" $ do
         let program = lowerProgram cafReferenceProgram
@@ -165,7 +165,7 @@ grinUnitTests =
           "dictionary constructor has an ordinary declared layout"
           [("Box", [IntRep]), ("$Dict$Test", [BoxedRep Lifted, BoxedRep Lifted])]
           (grinConstructors program)
-        assertBool ("direct dictionary constructor return:\n" <> rendered) ("return (C$Dict$Test" `isInfixOf` rendered)
+        assertBool ("explicit dictionary constructor store:\n" <> rendered) ("store (C$Dict$Test" `isInfixOf` rendered)
         assertBool "ordinary dictionary case" ("$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
         assertBool "no tuple encoding" (not ("C(,)" `isInfixOf` rendered || "C()" `isInfixOf` rendered))
         assertBool "no projection operation" (not ("project " `isInfixOf` rendered))
@@ -196,7 +196,7 @@ grinUnitTests =
               [function] ->
                 assertEqual
                   "constructor body"
-                  (GrinReturn [GrinNodeValue (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 72 Int32Rep)])])
+                  (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 72 Int32Rep)]))
                   (grinFunctionBody function)
               functions -> assertFailure ("expected one constructor function, got " <> show (length functions))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
@@ -551,8 +551,10 @@ heapProgram =
               grinFunctionBody =
                 GrinBind [pointer] (GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])) $
                   GrinBind [fetched] (GrinFetch (BoxedRep Lifted) (GrinVarValue pointer)) $
-                    GrinBind [updated] (GrinUpdate (GrinVarValue pointer) updatedBox) $
-                      GrinEval (BoxedRep Lifted) (GrinVarValue pointer)
+                    GrinBind [replacementPointer] (GrinStore replacementBox) $
+                      GrinBind [replacement] (GrinFetch (BoxedRep Lifted) (GrinVarValue replacementPointer)) $
+                        GrinBind [updated] (GrinUpdate (GrinVarValue pointer) (GrinVarValue replacement)) $
+                          GrinEval (BoxedRep Lifted) (GrinVarValue pointer)
             }
         ]
     }
@@ -560,8 +562,10 @@ heapProgram =
     answer = GrinVar "answer" 1 (BoxedRep Lifted)
     pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
     fetched = GrinVar "fetched" 3 (BoxedRep Lifted)
-    updated = GrinVar "updated" 4 (BoxedRep Lifted)
-    updatedBox = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)])
+    replacementPointer = GrinVar "replacement_pointer" 4 (BoxedRep Lifted)
+    replacement = GrinVar "replacement" 5 (BoxedRep Lifted)
+    updated = GrinVar "updated" 6 (BoxedRep Lifted)
+    replacementBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)]
     functionName = FunctionName "answer_code"
 
 exceptionBoundaryProgram :: GrinExpr -> GrinProgram
@@ -589,10 +593,10 @@ exceptionBoundaryFunction :: FunctionName
 exceptionBoundaryFunction = FunctionName "exception_boundary"
 
 exceptionAction :: GrinValue
-exceptionAction = GrinNodeValue (GrinNode (GrinConstructor "Action") [])
+exceptionAction = GrinLitValue (GrinLitString "action")
 
 exceptionHandler :: GrinValue
-exceptionHandler = GrinNodeValue (GrinNode (GrinConstructor "Handler") [])
+exceptionHandler = GrinLitValue (GrinLitString "handler")
 
 invalidUpdateProgram :: GrinProgram
 invalidUpdateProgram =
@@ -606,7 +610,7 @@ invalidUpdateProgram =
               grinFunctionBody =
                 GrinBind [pointer] (GrinStore initialBox) $
                   GrinBind [updated] (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt IntRep 2))) $
-                    GrinReturn [updatedBox]
+                    GrinConstant [GrinLitValue (GrinLitInt IntRep 0)]
             }
         ]
     }
@@ -614,7 +618,6 @@ invalidUpdateProgram =
     pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
     updated = GrinVar "updated" 3 IntRep
     initialBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)]
-    updatedBox = GrinNodeValue (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)])
 
 unliftedRuntimeReps :: [RuntimeRep]
 unliftedRuntimeReps =
@@ -645,7 +648,7 @@ unliftedHeapProgram runtimeRep =
                 GrinBind
                   [updated]
                   (GrinUpdate (GrinVarValue pointer) (GrinLitValue (GrinLitInt runtimeRep 0)))
-                  ( GrinReturn
+                  ( GrinConstant
                       [ GrinLitValue (GrinLitInt componentRep 0)
                       | componentRep <- runtimeRepComponents runtimeRep
                       ]

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -105,6 +105,16 @@ grinUnitTests =
               (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
+      testCase "FC lowering returns a tail constructor store directly" $ do
+        let program = lowerProgram tailStoredTupleProgram
+        assertEqual "lint" [] (lintProgram program)
+        case grinFunctions program of
+          [function] ->
+            assertEqual
+              "function body"
+              (GrinStore (GrinNode (GrinConstructor "Box") [GrinVarValue (GrinVar "value" 81 IntRep)]))
+              (grinFunctionBody function)
+          functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
       testCase "FC lowering emits saturated strict foreign calls" $ do
         let program = lowerProgram foreignProgram
             rendered = renderProgram program
@@ -724,6 +734,49 @@ saturatedConstructorProgram =
   where
     int32WrapperVar = Var "wrapInt32" (Unique 60) (TcFunTy int32Ty boxedInt32Ty)
     int32ConstructorVar = Var "I32#" (Unique 61) (TcFunTy int32Ty boxedInt32Ty)
+
+tailStoredTupleProgram :: FcProgram
+tailStoredTupleProgram =
+  FcProgram
+    [ FcData "Box" [] [("Box", [intTy])],
+      FcPrimitive tailStoredStateVar 0,
+      FcTopBind
+        ( FcNonRec
+            tailStoredFunctionVar
+            ( FcLam
+                tailStoredValueVar
+                ( FcApp
+                    (FcApp (FcVar tailStoredTupleConstructorVar) (FcVar tailStoredStateVar))
+                    (FcApp (FcVar tailStoredBoxConstructorVar) (FcVar tailStoredValueVar))
+                )
+            )
+        )
+    ]
+
+tailStoredFunctionVar :: Var
+tailStoredFunctionVar = Var "tailStored" (Unique 80) (TcFunTy intTy tailStoredTupleTy)
+
+tailStoredValueVar :: Var
+tailStoredValueVar = Var "value" (Unique 81) intTy
+
+tailStoredStateVar :: Var
+tailStoredStateVar = Var "realWorld#" (Unique 82) tailStoredStateTy
+
+tailStoredBoxConstructorVar :: Var
+tailStoredBoxConstructorVar = Var "Box" (Unique 83) (TcFunTy intTy tailStoredBoxTy)
+
+tailStoredTupleConstructorVar :: Var
+tailStoredTupleConstructorVar =
+  Var "(#,#)" (Unique 84) (TcFunTy tailStoredStateTy (TcFunTy tailStoredBoxTy tailStoredTupleTy))
+
+tailStoredStateTy :: TcType
+tailStoredStateTy = TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
+
+tailStoredBoxTy :: TcType
+tailStoredBoxTy = TcTyCon (TyCon "Box" 0) []
+
+tailStoredTupleTy :: TcType
+tailStoredTupleTy = TcTyCon (TyCon "(#,#)" 2) [tailStoredStateTy, tailStoredBoxTy]
 
 boxedInt32Ty :: TcType
 boxedInt32Ty = TcTyCon (TyCon "Int32" 0) []

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -4,7 +4,7 @@ expected: |-
   caf value%1003 :: BoxedRep Lifted = (F$grin_thunk_0)
 
   $grin_thunk_0 -> BoxedRep Lifted =
-    return (CIS 42)
+    store (CIS 42)
 extensions:
   - MagicHash
 reason: erases newtype constructors and casts before producing runtime GRIN

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -6,9 +6,9 @@ expected: |-
   $grin_thunk_0 -> BoxedRep Lifted =
     $grin_argument_1006%1006 :: IntRep <-
       $grin_tuple_1007%1007 :: IntRep, $grin_tuple_1008%1008 :: WordRep <-
-        return 1 2
-      return $grin_tuple_1007%1007 :: IntRep
-    return (CBox $grin_argument_1006%1006 :: IntRep)
+        constant 1 2
+      constant $grin_tuple_1007%1007 :: IntRep
+    store (CBox $grin_argument_1006%1006 :: IntRep)
 extensions:
 - MagicHash
 - UnboxedTuples

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -8,9 +8,9 @@ expected: |-
   $grin_thunk_0 -> BoxedRep Lifted =
     $grin_argument_1008%1008 :: IntRep <-
       $grin_tuple_1009%1009 :: IntRep <-
-        return 42
-      return $grin_tuple_1009%1009 :: IntRep
-    return (CBox $grin_argument_1008%1008 :: IntRep)
+        constant 42
+      constant $grin_tuple_1009%1009 :: IntRep
+    store (CBox $grin_argument_1008%1008 :: IntRep)
 extensions:
 - EmptyDataDecls
 - MagicHash

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -7,9 +7,7 @@ expected: |-
 
   $grin_thunk_0 -> BoxedRep Lifted =
     $grin_argument_1008%1008 :: IntRep <-
-      $grin_tuple_1009%1009 :: IntRep <-
-        constant 42
-      constant $grin_tuple_1009%1009 :: IntRep
+      constant 42
     store (CBox $grin_argument_1008%1008 :: IntRep)
 extensions:
 - EmptyDataDecls


### PR DESCRIPTION
## Summary

- replace `GrinReturn` with non-allocating `GrinConstant`
- remove `GrinNodeValue` from `GrinValue`, making dynamic nodes representable only through `GrinStore`/`GrinStoreRec`
- lower constructors, closures, partial primitives, and lambdas through explicit stores
- eliminate binds whose body only forwards every bound value unchanged
- keep forcing stored constructor results after native thunk updates

## Root cause

`GrinReturn` accepted inline node values. The ARM64 backend materialized those values with `_aihc_make_node`, so an instruction intended to return existing register values performed an implicit heap allocation. This made the interpreter-level value/location distinction disagree with native execution.

The revised syntax makes that state unrepresentable: `GrinValue` contains only variables and literals, while dynamic nodes enter the heap through explicit store expressions.

## Impact

Generated GRIN now exposes constructor and closure allocation directly. Tail-position stores are emitted directly instead of binding their location only to forward it unchanged with `constant`.

## Validation

- `just fmt`
- `just check`
- all 106 GRIN tests
- native ARM64 HelloWorld execution

## Progress counts

No progress-count change. No fixtures were added or removed; three existing GRIN golden expectations were updated for the new syntax and explicit store behavior.
