### PR TITLE
feat(cli): install reusable runtime and library artifacts

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -16,6 +16,8 @@ library
     Aihc.Cli.Install
     Aihc.Cli.Options
     Aihc.Cli.Repl
+    Aihc.Cli.Runtime
+    Aihc.Cli.Store
 
   other-modules:
     Aihc.Cli.Compile.Dependencies

--- a/bin/aihc/src/Aihc/Cli.hs
+++ b/bin/aihc/src/Aihc/Cli.hs
@@ -8,6 +8,7 @@ import Aihc.Cli.Compile (runCompile)
 import Aihc.Cli.Install (runInstall)
 import Aihc.Cli.Options (Command (..), ReplOptions (..), parseCommandIO)
 import Aihc.Cli.Repl (runRepl)
+import Aihc.Cli.Runtime (runPrepareRuntime)
 import Control.Exception (IOException, displayException, try)
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
@@ -24,4 +25,5 @@ main = do
 runCommand :: Command -> IO ()
 runCommand (CmdCompile opts) = runCompile opts
 runCommand (CmdInstall opts) = runInstall opts
+runCommand (CmdPrepareRuntime opts) = runPrepareRuntime opts
 runCommand (CmdRepl opts) = runRepl (replStoreRoot opts)

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -33,6 +33,8 @@ import Aihc.Cli.Compile.Dependencies
     buildDependencies,
   )
 import Aihc.Cli.Options (CompileOptions (..), GarbageCollector (..))
+import Aihc.Cli.Runtime (runtimeGarbageCollector, wasmClangCommand, wasmOptArguments)
+import Aihc.Cli.Store (defaultStoreRoot, installedRuntimeArchivePath)
 import Aihc.Fc
   ( DesugarResult (..),
     FcAlt (..),
@@ -53,14 +55,10 @@ import Aihc.Llvm qualified as Llvm
 import Aihc.Native
   ( LinkLayout,
     NativeTarget (..),
-    RuntimeGarbageCollector (..),
-    RuntimePlan (..),
     backendCompiler,
     buildLinkLayoutFromInterfaces,
     extendLinkLayout,
     hostNativeTarget,
-    nativeTargetTriple,
-    runtimePlan,
   )
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
@@ -69,17 +67,17 @@ import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
 import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithClassEnv)
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket)
-import Control.Monad (forM, forM_, when)
+import Control.Monad (forM_, when)
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Text.IO.Utf8 qualified as Utf8
-import System.Directory (XdgDirectory (XdgCache), createDirectory, findExecutable, getCurrentDirectory, getTemporaryDirectory, getXdgDirectory, removeDirectoryRecursive, removeFile)
+import System.Directory (createDirectory, doesFileExist, findExecutable, getTemporaryDirectory, removeDirectoryRecursive, removeFile)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
-import System.FilePath (dropExtension, takeDirectory, (</>))
+import System.FilePath (dropExtension, (</>))
 import System.IO (hClose, openTempFile)
 import System.Process (readProcessWithExitCode)
 
@@ -126,8 +124,8 @@ data IncrementalCompilation = IncrementalCompilation
 
 runCompile :: CompileOptions -> IO ()
 runCompile options = do
-  environment <- defaultCompileEnvironment
-  runCompileWithEnvironment environment options
+  storeRoot <- maybe defaultStoreRoot pure (compileStoreRoot options)
+  runCompileWithEnvironment (CompileEnvironment storeRoot) options
 
 runCompileWithEnvironment :: CompileEnvironment -> CompileOptions -> IO ()
 runCompileWithEnvironment environment options = do
@@ -148,11 +146,11 @@ runCompileWithEnvironment environment options = do
     then do
       let assemblyPath = output <> backendSourceExtension target
       TIO.writeFile assemblyPath (compiledAssembly artifacts)
-      assemble target (compileGarbageCollector options) (compileUseWasmOpt options) output assemblyPath (compiledArchives artifacts)
+      assemble (compileInstalledStoreRoot environment) target (compileGarbageCollector options) (compileUseWasmOpt options) output assemblyPath (compiledArchives artifacts)
     else withTemporaryDirectory "aihc-compile" $ \directory -> do
       let assemblyPath = directory </> "program" <> backendSourceExtension target
       TIO.writeFile assemblyPath (compiledAssembly artifacts)
-      assemble target (compileGarbageCollector options) (compileUseWasmOpt options) output assemblyPath (compiledArchives artifacts)
+      assemble (compileInstalledStoreRoot environment) target (compileGarbageCollector options) (compileUseWasmOpt options) output assemblyPath (compiledArchives artifacts)
 
 writeIntermediateArtifacts :: FilePath -> CompileOptions -> CompileArtifacts -> IO ()
 writeIntermediateArtifacts output options artifacts = do
@@ -163,13 +161,10 @@ writeIntermediateArtifacts output options artifacts = do
     TIO.writeFile (output <> ".cps.grin") (compiledCpsGrin artifacts)
     TIO.writeFile (output <> ".gc.grin") (compiledGcGrin artifacts)
 
--- | The project-local core libraries and shared compiled-library cache used by
--- the command-line compiler.
+-- | The installed runtime and library store used by the command-line
+-- compiler.
 defaultCompileEnvironment :: IO CompileEnvironment
-defaultCompileEnvironment = do
-  cwd <- getCurrentDirectory
-  cacheDirectory <- getXdgDirectory XdgCache "aihc"
-  pure (CompileEnvironment (cwd </> "core-libs") (cacheDirectory </> "libraries"))
+defaultCompileEnvironment = CompileEnvironment <$> defaultStoreRoot
 
 compileOutputPath :: CompileOptions -> FilePath
 compileOutputPath options =
@@ -314,8 +309,10 @@ compileIncrementalArtifacts target dependencies compilation = do
       dependencyLayout = buildLinkLayoutFromInterfaces (dependencyLinkInterfaces dependencies)
       layout = extendLinkLayout dependencyLayout mainGrin
       reachability = dependencyReachabilityInterface dependencies <> extractReachabilityInterface mainCore
-      runtimePrograms = map incrementalUnitGrin (incrementalDependencyUnits compilation) <> [mainGrin]
-      primitives = Set.toAscList (reachableRuntimePrimitiveNames "main" reachability runtimePrograms)
+      declaredPrimitives =
+        dependencyRuntimePrimitiveNames dependencies
+          <> Set.fromList [Grin.grinVarName primitive | (primitive, _) <- Grin.grinPrimitives mainGrin]
+      primitives = Set.toAscList (Set.intersection (reachablePrimitiveNames "main" reachability) declaredPrimitives)
   either (Left . CompileBackendError) Right (validateBackendPrimitiveNames target primitives)
   assembly <-
     either
@@ -517,20 +514,18 @@ renderCompileError compileError =
 defaultCompileTarget :: NativeTarget
 defaultCompileTarget = fromMaybe AppleArm64 hostNativeTarget
 
-assemble :: NativeTarget -> GarbageCollector -> Bool -> FilePath -> FilePath -> [FilePath] -> IO ()
-assemble Wasm32Wasip3 garbageCollector useWasmOpt output assemblyPath archives =
-  assembleWasip3 garbageCollector useWasmOpt output assemblyPath archives
-assemble target garbageCollector _useWasmOpt output assemblyPath archives = do
-  plan <- runtimePlan target (runtimeGarbageCollector garbageCollector)
+assemble :: FilePath -> NativeTarget -> GarbageCollector -> Bool -> FilePath -> FilePath -> [FilePath] -> IO ()
+assemble storeRoot Wasm32Wasip3 garbageCollector useWasmOpt output assemblyPath archives =
+  assembleWasip3 storeRoot garbageCollector useWasmOpt output assemblyPath archives
+assemble storeRoot target garbageCollector _useWasmOpt output assemblyPath archives = do
   (compiler, targetArguments) <- backendCompiler target
+  runtimeArchive <- requireInstalledRuntime storeRoot target garbageCollector
   (exitCode, _stdout, stderr) <-
     readProcessWithExitCode
       compiler
       ( targetArguments
-          <> ["-std=c11", "-Wall", "-Wextra", "-Werror"]
-          <> ["-I" <> directory | directory <- runtimeIncludeDirectories plan]
-          <> runtimeSources plan
           <> [assemblyPath]
+          <> [runtimeArchive]
           <> archives
           <> ["-o", output]
       )
@@ -539,48 +534,18 @@ assemble target garbageCollector _useWasmOpt output assemblyPath archives = do
     ExitSuccess -> pure ()
     ExitFailure _ -> ioError (userError (renderCompileError (CompileClangError exitCode stderr)))
 
-assembleWasip3 :: GarbageCollector -> Bool -> FilePath -> FilePath -> [FilePath] -> IO ()
-assembleWasip3 garbageCollector useWasmOpt output assemblyPath archives = do
-  plan <- runtimePlan Wasm32Wasip3 (runtimeGarbageCollector garbageCollector)
-  wasmRuntimeSources <- Wasm.wasip3RuntimeSourcePaths
-  driver <- Wasm.wasip3RuntimeSourcePath
-  world <- Wasm.wasip3WorldPath
+assembleWasip3 :: FilePath -> GarbageCollector -> Bool -> FilePath -> FilePath -> [FilePath] -> IO ()
+assembleWasip3 storeRoot garbageCollector useWasmOpt output assemblyPath archives = do
   clangOverride <- lookupEnv "AIHC_WASM_CLANG"
   wasmOpt <- if useWasmOpt then findExecutable "wasm-opt" else pure Nothing
   withTemporaryDirectory "aihc-wasip3-link" $ \directory -> do
-    let bindingsSource = directory </> "command.c"
-        bindingsObject = directory </> "bindings.o"
-        componentTypeObject = directory </> "command_component_type.o"
-        programObject = directory </> "program.o"
+    let programObject = directory </> "program.o"
         unoptimizedCoreModule = directory </> "core.unoptimized.wasm"
         coreModule = directory </> "core.wasm"
         linkedCoreModule = maybe coreModule (const unoptimizedCoreModule) wasmOpt
         (clang, clangTargetArguments) = wasmClangCommand clangOverride
-        includeArguments =
-          [ "-I" <> (takeDirectory driver </> "include"),
-            "-I" <> takeDirectory driver,
-            "-I" <> directory
-          ]
-            <> ["-I" <> includeDirectory | includeDirectory <- runtimeIncludeDirectories plan]
-        cArguments =
-          [ "-O2",
-            "-std=c11",
-            "-ffreestanding",
-            "-fno-builtin",
-            "-nostdlib",
-            "-Wall",
-            "-Wextra",
-            "-Werror"
-          ]
-            <> includeArguments
-    runTool "wit-bindgen" ["c", "--world", "command", "--out-dir", directory, world]
     runTool clang (clangTargetArguments <> ["-mtail-call", "-c", assemblyPath, "-o", programObject])
