### PR TITLE
fix(grin): restrict CPS to function calls

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -991,8 +991,8 @@ test_compileExplicitCoreImport =
     wholeCore <- expectCompileArtifact =<< compileSourceToWholeCoreWithDependencies environment "Main.hs" importedSource
     assertBool "dependency reference remains in incremental Core" ("identity" `T.isInfixOf` core)
     assertBool "dependency reference remains in incremental GRIN" ("identity" `T.isInfixOf` grin)
-    assertBool "CPS-GRIN allocates ordinary continuation closures" ("store (P$cps$" `T.isInfixOf` cpsGrin)
-    assertBool "CPS-GRIN invokes ordinary continuation closures" ("apply @" `T.isInfixOf` cpsGrin)
+    assertBool "dependency reference remains in incremental CPS-GRIN" ("identity" `T.isInfixOf` cpsGrin)
+    assertBool "CPS-GRIN avoids unnecessary continuation closures" (not ("store (P$cps$" `T.isInfixOf` cpsGrin))
     assertBool "dependency Core implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` core))
     assertBool "dependency GRIN implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` grin))
     assertBool "whole-program Core merges reachable dependency implementations" ("dependencyImplementation" `T.isInfixOf` wholeCore)

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -5,11 +5,11 @@
 -- This pass deliberately keeps the GRIN syntax. Each potentially suspending
 -- source 'GrinBind' is rewritten so its body lives in a generated function. A
 -- closure for that function is allocated with 'GrinStore' and invoked with
