### PR TITLE
fix(wasm): explain missing clang target

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -33,7 +33,7 @@ import Aihc.Cli.Compile.Dependencies
     buildDependencies,
   )
 import Aihc.Cli.Options (CompileOptions (..), GarbageCollector (..))
-import Aihc.Cli.Runtime (runtimeGarbageCollector, wasmClangCommand, wasmOptArguments)
+import Aihc.Cli.Runtime (readWasmClangProcessWithExitCode, runtimeGarbageCollector, wasmClangCommand, wasmOptArguments)
 import Aihc.Cli.Store (defaultStoreRoot, installedRuntimeArchivePath)
 import Aihc.Fc
   ( DesugarResult (..),
@@ -544,7 +544,7 @@ assembleWasip3 storeRoot garbageCollector useWasmOpt output assemblyPath archive
         coreModule = directory </> "core.wasm"
         linkedCoreModule = maybe coreModule (const unoptimizedCoreModule) wasmOpt
         (clang, clangTargetArguments) = wasmClangCommand clangOverride
-    runTool clang (clangTargetArguments <> ["-mtail-call", "-c", assemblyPath, "-o", programObject])
+    runWasmClangTool clang (clangTargetArguments <> ["-mtail-call", "-c", assemblyPath, "-o", programObject])
     runtimeArchive <- requireInstalledRuntime storeRoot Wasm32Wasip3 garbageCollector
     runTool
       "wasm-ld"
@@ -575,6 +575,13 @@ runTool tool arguments = do
   case exitCode of
     ExitSuccess -> pure ()
     ExitFailure _ -> ioError (userError (renderCompileError (CompileToolError tool exitCode stderr)))
+
+runWasmClangTool :: FilePath -> [String] -> IO ()
+runWasmClangTool clang arguments = do
+  (exitCode, _stdout, stderr) <- readWasmClangProcessWithExitCode clang arguments
+  case exitCode of
+    ExitSuccess -> pure ()
+    ExitFailure _ -> ioError (userError (renderCompileError (CompileToolError clang exitCode stderr)))
 
 backendSourceExtension :: NativeTarget -> String
 backendSourceExtension Llvm = ".ll"

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -17,7 +17,7 @@ where
 
 import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
-import Aihc.Cli.Runtime (wasmClangCommand)
+import Aihc.Cli.Runtime (readWasmClangProcessWithExitCode, wasmClangCommand)
 import Aihc.Cli.Store (installedLibrariesActivePath, installedLibrariesRoot)
 import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, optimizeProgram)
 import Aihc.Grin qualified as Grin
@@ -578,7 +578,10 @@ buildObject target layout unit = do
                 objectPath = temporary </> "module.o"
             TIO.writeFile sourcePath backendSource
             (compiler, arguments) <- objectCompiler target sourcePath objectPath
-            (exitCode, _stdout, stderr) <- readProcessWithExitCode compiler arguments ""
+            (exitCode, _stdout, stderr) <-
+              case target of
+                Wasm32Wasip3 -> readWasmClangProcessWithExitCode compiler arguments
+                _ -> readProcessWithExitCode compiler arguments ""
             case exitCode of
               ExitSuccess -> renameFile objectPath destination >> pure (Right ())
               ExitFailure _ -> pure (Left ("failed to compile dependency unit " <> dependencyUnitLabel (backendDependencyUnit unit) <> ": " <> stderr))

--- a/bin/aihc/src/Aihc/Cli/Runtime.hs
+++ b/bin/aihc/src/Aihc/Cli/Runtime.hs
@@ -4,6 +4,7 @@
 -- ordinary program links consume those immutable artifacts.
 module Aihc.Cli.Runtime
   ( prepareRuntimeArchive,
+    readWasmClangProcessWithExitCode,
     runPrepareRuntime,
     runtimeGarbageCollector,
     wasmClangCommand,
@@ -30,6 +31,7 @@ import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory, (</>))
 import System.IO (hClose, openTempFile)
+import System.IO.Error (tryIOError)
 import System.Process (readProcessWithExitCode)
 
 runPrepareRuntime :: PrepareRuntimeOptions -> IO ()
