### PR TITLE
feat(base): implement Data.Bits

### DIFF
--- a/core-libs/aihc-base/src/Data/Bits.hs
+++ b/core-libs/aihc-base/src/Data/Bits.hs
@@ -1,1 +1,170 @@
-module Data.Bits () where
+module Data.Bits
+  ( Bits (..),
+    FiniteBits (..),
+    bitDefault,
+    testBitDefault,
+    popCountDefault,
+    toIntegralSized,
+    oneBits,
+    (.^.),
+    (.>>.),
+    (.<<.),
+    (!>>.),
+    (!<<.),
+    And (And),
+    getAnd,
+    Ior (Ior),
+    getIor,
+    Xor (Xor),
+    getXor,
+    Iff (Iff),
+    getIff,
+  )
+where
+
+import GHC.Bits
+import Prelude (Eq (..), Int)
+
+oneBits :: (FiniteBits a) => a
+oneBits = complement zeroBits
+
+(.^.) :: (Bits a) => a -> a -> a
+(.^.) = xor
+
+infixl 6 .^.
+
+(.>>.) :: (Bits a) => a -> Int -> a
+(.>>.) = shiftR
+
+infixl 8 .>>.
+
+(.<<.) :: (Bits a) => a -> Int -> a
+(.<<.) = shiftL
+
+infixl 8 .<<.
+
+(!>>.) :: (Bits a) => a -> Int -> a
+(!>>.) = unsafeShiftR
+
+infixl 8 !>>.
+
+(!<<.) :: (Bits a) => a -> Int -> a
+(!<<.) = unsafeShiftL
+
+infixl 8 !<<.
+
+newtype And a = And a
+
+getAnd :: And a -> a
+getAnd (And value) = value
+
+newtype Ior a = Ior a
+
+getIor :: Ior a -> a
+getIor (Ior value) = value
+
+newtype Xor a = Xor a
+
+getXor :: Xor a -> a
+getXor (Xor value) = value
+
+newtype Iff a = Iff a
+
+getIff :: Iff a -> a
+getIff (Iff value) = value
+
+instance (Eq a) => Eq (And a) where
+  And left == And right = left == right
+  And left /= And right = left /= right
+
+instance (Eq a) => Eq (Ior a) where
+  Ior left == Ior right = left == right
+  Ior left /= Ior right = left /= right
+
+instance (Eq a) => Eq (Xor a) where
+  Xor left == Xor right = left == right
+  Xor left /= Xor right = left /= right
+
+instance (Eq a) => Eq (Iff a) where
+  Iff left == Iff right = left == right
+  Iff left /= Iff right = left /= right
+
+instance (Bits a) => Bits (And a) where
+  And left .&. And right = And (left .&. right)
+  And left .|. And right = And (left .|. right)
+  xor (And left) (And right) = And (xor left right)
+  complement (And value) = And (complement value)
+  shift (And value) amount = And (shift value amount)
+  rotate (And value) amount = And (rotate value amount)
+  zeroBits = And zeroBits
+  bit index = And (bit index)
+  testBit (And value) = testBit value
+  bitSizeMaybe (And value) = bitSizeMaybe value
+  bitSize (And value) = bitSize value
+  isSigned (And value) = isSigned value
+  popCount (And value) = popCount value
+
+instance (FiniteBits a) => FiniteBits (And a) where
+  finiteBitSize (And value) = finiteBitSize value
+  countLeadingZeros (And value) = countLeadingZeros value
+  countTrailingZeros (And value) = countTrailingZeros value
+
+instance (Bits a) => Bits (Ior a) where
+  Ior left .&. Ior right = Ior (left .&. right)
+  Ior left .|. Ior right = Ior (left .|. right)
+  xor (Ior left) (Ior right) = Ior (xor left right)
+  complement (Ior value) = Ior (complement value)
+  shift (Ior value) amount = Ior (shift value amount)
+  rotate (Ior value) amount = Ior (rotate value amount)
+  zeroBits = Ior zeroBits
+  bit index = Ior (bit index)
+  testBit (Ior value) = testBit value
+  bitSizeMaybe (Ior value) = bitSizeMaybe value
+  bitSize (Ior value) = bitSize value
+  isSigned (Ior value) = isSigned value
+  popCount (Ior value) = popCount value
+
+instance (FiniteBits a) => FiniteBits (Ior a) where
+  finiteBitSize (Ior value) = finiteBitSize value
+  countLeadingZeros (Ior value) = countLeadingZeros value
+  countTrailingZeros (Ior value) = countTrailingZeros value
+
+instance (Bits a) => Bits (Xor a) where
+  Xor left .&. Xor right = Xor (left .&. right)
+  Xor left .|. Xor right = Xor (left .|. right)
+  xor (Xor left) (Xor right) = Xor (xor left right)
+  complement (Xor value) = Xor (complement value)
+  shift (Xor value) amount = Xor (shift value amount)
+  rotate (Xor value) amount = Xor (rotate value amount)
+  zeroBits = Xor zeroBits
+  bit index = Xor (bit index)
+  testBit (Xor value) = testBit value
+  bitSizeMaybe (Xor value) = bitSizeMaybe value
+  bitSize (Xor value) = bitSize value
+  isSigned (Xor value) = isSigned value
+  popCount (Xor value) = popCount value
+
+instance (FiniteBits a) => FiniteBits (Xor a) where
+  finiteBitSize (Xor value) = finiteBitSize value
+  countLeadingZeros (Xor value) = countLeadingZeros value
+  countTrailingZeros (Xor value) = countTrailingZeros value
+
+instance (Bits a) => Bits (Iff a) where
+  Iff left .&. Iff right = Iff (left .&. right)
+  Iff left .|. Iff right = Iff (left .|. right)
+  xor (Iff left) (Iff right) = Iff (xor left right)
+  complement (Iff value) = Iff (complement value)
+  shift (Iff value) amount = Iff (shift value amount)
+  rotate (Iff value) amount = Iff (rotate value amount)
+  zeroBits = Iff zeroBits
+  bit index = Iff (bit index)
+  testBit (Iff value) = testBit value
+  bitSizeMaybe (Iff value) = bitSizeMaybe value
+  bitSize (Iff value) = bitSize value
+  isSigned (Iff value) = isSigned value
+  popCount (Iff value) = popCount value
+
+instance (FiniteBits a) => FiniteBits (Iff a) where
+  finiteBitSize (Iff value) = finiteBitSize value
+  countLeadingZeros (Iff value) = countLeadingZeros value
+  countTrailingZeros (Iff value) = countTrailingZeros value

