### PR TITLE
fix(grin): parenthesize pretty-printed operands

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -888,7 +888,7 @@ test_compileExecutable =
         assertBool "GRIN erases the CInt constructor" (not ("constructor CInt/" `T.isInfixOf` grin))
         assertBool "GRIN does not allocate putchar globally" (not ("global putchar" `T.isInfixOf` grin || "caf putchar" `T.isInfixOf` grin))
         assertBool "GRIN does not allocate char globally" (not ("global char" `T.isInfixOf` grin || "caf char" `T.isInfixOf` grin))
-        assertBool "GRIN uses direct known calls" ("call @BoxedRep Lifted $entry$>>" `T.isInfixOf` grin)
+        assertBool "GRIN uses direct known calls" ("call @(BoxedRep Lifted) $entry$>>" `T.isInfixOf` grin)
         assertBool "GRIN leaves forcing to case and apply" (not ("eval @" `T.isInfixOf` grin))
         assertNativeOutput keptOutput
 

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -6,7 +6,7 @@ module Aihc.Grin.Pretty
 where
 
 import Aihc.Grin.Syntax
-import Aihc.Tc.Types (RuntimeRep)
+import Aihc.Tc.Types (RuntimeRep (..))
 import Data.List (intercalate)
 import Data.Text qualified as T
 
@@ -65,7 +65,7 @@ renderCaf (var, node) =
 renderFunction :: GrinFunction -> String
 renderFunction function =
   T.unpack (unFunctionName (grinFunctionName function))
-    <> concatMap ((" " <>) . renderVar) (grinFunctionParameters function)
+    <> concatMap ((" " <>) . renderVarAtom) (grinFunctionParameters function)
     <> " -> "
     <> show (grinFunctionResultRep function)
     <> " =\n"
@@ -97,29 +97,29 @@ renderExprIndented indentation expr =
         <> "\n"
         <> renderExprIndented indentation body
     GrinFetch runtimeRep pointer ->
-      indent indentation <> "fetch @" <> show runtimeRep <> " " <> renderValue pointer
+      indent indentation <> "fetch @" <> renderRuntimeRepArgument runtimeRep <> " " <> renderValue pointer
     GrinUpdate pointer value ->
       indent indentation <> "update " <> renderValue pointer <> " " <> renderValue value
     GrinEval runtimeRep value ->
-      indent indentation <> "eval @" <> show runtimeRep <> " " <> renderValue value
+      indent indentation <> "eval @" <> renderRuntimeRepArgument runtimeRep <> " " <> renderValue value
     GrinCall runtimeRep functionName arguments ->
       indent indentation
         <> "call @"
-        <> show runtimeRep
+        <> renderRuntimeRepArgument runtimeRep
         <> " "
         <> T.unpack (unFunctionName functionName)
         <> renderValues arguments
     GrinPrimitiveCall runtimeRep name arguments ->
       indent indentation
         <> "primitive-call @"
-        <> show runtimeRep
+        <> renderRuntimeRepArgument runtimeRep
         <> " "
         <> T.unpack name
         <> renderValues arguments
     GrinApply runtimeRep function arguments ->
       indent indentation
         <> "apply @"
-        <> show runtimeRep
+        <> renderRuntimeRepArgument runtimeRep
         <> " "
         <> renderValue function
         <> renderValues arguments
@@ -135,7 +135,7 @@ renderExprIndented indentation expr =
     GrinCatch runtimeRep action handler state ->
       indent indentation
         <> "catch @"
-        <> show runtimeRep
+        <> renderRuntimeRepArgument runtimeRep
         <> " "
         <> unwords (map renderValue [action, handler])
         <> renderValues state
@@ -158,7 +158,7 @@ renderAlt :: Int -> GrinAlt -> String
 renderAlt indentation alt =
   indent indentation
     <> renderAltCon (grinAltCon alt)