-    runtimeObjects <-
-      forM (zip [0 :: Int ..] (runtimeSources plan <> wasmRuntimeSources)) $ \(index, source) -> do
-        let object = directory </> "runtime-" <> show index <> ".o"
-        runTool clang (clangTargetArguments <> cArguments <> ["-c", source, "-o", object])
-        pure object
-    runTool clang (clangTargetArguments <> cArguments <> ["-c", bindingsSource, "-o", bindingsObject])
+    runtimeArchive <- requireInstalledRuntime storeRoot Wasm32Wasip3 garbageCollector
     runTool
       "wasm-ld"
       ( [ "--no-entry",
@@ -588,8 +553,7 @@ assembleWasip3 garbageCollector useWasmOpt output assemblyPath archives = do
           "--allow-undefined",
           programObject
         ]
-          <> runtimeObjects
-          <> [bindingsObject, componentTypeObject]
+          <> ["--whole-archive", runtimeArchive, "--no-whole-archive"]
           <> archives
           <> ["-o", linkedCoreModule]
       )
@@ -597,15 +561,13 @@ assembleWasip3 garbageCollector useWasmOpt output assemblyPath archives = do
     runTool "wasm-tools" ["component", "new", coreModule, "-o", output]
     runTool "wasm-tools" ["validate", output]
 
--- | Select the ordinary Clang driver used for WebAssembly objects. Nix can
--- override only the executable to bypass its host-target compiler wrapper.
-wasmClangCommand :: Maybe FilePath -> (FilePath, [String])
-wasmClangCommand override =
-  (fromMaybe "clang" override, ["--target=" <> nativeTargetTriple Wasm32Wasip3])
-
-wasmOptArguments :: FilePath -> FilePath -> [String]
-wasmOptArguments input output =
-  [input, "-O3", "--enable-tail-call", "--emit-target-features", "-o", output]
+requireInstalledRuntime :: FilePath -> NativeTarget -> GarbageCollector -> IO FilePath
+requireInstalledRuntime storeRoot target garbageCollector = do
+  let archive = installedRuntimeArchivePath storeRoot target (runtimeGarbageCollector garbageCollector)
+  exists <- doesFileExist archive
+  if exists
+    then pure archive
+    else ioError (userError ("runtime is not installed: " <> archive <> "; run `aihc prepare-runtime` first"))
 
 runTool :: FilePath -> [String] -> IO ()
 runTool tool arguments = do
@@ -618,12 +580,6 @@ backendSourceExtension :: NativeTarget -> String
 backendSourceExtension Llvm = ".ll"
 backendSourceExtension Wasm32Wasip3 = ".s"
 backendSourceExtension _ = ".s"
-
-runtimeGarbageCollector :: GarbageCollector -> RuntimeGarbageCollector
-runtimeGarbageCollector garbageCollector =
-  case garbageCollector of
-    GcCalloc -> RuntimeGcCalloc
-    GcSemispace -> RuntimeGcSemispace
 
 withTemporaryDirectory :: String -> (FilePath -> IO value) -> IO value
 withTemporaryDirectory template = bracket acquire removeDirectoryRecursive

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -1,19 +1,24 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Core-library discovery and content-addressed compilation for @aihc compile@.
--- Each closure cache contains the frontend interfaces and one Core, GRIN, and
--- backend object artifact per strongly connected module component.
+-- | Installed-library compilation and loading for @aihc compile@.
+-- Incremental caches retain only frontend and linking interfaces; a companion
+-- whole-program cache keeps Core and GRIN bodies for backend construction and
+-- explicit whole-program compilation.
 module Aihc.Cli.Compile.Dependencies
   ( CompileEnvironment (..),
     DependencyArtifact (..),
     DependencyUnit (..),
+    LibraryPackage (..),
     buildDependencies,
+    installLibraries,
   )
 where
 
 import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
+import Aihc.Cli.Runtime (wasmClangCommand)
+import Aihc.Cli.Store (installedLibrariesActivePath, installedLibrariesRoot)
 import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, optimizeProgram)
 import Aihc.Grin qualified as Grin
 import Aihc.Llvm qualified as Llvm
@@ -63,12 +68,12 @@ import Aihc.Tc
   )
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket, bracketOnError)
-import Control.Monad (filterM, foldM)
+import Control.Monad (foldM)
 import Data.Bits (xor)
 import Data.ByteString qualified as BS
+import Data.Char (isHexDigit)
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (sort)
-import Data.Map.Strict (Map)
+import Data.List (sort, sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Set qualified as Set
@@ -81,29 +86,24 @@ import Data.Word (Word64)
 import Numeric (showHex)
 import System.Directory
   ( createDirectoryIfMissing,
-    doesDirectoryExist,
     doesFileExist,
-    listDirectory,
     removeDirectoryRecursive,
     removeFile,
     renameFile,
   )
+import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
 import System.FilePath
-  ( dropExtension,
-    makeRelative,
-    splitDirectories,
+  ( makeRelative,
     takeDirectory,
-    takeExtension,
     (</>),
   )
 import System.IO (hClose, hPutStr, openTempFile)
 import System.Process (readProcessWithExitCode)
 import Text.Read (readMaybe)
 
-data CompileEnvironment = CompileEnvironment
-  { compileCoreLibraryRoot :: !FilePath,
-    compileCacheRoot :: !FilePath
+newtype CompileEnvironment = CompileEnvironment
+  { compileInstalledStoreRoot :: FilePath
   }
   deriving (Eq, Show)
 
@@ -118,7 +118,9 @@ data DependencyArtifact = DependencyArtifact
     dependencyGrinInterface :: !Grin.GrinInterface,
     dependencyReachabilityInterface :: !ReachabilityInterface,
     dependencyLinkInterfaces :: ![LinkInterface],
+    dependencyRuntimePrimitiveNames :: !(Set.Set Text),
     dependencyUnits :: ![DependencyUnit],
+    dependencyUnitMetadata :: ![DependencyUnitMetadata],
     dependencyInitializerSymbols :: ![Text],
     dependencyArchivePaths :: ![FilePath]
   }
@@ -136,6 +138,12 @@ data DependencyUnit = DependencyUnit
   }
   deriving (Eq, Show, Read)
 
+data DependencyUnitMetadata = DependencyUnitMetadata
+  { dependencyMetadataLibraries :: ![Text],
+    dependencyMetadataModules :: ![Text]
+  }
+  deriving (Eq, Show, Read)
+
 data StoredDependencyArtifact = StoredDependencyArtifact
   { storedSchemaVersion :: !Int,
     storedExports :: !StoredModuleExports,
@@ -144,7 +152,13 @@ data StoredDependencyArtifact = StoredDependencyArtifact
     storedClasses :: ![ClassInfo],
     storedBindings :: ![TcBindingResult],
     storedInstances :: ![InstanceInfo],
-    storedUnits :: ![DependencyUnit]
+    storedNewtypeInterface :: !NewtypeInterface,
+    storedGrinInterface :: !Grin.GrinInterface,
+    storedReachabilityInterface :: !ReachabilityInterface,
+    storedLinkInterfaces :: ![LinkInterface],
+    storedRuntimePrimitiveNames :: !(Set.Set Text),
+    storedUnitMetadata :: ![DependencyUnitMetadata],
+    storedUnits :: !(Maybe [DependencyUnit])
   }
   deriving (Show, Read)
 
@@ -169,61 +183,143 @@ data StoredResolvedName
   | StoredError !String
   deriving (Show, Read)
 
-data ModuleSource = ModuleSource
-  { moduleSourceLibrary :: !Text,
-    moduleSourcePath :: !FilePath
-  }
-
 data LoadedModule = LoadedModule
   { loadedLibrary :: !Text,
     loadedModule :: !Module
   }
 
+-- | One Cabal-selected library package in an installation closure.
+data LibraryPackage = LibraryPackage
+  { libraryPackageName :: !Text,
+    libraryPackageRoot :: !FilePath,
+    libraryPackageFiles :: ![FilePath]
+  }
+  deriving (Eq, Show)
+
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 22
+cacheSchemaVersion = 26
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do
   let importedRoots = map importDeclModule (moduleImports mainModule)
       defaultRoots = if usesImplicitPrelude then ["GHC.Prim", "Prelude"] else []
-      initialRoots = sort (Set.toList (Set.fromList (defaultRoots <> importedRoots)))
-  if null initialRoots
+      requiredModules = sort (Set.toList (Set.fromList (defaultRoots <> importedRoots)))
+  if null requiredModules
     then pure (Right emptyDependencyArtifact)
     else do
-      indexResult <- discoverModules (compileCoreLibraryRoot environment)
-      case indexResult of
+      installed <- readInstalledLibraries environment buildBackend
+      case installed of
         Left err -> pure (Left err)
-        Right moduleIndex -> do
-          let roots = addLibraryRoots moduleIndex initialRoots
-          closureResult <- loadModuleClosure moduleIndex roots
-          case closureResult of
-            Left err -> pure (Left err)
-            Right loaded -> do
-              graphHash <- dependencyGraphHash target (compileCoreLibraryRoot environment) loaded
-              let closureHash = stableHash (map (Text.encodeUtf8 . frameText) roots)
-                  cacheDirectory = compileCacheRoot environment </> graphHash
-                  cachePath = cacheDirectory </> closureHash <> ".cache"
-              cached <- readCache cachePath
-              case cached of
-                Just artifact
-                  | buildBackend -> finishArtifact target cacheDirectory closureHash artifact
-                  | otherwise -> pure (Right artifact)
-                Nothing ->
-                  case compileLoadedModules loaded of
-                    Left err -> pure (Left err)
-                    Right artifact -> do
-                      createDirectoryIfMissing True cacheDirectory
-                      writeCache cacheDirectory cachePath artifact
-                      if buildBackend
-                        then finishArtifact target cacheDirectory closureHash artifact
-                        else pure (Right artifact)
+        Right (artifactRoot, artifact) ->
+          case filter (`Map.notMember` dependencyExports artifact) requiredModules of
+            missing@(_ : _) -> pure (Left ("library modules are not installed: " <> T.unpack (T.intercalate ", " missing)))
+            []
+              | buildBackend -> attachInstalledBackend target artifactRoot artifact
+              | otherwise -> pure (Right artifact)
 
-finishArtifact :: NativeTarget -> FilePath -> FilePath -> DependencyArtifact -> IO (Either String DependencyArtifact)
-finishArtifact target cacheDirectory closureHash artifact = do
-  backendArtifacts <- buildBackendArtifacts target (cacheDirectory </> closureHash) (dependencyUnits artifact)
+-- | Compile a package closure once, then install its frontend interfaces,
+-- whole-program bodies, and one archive set per requested target.
+installLibraries :: FilePath -> [LibraryPackage] -> [NativeTarget] -> IO (Either String FilePath)
+installLibraries storeRoot packages targets
+  | all (null . libraryPackageFiles) packages = pure (Left "the package closure contains no library modules")
+  | otherwise = do
+      graphHash <- dependencyGraphHash packages
+      let librariesRoot = installedLibrariesRoot storeRoot
+          artifactRoot = librariesRoot </> graphHash
+          incrementalPath = artifactRoot </> "interfaces.cache"
+          wholePath = artifactRoot </> "whole.cache"
+      cached <- readCache wholePath
+      artifactResult <-
+        case cached of
+          Just artifact
+            | not (null (dependencyUnits artifact)) -> pure (Right artifact)
+          _ -> do
+            loadedResult <- loadLibraryPackages packages
+            pure (loadedResult >>= compileLoadedModules)
+      case artifactResult of
+        Left err -> pure (Left err)
+        Right artifact -> do
+          createDirectoryIfMissing True artifactRoot
+          writeCache artifactRoot incrementalPath False artifact
+          writeCache artifactRoot wholePath True artifact
+          backendResults <-
+            mapM
+              (\target -> buildBackendArtifacts target (installedBackendRoot artifactRoot target) (dependencyUnits artifact))
+              (sort (Set.toList (Set.fromList targets)))
+          case sequence backendResults of
+            Left err -> pure (Left err)
+            Right _ -> do
+              writeActiveLibraries storeRoot graphHash
+              pure (Right artifactRoot)
+
+readInstalledLibraries :: CompileEnvironment -> Bool -> IO (Either String (FilePath, DependencyArtifact))
+readInstalledLibraries environment incremental = do
+  let storeRoot = compileInstalledStoreRoot environment
+      activePath = installedLibrariesActivePath storeRoot
+  activeExists <- doesFileExist activePath
+  if not activeExists
+    then pure (Left ("libraries are not installed in " <> storeRoot <> "; run `aihc install PACKAGE` first"))
+    else do
+      activeContents <- readFile activePath
+      case words activeContents of
+        [graphHash]
+          | length graphHash == 16 && all isHexDigit graphHash -> do
+              let artifactRoot = installedLibrariesRoot storeRoot </> graphHash
+                  artifactPath = artifactRoot </> if incremental then "interfaces.cache" else "whole.cache"
+              cached <- readCache artifactPath
+              pure $
+                case cached of
+                  Nothing -> Left ("installed library artifact is missing or incompatible: " <> artifactPath)
+                  Just artifact -> Right (artifactRoot, artifact)
+        _ -> pure (Left ("invalid installed library selector: " <> activePath))
+
+attachInstalledBackend :: NativeTarget -> FilePath -> DependencyArtifact -> IO (Either String DependencyArtifact)
+attachInstalledBackend target artifactRoot artifact = do
+  let backendRoot = installedBackendRoot artifactRoot target
+      (initializers, archives) = backendMetadataArtifacts backendRoot (dependencyUnitMetadata artifact)
+      finished = artifact {dependencyInitializerSymbols = initializers, dependencyArchivePaths = archives}
+  archivesExist <- and <$> mapM doesFileExist archives
   pure $
-    (\(initializers, archives) -> artifact {dependencyInitializerSymbols = initializers, dependencyArchivePaths = archives})
-      <$> backendArtifacts
+    if archivesExist
+      then Right finished
+      else Left ("compiled libraries for target " <> nativeTargetTriple target <> " are not installed")
+
+installedBackendRoot :: FilePath -> NativeTarget -> FilePath
+installedBackendRoot artifactRoot target = artifactRoot </> "backends" </> nativeTargetTriple target
+
+writeActiveLibraries :: FilePath -> String -> IO ()
+writeActiveLibraries storeRoot graphHash = do
+  let destination = installedLibrariesActivePath storeRoot
+      directory = takeDirectory destination
+  createDirectoryIfMissing True directory
+  bracketOnError
+    (openTempFile directory "active.tmp")
+    (\(path, handle) -> hClose handle >> removeFile path)
+    ( \(path, handle) -> do
+        hPutStr handle (graphHash <> "\n")
+        hClose handle
+        renameFile path destination
+    )
+
+backendMetadataArtifacts :: FilePath -> [DependencyUnitMetadata] -> ([Text], [FilePath])
+backendMetadataArtifacts artifactRoot metadata =
+  ( map metadataInitializerSymbol metadata,
+    [artifactRoot </> "archives" </> "lib" <> T.unpack library <> ".a" | library <- libraries]
+  )
+  where
+    libraries = sort (Set.toList (Set.fromList (map metadataPrimaryLibrary metadata)))
+
+metadataInitializerSymbol :: DependencyUnitMetadata -> Text
+metadataInitializerSymbol metadata =
+  "_aihc_init_"
+    <> symbolHex
+      ( metadataPrimaryLibrary metadata
+          <> "\0"
+          <> T.intercalate "\0" (dependencyMetadataModules metadata)
+      )
+
+metadataPrimaryLibrary :: DependencyUnitMetadata -> Text
+metadataPrimaryLibrary = fromMaybe "dependencies" . listToMaybe . dependencyMetadataLibraries
 
 emptyDependencyArtifact :: DependencyArtifact
 emptyDependencyArtifact =
@@ -238,87 +334,48 @@ emptyDependencyArtifact =
       dependencyGrinInterface = mempty,
       dependencyReachabilityInterface = mempty,
       dependencyLinkInterfaces = [],
+      dependencyRuntimePrimitiveNames = Set.empty,
       dependencyUnits = [],
+      dependencyUnitMetadata = [],
       dependencyInitializerSymbols = [],
       dependencyArchivePaths = []
     }
 
