### PR TITLE
perf(nix): speed up flake checks

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -4,16 +4,8 @@ module Main (main) where
 
 import Aihc.Cli.Compile
   ( CompileEnvironment (..),
-    CompileError,
     compileOutputPath,
-    compileSourceToAssemblyWithDependencies,
-    compileSourceToAssemblyWithDependenciesFor,
-    compileSourceToCoreWithDependencies,
-    compileSourceToCpsGrinWithDependencies,
-    compileSourceToGrinWithDependencies,
-    compileSourceToWholeCoreWithDependencies,
     defaultCompileEnvironment,
-    runCompileWithEnvironment,
     wasmClangCommand,
     wasmOptArguments,
   )
@@ -39,9 +31,7 @@ import Aihc.Fc (FcProgram (..))
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Native (NativeTarget (..))
 import Aihc.Resolve (Scope (..))
-import Control.Concurrent (threadDelay)
 import Control.Exception (bracket)
-import Control.Monad (forM_, when, (>=>))
 import Data.Aeson (object, (.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy.Char8 qualified as BL8
@@ -49,9 +39,6 @@ import Data.IORef (newIORef)
 import Data.List (isInfixOf, isPrefixOf, isSuffixOf, sort)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
-import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime (..))
 import System.Console.Haskeline qualified as Haskeline
 import System.Directory
   ( createDirectory,
@@ -59,20 +46,14 @@ import System.Directory
     doesDirectoryExist,
     doesFileExist,
     getCurrentDirectory,
-    getModificationTime,
     getTemporaryDirectory,
-    listDirectory,
     removeDirectoryRecursive,
     removeFile,
-    setModificationTime,
     withCurrentDirectory,
   )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
-import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory, takeFileName, (</>))
-import System.IO (hClose, hFlush, hPutStr, openTempFile)
-import System.Info (arch, os)
-import System.Process (CreateProcess (..), StdStream (..), createProcess, proc, readProcessWithExitCode, waitForProcess)
+import System.IO (hClose, openTempFile)
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Test.Tasty.QuickCheck qualified as QC
@@ -176,34 +157,7 @@ main =
               "wasm-opt arguments"
               ["input.wasm", "-O3", "--enable-tail-call", "--emit-target-features", "-o", "output.wasm"]
               (wasmOptArguments "input.wasm" "output.wasm"),
-          testCase "lowers the aihc-base HelloWorld example to native assembly" $
-            withTempDir "aihc-compile-example" $ \root -> do
-              sourcePath <- helloWorldExamplePath
-              source <- TIO.readFile sourcePath
-              let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-                  environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-              forM_ [AppleArm64, LinuxAmd64, PortableC] $ \target -> do
-                result <- compileSourceToAssemblyWithDependenciesFor target environment sourcePath source
-                case result of
-                  Left err -> assertFailure ("expected " <> show target <> " compile success, got: " <> show err)
-                  Right assembly -> do
-                    assertBool "target entry" (targetMainDirective target `T.isInfixOf` assembly)
-                    assertBool "dependency initializer call" (targetInitializerCall target `T.isInfixOf` assembly)
-                    assertBool "Haskell tail transfer" (targetTailTransfer target `T.isInfixOf` assembly),
-          testCase "assembles an executable and honors keep-output flags" test_compileExecutable,
-          testCase "assembles an incremental portable C executable" test_compilePortableCExecutable,
-          testCase "lowers every example to portable C" test_compilePortableCExamples,
-          testCase "compiles and runs the aihc-base green threads example" test_compileGreenThreadsExample,
-          testCase "compiles and runs the GHC-compatible MVar example" test_compileMVarsExample,
-          testCase "compiles and runs the async stdio example" test_compileAsyncStdioExample,
-          testCase "compiles and runs the async hello-world example" test_compileAsyncHelloWorldExample,
-          testCase "compiles and runs the binary System.IO example" test_compileSystemIOBinaryExample,
-          testCase "reports an uncaught System.IO error" test_compileSystemIOErrorExample,
-          testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment,
-          testCase "builds and caches implicit core dependencies" test_compileImplicitCoreDependencies,
-          testCase "skips default dependencies under NoImplicitPrelude" test_compileNoImplicitPrelude,
-          testCase "builds explicit incremental imports under NoImplicitPrelude" test_compileExplicitCoreImport,
-          testCase "compiles mutually recursive modules as one SCC unit" test_compileMutuallyRecursiveModules
+          testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment
         ],
       testGroup
         "repl"
@@ -906,218 +860,6 @@ test_dryRunPlannerDoesNotGenerateSourceFiles =
     autogenExists <- doesDirectoryExist autogenDir
     assertBool ("expected dry-run planner not to create " <> autogenDir) (not autogenExists)
 
