### PR TITLE
fix(c): grow portable argument buffer

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -176,7 +176,7 @@ data LoadedModule = LoadedModule
   }
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 18
+cacheSchemaVersion = 19
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do

--- a/components/aihc-c/src/Aihc/C/Codegen.hs
+++ b/components/aihc-c/src/Aihc/C/Codegen.hs
@@ -120,7 +120,6 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
           "",
           "AihcMachine *aihc_machine;",
           "AihcPortableTransfer aihc_next_transfer;",
-          "static AihcSlot aihc_arguments[" <> tshow (portableArgumentCapacity layout) <> "];",
           ""
         ]
           <> renderForeignDeclarations program
@@ -152,7 +151,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
                "  aihc_set_field(update_continuation, 0, aihc_machine->globals[" <> tshow rootSlot <> "]);",
                "  aihc_set_field(update_continuation, 1, (AihcSlot)(uintptr_t)top_continuation);",
                "  thread_done_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_thread_done_info);",
-               "  aihc_next_transfer = aihc_portable_start(aihc_machine, aihc_arguments, (AihcValue *)(uintptr_t)aihc_machine->globals[" <> tshow rootSlot <> "], top_continuation, update_continuation, thread_done_continuation, aihc_exit);",
+               "  aihc_next_transfer = aihc_portable_start(aihc_machine, (AihcValue *)(uintptr_t)aihc_machine->globals[" <> tshow rootSlot <> "], top_continuation, update_continuation, thread_done_continuation, aihc_exit);",
                "  while (aihc_next_transfer.entry != NULL) {",
                "    transfer = aihc_next_transfer;",
                "    aihc_next_transfer = (AihcPortableTransfer){0};",
@@ -180,7 +179,6 @@ compileModule layout initializerSymbol gcProgram = do
           "",
           "extern AihcMachine *aihc_machine;",
           "extern AihcPortableTransfer aihc_next_transfer;",
-          "static AihcSlot aihc_arguments[" <> tshow (portableArgumentCapacity layout) <> "];",
           ""
         ]
           <> renderForeignDeclarations program
@@ -270,9 +268,6 @@ compileEnvironment unitKind layout program =
       ]
     infoLabels = Map.fromList [(key, "aihc_function_info_" <> tshow index) | (index, key) <- zip [0 :: Int ..] infoKeys]
     third (_, _, value) = value
-
-portableArgumentCapacity :: LinkLayout -> Int
-portableArgumentCapacity layout = max 3 (linkMaximumArgumentSlots layout + 1)
 
 requiredNodeConstructorInfos :: GrinNode -> [RuntimeInfoKey]
 requiredNodeConstructorInfos node =
@@ -367,12 +362,12 @@ compileExpr env prefix label expression =
       values <- materializeIntoFresh env [value, continuation, updateContinuation]
       case snd values of
         [valueSlot, continuationSlot, updateSlot] ->
-          terminal label (prefix <> fst values <> [setNext ("aihc_portable_eval_cps(aihc_machine, aihc_arguments, " <> valuePointer (localRef valueSlot) <> ", " <> boolText (isLiftedRuntimeRep runtimeRep) <> ", " <> valuePointer (localRef continuationSlot) <> ", " <> valuePointer (localRef updateSlot) <> ")")])
+          terminal label (prefix <> fst values <> [setNext ("aihc_portable_eval_cps(aihc_machine, " <> valuePointer (localRef valueSlot) <> ", " <> boolText (isLiftedRuntimeRep runtimeRep) <> ", " <> valuePointer (localRef continuationSlot) <> ", " <> valuePointer (localRef updateSlot) <> ")")])
         _ -> unsupported "internal CPS evaluation slot arity"
     GrinCall _ functionName arguments -> do
       target <- liftEither (functionCodeLabel (valueCompileEnv env) functionName)
       values <- materializeIntoFresh env arguments
-      terminal label (prefix <> fst values <> setArguments (snd values) <> ["aihc_next_transfer = (AihcPortableTransfer){" <> target <> ", aihc_arguments};", "return;"])
+      terminal label (prefix <> fst values <> [setNext ("aihc_portable_call(aihc_machine, " <> target <> ", " <> tshow (length arguments) <> ", " <> slotPointer (snd values) <> ")")])
     GrinCpsPrimitiveCall _ name arguments continuation -> compileCpsPrimitive env prefix label name arguments continuation
     GrinCpsApply _ function arguments continuation -> do
       values <- materializeIntoFresh env (function : continuation : arguments)