--- aihc-base is defined in terms of the compiler-owned GHC.Prim interface even
--- when a selected base module does not import it directly.
-addLibraryRoots :: Map Text ModuleSource -> [Text] -> [Text]
-addLibraryRoots moduleIndex roots
-  | any isBaseModule roots = sort (Set.toList (Set.insert "GHC.Prim" (Set.fromList roots)))
-  | otherwise = roots
+loadLibraryPackages :: [LibraryPackage] -> IO (Either String [LoadedModule])
+loadLibraryPackages packages = do
+  parsed <- mapM loadPackage packages
+  pure $ sequence parsed >>= rejectDuplicateModules . concat
   where
-    isBaseModule name =
-      case Map.lookup name moduleIndex of
-        Just ModuleSource {moduleSourceLibrary = "aihc-base"} -> True
-        _ -> False
+    loadPackage package =
+      sequence
+        <$> mapM
+          (parseModuleFile (libraryPackageName package))
+          (sort (libraryPackageFiles package))
 
-discoverModules :: FilePath -> IO (Either String (Map Text ModuleSource))
-discoverModules root = do
-  exists <- doesDirectoryExist root
-  if not exists
-    then pure (Left ("core library directory does not exist: " <> root))
-    else do
-      entries <- sort <$> listDirectory root
-      libraries <- filterM (doesDirectoryExist . (root </>)) entries
-      foldM addLibrary (Right Map.empty) libraries
-  where
-    addLibrary (Left err) _ = pure (Left err)
-    addLibrary (Right index) library = do
-      let sourceRoot = root </> library </> "src"
-      sourceRootExists <- doesDirectoryExist sourceRoot
-      if not sourceRootExists
-        then pure (Right index)
-        else do
-          files <- listFilesRecursively sourceRoot
-          pure (foldM (insertModule sourceRoot (T.pack library)) index (filter ((== ".hs") . takeExtension) files))
+    rejectDuplicateModules loaded = snd <$> foldM insertModule (Map.empty, []) loaded
+    insertModule (seen, loaded) modu =
+      case moduleName (loadedModule modu) of
+        Nothing -> Left "installed library modules must have explicit module names"
+        Just name ->
+          case Map.lookup name seen of
+            Nothing -> Right (Map.insert name (loadedLibrary modu) seen, loaded <> [modu])
+            Just previous ->
+              Left
+                ( "module "
+                    <> T.unpack name
+                    <> " is provided by both "
+                    <> T.unpack previous
+                    <> " and "
+                    <> T.unpack (loadedLibrary modu)
+                )
 
