### PR TITLE
fix(grin): preserve WHNF pointers in interpreter

### DIFF
--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -309,6 +309,7 @@ snapshotCases =
     ("stores a self-referential value", "store-self-referential.yaml"),
     ("returns an unboxed value", "return-unboxed.yaml"),
     ("evaluates only through GrinEval", "eval.yaml"),
+    ("preserves WHNF pointers through GrinEval", "eval-whnf.yaml"),
     ("rejects blackholed thunk re-entry", "eval-blackhole.yaml"),
     ("applies a stored closure", "apply.yaml")
   ]

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/apply.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/apply.yaml
@@ -8,9 +8,8 @@ program: |
 
   $entry -> BoxedRep Lifted =
     (closure%2 :: BoxedRep Lifted) <- store (P$identity/1)
-    (function%5 :: BoxedRep Lifted) <- eval @(BoxedRep Lifted) (closure%2 :: BoxedRep Lifted)
     (value%3 :: BoxedRep Lifted) <- store (CI32# (9 :: Int32Rep))
-    (applied%4 :: BoxedRep Lifted) <- apply @(BoxedRep Lifted) (function%5 :: BoxedRep Lifted) (value%3 :: BoxedRep Lifted)
+    (applied%4 :: BoxedRep Lifted) <- apply @(BoxedRep Lifted) (closure%2 :: BoxedRep Lifted) (value%3 :: BoxedRep Lifted)
     store (CPair (closure%2 :: BoxedRep Lifted) (applied%4 :: BoxedRep Lifted))
 return: "@0"
 heap: |
@@ -18,4 +17,4 @@ heap: |
   @1 = P$identity/1
   @2 = CI32# 9
 status: pass
-reason: explicit GrinEval loads the stored closure before GrinApply enters it, while the heap snapshot still symbolizes its code pointer
+reason: GrinApply enters a stored closure that is already in WHNF without requiring GrinEval to change its heap pointer

--- a/components/aihc-arm64/test/Test/Fixtures/snapshot/eval-whnf.yaml
+++ b/components/aihc-arm64/test/Test/Fixtures/snapshot/eval-whnf.yaml
@@ -1,0 +1,24 @@
+entry: $entry
+program: |
+  constructor Box/0 []
+  constructor Value/0 []
+  constructor Result/5 [BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted]
+
+  $const (captured%1 :: BoxedRep Lifted) (ignored%2 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    constant (captured%1 :: BoxedRep Lifted)
+
+  $entry -> BoxedRep Lifted =
+    (captured%3 :: BoxedRep Lifted) <- store (CValue)
+    (partial%4 :: BoxedRep Lifted) <- store (P$const/1 (captured%3 :: BoxedRep Lifted))
+    (evaluated-partial%5 :: BoxedRep Lifted) <- eval @(BoxedRep Lifted) (partial%4 :: BoxedRep Lifted)
+    (constructor%6 :: BoxedRep Lifted) <- store (CBox)
+    (evaluated-constructor%7 :: BoxedRep Lifted) <- eval @(BoxedRep Lifted) (constructor%6 :: BoxedRep Lifted)
+    store (CResult (partial%4 :: BoxedRep Lifted) (evaluated-partial%5 :: BoxedRep Lifted) (captured%3 :: BoxedRep Lifted) (constructor%6 :: BoxedRep Lifted) (evaluated-constructor%7 :: BoxedRep Lifted))
+return: "@0"
+heap: |
+  @0 = CResult @1 @1 @2 @3 @3
+  @1 = P$const/1 @2
+  @2 = CValue
+  @3 = CBox
+status: pass
+reason: GrinEval returns the original heap pointer for partial applications and saturated data constructors that are already in WHNF

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -164,30 +164,26 @@ initialMachine program =
       machineHeap =
         IntMap.fromList
           [ (location, storedCell (staticNode node))
-          | ((_, node), location) <- zip cafs [0 ..]
+          | ((_, node), location) <- zip globalNodes [0 ..]
           ],
-      machineNextLocation = length cafs
+      machineNextLocation = length globalNodes
     }
   where
-    cafs = grinCafs program
-    cafLocations =
-      [ (var, RuntimeLocation location)
-      | ((var, _), location) <- zip cafs [0 ..]
-      ]
-    staticGlobals =
-      Map.fromList
-        [ (grinVarName var, staticNode node)
-        | (var, node) <- grinWhnfGlobals program
-        ]
-    globals =
+    globalNodes = Map.toAscList globalNodeMap
+    globalNodeMap =
       Map.unions
-        [ Map.fromList [(grinVarName var, value) | (var, value) <- cafLocations],
-          staticGlobals,
+        [ Map.fromList [(grinVarName var, node) | (var, node) <- grinCafs program],
+          Map.fromList [(grinVarName var, node) | (var, node) <- grinWhnfGlobals program],
           Map.fromList
-            [ (constructor, RuntimeNode (GrinConstructor constructor 0) [])
+            [ (constructor, GrinNode (GrinConstructor constructor 0) [])
             | (constructor, layouts) <- builtinConstructors <> grinConstructors program,
               null layouts
             ]
+        ]
+    globals =
+      Map.fromList
+        [ (name, RuntimeLocation location)
+        | ((name, _), location) <- zip globalNodes [0 ..]
         ]
     staticNode (GrinNode tag fields) = RuntimeNode tag (map staticValue fields)
     staticValue value =
@@ -363,7 +359,7 @@ forceLocation location = do
       case result of
         Right [value] -> do
           writeCell location (HeapValue value)
-          forceValue value
+          forceLocation location
         Right values -> do
           writeCell location cell
           throwInterpret (InterpretInvalidThunkResult values)
@@ -373,14 +369,16 @@ forceLocation location = do
         Left failure@(EvalInterpret _) -> do
           writeCell location cell
           throwE failure
-    HeapValue result -> forceValue result
+    HeapValue (RuntimeLocation target) -> forceLocation target
+    HeapValue _ -> pure (RuntimeLocation location)
     HeapRaised exception -> throwE (EvalRaised exception)
     HeapBlackhole -> throwInterpret (InterpretBlackhole location)
 
 applyValue :: RuntimeValue -> [RuntimeValue] -> EvalM [RuntimeValue]
-applyValue function arguments =
-  case function of
-    RuntimeNode (GrinClosure functionName remainingLayouts) fields ->
+applyValue function arguments = do
+  (tag, fields) <- appliedNode function
+  case tag of
+    GrinClosure functionName remainingLayouts ->
       case remainingLayouts of
         [] -> throwInterpret (InterpretFunctionArity functionName 0 1)
         layout : rest ->
@@ -393,13 +391,23 @@ applyValue function arguments =
               appliedFields = fields <> normalizedArguments
            in case rest of
                 [] -> callFunction functionName appliedFields
-                _ -> pure [RuntimeNode (GrinClosure functionName rest) appliedFields]
-    RuntimeNode (GrinConstructor name remaining) fields ->
+                _ -> pure <$> allocateCell (HeapValue (RuntimeNode (GrinClosure functionName rest) appliedFields))
+    GrinConstructor name remaining ->
       case compare remaining 1 of
-        GT -> pure [RuntimeNode (GrinConstructor name (remaining - 1)) (fields <> arguments)]
-        EQ -> pure [RuntimeNode (GrinConstructor name 0) (fields <> arguments)]
+        GT -> pure <$> allocateCell (HeapValue (RuntimeNode (GrinConstructor name (remaining - 1)) (fields <> arguments)))
+        EQ -> pure <$> allocateCell (HeapValue (RuntimeNode (GrinConstructor name 0) (fields <> arguments)))
         LT -> throwInterpret (InterpretConstructorArity name 0 1)
-    other -> throwInterpret (InterpretApplyNonFunction other)
+    GrinThunk _ -> throwInterpret (InterpretApplyNonFunction function)
+
+appliedNode :: RuntimeValue -> EvalM (GrinNodeTag, [RuntimeValue])
+appliedNode function =
+  case function of
+    RuntimeLocation location -> do
+      cell <- readCell location
+      case cell of
+        HeapValue (RuntimeNode tag fields) -> pure (tag, fields)
+        _ -> throwInterpret (InterpretApplyNonFunction function)
+    _ -> throwInterpret (InterpretApplyNonFunction function)
 
 callFunction :: FunctionName -> [RuntimeValue] -> EvalM [RuntimeValue]
 callFunction functionName arguments = do
@@ -562,19 +570,31 @@ runIOValue action = do
     _ -> throwInterpret (InterpretResultArity 1 (length results))
 
 matchAlternative :: Env -> RuntimeValue -> [GrinAlt] -> EvalM [RuntimeValue]
-matchAlternative env value alternatives =
-  case alternatives of
-    [] -> throwInterpret (InterpretNoMatchingAlternative value)
-    alt : rest ->
-      case matchAlt value alt of
+matchAlternative env value alternatives = do
+  inspected <- inspectCaseValue value
+  go inspected alternatives
+  where
+    go _ [] = throwInterpret (InterpretNoMatchingAlternative value)
+    go inspected (alt : rest) =
+      case matchAlt value inspected alt of
         Just bindings -> evalExpr (bindings `Map.union` env) (grinAltRhs alt)
-        Nothing -> matchAlternative env value rest
+        Nothing -> go inspected rest
 
-matchAlt :: RuntimeValue -> GrinAlt -> Maybe Env
-matchAlt value alt =
-  case (grinAltCon alt, value) of
+inspectCaseValue :: RuntimeValue -> EvalM RuntimeValue
+inspectCaseValue value =
+  case value of
+    RuntimeLocation location -> do
+      cell <- readCell location
+      case cell of
+        HeapValue node@RuntimeNode {} -> pure node
+        _ -> throwInterpret (InterpretNoMatchingAlternative value)
+    _ -> pure value
+
+matchAlt :: RuntimeValue -> RuntimeValue -> GrinAlt -> Maybe Env
+matchAlt original inspected alt =
+  case (grinAltCon alt, inspected) of
     (GrinDefaultAlt, _) ->
-      Just (Map.fromList [(var, value) | var <- grinAltBinders alt])
+      Just (Map.fromList [(var, original) | var <- grinAltBinders alt])
     (GrinLitAlt expected, RuntimeLit actual)
       | expected == actual -> Just Map.empty
     (GrinDataAlt expected, RuntimeNode (GrinConstructor actual 0) fields)
@@ -591,8 +611,8 @@ expectSingle values =
 
 renderRawValueM :: RuntimeValue -> EvalM Text
 renderRawValueM value = do
-  forced <- forceValue value
-  case forced of
+  exposed <- exposeWhnfValue value
+  case exposed of
     RuntimeLit literal -> pure (renderLiteral literal)
     RuntimeNode (GrinConstructor "C#" 0) [char] -> renderBoxedChar char
     RuntimeNode (GrinConstructor name 0) [] -> pure name
@@ -606,21 +626,28 @@ renderRawValueM value = do
     RuntimeNode GrinConstructor {} _ -> pure "<function>"
     RuntimeNode GrinClosure {} _ -> pure "<function>"
     RuntimeNode GrinThunk {} _ -> pure "<thunk>"
-    RuntimeLocation _ -> renderRawValueM forced
+    RuntimeLocation location -> throwInterpret (InterpretInvalidLocation location)
     RuntimeMutVar {} -> pure "<mutvar>"
     RuntimeStateToken -> pure "<state>"
 
 renderRawArgument :: RuntimeValue -> EvalM Text
 renderRawArgument value = do
-  forced <- forceValue value
-  rendered <- renderRawValueM forced
+  exposed <- exposeWhnfValue value
+  rendered <- renderRawValueM exposed
   pure $
-    case forced of
+    case exposed of
       RuntimeNode (GrinConstructor name 0) arguments
         | isTupleConstructor name (length arguments) -> rendered
       RuntimeNode (GrinConstructor "C#" 0) [_] -> rendered
       RuntimeNode (GrinConstructor _ 0) (_ : _) -> "(" <> rendered <> ")"
       _ -> rendered
+
+exposeWhnfValue :: RuntimeValue -> EvalM RuntimeValue
+exposeWhnfValue value = do
+  forced <- forceValue value
+  case forced of
+    RuntimeLocation _ -> fetchValue forced
+    _ -> pure forced
 
 renderLiteral :: GrinLiteral -> Text
 renderLiteral literal =

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -114,7 +114,10 @@ data GrinExpr
   | GrinStoreRec ![(GrinVar, GrinNode)] !GrinExpr
   | GrinFetch !RuntimeRep !GrinValue
   | GrinUpdate !GrinValue !GrinValue
-  | GrinEval !RuntimeRep !GrinValue
+  | -- | Enter a heap pointer until it points to a node in weak-head normal
+    -- form. The result remains a heap pointer; evaluation never returns the
+    -- fetched node payload directly.
+    GrinEval !RuntimeRep !GrinValue
   | -- | CPS-only evaluation. The first continuation receives a value already
     -- in weak-head normal form. The second continuation receives the result
     -- of an entered thunk and is responsible for updating its blackhole.
@@ -123,9 +126,10 @@ data GrinExpr
     GrinCall !RuntimeRep !FunctionName ![GrinValue]
   | -- | A saturated call to a statically known primitive entry.
     GrinPrimitiveCall !RuntimeRep !Text ![GrinValue]
-  | -- | Apply exactly one logical argument to a function already in weak-head
-    -- normal form. The list contains that argument's runtime values and may be
-    -- empty for a zero-width argument such as @State# RealWorld@.
+  | -- | Apply exactly one logical argument to a heap pointer whose node is
+    -- already in weak-head normal form. The list contains that argument's
+    -- runtime values and may be empty for a zero-width argument such as
+    -- @State# RealWorld@.
     GrinApply !RuntimeRep !GrinValue ![GrinValue]
   | -- | CPS-only application. Partial applications and saturated
     -- constructors transfer their result to the continuation; saturated

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -72,10 +72,38 @@ grinUnitTests =
         assertBool "apply operand is produced by eval" (any (containsExplicitOperand GrinApplyOperand) (grinFunctions applyProgram)),
       testCase "interpreter case does not evaluate its operand" $ do
         result <- interpretProgramBinding "answer" implicitCaseEvaluationProgram
-        assertEqual "result" (Left (InterpretNoMatchingAlternative (RuntimeLocation 1))) result,
+        case result of
+          Left (InterpretNoMatchingAlternative RuntimeLocation {}) -> pure ()
+          other -> assertFailure ("expected a non-matching heap pointer, got " <> show other),
       testCase "interpreter apply does not evaluate its operand" $ do
         result <- interpretProgramBinding "answer" implicitApplyEvaluationProgram
-        assertEqual "result" (Left (InterpretApplyNonFunction (RuntimeLocation 1))) result,
+        case result of
+          Left (InterpretApplyNonFunction RuntimeLocation {}) -> pure ()
+          other -> assertFailure ("expected a non-function heap pointer, got " <> show other),
+      testCase "interpreter eval preserves a stored WHNF pointer" $ do
+        result <- interpretProgramFunctionSnapshot storedWhnfEntry storedWhnfEvalProgram
+        assertEqual
+          "snapshot"
+          (Right "return: @0\nheap:\n  @0 = CBox\n")
+          (renderHeapSnapshot <$> result),
+      testCase "interpreter represents a static WHNF as a heap pointer" $ do
+        result <- interpretProgramFunctionSnapshot staticWhnfEntry staticWhnfProgram
+        assertEqual
+          "snapshot"
+          (Right "return: @0\nheap:\n  @0 = CBox\n")
+          (renderHeapSnapshot <$> result),
+      testCase "interpreter applies a stored WHNF closure" $ do
+        result <- interpretProgramFunctionSnapshot storedClosureEntry storedClosureApplyProgram
+        assertEqual
+          "snapshot"
+          (Right "return: @0\nheap:\n  @0 = CBox\n")
+          (renderHeapSnapshot <$> result),
+      testCase "interpreter matches a stored WHNF constructor" $ do
+        result <- interpretProgramFunctionSnapshot storedWhnfCaseEntry storedWhnfCaseProgram
+        assertEqual
+          "snapshot"
+          (Right "return: @0\nheap:\n  @0 = CBox\n")
+          (renderHeapSnapshot <$> result),
       testCase "interpreter implements fetch and update" $ do
         result <- interpretProgramBinding "answer" heapProgram
         assertEqual "result" (Right "Box 2") result,
@@ -1009,6 +1037,130 @@ implicitAnswerFunction = FunctionName "implicit_answer"
 
 implicitValueFunction :: FunctionName
 implicitValueFunction = FunctionName "implicit_value"
+
+storedWhnfEvalProgram :: GrinProgram
+storedWhnfEvalProgram =
+  emptyGrinProgram
+    { grinConstructors = [("Box", [])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = storedWhnfEntry,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [storedWhnfPointer]
+                  (GrinStore (GrinNode (GrinConstructor "Box" 0) []))
+                  (GrinEval (BoxedRep Lifted) (GrinVarValue storedWhnfPointer))
+            }
+        ]
+    }
+
+staticWhnfProgram :: GrinProgram
+staticWhnfProgram =
+  emptyGrinProgram
+    { grinConstructors = [("Box", [])],
+      grinWhnfGlobals = [(staticWhnfGlobal, GrinNode (GrinConstructor "Box" 0) [])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = staticWhnfEntry,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinEval (BoxedRep Lifted) (GrinVarValue staticWhnfGlobal)
+            }
+        ]
+    }
+
+storedClosureApplyProgram :: GrinProgram
+storedClosureApplyProgram =
+  emptyGrinProgram
+    { grinConstructors = [("Box", [])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = storedClosureEntry,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [storedClosurePointer]
+                  (GrinStore (GrinNode (GrinClosure storedClosureTarget [[BoxedRep Lifted]]) []))
+                  ( GrinBind
+                      [storedClosureArgument]
+                      (GrinStore (GrinNode (GrinConstructor "Box" 0) []))
+                      ( GrinApply
+                          (BoxedRep Lifted)
+                          (GrinVarValue storedClosurePointer)
+                          [GrinVarValue storedClosureArgument]
+                      )
+                  )
+            },
+          GrinFunction
+            { grinFunctionName = storedClosureTarget,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [storedClosureParameter],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinConstant [GrinVarValue storedClosureParameter]
+            }
+        ]
+    }
+
+storedWhnfCaseProgram :: GrinProgram
+storedWhnfCaseProgram =
+  emptyGrinProgram
+    { grinConstructors = [("Box", [])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = storedWhnfCaseEntry,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [storedWhnfPointer]
+                  (GrinStore (GrinNode (GrinConstructor "Box" 0) []))
+                  ( GrinCase
+                      (GrinVarValue storedWhnfPointer)
+                      storedWhnfBinder
+                      [ GrinAlt
+                          (GrinDataAlt "Box")
+                          []
+                          (GrinConstant [GrinVarValue storedWhnfBinder])
+                      ]
+                  )
+            }
+        ]
+    }
+
+emptyGrinProgram :: GrinProgram
+emptyGrinProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [],
+      grinCafs = [],
+      grinFunctions = []
+    }
+
+storedWhnfEntry, staticWhnfEntry, storedWhnfCaseEntry, storedClosureEntry, storedClosureTarget :: FunctionName
+storedWhnfEntry = FunctionName "stored_whnf"
+staticWhnfEntry = FunctionName "static_whnf"
+storedWhnfCaseEntry = FunctionName "stored_whnf_case"
+storedClosureEntry = FunctionName "stored_closure"
+storedClosureTarget = FunctionName "stored_closure_target"
+
+storedWhnfPointer, staticWhnfGlobal, storedWhnfBinder, storedClosurePointer, storedClosureArgument, storedClosureParameter :: GrinVar
+storedWhnfPointer = GrinVar "stored_whnf_pointer" 104 (BoxedRep Lifted)
+staticWhnfGlobal = GrinVar "static_whnf_global" 105 (BoxedRep Lifted)
+storedWhnfBinder = GrinVar "stored_whnf_binder" 106 (BoxedRep Lifted)
+storedClosurePointer = GrinVar "stored_closure_pointer" 107 (BoxedRep Lifted)
+storedClosureArgument = GrinVar "stored_closure_argument" 108 (BoxedRep Lifted)
+storedClosureParameter = GrinVar "stored_closure_parameter" 109 (BoxedRep Lifted)
 
 directBindProgram :: GrinProgram
 directBindProgram =


### PR DESCRIPTION
## Summary

- preserve heap-pointer identity when `GrinEval` observes a node already in weak-head normal form
- make `GrinApply` consume WHNF heap pointers without implicitly evaluating suspended thunks
- represent static WHNFs consistently as heap pointers and keep partial-application results heap allocated
- add a raw ARM64 snapshot proving that evaluation is a no-op for both a partial application and a saturated data constructor

## Root cause

The reference interpreter represented stored nodes as `RuntimeLocation`s but returned their inline `RuntimeNode` payloads from evaluation. `GrinApply` consequently rejected the original pointer even when it already referenced a closure in WHNF, diverging from the native runtime representation.

## Impact

Evaluation now follows thunks and indirections while returning a pointer to the resulting WHNF node. Structural consumers inspect the node behind that pointer without changing pointer identity or entering a suspended thunk.

## Progress

- `aihc-grin` tests: 122 → 126
- `aihc-arm64` tests: 22 → 23
- raw GRIN heap snapshots: 8 → 9

## Validation

- `just fmt`
- `just check`
- focused interpreter/native snapshot: `preserves WHNF pointers through GrinEval`
