### PR TITLE
feat(resolve): resolve deriving declarations

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -37,6 +37,8 @@ import Aihc.Parser.Syntax
     DataConDecl (..),
     DataDecl (..),
     Decl (..),
+    DerivingClause (..),
+    DerivingStrategy (..),
     DoStmt (..),
     Expr (..),
     Extension (..),
@@ -65,6 +67,7 @@ import Aihc.Parser.Syntax
     RecordField (..),
     Rhs (..),
     SourceSpan (..),
+    StandaloneDerivingDecl (..),
     TyVarBinder (..),
     Type (..),
     TypeSynDecl (..),
@@ -396,7 +399,8 @@ resolveDeclCore termDefinition decl =
     DeclPatSynSig {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclInstance instanceDecl ->
       DeclInstance <$> resolveInstanceDecl instanceDecl
-    DeclStandaloneDeriving {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclStandaloneDeriving derivingDecl ->
+      DeclStandaloneDeriving <$> resolveStandaloneDerivingDecl derivingDecl
     DeclTypeFamilyDecl {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclDataFamilyDecl {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
     DeclTypeFamilyInst {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
@@ -484,6 +488,38 @@ resolveInstanceDeclItem instanceDeclItem =
     InstanceItemTypeFamilyInst {} -> annotateUnhandledInstanceDeclItem <$> currentSpan <*> pure instanceDeclItem
     InstanceItemDataFamilyInst {} -> annotateUnhandledInstanceDeclItem <$> currentSpan <*> pure instanceDeclItem
     InstanceItemPragma {} -> annotateUnhandledInstanceDeclItem <$> currentSpan <*> pure instanceDeclItem
+
+resolveStandaloneDerivingDecl :: StandaloneDerivingDecl -> ResolveM StandaloneDerivingDecl
+resolveStandaloneDerivingDecl derivingDecl = do
+  (forallScope, forallBinders') <- bindTyVarBinders (standaloneDerivingForall derivingDecl)
+  (strategy', context', head') <-
+    extendScope forallScope $
+      (,,)
+        <$> traverse resolveDerivingStrategy (standaloneDerivingStrategy derivingDecl)
+        <*> mapM resolveType (standaloneDerivingContext derivingDecl)
+        <*> resolveType (standaloneDerivingHead derivingDecl)
+  pure
+    derivingDecl
+      { standaloneDerivingStrategy = strategy',
+        standaloneDerivingForall = forallBinders',
+        standaloneDerivingContext = context',
+        standaloneDerivingHead = head'
+      }
+
+resolveDerivingClause :: DerivingClause -> ResolveM DerivingClause
+resolveDerivingClause clause = do
+  strategy' <- traverse resolveDerivingStrategy (derivingStrategy clause)
+  classes' <-
+    case derivingClasses clause of
+      Left name -> Left <$> resolveTypeUseAtName name
+      Right tys -> Right <$> mapM resolveType tys
+  pure clause {derivingStrategy = strategy', derivingClasses = classes'}
+
+resolveDerivingStrategy :: DerivingStrategy -> ResolveM DerivingStrategy
+resolveDerivingStrategy strategy =
+  case strategy of
+    DerivingVia ty -> DerivingVia <$> resolveType ty
+    _ -> pure strategy
 
 resolveMatch :: Match -> ResolveM Match
 resolveMatch match =
@@ -1059,12 +1095,14 @@ resolveDataDecl keyword dataDecl = do
   context' <- mapM resolveType (dataDeclContext dataDecl)
   kind' <- traverse resolveType (dataDeclKind dataDecl)
   constructors' <- mapM resolveDataConDecl (dataDeclConstructors dataDecl)
+  deriving' <- mapM resolveDerivingClause (dataDeclDeriving dataDecl)
   pure
     dataDecl
       { dataDeclHead = head',
         dataDeclContext = context',
         dataDeclKind = kind',
-        dataDeclConstructors = map (resolveDataConDefinitions scope) constructors'
+        dataDeclConstructors = map (resolveDataConDefinitions scope) constructors',
+        dataDeclDeriving = deriving'
       }
 
 resolveTypeSynDecl :: TypeSynDecl -> ResolveM TypeSynDecl
@@ -1096,11 +1134,13 @@ resolveNewtypeDecl newtypeDecl = do
           InfixBinderHead lhs name rhs params -> InfixBinderHead lhs (resolveHeadName name) rhs params
   kind' <- traverse resolveType (newtypeDeclKind newtypeDecl)
   constructor' <- traverse resolveDataConDecl (newtypeDeclConstructor newtypeDecl)
+  deriving' <- mapM resolveDerivingClause (newtypeDeclDeriving newtypeDecl)
   pure
     newtypeDecl
       { newtypeDeclHead = head',
         newtypeDeclKind = kind',
-        newtypeDeclConstructor = resolveDataConDefinitions scope <$> constructor'
+        newtypeDeclConstructor = resolveDataConDefinitions scope <$> constructor',
+        newtypeDeclDeriving = deriving'
       }
 
 resolveDataConDecl :: DataConDecl -> ResolveM DataConDecl
@@ -1439,6 +1479,13 @@ resolveTypeUse name = do
   sp <- currentSpan
   scope <- currentScope
   pure (resolveNameTo sp ResolutionNamespaceType (resolveTypeName scope name) name)
+
+resolveTypeUseAtName :: Name -> ResolveM Name
+resolveTypeUseAtName name = do
+  sp <- currentSpan
+  scope <- currentScope
+  let nameSpan = effectiveResolutionSpan (spanStartNameSpan sp (nameText name)) (sourceSpanFromAnns (nameAnns name))
+  pure (resolveNameTo nameSpan ResolutionNamespaceType (resolveTypeName scope name) name)
 
 resolveScopedTypeVariableUse :: UnqualifiedName -> ResolveM UnqualifiedName
 resolveScopedTypeVariableUse name = do

--- a/components/aihc-resolve/test/Test/Fixtures/golden/deriving-clauses.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/deriving-clauses.yaml
@@ -1,0 +1,52 @@
+annotated:
+- |-
+  module Main where
+  class Stock a where
+        └─ t Main
+  class Anyclass a where
+        └─ t Main
+  class Via a where
+        └─ t Main
+  data Wrapper a = Wrapper a
+       └─ t Main   └─ v Main
+  data T a = T a
+       │     └─ v Main
+       └─ t Main
+    deriving stock Stock
+                   └─ t Main
+    deriving anyclass (Anyclass)
+                       └─ t Main
+    deriving (Via) via Wrapper a
+              │        └─ t Main
+              └─ t Main
+  newtype N a = N a
+          │     └─ v Main
+          └─ t Main
+    deriving stock Stock
+                   └─ t Main
+  data Bad = Bad
+       │     └─ v Main
+       └─ t Main
+    deriving Missing
+             └─ t Error unbound
+extensions:
+- DeriveAnyClass
+- DerivingStrategies
+- DerivingVia
+modules:
+- |
+  module Main where
+  class Stock a where
+  class Anyclass a where
+  class Via a where
+  data Wrapper a = Wrapper a
+  data T a = T a
+    deriving stock Stock
+    deriving anyclass (Anyclass)
+    deriving (Via) via Wrapper a
+  newtype N a = N a
+    deriving stock Stock
+  data Bad = Bad
+    deriving Missing
+reason: ''
+status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/standalone-deriving.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/standalone-deriving.yaml
@@ -1,0 +1,31 @@
+annotated:
+- |-
+  module Main where
+  class Context a where
+        └─ t Main
+  class Derived a where
+        └─ t Main
+  data Wrapper a = Wrapper a
+       └─ t Main   └─ v Main
+  data T a = T a
+       │     └─ v Main
+       └─ t Main
+  deriving via Wrapper a instance forall a. Context a => Derived (T a)
+               │       └─ t 0               │       │    └─ t Main│ └─ t 0
+               └─ t Main                    │       └─ t 0        └─ t Main
+                                            └─ t Main
+extensions:
+- DerivingStrategies
+- DerivingVia
+- ExplicitForAll
+- StandaloneDeriving
+modules:
+- |
+  module Main where
+  class Context a where
+  class Derived a where
+  data Wrapper a = Wrapper a
+  data T a = T a
+  deriving via Wrapper a instance forall a. Context a => Derived (T a)
+reason: ''
+status: pass


### PR DESCRIPTION
## Summary

- resolve attached `data` and `newtype` deriving class references
- resolve `via` types without generating derived methods or dictionaries
- resolve standalone deriving strategies, contexts, and heads under their explicit `forall` scope
- report unbound deriving classes through the normal type-namespace diagnostics

This keeps the phase boundary explicit: `aihc-resolve` supplies names needed by later deriving work, while type checking and System FC generation remain unchanged.

## Tests

- `cabal test -v0 aihc-resolve:spec --test-options="--pattern resolver-golden --hide-successes"`
- `just fmt`
- `just check`

## Progress

- resolver golden PASS: 38 → 40
- resolver golden XFAIL: 1 → 1
- resolver golden coverage: 39 → 41 cases (97.56% passing)
