### PR TITLE
feat(base): implement Prelude output functions

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -185,6 +185,7 @@ data StoredResolvedName
 
 data LoadedModule = LoadedModule
   { loadedLibrary :: !Text,
+    loadedModuleExposed :: !Bool,
     loadedModule :: !Module
   }
 
@@ -192,7 +193,8 @@ data LoadedModule = LoadedModule
 data LibraryPackage = LibraryPackage
   { libraryPackageName :: !Text,
     libraryPackageRoot :: !FilePath,
-    libraryPackageFiles :: ![FilePath]
+    libraryPackageFiles :: ![FilePath],
+    libraryPackageExposedModules :: ![Text]
   }
   deriving (Eq, Show)
 
@@ -349,7 +351,7 @@ loadLibraryPackages packages = do
     loadPackage package =
       sequence
         <$> mapM
-          (parseModuleFile (libraryPackageName package))
+          (parseModuleFile (libraryPackageName package) (Set.fromList (libraryPackageExposedModules package)))
           (sort (libraryPackageFiles package))
 
     rejectDuplicateModules loaded = snd <$> foldM insertModule (Map.empty, []) loaded
@@ -369,12 +371,12 @@ loadLibraryPackages packages = do
                     <> T.unpack (loadedLibrary modu)
                 )
 
-parseModuleFile :: Text -> FilePath -> IO (Either String LoadedModule)
-parseModuleFile library path = do
+parseModuleFile :: Text -> Set.Set Text -> FilePath -> IO (Either String LoadedModule)
+parseModuleFile library exposedModules path = do
   source <- Utf8.readFile path
   pure $
     case parseModule (parserConfig path source) source of
-      ([], modu) -> Right (LoadedModule library modu)
+      ([], modu) -> Right (LoadedModule library (maybe False (`Set.member` exposedModules) (moduleName modu)) modu)
       (errors, _) -> Left ("failed to parse library module " <> path <> ": " <> show errors)
 
 parserConfig :: FilePath -> Text -> ParserConfig
@@ -452,7 +454,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
 
     finish state =
       DependencyArtifact
