### PR TITLE
feat(tc): add constrained existential constructors

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -17,6 +17,7 @@ import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsMa
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Optimize (optimizeProgram)
+import Aihc.Fc.Subst (freeRigidTyVars, substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseSignatureType)
 import Aihc.Parser.Syntax
@@ -245,8 +246,13 @@ dsDecl _ = pure []
 dsDataDeclM :: DataDecl -> DsM FcTopBind
 dsDataDeclM dd = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
-  cons <- mapM dsDataConM (dataDeclConstructors dd)
-  pure (FcData tyName [] cons)
+  constructorInfos <- mapM dsDataConM (dataDeclConstructors dd)
+  let typeVariables =
+        case constructorInfos of
+          (_, universals, _) : _ -> universals
+          [] -> []
+      constructors = [(name, fields) | (name, _, fields) <- constructorInfos]
+  pure (FcData tyName typeVariables constructors)
 
 -- | Retain the nominal declaration and its representation type as an FC axiom.
 -- 'lowerNewtypes' turns all term-level construction and matching into casts.
@@ -391,13 +397,77 @@ unboxForeignValue binderName marshal expression continuation =
         )
 
 boxForeignValue :: TcForeignMarshal -> FcExpr -> DsM FcExpr
-boxForeignValue marshal rawValue =
-  foldM applyConstructor rawValue (reverse (tcForeignConstructors marshal))
+boxForeignValue marshal =
+  applyConstructors (tcForeignSourceType marshal) (tcForeignConstructors marshal)
   where
-    applyConstructor value constructor = do
+    applyConstructors _ [] value = pure value
+    applyConstructors resultType (constructor : constructors) value = do
       constructorType <- lookupType constructor
       constructorVar <- freshVar constructor constructorType
-      pure (FcApp (FcVar constructorVar) value)
+      (typeArguments, fieldType) <- instantiateUnaryConstructor constructor resultType constructorType
+      fieldValue <- applyConstructors fieldType constructors value
+      pure (FcApp (foldl FcTyApp (FcVar constructorVar) typeArguments) fieldValue)
+
+instantiateUnaryConstructor :: Text -> TcType -> TcType -> DsM ([TcType], TcType)
+instantiateUnaryConstructor constructor expectedResult constructorType = do
+  let (typeVariables, body) = collectForAlls constructorType
+  case body of
+    TcFunTy fieldType resultType ->
+      case matchConstructorResult typeVariables resultType expectedResult Map.empty of
+        Just substitution
+          | Just typeArguments <- traverse (`Map.lookup` substitution) typeVariables ->
+              pure (typeArguments, substType substitution fieldType)
+        _ ->
+          desugarBug
+            ( "foreign marshalling constructor result does not match "
+                <> show expectedResult
+                <> ": "
+                <> T.unpack constructor
+            )
+    _ -> desugarBug ("foreign marshalling constructor is not unary: " <> T.unpack constructor)
+
+matchConstructorResult :: [TyVarId] -> TcType -> TcType -> Map.Map TyVarId TcType -> Maybe (Map.Map TyVarId TcType)
+matchConstructorResult quantified patternType actualType substitution =
+  case patternType of
+    TcTyVar tyVar
+      | tyVar `elem` quantified ->
+          case Map.lookup tyVar substitution of
+            Nothing -> Just (Map.insert tyVar actualType substitution)
+            Just existing
+              | existing == actualType -> Just substitution
+              | otherwise -> Nothing
+    TcTyVar tyVar ->
+      case actualType of
+        TcTyVar actualTyVar | tyVar == actualTyVar -> Just substitution
+        _ -> Nothing
+    TcMetaTv meta ->
+      case actualType of
+        TcMetaTv actualMeta | meta == actualMeta -> Just substitution
+        _ -> Nothing
+    TcTyCon tyCon arguments ->
+      case actualType of
+        TcTyCon actualTyCon actualArguments
+          | tyCon == actualTyCon,
+            length arguments == length actualArguments ->
+              foldM
+                (\current (expectedArgument, actualArgument) -> matchConstructorResult quantified expectedArgument actualArgument current)
+                substitution
+                (zip arguments actualArguments)
+        _ -> Nothing
+    TcFunTy argument result ->
+      case actualType of
+        TcFunTy actualArgument actualResult -> do
+          substitution' <- matchConstructorResult quantified argument actualArgument substitution
+          matchConstructorResult quantified result actualResult substitution'
+        _ -> Nothing
+    TcAppTy function argument ->
+      case actualType of
+        TcAppTy actualFunction actualArgument -> do
+          substitution' <- matchConstructorResult quantified function actualFunction substitution
+          matchConstructorResult quantified argument actualArgument substitution'
+        _ -> Nothing
+    TcForAllTy {} -> Nothing
+    TcQualTy {} -> Nothing
 
 makeForeignIoWrapper :: FcForeignCall -> TcForeignMarshal -> [FcExpr] -> DsM FcExpr
 makeForeignIoWrapper foreignCall resultMarshal arguments = do
@@ -636,12 +706,24 @@ collectForAlls (TcForAllTy tv body) =
    in (tv : tvs, inner)
 collectForAlls ty = ([], ty)
 
-dsDataConM :: DataConDecl -> DsM (Text, [TcType])
+dsDataConM :: DataConDecl -> DsM (Text, [TyVarId], [TcType])
 dsDataConM con = do
   let (name, arity) = dsDataConPure con
   ty <- lookupType name
-  fields <- dataConFieldTypes name arity (dropForAlls ty)
-  pure (name, fields)
+  let (quantifiedVariables, qualifiedConstructorTy) = collectForAlls ty
+      (predicates, constructorTy) = splitConstructorContext qualifiedConstructorTy
+      resultVariables = freeRigidTyVars (constructorResultType constructorTy)
+      universalVariables = filter (`elem` resultVariables) quantifiedVariables
+  fields <- dataConFieldTypes name arity constructorTy
+  pure (name, universalVariables, map predType predicates <> fields)
+
+splitConstructorContext :: TcType -> ([Pred], TcType)
+splitConstructorContext (TcQualTy predicates body) = (predicates, body)
+splitConstructorContext ty = ([], ty)
+
+constructorResultType :: TcType -> TcType
+constructorResultType (TcFunTy _ result) = constructorResultType result
+constructorResultType ty = ty
 
 dataConFieldTypes :: Text -> Int -> TcType -> DsM [TcType]
 dataConFieldTypes _ 0 _ = pure []

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -358,13 +358,14 @@ dsOrdinaryPatternMatch scrutVar pat success failure = do
     _ -> do
       binderTys <- patternBinderTypesM pat (varType scrutVar)
       binders <- zipWithM freshVar binderNames binderTys
