### PR TITLE
feat(base): implement Show

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -197,7 +197,7 @@ data LibraryPackage = LibraryPackage
   deriving (Eq, Show)
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 26
+cacheSchemaVersion = 27
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -463,7 +463,7 @@ test_plansLibraryComponentsWithoutExecutables =
     createDirectoryIfMissing True storeRoot
     writeFile (sourceRoot </> "demo.cabal") libraryOnlyInstallCabal
     writeFile (sourceRoot </> "src" </> "Demo.hs") "module Demo where\nimport Demo.Internal\nimport Dep\nx = depId internalValue\n"
-    writeFile (sourceRoot </> "internal" </> "Demo" </> "Internal.hs") "module Demo.Internal where\ninternalValue = ()\n"
+    writeFile (sourceRoot </> "internal" </> "Demo" </> "Internal.hs") ("module Demo.Internal where\ninternalValue = ()\n" <> fixtureTupleDeclaration)
     writeFile (sourceRoot </> "app" </> "Main.hs") "module Main where\nthis executable is intentionally invalid\n"
     createFixturePackageWithSource depRoot "dep" "1.0.0" "Dep" [] "module Dep where\ndepId x = x\n"
 
@@ -1033,7 +1033,7 @@ withFixturePackage action =
     createDirectoryIfMissing True storeRoot
     writeFile (sourceRoot </> "demo.cabal") demoCabal
     writeFile (sourceRoot </> "Setup.hs") "import Distribution.Simple\nmain = defaultMain\n"
-    writeFile (srcDir </> "Demo.hs") "module Demo where\nx = ()\n"
+    writeFile (srcDir </> "Demo.hs") ("module Demo where\nx = ()\n" <> fixtureTupleDeclaration)
     action sourceRoot storeRoot
 
 withDependencyFixture :: (FilePath -> FilePath -> FilePath -> FilePath -> IO a) -> IO a
@@ -1111,7 +1111,7 @@ createFixturePackageWithOtherModules sourceRoot name version moduleName otherMod
   createDirectoryIfMissing True srcDir
   writeFile (sourceRoot </> name <> ".cabal") (fixtureCabal name version moduleName otherModules dependencies)
   writeFile (sourceRoot </> "Setup.hs") "import Distribution.Simple\nmain = defaultMain\n"
-  writeFile (srcDir </> moduleName <> ".hs") ("module " <> moduleName <> " where\nx = ()\n")
+  writeFile (srcDir </> moduleName <> ".hs") ("module " <> moduleName <> " where\nx = ()\n" <> fixtureTupleDeclaration)
 
 createFixturePackageWithSource :: FilePath -> String -> String -> String -> [String] -> String -> IO ()
 createFixturePackageWithSource sourceRoot name version moduleName dependencies source = do
@@ -1119,7 +1119,13 @@ createFixturePackageWithSource sourceRoot name version moduleName dependencies s
   createDirectoryIfMissing True srcDir
   writeFile (sourceRoot </> name <> ".cabal") (fixtureCabal name version moduleName [] dependencies)
   writeFile (sourceRoot </> "Setup.hs") "import Distribution.Simple\nmain = defaultMain\n"
-  writeFile (srcDir </> moduleName <> ".hs") source
+  writeFile (srcDir </> moduleName <> ".hs") (source <> fixtureTupleDeclaration)
+
+-- Installer fixtures intentionally have no dependency on the core libraries.
+-- Supply the primitive nullary tuple declaration in source so they exercise
+-- the same ordinary-constructor path as packages which depend on aihc-prim.
+fixtureTupleDeclaration :: String
+fixtureTupleDeclaration = "\ndata FixtureUnit = ()\n"
 
 createCoreProviderFixtures :: FilePath -> IO ()
 createCoreProviderFixtures root = do

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -31,9 +31,8 @@ import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
 import Data.Yaml qualified as Y
-import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
+import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
 
 data ExpectedStatus
@@ -72,24 +71,19 @@ loadFcCases = do
   if not exists
     then pure []
     else do
-      tupleSourcePath <- findTupleSource
-      tupleSource <- TIO.readFile tupleSourcePath
       paths <- listFixtureFiles fixtureRoot
-      mapM (loadFcCase [tupleSource]) paths
+      mapM (loadFcCase [tupleSupportModule]) paths
 
-findTupleSource :: IO FilePath
-findTupleSource = getCurrentDirectory >>= findUp
-  where
-    findUp directory = do
-      let candidate = directory </> "core-libs" </> "aihc-prim" </> "src" </> "GHC" </> "Tuple.hs"
-      exists <- doesFileExist candidate
-      if exists
-        then pure candidate
-        else do
-          let parent = takeDirectory directory
-          if parent == directory
-            then fail "could not find core-libs/aihc-prim/src/GHC/Tuple.hs"
-            else findUp parent
+-- Golden modules deliberately omit core-library dependencies. Keep their
+-- primitive tuple support source-defined while limiting the fixture to the
+-- arities exercised here; integration fixtures load the real aihc-prim module.
+tupleSupportModule :: Text
+tupleSupportModule =
+  T.unlines
+    [ "module GHC.Tuple where",
+      "data Unit = ()",
+      "data Tuple2 a b = (a, b)"
+    ]
 
 loadFcCase :: [Text] -> FilePath -> IO FcCase
 loadFcCase supportModules path = do

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -31,8 +31,9 @@ import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import Data.Yaml qualified as Y
-import System.Directory (doesDirectoryExist, listDirectory)
+import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
 
 data ExpectedStatus
@@ -54,6 +55,7 @@ data FcCase = FcCase
     caseCategory :: !String,
     casePath :: !FilePath,
     caseExtensions :: ![Extension],
+    caseSupportModules :: ![Text],
     caseModules :: ![Text],
     caseExpected :: !String,
     caseStatus :: !ExpectedStatus,
@@ -70,20 +72,36 @@ loadFcCases = do
   if not exists
     then pure []
     else do
+      tupleSourcePath <- findTupleSource
+      tupleSource <- TIO.readFile tupleSourcePath
       paths <- listFixtureFiles fixtureRoot
-      mapM loadFcCase paths
+      mapM (loadFcCase [tupleSource]) paths
 
-loadFcCase :: FilePath -> IO FcCase
-loadFcCase path = do
+findTupleSource :: IO FilePath
+findTupleSource = getCurrentDirectory >>= findUp
+  where
+    findUp directory = do
+      let candidate = directory </> "core-libs" </> "aihc-prim" </> "src" </> "GHC" </> "Tuple.hs"
+      exists <- doesFileExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory directory
+          if parent == directory
+            then fail "could not find core-libs/aihc-prim/src/GHC/Tuple.hs"
+            else findUp parent
+
+loadFcCase :: [Text] -> FilePath -> IO FcCase
+loadFcCase supportModules path = do
   raw <- Y.decodeFileEither path
   case raw of
     Left err -> fail ("Invalid YAML fixture " <> path <> ": " <> Y.prettyPrintParseException err)
-    Right value -> case parseFcFixture path value of
+    Right value -> case parseFcFixture supportModules path value of
       Left e -> fail e
       Right c -> pure c
 