-        { dependencyExports = compileStateExports state,
+        { dependencyExports = Map.restrictKeys (compileStateExports state) exposedModules,
           dependencyTerms = compileStateTerms state,
           dependencyTyCons = compileStateTyCons state,
           dependencyClasses = compileStateClasses state,
@@ -473,6 +475,14 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
           dependencyInitializerSymbols = [],
           dependencyArchivePaths = []
         }
+      where
+        exposedModules =
+          Set.fromList
+            [ name
+            | modu <- loaded,
+              loadedModuleExposed modu,
+              Just name <- [moduleName (loadedModule modu)]
+            ]
 
 data CompileState = CompileState
   { compileStateExports :: !ModuleExports,
@@ -651,7 +661,11 @@ dependencyGraphHash packages = do
   where
     packageChunks package = do
       files <- concat <$> mapM (fileChunks package) (sort (libraryPackageFiles package))
-      pure (Text.encodeUtf8 (frameText (libraryPackageName package)) : files)
+      pure
+        ( Text.encodeUtf8 (frameText (libraryPackageName package))
+            : Text.encodeUtf8 (frameText (T.intercalate "," (sort (libraryPackageExposedModules package))))
+            : files
+        )
 
     fileChunks package path = do
       bytes <- BS.readFile path

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -403,12 +403,14 @@ installPackageLibraries targets plan = do
   installLibraries (planStoreRoot plan) packages targets
   where
     packageLibrary package = do
-      files <- collectPlanFiles package
+      gpd <- readPlanPackageDescription package
+      files <- HackageCabal.collectLibraryFiles gpd (planSourcePath package)
       pure
         LibraryPackage
           { libraryPackageName = T.pack (pkgName (packageKeySpec (planPackageKey package))),
             libraryPackageRoot = planSourcePath package,
-            libraryPackageFiles = map HackageCabal.fileInfoPath files
+            libraryPackageFiles = map HackageCabal.fileInfoPath files,
+            libraryPackageExposedModules = HackageCabal.collectLibraryExposedModules gpd
           }
 
     flattenPackagePlan =
@@ -1245,7 +1247,8 @@ fcArtifactValue plan result =
 
 generatePackageInterface :: ModuleExports -> [(Text, TypeScheme)] -> [TcBindingResult] -> PackagePlan -> IO InterfaceBuildResult
 generatePackageInterface depExports importedTerms importedBindings plan = do
-  files <- collectPlanFiles plan
+  gpd <- readPlanPackageDescription plan
+  files <- HackageCabal.collectLibraryFiles gpd (planSourcePath plan)
   parsedFiles <- mapM (parseInterfaceFile (planSourcePath plan)) files
   let parsedModules = [modu | ParsedFileOk _ modu _ _ <- parsedFiles]
       sourceLinesByFile = Map.unionsWith Map.union (map parsedFileSourceLines parsedFiles)
@@ -1253,7 +1256,8 @@ generatePackageInterface depExports importedTerms importedBindings plan = do
       parseDiagnostics = enrichDiagnostics (concatMap parsedFileParseDiagnostics parsedFiles)
       cppDiagnostics = enrichDiagnostics (concatMap parsedFileCppDiagnostics parsedFiles)
       resolveResult = resolveWithDeps depExports parsedModules
-      ownExports = extractInterface resolveResult
+      exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
+      ownExports = Map.restrictKeys (extractInterface resolveResult) exposedModules
   (checkedModules, tcModules, tcDiagnostics, ownTerms) <- typecheckInterfaceModules importedTerms (resolvedModules resolveResult)
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
@@ -1378,14 +1382,12 @@ parsedFileCppDiagnostics parsed =
     ParsedFileOk _ _ _ cppDiagnostics -> cppDiagnostics
     ParsedFileFailed _ _ _ cppDiagnostics -> cppDiagnostics
 
-collectPlanFiles :: PackagePlan -> IO [HackageCabal.FileInfo]
-collectPlanFiles plan = do
+readPlanPackageDescription :: PackagePlan -> IO GenericPackageDescription
+readPlanPackageDescription plan = do
   cabalBytes <- BS.readFile (planCabalFile plan)
-  gpd <-
-    case runParseResult (parseGenericPackageDescription cabalBytes) of
-      (_, Right parsed) -> pure parsed
-      (_, Left (_, errs)) -> ioError (userError ("Failed to parse " <> planCabalFile plan <> ": " <> show errs))
-  HackageCabal.collectLibraryFiles gpd (planSourcePath plan)
+  case runParseResult (parseGenericPackageDescription cabalBytes) of
+    (_, Right parsed) -> pure parsed
+    (_, Left (_, errs)) -> ioError (userError ("Failed to parse " <> planCabalFile plan <> ": " <> show errs))
 
 parseInterfaceFile :: FilePath -> HackageCabal.FileInfo -> IO ParsedInterfaceFile
 parseInterfaceFile packageRoot fileInfo = do

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -49,6 +49,7 @@ import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
 import Control.Exception (bracket)
 import Data.Aeson (object, (.=))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Lazy.Char8 qualified as BL8
 import Data.IORef (newIORef)
 import Data.List (isInfixOf, isPrefixOf, isSuffixOf, sort)
@@ -458,11 +459,13 @@ test_plansLibraryComponentsWithoutExecutables =
         depRoot = root </> "dep"
         storeRoot = root </> "store"
     createDirectoryIfMissing True (sourceRoot </> "src")
+    createDirectoryIfMissing True (sourceRoot </> "src" </> "Demo")
     createDirectoryIfMissing True (sourceRoot </> "internal" </> "Demo")
     createDirectoryIfMissing True (sourceRoot </> "app")
     createDirectoryIfMissing True storeRoot
     writeFile (sourceRoot </> "demo.cabal") libraryOnlyInstallCabal
-    writeFile (sourceRoot </> "src" </> "Demo.hs") "module Demo where\nimport Demo.Internal\nimport Dep\nx = depId internalValue\n"
+    writeFile (sourceRoot </> "src" </> "Demo.hs") "module Demo where\nimport Demo.Internal\nimport Demo.Private\nimport Dep\nx = depId (privateValue internalValue)\n"
+    writeFile (sourceRoot </> "src" </> "Demo" </> "Private.hs") "module Demo.Private where\nprivateValue x = x\n"
     writeFile (sourceRoot </> "internal" </> "Demo" </> "Internal.hs") ("module Demo.Internal where\ninternalValue = ()\n" <> fixtureTupleDeclaration)
     writeFile (sourceRoot </> "app" </> "Main.hs") "module Main where\nthis executable is intentionally invalid\n"
     createFixturePackageWithSource depRoot "dep" "1.0.0" "Dep" [] "module Dep where\ndepId x = x\n"
@@ -473,10 +476,23 @@ test_plansLibraryComponentsWithoutExecutables =
         storeRoot
         (PackageSpec "demo" "0.1.0.0")
 
-    assertEqual "library source file count" 2 (planSourceFileCount plan)
+    assertEqual "library source file count" 3 (planSourceFileCount plan)
     assertEqual "external library dependencies" ["dep"] [pkgName (packageKeySpec (planPackageKey dependencyPlan)) | dependencyPlan <- planDependencyPlans plan]
     _ <- expectInstallSuccess (checkPackagePlan plan)
-    pure ()
+    result <- expectInstallSuccess (writeInstallScaffold plan)
+    interface <- BL8.readFile (resultInterfacePath result)
+    case Aeson.decode interface of
+      Just (Aeson.Object artifact) ->
+        case KeyMap.lookup "modules" artifact of
+          Just (Aeson.Array modules) -> do
+            let moduleNames =
+                  [ name
+                  | Aeson.Object moduleEntry <- foldr (:) [] modules,
+                    Just (Aeson.String name) <- [KeyMap.lookup "module" moduleEntry]
+                  ]
+            assertEqual "public interface modules" ["Demo", "Demo.Internal"] moduleNames
+          other -> assertFailure ("expected interface modules, got " <> show other)
+      other -> assertFailure ("expected interface artifact, got " <> show other)
 
 test_writeInstallScaffold :: Assertion
 test_writeInstallScaffold =
@@ -943,6 +959,7 @@ test_installedPackage =
   withTempDir "aihc-installed-package" $ \root -> do
     let sourceRoot = root </> "prim-fixture"
         primSource = sourceRoot </> "src" </> "GHC" </> "Prim.hs"
+        internalSource = sourceRoot </> "src" </> "GHC" </> "Prim" </> "Internal.hs"
         cabalFile = sourceRoot </> "prim-fixture.cabal"
         storeRoot = root </> "store"
         environment = CompileEnvironment storeRoot
@@ -952,6 +969,13 @@ test_installedPackage =
               "{-# LANGUAGE NoImplicitPrelude #-}",
               "module Main where",
               "import GHC.Prim",
+              "main = Unit"
+            ]
+        privateMainSource =
+          T.unlines
+            [ "{-# LANGUAGE NoImplicitPrelude #-}",
+              "module Main where",
+              "import GHC.Prim.Internal",
               "main = Unit"
             ]
     createDirectoryIfMissing True (takeDirectory primSource)
@@ -964,6 +988,7 @@ test_installedPackage =
             "build-type: Simple",
             "library",
             "  exposed-modules: GHC.Prim",
+            "  other-modules: GHC.Prim.Internal",
             "  hs-source-dirs: src",
             "  default-extensions: NoImplicitPrelude",
             "  default-language: GHC2021"
@@ -974,7 +999,16 @@ test_installedPackage =
       ( unlines
           [ "{-# LANGUAGE MagicHash #-}",
             "{-# LANGUAGE NoImplicitPrelude #-}",
-            "module GHC.Prim where",
+            "module GHC.Prim (Unit(..)) where",
+            "import GHC.Prim.Internal (Unit(..))"
+          ]
+      )
+    createDirectoryIfMissing True (takeDirectory internalSource)
+    writeFile
+      internalSource
+      ( unlines
+          [ "{-# LANGUAGE NoImplicitPrelude #-}",
+            "module GHC.Prim.Internal where",
             "data Unit = Unit"
           ]
       )
@@ -988,6 +1022,10 @@ test_installedPackage =
     case compileResult of
       Left err -> assertFailure (show err)
       Right assembly -> assertBool "expected installed dependency initializer" ("_aihc_init_" `T.isInfixOf` assembly)
+    privateCompileResult <- compileSourceToAssemblyWithDependenciesFor Llvm environment "PrivateMain.hs" privateMainSource
+    case privateCompileResult of
+      Left err -> assertBool ("expected private module error, got: " <> show err) ("GHC.Prim.Internal" `isInfixOf` show err)
+      Right _ -> assertFailure "expected private other-module import to be rejected"
     wholeResult <- compileSourceToWholeCoreWithDependencies environment "Main.hs" mainSource
     case wholeResult of
       Left err -> assertFailure (show err)
@@ -1220,6 +1258,7 @@ libraryOnlyInstallCabal =
       "",
       "library",
       "  exposed-modules: Demo",
+      "  other-modules: Demo.Private",
       "  hs-source-dirs: src",
       "  build-depends: demo-internal, dep",
       "  default-language: Haskell2010",

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -209,17 +209,18 @@ resolveModule exports nextLocal modu =
   let imports' = resolveModuleImports exports (moduleImports modu)
       modu' = modu {moduleImports = imports'}
       scope = moduleScope exports modu'