-    insertModule sourceRoot library index path =
-      let relative = dropExtension (makeRelative sourceRoot path)
-          discoveredModuleName = T.intercalate "." (map T.pack (splitDirectories relative))
-       in case Map.lookup discoveredModuleName index of
-            Nothing -> Right (Map.insert discoveredModuleName (ModuleSource library path) index)
-            Just previous
-              | libraryPriority library < libraryPriority (moduleSourceLibrary previous) ->
-                  Right (Map.insert discoveredModuleName (ModuleSource library path) index)
-              | otherwise -> Right index
-
-    libraryPriority "aihc-prim" = 0 :: Int
-    libraryPriority "aihc-base" = 1
-    libraryPriority "aihc-internal" = 3
-    libraryPriority _ = 2
-
-loadModuleClosure :: Map Text ModuleSource -> [Text] -> IO (Either String [LoadedModule])
-loadModuleClosure index roots = fmap (fmap snd) (go Set.empty [] roots)
-  where
-    go seen loaded [] = pure (Right (seen, loaded))
-    go seen loaded (name : remaining)
-      | name `Set.member` seen = go seen loaded remaining
-      | otherwise =
-          case Map.lookup name index of
-            Nothing -> pure (Left ("core module not found in ./core-libs: " <> T.unpack name))
-            Just source -> do
-              parsed <- parseModuleFile source
-              case parsed of
-                Left err -> pure (Left err)
-                Right modu -> do
-                  let seen' = Set.insert name seen
-                      imports = map importDeclModule (moduleImports modu)
-                  dependencies <- go seen' loaded imports
-                  case dependencies of
-                    Left err -> pure (Left err)
-                    Right (seen'', loaded') ->
-                      go seen'' (loaded' <> [LoadedModule (moduleSourceLibrary source) modu]) remaining
-
-parseModuleFile :: ModuleSource -> IO (Either String Module)
-parseModuleFile ModuleSource {moduleSourcePath} = do
-  source <- Utf8.readFile moduleSourcePath
+parseModuleFile :: Text -> FilePath -> IO (Either String LoadedModule)
+parseModuleFile library path = do
+  source <- Utf8.readFile path
   pure $
-    case parseModule (parserConfig moduleSourcePath source) source of
-      ([], modu) -> Right modu
-      (errors, _) -> Left ("failed to parse core module " <> moduleSourcePath <> ": " <> show errors)
+    case parseModule (parserConfig path source) source of
+      ([], modu) -> Right (LoadedModule library modu)
+      (errors, _) -> Left ("failed to parse library module " <> path <> ": " <> show errors)
 
 parserConfig :: FilePath -> Text -> ParserConfig
 parserConfig sourceName source =
@@ -337,7 +394,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
 
     compileScc state members =
       case resolveWithDeps (compileStateExports state) (map loadedModule members) of
-        ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("core library resolve error: " <> show errors)
+        ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("library resolve error: " <> show errors)
         resolved@ResolveResult {resolvedModules} ->
           let (checkedModules, termSchemes, tyCons, classes) =
                 typecheckModuleSccWithClassEnv
@@ -347,14 +404,14 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                   (compileStateInstances state)
                   resolvedModules
            in if not (all tcModuleSuccess checkedModules)
-                then Left ("core library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
+                then Left ("library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
                 else
                   let localBindings = concatMap tcModuleBindings checkedModules
                       bindings = compileStateBindings state <> localBindings
                       localInstances = concatMap tcModuleInstances checkedModules
                       desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
                    in if not (all dsSuccess desugared)
-                        then Left ("core library desugar error: " <> unlines (concatMap dsErrors desugared))
+                        then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else
                           let sourceCore = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                               core = optimizeProgram (lowerNewtypesWithInterface (compileStateNewtypes state) sourceCore)
@@ -364,7 +421,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                               grin = Grin.lowerProgramWithInterface (compileStateGrin state) core
                               linkInterface = extractLinkInterface grin
                            in case Grin.toCpsGrin grin of
-                                Left err -> Left ("core library CPS-GRIN error: " <> show err)
+                                Left err -> Left ("library CPS-GRIN error: " <> show err)
                                 Right cpsGrin ->
                                   let unit =
                                         DependencyUnit
@@ -405,7 +462,14 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
           dependencyGrinInterface = compileStateGrin state,
           dependencyReachabilityInterface = compileStateReachability state,
           dependencyLinkInterfaces = compileStateLinks state,
+          dependencyRuntimePrimitiveNames =
+            Set.fromList
+              [ Grin.grinVarName primitive
+              | unit <- compileStateUnits state,
+                (primitive, _) <- Grin.grinPrimitives (dependencyUnitGrin unit)
+              ],
           dependencyUnits = compileStateUnits state,
+          dependencyUnitMetadata = map dependencyMetadata (compileStateUnits state),
           dependencyInitializerSymbols = [],
           dependencyArchivePaths = []
         }
@@ -479,6 +543,13 @@ backendUnit objectRoot unit =
     unitName = T.intercalate "+" (dependencyUnitModules unit)
     initializer = "_aihc_init_" <> symbolHex (library <> "\0" <> T.intercalate "\0" (dependencyUnitModules unit))
 
+dependencyMetadata :: DependencyUnit -> DependencyUnitMetadata
+dependencyMetadata unit =
+  DependencyUnitMetadata
+    { dependencyMetadataLibraries = dependencyUnitLibraries unit,
+      dependencyMetadataModules = dependencyUnitModules unit
+    }
+
 backendUnitLibrary :: BackendUnit -> Text
 backendUnitLibrary = dependencyUnitPrimaryLibrary . backendDependencyUnit
 
@@ -527,7 +598,10 @@ backendSourceExtension _ = ".s"
 
 objectCompiler :: NativeTarget -> FilePath -> FilePath -> IO (FilePath, [String])
 objectCompiler target sourcePath objectPath = do
-  (compiler, targetArguments) <- backendCompiler target
+  (compiler, targetArguments) <-
+    case target of
+      Wasm32Wasip3 -> wasmClangCommand <$> lookupEnv "AIHC_WASM_CLANG"
+      _ -> backendCompiler target
   case target of
     Llvm -> pure (compiler, targetArguments <> ["-c", sourcePath, "-o", objectPath])
     AppleArm64 -> pure (compiler, nativeArguments targetArguments)
@@ -562,49 +636,27 @@ withTemporaryDirectory parent template = bracket acquire removeDirectoryRecursiv
       createDirectoryIfMissing True path
       pure path
 
-dependencyGraphHash :: NativeTarget -> FilePath -> [LoadedModule] -> IO String
-dependencyGraphHash target root loaded = do
-  let libraries = sort (Set.toList (Set.fromList (map (T.unpack . loadedLibrary) loaded)))
-  chunks <- concat <$> mapM libraryChunks libraries
+dependencyGraphHash :: [LibraryPackage] -> IO String
+dependencyGraphHash packages = do
+  chunks <- concat <$> mapM packageChunks (sortOn libraryPackageName packages)
   pure
     ( stableHash
         ( Text.encodeUtf8 (frameText (T.pack (show cacheSchemaVersion)))
-            : Text.encodeUtf8 (frameText (T.pack (nativeTargetTriple target)))
             : chunks
         )
     )
   where
-    libraryChunks library = do
-      let libraryRoot = root </> library
-      exists <- doesDirectoryExist libraryRoot
-      if not exists
-        then pure [Text.encodeUtf8 (frameText (T.pack library))]
-        else do
-          files <- sort <$> listFilesRecursively libraryRoot
-          fmap concat . mapM (fileChunks libraryRoot) $ files
+    packageChunks package = do
+      files <- concat <$> mapM (fileChunks package) (sort (libraryPackageFiles package))
+      pure (Text.encodeUtf8 (frameText (libraryPackageName package)) : files)
 
-    fileChunks libraryRoot path = do
+    fileChunks package path = do
       bytes <- BS.readFile path
       pure
-        [ Text.encodeUtf8 (frameText (T.pack (makeRelative root libraryRoot))),
-          Text.encodeUtf8 (frameText (T.pack (makeRelative libraryRoot path))),
+        [ Text.encodeUtf8 (frameText (T.pack (makeRelative (libraryPackageRoot package) path))),
           Text.encodeUtf8 (frameText (T.pack (show (BS.length bytes)))),
           bytes
         ]
-
-listFilesRecursively :: FilePath -> IO [FilePath]
-listFilesRecursively root = do
-  entries <- sort <$> listDirectory root
-  fmap concat . mapM visit $ entries
-  where
-    visit name = do
-      let path = root </> name
-      directory <- doesDirectoryExist path
-      if directory
-        then listFilesRecursively path
-        else do
-          file <- doesFileExist path
-          pure [path | file]
 
 frameText :: Text -> Text
 frameText value = T.pack (show (T.length value)) <> ":" <> value
@@ -637,19 +689,19 @@ readCache path = do
           then Just (fromStoredArtifact stored)
           else Nothing
 
-writeCache :: FilePath -> FilePath -> DependencyArtifact -> IO ()
-writeCache directory destination artifact =
+writeCache :: FilePath -> FilePath -> Bool -> DependencyArtifact -> IO ()
+writeCache directory destination includeUnits artifact =
   bracketOnError
     (openTempFile directory "dependency.cache.tmp")
     (\(path, handle) -> hClose handle >> removeFile path)
     ( \(path, handle) -> do
-        hPutStr handle (show (toStoredArtifact artifact))
+        hPutStr handle (show (toStoredArtifact includeUnits artifact))
         hClose handle
         renameFile path destination
     )
 
-toStoredArtifact :: DependencyArtifact -> StoredDependencyArtifact
-toStoredArtifact artifact =
+toStoredArtifact :: Bool -> DependencyArtifact -> StoredDependencyArtifact
+toStoredArtifact includeUnits artifact =
   StoredDependencyArtifact
     { storedSchemaVersion = cacheSchemaVersion,
       storedExports = toStoredExports (dependencyExports artifact),
@@ -658,7 +710,13 @@ toStoredArtifact artifact =
       storedClasses = dependencyClasses artifact,
       storedBindings = dependencyBindings artifact,
       storedInstances = dependencyInstances artifact,
-      storedUnits = dependencyUnits artifact
+      storedNewtypeInterface = dependencyNewtypeInterface artifact,
+      storedGrinInterface = dependencyGrinInterface artifact,
+      storedReachabilityInterface = dependencyReachabilityInterface artifact,
+      storedLinkInterfaces = dependencyLinkInterfaces artifact,
+      storedRuntimePrimitiveNames = dependencyRuntimePrimitiveNames artifact,
+      storedUnitMetadata = dependencyUnitMetadata artifact,
+      storedUnits = if includeUnits then Just (dependencyUnits artifact) else Nothing
     }
 
 fromStoredArtifact :: StoredDependencyArtifact -> DependencyArtifact
@@ -670,16 +728,16 @@ fromStoredArtifact stored =
       dependencyClasses = storedClasses stored,
       dependencyBindings = storedBindings stored,
       dependencyInstances = storedInstances stored,
-      dependencyNewtypeInterface = foldMap dependencyUnitNewtypeInterface units,
-      dependencyGrinInterface = foldMap dependencyUnitGrinInterface units,
-      dependencyReachabilityInterface = foldMap dependencyUnitReachabilityInterface units,
-      dependencyLinkInterfaces = map dependencyUnitLinkInterface units,
-      dependencyUnits = storedUnits stored,
+      dependencyNewtypeInterface = storedNewtypeInterface stored,
+      dependencyGrinInterface = storedGrinInterface stored,
+      dependencyReachabilityInterface = storedReachabilityInterface stored,
+      dependencyLinkInterfaces = storedLinkInterfaces stored,
+      dependencyRuntimePrimitiveNames = storedRuntimePrimitiveNames stored,
+      dependencyUnits = fromMaybe [] (storedUnits stored),
+      dependencyUnitMetadata = storedUnitMetadata stored,
       dependencyInitializerSymbols = [],
       dependencyArchivePaths = []
     }
-  where
-    units = storedUnits stored
 
 toStoredExports :: ModuleExports -> StoredModuleExports
 toStoredExports = StoredModuleExports . map (fmap toStoredScope) . Map.toAscList

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -21,6 +21,7 @@ module Aihc.Cli.Install
     defaultStoreRoot,
     dryRunInstallScaffold,
     installFailureIsForPackage,
+    installPackageLibraries,
     lookupPackagePlanSourceLineCount,
     newPackageCheckCache,
     newPackagePlanCache,
@@ -32,7 +33,9 @@ module Aihc.Cli.Install
   )
 where
 
+import Aihc.Cli.Compile.Dependencies (LibraryPackage (..), installLibraries)
 import Aihc.Cli.Options (InstallErrorFormat (..), InstallOptions (..))
+import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cpp qualified as Cpp
 import Aihc.Fc (DesugarResult (..), desugarModuleWithBindings, renderProgram)
 import Aihc.Hackage.Cabal qualified as HackageCabal
@@ -42,6 +45,7 @@ import Aihc.Hackage.Download qualified as HackageDownload
 import Aihc.Hackage.Types (PackageSpec (..), formatPackage)
 import Aihc.Hackage.Util qualified as HackageUtil
 import Aihc.Hackage.VersionResolver (getLatestVersion)
+import Aihc.Native (NativeTarget)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax
   ( Extension (..),
@@ -85,7 +89,6 @@ import Aihc.Tc
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar)
 import Control.Exception (AsyncException, Exception (..), SomeException, evaluate, fromException, mask, throwIO, try)
-import Control.Monad (when)
 import Data.Aeson (ToJSON (..), object, (.:), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
@@ -97,7 +100,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Either (rights)
 import Data.Foldable (toList)
 import Data.IORef (newIORef, readIORef, writeIORef)
-import Data.List (nub, sort, sortOn)
+import Data.List (nub, nubBy, sort, sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Set qualified as Set
@@ -108,15 +111,15 @@ import Data.Word (Word64)
 import Distribution.Package qualified as CabalPackage
 import Distribution.PackageDescription (buildable, condLibrary, condSubLibraries, genPackageFlags, libBuildInfo, package, packageDescription)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Pretty (prettyShow)
 import Distribution.Types.Flag (flagDefault, flagName, unFlagName)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
 import Numeric (showHex)
 import System.Directory
-  ( XdgDirectory (XdgCache),
-    createDirectoryIfMissing,
+  ( createDirectoryIfMissing,
+    doesDirectoryExist,
     doesFileExist,
     getCurrentDirectory,
-    getXdgDirectory,
   )
 import System.Environment (lookupEnv)
 import System.Exit (exitFailure)
@@ -306,29 +309,113 @@ instance ToJSON PhaseStatus where
 runInstall :: InstallOptions -> IO ()
 runInstall opts = do
   storeRoot <- maybe defaultStoreRoot pure (installStoreRoot opts)
-  version <- resolveVersion opts
-  let spec = PackageSpec (installPackageName opts) version
-      resolver = hackageDependencyResolver opts
+  (spec, resolver) <- installRequest opts
   plan <-
     if installDryRun opts
       then buildDryRunPackagePlanWithResolver resolver storeRoot spec
       else buildPackagePlanWithResolver resolver storeRoot spec
-  result <-
-    if installDryRun opts
-      then dryRunInstallScaffold plan
-      else do
-        writeResult <- writeInstallScaffold plan
-        case writeResult of
-          Right installResult -> pure installResult
-          Left failure -> do
-            hPutStrLn stderr (renderInstallFailureWithOptions opts failure)
-            exitFailure
-  putStrLn ("store: " <> resultStorePath result)
-  putStrLn ("manifest: " <> resultManifestPath result)
-  putStrLn ("interfaces: " <> resultInterfacePath result)
-  putStrLn ("system-fc: " <> resultFcPath result)
-  when (installDryRun opts) $
-    putStrLn "dry-run: no files written"
+  if installDryRun opts
+    then do
+      result <- dryRunInstallScaffold plan
+      printInstallResult result
+      putStrLn "dry-run: no files written"
+    else
+      if null (installTargets opts)
+        then do
+          writeResult <- writeInstallScaffold plan
+          case writeResult of
+            Right result -> printInstallResult result
+            Left failure -> do
+              hPutStrLn stderr (renderInstallFailureWithOptions opts failure)
+              exitFailure
+        else do
+          libraryResult <- installPackageLibraries (installTargets opts) plan
+          artifactRoot <- either (ioError . userError) pure libraryResult
+          putStrLn ("libraries: " <> artifactRoot)
+  where
+    printInstallResult result = do
+      putStrLn ("store: " <> resultStorePath result)
+      putStrLn ("manifest: " <> resultManifestPath result)
+      putStrLn ("interfaces: " <> resultInterfacePath result)
+      putStrLn ("system-fc: " <> resultFcPath result)
+
+installRequest :: InstallOptions -> IO (PackageSpec, DependencyResolver)
+installRequest opts = do
+  let packageArgument = installPackageName opts
+  localSource <- doesDirectoryExist packageArgument
+  if localSource
+    then do
+      spec <- packageSpecFromSource packageArgument
+      pure (spec, localDependencyResolver opts packageArgument)
+    else do
+      version <- resolveVersion opts
+      pure (PackageSpec packageArgument version, hackageDependencyResolver opts)
+
+localDependencyResolver :: InstallOptions -> FilePath -> DependencyResolver
+localDependencyResolver opts rootSource =
+  DependencyResolver
+    { resolverResolveVersion = \name -> do
+        local <- localPackage name
+        maybe (resolverResolveVersion fallback name) (pure . pkgVersion . fst) local,
+      resolverSourcePath = \spec -> do
+        local <- localPackage (pkgName spec)
+        case local of
+          Just (localSpec, path)
+            | pkgVersion localSpec == pkgVersion spec -> pure path
+          _ -> resolverSourcePath fallback spec
+    }
+  where
+    fallback = hackageDependencyResolver opts
+    workspace = takeDirectory (normalise rootSource)
+    localPackage name = do
+      let candidate = workspace </> name
+      exists <- doesDirectoryExist candidate
+      if exists
+        then do
+          spec <- packageSpecFromSource candidate
+          pure (Just (spec, candidate))
+        else pure Nothing
+
+packageSpecFromSource :: FilePath -> IO PackageSpec
+packageSpecFromSource sourcePath = do
+  cabalFiles <- HackageUtil.findCabalFiles sourcePath
+  cabalFile <-
+    case cabalFiles of
+      [] -> ioError (userError ("No .cabal file found under " <> sourcePath))
+      files -> pure (HackageUtil.chooseBestCabalFile sourcePath files)
+  cabalBytes <- BS.readFile cabalFile
+  gpd <-
+    case runParseResult (parseGenericPackageDescription cabalBytes) of
+      (_, Right parsed) -> pure parsed
+      (_, Left (_, errs)) -> ioError (userError ("Failed to parse " <> cabalFile <> ": " <> show errs))
+  let packageId = package (packageDescription gpd)
+  pure
+    PackageSpec
+      { pkgName = CabalPackage.unPackageName (CabalPackage.packageName packageId),
+        pkgVersion = prettyShow (CabalPackage.packageVersion packageId)
+      }
+
+-- | Install the compiled library closure represented by a generic package
+-- plan. Cabal chooses the modules; callers never enumerate them.
+installPackageLibraries :: [NativeTarget] -> PackagePlan -> IO (Either String FilePath)
+installPackageLibraries targets plan = do
+  packages <- mapM packageLibrary (flattenPackagePlan plan)
+  installLibraries (planStoreRoot plan) packages targets
+  where
+    packageLibrary package = do
+      files <- collectPlanFiles package
+      pure
+        LibraryPackage
+          { libraryPackageName = T.pack (pkgName (packageKeySpec (planPackageKey package))),
+            libraryPackageRoot = planSourcePath package,
+            libraryPackageFiles = map HackageCabal.fileInfoPath files
+          }
+
+    flattenPackagePlan =
+      nubBy samePackage . go
+      where
+        go package = concatMap go (planDependencyPlans package) <> [package]
+        samePackage left right = planPackageKey left == planPackageKey right
 
 hackageDependencyResolver :: InstallOptions -> DependencyResolver
 hackageDependencyResolver opts =
@@ -367,11 +454,6 @@ resolveVersion opts =
           case result of
             Right version -> pure version
             Left err -> ioError (userError err)
-
-defaultStoreRoot :: IO FilePath
-defaultStoreRoot = do
-  cacheDir <- getXdgDirectory XdgCache "aihc"
-  pure (cacheDir </> "store")
 
 buildPackagePlanWithResolver :: DependencyResolver -> FilePath -> PackageSpec -> IO PackagePlan
 buildPackagePlanWithResolver resolver storeRoot spec = do

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -4,6 +4,7 @@ module Aihc.Cli.Options
     GarbageCollector (..),
     InstallErrorFormat (..),
     InstallOptions (..),
+    PrepareRuntimeOptions (..),
     ReplOptions (..),
     parseCommandIO,
     parseCommandPure,
@@ -12,11 +13,13 @@ module Aihc.Cli.Options
 where
 
 import Aihc.Native (NativeTarget, parseNativeTarget)
+import Control.Applicative (many)
 import Options.Applicative qualified as OA
 
 data Command
   = CmdCompile !CompileOptions
   | CmdInstall !InstallOptions
+  | CmdPrepareRuntime !PrepareRuntimeOptions
   | CmdRepl !ReplOptions
   deriving (Eq, Show)
 
@@ -29,6 +32,7 @@ data CompileOptions = CompileOptions
     compileWholeProgram :: !Bool,
     compileTarget :: !(Maybe NativeTarget),
     compileGarbageCollector :: !GarbageCollector,
+    compileStoreRoot :: !(Maybe FilePath),
     compileUseWasmOpt :: !Bool
   }
   deriving (Eq, Show)
@@ -36,6 +40,13 @@ data CompileOptions = CompileOptions
 data GarbageCollector
   = GcCalloc
   | GcSemispace
+  deriving (Eq, Show)
+
+data PrepareRuntimeOptions = PrepareRuntimeOptions
+  { prepareRuntimeTarget :: !NativeTarget,
+    prepareRuntimeGarbageCollector :: !GarbageCollector,
+    prepareRuntimeStoreRoot :: !(Maybe FilePath)
+  }
   deriving (Eq, Show)
 
 newtype ReplOptions = ReplOptions
@@ -49,6 +60,7 @@ data InstallOptions = InstallOptions
     installStoreRoot :: !(Maybe FilePath),
     installOffline :: !Bool,
     installDryRun :: !Bool,
+    installTargets :: ![NativeTarget],
     installFirstErrorModule :: !Bool,
     installErrorFormat :: !InstallErrorFormat
   }
@@ -92,7 +104,13 @@ commandParser =
           "install"
           ( OA.info
               (CmdInstall <$> installOptionsParser OA.<**> OA.helper)
-              (OA.progDesc "Install a Hackage package into the aihc store scaffold")
+              (OA.progDesc "Compile and install a library package and its dependencies")
+          )
+        <> OA.command
+          "prepare-runtime"
+          ( OA.info
+              (CmdPrepareRuntime <$> prepareRuntimeOptionsParser OA.<**> OA.helper)
+              (OA.progDesc "Compile and install a runtime for one backend and garbage collector")
           )
         <> OA.command
           "repl"
@@ -149,6 +167,13 @@ compileOptionsParser =
           <> OA.showDefaultWith (const "calloc")
           <> OA.help "Select the garbage collector compiled into the executable"
       )
+    <*> OA.optional
+      ( OA.strOption
+          ( OA.long "store"
+              <> OA.metavar "DIR"
+              <> OA.help "Read installed runtimes and core libraries from DIR"
+          )
+      )
     <*> OA.switch
       ( OA.long "use-wasm-opt"
           <> OA.help "Optimize the linked core WebAssembly module with wasm-opt when available"
@@ -160,6 +185,43 @@ parseGarbageCollector value =
     "calloc" -> Right GcCalloc
     "semispace" -> Right GcSemispace
     _ -> Left "expected calloc or semispace"
+
+prepareRuntimeOptionsParser :: OA.Parser PrepareRuntimeOptions
+prepareRuntimeOptionsParser =
+  PrepareRuntimeOptions
+    <$> nativeTargetOption
+    <*> garbageCollectorOption
+    <*> storeRootOption "Install the prepared runtime into DIR"
+
+nativeTargetOption :: OA.Parser NativeTarget
+nativeTargetOption =
+  OA.option
+    (OA.eitherReader parseNativeTarget)
+    ( OA.long "target"
+        <> OA.metavar "TARGET"
+        <> OA.help "Target: apple-arm64, linux-amd64, llvm, or wasm32-wasip3"
+    )
+
+garbageCollectorOption :: OA.Parser GarbageCollector
+garbageCollectorOption =
+  OA.option
+    (OA.eitherReader parseGarbageCollector)
+    ( OA.long "gc"
+        <> OA.metavar "calloc|semispace"
+        <> OA.value GcCalloc
+        <> OA.showDefaultWith (const "calloc")
+        <> OA.help "Select the garbage collector"
+    )
+
+storeRootOption :: String -> OA.Parser (Maybe FilePath)
+storeRootOption description =
+  OA.optional
+    ( OA.strOption
+        ( OA.long "store"
+            <> OA.metavar "DIR"
+            <> OA.help description
+        )
+    )
 
 replOptionsParser :: OA.Parser ReplOptions
 replOptionsParser =
@@ -177,7 +239,7 @@ installOptionsParser =
   InstallOptions
     <$> OA.strArgument
       ( OA.metavar "PACKAGE"
-          <> OA.help "Hackage package name"
+          <> OA.help "Hackage package name or local package directory"
       )
     <*> OA.optional
       ( OA.strOption
@@ -201,6 +263,7 @@ installOptionsParser =
       ( OA.long "dry-run"
           <> OA.help "Plan the install without writing store artifacts or package cache files"
       )
+    <*> many nativeTargetOption
     <*> OA.switch
       ( OA.long "first-error-module"
           <> OA.help "Only print diagnostics from the module or file that produced the first install error"

--- a/bin/aihc/src/Aihc/Cli/Runtime.hs
+++ b/bin/aihc/src/Aihc/Cli/Runtime.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Build runtime archives once, install them in the aihc store, and let
+-- ordinary program links consume those immutable artifacts.
+module Aihc.Cli.Runtime
+  ( prepareRuntimeArchive,
+    runPrepareRuntime,
+    runtimeGarbageCollector,
+    wasmClangCommand,
+    wasmOptArguments,
+  )
+where
+
+import Aihc.Cli.Options (GarbageCollector (..), PrepareRuntimeOptions (..))
+import Aihc.Cli.Store (defaultStoreRoot, installedRuntimeArchivePath)
+import Aihc.Native
+  ( NativeTarget (..),
+    RuntimeGarbageCollector (..),
+    RuntimePlan (..),
+    backendCompiler,
+    nativeTargetTriple,
+    runtimePlan,
+  )
+import Aihc.Wasm qualified as Wasm
+import Control.Exception (bracket)
+import Control.Monad (forM)
+import Data.Maybe (fromMaybe)
+import System.Directory (createDirectory, createDirectoryIfMissing, removeDirectoryRecursive, removeFile, renameFile)
+import System.Environment (lookupEnv)
+import System.Exit (ExitCode (..))
+import System.FilePath (takeDirectory, (</>))
+import System.IO (hClose, openTempFile)
+import System.Process (readProcessWithExitCode)
+
+runPrepareRuntime :: PrepareRuntimeOptions -> IO ()
+runPrepareRuntime options = do
+  storeRoot <- maybe defaultStoreRoot pure (prepareRuntimeStoreRoot options)
+  archive <-
+    prepareRuntimeArchive
+      storeRoot
+      (prepareRuntimeTarget options)
+      (prepareRuntimeGarbageCollector options)
+  putStrLn ("runtime: " <> archive)
+
+prepareRuntimeArchive :: FilePath -> NativeTarget -> GarbageCollector -> IO FilePath
+prepareRuntimeArchive storeRoot target garbageCollector = do
+  let destination = installedRuntimeArchivePath storeRoot target (runtimeGarbageCollector garbageCollector)
+      destinationDirectory = takeDirectory destination
+  createDirectoryIfMissing True destinationDirectory
+  withTemporaryDirectory destinationDirectory "runtime-build" $ \directory -> do
+    objects <-
+      case target of
+        Wasm32Wasip3 -> buildWasip3RuntimeObjects garbageCollector directory
+        _ -> buildNativeRuntimeObjects target garbageCollector directory
+    let archive = directory </> "runtime.a"
+    runTool "ar" (["rcs", archive] <> objects)
+    renameFile archive destination
+  pure destination
+
+buildNativeRuntimeObjects :: NativeTarget -> GarbageCollector -> FilePath -> IO [FilePath]
+buildNativeRuntimeObjects target garbageCollector directory = do
+  RuntimePlan {runtimeSources, runtimeIncludeDirectories} <- runtimePlan target (runtimeGarbageCollector garbageCollector)
+  (compiler, targetArguments) <- backendCompiler target
+  let commonArguments =
+        targetArguments
+          <> ["-std=c11", "-Wall", "-Wextra", "-Werror"]
+          <> ["-I" <> includeDirectory | includeDirectory <- runtimeIncludeDirectories]
+  forM (zip [0 :: Int ..] runtimeSources) $ \(index, source) -> do
+    let object = directory </> "runtime-" <> show index <> ".o"
+    runTool compiler (commonArguments <> ["-c", source, "-o", object])
+    pure object
+
+buildWasip3RuntimeObjects :: GarbageCollector -> FilePath -> IO [FilePath]
+buildWasip3RuntimeObjects garbageCollector directory = do
+  RuntimePlan {runtimeSources, runtimeIncludeDirectories} <- runtimePlan Wasm32Wasip3 (runtimeGarbageCollector garbageCollector)
+  wasmRuntimeSources <- Wasm.wasip3RuntimeSourcePaths
+  driver <- Wasm.wasip3RuntimeSourcePath
+  world <- Wasm.wasip3WorldPath
+  clangOverride <- lookupEnv "AIHC_WASM_CLANG"
+  let bindingsSource = directory </> "command.c"
+      bindingsObject = directory </> "bindings.o"
+      componentTypeObject = directory </> "command_component_type.o"
+      (clang, clangTargetArguments) = wasmClangCommand clangOverride
+      includeArguments =
+        [ "-I" <> (takeDirectory driver </> "include"),
+          "-I" <> takeDirectory driver,
+          "-I" <> directory
+        ]
+          <> ["-I" <> includeDirectory | includeDirectory <- runtimeIncludeDirectories]
+      cArguments =
+        [ "-O2",
+          "-std=c11",
+          "-ffreestanding",
+          "-fno-builtin",
+          "-nostdlib",
+          "-Wall",
+          "-Wextra",
+          "-Werror"
+        ]
+          <> includeArguments
+  runTool "wit-bindgen" ["c", "--world", "command", "--out-dir", directory, world]
+  runtimeObjects <-
+    forM (zip [0 :: Int ..] (runtimeSources <> wasmRuntimeSources)) $ \(index, source) -> do
+      let object = directory </> "runtime-" <> show index <> ".o"
+      runTool clang (clangTargetArguments <> cArguments <> ["-c", source, "-o", object])
+      pure object
+  runTool clang (clangTargetArguments <> cArguments <> ["-c", bindingsSource, "-o", bindingsObject])
+  pure (runtimeObjects <> [bindingsObject, componentTypeObject])
+
+runtimeGarbageCollector :: GarbageCollector -> RuntimeGarbageCollector
+runtimeGarbageCollector garbageCollector =
+  case garbageCollector of
+    GcCalloc -> RuntimeGcCalloc
+    GcSemispace -> RuntimeGcSemispace
+
+-- | Select the ordinary Clang driver used for WebAssembly objects. Nix can
+-- override only the executable to bypass its host-target compiler wrapper.
+wasmClangCommand :: Maybe FilePath -> (FilePath, [String])
+wasmClangCommand override =
+  (fromMaybe "clang" override, ["--target=" <> nativeTargetTriple Wasm32Wasip3])
+
+wasmOptArguments :: FilePath -> FilePath -> [String]
+wasmOptArguments input output =
+  [input, "-O3", "--enable-tail-call", "--emit-target-features", "-o", output]
+
+runTool :: FilePath -> [String] -> IO ()
+runTool tool arguments = do
+  (exitCode, _stdout, stderr) <- readProcessWithExitCode tool arguments ""
+  case exitCode of
+    ExitSuccess -> pure ()
+    ExitFailure _ -> ioError (userError (tool <> " failed (" <> show exitCode <> "): " <> stderr))
+
+withTemporaryDirectory :: FilePath -> String -> (FilePath -> IO value) -> IO value
+withTemporaryDirectory parent template = bracket acquire removeDirectoryRecursive
+  where
+    acquire = do
+      createDirectoryIfMissing True parent
+      (path, handle) <- openTempFile parent template
+      hClose handle
+      removeFile path
+      createDirectory path
+      pure path

--- a/bin/aihc/src/Aihc/Cli/Store.hs
+++ b/bin/aihc/src/Aihc/Cli/Store.hs
@@ -1,0 +1,38 @@
+-- | Filesystem layout shared by installed runtimes, libraries, and the
+-- compiler that consumes them.
+module Aihc.Cli.Store
+  ( defaultStoreRoot,
+    installedLibrariesActivePath,
+    installedLibrariesRoot,
+    installedRuntimeArchivePath,
+  )
+where
+
+import Aihc.Native (NativeTarget, RuntimeGarbageCollector (..), renderNativeTarget)
+import System.Directory (XdgDirectory (XdgCache), getXdgDirectory)
+import System.FilePath ((</>))
+
+defaultStoreRoot :: IO FilePath
+defaultStoreRoot = do
+  cacheDirectory <- getXdgDirectory XdgCache "aihc"
+  pure (cacheDirectory </> "store")
+
+installedLibrariesRoot :: FilePath -> FilePath
+installedLibrariesRoot storeRoot = storeRoot </> "libraries"
+
+installedLibrariesActivePath :: FilePath -> FilePath
+installedLibrariesActivePath storeRoot = installedLibrariesRoot storeRoot </> "active"
+
+installedRuntimeArchivePath :: FilePath -> NativeTarget -> RuntimeGarbageCollector -> FilePath
+installedRuntimeArchivePath storeRoot target garbageCollector =
+  storeRoot
+    </> "runtimes"
+    </> renderNativeTarget target
+    </> renderGarbageCollector garbageCollector
+    </> "runtime.a"
+
+renderGarbageCollector :: RuntimeGarbageCollector -> FilePath
+renderGarbageCollector garbageCollector =
+  case garbageCollector of
+    RuntimeGcCalloc -> "calloc"
+    RuntimeGcSemispace -> "semispace"

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -5,6 +5,8 @@ module Main (main) where
 import Aihc.Cli.Compile
   ( CompileEnvironment (..),
     compileOutputPath,
+    compileSourceToAssemblyWithDependenciesFor,
+    compileSourceToWholeCoreWithDependencies,
     defaultCompileEnvironment,
     reachableRuntimePrimitiveNames,
     wasmClangCommand,
@@ -22,12 +24,14 @@ import Aihc.Cli.Install
     buildPackagePlanWithResolver,
     checkPackagePlan,
     dryRunInstallScaffold,
+    installPackageLibraries,
     renderInstallFailure,
     renderInstallFailureWithOptions,
     writeInstallScaffold,
   )
-import Aihc.Cli.Options (Command (..), CompileOptions (..), GarbageCollector (..), InstallErrorFormat (..), InstallOptions (..), ReplOptions (..), parseCommandPure)
+import Aihc.Cli.Options (Command (..), CompileOptions (..), GarbageCollector (..), InstallErrorFormat (..), InstallOptions (..), PrepareRuntimeOptions (..), ReplOptions (..), parseCommandPure)
 import Aihc.Cli.Repl (ReplError (..), ReplSession (..), ReplStep (..), defaultReplSettings, evaluateExpression, handleReplInput, loadReplSession, replCompletion)
+import Aihc.Cli.Runtime (prepareRuntimeArchive)
 import Aihc.Fc
   ( FcBind (..),
     FcExpr (..),
@@ -57,7 +61,6 @@ import System.Directory
     createDirectoryIfMissing,
     doesDirectoryExist,
     doesFileExist,
-    getCurrentDirectory,
     getTemporaryDirectory,
     removeDirectoryRecursive,
     removeFile,
@@ -78,32 +81,32 @@ main =
         [ testCase "parses compile source" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False Nothing GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False Nothing GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs"]),
           testCase "parses compile output and keep-asm" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False True False Nothing GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" (Just "hello") False False True False Nothing GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "-o", "hello", "--keep-asm"]),
           testCase "parses keep-core" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False False Nothing GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing True False False False Nothing GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--keep-core"]),
           testCase "parses keep-grin" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False False Nothing GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False True False False Nothing GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--keep-grin"]),
           testCase "parses whole-program compatibility mode" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False True Nothing GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False True Nothing GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--whole-program"]),
           testCase "parses a cross-compilation target" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just LinuxAmd64) GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just LinuxAmd64) GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--target", "linux-amd64"]),
           testCase "rejects the removed portable C target" $
             case parseCommandPure ["compile", "Main.hs", "--target", "portable-c"] of
@@ -112,12 +115,12 @@ main =
           testCase "parses the LLVM target" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just Llvm) GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just Llvm) GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--target", "llvm"]),
           testCase "parses the WASI P3 target" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just Wasm32Wasip3) GcCalloc False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False (Just Wasm32Wasip3) GcCalloc Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--target", "wasm32-wasip3"]),
           testCase "parses optional wasm-opt optimization" $
             case parseCommandPure ["compile", "Main.hs", "--target", "wasm32-wasip3", "--use-wasm-opt"] of
@@ -126,36 +129,51 @@ main =
           testCase "selects the semispace collector" $
             assertEqual
               "command"
-              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False Nothing GcSemispace False)))
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False Nothing GcSemispace Nothing False)))
               (parseCommandPure ["compile", "Main.hs", "--gc", "semispace"]),
