### PR TITLE
feat(tc): add typed deriving plans

### DIFF
--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -19,6 +19,7 @@ library
     Aihc.Tc
     Aihc.Tc.Annotations
     Aihc.Tc.Constraint
+    Aihc.Tc.Deriving
     Aihc.Tc.Env
     Aihc.Tc.Error
     Aihc.Tc.Evidence

--- a/components/aihc-tc/common/TcAnnotatedRender.hs
+++ b/components/aihc-tc/common/TcAnnotatedRender.hs
@@ -18,6 +18,10 @@ import Aihc.Tc.Annotations
   ( TcAnnotation (..),
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
+    TcDerivingAnnotation (..),
+    TcDerivingContext (..),
+    TcDerivingPlan (..),
+    TcDerivingStrategy (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
   )
@@ -50,6 +54,7 @@ renderTcAnnotation annotation =
   pretty
     <$> ( renderTypeAnnotation <$> fromAnnotation @TcAnnotation annotation
             <|> renderClassAnnotation <$> fromAnnotation @TcClassAnnotation annotation
+            <|> renderDerivingAnnotation <$> fromAnnotation @TcDerivingAnnotation annotation
             <|> renderInstanceAnnotation <$> fromAnnotation @TcInstanceAnnotation annotation
             <|> renderInstanceMethodAnnotation <$> fromAnnotation @TcInstanceMethodAnnotation annotation
             <|> renderDiagnostic <$> fromAnnotation @TcDiagnostic annotation
@@ -61,11 +66,45 @@ renderTypeAnnotation ann =
 
 renderClassAnnotation :: TcClassAnnotation -> String
 renderClassAnnotation classAnnotation =
-  "class methods: " <> intercalate ", " (map renderClassMethod (tcClassMethods classAnnotation))
+  "class methods:" <> case tcClassMethods classAnnotation of
+    [] -> ""
+    methods -> " " <> intercalate ", " (map renderClassMethod methods)
 
 renderClassMethod :: TcClassMethodAnnotation -> String
 renderClassMethod method =
   renderTcSignature (tcClassMethodName method) (tcClassMethodType method)
+
+renderDerivingAnnotation :: TcDerivingAnnotation -> String
+renderDerivingAnnotation annotation =
+  "deriving plans: " <> intercalate ", " (map renderDerivingPlan (tcDerivingPlans annotation))
+
+renderDerivingPlan :: TcDerivingPlan -> String
+renderDerivingPlan plan =
+  renderDerivingStrategy (tcDerivingStrategy plan)
+    <> " "
+    <> renderTcType (TcTyCon (TyCon (tcDerivingClassName plan) (length (tcDerivingHeadTypes plan))) (tcDerivingHeadTypes plan))
+    <> renderDerivingContext (tcDerivingContext plan)
+    <> renderDerivingMethods (tcDerivingClassMethods plan)
+
+renderDerivingStrategy :: TcDerivingStrategy -> String
+renderDerivingStrategy strategy =
+  case strategy of
+    TcDerivingDefault -> "default"
+    TcDerivingStock -> "stock"
+    TcDerivingNewtype -> "newtype"
+    TcDerivingAnyclass -> "anyclass"
+    TcDerivingVia viaType -> "via " <> renderTcType viaType
+
+renderDerivingContext :: TcDerivingContext -> String
+renderDerivingContext context =
+  case context of
+    TcDerivingInferContext -> " [context: infer]"
+    TcDerivingExplicitContext [] -> " [context: ()]"
+    TcDerivingExplicitContext predicates -> " [context: " <> intercalate ", " (map renderPred predicates) <> "]"
+
+renderDerivingMethods :: [TcClassMethodAnnotation] -> String
+renderDerivingMethods [] = ""
+renderDerivingMethods methods = " [methods: " <> intercalate ", " (map (T.unpack . tcClassMethodName) methods) <> "]"
 
 renderInstanceAnnotation :: TcInstanceAnnotation -> String
 renderInstanceAnnotation ann =

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -53,6 +53,7 @@ module Aihc.Tc
     Pred (..),
     InstanceInfo (..),
     ClassInfo (..),
+    TyConFlavor (..),
     TyConInfo (..),
     Unique (..),
     liftedRuntimeRep,
@@ -62,6 +63,10 @@ module Aihc.Tc
     isLiftedType,
     isUnliftedType,
     TcAnnotation (..),
+    TcDerivingAnnotation (..),
+    TcDerivingContext (..),
+    TcDerivingPlan (..),
+    TcDerivingStrategy (..),
     TcDiagnostic (..),
     TcErrorKind (..),
     TcSeverity (..),
@@ -96,8 +101,8 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
-import Aihc.Tc.Annotations (TcAnnotation (..), renderPred, renderTcSignature, renderTcType)
-import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConInfo (..))
+import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), renderPred, renderTcSignature, renderTcType)
+import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..))
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tcModule, tcModuleScc)
 import Aihc.Tc.Generate.Expr (inferExpr)

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -17,6 +17,10 @@ module Aihc.Tc.Annotations
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
     TcDictBinderAnnotation (..),
