### PR TITLE
build: add C formatting and linting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+# The runtime intentionally stores pointers in machine-word slots, uses C's
+# implicit void-pointer allocation conversions, and targets portable C11 rather
+# than optional Annex K APIs. Its uniform runtime entry points also make the
+# similar-parameter heuristic noisy. Keep those exclusions narrow and explicit.
+Checks: >
+  -*,
+  bugprone-*,
+  clang-analyzer-*,
+  performance-*,
+  portability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -performance-no-int-to-ptr
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'

--- a/components/aihc-arm64/runtime/aihc_runtime.c
+++ b/components/aihc-arm64/runtime/aihc_runtime.c
@@ -55,7 +55,7 @@ static void *aihc_allocate(size_t bytes) {
 }
 
 static AihcContinuation *aihc_push_special(AihcMachine *machine,
-                                            uint64_t kind) {
+                                           uint64_t kind) {
   AihcContinuation *continuation = aihc_allocate(sizeof(*continuation));
   continuation->kind = kind;
   continuation->parent = machine->continuation;
@@ -106,13 +106,11 @@ AihcValue *aihc_make_node(uint64_t tag, uintptr_t info, uint64_t arity,
 }
 
 static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t result_tag,
-                                        uint64_t result_arity,
-                                        uint64_t count,
+                                        uint64_t result_arity, uint64_t count,
                                         const AihcSlot *fields) {
   uint64_t original_count = aihc_value_count(value);
-  AihcValue *copy =
-      aihc_make_node(result_tag, aihc_value_info(value), result_arity,
-                     original_count + count);
+  AihcValue *copy = aihc_make_node(result_tag, aihc_value_info(value),
+                                   result_arity, original_count + count);
   AihcSlot *original_fields = aihc_value_fields(value);
   AihcSlot *copy_fields = aihc_value_fields(copy);
   for (uint64_t index = 0; index < original_count; ++index) {
@@ -124,9 +122,8 @@ static AihcValue *aihc_copy_with_fields(AihcValue *value, uint64_t result_tag,
   return copy;
 }
 
-static AihcSlot *aihc_arguments_with_fields(AihcValue *function,
-                                             uint64_t count,
-                                             const AihcSlot *fields) {
+static AihcSlot *aihc_arguments_with_fields(AihcValue *function, uint64_t count,
+                                            const AihcSlot *fields) {
   uint64_t field_count = aihc_value_count(function);
   uint64_t total = field_count + count;
   AihcSlot *arguments =
@@ -180,39 +177,37 @@ static void aihc_schedule_function(AihcMachine *machine, AihcValue *function,
 }
 
 static void aihc_apply_forced(AihcMachine *machine, AihcValue *function,
-                              uint64_t count,
-                              const AihcSlot *arguments) {
+                              uint64_t count, const AihcSlot *arguments) {
   switch (aihc_value_tag(function)) {
   case AIHC_TAG_CLOSURE: {
     uint64_t arity = aihc_value_arity(function);
     if (arity > 1) {
-      AihcValue *applied = aihc_copy_with_fields(
-          function, AIHC_TAG_CLOSURE, arity - 1, count, arguments);
+      AihcValue *applied = aihc_copy_with_fields(function, AIHC_TAG_CLOSURE,
+                                                 arity - 1, count, arguments);
       aihc_return_value(machine, (AihcSlot)applied);
       return;
     }
     if (arity == 0) {
       aihc_fail("saturated closure was applied");
     }
-    aihc_schedule_function(machine, function,
-                           aihc_arguments_with_fields(function, count,
-                                                      arguments));
+    aihc_schedule_function(
+        machine, function,
+        aihc_arguments_with_fields(function, count, arguments));
     return;
   }
   case AIHC_TAG_PARTIAL_CONSTRUCTOR: {
     uint64_t arity = aihc_value_arity(function);
     if (arity > 1) {
       AihcValue *applied = aihc_copy_with_fields(
-          function, AIHC_TAG_PARTIAL_CONSTRUCTOR, arity - 1, count,
-          arguments);
+          function, AIHC_TAG_PARTIAL_CONSTRUCTOR, arity - 1, count, arguments);
       aihc_return_value(machine, (AihcSlot)applied);
       return;
     }
     if (arity == 0) {
       aihc_fail("saturated constructor was applied");
     }
-    AihcValue *applied = aihc_copy_with_fields(
-        function, AIHC_TAG_NODE, 0, count, arguments);
+    AihcValue *applied =
+        aihc_copy_with_fields(function, AIHC_TAG_NODE, 0, count, arguments);
     aihc_return_value(machine, (AihcSlot)applied);
     return;
   }
@@ -272,8 +267,8 @@ static void aihc_return_values_internal(AihcMachine *machine, uint64_t count,
       aihc_fail("continuation received the wrong number of values");
     }
     for (uint64_t index = 0; index < count; ++index) {
-      continuation->payload.normal.locals
-          [continuation->payload.normal.slot + index] = values[index];
+      continuation->payload.normal
+          .locals[continuation->payload.normal.slot + index] = values[index];
     }
     machine->locals = continuation->payload.normal.locals;
     machine->next = continuation->payload.normal.code;
@@ -325,8 +320,7 @@ void aihc_eval(AihcMachine *machine, AihcValue *value,
   aihc_eval_value(machine, value, result_is_lifted);
 }
 
-void aihc_apply(AihcMachine *machine, AihcValue *function,
-                AihcSlot argument) {
+void aihc_apply(AihcMachine *machine, AihcValue *function, AihcSlot argument) {
   aihc_apply_forced(machine, function, 1, &argument);
 }
 

--- a/components/aihc-arm64/runtime/aihc_snapshot.c
+++ b/components/aihc-arm64/runtime/aihc_snapshot.c
@@ -19,8 +19,8 @@ static void snapshot_fail(const char *message) {
   exit(1);
 }
 
-static const AihcSnapshotConstructor *find_constructor(
-    const SnapshotState *state, uintptr_t info) {
+static const AihcSnapshotConstructor *
+find_constructor(const SnapshotState *state, uintptr_t info) {
   for (uint64_t index = 0; index < state->constructor_count; ++index) {
     if (state->constructors[index].info == info) {
       return &state->constructors[index];
@@ -30,7 +30,7 @@ static const AihcSnapshotConstructor *find_constructor(
 }
 
 static const AihcSnapshotFunction *find_function(const SnapshotState *state,
-                                                  uintptr_t info) {
+                                                 uintptr_t info) {
   for (uint64_t index = 0; index < state->function_count; ++index) {
     if (state->functions[index].info == info) {
       return &state->functions[index];
@@ -48,8 +48,7 @@ static uint64_t location_for_object(SnapshotState *state, AihcValue *object) {
   if (state->object_count == state->object_capacity) {
     uint64_t capacity =
         state->object_capacity == 0 ? 8 : state->object_capacity * 2;
-    AihcValue **objects =
-        realloc(state->objects, sizeof(*objects) * capacity);
+    AihcValue **objects = realloc(state->objects, sizeof(*objects) * capacity);
     if (objects == NULL) {
       snapshot_fail("out of memory");
     }
@@ -156,9 +155,8 @@ static void discover_object(SnapshotState *state, AihcValue *object) {
     if (function == NULL) {
       snapshot_fail("function descriptor is missing");
     }
-    uint64_t count = tag == AIHC_TAG_CLOSURE
-                         ? aihc_value_count(object)
-                         : function->parameter_count;
+    uint64_t count = tag == AIHC_TAG_CLOSURE ? aihc_value_count(object)
+                                             : function->parameter_count;
     discover_fields(state, aihc_value_fields_const(object), count,
                     function->parameter_count, function->parameter_reps);
     return;

--- a/justfile
+++ b/justfile
@@ -17,9 +17,9 @@ qc:
 qc1:
   cabal test all -v0 --jobs=1 --test-options="--quickcheck-tests 10000 --quickcheck-shrinks 1000000 --hide-successes"
 
-# Auto-format Nix, Cabal, and Haskell files (excludes dist-newstyle, result, .git; Haskell excludes test fixtures)
+# Auto-format Nix, Cabal, Haskell, and C files (excludes dist-newstyle, result, .git; Haskell excludes test fixtures)
 fmt:
-  nix develop --quiet --command bash -c 'find . -name "*.nix" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0 | xargs -0 -r alejandra; while IFS= read -r -d "" file; do cabal-gild --mode format --io "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); ormolu --mode inplace $(find components tooling bin core-libs scripts/nix/ucd2haskell-aihc test/support -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'find . -name "*.nix" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0 | xargs -0 -r alejandra; while IFS= read -r -d "" file; do cabal-gild --mode format --io "$file"; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); ormolu --mode inplace $(find components tooling bin core-libs scripts/nix/ucd2haskell-aihc test/support -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*"); find components tooling bin core-libs scripts test -type f \( -name "*.c" -o -name "*.h" \) -not -path "*/dist-newstyle/*" -print0 | xargs -0 -r clang-format -i'
 
 # Apply HLint hints in place via apply-refact (HLint --refactor accepts one file at a time; same file set as fmt/check)
 hlint-refactor:
@@ -36,6 +36,8 @@ check:
   nix develop --quiet --command bash -c 'failed=0; while IFS= read -r -d "" file; do cabal-gild --mode check --input "$file" || failed=1; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); exit "$failed"'
   nix develop --quiet --command bash -c 'ormolu --mode check $(find components tooling bin core-libs scripts/nix/ucd2haskell-aihc test/support -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   nix develop --quiet --command bash -c 'hlint -j $(find components tooling bin core-libs scripts/nix/ucd2haskell-aihc test/support -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
+  nix develop --quiet --command bash -c 'find components tooling bin core-libs scripts test -type f \( -name "*.c" -o -name "*.h" \) -not -path "*/dist-newstyle/*" -print0 | xargs -0 -r clang-format --dry-run --Werror'
+  nix develop --quiet --command bash -c 'while IFS= read -r -d "" file; do clang-tidy --quiet "$file" -- -std=c11 -Wall -Wextra -Wpedantic; done < <(find components tooling bin core-libs scripts test -type f -name "*.c" -not -path "*/dist-newstyle/*" -print0)'
   cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'
 
 # Generate boot package interfaces for the resolver (requires GHC dev env)

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -4,6 +4,12 @@
   mkHsPkgsForChecks,
 }: pkgs: let
   hsPkgs = mkHsPkgsForChecks pkgs;
+  cTidyCompilerFlags =
+    ["-std=c11" "-Wall" "-Wextra" "-Wpedantic"]
+    ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+      "-isysroot"
+      "${pkgs.apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+    ];
 
   addHiddenSuccesses = old: {
     # Hide passing tests so failures are visible in Nix's truncated output.
@@ -115,6 +121,17 @@
       | xargs -0 -r ormolu --mode check
   '';
 
+  cLint = mkSourceCheck "aihc-c-lint" (sources.cSrc pkgs) [pkgs.clang-tools pkgs.findutils] ''
+    while IFS= read -r -d "" file; do
+      clang-tidy --quiet "$file" -- ${pkgs.lib.escapeShellArgs cTidyCompilerFlags}
+    done < <(find . -type f -name '*.c' -print0)
+  '';
+
+  cFormat = mkSourceCheck "aihc-c-format" (sources.cSrc pkgs) [pkgs.clang-tools pkgs.findutils] ''
+    find . -type f \( -name '*.c' -o -name '*.h' \) -print0 \
+      | xargs -0 -r clang-format --dry-run --Werror
+  '';
+
   cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.haskellSrc pkgs) [pkgs.haskellPackages.cabal-gild pkgs.findutils] ''
     failed=0
     while IFS= read -r -d "" file; do
@@ -188,6 +205,8 @@ in {
   nix-format = nixFormat;
   haskell-lint = haskellLint;
   haskell-format = haskellFormat;
+  c-lint = cLint;
+  c-format = cFormat;
   cabal-format = cabalFormat;
 
   all-tests = pkgs.linkFarm "aihc-all-tests" [
@@ -278,6 +297,14 @@ in {
     {
       name = "haskell-format";
       path = haskellFormat;
+    }
+    {
+      name = "c-lint";
+      path = cLint;
+    }
+    {
+      name = "c-format";
+      path = cFormat;
     }
     {
       name = "cabal-format";

--- a/scripts/nix/dev-shells.nix
+++ b/scripts/nix/dev-shells.nix
@@ -9,6 +9,7 @@ in {
       pkgs.haskellPackages.cabal-gild
       pkgs.alejandra
       pkgs.hlint
+      pkgs.clang-tools
     ];
   };
 }

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -207,6 +207,20 @@ in rec {
         type == "directory" || ((inComponents || inTooling || inBin || inCoreLibs || inNixHaskell || inTestSupport) && (isCabal || (isHaskell && !isFixture)));
     };
 
+  # Filtered source for C linting/formatting, including tool configuration.
+  cSrc = pkgs:
+    pkgs.lib.cleanSourceWith {
+      src = root;
+      filter = path: type: let
+        baseName = baseNameOf path;
+        relPath = pkgs.lib.removePrefix ((toString root) + "/") (toString path);
+        isBuildOutput = relPath == "dist-newstyle" || pkgs.lib.hasPrefix "dist-newstyle/" relPath;
+        isCSource = pkgs.lib.hasSuffix ".c" baseName || pkgs.lib.hasSuffix ".h" baseName;
+        isCConfig = baseName == ".clang-format" || baseName == ".clang-tidy";
+      in
+        !isBuildOutput && (type == "directory" || isCSource || isCConfig);
+    };
+
   # Filtered source for scripts - only shell scripts.
   scriptsSrc = pkgs:
     pkgs.lib.cleanSourceWith {


### PR DESCRIPTION
## Summary

- add repository-wide `clang-format` and `clang-tidy` configuration for C sources
- expose `c-format` and `c-lint` as Nix flake checks and add `clang-tools` to the development shell
- integrate C formatting and linting into `just fmt` and `just check`
- format the existing ARM64 runtime sources
- keep the tidy check hermetic on Darwin and exclude generated `dist-newstyle` headers

## Impact

C runtime changes are now formatted consistently and statically analyzed in both local development and Nix checks. The tidy configuration enables bug-prone, Clang analyzer, performance, and portability checks with narrow documented exclusions for intentional runtime representations and portable C11 APIs.

## Progress counts

Compiler progress counts are unchanged.

## Validation

- `just fmt`
- `just check`
- `nix build --no-link path:.#checks.aarch64-darwin.c-format path:.#checks.aarch64-darwin.c-lint`
