### PR TITLE
fix(ci): make generated docs writable after assembly

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,11 +40,13 @@ jobs:
           echo "=== Building Haddock documentation ==="
           nix build .#docs --print-out-paths
           cp -rL result docs-output
-          chmod -R u+w docs-output
 
           echo "=== Building coverage report ==="
           nix build .#coverage --print-out-paths
           cp -rL result docs-output/coverage
+
+          # Nix outputs are read-only; the publishing worktree must be removable.
+          chmod -R u+w docs-output
 
           echo "=== Site structure ==="
           find docs-output -type f | head -50


### PR DESCRIPTION
## Summary

- move the docs permission normalization until after both documentation and coverage outputs have been assembled
- document why the generated tree must be writable before publication

## Root cause

The coverage report is copied from the read-only Nix store after the existing `chmod -R u+w docs-output`. That leaves `docs-output/coverage` read-only. The publish step copies those modes into its temporary Git worktree, so the exit trap fails with `Permission denied` when `git worktree remove --force` cleans up—even when the generated site is already current.

## Impact

The deploy workflow can cleanly remove its publishing worktree after either a no-op or a pushed documentation deployment.

## Validation

- local regression fixture reproducing a publishing worktree populated from a nested read-only output
- `actionlint .github/workflows/deploy-docs.yml`
- `just fmt`
- `just check`

## Progress counts

Unchanged.