+    TcDerivingAnnotation (..),
+    TcDerivingContext (..),
+    TcDerivingPlan (..),
+    TcDerivingStrategy (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
 
@@ -138,6 +142,47 @@ data TcClassAnnotation = TcClassAnnotation
     tcClassSuperClasses :: ![TcDictBinderAnnotation],
     tcClassMethods :: ![TcClassMethodAnnotation],
     tcClassDefaultMethods :: ![Text]
+  }
+  deriving (Eq, Show)
+
+-- | A checked deriving strategy. The default case remains explicit because
+-- choosing between stock, newtype, and anyclass is a type-checker policy
+-- decision that depends on the enabled extensions and the requested class.
+data TcDerivingStrategy
+  = TcDerivingDefault
+  | TcDerivingStock
+  | TcDerivingNewtype
+  | TcDerivingAnyclass
+  | TcDerivingVia !TcType
+  deriving (Eq, Show)
+
+-- | How the derived instance context is supplied. Standalone deriving has an
+-- explicit checked context; attached clauses require strategy-specific
+-- inference in a later type-checker step.
+data TcDerivingContext
+  = TcDerivingInferContext
+  | TcDerivingExplicitContext ![Pred]
+  deriving (Eq, Show)
+
+-- | Typed input to strategy-specific deriving. This deliberately contains
+-- the class layout needed by System FC lowering so downstream phases never
+-- need to reconstruct Haskell class information.
+data TcDerivingPlan = TcDerivingPlan
+  { tcDerivingStrategy :: !TcDerivingStrategy,
+    tcDerivingClassName :: !Text,
+    tcDerivingDictName :: !Text,
+    tcDerivingTyVars :: ![TyVarId],
+    tcDerivingHeadTypes :: ![TcType],
+    tcDerivingContext :: !TcDerivingContext,
+    tcDerivingClassTyVars :: ![TyVarId],
+    tcDerivingClassSuperClasses :: ![TcDictBinderAnnotation],
+    tcDerivingClassMethods :: ![TcClassMethodAnnotation],
+    tcDerivingDefaultMethods :: ![Text]
+  }
+  deriving (Eq, Show)
+
+newtype TcDerivingAnnotation = TcDerivingAnnotation
+  { tcDerivingPlans :: [TcDerivingPlan]
   }
   deriving (Eq, Show)
 

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -1,0 +1,409 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Normalize deriving syntax into typed plans for later strategy-specific
+-- checking and System FC lowering. This module checks the shared structure;
+-- individual deriving mechanisms remain responsible for inferring attached
+-- contexts and validating their class-specific rules.
+module Aihc.Tc.Deriving
+  ( annotateAttachedDerivingTc,
+    annotateStandaloneDerivingTc,
+  )
+where
+
+import Aihc.Parser.Syntax
+  ( Annotation,
+    BinderHead,
+    Decl (..),
+    DerivingClause (..),
+    DerivingStrategy (..),
+    Name (..),
+    SourceSpan (..),
+    StandaloneDerivingDecl (..),
+    Type (..),
+    UnqualifiedName,
+    binderHeadName,
+    binderHeadParams,
+    fromAnnotation,
+    instanceHeadName,
+    instanceHeadTypes,
+    mkAnnotation,
+    nameText,
+    tyVarBinderName,
+    unqualifiedNameText,
+  )
+import Aihc.Tc.Annotations
+  ( TcClassMethodAnnotation (..),
+    TcDerivingAnnotation (..),
+    TcDerivingContext (..),
+    TcDerivingPlan (..),
+    TcDerivingStrategy (..),
+    TcDictBinderAnnotation (..),
+  )
+import Aihc.Tc.Env (ClassInfo (..), TyConFlavor (..), TyConInfo (..))
+import Aihc.Tc.Error (TcErrorKind (..))
+import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkSurfaceType, defaultKindMetas, freeTypeVars, freshKindMeta, makeParamEnv, surfacePredToPred)
+import Aihc.Tc.Monad
+import Aihc.Tc.Types
+import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds)
+import Control.Monad (unless, zipWithM)
+import Data.List (find, nub, (\\))
+import Data.Map.Strict qualified as Map
+import Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import Data.Text (Text)
+import Data.Text qualified as T
+
+annotateAttachedDerivingTc :: TyConFlavor -> BinderHead UnqualifiedName -> [DerivingClause] -> Decl -> TcM Decl
+annotateAttachedDerivingTc targetFlavor targetHead clauses decl = do
+  plans <- checkAttachedDerivingPlans targetFlavor targetHead clauses
+  pure (annotateDerivingPlans plans decl)
+
+annotateDerivingPlans :: [TcDerivingPlan] -> Decl -> Decl
+annotateDerivingPlans [] decl = decl
+annotateDerivingPlans plans decl =
+  DeclAnn (mkAnnotation (TcDerivingAnnotation plans)) decl
+
+checkAttachedDerivingPlans :: TyConFlavor -> BinderHead UnqualifiedName -> [DerivingClause] -> TcM [TcDerivingPlan]
+checkAttachedDerivingPlans targetFlavor targetHead clauses = do
+  rawParams <- makeParamEnv (binderHeadParams targetHead)
+  params <- mapM defaultParam rawParams
+  let targetName = unqualifiedNameText (binderHeadName targetHead)
+      tvEnv = Map.fromList [(paramName param, (paramTyVar param, paramKind param)) | param <- params]
+  targetInfo <- lookupTyCon targetName
+  case targetInfo of
+    Nothing -> missingTypeInfo ("deriving target " <> T.unpack targetName)
+    Just info -> concat <$> mapM (checkClause info params tvEnv) clauses
+  where
+    defaultParam param = do
+      tyVar <- defaultTyVarKinds (paramTyVar param)
+      pure param {paramTyVar = tyVar, paramKind = tvKind tyVar}
+
+    checkClause targetInfo params tvEnv clause = do
+      classHeads <- attachedDerivingClassHeads clause
+      catMaybes <$> mapM (checkOne targetInfo params tvEnv (derivingStrategy clause)) classHeads
+
+    checkOne targetInfo params tvEnv strategy classHead = do
+      (plan, hadErrors) <-
+        withErrorTracking (checkAttachedDerivingPlan targetFlavor targetInfo params tvEnv strategy classHead)
+      pure (if hadErrors then Nothing else plan)
+
+data AttachedDerivingClassHead = AttachedDerivingClassHead
+  { attachedClassName :: !Name,
+    attachedClassArguments :: ![Type],
+    attachedClassSpan :: !SourceSpan
+  }
+
+attachedDerivingClassHeads :: DerivingClause -> TcM [AttachedDerivingClassHead]
+attachedDerivingClassHeads clause =
+  case derivingClasses clause of
+    Left className ->
+      pure [AttachedDerivingClassHead className [] (nameSourceSpan className)]
+    Right classTypes -> catMaybes <$> mapM classTypeHead classTypes
+  where
+    classTypeHead classType =
+      case instanceHeadName classType of
+        Just className ->
+          pure
+            ( Just
+                AttachedDerivingClassHead
+                  { attachedClassName = className,
+                    attachedClassArguments = instanceHeadTypes classType,
+                    attachedClassSpan = nameSourceSpan className `orSourceSpan` typeSpan classType
+                  }
+            )
+        Nothing -> do
+          emitError (typeSpan classType) (OtherError "invalid class in deriving clause")
+          pure Nothing
+
+checkAttachedDerivingPlan :: TyConFlavor -> TyConInfo -> [ParamInfo] -> TvKindEnv -> Maybe DerivingStrategy -> AttachedDerivingClassHead -> TcM (Maybe TcDerivingPlan)
+checkAttachedDerivingPlan targetFlavor targetInfo params tvEnv strategy classHead = do
+  let className = nameText (attachedClassName classHead)
+      classSpan = attachedClassSpan classHead
+      suppliedArguments = attachedClassArguments classHead
+  maybeClassInfo <- lookupClass className
+  case maybeClassInfo of
+    Nothing -> do
+      emitError classSpan (OtherError ("deriving target " <> T.unpack className <> " is not a type class"))
+      pure Nothing
+    Just classInfo ->
+      case unsnoc (ciTyVars classInfo) of
+        Nothing -> do
+          emitError classSpan (OtherError ("deriving class " <> T.unpack className <> " has no target parameter"))
+          pure Nothing
+        Just (prefixClassVars, targetClassVar)
+          | length suppliedArguments /= length prefixClassVars -> do
+              emitError classSpan (derivingArityError className (length prefixClassVars) (length suppliedArguments))
+              pure Nothing
+          | otherwise -> do
+              checkedArguments <- zipWithM (checkSurfaceType tvEnv) suppliedArguments (map tvKind prefixClassVars)
+              targetKind <- defaultKindMetas (tvKind targetClassVar)
+              targetType <- attachedTargetType classSpan targetInfo params targetKind
+              checkedStrategy <- checkDerivingStrategy targetFlavor tvEnv targetKind classSpan strategy
+              methods <- derivingClassMethods classInfo
+              let headTypes = checkedArguments <> [targetType]
+                  strategyTypes = case checkedStrategy of TcDerivingVia viaType -> [viaType]; _ -> []
+                  quantified = filter (\param -> any (typeMentionsTyVar (paramTyVar param)) (headTypes <> strategyTypes)) params
+              pure (Just (mkDerivingPlan checkedStrategy classInfo (map paramTyVar quantified) headTypes TcDerivingInferContext methods))
+
+attachedTargetType :: SourceSpan -> TyConInfo -> [ParamInfo] -> Kind -> TcM TcType
+attachedTargetType sourceSpan targetInfo params expectedKind = do
+  let tyCon = tciTyCon targetInfo
+      arguments = map (TcTyVar . paramTyVar) params
+      candidates =
+        [ TcTyCon tyCon (take argumentCount arguments)
+        | argumentCount <- [length arguments, length arguments - 1 .. 0]
+        ]
+  case find ((== expectedKind) . typeKind) candidates of
+    Just target -> pure target
+    Nothing -> do
+      emitError sourceSpan (KindMismatch expectedKind (tciKind targetInfo))
+      pure (TcTyCon tyCon arguments)
+
+annotateStandaloneDerivingTc :: StandaloneDerivingDecl -> TcM Decl
+annotateStandaloneDerivingTc derivingDecl = do
+  (maybePlan, hadErrors) <- withErrorTracking (checkStandaloneDerivingPlan derivingDecl)
+  let plans = if hadErrors then [] else maybeToList maybePlan
+  pure (annotateDerivingPlans plans (DeclStandaloneDeriving derivingDecl))
+
+checkStandaloneDerivingPlan :: StandaloneDerivingDecl -> TcM (Maybe TcDerivingPlan)
+checkStandaloneDerivingPlan derivingDecl =
+  case instanceHeadName (standaloneDerivingHead derivingDecl) of
+    Nothing -> do
+      emitError (typeSpan (standaloneDerivingHead derivingDecl)) (OtherError "invalid standalone deriving instance head")
+      pure Nothing
+    Just classNameSyntax -> do
+      let className = nameText classNameSyntax
+          classSpan = nameSourceSpan classNameSyntax `orSourceSpan` typeSpan (standaloneDerivingHead derivingDecl)
+          headArguments = instanceHeadTypes (standaloneDerivingHead derivingDecl)
+          surfaceTypes = standaloneDerivingContext derivingDecl <> headArguments <> derivingStrategyTypes (standaloneDerivingStrategy derivingDecl)
+          explicitNames = map tyVarBinderName (standaloneDerivingForall derivingDecl)
+          implicitNames = nub (concatMap freeTypeVars surfaceTypes) \\ explicitNames
+      explicitParams <- makeParamEnv (standaloneDerivingForall derivingDecl)
+      implicitParams <- mapM implicitParam implicitNames
+      let params = explicitParams <> implicitParams
+          tvEnv = Map.fromList [(paramName param, (paramTyVar param, paramKind param)) | param <- params]
+      maybeClassInfo <- lookupClass className
+      case maybeClassInfo of
+        Nothing -> do
+          emitError classSpan (OtherError ("deriving target " <> T.unpack className <> " is not a type class"))
+          pure Nothing
+        Just classInfo
+          | length headArguments /= length (ciTyVars classInfo) -> do
+              emitError classSpan (standaloneDerivingArityError className (length (ciTyVars classInfo)) (length headArguments))
+              pure Nothing
+          | otherwise -> do
+              checkedHead <- zipWithM (checkSurfaceType tvEnv) headArguments (map tvKind (ciTyVars classInfo))
+              checkedContext <- mapM (surfacePredToPred tvEnv) (standaloneDerivingContext derivingDecl)
+              let targetKind = maybe KType (tvKind . snd) (unsnoc (ciTyVars classInfo))
+              targetFlavor <- standaloneTargetFlavor checkedHead
+              checkedStrategy <- checkDerivingStrategy targetFlavor tvEnv targetKind classSpan (standaloneDerivingStrategy derivingDecl)
+              tyVars <- mapM (defaultTyVarKinds . paramTyVar) params
+              headTypes <- mapM defaultTypeKinds checkedHead
+              context <- mapM defaultPredKinds checkedContext
+              strategy <- defaultDerivingStrategyKinds checkedStrategy
+              methods <- derivingClassMethods classInfo
+              pure (Just (mkDerivingPlan strategy classInfo tyVars headTypes (TcDerivingExplicitContext context) methods))
+  where
+    implicitParam name = do
+      rawTyVar <- freshSkolemTv name
+      kind <- freshKindMeta
+      let tyVar = setTyVarKind kind rawTyVar
+      pure ParamInfo {paramName = name, paramTyVar = tyVar, paramKind = kind}
+
+mkDerivingPlan :: TcDerivingStrategy -> ClassInfo -> [TyVarId] -> [TcType] -> TcDerivingContext -> [TcClassMethodAnnotation] -> TcDerivingPlan
+mkDerivingPlan strategy classInfo tyVars headTypes context methods =
+  TcDerivingPlan
+    { tcDerivingStrategy = strategy,
+      tcDerivingClassName = className,
+      tcDerivingDictName = instanceDictName className headTypes,
+      tcDerivingTyVars = tyVars,
+      tcDerivingHeadTypes = headTypes,
+      tcDerivingContext = context,
+      tcDerivingClassTyVars = ciTyVars classInfo,
+      tcDerivingClassSuperClasses = map constraintTypeDictBinder (ciSuperClassTypes classInfo),
+      tcDerivingClassMethods = methods,
+      tcDerivingDefaultMethods = ciDefaultMethods classInfo
+    }
+  where
+    className = ciName classInfo
+
+checkDerivingStrategy :: TyConFlavor -> TvKindEnv -> Kind -> SourceSpan -> Maybe DerivingStrategy -> TcM TcDerivingStrategy
+checkDerivingStrategy targetFlavor tvEnv targetKind sourceSpan strategy =
+  case strategy of
+    Nothing -> pure TcDerivingDefault
+    Just DerivingStock -> pure TcDerivingStock
+    Just DerivingAnyclass -> pure TcDerivingAnyclass
+    Just DerivingNewtype -> do
+      unless (targetFlavor == NewtypeTyCon) $
+        emitError sourceSpan (OtherError "newtype deriving requires a newtype instance target")
+      pure TcDerivingNewtype
+    Just (DerivingVia viaType) ->
+      TcDerivingVia <$> checkSurfaceType tvEnv viaType targetKind
+
+derivingClassMethods :: ClassInfo -> TcM [TcClassMethodAnnotation]
+derivingClassMethods classInfo =
+  zipWithM method [0 :: Int ..] (ciMethods classInfo)
+  where
+    method index (methodName, scheme) = do
+      let methodType = schemeToType scheme
+      dictType <- selectorDictTypeTc methodName methodType
+      pure
+        TcClassMethodAnnotation
+          { tcClassMethodName = methodName,
+            tcClassMethodType = methodType,
+            tcClassMethodTyVars = fst (peelForAlls methodType),
+            tcClassMethodDictType = dictType,
+            tcClassMethodIndex = index
+          }
+
+selectorDictTypeTc :: Text -> TcType -> TcM TcType
+selectorDictTypeTc methodName methodType =
+  case snd (peelForAlls methodType) of
+    TcQualTy (predicate : _) _ -> pure (predType predicate)
+    _ -> missingTypeInfo ("class dictionary type for method selector " <> T.unpack methodName)
+
+derivingStrategyTypes :: Maybe DerivingStrategy -> [Type]
+derivingStrategyTypes (Just (DerivingVia viaType)) = [viaType]
+derivingStrategyTypes _ = []
+
+standaloneTargetFlavor :: [TcType] -> TcM TyConFlavor
+standaloneTargetFlavor headTypes =
+  case reverse headTypes of
+    targetType : _
+      | Just targetName <- tcTypeConstructorName targetType -> do
+          maybeInfo <- lookupTyCon targetName
+          pure (maybe DataTyCon tciFlavor maybeInfo)
+    _ -> pure DataTyCon
+
+tcTypeConstructorName :: TcType -> Maybe Text
+tcTypeConstructorName ty =
+  case ty of
+    TcTyCon tyCon _ -> Just (tyConName tyCon)
+    TcAppTy function _ -> tcTypeConstructorName function
+    _ -> Nothing
+
+defaultDerivingStrategyKinds :: TcDerivingStrategy -> TcM TcDerivingStrategy
+defaultDerivingStrategyKinds strategy =
+  case strategy of
+    TcDerivingVia viaType -> TcDerivingVia <$> defaultTypeKinds viaType
+    _ -> pure strategy
+
+constraintTypeDictBinder :: TcType -> TcDictBinderAnnotation
+constraintTypeDictBinder ty =
+  case constraintTypeToPred ty of
+    Just (ClassPred className arguments) -> TcDictBinderAnnotation className arguments ty
+    _ -> TcDictBinderAnnotation "<constraint>" [] ty
+
+constraintTypeToPred :: TcType -> Maybe Pred
+constraintTypeToPred ty =
+  case collectTypeApplications ty of
+    (TcTyCon (TyCon "~" 2) [], [left, right]) -> Just (EqPred left right)
+    (TcTyCon tyCon headArguments, arguments) ->
+      Just (ClassPred (tyConName tyCon) (headArguments <> arguments))
+    _ -> Nothing
+
+collectTypeApplications :: TcType -> (TcType, [TcType])
+collectTypeApplications ty =
+  case ty of
+    TcAppTy function argument ->
+      let (headType, arguments) = collectTypeApplications function
+       in (headType, arguments <> [argument])
+    _ -> (ty, [])
+
+predType :: Pred -> TcType
+predType (ClassPred className arguments) = TcTyCon (TyCon className (length arguments)) arguments
+predType (EqPred left right) = TcTyCon (TyCon "~" 2) [left, right]
+
+instanceDictName :: Text -> [TcType] -> Text
+instanceDictName className types = "$f" <> className <> T.concat (map typeSuffix types)
+
+typeSuffix :: TcType -> Text
+typeSuffix ty =
+  case ty of
+    TcTyVar tyVar -> tvName tyVar
+    TcTyCon tyCon [] -> tyConName tyCon
+    TcTyCon (TyCon "[]" _) [_] -> "List"
+    TcTyCon tyCon arguments -> tyConName tyCon <> T.concat (map typeSuffix arguments)
+    _ -> "T"
+
+schemeToType :: TypeScheme -> TcType
+schemeToType (ForAll [] [] ty) = ty
+schemeToType (ForAll tyVars [] ty) = foldr TcForAllTy ty tyVars
+schemeToType (ForAll [] predicates ty) = TcQualTy predicates ty
+schemeToType (ForAll tyVars predicates ty) = foldr TcForAllTy (TcQualTy predicates ty) tyVars
+
+peelForAlls :: TcType -> ([TyVarId], TcType)
+peelForAlls (TcForAllTy tyVar body) =
+  let (tyVars, inner) = peelForAlls body
+   in (tyVar : tyVars, inner)
+peelForAlls ty = ([], ty)
+
+typeMentionsTyVar :: TyVarId -> TcType -> Bool
+typeMentionsTyVar target ty =
+  case ty of
+    TcTyVar tyVar -> tyVar == target
+    TcMetaTv {} -> False
+    TcTyCon _ arguments -> any (typeMentionsTyVar target) arguments
+    TcFunTy argument result -> typeMentionsTyVar target argument || typeMentionsTyVar target result
+    TcForAllTy tyVar body -> tyVar /= target && typeMentionsTyVar target body
+    TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
+    TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+
+predicateMentionsTyVar :: TyVarId -> Pred -> Bool
+predicateMentionsTyVar target predicate =
+  case predicate of
+    ClassPred _ arguments -> any (typeMentionsTyVar target) arguments
+    EqPred left right -> typeMentionsTyVar target left || typeMentionsTyVar target right
+
+derivingArityError :: Text -> Int -> Int -> TcErrorKind
+derivingArityError className expected supplied =
+  OtherError
+    ( "deriving class "
+        <> T.unpack className
+        <> " expects "
+        <> show expected
+        <> " argument(s) before the instance target, but got "
+        <> show supplied
+    )
+
+standaloneDerivingArityError :: Text -> Int -> Int -> TcErrorKind
+standaloneDerivingArityError className expected supplied =
+  OtherError
+    ( "standalone deriving class "
+        <> T.unpack className
+        <> " expects "
+        <> show expected
+        <> " instance argument(s), but got "
+        <> show supplied
+    )
+
+nameSourceSpan :: Name -> SourceSpan
+nameSourceSpan = sourceSpanFromAnns . nameAnns
+
+sourceSpanFromAnns :: [Annotation] -> SourceSpan
+sourceSpanFromAnns annotations =
+  case [sourceSpan | annotation <- annotations, Just sourceSpan <- [fromAnnotation @SourceSpan annotation]] of
+    sourceSpan : _ -> sourceSpan
+    [] -> NoSourceSpan
+
+typeSpan :: Type -> SourceSpan
+typeSpan ty =
+  case ty of
+    TAnn annotation inner -> fromMaybe (typeSpan inner) (fromAnnotation @SourceSpan annotation)
+    TParen inner -> typeSpan inner
+    TForall _ inner -> typeSpan inner
+    TContext _ inner -> typeSpan inner
+    TKindSig inner _ -> typeSpan inner
+    _ -> NoSourceSpan
+
+orSourceSpan :: SourceSpan -> SourceSpan -> SourceSpan
+orSourceSpan NoSourceSpan fallback = fallback
+orSourceSpan sourceSpan _ = sourceSpan
+
+unsnoc :: [a] -> Maybe ([a], a)
+unsnoc [] = Nothing
+unsnoc values = Just (init values, last values)
+
+missingTypeInfo :: String -> TcM a
+missingTypeInfo message =
+  abortTc ("internal type annotation error: missing " <> message)

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -8,6 +8,7 @@ module Aihc.Tc.Env
     emptyGlobalEnv,
 
     -- * Type constructor info