@@ -102,9 +104,9 @@ buildWasip3RuntimeObjects garbageCollector directory = do
   runtimeObjects <-
     forM (zip [0 :: Int ..] (runtimeSources <> wasmRuntimeSources)) $ \(index, source) -> do
       let object = directory </> "runtime-" <> show index <> ".o"
-      runTool clang (clangTargetArguments <> cArguments <> ["-c", source, "-o", object])
+      runWasmClangTool clang (clangTargetArguments <> cArguments <> ["-c", source, "-o", object])
       pure object
-  runTool clang (clangTargetArguments <> cArguments <> ["-c", bindingsSource, "-o", bindingsObject])
+  runWasmClangTool clang (clangTargetArguments <> cArguments <> ["-c", bindingsSource, "-o", bindingsObject])
   pure (runtimeObjects <> [bindingsObject, componentTypeObject])
 
 runtimeGarbageCollector :: GarbageCollector -> RuntimeGarbageCollector
@@ -122,6 +124,57 @@ wasmClangCommand override =
 wasmOptArguments :: FilePath -> FilePath -> [String]
 wasmOptArguments input output =
   [input, "-O3", "--enable-tail-call", "--emit-target-features", "-o", output]
+
+-- | Run Clang and, after a WebAssembly compilation failure, inspect its
+-- registered targets so a target-limited installation gets an actionable
+-- diagnostic without obscuring Clang's original error.
+readWasmClangProcessWithExitCode :: FilePath -> [String] -> IO (ExitCode, String, String)
+readWasmClangProcessWithExitCode clang arguments = do
+  result@(exitCode, stdout, stderr) <- readProcessWithExitCode clang arguments ""
+  case exitCode of
+    ExitSuccess -> pure result
+    ExitFailure _ -> do
+      targetsResult <- tryIOError (readProcessWithExitCode clang ["-print-targets"] "")
+      pure
+        ( exitCode,
+          stdout,
+          case targetsResult of
+            Right (ExitSuccess, targets, _targetsStderr)
+              | not (hasWasm32Target targets) -> appendWasm32TargetNotice stderr
+            _ -> stderr
+        )
+
+hasWasm32Target :: String -> Bool
+hasWasm32Target = any lineIsWasm32Target . lines
+  where
+    lineIsWasm32Target line =
+      case words line of
+        target : _ -> target == "wasm32"
+        [] -> False
+
+appendWasm32TargetNotice :: String -> String
+appendWasm32TargetNotice originalError =
+  originalError
+    <> separator
+    <> unlines
+      [ "AIHC notice: this Clang installation does not include the wasm32 target.",
+        "The default Clang shipped with macOS omits WebAssembly support. Install LLVM Clang",
+        "with Homebrew (`brew install llvm`) or Nix",
+        "(`nix shell nixpkgs#llvmPackages.clang-unwrapped`), then set AIHC_WASM_CLANG",
+        "to that Clang executable."
+      ]
+  where
+    separator
+      | null originalError = ""
+      | last originalError == '\n' = "\n"
+      | otherwise = "\n\n"
+
+runWasmClangTool :: FilePath -> [String] -> IO ()
+runWasmClangTool clang arguments = do
+  (exitCode, _stdout, stderr) <- readWasmClangProcessWithExitCode clang arguments
+  case exitCode of
+    ExitSuccess -> pure ()
+    ExitFailure _ -> ioError (userError (clang <> " failed (" <> show exitCode <> "): " <> stderr))
 
 runTool :: FilePath -> [String] -> IO ()
 runTool tool arguments = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -31,7 +31,7 @@ import Aihc.Cli.Install
   )
 import Aihc.Cli.Options (Command (..), CompileOptions (..), GarbageCollector (..), InstallErrorFormat (..), InstallOptions (..), PrepareRuntimeOptions (..), ReplOptions (..), parseCommandPure)
 import Aihc.Cli.Repl (ReplError (..), ReplSession (..), ReplStep (..), defaultReplSettings, evaluateExpression, handleReplInput, loadReplSession, replCompletion)
