### PR TITLE
feat(c): add incremental portable C backend

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -26,6 +26,7 @@ library
     aeson >=2.0 && <2.3,
     aihc-amd64,
     aihc-arm64,
+    aihc-c,
     aihc-cpp,
     aihc-fc,
     aihc-grin,

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Compile a standalone Haskell module through System FC and GRIN to a
--- native executable for the host platform.
+-- | Compile a standalone Haskell module through System FC and GRIN to an
+-- executable through an assembly or portable C backend.
 module Aihc.Cli.Compile
   ( CompileEnvironment (..),
     CompileError (..),
@@ -23,6 +23,7 @@ where
 
 import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
+import Aihc.C qualified as C
 import Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
@@ -49,10 +50,10 @@ import Aihc.Grin qualified as Grin
 import Aihc.Native
   ( LinkLayout,
     NativeTarget (..),
+    backendCompiler,
     buildLinkLayoutFromInterfaces,
     extendLinkLayout,
     hostNativeTarget,
-    nativeTargetTriple,
     runtimeSourcePath,
   )
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
@@ -69,7 +70,7 @@ import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import System.Directory (XdgDirectory (XdgCache), createDirectory, getCurrentDirectory, getTemporaryDirectory, getXdgDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
-import System.FilePath (dropExtension, (</>))
+import System.FilePath (dropExtension, takeDirectory, (</>))
 import System.IO (hClose, openTempFile)
 import System.Process (readProcessWithExitCode)
 
@@ -78,14 +79,15 @@ data CompileError
   | CompileFrontendError ![String]
   | CompileDependencyError !String
   | CompileCpsGrinError !Grin.CpsGrinError
-  | CompileNativeError !NativeError
+  | CompileBackendError !BackendError
   | CompileTargetError !String
   | CompileClangError !ExitCode !String
   deriving (Eq, Show)
 
-data NativeError
-  = NativeArm64Error !Arm64.Arm64Error
-  | NativeAmd64Error !Amd64.Amd64Error
+data BackendError
+  = BackendArm64Error !Arm64.Arm64Error
+  | BackendAmd64Error !Amd64.Amd64Error
+  | BackendCError !C.CError
   deriving (Eq, Show)
 
 data CompileArtifacts = CompileArtifacts
@@ -123,7 +125,7 @@ runCompileWithEnvironment environment options = do
       Just explicitTarget -> pure explicitTarget
       Nothing ->
         maybe
-          (ioError (userError (renderCompileError (CompileTargetError "unsupported host; pass --target apple-arm64 or --target linux-amd64"))))
+          (ioError (userError (renderCompileError (CompileTargetError "unsupported host; pass --target portable-c or another explicit target"))))
           pure
           hostNativeTarget
   source <- TIO.readFile (compileSourceFile options)
@@ -133,11 +135,11 @@ runCompileWithEnvironment environment options = do
   writeIntermediateArtifacts output options artifacts
   if compileKeepAsm options
     then do
-      let assemblyPath = output <> ".s"
+      let assemblyPath = output <> backendSourceExtension target
       TIO.writeFile assemblyPath (compiledAssembly artifacts)
       assemble target (compileGarbageCollector options) output assemblyPath (compiledArchives artifacts)
     else withTemporaryDirectory "aihc-compile" $ \directory -> do
-      let assemblyPath = directory </> "program.s"
+      let assemblyPath = directory </> "program" <> backendSourceExtension target
       TIO.writeFile assemblyPath (compiledAssembly artifacts)
       assemble target (compileGarbageCollector options) output assemblyPath (compiledArchives artifacts)
 
@@ -301,12 +303,12 @@ compileIncrementalArtifacts target dependencies compilation = do
       layout = extendLinkLayout dependencyLayout mainGrin
       reachability = dependencyReachabilityInterface dependencies <> extractReachabilityInterface mainCore
       primitives = Set.toAscList (reachablePrimitiveNames "main" reachability)
-  either (Left . CompileNativeError) Right (validateNativePrimitiveNames target primitives)
+  either (Left . CompileBackendError) Right (validateBackendPrimitiveNames target primitives)
   assembly <-
     either
-      (Left . CompileNativeError)
+      (Left . CompileBackendError)
       Right
-      (compileNativeProgramWithDependencies target layout (dependencyInitializerSymbols dependencies) "main" mainGcGrin)
+      (compileBackendProgramWithDependencies target layout (dependencyInitializerSymbols dependencies) "main" mainGcGrin)
   pure
     CompileArtifacts
       { compiledCore = renderCore mainCore,
@@ -323,7 +325,7 @@ compileProgramArtifacts target sourceCore = do
   let grin = Grin.lowerProgram core
   cpsGrin <- either (Left . CompileCpsGrinError) Right (Grin.toCpsGrin grin)
   let gcGrin = Grin.lowerGc cpsGrin
-  assembly <- either (Left . CompileNativeError) Right (compileNativeProgram target "main" gcGrin)
+  assembly <- either (Left . CompileBackendError) Right (compileBackendProgram target "main" gcGrin)
   pure
     CompileArtifacts
       { compiledCore = renderCore core,
@@ -334,23 +336,32 @@ compileProgramArtifacts target sourceCore = do
         compiledArchives = []
       }
 
-validateNativePrimitiveNames :: NativeTarget -> [Text] -> Either NativeError ()
-validateNativePrimitiveNames target names =
+validateBackendPrimitiveNames :: NativeTarget -> [Text] -> Either BackendError ()
+validateBackendPrimitiveNames target names =
   case target of
-    AppleArm64 -> either (Left . NativeArm64Error) Right (Arm64.validatePrimitiveNames names)
-    LinuxAmd64 -> either (Left . NativeAmd64Error) Right (Amd64.validatePrimitiveNames names)
+    AppleArm64 -> either (Left . BackendArm64Error) Right (Arm64.validatePrimitiveNames names)
+    LinuxAmd64 -> either (Left . BackendAmd64Error) Right (Amd64.validatePrimitiveNames names)
+    PortableC -> validateC
+  where
+    validateC = either (Left . BackendCError) Right (C.validatePrimitiveNames names)
 
-compileNativeProgram :: NativeTarget -> Text -> Grin.GcGrinProgram -> Either NativeError Text
-compileNativeProgram target entry program =
+compileBackendProgram :: NativeTarget -> Text -> Grin.GcGrinProgram -> Either BackendError Text
+compileBackendProgram target entry program =
   case target of
-    AppleArm64 -> either (Left . NativeArm64Error) Right (Arm64.compileProgram entry program)
-    LinuxAmd64 -> either (Left . NativeAmd64Error) Right (Amd64.compileProgram entry program)
+    AppleArm64 -> either (Left . BackendArm64Error) Right (Arm64.compileProgram entry program)
+    LinuxAmd64 -> either (Left . BackendAmd64Error) Right (Amd64.compileProgram entry program)
+    PortableC -> compileC
+  where
+    compileC = either (Left . BackendCError) Right (C.compileProgram entry program)
 
-compileNativeProgramWithDependencies :: NativeTarget -> LinkLayout -> [Text] -> Text -> Grin.GcGrinProgram -> Either NativeError Text
-compileNativeProgramWithDependencies target layout initializers entry program =
+compileBackendProgramWithDependencies :: NativeTarget -> LinkLayout -> [Text] -> Text -> Grin.GcGrinProgram -> Either BackendError Text
+compileBackendProgramWithDependencies target layout initializers entry program =
   case target of
-    AppleArm64 -> either (Left . NativeArm64Error) Right (Arm64.compileProgramWithDependencies layout initializers entry program)
-    LinuxAmd64 -> either (Left . NativeAmd64Error) Right (Amd64.compileProgramWithDependencies layout initializers entry program)
+    AppleArm64 -> either (Left . BackendArm64Error) Right (Arm64.compileProgramWithDependencies layout initializers entry program)
+    LinuxAmd64 -> either (Left . BackendAmd64Error) Right (Amd64.compileProgramWithDependencies layout initializers entry program)
+    PortableC -> compileC
+  where
+    compileC = either (Left . BackendCError) Right (C.compileProgramWithDependencies layout initializers entry program)
 
 renderCore :: FcProgram -> Text
 renderCore = withFinalNewline . Fc.renderProgram
@@ -473,8 +484,8 @@ renderCompileError compileError =
     CompileFrontendError errors -> "frontend error: " <> unwords errors
     CompileDependencyError err -> "dependency error: " <> err
     CompileCpsGrinError err -> "CPS-GRIN error: " <> show err
-    CompileNativeError err -> "native code generation error: " <> show err
-    CompileTargetError err -> "native target error: " <> err
+    CompileBackendError err -> "backend code generation error: " <> show err
+    CompileTargetError err -> "target error: " <> err
     CompileClangError exitCode err -> "clang failed (" <> show exitCode <> "): " <> err
 
 defaultCompileTarget :: NativeTarget
@@ -483,18 +494,20 @@ defaultCompileTarget = fromMaybe AppleArm64 hostNativeTarget
 assemble :: NativeTarget -> GarbageCollector -> FilePath -> FilePath -> [FilePath] -> IO ()
 assemble target garbageCollector output assemblyPath archives = do
   runtime <- runtimeSourcePath
+  (compiler, targetArguments) <- backendCompiler target
   (exitCode, _stdout, stderr) <-
     readProcessWithExitCode
-      "clang"
-      ( [ "--target=" <> nativeTargetTriple target,
-          "-std=c11",
-          "-Wall",
-          "-Wextra",
-          "-Werror",
-          garbageCollectorDefine garbageCollector,
-          runtime,
-          assemblyPath
-        ]
+      compiler
+      ( targetArguments
+          <> [ "-std=c11",
+               "-Wall",
+               "-Wextra",
+               "-Werror",
+               "-I" <> takeDirectory runtime,
+               garbageCollectorDefine garbageCollector,
+               runtime,
+               assemblyPath
+             ]
           <> archives
           <> ["-o", output]
       )
@@ -502,6 +515,10 @@ assemble target garbageCollector output assemblyPath archives = do
   case exitCode of
     ExitSuccess -> pure ()
     ExitFailure _ -> ioError (userError (renderCompileError (CompileClangError exitCode stderr)))
+
+backendSourceExtension :: NativeTarget -> String
+backendSourceExtension PortableC = ".c"
+backendSourceExtension _ = ".s"
 
 garbageCollectorDefine :: GarbageCollector -> String
 garbageCollectorDefine garbageCollector =

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -3,7 +3,7 @@
 
 -- | Core-library discovery and content-addressed compilation for @aihc compile@.
 -- Each closure cache contains the frontend interfaces and one Core, GRIN, and
--- native object artifact per strongly connected module component.
+-- backend object artifact per strongly connected module component.
 module Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
@@ -14,15 +14,18 @@ where
 
 import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
+import Aihc.C qualified as C
 import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface)
 import Aihc.Grin qualified as Grin
 import Aihc.Native
   ( LinkInterface,
     LinkLayout,
     NativeTarget (..),
+    backendCompiler,
     buildLinkLayoutFromInterfaces,
     extractLinkInterface,
     nativeTargetTriple,
+    runtimeSourcePath,
   )
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax
@@ -173,10 +176,10 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 13
+cacheSchemaVersion = 15
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
-buildDependencies target environment usesImplicitPrelude buildNative mainModule = do
+buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do
   let importedRoots = map importDeclModule (moduleImports mainModule)
       defaultRoots = if usesImplicitPrelude then ["GHC.Prim", "Prelude"] else []
       initialRoots = sort (Set.toList (Set.fromList (defaultRoots <> importedRoots)))
@@ -199,7 +202,7 @@ buildDependencies target environment usesImplicitPrelude buildNative mainModule 
               cached <- readCache cachePath
               case cached of
                 Just artifact
-                  | buildNative -> finishArtifact target cacheDirectory closureHash artifact
+                  | buildBackend -> finishArtifact target cacheDirectory closureHash artifact
                   | otherwise -> pure (Right artifact)
                 Nothing ->
                   case compileLoadedModules loaded of
@@ -207,16 +210,16 @@ buildDependencies target environment usesImplicitPrelude buildNative mainModule 
                     Right artifact -> do
                       createDirectoryIfMissing True cacheDirectory
                       writeCache cacheDirectory cachePath artifact
-                      if buildNative
+                      if buildBackend
                         then finishArtifact target cacheDirectory closureHash artifact
                         else pure (Right artifact)
 
 finishArtifact :: NativeTarget -> FilePath -> FilePath -> DependencyArtifact -> IO (Either String DependencyArtifact)
 finishArtifact target cacheDirectory closureHash artifact = do
-  native <- buildNativeArtifacts target (cacheDirectory </> closureHash) (dependencyUnits artifact)
+  backendArtifacts <- buildBackendArtifacts target (cacheDirectory </> closureHash) (dependencyUnits artifact)
   pure $
     (\(initializers, archives) -> artifact {dependencyInitializerSymbols = initializers, dependencyArchivePaths = archives})
-      <$> native
+      <$> backendArtifacts
 
 emptyDependencyArtifact :: DependencyArtifact
 emptyDependencyArtifact =
@@ -426,49 +429,49 @@ loadedModuleSccs = map flatten . stronglyConnComp . map graphNode
 loadedModuleName :: LoadedModule -> Text
 loadedModuleName = fromMaybe "Main" . moduleName . loadedModule
 
-buildNativeArtifacts :: NativeTarget -> FilePath -> [DependencyUnit] -> IO (Either String ([Text], [FilePath]))
-buildNativeArtifacts target artifactRoot units = do
+buildBackendArtifacts :: NativeTarget -> FilePath -> [DependencyUnit] -> IO (Either String ([Text], [FilePath]))
+buildBackendArtifacts target artifactRoot units = do
   let layout = buildLinkLayoutFromInterfaces (map dependencyUnitLinkInterface units)
       objectRoot = artifactRoot </> "objects"
       archiveRoot = artifactRoot </> "archives"
-      nativeUnits = map (nativeUnit objectRoot) units
-  objectResults <- mapM (buildObject target layout) nativeUnits
+      backendUnits = map (backendUnit objectRoot) units
+  objectResults <- mapM (buildObject target layout) backendUnits
   case sequence objectResults of
     Left err -> pure (Left err)
     Right _ -> do
       createDirectoryIfMissing True archiveRoot
       let archiveMembers =
             foldl'
-              (\archives unit -> Map.insertWith (flip (<>)) (nativeUnitLibrary unit) [nativeObjectPath unit] archives)
+              (\archives unit -> Map.insertWith (flip (<>)) (backendUnitLibrary unit) [backendObjectPath unit] archives)
               Map.empty
-              nativeUnits
+              backendUnits
       archives <- mapM (buildArchive archiveRoot) (Map.toAscList archiveMembers)
       pure $ do
         archivePaths <- sequence archives
-        Right (map nativeInitializerSymbol nativeUnits, archivePaths)
+        Right (map backendInitializerSymbol backendUnits, archivePaths)
 
-data NativeUnit = NativeUnit
-  { nativeDependencyUnit :: !DependencyUnit,
-    nativeProgram :: !Grin.GcGrinProgram,
-    nativeInitializerSymbol :: !Text,
-    nativeObjectPath :: !FilePath
+data BackendUnit = BackendUnit
+  { backendDependencyUnit :: !DependencyUnit,
+    backendProgram :: !Grin.GcGrinProgram,
+    backendInitializerSymbol :: !Text,
+    backendObjectPath :: !FilePath
   }
 
-nativeUnit :: FilePath -> DependencyUnit -> NativeUnit
-nativeUnit objectRoot unit =
-  NativeUnit
-    { nativeDependencyUnit = unit,
-      nativeProgram = Grin.lowerGc (dependencyUnitCpsGrin unit),
-      nativeInitializerSymbol = initializer,
-      nativeObjectPath = objectRoot </> T.unpack library </> T.unpack unitName <> ".o"
+backendUnit :: FilePath -> DependencyUnit -> BackendUnit
+backendUnit objectRoot unit =
+  BackendUnit
+    { backendDependencyUnit = unit,
+      backendProgram = Grin.lowerGc (dependencyUnitCpsGrin unit),
+      backendInitializerSymbol = initializer,
+      backendObjectPath = objectRoot </> T.unpack library </> T.unpack unitName <> ".o"
     }
   where
     library = dependencyUnitPrimaryLibrary unit
     unitName = T.intercalate "+" (dependencyUnitModules unit)
     initializer = "_aihc_init_" <> symbolHex (library <> "\0" <> T.intercalate "\0" (dependencyUnitModules unit))
 
-nativeUnitLibrary :: NativeUnit -> Text
-nativeUnitLibrary = dependencyUnitPrimaryLibrary . nativeDependencyUnit
+backendUnitLibrary :: BackendUnit -> Text
+backendUnitLibrary = dependencyUnitPrimaryLibrary . backendDependencyUnit
 
 dependencyUnitPrimaryLibrary :: DependencyUnit -> Text
 dependencyUnitPrimaryLibrary unit = fromMaybe "dependencies" (listToMaybe (dependencyUnitLibraries unit))
@@ -478,32 +481,66 @@ symbolHex = T.concat . map renderByte . BS.unpack . Text.encodeUtf8
   where
     renderByte byte = T.pack (padLeft 2 '0' (showHex byte ""))
 
-buildObject :: NativeTarget -> LinkLayout -> NativeUnit -> IO (Either String ())
+buildObject :: NativeTarget -> LinkLayout -> BackendUnit -> IO (Either String ())
 buildObject target layout unit = do
-  let destination = nativeObjectPath unit
+  let destination = backendObjectPath unit
       directory = takeDirectory destination
   exists <- doesFileExist destination
   if exists
     then pure (Right ())
     else do
-      case compileNativeModule target layout (nativeInitializerSymbol unit) (nativeProgram unit) of
-        Left err -> pure (Left ("native dependency code generation failed for " <> dependencyUnitLabel (nativeDependencyUnit unit) <> ": " <> err))
-        Right assembly -> do
+      case compileBackendModule target layout (backendInitializerSymbol unit) (backendProgram unit) of
+        Left err -> pure (Left ("backend dependency code generation failed for " <> dependencyUnitLabel (backendDependencyUnit unit) <> ": " <> err))
+        Right backendSource -> do
           createDirectoryIfMissing True directory
           withTemporaryDirectory directory "module-build" $ \temporary -> do
-            let assemblyPath = temporary </> "module.s"
+            let sourcePath = temporary </> "module" <> backendSourceExtension target
                 objectPath = temporary </> "module.o"
-            TIO.writeFile assemblyPath assembly
-            (exitCode, _stdout, stderr) <- readProcessWithExitCode "clang" ["--target=" <> nativeTargetTriple target, "-c", assemblyPath, "-o", objectPath] ""
+            TIO.writeFile sourcePath backendSource
+            (compiler, arguments) <- objectCompiler target sourcePath objectPath
+            (exitCode, _stdout, stderr) <- readProcessWithExitCode compiler arguments ""
             case exitCode of
               ExitSuccess -> renameFile objectPath destination >> pure (Right ())
-              ExitFailure _ -> pure (Left ("failed to assemble dependency unit " <> dependencyUnitLabel (nativeDependencyUnit unit) <> ": " <> stderr))
+              ExitFailure _ -> pure (Left ("failed to compile dependency unit " <> dependencyUnitLabel (backendDependencyUnit unit) <> ": " <> stderr))
 
-compileNativeModule :: NativeTarget -> LinkLayout -> Text -> Grin.GcGrinProgram -> Either String Text
-compileNativeModule target layout initializer program =
+compileBackendModule :: NativeTarget -> LinkLayout -> Text -> Grin.GcGrinProgram -> Either String Text
+compileBackendModule target layout initializer program =
   case target of
     AppleArm64 -> either (Left . show) Right (Arm64.compileModule layout initializer program)
     LinuxAmd64 -> either (Left . show) Right (Amd64.compileModule layout initializer program)
+    PortableC -> compileC
+  where
+    compileC = either (Left . show) Right (C.compileModule layout initializer program)
+
+backendSourceExtension :: NativeTarget -> String
+backendSourceExtension PortableC = ".c"
+backendSourceExtension _ = ".s"
+
+objectCompiler :: NativeTarget -> FilePath -> FilePath -> IO (FilePath, [String])
+objectCompiler target sourcePath objectPath = do
+  (compiler, targetArguments) <- backendCompiler target
+  case target of
+    PortableC -> cCompiler compiler targetArguments
+    AppleArm64 -> pure (compiler, nativeArguments targetArguments)
+    LinuxAmd64 -> pure (compiler, nativeArguments targetArguments)
+  where
+    nativeArguments targetArguments = targetArguments <> ["-c", sourcePath, "-o", objectPath]
+    cCompiler compiler targetArguments = do
+      runtime <- runtimeSourcePath
+      pure
+        ( compiler,
+          targetArguments
+            <> [ "-std=c11",
+                 "-Wall",
+                 "-Wextra",
+                 "-Werror",
+                 "-I" <> takeDirectory runtime,
+                 "-c",
+                 sourcePath,
+                 "-o",
+                 objectPath
+               ]
+        )
 
 dependencyUnitLabel :: DependencyUnit -> String
 dependencyUnitLabel = T.unpack . T.intercalate "," . dependencyUnitModules

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -85,7 +85,7 @@ commandParser =
         "compile"
         ( OA.info
             (CmdCompile <$> compileOptionsParser OA.<**> OA.helper)
-            (OA.progDesc "Compile a Haskell source file to a native executable")
+            (OA.progDesc "Compile a Haskell source file to an executable")
         )
         <> OA.command
           "install"
@@ -126,7 +126,7 @@ compileOptionsParser =
       )
     <*> OA.switch
       ( OA.long "keep-asm"
-          <> OA.help "Keep the generated assembly as OUTPUT.s"
+          <> OA.help "Keep generated backend source as OUTPUT.s (assembly) or OUTPUT.c (portable C)"
       )
     <*> OA.switch
       ( OA.long "whole-program"
@@ -137,7 +137,7 @@ compileOptionsParser =
           (OA.eitherReader parseNativeTarget)
           ( OA.long "target"
               <> OA.metavar "TARGET"
-              <> OA.help "Native target: apple-arm64 or linux-amd64 (default: host)"
+              <> OA.help "Target: apple-arm64, linux-amd64, or portable-c (default: host)"
           )
       )
     <*> OA.option

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -109,6 +109,11 @@ main =
               "command"
               (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just LinuxAmd64) GcCalloc)))
               (parseCommandPure ["compile", "Main.hs", "--target", "linux-amd64"]),
+          testCase "parses the portable C target" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just PortableC) GcCalloc)))
+              (parseCommandPure ["compile", "Main.hs", "--target", "portable-c"]),
           testCase "selects the semispace collector" $
             assertEqual
               "command"