+    TyConFlavor (..),
     TyConInfo (..),
     TypeSynonymInfo (..),
 
@@ -47,11 +48,19 @@ emptyGlobalEnv =
     }
 
 -- | Information about a type constructor.
+data TyConFlavor
+  = ClassTyCon
+  | DataTyCon
+  | NewtypeTyCon
+  | SynonymTyCon
+  deriving (Eq, Show, Read)
+
 data TyConInfo = TyConInfo
   { tciName :: !Text,
     tciArity :: !Int,
     tciTyCon :: !TyCon,
     tciKind :: !Kind,
+    tciFlavor :: !TyConFlavor,
     tciTypeSynonym :: !(Maybe TypeSynonymInfo)
   }
   deriving (Show, Read)

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -14,6 +14,10 @@ import Aihc.Tc.Annotations
     TcAnnotation (..),
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
+    TcDerivingAnnotation (..),
+    TcDerivingContext (..),
+    TcDerivingPlan (..),
+    TcDerivingStrategy (..),
     TcDictBinderAnnotation (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
@@ -126,6 +130,7 @@ rejectMetaFinalAnnotation :: Annotation -> TcM ()
 rejectMetaFinalAnnotation ann = do
   traverseReject "type annotation" (firstMetaTcAnnotation <$> fromAnnotation @TcAnnotation ann)
   traverseReject "class annotation" (firstMetaClassAnnotation <$> fromAnnotation @TcClassAnnotation ann)
+  traverseReject "deriving annotation" (firstMetaDerivingAnnotation <$> fromAnnotation @TcDerivingAnnotation ann)
   traverseReject "instance annotation" (firstMetaInstanceAnnotation <$> fromAnnotation @TcInstanceAnnotation ann)
   traverseReject "instance method annotation" (firstMetaInstanceMethodAnnotation <$> fromAnnotation @TcInstanceMethodAnnotation ann)
   where
@@ -157,6 +162,31 @@ firstMetaClassAnnotation classAnnotation =
 firstMetaClassMethodAnnotation :: TcClassMethodAnnotation -> Maybe Unique
 firstMetaClassMethodAnnotation method =
   firstMetaType (tcClassMethodType method) <|> firstMetaType (tcClassMethodDictType method)
+
+firstMetaDerivingAnnotation :: TcDerivingAnnotation -> Maybe Unique
+firstMetaDerivingAnnotation annotation =
+  firstJusts (map firstMetaDerivingPlan (tcDerivingPlans annotation))
+
+firstMetaDerivingPlan :: TcDerivingPlan -> Maybe Unique
+firstMetaDerivingPlan plan =
+  firstJusts
+    ( map firstMetaType (tcDerivingHeadTypes plan)
+        ++ map firstMetaClassMethodAnnotation (tcDerivingClassMethods plan)
+        ++ map firstMetaDictBinderAnnotation (tcDerivingClassSuperClasses plan)
+        ++ [firstMetaDerivingStrategy (tcDerivingStrategy plan), firstMetaDerivingContext (tcDerivingContext plan)]
+    )
+
+firstMetaDerivingStrategy :: TcDerivingStrategy -> Maybe Unique
+firstMetaDerivingStrategy strategy =
+  case strategy of
+    TcDerivingVia viaType -> firstMetaType viaType
+    _ -> Nothing
+
+firstMetaDerivingContext :: TcDerivingContext -> Maybe Unique
+firstMetaDerivingContext context =
+  case context of
+    TcDerivingInferContext -> Nothing
+    TcDerivingExplicitContext predicates -> firstJusts (map firstMetaPred predicates)
 
 firstMetaInstanceAnnotation :: TcInstanceAnnotation -> Maybe Unique
 firstMetaInstanceAnnotation ann =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -74,7 +74,8 @@ import Aihc.Tc.Annotations
     annotateDecl,
   )
 import Aihc.Tc.Constraint