+          testCase "selects an installed toolchain store" $
+            assertEqual
+              "command"
+              (Right (CmdCompile (CompileOptions "Main.hs" Nothing False False False False Nothing GcCalloc (Just "/tmp/aihc-store") False)))
+              (parseCommandPure ["compile", "Main.hs", "--store", "/tmp/aihc-store"]),
+          testCase "prepares one installed runtime" $
+            assertEqual
+              "command"
+              (Right (CmdPrepareRuntime (PrepareRuntimeOptions Llvm GcSemispace (Just "/tmp/aihc-store"))))
+              (parseCommandPure ["prepare-runtime", "--target", "llvm", "--gc", "semispace", "--store", "/tmp/aihc-store"]),
           testCase "derives safe default compile output paths" $ do
-            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False False Nothing GcCalloc False))
-            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False False Nothing GcCalloc False)),
+            assertEqual "Haskell source" "src/Main" (compileOutputPath (CompileOptions "src/Main.hs" Nothing False False False False Nothing GcCalloc Nothing False))
+            assertEqual "extensionless source" "program.out" (compileOutputPath (CompileOptions "program" Nothing False False False False Nothing GcCalloc Nothing False)),
           testCase "parses install package" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text"]),
           testCase "parses install version" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" (Just "2.1") Nothing False False False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" (Just "2.1") Nothing False False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--version", "2.1"]),
           testCase "parses install offline and store" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") True False False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") True False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--offline", "--store", "/tmp/aihc-store"]),
           testCase "parses install dry run" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False True False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False True [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--dry-run"]),
           testCase "parses first error module and JSON errors" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False True InstallErrorsJson)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False [] True InstallErrorsJson)))
               (parseCommandPure ["install", "text", "--first-error-module", "--json-errors"]),
