### PR TITLE
fix: rename intToChar# primitive to chr#

### DIFF
--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen/Function.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen/Function.hs
@@ -461,7 +461,7 @@ compileDirectBinding env vars expression =
     unaryPrimitives =
       ("not#", ["  not rax"])
         : [ (name, [])
-          | name <- ["int2Word#", "word2Int#", "ord#", "intToChar#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"]
+          | name <- ["int2Word#", "word2Int#", "ord#", "chr#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"]
           ]
     binary instruction names =
       [(name, ["  " <> instruction <> " r10, rax", "  mov rax, r10"]) | name <- names]

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen/Function.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen/Function.hs
@@ -467,7 +467,7 @@ compileDirectBinding env vars expression =
     unaryPrimitives =
       ("not#", ["  mvn x0, x0"])
         : [ (name, [])
-          | name <- ["int2Word#", "word2Int#", "ord#", "intToChar#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"]
+          | name <- ["int2Word#", "word2Int#", "ord#", "chr#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"]
           ]
     binary instruction names =
       [(name, ["  " <> instruction <> " x0, x9, x0"]) | name <- names]

--- a/components/aihc-c/src/Aihc/C/Codegen.hs
+++ b/components/aihc-c/src/Aihc/C/Codegen.hs
@@ -587,7 +587,7 @@ compileDirectBinding env vars expression =
     GrinPrimitiveCall runtimeRep "realWorld#" []
       | null vars && null (runtimeRepComponents runtimeRep) -> pure []
     GrinPrimitiveCall _ name [value]
-      | name `elem` ["ord#", "intToChar#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"] ->
+      | name `elem` ["ord#", "chr#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"] ->
           liftEither (materializeValue env value) >>= storeExpression
     GrinPrimitiveCall _ name arguments
       | Just foreignCall <- nativeRuntimePrimitiveCall name -> do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -532,7 +532,7 @@ primitiveImportSpecs =
       primitive "<#" "Int# -> Int# -> Int#",
       primitive "==#" "Int# -> Int# -> Int#",
       primitive "ord#" "Char# -> Int#",
-      primitive "intToChar#" "Int# -> Char#",
+      primitive "chr#" "Int# -> Char#",
       primitive "plusWord#" "Word# -> Word# -> Word#",
       primitive "minusWord#" "Word# -> Word# -> Word#",
       primitive "timesWord#" "Word# -> Word# -> Word#",

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -270,11 +270,11 @@ evalPrimitive "==#" [left, right] =
 evalPrimitive "ord#" [value] = do
   charValue <- forceCharPrimitiveArg "ord#" value
   pure (VLit (LitInt IntRep (fromIntegral (Char.ord charValue))))
-evalPrimitive "intToChar#" [value] = do
-  intValue <- forceIntPrimitiveArg "intToChar#" value
+evalPrimitive "chr#" [value] = do
+  intValue <- forceIntPrimitiveArg "chr#" value
   if intValue >= 0 && intValue <= 0x10ffff
     then pure (VLit (LitChar WordRep (Char.chr (fromIntegral intValue))))
-    else throwE (EvalPrimitiveTypeError "intToChar#" (VLit (LitInt IntRep intValue)))
+    else throwE (EvalPrimitiveTypeError "chr#" (VLit (LitInt IntRep intValue)))
 evalPrimitive "plusWord#" [left, right] = evalWordPrimitive "plusWord#" (+) left right
 evalPrimitive "minusWord#" [left, right] = evalWordPrimitive "minusWord#" (-) left right
 evalPrimitive "timesWord#" [left, right] = evalWordPrimitive "timesWord#" (*) left right

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -758,11 +758,11 @@ evalPrimitive "==#" [left, right] =
 evalPrimitive "ord#" [value] = do
   charValue <- expectCharPrimitiveArgument "ord#" value
   pure [RuntimeLit (GrinLitInt IntRep (fromIntegral (Char.ord charValue)))]
-evalPrimitive "intToChar#" [value] = do
-  intValue <- expectIntPrimitiveArgument "intToChar#" value
+evalPrimitive "chr#" [value] = do
+  intValue <- expectIntPrimitiveArgument "chr#" value
   if intValue >= 0 && intValue <= 0x10ffff
     then pure [RuntimeLit (GrinLitChar WordRep (Char.chr (fromIntegral intValue)))]