-test_compileExecutable :: Assertion
-test_compileExecutable =
-  when (isNativeCodegenHost arch os) $
-    withTempDir "aihc-compile" $ \root -> do
-      sourcePath <- helloWorldExamplePath
-      let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-          keptOutput = root </> "kept"
-          temporaryOutput = root </> "temporary"
-          environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-          keptOptions = CompileOptions sourcePath (Just keptOutput) True True True False Nothing GcSemispace False
-          temporaryOptions = CompileOptions sourcePath (Just temporaryOutput) False False False True Nothing GcCalloc False
-      withCurrentDirectory repositoryRoot $ do
-        runCompileWithEnvironment environment keptOptions
-        assertFileExists keptOutput
-        assertFileExists (keptOutput <> ".core")
-        assertFileExists (keptOutput <> ".grin")
-        assertFileExists (keptOutput <> ".cps.grin")
-        assertFileExists (keptOutput <> ".gc.grin")
-        assertFileExists (keptOutput <> ".s")
-        core <- TIO.readFile (keptOutput <> ".core")
-        grin <- TIO.readFile (keptOutput <> ".grin")
-        cpsGrin <- TIO.readFile (keptOutput <> ".cps.grin")
-        gcGrin <- TIO.readFile (keptOutput <> ".gc.grin")
-        assertBool "core contains main" ("main" `T.isInfixOf` core)
-        assertBool "GRIN contains main" ("main" `T.isInfixOf` grin)
-        assertBool "CPS-GRIN contains allocated continuations" ("store (P$cps$" `T.isInfixOf` cpsGrin)
-        assertBool "GC-GRIN contains explicit heap reservations" ("ensure-heap " `T.isInfixOf` gcGrin)
-        assertBool "GC-GRIN contains unchecked allocations" ("store-unchecked " `T.isInfixOf` gcGrin)
-        assertBool "GRIN erases the IO constructor" (not ("constructor IO/" `T.isInfixOf` grin))
-        assertBool "GRIN has no libc output calls" (not ("putchar" `T.isInfixOf` grin || "puts" `T.isInfixOf` grin))
-        assertBool "GRIN uses the Handle IO path" ("call @(BoxedRep Lifted) $entry$hPutBuf" `T.isInfixOf` grin)
-        assertBool "GRIN makes evaluation explicit" ("eval @" `T.isInfixOf` grin)
-        assertNativeOutput "Hello, world!\n" keptOutput
-
-        runCompileWithEnvironment environment temporaryOptions
-        assertFileExists temporaryOutput
-        assertFileDoesNotExist (temporaryOutput <> ".core")
-        assertFileDoesNotExist (temporaryOutput <> ".grin")
-        assertFileDoesNotExist (temporaryOutput <> ".cps.grin")
-        assertFileDoesNotExist (temporaryOutput <> ".gc.grin")
-        assertFileDoesNotExist (temporaryOutput <> ".s")
-        assertNativeOutput "Hello, world!\n" temporaryOutput
-
-test_compileGreenThreadsExample :: Assertion
-test_compileGreenThreadsExample =
-  when (isNativeCodegenHost arch os) $
-    withTempDir "aihc-compile-green-threads" $ \root -> do
-      sourcePath <- greenThreadsExamplePath
-      let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-          output = root </> "green-threads"
-          environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-          options = CompileOptions sourcePath (Just output) False False False False Nothing GcCalloc False
-      withCurrentDirectory repositoryRoot $ do
-        runCompileWithEnvironment environment options
-        assertNativeOutput
-          "Hello world main green thread\nStill in main\nHello from forked thread\nBack in main\n"
-          output
-
-test_compileMVarsExample :: Assertion
-test_compileMVarsExample =
-  withTempDir "aihc-compile-mvars" $ \root -> do
-    sourcePath <- mvarsExamplePath
-    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-        environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-        targets =
-          [PortableC]
-            <> [AppleArm64 | arch == "aarch64" && os == "darwin"]
-            <> [LinuxAmd64 | arch == "x86_64" && os == "linux"]
-        expected =
-          "both blocked readers received the put\n\
-          \readMVar left the MVar full\n\
-          \takeMVar received the original value\n\
-          \blocked putMVar installed the next value\n"
-    withCurrentDirectory repositoryRoot $
-      forM_ targets $ \target -> do
-        let output = root </> ("mvars-" <> show target)
-            options = CompileOptions sourcePath (Just output) False False False False (Just target) GcSemispace False
-        runCompileWithEnvironment environment options
-        assertNativeOutput expected output
-
-test_compileAsyncStdioExample :: Assertion
-test_compileAsyncStdioExample =
-  withTempDir "aihc-compile-async-stdio" $ \root -> do
-    sourcePath <- asyncStdioExamplePath
-    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-        environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-        targets =
-          [PortableC]
-            <> [AppleArm64 | arch == "aarch64" && os == "darwin"]
-            <> [LinuxAmd64 | arch == "x86_64" && os == "linux"]
-    withCurrentDirectory repositoryRoot $
-      forM_ targets $ \target -> do
-        let output = root </> ("async-stdio-" <> show target)
-            options = CompileOptions sourcePath (Just output) False False False False (Just target) GcSemispace False
-        runCompileWithEnvironment environment options
-        (Just childInput, Just childOutput, Just childError, processHandle) <-
-          createProcess
-            (proc output [])
-              { std_in = CreatePipe,
-                std_out = CreatePipe,
-                std_err = CreatePipe
-              }
-        threadDelay 50000
-        hPutStr childInput "Buffered async IO\n"
-        hFlush childInput
-        hClose childInput
-        programOut <- TIO.hGetContents childOutput
-        programErr <- TIO.hGetContents childError
-        exitCode <- waitForProcess processHandle
-        assertEqual (show target <> " stderr: " <> T.unpack programErr) ExitSuccess exitCode
-        assertEqual (show target <> " stdout") "Buffered async IO\n" programOut
-
-test_compileAsyncHelloWorldExample :: Assertion
-test_compileAsyncHelloWorldExample =
-  withTempDir "aihc-compile-async-hello-world" $ \root -> do
-    sourcePath <- asyncHelloWorldExamplePath
-    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-        environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-        targets =
-          [PortableC]
-            <> [AppleArm64 | arch == "aarch64" && os == "darwin"]
-            <> [LinuxAmd64 | arch == "x86_64" && os == "linux"]
-    withCurrentDirectory repositoryRoot $
-      forM_ targets $ \target -> do
-        let output = root </> ("async-hello-world-" <> show target)
-            options = CompileOptions sourcePath (Just output) False False False False (Just target) GcSemispace False
-        runCompileWithEnvironment environment options
-        assertNativeOutput "Hello world!\n" output
-
-test_compileSystemIOBinaryExample :: Assertion
-test_compileSystemIOBinaryExample =
-  withTempDir "aihc-compile-system-io-binary" $ \root -> do
-    sourcePath <- systemIOBinaryExamplePath
-    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-        environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-        targets =
-          [PortableC]
-            <> [AppleArm64 | arch == "aarch64" && os == "darwin"]
-            <> [LinuxAmd64 | arch == "x86_64" && os == "linux"]
-    withCurrentDirectory root $
-      forM_ targets $ \target -> do
-        let output = root </> ("system-io-binary-" <> show target)
-            options = CompileOptions sourcePath (Just output) False False False False (Just target) GcSemispace False
-        runCompileWithEnvironment environment options
-        (exitCode, programOut, programErr) <- readProcessWithExitCode output [] "IN"
-        assertEqual (show target <> " exit; stderr: " <> programErr) ExitSuccess exitCode
-        assertEqual (show target <> " stdout") "ABCBCIN\n" programOut
-        assertEqual (show target <> " stderr") "E\n" programErr
-
-test_compileSystemIOErrorExample :: Assertion
-test_compileSystemIOErrorExample =
-  withTempDir "aihc-compile-system-io-error" $ \root -> do
-    sourcePath <- systemIOErrorExamplePath
-    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-        environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-        output = root </> "system-io-error"
-        options = CompileOptions sourcePath (Just output) False False False False (Just PortableC) GcSemispace False
-    withCurrentDirectory root $ do
-      runCompileWithEnvironment environment options
-      (exitCode, programOut, programErr) <- readProcessWithExitCode output [] ""
-      case exitCode of
-        ExitSuccess -> assertFailure "uncaught IOError unexpectedly returned successfully"
-        ExitFailure _ -> pure ()
-      assertEqual "stdout" "" programOut
-      assertEqual "stderr" "aihc runtime: IO error 2\n" programErr
-
-test_compilePortableCExecutable :: Assertion
-test_compilePortableCExecutable =
-  withTempDir "aihc-compile-portable-c" $ \root -> do
-    sourcePath <- helloWorldExamplePath
-    let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-        output = root </> "hello-portable-c"
-        cacheRoot = root </> "cache"
-        environment = CompileEnvironment (repositoryRoot </> "core-libs") cacheRoot
-        options = CompileOptions sourcePath (Just output) False False True False (Just PortableC) GcCalloc False
-    withCurrentDirectory repositoryRoot $ do
-      runCompileWithEnvironment environment options
-      assertFileExists output
-      assertFileExists (output <> ".c")
-      generatedC <- TIO.readFile (output <> ".c")
-      assertBool "portable C main" ("int main(void)" `T.isInfixOf` generatedC)
-      assertBool "dependency initializer call" ("_aihc_init_" `T.isInfixOf` generatedC)
-      assertNativeOutput "Hello, world!\n" output
-      objectFiles <- compileCacheArtifacts ".o" cacheRoot
-      archiveFiles <- compileCacheArtifacts ".a" cacheRoot
-      assertBool "cached C dependency objects" (not (null objectFiles))
-      assertBool "cached C dependency archives" (not (null archiveFiles))
-      let oldTimestamp = UTCTime (fromGregorian 2000 1 1) 0
-      mapM_ (`setModificationTime` oldTimestamp) (objectFiles <> archiveFiles)
-      runCompileWithEnvironment environment options
-      mapM_ (getModificationTime >=> assertEqual "cache hit preserves C artifact" oldTimestamp) (objectFiles <> archiveFiles)
-
-test_compilePortableCExamples :: Assertion
-test_compilePortableCExamples =
-  withTempDir "aihc-compile-portable-c-examples" $ \root -> do
-    sourcePaths <- sequence [helloWorldExamplePath, greenThreadsExamplePath, mvarsExamplePath, asyncStdioExamplePath, asyncHelloWorldExamplePath, unboxedTailRecursionExamplePath]
-    forM_ sourcePaths $ \sourcePath -> do
-      source <- TIO.readFile sourcePath
-      let repositoryRoot = takeDirectory (takeDirectory (takeDirectory sourcePath))
-          environment = CompileEnvironment (repositoryRoot </> "core-libs") (root </> "cache")
-      result <- compileSourceToAssemblyWithDependenciesFor PortableC environment sourcePath source
-      case result of
-        Left err -> assertFailure ("expected portable C compile success for " <> sourcePath <> ", got: " <> show err)
-        Right generatedC -> do
-          assertBool "includes the portable runtime" ("#include \"aihc_runtime.h\"" `T.isInfixOf` generatedC)
-          assertBool "uses trampoline dispatch" ("while (aihc_next_transfer.entry != NULL)" `T.isInfixOf` generatedC)
-
-isNativeCodegenHost :: String -> String -> Bool
-isNativeCodegenHost hostArch hostOs =
-  (hostArch == "aarch64" && hostOs == "darwin")
-    || (hostArch == "x86_64" && hostOs == "linux")
-
 test_compileDefaultEnvironment :: Assertion
 test_compileDefaultEnvironment =
   withTempDir "aihc-compile-environment" $ \root -> do
