### PR TITLE
feat(grin): add continuation frame metadata

### DIFF
--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -25,8 +25,10 @@ where
 
 import Aihc.Amd64.Codegen.Function
 import Aihc.Amd64.Codegen.Runtime
+import Aihc.Grin.Cps (ContinuationFrameKind (..))
 import Aihc.Grin.Gc
   ( GcGrinProgram,
+    gcContinuationFrames,
     gcContinuationFunctions,
     gcFunctionContinuations,
     gcGrinProgram,
@@ -113,7 +115,7 @@ compileObservedFunction entryName gcProgram = do
   where
     program = gcGrinProgram gcProgram
     layout = buildLinkLayout [program]
-    compileEnv = (compileEnvironmentWith True layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
+    compileEnv = (compileEnvironmentWith True (gcContinuationFrames gcProgram) layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
     globalNames = linkGlobalNames layout
     resultReps =
       maybe [] (runtimeRepComponents . grinFunctionResultRep) $
@@ -121,6 +123,7 @@ compileObservedFunction entryName gcProgram = do
     observedRuntimeInfos =
       threadDoneRuntimeInfos
         <> continuationRuntimeInfos
+          ContinuationFrameStop
           ".Laihc_snapshot_info"
           ".Laihc_snapshot_applied_info"
           ".Laihc_snapshot_result"
@@ -156,7 +159,7 @@ compileModule layout initializerSymbol gcProgram = do
   where
     program = gcGrinProgram gcProgram
     compileEnv =
-      (compileEnvironment layout program)
+      (compileEnvironment (gcContinuationFrames gcProgram) layout program)
         { compileAllowUnsupportedPrimitives = True,
           compileContinuationFunctions = gcContinuationFunctions gcProgram
         }
@@ -195,14 +198,14 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
          ]
       <> makeNodeUncheckedLines runtimeTagClosure (InfoAddress ".Laihc_update_info")
       <> [ storeAt "rax" "r14" 0,
-           loadByteOffset "r11" "r15" 0,
-           loadAt "rdx" "r11" rootSlot,
+           "  mov rdx, r12",
            loadAt "rdi" "r14" 0,
            "  xor esi, esi",
            "  call aihc_set_field",
            loadAt "rdi" "r14" 0,
            "  mov esi, 1",
-           "  mov rdx, r12",
+           loadByteOffset "r11" "r15" 0,
+           loadAt "rdx" "r11" rootSlot,
            "  call aihc_set_field"
          ]
       <> makeNodeUncheckedLines runtimeTagClosure (InfoAddress ".Laihc_thread_done_info")
@@ -215,7 +218,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
            loadByteOffset "r11" "r15" 0,
            loadAt applyFunctionRegister "r11" rootSlot,
            loadAt "rax" "r14" 0,
-           "  mov r13, QWORD PTR [rax + 16]",
+           "  mov r13, QWORD PTR [rax + 8]",
            "  mov r11, 1",
            "  jmp .Laihc_eval"
          ]
@@ -238,24 +241,27 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
       <> nonExecutableStack
   where
     program = gcGrinProgram gcProgram
-    compileEnv = (compileEnvironment layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
+    compileEnv = (compileEnvironment (gcContinuationFrames gcProgram) layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
     globalSlots = compileGlobalSlots compileEnv
     globalNames = linkGlobalNames layout
     pointerRep = BoxedRep Lifted
     programRuntimeInfos updateLabel =
       continuationRuntimeInfos
+        ContinuationFrameStop
         ".Laihc_final_info"
         ".Laihc_final_applied_info"
         ".Laihc_final_continuation"
         []
         [pointerRep]
         <> continuationRuntimeInfos
+          ContinuationFrameNormal
           ".Laihc_top_info"
           ".Laihc_top_applied_info"
           ".Laihc_top_continuation"
           [pointerRep]
           [pointerRep]
         <> continuationRuntimeInfos
+          ContinuationFrameUpdate
           ".Laihc_update_info"
           ".Laihc_update_applied_info"
           updateLabel
@@ -309,6 +315,7 @@ threadDoneContinuation =
 threadDoneRuntimeInfos :: [RuntimeInfo]
 threadDoneRuntimeInfos =
   continuationRuntimeInfos
+    ContinuationFrameStop
     ".Laihc_thread_done_info"
     ".Laihc_thread_done_applied_info"
     ".Laihc_thread_done_continuation"
@@ -324,11 +331,11 @@ renderCompiledSupport env functions runtimeInfos =
 nonExecutableStack :: [Text]
 nonExecutableStack = [".section .note.GNU-stack,\"\",@progbits"]
 
-compileEnvironment :: LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironment :: Map.Map FunctionName ContinuationFrameKind -> LinkLayout -> GrinProgram -> CompileEnv
 compileEnvironment = compileEnvironmentWith False
 
-compileEnvironmentWith :: Bool -> LinkLayout -> GrinProgram -> CompileEnv
-compileEnvironmentWith exposeAllFunctions layout program =
+compileEnvironmentWith :: Bool -> Map.Map FunctionName ContinuationFrameKind -> LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironmentWith exposeAllFunctions continuationFrames layout program =
   CompileEnv
     { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
       compileConstructorArities = Map.fromList constructors,
@@ -349,7 +356,7 @@ compileEnvironmentWith exposeAllFunctions layout program =
     constructorInfoEntries =
       [ ( key,
           label,
-          RuntimeInfo label (InfoImmediate identifier) fields remaining next Nothing
+          RuntimeInfo label (InfoImmediate identifier) fields remaining next Nothing Nothing
         )
       | ((name, layouts), (_, identifier)) <- zip constructorLayouts constructorIdentifiers,
         let arity = length layouts,
@@ -393,6 +400,7 @@ compileEnvironmentWith exposeAllFunctions layout program =
                 Just (RuntimeEnter target (length fields) 0)
               _ -> Nothing
           )
+          (Map.lookup functionName continuationFrames)
       | (key, functionName) <- functionInfoKeys,
         let label = functionInfoLabels Map.! key
             target = functionLabelMap Map.! functionName

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen/Runtime.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen/Runtime.hs
@@ -64,6 +64,7 @@ module Aihc.Amd64.Codegen.Runtime
   )
 where
 
+import Aihc.Grin.Cps (ContinuationFrameKind, continuationFrameKindCode)
 import Aihc.Grin.Syntax
 import Aihc.Native.BlockLayout qualified as BlockLayout
 import Aihc.Native.RegisterAllocate (Location (..))
@@ -138,7 +139,8 @@ data RuntimeInfo = RuntimeInfo
     runtimeInfoFields :: ![RuntimeRep],
     runtimeInfoRemainingArity :: !Int,
     runtimeInfoNext :: !(Maybe Text),
-    runtimeInfoEnter :: !(Maybe RuntimeEnter)
+    runtimeInfoEnter :: !(Maybe RuntimeEnter),
+    runtimeInfoFrameKind :: !(Maybe ContinuationFrameKind)
   }
 
 data RuntimeEnter = RuntimeEnter
@@ -153,15 +155,16 @@ data RuntimeInfoKey
   | ThunkRuntimeInfo !FunctionName ![RuntimeRep]
   deriving (Eq, Ord, Show)
 
-continuationRuntimeInfos :: Text -> Text -> Text -> [RuntimeRep] -> [RuntimeRep] -> [RuntimeInfo]
-continuationRuntimeInfos infoLabel appliedInfoLabel target storedFields suppliedFields =
+continuationRuntimeInfos :: ContinuationFrameKind -> Text -> Text -> Text -> [RuntimeRep] -> [RuntimeRep] -> [RuntimeInfo]
+continuationRuntimeInfos frameKind infoLabel appliedInfoLabel target storedFields suppliedFields =
   [ RuntimeInfo
       infoLabel
       (InfoAddress target)
       storedFields
       1
       (Just appliedInfoLabel)
-      (Just (RuntimeEnter target (length storedFields) (length suppliedFields))),
+      (Just (RuntimeEnter target (length storedFields) (length suppliedFields)))
+      (Just frameKind),
     RuntimeInfo
       appliedInfoLabel
       (InfoAddress target)
@@ -169,6 +172,7 @@ continuationRuntimeInfos infoLabel appliedInfoLabel target storedFields supplied
       0
       Nothing
       Nothing
+      (Just frameKind)
   ]
 
 materializeValue :: ValueEnv -> GrinValue -> Either Amd64Error [Text]
@@ -389,7 +393,8 @@ renderRuntimeInfos infos =
              "  .quad " <> tshow (runtimeInfoRemainingArity info),
              "  .quad " <> if null fields then "0" else bitmapLabel,
              "  .quad " <> fromMaybe "0" (runtimeInfoNext info),
-             "  .quad " <> maybe "0" (const (enterEntryLabel info)) (runtimeInfoEnter info)
+             "  .quad " <> maybe "0" (const (enterEntryLabel info)) (runtimeInfoEnter info),
+             "  .quad " <> tshow (continuationFrameKindCode (runtimeInfoFrameKind info))
            ]
       where
         fields = runtimeInfoFields info

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -687,6 +687,10 @@ testNativeScheduler = do
   assertBool "emits fork state operation" ("call aihc_fork" `T.isInfixOf` assembly)
   assertBool "emits yield state operation" ("call aihc_yield" `T.isInfixOf` assembly)
   assertBool "emits child completion transfer" ("call aihc_thread_done" `T.isInfixOf` assembly)
+  let updateInfo = T.unlines (take 9 (dropWhile (/= ".Laihc_update_info:") (T.lines assembly)))
+      finalInfo = T.unlines (take 9 (dropWhile (/= ".Laihc_final_info:") (T.lines assembly)))
+  assertBool "emits update continuation frame metadata" ("  .quad 3" `T.isSuffixOf` T.stripEnd updateInfo)
+  assertBool "emits stop continuation frame metadata" ("  .quad 5" `T.isSuffixOf` T.stripEnd finalInfo)
   assertAssemblyAccepted assembly
   when (arch == "x86_64" && os == "linux") $
     runSchedulerAssembly "PCAB" assembly

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -25,8 +25,10 @@ where
 
 import Aihc.Arm64.Codegen.Function
 import Aihc.Arm64.Codegen.Runtime
+import Aihc.Grin.Cps (ContinuationFrameKind (..))
 import Aihc.Grin.Gc
   ( GcGrinProgram,
+    gcContinuationFrames,
     gcContinuationFunctions,
     gcFunctionContinuations,
     gcGrinProgram,
@@ -111,7 +113,7 @@ compileObservedFunction entryName gcProgram = do
   where
     program = gcGrinProgram gcProgram
     layout = buildLinkLayout [program]
-    compileEnv = (compileEnvironmentWith True layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
+    compileEnv = (compileEnvironmentWith True (gcContinuationFrames gcProgram) layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
     globalNames = linkGlobalNames layout
     resultReps =
       maybe [] (runtimeRepComponents . grinFunctionResultRep) $
@@ -119,6 +121,7 @@ compileObservedFunction entryName gcProgram = do
     observedRuntimeInfos =
       threadDoneRuntimeInfos
         <> continuationRuntimeInfos
+          ContinuationFrameStop
           ".Laihc_snapshot_info"
           ".Laihc_snapshot_applied_info"
           ".Laihc_snapshot_result"
@@ -143,7 +146,7 @@ compileModule layout initializerSymbol gcProgram = do
   where
     program = gcGrinProgram gcProgram
     compileEnv =
-      (compileEnvironment layout program)
+      (compileEnvironment (gcContinuationFrames gcProgram) layout program)
         { compileAllowUnsupportedPrimitives = True,
           compileContinuationFunctions = gcContinuationFunctions gcProgram
         }
@@ -181,14 +184,14 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
          ]
       <> makeNodeUncheckedLines runtimeTagClosure (InfoAddress ".Laihc_update_info")
       <> [ storeAt "x0" "x19" 0,
-           "  ldr x9, [x22, #0]",
-           loadAt "x2" "x9" rootSlot,
+           "  mov x2, x20",
            loadAt "x0" "x19" 0,
            "  mov x1, #0",
            "  bl _aihc_set_field",
            loadAt "x0" "x19" 0,
            "  mov x1, #1",
-           "  mov x2, x20",
+           "  ldr x9, [x22, #0]",
+           loadAt "x2" "x9" rootSlot,
            "  bl _aihc_set_field"
          ]
       <> makeNodeUncheckedLines runtimeTagClosure (InfoAddress ".Laihc_thread_done_info")
@@ -201,7 +204,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
            "  ldr x9, [x22, #0]",
            loadAt applyFunctionRegister "x9" rootSlot,
            loadAt "x0" "x19" 0,
-           "  ldr x21, [x0, #16]",
+           "  ldr x21, [x0, #8]",
            "  mov x8, #1",
            "  b .Laihc_eval"
          ]
@@ -223,24 +226,27 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
       <> renderCompiledSupport compileEnv functions (programRuntimeInfos updateLabel)
   where
     program = gcGrinProgram gcProgram
-    compileEnv = (compileEnvironment layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
+    compileEnv = (compileEnvironment (gcContinuationFrames gcProgram) layout program) {compileContinuationFunctions = gcContinuationFunctions gcProgram}
     globalSlots = compileGlobalSlots compileEnv
     globalNames = linkGlobalNames layout
     pointerRep = BoxedRep Lifted
     programRuntimeInfos updateLabel =
       continuationRuntimeInfos
+        ContinuationFrameStop
         ".Laihc_final_info"
         ".Laihc_final_applied_info"
         ".Laihc_final_continuation"
         []
         [pointerRep]
         <> continuationRuntimeInfos
+          ContinuationFrameNormal
           ".Laihc_top_info"
           ".Laihc_top_applied_info"
           ".Laihc_top_continuation"
           [pointerRep]
           [pointerRep]
         <> continuationRuntimeInfos
+          ContinuationFrameUpdate
           ".Laihc_update_info"
           ".Laihc_update_applied_info"
           updateLabel
@@ -252,11 +258,11 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
         "  bl " <> symbol
       ]
 
-compileEnvironment :: LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironment :: Map.Map FunctionName ContinuationFrameKind -> LinkLayout -> GrinProgram -> CompileEnv
 compileEnvironment = compileEnvironmentWith False
 
-compileEnvironmentWith :: Bool -> LinkLayout -> GrinProgram -> CompileEnv
-compileEnvironmentWith exposeAllFunctions layout program =
+compileEnvironmentWith :: Bool -> Map.Map FunctionName ContinuationFrameKind -> LinkLayout -> GrinProgram -> CompileEnv
+compileEnvironmentWith exposeAllFunctions continuationFrames layout program =
   CompileEnv
     { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
       compileConstructorArities = Map.fromList constructors,
@@ -278,7 +284,7 @@ compileEnvironmentWith exposeAllFunctions layout program =
     constructorInfoEntries =
       [ ( key,
           label,
-          RuntimeInfo label (InfoImmediate identifier) fields remaining next Nothing
+          RuntimeInfo label (InfoImmediate identifier) fields remaining next Nothing Nothing
         )
       | ((name, layouts), (_, identifier)) <- zip constructorLayouts constructorIdentifiers,
         let arity = length layouts,
@@ -322,6 +328,7 @@ compileEnvironmentWith exposeAllFunctions layout program =
                 Just (RuntimeEnter target (length fields) 0)
               _ -> Nothing
           )
+          (Map.lookup functionName continuationFrames)
       | (key, functionName) <- functionInfoKeys,
         let label = functionInfoLabels Map.! key
             target = functionLabelMap Map.! functionName
@@ -392,6 +399,7 @@ threadDoneContinuation =
 threadDoneRuntimeInfos :: [RuntimeInfo]
 threadDoneRuntimeInfos =
   continuationRuntimeInfos
+    ContinuationFrameStop
     ".Laihc_thread_done_info"
     ".Laihc_thread_done_applied_info"
     ".Laihc_thread_done_continuation"

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen/Runtime.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen/Runtime.hs
@@ -63,6 +63,7 @@ module Aihc.Arm64.Codegen.Runtime
   )
 where
 
+import Aihc.Grin.Cps (ContinuationFrameKind, continuationFrameKindCode)
 import Aihc.Grin.Syntax
 import Aihc.Native.BlockLayout qualified as BlockLayout
 import Aihc.Native.RegisterAllocate (Location (..))
@@ -137,7 +138,8 @@ data RuntimeInfo = RuntimeInfo
     runtimeInfoFields :: ![RuntimeRep],
     runtimeInfoRemainingArity :: !Int,
     runtimeInfoNext :: !(Maybe Text),
-    runtimeInfoEnter :: !(Maybe RuntimeEnter)
+    runtimeInfoEnter :: !(Maybe RuntimeEnter),
+    runtimeInfoFrameKind :: !(Maybe ContinuationFrameKind)
   }
 
 data RuntimeEnter = RuntimeEnter
@@ -176,15 +178,16 @@ makeNodeUncheckedLines kind info =
 -- | Describe a unary continuation before and after it receives its result.
 -- The result can occupy several machine slots even though it is one GRIN
 -- argument, hence the distinct runtime arity and supplied-slot count.
-continuationRuntimeInfos :: Text -> Text -> Text -> [RuntimeRep] -> [RuntimeRep] -> [RuntimeInfo]
-continuationRuntimeInfos infoLabel appliedInfoLabel target storedFields suppliedFields =
+continuationRuntimeInfos :: ContinuationFrameKind -> Text -> Text -> Text -> [RuntimeRep] -> [RuntimeRep] -> [RuntimeInfo]
+continuationRuntimeInfos frameKind infoLabel appliedInfoLabel target storedFields suppliedFields =
   [ RuntimeInfo
       infoLabel
       (InfoAddress target)
       storedFields
       1
       (Just appliedInfoLabel)
-      (Just (RuntimeEnter target (length storedFields) (length suppliedFields))),
+      (Just (RuntimeEnter target (length storedFields) (length suppliedFields)))
+      (Just frameKind),
     RuntimeInfo
       appliedInfoLabel
       (InfoAddress target)
@@ -192,6 +195,7 @@ continuationRuntimeInfos infoLabel appliedInfoLabel target storedFields supplied
       0
       Nothing
       Nothing
+      (Just frameKind)
   ]
 
 renderEnterStubs :: [RuntimeInfo] -> [Text]
@@ -274,7 +278,8 @@ renderRuntimeInfos infos = [".section __DATA,__const"] <> concatMap renderInfo i
              "  .quad " <> tshow (runtimeInfoRemainingArity info),
              "  .quad " <> if null fields then "0" else bitmapLabel,
              "  .quad " <> fromMaybe "0" (runtimeInfoNext info),
-             "  .quad " <> maybe "0" (const (enterEntryLabel info)) (runtimeInfoEnter info)
+             "  .quad " <> maybe "0" (const (enterEntryLabel info)) (runtimeInfoEnter info),
+             "  .quad " <> tshow (continuationFrameKindCode (runtimeInfoFrameKind info))
            ]
       where
         fields = runtimeInfoFields info

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -337,19 +337,19 @@ tests =
                     "static void entry_12(AihcSlot *arguments) { (void)arguments; }",
                     "static const uint8_t pointer_field[] = {1};",
                     "static const uint8_t pointer_then_scalar[] = {1, 0};",