-    else throwInterpret (InterpretPrimitiveTypeError "intToChar#" (RuntimeLit (GrinLitInt IntRep intValue)))
+    else throwInterpret (InterpretPrimitiveTypeError "chr#" (RuntimeLit (GrinLitInt IntRep intValue)))
 evalPrimitive "realWorld#" [] = pure []
 evalPrimitive "raise#" [exception] =
   throwE (EvalRaised exception)

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -188,7 +188,7 @@ supportedNativePrimitiveNames =
     "<#",
     "==#",
     "ord#",
-    "intToChar#",
+    "chr#",
     "addIntC#",
     "subIntC#",
     "plusWord#",

--- a/components/aihc-native/src/Aihc/Native/RegisterAllocate.hs
+++ b/components/aihc-native/src/Aihc/Native/RegisterAllocate.hs
@@ -271,7 +271,7 @@ exprCallsC expression =
     GrinUpdate {} -> True
     GrinUpdateBlackhole {} -> True
     GrinForeignCallExpr {} -> True
-    GrinPrimitiveCall _ name _ -> name `notElem` ["+#", "-#", "*#", "compareInt#", "<#", "==#", "ord#", "intToChar#", "realWorld#"]
+    GrinPrimitiveCall _ name _ -> name `notElem` ["+#", "-#", "*#", "compareInt#", "<#", "==#", "ord#", "chr#", "realWorld#"]
     _ -> False
 
 -- | Some expressions make several C calls while consuming their operands, so

--- a/components/aihc-native/test/Test/Native/Primitive.hs
+++ b/components/aihc-native/test/Test/Native/Primitive.hs
@@ -54,7 +54,7 @@ tests =
       testCase "accepts the Prelude Int# primitive API in native programs" $
         mapM_
           (\primitive -> assertEqual ("native support for " <> show primitive) True (primitive `elem` supportedNativePrimitiveNames))
-          ["+#", "-#", "*#", "compareInt#", "<#", "==#", "ord#", "intToChar#"]
+          ["+#", "-#", "*#", "compareInt#", "<#", "==#", "ord#", "chr#"]
     ]
 
 byteArrayRuntimeSymbols :: [(Text, Text)]

--- a/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
+++ b/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
@@ -572,7 +572,7 @@ compileDirectBinding env vars expression =
     GrinPrimitiveCall runtimeRep "realWorld#" []
       | null vars && null (runtimeRepComponents runtimeRep) -> pure []
     GrinPrimitiveCall _ name [value]
-      | name `elem` ["ord#", "intToChar#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"] -> storeSingle (materializeValue env value)
+      | name `elem` ["ord#", "chr#", "unsafeFreezeByteArray#", "unsafeThawByteArray#"] -> storeSingle (materializeValue env value)
     GrinPrimitiveCall _ name arguments
       | Just foreignCall <- nativeRuntimePrimitiveCall name -> do
           instructions <- compileForeignCall env foreignCall arguments

--- a/core-libs/aihc-base/src/GHC/Char.hs
+++ b/core-libs/aihc-base/src/GHC/Char.hs
@@ -7,11 +7,11 @@ module GHC.Char
 where
 
 import GHC.Int (Int (..))