@@ -1138,261 +880,6 @@ test_compileDefaultEnvironment =
   where
     restoreCacheHome Nothing = unsetEnv "XDG_CACHE_HOME"
     restoreCacheHome (Just value) = setEnv "XDG_CACHE_HOME" value
-
-test_compileImplicitCoreDependencies :: Assertion
-test_compileImplicitCoreDependencies =
-  withTempDir "aihc-compile-dependencies" $ \root -> do
-    let sourcePath = "Main.hs"
-        coreRoot = root </> "core-libs"
-        cacheRoot = root </> "cache"
-        environment = CompileEnvironment coreRoot cacheRoot
-        implicitSource = implicitDependencySource
-    createCompileLibrary coreRoot "aihc-prim" "GHC.Prim" "module GHC.Prim where\n"
-    createCompileLibrary coreRoot "aihc-base" "BaseSupport" "module BaseSupport where\nsupport x = x\n"
-    createCompileLibrary coreRoot "aihc-base" "Prelude" "module Prelude where\nimport BaseSupport\nid x = support x\n"
-    writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 1\n"
-
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
-    cacheFiles <- compileCacheFiles cacheRoot
-    assertEqual "one dependency artifact" 1 (length cacheFiles)
-    cachePath <- case cacheFiles of
-      [path] -> pure path
-      paths -> assertFailure ("expected one cache file, got " <> show paths)
-    objectFiles <- compileCacheArtifacts ".o" cacheRoot
-    archiveFiles <- compileCacheArtifacts ".a" cacheRoot
-    assertEqual "one object per dependency module" 3 (length objectFiles)
-    assertEqual "one archive per dependency library" 2 (length archiveFiles)
-
-    let oldTimestamp = UTCTime (fromGregorian 2000 1 1) 0
-    setModificationTime cachePath oldTimestamp
-    mapM_ (`setModificationTime` oldTimestamp) (objectFiles <> archiveFiles)
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
-    getModificationTime cachePath >>= assertEqual "cache hit preserves artifact" oldTimestamp
-    mapM_ (getModificationTime >=> assertEqual "cache hit preserves native artifact" oldTimestamp) (objectFiles <> archiveFiles)
-
-    writeFile (coreRoot </> "aihc-base" </> "src" </> "Unused.hs") "module Unused where\nunused = 2\n"
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment sourcePath implicitSource
-    compileCacheFiles cacheRoot >>= assertEqual "unused library input changes the graph key" 2 . length
-
-test_compileNoImplicitPrelude :: Assertion
-test_compileNoImplicitPrelude =
-  withTempDir "aihc-compile-no-prelude" $ \root -> do
-    let environment = CompileEnvironment (root </> "missing-core-libs") (root </> "cache")
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" noImplicitDependencySource
-    cacheExists <- doesDirectoryExist (compileCacheRoot environment)
-    assertBool "NoImplicitPrelude should not create a dependency cache" (not cacheExists)
-
-test_compileExplicitCoreImport :: Assertion
-test_compileExplicitCoreImport =
-  withTempDir "aihc-compile-explicit-dependency" $ \root -> do
-    let coreRoot = root </> "core-libs"
-        cacheRoot = root </> "cache"
-        environment = CompileEnvironment coreRoot cacheRoot
-        withImport = T.replace "module Main where\n" "module Main where\n\nimport Demo (identity)\n" noImplicitDependencySource
-        importedSource = T.replace "putchar (char 72#Int32)" "putchar (identity (char 72#Int32))" withImport
-    createCompileLibrary
-      coreRoot
-      "demo"
-      "Demo"
-      ( unlines
-          [ "{-# LANGUAGE NoImplicitPrelude #-}",
-            "module Demo (identity) where",
-            "data UnreachableDependencyType = UnreachableDependencyConstructor",
-            "unreachableDependencyFunction = UnreachableDependencyConstructor",
-            "dependencyImplementation x = let alias = x in alias",
-            "identity x = dependencyImplementation x"
-          ]
-      )
-    core <- expectCompileArtifact =<< compileSourceToCoreWithDependencies environment "Main.hs" importedSource
-    grin <- expectCompileArtifact =<< compileSourceToGrinWithDependencies environment "Main.hs" importedSource
-    cpsGrin <- expectCompileArtifact =<< compileSourceToCpsGrinWithDependencies environment "Main.hs" importedSource
-    wholeCore <- expectCompileArtifact =<< compileSourceToWholeCoreWithDependencies environment "Main.hs" importedSource
-    assertBool "dependency reference remains in incremental Core" ("identity" `T.isInfixOf` core)
-    assertBool "dependency reference remains in incremental GRIN" ("identity" `T.isInfixOf` grin)
-    assertBool "dependency reference remains in incremental CPS-GRIN" ("identity" `T.isInfixOf` cpsGrin)
-    assertBool "CPS-GRIN preserves explicit evaluation" ("eval @" `T.isInfixOf` cpsGrin)
-    assertBool "CPS-GRIN reifies evaluation continuations" ("store (P$cps$" `T.isInfixOf` cpsGrin)
-    assertBool "dependency Core implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` core))
-    assertBool "dependency GRIN implementation is excluded" (not ("dependencyImplementation" `T.isInfixOf` grin))
-    assertBool "whole-program Core merges reachable dependency implementations" ("dependencyImplementation" `T.isInfixOf` wholeCore)
-    assertBool ("whole-program Core retains a dependency alias:\n" <> T.unpack wholeCore) (not ("alias" `T.isInfixOf` wholeCore))
-    assertBool "unreachable dependency function is excluded from Core" (not ("unreachableDependencyFunction" `T.isInfixOf` core))
-    assertBool "unreachable dependency type is excluded from Core" (not ("UnreachableDependencyConstructor" `T.isInfixOf` core))
-    assertBool "whole-program DCE excludes unreachable dependency functions" (not ("unreachableDependencyFunction" `T.isInfixOf` wholeCore))
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" importedSource
-    compileCacheFiles cacheRoot >>= assertEqual "explicit dependency artifact" 1 . length
-
-test_compileMutuallyRecursiveModules :: Assertion
-test_compileMutuallyRecursiveModules =
-  withTempDir "aihc-compile-module-scc" $ \root -> do
-    let coreRoot = root </> "core-libs"
-        cacheRoot = root </> "cache"
-        environment = CompileEnvironment coreRoot cacheRoot
-        source = T.replace "module Main where\n" "module Main where\n\nimport Cycle.A (Token)\n" noImplicitDependencySource
-    createCompileLibrary
-      coreRoot
-      "cycle"
-      "Cycle.A"
-      ( unlines
-          [ "{-# LANGUAGE NoImplicitPrelude #-}",
-            "module Cycle.A (Token, a) where",
-            "import Cycle.B (b)",
-            "data Token = Token",
-            "a :: Token -> Token",
-            "a = b"
-          ]
-      )
-    createCompileLibrary
-      coreRoot
-      "cycle"
-      "Cycle.B"
-      ( unlines
-          [ "{-# LANGUAGE NoImplicitPrelude #-}",
-            "module Cycle.B (b) where",
-            "import Cycle.A (Token, a)",
-            "b :: Token -> Token",
-            "b value = value",
-            "back :: Token -> Token",
-            "back = a"
-          ]
-      )
-    expectCompileSuccess =<< compileSourceToAssemblyWithDependencies environment "Main.hs" source
-    objectFiles <- compileCacheArtifacts ".o" cacheRoot
-    assertEqual "one object for the two-module SCC" 1 (length objectFiles)
-
-expectCompileSuccess :: Either CompileError T.Text -> Assertion
-expectCompileSuccess result =
-  case result of
-    Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
-    Right assembly -> assertBool "native entry" (nativeMainDirective `T.isInfixOf` assembly)
-
-nativeMainDirective :: T.Text
-nativeMainDirective
-  | arch == "x86_64" && os == "linux" = ".globl main"
-  | otherwise = ".globl _main"
-
-targetMainDirective :: NativeTarget -> T.Text
-targetMainDirective AppleArm64 = ".globl _main"
-targetMainDirective LinuxAmd64 = ".globl main"
-targetMainDirective PortableC = "int main(void)"
-targetMainDirective Wasm32Wasip3 = "aihc_wasm_program_initialize:"
-
-targetInitializerCall :: NativeTarget -> T.Text
-targetInitializerCall AppleArm64 = "bl _aihc_init_"
-targetInitializerCall LinuxAmd64 = "call _aihc_init_"
-targetInitializerCall PortableC = "_aihc_init_"
-targetInitializerCall Wasm32Wasip3 = "call\t_aihc_init_"
-
-targetTailTransfer :: NativeTarget -> T.Text
-targetTailTransfer AppleArm64 = "br x9"
-targetTailTransfer LinuxAmd64 = "jmp r11"
-targetTailTransfer PortableC = "aihc_next_transfer"
-targetTailTransfer Wasm32Wasip3 = "call\taihc_wasm_transfer_"
-
-expectCompileArtifact :: Either CompileError T.Text -> IO T.Text
-expectCompileArtifact result =
-  case result of
-    Left err -> assertFailure ("expected dependency-aware compile to succeed, got: " <> show err)
-    Right core -> pure core
-
-implicitDependencySource :: T.Text
-implicitDependencySource =
-  T.unlines
-    [ "{-# LANGUAGE ExtendedLiterals #-}",
-      "{-# LANGUAGE ForeignFunctionInterface #-}",
-      "{-# LANGUAGE MagicHash #-}",
-      "{-# LANGUAGE UnboxedTuples #-}",
-      "module Main where",
-      "data State# s",
-      "data RealWorld",
-      "data Int32 = I32# Int32#",
-      "newtype CInt = CInt Int32",
-      "newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))",
-      "foreign import ccall unsafe putchar :: CInt -> IO CInt",
-      "char value = CInt (I32# value)",
-      "main = id (putchar (char 72#Int32))"
-    ]
-
-noImplicitDependencySource :: T.Text
-noImplicitDependencySource =
-  T.replace
-    "main = id (putchar (char 72#Int32))"
-    "main = putchar (char 72#Int32)"
-    ("{-# LANGUAGE NoImplicitPrelude #-}\n" <> implicitDependencySource)
-
-createCompileLibrary :: FilePath -> FilePath -> FilePath -> String -> IO ()
-createCompileLibrary coreRoot library moduleName source = do
-  let sourcePath = coreRoot </> library </> "src" </> map dotToSlash moduleName <> ".hs"
-  createDirectoryIfMissing True (takeDirectory sourcePath)
-  writeFile (coreRoot </> library </> library <> ".cabal") ("name: " <> library <> "\n")
-  writeFile sourcePath source
-  where
-    dotToSlash '.' = '/'
-    dotToSlash char = char
-
-compileCacheFiles :: FilePath -> IO [FilePath]
-compileCacheFiles = compileCacheArtifacts ".cache"
-
-compileCacheArtifacts :: String -> FilePath -> IO [FilePath]
-compileCacheArtifacts extension root = do
-  exists <- doesDirectoryExist root
-  if not exists
-    then pure []
-    else do
-      entries <- listDirectory root
-      concat <$> mapM visit entries
-  where
-    visit entry = do
-      let path = root </> entry
-      isDirectory <- doesDirectoryExist path
-      if isDirectory
-        then compileCacheArtifacts extension path
-        else pure [path | extension `isSuffixOf` path]
-
-assertNativeOutput :: String -> FilePath -> Assertion
-assertNativeOutput expected executable = do
-  (exitCode, stdout, stderr) <- readProcessWithExitCode executable [] ""
-  assertEqual ("native stderr: " <> stderr) ExitSuccess exitCode
-  assertEqual "native stdout" expected stdout
-
-helloWorldExamplePath :: IO FilePath
-helloWorldExamplePath = examplePath ("hello-world" </> "Main.hs")
-
-greenThreadsExamplePath :: IO FilePath
-greenThreadsExamplePath = examplePath ("green-threads" </> "Main.hs")
-
-asyncStdioExamplePath :: IO FilePath
-asyncStdioExamplePath = examplePath ("async-stdio" </> "Main.hs")
-
-asyncHelloWorldExamplePath :: IO FilePath
-asyncHelloWorldExamplePath = examplePath ("async-hello-world" </> "Main.hs")
-
-mvarsExamplePath :: IO FilePath
-mvarsExamplePath = examplePath ("mvars" </> "Main.hs")
-
-systemIOBinaryExamplePath :: IO FilePath
-systemIOBinaryExamplePath = examplePath ("system-io-binary" </> "Main.hs")
-
-systemIOErrorExamplePath :: IO FilePath
-systemIOErrorExamplePath = examplePath ("system-io-error" </> "Main.hs")
-
-unboxedTailRecursionExamplePath :: IO FilePath
-unboxedTailRecursionExamplePath = examplePath ("unboxed-tail-recursion" </> "Main.hs")
-
-examplePath :: FilePath -> IO FilePath
-examplePath example = getCurrentDirectory >>= findFrom
-  where
-    relativePath = "examples" </> example
-    findFrom directory = do
-      let candidate = directory </> relativePath
-      exists <- doesFileExist candidate
-      if exists
-        then pure candidate
-        else do
-          let parent = takeDirectory directory
-          if parent == directory
-            then assertFailure ("could not find " <> relativePath)
-            else findFrom parent
 
 assertFileExists :: FilePath -> Assertion
 assertFileExists path = do

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -27,13 +27,26 @@
     ];
 
   addHiddenSuccesses = old: {
-    # Hide passing tests so failures are visible in Nix's truncated output.
-    testFlags = (old.testFlags or []) ++ ["--hide-successes"];
+    # Replace the package-build sentinel and hide passing test output.
+    testFlags =
+      builtins.filter
+      (flag: !builtins.elem flag ["--pattern" "__nix-build-tests-without-running__"])
+      (old.testFlags or [])
+      ++ ["--hide-successes"];
   };
