### PR TITLE
fix(grin): enforce WHNF function results

### DIFF
--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -23,6 +23,7 @@ data GrinLintError
   | GrinLintUnknownFunction !FunctionName
   | GrinLintUnknownPrimitive !Text
   | GrinLintFunctionArity !FunctionName !Int !Int
+  | GrinLintSaturatedClosure !FunctionName
   | GrinLintThunkResult !FunctionName !RuntimeRep
   | GrinLintRepresentationMismatch !String !RuntimeRep !RuntimeRep
   | GrinLintResultLayout !String ![RuntimeRep] ![RuntimeRep]
@@ -109,6 +110,7 @@ lintCaf env (var, node) =
 lintFunction :: LintEnv -> GrinFunction -> [GrinLintError]
 lintFunction env function =
   resultErrors
+    <> lintFunctionResult env (grinFunctionResultRep function) (grinFunctionBody function)
     <> lintExpr env bound (grinFunctionBody function)
   where
     bound = Set.fromList (grinFunctionParameters function) <> lintGlobalVars env
@@ -119,6 +121,19 @@ lintFunction env function =
               [GrinLintResultLayout "function result" expected actual]
         _ -> []
     expected = runtimeRepComponents (grinFunctionResultRep function)
+
+lintFunctionResult :: LintEnv -> RuntimeRep -> GrinExpr -> [GrinLintError]
+lintFunctionResult env resultRep expr =
+  case expr of
+    GrinBind _ _ body -> lintFunctionResult env resultRep body
+    GrinStore (GrinNode (GrinClosure functionName 0) _) ->
+      [ GrinLintSaturatedClosure functionName
+      | Map.lookup functionName (lintFunctionResults env) == Just resultRep
+      ]
+    GrinStore {} -> []
+    GrinStoreRec _ body -> lintFunctionResult env resultRep body
+    GrinCase _ _ alternatives -> concatMap (lintFunctionResult env resultRep . grinAltRhs) alternatives
+    _ -> []
 
 lintExpr :: LintEnv -> Set GrinVar -> GrinExpr -> [GrinLintError]
 lintExpr env bound expr =

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -276,7 +276,7 @@ lowerNonTupleExpr expr =
       do
         codeInfo <- lookupCodeInfo var
         case codeInfo of
-          Just info -> pure (GrinStore (knownFunctionNode info 0 []))
+          Just info -> pure (GrinStore (knownFunctionNode info (codeRuntimeArity info) []))
           Nothing -> do
             direct <- lowerDirectValues expr
             case direct of
@@ -316,22 +316,24 @@ lowerApplication expr =
     _ -> lowerUnknownApplication expr
 
 lowerKnownApplication :: FcExpr -> GrinCodeInfo -> [FcExpr] -> LowerM GrinExpr
-lowerKnownApplication originalExpr info arguments =
-  case compare suppliedArity termArity of
-    LT ->
-      lowerArgumentMany arguments $ \values ->
-        if remainingRuntimeArity info suppliedArity == 0
-          && grinCodeResultRep info == exprRuntimeRep originalExpr
-          then pure (GrinCall (grinCodeResultRep info) (grinCodeFunctionName info) values)
-          else pure (GrinStore (knownFunctionNode info suppliedArity values))
-    EQ ->
-      lowerArgumentMany arguments $ \values ->
-        pure (GrinCall (exprRuntimeRep appliedExpr) (grinCodeFunctionName info) values)
-    GT -> do
-      let (saturatedArguments, extraArguments) = splitAt termArity arguments
-          saturatedExpr = dropLastTermApplications (suppliedArity - termArity) originalExpr
-          saturatedRep = exprRuntimeRep saturatedExpr
-      lowerArgumentMany saturatedArguments $ \values -> do
+lowerKnownApplication originalExpr info arguments = do
+  let (entryArguments, extraArguments) = splitAt termArity arguments
+  lowerArgumentMany entryArguments $ \values ->
+    case extraArguments of
+      [] ->
+        case compare (length values) runtimeArity of
+          LT -> pure (GrinStore (knownFunctionNode info (runtimeArity - length values) values))
+          EQ
+            | length entryArguments == termArity ->
+                pure (GrinCall (exprRuntimeRep originalExpr) (grinCodeFunctionName info) values)
+            | grinCodeResultRep info == exprRuntimeRep originalExpr ->
+                pure (GrinCall (grinCodeResultRep info) (grinCodeFunctionName info) values)
+            | otherwise ->
+                pure (GrinStore (knownFunctionNode info 0 values))
+          GT -> error "GRIN lowering supplied more runtime arguments than the known function accepts"
+      _ -> do
+        let saturatedExpr = dropLastTermApplications (length extraArguments) originalExpr
+            saturatedRep = exprRuntimeRep saturatedExpr
         resultVars <- freshVars "call" saturatedRep
         case resultVars of
           [resultVar] -> do
