### PR TITLE
feat(dev): add parallel QuickCheck fuzz runner

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,4 +20,16 @@ packages:
   tooling/aihc-resolve-tooling-common
   tooling/aihc-dev
 
+package aihc-parser
+  flags: +fuzz
+
+package aihc-parser-compat
+  flags: +fuzz
+
+package aihc-tc
+  flags: +fuzz
+
+package aihc-grin
+  flags: +fuzz
+
 tests: True

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -41,6 +41,30 @@ library
   ghc-options: -Wall
   default-language: GHC2021
 
+library fuzz
+  visibility: public
+  hs-source-dirs:
+    fuzz
+    test
+
+  exposed-modules:
+    Aihc.Grin.Fuzz
+
+  other-modules:
+    Test.Grin.Arbitrary
+
+  build-depends:
+    QuickCheck,
+    aihc-grin,
+    aihc-tc,
+    base >=4.16 && <5,
+    bytestring,
+    tasty-quickcheck,
+    text,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
 test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -9,6 +9,11 @@ maintainer: lemmih@gmail.com
 category: Development
 synopsis: Strict graph-reduction intermediate language for AIHC
 
+flag fuzz
+  description: Build the developer-only QuickCheck property registry
+  default: False
+  manual: True
+
 library
   exposed-modules:
     Aihc.Grin
@@ -42,6 +47,8 @@ library
   default-language: GHC2021
 
 library fuzz
+  if !flag(fuzz)
+    buildable: False
   visibility: public
   hs-source-dirs:
     fuzz

--- a/components/aihc-grin/fuzz/Aihc/Grin/Fuzz.hs
+++ b/components/aihc-grin/fuzz/Aihc/Grin/Fuzz.hs
@@ -1,0 +1,12 @@
+-- | Continuously runnable QuickCheck properties owned by @aihc-grin@.
+module Aihc.Grin.Fuzz
+  ( grinFuzzProperties,
+  )
+where
+
+import Test.Grin.Arbitrary (prop_grinPrettyRoundTrip)
+import Test.QuickCheck (Property)
+
+grinFuzzProperties :: [(String, Property)]
+grinFuzzProperties =
+  [("generated GRIN pretty-printer round-trip", prop_grinPrettyRoundTrip)]

--- a/components/aihc-parser-compat/aihc-parser-compat.cabal
+++ b/components/aihc-parser-compat/aihc-parser-compat.cabal
@@ -12,6 +12,7 @@ synopsis: Compatibility conversion from aihc-parser ASTs to ghc-lib-parser ASTs
 library
   exposed-modules:
     Aihc.Parser.Compat
+    Aihc.Parser.Compat.Internal.Testing
 
   other-modules:
     Aihc.Parser.Compat.Internal.Convert
@@ -30,6 +31,37 @@ library
   ghc-options: -Wall
   default-language: GHC2021
 
+library fuzz
+  visibility: public
+  hs-source-dirs:
+    fuzz
+    test
+
+  exposed-modules:
+    Aihc.Parser.Compat.Fuzz
+
+  other-modules:
+    Test.Compat.Decl
+    Test.Compat.Expr
+
+  build-depends:
+    QuickCheck,
+    aihc-parser,
+    aihc-parser:fuzz,
+    aihc-parser-compat,
+    base >=4.16 && <5,
+    bytestring,
+    containers,
+    ghc-lib-parser,
+    prettyprinter,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text >=1.2,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
 test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:
@@ -42,6 +74,7 @@ test-suite spec
     Aihc.Parser.Compat
     Aihc.Parser.Compat.Internal.Convert
     Aihc.Parser.Compat.Internal.Ghc
+    Aihc.Parser.Compat.Internal.Testing
     Test.Compat.Decl
     Test.Compat.Expr
     Test.Properties.Arb.Decl

--- a/components/aihc-parser-compat/aihc-parser-compat.cabal
+++ b/components/aihc-parser-compat/aihc-parser-compat.cabal
@@ -9,6 +9,11 @@ maintainer: lemmih@gmail.com
 category: Development
 synopsis: Compatibility conversion from aihc-parser ASTs to ghc-lib-parser ASTs
 
+flag fuzz
+  description: Build the developer-only QuickCheck property registry
+  default: False
+  manual: True
+
 library
   exposed-modules:
     Aihc.Parser.Compat
@@ -32,6 +37,8 @@ library
   default-language: GHC2021
 
 library fuzz
+  if !flag(fuzz)
+    buildable: False
   visibility: public
   hs-source-dirs:
     fuzz

--- a/components/aihc-parser-compat/fuzz/Aihc/Parser/Compat/Fuzz.hs
+++ b/components/aihc-parser-compat/fuzz/Aihc/Parser/Compat/Fuzz.hs
@@ -1,0 +1,18 @@
+-- | Continuously runnable QuickCheck properties owned by @aihc-parser-compat@.
+module Aihc.Parser.Compat.Fuzz
+  ( parserCompatFuzzProperties,
+  )
+where
+
+import Test.Compat.Decl (prop_declCompat)
+import Test.Compat.Expr (prop_exprCompat)
+import Test.QuickCheck (Property, Testable, property)
+
+parserCompatFuzzProperties :: [(String, Property)]
+parserCompatFuzzProperties =
+  [ named "generated expr converts to normalized GHC parsed AST" prop_exprCompat,
+    named "generated decl converts to normalized GHC parsed AST" prop_declCompat
+  ]
+  where
+    named :: (Testable prop) => String -> prop -> (String, Property)
+    named name value = (name, property value)

--- a/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Testing.hs
+++ b/components/aihc-parser-compat/src/Aihc/Parser/Compat/Internal/Testing.hs
@@ -1,0 +1,13 @@
+-- | Internal compatibility helpers used by generative tests.
+--
+-- This module is exposed so the test-only @fuzz@ component can exercise the
+-- GHC conversion code compiled into the main library. It is not a stable API.
+module Aihc.Parser.Compat.Internal.Testing
+  ( compatGhcExtensions,
+    normalizeGhcAst,
+    parseGhcLocatedDecl,
+    parseGhcLocatedExpr,
+  )
+where
+
+import Aihc.Parser.Compat.Internal.Ghc

--- a/components/aihc-parser-compat/test/Test/Compat/Decl.hs
+++ b/components/aihc-parser-compat/test/Test/Compat/Decl.hs
@@ -2,12 +2,13 @@
 
 module Test.Compat.Decl
   ( declCompatTests,
+    prop_declCompat,
   )
 where
 
 import Aihc.Parser qualified as Aihc
 import Aihc.Parser.Compat (toGhcHsDecl)