-    <> concatMap ((" " <>) . renderVar) (grinAltBinders alt)
+    <> concatMap ((" " <>) . renderVarAtom) (grinAltBinders alt)
     <> " ->\n"
     <> renderExprIndented (indentation + 2) (grinAltRhs alt)
 
@@ -172,7 +172,7 @@ renderAltCon altCon =
 renderValue :: GrinValue -> String
 renderValue value =
   case value of
-    GrinVarValue var -> renderVar var
+    GrinVarValue var -> renderVarAtom var
     GrinLitValue literal -> renderLiteral literal
 
 renderNode :: GrinNode -> String
@@ -205,6 +205,22 @@ renderVar var =
     <> show (grinVarUnique var)
     <> " :: "
     <> show (grinVarRuntimeRep var)
+
+renderVarAtom :: GrinVar -> String
+renderVarAtom var = "(" <> renderVar var <> ")"
+
+renderRuntimeRepArgument :: RuntimeRep -> String
+renderRuntimeRepArgument runtimeRep =
+  case runtimeRep of
+    VecRep {} -> parenthesized
+    TupleRep {} -> parenthesized
+    SumRep {} -> parenthesized
+    BoxedRep {} -> parenthesized
+    RuntimeRepVar {} -> parenthesized
+    RuntimeRepMeta {} -> parenthesized
+    _ -> show runtimeRep
+  where
+    parenthesized = "(" <> show runtimeRep <> ")"
 
 indent :: Int -> String
 indent count = replicate count ' '

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -25,7 +25,37 @@ grinUnitTests :: TestTree
 grinUnitTests =
   testGroup
     "GRIN"
