### PR TITLE
fix(grin): make evaluation explicit

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -889,7 +889,7 @@ test_compileExecutable =
         assertBool "GRIN does not allocate putchar globally" (not ("global putchar" `T.isInfixOf` grin || "caf putchar" `T.isInfixOf` grin))
         assertBool "GRIN does not allocate char globally" (not ("global char" `T.isInfixOf` grin || "caf char" `T.isInfixOf` grin))
         assertBool "GRIN uses direct known calls" ("call @(BoxedRep Lifted) $entry$>>" `T.isInfixOf` grin)
-        assertBool "GRIN leaves forcing to case and apply" (not ("eval @" `T.isInfixOf` grin))
+        assertBool "GRIN makes evaluation explicit" ("eval @" `T.isInfixOf` grin)
         assertNativeOutput keptOutput
 
         runCompileWithEnvironment environment temporaryOptions

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -21,9 +21,8 @@ enum {
 enum {
   AIHC_CONT_NORMAL = 0,
   AIHC_CONT_UPDATE = 1,
-  AIHC_CONT_APPLY = 2,
-  AIHC_CONT_TOP = 3,
-  AIHC_CONT_FINAL = 4,
+  AIHC_CONT_TOP = 2,
+  AIHC_CONT_FINAL = 3,
 };
 
 enum {
@@ -57,10 +56,6 @@ struct AihcContinuation {
     struct {
       AihcValue *cell;
     } update;
-    struct {
-      AihcSlot *arguments;
-      uint64_t count;
-    } apply;
   } payload;
 };
 
@@ -136,9 +131,6 @@ static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
 static void aihc_return_value(AihcMachine *machine, AihcSlot value);
 static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
                             uint64_t result_is_lifted);
-static void aihc_apply_values_internal(AihcMachine *machine,
-                                       AihcValue *function, uint64_t count,
-                                       const AihcSlot *arguments);
 
 AihcValue *aihc_make_node(uint64_t kind, uintptr_t info, uint64_t arity,
                           uint64_t count) {
@@ -278,19 +270,9 @@ static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
   aihc_return_value(machine, (AihcSlot)value);
 }
 
-static void aihc_apply_values_internal(AihcMachine *machine,
-                                       AihcValue *function, uint64_t count,
-                                       const AihcSlot *arguments) {
-  AihcContinuation *continuation =
-      aihc_push_special(machine, AIHC_CONT_APPLY);
-  continuation->payload.apply.arguments = (AihcSlot *)arguments;
-  continuation->payload.apply.count = count;
-  aihc_eval_value(machine, function, 1);
-}
-
 static void aihc_run_io(AihcMachine *machine, AihcValue *value) {
   aihc_push_special(machine, AIHC_CONT_FINAL);
-  aihc_apply_values_internal(machine, value, 0, NULL);
+  aihc_apply_forced(machine, value, 0, NULL);
 }
 
 static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
@@ -323,14 +305,6 @@ static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
      * forcing the thunk result so the awaiting continuation receives the
      * constructor node rather than that intermediate heap location. */
     aihc_eval_value(machine, (AihcValue *)values[0], 1);