-import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConInfo (..), TypeSynonymInfo (..))
+import Aihc.Tc.Deriving (annotateAttachedDerivingTc, annotateStandaloneDerivingTc)
+import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Finalize (finalizeModuleTc)
@@ -503,6 +504,7 @@ annotateDeclTc classMethods checkedValueNames decl =
       | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
     DeclClass classDecl -> annotateClassDeclTc classDecl
     DeclInstance instanceDecl -> annotateInstanceDeclTc classMethods instanceDecl
+    DeclStandaloneDeriving derivingDecl -> annotateStandaloneDerivingTc derivingDecl
     _ -> pure decl
 
 valueDeclWasChecked :: Set.Set Text -> ValueDecl -> Bool
@@ -569,7 +571,8 @@ annotateDataDeclTc dataDecl = do
   ty <- tyConBindingType tyName
   constructors <- mapM annotateDataConDeclTc (dataDeclConstructors dataDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (dataDeclHead dataDecl)
-  pure (DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors}))
+      annotatedDecl = DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors})
+  annotateAttachedDerivingTc DataTyCon (dataDeclHead dataDecl) (dataDeclDeriving dataDecl) annotatedDecl
 
 annotateNewtypeDeclTc :: NewtypeDecl -> TcM Decl
 annotateNewtypeDeclTc newtypeDecl = do