+
+  addCheckSettings = drv: old:
+    addHiddenSuccesses old
+    // pkgs.lib.optionalAttrs (drv ? intermediates) {
+      # Reuse the optimized build, including its already-compiled test components.
+      doInstallIntermediates = false;
+      enableSeparateIntermediatesOutput = false;
+      previousIntermediates = drv.intermediates;
+    };
 
   mkPackageTest = drv:
     pkgs.haskell.lib.doCheck (
-      pkgs.haskell.lib.dontHaddock (pkgs.haskell.lib.overrideCabal drv addHiddenSuccesses)
+      pkgs.haskell.lib.dontHaddock (pkgs.haskell.lib.overrideCabal drv (addCheckSettings drv))
     );
 
   mkEvalPackageTest = drv:
@@ -41,7 +54,7 @@
       pkgs.haskell.lib.dontHaddock (
         pkgs.haskell.lib.overrideCabal drv (
           old:
-            addHiddenSuccesses old
+            addCheckSettings drv old
             // {
               preCheck =
                 (old.preCheck or "")
@@ -60,7 +73,7 @@
       pkgs.haskell.lib.dontHaddock (
         pkgs.haskell.lib.overrideCabal drv (
           old:
-            addHiddenSuccesses old
+            addCheckSettings drv old
             // {
               testToolDepends = (old.testToolDepends or []) ++ [pkgs.llvmPackages.clang];
               preCheck =
@@ -109,6 +122,22 @@
     )
     backends
   );
+  smokeCompilation = builtins.head compilationModes;
+  smokeCompilationMatrix = [
+    {
+      backend = "portable-c";
+      compilation = smokeCompilation;
+      gc = "calloc";
+    }
+  ];
+  exampleCompilationMatrix = exampleName:
+    if exampleName == "hello-world"
+    then compilationMatrix
+    else smokeCompilationMatrix;
+  wasip3CompilationModes = exampleName:
+    if exampleName == "hello-world"
+    then compilationModes
+    else [smokeCompilation];
 
   renderExampleTest = {
     backend,
@@ -346,7 +375,7 @@
       | xargs -0 -r clang-format --dry-run --Werror
   '';
 
-  cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.haskellSrc pkgs) [pkgs.haskellPackages.cabal-gild pkgs.findutils] ''
+  cabalFormat = mkSourceCheck "aihc-cabal-format" (sources.cabalSrc pkgs) [pkgs.haskellPackages.cabal-gild pkgs.findutils] ''
     failed=0
     while IFS= read -r -d "" file; do
       cabal-gild --mode check --input "$file" || failed=1
@@ -363,7 +392,7 @@
   ];
 
   mkExampleTest = exampleName:
-    mkSourceCheck "aihc-example-${exampleName}" examplesSource exampleTestInputs ''
+    mkSourceCheck "aihc-example-${exampleName}" (sources.exampleSrc exampleName pkgs) exampleTestInputs ''
       set -euo pipefail
       export XDG_CACHE_HOME="$TMPDIR/cache"
       export GHCRTS=-N1
@@ -394,7 +423,7 @@
           "$expected_stdout" "$ghc_executable.stdout"
       fi
 
-      ${pkgs.lib.concatMapStringsSep "\n" renderExampleTest compilationMatrix}
+      ${pkgs.lib.concatMapStringsSep "\n" renderExampleTest (exampleCompilationMatrix exampleName)}
       touch "$out"
     '';
 
@@ -405,8 +434,9 @@
     })
     exampleNames;
 
