### PR TITLE
docs: add user guide infrastructure

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,14 +2,22 @@ name: Deploy Documentation
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/deploy-docs.yml
+      - docs/aihc-users-guide/**
+      - flake.lock
+      - flake.nix
+      - scripts/nix/docs.nix
+      - scripts/nix/packages.nix
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: documentation-content
   cancel-in-progress: false
 
 jobs:
@@ -41,21 +49,39 @@ jobs:
           echo "=== Site structure ==="
           find docs-output -type f | head -50
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
+      - name: Publish generated site
+        run: |
+          set -euo pipefail
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs-output
+          publish_dir=$(mktemp -d)
+          trap 'git worktree remove --force "$publish_dir"' EXIT
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-24.04
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null; then
+            git fetch origin gh-pages
+            git worktree add --detach "$publish_dir" origin/gh-pages
+          else
+            git worktree add --detach "$publish_dir" HEAD
+            git -C "$publish_dir" switch --orphan gh-pages
+            git -C "$publish_dir" rm -rf .
+          fi
+
+          find "$publish_dir" \
+            -mindepth 1 \
+            -maxdepth 1 \
+            ! -name .git \
+            ! -name pr-preview \
+            -exec rm -rf {} +
+          cp -r docs-output/. "$publish_dir/"
+          touch "$publish_dir/.nojekyll"
+
+          git -C "$publish_dir" config user.name github-actions[bot]
+          git -C "$publish_dir" config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C "$publish_dir" add --all
+
+          if git -C "$publish_dir" diff --cached --quiet; then
+            echo "Documentation site is already current."
+            exit 0
+          fi
+
+          git -C "$publish_dir" commit -m "docs: deploy $GITHUB_SHA"
+          git -C "$publish_dir" push origin HEAD:gh-pages

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,55 @@
+name: Documentation Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - .github/workflows/docs-preview.yml
+      - docs/aihc-users-guide/**
+      - flake.lock
+      - flake.nix
+      - scripts/nix/docs.nix
+      - scripts/nix/packages.nix
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: documentation-content
+  cancel-in-progress: false
+
+jobs:
+  preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Nix CI
+        if: github.event.action != 'closed'
+        uses: ./.github/actions/setup-nix-ci
+        with:
+          r2-account-id: ${{ vars.R2_ACCOUNT_ID }}
+          r2-access-key: ${{ vars.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          nix-cache-private-key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+
+      - name: Build user guide
+        if: github.event.action != 'closed'
+        run: |
+          nix build .#user-guide --out-link user-guide-result
+          cp -rL user-guide-result user-guide-preview
+
+      - name: Publish preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: user-guide-preview
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pages-base-url: https://ai-haskell-compiler.github.io/aihc/

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -52,4 +52,3 @@ jobs:
           source-dir: user-guide-preview
           preview-branch: gh-pages
           umbrella-dir: pr-preview
-          pages-base-url: https://ai-haskell-compiler.github.io/aihc/

--- a/.github/workflows/publish-docs-site.yml
+++ b/.github/workflows/publish-docs-site.yml
@@ -1,0 +1,43 @@
+name: Publish Documentation Site
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Documentation
+      - Documentation Preview
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout generated site
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Documentation](https://img.shields.io/github/actions/workflow/status/ai-haskell-compiler/aihc/deploy-docs.yml?label=docs)](https://ai-haskell-compiler.github.io/aihc/)
+[![User guide](https://img.shields.io/github/actions/workflow/status/ai-haskell-compiler/aihc/deploy-docs.yml?label=user%20guide)](https://ai-haskell-compiler.github.io/aihc/)
+[![API docs](https://img.shields.io/github/actions/workflow/status/ai-haskell-compiler/aihc/deploy-docs.yml?label=API%20docs)](https://ai-haskell-compiler.github.io/aihc/api/)
 [![Generated Reports](https://img.shields.io/github/actions/workflow/status/ai-haskell-compiler/aihc/generated-reports-update.yml?label=reports)](https://github.com/ai-haskell-compiler/aihc/actions/workflows/generated-reports-update.yml)
 [![aihc-parser coverage](https://img.shields.io/endpoint?url=https://ai-haskell-compiler.github.io/aihc/coverage/aihc-parser-badge.json)](https://ai-haskell-compiler.github.io/aihc/coverage/aihc-parser-html/hpc_index.html)
 [![aihc-cpp coverage](https://img.shields.io/endpoint?url=https://ai-haskell-compiler.github.io/aihc/coverage/aihc-cpp-badge.json)](https://ai-haskell-compiler.github.io/aihc/coverage/aihc-cpp-html/hpc_index.html)

--- a/docs/aihc-users-guide/mkdocs.yml
+++ b/docs/aihc-users-guide/mkdocs.yml
@@ -1,0 +1,33 @@
+site_name: AIHC User Guide
+site_description: User documentation for the AI-written Haskell Compiler
+site_url: https://ai-haskell-compiler.github.io/aihc/
+
+repo_name: ai-haskell-compiler/aihc
+repo_url: https://github.com/ai-haskell-compiler/aihc
+edit_uri: edit/main/docs/aihc-users-guide/src/
+
+docs_dir: src
+
+theme:
+  name: material
+  features:
+    - content.action.edit
+    - content.code.copy
+    - navigation.footer
+    - navigation.sections
+    - navigation.top
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - toc:
+      permalink: true
+
+nav:
+  - User Guide: index.md
+  - API documentation: https://ai-haskell-compiler.github.io/aihc/api/

--- a/docs/aihc-users-guide/src/index.md
+++ b/docs/aihc-users-guide/src/index.md
@@ -1,0 +1,6 @@
+# AIHC User Guide
+
+The AIHC user guide is under construction.
+
+For library interfaces, see the
+[API documentation](https://ai-haskell-compiler.github.io/aihc/api/).

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
       inherit (haskell) mkHsPkgsWithCoverage;
     };
     mkPackages = import ./scripts/nix/packages.nix {
-      inherit (docs) mkCombinedDocs;
+      inherit (docs) mkApiDocs mkCombinedDocs mkUserGuide;
       inherit (coverage) mkCoverageReport;
     };
     mkApps = import ./scripts/nix/apps.nix {

--- a/justfile
+++ b/justfile
@@ -33,12 +33,17 @@ hlint-refactor:
 
 # Run full CI check: format, lint, then tests (warnings are errors only here, not in plain `cabal` / `just test`)
 check:
+  nix build .#user-guide --no-link
   nix develop --quiet --command bash -c 'failed=0; while IFS= read -r -d "" file; do cabal-gild --mode check --input "$file" || failed=1; done < <(find . -name "*.cabal" -not -path "*/.git/*" -not -path "*/dist-newstyle/*" -not -path "*/result/*" -print0); exit "$failed"'
   nix develop --quiet --command bash -c 'ormolu --mode check $(find components tooling bin core-libs scripts/nix/ucd2haskell-aihc test/support -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   nix develop --quiet --command bash -c 'hlint -j $(find components tooling bin core-libs scripts/nix/ucd2haskell-aihc test/support -name "*.hs" -not -path "*/dist-newstyle/*" -not -path "*/test/Test/Fixtures/*")'
   nix develop --quiet --command bash -c 'find components tooling bin core-libs scripts test -type f \( -name "*.c" -o -name "*.h" \) -not -path "*/dist-newstyle/*" -print0 | xargs -0 -r clang-format --dry-run --Werror'
   nix develop --quiet --command bash -c 'while IFS= read -r -d "" file; do clang-tidy --quiet "$file" -- -std=c11 -Wall -Wextra -Wpedantic; done < <(find components tooling bin core-libs scripts test -type f -name "*.c" -not -path "*/dist-newstyle/*" -print0)'
   cabal test -v0 all --ghc-options=-Werror --test-options='--hide-successes --quickcheck-tests 1000'
+
+# Preview the user guide at http://127.0.0.1:8000/.
+docs:
+  nix develop --quiet --command mkdocs serve --config-file docs/aihc-users-guide/mkdocs.yml
 
 # Generate boot package interfaces for the resolver (requires GHC dev env)
 gen-boot-ifaces:

--- a/scripts/nix/dev-shells.nix
+++ b/scripts/nix/dev-shells.nix
@@ -10,6 +10,7 @@ in {
       pkgs.alejandra
       pkgs.hlint
       pkgs.clang-tools
+      pkgs.python3Packages.mkdocs-material
     ];
   };
 }

--- a/scripts/nix/docs.nix
+++ b/scripts/nix/docs.nix
@@ -2,7 +2,7 @@
   projectHsPackages,
   mkHsPkgsWithHaddock,
 }: let
-  mkCombinedDocsFrom = mkHsPkgsBuilder: pkgs: let
+  mkApiDocsFrom = mkHsPkgsBuilder: pkgs: let
     hsPkgsHaddock = mkHsPkgsBuilder pkgs;
     parserDoc = hsPkgsHaddock.aihc-parser.doc;
     cppDoc = hsPkgsHaddock.aihc-cpp.doc;
@@ -37,6 +37,28 @@
         --read-interface=aihc-parser,"$out/aihc-parser/aihc-parser.haddock" \
         --read-interface=aihc-cpp,"$out/aihc-cpp/aihc-cpp.haddock"
     '';
+
+  mkUserGuide = pkgs:
+    pkgs.runCommand "aihc-user-guide" {
+      nativeBuildInputs = [pkgs.python3Packages.mkdocs-material];
+    } ''
+      mkdocs build \
+        --strict \
+        --config-file ${../../docs/aihc-users-guide}/mkdocs.yml \
+        --site-dir "$out"
+    '';
+
+  mkApiDocs = mkApiDocsFrom mkHsPkgsWithHaddock;
+
+  mkCombinedDocs = pkgs: let
+    userGuide = mkUserGuide pkgs;
+    apiDocs = mkApiDocs pkgs;
+  in
+    pkgs.runCommand "aihc-documentation" {} ''
+      mkdir -p "$out/api"
+      cp -r ${userGuide}/. "$out/"
+      cp -r ${apiDocs}/. "$out/api/"
+    '';
 in {
-  mkCombinedDocs = mkCombinedDocsFrom mkHsPkgsWithHaddock;
+  inherit mkApiDocs mkCombinedDocs mkUserGuide;
 }

--- a/scripts/nix/packages.nix
+++ b/scripts/nix/packages.nix
@@ -1,8 +1,12 @@
 {
+  mkApiDocs,
   mkCombinedDocs,
   mkCoverageReport,
+  mkUserGuide,
 }: pkgs: {
+  api-docs = mkApiDocs pkgs;
   docs = mkCombinedDocs pkgs;
   coverage = mkCoverageReport pkgs;
+  user-guide = mkUserGuide pkgs;
   default = mkCombinedDocs pkgs;
 }


### PR DESCRIPTION
## Summary

- add a minimal MkDocs Material user guide under `docs/aihc-users-guide/`
- publish the user guide at the Pages root while moving generated Haddock output to `/api/`
- add `user-guide` and `api-docs` Nix outputs plus `just docs` for local preview
- split the README badge into User guide and API docs links
- add same-repository PR previews at `/pr-preview/pr-<number>/`, with automatic comments, updates, and cleanup
- retain the current GitHub Actions Pages source by publishing production and preview content through a generated `gh-pages` branch snapshot

The preview publisher is activated from the default branch, so live preview comments begin for documentation PRs after this infrastructure PR is merged. Fork PRs do not receive live deployments because their workflow tokens are intentionally read-only.

## Validation

- `just fmt`
- `just check`
- `nix build .#docs`
- `actionlint` on all changed/new documentation workflows
- verified the combined output contains the MkDocs root, its GitHub edit link, and the Haddock `/api/` index

## Progress counts

Unchanged.