-                    "static const AihcInfo leaf_info = {1, 0, 0, 0, 0, 0, 0};",
-                    "static const AihcInfo box_info = {2, 0, 1, 0, pointer_field, 0, 0};",
-                    "static const AihcInfo partial_final_info = {3, 0, 2, 0, pointer_then_scalar, 0, 0};",
-                    "static const AihcInfo partial_one_info = {3, 0, 1, 1, pointer_then_scalar, &partial_final_info, 0};",
-                    "static const AihcInfo partial_info = {3, 0, 0, 2, 0, &partial_one_info, 0};",
-                    "static const AihcInfo continuation_final_info = {8, entry_8, 1, 0, pointer_field, 0, 0};",
-                    "static const AihcInfo continuation_info = {8, entry_8, 0, 1, 0, &continuation_final_info, 0};",
-                    "static const AihcInfo action_final_info = {9, entry_9, 0, 0, 0, 0, 0};",
-                    "static const AihcInfo action_info = {9, entry_9, 0, 1, 0, &action_final_info, 0};",
-                    "static const AihcInfo thread_done_final_info = {10, entry_10, 1, 0, pointer_field, 0, 0};",
-                    "static const AihcInfo thread_done_info = {10, entry_10, 0, 1, 0, &thread_done_final_info, 0};",
-                    "static const AihcInfo yield_final_info = {12, entry_12, 0, 0, 0, 0, 0};",
-                    "static const AihcInfo yield_info = {12, entry_12, 0, 1, 0, &yield_final_info, 0};",
+                    "static const AihcInfo leaf_info = {1, 0, 0, 0, 0, 0, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo box_info = {2, 0, 1, 0, pointer_field, 0, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo partial_final_info = {3, 0, 2, 0, pointer_then_scalar, 0, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo partial_one_info = {3, 0, 1, 1, pointer_then_scalar, &partial_final_info, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo partial_info = {3, 0, 0, 2, 0, &partial_one_info, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo continuation_final_info = {8, entry_8, 1, 0, pointer_field, 0, 0, AIHC_FRAME_NORMAL};",
+                    "static const AihcInfo continuation_info = {8, entry_8, 0, 1, 0, &continuation_final_info, 0, AIHC_FRAME_NORMAL};",
+                    "static const AihcInfo action_final_info = {9, entry_9, 0, 0, 0, 0, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo action_info = {9, entry_9, 0, 1, 0, &action_final_info, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo thread_done_final_info = {10, entry_10, 1, 0, pointer_field, 0, 0, AIHC_FRAME_STOP};",
+                    "static const AihcInfo thread_done_info = {10, entry_10, 0, 1, 0, &thread_done_final_info, 0, AIHC_FRAME_STOP};",
+                    "static const AihcInfo yield_final_info = {12, entry_12, 0, 0, 0, 0, 0, AIHC_FRAME_NONE};",
+                    "static const AihcInfo yield_info = {12, entry_12, 0, 1, 0, &yield_final_info, 0, AIHC_FRAME_NONE};",
                     "static int test_apply_roots(void) {",
                     "  AihcMachine *machine = aihc_machine_new(0);",
                     "  AihcValue *leaf = aihc_make_node(machine, AIHC_TAG_NODE, &leaf_info);",