-    [ testCase "FC lowering passes known WHNF arguments without thunk cells" $ do
+    [ testCase "pretty printer parenthesizes compound applications" $ do
+        let first = GrinVar "$grin_tuple_2720" 2720 (BoxedRep Lifted)
+            second = GrinVar "$grin_tuple_2721" 2721 (BoxedRep Lifted)
+            function =
+              GrinFunction
+                { grinFunctionName = FunctionName "$grin_thunk_4",
+                  grinFunctionLinkName = Nothing,
+                  grinFunctionParameters = [first, second],
+                  grinFunctionResultRep = BoxedRep Lifted,
+                  grinFunctionBody = GrinApply (BoxedRep Lifted) (GrinVarValue first) [GrinVarValue second]
+                }
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [],
+                  grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions = [function]
+                }
+        assertEqual
+          "rendered program"
+          ( unlines
+              [ "$grin_thunk_4 ($grin_tuple_2720%2720 :: BoxedRep Lifted) ($grin_tuple_2721%2721 :: BoxedRep Lifted) -> BoxedRep Lifted =",
+                "  apply @(BoxedRep Lifted) ($grin_tuple_2720%2720 :: BoxedRep Lifted) ($grin_tuple_2721%2721 :: BoxedRep Lifted)"
+              ]
+          )
+          (renderProgram program <> "\n"),
+      testCase "FC lowering passes known WHNF arguments without thunk cells" $ do
         let program = lowerProgram applicationProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
@@ -67,7 +97,7 @@ grinUnitTests =
             rendered = renderProgram program
         assertEqual "transformed lint" [] (lintProgram program)
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
-        assertBool "invokes a continuation closure" ("apply @BoxedRep Lifted $cps_continuation" `isInfixOf` rendered)
+        assertBool "invokes a continuation closure" ("apply @(BoxedRep Lifted) ($cps_continuation" `isInfixOf` rendered)
         assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
       testCase "CPS-GRIN preserves evaluation semantics" $ do
         cps <- expectCpsGrin heapProgram
@@ -99,7 +129,7 @@ grinUnitTests =
         let program = lowerProgram zeroWidthSaturatedApplicationProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "direct call" ("call @BoxedRep Lifted $entry$zeroWidthTarget" `isInfixOf` rendered)
+        assertBool "direct call" ("call @(BoxedRep Lifted) $entry$zeroWidthTarget" `isInfixOf` rendered)
         assertBool "no saturated closure" (not ("P$entry$zeroWidthTarget/0" `isInfixOf` rendered)),
       testCase "lint rejects saturated closure nodes" $ do
         let target = FunctionName "target"
@@ -160,13 +190,13 @@ grinUnitTests =
         let program = lowerProgram shadowingProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "raw local is emitted as a constant" ("constant answer%2 :: IntRep" `isInfixOf` rendered)
-        assertBool "raw local is not treated as a global cell" (not ("eval @IntRep answer%2" `isInfixOf` rendered)),
+        assertBool "raw local is emitted as a constant" ("constant (answer%2 :: IntRep)" `isInfixOf` rendered)
+        assertBool "raw local is not treated as a global cell" (not ("eval @IntRep (answer%2" `isInfixOf` rendered)),
       testCase "FC lowering still evaluates CAF references" $ do
         let program = lowerProgram cafReferenceProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "CAF reference is evaluated" ("eval @BoxedRep Lifted source%" `isInfixOf` rendered),
+        assertBool "CAF reference is evaluated" ("eval @(BoxedRep Lifted) (source%" `isInfixOf` rendered),
       testCase "FC lowering initializes static constructor values without CAF cells" $ do
         let program = lowerProgram staticConstructorProgram
         assertEqual "lint" [] (lintProgram program)
@@ -225,7 +255,7 @@ grinUnitTests =
                 rendered = renderProgram consumer
             assertEqual "lint" [] (lintProgram consumer)
             assertEqual "external code" ["identity"] (map grinCodeSourceName (grinExternalFunctions consumer))
-            assertBool "direct dependency call" ("call @BoxedRep Lifted $entry$identity" `isInfixOf` rendered)
+            assertBool "direct dependency call" ("call @(BoxedRep Lifted) $entry$identity" `isInfixOf` rendered)
             assertBool "dependency function has no global slot" (not ("global identity" `isInfixOf` rendered))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
       testCase "separate FC units store saturated dependency constructors directly" $ do

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -7,8 +7,8 @@ expected: |-
     $grin_argument_1006%1006 :: IntRep <-
       $grin_tuple_1007%1007 :: IntRep, $grin_tuple_1008%1008 :: WordRep <-
         constant 1 2
-      constant $grin_tuple_1007%1007 :: IntRep
-    store (CBox $grin_argument_1006%1006 :: IntRep)
+      constant ($grin_tuple_1007%1007 :: IntRep)
+    store (CBox ($grin_argument_1006%1006 :: IntRep))
 extensions:
 - MagicHash
 - UnboxedTuples

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -8,7 +8,7 @@ expected: |-
   $grin_thunk_0 -> BoxedRep Lifted =
     $grin_argument_1008%1008 :: IntRep <-
       constant 42
-    store (CBox $grin_argument_1008%1008 :: IntRep)
+    store (CBox ($grin_argument_1008%1008 :: IntRep))
 extensions:
 - EmptyDataDecls
 - MagicHash


### PR DESCRIPTION
## Summary

- parenthesize typed GRIN variables when they appear as function parameters, alternatives, values, and node fields
- parenthesize compound runtime representations used as visible `@` arguments while leaving atomic representations such as `IntRep` bare
- add an exact regression test for the ambiguous thunk/application rendering and update affected golden expectations

## Root cause

The GRIN pretty-printer rendered annotated variables and compound runtime representations as whitespace-separated text without accounting for their precedence. In application-like contexts, adjacent operands became visually ambiguous because it was unclear where a `::` annotation or visible runtime-representation argument ended.

## Impact

Generated GRIN now preserves operand boundaries explicitly. For example, lifted arguments render as `(value :: BoxedRep Lifted)` and lifted visible arguments as `@(BoxedRep Lifted)`, while delimited result representations remain unchanged.

## Validation

- `just fmt`
- `just check`
- GRIN suite: 109 tests passed
- `git diff --check`

## Progress counts

- GRIN spec: 108 → 109 tests (+1 pretty-printer regression)
- README progress counts unchanged (cron-managed)