@@ -380,13 +375,13 @@ compileExpr env prefix label expression =
           argumentSlots = drop 2 slots
       case slots of
         functionSlot : continuationSlot : _ ->
-          terminal label (prefix <> fst values <> [setNext ("aihc_portable_apply_cps(aihc_machine, aihc_arguments, " <> valuePointer (localRef functionSlot) <> ", " <> tshow (length arguments) <> ", " <> slotPointer argumentSlots <> ", " <> valuePointer (localRef continuationSlot) <> ")")])
+          terminal label (prefix <> fst values <> [setNext ("aihc_portable_apply_cps(aihc_machine, " <> valuePointer (localRef functionSlot) <> ", " <> tshow (length arguments) <> ", " <> slotPointer argumentSlots <> ", " <> valuePointer (localRef continuationSlot) <> ")")])
         _ -> unsupported "internal CPS application slot arity"
     GrinContinue continuation values -> do
       stored <- materializeIntoFresh env (continuation : values)
       case snd stored of
         continuationSlot : valueSlots ->
-          terminal label (prefix <> fst stored <> [setNext ("aihc_portable_continue_values(aihc_machine, aihc_arguments, " <> valuePointer (localRef continuationSlot) <> ", " <> tshow (length values) <> ", " <> slotPointer valueSlots <> ")")])
+          terminal label (prefix <> fst stored <> [setNext ("aihc_portable_continue_values(aihc_machine, " <> valuePointer (localRef continuationSlot) <> ", " <> tshow (length values) <> ", " <> slotPointer valueSlots <> ")")])
         [] -> unsupported "internal continuation slot arity"
     GrinHalt _ -> terminal label (prefix <> [setNext "aihc_halt(aihc_machine)"])
     GrinCase scrutinee binder alternatives -> compileCase env prefix label scrutinee binder alternatives
@@ -430,7 +425,7 @@ compileCpsPrimitive env prefix label name arguments continuation =
     transfer function values = do
       stored <- materializeIntoFresh env values
       let arguments' = T.intercalate ", " (map (valuePointer . localRef) (snd stored))
