### PR TITLE
feat: add Addr# literals and FFI support

### DIFF
--- a/components/aihc-amd64/aihc-amd64.cabal
+++ b/components/aihc-amd64/aihc-amd64.cabal
@@ -23,6 +23,7 @@ library
     aihc-native,
     aihc-tc,
     base >=4.16 && <5,
+    bytestring,
     containers,
     text,
     transformers,

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -34,11 +34,13 @@ import Aihc.Grin.Syntax
 import Aihc.Native
   ( LinkInterface,
     LinkLayout (..),
+    buildAddrLiteralPool,
     buildLinkLayout,
     buildLinkLayoutFromInterfaces,
     extendLinkLayout,
     extendLinkLayoutWithInterface,
     extractLinkInterface,
+    utf8Bytes,
   )
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM, replicateM)
@@ -68,6 +70,7 @@ data CompileEnv = CompileEnv
     compileConstructorArities :: !(Map Text Int),
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
+    compileAddrLiteralLabels :: !(Map Text Text),
     compileExposeAllFunctions :: !Bool,
     compileAllowUnsupportedPrimitives :: !Bool
   }
@@ -156,6 +159,7 @@ compileObservedFunction entryName cpsProgram = do
                ]
             <> mainEpilogue
             <> concat functions
+            <> renderAddrLiteralPool compileEnv
             <> nonExecutableStack
   pure ObservedProgram {observedAssembly = assembly, observedMetadataSource = metadata}
   where
@@ -202,6 +206,7 @@ compileModule layout initializerSymbol cpsProgram = do
       <> initLines
       <> mainEpilogue
       <> concat functions
+      <> renderAddrLiteralPool compileEnv
       <> nonExecutableStack
   where
     program = cpsGrinProgram cpsProgram
@@ -288,6 +293,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName cpsProgra
          ]
       <> mainEpilogue
       <> concat functions
+      <> renderAddrLiteralPool compileEnv
       <> nonExecutableStack
   where
     program = cpsGrinProgram cpsProgram
@@ -330,6 +336,8 @@ compileEnvironmentWith exposeAllFunctions layout program =
                  | (index, function) <- zip [0 ..] (grinFunctions program)
                  ]
           ),
+      compileAddrLiteralLabels =
+        Map.fromList (buildAddrLiteralPool program),
       compileExposeAllFunctions = exposeAllFunctions,
       compileAllowUnsupportedPrimitives = False
     }
@@ -625,6 +633,7 @@ normalizeForeignResult foreignType =
   case foreignType of
     GrinForeignInt32 -> ["  movsxd rax, eax"]
     GrinForeignWord64 -> []
+    GrinForeignAddr -> []
 
 foreignArgumentRegisters :: [Text]
 foreignArgumentRegisters = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"]
@@ -718,13 +727,22 @@ materializeValue :: ValueEnv -> GrinValue -> Either Amd64Error [Text]
 materializeValue env value =
   case value of
     GrinVarValue var -> loadVariable env var
-    GrinLitValue literal -> materializeLiteral literal
+    GrinLitValue literal -> materializeLiteral (valueCompileEnv env) literal
 
-materializeLiteral :: GrinLiteral -> Either Amd64Error [Text]
-materializeLiteral literal =
-  case normalizedLiteralInteger literal of
-    Just integer -> Right [immediate "rax" integer]
-    Nothing -> Left (Amd64UnsupportedValue "string literal")
+materializeLiteral :: CompileEnv -> GrinLiteral -> Either Amd64Error [Text]
+materializeLiteral env literal =
+  case literal of
+    GrinLitAddr value -> do
+      label <-
+        maybe
+          (Left (Amd64UnsupportedValue "unregistered Addr# literal"))
+          Right
+          (Map.lookup value (compileAddrLiteralLabels env))
+      pure [address "rax" label]
+    _ ->
+      case normalizedLiteralInteger literal of
+        Just integer -> Right [immediate "rax" integer]
+        Nothing -> Left (Amd64UnsupportedValue "string literal")
 
 normalizedLiteralInteger :: GrinLiteral -> Maybe Integer
 normalizedLiteralInteger literal = do
@@ -734,6 +752,7 @@ normalizedLiteralInteger literal = do
       GrinLitInt runtimeRep _ -> normalizeScalar runtimeRep integer
       GrinLitChar {} -> normalizeUnsigned 64 integer
       GrinLitString {} -> integer
+      GrinLitAddr {} -> integer
 
 normalizeScalar :: RuntimeRep -> Integer -> Integer
 normalizeScalar runtimeRep integer =
@@ -766,6 +785,7 @@ literalInteger literal =
     GrinLitInt _ integer -> Just integer
     GrinLitChar _ character -> Just (fromIntegral (ord character))
     GrinLitString _ -> Nothing
+    GrinLitAddr _ -> Nothing
 
 materializeNode :: ValueEnv -> GrinNode -> Either Amd64Error [Text]
 materializeNode env node = do
@@ -1174,6 +1194,19 @@ cString value = "\"" <> T.concatMap escape value <> "\""
     escape '\r' = "\\r"
     escape '\t' = "\\t"
     escape character = T.singleton character
+
+renderAddrLiteralPool :: CompileEnv -> [Text]
+renderAddrLiteralPool env =
+  case Map.toAscList (compileAddrLiteralLabels env) of
+    [] -> []
+    literals ->
+      [".section .rodata"]
+        <> concatMap renderLiteral literals
+  where
+    renderLiteral (value, label) =
+      [ label <> ":",
+        "  .byte " <> T.intercalate ", " (map tshow (utf8Bytes value <> [0]))
+      ]
 
 functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -40,12 +40,12 @@ import Aihc.Native
     extendLinkLayout,
     extendLinkLayoutWithInterface,
     extractLinkInterface,
-    utf8Bytes,
   )
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM, replicateM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (StateT, execStateT, get, modify')
+import Data.ByteString qualified as BS
 import Data.Char (ord)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -70,7 +70,7 @@ data CompileEnv = CompileEnv
     compileConstructorArities :: !(Map Text Int),
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
-    compileAddrLiteralLabels :: !(Map Text Text),
+    compileAddrLiteralLabels :: !(Map BS.ByteString Text),
     compileExposeAllFunctions :: !Bool,
     compileAllowUnsupportedPrimitives :: !Bool
   }
@@ -1205,7 +1205,7 @@ renderAddrLiteralPool env =
   where
     renderLiteral (value, label) =
       [ label <> ":",
-        "  .byte " <> T.intercalate ", " (map tshow (utf8Bytes value <> [0]))
+        "  .byte " <> T.intercalate ", " (map tshow (BS.unpack value <> [0]))
       ]
 
 functionLabel :: Int -> Text

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -125,6 +125,45 @@ tests =
             assertBool "255 :: Int8# is stored as -1" ("mov rax, -1" `T.isInfixOf` assembly)
             assertBool "maxBound :: Word64# remains unsigned" ("mov rax, 18446744073709551615" `T.isInfixOf` assembly)
             assertAssemblyAccepted assembly,
+      testCase "passes static Addr# literals to native foreign calls" $ do
+        let functionName = FunctionName "puts_addr"
+            foreignCall =
+              GrinForeignCall
+                { grinForeignCallName = "$ffi$puts",
+                  grinForeignCallSymbol = "puts",
+                  grinForeignCallSignature =
+                    GrinForeignSignature
+                      { grinForeignArgumentTypes = [GrinForeignAddr],
+                        grinForeignResultType = GrinForeignInt32,
+                        grinForeignEffect = GrinForeignPure
+                      }
+                }
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [],
+                  grinForeignCalls = [foreignCall],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = functionName,
+                          grinFunctionLinkName = Nothing,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = Int32Rep,
+                          grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "hello\n")]
+                        }
+                    ]
+                }
+        case compileModule (buildLinkLayout [program]) "_aihc_init_addr" (expectCpsGrin program) of
+          Left err -> assertFailure ("native compilation failed: " <> show err)
+          Right assembly -> do
+            assertBool "loads the static string address" ("lea rax, [rip + .Laihc_addr_0]" `T.isInfixOf` assembly)
+            assertBool "emits NUL-terminated UTF-8" (".byte 104, 101, 108, 108, 111, 10, 0" `T.isInfixOf` assembly)
+            assertBool "calls puts" ("call puts" `T.isInfixOf` assembly)
+            assertAssemblyAccepted assembly,
       testCase "returns unboxed tuples as direct machine values" $ do
         let functionName = FunctionName "pair_code"
             program =

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -153,7 +153,7 @@ tests =
                           grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int32Rep,
-                          grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "hello\n")]
+                          grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "\xFF\0bar")]
                         }
                     ]
                 }