@@ -720,6 +720,10 @@ testNativeScheduler = do
   assertBool "emits fork state operation" ("bl _aihc_fork" `T.isInfixOf` assembly)
   assertBool "emits yield state operation" ("bl _aihc_yield" `T.isInfixOf` assembly)
   assertBool "emits child completion transfer" ("bl _aihc_thread_done" `T.isInfixOf` assembly)
+  let updateInfo = T.unlines (take 9 (dropWhile (/= ".Laihc_update_info:") (T.lines assembly)))
+      finalInfo = T.unlines (take 9 (dropWhile (/= ".Laihc_final_info:") (T.lines assembly)))
+  assertBool "emits update continuation frame metadata" ("  .quad 3" `T.isSuffixOf` T.stripEnd updateInfo)
+  assertBool "emits stop continuation frame metadata" ("  .quad 5" `T.isSuffixOf` T.stripEnd finalInfo)
   when (arch == "aarch64" && os == "darwin") $
     runSchedulerAssembly "PCAB" assembly
 

--- a/components/aihc-c/src/Aihc/C/Codegen.hs
+++ b/components/aihc-c/src/Aihc/C/Codegen.hs
@@ -13,7 +13,8 @@ module Aihc.C.Codegen
   )
 where
 
-import Aihc.Grin.Gc (GcGrinProgram, gcGrinProgram, gcUpdateFunction)
+import Aihc.Grin.Cps (ContinuationFrameKind (..))
+import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcGrinProgram, gcUpdateFunction)
 import Aihc.Grin.Syntax
 import Aihc.Native (LinkLayout (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, supportedNativePrimitiveNames)
 import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
@@ -61,7 +62,8 @@ data RuntimeInfo = RuntimeInfo
     runtimeInfoEntry :: !(Maybe Text),
     runtimeInfoFields :: ![RuntimeRep],
     runtimeInfoRemainingArity :: !Int,
-    runtimeInfoNext :: !(Maybe Text)
+    runtimeInfoNext :: !(Maybe Text),
+    runtimeInfoFrameKind :: !(Maybe ContinuationFrameKind)
   }
 
 data RuntimeInfoKey