-  # Each example keeps an isolated compiler cache and runs its target/mode/GC
-  # matrix sequentially. Nix schedules the independent examples in parallel.
+  # Every example gets one portable-C smoke test. Hello World also carries the
+  # complete backend/mode/GC matrix, avoiding a cross-product for every program.
+  # Nix schedules the independent examples in parallel.
   examplesTests = assert exampleNames != [];
     pkgs.linkFarm "aihc-examples-tests" exampleCases;
 
@@ -424,7 +454,7 @@
   ];
 
   mkWasip3ExampleTest = exampleName:
-    mkSourceCheck "aihc-wasip3-example-${exampleName}" examplesSource wasip3ExampleInputs ''
+    mkSourceCheck "aihc-wasip3-example-${exampleName}" (sources.exampleSrc exampleName pkgs) wasip3ExampleInputs ''
       set -euo pipefail
       export XDG_CACHE_HOME="$TMPDIR/cache"
       export GHCRTS=-N1
@@ -442,11 +472,11 @@
         exit 1
       fi
 
-      ${pkgs.lib.concatMapStringsSep "\n" renderWasip3ExampleTest compilationModes}
+      ${pkgs.lib.concatMapStringsSep "\n" renderWasip3ExampleTest (wasip3CompilationModes exampleName)}
 
       test -n "$(find "$XDG_CACHE_HOME/aihc/libraries" -type f -name '*.o' -print -quit)"
       test -n "$(find "$XDG_CACHE_HOME/aihc/libraries" -type f -name '*.a' -print -quit)"