@@ -161,7 +161,7 @@ tests =
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> do
             assertBool "loads the static string address" ("lea rax, [rip + .Laihc_addr_0]" `T.isInfixOf` assembly)
-            assertBool "emits NUL-terminated UTF-8" (".byte 104, 101, 108, 108, 111, 10, 0" `T.isInfixOf` assembly)
+            assertBool "emits NUL-terminated Latin-1" (".byte 255, 0, 98, 97, 114, 0" `T.isInfixOf` assembly)
             assertBool "calls puts" ("call puts" `T.isInfixOf` assembly)
             assertAssemblyAccepted assembly,
       testCase "returns unboxed tuples as direct machine values" $ do

--- a/components/aihc-arm64/aihc-arm64.cabal
+++ b/components/aihc-arm64/aihc-arm64.cabal
@@ -23,6 +23,7 @@ library
     aihc-native,
     aihc-tc,
     base >=4.16 && <5,
+    bytestring,
     containers,
     text,
     transformers,

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -34,11 +34,13 @@ import Aihc.Grin.Syntax
 import Aihc.Native
   ( LinkInterface,
     LinkLayout (..),
+    buildAddrLiteralPool,
     buildLinkLayout,
     buildLinkLayoutFromInterfaces,
     extendLinkLayout,
     extendLinkLayoutWithInterface,
     extractLinkInterface,
+    utf8Bytes,
   )
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM, replicateM)
@@ -68,6 +70,7 @@ data CompileEnv = CompileEnv
     compileConstructorArities :: !(Map Text Int),
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
+    compileAddrLiteralLabels :: !(Map Text Text),
     compileExposeAllFunctions :: !Bool,
     compileAllowUnsupportedPrimitives :: !Bool
   }
@@ -156,6 +159,7 @@ compileObservedFunction entryName cpsProgram = do
                  "  ret"
                ]
             <> concat functions
+            <> renderAddrLiteralPool compileEnv
   pure ObservedProgram {observedAssembly = assembly, observedMetadataSource = metadata}
   where
     program = cpsGrinProgram cpsProgram
@@ -202,6 +206,7 @@ compileModule layout initializerSymbol cpsProgram = do
            "  ret"
          ]
       <> concat functions
+      <> renderAddrLiteralPool compileEnv
   where
     program = cpsGrinProgram cpsProgram
     compileEnv = (compileEnvironment layout program) {compileAllowUnsupportedPrimitives = True}
@@ -286,6 +291,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName cpsProgra
            "  ret"
          ]
       <> concat functions
+      <> renderAddrLiteralPool compileEnv
   where
     program = cpsGrinProgram cpsProgram
     compileEnv = compileEnvironment layout program
@@ -314,6 +320,8 @@ compileEnvironmentWith exposeAllFunctions layout program =
                  | (index, function) <- zip [0 ..] (grinFunctions program)
                  ]
           ),
+      compileAddrLiteralLabels =
+        Map.fromList (buildAddrLiteralPool program),
       compileExposeAllFunctions = exposeAllFunctions,
       compileAllowUnsupportedPrimitives = False
     }
@@ -609,6 +617,7 @@ normalizeForeignResult foreignType =
   case foreignType of
     GrinForeignInt32 -> ["  sxtw x0, w0"]
     GrinForeignWord64 -> []
+    GrinForeignAddr -> []
 
 compileCase :: ValueEnv -> [Text] -> Text -> GrinValue -> GrinVar -> [GrinAlt] -> FunctionM ()
 compileCase env prefix label scrutinee binder alternatives = do
@@ -699,13 +708,22 @@ materializeValue :: ValueEnv -> GrinValue -> Either Arm64Error [Text]
 materializeValue env value =
   case value of
     GrinVarValue var -> loadVariable env var
-    GrinLitValue literal -> materializeLiteral literal
+    GrinLitValue literal -> materializeLiteral (valueCompileEnv env) literal
 
-materializeLiteral :: GrinLiteral -> Either Arm64Error [Text]
-materializeLiteral literal =
-  case normalizedLiteralInteger literal of
-    Just integer -> Right [immediate "x0" integer]
-    Nothing -> Left (Arm64UnsupportedValue "string literal")
+materializeLiteral :: CompileEnv -> GrinLiteral -> Either Arm64Error [Text]
+materializeLiteral env literal =
+  case literal of
+    GrinLitAddr value -> do
+      label <-
+        maybe
+          (Left (Arm64UnsupportedValue "unregistered Addr# literal"))
+          Right
+          (Map.lookup value (compileAddrLiteralLabels env))
+      pure [address "x0" label]
+    _ ->
+      case normalizedLiteralInteger literal of
+        Just integer -> Right [immediate "x0" integer]
+        Nothing -> Left (Arm64UnsupportedValue "string literal")
 
 normalizedLiteralInteger :: GrinLiteral -> Maybe Integer
 normalizedLiteralInteger literal = do
@@ -715,6 +733,7 @@ normalizedLiteralInteger literal = do
       GrinLitInt runtimeRep _ -> normalizeScalar runtimeRep integer
       GrinLitChar {} -> normalizeUnsigned 64 integer
       GrinLitString {} -> integer
+      GrinLitAddr {} -> integer
 
 normalizeScalar :: RuntimeRep -> Integer -> Integer
 normalizeScalar runtimeRep integer =
@@ -747,6 +766,7 @@ literalInteger literal =
     GrinLitInt _ integer -> Just integer
     GrinLitChar _ character -> Just (fromIntegral (ord character))
     GrinLitString _ -> Nothing
+    GrinLitAddr _ -> Nothing
 
 materializeNode :: ValueEnv -> GrinNode -> Either Arm64Error [Text]
 materializeNode env node = do
@@ -1155,6 +1175,19 @@ cString value = "\"" <> T.concatMap escape value <> "\""
     escape '\r' = "\\r"
     escape '\t' = "\\t"
     escape character = T.singleton character
+
+renderAddrLiteralPool :: CompileEnv -> [Text]
+renderAddrLiteralPool env =
+  case Map.toAscList (compileAddrLiteralLabels env) of
+    [] -> []
+    literals ->
+      [".section __TEXT,__cstring,cstring_literals"]
+        <> concatMap renderLiteral literals
+  where
+    renderLiteral (value, label) =
+      [ label <> ":",
+        "  .byte " <> T.intercalate ", " (map tshow (utf8Bytes value <> [0]))
+      ]
 
 functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -40,12 +40,12 @@ import Aihc.Native
     extendLinkLayout,
     extendLinkLayoutWithInterface,
     extractLinkInterface,
-    utf8Bytes,
   )
 import Aihc.Tc.Types (RuntimeRep (..))
 import Control.Monad (forM, replicateM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (StateT, execStateT, get, modify')
+import Data.ByteString qualified as BS
 import Data.Char (ord)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -70,7 +70,7 @@ data CompileEnv = CompileEnv
     compileConstructorArities :: !(Map Text Int),
     compileGlobalSlots :: !(Map Text Int),
     compileFunctionLabels :: !(Map FunctionName Text),
-    compileAddrLiteralLabels :: !(Map Text Text),
+    compileAddrLiteralLabels :: !(Map BS.ByteString Text),
     compileExposeAllFunctions :: !Bool,
     compileAllowUnsupportedPrimitives :: !Bool
   }
@@ -1186,7 +1186,7 @@ renderAddrLiteralPool env =
   where
     renderLiteral (value, label) =
       [ label <> ":",
-        "  .byte " <> T.intercalate ", " (map tshow (utf8Bytes value <> [0]))
+        "  .byte " <> T.intercalate ", " (map tshow (BS.unpack value <> [0]))
       ]
 
 functionLabel :: Int -> Text

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -146,7 +146,7 @@ tests =
                           grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int32Rep,
-                          grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "hello\n")]
+                          grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "\xFF\0bar")]
                         }
                     ]
                 }
@@ -154,7 +154,7 @@ tests =
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> do
             assertBool "loads the static string address" ("adrp x0, .Laihc_addr_0@PAGE" `T.isInfixOf` assembly)
-            assertBool "emits NUL-terminated UTF-8" (".byte 104, 101, 108, 108, 111, 10, 0" `T.isInfixOf` assembly)
+            assertBool "emits NUL-terminated Latin-1" (".byte 255, 0, 98, 97, 114, 0" `T.isInfixOf` assembly)
             assertBool "calls puts" ("bl _puts" `T.isInfixOf` assembly),
       testCase "returns unboxed tuples as direct machine values" $ do
         let functionName = FunctionName "pair_code"

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -118,6 +118,44 @@ tests =
         case compileModule (buildLinkLayout [program]) "_aihc_init_narrow" (expectCpsGrin program) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> assertBool "255 :: Int8# is stored as -1" ("ldr x0, =-1" `T.isInfixOf` assembly),