@@ -157,7 +162,7 @@ main =
               source <- TIO.readFile sourcePath
               let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
                   environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-              forM_ [AppleArm64, LinuxAmd64] $ \target -> do
+              forM_ [AppleArm64, LinuxAmd64, PortableC] $ \target -> do
                 result <- compileSourceToAssemblyWithDependenciesFor target environment sourcePath source
                 case result of
                   Left err -> assertFailure ("expected " <> show target <> " compile success, got: " <> show err)
@@ -166,6 +171,8 @@ main =
                     assertBool "dependency initializer call" (targetInitializerCall target `T.isInfixOf` assembly)
                     assertBool "Haskell tail transfer" (targetTailTransfer target `T.isInfixOf` assembly),
           testCase "assembles an executable and honors keep-output flags" test_compileExecutable,
+          testCase "assembles an incremental portable C executable" test_compilePortableCExecutable,
+          testCase "lowers every example to portable C" test_compilePortableCExamples,
           testCase "compiles and runs the aihc-base green threads example" test_compileGreenThreadsExample,
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
           testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
@@ -934,6 +941,47 @@ test_compileGreenThreadsExample =
           "Hello world main green thread\nStill in main\nHello from forked thread\nBack in main\n"
           output
 
+test_compilePortableCExecutable :: Assertion
+test_compilePortableCExecutable =
+  withTempDir "aihc-compile-portable-c" $ \root -> do
+    sourcePath <- helloWorldExamplePath
+    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
+        output = root </> "hello-portable-c"
+        cacheRoot = root </> "cache"
+        environment = CompileEnvironment (repositoryRoot </> "core-libs") cacheRoot
+        options = CompileOptions sourcePath (Just output) False False True False (Just PortableC) GcCalloc
+    withCurrentDirectory repositoryRoot $ do
+      runCompileWithEnvironment environment options
+      assertFileExists output
+      assertFileExists (output <> ".c")
+      generatedC <- TIO.readFile (output <> ".c")
+      assertBool "portable C main" ("int main(void)" `T.isInfixOf` generatedC)
+      assertBool "dependency initializer call" ("_aihc_init_" `T.isInfixOf` generatedC)
+      assertNativeOutput "Hello, world!\n" output
+      objectFiles <- compileCacheArtifacts ".o" cacheRoot
+      archiveFiles <- compileCacheArtifacts ".a" cacheRoot
+      assertBool "cached C dependency objects" (not (null objectFiles))
+      assertBool "cached C dependency archives" (not (null archiveFiles))
+      let oldTimestamp = UTCTime (fromGregorian 2000 1 1) 0
+      mapM_ (`setModificationTime` oldTimestamp) (objectFiles <> archiveFiles)
+      runCompileWithEnvironment environment options
+      mapM_ (getModificationTime >=> assertEqual "cache hit preserves C artifact" oldTimestamp) (objectFiles <> archiveFiles)
+
+test_compilePortableCExamples :: Assertion
+test_compilePortableCExamples =
+  withTempDir "aihc-compile-portable-c-examples" $ \root -> do
+    sourcePaths <- sequence [helloWorldExamplePath, greenThreadsExamplePath, unboxedTailRecursionExamplePath]
+    forM_ sourcePaths $ \sourcePath -> do
+      source <- TIO.readFile sourcePath
+      let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
+          environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
+      result <- compileSourceToAssemblyWithDependenciesFor PortableC environment sourcePath source
+      case result of
+        Left err -> assertFailure ("expected portable C compile success for " <> sourcePath <> ", got: " <> show err)
+        Right generatedC -> do
+          assertBool "includes the portable runtime" ("#include \"aihc_runtime.h\"" `T.isInfixOf` generatedC)
+          assertBool "uses trampoline dispatch" ("while (aihc_next_entry != NULL)" `T.isInfixOf` generatedC)
+
 isNativeCodegenHost :: String -> String -> Bool
 isNativeCodegenHost hostArch hostOs =
   (hostArch == "aarch64" && hostOs == "darwin")
@@ -1094,14 +1142,17 @@ nativeMainDirective
 targetMainDirective :: NativeTarget -> T.Text
 targetMainDirective AppleArm64 = ".globl _main"
 targetMainDirective LinuxAmd64 = ".globl main"
+targetMainDirective PortableC = "int main(void)"
 
 targetInitializerCall :: NativeTarget -> T.Text
 targetInitializerCall AppleArm64 = "bl _aihc_init_"
 targetInitializerCall LinuxAmd64 = "call _aihc_init_"
+targetInitializerCall PortableC = "_aihc_init_"
 
 targetTailTransfer :: NativeTarget -> T.Text
 targetTailTransfer AppleArm64 = "br x0"
 targetTailTransfer LinuxAmd64 = "jmp rax"
+targetTailTransfer PortableC = "aihc_next_entry"
 
 expectCompileArtifact :: Either CompileError T.Text -> IO T.Text
 expectCompileArtifact result =
@@ -1174,6 +1225,9 @@ helloWorldExamplePath = examplePath ("hello-world" </> "Main.hs")
 
 greenThreadsExamplePath :: IO FilePath
 greenThreadsExamplePath = examplePath ("green-threads" </> "Main.hs")
+
+unboxedTailRecursionExamplePath :: IO FilePath
+unboxedTailRecursionExamplePath = examplePath ("unboxed-tail-recursion" </> "Main.hs")
 
 examplePath :: FilePath -> IO FilePath
 examplePath example = getCurrentDirectory >>= findFrom

--- a/cabal.project
+++ b/cabal.project
@@ -12,6 +12,7 @@ packages:
   components/aihc-native
   components/aihc-amd64
   components/aihc-arm64