-      matched <- withLocals (zip binderNames binders) success
+      (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
+      matched <- withDicts dictionaries (withLocals (zip binderNames binders) success)
       caseBinder <- freshInternalVar "_match" (varType scrutVar)
       pure
         ( FcCase
             (FcVar scrutVar)
             caseBinder
-            [ FcAlt con binders matched,
+            [ FcAlt con (evidenceBinders <> binders) matched,
               FcAlt DefaultAlt [] failure
             ]
         )
@@ -446,8 +447,9 @@ buildAltGroup scrutVar restVars resTy (FirstPatternGroup pat matches) =
           (con, binderNames) = dsPatternPure pat
       binderTys <- patternBinderTypesM pat (varType scrutVar)
       binders <- zipWithM freshVar binderNames binderTys
-      body <- withLocals (zip binderNames binders) (buildCaseChain restVars resTy innerMatches)
-      pure (FcAlt con binders body)
+      (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
+      body <- withDicts dictionaries (withLocals (zip binderNames binders) (buildCaseChain restVars resTy innerMatches))
+      pure (FcAlt con (evidenceBinders <> binders) body)
 
 dsRhs :: Rhs Expr -> DsM FcExpr
 dsRhs (UnguardedRhs _sp expr maybeDecls) =
@@ -511,14 +513,15 @@ dsAnnotatedVar :: TcAnnotation -> Name -> Expr -> DsM FcExpr
 dsAnnotatedVar tcAnn name _expr = do
   let n = nameToText name
   mLocal <- lookupLocalName name
-  case mLocal of
-    Just v -> pure (FcVar v)
-    Nothing -> do
-      ty <- lookupTypeName name
-      v <- freshVar n ty
-      let typedExpr = List.foldl' FcTyApp (FcVar v) (tcAnnTypeArgs tcAnn)
-      dicts <- mapM dsEvidence (tcAnnEvidenceTerms tcAnn)
-      pure (List.foldl' FcApp typedExpr dicts)
+  variable <-
+    case mLocal of
+      Just local -> pure local
+      Nothing -> do
+        ty <- lookupTypeName name
+        freshVar n ty
+  let typedExpr = List.foldl' FcTyApp (FcVar variable) (tcAnnTypeArgs tcAnn)
+  dicts <- mapM dsEvidence (tcAnnEvidenceTerms tcAnn)
+  pure (List.foldl' FcApp typedExpr dicts)
 
 dsAnnotatedExpr :: TcAnnotation -> Expr -> DsM FcExpr
 dsAnnotatedExpr tcAnn inner =
@@ -1032,13 +1035,14 @@ dsCompGenMatch elemTy body pat rest headVar skipExpr =
         _ -> do
           binderTys <- patternBinderTypesM pat (varType headVar)
           binders <- zipWithM freshVar binderNames binderTys
-          matched <- withLocals (zip binderNames binders) (dsCompQuals elemTy body rest skipExpr)
+          (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
+          matched <- withDicts dictionaries (withLocals (zip binderNames binders) (dsCompQuals elemTy body rest skipExpr))
           caseBinder <- freshInternalVar "_lc_match" (varType headVar)
           pure
             ( FcCase
                 (FcVar headVar)
                 caseBinder
-                [ FcAlt con binders matched,
+                [ FcAlt con (evidenceBinders <> binders) matched,
                   FcAlt DefaultAlt [] skipExpr
                 ]
             )
@@ -1059,11 +1063,11 @@ dsLambda pats body = do
   argTys <- mapM lambdaPatternTypeRequired pats
   vars <- zipWithM freshInternalVar (map lambdaArgName pats) argTys
   body' <-
-    if any isOverloadedIntegerPattern pats
-      then do
+    case traverse (uncurry directPatternBindings) (zip pats vars) of
+      Nothing -> do
         failure <- noPatternMatch vars
         dsMatchPatterns vars pats (dsExpr body) failure
-      else withLocals (concat (zipWith lambdaPatternBindings pats vars)) (dsExpr body)
+      Just bindings -> withLocals (concat bindings) (dsExpr body)
   pure (foldr FcLam body' vars)
 
 dsLambdaCase :: [CaseAlt Expr] -> DsM FcExpr
@@ -1102,15 +1106,6 @@ lambdaArgName pat =
     PParen inner -> lambdaArgName inner
     PAs name _ -> unqualifiedNameText name
     _ -> "_lam"
-
-lambdaPatternBindings :: Pattern -> Var -> [(Text, Var)]
-lambdaPatternBindings pat var =
-  case pat of
-    PVar name -> [(unqualifiedNameText name, var)]
-    PAnn _ inner -> lambdaPatternBindings inner var
-    PParen inner -> lambdaPatternBindings inner var
-    PAs name inner -> (unqualifiedNameText name, var) : lambdaPatternBindings inner var
-    _ -> []
 
 dsTuple :: TupleFlavor -> TcAnnotation -> [Maybe Expr] -> DsM FcExpr
 dsTuple flavor tcAnn elems = do
@@ -1320,6 +1315,34 @@ nameTcAnnotation :: Name -> Maybe TcAnnotation
 nameTcAnnotation =
   listToMaybe . mapMaybe fromAnnotation . nameAnns
 
+patternEvidenceBinders :: Pattern -> DsM ([Var], [ClassDict])
+patternEvidenceBinders pattern' = do
+  let predicates =
+        case patternTcAnnotation pattern' of
+          Just annotation -> [predicate | EvGiven predicate <- tcAnnEvidenceTerms annotation]
+          Nothing -> []
+  binders <- mapM (freshVar "$dpattern" . predType) predicates
+  pure (binders, zipWith patternDictionary predicates binders)
+  where
+    patternDictionary predicate binder =
+      case predicate of
+        ClassPred className arguments -> ClassDict className arguments binder
+        EqPred {} -> ClassDict "<constraint>" [] binder
+
+patternTcAnnotation :: Pattern -> Maybe TcAnnotation
+patternTcAnnotation pattern' =
+  case pattern' of
+    PAnn ann inner ->
+      case fromAnnotation ann of
+        Just annotation -> Just annotation
+        Nothing -> patternTcAnnotation inner
+    PParen inner -> patternTcAnnotation inner
+    PStrict inner -> patternTcAnnotation inner
+    PIrrefutable inner -> patternTcAnnotation inner
+    PAs _ inner -> patternTcAnnotation inner
+    PTypeSig inner _ -> patternTcAnnotation inner
+    _ -> Nothing
+
 patternBinderTypesM :: Pattern -> TcType -> DsM [TcType]
 patternBinderTypesM pat scrutTy =
   case pat of
@@ -1347,7 +1370,7 @@ patternBinderTypesM pat scrutTy =
 constructorFieldTypesM :: Name -> Int -> DsM [TcType]
 constructorFieldTypesM name arity = do
   ty <- lookupTypeName name
-  takeConstructorFields (nameToText name) arity (dropForAlls ty)
+  takeConstructorFields (nameToText name) arity (dropConstructorContext (dropForAlls ty))
 
 takeConstructorFields :: Text -> Int -> TcType -> DsM [TcType]
 takeConstructorFields _ 0 _ = pure []
@@ -1359,6 +1382,10 @@ takeConstructorFields name arity ty =
 dropForAlls :: TcType -> TcType
 dropForAlls (TcForAllTy _ body) = dropForAlls body
 dropForAlls ty = ty
+
+dropConstructorContext :: TcType -> TcType
+dropConstructorContext (TcQualTy _ body) = body
+dropConstructorContext ty = ty
 
 listElemTyM :: TcType -> DsM TcType
 listElemTyM (TcTyCon (TyCon "[]" 1) [elemTy]) = pure elemTy
@@ -1470,8 +1497,9 @@ dsCaseAlt scrutTy (CaseAlt _anns pat rhs) = do
   let (con, binderNames) = dsPatternPure pat
   binderTys <- patternBinderTypesM pat scrutTy
   binders <- zipWithM freshVar binderNames binderTys
-  body <- withLocals (zip binderNames binders) (dsRhs rhs)
-  pure (FcAlt con binders body)
+  (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
+  body <- withDicts dictionaries (withLocals (zip binderNames binders) (dsRhs rhs))
+  pure (FcAlt con (evidenceBinders <> binders) body)
 
 -- | Convert a Name to Text.
 nameToText :: Name -> Text

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -26,7 +26,7 @@ module Aihc.Fc.Lint
   )
 where
 
-import Aihc.Fc.Subst (substType)
+import Aihc.Fc.Subst (freeRigidTyVarsOf, substType)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
@@ -89,7 +89,10 @@ lintProgram env0 prog = go envWithDeclarations (fcTopBinds prog)
       env
         { leDataCons =
             foldr
-              (\(constructor, fields) -> Map.insert constructor (tyVars, fields, resultType))
+              ( \(constructor, fields) ->
+                  let existentialVariables = filter (`notElem` tyVars) (freeRigidTyVarsOf fields)
+                   in Map.insert constructor (tyVars <> existentialVariables, fields, resultType)
+              )
               (leDataCons env)
               constructors
         }

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -18,6 +18,7 @@ module Aihc.Fc.Pretty
   )
 where
 
+import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..))
 import Data.ByteString qualified as BS
@@ -46,7 +47,7 @@ renderTopBind (FcData tyName tyVars cons) =
   "data "
     ++ T.unpack tyName
     ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
-    ++ renderDataCons cons
+    ++ renderDataCons tyVars cons
 renderTopBind (FcNewtype declaration) =
   "newtype "
     ++ T.unpack (fcNewtypeName declaration)
@@ -72,15 +73,24 @@ renderTopBind (FcForeignImport foreignCall) =
 renderTopBind (FcTopBind bind) = renderBind 0 bind
 
 -- | Render data constructors.
-renderDataCons :: [(Text, [TcType])] -> String
-renderDataCons [] = ""
-renderDataCons cons =
+renderDataCons :: [TyVarId] -> [(Text, [TcType])] -> String
+renderDataCons _ [] = ""
+renderDataCons dataTyVars cons =
   "\n" ++ intercalate "\n" (zipWith renderOne (" = " : repeat " | ") cons)
   where
     renderOne prefix (name, args) =
       prefix
+        ++ renderExistentials args
         ++ T.unpack name
         ++ concatMap (\ty -> " " ++ renderTypePrec True ty) args
+
+    renderExistentials arguments =
+      case filter (`notElem` dataTyVars) (freeRigidTyVarsOf arguments) of
+        [] -> ""
+        existentials ->
+          "forall "
+            ++ unwords (map (T.unpack . tvName) existentials)
+            ++ ". "
 
 -- | Render a binding at a given indentation level.
 renderBind :: Int -> FcBind -> String

--- a/components/aihc-fc/src/Aihc/Fc/Subst.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Subst.hs
@@ -10,6 +10,7 @@ module Aihc.Fc.Subst
 where
 
 import Aihc.Tc.Types (Pred (..), TcType (..), TyVarId (..))
+import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 
@@ -36,7 +37,7 @@ freeRigidTyVarsOf = uniqueTyVars . concatMap go
         ClassPred _ arguments -> concatMap go arguments
         EqPred left right -> go left <> go right
 
-    uniqueTyVars = foldl' (\variables tyVar -> if tyVar `elem` variables then variables else variables <> [tyVar]) []
+    uniqueTyVars = List.foldl' (\variables tyVar -> if tyVar `elem` variables then variables else variables <> [tyVar]) []
 
 -- | Substitute type variables in a type according to the given mapping.
 --

--- a/components/aihc-fc/src/Aihc/Fc/Subst.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Subst.hs
@@ -4,12 +4,39 @@
 -- instantiated with a concrete type.
 module Aihc.Fc.Subst
   ( substType,
+    freeRigidTyVars,
+    freeRigidTyVarsOf,
   )
 where
 
 import Aihc.Tc.Types (Pred (..), TcType (..), TyVarId (..))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+
+-- | Free rigid type variables in stable left-to-right order.
+freeRigidTyVars :: TcType -> [TyVarId]
+freeRigidTyVars = freeRigidTyVarsOf . pure
+
+-- | Free rigid type variables across several types, without duplicates.
+freeRigidTyVarsOf :: [TcType] -> [TyVarId]
+freeRigidTyVarsOf = uniqueTyVars . concatMap go
+  where
+    go ty =
+      case ty of
+        TcTyVar tyVar -> [tyVar]
+        TcMetaTv {} -> []
+        TcTyCon _ arguments -> concatMap go arguments
+        TcFunTy argument result -> go argument <> go result
+        TcForAllTy tyVar body -> filter (/= tyVar) (go body)
+        TcQualTy predicates body -> concatMap goPredicate predicates <> go body
+        TcAppTy function argument -> go function <> go argument
+
+    goPredicate predicate =
+      case predicate of
+        ClassPred _ arguments -> concatMap go arguments
+        EqPred left right -> go left <> go right
+
+    uniqueTyVars = foldl' (\variables tyVar -> if tyVar `elem` variables then variables else variables <> [tyVar]) []
 
 -- | Substitute type variables in a type according to the given mapping.
 --

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -10,7 +10,8 @@ module Test.Fc.Suite
 where
 
 import Aihc.Fc
-import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
+import Aihc.Fc.Subst (freeRigidTyVarsOf)
+import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Data.Text (Text)
@@ -48,6 +49,10 @@ fcEvalTests =
         let literal = LitAddr "hello"
         assertEqual "runtime representation" AddrRep (literalRuntimeRep literal)
         assertEqual "literal type" (Just (TcTyCon (TyCon "Addr#" 0) [])) (literalType literal),
+      testCase "keeps free rigid variables in first-occurrence order" $ do
+        let first = TyVarId "first" (Unique 1)
+            second = TyVarId "second" (Unique 2)
+        assertEqual "ordered variables" [first, second] (freeRigidTyVarsOf [TcTyVar first, TcTyVar second, TcTyVar first]),
       testCase "applies lambdas" $
         assertEvalExpr
           "\"ok\""

--- a/components/aihc-fc/test/Test/Fixtures/golden/constrained-existential-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/constrained-existential-constructor.yaml
@@ -1,0 +1,36 @@
+extensions:
+  - ExistentialQuantification
+modules:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Test where
+    data Mark = Marked
+    class Markable a where
+      mark :: a -> Mark
+    data Box = forall a. Markable a => Box a
+    inspect :: Box -> Mark
+    inspect (Box value) = mark value
+expected: |-
+  data Mark
+   = Marked
+
+  data Markable a
+   = $Dict$Markable (a → Mark)
+
+  mark : ∀ a. (Markable a) → a → Mark =
+    Λa.
+      λ$d0 : Markable a.
+        case $d0 as $dict : Markable a of
+          $Dict$Markable $method0 →
+            $method0
+
+  data Box
+   = forall a. Box (Markable a) a
+
+  inspect : Box → Mark =
+    λx1005 : Box.
+      case x1005 as _scrut : Box of
+        Box $dpattern value →
+          mark @a $dpattern value
+status: pass
+reason: System FC stores the constructor dictionary and binds it before the existential payload

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -1107,20 +1107,32 @@ resolveDataConDecl :: DataConDecl -> ResolveM DataConDecl
 resolveDataConDecl dataConDecl =
   case dataConDecl of
     DataConAnn ann inner -> DataConAnn ann <$> withPushedSpan ann (resolveDataConDecl inner)
-    PrefixCon forallVars context name bangTypes ->
-      PrefixCon forallVars <$> mapM resolveType context <*> pure name <*> mapM resolveBangType bangTypes
-    InfixCon forallVars context lhs name rhs ->
-      InfixCon forallVars <$> mapM resolveType context <*> resolveBangType lhs <*> pure name <*> resolveBangType rhs
-    RecordCon forallVars context name fields ->
-      RecordCon forallVars <$> mapM resolveType context <*> pure name <*> mapM resolveFieldDecl fields
+    PrefixCon forallVars context name bangTypes -> do
+      (forallScope, forallVars') <- bindTyVarBinders forallVars
+      extendScope forallScope $
+        PrefixCon forallVars' <$> mapM resolveType context <*> pure name <*> mapM resolveBangType bangTypes
+    InfixCon forallVars context lhs name rhs -> do
+      (forallScope, forallVars') <- bindTyVarBinders forallVars
+      extendScope forallScope $
+        InfixCon forallVars' <$> mapM resolveType context <*> resolveBangType lhs <*> pure name <*> resolveBangType rhs
+    RecordCon forallVars context name fields -> do
+      (forallScope, forallVars') <- bindTyVarBinders forallVars
+      extendScope forallScope $
+        RecordCon forallVars' <$> mapM resolveType context <*> pure name <*> mapM resolveFieldDecl fields
     GadtCon forallVars context names body ->
       GadtCon forallVars <$> mapM resolveType context <*> pure names <*> resolveGadtBody body
-    TupleCon forallVars context flavor fields ->
-      TupleCon forallVars <$> mapM resolveType context <*> pure flavor <*> mapM resolveBangType fields
-    UnboxedSumCon forallVars context pos arity field ->
-      UnboxedSumCon forallVars <$> mapM resolveType context <*> pure pos <*> pure arity <*> resolveBangType field
-    ListCon forallVars context ->
-      ListCon forallVars <$> mapM resolveType context
+    TupleCon forallVars context flavor fields -> do
+      (forallScope, forallVars') <- bindTyVarBinders forallVars
+      extendScope forallScope $
+        TupleCon forallVars' <$> mapM resolveType context <*> pure flavor <*> mapM resolveBangType fields
+    UnboxedSumCon forallVars context pos arity field -> do
+      (forallScope, forallVars') <- bindTyVarBinders forallVars
+      extendScope forallScope $
+        UnboxedSumCon forallVars' <$> mapM resolveType context <*> pure pos <*> pure arity <*> resolveBangType field
+    ListCon forallVars context -> do
+      (forallScope, forallVars') <- bindTyVarBinders forallVars
+      extendScope forallScope $
+        ListCon forallVars' <$> mapM resolveType context
   where
     resolveBangType bt = do
       ty' <- resolveType (bangType bt)

--- a/components/aihc-resolve/test/Test/Fixtures/golden/existential-constructor-scope.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/existential-constructor-scope.yaml
@@ -1,0 +1,20 @@
+extensions:
+  - ExistentialQuantification
+modules:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Main where
+    class Markable a
+    data Box = forall a. Markable a => Box a
+annotated:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Main where
+    class Markable a
+          └─ t Main
+    data Box = forall a. Markable a => Box a
+         └─ t Main       └─ t Main│    │   └─ t 0
+                                  │    └─ v Main
+                                  └─ t 0
+status: pass
+reason: constructor forall binders scope over the constructor context and fields

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -28,6 +28,7 @@ library
     Aihc.Tc.Generate.Decl
     Aihc.Tc.Generate.Expr
     Aihc.Tc.Generate.Pattern
+    Aihc.Tc.Generate.PatternBranch
     Aihc.Tc.Instantiate
     Aihc.Tc.Kind
     Aihc.Tc.Monad

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Bind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Bind.hs
@@ -33,6 +33,7 @@ import Aihc.Tc.Annotations (pendingAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Generalize (generalizeAndCommitIgnoring)
 import Aihc.Tc.Generate.Pattern
+import Aihc.Tc.Generate.PatternBranch (solvePatternBranch)
 import Aihc.Tc.Instantiate qualified
 import Aihc.Tc.Kind (sigToScheme)
 import Aihc.Tc.Monad
@@ -271,12 +272,14 @@ inferZeroArgMatch inferExpr match = do
 tcMatchEquation :: InferExpr -> [TcType] -> TcType -> Match -> TcM (Match, [Ct])
 tcMatchEquation inferExpr argTys resTy match = do
   let pats = matchPats match
-  patCheck <- checkPatterns NoSourceSpan (zip pats argTys)
+  patCheck <- checkPatternsWithGivens NoSourceSpan (zip pats argTys)
   (rhs', rhsTy, rhsCts) <- withPatternBindings (pcBindings patCheck) (inferRhsWithLocals inferExpr (matchRhs match))
   ev <- freshEvVar
   let pats' = map (annotatePatternBindings (pcBindings patCheck)) (pcPatterns patCheck)
       resCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin NoSourceSpan) NoSourceSpan
-  pure (match {matchPats = pats', matchRhs = rhs'}, pcWantedCts patCheck ++ rhsCts ++ [resCt])
+      bodyWanteds = rhsCts ++ [resCt]
+  remainingCts <- solvePatternBranch NoSourceSpan patCheck resTy bodyWanteds
+  pure (match {matchPats = pats', matchRhs = rhs'}, remainingCts)
 
 unifyMatchRhs :: InferExpr -> TcType -> Match -> TcM (Match, [Ct])
 unifyMatchRhs inferExpr expectedTy match = do

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -88,7 +88,7 @@ import Aihc.Tc.Solve.Dict (solveDictWithGivens)
 import Aihc.Tc.Solve.InertSet (InertSet (..))
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds, defaultTypeSchemeKinds, zonkType)
-import Control.Monad (foldM, forM_, when, zipWithM)
+import Control.Monad (foldM, forM_, unless, when, zipWithM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
 import Data.Graph (SCC (..), stronglyConnComp)
@@ -512,7 +512,7 @@ dataConBindingType :: Text -> TcM TcType
 dataConBindingType name = do
   mBinder <- lookupTerm name
   case mBinder of
-    Just (TcIdBinder (ForAll _ _ body) _) -> zonkType body
+    Just (TcIdBinder scheme _) -> zonkType (schemeToType scheme)
     Just (TcMonoIdBinder ty) -> zonkType ty
     Nothing -> missingTypeInfo ("data constructor " <> T.unpack name)
 
@@ -1232,6 +1232,7 @@ tcFunctionWithSig displayName name sig matches = do
           allCts = concat ctsList
           allImpls = concat implsList
       solveBodyConstraintsWithGivens sigPreds allCts allImpls
+      rejectEscapingExistentials sigTy allImpls
       pure _matches'
   if failed
     then pure (Nothing, [])
@@ -1250,6 +1251,7 @@ tcFunctionInfer displayName name matches = do
       extendTermEnvPermanent name (TcMonoIdBinder placeholderTy)
       (matches', ty, cts', impls') <- tcMatches matches
       solveResult <- solveWithImpls cts' impls'
+      rejectEscapingExistentials ty impls'
       residualPreds <- generalizableResidualPreds solveResult
       pure (matches', ty, residualPreds)
   if failed
@@ -1286,6 +1288,37 @@ generalizableResidualPreds solveResult = do
 predicateCanGeneralize :: Pred -> Bool
 predicateCanGeneralize =
   not . null . predMetaVars
+
+rejectEscapingExistentials :: TcType -> [Implication] -> TcM ()
+rejectEscapingExistentials outerType implications = do
+  zonkedOuterType <- zonkType outerType
+  let skolems = concatMap implSkols implications
+      escaping = filter (`typeMentionsTyVar` zonkedOuterType) skolems
+  unless (null escaping) $
+    emitError
+      NoSourceSpan
+      ( OtherError
+          ( "existential type variable escapes its pattern-match branch: "
+              <> T.unpack (T.intercalate ", " (map tvName escaping))
+          )
+      )
+
+typeMentionsTyVar :: TyVarId -> TcType -> Bool
+typeMentionsTyVar target ty =
+  case ty of
+    TcTyVar tyVar -> tyVar == target
+    TcMetaTv {} -> False
+    TcTyCon _ arguments -> any (typeMentionsTyVar target) arguments
+    TcFunTy argument result -> typeMentionsTyVar target argument || typeMentionsTyVar target result
+    TcForAllTy tyVar body -> tyVar /= target && typeMentionsTyVar target body
+    TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
+    TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+
+predicateMentionsTyVar :: TyVarId -> Pred -> Bool
+predicateMentionsTyVar target predicate =
+  case predicate of
+    ClassPred _ arguments -> any (typeMentionsTyVar target) arguments
+    EqPred left right -> typeMentionsTyVar target left || typeMentionsTyVar target right
 
 zonkPred :: Pred -> TcM Pred
 zonkPred pred' =
@@ -1469,18 +1502,18 @@ dataDeclTyCon name arity kind = mkTyCon name arity kind
 registerDataCon :: TyCon -> [ParamInfo] -> DataConDecl -> TcM TcBindingResult
 registerDataCon tc paramInfos con = case con of
   DataConAnn _ inner -> registerDataCon tc paramInfos inner
-  PrefixCon _docs _ctx conName args ->
-    mapM (fieldTypeTc . bangType) args >>= registerNamedDataCon (unqualifiedNameText conName)
-  InfixCon _docs _ctx lhs conName rhs ->
-    mapM (fieldTypeTc . bangType) [lhs, rhs] >>= registerNamedDataCon (unqualifiedNameText conName)
-  RecordCon _docs _ctx conName fields ->
-    mapM (fieldTypeTc . bangType . fieldType) fields >>= registerNamedDataCon (unqualifiedNameText conName)
-  TupleCon _docs _ctx flavor fields ->
-    mapM (fieldTypeTc . bangType) fields >>= registerNamedDataCon (tupleConText flavor (length fields))
-  UnboxedSumCon _docs _ctx pos arity field ->
-    fieldTypeTc (bangType field) >>= \fieldTy -> registerNamedDataCon (unboxedSumConText pos arity) [fieldTy]
-  ListCon {} ->
-    registerNamedDataCon "[]" []
+  PrefixCon forallVars context conName args ->
+    registerH98DataCon forallVars context (unqualifiedNameText conName) (map bangType args)
+  InfixCon forallVars context lhs conName rhs ->
+    registerH98DataCon forallVars context (unqualifiedNameText conName) (map bangType [lhs, rhs])
+  RecordCon forallVars context conName fields ->
+    registerH98DataCon forallVars context (unqualifiedNameText conName) (map (bangType . fieldType) fields)
+  TupleCon forallVars context flavor fields ->
+    registerH98DataCon forallVars context (tupleConText flavor (length fields)) (map bangType fields)
+  UnboxedSumCon forallVars context pos arity field ->
+    registerH98DataCon forallVars context (unboxedSumConText pos arity) [bangType field]
+  ListCon forallVars context ->
+    registerH98DataCon forallVars context "[]" []
   GadtCon _forallBinders _ctx names body ->
     do
       let resultSurfTy = gadtBodyResultType body
@@ -1510,15 +1543,21 @@ registerDataCon tc paramInfos con = case con of
         ]
     paramVarIds = map paramTyVar paramInfos
     resTy = TcTyCon tc (map TcTyVar paramVarIds)
-    conScheme argTys = ForAll paramVarIds [] (foldr TcFunTy resTy argTys)
-
-    fieldTypeTc = checkRuntimeType paramEnv
-
-    registerNamedDataCon name argTys = do
+    registerH98DataCon forallVars context name fieldTypes = do
+      constructorParams <- makeParamEnv forallVars
+      let constructorEnv =
+            Map.fromList
+              [ (paramName param, (paramTyVar param, paramKind param))
+              | param <- constructorParams
+              ]
+              <> paramEnv
+          constructorTyVars = map paramTyVar constructorParams
+      argTys <- mapM (checkRuntimeType constructorEnv) fieldTypes
+      predicates <- mapM (surfacePredToPred constructorEnv) context
       let conTy = foldr TcFunTy resTy argTys
-          scheme = conScheme argTys
+          scheme = ForAll (paramVarIds <> constructorTyVars) predicates conTy
       extendTermEnvPermanent name (TcIdBinder scheme Closed)
-      zonkedTy <- zonkType conTy
+      zonkedTy <- zonkType (schemeToType scheme)
       pure (TcBindingResult name name zonkedTy)
 
 tupleConText :: TupleFlavor -> Int -> Text
@@ -1707,15 +1746,15 @@ tcMatchEquation expectedOrigin argTys resTy match = do
   let pats' = map (annotatePatternBindings (pcBindings patCheck)) (pcPatterns patCheck)
       givenCts = pcGivenCts patCheck
       bodyWanteds = pcWantedCts patCheck ++ rhsCts ++ [resCt]
-  if null givenCts
-    then -- No GADT givens: emit everything as flat wanteds.
+  if null givenCts && null (pcSkolems patCheck)
+    then -- No constructor-local type variables or givens: keep flat wanteds.
       pure (match {matchPats = pats', matchRhs = rhs'}, bodyWanteds, [])
     else do
       -- GADT givens: wrap body wanteds in an implication.
       level <- getTcLevel
       let impl =
             Implication
-              { implSkols = [],
+              { implSkols = pcSkolems patCheck,
                 implGivenEvs = map ctEvVar givenCts,
                 implGivenCts = givenCts,
                 implWantedCts = bodyWanteds,

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -36,6 +36,7 @@ import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Generate.Bind (inferLocalDecls, inferRhsWithLocals)
 import Aihc.Tc.Generate.Pattern
+import Aihc.Tc.Generate.PatternBranch (solvePatternBranch)
 import Aihc.Tc.Instantiate (Instantiation (..), instantiateWithArgs)
 import Aihc.Tc.Kind (checkSurfaceType)
 import Aihc.Tc.Monad
@@ -270,9 +271,10 @@ inferLambda sp pats body = do
   argTys <- mapM (const freshMetaTv) pats
   patCheck <- checkPatterns sp (zip pats argTys)
   (body', bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferExpr body)
+  remainingCts <- solvePatternBranch sp patCheck bodyTy bodyCts
   let funTy = foldr TcFunTy bodyTy argTys
       pats' = map (annotatePatternBindings (pcBindings patCheck)) (pcPatterns patCheck)
-  pure (ELambdaPats pats' body', funTy, pcWantedCts patCheck ++ bodyCts)
+  pure (ELambdaPats pats' body', funTy, remainingCts)
 
 inferLambdaCase :: SourceSpan -> [CaseAlt Expr] -> TcM (Expr, TcType, [Ct])
 inferLambdaCase sp alts = do
@@ -300,42 +302,18 @@ inferLambdaCases sp alts = do
 
 inferCaseAlts :: SourceSpan -> TcType -> TcType -> [CaseAlt Expr] -> TcM ([CaseAlt Expr], [Ct])
 inferCaseAlts _sp _scrutTy _resTy [] = pure ([], [])
-inferCaseAlts sp scrutTy resTy (firstAlt : restAlts) = do
-  (firstAlt', firstBranchSp, firstRhsSp, firstRhsTy, firstCts) <- inferAlt firstAlt
-  resultEv <- freshEvVar
-  let resultCt =
-        mkWantedEqCt
-          TypeTrace
-            { typeTraceType = firstRhsTy,
-              typeTraceRole = ActualType,
-              typeTraceOrigin = ExpressionTypeOrigin firstRhsSp
-            }
-          TypeTrace
-            { typeTraceType = resTy,
-              typeTraceRole = ExpectedType,
-              typeTraceOrigin = ConstraintTypeOrigin (CaseBranchOrigin firstBranchSp)
-            }
-          resultEv
-          (CaseBranchOrigin firstRhsSp)
-          firstRhsSp
-  restResults <- mapM (inferAltAgainst firstBranchSp firstRhsTy) restAlts
-  let restAlts' = map fst restResults
-      restCts = concatMap snd restResults
-  pure (firstAlt' : restAlts', firstCts ++ [resultCt] ++ restCts)
+inferCaseAlts sp scrutTy resTy alternatives = do
+  results <- mapM inferAlt alternatives
+  pure (map fst results, concatMap snd results)
   where
     inferAlt (CaseAlt altAnns pat rhs) = do
       let altSp = sourceSpanFromAnns altAnns
           branchSp = combineSourceSpan altSp sp
       patCheck <- checkPattern branchSp pat scrutTy
       (rhs', rhsTy, rhsCts) <- withPatternBindings (pcBindings patCheck) (inferRhs rhs)
+      resultEv <- freshEvVar
       let rhsSp = rhsExprSpan rhs `orSourceSpan` branchSp
-          pat' = annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)
-      pure (CaseAlt altAnns pat' rhs', branchSp, rhsSp, rhsTy, pcWantedCts patCheck ++ rhsCts)
-
-    inferAltAgainst expectedBranchSp expectedTy alt = do
-      (alt', branchSp, rhsSp, rhsTy, cts) <- inferAlt alt
-      ev <- freshEvVar
-      let rhsCt =
+          resultCt =
             mkWantedEqCt
               TypeTrace
                 { typeTraceType = rhsTy,
@@ -343,14 +321,16 @@ inferCaseAlts sp scrutTy resTy (firstAlt : restAlts) = do
                   typeTraceOrigin = ExpressionTypeOrigin rhsSp
                 }
               TypeTrace
-                { typeTraceType = expectedTy,
+                { typeTraceType = resTy,
                   typeTraceRole = ExpectedType,
-                  typeTraceOrigin = ConstraintTypeOrigin (CaseBranchOrigin expectedBranchSp)
+                  typeTraceOrigin = ConstraintTypeOrigin (CaseBranchOrigin branchSp)
                 }
-              ev
-              (CaseBranchOrigin branchSp)
+              resultEv
+              (CaseBranchOrigin rhsSp)
               rhsSp
-      pure (alt', cts ++ [rhsCt])
+          pat' = annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)
+      remainingCts <- solvePatternBranch branchSp patCheck resTy (rhsCts <> [resultCt])
+      pure (CaseAlt altAnns pat' rhs', remainingCts)
 
 inferLambdaCaseAlt :: SourceSpan -> [TcType] -> TcType -> LambdaCaseAlt -> TcM (LambdaCaseAlt, [Ct])
 inferLambdaCaseAlt sp argTys resTy alt = do
@@ -361,7 +341,8 @@ inferLambdaCaseAlt sp argTys resTy alt = do
   ev <- freshEvVar
   let pats' = map (annotatePatternBindings (pcBindings patCheck)) (pcPatterns patCheck)
       rhsCt = mkWantedCt (EqPred rhsTy resTy) ev (AppOrigin sp) sp
-  pure (alt {lambdaCaseAltPats = pats', lambdaCaseAltRhs = rhs'}, pcWantedCts patCheck ++ rhsCts ++ [rhsCt])
+  remainingCts <- solvePatternBranch sp patCheck resTy (rhsCts <> [rhsCt])
+  pure (alt {lambdaCaseAltPats = pats', lambdaCaseAltRhs = rhs'}, remainingCts)
 
 sourceSpanFromAnns :: [Annotation] -> SourceSpan
 sourceSpanFromAnns anns =
@@ -551,7 +532,8 @@ inferListComp sp body quals = do
           let srcSp = exprSpan src `orSourceSpan` ambient
               srcListCt = mkWantedCt (EqPred srcTy (listType elemTy)) ev (AppOrigin srcSp) srcSp
           (rest', body', bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferCompQuals ambient rest action)
-          pure (CompGen (annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)) src' : rest', body', bodyTy, srcCts ++ pcWantedCts patCheck ++ [srcListCt] ++ bodyCts)
+          remainingCts <- solvePatternBranch ambient patCheck bodyTy bodyCts
+          pure (CompGen (annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)) src' : rest', body', bodyTy, srcCts ++ [srcListCt] ++ remainingCts)
         CompGuard guard -> do
           (guard', guardTy, guardCts) <- inferExpr guard
           ev <- freshEvVar
@@ -637,10 +619,11 @@ inferDoStmt ambient stmt rest =
       resultEq <- wantedDoEq ambient resultTy (TcAppTy monadTy resultItemTy)
       monadCt <- wantedMonad ambient monadTy
       let pat' = annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)
+      remainingCts <- solvePatternBranch ambient patCheck resultTy restCts
       pure
         ( DoBind pat' action' : rest',
           resultTy,
-          actionCts <> pcWantedCts patCheck <> restCts <> [actionEq, resultEq, monadCt]
+          actionCts <> remainingCts <> [actionEq, resultEq, monadCt]
         )
     DoExpr action -> do
       monadTy <- freshMetaTv
@@ -679,7 +662,8 @@ inferResolvedDoStmt ambient resolutionAnn resolution stmt rest =
       (pending, methodCts) <- inferDoBindMethod ambient resolution actionTy itemTy resultTy
       let pat' = annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)
           stmt' = DoAnn (mkAnnotation pending) (DoAnn resolutionAnn (DoBind pat' action'))
-      pure (stmt' : rest', resultTy, actionCts <> pcWantedCts patCheck <> restCts <> methodCts)
+      remainingCts <- solvePatternBranch ambient patCheck resultTy restCts
+      pure (stmt' : rest', resultTy, actionCts <> remainingCts <> methodCts)
     DoExpr action -> do
       itemTy <- freshMetaTv
       (action', actionTy, actionCts) <- inferExprAt ambient action

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -31,10 +31,13 @@ import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
 import Aihc.Tc.Annotations (PendingTcAnnotation, pendingAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
-import Aihc.Tc.Instantiate (Instantiation (..), instantiate, instantiateWithArgs)
+import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Instantiate (Instantiation (..), applySubst, instantiateWithArgs)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -42,6 +45,7 @@ data PatternCheck = PatternCheck
   { pcBindings :: ![(UnqualifiedName, TcType)],
     pcWantedCts :: ![Ct],
     pcGivenCts :: ![Ct],
+    pcSkolems :: ![TyVarId],
     pcPatterns :: ![Pattern]
   }
   deriving (Show)
@@ -52,11 +56,12 @@ instance Semigroup PatternCheck where
       { pcBindings = pcBindings left <> pcBindings right,
         pcWantedCts = pcWantedCts left <> pcWantedCts right,
         pcGivenCts = pcGivenCts left <> pcGivenCts right,
+        pcSkolems = pcSkolems left <> pcSkolems right,
         pcPatterns = pcPatterns left <> pcPatterns right
       }
 
 instance Monoid PatternCheck where
-  mempty = PatternCheck [] [] [] []
+  mempty = PatternCheck [] [] [] [] []
 
 data GadtHandling
   = GadtAsWanted
@@ -178,6 +183,7 @@ checkOverloadedIntegerPattern sp pat isNegative scrutTy = do
       { pcBindings = [],
         pcWantedCts = fromIntegerCts <> negateCts <> eqCts,
         pcGivenCts = [],
+        pcSkolems = [],
         pcPatterns = [pat']
       }
 
@@ -314,20 +320,97 @@ checkConPattern gadtHandling sp originalPat conSyntax subPats scrutTy = do
   mBinder <- lookupResolvedTerm conName target
   case mBinder of
     Just (TcIdBinder scheme _) -> do
-      (conTy, _preds) <- instantiate scheme
+      (conTy, typeArgs, predicates, skolems) <- instantiateConstructorPattern scheme
       (argTys, conResTy) <- splitConTy (length subPats) conTy
       scrutCt <- constructorScrutineeCt gadtHandling sp conName scrutTy conResTy
       subCheck <- checkPatternsWith gadtHandling sp (zip subPats argTys)
+      predicateGivens <- mapM (constructorGiven sp conName) predicates
+      let rebuiltPattern = replaceConstructorSubpatterns originalPat (pcPatterns subCheck)
+          annotatedPattern
+            | null predicateGivens && null skolems = rebuiltPattern
+            | otherwise =
+                PAnn
+                  (mkAnnotation (pendingAnnotation conTy typeArgs (map ctEvVar predicateGivens) []))
+                  rebuiltPattern
       pure
         subCheck
           { pcWantedCts = fst scrutCt <> pcWantedCts subCheck,
-            pcGivenCts = snd scrutCt <> pcGivenCts subCheck,
-            pcPatterns = [replaceConstructorSubpatterns originalPat (pcPatterns subCheck)]
+            pcGivenCts = predicateGivens <> snd scrutCt <> pcGivenCts subCheck,
+            pcSkolems = skolems <> pcSkolems subCheck,
+            pcPatterns = [annotatedPattern]
           }
     Just other ->
       abortTc ("resolved constructor is not an identifier binder: " <> show conName <> " resolved as " <> show target <> " with binder " <> show other)
     Nothing ->
       abortTc ("resolved constructor missing from type environment: " <> show conName <> " resolved as " <> show target)
+
+constructorGiven :: SourceSpan -> Text -> Pred -> TcM Ct
+constructorGiven sp constructorName predicate = do
+  evidence <- freshEvVar
+  bindEvidence evidence (EvGiven predicate)
+  let origin = OccurrenceOf constructorName
+  pure
+    Ct
+      { ctPred = predicate,
+        ctFlavor = Given,
+        ctEvVar = evidence,
+        ctOrigin = origin,
+        ctProvenance = FromCtOrigin origin,
+        ctLoc = sp
+      }
+
+instantiateConstructorPattern :: TypeScheme -> TcM (TcType, [TcType], [Pred], [TyVarId])
+instantiateConstructorPattern (ForAll tyVars predicates body) = do
+  let resultTyVars = constructorResultTyVars body
+      isUniversal tyVar = tvUnique tyVar `Set.member` resultTyVars
+  substitutions <- mapM (instantiateTyVar isUniversal) tyVars
+  let substitution = Map.fromList [(tvUnique tyVar, ty) | (tyVar, ty, _) <- substitutions]
+      instantiateType = applySubst substitution
+      typeArgs = map (instantiateType . TcTyVar) tyVars
+      skolems = [skolem | (_, _, Just skolem) <- substitutions]
+  pure
+    ( instantiateType body,
+      typeArgs,
+      map (instantiatePred substitution) predicates,
+      skolems
+    )
+  where
+    instantiateTyVar isUniversal tyVar
+      | isUniversal tyVar = do
+          meta <- freshMetaTv
+          pure (tyVar, meta, Nothing)
+      | otherwise = do
+          skolem <- setTyVarKind (tvKind tyVar) <$> freshSkolemTv (tvName tyVar)
+          pure (tyVar, TcTyVar skolem, Just skolem)
+
+constructorResultTyVars :: TcType -> Set.Set Unique
+constructorResultTyVars = typeTyVars . dropConstructorArguments
+  where
+    dropConstructorArguments (TcFunTy _ result) = dropConstructorArguments result
+    dropConstructorArguments result = result
+
+typeTyVars :: TcType -> Set.Set Unique
+typeTyVars ty =
+  case ty of
+    TcTyVar tyVar -> Set.singleton (tvUnique tyVar)
+    TcMetaTv {} -> Set.empty
+    TcTyCon _ arguments -> Set.unions (map typeTyVars arguments)
+    TcFunTy argument result -> typeTyVars argument <> typeTyVars result
+    TcForAllTy tyVar body -> Set.delete (tvUnique tyVar) (typeTyVars body)
+    TcQualTy predicates body -> Set.unions (typeTyVars body : map predTyVars predicates)
+    TcAppTy function argument -> typeTyVars function <> typeTyVars argument
+
+predTyVars :: Pred -> Set.Set Unique
+predTyVars predicate =
+  case predicate of
+    ClassPred _ arguments -> Set.unions (map typeTyVars arguments)
+    EqPred left right -> typeTyVars left <> typeTyVars right
+
+instantiatePred :: Map.Map Unique TcType -> Pred -> Pred
+instantiatePred substitution predicate =
+  case predicate of
+    ClassPred className arguments -> ClassPred className (map (applySubst substitution) arguments)
+    EqPred left right -> EqPred (applySubst substitution left) (applySubst substitution right)
 
 replaceConstructorSubpatterns :: Pattern -> [Pattern] -> Pattern
 replaceConstructorSubpatterns pat subPats =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/PatternBranch.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/PatternBranch.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Solve constraints that are valid only inside a constructor pattern branch.
+module Aihc.Tc.Generate.PatternBranch
+  ( solvePatternBranch,
+  )
+where
+
+import Aihc.Parser.Syntax (SourceSpan)
+import Aihc.Tc.Constraint
+import Aihc.Tc.Error (TcErrorKind (..))
+import Aihc.Tc.Generate.Pattern (PatternCheck (..))
+import Aihc.Tc.Monad
+import Aihc.Tc.Solve (solveWithImpls)
+import Aihc.Tc.Types
+import Aihc.Tc.Zonk (zonkType)
+import Control.Monad (unless)
+import Data.Text qualified as T
+
+solvePatternBranch :: SourceSpan -> PatternCheck -> TcType -> [Ct] -> TcM [Ct]
+solvePatternBranch sourceSpan patternCheck branchResultType bodyWanteds
+  | null (pcGivenCts patternCheck) && null (pcSkolems patternCheck) =
+      pure (pcWantedCts patternCheck <> bodyWanteds)
+  | otherwise = do
+      level <- getTcLevel
+      let givens = pcGivenCts patternCheck
+          implication =
+            Implication
+              { implSkols = pcSkolems patternCheck,
+                implGivenEvs = map ctEvVar givens,
+                implGivenCts = givens,
+                implWantedCts = pcWantedCts patternCheck <> bodyWanteds,
+                implTcLevel = level,
+                implInfo = CaseBranchOrigin sourceSpan
+              }
+      _ <- solveWithImpls [] [implication]
+      rejectEscapingPatternType sourceSpan (pcSkolems patternCheck) branchResultType
+      pure []
+
+rejectEscapingPatternType :: SourceSpan -> [TyVarId] -> TcType -> TcM ()
+rejectEscapingPatternType sourceSpan skolems outerType = do
+  zonkedOuterType <- zonkType outerType
+  let escaping = filter (`typeMentionsTyVar` zonkedOuterType) skolems
+  unless (null escaping) $
+    emitError
+      sourceSpan
+      ( OtherError
+          ( "existential type variable escapes its pattern-match branch: "
+              <> T.unpack (T.intercalate ", " (map tvName escaping))
+          )
+      )
+
+typeMentionsTyVar :: TyVarId -> TcType -> Bool
+typeMentionsTyVar target ty =
+  case ty of
+    TcTyVar tyVar -> tyVar == target
+    TcMetaTv {} -> False
+    TcTyCon _ arguments -> any (typeMentionsTyVar target) arguments
+    TcFunTy argument result -> typeMentionsTyVar target argument || typeMentionsTyVar target result
+    TcForAllTy tyVar body -> tyVar /= target && typeMentionsTyVar target body
+    TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
+    TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+
+predicateMentionsTyVar :: TyVarId -> Pred -> Bool
+predicateMentionsTyVar target predicate =
+  case predicate of
+    ClassPred _ arguments -> any (typeMentionsTyVar target) arguments
+    EqPred left right -> typeMentionsTyVar target left || typeMentionsTyVar target right

--- a/components/aihc-tc/src/Aihc/Tc/Solve.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve.hs
@@ -23,7 +23,7 @@ import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve.Canonicalize
-import Aihc.Tc.Solve.Dict (DictResult (..), solveDict)
+import Aihc.Tc.Solve.Dict (DictResult (..), solveDict, solveDictWithGivens)
 import Aihc.Tc.Solve.Equality (EqResult (..), solveEquality)
 import Aihc.Tc.Solve.InertSet (InertSet, addInertDict, emptyInertSet)
 import Aihc.Tc.Solve.Worklist
@@ -116,10 +116,22 @@ solveImplication :: Implication -> TcM ()
 solveImplication impl = withTcLevel $ do
   let rawGivens = implGivenCts impl
       wanteds = implWantedCts impl
+      givenPredicates = map ctPred rawGivens
   -- Canonicalize the given equalities by structural decomposition.
   givenEqs <- concat <$> mapM canonicalizeGiven rawGivens
-  -- Solve each wanted using the given equalities as rewrite rules.
-  mapM_ (solveWantedWithGivens givenEqs) wanteds
+  -- Equalities refine the types mentioned by dictionary wanteds, so preserve
+  -- the main worklist's equality-before-dictionary ordering inside branches.
+  let (equalityWanteds, dictionaryWanteds) = partitionWanteds wanteds
+  mapM_ (solveWantedWithGivens givenPredicates givenEqs) equalityWanteds
+  mapM_ (solveWantedWithGivens givenPredicates givenEqs) dictionaryWanteds
+
+partitionWanteds :: [Ct] -> ([Ct], [Ct])
+partitionWanteds = foldr partitionOne ([], [])
+  where
+    partitionOne ct (equalities, dictionaries) =
+      case ctPred ct of
+        EqPred {} -> (ct : equalities, dictionaries)
+        ClassPred {} -> (equalities, ct : dictionaries)
 
 -- | Decompose a given constraint into atomic equalities.
 -- For example, @GADT a ~ GADT Bool@ decomposes into @[(a, Bool)]@.
@@ -159,13 +171,13 @@ applyGivenSubst givens ty = foldr applyOne ty givens
 -- | Attempt to solve a wanted constraint using given equalities.
 -- Rewrites both sides of the wanted using the given substitution and
 -- then tries to solve the resulting equality.
-solveWantedWithGivens :: [(TcType, TcType)] -> Ct -> TcM ()
-solveWantedWithGivens givens ct = case ctPred ct of
+solveWantedWithGivens :: [Pred] -> [(TcType, TcType)] -> Ct -> TcM ()
+solveWantedWithGivens givenPredicates givenEqualities ct = case ctPred ct of
   EqPred t1 t2 -> do
     t1' <- zonkType t1
     t2' <- zonkType t2
-    let t1'' = applyGivenSubst givens t1'
-        t2'' = applyGivenSubst givens t2'
+    let t1'' = applyGivenSubst givenEqualities t1'
+        t2'' = applyGivenSubst givenEqualities t2'
     result <- solveEquality (ct {ctPred = EqPred t1'' t2''})
     case result of
       EqSolved -> pure ()
@@ -176,7 +188,20 @@ solveWantedWithGivens givens ct = case ctPred ct of
             emitError (ctLoc errCt) . UnificationError et1 et2 (ctOrigin errCt) =<< zonkCtEqProvenance errCt
           p ->
             emitError (ctLoc errCt) (UnsolvedWanted p (ctOrigin errCt))
-  _ -> pure ()
+  ClassPred className arguments -> do
+    arguments' <- mapM zonkType arguments
+    let rewritten = ClassPred className (map (applyGivenSubst givenEqualities) arguments')
+        rewrittenGivens = map (rewritePred givenEqualities) givenPredicates
+    result <- solveDictWithGivens rewrittenGivens (ct {ctPred = rewritten})
+    case result of
+      DictSolved -> pure ()
+      DictStuck stuck -> emitError (ctLoc stuck) (UnsolvedWanted (ctPred stuck) (ctOrigin stuck))
+
+rewritePred :: [(TcType, TcType)] -> Pred -> Pred
+rewritePred equalities predicate =
+  case predicate of
+    ClassPred className arguments -> ClassPred className (map (applyGivenSubst equalities) arguments)
+    EqPred left right -> EqPred (applyGivenSubst equalities left) (applyGivenSubst equalities right)
 
 zonkCtEqProvenance :: Ct -> TcM (Maybe EqProvenance)
 zonkCtEqProvenance ct =

--- a/components/aihc-tc/test/Test/Fixtures/annotated/constrained-existential-constructor.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/constrained-existential-constructor.yaml
@@ -1,0 +1,33 @@
+extensions:
+  - ExistentialQuantification
+modules:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Test where
+    data Mark = Marked
+    class Markable a where
+      mark :: a -> Mark
+    data Box = forall a. Markable a => Box a
+    inspect :: Box -> Mark
+    inspect (Box value) = mark value
+annotated:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Test where
+    data Mark = Marked
+         │      └─ type: Mark
+         └─ type: *
+    class Markable a where
+    └─ class methods: mark ∷ ∀ a. (Markable a) ⇒ a → Mark
+      mark :: a -> Mark
+    data Box = forall a. Markable a => Box a
+         │     └─ type: ∀ a. (Markable a) ⇒ a → Box
+         └─ type: *
+    inspect :: Box -> Mark
+    inspect (Box value) = mark value
+    │        │   │        └─ type: a → Mark; type-args: a; evidence: given Markable a
+    │        │   └─ type: a
+    │        └─ type: a → Box; type-args: a; evidence: given Markable a
+    └─ type: Box → Mark
+status: pass
+reason: constrained constructors quantify existential fields and provide their dictionaries while matching

--- a/components/aihc-tc/test/Test/Fixtures/annotated/parenthesized-type-application-field.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/parenthesized-type-application-field.yaml
@@ -5,10 +5,10 @@ annotated:
        │     └─ type: Int
        └─ type: *
   data Foo a = Foo
-       │       └─ type: Foo a
+       │       └─ type: ∀ a. Foo a
        └─ type: * → *
   data Chan a = Chan (Foo Int)
-       │        └─ type: Foo Int → Chan a
+       │        └─ type: ∀ a. Foo Int → Chan a
        └─ type: * → *
 extensions: []
 modules:

--- a/components/aihc-tc/test/Test/Fixtures/annotated/prelude-list-core-lib.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/prelude-list-core-lib.yaml
@@ -2,8 +2,8 @@ annotated:
 - |-
   module Test where
   data List a = [] | a : [a]
-       │        │    └─ type: a → [a] → [a]
-       │        └─ type: [a]
+       │        │    └─ type: ∀ a. a → [a] → [a]
+       │        └─ type: ∀ a. [a]
        └─ type: * → *
   infixr 5 :
   (++) :: [a] -> [a] -> [a]

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -253,12 +253,14 @@ kindTests =
           constructorTypes = [tbType binding | binding <- tcModuleBindings result, tbName binding == "R"]
       assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
       case constructorTypes of
-        [TcTyCon _ [TcTyVar repVar, TcTyVar valueVar]] -> do
+        [TcForAllTy repVar (TcForAllTy valueVar (TcTyCon _ [TcTyVar resultRepVar, TcTyVar resultValueVar]))] -> do
           assertEqual "representation binder kind" KRuntimeRep (tvKind repVar)
           assertEqual
             "value binder kind"
             (KTYPE (RuntimeRepVar (tvUnique repVar)))
             (tvKind valueVar)
+          assertEqual "result representation argument" repVar resultRepVar
+          assertEqual "result value argument" valueVar resultValueVar
         other -> assertFailure ("unexpected R constructor types: " <> show other),
     testCase "rejects unsaturated type constructor in signature" $ do
       let result =

--- a/examples/constrained-existential/Main.hs
+++ b/examples/constrained-existential/Main.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE MagicHash #-}
+
+module Main where
+
+import GHC.Ptr (Ptr (..))
+import System.IO (hPutBuf, stdout)
+
+data Mark = Marked | Unmarked
+
+data Payload = Payload
+
+data Tag = Tag
+
+class Markable a where
+  mark :: a -> Mark
+
+instance Markable Payload where
+  mark Payload = Marked
+
+data Box tag = forall value. (Markable value) => Box tag value
+
+boxed :: Box Tag
+boxed = Box Tag Payload
+
+inspect :: Box tag -> Mark
+inspect box =
+  case box of
+    Box _ value -> mark value
+
+main :: IO ()
+main =
+  case inspect boxed of
+    Marked -> hPutBuf stdout (Ptr "existential dictionary\n"# :: Ptr ()) 23
+    Unmarked -> hPutBuf stdout (Ptr "missing dictionary\n"# :: Ptr ()) 19

--- a/examples/constrained-existential/stdout
+++ b/examples/constrained-existential/stdout
@@ -1,0 +1,1 @@
+existential dictionary

--- a/test/Test/Fixtures/eval/constrained-existential-constructor.yaml
+++ b/test/Test/Fixtures/eval/constrained-existential-constructor.yaml
@@ -1,0 +1,45 @@
+extensions:
+  - ExistentialQuantification
+dependencies: []
+modules:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Test where
+
+    data Mark = Marked | Unmarked
+    data Payload = Payload
+    data Tag = Tag
+
+    class Markable a where
+      mark :: a -> Mark
+
+    instance Markable Payload where
+      mark Payload = Marked
+
+    data Box tag = forall a. Markable a => Box tag a
+
+    boxed :: Box Tag
+    boxed = Box Tag Payload
+
+    inspect :: Box tag -> Mark
+    inspect (Box _ value) = mark value
+
+    inspectCase :: Box tag -> Mark
+    inspectCase box =
+      case box of
+        Box _ value -> mark value
+
+    inspectLambda :: Box tag -> Mark
+    inspectLambda box = (\(Box _ value) -> mark value) box
+
+    inspectLocal :: Box tag -> Mark
+    inspectLocal box =
+      let
+        unpack (Box _ value) = mark value
+      in unpack box
+output: |
+  Marked
+expression: |
+  inspectLocal boxed
+status: pass
+reason: existential constructors store class dictionaries and recover them while matching

--- a/test/Test/Fixtures/eval/existential-type-cannot-escape.yaml
+++ b/test/Test/Fixtures/eval/existential-type-cannot-escape.yaml
@@ -1,0 +1,16 @@
+extensions:
+  - ExistentialQuantification
+dependencies: []
+modules:
+  - |
+    {-# LANGUAGE ExistentialQuantification #-}
+    module Test where
+
+    data Box = forall a. Box a
+
+    escape (Box value) = value
+output: ""
+expression: |
+  escape
+status: fail
+reason: a constructor-local existential type must not escape its pattern-match branch


### PR DESCRIPTION
## Summary

- resolve constructor-local `forall` binders across constructor contexts and fields
- register H98 constructors with their full polymorphic, qualified schemes and reject existential types that escape a match branch
- solve class wanteds from constructor-provided givens in top-level equations, local functions, cases, lambdas, comprehensions, and `do` binds
- lower constructor dictionaries as hidden System FC/GRIN fields and restore them when matching
- preserve polymorphic constructor types through FC, including foreign-marshalling and local polymorphic applications
- add a portable example demonstrating the shape needed by `SomeException`

This makes declarations such as `data SomeException = forall e. Exception e => SomeException e` expressible end-to-end. Defining the `Exception` class and `SomeException` library API remains a follow-up.

## Progress

- Resolver golden coverage: +1 constructor-local type-variable scope fixture
- Type-checker coverage: +1 annotated constrained-existential fixture and +1 dependent-constructor scheme assertion
- System FC coverage: +1 golden dictionary-layout fixture and +1 free-variable ordering assertion
- Shared evaluation coverage: +2 fixtures (successful dictionary recovery and rejected existential escape)
- Portable examples: +1 (`constrained-existential`), exercised by portable C, host ARM64, and WASI
- README progress counts: unchanged (README updates remain automated)

## Validation

- `just fmt`
- `just check`
- `nix build .#checks.aarch64-darwin.examples-tests .#checks.aarch64-darwin.wasip3-example-test --no-link`
- compiled and executed `examples/constrained-existential/Main.hs` with `--target apple-arm64`