-    return;
-  case AIHC_CONT_APPLY:
-    if (count != 1) {
-      aihc_fail("function evaluation returned multiple values");
-    }
-    aihc_apply_forced(machine, (AihcValue *)values[0],
-                      continuation->payload.apply.count,
-                      continuation->payload.apply.arguments);
     return;
   case AIHC_CONT_TOP:
     if (count != 1) {
@@ -370,12 +344,12 @@ void aihc_eval(AihcMachine *machine, AihcValue *value,
 
 void aihc_apply(AihcMachine *machine, AihcValue *function,
                 AihcSlot argument) {
-  aihc_apply_values_internal(machine, function, 1, &argument);
+  aihc_apply_forced(machine, function, 1, &argument);
 }
 
 void aihc_apply_values(AihcMachine *machine, AihcValue *function,
                        uint64_t count, const AihcSlot *arguments) {
-  aihc_apply_values_internal(machine, function, count, arguments);
+  aihc_apply_forced(machine, function, count, arguments);
 }
 
 void aihc_start(AihcMachine *machine, AihcValue *root, void *exit_code) {

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -470,31 +470,13 @@ compileCase env prefix label scrutinee binder alternatives = do
   resultSlot <- freshSlot
   dispatchLabel <- freshLabel label "case_dispatch"
   scrutineeLines <- liftEither (materializeValue env scrutinee)
-  let scrutineeRep = grinValueRuntimeRep scrutinee
-      scrutineeIsLifted = isLiftedRuntimeRep scrutineeRep
-      scrutineeIsPointer = isPointerRuntimeRep scrutineeRep
-  if scrutineeIsLifted
-    then
-      addBlock
-        label
-        ( prefix
-            <> scrutineeLines
-            <> ["  mov x20, x0"]
-            <> pushNormalLines dispatchLabel resultSlot 1
-            <> [ "  mov x1, x20",
-                 immediate "x2" (1 :: Int),
-                 "  mov x0, x22",
-                 "  bl _aihc_eval"
-               ]
-            <> dispatchLines
-        )
-    else
-      addBlock
-        label
-        ( prefix
-            <> scrutineeLines
-            <> [storeAt "x0" "x19" resultSlot, "  b " <> dispatchLabel]
-        )
+  let scrutineeIsPointer = isPointerRuntimeRep (grinValueRuntimeRep scrutinee)
+  addBlock
+    label
+    ( prefix
+        <> scrutineeLines
+        <> [storeAt "x0" "x19" resultSlot, "  b " <> dispatchLabel]
+    )
   binderSlot <- localSlot env binder
   alternativeTargets <- forM alternatives $ \alternative -> do
     alternativeLabel <- freshLabel label "case_alt"

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -191,8 +191,53 @@ tests =
           Right assembly -> do
             assertBool "exports caller entry" (".globl _aihc_entry_63_61_6c_6c_65_72_" `T.isInfixOf` assembly)
             assertBool "branches to dependency entry" ("b _aihc_entry_69_64_65_6e_74_69_74_79_" `T.isInfixOf` assembly),
+      testCase "case and apply never evaluate operands implicitly" $ do
+        case compileModule (buildLinkLayout [explicitEvaluationProgram]) "_aihc_init_explicit_eval" (expectCpsGrin explicitEvaluationProgram) of
+          Left err -> assertFailure ("native compilation failed: " <> show err)
+          Right assembly ->
+            assertBool "generated case and apply contain no eval call" (not ("bl _aihc_eval" `T.isInfixOf` assembly))
+        runtime <- readFile =<< runtimeSourcePath
+        assertBool
+          "runtime apply does not enter its function"
+          (not ("aihc_eval_value(machine, function" `isInfixOf` runtime)),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
+
+explicitEvaluationProgram :: GrinProgram
+explicitEvaluationProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = FunctionName "case_operand",
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [caseOperand],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinCase
+                  (GrinVarValue caseOperand)
+                  caseBinder
+                  [GrinAlt GrinDefaultAlt [] (GrinConstant [GrinVarValue caseBinder])]
+            },
+          GrinFunction
+            { grinFunctionName = FunctionName "apply_operand",
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [applyOperand],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinApply (BoxedRep Lifted) (GrinVarValue applyOperand) []
+            }
+        ]
+    }
+  where
+    caseOperand = GrinVar "case_operand" 201 (BoxedRep Lifted)
+    caseBinder = GrinVar "case_binder" 202 (BoxedRep Lifted)
+    applyOperand = GrinVar "apply_operand" 203 (BoxedRep Lifted)
 
 testNativeHelloWorld :: IO ()
 testNativeHelloWorld = do

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -4,9 +4,10 @@
 --
 -- This pass deliberately keeps the GRIN syntax. Each source 'GrinBind' is
 -- rewritten so its body lives in a generated function. A closure for that
--- function is allocated with 'GrinStore' and invoked with 'GrinApply' after
--- the bound expression produces its values. The introduced administrative
--- binds retain the current runtime-operation protocol; future suspension
+-- function is allocated with 'GrinStore', entered with 'GrinEval', and invoked
+-- with 'GrinApply' after the bound expression produces its values. The
+-- introduced administrative binds retain the current runtime-operation
+-- protocol; future suspension
 -- lowering can transfer ownership of the explicit closure instead of
 -- returning through them.
 module Aihc.Grin.Cps
@@ -84,7 +85,8 @@ transformExpr parent bound resultRep expression =
       transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
       transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
       continuationName <- freshContinuationName parent
-      continuationVar <- freshContinuationVar
+      continuationPointer <- freshContinuationVar "$cps_continuation_pointer"
+      continuation <- freshContinuationVar "$cps_continuation"
       let captures = Set.toAscList (freeExprVars transformedBody `Set.intersection` bound)
           continuationFunction =
             GrinFunction