@@ -104,14 +106,14 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
   initializer <- compileInitializers env program
   constructorInitializer <- compileConstructorInitializers env
   let specialInfos =
-        [ specialInfo "aihc_final_info" "aihc_final_continuation" [] 1 (Just "aihc_final_applied_info"),
-          specialInfo "aihc_final_applied_info" "aihc_final_continuation" [BoxedRep Lifted] 0 Nothing,
-          specialInfo "aihc_top_info" "aihc_top_continuation" [BoxedRep Lifted] 1 (Just "aihc_top_applied_info"),
-          specialInfo "aihc_top_applied_info" "aihc_top_continuation" [BoxedRep Lifted, BoxedRep Lifted] 0 Nothing,
-          specialInfo "aihc_update_info" updateLabel [BoxedRep Lifted, BoxedRep Lifted] 1 (Just "aihc_update_applied_info"),
-          specialInfo "aihc_update_applied_info" updateLabel [BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted] 0 Nothing,
-          specialInfo "aihc_thread_done_info" "aihc_thread_done_continuation" [] 1 (Just "aihc_thread_done_applied_info"),
-          specialInfo "aihc_thread_done_applied_info" "aihc_thread_done_continuation" [BoxedRep Lifted] 0 Nothing
+        [ specialInfo "aihc_final_info" "aihc_final_continuation" [] 1 (Just "aihc_final_applied_info") ContinuationFrameStop,
+          specialInfo "aihc_final_applied_info" "aihc_final_continuation" [BoxedRep Lifted] 0 Nothing ContinuationFrameStop,
+          specialInfo "aihc_top_info" "aihc_top_continuation" [BoxedRep Lifted] 1 (Just "aihc_top_applied_info") ContinuationFrameNormal,
+          specialInfo "aihc_top_applied_info" "aihc_top_continuation" [BoxedRep Lifted, BoxedRep Lifted] 0 Nothing ContinuationFrameNormal,
+          specialInfo "aihc_update_info" updateLabel [BoxedRep Lifted, BoxedRep Lifted] 1 (Just "aihc_update_applied_info") ContinuationFrameUpdate,
+          specialInfo "aihc_update_applied_info" updateLabel [BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted] 0 Nothing ContinuationFrameUpdate,
+          specialInfo "aihc_thread_done_info" "aihc_thread_done_continuation" [] 1 (Just "aihc_thread_done_applied_info") ContinuationFrameStop,
+          specialInfo "aihc_thread_done_applied_info" "aihc_thread_done_continuation" [BoxedRep Lifted] 0 Nothing ContinuationFrameStop
         ]
       source =
         [ "#include \"aihc_runtime_trampoline.h\"",
@@ -148,8 +150,8 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
                "  top_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_top_info);",
                "  aihc_set_field(top_continuation, 0, (AihcSlot)(uintptr_t)final_continuation);",
                "  update_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_update_info);",
-               "  aihc_set_field(update_continuation, 0, aihc_machine->globals[" <> tshow rootSlot <> "]);",
-               "  aihc_set_field(update_continuation, 1, (AihcSlot)(uintptr_t)top_continuation);",
+               "  aihc_set_field(update_continuation, 0, (AihcSlot)(uintptr_t)top_continuation);",
+               "  aihc_set_field(update_continuation, 1, aihc_machine->globals[" <> tshow rootSlot <> "]);",
                "  thread_done_continuation = aihc_make_node_unchecked(aihc_machine, AIHC_TAG_CLOSURE, &aihc_thread_done_info);",
                "  aihc_next_transfer = aihc_trampoline_start(aihc_machine, (AihcValue *)(uintptr_t)aihc_machine->globals[" <> tshow rootSlot <> "], top_continuation, update_continuation, thread_done_continuation, aihc_exit);",
                "  while (aihc_next_transfer.entry != NULL) {",
@@ -163,9 +165,9 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
   pure (T.unlines source)
   where
     program = gcGrinProgram gcProgram
-    env = compileEnvironment ExecutableUnit layout program
+    env = compileEnvironment ExecutableUnit layout gcProgram
     globalSlots = compileGlobalSlots env
-    specialInfo label entry = RuntimeInfo label Nothing (Just entry)
+    specialInfo label entry fields remaining next frameKind = RuntimeInfo label Nothing (Just entry) fields remaining next (Just frameKind)
 
 compileModule :: LinkLayout -> Text -> GcGrinProgram -> Either CError Text
 compileModule layout initializerSymbol gcProgram = do
@@ -194,7 +196,7 @@ compileModule layout initializerSymbol gcProgram = do
   pure (T.unlines source)
   where
     program = gcGrinProgram gcProgram
-    env = compileEnvironment LibraryUnit layout program
+    env = compileEnvironment LibraryUnit layout gcProgram
 
 validateProgramPrimitives :: GrinProgram -> Either CError ()
 validateProgramPrimitives = validatePrimitiveNames . map (grinVarName . fst) . grinPrimitives
@@ -205,8 +207,8 @@ validatePrimitiveNames = mapM_ $ \name ->
     then Right ()
     else Left (CUnsupportedPrimitive name)
 
-compileEnvironment :: CompilationUnit -> LinkLayout -> GrinProgram -> CompileEnv
-compileEnvironment unitKind layout program =
+compileEnvironment :: CompilationUnit -> LinkLayout -> GcGrinProgram -> CompileEnv
+compileEnvironment unitKind layout gcProgram =
   CompileEnv
     { compileConstructorIds = Map.fromList (zip (map fst constructors) [1 ..]),
       compileConstructorArities = Map.fromList constructors,
@@ -221,6 +223,7 @@ compileEnvironment unitKind layout program =
           LibraryUnit -> True
     }
   where
+    program = gcGrinProgram gcProgram
     constructors = [(name, length layouts) | (name, layouts) <- linkConstructors layout]
     constructorIds = zip (map fst constructors) [1 ..]
     functionLabels =
@@ -233,7 +236,7 @@ compileEnvironment unitKind layout program =
                ]
         )
     constructorEntries =
-      [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next)
+      [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next Nothing)
       | ((name, layouts), (_, identifier)) <- zip (linkConstructors layout) constructorIds,
         let arity = length layouts,
         remaining <- [arity, arity - 1 .. 0],