+  components/aihc-c
   bin/aihc-fmt
   tooling/aihc-hackage
   tooling/aihc-testing

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -1072,6 +1072,7 @@ renderRuntimeInfos infos =
         <> [ ".p2align 3",
              runtimeInfoLabel info <> ":",
              identityLine (runtimeInfoIdentity info),
+             entryLine (runtimeInfoIdentity info),
              "  .quad " <> tshow (length fields),
              "  .quad " <> tshow (runtimeInfoRemainingArity info),
              "  .quad " <> if null fields then "0" else bitmapLabel,
@@ -1090,6 +1091,10 @@ renderRuntimeInfos infos =
     identityLine nodeInfo =
       case nodeInfo of
         InfoImmediate integer -> "  .quad " <> tshow integer
+        InfoAddress label -> "  .quad " <> label
+    entryLine nodeInfo =
+      case nodeInfo of
+        InfoImmediate {} -> "  .quad 0"
         InfoAddress label -> "  .quad " <> label
 
 runtimeTagNode, runtimeTagClosure, runtimeTagThunk, runtimeTagPartialConstructor :: Int

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -251,7 +251,7 @@ tests =
               "generated code does not reload a scheduled entry"
               (not ("mov r11, QWORD PTR [r15]\n  jmp r11" `T.isInfixOf` assembly))
         runtime <- readFile =<< runtimeSourcePath
-        assertBool "apply returns its selected entry" ("void *aihc_apply_cps" `isInfixOf` runtime)
+        assertBool "apply returns its selected entry" ("AihcEntry aihc_apply_cps" `isInfixOf` runtime)
         forM_ ["void *next;", "machine->next", "machine->locals", "aihc_schedule"] $ \forbidden ->
           assertBool ("runtime still contains " <> forbidden) (not (forbidden `isInfixOf` runtime)),
       testCase "runtime has no built-in continuation stack" $ do

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -738,6 +738,17 @@ compileDirectBinding env vars expression =
       storeSingleResult vars pointerLines
     GrinUpdate pointer value -> compileUpdateBinding False "_aihc_update" pointer value
     GrinUpdateBlackhole pointer value -> compileUpdateBinding True "_aihc_update_blackhole" pointer value
+    GrinPrimitiveCall IntRep "+#" [left, right] -> do
+      leftSlot <- freshSlot
+      leftLines <- liftEither (materializeValue env left)
+      rightLines <- liftEither (materializeValue env right)
+      storeSingleResult
+        vars
+        ( leftLines
+            <> [storeAt "x0" "x19" leftSlot]
+            <> rightLines
+            <> [loadAt "x1" "x19" leftSlot, "  add x0, x1, x0"]
+        )
     GrinPrimitiveCall runtimeRep name arguments
       | name == "realWorld#",
         null arguments,
@@ -1054,6 +1065,7 @@ renderRuntimeInfos infos =
         <> [ ".p2align 3",
              runtimeInfoLabel info <> ":",
              identityLine (runtimeInfoIdentity info),
+             entryLine (runtimeInfoIdentity info),
              "  .quad " <> tshow (length fields),
              "  .quad " <> tshow (runtimeInfoRemainingArity info),
              "  .quad " <> if null fields then "0" else bitmapLabel,
@@ -1072,6 +1084,10 @@ renderRuntimeInfos infos =
     identityLine nodeInfo =
       case nodeInfo of
         InfoImmediate integer -> "  .quad " <> tshow integer
+        InfoAddress label -> "  .quad " <> label
+    entryLine nodeInfo =
+      case nodeInfo of
+        InfoImmediate {} -> "  .quad 0"
         InfoAddress label -> "  .quad " <> label
 
 runtimeTagNode, runtimeTagClosure, runtimeTagThunk, runtimeTagPartialConstructor :: Int
@@ -1202,7 +1218,7 @@ runtimeInfoKeyNext key =
 
 validatePrimitiveName :: Bool -> Text -> Either Arm64Error ()
 validatePrimitiveName allowUnsupported name
-  | name `elem` ["fork#", "realWorld#", "yield#"] = Right ()
+  | name `elem` ["+#", "fork#", "realWorld#", "yield#"] = Right ()
   | allowUnsupported = Right ()
   | otherwise = Left (Arm64UnsupportedPrimitive name)
 

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -79,7 +79,7 @@ tests =
           (Left (Arm64UnsupportedRuntimeRep runtimeRep))
           (compileProgram "missing" (expectGcGrin program)),
       testCase "keeps unsupported dormant primitives out of linked programs" $ do
-        let primitive = GrinVar "+#" 1 (BoxedRep Lifted)
+        let primitive = GrinVar "unsupported#" 1 (BoxedRep Lifted)
             program =
               GrinProgram
                 { grinConstructors = [],
@@ -91,10 +91,54 @@ tests =
                   grinCafs = [],
                   grinFunctions = []
                 }
-        assertEqual "linked primitive validation" (Left (Arm64UnsupportedPrimitive "+#")) (validateProgramPrimitives program)
+        assertEqual "linked primitive validation" (Left (Arm64UnsupportedPrimitive "unsupported#")) (validateProgramPrimitives program)
         case compileModule (buildLinkLayout [program]) "_aihc_init_test" (expectGcGrin program) of
           Left err -> assertFailure ("relocatable module rejected a dormant primitive: " <> show err)
           Right assembly -> assertBool "module initializer" (".globl _aihc_init_test" `T.isInfixOf` assembly),
+      testCase "adds Int# values with wrapping machine arithmetic" $ do
+        let entryName = FunctionName "int_add"
+            result = GrinVar "result" 2 IntRep
+            program =
+              GrinProgram
+                { grinConstructors = [],
+                  grinPrimitives = [(GrinVar "+#" 1 IntRep, 2)],
+                  grinForeignCalls = [],
+                  grinExternalGlobals = [],
+                  grinExternalFunctions = [],
+                  grinWhnfGlobals = [],
+                  grinCafs = [],
+                  grinFunctions =
+                    [ GrinFunction
+                        { grinFunctionName = entryName,
+                          grinFunctionLinkName = Nothing,
+                          grinFunctionParameters = [],
+                          grinFunctionResultRep = IntRep,
+                          grinFunctionBody =
+                            GrinBind
+                              [result]
+                              ( GrinPrimitiveCall
+                                  IntRep
+                                  "+#"
+                                  [ GrinLitValue (GrinLitInt IntRep 9223372036854775807),
+                                    GrinLitValue (GrinLitInt IntRep 1)
+                                  ]
+                              )
+                              (GrinConstant [GrinVarValue result])
+                        }
+                    ]
+                }
+        assertEqual "direct GRIN lint" [] (lintProgram program)
+        assertEqual "linked primitive validation" (Right ()) (validateProgramPrimitives program)
+        let gc = expectGcGrin program
+        assertEqual "GC-GRIN lint" [] (lintProgram (gcGrinProgram gc))
+        observed <-
+          case compileObservedFunction entryName gc of
+            Left err -> assertFailure ("native Int# addition compilation failed: " <> show err)
+            Right value -> pure value
+        assertBool "emits a wrapping 64-bit add" ("  add x0, x1, x0" `T.isInfixOf` observedAssembly observed)
+        when (arch == "aarch64" && os == "darwin") $ do
+          native <- runObservedProgram observed
+          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\n") native,
       testCase "canonicalizes narrow signed literals in machine-word slots" $ do
         let functionName = FunctionName "narrow_code"
             program =
@@ -243,7 +287,7 @@ tests =
               "generated code does not reload a scheduled entry"
               (not ("ldr x9, [x22, #0]\n  br x9" `T.isInfixOf` assembly))
         runtime <- readFile =<< runtimeSourcePath
-        assertBool "apply returns its selected entry" ("void *aihc_apply_cps" `isInfixOf` runtime)
+        assertBool "apply returns its selected entry" ("AihcEntry aihc_apply_cps" `isInfixOf` runtime)
         forM_ ["void *next;", "machine->next", "machine->locals", "aihc_schedule"] $ \forbidden ->
           assertBool ("runtime still contains " <> forbidden) (not (forbidden `isInfixOf` runtime)),
       testCase "runtime has no built-in continuation stack" $ do
@@ -288,24 +332,29 @@ tests =
               source =
                 unlines
                   [ "#include \"aihc_runtime.h\"",
-                    "_Static_assert(sizeof(AihcValue) == sizeof(uintptr_t), \"one-word object header\");",
+                    "_Static_assert(sizeof(AihcValue) == sizeof(AihcSlot), \"one-word object header\");",
+                    "static void entry_8(void) {}",
+                    "static void entry_9(void) {}",
+                    "static void entry_10(void) {}",
+                    "static void entry_11(void) {}",
+                    "static void entry_12(void) {}",
                     "static const uint8_t pointer_field[] = {1};",
                     "static const uint8_t pointer_then_scalar[] = {1, 0};",
-                    "static const AihcInfo leaf_info = {1, 0, 0, 0, 0};",
-                    "static const AihcInfo box_info = {2, 1, 0, pointer_field, 0};",
-                    "static const AihcInfo partial_final_info = {3, 2, 0, pointer_then_scalar, 0};",
-                    "static const AihcInfo partial_one_info = {3, 1, 1, pointer_then_scalar, &partial_final_info};",
-                    "static const AihcInfo partial_info = {3, 0, 2, 0, &partial_one_info};",
-                    "static const AihcInfo continuation_final_info = {8, 1, 0, pointer_field, 0};",
-                    "static const AihcInfo continuation_info = {8, 0, 1, 0, &continuation_final_info};",
-                    "static const AihcInfo action_final_info = {9, 0, 0, 0, 0};",
-                    "static const AihcInfo action_info = {9, 0, 1, 0, &action_final_info};",
-                    "static const AihcInfo thread_done_final_info = {10, 1, 0, pointer_field, 0};",
-                    "static const AihcInfo thread_done_info = {10, 0, 1, 0, &thread_done_final_info};",
-                    "static const AihcInfo parent_final_info = {11, 1, 0, pointer_field, 0};",
-                    "static const AihcInfo parent_info = {11, 0, 1, 0, &parent_final_info};",
-                    "static const AihcInfo yield_final_info = {12, 0, 0, 0, 0};",
-                    "static const AihcInfo yield_info = {12, 0, 1, 0, &yield_final_info};",
+                    "static const AihcInfo leaf_info = {1, 0, 0, 0, 0, 0};",
+                    "static const AihcInfo box_info = {2, 0, 1, 0, pointer_field, 0};",
+                    "static const AihcInfo partial_final_info = {3, 0, 2, 0, pointer_then_scalar, 0};",
+                    "static const AihcInfo partial_one_info = {3, 0, 1, 1, pointer_then_scalar, &partial_final_info};",
+                    "static const AihcInfo partial_info = {3, 0, 0, 2, 0, &partial_one_info};",
+                    "static const AihcInfo continuation_final_info = {8, entry_8, 1, 0, pointer_field, 0};",
+                    "static const AihcInfo continuation_info = {8, entry_8, 0, 1, 0, &continuation_final_info};",
+                    "static const AihcInfo action_final_info = {9, entry_9, 0, 0, 0, 0};",
+                    "static const AihcInfo action_info = {9, entry_9, 0, 1, 0, &action_final_info};",
+                    "static const AihcInfo thread_done_final_info = {10, entry_10, 1, 0, pointer_field, 0};",
+                    "static const AihcInfo thread_done_info = {10, entry_10, 0, 1, 0, &thread_done_final_info};",
+                    "static const AihcInfo parent_final_info = {11, entry_11, 1, 0, pointer_field, 0};",
+                    "static const AihcInfo parent_info = {11, entry_11, 0, 1, 0, &parent_final_info};",
+                    "static const AihcInfo yield_final_info = {12, entry_12, 0, 0, 0, 0};",
+                    "static const AihcInfo yield_info = {12, entry_12, 0, 1, 0, &yield_final_info};",
                     "static int test_apply_roots(void) {",
                     "  AihcMachine *machine = aihc_machine_new(0);",
                     "  AihcValue *leaf = aihc_make_node(machine, AIHC_TAG_NODE, &leaf_info);",
@@ -316,7 +365,7 @@ tests =
                     "  (void)aihc_make_node(machine, AIHC_TAG_NODE, &leaf_info);",
                     "  (void)aihc_make_node(machine, AIHC_TAG_NODE, &leaf_info);",
                     "  AihcSlot argument = (AihcSlot)leaf;",
-                    "  if (aihc_apply_cps(machine, partial, 1, &argument, continuation) != (void *)8) return 0;",
+                    "  if (aihc_apply_cps(machine, partial, 1, &argument, continuation) != entry_8) return 0;",
                     "  AihcValue *result = (AihcValue *)machine->args[0];",
                     "  return aihc_value_tag(result) == AIHC_TAG_PARTIAL_CONSTRUCTOR &&",
                     "         aihc_value_arity(result) == 1 && aihc_value_count(result) == 1 &&",
@@ -331,12 +380,12 @@ tests =
                     "  AihcValue *yield = aihc_make_node(machine, AIHC_TAG_CLOSURE, &yield_info);",
                     "  aihc_set_thread_done_continuation(machine, thread_done);",
                     "  machine->globals[0] = (AihcSlot)yield;",
-                    "  if (aihc_fork_cps(machine, action, parent) != (void *)11) return 0;",
+                    "  if (aihc_fork_cps(machine, action, parent) != entry_11) return 0;",
                     "  for (int index = 0; index < 5; ++index) {",
                     "    (void)aihc_make_node(machine, AIHC_TAG_NODE, &leaf_info);",
                     "  }",
                     "  yield = (AihcValue *)machine->globals[0];",
-                    "  if (aihc_yield_cps(machine, yield) != (void *)9) return 0;",
+                    "  if (aihc_yield_cps(machine, yield) != entry_9) return 0;",
                     "  thread_done = machine->thread_done_continuation;",
                     "  return machine->args[0] == (AihcSlot)thread_done &&",
                     "         aihc_value_info(thread_done) == 10;",

--- a/components/aihc-c/LICENSE
+++ b/components/aihc-c/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/components/aihc-c/aihc-c.cabal
+++ b/components/aihc-c/aihc-c.cabal
@@ -1,5 +1,5 @@
 cabal-version: 3.8
-name: aihc-native
+name: aihc-c
 version: 0.1.0.0
 build-type: Simple
 license: Unlicense
@@ -7,44 +7,51 @@ license-file: LICENSE
 author: David Himmelstrup
 maintainer: lemmih@gmail.com
 category: Development
-synopsis: Shared backend compilation support for AIHC
-data-files:
-  runtime/aihc_runtime.c
-  runtime/aihc_runtime.h
-  runtime/aihc_snapshot.c
+synopsis: Portable C backend for AIHC GRIN
 
 library
   exposed-modules:
-    Aihc.Native
-    Aihc.Native.Lir
-    Aihc.Native.RegisterAllocate
+    Aihc.C
+    Aihc.C.Codegen
 
-  other-modules: Paths_aihc_native
-  autogen-modules: Paths_aihc_native
   hs-source-dirs: src
   build-depends:
     aihc-grin,
+    aihc-native,
     aihc-tc,
     base >=4.16 && <5,
     bytestring,
     containers,
     text,
+    transformers,
 
   ghc-options: -Wall
   default-language: GHC2021
 
 test-suite spec
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
+  hs-source-dirs:
+    test
+    ../../test/support
+
   main-is: Spec.hs
-  other-modules: Test.Native.RegisterAllocate
+  other-modules:
+    Aihc.Testing.SchedulerProgram
+    Test.C.Suite
+
   build-depends:
+    aihc-c,
+    aihc-grin,
     aihc-native,
+    aihc-tc,
     base >=4.16 && <5,
-    containers,
+    directory,
+    filepath,
+    process,
     tasty,
     tasty-hunit,
     tasty-quickcheck,
+    text,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/components/aihc-c/src/Aihc/C.hs
+++ b/components/aihc-c/src/Aihc/C.hs
@@ -1,0 +1,12 @@
+-- | Portable C11 code generation with explicit trampoline control flow.
+module Aihc.C
+  ( CError (..),
+    compileModule,
+    compileProgram,
+    compileProgramWithDependencies,
+    validatePrimitiveNames,
+    validateProgramPrimitives,
+  )
+where
+
+import Aihc.C.Codegen

--- a/components/aihc-c/src/Aihc/C/Codegen.hs
+++ b/components/aihc-c/src/Aihc/C/Codegen.hs
@@ -1,0 +1,921 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Lower runtime-explicit GRIN to portable C11.
+-- Generated entries form a trampoline: every entry stores its successor in
+-- @aihc_next_entry@ and returns, avoiding dependence on C tail-call support.
+module Aihc.C.Codegen
+  ( CError (..),
+    compileModule,
+    compileProgram,
+    compileProgramWithDependencies,
+    validatePrimitiveNames,
+    validateProgramPrimitives,
+  )
+where
+
+import Aihc.Grin.Gc (GcGrinProgram, gcGrinProgram, gcUpdateFunction)
+import Aihc.Grin.Syntax
+import Aihc.Native (LinkLayout (..), buildAddrLiteralPool, buildLinkLayout)
+import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
+import Control.Monad (forM, replicateM)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict (StateT, execStateT, get, modify')
+import Data.ByteString qualified as BS
+import Data.Char (ord)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Numeric (showHex)
+
+data CError
+  = CMissingEntry !Text
+  | CMissingGlobal !Text
+  | CMissingFunction !FunctionName
+  | CMissingConstructor !Text
+  | CUnsupportedPrimitive !Text
+  | CUnsupportedExpression !Text
+  | CUnsupportedValue !Text
+  | CUnsupportedRuntimeRep !RuntimeRep
+  deriving (Eq, Show)
+
+data CompileEnv = CompileEnv
+  { compileConstructorIds :: !(Map Text Int),
+    compileConstructorArities :: !(Map Text Int),
+    compileGlobalSlots :: !(Map Text Int),
+    compileFunctionLabels :: !(Map FunctionName Text),
+    compileAddrLiteralLabels :: !(Map BS.ByteString Text),
+    compileNodeInfoLabels :: !(Map RuntimeInfoKey Text),
+    compileRuntimeInfos :: ![RuntimeInfo],
+    compileAllowUnsupportedPrimitives :: !Bool
+  }
+
+data CompilationUnit
+  = ExecutableUnit
+  | LibraryUnit
+
+data RuntimeInfo = RuntimeInfo
+  { runtimeInfoLabel :: !Text,
+    runtimeInfoIdentity :: !(Maybe Int),
+    runtimeInfoEntry :: !(Maybe Text),
+    runtimeInfoFields :: ![RuntimeRep],
+    runtimeInfoRemainingArity :: !Int,
+    runtimeInfoNext :: !(Maybe Text)
+  }
+
+data RuntimeInfoKey
+  = ConstructorRuntimeInfo !Text !Int
+  | ClosureRuntimeInfo !FunctionName ![RuntimeRep] ![[RuntimeRep]]
+  | ThunkRuntimeInfo !FunctionName ![RuntimeRep]
+  deriving (Eq, Ord, Show)
+
+data FunctionState = FunctionState
+  { functionNextLabel :: !Int,
+    functionNextSlot :: !Int,
+    functionBlocksRev :: ![(Text, [Text])]
+  }
+
+type FunctionM = StateT FunctionState (Either CError)
+
+data ValueEnv = ValueEnv
+  { valueCompileEnv :: !CompileEnv,
+    valueLocalSlots :: !(Map GrinVar Int)
+  }
+
+compileProgram :: Text -> GcGrinProgram -> Either CError Text
+compileProgram entryName gcProgram =
+  compileProgramWithDependencies (buildLinkLayout [program]) [] entryName gcProgram
+  where
+    program = gcGrinProgram gcProgram
+
+compileProgramWithDependencies :: LinkLayout -> [Text] -> Text -> GcGrinProgram -> Either CError Text
+compileProgramWithDependencies layout dependencyInitializers entryName gcProgram = do
+  mapM_ validateRuntimeRep (programRuntimeReps program)
+  validateProgramPrimitives program
+  rootSlot <- maybe (Left (CMissingEntry entryName)) Right (Map.lookup entryName globalSlots)
+  updateLabel <- functionCodeLabel env (gcUpdateFunction gcProgram)
+  functionDefinitions <- mapM (compileFunction env) (grinFunctions program)
+  initializer <- compileInitializers env program
+  constructorInitializer <- compileConstructorInitializers env
+  let specialInfos =
+        [ specialInfo "aihc_final_info" "aihc_final_continuation" [] 1 (Just "aihc_final_applied_info"),
+          specialInfo "aihc_final_applied_info" "aihc_final_continuation" [BoxedRep Lifted] 0 Nothing,
+          specialInfo "aihc_top_info" "aihc_top_continuation" [BoxedRep Lifted] 1 (Just "aihc_top_applied_info"),
+          specialInfo "aihc_top_applied_info" "aihc_top_continuation" [BoxedRep Lifted, BoxedRep Lifted] 0 Nothing,
+          specialInfo "aihc_update_info" updateLabel [BoxedRep Lifted, BoxedRep Lifted] 1 (Just "aihc_update_applied_info"),
+          specialInfo "aihc_update_applied_info" updateLabel [BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted] 0 Nothing,
+          specialInfo "aihc_thread_done_info" "aihc_thread_done_continuation" [] 1 (Just "aihc_thread_done_applied_info"),
+          specialInfo "aihc_thread_done_applied_info" "aihc_thread_done_continuation" [BoxedRep Lifted] 0 Nothing
+        ]
+      source =
+        [ "#include \"aihc_runtime.h\"",
+          "#include <stdint.h>",
+          "#include <stddef.h>",
+          "",
+          "AihcMachine *aihc_machine;",
+          "AihcEntry aihc_next_entry;",
+          ""
+        ]
+          <> renderForeignDeclarations program
+          <> renderFunctionDeclarations env program
+          <> ["extern void " <> dependencyInitializer <> "(void);" | dependencyInitializer <- dependencyInitializers]
+          <> ["" | not (null dependencyInitializers)]
+          <> renderSpecialDeclarations
+          <> renderAddrLiterals env
+          <> renderRuntimeInfos (compileRuntimeInfos env <> specialInfos)
+          <> concat functionDefinitions
+          <> renderSpecialFunctions
+          <> [ "int main(void) {",
+               "  AihcValue *final_continuation;",
+               "  AihcValue *top_continuation;",
+               "  AihcValue *update_continuation;",
+               "  AihcValue *thread_done_continuation;",
+               "  AihcEntry entry;",
+               "  aihc_machine = aihc_machine_new(" <> tshow (length (linkGlobalNames layout)) <> ");"
+             ]
+          <> indent constructorInitializer
+          <> indent [dependencyInitializer <> "();" | dependencyInitializer <- dependencyInitializers]
+          <> indent initializer
+          <> [ "  aihc_ensure_heap(aihc_machine, 7, 0, NULL);",
+               "  final_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_final_info);",
+               "  top_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_top_info);",
+               "  aihc_set_field(top_continuation, 0, (AihcSlot)(uintptr_t)final_continuation);",
+               "  update_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_update_info);",
+               "  aihc_set_field(update_continuation, 0, aihc_machine->globals[" <> tshow rootSlot <> "]);",
+               "  aihc_set_field(update_continuation, 1, (AihcSlot)(uintptr_t)top_continuation);",
+               "  thread_done_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_thread_done_info);",
+               "  aihc_next_entry = aihc_start(aihc_machine, (AihcValue *)(uintptr_t)aihc_machine->globals[" <> tshow rootSlot <> "], top_continuation, update_continuation, thread_done_continuation, aihc_exit);",
+               "  while (aihc_next_entry != NULL) {",
+               "    entry = aihc_next_entry;",
+               "    aihc_next_entry = NULL;",
+               "    entry();",
+               "  }",
+               "  return 0;",
+               "}"
+             ]
+  pure (T.unlines source)
+  where
+    program = gcGrinProgram gcProgram
+    env = compileEnvironment ExecutableUnit layout program
+    globalSlots = compileGlobalSlots env
+    specialInfo label entry = RuntimeInfo label Nothing (Just entry)
+
+compileModule :: LinkLayout -> Text -> GcGrinProgram -> Either CError Text
+compileModule layout initializerSymbol gcProgram = do
+  mapM_ validateRuntimeRep (programRuntimeReps program)
+  functionDefinitions <- mapM (compileFunction env) (grinFunctions program)
+  initializer <- compileInitializers env program
+  let source =
+        [ "#include \"aihc_runtime.h\"",
+          "#include <stdint.h>",
+          "#include <stddef.h>",
+          "",
+          "extern AihcMachine *aihc_machine;",
+          "extern AihcEntry aihc_next_entry;",
+          ""
+        ]
+          <> renderForeignDeclarations program
+          <> renderFunctionDeclarations env program
+          <> renderAddrLiterals env
+          <> renderRuntimeInfos (compileRuntimeInfos env)
+          <> concat functionDefinitions
+          <> [ "void " <> initializerSymbol <> "(void) {"
+             ]
+          <> indent initializer
+          <> ["}"]
+  pure (T.unlines source)
+  where
+    program = gcGrinProgram gcProgram
+    env = compileEnvironment LibraryUnit layout program
+
+validateProgramPrimitives :: GrinProgram -> Either CError ()
+validateProgramPrimitives = validatePrimitiveNames . map (grinVarName . fst) . grinPrimitives
+
+validatePrimitiveNames :: [Text] -> Either CError ()
+validatePrimitiveNames = mapM_ $ \name ->
+  if name `elem` ["+#", "fork#", "realWorld#", "yield#"]
+    then Right ()
+    else Left (CUnsupportedPrimitive name)
+
+compileEnvironment :: CompilationUnit -> LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironment unitKind layout program =
+  CompileEnv
+    { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
+      compileConstructorArities = Map.fromList constructors,
+      compileGlobalSlots = Map.fromList (zip (linkGlobalNames layout) [0 ..]),
+      compileFunctionLabels = functionLabels,
+      compileAddrLiteralLabels = Map.fromList [(bytes, cLabel label) | (bytes, label) <- buildAddrLiteralPool program],
+      compileNodeInfoLabels = Map.fromList [(key, label) | (key, label, _) <- constructorEntries <> functionEntries],
+      compileRuntimeInfos = map third (constructorEntries <> functionEntries),
+      compileAllowUnsupportedPrimitives =
+        case unitKind of
+          ExecutableUnit -> False
+          LibraryUnit -> True
+    }
+  where
+    constructors = [(name, length layouts) | (name, layouts) <- linkConstructors layout]
+    constructorIds = zip (map fst constructors) [1 ..]
+    functionLabels =
+      Map.fromList
+        ( [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
+          | info <- grinExternalFunctions program
+          ]
+            <> [ (grinFunctionName function, localFunctionLabel index function)
+               | (index, function) <- zip [0 :: Int ..] (grinFunctions program)
+               ]
+        )
+    constructorEntries =
+      [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next)
+      | ((name, layouts), (_, identifier)) <- zip (linkConstructors layout) constructorIds,
+        let arity = length layouts,
+        remaining <- [arity, arity - 1 .. 0],
+        let key = ConstructorRuntimeInfo name remaining,
+        key `Set.member` requiredConstructorInfos,
+        let label = "aihc_constructor_info_" <> tshow identifier <> "_remaining_" <> tshow remaining
+            fields = concat (take (arity - remaining) layouts)
+            next = if remaining == 0 then Nothing else Just ("aihc_constructor_info_" <> tshow identifier <> "_remaining_" <> tshow (remaining - 1))
+      ]
+    requiredConstructorInfos =
+      Set.fromList
+        ( executableConstructorInfos
+            <> concatMap requiredNodeConstructorInfos (programNodes program)
+        )
+    executableConstructorInfos =
+      case unitKind of
+        ExecutableUnit -> [ConstructorRuntimeInfo name 0 | (name, arity) <- constructors, arity == 0]
+        LibraryUnit -> []
+    infoKeys =
+      [ key
+      | key <- Set.toAscList (Set.fromList (concatMap runtimeInfoKeyStages (programNodes program))),
+        Just functionName <- [runtimeInfoFunctionName key],
+        functionName `Map.member` functionLabels
+      ]
+    functionEntries =
+      [ ( key,
+          label,
+          RuntimeInfo label Nothing (runtimeInfoFunctionName key >>= (`Map.lookup` functionLabels)) (runtimeInfoKeyFields key) (runtimeInfoKeyRemainingArity key) (runtimeInfoKeyNext key >>= (`Map.lookup` infoLabels))
+        )
+      | (index, key) <- zip [0 :: Int ..] infoKeys,
+        let label = "aihc_function_info_" <> tshow index
+      ]
+    infoLabels = Map.fromList [(key, "aihc_function_info_" <> tshow index) | (index, key) <- zip [0 :: Int ..] infoKeys]
+    third (_, _, value) = value
+
+requiredNodeConstructorInfos :: GrinNode -> [RuntimeInfoKey]
+requiredNodeConstructorInfos node =
+  case grinNodeTag node of
+    GrinConstructor name remaining -> [ConstructorRuntimeInfo name stage | stage <- [remaining, remaining - 1 .. 0]]
+    GrinClosure {} -> []
+    GrinThunk {} -> []
+
+compileConstructorInitializers :: CompileEnv -> Either CError [Text]
+compileConstructorInitializers env = fmap concat . forM nullary $ \(name, identifier) -> do
+  slot <- globalSlot env name
+  info <- lookupRuntimeInfoLabel env (ConstructorRuntimeInfo name 0)
+  pure ["aihc_machine->globals[" <> tshow slot <> "] = (AihcSlot)(uintptr_t)aihc_make_node(aihc_machine, AIHC_TAG_NODE, &" <> info <> "); /* constructor " <> tshow identifier <> " */"]
+  where
+    nullary =
+      [ (name, identifier)
+      | (name, identifier) <- Map.toAscList (compileConstructorIds env),
+        Map.lookup name (compileConstructorArities env) == Just 0
+      ]
+
+compileInitializers :: CompileEnv -> GrinProgram -> Either CError [Text]
+compileInitializers env program = do
+  cafAllocations <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
+    slot <- globalSlot env (grinVarName var)
+    (tag, info) <- nodeHeader env node
+    pure ["aihc_machine->globals[" <> tshow slot <> "] = (AihcSlot)(uintptr_t)aihc_make_node(aihc_machine, " <> tag <> ", &" <> info <> ");"]
+  whnfs <- fmap concat . forM (grinWhnfGlobals program) $ \(var, node) -> do
+    slot <- globalSlot env (grinVarName var)
+    renderGlobalNode env slot node
+  cafFields <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
+    slot <- globalSlot env (grinVarName var)
+    initializeGlobalFields env ("(AihcValue *)(uintptr_t)aihc_machine->globals[" <> tshow slot <> "]") node
+  pure (cafAllocations <> whnfs <> cafFields)
+
+renderGlobalNode :: CompileEnv -> Int -> GrinNode -> Either CError [Text]
+renderGlobalNode env slot node = do
+  (tag, info) <- nodeHeader env node
+  fields <- initializeGlobalFields env ("(AihcValue *)(uintptr_t)aihc_machine->globals[" <> tshow slot <> "]") node
+  pure (["aihc_machine->globals[" <> tshow slot <> "] = (AihcSlot)(uintptr_t)aihc_make_node(aihc_machine, " <> tag <> ", &" <> info <> ");"] <> fields)
+
+initializeGlobalFields :: CompileEnv -> Text -> GrinNode -> Either CError [Text]
+initializeGlobalFields env object node =
+  forM (zip [0 :: Int ..] (grinNodeFields node)) $ \(index, value) -> do
+    expression <- materializeGlobalValue env value
+    pure ("aihc_set_field(" <> object <> ", " <> tshow index <> ", " <> expression <> ");")
+
+compileFunction :: CompileEnv -> GrinFunction -> Either CError [Text]
+compileFunction env function = do
+  label <- functionCodeLabel env (grinFunctionName function)
+  let slots = functionLocalSlots function
+      initial = FunctionState 0 (Map.size slots) []
+      valueEnv = ValueEnv env slots
+  final <- execStateT (compileExpr valueEnv [] (label <> "_body") (grinFunctionBody function)) initial
+  let slotCount = max 1 (functionNextSlot final)
+      parameters =
+        [ "  locals[" <> tshow slot <> "] = aihc_machine->args[" <> tshow index <> "];"
+        | (index, var) <- zip [0 :: Int ..] (grinFunctionParameters function),
+          Just slot <- [Map.lookup var slots]
+        ]
+      blocks = concatMap renderBlock (reverse (functionBlocksRev final))
+  pure
+    ( [ functionStorage function <> "void " <> label <> "(void) {",
+        "  AihcSlot *locals = aihc_alloc_locals(" <> tshow slotCount <> ");",
+        "  AihcSlot aihc_scratch = 0;"
+      ]
+        <> ["  (void)aihc_scratch;"]
+        <> parameters
+        <> ["  goto " <> label <> "_body;"]
+        <> indent blocks
+        <> ["}", ""]
+    )
+
+compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
+compileExpr env prefix label expression =
+  case expression of
+    GrinBind vars valueExpression body -> do
+      direct <- compileDirectBinding env vars valueExpression
+      compileExpr env (prefix <> direct) label body
+    GrinStoreRec bindings body -> compileStoreRec False bindings body
+    GrinStoreRecUnchecked bindings body -> compileStoreRec True bindings body
+    GrinCpsEval runtimeRep value continuation updateContinuation -> do
+      values <- materializeIntoFresh env [value, continuation, updateContinuation]
+      case snd values of
+        [valueSlot, continuationSlot, updateSlot] ->
+          terminal label (prefix <> fst values <> [setNext ("aihc_eval_cps(aihc_machine, " <> valuePointer (localRef valueSlot) <> ", " <> boolText (isLiftedRuntimeRep runtimeRep) <> ", " <> valuePointer (localRef continuationSlot) <> ", " <> valuePointer (localRef updateSlot) <> ")")])
+        _ -> unsupported "internal CPS evaluation slot arity"
+    GrinCall _ functionName arguments -> do
+      target <- liftEither (functionCodeLabel (valueCompileEnv env) functionName)
+      values <- materializeIntoFresh env arguments
+      terminal label (prefix <> fst values <> setArguments (snd values) <> ["aihc_next_entry = " <> target <> ";", "return;"])
+    GrinCpsPrimitiveCall _ name arguments continuation -> compileCpsPrimitive env prefix label name arguments continuation
+    GrinCpsApply _ function arguments continuation -> do
+      values <- materializeIntoFresh env (function : continuation : arguments)
+      let slots = snd values
+          argumentSlots = drop 2 slots
+      case slots of
+        functionSlot : continuationSlot : _ ->
+          terminal label (prefix <> fst values <> [setNext ("aihc_apply_cps(aihc_machine, " <> valuePointer (localRef functionSlot) <> ", " <> tshow (length arguments) <> ", " <> slotPointer argumentSlots <> ", " <> valuePointer (localRef continuationSlot) <> ")")])
+        _ -> unsupported "internal CPS application slot arity"
+    GrinContinue continuation values -> do
+      stored <- materializeIntoFresh env (continuation : values)
+      case snd stored of
+        continuationSlot : valueSlots ->
+          terminal label (prefix <> fst stored <> [setNext ("aihc_continue_values(aihc_machine, " <> valuePointer (localRef continuationSlot) <> ", " <> tshow (length values) <> ", " <> slotPointer valueSlots <> ")")])
+        [] -> unsupported "internal continuation slot arity"
+    GrinHalt _ -> terminal label (prefix <> [setNext "aihc_halt(aihc_machine)"])
+    GrinCase scrutinee binder alternatives -> compileCase env prefix label scrutinee binder alternatives
+    GrinConstant {} -> unsupported "direct-style constant return after CPS"
+    GrinStore {} -> unsupported "direct-style store return after CPS"
+    GrinEnsureHeap {} -> unsupported "unbound heap reservation"
+    GrinStoreUnchecked {} -> unsupported "unbound unchecked store"
+    GrinFetch {} -> unsupported "direct-style fetch return after CPS"
+    GrinUpdate {} -> unsupported "direct-style update return after CPS"
+    GrinUpdateBlackhole {} -> unsupported "unbound blackhole update"
+    GrinEval {} -> unsupported "direct-style eval after CPS"
+    GrinPrimitiveCall {} -> unsupported "unbound primitive call after CPS"
+    GrinApply {} -> unsupported "direct-style apply after CPS"
+    GrinThrow {} -> unsupported "throw"
+    GrinCatch {} -> unsupported "catch"
+    GrinForeignCallExpr {} -> unsupported "unbound foreign call after CPS"
+  where
+    unsupported = lift . Left . CUnsupportedExpression
+    terminal blockLabel lines' = addBlock blockLabel (lines' <> ["return;"])
+    compileStoreRec unchecked bindings body = do
+      allocations <- fmap concat . forM bindings $ \(var, node) -> do
+        destination <- localSlot env var
+        (tag, info) <- liftEither (nodeHeader (valueCompileEnv env) node)
+        pure [localRef destination <> " = (AihcSlot)(uintptr_t)" <> allocation unchecked tag info <> ";"]
+      fields <- fmap concat . forM bindings $ \(var, node) -> do
+        destination <- localSlot env var
+        initializeLocalFields env (valuePointer (localRef destination)) node
+      compileExpr env (prefix <> allocations <> fields) label body
+
+compileCpsPrimitive :: ValueEnv -> [Text] -> Text -> Text -> [GrinValue] -> GrinValue -> FunctionM ()
+compileCpsPrimitive env prefix label name arguments continuation =
+  case (name, arguments) of
+    ("fork#", [action]) -> transfer "aihc_fork_cps" [action, continuation]
+    ("yield#", []) -> transfer "aihc_yield_cps" [continuation]
+    _
+      | compileAllowUnsupportedPrimitives (valueCompileEnv env) ->
+          addBlock label (prefix <> ["aihc_unsupported_primitive();", "return;"])
+    _ -> lift (Left (CUnsupportedExpression ("CPS primitive call " <> name)))
+  where
+    transfer function values = do
+      stored <- materializeIntoFresh env values
+      let arguments' = T.intercalate ", " (map (valuePointer . localRef) (snd stored))
+      addBlock label (prefix <> fst stored <> [setNext (function <> "(aihc_machine, " <> arguments' <> ")"), "return;"])
+
+compileDirectBinding :: ValueEnv -> [GrinVar] -> GrinExpr -> FunctionM [Text]
+compileDirectBinding env vars expression =
+  case expression of
+    GrinConstant values
+      | length vars == length values -> fmap concat . forM (zip vars values) $ \(var, value) -> do
+          destination <- localSlot env var
+          source <- liftEither (materializeValue env value)
+          pure [localRef destination <> " = " <> source <> ";"]
+    GrinStore node -> materializeNode False node >>= storeOne
+    GrinEnsureHeap requiredWords roots
+      | length vars == length roots -> do
+          rootLines <- fmap concat . forM (zip vars roots) $ \(var, value) -> do
+            destination <- localSlot env var
+            source <- liftEither (materializeValue env value)
+            pure [localRef destination <> " = " <> source <> ";"]
+          rootSlots <- mapM (localSlot env) vars
+          pure (rootLines <> ["aihc_ensure_heap(aihc_machine, " <> tshow requiredWords <> ", " <> tshow (length roots) <> ", " <> slotPointer rootSlots <> ");"])
+    GrinStoreUnchecked node -> materializeNode True node >>= storeOne
+    GrinFetch _ pointer -> liftEither (materializeValue env pointer) >>= storeOne . pure
+    GrinUpdate pointer value -> update "aihc_update" False pointer value
+    GrinUpdateBlackhole pointer value -> update "aihc_update_blackhole" True pointer value
+    GrinPrimitiveCall IntRep "+#" [left, right] -> binaryIntPrimitive "+" left right
+    GrinPrimitiveCall runtimeRep "realWorld#" []
+      | null vars && null (runtimeRepComponents runtimeRep) -> pure []
+    GrinPrimitiveCall {}
+      | compileAllowUnsupportedPrimitives (valueCompileEnv env) -> do
+          zeroResults <- forM vars $ \var -> do
+            destination <- localSlot env var
+            pure (localRef destination <> " = 0;")
+          pure (["aihc_unsupported_primitive();"] <> zeroResults)
+    GrinPrimitiveCall _ name _ -> lift (Left (CUnsupportedExpression ("primitive call " <> name)))
+    GrinForeignCallExpr foreignCall arguments -> compileForeignCall env foreignCall arguments >>= storeOne
+    _ -> lift (Left (CUnsupportedExpression "non-direct expression remained in a CPS bind"))
+  where
+    storeOne lines' =
+      case vars of
+        [var] -> do
+          destination <- localSlot env var
+          pure (lines' <> [localRef destination <> " = aihc_scratch;"])
+        _ -> lift (Left (CUnsupportedExpression "direct expression result arity"))
+    materializeNode unchecked node = do
+      scratch <- freshSlot
+      (tag, info) <- liftEither (nodeHeader (valueCompileEnv env) node)
+      fields <- initializeLocalFields env (valuePointer (localRef scratch)) node
+      pure ([localRef scratch <> " = (AihcSlot)(uintptr_t)" <> allocation unchecked tag info <> ";"] <> fields <> ["aihc_scratch = " <> localRef scratch <> ";"])
+    update function passMachine pointer value = do
+      stored <- materializeIntoFresh env [pointer, value]
+      case snd stored of
+        [pointerSlot, valueSlot] -> do
+          let callArguments = (if passMachine then "aihc_machine, " else "") <> valuePointer (localRef pointerSlot) <> ", " <> valuePointer (localRef valueSlot)
+          result <- storeOne [function <> "(" <> callArguments <> ");", "aihc_scratch = " <> localRef valueSlot <> ";"]
+          pure (fst stored <> result)
+        _ -> lift (Left (CUnsupportedExpression "internal update slot arity"))
+    binaryIntPrimitive operator left right = do
+      stored <- materializeIntoFresh env [left, right]
+      case snd stored of
+        [leftSlot, rightSlot] ->
+          storeOne
+            ( fst stored
+                <> [ "aihc_scratch = (AihcSlot)((uint64_t)"
+                       <> localRef leftSlot
+                       <> " "
+                       <> operator
+                       <> " (uint64_t)"
+                       <> localRef rightSlot
+                       <> ");"
+                   ]
+            )
+        _ -> lift (Left (CUnsupportedExpression "internal binary Int# primitive arity"))
+
+compileForeignCall :: ValueEnv -> GrinForeignCall -> [GrinValue] -> FunctionM [Text]
+compileForeignCall env foreignCall arguments = do
+  let signature = grinForeignCallSignature foreignCall
+      argumentTypes = grinForeignArgumentTypes signature
+  if length arguments /= length (grinForeignOperandReps signature)
+    then lift (Left (CUnsupportedExpression "foreign call arity mismatch"))
+    else do
+      stored <- materializeIntoFresh env arguments
+      let abiSlots = take (length argumentTypes) (snd stored)
+          callArguments = T.intercalate ", " (zipWith foreignArgument argumentTypes abiSlots)
+          call = grinForeignCallSymbol foreignCall <> "(" <> callArguments <> ")"
+      pure (fst stored <> ["aihc_scratch = " <> foreignResult (grinForeignResultType signature) call <> ";"])
+
+compileCase :: ValueEnv -> [Text] -> Text -> GrinValue -> GrinVar -> [GrinAlt] -> FunctionM ()
+compileCase env prefix label scrutinee binder alternatives = do
+  result <- freshSlot
+  dispatch <- freshLabel label "case_dispatch"
+  value <- liftEither (materializeValue env scrutinee)
+  addBlock label (prefix <> [localRef result <> " = " <> value <> ";", "goto " <> dispatch <> ";"])
+  binderSlot <- localSlot env binder
+  targets <- forM alternatives $ \alternative -> do
+    target <- freshLabel label "case_alt"
+    alternativeLines <- alternativePrefix env result alternative
+    compileExpr env alternativeLines target (grinAltRhs alternative)
+    pure (alternative, target)
+  checks <- caseChecks env result (isPointerRuntimeRep (grinValueRuntimeRep scrutinee)) targets
+  addBlock dispatch ([localRef binderSlot <> " = " <> localRef result <> ";"] <> checks)
+
+alternativePrefix :: ValueEnv -> Int -> GrinAlt -> FunctionM [Text]
+alternativePrefix env result alternative =
+  case grinAltCon alternative of
+    GrinDataAlt _ -> fmap concat . forM (zip [0 :: Int ..] (grinAltBinders alternative)) $ \(index, binder) -> do
+      destination <- localSlot env binder
+      pure [localRef destination <> " = aihc_value_fields(" <> valuePointer (localRef result) <> ")[" <> tshow index <> "];"]
+    GrinLitAlt _ -> pure []
+    GrinDefaultAlt -> fmap concat . forM (grinAltBinders alternative) $ \binder -> do
+      destination <- localSlot env binder
+      pure [localRef destination <> " = " <> localRef result <> ";"]
+
+caseChecks :: ValueEnv -> Int -> Bool -> [(GrinAlt, Text)] -> FunctionM [Text]
+caseChecks env result pointer targets = do
+  checks <- fmap concat . forM nonDefault $ \(alternative, target) ->
+    case grinAltCon alternative of
+      GrinDataAlt name
+        | pointer -> do
+            identifier <- liftEither (constructorId (valueCompileEnv env) name)
+            pure ["if (aihc_value_info(" <> valuePointer (localRef result) <> ") == " <> tshow identifier <> ") goto " <> target <> ";"]
+        | otherwise -> lift (Left (CUnsupportedExpression "constructor case on an unboxed value"))
+      GrinLitAlt literal
+        | pointer -> lift (Left (CUnsupportedExpression "literal case on a lifted value"))
+        | otherwise ->
+            case normalizedLiteralInteger literal of
+              Just integer -> pure ["if (" <> localRef result <> " == " <> renderSlotInteger integer <> ") goto " <> target <> ";"]
+              Nothing -> lift (Left (CUnsupportedValue "string case alternative"))
+      GrinDefaultAlt -> pure []
+  pure (checks <> maybe ["aihc_no_match();", "return;"] (\target -> ["goto " <> target <> ";"]) defaultTarget)
+  where
+    nonDefault = [(alternative, target) | (alternative, target) <- targets, grinAltCon alternative /= GrinDefaultAlt]
+    defaultTarget = case [target | (alternative, target) <- targets, grinAltCon alternative == GrinDefaultAlt] of
+      target : _ -> Just target
+      [] -> Nothing
+
+materializeIntoFresh :: ValueEnv -> [GrinValue] -> FunctionM ([Text], [Int])
+materializeIntoFresh env values = do
+  slots <- replicateM (length values) freshSlot
+  lines' <- fmap concat . forM (zip values slots) $ \(value, destination) -> do
+    source <- liftEither (materializeValue env value)
+    pure [localRef destination <> " = " <> source <> ";"]
+  pure (lines', slots)
+
+initializeLocalFields :: ValueEnv -> Text -> GrinNode -> FunctionM [Text]
+initializeLocalFields env object node =
+  forM (zip [0 :: Int ..] (grinNodeFields node)) $ \(index, field) -> do
+    value <- liftEither (materializeValue env field)
+    pure ("aihc_set_field(" <> object <> ", " <> tshow index <> ", " <> value <> ");")
+
+materializeValue :: ValueEnv -> GrinValue -> Either CError Text
+materializeValue env value =
+  case value of
+    GrinVarValue var ->
+      case Map.lookup var (valueLocalSlots env) of
+        Just index -> Right (localRef index)
+        Nothing -> do
+          index <- globalSlot (valueCompileEnv env) (grinVarName var)
+          pure ("aihc_machine->globals[" <> tshow index <> "]")
+    GrinLitValue literal -> materializeLiteral (valueCompileEnv env) literal
+
+materializeGlobalValue :: CompileEnv -> GrinValue -> Either CError Text
+materializeGlobalValue env value =
+  case value of
+    GrinVarValue var -> do
+      index <- globalSlot env (grinVarName var)
+      pure ("aihc_machine->globals[" <> tshow index <> "]")
+    GrinLitValue literal -> materializeLiteral env literal
+
+materializeLiteral :: CompileEnv -> GrinLiteral -> Either CError Text
+materializeLiteral env literal =
+  case literal of
+    GrinLitAddr bytes ->
+      maybe (Left (CUnsupportedValue "unregistered Addr# literal")) (Right . ("(AihcSlot)(uintptr_t)" <>)) (Map.lookup bytes (compileAddrLiteralLabels env))
+    _ -> maybe (Left (CUnsupportedValue "string literal")) (Right . renderSlotInteger) (normalizedLiteralInteger literal)
+
+nodeHeader :: CompileEnv -> GrinNode -> Either CError (Text, Text)
+nodeHeader env node = do
+  info <- lookupRuntimeInfoLabel env key
+  pure (tag, info)
+  where
+    fields = map grinValueRuntimeRep (grinNodeFields node)
+    (tag, key) =
+      case grinNodeTag node of
+        GrinConstructor name remaining -> (if remaining == 0 then "AIHC_TAG_NODE" else "AIHC_TAG_PARTIAL_CONSTRUCTOR", ConstructorRuntimeInfo name remaining)
+        GrinClosure functionName layouts -> ("AIHC_TAG_CLOSURE", ClosureRuntimeInfo functionName fields layouts)
+        GrinThunk functionName -> ("AIHC_TAG_THUNK", ThunkRuntimeInfo functionName fields)
+
+renderRuntimeInfos :: [RuntimeInfo] -> [Text]
+renderRuntimeInfos infos = concatMap bitmap infos <> [""] <> map declaration infos <> [""] <> map definition infos <> [""]
+  where
+    bitmap info
+      | null (runtimeInfoFields info) = []
+      | otherwise = ["static const uint8_t " <> runtimeInfoLabel info <> "_bitmap[] = {" <> T.intercalate ", " [if isPointerRuntimeRep field then "1" else "0" | field <- runtimeInfoFields info] <> "};"]
+    declaration info = "static const AihcInfo " <> runtimeInfoLabel info <> ";"
+    definition info =
+      "static const AihcInfo "
+        <> runtimeInfoLabel info
+        <> " = {"
+        <> maybe "0" tshow (runtimeInfoIdentity info)
+        <> ", "
+        <> maybe "NULL" ("&" <>) (runtimeInfoEntry info)
+        <> ", "
+        <> tshow (length (runtimeInfoFields info))
+        <> ", "
+        <> tshow (runtimeInfoRemainingArity info)
+        <> ", "
+        <> (if null (runtimeInfoFields info) then "NULL" else runtimeInfoLabel info <> "_bitmap")
+        <> ", "
+        <> maybe "NULL" ("&" <>) (runtimeInfoNext info)
+        <> "};"
+
+renderForeignDeclarations :: GrinProgram -> [Text]
+renderForeignDeclarations program =
+  [ "extern " <> foreignType (grinForeignResultType signature) <> " " <> grinForeignCallSymbol foreignCall <> "(" <> arguments signature <> ");"
+  | foreignCall <- grinForeignCalls program,
+    let signature = grinForeignCallSignature foreignCall
+  ]
+    <> [""]
+  where
+    arguments signature =
+      case grinForeignArgumentTypes signature of
+        [] -> "void"
+        types -> T.intercalate ", " (map foreignType types)
+
+renderFunctionDeclarations :: CompileEnv -> GrinProgram -> [Text]
+renderFunctionDeclarations env program =
+  [ functionStorage function <> "void " <> label <> "(void);"
+  | function <- grinFunctions program,
+    Just label <- [Map.lookup (grinFunctionName function) (compileFunctionLabels env)]
+  ]
+    <> [ "extern void " <> label <> "(void);"
+       | info <- grinExternalFunctions program,
+         Just label <- [Map.lookup (grinCodeFunctionName info) (compileFunctionLabels env)]
+       ]
+    <> [""]
+
+functionStorage :: GrinFunction -> Text
+functionStorage function =
+  case grinFunctionLinkName function of
+    Nothing -> "static "
+    Just _ -> ""
+
+renderSpecialDeclarations :: [Text]
+renderSpecialDeclarations =
+  [ "static void aihc_top_continuation(void);",
+    "static void aihc_thread_done_continuation(void);",
+    "static void aihc_final_continuation(void);",
+    "static void aihc_exit(void);",
+    ""
+  ]
+
+renderSpecialFunctions :: [Text]
+renderSpecialFunctions =
+  [ "static void aihc_top_continuation(void) {",
+    "  aihc_next_entry = aihc_apply_cps(aihc_machine, (AihcValue *)(uintptr_t)aihc_machine->args[1], 0, NULL, (AihcValue *)(uintptr_t)aihc_machine->args[0]);",
+    "}",
+    "",
+    "static void aihc_thread_done_continuation(void) {",
+    "  aihc_next_entry = aihc_thread_done(aihc_machine);",
+    "}",
+    "",
+    "static void aihc_final_continuation(void) {",
+    "  aihc_next_entry = aihc_halt(aihc_machine);",
+    "}",
+    "",
+    "static void aihc_exit(void) {",
+    "  aihc_next_entry = NULL;",
+    "}",
+    ""
+  ]
+
+renderAddrLiterals :: CompileEnv -> [Text]
+renderAddrLiterals env =
+  [ "static const unsigned char " <> label <> "[] = {" <> T.intercalate ", " (map tshow (BS.unpack bytes <> [0])) <> "};"
+  | (bytes, label) <- Map.toAscList (compileAddrLiteralLabels env)
+  ]
+    <> [""]
+
+foreignType :: GrinForeignType -> Text
+foreignType foreignType' =
+  case foreignType' of
+    GrinForeignInt32 -> "int32_t"
+    GrinForeignWord64 -> "uint64_t"
+    GrinForeignAddr -> "void *"
+
+foreignArgument :: GrinForeignType -> Int -> Text
+foreignArgument foreignType' index =
+  case foreignType' of
+    GrinForeignInt32 -> "(int32_t)" <> localRef index
+    GrinForeignWord64 -> "(uint64_t)" <> localRef index
+    GrinForeignAddr -> "(void *)(uintptr_t)" <> localRef index
+
+foreignResult :: GrinForeignType -> Text -> Text
+foreignResult foreignType' call =
+  case foreignType' of
+    GrinForeignInt32 -> "(AihcSlot)(int64_t)(int32_t)" <> call
+    GrinForeignWord64 -> "(AihcSlot)" <> call
+    GrinForeignAddr -> "(AihcSlot)(uintptr_t)" <> call
+
+allocation :: Bool -> Text -> Text -> Text
+allocation unchecked tag info =
+  (if unchecked then "aihc_make_node_unchecked" else "aihc_make_node") <> "(aihc_machine, " <> tag <> ", &" <> info <> ")"
+
+setArguments :: [Int] -> [Text]
+setArguments slots = ["aihc_machine->args = " <> slotPointer slots <> ";"]
+
+setNext :: Text -> Text
+setNext expression = "aihc_next_entry = " <> expression <> ";"
+
+slotPointer :: [Int] -> Text
+slotPointer slots = maybe "NULL" (\index -> "&locals[" <> tshow index <> "]") (safeHead slots)
+
+localRef :: Int -> Text
+localRef index = "locals[" <> tshow index <> "]"
+
+valuePointer :: Text -> Text
+valuePointer expression = "(AihcValue *)(uintptr_t)" <> expression
+
+boolText :: Bool -> Text
+boolText True = "1"
+boolText False = "0"
+
+localSlot :: ValueEnv -> GrinVar -> FunctionM Int
+localSlot env var = maybe (lift (Left (CUnsupportedExpression ("missing local slot for " <> grinVarName var)))) pure (Map.lookup var (valueLocalSlots env))
+
+freshSlot :: FunctionM Int
+freshSlot = do
+  state <- get
+  let result = functionNextSlot state
+  modify' $ \current -> current {functionNextSlot = result + 1}
+  pure result
+
+freshLabel :: Text -> Text -> FunctionM Text
+freshLabel parent kind = do
+  state <- get
+  let identifier = functionNextLabel state
+  modify' $ \current -> current {functionNextLabel = identifier + 1}
+  pure (parent <> "_" <> kind <> "_" <> tshow identifier)
+
+addBlock :: Text -> [Text] -> FunctionM ()
+addBlock label lines' = modify' $ \state -> state {functionBlocksRev = (label, lines') : functionBlocksRev state}
+
+renderBlock :: (Text, [Text]) -> [Text]
+renderBlock (label, lines') = (label <> ":;") : lines'
+
+globalSlot :: CompileEnv -> Text -> Either CError Int
+globalSlot env name = maybe (Left (CMissingGlobal name)) Right (Map.lookup name (compileGlobalSlots env))
+
+constructorId :: CompileEnv -> Text -> Either CError Int
+constructorId env name = maybe (Left (CMissingConstructor name)) Right (Map.lookup name (compileConstructorIds env))
+
+lookupRuntimeInfoLabel :: CompileEnv -> RuntimeInfoKey -> Either CError Text
+lookupRuntimeInfoLabel env key =
+  case Map.lookup key (compileNodeInfoLabels env) of
+    Just label -> Right label
+    Nothing -> case key of
+      ConstructorRuntimeInfo name _ -> Left (CMissingConstructor name)
+      ClosureRuntimeInfo functionName _ _ -> Left (CMissingFunction functionName)
+      ThunkRuntimeInfo functionName _ -> Left (CMissingFunction functionName)
+
+functionCodeLabel :: CompileEnv -> FunctionName -> Either CError Text
+functionCodeLabel env name = maybe (Left (CMissingFunction name)) Right (Map.lookup name (compileFunctionLabels env))
+
+runtimeInfoKeyStages :: GrinNode -> [RuntimeInfoKey]
+runtimeInfoKeyStages node =
+  case grinNodeTag node of
+    GrinConstructor name remaining -> [ConstructorRuntimeInfo name remaining]
+    GrinClosure functionName layouts -> stages fields layouts
+      where
+        stages current remaining =
+          ClosureRuntimeInfo functionName current remaining : case remaining of
+            [] -> []
+            layout : rest -> stages (current <> layout) rest
+    GrinThunk functionName -> [ThunkRuntimeInfo functionName fields]
+  where
+    fields = map grinValueRuntimeRep (grinNodeFields node)
+
+runtimeInfoFunctionName :: RuntimeInfoKey -> Maybe FunctionName
+runtimeInfoFunctionName key = case key of
+  ConstructorRuntimeInfo {} -> Nothing
+  ClosureRuntimeInfo name _ _ -> Just name
+  ThunkRuntimeInfo name _ -> Just name
+
+runtimeInfoKeyFields :: RuntimeInfoKey -> [RuntimeRep]
+runtimeInfoKeyFields key = case key of
+  ConstructorRuntimeInfo {} -> []
+  ClosureRuntimeInfo _ fields _ -> fields
+  ThunkRuntimeInfo _ fields -> fields
+
+runtimeInfoKeyRemainingArity :: RuntimeInfoKey -> Int
+runtimeInfoKeyRemainingArity key = case key of
+  ConstructorRuntimeInfo _ remaining -> remaining
+  ClosureRuntimeInfo _ _ layouts -> length layouts
+  ThunkRuntimeInfo {} -> 0
+
+runtimeInfoKeyNext :: RuntimeInfoKey -> Maybe RuntimeInfoKey
+runtimeInfoKeyNext key = case key of
+  ConstructorRuntimeInfo name remaining | remaining > 0 -> Just (ConstructorRuntimeInfo name (remaining - 1))
+  ConstructorRuntimeInfo {} -> Nothing
+  ClosureRuntimeInfo name fields (layout : rest) -> Just (ClosureRuntimeInfo name (fields <> layout) rest)
+  ClosureRuntimeInfo {} -> Nothing
+  ThunkRuntimeInfo {} -> Nothing
+
+functionLocalSlots :: GrinFunction -> Map GrinVar Int
+functionLocalSlots function = snd (foldl' assignGroup (0, Map.empty) groups)
+  where
+    groups = grinFunctionParameters function : boundVarGroups (grinFunctionBody function)
+    assignGroup = foldl' $ \(next, slots) var -> case Map.lookup var slots of
+      Just _ -> (next, slots)
+      Nothing -> (next + 1, Map.insert var next slots)
+
+boundVarGroups :: GrinExpr -> [[GrinVar]]
+boundVarGroups expression = case expression of
+  GrinBind vars value body -> vars : boundVarGroups value <> boundVarGroups body
+  GrinStoreRec bindings body -> map (pure . fst) bindings <> boundVarGroups body
+  GrinStoreRecUnchecked bindings body -> map (pure . fst) bindings <> boundVarGroups body
+  GrinCase _ binder alternatives -> [binder] : concatMap (\alternative -> grinAltBinders alternative : boundVarGroups (grinAltRhs alternative)) alternatives
+  _ -> []
+
+programNodes :: GrinProgram -> [GrinNode]
+programNodes program = map snd (grinWhnfGlobals program <> grinCafs program) <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
+
+exprNodes :: GrinExpr -> [GrinNode]
+exprNodes expression = case expression of
+  GrinBind _ value body -> exprNodes value <> exprNodes body
+  GrinStore node -> [node]
+  GrinStoreUnchecked node -> [node]
+  GrinStoreRec bindings body -> map snd bindings <> exprNodes body
+  GrinStoreRecUnchecked bindings body -> map snd bindings <> exprNodes body
+  GrinCase _ _ alternatives -> concatMap (exprNodes . grinAltRhs) alternatives
+  _ -> []
+
+programRuntimeReps :: GrinProgram -> [RuntimeRep]
+programRuntimeReps program = concatMap (concat . snd) (grinConstructors program) <> concatMap nodeReps (programNodes program) <> concatMap functionReps (grinFunctions program)
+  where
+    nodeReps = map grinValueRuntimeRep . grinNodeFields
+    functionReps function = grinFunctionResultRep function : map grinVarRuntimeRep (grinFunctionParameters function) <> exprReps (grinFunctionBody function)
+
+exprReps :: GrinExpr -> [RuntimeRep]
+exprReps expression = case expression of
+  GrinBind vars value body -> map grinVarRuntimeRep vars <> exprReps value <> exprReps body
+  GrinStore node -> nodeReps node
+  GrinEnsureHeap _ roots -> map grinValueRuntimeRep roots
+  GrinStoreUnchecked node -> nodeReps node
+  GrinStoreRec bindings body -> concatMap (nodeReps . snd) bindings <> exprReps body
+  GrinStoreRecUnchecked bindings body -> concatMap (nodeReps . snd) bindings <> exprReps body
+  GrinCase value binder alternatives -> grinValueRuntimeRep value : grinVarRuntimeRep binder : concatMap (exprReps . grinAltRhs) alternatives
+  _ -> []
+  where
+    nodeReps = map grinValueRuntimeRep . grinNodeFields
+
+validateRuntimeRep :: RuntimeRep -> Either CError ()
+validateRuntimeRep runtimeRep = case runtimeRep of
+  VecRep {} -> Left (CUnsupportedRuntimeRep runtimeRep)
+  TupleRep reps -> mapM_ validateRuntimeRep reps
+  SumRep reps -> mapM_ validateRuntimeRep reps
+  RuntimeRepVar {} -> Left (CUnsupportedRuntimeRep runtimeRep)
+  RuntimeRepMeta {} -> Left (CUnsupportedRuntimeRep runtimeRep)
+  _ -> Right ()
+
+normalizedLiteralInteger :: GrinLiteral -> Maybe Integer
+normalizedLiteralInteger literal = do
+  integer <- case literal of
+    GrinLitInt _ value -> Just value
+    GrinLitChar _ value -> Just (fromIntegral (ord value))
+    _ -> Nothing
+  pure $ case literal of
+    GrinLitInt runtimeRep _ -> normalizeScalar runtimeRep integer
+    _ -> integer
+
+normalizeScalar :: RuntimeRep -> Integer -> Integer
+normalizeScalar runtimeRep integer = case runtimeRep of
+  IntRep -> signed 64
+  Int8Rep -> signed 8
+  Int16Rep -> signed 16
+  Int32Rep -> signed 32
+  Int64Rep -> signed 64
+  WordRep -> unsigned 64
+  Word8Rep -> unsigned 8
+  Word16Rep -> unsigned 16
+  Word32Rep -> unsigned 32
+  Word64Rep -> unsigned 64
+  _ -> integer
+  where
+    unsigned :: Int -> Integer
+    unsigned bits = integer `mod` (2 ^ bits)
+    signed :: Int -> Integer
+    signed bits = let value = unsigned bits; sign = 2 ^ (bits - 1) in if value >= sign then value - 2 ^ bits else value
+
+renderSlotInteger :: Integer -> Text
+renderSlotInteger integer = "(AihcSlot)UINT64_C(" <> tshow (integer `mod` (2 ^ (64 :: Int))) <> ")"
+
+localFunctionLabel :: Int -> GrinFunction -> Text
+localFunctionLabel index function = maybe ("aihc_function_" <> tshow index) linkedFunctionLabel (grinFunctionLinkName function)
+
+linkedFunctionLabel :: Text -> Text
+linkedFunctionLabel name = "aihc_entry_" <> T.concatMap (\character -> T.pack (showHex (ord character) "_")) name
+
+cLabel :: Text -> Text
+cLabel = T.map (\character -> if character `elem` ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> ['_'] then character else '_')
+
+safeHead :: [value] -> Maybe value
+safeHead [] = Nothing
+safeHead (value : _) = Just value
+
+indent :: [Text] -> [Text]
+indent = map ("  " <>)
+
+tshow :: (Show value) => value -> Text
+tshow = T.pack . show
+
+liftEither :: Either CError value -> FunctionM value
+liftEither = either (lift . Left) pure

--- a/components/aihc-c/test/Spec.hs
+++ b/components/aihc-c/test/Spec.hs
@@ -1,0 +1,19 @@
+module Main (main) where
+
+import Test.C.Suite (tests)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck qualified as QC
+
+main :: IO ()
+main =
+  defaultMain
+    ( testGroup
+        "aihc-c"
+        [ tests,
+          QC.testProperty "dummy quickcheck property" prop_dummy
+        ]
+    )
+
+-- | Keep the workspace-wide QuickCheck controls accepted by this suite.
+prop_dummy :: Bool -> Bool
+prop_dummy _ = True

--- a/components/aihc-c/test/Test/C/Suite.hs
+++ b/components/aihc-c/test/Test/C/Suite.hs
@@ -1,0 +1,290 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.C.Suite (tests) where
+
+import Aihc.C (CError (..), compileModule, compileProgram, compileProgramWithDependencies, validateProgramPrimitives)
+import Aihc.Grin (GcGrinProgram, lintProgram, lowerGc, toCpsGrin)
+import Aihc.Grin.Gc (gcGrinProgram)
+import Aihc.Grin.Syntax
+import Aihc.Native (buildLinkLayout, runtimeSourcePath)
+import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
+import Aihc.Testing.SchedulerProgram (blackholeSchedulerProgram, schedulerProgram)
+import Control.Exception (bracket)
+import Control.Monad (forM_)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import System.Directory (createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
+import System.Exit (ExitCode (..))
+import System.FilePath (takeDirectory, (</>))
+import System.IO (hClose, openTempFile)
+import System.Process (readProcessWithExitCode)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Portable C backend"
+    [ testCase "emits a portable trampoline" testTrampoline,
+      testCase "links separately compiled C units" testIncrementalProgram,
+      testCase "traps dormant unsupported primitives in compiled modules" testDormantPrimitive,
+      testCase "executes Int# addition" (testProgram "*" (intAddProgram 40 2 42)),
+      testCase "wraps overflowing Int# addition" (testProgram "*" (intAddProgram 9223372036854775807 1 (-9223372036854775808))),
+      testCase "executes cooperative scheduling" (testProgram "PCAB" schedulerProgram),
+      testCase "executes blackhole wakeups" (testProgram "TA" blackholeSchedulerProgram)
+    ]
+
+intAddProgram :: Integer -> Integer -> Integer -> GrinProgram
+intAddProgram left right expected =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [(GrinVar "+#" 30 IntRep, 2)],
+      grinForeignCalls = [putcharCall],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = mainFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = lifted,
+              grinFunctionBody =
+                GrinBind [sumValue] (GrinPrimitiveCall IntRep "+#" [intLiteral left, intLiteral right]) $
+                  GrinCase
+                    (GrinVarValue sumValue)
+                    caseBinder
+                    [ outputAlternative (GrinLitAlt (GrinLitInt IntRep expected)) '*' successOutput,
+                      outputAlternative GrinDefaultAlt '?' failureOutput
+                    ]
+            }
+        ]
+    }
+  where
+    lifted = BoxedRep Lifted
+    mainFunction = FunctionName "$int_add_main"
+    mainClosure = GrinVar "main" 31 lifted
+    sumValue = GrinVar "sum" 32 IntRep
+    caseBinder = GrinVar "case_binder" 33 IntRep
+    successOutput = GrinVar "success_output" 34 Int32Rep
+    failureOutput = GrinVar "failure_output" 35 Int32Rep
+    unitValue = GrinVar "()" 36 lifted
+    intLiteral = GrinLitValue . GrinLitInt IntRep
+    outputAlternative constructor character output =
+      GrinAlt
+        { grinAltCon = constructor,
+          grinAltBinders = [],
+          grinAltRhs =
+            GrinBind [output] (GrinForeignCallExpr putcharCall [GrinLitValue (GrinLitInt Int32Rep (toInteger (fromEnum character)))]) $
+              GrinConstant [GrinVarValue unitValue]
+        }
+
+putcharCall :: GrinForeignCall
+putcharCall =
+  GrinForeignCall
+    { grinForeignCallName = "$ffi$putchar",
+      grinForeignCallSymbol = "putchar",
+      grinForeignCallSignature =
+        GrinForeignSignature
+          { grinForeignArgumentTypes = [GrinForeignInt32],
+            grinForeignResultType = GrinForeignInt32,
+            grinForeignEffect = GrinForeignPure
+          }
+    }
+
+testTrampoline :: IO ()
+testTrampoline = do
+  source <- compile schedulerProgram
+  forM_
+    [ "while (aihc_next_entry != NULL)",
+      "aihc_next_entry = aihc_fork_cps",
+      "aihc_next_entry = aihc_yield_cps",
+      "extern int32_t putchar(int32_t)"
+    ]
+    (\needle -> assertBool ("missing generated C fragment: " <> T.unpack needle) (needle `T.isInfixOf` source))
+
+testIncrementalProgram :: IO ()
+testIncrementalProgram = do
+  let initializer = "aihc_init_dependency"
+      layout = buildLinkLayout [incrementalDependencyProgram, incrementalMainProgram]
+      dependencyGc = expectGcGrin incrementalDependencyProgram
+      mainGc = expectGcGrin incrementalMainProgram
+  dependencySource <-
+    case compileModule layout initializer dependencyGc of
+      Right source -> pure source
+      Left err -> assertFailure ("dependency C lowering failed: " <> show err)
+  mainSource <-
+    case compileProgramWithDependencies layout [initializer] "main" mainGc of
+      Right source -> pure source
+      Left err -> assertFailure ("main C lowering failed: " <> show err)
+  assertBool "exports the dependency initializer" (("void " <> initializer <> "(void)") `T.isInfixOf` dependencySource)
+  assertBool "calls the dependency initializer" ((initializer <> "();") `T.isInfixOf` mainSource)
+  withTempDirectory "aihc-c-incremental" $ \directory -> do
+    runtime <- runtimeSourcePath
+    let dependencyPath = directory </> "dependency.c"
+        mainPath = directory </> "main.c"
+        executablePath = directory </> "program"
+    TIO.writeFile dependencyPath dependencySource
+    TIO.writeFile mainPath mainSource
+    (clangExit, _clangOut, clangErr) <-
+      readProcessWithExitCode
+        "clang"
+        [ "-std=c11",
+          "-Wall",
+          "-Wextra",
+          "-Werror",
+          "-I" <> takeDirectory runtime,
+          runtime,
+          dependencyPath,
+          mainPath,
+          "-o",
+          executablePath
+        ]
+        ""
+    assertEqual ("clang rejected incremental generated C:\n" <> clangErr) ExitSuccess clangExit
+    (programExit, programOut, programErr) <- readProcessWithExitCode executablePath [] ""
+    assertEqual ("incremental program stderr: " <> programErr) ExitSuccess programExit
+    assertEqual "incremental program stdout" "D" programOut
+
+testDormantPrimitive :: IO ()
+testDormantPrimitive = do
+  let result = GrinVar "result" 51 IntRep
+      program =
+        GrinProgram
+          { grinConstructors = [],
+            grinPrimitives = [(GrinVar "unsupported#" 50 IntRep, 1)],
+            grinForeignCalls = [],
+            grinExternalGlobals = [],
+            grinExternalFunctions = [],
+            grinWhnfGlobals = [],
+            grinCafs = [],
+            grinFunctions =
+              [ GrinFunction
+                  { grinFunctionName = FunctionName "dormant_unsupported",
+                    grinFunctionLinkName = Nothing,
+                    grinFunctionParameters = [],
+                    grinFunctionResultRep = IntRep,
+                    grinFunctionBody =
+                      GrinBind
+                        [result]
+                        (GrinPrimitiveCall IntRep "unsupported#" [GrinLitValue (GrinLitInt IntRep 1)])
+                        (GrinConstant [GrinVarValue result])
+                  }
+              ]
+          }
+      layout = buildLinkLayout [program]
+  assertEqual "linked primitive validation" (Left (CUnsupportedPrimitive "unsupported#")) (validateProgramPrimitives program)
+  case compileModule layout "aihc_init_dormant" (expectGcGrin program) of
+    Left err -> assertFailure ("dormant primitive module lowering failed: " <> show err)
+    Right source -> assertBool "emits the runtime trap" ("aihc_unsupported_primitive();" `T.isInfixOf` source)
+
+incrementalDependencyProgram :: GrinProgram
+incrementalDependencyProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [putcharCall],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = incrementalDependencyFunction,
+              grinFunctionLinkName = Just "dependency",
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [GrinVar "output" 41 Int32Rep]
+                  (GrinForeignCallExpr putcharCall [GrinLitValue (GrinLitInt Int32Rep 68)])
+                  (GrinConstant [GrinVarValue (GrinVar "()" 42 (BoxedRep Lifted))])
+            }
+        ]
+    }
+
+incrementalMainProgram :: GrinProgram
+incrementalMainProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [],
+      grinExternalGlobals = [],
+      grinExternalFunctions =
+        [ GrinCodeInfo
+            { grinCodeSourceName = "dependency",
+              grinCodeFunctionName = incrementalDependencyFunction,
+              grinCodeParameterLayouts = [],
+              grinCodeResultRep = BoxedRep Lifted
+            }
+        ],
+      grinWhnfGlobals = [(GrinVar "main" 43 (BoxedRep Lifted), GrinNode (GrinClosure incrementalMainFunction [[]]) [])],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = incrementalMainFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinCall (BoxedRep Lifted) incrementalDependencyFunction []
+            }
+        ]
+    }
+
+incrementalDependencyFunction, incrementalMainFunction :: FunctionName
+incrementalDependencyFunction = FunctionName "$entry$dependency"
+incrementalMainFunction = FunctionName "$incremental_main"
+
+testProgram :: String -> GrinProgram -> IO ()
+testProgram expected program = do
+  source <- compile program
+  withTempDirectory "aihc-c" $ \directory -> do
+    runtime <- runtimeSourcePath
+    let sourcePath = directory </> "program.c"
+        executablePath = directory </> "program"
+    TIO.writeFile sourcePath source
+    (clangExit, _clangOut, clangErr) <-
+      readProcessWithExitCode
+        "clang"
+        [ "-std=c11",
+          "-Wall",
+          "-Wextra",
+          "-Werror",
+          "-I" <> takeDirectory runtime,
+          runtime,
+          sourcePath,
+          "-o",
+          executablePath
+        ]
+        ""
+    assertEqual ("clang rejected generated C:\n" <> clangErr) ExitSuccess clangExit
+    (programExit, programOut, programErr) <- readProcessWithExitCode executablePath [] ""
+    assertEqual ("generated program stderr: " <> programErr) ExitSuccess programExit
+    assertEqual "generated program stdout" expected programOut
+
+compile :: GrinProgram -> IO T.Text
+compile program = do
+  assertEqual "direct GRIN lint" [] (lintProgram program)
+  let gcProgram = expectGcGrin program
+  assertEqual "GC-GRIN lint" [] (lintProgram (gcGrinProgram gcProgram))
+  case compileProgram "main" gcProgram of
+    Right source -> pure source
+    Left err -> assertFailure ("C lowering failed: " <> show err)
+
+expectGcGrin :: GrinProgram -> GcGrinProgram
+expectGcGrin program =
+  case toCpsGrin program of
+    Right cpsProgram -> lowerGc cpsProgram
+    Left err -> error ("test GRIN failed CPS conversion: " <> show err)
+
+withTempDirectory :: String -> (FilePath -> IO value) -> IO value
+withTempDirectory template = bracket acquire removeDirectoryRecursive
+  where
+    acquire = do
+      temporary <- getTemporaryDirectory
+      (path, handle) <- openTempFile temporary template
+      hClose handle
+      removeFile path
+      createDirectory path
+      pure path

--- a/components/aihc-native/runtime/aihc_runtime.c
+++ b/components/aihc-native/runtime/aihc_runtime.c
@@ -8,8 +8,8 @@
 typedef struct AihcBlackholeWaiter AihcBlackholeWaiter;
 
 struct AihcThread {
-  uintptr_t header;
-  void *entry;
+  AihcSlot header;
+  AihcEntry entry;
   AihcSlot *args;
   const AihcInfo *args_info;
   uint64_t args_trailing_pointers;
@@ -30,11 +30,13 @@ struct AihcBlackhole {
   AihcBlackhole *next;
 };
 
+#if UINTPTR_MAX == UINT64_MAX
 _Static_assert(offsetof(AihcMachine, args) == 0, "machine args ABI");
 _Static_assert(offsetof(AihcMachine, globals) == 8, "machine globals ABI");
 _Static_assert(offsetof(AihcMachine, heap_next) == 32, "machine heap-next ABI");
 _Static_assert(offsetof(AihcMachine, heap_limit) == 40,
                "machine heap-limit ABI");
+#endif
 
 static _Noreturn void aihc_fail(const char *message) {
   fprintf(stderr, "aihc runtime: %s\n", message);
@@ -53,7 +55,7 @@ static void *aihc_allocate_auxiliary(size_t bytes) {
   return pointer;
 }
 
-static uintptr_t aihc_make_header(uint64_t tag, const AihcInfo *info) {
+static AihcSlot aihc_make_header(uint64_t tag, const AihcInfo *info) {
   uintptr_t address = (uintptr_t)info;
   if (info == NULL || (address & AIHC_TAG_MASK) != 0) {
     aihc_fail("info table is null or insufficiently aligned");
@@ -343,10 +345,10 @@ static AihcSlot *aihc_arguments(AihcValue *function, uint64_t count,
   return arguments;
 }
 
-static void *aihc_prepare_entry(AihcMachine *machine, void *entry,
-                                AihcSlot *arguments,
-                                const AihcInfo *arguments_info,
-                                uint64_t trailing_pointers) {
+static AihcEntry aihc_prepare_entry(AihcMachine *machine, AihcEntry entry,
+                                    AihcSlot *arguments,
+                                    const AihcInfo *arguments_info,
+                                    uint64_t trailing_pointers) {
   machine->args = arguments;
   machine->args_info = arguments_info;
   machine->args_trailing_pointers = trailing_pointers;
@@ -384,7 +386,7 @@ static AihcThread *aihc_dequeue_thread(AihcMachine *machine) {
   return thread;
 }
 
-static void *aihc_select_thread(AihcMachine *machine, AihcThread *thread) {
+static AihcEntry aihc_select_thread(AihcMachine *machine, AihcThread *thread) {
   machine->current_thread = thread;
   machine->args = thread->args;
   machine->args_info = thread->args_info;
@@ -468,8 +470,8 @@ AihcSlot *aihc_alloc_locals(uint64_t count) {
 
 void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
 
-void *aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
-                           uint64_t count, const AihcSlot *values) {
+AihcEntry aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
+                               uint64_t count, const AihcSlot *values) {
   if (continuation == NULL ||
       aihc_value_tag(continuation) != AIHC_TAG_CLOSURE) {
     aihc_fail("attempted to invoke a non-continuation value");
@@ -479,18 +481,19 @@ void *aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
   }
   const AihcInfo *arguments_info =
       aihc_next_application_info(aihc_value_info_table(continuation), count);
-  return aihc_prepare_entry(machine, (void *)aihc_value_info(continuation),
+  return aihc_prepare_entry(machine, aihc_value_entry(continuation),
                             aihc_arguments(continuation, count, values, NULL),
                             arguments_info, 0);
 }
 
-static void *aihc_continue_value(AihcMachine *machine, AihcValue *continuation,
-                                 AihcSlot value) {
+static AihcEntry aihc_continue_value(AihcMachine *machine,
+                                     AihcValue *continuation, AihcSlot value) {
   return aihc_continue_values(machine, continuation, 1, &value);
 }
 
-void *aihc_apply_cps(AihcMachine *machine, AihcValue *function, uint64_t count,
-                     const AihcSlot *arguments, AihcValue *continuation) {
+AihcEntry aihc_apply_cps(AihcMachine *machine, AihcValue *function,
+                         uint64_t count, const AihcSlot *arguments,
+                         AihcValue *continuation) {
   if (function == NULL) {
     aihc_fail("attempted to apply null");
   }
@@ -509,7 +512,7 @@ void *aihc_apply_cps(AihcMachine *machine, AihcValue *function, uint64_t count,
     const AihcInfo *arguments_info =
         aihc_next_application_info(aihc_value_info_table(function), count);
     return aihc_prepare_entry(
-        machine, (void *)aihc_value_info(function),
+        machine, aihc_value_entry(function),
         aihc_arguments(function, count, arguments, continuation),
         arguments_info, continuation == NULL ? 0 : 1);
   }
@@ -533,16 +536,16 @@ void *aihc_apply_cps(AihcMachine *machine, AihcValue *function, uint64_t count,
   }
 }
 
-void *aihc_eval_cps(AihcMachine *machine, AihcValue *value,
-                    uint64_t result_is_lifted, AihcValue *continuation,
-                    AihcValue *update_continuation) {
+AihcEntry aihc_eval_cps(AihcMachine *machine, AihcValue *value,
+                        uint64_t result_is_lifted, AihcValue *continuation,
+                        AihcValue *update_continuation) {
   if (value == NULL) {
     aihc_fail("attempted to evaluate null");
   }
   switch (aihc_value_tag(value)) {
   case AIHC_TAG_THUNK: {
     AihcSlot *arguments = aihc_arguments(value, 0, NULL, update_continuation);
-    void *entry = (void *)aihc_value_info(value);
+    AihcEntry entry = aihc_value_entry(value);
     const AihcInfo *arguments_info = aihc_value_info_table(value);
     value->header = (value->header & ~AIHC_TAG_MASK) | AIHC_TAG_BLACKHOLE;
     aihc_find_blackhole(machine, value);
@@ -595,8 +598,8 @@ void aihc_update_blackhole(AihcMachine *machine, AihcValue *object,
   free(blackhole);
 }
 
-void *aihc_fork_cps(AihcMachine *machine, AihcValue *action,
-                    AihcValue *continuation) {
+AihcEntry aihc_fork_cps(AihcMachine *machine, AihcValue *action,
+                        AihcValue *continuation) {
   if (machine->thread_done_continuation == NULL) {
     aihc_fail("thread completion continuation is not initialized");
   }
@@ -611,7 +614,7 @@ void *aihc_fork_cps(AihcMachine *machine, AihcValue *action,
   return aihc_continue_values(machine, continuation, 1, &thread_id);
 }
 
-void *aihc_yield_cps(AihcMachine *machine, AihcValue *continuation) {
+AihcEntry aihc_yield_cps(AihcMachine *machine, AihcValue *continuation) {
   AihcThread *current = machine->current_thread;
   current->entry = aihc_continue_values(machine, continuation, 0, NULL);
   current->args = machine->args;
@@ -621,7 +624,7 @@ void *aihc_yield_cps(AihcMachine *machine, AihcValue *continuation) {
   return aihc_select_thread(machine, aihc_dequeue_thread(machine));
 }
 
-void *aihc_thread_done(AihcMachine *machine) {
+AihcEntry aihc_thread_done(AihcMachine *machine) {
   return aihc_select_thread(machine, aihc_dequeue_thread(machine));
 }
 
@@ -635,11 +638,11 @@ void aihc_set_thread_done_continuation(AihcMachine *machine,
   machine->thread_done_continuation = thread_done_continuation;
 }
 
-void *aihc_halt(AihcMachine *machine) { return machine->exit_code; }
+AihcEntry aihc_halt(AihcMachine *machine) { return machine->exit_code; }
 
-void *aihc_start(AihcMachine *machine, AihcValue *root, AihcValue *continuation,
-                 AihcValue *update_continuation,
-                 AihcValue *thread_done_continuation, void *exit_code) {
+AihcEntry aihc_start(AihcMachine *machine, AihcValue *root,
+                     AihcValue *continuation, AihcValue *update_continuation,
+                     AihcValue *thread_done_continuation, AihcEntry exit_code) {
   machine->exit_code = exit_code;
   aihc_set_thread_done_continuation(machine, thread_done_continuation);
   return aihc_eval_cps(machine, root, 1, continuation, update_continuation);

--- a/components/aihc-native/runtime/aihc_runtime.h
+++ b/components/aihc-native/runtime/aihc_runtime.h
@@ -33,10 +33,12 @@ typedef struct AihcMachine AihcMachine;
 typedef struct AihcInfo AihcInfo;
 typedef struct AihcThread AihcThread;
 typedef struct AihcBlackhole AihcBlackhole;
-typedef uintptr_t AihcSlot;
+typedef uint64_t AihcSlot;
+typedef void (*AihcEntry)(void);
 
 struct AihcInfo {
   uintptr_t identity;
+  AihcEntry entry;
   uint64_t field_count;
   uint64_t remaining_arity;
   const uint8_t *field_is_pointer;
@@ -46,7 +48,7 @@ struct AihcInfo {
 struct AihcValue {
   /* Low AIHC_TAG_BITS select the runtime state. Remaining bits point to the
      static info table, or to the copied object for a forwarding header. */
-  uintptr_t header;
+  AihcSlot header;
   AihcSlot fields[];
 };
 
@@ -54,7 +56,7 @@ struct AihcMachine {
   AihcSlot *args;
   AihcSlot *globals;
   uint64_t global_count;
-  void *exit_code;
+  AihcEntry exit_code;
   uint8_t *heap_next;
   uint8_t *heap_limit;
   uint8_t *heap_start;
@@ -69,8 +71,10 @@ struct AihcMachine {
   AihcBlackhole *blackholes;
 };
 
-_Static_assert(sizeof(AihcValue) == sizeof(uintptr_t),
+_Static_assert(sizeof(AihcValue) == sizeof(AihcSlot),
                "AIHC objects must have a one-word base header");
+_Static_assert(_Alignof(AihcInfo) >= (1U << AIHC_TAG_BITS),
+               "AIHC info tables must leave the tag bits clear");
 
 static inline uint64_t aihc_value_tag(const AihcValue *value) {
   return value->header & AIHC_TAG_MASK;
@@ -82,6 +86,10 @@ static inline const AihcInfo *aihc_value_info_table(const AihcValue *value) {
 
 static inline uintptr_t aihc_value_info(const AihcValue *value) {
   return aihc_value_info_table(value)->identity;
+}
+
+static inline AihcEntry aihc_value_entry(const AihcValue *value) {
+  return aihc_value_info_table(value)->entry;
 }
 
 static inline uint64_t aihc_value_arity(const AihcValue *value) {
@@ -108,27 +116,30 @@ void aihc_ensure_heap(AihcMachine *machine, uint64_t words, uint64_t root_count,
                       AihcSlot *roots);
 AihcMachine *aihc_machine_new(uint64_t global_count);
 AihcSlot *aihc_alloc_locals(uint64_t count);
+void aihc_no_match(void);
+void aihc_unsupported_primitive(void);
 void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field);
-void *aihc_apply_cps(AihcMachine *machine, AihcValue *function, uint64_t count,
-                     const AihcSlot *arguments, AihcValue *continuation);
-void *aihc_eval_cps(AihcMachine *machine, AihcValue *value,
-                    uint64_t result_is_lifted, AihcValue *continuation,
-                    AihcValue *update_continuation);
-void *aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
-                           uint64_t count, const AihcSlot *values);
+AihcEntry aihc_apply_cps(AihcMachine *machine, AihcValue *function,
+                         uint64_t count, const AihcSlot *arguments,
+                         AihcValue *continuation);
+AihcEntry aihc_eval_cps(AihcMachine *machine, AihcValue *value,
+                        uint64_t result_is_lifted, AihcValue *continuation,
+                        AihcValue *update_continuation);
+AihcEntry aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
+                               uint64_t count, const AihcSlot *values);
 void aihc_update(AihcValue *object, AihcValue *value);
 void aihc_update_blackhole(AihcMachine *machine, AihcValue *object,
                            AihcValue *value);
-void *aihc_fork_cps(AihcMachine *machine, AihcValue *action,
-                    AihcValue *continuation);
-void *aihc_yield_cps(AihcMachine *machine, AihcValue *continuation);
-void *aihc_thread_done(AihcMachine *machine);
+AihcEntry aihc_fork_cps(AihcMachine *machine, AihcValue *action,
+                        AihcValue *continuation);
+AihcEntry aihc_yield_cps(AihcMachine *machine, AihcValue *continuation);
+AihcEntry aihc_thread_done(AihcMachine *machine);
 void aihc_set_thread_done_continuation(AihcMachine *machine,
                                        AihcValue *thread_done_continuation);
-void *aihc_halt(AihcMachine *machine);
-void *aihc_start(AihcMachine *machine, AihcValue *root, AihcValue *continuation,
-                 AihcValue *update_continuation,
-                 AihcValue *thread_done_continuation, void *exit_code);
+AihcEntry aihc_halt(AihcMachine *machine);
+AihcEntry aihc_start(AihcMachine *machine, AihcValue *root,
+                     AihcValue *continuation, AihcValue *update_continuation,
+                     AihcValue *thread_done_continuation, AihcEntry exit_code);
 
 typedef enum {
   AIHC_SNAPSHOT_POINTER,

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Architecture-neutral support shared by native code generators.
+-- | Architecture-neutral support shared by backend code generators.
 module Aihc.Native
   ( NativeTarget (..),
+    backendCompiler,
     LinkInterface (..),
     LinkLayout (..),
     buildLinkLayout,
@@ -29,10 +30,11 @@ import Data.Text qualified as T
 import Paths_aihc_native (getDataFileName)
 import System.Info qualified as System
 
--- | A complete native assembly and executable target.
+-- | A complete backend and executable target.
 data NativeTarget
   = AppleArm64
   | LinuxAmd64
+  | PortableC
   deriving (Bounded, Enum, Eq, Ord, Show)
 
 renderNativeTarget :: NativeTarget -> String
@@ -40,6 +42,7 @@ renderNativeTarget target =
   case target of
     AppleArm64 -> "apple-arm64"
     LinuxAmd64 -> "linux-amd64"
+    PortableC -> "portable-c"
 
 parseNativeTarget :: String -> Either String NativeTarget
 parseNativeTarget value =
@@ -48,7 +51,9 @@ parseNativeTarget value =
     "arm64-apple-darwin" -> Right AppleArm64
     "linux-amd64" -> Right LinuxAmd64
     "x86_64-unknown-linux-gnu" -> Right LinuxAmd64
-    _ -> Left "target must be apple-arm64 or linux-amd64"
+    "portable-c" -> Right PortableC
+    "c" -> Right PortableC
+    _ -> Left "target must be apple-arm64, linux-amd64, or portable-c"
 
 hostNativeTarget :: Maybe NativeTarget
 hostNativeTarget
@@ -61,16 +66,27 @@ nativeTargetTriple target =
   case target of
     AppleArm64 -> "arm64-apple-darwin"
     LinuxAmd64 -> "x86_64-unknown-linux-gnu"
+    PortableC -> "portable-c"
+
+-- | Select the C or assembly compiler driver and target arguments.
+backendCompiler :: NativeTarget -> IO (FilePath, [String])
+backendCompiler target =
+  case target of
+    PortableC -> pure ("clang", [])
+    AppleArm64 -> nativeCompiler
+    LinuxAmd64 -> nativeCompiler
+  where
+    nativeCompiler = pure ("clang", ["--target=" <> nativeTargetTriple target])
 
 -- | The process-wide constructor tags and global table slots shared by all
--- native compilation units in one executable.
+-- compilation units in one executable.
 data LinkLayout = LinkLayout
   { linkConstructors :: ![(Text, [[RuntimeRep]])],
     linkGlobalNames :: ![Text]
   }
   deriving (Eq, Show)
 
--- | Constructor and global-table metadata exported by a native compilation
+-- | Constructor and global-table metadata exported by a compilation
 -- unit. Code generation for another unit never needs its GRIN bodies.
 data LinkInterface = LinkInterface
   { linkInterfaceConstructors :: ![(Text, [[RuntimeRep]])],

--- a/examples/unboxed-tail-recursion/Main.hs
+++ b/examples/unboxed-tail-recursion/Main.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE ExtendedLiterals #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GHCForeignImportPrim #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main where
+
+import Foreign.C.Types (CInt (..))
+import GHC.Int (Int32 (..))
+
+foreign import prim (+#) :: Int# -> Int# -> Int#
+
+foreign import ccall unsafe putchar :: CInt -> IO CInt
+
+countToTenMillion :: Int# -> Int#
+countToTenMillion current =
+  case current of
+    10_000_000# -> current
+    _ -> countToTenMillion ((+#) current 1#)
+
+char :: Int32# -> CInt
+char value = CInt (I32# value)
+
+main :: IO CInt
+main =
+  case countToTenMillion 0# of
+    10_000_000# -> putchar (char 10#Int32)
+    _ -> putchar (char 70#Int32)

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -84,6 +84,11 @@
     })
   );
   arm64Tests = mkEvalPackageTest hsPkgs.aihc-arm64;
+  cBackendTests = mkEvalPackageTest (
+    pkgs.haskell.lib.overrideCabal hsPkgs.aihc-c (old: {
+      testToolDepends = (old.testToolDepends or []) ++ [pkgs.llvmPackages.clang];
+    })
+  );
   nativeTests = mkPackageTest hsPkgs.aihc-native;
   fcTests = mkEvalPackageTest hsPkgs.aihc-fc;
   grinTests = mkEvalPackageTest hsPkgs.aihc-grin;
@@ -193,6 +198,7 @@ in {
   cpp-tests = cppTests;
   amd64-tests = amd64Tests;
   arm64-tests = arm64Tests;
+  c-tests = cBackendTests;
   native-tests = nativeTests;
   fc-tests = fcTests;
   grin-tests = grinTests;
@@ -233,6 +239,10 @@ in {
     {
       name = "arm64-tests";
       path = arm64Tests;
+    }
+    {
+      name = "c-tests";
+      path = cBackendTests;
     }
     {
       name = "native-tests";

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -25,6 +25,17 @@
       supportsDocs = false;
       supportsCoverage = false;
     };
+    aihc-c = {
+      src = sources.cBackendSrc;
+      cabal2nixOptions = {
+        extraCabal2nixOptions = "--subpath components/aihc-c";
+        srcModifier = src: src;
+      };
+      disableProfiling = true;
+      optimizeForChecks = true;
+      supportsDocs = false;
+      supportsCoverage = false;
+    };
     aihc-native = {
       src = sources.nativeSrc;
       disableProfiling = true;

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -77,6 +77,11 @@ in rec {
     ".yml"
   ];
 
+  cBackendSrc = mkRootSubsetSrc ["components/aihc-c/" "test/support/"] [
+    ".hs"
+    ".cabal"
+  ];
+
   nativeSrc = mkComponentSrc "/components/aihc-native" [
     ".hs"
     ".cabal"
@@ -180,7 +185,7 @@ in rec {
         type == "directory" || ((inToolingCommon || inResolveCommon) && matchesSourceSuffix);
     };
 
-  aihcSrc = mkRootSubsetSrc ["bin/aihc/" "core-libs/" "examples/green-threads/" "examples/hello-world/"] [
+  aihcSrc = mkRootSubsetSrc ["bin/aihc/" "core-libs/" "examples/green-threads/" "examples/hello-world/" "examples/unboxed-tail-recursion/"] [
     ".hs"
     ".cabal"
   ];


### PR DESCRIPTION
## Summary

- add an aihc-c backend that lowers runtime-explicit GRIN to portable C11
- expose portable-c as a first-class compiler target
- use an explicit trampoline so correctness does not depend on C tail-call optimization
- compile dependency SCCs independently to cached objects and per-library archives
- give exported GRIN functions external linkage and initialize separately compiled dependency units from the main translation unit
- support wrapping Int# +# in portable C and Arm64
- add an allocation-free inner-loop recursion example that counts to 10,000,000

## Incremental compilation

The portable C backend uses the existing content-addressed dependency cache. Each dependency SCC is lowered to its own C translation unit and object file, grouped into a library archive, and reused when its cache key is unchanged. The final main translation unit references dependency initializers and exported functions instead of regenerating the dependency closure.

## Current limitation

The explicit C trampoline avoids relying on implementation-defined tail-call optimization, but every entry currently allocates a fresh locals array through aihc_alloc_locals. The 10,000,000-step example therefore establishes the intended unboxed recursion workload without claiming that the current portable C implementation executes it in constant space.

## Progress

- examples lowering through the portable C target: **3/3**
- portable C backend tests: **8/8**
- compiler driver tests: **72/72**
- separately compiled dependency/main link tests: **1/1**
- unchanged dependency cache reuse tests: **1/1**
- unboxed tail-recursion examples lowering through portable C: **1/1**
- unboxed tail-recursion examples executing in constant space: **0/1**

## Validation

- just fmt
- just check
- cabal test -v0 aihc:spec --ghc-options=-Werror --test-options=--hide-successes
- portable C separate-translation-unit execution test
- portable C incremental object/archive cache-hit test
- portable C and Arm64 +# execution and signed-overflow wrapping tests