-import Aihc.Parser.Compat.Internal.Ghc
+import Aihc.Parser.Compat.Internal.Testing
   ( compatGhcExtensions,
     normalizeGhcAst,
     parseGhcLocatedDecl,

--- a/components/aihc-parser-compat/test/Test/Compat/Expr.hs
+++ b/components/aihc-parser-compat/test/Test/Compat/Expr.hs
@@ -6,6 +6,7 @@
 module Test.Compat.Expr
   ( comparisonDump,
     exprCompatTests,
+    prop_exprCompat,
     renderGhc,
     sameStructural,
   )
@@ -13,7 +14,7 @@ where
 
 import Aihc.Parser qualified as Aihc
 import Aihc.Parser.Compat (toGhcHsExpr)
-import Aihc.Parser.Compat.Internal.Ghc
+import Aihc.Parser.Compat.Internal.Testing
   ( compatGhcExtensions,
     normalizeGhcAst,
     parseGhcLocatedExpr,

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -32,6 +32,11 @@ source-repository head
   location: https://github.com/ai-haskell-compiler/aihc.git
   subdir: components/aihc-parser
 
+flag fuzz
+  description: Build the developer-only QuickCheck property registry
+  default: False
+  manual: True
+
 library
   exposed-modules:
     Aihc.Parser
@@ -78,6 +83,8 @@ library
   default-language: GHC2021
 
 library fuzz
+  if !flag(fuzz)
+    buildable: False
   visibility: public
   hs-source-dirs:
     fuzz

--- a/components/aihc-parser/aihc-parser.cabal
+++ b/components/aihc-parser/aihc-parser.cabal
@@ -35,6 +35,7 @@ source-repository head
 library
   exposed-modules:
     Aihc.Parser
+    Aihc.Parser.Internal.Testing
     Aihc.Parser.Parens
     Aihc.Parser.Pretty
     Aihc.Parser.Shorthand
@@ -76,6 +77,56 @@ library
   ghc-options: -Wall
   default-language: GHC2021
 
+library fuzz
+  visibility: public
+  hs-source-dirs:
+    fuzz
+    test
+    common
+
+  exposed-modules:
+    Aihc.Parser.Fuzz
+    Test.Properties.Arb.Decl
+    Test.Properties.Arb.Expr
+    Test.Properties.Arb.Identifiers
+    Test.Properties.Arb.Module
+    Test.Properties.Arb.Pattern
+    Test.Properties.Arb.Type
+    Test.Properties.Arb.Utils
+
+  other-modules:
+    CppSupport
+    GhcOracle
+    ParserValidation
+    Test.Properties.Coverage
+    Test.Properties.DeclRoundTrip
+    Test.Properties.ExprRoundTrip
+    Test.Properties.MinimalParentheses
+    Test.Properties.ModuleRoundTrip
+    Test.Properties.NoExceptions
+    Test.Properties.ParensIdempotency
+    Test.Properties.PatternRoundTrip
+    Test.Properties.ShorthandSubset
+    Test.Properties.TypeRoundTrip
+
+  build-depends:
+    Diff >=1.0 && <1.1,
+    QuickCheck >=2.14 && <2.19,
+    aihc-cpp >=1.0 && <1.1,
+    aihc-hackage >=0.1 && <0.2,
+    aihc-parser,
+    base >=4.19 && <5,
+    bytestring >=0.10.8 && <0.13,
+    containers >=0.5 && <0.9,
+    deepseq >=1.4 && <1.6,
+    filepath >=1.3.0.1 && <1.6,
+    ghc-lib-parser >=9.14.1 && <9.15,
+    prettyprinter >=1.7 && <1.8,
+    text >=2.1.2 && <2.2,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
 test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:
@@ -96,6 +147,7 @@ test-suite spec
     Aihc.Parser.Internal.Import
     Aihc.Parser.Internal.Module
     Aihc.Parser.Internal.Pattern
+    Aihc.Parser.Internal.Testing
     Aihc.Parser.Internal.Type
     Aihc.Parser.Lex
     Aihc.Parser.Lex.Header

--- a/components/aihc-parser/fuzz/Aihc/Parser/Fuzz.hs
+++ b/components/aihc-parser/fuzz/Aihc/Parser/Fuzz.hs
@@ -1,0 +1,64 @@
+-- | Continuously runnable QuickCheck properties owned by @aihc-parser@.
+module Aihc.Parser.Fuzz
+  ( parserFuzzProperties,
+  )
+where
+
+import Test.Properties.DeclRoundTrip (prop_declPrettyRoundTrip)
+import Test.Properties.ExprRoundTrip (prop_exprPrettyRoundTrip)
+import Test.Properties.MinimalParentheses (prop_minimalParenthesesExpr, prop_minimalParenthesesPattern, prop_minimalParenthesesSignatureType, prop_minimalParenthesesType)
+import Test.Properties.ModuleRoundTrip (prop_modulePrettyRoundTrip, prop_moduleValidator)
+import Test.Properties.NoExceptions
+  ( prop_declParserArbitraryTokensNoExceptions,
+    prop_exprParserArbitraryTokensNoExceptions,
+    prop_genLexTokenKindConstructorCoverage,
+    prop_importDeclParserArbitraryTokensNoExceptions,
+    prop_lexerArbitraryTextNoExceptions,
+    prop_moduleHeaderParserArbitraryTokensNoExceptions,
+    prop_moduleParserArbitraryTokensNoExceptions,
+    prop_patternParserArbitraryTokensNoExceptions,
+    prop_preprocessorArbitraryTextNoExceptions,
+    prop_typeParserArbitraryTokensNoExceptions,
+  )
+import Test.Properties.ParensIdempotency (prop_declParensIdempotent, prop_exprParensIdempotent, prop_moduleParensIdempotent, prop_patternParensIdempotent, prop_typeParensIdempotent)
+import Test.Properties.PatternRoundTrip (prop_patternPrettyRoundTrip)
+import Test.Properties.ShorthandSubset (prop_shorthandDeclSubsetOfShow, prop_shorthandExprSubsetOfShow, prop_shorthandLexTokenSubsetOfShow, prop_shorthandModuleSubsetOfShow, prop_shorthandTypeSubsetOfShow)
+import Test.Properties.TypeRoundTrip (prop_typePrettyRoundTrip)
+import Test.QuickCheck (Property, Testable, property)
+
+parserFuzzProperties :: [(String, Property)]
+parserFuzzProperties =
+  [ named "expr paren insertion is minimal" prop_minimalParenthesesExpr,
+    named "pattern paren insertion is minimal" prop_minimalParenthesesPattern,
+    named "signature type paren insertion is minimal" prop_minimalParenthesesSignatureType,
+    named "type paren insertion is minimal" prop_minimalParenthesesType,
+    named "generated expr AST pretty-printer round-trip" prop_exprPrettyRoundTrip,
+    named "generated decl AST pretty-printer round-trip" prop_declPrettyRoundTrip,
+    named "generated module AST pretty-printer round-trip" prop_modulePrettyRoundTrip,
+    named "generated module AST validator" prop_moduleValidator,
+    named "generated pattern AST pretty-printer round-trip" prop_patternPrettyRoundTrip,
+    named "generated type AST pretty-printer round-trip" prop_typePrettyRoundTrip,
+    named "module paren insertion is idempotent" prop_moduleParensIdempotent,
+    named "decl paren insertion is idempotent" prop_declParensIdempotent,
+    named "expr paren insertion is idempotent" prop_exprParensIdempotent,
+    named "pattern paren insertion is idempotent" prop_patternParensIdempotent,
+    named "type paren insertion is idempotent" prop_typeParensIdempotent,
+    named "module shorthand is a subset of Show" prop_shorthandModuleSubsetOfShow,
+    named "decl shorthand is a subset of Show" prop_shorthandDeclSubsetOfShow,
+    named "expr shorthand is a subset of Show" prop_shorthandExprSubsetOfShow,
+    named "type shorthand is a subset of Show" prop_shorthandTypeSubsetOfShow,
+    named "lex token shorthand is a subset of Show" prop_shorthandLexTokenSubsetOfShow,
+    named "lex token kind generator covers constructors" prop_genLexTokenKindConstructorCoverage,
+    named "no exceptions.preprocessor accepts arbitrary text" prop_preprocessorArbitraryTextNoExceptions,
+    named "no exceptions.lexer accepts arbitrary text" prop_lexerArbitraryTextNoExceptions,
+    named "no exceptions.module parser accepts arbitrary tokens" prop_moduleParserArbitraryTokensNoExceptions,
+    named "no exceptions.expr parser accepts arbitrary tokens" prop_exprParserArbitraryTokensNoExceptions,
+    named "no exceptions.type parser accepts arbitrary tokens" prop_typeParserArbitraryTokensNoExceptions,
+    named "no exceptions.pattern parser accepts arbitrary tokens" prop_patternParserArbitraryTokensNoExceptions,
+    named "no exceptions.decl parser accepts arbitrary tokens" prop_declParserArbitraryTokensNoExceptions,
+    named "no exceptions.import decl parser accepts arbitrary tokens" prop_importDeclParserArbitraryTokensNoExceptions,
+    named "no exceptions.module header parser accepts arbitrary tokens" prop_moduleHeaderParserArbitraryTokensNoExceptions
+  ]
+  where
+    named :: (Testable prop) => String -> prop -> (String, Property)
+    named name value = (name, property value)

--- a/components/aihc-parser/src/Aihc/Parser/Internal/Testing.hs
+++ b/components/aihc-parser/src/Aihc/Parser/Internal/Testing.hs
@@ -1,0 +1,22 @@
+-- | Internal parser entry points used by generative tests.
+--
+-- This module is exposed so the test-only @fuzz@ component can exercise the
+-- token parsers compiled into the main library. It is not a stable public API.
+module Aihc.Parser.Internal.Testing
+  ( LexToken (..),
+    LexTokenKind (..),
+    TokenOrigin (..),
+    lexModuleTokens,
+    lexTokens,
+    parseDeclFromTokens,
+    parseExprFromTokens,
+    parseImportDeclFromTokens,
+    parseModuleFromTokens,
+    parseModuleHeaderFromTokens,
+    parsePatternFromTokens,
+    parseTypeFromTokens,
+  )
+where
+
+import Aihc.Parser.Internal.FromTokens
+import Aihc.Parser.Lex

--- a/components/aihc-parser/test/Test/Properties/NoExceptions.hs
+++ b/components/aihc-parser/test/Test/Properties/NoExceptions.hs
@@ -17,21 +17,19 @@ module Test.Properties.NoExceptions
   )
 where
 
-import Aihc.Parser.Internal.FromTokens
-  ( parseDeclFromTokens,
+import Aihc.Parser.Internal.Testing
+  ( LexToken (..),
+    LexTokenKind (..),
+    TokenOrigin (..),
+    lexModuleTokens,
+    lexTokens,
+    parseDeclFromTokens,
     parseExprFromTokens,
     parseImportDeclFromTokens,
     parseModuleFromTokens,
     parseModuleHeaderFromTokens,
     parsePatternFromTokens,
     parseTypeFromTokens,
-  )
-import Aihc.Parser.Lex
-  ( LexToken (..),
-    LexTokenKind (..),
-    TokenOrigin (..),
-    lexModuleTokens,
-    lexTokens,
   )
 import Aihc.Parser.Syntax (ExtensionSetting (..), FloatType (..), NumericType (..), SourceSpan (..))
 import Aihc.Parser.Syntax qualified as Syntax

--- a/components/aihc-parser/test/Test/Properties/ShorthandSubset.hs
+++ b/components/aihc-parser/test/Test/Properties/ShorthandSubset.hs
@@ -9,9 +9,9 @@ module Test.Properties.ShorthandSubset
   )
 where
 
-import Aihc.Parser.Lex (LexToken)
 import Aihc.Parser.Shorthand (Shorthand (shorthand))
 import Aihc.Parser.Syntax
+import Aihc.Parser.Token (LexToken)
 import Data.Char (isAlphaNum, isSpace)
 import Data.List (isSubsequenceOf)
 import Test.Properties.Arb.Decl ()

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -48,6 +48,28 @@ library
   ghc-options: -Wall
   default-language: GHC2021
 
+library fuzz
+  visibility: public
+  hs-source-dirs:
+    fuzz
+    test
+
+  exposed-modules:
+    Aihc.Tc.Fuzz
+
+  other-modules:
+    Test.Tc.Properties
+
+  build-depends:
+    QuickCheck,
+    aihc-tc,
+    base >=4.16 && <5,
+    tasty,
+    tasty-quickcheck,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
 test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -9,6 +9,11 @@ maintainer: lemmih@gmail.com
 category: Development
 synopsis: OutsideIn(X) type checker for parsed Haskell modules
 
+flag fuzz
+  description: Build the developer-only QuickCheck property registry
+  default: False
+  manual: True
+
 library
   exposed-modules:
     Aihc.Tc
@@ -49,6 +54,8 @@ library
   default-language: GHC2021
 
 library fuzz
+  if !flag(fuzz)
+    buildable: False
   visibility: public
   hs-source-dirs:
     fuzz

--- a/components/aihc-tc/fuzz/Aihc/Tc/Fuzz.hs
+++ b/components/aihc-tc/fuzz/Aihc/Tc/Fuzz.hs
@@ -1,0 +1,17 @@
+-- | Continuously runnable QuickCheck properties owned by @aihc-tc@.
+module Aihc.Tc.Fuzz
+  ( tcFuzzProperties,
+  )
+where
+
+import Test.QuickCheck (Property, Testable, property)
+import Test.Tc.Properties (prop_reflexiveEq, prop_zonkIdempotent)
+
+tcFuzzProperties :: [(String, Property)]
+tcFuzzProperties =
+  [ named "zonking idempotent" prop_zonkIdempotent,
+    named "reflexive equality solved" prop_reflexiveEq
+  ]
+  where
+    named :: (Testable prop) => String -> prop -> (String, Property)
+    named name value = (name, property value)

--- a/components/aihc-tc/test/Test/Tc/Properties.hs
+++ b/components/aihc-tc/test/Test/Tc/Properties.hs
@@ -2,7 +2,9 @@
 
 -- | QuickCheck property tests for the type checker.
 module Test.Tc.Properties
-  ( tcProperties,
+  ( prop_reflexiveEq,
+    prop_zonkIdempotent,
+    tcProperties,
   )
 where
 

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -45,6 +45,9 @@
     };
     aihc-parser = {
       src = sources.parserSrc;
+      cabal2nixOptions = {
+        extraCabal2nixOptions = "--flag fuzz";
+      };
       disableProfiling = true;
       optimizeForChecks = true;
       supportsDocs = true;
@@ -52,6 +55,9 @@
     };
     aihc-parser-compat = {
       src = sources.parserCompatSrc;
+      cabal2nixOptions = {
+        extraCabal2nixOptions = "--flag fuzz";
+      };
       disableProfiling = true;
       optimizeForChecks = true;
       supportsDocs = false;
@@ -78,7 +84,7 @@
     aihc-grin = {
       src = sources.grinSrc;
       cabal2nixOptions = {
-        extraCabal2nixOptions = "--subpath components/aihc-grin";
+        extraCabal2nixOptions = "--flag fuzz --subpath components/aihc-grin";
         srcModifier = src: src;
       };
       disableProfiling = true;
@@ -95,6 +101,9 @@
     };
     aihc-tc = {
       src = sources.tcSrc;
+      cabal2nixOptions = {
+        extraCabal2nixOptions = "--flag fuzz";
+      };
       disableProfiling = true;
       optimizeForChecks = true;
       supportsDocs = false;

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -153,6 +153,7 @@ library fuzz
     Aihc.Dev.Fuzz
     Aihc.Dev.Fuzz.CLI
     Aihc.Dev.Fuzz.Registry
+    Aihc.Dev.Fuzz.TUI
 
   build-depends:
     QuickCheck >=2.14 && <2.19,
@@ -165,6 +166,7 @@ library fuzz
     containers >=0.5 && <0.8,
     optparse-applicative >=0.16 && <0.19,
     stm >=2.5 && <2.6,
+    terminal-size >=0.3.2 && <0.4,
     time >=1.9 && <1.15,
 
   ghc-options: -Wall

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -147,6 +147,29 @@ library golden-tools
   ghc-options: -Wall
   default-language: GHC2021
 
+library fuzz
+  hs-source-dirs: src
+  exposed-modules:
+    Aihc.Dev.Fuzz
+    Aihc.Dev.Fuzz.CLI
+    Aihc.Dev.Fuzz.Registry
+
+  build-depends:
+    QuickCheck >=2.14 && <2.19,
+    aihc-grin:fuzz,
+    aihc-parser:fuzz,
+    aihc-parser-compat:fuzz,
+    aihc-tc:fuzz,
+    async >=2.2 && <2.3,
+    base >=4.16 && <5,
+    containers >=0.5 && <0.8,
+    optparse-applicative >=0.16 && <0.19,
+    stm >=2.5 && <2.6,
+    time >=1.9 && <1.15,
+
+  ghc-options: -Wall
+  default-language: GHC2021
+
 executable aihc-dev
   main-is: Main.hs
   hs-source-dirs:
@@ -178,6 +201,7 @@ executable aihc-dev
     aihc,
     aihc-cpp,
     aihc-dev:extract-hi,
+    aihc-dev:fuzz,
     aihc-dev:golden-tools,
     aihc-dev:parser-tools,
     aihc-dev:snippet,
@@ -235,6 +259,7 @@ test-suite spec
     StackageProgress.Snapshot
     TcStackageProgress
     Test.ExtractHiCompare
+    Test.Fuzz
     Test.GoldenUpdate
     Test.ParserBenchReport
     Test.ParserCLI.Golden
@@ -252,6 +277,7 @@ test-suite spec
     aihc,
     aihc-cpp,
     aihc-dev:extract-hi,
+    aihc-dev:fuzz,
     aihc-dev:golden-tools,
     aihc-dev:parser-tools,
     aihc-dev:snippet,

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -168,6 +168,7 @@ library fuzz
     stm >=2.5 && <2.6,
     terminal-size >=0.3.2 && <0.4,
     time >=1.9 && <1.15,
+    unix >=2.7 && <2.9,
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/tooling/aihc-dev/exe/Main.hs
+++ b/tooling/aihc-dev/exe/Main.hs
@@ -3,6 +3,8 @@ module Main (main) where
 import Aihc.Dev.ExtractHi (extractPackage)
 import Aihc.Dev.ExtractHi.Compare (comparePackageSubset, renderCoreLibProgressReports, renderInterfaceMismatch, runCoreLibProgressReports)
 import Aihc.Dev.ExtractHi.ToResolveIface (toResolveIface)
+import Aihc.Dev.Fuzz qualified as Fuzz
+import Aihc.Dev.Fuzz.CLI qualified as FuzzCLI
 import Aihc.Dev.Golden.Update qualified as GoldenUpdate
 import Aihc.Dev.HackageTester.Run qualified as HackageTesterRun
 import Aihc.Dev.Parser.Bench.CLI qualified as ParserBenchCLI
@@ -46,6 +48,7 @@ data Command
   | CompareHiSubset CompareHiSubsetOpts
   | CoreLibsProgress
   | ExtractResolveIface ExtractResolveIfaceOpts
+  | Fuzz FuzzCLI.Command
   | Snippet SnippetOpts
   | Parser ParserRun.Options
   | ParserBench ParserBenchCLI.Options
@@ -101,6 +104,12 @@ commandParser =
           ( info
               (ExtractResolveIface <$> extractResolveIfaceParser <**> helper)
               (progDesc "Extract minimal resolver interface (names only) from .hi files")
+          )
+        <> command
+          "fuzz"
+          ( info
+              (Fuzz <$> FuzzCLI.commandParser <**> helper)
+              (progDesc "Continuously run QuickCheck properties in parallel")
           )
         <> command
           "snippet"
@@ -251,6 +260,8 @@ runCommand (ExtractResolveIface opts) = do
       outputPath = eriOutput opts
   createDirectoryIfMissing True (takeDirectory outputPath)
   BL.writeFile outputPath (encodePretty resolveIface)
+runCommand (Fuzz fuzzCommand) =
+  Fuzz.runCommand fuzzCommand
 runCommand (Snippet opts) =
   runSnippet opts
 runCommand (Parser opts) =

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
@@ -5,6 +5,7 @@ module Aihc.Dev.Fuzz
   ( batchSize,
     cycleProperties,
     dashboardRefreshMicroseconds,
+    isQuitKey,
     resolveJobCount,
     runCommand,
     selectProperties,
@@ -18,7 +19,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, async, cancel, race, waitAnyCatch)
 import Control.Concurrent.STM
 import Control.Exception (SomeException, bracket_, displayException, finally, onException)
-import Control.Monad (forM, forM_, unless, when)
+import Control.Monad (forM, forM_, unless, void, when)
 import Data.Char (toLower)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
@@ -28,7 +29,9 @@ import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
 import GHC.Conc (getNumCapabilities)
 import System.Console.Terminal.Size qualified as Terminal
 import System.Exit (exitFailure)
-import System.IO (BufferMode (NoBuffering), hFlush, hGetBuffering, hIsTerminalDevice, hPutStr, hPutStrLn, hSetBuffering, stderr)
+import System.IO (BufferMode (NoBuffering), hFlush, hGetBuffering, hIsTerminalDevice, hPutStr, hPutStrLn, hReady, hSetBuffering, stderr, stdin)
+import System.Posix.IO (stdInput)
+import System.Posix.Terminal qualified as Posix
 import Test.QuickCheck qualified as QC
 import Test.QuickCheck.Property qualified as QCP
 
@@ -99,12 +102,14 @@ runFuzzer Options {optionsSelection, optionsJobs, optionsTimeLimit} = do
   scheduler <- newTVarIO (cycleProperties selected)
   stats <- Stats <$> newTVarIO IntMap.empty <*> newTVarIO 0 <*> newTVarIO 0
   startedAt <- getCurrentTime
-  workers <- forM [1 .. jobs] $ \workerId -> async (worker scheduler stats workerId)
   interactive <- hIsTerminalDevice stderr
-  let run = awaitOutcome optionsTimeLimit workers
+  keyboardEnabled <- (interactive &&) <$> hIsTerminalDevice stdin
+  quitSignal <- newEmptyTMVarIO
+  workers <- forM [1 .. jobs] $ \workerId -> async (worker scheduler stats workerId)
+  let run = awaitOutcome optionsTimeLimit workers quitSignal
   outcome <-
     ( if interactive
-        then withDashboard startedAt (length selected) jobs stats run
+        then withDashboard keyboardEnabled quitSignal startedAt (length selected) jobs stats run
         else do
           hPutStrLn stderr ("Fuzzing " <> show (length selected) <> " properties with " <> show jobs <> " jobs (10,000 cases per batch)")
           run
@@ -115,6 +120,8 @@ runFuzzer Options {optionsSelection, optionsJobs, optionsTimeLimit} = do
   case outcome of
     TimeLimitReached ->
       putStrLn ("Time limit reached after " <> formatInteger successfulCases <> " successful QuickCheck cases.")
+    UserQuit ->
+      putStrLn ("Stopped after " <> formatInteger successfulCases <> " successful QuickCheck cases.")
     PropertyFailed WorkerFailure {workerFailureProperty, workerFailureResult} -> do
       hPutStrLn stderr ("Fuzz failure in " <> fuzzPropertyId workerFailureProperty)
       hPutStr stderr (QC.output workerFailureResult)
@@ -125,19 +132,25 @@ runFuzzer Options {optionsSelection, optionsJobs, optionsTimeLimit} = do
 
 data Outcome
   = TimeLimitReached
+  | UserQuit
   | PropertyFailed WorkerFailure
   | WorkerCrashed SomeException
 
-awaitOutcome :: Maybe NominalDiffTime -> [Async WorkerFailure] -> IO Outcome
-awaitOutcome maybeTimeLimit workers =
+awaitOutcome :: Maybe NominalDiffTime -> [Async WorkerFailure] -> TMVar () -> IO Outcome
+awaitOutcome maybeTimeLimit workers quitSignal =
   case maybeTimeLimit of
-    Nothing -> waitForWorker
+    Nothing -> waitForStop
     Just timeLimit -> do
-      result <- race (threadDelay (durationMicroseconds timeLimit)) waitForWorker
+      result <- race (threadDelay (durationMicroseconds timeLimit)) waitForStop
       pure $ case result of
         Left () -> TimeLimitReached
         Right outcome -> outcome
   where
+    waitForStop = do
+      result <- race (atomically (takeTMVar quitSignal)) waitForWorker
+      pure $ case result of
+        Left () -> UserQuit
+        Right outcome -> outcome
     waitForWorker = do
       (_, result) <- waitAnyCatch workers
       pure $ case result of
@@ -196,16 +209,71 @@ runBatch stats workerId FuzzProperty {fuzzPropertyValue} =
     increment active =
       active {activeSuccessfulCases = activeSuccessfulCases active + 1}
 
-withDashboard :: UTCTime -> Int -> Int -> Stats -> IO Outcome -> IO Outcome
-withDashboard startedAt propertyCount jobs stats action = do
+withDashboard :: Bool -> TMVar () -> UTCTime -> Int -> Int -> Stats -> IO Outcome -> IO Outcome
+withDashboard keyboardEnabled quitSignal startedAt propertyCount jobs stats action = do
   originalBuffering <- hGetBuffering stderr
   bracket_
     enterDashboard
     (leaveDashboard originalBuffering)
+    (if keyboardEnabled then withKeyboard quitSignal run else run)
+  where
+    run = do
+      renderer <- async (renderLoop startedAt propertyCount jobs stats)
+      action `finally` cancel renderer
+
+withKeyboard :: TMVar () -> IO Outcome -> IO Outcome
+withKeyboard quitSignal action = do
+  originalBuffering <- hGetBuffering stdin
+  originalAttributes <- Posix.getTerminalAttributes stdInput
+  bracket_
+    (enterKeyboardMode originalBuffering originalAttributes)
+    (leaveKeyboardMode originalBuffering originalAttributes)
     ( do
-        renderer <- async (renderLoop startedAt propertyCount jobs stats)
-        action `finally` cancel renderer
+        watcher <- async (watchKeyboard quitSignal)
+        action `finally` cancel watcher
     )
+
+enterKeyboardMode :: BufferMode -> Posix.TerminalAttributes -> IO ()
+enterKeyboardMode originalBuffering originalAttributes = do
+  let immediateInput =
+        Posix.withTime
+          (Posix.withMinInput (Posix.withoutMode (Posix.withoutMode originalAttributes Posix.EnableEcho) Posix.ProcessInput) 1)
+          0
+  hSetBuffering stdin NoBuffering
+  Posix.setTerminalAttributes stdInput immediateInput Posix.Immediately
+    `onException` hSetBuffering stdin originalBuffering
+
+leaveKeyboardMode :: BufferMode -> Posix.TerminalAttributes -> IO ()
+leaveKeyboardMode originalBuffering originalAttributes =
+  Posix.setTerminalAttributes stdInput originalAttributes Posix.Immediately
+    `finally` hSetBuffering stdin originalBuffering
+
+watchKeyboard :: TMVar () -> IO ()
+watchKeyboard quitSignal = go
+  where
+    go = do
+      key <- getChar
+      quit <-
+        if key == '\ESC'
+          then do
+            threadDelay 50000
+            hasContinuation <- hReady stdin
+            if hasContinuation
+              then drainAvailableInput >> pure False
+              else pure True
+          else pure (isQuitKey key)
+      if quit
+        then atomically (void (tryPutTMVar quitSignal ()))
+        else go
+
+drainAvailableInput :: IO ()
+drainAvailableInput = do
+  available <- hReady stdin
+  when available (getChar >> drainAvailableInput)
+
+-- | Keys that request an immediate, successful stop.
+isQuitKey :: Char -> Bool
+isQuitKey key = key == 'q' || key == 'Q' || key == '\ESC'
 
 enterDashboard :: IO ()
 enterDashboard = do

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Parallel, round-robin QuickCheck fuzz runner with a terminal dashboard.
+module Aihc.Dev.Fuzz
+  ( batchSize,
+    runCommand,
+    selectProperties,
+  )
+where
+
+import Aihc.Dev.Fuzz.CLI (Command (..), Options (..), Selection (..))
+import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async, cancel, race, waitAnyCatch)
+import Control.Concurrent.STM
+import Control.Exception (SomeException, bracket_, displayException, finally, onException)
+import Control.Monad (forM, forM_, when)
+import Data.Char (toLower)
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Data.List (groupBy, intercalate, isInfixOf, sortOn)
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import GHC.Conc (getNumCapabilities)
+import System.Exit (exitFailure)
+import System.IO (BufferMode (NoBuffering), hFlush, hGetBuffering, hIsTerminalDevice, hPutStr, hPutStrLn, hSetBuffering, stderr)
+import Test.QuickCheck qualified as QC
+import Test.QuickCheck.Property qualified as QCP
+
+-- | Number of successful cases a worker runs before rotating the property.
+batchSize :: Int
+batchSize = 10000
+
+data ActiveProperty = ActiveProperty
+  { activePropertyId :: String,
+    activeSuccessfulCases :: Int
+  }
+
+data Stats = Stats
+  { statsActive :: TVar (IntMap ActiveProperty),
+    statsCompletedBatches :: TVar Int,
+    statsSuccessfulCases :: TVar Int
+  }
+
+data WorkerFailure = WorkerFailure
+  { workerFailureProperty :: FuzzProperty,
+    workerFailureResult :: QC.Result
+  }
+
+runCommand :: Command -> IO ()
+runCommand command =
+  case command of
+    List selection -> listProperties (selectProperties selection fuzzProperties)
+    Run options -> runFuzzer options
+
+-- | Apply case-insensitive substring inclusion and exclusion rules.
+selectProperties :: Selection -> [FuzzProperty] -> [FuzzProperty]
+selectProperties Selection {selectionFilters, selectionExclusions} =
+  filter selected
+  where
+    selected fuzzProperty =
+      let propertyId = lowercase (fuzzPropertyId fuzzProperty)
+          matches term = lowercase term `isInfixOf` propertyId
+       in (null selectionFilters || any matches selectionFilters)
+            && not (any matches selectionExclusions)
+    lowercase = map toLower
+
+listProperties :: [FuzzProperty] -> IO ()
+listProperties properties =
+  forM_ grouped printComponent
+  where
+    grouped =
+      groupBy sameComponent . sortOn fuzzPropertyComponent $ properties
+    sameComponent left right =
+      fuzzPropertyComponent left == fuzzPropertyComponent right
+    printComponent [] = pure ()
+    printComponent componentProperties@(firstProperty : _) = do
+      putStrLn (fuzzPropertyComponent firstProperty)
+      forM_ componentProperties $ \fuzzProperty ->
+        putStrLn ("  " <> fuzzPropertyName fuzzProperty)
+
+runFuzzer :: Options -> IO ()
+runFuzzer Options {optionsSelection, optionsJobs, optionsTimeLimit} = do
+  let selected = selectProperties optionsSelection fuzzProperties
+  when (null selected) $ do
+    hPutStrLn stderr "aihc-dev fuzz: no properties matched the selection"
+    exitFailure
+  capabilities <- getNumCapabilities
+  let requestedJobs = fromMaybe capabilities optionsJobs
+      jobs = min requestedJobs (length selected)
+  queue <- newTQueueIO
+  atomically (forM_ selected (writeTQueue queue))
+  stats <- Stats <$> newTVarIO IntMap.empty <*> newTVarIO 0 <*> newTVarIO 0
+  startedAt <- getCurrentTime
+  workers <- forM [1 .. jobs] $ \workerId -> async (worker queue stats workerId)
+  interactive <- hIsTerminalDevice stderr
+  let run = awaitOutcome optionsTimeLimit workers
+  outcome <-
+    ( if interactive
+        then withDashboard startedAt (length selected) jobs stats run
+        else do
+          hPutStrLn stderr ("Fuzzing " <> show (length selected) <> " properties with " <> show jobs <> " jobs (10,000 cases per batch)")
+          run
+    )
+      `onException` mapM_ cancel workers
+  mapM_ cancel workers
+  successfulCases <- readTVarIO (statsSuccessfulCases stats)
+  case outcome of
+    TimeLimitReached ->
+      putStrLn ("Time limit reached after " <> formatInteger successfulCases <> " successful QuickCheck cases.")
+    PropertyFailed WorkerFailure {workerFailureProperty, workerFailureResult} -> do
+      hPutStrLn stderr ("Fuzz failure in " <> fuzzPropertyId workerFailureProperty)
+      hPutStr stderr (QC.output workerFailureResult)
+      exitFailure
+    WorkerCrashed exception -> do
+      hPutStrLn stderr ("Fuzz worker crashed: " <> displayException exception)
+      exitFailure
+
+data Outcome
+  = TimeLimitReached
+  | PropertyFailed WorkerFailure
+  | WorkerCrashed SomeException
+
+awaitOutcome :: Maybe NominalDiffTime -> [Async WorkerFailure] -> IO Outcome
+awaitOutcome maybeTimeLimit workers =
+  case maybeTimeLimit of
+    Nothing -> waitForWorker
+    Just timeLimit -> do
+      result <- race (threadDelay (durationMicroseconds timeLimit)) waitForWorker
+      pure $ case result of
+        Left () -> TimeLimitReached
+        Right outcome -> outcome
+  where
+    waitForWorker = do
+      (_, result) <- waitAnyCatch workers
+      pure $ case result of
+        Left exception -> WorkerCrashed exception
+        Right failure -> PropertyFailed failure
+
+durationMicroseconds :: NominalDiffTime -> Int
+durationMicroseconds duration =
+  max 1 (floor (realToFrac duration * (1000000 :: Double)))
+
+worker :: TQueue FuzzProperty -> Stats -> Int -> IO WorkerFailure
+worker queue stats workerId = do
+  fuzzProperty <- atomically (readTQueue queue)
+  let propertyId = fuzzPropertyId fuzzProperty
+      clearActive = atomically (modifyTVar' (statsActive stats) (IntMap.delete workerId))
+  atomically $ modifyTVar' (statsActive stats) (IntMap.insert workerId (ActiveProperty propertyId 0))
+  result <- runBatch stats workerId fuzzProperty `finally` clearActive
+  case result of
+    QC.Success {} -> do
+      atomically $ do
+        modifyTVar' (statsCompletedBatches stats) (+ 1)
+        writeTQueue queue fuzzProperty
+      worker queue stats workerId
+    _ -> pure (WorkerFailure fuzzProperty result)
+
+runBatch :: Stats -> Int -> FuzzProperty -> IO QC.Result
+runBatch stats workerId FuzzProperty {fuzzPropertyValue} =
+  QC.quickCheckWithResult
+    QC.stdArgs
+      { QC.chatty = False,
+        QC.maxSuccess = batchSize
+      }
+    (QCP.callback progressCallback fuzzPropertyValue)
+  where
+    progressCallback =
+      QCP.PostTest QCP.NotCounterexample $ \_ result ->
+        when (QCP.ok result == Just True) $ atomically $ do
+          modifyTVar' (statsSuccessfulCases stats) (+ 1)
+          modifyTVar' (statsActive stats) $ IntMap.adjust increment workerId
+    increment active =
+      active {activeSuccessfulCases = activeSuccessfulCases active + 1}
+
+withDashboard :: UTCTime -> Int -> Int -> Stats -> IO Outcome -> IO Outcome
+withDashboard startedAt propertyCount jobs stats action = do
+  originalBuffering <- hGetBuffering stderr
+  bracket_
+    enterDashboard
+    (leaveDashboard originalBuffering)
+    ( do
+        renderer <- async (renderLoop startedAt propertyCount jobs stats)
+        action `finally` cancel renderer
+    )
+
+enterDashboard :: IO ()
+enterDashboard = do
+  hSetBuffering stderr NoBuffering
+  hPutStr stderr "\ESC[?1049h\ESC[?25l"
+
+leaveDashboard :: BufferMode -> IO ()
+leaveDashboard originalBuffering = do
+  hPutStr stderr "\ESC[?25h\ESC[?1049l"
+  hSetBuffering stderr originalBuffering
+
+renderLoop :: UTCTime -> Int -> Int -> Stats -> IO ()
+renderLoop startedAt propertyCount jobs stats = go
+  where
+    go = do
+      now <- getCurrentTime
+      active <- readTVarIO (statsActive stats)
+      successfulCases <- readTVarIO (statsSuccessfulCases stats)
+      completedBatches <- readTVarIO (statsCompletedBatches stats)
+      hPutStr stderr "\ESC[H\ESC[2J"
+      hPutStrLn stderr "AIHC fuzz"
+      hPutStrLn stderr (replicate 72 '=')
+      hPutStrLn stderr $
+        intercalate
+          "   "
+          [ "elapsed " <> formatElapsed (diffUTCTime now startedAt),
+            "cases " <> formatInteger successfulCases,
+            "batches " <> formatInteger completedBatches
+          ]
+      hPutStrLn stderr ("properties " <> show propertyCount <> "   jobs " <> show jobs <> "   batch size " <> formatInteger batchSize)
+      hPutStrLn stderr ""
+      hPutStrLn stderr "Active properties"
+      if IntMap.null active
+        then hPutStrLn stderr "  waiting for workers..."
+        else forM_ (IntMap.toAscList active) $ \(workerId, ActiveProperty {activePropertyId, activeSuccessfulCases}) ->
+          hPutStrLn stderr $
+            "  ["
+              <> show workerId
+              <> "] "
+              <> leftPad 6 (formatInteger activeSuccessfulCases)
+              <> " / 10,000  "
+              <> activePropertyId
+      hFlush stderr
+      threadDelay 100000
+      go
+
+formatElapsed :: NominalDiffTime -> String
+formatElapsed elapsed =
+  let totalSeconds = max 0 (floor elapsed :: Int)
+      (hours, afterHours) = totalSeconds `divMod` 3600
+      (minutes, seconds) = afterHours `divMod` 60
+   in pad2 hours <> ":" <> pad2 minutes <> ":" <> pad2 seconds
+
+pad2 :: Int -> String
+pad2 value =
+  let rendered = show value
+   in replicate (max 0 (2 - length rendered)) '0' <> rendered
+
+leftPad :: Int -> String -> String
+leftPad width value = replicate (max 0 (width - length value)) ' ' <> value
+
+formatInteger :: Int -> String
+formatInteger value =
+  reverse . intercalate "," . chunksOfThree . reverse $ show value
+  where
+    chunksOfThree [] = []
+    chunksOfThree input = take 3 input : chunksOfThree (drop 3 input)

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
@@ -3,6 +3,7 @@
 -- | Parallel, round-robin QuickCheck fuzz runner with a terminal dashboard.
 module Aihc.Dev.Fuzz
   ( batchSize,
+    dashboardRefreshMicroseconds,
     runCommand,
     selectProperties,
   )
@@ -32,6 +33,10 @@ import Test.QuickCheck.Property qualified as QCP
 -- | Number of successful cases a worker runs before rotating the property.
 batchSize :: Int
 batchSize = 10000
+
+-- | Keep dashboard redraws deliberately infrequent to avoid terminal flicker.
+dashboardRefreshMicroseconds :: Int
+dashboardRefreshMicroseconds = 5 * 1000000
 
 data ActiveProperty = ActiveProperty
   { activePropertyId :: String,
@@ -226,7 +231,7 @@ renderLoop startedAt propertyCount jobs stats = go []
                 }
           update = renderFrameUpdate rows previousFrame currentFrame
       unless (null update) $ hPutStr stderr update >> hFlush stderr
-      threadDelay 125000
+      threadDelay dashboardRefreshMicroseconds
       go currentFrame
 
 formatInteger :: Int -> String

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
@@ -3,7 +3,9 @@
 -- | Parallel, round-robin QuickCheck fuzz runner with a terminal dashboard.
 module Aihc.Dev.Fuzz
   ( batchSize,
+    cycleProperties,
     dashboardRefreshMicroseconds,
+    resolveJobCount,
     runCommand,
     selectProperties,
   )
@@ -93,13 +95,11 @@ runFuzzer Options {optionsSelection, optionsJobs, optionsTimeLimit} = do
     hPutStrLn stderr "aihc-dev fuzz: no properties matched the selection"
     exitFailure
   capabilities <- getNumCapabilities
-  let requestedJobs = fromMaybe capabilities optionsJobs
-      jobs = min requestedJobs (length selected)
-  queue <- newTQueueIO
-  atomically (forM_ selected (writeTQueue queue))
+  let jobs = resolveJobCount capabilities optionsJobs
+  scheduler <- newTVarIO (cycleProperties selected)
   stats <- Stats <$> newTVarIO IntMap.empty <*> newTVarIO 0 <*> newTVarIO 0
   startedAt <- getCurrentTime
-  workers <- forM [1 .. jobs] $ \workerId -> async (worker queue stats workerId)
+  workers <- forM [1 .. jobs] $ \workerId -> async (worker scheduler stats workerId)
   interactive <- hIsTerminalDevice stderr
   let run = awaitOutcome optionsTimeLimit workers
   outcome <-
@@ -148,19 +148,35 @@ durationMicroseconds :: NominalDiffTime -> Int
 durationMicroseconds duration =
   max 1 (floor (realToFrac duration * (1000000 :: Double)))
 
-worker :: TQueue FuzzProperty -> Stats -> Int -> IO WorkerFailure
-worker queue stats workerId = do
-  fuzzProperty <- atomically (readTQueue queue)
+-- | Repeat the selected properties forever in stable registry order.
+cycleProperties :: [property] -> [property]
+cycleProperties [] = []
+cycleProperties properties = cycle properties
+
+-- | Honor the requested parallelism even when fewer properties are selected.
+resolveJobCount :: Int -> Maybe Int -> Int
+resolveJobCount = fromMaybe
+
+nextProperty :: TVar [FuzzProperty] -> STM FuzzProperty
+nextProperty scheduler = do
+  scheduled <- readTVar scheduler
+  case scheduled of
+    fuzzProperty : remaining -> do
+      writeTVar scheduler remaining
+      pure fuzzProperty
+    [] -> retry
+
+worker :: TVar [FuzzProperty] -> Stats -> Int -> IO WorkerFailure
+worker scheduler stats workerId = do
+  fuzzProperty <- atomically (nextProperty scheduler)
   let propertyId = fuzzPropertyId fuzzProperty
       clearActive = atomically (modifyTVar' (statsActive stats) (IntMap.delete workerId))
   atomically $ modifyTVar' (statsActive stats) (IntMap.insert workerId (ActiveProperty propertyId 0))
   result <- runBatch stats workerId fuzzProperty `finally` clearActive
   case result of
     QC.Success {} -> do
-      atomically $ do
-        modifyTVar' (statsCompletedBatches stats) (+ 1)
-        writeTQueue queue fuzzProperty
-      worker queue stats workerId
+      atomically $ modifyTVar' (statsCompletedBatches stats) (+ 1)
+      worker scheduler stats workerId
     _ -> pure (WorkerFailure fuzzProperty result)
 
 runBatch :: Stats -> Int -> FuzzProperty -> IO QC.Result

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz.hs
@@ -10,11 +10,12 @@ where
 
 import Aihc.Dev.Fuzz.CLI (Command (..), Options (..), Selection (..))
 import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
+import Aihc.Dev.Fuzz.TUI (Dashboard (..), renderDashboard, renderFrameUpdate)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, async, cancel, race, waitAnyCatch)
 import Control.Concurrent.STM
 import Control.Exception (SomeException, bracket_, displayException, finally, onException)
-import Control.Monad (forM, forM_, when)
+import Control.Monad (forM, forM_, unless, when)
 import Data.Char (toLower)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
@@ -22,6 +23,7 @@ import Data.List (groupBy, intercalate, isInfixOf, sortOn)
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
 import GHC.Conc (getNumCapabilities)
+import System.Console.Terminal.Size qualified as Terminal
 import System.Exit (exitFailure)
 import System.IO (BufferMode (NoBuffering), hFlush, hGetBuffering, hIsTerminalDevice, hPutStr, hPutStrLn, hSetBuffering, stderr)
 import Test.QuickCheck qualified as QC
@@ -187,7 +189,7 @@ withDashboard startedAt propertyCount jobs stats action = do
 enterDashboard :: IO ()
 enterDashboard = do
   hSetBuffering stderr NoBuffering
-  hPutStr stderr "\ESC[?1049h\ESC[?25l"
+  hPutStr stderr "\ESC[?1049h\ESC[2J\ESC[H\ESC[?25l"
 
 leaveDashboard :: BufferMode -> IO ()
 leaveDashboard originalBuffering = do
@@ -195,54 +197,37 @@ leaveDashboard originalBuffering = do
   hSetBuffering stderr originalBuffering
 
 renderLoop :: UTCTime -> Int -> Int -> Stats -> IO ()
-renderLoop startedAt propertyCount jobs stats = go
+renderLoop startedAt propertyCount jobs stats = go []
   where
-    go = do
+    go previousFrame = do
       now <- getCurrentTime
       active <- readTVarIO (statsActive stats)
       successfulCases <- readTVarIO (statsSuccessfulCases stats)
       completedBatches <- readTVarIO (statsCompletedBatches stats)
-      hPutStr stderr "\ESC[H\ESC[2J"
-      hPutStrLn stderr "AIHC fuzz"
-      hPutStrLn stderr (replicate 72 '=')
-      hPutStrLn stderr $
-        intercalate
-          "   "
-          [ "elapsed " <> formatElapsed (diffUTCTime now startedAt),
-            "cases " <> formatInteger successfulCases,
-            "batches " <> formatInteger completedBatches
-          ]
-      hPutStrLn stderr ("properties " <> show propertyCount <> "   jobs " <> show jobs <> "   batch size " <> formatInteger batchSize)
-      hPutStrLn stderr ""
-      hPutStrLn stderr "Active properties"
-      if IntMap.null active
-        then hPutStrLn stderr "  waiting for workers..."
-        else forM_ (IntMap.toAscList active) $ \(workerId, ActiveProperty {activePropertyId, activeSuccessfulCases}) ->
-          hPutStrLn stderr $
-            "  ["
-              <> show workerId
-              <> "] "
-              <> leftPad 6 (formatInteger activeSuccessfulCases)
-              <> " / 10,000  "
-              <> activePropertyId
-      hFlush stderr
-      threadDelay 100000
-      go
-
-formatElapsed :: NominalDiffTime -> String
-formatElapsed elapsed =
-  let totalSeconds = max 0 (floor elapsed :: Int)
-      (hours, afterHours) = totalSeconds `divMod` 3600
-      (minutes, seconds) = afterHours `divMod` 60
-   in pad2 hours <> ":" <> pad2 minutes <> ":" <> pad2 seconds
-
-pad2 :: Int -> String
-pad2 value =
-  let rendered = show value
-   in replicate (max 0 (2 - length rendered)) '0' <> rendered
-
-leftPad :: Int -> String -> String
-leftPad width value = replicate (max 0 (width - length value)) ' ' <> value
+      terminalSize <- Terminal.size
+      let (rows, columns) =
+            case terminalSize of
+              Just window -> (Terminal.height window, Terminal.width window)
+              Nothing -> (24, 80)
+          currentFrame =
+            renderDashboard
+              rows
+              columns
+              Dashboard
+                { dashboardActive =
+                    [ (workerId, activePropertyId, activeSuccessfulCases)
+                    | (workerId, ActiveProperty {activePropertyId, activeSuccessfulCases}) <- IntMap.toAscList active
+                    ],
+                  dashboardBatches = completedBatches,
+                  dashboardCases = successfulCases,
+                  dashboardElapsed = diffUTCTime now startedAt,
+                  dashboardJobs = jobs,
+                  dashboardProperties = propertyCount
+                }
+          update = renderFrameUpdate rows previousFrame currentFrame
+      unless (null update) $ hPutStr stderr update >> hFlush stderr
+      threadDelay 125000
+      go currentFrame
 
 formatInteger :: Int -> String
 formatInteger value =

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz/CLI.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz/CLI.hs
@@ -1,0 +1,114 @@
+-- | Command-line interface for @aihc-dev fuzz@.
+module Aihc.Dev.Fuzz.CLI
+  ( Command (..),
+    Options (..),
+    Selection (..),
+    commandParser,
+    parseDuration,
+  )
+where
+
+import Data.Char (isDigit)
+import Data.Time.Clock (NominalDiffTime)
+import Options.Applicative
+import Text.Read (readMaybe)
+
+data Command
+  = List Selection
+  | Run Options
+  deriving (Eq, Show)
+
+data Options = Options
+  { optionsSelection :: Selection,
+    optionsJobs :: Maybe Int,
+    optionsTimeLimit :: Maybe NominalDiffTime
+  }
+  deriving (Eq, Show)
+
+data Selection = Selection
+  { selectionFilters :: [String],
+    selectionExclusions :: [String]
+  }
+  deriving (Eq, Show)
+
+commandParser :: Parser Command
+commandParser =
+  hsubparser
+    ( command
+        "list"
+        ( info
+            (List <$> selectionParser <**> helper)
+            (progDesc "List available QuickCheck properties")
+        )
+    )
+    <|> (Run <$> optionsParser)
+
+optionsParser :: Parser Options
+optionsParser =
+  Options
+    <$> selectionParser
+    <*> optional
+      ( option
+          positiveInt
+          ( long "jobs"
+              <> short 'j'
+              <> metavar "N"
+              <> help "Number of properties to run in parallel (default: RTS capabilities)"
+          )
+      )
+    <*> optional
+      ( option
+          durationReader
+          ( long "time-limit"
+              <> metavar "DURATION"
+              <> help "Stop after a duration such as 30s, 10m, or 2h"
+          )
+      )
+
+selectionParser :: Parser Selection
+selectionParser =
+  Selection
+    <$> many
+      ( strOption
+          ( long "filter"
+              <> short 'f'
+              <> metavar "TEXT"
+              <> help "Run properties whose component-qualified name contains TEXT (repeatable)"
+          )
+      )
+    <*> many
+      ( strOption
+          ( long "exclude"
+              <> short 'x'
+              <> metavar "TEXT"
+              <> help "Skip properties whose component-qualified name contains TEXT (repeatable)"
+          )
+      )
+
+positiveInt :: ReadM Int
+positiveInt = eitherReader $ \raw ->
+  case readMaybe raw of
+    Just parsed | parsed > 0 -> Right parsed
+    _ -> Left "expected a positive integer"
+
+durationReader :: ReadM NominalDiffTime
+durationReader = eitherReader parseDuration
+
+parseDuration :: String -> Either String NominalDiffTime
+parseDuration raw =
+  case span (\char -> isDigit char || char == '.') raw of
+    (number, suffix)
+      | Just durationValue <- readMaybe number,
+        durationValue > (0 :: Double),
+        Just multiplier <- durationMultiplier suffix ->
+          Right (realToFrac (durationValue * multiplier))
+    _ -> Left "expected a positive duration with suffix ms, s, m, or h (for example 30s)"
+
+durationMultiplier :: String -> Maybe Double
+durationMultiplier suffix =
+  case suffix of
+    "ms" -> Just 0.001
+    "s" -> Just 1
+    "m" -> Just 60
+    "h" -> Just 3600
+    _ -> Nothing

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz/Registry.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz/Registry.hs
@@ -1,0 +1,35 @@
+-- | Workspace-wide QuickCheck property registry.
+module Aihc.Dev.Fuzz.Registry
+  ( FuzzProperty (..),
+    fuzzProperties,
+    fuzzPropertyId,
+  )
+where
+
+import Aihc.Grin.Fuzz (grinFuzzProperties)
+import Aihc.Parser.Compat.Fuzz (parserCompatFuzzProperties)
+import Aihc.Parser.Fuzz (parserFuzzProperties)
+import Aihc.Tc.Fuzz (tcFuzzProperties)
+import Test.QuickCheck (Property)
+
+data FuzzProperty = FuzzProperty
+  { fuzzPropertyComponent :: String,
+    fuzzPropertyName :: String,
+    fuzzPropertyValue :: Property
+  }
+
+fuzzPropertyId :: FuzzProperty -> String
+fuzzPropertyId fuzzProperty =
+  fuzzPropertyComponent fuzzProperty <> "." <> fuzzPropertyName fuzzProperty
+
+-- | All continuously runnable properties, grouped by their owning component.
+fuzzProperties :: [FuzzProperty]
+fuzzProperties =
+  concat
+    [ qualify "aihc-parser" parserFuzzProperties,
+      qualify "aihc-parser-compat" parserCompatFuzzProperties,
+      qualify "aihc-tc" tcFuzzProperties,
+      qualify "aihc-grin" grinFuzzProperties
+    ]
+  where
+    qualify component = map (uncurry (FuzzProperty component))

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz/TUI.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz/TUI.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Pure dashboard layout and incremental ANSI rendering.
+module Aihc.Dev.Fuzz.TUI
+  ( Dashboard (..),
+    renderDashboard,
+    renderFrameUpdate,
+  )
+where
+
+import Data.List (intercalate, isPrefixOf)
+import Data.Time.Clock (NominalDiffTime)
+import Text.Printf (printf)
+
+data Dashboard = Dashboard
+  { dashboardActive :: [(Int, String, Int)],
+    dashboardBatches :: Int,
+    dashboardCases :: Int,
+    dashboardElapsed :: NominalDiffTime,
+    dashboardJobs :: Int,
+    dashboardProperties :: Int
+  }
+
+-- | Lay out a dashboard that never exceeds the usable terminal rectangle.
+renderDashboard :: Int -> Int -> Dashboard -> [String]
+renderDashboard rows columns dashboard
+  | rows <= 0 || columns <= 1 = []
+  | rows < 8 || columns < 50 = compactDashboard rows usableWidth dashboard
+  | otherwise = fullDashboard rows usableWidth dashboard
+  where
+    -- Avoid writing in the bottom-right cell, which makes many terminals scroll.
+    usableWidth = columns - 1
+
+fullDashboard :: Int -> Int -> Dashboard -> [String]
+fullDashboard rows width dashboard@Dashboard {dashboardActive, dashboardBatches, dashboardCases, dashboardElapsed, dashboardJobs, dashboardProperties} =
+  map (clip width) $
+    [ alignedTitle width (" AIHC FUZZ  " <> statusDot <> " RUNNING") (formatElapsed dashboardElapsed),
+      replicate width '─',
+      " "
+        <> formatInteger dashboardCases
+        <> " cases  ·  "
+        <> formatInteger dashboardBatches
+        <> " batches  ·  "
+        <> show dashboardProperties
+        <> " properties",
+      " " <> show dashboardJobs <> " workers  ·  10,000 cases per batch",
+      "",
+      " ACTIVE  " <> show (length dashboardActive)
+    ]
+      <> activeLines (rows - 6) width dashboard
+
+compactDashboard :: Int -> Int -> Dashboard -> [String]
+compactDashboard rows width dashboard@Dashboard {dashboardCases, dashboardElapsed} =
+  map (clip width) $
+    take rows $
+      [ "AIHC FUZZ "
+          <> statusDot
+          <> "  "
+          <> formatElapsed dashboardElapsed
+          <> "  ·  "
+          <> formatInteger dashboardCases
+          <> " cases"
+      ]
+        <> activeLines (rows - 1) width dashboard
+
+activeLines :: Int -> Int -> Dashboard -> [String]
+activeLines slots width Dashboard {dashboardActive = firstActive : remainingActive}
+  | slots <= 0 = []
+  | length dashboardActive <= slots = map (renderActive width) dashboardActive
+  | slots == 1 = [renderCompactActive firstActive <> "  (+" <> show (length remainingActive) <> ")"]
+  | otherwise =
+      map (renderActive width) (take (slots - 1) dashboardActive)
+        <> ["  + " <> show (length dashboardActive - slots + 1) <> " more active workers"]
+  where
+    dashboardActive = firstActive : remainingActive
+activeLines _ _ Dashboard {dashboardActive = []} = []
+
+renderActive :: Int -> (Int, String, Int) -> String
+renderActive width active@(workerId, propertyId, successfulCases)
+  | width < 50 = renderCompactActive active
+  | otherwise =
+      "  "
+        <> leftPad 2 (show workerId)
+        <> "  "
+        <> progressBar barWidth successfulCases
+        <> "  "
+        <> leftPad 6 (formatInteger successfulCases)
+        <> " / 10,000  "
+        <> propertyId
+  where
+    barWidth = max 8 (min 18 (width `div` 5))
+
+renderCompactActive :: (Int, String, Int) -> String
+renderCompactActive (workerId, propertyId, successfulCases) =
+  "[" <> show workerId <> "] " <> leftPad 3 (show percentage) <> "%  " <> propertyId
+  where
+    percentage = min 100 (successfulCases * 100 `div` 10000)
+
+progressBar :: Int -> Int -> String
+progressBar width successfulCases =
+  replicate complete '━' <> replicate (width - complete) '─'
+  where
+    complete = min width (successfulCases * width `div` 10000)
+
+alignedTitle :: Int -> String -> String -> String
+alignedTitle width left right =
+  left <> replicate padding ' ' <> right
+  where
+    padding = max 1 (width - length left - length right)
+
+-- | Render only rows whose contents changed. The returned update never clears
+-- the whole screen, so frequent progress updates do not produce visible flashes.
+renderFrameUpdate :: Int -> [String] -> [String] -> String
+renderFrameUpdate rows previous current =
+  concatMap renderChangedRow [1 .. min rows (max (length previous) (length current))]
+  where
+    renderChangedRow row
+      | previousLine == currentLine = ""
+      | otherwise = cursorAt row <> "\ESC[2K" <> styleLine currentLine
+      where
+        previousLine = lineAt row previous
+        currentLine = lineAt row current
+
+lineAt :: Int -> [String] -> String
+lineAt row lines' =
+  case drop (row - 1) lines' of
+    line : _ -> line
+    [] -> ""
+
+cursorAt :: Int -> String
+cursorAt row = "\ESC[" <> show row <> ";1H"
+
+styleLine :: String -> String
+styleLine line
+  | "AIHC FUZZ" `isPrefixOf` dropWhile (== ' ') line = bold <> cyan <> line <> reset
+  | not (null line) && all (== '─') line = dim <> line <> reset
+  | " ACTIVE" `isPrefixOf` line = bold <> line <> reset
+  | "  + " `isPrefixOf` line = yellow <> line <> reset
+  | otherwise = line
+
+statusDot :: String
+statusDot = "●"
+
+bold, cyan, dim, reset, yellow :: String
+bold = "\ESC[1m"
+cyan = "\ESC[36m"
+dim = "\ESC[2m"
+yellow = "\ESC[33m"
+reset = "\ESC[0m"
+
+clip :: Int -> String -> String
+clip width value
+  | width <= 0 = ""
+  | length value <= width = value
+  | width == 1 = "…"
+  | otherwise = take (width - 1) value <> "…"
+
+formatElapsed :: NominalDiffTime -> String
+formatElapsed elapsed =
+  let totalSeconds = max 0 (floor elapsed :: Int)
+      (hours, afterHours) = totalSeconds `divMod` 3600
+      (minutes, seconds) = afterHours `divMod` 60
+   in printf "%02d:%02d:%02d" hours minutes seconds
+
+leftPad :: Int -> String -> String
+leftPad width value = replicate (max 0 (width - length value)) ' ' <> value
+
+formatInteger :: Int -> String
+formatInteger value =
+  reverse . intercalate "," . chunksOfThree . reverse $ show value
+  where
+    chunksOfThree [] = []
+    chunksOfThree input = take 3 input : chunksOfThree (drop 3 input)

--- a/tooling/aihc-dev/src/Aihc/Dev/Fuzz/TUI.hs
+++ b/tooling/aihc-dev/src/Aihc/Dev/Fuzz/TUI.hs
@@ -43,7 +43,7 @@ fullDashboard rows width dashboard@Dashboard {dashboardActive, dashboardBatches,
         <> " batches  ·  "
         <> show dashboardProperties
         <> " properties",
-      " " <> show dashboardJobs <> " workers  ·  10,000 cases per batch",
+      " " <> show dashboardJobs <> " workers  ·  10,000 cases per batch  ·  q/esc quit",
       "",
       " ACTIVE  " <> show (length dashboardActive)
     ]

--- a/tooling/aihc-dev/test/Spec.hs
+++ b/tooling/aihc-dev/test/Spec.hs
@@ -12,6 +12,7 @@ import Aihc.Dev.Snippet
   )
 import Aihc.Parser.Syntax (Extension (TypeApplications), ExtensionSetting (..))
 import Test.ExtractHiCompare (extractHiCompareTests)
+import Test.Fuzz (fuzzTests)
 import Test.GoldenUpdate (goldenUpdateTests)
 import Test.ParserBenchReport (parserBenchReportTests)
 import Test.ParserCLI.Suite (cliTests)
@@ -73,6 +74,7 @@ main = do
         assertEqual "extension" (Right (EnableExtension TypeApplications)) (parseExtensionSettingArg "TypeApplications"),
       QC.testProperty "dummy quickcheck property" prop_dummy,
       extractHiCompareTests,
+      fuzzTests,
       resolvePackageTests,
       goldenUpdateTests,
       resolveStackagePathsModuleTests,

--- a/tooling/aihc-dev/test/Test/Fuzz.hs
+++ b/tooling/aihc-dev/test/Test/Fuzz.hs
@@ -1,0 +1,59 @@
+module Test.Fuzz
+  ( fuzzTests,
+  )
+where
+
+import Aihc.Dev.Fuzz (batchSize, selectProperties)
+import Aihc.Dev.Fuzz.CLI (Command (..), Selection (..), commandParser, parseDuration)
+import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
+import Data.List (isInfixOf, nub)
+import Data.Set qualified as Set
+import Options.Applicative (ParserResult (..), defaultPrefs, execParserPure, info)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+fuzzTests :: TestTree
+fuzzTests =
+  testGroup
+    "fuzz"
+    [ testCase "uses 10,000-case scheduling batches" $
+        assertEqual "batch size" 10000 batchSize,
+      testCase "parses supported time-limit units" $ do
+        assertEqual "milliseconds" (Right 0.25) (parseDuration "250ms")
+        assertEqual "seconds" (Right 30) (parseDuration "30s")
+        assertEqual "fractional minutes" (Right 90) (parseDuration "1.5m")
+        assertEqual "hours" (Right 7200) (parseDuration "2h"),
+      testCase "rejects invalid time limits" $ do
+        assertBool "missing unit" (isLeft (parseDuration "30"))
+        assertBool "zero" (isLeft (parseDuration "0s"))
+        assertBool "unknown unit" (isLeft (parseDuration "1d")),
+      testCase "parses the list subcommand with selection flags" $
+        case execParserPure defaultPrefs (info commandParser mempty) ["list", "--filter", "TC", "--exclude", "reflexive"] of
+          Success command ->
+            assertEqual
+              "command"
+              (List (Selection ["TC"] ["reflexive"]))
+              command
+          Failure failure -> fail (show failure)
+          CompletionInvoked _ -> fail "unexpected shell completion",
+      testCase "filters and excludes component-qualified names case-insensitively" $ do
+        let selected = selectProperties (Selection ["ROUND-TRIP"] ["compat"]) fuzzProperties
+            identifiers = map fuzzPropertyId selected
+        assertBool "selected at least one property" (not (null selected))
+        assertBool "all match filter" (all ("round-trip" `isInfixOf`) identifiers)
+        assertBool "none match exclusion" (not (any ("compat" `isInfixOf`) identifiers)),
+      testCase "registry has unique properties organized by component" $ do
+        let identifiers = map fuzzPropertyId fuzzProperties
+            components = Set.fromList (map fuzzPropertyComponent fuzzProperties)
+        assertEqual "unique identifiers" (length identifiers) (length (nub identifiers))
+        assertEqual
+          "components"
+          (Set.fromList ["aihc-grin", "aihc-parser", "aihc-parser-compat", "aihc-tc"])
+          components
+    ]
+
+isLeft :: Either left right -> Bool
+isLeft value =
+  case value of
+    Left _ -> True
+    Right _ -> False

--- a/tooling/aihc-dev/test/Test/Fuzz.hs
+++ b/tooling/aihc-dev/test/Test/Fuzz.hs
@@ -6,6 +6,7 @@ where
 import Aihc.Dev.Fuzz (batchSize, selectProperties)
 import Aihc.Dev.Fuzz.CLI (Command (..), Selection (..), commandParser, parseDuration)
 import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
+import Aihc.Dev.Fuzz.TUI (Dashboard (..), renderDashboard, renderFrameUpdate)
 import Data.List (isInfixOf, nub)
 import Data.Set qualified as Set
 import Options.Applicative (ParserResult (..), defaultPrefs, execParserPure, info)
@@ -49,8 +50,51 @@ fuzzTests =
         assertEqual
           "components"
           (Set.fromList ["aihc-grin", "aihc-parser", "aihc-parser-compat", "aihc-tc"])
-          components
+          components,
+      testCase "dashboard stays within short and narrow terminals" $ do
+        let frame = renderDashboard 3 24 sampleDashboard
+        assertEqual "uses available rows" 3 (length frame)
+        assertBool "respects terminal width" (all ((<= 23) . length) frame)
+        assertBool "reports hidden workers" (any ("more active" `isInfixOf`) frame),
+      testCase "dashboard has a useful one-row fallback" $ do
+        let frame = renderDashboard 1 18 sampleDashboard
+        assertEqual "one row" 1 (length frame)
+        assertBool "keeps identity" $ case frame of
+          line : _ -> "AIHC FUZZ" `isInfixOf` line
+          [] -> False,
+      testCase "dashboard renders progress without filling unused rows" $ do
+        let frame = renderDashboard 20 90 sampleDashboard
+        assertBool "does not pad to terminal height" (length frame < 20)
+        assertBool "shows active count" (any ("ACTIVE  5" `isInfixOf`) frame)
+        assertBool "shows progress bar" (any ('━' `elem`) frame)
+        assertBool "respects terminal width" (all ((<= 89) . length) frame),
+      testCase "incremental renderer only updates changed rows" $ do
+        let update = renderFrameUpdate 10 ["title", "old", "same"] ["title", "new", "same"]
+        assertBool "does not clear screen" (not ("\ESC[2J" `isInfixOf` update))
+        assertBool "leaves unchanged first row alone" (not ("\ESC[1;1H" `isInfixOf` update))
+        assertBool "updates changed row" ("\ESC[2;1H" `isInfixOf` update),
+      testCase "incremental renderer clears stale rows" $
+        assertBool
+          "clears removed second row"
+          ("\ESC[2;1H\ESC[2K" `isInfixOf` renderFrameUpdate 10 ["title", "stale"] ["title"])
     ]
+
+sampleDashboard :: Dashboard
+sampleDashboard =
+  Dashboard
+    { dashboardActive =
+        [ (1, "aihc-parser.expr round-trip", 1250),
+          (2, "aihc-parser.decl round-trip", 5000),
+          (3, "aihc-parser.module validator", 9999),
+          (4, "aihc-tc.zonking idempotent", 2500),
+          (5, "aihc-grin.pretty-printer round-trip", 7500)
+        ],
+      dashboardBatches = 42,
+      dashboardCases = 424242,
+      dashboardElapsed = 65,
+      dashboardJobs = 5,
+      dashboardProperties = 35
+    }
 
 isLeft :: Either left right -> Bool
 isLeft value =

--- a/tooling/aihc-dev/test/Test/Fuzz.hs
+++ b/tooling/aihc-dev/test/Test/Fuzz.hs
@@ -3,7 +3,7 @@ module Test.Fuzz
   )
 where
 
-import Aihc.Dev.Fuzz (batchSize, cycleProperties, dashboardRefreshMicroseconds, resolveJobCount, selectProperties)
+import Aihc.Dev.Fuzz (batchSize, cycleProperties, dashboardRefreshMicroseconds, isQuitKey, resolveJobCount, selectProperties)
 import Aihc.Dev.Fuzz.CLI (Command (..), Selection (..), commandParser, parseDuration)
 import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
 import Aihc.Dev.Fuzz.TUI (Dashboard (..), renderDashboard, renderFrameUpdate)
@@ -30,6 +30,11 @@ fuzzTests =
           (take 7 (cycleProperties ["one", "two", "three"])),
       testCase "does not cap jobs at the selected property count" $
         assertEqual "jobs" 10 (resolveJobCount 4 (Just 10)),
+      testCase "recognizes q and escape as quit keys" $ do
+        assertBool "lowercase q" (isQuitKey 'q')
+        assertBool "uppercase q" (isQuitKey 'Q')
+        assertBool "escape" (isQuitKey '\ESC')
+        assertBool "other key" (not (isQuitKey 'x')),
       testCase "parses supported time-limit units" $ do
         assertEqual "milliseconds" (Right 0.25) (parseDuration "250ms")
         assertEqual "seconds" (Right 30) (parseDuration "30s")

--- a/tooling/aihc-dev/test/Test/Fuzz.hs
+++ b/tooling/aihc-dev/test/Test/Fuzz.hs
@@ -3,7 +3,7 @@ module Test.Fuzz
   )
 where
 