+          testCase "parses install targets" $
+            assertEqual
+              "command"
+              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") False False [Llvm, Wasm32Wasip3] False InstallErrorsHuman)))
+              (parseCommandPure ["install", "text", "--store", "/tmp/aihc-store", "--target", "llvm", "--target", "wasm32-wasip3"]),
           testCase "rejects explicit dependency variants" $
             assertLeftContains "dependency" (parseCommandPure ["install", "a", "--dependency", "b=1.0.0:abcdef"]),
           testCase "parses repl" $
@@ -173,6 +191,8 @@ main =
               "wasm-opt arguments"
               ["input.wasm", "-O3", "--enable-tail-call", "--emit-target-features", "-o", "output.wasm"]
               (wasmOptArguments "input.wasm" "output.wasm"),
+          testCase "compiles against an installed package without its sources" test_installedPackage,
+          testCase "prepares an installed runtime archive" test_preparedRuntime,
           testCase "validates only primitives that survive GRIN lowering" test_runtimePrimitiveValidation,
           testCase "uses the shared XDG cache for compiled dependencies" test_compileDefaultEnvironment
         ],
@@ -614,7 +634,7 @@ test_rendersPreprocessedSourceForRenameErrors =
 
 defaultInstallOptionsForTest :: InstallOptions
 defaultInstallOptionsForTest =