@@ -101,14 +103,18 @@ transformExpr parent bound resultRep expression =
           invokeContinuation =
             GrinApply
               resultRep
-              (GrinVarValue continuationVar)
+              (GrinVarValue continuation)
               (map GrinVarValue resultVars)
       addGeneratedFunction continuationFunction
       pure
         ( GrinBind
-            [continuationVar]
+            [continuationPointer]
             (GrinStore continuationNode)
-            (GrinBind resultVars transformedValue invokeContinuation)
+            ( GrinBind
+                [continuation]
+                (GrinEval liftedRuntimeRep (GrinVarValue continuationPointer))
+                (GrinBind resultVars transformedValue invokeContinuation)
+            )
         )
     GrinStore {} -> pure expression
     GrinStoreRec bindings body -> do
@@ -149,12 +155,12 @@ freshContinuationName parent = do
       modify' $ \current -> current {cpsUsedFunctionNames = Set.insert candidate (cpsUsedFunctionNames current)}
       pure candidate
 
-freshContinuationVar :: CpsM GrinVar
-freshContinuationVar = do
+freshContinuationVar :: T.Text -> CpsM GrinVar
+freshContinuationVar name = do
   state <- get
   let unique = cpsNextVarUnique state
   put state {cpsNextVarUnique = unique + 1}
-  pure (GrinVar "$cps_continuation" unique liftedRuntimeRep)
+  pure (GrinVar name unique liftedRuntimeRep)
 
 addGeneratedFunction :: GrinFunction -> CpsM ()
 addGeneratedFunction function =

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -207,10 +207,10 @@ evalExpr env expr =
       argumentValues <- mapM (materializeValue env) arguments
       applyValue functionValue argumentValues
     GrinCase scrutinee binder alternatives -> do
-      value <- materializeValue env scrutinee >>= forceValue
+      value <- materializeValue env scrutinee
       matchAlternative (Map.insert binder value env) value alternatives
     GrinThrow exception -> do
-      exceptionValue <- materializeValue env exception >>= forceValue
+      exceptionValue <- materializeValue env exception
       throwE (EvalRaised exceptionValue)
     GrinCatch runtimeRep action handler state -> do
       actionValue <- materializeValue env action
@@ -346,8 +346,7 @@ forceLocation location = do
 
 applyValue :: RuntimeValue -> [RuntimeValue] -> EvalM [RuntimeValue]
 applyValue function arguments = do
-  forcedFunction <- forceValue function
-  case forcedFunction of
+  case function of
     RuntimeNode (GrinClosure functionName argumentCount) fields ->
       let runtimeArguments
             | argumentCount == length arguments = arguments
@@ -413,27 +412,27 @@ evalPrimitive "<#" [left, right] =
 evalPrimitive "==#" [left, right] =
   evalIntPrimitive "==#" (\leftInt rightInt -> if leftInt == rightInt then 1 else 0) left right
 evalPrimitive "charToInt#" [value] = do
-  charValue <- forceCharPrimitiveArgument "charToInt#" value
+  charValue <- expectCharPrimitiveArgument "charToInt#" value
   pure [RuntimeLit (GrinLitInt IntRep (fromIntegral (Char.ord charValue)))]
 evalPrimitive "intToChar#" [value] = do
-  intValue <- forceIntPrimitiveArgument "intToChar#" value
+  intValue <- expectIntPrimitiveArgument "intToChar#" value
   if intValue >= 0 && intValue <= 0x10ffff
     then pure [RuntimeLit (GrinLitChar WordRep (Char.chr (fromIntegral intValue)))]
     else throwInterpret (InterpretPrimitiveTypeError "intToChar#" (RuntimeLit (GrinLitInt IntRep intValue)))
 evalPrimitive "realWorld#" [] = pure []
 evalPrimitive "raise#" [exception] =
-  forceValue exception >>= throwE . EvalRaised
+  throwE (EvalRaised exception)
 evalPrimitive "catch#" [action, handler] =
   applyValue action [] `catchE` handleRaised handler []
 evalPrimitive "newMutVar#" [initialValue] = do
   mutVar <- GrinMutVar <$> liftEvalIO (newIORef initialValue)
   pure [RuntimeMutVar mutVar]
 evalPrimitive "readMutVar#" [mutVar] = do