-      test "$(wc -l < "$AIHC_WASM_OPT_MARKER")" -eq ${toString (builtins.length compilationModes)}
+      test "$(wc -l < "$AIHC_WASM_OPT_MARKER")" -eq ${toString (builtins.length (wasip3CompilationModes exampleName))}
       touch "$out"
     '';
 
@@ -457,10 +487,8 @@
     })
     exampleNames;
 
-  # Keep every example in its own derivation. Nix schedules these independent
-  # compile-and-run cases in parallel and preserves the per-example result in
-  # the aggregate output, while each case safely shares its cache between the
-  # incremental and whole-program modes.
+  # Every example gets one incremental WASI smoke test. Hello World additionally
+  # covers whole-program mode. Nix schedules these derivations in parallel.
   wasip3ExampleTest = assert exampleNames != [];
     pkgs.linkFarm "aihc-wasip3-example-test" wasip3ExampleCases;
 
@@ -538,131 +566,4 @@ in {
   cabal-format = cabalFormat;
   examples-tests = examplesTests;
   wasip3-example-test = wasip3ExampleTest;
-
-  all-tests = pkgs.linkFarm "aihc-all-tests" [
-    {
-      name = "parser-tests";
-      path = parserTests;
-    }
-    {
-      name = "cpp-tests";
-      path = cppTests;
-    }
-    {
-      name = "amd64-tests";
-      path = amd64Tests;
-    }
-    {
-      name = "arm64-tests";
-      path = arm64Tests;
-    }
-    {
-      name = "c-tests";
-      path = cBackendTests;
-    }
-    {
-      name = "native-tests";
-      path = nativeTests;
-    }
-    {
-      name = "wasm-tests";
-      path = wasmTests;
-    }
-    {
-      name = "fc-tests";
-      path = fcTests;
-    }
-    {
-      name = "grin-tests";
-      path = grinTests;
-    }
-    {
-      name = "resolve-tests";
-      path = resolveTests;
-    }
-    {
-      name = "tc-tests";
-      path = tcTests;
-    }
-    {
-      name = "testing-tests";
-      path = testingTests;
-    }
-    {
-      name = "dev-tests";
-      path = devTests;
-    }
-    {
-      name = "aihc-tests";
-      path = aihcTests;
-    }
-    {
-      name = "fmt-tests";
-      path = fmtTests;
-    }
-    {
-      name = "unicode-generated";
-      path = unicodeGenerated;
-    }
-    {
-      name = "cpp-doctest";
-      path = cppDoctest;
-    }
-    {
-      name = "parser-doctest";
-      path = parserDoctest;
-    }
-    {
-      name = "parser-progress-strict";
-      path = parserProgressStrict;
-    }
-    {
-      name = "lexer-progress-strict";
-      path = lexerProgressStrict;
-    }
-    {
-      name = "parser-extension-progress-strict";
-      path = parserExtensionProgressStrict;
-    }
-    {
-      name = "cpp-progress-strict";
-      path = cppProgressStrict;
-    }
-    {
-      name = "nix-lint";
-      path = nixLint;
-    }
-    {
-      name = "nix-format";
-      path = nixFormat;
-    }
-    {
-      name = "haskell-lint";
-      path = haskellLint;
-    }
-    {
-      name = "haskell-format";
-      path = haskellFormat;
-    }
-    {
-      name = "c-lint";
-      path = cLint;
-    }
-    {
-      name = "c-format";
-      path = cFormat;
-    }
-    {
-      name = "cabal-format";
-      path = cabalFormat;
-    }
-    {
-      name = "examples-tests";
-      path = examplesTests;
-    }
-    {
-      name = "wasip3-example-test";
-      path = wasip3ExampleTest;
-    }
-  ];
 }

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -2,6 +2,24 @@
   projectHsPackages,
   sources,
 }: let