--- 'GrinApply' after the bound expression produces its values. Heap allocation
--- itself cannot suspend, so binds of 'GrinStore' remain in direct style. The
--- introduced administrative binds retain the current runtime-operation
--- protocol; future suspension lowering can transfer ownership of the explicit
--- closure instead of returning through them.
+-- 'GrinApply' after the bound expression produces its values. Only 'GrinEval',
+-- 'GrinCall', 'GrinPrimitiveCall', and 'GrinApply' can suspend; all other binds
+-- remain in direct style. The introduced administrative binds retain the
+-- current runtime-operation protocol; future suspension lowering can transfer
+-- ownership of the explicit closure instead of returning through them.
 module Aihc.Grin.Cps
   ( CpsGrinProgram,
     CpsGrinError (..),
@@ -81,9 +81,11 @@ transformExpr :: FunctionName -> Set GrinVar -> RuntimeRep -> GrinExpr -> CpsM G
 transformExpr parent bound resultRep expression =
   case expression of
     GrinConstant {} -> pure expression
-    GrinBind resultVars valueExpression@GrinStore {} body -> do
-      transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
-      pure (GrinBind resultVars valueExpression transformedBody)
+    GrinBind resultVars valueExpression body
+      | not (requiresContinuation valueExpression) -> do
+          transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
+          transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
+          pure (GrinBind resultVars transformedValue transformedBody)
     GrinBind resultVars valueExpression body -> do
       transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
       transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
@@ -134,6 +136,15 @@ transformExpr parent bound resultRep expression =
     GrinThrow {} -> lift (Left (CpsGrinUnexpectedThrow parent))
     GrinCatch {} -> lift (Left (CpsGrinUnexpectedCatch parent))
     GrinForeignCallExpr {} -> pure expression
+
+requiresContinuation :: GrinExpr -> Bool
+requiresContinuation expression =
+  case expression of
+    GrinEval {} -> True
+    GrinCall {} -> True
+    GrinPrimitiveCall {} -> True
+    GrinApply {} -> True
+    _ -> False
 
 freshContinuationName :: FunctionName -> CpsM FunctionName
 freshContinuationName parent = do

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -2,13 +2,14 @@
 
 -- | Reify direct-style GRIN continuations as ordinary GRIN closures.
 --
--- This pass deliberately keeps the GRIN syntax. Each source 'GrinBind' is
--- rewritten so its body lives in a generated function. A closure for that
--- function is allocated with 'GrinStore' and invoked with 'GrinApply' after
--- the bound expression produces its values. The introduced administrative
--- binds retain the current runtime-operation protocol; future suspension
--- lowering can transfer ownership of the explicit closure instead of
--- returning through them.
+-- This pass deliberately keeps the GRIN syntax. Each potentially suspending
+-- source 'GrinBind' is rewritten so its body lives in a generated function. A
+-- closure for that function is allocated with 'GrinStore' and invoked with
+-- 'GrinApply' after the bound expression produces its values. Heap allocation
+-- itself cannot suspend, so binds of 'GrinStore' remain in direct style. The
+-- introduced administrative binds retain the current runtime-operation
+-- protocol; future suspension lowering can transfer ownership of the explicit
+-- closure instead of returning through them.
 module Aihc.Grin.Cps
   ( CpsGrinProgram,
     CpsGrinError (..),
@@ -80,6 +81,9 @@ transformExpr :: FunctionName -> Set GrinVar -> RuntimeRep -> GrinExpr -> CpsM G
 transformExpr parent bound resultRep expression =
   case expression of
     GrinConstant {} -> pure expression
+    GrinBind resultVars valueExpression@GrinStore {} body -> do
+      transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
+      pure (GrinBind resultVars valueExpression transformedBody)
     GrinBind resultVars valueExpression body -> do
       transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
       transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -92,16 +92,21 @@ grinUnitTests =
         assertBool "contains explicit throw" ("throw " `isInfixOf` rendered)
         assertBool "contains explicit catch" ("catch " `isInfixOf` rendered),
       testCase "CPS-GRIN allocates and applies ordinary continuation closures" $ do
-        cps <- expectCpsGrin heapProgram
+        cps <- expectCpsGrin callBindProgram
         let program = cpsGrinProgram cps
             rendered = renderProgram program
         assertEqual "transformed lint" [] (lintProgram program)
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
         assertBool "invokes a continuation closure" ("apply @(BoxedRep Lifted) ($cps_continuation" `isInfixOf` rendered)
         assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
-      testCase "CPS-GRIN keeps store binds in direct style" $ do
-        cps <- expectCpsGrin storeBindProgram
-        assertEqual "transformed program" storeBindProgram (cpsGrinProgram cps),
+      testCase "CPS-GRIN reifies every function-call bind" $
+        forM_ functionCallExpressions $ \valueExpression -> do
+          let source = singleBindProgram valueExpression
+          cps <- expectCpsGrin source
+          assertEqual (show valueExpression) 2 (length (grinFunctions (cpsGrinProgram cps))),
+      testCase "CPS-GRIN keeps non-call binds in direct style" $ do
+        cps <- expectCpsGrin directBindProgram
+        assertEqual "transformed program" directBindProgram (cpsGrinProgram cps),
       testCase "CPS-GRIN preserves evaluation semantics" $ do
         cps <- expectCpsGrin heapProgram
         directResult <- interpretProgramBinding "answer" heapProgram
@@ -663,25 +668,96 @@ heapProgram =
     replacementBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)]
     functionName = FunctionName "answer_code"
 
-storeBindProgram :: GrinProgram
-storeBindProgram =
+directBindProgram :: GrinProgram
+directBindProgram =
   heapProgram
     { grinCafs = [],
       grinFunctions =
         [ GrinFunction
-            { grinFunctionName = FunctionName "store_bind",
+            { grinFunctionName = FunctionName "direct_binds",
               grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
-                GrinBind [pointer] (GrinStore box) $
-                  GrinConstant [GrinVarValue pointer]
+                GrinBind [constant] (GrinConstant [zero]) $
+                  GrinBind [pointer] (GrinStore box) $
+                    GrinBind [selected] (GrinCase (GrinVarValue constant) caseBinder [alternative]) $
+                      GrinConstant [GrinVarValue selected]
             }
         ]
     }
   where
-    pointer = GrinVar "pointer" 1 (BoxedRep Lifted)
+    constant = GrinVar "constant" 1 IntRep
+    pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
+    caseBinder = GrinVar "case" 3 IntRep
+    selected = GrinVar "selected" 4 (BoxedRep Lifted)
+    zero = GrinLitValue (GrinLitInt IntRep 0)
     box = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)]