@@ -261,7 +264,7 @@ compileEnvironment unitKind layout program =
     functionEntries =
       [ ( key,
           label,
-          RuntimeInfo label Nothing (runtimeInfoFunctionName key >>= (`Map.lookup` functionLabels)) (runtimeInfoKeyFields key) (runtimeInfoKeyRemainingArity key) (runtimeInfoKeyNext key >>= (`Map.lookup` infoLabels))
+          RuntimeInfo label Nothing (runtimeInfoFunctionName key >>= (`Map.lookup` functionLabels)) (runtimeInfoKeyFields key) (runtimeInfoKeyRemainingArity key) (runtimeInfoKeyNext key >>= (`Map.lookup` infoLabels)) (runtimeInfoFunctionName key >>= (`Map.lookup` gcContinuationFrames gcProgram))
         )
       | (index, key) <- zip [0 :: Int ..] infoKeys,
         let label = "aihc_function_info_" <> tshow index
@@ -853,7 +856,18 @@ renderRuntimeInfos infos = concatMap bitmap infos <> [""] <> map declaration inf
         <> ", "
         <> maybe "NULL" ("&" <>) (runtimeInfoNext info)
         <> ", NULL"
+        <> ", "
+        <> renderFrameKind (runtimeInfoFrameKind info)
         <> "};"
+
+    renderFrameKind frameKind =
+      case frameKind of
+        Nothing -> "AIHC_FRAME_NONE"
+        Just ContinuationFrameNormal -> "AIHC_FRAME_NORMAL"
+        Just ContinuationFrameCatch -> "AIHC_FRAME_CATCH"
+        Just ContinuationFrameUpdate -> "AIHC_FRAME_UPDATE"
+        Just ContinuationFrameRestoreMask -> "AIHC_FRAME_RESTORE_MASK"
+        Just ContinuationFrameStop -> "AIHC_FRAME_STOP"
 
 renderForeignDeclarations :: GrinProgram -> [Text]
 renderForeignDeclarations program =

--- a/components/aihc-c/test/Test/C/Suite.hs
+++ b/components/aihc-c/test/Test/C/Suite.hs
@@ -103,6 +103,9 @@ putcharCall =
 testTrampoline :: IO ()
 testTrampoline = do
   source <- compile schedulerProgram
+  assertBool "emits normal continuation frame metadata" ("AIHC_FRAME_NORMAL" `T.isInfixOf` source)
+  assertBool "emits update continuation frame metadata" ("AIHC_FRAME_UPDATE" `T.isInfixOf` source)
+  assertBool "emits stop continuation frame metadata" ("AIHC_FRAME_STOP" `T.isInfixOf` source)
   forM_
     [ "while (aihc_next_transfer.entry != NULL)",
       "aihc_next_transfer = aihc_trampoline_fork_cps",

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -3,12 +3,16 @@ module Aihc.Grin
   ( module Aihc.Grin.Syntax,
     CpsGrinProgram,
     CpsGrinError (..),
+    ContinuationFrameKind (..),
+    continuationFrameKindCode,
+    cpsContinuationFrames,
     cpsContinuationFunctions,
     cpsFunctionContinuations,
     cpsGrinProgram,
     cpsUpdateFunction,
     toCpsGrin,
     GcGrinProgram,
+    gcContinuationFrames,
     gcContinuationFunctions,
     gcFunctionContinuations,
     gcGrinProgram,
@@ -41,15 +45,18 @@ module Aihc.Grin
 where
 
 import Aihc.Grin.Cps
-  ( CpsGrinError (..),
+  ( ContinuationFrameKind (..),
+    CpsGrinError (..),
     CpsGrinProgram,
+    continuationFrameKindCode,
+    cpsContinuationFrames,
     cpsContinuationFunctions,
     cpsFunctionContinuations,
     cpsGrinProgram,
     cpsUpdateFunction,
     toCpsGrin,
   )
-import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFunctions, gcFunctionContinuations, gcGrinProgram, gcUpdateFunction, lowerGc)
+import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcFunctionContinuations, gcGrinProgram, gcUpdateFunction, lowerGc)
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramFunctionSnapshot, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
 import Aihc.Grin.Lower (GrinInterface, extractGrinInterface, lowerProgram, lowerProgramWithInterface)

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -9,6 +9,9 @@
 module Aihc.Grin.Cps
   ( CpsGrinProgram,
     CpsGrinError (..),
+    ContinuationFrameKind (..),
+    continuationFrameKindCode,
+    cpsContinuationFrames,
     cpsContinuationFunctions,
     cpsFunctionContinuations,
     cpsGrinProgram,
@@ -34,15 +37,40 @@ import Data.Text qualified as T
 data CpsGrinProgram = CpsGrinProgram
   { cpsGrinProgram :: !GrinProgram,
     cpsContinuationFunctions :: !(Set FunctionName),
+    cpsContinuationFrames :: !(Map FunctionName ContinuationFrameKind),
     cpsFunctionContinuations :: !(Map FunctionName GrinVar),
     cpsUpdateFunction :: !FunctionName
   }
   deriving (Eq, Show, Read)
 
+-- | Runtime-visible kinds of continuation frame. Field zero of every such
+-- closure is its parent continuation. The explicit kind lets exception
+-- unwinding inspect frames without relying on backend labels or code pointers.
+data ContinuationFrameKind
+  = ContinuationFrameNormal
+  | ContinuationFrameCatch
+  | ContinuationFrameUpdate
+  | ContinuationFrameRestoreMask
+  | ContinuationFrameStop
+  deriving (Eq, Ord, Show, Read, Enum, Bounded)
+
+-- | Stable value stored in the shared runtime info-table ABI. Zero is reserved
+-- for closures that are not continuation frames.
+continuationFrameKindCode :: Maybe ContinuationFrameKind -> Int
+continuationFrameKindCode frameKind =
+  case frameKind of
+    Nothing -> 0
+    Just ContinuationFrameNormal -> 1
+    Just ContinuationFrameCatch -> 2
+    Just ContinuationFrameUpdate -> 3
+    Just ContinuationFrameRestoreMask -> 4
+    Just ContinuationFrameStop -> 5
+
 data CpsGrinError
   = CpsGrinUnexpectedThrow !FunctionName
   | CpsGrinUnexpectedCatch !FunctionName
   | CpsGrinAlreadyTransformed !FunctionName
+  | CpsGrinInvalidContinuationParent !FunctionName
   deriving (Eq, Show)
 
 data CpsState = CpsState
@@ -50,7 +78,7 @@ data CpsState = CpsState
     cpsNextContinuationUnique :: !Int,
     cpsUsedFunctionNames :: !(Set FunctionName),
     cpsGeneratedFunctionsRev :: ![GrinFunction],
-    cpsContinuationNames :: !(Set FunctionName),
+    cpsContinuationFramesState :: !(Map FunctionName ContinuationFrameKind),
     cpsComputationContinuations :: !(Map FunctionName GrinVar)
   }
 
@@ -59,6 +87,8 @@ type CpsM = StateT CpsState (Either CpsGrinError)
 toCpsGrin :: GrinProgram -> Either CpsGrinError CpsGrinProgram
 toCpsGrin program = do
   ((functions, updateFunction), finalState) <- runStateT transform initialState
+  let continuationFrames =
+        Map.insert (grinFunctionName updateFunction) ContinuationFrameUpdate (cpsContinuationFramesState finalState)
   pure
     CpsGrinProgram
       { cpsGrinProgram =
@@ -69,8 +99,8 @@ toCpsGrin program = do
                   <> reverse (cpsGeneratedFunctionsRev finalState)
                   <> [updateFunction]
             },
-        cpsContinuationFunctions =
-          Set.insert (grinFunctionName updateFunction) (cpsContinuationNames finalState),
+        cpsContinuationFunctions = Map.keysSet continuationFrames,
+        cpsContinuationFrames = continuationFrames,
         cpsFunctionContinuations = cpsComputationContinuations finalState,
         cpsUpdateFunction = grinFunctionName updateFunction
       }
@@ -82,7 +112,7 @@ toCpsGrin program = do
           cpsNextContinuationUnique = 0,
           cpsUsedFunctionNames = Set.fromList (map grinFunctionName sourceFunctions),
           cpsGeneratedFunctionsRev = [],
-          cpsContinuationNames = Set.empty,
+          cpsContinuationFramesState = Map.empty,
           cpsComputationContinuations = Map.empty
         }
     transform = do