@@ -339,9 +341,8 @@ lowerKnownApplication originalExpr info arguments =
             pure (bindExpr resultVars (GrinCall saturatedRep (grinCodeFunctionName info) values) rest)
           _ -> error "GRIN lowering expected an overapplied function call to return one function value"
   where
-    suppliedArity = length arguments
     termArity = length (grinCodeParameterLayouts info)
-    appliedExpr = originalExpr
+    runtimeArity = codeRuntimeArity info
 
 lowerPrimitiveApplication :: FcExpr -> Text -> Int -> [FcExpr] -> LowerM GrinExpr
 lowerPrimitiveApplication originalExpr name arity arguments =
@@ -404,12 +405,15 @@ lowerUnknownApplication expr =
     _ -> error "GRIN lowering expected an application"
 
 knownFunctionNode :: GrinCodeInfo -> Int -> [GrinValue] -> GrinNode
-knownFunctionNode info suppliedTermArity =
+knownFunctionNode info remainingRuntimeArity =
   GrinNode
-    (GrinClosure (grinCodeFunctionName info) (remainingRuntimeArity info suppliedTermArity))
+    (GrinClosure (grinCodeFunctionName info) remainingRuntimeArity)
 
-remainingRuntimeArity :: GrinCodeInfo -> Int -> Int
-remainingRuntimeArity info suppliedTermArity =
+codeRuntimeArity :: GrinCodeInfo -> Int
+codeRuntimeArity = length . concat . grinCodeParameterLayouts
+
+runtimeArityAfterTerms :: GrinCodeInfo -> Int -> Int
+runtimeArityAfterTerms info suppliedTermArity =
   length (concat (drop suppliedTermArity (grinCodeParameterLayouts info)))
 
 lowerCase :: FcExpr -> Var -> [FcAlt] -> LowerM GrinExpr
@@ -993,7 +997,7 @@ knownSaturatedApplication expr =
       pure $ do
         info <- codeInfo
         if length arguments <= length (grinCodeParameterLayouts info)
-          && remainingRuntimeArity info (length arguments) == 0
+          && runtimeArityAfterTerms info (length arguments) == 0
           && isLiftedRuntimeRep (grinCodeResultRep info)
           then Just (info, arguments)
           else Nothing
@@ -1013,7 +1017,7 @@ isWhnfExpr expr =
       pure
         ( case codeInfo of
             Just info ->
-              remainingRuntimeArity info 0 > 0
+              runtimeArityAfterTerms info 0 > 0
                 || grinCodeResultRep info /= exprRuntimeRep expr
             Nothing -> maybe False (> 0) primitiveArity || maybe False (> 0) constructorArity
         )
@@ -1028,7 +1032,7 @@ isWhnfExpr expr =
               codeInfo <- lookupCodeInfo var
               pure $ case codeInfo of
                 Just info ->
-                  remainingRuntimeArity info (length arguments) > 0
+                  runtimeArityAfterTerms info (length arguments) > 0
                     || grinCodeResultRep info /= exprRuntimeRep expr
                 Nothing -> False
             _ -> pure False

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -320,7 +320,10 @@ lowerKnownApplication originalExpr info arguments =
   case compare suppliedArity termArity of
     LT ->
       lowerArgumentMany arguments $ \values ->
-        pure (GrinStore (knownFunctionNode info suppliedArity values))
+        if remainingRuntimeArity info suppliedArity == 0
+          && grinCodeResultRep info == exprRuntimeRep originalExpr
+          then pure (GrinCall (grinCodeResultRep info) (grinCodeFunctionName info) values)
+          else pure (GrinStore (knownFunctionNode info suppliedArity values))
     EQ ->
       lowerArgumentMany arguments $ \values ->
         pure (GrinCall (exprRuntimeRep appliedExpr) (grinCodeFunctionName info) values)
@@ -403,10 +406,11 @@ lowerUnknownApplication expr =
 knownFunctionNode :: GrinCodeInfo -> Int -> [GrinValue] -> GrinNode
 knownFunctionNode info suppliedTermArity =
   GrinNode