-  GrinMutVar reference <- forceMutVarPrimitiveArgument "readMutVar#" mutVar
+  GrinMutVar reference <- expectMutVarPrimitiveArgument "readMutVar#" mutVar
   value <- liftEvalIO (readIORef reference)
   pure [value]
 evalPrimitive "writeMutVar#" [mutVar, value] = do
-  GrinMutVar reference <- forceMutVarPrimitiveArgument "writeMutVar#" mutVar
+  GrinMutVar reference <- expectMutVarPrimitiveArgument "writeMutVar#" mutVar
   liftEvalIO (writeIORef reference value)
   pure []
 evalPrimitive name arguments =
@@ -441,28 +440,25 @@ evalPrimitive name arguments =
 
 evalIntPrimitive :: Text -> (Integer -> Integer -> Integer) -> RuntimeValue -> RuntimeValue -> EvalM [RuntimeValue]
 evalIntPrimitive name operation left right = do
-  leftInt <- forceIntPrimitiveArgument name left
-  rightInt <- forceIntPrimitiveArgument name right
+  leftInt <- expectIntPrimitiveArgument name left
+  rightInt <- expectIntPrimitiveArgument name right
   pure [RuntimeLit (GrinLitInt IntRep (operation leftInt rightInt))]
 
-forceIntPrimitiveArgument :: Text -> RuntimeValue -> EvalM Integer
-forceIntPrimitiveArgument name value = do
-  forced <- forceValue value
-  case forced of
+expectIntPrimitiveArgument :: Text -> RuntimeValue -> EvalM Integer
+expectIntPrimitiveArgument name value =
+  case value of
     RuntimeLit (GrinLitInt _ intValue) -> pure intValue
     other -> throwInterpret (InterpretPrimitiveTypeError name other)
 
-forceCharPrimitiveArgument :: Text -> RuntimeValue -> EvalM Char
-forceCharPrimitiveArgument name value = do
-  forced <- forceValue value
-  case forced of
+expectCharPrimitiveArgument :: Text -> RuntimeValue -> EvalM Char
+expectCharPrimitiveArgument name value =
+  case value of
     RuntimeLit (GrinLitChar _ charValue) -> pure charValue
     other -> throwInterpret (InterpretPrimitiveTypeError name other)
 
-forceMutVarPrimitiveArgument :: Text -> RuntimeValue -> EvalM GrinMutVar
-forceMutVarPrimitiveArgument name value = do
-  forced <- forceValue value
-  case forced of
+expectMutVarPrimitiveArgument :: Text -> RuntimeValue -> EvalM GrinMutVar
+expectMutVarPrimitiveArgument name value =
+  case value of
     RuntimeMutVar mutVar -> pure mutVar
     other -> throwInterpret (InterpretPrimitiveTypeError name other)
 
@@ -502,10 +498,10 @@ callForeign foreignCall arguments = do
 
 marshalForeignArgument :: Text -> GrinForeignType -> RuntimeValue -> EvalM Arg
 marshalForeignArgument symbol GrinForeignInt32 argument = do
-  argumentValue <- forceInt32 symbol argument
+  argumentValue <- expectInt32 symbol argument
   pure (argCInt (CInt (fromInteger argumentValue)))
 marshalForeignArgument symbol GrinForeignWord64 argument = do
-  argumentValue <- forceWord64 symbol argument
+  argumentValue <- expectWord64 symbol argument
   pure (argWord64 (fromInteger argumentValue :: Word64))
 
 lookupForeignFunction :: GrinForeignCall -> EvalM (FunPtr ())
@@ -523,17 +519,15 @@ lookupForeignFunction foreignCall = do
 tryForeign :: IO value -> IO (Either SomeException value)
 tryForeign = try
 
-forceInt32 :: Text -> RuntimeValue -> EvalM Integer
-forceInt32 symbol value = do
-  forced <- forceValue value
-  case forced of
+expectInt32 :: Text -> RuntimeValue -> EvalM Integer
+expectInt32 symbol value =
+  case value of
     RuntimeLit (GrinLitInt Int32Rep intValue) -> pure intValue
     other -> throwInterpret (InterpretForeignTypeError symbol other)
 