@@ -238,7 +268,12 @@ reifyContinuation updateName parent bound resultRep outerContinuation resultVars
       body
   continuationName <- freshContinuationName parent
   pointer <- freshVar "$cps_continuation" liftedRuntimeRep
-  let captures = Set.toAscList (freeExprVars transformedBody `Set.intersection` bound)
+  parentContinuation <-
+    case outerContinuation of
+      GrinVarValue var -> pure var
+      GrinLitValue {} -> lift (Left (CpsGrinInvalidContinuationParent parent))
+  let freeCaptures = freeExprVars transformedBody `Set.intersection` bound
+      captures = parentContinuation : Set.toAscList (Set.delete parentContinuation freeCaptures)
       continuationFunction =
         GrinFunction
           { grinFunctionName = continuationName,
@@ -251,7 +286,7 @@ reifyContinuation updateName parent bound resultRep outerContinuation resultVars
         GrinNode
           (GrinClosure continuationName [map grinVarRuntimeRep resultVars])
           (map GrinVarValue captures)
-  addContinuationFunction continuationFunction
+  addContinuationFunction ContinuationFrameNormal continuationFunction
   pure (pointer, continuationNode)
 
 continueDirect :: RuntimeRep -> GrinValue -> GrinExpr -> CpsM GrinExpr
@@ -269,25 +304,25 @@ makeUpdateContinuation updateName blackhole continuation = do
   pointer <- freshVar "$cps_update" liftedRuntimeRep
   pure
     ( pointer,
-      GrinNode (GrinClosure updateName [[liftedRuntimeRep]]) [blackhole, continuation]
+      GrinNode (GrinClosure updateName [[liftedRuntimeRep]]) [continuation, blackhole]
     )
 
 makeUpdateFunction :: FunctionName -> CpsM GrinFunction
 makeUpdateFunction updateName = do
-  blackhole <- freshVar "$cps_blackhole" liftedRuntimeRep
   outerContinuation <- freshVar "$cps_outer" liftedRuntimeRep
+  blackhole <- freshVar "$cps_blackhole" liftedRuntimeRep
   result <- freshVar "$cps_thunk_result" liftedRuntimeRep
   updated <- freshVar "$cps_updated" liftedRuntimeRep
   nextUpdate <- freshVar "$cps_next_update" liftedRuntimeRep
   let nextUpdateNode =
         GrinNode
           (GrinClosure updateName [[liftedRuntimeRep]])
-          [GrinVarValue result, GrinVarValue outerContinuation]
+          [GrinVarValue outerContinuation, GrinVarValue result]
   pure
     GrinFunction
       { grinFunctionName = updateName,
         grinFunctionLinkName = Nothing,
-        grinFunctionParameters = [blackhole, outerContinuation, result],
+        grinFunctionParameters = [outerContinuation, blackhole, result],
         grinFunctionResultRep = liftedRuntimeRep,
         grinFunctionBody =
           GrinBind
@@ -342,13 +377,13 @@ freshVar name runtimeRep = do
   put state {cpsNextVarUnique = unique + 1}
   pure (GrinVar name unique runtimeRep)
 
-addContinuationFunction :: GrinFunction -> CpsM ()
-addContinuationFunction function = do
+addContinuationFunction :: ContinuationFrameKind -> GrinFunction -> CpsM ()
+addContinuationFunction frameKind function = do
   addGeneratedFunction function
   modify' $ \state ->
     state
-      { cpsContinuationNames =
-          Set.insert (grinFunctionName function) (cpsContinuationNames state)
+      { cpsContinuationFramesState =
+          Map.insert (grinFunctionName function) frameKind (cpsContinuationFramesState state)
       }
 
 addGeneratedFunction :: GrinFunction -> CpsM ()

--- a/components/aihc-grin/src/Aihc/Grin/Gc.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Gc.hs
@@ -3,6 +3,7 @@
 -- | Make post-CPS allocation safepoints and relocated roots explicit.
 module Aihc.Grin.Gc
   ( GcGrinProgram,
+    gcContinuationFrames,
     gcContinuationFunctions,
     gcFunctionContinuations,
     gcGrinProgram,
@@ -12,7 +13,7 @@ module Aihc.Grin.Gc
 where
 
 import Aihc.Grin.Analysis (freeExprVars, freeNodeVars)
-import Aihc.Grin.Cps (CpsGrinProgram (..))
+import Aihc.Grin.Cps (ContinuationFrameKind, CpsGrinProgram (..))
 import Aihc.Grin.Syntax
 import Control.Monad.Trans.State.Strict (State, evalState, get, put)
 import Data.Map.Strict (Map)
@@ -26,6 +27,7 @@ import Data.Set qualified as Set
 data GcGrinProgram = GcGrinProgram
   { gcGrinProgram :: !GrinProgram,
     gcContinuationFunctions :: !(Set FunctionName),
+    gcContinuationFrames :: !(Map FunctionName ContinuationFrameKind),
     gcFunctionContinuations :: !(Map FunctionName GrinVar),
     gcUpdateFunction :: !FunctionName
   }
@@ -42,6 +44,7 @@ lowerGc cps =
           { grinFunctions = evalState (mapM lowerFunction (grinFunctions program)) nextUnique
           },
       gcContinuationFunctions = cpsContinuationFunctions cps,
+      gcContinuationFrames = cpsContinuationFrames cps,
       gcFunctionContinuations = cpsFunctionContinuations cps,
       gcUpdateFunction = cpsUpdateFunction cps
     }

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -144,11 +144,30 @@ grinUnitTests =
         cps <- expectCpsGrin callBindProgram
         let program = cpsGrinProgram cps
             rendered = renderProgram program
+            callerContinuation = cpsFunctionContinuations cps Map.! FunctionName "caller"
+            callerNodes =
+              [ node
+              | function <- grinFunctions program,
+                grinFunctionName function == FunctionName "caller",
+                node@(GrinNode (GrinClosure name _) _) <- expressionStoredNodes (grinFunctionBody function),
+                name `Set.member` cpsContinuationFunctions cps
+              ]
         assertEqual "transformed lint" [] (lintProgram program)
         assertBool "allocates a continuation closure" ("store (P$cps$" `isInfixOf` rendered)
         assertBool "invokes a continuation closure" ("continue ($cps_return" `isInfixOf` rendered)
         assertBool "passes an explicit continuation to the call" (any callEndsInContinuation (grinFunctions program))
-        assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program)),
+        assertBool "generated continuation captures its environment" (any continuationHasCaptures (grinFunctions program))
+        assertEqual "one caller continuation" 1 (length callerNodes)
+        case callerNodes of
+          [GrinNode _ fields] -> assertEqual "parent continuation occupies field zero" (Just (GrinVarValue callerContinuation)) (firstMaybe fields)
+          _ -> pure ()
+        assertEqual
+          "ordinary continuation frame kinds"
+          (Just ContinuationFrameNormal)
+          ( do
+              GrinNode (GrinClosure name _) _ <- firstMaybe callerNodes
+              Map.lookup name (cpsContinuationFrames cps)
+          ),
       testCase "CPS-GRIN treats a multi-value result as one logical argument" $ do
         cps <- expectCpsGrin multiValueContinuationProgram
         case grinFunctions (cpsGrinProgram cps) of
@@ -195,6 +214,7 @@ grinUnitTests =
             roots = map snd reservations
             rendered = renderProgram gcProgram
         assertEqual "preserves continuation entries" (cpsContinuationFunctions cps) (gcContinuationFunctions gc)
+        assertEqual "preserves continuation frame kinds" (cpsContinuationFrames cps) (gcContinuationFrames gc)
         assertEqual "preserves computation continuations" (cpsFunctionContinuations cps) (gcFunctionContinuations gc)
         assertEqual "preserves update entry" (cpsUpdateFunction cps) (gcUpdateFunction gc)
         assertEqual "GC-GRIN lint" [] (lintProgram gcProgram)
@@ -217,8 +237,23 @@ grinUnitTests =
             updateName = cpsUpdateFunction cps
         case [function | function <- grinFunctions program, grinFunctionName function == updateName] of
           [function] -> do
+            assertEqual "update frame kind" (Just ContinuationFrameUpdate) (Map.lookup updateName (cpsContinuationFrames cps))
+            assertEqual
+              "parent and blackhole lead the update entry parameters"
+              ["$cps_outer", "$cps_blackhole"]
+              (map grinVarName (take 2 (grinFunctionParameters function)))
             assertBool "updates only a blackhole" (containsUpdateBlackhole (grinFunctionBody function))
             assertBool "re-forces the updated result" (containsCpsEval (grinFunctionBody function))
+            let parentByOwner =
+                  case grinFunctionParameters function of
+                    parent : _ -> Map.insert updateName parent (cpsFunctionContinuations cps)
+                    [] -> cpsFunctionContinuations cps
+            forM_ (updateContinuationNodes updateName program) $ \(owner, node) -> do
+              assertEqual "update frame has parent and blackhole fields" 2 (length (grinNodeFields node))
+              assertEqual
+                "update frame parent occupies field zero"
+                (GrinVarValue <$> Map.lookup owner parentByOwner)
+                (firstMaybe (grinNodeFields node))
           _ -> assertFailure "missing unique update continuation",
       testCase "CPS-GRIN requires exception control to be eliminated" $ do
         assertEqual
@@ -530,6 +565,14 @@ expressionStoredNodes expression =
     GrinCase _ _ alternatives -> concatMap (expressionStoredNodes . grinAltRhs) alternatives
     _ -> []
 
+updateContinuationNodes :: FunctionName -> GrinProgram -> [(FunctionName, GrinNode)]
+updateContinuationNodes updateName program =
+  [ (grinFunctionName function, node)
+  | function <- grinFunctions program,
+    node@(GrinNode (GrinClosure name _) _) <- expressionStoredNodes (grinFunctionBody function),
+    name == updateName
+  ]
+
 expressionCalledFunctions :: GrinExpr -> [FunctionName]
 expressionCalledFunctions expression =
   case expression of
@@ -702,6 +745,12 @@ containsCpsEval expression =
     GrinStoreRec _ body -> containsCpsEval body
     GrinCase _ _ alternatives -> any (containsCpsEval . grinAltRhs) alternatives
     _ -> False
+
+firstMaybe :: [value] -> Maybe value
+firstMaybe values =
+  case values of
+    value : _ -> Just value
+    [] -> Nothing
 
 lastMaybe :: [value] -> Maybe value
 lastMaybe values =

--- a/components/aihc-native/runtime/aihc_runtime.c
+++ b/components/aihc-native/runtime/aihc_runtime.c
@@ -12,6 +12,8 @@ _Static_assert(offsetof(AihcMachine, heap_limit) == 32,
                "machine heap-limit ABI");
 _Static_assert(offsetof(AihcInfo, backend_entry) == 48,
                "info-table backend-entry ABI");
+_Static_assert(offsetof(AihcInfo, frame_kind) == 56,
+               "info-table frame-kind ABI");
 _Static_assert(offsetof(AihcResume, kind) == 0, "resume kind ABI");
 _Static_assert(offsetof(AihcResume, function) == 8, "resume function ABI");
 _Static_assert(offsetof(AihcResume, continuation) == 16,

--- a/components/aihc-native/runtime/aihc_runtime.h
+++ b/components/aihc-native/runtime/aihc_runtime.h
@@ -51,6 +51,16 @@ typedef struct {
   uint64_t count;
 } AihcResume;
 
+enum {
+  AIHC_FRAME_NONE = 0,
+  AIHC_FRAME_NORMAL = 1,
+  AIHC_FRAME_CATCH = 2,
+  AIHC_FRAME_UPDATE = 3,
+  AIHC_FRAME_RESTORE_MASK = 4,
+  AIHC_FRAME_STOP = 5,
+};
+typedef uint64_t AihcFrameKind;
+
 struct AihcInfo {
   uintptr_t identity;
   AihcEntry entry;
@@ -61,6 +71,9 @@ struct AihcInfo {
   /* Backend-owned dynamic entry. Native and WebAssembly adapters give this
      word their own callable type; portable C leaves it null. */
   AihcBackendEntry backend_entry;
+  /* Continuation closures have their parent in field zero. This kind is
+     backend-independent so the runtime can unwind them uniformly. */
+  AihcFrameKind frame_kind;
 };
 
 struct AihcValue {

--- a/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
+++ b/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
@@ -14,7 +14,8 @@ module Aihc.Wasm.Codegen
   )
 where
 
-import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFunctions, gcGrinProgram, gcUpdateFunction)
+import Aihc.Grin.Cps (ContinuationFrameKind (..), continuationFrameKindCode)
+import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcGrinProgram, gcUpdateFunction)
 import Aihc.Grin.Syntax
 import Aihc.Native (LinkLayout (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, supportedNativePrimitiveNames)
 import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
@@ -78,7 +79,8 @@ data RuntimeInfo = RuntimeInfo
     runtimeInfoFields :: ![RuntimeRep],
     runtimeInfoRemainingArity :: !Int,
     runtimeInfoNext :: !(Maybe Text),
-    runtimeInfoAdapter :: !(Maybe RuntimeAdapter)
+    runtimeInfoAdapter :: !(Maybe RuntimeAdapter),
+    runtimeInfoFrameKind :: !(Maybe ContinuationFrameKind)
   }
 
 data RuntimeInfoKey
@@ -124,7 +126,7 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
   functions <- mapM (compileFunction env) (grinFunctions program)
   constructorInit <- compileConstructorInitializers env
   programInit <- compileInitializers env program
-  let specialInfo label entry fields remaining next = RuntimeInfo label Nothing (Just entry) fields remaining next Nothing
+  let specialInfo label entry fields remaining next frameKind = RuntimeInfo label Nothing (Just entry) fields remaining next Nothing (Just frameKind)
       updateInfo label fields remaining next enter =
         RuntimeInfo
           label
@@ -134,15 +136,16 @@ compileProgramWithDependencies layout dependencyInitializers entryName gcProgram
           remaining
           next
           (Just (RuntimeAdapter updateLabel updateArity enter))
+          (Just ContinuationFrameUpdate)
       specialInfos =
-        [ specialInfo "aihc_wasm_final_info" "aihc_wasm_final_continuation" [] 1 (Just "aihc_wasm_final_applied_info"),
-          specialInfo "aihc_wasm_final_applied_info" "aihc_wasm_final_continuation" [BoxedRep Lifted] 0 Nothing,
-          specialInfo "aihc_wasm_top_info" "aihc_wasm_top_continuation" [BoxedRep Lifted] 1 (Just "aihc_wasm_top_applied_info"),
-          specialInfo "aihc_wasm_top_applied_info" "aihc_wasm_top_continuation" [BoxedRep Lifted, BoxedRep Lifted] 0 Nothing,
+        [ specialInfo "aihc_wasm_final_info" "aihc_wasm_final_continuation" [] 1 (Just "aihc_wasm_final_applied_info") ContinuationFrameStop,
+          specialInfo "aihc_wasm_final_applied_info" "aihc_wasm_final_continuation" [BoxedRep Lifted] 0 Nothing ContinuationFrameStop,
+          specialInfo "aihc_wasm_top_info" "aihc_wasm_top_continuation" [BoxedRep Lifted] 1 (Just "aihc_wasm_top_applied_info") ContinuationFrameNormal,
+          specialInfo "aihc_wasm_top_applied_info" "aihc_wasm_top_continuation" [BoxedRep Lifted, BoxedRep Lifted] 0 Nothing ContinuationFrameNormal,
           updateInfo "aihc_wasm_update_info" [BoxedRep Lifted, BoxedRep Lifted] 1 (Just "aihc_wasm_update_applied_info") (Just (RuntimeEnter 2 1 False)),
           updateInfo "aihc_wasm_update_applied_info" [BoxedRep Lifted, BoxedRep Lifted, BoxedRep Lifted] 0 Nothing Nothing,
-          specialInfo "aihc_wasm_thread_done_info" "aihc_wasm_thread_done_continuation" [] 1 (Just "aihc_wasm_thread_done_applied_info"),
-          specialInfo "aihc_wasm_thread_done_applied_info" "aihc_wasm_thread_done_continuation" [BoxedRep Lifted] 0 Nothing
+          specialInfo "aihc_wasm_thread_done_info" "aihc_wasm_thread_done_continuation" [] 1 (Just "aihc_wasm_thread_done_applied_info") ContinuationFrameStop,
+          specialInfo "aihc_wasm_thread_done_applied_info" "aihc_wasm_thread_done_continuation" [BoxedRep Lifted] 0 Nothing ContinuationFrameStop
         ]
       runtimeInfos = compileRuntimeInfos env <> specialInfos
       source =
@@ -228,7 +231,7 @@ compileEnvironment unitKind layout gcProgram =
                ]
         )
     constructorEntries =