-  InstallOptions "demo" Nothing Nothing False False False InstallErrorsHuman
+  InstallOptions "demo" Nothing Nothing False False [] False InstallErrorsHuman
 
 syntheticInstallFailure :: InstallFailure
 syntheticInstallFailure =
@@ -889,10 +909,8 @@ test_compileDefaultEnvironment =
       ( \_ -> do
           setEnv "XDG_CACHE_HOME" cacheHome
           withCurrentDirectory workingDirectory $ do
-            actualWorkingDirectory <- getCurrentDirectory
             environment <- defaultCompileEnvironment
-            assertEqual "core libraries" (actualWorkingDirectory </> "core-libs") (compileCoreLibraryRoot environment)
-            assertEqual "compiled dependency cache" (cacheHome </> "aihc" </> "libraries") (compileCacheRoot environment)
+            assertEqual "installed toolchain store" (cacheHome </> "aihc" </> "store") (compileInstalledStoreRoot environment)
       )
   where
     restoreCacheHome Nothing = unsetEnv "XDG_CACHE_HOME"
@@ -914,6 +932,67 @@ test_runtimePrimitiveValidation = do
       grin = Grin.lowerProgram core
       reachable = reachableRuntimePrimitiveNames "main" (extractReachabilityInterface core) [grin]
   assertEqual "runtime primitives" (Set.singleton "kept#") reachable
+
+test_installedPackage :: Assertion
+test_installedPackage =
+  withTempDir "aihc-installed-package" $ \root -> do
+    let sourceRoot = root </> "prim-fixture"
+        primSource = sourceRoot </> "src" </> "GHC" </> "Prim.hs"
+        cabalFile = sourceRoot </> "prim-fixture.cabal"
+        storeRoot = root </> "store"
+        environment = CompileEnvironment storeRoot
+        mainSource =
+          T.unlines
+            [ "{-# LANGUAGE MagicHash #-}",
+              "{-# LANGUAGE NoImplicitPrelude #-}",
+              "module Main where",
+              "import GHC.Prim",
+              "main = Unit"
+            ]
+    createDirectoryIfMissing True (takeDirectory primSource)
+    writeFile
+      cabalFile
+      ( unlines
+          [ "cabal-version: 3.8",
+            "name: prim-fixture",
+            "version: 0.1.0.0",
+            "build-type: Simple",
+            "library",
+            "  exposed-modules: GHC.Prim",
+            "  hs-source-dirs: src",
+            "  default-extensions: NoImplicitPrelude",
+            "  default-language: GHC2021"
+          ]
+      )
+    writeFile
+      primSource
+      ( unlines
+          [ "{-# LANGUAGE MagicHash #-}",
+            "{-# LANGUAGE NoImplicitPrelude #-}",
+            "module GHC.Prim where",
+            "data Unit = Unit"
+          ]
+      )
+    plan <- buildPackagePlanFromSource storeRoot (PackageSpec "prim-fixture" "0.1.0.0") sourceRoot
+    installResult <- installPackageLibraries [Llvm] plan
+    case installResult of
+      Left err -> assertFailure err
+      Right _ -> pure ()
+    removeDirectoryRecursive sourceRoot
+    compileResult <- compileSourceToAssemblyWithDependenciesFor Llvm environment "Main.hs" mainSource
+    case compileResult of
+      Left err -> assertFailure (show err)
+      Right assembly -> assertBool "expected installed dependency initializer" ("_aihc_init_" `T.isInfixOf` assembly)
+    wholeResult <- compileSourceToWholeCoreWithDependencies environment "Main.hs" mainSource
+    case wholeResult of
+      Left err -> assertFailure (show err)
+      Right core -> assertBool "expected installed dependency body" ("main" `T.isInfixOf` core)
+
+test_preparedRuntime :: Assertion
+test_preparedRuntime =
+  withTempDir "aihc-prepared-runtime" $ \root -> do
+    archive <- prepareRuntimeArchive root Llvm GcCalloc
+    assertFileExists archive
 
 assertFileExists :: FilePath -> Assertion
 assertFileExists path = do

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages:
   core-libs/aihc-base
   core-libs/aihc-internal
+  core-libs/aihc-prim
   bin/aihc
   components/aihc-resolve
   components/aihc-tc

--- a/core-libs/aihc-base/aihc-base.cabal
+++ b/core-libs/aihc-base/aihc-base.cabal
@@ -252,6 +252,7 @@ library
     GHC.Internal.Integer
 
   hs-source-dirs: src
+  build-depends: aihc-prim ==0.13.0
   default-extensions: NoImplicitPrelude
   ghc-options: -Wall
   default-language: GHC2021

--- a/core-libs/aihc-base/src/GHC/Enum.hs
+++ b/core-libs/aihc-base/src/GHC/Enum.hs
@@ -14,6 +14,7 @@ where
 
 import Data.Bool (Bool (..))
 import GHC.Int (Int (..))
+import Prelude (Char)
 
 class Bounded a where
   minBound :: a

--- a/docs/installed-toolchain.md
+++ b/docs/installed-toolchain.md
@@ -1,0 +1,44 @@
+# Installed runtimes and libraries
+
+`aihc compile` consumes prepared runtime archives and installed library
+artifacts. It does not compile either dependency from source while building an
+application.
+
+Prepare every runtime variant that applications will select:
+
+```console
+aihc prepare-runtime --target llvm --gc calloc --store "$AIHC_STORE"
+aihc prepare-runtime --target llvm --gc semispace --store "$AIHC_STORE"
+aihc prepare-runtime --target wasm32-wasip3 --gc calloc --store "$AIHC_STORE"
+```
+
+Then install the packages needed by the applications. Package dependencies are
+installed recursively, and Cabal metadata selects the library modules. The
+frontend is compiled once even when several targets are requested:
+
+```console
+aihc install core-libs/aihc-base \
+  --offline \
+  --store "$AIHC_STORE" \
+  --target llvm \
+  --target wasm32-wasip3
+```
+
+Application compilation only selects the installed store, target, and runtime
+variant:
+
+```console
+aihc compile Main.hs \
+  --store "$AIHC_STORE" \
+  --target llvm \
+  --gc calloc \
+  --output program
+```
+
+There is no special core-library installation mechanism: `aihc-base` and
+`aihc-prim` are ordinary packages, with the latter installed through the
+former's package dependency. The store contains content-addressed library
+interfaces and whole-program bodies, target-specific library archives, and
+runtime archives keyed by target and garbage collector. An incomplete store is
+an error; application compilation never fills in missing artifacts by rebuilding
+source dependencies.

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -7,10 +7,6 @@
   wasmLd = pkgs.writeShellScriptBin "wasm-ld" ''
     exec ${pkgs.lld}/bin/wasm-ld "$@"
   '';