-forceWord64 :: Text -> RuntimeValue -> EvalM Integer
-forceWord64 symbol value = do
-  forced <- forceValue value
-  case forced of
+expectWord64 :: Text -> RuntimeValue -> EvalM Integer
+expectWord64 symbol value =
+  case value of
     RuntimeLit (GrinLitInt Word64Rep intValue) -> pure intValue
     other -> throwInterpret (InterpretForeignTypeError symbol other)
 
@@ -541,7 +535,7 @@ runIOValue :: RuntimeValue -> EvalM RuntimeValue
 runIOValue action = do
   results <- applyValue action []
   case results of
-    [ioResult] -> forceValue ioResult
+    [ioResult] -> pure ioResult
     _ -> throwInterpret (InterpretResultArity 1 (length results))
 
 matchAlternative :: Env -> RuntimeValue -> [GrinAlt] -> EvalM [RuntimeValue]

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -253,8 +253,8 @@ lowerExpr expr = do
         Just ("raise#", [exception]) ->
           lowerSingleOperand "exception" exception (pure . GrinThrow)
         Just ("catch#", [action, handler, _state]) ->
-          lowerSingleArgument action $ \actionValue ->
-            lowerSingleArgument handler $ \handlerValue ->
+          lowerSingleEvaluatedOperand "catch_action" action $ \actionValue ->
+            lowerCatchHandler handler $ \handlerValue ->
               pure (GrinCatch (exprRuntimeRep expr) actionValue handlerValue [])
         Just (name, arguments) ->
           case Map.lookup name primitiveArities of
@@ -381,25 +381,26 @@ lowerRemainingApplications :: FcExpr -> GrinValue -> [FcExpr] -> LowerM GrinExpr
 lowerRemainingApplications functionExpr functionValue arguments =
   case arguments of
     [] -> pure (GrinConstant [functionValue])
-    argument : rest -> do
-      let appliedExpr = FcApp functionExpr argument
-          resultRep = exprRuntimeRep appliedExpr
-      lowerArgument argument $ \argumentValues ->
-        if null rest
-          then pure (GrinApply resultRep functionValue argumentValues)
-          else do
-            resultVars <- freshVars "function" resultRep
-            case resultVars of
-              [resultVar] -> do
-                body <- lowerRemainingApplications appliedExpr (GrinVarValue resultVar) rest
-                pure (bindExpr resultVars (GrinApply resultRep functionValue argumentValues) body)
-              _ -> error "GRIN lowering expected an intermediate application to return one function value"
+    argument : rest ->
+      evaluateGrinValue "function" (exprRuntimeRep functionExpr) functionValue $ \evaluatedFunction -> do
+        let appliedExpr = FcApp functionExpr argument
+            resultRep = exprRuntimeRep appliedExpr
+        lowerArgument argument $ \argumentValues ->
+          if null rest
+            then pure (GrinApply resultRep evaluatedFunction argumentValues)
+            else do
+              resultVars <- freshVars "function" resultRep
+              case resultVars of
+                [resultVar] -> do
+                  body <- lowerRemainingApplications appliedExpr (GrinVarValue resultVar) rest
+                  pure (bindExpr resultVars (GrinApply resultRep evaluatedFunction argumentValues) body)
+                _ -> error "GRIN lowering expected an intermediate application to return one function value"
 
 lowerUnknownApplication :: FcExpr -> LowerM GrinExpr
 lowerUnknownApplication expr =
   case expr of
     FcApp function argument ->
-      lowerSingleOperand "function" function $ \functionValue ->
+      lowerSingleEvaluatedOperand "function" function $ \functionValue ->
         lowerArgument argument $ \argumentValues ->
           pure (GrinApply (applicationResultRep function) functionValue argumentValues)
     _ -> error "GRIN lowering expected an application"
@@ -431,7 +432,7 @@ lowerCase scrutinee binder alternatives =
         isUnboxedTupleConstructor constructor ->
           lowerUnboxedTupleCase scrutinee binder alternative
     _ ->
-      lowerSingleOperand "scrutinee" scrutinee $ \value -> do
+      lowerSingleEvaluatedOperand "scrutinee" scrutinee $ \value -> do
         caseVars <- binderVars binder
         caseVar <-
           case caseVars of
@@ -635,6 +636,59 @@ lowerSingleOperand hint expr continuation =
   lowerOperand hint expr $ \case
     [value] -> continuation value
     _ -> error ("GRIN lowering expected one operand for " <> T.unpack hint)