-    (GrinClosure (grinCodeFunctionName info) remainingRuntimeArity)
-  where
-    remainingRuntimeArity =
-      length (concat (drop suppliedTermArity (grinCodeParameterLayouts info)))
+    (GrinClosure (grinCodeFunctionName info) (remainingRuntimeArity info suppliedTermArity))
+
+remainingRuntimeArity :: GrinCodeInfo -> Int -> Int
+remainingRuntimeArity info suppliedTermArity =
+  length (concat (drop suppliedTermArity (grinCodeParameterLayouts info)))
 
 lowerCase :: FcExpr -> Var -> [FcAlt] -> LowerM GrinExpr
 lowerCase scrutinee binder alternatives =
@@ -719,8 +723,44 @@ freshFunction kind = do
   pure (FunctionName ("$grin_" <> kind <> "_" <> T.pack (show index)))
 
 emitFunction :: GrinFunction -> LowerM ()
-emitFunction function =
-  modify' $ \state -> state {lowerFunctionsRev = function : lowerFunctionsRev state}
+emitFunction function = do
+  body <- ensureWhnfResult function (grinFunctionBody function)
+  modify' $ \state -> state {lowerFunctionsRev = function {grinFunctionBody = body} : lowerFunctionsRev state}
+
+-- A zero-runtime-argument closure whose entry preserves the result layout is
+-- a saturated computation, not a WHNF. Enter it at function exits while
+-- retaining closures in intermediate positions where they encode delayed
+-- source-level application. If entry changes the layout, the closure remains
+-- a genuine function value despite having no physical arguments.
+ensureWhnfResult :: GrinFunction -> GrinExpr -> LowerM GrinExpr
+ensureWhnfResult owner expr =
+  case expr of
+    GrinBind vars valueExpr body -> GrinBind vars valueExpr <$> ensureWhnfResult owner body
+    GrinStore node@(GrinNode (GrinClosure functionName 0) fields) -> do
+      resultRep <- lookupFunctionResultRep owner functionName
+      if resultRep == grinFunctionResultRep owner
+        then pure (GrinCall resultRep functionName fields)
+        else pure (GrinStore node)
+    GrinStore {} -> pure expr
+    GrinStoreRec bindings body -> GrinStoreRec bindings <$> ensureWhnfResult owner body
+    GrinCase scrutinee binder alternatives ->
+      GrinCase scrutinee binder <$> mapM lowerResultAlt alternatives
+    _ -> pure expr
+  where
+    lowerResultAlt alternative = do
+      rhs <- ensureWhnfResult owner (grinAltRhs alternative)
+      pure alternative {grinAltRhs = rhs}
+
+lookupFunctionResultRep :: GrinFunction -> FunctionName -> LowerM RuntimeRep
+lookupFunctionResultRep owner functionName
+  | functionName == grinFunctionName owner = pure (grinFunctionResultRep owner)
+  | otherwise = do
+      localFunctions <- gets lowerFunctionsRev
+      codeInfos <- gets lowerCodeInfos
+      case [grinFunctionResultRep function | function <- localFunctions, grinFunctionName function == functionName]
+        <> [grinCodeResultRep info | info <- Map.elems codeInfos, grinCodeFunctionName info == functionName] of
+        resultRep : _ -> pure resultRep
+        [] -> error ("GRIN lowering could not find saturated closure target " <> show functionName)
 
 primitiveApplication :: Map Text Int -> Set (Text, Unique) -> FcExpr -> Maybe (Text, [FcExpr])
 primitiveApplication primitiveArities localVars expr =
@@ -952,7 +992,9 @@ knownSaturatedApplication expr =
       codeInfo <- lookupCodeInfo var
       pure $ do
         info <- codeInfo
-        if length arguments == length (grinCodeParameterLayouts info)
+        if length arguments <= length (grinCodeParameterLayouts info)
+          && remainingRuntimeArity info (length arguments) == 0
+          && isLiftedRuntimeRep (grinCodeResultRep info)
           then Just (info, arguments)
           else Nothing
     _ -> pure Nothing
@@ -970,7 +1012,9 @@ isWhnfExpr expr =
       constructorArity <- lookupConstructorArity var
       pure
         ( case codeInfo of
-            Just _ -> True
+            Just info ->
+              remainingRuntimeArity info 0 > 0
+                || grinCodeResultRep info /= exprRuntimeRep expr
             Nothing -> maybe False (> 0) primitiveArity || maybe False (> 0) constructorArity
         )
     FcApp {} -> do
