### PR TITLE
test(arm64): cover blackholed thunk re-entry

### DIFF
--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -26,9 +26,10 @@ import Aihc.Testing.EvalFixture (EvalCase (..), compileEvalCase, evalBindingName
 import Aihc.Testing.GrinProgram (parseProgram)
 import Control.Exception (bracket)
 import Control.Monad (when)
-import Data.Aeson (FromJSON (..), withObject, (.:))
+import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
 import Data.List (find, isInfixOf)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Yaml qualified as Y
@@ -247,14 +248,19 @@ data SnapshotCase = SnapshotCase
   { snapshotCaseName :: !String,
     snapshotCaseProgram :: !GrinProgram,
     snapshotCaseEntry :: !FunctionName,
-    snapshotCaseExpected :: !T.Text
+    snapshotCaseExpectation :: !SnapshotExpectation
   }
+
+data SnapshotExpectation
+  = SnapshotSuccess !T.Text
+  | SnapshotFailure !T.Text
 
 data SnapshotFixture = SnapshotFixture
   { snapshotFixtureEntry :: !T.Text,
     snapshotFixtureProgram :: !T.Text,
-    snapshotFixtureReturn :: !T.Text,
-    snapshotFixtureHeap :: !T.Text,
+    snapshotFixtureReturn :: !(Maybe T.Text),
+    snapshotFixtureHeap :: !(Maybe T.Text),
+    snapshotFixtureError :: !(Maybe T.Text),
     snapshotFixtureStatus :: !T.Text,
     snapshotFixtureReason :: !T.Text
   }
@@ -265,8 +271,9 @@ instance FromJSON SnapshotFixture where
       SnapshotFixture
         <$> object .: "entry"
         <*> object .: "program"
-        <*> object .: "return"
-        <*> object .: "heap"
+        <*> object .:? "return"
+        <*> object .:? "heap"
+        <*> object .:? "error"
         <*> object .: "status"
         <*> object .: "reason"
 
@@ -278,6 +285,7 @@ snapshotCases =
     ("stores a self-referential value", "store-self-referential.yaml"),
     ("returns an unboxed value", "return-unboxed.yaml"),
     ("evaluates only through GrinEval", "eval.yaml"),
+    ("rejects blackholed thunk re-entry", "eval-blackhole.yaml"),
     ("applies a stored closure", "apply.yaml")
   ]
 
@@ -287,14 +295,10 @@ snapshotTest (name, fixtureName) =
     snapshotCase <- loadSnapshotCase name fixtureName
     let program = snapshotCaseProgram snapshotCase
         entry = snapshotCaseEntry snapshotCase
-        expected = T.stripEnd (snapshotCaseExpected snapshotCase)
+        expectation = snapshotCaseExpectation snapshotCase
     assertEqual "direct GRIN lint" [] (lintProgram program)
     interpreted <- interpretProgramFunctionSnapshot entry program
-    snapshot <-
-      case interpreted of
-        Left err -> assertFailure ("GRIN interpreter failed: " <> show err)
-        Right value -> pure value
-    assertEqual "interpreter snapshot" expected (T.stripEnd (renderHeapSnapshot snapshot))
+    assertInterpretedExpectation expectation interpreted
     let cps = expectCpsGrin program
     assertEqual "CPS GRIN lint" [] (lintProgram (cpsGrinProgram cps))
     observed <-
@@ -303,7 +307,37 @@ snapshotTest (name, fixtureName) =
         Right value -> pure value
     when (arch == "aarch64" && os == "darwin") $ do
       native <- runObservedProgram observed
-      assertEqual "native snapshot" expected (T.stripEnd native)
+      assertNativeExpectation expectation native
+
+assertInterpretedExpectation :: SnapshotExpectation -> Either InterpretError HeapSnapshot -> IO ()
+assertInterpretedExpectation expectation interpreted =
+  case (expectation, interpreted) of
+    (SnapshotSuccess expected, Right snapshot) ->
+      assertEqual "interpreter snapshot" (T.stripEnd expected) (T.stripEnd (renderHeapSnapshot snapshot))
+    (SnapshotFailure expected, Left err) ->
+      assertEqual "interpreter error" expected (renderInterpretFailure err)
+    (SnapshotSuccess _, Left err) ->
+      assertFailure ("GRIN interpreter failed: " <> show err)
+    (SnapshotFailure _, Right snapshot) ->
+      assertFailure ("GRIN interpreter unexpectedly succeeded:\n" <> T.unpack (renderHeapSnapshot snapshot))
+
+assertNativeExpectation :: SnapshotExpectation -> Either T.Text T.Text -> IO ()
+assertNativeExpectation expectation native =
+  case (expectation, native) of
+    (SnapshotSuccess expected, Right snapshot) ->
+      assertEqual "native snapshot" (T.stripEnd expected) (T.stripEnd snapshot)
+    (SnapshotFailure expected, Left err) ->
+      assertEqual "native error" expected err
+    (SnapshotSuccess _, Left err) ->
+      assertFailure ("native snapshot failed: " <> T.unpack err)
+    (SnapshotFailure _, Right snapshot) ->
+      assertFailure ("native snapshot unexpectedly succeeded:\n" <> T.unpack snapshot)
+
+renderInterpretFailure :: InterpretError -> T.Text
+renderInterpretFailure err =
+  case err of
+    InterpretBlackhole _ -> "blackholed thunk re-entered"
+    _ -> T.pack (show err)
 
 loadSnapshotCase :: String -> FilePath -> IO SnapshotCase
 loadSnapshotCase name fixtureName = do
@@ -319,20 +353,27 @@ loadSnapshotCase name fixtureName = do
     case parseProgram (snapshotFixtureProgram fixture) of
       Left err -> assertFailure ("invalid GRIN program: " <> err)
       Right value -> pure value