@@ -577,7 +580,8 @@ annotateNewtypeDeclTc newtypeDecl = do
   ty <- tyConBindingType tyName
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (newtypeDeclHead newtypeDecl)
-  pure (DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor}))
+      annotatedDecl = DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor})
+  annotateAttachedDerivingTc NewtypeTyCon (newtypeDeclHead newtypeDecl) (newtypeDeclDeriving newtypeDecl) annotatedDecl
 
 annotateBinderHeadName :: TcAnnotation -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName tcAnn head' =
@@ -1588,6 +1592,7 @@ registerClassDecl classDecl = do
         tciArity = length params,
         tciTyCon = mkTyCon className (length params) classKind,
         tciKind = classKind,
+        tciFlavor = ClassTyCon,
         tciTypeSynonym = Nothing
       }
   methodResults <- concat <$> mapM (registerClassItem classPred paramTvEnv paramTyVars) (classDeclItems classDecl)
@@ -1707,6 +1712,7 @@ registerDataDeclHeader dd = do
         tciArity = arity,
         tciTyCon = tc,
         tciKind = declaredKind,
+        tciFlavor = DataTyCon,
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
@@ -1741,6 +1747,7 @@ registerNewtypeDeclHeader nd = do
         tciArity = arity,
         tciTyCon = tc,
         tciKind = declaredKind,