-parseFcFixture :: FilePath -> Y.Value -> Either String FcCase
-parseFcFixture path value = do
+parseFcFixture :: [Text] -> FilePath -> Y.Value -> Either String FcCase
+parseFcFixture supportModules path value = do
   (extNames, modules, expectedText, statusText, reasonText) <-
     parseEither
       ( withObject "fc fixture" $ \obj -> do
@@ -107,6 +125,7 @@ parseFcFixture path value = do
         caseCategory = category,
         casePath = relPath,
         caseExtensions = exts,
+        caseSupportModules = supportModules,
         caseModules = modules,
         caseExpected = expected,
         caseStatus = status,
@@ -130,7 +149,8 @@ parseExpectedValue _ = fail "expected must be a string or list"
 
 evaluateFcCase :: FcCase -> (Outcome, String)
 evaluateFcCase tc =
-  let parsedModules = map parseOne (caseModules tc)
+  let supportModuleCount = length (caseSupportModules tc)
+      parsedModules = map parseOne (caseSupportModules tc <> caseModules tc)
    in case sequence parsedModules of
         Left errMsg -> classifyFailure tc ("parse error: " <> errMsg)
         Right modules ->
@@ -141,8 +161,9 @@ evaluateFcCase tc =
                     then
                       let allBindings = moduleGroupBindings tcResults
                           results = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
+                          fixtureResults = drop supportModuleCount results
                        in if all dsSuccess results
-                            then classifySuccess tc (renderResults results)
+                            then classifySuccess tc (renderResults fixtureResults)
                             else classifyFailure tc (renderErrors results)
                     else classifyFailure tc ("typecheck error: " <> renderTcErrors tcResults)
             ResolveResult {resolveErrors} ->

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1122,7 +1122,8 @@ dsTuple flavor tcAnn elems = do
   if length elemTys == length elems
     then do
       elems' <- zipWithM dsMaybeTupleElem elemTys elems
-      pure (List.foldl' FcApp (tupleConExpr flavor elemTys) elems')
+      constructor <- tupleConExpr flavor elemTys
+      pure (List.foldl' FcApp constructor elems')
     else desugarBug ("tuple annotation arity mismatch: expected " <> show (length elems) <> " type argument(s), got " <> show (length elemTys))
 
 dsMaybeTupleElem :: TcType -> Maybe Expr -> DsM FcExpr
@@ -1131,18 +1132,23 @@ dsMaybeTupleElem ty Nothing = do
   v <- freshVar "_tuple_section" ty
   pure (FcVar v)
 
-tupleConExpr :: TupleFlavor -> [TcType] -> FcExpr
-tupleConExpr flavor elemTys =
+tupleConExpr :: TupleFlavor -> [TcType] -> DsM FcExpr
+tupleConExpr flavor elemTys = do
   let arity = length elemTys
-   in List.foldl' FcTyApp (FcVar (Var (tupleConName flavor arity) (Unique (-20 - arity)) (tupleConType flavor elemTys))) elemTys
+      name = tupleConName flavor arity
+  constructorTy <-
+    case flavor of
+      Boxed -> lookupType name
+      Unboxed -> pure (unboxedTupleConType elemTys)
+  pure (List.foldl' FcTyApp (FcVar (Var name (Unique (-20 - arity)) constructorTy)) elemTys)
 
-tupleConType :: TupleFlavor -> [TcType] -> TcType
-tupleConType flavor elemTys =
+unboxedTupleConType :: [TcType] -> TcType
+unboxedTupleConType elemTys =
   foldr TcForAllTy (foldr (TcFunTy . TcTyVar) resultTy tyVars) tyVars
   where
     arity = length elemTys
     tyVars = [TyVarId ("t" <> T.pack (show i)) (Unique (-2100 - i)) | i <- [0 .. arity - 1]]
-    resultTy = TcTyCon (TyCon (tupleConName flavor arity) arity) (map TcTyVar tyVars)
+    resultTy = TcTyCon (TyCon (tupleConName Unboxed arity) arity) (map TcTyVar tyVars)
 
 tupleConName :: TupleFlavor -> Int -> Text
 tupleConName flavor arity =
@@ -1199,14 +1205,14 @@ dsEvidence evidence =
         Nothing ->
           desugarBug ("missing local dictionary for " <> T.unpack (dictKey className args))
     EvGiven EqPred {} ->
-      pure unitConstructor
+      unitConstructor
     EvDict dictName typeArgs contextEvidence -> do
       dictTy <- lookupType dictName
       contextDicts <- mapM dsEvidence contextEvidence
       let dictExpr = List.foldl' FcTyApp (FcVar (Var dictName (Unique (-199)) dictTy)) typeArgs
       pure (List.foldl' FcApp dictExpr contextDicts)
     EvCoercion {} ->
-      pure unitConstructor
+      unitConstructor
     EvSuperClass source sourcePredicate fieldTypes fieldIndex -> do
       sourceExpression <- dsEvidence source
       sourceBinder <- freshVar "$super_source" (predType sourcePredicate)
@@ -1316,9 +1322,10 @@ tyConTy = TcTyCon (TyCon "TyCon" 0) []
 stringTy :: TcType
 stringTy = listType charTy
 
-unitConstructor :: FcExpr
-unitConstructor =
-  FcVar (Var "()" (Unique (-13)) (TcTyCon (TyCon "()" 0) []))
+unitConstructor :: DsM FcExpr
+unitConstructor = do
+  ty <- lookupType "()"
+  pure (FcVar (Var "()" (Unique (-13)) ty))
 
 exprAnnotationType :: Expr -> Maybe TcType
 exprAnnotationType expr =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -185,8 +185,6 @@ builtinConstructorEnv =
     [ ("C#", VConstructor "C#" []),
       ("[]", VConstructor "[]" []),
       (":", VConstructor ":" []),
-      ("()", VConstructor "()" []),
-      ("(,)", VConstructor "(,)" []),
       ("(#,#)", VConstructor "(#,#)" [])
     ]
 

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
@@ -53,7 +53,7 @@ expected: |-
   asInteger : Integer =
     fromInteger @Integer $fNumInteger (IS 1)
 
-  caseInt : () =
+  caseInt : Unit =
     case fromInteger @Int $fNumInt (IS 1) as _case : Int of
       _ _case_value →
         case == @Int $fEqInt _case_value (fromInteger @Int $fNumInt (IS 1)) as _case_guard : Bool of

--- a/components/aihc-fc/test/Test/Fixtures/golden/tuple-type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/tuple-type-application.yaml
@@ -11,7 +11,7 @@ expected: |
    = True
    | False
 
-  pair : (,) Bool () =
-    (,) @Bool @() True ()
+  pair : Tuple2 Bool Unit =
+    (,) @Bool @Unit True ()
 status: pass
 reason: reifies tuple constructor type arguments from type-checker annotations

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -150,7 +150,7 @@ programEnvironment interface =
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
 lowerProgramWithEnvironment environment program =
   GrinProgram
-    { grinConstructors = loweredConstructors tops <> programBoxedTupleConstructors program,
+    { grinConstructors = loweredConstructors tops,
       grinPrimitives = loweredPrimitives tops,
       grinForeignCalls = loweredForeignCalls tops,
       grinExternalGlobals = Set.toAscList (lowerReferencedExternalGlobalNames finalState),
@@ -1437,61 +1437,6 @@ programConstructors program =
   | FcData _ _ constructors <- fcTopBinds program,
     (name, fields) <- constructors
   ]
-    <> [(name, length layouts) | (name, layouts) <- programBoxedTupleConstructors program]
-
--- | Boxed tuple constructors are wired into System FC rather than declared by
--- an 'FcData' binding. Materialize the tuple arities used by each compilation
--- unit so linking and every backend receive the same constructor layouts.
-programBoxedTupleConstructors :: FcProgram -> [(Text, [[RuntimeRep]])]
-programBoxedTupleConstructors program =
-  Map.toAscList . Map.fromList $
-    [ (name, replicate arity [liftedRuntimeRep])
-    | name <- map varName (programVars program) <> concatMap topAlternativeConstructors (fcTopBinds program),
-      name `Map.notMember` builtinArities,
-      Just arity <- [boxedTupleConstructorArity name]
-    ]
-  where
-    builtinArities = Map.fromList [(name, length layouts) | (name, layouts) <- builtinConstructors]
-
-boxedTupleConstructorArity :: Text -> Maybe Int
-boxedTupleConstructorArity name = do
-  contents <- T.stripPrefix "(" name >>= T.stripSuffix ")"
-  if not (T.null contents) && T.all (== ',') contents
-    then Just (T.length contents + 1)
-    else Nothing
-
-topAlternativeConstructors :: FcTopBind -> [Text]
-topAlternativeConstructors topBind =
-  case topBind of
-    FcTopBind bind -> bindAlternativeConstructors bind
-    _ -> []
-
-bindAlternativeConstructors :: FcBind -> [Text]
-bindAlternativeConstructors bind =
-  case bind of
-    FcNonRec _ expr -> exprAlternativeConstructors expr
-    FcRec bindings -> concatMap (exprAlternativeConstructors . snd) bindings
-
-exprAlternativeConstructors :: FcExpr -> [Text]
-exprAlternativeConstructors expr =
-  case expr of
-    FcVar {} -> []
-    FcLit {} -> []
-    FcApp function argument -> exprAlternativeConstructors function <> exprAlternativeConstructors argument
-    FcTyApp inner _ -> exprAlternativeConstructors inner
-    FcLam _ body -> exprAlternativeConstructors body
-    FcTyLam _ body -> exprAlternativeConstructors body
-    FcLet bind body -> bindAlternativeConstructors bind <> exprAlternativeConstructors body
-    FcCase scrutinee _ alternatives ->
-      exprAlternativeConstructors scrutinee <> concatMap alternativeConstructors alternatives
-    FcCast inner _ -> exprAlternativeConstructors inner
-    FcCallForeign _ arguments -> concatMap exprAlternativeConstructors arguments
-
-alternativeConstructors :: FcAlt -> [Text]
-alternativeConstructors alternative =
-  case altCon alternative of
-    DataAlt name -> name : exprAlternativeConstructors (altRhs alternative)
-    _ -> exprAlternativeConstructors (altRhs alternative)
 
 programWhnfGlobalNames :: FcProgram -> [Text]
 programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds program)

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -150,7 +150,7 @@ programEnvironment interface =
 lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
 lowerProgramWithEnvironment environment program =
   GrinProgram
-    { grinConstructors = loweredConstructors tops,
+    { grinConstructors = loweredConstructors tops <> programBoxedTupleConstructors program,
       grinPrimitives = loweredPrimitives tops,
       grinForeignCalls = loweredForeignCalls tops,
       grinExternalGlobals = Set.toAscList (lowerReferencedExternalGlobalNames finalState),
@@ -1437,6 +1437,61 @@ programConstructors program =
   | FcData _ _ constructors <- fcTopBinds program,
     (name, fields) <- constructors
   ]
+    <> [(name, length layouts) | (name, layouts) <- programBoxedTupleConstructors program]
+
+-- | Boxed tuple constructors are wired into System FC rather than declared by
+-- an 'FcData' binding. Materialize the tuple arities used by each compilation
+-- unit so linking and every backend receive the same constructor layouts.
+programBoxedTupleConstructors :: FcProgram -> [(Text, [[RuntimeRep]])]
+programBoxedTupleConstructors program =
+  Map.toAscList . Map.fromList $
+    [ (name, replicate arity [liftedRuntimeRep])
+    | name <- map varName (programVars program) <> concatMap topAlternativeConstructors (fcTopBinds program),
+      name `Map.notMember` builtinArities,
+      Just arity <- [boxedTupleConstructorArity name]
+    ]
+  where
+    builtinArities = Map.fromList [(name, length layouts) | (name, layouts) <- builtinConstructors]
+
+boxedTupleConstructorArity :: Text -> Maybe Int
+boxedTupleConstructorArity name = do
+  contents <- T.stripPrefix "(" name >>= T.stripSuffix ")"
+  if not (T.null contents) && T.all (== ',') contents
+    then Just (T.length contents + 1)
+    else Nothing
+
+topAlternativeConstructors :: FcTopBind -> [Text]
+topAlternativeConstructors topBind =
+  case topBind of
+    FcTopBind bind -> bindAlternativeConstructors bind
+    _ -> []
+
+bindAlternativeConstructors :: FcBind -> [Text]
+bindAlternativeConstructors bind =
+  case bind of
+    FcNonRec _ expr -> exprAlternativeConstructors expr
+    FcRec bindings -> concatMap (exprAlternativeConstructors . snd) bindings
+
+exprAlternativeConstructors :: FcExpr -> [Text]
+exprAlternativeConstructors expr =
+  case expr of
+    FcVar {} -> []
+    FcLit {} -> []
+    FcApp function argument -> exprAlternativeConstructors function <> exprAlternativeConstructors argument
+    FcTyApp inner _ -> exprAlternativeConstructors inner
+    FcLam _ body -> exprAlternativeConstructors body
+    FcTyLam _ body -> exprAlternativeConstructors body
+    FcLet bind body -> bindAlternativeConstructors bind <> exprAlternativeConstructors body
+    FcCase scrutinee _ alternatives ->
+      exprAlternativeConstructors scrutinee <> concatMap alternativeConstructors alternatives
+    FcCast inner _ -> exprAlternativeConstructors inner
+    FcCallForeign _ arguments -> concatMap exprAlternativeConstructors arguments
+
+alternativeConstructors :: FcAlt -> [Text]
+alternativeConstructors alternative =
+  case altCon alternative of
+    DataAlt name -> name : exprAlternativeConstructors (altRhs alternative)
+    _ -> exprAlternativeConstructors (altRhs alternative)
 
 programWhnfGlobalNames :: FcProgram -> [Text]
 programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds program)

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -302,9 +302,7 @@ builtinConstructors :: [(Text, [[RuntimeRep]])]
 builtinConstructors =
   [ ("C#", [[WordRep]]),
     ("[]", []),
-    (":", [[liftedRuntimeRep], [liftedRuntimeRep]]),
-    ("()", []),
-    ("(,)", [[liftedRuntimeRep], [liftedRuntimeRep]])
+    (":", [[liftedRuntimeRep], [liftedRuntimeRep]])
   ]
 
 -- | Flattened storage layouts for runtime-supplied constructors. Source-level

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -10,7 +10,7 @@ where
 import Aihc.Fc.Newtype (extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
 import Aihc.Fc.Syntax
 import Aihc.Grin
-import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), runtimeRepOfType)
+import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), liftedRuntimeRep, runtimeRepOfType)
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Control.Monad (forM_)
@@ -377,6 +377,13 @@ grinUnitTests =
               (GrinStore (GrinNode (GrinConstructor "I32#" 0) [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
+      testCase "FC lowering materializes boxed tuple constructors used only by patterns" $ do
+        let program = lowerProgram triplePatternProgram
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual
+          "triple layout"
+          (Just [[liftedRuntimeRep], [liftedRuntimeRep], [liftedRuntimeRep]])
+          (lookup "(,,)" (grinConstructors program)),
       testCase "FC lowering returns a tail constructor store directly" $ do
         let program = lowerProgram tailStoredTupleProgram
         assertEqual "lint" [] (lintProgram program)
@@ -1957,6 +1964,27 @@ saturatedConstructorProgram =
   where
     int32WrapperVar = Var "wrapInt32" (Unique 60) (TcFunTy int32Ty boxedInt32Ty)
     int32ConstructorVar = Var "I32#" (Unique 61) (TcFunTy int32Ty boxedInt32Ty)
+
+triplePatternProgram :: FcProgram
+triplePatternProgram =
+  FcProgram
+    [ FcTopBind
+        ( FcNonRec
+            projectVar
+            ( FcLam
+                inputVar
+                (FcCase (FcVar inputVar) caseVar [FcAlt (DataAlt "(,,)") [firstVar, secondVar, thirdVar] (FcVar firstVar)])
+            )
+        )
+    ]
+  where
+    tripleTy = TcTyCon (TyCon "(,,)" 3) [boxedIntTy, boxedIntTy, boxedIntTy]
+    projectVar = Var "firstOfThree" (Unique 70) (TcFunTy tripleTy boxedIntTy)
+    inputVar = Var "triple" (Unique 71) tripleTy
+    caseVar = Var "tripleCase" (Unique 72) tripleTy
+    firstVar = Var "first" (Unique 73) boxedIntTy
+    secondVar = Var "second" (Unique 74) boxedIntTy
+    thirdVar = Var "third" (Unique 75) boxedIntTy
 
 tailStoredTupleProgram :: FcProgram
 tailStoredTupleProgram =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -10,7 +10,7 @@ where
 import Aihc.Fc.Newtype (extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
 import Aihc.Fc.Syntax
 import Aihc.Grin
-import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), liftedRuntimeRep, runtimeRepOfType)
+import Aihc.Tc (Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), runtimeRepOfType)
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Control.Monad (forM_)
@@ -377,13 +377,6 @@ grinUnitTests =
               (GrinStore (GrinNode (GrinConstructor "I32#" 0) [GrinVarValue (GrinVar "value" 62 Int32Rep)]))
               (grinFunctionBody function)
           functions -> assertFailure ("expected one constructor function, got " <> show (length functions)),
-      testCase "FC lowering materializes boxed tuple constructors used only by patterns" $ do
-        let program = lowerProgram triplePatternProgram
-        assertEqual "lint" [] (lintProgram program)
-        assertEqual
-          "triple layout"
-          (Just [[liftedRuntimeRep], [liftedRuntimeRep], [liftedRuntimeRep]])
-          (lookup "(,,)" (grinConstructors program)),
       testCase "FC lowering returns a tail constructor store directly" $ do
         let program = lowerProgram tailStoredTupleProgram
         assertEqual "lint" [] (lintProgram program)
@@ -1964,27 +1957,6 @@ saturatedConstructorProgram =
   where
     int32WrapperVar = Var "wrapInt32" (Unique 60) (TcFunTy int32Ty boxedInt32Ty)
     int32ConstructorVar = Var "I32#" (Unique 61) (TcFunTy int32Ty boxedInt32Ty)
-
-triplePatternProgram :: FcProgram
-triplePatternProgram =
-  FcProgram
-    [ FcTopBind
-        ( FcNonRec
-            projectVar
-            ( FcLam
-                inputVar
-                (FcCase (FcVar inputVar) caseVar [FcAlt (DataAlt "(,,)") [firstVar, secondVar, thirdVar] (FcVar firstVar)])
-            )
-        )
-    ]
-  where
-    tripleTy = TcTyCon (TyCon "(,,)" 3) [boxedIntTy, boxedIntTy, boxedIntTy]
-    projectVar = Var "firstOfThree" (Unique 70) (TcFunTy tripleTy boxedIntTy)
-    inputVar = Var "triple" (Unique 71) tripleTy
-    caseVar = Var "tripleCase" (Unique 72) tripleTy
-    firstVar = Var "first" (Unique 73) boxedIntTy
-    secondVar = Var "second" (Unique 74) boxedIntTy
-    thirdVar = Var "third" (Unique 75) boxedIntTy
 
 tailStoredTupleProgram :: FcProgram
 tailStoredTupleProgram =

--- a/components/aihc-llvm/test/Test/Llvm/Suite.hs
+++ b/components/aihc-llvm/test/Test/Llvm/Suite.hs
@@ -206,7 +206,7 @@ verifyModule source =
 intAddProgram :: GrinProgram
 intAddProgram =
   GrinProgram
-    { grinConstructors = [],
+    { grinConstructors = [("()", [])],
       grinPrimitives = [(GrinVar "+#" 30 IntRep, 2)],
       grinForeignCalls = [putcharCall],
       grinExternalGlobals = [],
@@ -252,7 +252,7 @@ intAddProgram =
 firstMatchCaseProgram :: GrinProgram
 firstMatchCaseProgram =
   GrinProgram
-    { grinConstructors = [],
+    { grinConstructors = [("()", [])],
       grinPrimitives = [],
       grinForeignCalls = [putcharCall],
       grinExternalGlobals = [],
@@ -298,7 +298,7 @@ firstMatchCaseProgram =
 thunkEntryProgram :: GrinProgram
 thunkEntryProgram =
   GrinProgram
-    { grinConstructors = [],
+    { grinConstructors = [("()", [])],
       grinPrimitives = [],
       grinForeignCalls = [putcharCall],
       grinExternalGlobals = [],
@@ -350,7 +350,7 @@ putcharCall =
 foreignIntProgram :: GrinProgram
 foreignIntProgram =
   GrinProgram
-    { grinConstructors = [],
+    { grinConstructors = [("()", [])],
       grinPrimitives = [],
       grinForeignCalls = [labsCall, putcharCall],
       grinExternalGlobals = [],

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -195,7 +195,7 @@ resolveWithDeps depExports modules =
        in (nextLocal', modu')
     (_, resolved) = mapAccumL step 0 modules
     modules' = resolved
-    ownExports = collectModuleExports modules
+    ownExports = collectModuleExportsWithDeps depExports modules
     exports = ownExports `Map.union` depExports
 
 extractInterface :: ResolveResult -> ModuleExports

--- a/components/aihc-resolve/test/Spec.hs
+++ b/components/aihc-resolve/test/Spec.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Test.Resolver.Suite (resolverGoldenTests)
+import Test.Resolver.Suite (resolverGoldenTests, resolverUnitTests)
 import Test.Tasty
 import qualified Test.Tasty.QuickCheck as QC
 
@@ -8,7 +8,7 @@ main :: IO ()
 main = do
   resolverGolden <- resolverGoldenTests
   let dummyQC = QC.testProperty "dummy quickcheck property" prop_dummy
-  defaultMain (testGroup "aihc-resolve" [resolverGolden, dummyQC])
+  defaultMain (testGroup "aihc-resolve" [resolverGolden, resolverUnitTests, dummyQC])
 
 -- | Dummy QuickCheck property that always passes.
 -- Added so that --quickcheck-tests flag is accepted by the test suite.

--- a/components/aihc-resolve/test/Test/Resolver/Suite.hs
+++ b/components/aihc-resolve/test/Test/Resolver/Suite.hs
@@ -2,13 +2,55 @@
 
 module Test.Resolver.Suite
   ( resolverGoldenTests,
+    resolverUnitTests,
   )
 where
 
+import Aihc.Parser (defaultConfig, parseModule)
+import Aihc.Resolve (ResolveResult (..), extractInterface, resolve, resolveWithDeps)
 import Control.Monad (when)
+import Data.Text (Text)
 import qualified ResolverGolden as RG
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase, testCaseInfo)
+
+resolverUnitTests :: TestTree
+resolverUnitTests =
+  testGroup
+    "resolver-unit"
+    [ testCase "dependency-backed Prelude re-export supplies fromInteger" testDependencyBackedPreludeReExport
+    ]
+
+testDependencyBackedPreludeReExport :: Assertion
+testDependencyBackedPreludeReExport =
+  case (parse "GHC.Num" numSource, parse "Prelude" preludeSource) of
+    (Right numModule, Right preludeModule) -> do
+      let dependencyResult = resolve [numModule]
+          result = resolveWithDeps (extractInterface dependencyResult) [preludeModule]
+      case resolveErrors dependencyResult of
+        [] ->
+          case resolveErrors result of
+            [] -> pure ()
+            errors -> assertFailure ("failed to resolve Prelude through dependency exports: " <> show errors)
+        errors -> assertFailure ("failed to resolve dependency module: " <> show errors)
+    (Left errors, _) -> assertFailure errors
+    (_, Left errors) -> assertFailure errors
+  where
+    parse sourceName source =
+      case parseModule defaultConfig source of
+        ([], modu) -> Right modu
+        (errors, _) -> Left (sourceName <> " parse failure: " <> show errors)
+    numSource :: Text
+    numSource =
+      "module GHC.Num (Num (..)) where\n\
+      \data Integer = Integer\n\
+      \class Num a where\n\
+      \  fromInteger :: Integer -> a\n"
+    preludeSource :: Text
+    preludeSource =
+      "module Prelude (Num (..)) where\n\
+      \import GHC.Num (Num (..))\n\
+      \one = 1\n"
 
 resolverGoldenTests :: IO TestTree
 resolverGoldenTests = do

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -49,6 +49,7 @@ module Aihc.Tc
     TyVarId (..),
     tvKind,
     TypeScheme (..),
+    boxedTupleTyConName,
     Pred (..),
     InstanceInfo (..),
     ClassInfo (..),

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -47,7 +47,7 @@ import Aihc.Parser.Syntax
     mkAnnotation,
   )
 import Aihc.Tc.Evidence (EvTerm, EvVar)
-import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -213,7 +213,6 @@ renderTcType = go 0
     go :: Int -> TcType -> String
     go _ (TcTyVar tv) = T.unpack (tvName tv)
     go _ (TcMetaTv (Unique u)) = "?" ++ show u
-    go _ (TcTyCon tc []) = T.unpack (tyConName tc)
     go _ (TcTyCon (TyCon name 1) [arg])
       | name == T.pack "[]" = "[" ++ go 0 arg ++ "]"
     go _ (TcTyCon (TyCon name arity) args)
@@ -224,6 +223,7 @@ renderTcType = go 0
       | isUnboxedTupleCon name arity,
         arity == length args =
           "(# " ++ commaSep (map (go 0) args) ++ " #)"
+    go _ (TcTyCon tc []) = T.unpack (tyConName tc)
     go p (TcTyCon tc args) =
       parenIf (p >= 2) $
         unwords (T.unpack (tyConName tc) : map (go 2) args)
@@ -252,7 +252,7 @@ renderTcType = go 0
     commaSep = T.unpack . T.intercalate (T.pack ", ") . map T.pack
 
     isBoxedTupleCon name arity =
-      name == T.pack "(" <> commas arity <> T.pack ")"
+      arity /= 1 && name == boxedTupleTyConName arity
 
     isUnboxedTupleCon name arity =
       name == T.pack "(#" <> commas arity <> T.pack "#)"

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -9,6 +9,7 @@ module Aihc.Tc.Env
 
     -- * Type constructor info
     TyConInfo (..),
+    TypeSynonymInfo (..),
 
     -- * Data constructor info
     DataConInfo (..),
@@ -50,7 +51,14 @@ data TyConInfo = TyConInfo
   { tciName :: !Text,
     tciArity :: !Int,
     tciTyCon :: !TyCon,
-    tciKind :: !Kind
+    tciKind :: !Kind,
+    tciTypeSynonym :: !(Maybe TypeSynonymInfo)
+  }
+  deriving (Show, Read)
+
+data TypeSynonymInfo = TypeSynonymInfo
+  { tsiParams :: ![TyVarId],
+    tsiBody :: !(Maybe TcType)
   }
   deriving (Show, Read)
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -45,6 +45,7 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     TupleFlavor (..),
     Type (..),
+    TypeSynDecl (..),
     UnqualifiedName (..),
     ValueDecl (..),
     binderHeadName,
@@ -73,7 +74,7 @@ import Aihc.Tc.Annotations
     annotateDecl,
   )
 import Aihc.Tc.Constraint
-import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConInfo (..))
+import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Finalize (finalizeModuleTc)
@@ -340,9 +341,14 @@ tcModule m = do
 -- in another member of the same import cycle.
 tcModuleScc :: [Module] -> TcM [Module]
 tcModuleScc modules = do
-  -- Phase 1: collect data declarations, register constructors,
-  --          and report their types.
-  mapM_ registerDecl (concatMap moduleDecls modules)
+  -- Phase 1: register type constructor headers before expanding synonym
+  -- bodies, then register value-level declarations against those expanded
+  -- types. This permits forward references from synonyms to data types while
+  -- making aliases available in constructor fields and class methods.
+  let declarations = concatMap moduleDecls modules
+  mapM_ registerTypeDeclHeader declarations
+  mapM_ registerTypeSynonymBody declarations
+  mapM_ registerValueLevelDecl declarations
   -- Phase 2: collect type signatures and convert them to schemes.
   rawSigs <- mapM (collectUserSigs . moduleDecls) modules
   schemes <- mapM (traverse checkUserSig) rawSigs
@@ -418,12 +424,18 @@ defaultGlobalKindMetas = do
         TcMonoIdBinder ty -> TcMonoIdBinder <$> defaultTypeKinds ty
     defaultTyConInfoKinds info = do
       kind <- defaultKindMetas (tciKind info)
+      synonym <- traverse defaultTypeSynonymKinds (tciTypeSynonym info)
       let tyCon = tciTyCon info
       pure
         info
           { tciTyCon = mkTyCon (tyConName tyCon) (tyConArity tyCon) kind,
-            tciKind = kind
+            tciKind = kind,
+            tciTypeSynonym = synonym
           }
+    defaultTypeSynonymKinds synonym =
+      TypeSynonymInfo
+        <$> mapM defaultTyVarKinds (tsiParams synonym)
+        <*> traverse defaultTypeKinds (tsiBody synonym)
     defaultClassKinds info =
       ClassInfo
         (ciName info)
@@ -1526,18 +1538,23 @@ zonkPred pred' =
     ClassPred className args -> ClassPred className <$> mapM zonkType args
     EqPred left right -> EqPred <$> zonkType left <*> zonkType right
 
--- | Register a declaration in the environment (data types, etc.).
--- Returns binding results for the declared names.
-registerDecl :: Decl -> TcM [TcBindingResult]
-registerDecl (DeclData dd) = registerDataDecl dd
-registerDecl (DeclNewtype nd) = registerNewtypeDecl nd
-registerDecl (DeclClass classDecl) = registerClassDecl classDecl
-registerDecl (DeclInstance instanceDecl) = registerInstanceDecl instanceDecl
-registerDecl (DeclForeign foreignDecl)
+registerTypeDeclHeader :: Decl -> TcM [TcBindingResult]
+registerTypeDeclHeader (DeclData dataDecl) = registerDataDeclHeader dataDecl
+registerTypeDeclHeader (DeclNewtype newtypeDecl) = registerNewtypeDeclHeader newtypeDecl
+registerTypeDeclHeader (DeclTypeSyn typeSynDecl) = registerTypeSynonymHeader typeSynDecl
+registerTypeDeclHeader (DeclAnn _ inner) = registerTypeDeclHeader inner
+registerTypeDeclHeader _ = pure []
+
+registerValueLevelDecl :: Decl -> TcM [TcBindingResult]
+registerValueLevelDecl (DeclData dataDecl) = registerDataConstructors dataDecl
+registerValueLevelDecl (DeclNewtype newtypeDecl) = registerNewtypeConstructor newtypeDecl
+registerValueLevelDecl (DeclClass classDecl) = registerClassDecl classDecl
+registerValueLevelDecl (DeclInstance instanceDecl) = registerInstanceDecl instanceDecl
+registerValueLevelDecl (DeclForeign foreignDecl)
   | isForeignImport foreignDecl =
       registerForeignImport foreignDecl
-registerDecl (DeclAnn _ inner) = registerDecl inner
-registerDecl _ = pure []
+registerValueLevelDecl (DeclAnn _ inner) = registerValueLevelDecl inner
+registerValueLevelDecl _ = pure []
 
 isForeignImport :: ForeignDecl -> Bool
 isForeignImport foreignDecl =
@@ -1570,7 +1587,8 @@ registerClassDecl classDecl = do
       { tciName = className,
         tciArity = length params,
         tciTyCon = mkTyCon className (length params) classKind,
-        tciKind = classKind
+        tciKind = classKind,
+        tciTypeSynonym = Nothing
       }
   methodResults <- concat <$> mapM (registerClassItem classPred paramTvEnv paramTyVars) (classDeclItems classDecl)
   methods <- mapM registeredMethod (classDeclMethodNames classDecl)
@@ -1674,8 +1692,8 @@ typeSuffix ty =
 --   - @Bool :: *@
 --   - @True :: Bool@
 --   - @False :: Bool@
-registerDataDecl :: DataDecl -> TcM [TcBindingResult]
-registerDataDecl dd = do
+registerDataDeclHeader :: DataDecl -> TcM [TcBindingResult]
+registerDataDeclHeader dd = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
       params = binderHeadParams (dataDeclHead dd)
       arity = length params
@@ -1688,18 +1706,28 @@ registerDataDecl dd = do
       { tciName = tyName,
         tciArity = arity,
         tciTyCon = tc,
-        tciKind = declaredKind
+        tciKind = declaredKind,
+        tciTypeSynonym = Nothing
       }
-  conResults <- mapM (registerDataCon tc paramInfos) (dataDeclConstructors dd)
   zonkedKind <- defaultKindMetas declaredKind
   let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
-  pure (tyConResult : conResults)
+  pure [tyConResult]
+
+registerDataConstructors :: DataDecl -> TcM [TcBindingResult]
+registerDataConstructors dataDecl = do
+  let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
+  maybeInfo <- lookupTyCon tyName
+  case maybeInfo of
+    Nothing -> missingTypeInfo ("data type " <> T.unpack tyName)
+    Just info -> do
+      paramInfos <- makeParamEnv (binderHeadParams (dataDeclHead dataDecl))
+      mapM (registerDataCon (tciTyCon info) paramInfos) (dataDeclConstructors dataDecl)
 
 -- | Register a newtype declaration's type constructor and representation
 -- constructor.  Newtype erasure/coercion semantics are handled elsewhere; at
 -- this stage the type checker only needs the source-level names and types.
-registerNewtypeDecl :: NewtypeDecl -> TcM [TcBindingResult]
-registerNewtypeDecl nd = do
+registerNewtypeDeclHeader :: NewtypeDecl -> TcM [TcBindingResult]
+registerNewtypeDeclHeader nd = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead nd))
       params = binderHeadParams (newtypeDeclHead nd)
       arity = length params
@@ -1712,12 +1740,58 @@ registerNewtypeDecl nd = do
       { tciName = tyName,
         tciArity = arity,
         tciTyCon = tc,
-        tciKind = declaredKind
+        tciKind = declaredKind,
+        tciTypeSynonym = Nothing
       }
-  conResults <- mapM (registerDataCon tc paramInfos) (newtypeDeclConstructor nd)
   zonkedKind <- defaultKindMetas declaredKind
   let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
-  pure (tyConResult : maybeToList conResults)
+  pure [tyConResult]
+
+registerNewtypeConstructor :: NewtypeDecl -> TcM [TcBindingResult]
+registerNewtypeConstructor newtypeDecl = do
+  let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
+  maybeInfo <- lookupTyCon tyName
+  case maybeInfo of
+    Nothing -> missingTypeInfo ("newtype " <> T.unpack tyName)
+    Just info -> do
+      paramInfos <- makeParamEnv (binderHeadParams (newtypeDeclHead newtypeDecl))
+      constructor <- mapM (registerDataCon (tciTyCon info) paramInfos) (newtypeDeclConstructor newtypeDecl)
+      pure (maybeToList constructor)
+
+registerTypeSynonymHeader :: TypeSynDecl -> TcM [TcBindingResult]
+registerTypeSynonymHeader typeSynDecl = do
+  let tyName = unqualifiedNameText (binderHeadName (typeSynHead typeSynDecl))
+      params = binderHeadParams (typeSynHead typeSynDecl)
+      arity = length params
+  paramInfos <- makeParamEnv params
+  let declaredKind = foldr (KFun . paramKind) KType paramInfos
+      tyCon = mkTyCon tyName arity declaredKind
+      synonym = TypeSynonymInfo (map paramTyVar paramInfos) Nothing
+  extendTyConEnvPermanent
+    tyName
+    TyConInfo
+      { tciName = tyName,
+        tciArity = arity,
+        tciTyCon = tyCon,
+        tciKind = declaredKind,
+        tciTypeSynonym = Just synonym
+      }
+  pure [TcBindingResult tyName tyName (kindToTcType declaredKind)]
+
+registerTypeSynonymBody :: Decl -> TcM ()
+registerTypeSynonymBody (DeclAnn _ inner) = registerTypeSynonymBody inner
+registerTypeSynonymBody (DeclTypeSyn typeSynDecl) = do
+  let tyName = unqualifiedNameText (binderHeadName (typeSynHead typeSynDecl))
+  maybeInfo <- lookupTyCon tyName
+  case maybeInfo of
+    Just info
+      | Just synonym <- tciTypeSynonym info -> do
+          let params = tsiParams synonym
+              tvEnv = Map.fromList [(tvName param, (param, tvKind param)) | param <- params]
+          body <- checkSurfaceType tvEnv (typeSynBody typeSynDecl) KType
+          extendTyConEnvPermanent tyName (info {tciTypeSynonym = Just (synonym {tsiBody = Just body})})
+    _ -> missingTypeInfo ("type synonym " <> T.unpack tyName)
+registerTypeSynonymBody _ = pure ()
 
 dataDeclTyCon :: Text -> Int -> Kind -> TyCon
 dataDeclTyCon "List" 1 kind = mkTyCon "[]" 1 kind

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -461,7 +461,7 @@ inferTuple sp flavor elems = do
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
   case flavor of
-    Boxed -> "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
+    Boxed -> boxedTupleTyConName arity
     Unboxed -> "(#" <> T.replicate (max 0 (arity - 1)) "," <> "#)"
 
 inferList :: SourceSpan -> [Expr] -> TcM (Expr, TcType, [Ct])

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -469,7 +469,7 @@ listType elemTy = TcTyCon (TyCon "[]" 1) [elemTy]
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
   case flavor of
-    Boxed -> "(" <> commas arity <> ")"
+    Boxed -> boxedTupleTyConName arity
     Unboxed -> "(#" <> commas arity <> "#)"
 
 commas :: Int -> Text

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -38,14 +38,17 @@ import Aihc.Parser.Syntax
     tyVarBinderName,
     unqualifiedNameText,
   )
-import Aihc.Tc.Env (TyConInfo (..))
+import Aihc.Tc.Env (TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
+import Aihc.Tc.Instantiate (applySubst)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
 import Control.Monad (zipWithM)
 import Data.List (nub, (\\))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -94,8 +97,15 @@ checkRuntimeType tvEnv ty = do
     _ -> emitError NoSourceSpan (KindMismatch KType actual') >> pure tcTy
 
 convertSurfaceTypeWithKinds :: TvKindEnv -> Type -> TcM (TcType, Kind)
-convertSurfaceTypeWithKinds tvEnv ty =
-  case peelTypeHead ty of
+convertSurfaceTypeWithKinds tvEnv ty = do
+  expanded <- expandTypeSynonym tvEnv (peelTypeHead ty)
+  case expanded of
+    Just result -> pure result
+    Nothing -> convertNonSynonymTypeWithKinds tvEnv (peelTypeHead ty)
+
+convertNonSynonymTypeWithKinds :: TvKindEnv -> Type -> TcM (TcType, Kind)
+convertNonSynonymTypeWithKinds tvEnv ty =
+  case ty of
     TAnn _ inner ->
       convertSurfaceTypeWithKinds tvEnv inner
     TVar name ->
@@ -166,6 +176,91 @@ convertSurfaceTypeWithKinds tvEnv ty =
       emitError NoSourceSpan (OtherError ("unsupported surface type in kind checker: " <> take 80 (show ty)))
       meta <- freshMetaTv
       pure (meta, KType)
+
+expandTypeSynonym :: TvKindEnv -> Type -> TcM (Maybe (TcType, Kind))
+expandTypeSynonym tvEnv ty =
+  case typeApplicationSpine ty of
+    (TCon name Unpromoted, arguments) -> do
+      maybeInfo <- lookupTyCon (nameText name)
+      case maybeInfo >>= tciTypeSynonym of
+        Just synonym
+          | Just {} <- tsiBody synonym -> Just <$> instantiateTypeSynonym tvEnv (nameText name) synonym arguments
+        _ -> pure Nothing
+    _ -> pure Nothing
+
+instantiateTypeSynonym :: TvKindEnv -> Text -> TypeSynonymInfo -> [Type] -> TcM (TcType, Kind)
+instantiateTypeSynonym tvEnv synonymName synonym arguments =
+  case tsiBody synonym of
+    Nothing -> do
+      emitError NoSourceSpan (OtherError ("recursive or incomplete type synonym: " <> T.unpack synonymName))
+      meta <- freshMetaTv
+      pure (meta, KType)
+    Just body -> do
+      let params = tsiParams synonym
+          arity = length params
+          (synonymArguments, remainingArguments) = splitAt arity arguments
+      if length synonymArguments /= arity
+        then do
+          emitError NoSourceSpan (OtherError ("type synonym " <> T.unpack synonymName <> " is not fully applied"))
+          meta <- freshMetaTv
+          pure (meta, KType)
+        else do
+          checkedArguments <- zipWithM checkArgument params synonymArguments
+          let substitution = Map.fromList (zip (map tvUnique params) checkedArguments)
+          expandedBody <- expandTcTypeSynonyms Set.empty (applySubst substitution body)
+          applyRemainingArguments (expandedBody, typeKind expandedBody) remainingArguments
+  where
+    checkArgument param argument = checkSurfaceType tvEnv argument (tvKind param)
+
+    applyRemainingArguments result [] = pure result
+    applyRemainingArguments (functionType, functionKind) (argument : rest) = do
+      (argumentType, argumentKind) <- convertSurfaceTypeWithKinds tvEnv argument
+      resultKind <- freshKindMeta
+      unifyKinds functionKind (KFun argumentKind resultKind)
+      zonkedResultKind <- zonkKind resultKind
+      applyRemainingArguments (applyType functionType argumentType, zonkedResultKind) rest
+
+typeApplicationSpine :: Type -> (Type, [Type])
+typeApplicationSpine = go []
+  where
+    go arguments (TAnn _ inner) = go arguments inner
+    go arguments (TApp function argument) = go (argument : arguments) function
+    go arguments (TTypeApp function argument) = go (argument : arguments) function
+    go arguments headType = (headType, arguments)
+
+expandTcTypeSynonyms :: Set Text -> TcType -> TcM TcType
+expandTcTypeSynonyms expanding ty =
+  case ty of
+    TcTyVar {} -> pure ty
+    TcMetaTv {} -> pure ty
+    TcTyCon tyCon arguments -> do
+      expandedArguments <- mapM (expandTcTypeSynonyms expanding) arguments
+      maybeInfo <- lookupTyCon (tyConName tyCon)
+      case maybeInfo >>= tciTypeSynonym of
+        Just synonym
+          | Just body <- tsiBody synonym,
+            let params = tsiParams synonym,
+            length expandedArguments >= length params ->
+              if tyConName tyCon `Set.member` expanding
+                then do
+                  emitError NoSourceSpan (OtherError ("recursive type synonym: " <> T.unpack (tyConName tyCon)))
+                  pure (TcTyCon tyCon expandedArguments)
+                else do
+                  let (synonymArguments, remainingArguments) = splitAt (length params) expandedArguments
+                      substitution = Map.fromList (zip (map tvUnique params) synonymArguments)
+                      expandedBody = applySubst substitution body
+                  normalizedBody <- expandTcTypeSynonyms (Set.insert (tyConName tyCon) expanding) expandedBody
+                  expandTcTypeSynonyms expanding (foldl applyType normalizedBody remainingArguments)
+        _ -> pure (TcTyCon tyCon expandedArguments)
+    TcFunTy argument result -> TcFunTy <$> expandTcTypeSynonyms expanding argument <*> expandTcTypeSynonyms expanding result
+    TcForAllTy tyVar body -> TcForAllTy tyVar <$> expandTcTypeSynonyms expanding body
+    TcQualTy predicates body -> TcQualTy <$> mapM expandPredicate predicates <*> expandTcTypeSynonyms expanding body
+    TcAppTy function argument -> applyType <$> expandTcTypeSynonyms expanding function <*> expandTcTypeSynonyms expanding argument
+  where
+    expandPredicate predicate =
+      case predicate of
+        ClassPred className arguments -> ClassPred className <$> mapM (expandTcTypeSynonyms expanding) arguments
+        EqPred left right -> EqPred <$> expandTcTypeSynonyms expanding left <*> expandTcTypeSynonyms expanding right
 
 inferTypeVariable :: TvKindEnv -> UnqualifiedName -> TcM (TcType, Kind)
 inferTypeVariable tvEnv name =

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -634,7 +634,7 @@ takeClassArgKinds n kind
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
   case flavor of
-    Boxed -> "(" <> commas arity <> ")"
+    Boxed -> boxedTupleTyConName arity
     Unboxed -> "(#" <> commas arity <> "#)"
 
 commas :: Int -> Text

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -31,6 +31,7 @@ module Aihc.Tc.Types
     VecCount (..),
     VecElem (..),
     TypeScheme (..),
+    boxedTupleTyConName,
     liftedRuntimeRep,
     liftedTypeKind,
     typeKind,
@@ -51,6 +52,15 @@ where
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+
+-- | Source-level names of the lifted tuple types declared by @ghc-prim@.
+-- Their data constructors retain the familiar parenthesized comma syntax.
+boxedTupleTyConName :: Int -> Text
+boxedTupleTyConName arity =
+  case arity of
+    0 -> "Unit"
+    1 -> "Solo"
+    _ -> "Tuple" <> T.pack (show arity)
 
 -- | Unique identifier for type variables and evidence variables.
 newtype Unique = Unique Int

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym-parameterized.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym-parameterized.yaml
@@ -4,7 +4,29 @@ modules:
     module Test where
     data Bool = True | False
     type Pair a b = (a, b)
+    type Wrapped a = Box a
+    data Box a = Box a
     p = (True, False)
-annotated: []
-status: xfail
-reason: "parameterized type synonyms not yet supported"
+    wrapped :: Wrapped Bool
+    wrapped = Box True
+annotated:
+  - |-
+    module Test where
+    data Bool = True | False
+         │      │      └─ type: Bool
+         │      └─ type: Bool
+         └─ type: *
+    type Pair a b = (a, b)
+    type Wrapped a = Box a
+    data Box a = Box a
+         │       └─ type: ∀ a. a → Box a
+         └─ type: * → *
+    p = (True, False)
+    │   └─ type: (Bool, Bool); type-args: Bool, Bool
+    └─ type: (Bool, Bool)
+    wrapped :: Wrapped Bool
+    wrapped = Box True
+    │         └─ type: Bool → Box Bool; type-args: Bool
+    └─ type: Box Bool
+status: pass
+reason: "parameterized type synonyms substitute their applied arguments"

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym.yaml
@@ -6,6 +6,16 @@ modules:
     data Bool = True | False
     x :: MyBool
     x = True
-annotated: []
-status: xfail
-reason: "type synonyms not yet supported in type checker"
+annotated:
+  - |-
+    module Test where
+    type MyBool = Bool
+    data Bool = True | False
+         │      │      └─ type: Bool
+         │      └─ type: Bool
+         └─ type: *
+    x :: MyBool
+    x = True
+    └─ type: Bool
+status: pass
+reason: "nullary type synonyms expand to their representation type"

--- a/core-libs/aihc-base/src/GHC/Internal/Integer.hs
+++ b/core-libs/aihc-base/src/GHC/Internal/Integer.hs
@@ -9,6 +9,7 @@ module GHC.Internal.Integer
     integerAdd,
     integerMul,
     integerNegate,
+    integerQuotRemWord#,
     integerSignum,
     integerSub,
     integerToInt#,
@@ -28,6 +29,7 @@ import GHC.Prim
     ltWord#,
     newByteArray#,
     plusWord#,
+    quotRemWord2#,
     quotWord#,
     readWordArray#,
     realWorld#,
@@ -129,6 +131,32 @@ integerToInt# :: Integer -> Int#
 integerToInt# (IS value) = value
 integerToInt# (IP magnitude) = word2Int# (indexWordArray# magnitude 0#)
 integerToInt# (IN magnitude) = (-#) 0# (word2Int# (indexWordArray# magnitude 0#))
+
+integerQuotRemWord# :: Integer -> Word# -> (# Integer, Word# #)
+integerQuotRemWord# value divisor =
+  case signInteger# value of
+    0# -> (# IS 0#, int2Word# 0# #)
+    sign ->
+      case magnitudeSize# value of
+        wordCount ->
+          case newByteArray# ((*#) wordCount 8#) realWorld# of
+            (# state0, mutable #) ->
+              case divideMagnitudeByWord# value divisor mutable ((-#) wordCount 1#) (int2Word# 0#) state0 of
+                (# state1, remainder #) ->
+                  case trimMagnitudeWords# mutable ((-#) wordCount 1#) state1 of
+                    (# state2, usedWords #) ->
+                      case freezeTrimmed# mutable usedWords state2 of
+                        quotientMagnitude -> (# integerFromMagnitude# sign quotientMagnitude, remainder #)
+
+divideMagnitudeByWord# :: Integer -> Word# -> MutableByteArray# RealWorld -> Int# -> Word# -> State# RealWorld -> (# State# RealWorld, Word# #)
+divideMagnitudeByWord# value divisor mutable index remainder state =
+  case (<#) index 0# of
+    1# -> (# state, remainder #)
+    _ ->
+      case quotRemWord2# remainder (magnitudeWord# value index) divisor of
+        (# quotientWord, nextRemainder #) ->
+          case writeWordArray# mutable index quotientWord state of
+            state1 -> divideMagnitudeByWord# value divisor mutable ((-#) index 1#) nextRemainder state1
 
 compareInteger# :: Integer -> Integer -> Int#
 compareInteger# left right =

--- a/core-libs/aihc-base/src/GHC/Show.hs
+++ b/core-libs/aihc-base/src/GHC/Show.hs
@@ -1,1 +1,11 @@
-module GHC.Show () where
+module GHC.Show
+  ( Show (..),
+    ShowS,
+    showChar,
+    showParen,
+    shows,
+    showString,
+  )
+where
+
+import Prelude (Show (..), ShowS, showChar, showParen, showString, shows)

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -18,6 +18,8 @@ module Prelude
     Num (..),
     Ord (..),
     Ordering (..),
+    Show (..),
+    ShowS,
     String,
     (&&),
     (.),
@@ -28,6 +30,10 @@ module Prelude
     id,
     not,
     otherwise,
+    showChar,
+    showParen,
+    shows,
+    showString,
     (||),
   )
 where
@@ -37,9 +43,9 @@ import Data.Kind (Type)
 import GHC.IO (IO (..))
 import GHC.Int (Int (..))
 import GHC.Integer (Integer)
-import GHC.Internal.Integer (compareInteger#, eqInteger#)
+import GHC.Internal.Integer (Integer (..), compareInteger#, eqInteger#, integerAbs, integerQuotRemWord#)
 import GHC.Num (Num (..))
-import GHC.Prim (RealWorld, State#, compareInt#, (==#))
+import GHC.Prim (RealWorld, State#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
 
 data Char = C# Char#
 
@@ -90,6 +96,14 @@ instance Eq Int where
 instance Eq Integer where
   x == y =
     case eqInteger# x y of
+      0# -> False
+      _ -> True
+
+  x /= y = not (x == y)
+
+instance Eq Char where
+  C# x == C# y =
+    case (==#) (ord# x) (ord# y) of
       0# -> False
       _ -> True
 
@@ -286,6 +300,195 @@ minBy cmp x y =
   case cmp x y of
     GT -> y
     _ -> x
+
+type ShowS = String -> String
+
+class Show a where
+  showsPrec :: Int -> a -> ShowS
+  show :: a -> String
+  showList :: [a] -> ShowS
+
+  showsPrec _ value suffix = show value ++ suffix
+  show value = showsPrec (I# 0#) value []
+  showList = showListWith shows
+
+shows :: (Show a) => a -> ShowS
+shows = showsPrec (I# 0#)
+
+showChar :: Char -> ShowS
+showChar char suffix = char : suffix
+
+showString :: String -> ShowS
+showString = (++)
+
+showParen :: Bool -> ShowS -> ShowS
+showParen condition output =
+  case condition of
+    False -> output
+    True -> showChar '(' . output . showChar ')'
+
+instance Show Bool where
+  showsPrec _ False = showString "False"
+  showsPrec _ True = showString "True"
+
+instance Show Int where
+  showsPrec precedence (I# value) = showsSignedInteger precedence (IS value)
+
+instance Show Integer where
+  showsPrec = showsSignedInteger
+
+instance Show () where
+  showsPrec _ () = showString "()"
+
+instance Show Ordering where
+  showsPrec _ LT = showString "LT"
+  showsPrec _ EQ = showString "EQ"
+  showsPrec _ GT = showString "GT"
+
+instance Show Char where
+  showsPrec _ char = showChar '\'' . showLitChar char . showChar '\''
+  showList chars = showChar '"' . showLitString chars . showChar '"'
+
+instance (Show a) => Show [a] where
+  showsPrec _ = showList
+
+instance (Show a) => Show (Maybe a) where
+  showsPrec _ Nothing = showString "Nothing"
+  showsPrec precedence (Just value) =
+    showParen (precedence > 10) (showString "Just " . showsPrec 11 value)
+
+instance (Show a, Show b) => Show (Either a b) where
+  showsPrec precedence (Left value) =
+    showParen (precedence > 10) (showString "Left " . showsPrec 11 value)
+  showsPrec precedence (Right value) =
+    showParen (precedence > 10) (showString "Right " . showsPrec 11 value)
+
+instance (Show a, Show b) => Show (a, b) where
+  showsPrec _ (first, second) =
+    showChar '(' . shows first . showChar ',' . shows second . showChar ')'
+
+instance (Show a, Show b, Show c) => Show (a, b, c) where
+  showsPrec _ (first, second, third) =
+    showChar '('
+      . shows first
+      . showChar ','
+      . shows second
+      . showChar ','
+      . shows third
+      . showChar ')'
+
+showsSignedInteger :: Int -> Integer -> ShowS
+showsSignedInteger precedence value =
+  case (<#) (compareInteger# value (IS 0#)) 0# of
+    0# -> showsUnsignedInteger value
+    _ -> showParen (precedence > 6) (showChar '-' . showsUnsignedInteger (integerAbs value))
+
+showsUnsignedInteger :: Integer -> ShowS
+showsUnsignedInteger value suffix =
+  case integerQuotRemWord# value (int2Word# 10#) of
+    (# quotient, remainder #) ->
+      case eqInteger# quotient (IS 0#) of
+        1# -> digitChar remainder : suffix
+        _ -> showsUnsignedInteger quotient (digitChar remainder : suffix)
+
+digitChar :: Word# -> Char
+digitChar digit = C# (chr# ((+#) (word2Int# digit) 48#))
+
+showListWith :: (a -> ShowS) -> [a] -> ShowS
+showListWith _ [] = showString "[]"
+showListWith showElement (value : values) =
+  showChar '[' . showElement value . showListTail showElement values
+
+showListTail :: (a -> ShowS) -> [a] -> ShowS
+showListTail _ [] = showChar ']'
+showListTail showElement (value : values) =
+  showChar ',' . showElement value . showListTail showElement values
+
+showLitString :: String -> ShowS
+showLitString [] = id
+showLitString ('"' : chars) = showString "\\\"" . showLitString chars
+showLitString ('\'' : chars) = showChar '\'' . showLitString chars
+showLitString (char : chars) = showLitChar char . showLitString chars
+
+showLitChar :: Char -> ShowS
+showLitChar '\a' = showString "\\a"
+showLitChar '\b' = showString "\\b"
+showLitChar '\f' = showString "\\f"
+showLitChar '\n' = showString "\\n"
+showLitChar '\r' = showString "\\r"
+showLitChar '\t' = showString "\\t"
+showLitChar '\v' = showString "\\v"
+showLitChar '\\' = showString "\\\\"
+showLitChar '\'' = showString "\\'"
+showLitChar char@(C# value) =
+  case ord# value of
+    code -> showLitCode char code
+
+showLitCode :: Char -> Int# -> ShowS
+showLitCode char code =
+  case (<#) code 32# of
+    1# -> showChar '\\' . showString (asciiControlName code)
+    _ ->
+      case (==#) code 127# of
+        1# -> showString "\\DEL"
+        _ ->
+          case (<#) code 160# of
+            1# -> showNumericEscape code
+            _ -> showChar char
+
+asciiControlName :: Int# -> String
+asciiControlName code =
+  case code of
+    0# -> "NUL"
+    1# -> "SOH"
+    2# -> "STX"
+    3# -> "ETX"
+    4# -> "EOT"
+    5# -> "ENQ"
+    6# -> "ACK"
+    7# -> "BEL"
+    8# -> "BS"
+    9# -> "HT"
+    10# -> "LF"
+    11# -> "VT"
+    12# -> "FF"
+    13# -> "CR"
+    14# -> "SO"
+    15# -> "SI"
+    16# -> "DLE"
+    17# -> "DC1"
+    18# -> "DC2"
+    19# -> "DC3"
+    20# -> "DC4"
+    21# -> "NAK"
+    22# -> "SYN"
+    23# -> "ETB"
+    24# -> "CAN"
+    25# -> "EM"
+    26# -> "SUB"
+    27# -> "ESC"
+    28# -> "FS"
+    29# -> "GS"
+    30# -> "RS"
+    _ -> "US"
+
+showNumericEscape :: Int# -> ShowS
+showNumericEscape value suffix =
+  showChar '\\' (showsUnsignedInteger (IS value) (protectNumericEscape suffix))
+
+protectNumericEscape :: String -> String
+protectNumericEscape [] = []
+protectNumericEscape chars@('0' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('1' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('2' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('3' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('4' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('5' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('6' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('7' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('8' : _) = '\\' : '&' : chars
+protectNumericEscape chars@('9' : _) = '\\' : '&' : chars
+protectNumericEscape chars = chars
 
 (++) :: [a] -> [a] -> [a]
 (++) [] ys = ys

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -46,6 +46,7 @@ import GHC.Integer (Integer)
 import GHC.Internal.Integer (Integer (..), compareInteger#, eqInteger#, integerAbs, integerQuotRemWord#)
 import GHC.Num (Num (..))
 import GHC.Prim (RealWorld, State#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
+import GHC.Tuple ()
 
 data Char = C# Char#
 

--- a/core-libs/aihc-base/src/Text/Show.hs
+++ b/core-libs/aihc-base/src/Text/Show.hs
@@ -1,1 +1,11 @@
-module Text.Show () where
+module Text.Show
+  ( Show (..),
+    ShowS,
+    showChar,
+    showParen,
+    shows,
+    showString,
+  )
+where
+
+import Prelude (Show (..), ShowS, showChar, showParen, showString, shows)

--- a/core-libs/aihc-prim/src/GHC/Tuple.hs
+++ b/core-libs/aihc-prim/src/GHC/Tuple.hs
@@ -1,1 +1,209 @@
-module GHC.Tuple () where
+module GHC.Tuple
+  ( Tuple0,
+    Tuple1,
+    Unit (..),
+    Solo (..),
+    Tuple2 (..),
+    Tuple3 (..),
+    Tuple4 (..),
+    Tuple5 (..),
+    Tuple6 (..),
+    Tuple7 (..),
+    Tuple8 (..),
+    Tuple9 (..),
+    Tuple10 (..),
+    Tuple11 (..),
+    Tuple12 (..),
+    Tuple13 (..),
+    Tuple14 (..),
+    Tuple15 (..),
+    Tuple16 (..),
+    Tuple17 (..),
+    Tuple18 (..),
+    Tuple19 (..),
+    Tuple20 (..),
+    Tuple21 (..),
+    Tuple22 (..),
+    Tuple23 (..),
+    Tuple24 (..),
+    Tuple25 (..),
+    Tuple26 (..),
+    Tuple27 (..),
+    Tuple28 (..),
+    Tuple29 (..),
+    Tuple30 (..),
+    Tuple31 (..),
+    Tuple32 (..),
+    Tuple33 (..),
+    Tuple34 (..),
+    Tuple35 (..),
+    Tuple36 (..),
+    Tuple37 (..),
+    Tuple38 (..),
+    Tuple39 (..),
+    Tuple40 (..),
+    Tuple41 (..),
+    Tuple42 (..),
+    Tuple43 (..),
+    Tuple44 (..),
+    Tuple45 (..),
+    Tuple46 (..),
+    Tuple47 (..),
+    Tuple48 (..),
+    Tuple49 (..),
+    Tuple50 (..),
+    Tuple51 (..),
+    Tuple52 (..),
+    Tuple53 (..),
+    Tuple54 (..),
+    Tuple55 (..),
+    Tuple56 (..),
+    Tuple57 (..),
+    Tuple58 (..),
+    Tuple59 (..),
+    Tuple60 (..),
+    Tuple61 (..),
+    Tuple62 (..),
+    Tuple63 (..),
+    Tuple64 (..),
+  )
+where
+
+{- ORMOLU_DISABLE -}
+
+data Unit = ()
+
+{- HLINT ignore Solo "Use newtype instead of data" -}
+data Solo a = Solo a
+
+type Tuple0 = Unit
+
+type Tuple1 a = Solo a
+
+data Tuple2 a1 a2 = (a1,a2)
+
+data Tuple3 a1 a2 a3 = (a1,a2,a3)
+
+data Tuple4 a1 a2 a3 a4 = (a1,a2,a3,a4)
+
+data Tuple5 a1 a2 a3 a4 a5 = (a1,a2,a3,a4,a5)
+
+data Tuple6 a1 a2 a3 a4 a5 a6 = (a1,a2,a3,a4,a5,a6)
+
+data Tuple7 a1 a2 a3 a4 a5 a6 a7 = (a1,a2,a3,a4,a5,a6,a7)
+
+data Tuple8 a1 a2 a3 a4 a5 a6 a7 a8 = (a1,a2,a3,a4,a5,a6,a7,a8)
+
+data Tuple9 a1 a2 a3 a4 a5 a6 a7 a8 a9 = (a1,a2,a3,a4,a5,a6,a7,a8,a9)
+
+data Tuple10 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10)
+
+data Tuple11 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11)
+
+data Tuple12 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12)
+
+data Tuple13 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13)
+
+data Tuple14 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14)
+
+data Tuple15 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15)
+
+data Tuple16 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16)
+
+data Tuple17 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17)
+
+data Tuple18 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18)
+
+data Tuple19 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19)
+
+data Tuple20 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20)
+
+data Tuple21 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21)
+
+data Tuple22 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22)
+
+data Tuple23 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23)
+
+data Tuple24 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24)
+
+data Tuple25 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25)
+
+data Tuple26 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26)
+
+data Tuple27 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27)
+
+data Tuple28 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28)
+
+data Tuple29 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29)
+
+data Tuple30 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30)
+
+data Tuple31 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31)
+
+data Tuple32 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32)
+
+data Tuple33 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33)
+
+data Tuple34 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34)
+
+data Tuple35 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35)
+
+data Tuple36 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36)
+
+data Tuple37 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37)
+
+data Tuple38 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38)
+
+data Tuple39 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39)
+
+data Tuple40 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40)
+
+data Tuple41 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41)
+
+data Tuple42 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42)
+
+data Tuple43 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43)
+
+data Tuple44 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44)
+
+data Tuple45 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45)
+
+data Tuple46 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46)
+
+data Tuple47 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47)
+
+data Tuple48 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48)
+
+data Tuple49 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49)
+
+data Tuple50 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50)
+
+data Tuple51 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51)
+
+data Tuple52 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52)
+
+data Tuple53 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53)
+
+data Tuple54 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54)
+
+data Tuple55 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55)
+
+data Tuple56 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56)
+
+data Tuple57 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57)
+
+data Tuple58 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58)
+
+data Tuple59 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59)
+
+data Tuple60 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 a60 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60)
+
+data Tuple61 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 a60 a61 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61)
+
+data Tuple62 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 a60 a61 a62 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62)
+
+data Tuple63 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 a60 a61 a62 a63 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62,a63)
+
+data Tuple64 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 a60 a61 a62 a63 a64 = (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62,a63,a64)
+
+{- ORMOLU_ENABLE -}

