### PR TITLE
perf(grin): simplify generated closures and thunks

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -263,7 +263,7 @@ compileIncrementally dependencies unoptimizedMain =
           incrementalMainUnit = IncrementalUnit mainCore mainGrin mainCpsGrin
         }
   where
-    mainCore = Fc.lowerNewtypesWithInterface (dependencyNewtypeInterface dependencies) (eliminateDeadCode "main" unoptimizedMain)
+    mainCore = Fc.optimizeProgram (Fc.lowerNewtypesWithInterface (dependencyNewtypeInterface dependencies) (eliminateDeadCode "main" unoptimizedMain))
     mainGrin = Grin.lowerProgramWithInterface (dependencyGrinInterface dependencies) mainCore
 
 -- | Link already-incremental Core units for whole-program analysis. Unique
@@ -319,7 +319,7 @@ compileIncrementalArtifacts target dependencies compilation = do
 
 compileProgramArtifacts :: NativeTarget -> FcProgram -> Either CompileError CompileArtifacts
 compileProgramArtifacts target sourceCore = do
-  let core = Fc.lowerNewtypes sourceCore
+  let core = Fc.optimizeProgram (Fc.lowerNewtypes sourceCore)
   let grin = Grin.lowerProgram core
   cpsGrin <- either (Left . CompileCpsGrinError) Right (Grin.toCpsGrin grin)
   let gcGrin = Grin.lowerGc cpsGrin

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -14,7 +14,7 @@ where
 
 import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
-import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface)
+import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, optimizeProgram)
 import Aihc.Grin qualified as Grin
 import Aihc.Native
   ( LinkInterface,
@@ -173,7 +173,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 13
+cacheSchemaVersion = 17
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildNative mainModule = do
@@ -348,7 +348,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                         then Left ("core library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else
                           let sourceCore = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
-                              core = lowerNewtypesWithInterface (compileStateNewtypes state) sourceCore
+                              core = optimizeProgram (lowerNewtypesWithInterface (compileStateNewtypes state) sourceCore)
                               newtypes = extractNewtypeInterface core
                               grinInterface = Grin.extractGrinInterface core
                               reachabilityInterface = extractReachabilityInterface core

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -1020,7 +1020,7 @@ test_compileExplicitCoreImport =
             "module Demo (identity) where",
             "data UnreachableDependencyType = UnreachableDependencyConstructor",
             "unreachableDependencyFunction = UnreachableDependencyConstructor",
-            "dependencyImplementation x = x",
+            "dependencyImplementation x = let alias = x in alias",
             "identity x = dependencyImplementation x"
           ]
       )
@@ -1036,6 +1036,7 @@ test_compileExplicitCoreImport =
     assertBool "dependency Core implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` core))
     assertBool "dependency GRIN implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` grin))
     assertBool "whole-program Core merges reachable dependency implementations" ("dependencyImplementation" `T.isInfixOf` wholeCore)
+    assertBool ("whole-program Core retains a dependency alias:\n" <> T.unpack wholeCore) (not ("alias" `T.isInfixOf` wholeCore))
     assertBool "unreachable dependency function is excluded from Core" (not ("unreachableDependencyFunction" `T.isInfixOf` core))
     assertBool "unreachable dependency type is excluded from Core" (not ("UnreachableDependencyConstructor" `T.isInfixOf` core))
     assertBool "whole-program DCE excludes unreachable dependency functions" (not ("unreachableDependencyFunction" `T.isInfixOf` wholeCore))

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -19,6 +19,7 @@ library
     Aihc.Fc.Eval
     Aihc.Fc.Lint
     Aihc.Fc.Newtype
+    Aihc.Fc.Optimize
     Aihc.Fc.Pretty
     Aihc.Fc.Subst
     Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -27,6 +27,7 @@ module Aihc.Fc
 
     -- * Optimization
     eliminateDeadCode,
+    optimizeProgram,
     ReachabilityInterface,
     extractReachabilityInterface,
     reachablePrimitiveNames,
@@ -55,5 +56,6 @@ import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBind
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)
 import Aihc.Fc.Newtype (NewtypeInterface, extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
+import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Pretty (renderExpr, renderProgram, renderTopBind, renderType)
 import Aihc.Fc.Syntax

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -16,6 +16,7 @@ where
 import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsMatches, dsMatchesWithGivenDicts, freshUnique, freshVar, lookupType)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Newtype (lowerNewtypes)
+import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
@@ -106,7 +107,7 @@ desugarModuleWithBindings bindings tcResult _m =
                 }
             Right (binds, _) ->
               DesugarResult