-import Aihc.Cli.Runtime (prepareRuntimeArchive)
+import Aihc.Cli.Runtime (prepareRuntimeArchive, readWasmClangProcessWithExitCode)
 import Aihc.Fc
   ( FcBind (..),
     FcExpr (..),
@@ -57,16 +57,20 @@ import Data.Set qualified as Set
 import Data.Text qualified as T
 import System.Console.Haskeline qualified as Haskeline
 import System.Directory
-  ( createDirectory,
+  ( Permissions (executable),
+    createDirectory,
     createDirectoryIfMissing,
     doesDirectoryExist,
     doesFileExist,
+    getPermissions,
     getTemporaryDirectory,
     removeDirectoryRecursive,
     removeFile,
+    setPermissions,
     withCurrentDirectory,
   )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory, takeFileName, (</>))
 import System.IO (hClose, openTempFile)
 import Test.Tasty (defaultMain, testGroup)
@@ -186,6 +190,7 @@ main =
         [ testCase "uses standard Clang for the WebAssembly target" $ do
             assertEqual "default command" ("clang", ["--target=wasm32-unknown-unknown"]) (wasmClangCommand Nothing)
             assertEqual "configured command" ("custom-clang", ["--target=wasm32-unknown-unknown"]) (wasmClangCommand (Just "custom-clang")),
+          testCase "explains when Clang has no wasm32 target" test_missingWasm32ClangTarget,
           testCase "enables Binaryen optimization and tail calls" $
             assertEqual
               "wasm-opt arguments"
@@ -1231,3 +1236,37 @@ withTempDir prefix action = do
     (pure tempFile)
     removeDirectoryRecursive
     action
+
+test_missingWasm32ClangTarget :: Assertion
+test_missingWasm32ClangTarget = do
+  withFakeClang "  arm64 - AArch64\n  x86-64 - 64-bit X86\n" $ \clang -> do
+    (exitCode, _stdout, stderr) <- readWasmClangProcessWithExitCode clang ["--target=wasm32-unknown-unknown"]
+    assertEqual "Clang failure" (ExitFailure 1) exitCode
+    assertBool "original Clang error" ("original Clang failure" `isInfixOf` stderr)
+    assertBool "missing target notice" ("does not include the wasm32 target" `isInfixOf` stderr)
+    assertBool "Homebrew advice" ("brew install llvm" `isInfixOf` stderr)
+    assertBool "Nix advice" ("nix shell nixpkgs#llvmPackages.clang-unwrapped" `isInfixOf` stderr)
+  withFakeClang "  wasm32 - WebAssembly 32-bit\n" $ \clang -> do
+    (exitCode, _stdout, stderr) <- readWasmClangProcessWithExitCode clang ["--target=wasm32-unknown-unknown"]
+    assertEqual "Clang failure" (ExitFailure 1) exitCode
+    assertEqual "supported target error" "original Clang failure\n" stderr
+
+withFakeClang :: String -> (FilePath -> IO a) -> IO a
+withFakeClang targets action =
+  withTempDir "aihc-fake-clang" $ \directory -> do
+    let clang = directory </> "clang"
+    writeFile
+      clang
+      ( unlines
+          [ "#!/bin/sh",
+            "if [ \"$1\" = \"-print-targets\" ]; then",
+            "  printf '%s' '" <> targets <> "'",
+            "  exit 0",
+            "fi",
+            "printf '%s\\n' 'original Clang failure' >&2",
+            "exit 1"
+          ]
+      )
+    permissions <- getPermissions clang
+    setPermissions clang permissions {executable = True}
+    action clang


### PR DESCRIPTION
## Summary

- probe `clang -print-targets` after a failed `wasm32-unknown-unknown` compilation
- preserve the original Clang error and append an actionable notice when `wasm32` is not registered
- recommend Homebrew or Nix LLVM Clang and explain how to select it with `AIHC_WASM_CLANG`
- apply the diagnostic consistently to program, dependency, and runtime object compilation
- add regression coverage for Clang installations with and without the `wasm32` target

## Root cause and impact

Apple's default Clang is built without LLVM's WebAssembly backend. AIHC previously surfaced only Clang's low-level target error, leaving macOS users without a clear remediation path. The new notice identifies the missing backend while retaining the original compiler diagnostic.

## Progress counts

No language-feature, backend-progress, or fixture status counts changed.

## Validation

- `cabal test -v0 aihc:spec --test-options='--hide-successes'`
- `just fmt`
- `just check`