@@ -983,7 +1027,9 @@ isWhnfExpr expr =
             (FcVar var, arguments) -> do
               codeInfo <- lookupCodeInfo var
               pure $ case codeInfo of
-                Just info -> length arguments < length (grinCodeParameterLayouts info)
+                Just info ->
+                  remainingRuntimeArity info (length arguments) > 0
+                    || grinCodeResultRep info /= exprRuntimeRep expr
                 Nothing -> False
             _ -> pure False
     _ -> pure False

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -95,6 +95,36 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "contains a direct primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered)
         assertBool "primitive is not global" (not ("global +#" `isInfixOf` rendered)),
+      testCase "FC lowering calls functions when only zero-width arguments remain" $ do
+        let program = lowerProgram zeroWidthSaturatedApplicationProgram
+            rendered = renderProgram program
+        assertEqual "lint" [] (lintProgram program)
+        assertBool "direct call" ("call @BoxedRep Lifted $entry$zeroWidthTarget" `isInfixOf` rendered)
+        assertBool "no saturated closure" (not ("P$entry$zeroWidthTarget/0" `isInfixOf` rendered)),
+      testCase "lint rejects saturated closure nodes" $ do
+        let target = FunctionName "target"
+            wrapper = FunctionName "wrapper"
+            program =
+              heapProgram
+                { grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = target,
+                          grinFunctionLinkName = Nothing,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = BoxedRep Lifted,
+                          grinFunctionBody = GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])
+                        },
+                      GrinFunction
+                        { grinFunctionName = wrapper,
+                          grinFunctionLinkName = Nothing,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = BoxedRep Lifted,
+                          grinFunctionBody = GrinStore (GrinNode (GrinClosure target 0) [])
+                        }
+                    ]
+                }
+        assertBool "saturated closure" (GrinLintSaturatedClosure target `elem` lintProgram program),
       testCase "FC lowering stores saturated constructor nodes" $ do
         let program = lowerProgram saturatedConstructorProgram
         assertEqual "lint" [] (lintProgram program)
@@ -457,6 +487,28 @@ primitiveCallProgram =
     addVar = Var "+#" (Unique 29) (TcFunTy intTy (TcFunTy intTy intTy))
     addOneVar = Var "addOne" (Unique 30) (TcFunTy intTy intTy)
     argumentVar = Var "argument" (Unique 31) intTy
+
+zeroWidthSaturatedApplicationProgram :: FcProgram
+zeroWidthSaturatedApplicationProgram =
+  FcProgram
+    [ FcTopBind
+        ( FcNonRec
+            targetVar
+            (FcLam targetValueVar (FcLam stateVar (FcVar targetValueVar)))
+        ),
+      FcTopBind
+        ( FcNonRec
+            callerVar
+            (FcLam callerValueVar (FcApp (FcVar targetVar) (FcVar callerValueVar)))
+        )
+    ]
+  where
+    stateTy = TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
+    targetVar = Var "zeroWidthTarget" (Unique 32) (TcFunTy boxedIntTy (TcFunTy stateTy boxedIntTy))
+    callerVar = Var "zeroWidthCaller" (Unique 33) (TcFunTy boxedIntTy (TcFunTy stateTy boxedIntTy))
+    targetValueVar = Var "targetValue" (Unique 34) boxedIntTy
+    stateVar = Var "state" (Unique 35) stateTy
+    callerValueVar = Var "callerValue" (Unique 36) boxedIntTy
 
 functionClassificationProgram :: FcProgram
 functionClassificationProgram =


### PR DESCRIPTION
## Summary

- enter known functions directly when their remaining source binders erase to zero runtime arguments and the result layout is preserved
- normalize representation-preserving saturated closures at every GRIN function exit, including exits through binds, cases, and recursive stores
- lint function results that still return a representation-preserving saturated closure
- preserve zero-width closures that are genuine function values because entering them changes the runtime result layout

## Root cause

GRIN lowering compared source-level term arity when deciding whether to allocate a closure, but `GrinClosure` records runtime arity. A function with only erased binders remaining, such as `State#`, could therefore be emitted as a `/0` closure and returned without being entered, violating the WHNF result invariant.

## Impact

The hello-world continuation now calls the `pureIO` entry directly instead of returning `P$entry$pureIO/0`. Lazy intermediate actions remain delayed, and unboxed state-function results retain their declared layouts.

## Validation

- `just fmt`
- `just check`
- GRIN suite: 108 tests passed

## Progress counts

- GRIN structural unit tests: +2
- README progress counts unchanged (cron-managed)