+    alternative =
+      GrinAlt
+        { grinAltCon = GrinDefaultAlt,
+          grinAltBinders = [],
+          grinAltRhs = GrinConstant [GrinVarValue pointer]
+        }
+
+callBindProgram :: GrinProgram
+callBindProgram =
+  heapProgram
+    { grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = caller,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [capture],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind [result] (GrinCall (BoxedRep Lifted) callee []) $
+                  GrinConstant [GrinVarValue capture]
+            },
+          GrinFunction
+            { grinFunctionName = callee,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinStore box
+            }
+        ]
+    }
+  where
+    caller = FunctionName "caller"
+    callee = FunctionName "callee"
+    capture = GrinVar "capture" 1 (BoxedRep Lifted)
+    result = GrinVar "result" 2 (BoxedRep Lifted)
+    box = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)]
+
+functionCallExpressions :: [GrinExpr]
+functionCallExpressions =
+  [ GrinEval lifted string,
+    GrinCall lifted (FunctionName "callee") [],
+    GrinPrimitiveCall lifted "primitive" [],
+    GrinApply lifted string []
+  ]
+  where
+    lifted = BoxedRep Lifted
+    string = GrinLitValue (GrinLitString "function")
+
+singleBindProgram :: GrinExpr -> GrinProgram
+singleBindProgram valueExpression =
+  directBindProgram
+    { grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = FunctionName "single_bind",
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind [result] valueExpression $
+                  GrinConstant [GrinVarValue result]
+            }
+        ]
+    }
+  where
+    result = GrinVar "result" 1 (BoxedRep Lifted)
 
 exceptionBoundaryProgram :: GrinExpr -> GrinProgram
 exceptionBoundaryProgram body =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -99,6 +99,9 @@ grinUnitTests =
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
         assertBool "invokes a continuation closure" ("apply @(BoxedRep Lifted) ($cps_continuation" `isInfixOf` rendered)
         assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
+      testCase "CPS-GRIN keeps store binds in direct style" $ do
+        cps <- expectCpsGrin storeBindProgram
+        assertEqual "transformed program" storeBindProgram (cpsGrinProgram cps),
       testCase "CPS-GRIN preserves evaluation semantics" $ do
         cps <- expectCpsGrin heapProgram
         directResult <- interpretProgramBinding "answer" heapProgram
@@ -659,6 +662,26 @@ heapProgram =
     updated = GrinVar "updated" 6 (BoxedRep Lifted)
     replacementBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)]
     functionName = FunctionName "answer_code"
+
+storeBindProgram :: GrinProgram
+storeBindProgram =
+  heapProgram
+    { grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = FunctionName "store_bind",
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind [pointer] (GrinStore box) $
+                  GrinConstant [GrinVarValue pointer]
+            }
+        ]
+    }
+  where
+    pointer = GrinVar "pointer" 1 (BoxedRep Lifted)
+    box = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)]
 
 exceptionBoundaryProgram :: GrinExpr -> GrinProgram
 exceptionBoundaryProgram body =


### PR DESCRIPTION
## Summary

- create continuations only for binds of `GrinEval`, `GrinCall`, `GrinPrimitiveCall`, and `GrinApply`
- keep all non-call binds, including `GrinConstant`, `GrinStore`, and `GrinCase`, in direct style
- continue recursively CPS-transforming nested expressions and bind bodies
- add focused structural and compiler integration regressions

## Root cause

The CPS pass reified every `GrinBind` body as a continuation. Only the four function-call-capable GRIN nodes can suspend and need their remaining computation reified.

## Impact

GRIN CPS output no longer allocates and applies administrative continuation closures around constants, heap operations, cases, or other non-call expressions. All four potentially suspending call forms retain CPS continuations.

## Validation

- `cabal test -v0 aihc-grin:spec --test-options="--hide-successes"` (111 tests)
- `cabal test -v0 aihc:spec --test-options="--pattern=explicit --hide-successes"` (2 tests)
- `just fmt`
- `just check`

## Progress counts

No compatibility progress counts changed; this adds two GRIN structural unit tests and updates one compiler integration assertion.