-                { dsProgram = lowerConstraintProgram (lowerNewtypes (FcProgram binds)),
+                { dsProgram = optimizeProgram (lowerConstraintProgram (lowerNewtypes (FcProgram binds))),
                   dsSuccess = True,
                   dsErrors = []
                 }

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -12,6 +12,7 @@ module Aihc.Fc.Eval
 where
 
 import Aihc.Fc.Newtype (lowerNewtypes)
+import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Types (RuntimeRep (..), TcType (..), TyCon (..))
 import Control.Exception (SomeException, displayException, try)
@@ -79,7 +80,7 @@ evalProgramBinding name sourceProgram = runExceptT $
         else pure forced
     Nothing -> throwE (EvalMissingBinding name)
   where
-    program = lowerNewtypes sourceProgram
+    program = optimizeProgram (lowerNewtypes sourceProgram)
     ioBindings =
       Map.fromList
         [ (varName var, ())

--- a/components/aihc-fc/src/Aihc/Fc/Optimize.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Optimize.hs
@@ -10,6 +10,7 @@ module Aihc.Fc.Optimize
 where
 
 import Aihc.Fc.Syntax
+import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 
@@ -19,7 +20,7 @@ type CoreOptimization = FcProgram -> FcProgram
 optimizeProgram :: FcProgram -> FcProgram
 optimizeProgram = untilStable runOptimizations
   where
-    runOptimizations program = foldl' (flip ($)) program coreOptimizations
+    runOptimizations program = List.foldl' (flip ($)) program coreOptimizations
 
 -- Keep this list ordered from local canonicalizations to broader rewrites so
 -- later rules see the simplest output available from earlier rules.

--- a/components/aihc-fc/src/Aihc/Fc/Optimize.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Optimize.hs
@@ -1,0 +1,103 @@
+-- | Small, monotone System FC simplifications.
+--
+-- Every optimization in this module must strictly simplify the Core program:
+-- rules may remove structure, but must not trade one form for another form of
+-- equal complexity. This makes it safe to run the complete rule set to a
+-- fixpoint and keeps interactions between independent rules predictable.
+module Aihc.Fc.Optimize
+  ( optimizeProgram,
+  )
+where
+
+import Aihc.Fc.Syntax
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+
+type CoreOptimization = FcProgram -> FcProgram
+
+-- | Apply every Core simplification until a complete pass makes no change.
+optimizeProgram :: FcProgram -> FcProgram
+optimizeProgram = untilStable runOptimizations
+  where
+    runOptimizations program = foldl' (flip ($)) program coreOptimizations
+
+-- Keep this list ordered from local canonicalizations to broader rewrites so
+-- later rules see the simplest output available from earlier rules.
+coreOptimizations :: [CoreOptimization]
+coreOptimizations = [copyPropagateProgram]
+
+untilStable :: (Eq value) => (value -> value) -> value -> value
+untilStable transform input =
+  let output = transform input
+   in if output == input then input else untilStable transform output
+
+-- | Eliminate aliases of the form @let x = y in body@. Source lets currently
+-- arrive as singleton recursive groups, so that representation is simplified
+-- when it is not genuinely recursive. Computed right-hand sides are
+-- intentionally retained.
+copyPropagateProgram :: FcProgram -> FcProgram
+copyPropagateProgram (FcProgram topBinds) =
+  FcProgram (map copyTopBind topBinds)
+  where
+    copyTopBind topBind =
+      case topBind of
+        FcTopBind bind -> FcTopBind (copyBind Map.empty bind)
+        _ -> topBind
+
+copyBind :: Map Var Var -> FcBind -> FcBind
+copyBind aliases bind =
+  case bind of
+    FcNonRec binder rhs ->
+      FcNonRec binder (copyExpr aliases rhs)
+    FcRec bindings ->
+      let innerAliases = removeAliases (map fst bindings) aliases
+       in FcRec [(binder, copyExpr innerAliases rhs) | (binder, rhs) <- bindings]
+
+copyExpr :: Map Var Var -> FcExpr -> FcExpr
+copyExpr aliases expression =
+  case expression of
+    FcVar var -> FcVar (resolveAlias aliases var)
+    FcLit {} -> expression
+    FcApp function argument -> FcApp (copyExpr aliases function) (copyExpr aliases argument)
+    FcTyApp function ty -> FcTyApp (copyExpr aliases function) ty
+    FcLam binder body -> FcLam binder (copyExpr (Map.delete binder aliases) body)
+    FcTyLam tyVar body -> FcTyLam tyVar (copyExpr aliases body)
+    FcLet (FcNonRec binder (FcVar source)) body ->
+      copyExpr (Map.insert binder (resolveAlias aliases source) aliases) body
+    FcLet (FcRec [(binder, FcVar source)]) body
+      | binder /= source ->
+          copyExpr (Map.insert binder (resolveAlias aliases source) aliases) body
+    FcLet bind@(FcNonRec binder _) body ->
+      FcLet
+        (copyBind aliases bind)
+        (copyExpr (Map.delete binder aliases) body)
+    FcLet bind@(FcRec bindings) body ->
+      let binders = map fst bindings
+          innerAliases = removeAliases binders aliases
+       in FcLet (copyBind innerAliases bind) (copyExpr innerAliases body)
+    FcCase scrutinee binder alternatives ->
+      FcCase
+        (copyExpr aliases scrutinee)
+        binder
+        (map (copyAlt (Map.delete binder aliases)) alternatives)
+    FcCast inner coercion -> FcCast (copyExpr aliases inner) coercion
+    FcCallForeign foreignCall arguments ->
+      FcCallForeign foreignCall (map (copyExpr aliases) arguments)
+
+copyAlt :: Map Var Var -> FcAlt -> FcAlt
+copyAlt aliases alternative =
+  alternative
+    { altRhs =
+        copyExpr
+          (removeAliases (altBinders alternative) aliases)
+          (altRhs alternative)
+    }
+
+removeAliases :: [Var] -> Map Var Var -> Map Var Var
+removeAliases binders aliases = foldr Map.delete aliases binders
+
+resolveAlias :: Map Var Var -> Var -> Var
+resolveAlias aliases var =
+  case Map.lookup var aliases of
+    Just target -> resolveAlias aliases target
+    Nothing -> var

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -75,7 +75,53 @@ fcOptimizationTests :: TestTree
 fcOptimizationTests =
   testGroup
     "FC optimizations"
-    [ testCase "eliminates values and types unreachable from the entry point" $ do
+    [ testCase "copy propagates simple non-recursive lets" $ do
+        let value = Var "value" (Unique 1) stringTy
+            alias = Var "alias" (Unique 2) stringTy
+            consume = Var "consume" (Unique 3) (TcFunTy stringTy stringTy)
+            result = Var "result" (Unique 4) stringTy
+            source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcNonRec alias (FcVar value)) (FcApp (FcVar consume) (FcVar alias))))]
+            expected = FcProgram [FcTopBind (FcNonRec result (FcApp (FcVar consume) (FcVar value)))]
+        assertEqual "optimized program" expected (optimizeProgram source),
+      testCase "runs the Core optimization set to a fixpoint" $ do
+        let value = Var "value" (Unique 5) stringTy
+            outer = Var "outer" (Unique 6) stringTy
+            inner = Var "inner" (Unique 7) stringTy
+            result = Var "result" (Unique 8) stringTy
+            source =
+              FcProgram
+                [ FcTopBind
+                    ( FcNonRec
+                        result
+                        ( FcLet
+                            (FcNonRec outer (FcLet (FcNonRec inner (FcVar value)) (FcVar inner)))
+                            (FcVar outer)
+                        )
+                    )
+                ]
+            expected = FcProgram [FcTopBind (FcNonRec result (FcVar value))]
+        assertEqual "optimized program" expected (optimizeProgram source),
+      testCase "copy propagates non-recursive singleton rec groups" $ do
+        let value = Var "value" (Unique 13) stringTy
+            alias = Var "alias" (Unique 14) stringTy
+            result = Var "result" (Unique 15) stringTy
+            source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcRec [(alias, FcVar value)]) (FcVar alias)))]
+            expected = FcProgram [FcTopBind (FcNonRec result (FcVar value))]
+        assertEqual "optimized program" expected (optimizeProgram source),
+      testCase "retains genuinely recursive singleton aliases" $ do
+        let alias = Var "alias" (Unique 16) stringTy
+            result = Var "result" (Unique 17) stringTy
+            source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcRec [(alias, FcVar alias)]) (FcVar alias)))]
+        assertEqual "optimized program" source (optimizeProgram source),
+      testCase "retains non-trivial let right-hand sides" $ do
+        let value = Var "value" (Unique 9) stringTy
+            binder = Var "computed" (Unique 10) stringTy
+            identity = Var "identity" (Unique 11) (TcFunTy stringTy stringTy)
+            result = Var "result" (Unique 12) stringTy
+            computed = FcApp (FcVar identity) (FcVar value)
+            source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcNonRec binder computed) (FcVar binder)))]
+        assertEqual "optimized program" source (optimizeProgram source),
+      testCase "eliminates values and types unreachable from the entry point" $ do
         let liveTy = ty "Live"
             leafTy = ty "Leaf"
             deadTy = ty "Dead"

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-primitive-wrapper.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-primitive-wrapper.yaml
@@ -15,19 +15,15 @@ expected: |-
   putchar : CInt → IO CInt =
     λ$ffi_arg_0 : CInt.
       let
-        $ffi_case : CInt =
-          $ffi_arg_0
+        $ffi_field : Int32 =
+          $ffi_arg_0 ▷ <co>
       in