-  wasmOpt = pkgs.writeShellScriptBin "wasm-opt" ''
-    printf 'invoked\n' >> "''${AIHC_WASM_OPT_MARKER:?}"
-    exec ${pkgs.binaryen}/bin/wasm-opt "$@"
-  '';
   examplesSource = sources.examplesSrc pkgs;
   exampleEntries = builtins.readDir "${examplesSource}/examples";
   exampleNames = builtins.filter (
@@ -101,10 +97,6 @@
       name = "incremental";
       flags = [];
     }
-    {
-      name = "whole-program";
-      flags = ["--whole-program"];
-    }
   ];
   garbageCollectors = ["calloc" "semispace"];
   nativeBackendBySystem = {
@@ -113,6 +105,8 @@
   };
   nativeBackend = nativeBackendBySystem.${pkgs.stdenv.hostPlatform.system} or null;
   backends = ["llvm"] ++ pkgs.lib.optional (nativeBackend != null) nativeBackend;
+  exampleToolchainTargets = ["llvm"] ++ pkgs.lib.optional (nativeBackend != null) nativeBackend ++ ["wasm32-wasip3"];
+  exampleToolchainTargetArguments = builtins.concatMap (target: ["--target" target]) exampleToolchainTargets;
   compilationMatrix = builtins.concatLists (
     map (
       backend:
@@ -143,10 +137,7 @@
     else if exampleName == "exceptions-sync"
     then allBackendSmokeMatrix
     else smokeCompilationMatrix;
-  wasip3CompilationModes = exampleName:
-    if exampleName == "hello-world"
-    then compilationModes
-    else [smokeCompilation];
+  wasip3CompilationModes = _exampleName: compilationModes;
 
   renderExampleTest = {
     backend,
@@ -173,6 +164,7 @@
     if timeout --foreground --kill-after=5s 120s ${aihcExe} compile "$source" \
       --target ${backend} \
       --gc ${gc} \
+      --store ${exampleToolchain} \
       ${pkgs.lib.escapeShellArgs compilation.flags} \
       --output "$executable"; then
       :
@@ -242,7 +234,7 @@
     fi
     if timeout --foreground --kill-after=5s 120s ${aihcExe} compile "$source" \
       --target wasm32-wasip3 \
-      --use-wasm-opt \
+      --store ${exampleToolchain} \
       ${pkgs.lib.escapeShellArgs compilation.flags} \
       --output "$executable"; then
       :
@@ -383,6 +375,44 @@
     test "$failed" -eq 0
   '';
 
+  # The compiler owns preparation of the installed toolchain. Runtime archives
+  # are built once per backend/GC pair, and ordinary package installation emits
+  # the reusable library interfaces and target-specific archives.
+  exampleToolchain =
+    pkgs.runCommand "aihc-example-toolchain" {
+      src = sources.coreLibrariesSrc pkgs;
+      nativeBuildInputs = [
+        pkgs.llvmPackages.bintools
+        pkgs.llvmPackages.clang
+        pkgs.llvmPackages.clang-unwrapped
+        pkgs.wasm-tools
+        pkgs.wit-bindgen
+        wasmLd
+      ];
+    } ''
+      cd "$src"
+      export GHCRTS=-N1
+      export AIHC_WASM_CLANG=${pkgs.llvmPackages.clang-unwrapped}/bin/clang
+      mkdir -p "$out"
+
+      ${aihcExe} prepare-runtime --target llvm --gc calloc --store "$out"
+      ${aihcExe} prepare-runtime --target llvm --gc semispace --store "$out"
+      ${pkgs.lib.optionalString (nativeBackend != null) ''
+        ${aihcExe} prepare-runtime --target ${nativeBackend} --gc calloc --store "$out"
+        ${aihcExe} prepare-runtime --target ${nativeBackend} --gc semispace --store "$out"
+      ''}
+      ${aihcExe} prepare-runtime --target wasm32-wasip3 --gc calloc --store "$out"
+
+      ${aihcExe} install core-libs/aihc-base \
+        --offline \
+        --store "$out" \
+        ${pkgs.lib.escapeShellArgs exampleToolchainTargetArguments}
+
+      test -f "$out/libraries/active"
+      test -n "$(find "$out/libraries" -type f -name 'interfaces.cache' -print -quit)"
+      test -n "$(find "$out/libraries" -type f -name 'libaihc-base.a' -print -quit)"
+    '';
+
   exampleTestInputs = [
     pkgs.coreutils
     pkgs.diffutils
@@ -394,7 +424,6 @@
   mkExampleTest = exampleName:
     mkSourceCheck "aihc-example-${exampleName}" (sources.exampleSrc exampleName pkgs) exampleTestInputs ''
       set -euo pipefail
-      export XDG_CACHE_HOME="$TMPDIR/cache"
       export GHCRTS=-N1
       empty_stderr="$TMPDIR/empty-stderr"
       touch "$empty_stderr"
@@ -436,8 +465,8 @@
 
   # Every example gets one LLVM smoke test. The synchronous exception example
   # also exercises the host-native backend, while Hello World carries the
-  # complete backend/mode/GC matrix. Nix schedules independent examples in
-  # parallel.
+  # complete backend/GC matrix. Nix schedules independent examples in
+  # parallel against the immutable shared library and runtime artifacts.
   examplesTests = assert exampleNames != [];
     pkgs.linkFarm "aihc-examples-tests" exampleCases;
 
@@ -451,16 +480,13 @@
     pkgs.wasmtime
     pkgs.wit-bindgen
     wasmLd
-    wasmOpt
   ];
 
   mkWasip3ExampleTest = exampleName:
     mkSourceCheck "aihc-wasip3-example-${exampleName}" (sources.exampleSrc exampleName pkgs) wasip3ExampleInputs ''
       set -euo pipefail
-      export XDG_CACHE_HOME="$TMPDIR/cache"
       export GHCRTS=-N1
       export AIHC_WASM_CLANG=${pkgs.llvmPackages.clang-unwrapped}/bin/clang
-      export AIHC_WASM_OPT_MARKER="$TMPDIR/wasm-opt-invocations"
       empty_stderr="$TMPDIR/empty-stderr"
       touch "$empty_stderr"
 
@@ -475,9 +501,6 @@
 
       ${pkgs.lib.concatMapStringsSep "\n" renderWasip3ExampleTest (wasip3CompilationModes exampleName)}
 
-      test -n "$(find "$XDG_CACHE_HOME/aihc/libraries" -type f -name '*.o' -print -quit)"
-      test -n "$(find "$XDG_CACHE_HOME/aihc/libraries" -type f -name '*.a' -print -quit)"
-      test "$(wc -l < "$AIHC_WASM_OPT_MARKER")" -eq ${toString (builtins.length (wasip3CompilationModes exampleName))}
       touch "$out"
     '';
 
@@ -488,8 +511,10 @@
     })
     exampleNames;
 
-  # Every example gets one incremental WASI smoke test. Hello World additionally
-  # covers whole-program mode. Nix schedules these derivations in parallel.
+  # Every example gets one incremental WASI smoke test. Nix schedules these
+  # derivations in parallel against the immutable shared library and runtime
+  # artifacts. Whole-program linking has focused CLI coverage because it
+  # intentionally recompiles the merged dependency bodies.
   wasip3ExampleTest = assert exampleNames != [];
     pkgs.linkFarm "aihc-wasip3-example-test" wasip3ExampleCases;
 in {

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -169,10 +169,12 @@ in rec {
     ".cabal"
   ];
 
-  examplesSrc = mkRootSubsetSrc ["core-libs/" "examples/"] exampleSourceSuffixes;
+  examplesSrc = mkRootSubsetSrc ["examples/"] exampleSourceSuffixes;
+
+  coreLibrariesSrc = mkRootSubsetSrc ["core-libs/"] exampleSourceSuffixes;
 
   exampleSrc = exampleName:
-    mkRootSubsetSrc ["core-libs/" "examples/${exampleName}/"] exampleSourceSuffixes;
+    mkRootSubsetSrc ["examples/${exampleName}/"] exampleSourceSuffixes;
 
   fmtSrc = mkComponentSrc "/bin/aihc-fmt" [
     ".hs"


### PR DESCRIPTION
## Summary

- add `aihc prepare-runtime` to compile and install one runtime archive per backend/GC pair
- make target-aware `aihc install` compile any Cabal library package closure and emit reusable frontend artifacts plus target-specific archives
- accept local package directories and resolve sibling packages from ordinary Cabal dependencies, so the example toolchain uses `aihc install core-libs/aihc-base`
- make `aihc compile --store DIR` consume installed artifacts only, with no module-root list or source-compilation fallback
- build one installed toolchain in Nix and share it across source-minimal native, LLVM, and WASI example derivations

## Why

The previous example checks optimized an on-demand source cache by forcing every program onto a manually enumerated module closure. The first revision replaced that with a dedicated core-library command, but core libraries are packages and do not warrant a separate installation mechanism.

This revision puts the boundary at generic package installation. Cabal metadata chooses the modules and dependency closure. Runtime preparation and library installation happen before application compilation, and missing installed artifacts are errors rather than triggers for source rebuilding.

## Impact

- all 13 LLVM examples compile in 0.26–0.41 seconds using only the installed store
- example source derivations contain only the individual example sources, not `core-libs`
- `aihc-base` declares its ordinary `aihc-prim` package dependency; no module list appears in Nix or the CLI
- `--whole-program` remains an explicitly slower mode because it intentionally recompiles merged dependency bodies; it has focused CLI coverage instead of participating in the fast example matrix

## Progress

- installed library frontend builds: 1 package closure (`aihc-base` plus `aihc-prim`) per toolchain
- installed library backend builds: 3 target archive sets (LLVM, host-native, WASI-P3)
- runtime builds on aarch64-darwin: 5 installed variants (LLVM × 2 GCs, Apple ARM64 × 2 GCs, WASI-P3 calloc)
- fast compile-and-run coverage: 30 cases (17 native/LLVM and 13 WASI-P3)

## Validation

- `just fmt`
- `just check`
- `nix build .#checks.aarch64-darwin.examples-tests --print-build-logs`
- `nix build .#checks.aarch64-darwin.wasip3-example-test --print-build-logs`
- direct source-isolated timing of every LLVM example against the exact Nix-built installed toolchain

All checks pass on top of `origin/main` at `579ea4dbf`.