+      testCase "passes static Addr# literals to native foreign calls" $ do
+        let functionName = FunctionName "puts_addr"
+            foreignCall =
+              GrinForeignCall
+                { grinForeignCallName = "$ffi$puts",
+                  grinForeignCallSymbol = "puts",
+                  grinForeignCallSignature =
+                    GrinForeignSignature
+                      { grinForeignArgumentTypes = [GrinForeignAddr],
+                        grinForeignResultType = GrinForeignInt32,
+                        grinForeignEffect = GrinForeignPure
+                      }
+                }
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [],
+                  grinForeignCalls = [foreignCall],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = functionName,
+                          grinFunctionLinkName = Nothing,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = Int32Rep,
+                          grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "hello\n")]
+                        }
+                    ]
+                }
+        case compileModule (buildLinkLayout [program]) "_aihc_init_addr" (expectCpsGrin program) of
+          Left err -> assertFailure ("native compilation failed: " <> show err)
+          Right assembly -> do
+            assertBool "loads the static string address" ("adrp x0, .Laihc_addr_0@PAGE" `T.isInfixOf` assembly)
+            assertBool "emits NUL-terminated UTF-8" (".byte 104, 101, 108, 108, 111, 10, 0" `T.isInfixOf` assembly)
+            assertBool "calls puts" ("bl _puts" `T.isInfixOf` assembly),
       testCase "returns unboxed tuples as direct machine values" $ do
         let functionName = FunctionName "pair_code"
             program =

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -29,6 +29,7 @@ library
     aihc-resolve,
     aihc-tc,
     base >=4.16 && <5,
+    bytestring,
     containers,
     libffi >=0.2 && <0.3,
     text >=1.2,

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -302,10 +302,9 @@ dsForeignPrim tcAnn foreignDecl = do
 
 dsForeignCcall :: TcAnnotation -> TcForeignImportAnnotation -> ForeignDecl -> DsM [FcTopBind]
 dsForeignCcall tcAnn foreignPlan foreignDecl = do
-  case foreignSafety foreignDecl of
-    Nothing -> pure ()
-    Just Unsafe -> pure ()
-    _ -> desugarBug "safe and interruptible foreign imports are not supported"
+  if foreignSafety foreignDecl == Just Unsafe
+    then pure ()
+    else desugarBug "only unsafe foreign imports are supported"
   symbol <-
     case foreignEntity foreignDecl of
       ForeignEntityNamed name -> pure name

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -302,9 +302,10 @@ dsForeignPrim tcAnn foreignDecl = do
 
 dsForeignCcall :: TcAnnotation -> TcForeignImportAnnotation -> ForeignDecl -> DsM [FcTopBind]
 dsForeignCcall tcAnn foreignPlan foreignDecl = do
-  if foreignSafety foreignDecl == Just Unsafe
-    then pure ()
-    else desugarBug "only unsafe foreign imports are supported"
+  case foreignSafety foreignDecl of
+    Nothing -> pure ()
+    Just Unsafe -> pure ()
+    _ -> desugarBug "safe and interruptible foreign imports are not supported"
   symbol <-
     case foreignEntity foreignDecl of
       ForeignEntityNamed name -> pure name
@@ -346,6 +347,7 @@ lowerForeignAbiType foreignType =
   case foreignType of
     TcForeignInt32 -> FcForeignInt32
     TcForeignWord64 -> FcForeignWord64