+
+-- | Produce the weak-head normal form required by an operation whose operand
+-- is structural. GRIN operations never enter heap cells implicitly: a lifted
+-- function or case scrutinee must pass through 'GrinEval' before use.
+lowerSingleEvaluatedOperand :: Text -> FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerSingleEvaluatedOperand hint expr continuation =
+  lowerSingleOperand hint expr $ \value ->
+    evaluateGrinValue hint (exprRuntimeRep expr) value continuation
+
+evaluateGrinValue :: Text -> RuntimeRep -> GrinValue -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+evaluateGrinValue hint runtimeRep value continuation
+  | isLiftedRuntimeRep runtimeRep = do
+      evaluated <- freshVar (hint <> "_whnf") runtimeRep
+      rest <- continuation (GrinVarValue evaluated)
+      pure (bindExpr [evaluated] (GrinEval runtimeRep value) rest)
+  | otherwise = continuation value
+
+-- | Keep a catch handler lazy until an exception is raised while still making
+-- every function entry explicit. The wrapper is already in WHNF; when called,
+-- it evaluates the captured handler and the action returned by that handler
+-- before either value is applied.
+lowerCatchHandler :: FcExpr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerCatchHandler handler continuation =
+  lowerSingleArgument handler $ \handlerValue -> do
+    let handlerRep = exprRuntimeRep handler
+        actionRep = applicationResultRep handler
+        exceptionRep = functionArgumentRep handler
+    capturedHandler <- freshVar "catch_handler" handlerRep
+    exception <- freshVar "catch_exception" exceptionRep
+    evaluatedHandler <- freshVar "catch_handler_whnf" handlerRep
+    actionPointer <- freshVar "catch_handler_action" actionRep
+    wrapperName <- freshFunction "catch_handler"
+    emitFunction
+      GrinFunction
+        { grinFunctionName = wrapperName,
+          grinFunctionLinkName = Nothing,
+          grinFunctionParameters = [capturedHandler, exception],
+          grinFunctionResultRep = actionRep,
+          grinFunctionBody =
+            bindExpr [evaluatedHandler] (GrinEval handlerRep (GrinVarValue capturedHandler)) $
+              bindExpr
+                [actionPointer]
+                (GrinApply actionRep (GrinVarValue evaluatedHandler) [GrinVarValue exception])
+                (GrinEval actionRep (GrinVarValue actionPointer))
+        }
+    wrapperPointer <- freshVar "catch_handler_wrapper" liftedRuntimeRep
+    evaluatedWrapper <- freshVar "catch_handler_wrapper_whnf" liftedRuntimeRep
+    rest <- continuation (GrinVarValue evaluatedWrapper)
+    pure $
+      bindExpr
+        [wrapperPointer]
+        (GrinStore (GrinNode (GrinClosure wrapperName 1) [handlerValue]))
+        (bindExpr [evaluatedWrapper] (GrinEval liftedRuntimeRep (GrinVarValue wrapperPointer)) rest)
 
 lowerDelayed :: FcExpr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
 lowerDelayed expr continuation = do
@@ -1183,6 +1237,18 @@ applicationResultRep function =
         TcFunTy _ result -> Just result
         TcQualTy [] body -> functionResultType body
         TcQualTy (_ : predicates) body -> Just (if null predicates then body else TcQualTy predicates body)
+        _ -> Nothing
+
+functionArgumentRep :: FcExpr -> RuntimeRep
+functionArgumentRep function =
+  case exprType function >>= functionArgumentType of
+    Just argument -> typeRuntimeRep argument
+    Nothing -> error ("GRIN lowering could not determine function argument type: " <> show function)
+  where
+    functionArgumentType functionType =
+      case functionType of
+        TcFunTy argument _ -> Just argument
+        TcQualTy [] body -> functionArgumentType body
         _ -> Nothing
 
 programVars :: FcProgram -> [Var]

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -118,8 +118,10 @@ data GrinExpr
     GrinCall !RuntimeRep !FunctionName ![GrinValue]
   | -- | A saturated call to a statically known primitive entry.
     GrinPrimitiveCall !RuntimeRep !Text ![GrinValue]