-      [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next Nothing)
+      [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next Nothing Nothing)
       | ((name, layouts), (_, identifier)) <- zip (linkConstructors layout) constructorIds,
         let arity = length layouts,
         remaining <- [arity, arity - 1 .. 0],
@@ -265,6 +268,7 @@ compileEnvironment unitKind layout gcProgram =
             (runtimeInfoKeyRemainingArity key)
             (runtimeInfoKeyNext key >>= (`Map.lookup` infoLabels))
             (Just (RuntimeAdapter target arity enter))
+            (Map.lookup functionName (gcContinuationFrames gcProgram))
         )
       | (index, key) <- zip [0 :: Int ..] infoKeys,
         Just functionName <- [runtimeInfoFunctionName key],
@@ -872,11 +876,11 @@ renderProgramInitializer globalCount rootSlot dependencyInitializers constructor
         <> specialSet 2 (makeSpecial "aihc_wasm_update_info")
         <> specialGet 2
         <> i64Const "0"
-        <> globalGet rootSlot
+        <> specialGet 1
         <> call "aihc_wasm_set_field"
         <> specialGet 2
         <> i64Const "1"
-        <> specialGet 1
+        <> globalGet rootSlot
         <> call "aihc_wasm_set_field"
         <> specialSet 3 (makeSpecial "aihc_wasm_thread_done_info")
         <> ["local.get\t0"]
