### PR TITLE
fix(grin): preserve logical application arity

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -164,7 +164,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 7
+cacheSchemaVersion = 9
 
 buildDependencies :: CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies environment usesImplicitPrelude buildNative mainModule = do

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -203,14 +203,14 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
                               const AihcSlot *arguments) {
   switch (function->kind) {
   case AIHC_CLOSURE:
-    if (count < function->arity) {
+    if (function->arity > 1) {
       AihcValue *applied = aihc_copy_with_fields(function, count, arguments);
-      applied->arity -= count;
+      applied->arity -= 1;
       aihc_return_value(machine, (AihcSlot)applied);
       return;
     }
-    if (count > function->arity) {
-      aihc_fail("closure received the wrong number of values");
+    if (function->arity == 0) {
+      aihc_fail("saturated closure was applied");
     }
     aihc_schedule_function(machine, function,
                            aihc_arguments_with_fields(function, count,
@@ -218,13 +218,15 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
     return;
   case AIHC_CONSTRUCTOR: {
     AihcValue *applied = aihc_copy_with_fields(function, count, arguments);
-    if (applied->count < applied->arity) {
+    if (function->arity > 1) {
+      applied->arity -= 1;
       aihc_return_value(machine, (AihcSlot)applied);
       return;
     }
-    if (applied->count > applied->arity) {
-      aihc_fail("overapplication is not implemented");
+    if (function->arity == 0) {
+      aihc_fail("saturated constructor was applied");
     }
+    applied->arity = 0;
     aihc_return_value(machine, (AihcSlot)applied);
     return;
   }

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -219,8 +219,8 @@ compileProgramWithDependencies layout dependencyInitializers entryName cpsProgra
 emptyLinkLayout :: LinkLayout
 emptyLinkLayout =
   LinkLayout
-    { linkConstructors = builtinConstructors,
-      linkGlobalNames = [name | (name, arity) <- builtinConstructors, arity == 0]
+    { linkConstructors = [(name, length layouts) | (name, layouts) <- builtinConstructors],
+      linkGlobalNames = [name | (name, layouts) <- builtinConstructors, null layouts]
     }
 
 programGlobalNames :: GrinProgram -> [Text]
@@ -645,13 +645,12 @@ materializeNode env node = do
 nodeHeader :: ValueEnv -> GrinNode -> Either Arm64Error (Int, NodeInfo, Int)
 nodeHeader env node =
   case grinNodeTag node of
-    GrinConstructor name -> do
+    GrinConstructor name remaining -> do
       identifier <- constructorId compileEnv name
-      arity <- constructorArity compileEnv name
-      pure (1, InfoImmediate identifier, arity)
-    GrinClosure functionName argumentCount -> do
+      pure (1, InfoImmediate identifier, remaining)
+    GrinClosure functionName argumentLayouts -> do
       label <- functionCodeLabel compileEnv functionName
-      pure (2, InfoAddress label, argumentCount)
+      pure (2, InfoAddress label, length argumentLayouts)
     GrinThunk functionName -> do
       label <- functionCodeLabel compileEnv functionName
       arity <- functionArity compileEnv functionName
@@ -785,10 +784,6 @@ constructorId :: CompileEnv -> Text -> Either Arm64Error Int
 constructorId env name =
   maybe (Left (Arm64MissingConstructor name)) Right (Map.lookup name (compileConstructorIds env))
 
-constructorArity :: CompileEnv -> Text -> Either Arm64Error Int
-constructorArity env name =
-  maybe (Left (Arm64MissingConstructor name)) Right (Map.lookup name (compileConstructorArities env))
-
 functionCodeLabel :: CompileEnv -> FunctionName -> Either Arm64Error Text
 functionCodeLabel env name =
   maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionLabels env))
@@ -852,7 +847,7 @@ uniqueByName values =
 
 programConstructorArities :: GrinProgram -> [(Text, Int)]
 programConstructorArities program =
-  [(name, length fieldReps) | (name, fieldReps) <- grinConstructors program]
+  [(name, length fieldLayouts) | (name, fieldLayouts) <- grinConstructors program]
 
 validateRuntimeRep :: RuntimeRep -> Either Arm64Error ()
 validateRuntimeRep runtimeRep =
@@ -866,7 +861,7 @@ validateRuntimeRep runtimeRep =
 
 programRuntimeReps :: GrinProgram -> [RuntimeRep]
 programRuntimeReps program =
-  concatMap snd (grinConstructors program)
+  concatMap (concat . snd) (grinConstructors program)
     <> map (grinVarRuntimeRep . fst) (grinPrimitives program)
     <> concatMap globalRuntimeReps (grinWhnfGlobals program)
     <> concatMap cafRuntimeReps (grinCafs program)

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -71,7 +71,7 @@ tests =
         let runtimeRep = RuntimeRepVar (Unique 1)
             program =
               GrinProgram
-                { grinConstructors = [("Box", [runtimeRep])],
+                { grinConstructors = [("Box", [[runtimeRep]])],
                   grinPrimitives = [],
                   grinForeignCalls = [],
                   grinExternalGlobals = [],

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -96,7 +96,7 @@ transformExpr parent bound resultRep expression =
               }
           continuationNode =
             GrinNode
-              (GrinClosure continuationName (length resultVars))
+              (GrinClosure continuationName [map grinVarRuntimeRep resultVars])
               (map GrinVarValue captures)
           invokeContinuation =
             GrinApply

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -10,7 +10,7 @@ module Aihc.Grin.Interpret
 where
 
 import Aihc.Grin.Syntax
-import Aihc.Tc.Types (RuntimeRep (..))
+import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
@@ -35,6 +35,7 @@ data InterpretError
   | InterpretMissingBinding !Text
   | InterpretUnknownFunction !FunctionName
   | InterpretFunctionArity !FunctionName !Int !Int
+  | InterpretConstructorArity !Text !Int !Int
   | InterpretApplyNonFunction !RuntimeValue
   | InterpretNoMatchingAlternative !RuntimeValue
   | InterpretPrimitiveArity !Text !Int
@@ -158,9 +159,9 @@ initialMachine program =
         [ Map.fromList [(grinVarName var, value) | (var, value) <- cafLocations],
           staticGlobals,
           Map.fromList
-            [ (constructor, RuntimeNode (GrinConstructor constructor) [])
-            | (constructor, arity) <- builtinConstructors <> [(name, length fields) | (name, fields) <- grinConstructors program],
-              arity == 0
+            [ (constructor, RuntimeNode (GrinConstructor constructor 0) [])
+            | (constructor, layouts) <- builtinConstructors <> grinConstructors program,
+              null layouts
             ]
         ]
     staticNode (GrinNode tag fields) = RuntimeNode tag (map staticValue fields)
@@ -348,27 +349,25 @@ applyValue :: RuntimeValue -> [RuntimeValue] -> EvalM [RuntimeValue]
 applyValue function arguments = do
   forcedFunction <- forceValue function
   case forcedFunction of
-    RuntimeNode (GrinClosure functionName argumentCount) fields ->
-      let runtimeArguments
-            | argumentCount == length arguments = arguments
-            -- Synthetic evaluator fixtures may leave an ignored State#
-            -- lambda binder lifted even though the call site correctly has
-            -- no runtime component for it.
-            | null arguments,
-              argumentCount == 1 =
-                [RuntimeStateToken]
-            | otherwise = arguments
-       in case compare (length runtimeArguments) argumentCount of
-            LT ->
-              pure
-                [ RuntimeNode
-                    (GrinClosure functionName (argumentCount - length runtimeArguments))
-                    (fields <> runtimeArguments)
-                ]
-            EQ -> callFunction functionName (fields <> runtimeArguments)
-            GT -> throwInterpret (InterpretFunctionArity functionName argumentCount (length arguments))
-    RuntimeNode constructor@(GrinConstructor _) fields ->
-      pure [RuntimeNode constructor (fields <> arguments)]
+    RuntimeNode (GrinClosure functionName remainingLayouts) fields ->
+      case remainingLayouts of
+        [] -> throwInterpret (InterpretFunctionArity functionName 0 1)
+        layout : rest ->
+          let normalizedArguments
+                -- Synthetic evaluator fixtures can leave an ignored State#
+                -- binder lifted. The logical zero-width argument is still
+                -- present; only its fixture-local placeholder needs restoring.
+                | layout == [BoxedRep Lifted], null arguments = [RuntimeStateToken]
+                | otherwise = arguments
+              appliedFields = fields <> normalizedArguments
+           in case rest of
+                [] -> callFunction functionName appliedFields
+                _ -> pure [RuntimeNode (GrinClosure functionName rest) appliedFields]
+    RuntimeNode (GrinConstructor name remaining) fields ->
+      case compare remaining 1 of
+        GT -> pure [RuntimeNode (GrinConstructor name (remaining - 1)) (fields <> arguments)]
+        EQ -> pure [RuntimeNode (GrinConstructor name 0) (fields <> arguments)]
+        LT -> throwInterpret (InterpretConstructorArity name 0 1)
     RuntimeNode (GrinPrimitive name arity) fields ->
       applyPrimitive name arity fields arguments
     other -> throwInterpret (InterpretApplyNonFunction other)
@@ -401,7 +400,7 @@ applyPrimitive :: Text -> Int -> [RuntimeValue] -> [RuntimeValue] -> EvalM [Runt
 applyPrimitive name remaining captured arguments
   | remaining > 1 = pure [RuntimeNode (GrinPrimitive name (remaining - 1)) (captured <> arguments)]
   | remaining == 1 = evalPrimitive name (captured <> arguments)
-  | otherwise = throwInterpret (InterpretPrimitiveArity name (length captured))
+  | otherwise = throwInterpret (InterpretPrimitiveArity name 1)
 
 evalPrimitive :: Text -> [RuntimeValue] -> EvalM [RuntimeValue]
 evalPrimitive "+#" [left, right] = evalIntPrimitive "+#" (+) left right
@@ -560,7 +559,7 @@ matchAlt value alt =
       Just (Map.fromList [(var, value) | var <- grinAltBinders alt])
     (GrinLitAlt expected, RuntimeLit actual)
       | expected == actual -> Just Map.empty
-    (GrinDataAlt expected, RuntimeNode (GrinConstructor actual) fields)
+    (GrinDataAlt expected, RuntimeNode (GrinConstructor actual 0) fields)
       | expected == actual,
         length fields == length (grinAltBinders alt) ->
           Just (Map.fromList (zip (grinAltBinders alt) fields))
@@ -577,15 +576,16 @@ renderRawValueM value = do
   forced <- forceValue value
   case forced of
     RuntimeLit literal -> pure (renderLiteral literal)
-    RuntimeNode (GrinConstructor "C#") [char] -> renderBoxedChar char
-    RuntimeNode (GrinConstructor name) [] -> pure name
-    RuntimeNode (GrinConstructor name) arguments
+    RuntimeNode (GrinConstructor "C#" 0) [char] -> renderBoxedChar char
+    RuntimeNode (GrinConstructor name 0) [] -> pure name
+    RuntimeNode (GrinConstructor name 0) arguments
       | isTupleConstructor name (length arguments) -> do
           renderedArguments <- mapM renderRawArgument arguments
           pure ("(" <> T.intercalate "," renderedArguments <> ")")
-    RuntimeNode (GrinConstructor name) arguments -> do
+    RuntimeNode (GrinConstructor name 0) arguments -> do
       renderedArguments <- mapM renderRawArgument arguments
       pure (T.unwords (name : renderedArguments))
+    RuntimeNode GrinConstructor {} _ -> pure "<function>"
     RuntimeNode GrinClosure {} _ -> pure "<function>"
     RuntimeNode GrinPrimitive {} _ -> pure "<function>"
     RuntimeNode GrinThunk {} _ -> pure "<thunk>"
@@ -599,10 +599,10 @@ renderRawArgument value = do
   rendered <- renderRawValueM forced
   pure $
     case forced of
-      RuntimeNode (GrinConstructor name) arguments
+      RuntimeNode (GrinConstructor name 0) arguments
         | isTupleConstructor name (length arguments) -> rendered
-      RuntimeNode (GrinConstructor "C#") [_] -> rendered
-      RuntimeNode (GrinConstructor _) (_ : _) -> "(" <> rendered <> ")"
+      RuntimeNode (GrinConstructor "C#" 0) [_] -> rendered
+      RuntimeNode (GrinConstructor _ 0) (_ : _) -> "(" <> rendered <> ")"
       _ -> rendered
 
 renderLiteral :: GrinLiteral -> Text

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -41,7 +41,7 @@ data LintEnv = LintEnv
     lintPrimitiveArities :: !(Map Text Int),
     lintGlobalVars :: !(Set GrinVar),
     lintGlobalNames :: !(Set Text),
-    lintConstructorLayouts :: !(Map Text [RuntimeRep]),
+    lintConstructorLayouts :: !(Map Text [[RuntimeRep]]),
     lintForeignCalls :: !(Map Text GrinForeignCall)
   }
 
@@ -83,7 +83,7 @@ lintProgram program =
           lintGlobalVars = Set.fromList (globalVars <> cafVars),
           lintGlobalNames =
             Set.fromList
-              ( [name | (name, arity) <- builtinConstructors, arity == 0]
+              ( [name | (name, layouts) <- builtinConstructors, null layouts]
                   <> [name | (name, fields) <- grinConstructors program, null fields]
                   <> grinExternalGlobals program
                   <> map grinVarName globalVars
@@ -126,7 +126,7 @@ lintFunctionResult :: LintEnv -> RuntimeRep -> GrinExpr -> [GrinLintError]
 lintFunctionResult env resultRep expr =
   case expr of
     GrinBind _ _ body -> lintFunctionResult env resultRep body
-    GrinStore (GrinNode (GrinClosure functionName 0) _) ->
+    GrinStore (GrinNode (GrinClosure functionName []) _) ->
       [ GrinLintSaturatedClosure functionName
       | Map.lookup functionName (lintFunctionResults env) == Just resultRep
       ]
@@ -232,11 +232,13 @@ lintNode env bound node =
 lintConstructorFields :: LintEnv -> GrinNode -> [GrinLintError]
 lintConstructorFields env node =
   case grinNodeTag node of
-    GrinConstructor name ->
+    GrinConstructor name remaining ->
       case Map.lookup name (lintConstructorLayouts env) of
-        Just expected
-          | actual /= take (length actual) expected || length actual > length expected ->
-              [GrinLintConstructorLayout name expected actual]
+        Just layouts
+          | let suppliedCount = length layouts - remaining,
+            suppliedCount < 0
+              || actual /= concat (take suppliedCount layouts) ->
+              [GrinLintConstructorLayout name (concat layouts) actual]
         _ -> []
     _ -> []
   where
@@ -246,7 +248,7 @@ lintNodeFunction :: LintEnv -> GrinNode -> [GrinLintError]
 lintNodeFunction env node =
   case grinNodeTag node of
     GrinThunk functionName -> checkFunctionArity functionName fieldCount <> checkThunkResult functionName
-    GrinClosure functionName argumentCount -> checkClosureArity functionName argumentCount
+    GrinClosure functionName argumentLayouts -> checkClosureArity functionName argumentLayouts
     _ -> []
   where
     fieldCount = length (grinNodeFields node)
@@ -256,8 +258,8 @@ lintNodeFunction env node =
         Just expected
           | expected == actual -> []
           | otherwise -> [GrinLintFunctionArity functionName expected actual]
-    checkClosureArity functionName argumentCount =
-      checkFunctionArity functionName (fieldCount + argumentCount)
+    checkClosureArity functionName argumentLayouts =
+      checkFunctionArity functionName (fieldCount + length (concat argumentLayouts))
     checkThunkResult functionName =
       case Map.lookup functionName (lintFunctionResults env) of
         Just runtimeRep

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -48,7 +48,7 @@ data LowerState = LowerState
 type LowerM = State LowerState
 
 data LoweredTop = LoweredTop
-  { loweredConstructors :: ![(Text, [RuntimeRep])],
+  { loweredConstructors :: ![(Text, [[RuntimeRep]])],
     loweredPrimitives :: ![(GrinVar, Int)],
     loweredForeignCalls :: ![GrinForeignCall],
     loweredWhnfGlobals :: ![(GrinVar, GrinNode)],
@@ -134,7 +134,7 @@ programEnvironment interface =
   ProgramEnvironment
     { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
       programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
-      programEnvironmentConstructorArities = Map.fromList builtinConstructors <> grinInterfaceConstructorArities interface,
+      programEnvironmentConstructorArities = Map.fromList [(name, length layouts) | (name, layouts) <- builtinConstructors] <> grinInterfaceConstructorArities interface,
       programEnvironmentPrimitiveArities = grinInterfacePrimitiveArities interface,
       programEnvironmentCodeInfos = grinInterfaceCodeInfos interface
     }
@@ -181,7 +181,7 @@ lowerTopBind :: FcTopBind -> LowerM LoweredTop
 lowerTopBind topBind =
   case topBind of
     FcData _ _ constructors ->
-      pure mempty {loweredConstructors = [(name, concatMap (runtimeRepComponents . typeRuntimeRep) fields) | (name, fields) <- constructors]}
+      pure mempty {loweredConstructors = [(name, map (runtimeRepComponents . typeRuntimeRep) fields) | (name, fields) <- constructors]}
     FcNewtype {} ->
       pure mempty
     FcPrimitive var arity ->
@@ -247,7 +247,8 @@ lowerExpr expr = do
   case constructorApplication constructorArities (Map.keysSet localVars) expr of
     Just (constructor, arguments) ->
       lowerArgumentMany arguments $ \values ->
-        pure (GrinStore (GrinNode (GrinConstructor constructor) values))
+        let remaining = constructorArities Map.! constructor - length arguments
+         in pure (GrinStore (GrinNode (GrinConstructor constructor remaining) values))
     Nothing ->
       case primitiveApplication primitiveArities (Map.keysSet localVars) expr of
         Just ("raise#", [exception]) ->
@@ -276,7 +277,7 @@ lowerNonTupleExpr expr =
       do
         codeInfo <- lookupCodeInfo var
         case codeInfo of
-          Just info -> pure (GrinStore (knownFunctionNode info (codeRuntimeArity info) []))
+          Just info -> pure (GrinStore (knownFunctionNode info 0 []))
           Nothing -> do
             direct <- lowerDirectValues expr
             case direct of
@@ -321,16 +322,10 @@ lowerKnownApplication originalExpr info arguments = do
   lowerArgumentMany entryArguments $ \values ->
     case extraArguments of
       [] ->
-        case compare (length values) runtimeArity of
-          LT -> pure (GrinStore (knownFunctionNode info (runtimeArity - length values) values))
-          EQ
-            | length entryArguments == termArity ->
-                pure (GrinCall (exprRuntimeRep originalExpr) (grinCodeFunctionName info) values)
-            | grinCodeResultRep info == exprRuntimeRep originalExpr ->
-                pure (GrinCall (grinCodeResultRep info) (grinCodeFunctionName info) values)
-            | otherwise ->
-                pure (GrinStore (knownFunctionNode info 0 values))
-          GT -> error "GRIN lowering supplied more runtime arguments than the known function accepts"
+        case compare (length entryArguments) termArity of
+          LT -> pure (GrinStore (knownFunctionNode info (length entryArguments) values))
+          EQ -> pure (GrinCall (exprRuntimeRep originalExpr) (grinCodeFunctionName info) values)
+          GT -> error "GRIN lowering supplied more logical arguments than the known function accepts"
       _ -> do
         let saturatedExpr = dropLastTermApplications (length extraArguments) originalExpr
             saturatedRep = exprRuntimeRep saturatedExpr
@@ -342,7 +337,6 @@ lowerKnownApplication originalExpr info arguments = do
           _ -> error "GRIN lowering expected an overapplied function call to return one function value"
   where
     termArity = length (grinCodeParameterLayouts info)
-    runtimeArity = codeRuntimeArity info
 
 lowerPrimitiveApplication :: FcExpr -> Text -> Int -> [FcExpr] -> LowerM GrinExpr
 lowerPrimitiveApplication originalExpr name arity arguments =
@@ -405,16 +399,9 @@ lowerUnknownApplication expr =
     _ -> error "GRIN lowering expected an application"
 
 knownFunctionNode :: GrinCodeInfo -> Int -> [GrinValue] -> GrinNode
-knownFunctionNode info remainingRuntimeArity =
+knownFunctionNode info suppliedTermArity =
   GrinNode
-    (GrinClosure (grinCodeFunctionName info) remainingRuntimeArity)
-
-codeRuntimeArity :: GrinCodeInfo -> Int
-codeRuntimeArity = length . concat . grinCodeParameterLayouts
-
-runtimeArityAfterTerms :: GrinCodeInfo -> Int -> Int
-runtimeArityAfterTerms info suppliedTermArity =
-  length (concat (drop suppliedTermArity (grinCodeParameterLayouts info)))
+    (GrinClosure (grinCodeFunctionName info) (drop suppliedTermArity (grinCodeParameterLayouts info)))
 
 lowerCase :: FcExpr -> Var -> [FcAlt] -> LowerM GrinExpr
 lowerCase scrutinee binder alternatives =
@@ -484,9 +471,9 @@ makeClosureNode expr = do
   let (binders, lambdaBody) = collectLeadingLambdas expr
   captures <- capturesFor expr
   functionName <- freshFunction "closure"
-  (parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
+  (parameterLayouts, parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
     body' <- lowerExpr lambdaBody
-    pure (concat groups, body')
+    pure (map (map grinVarRuntimeRep) groups, concat groups, body')
   emitFunction
     GrinFunction
       { grinFunctionName = functionName,
@@ -495,7 +482,7 @@ makeClosureNode expr = do
         grinFunctionResultRep = exprRuntimeRep lambdaBody,
         grinFunctionBody = loweredBody
       }
-  pure (GrinNode (GrinClosure functionName (length parameters)) (map GrinVarValue captures))
+  pure (GrinNode (GrinClosure functionName parameterLayouts) (map GrinVarValue captures))
 
 lowerLet :: FcBind -> FcExpr -> LowerM GrinExpr
 lowerLet bind body =
@@ -578,7 +565,8 @@ lowerStaticNode expr = do
   case constructorApplication constructorArities (Map.keysSet localVars) expr of
     Just (constructor, arguments) -> do
       values <- mapM lowerStaticValues arguments
-      pure (GrinNode (GrinConstructor constructor) . concat <$> sequence values)
+      let remaining = constructorArities Map.! constructor - length arguments
+      pure (GrinNode (GrinConstructor constructor remaining) . concat <$> sequence values)
     Nothing -> pure Nothing
 
 lowerStaticValues :: FcExpr -> LowerM (Maybe [GrinValue])
@@ -731,16 +719,16 @@ emitFunction function = do
   body <- ensureWhnfResult function (grinFunctionBody function)
   modify' $ \state -> state {lowerFunctionsRev = function {grinFunctionBody = body} : lowerFunctionsRev state}
 
--- A zero-runtime-argument closure whose entry preserves the result layout is
--- a saturated computation, not a WHNF. Enter it at function exits while
--- retaining closures in intermediate positions where they encode delayed
--- source-level application. If entry changes the layout, the closure remains
--- a genuine function value despite having no physical arguments.
+-- A closure with no remaining logical arguments is a saturated computation,
+-- not a WHNF. Enter it at function exits while retaining closures in
+-- intermediate positions where they encode delayed source-level application.
+-- Zero-width arguments remain present as empty layouts and therefore do not
+-- make a closure appear saturated.
 ensureWhnfResult :: GrinFunction -> GrinExpr -> LowerM GrinExpr
 ensureWhnfResult owner expr =
   case expr of
     GrinBind vars valueExpr body -> GrinBind vars valueExpr <$> ensureWhnfResult owner body
-    GrinStore node@(GrinNode (GrinClosure functionName 0) fields) -> do
+    GrinStore node@(GrinNode (GrinClosure functionName []) fields) -> do
       resultRep <- lookupFunctionResultRep owner functionName
       if resultRep == grinFunctionResultRep owner
         then pure (GrinCall resultRep functionName fields)
@@ -996,8 +984,7 @@ knownSaturatedApplication expr =
       codeInfo <- lookupCodeInfo var
       pure $ do
         info <- codeInfo
-        if length arguments <= length (grinCodeParameterLayouts info)
-          && runtimeArityAfterTerms info (length arguments) == 0
+        if length arguments == length (grinCodeParameterLayouts info)
           && isLiftedRuntimeRep (grinCodeResultRep info)
           then Just (info, arguments)
           else Nothing
@@ -1017,7 +1004,7 @@ isWhnfExpr expr =
       pure
         ( case codeInfo of
             Just info ->
-              runtimeArityAfterTerms info 0 > 0
+              not (null (grinCodeParameterLayouts info))
                 || grinCodeResultRep info /= exprRuntimeRep expr
             Nothing -> maybe False (> 0) primitiveArity || maybe False (> 0) constructorArity
         )
@@ -1032,7 +1019,7 @@ isWhnfExpr expr =
               codeInfo <- lookupCodeInfo var
               pure $ case codeInfo of
                 Just info ->
-                  runtimeArityAfterTerms info (length arguments) > 0
+                  length arguments < length (grinCodeParameterLayouts info)
                     || grinCodeResultRep info /= exprRuntimeRep expr
                 Nothing -> False
             _ -> pure False
@@ -1217,7 +1204,9 @@ programConstructors program =
 programWhnfGlobalNames :: FcProgram -> [Text]
 programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds program)
   where
-    constructorArities = Map.fromList (builtinConstructors <> programConstructors program)
+    constructorArities =
+      Map.fromList [(name, length layouts) | (name, layouts) <- builtinConstructors]
+        <> Map.fromList (programConstructors program)
     topWhnfGlobalNames topBind =
       case topBind of
         FcData _ _ constructors -> map fst constructors

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -33,15 +33,20 @@ renderExternalFunction info =
     <> " = "
     <> T.unpack (unFunctionName (grinCodeFunctionName info))
 
-renderConstructor :: (T.Text, [RuntimeRep]) -> String
-renderConstructor (name, fieldReps) =
+renderConstructor :: (T.Text, [[RuntimeRep]]) -> String
+renderConstructor (name, fieldLayouts) =
   "constructor "
     <> T.unpack name
     <> "/"
-    <> show (length fieldReps)
+    <> show (length fieldLayouts)
     <> " ["
-    <> intercalate ", " (map show fieldReps)
+    <> intercalate ", " (map renderLayout fieldLayouts)
     <> "]"
+  where
+    renderLayout layout =
+      case layout of
+        [runtimeRep] -> show runtimeRep
+        _ -> "[" <> intercalate ", " (map show layout) <> "]"
 
 renderPrimitive :: (GrinVar, Int) -> String
 renderPrimitive (var, arity) =
@@ -122,7 +127,7 @@ renderExprIndented indentation expr =
         <> show runtimeRep
         <> " "
         <> renderValue function
-        <> renderValues arguments
+        <> renderArgument arguments
     GrinCase scrutinee binder alternatives ->
       indent indentation
         <> "case "
@@ -147,6 +152,9 @@ renderExprIndented indentation expr =
 
 renderValues :: [GrinValue] -> String
 renderValues = concatMap ((" " <>) . renderValue)
+
+renderArgument :: [GrinValue] -> String
+renderArgument values = " (" <> unwords (map renderValue values) <> ")"
 
 renderBinders :: [GrinVar] -> String
 renderBinders vars =
@@ -185,9 +193,10 @@ renderNode node =
 renderNodeTag :: GrinNodeTag -> String
 renderNodeTag nodeTag =
   case nodeTag of
-    GrinConstructor name -> "C" <> T.unpack name
-    GrinClosure functionName argumentCount ->
-      "P" <> T.unpack (unFunctionName functionName) <> "/" <> show argumentCount
+    GrinConstructor name remaining ->
+      "C" <> T.unpack name <> if remaining == 0 then "" else "/" <> show remaining
+    GrinClosure functionName argumentLayouts ->
+      "P" <> T.unpack (unFunctionName functionName) <> "/" <> show (length argumentLayouts)
     GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
     GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
 

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -37,7 +37,7 @@ import Data.Text (Text)
 
 -- | A whole GRIN program.
 data GrinProgram = GrinProgram
-  { grinConstructors :: ![(Text, [RuntimeRep])],
+  { grinConstructors :: ![(Text, [[RuntimeRep]])],
     grinPrimitives :: ![(GrinVar, Int)],
     grinForeignCalls :: ![GrinForeignCall],
     -- | Global slots supplied by dependency units and referenced by this unit.
@@ -118,7 +118,10 @@ data GrinExpr
     GrinCall !RuntimeRep !FunctionName ![GrinValue]
   | -- | A saturated call to a statically known primitive entry.
     GrinPrimitiveCall !RuntimeRep !Text ![GrinValue]
-  | GrinApply !RuntimeRep !GrinValue ![GrinValue]
+  | -- | Apply exactly one logical argument. The list contains that argument's
+    -- runtime values and may be empty for a zero-width argument such as
+    -- @State# RealWorld@.
+    GrinApply !RuntimeRep !GrinValue ![GrinValue]
   | GrinCase !GrinValue !GrinVar ![GrinAlt]
   | GrinThrow !GrinValue
   | GrinCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
@@ -139,8 +142,12 @@ data GrinNode = GrinNode
   deriving (Eq, Show, Read)
 
 data GrinNodeTag
-  = GrinConstructor !Text
-  | GrinClosure !FunctionName !Int
+  = -- | A constructor with its remaining logical field count.
+    GrinConstructor !Text !Int
+  | -- | A function closure with the runtime layout of every remaining logical
+    -- argument. Empty layouts are retained because they still count toward
+    -- semantic arity even though they carry no runtime values.
+    GrinClosure !FunctionName ![[RuntimeRep]]
   | -- | A suspended computation. Its target function must return exactly
     -- @BoxedRep Lifted@; unlifted computations are always evaluated strictly.
     GrinThunk !FunctionName
@@ -200,13 +207,13 @@ isPointerRuntimeRep runtimeRep =
 -- Keeping their arities with the shared GRIN syntax makes lowering,
 -- interpretation, linting, and native code generation agree on which global
 -- constructor values exist before the program starts.
-builtinConstructors :: [(Text, Int)]
+builtinConstructors :: [(Text, [[RuntimeRep]])]
 builtinConstructors =
-  [ ("C#", 1),
-    ("[]", 0),
-    (":", 2),
-    ("()", 0),
-    ("(,)", 2)
+  [ ("C#", [[WordRep]]),
+    ("[]", []),
+    (":", [[liftedRuntimeRep], [liftedRuntimeRep]]),
+    ("()", []),
+    ("(,)", [[liftedRuntimeRep], [liftedRuntimeRep]])
   ]
 
 data GrinForeignCall = GrinForeignCall

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -51,7 +51,7 @@ grinUnitTests =
                   ("accepted heap update with " <> show runtimeRep)
                   (GrinLintUpdateNonLifted runtimeRep `elem` errors),
       testCase "lint rejects constructor field representation mismatches" $ do
-        let program = heapProgram {grinConstructors = [("Box", [WordRep])]}
+        let program = heapProgram {grinConstructors = [("Box", [[WordRep]])]}
         assertBool
           "constructor layout mismatch"
           (GrinLintConstructorLayout "Box" [WordRep] [IntRep] `elem` lintProgram program),
@@ -69,6 +69,15 @@ grinUnitTests =
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
         assertBool "invokes a continuation closure" ("apply @BoxedRep Lifted $cps_continuation" `isInfixOf` rendered)
         assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
+      testCase "CPS-GRIN treats a multi-value result as one logical argument" $ do
+        cps <- expectCpsGrin multiValueContinuationProgram
+        case grinFunctions (cpsGrinProgram cps) of
+          [function, _continuation] ->
+            case grinFunctionBody function of
+              GrinBind _ (GrinStore (GrinNode (GrinClosure _ layouts) [])) _ ->
+                assertEqual "one multi-value argument layout" [[IntRep, WordRep]] layouts
+              body -> assertFailure ("expected a stored continuation closure, got " <> show body)
+          functions -> assertFailure ("expected source and continuation functions, got " <> show (length functions)),
       testCase "CPS-GRIN preserves evaluation semantics" $ do
         cps <- expectCpsGrin heapProgram
         directResult <- interpretProgramBinding "answer" heapProgram
@@ -95,12 +104,36 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "contains a direct primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered)
         assertBool "primitive is not global" (not ("global +#" `isInfixOf` rendered)),
-      testCase "FC lowering calls functions when only zero-width arguments remain" $ do
+      testCase "FC lowering counts zero-width arguments in closure arity" $ do
         let program = lowerProgram zeroWidthSaturatedApplicationProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "direct call" ("call @BoxedRep Lifted $entry$zeroWidthTarget" `isInfixOf` rendered)
-        assertBool "no saturated closure" (not ("P$entry$zeroWidthTarget/0" `isInfixOf` rendered)),
+        assertBool "one logical argument remains" ("P$entry$zeroWidthTarget/1" `isInfixOf` rendered)
+        assertBool "closure is not saturated" (not ("P$entry$zeroWidthTarget/0" `isInfixOf` rendered)),
+      testCase "FC lowering preserves a zero-width application" $ do
+        let program = lowerProgram zeroWidthUnknownApplicationProgram
+        assertEqual "lint" [] (lintProgram program)
+        case grinFunctions program of
+          [function] ->
+            case grinFunctionBody function of
+              GrinApply _ _ argumentValues -> assertEqual "zero runtime values" [] argumentValues
+              body -> assertFailure ("expected an application, got " <> show body)
+          functions -> assertFailure ("expected one function, got " <> show (length functions)),
+      testCase "interpreter consumes one logical zero-width argument" $ do
+        assertEqual "lint" [] (lintProgram zeroWidthApplyProgram)
+        result <- interpretProgramBinding "answer" zeroWidthApplyProgram
+        assertEqual "result" (Right "Box 1") result,
+      testCase "FC lowering counts zero-width constructor fields" $ do
+        let program = lowerProgram zeroWidthConstructorProgram
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual "field layouts" [("StateBox", [[], [BoxedRep Lifted]])] (grinConstructors program)
+        case grinFunctions program of
+          [function] ->
+            assertEqual
+              "one logical field remains"
+              (GrinStore (GrinNode (GrinConstructor "StateBox" 1) []))
+              (grinFunctionBody function)
+          functions -> assertFailure ("expected one function, got " <> show (length functions)),
       testCase "lint rejects saturated closure nodes" $ do
         let target = FunctionName "target"
             wrapper = FunctionName "wrapper"
@@ -113,14 +146,14 @@ grinUnitTests =
                           grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = BoxedRep Lifted,
-                          grinFunctionBody = GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])
+                          grinFunctionBody = GrinStore (GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)])
                         },
                       GrinFunction
                         { grinFunctionName = wrapper,
                           grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = BoxedRep Lifted,
-                          grinFunctionBody = GrinStore (GrinNode (GrinClosure target 0) [])
+                          grinFunctionBody = GrinStore (GrinNode (GrinClosure target []) [])
                         }
                     ]
                 }
@@ -132,7 +165,7 @@ grinUnitTests =
           [function] ->
             assertEqual
               "constructor body"
-              (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
+              (GrinStore (GrinNode (GrinConstructor "I32#" 0) [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
       testCase "FC lowering returns a tail constructor store directly" $ do
@@ -142,7 +175,7 @@ grinUnitTests =
           [function] ->
             assertEqual
               "function body"
-              (GrinStore (GrinNode (GrinConstructor "Box") [GrinVarValue (GrinVar "value" 81 IntRep)]))
+              (GrinStore (GrinNode (GrinConstructor "Box" 0) [GrinVarValue (GrinVar "value" 81 IntRep)]))
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
       testCase "FC lowering emits saturated strict foreign calls" $ do
@@ -203,7 +236,7 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertEqual
           "dictionary constructor has an ordinary declared layout"
-          [("Box", [IntRep]), ("$Dict$Test", [BoxedRep Lifted, BoxedRep Lifted])]
+          [("Box", [[IntRep]]), ("$Dict$Test", [[BoxedRep Lifted], [BoxedRep Lifted]])]
           (grinConstructors program)
         assertBool ("explicit dictionary constructor store:\n" <> rendered) ("store (C$Dict$Test" `isInfixOf` rendered)
         assertBool "ordinary dictionary case" ("$Dict$Test" `isInfixOf` rendered && "case " `isInfixOf` rendered)
@@ -236,7 +269,7 @@ grinUnitTests =
               [function] ->
                 assertEqual
                   "constructor body"
-                  (GrinStore (GrinNode (GrinConstructor "I32#") [GrinVarValue (GrinVar "value" 72 Int32Rep)]))
+                  (GrinStore (GrinNode (GrinConstructor "I32#" 0) [GrinVarValue (GrinVar "value" 72 Int32Rep)]))
                   (grinFunctionBody function)
               functions -> assertFailure ("expected one constructor function, got " <> show (length functions))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
@@ -510,6 +543,39 @@ zeroWidthSaturatedApplicationProgram =
     stateVar = Var "state" (Unique 35) stateTy
     callerValueVar = Var "callerValue" (Unique 36) boxedIntTy
 
+zeroWidthUnknownApplicationProgram :: FcProgram
+zeroWidthUnknownApplicationProgram =
+  FcProgram
+    [ FcTopBind
+        ( FcNonRec
+            callerVar
+            (FcLam actionVar (FcLam stateVar (FcApp (FcVar actionVar) (FcVar stateVar))))
+        )
+    ]
+  where
+    stateTy = TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
+    actionTy = TcFunTy stateTy boxedIntTy
+    callerVar = Var "applyZeroWidth" (Unique 37) (TcFunTy actionTy actionTy)
+    actionVar = Var "action" (Unique 38) actionTy
+    stateVar = Var "state" (Unique 39) stateTy
+
+zeroWidthConstructorProgram :: FcProgram
+zeroWidthConstructorProgram =
+  FcProgram
+    [ FcData "StateBox" [] [("StateBox", [stateTy, boxedIntTy])],
+      FcTopBind
+        ( FcNonRec
+            partialVar
+            (FcLam stateVar (FcApp (FcVar constructorVar) (FcVar stateVar)))
+        )
+    ]
+  where
+    stateTy = TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
+    resultTy = TcTyCon (TyCon "StateBox" 0) []
+    constructorVar = Var "StateBox" (Unique 40) (TcFunTy stateTy (TcFunTy boxedIntTy resultTy))
+    partialVar = Var "partialStateBox" (Unique 41) (TcFunTy stateTy (TcFunTy boxedIntTy resultTy))
+    stateVar = Var "state" (Unique 42) stateTy
+
 functionClassificationProgram :: FcProgram
 functionClassificationProgram =
   FcProgram
@@ -590,10 +656,75 @@ exceptionProgram =
         (FcApp (FcApp (FcVar catchVar) action) handler)
         (FcLit (LitInt IntRep 0))
 
+multiValueContinuationProgram :: GrinProgram
+multiValueContinuationProgram =
+  GrinProgram
+    { grinConstructors = [("Box", [[IntRep]])],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = FunctionName "multiValue",
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [first, second]
+                  (GrinConstant [GrinLitValue (GrinLitInt IntRep 1), GrinLitValue (GrinLitInt WordRep 2)])
+                  (GrinStore (GrinNode (GrinConstructor "Box" 0) [GrinVarValue first]))
+            }
+        ]
+    }
+  where
+    first = GrinVar "first" 1 IntRep
+    second = GrinVar "second" 2 WordRep
+
+zeroWidthApplyProgram :: GrinProgram
+zeroWidthApplyProgram =
+  GrinProgram
+    { grinConstructors = [("Box", [[IntRep]])],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [],
+      grinCafs = [(answer, GrinNode (GrinThunk wrapperName) [])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = wrapperName,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [closure]
+                  (GrinStore (GrinNode (GrinClosure targetName [[]]) []))
+                  (GrinApply (BoxedRep Lifted) (GrinVarValue closure) [])
+            },
+          GrinFunction
+            { grinFunctionName = targetName,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinStore (GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)])
+            }
+        ]
+    }
+  where
+    answer = GrinVar "answer" 1 (BoxedRep Lifted)
+    closure = GrinVar "closure" 2 (BoxedRep Lifted)
+    wrapperName = FunctionName "zeroWidthWrapper"
+    targetName = FunctionName "zeroWidthTarget"
+
 heapProgram :: GrinProgram
 heapProgram =
   GrinProgram
-    { grinConstructors = [("Box", [IntRep])],
+    { grinConstructors = [("Box", [[IntRep]])],
       grinPrimitives = [],
       grinForeignCalls = [],
       grinExternalGlobals = [],
@@ -611,7 +742,7 @@ heapProgram =
               grinFunctionParameters = [],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
-                GrinBind [pointer] (GrinStore (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])) $
+                GrinBind [pointer] (GrinStore (GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)])) $
                   GrinBind [fetched] (GrinFetch (BoxedRep Lifted) (GrinVarValue pointer)) $
                     GrinBind [replacementPointer] (GrinStore replacementBox) $
                       GrinBind [replacement] (GrinFetch (BoxedRep Lifted) (GrinVarValue replacementPointer)) $
@@ -627,7 +758,7 @@ heapProgram =
     replacementPointer = GrinVar "replacement_pointer" 4 (BoxedRep Lifted)
     replacement = GrinVar "replacement" 5 (BoxedRep Lifted)
     updated = GrinVar "updated" 6 (BoxedRep Lifted)
-    replacementBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)]
+    replacementBox = GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 2)]
     functionName = FunctionName "answer_code"
 
 exceptionBoundaryProgram :: GrinExpr -> GrinProgram
@@ -679,7 +810,7 @@ invalidUpdateProgram =
   where
     pointer = GrinVar "pointer" 2 (BoxedRep Lifted)
     updated = GrinVar "updated" 3 IntRep
-    initialBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)]
+    initialBox = GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)]
 
 unliftedRuntimeReps :: [RuntimeRep]
 unliftedRuntimeReps =


### PR DESCRIPTION
## Summary

- preserve source argument boundaries in GRIN closure and constructor layouts, including zero-width arguments
- define every `GrinApply` as exactly one logical application whose argument may contain zero, one, or multiple runtime values
- decrement logical arity by exactly one in the interpreter and ARM64 runtime
- make CPS continuations receive multi-value results as one logical argument
- add focused lowering, interpreter, and CPS regressions

## Root cause

GRIN arity was derived from the number of physical runtime values after representation flattening. This erased zero-width arguments such as `State# RealWorld`, so a logically unary action could be tagged as arity zero. Application behavior could consequently depend on backend representation details instead of source-level function arity.

## Impact

Zero-width arguments remain real logical arguments throughout closure conversion and application. A suspended `State# RealWorld` action is represented as `/1`, and applying it once with an empty runtime-value list saturates it. Multi-value argument representations similarly consume one unit of logical arity rather than one unit per physical value.

The compilation cache schema is bumped so artifacts using the previous GRIN node representation are not reused.

## Validation

- `just fmt`
- `just check`
- focused zero-width GRIN tests (5 passed)
- focused CPS-GRIN tests (4 passed)
- incremental Hello World compilation and execution
- whole-program Hello World compilation and execution

## Progress counts

No compatibility progress counts changed; this adds four focused GRIN unit regressions and updates one existing zero-width lowering regression.