-      (nextLocal', decls') = runResolveM scope (moduleInfo modu') nextLocal (resolveTopLevelDecls Map.empty (moduleDecls modu))
+      (nextLocal', decls') = runResolveM scope (moduleInfo exports modu') nextLocal (resolveTopLevelDecls Map.empty (moduleDecls modu))
    in (nextLocal', modu' {moduleDecls = decls'})
 
-moduleInfo :: Module -> ModuleInfo
-moduleInfo modu =
+moduleInfo :: ModuleExports -> Module -> ModuleInfo
+moduleInfo exports modu =
   ModuleInfo
     { moduleInfoExtensions =
         applyImpliedExtensions $
           foldr applyExtensionSetting [] (moduleLanguagePragmas modu),
       moduleInfoExplicitPreludeImport =
-        any ((== "Prelude") . importDeclModule) (moduleImports modu)
+        any ((== "Prelude") . importDeclModule) (moduleImports modu),
+      moduleInfoGhcBaseScope = Map.findWithDefault emptyScope "GHC.Base" exports
     }
 
 resolveModuleImports :: ModuleExports -> [ImportDecl] -> [ImportDecl]
@@ -841,8 +842,21 @@ annotateDoBind isLast stmt
   | isLast = pure stmt
   | otherwise = do
       sp <- currentSpan
-      bindAnn <- syntaxTermAnnotation sp ">>="
+      bindAnn <- doBindAnnotation sp
       pure (DoAnn (mkAnnotation bindAnn) stmt)
+
+doBindAnnotation :: SourceSpan -> ResolveM ResolutionAnnotation
+doBindAnnotation sp = do
+  scope <- currentScope
+  info <- currentModuleInfo
+  -- GHC wires ordinary do notation to the canonical Monad method even when
+  -- GHC.Base is not imported. RebindableSyntax deliberately restores lexical
+  -- lookup so user-defined bind operators can replace it.
+  let resolved =
+        if RebindableSyntax `elem` moduleInfoExtensions info
+          then rebindableSyntaxTerm info scope ">>="
+          else lookupTerm ">>=" (moduleInfoGhcBaseScope info)
+  pure (ResolutionAnnotation sp ">>=" ResolutionNamespaceTerm resolved)
 
 resolveArithSeq :: ArithSeq -> ResolveM ArithSeq
 resolveArithSeq arithSeq =

--- a/components/aihc-resolve/src/Aihc/Resolve/Monad.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Monad.hs
@@ -33,7 +33,8 @@ data ResolveEnv = ResolveEnv
 
 data ModuleInfo = ModuleInfo
   { moduleInfoExtensions :: ![Extension],
-    moduleInfoExplicitPreludeImport :: !Bool
+    moduleInfoExplicitPreludeImport :: !Bool,
+    moduleInfoGhcBaseScope :: !Scope
   }
 
 newtype ResolveState = ResolveState

--- a/components/aihc-resolve/test/Test/Fixtures/golden/do-notation-ghc-base-bind.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/do-notation-ghc-base-bind.yaml
@@ -1,0 +1,41 @@
+extensions: []
+modules:
+  - |
+    module GHC.Base (Monad(..)) where
+
+    class Monad m where
+      (>>=) :: m a -> (a -> m b) -> m b
+      return :: a -> m a
+  - |
+    module Main where
+
+    import GHC.Base (return)
+
+    program value = do
+      result <- value
+      return result
+annotated:
+  - |
+    module GHC.Base (Monad(..)) where
+
+    class Monad m where
+          └─ t GHC.Base
+      (>>=) :: m a -> (a -> m b) -> m b
+      return :: a -> m a
+  - |
+    module Main where
+
+    import GHC.Base (return)
+
+    program value = do
+    │       └─ v 0
+    └─ v Main
+      result <- value
+      └─ v 1    └─ v 0
+      └─ v GHC.Base
+      return result
+      │      └─ v 1
+      └─ v GHC.Base
+status: pass
+reason: ordinary do notation resolves the canonical GHC.Base Monad method without
+  importing it, while return remains an ordinary imported method

--- a/core-libs/aihc-base/aihc-base.cabal
+++ b/core-libs/aihc-base/aihc-base.cabal
@@ -149,7 +149,6 @@ library
     GHC.IO
     GHC.IO.Buffer
     GHC.IO.BufferedIO
-    GHC.IO.Console
     GHC.IO.Device
     GHC.IO.Encoding
     GHC.IO.Encoding.CodePage
@@ -169,7 +168,6 @@ library
     GHC.IO.Handle.Text
     GHC.IO.Handle.Types
     GHC.IO.IOMode
-    GHC.IO.Runtime
     GHC.IO.StdHandles
     GHC.IO.SubSystem
     GHC.IO.Unsafe
@@ -251,6 +249,8 @@ library
     Unsafe.Coerce
 
   other-modules:
+    GHC.IO.Console
+    GHC.IO.Runtime
     GHC.Internal.Integer
 
   hs-source-dirs: src

--- a/core-libs/aihc-base/aihc-base.cabal
+++ b/core-libs/aihc-base/aihc-base.cabal
@@ -149,6 +149,7 @@ library
     GHC.IO
     GHC.IO.Buffer
     GHC.IO.BufferedIO
+    GHC.IO.Console
     GHC.IO.Device
     GHC.IO.Encoding
     GHC.IO.Encoding.CodePage
@@ -168,6 +169,7 @@ library
     GHC.IO.Handle.Text
     GHC.IO.Handle.Types
     GHC.IO.IOMode
+    GHC.IO.Runtime
     GHC.IO.StdHandles
     GHC.IO.SubSystem
     GHC.IO.Unsafe

--- a/core-libs/aihc-base/aihc-base.cabal
+++ b/core-libs/aihc-base/aihc-base.cabal
@@ -249,6 +249,7 @@ library
     Unsafe.Coerce
 
   other-modules:
+    GHC.IO.Buffer.Internal
     GHC.IO.Console
     GHC.IO.Runtime
     GHC.Internal.Integer

--- a/core-libs/aihc-base/src/GHC/Base.hs
+++ b/core-libs/aihc-base/src/GHC/Base.hs
@@ -1,1 +1,82 @@
-module GHC.Base () where
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module GHC.Base
+  ( Applicative (..),
+    Functor (..),
+    Monad (..),
+    bindIO,
+    returnIO,
+    thenIO,
+  )
+where
+
+import Data.Kind (Type)
+import GHC.IO (IO (..))
+import GHC.Prim (RealWorld, State#)
+
+class Functor (f :: Type -> Type) where
+  fmap :: (a -> b) -> f a -> f b
+
+class (Functor f) => Applicative (f :: Type -> Type) where
+  pure :: a -> f a
+  (<*>) :: f (a -> b) -> f a -> f b
+
+infixl 4 <*>
+
+class (Applicative m) => Monad (m :: Type -> Type) where
+  (>>=) :: m a -> (a -> m b) -> m b
+  (>>) :: m a -> m b -> m b
+  return :: a -> m a
+
+infixl 1 >>=, >>
+
+instance Functor IO where
+  fmap f (IO action) =
+    IO
+      ( \state ->
+          case action state of
+            (# nextState, value #) -> (# nextState, f value #)
+      )
+
+instance Applicative IO where
+  pure = returnIO
+
+  IO function <*> IO argument =
+    IO
+      ( \state ->
+          case function state of
+            (# functionState, f #) ->
+              case argument functionState of
+                (# resultState, value #) -> (# resultState, f value #)
+      )
+
+instance Monad IO where
+  (>>=) = bindIO
+  (>>) = thenIO
+  return = returnIO
+
+bindIO :: IO a -> (a -> IO b) -> IO b
+bindIO (IO action) next =
+  IO
+    ( \state ->
+        case action state of
+          (# nextState, value #) ->
+            case next value of
+              IO nextAction -> nextAction nextState
+    )
+
+thenIO :: IO a -> IO b -> IO b
+thenIO (IO action) (IO nextAction) =
+  IO
+    ( \state ->
+        case action state of
+          (# nextState, _ #) -> nextAction nextState
+    )
+
+returnIO :: a -> IO a
+returnIO value = IO (returnIOState value)
+
+returnIOState :: a -> State# RealWorld -> (# State# RealWorld, a #)
+returnIOState value state = (# state, value #)

--- a/core-libs/aihc-base/src/GHC/Foreign.hs
+++ b/core-libs/aihc-base/src/GHC/Foreign.hs
@@ -4,7 +4,8 @@
 module GHC.Foreign (openUtf8FilePath) where
 
 import GHC.Char (ord)
-import GHC.IO.FD (IOHandle, openIOHandle, withPinnedByteArray, writeMemoryByte)
+import GHC.IO.Buffer.Internal (withPinnedByteArray)
+import GHC.IO.FD (IOHandle, openIOHandle, writeMemoryByte)
 import GHC.Int (Int (..))
 import GHC.Prim (mutableByteArrayContents#)
 import GHC.Ptr (Ptr)

--- a/core-libs/aihc-base/src/GHC/IO/Buffer/Internal.hs
+++ b/core-libs/aihc-base/src/GHC/IO/Buffer/Internal.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+-- | Primitive pinned-buffer allocation shared by the internal IO layers.
+module GHC.IO.Buffer.Internal (withPinnedByteArray) where
+
+import GHC.IO (IO (..))
+import GHC.Prim (MutableByteArray#, RealWorld, newPinnedByteArray#)
+
+-- | Allocate zero-filled pinned storage for the duration of an action. The
+-- proof-of-concept runtime does not reclaim the allocation yet.
+withPinnedByteArray :: Int# -> (MutableByteArray# RealWorld -> IO a) -> IO a
+withPinnedByteArray size action =
+  IO
+    ( \state ->
+        case newPinnedByteArray# size state of
+          (# allocatedState, buffer #) ->
+            case action buffer of
+              IO run -> run allocatedState
+    )

--- a/core-libs/aihc-base/src/GHC/IO/Console.hs
+++ b/core-libs/aihc-base/src/GHC/IO/Console.hs
@@ -1,79 +1,55 @@
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
 
 -- | Low-level byte output used to bootstrap the text operations exported by
 -- 'Prelude'. This module must not depend on 'Prelude', because 'Prelude'
 -- supplies the public 'String' traversal and encoding policy.
 module GHC.IO.Console
-  ( withOutputBuffer,
-    writeOutputByte,
+  ( writeOutputByte,
     writeStdout,
   )
 where
 
-import GHC.Base (bindIO, returnIO)
-import GHC.IO (IO (..))
-import GHC.IO.Runtime (IOHandle, IORequest, raiseIOErrorRaw, stdoutHandle, submitWrite, takeResult, writeMemoryByte)
+import GHC.Base (Monad (return))
+import GHC.Event (awaitIO)
+import GHC.IO (IO)
+import GHC.IO.Runtime (IOHandle, raiseIOErrorRaw, stdoutHandle, submitWrite, takeResult, writeMemoryByte)
 import GHC.Int (Int (..))
 import GHC.Prim
   ( MutableByteArray#,
     RealWorld,
-    awaitIO#,
     mutableByteArrayContents#,
-    newPinnedByteArray#,
     (+#),
     (-#),
     (<#),
     (==#),
   )
-import GHC.Ptr (Ptr (..))
-
-withOutputBuffer :: Int# -> (MutableByteArray# RealWorld -> IO a) -> IO a
-withOutputBuffer size action =
-  IO
-    ( \state ->
-        case newPinnedByteArray# size state of
-          (# allocatedState, buffer #) ->
-            case action buffer of
-              IO run -> run allocatedState
-    )
+import GHC.Ptr (Ptr)
 
 writeOutputByte :: MutableByteArray# RealWorld -> Int# -> Int# -> IO ()
-writeOutputByte buffer offset value =
-  bindIO
-    (writeMemoryByte (mutableByteArrayContents# buffer) (I# offset) (I# value))
-    checkOutputByteResult
+writeOutputByte buffer offset value = do
+  encodedError <- writeMemoryByte (mutableByteArrayContents# buffer) (I# offset) (I# value)
+  checkOutputByteResult encodedError
 
 checkOutputByteResult :: Int -> IO ()
 checkOutputByteResult (I# encodedError) =
   case (<#) encodedError 0# of
     1# -> raiseConsoleIOError ((-#) ((-#) 0# encodedError) 1#)
-    _ -> returnIO ()
+    _ -> return ()
 
 writeStdout :: MutableByteArray# RealWorld -> Int# -> IO ()
 writeStdout buffer count =
   case (==#) count 0# of
-    1# -> returnIO ()
-    _ ->
-      bindIO
-        stdoutHandle
-        ( \handle ->
-            writeStdoutLoop handle (mutableByteArrayContents# buffer) 0# count
-        )
+    1# -> return ()
+    _ -> do
+      handle <- stdoutHandle
+      writeStdoutLoop handle (mutableByteArrayContents# buffer) 0# count
 
 writeStdoutLoop :: Ptr IOHandle -> Addr# -> Int# -> Int# -> IO ()
-writeStdoutLoop handle buffer offset remaining =
-  bindIO
-    (submitWrite handle buffer (I# offset) (I# remaining))
-    ( \request ->
-        bindIO
-          (awaitConsoleIO request)
-          (takeWriteResult request handle buffer offset remaining)
-    )
-
-takeWriteResult :: Ptr IORequest -> Ptr IOHandle -> Addr# -> Int# -> Int# -> () -> IO ()
-takeWriteResult request handle buffer offset remaining () =
-  bindIO (takeResult request) (finishWriteResult handle buffer offset remaining)
+writeStdoutLoop handle buffer offset remaining = do
+  request <- submitWrite handle buffer (I# offset) (I# remaining)
+  awaitIO request
+  transferred <- takeResult request
+  finishWriteResult handle buffer offset remaining transferred
 
 finishWriteResult :: Ptr IOHandle -> Addr# -> Int# -> Int# -> Int -> IO ()
 finishWriteResult handle buffer offset remaining (I# transferred) =
@@ -84,20 +60,11 @@ finishWriteResult handle buffer offset remaining (I# transferred) =
         1# -> raiseConsoleIOError 6#
         _ ->
           case (==#) transferred remaining of
-            1# -> returnIO ()
+            1# -> return ()
             _ -> writeStdoutLoop handle buffer ((+#) offset transferred) ((-#) remaining transferred)
 
-awaitConsoleIO :: Ptr request -> IO ()
-awaitConsoleIO (Ptr request) =
-  IO
-    ( \state ->
-        case awaitIO# request state of
-          nextState -> (# nextState, () #)
-    )
-
 raiseConsoleIOError :: Int# -> IO ()
-raiseConsoleIOError exceptionCode =
-  bindIO (raiseIOErrorRaw (I# exceptionCode)) retryConsoleIOError
-
-retryConsoleIOError :: Int -> IO ()
-retryConsoleIOError (I# exceptionCode) = raiseConsoleIOError exceptionCode
+raiseConsoleIOError exceptionCode = do
+  nextException <- raiseIOErrorRaw (I# exceptionCode)
+  case nextException of
+    I# nextExceptionCode -> raiseConsoleIOError nextExceptionCode

--- a/core-libs/aihc-base/src/GHC/IO/Console.hs
+++ b/core-libs/aihc-base/src/GHC/IO/Console.hs
@@ -11,13 +11,13 @@ module GHC.IO.Console
   )
 where
 
+import GHC.Base (bindIO, returnIO)
 import GHC.IO (IO (..))
 import GHC.IO.Runtime (IOHandle, IORequest, raiseIOErrorRaw, stdoutHandle, submitWrite, takeResult, writeMemoryByte)
 import GHC.Int (Int (..))
 import GHC.Prim
   ( MutableByteArray#,
     RealWorld,
-    State#,
     awaitIO#,
     mutableByteArrayContents#,
     newPinnedByteArray#,
@@ -40,7 +40,7 @@ withOutputBuffer size action =
 
 writeOutputByte :: MutableByteArray# RealWorld -> Int# -> Int# -> IO ()
 writeOutputByte buffer offset value =
-  bindConsoleIO
+  bindIO
     (writeMemoryByte (mutableByteArrayContents# buffer) (I# offset) (I# value))
     checkOutputByteResult
 
@@ -48,14 +48,14 @@ checkOutputByteResult :: Int -> IO ()
 checkOutputByteResult (I# encodedError) =
   case (<#) encodedError 0# of
     1# -> raiseConsoleIOError ((-#) ((-#) 0# encodedError) 1#)
-    _ -> pureConsoleIO ()
+    _ -> returnIO ()
 
 writeStdout :: MutableByteArray# RealWorld -> Int# -> IO ()
 writeStdout buffer count =
   case (==#) count 0# of
-    1# -> pureConsoleIO ()
+    1# -> returnIO ()
     _ ->
-      bindConsoleIO
+      bindIO
         stdoutHandle
         ( \handle ->
             writeStdoutLoop handle (mutableByteArrayContents# buffer) 0# count
@@ -63,17 +63,17 @@ writeStdout buffer count =
 
 writeStdoutLoop :: Ptr IOHandle -> Addr# -> Int# -> Int# -> IO ()
 writeStdoutLoop handle buffer offset remaining =
-  bindConsoleIO
+  bindIO
     (submitWrite handle buffer (I# offset) (I# remaining))
     ( \request ->
-        bindConsoleIO
+        bindIO
           (awaitConsoleIO request)
           (takeWriteResult request handle buffer offset remaining)
     )
 
 takeWriteResult :: Ptr IORequest -> Ptr IOHandle -> Addr# -> Int# -> Int# -> () -> IO ()
 takeWriteResult request handle buffer offset remaining () =
-  bindConsoleIO (takeResult request) (finishWriteResult handle buffer offset remaining)
+  bindIO (takeResult request) (finishWriteResult handle buffer offset remaining)
 
 finishWriteResult :: Ptr IOHandle -> Addr# -> Int# -> Int# -> Int -> IO ()
 finishWriteResult handle buffer offset remaining (I# transferred) =
@@ -84,7 +84,7 @@ finishWriteResult handle buffer offset remaining (I# transferred) =
         1# -> raiseConsoleIOError 6#
         _ ->
           case (==#) transferred remaining of
-            1# -> pureConsoleIO ()
+            1# -> returnIO ()
             _ -> writeStdoutLoop handle buffer ((+#) offset transferred) ((-#) remaining transferred)
 
 awaitConsoleIO :: Ptr request -> IO ()
@@ -97,23 +97,7 @@ awaitConsoleIO (Ptr request) =
 
 raiseConsoleIOError :: Int# -> IO ()
 raiseConsoleIOError exceptionCode =
-  bindConsoleIO (raiseIOErrorRaw (I# exceptionCode)) retryConsoleIOError
+  bindIO (raiseIOErrorRaw (I# exceptionCode)) retryConsoleIOError
 
 retryConsoleIOError :: Int -> IO ()
 retryConsoleIOError (I# exceptionCode) = raiseConsoleIOError exceptionCode
-
-bindConsoleIO :: IO a -> (a -> IO b) -> IO b
-bindConsoleIO (IO action) next =
-  IO
-    ( \state ->
-        case action state of
-          (# nextState, value #) ->
-            case next value of
-              IO nextAction -> nextAction nextState
-    )
-
-pureConsoleIO :: a -> IO a
-pureConsoleIO value = IO (pureConsoleState value)
-
-pureConsoleState :: a -> State# RealWorld -> (# State# RealWorld, a #)
-pureConsoleState value state = (# state, value #)

--- a/core-libs/aihc-base/src/GHC/IO/Console.hs
+++ b/core-libs/aihc-base/src/GHC/IO/Console.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+-- | Low-level byte output used to bootstrap the text operations exported by
+-- 'Prelude'. This module must not depend on 'Prelude', because 'Prelude'
+-- supplies the public 'String' traversal and encoding policy.
+module GHC.IO.Console
+  ( withOutputBuffer,
+    writeOutputByte,
+    writeStdout,
+  )
+where
+
+import GHC.IO (IO (..))
+import GHC.IO.Runtime (IOHandle, IORequest, raiseIOErrorRaw, stdoutHandle, submitWrite, takeResult, writeMemoryByte)
+import GHC.Int (Int (..))
+import GHC.Prim
+  ( MutableByteArray#,
+    RealWorld,
+    State#,
+    awaitIO#,
+    mutableByteArrayContents#,
+    newPinnedByteArray#,
+    (+#),
+    (-#),
+    (<#),
+    (==#),
+  )
+import GHC.Ptr (Ptr (..))
+
+withOutputBuffer :: Int# -> (MutableByteArray# RealWorld -> IO a) -> IO a
+withOutputBuffer size action =
+  IO
+    ( \state ->
+        case newPinnedByteArray# size state of
+          (# allocatedState, buffer #) ->
+            case action buffer of
+              IO run -> run allocatedState
+    )
+
+writeOutputByte :: MutableByteArray# RealWorld -> Int# -> Int# -> IO ()
+writeOutputByte buffer offset value =
+  bindConsoleIO
+    (writeMemoryByte (mutableByteArrayContents# buffer) (I# offset) (I# value))
+    checkOutputByteResult
+
+checkOutputByteResult :: Int -> IO ()
+checkOutputByteResult (I# encodedError) =
+  case (<#) encodedError 0# of
+    1# -> raiseConsoleIOError ((-#) ((-#) 0# encodedError) 1#)
+    _ -> pureConsoleIO ()
+
+writeStdout :: MutableByteArray# RealWorld -> Int# -> IO ()
+writeStdout buffer count =
+  case (==#) count 0# of
+    1# -> pureConsoleIO ()
+    _ ->
+      bindConsoleIO
+        stdoutHandle
+        ( \handle ->
+            writeStdoutLoop handle (mutableByteArrayContents# buffer) 0# count
+        )
+
+writeStdoutLoop :: Ptr IOHandle -> Addr# -> Int# -> Int# -> IO ()
+writeStdoutLoop handle buffer offset remaining =
+  bindConsoleIO
+    (submitWrite handle buffer (I# offset) (I# remaining))
+    ( \request ->
+        bindConsoleIO
+          (awaitConsoleIO request)
+          (takeWriteResult request handle buffer offset remaining)
+    )
+
+takeWriteResult :: Ptr IORequest -> Ptr IOHandle -> Addr# -> Int# -> Int# -> () -> IO ()
+takeWriteResult request handle buffer offset remaining () =
+  bindConsoleIO (takeResult request) (finishWriteResult handle buffer offset remaining)
+
+finishWriteResult :: Ptr IOHandle -> Addr# -> Int# -> Int# -> Int -> IO ()
+finishWriteResult handle buffer offset remaining (I# transferred) =
+  case (<#) transferred 0# of
+    1# -> raiseConsoleIOError ((-#) ((-#) 0# transferred) 1#)
+    _ ->
+      case (==#) transferred 0# of
+        1# -> raiseConsoleIOError 6#
+        _ ->
+          case (==#) transferred remaining of
+            1# -> pureConsoleIO ()
+            _ -> writeStdoutLoop handle buffer ((+#) offset transferred) ((-#) remaining transferred)
+
+awaitConsoleIO :: Ptr request -> IO ()
+awaitConsoleIO (Ptr request) =
+  IO
+    ( \state ->
+        case awaitIO# request state of
+          nextState -> (# nextState, () #)
+    )
+
+raiseConsoleIOError :: Int# -> IO ()
+raiseConsoleIOError exceptionCode =
+  bindConsoleIO (raiseIOErrorRaw (I# exceptionCode)) retryConsoleIOError
+
+retryConsoleIOError :: Int -> IO ()
+retryConsoleIOError (I# exceptionCode) = raiseConsoleIOError exceptionCode
+
+bindConsoleIO :: IO a -> (a -> IO b) -> IO b
+bindConsoleIO (IO action) next =
+  IO
+    ( \state ->
+        case action state of
+          (# nextState, value #) ->
+            case next value of
+              IO nextAction -> nextAction nextState
+    )
+
+pureConsoleIO :: a -> IO a
+pureConsoleIO value = IO (pureConsoleState value)
+
+pureConsoleState :: a -> State# RealWorld -> (# State# RealWorld, a #)
+pureConsoleState value state = (# state, value #)

--- a/core-libs/aihc-base/src/GHC/IO/Exception.hs
+++ b/core-libs/aihc-base/src/GHC/IO/Exception.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
-
 -- | The minimal synchronous IO error model used by the first 'Handle' layer.
 module GHC.IO.Exception
   ( IOError,
@@ -14,8 +10,9 @@ module GHC.IO.Exception
   )
 where
 
-import GHC.IO (IO (..))
-import GHC.Int (Int (..))
+import GHC.IO (IO)
+import GHC.IO.Runtime (raiseIOErrorRaw)
+import GHC.Int (Int)
 import Prelude hiding (Int)
 
 data IOErrorType
@@ -34,23 +31,12 @@ newtype IOException = IOError Int
 
 type IOError = IOException
 
-foreign import ccall unsafe "aihc_io_raise_error"
-  raiseIOErrorRaw :: Int# -> Int#
-
-raiseIOError :: Int -> IO Int
-raiseIOError (I# exceptionCode) =
-  IO
-    ( \state ->
-        case raiseIOErrorRaw exceptionCode of
-          result -> (# state, I# result #)
-    )
-
 -- | Raise an uncaught IO error. Catching typed exceptions is deliberately
 -- outside the initial IO milestone; native execution terminates after the
 -- runtime reports the encoded error number.
 ioError :: IOException -> IO a
 ioError (IOError exceptionCode) = do
-  raiseIOError exceptionCode
+  raiseIOErrorRaw exceptionCode
   ioError (IOError exceptionCode)
 
 ioErrorFromErrno :: String -> Maybe String -> Int -> IOException

--- a/core-libs/aihc-base/src/GHC/IO/FD.hs
+++ b/core-libs/aihc-base/src/GHC/IO/FD.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 
--- | Raw runtime-owned IO resources. 'Handle' supplies locking, lifecycle,
--- direction checks, and complete-transfer semantics above this module.
+-- | Buffer operations over runtime-owned IO resources. 'Handle' supplies
+-- locking, lifecycle, direction checks, and complete-transfer semantics above
+-- this module.
 module GHC.IO.FD
   ( IOHandle,
     stdinHandle,

--- a/core-libs/aihc-base/src/GHC/IO/FD.hs
+++ b/core-libs/aihc-base/src/GHC/IO/FD.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 
@@ -23,48 +22,25 @@ where
 
 import GHC.Event (awaitIO)
 import GHC.IO (IO (..))
+import GHC.IO.Runtime
+  ( IOHandle,
+    IORequest,
+    closeIOHandle,
+    openResultError,
+    stderrHandle,
+    stdinHandle,
+    stdoutHandle,
+    submitOpen,
+    submitRead,
+    submitWrite,
+    takeOpenResult,
+    takeResult,
+    writeMemoryByte,
+  )
 import GHC.Int (Int (..))
 import GHC.Prim (MutableByteArray#, RealWorld, copyAddrToByteArray#, mutableByteArrayContents#, newPinnedByteArray#)
 import GHC.Ptr (Ptr (..))
 import Prelude hiding (Int)
-
--- | An opaque IO resource owned by the runtime.
-data IOHandle
-
-data IORequest
-
-foreign import ccall unsafe "aihc_io_stdin"
-  stdinHandle :: IO (Ptr IOHandle)
-
-foreign import ccall unsafe "aihc_io_stdout"
-  stdoutHandle :: IO (Ptr IOHandle)
-
-foreign import ccall unsafe "aihc_io_stderr"
-  stderrHandle :: IO (Ptr IOHandle)
-
-foreign import ccall unsafe "aihc_io_submit_open"
-  submitOpen :: Addr# -> Int -> Int -> IO (Ptr IORequest)
-
-foreign import ccall unsafe "aihc_io_open_result_error"
-  openResultError :: Ptr IOHandle -> IO Int
-
-foreign import ccall unsafe "aihc_io_close"
-  closeIOHandle :: Ptr IOHandle -> IO Int
-
-foreign import ccall unsafe "aihc_memory_write_byte"
-  writeMemoryByte :: Addr# -> Int -> Int -> IO Int
-
-foreign import ccall unsafe "aihc_io_submit_read"
-  submitRead :: Ptr IOHandle -> Addr# -> Int -> Int -> IO (Ptr IORequest)
-
-foreign import ccall unsafe "aihc_io_submit_write"
-  submitWrite :: Ptr IOHandle -> Addr# -> Int -> Int -> IO (Ptr IORequest)
-
-foreign import ccall unsafe "aihc_io_take_result"
-  takeResult :: Ptr IORequest -> IO Int
-
-foreign import ccall unsafe "aihc_io_take_open_result"
-  takeOpenResult :: Ptr IORequest -> IO (Ptr IOHandle)
 
 openIOHandle :: Addr# -> Int -> Int -> IO (Either Int (Ptr IOHandle))
 openIOHandle path length mode = do

--- a/core-libs/aihc-base/src/GHC/IO/FD.hs
+++ b/core-libs/aihc-base/src/GHC/IO/FD.hs
@@ -12,7 +12,6 @@ module GHC.IO.FD
     openIOHandle,
     closeIOHandle,
     writeMemoryByte,
-    withPinnedByteArray,
     copyAddrToByteArray,
     readIntoBuffer,
     writeFromBuffer,
@@ -39,7 +38,7 @@ import GHC.IO.Runtime
     writeMemoryByte,
   )
 import GHC.Int (Int (..))
-import GHC.Prim (MutableByteArray#, RealWorld, copyAddrToByteArray#, mutableByteArrayContents#, newPinnedByteArray#)
+import GHC.Prim (MutableByteArray#, RealWorld, copyAddrToByteArray#, mutableByteArrayContents#)
 import GHC.Ptr (Ptr (..))
 import Prelude hiding (Int)
 
@@ -52,18 +51,6 @@ openIOHandle path length mode = do
   case openCode of
     0 -> return (Right result)
     _ -> return (Left openCode)
-
--- | Allocate zero-filled pinned storage for the duration of an action. The
--- proof-of-concept runtime does not reclaim the allocation yet.
-withPinnedByteArray :: Int# -> (MutableByteArray# RealWorld -> IO a) -> IO a
-withPinnedByteArray size action =
-  IO
-    ( \state ->
-        case newPinnedByteArray# size state of
-          (# allocatedState, buffer #) ->
-            case action buffer of
-              IO run -> run allocatedState
-    )
 
 copyAddrToByteArray :: Addr# -> MutableByteArray# RealWorld -> Int# -> Int# -> IO ()
 copyAddrToByteArray source buffer offset length =

--- a/core-libs/aihc-base/src/GHC/IO/Runtime.hs
+++ b/core-libs/aihc-base/src/GHC/IO/Runtime.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE MagicHash #-}
+
+-- | Dependency-free bindings to the runtime IO ABI. Higher layers share these
+-- declarations so each foreign wrapper has exactly one compiled definition.
+module GHC.IO.Runtime
+  ( IOHandle,
+    IORequest,
+    stdinHandle,
+    stdoutHandle,
+    stderrHandle,
+    submitOpen,
+    openResultError,
+    closeIOHandle,
+    writeMemoryByte,
+    submitRead,
+    submitWrite,
+    takeResult,
+    takeOpenResult,
+    raiseIOErrorRaw,
+  )
+where
+
+import GHC.IO (IO)
+import GHC.Int (Int)
+import GHC.Ptr (Ptr)
+
+data IOHandle
+
+data IORequest
+
+foreign import ccall unsafe "aihc_io_stdin"
+  stdinHandle :: IO (Ptr IOHandle)
+
+foreign import ccall unsafe "aihc_io_stdout"
+  stdoutHandle :: IO (Ptr IOHandle)
+
+foreign import ccall unsafe "aihc_io_stderr"
+  stderrHandle :: IO (Ptr IOHandle)
+
+foreign import ccall unsafe "aihc_io_submit_open"
+  submitOpen :: Addr# -> Int -> Int -> IO (Ptr IORequest)
+
+foreign import ccall unsafe "aihc_io_open_result_error"
+  openResultError :: Ptr IOHandle -> IO Int
+
+foreign import ccall unsafe "aihc_io_close"
+  closeIOHandle :: Ptr IOHandle -> IO Int
+
+foreign import ccall unsafe "aihc_memory_write_byte"
+  writeMemoryByte :: Addr# -> Int -> Int -> IO Int
+
+foreign import ccall unsafe "aihc_io_submit_read"
+  submitRead :: Ptr IOHandle -> Addr# -> Int -> Int -> IO (Ptr IORequest)
+
+foreign import ccall unsafe "aihc_io_submit_write"
+  submitWrite :: Ptr IOHandle -> Addr# -> Int -> Int -> IO (Ptr IORequest)
+
+foreign import ccall unsafe "aihc_io_take_result"
+  takeResult :: Ptr IORequest -> IO Int
+
+foreign import ccall unsafe "aihc_io_take_open_result"
+  takeOpenResult :: Ptr IORequest -> IO (Ptr IOHandle)
+
+foreign import ccall unsafe "aihc_io_raise_error"
+  raiseIOErrorRaw :: Int -> IO Int

--- a/core-libs/aihc-base/src/GHC/IO/StdHandles.hs
+++ b/core-libs/aihc-base/src/GHC/IO/StdHandles.hs
@@ -15,6 +15,7 @@ module GHC.IO.StdHandles
 where
 
 import GHC.Foreign (openUtf8FilePath)
+import GHC.IO.Buffer.Internal (withPinnedByteArray)
 import GHC.IO.Exception (ioError, ioErrorFromErrno)
 import GHC.IO.FD
   ( IOHandle,
@@ -23,7 +24,6 @@ import GHC.IO.FD
     stderrHandle,
     stdinHandle,
     stdoutHandle,
-    withPinnedByteArray,
     writeFromBuffer,
   )
 import GHC.IO.Handle.Types (Handle, newHandle)

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -45,14 +45,14 @@ module Prelude
 where
 
 import Data.Bool (Bool (..), not, otherwise, (&&), (||))
-import Data.Kind (Type)
-import GHC.IO (IO (..))
+import GHC.Base (Applicative (..), Functor (..), Monad (..))
+import GHC.IO (IO)
 import GHC.IO.Console (withOutputBuffer, writeOutputByte, writeStdout)
 import GHC.Int (Int (..))
 import GHC.Integer (Integer)
 import GHC.Internal.Integer (Integer (..), compareInteger#, eqInteger#, integerAbs, integerQuotRemWord#)
 import GHC.Num (Num (..))
-import GHC.Prim (MutableByteArray#, RealWorld, State#, and#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
+import GHC.Prim (MutableByteArray#, RealWorld, and#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
 import GHC.Real (Integral (..), fromIntegral)
 import GHC.Tuple ()
 
@@ -542,9 +542,6 @@ writeCharacterByte buffer offset (C# character) =
 (++) [] ys = ys
 (++) (x : xs) ys = x : (xs ++ ys)
 
-class Functor (f :: Type -> Type) where
-  fmap :: (a -> b) -> f a -> f b
-
 instance Functor List where
   fmap = fmapList
 
@@ -559,20 +556,6 @@ instance Functor (Either e) where
     case mx of
       Left e -> Left e
       Right x -> Right (f x)
-
-instance Functor IO where
-  fmap f (IO action) =
-    IO
-      ( \state ->
-          case action state of
-            (# nextState, value #) -> (# nextState, f value #)
-      )
-
-class (Functor f) => Applicative (f :: Type -> Type) where
-  pure :: a -> f a
-  (<*>) :: f (a -> b) -> f a -> f b
-
-infixl 4 <*>
 
 instance Applicative List where
   pure x = [x]
@@ -600,25 +583,6 @@ instance Applicative (Either e) where
         case mx of
           Left e -> Left e
           Right x -> Right (f x)
-
-instance Applicative IO where
-  pure value = IO (pureIO value)
-
-  IO function <*> IO argument =
-    IO
-      ( \state ->
-          case function state of
-            (# functionState, f #) ->
-              case argument functionState of
-                (# resultState, value #) -> (# resultState, f value #)
-      )
-
-class (Applicative m) => Monad (m :: Type -> Type) where
-  (>>=) :: m a -> (a -> m b) -> m b
-  (>>) :: m a -> m b -> m b
-  return :: a -> m a
-
-infixl 1 >>=, >>
 
 (=<<) :: (Monad m) => (a -> m b) -> m a -> m b
 f =<< mx = mx >>= f
@@ -651,27 +615,6 @@ instance Monad (Either e) where
       Left e -> Left e
       Right _ -> my
   return = Right
-
-instance Monad IO where
-  IO action >>= k =
-    IO
-      ( \state ->
-          case action state of
-            (# nextState, value #) ->
-              case k value of
-                IO nextAction -> nextAction nextState
-      )
-
-  IO action >> IO nextAction =
-    IO
-      ( \state ->
-          case action state of
-            (# nextState, _ #) -> nextAction nextState
-      )
-  return = pure
-
-pureIO :: a -> State# RealWorld -> (# State# RealWorld, a #)
-pureIO value state = (# state, value #)
 
 fmapList :: (a -> b) -> [a] -> [b]
 fmapList _ [] = []

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -47,7 +47,8 @@ where
 import Data.Bool (Bool (..), not, otherwise, (&&), (||))
 import GHC.Base (Applicative (..), Functor (..), Monad (..))
 import GHC.IO (IO)
-import GHC.IO.Console (withOutputBuffer, writeOutputByte, writeStdout)
+import GHC.IO.Buffer.Internal (withPinnedByteArray)
+import GHC.IO.Console (writeOutputByte, writeStdout)
 import GHC.Int (Int (..))
 import GHC.Integer (Integer)
 import GHC.Internal.Integer (Integer (..), compareInteger#, eqInteger#, integerAbs, integerQuotRemWord#)
@@ -505,7 +506,7 @@ putChar character = putStr [character]
 putStr :: String -> IO ()
 putStr [] = return ()
 putStr characters =
-  withOutputBuffer
+  withPinnedByteArray
     4096#
     ( \buffer ->
         writeStringChunks buffer 0# characters

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -32,6 +32,10 @@ module Prelude
     fromIntegral,
     not,
     otherwise,
+    print,
+    putChar,
+    putStr,
+    putStrLn,
     showChar,
     showParen,
     shows,
@@ -43,11 +47,12 @@ where
 import Data.Bool (Bool (..), not, otherwise, (&&), (||))
 import Data.Kind (Type)
 import GHC.IO (IO (..))
+import GHC.IO.Console (withOutputBuffer, writeOutputByte, writeStdout)
 import GHC.Int (Int (..))
 import GHC.Integer (Integer)
 import GHC.Internal.Integer (Integer (..), compareInteger#, eqInteger#, integerAbs, integerQuotRemWord#)
 import GHC.Num (Num (..))
-import GHC.Prim (RealWorld, State#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
+import GHC.Prim (MutableByteArray#, RealWorld, State#, and#, chr#, compareInt#, int2Word#, ord#, word2Int#, (+#), (<#), (==#))
 import GHC.Real (Integral (..), fromIntegral)
 import GHC.Tuple ()
 
@@ -493,6 +498,45 @@ protectNumericEscape chars@('7' : _) = '\\' : '&' : chars
 protectNumericEscape chars@('8' : _) = '\\' : '&' : chars
 protectNumericEscape chars@('9' : _) = '\\' : '&' : chars
 protectNumericEscape chars = chars
+
+putChar :: Char -> IO ()
+putChar character = putStr [character]
+
+putStr :: String -> IO ()
+putStr [] = return ()
+putStr characters =
+  withOutputBuffer
+    4096#
+    ( \buffer ->
+        writeStringChunks buffer 0# characters
+    )
+
+putStrLn :: String -> IO ()
+putStrLn characters = do
+  putStr characters
+  putChar '\n'
+
+print :: (Show a) => a -> IO ()
+print value = putStrLn (show value)
+
+writeStringChunks :: MutableByteArray# RealWorld -> Int# -> String -> IO ()
+writeStringChunks buffer count characters =
+  case characters of
+    [] -> writeStdout buffer count
+    character : remaining ->
+      case (==#) count 4096# of
+        1# -> do
+          writeStdout buffer count
+          writeStringChunks buffer 0# characters
+        _ -> do
+          writeCharacterByte buffer count character
+          writeStringChunks buffer ((+#) count 1#) remaining
+
+writeCharacterByte :: MutableByteArray# RealWorld -> Int# -> Char -> IO ()
+writeCharacterByte buffer offset (C# character) =
+  -- This initial text layer is intentionally byte-oriented. Handle encoding
+  -- will replace the low-byte mapping when the encoding API is implemented.
+  writeOutputByte buffer offset (word2Int# (and# (int2Word# (ord# character)) (int2Word# 255#)))
 
 (++) :: [a] -> [a] -> [a]
 (++) [] ys = ys

--- a/examples/hello-world/Main.hs
+++ b/examples/hello-world/Main.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE MagicHash #-}
-
 module Main where
 
-import GHC.Ptr (Ptr (..))
-import System.IO (hPutBuf, stdout)
-
 main :: IO ()
-main = hPutBuf stdout (Ptr "Hello, world!\n"# :: Ptr ()) 14
+main = putStrLn "Hello, world!"

--- a/test/Test/Fixtures/eval/base/prelude-io-output.yaml
+++ b/test/Test/Fixtures/eval/base/prelude-io-output.yaml
@@ -1,0 +1,26 @@
+dependencies:
+  - aihc-base
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+
+    main :: IO ()
+    main = do
+      putChar 'A'
+      putStr "BC"
+      putStrLn ""
+      putStrLn "line"
+      print True
+      print (42 :: Int)
+stdout: |
+  ABC
+  line
+  True
+  42
+output: |
+  ()
+expression: main
+status: pass
+reason: Prelude character, string, line, and Show-based output writes to stdout

--- a/test/Test/Fixtures/eval/base/prelude-io-output.yaml
+++ b/test/Test/Fixtures/eval/base/prelude-io-output.yaml
@@ -6,8 +6,12 @@ modules:
   - |
     module Test where
 
+    writeWithMonad :: IO ()
+    writeWithMonad = putStr "monad\n" >>= \ignored -> return ()
+
     main :: IO ()
     main = do
+      writeWithMonad
       putChar 'A'
       putStr "BC"
       putStrLn ""
@@ -15,6 +19,7 @@ modules:
       print True
       print (42 :: Int)
 stdout: |
+  monad
   ABC
   line
   True

--- a/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
+++ b/tooling/aihc-hackage/src/Aihc/Hackage/Cabal.hs
@@ -7,6 +7,7 @@ module Aihc.Hackage.Cabal
 
     -- * Component file discovery
     collectComponentFiles,
+    collectLibraryExposedModules,
     collectLibraryFiles,
 
     -- * Condition evaluation
@@ -149,6 +150,23 @@ collectLibraryFiles gpd packageRoot = do
 
   libraryFiles <- fmap concat (mapM (uncurry (libraryFilesFor pkgDescr evalCond packageRoot)) libraryTrees)
   pure (dedupeFiles libraryFiles)
+
+-- | Collect the public module interface selected by active Cabal conditions.
+-- Private @other-modules@ are intentionally absent even though
+-- 'collectLibraryFiles' includes their source files for compilation.
+collectLibraryExposedModules :: GenericPackageDescription -> [Text]
+collectLibraryExposedModules gpd =
+  nub
+    [ T.pack (prettyShow moduleName)
+    | tree <- libraryTrees,
+      let build = collectMergedBuildInfo evalCond libBuildInfo tree,
+      buildable build,
+      library <- collectCondTreeData evalCond tree,
+      moduleName <- exposedModules library
+    ]
+  where
+    evalCond = conditionEvaluator gpd
+    libraryTrees = maybe [] pure (condLibrary gpd) <> map snd (condSubLibraries gpd)
 
 collectExecutableFiles :: GenericPackageDescription -> FilePath -> IO [FileInfo]
 collectExecutableFiles gpd packageRoot = do


### PR DESCRIPTION
## Summary

- export `putChar`, `putStr`, `putStrLn`, and `print` from `Prelude`
- stream strings through a bounded pinned buffer and the asynchronous runtime stdout request path, including partial-write and IO-error handling
- define `Functor`, `Applicative`, `Monad`, their `IO` instances, and `bindIO`/`thenIO`/`returnIO` in `GHC.Base`, with `Prelude` reexporting the classes
- resolve ordinary do notation directly to the canonical `GHC.Base.>>=` method while preserving lexical lookup under `RebindableSyntax`
- share pinned allocation through the private `GHC.IO.Buffer.Internal`, use ordinary do notation in console code, and reuse `GHC.Event.awaitIO`
- keep `GHC.IO.Console` and `GHC.IO.Runtime` as private `other-modules`; neither extends the public `aihc-base` interface beyond GHC's
- compile Cabal `other-modules` for installed packages without publishing them in dependency or scaffold interfaces
- exercise every new operation in a shared FC/GRIN stdout fixture and use `putStrLn` in the hello-world example

## Why

Programs could use binary `System.IO` handles, but ordinary Prelude output still required manually constructing a pointer and byte count. These definitions provide the expected source-level API on top of the existing runtime IO machinery.

Text output is deliberately byte-oriented for this milestone: each `Char` contributes its low byte. Encoding-aware handle behavior remains future work.

## Impact

Simple programs can now write characters, strings, lines, and `Show` values without importing `System.IO` or using unboxed string addresses. `IO` supports the normal `Monad` API, and ordinary do notation uses the canonical GHC module even when `(>>=)` is not imported; `RebindableSyntax` remains rebindable. The implementation remains portable across the FC and GRIN interpreters, native/LLVM targets, and WASI P3. Installed package interfaces now also honor Cabal's `exposed-modules`/`other-modules` boundary, with regression coverage proving that public modules may use private helpers while downstream code cannot import them directly.

## Progress counts

- Prelude output operations: 0 -> 4
- shared FC/GRIN evaluation fixtures: +1
- examples using Prelude text output: 0 -> 1
- private runtime IO helper modules: 0 -> 3
- canonical `GHC.Base` IO primitives: 0 -> 3
- ordinary do-notation resolution regressions: +1
- installed-package visibility regressions: +2
- README progress tables: unchanged (maintained by the scheduled workflow)

## Validation

- `just fmt`
- `just check`
- `cabal test -v0 aihc-fc:spec --test-options="--pattern prelude-io-output --hide-successes"`
- `cabal test -v0 aihc-grin:spec --test-options="--pattern prelude-io-output --hide-successes"`
- `cabal test -v0 aihc-resolve:spec --ghc-options=-Werror --test-options="--hide-successes"`
- `cabal test -v0 aihc-fc:spec --ghc-options=-Werror --test-options="--hide-successes"`
- `cabal test -v0 aihc-grin:spec --ghc-options=-Werror --test-options="--hide-successes"`
- `cabal test -v0 aihc:spec --ghc-options=-Werror --test-options="--pattern plans --hide-successes"`
- `cabal test -v0 aihc:spec --ghc-options=-Werror --test-options="--pattern installed --hide-successes"`
- `nix build .#checks.aarch64-darwin.examples-tests --no-link`
- `nix build .#checks.aarch64-darwin.wasip3-example-test --no-link`