-import Aihc.Dev.Fuzz (batchSize, dashboardRefreshMicroseconds, selectProperties)
+import Aihc.Dev.Fuzz (batchSize, cycleProperties, dashboardRefreshMicroseconds, resolveJobCount, selectProperties)
 import Aihc.Dev.Fuzz.CLI (Command (..), Selection (..), commandParser, parseDuration)
 import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
 import Aihc.Dev.Fuzz.TUI (Dashboard (..), renderDashboard, renderFrameUpdate)
@@ -21,6 +21,15 @@ fuzzTests =
         assertEqual "batch size" 10000 batchSize,
       testCase "refreshes the dashboard at most every five seconds" $
         assertEqual "refresh interval" (5 * 1000000) dashboardRefreshMicroseconds,
+      testCase "feeds one selected property to every worker" $
+        assertEqual "assignments" (replicate 10 "only") (take 10 (cycleProperties ["only"])),
+      testCase "cycles property assignments without tracking active work" $
+        assertEqual
+          "assignments"
+          ["one", "two", "three", "one", "two", "three", "one"]
+          (take 7 (cycleProperties ["one", "two", "three"])),
+      testCase "does not cap jobs at the selected property count" $
+        assertEqual "jobs" 10 (resolveJobCount 4 (Just 10)),
       testCase "parses supported time-limit units" $ do
         assertEqual "milliseconds" (Right 0.25) (parseDuration "250ms")
         assertEqual "seconds" (Right 30) (parseDuration "30s")