-      addBlock label (prefix <> fst stored <> [setNext (function <> "(aihc_machine, aihc_arguments, " <> arguments' <> ")"), "return;"])
+      addBlock label (prefix <> fst stored <> [setNext (function <> "(aihc_machine, " <> arguments' <> ")"), "return;"])
 
 compileDirectBinding :: ValueEnv -> [GrinVar] -> GrinExpr -> FunctionM [Text]
 compileDirectBinding env vars expression =
@@ -694,12 +689,12 @@ renderSpecialDeclarations =
 renderSpecialFunctions :: [Text]
 renderSpecialFunctions =
   [ "static void aihc_top_continuation(AihcSlot *arguments) {",
-    "  aihc_next_transfer = aihc_portable_apply_cps(aihc_machine, aihc_arguments, (AihcValue *)(uintptr_t)arguments[1], 0, NULL, (AihcValue *)(uintptr_t)arguments[0]);",
+    "  aihc_next_transfer = aihc_portable_apply_cps(aihc_machine, (AihcValue *)(uintptr_t)arguments[1], 0, NULL, (AihcValue *)(uintptr_t)arguments[0]);",
     "}",
     "",
     "static void aihc_thread_done_continuation(AihcSlot *arguments) {",
     "  (void)arguments;",
-    "  aihc_next_transfer = aihc_portable_thread_done(aihc_machine, aihc_arguments);",
+    "  aihc_next_transfer = aihc_portable_thread_done(aihc_machine);",
     "}",
     "",
     "static void aihc_final_continuation(AihcSlot *arguments) {",
@@ -745,10 +740,6 @@ foreignResult foreignType' call =
 allocation :: Bool -> Text -> Text -> Text
 allocation unchecked tag info =
   (if unchecked then "aihc_make_node_unchecked" else "aihc_make_node") <> "(aihc_machine, " <> tag <> ", &" <> info <> ")"
-
-setArguments :: [Int] -> [Text]
-setArguments slots =
-  ["aihc_arguments[" <> tshow index <> "] = " <> localRef slot <> ";" | (index, slot) <- zip [0 :: Int ..] slots]
 
 setNext :: Text -> Text
 setNext expression = "aihc_next_transfer = " <> expression <> ";"

--- a/components/aihc-c/test/Test/C/Suite.hs
+++ b/components/aihc-c/test/Test/C/Suite.hs
@@ -27,6 +27,7 @@ tests =
   testGroup
     "Portable C backend"
     [ testCase "emits a portable trampoline" testTrampoline,
+      testCase "grows the argument buffer for wide continuations" (testProgram "WIDE" wideContinuationProgram),
       testCase "links separately compiled C units" testIncrementalProgram,
       testCase "traps dormant unsupported primitives in compiled modules" testDormantPrimitive,
       testCase "executes Int# addition" (testProgram "*" (intAddProgram 40 2 42)),
@@ -105,43 +106,65 @@ testTrampoline = do
     ]
     (\needle -> assertBool ("missing generated C fragment: " <> T.unpack needle) (needle `T.isInfixOf` source))
   assertBool "generated C does not use a machine argument field" (not ("aihc_machine->args" `T.isInfixOf` source))
-  assertBool "portable C owns a static reusable argument buffer" ("static AihcSlot aihc_arguments[" `T.isInfixOf` source)
-  let wideGcProgram = expectGcGrin wideArgumentProgram
-      wideLayout = buildLinkLayout [wideArgumentProgram]
-  wideSource <-
-    case compileProgramWithDependencies wideLayout [] "main" wideGcProgram of
-      Right generated -> pure generated
-      Left err -> assertFailure ("wide-argument C lowering failed: " <> show err)
-  assertBool "argument buffer includes the CPS continuation" ("static AihcSlot aihc_arguments[5];" `T.isInfixOf` wideSource)
+  assertBool "generated C does not own a fixed argument buffer" (not ("static AihcSlot aihc_arguments[" `T.isInfixOf` source))
   runtime <- readFile =<< runtimeSourcePath
   assertBool "runtime does not contain a machine argument field" (not ("machine->args" `isInfixOf` runtime))
+  assertBool "runtime owns direct-call argument transfers" ("AihcPortableTransfer aihc_portable_call" `isInfixOf` runtime)
+  assertBool "runtime owns a growable portable argument buffer" ("&machine->portable_arguments_capacity" `isInfixOf` runtime)
 
-wideArgumentProgram :: GrinProgram
-wideArgumentProgram =
-  schedulerProgram
-    { grinFunctions =
-        grinFunctions schedulerProgram
-          <> [ GrinFunction
-                 { grinFunctionName = FunctionName "$wide_arguments",
-                   grinFunctionLinkName = Nothing,
-                   grinFunctionParameters = parameters,
-                   grinFunctionResultRep = Int32Rep,
-                   grinFunctionBody = GrinConstant [GrinVarValue firstParameter]
-                 }
-             ]
+wideContinuationProgram :: GrinProgram
+wideContinuationProgram =
+  GrinProgram
+    { grinConstructors = [],
+      grinPrimitives = [],
+      grinForeignCalls = [putcharCall],
+      grinExternalGlobals = [],
+      grinExternalFunctions = [],
+      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
+      grinCafs = [],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = mainFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = lifted,
+              grinFunctionBody =
+                GrinBind characters (GrinConstant characterValues) $
+                  GrinBind [ignored] (GrinCall lifted helperFunction []) $
+                    foldr outputCharacter (GrinConstant [GrinVarValue unitValue]) characters
+            },
+          GrinFunction
+            { grinFunctionName = helperFunction,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = lifted,
+              grinFunctionBody = GrinConstant [GrinVarValue unitValue]
+            }
+        ]
     }
   where
-    firstParameter = GrinVar "argument_0" 50 Int32Rep
-    parameters = firstParameter : [GrinVar ("argument_" <> T.pack (show index)) (50 + index) Int32Rep | index <- [1 .. 3]]
+    lifted = BoxedRep Lifted
+    mainFunction = FunctionName "$wide_continuation_main"
+    helperFunction = FunctionName "$wide_continuation_helper"
+    mainClosure = GrinVar "main" 50 lifted
+    characters = zipWith (\index character -> GrinVar (T.singleton character) index Int32Rep) [51 ..] "WIDE"
+    characterValues = map (GrinLitValue . GrinLitInt Int32Rep . toInteger . fromEnum) "WIDE"
+    ignored = GrinVar "ignored" 55 lifted
+    unitValue = GrinVar "()" 56 lifted
+    outputCharacter character =
+      GrinBind
+        [GrinVar ("output_" <> grinVarName character) (grinVarUnique character + 10) Int32Rep]
+        (GrinForeignCallExpr putcharCall [GrinVarValue character])
 
 testIncrementalProgram :: IO ()
 testIncrementalProgram = do
   let initializer = "aihc_init_dependency"
+      dependencyLayout = buildLinkLayout [incrementalDependencyProgram]
       layout = buildLinkLayout [incrementalDependencyProgram, incrementalMainProgram]
       dependencyGc = expectGcGrin incrementalDependencyProgram
       mainGc = expectGcGrin incrementalMainProgram
   dependencySource <-
-    case compileModule layout initializer dependencyGc of
+    case compileModule dependencyLayout initializer dependencyGc of
       Right source -> pure source
       Left err -> assertFailure ("dependency C lowering failed: " <> show err)
   mainSource <-
@@ -175,7 +198,7 @@ testIncrementalProgram = do
     assertEqual ("clang rejected incremental generated C:\n" <> clangErr) ExitSuccess clangExit
     (programExit, programOut, programErr) <- readProcessWithExitCode executablePath [] ""
     assertEqual ("incremental program stderr: " <> programErr) ExitSuccess programExit
-    assertEqual "incremental program stdout" "D" programOut
+    assertEqual "incremental program stdout" "DWIDE" programOut
 
 testDormantPrimitive :: IO ()
 testDormantPrimitive = do
@@ -239,7 +262,7 @@ incrementalMainProgram =
   GrinProgram
     { grinConstructors = [],
       grinPrimitives = [],
-      grinForeignCalls = [],
+      grinForeignCalls = [putcharCall],
       grinExternalGlobals = [],
       grinExternalFunctions =
         [ GrinCodeInfo
@@ -256,11 +279,24 @@ incrementalMainProgram =
             { grinFunctionName = incrementalMainFunction,
               grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
-              grinFunctionResultRep = BoxedRep Lifted,
-              grinFunctionBody = GrinCall (BoxedRep Lifted) incrementalDependencyFunction []
+              grinFunctionResultRep = lifted,
+              grinFunctionBody =
+                GrinBind characters (GrinConstant characterValues) $
+                  GrinBind [dependencyResult] (GrinCall lifted incrementalDependencyFunction []) $
+                    foldr outputCharacter (GrinConstant [GrinVarValue unitValue]) characters
             }
         ]
     }
+  where
+    lifted = BoxedRep Lifted
+    characters = zipWith (\index character -> GrinVar (T.singleton character) index Int32Rep) [44 ..] "WIDE"
+    characterValues = map (GrinLitValue . GrinLitInt Int32Rep . toInteger . fromEnum) "WIDE"
+    dependencyResult = GrinVar "dependency_result" 48 lifted
+    unitValue = GrinVar "()" 49 lifted
+    outputCharacter character =
+      GrinBind
+        [GrinVar ("output_" <> grinVarName character) (grinVarUnique character + 20) Int32Rep]
+        (GrinForeignCallExpr putcharCall [GrinVarValue character])
 
 incrementalDependencyFunction, incrementalMainFunction :: FunctionName
 incrementalDependencyFunction = FunctionName "$entry$dependency"

--- a/components/aihc-native/runtime/aihc_runtime.c
+++ b/components/aihc-native/runtime/aihc_runtime.c
@@ -423,8 +423,9 @@ static AihcValue *aihc_copy_with_fields(AihcMachine *machine,
   return copy;
 }
 
-static AihcSlot *aihc_portable_arguments(AihcSlot *buffer, AihcValue *function,
-                                         uint64_t count, const AihcSlot *values,
+static AihcSlot *aihc_portable_arguments(AihcMachine *machine,
+                                         AihcValue *function, uint64_t count,
+                                         const AihcSlot *values,
                                          AihcValue *continuation) {
   uint64_t field_count = aihc_value_info_table(function)->field_count;
   size_t maximum_count = SIZE_MAX / sizeof(AihcSlot);
@@ -438,6 +439,9 @@ static AihcSlot *aihc_portable_arguments(AihcSlot *buffer, AihcValue *function,
     }
     ++total;
   }
+  AihcSlot *buffer =
+      aihc_reserve_slots(machine, &machine->portable_arguments,
+                         &machine->portable_arguments_capacity, total);
   if (count != 0) {
     memmove(buffer + field_count, values, sizeof(*values) * (size_t)count);
   }
@@ -455,6 +459,18 @@ static AihcSlot *aihc_portable_arguments(AihcSlot *buffer, AihcValue *function,
 static AihcPortableTransfer aihc_portable_transfer(AihcEntry entry,
                                                    AihcSlot *arguments) {
   return (AihcPortableTransfer){entry, arguments};
+}
+
+AihcPortableTransfer aihc_portable_call(AihcMachine *machine, AihcEntry entry,
+                                        uint64_t count,
+                                        const AihcSlot *arguments) {
+  AihcSlot *buffer =
+      aihc_reserve_slots(machine, &machine->portable_arguments,
+                         &machine->portable_arguments_capacity, count);
+  if (count != 0) {
+    memmove(buffer, arguments, sizeof(*arguments) * (size_t)count);
+  }
+  return aihc_portable_transfer(entry, buffer);
 }
 
 static AihcThread *aihc_thread_new(AihcMachine *machine) {
@@ -573,10 +589,8 @@ AihcSlot *aihc_alloc_locals(AihcMachine *machine, uint64_t count) {
 void aihc_no_match(void) { aihc_fail("no matching case alternative"); }
 
 static AihcPortableTransfer
-aihc_portable_continue_values_now(AihcMachine *machine, AihcSlot *buffer,
-                                  AihcValue *continuation, uint64_t count,
-                                  const AihcSlot *values) {
-  (void)machine;
+aihc_portable_continue_values_now(AihcMachine *machine, AihcValue *continuation,
+                                  uint64_t count, const AihcSlot *values) {
   if (continuation == NULL ||
       aihc_value_tag(continuation) != AIHC_TAG_CLOSURE) {
     aihc_fail("attempted to invoke a non-continuation value");
@@ -587,23 +601,21 @@ aihc_portable_continue_values_now(AihcMachine *machine, AihcSlot *buffer,
   (void)aihc_next_application_info(aihc_value_info_table(continuation), count);
   return aihc_portable_transfer(
       aihc_value_entry(continuation),
-      aihc_portable_arguments(buffer, continuation, count, values, NULL));
+      aihc_portable_arguments(machine, continuation, count, values, NULL));
 }
 
 AihcPortableTransfer aihc_portable_continue_values(AihcMachine *machine,
-                                                   AihcSlot *buffer,
                                                    AihcValue *continuation,
                                                    uint64_t count,
                                                    const AihcSlot *values) {
-  return aihc_portable_continue_values_now(machine, buffer, continuation, count,
+  return aihc_portable_continue_values_now(machine, continuation, count,
                                            values);
 }
 
 static AihcPortableTransfer
-aihc_portable_continue_value(AihcMachine *machine, AihcSlot *buffer,
-                             AihcValue *continuation, AihcSlot value) {
-  return aihc_portable_continue_values_now(machine, buffer, continuation, 1,
-                                           &value);
+aihc_portable_continue_value(AihcMachine *machine, AihcValue *continuation,
+                             AihcSlot value) {
+  return aihc_portable_continue_values_now(machine, continuation, 1, &value);
 }
 
 AihcValue *aihc_apply_slow(AihcMachine *machine, AihcValue *function,
@@ -636,10 +648,11 @@ AihcValue *aihc_apply_slow(AihcMachine *machine, AihcValue *function,
   }
 }
 
-AihcPortableTransfer
-aihc_portable_apply_cps(AihcMachine *machine, AihcSlot *buffer,
-                        AihcValue *function, uint64_t count,
-                        const AihcSlot *arguments, AihcValue *continuation) {
+AihcPortableTransfer aihc_portable_apply_cps(AihcMachine *machine,
+                                             AihcValue *function,
+                                             uint64_t count,
+                                             const AihcSlot *arguments,
+                                             AihcValue *continuation) {
   if (function == NULL) {
     aihc_fail("attempted to apply null");
   }
@@ -647,14 +660,13 @@ aihc_portable_apply_cps(AihcMachine *machine, AihcSlot *buffer,
       aihc_value_arity(function) == 1) {
     (void)aihc_next_application_info(aihc_value_info_table(function), count);
     return aihc_portable_transfer(aihc_value_entry(function),
-                                  aihc_portable_arguments(buffer, function,
+                                  aihc_portable_arguments(machine, function,
                                                           count, arguments,
                                                           continuation));
   }
   AihcValue *applied =
       aihc_apply_slow(machine, function, count, arguments, &continuation);
-  return aihc_portable_continue_value(machine, buffer, continuation,
-                                      (AihcSlot)applied);
+  return aihc_portable_continue_value(machine, continuation, (AihcSlot)applied);
 }
 
 static void aihc_suspend_apply(AihcThread *thread, AihcValue *function,
@@ -1075,17 +1087,16 @@ const AihcResume *aihc_block_on_blackhole(AihcMachine *machine,
 }
 
 static AihcPortableTransfer aihc_portable_resume(AihcMachine *machine,
-                                                 AihcSlot *buffer,
                                                  const AihcResume *resume) {
   AihcPortableTransfer transfer;
   switch (resume->kind) {
   case AIHC_RESUME_APPLY:
-    transfer = aihc_portable_apply_cps(machine, buffer, resume->function, 0,
-                                       NULL, resume->continuation);
+    transfer = aihc_portable_apply_cps(machine, resume->function, 0, NULL,
+                                       resume->continuation);
     break;
   case AIHC_RESUME_CONTINUE:
     transfer = aihc_portable_continue_values_now(
-        machine, buffer, resume->function, resume->count,
+        machine, resume->function, resume->count,
         resume->count == 0 ? NULL : &resume->value);
     break;
   default:
@@ -1096,7 +1107,7 @@ static AihcPortableTransfer aihc_portable_resume(AihcMachine *machine,
 }
 
 AihcPortableTransfer aihc_portable_eval_cps(AihcMachine *machine,
-                                            AihcSlot *buffer, AihcValue *value,
+                                            AihcValue *value,
                                             uint64_t result_is_lifted,
                                             AihcValue *continuation,
                                             AihcValue *update_continuation) {
@@ -1106,25 +1117,23 @@ AihcPortableTransfer aihc_portable_eval_cps(AihcMachine *machine,
   switch (aihc_value_tag(value)) {
   case AIHC_TAG_THUNK: {
     AihcSlot *arguments =
-        aihc_portable_arguments(buffer, value, 0, NULL, update_continuation);
+        aihc_portable_arguments(machine, value, 0, NULL, update_continuation);
     AihcEntry entry = aihc_value_entry(value);
     aihc_begin_blackhole(machine, value);
     return aihc_portable_transfer(entry, arguments);
   }
   case AIHC_TAG_INDIRECTION:
     if (result_is_lifted) {
-      return aihc_portable_eval_cps(machine, buffer,
-                                    (AihcValue *)value->fields[0], 1,
+      return aihc_portable_eval_cps(machine, (AihcValue *)value->fields[0], 1,
                                     continuation, update_continuation);
     }
-    return aihc_portable_continue_value(machine, buffer, continuation,
+    return aihc_portable_continue_value(machine, continuation,
                                         value->fields[0]);
   case AIHC_TAG_BLACKHOLE:
     return aihc_portable_resume(
-        machine, buffer, aihc_block_on_blackhole(machine, value, continuation));
+        machine, aihc_block_on_blackhole(machine, value, continuation));
   default:
-    return aihc_portable_continue_value(machine, buffer, continuation,
-                                        (AihcSlot)value);
+    return aihc_portable_continue_value(machine, continuation, (AihcSlot)value);
   }
 }
 
@@ -1192,37 +1201,35 @@ void aihc_set_thread_done_continuation(AihcMachine *machine,
 AihcEntry aihc_halt(AihcMachine *machine) { return machine->exit_code; }
 
 AihcPortableTransfer aihc_portable_fork_cps(AihcMachine *machine,
-                                            AihcSlot *buffer, AihcValue *action,
+                                            AihcValue *action,
                                             AihcValue *continuation) {
   AihcSlot thread_id = aihc_fork(machine, action);
-  return aihc_portable_continue_value(machine, buffer, continuation, thread_id);
+  return aihc_portable_continue_value(machine, continuation, thread_id);
 }
 
 AihcPortableTransfer aihc_portable_yield_cps(AihcMachine *machine,
-                                             AihcSlot *buffer,
                                              AihcValue *continuation) {
-  return aihc_portable_resume(machine, buffer,
-                              aihc_yield(machine, continuation));
+  return aihc_portable_resume(machine, aihc_yield(machine, continuation));
 }
 
 AihcPortableTransfer aihc_portable_await_io_cps(AihcMachine *machine,
-                                                AihcSlot *buffer, void *request,
+                                                void *request,
                                                 AihcValue *continuation) {
-  return aihc_portable_resume(machine, buffer,
+  return aihc_portable_resume(machine,
                               aihc_await_io(machine, request, continuation));
 }
 
-AihcPortableTransfer aihc_portable_thread_done(AihcMachine *machine,
-                                               AihcSlot *buffer) {
-  return aihc_portable_resume(machine, buffer, aihc_thread_done(machine));
+AihcPortableTransfer aihc_portable_thread_done(AihcMachine *machine) {
+  return aihc_portable_resume(machine, aihc_thread_done(machine));
 }
 
-AihcPortableTransfer
-aihc_portable_start(AihcMachine *machine, AihcSlot *buffer, AihcValue *root,
-                    AihcValue *continuation, AihcValue *update_continuation,
-                    AihcValue *thread_done_continuation, AihcEntry exit_code) {
+AihcPortableTransfer aihc_portable_start(AihcMachine *machine, AihcValue *root,
+                                         AihcValue *continuation,
+                                         AihcValue *update_continuation,
+                                         AihcValue *thread_done_continuation,
+                                         AihcEntry exit_code) {
   machine->exit_code = exit_code;
   aihc_set_thread_done_continuation(machine, thread_done_continuation);
-  return aihc_portable_eval_cps(machine, buffer, root, 1, continuation,
+  return aihc_portable_eval_cps(machine, root, 1, continuation,
                                 update_continuation);
 }

--- a/components/aihc-native/runtime/aihc_runtime.h
+++ b/components/aihc-native/runtime/aihc_runtime.h
@@ -101,6 +101,8 @@ struct AihcMachine {
   uint64_t allocation_count;
   AihcSlot *locals;
   uint64_t locals_capacity;
+  AihcSlot *portable_arguments;
+  uint64_t portable_arguments_capacity;
   AihcResume selected_resume;
 };
 
@@ -195,37 +197,39 @@ void aihc_set_thread_done_continuation(AihcMachine *machine,
                                        AihcValue *thread_done_continuation);
 AihcEntry aihc_halt(AihcMachine *machine);
 
-/* Portable-C control operations. The generated backend owns and supplies the
-   reusable buffer; the machine and native backends never contain one. */
-AihcPortableTransfer
-aihc_portable_apply_cps(AihcMachine *machine, AihcSlot *buffer,
-                        AihcValue *function, uint64_t count,
-                        const AihcSlot *arguments, AihcValue *continuation);
+/* Portable-C control operations. The machine owns one reusable argument
+   vector and grows it to the width required by each transfer. */
+AihcPortableTransfer aihc_portable_call(AihcMachine *machine, AihcEntry entry,
+                                        uint64_t count,
+                                        const AihcSlot *arguments);
+AihcPortableTransfer aihc_portable_apply_cps(AihcMachine *machine,
+                                             AihcValue *function,
+                                             uint64_t count,
+                                             const AihcSlot *arguments,
+                                             AihcValue *continuation);
 AihcPortableTransfer aihc_portable_eval_cps(AihcMachine *machine,
-                                            AihcSlot *buffer, AihcValue *value,
+                                            AihcValue *value,
                                             uint64_t result_is_lifted,
                                             AihcValue *continuation,
                                             AihcValue *update_continuation);
 AihcPortableTransfer aihc_portable_continue_values(AihcMachine *machine,
-                                                   AihcSlot *buffer,
                                                    AihcValue *continuation,
                                                    uint64_t count,
                                                    const AihcSlot *values);
 AihcPortableTransfer aihc_portable_fork_cps(AihcMachine *machine,
-                                            AihcSlot *buffer, AihcValue *action,
+                                            AihcValue *action,
                                             AihcValue *continuation);
 AihcPortableTransfer aihc_portable_yield_cps(AihcMachine *machine,
-                                             AihcSlot *buffer,
                                              AihcValue *continuation);
 AihcPortableTransfer aihc_portable_await_io_cps(AihcMachine *machine,
-                                                AihcSlot *buffer, void *request,
+                                                void *request,
                                                 AihcValue *continuation);
-AihcPortableTransfer aihc_portable_thread_done(AihcMachine *machine,
-                                               AihcSlot *buffer);
-AihcPortableTransfer
-aihc_portable_start(AihcMachine *machine, AihcSlot *buffer, AihcValue *root,
-                    AihcValue *continuation, AihcValue *update_continuation,
-                    AihcValue *thread_done_continuation, AihcEntry exit_code);
+AihcPortableTransfer aihc_portable_thread_done(AihcMachine *machine);
+AihcPortableTransfer aihc_portable_start(AihcMachine *machine, AihcValue *root,
+                                         AihcValue *continuation,
+                                         AihcValue *update_continuation,
+                                         AihcValue *thread_done_continuation,
+                                         AihcEntry exit_code);
 
 typedef enum {
   AIHC_SNAPSHOT_POINTER,

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -84,8 +84,7 @@ backendCompiler target =
 -- compilation units in one executable.
 data LinkLayout = LinkLayout
   { linkConstructors :: ![(Text, [[RuntimeRep]])],
-    linkGlobalNames :: ![Text],
-    linkMaximumArgumentSlots :: !Int
+    linkGlobalNames :: ![Text]
   }
   deriving (Eq, Show)
 
@@ -93,8 +92,7 @@ data LinkLayout = LinkLayout
 -- unit. Code generation for another unit never needs its GRIN bodies.
 data LinkInterface = LinkInterface
   { linkInterfaceConstructors :: ![(Text, [[RuntimeRep]])],
-    linkInterfaceGlobalNames :: ![Text],
-    linkInterfaceMaximumArgumentSlots :: !Int
+    linkInterfaceGlobalNames :: ![Text]
   }
   deriving (Eq, Show, Read)
 
@@ -117,9 +115,7 @@ extractLinkInterface :: GrinProgram -> LinkInterface
 extractLinkInterface program =
   LinkInterface
     { linkInterfaceConstructors = grinConstructors program,
-      linkInterfaceGlobalNames = programGlobalNames program,
-      linkInterfaceMaximumArgumentSlots =
-        maximum (0 : map (length . grinFunctionParameters) (grinFunctions program))
+      linkInterfaceGlobalNames = programGlobalNames program
     }
 
 extendLinkLayout :: LinkLayout -> GrinProgram -> LinkLayout
@@ -129,8 +125,7 @@ extendLinkLayoutWithInterface :: LinkLayout -> LinkInterface -> LinkLayout
 extendLinkLayoutWithInterface layout interface =
   LinkLayout
     { linkConstructors = uniqueByName (linkConstructors layout <> linkInterfaceConstructors interface),
-      linkGlobalNames = uniqueTexts (linkGlobalNames layout <> linkInterfaceGlobalNames interface),
-      linkMaximumArgumentSlots = max (linkMaximumArgumentSlots layout) (linkInterfaceMaximumArgumentSlots interface)
+      linkGlobalNames = uniqueTexts (linkGlobalNames layout <> linkInterfaceGlobalNames interface)
     }
 
 runtimeSourcePath :: IO FilePath
@@ -200,8 +195,7 @@ emptyLinkLayout :: LinkLayout
 emptyLinkLayout =
   LinkLayout
     { linkConstructors = builtinConstructors,
-      linkGlobalNames = [name | (name, layouts) <- builtinConstructors, null layouts],
-      linkMaximumArgumentSlots = 0
+      linkGlobalNames = [name | (name, layouts) <- builtinConstructors, null layouts]
     }
 
 programGlobalNames :: GrinProgram -> [Text]

--- a/docs/cps-grin.md
+++ b/docs/cps-grin.md
@@ -92,5 +92,5 @@ without changing Haskell code, System FC, or CPS-GRIN.
 Native saturated applications bypass that area: the closure's application-stage
 info table selects generated code which loads captured fields and supplied
 values into backend argument registers before tail-entering the function.
-Portable C and allocation-requiring native slow paths reuse the machine's
-argument area instead of allocating a vector for every transfer.
+Portable C grows and reuses a machine-owned argument vector instead of requiring
+a whole-program arity bound or allocating a vector for every transfer.

--- a/docs/native-runtime-objects.md
+++ b/docs/native-runtime-objects.md
@@ -59,11 +59,14 @@ collector's temporary forwarding marker.
 
 The cooperative scheduler keeps thread records, blackhole records, wait queues,
 and pending IO requests in auxiliary C allocations. Suspended threads retain
-ordinary action or continuation closures, which portable C expands into its
-reusable argument buffer only when selected. Native backends resume the same
-records through their register convention. The machine reuses one locals area
-because CPS transfers discard the preceding function frame; all retained
-closure values and pending-request continuations are precise collector roots.
+ordinary action or continuation closures, which portable C expands into the
+machine's growable reusable argument buffer only when selected. Native backends
+resume the same records through their register convention. The machine reuses
+one locals area because CPS transfers discard the preceding function frame; all
+retained closure values and pending-request continuations are precise collector
+roots. The argument buffer contains only transient transfers: generated entries
+copy their parameters into the locals area before reaching an allocation
+safepoint, so the collector does not scan the buffer.
 
 ## IO manager
 


### PR DESCRIPTION
## Summary

- remove the portable-C-only maximum argument-slot count from the shared link interface
- move portable transfer arguments into a machine-owned buffer that grows to each transfer width
- route direct calls and runtime control transfers through the growable buffer
- document the transient-buffer GC invariant and invalidate the old dependency-cache schema
- add wide-continuation and separately compiled cross-unit regressions

## Root cause

The fixed portable-C arrays were sized from a pre-CPS maximum function parameter count. CPS-generated continuation entries can capture more slots than that bound, and cached dependency objects cannot know the width of continuations later supplied by the main unit. The runtime also had no capacity parameter with which to detect an overrun.

## Impact

Portable C no longer depends on a whole-program argument-width estimate. Each transfer reserves its actual required capacity in reusable machine-owned storage. Native register calling conventions are unchanged.

## Progress counts

- Portable C backend test cases: 8 → 9
- README progress counts are unchanged and remain cron-managed

## Validation

- `cabal test -v0 aihc-c:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`