@@ -1017,7 +1021,8 @@ renderRuntimeInfos infos = concatMap renderBitmap infos <> concatMap renderInfo 
              "\t.int32\t" <> maybe "0" dataLabel (runtimeInfoNext info),
              "\t.int32\t" <> maybe "0" (const (objectEntryLabel info)) (runtimeInfoAdapter info >>= runtimeAdapterEnter),
              "\t.skip\t4",
-             "\t.size\t" <> dataLabel (runtimeInfoLabel info) <> ", 40",
+             "\t.int64\t" <> tshow (continuationFrameKindCode (runtimeInfoFrameKind info)),
+             "\t.size\t" <> dataLabel (runtimeInfoLabel info) <> ", 48",
              ""
            ]
 

--- a/components/aihc-wasm/test/Test/Wasm/Suite.hs
+++ b/components/aihc-wasm/test/Test/Wasm/Suite.hs
@@ -50,6 +50,8 @@ testDirectModule =
           assertBool "generated entry is object-local" (not (".globl\t.Laihc_wasm_function_0" `T.isInfixOf` source))
           assertBool "not portable C" (not ("#include" `T.isInfixOf` source))
           assertBool "not LLVM IR" (not ("target triple" `T.isInfixOf` source))
+          assertBool "uses the expanded shared info-table ABI" ("\t.int64\t3\n\t.size\t.Laihc_wasm_update_info, 48" `T.isInfixOf` source)
+          assertBool "emits stop continuation frame metadata" ("\t.int64\t5\n\t.size\t.Laihc_wasm_final_info, 48" `T.isInfixOf` source)
 
 testWasmLocals :: IO ()
 testWasmLocals =

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -20,10 +20,13 @@ failure. `toCpsGrin` rejects both nodes, and the native and Wasm backends reject
 them as well. This is useful reference behavior, but it is not the runtime
 model.
 
-The CPS pass already reifies the rest of a computation as an ordinary closure.
-It does not yet guarantee that every such closure contains a discoverable link
-to its parent, so the first exception-runtime change is to strengthen that
-invariant.
+Structural `Typeable` evidence and checked casts are implemented. The CPS pass
+now reifies the rest of a computation as an ordinary closure whose field zero
+is always its parent continuation. CPS records a frame kind for every generated
+continuation, GC-GRIN preserves it, and every backend emits it in `AihcInfo`.
+
+`GrinThrow` and `GrinCatch` are still rejected at the CPS boundary. The next
+runtime change is to lower those nodes to continuation-chain operations.
 
 ## Continuation-chain invariant
 
@@ -290,10 +293,10 @@ checks `UserInterrupt` handling. It is not the semantic cross-backend test.
 
 ## Implementation sequence
 
-1. Land structural `Typeable`, exact comparison, and the trusted
+1. **Complete:** land structural `Typeable`, exact comparison, and the trusted
    `unsafeCoerce#` primitive as an independent change.
-2. Make the continuation parent link and frame metadata explicit without
-   changing behavior.
+2. **Complete:** make the continuation parent link and frame metadata explicit
+   without changing behavior.
 3. Lower synchronous raise/catch during CPS conversion and implement shared
    unwinding, update cleanup, `Exception`, and `SomeException`.
 4. Add masking state and restore frames, then implement the library masking and


### PR DESCRIPTION
## Summary

- guarantee that every generated continuation closure stores its parent in field zero, even when ordinary free-variable analysis would omit it
- normalize update frames from `[blackhole, parent]` to `[parent, blackhole]` and update the native startup paths accordingly
- add explicit normal, catch, update, restore-mask, and stop frame kinds to CPS-GRIN metadata
- preserve continuation frame kinds through GC-GRIN
- append a stable frame-kind word to the shared `AihcInfo` ABI and emit it from the portable C, WebAssembly, ARM64, and AMD64 backends
- classify top, update, final, snapshot, and thread-completion frames without changing their behavior
- update the exception roadmap to record phase 2 as complete

## Why

Synchronous exception handling must unwind the heap-resident CPS continuation chain rather than use sentinel results or the system stack. A portable unwinder needs two structural guarantees before `raise#` and `catch#` can be lowered: field zero must always identify the parent frame, and the runtime must be able to distinguish normal, catch, update, restore-mask, and stop frames without interpreting backend code pointers.

This PR establishes those guarantees while preserving existing control-flow behavior. The next phase can add catch-frame construction and synchronous unwinding against one shared representation.

## Progress

- exception roadmap: phase 2 of 6 complete; structural `Typeable` and continuation metadata are complete
- synchronous unwinding, masking, async queues/safe points, and host signal adapters remain
- 2 CPS layout/metadata regression tests added or strengthened
- 1 GC metadata-preservation assertion added
- frame-metadata emission assertions cover all 4 backends
- README progress counts intentionally unchanged; they remain cron-managed

## Validation

- `just fmt`
- `just check` — all formatting, lint, warning-as-error compiler/runtime builds, and test suites passed
- 1,874 parser tests passed
- 78 cross-backend tests passed
- focused ARM64 and AMD64 scheduler suites passed after the update-frame layout migration

## Scope

- `GrinThrow` and `GrinCatch` remain rejected by CPS-GRIN in this behavior-preserving phase
- catch and restore-mask frame kinds are reserved in the shared ABI but are not emitted until their lowering lands
- asynchronous delivery state and polling are unchanged