-  | GrinApply !RuntimeRep !GrinValue ![GrinValue]
-  | GrinCase !GrinValue !GrinVar ![GrinAlt]
+  | -- | Apply a function that is already in weak-head normal form.
+    GrinApply !RuntimeRep !GrinValue ![GrinValue]
+  | -- | Match a value that is already in weak-head normal form.
+    GrinCase !GrinValue !GrinVar ![GrinAlt]
   | GrinThrow !GrinValue
   | GrinCatch !RuntimeRep !GrinValue !GrinValue ![GrinValue]
   | -- | A saturated call whose operands are already strict primitive values.

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -15,6 +15,7 @@ import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Control.Monad (forM_)
 import Data.List (isInfixOf)
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import GrinGolden qualified
@@ -61,6 +62,19 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "does not allocate a constructor argument thunk" (not ("store (F$grin_thunk" `isInfixOf` rendered))
         assertBool "contains explicit application" ("apply " `isInfixOf` rendered),
+      testCase "FC lowering evaluates case and apply operands explicitly" $ do
+        let caseProgram = lowerProgram dictionaryProgram
+            applyProgram = lowerProgram applicationProgram
+        assertEqual "case lint" [] (lintProgram caseProgram)
+        assertEqual "apply lint" [] (lintProgram applyProgram)
+        assertBool "case operand is produced by eval" (any (containsExplicitOperand GrinCaseOperand) (grinFunctions caseProgram))
+        assertBool "apply operand is produced by eval" (any (containsExplicitOperand GrinApplyOperand) (grinFunctions applyProgram)),
+      testCase "interpreter case does not evaluate its operand" $ do
+        result <- interpretProgramBinding "answer" implicitCaseEvaluationProgram
+        assertEqual "result" (Left (InterpretNoMatchingAlternative (RuntimeLocation 1))) result,
+      testCase "interpreter apply does not evaluate its operand" $ do
+        result <- interpretProgramBinding "answer" implicitApplyEvaluationProgram
+        assertEqual "result" (Left (InterpretApplyNonFunction (RuntimeLocation 1))) result,
       testCase "interpreter implements fetch and update" $ do
         result <- interpretProgramBinding "answer" heapProgram
         assertEqual "result" (Right "Box 2") result,
@@ -97,6 +111,7 @@ grinUnitTests =
             rendered = renderProgram program
         assertEqual "transformed lint" [] (lintProgram program)
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
+        assertBool "evaluates a continuation closure explicitly" ("eval @(BoxedRep Lifted) ($cps_continuation_pointer" `isInfixOf` rendered)
         assertBool "invokes a continuation closure" ("apply @(BoxedRep Lifted) ($cps_continuation" `isInfixOf` rendered)
         assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
       testCase "CPS-GRIN preserves evaluation semantics" $ do
@@ -292,6 +307,32 @@ continuationHasCaptures :: GrinFunction -> Bool
 continuationHasCaptures function =
   "$cps$" `T.isInfixOf` unFunctionName (grinFunctionName function)
     && length (grinFunctionParameters function) > 1
+
+data ExplicitOperand
+  = GrinCaseOperand
+  | GrinApplyOperand
+  deriving (Eq)
+
+containsExplicitOperand :: ExplicitOperand -> GrinFunction -> Bool
+containsExplicitOperand operand = go Set.empty . grinFunctionBody
+  where
+    go evaluated expression =
+      case expression of
+        GrinBind vars value body ->
+          go evaluated value
+            || go (recordEvaluation evaluated vars value) body
+        GrinStoreRec _ body -> go evaluated body
+        GrinApply _ (GrinVarValue function) _ ->
+          operand == GrinApplyOperand && function `Set.member` evaluated
+        GrinCase (GrinVarValue scrutinee) _ alternatives ->
+          (operand == GrinCaseOperand && scrutinee `Set.member` evaluated)
+            || any (go evaluated . grinAltRhs) alternatives
+        GrinCase _ _ alternatives -> any (go evaluated . grinAltRhs) alternatives
+        _ -> False
+    recordEvaluation evaluated vars value =
+      case (vars, value) of
+        ([var], GrinEval {}) -> Set.insert var evaluated
+        _ -> evaluated `Set.difference` Set.fromList vars
 
 grinGoldenTests :: IO TestTree
 grinGoldenTests =
@@ -659,6 +700,78 @@ heapProgram =
     updated = GrinVar "updated" 6 (BoxedRep Lifted)
     replacementBox = GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 2)]
     functionName = FunctionName "answer_code"