-        let
-          $ffi_field : Int32 =
-            $ffi_case ▷ <co>
-        in
-          case $ffi_field as $ffi_case : Int32 of
-            I32# $ffi_field →
-              (λ$ffi_state : State# RealWorld.
-                case foreign-call $ffi$putchar $ffi_field $ffi_state as $ffi_result : (#,#) (State# RealWorld) Int32# of
-                  (#,#) $ffi_next_state $ffi_raw_result →
-                    (#,#) $ffi_next_state ((I32# $ffi_raw_result) ▷ <co>)) ▷ <co>
+        case $ffi_field as $ffi_case : Int32 of
+          I32# $ffi_field →
+            (λ$ffi_state : State# RealWorld.
+              case foreign-call $ffi$putchar $ffi_field $ffi_state as $ffi_result : (#,#) (State# RealWorld) Int32# of
+                (#,#) $ffi_next_state $ffi_raw_result →
+                  (#,#) $ffi_next_state ((I32# $ffi_raw_result) ▷ <co>)) ▷ <co>
 extensions:
 - ForeignFunctionInterface
 - MagicHash

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -21,6 +21,9 @@ library
     Aihc.Grin.Snapshot
     Aihc.Grin.Syntax
 
+  other-modules:
+    Aihc.Grin.Analysis
+
   hs-source-dirs: src
   build-depends:
     aihc-fc,

--- a/components/aihc-grin/src/Aihc/Grin/Analysis.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Analysis.hs
@@ -1,0 +1,62 @@
+-- | Shared structural analyses over strict GRIN.
+module Aihc.Grin.Analysis
+  ( freeExprVars,
+    freeNodeVars,
+  )
+where
+
+import Aihc.Grin.Syntax
+import Data.Set (Set)
+import Data.Set qualified as Set
+
+freeExprVars :: GrinExpr -> Set GrinVar
+freeExprVars expression =
+  case expression of
+    GrinConstant values -> foldMap freeValueVars values
+    GrinBind vars valueExpression body ->
+      freeExprVars valueExpression <> (freeExprVars body `Set.difference` Set.fromList vars)
+    GrinStore node -> freeNodeVars node
+    GrinEnsureHeap _ roots -> foldMap freeValueVars roots
+    GrinStoreUnchecked node -> freeNodeVars node
+    GrinStoreRec bindings body -> freeStoreRecVars bindings body
+    GrinStoreRecUnchecked bindings body -> freeStoreRecVars bindings body
+    GrinFetch _ pointer -> freeValueVars pointer
+    GrinUpdate pointer value -> freeValueVars pointer <> freeValueVars value
+    GrinUpdateBlackhole pointer value -> freeValueVars pointer <> freeValueVars value
+    GrinEval _ value -> freeValueVars value
+    GrinCpsEval _ value continuation updateContinuation ->
+      freeValueVars value <> freeValueVars continuation <> freeValueVars updateContinuation
+    GrinCall _ _ arguments -> foldMap freeValueVars arguments
+    GrinPrimitiveCall _ _ arguments -> foldMap freeValueVars arguments
+    GrinCpsPrimitiveCall _ _ arguments continuation ->
+      foldMap freeValueVars arguments <> freeValueVars continuation
+    GrinApply _ function arguments -> freeValueVars function <> foldMap freeValueVars arguments
+    GrinCpsApply _ function arguments continuation ->
+      freeValueVars function <> foldMap freeValueVars arguments <> freeValueVars continuation
+    GrinContinue continuation values -> freeValueVars continuation <> foldMap freeValueVars values
+    GrinHalt values -> foldMap freeValueVars values
+    GrinCase scrutinee binder alternatives ->
+      freeValueVars scrutinee <> foldMap (freeAlternativeVars binder) alternatives
+    GrinThrow exception -> freeValueVars exception
+    GrinCatch _ action handler state ->
+      freeValueVars action <> freeValueVars handler <> foldMap freeValueVars state
+    GrinForeignCallExpr _ arguments -> foldMap freeValueVars arguments
+
+freeStoreRecVars :: [(GrinVar, GrinNode)] -> GrinExpr -> Set GrinVar
+freeStoreRecVars bindings body =
+  (foldMap (freeNodeVars . snd) bindings <> freeExprVars body)
+    `Set.difference` Set.fromList (map fst bindings)
+
+freeAlternativeVars :: GrinVar -> GrinAlt -> Set GrinVar
+freeAlternativeVars binder alternative =
+  freeExprVars (grinAltRhs alternative)
+    `Set.difference` Set.fromList (binder : grinAltBinders alternative)
+
+freeValueVars :: GrinValue -> Set GrinVar
+freeValueVars value =
+  case value of
+    GrinVarValue var -> Set.singleton var
+    GrinLitValue {} -> Set.empty
+
+freeNodeVars :: GrinNode -> Set GrinVar
+freeNodeVars = foldMap freeValueVars . grinNodeFields

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -17,6 +17,7 @@ module Aihc.Grin.Cps
   )
 where
 
+import Aihc.Grin.Analysis (freeExprVars)
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
 import Control.Monad.Trans.Class (lift)
@@ -362,59 +363,6 @@ varsRuntimeRep vars =
   case map grinVarRuntimeRep vars of
     [runtimeRep] -> runtimeRep
     runtimeReps -> TupleRep runtimeReps
-
-freeExprVars :: GrinExpr -> Set GrinVar
-freeExprVars expression =
-  case expression of
-    GrinConstant values -> foldMap freeValueVars values
-    GrinBind vars valueExpression body ->
-      freeExprVars valueExpression
-        <> (freeExprVars body `Set.difference` Set.fromList vars)
-    GrinStore node -> freeNodeVars node
-    GrinEnsureHeap _ roots -> foldMap freeValueVars roots
-    GrinStoreUnchecked node -> freeNodeVars node
-    GrinStoreRec bindings body ->
-      (foldMap (freeNodeVars . snd) bindings <> freeExprVars body)
-        `Set.difference` Set.fromList (map fst bindings)
-    GrinStoreRecUnchecked bindings body ->
-      (foldMap (freeNodeVars . snd) bindings <> freeExprVars body)
-        `Set.difference` Set.fromList (map fst bindings)
-    GrinFetch _ pointer -> freeValueVars pointer
-    GrinUpdate pointer value -> freeValueVars pointer <> freeValueVars value
-    GrinUpdateBlackhole pointer value -> freeValueVars pointer <> freeValueVars value
-    GrinEval _ value -> freeValueVars value
-    GrinCpsEval _ value continuation updateContinuation ->
-      freeValueVars value <> freeValueVars continuation <> freeValueVars updateContinuation
-    GrinCall _ _ arguments -> foldMap freeValueVars arguments
-    GrinPrimitiveCall _ _ arguments -> foldMap freeValueVars arguments
-    GrinCpsPrimitiveCall _ _ arguments continuation ->
-      foldMap freeValueVars arguments <> freeValueVars continuation
-    GrinApply _ function arguments -> freeValueVars function <> foldMap freeValueVars arguments
-    GrinCpsApply _ function arguments continuation ->
-      freeValueVars function <> foldMap freeValueVars arguments <> freeValueVars continuation
-    GrinContinue continuation values -> freeValueVars continuation <> foldMap freeValueVars values
-    GrinHalt values -> foldMap freeValueVars values
-    GrinCase scrutinee binder alternatives ->
-      freeValueVars scrutinee
-        <> foldMap (freeAlternativeVars binder) alternatives
-    GrinThrow exception -> freeValueVars exception
-    GrinCatch _ action handler state ->
-      freeValueVars action <> freeValueVars handler <> foldMap freeValueVars state
-    GrinForeignCallExpr _ arguments -> foldMap freeValueVars arguments
-
-freeAlternativeVars :: GrinVar -> GrinAlt -> Set GrinVar
-freeAlternativeVars binder alternative =
-  freeExprVars (grinAltRhs alternative)
-    `Set.difference` Set.fromList (binder : grinAltBinders alternative)
-
-freeValueVars :: GrinValue -> Set GrinVar
-freeValueVars value =
-  case value of
-    GrinVarValue var -> Set.singleton var
-    GrinLitValue {} -> Set.empty
-
-freeNodeVars :: GrinNode -> Set GrinVar
-freeNodeVars = foldMap freeValueVars . grinNodeFields
 
 maximumProgramVarUnique :: GrinProgram -> Int
 maximumProgramVarUnique program =

--- a/components/aihc-grin/src/Aihc/Grin/Gc.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Gc.hs
@@ -11,6 +11,7 @@ module Aihc.Grin.Gc
   )
 where
 
+import Aihc.Grin.Analysis (freeExprVars, freeNodeVars)
 import Aihc.Grin.Cps (CpsGrinProgram (..))
 import Aihc.Grin.Syntax
 import Control.Monad.Trans.State.Strict (State, evalState, get, put)
@@ -156,58 +157,6 @@ nodeWords node =
       _ -> fieldCount
   where
     fieldCount = length (grinNodeFields node)
-
-freeExprVars :: GrinExpr -> Set GrinVar
-freeExprVars expression =
-  case expression of
-    GrinConstant values -> foldMap freeValueVars values
-    GrinBind vars valueExpression body ->
-      freeExprVars valueExpression <> (freeExprVars body `Set.difference` Set.fromList vars)
-    GrinStore node -> freeNodeVars node
-    GrinEnsureHeap _ roots -> foldMap freeValueVars roots
-    GrinStoreUnchecked node -> freeNodeVars node
-    GrinStoreRec bindings body -> freeStoreRecVars bindings body
-    GrinStoreRecUnchecked bindings body -> freeStoreRecVars bindings body
-    GrinFetch _ pointer -> freeValueVars pointer
-    GrinUpdate pointer value -> freeValueVars pointer <> freeValueVars value
-    GrinUpdateBlackhole pointer value -> freeValueVars pointer <> freeValueVars value
-    GrinEval _ value -> freeValueVars value
-    GrinCpsEval _ value continuation updateContinuation ->
-      freeValueVars value <> freeValueVars continuation <> freeValueVars updateContinuation
-    GrinCall _ _ arguments -> foldMap freeValueVars arguments
-    GrinPrimitiveCall _ _ arguments -> foldMap freeValueVars arguments
-    GrinCpsPrimitiveCall _ _ arguments continuation ->
-      foldMap freeValueVars arguments <> freeValueVars continuation
-    GrinApply _ function arguments -> freeValueVars function <> foldMap freeValueVars arguments
-    GrinCpsApply _ function arguments continuation ->
-      freeValueVars function <> foldMap freeValueVars arguments <> freeValueVars continuation
-    GrinContinue continuation values -> freeValueVars continuation <> foldMap freeValueVars values
-    GrinHalt values -> foldMap freeValueVars values
-    GrinCase scrutinee binder alternatives ->
-      freeValueVars scrutinee <> foldMap (freeAlternativeVars binder) alternatives
-    GrinThrow exception -> freeValueVars exception
-    GrinCatch _ action handler state ->
-      freeValueVars action <> freeValueVars handler <> foldMap freeValueVars state
-    GrinForeignCallExpr _ arguments -> foldMap freeValueVars arguments
-
-freeStoreRecVars :: [(GrinVar, GrinNode)] -> GrinExpr -> Set GrinVar
-freeStoreRecVars bindings body =
-  (foldMap (freeNodeVars . snd) bindings <> freeExprVars body)
-    `Set.difference` Set.fromList (map fst bindings)
-
-freeAlternativeVars :: GrinVar -> GrinAlt -> Set GrinVar
-freeAlternativeVars binder alternative =
-  freeExprVars (grinAltRhs alternative)
-    `Set.difference` Set.fromList (binder : grinAltBinders alternative)
-
-freeValueVars :: GrinValue -> Set GrinVar
-freeValueVars value =
-  case value of
-    GrinVarValue var -> Set.singleton var
-    GrinLitValue {} -> Set.empty
-
-freeNodeVars :: GrinNode -> Set GrinVar
-freeNodeVars = foldMap freeValueVars . grinNodeFields
 
 substituteExpr :: Map GrinVar GrinVar -> GrinExpr -> GrinExpr
 substituteExpr substitutions expression =

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -11,8 +11,10 @@ module Aihc.Grin.Lower
 where
 
 import Aihc.Fc.Newtype (lowerNewtypes)
+import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
+import Aihc.Grin.Analysis (freeExprVars)
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types
   ( RuntimeRep (..),
@@ -24,6 +26,7 @@ import Aihc.Tc.Types
 import Control.Monad.Trans.State.Strict (State, gets, modify', runState)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -42,7 +45,8 @@ data LowerState = LowerState
     lowerReferencedExternalGlobalNames :: !(Set Text),
     lowerGlobalNames :: !(Set Text),
     lowerWhnfGlobalNames :: !(Set Text),
-    lowerLocalVars :: !(Map (Text, Unique) [GrinVar])
+    lowerLocalVars :: !(Map (Text, Unique) [GrinVar]),
+    lowerCurrentProvenance :: !(Maybe Text)
   }
 
 type LowerM = State LowerState
@@ -74,7 +78,7 @@ instance Monoid LoweredTop where
 lowerProgram :: FcProgram -> GrinProgram
 lowerProgram sourceProgram = lowerProgramWithInterface mempty program
   where
-    program = lowerNewtypes sourceProgram
+    program = optimizeProgram (lowerNewtypes sourceProgram)
 
 -- | Runtime facts exported by one compiled unit. Lowering consumers need to
 -- know which external names are globals, already in WHNF, constructors, or
@@ -102,7 +106,7 @@ instance Monoid GrinInterface where
   mempty = GrinInterface Set.empty Set.empty Map.empty Map.empty Map.empty
 
 extractGrinInterface :: FcProgram -> GrinInterface
-extractGrinInterface program =
+extractGrinInterface sourceProgram =
   GrinInterface
     { grinInterfaceGlobals = Set.fromList (programGlobalNames program),
       grinInterfaceWhnfGlobals = Set.fromList (programWhnfGlobalNames program),
@@ -114,12 +118,16 @@ extractGrinInterface program =
           ],
       grinInterfaceCodeInfos = Map.fromList (programCodeInfos program)
     }
+  where
+    program = optimizeProgram sourceProgram
 
 -- | Lower one SCC using only the exported runtime facts of predecessor SCCs.
 -- The supplied program must already have completed its FC transformations.
 lowerProgramWithInterface :: GrinInterface -> FcProgram -> GrinProgram
-lowerProgramWithInterface imported program =
+lowerProgramWithInterface imported sourceProgram =
   lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program)) program
+  where
+    program = optimizeProgram sourceProgram
 
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),
@@ -166,7 +174,8 @@ lowerProgramWithEnvironment environment program =
           lowerReferencedExternalGlobalNames = Set.empty,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
-          lowerLocalVars = Map.empty
+          lowerLocalVars = Map.empty,
+          lowerCurrentProvenance = Nothing
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
     tops = mconcat topParts
@@ -197,19 +206,20 @@ lowerTopValueBind bind =
     FcRec bindings ->
       mconcat <$> mapM (uncurry lowerBinding) bindings
   where
-    lowerBinding var expr = do
-      if isDirectFunction expr
-        then do
-          emitTopFunction var expr
-          pure mempty
-        else do
-          staticNode <- lowerStaticNode expr
-          topVar <- freshTopVar var
-          case staticNode of
-            Just node -> pure mempty {loweredWhnfGlobals = [(topVar, node)]}
-            Nothing -> do
-              node <- makeThunk expr
-              pure mempty {loweredCafs = [(topVar, node)]}
+    lowerBinding var expr =
+      withProvenance (varName var) $ do
+        if isDirectFunction expr
+          then do
+            emitTopFunction var expr
+            pure mempty
+          else do
+            staticNode <- lowerStaticNode expr
+            topVar <- freshTopVar var
+            case staticNode of
+              Just node -> pure mempty {loweredWhnfGlobals = [(topVar, node)]}
+              Nothing -> do
+                node <- makeTopThunk var expr
+                pure mempty {loweredCafs = [(topVar, node)]}
 
 -- | A top-level RHS is already a function value exactly when reaching its
 -- first runtime construct requires only erasing type abstraction or casts.
@@ -497,27 +507,71 @@ bindExpr vars valueExpr body =
       | values == map GrinVarValue vars -> valueExpr
     _ -> GrinBind vars valueExpr body
 
+-- | A non-recursive lifted binding whose pointer is forced immediately and is
+-- dead afterward needs neither an updateable cell nor an outlined entry. The
+-- caller can lower its right-hand side directly into this continuation.
+discardedImmediateEval :: [GrinVar] -> GrinExpr -> Maybe ([GrinVar], GrinExpr)
+discardedImmediateEval vars body =
+  case (vars, body) of
+    ( [pointer],
+      GrinBind resultVars (GrinEval _ (GrinVarValue evaluatedPointer)) rest
+      )
+        | pointer == evaluatedPointer,
+          pointer `Set.notMember` freeExprVars rest ->
+            Just (resultVars, rest)
+    _ -> Nothing
+
 lowerLambda :: Var -> FcExpr -> LowerM GrinExpr
 lowerLambda binder body =
   GrinStore <$> makeClosureNode (FcLam binder body)
 
 makeClosureNode :: FcExpr -> LowerM GrinNode
 makeClosureNode expr = do
-  let (binders, lambdaBody) = collectLeadingLambdas expr
-  captures <- capturesFor expr
-  functionName <- freshFunction "closure"
-  (parameterLayouts, parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
-    body' <- lowerExpr lambdaBody
-    pure (map (map grinVarRuntimeRep) groups, concat groups, body')
-  emitFunction
-    GrinFunction
-      { grinFunctionName = functionName,
-        grinFunctionLinkName = Nothing,
-        grinFunctionParameters = captures <> parameters,
-        grinFunctionResultRep = exprRuntimeRep lambdaBody,
-        grinFunctionBody = loweredBody
-      }
-  pure (GrinNode (GrinClosure functionName parameterLayouts) (map GrinVarValue captures))
+  etaReduced <- etaReduceKnownFunction expr
+  case etaReduced of
+    Just node -> pure node
+    Nothing -> do
+      let (binders, lambdaBody) = collectLeadingLambdas expr
+      captures <- capturesFor expr
+      functionName <- freshFunction "closure"
+      (parameterLayouts, parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
+        body' <- lowerExpr lambdaBody
+        pure (map (map grinVarRuntimeRep) groups, concat groups, body')
+      emitFunction
+        GrinFunction
+          { grinFunctionName = functionName,
+            grinFunctionLinkName = Nothing,
+            grinFunctionParameters = captures <> parameters,
+            grinFunctionResultRep = exprRuntimeRep lambdaBody,
+            grinFunctionBody = loweredBody
+          }
+      pure (GrinNode (GrinClosure functionName parameterLayouts) (map GrinVarValue captures))
+
+-- A closure such as @\x -> pureIO x@ is only an eta-expanded view of known
+-- code. Pointing at that code directly preserves partial-application behavior
+-- while avoiding both the wrapper entry and an extra closure allocation.
+etaReduceKnownFunction :: FcExpr -> LowerM (Maybe GrinNode)
+etaReduceKnownFunction expr =
+  case collectLeadingLambdas expr of
+    ([], _) -> pure Nothing
+    (binders, body) ->
+      case collectApplications body of
+        (FcVar target, arguments)
+          | map etaArgumentVar arguments == map Just binders -> do
+              codeInfo <- lookupCodeInfo target
+              pure $ do
+                info <- codeInfo
+                let binderLayouts = map (runtimeRepComponents . typeRuntimeRep . varType) binders
+                if binderLayouts == take (length binders) (grinCodeParameterLayouts info)
+                  then Just (knownFunctionNode info 0 [])
+                  else Nothing
+        _ -> pure Nothing
+  where
+    etaArgumentVar argument =
+      case argument of
+        FcVar var -> Just var
+        FcCast inner _ -> etaArgumentVar inner
+        _ -> Nothing
 
 lowerLet :: FcBind -> FcExpr -> LowerM GrinExpr
 lowerLet bind body =
@@ -534,25 +588,30 @@ lowerLet bind body =
                 pure (concat groups, body')
               if rhsIsWhnf
                 then do
-                  loweredRhs <- lowerExpr rhs
+                  loweredRhs <- withProvenance (varName var) (lowerExpr rhs)
                   pure (bindExpr vars loweredRhs loweredBody)
-                else do
-                  node <- makeThunk rhs
-                  pure (bindExpr vars (GrinStore node) loweredBody)
+                else case discardedImmediateEval vars loweredBody of
+                  Just (resultVars, rest) -> do
+                    loweredRhs <- withProvenance (varName var) (lowerExpr rhs)
+                    pure (bindExpr resultVars loweredRhs rest)
+                  Nothing -> do
+                    node <- withProvenance (varName var) (makeThunk rhs)
+                    pure (bindExpr vars (GrinStore node) loweredBody)
       | otherwise -> do
           (vars, loweredBody) <- withFreshLocalVars [var] $ \groups -> do
             body' <- lowerExpr body
             pure (concat groups, body')
-          loweredRhs <- lowerExpr rhs
+          loweredRhs <- withProvenance (varName var) (lowerExpr rhs)
           pure (bindExpr vars loweredRhs loweredBody)
     FcRec bindings -> do
       withFreshLocalVars (map fst bindings) $ \groups -> do
         nodes <-
           mapM
-            ( \(_, rhs) ->
-                if isDirectFunction rhs
-                  then makeClosureNode rhs
-                  else makeThunk rhs
+            ( \(var, rhs) ->
+                withProvenance (varName var) $
+                  if isDirectFunction rhs
+                    then makeClosureNode rhs
+                    else makeThunk rhs
             )
             bindings
         loweredBody <- lowerExpr body
@@ -574,12 +633,18 @@ lowerAlt caseBinding alt = do
       }
 
 makeThunk :: FcExpr -> LowerM GrinNode
-makeThunk expr
+makeThunk = makeThunkNamed Nothing
+
+makeTopThunk :: Var -> FcExpr -> LowerM GrinNode
+makeTopThunk var = makeThunkNamed (Just (FunctionName (varName var <> "_thunk")))
+
+makeThunkNamed :: Maybe FunctionName -> FcExpr -> LowerM GrinNode
+makeThunkNamed requestedName expr
   | not (isLiftedRuntimeRep runtimeRep) =
       error ("GRIN lowering cannot suspend an expression with runtime representation " <> show runtimeRep)
   | otherwise = do
       captures <- capturesFor expr
-      functionName <- freshFunction "thunk"
+      functionName <- maybe (freshFunction "thunk") freshNamedFunction requestedName
       body <- lowerExpr expr
       emitFunction
         GrinFunction
@@ -798,9 +863,28 @@ freshTopVar var = do
 
 freshFunction :: Text -> LowerM FunctionName
 freshFunction kind = do
+  index <- freshFunctionIndex
+  provenance <- gets lowerCurrentProvenance
+  pure
+    ( FunctionName
+        ( fromMaybe "$grin" provenance
+            <> "_"
+            <> kind
+            <> "_"
+            <> T.pack (show index)
+        )
+    )
+
+-- Source-derived names still reserve a generated-name index so introducing a
+-- readable name does not renumber every anonymous function that follows it.
+freshNamedFunction :: FunctionName -> LowerM FunctionName
+freshNamedFunction name = name <$ freshFunctionIndex
+
+freshFunctionIndex :: LowerM Int
+freshFunctionIndex = do
   index <- gets lowerNextFunction
   modify' $ \state -> state {lowerNextFunction = index + 1}
-  pure (FunctionName ("$grin_" <> kind <> "_" <> T.pack (show index)))
+  pure index
 
 emitFunction :: GrinFunction -> LowerM ()
 emitFunction function = do
@@ -1133,6 +1217,14 @@ withBindings bindings action = do
   modify' $ \state -> state {lowerLocalVars = previous}
   pure result
 
+withProvenance :: Text -> LowerM a -> LowerM a
+withProvenance provenance action = do
+  previous <- gets lowerCurrentProvenance
+  modify' $ \state -> state {lowerCurrentProvenance = Just provenance}
+  result <- action
+  modify' $ \state -> state {lowerCurrentProvenance = previous}
+  pure result
+
 binderVars :: Var -> LowerM [GrinVar]
 binderVars var =
   case runtimeRepComponents (typeRuntimeRep (varType var)) of
@@ -1363,7 +1455,25 @@ collectLeadingLambdas expr =
        in (binder : binders, result)
     FcTyLam _ body -> collectLeadingLambdas body
     FcCast inner _ -> collectLeadingLambdas inner
+    FcLet bind@(FcNonRec _ rhs) body
+      | isRuntimeAliasExpression rhs ->
+          case collectLeadingLambdas body of
+            ([], _) -> ([], expr)
+            (binders, result) -> (binders, FcLet bind result)
     _ -> ([], expr)
+
+-- Moving an allocation-free alias into the body of a following lambda exposes
+-- the lambda to closure conversion without duplicating work or changing
+-- sharing. Keep the let itself so its binder continues to carry the cast's
+-- result type; GRIN deliberately does not reconstruct that type from coercion
+-- axioms.
+isRuntimeAliasExpression :: FcExpr -> Bool
+isRuntimeAliasExpression expression =
+  case expression of
+    FcVar {} -> True
+    FcTyApp inner _ -> isRuntimeAliasExpression inner
+    FcCast inner _ -> isRuntimeAliasExpression inner
+    _ -> False
 
 isStaticWhnf :: Map Text Int -> FcExpr -> Bool
 isStaticWhnf constructorArities expr =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -11,6 +11,7 @@ import Aihc.Fc.Newtype (extractNewtypeInterface, lowerNewtypes, lowerNewtypesWit
 import Aihc.Fc.Syntax
 import Aihc.Grin
 import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), runtimeRepOfType)
+import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Control.Monad (forM_)
 import Data.List (isInfixOf)
@@ -60,8 +61,9 @@ grinUnitTests =
       testCase "FC lowering passes known WHNF arguments without thunk cells" $ do
         let program = lowerProgram applicationProgram
             rendered = renderProgram program
+            storedNodes = concatMap (expressionStoredNodes . grinFunctionBody) (grinFunctions program)
         assertEqual "lint" [] (lintProgram program)
-        assertBool "does not allocate a constructor argument thunk" (not ("store (F$grin_thunk" `isInfixOf` rendered))
+        assertBool "does not allocate a constructor argument thunk" (not (any isThunkNode storedNodes))
         assertBool "contains explicit application" ("apply " `isInfixOf` rendered),
       testCase "FC lowering evaluates case and apply operands explicitly" $ do
         let caseProgram = lowerProgram dictionaryProgram
@@ -230,9 +232,10 @@ grinUnitTests =
       testCase "FC lowering evaluates Int# arguments without allocating thunks" $ do
         let program = lowerProgram unboxedApplicationProgram
             rendered = renderProgram program
+            storedNodes = concatMap (expressionStoredNodes . grinFunctionBody) (grinFunctions program)
         assertEqual "lint" [] (lintProgram program)
         assertBool "records IntRep" ("IntRep" `isInfixOf` rendered)
-        assertBool "does not allocate an argument thunk" (not ("store (F$grin_thunk" `isInfixOf` rendered)),
+        assertBool "does not allocate an argument thunk" (not (any isThunkNode storedNodes)),
       testCase "FC lowering calls saturated primitives without global slots" $ do
         let program = lowerProgram primitiveCallProgram
             rendered = renderProgram program
@@ -243,7 +246,7 @@ grinUnitTests =
         let program = lowerProgram partialPrimitiveProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "allocates an ordinary closure" ("P$grin_primitive_" `isInfixOf` rendered)
+        assertBool "allocates a provenance-named ordinary closure" ("PmakeAdder_primitive_" `isInfixOf` rendered)
         assertBool "wrapper makes a saturated primitive call" ("primitive-call @IntRep +#" `isInfixOf` rendered),
       testCase "FC lowering counts zero-width arguments in closure arity" $ do
         let program = lowerProgram zeroWidthSaturatedApplicationProgram
@@ -359,6 +362,72 @@ grinUnitTests =
         case exported of
           [function] -> assertEqual "runtime parameters" 2 (length (grinFunctionParameters function))
           _ -> assertFailure ("expected one exported direct entry, got " <> show (length exported)),
+      testCase "FC lowering names CAF thunks after their source binding" $ do
+        let program = lowerProgram etaExpandedKnownFunctionProgram
+        case grinCafs program of
+          [(caf, GrinNode (GrinThunk thunkName) [])] -> do
+            assertEqual "CAF name" "$fApplicativeIO" (grinVarName caf)
+            assertEqual "source-derived thunk name" (FunctionName "$fApplicativeIO_thunk") thunkName
+          cafs -> assertFailure ("expected one capture-free CAF thunk, got " <> show cafs),
+      testCase "FC lowering eliminates known-function eta wrappers" $ do
+        let program = lowerProgram etaExpandedKnownFunctionProgram
+            rendered = renderProgram program
+        assertEqual "lint" [] (lintProgram program)
+        assertBool
+          "stores the original function with all arguments remaining"
+          ("store (P$entry$pureIO/2)" `isInfixOf` rendered)
+        assertEqual
+          "emits no eta-wrapper entry"
+          [FunctionName "$entry$pureIO", FunctionName "$fApplicativeIO_thunk"]
+          (map grinFunctionName (grinFunctions program)),
+      testCase "FC lowering retains known-function lambdas that are not eta expansions" $ do
+        let program = lowerProgram nonEtaExpandedKnownFunctionProgram
+            generatedNames = map (unFunctionName . grinFunctionName) (grinFunctions program)
+        assertEqual "lint" [] (lintProgram program)
+        assertBool "retains the argument-changing wrapper" (any ("$fApplicativeIO_closure_" `T.isPrefixOf`) generatedNames),
+      testCase "FC lowering names local helpers after their Core provenance" $ do
+        let program = lowerProgram provenanceNamingProgram
+            generatedNames = map (unFunctionName . grinFunctionName) (grinFunctions program)
+        assertEqual "lint" [] (lintProgram program)
+        assertBool "names the returned closure after its owner" (any ("owner_closure_" `T.isPrefixOf`) generatedNames)
+        assertBool "names the local thunk after its binder" (any ("delayed_thunk_" `T.isPrefixOf`) generatedNames)
+        assertBool "names helpers inside the thunk after its binder" (any ("delayed_closure_" `T.isPrefixOf`) generatedNames)
+        assertBool "emits no anonymous closure names" (not (any (T.isPrefixOf "$grin_closure_") generatedNames))
+        assertBool "emits no anonymous thunk names" (not (any (T.isPrefixOf "$grin_thunk_") generatedNames)),
+      testCase "FC lowering flattens lambdas hidden by cast aliases" $ do
+        let program = lowerProgram castAliasClosureProgram
+            closureFunctions = [function | function <- grinFunctions program, "dictionary_closure_" `T.isPrefixOf` unFunctionName (grinFunctionName function)]
+            storedClosures =
+              [ layouts
+              | function <- grinFunctions program,
+                GrinNode (GrinClosure _ layouts) _ <- expressionStoredNodes (grinFunctionBody function)
+              ]
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual "one flattened closure entry" 1 (length closureFunctions)
+        assertEqual "two logical arguments" [2] (map length storedClosures),
+      testCase "FC lowering preserves computed-let closure boundaries" $ do
+        let program = lowerProgram computedLetClosureProgram
+            closureFunctions = [function | function <- grinFunctions program, "dictionary_closure_" `T.isPrefixOf` unFunctionName (grinFunctionName function)]
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual "two closure entries around computed work" 2 (length closureFunctions),
+      testCase "FC lowering avoids outlining an immediately forced and discarded let" $ do
+        let program = lowerProgram immediatelyForcedLetProgram
+            ownerFunctions = [function | function <- grinFunctions program, grinFunctionLinkName function == Just "forceOnce"]
+            thunkNames = [grinFunctionName function | function <- grinFunctions program, "delayed_thunk_" `T.isPrefixOf` unFunctionName (grinFunctionName function)]
+        assertEqual "lint" [] (lintProgram program)
+        case (ownerFunctions, thunkNames) of
+          ([_], []) -> pure ()
+          _ -> assertFailure ("expected one owner and no local thunk entry, got " <> show (length ownerFunctions, length thunkNames)),
+      testCase "FC lowering retains an immediately forced thunk cell when it remains shared" $ do
+        let program = lowerProgram sharedForcedLetProgram
+            ownerFunctions = [function | function <- grinFunctions program, grinFunctionLinkName function == Just "forceShared"]
+            thunkNames = [grinFunctionName function | function <- grinFunctions program, "delayed_thunk_" `T.isPrefixOf` unFunctionName (grinFunctionName function)]
+        assertEqual "lint" [] (lintProgram program)
+        case (ownerFunctions, thunkNames) of
+          ([owner], [thunkName]) -> do
+            assertBool "retains the shared thunk cell" (any (isNamedThunkNode thunkName) (expressionStoredNodes (grinFunctionBody owner)))
+            assertBool "does not bypass the shared cell" (thunkName `notElem` expressionCalledFunctions (grinFunctionBody owner))
+          _ -> assertFailure ("expected one owner and one local thunk entry, got " <> show (length ownerFunctions, length thunkNames)),
       testCase "recursive function bindings store closures without thunk wrappers" $ do
         let program = lowerProgram recursiveFunctionProgram
             recursiveNodes =
@@ -443,6 +512,39 @@ ensureHeapReservations expression =
     GrinStoreRecUnchecked _ body -> ensureHeapReservations body
     GrinCase _ _ alternatives -> concatMap (ensureHeapReservations . grinAltRhs) alternatives
     _ -> []
+
+expressionStoredNodes :: GrinExpr -> [GrinNode]
+expressionStoredNodes expression =
+  case expression of
+    GrinBind _ valueExpression body -> expressionStoredNodes valueExpression <> expressionStoredNodes body
+    GrinStore node -> [node]
+    GrinStoreUnchecked node -> [node]
+    GrinStoreRec bindings body -> map snd bindings <> expressionStoredNodes body
+    GrinStoreRecUnchecked bindings body -> map snd bindings <> expressionStoredNodes body
+    GrinCase _ _ alternatives -> concatMap (expressionStoredNodes . grinAltRhs) alternatives
+    _ -> []
+
+expressionCalledFunctions :: GrinExpr -> [FunctionName]
+expressionCalledFunctions expression =
+  case expression of
+    GrinBind _ valueExpression body -> expressionCalledFunctions valueExpression <> expressionCalledFunctions body
+    GrinStoreRec _ body -> expressionCalledFunctions body
+    GrinStoreRecUnchecked _ body -> expressionCalledFunctions body
+    GrinCall _ functionName _ -> [functionName]
+    GrinCase _ _ alternatives -> concatMap (expressionCalledFunctions . grinAltRhs) alternatives
+    _ -> []
+
+isThunkNode :: GrinNode -> Bool
+isThunkNode node =
+  case grinNodeTag node of
+    GrinThunk {} -> True
+    _ -> False
+
+isNamedThunkNode :: FunctionName -> GrinNode -> Bool
+isNamedThunkNode expected node =
+  case grinNodeTag node of
+    GrinThunk actual -> actual == expected
+    _ -> False
 
 continuationHasCaptures :: GrinFunction -> Bool
 continuationHasCaptures function =
@@ -630,6 +732,123 @@ applicationProgram =
     answerVar = Var "answer" (Unique 1) boxedIntTy
     argumentVar = Var "argument" (Unique 2) boxedIntTy
     boxConstructorVar = Var "BoxedInt" (Unique 3) (TcFunTy intTy boxedIntTy)
+
+provenanceNamingProgram :: FcProgram
+provenanceNamingProgram =
+  FcProgram
+    [ FcTopBind
+        ( FcNonRec
+            ownerVar
+            ( FcLam
+                inputVar
+                ( FcLet
+                    ( FcNonRec
+                        delayedVar
+                        (FcApp (FcLam evaluatedVar (FcVar evaluatedVar)) (FcVar inputVar))
+                    )
+                    (FcLam returnedVar (FcVar returnedVar))
+                )
+            )
+        )
+    ]
+  where
+    functionTy = TcFunTy boxedIntTy boxedIntTy
+    ownerVar = Var "owner" (Unique 160) (TcFunTy boxedIntTy functionTy)
+    inputVar = Var "input" (Unique 161) boxedIntTy
+    delayedVar = Var "delayed" (Unique 162) boxedIntTy
+    evaluatedVar = Var "evaluated" (Unique 163) boxedIntTy
+    returnedVar = Var "returned" (Unique 164) boxedIntTy
+
+castAliasClosureProgram :: FcProgram
+castAliasClosureProgram = hiddenLambdaProgram castAlias
+  where
+    firstVar = Var "first" (Unique 172) boxedIntTy
+    castAlias = FcCast (FcVar firstVar) (AxiomInstCo "FunctionWrapper" [])
+
+computedLetClosureProgram :: FcProgram
+computedLetClosureProgram = hiddenLambdaProgram computed
+  where
+    unaryFunctionTy = TcFunTy boxedIntTy boxedIntTy
+    evaluatedVar = Var "evaluated" (Unique 175) unaryFunctionTy
+    parameterVar = Var "parameter" (Unique 176) boxedIntTy
+    computed = FcApp (FcLam evaluatedVar (FcVar evaluatedVar)) (FcLam parameterVar (FcVar parameterVar))
+
+hiddenLambdaProgram :: FcExpr -> FcProgram
+hiddenLambdaProgram aliasRhs =
+  FcProgram
+    [ FcData "Holder" [] [("Holder", [binaryFunctionTy])],
+      FcTopBind
+        ( FcNonRec
+            dictionaryVar
+            (FcApp (FcVar holderVar) castHiddenLambda)
+        )
+    ]
+  where
+    binaryFunctionTy = TcFunTy boxedIntTy (TcFunTy boxedIntTy boxedIntTy)
+    unaryFunctionTy = TcFunTy boxedIntTy boxedIntTy
+    holderTy = TcTyCon (TyCon "Holder" 0) []
+    dictionaryVar = Var "dictionary" (Unique 170) holderTy
+    holderVar = Var "Holder" (Unique 171) (TcFunTy binaryFunctionTy holderTy)
+    firstVar = Var "first" (Unique 172) boxedIntTy
+    aliasVar = Var "alias" (Unique 173) unaryFunctionTy
+    secondVar = Var "second" (Unique 174) boxedIntTy
+    castHiddenLambda =
+      FcLam firstVar $
+        FcLet
+          (FcNonRec aliasVar aliasRhs)
+          (FcCast (FcLam secondVar (FcApp (FcVar aliasVar) (FcVar secondVar))) (Refl unaryFunctionTy))
+
+immediatelyForcedLetProgram :: FcProgram
+immediatelyForcedLetProgram =
+  FcProgram
+    [ FcTopBind
+        ( FcNonRec
+            ownerVar
+            ( FcLam inputVar $
+                FcLet
+                  (FcNonRec delayedVar computedFunction)
+                  (FcApp (FcVar delayedVar) (FcVar inputVar))
+            )
+        )
+    ]
+  where
+    unaryFunctionTy = TcFunTy boxedIntTy boxedIntTy
+    ownerVar = Var "forceOnce" (Unique 180) unaryFunctionTy
+    inputVar = Var "input" (Unique 181) boxedIntTy
+    delayedVar = Var "delayed" (Unique 182) unaryFunctionTy
+    identityVar = Var "identity" (Unique 183) unaryFunctionTy
+    argumentVar = Var "argument" (Unique 184) boxedIntTy
+    computedFunction = FcApp (FcLam identityVar (FcVar identityVar)) (FcLam argumentVar (FcVar argumentVar))
+
+sharedForcedLetProgram :: FcProgram
+sharedForcedLetProgram =
+  FcProgram
+    [ FcData "FunctionPair" [] [("FunctionPair", [unaryFunctionTy, unaryFunctionTy])],
+      FcTopBind
+        ( FcNonRec
+            ownerVar
+            ( FcLam inputVar $
+                FcLet
+                  (FcNonRec delayedVar computedFunction)
+                  ( FcCase
+                      (FcVar delayedVar)
+                      evaluatedVar
+                      [FcAlt DefaultAlt [] (FcApp (FcApp (FcVar pairVar) (FcVar evaluatedVar)) (FcVar delayedVar))]
+                  )
+            )
+        )
+    ]
+  where
+    unaryFunctionTy = TcFunTy boxedIntTy boxedIntTy
+    pairTy = TcTyCon (TyCon "FunctionPair" 0) []
+    ownerVar = Var "forceShared" (Unique 185) (TcFunTy boxedIntTy pairTy)
+    inputVar = Var "input" (Unique 186) boxedIntTy
+    delayedVar = Var "delayed" (Unique 187) unaryFunctionTy
+    identityVar = Var "identity" (Unique 188) unaryFunctionTy
+    argumentVar = Var "argument" (Unique 189) boxedIntTy
+    evaluatedVar = Var "evaluated" (Unique 190) unaryFunctionTy
+    pairVar = Var "FunctionPair" (Unique 191) (TcFunTy unaryFunctionTy (TcFunTy unaryFunctionTy pairTy))
+    computedFunction = FcApp (FcLam identityVar (FcVar identityVar)) (FcLam argumentVar (FcVar argumentVar))
 
 unboxedApplicationProgram :: FcProgram
 unboxedApplicationProgram =
@@ -832,6 +1051,44 @@ functionClassificationProgram =
     computedArgumentVar = Var "argument" (Unique 35) boxedIntTy
     computedVar = Var "computed" (Unique 36) (TcFunTy boxedIntTy boxedIntTy)
     boxConstructorVar = Var "BoxedInt" (Unique 37) (TcFunTy intTy boxedIntTy)
+
+etaExpandedKnownFunctionProgram :: FcProgram
+etaExpandedKnownFunctionProgram = knownFunctionWrapperProgram True
+
+nonEtaExpandedKnownFunctionProgram :: FcProgram
+nonEtaExpandedKnownFunctionProgram = knownFunctionWrapperProgram False
+
+knownFunctionWrapperProgram :: Bool -> FcProgram
+knownFunctionWrapperProgram isEtaExpansion =
+  FcProgram
+    [ FcData "Applicative" [] [("$Dict$Applicative", [unaryFunctionTy])],
+      FcTopBind
+        ( FcNonRec
+            pureIoVar
+            (FcLam pureValueVar (FcLam stateVar (FcVar pureValueVar)))
+        ),
+      FcTopBind
+        ( FcNonRec
+            dictionaryVar
+            ( FcApp
+                (FcVar dictionaryConstructorVar)
+                (FcLam valueVar (FcApp (FcVar pureIoVar) argument))
+            )
+        )
+    ]
+  where
+    unaryFunctionTy = TcFunTy boxedIntTy boxedIntTy
+    pureIoTy = TcFunTy boxedIntTy unaryFunctionTy
+    dictionaryTy = TcTyCon (TyCon "Applicative" 0) []
+    pureIoVar = Var "pureIO" (Unique 140) pureIoTy
+    pureValueVar = Var "value" (Unique 141) boxedIntTy
+    stateVar = Var "state" (Unique 142) boxedIntTy
+    dictionaryVar = Var "$fApplicativeIO" (Unique 143) dictionaryTy
+    dictionaryConstructorVar = Var "$Dict$Applicative" (Unique 144) (TcFunTy unaryFunctionTy dictionaryTy)
+    valueVar = Var "value" (Unique 145) boxedIntTy
+    argument
+      | isEtaExpansion = FcVar valueVar
+      | otherwise = FcLit (LitString "changed")
 
 dictionaryProgram :: FcProgram
 dictionaryProgram =

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -1,9 +1,9 @@
 expected: |-
   constructor IS/1 [IntRep]
 
-  caf value%1003 :: BoxedRep Lifted = (F$grin_thunk_0)
+  caf value%1003 :: BoxedRep Lifted = (Fvalue_thunk)
 
-  $grin_thunk_0 -> BoxedRep Lifted =
+  value_thunk -> BoxedRep Lifted =
     store (CIS 42)
 extensions:
   - MagicHash

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -1,9 +1,9 @@
 expected: |-
   constructor Box/1 [IntRep]
 
-  caf value%1005 :: BoxedRep Lifted = (F$grin_thunk_0)
+  caf value%1005 :: BoxedRep Lifted = (Fvalue_thunk)
 
-  $grin_thunk_0 -> BoxedRep Lifted =
+  value_thunk -> BoxedRep Lifted =
     $grin_argument_1006%1006 :: IntRep <-
       $grin_tuple_1007%1007 :: IntRep, $grin_tuple_1008%1008 :: WordRep <-
         constant 1 2

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -3,9 +3,9 @@ expected: |-
 
   primitive realWorld#%1000 :: BoxedRep Lifted/0
 
-  caf value%1007 :: BoxedRep Lifted = (F$grin_thunk_0)
+  caf value%1007 :: BoxedRep Lifted = (Fvalue_thunk)
 
-  $grin_thunk_0 -> BoxedRep Lifted =
+  value_thunk -> BoxedRep Lifted =
     $grin_argument_1008%1008 :: IntRep <-
       constant 42
     store (CBox ($grin_argument_1008%1008 :: IntRep))


### PR DESCRIPTION
## Summary

- add a small monotone System FC optimization framework that runs copy propagation to a fixpoint across compilation and evaluation entry points
- give generated GRIN thunks and closures source-provenance names, eliminate known-function eta wrappers, and flatten lambdas hidden by allocation-free cast aliases
- directly lower immediately forced, dead lifted bindings without allocating a thunk cell or outlining a helper, while preserving updateable cells when sharing remains observable
- centralize GRIN free-variable analysis for lowering, CPS conversion, and GC root analysis

## Root cause

GRIN helper names came from a global anonymous counter, making generated code difficult to relate to Core. Separately, administrative Core lets and representational casts obscured lambda structure and routed one-shot computations through the generic thunk path. That produced wrapper entries, avoidable closure boundaries, and store/eval sequences even when the pointer was immediately forced and dead.

## Impact

Generated GRIN now follows Core provenance more closely and contains fewer indirections, allocations, and outlined one-use helpers. The lowering remains conservative around computed lets and shared thunk pointers.

## Progress counts

- added 5 FC regression cases; the FC suite now contains 109 tests
- added 8 GRIN regression cases; the GRIN suite now contains 138 tests
- README progress counts were intentionally left unchanged

## Validation

- `just fmt`
- `just check`
- compiled and ran `examples/hello-world/Main.hs`; output remains `Hello, world!`
