### PR TITLE
feat(grin): make continuations explicit in CPS

### DIFF
--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -3,35 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-enum {
-  AIHC_CONT_NORMAL = 0,
-  AIHC_CONT_UPDATE = 1,
-  AIHC_CONT_TOP = 2,
-  AIHC_CONT_FINAL = 3,
-};
-
-typedef struct AihcContinuation AihcContinuation;
-
-struct AihcContinuation {
-  uint64_t kind;
-  AihcContinuation *parent;
-  union {
-    struct {
-      void *code;
-      AihcSlot *locals;
-      uint64_t slot;
-      uint64_t count;
-    } normal;
-    struct {
-      AihcValue *object;
-    } update;
-  } payload;
-};
-
 typedef struct {
   void *next;
   AihcSlot *args;
-  AihcContinuation *continuation;
   AihcSlot *globals;
   AihcSlot *locals;
   void *exit_code;
@@ -52,15 +26,6 @@ static void *aihc_allocate(size_t bytes) {
     aihc_fail("out of memory");
   }
   return pointer;
-}
-
-static AihcContinuation *aihc_push_special(AihcMachine *machine,
-                                            uint64_t kind) {
-  AihcContinuation *continuation = aihc_allocate(sizeof(*continuation));
-  continuation->kind = kind;
-  continuation->parent = machine->continuation;
-  machine->continuation = continuation;
-  return continuation;
 }
 
 static uintptr_t aihc_make_header(uint64_t tag, uintptr_t info) {
@@ -89,8 +54,10 @@ static AihcSlot aihc_make_shape(uint64_t arity, uint64_t count) {
 
 AihcValue *aihc_make_node(uint64_t tag, uintptr_t info, uint64_t arity,
                           uint64_t count) {
-  uint64_t shape_words =
-      tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_PARTIAL_CONSTRUCTOR ? 1 : 0;
+  uint64_t shape_words = tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_THUNK ||
+                                 tag == AIHC_TAG_PARTIAL_CONSTRUCTOR
+                             ? 1
+                             : 0;
   uint64_t object_words = 1 + shape_words + count;
   if (object_words < 2) {
     object_words = 2;
@@ -100,14 +67,13 @@ AihcValue *aihc_make_node(uint64_t tag, uintptr_t info, uint64_t arity,
   if (shape_words != 0) {
     value->fields[0] = aihc_make_shape(arity, count);
   } else if (arity != 0) {
-    aihc_fail("only partial applications may carry dynamic arity");
+    aihc_fail("only functions and partial applications may carry shape");
   }
   return value;
 }
 
 static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t result_tag,
-                                        uint64_t result_arity,
-                                        uint64_t count,
+                                        uint64_t result_arity, uint64_t count,
                                         const AihcSlot *fields) {
   uint64_t original_count = aihc_value_count(value);
   AihcValue *copy =
@@ -124,11 +90,12 @@ static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t result_tag,
   return copy;
 }
 
-static AihcSlot *aihc_arguments_with_fields(AihcValue *function,
-                                             uint64_t count,
-                                             const AihcSlot *fields) {
+static AihcSlot *aihc_arguments(AihcValue *function, uint64_t count,
+                                const AihcSlot *values,
+                                AihcValue *continuation) {
   uint64_t field_count = aihc_value_count(function);
-  uint64_t total = field_count + count;
+  uint64_t continuation_count = continuation == NULL ? 0 : 1;
+  uint64_t total = field_count + count + continuation_count;
   AihcSlot *arguments =
       aihc_allocate(sizeof(*arguments) * (total == 0 ? 1 : total));
   AihcSlot *function_fields = aihc_value_fields(function);
@@ -136,16 +103,20 @@ static AihcSlot *aihc_arguments_with_fields(AihcValue *function,
     arguments[index] = function_fields[index];
   }
   for (uint64_t index = 0; index < count; ++index) {
-    arguments[field_count + index] = fields[index];
+    arguments[field_count + index] = values[index];
+  }
+  if (continuation != NULL) {
+    arguments[field_count + count] = (AihcSlot)continuation;
   }
   return arguments;
 }
 
-static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
-                                        const AihcSlot *values);
-static void aihc_return_value(AihcMachine *machine, AihcSlot value);
-static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
-                            uint64_t result_is_lifted);
+static void aihc_schedule(AihcMachine *machine, AihcValue *function,
+                          AihcSlot *arguments) {
+  machine->next = (void *)aihc_value_info(function);
+  machine->args = arguments;
+  machine->locals = NULL;
+}
 
 void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field) {
   aihc_value_fields(value)[index] = field;
@@ -163,40 +134,42 @@ AihcSlot *aihc_alloc_locals(uint64_t count) {
 
 void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
 
-void aihc_push_normal(AihcMachine *machine, void *code, AihcSlot *locals,
-                      uint64_t slot, uint64_t count) {
-  AihcContinuation *continuation = aihc_push_special(machine, AIHC_CONT_NORMAL);
-  continuation->payload.normal.code = code;
-  continuation->payload.normal.locals = locals;
-  continuation->payload.normal.slot = slot;
-  continuation->payload.normal.count = count;
+void aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
+                          uint64_t count, const AihcSlot *values) {
+  if (continuation == NULL || aihc_value_tag(continuation) != AIHC_TAG_CLOSURE) {
+    aihc_fail("attempted to invoke a non-continuation value");
+  }
+  if (aihc_value_arity(continuation) != 1) {
+    aihc_fail("continuation closure does not accept exactly one result");
+  }
+  aihc_schedule(machine, continuation,
+                aihc_arguments(continuation, count, values, NULL));
 }
 
-static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
-                                   AihcSlot *arguments) {
-  machine->next = (void *)aihc_value_info(function);
-  machine->args = arguments;
-  machine->locals = NULL;
+static void aihc_continue_value(AihcMachine *machine,
+                                AihcValue *continuation, AihcSlot value) {
+  aihc_continue_values(machine, continuation, 1, &value);
 }
 
-static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
-                              uint64_t count,
-                              const AihcSlot *arguments) {
+void aihc_apply_cps(AihcMachine *machine, AihcValue *function, uint64_t count,
+                    const AihcSlot *arguments, AihcValue *continuation) {
+  if (function == NULL) {
+    aihc_fail("attempted to apply null");
+  }
   switch (aihc_value_tag(function)) {
   case AIHC_TAG_CLOSURE: {
     uint64_t arity = aihc_value_arity(function);
     if (arity > 1) {
       AihcValue *applied = aihc_copy_with_fields(
           function, AIHC_TAG_CLOSURE, arity - 1, count, arguments);
-      aihc_return_value(machine, (AihcSlot)applied);
+      aihc_continue_value(machine, continuation, (AihcSlot)applied);
       return;
     }
     if (arity == 0) {
       aihc_fail("saturated closure was applied");
     }
-    aihc_schedule_function(machine, function,
-                           aihc_arguments_with_fields(function, count,
-                                                      arguments));
+    aihc_schedule(machine, function,
+                  aihc_arguments(function, count, arguments, continuation));
     return;
   }
   case AIHC_TAG_PARTIAL_CONSTRUCTOR: {
@@ -205,7 +178,7 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
       AihcValue *applied = aihc_copy_with_fields(
           function, AIHC_TAG_PARTIAL_CONSTRUCTOR, arity - 1, count,
           arguments);
-      aihc_return_value(machine, (AihcSlot)applied);
+      aihc_continue_value(machine, continuation, (AihcSlot)applied);
       return;
     }
     if (arity == 0) {
@@ -213,7 +186,7 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
     }
     AihcValue *applied = aihc_copy_with_fields(
         function, AIHC_TAG_NODE, 0, count, arguments);
-    aihc_return_value(machine, (AihcSlot)applied);
+    aihc_continue_value(machine, continuation, (AihcSlot)applied);
     return;
   }
   default:
@@ -221,122 +194,62 @@ static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
   }
 }
 
-static void aihc_eval_value(AihcMachine *machine, AihcValue *value,
-                            uint64_t result_is_lifted) {
+void aihc_eval_cps(AihcMachine *machine, AihcValue *value,
+                   uint64_t result_is_lifted, AihcValue *continuation,
+                   AihcValue *update_continuation) {
   if (value == NULL) {
     aihc_fail("attempted to evaluate null");
   }
   switch (aihc_value_tag(value)) {
   case AIHC_TAG_THUNK: {
-    uintptr_t entry = aihc_value_info(value);
-    AihcSlot *arguments = aihc_value_fields(value);
+    AihcSlot *arguments =
+        aihc_arguments(value, 0, NULL, update_continuation);
+    void *entry = (void *)aihc_value_info(value);
     value->header = AIHC_TAG_BLACKHOLE;
-    AihcContinuation *continuation =
-        aihc_push_special(machine, AIHC_CONT_UPDATE);
-    continuation->payload.update.object = value;
-    machine->next = (void *)entry;
+    machine->next = entry;
     machine->args = arguments;
     machine->locals = NULL;
     return;
   }
   case AIHC_TAG_INDIRECTION:
     if (result_is_lifted) {
-      aihc_eval_value(machine, (AihcValue *)value->fields[0], 1);
+      aihc_eval_cps(machine, (AihcValue *)value->fields[0], 1, continuation,
+                    update_continuation);
     } else {
-      aihc_return_value(machine, value->fields[0]);
+      aihc_continue_value(machine, continuation, value->fields[0]);
     }
     return;
   case AIHC_TAG_BLACKHOLE:
     aihc_fail("blackholed thunk re-entered");
   default:
-    break;
-  }
-  aihc_return_value(machine, (AihcSlot)value);
-}
-
-static void aihc_run_io(AihcMachine *machine, AihcValue *value) {
-  aihc_push_special(machine, AIHC_CONT_FINAL);
-  aihc_apply_forced(machine, value, 0, NULL);
-}
-
-static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
-                                        const AihcSlot *values) {
-  AihcContinuation *continuation = machine->continuation;
-  if (continuation == NULL) {
-    aihc_fail("returned without a continuation");
-  }
-  machine->continuation = continuation->parent;
-  switch (continuation->kind) {
-  case AIHC_CONT_NORMAL: {
-    if (count != continuation->payload.normal.count) {
-      aihc_fail("continuation received the wrong number of values");
-    }
-    for (uint64_t index = 0; index < count; ++index) {
-      continuation->payload.normal.locals
-          [continuation->payload.normal.slot + index] = values[index];
-    }
-    machine->locals = continuation->payload.normal.locals;
-    machine->next = continuation->payload.normal.code;
+    aihc_continue_value(machine, continuation, (AihcSlot)value);
     return;
   }
-  case AIHC_CONT_UPDATE:
-    if (count != 1) {
-      aihc_fail("attempted to update a thunk with multiple values");
-    }
-    continuation->payload.update.object->fields[0] = values[0];
-    continuation->payload.update.object->header = AIHC_TAG_INDIRECTION;
-    /* Continue forcing through the freshly installed indirection so the
-     * awaiting continuation receives the result in weak-head normal form. */
-    aihc_eval_value(machine, (AihcValue *)values[0], 1);
-    return;
-  case AIHC_CONT_TOP:
-    if (count != 1) {
-      aihc_fail("top-level evaluation returned multiple values");
-    }
-    aihc_run_io(machine, (AihcValue *)values[0]);
-    return;
-  case AIHC_CONT_FINAL:
-    if (count != 1) {
-      aihc_fail("IO action returned the wrong number of values");
-    }
-    machine->locals = NULL;
-    machine->next = machine->exit_code;
-    return;
-  default:
-    aihc_fail("unknown continuation kind");
+}
+
+void aihc_update(AihcValue *object, AihcValue *value) {
+  if (object == NULL || value == NULL) {
+    aihc_fail("attempted to update with null");
   }
+  object->fields[0] = (AihcSlot)value;
+  object->header = AIHC_TAG_INDIRECTION;
 }
 
-static void aihc_return_value(AihcMachine *machine, AihcSlot value) {
-  aihc_return_values_internal(machine, 1, &value);
+void aihc_update_blackhole(AihcValue *object, AihcValue *value) {
+  if (object == NULL || aihc_value_tag(object) != AIHC_TAG_BLACKHOLE) {
+    aihc_fail("attempted to update a cell that is not blackholed");
+  }
+  aihc_update(object, value);
 }
 
-void aihc_return(AihcMachine *machine, AihcSlot value) {
-  aihc_return_value(machine, value);
+void aihc_halt(AihcMachine *machine) {
+  machine->locals = NULL;
+  machine->next = machine->exit_code;
 }
 
-void aihc_return_values(AihcMachine *machine, uint64_t count,
-                        const AihcSlot *values) {
-  aihc_return_values_internal(machine, count, values);
-}
-
-void aihc_eval(AihcMachine *machine, AihcValue *value,
-               uint64_t result_is_lifted) {
-  aihc_eval_value(machine, value, result_is_lifted);
-}
-
-void aihc_apply(AihcMachine *machine, AihcValue *function,
-                AihcSlot argument) {
-  aihc_apply_forced(machine, function, 1, &argument);
-}
-
-void aihc_apply_values(AihcMachine *machine, AihcValue *function,
-                       uint64_t count, const AihcSlot *arguments) {
-  aihc_apply_forced(machine, function, count, arguments);
-}
-
-void aihc_start(AihcMachine *machine, AihcValue *root, void *exit_code) {
+void aihc_start(AihcMachine *machine, AihcValue *root,
+                AihcValue *continuation, AihcValue *update_continuation,
+                void *exit_code) {
   machine->exit_code = exit_code;
-  aihc_push_special(machine, AIHC_CONT_TOP);
-  aihc_eval_value(machine, root, 1);
+  aihc_eval_cps(machine, root, 1, continuation, update_continuation);
 }

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -11,7 +11,7 @@ typedef struct {
   void *exit_code;
 } AihcMachine;
 
-static void aihc_fail(const char *message) {
+static _Noreturn void aihc_fail(const char *message) {
   fprintf(stderr, "aihc runtime: %s\n", message);
   abort();
 }

--- a/components/aihc-arm64/runtime/aihc_runtime.h
+++ b/components/aihc-arm64/runtime/aihc_runtime.h
@@ -48,7 +48,8 @@ static inline uintptr_t aihc_value_info(const AihcValue *value) {
 
 static inline int aihc_value_has_shape(const AihcValue *value) {
   uint64_t tag = aihc_value_tag(value);
-  return tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_PARTIAL_CONSTRUCTOR;
+  return tag == AIHC_TAG_CLOSURE || tag == AIHC_TAG_THUNK ||
+         tag == AIHC_TAG_PARTIAL_CONSTRUCTOR;
 }
 
 static inline uint64_t aihc_value_arity(const AihcValue *value) {

--- a/components/aihc-arm64/runtime/aihc_snapshot.c
+++ b/components/aihc-arm64/runtime/aihc_snapshot.c
@@ -156,9 +156,7 @@ static void discover_object(SnapshotState *state, AihcValue *object) {
     if (function == NULL) {
       snapshot_fail("function descriptor is missing");
     }
-    uint64_t count = tag == AIHC_TAG_CLOSURE
-                         ? aihc_value_count(object)
-                         : function->parameter_count;
+    uint64_t count = aihc_value_count(object);
     discover_fields(state, aihc_value_fields_const(object), count,
                     function->parameter_count, function->parameter_reps);
     return;
@@ -241,7 +239,7 @@ static void print_object(SnapshotState *state, const AihcValue *object) {
       count = aihc_value_count(object);
     } else {
       printf("F%s", function->name);
-      count = function->parameter_count;
+      count = aihc_value_count(object);
     }
     print_fields(state, aihc_value_fields_const(object), count,
                  function->parameter_count, function->parameter_reps);

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -24,7 +24,12 @@ where
 
 import Aihc.Arm64.Emit (EmitError, renderAllocatedBlock)
 import Aihc.Arm64.Lir qualified as Lir
-import Aihc.Grin.Cps (CpsGrinProgram, cpsGrinProgram)
+import Aihc.Grin.Cps
+  ( CpsGrinProgram,
+    cpsFunctionContinuations,
+    cpsGrinProgram,
+    cpsUpdateFunction,
+  )
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM, replicateM)
@@ -116,9 +121,10 @@ compileObservedFunction entryName cpsProgram = do
   entryFunction <-
     maybe (Left (Arm64MissingFunction entryName)) Right $
       findFunction entryName (grinFunctions program)
-  if null (grinFunctionParameters entryFunction)
-    then pure ()
-    else Left (Arm64UnsupportedExpression "observed entry function must be nullary")
+  case Map.lookup entryName (cpsFunctionContinuations cpsProgram) of
+    Just continuation
+      | grinFunctionParameters entryFunction == [continuation] -> pure ()
+    _ -> Left (Arm64UnsupportedExpression "observed entry function must have only its CPS continuation")
   entryLabel <- functionCodeLabel compileEnv entryName
   constructorLines <- compileConstructorInitializers compileEnv
   initLines <- compileInitializers compileEnv program
@@ -141,16 +147,16 @@ compileObservedFunction entryName cpsProgram = do
           ]
             <> constructorLines
             <> initLines
-            <> [ immediate "x0" (max 1 resultCount),
+            <> makeNodeLines runtimeTagClosure (InfoAddress ".Laihc_snapshot_result") 1 0
+            <> [ "  mov x21, x0",
+                 immediate "x0" (1 :: Int),
                  "  bl _aihc_alloc_locals",
-                 "  mov x19, x0",
-                 "  str x19, [x22, #32]"
-               ]
-            <> pushNormalLines ".Laihc_snapshot_result" 0 resultCount
-            <> [ "  str xzr, [x22, #8]",
+                 "  str x21, [x0]",
+                 "  str x0, [x22, #8]",
                  "  b " <> entryLabel,
+                 ".p2align 3",
                  ".Laihc_snapshot_result:",
-                 "  ldr x1, [x22, #32]",
+                 "  ldr x1, [x22, #8]",
                  immediate "x0" resultCount,
                  "  bl _aihc_snapshot_dump_result",
                  "  mov w0, #0",
@@ -246,6 +252,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName cpsProgra
   constructorLines <- compileConstructorInitializers compileEnv
   initLines <- compileInitializers compileEnv program
   functions <- mapM (compileFunction compileEnv) (grinFunctions program)
+  updateLabel <- functionCodeLabel compileEnv (cpsUpdateFunction cpsProgram)
   pure . T.unlines $
     [ ".section __TEXT,__text,regular,pure_instructions",
       ".p2align 2",
@@ -262,11 +269,49 @@ compileProgramWithDependencies layout dependencyInitializers entryName cpsProgra
       <> constructorLines
       <> concatMap callInitializer dependencyInitializers
       <> initLines
-      <> [ "  ldr x9, [x22, #24]",
+      <> makeNodeLines runtimeTagClosure (InfoAddress ".Laihc_final_continuation") 1 0
+      <> ["  mov x21, x0"]
+      <> makeNodeLines runtimeTagClosure (InfoAddress ".Laihc_top_continuation") 1 1
+      <> [ "  mov x20, x0",
+           "  mov x2, x21",
+           "  mov x1, #0",
+           "  bl _aihc_set_field"
+         ]
+      <> makeNodeLines runtimeTagClosure (InfoAddress updateLabel) 1 2
+      <> [ "  mov x19, x0",
+           "  ldr x9, [x22, #16]",
+           loadAt "x2" "x9" rootSlot,
+           "  mov x0, x19",
+           "  mov x1, #0",
+           "  bl _aihc_set_field",
+           "  mov x0, x19",
+           "  mov x1, #1",
+           "  mov x2, x20",
+           "  bl _aihc_set_field",
+           "  ldr x9, [x22, #16]",
            loadAt "x1" "x9" rootSlot,
            "  mov x0, x22",
-           "  adr x2, .Laihc_exit",
+           "  mov x2, x20",
+           "  mov x3, x19",
+           "  adr x4, .Laihc_exit",
            "  bl _aihc_start"
+         ]
+      <> dispatchLines
+      <> [ ".p2align 3",
+           ".Laihc_top_continuation:",
+           "  ldr x9, [x22, #8]",
+           "  ldr x4, [x9]",
+           "  ldr x1, [x9, #8]",
+           "  mov x0, x22",
+           "  mov x2, #0",
+           "  mov x3, xzr",
+           "  bl _aihc_apply_cps"
+         ]
+      <> dispatchLines
+      <> [ ".p2align 3",
+           ".Laihc_final_continuation:",
+           "  mov x0, x22",
+           "  bl _aihc_halt"
          ]
       <> dispatchLines
       <> [ ".Laihc_exit:",
@@ -350,7 +395,7 @@ compileInitializers env program = do
     slot <- globalSlot env (grinVarName var)
     fieldLines <- initializeNodeFields (ValueEnv env Map.empty) node
     pure $
-      ["  ldr x9, [x22, #24]", loadAt "x20" "x9" slot]
+      ["  ldr x9, [x22, #16]", loadAt "x20" "x9" slot]
         <> fieldLines
   pure (cafAllocationLines <> whnfGlobalLines <> cafInitializationLines)
 
@@ -374,7 +419,7 @@ compileFunction env function = do
                immediate "x0" slotCount,
                "  bl _aihc_alloc_locals",
                "  mov x19, x0",
-               "  str x19, [x22, #32]",
+               "  str x19, [x22, #24]",
                "  ldr x8, [x22, #8]"
              ]
           <> parameterCopies
@@ -404,28 +449,11 @@ parameterCopyLir slots parameters =
 compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
 compileExpr env prefix label expression =
   case expression of
-    GrinConstant values -> do
-      valueSlots <- freshSlots (length values)
-      valueLines <-
-        fmap concat . forM (zip values valueSlots) $ \(value, slot) -> do
-          lines' <- liftEither (materializeValue env value)
-          pure (lines' <> [storeAt "x0" "x19" slot])
-      addBlock label (prefix <> valueLines <> returnValuesLines valueSlots)
+    GrinConstant {} -> unsupportedExpression "direct-style constant return after CPS"
     GrinBind vars valueExpression body -> do
-      valueLabel <- freshLabel label "bind_value"
-      bodyLabel <- freshLabel label "bind_body"
-      slot <- contiguousLocalSlots env vars
-      addBlock
-        label
-        ( prefix
-            <> pushNormalLines bodyLabel slot (length vars)
-            <> ["  b " <> valueLabel]
-        )
-      compileExpr env [] valueLabel valueExpression
-      compileExpr env [] bodyLabel body
-    GrinStore node -> do
-      nodeLines <- liftEither (materializeNode env node)
-      addBlock label (prefix <> nodeLines <> returnLines)
+      directLines <- compileDirectBinding env vars valueExpression
+      compileExpr env (prefix <> directLines) label body
+    GrinStore {} -> unsupportedExpression "direct-style store return after CPS"
     GrinStoreRec bindings body -> do
       allocationLines <-
         fmap concat . forM bindings $ \(var, node) -> do
@@ -438,11 +466,35 @@ compileExpr env prefix label expression =
           fieldLines <- liftEither (initializeNodeFields env node)
           pure ([loadAt "x20" "x19" slot] <> fieldLines)
       compileExpr env (prefix <> allocationLines <> initializationLines) label body
-    GrinFetch {} -> unsupportedExpression "fetch"
-    GrinUpdate {} -> unsupportedExpression "update"
-    GrinEval runtimeRep value -> do
+    GrinFetch {} -> unsupportedExpression "direct-style fetch return after CPS"
+    GrinUpdate {} -> unsupportedExpression "direct-style update return after CPS"
+    GrinUpdateBlackhole {} -> unsupportedExpression "unbound blackhole update"
+    GrinEval {} -> unsupportedExpression "direct-style eval after CPS"
+    GrinCpsEval runtimeRep value continuation updateContinuation -> do
+      valueSlot <- freshSlot
+      continuationSlot <- freshSlot
+      updateSlot <- freshSlot
       valueLines <- liftEither (materializeValue env value)
-      addBlock label (prefix <> valueLines <> evalLines runtimeRep)
+      continuationLines <- liftEither (materializeValue env continuation)
+      updateLines <- liftEither (materializeValue env updateContinuation)
+      addBlock
+        label
+        ( prefix
+            <> valueLines
+            <> [storeAt "x0" "x19" valueSlot]
+            <> continuationLines
+            <> [storeAt "x0" "x19" continuationSlot]
+            <> updateLines
+            <> [ storeAt "x0" "x19" updateSlot,
+                 loadAt "x1" "x19" valueSlot,
+                 immediate "x2" (fromEnum (isLiftedRuntimeRep runtimeRep)),
+                 loadAt "x3" "x19" continuationSlot,
+                 loadAt "x4" "x19" updateSlot,
+                 "  mov x0, x22",
+                 "  bl _aihc_eval_cps"
+               ]
+            <> dispatchLines
+        )
     GrinCall _ functionName arguments -> do
       target <- liftEither (functionCodeLabel (valueCompileEnv env) functionName)
       argumentSlots <- freshSlots (length arguments)
@@ -456,17 +508,13 @@ compileExpr env prefix label expression =
             <> argumentLines
             <> [slotPointer "x8" argumentSlots, "  str x8, [x22, #8]", "  b " <> target]
         )
-    GrinPrimitiveCall runtimeRep name arguments
-      | name == "realWorld#",
-        null arguments,
-        null (runtimeRepComponents runtimeRep) ->
-          addBlock label (prefix <> returnValuesLines [])
-      | compileAllowUnsupportedPrimitives (valueCompileEnv env) ->
-          addBlock label (prefix <> ["  bl _aihc_unsupported_primitive", "  b " <> label])
-      | otherwise -> unsupportedExpression ("primitive call " <> name)
-    GrinApply _ function arguments -> do
+    GrinPrimitiveCall {} -> unsupportedExpression "unbound primitive call after CPS"
+    GrinApply {} -> unsupportedExpression "direct-style apply after CPS"
+    GrinCpsApply _ function arguments continuation -> do
       scratch <- freshSlot
+      continuationSlot <- freshSlot
       functionLines <- liftEither (materializeValue env function)
+      continuationLines <- liftEither (materializeValue env continuation)
       argumentSlots <- freshSlots (length arguments)
       argumentLines <-
         fmap concat . forM (zip arguments argumentSlots) $ \(argument, slot) -> do
@@ -477,26 +525,109 @@ compileExpr env prefix label expression =
         ( prefix
             <> functionLines
             <> [storeAt "x0" "x19" scratch]
+            <> continuationLines
+            <> [storeAt "x0" "x19" continuationSlot]
             <> argumentLines
             <> [ loadAt "x1" "x19" scratch,
                  immediate "x2" (length arguments),
                  slotPointer "x3" argumentSlots,
+                 loadAt "x4" "x19" continuationSlot,
                  "  mov x0, x22",
-                 "  bl _aihc_apply_values"
+                 "  bl _aihc_apply_cps"
                ]
             <> dispatchLines
         )
+    GrinContinue continuation values -> do
+      continuationSlot <- freshSlot
+      valueSlots <- freshSlots (length values)
+      continuationLines <- liftEither (materializeValue env continuation)
+      valueLines <-
+        fmap concat . forM (zip values valueSlots) $ \(value, slot) -> do
+          lines' <- liftEither (materializeValue env value)
+          pure (lines' <> [storeAt "x0" "x19" slot])
+      addBlock
+        label
+        ( prefix
+            <> continuationLines
+            <> [storeAt "x0" "x19" continuationSlot]
+            <> valueLines
+            <> [ loadAt "x1" "x19" continuationSlot,
+                 immediate "x2" (length values),
+                 slotPointer "x3" valueSlots,
+                 "  mov x0, x22",
+                 "  bl _aihc_continue_values"
+               ]
+            <> dispatchLines
+        )
+    GrinHalt _ ->
+      addBlock
+        label
+        (prefix <> ["  mov x0, x22", "  bl _aihc_halt"] <> dispatchLines)
     GrinCase scrutinee binder alternatives ->
       compileCase env prefix label scrutinee binder alternatives
     GrinThrow {} -> unsupportedExpression "throw"
     GrinCatch {} -> unsupportedExpression "catch"
-    GrinForeignCallExpr foreignCall arguments ->
-      compileForeignCall env prefix label foreignCall arguments
+    GrinForeignCallExpr {} -> unsupportedExpression "unbound foreign call after CPS"
   where
     unsupportedExpression name = lift (Left (Arm64UnsupportedExpression name))
 
-compileForeignCall :: ValueEnv -> [Text] -> Text -> GrinForeignCall -> [GrinValue] -> FunctionM ()
-compileForeignCall env prefix label foreignCall arguments = do
+compileDirectBinding :: ValueEnv -> [GrinVar] -> GrinExpr -> FunctionM [Text]
+compileDirectBinding env vars expression =
+  case expression of
+    GrinConstant values
+      | length vars == length values ->
+          fmap concat . forM (zip vars values) $ \(var, value) -> do
+            slot <- localSlot env var
+            valueLines <- liftEither (materializeValue env value)
+            pure (valueLines <> [storeAt "x0" "x19" slot])
+    GrinStore node -> do
+      nodeLines <- liftEither (materializeNode env node)
+      storeSingleResult vars nodeLines
+    GrinFetch _ pointer -> do
+      pointerLines <- liftEither (materializeValue env pointer)
+      storeSingleResult vars pointerLines
+    GrinUpdate pointer value -> compileUpdateBinding "_aihc_update" pointer value
+    GrinUpdateBlackhole pointer value -> compileUpdateBinding "_aihc_update_blackhole" pointer value
+    GrinPrimitiveCall runtimeRep name arguments
+      | name == "realWorld#",
+        null arguments,
+        null vars,
+        null (runtimeRepComponents runtimeRep) ->
+          pure []
+      | compileAllowUnsupportedPrimitives (valueCompileEnv env) ->
+          pure ["  bl _aihc_unsupported_primitive"]
+      | otherwise -> lift (Left (Arm64UnsupportedExpression ("primitive call " <> name)))
+    GrinForeignCallExpr foreignCall arguments -> do
+      callLines <- compileForeignCallLines env foreignCall arguments
+      storeSingleResult vars callLines
+    _ -> lift (Left (Arm64UnsupportedExpression "non-direct expression remained in a CPS bind"))
+  where
+    storeSingleResult resultVars lines' =
+      case resultVars of
+        [var] -> do
+          slot <- localSlot env var
+          pure (lines' <> [storeAt "x0" "x19" slot])
+        _ -> lift (Left (Arm64UnsupportedExpression "direct expression result arity"))
+    compileUpdateBinding symbol pointer value = do
+      pointerSlot <- freshSlot
+      valueSlot <- freshSlot
+      pointerLines <- liftEither (materializeValue env pointer)
+      valueLines <- liftEither (materializeValue env value)
+      resultLines <- storeSingleResult vars [loadAt "x0" "x19" valueSlot]
+      pure
+        ( pointerLines
+            <> [storeAt "x0" "x19" pointerSlot]
+            <> valueLines
+            <> [ storeAt "x0" "x19" valueSlot,
+                 loadAt "x0" "x19" pointerSlot,
+                 loadAt "x1" "x19" valueSlot,
+                 "  bl " <> symbol
+               ]
+            <> resultLines
+        )
+
+compileForeignCallLines :: ValueEnv -> GrinForeignCall -> [GrinValue] -> FunctionM [Text]
+compileForeignCallLines env foreignCall arguments = do
   let signature = grinForeignCallSignature foreignCall
       abiArity = length (grinForeignArgumentTypes signature)
       expectedArity = length (grinForeignOperandReps signature)
@@ -521,7 +652,7 @@ compileForeignCall env prefix label foreignCall arguments = do
                   <> loadAbiArguments
                   <> ["  bl _" <> grinForeignCallSymbol foreignCall]
                   <> normalizeForeignResult (grinForeignResultType signature)
-          addBlock label (prefix <> callLines <> returnLines)
+          pure callLines
 
 normalizeForeignResult :: GrinForeignType -> [Text]
 normalizeForeignResult foreignType =
@@ -743,7 +874,7 @@ loadVariable env var =
     Just slot -> Right [loadAt "x0" "x19" slot]
     Nothing -> do
       slot <- globalSlot (valueCompileEnv env) (grinVarName var)
-      pure ["  ldr x9, [x22, #24]", loadAt "x0" "x9" slot]
+      pure ["  ldr x9, [x22, #16]", loadAt "x0" "x9" slot]
 
 localSlot :: ValueEnv -> GrinVar -> FunctionM Int
 localSlot env var =
@@ -761,16 +892,6 @@ freshSlot = do
 freshSlots :: Int -> FunctionM [Int]
 freshSlots count = replicateM count freshSlot
 
-contiguousLocalSlots :: ValueEnv -> [GrinVar] -> FunctionM Int
-contiguousLocalSlots _ [] = pure 0
-contiguousLocalSlots env vars = do
-  slots <- mapM (localSlot env) vars
-  case slots of
-    first : rest
-      | rest == [first + 1 .. first + length rest] -> pure first
-      | otherwise -> lift (Left (Arm64UnsupportedExpression "non-contiguous multi-value bind"))
-    [] -> pure 0
-
 freshLabel :: Text -> Text -> FunctionM Text
 freshLabel parent kind = do
   state <- get
@@ -785,51 +906,15 @@ addBlock label lines' =
 renderBlock :: Block -> [Text]
 renderBlock block = blockLabel block <> ":" : blockLines block
 
-pushNormalLines :: Text -> Int -> Int -> [Text]
-pushNormalLines code slot count =
-  [ "  mov x0, x22",
-    "  adr x1, " <> code,
-    "  mov x2, x19",
-    immediate "x3" slot,
-    immediate "x4" count,
-    "  bl _aihc_push_normal"
-  ]
-
-returnValuesLines :: [Int] -> [Text]
-returnValuesLines slots =
-  [ "  mov x0, x22",
-    immediate "x1" (length slots),
-    slotPointer "x2" slots,
-    "  bl _aihc_return_values"
-  ]
-    <> dispatchLines
-
 slotPointer :: Text -> [Int] -> Text
 slotPointer register slots =
   case slots of
     first : _ -> "  add " <> register <> ", x19, #" <> tshow (first * 8)
     [] -> "  mov " <> register <> ", xzr"
 
-returnLines :: [Text]
-returnLines =
-  [ "  mov x1, x0",
-    "  mov x0, x22",
-    "  bl _aihc_return"
-  ]
-    <> dispatchLines
-
-evalLines :: RuntimeRep -> [Text]
-evalLines runtimeRep =
-  [ "  mov x1, x0",
-    immediate "x2" (fromEnum (isLiftedRuntimeRep runtimeRep)),
-    "  mov x0, x22",
-    "  bl _aihc_eval"
-  ]
-    <> dispatchLines
-
 dispatchLines :: [Text]
 dispatchLines =
-  [ "  ldr x19, [x22, #32]",
+  [ "  ldr x19, [x22, #24]",
     "  ldr x9, [x22, #0]",
     "  br x9"
   ]
@@ -871,10 +956,15 @@ boundVarGroups expression =
     GrinStoreRec bindings body -> map (pure . fst) bindings <> boundVarGroups body
     GrinFetch _ _ -> []
     GrinUpdate _ _ -> []
+    GrinUpdateBlackhole _ _ -> []
     GrinEval _ _ -> []
+    GrinCpsEval {} -> []
     GrinCall {} -> []
     GrinPrimitiveCall {} -> []
     GrinApply {} -> []
+    GrinCpsApply {} -> []
+    GrinContinue {} -> []
+    GrinHalt {} -> []
     GrinCase _ binder alternatives -> [binder] : concatMap altBoundVarGroups alternatives
     GrinThrow _ -> []
     GrinCatch {} -> []
@@ -937,13 +1027,25 @@ exprRuntimeReps expression =
         <> exprRuntimeReps body
     GrinFetch runtimeRep pointer -> runtimeRep : valueRuntimeReps pointer
     GrinUpdate pointer value -> valueRuntimeReps pointer <> valueRuntimeReps value
+    GrinUpdateBlackhole pointer value -> valueRuntimeReps pointer <> valueRuntimeReps value
     GrinEval runtimeRep value -> runtimeRep : valueRuntimeReps value
+    GrinCpsEval runtimeRep value continuation updateContinuation ->
+      runtimeRep
+        : concatMap valueRuntimeReps [value, continuation, updateContinuation]
     GrinCall runtimeRep _ arguments ->
       runtimeRep : concatMap valueRuntimeReps arguments
     GrinPrimitiveCall runtimeRep _ arguments ->
       runtimeRep : concatMap valueRuntimeReps arguments
     GrinApply runtimeRep function arguments ->
       runtimeRep : valueRuntimeReps function <> concatMap valueRuntimeReps arguments
+    GrinCpsApply runtimeRep function arguments continuation ->
+      runtimeRep
+        : valueRuntimeReps function
+          <> concatMap valueRuntimeReps arguments
+          <> valueRuntimeReps continuation
+    GrinContinue continuation values ->
+      valueRuntimeReps continuation <> concatMap valueRuntimeReps values
+    GrinHalt values -> concatMap valueRuntimeReps values
     GrinCase scrutinee binder alternatives ->
       valueRuntimeReps scrutinee
         <> (grinVarRuntimeRep binder : concatMap altRuntimeReps alternatives)
@@ -1145,7 +1247,7 @@ linkedFunctionLabel name =
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot =
-  [ "  ldr x9, [x22, #24]",
+  [ "  ldr x9, [x22, #16]",
     storeAt "x0" "x9" slot
   ]
 

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -25,7 +25,7 @@ import Aihc.Tc (Levity (..), RuntimeRep (..), Unique (..))
 import Aihc.Testing.EvalFixture (EvalCase (..), compileEvalCase, evalBindingName, loadEvalCases)
 import Aihc.Testing.GrinProgram (parseProgram)
 import Control.Exception (bracket)
-import Control.Monad (when)
+import Control.Monad (forM_, when)
 import Data.Aeson (FromJSON (..), withObject, (.:))
 import Data.List (find, isInfixOf)
 import Data.Map.Strict qualified as Map
@@ -168,9 +168,8 @@ tests =
         case compileModule (buildLinkLayout [program]) "_aihc_init_pair" (expectCpsGrin program) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> do
-            assertBool "returns two values" ("ldr x1, =2" `T.isInfixOf` assembly)
-            assertBool "uses the multi-value return ABI" ("bl _aihc_return_values" `T.isInfixOf` assembly)
-            assertBool "does not allocate an aggregate node" (not ("bl _aihc_make_node" `T.isInfixOf` assembly)),
+            assertBool "passes two values" ("ldr x2, =2" `T.isInfixOf` assembly)
+            assertBool "uses the explicit continuation ABI" ("bl _aihc_continue_values" `T.isInfixOf` assembly),
       testCase "exports stable entries and branches directly to dependency code" $ do
         let identityName = FunctionName "$entry$identity"
             callerName = FunctionName "$entry$caller"
@@ -211,11 +210,22 @@ tests =
         case compileModule (buildLinkLayout [explicitEvaluationProgram]) "_aihc_init_explicit_eval" (expectCpsGrin explicitEvaluationProgram) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly ->
-            assertBool "generated case and apply contain no eval call" (not ("bl _aihc_eval" `T.isInfixOf` assembly))
+            assertBool "generated case and apply contain no direct-style eval call" (not ("bl _aihc_eval\n" `T.isInfixOf` assembly))
         runtime <- readFile =<< runtimeSourcePath
         assertBool
           "runtime apply does not enter its function"
-          (not ("aihc_eval_value(machine, function" `isInfixOf` runtime)),
+          (not ("aihc_eval_cps(machine, function" `isInfixOf` runtime)),
+      testCase "runtime has no built-in continuation stack" $ do
+        runtime <- readFile =<< runtimeSourcePath
+        forM_
+          [ "AihcContinuation",
+            "AIHC_CONT_",
+            "aihc_push_normal",
+            "aihc_return_values",
+            "aihc_return("
+          ]
+          $ \forbidden ->
+            assertBool ("runtime still contains " <> forbidden) (not (forbidden `isInfixOf` runtime)),
       testCase "runtime object ABI compiles cleanly on the host C compiler" $
         withTempDirectory "aihc-arm64-runtime" $ \directory -> do
           runtime <- runtimeSourcePath

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -3,7 +3,10 @@ module Aihc.Grin
   ( module Aihc.Grin.Syntax,
     CpsGrinProgram,
     CpsGrinError (..),
+    cpsContinuationFunctions,
+    cpsFunctionContinuations,
     cpsGrinProgram,
+    cpsUpdateFunction,
     toCpsGrin,
     lowerProgram,
     GrinInterface,
@@ -27,7 +30,15 @@ module Aihc.Grin
   )
 where
 
-import Aihc.Grin.Cps (CpsGrinError (..), CpsGrinProgram, cpsGrinProgram, toCpsGrin)
+import Aihc.Grin.Cps
+  ( CpsGrinError (..),
+    CpsGrinProgram,
+    cpsContinuationFunctions,
+    cpsFunctionContinuations,
+    cpsGrinProgram,
+    cpsUpdateFunction,
+    toCpsGrin,
+  )
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramFunctionSnapshot, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
 import Aihc.Grin.Lower (GrinInterface, extractGrinInterface, lowerProgram, lowerProgramWithInterface)

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -1,20 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Reify direct-style GRIN continuations as ordinary GRIN closures.
+-- | Convert direct-style GRIN into explicit continuation-passing style.
 --
--- This pass deliberately keeps the GRIN syntax. Each potentially suspending
--- source 'GrinBind' is rewritten so its body lives in a generated function. A
--- closure for that function is allocated with 'GrinStore', entered with
--- 'GrinEval', and invoked with 'GrinApply' after the bound expression produces
--- its values. Only 'GrinEval', 'GrinCall', 'GrinPrimitiveCall', and 'GrinApply'
--- can suspend; all other binds remain in direct style. The introduced
--- administrative binds retain the current runtime-operation protocol; future
--- suspension lowering can transfer ownership of the explicit closure instead
--- of returning through them.
+-- Computation entries receive an ordinary heap closure as their hidden final
+-- parameter. Generated continuation entries consume one logical result and
+-- never return. Consequently every potentially transferring operation is in
+-- tail position and the runtime never needs a continuation stack.
 module Aihc.Grin.Cps
   ( CpsGrinProgram,
     CpsGrinError (..),
+    cpsContinuationFunctions,
+    cpsFunctionContinuations,
     cpsGrinProgram,
+    cpsUpdateFunction,
     toCpsGrin,
   )
 where
@@ -23,40 +21,57 @@ import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (StateT, get, modify', put, runStateT)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text qualified as T
 
--- | A GRIN program known to have passed through continuation reification.
--- Keeping the constructor private prevents accidentally applying the pass
--- twice or sending direct-style GRIN to a backend that expects CPS-GRIN.
-newtype CpsGrinProgram = CpsGrinProgram
-  { cpsGrinProgram :: GrinProgram
+-- | A GRIN program whose computation entries and control transfers obey the
+-- CPS calling convention. The metadata distinguishes computation entries from
+-- continuation entries without polluting direct GRIN syntax.
+data CpsGrinProgram = CpsGrinProgram
+  { cpsGrinProgram :: !GrinProgram,
+    cpsContinuationFunctions :: !(Set FunctionName),
+    cpsFunctionContinuations :: !(Map FunctionName GrinVar),
+    cpsUpdateFunction :: !FunctionName
   }
   deriving (Eq, Show, Read)
 
--- | A violated precondition at the CPS boundary. Exception control must have
--- been lowered to ordinary GRIN control flow before continuations are reified.
 data CpsGrinError
   = CpsGrinUnexpectedThrow !FunctionName
   | CpsGrinUnexpectedCatch !FunctionName
+  | CpsGrinAlreadyTransformed !FunctionName
   deriving (Eq, Show)
 
 data CpsState = CpsState
   { cpsNextVarUnique :: !Int,
     cpsNextContinuationUnique :: !Int,
     cpsUsedFunctionNames :: !(Set FunctionName),
-    cpsGeneratedFunctionsRev :: ![GrinFunction]
+    cpsGeneratedFunctionsRev :: ![GrinFunction],
+    cpsContinuationNames :: !(Set FunctionName),
+    cpsComputationContinuations :: !(Map FunctionName GrinVar)
   }
 
 type CpsM = StateT CpsState (Either CpsGrinError)
 
 toCpsGrin :: GrinProgram -> Either CpsGrinError CpsGrinProgram
 toCpsGrin program = do
-  (functions, finalState) <- runStateT (mapM transformFunction sourceFunctions) initialState
-  pure . CpsGrinProgram $
-    program
-      { grinFunctions = functions <> reverse (cpsGeneratedFunctionsRev finalState)
+  ((functions, updateFunction), finalState) <- runStateT transform initialState
+  pure
+    CpsGrinProgram
+      { cpsGrinProgram =
+          program
+            { grinExternalFunctions = map addExternalContinuation (grinExternalFunctions program),
+              grinFunctions =
+                functions
+                  <> reverse (cpsGeneratedFunctionsRev finalState)
+                  <> [updateFunction]
+            },
+        cpsContinuationFunctions =
+          Set.insert (grinFunctionName updateFunction) (cpsContinuationNames finalState),
+        cpsFunctionContinuations = cpsComputationContinuations finalState,
+        cpsUpdateFunction = grinFunctionName updateFunction
       }
   where
     sourceFunctions = grinFunctions program
@@ -65,117 +80,267 @@ toCpsGrin program = do
         { cpsNextVarUnique = 1 + maximumProgramVarUnique program,
           cpsNextContinuationUnique = 0,
           cpsUsedFunctionNames = Set.fromList (map grinFunctionName sourceFunctions),
-          cpsGeneratedFunctionsRev = []
+          cpsGeneratedFunctionsRev = [],
+          cpsContinuationNames = Set.empty,
+          cpsComputationContinuations = Map.empty
+        }
+    transform = do
+      updateName <- freshFunctionName "$cps$update"
+      functions <- mapM (transformFunction updateName) sourceFunctions
+      updateFunction <- makeUpdateFunction updateName
+      pure (functions, updateFunction)
+
+    addExternalContinuation info =
+      info
+        { grinCodeParameterLayouts =
+            grinCodeParameterLayouts info <> [[liftedRuntimeRep]]
         }
 
-transformFunction :: GrinFunction -> CpsM GrinFunction
-transformFunction function = do
+transformFunction :: FunctionName -> GrinFunction -> CpsM GrinFunction
+transformFunction updateName function = do
+  continuation <- freshVar "$cps_return" liftedRuntimeRep
+  let parameters = grinFunctionParameters function
+      bound = Set.fromList (continuation : parameters)
   body <-
-    transformExpr
+    transformTail
+      updateName
       (grinFunctionName function)
-      (Set.fromList (grinFunctionParameters function))
+      bound
       (grinFunctionResultRep function)
+      (GrinVarValue continuation)
       (grinFunctionBody function)
-  pure function {grinFunctionBody = body}
+  modify' $ \state ->
+    state
+      { cpsComputationContinuations =
+          Map.insert (grinFunctionName function) continuation (cpsComputationContinuations state)
+      }
+  pure
+    function
+      { grinFunctionParameters = parameters <> [continuation],
+        grinFunctionBody = body
+      }
 
-transformExpr :: FunctionName -> Set GrinVar -> RuntimeRep -> GrinExpr -> CpsM GrinExpr
-transformExpr parent bound resultRep expression =
+transformTail :: FunctionName -> FunctionName -> Set GrinVar -> RuntimeRep -> GrinValue -> GrinExpr -> CpsM GrinExpr
+transformTail updateName parent bound resultRep continuation expression =
   case expression of
-    GrinConstant {} -> pure expression
-    GrinBind resultVars valueExpression body
-      | not (requiresContinuation valueExpression) -> do
-          transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
-          transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
-          pure (GrinBind resultVars transformedValue transformedBody)
-    GrinBind resultVars valueExpression body -> do
-      transformedValue <- transformExpr parent bound (varsRuntimeRep resultVars) valueExpression
-      transformedBody <- transformExpr parent (bound <> Set.fromList resultVars) resultRep body
-      continuationName <- freshContinuationName parent
-      continuationPointer <- freshContinuationVar "$cps_continuation_pointer"
-      continuation <- freshContinuationVar "$cps_continuation"
-      let captures = Set.toAscList (freeExprVars transformedBody `Set.intersection` bound)
-          continuationFunction =
-            GrinFunction
-              { grinFunctionName = continuationName,
-                grinFunctionLinkName = Nothing,
-                grinFunctionParameters = captures <> resultVars,
-                grinFunctionResultRep = resultRep,
-                grinFunctionBody = transformedBody
-              }
-          continuationNode =
-            GrinNode
-              (GrinClosure continuationName [map grinVarRuntimeRep resultVars])
-              (map GrinVarValue captures)
-          invokeContinuation =
-            GrinApply
+    GrinConstant values -> pure (GrinContinue continuation values)
+    GrinBind resultVars (GrinCase scrutinee binder alternatives) body ->
+      GrinCase scrutinee binder <$> mapM transformBoundAlternative alternatives
+      where
+        transformBoundAlternative alternative = do
+          let alternativeBound = bound <> Set.fromList (binder : grinAltBinders alternative)
+          rhs <-
+            transformTail
+              updateName
+              parent
+              alternativeBound
               resultRep
-              (GrinVarValue continuation)
-              (map GrinVarValue resultVars)
-      addGeneratedFunction continuationFunction
-      pure
-        ( GrinBind
-            [continuationPointer]
-            (GrinStore continuationNode)
-            ( GrinBind
-                [continuation]
-                (GrinEval liftedRuntimeRep (GrinVarValue continuationPointer))
-                (GrinBind resultVars transformedValue invokeContinuation)
-            )
-        )
-    GrinStore {} -> pure expression
+              continuation
+              (GrinBind resultVars (grinAltRhs alternative) body)
+          pure alternative {grinAltRhs = rhs}
+    GrinBind resultVars valueExpression body
+      | isDirectExpression valueExpression -> do
+          transformedBody <-
+            transformTail
+              updateName
+              parent
+              (bound <> Set.fromList resultVars)
+              resultRep
+              continuation
+              body
+          pure (GrinBind resultVars valueExpression transformedBody)
+      | otherwise -> do
+          (nextVar, nextNode) <-
+            reifyContinuation
+              updateName
+              parent
+              bound
+              resultRep
+              continuation
+              resultVars
+              body
+          transformedValue <-
+            transformTail
+              updateName
+              parent
+              (Set.insert nextVar bound)
+              (varsRuntimeRep resultVars)
+              (GrinVarValue nextVar)
+              valueExpression
+          pure (GrinBind [nextVar] (GrinStore nextNode) transformedValue)
+    GrinStore node -> continueDirect resultRep continuation (GrinStore node)
     GrinStoreRec bindings body -> do
       let recursiveVars = Set.fromList (map fst bindings)
-      GrinStoreRec bindings <$> transformExpr parent (bound <> recursiveVars) resultRep body
-    GrinFetch {} -> pure expression
-    GrinUpdate {} -> pure expression
-    GrinEval {} -> pure expression
-    GrinCall {} -> pure expression
-    GrinPrimitiveCall {} -> pure expression
-    GrinApply {} -> pure expression
+      GrinStoreRec bindings
+        <$> transformTail updateName parent (bound <> recursiveVars) resultRep continuation body
+    GrinFetch runtimeRep value ->
+      continueDirect runtimeRep continuation (GrinFetch runtimeRep value)
+    GrinUpdate pointer value ->
+      continueDirect (grinValueRuntimeRep value) continuation (GrinUpdate pointer value)
+    GrinUpdateBlackhole pointer value ->
+      continueDirect (grinValueRuntimeRep value) continuation (GrinUpdateBlackhole pointer value)
+    GrinEval runtimeRep value -> do
+      (updateVar, updateNode) <- makeUpdateContinuation updateName value continuation
+      pure
+        ( GrinBind
+            [updateVar]
+            (GrinStore updateNode)
+            (GrinCpsEval runtimeRep value continuation (GrinVarValue updateVar))
+        )
+    GrinCpsEval {} -> alreadyTransformed
+    GrinCall runtimeRep functionName arguments ->
+      pure (GrinCall runtimeRep functionName (arguments <> [continuation]))
+    GrinPrimitiveCall runtimeRep name arguments ->
+      continueDirect runtimeRep continuation (GrinPrimitiveCall runtimeRep name arguments)
+    GrinApply runtimeRep function arguments ->
+      pure (GrinCpsApply runtimeRep function arguments continuation)
+    GrinCpsApply {} -> alreadyTransformed
+    GrinContinue {} -> alreadyTransformed
+    GrinHalt {} -> alreadyTransformed
     GrinCase scrutinee binder alternatives ->
       GrinCase scrutinee binder <$> mapM transformAlternative alternatives
       where
         transformAlternative alternative = do
           let alternativeBound = bound <> Set.fromList (binder : grinAltBinders alternative)
-          rhs <- transformExpr parent alternativeBound resultRep (grinAltRhs alternative)
+          rhs <-
+            transformTail
+              updateName
+              parent
+              alternativeBound
+              resultRep
+              continuation
+              (grinAltRhs alternative)
           pure alternative {grinAltRhs = rhs}
     GrinThrow {} -> lift (Left (CpsGrinUnexpectedThrow parent))
     GrinCatch {} -> lift (Left (CpsGrinUnexpectedCatch parent))
-    GrinForeignCallExpr {} -> pure expression
+    GrinForeignCallExpr foreignCall arguments ->
+      continueDirect resultRep continuation (GrinForeignCallExpr foreignCall arguments)
+  where
+    alreadyTransformed = lift (Left (CpsGrinAlreadyTransformed parent))
 
-requiresContinuation :: GrinExpr -> Bool
-requiresContinuation expression =
+reifyContinuation :: FunctionName -> FunctionName -> Set GrinVar -> RuntimeRep -> GrinValue -> [GrinVar] -> GrinExpr -> CpsM (GrinVar, GrinNode)
+reifyContinuation updateName parent bound resultRep outerContinuation resultVars body = do
+  transformedBody <-
+    transformTail
+      updateName
+      parent
+      (bound <> Set.fromList resultVars)
+      resultRep
+      outerContinuation
+      body
+  continuationName <- freshContinuationName parent
+  pointer <- freshVar "$cps_continuation" liftedRuntimeRep
+  let captures = Set.toAscList (freeExprVars transformedBody `Set.intersection` bound)
+      continuationFunction =
+        GrinFunction
+          { grinFunctionName = continuationName,
+            grinFunctionLinkName = Nothing,
+            grinFunctionParameters = captures <> resultVars,
+            grinFunctionResultRep = resultRep,
+            grinFunctionBody = transformedBody
+          }
+      continuationNode =
+        GrinNode
+          (GrinClosure continuationName [map grinVarRuntimeRep resultVars])
+          (map GrinVarValue captures)
+  addContinuationFunction continuationFunction
+  pure (pointer, continuationNode)
+
+continueDirect :: RuntimeRep -> GrinValue -> GrinExpr -> CpsM GrinExpr
+continueDirect runtimeRep continuation directExpression = do
+  resultVars <- mapM (freshVar "$cps_result") (runtimeRepComponents runtimeRep)
+  pure
+    ( GrinBind
+        resultVars
+        directExpression
+        (GrinContinue continuation (map GrinVarValue resultVars))
+    )
+
+makeUpdateContinuation :: FunctionName -> GrinValue -> GrinValue -> CpsM (GrinVar, GrinNode)
+makeUpdateContinuation updateName blackhole continuation = do
+  pointer <- freshVar "$cps_update" liftedRuntimeRep
+  pure
+    ( pointer,
+      GrinNode (GrinClosure updateName [[liftedRuntimeRep]]) [blackhole, continuation]
+    )
+
+makeUpdateFunction :: FunctionName -> CpsM GrinFunction
+makeUpdateFunction updateName = do
+  blackhole <- freshVar "$cps_blackhole" liftedRuntimeRep
+  outerContinuation <- freshVar "$cps_outer" liftedRuntimeRep
+  result <- freshVar "$cps_thunk_result" liftedRuntimeRep
+  updated <- freshVar "$cps_updated" liftedRuntimeRep
+  nextUpdate <- freshVar "$cps_next_update" liftedRuntimeRep
+  let nextUpdateNode =
+        GrinNode
+          (GrinClosure updateName [[liftedRuntimeRep]])
+          [GrinVarValue result, GrinVarValue outerContinuation]
+  pure
+    GrinFunction
+      { grinFunctionName = updateName,
+        grinFunctionLinkName = Nothing,
+        grinFunctionParameters = [blackhole, outerContinuation, result],
+        grinFunctionResultRep = liftedRuntimeRep,
+        grinFunctionBody =
+          GrinBind
+            [updated]
+            (GrinUpdateBlackhole (GrinVarValue blackhole) (GrinVarValue result))
+            ( GrinBind
+                [nextUpdate]
+                (GrinStore nextUpdateNode)
+                ( GrinCpsEval
+                    liftedRuntimeRep
+                    (GrinVarValue result)
+                    (GrinVarValue outerContinuation)
+                    (GrinVarValue nextUpdate)
+                )
+            )
+      }
+
+isDirectExpression :: GrinExpr -> Bool
+isDirectExpression expression =
   case expression of
-    GrinEval {} -> True
-    GrinCall {} -> True
+    GrinConstant {} -> True
+    GrinStore {} -> True
+    GrinFetch {} -> True
+    GrinUpdate {} -> True
+    GrinUpdateBlackhole {} -> True
     GrinPrimitiveCall {} -> True
-    GrinApply {} -> True
+    GrinForeignCallExpr {} -> True
     _ -> False
 
 freshContinuationName :: FunctionName -> CpsM FunctionName
-freshContinuationName parent = do
+freshContinuationName parent =
+  freshFunctionName ("$cps$" <> unFunctionName parent <> "$")
+
+freshFunctionName :: T.Text -> CpsM FunctionName
+freshFunctionName prefix = do
   state <- get
   let unique = cpsNextContinuationUnique state
-      candidate =
-        FunctionName
-          ( "$cps$"
-              <> unFunctionName parent
-              <> "$"
-              <> T.pack (show unique)
-          )
+      candidate = FunctionName (prefix <> T.pack (show unique))
   put state {cpsNextContinuationUnique = unique + 1}
   if candidate `Set.member` cpsUsedFunctionNames state
-    then freshContinuationName parent
+    then freshFunctionName prefix
     else do
-      modify' $ \current -> current {cpsUsedFunctionNames = Set.insert candidate (cpsUsedFunctionNames current)}
+      modify' $ \current ->
+        current {cpsUsedFunctionNames = Set.insert candidate (cpsUsedFunctionNames current)}
       pure candidate
 
-freshContinuationVar :: T.Text -> CpsM GrinVar
-freshContinuationVar name = do
+freshVar :: T.Text -> RuntimeRep -> CpsM GrinVar
+freshVar name runtimeRep = do
   state <- get
   let unique = cpsNextVarUnique state
   put state {cpsNextVarUnique = unique + 1}
-  pure (GrinVar name unique liftedRuntimeRep)
+  pure (GrinVar name unique runtimeRep)
+
+addContinuationFunction :: GrinFunction -> CpsM ()
+addContinuationFunction function = do
+  addGeneratedFunction function
+  modify' $ \state ->
+    state
+      { cpsContinuationNames =
+          Set.insert (grinFunctionName function) (cpsContinuationNames state)
+      }
 
 addGeneratedFunction :: GrinFunction -> CpsM ()
 addGeneratedFunction function =
@@ -203,10 +368,17 @@ freeExprVars expression =
         `Set.difference` Set.fromList (map fst bindings)
     GrinFetch _ pointer -> freeValueVars pointer
     GrinUpdate pointer value -> freeValueVars pointer <> freeValueVars value
+    GrinUpdateBlackhole pointer value -> freeValueVars pointer <> freeValueVars value
     GrinEval _ value -> freeValueVars value
+    GrinCpsEval _ value continuation updateContinuation ->
+      freeValueVars value <> freeValueVars continuation <> freeValueVars updateContinuation
     GrinCall _ _ arguments -> foldMap freeValueVars arguments
     GrinPrimitiveCall _ _ arguments -> foldMap freeValueVars arguments
     GrinApply _ function arguments -> freeValueVars function <> foldMap freeValueVars arguments
+    GrinCpsApply _ function arguments continuation ->
+      freeValueVars function <> foldMap freeValueVars arguments <> freeValueVars continuation
+    GrinContinue continuation values -> freeValueVars continuation <> foldMap freeValueVars values
+    GrinHalt values -> foldMap freeValueVars values
     GrinCase scrutinee binder alternatives ->
       freeValueVars scrutinee
         <> foldMap (freeAlternativeVars binder) alternatives
@@ -256,10 +428,17 @@ exprUniques expression =
         <> exprUniques body
     GrinFetch _ pointer -> valueUniques pointer
     GrinUpdate pointer value -> valueUniques pointer <> valueUniques value
+    GrinUpdateBlackhole pointer value -> valueUniques pointer <> valueUniques value
     GrinEval _ value -> valueUniques value
+    GrinCpsEval _ value continuation updateContinuation ->
+      valueUniques value <> valueUniques continuation <> valueUniques updateContinuation
     GrinCall _ _ arguments -> concatMap valueUniques arguments
     GrinPrimitiveCall _ _ arguments -> concatMap valueUniques arguments
     GrinApply _ function arguments -> valueUniques function <> concatMap valueUniques arguments
+    GrinCpsApply _ function arguments continuation ->
+      valueUniques function <> concatMap valueUniques arguments <> valueUniques continuation
+    GrinContinue continuation values -> valueUniques continuation <> concatMap valueUniques values
+    GrinHalt values -> concatMap valueUniques values
     GrinCase scrutinee binder alternatives ->
       valueUniques scrutinee
         <> (grinVarUnique binder : concatMap alternativeUniques alternatives)

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -52,6 +52,7 @@ data InterpretError
   | InterpretExpectedLocation !RuntimeValue
   | InterpretInvalidLocation !Int
   | InterpretBlackhole !Int
+  | InterpretCpsExpression !GrinExpr
   | InterpretRaisedException !Text
   deriving (Eq, Show)
 
@@ -221,8 +222,10 @@ evalExpr env expr =
       pointerValue <- materializeValue env pointer
       updatedValue <- materializeValue env value
       pure <$> updateValue pointerValue updatedValue
+    GrinUpdateBlackhole {} -> rejectCpsExpression
     GrinEval _ value ->
       (: []) <$> (materializeValue env value >>= forceValue)
+    GrinCpsEval {} -> rejectCpsExpression
     GrinCall _ functionName arguments ->
       callFunction functionName =<< mapM (materializeValue env) arguments
     GrinPrimitiveCall _ name arguments ->
@@ -231,6 +234,9 @@ evalExpr env expr =
       functionValue <- materializeValue env function
       argumentValues <- mapM (materializeValue env) arguments
       applyValue functionValue argumentValues
+    GrinCpsApply {} -> rejectCpsExpression
+    GrinContinue {} -> rejectCpsExpression
+    GrinHalt {} -> rejectCpsExpression
     GrinCase scrutinee binder alternatives -> do
       value <- materializeValue env scrutinee
       matchAlternative (Map.insert binder value env) value alternatives
@@ -252,6 +258,8 @@ evalExpr env expr =
     GrinForeignCallExpr foreignCall arguments -> do
       argumentValues <- mapM (materializeValue env) arguments
       executeForeignCall foreignCall argumentValues
+  where
+    rejectCpsExpression = throwInterpret (InterpretCpsExpression expr)
 
 handleRaised :: RuntimeValue -> [RuntimeValue] -> EvalFailure -> EvalM [RuntimeValue]
 handleRaised handler state failure =

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -8,7 +8,7 @@ module Aihc.Grin.Lint
 where
 
 import Aihc.Grin.Syntax
-import Aihc.Tc.Types (RuntimeRep, liftedRuntimeRep)
+import Aihc.Tc.Types (Levity (..), RuntimeRep (..), liftedRuntimeRep)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
@@ -37,6 +37,7 @@ data GrinLintError
 
 data LintEnv = LintEnv
   { lintFunctionArities :: !(Map FunctionName Int),
+    lintFunctionNodeArities :: !(Map FunctionName Int),
     lintFunctionResults :: !(Map FunctionName RuntimeRep),
     lintPrimitiveArities :: !(Map Text Int),
     lintGlobalVars :: !(Set GrinVar),
@@ -79,6 +80,15 @@ lintProgram program =
               ( [(grinFunctionName function, grinFunctionResultRep function) | function <- functions]
                   <> [(grinCodeFunctionName info, grinCodeResultRep info) | info <- grinExternalFunctions program]
               ),
+          lintFunctionNodeArities =
+            Map.fromList
+              ( [ (grinFunctionName function, semanticFunctionArity function)
+                | function <- functions
+                ]
+                  <> [ (grinCodeFunctionName info, semanticExternalArity info)
+                     | info <- grinExternalFunctions program
+                     ]
+              ),
           lintPrimitiveArities = Map.fromList [(grinVarName var, arity) | (var, arity) <- grinPrimitives program],
           lintGlobalVars = Set.fromList (globalVars <> cafVars),
           lintGlobalNames =
@@ -92,6 +102,15 @@ lintProgram program =
           lintConstructorLayouts = Map.fromList (grinConstructors program),
           lintForeignCalls = Map.fromList [(grinForeignCallName call, call) | call <- grinForeignCalls program]
         }
+    semanticFunctionArity function =
+      case reverse (grinFunctionParameters function) of
+        continuation : rest
+          | grinVarName continuation == "$cps_return" -> length rest
+        _ -> length (grinFunctionParameters function)
+    semanticExternalArity info =
+      case reverse (grinCodeParameterLayouts info) of
+        [BoxedRep Lifted] : rest -> length (concat (reverse rest))
+        _ -> length (concat (grinCodeParameterLayouts info))
 
 lintWhnfGlobal :: LintEnv -> (GrinVar, GrinNode) -> [GrinLintError]
 lintWhnfGlobal env (var, node) =
@@ -153,15 +172,31 @@ lintExpr env bound expr =
       [GrinLintUpdateNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, not (isLiftedRuntimeRep runtimeRep)]
         <> lintValue env bound pointer
         <> lintValue env bound value
+    GrinUpdateBlackhole pointer value ->
+      [GrinLintUpdateNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, not (isLiftedRuntimeRep runtimeRep)]
+        <> lintValue env bound pointer
+        <> lintValue env bound value
     GrinEval _ value ->
       [GrinLintEvalNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, runtimeRep /= liftedRuntimeRep]
         <> lintValue env bound value
+    GrinCpsEval _ value continuation updateContinuation ->
+      [GrinLintEvalNonLifted runtimeRep | let runtimeRep = grinValueRuntimeRep value, runtimeRep /= liftedRuntimeRep]
+        <> lintValue env bound value
+        <> lintValue env bound continuation
+        <> lintValue env bound updateContinuation
     GrinCall runtimeRep functionName arguments ->
       lintKnownCall env bound runtimeRep functionName arguments
     GrinPrimitiveCall _ name arguments ->
       [GrinLintUnknownPrimitive name | name `Map.notMember` lintPrimitiveArities env]
         <> concatMap (lintValue env bound) arguments
     GrinApply _ function arguments -> lintValue env bound function <> concatMap (lintValue env bound) arguments
+    GrinCpsApply _ function arguments continuation ->
+      lintValue env bound function
+        <> concatMap (lintValue env bound) arguments
+        <> lintValue env bound continuation
+    GrinContinue continuation values ->
+      lintValue env bound continuation <> concatMap (lintValue env bound) values
+    GrinHalt values -> concatMap (lintValue env bound) values
     GrinCase scrutinee binder alternatives ->
       lintValue env bound scrutinee
         <> concatMap (lintAlt env (Set.insert binder bound)) alternatives
@@ -253,7 +288,7 @@ lintNodeFunction env node =
   where
     fieldCount = length (grinNodeFields node)
     checkFunctionArity functionName actual =
-      case Map.lookup functionName (lintFunctionArities env) of
+      case Map.lookup functionName (lintFunctionNodeArities env) of
         Nothing -> [GrinLintUnknownFunction functionName]
         Just expected
           | expected == actual -> []
@@ -283,10 +318,15 @@ exprRuntimeReps expr =
     GrinStoreRec _ body -> exprRuntimeReps body
     GrinFetch runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
     GrinUpdate _ value -> Just [grinValueRuntimeRep value]
+    GrinUpdateBlackhole _ value -> Just [grinValueRuntimeRep value]
     GrinEval runtimeRep _ -> Just (runtimeRepComponents runtimeRep)
+    GrinCpsEval {} -> Nothing
     GrinCall runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinPrimitiveCall runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
     GrinApply runtimeRep _ _ -> Just (runtimeRepComponents runtimeRep)
+    GrinCpsApply {} -> Nothing
+    GrinContinue {} -> Nothing
+    GrinHalt {} -> Nothing
     GrinCase _ _ alternatives ->
       case alternatives of
         first : _ -> exprRuntimeReps (grinAltRhs first)

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -105,8 +105,16 @@ renderExprIndented indentation expr =
       indent indentation <> "fetch @" <> renderRuntimeRepArgument runtimeRep <> " " <> renderValue pointer
     GrinUpdate pointer value ->
       indent indentation <> "update " <> renderValue pointer <> " " <> renderValue value
+    GrinUpdateBlackhole pointer value ->
+      indent indentation <> "update-blackhole " <> renderValue pointer <> " " <> renderValue value
     GrinEval runtimeRep value ->
       indent indentation <> "eval @" <> renderRuntimeRepArgument runtimeRep <> " " <> renderValue value
+    GrinCpsEval runtimeRep value continuation updateContinuation ->
+      indent indentation
+        <> "cps-eval @"
+        <> renderRuntimeRepArgument runtimeRep
+        <> " "
+        <> unwords (map renderValue [value, continuation, updateContinuation])
     GrinCall runtimeRep functionName arguments ->
       indent indentation
         <> "call @"
@@ -128,6 +136,21 @@ renderExprIndented indentation expr =
         <> " "
         <> renderValue function
         <> renderArgument arguments
+    GrinCpsApply runtimeRep function arguments continuation ->
+      indent indentation
+        <> "cps-apply @"
+        <> renderRuntimeRepArgument runtimeRep
+        <> " "
+        <> renderValue function
+        <> renderArgument arguments
+        <> " -> "
+        <> renderValue continuation
+    GrinContinue continuation values ->
+      indent indentation
+        <> "continue "
+        <> renderValue continuation
+        <> renderArgument values
+    GrinHalt values -> indent indentation <> "halt" <> renderValues values
     GrinCase scrutinee binder alternatives ->
       indent indentation
         <> "case "

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -115,6 +115,10 @@ data GrinExpr
   | GrinFetch !RuntimeRep !GrinValue
   | GrinUpdate !GrinValue !GrinValue
   | GrinEval !RuntimeRep !GrinValue
+  | -- | CPS-only evaluation. The first continuation receives a value already
+    -- in weak-head normal form. The second continuation receives the result
+    -- of an entered thunk and is responsible for updating its blackhole.
+    GrinCpsEval !RuntimeRep !GrinValue !GrinValue !GrinValue
   | -- | A saturated call to a statically known code entry.
     GrinCall !RuntimeRep !FunctionName ![GrinValue]
   | -- | A saturated call to a statically known primitive entry.
@@ -123,6 +127,21 @@ data GrinExpr
     -- normal form. The list contains that argument's runtime values and may be
     -- empty for a zero-width argument such as @State# RealWorld@.
     GrinApply !RuntimeRep !GrinValue ![GrinValue]
+  | -- | CPS-only application. Partial applications and saturated
+    -- constructors transfer their result to the continuation; saturated
+    -- closures enter their code with the continuation as the hidden final
+    -- argument.
+    GrinCpsApply !RuntimeRep !GrinValue ![GrinValue] !GrinValue
+  | -- | Invoke an ordinary continuation closure with one logical result.
+    -- Unlike 'GrinCpsApply', continuation entries do not themselves receive a
+    -- return continuation.
+    GrinContinue !GrinValue ![GrinValue]
+  | -- | Update a cell that was blackholed by 'GrinCpsEval'. This is separate
+    -- from an ordinary explicit heap update so the runtime can enforce the
+    -- thunk-update protocol.
+    GrinUpdateBlackhole !GrinValue !GrinValue
+  | -- | Terminate CPS execution with the supplied observable result values.
+    GrinHalt ![GrinValue]
   | -- | Match a value that is already in weak-head normal form.
     GrinCase !GrinValue !GrinVar ![GrinAlt]
   | GrinThrow !GrinValue

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -85,6 +85,10 @@ grinUnitTests =
       testCase "interpreter rejects unlifted heap updates" $ do
         result <- interpretProgramBinding "answer" invalidUpdateProgram
         assertEqual "result" (Left (InterpretInvalidUpdateValue (RuntimeLit (GrinLitInt IntRep 2)))) result,
+      testCase "direct interpreter rejects CPS-only expressions" $
+        forM_ cpsOnlyExpressions $ \expression -> do
+          result <- interpretProgramFunctionSnapshot cpsOnlyFunction (cpsOnlyProgram expression)
+          assertEqual (show expression) (Left (InterpretCpsExpression expression)) result,
       testCase "lint rejects unlifted thunk results and heap updates" $
         forM_ unliftedRuntimeReps $ \runtimeRep ->
           let errors = lintProgram (unliftedHeapProgram runtimeRep)
@@ -1077,6 +1081,35 @@ transferringExpressions =
   where
     lifted = BoxedRep Lifted
     string = GrinLitValue (GrinLitString "function")
+
+cpsOnlyExpressions :: [GrinExpr]
+cpsOnlyExpressions =
+  [ GrinCpsEval lifted string string string,
+    GrinCpsApply lifted string [] string,
+    GrinContinue string [],
+    GrinUpdateBlackhole string string,
+    GrinHalt []
+  ]
+  where
+    lifted = BoxedRep Lifted
+    string = GrinLitValue (GrinLitString "continuation")
+
+cpsOnlyFunction :: FunctionName
+cpsOnlyFunction = FunctionName "cps_only"
+
+cpsOnlyProgram :: GrinExpr -> GrinProgram
+cpsOnlyProgram expression =
+  directBindProgram
+    { grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = cpsOnlyFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = expression
+            }
+        ]
+    }
 
 singleBindProgram :: GrinExpr -> GrinProgram
 singleBindProgram valueExpression =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -14,6 +14,7 @@ import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Control.Monad (forM_)
 import Data.List (isInfixOf)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -111,31 +112,53 @@ grinUnitTests =
             rendered = renderProgram program
         assertEqual "transformed lint" [] (lintProgram program)
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
-        assertBool "evaluates a continuation closure explicitly" ("eval @(BoxedRep Lifted) ($cps_continuation_pointer" `isInfixOf` rendered)
-        assertBool "invokes a continuation closure" ("apply @(BoxedRep Lifted) ($cps_continuation" `isInfixOf` rendered)
+        assertBool "invokes a continuation closure" ("continue ($cps_return" `isInfixOf` rendered)
+        assertBool "passes an explicit continuation to the call" (any callEndsInContinuation (grinFunctions program))
         assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
       testCase "CPS-GRIN treats a multi-value result as one logical argument" $ do
         cps <- expectCpsGrin multiValueContinuationProgram
         case grinFunctions (cpsGrinProgram cps) of
-          function : _callee : [_continuation] ->
+          function : _ ->
             case grinFunctionBody function of
-              GrinBind _ (GrinStore (GrinNode (GrinClosure _ layouts) [])) _ ->
+              GrinBind _ (GrinStore (GrinNode (GrinClosure _ layouts) _)) _ ->
                 assertEqual "one multi-value argument layout" [[IntRep, WordRep]] layouts
               body -> assertFailure ("expected a stored continuation closure, got " <> show body)
-          functions -> assertFailure ("expected source and continuation functions, got " <> show (length functions)),
-      testCase "CPS-GRIN reifies every function-call bind" $
-        forM_ functionCallExpressions $ \valueExpression -> do
+          [] -> assertFailure "expected transformed functions",
+      testCase "CPS-GRIN reifies only transferring binds" $ do
+        forM_ transferringExpressions $ \valueExpression -> do
           let source = singleBindProgram valueExpression
           cps <- expectCpsGrin source
-          assertEqual (show valueExpression) 2 (length (grinFunctions (cpsGrinProgram cps))),
+          assertEqual (show valueExpression) 1 (Set.size (cpsContinuationFunctions cps `Set.difference` Set.singleton (cpsUpdateFunction cps)))
+        primitiveCps <- expectCpsGrin (singleBindProgram (GrinPrimitiveCall (BoxedRep Lifted) "primitive" []))
+        assertEqual
+          "primitive calls stay direct"
+          Set.empty
+          (cpsContinuationFunctions primitiveCps `Set.difference` Set.singleton (cpsUpdateFunction primitiveCps)),
       testCase "CPS-GRIN keeps non-call binds in direct style" $ do
         cps <- expectCpsGrin directBindProgram
-        assertEqual "transformed program" directBindProgram (cpsGrinProgram cps),
-      testCase "CPS-GRIN preserves evaluation semantics" $ do
+        let rendered = renderProgram (cpsGrinProgram cps)
+        assertBool "constant bind remains direct" ("constant" `isInfixOf` rendered)
+        assertBool "store bind remains direct" ("store (CBox" `isInfixOf` rendered)
+        assertEqual
+          "case does not allocate a continuation"
+          Set.empty
+          (cpsContinuationFunctions cps `Set.difference` Set.singleton (cpsUpdateFunction cps)),
+      testCase "CPS-GRIN gives every computation entry a return continuation" $ do
+        cps <- expectCpsGrin callBindProgram
+        forM_ (Map.toList (cpsFunctionContinuations cps)) $ \(name, continuation) ->
+          case [function | function <- grinFunctions (cpsGrinProgram cps), grinFunctionName function == name] of
+            [function] ->
+              assertEqual "hidden final parameter" (Just continuation) (lastMaybe (grinFunctionParameters function))
+            _ -> assertFailure ("missing computation entry " <> show name),
+      testCase "CPS-GRIN makes thunk update an explicit continuation" $ do
         cps <- expectCpsGrin heapProgram
-        directResult <- interpretProgramBinding "answer" heapProgram
-        cpsResult <- interpretProgramBinding "answer" (cpsGrinProgram cps)
-        assertEqual "result" directResult cpsResult,
+        let program = cpsGrinProgram cps
+            updateName = cpsUpdateFunction cps
+        case [function | function <- grinFunctions program, grinFunctionName function == updateName] of
+          [function] -> do
+            assertBool "updates only a blackhole" (containsUpdateBlackhole (grinFunctionBody function))
+            assertBool "re-forces the updated result" (containsCpsEval (grinFunctionBody function))
+          _ -> assertFailure "missing unique update continuation",
       testCase "CPS-GRIN requires exception control to be eliminated" $ do
         assertEqual
           "throw"
@@ -474,6 +497,40 @@ isIOType ty =
     TcForAllTy _ body -> isIOType body
     TcQualTy _ body -> isIOType body
     _ -> False
+
+callEndsInContinuation :: GrinFunction -> Bool
+callEndsInContinuation function =
+  case grinFunctionBody function of
+    GrinBind _ _ body -> callEndsInContinuation function {grinFunctionBody = body}
+    GrinCall _ _ arguments ->
+      case reverse arguments of
+        GrinVarValue continuation : _ -> grinVarName continuation == "$cps_continuation"
+        _ -> False
+    _ -> False
+
+containsUpdateBlackhole :: GrinExpr -> Bool
+containsUpdateBlackhole expression =
+  case expression of
+    GrinUpdateBlackhole {} -> True
+    GrinBind _ value body -> containsUpdateBlackhole value || containsUpdateBlackhole body
+    GrinStoreRec _ body -> containsUpdateBlackhole body
+    GrinCase _ _ alternatives -> any (containsUpdateBlackhole . grinAltRhs) alternatives
+    _ -> False
+
+containsCpsEval :: GrinExpr -> Bool
+containsCpsEval expression =
+  case expression of
+    GrinCpsEval {} -> True
+    GrinBind _ value body -> containsCpsEval value || containsCpsEval body
+    GrinStoreRec _ body -> containsCpsEval body
+    GrinCase _ _ alternatives -> any (containsCpsEval . grinAltRhs) alternatives
+    _ -> False
+
+lastMaybe :: [value] -> Maybe value
+lastMaybe values =
+  case reverse values of
+    value : _ -> Just value
+    [] -> Nothing
 
 evalResultConstructor :: Int -> Text
 evalResultConstructor componentCount
@@ -1011,11 +1068,10 @@ callBindProgram =
     result = GrinVar "result" 2 (BoxedRep Lifted)
     box = GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)]
 
-functionCallExpressions :: [GrinExpr]
-functionCallExpressions =
+transferringExpressions :: [GrinExpr]
+transferringExpressions =
   [ GrinEval lifted string,
     GrinCall lifted (FunctionName "callee") [],
-    GrinPrimitiveCall lifted "primitive" [],
     GrinApply lifted string []
   ]
   where


### PR DESCRIPTION
## Summary

- give every value-producing GRIN computation entry an explicit return-continuation parameter
- reify non-tail call, apply, and eval contexts as ordinary GRIN continuation closures
- split forcing from blackhole update with `GrinCpsEval` and `GrinUpdateBlackhole`
- replace ARM64 runtime continuation push/return machinery with explicit CPS helpers that return their next entry for an immediate tail branch
- represent startup, IO completion, observed results, and thunk updates as closure-based continuations

## Why

The previous CPS pass only allocated continuation-looking closures around binds. Calls still returned through `AihcMachine.continuation`, so the native runtime retained a linked list of normal, update, top-level, and final continuations. Primitive calls were also incorrectly classified as transferring operations.

This change makes CPS ownership real: computation entries tail-transfer to explicit continuations, continuation entries consume results terminally, and runtime helpers only prepare arguments and return the next code entry.

## Implementation notes

- continuation closures preserve one logical result argument, including flattened multi-value and zero-width layouts
- closure and thunk logical arity excludes the hidden computation continuation
- thunk objects now retain their captured-field count so forcing can append an update continuation
- update continuations install an indirection and re-force the result, preserving thunk-returning-thunk behavior
- case alternatives receive the surrounding continuation structurally; cases and primitives do not allocate continuations themselves
- cross-unit code metadata carries the hidden CPS ABI parameter
- runtime control-transfer helpers return code addresses in `x0`; generated ARM64 immediately executes `br x0`

## Impact

The native runtime no longer defines `AihcContinuation`, continuation tags, a continuation field in `AihcMachine`, push operations, return-dispatch operations, or scheduled `next`/`locals` machine state. Generated Haskell code tail-branches directly to runtime-selected entries and does not require the native call stack for GRIN control flow.

## Validation

- `just fmt`
- `just check`
- `nix flake check`
- C formatting and clang-tidy checks
- host C compiler checks for the runtime ABI
- native ARM64 HelloWorld execution
- runtime source regression asserting the old continuation machinery is absent

Progress counts:

- GRIN unit/golden/eval tests: 120 → 122
- ARM64 tests: 19 → 22