--- a/test/Test/Fixtures/eval/base/prelude-show.yaml
+++ b/test/Test/Fixtures/eval/base/prelude-show.yaml
@@ -1,0 +1,69 @@
+dependencies:
+  - aihc-base
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+
+    import GHC.Int (Int(I#))
+
+    data Wrapped = Wrapped Bool
+
+    instance Show Wrapped where
+      showsPrec precedence (Wrapped value) =
+        showParen
+          (precedence > 10)
+          (showString "Wrapped " . showsPrec 11 value)
+
+    data Named = Named
+
+    instance Show Named where
+      show Named = "Named"
+
+    renderFalse :: ShowS
+    renderFalse = shows False
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : values) = allTrue values
+    allTrue (False : _) = False
+
+    results :: Bool
+    results =
+      allTrue
+        [ show False == "False",
+          show (I# 0#) == "0",
+          show (I# 42#) == "42",
+          show (negate (I# 42#)) == "-42",
+          show (18446744073709551616 :: Integer) == "18446744073709551616",
+          show (negate (18446744073709551616 :: Integer)) == "-18446744073709551616",
+          show (100000000000000000000000000000000000000000000000000 :: Integer) == "100000000000000000000000000000000000000000000000000",
+          show () == "()",
+          show GT == "GT",
+          show ('a' :: Char) == "'a'",
+          show ('\n' :: Char) == "'\\n'",
+          show ('\x01' :: Char) == "'\\SOH'",
+          show (Nothing :: Maybe Bool) == "Nothing",
+          show (Just True) == "Just True",
+          show (Left False :: Either Bool Int) == "Left False",
+          show (Right (I# 2#) :: Either Bool Int) == "Right 2",
+          show ([] :: [Bool]) == "[]",
+          show [False, True] == "[False,True]",
+          show (False, Just True) == "(False,Just True)",
+          show "a\n\"\\" == "\"a\\n\\\"\\\\\"",
+          show ['\x80', '2'] == "\"\\128\\&2\"",
+          showsPrec 11 (negate (I# 1#)) "!" == "(-1)!",
+          showList [True, False] "!" == "[True,False]!",
+          showsPrec 0 True "!" == "True!",
+          renderFalse "" == "False",
+          show (Wrapped False) == "Wrapped False",
+          showsPrec 11 (Wrapped True) "!" == "(Wrapped True)!",
+          showsPrec 0 Named "!" == "Named!"
+        ]
+output: |
+  True
+expression: |
+  results
+status: pass
+reason: Prelude Show defaults and instances render supported primitive and algebraic types

--- a/test/Test/Fixtures/eval/base/prelude-show.yaml
+++ b/test/Test/Fixtures/eval/base/prelude-show.yaml
@@ -51,6 +51,7 @@ modules:
           show ([] :: [Bool]) == "[]",
           show [False, True] == "[False,True]",
           show (False, Just True) == "(False,Just True)",
+          show (False, Just True, I# 2#) == "(False,Just True,2)",
           show "a\n\"\\" == "\"a\\n\\\"\\\\\"",
           show ['\x80', '2'] == "\"\\128\\&2\"",
           showsPrec 11 (negate (I# 1#)) "!" == "(-1)!",

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -299,20 +299,17 @@ concatPrograms programs =
   FcProgram (concatMap fcTopBinds programs)
 
 loadDependencyModules :: EvalCase -> [Module] -> IO (Either String [Module])
-loadDependencyModules tc evalModules =
-  case evalCaseDependencies tc of
-    [] -> pure (Right [])
-    dependencies -> do
-      let transitiveDependencies
-            | "aihc-base" `elem` dependencies,
-              "aihc-prim" `notElem` dependencies =
-                dependencies <> ["aihc-prim"]
-            | otherwise = dependencies
-      roots <- traverse resolveDependencyRoot transitiveDependencies
-      case sequence roots of
-        Left errMsg -> pure (Left errMsg)
-        Right packageRoots ->
-          loadTransitiveModules packageRoots (initialDependencyModules evalModules)
+loadDependencyModules tc evalModules = do
+  let dependencies = evalCaseDependencies tc
+      transitiveDependencies = nub (dependencies <> ["aihc-prim"])
+      initialModules
+        | null dependencies = ["GHC.Tuple"]
+        | otherwise = initialDependencyModules evalModules
+  roots <- traverse resolveDependencyRoot transitiveDependencies
+  case sequence roots of
+    Left errMsg -> pure (Left errMsg)
+    Right packageRoots ->
+      loadTransitiveModules packageRoots initialModules
 
 resolveDependencyRoot :: Text -> IO (Either String (Text, FilePath))
 resolveDependencyRoot dependency =

--- a/test/support/Aihc/Testing/SchedulerProgram.hs
+++ b/test/support/Aihc/Testing/SchedulerProgram.hs
@@ -13,7 +13,7 @@ import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
 schedulerProgram :: GrinProgram
 schedulerProgram =
   GrinProgram
-    { grinConstructors = [],
+    { grinConstructors = [("()", [])],
       grinPrimitives =
         [ (GrinVar "fork#" 1 lifted, 2),
           (GrinVar "yield#" 2 lifted, 1)
@@ -73,7 +73,7 @@ schedulerProgram =
 stdioSchedulerProgram :: GrinProgram
 stdioSchedulerProgram =
   GrinProgram
-    { grinConstructors = [],
+    { grinConstructors = [("()", [])],
       grinPrimitives =
         [ (GrinVar "awaitIO#" 30 lifted, 2),
           (GrinVar "newPinnedByteArray#" 31 (BoxedRep Unlifted), 2),


### PR DESCRIPTION
## Summary

- implement `Show`, `ShowS`, standard defaults, and helper functions in `Prelude`
- add `Show` instances for `Bool`, `Int`, `Integer`, `()`, `Ordering`, `Char`, lists, `Maybe`, `Either`, pairs, and triples
- render arbitrary-precision integers in decimal and escape character/string literals compatibly with GHC
- define `Unit`, `Solo`, and `Tuple2` through `Tuple64` in `aihc-prim:GHC.Tuple`, so boxed tuples reach System FC and GRIN as ordinary data declarations
- re-export the API from `GHC.Show` and `Text.Show`

## Prerequisites fixed

`ShowS` exposed an existing type-checker gap: type synonym declarations were parsed and resolved but not represented or expanded during type checking. This PR implements nullary and parameterized synonym expansion, supports forward references to data types, persists synonyms in dependency interfaces, and bumps the dependency cache schema.

The CI failure also exposed that `resolveWithDeps` collected exports without dependency re-exports. That dropped `GHC.Num.fromInteger` from the `Prelude` scope. Resolution now preserves the full transitive export view, so `fromInteger` is available for the right reason.

Boxed tuples are no longer synthesized by System FC or materialized ad hoc by GRIN. Tuple syntax uses the source-defined type constructors from `GHC.Tuple`; only unboxed tuples remain representation-level compiler constructs.

## Impact

- `ShowS` works across module boundaries instead of behaving like an unrelated open type constructor.
- Prelude values can be rendered through both FC and GRIN, including multi-limb positive and negative `Integer` values and triples.
- Existing type-synonym tracking fixtures move from `XFAIL` to `PASS`.
- `aihc-base` API progress increases by 15 symbols, from 164 to 179 (`1.78%` against the current 10,055-symbol oracle).

## Validation

- `just fmt`
- `just check`
- focused FC, GRIN, LLVM, AArch64, AMD64, and installer suites
- production `aihc-base` installation through `aihc-prim`
- focused type-checker golden tests for nullary, parameterized, and forward-referencing type synonyms