--- a/core-libs/aihc-base/src/GHC/Bits.hs
+++ b/core-libs/aihc-base/src/GHC/Bits.hs
@@ -1,1 +1,378 @@
-module GHC.Bits () where
+{-# LANGUAGE MagicHash #-}
+
+module GHC.Bits
+  ( Bits (..),
+    FiniteBits (..),
+    bitDefault,
+    testBitDefault,
+    popCountDefault,
+    toIntegralSized,
+  )
+where
+
+import GHC.Int (Int (..))
+import GHC.Internal.Integer
+  ( Integer,
+    compareInteger#,
+    integerAnd,
+    integerBit#,
+    integerComplement,
+    integerOr,
+    integerPopCount#,
+    integerShiftL#,
+    integerShiftR#,
+    integerTestBit#,
+    integerXor,
+  )
+import GHC.Prim
+  ( and#,
+    clz#,
+    ctz#,
+    int2Word#,
+    not#,
+    or#,
+    popCnt#,
+    uncheckedShiftL#,
+    uncheckedShiftRL#,
+    word2Int#,
+    xor#,
+    (+#),
+    (-#),
+    (<#),
+    (==#),
+  )
+import GHC.Real (Integral (..), fromIntegral)
+import Prelude
+  ( Bool (..),
+    Eq (..),
+    Maybe (..),
+    Num (..),
+    not,
+    (&&),
+    (<),
+    (>=),
+    (||),
+  )
+
+infixl 8 `shift`, `rotate`, `shiftL`, `shiftR`, `rotateL`, `rotateR`
+
+infixl 7 .&.
+
+infixl 6 `xor`
+
+infixl 5 .|.
+
+class (Eq a) => Bits a where
+  (.&.) :: a -> a -> a
+  (.|.) :: a -> a -> a
+  xor :: a -> a -> a
+  complement :: a -> a
+
+  shift :: a -> Int -> a
+  shift = shiftDefault
+
+  rotate :: a -> Int -> a
+  rotate = rotateDefault
+
+  zeroBits :: a
+  zeroBits = zeroBitsDefault
+
+  bit :: Int -> a
+
+  setBit :: a -> Int -> a
+  setBit = setBitDefault
+
+  clearBit :: a -> Int -> a
+  clearBit = clearBitDefault
+
+  complementBit :: a -> Int -> a
+  complementBit = complementBitDefault
+
+  testBit :: a -> Int -> Bool
+
+  bitSizeMaybe :: a -> Maybe Int
+
+  bitSize :: a -> Int
+  bitSize = bitSizeDefault
+
+  isSigned :: a -> Bool
+
+  shiftL :: a -> Int -> a
+  shiftL = shiftLDefault
+
+  unsafeShiftL :: a -> Int -> a
+  unsafeShiftL = unsafeShiftLDefault
+
+  shiftR :: a -> Int -> a
+  shiftR = shiftRDefault
+
+  unsafeShiftR :: a -> Int -> a
+  unsafeShiftR = unsafeShiftRDefault
+
+  rotateL :: a -> Int -> a
+  rotateL = rotateLDefault
+
+  rotateR :: a -> Int -> a
+  rotateR = rotateRDefault
+
+  popCount :: a -> Int
+
+class (Bits a) => FiniteBits a where
+  finiteBitSize :: a -> Int
+
+  countLeadingZeros :: a -> Int
+  countLeadingZeros = countLeadingZerosDefault
+
+  countTrailingZeros :: a -> Int
+  countTrailingZeros = countTrailingZerosDefault
+
+shiftDefault :: (Bits a) => a -> Int -> a
+shiftDefault value amount =
+  case amount < 0 of
+    True -> shiftR value (negate amount)
+    False -> shiftL value amount
+
+rotateDefault :: (Bits a) => a -> Int -> a
+rotateDefault value amount =
+  case amount < 0 of
+    True -> rotateR value (negate amount)
+    False -> rotateL value amount
+
+zeroBitsDefault :: (Bits a) => a
+zeroBitsDefault = clearBit (bit 0) 0
+
+setBitDefault :: (Bits a) => a -> Int -> a
+setBitDefault value index = value .|. bit index
+
+clearBitDefault :: (Bits a) => a -> Int -> a
+clearBitDefault value index = value .&. complement (bit index)
+
+complementBitDefault :: (Bits a) => a -> Int -> a
+complementBitDefault value index = xor value (bit index)
+
+bitSizeDefault :: (Bits a) => a -> Int
+bitSizeDefault value =
+  case bitSizeMaybe value of
+    Just size -> size
+    Nothing -> undefinedBitSize value
+
+shiftLDefault :: (Bits a) => a -> Int -> a
+shiftLDefault = shift
+
+unsafeShiftLDefault :: (Bits a) => a -> Int -> a
+unsafeShiftLDefault = shiftL
+
+shiftRDefault :: (Bits a) => a -> Int -> a
+shiftRDefault value amount = shift value (negate amount)
+
+unsafeShiftRDefault :: (Bits a) => a -> Int -> a
+unsafeShiftRDefault = shiftR
+
+rotateLDefault :: (Bits a) => a -> Int -> a
+rotateLDefault = rotate
+
+rotateRDefault :: (Bits a) => a -> Int -> a
+rotateRDefault value amount = rotate value (negate amount)
+
+countLeadingZerosDefault :: (FiniteBits a) => a -> Int
+countLeadingZerosDefault value = leading (finiteBitSize value - 1)
+  where
+    leading index =
+      case index < 0 of
+        True -> finiteBitSize value
+        False ->
+          case testBit value index of
+            True -> finiteBitSize value - 1 - index
+            False -> leading (index - 1)
+
+countTrailingZerosDefault :: (FiniteBits a) => a -> Int
+countTrailingZerosDefault value = trailing 0
+  where
+    trailing index =
+      case index >= finiteBitSize value of
+        True -> finiteBitSize value
+        False ->
+          case testBit value index of
+            True -> index
+            False -> trailing (index + 1)
+
+bitDefault :: (Bits a, Num a) => Int -> a
+bitDefault = shiftL 1
+
+testBitDefault :: (Bits a, Num a) => a -> Int -> Bool
+testBitDefault value index =
+  case popCount (value .&. bit index) of
+    0 -> False
+    _ -> True
+
+popCountDefault :: (Bits a, Num a) => a -> Int
+popCountDefault value =
+  case bitSizeMaybe value of
+    Just width -> countBits value 0 width 0
+    Nothing -> popCount value
+
+countBits :: (Bits a) => a -> Int -> Int -> Int -> Int
+countBits value index width total =
+  case index >= width of
+    True -> total
+    False ->
+      case testBit value index of
+        True -> countBits value (index + 1) width (total + 1)
+        False -> countBits value (index + 1) width total
+
+toIntegralSized :: (Integral a, Integral b, Bits a, Bits b) => a -> Maybe b
+toIntegralSized value =
+  case fromIntegral value of
+    converted ->
+      case compareInteger# (toInteger value) (toInteger converted) of
+        0# -> Just converted
+        _ -> Nothing
+
+undefinedBitSize :: a -> Int
+undefinedBitSize = undefinedBitSize
+
+invalidShift :: a -> Int -> a
+invalidShift = invalidShift
+
+instance Bits Bool where
+  (.&.) = (&&)
+  (.|.) = (||)
+  xor = (/=)
+  complement = not
+  shift value (I# amount) =
+    case amount of
+      0# -> value
+      _ -> False
+  rotate value _ = value
+  zeroBits = False
+  bit (I# index) =
+    case index of
+      0# -> True
+      _ -> False
+  testBit value (I# index) =
+    case index of
+      0# -> value
+      _ -> False
+  bitSizeMaybe _ = Just 1
+  bitSize _ = 1
+  isSigned _ = False
+  popCount False = 0
+  popCount True = 1
+
+instance FiniteBits Bool where
+  finiteBitSize _ = 1
+  countLeadingZeros False = 1
+  countLeadingZeros True = 0
+  countTrailingZeros False = 1
+  countTrailingZeros True = 0
+
+instance Bits Int where
+  I# left .&. I# right = I# (word2Int# (and# (int2Word# left) (int2Word# right)))
+  I# left .|. I# right = I# (word2Int# (or# (int2Word# left) (int2Word# right)))
+  xor (I# left) (I# right) = I# (word2Int# (xor# (int2Word# left) (int2Word# right)))
+  complement (I# value) = I# (word2Int# (not# (int2Word# value)))
+  shift value (I# amount) =
+    case (<#) amount 0# of
+      1# -> shiftR value (I# ((-#) 0# amount))
+      _ -> shiftL value (I# amount)
+  shiftL (I# word) (I# count) =
+    case (<#) count 0# of
+      1# -> invalidShift (I# word) (I# count)
+      _ ->
+        case (<#) count 64# of
+          1# -> I# (word2Int# (uncheckedShiftL# (int2Word# word) count))
+          _ -> I# 0#
+  unsafeShiftL (I# word) (I# count) = I# (word2Int# (uncheckedShiftL# (int2Word# word) count))
+  shiftR (I# word) (I# count) =
+    case (<#) count 0# of
+      1# -> invalidShift (I# word) (I# count)
+      _ ->
+        case (<#) count 64# of
+          1# -> I# (arithmeticShiftR# word count)
+          _ ->
+            case (<#) word 0# of
+              1# -> I# ((-#) 0# 1#)
+              _ -> I# 0#
+  unsafeShiftR (I# word) (I# count) = I# (arithmeticShiftR# word count)
+  rotate (I# word) (I# amount) = I# (word2Int# (rotateWord# (int2Word# word) (normalizeRotate# amount)))
+  zeroBits = I# 0#
+  bit (I# index) =
+    case (<#) index 0# of
+      1# -> I# 0#
+      _ ->
+        case (<#) index 64# of
+          1# -> I# (word2Int# (uncheckedShiftL# (int2Word# 1#) index))
+          _ -> I# 0#
+  testBit (I# value) (I# index) =
+    case (<#) index 0# of
+      1# -> False
+      _ ->
+        case (<#) index 64# of
+          1# -> wordIsNonzero# (and# (int2Word# value) (uncheckedShiftL# (int2Word# 1#) index))
+          _ -> False
+  bitSizeMaybe _ = Just (I# 64#)
+  bitSize _ = I# 64#
+  isSigned _ = True
+  popCount (I# value) = I# (word2Int# (popCnt# (int2Word# value)))
+
+instance FiniteBits Int where
+  finiteBitSize _ = I# 64#
+  countLeadingZeros (I# value) = I# (word2Int# (clz# (int2Word# value)))
+  countTrailingZeros (I# value) = I# (word2Int# (ctz# (int2Word# value)))
+
+instance Bits Integer where
+  (.&.) = integerAnd
+  (.|.) = integerOr
+  xor = integerXor
+  complement = integerComplement
+  shift value (I# amount) =
+    case (<#) amount 0# of
+      1# -> integerShiftR# value ((-#) 0# amount)
+      _ -> integerShiftL# value amount
+  shiftL value (I# count) =
+    case (<#) count 0# of
+      1# -> invalidShift value (I# count)
+      _ -> integerShiftL# value count
+  unsafeShiftL value (I# count) = integerShiftL# value count
+  shiftR value (I# count) =
+    case (<#) count 0# of
+      1# -> invalidShift value (I# count)
+      _ -> integerShiftR# value count
+  unsafeShiftR value (I# count) = integerShiftR# value count
+  rotate = shift
+  zeroBits = 0
+  bit (I# index) = integerBit# index
+  testBit value (I# index) =
+    case integerTestBit# value index of
+      0# -> False
+      _ -> True
+  bitSizeMaybe _ = Nothing
+  bitSize = undefinedBitSize
+  isSigned _ = True
+  popCount value = I# (integerPopCount# value)
+
+arithmeticShiftR# :: Int# -> Int# -> Int#
+arithmeticShiftR# value amount =
+  case amount of
+    0# -> value
+    _ ->
+      case uncheckedShiftRL# (int2Word# value) amount of
+        shifted ->
+          case (<#) value 0# of
+            1# -> word2Int# (or# shifted (uncheckedShiftL# (not# (int2Word# 0#)) ((-#) 64# amount)))
+            _ -> word2Int# shifted
+
+normalizeRotate# :: Int# -> Int#
+normalizeRotate# amount = word2Int# (and# (int2Word# amount) (int2Word# 63#))
+
+rotateWord# :: Word# -> Int# -> Word#
+rotateWord# value amount =
+  case amount of
+    0# -> value
+    _ -> or# (uncheckedShiftL# value amount) (uncheckedShiftRL# value ((-#) 64# amount))
+
+wordIsNonzero# :: Word# -> Bool
+wordIsNonzero# value =
+  case word2Int# value of
+    0# -> False
+    _ -> True

--- a/core-libs/aihc-base/src/GHC/Internal/Integer.hs
+++ b/core-libs/aihc-base/src/GHC/Internal/Integer.hs
@@ -7,12 +7,21 @@ module GHC.Internal.Integer
     eqInteger#,
     integerAbs,
     integerAdd,
+    integerAnd,
+    integerBit#,
+    integerComplement,
     integerMul,
     integerNegate,
+    integerOr,
+    integerPopCount#,
     integerQuotRemWord#,
+    integerShiftL#,
+    integerShiftR#,
     integerSignum,
     integerSub,
+    integerTestBit#,
     integerToInt#,
+    integerXor,
   )
 where
 
@@ -23,12 +32,16 @@ import GHC.Prim
     State#,
     addIntC#,
     addWordC#,
+    and#,
     eqWord#,
     indexWordArray#,
     int2Word#,
     ltWord#,
     newByteArray#,
+    not#,
+    or#,
     plusWord#,
+    popCnt#,
     quotRemWord2#,
     quotWord#,
     readWordArray#,
@@ -38,9 +51,12 @@ import GHC.Prim
     subIntC#,
     subWordC#,
     timesWord2#,
+    uncheckedShiftL#,
+    uncheckedShiftRL#,
     unsafeFreezeByteArray#,
     word2Int#,
     writeWordArray#,
+    xor#,
     (*#),
     (+#),
     (-#),
@@ -126,6 +142,252 @@ integerAbs value =
 
 integerSignum :: Integer -> Integer
 integerSignum value = IS (signInteger# value)
+
+integerAnd :: Integer -> Integer -> Integer
+integerAnd left right =
+  case signInteger# left of
+    1# ->
+      case signInteger# right of
+        1# -> positiveBitwise# 0# left right
+        0# -> IS 0#
+        _ -> positiveAndNot left (integerPredecessorMagnitude right)
+    0# -> IS 0#
+    _ ->
+      case signInteger# right of
+        1# -> positiveAndNot right (integerPredecessorMagnitude left)
+        0# -> IS 0#
+        _ -> negativeFromComplement (positiveBitwise# 1# (integerPredecessorMagnitude left) (integerPredecessorMagnitude right))
+
+integerOr :: Integer -> Integer -> Integer
+integerOr left right =
+  case signInteger# left of
+    1# ->
+      case signInteger# right of
+        1# -> positiveBitwise# 1# left right
+        0# -> left
+        _ -> negativeFromComplement (positiveAndNot (integerPredecessorMagnitude right) left)
+    0# -> right
+    _ ->
+      case signInteger# right of
+        1# -> negativeFromComplement (positiveAndNot (integerPredecessorMagnitude left) right)
+        0# -> left
+        _ -> negativeFromComplement (positiveBitwise# 0# (integerPredecessorMagnitude left) (integerPredecessorMagnitude right))
+
+integerXor :: Integer -> Integer -> Integer
+integerXor left right =
+  case signInteger# left of
+    1# ->
+      case signInteger# right of
+        1# -> positiveBitwise# 2# left right
+        0# -> left
+        _ -> negativeFromComplement (positiveBitwise# 2# left (integerPredecessorMagnitude right))
+    0# -> right
+    _ ->
+      case signInteger# right of
+        1# -> negativeFromComplement (positiveBitwise# 2# (integerPredecessorMagnitude left) right)
+        0# -> left
+        _ -> positiveBitwise# 2# (integerPredecessorMagnitude left) (integerPredecessorMagnitude right)
+
+integerComplement :: Integer -> Integer
+integerComplement value = integerSub (integerNegate value) (IS 1#)
+
+integerBit# :: Int# -> Integer
+integerBit# amount =
+  case (<#) amount 0# of
+    1# -> IS 0#
+    _ -> integerShiftL# (IS 1#) amount
+
+integerTestBit# :: Integer -> Int# -> Int#
+integerTestBit# value amount =
+  case (<#) amount 0# of
+    1# -> 0#
+    _ ->
+      case (<#) (signInteger# value) 0# of
+        1# ->
+          case testMagnitudeBit# (integerPredecessorMagnitude value) amount of
+            0# -> 1#
+            _ -> 0#
+        _ -> testMagnitudeBit# value amount
+
+integerShiftL# :: Integer -> Int# -> Integer
+integerShiftL# value amount =
+  case (<#) amount 0# of
+    1# -> integerShiftL# value amount
+    _ ->
+      case signInteger# value of
+        0# -> IS 0#
+        sign -> integerFromMagnitude# sign (shiftMagnitudeL# value amount)
+
+integerShiftR# :: Integer -> Int# -> Integer
+integerShiftR# value amount =
+  case (<#) amount 0# of
+    1# -> integerShiftR# value amount
+    _ ->
+      case signInteger# value of
+        0# -> IS 0#
+        1# -> integerFromMagnitude# 1# (shiftMagnitudeR# value amount)
+        _ -> negativeFromComplement (integerFromMagnitude# 1# (shiftMagnitudeR# (integerPredecessorMagnitude value) amount))
+
+integerPopCount# :: Integer -> Int#
+integerPopCount# value =
+  case signInteger# value of
+    0# -> 0#
+    1# -> popCountMagnitude# value 0# 0#
+    _ -> (-#) 0# (popCountMagnitude# value 0# 0#)
+
+integerPredecessorMagnitude :: Integer -> Integer
+integerPredecessorMagnitude value = integerSub (integerAbs value) (IS 1#)
+
+negativeFromComplement :: Integer -> Integer
+negativeFromComplement value = integerNegate (integerAdd value (IS 1#))
+
+positiveBitwise# :: Int# -> Integer -> Integer -> Integer
+positiveBitwise# operation left right =
+  case maxInt# (magnitudeSize# left) (magnitudeSize# right) of
+    wordCount ->
+      case newByteArray# ((*#) wordCount 8#) realWorld# of
+        (# state0, mutable #) ->
+          case writeBitwiseWords# operation left right mutable wordCount 0# state0 of
+            (# state1, _ #) ->
+              case trimMagnitudeWords# mutable ((-#) wordCount 1#) state1 of
+                (# state2, usedWords #) -> integerFromMagnitude# 1# (freezeTrimmed# mutable usedWords state2)
+
+positiveAndNot :: Integer -> Integer -> Integer
+positiveAndNot left right =
+  case magnitudeSize# left of
+    wordCount ->
+      case newByteArray# ((*#) wordCount 8#) realWorld# of
+        (# state0, mutable #) ->
+          case writeAndNotWords# left right mutable wordCount 0# state0 of
+            (# state1, _ #) ->
+              case trimMagnitudeWords# mutable ((-#) wordCount 1#) state1 of
+                (# state2, usedWords #) -> integerFromMagnitude# 1# (freezeTrimmed# mutable usedWords state2)
+
+writeBitwiseWords# :: Int# -> Integer -> Integer -> MutableByteArray# RealWorld -> Int# -> Int# -> State# RealWorld -> (# State# RealWorld, Int# #)
+writeBitwiseWords# operation left right mutable wordCount index state =
+  case (==#) index wordCount of
+    1# -> (# state, index #)
+    _ ->
+      case bitwiseWord# operation (magnitudeWordOrZero# left index) (magnitudeWordOrZero# right index) of
+        result ->
+          case writeWordArray# mutable index result state of
+            state1 -> writeBitwiseWords# operation left right mutable wordCount ((+#) index 1#) state1
+
+writeAndNotWords# :: Integer -> Integer -> MutableByteArray# RealWorld -> Int# -> Int# -> State# RealWorld -> (# State# RealWorld, Int# #)
+writeAndNotWords# left right mutable wordCount index state =
+  case (==#) index wordCount of
+    1# -> (# state, index #)
+    _ ->
+      case and# (magnitudeWord# left index) (not# (magnitudeWordOrZero# right index)) of
+        result ->
+          case writeWordArray# mutable index result state of
+            state1 -> writeAndNotWords# left right mutable wordCount ((+#) index 1#) state1
+
+bitwiseWord# :: Int# -> Word# -> Word# -> Word#
+bitwiseWord# operation left right =
+  case operation of
+    0# -> and# left right
+    1# -> or# left right
+    _ -> xor# left right
+
+splitBitIndex# :: Int# -> (# Int#, Int# #)
+splitBitIndex# amount =
+  (# word2Int# (uncheckedShiftRL# (int2Word# amount) 6#), word2Int# (and# (int2Word# amount) (int2Word# 63#)) #)
+
+testMagnitudeBit# :: Integer -> Int# -> Int#
+testMagnitudeBit# value amount =
+  case splitBitIndex# amount of
+    (# wordIndex, bitIndex #) ->
+      case (<#) wordIndex (magnitudeSize# value) of
+        1# ->
+          case eqWord# (and# (magnitudeWord# value wordIndex) (uncheckedShiftL# (int2Word# 1#) bitIndex)) (int2Word# 0#) of
+            1# -> 0#
+            _ -> 1#
+        _ -> 0#
+
+shiftMagnitudeL# :: Integer -> Int# -> ByteArray#
+shiftMagnitudeL# value amount =
+  case splitBitIndex# amount of
+    (# wordShift, bitShift #) ->
+      case (+#) ((+#) (magnitudeSize# value) wordShift) 1# of
+        resultSize ->
+          case newByteArray# ((*#) resultSize 8#) realWorld# of
+            (# state0, mutable #) ->
+              case zeroMagnitudeWords# mutable wordShift 0# state0 of
+                (# state1, _ #) ->
+                  case writeShiftedLeftWords# value mutable wordShift bitShift 0# (int2Word# 0#) state1 of
+                    (# state2, usedWords #) -> freezeTrimmed# mutable usedWords state2
+
+writeShiftedLeftWords# :: Integer -> MutableByteArray# RealWorld -> Int# -> Int# -> Int# -> Word# -> State# RealWorld -> (# State# RealWorld, Int# #)
+writeShiftedLeftWords# value mutable wordShift bitShift index carry state =
+  case (==#) index (magnitudeSize# value) of
+    1# ->
+      case eqWord# carry (int2Word# 0#) of
+        1# -> (# state, (+#) wordShift index #)
+        _ ->
+          case writeWordArray# mutable ((+#) wordShift index) carry state of
+            state1 -> (# state1, (+#) ((+#) wordShift index) 1# #)
+    _ ->
+      case magnitudeWord# value index of
+        word ->
+          case shiftedLeftWord# word bitShift carry of
+            (# result, nextCarry #) ->
+              case writeWordArray# mutable ((+#) wordShift index) result state of
+                state1 -> writeShiftedLeftWords# value mutable wordShift bitShift ((+#) index 1#) nextCarry state1
+
+shiftedLeftWord# :: Word# -> Int# -> Word# -> (# Word#, Word# #)
+shiftedLeftWord# word bitShift carry =
+  case bitShift of
+    0# -> (# word, int2Word# 0# #)
+    _ -> (# or# (uncheckedShiftL# word bitShift) carry, uncheckedShiftRL# word ((-#) 64# bitShift) #)
+
+shiftMagnitudeR# :: Integer -> Int# -> ByteArray#
+shiftMagnitudeR# value amount =
+  case splitBitIndex# amount of
+    (# wordShift, bitShift #) ->
+      case (<#) wordShift (magnitudeSize# value) of
+        0# -> emptyMagnitude# 0#
+        _ ->
+          case (-#) (magnitudeSize# value) wordShift of
+            resultSize ->
+              case newByteArray# ((*#) resultSize 8#) realWorld# of
+                (# state0, mutable #) ->
+                  case writeShiftedRightWords# value mutable wordShift bitShift resultSize 0# state0 of
+                    (# state1, _ #) ->
+                      case trimMagnitudeWords# mutable ((-#) resultSize 1#) state1 of
+                        (# state2, usedWords #) -> freezeTrimmed# mutable usedWords state2
+
+writeShiftedRightWords# :: Integer -> MutableByteArray# RealWorld -> Int# -> Int# -> Int# -> Int# -> State# RealWorld -> (# State# RealWorld, Int# #)
+writeShiftedRightWords# value mutable wordShift bitShift resultSize index state =
+  case (==#) index resultSize of
+    1# -> (# state, index #)
+    _ ->
+      case shiftedRightWord# value ((+#) wordShift index) bitShift of
+        result ->
+          case writeWordArray# mutable index result state of
+            state1 -> writeShiftedRightWords# value mutable wordShift bitShift resultSize ((+#) index 1#) state1
+
+shiftedRightWord# :: Integer -> Int# -> Int# -> Word#
+shiftedRightWord# value sourceIndex bitShift =
+  case bitShift of
+    0# -> magnitudeWord# value sourceIndex
+    _ ->
+      or#
+        (uncheckedShiftRL# (magnitudeWord# value sourceIndex) bitShift)
+        (uncheckedShiftL# (magnitudeWordOrZero# value ((+#) sourceIndex 1#)) ((-#) 64# bitShift))
+
+emptyMagnitude# :: Int# -> ByteArray#
+emptyMagnitude# size =
+  case newByteArray# size realWorld# of
+    (# state, mutable #) ->
+      case unsafeFreezeByteArray# mutable state of
+        (# _, magnitude #) -> magnitude
+
+popCountMagnitude# :: Integer -> Int# -> Int# -> Int#
+popCountMagnitude# value index total =
+  case (==#) index (magnitudeSize# value) of
+    1# -> total
+    _ -> popCountMagnitude# value ((+#) index 1#) ((+#) total (word2Int# (popCnt# (magnitudeWord# value index))))
 
 integerToInt# :: Integer -> Int#
 integerToInt# (IS value) = value

--- a/core-libs/aihc-base/src/GHC/Real.hs
+++ b/core-libs/aihc-base/src/GHC/Real.hs
@@ -1,1 +1,23 @@
-module GHC.Real () where
+{-# LANGUAGE MagicHash #-}
+
+module GHC.Real
+  ( Integral (..),
+    fromIntegral,
+  )
+where
+
+import GHC.Int (Int (..))
+import GHC.Internal.Integer (Integer (..))
+import GHC.Num (Num (..))
+
+class (Num a) => Integral a where
+  toInteger :: a -> Integer
+
+fromIntegral :: (Integral a, Num b) => a -> b
+fromIntegral value = fromInteger (toInteger value)
+
+instance Integral Int where
+  toInteger (I# value) = IS value
+
+instance Integral Integer where
+  toInteger value = value

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -11,6 +11,7 @@ module Prelude
     Functor (..),
     IO,
     Int,
+    Integral (..),
     Integer,
     List (..),
     Maybe (..),
@@ -28,6 +29,7 @@ module Prelude
     (/=),
     (==),
     id,
+    fromIntegral,
     not,
     otherwise,
     showChar,
@@ -46,6 +48,7 @@ import GHC.Integer (Integer)
 import GHC.Internal.Integer (Integer (..), compareInteger#, eqInteger#, integerAbs, integerQuotRemWord#)
 import GHC.Num (Num (..))
 import GHC.Prim (RealWorld, State#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
+import GHC.Real (Integral (..), fromIntegral)
 import GHC.Tuple ()
 
 data Char = C# Char#

--- a/test/Test/Fixtures/eval/base/data-bits-api.yaml
+++ b/test/Test/Fixtures/eval/base/data-bits-api.yaml
@@ -1,0 +1,134 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Bits
+
+    intChecks :: [Bool]
+    intChecks =
+      [ (12 .&. 10 :: Int) == 8
+      , (12 .|. 3 :: Int) == 15
+      , xor (12 :: Int) 10 == 6
+      , complement (0 :: Int) == negate 1
+      , shift (3 :: Int) 2 == 12
+      , shift (8 :: Int) (negate 2) == 2
+      , shiftL (1 :: Int) 64 == 0
+      , shift (1 :: Int) (negate 64) == 0
+      , shiftR (negate 2 :: Int) 1 == negate 1
+      , shiftR (1 :: Int) 64 == 0
+      , rotateL (1 :: Int) 1 == 2
+      , rotateR (1 :: Int) 1 == bit 63
+      , rotate (1 :: Int) (negate 1) == bit 63
+      , rotate (1 :: Int) 64 == 1
+      , rotate (1 :: Int) 65 == 2
+      , unsafeShiftL (3 :: Int) 2 == 12
+      , unsafeShiftR (8 :: Int) 2 == 2
+      , (zeroBits :: Int) == 0
+      , (bit 5 :: Int) == 32
+      , setBit (8 :: Int) 1 == 10
+      , clearBit (10 :: Int) 1 == 8
+      , complementBit (10 :: Int) 2 == 14
+      , testBit (10 :: Int) 3
+      , not (testBit (10 :: Int) 2)
+      , bitSizeMaybe (0 :: Int) == Just 64
+      , bitSize (0 :: Int) == 64
+      , finiteBitSize (0 :: Int) == 64
+      , isSigned (0 :: Int)
+      , popCount (negate 3 :: Int) == 63
+      , countLeadingZeros (1 :: Int) == 63
+      , countLeadingZeros (0 :: Int) == 64
+      , countTrailingZeros (negate 8 :: Int) == 3
+      , countTrailingZeros (0 :: Int) == 64
+      , clearBit (7 :: Int) 64 == 7
+      ]
+
+    boolChecks :: [Bool]
+    boolChecks =
+      [ True .&. False == False
+      , True .|. False == True
+      , xor True True == False
+      , complement False == True
+      , shift True 0 == True
+      , shift True 1 == False
+      , rotate False 17 == False
+      , (zeroBits :: Bool) == False
+      , bit 0 == True
+      , bit 1 == False
+      , testBit True 0
+      , not (testBit True 1)
+      , bitSizeMaybe False == Just 1
+      , finiteBitSize False == 1
+      , not (isSigned False)
+      , popCount True == 1
+      , countLeadingZeros False == 1
+      , countTrailingZeros True == 0
+      , setBit False 0 == True
+      , clearBit True 0 == False
+      ]
+
+    integerChecks :: [Bool]
+    integerChecks =
+      [ ((bit 130 .|. bit 5) .&. complement (bit 5) :: Integer) == bit 130
+      , xor (bit 130 :: Integer) (bit 129) == bit 130 + bit 129
+      , complement (0 :: Integer) == negate 1
+      , ((negate 5) .&. 3 :: Integer) == 3
+      , ((negate 5) .|. 2 :: Integer) == negate 5
+      , xor (negate 5 :: Integer) 3 == negate 8
+      , ((negate 5) .&. negate 3 :: Integer) == negate 7
+      , ((negate 5) .|. negate 3 :: Integer) == negate 1
+      , xor (negate 5 :: Integer) (negate 3) == 6
+      , shiftL (3 :: Integer) 130 == bit 131 + bit 130
+      , shiftL (negate 3 :: Integer) 65 == negate (bit 66 + bit 65)
+      , shiftR (bit 130 + 3 :: Integer) 129 == 2
+      , shiftR (bit 130 + bit 64 + 1 :: Integer) 64 == bit 66 + 1
+      , shiftR (negate 3 :: Integer) 1 == negate 2
+      , rotate (3 :: Integer) (negate 1) == 1
+      , testBit (negate 2 :: Integer) 130
+      , not (testBit (negate 2 :: Integer) 0)
+      , popCount (bit 130 + bit 5 + 1 :: Integer) == 3
+      , popCount (negate 3 :: Integer) == negate 2
+      , (bit (negate 1) :: Integer) == 0
+      , bitSizeMaybe (0 :: Integer) == Nothing
+      , isSigned (0 :: Integer)
+      ]
+
+    defaultAndExtraChecks :: [Bool]
+    defaultAndExtraChecks =
+      [ (bitDefault 6 :: Int) == 64
+      , testBitDefault (64 :: Int) 6
+      , popCountDefault (42 :: Int) == 3
+      , (oneBits :: Int) == negate 1
+      , (12 .^. 10 :: Int) == 6
+      , (8 .>>. 2 :: Int) == 2
+      , (3 .<<. 2 :: Int) == 12
+      , (8 !>>. 2 :: Int) == 2
+      , (3 !<<. 2 :: Int) == 12
+      , getAnd (And 12 .&. And 10 :: And Int) == 8
+      , getAnd (setBit (And 8) 1 :: And Int) == 10
+      , getAnd (clearBit (And 10) 1 :: And Int) == 8
+      , getAnd (complementBit (And 10) 2 :: And Int) == 14
+      , getAnd (unsafeShiftR (And 8) 2 :: And Int) == 2
+      , getIor (Ior 12 .|. Ior 3 :: Ior Int) == 15
+      , getXor (xor (Xor 12) (Xor 10) :: Xor Int) == 6
+      , getIff (complement (Iff 0) :: Iff Int) == negate 1
+      , toIntegralSized (42 :: Integer) == (Just 42 :: Maybe Int)
+      , toIntegralSized (9223372036854775808 :: Integer) == (Nothing :: Maybe Int)
+      , toIntegralSized (negate (bit 63) - 1 :: Integer) == (Nothing :: Maybe Int)
+      , toIntegralSized (42 :: Int) == (Just 42 :: Maybe Integer)
+      ]
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (value : values) = value && allTrue values
+
+    checks :: Bool
+    checks = allTrue intChecks && allTrue boolChecks && allTrue integerChecks && allTrue defaultAndExtraChecks
+output: |
+  True
+expression: |
+  checks
+status: pass
+reason: Data.Bits matches the base-4.22 API for class defaults, Bool, Int, Integer, aliases, sized conversions, and bitwise wrapper types

--- a/test/Test/Fixtures/eval/base/data-bits-wrapper-exports.yaml
+++ b/test/Test/Fixtures/eval/base/data-bits-wrapper-exports.yaml
@@ -1,0 +1,21 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Bits (And (And), Iff (Iff), Ior (Ior), Xor (Xor), getAnd, getIff, getIor, getXor)
+
+    checks :: Bool
+    checks =
+      getAnd (And True)
+        && getIor (Ior True)
+        && getXor (Xor True)
+        && getIff (Iff True)
+output: |
+  True
+expression: |
+  checks
+status: pass
+reason: Data.Bits exports the base-4.22 bitwise wrapper constructors and getter functions


### PR DESCRIPTION
## Summary

- implement the `base-4.22` `Bits` and `FiniteBits` class surface in `GHC.Bits`, with `Data.Bits` aliases and the `And`, `Ior`, `Xor`, and `Iff` wrappers
- add `Bits` instances for `Bool`, `Int`, and arbitrary-precision `Integer`, including signed shifts, rotations, bit counts, and cross-limb operations
- add the minimal `Integral` conversion foundation needed for `toIntegralSized`
- cover 64-bit boundaries, mixed-sign integer truth tables, multi-limb shifts, defaults, aliases, conversions, and wrapper exports in shared FC/GRIN evaluation fixtures

No new primops or type-checker/desugarer changes were required; the implementation uses the existing word bitwise, shift, CLZ/CTZ, and popcount primitives.

## Impact

`Data.Bits` is now usable by core-library consumers for `Bool`, `Int`, and `Integer`, including arbitrary-precision signed bit operations. API progress increases by 40 symbols, from 179 to 219 (`1.78%` to `2.18%` against the current 10,055-symbol oracle).

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--pattern data-bits --hide-successes"`
- `cabal test -v0 aihc-grin:spec --test-options="--pattern data-bits --hide-successes"`
- `just fmt`
- `just check`
