### PR TITLE
test(grin): track native snapshot allocations

### DIFF
--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -175,10 +175,13 @@ compileObservedFunction entryName gcProgram = do
                  "  call aihc_alloc_locals",
                  storeByteOffset "r13" "rax" 0,
                  storeByteOffset "rax" "r15" 0,
+                 "  mov rdi, r15",
+                 "  call aihc_reset_allocation_count",
                  "  jmp " <> entryLabel,
                  ".p2align 3",
                  ".Laihc_snapshot_result:",
                  loadByteOffset "rsi" "r15" 0,
+                 "  mov rdx, r15",
                  immediate "rdi" resultCount,
                  "  call aihc_snapshot_dump_result",
                  "  xor eax, eax"
@@ -1422,8 +1425,9 @@ renderObservedMetadata env program resultReps = do
       <> renderRepDeclaration "result_reps" renderedResultReps
       <> renderConstructorTable constructors
       <> renderFunctionTable functions
-      <> [ "void aihc_snapshot_dump_result(uint64_t count, const AihcSlot *values) {",
+      <> [ "void aihc_snapshot_dump_result(uint64_t count, const AihcSlot *values, const AihcMachine *machine) {",
            "  aihc_snapshot_dump(count, values, " <> pointerOrNull renderedResultReps "result_reps" <> ",",
+           "                     aihc_allocation_count(machine),",
            "                     " <> tshow (length constructors) <> ", " <> tableOrNull constructors "constructors" <> ",",
            "                     " <> tshow (length functions) <> ", " <> tableOrNull functions "functions" <> ");",
            "}"

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -171,7 +171,8 @@ compileObservedFunction entryName gcProgram = do
                ]
             <> makeNodeLines runtimeTagClosure (InfoAddress ".Laihc_snapshot_info")
             <> [ "  mov r13, rax",
-                 immediate "rdi" (1 :: Int),
+                 immediate "rsi" (1 :: Int),
+                 "  mov rdi, r15",
                  "  call aihc_alloc_locals",
                  storeByteOffset "r13" "rax" 0,
                  storeByteOffset "rax" "r15" 0,
@@ -504,7 +505,8 @@ compileFunction env function = do
         exportLines env function label
           <> [ ".p2align 3",
                label <> ":",
-               immediate "rdi" slotCount,
+               immediate "rsi" slotCount,
+               "  mov rdi, r15",
                "  call aihc_alloc_locals",
                "  mov r14, rax",
                loadByteOffset "r12" "r15" 0

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -33,6 +33,7 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
+import Data.Word (Word64)
 import Data.Yaml qualified as Y
 import System.Directory (createDirectory, doesDirectoryExist, getCurrentDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
@@ -346,7 +347,7 @@ data SnapshotCase = SnapshotCase
   }
 
 data SnapshotExpectation
-  = SnapshotSuccess !T.Text
+  = SnapshotSuccess !T.Text !Word64
   | SnapshotFailure !T.Text
 
 data SnapshotFixture = SnapshotFixture
@@ -355,6 +356,7 @@ data SnapshotFixture = SnapshotFixture
     snapshotFixtureReturn :: !(Maybe T.Text),
     snapshotFixtureHeap :: !(Maybe T.Text),
     snapshotFixtureError :: !(Maybe T.Text),
+    snapshotFixtureAllocations :: !(Maybe (Map.Map T.Text Word64)),
     snapshotFixtureStatus :: !T.Text,
     snapshotFixtureReason :: !T.Text
   }
@@ -368,6 +370,7 @@ instance FromJSON SnapshotFixture where
         <*> object .:? "return"
         <*> object .:? "heap"
         <*> object .:? "error"
+        <*> object .:? "allocations"
         <*> object .: "status"
         <*> object .: "reason"
 
@@ -378,6 +381,7 @@ snapshotCases =
     ("stores linked values", "store-linked.yaml"),
     ("stores a self-referential value", "store-self-referential.yaml"),
     ("returns an unboxed value", "return-unboxed.yaml"),
+    ("loops ten million times without allocating", "loop-add.yaml"),
     ("evaluates only through GrinEval", "eval.yaml"),
     ("preserves WHNF pointers through GrinEval", "eval-whnf.yaml"),
     ("rejects blackholed thunk re-entry", "eval-blackhole.yaml"),
@@ -409,11 +413,11 @@ snapshotTest (name, fixtureName) =
 assertInterpretedExpectation :: SnapshotExpectation -> Either InterpretError HeapSnapshot -> IO ()
 assertInterpretedExpectation expectation interpreted =
   case (expectation, interpreted) of
-    (SnapshotSuccess expected, Right snapshot) ->
+    (SnapshotSuccess expected _, Right snapshot) ->
       assertEqual "interpreter snapshot" (T.stripEnd expected) (T.stripEnd (renderHeapSnapshot snapshot))
     (SnapshotFailure expected, Left err) ->
       assertEqual "interpreter error" expected (renderInterpretFailure err)
-    (SnapshotSuccess _, Left err) ->
+    (SnapshotSuccess _ _, Left err) ->
       assertFailure ("GRIN interpreter failed: " <> show err)
     (SnapshotFailure _, Right snapshot) ->
       assertFailure ("GRIN interpreter unexpectedly succeeded:\n" <> T.unpack (renderHeapSnapshot snapshot))
@@ -421,11 +425,14 @@ assertInterpretedExpectation expectation interpreted =
 assertNativeExpectation :: SnapshotExpectation -> Either T.Text T.Text -> IO ()
 assertNativeExpectation expectation native =
   case (expectation, native) of
-    (SnapshotSuccess expected, Right snapshot) ->
-      assertEqual "native snapshot" (T.stripEnd expected) (T.stripEnd snapshot)
+    (SnapshotSuccess expected expectedAllocations, Right snapshot) ->
+      assertEqual
+        "native snapshot"
+        (T.stripEnd expected <> "\nallocations: " <> T.pack (show expectedAllocations))
+        (T.stripEnd snapshot)
     (SnapshotFailure expected, Left err) ->
       assertEqual "native error" expected err
-    (SnapshotSuccess _, Left err) ->
+    (SnapshotSuccess _ _, Left err) ->
       assertFailure ("native snapshot failed: " <> T.unpack err)
     (SnapshotFailure _, Right snapshot) ->
       assertFailure ("native snapshot unexpectedly succeeded:\n" <> T.unpack snapshot)
@@ -461,9 +468,15 @@ loadSnapshotCase name fixtureName = do
                     <> returnValue
                     <> "\nheap:\n"
                     <> T.unlines (map ("  " <>) (T.lines heap))
-        pure (SnapshotSuccess expected)
+        allocations <-
+          case snapshotFixtureAllocations fixture >>= Map.lookup "linux-amd64" of
+            Just count -> pure count
+            Nothing -> assertFailure "successful snapshot fixture must define allocations.linux-amd64"
+        pure (SnapshotSuccess expected allocations)
       (Nothing, Nothing, Just err)
-        | not (T.null (T.strip err)) -> pure (SnapshotFailure (T.strip err))
+        | not (T.null (T.strip err)) -> do
+            assertEqual "failing snapshot allocations" Nothing (snapshotFixtureAllocations fixture)
+            pure (SnapshotFailure (T.strip err))
       _ -> assertFailure "snapshot fixture must define either return and heap, or a non-empty error"
   pure
     SnapshotCase

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -381,7 +381,7 @@ snapshotCases =
     ("stores linked values", "store-linked.yaml"),
     ("stores a self-referential value", "store-self-referential.yaml"),
     ("returns an unboxed value", "return-unboxed.yaml"),
-    ("loops ten million times without allocating", "loop-add.yaml"),
+    ("loops ten million times", "loop-add.yaml"),
     ("evaluates only through GrinEval", "eval.yaml"),
     ("preserves WHNF pointers through GrinEval", "eval-whnf.yaml"),
     ("rejects blackholed thunk re-entry", "eval-blackhole.yaml"),

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -139,7 +139,7 @@ tests =
         assertBool "emits a wrapping 64-bit add" ("  add rax, r10" `T.isInfixOf` observedAssembly observed)
         when (arch == "x86_64" && os == "linux") $ do
           native <- runObservedProgram observed
-          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\n") native,
+          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\nallocations: 2\n") native,
       testCase "emits boundary integer literals in machine-word slots" $ do
         let functionName = FunctionName "narrow_code"
             program =

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -172,10 +172,13 @@ compileObservedFunction entryName gcProgram = do
                  "  bl _aihc_alloc_locals",
                  "  str x21, [x0]",
                  "  str x0, [x22, #0]",
+                 "  mov x0, x22",
+                 "  bl _aihc_reset_allocation_count",
                  "  b " <> entryLabel,
                  ".p2align 3",
                  ".Laihc_snapshot_result:",
                  "  ldr x1, [x22, #0]",
+                 "  mov x2, x22",
                  immediate "x0" resultCount,
                  "  bl _aihc_snapshot_dump_result",
                  "  mov w0, #0",
@@ -1404,8 +1407,9 @@ renderObservedMetadata env program resultReps = do
       <> renderRepDeclaration "result_reps" renderedResultReps
       <> renderConstructorTable constructors
       <> renderFunctionTable functions
-      <> [ "void aihc_snapshot_dump_result(uint64_t count, const AihcSlot *values) {",
+      <> [ "void aihc_snapshot_dump_result(uint64_t count, const AihcSlot *values, const AihcMachine *machine) {",
            "  aihc_snapshot_dump(count, values, " <> pointerOrNull renderedResultReps "result_reps" <> ",",
+           "                     aihc_allocation_count(machine),",
            "                     " <> tshow (length constructors) <> ", " <> tableOrNull constructors "constructors" <> ",",
            "                     " <> tshow (length functions) <> ", " <> tableOrNull functions "functions" <> ");",
            "}"

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -168,7 +168,8 @@ compileObservedFunction entryName gcProgram = do
                ]
             <> makeNodeLines runtimeTagClosure (InfoAddress ".Laihc_snapshot_info")
             <> [ "  mov x21, x0",
-                 immediate "x0" (1 :: Int),
+                 immediate "x1" (1 :: Int),
+                 "  mov x0, x22",
                  "  bl _aihc_alloc_locals",
                  "  str x21, [x0]",
                  "  str x0, [x22, #0]",
@@ -489,7 +490,8 @@ compileFunction env function = do
         exportLines env function label
           <> [ ".p2align 3",
                label <> ":",
-               immediate "x0" slotCount,
+               immediate "x1" slotCount,
+               "  mov x0, x22",
                "  bl _aihc_alloc_locals",
                "  mov x19, x0",
                "  ldr x8, [x22, #0]"

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -33,6 +33,7 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
+import Data.Word (Word64)
 import Data.Yaml qualified as Y
 import System.Directory (createDirectory, doesDirectoryExist, getCurrentDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.Exit (ExitCode (..))
@@ -138,7 +139,7 @@ tests =
         assertBool "emits a wrapping 64-bit add" ("  add x0, x1, x0" `T.isInfixOf` observedAssembly observed)
         when (arch == "aarch64" && os == "darwin") $ do
           native <- runObservedProgram observed
-          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\n") native,
+          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\nallocations: 0\n") native,
       testCase "canonicalizes narrow signed literals in machine-word slots" $ do
         let functionName = FunctionName "narrow_code"
             program =
@@ -441,7 +442,7 @@ data SnapshotCase = SnapshotCase
   }
 
 data SnapshotExpectation
-  = SnapshotSuccess !T.Text
+  = SnapshotSuccess !T.Text !Word64
   | SnapshotFailure !T.Text
 
 data SnapshotFixture = SnapshotFixture
@@ -450,6 +451,7 @@ data SnapshotFixture = SnapshotFixture
     snapshotFixtureReturn :: !(Maybe T.Text),
     snapshotFixtureHeap :: !(Maybe T.Text),
     snapshotFixtureError :: !(Maybe T.Text),
+    snapshotFixtureAllocations :: !(Maybe (Map.Map T.Text Word64)),
     snapshotFixtureStatus :: !T.Text,
     snapshotFixtureReason :: !T.Text
   }
@@ -463,6 +465,7 @@ instance FromJSON SnapshotFixture where
         <*> object .:? "return"
         <*> object .:? "heap"
         <*> object .:? "error"
+        <*> object .:? "allocations"
         <*> object .: "status"
         <*> object .: "reason"
 
@@ -473,6 +476,7 @@ snapshotCases =
     ("stores linked values", "store-linked.yaml"),
     ("stores a self-referential value", "store-self-referential.yaml"),
     ("returns an unboxed value", "return-unboxed.yaml"),
+    ("loops ten million times without allocating", "loop-add.yaml"),
     ("evaluates only through GrinEval", "eval.yaml"),
     ("preserves WHNF pointers through GrinEval", "eval-whnf.yaml"),
     ("rejects blackholed thunk re-entry", "eval-blackhole.yaml"),
@@ -504,11 +508,11 @@ snapshotTest (name, fixtureName) =
 assertInterpretedExpectation :: SnapshotExpectation -> Either InterpretError HeapSnapshot -> IO ()
 assertInterpretedExpectation expectation interpreted =
   case (expectation, interpreted) of
-    (SnapshotSuccess expected, Right snapshot) ->
+    (SnapshotSuccess expected _, Right snapshot) ->
       assertEqual "interpreter snapshot" (T.stripEnd expected) (T.stripEnd (renderHeapSnapshot snapshot))
     (SnapshotFailure expected, Left err) ->
       assertEqual "interpreter error" expected (renderInterpretFailure err)
-    (SnapshotSuccess _, Left err) ->
+    (SnapshotSuccess _ _, Left err) ->
       assertFailure ("GRIN interpreter failed: " <> show err)
     (SnapshotFailure _, Right snapshot) ->
       assertFailure ("GRIN interpreter unexpectedly succeeded:\n" <> T.unpack (renderHeapSnapshot snapshot))
@@ -516,11 +520,14 @@ assertInterpretedExpectation expectation interpreted =
 assertNativeExpectation :: SnapshotExpectation -> Either T.Text T.Text -> IO ()
 assertNativeExpectation expectation native =
   case (expectation, native) of
-    (SnapshotSuccess expected, Right snapshot) ->
-      assertEqual "native snapshot" (T.stripEnd expected) (T.stripEnd snapshot)
+    (SnapshotSuccess expected expectedAllocations, Right snapshot) ->
+      assertEqual
+        "native snapshot"
+        (T.stripEnd expected <> "\nallocations: " <> T.pack (show expectedAllocations))
+        (T.stripEnd snapshot)
     (SnapshotFailure expected, Left err) ->
       assertEqual "native error" expected err
-    (SnapshotSuccess _, Left err) ->
+    (SnapshotSuccess _ _, Left err) ->
       assertFailure ("native snapshot failed: " <> T.unpack err)
     (SnapshotFailure _, Right snapshot) ->
       assertFailure ("native snapshot unexpectedly succeeded:\n" <> T.unpack snapshot)
@@ -556,9 +563,15 @@ loadSnapshotCase name fixtureName = do
                     <> returnValue
                     <> "\nheap:\n"
                     <> T.unlines (map ("  " <>) (T.lines heap))
-        pure (SnapshotSuccess expected)
+        allocations <-
+          case snapshotFixtureAllocations fixture >>= Map.lookup "macos-arm64" of
+            Just count -> pure count
+            Nothing -> assertFailure "successful snapshot fixture must define allocations.macos-arm64"
+        pure (SnapshotSuccess expected allocations)
       (Nothing, Nothing, Just err)
-        | not (T.null (T.strip err)) -> pure (SnapshotFailure (T.strip err))
+        | not (T.null (T.strip err)) -> do
+            assertEqual "failing snapshot allocations" Nothing (snapshotFixtureAllocations fixture)
+            pure (SnapshotFailure (T.strip err))
       _ -> assertFailure "snapshot fixture must define either return and heap, or a non-empty error"
   pure
     SnapshotCase

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -139,7 +139,7 @@ tests =
         assertBool "emits a wrapping 64-bit add" ("  add x0, x1, x0" `T.isInfixOf` observedAssembly observed)
         when (arch == "aarch64" && os == "darwin") $ do
           native <- runObservedProgram observed
-          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\nallocations: 0\n") native,
+          assertEqual "native result" (Right "return: -9223372036854775808\nheap: []\nallocations: 2\n") native,
       testCase "canonicalizes narrow signed literals in machine-word slots" $ do
         let functionName = FunctionName "narrow_code"
             program =
@@ -476,7 +476,7 @@ snapshotCases =
     ("stores linked values", "store-linked.yaml"),
     ("stores a self-referential value", "store-self-referential.yaml"),
     ("returns an unboxed value", "return-unboxed.yaml"),
-    ("loops ten million times without allocating", "loop-add.yaml"),
+    ("loops ten million times", "loop-add.yaml"),
     ("evaluates only through GrinEval", "eval.yaml"),
     ("preserves WHNF pointers through GrinEval", "eval-whnf.yaml"),
     ("rejects blackholed thunk re-entry", "eval-blackhole.yaml"),

--- a/components/aihc-c/src/Aihc/C/Codegen.hs
+++ b/components/aihc-c/src/Aihc/C/Codegen.hs
@@ -323,7 +323,7 @@ compileFunction env function = do
       blocks = concatMap renderBlock (reverse (functionBlocksRev final))
   pure
     ( [ functionStorage function <> "void " <> label <> "(void) {",
-        "  AihcSlot *locals = aihc_alloc_locals(" <> tshow slotCount <> ");",
+        "  AihcSlot *locals = aihc_alloc_locals(aihc_machine, " <> tshow slotCount <> ");",
         "  AihcSlot aihc_scratch = 0;"
       ]
         <> ["  (void)aihc_scratch;"]

--- a/components/aihc-native/runtime/aihc_runtime.c
+++ b/components/aihc-native/runtime/aihc_runtime.c
@@ -244,6 +244,7 @@ AihcValue *aihc_make_node_unchecked(AihcMachine *machine, uint64_t tag,
 #else
 #error "unknown AIHC_GC selection"
 #endif
+  ++machine->allocation_count;
   value->header = aihc_make_header(tag, info);
   return value;
 }
@@ -253,6 +254,14 @@ AihcValue *aihc_make_node(AihcMachine *machine, uint64_t tag,
   uint64_t words = aihc_object_words(tag, info);
   aihc_ensure_heap(machine, words, 0, NULL);
   return aihc_make_node_unchecked(machine, tag, info);
+}
+
+uint64_t aihc_allocation_count(const AihcMachine *machine) {
+  return machine->allocation_count;
+}
+
+void aihc_reset_allocation_count(AihcMachine *machine) {
+  machine->allocation_count = 0;
 }
 
 static const AihcInfo *aihc_next_application_info(const AihcInfo *info,

--- a/components/aihc-native/runtime/aihc_runtime.c
+++ b/components/aihc-native/runtime/aihc_runtime.c
@@ -47,11 +47,24 @@ void aihc_unsupported_primitive(void) {
   aihc_fail("primitive is not implemented by the native runtime");
 }
 
-static void *aihc_allocate_auxiliary(size_t bytes) {
+static void aihc_record_allocation(AihcMachine *machine) {
+  if (machine->allocation_count == UINT64_MAX) {
+    aihc_fail("allocation counter overflow");
+  }
+  ++machine->allocation_count;
+}
+
+static void *aihc_allocate_zeroed(size_t bytes) {
   void *pointer = calloc(1, bytes);
   if (pointer == NULL) {
     aihc_fail("out of memory");
   }
+  return pointer;
+}
+
+static void *aihc_allocate_auxiliary(AihcMachine *machine, size_t bytes) {
+  void *pointer = aihc_allocate_zeroed(bytes);
+  aihc_record_allocation(machine);
   return pointer;
 }
 
@@ -231,8 +244,7 @@ AihcValue *aihc_make_node_unchecked(AihcMachine *machine, uint64_t tag,
   uint64_t words = aihc_object_words(tag, info);
   AihcValue *value;
 #if AIHC_GC == AIHC_GC_CALLOC
-  (void)machine;
-  value = aihc_allocate_auxiliary(sizeof(AihcSlot) * words);
+  value = aihc_allocate_zeroed(sizeof(AihcSlot) * words);
 #elif AIHC_GC == AIHC_GC_SEMISPACE
   size_t bytes = sizeof(AihcSlot) * words;
   if (machine->heap_next + bytes > machine->heap_limit) {
@@ -244,7 +256,7 @@ AihcValue *aihc_make_node_unchecked(AihcMachine *machine, uint64_t tag,
 #else
 #error "unknown AIHC_GC selection"
 #endif
-  ++machine->allocation_count;
+  aihc_record_allocation(machine);
   value->header = aihc_make_header(tag, info);
   return value;
 }
@@ -324,8 +336,8 @@ static AihcValue *aihc_copy_with_fields(AihcMachine *machine,
   return copy;
 }
 
-static AihcSlot *aihc_arguments(AihcValue *function, uint64_t count,
-                                const AihcSlot *values,
+static AihcSlot *aihc_arguments(AihcMachine *machine, AihcValue *function,
+                                uint64_t count, const AihcSlot *values,
                                 AihcValue *continuation) {
   uint64_t field_count = aihc_value_info_table(function)->field_count;
   size_t maximum_count = SIZE_MAX / sizeof(AihcSlot);
@@ -339,8 +351,8 @@ static AihcSlot *aihc_arguments(AihcValue *function, uint64_t count,
     }
     ++total;
   }
-  AihcSlot *arguments =
-      aihc_allocate_auxiliary(sizeof(*arguments) * (total == 0 ? 1 : total));
+  AihcSlot *arguments = aihc_allocate_auxiliary(
+      machine, sizeof(*arguments) * (total == 0 ? 1 : total));
   const AihcSlot *function_fields = aihc_value_fields_const(function);
   for (size_t index = 0; index < (size_t)field_count; ++index) {
     arguments[index] = function_fields[index];
@@ -364,8 +376,8 @@ static AihcEntry aihc_prepare_entry(AihcMachine *machine, AihcEntry entry,
   return entry;
 }
 
-static AihcThread *aihc_thread_new(void) {
-  AihcThread *thread = aihc_allocate_auxiliary(sizeof(*thread));
+static AihcThread *aihc_thread_new(AihcMachine *machine) {
+  AihcThread *thread = aihc_allocate_auxiliary(machine, sizeof(*thread));
   thread->header = AIHC_TAG_THREAD;
   return thread;
 }
@@ -411,7 +423,8 @@ static AihcBlackhole *aihc_find_blackhole(AihcMachine *machine,
       return blackhole;
     }
   }
-  AihcBlackhole *blackhole = aihc_allocate_auxiliary(sizeof(*blackhole));
+  AihcBlackhole *blackhole =
+      aihc_allocate_auxiliary(machine, sizeof(*blackhole));
   blackhole->object = object;
   blackhole->owner = machine->current_thread;
   blackhole->next = machine->blackholes;
@@ -425,7 +438,8 @@ static void aihc_block_on_blackhole(AihcMachine *machine, AihcValue *object,
   if (blackhole->owner == machine->current_thread) {
     aihc_fail("blackholed thunk re-entered");
   }
-  AihcBlackholeWaiter *waiter = aihc_allocate_auxiliary(sizeof(*waiter));
+  AihcBlackholeWaiter *waiter =
+      aihc_allocate_auxiliary(machine, sizeof(*waiter));
   waiter->thread = machine->current_thread;
   waiter->continuation = continuation;
   if (blackhole->waiters_tail == NULL) {
@@ -455,26 +469,31 @@ void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field) {
 }
 
 AihcMachine *aihc_machine_new(uint64_t global_count) {
-  AihcMachine *machine = aihc_allocate_auxiliary(sizeof(*machine));
+  AihcMachine *machine = aihc_allocate_zeroed(sizeof(*machine));
+  machine->allocation_count = 1;
   machine->global_count = global_count;
   machine->globals = aihc_allocate_auxiliary(
+      machine,
       sizeof(*machine->globals) * (global_count == 0 ? 1 : global_count));
 #if AIHC_GC == AIHC_GC_CALLOC
   machine->heap_next = NULL;
   machine->heap_limit = (uint8_t *)UINTPTR_MAX;
 #elif AIHC_GC == AIHC_GC_SEMISPACE
   machine->semispace_bytes = AIHC_SEMISPACE_BYTES;
-  machine->heap_start = aihc_allocate_auxiliary(machine->semispace_bytes);
-  machine->other_space = aihc_allocate_auxiliary(machine->semispace_bytes);
+  machine->heap_start =
+      aihc_allocate_auxiliary(machine, machine->semispace_bytes);
+  machine->other_space =
+      aihc_allocate_auxiliary(machine, machine->semispace_bytes);
   machine->heap_next = machine->heap_start;
   machine->heap_limit = machine->heap_start + machine->semispace_bytes;
 #endif
-  machine->current_thread = aihc_thread_new();
+  machine->current_thread = aihc_thread_new(machine);
   return machine;
 }
 
-AihcSlot *aihc_alloc_locals(uint64_t count) {
-  return aihc_allocate_auxiliary(sizeof(AihcSlot) * (count == 0 ? 1 : count));
+AihcSlot *aihc_alloc_locals(AihcMachine *machine, uint64_t count) {
+  return aihc_allocate_auxiliary(machine,
+                                 sizeof(AihcSlot) * (count == 0 ? 1 : count));
 }
 
 void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
@@ -490,9 +509,10 @@ AihcEntry aihc_continue_values(AihcMachine *machine, AihcValue *continuation,
   }
   const AihcInfo *arguments_info =
       aihc_next_application_info(aihc_value_info_table(continuation), count);
-  return aihc_prepare_entry(machine, aihc_value_entry(continuation),
-                            aihc_arguments(continuation, count, values, NULL),
-                            arguments_info, 0);
+  return aihc_prepare_entry(
+      machine, aihc_value_entry(continuation),
+      aihc_arguments(machine, continuation, count, values, NULL),
+      arguments_info, 0);
 }
 
 static AihcEntry aihc_continue_value(AihcMachine *machine,
@@ -522,7 +542,7 @@ AihcEntry aihc_apply_cps(AihcMachine *machine, AihcValue *function,
         aihc_next_application_info(aihc_value_info_table(function), count);
     return aihc_prepare_entry(
         machine, aihc_value_entry(function),
-        aihc_arguments(function, count, arguments, continuation),
+        aihc_arguments(machine, function, count, arguments, continuation),
         arguments_info, continuation == NULL ? 0 : 1);
   }
   case AIHC_TAG_PARTIAL_CONSTRUCTOR: {
@@ -553,7 +573,8 @@ AihcEntry aihc_eval_cps(AihcMachine *machine, AihcValue *value,
   }
   switch (aihc_value_tag(value)) {
   case AIHC_TAG_THUNK: {
-    AihcSlot *arguments = aihc_arguments(value, 0, NULL, update_continuation);
+    AihcSlot *arguments =
+        aihc_arguments(machine, value, 0, NULL, update_continuation);
     AihcEntry entry = aihc_value_entry(value);
     const AihcInfo *arguments_info = aihc_value_info_table(value);
     value->header = (value->header & ~AIHC_TAG_MASK) | AIHC_TAG_BLACKHOLE;
@@ -612,7 +633,7 @@ AihcEntry aihc_fork_cps(AihcMachine *machine, AihcValue *action,
   if (machine->thread_done_continuation == NULL) {
     aihc_fail("thread completion continuation is not initialized");
   }
-  AihcThread *child = aihc_thread_new();
+  AihcThread *child = aihc_thread_new(machine);
   child->entry = aihc_apply_cps(machine, action, 0, NULL,
                                 machine->thread_done_continuation);
   child->args = machine->args;

--- a/components/aihc-native/runtime/aihc_runtime.h
+++ b/components/aihc-native/runtime/aihc_runtime.h
@@ -118,7 +118,7 @@ void aihc_ensure_heap(AihcMachine *machine, uint64_t words, uint64_t root_count,
 AihcMachine *aihc_machine_new(uint64_t global_count);
 uint64_t aihc_allocation_count(const AihcMachine *machine);
 void aihc_reset_allocation_count(AihcMachine *machine);
-AihcSlot *aihc_alloc_locals(uint64_t count);
+AihcSlot *aihc_alloc_locals(AihcMachine *machine, uint64_t count);
 void aihc_no_match(void);
 void aihc_unsupported_primitive(void);
 void aihc_set_field(AihcValue *value, uint64_t index, AihcSlot field);

--- a/components/aihc-native/runtime/aihc_runtime.h
+++ b/components/aihc-native/runtime/aihc_runtime.h
@@ -69,6 +69,7 @@ struct AihcMachine {
   AihcThread *run_queue_head;
   AihcThread *run_queue_tail;
   AihcBlackhole *blackholes;
+  uint64_t allocation_count;
 };
 
 _Static_assert(sizeof(AihcValue) == sizeof(AihcSlot),
@@ -115,6 +116,8 @@ AihcValue *aihc_make_node_unchecked(AihcMachine *machine, uint64_t tag,
 void aihc_ensure_heap(AihcMachine *machine, uint64_t words, uint64_t root_count,
                       AihcSlot *roots);
 AihcMachine *aihc_machine_new(uint64_t global_count);
+uint64_t aihc_allocation_count(const AihcMachine *machine);
+void aihc_reset_allocation_count(AihcMachine *machine);
 AihcSlot *aihc_alloc_locals(uint64_t count);
 void aihc_no_match(void);
 void aihc_unsupported_primitive(void);
@@ -174,7 +177,7 @@ typedef struct {
 
 void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
                         const AihcSnapshotRep *result_reps,
-                        uint64_t constructor_count,
+                        uint64_t allocation_count, uint64_t constructor_count,
                         const AihcSnapshotConstructor *constructors,
                         uint64_t function_count,
                         const AihcSnapshotFunction *functions);

--- a/components/aihc-native/runtime/aihc_snapshot.c
+++ b/components/aihc-native/runtime/aihc_snapshot.c
@@ -262,7 +262,7 @@ static void print_object(SnapshotState *state, const AihcValue *object) {
 
 void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
                         const AihcSnapshotRep *result_reps,
-                        uint64_t constructor_count,
+                        uint64_t allocation_count, uint64_t constructor_count,
                         const AihcSnapshotConstructor *constructors,
                         uint64_t function_count,
                         const AihcSnapshotFunction *functions) {
@@ -303,5 +303,6 @@ void aihc_snapshot_dump(uint64_t result_count, const AihcSlot *results,
       putchar('\n');
     }
   }
+  printf("allocations: %" PRIu64 "\n", allocation_count);
   free(state.objects);
 }

--- a/docs/grin-snapshot-tests.md
+++ b/docs/grin-snapshot-tests.md
@@ -19,8 +19,8 @@ return: "@0"
 heap: |
   @0 = CI32# 1
 allocations:
-  macos-arm64: 1
-  linux-amd64: 1
+  macos-arm64: 3
+  linux-amd64: 3
 status: pass
 reason: a stored constructor is returned as a location
 ```
@@ -52,11 +52,11 @@ Snapshotting reads heap objects but never enters them. A suspended thunk remains
 are recovered through descriptor tables generated beside the assembly, so
 snapshot output does not depend on debug symbols or raw addresses.
 
-Successful fixtures also record the number of logical heap objects allocated
-while the observed entry executes. The native harness resets the counter after
-creating its own continuations and initializing globals, then selects the
-expectation for its backend from `allocations`. Collector relocation and
-auxiliary C allocations do not increment this count. Interpreter execution
+Successful fixtures also record every managed-object and auxiliary C allocation
+made while the observed entry executes. The native harness resets the counter
+after creating its own continuations and initializing globals, then selects the
+expectation for its backend from `allocations`. This includes locals, argument
+vectors, thread records, blackhole records, and waiters. Interpreter execution
 does not check allocations.
 
 Fixtures may replace `return` and `heap` with an `error` expectation. These

--- a/docs/grin-snapshot-tests.md
+++ b/docs/grin-snapshot-tests.md
@@ -18,6 +18,9 @@ program: |
 return: "@0"
 heap: |
   @0 = CI32# 1
+allocations:
+  macos-arm64: 1
+  linux-amd64: 1
 status: pass
 reason: a stored constructor is returned as a location
 ```
@@ -49,6 +52,13 @@ Snapshotting reads heap objects but never enters them. A suspended thunk remains
 are recovered through descriptor tables generated beside the assembly, so
 snapshot output does not depend on debug symbols or raw addresses.
 
+Successful fixtures also record the number of logical heap objects allocated
+while the observed entry executes. The native harness resets the counter after
+creating its own continuations and initializing globals, then selects the
+expectation for its backend from `allocations`. Collector relocation and
+auxiliary C allocations do not increment this count. Interpreter execution
+does not check allocations.
+
 Fixtures may replace `return` and `heap` with an `error` expectation. These
 cases assert the same stable runtime diagnostic from the interpreter and native
 execution. For example, a thunk that re-enters itself while it is marked as a
@@ -58,7 +68,10 @@ blackhole uses:
 error: blackholed thunk re-entered
 ```
 
+Error fixtures omit `allocations` because the native runtime terminates before
+the snapshot harness can observe the counter.
+
 The focused fixture parser currently accepts constructor and function
 declarations plus `constant`, `store`, `store-rec`, `eval`, `apply`,
-`call`, and inline binds. Variables and literals carry explicit runtime
+`call`, `case`, and inline binds. Variables and literals carry explicit runtime
 representations.

--- a/test/Test/Fixtures/grin-snapshot/apply.yaml
+++ b/test/Test/Fixtures/grin-snapshot/apply.yaml
@@ -17,7 +17,7 @@ heap: |
   @1 = P$identity/1
   @2 = CI32# 9
 allocations:
-  macos-arm64: 4
-  linux-amd64: 4
+  macos-arm64: 10
+  linux-amd64: 10
 status: pass
 reason: GrinApply enters a stored closure that is already in WHNF without requiring GrinEval to change its heap pointer

--- a/test/Test/Fixtures/grin-snapshot/apply.yaml
+++ b/test/Test/Fixtures/grin-snapshot/apply.yaml
@@ -16,5 +16,8 @@ heap: |
   @0 = CPair @1 @2
   @1 = P$identity/1
   @2 = CI32# 9
+allocations:
+  macos-arm64: 4
+  linux-amd64: 4
 status: pass
 reason: GrinApply enters a stored closure that is already in WHNF without requiring GrinEval to change its heap pointer

--- a/test/Test/Fixtures/grin-snapshot/eval-whnf.yaml
+++ b/test/Test/Fixtures/grin-snapshot/eval-whnf.yaml
@@ -20,5 +20,8 @@ heap: |
   @1 = P$const/1 @2
   @2 = CValue
   @3 = CBox
+allocations:
+  macos-arm64: 8
+  linux-amd64: 8
 status: pass
 reason: GrinEval returns the original heap pointer for partial applications and saturated data constructors that are already in WHNF

--- a/test/Test/Fixtures/grin-snapshot/eval-whnf.yaml
+++ b/test/Test/Fixtures/grin-snapshot/eval-whnf.yaml
@@ -21,7 +21,7 @@ heap: |
   @2 = CValue
   @3 = CBox
 allocations:
-  macos-arm64: 8
-  linux-amd64: 8
+  macos-arm64: 14
+  linux-amd64: 14
 status: pass
 reason: GrinEval returns the original heap pointer for partial applications and saturated data constructors that are already in WHNF

--- a/test/Test/Fixtures/grin-snapshot/eval.yaml
+++ b/test/Test/Fixtures/grin-snapshot/eval.yaml
@@ -15,5 +15,8 @@ heap: |
   @0 = CPair @1 @2
   @1 = Indirection @2
   @2 = CI32# 7
+allocations:
+  macos-arm64: 6
+  linux-amd64: 6
 status: pass
 reason: only explicit GrinEval enters the thunk, preserving its heap-pointer result and exposing the update as an indirection

--- a/test/Test/Fixtures/grin-snapshot/eval.yaml
+++ b/test/Test/Fixtures/grin-snapshot/eval.yaml
@@ -16,7 +16,7 @@ heap: |
   @1 = Indirection @2
   @2 = CI32# 7
 allocations:
-  macos-arm64: 6
-  linux-amd64: 6
+  macos-arm64: 15
+  linux-amd64: 15
 status: pass
 reason: only explicit GrinEval enters the thunk, preserving its heap-pointer result and exposing the update as an indirection

--- a/test/Test/Fixtures/grin-snapshot/fork.yaml
+++ b/test/Test/Fixtures/grin-snapshot/fork.yaml
@@ -14,7 +14,7 @@ return: "@0"
 heap: |
   @0 = ThreadId#
 allocations:
-  macos-arm64: 1
-  linux-amd64: 1
+  macos-arm64: 7
+  linux-amd64: 7
 status: pass
 reason: fork# returns an opaque heap-resident ThreadId# that both snapshot implementations can traverse and render

--- a/test/Test/Fixtures/grin-snapshot/fork.yaml
+++ b/test/Test/Fixtures/grin-snapshot/fork.yaml
@@ -13,5 +13,8 @@ program: |
 return: "@0"
 heap: |
   @0 = ThreadId#
+allocations:
+  macos-arm64: 1
+  linux-amd64: 1
 status: pass
 reason: fork# returns an opaque heap-resident ThreadId# that both snapshot implementations can traverse and render

--- a/test/Test/Fixtures/grin-snapshot/loop-add.yaml
+++ b/test/Test/Fixtures/grin-snapshot/loop-add.yaml
@@ -1,0 +1,21 @@
+entry: $entry
+program: |
+  primitive +#%1 :: IntRep/2
+
+  $loop (counter%2 :: IntRep) -> IntRep =
+    case (counter%2 :: IntRep) as tested%3 :: IntRep of
+      10000000 ->
+        constant (counter%2 :: IntRep)
+      _ ->
+        (next%4 :: IntRep) <- primitive-call @IntRep +# (counter%2 :: IntRep) (1 :: IntRep)
+        call @IntRep $loop (next%4 :: IntRep)
+
+  $entry -> IntRep =
+    call @IntRep $loop (0 :: IntRep)
+return: "10000000"
+heap: "[]"
+allocations:
+  macos-arm64: 0
+  linux-amd64: 0
+status: pass
+reason: a ten-million-iteration tail loop uses unboxed addition without allocating heap objects

--- a/test/Test/Fixtures/grin-snapshot/loop-add.yaml
+++ b/test/Test/Fixtures/grin-snapshot/loop-add.yaml
@@ -15,7 +15,7 @@ program: |
 return: "10000000"
 heap: "[]"
 allocations:
-  macos-arm64: 0
-  linux-amd64: 0
+  macos-arm64: 10000003
+  linux-amd64: 10000003
 status: pass
-reason: a ten-million-iteration tail loop uses unboxed addition without allocating heap objects
+reason: a ten-million-iteration tail loop exposes every auxiliary locals allocation while using unboxed addition

--- a/test/Test/Fixtures/grin-snapshot/return-unboxed.yaml
+++ b/test/Test/Fixtures/grin-snapshot/return-unboxed.yaml
@@ -5,7 +5,7 @@ program: |
 return: "42"
 heap: "[]"
 allocations:
-  macos-arm64: 0
-  linux-amd64: 0
+  macos-arm64: 2
+  linux-amd64: 2
 status: pass
 reason: a native function may return an unboxed machine value without allocating

--- a/test/Test/Fixtures/grin-snapshot/return-unboxed.yaml
+++ b/test/Test/Fixtures/grin-snapshot/return-unboxed.yaml
@@ -4,5 +4,8 @@ program: |
     constant (42 :: Int32Rep)
 return: "42"
 heap: "[]"
+allocations:
+  macos-arm64: 0
+  linux-amd64: 0
 status: pass
 reason: a native function may return an unboxed machine value without allocating

--- a/test/Test/Fixtures/grin-snapshot/store-linked.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-linked.yaml
@@ -11,7 +11,7 @@ heap: |
   @0 = CLink @1
   @1 = CI32# 2
 allocations:
-  macos-arm64: 2
-  linux-amd64: 2
+  macos-arm64: 4
+  linux-amd64: 4
 status: pass
 reason: snapshot traversal follows links between separately stored heap values

--- a/test/Test/Fixtures/grin-snapshot/store-linked.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-linked.yaml
@@ -10,5 +10,8 @@ return: "@0"
 heap: |
   @0 = CLink @1
   @1 = CI32# 2
+allocations:
+  macos-arm64: 2
+  linux-amd64: 2
 status: pass
 reason: snapshot traversal follows links between separately stored heap values

--- a/test/Test/Fixtures/grin-snapshot/store-one.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-one.yaml
@@ -7,5 +7,8 @@ program: |
 return: "@0"
 heap: |
   @0 = CI32# 1
+allocations:
+  macos-arm64: 1
+  linux-amd64: 1
 status: pass
 reason: a stored constructor is returned as a location with its raw scalar field

--- a/test/Test/Fixtures/grin-snapshot/store-one.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-one.yaml
@@ -8,7 +8,7 @@ return: "@0"
 heap: |
   @0 = CI32# 1
 allocations:
-  macos-arm64: 1
-  linux-amd64: 1
+  macos-arm64: 3
+  linux-amd64: 3
 status: pass
 reason: a stored constructor is returned as a location with its raw scalar field

--- a/test/Test/Fixtures/grin-snapshot/store-self-referential.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-self-referential.yaml
@@ -10,7 +10,7 @@ return: "@0"
 heap: |
   @0 = CLoop @0
 allocations:
-  macos-arm64: 1
-  linux-amd64: 1
+  macos-arm64: 3
+  linux-amd64: 3
 status: pass
 reason: snapshot object identifiers preserve a self-reference without traversing forever

--- a/test/Test/Fixtures/grin-snapshot/store-self-referential.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-self-referential.yaml
@@ -9,5 +9,8 @@ program: |
 return: "@0"
 heap: |
   @0 = CLoop @0
+allocations:
+  macos-arm64: 1
+  linux-amd64: 1
 status: pass
 reason: snapshot object identifiers preserve a self-reference without traversing forever

--- a/test/Test/Fixtures/grin-snapshot/store-suspended.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-suspended.yaml
@@ -10,5 +10,8 @@ program: |
 return: "@0"
 heap: |
   @0 = F$delayed
+allocations:
+  macos-arm64: 1
+  linux-amd64: 1
 status: pass
 reason: observing a stored thunk symbolizes its code pointer without entering the thunk

--- a/test/Test/Fixtures/grin-snapshot/store-suspended.yaml
+++ b/test/Test/Fixtures/grin-snapshot/store-suspended.yaml
@@ -11,7 +11,7 @@ return: "@0"
 heap: |
   @0 = F$delayed
 allocations:
-  macos-arm64: 1
-  linux-amd64: 1
+  macos-arm64: 3
+  linux-amd64: 3
 status: pass
 reason: observing a stored thunk symbolizes its code pointer without entering the thunk

--- a/test/Test/Fixtures/grin-snapshot/yield.yaml
+++ b/test/Test/Fixtures/grin-snapshot/yield.yaml
@@ -24,7 +24,7 @@ heap: |
   @2 = Indirection @3
   @3 = CChildResult
 allocations:
-  macos-arm64: 6
-  linux-amd64: 6
+  macos-arm64: 21
+  linux-amd64: 21
 status: pass
 reason: yield# runs the queued child before resuming the parent, exposing the child's shared-thunk update in the final snapshot

--- a/test/Test/Fixtures/grin-snapshot/yield.yaml
+++ b/test/Test/Fixtures/grin-snapshot/yield.yaml
@@ -23,5 +23,8 @@ heap: |
   @1 = ThreadId#
   @2 = Indirection @3
   @3 = CChildResult
+allocations:
+  macos-arm64: 6
+  linux-amd64: 6
 status: pass
 reason: yield# runs the queued child before resuming the parent, exposing the child's shared-thunk update in the final snapshot

--- a/test/support/Aihc/Testing/GrinProgram.hs
+++ b/test/support/Aihc/Testing/GrinProgram.hs
@@ -135,6 +135,7 @@ parseExpr indentation lines' =
       | sourceIndent line /= indentation ->
           Left ("unexpected expression indentation: " <> T.unpack (sourceText line))
       | sourceText line == "store-rec" -> parseStoreRec indentation rest
+      | Just caseHeader <- T.stripPrefix "case " (sourceText line) -> parseCase indentation caseHeader rest
       | otherwise ->
           case T.breakOn " <- " (sourceText line) of
             (bindersText, rhsWithArrow)
@@ -147,6 +148,50 @@ parseExpr indentation lines' =
                   (body, remaining) <- parseExpr indentation rest
                   pure (GrinBind binders rhs body, remaining)
             _ -> (,rest) <$> parseAtomicExpr (sourceText line)
+
+parseCase :: Int -> Text -> [SourceLine] -> Either String (GrinExpr, [SourceLine])
+parseCase indentation header lines' = do
+  caseHeader <- maybe (Left "case expression must end with 'of'") pure (T.stripSuffix " of" header)
+  let (scrutineeText, binderWithAs) = T.breakOn " as " caseHeader
+  when (T.null binderWithAs) (Left ("case expression has no binder: " <> T.unpack header))
+  scrutinee <- parseValueAtom scrutineeText
+  binder <- parseBareVar (T.drop 4 binderWithAs)
+  alternativeIndent <-
+    case lines' of
+      line : _
+        | sourceIndent line > indentation -> pure (sourceIndent line)
+      _ -> Left "case expression has no alternatives"
+  (alternatives, remaining) <- parseAlternatives binder alternativeIndent lines'
+  pure (GrinCase scrutinee binder alternatives, remaining)
+
+parseAlternatives :: GrinVar -> Int -> [SourceLine] -> Either String ([GrinAlt], [SourceLine])
+parseAlternatives binder indentation = go []
+  where
+    go alternatives lines' =
+      case lines' of
+        line : rest
+          | sourceIndent line == indentation -> do
+              header <- maybe (Left ("case alternative must end with '->': " <> T.unpack (sourceText line))) pure (T.stripSuffix " ->" (sourceText line))
+              let (constructorText, bindersText) = T.break isSpaceChar header
+              constructor <- parseAltCon binder constructorText
+              binders <- parseVarAtoms bindersText
+              rhsIndent <-
+                case rest of
+                  rhs : _
+                    | sourceIndent rhs > indentation -> pure (sourceIndent rhs)
+                  _ -> Left ("case alternative has no right-hand side: " <> T.unpack header)
+              (rhs, remaining) <- parseExpr rhsIndent rest
+              go (GrinAlt constructor binders rhs : alternatives) remaining
+        _
+          | null alternatives -> Left "case expression has no alternatives"
+          | otherwise -> pure (reverse alternatives, lines')
+
+parseAltCon :: GrinVar -> Text -> Either String GrinAltCon
+parseAltCon binder text
+  | text == "_" = pure GrinDefaultAlt
+  | isInteger text = GrinLitAlt . GrinLitInt (grinVarRuntimeRep binder) <$> readText "case literal" text
+  | T.null text = Left "case alternative has no constructor"
+  | otherwise = pure (GrinDataAlt text)
 
 parseStoreRec :: Int -> [SourceLine] -> Either String (GrinExpr, [SourceLine])
 parseStoreRec indentation lines' = do


### PR DESCRIPTION
## Summary

- record per-backend counts for every managed-object and auxiliary C allocation in successful GRIN snapshot fixtures
- reset and report the native runtime counter while leaving interpreter assertions unchanged
- add a tail-recursive `+#` snapshot that loops 10,000,000 times and verifies 10,000,003 total allocations
- extend the focused GRIN fixture parser with literal/default `case` expressions

## Why

Heap snapshots previously verified only returned values and reachable objects, so allocation regressions could remain invisible when the final heap shape was unchanged. The new backend-specific expectations make all native runtime allocation behavior part of the snapshot contract, including locals, argument vectors, thread records, blackhole records, and waiters.

## Impact

Successful snapshot fixtures now require `allocations.macos-arm64` and `allocations.linux-amd64`. Error fixtures remain allocation-agnostic because the runtime terminates before the harness can read the counter. The observed-program harness resets the counter after its own setup and global initialization.

Progress: shared GRIN native snapshot fixtures increase from 11 to 12.

## Validation

- `just fmt`
- `just check`
- focused ARM64 and AMD64 snapshot suites