+    TcForeignAddr -> FcForeignAddr
 
 lowerForeignEffect :: TcForeignEffect -> FcForeignEffect
 lowerForeignEffect effect =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -59,6 +59,8 @@ import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (StateT, get, modify')
+import Data.ByteString qualified as BS
+import Data.Char (ord)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -473,7 +475,7 @@ dsExpr (EInt i numericType _) = pure (FcLit (LitInt (numericRuntimeRep numericTy
 dsExpr (EChar c _) = pure (boxCharLiteral c)
 dsExpr (ECharHash c _) = pure (FcLit (LitChar WordRep c))
 dsExpr (EString s _) = dsStringLiteral s
-dsExpr (EStringHash s _) = pure (FcLit (LitAddr s))
+dsExpr (EStringHash s _) = FcLit . LitAddr <$> primitiveStringBytes s
 dsExpr (EApp fun arg) =
   FcApp <$> dsExpr fun <*> dsExpr arg
 dsExpr (EInfix lhs op rhs) =
@@ -902,6 +904,16 @@ dsLocalGroup var group =
 dsStringLiteral :: Text -> DsM FcExpr
 dsStringLiteral text =
   pure (T.foldr consChar (nilList charTy) text)
+
+primitiveStringBytes :: Text -> DsM BS.ByteString
+primitiveStringBytes text =
+  case traverse toLatin1Byte (T.unpack text) of
+    Just bytes -> pure (BS.pack bytes)
+    Nothing -> desugarBug "primitive string literal escaped parser Latin-1 validation"
+  where
+    toLatin1Byte character
+      | ord character < 256 = Just (fromIntegral (ord character))
+      | otherwise = Nothing
 
 dsList :: TcAnnotation -> [Expr] -> DsM FcExpr
 dsList tcAnn elems =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -473,6 +473,7 @@ dsExpr (EInt i numericType _) = pure (FcLit (LitInt (numericRuntimeRep numericTy
 dsExpr (EChar c _) = pure (boxCharLiteral c)
 dsExpr (ECharHash c _) = pure (FcLit (LitChar WordRep c))
 dsExpr (EString s _) = dsStringLiteral s
+dsExpr (EStringHash s _) = pure (FcLit (LitAddr s))
 dsExpr (EApp fun arg) =
   FcApp <$> dsExpr fun <*> dsExpr arg
 dsExpr (EInfix lhs op rhs) =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -18,6 +18,7 @@ import Control.Exception (SomeException, displayException, try)
 import Control.Monad (zipWithM, (<=<), (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
+import Data.ByteString qualified as BS
 import Data.Char qualified as Char
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Map.Strict (Map)
@@ -26,7 +27,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
-import Foreign.LibFFI (Arg, argCInt, argPtr, argString, argWord64, callFFI, retCInt, retPtr, retVoid, retWord64)
+import Foreign.LibFFI (Arg, argCInt, argPtr, argWord64, callFFI, retCInt, retPtr, retVoid, retWord64)
+import Foreign.Marshal.Array (newArray0)
 import Foreign.Ptr (FunPtr, Ptr)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
@@ -300,7 +302,9 @@ marshalForeignArgument symbol FcForeignWord64 argument = do
 marshalForeignArgument symbol FcForeignAddr argument = do
   forced <- forceValue argument
   case forced of
-    VLit (LitAddr value) -> pure (argString (T.unpack value))
+    VLit (LitAddr value) -> do
+      pointer <- lift (newArray0 0 (BS.unpack value))
+      pure (argPtr pointer)
     VAddress pointer -> pure (argPtr pointer)
     other -> throwE (EvalForeignTypeError symbol other)
 
@@ -465,7 +469,7 @@ renderLiteral lit =
     LitInt _ i -> T.pack (show i)
     LitChar _ c -> T.pack (show c) <> "#"
     LitString s -> T.pack (show (T.unpack s))
-    LitAddr s -> T.pack (show (T.unpack s)) <> "#"
+    LitAddr s -> T.pack (show (map (Char.chr . fromIntegral) (BS.unpack s))) <> "#"
 
 renderBoxedChar :: Value -> EvalM Text
 renderBoxedChar value = do

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -26,8 +26,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
-import Foreign.LibFFI (Arg, argCInt, argWord64, callFFI, retCInt, retWord64)
-import Foreign.Ptr (FunPtr)
+import Foreign.LibFFI (Arg, argCInt, argPtr, argString, argWord64, callFFI, retCInt, retPtr, retVoid, retWord64)
+import Foreign.Ptr (FunPtr, Ptr)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
 data EvalError
@@ -46,6 +46,7 @@ data EvalError
 
 data Value
   = VLit Literal
+  | VAddress !(Ptr ())
   | VClosure Env Var FcExpr
   | VConstructor Text [Value]
   | VPrim Text Int [Value]
@@ -286,6 +287,8 @@ callForeign foreignCall args = do
     FcForeignWord64 -> do
       result <- lift (callFFI functionPointer retWord64 marshalledArgs)
       pure (VLit (LitInt Word64Rep (toInteger result)))
+    FcForeignAddr ->
+      VAddress <$> lift (callFFI functionPointer (retPtr retVoid) marshalledArgs)
 
 marshalForeignArgument :: Text -> FcForeignType -> Value -> EvalM Arg
 marshalForeignArgument symbol FcForeignInt32 argument = do
@@ -294,6 +297,12 @@ marshalForeignArgument symbol FcForeignInt32 argument = do
 marshalForeignArgument symbol FcForeignWord64 argument = do
   argumentValue <- forceWord64 symbol argument
   pure (argWord64 (fromInteger argumentValue :: Word64))
+marshalForeignArgument symbol FcForeignAddr argument = do
+  forced <- forceValue argument
+  case forced of
+    VLit (LitAddr value) -> pure (argString (T.unpack value))
+    VAddress pointer -> pure (argPtr pointer)
+    other -> throwE (EvalForeignTypeError symbol other)
 
 lookupForeignFunction :: FcForeignCall -> EvalM (FunPtr ())
 lookupForeignFunction foreignCall = do
@@ -396,6 +405,7 @@ renderForcedValue :: Value -> EvalM Text
 renderForcedValue value =
   case value of
     VLit lit -> pure (renderLiteral lit)
+    VAddress address -> pure (T.pack (show address))
     VConstructor "C#" [char] -> renderBoxedChar char
     VConstructor name [] -> pure name
     VConstructor ":" _ -> do
@@ -455,6 +465,7 @@ renderLiteral lit =
     LitInt _ i -> T.pack (show i)
     LitChar _ c -> T.pack (show c) <> "#"
     LitString s -> T.pack (show (T.unpack s))
+    LitAddr s -> T.pack (show (T.unpack s)) <> "#"
 
 renderBoxedChar :: Value -> EvalM Text
 renderBoxedChar value = do
@@ -471,6 +482,7 @@ renderRawValueM value = do
   forced <- forceValue value
   case forced of
     VLit lit -> pure (renderLiteral lit)
+    VAddress address -> pure (T.pack (show address))
     VConstructor "C#" [char] -> renderBoxedChar char
     VConstructor name [] -> pure name
     VConstructor name args | isTupleConstructor name (length args) -> do

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -20,6 +20,8 @@ where
 
 import Aihc.Fc.Syntax
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..))
+import Data.ByteString qualified as BS
+import Data.Char (chr)
 import Data.List (intercalate)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -187,7 +189,7 @@ renderLiteral :: Literal -> String
 renderLiteral (LitInt _ i) = show i
 renderLiteral (LitChar _ c) = show c <> "#"
 renderLiteral (LitString s) = show (T.unpack s)
-renderLiteral (LitAddr s) = show (T.unpack s) <> "#"
+renderLiteral (LitAddr s) = show (map (chr . fromIntegral) (BS.unpack s)) <> "#"
 
 -- | Render a type.
 renderType :: TcType -> String

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -187,6 +187,7 @@ renderLiteral :: Literal -> String
 renderLiteral (LitInt _ i) = show i
 renderLiteral (LitChar _ c) = show c <> "#"
 renderLiteral (LitString s) = show (T.unpack s)
+renderLiteral (LitAddr s) = show (T.unpack s) <> "#"
 
 -- | Render a type.
 renderType :: TcType -> String

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -119,6 +119,7 @@ data FcForeignEffect
 data FcForeignType
   = FcForeignInt32
   | FcForeignWord64
+  | FcForeignAddr
   deriving (Eq, Show, Read)
 
 fcForeignOperandTypes :: FcForeignSignature -> [TcType]
@@ -146,6 +147,7 @@ foreignPrimitiveType foreignType =
   case foreignType of
     FcForeignInt32 -> TcTyCon (TyCon "Int32#" 0) []
     FcForeignWord64 -> TcTyCon (TyCon "Word64#" 0) []
+    FcForeignAddr -> TcTyCon (TyCon "Addr#" 0) []
 
 statePrimRealWorldType :: TcType
 statePrimRealWorldType =
@@ -231,6 +233,8 @@ data Literal
   | -- | An unboxed character literal, such as @'x'#@.
     LitChar !RuntimeRep !Char
   | LitString !Text
+  | -- | A null-terminated UTF-8 address literal, such as @"hello"#@.
+    LitAddr !Text
   deriving (Eq, Show, Read)
 
 -- | The runtime representation carried by a Core literal. This is recorded
@@ -242,6 +246,7 @@ literalRuntimeRep literal =
     LitInt runtimeRep _ -> runtimeRep
     LitChar runtimeRep _ -> runtimeRep
     LitString {} -> liftedRuntimeRep
+    LitAddr {} -> AddrRep
 
 -- | The primitive type denoted by a literal. Unsupported combinations are
 -- deliberately absent so Core Lint can reject them.
@@ -252,6 +257,7 @@ literalType literal =
     LitChar WordRep _ -> Just (primitiveType "Char#")
     LitChar _ _ -> Nothing
     LitString {} -> Just (TcTyCon (TyCon "[]" 1) [TcTyCon (TyCon "Char" 0) []])
+    LitAddr {} -> Just (primitiveType "Addr#")
   where
     scalarType runtimeRep =
       primitiveType

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -53,6 +53,7 @@ import Aihc.Tc.Types
     Unique,
     liftedRuntimeRep,
   )
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 
 -- | A System FC program: a collection of top-level bindings.
@@ -233,8 +234,8 @@ data Literal
   | -- | An unboxed character literal, such as @'x'#@.
     LitChar !RuntimeRep !Char
   | LitString !Text
-  | -- | A null-terminated UTF-8 address literal, such as @"hello"#@.
-    LitAddr !Text
+  | -- | Latin-1 bytes with an implicit trailing NUL, such as @"hello"#@.
+    LitAddr !ByteString
   deriving (Eq, Show, Read)
 
 -- | The runtime representation carried by a Core literal. This is recorded

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -44,6 +44,10 @@ fcEvalTests =
         assertEvalExpr "'x'#" (FcLit (LitChar WordRep 'x')),
       testCase "renders int literals" $
         assertEvalExpr "42" (FcLit (LitInt IntRep 42)),
+      testCase "records Addr# literal type and representation" $ do
+        let literal = LitAddr "hello"
+        assertEqual "runtime representation" AddrRep (literalRuntimeRep literal)
+        assertEqual "literal type" (Just (TcTyCon (TyCon "Addr#" 0) [])) (literalType literal),
       testCase "applies lambdas" $
         assertEvalExpr
           "\"ok\""

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
@@ -35,9 +35,9 @@ modules:
   newtype CInt = CInt Int32
   newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
 
-  foreign import ccall puts :: Addr# -> IO CInt
+  foreign import ccall unsafe puts :: Addr# -> IO CInt
 
   main :: IO CInt
   main = puts "hello world\n"#
-reason: lowers Addr# literals and ccall arguments without boxing
+reason: lowers Addr# literals and unsafe ccall arguments without boxing
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
@@ -1,0 +1,43 @@
+expected: |-
+  data State#
+
+  data RealWorld
+
+  data Int32
+   = I32# Int32#
+
+  newtype CInt = CInt Int32
+
+  newtype IO a = IO ((State# RealWorld) → (#,#) (State# RealWorld) a)
+
+  foreign ccall "puts" $ffi$puts : Addr# → (State# RealWorld) → (#,#) (State# RealWorld) Int32#
+
+  puts : Addr# → IO CInt =
+    λ$ffi_arg_0 : Addr#.
+      (λ$ffi_state : State# RealWorld.
+        case foreign-call $ffi$puts $ffi_arg_0 $ffi_state as $ffi_result : (#,#) (State# RealWorld) Int32# of
+          (#,#) $ffi_next_state $ffi_raw_result →
+            (#,#) $ffi_next_state ((I32# $ffi_raw_result) ▷ <co>)) ▷ <co>
+
+  main : IO CInt =
+    puts "hello world\n"#
+extensions:
+- ForeignFunctionInterface
+- MagicHash
+- UnboxedTuples
+modules:
+- |
+  module Test where
+
+  data State# s
+  data RealWorld
+  data Int32 = I32# Int32#
+  newtype CInt = CInt Int32
+  newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
+
+  foreign import ccall puts :: Addr# -> IO CInt
+
+  main :: IO CInt
+  main = puts "hello world\n"#
+reason: lowers Addr# literals and ccall arguments without boxing
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-omitted-safety.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-omitted-safety.yaml
@@ -1,0 +1,13 @@
+extensions:
+- ForeignFunctionInterface
+- MagicHash
+modules:
+- |
+  module Test where
+
+  data Int32 = I32# Int32#
+  newtype CInt = CInt Int32
+
+  foreign import ccall puts :: Addr# -> CInt
+status: fail
+reason: ccalls must be marked explicitly unsafe

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -25,6 +25,7 @@ library
     aihc-fc,
     aihc-tc,
     base >=4.16 && <5,
+    bytestring,
     containers,
     libffi >=0.2 && <0.3,
     text >=1.2,

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -28,8 +28,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
-import Foreign.LibFFI (Arg, argCInt, argWord64, callFFI, retCInt, retWord64)
-import Foreign.Ptr (FunPtr)
+import Foreign.LibFFI (Arg, argCInt, argPtr, argString, argWord64, callFFI, retCInt, retPtr, retVoid, retWord64)
+import Foreign.Ptr (FunPtr, Ptr)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
 data InterpretError
@@ -58,6 +58,7 @@ data InterpretError
 
 data RuntimeValue
   = RuntimeLit !GrinLiteral
+  | RuntimeAddress !(Ptr ())
   | RuntimeNode !GrinNodeTag ![RuntimeValue]
   | RuntimeLocation !Int
   | RuntimeMutVar !GrinMutVar
@@ -428,6 +429,7 @@ isLiftedRuntimeValue :: RuntimeValue -> Bool
 isLiftedRuntimeValue value =
   case value of
     RuntimeLit literal -> isLiftedRuntimeRep (grinValueRuntimeRep (GrinLitValue literal))
+    RuntimeAddress {} -> False
     RuntimeNode {} -> True
     RuntimeLocation {} -> True
     RuntimeMutVar {} -> False
@@ -526,6 +528,8 @@ callForeign foreignCall arguments = do
     GrinForeignWord64 -> do
       result <- liftEvalIO (callFFI functionPointer retWord64 marshalledArguments)
       pure (RuntimeLit (GrinLitInt Word64Rep (toInteger result)))
+    GrinForeignAddr ->
+      RuntimeAddress <$> liftEvalIO (callFFI functionPointer (retPtr retVoid) marshalledArguments)
 
 marshalForeignArgument :: Text -> GrinForeignType -> RuntimeValue -> EvalM Arg
 marshalForeignArgument symbol GrinForeignInt32 argument = do
@@ -534,6 +538,11 @@ marshalForeignArgument symbol GrinForeignInt32 argument = do
 marshalForeignArgument symbol GrinForeignWord64 argument = do
   argumentValue <- expectWord64 symbol argument
   pure (argWord64 (fromInteger argumentValue :: Word64))
+marshalForeignArgument symbol GrinForeignAddr argument =
+  case argument of
+    RuntimeLit (GrinLitAddr value) -> pure (argString (T.unpack value))
+    RuntimeAddress pointer -> pure (argPtr pointer)
+    other -> throwInterpret (InterpretForeignTypeError symbol other)
 
 lookupForeignFunction :: GrinForeignCall -> EvalM (FunPtr ())
 lookupForeignFunction foreignCall = do
@@ -614,6 +623,7 @@ renderRawValueM value = do
   exposed <- exposeWhnfValue value
   case exposed of
     RuntimeLit literal -> pure (renderLiteral literal)
+    RuntimeAddress address -> pure (T.pack (show address))
     RuntimeNode (GrinConstructor "C#" 0) [char] -> renderBoxedChar char
     RuntimeNode (GrinConstructor name 0) [] -> pure name
     RuntimeNode (GrinConstructor name 0) arguments
@@ -655,6 +665,7 @@ renderLiteral literal =
     GrinLitInt _ value -> T.pack (show value)
     GrinLitChar _ value -> T.pack (show value) <> "#"
     GrinLitString value -> T.pack (show (T.unpack value))
+    GrinLitAddr value -> T.pack (show (T.unpack value)) <> "#"
 
 renderBoxedChar :: RuntimeValue -> EvalM Text
 renderBoxedChar value = do
@@ -734,6 +745,7 @@ snapshotRuntimeValue :: RuntimeValue -> State SnapshotBuild SnapshotValue
 snapshotRuntimeValue value =
   case value of
     RuntimeLit literal -> pure (SnapshotLiteral literal)
+    RuntimeAddress {} -> pure SnapshotAddress
     RuntimeNode {} -> do
       valueSources <- gets snapshotBuildValueSources
       case lookup value valueSources of

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -18,6 +18,7 @@ import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
 import Control.Monad.Trans.State.Strict (State, StateT, execState, get, gets, modify', runState, runStateT)
+import Data.ByteString qualified as BS
 import Data.Char qualified as Char
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.IntMap.Strict (IntMap)
@@ -28,7 +29,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word64)
 import Foreign.C.Types (CInt (..))
-import Foreign.LibFFI (Arg, argCInt, argPtr, argString, argWord64, callFFI, retCInt, retPtr, retVoid, retWord64)
+import Foreign.LibFFI (Arg, argCInt, argPtr, argWord64, callFFI, retCInt, retPtr, retVoid, retWord64)
+import Foreign.Marshal.Array (newArray0)
 import Foreign.Ptr (FunPtr, Ptr)
 import System.Posix.DynamicLinker (DL (Default), dlsym)
 
@@ -540,7 +542,9 @@ marshalForeignArgument symbol GrinForeignWord64 argument = do
   pure (argWord64 (fromInteger argumentValue :: Word64))
 marshalForeignArgument symbol GrinForeignAddr argument =
   case argument of
-    RuntimeLit (GrinLitAddr value) -> pure (argString (T.unpack value))
+    RuntimeLit (GrinLitAddr value) -> do
+      pointer <- liftEvalIO (newArray0 0 (BS.unpack value))
+      pure (argPtr pointer)
     RuntimeAddress pointer -> pure (argPtr pointer)
     other -> throwInterpret (InterpretForeignTypeError symbol other)
 
@@ -665,7 +669,7 @@ renderLiteral literal =
     GrinLitInt _ value -> T.pack (show value)
     GrinLitChar _ value -> T.pack (show value) <> "#"
     GrinLitString value -> T.pack (show (T.unpack value))
-    GrinLitAddr value -> T.pack (show (T.unpack value)) <> "#"
+    GrinLitAddr value -> T.pack (show (map (Char.chr . fromIntegral) (BS.unpack value))) <> "#"
 
 renderBoxedChar :: RuntimeValue -> EvalM Text
 renderBoxedChar value = do

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -1165,6 +1165,7 @@ lowerLiteral literal =
     LitInt runtimeRep value -> GrinLitInt runtimeRep value
     LitChar runtimeRep value -> GrinLitChar runtimeRep value
     LitString value -> GrinLitString value
+    LitAddr value -> GrinLitAddr value
 
 lowerAltCon :: FcAltCon -> GrinAltCon
 lowerAltCon altCon =
@@ -1200,6 +1201,7 @@ lowerForeignType foreignType =
   case foreignType of
     FcForeignInt32 -> GrinForeignInt32
     FcForeignWord64 -> GrinForeignWord64
+    FcForeignAddr -> GrinForeignAddr
 
 exprRuntimeRep :: FcExpr -> RuntimeRep
 exprRuntimeRep expr =

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -7,6 +7,8 @@ where
 
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..))
+import Data.ByteString qualified as BS
+import Data.Char (chr)
 import Data.List (intercalate)
 import Data.Text qualified as T
 
@@ -232,7 +234,7 @@ renderLiteral literal =
     GrinLitInt _ value -> show value
     GrinLitChar _ value -> show value
     GrinLitString value -> show (T.unpack value)
-    GrinLitAddr value -> show (T.unpack value) <> "#"
+    GrinLitAddr value -> show (map (chr . fromIntegral) (BS.unpack value)) <> "#"
 
 renderVar :: GrinVar -> String
 renderVar var =

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -232,6 +232,7 @@ renderLiteral literal =
     GrinLitInt _ value -> show value
     GrinLitChar _ value -> show value
     GrinLitString value -> show (T.unpack value)
+    GrinLitAddr value -> show (T.unpack value) <> "#"
 
 renderVar :: GrinVar -> String
 renderVar var =

--- a/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
@@ -13,6 +13,8 @@ module Aihc.Grin.Snapshot
 where
 
 import Aihc.Grin.Syntax
+import Data.ByteString qualified as BS
+import Data.Char (chr)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Text (Text)
@@ -107,7 +109,7 @@ renderLiteral literal =
     GrinLitInt _ value -> tshow value
     GrinLitChar _ value -> T.pack (show value) <> "#"
     GrinLitString value -> T.pack (show (T.unpack value))
-    GrinLitAddr value -> T.pack (show (T.unpack value)) <> "#"
+    GrinLitAddr value -> T.pack (show (map (chr . fromIntegral) (BS.unpack value))) <> "#"
 
 parenthesize :: Bool -> Text -> Text
 parenthesize shouldParenthesize value

--- a/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Snapshot.hs
@@ -29,6 +29,7 @@ data HeapSnapshot = HeapSnapshot
 
 data SnapshotValue
   = SnapshotLiteral !GrinLiteral
+  | SnapshotAddress
   | SnapshotNode !GrinNodeTag ![SnapshotValue]
   | SnapshotLocation !Int
   | SnapshotMutVar
@@ -80,6 +81,7 @@ renderValue :: Bool -> SnapshotValue -> Text
 renderValue nested value =
   case value of
     SnapshotLiteral literal -> renderLiteral literal
+    SnapshotAddress -> "<addr>"
     SnapshotNode tag fields -> renderNode nested tag fields
     SnapshotLocation location -> "@" <> tshow location
     SnapshotMutVar -> "<mutvar>"
@@ -105,6 +107,7 @@ renderLiteral literal =
     GrinLitInt _ value -> tshow value
     GrinLitChar _ value -> T.pack (show value) <> "#"
     GrinLitString value -> T.pack (show (T.unpack value))
+    GrinLitAddr value -> T.pack (show (T.unpack value)) <> "#"
 
 parenthesize :: Bool -> Text -> Text
 parenthesize shouldParenthesize value

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -35,6 +35,7 @@ module Aihc.Grin.Syntax
 where
 
 import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 
 -- | A whole GRIN program.
@@ -196,7 +197,7 @@ data GrinLiteral
   = GrinLitInt !RuntimeRep !Integer
   | GrinLitChar !RuntimeRep !Char
   | GrinLitString !Text
-  | GrinLitAddr !Text
+  | GrinLitAddr !ByteString
   deriving (Eq, Show, Read)
 
 -- | Every literal embedded in a program, including node fields and case

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -25,6 +25,7 @@ module Aihc.Grin.Syntax
     runtimeRepComponents,
     grinForeignOperandReps,
     grinForeignCallResultReps,
+    grinProgramLiterals,
     grinValueRuntimeRep,
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
@@ -195,7 +196,50 @@ data GrinLiteral
   = GrinLitInt !RuntimeRep !Integer
   | GrinLitChar !RuntimeRep !Char
   | GrinLitString !Text
+  | GrinLitAddr !Text
   deriving (Eq, Show, Read)
+
+-- | Every literal embedded in a program, including node fields and case
+-- alternatives. Native backends use this to build static literal pools.
+grinProgramLiterals :: GrinProgram -> [GrinLiteral]
+grinProgramLiterals program =
+  concatMap (nodeLiterals . snd) (grinWhnfGlobals program <> grinCafs program)
+    <> concatMap (exprLiterals . grinFunctionBody) (grinFunctions program)
+  where
+    exprLiterals expression =
+      case expression of
+        GrinConstant values -> concatMap valueLiterals values
+        GrinBind _ valueExpression body -> exprLiterals valueExpression <> exprLiterals body
+        GrinStore node -> nodeLiterals node
+        GrinStoreRec bindings body -> concatMap (nodeLiterals . snd) bindings <> exprLiterals body
+        GrinFetch _ pointer -> valueLiterals pointer
+        GrinUpdate pointer value -> valueLiterals pointer <> valueLiterals value
+        GrinEval _ value -> valueLiterals value
+        GrinCpsEval _ value continuation updateContinuation ->
+          valueLiterals value <> valueLiterals continuation <> valueLiterals updateContinuation
+        GrinCall _ _ arguments -> concatMap valueLiterals arguments
+        GrinPrimitiveCall _ _ arguments -> concatMap valueLiterals arguments
+        GrinApply _ function arguments -> valueLiterals function <> concatMap valueLiterals arguments
+        GrinCpsApply _ function arguments continuation ->
+          valueLiterals function <> concatMap valueLiterals arguments <> valueLiterals continuation
+        GrinContinue continuation values -> valueLiterals continuation <> concatMap valueLiterals values
+        GrinUpdateBlackhole pointer value -> valueLiterals pointer <> valueLiterals value
+        GrinHalt values -> concatMap valueLiterals values
+        GrinCase scrutinee _ alternatives -> valueLiterals scrutinee <> concatMap altLiterals alternatives
+        GrinThrow exception -> valueLiterals exception
+        GrinCatch _ action handler state ->
+          valueLiterals action <> valueLiterals handler <> concatMap valueLiterals state
+        GrinForeignCallExpr _ arguments -> concatMap valueLiterals arguments
+    altLiterals alternative = altConLiterals (grinAltCon alternative) <> exprLiterals (grinAltRhs alternative)
+    altConLiterals altCon =
+      case altCon of
+        GrinLitAlt literal -> [literal]
+        _ -> []
+    nodeLiterals = concatMap valueLiterals . grinNodeFields
+    valueLiterals value =
+      case value of
+        GrinLitValue literal -> [literal]
+        GrinVarValue {} -> []
 
 grinValueRuntimeRep :: GrinValue -> RuntimeRep
 grinValueRuntimeRep value =
@@ -206,6 +250,7 @@ grinValueRuntimeRep value =
         GrinLitInt runtimeRep _ -> runtimeRep
         GrinLitChar runtimeRep _ -> runtimeRep
         GrinLitString {} -> liftedRuntimeRep
+        GrinLitAddr {} -> AddrRep
 
 isLiftedRuntimeRep :: RuntimeRep -> Bool
 isLiftedRuntimeRep runtimeRep = runtimeRep == liftedRuntimeRep
@@ -269,6 +314,7 @@ data GrinForeignEffect
 data GrinForeignType
   = GrinForeignInt32
   | GrinForeignWord64
+  | GrinForeignAddr
   deriving (Eq, Show, Read)
 
 grinForeignOperandReps :: GrinForeignSignature -> [RuntimeRep]
@@ -284,3 +330,4 @@ foreignTypeRuntimeRep foreignType =
   case foreignType of
     GrinForeignInt32 -> Int32Rep
     GrinForeignWord64 -> Word64Rep
+    GrinForeignAddr -> AddrRep

--- a/components/aihc-native/aihc-native.cabal
+++ b/components/aihc-native/aihc-native.cabal
@@ -25,6 +25,7 @@ library
   build-depends:
     aihc-grin,
     base >=4.16 && <5,
+    bytestring,
     containers,
     text,
 

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -17,12 +17,11 @@ module Aihc.Native
     renderNativeTarget,
     runtimeSourcePath,
     snapshotSourcePath,
-    utf8Bytes,
   )
 where
 
 import Aihc.Grin.Syntax
-import Data.Char (ord)
+import Data.ByteString (ByteString)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -85,7 +84,7 @@ buildLinkLayoutFromInterfaces :: [LinkInterface] -> LinkLayout
 buildLinkLayoutFromInterfaces = foldl extendLinkLayoutWithInterface emptyLinkLayout
 
 -- | Deduplicate address literals and assign short, unit-local assembly labels.
-buildAddrLiteralPool :: GrinProgram -> [(Text, Text)]
+buildAddrLiteralPool :: GrinProgram -> [(ByteString, Text)]
 buildAddrLiteralPool program =
   [ (value, ".Laihc_addr_" <> T.pack (show index))
   | (index, value) <- zip [0 :: Int ..] values
@@ -115,30 +114,6 @@ runtimeSourcePath = getDataFileName "runtime/aihc_runtime.c"
 
 snapshotSourcePath :: IO FilePath
 snapshotSourcePath = getDataFileName "runtime/aihc_snapshot.c"
-
--- | Encode text as UTF-8 bytes without adding a terminator.
-utf8Bytes :: Text -> [Int]
-utf8Bytes = concatMap encode . T.unpack
-  where
-    encode character
-      | codePoint <= 0x7f = [codePoint]
-      | codePoint <= 0x7ff =
-          [ 0xc0 + codePoint `div` 0x40,
-            0x80 + codePoint `mod` 0x40
-          ]
-      | codePoint <= 0xffff =
-          [ 0xe0 + codePoint `div` 0x1000,
-            0x80 + (codePoint `div` 0x40) `mod` 0x40,
-            0x80 + codePoint `mod` 0x40
-          ]
-      | otherwise =
-          [ 0xf0 + codePoint `div` 0x40000,
-            0x80 + (codePoint `div` 0x1000) `mod` 0x40,
-            0x80 + (codePoint `div` 0x40) `mod` 0x40,
-            0x80 + codePoint `mod` 0x40
-          ]
-      where
-        codePoint = ord character
 
 emptyLinkLayout :: LinkLayout
 emptyLinkLayout =

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Architecture-neutral support shared by native code generators.
 module Aihc.Native
   ( NativeTarget (..),
@@ -5,6 +7,7 @@ module Aihc.Native
     LinkLayout (..),
     buildLinkLayout,
     buildLinkLayoutFromInterfaces,
+    buildAddrLiteralPool,
     extendLinkLayout,
     extendLinkLayoutWithInterface,
     extractLinkInterface,
@@ -14,12 +17,15 @@ module Aihc.Native
     renderNativeTarget,
     runtimeSourcePath,
     snapshotSourcePath,
+    utf8Bytes,
   )
 where
 
 import Aihc.Grin.Syntax
+import Data.Char (ord)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 import Paths_aihc_native (getDataFileName)
 import System.Info qualified as System
 
@@ -78,6 +84,15 @@ buildLinkLayout = buildLinkLayoutFromInterfaces . map extractLinkInterface
 buildLinkLayoutFromInterfaces :: [LinkInterface] -> LinkLayout
 buildLinkLayoutFromInterfaces = foldl extendLinkLayoutWithInterface emptyLinkLayout
 
+-- | Deduplicate address literals and assign short, unit-local assembly labels.
+buildAddrLiteralPool :: GrinProgram -> [(Text, Text)]
+buildAddrLiteralPool program =
+  [ (value, ".Laihc_addr_" <> T.pack (show index))
+  | (index, value) <- zip [0 :: Int ..] values
+  ]
+  where
+    values = Set.toAscList (Set.fromList [value | GrinLitAddr value <- grinProgramLiterals program])
+
 extractLinkInterface :: GrinProgram -> LinkInterface
 extractLinkInterface program =
   LinkInterface
@@ -100,6 +115,30 @@ runtimeSourcePath = getDataFileName "runtime/aihc_runtime.c"
 
 snapshotSourcePath :: IO FilePath
 snapshotSourcePath = getDataFileName "runtime/aihc_snapshot.c"
+
+-- | Encode text as UTF-8 bytes without adding a terminator.
+utf8Bytes :: Text -> [Int]
+utf8Bytes = concatMap encode . T.unpack
+  where
+    encode character
+      | codePoint <= 0x7f = [codePoint]
+      | codePoint <= 0x7ff =
+          [ 0xc0 + codePoint `div` 0x40,
+            0x80 + codePoint `mod` 0x40
+          ]
+      | codePoint <= 0xffff =
+          [ 0xe0 + codePoint `div` 0x1000,
+            0x80 + (codePoint `div` 0x40) `mod` 0x40,
+            0x80 + codePoint `mod` 0x40
+          ]
+      | otherwise =
+          [ 0xf0 + codePoint `div` 0x40000,
+            0x80 + (codePoint `div` 0x1000) `mod` 0x40,
+            0x80 + (codePoint `div` 0x40) `mod` 0x40,
+            0x80 + codePoint `mod` 0x40
+          ]
+      where
+        codePoint = ord character
 
 emptyLinkLayout :: LinkLayout
 emptyLinkLayout =

--- a/components/aihc-native/test/Test/Native/RegisterAllocate.hs
+++ b/components/aihc-native/test/Test/Native/RegisterAllocate.hs
@@ -5,6 +5,7 @@ module Test.Native.RegisterAllocate
   )
 where
 
+import Aihc.Native (utf8Bytes)
 import Aihc.Native.Lir
 import Aihc.Native.RegisterAllocate
 import Data.Map.Strict qualified as Map
@@ -17,8 +18,10 @@ data TestReg = First | Second
 tests :: TestTree
 tests =
   testGroup
-    "register allocator"
-    [ testCase "reuses an expired register" $ do
+    "native support"
+    [ testCase "encodes literal pools as UTF-8" $
+        assertEqual "UTF-8 bytes" [65, 206, 187, 240, 159, 152, 128] (utf8Bytes "Aλ😀"),
+      testCase "reuses an expired register" $ do
         let first = VirtualReg 0
             second = VirtualReg 1
             allocation =

--- a/components/aihc-native/test/Test/Native/RegisterAllocate.hs
+++ b/components/aihc-native/test/Test/Native/RegisterAllocate.hs
@@ -5,7 +5,6 @@ module Test.Native.RegisterAllocate
   )
 where
 
-import Aihc.Native (utf8Bytes)
 import Aihc.Native.Lir
 import Aihc.Native.RegisterAllocate
 import Data.Map.Strict qualified as Map
@@ -19,9 +18,7 @@ tests :: TestTree
 tests =
   testGroup
     "native support"
-    [ testCase "encodes literal pools as UTF-8" $
-        assertEqual "UTF-8 bytes" [65, 206, 187, 240, 159, 152, 128] (utf8Bytes "Aλ😀"),
-      testCase "reuses an expired register" $ do
+    [ testCase "reuses an expired register" $ do
         let first = VirtualReg 0
             second = VirtualReg 1
             allocation =

--- a/components/aihc-parser/src/Aihc/Parser/Lex.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Lex.hs
@@ -71,7 +71,7 @@ import Aihc.Parser.Lex.Trivia
 import Aihc.Parser.Lex.Types
 import Aihc.Parser.Syntax
 import Control.Applicative ((<|>))
-import Data.Char (GeneralCategory (..), generalCategory, isAscii, isAsciiLower, isAsciiUpper, isDigit)
+import Data.Char (GeneralCategory (..), generalCategory, isAscii, isAsciiLower, isAsciiUpper, isDigit, ord)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text, pattern Empty, pattern (:<))
 import Data.Text qualified as T
@@ -820,8 +820,7 @@ lexString env st =
             Right (body, _) ->
               let raw = "\"\"\"" <> body <> "\"\"\""
                   decoded = T.pack (processMultilineString (T.unpack body))
-                  (tokTxt, tokKind, st') =
-                    withOptionalMagicHashSuffix 1 env st raw (TkString decoded) (TkStringHash decoded)
+                  (tokTxt, tokKind, st') = lexStringKind env st raw decoded
                in Just (mkToken st st' tokTxt tokKind, st')
             Left raw ->
               let full = "\"\"\"" <> raw
@@ -834,14 +833,21 @@ lexString env st =
                 Right (body, _) ->
                   let rawT = "\"" <> body <> "\""
                       decoded = fromMaybe body (decodeStringBody body)
-                      (tokTxt, tokKind, st') =
-                        withOptionalMagicHashSuffix 1 env st rawT (TkString decoded) (TkStringHash decoded)
+                      (tokTxt, tokKind, st') = lexStringKind env st rawT decoded
                    in Just (mkToken st st' tokTxt tokKind, st')
                 Left raw ->
                   let full = "\"" <> raw
                       st' = advanceChars full st
                    in Just (mkErrorToken st st' full "unterminated string literal", st')
             _ -> Nothing
+
+lexStringKind :: LexerEnv -> LexerState -> Text -> Text -> (Text, LexTokenKind, LexerState)
+lexStringKind env st raw decoded =
+  case withOptionalMagicHashSuffix 1 env st raw (TkString decoded) (TkStringHash decoded) of
+    (tokTxt, TkStringHash _ _, st')
+      | T.any ((>= 256) . ord) decoded ->
+          (tokTxt, TkError "primitive string literal contains a character outside Latin-1", st')
+    result -> result
 
 lexQuasiQuote :: LexerState -> Maybe (LexToken, LexerState)
 lexQuasiQuote st =

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-hash-latin1.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-hash-latin1.yaml
@@ -1,0 +1,6 @@
+extensions: [MagicHash]
+input: '"\xFF\0bar"#'
+tokens:
+  - 'TkStringHash "\255\NULbar" "\"\\xFF\\0bar\"#"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-hash-non-latin1.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-hash-non-latin1.yaml
@@ -1,0 +1,6 @@
+extensions: [MagicHash]
+input: '"\x3B1"#'
+tokens:
+  - 'TkError "primitive string literal contains a character outside Latin-1"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-parser/test/Test/Fixtures/lexer/core/string-non-latin1-boxed.yaml
+++ b/components/aihc-parser/test/Test/Fixtures/lexer/core/string-non-latin1-boxed.yaml
@@ -1,0 +1,6 @@
+extensions: [MagicHash]
+input: '"\x3B1"'
+tokens:
+  - 'TkString "\945"'
+  - 'TkEOF'
+status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -100,6 +100,7 @@ data TcForeignMarshal = TcForeignMarshal
 data TcForeignAbiType
   = TcForeignInt32
   | TcForeignWord64
+  | TcForeignAddr
   deriving (Eq, Show)
 
 -- | Type-checker annotation payload before constraint solving has finished.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -559,6 +559,7 @@ checkForeignValueType sourceSpan ty =
     TcTyCon (TyCon "Int32#" 0) [] -> pure (int32Marshal ty [])
     TcTyCon (TyCon "Word64" 0) [] -> pure (word64Marshal ty ["W64#"])
     TcTyCon (TyCon "Word64#" 0) [] -> pure (word64Marshal ty [])
+    TcTyCon (TyCon "Addr#" 0) [] -> pure (addrMarshal ty)
     _ -> do
       emitError sourceSpan (OtherError ("unsupported foreign import value type: " <> show ty))
       pure (int32Marshal ty [])
@@ -576,6 +577,13 @@ checkForeignValueType sourceSpan ty =
           tcForeignPrimitiveType = TcTyCon (TyCon "Word64#" 0) [],
           tcForeignConstructors = constructors,
           tcForeignAbiType = TcForeignWord64
+        }
+    addrMarshal sourceType =
+      TcForeignMarshal
+        { tcForeignSourceType = sourceType,
+          tcForeignPrimitiveType = TcTyCon (TyCon "Addr#" 0) [],
+          tcForeignConstructors = [],
+          tcForeignAbiType = TcForeignAddr
         }
 
 annotateDeclAt :: SourceSpan -> TcAnnotation -> Decl -> Decl

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -71,6 +71,8 @@ inferExprAt ambient expr = case expr of
     pure (expr, charHashTyCon, [])
   EString _ _ ->
     pure (expr, stringTyCon, [])
+  EStringHash _ _ ->
+    pure (expr, addrHashTyCon, [])
   ELambdaPats pats body ->
     inferLambda (exprSpan expr `orSourceSpan` ambient) pats body
   ELambdaCase alts ->
@@ -788,6 +790,9 @@ charTyCon = TcTyCon (TyCon "Char" 0) []
 
 charHashTyCon :: TcType
 charHashTyCon = TcTyCon (TyCon "Char#" 0) []
+
+addrHashTyCon :: TcType
+addrHashTyCon = TcTyCon (TyCon "Addr#" 0) []
 
 stringTyCon :: TcType
 stringTyCon = TcTyCon (TyCon "[]" 1) [charTyCon]

--- a/components/aihc-tc/test/Test/Fixtures/annotated/addr-unboxed-string-ffi.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/addr-unboxed-string-ffi.yaml
@@ -1,0 +1,31 @@
+annotated:
+- |-
+  module Test where
+
+  data CInt
+       └─ type: *
+  data IO a
+       └─ type: * → *
+
+  foreign import ccall puts :: Addr# -> IO CInt
+  └─ type: Addr# → IO CInt
+
+  main :: IO CInt
+  main = puts "hello world\n"#
+  └─ type: IO CInt
+extensions:
+- ForeignFunctionInterface
+- MagicHash
+modules:
+- |
+  module Test where
+
+  data CInt
+  data IO a
+
+  foreign import ccall puts :: Addr# -> IO CInt
+
+  main :: IO CInt
+  main = puts "hello world\n"#
+reason: infers unboxed strings as Addr# and accepts Addr# as a ccall argument
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/addr-unboxed-string-ffi.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/addr-unboxed-string-ffi.yaml
@@ -7,7 +7,7 @@ annotated:
   data IO a
        └─ type: * → *
 
-  foreign import ccall puts :: Addr# -> IO CInt
+  foreign import ccall unsafe puts :: Addr# -> IO CInt
   └─ type: Addr# → IO CInt
 
   main :: IO CInt
@@ -23,9 +23,9 @@ modules:
   data CInt
   data IO a
 
-  foreign import ccall puts :: Addr# -> IO CInt
+  foreign import ccall unsafe puts :: Addr# -> IO CInt
 
   main :: IO CInt
   main = puts "hello world\n"#
-reason: infers unboxed strings as Addr# and accepts Addr# as a ccall argument
+reason: infers unboxed strings as Addr# and accepts Addr# as an unsafe ccall argument
 status: pass

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-puts-addr.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-puts-addr.yaml
@@ -1,0 +1,32 @@
+extensions:
+  - ExtendedLiterals
+  - ForeignFunctionInterface
+  - MagicHash
+  - UnboxedTuples
+dependencies: []
+modules:
+  - |
+    module Test where
+
+    data State# s
+    data RealWorld
+    data Int32 = I32# Int32#
+    newtype CInt = CInt Int32
+    newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
+
+    foreign import ccall puts :: Addr# -> IO CInt
+
+    main :: IO CInt
+    main =
+      IO (\state ->
+        case puts "hello world\n"# of
+          IO action ->
+            case action state of
+              (# nextState, ignored #) ->
+                (# nextState, CInt (I32# 0#Int32) #))
+stdout: "hello world\n\n"
+output: |
+  I32# 0
+expression: main
+status: pass
+reason: passes an Addr# unboxed string literal directly to libc puts

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-puts-addr.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-puts-addr.yaml
@@ -14,7 +14,7 @@ modules:
     newtype CInt = CInt Int32
     newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
 
-    foreign import ccall puts :: Addr# -> IO CInt
+    foreign import ccall unsafe puts :: Addr# -> IO CInt
 
     main :: IO CInt
     main =

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-strlen-addr-latin1.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-strlen-addr-latin1.yaml
@@ -6,7 +6,7 @@ modules:
   - |
     module Test where
 
-    foreign import ccall strlen :: Addr# -> Word64#
+    foreign import ccall unsafe strlen :: Addr# -> Word64#
 output: "1"
 expression: strlen "\xFF\0bar"#
 status: pass

--- a/test/Test/Fixtures/eval/foreign-ccall-libc-strlen-addr-latin1.yaml
+++ b/test/Test/Fixtures/eval/foreign-ccall-libc-strlen-addr-latin1.yaml
@@ -1,0 +1,13 @@
+extensions:
+  - ForeignFunctionInterface
+  - MagicHash
+dependencies: []
+modules:
+  - |
+    module Test where
+
+    foreign import ccall strlen :: Addr# -> Word64#
+output: "1"
+expression: strlen "\xFF\0bar"#
+status: pass
+reason: preserves each Latin-1 code point as one byte and permits embedded NUL bytes


### PR DESCRIPTION
## Summary

- infer primitive string literals such as `"hello"#` as `Addr#`, preserving the existing `TYPE AddrRep` kind
- reject primitive string characters above `0xFF` while leaving ordinary Unicode strings unchanged
- lower accepted literals to Latin-1 byte strings, preserving embedded NUL bytes and adding one implicit trailing NUL
- carry address literals and address ABI descriptors through System FC and GRIN without boxing or Unicode re-encoding
- marshal `Addr#` arguments and results in the FC and GRIN FFI evaluators
- emit deduplicated static Latin-1 literal pools in both native backends and pass their addresses through the platform ABI
- require direct ccalls to be marked explicitly `unsafe`; omitted, `safe`, and `interruptible` safety modes remain unsupported

## Why

The parser and kind checker already knew the `Addr#` name, but `EStringHash` had no inferred type or downstream literal representation. The ccall lowering plan also only recognized `Int32` and `Word64`, so an `Addr#` parameter was rejected before desugaring.

Primitive strings represent bytes, not Unicode text. The lexer therefore enforces the Latin-1 range after escape decoding, while System FC and GRIN store the resulting bytes directly. Evaluators and native code generators consume those bytes without applying UTF-8 or locale encoding.

This PR deliberately retains the existing FFI execution restriction: only `foreign import ccall unsafe` reaches FC lowering. An omitted safety annotation is not treated as an implicit opt-in.

## User impact

Programs can pass primitive strings directly to explicitly unsafe C imports:

```haskell
foreign import ccall unsafe puts :: Addr# -> IO CInt
main = puts "hello world\n"#
```

Embedded NUL and the full Latin-1 range are supported:

```haskell
"foo\0bar"# :: Addr#
"\xFF"# :: Addr#
```

A character above `0xFF`, such as `"\x3B1"#`, is rejected.

## Progress counts

- parser lexer fixtures: +3 passing cases
- type-checker annotated fixtures: +1 passing case
- System FC unit cases: +1 passing case
- System FC golden fixtures: +2 cases, including one expected rejection
- shared FC/GRIN evaluation fixtures: +2 passing cases
- native backend unit cases: +1 AMD64 and +1 ARM64 case

README progress counts are intentionally unchanged; the cron workflow owns those updates.

## Validation

- `just fmt`
- `just check`
  - Cabal and Haskell formatting
  - HLint
  - C formatting and clang-tidy
  - full component test suite under `-Werror`
  - QuickCheck with 1,000 cases
  - FC and GRIN libc FFI evaluation
  - AMD64 and ARM64 assembly validation
