### PR TITLE
fix(ci): restore docs assembly permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,6 +40,9 @@ jobs:
           echo "=== Building Haddock documentation ==="
           nix build .#docs --print-out-paths
           cp -rL result docs-output
+          # The copied Nix output is read-only; make its root writable before
+          # adding the coverage report below.
+          chmod u+w docs-output
 
           echo "=== Building coverage report ==="
           nix build .#coverage --print-out-paths

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,14 +2,28 @@ name: Deploy Documentation
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
       - main
     paths:
+      - .github/actions/setup-nix-ci/action.yml
       - .github/workflows/deploy-docs.yml
       - docs/aihc-users-guide/**
       - flake.lock
       - flake.nix
+      - scripts/nix/coverage.nix
+      - scripts/nix/docs.nix
+      - scripts/nix/packages.nix
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actions/setup-nix-ci/action.yml
+      - .github/workflows/deploy-docs.yml
+      - docs/aihc-users-guide/**
+      - flake.lock
+      - flake.nix
+      - scripts/nix/coverage.nix
       - scripts/nix/docs.nix
       - scripts/nix/packages.nix
 
@@ -22,6 +36,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -54,7 +69,9 @@ jobs:
           echo "=== Site structure ==="
           find docs-output -type f | head -50
 
-      - name: Publish generated site
+      - name: Stage and publish generated site
+        env:
+          DRY_RUN: ${{ github.event_name == 'pull_request' }}
         run: |
           set -euo pipefail
 
@@ -89,4 +106,10 @@ jobs:
           fi
 
           git -C "$publish_dir" commit -m "docs: deploy $GITHUB_SHA"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run complete; generated site was committed locally."
+            exit 0
+          fi
+
           git -C "$publish_dir" push origin HEAD:gh-pages


### PR DESCRIPTION
## Summary

- make the copied Haddock output root writable before adding the coverage report
- run the full documentation deployment workflow for same-repository pull requests
- stage and locally commit the generated `gh-pages` worktree during pull requests, while suppressing only the final push
- trigger deployment checks when the shared Nix setup or coverage derivation changes

## Root cause

`cp -rL result docs-output` copies the Nix output with a read-only root directory. The workflow moved its permission fix until after the coverage copy, so `cp -rL result docs-output/coverage` failed with `Permission denied` before the fix could run.

The deployment workflow previously ran only after changes reached `main`, so pull-request checks could not detect failures in its assembly or publishing path.

## Impact

Documentation deployments can assemble Haddock output and coverage again. Future same-repository pull requests exercise the real Nix builds, site assembly, `gh-pages` cleanup, copy, staging, and local commit without pushing deployment content.

## Progress counts

Unchanged; this is a CI-only fix and does not change compiler feature progress.

## Validation

- reproduced the failing copy order against locally built `.#docs` and `.#coverage` Nix outputs
- verified the corrected assembly order succeeds and leaves the site writable
- hosted pull-request dry run passed: https://github.com/ai-haskell-compiler/aihc/actions/runs/30002861547
- `nix run nixpkgs#actionlint -- .github/workflows/deploy-docs.yml`
- `just fmt`
- `just check`