+        tciFlavor = NewtypeTyCon,
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
@@ -1774,6 +1781,7 @@ registerTypeSynonymHeader typeSynDecl = do
         tciArity = arity,
         tciTyCon = tyCon,
         tciKind = declaredKind,
+        tciFlavor = SynonymTyCon,
         tciTypeSynonym = Just synonym
       }
   pure [TcBindingResult tyName tyName (kindToTcType declaredKind)]

--- a/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plan-errors.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plan-errors.yaml
@@ -1,0 +1,41 @@
+annotated:
+- |-
+  {-# LANGUAGE DeriveAnyClass, DerivingStrategies, GeneralizedNewtypeDeriving #-}
+  module Main where
+  class C a where
+  └─ class methods:
+  class Pair a b where
+  └─ class methods:
+  data NotClass
+       └─ type: *
+  data WrongRepresentation = WrongRepresentation
+       └─ type: *            └─ type: WrongRepresentation
+    deriving newtype C
+                     └─ error: newtype deriving requires a newtype instance target
+  data MissingArgument = MissingArgument
+       └─ type: *        └─ type: MissingArgument
+    deriving anyclass Pair
+                      └─ error: deriving class Pair expects 1 argument(s) before the instance target, but got 0
+  data WrongClass = WrongClass
+       └─ type: *   └─ type: WrongClass
+    deriving anyclass NotClass
+                      └─ error: deriving target NotClass is not a type class
+extensions:
+- DeriveAnyClass
+- DerivingStrategies
+- GeneralizedNewtypeDeriving
+modules:
+- |
+  {-# LANGUAGE DeriveAnyClass, DerivingStrategies, GeneralizedNewtypeDeriving #-}
+  module Main where
+  class C a where
+  class Pair a b where
+  data NotClass
+  data WrongRepresentation = WrongRepresentation
+    deriving newtype C
+  data MissingArgument = MissingArgument
+    deriving anyclass Pair
+  data WrongClass = WrongClass
+    deriving anyclass NotClass
+reason: invalid strategies and class heads are rejected before FC lowering
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plans.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plans.yaml
@@ -1,0 +1,59 @@
+annotated:
+- |-
+  {-# LANGUAGE DeriveAnyClass, DerivingStrategies, DerivingVia, GeneralizedNewtypeDeriving, KindSignatures #-}
+  module Main where
+  data Type
+       └─ type: *
+  class C a where
+  └─ class methods: c ∷ ∀ a. (C a) ⇒ a → a
+    c :: a -> a
+  class D a where
+  └─ class methods:
+  class HK (f :: Type -> Type) where
+  └─ class methods:
+  data Wrapper a = Wrapper a
+       │           └─ type: ∀ a. a → Wrapper a
+       └─ type: * → *
+  data T a = T a
+  │    │     └─ type: ∀ a. a → T a
+  │    └─ type: * → *
+  └─ deriving plans: anyclass C (T a) [context: infer] [methods: c], anyclass HK T [context: infer], via Wrapper a D (T a) [context: infer]
+    deriving anyclass C
+    deriving anyclass HK
+    deriving D via Wrapper a
+  newtype N a = N a
+  │       │     └─ type: ∀ a. a → N a
+  │       └─ type: * → *
+  └─ deriving plans: newtype C (N a) [context: infer] [methods: c]
+    deriving newtype C
+  data Default a = Default a
+  │    │           └─ type: ∀ a. a → Default a
+  │    └─ type: * → *
+  └─ deriving plans: default C (Default a) [context: infer] [methods: c]
+    deriving C
+extensions:
+- DeriveAnyClass
+- DerivingStrategies
+- DerivingVia
+- GeneralizedNewtypeDeriving
+- KindSignatures
+modules:
+- |
+  {-# LANGUAGE DeriveAnyClass, DerivingStrategies, DerivingVia, GeneralizedNewtypeDeriving, KindSignatures #-}
+  module Main where
+  data Type
+  class C a where
+    c :: a -> a
+  class D a where
+  class HK (f :: Type -> Type) where
+  data Wrapper a = Wrapper a
+  data T a = T a
+    deriving anyclass C
+    deriving anyclass HK
+    deriving D via Wrapper a
+  newtype N a = N a
+    deriving newtype C
+  data Default a = Default a
+    deriving C
+reason: deriving clauses become typed plans without generating declarations
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/standalone-deriving-plan.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/standalone-deriving-plan.yaml
@@ -1,0 +1,42 @@
+annotated:
+- |-
+  {-# LANGUAGE DerivingStrategies, DerivingVia, ExplicitForAll, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+  module Main where
+  class Context a where
+  └─ class methods:
+  class Derived a where
+  └─ class methods: derived ∷ ∀ a. (Derived a) ⇒ a → a
+    derived :: a -> a
+  data Wrapper a = Wrapper a
+       │           └─ type: ∀ a. a → Wrapper a
+       └─ type: * → *
+  data T a = T a
+       │     └─ type: ∀ a. a → T a
+       └─ type: * → *
+  newtype N a = N a
+          │     └─ type: ∀ a. a → N a
+          └─ type: * → *
+  deriving via Wrapper a instance forall a. Context a => Derived (T a)
+  └─ deriving plans: via Wrapper a Derived (T a) [context: Context a] [methods: derived]
+  deriving newtype instance Derived (N a)
+  └─ deriving plans: newtype Derived (N a) [context: ()] [methods: derived]
+extensions:
+- DerivingStrategies
+- DerivingVia
+- ExplicitForAll
+- GeneralizedNewtypeDeriving
+- StandaloneDeriving
+modules:
+- |
+  {-# LANGUAGE DerivingStrategies, DerivingVia, ExplicitForAll, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+  module Main where
+  class Context a where
+  class Derived a where
+    derived :: a -> a
+  data Wrapper a = Wrapper a
+  data T a = T a
+  newtype N a = N a
+  deriving via Wrapper a instance forall a. Context a => Derived (T a)
+  deriving newtype instance Derived (N a)
+reason: standalone deriving plans preserve their checked explicit context
+status: pass


### PR DESCRIPTION
## Summary

- add a dedicated `Aihc.Tc.Deriving` module that normalizes attached and standalone deriving syntax into typed annotations
- record the selected syntax strategy, dictionary identity, quantified variables, checked instance head, class layout, methods, defaults, superclasses, and checked `via` type
- preserve the phase boundary: standalone contexts are checked immediately, while attached plans explicitly carry `context: infer` for a later strategy-specific TC step
- kind-check higher-kinded deriving targets and eta-reduce the datatype application, such as producing `HK T` rather than `HK (T a)`
- track data/newtype/class/synonym type-constructor flavor and reject invalid `newtype` strategies, non-class targets, and class-arity mismatches

No derived methods, dictionaries, instances, or System FC are generated in this change.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`

## Progress

- TC annotated golden PASS: 65 → 68
- `aihc-tc` tests: 92 → 95