-  let heap = T.stripEnd (snapshotFixtureHeap fixture)
-      expected
-        | heap == "[]" = "return: " <> snapshotFixtureReturn fixture <> "\nheap: []"
-        | otherwise =
-            "return: "
-              <> snapshotFixtureReturn fixture
-              <> "\nheap:\n"
-              <> T.unlines (map ("  " <>) (T.lines heap))
+  expectation <-
+    case (snapshotFixtureReturn fixture, snapshotFixtureHeap fixture, snapshotFixtureError fixture) of
+      (Just returnValue, Just heapValue, Nothing) -> do
+        let heap = T.stripEnd heapValue
+            expected
+              | heap == "[]" = "return: " <> returnValue <> "\nheap: []"
+              | otherwise =
+                  "return: "
+                    <> returnValue
+                    <> "\nheap:\n"
+                    <> T.unlines (map ("  " <>) (T.lines heap))
+        pure (SnapshotSuccess expected)
+      (Nothing, Nothing, Just err)
+        | not (T.null (T.strip err)) -> pure (SnapshotFailure (T.strip err))
+      _ -> assertFailure "snapshot fixture must define either return and heap, or a non-empty error"
   pure
     SnapshotCase
       { snapshotCaseName = name,
         snapshotCaseProgram = program,
         snapshotCaseEntry = FunctionName (snapshotFixtureEntry fixture),
-        snapshotCaseExpected = expected
+        snapshotCaseExpectation = expectation
       }
 
 snapshotFixtureRoot :: IO FilePath
@@ -349,7 +390,7 @@ snapshotFixtureRoot = getCurrentDirectory >>= findRoot
             then assertFailure "GRIN snapshot fixture root is missing"
             else findRoot parent
 
-runObservedProgram :: ObservedProgram -> IO T.Text
+runObservedProgram :: ObservedProgram -> IO (Either T.Text T.Text)
 runObservedProgram observed =
   withTempDirectory "aihc-arm64-snapshot" $ \directory -> do
     runtime <- runtimeSourcePath
@@ -381,8 +422,18 @@ runObservedProgram observed =
       ExitSuccess -> pure ()
       ExitFailure _ -> assertFailure ("clang failed to assemble observed GRIN:\n" <> clangErr)
     (programExit, programOut, programErr) <- readProcessWithExitCode executablePath [] ""
-    assertEqual ("native stderr: " <> programErr) ExitSuccess programExit
-    pure (T.pack programOut)
+    case programExit of
+      ExitSuccess -> do
+        assertEqual "native stderr" "" programErr
+        pure (Right (T.pack programOut))
+      ExitFailure _ -> do
+        assertEqual "native stdout" "" programOut
+        pure (Left (renderNativeFailure (T.pack programErr)))
+
+renderNativeFailure :: T.Text -> T.Text
+renderNativeFailure stderr =
+  let message = T.strip stderr
+   in fromMaybe message (T.stripPrefix "aihc runtime: " message)
 
 explicitEvaluationProgram :: GrinProgram
 explicitEvaluationProgram =

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/eval-blackhole.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/eval-blackhole.yaml
@@ -1,0 +1,12 @@
+entry: $entry
+program: |
+  $loop (self%1 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    eval @(BoxedRep Lifted) (self%1 :: BoxedRep Lifted)
+
+  $entry -> BoxedRep Lifted =
+    store-rec
+      (self%2 :: BoxedRep Lifted) = (F$loop (self%2 :: BoxedRep Lifted))
+    eval @(BoxedRep Lifted) (self%2 :: BoxedRep Lifted)
+error: blackholed thunk re-entered
+status: pass
+reason: re-entering a thunk while its evaluation is in progress reports the blackhole instead of recursing indefinitely

--- a/docs/grin-snapshot-tests.md
+++ b/docs/grin-snapshot-tests.md
@@ -48,6 +48,15 @@ Snapshotting reads heap objects but never enters them. A suspended thunk remains
 are recovered through descriptor tables generated beside the assembly, so
 snapshot output does not depend on debug symbols or raw addresses.
 
+Fixtures may replace `return` and `heap` with an `error` expectation. These
+cases assert the same stable runtime diagnostic from the interpreter and native
+execution. For example, a thunk that re-enters itself while it is marked as a
+blackhole uses:
+
+```yaml
+error: blackholed thunk re-entered
+```
+
 The focused fixture parser currently accepts constructor and function
 declarations plus `constant`, `store`, `store-rec`, `eval`, `apply`,
 `call`, and inline binds. Variables and literals carry explicit runtime


### PR DESCRIPTION
## Summary

- extend raw GRIN snapshot fixtures with stable `error` expectations
- add a recursively stored thunk that re-enters itself during `GrinEval`
- assert the same `blackholed thunk re-entered` diagnostic from the GRIN interpreter and native AArch64 runtime
- document negative snapshot fixtures

## Why

Thunk evaluation replaces the node tag with `AIHC_TAG_BLACKHOLE`. If the thunk's evaluation depends on that same node, re-entry must fail deterministically instead of recursing indefinitely. The runtime already reports this condition, but the shared interpreter/native snapshot infrastructure did not support error expectations, so the behavior was not covered end to end.

## Impact

The snapshot harness can now express expected runtime failures as well as successful return/heap snapshots. The new regression proves blackhole detection in both execution engines without changing runtime behavior.

## Test progress

- GRIN interpreter/native snapshot cases: +1 (7 to 8)
- ARM64 suite: +1 (19 to 20)
- README progress files remain unchanged because they are cron-managed

## Validation

- `cabal test -v0 aihc-arm64:spec --test-options="--pattern blackholed --hide-successes"`
- `cabal test -v0 aihc-arm64:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