--- a/tooling/aihc-dev/test/Test/Fuzz.hs
+++ b/tooling/aihc-dev/test/Test/Fuzz.hs
@@ -3,7 +3,7 @@ module Test.Fuzz
   )
 where
 
-import Aihc.Dev.Fuzz (batchSize, selectProperties)
+import Aihc.Dev.Fuzz (batchSize, dashboardRefreshMicroseconds, selectProperties)
 import Aihc.Dev.Fuzz.CLI (Command (..), Selection (..), commandParser, parseDuration)
 import Aihc.Dev.Fuzz.Registry (FuzzProperty (..), fuzzProperties, fuzzPropertyId)
 import Aihc.Dev.Fuzz.TUI (Dashboard (..), renderDashboard, renderFrameUpdate)
@@ -19,6 +19,8 @@ fuzzTests =
     "fuzz"
     [ testCase "uses 10,000-case scheduling batches" $
         assertEqual "batch size" 10000 batchSize,
+      testCase "refreshes the dashboard at most every five seconds" $
+        assertEqual "refresh interval" (5 * 1000000) dashboardRefreshMicroseconds,
       testCase "parses supported time-limit units" $ do
         assertEqual "milliseconds" (Right 0.25) (parseDuration "250ms")
         assertEqual "seconds" (Right 30) (parseDuration "30s")


### PR DESCRIPTION
## Summary

- add an in-process aihc-dev fuzz runner with round-robin 10,000-case QuickCheck batches
- add a live terminal dashboard with aggregate counts and per-worker active-property progress
- add case-insensitive include/exclude filters, job limits, duration limits, and the fuzz list subcommand
- expose component-owned fuzz registries for parser, parser compatibility, type checking, and GRIN

## Testing

- just fmt
- just check
- manual non-interactive and PTY smoke tests with filtered, time-limited runs

## Progress counts

- 35 continuously runnable properties: 30 aihc-parser, 2 aihc-parser-compat, 2 aihc-tc, and 1 aihc-grin
- no README progress counts changed; those remain cron-managed