### PR TITLE
feat(grin): add native heap snapshot tests

### DIFF
--- a/components/aihc-arm64/aihc-arm64.cabal
+++ b/components/aihc-arm64/aihc-arm64.cabal
@@ -10,6 +10,8 @@ category: Development
 synopsis: Native AArch64 backend for AIHC GRIN
 data-files:
   runtime/aihc_runtime.c
+  runtime/aihc_runtime.h
+  runtime/aihc_snapshot.c
 
 library
   exposed-modules:
@@ -42,6 +44,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
     Aihc.Testing.EvalFixture
+    Aihc.Testing.GrinProgram
     Test.Arm64.Suite
 
   build-depends:

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -10,10 +10,6 @@ enum {
   AIHC_CONT_FINAL = 3,
 };
 
-enum {
-  AIHC_PRIM_REAL_WORLD = 1,
-};
-
 typedef struct AihcContinuation AihcContinuation;
 
 struct AihcContinuation {
@@ -77,7 +73,6 @@ static uintptr_t aihc_make_header(uint64_t tag, uintptr_t info) {
     return info | tag;
   case AIHC_TAG_NODE:
   case AIHC_TAG_PARTIAL_CONSTRUCTOR:
-  case AIHC_TAG_PRIMITIVE:
     return (info << AIHC_TAG_BITS) | tag;
   default:
     aihc_fail("attempted to allocate an invalid object tag");
@@ -95,10 +90,7 @@ static AihcSlot aihc_make_shape(uint64_t arity, uint64_t count) {
 AihcValue *aihc_make_node(uint64_t tag, uintptr_t info, uint64_t arity,
                           uint64_t count) {
   uint64_t shape_words =
-      tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_PARTIAL_CONSTRUCTOR ||
-              tag == AIHC_TAG_PRIMITIVE
-          ? 1
-          : 0;
+      tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_PARTIAL_CONSTRUCTOR ? 1 : 0;
   uint64_t object_words = 1 + shape_words + count;
   if (object_words < 2) {
     object_words = 2;
@@ -224,9 +216,6 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
     aihc_return_value(machine, (AihcSlot)applied);
     return;
   }
-  case AIHC_TAG_PRIMITIVE:
-    aihc_fail("primitive is not implemented by the native runtime");
-    return;
   default:
     aihc_fail("attempted to apply a non-function value");
   }
@@ -261,14 +250,6 @@ static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
     aihc_fail("blackholed thunk re-entered");
   default:
     break;
-  }
-  if (aihc_value_tag(value) == AIHC_TAG_PRIMITIVE &&
-      aihc_value_arity(value) == 0) {
-    if (aihc_value_info(value) == AIHC_PRIM_REAL_WORLD) {
-      aihc_return_value(machine, 0);
-      return;
-    }
-    aihc_fail("unknown zero-arity primitive");
   }
   aihc_return_value(machine, (AihcSlot)value);
 }

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -1,22 +1,7 @@
-#include <stdint.h>
+#include "aihc_runtime.h"
+
 #include <stdio.h>
 #include <stdlib.h>
-
-enum {
-  AIHC_LITERAL_INT = 0,
-  AIHC_CONSTRUCTOR = 1,
-  AIHC_CLOSURE = 2,
-  AIHC_THUNK = 3,
-  AIHC_PRIMITIVE = 4,
-  AIHC_CELL = 5,
-  AIHC_STATE_TOKEN = 6,
-};
-
-enum {
-  AIHC_CELL_SUSPENDED = 0,
-  AIHC_CELL_VALUE = 1,
-  AIHC_CELL_BLACKHOLE = 2,
-};
 
 enum {
   AIHC_CONT_NORMAL = 0,
@@ -30,19 +15,7 @@ enum {
   AIHC_PRIM_REAL_WORLD = 1,
 };
 
-typedef struct AihcValue AihcValue;
 typedef struct AihcContinuation AihcContinuation;
-/* Every runtime location is one machine word. Static RuntimeRep metadata says
- * whether that word is a heap pointer or an unboxed payload. */
-typedef uintptr_t AihcSlot;
-
-struct AihcValue {
-  uint64_t kind;
-  uintptr_t info;
-  uint64_t arity;
-  uint64_t count;
-  AihcSlot fields[];
-};
 
 struct AihcContinuation {
   uint64_t kind;

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -27,7 +27,7 @@ struct AihcContinuation {
       uint64_t count;
     } normal;
     struct {
-      AihcValue *cell;
+      AihcValue *object;
     } update;
   } payload;
 };
@@ -67,19 +67,67 @@ static AihcContinuation *aihc_push_special(AihcMachine *machine,
   return continuation;
 }
 
-static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t count,
+static uintptr_t aihc_make_header(uint64_t tag, uintptr_t info) {
+  switch (tag) {
+  case AIHC_TAG_CLOSURE:
+  case AIHC_TAG_THUNK:
+    if ((info & AIHC_TAG_MASK) != 0) {
+      aihc_fail("function entry is not aligned for pointer tagging");
+    }
+    return info | tag;
+  case AIHC_TAG_NODE:
+  case AIHC_TAG_PARTIAL_CONSTRUCTOR:
+  case AIHC_TAG_PRIMITIVE:
+    return (info << AIHC_TAG_BITS) | tag;
+  default:
+    aihc_fail("attempted to allocate an invalid object tag");
+  }
+  return 0;
+}
+
+static AihcSlot aihc_make_shape(uint64_t arity, uint64_t count) {
+  if (arity > UINT32_MAX || count > UINT32_MAX) {
+    aihc_fail("object shape exceeds 32-bit limits");
+  }
+  return (arity << AIHC_SHAPE_ARITY_SHIFT) | count;
+}
+
+AihcValue *aihc_make_node(uint64_t tag, uintptr_t info, uint64_t arity,
+                          uint64_t count) {
+  uint64_t shape_words =
+      tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_PARTIAL_CONSTRUCTOR ||
+              tag == AIHC_TAG_PRIMITIVE
+          ? 1
+          : 0;
+  uint64_t object_words = 1 + shape_words + count;
+  if (object_words < 2) {
+    object_words = 2;
+  }
+  AihcValue *value = aihc_allocate(sizeof(AihcSlot) * object_words);
+  value->header = aihc_make_header(tag, info);
+  if (shape_words != 0) {
+    value->fields[0] = aihc_make_shape(arity, count);
+  } else if (arity != 0) {
+    aihc_fail("only partial applications may carry dynamic arity");
+  }
+  return value;
+}
+
+static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t result_tag,
+                                        uint64_t result_arity,
+                                        uint64_t count,
                                         const AihcSlot *fields) {
-  AihcValue *copy = aihc_allocate(
-      sizeof(*copy) + sizeof(AihcSlot) * (value->count + count));
-  copy->kind = value->kind;
-  copy->info = value->info;
-  copy->arity = value->arity;
-  copy->count = value->count + count;
-  for (uint64_t index = 0; index < value->count; ++index) {
-    copy->fields[index] = value->fields[index];
+  uint64_t original_count = aihc_value_count(value);
+  AihcValue *copy =
+      aihc_make_node(result_tag, aihc_value_info(value), result_arity,
+                     original_count + count);
+  AihcSlot *original_fields = aihc_value_fields(value);
+  AihcSlot *copy_fields = aihc_value_fields(copy);
+  for (uint64_t index = 0; index < original_count; ++index) {
+    copy_fields[index] = original_fields[index];
   }
   for (uint64_t index = 0; index < count; ++index) {
-    copy->fields[value->count + index] = fields[index];
+    copy_fields[original_count + index] = fields[index];
   }
   return copy;
 }
@@ -87,14 +135,16 @@ static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t count,
 static AihcSlot *aihc_arguments_with_fields(AihcValue *function,
                                              uint64_t count,
                                              const AihcSlot *fields) {
-  uint64_t total = function->count + count;
+  uint64_t field_count = aihc_value_count(function);
+  uint64_t total = field_count + count;
   AihcSlot *arguments =
       aihc_allocate(sizeof(*arguments) * (total == 0 ? 1 : total));
-  for (uint64_t index = 0; index < function->count; ++index) {
-    arguments[index] = function->fields[index];
+  AihcSlot *function_fields = aihc_value_fields(function);
+  for (uint64_t index = 0; index < field_count; ++index) {
+    arguments[index] = function_fields[index];
   }
   for (uint64_t index = 0; index < count; ++index) {
-    arguments[function->count + index] = fields[index];
+    arguments[field_count + index] = fields[index];
   }
   return arguments;
 }
@@ -105,34 +155,8 @@ static void aihc_return_value(AihcMachine *machine, AihcSlot value);
 static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
                             uint64_t result_is_lifted);
 
-AihcValue *aihc_make_node(uint64_t kind, uintptr_t info, uint64_t arity,
-                          uint64_t count) {
-  AihcValue *value = aihc_allocate(sizeof(*value) + sizeof(AihcSlot) * count);
-  value->kind = kind;
-  value->info = info;
-  value->arity = arity;
-  value->count = count;
-  return value;
-}
-
-AihcValue *aihc_make_cell(void) {
-  return aihc_make_node(AIHC_CELL, AIHC_CELL_SUSPENDED, 1, 1);
-}
-
 void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field) {
-  if (index >= value->count) {
-    aihc_fail("field index out of bounds");
-  }
-  value->fields[index] = field;
-}
-
-void aihc_set_cell(AihcValue *cell, AihcValue *value) {
-  if (cell->kind != AIHC_CELL) {
-    aihc_fail("attempted to initialize a non-cell");
-  }
-  cell->info =
-      value->kind == AIHC_THUNK ? AIHC_CELL_SUSPENDED : AIHC_CELL_VALUE;
-  cell->fields[0] = (AihcSlot)value;
+  aihc_value_fields(value)[index] = field;
 }
 
 AihcMachine *aihc_machine_new(uint64_t global_count) {
@@ -158,7 +182,7 @@ void aihc_push_normal(AihcMachine *machine, void *code, AihcSlot *locals,
 
 static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
                                    AihcSlot *arguments) {
-  machine->next = (void *)function->info;
+  machine->next = (void *)aihc_value_info(function);
   machine->args = arguments;
   machine->locals = NULL;
 }
@@ -166,36 +190,41 @@ static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
 static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
                               uint64_t count,
                               const AihcSlot *arguments) {
-  switch (function->kind) {
-  case AIHC_CLOSURE:
-    if (function->arity > 1) {
-      AihcValue *applied = aihc_copy_with_fields(function, count, arguments);
-      applied->arity -= 1;
+  switch (aihc_value_tag(function)) {
+  case AIHC_TAG_CLOSURE: {
+    uint64_t arity = aihc_value_arity(function);
+    if (arity > 1) {
+      AihcValue *applied = aihc_copy_with_fields(
+          function, AIHC_TAG_CLOSURE, arity - 1, count, arguments);
       aihc_return_value(machine, (AihcSlot)applied);
       return;
     }
-    if (function->arity == 0) {
+    if (arity == 0) {
       aihc_fail("saturated closure was applied");
     }
     aihc_schedule_function(machine, function,
                            aihc_arguments_with_fields(function, count,
                                                       arguments));
     return;
-  case AIHC_CONSTRUCTOR: {
-    AihcValue *applied = aihc_copy_with_fields(function, count, arguments);
-    if (function->arity > 1) {
-      applied->arity -= 1;
+  }
+  case AIHC_TAG_PARTIAL_CONSTRUCTOR: {
+    uint64_t arity = aihc_value_arity(function);
+    if (arity > 1) {
+      AihcValue *applied = aihc_copy_with_fields(
+          function, AIHC_TAG_PARTIAL_CONSTRUCTOR, arity - 1, count,
+          arguments);
       aihc_return_value(machine, (AihcSlot)applied);
       return;
     }
-    if (function->arity == 0) {
+    if (arity == 0) {
       aihc_fail("saturated constructor was applied");
     }
-    applied->arity = 0;
+    AihcValue *applied = aihc_copy_with_fields(
+        function, AIHC_TAG_NODE, 0, count, arguments);
     aihc_return_value(machine, (AihcSlot)applied);
     return;
   }
-  case AIHC_PRIMITIVE:
+  case AIHC_TAG_PRIMITIVE:
     aihc_fail("primitive is not implemented by the native runtime");
     return;
   default:
@@ -208,35 +237,34 @@ static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
   if (value == NULL) {
     aihc_fail("attempted to evaluate null");
   }
-  if (value->kind == AIHC_CELL) {
-    switch (value->info) {
-    case AIHC_CELL_SUSPENDED: {
-      AihcValue *thunk = (AihcValue *)value->fields[0];
-      if (thunk == NULL || thunk->kind != AIHC_THUNK) {
-        aihc_fail("suspended cell does not contain a thunk");
-      }
-      value->info = AIHC_CELL_BLACKHOLE;
-      AihcContinuation *continuation =
-          aihc_push_special(machine, AIHC_CONT_UPDATE);
-      continuation->payload.update.cell = value;
-      aihc_schedule_function(machine, thunk, thunk->fields);
-      return;
-    }
-    case AIHC_CELL_VALUE:
-      if (result_is_lifted) {
-        aihc_eval_value(machine, (AihcValue *)value->fields[0], 1);
-      } else {
-        aihc_return_value(machine, value->fields[0]);
-      }
-      return;
-    case AIHC_CELL_BLACKHOLE:
-      aihc_fail("blackholed thunk re-entered");
-    default:
-      aihc_fail("unknown cell state");
-    }
+  switch (aihc_value_tag(value)) {
+  case AIHC_TAG_THUNK: {
+    uintptr_t entry = aihc_value_info(value);
+    AihcSlot *arguments = aihc_value_fields(value);
+    value->header = AIHC_TAG_BLACKHOLE;
+    AihcContinuation *continuation =
+        aihc_push_special(machine, AIHC_CONT_UPDATE);
+    continuation->payload.update.object = value;
+    machine->next = (void *)entry;
+    machine->args = arguments;
+    machine->locals = NULL;
+    return;
   }
-  if (value->kind == AIHC_PRIMITIVE && value->arity == 0) {
-    if (value->info == AIHC_PRIM_REAL_WORLD) {
+  case AIHC_TAG_INDIRECTION:
+    if (result_is_lifted) {
+      aihc_eval_value(machine, (AihcValue *)value->fields[0], 1);
+    } else {
+      aihc_return_value(machine, value->fields[0]);
+    }
+    return;
+  case AIHC_TAG_BLACKHOLE:
+    aihc_fail("blackholed thunk re-entered");
+  default:
+    break;
+  }
+  if (aihc_value_tag(value) == AIHC_TAG_PRIMITIVE &&
+      aihc_value_arity(value) == 0) {
+    if (aihc_value_info(value) == AIHC_PRIM_REAL_WORLD) {
       aihc_return_value(machine, 0);
       return;
     }
@@ -274,11 +302,10 @@ static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
     if (count != 1) {
       aihc_fail("attempted to update a thunk with multiple values");
     }
-    continuation->payload.update.cell->info = AIHC_CELL_VALUE;
-    continuation->payload.update.cell->fields[0] = values[0];
-    /* A stored constructor is itself represented by a value cell. Continue
-     * forcing the thunk result so the awaiting continuation receives the
-     * constructor node rather than that intermediate heap location. */
+    continuation->payload.update.object->fields[0] = values[0];
+    continuation->payload.update.object->header = AIHC_TAG_INDIRECTION;
+    /* Continue forcing through the freshly installed indirection so the
+     * awaiting continuation receives the result in weak-head normal form. */
     aihc_eval_value(machine, (AihcValue *)values[0], 1);
     return;
   case AIHC_CONT_TOP:

--- a/components/aihc-arm64/runtime/aihc_runtime.h
+++ b/components/aihc-arm64/runtime/aihc_runtime.h
@@ -4,31 +4,72 @@
 #include <stdint.h>
 
 enum {
-  AIHC_LITERAL_INT = 0,
-  AIHC_CONSTRUCTOR = 1,
-  AIHC_CLOSURE = 2,
-  AIHC_THUNK = 3,
-  AIHC_PRIMITIVE = 4,
-  AIHC_CELL = 5,
-  AIHC_STATE_TOKEN = 6,
+  AIHC_TAG_NODE = 0,
+  AIHC_TAG_CLOSURE = 1,
+  AIHC_TAG_THUNK = 2,
+  AIHC_TAG_PARTIAL_CONSTRUCTOR = 3,
+  AIHC_TAG_PRIMITIVE = 4,
+  AIHC_TAG_INDIRECTION = 5,
+  AIHC_TAG_BLACKHOLE = 6,
 };
 
-enum {
-  AIHC_CELL_SUSPENDED = 0,
-  AIHC_CELL_VALUE = 1,
-  AIHC_CELL_BLACKHOLE = 2,
-};
+#define AIHC_TAG_BITS 3
+#define AIHC_TAG_MASK ((uintptr_t)((1U << AIHC_TAG_BITS) - 1U))
+#define AIHC_SHAPE_ARITY_SHIFT 32
+#define AIHC_SHAPE_COUNT_MASK UINT32_MAX
 
 typedef struct AihcValue AihcValue;
 typedef uintptr_t AihcSlot;
 
 struct AihcValue {
-  uint64_t kind;
-  uintptr_t info;
-  uint64_t arity;
-  uint64_t count;
+  /* Low AIHC_TAG_BITS select the physical shape. Remaining bits carry info. */
+  uintptr_t header;
   AihcSlot fields[];
 };
+
+_Static_assert(sizeof(AihcValue) == sizeof(uintptr_t),
+               "AIHC objects must have a one-word base header");
+
+static inline uint64_t aihc_value_tag(const AihcValue *value) {
+  return value->header & AIHC_TAG_MASK;
+}
+
+static inline uintptr_t aihc_value_info(const AihcValue *value) {
+  switch (aihc_value_tag(value)) {
+  case AIHC_TAG_CLOSURE:
+  case AIHC_TAG_THUNK:
+    return value->header & ~AIHC_TAG_MASK;
+  case AIHC_TAG_NODE:
+  case AIHC_TAG_PARTIAL_CONSTRUCTOR:
+  case AIHC_TAG_PRIMITIVE:
+    return value->header >> AIHC_TAG_BITS;
+  default:
+    return 0;
+  }
+}
+
+static inline int aihc_value_has_shape(const AihcValue *value) {
+  uint64_t tag = aihc_value_tag(value);
+  return tag == AIHC_TAG_CLOSURE ||
+         tag == AIHC_TAG_PARTIAL_CONSTRUCTOR ||
+         tag == AIHC_TAG_PRIMITIVE;
+}
+
+static inline uint64_t aihc_value_arity(const AihcValue *value) {
+  return value->fields[0] >> AIHC_SHAPE_ARITY_SHIFT;
+}
+
+static inline uint64_t aihc_value_count(const AihcValue *value) {
+  return value->fields[0] & AIHC_SHAPE_COUNT_MASK;
+}
+
+static inline AihcSlot *aihc_value_fields(AihcValue *value) {
+  return value->fields + (aihc_value_has_shape(value) ? 1 : 0);
+}
+
+static inline const AihcSlot *aihc_value_fields_const(const AihcValue *value) {
+  return value->fields + (aihc_value_has_shape(value) ? 1 : 0);
+}
 
 typedef enum {
   AIHC_SNAPSHOT_POINTER,

--- a/components/aihc-arm64/runtime/aihc_runtime.h
+++ b/components/aihc-arm64/runtime/aihc_runtime.h
@@ -1,0 +1,71 @@
+#ifndef AIHC_RUNTIME_H
+#define AIHC_RUNTIME_H
+
+#include <stdint.h>
+
+enum {
+  AIHC_LITERAL_INT = 0,
+  AIHC_CONSTRUCTOR = 1,
+  AIHC_CLOSURE = 2,
+  AIHC_THUNK = 3,
+  AIHC_PRIMITIVE = 4,
+  AIHC_CELL = 5,
+  AIHC_STATE_TOKEN = 6,
+};
+
+enum {
+  AIHC_CELL_SUSPENDED = 0,
+  AIHC_CELL_VALUE = 1,
+  AIHC_CELL_BLACKHOLE = 2,
+};
+
+typedef struct AihcValue AihcValue;
+typedef uintptr_t AihcSlot;
+
+struct AihcValue {
+  uint64_t kind;
+  uintptr_t info;
+  uint64_t arity;
+  uint64_t count;
+  AihcSlot fields[];
+};
+
+typedef enum {
+  AIHC_SNAPSHOT_POINTER,
+  AIHC_SNAPSHOT_INT,
+  AIHC_SNAPSHOT_INT8,
+  AIHC_SNAPSHOT_INT16,
+  AIHC_SNAPSHOT_INT32,
+  AIHC_SNAPSHOT_INT64,
+  AIHC_SNAPSHOT_WORD,
+  AIHC_SNAPSHOT_WORD8,
+  AIHC_SNAPSHOT_WORD16,
+  AIHC_SNAPSHOT_WORD32,
+  AIHC_SNAPSHOT_WORD64,
+  AIHC_SNAPSHOT_ADDR,
+  AIHC_SNAPSHOT_FLOAT,
+  AIHC_SNAPSHOT_DOUBLE,
+} AihcSnapshotRep;
+
+typedef struct {
+  uintptr_t info;
+  const char *name;
+  uint64_t field_count;
+  const AihcSnapshotRep *field_reps;
+} AihcSnapshotConstructor;
+
+typedef struct {
+  uintptr_t info;
+  const char *name;
+  uint64_t parameter_count;
+  const AihcSnapshotRep *parameter_reps;
+} AihcSnapshotFunction;
+
+void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
+                        const AihcSnapshotRep *result_reps,
+                        uint64_t constructor_count,
+                        const AihcSnapshotConstructor *constructors,
+                        uint64_t function_count,
+                        const AihcSnapshotFunction *functions);
+
+#endif

--- a/components/aihc-arm64/runtime/aihc_runtime.h
+++ b/components/aihc-arm64/runtime/aihc_runtime.h
@@ -8,9 +8,8 @@ enum {
   AIHC_TAG_CLOSURE = 1,
   AIHC_TAG_THUNK = 2,
   AIHC_TAG_PARTIAL_CONSTRUCTOR = 3,
-  AIHC_TAG_PRIMITIVE = 4,
-  AIHC_TAG_INDIRECTION = 5,
-  AIHC_TAG_BLACKHOLE = 6,
+  AIHC_TAG_INDIRECTION = 4,
+  AIHC_TAG_BLACKHOLE = 5,
 };
 
 #define AIHC_TAG_BITS 3
@@ -41,7 +40,6 @@ static inline uintptr_t aihc_value_info(const AihcValue *value) {
     return value->header & ~AIHC_TAG_MASK;
   case AIHC_TAG_NODE:
   case AIHC_TAG_PARTIAL_CONSTRUCTOR:
-  case AIHC_TAG_PRIMITIVE:
     return value->header >> AIHC_TAG_BITS;
   default:
     return 0;
@@ -50,9 +48,7 @@ static inline uintptr_t aihc_value_info(const AihcValue *value) {
 
 static inline int aihc_value_has_shape(const AihcValue *value) {
   uint64_t tag = aihc_value_tag(value);
-  return tag == AIHC_TAG_CLOSURE ||
-         tag == AIHC_TAG_PARTIAL_CONSTRUCTOR ||
-         tag == AIHC_TAG_PRIMITIVE;
+  return tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_PARTIAL_CONSTRUCTOR;
 }
 
 static inline uint64_t aihc_value_arity(const AihcValue *value) {

--- a/components/aihc-arm64/runtime/aihc_snapshot.c
+++ b/components/aihc-arm64/runtime/aihc_snapshot.c
@@ -59,6 +59,28 @@ static uint64_t location_for_cell(SnapshotState *state, AihcValue *cell) {
   return location;
 }
 
+static int location_for_stored_value(const SnapshotState *state,
+                                     const AihcValue *value,
+                                     uint64_t *location) {
+  for (uint64_t index = 0; index < state->cell_count; ++index) {
+    AihcValue *cell = state->cells[index];
+    if (cell->info != AIHC_CELL_VALUE ||
+        (AihcValue *)cell->fields[0] != value) {
+      continue;
+    }
+    for (uint64_t owner_index = 0; owner_index < state->cell_count;
+         ++owner_index) {
+      AihcValue *owner = state->cells[owner_index];
+      if (owner->info == AIHC_CELL_VALUE &&
+          (AihcValue *)owner->fields[0] == cell) {
+        *location = index;
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
 static void print_scalar(AihcSlot value, AihcSnapshotRep rep) {
   union {
     uint32_t bits;
@@ -113,6 +135,84 @@ static void print_scalar(AihcSlot value, AihcSnapshotRep rep) {
 
 static void print_value(SnapshotState *state, AihcSlot slot,
                         AihcSnapshotRep rep, int nested);
+
+static void discover_value(SnapshotState *state, AihcSlot slot,
+                           AihcSnapshotRep rep);
+
+static void discover_fields(SnapshotState *state, const AihcValue *value,
+                            uint64_t rep_count,
+                            const AihcSnapshotRep *field_reps) {
+  if (value->count > rep_count) {
+    snapshot_fail("node contains more fields than its descriptor");
+  }
+  for (uint64_t index = 0; index < value->count; ++index) {
+    discover_value(state, value->fields[index], field_reps[index]);
+  }
+}
+
+static void discover_node(SnapshotState *state, const AihcValue *value) {
+  switch (value->kind) {
+  case AIHC_CONSTRUCTOR: {
+    const AihcSnapshotConstructor *constructor =
+        find_constructor(state, value->info);
+    if (constructor == NULL) {
+      snapshot_fail("constructor descriptor is missing");
+    }
+    discover_fields(state, value, constructor->field_count,
+                    constructor->field_reps);
+    return;
+  }
+  case AIHC_CLOSURE:
+  case AIHC_THUNK: {
+    const AihcSnapshotFunction *function = find_function(state, value->info);
+    if (function == NULL) {
+      snapshot_fail("function descriptor is missing");
+    }
+    discover_fields(state, value, function->parameter_count,
+                    function->parameter_reps);
+    return;
+  }
+  case AIHC_PRIMITIVE:
+    if (value->count != 0) {
+      snapshot_fail("captured primitive fields are not yet describable");
+    }
+    return;
+  case AIHC_STATE_TOKEN:
+  case AIHC_LITERAL_INT:
+    return;
+  case AIHC_CELL:
+    snapshot_fail("cell reached node discovery");
+  default:
+    snapshot_fail("unknown heap object kind");
+  }
+}
+
+static void discover_value(SnapshotState *state, AihcSlot slot,
+                           AihcSnapshotRep rep) {
+  if (rep != AIHC_SNAPSHOT_POINTER || slot == 0) {
+    return;
+  }
+  AihcValue *value = (AihcValue *)slot;
+  if (value->kind != AIHC_CELL) {
+    discover_node(state, value);
+    return;
+  }
+  uint64_t previous_count = state->cell_count;
+  location_for_cell(state, value);
+  if (state->cell_count == previous_count) {
+    return;
+  }
+  switch (value->info) {
+  case AIHC_CELL_SUSPENDED:
+  case AIHC_CELL_VALUE:
+    discover_value(state, value->fields[0], AIHC_SNAPSHOT_POINTER);
+    return;
+  case AIHC_CELL_BLACKHOLE:
+    return;
+  default:
+    snapshot_fail("unknown cell state");
+  }
+}
 
 static void print_fields(SnapshotState *state, const AihcValue *value,
                          uint64_t rep_count,
@@ -199,16 +299,36 @@ static void print_value(SnapshotState *state, AihcSlot slot,
   } else if (value->kind == AIHC_CELL) {
     printf("@%" PRIu64, location_for_cell(state, value));
   } else {
-    print_node(state, value, nested);
+    uint64_t location;
+    if (location_for_stored_value(state, value, &location)) {
+      printf("@%" PRIu64, location);
+    } else {
+      print_node(state, value, nested);
+    }
   }
 }
 
 static void print_cell(SnapshotState *state, AihcValue *cell) {
   switch (cell->info) {
-  case AIHC_CELL_SUSPENDED:
-  case AIHC_CELL_VALUE:
-    print_value(state, cell->fields[0], AIHC_SNAPSHOT_POINTER, 0);
+  case AIHC_CELL_SUSPENDED: {
+    AihcValue *value = (AihcValue *)cell->fields[0];
+    if (value == NULL || value->kind == AIHC_CELL) {
+      snapshot_fail("suspended cell does not contain a thunk");
+    }
+    print_node(state, value, 0);
     return;
+  }
+  case AIHC_CELL_VALUE: {
+    AihcValue *value = (AihcValue *)cell->fields[0];
+    if (value != NULL && value->kind == AIHC_CELL) {
+      printf("Indirection @%" PRIu64, location_for_cell(state, value));
+    } else if (value != NULL) {
+      print_node(state, value, 0);
+    } else {
+      fputs("<null>", stdout);
+    }
+    return;
+  }
   case AIHC_CELL_BLACKHOLE:
     fputs("<blackhole>", stdout);
     return;
@@ -229,6 +349,10 @@ void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
       .function_count = function_count,
       .functions = functions,
   };
+
+  for (uint64_t index = 0; index < result_count; ++index) {
+    discover_value(&state, results[index], result_reps[index]);
+  }
 
   fputs("return: ", stdout);
   if (result_count == 0) {

--- a/components/aihc-arm64/runtime/aihc_snapshot.c
+++ b/components/aihc-arm64/runtime/aihc_snapshot.c
@@ -1,0 +1,260 @@
+#include "aihc_runtime.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+  AihcValue **cells;
+  uint64_t cell_count;
+  uint64_t cell_capacity;
+  uint64_t constructor_count;
+  const AihcSnapshotConstructor *constructors;
+  uint64_t function_count;
+  const AihcSnapshotFunction *functions;
+} SnapshotState;
+
+static void snapshot_fail(const char *message) {
+  fprintf(stderr, "aihc snapshot: %s\n", message);
+  exit(1);
+}
+
+static const AihcSnapshotConstructor *find_constructor(
+    const SnapshotState *state, uintptr_t info) {
+  for (uint64_t index = 0; index < state->constructor_count; ++index) {
+    if (state->constructors[index].info == info) {
+      return &state->constructors[index];
+    }
+  }
+  return NULL;
+}
+
+static const AihcSnapshotFunction *find_function(const SnapshotState *state,
+                                                  uintptr_t info) {
+  for (uint64_t index = 0; index < state->function_count; ++index) {
+    if (state->functions[index].info == info) {
+      return &state->functions[index];
+    }
+  }
+  return NULL;
+}
+
+static uint64_t location_for_cell(SnapshotState *state, AihcValue *cell) {
+  for (uint64_t index = 0; index < state->cell_count; ++index) {
+    if (state->cells[index] == cell) {
+      return index;
+    }
+  }
+  if (state->cell_count == state->cell_capacity) {
+    uint64_t capacity = state->cell_capacity == 0 ? 8 : state->cell_capacity * 2;
+    AihcValue **cells = realloc(state->cells, sizeof(*cells) * capacity);
+    if (cells == NULL) {
+      snapshot_fail("out of memory");
+    }
+    state->cells = cells;
+    state->cell_capacity = capacity;
+  }
+  uint64_t location = state->cell_count++;
+  state->cells[location] = cell;
+  return location;
+}
+
+static void print_scalar(AihcSlot value, AihcSnapshotRep rep) {
+  union {
+    uint32_t bits;
+    float value;
+  } float_value = {.bits = (uint32_t)value};
+  union {
+    uint64_t bits;
+    double value;
+  } double_value = {.bits = (uint64_t)value};
+
+  switch (rep) {
+  case AIHC_SNAPSHOT_INT:
+  case AIHC_SNAPSHOT_INT64:
+    printf("%" PRId64, (int64_t)value);
+    return;
+  case AIHC_SNAPSHOT_INT8:
+    printf("%" PRId8, (int8_t)value);
+    return;
+  case AIHC_SNAPSHOT_INT16:
+    printf("%" PRId16, (int16_t)value);
+    return;
+  case AIHC_SNAPSHOT_INT32:
+    printf("%" PRId32, (int32_t)value);
+    return;
+  case AIHC_SNAPSHOT_WORD:
+  case AIHC_SNAPSHOT_WORD64:
+    printf("%" PRIu64, (uint64_t)value);
+    return;
+  case AIHC_SNAPSHOT_WORD8:
+    printf("%" PRIu8, (uint8_t)value);
+    return;
+  case AIHC_SNAPSHOT_WORD16:
+    printf("%" PRIu16, (uint16_t)value);
+    return;
+  case AIHC_SNAPSHOT_WORD32:
+    printf("%" PRIu32, (uint32_t)value);
+    return;
+  case AIHC_SNAPSHOT_ADDR:
+    printf("0x%" PRIxPTR, (uintptr_t)value);
+    return;
+  case AIHC_SNAPSHOT_FLOAT:
+    printf("%.9g", (double)float_value.value);
+    return;
+  case AIHC_SNAPSHOT_DOUBLE:
+    printf("%.17g", double_value.value);
+    return;
+  case AIHC_SNAPSHOT_POINTER:
+    snapshot_fail("attempted to print a pointer as a scalar");
+  }
+  snapshot_fail("unknown runtime representation");
+}
+
+static void print_value(SnapshotState *state, AihcSlot slot,
+                        AihcSnapshotRep rep, int nested);
+
+static void print_fields(SnapshotState *state, const AihcValue *value,
+                         uint64_t rep_count,
+                         const AihcSnapshotRep *field_reps) {
+  if (value->count > rep_count) {
+    snapshot_fail("node contains more fields than its descriptor");
+  }
+  for (uint64_t index = 0; index < value->count; ++index) {
+    putchar(' ');
+    print_value(state, value->fields[index], field_reps[index], 1);
+  }
+}
+
+static void print_node(SnapshotState *state, const AihcValue *value,
+                       int nested) {
+  int parenthesized = nested && value->count != 0;
+  if (parenthesized) {
+    putchar('(');
+  }
+  switch (value->kind) {
+  case AIHC_CONSTRUCTOR: {
+    const AihcSnapshotConstructor *constructor =
+        find_constructor(state, value->info);
+    if (constructor == NULL) {
+      snapshot_fail("constructor descriptor is missing");
+    }
+    printf("C%s", constructor->name);
+    print_fields(state, value, constructor->field_count,
+                 constructor->field_reps);
+    break;
+  }
+  case AIHC_CLOSURE: {
+    const AihcSnapshotFunction *function = find_function(state, value->info);
+    if (function == NULL) {
+      snapshot_fail("closure function descriptor is missing");
+    }
+    printf("P%s/%" PRIu64, function->name, value->arity);
+    print_fields(state, value, function->parameter_count,
+                 function->parameter_reps);
+    break;
+  }
+  case AIHC_THUNK: {
+    const AihcSnapshotFunction *function = find_function(state, value->info);
+    if (function == NULL) {
+      snapshot_fail("thunk function descriptor is missing");
+    }
+    printf("F%s", function->name);
+    print_fields(state, value, function->parameter_count,
+                 function->parameter_reps);
+    break;
+  }
+  case AIHC_PRIMITIVE:
+    printf("Prim[%" PRIuPTR "/%" PRIu64 "]", value->info, value->arity);
+    if (value->count != 0) {
+      snapshot_fail("captured primitive fields are not yet describable");
+    }
+    break;
+  case AIHC_STATE_TOKEN:
+    fputs("<state>", stdout);
+    break;
+  case AIHC_LITERAL_INT:
+    printf("%" PRIuPTR, value->info);
+    break;
+  case AIHC_CELL:
+    snapshot_fail("cell reached node printer");
+    break;
+  default:
+    snapshot_fail("unknown heap object kind");
+  }
+  if (parenthesized) {
+    putchar(')');
+  }
+}
+
+static void print_value(SnapshotState *state, AihcSlot slot,
+                        AihcSnapshotRep rep, int nested) {
+  if (rep != AIHC_SNAPSHOT_POINTER) {
+    print_scalar(slot, rep);
+    return;
+  }
+  AihcValue *value = (AihcValue *)slot;
+  if (value == NULL) {
+    fputs("<null>", stdout);
+  } else if (value->kind == AIHC_CELL) {
+    printf("@%" PRIu64, location_for_cell(state, value));
+  } else {
+    print_node(state, value, nested);
+  }
+}
+
+static void print_cell(SnapshotState *state, AihcValue *cell) {
+  switch (cell->info) {
+  case AIHC_CELL_SUSPENDED:
+  case AIHC_CELL_VALUE:
+    print_value(state, cell->fields[0], AIHC_SNAPSHOT_POINTER, 0);
+    return;
+  case AIHC_CELL_BLACKHOLE:
+    fputs("<blackhole>", stdout);
+    return;
+  default:
+    snapshot_fail("unknown cell state");
+  }
+}
+
+void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
+                        const AihcSnapshotRep *result_reps,
+                        uint64_t constructor_count,
+                        const AihcSnapshotConstructor *constructors,
+                        uint64_t function_count,
+                        const AihcSnapshotFunction *functions) {
+  SnapshotState state = {
+      .constructor_count = constructor_count,
+      .constructors = constructors,
+      .function_count = function_count,
+      .functions = functions,
+  };
+
+  fputs("return: ", stdout);
+  if (result_count == 0) {
+    fputs("()", stdout);
+  } else if (result_count == 1) {
+    print_value(&state, results[0], result_reps[0], 0);
+  } else {
+    putchar('(');
+    for (uint64_t index = 0; index < result_count; ++index) {
+      if (index != 0) {
+        fputs(", ", stdout);
+      }
+      print_value(&state, results[index], result_reps[index], 0);
+    }
+    putchar(')');
+  }
+
+  if (state.cell_count == 0) {
+    fputs("\nheap: []\n", stdout);
+  } else {
+    fputs("\nheap:\n", stdout);
+    for (uint64_t location = 0; location < state.cell_count; ++location) {
+      printf("  @%" PRIu64 " = ", location);
+      print_cell(&state, state.cells[location]);
+      putchar('\n');
+    }
+  }
+  free(state.cells);
+}

--- a/components/aihc-arm64/runtime/aihc_snapshot.c
+++ b/components/aihc-arm64/runtime/aihc_snapshot.c
@@ -163,11 +163,6 @@ static void discover_object(SnapshotState *state, AihcValue *object) {
                     function->parameter_count, function->parameter_reps);
     return;
   }
-  case AIHC_TAG_PRIMITIVE:
-    if (aihc_value_count(object) != 0) {
-      snapshot_fail("captured primitive fields are not yet describable");
-    }
-    return;
   case AIHC_TAG_INDIRECTION:
     discover_value(state, object->fields[0], AIHC_SNAPSHOT_POINTER);
     return;
@@ -252,13 +247,6 @@ static void print_object(SnapshotState *state, const AihcValue *object) {
                  function->parameter_count, function->parameter_reps);
     return;
   }
-  case AIHC_TAG_PRIMITIVE:
-    printf("Prim[%" PRIuPTR "/%" PRIu64 "]", aihc_value_info(object),
-           aihc_value_arity(object));
-    if (aihc_value_count(object) != 0) {
-      snapshot_fail("captured primitive fields are not yet describable");
-    }
-    return;
   case AIHC_TAG_INDIRECTION:
     fputs("Indirection ", stdout);
     print_value(state, object->fields[0], AIHC_SNAPSHOT_POINTER);

--- a/components/aihc-arm64/runtime/aihc_snapshot.c
+++ b/components/aihc-arm64/runtime/aihc_snapshot.c
@@ -5,9 +5,9 @@
 #include <stdlib.h>
 
 typedef struct {
-  AihcValue **cells;
-  uint64_t cell_count;
-  uint64_t cell_capacity;
+  AihcValue **objects;
+  uint64_t object_count;
+  uint64_t object_capacity;
   uint64_t constructor_count;
   const AihcSnapshotConstructor *constructors;
   uint64_t function_count;
@@ -39,46 +39,26 @@ static const AihcSnapshotFunction *find_function(const SnapshotState *state,
   return NULL;
 }
 
-static uint64_t location_for_cell(SnapshotState *state, AihcValue *cell) {
-  for (uint64_t index = 0; index < state->cell_count; ++index) {
-    if (state->cells[index] == cell) {
+static uint64_t location_for_object(SnapshotState *state, AihcValue *object) {
+  for (uint64_t index = 0; index < state->object_count; ++index) {
+    if (state->objects[index] == object) {
       return index;
     }
   }
-  if (state->cell_count == state->cell_capacity) {
-    uint64_t capacity = state->cell_capacity == 0 ? 8 : state->cell_capacity * 2;
-    AihcValue **cells = realloc(state->cells, sizeof(*cells) * capacity);
-    if (cells == NULL) {
+  if (state->object_count == state->object_capacity) {
+    uint64_t capacity =
+        state->object_capacity == 0 ? 8 : state->object_capacity * 2;
+    AihcValue **objects =
+        realloc(state->objects, sizeof(*objects) * capacity);
+    if (objects == NULL) {
       snapshot_fail("out of memory");
     }
-    state->cells = cells;
-    state->cell_capacity = capacity;
+    state->objects = objects;
+    state->object_capacity = capacity;
   }
-  uint64_t location = state->cell_count++;
-  state->cells[location] = cell;
+  uint64_t location = state->object_count++;
+  state->objects[location] = object;
   return location;
-}
-
-static int location_for_stored_value(const SnapshotState *state,
-                                     const AihcValue *value,
-                                     uint64_t *location) {
-  for (uint64_t index = 0; index < state->cell_count; ++index) {
-    AihcValue *cell = state->cells[index];
-    if (cell->info != AIHC_CELL_VALUE ||
-        (AihcValue *)cell->fields[0] != value) {
-      continue;
-    }
-    for (uint64_t owner_index = 0; owner_index < state->cell_count;
-         ++owner_index) {
-      AihcValue *owner = state->cells[owner_index];
-      if (owner->info == AIHC_CELL_VALUE &&
-          (AihcValue *)owner->fields[0] == cell) {
-        *location = index;
-        return 1;
-      }
-    }
-  }
-  return 0;
 }
 
 static void print_scalar(AihcSlot value, AihcSnapshotRep rep) {
@@ -133,207 +113,161 @@ static void print_scalar(AihcSlot value, AihcSnapshotRep rep) {
   snapshot_fail("unknown runtime representation");
 }
 
-static void print_value(SnapshotState *state, AihcSlot slot,
-                        AihcSnapshotRep rep, int nested);
-
 static void discover_value(SnapshotState *state, AihcSlot slot,
                            AihcSnapshotRep rep);
 
-static void discover_fields(SnapshotState *state, const AihcValue *value,
-                            uint64_t rep_count,
+static void discover_fields(SnapshotState *state, const AihcSlot *fields,
+                            uint64_t count, uint64_t rep_count,
                             const AihcSnapshotRep *field_reps) {
-  if (value->count > rep_count) {
+  if (count > rep_count) {
     snapshot_fail("node contains more fields than its descriptor");
   }
-  for (uint64_t index = 0; index < value->count; ++index) {
-    discover_value(state, value->fields[index], field_reps[index]);
+  for (uint64_t index = 0; index < count; ++index) {
+    discover_value(state, fields[index], field_reps[index]);
   }
 }
 
-static void discover_node(SnapshotState *state, const AihcValue *value) {
-  switch (value->kind) {
-  case AIHC_CONSTRUCTOR: {
+static void discover_object(SnapshotState *state, AihcValue *object) {
+  uint64_t previous_count = state->object_count;
+  location_for_object(state, object);
+  if (previous_count == state->object_count) {
+    return;
+  }
+
+  uint64_t tag = aihc_value_tag(object);
+  switch (tag) {
+  case AIHC_TAG_NODE:
+  case AIHC_TAG_PARTIAL_CONSTRUCTOR: {
     const AihcSnapshotConstructor *constructor =
-        find_constructor(state, value->info);
+        find_constructor(state, aihc_value_info(object));
     if (constructor == NULL) {
       snapshot_fail("constructor descriptor is missing");
     }
-    discover_fields(state, value, constructor->field_count,
-                    constructor->field_reps);
+    uint64_t count = tag == AIHC_TAG_NODE ? constructor->field_count
+                                          : aihc_value_count(object);
+    discover_fields(state, aihc_value_fields_const(object), count,
+                    constructor->field_count, constructor->field_reps);
     return;
   }
-  case AIHC_CLOSURE:
-  case AIHC_THUNK: {
-    const AihcSnapshotFunction *function = find_function(state, value->info);
+  case AIHC_TAG_CLOSURE:
+  case AIHC_TAG_THUNK: {
+    const AihcSnapshotFunction *function =
+        find_function(state, aihc_value_info(object));
     if (function == NULL) {
       snapshot_fail("function descriptor is missing");
     }
-    discover_fields(state, value, function->parameter_count,
-                    function->parameter_reps);
+    uint64_t count = tag == AIHC_TAG_CLOSURE
+                         ? aihc_value_count(object)
+                         : function->parameter_count;
+    discover_fields(state, aihc_value_fields_const(object), count,
+                    function->parameter_count, function->parameter_reps);
     return;
   }
-  case AIHC_PRIMITIVE:
-    if (value->count != 0) {
+  case AIHC_TAG_PRIMITIVE:
+    if (aihc_value_count(object) != 0) {
       snapshot_fail("captured primitive fields are not yet describable");
     }
     return;
-  case AIHC_STATE_TOKEN:
-  case AIHC_LITERAL_INT:
+  case AIHC_TAG_INDIRECTION:
+    discover_value(state, object->fields[0], AIHC_SNAPSHOT_POINTER);
     return;
-  case AIHC_CELL:
-    snapshot_fail("cell reached node discovery");
+  case AIHC_TAG_BLACKHOLE:
+    return;
   default:
-    snapshot_fail("unknown heap object kind");
+    snapshot_fail("unknown heap object tag");
   }
 }
 
 static void discover_value(SnapshotState *state, AihcSlot slot,
                            AihcSnapshotRep rep) {
-  if (rep != AIHC_SNAPSHOT_POINTER || slot == 0) {
-    return;
-  }
-  AihcValue *value = (AihcValue *)slot;
-  if (value->kind != AIHC_CELL) {
-    discover_node(state, value);
-    return;
-  }
-  uint64_t previous_count = state->cell_count;
-  location_for_cell(state, value);
-  if (state->cell_count == previous_count) {
-    return;
-  }
-  switch (value->info) {
-  case AIHC_CELL_SUSPENDED:
-  case AIHC_CELL_VALUE:
-    discover_value(state, value->fields[0], AIHC_SNAPSHOT_POINTER);
-    return;
-  case AIHC_CELL_BLACKHOLE:
-    return;
-  default:
-    snapshot_fail("unknown cell state");
-  }
-}
-
-static void print_fields(SnapshotState *state, const AihcValue *value,
-                         uint64_t rep_count,
-                         const AihcSnapshotRep *field_reps) {
-  if (value->count > rep_count) {
-    snapshot_fail("node contains more fields than its descriptor");
-  }
-  for (uint64_t index = 0; index < value->count; ++index) {
-    putchar(' ');
-    print_value(state, value->fields[index], field_reps[index], 1);
-  }
-}
-
-static void print_node(SnapshotState *state, const AihcValue *value,
-                       int nested) {
-  int parenthesized = nested && value->count != 0;
-  if (parenthesized) {
-    putchar('(');
-  }
-  switch (value->kind) {
-  case AIHC_CONSTRUCTOR: {
-    const AihcSnapshotConstructor *constructor =
-        find_constructor(state, value->info);
-    if (constructor == NULL) {
-      snapshot_fail("constructor descriptor is missing");
-    }
-    printf("C%s", constructor->name);
-    print_fields(state, value, constructor->field_count,
-                 constructor->field_reps);
-    break;
-  }
-  case AIHC_CLOSURE: {
-    const AihcSnapshotFunction *function = find_function(state, value->info);
-    if (function == NULL) {
-      snapshot_fail("closure function descriptor is missing");
-    }
-    printf("P%s/%" PRIu64, function->name, value->arity);
-    print_fields(state, value, function->parameter_count,
-                 function->parameter_reps);
-    break;
-  }
-  case AIHC_THUNK: {
-    const AihcSnapshotFunction *function = find_function(state, value->info);
-    if (function == NULL) {
-      snapshot_fail("thunk function descriptor is missing");
-    }
-    printf("F%s", function->name);
-    print_fields(state, value, function->parameter_count,
-                 function->parameter_reps);
-    break;
-  }
-  case AIHC_PRIMITIVE:
-    printf("Prim[%" PRIuPTR "/%" PRIu64 "]", value->info, value->arity);
-    if (value->count != 0) {
-      snapshot_fail("captured primitive fields are not yet describable");
-    }
-    break;
-  case AIHC_STATE_TOKEN:
-    fputs("<state>", stdout);
-    break;
-  case AIHC_LITERAL_INT:
-    printf("%" PRIuPTR, value->info);
-    break;
-  case AIHC_CELL:
-    snapshot_fail("cell reached node printer");
-    break;
-  default:
-    snapshot_fail("unknown heap object kind");
-  }
-  if (parenthesized) {
-    putchar(')');
+  if (rep == AIHC_SNAPSHOT_POINTER && slot != 0) {
+    discover_object(state, (AihcValue *)slot);
   }
 }
 
 static void print_value(SnapshotState *state, AihcSlot slot,
-                        AihcSnapshotRep rep, int nested) {
+                        AihcSnapshotRep rep) {
   if (rep != AIHC_SNAPSHOT_POINTER) {
     print_scalar(slot, rep);
     return;
   }
-  AihcValue *value = (AihcValue *)slot;
-  if (value == NULL) {
+  if (slot == 0) {
     fputs("<null>", stdout);
-  } else if (value->kind == AIHC_CELL) {
-    printf("@%" PRIu64, location_for_cell(state, value));
-  } else {
-    uint64_t location;
-    if (location_for_stored_value(state, value, &location)) {
-      printf("@%" PRIu64, location);
-    } else {
-      print_node(state, value, nested);
-    }
+    return;
+  }
+  printf("@%" PRIu64, location_for_object(state, (AihcValue *)slot));
+}
+
+static void print_fields(SnapshotState *state, const AihcSlot *fields,
+                         uint64_t count, uint64_t rep_count,
+                         const AihcSnapshotRep *field_reps) {
+  if (count > rep_count) {
+    snapshot_fail("node contains more fields than its descriptor");
+  }
+  for (uint64_t index = 0; index < count; ++index) {
+    putchar(' ');
+    print_value(state, fields[index], field_reps[index]);
   }
 }
 
-static void print_cell(SnapshotState *state, AihcValue *cell) {
-  switch (cell->info) {
-  case AIHC_CELL_SUSPENDED: {
-    AihcValue *value = (AihcValue *)cell->fields[0];
-    if (value == NULL || value->kind == AIHC_CELL) {
-      snapshot_fail("suspended cell does not contain a thunk");
+static void print_object(SnapshotState *state, const AihcValue *object) {
+  uint64_t tag = aihc_value_tag(object);
+  switch (tag) {
+  case AIHC_TAG_NODE:
+  case AIHC_TAG_PARTIAL_CONSTRUCTOR: {
+    const AihcSnapshotConstructor *constructor =
+        find_constructor(state, aihc_value_info(object));
+    if (constructor == NULL) {
+      snapshot_fail("constructor descriptor is missing");
     }
-    print_node(state, value, 0);
-    return;
-  }
-  case AIHC_CELL_VALUE: {
-    AihcValue *value = (AihcValue *)cell->fields[0];
-    if (value != NULL && value->kind == AIHC_CELL) {
-      printf("Indirection @%" PRIu64, location_for_cell(state, value));
-    } else if (value != NULL) {
-      print_node(state, value, 0);
+    fputs("C", stdout);
+    fputs(constructor->name, stdout);
+    uint64_t count;
+    if (tag == AIHC_TAG_PARTIAL_CONSTRUCTOR) {
+      printf("/%" PRIu64, aihc_value_arity(object));
+      count = aihc_value_count(object);
     } else {
-      fputs("<null>", stdout);
+      count = constructor->field_count;
     }
+    print_fields(state, aihc_value_fields_const(object), count,
+                 constructor->field_count, constructor->field_reps);
     return;
   }
-  case AIHC_CELL_BLACKHOLE:
+  case AIHC_TAG_CLOSURE:
+  case AIHC_TAG_THUNK: {
+    const AihcSnapshotFunction *function =
+        find_function(state, aihc_value_info(object));
+    if (function == NULL) {
+      snapshot_fail("function descriptor is missing");
+    }
+    uint64_t count;
+    if (tag == AIHC_TAG_CLOSURE) {
+      printf("P%s/%" PRIu64, function->name, aihc_value_arity(object));
+      count = aihc_value_count(object);
+    } else {
+      printf("F%s", function->name);
+      count = function->parameter_count;
+    }
+    print_fields(state, aihc_value_fields_const(object), count,
+                 function->parameter_count, function->parameter_reps);
+    return;
+  }
+  case AIHC_TAG_PRIMITIVE:
+    printf("Prim[%" PRIuPTR "/%" PRIu64 "]", aihc_value_info(object),
+           aihc_value_arity(object));
+    if (aihc_value_count(object) != 0) {
+      snapshot_fail("captured primitive fields are not yet describable");
+    }
+    return;
+  case AIHC_TAG_INDIRECTION:
+    fputs("Indirection ", stdout);
+    print_value(state, object->fields[0], AIHC_SNAPSHOT_POINTER);
+    return;
+  case AIHC_TAG_BLACKHOLE:
     fputs("<blackhole>", stdout);
     return;
   default:
-    snapshot_fail("unknown cell state");
+    snapshot_fail("unknown heap object tag");
   }
 }
 
@@ -358,27 +292,27 @@ void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
   if (result_count == 0) {
     fputs("()", stdout);
   } else if (result_count == 1) {
-    print_value(&state, results[0], result_reps[0], 0);
+    print_value(&state, results[0], result_reps[0]);
   } else {
     putchar('(');
     for (uint64_t index = 0; index < result_count; ++index) {
       if (index != 0) {
         fputs(", ", stdout);
       }
-      print_value(&state, results[index], result_reps[index], 0);
+      print_value(&state, results[index], result_reps[index]);
     }
     putchar(')');
   }
 
-  if (state.cell_count == 0) {
+  if (state.object_count == 0) {
     fputs("\nheap: []\n", stdout);
   } else {
     fputs("\nheap:\n", stdout);
-    for (uint64_t location = 0; location < state.cell_count; ++location) {
+    for (uint64_t location = 0; location < state.object_count; ++location) {
       printf("  @%" PRIu64 " = ", location);
-      print_cell(&state, state.cells[location]);
+      print_object(&state, state.objects[location]);
       putchar('\n');
     }
   }
-  free(state.cells);
+  free(state.objects);
 }

--- a/components/aihc-arm64/src/Aihc/Arm64.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64.hs
@@ -6,12 +6,15 @@ module Aihc.Arm64
     buildLinkLayout,
     buildLinkLayoutFromInterfaces,
     compileModule,
+    ObservedProgram (..),
+    compileObservedFunction,
     compileProgram,
     compileProgramWithDependencies,
     extendLinkLayout,
     extendLinkLayoutWithInterface,
     extractLinkInterface,
     runtimeSourcePath,
+    snapshotSourcePath,
     targetTriple,
     validateProgramPrimitives,
     validatePrimitiveNames,
@@ -22,9 +25,11 @@ import Aihc.Arm64.Codegen
   ( Arm64Error (..),
     LinkInterface,
     LinkLayout,
+    ObservedProgram (..),
     buildLinkLayout,
     buildLinkLayoutFromInterfaces,
     compileModule,
+    compileObservedFunction,
     compileProgram,
     compileProgramWithDependencies,
     extendLinkLayout,
@@ -38,6 +43,9 @@ import Paths_aihc_arm64 (getDataFileName)
 -- | Locate the C runtime used by generated assembly.
 runtimeSourcePath :: IO FilePath
 runtimeSourcePath = getDataFileName "runtime/aihc_runtime.c"
+
+snapshotSourcePath :: IO FilePath
+snapshotSourcePath = getDataFileName "runtime/aihc_snapshot.c"
 
 -- | LLVM target triple for the assembly emitted by this backend.
 targetTriple :: String

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -178,7 +178,7 @@ validateProgramPrimitives program =
   validatePrimitiveNames (map (grinVarName . fst) (grinPrimitives program))
 
 validatePrimitiveNames :: [Text] -> Either Arm64Error ()
-validatePrimitiveNames = mapM_ (primitiveIdentifier False)
+validatePrimitiveNames = mapM_ (validatePrimitiveName False)
 
 -- | Build the stable layout for a dependency closure in dependency order.
 buildLinkLayout :: [GrinProgram] -> LinkLayout
@@ -710,9 +710,6 @@ nodeHeader env node =
     GrinThunk functionName -> do
       label <- functionCodeLabel compileEnv functionName
       pure (runtimeTagThunk, InfoAddress label, 0)
-    GrinPrimitive name arity -> do
-      identifier <- primitiveId compileEnv name
-      pure (runtimeTagPrimitive, InfoImmediate identifier, arity)
   where
     compileEnv = valueCompileEnv env
 
@@ -734,12 +731,11 @@ makeNodeLines kind info arity count =
         InfoImmediate integer -> immediate "x1" integer
         InfoAddress label -> address "x1" label
 
-runtimeTagNode, runtimeTagClosure, runtimeTagThunk, runtimeTagPartialConstructor, runtimeTagPrimitive :: Int
+runtimeTagNode, runtimeTagClosure, runtimeTagThunk, runtimeTagPartialConstructor :: Int
 runtimeTagNode = 0
 runtimeTagClosure = 1
 runtimeTagThunk = 2
 runtimeTagPartialConstructor = 3
-runtimeTagPrimitive = 4
 
 loadVariable :: ValueEnv -> GrinVar -> Either Arm64Error [Text]
 loadVariable env var =
@@ -850,13 +846,10 @@ functionCodeLabel :: CompileEnv -> FunctionName -> Either Arm64Error Text
 functionCodeLabel env name =
   maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionLabels env))
 
-primitiveId :: CompileEnv -> Text -> Either Arm64Error Int
-primitiveId env = primitiveIdentifier (compileAllowUnsupportedPrimitives env)
-
-primitiveIdentifier :: Bool -> Text -> Either Arm64Error Int
-primitiveIdentifier allowUnsupported name
-  | name == "realWorld#" = Right 1
-  | allowUnsupported = Right 0
+validatePrimitiveName :: Bool -> Text -> Either Arm64Error ()
+validatePrimitiveName allowUnsupported name
+  | name == "realWorld#" = Right ()
+  | allowUnsupported = Right ()
   | otherwise = Left (Arm64UnsupportedPrimitive name)
 
 functionLocalSlots :: GrinFunction -> Map GrinVar Int

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -10,6 +10,8 @@ module Aihc.Arm64.Codegen
     buildLinkLayout,
     buildLinkLayoutFromInterfaces,
     compileModule,
+    ObservedProgram (..),
+    compileObservedFunction,
     compileProgram,
     compileProgramWithDependencies,
     extendLinkLayout,
@@ -54,8 +56,15 @@ data CompileEnv = CompileEnv
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
     compileFunctionArities :: !(Map FunctionName Int),
+    compileExposeAllFunctions :: !Bool,
     compileAllowUnsupportedPrimitives :: !Bool
   }
+
+data ObservedProgram = ObservedProgram
+  { observedAssembly :: !Text,
+    observedMetadataSource :: !Text
+  }
+  deriving (Eq, Show)
 
 -- | The process-wide constructor tags and global table slots shared by all
 -- native compilation units in one executable. Extending a dependency layout
@@ -98,6 +107,69 @@ compileProgram entryName cpsProgram =
   compileProgramWithDependencies (buildLinkLayout [program]) [] entryName cpsProgram
   where
     program = cpsGrinProgram cpsProgram
+
+-- | Compile a nullary function with a driver that snapshots its raw return
+-- values. The driver does not evaluate or apply any returned heap object.
+compileObservedFunction :: FunctionName -> CpsGrinProgram -> Either Arm64Error ObservedProgram
+compileObservedFunction entryName cpsProgram = do
+  mapM_ validateRuntimeRep (programRuntimeReps program)
+  validateProgramPrimitives program
+  entryFunction <-
+    maybe (Left (Arm64MissingFunction entryName)) Right $
+      findFunction entryName (grinFunctions program)
+  if null (grinFunctionParameters entryFunction)
+    then pure ()
+    else Left (Arm64UnsupportedExpression "observed entry function must be nullary")
+  entryLabel <- functionCodeLabel compileEnv entryName
+  constructorLines <- compileConstructorInitializers compileEnv
+  initLines <- compileInitializers compileEnv program
+  functions <- mapM (compileFunction compileEnv) (grinFunctions program)
+  metadata <- renderObservedMetadata compileEnv program resultReps
+  let resultCount = length resultReps
+      assembly =
+        T.unlines $
+          [ ".section __TEXT,__text,regular,pure_instructions",
+            ".p2align 2",
+            ".globl _main",
+            "_main:",
+            "  stp x29, x30, [sp, #-48]!",
+            "  mov x29, sp",
+            "  stp x19, x20, [sp, #16]",
+            "  stp x21, x22, [sp, #32]",
+            immediate "x0" (length globalNames),
+            "  bl _aihc_machine_new",
+            "  mov x22, x0"
+          ]
+            <> constructorLines
+            <> initLines
+            <> [ immediate "x0" (max 1 resultCount),
+                 "  bl _aihc_alloc_locals",
+                 "  mov x19, x0",
+                 "  str x19, [x22, #32]"
+               ]
+            <> pushNormalLines ".Laihc_snapshot_result" 0 resultCount
+            <> [ "  str xzr, [x22, #8]",
+                 "  b " <> entryLabel,
+                 ".Laihc_snapshot_result:",
+                 "  ldr x1, [x22, #32]",
+                 immediate "x0" resultCount,
+                 "  bl _aihc_snapshot_dump_result",
+                 "  mov w0, #0",
+                 "  ldp x21, x22, [sp, #32]",
+                 "  ldp x19, x20, [sp, #16]",
+                 "  ldp x29, x30, [sp], #48",
+                 "  ret"
+               ]
+            <> concat functions
+  pure ObservedProgram {observedAssembly = assembly, observedMetadataSource = metadata}
+  where
+    program = cpsGrinProgram cpsProgram
+    layout = buildLinkLayout [program]
+    compileEnv = compileEnvironmentWith True layout program
+    globalNames = linkGlobalNames layout
+    resultReps =
+      maybe [] (runtimeRepComponents . grinFunctionResultRep) $
+        findFunction entryName (grinFunctions program)
 
 -- | Reject primitives that reachable native code would not execute correctly.
 -- Relocatable library objects may carry dormant primitive declarations, but
@@ -230,7 +302,10 @@ programGlobalNames program =
     <> map (grinVarName . fst) (grinCafs program)
 
 compileEnvironment :: LinkLayout -> GrinProgram -> CompileEnv
-compileEnvironment layout program =
+compileEnvironment = compileEnvironmentWith False
+
+compileEnvironmentWith :: Bool -> LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironmentWith exposeAllFunctions layout program =
   CompileEnv
     { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
       compileConstructorArities = Map.fromList constructors,
@@ -240,7 +315,7 @@ compileEnvironment layout program =
           ( [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
             | info <- grinExternalFunctions program
             ]
-              <> [ (grinFunctionName function, localFunctionLabel index function)
+              <> [ (grinFunctionName function, localFunctionLabelWith exposeAllFunctions index function)
                  | (index, function) <- zip [0 ..] (grinFunctions program)
                  ]
           ),
@@ -253,6 +328,7 @@ compileEnvironment layout program =
                  | function <- grinFunctions program
                  ]
           ),
+      compileExposeAllFunctions = exposeAllFunctions,
       compileAllowUnsupportedPrimitives = False
     }
   where
@@ -306,7 +382,7 @@ compileFunction env function = do
     either (Left . Arm64EmitError) Right (renderAllocatedBlock spillBase (parameterCopyLir localSlots (grinFunctionParameters function)))
   let slotCount = max 1 (spillBase + spillCount)
       entry =
-        exportLines function label
+        exportLines env function label
           <> [ label <> ":",
                immediate "x0" slotCount,
                "  bl _aihc_alloc_locals",
@@ -319,11 +395,13 @@ compileFunction env function = do
       blocks = concatMap renderBlock (reverse (functionBlocksRev finalState))
   pure (entry <> blocks)
 
-exportLines :: GrinFunction -> Text -> [Text]
-exportLines function label =
-  case grinFunctionLinkName function of
-    Just _ -> [".globl " <> label]
-    Nothing -> []
+exportLines :: CompileEnv -> GrinFunction -> Text -> [Text]
+exportLines env function label
+  | compileExposeAllFunctions env = [".globl " <> label]
+  | otherwise =
+      case grinFunctionLinkName function of
+        Just _ -> [".globl " <> label]
+        Nothing -> []
 
 parameterCopyLir :: Map GrinVar Int -> [GrinVar] -> [Lir.Instruction]
 parameterCopyLir slots parameters =
@@ -373,7 +451,23 @@ compileExpr env prefix label expression =
                ]
             <> returnLines
         )
-    GrinStoreRec {} -> unsupportedExpression "recursive heap allocation"
+    GrinStoreRec bindings body -> do
+      allocationLines <-
+        fmap concat . forM bindings $ \(var, _) -> do
+          slot <- localSlot env var
+          pure ["  bl _aihc_make_cell", storeAt "x0" "x19" slot]
+      initializationLines <-
+        fmap concat . forM bindings $ \(var, node) -> do
+          slot <- localSlot env var
+          nodeLines <- liftEither (materializeNode env node)
+          pure $
+            nodeLines
+              <> [ "  mov x20, x0",
+                   loadAt "x0" "x19" slot,
+                   "  mov x1, x20",
+                   "  bl _aihc_set_cell"
+                 ]
+      compileExpr env (prefix <> allocationLines <> initializationLines) label body
     GrinFetch {} -> unsupportedExpression "fetch"
     GrinUpdate {} -> unsupportedExpression "update"
     GrinEval runtimeRep value -> do
@@ -918,14 +1012,174 @@ valueRuntimeReps value = [grinValueRuntimeRep value]
 nodeRuntimeReps :: GrinNode -> [RuntimeRep]
 nodeRuntimeReps node = concatMap valueRuntimeReps (grinNodeFields node)
 
+findFunction :: FunctionName -> [GrinFunction] -> Maybe GrinFunction
+findFunction name =
+  foldr
+    ( \function rest ->
+        if grinFunctionName function == name
+          then Just function
+          else rest
+    )
+    Nothing
+
+renderObservedMetadata :: CompileEnv -> GrinProgram -> [RuntimeRep] -> Either Arm64Error Text
+renderObservedMetadata env program resultReps = do
+  renderedResultReps <- mapM snapshotRepName resultReps
+  constructors <- mapM renderConstructorDescriptor constructorEntries
+  functions <- mapM renderFunctionDescriptor functionEntries
+  pure . T.unlines $
+    [ "#include \"aihc_runtime.h\"",
+      "#include <stddef.h>",
+      ""
+    ]
+      <> map renderFunctionDeclaration functions
+      <> [""]
+      <> concatMap renderConstructorRepDeclaration constructors
+      <> concatMap renderFunctionRepDeclaration functions
+      <> renderRepDeclaration "result_reps" renderedResultReps
+      <> renderConstructorTable constructors
+      <> renderFunctionTable functions
+      <> [ "void aihc_snapshot_dump_result(uint64_t count, const AihcSlot *values) {",
+           "  aihc_snapshot_dump(count, values, " <> pointerOrNull renderedResultReps "result_reps" <> ",",
+           "                     " <> tshow (length constructors) <> ", " <> tableOrNull constructors "constructors" <> ",",
+           "                     " <> tshow (length functions) <> ", " <> tableOrNull functions "functions" <> ");",
+           "}"
+         ]
+  where
+    layouts = Map.fromList (builtinConstructorLayouts <> grinConstructors program)
+    constructorEntries =
+      [ (identifier, name, fields)
+      | (name, identifier) <- Map.toAscList (compileConstructorIds env),
+        Just fields <- [Map.lookup name layouts]
+      ]
+    localFunctionEntries =
+      [ (grinFunctionName function, map grinVarRuntimeRep (grinFunctionParameters function))
+      | function <- grinFunctions program
+      ]
+    externalFunctionEntries =
+      [ (grinCodeFunctionName info, concat (grinCodeParameterLayouts info))
+      | info <- grinExternalFunctions program
+      ]
+    functionEntries = externalFunctionEntries <> localFunctionEntries
+
+    renderConstructorDescriptor (identifier, name, fields) = do
+      reps <- mapM snapshotRepName fields
+      pure (identifier, name, reps)
+
+    renderFunctionDescriptor (name, parameters) = do
+      label <- functionCodeLabel env name
+      reps <- mapM snapshotRepName parameters
+      pure (name, label, reps)
+
+renderFunctionDeclaration :: (FunctionName, Text, [Text]) -> Text
+renderFunctionDeclaration (_, label, _) =
+  "extern void " <> cSymbol label <> "(void);"
+
+renderConstructorRepDeclaration :: (Int, Text, [Text]) -> [Text]
+renderConstructorRepDeclaration (identifier, _, reps) =
+  renderRepDeclaration ("constructor_reps_" <> tshow identifier) reps
+
+renderFunctionRepDeclaration :: (FunctionName, Text, [Text]) -> [Text]
+renderFunctionRepDeclaration (_, label, reps) =
+  renderRepDeclaration ("function_reps_" <> cSymbol label) reps
+
+renderRepDeclaration :: Text -> [Text] -> [Text]
+renderRepDeclaration _ [] = []
+renderRepDeclaration name reps =
+  [ "static const AihcSnapshotRep "
+      <> name
+      <> "[] = {"
+      <> T.intercalate ", " reps
+      <> "};"
+  ]
+
+renderConstructorTable :: [(Int, Text, [Text])] -> [Text]
+renderConstructorTable [] = []
+renderConstructorTable constructors =
+  [ "static const AihcSnapshotConstructor constructors[] = {"
+  ]
+    <> [ "  {"
+           <> tshow identifier
+           <> ", "
+           <> cString name
+           <> ", "
+           <> tshow (length reps)
+           <> ", "
+           <> pointerOrNull reps ("constructor_reps_" <> tshow identifier)
+           <> "},"
+       | (identifier, name, reps) <- constructors
+       ]
+    <> ["};"]
+
+renderFunctionTable :: [(FunctionName, Text, [Text])] -> [Text]
+renderFunctionTable [] = []
+renderFunctionTable functions =
+  [ "static const AihcSnapshotFunction functions[] = {"
+  ]
+    <> [ "  {(uintptr_t)&"
+           <> cSymbol label
+           <> ", "
+           <> cString (unFunctionName name)
+           <> ", "
+           <> tshow (length reps)
+           <> ", "
+           <> pointerOrNull reps ("function_reps_" <> cSymbol label)
+           <> "},"
+       | (name, label, reps) <- functions
+       ]
+    <> ["};"]
+
+snapshotRepName :: RuntimeRep -> Either Arm64Error Text
+snapshotRepName runtimeRep =
+  case runtimeRep of
+    BoxedRep {} -> pure "AIHC_SNAPSHOT_POINTER"
+    SumRep {} -> pure "AIHC_SNAPSHOT_POINTER"
+    IntRep -> pure "AIHC_SNAPSHOT_INT"
+    Int8Rep -> pure "AIHC_SNAPSHOT_INT8"
+    Int16Rep -> pure "AIHC_SNAPSHOT_INT16"
+    Int32Rep -> pure "AIHC_SNAPSHOT_INT32"
+    Int64Rep -> pure "AIHC_SNAPSHOT_INT64"
+    WordRep -> pure "AIHC_SNAPSHOT_WORD"
+    Word8Rep -> pure "AIHC_SNAPSHOT_WORD8"
+    Word16Rep -> pure "AIHC_SNAPSHOT_WORD16"
+    Word32Rep -> pure "AIHC_SNAPSHOT_WORD32"
+    Word64Rep -> pure "AIHC_SNAPSHOT_WORD64"
+    AddrRep -> pure "AIHC_SNAPSHOT_ADDR"
+    FloatRep -> pure "AIHC_SNAPSHOT_FLOAT"
+    DoubleRep -> pure "AIHC_SNAPSHOT_DOUBLE"
+    _ -> Left (Arm64UnsupportedRuntimeRep runtimeRep)
+
+pointerOrNull :: [value] -> Text -> Text
+pointerOrNull values name
+  | null values = "NULL"
+  | otherwise = name
+
+tableOrNull :: [value] -> Text -> Text
+tableOrNull = pointerOrNull
+
+cSymbol :: Text -> Text
+cSymbol = T.drop 1
+
+cString :: Text -> Text
+cString value = "\"" <> T.concatMap escape value <> "\""
+  where
+    escape '"' = "\\\""
+    escape '\\' = "\\\\"
+    escape '\n' = "\\n"
+    escape '\r' = "\\r"
+    escape '\t' = "\\t"
+    escape character = T.singleton character
+
 functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index
 
-localFunctionLabel :: Int -> GrinFunction -> Text
-localFunctionLabel index function =
-  case grinFunctionLinkName function of
-    Just name -> linkedFunctionLabel name
-    Nothing -> functionLabel index
+localFunctionLabelWith :: Bool -> Int -> GrinFunction -> Text
+localFunctionLabelWith exposeAllFunctions index function
+  | exposeAllFunctions = "_aihc_snapshot_function_" <> tshow index
+  | otherwise =
+      case grinFunctionLinkName function of
+        Just name -> linkedFunctionLabel name
+        Nothing -> functionLabel index
 
 linkedFunctionLabel :: Text -> Text
 linkedFunctionLabel name =

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -55,7 +55,6 @@ data CompileEnv = CompileEnv
     compileConstructorArities :: !(Map Text Int),
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
-    compileFunctionArities :: !(Map FunctionName Int),
     compileExposeAllFunctions :: !Bool,
     compileAllowUnsupportedPrimitives :: !Bool
   }
@@ -319,15 +318,6 @@ compileEnvironmentWith exposeAllFunctions layout program =
                  | (index, function) <- zip [0 ..] (grinFunctions program)
                  ]
           ),
-      compileFunctionArities =
-        Map.fromList
-          ( [ (grinCodeFunctionName info, length (concat (grinCodeParameterLayouts info)))
-            | info <- grinExternalFunctions program
-            ]
-              <> [ (grinFunctionName function, length (grinFunctionParameters function))
-                 | function <- grinFunctions program
-                 ]
-          ),
       compileExposeAllFunctions = exposeAllFunctions,
       compileAllowUnsupportedPrimitives = False
     }
@@ -338,7 +328,7 @@ compileConstructorInitializers :: CompileEnv -> Either Arm64Error [Text]
 compileConstructorInitializers env =
   fmap concat . forM nullaryConstructors $ \(name, constructor) -> do
     slot <- globalSlot env name
-    pure $ makeNodeLines 1 (InfoImmediate constructor) 0 0 <> storeGlobal slot
+    pure $ makeNodeLines runtimeTagNode (InfoImmediate constructor) 0 0 <> storeGlobal slot
   where
     nullaryConstructors =
       [ (name, constructor)
@@ -352,21 +342,17 @@ compileInitializers env program = do
     slot <- globalSlot env (grinVarName var)
     nodeLines <- materializeNode (ValueEnv env Map.empty) node
     pure (nodeLines <> storeGlobal slot)
-  cafCellLines <- fmap concat . forM (grinCafs program) $ \(var, _) -> do
+  cafAllocationLines <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
     slot <- globalSlot env (grinVarName var)
-    pure (["  bl _aihc_make_cell"] <> storeGlobal slot)
-  cafValueLines <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
+    allocationLines <- allocateNode (ValueEnv env Map.empty) node
+    pure (allocationLines <> storeGlobal slot)
+  cafInitializationLines <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
     slot <- globalSlot env (grinVarName var)
-    nodeLines <- materializeNode (ValueEnv env Map.empty) node
+    fieldLines <- initializeNodeFields (ValueEnv env Map.empty) node
     pure $
-      nodeLines
-        <> [ "  mov x20, x0",
-             "  ldr x9, [x22, #24]",
-             loadAt "x0" "x9" slot,
-             "  mov x1, x20",
-             "  bl _aihc_set_cell"
-           ]
-  pure (cafCellLines <> whnfGlobalLines <> cafValueLines)
+      ["  ldr x9, [x22, #24]", loadAt "x20" "x9" slot]
+        <> fieldLines
+  pure (cafAllocationLines <> whnfGlobalLines <> cafInitializationLines)
 
 compileFunction :: CompileEnv -> GrinFunction -> Either Arm64Error [Text]
 compileFunction env function = do
@@ -383,7 +369,8 @@ compileFunction env function = do
   let slotCount = max 1 (spillBase + spillCount)
       entry =
         exportLines env function label
-          <> [ label <> ":",
+          <> [ ".p2align 3",
+               label <> ":",
                immediate "x0" slotCount,
                "  bl _aihc_alloc_locals",
                "  mov x19, x0",
@@ -438,35 +425,18 @@ compileExpr env prefix label expression =
       compileExpr env [] bodyLabel body
     GrinStore node -> do
       nodeLines <- liftEither (materializeNode env node)
-      addBlock
-        label
-        ( prefix
-            <> nodeLines
-            <> [ "  mov x20, x0",
-                 "  bl _aihc_make_cell",
-                 "  mov x21, x0",
-                 "  mov x1, x20",
-                 "  bl _aihc_set_cell",
-                 "  mov x0, x21"
-               ]
-            <> returnLines
-        )
+      addBlock label (prefix <> nodeLines <> returnLines)
     GrinStoreRec bindings body -> do
       allocationLines <-
-        fmap concat . forM bindings $ \(var, _) -> do
+        fmap concat . forM bindings $ \(var, node) -> do
           slot <- localSlot env var
-          pure ["  bl _aihc_make_cell", storeAt "x0" "x19" slot]
+          nodeLines <- liftEither (allocateNode env node)
+          pure (nodeLines <> [storeAt "x0" "x19" slot])
       initializationLines <-
         fmap concat . forM bindings $ \(var, node) -> do
           slot <- localSlot env var
-          nodeLines <- liftEither (materializeNode env node)
-          pure $
-            nodeLines
-              <> [ "  mov x20, x0",
-                   loadAt "x0" "x19" slot,
-                   "  mov x1, x20",
-                   "  bl _aihc_set_cell"
-                 ]
+          fieldLines <- liftEither (initializeNodeFields env node)
+          pure ([loadAt "x20" "x19" slot] <> fieldLines)
       compileExpr env (prefix <> allocationLines <> initializationLines) label body
     GrinFetch {} -> unsupportedExpression "fetch"
     GrinUpdate {} -> unsupportedExpression "update"
@@ -594,7 +564,7 @@ alternativePrefix env resultSlot alternative =
         slot <- localSlot env binder
         pure
           [ loadAt "x9" "x19" resultSlot,
-            loadByteOffset "x10" "x9" (32 + index * 8),
+            loadByteOffset "x10" "x9" (8 + index * 8),
             storeAt "x10" "x19" slot
           ]
     GrinLitAlt _ -> pure []
@@ -619,12 +589,9 @@ caseChecks env resultSlot scrutineeIsPointer targets = do
             pure
               [ loadAt "x9" "x19" resultSlot,
                 "  ldr x10, [x9, #0]",
-                "  cmp x10, #1",
-                "  b.ne 1f",
-                "  ldr x10, [x9, #8]",
-                "  cmp x10, #" <> tshow identifier,
-                "  b.eq " <> target,
-                "1:"
+                immediate "x11" (identifier * 8),
+                "  cmp x10, x11",
+                "  b.eq " <> target
               ]
           else lift (Left (Arm64UnsupportedExpression "constructor case on an unboxed value"))
       GrinLitAlt literal ->
@@ -702,8 +669,22 @@ literalInteger literal =
 
 materializeNode :: ValueEnv -> GrinNode -> Either Arm64Error [Text]
 materializeNode env node = do
-  (kind, info, arity) <- nodeHeader env node
-  fieldLines <- fmap concat . forM (zip [0 :: Int ..] (grinNodeFields node)) $ \(index, field) -> do
+  allocationLines <- allocateNode env node
+  fieldLines <- initializeNodeFields env node
+  pure $
+    allocationLines
+      <> ["  mov x20, x0"]
+      <> fieldLines
+      <> ["  mov x0, x20"]
+
+allocateNode :: ValueEnv -> GrinNode -> Either Arm64Error [Text]
+allocateNode env node = do
+  (tag, info, arity) <- nodeHeader env node
+  pure (makeNodeLines tag info arity (length (grinNodeFields node)))
+
+initializeNodeFields :: ValueEnv -> GrinNode -> Either Arm64Error [Text]
+initializeNodeFields env node =
+  fmap concat . forM (zip [0 :: Int ..] (grinNodeFields node)) $ \(index, field) -> do
     valueLines <- materializeValue env field
     pure $
       valueLines
@@ -712,28 +693,26 @@ materializeNode env node = do
              immediate "x1" index,
              "  bl _aihc_set_field"
            ]
-  pure $
-    makeNodeLines kind info arity (length (grinNodeFields node))
-      <> ["  mov x20, x0"]
-      <> fieldLines
-      <> ["  mov x0, x20"]
 
 nodeHeader :: ValueEnv -> GrinNode -> Either Arm64Error (Int, NodeInfo, Int)
 nodeHeader env node =
   case grinNodeTag node of
     GrinConstructor name remaining -> do
       identifier <- constructorId compileEnv name
-      pure (1, InfoImmediate identifier, remaining)
+      pure
+        ( if remaining == 0 then runtimeTagNode else runtimeTagPartialConstructor,
+          InfoImmediate identifier,
+          remaining
+        )
     GrinClosure functionName argumentLayouts -> do
       label <- functionCodeLabel compileEnv functionName
-      pure (2, InfoAddress label, length argumentLayouts)
+      pure (runtimeTagClosure, InfoAddress label, length argumentLayouts)
     GrinThunk functionName -> do
       label <- functionCodeLabel compileEnv functionName
-      arity <- functionArity compileEnv functionName
-      pure (3, InfoAddress label, arity)
+      pure (runtimeTagThunk, InfoAddress label, 0)
     GrinPrimitive name arity -> do
       identifier <- primitiveId compileEnv name
-      pure (4, InfoImmediate identifier, arity)
+      pure (runtimeTagPrimitive, InfoImmediate identifier, arity)
   where
     compileEnv = valueCompileEnv env
 
@@ -754,6 +733,13 @@ makeNodeLines kind info arity count =
       case nodeInfo of
         InfoImmediate integer -> immediate "x1" integer
         InfoAddress label -> address "x1" label
+
+runtimeTagNode, runtimeTagClosure, runtimeTagThunk, runtimeTagPartialConstructor, runtimeTagPrimitive :: Int
+runtimeTagNode = 0
+runtimeTagClosure = 1
+runtimeTagThunk = 2
+runtimeTagPartialConstructor = 3
+runtimeTagPrimitive = 4
 
 loadVariable :: ValueEnv -> GrinVar -> Either Arm64Error [Text]
 loadVariable env var =
@@ -863,10 +849,6 @@ constructorId env name =
 functionCodeLabel :: CompileEnv -> FunctionName -> Either Arm64Error Text
 functionCodeLabel env name =
   maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionLabels env))
-
-functionArity :: CompileEnv -> FunctionName -> Either Arm64Error Int
-functionArity env name =
-  maybe (Left (Arm64MissingFunction name)) Right (Map.lookup name (compileFunctionArities env))
 
 primitiveId :: CompileEnv -> Text -> Either Arm64Error Int
 primitiveId env = primitiveIdentifier (compileAllowUnsupportedPrimitives env)

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -216,24 +216,30 @@ tests =
         assertBool
           "runtime apply does not enter its function"
           (not ("aihc_eval_value(machine, function" `isInfixOf` runtime)),
-      testCase "runtime object ABI is warning-free on the host compiler" $ do
-        runtime <- runtimeSourcePath
-        snapshotRuntime <- snapshotSourcePath
-        (clangExit, _clangOut, clangErr) <-
-          readProcessWithExitCode
-            "clang"
-            [ "-std=c11",
-              "-Wall",
-              "-Wextra",
-              "-Werror",
-              "-I",
-              takeDirectory runtime,
-              "-fsyntax-only",
-              runtime,
-              snapshotRuntime
-            ]
-            ""
-        assertEqual ("clang runtime diagnostics:\n" <> clangErr) ExitSuccess clangExit,
+      testCase "runtime object ABI compiles cleanly on the host C compiler" $
+        withTempDirectory "aihc-arm64-runtime" $ \directory -> do
+          runtime <- runtimeSourcePath
+          snapshotRuntime <- snapshotSourcePath
+          let executable = directory </> "runtime-check"
+          (compilerExit, _compilerOut, compilerErr) <-
+            readProcessWithExitCode
+              "cc"
+              [ "-std=c11",
+                "-Wall",
+                "-Wextra",
+                "-Werror",
+                "-I",
+                takeDirectory runtime,
+                runtime,
+                snapshotRuntime,
+                "-x",
+                "c",
+                "-",
+                "-o",
+                executable
+              ]
+              "int main(void) { return 0; }\n"
+          assertEqual ("C compiler runtime diagnostics:\n" <> compilerErr) ExitSuccess compilerExit,
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -216,6 +216,24 @@ tests =
         assertBool
           "runtime apply does not enter its function"
           (not ("aihc_eval_value(machine, function" `isInfixOf` runtime)),
+      testCase "runtime object ABI is warning-free on the host compiler" $ do
+        runtime <- runtimeSourcePath
+        snapshotRuntime <- snapshotSourcePath
+        (clangExit, _clangOut, clangErr) <-
+          readProcessWithExitCode
+            "clang"
+            [ "-std=c11",
+              "-Wall",
+              "-Wextra",
+              "-Werror",
+              "-I",
+              takeDirectory runtime,
+              "-fsyntax-only",
+              runtime,
+              snapshotRuntime
+            ]
+            ""
+        assertEqual ("clang runtime diagnostics:\n" <> clangErr) ExitSuccess clangExit,
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
 

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -5,21 +5,36 @@ module Test.Arm64.Suite
   )
 where
 
-import Aihc.Arm64 (Arm64Error (..), buildLinkLayout, compileModule, compileProgram, runtimeSourcePath, validateProgramPrimitives)
+import Aihc.Arm64
+  ( Arm64Error (..),
+    ObservedProgram (..),
+    buildLinkLayout,
+    compileModule,
+    compileObservedFunction,
+    compileProgram,
+    runtimeSourcePath,
+    snapshotSourcePath,
+    targetTriple,
+    validateProgramPrimitives,
+  )
 import Aihc.Arm64.Emit (renderAllocatedBlock)
 import Aihc.Arm64.Lir
 import Aihc.Arm64.RegisterAllocate
 import Aihc.Grin
 import Aihc.Tc (Levity (..), RuntimeRep (..), Unique (..))
 import Aihc.Testing.EvalFixture (EvalCase (..), compileEvalCase, evalBindingName, loadEvalCases)
+import Aihc.Testing.GrinProgram (parseProgram)
 import Control.Exception (bracket)
 import Control.Monad (when)
+import Data.Aeson (FromJSON (..), withObject, (.:))
 import Data.List (find, isInfixOf)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
-import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import Data.Text.IO qualified as TIO
+import Data.Yaml qualified as Y
+import System.Directory (createDirectory, doesDirectoryExist, getCurrentDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
-import System.FilePath ((</>))
+import System.FilePath (takeDirectory, (</>))
 import System.IO (hClose, openTempFile)
 import System.Info (arch, os)
 import System.Process (readProcessWithExitCode)
@@ -191,8 +206,150 @@ tests =
           Right assembly -> do
             assertBool "exports caller entry" (".globl _aihc_entry_63_61_6c_6c_65_72_" `T.isInfixOf` assembly)
             assertBool "branches to dependency entry" ("b _aihc_entry_69_64_65_6e_74_69_74_79_" `T.isInfixOf` assembly),
+      testGroup "raw GRIN heap snapshots" (map snapshotTest snapshotCases),
       testCase "compiles standalone HelloWorld GRIN to native ARM64" testNativeHelloWorld
     ]
+
+data SnapshotCase = SnapshotCase
+  { snapshotCaseName :: !String,
+    snapshotCaseProgram :: !GrinProgram,
+    snapshotCaseEntry :: !FunctionName,
+    snapshotCaseExpected :: !T.Text
+  }
+
+data SnapshotFixture = SnapshotFixture
+  { snapshotFixtureEntry :: !T.Text,
+    snapshotFixtureProgram :: !T.Text,
+    snapshotFixtureReturn :: !T.Text,
+    snapshotFixtureHeap :: !T.Text,
+    snapshotFixtureStatus :: !T.Text,
+    snapshotFixtureReason :: !T.Text
+  }
+
+instance FromJSON SnapshotFixture where
+  parseJSON =
+    withObject "GRIN snapshot fixture" $ \object ->
+      SnapshotFixture
+        <$> object .: "entry"
+        <*> object .: "program"
+        <*> object .: "return"
+        <*> object .: "heap"
+        <*> object .: "status"
+        <*> object .: "reason"
+
+snapshotCases :: [(String, FilePath)]
+snapshotCases =
+  [ ("stores one value", "store-one.yaml"),
+    ("preserves a suspended thunk", "store-suspended.yaml"),
+    ("stores linked values", "store-linked.yaml"),
+    ("stores a self-referential value", "store-self-referential.yaml"),
+    ("returns an unboxed value", "return-unboxed.yaml"),
+    ("evaluates only through GrinEval", "eval.yaml"),
+    ("applies a stored closure", "apply.yaml")
+  ]
+
+snapshotTest :: (String, FilePath) -> TestTree
+snapshotTest (name, fixtureName) =
+  testCase name $ do
+    snapshotCase <- loadSnapshotCase name fixtureName
+    let program = snapshotCaseProgram snapshotCase
+        entry = snapshotCaseEntry snapshotCase
+        expected = T.stripEnd (snapshotCaseExpected snapshotCase)
+    assertEqual "direct GRIN lint" [] (lintProgram program)
+    interpreted <- interpretProgramFunctionSnapshot entry program
+    snapshot <-
+      case interpreted of
+        Left err -> assertFailure ("GRIN interpreter failed: " <> show err)
+        Right value -> pure value
+    assertEqual "interpreter snapshot" expected (T.stripEnd (renderHeapSnapshot snapshot))
+    let cps = expectCpsGrin program
+    assertEqual "CPS GRIN lint" [] (lintProgram (cpsGrinProgram cps))
+    observed <-
+      case compileObservedFunction entry cps of
+        Left err -> assertFailure ("native snapshot compilation failed: " <> show err)
+        Right value -> pure value
+    when (arch == "aarch64" && os == "darwin") $ do
+      native <- runObservedProgram observed
+      assertEqual "native snapshot" expected (T.stripEnd native)
+
+loadSnapshotCase :: String -> FilePath -> IO SnapshotCase
+loadSnapshotCase name fixtureName = do
+  root <- snapshotFixtureRoot
+  result <- Y.decodeFileEither (root </> fixtureName)
+  fixture <-
+    case result of
+      Left err -> assertFailure ("invalid GRIN snapshot fixture: " <> Y.prettyPrintParseException err)
+      Right value -> pure value
+  assertEqual "fixture status" "pass" (snapshotFixtureStatus fixture)
+  assertBool "fixture reason is present" (not (T.null (T.strip (snapshotFixtureReason fixture))))
+  program <-
+    case parseProgram (snapshotFixtureProgram fixture) of
+      Left err -> assertFailure ("invalid GRIN program: " <> err)
+      Right value -> pure value
+  let heap = T.stripEnd (snapshotFixtureHeap fixture)
+      expected
+        | heap == "[]" = "return: " <> snapshotFixtureReturn fixture <> "\nheap: []"
+        | otherwise =
+            "return: "
+              <> snapshotFixtureReturn fixture
+              <> "\nheap:\n"
+              <> T.unlines (map ("  " <>) (T.lines heap))
+  pure
+    SnapshotCase
+      { snapshotCaseName = name,
+        snapshotCaseProgram = program,
+        snapshotCaseEntry = FunctionName (snapshotFixtureEntry fixture),
+        snapshotCaseExpected = expected
+      }
+
+snapshotFixtureRoot :: IO FilePath
+snapshotFixtureRoot = getCurrentDirectory >>= findRoot
+  where
+    findRoot directory = do
+      let candidate = directory </> "components" </> "aihc-arm64" </> "test" </> "Test" </> "Fixtures" </> "snapshot"
+      exists <- doesDirectoryExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory directory
+          if parent == directory
+            then assertFailure "GRIN snapshot fixture root is missing"
+            else findRoot parent
+
+runObservedProgram :: ObservedProgram -> IO T.Text
+runObservedProgram observed =
+  withTempDirectory "aihc-arm64-snapshot" $ \directory -> do
+    runtime <- runtimeSourcePath
+    snapshotRuntime <- snapshotSourcePath
+    let assemblyPath = directory </> "snapshot.s"
+        metadataPath = directory </> "snapshot_metadata.c"
+        executablePath = directory </> "snapshot"
+    TIO.writeFile assemblyPath (observedAssembly observed)
+    TIO.writeFile metadataPath (observedMetadataSource observed)
+    (clangExit, _clangOut, clangErr) <-
+      readProcessWithExitCode
+        "clang"
+        [ "--target=" <> targetTriple,
+          "-std=c11",
+          "-Wall",
+          "-Wextra",
+          "-Werror",
+          "-I",
+          takeDirectory runtime,
+          runtime,
+          snapshotRuntime,
+          metadataPath,
+          assemblyPath,
+          "-o",
+          executablePath
+        ]
+        ""
+    case clangExit of
+      ExitSuccess -> pure ()
+      ExitFailure _ -> assertFailure ("clang failed to assemble observed GRIN:\n" <> clangErr)
+    (programExit, programOut, programErr) <- readProcessWithExitCode executablePath [] ""
+    assertEqual ("native stderr: " <> programErr) ExitSuccess programExit
+    pure (T.pack programOut)
 
 testNativeHelloWorld :: IO ()
 testNativeHelloWorld = do

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/apply.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/apply.yaml
@@ -1,0 +1,20 @@
+entry: $entry
+program: |
+  constructor I32#/1 [Int32Rep]
+  constructor Pair/2 [BoxedRep Lifted, BoxedRep Lifted]
+
+  $identity (argument%1 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    constant (argument%1 :: BoxedRep Lifted)
+
+  $entry -> BoxedRep Lifted =
+    (closure%2 :: BoxedRep Lifted) <- store (P$identity/1)
+    (value%3 :: BoxedRep Lifted) <- store (CI32# (9 :: Int32Rep))
+    (applied%4 :: BoxedRep Lifted) <- apply @(BoxedRep Lifted) (closure%2 :: BoxedRep Lifted) (value%3 :: BoxedRep Lifted)
+    store (CPair (closure%2 :: BoxedRep Lifted) (applied%4 :: BoxedRep Lifted))
+return: "@0"
+heap: |
+  @0 = CPair @1 @2
+  @1 = P$identity/1
+  @2 = CI32# 9
+status: pass
+reason: GrinApply enters the closure while the heap snapshot still symbolizes its code pointer

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/eval.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/eval.yaml
@@ -12,8 +12,8 @@ program: |
     store (CPair (thunk%1 :: BoxedRep Lifted) (evaluated%2 :: BoxedRep Lifted))
 return: "@0"
 heap: |
-  @0 = CPair @1 (CI32# 7)
-  @1 = @2
+  @0 = CPair @1 @2
+  @1 = Indirection @2
   @2 = CI32# 7
 status: pass
-reason: only the explicit GrinEval enters the thunk and updates its heap cell
+reason: only explicit GrinEval enters the thunk, preserving its heap-pointer result and exposing the update as an indirection

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/eval.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/eval.yaml
@@ -1,0 +1,19 @@
+entry: $entry
+program: |
+  constructor I32#/1 [Int32Rep]
+  constructor Pair/2 [BoxedRep Lifted, BoxedRep Lifted]
+
+  $delayed -> BoxedRep Lifted =
+    store (CI32# (7 :: Int32Rep))
+
+  $entry -> BoxedRep Lifted =
+    (thunk%1 :: BoxedRep Lifted) <- store (F$delayed)
+    (evaluated%2 :: BoxedRep Lifted) <- eval @(BoxedRep Lifted) (thunk%1 :: BoxedRep Lifted)
+    store (CPair (thunk%1 :: BoxedRep Lifted) (evaluated%2 :: BoxedRep Lifted))
+return: "@0"
+heap: |
+  @0 = CPair @1 (CI32# 7)
+  @1 = @2
+  @2 = CI32# 7
+status: pass
+reason: only the explicit GrinEval enters the thunk and updates its heap cell

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/return-unboxed.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/return-unboxed.yaml
@@ -1,0 +1,8 @@
+entry: $entry
+program: |
+  $entry -> Int32Rep =
+    constant (42 :: Int32Rep)
+return: "42"
+heap: "[]"
+status: pass
+reason: a native function may return an unboxed machine value without allocating

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/store-linked.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/store-linked.yaml
@@ -1,0 +1,14 @@
+entry: $entry
+program: |
+  constructor I32#/1 [Int32Rep]
+  constructor Link/1 [BoxedRep Lifted]
+
+  $entry -> BoxedRep Lifted =
+    (leaf%1 :: BoxedRep Lifted) <- store (CI32# (2 :: Int32Rep))
+    store (CLink (leaf%1 :: BoxedRep Lifted))
+return: "@0"
+heap: |
+  @0 = CLink @1
+  @1 = CI32# 2
+status: pass
+reason: snapshot traversal follows links between separately stored heap values

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/store-one.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/store-one.yaml
@@ -1,0 +1,11 @@
+entry: $entry
+program: |
+  constructor I32#/1 [Int32Rep]
+
+  $entry -> BoxedRep Lifted =
+    store (CI32# (1 :: Int32Rep))
+return: "@0"
+heap: |
+  @0 = CI32# 1
+status: pass
+reason: a stored constructor is returned as a location with its raw scalar field

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/store-self-referential.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/store-self-referential.yaml
@@ -1,0 +1,13 @@
+entry: $entry
+program: |
+  constructor Loop/1 [BoxedRep Lifted]
+
+  $entry -> BoxedRep Lifted =
+    store-rec
+      (self%1 :: BoxedRep Lifted) = (CLoop (self%1 :: BoxedRep Lifted))
+    constant (self%1 :: BoxedRep Lifted)
+return: "@0"
+heap: |
+  @0 = CLoop @0
+status: pass
+reason: snapshot object identifiers preserve a self-reference without traversing forever

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/store-suspended.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/store-suspended.yaml
@@ -1,0 +1,14 @@
+entry: $entry
+program: |
+  constructor I32#/1 [Int32Rep]
+
+  $delayed -> BoxedRep Lifted =
+    store (CI32# (99 :: Int32Rep))
+
+  $entry -> BoxedRep Lifted =
+    store (F$delayed)
+return: "@0"
+heap: |
+  @0 = F$delayed
+status: pass
+reason: observing a stored thunk symbolizes its code pointer without entering the thunk

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -17,6 +17,7 @@ library
     Aihc.Grin.Lint
     Aihc.Grin.Lower
     Aihc.Grin.Pretty
+    Aihc.Grin.Snapshot
     Aihc.Grin.Syntax
 
   hs-source-dirs: src

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -15,14 +15,22 @@ module Aihc.Grin
     renderExpr,
     interpretProgramBinding,
     interpretProgramIoBinding,
+    interpretProgramFunctionSnapshot,
     InterpretError (..),
     RuntimeValue (..),
+    HeapSnapshot (..),
+    SnapshotValue (..),
+    SnapshotCell (..),
+    renderSnapshotReturn,
+    renderSnapshotHeap,
+    renderHeapSnapshot,
   )
 where
 
 import Aihc.Grin.Cps (CpsGrinError (..), CpsGrinProgram, cpsGrinProgram, toCpsGrin)
-import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramIoBinding)
+import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramFunctionSnapshot, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
 import Aihc.Grin.Lower (GrinInterface, extractGrinInterface, lowerProgram, lowerProgramWithInterface)
 import Aihc.Grin.Pretty (renderExpr, renderProgram)
+import Aihc.Grin.Snapshot
 import Aihc.Grin.Syntax

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -6,16 +6,18 @@ module Aihc.Grin.Interpret
     RuntimeValue (..),
     interpretProgramBinding,
     interpretProgramIoBinding,
+    interpretProgramFunctionSnapshot,
   )
 where
 
+import Aihc.Grin.Snapshot
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
-import Control.Monad.Trans.State.Strict (StateT, gets, modify', runStateT)
+import Control.Monad.Trans.State.Strict (State, StateT, execState, get, gets, modify', runState, runStateT)
 import Data.Char qualified as Char
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.IntMap.Strict (IntMap)
@@ -90,6 +92,14 @@ data EvalFailure
 
 type EvalM = ExceptT EvalFailure (StateT Machine IO)
 
+data SnapshotBuild = SnapshotBuild
+  { snapshotBuildSource :: !(IntMap HeapCell),
+    snapshotBuildLocations :: !(IntMap Int),
+    snapshotBuildSources :: !(IntMap Int),
+    snapshotBuildNextLocation :: !Int,
+    snapshotBuildCells :: !(IntMap SnapshotCell)
+  }
+
 -- | Interpret and render a named top-level binding using the raw constructor
 -- representation shared by the compiler pipeline evaluation fixtures.
 interpretProgramBinding :: Text -> GrinProgram -> IO (Either InterpretError Text)
@@ -100,6 +110,19 @@ interpretProgramBinding = interpretProgramBindingWith pure
 -- point.
 interpretProgramIoBinding :: Text -> GrinProgram -> IO (Either InterpretError Text)
 interpretProgramIoBinding = interpretProgramBindingWith runIOValue
+
+-- | Execute a nullary GRIN function and snapshot its raw return values and
+-- reachable heap. Snapshotting reads cells but never enters a thunk or forces
+-- a location; only 'GrinEval' nodes executed by the function may do that.
+interpretProgramFunctionSnapshot :: FunctionName -> GrinProgram -> IO (Either InterpretError HeapSnapshot)
+interpretProgramFunctionSnapshot functionName program = do
+  let machine = initialMachine program
+  (result, finalMachine) <- runStateT (runExceptT (callFunction functionName [])) machine
+  pure $
+    case result of
+      Right values -> Right (buildHeapSnapshot (machineHeap finalMachine) values)
+      Left (EvalInterpret err) -> Left err
+      Left (EvalRaised exception) -> Left (InterpretRaisedException (T.pack (show exception)))
 
 interpretProgramBindingWith :: (RuntimeValue -> EvalM RuntimeValue) -> Text -> GrinProgram -> IO (Either InterpretError Text)
 interpretProgramBindingWith enterValue name program = do
@@ -637,3 +660,65 @@ getsMachine = lift . gets
 
 modifyMachine :: (Machine -> Machine) -> EvalM ()
 modifyMachine = lift . modify'
+
+buildHeapSnapshot :: IntMap HeapCell -> [RuntimeValue] -> HeapSnapshot
+buildHeapSnapshot source values =
+  let initial =
+        SnapshotBuild
+          { snapshotBuildSource = source,
+            snapshotBuildLocations = IntMap.empty,
+            snapshotBuildSources = IntMap.empty,
+            snapshotBuildNextLocation = 0,
+            snapshotBuildCells = IntMap.empty
+          }
+      (returnValues, afterRoots) = runState (mapM snapshotRuntimeValue values) initial
+      final = execState (snapshotPendingCells 0) afterRoots
+   in HeapSnapshot
+        { snapshotReturnValues = returnValues,
+          snapshotHeap = snapshotBuildCells final
+        }
+
+snapshotPendingCells :: Int -> State SnapshotBuild ()
+snapshotPendingCells location = do
+  state <- get
+  if location >= snapshotBuildNextLocation state
+    then pure ()
+    else do
+      case IntMap.lookup location (snapshotBuildSources state) >>= (`IntMap.lookup` snapshotBuildSource state) of
+        Nothing -> pure ()
+        Just cell -> do
+          snapshotCell <- snapshotHeapCell cell
+          modify' $ \current -> current {snapshotBuildCells = IntMap.insert location snapshotCell (snapshotBuildCells current)}
+      snapshotPendingCells (location + 1)
+
+snapshotHeapCell :: HeapCell -> State SnapshotBuild SnapshotCell
+snapshotHeapCell cell =
+  case cell of
+    HeapSuspended functionName fields -> SnapshotSuspended functionName <$> mapM snapshotRuntimeValue fields
+    HeapValue value -> SnapshotValue <$> snapshotRuntimeValue value
+    HeapRaised exception -> SnapshotRaised <$> snapshotRuntimeValue exception
+    HeapBlackhole -> pure SnapshotBlackhole
+
+snapshotRuntimeValue :: RuntimeValue -> State SnapshotBuild SnapshotValue
+snapshotRuntimeValue value =
+  case value of
+    RuntimeLit literal -> pure (SnapshotLiteral literal)
+    RuntimeNode tag fields -> SnapshotNode tag <$> mapM snapshotRuntimeValue fields
+    RuntimeLocation sourceLocation -> SnapshotLocation <$> snapshotLocation sourceLocation
+    RuntimeMutVar {} -> pure SnapshotMutVar
+    RuntimeStateToken -> pure SnapshotStateToken
+
+snapshotLocation :: Int -> State SnapshotBuild Int
+snapshotLocation sourceLocation = do
+  state <- get
+  case IntMap.lookup sourceLocation (snapshotBuildLocations state) of
+    Just location -> pure location
+    Nothing -> do
+      let location = snapshotBuildNextLocation state
+      modify' $ \current ->
+        current
+          { snapshotBuildLocations = IntMap.insert sourceLocation location (snapshotBuildLocations current),
+            snapshotBuildSources = IntMap.insert location sourceLocation (snapshotBuildSources current),
+            snapshotBuildNextLocation = location + 1
+          }
+      pure location

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -391,8 +391,6 @@ applyValue function arguments =
         GT -> pure [RuntimeNode (GrinConstructor name (remaining - 1)) (fields <> arguments)]
         EQ -> pure [RuntimeNode (GrinConstructor name 0) (fields <> arguments)]
         LT -> throwInterpret (InterpretConstructorArity name 0 1)
-    RuntimeNode (GrinPrimitive name arity) fields ->
-      applyPrimitive name arity fields arguments
     other -> throwInterpret (InterpretApplyNonFunction other)
 
 callFunction :: FunctionName -> [RuntimeValue] -> EvalM [RuntimeValue]
@@ -418,12 +416,6 @@ isLiftedRuntimeValue value =
     RuntimeLocation {} -> True
     RuntimeMutVar {} -> False
     RuntimeStateToken -> False
-
-applyPrimitive :: Text -> Int -> [RuntimeValue] -> [RuntimeValue] -> EvalM [RuntimeValue]
-applyPrimitive name remaining captured arguments
-  | remaining > 1 = pure [RuntimeNode (GrinPrimitive name (remaining - 1)) (captured <> arguments)]
-  | remaining == 1 = evalPrimitive name (captured <> arguments)
-  | otherwise = throwInterpret (InterpretPrimitiveArity name 1)
 
 evalPrimitive :: Text -> [RuntimeValue] -> EvalM [RuntimeValue]
 evalPrimitive "+#" [left, right] = evalIntPrimitive "+#" (+) left right
@@ -605,7 +597,6 @@ renderRawValueM value = do
       pure (T.unwords (name : renderedArguments))
     RuntimeNode GrinConstructor {} _ -> pure "<function>"
     RuntimeNode GrinClosure {} _ -> pure "<function>"
-    RuntimeNode GrinPrimitive {} _ -> pure "<function>"
     RuntimeNode GrinThunk {} _ -> pure "<thunk>"
     RuntimeLocation _ -> renderRawValueM forced
     RuntimeMutVar {} -> pure "<mutvar>"

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -95,6 +95,7 @@ type EvalM = ExceptT EvalFailure (StateT Machine IO)
 
 data SnapshotBuild = SnapshotBuild
   { snapshotBuildSource :: !(IntMap HeapCell),
+    snapshotBuildValueSources :: ![(RuntimeValue, Int)],
     snapshotBuildLocations :: !(IntMap Int),
     snapshotBuildSources :: !(IntMap Int),
     snapshotBuildNextLocation :: !Int,
@@ -657,9 +658,18 @@ modifyMachine = lift . modify'
 
 buildHeapSnapshot :: IntMap HeapCell -> [RuntimeValue] -> HeapSnapshot
 buildHeapSnapshot source values =
-  let initial =
+  let indirectionTargets =
+        [ target
+        | HeapValue (RuntimeLocation target) <- IntMap.elems source
+        ]
+      initial =
         SnapshotBuild
           { snapshotBuildSource = source,
+            snapshotBuildValueSources =
+              [ (value, location)
+              | (location, HeapValue value@RuntimeNode {}) <- IntMap.toAscList source,
+                location `elem` indirectionTargets
+              ],
             snapshotBuildLocations = IntMap.empty,
             snapshotBuildSources = IntMap.empty,
             snapshotBuildNextLocation = 0,
@@ -689,7 +699,8 @@ snapshotHeapCell :: HeapCell -> State SnapshotBuild SnapshotCell
 snapshotHeapCell cell =
   case cell of
     HeapSuspended functionName fields -> SnapshotSuspended functionName <$> mapM snapshotRuntimeValue fields
-    HeapValue value -> SnapshotValue <$> snapshotRuntimeValue value
+    HeapValue (RuntimeLocation sourceLocation) -> SnapshotIndirection <$> snapshotLocation sourceLocation
+    HeapValue value -> SnapshotValue <$> snapshotStoredValue value
     HeapRaised exception -> SnapshotRaised <$> snapshotRuntimeValue exception
     HeapBlackhole -> pure SnapshotBlackhole
 
@@ -697,10 +708,23 @@ snapshotRuntimeValue :: RuntimeValue -> State SnapshotBuild SnapshotValue
 snapshotRuntimeValue value =
   case value of
     RuntimeLit literal -> pure (SnapshotLiteral literal)
-    RuntimeNode tag fields -> SnapshotNode tag <$> mapM snapshotRuntimeValue fields
+    RuntimeNode {} -> do
+      valueSources <- gets snapshotBuildValueSources
+      case lookup value valueSources of
+        Just sourceLocation -> SnapshotLocation <$> snapshotLocation sourceLocation
+        Nothing -> snapshotStoredValue value
     RuntimeLocation sourceLocation -> SnapshotLocation <$> snapshotLocation sourceLocation
     RuntimeMutVar {} -> pure SnapshotMutVar
     RuntimeStateToken -> pure SnapshotStateToken
+
+-- Heap-cell payloads define locations and therefore render their node inline.
+-- The same node encountered elsewhere is rendered as a pointer back to this
+-- owning value cell.
+snapshotStoredValue :: RuntimeValue -> State SnapshotBuild SnapshotValue
+snapshotStoredValue value =
+  case value of
+    RuntimeNode tag fields -> SnapshotNode tag <$> mapM snapshotRuntimeValue fields
+    _ -> snapshotRuntimeValue value
 
 snapshotLocation :: Int -> State SnapshotBuild Int
 snapshotLocation sourceLocation = do

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -342,8 +342,8 @@ lowerPrimitiveApplication :: FcExpr -> Text -> Int -> [FcExpr] -> LowerM GrinExp
 lowerPrimitiveApplication originalExpr name arity arguments =
   case compare suppliedArity arity of
     LT ->
-      lowerArgumentMany arguments $ \values ->
-        pure (GrinStore (GrinNode (GrinPrimitive name (arity - suppliedArity)) values))
+      lowerArgumentMany arguments $
+        fmap GrinStore . makePrimitiveClosure originalExpr name (arity - suppliedArity)
     EQ ->
       lowerArgumentMany arguments $ \values ->
         pure (GrinPrimitiveCall (exprRuntimeRep originalExpr) name values)
@@ -360,6 +360,40 @@ lowerPrimitiveApplication originalExpr name arity arguments =
           _ -> error "GRIN lowering expected an overapplied primitive to return one function value"
   where
     suppliedArity = length arguments
+
+-- Primitive operations have no heap representation. Under-application is
+-- represented by an ordinary closure whose generated entry makes the direct,
+-- saturated primitive call once all remaining logical arguments arrive.
+makePrimitiveClosure :: FcExpr -> Text -> Int -> [GrinValue] -> LowerM GrinNode
+makePrimitiveClosure originalExpr name remaining captured = do
+  (argumentTypes, resultType) <-
+    case exprType originalExpr >>= splitFunctionTypes remaining of
+      Just wrapperType -> pure wrapperType
+      Nothing -> error ("GRIN lowering could not construct primitive wrapper for " <> show name)
+  captureParameters <- mapM (freshVar "primitive_capture" . grinValueRuntimeRep) captured
+  argumentGroups <- mapM (freshVars "primitive_argument" . typeRuntimeRep) argumentTypes
+  functionName <- freshFunction "primitive"
+  let argumentLayouts = map (map grinVarRuntimeRep) argumentGroups
+      arguments = map GrinVarValue (captureParameters <> concat argumentGroups)
+      resultRep = typeRuntimeRep resultType
+  emitFunction
+    GrinFunction
+      { grinFunctionName = functionName,
+        grinFunctionLinkName = Nothing,
+        grinFunctionParameters = captureParameters <> concat argumentGroups,
+        grinFunctionResultRep = resultRep,
+        grinFunctionBody = GrinPrimitiveCall resultRep name arguments
+      }
+  pure (GrinNode (GrinClosure functionName argumentLayouts) captured)
+
+splitFunctionTypes :: Int -> TcType -> Maybe ([TcType], TcType)
+splitFunctionTypes count ty
+  | count == 0 = Just ([], ty)
+splitFunctionTypes count (TcFunTy argument result) = do
+  (arguments, finalResult) <- splitFunctionTypes (count - 1) result
+  pure (argument : arguments, finalResult)
+splitFunctionTypes count (TcQualTy [] body) = splitFunctionTypes count body
+splitFunctionTypes _ _ = Nothing
 
 dropLastTermApplications :: Int -> FcExpr -> FcExpr
 dropLastTermApplications count expr

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -202,7 +202,6 @@ renderNodeTag nodeTag =
     GrinClosure functionName argumentLayouts ->
       "P" <> T.unpack (unFunctionName functionName) <> "/" <> show (length argumentLayouts)
     GrinThunk functionName -> "F" <> T.unpack (unFunctionName functionName)
-    GrinPrimitive name arity -> "Prim[" <> T.unpack name <> "/" <> show arity <> "]"
 
 renderLiteral :: GrinLiteral -> String
 renderLiteral literal =

--- a/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
@@ -98,7 +98,6 @@ renderNodeTag tag =
     GrinClosure functionName argumentLayouts ->
       "P" <> unFunctionName functionName <> "/" <> tshow (length argumentLayouts)
     GrinThunk functionName -> "F" <> unFunctionName functionName
-    GrinPrimitive name arity -> "Prim[" <> name <> "/" <> tshow arity <> "]"
 
 renderLiteral :: GrinLiteral -> Text
 renderLiteral literal =

--- a/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
@@ -37,6 +37,7 @@ data SnapshotValue
 
 data SnapshotCell
   = SnapshotSuspended !FunctionName ![SnapshotValue]
+  | SnapshotIndirection !Int
   | SnapshotValue !SnapshotValue
   | SnapshotRaised !SnapshotValue
   | SnapshotBlackhole
@@ -70,6 +71,7 @@ renderCell :: SnapshotCell -> Text
 renderCell cell =
   case cell of
     SnapshotSuspended functionName fields -> renderNode False (GrinThunk functionName) fields
+    SnapshotIndirection location -> "Indirection @" <> tshow location
     SnapshotValue value -> renderValue False value
     SnapshotRaised exception -> "<raised " <> renderValue False exception <> ">"
     SnapshotBlackhole -> "<blackhole>"

--- a/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | A stable, non-evaluating view of a GRIN result and its reachable heap.
+module Aihc.Grin.Snapshot
+  ( HeapSnapshot (..),
+    SnapshotValue (..),
+    SnapshotCell (..),
+    renderSnapshotReturn,
+    renderSnapshotHeap,
+    renderHeapSnapshot,
+  )
+where
+
+import Aihc.Grin.Syntax
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Data.Text (Text)
+import Data.Text qualified as T
+
+-- | Result values plus the heap cells reachable from them. Location numbers
+-- are assigned in graph-discovery order, so they do not expose interpreter or
+-- native allocator addresses.
+data HeapSnapshot = HeapSnapshot
+  { snapshotReturnValues :: ![SnapshotValue],
+    snapshotHeap :: !(IntMap SnapshotCell)
+  }
+  deriving (Eq, Show)
+
+data SnapshotValue
+  = SnapshotLiteral !GrinLiteral
+  | SnapshotNode !GrinNodeTag ![SnapshotValue]
+  | SnapshotLocation !Int
+  | SnapshotMutVar
+  | SnapshotStateToken
+  deriving (Eq, Show)
+
+data SnapshotCell
+  = SnapshotSuspended !FunctionName ![SnapshotValue]
+  | SnapshotValue !SnapshotValue
+  | SnapshotRaised !SnapshotValue
+  | SnapshotBlackhole
+  deriving (Eq, Show)
+
+renderSnapshotReturn :: HeapSnapshot -> Text
+renderSnapshotReturn snapshot =
+  case snapshotReturnValues snapshot of
+    [] -> "()"
+    [value] -> renderValue False value
+    values -> "(" <> T.intercalate ", " (map (renderValue False) values) <> ")"
+
+renderSnapshotHeap :: HeapSnapshot -> Text
+renderSnapshotHeap snapshot =
+  T.intercalate
+    "\n"
+    [ "@" <> tshow location <> " = " <> renderCell cell
+    | (location, cell) <- IntMap.toAscList (snapshotHeap snapshot)
+    ]
+
+renderHeapSnapshot :: HeapSnapshot -> Text
+renderHeapSnapshot snapshot =
+  "return: "
+    <> renderSnapshotReturn snapshot
+    <> "\nheap:"
+    <> case renderSnapshotHeap snapshot of
+      "" -> " []"
+      heap -> "\n" <> indent heap
+
+renderCell :: SnapshotCell -> Text
+renderCell cell =
+  case cell of
+    SnapshotSuspended functionName fields -> renderNode False (GrinThunk functionName) fields
+    SnapshotValue value -> renderValue False value
+    SnapshotRaised exception -> "<raised " <> renderValue False exception <> ">"
+    SnapshotBlackhole -> "<blackhole>"
+
+renderValue :: Bool -> SnapshotValue -> Text
+renderValue nested value =
+  case value of
+    SnapshotLiteral literal -> renderLiteral literal
+    SnapshotNode tag fields -> renderNode nested tag fields
+    SnapshotLocation location -> "@" <> tshow location
+    SnapshotMutVar -> "<mutvar>"
+    SnapshotStateToken -> "<state>"
+
+renderNode :: Bool -> GrinNodeTag -> [SnapshotValue] -> Text
+renderNode nested tag fields =
+  parenthesize (nested && not (null fields)) $
+    T.unwords (renderNodeTag tag : map (renderValue True) fields)
+
+renderNodeTag :: GrinNodeTag -> Text
+renderNodeTag tag =
+  case tag of
+    GrinConstructor name -> "C" <> name
+    GrinClosure functionName arity -> "P" <> unFunctionName functionName <> "/" <> tshow arity
+    GrinThunk functionName -> "F" <> unFunctionName functionName
+    GrinPrimitive name arity -> "Prim[" <> name <> "/" <> tshow arity <> "]"
+
+renderLiteral :: GrinLiteral -> Text
+renderLiteral literal =
+  case literal of
+    GrinLitInt _ value -> tshow value
+    GrinLitChar _ value -> T.pack (show value) <> "#"
+    GrinLitString value -> T.pack (show (T.unpack value))
+
+parenthesize :: Bool -> Text -> Text
+parenthesize shouldParenthesize value
+  | shouldParenthesize = "(" <> value <> ")"
+  | otherwise = value
+
+indent :: Text -> Text
+indent = T.unlines . map ("  " <>) . T.lines
+
+tshow :: (Show value) => value -> Text
+tshow = T.pack . show

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -153,7 +153,6 @@ data GrinNodeTag
   | -- | A suspended computation. Its target function must return exactly
     -- @BoxedRep Lifted@; unlifted computations are always evaluated strictly.
     GrinThunk !FunctionName
-  | GrinPrimitive !Text !Int
   deriving (Eq, Show, Read)
 
 data GrinAlt = GrinAlt

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -28,6 +28,7 @@ module Aihc.Grin.Syntax
     grinValueRuntimeRep,
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
+    builtinConstructorLayouts,
     builtinConstructors,
   )
 where
@@ -200,14 +201,18 @@ isPointerRuntimeRep runtimeRep =
 -- Keeping their arities with the shared GRIN syntax makes lowering,
 -- interpretation, linting, and native code generation agree on which global
 -- constructor values exist before the program starts.
+builtinConstructorLayouts :: [(Text, [RuntimeRep])]
+builtinConstructorLayouts =
+  [ ("C#", [WordRep]),
+    ("[]", []),
+    (":", [liftedRuntimeRep, liftedRuntimeRep]),
+    ("()", []),
+    ("(,)", [liftedRuntimeRep, liftedRuntimeRep])
+  ]
+
 builtinConstructors :: [(Text, Int)]
 builtinConstructors =
-  [ ("C#", 1),
-    ("[]", 0),
-    (":", 2),
-    ("()", 0),
-    ("(,)", 2)
-  ]
+  [(name, length fields) | (name, fields) <- builtinConstructorLayouts]
 
 data GrinForeignCall = GrinForeignCall
   { grinForeignCallName :: !Text,

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -157,6 +157,12 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "contains a direct primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered)
         assertBool "primitive is not global" (not ("global +#" `isInfixOf` rendered)),
+      testCase "FC lowering wraps partially applied primitives in ordinary closures" $ do
+        let program = lowerProgram partialPrimitiveProgram
+            rendered = renderProgram program
+        assertEqual "lint" [] (lintProgram program)
+        assertBool "allocates an ordinary closure" ("P$grin_primitive_" `isInfixOf` rendered)
+        assertBool "wrapper makes a saturated primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered),
       testCase "FC lowering counts zero-width arguments in closure arity" $ do
         let program = lowerProgram zeroWidthSaturatedApplicationProgram
             rendered = renderProgram program
@@ -601,6 +607,21 @@ primitiveCallProgram =
     addVar = Var "+#" (Unique 29) (TcFunTy intTy (TcFunTy intTy intTy))
     addOneVar = Var "addOne" (Unique 30) (TcFunTy intTy intTy)
     argumentVar = Var "argument" (Unique 31) intTy
+
+partialPrimitiveProgram :: FcProgram
+partialPrimitiveProgram =
+  FcProgram
+    [ FcPrimitive addVar 2,
+      FcTopBind
+        ( FcNonRec
+            makeAdderVar
+            (FcLam firstVar (FcApp (FcVar addVar) (FcVar firstVar)))
+        )
+    ]
+  where
+    addVar = Var "+#" (Unique 130) (TcFunTy intTy (TcFunTy intTy intTy))
+    makeAdderVar = Var "makeAdder" (Unique 131) (TcFunTy intTy (TcFunTy intTy intTy))
+    firstVar = Var "first" (Unique 132) intTy
 
 zeroWidthSaturatedApplicationProgram :: FcProgram
 zeroWidthSaturatedApplicationProgram =

--- a/docs/arm64-runtime-objects.md
+++ b/docs/arm64-runtime-objects.md
@@ -1,0 +1,27 @@
+# ARM64 runtime objects
+
+Native heap objects use a one-word tagged header followed by shape-specific
+payload words. The low three header bits are the physical tag. The remaining
+bits contain either an aligned function entry address or an immediate info
+identifier.
+
+```text
+saturated constructor: [header] [fields...]
+thunk:                 [header] [environment...]
+partial application:   [header] [shape] [fields...]
+indirection:           [header] [target]
+blackhole:             [header] [unused]
+```
+
+The shape word exists only for closures, partial constructors, and primitives.
+It packs the remaining logical arity and current field count into one word.
+Saturated constructors derive their field count from constructor metadata;
+thunks derive it from their function signature.
+
+Every updateable object reserves at least two words. Evaluating a thunk changes
+its header to `BLACKHOLE`, executes the entry encoded by its old header, then
+changes the same object to `INDIRECTION` and writes the returned heap pointer
+into its first payload word. There is no separate cell allocation.
+
+Exceptions have no native heap tag or object representation. They are removed
+before native runtime lowering. Unused tag values remain reserved.

--- a/docs/arm64-runtime-objects.md
+++ b/docs/arm64-runtime-objects.md
@@ -13,10 +13,14 @@ indirection:           [header] [target]
 blackhole:             [header] [unused]
 ```
 
-The shape word exists only for closures, partial constructors, and primitives.
+The shape word exists only for closures and partial constructors.
 It packs the remaining logical arity and current field count into one word.
 Saturated constructors derive their field count from constructor metadata;
 thunks derive it from their function signature.
+
+Primitive operations have no heap-object tag. A partially applied primitive is
+lowered to an ordinary closure whose generated entry makes the saturated
+primitive call.
 
 Every updateable object reserves at least two words. Evaluating a thunk changes
 its header to `BLACKHOLE`, executes the entry encoded by its old header, then

--- a/docs/grin-snapshot-tests.md
+++ b/docs/grin-snapshot-tests.md
@@ -31,9 +31,8 @@ heap:
   @0 = CLoop @0
 ```
 
-Nodes owned by reachable value cells are rendered through their heap location,
-even when evaluation also returns the node pointer directly. Updated thunk
-cells name their target explicitly:
+Stored nodes are the reachable heap objects themselves. When evaluation updates
+a thunk, that same object becomes an explicit indirection:
 
 ```text
 return: @0
@@ -43,7 +42,7 @@ heap:
   @2 = CI32# 7
 ```
 
-Snapshotting reads heap cells but never enters them. A suspended thunk remains
+Snapshotting reads heap objects but never enters them. A suspended thunk remains
 `F$function`, and a closure remains `P$function/arity`. Only an explicit
 `GrinEval` executed by the fixture may evaluate a thunk. Native code pointers
 are recovered through descriptor tables generated beside the assembly, so

--- a/docs/grin-snapshot-tests.md
+++ b/docs/grin-snapshot-tests.md
@@ -31,6 +31,18 @@ heap:
   @0 = CLoop @0
 ```
 
+Nodes owned by reachable value cells are rendered through their heap location,
+even when evaluation also returns the node pointer directly. Updated thunk
+cells name their target explicitly:
+
+```text
+return: @0
+heap:
+  @0 = CPair @1 @2
+  @1 = Indirection @2
+  @2 = CI32# 7
+```
+
 Snapshotting reads heap cells but never enters them. A suspended thunk remains
 `F$function`, and a closure remains `P$function/arity`. Only an explicit
 `GrinEval` executed by the fixture may evaluate a thunk. Native code pointers

--- a/docs/grin-snapshot-tests.md
+++ b/docs/grin-snapshot-tests.md
@@ -1,0 +1,43 @@
+# GRIN heap snapshot tests
+
+GRIN snapshot fixtures execute the same hand-written program with the reference
+interpreter and the native AArch64 backend. Each fixture independently asserts
+the returned values and the reachable abstract GRIN heap.
+
+Fixtures live under
+`components/aihc-arm64/test/Test/Fixtures/snapshot`:
+
+```yaml
+entry: $entry
+program: |
+  constructor I32#/1 [Int32Rep]
+
+  $entry -> BoxedRep Lifted =
+    store (CI32# (1 :: Int32Rep))
+return: "@0"
+heap: |
+  @0 = CI32# 1
+status: pass
+reason: a stored constructor is returned as a location
+```
+
+Locations are numbered by traversal from the returned values, not by allocator
+address. This makes native and interpreted snapshots comparable and preserves
+sharing and cycles:
+
+```text
+return: @0
+heap:
+  @0 = CLoop @0
+```
+
+Snapshotting reads heap cells but never enters them. A suspended thunk remains
+`F$function`, and a closure remains `P$function/arity`. Only an explicit
+`GrinEval` executed by the fixture may evaluate a thunk. Native code pointers
+are recovered through descriptor tables generated beside the assembly, so
+snapshot output does not depend on debug symbols or raw addresses.
+
+The focused fixture parser currently accepts constructor and function
+declarations plus `constant`, `store`, `store-rec`, `eval`, `apply`,
+`call`, and inline binds. Variables and literals carry explicit runtime
+representations.

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -63,6 +63,7 @@ in rec {
     ".hs"
     ".cabal"
     ".c"
+    ".h"
     ".yaml"
     ".yml"
   ];

--- a/test/support/Aihc/Testing/GrinProgram.hs
+++ b/test/support/Aihc/Testing/GrinProgram.hs
@@ -1,0 +1,275 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Parser for the focused human-readable GRIN dialect used by runtime
+-- fixtures. The accepted subset grows with the runtime operations exercised
+-- by hand-written tests.
+module Aihc.Testing.GrinProgram
+  ( parseProgram,
+  )
+where
+
+import Aihc.Grin.Syntax
+import Aihc.Tc.Types (RuntimeRep)
+import Control.Monad (unless, when)
+import Data.Char (isDigit)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Text.Read (readMaybe)
+
+data SourceLine = SourceLine
+  { sourceIndent :: !Int,
+    sourceText :: !Text
+  }
+
+parseProgram :: Text -> Either String GrinProgram
+parseProgram source = do
+  lines' <- traverse sourceLine (filter (not . T.null . T.strip) (T.lines source))
+  (constructors, functions) <- parseDeclarations lines'
+  pure
+    GrinProgram
+      { grinConstructors = constructors,
+        grinPrimitives = [],
+        grinForeignCalls = [],
+        grinExternalGlobals = [],
+        grinExternalFunctions = [],
+        grinWhnfGlobals = [],
+        grinCafs = [],
+        grinFunctions = functions
+      }
+
+sourceLine :: Text -> Either String SourceLine
+sourceLine line = do
+  when (T.isInfixOf "\t" line) (Left "tabs are not allowed in GRIN indentation")
+  let indentation = T.length (T.takeWhile (== ' ') line)
+  pure SourceLine {sourceIndent = indentation, sourceText = T.strip line}
+
+parseDeclarations :: [SourceLine] -> Either String ([(Text, [RuntimeRep])], [GrinFunction])
+parseDeclarations = go [] []
+  where
+    go constructors functions [] = pure (reverse constructors, reverse functions)
+    go constructors functions (line : rest)
+      | sourceIndent line /= 0 = Left ("top-level declaration is indented: " <> T.unpack (sourceText line))
+      | T.isPrefixOf "constructor " (sourceText line) = do
+          constructor <- parseConstructor (T.drop (T.length ("constructor " :: Text)) (sourceText line))
+          go (constructor : constructors) functions rest
+      | otherwise = do
+          let (bodyLines, remaining) = span ((> 0) . sourceIndent) rest
+          function <- parseFunction (sourceText line) bodyLines
+          go constructors (function : functions) remaining
+
+parseConstructor :: Text -> Either String (Text, [RuntimeRep])
+parseConstructor text = do
+  let (headText, layoutTextWithSpace) = T.breakOn " [" text
+  unless (not (T.null layoutTextWithSpace) && T.last layoutTextWithSpace == ']') $
+    Left ("invalid constructor declaration: " <> T.unpack text)
+  let (nameWithSlash, arityText) = T.breakOnEnd "/" headText
+      name = T.dropEnd 1 nameWithSlash
+  arity <- readText "constructor arity" arityText
+  let layoutText = T.dropEnd 1 (T.drop 2 layoutTextWithSpace)
+      repTexts = if T.null (T.strip layoutText) then [] else map T.strip (T.splitOn "," layoutText)
+  reps <- traverse (readRuntimeRep "constructor field") repTexts
+  unless (arity == length reps) $
+    Left ("constructor arity does not match its layout: " <> T.unpack text)
+  pure (name, reps)
+
+parseFunction :: Text -> [SourceLine] -> Either String GrinFunction
+parseFunction header bodyLines = do
+  let (left, resultWithArrow) = T.breakOn " -> " header
+  unless (not (T.null resultWithArrow) && T.isSuffixOf " =" resultWithArrow) $
+    Left ("invalid function header: " <> T.unpack header)
+  let (name, parametersText) = T.break isSpaceChar left
+      resultText = T.dropEnd 2 (T.drop 4 resultWithArrow)
+  parameters <- parseVarAtoms parametersText
+  resultRep <- readRuntimeRep "function result" (T.strip resultText)
+  body <-
+    case bodyLines of
+      [] -> Left ("function has no body: " <> T.unpack name)
+      first : _ -> do
+        (expression, remaining) <- parseExpr (sourceIndent first) bodyLines
+        case remaining of
+          unexpected : _ ->
+            Left ("unconsumed function body near: " <> T.unpack (sourceText unexpected))
+          [] -> pure ()
+        pure expression
+  pure
+    GrinFunction
+      { grinFunctionName = FunctionName name,
+        grinFunctionLinkName = Nothing,
+        grinFunctionParameters = parameters,
+        grinFunctionResultRep = resultRep,
+        grinFunctionBody = body
+      }
+
+parseExpr :: Int -> [SourceLine] -> Either String (GrinExpr, [SourceLine])
+parseExpr indentation lines' =
+  case lines' of
+    [] -> Left "expected a GRIN expression"
+    line : rest
+      | sourceIndent line /= indentation ->
+          Left ("unexpected expression indentation: " <> T.unpack (sourceText line))
+      | sourceText line == "store-rec" -> parseStoreRec indentation rest
+      | otherwise ->
+          case T.breakOn " <- " (sourceText line) of
+            (bindersText, rhsWithArrow)
+              | not (T.null rhsWithArrow) -> do
+                  binders <- parseVarAtoms bindersText
+                  rhs <- parseAtomicExpr (T.drop 4 rhsWithArrow)
+                  (body, remaining) <- parseExpr indentation rest
+                  pure (GrinBind binders rhs body, remaining)
+            _ -> (,rest) <$> parseAtomicExpr (sourceText line)
+
+parseStoreRec :: Int -> [SourceLine] -> Either String (GrinExpr, [SourceLine])
+parseStoreRec indentation lines' = do
+  bindingIndent <-
+    case lines' of
+      line : _
+        | sourceIndent line > indentation -> pure (sourceIndent line)
+      _ -> Left "store-rec has no bindings"
+  let (bindingLines, bodyLines) = span ((== bindingIndent) . sourceIndent) lines'
+  bindings <- traverse parseBinding bindingLines
+  (body, remaining) <- parseExpr indentation bodyLines
+  pure (GrinStoreRec bindings body, remaining)
+  where
+    parseBinding line = do
+      let (varText, nodeWithEquals) = T.breakOn " = " (sourceText line)
+      when (T.null nodeWithEquals) $
+        Left ("invalid store-rec binding: " <> T.unpack (sourceText line))
+      var <- parseVarAtom varText
+      node <- parseNode (T.drop 3 nodeWithEquals)
+      pure (var, node)
+
+parseAtomicExpr :: Text -> Either String GrinExpr
+parseAtomicExpr text
+  | Just valuesText <- T.stripPrefix "constant" text =
+      GrinConstant <$> parseValueAtoms valuesText
+  | Just nodeText <- T.stripPrefix "store " text =
+      GrinStore <$> parseNode nodeText
+  | Just rest <- T.stripPrefix "eval " text = do
+      (runtimeRep, valueText) <- parseRuntimeRepArgument rest
+      value <- parseValueAtom valueText
+      pure (GrinEval runtimeRep value)
+  | Just rest <- T.stripPrefix "apply " text = do
+      (runtimeRep, operandsText) <- parseRuntimeRepArgument rest
+      operands <- parseValueAtoms operandsText
+      case operands of
+        function : arguments -> pure (GrinApply runtimeRep function arguments)
+        [] -> Left "apply has no function operand"
+  | Just rest <- T.stripPrefix "call " text = do
+      (runtimeRep, callText) <- parseRuntimeRepArgument rest
+      let (name, argumentsText) = T.break isSpaceChar (T.strip callText)
+      arguments <- parseValueAtoms argumentsText
+      pure (GrinCall runtimeRep (FunctionName name) arguments)
+  | otherwise = Left ("unsupported GRIN expression: " <> T.unpack text)
+
+parseRuntimeRepArgument :: Text -> Either String (RuntimeRep, Text)
+parseRuntimeRepArgument text = do
+  rest <- maybe (Left "runtime representation argument must start with @") pure (T.stripPrefix "@" (T.strip text))
+  if T.isPrefixOf "(" rest
+    then do
+      (repText, remaining) <- takeParenthesized rest
+      rep <- readRuntimeRep "runtime representation argument" repText
+      pure (rep, T.strip remaining)
+    else do
+      let (repText, remaining) = T.break isSpaceChar rest
+      rep <- readRuntimeRep "runtime representation argument" repText
+      pure (rep, T.strip remaining)
+
+parseNode :: Text -> Either String GrinNode
+parseNode text = do
+  (inside, remaining) <- takeParenthesized (T.strip text)
+  unless (T.null (T.strip remaining)) (Left ("unexpected text after node: " <> T.unpack remaining))
+  let (tagText, fieldsText) = T.break isSpaceChar inside
+  tag <- parseNodeTag tagText
+  fields <- parseValueAtoms fieldsText
+  pure (GrinNode tag fields)
+
+parseNodeTag :: Text -> Either String GrinNodeTag
+parseNodeTag tag
+  | Just closure <- T.stripPrefix "P" tag = do
+      let (nameWithSlash, arityText) = T.breakOnEnd "/" closure
+      when (T.null nameWithSlash) (Left ("closure tag has no arity: " <> T.unpack tag))
+      arity <- readText "closure arity" arityText
+      pure (GrinClosure (FunctionName (T.dropEnd 1 nameWithSlash)) arity)
+  | Just thunk <- T.stripPrefix "F" tag = pure (GrinThunk (FunctionName thunk))
+  | Just constructor <- T.stripPrefix "C" tag = pure (GrinConstructor constructor)
+  | otherwise = Left ("unsupported node tag: " <> T.unpack tag)
+
+parseVarAtoms :: Text -> Either String [GrinVar]
+parseVarAtoms text = traverse parseVarAtom =<< parseAtomTexts text
+
+parseValueAtoms :: Text -> Either String [GrinValue]
+parseValueAtoms text = traverse parseValueAtom =<< parseAtomTexts text
+
+parseValueAtom :: Text -> Either String GrinValue
+parseValueAtom text = do
+  (inside, remaining) <- takeParenthesized (T.strip text)
+  unless (T.null (T.strip remaining)) (Left ("unexpected text after value: " <> T.unpack remaining))
+  let (valueText, repWithSeparator) = T.breakOn " :: " inside
+  when (T.null repWithSeparator) (Left ("value has no runtime representation: " <> T.unpack text))
+  runtimeRep <- readRuntimeRep "value" (T.drop 4 repWithSeparator)
+  if isInteger valueText
+    then GrinLitValue . GrinLitInt runtimeRep <$> readText "integer literal" valueText
+    else GrinVarValue <$> parseVarParts valueText runtimeRep
+
+parseVarAtom :: Text -> Either String GrinVar
+parseVarAtom text =
+  case parseValueAtom text of
+    Right (GrinVarValue var) -> pure var
+    Right _ -> Left ("expected variable binder: " <> T.unpack text)
+    Left err -> Left err
+
+parseVarParts :: Text -> RuntimeRep -> Either String GrinVar
+parseVarParts text runtimeRep = do
+  let (nameWithPercent, uniqueText) = T.breakOnEnd "%" text
+  when (T.null nameWithPercent) (Left ("variable has no unique: " <> T.unpack text))
+  unique <- readText "variable unique" uniqueText
+  pure (GrinVar (T.dropEnd 1 nameWithPercent) unique runtimeRep)
+
+parseAtomTexts :: Text -> Either String [Text]
+parseAtomTexts text =
+  case T.strip text of
+    "" -> pure []
+    remaining -> do
+      (inside, rest) <- takeParenthesized remaining
+      atoms <- parseAtomTexts rest
+      pure (("(" <> inside <> ")") : atoms)
+
+takeParenthesized :: Text -> Either String (Text, Text)
+takeParenthesized text =
+  case T.uncons (T.stripStart text) of
+    Just ('(', rest) -> go 1 [] rest
+    _ -> Left ("expected parenthesized value: " <> T.unpack text)
+  where
+    go :: Int -> [Char] -> Text -> Either String (Text, Text)
+    go _ _ "" = Left ("unterminated parenthesized value: " <> T.unpack text)
+    go depth chunks remaining =
+      case T.uncons remaining of
+        Nothing -> Left ("unterminated parenthesized value: " <> T.unpack text)
+        Just (character, tailText)
+          | character == '(' -> go (depth + 1) (character : chunks) tailText
+          | character == ')' && depth == 1 -> pure (T.pack (reverse chunks), tailText)
+          | character == ')' -> go (depth - 1) (character : chunks) tailText
+          | otherwise -> go depth (character : chunks) tailText
+
+readRuntimeRep :: String -> Text -> Either String RuntimeRep
+readRuntimeRep = readMaybeText
+
+readText :: (Read value) => String -> Text -> Either String value
+readText = readMaybeText
+
+readMaybeText :: (Read value) => String -> Text -> Either String value
+readMaybeText context text =
+  maybe
+    (Left ("invalid " <> context <> ": " <> T.unpack text))
+    pure
+    (readMaybe (T.unpack (T.strip text)))
+
+isInteger :: Text -> Bool
+isInteger text =
+  case T.unpack text of
+    '-' : digits -> not (null digits) && all isDigit digits
+    digits -> not (null digits) && all isDigit digits
+
+isSpaceChar :: Char -> Bool
+isSpaceChar = (== ' ')


### PR DESCRIPTION
## Summary

- add stable, non-evaluating GRIN heap snapshots for interpreter and native ARM64 execution
- symbolize native constructor and function pointers through generated descriptor tables
- preserve heap-pointer identity and render updated thunk cells as explicit `Indirection @n` edges
- replace wrapper cells and four-word headers with compact, directly updateable tagged objects
- remove primitive heap objects and lower partial primitive applications to ordinary closures
- add handwritten GRIN fixtures covering stored, linked, recursive, suspended, unboxed, `GrinEval`, and `GrinApply` results
- lower recursive GRIN heap allocation in the ARM64 backend

## Why

GRIN runtime tests could inspect interpreted values, but native execution discarded the final result and exposed only raw heap and code addresses. This gives both engines the same address-independent return-and-heap representation without implicitly evaluating suspended computations. Only explicit `GrinEval` nodes force values.

## Test progress

- GRIN interpreter/native snapshot cases: +7
- GRIN suite: 119 to 120 tests
- ARM64 suite: 11 to 19 tests
- README progress files remain unchanged because they are cron-managed

## Validation

- `just fmt`
- `just check`
- `just test`
- `cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'`