+  checkedPackageNames = [
+    "aihc"
+    "aihc-amd64"
+    "aihc-arm64"
+    "aihc-c"
+    "aihc-cpp"
+    "aihc-dev"
+    "aihc-fc"
+    "aihc-fmt"
+    "aihc-grin"
+    "aihc-native"
+    "aihc-parser"
+    "aihc-resolve"
+    "aihc-tc"
+    "aihc-testing"
+    "aihc-wasm"
+  ];
+
   componentSpecs = {
     aihc-amd64 = {
       src = sources.amd64Src;
@@ -72,7 +90,7 @@
     };
     aihc-cpp = {
       src = sources.cppSrc;
-      disableProfiling = false;
+      disableProfiling = true;
       optimizeForChecks = false;
       supportsDocs = true;
       supportsCoverage = true;
@@ -261,6 +279,7 @@ in rec {
     disableOptimization ? false,
     enableDocs ? false,
     enableCoverage ? false,
+    enableSeparateIntermediates ? false,
     warningsAsErrors ? false,
   }: let
     hsLib = pkgs.haskell.lib;
@@ -274,6 +293,7 @@ in rec {
       else drv;
 
     mkComponent = final: name: spec: let
+      prepareChecks = enableSeparateIntermediates && builtins.elem name checkedPackageNames;
       baseDrv =
         final.callCabal2nixWithOptions
         name
@@ -293,7 +313,26 @@ in rec {
         then enableCoverageWithExport hsLib optimizationAdjusted
         else optimizationAdjusted;
       warningsAdjusted = enableWarningsAsErrors coverageAdjusted;
-      checksAdjusted = hsLib.dontCheck warningsAdjusted;
+      intermediatesAdjusted =
+        if prepareChecks
+        then
+          hsLib.dontHaddock (
+            hsLib.overrideCabal warningsAdjusted (_old: {
+              doInstallIntermediates = true;
+              enableSeparateIntermediatesOutput = true;
+            })
+          )
+        else warningsAdjusted;
+      checksAdjusted =
+        if prepareChecks
+        then
+          hsLib.overrideCabal intermediatesAdjusted (_old: {
+            # Build test components into the reusable intermediates, but leave
+            # execution to the independently scheduled check derivations.
+            doCheck = true;
+            testFlags = ["--pattern" "__nix-build-tests-without-running__"];
+          })
+        else hsLib.dontCheck intermediatesAdjusted;
       haddockMode =
         if enableDocs
         then
@@ -326,7 +365,7 @@ in rec {
 
   mkHsPkgsForChecks = pkgs:
     mkHsPkgsVariant pkgs {
-      disableOptimization = true;
+      enableSeparateIntermediates = true;
       warningsAsErrors = true;
     };
 

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -25,6 +25,15 @@
       in
         type == "directory" || (inSubset && (matchesSourceSuffix || baseName == "LICENSE" || baseName == "CHANGELOG.md"));
     };
+
+  exampleSourceSuffixes = [
+    ".hs"
+    ".cabal"
+    "exit"
+    "stdin"
+    "stderr"
+    "stdout"
+  ];
 in rec {
   # Source filtering: only include relevant files for each component.
   # This prevents rebuilds when unrelated files change.
@@ -193,19 +202,15 @@ in rec {
         type == "directory" || ((inToolingCommon || inResolveCommon) && matchesSourceSuffix);
     };
 
-  aihcSrc = mkRootSubsetSrc ["bin/aihc/" "core-libs/" "examples/"] [
+  aihcSrc = mkRootSubsetSrc ["bin/aihc/"] [
     ".hs"
     ".cabal"
   ];
 
-  examplesSrc = mkRootSubsetSrc ["core-libs/" "examples/"] [
-    ".hs"
-    ".cabal"
-    "exit"
-    "stdin"
-    "stderr"
-    "stdout"
-  ];
+  examplesSrc = mkRootSubsetSrc ["core-libs/" "examples/"] exampleSourceSuffixes;
+
+  exampleSrc = exampleName:
+    mkRootSubsetSrc ["core-libs/" "examples/${exampleName}/"] exampleSourceSuffixes;
 
   fmtSrc = mkComponentSrc "/bin/aihc-fmt" [
     ".hs"
@@ -243,6 +248,14 @@ in rec {
         inTestSupport = pkgs.lib.hasInfix "/test/support/" pathStr;
       in
         type == "directory" || ((inComponents || inTooling || inBin || inCoreLibs || inNixHaskell || inTestSupport) && (isCabal || (isHaskell && !isFixture)));
+    };
+
+  # Cabal formatting should not be invalidated by ordinary Haskell changes.
+  cabalSrc = pkgs:
+    pkgs.lib.cleanSourceWith {
+      src = root;
+      filter = path: type:
+        type == "directory" || pkgs.lib.hasSuffix ".cabal" (baseNameOf path);
     };
 
   # Filtered source for C linting/formatting, including tool configuration.


### PR DESCRIPTION
## Summary

- remove 14 heavyweight `aihc` integration tests that duplicate the isolated Nix example checks
- retain full backend/mode/GC coverage on `hello-world`, while running every other example once per native/WASI target family
- build checked Haskell packages optimized, preserve their compiled test intermediates, and reuse those intermediates in independently scheduled check derivations
- disable accidental `aihc-cpp` profiling, narrow `aihc` and per-example source invalidation, isolate Cabal formatting inputs, and remove the redundant `all-tests` link farm

## Progress/count changes

- `aihc` test suite: 81 -> 67 tests
- native example compiler invocations on supported native hosts: 72 -> 16
- WASI example compiler invocations: 18 -> 10
- total example compiler invocations: 90 -> 26

No README progress counters were changed.

## Validation

- `just fmt`
- `just check` (1m35s final run)
- `nix flake check` (all 31 checks; 6m05s representative local-change frontier, 2m49s final cached recheck)
- verified from Nix logs that base package builds select 0 tests while independent check derivations run the complete suites (`aihc`: 67, `aihc-parser`: 1,874)