-import GHC.Prim (intToChar#, ord#)
+import GHC.Prim (chr#, ord#)
 import Prelude (Char (C#))
 
 chr :: Int -> Char
-chr (I# value) = C# (intToChar# value)
+chr (I# value) = C# (chr# value)
 
 ord :: Char -> Int
 ord (C# value) = I# (ord# value)

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -23,7 +23,7 @@ module GHC.Prim
     getSizeofMutableByteArray#,
     indexWordArray#,
     int2Word#,
-    intToChar#,
+    chr#,
     isByteArrayPinned#,
     isMutableByteArrayPinned#,
     MVar#,
@@ -122,7 +122,7 @@ foreign import prim (==#) :: Int# -> Int# -> Int#
 
 foreign import prim ord# :: Char# -> Int#
 
-foreign import prim intToChar# :: Int# -> Char#
+foreign import prim chr# :: Int# -> Char#
 
 foreign import prim addIntC# :: Int# -> Int# -> (# Int#, Int# #)
 

--- a/core-libs/aihc-prim/src/GHC/Prim/Unicode.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim/Unicode.hs
@@ -12,7 +12,7 @@ module GHC.Prim.Unicode
   )
 where
 
-import GHC.Prim (intToChar#, ord#, (+#), (-#), (<#))
+import GHC.Prim (chr#, ord#, (+#), (-#), (<#))
 
 generalCategory# :: Char# -> Int#
 generalCategory# value = generalCategoryCode# (ord# value)
@@ -24,13 +24,13 @@ isLowercase# :: Char# -> Int#
 isLowercase# value = isLowercaseCode# (ord# value)
 
 unicodeToUpper :: Char# -> Char#
-unicodeToUpper value = intToChar# (toUpperCode# (ord# value))
+unicodeToUpper value = chr# (toUpperCode# (ord# value))
 
 unicodeToLower :: Char# -> Char#
-unicodeToLower value = intToChar# (toLowerCode# (ord# value))
+unicodeToLower value = chr# (toLowerCode# (ord# value))
 
 unicodeToTitle :: Char# -> Char#
-unicodeToTitle value = intToChar# (toTitleCode# (ord# value))
+unicodeToTitle value = chr# (toTitleCode# (ord# value))
 
 generalCategoryCode# :: Int# -> Int#
 generalCategoryCode# n =

--- a/scripts/nix/ucd2haskell-aihc/AIHC.hs
+++ b/scripts/nix/ucd2haskell-aihc/AIHC.hs
@@ -147,7 +147,7 @@ renderHeader version =
       "  )",
       "where",
       "",
-      "import GHC.Prim (intToChar#, ord#, (+#), (-#), (<#))",
+      "import GHC.Prim (chr#, ord#, (+#), (-#), (<#))",
       "",
       "generalCategory# :: Char# -> Int#",
       "generalCategory# value = generalCategoryCode# (ord# value)",
@@ -159,13 +159,13 @@ renderHeader version =
       "isLowercase# value = isLowercaseCode# (ord# value)",
       "",
       "unicodeToUpper :: Char# -> Char#",
-      "unicodeToUpper value = intToChar# (toUpperCode# (ord# value))",
+      "unicodeToUpper value = chr# (toUpperCode# (ord# value))",
       "",
       "unicodeToLower :: Char# -> Char#",
-      "unicodeToLower value = intToChar# (toLowerCode# (ord# value))",
+      "unicodeToLower value = chr# (toLowerCode# (ord# value))",
       "",
       "unicodeToTitle :: Char# -> Char#",
-      "unicodeToTitle value = intToChar# (toTitleCode# (ord# value))",
+      "unicodeToTitle value = chr# (toTitleCode# (ord# value))",
       ""
     ]
 

--- a/test/Test/Fixtures/eval/aihc-prim-char-codepoint.yaml
+++ b/test/Test/Fixtures/eval/aihc-prim-char-codepoint.yaml
@@ -7,7 +7,7 @@ modules:
   - |
     module Test where
 
-    import GHC.Prim (intToChar#, ord#)
+    import GHC.Prim (chr#, ord#)
 
     foreign import prim (+#) :: Int# -> Int# -> Int#
 
@@ -21,6 +21,6 @@ modules:
 output: |
   957
 expression: |
-  ord# (intToChar# (ord# '\x03BB'#)) +# boxedMatch '\x03BB' +# unboxedMatch '\x03BB'#
+  ord# (chr# (ord# '\x03BB'#)) +# boxedMatch '\x03BB' +# unboxedMatch '\x03BB'#
 status: pass
 reason: boxed Char uses C# while Unicode character/codepoint primitives and unboxed literals use Char#


### PR DESCRIPTION
## Summary

- rename the AIHC `intToChar#` primitive to GHC's `chr#` spelling
- update the core libraries, Unicode generator, FC/GRIN evaluators, and every native code generator consistently
- update the shared character/codepoint evaluation fixture and native primitive test

## Why

AIHC exposed the integer-to-character primitive under a non-GHC name. Matching GHC's `chr#` spelling makes primitive imports source-compatible and removes a needless naming difference.

## Impact

Code importing this primitive should now use `GHC.Prim.chr#`. The old `intToChar#` name is no longer exposed.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `cabal test -v0 aihc-grin:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`

## Progress counts

No progress-count changes.