+
+implicitCaseEvaluationProgram :: GrinProgram
+implicitCaseEvaluationProgram =
+  implicitEvaluationProgram $
+    GrinCase
+      (GrinVarValue implicitPointer)
+      implicitValue
+      [ GrinAlt
+          (GrinDataAlt "Box")
+          [implicitField]
+          (GrinConstant [GrinVarValue implicitValue])
+      ]
+
+implicitApplyEvaluationProgram :: GrinProgram
+implicitApplyEvaluationProgram =
+  implicitEvaluationProgram $
+    GrinApply
+      (BoxedRep Lifted)
+      (GrinVarValue implicitPointer)
+      []
+
+implicitEvaluationProgram :: GrinExpr -> GrinProgram
+implicitEvaluationProgram operation =
+  GrinProgram
+    { grinConstructors = [("Box", [IntRep])],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [],
+      grinCafs = [(implicitAnswer, GrinNode (GrinThunk implicitAnswerFunction) [])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = implicitAnswerFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [implicitPointer]
+                  (GrinStore (GrinNode (GrinThunk implicitValueFunction) []))
+                  operation
+            },
+          GrinFunction
+            { grinFunctionName = implicitValueFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinStore
+                  (GrinNode (GrinConstructor "Box") [GrinLitValue (GrinLitInt IntRep 1)])
+            }
+        ]
+    }
+
+implicitAnswer :: GrinVar
+implicitAnswer = GrinVar "answer" 100 (BoxedRep Lifted)
+
+implicitPointer :: GrinVar
+implicitPointer = GrinVar "pointer" 101 (BoxedRep Lifted)
+
+implicitValue :: GrinVar
+implicitValue = GrinVar "value" 102 (BoxedRep Lifted)
+
+implicitField :: GrinVar
+implicitField = GrinVar "field" 103 IntRep
+
+implicitAnswerFunction :: FunctionName
+implicitAnswerFunction = FunctionName "implicit_answer"
+
+implicitValueFunction :: FunctionName
+implicitValueFunction = FunctionName "implicit_value"
 
 exceptionBoundaryProgram :: GrinExpr -> GrinProgram
 exceptionBoundaryProgram body =

--- a/test/Test/Fixtures/eval/exception-catch-lazy-handler.yaml
+++ b/test/Test/Fixtures/eval/exception-catch-lazy-handler.yaml
@@ -1,0 +1,29 @@
+extensions:
+  - EmptyDataDecls
+  - MagicHash
+  - UnboxedTuples
+modules:
+  - |
+    module Test where
+    data State# s
+    data RealWorld
+
+    foreign import prim raise# :: a -> b
+    foreign import prim catch# ::
+      (State# RealWorld -> (# State# RealWorld, a #)) ->
+      (b -> State# RealWorld -> (# State# RealWorld, a #)) ->
+      State# RealWorld ->
+      (# State# RealWorld, a #)
+    foreign import prim realWorld# :: State# RealWorld
+
+    successful :: State# RealWorld -> (# State# RealWorld, Int# #)
+    successful s = (# s, 42# #)
+    failingHandler :: Int# -> State# RealWorld -> (# State# RealWorld, Int# #)
+    failingHandler = raise# 99#
+output: |
+  42
+expression: |
+  case catch# successful failingHandler realWorld# of
+    (# _, x #) -> x
+status: pass
+reason: catch# does not evaluate its handler unless the protected action raises


### PR DESCRIPTION
## Summary

- emit explicit `GrinEval` operations before lifted case scrutinees and function applications
- explicitly enter CPS-generated continuation closures before applying them
- make the reference interpreter, ARM64 case lowering, and native apply runtime consume operands without evaluating them
- preserve lazy catch handlers with an explicit-evaluation wrapper
- document and test the WHNF preconditions of `GrinCase` and `GrinApply`

## Root cause

FC-to-GRIN lowering delegated evaluation to `case` and `apply`. The reference interpreter and native backend implemented the same implicit-forcing behavior, so internally generated programs appeared correct even though the rendered GRIN omitted the operation that converts a heap location to WHNF.

## Impact

Generated GRIN now represents evaluation faithfully. Semantics-correct GRIN consumers no longer need hidden thunk entry in case dispatch or function application, and malformed raw `case`/`apply` operands are exposed instead of silently repaired.

## Progress counts

- +1 passing shared evaluation fixture
- +3 focused GRIN unit tests
- +1 ARM64 unit test

README progress counts are intentionally unchanged; they are cron-managed.

## Validation

- `just fmt`
- `just check`
- focused `aihc-fc`, `aihc-grin`, and `aihc-arm64` suites
- native ARM64 Hello World execution
