### PR TITLE
feat(tc): select deriving strategies

### DIFF
--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -20,6 +20,7 @@ library
     Aihc.Tc.Annotations
     Aihc.Tc.Constraint
     Aihc.Tc.Deriving
+    Aihc.Tc.Deriving.Strategy
     Aihc.Tc.Env
     Aihc.Tc.Error
     Aihc.Tc.Evidence

--- a/components/aihc-tc/common/TcAnnotatedRender.hs
+++ b/components/aihc-tc/common/TcAnnotatedRender.hs
@@ -89,7 +89,6 @@ renderDerivingPlan plan =
 renderDerivingStrategy :: TcDerivingStrategy -> String
 renderDerivingStrategy strategy =
   case strategy of
-    TcDerivingDefault -> "default"
     TcDerivingStock -> "stock"
     TcDerivingNewtype -> "newtype"
     TcDerivingAnyclass -> "anyclass"

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -145,12 +145,11 @@ data TcClassAnnotation = TcClassAnnotation
   }
   deriving (Eq, Show)
 
--- | A checked deriving strategy. The default case remains explicit because
--- choosing between stock, newtype, and anyclass is a type-checker policy
--- decision that depends on the enabled extensions and the requested class.
+-- | The effective deriving strategy selected by the type checker. Source
+-- declarations without an explicit strategy are resolved before a plan is
+-- attached, so System FC never has to reproduce extension-sensitive policy.
 data TcDerivingStrategy
-  = TcDerivingDefault
-  | TcDerivingStock
+  = TcDerivingStock
   | TcDerivingNewtype
   | TcDerivingAnyclass
   | TcDerivingVia !TcType

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -17,6 +17,7 @@ import Aihc.Parser.Syntax
     Decl (..),
     DerivingClause (..),
     DerivingStrategy (..),
+    Extension,
     Name (..),
     SourceSpan (..),
     StandaloneDerivingDecl (..),
@@ -40,22 +41,23 @@ import Aihc.Tc.Annotations
     TcDerivingStrategy (..),
     TcDictBinderAnnotation (..),
   )
+import Aihc.Tc.Deriving.Strategy (checkDerivingStrategy)
 import Aihc.Tc.Env (ClassInfo (..), TyConFlavor (..), TyConInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkSurfaceType, defaultKindMetas, freeTypeVars, freshKindMeta, makeParamEnv, surfacePredToPred)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds)
-import Control.Monad (unless, zipWithM)
+import Control.Monad (zipWithM)
 import Data.List (find, nub, (\\))
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe, maybeToList)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-annotateAttachedDerivingTc :: TyConFlavor -> BinderHead UnqualifiedName -> [DerivingClause] -> Decl -> TcM Decl
-annotateAttachedDerivingTc targetFlavor targetHead clauses decl = do
-  plans <- checkAttachedDerivingPlans targetFlavor targetHead clauses
+annotateAttachedDerivingTc :: [Extension] -> TyConFlavor -> BinderHead UnqualifiedName -> [DerivingClause] -> Decl -> TcM Decl
+annotateAttachedDerivingTc extensions targetFlavor targetHead clauses decl = do
+  plans <- checkAttachedDerivingPlans extensions targetFlavor targetHead clauses
   pure (annotateDerivingPlans plans decl)
 
 annotateDerivingPlans :: [TcDerivingPlan] -> Decl -> Decl
@@ -63,8 +65,8 @@ annotateDerivingPlans [] decl = decl
 annotateDerivingPlans plans decl =
   DeclAnn (mkAnnotation (TcDerivingAnnotation plans)) decl
 
-checkAttachedDerivingPlans :: TyConFlavor -> BinderHead UnqualifiedName -> [DerivingClause] -> TcM [TcDerivingPlan]
-checkAttachedDerivingPlans targetFlavor targetHead clauses = do
+checkAttachedDerivingPlans :: [Extension] -> TyConFlavor -> BinderHead UnqualifiedName -> [DerivingClause] -> TcM [TcDerivingPlan]
+checkAttachedDerivingPlans extensions targetFlavor targetHead clauses = do
   rawParams <- makeParamEnv (binderHeadParams targetHead)
   params <- mapM defaultParam rawParams
   let targetName = unqualifiedNameText (binderHeadName targetHead)
@@ -84,7 +86,7 @@ checkAttachedDerivingPlans targetFlavor targetHead clauses = do
 
     checkOne targetInfo params tvEnv strategy classHead = do
       (plan, hadErrors) <-
-        withErrorTracking (checkAttachedDerivingPlan targetFlavor targetInfo params tvEnv strategy classHead)
+        withErrorTracking (checkAttachedDerivingPlan extensions targetFlavor targetInfo params tvEnv strategy classHead)
       pure (if hadErrors then Nothing else plan)
 
 data AttachedDerivingClassHead = AttachedDerivingClassHead
@@ -115,8 +117,8 @@ attachedDerivingClassHeads clause =
           emitError (typeSpan classType) (OtherError "invalid class in deriving clause")
           pure Nothing
 
-checkAttachedDerivingPlan :: TyConFlavor -> TyConInfo -> [ParamInfo] -> TvKindEnv -> Maybe DerivingStrategy -> AttachedDerivingClassHead -> TcM (Maybe TcDerivingPlan)
-checkAttachedDerivingPlan targetFlavor targetInfo params tvEnv strategy classHead = do
+checkAttachedDerivingPlan :: [Extension] -> TyConFlavor -> TyConInfo -> [ParamInfo] -> TvKindEnv -> Maybe DerivingStrategy -> AttachedDerivingClassHead -> TcM (Maybe TcDerivingPlan)
+checkAttachedDerivingPlan extensions targetFlavor targetInfo params tvEnv strategy classHead = do
   let className = nameText (attachedClassName classHead)
       classSpan = attachedClassSpan classHead
       suppliedArguments = attachedClassArguments classHead
@@ -138,7 +140,7 @@ checkAttachedDerivingPlan targetFlavor targetInfo params tvEnv strategy classHea
               checkedArguments <- zipWithM (checkSurfaceType tvEnv) suppliedArguments (map tvKind prefixClassVars)
               targetKind <- defaultKindMetas (tvKind targetClassVar)
               targetType <- attachedTargetType classSpan targetInfo params targetKind
-              checkedStrategy <- checkDerivingStrategy targetFlavor tvEnv targetKind classSpan strategy
+              checkedStrategy <- checkDerivingStrategy extensions targetFlavor className tvEnv targetKind classSpan strategy
               methods <- derivingClassMethods classInfo
               let headTypes = checkedArguments <> [targetType]
                   strategyTypes = case checkedStrategy of TcDerivingVia viaType -> [viaType]; _ -> []
@@ -159,14 +161,14 @@ attachedTargetType sourceSpan targetInfo params expectedKind = do
       emitError sourceSpan (KindMismatch expectedKind (tciKind targetInfo))
       pure (TcTyCon tyCon arguments)
 
-annotateStandaloneDerivingTc :: StandaloneDerivingDecl -> TcM Decl
-annotateStandaloneDerivingTc derivingDecl = do
-  (maybePlan, hadErrors) <- withErrorTracking (checkStandaloneDerivingPlan derivingDecl)
+annotateStandaloneDerivingTc :: [Extension] -> StandaloneDerivingDecl -> TcM Decl
+annotateStandaloneDerivingTc extensions derivingDecl = do
+  (maybePlan, hadErrors) <- withErrorTracking (checkStandaloneDerivingPlan extensions derivingDecl)
   let plans = if hadErrors then [] else maybeToList maybePlan
   pure (annotateDerivingPlans plans (DeclStandaloneDeriving derivingDecl))
 
-checkStandaloneDerivingPlan :: StandaloneDerivingDecl -> TcM (Maybe TcDerivingPlan)
-checkStandaloneDerivingPlan derivingDecl =
+checkStandaloneDerivingPlan :: [Extension] -> StandaloneDerivingDecl -> TcM (Maybe TcDerivingPlan)
+checkStandaloneDerivingPlan extensions derivingDecl =
   case instanceHeadName (standaloneDerivingHead derivingDecl) of
     Nothing -> do
       emitError (typeSpan (standaloneDerivingHead derivingDecl)) (OtherError "invalid standalone deriving instance head")
@@ -196,7 +198,7 @@ checkStandaloneDerivingPlan derivingDecl =
               checkedContext <- mapM (surfacePredToPred tvEnv) (standaloneDerivingContext derivingDecl)
               let targetKind = maybe KType (tvKind . snd) (unsnoc (ciTyVars classInfo))
               targetFlavor <- standaloneTargetFlavor checkedHead
-              checkedStrategy <- checkDerivingStrategy targetFlavor tvEnv targetKind classSpan (standaloneDerivingStrategy derivingDecl)
+              checkedStrategy <- checkDerivingStrategy extensions targetFlavor className tvEnv targetKind classSpan (standaloneDerivingStrategy derivingDecl)
               tyVars <- mapM (defaultTyVarKinds . paramTyVar) params
               headTypes <- mapM defaultTypeKinds checkedHead
               context <- mapM defaultPredKinds checkedContext
@@ -226,19 +228,6 @@ mkDerivingPlan strategy classInfo tyVars headTypes context methods =
     }
   where
     className = ciName classInfo
-
-checkDerivingStrategy :: TyConFlavor -> TvKindEnv -> Kind -> SourceSpan -> Maybe DerivingStrategy -> TcM TcDerivingStrategy
-checkDerivingStrategy targetFlavor tvEnv targetKind sourceSpan strategy =
-  case strategy of
-    Nothing -> pure TcDerivingDefault
-    Just DerivingStock -> pure TcDerivingStock
-    Just DerivingAnyclass -> pure TcDerivingAnyclass
-    Just DerivingNewtype -> do
-      unless (targetFlavor == NewtypeTyCon) $
-        emitError sourceSpan (OtherError "newtype deriving requires a newtype instance target")
-      pure TcDerivingNewtype
-    Just (DerivingVia viaType) ->
-      TcDerivingVia <$> checkSurfaceType tvEnv viaType targetKind
 
 derivingClassMethods :: ClassInfo -> TcM [TcClassMethodAnnotation]
 derivingClassMethods classInfo =

--- a/components/aihc-tc/src/Aihc/Tc/Deriving/Strategy.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving/Strategy.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Select and validate the effective mechanism for a deriving request.
+-- Keeping extension-sensitive policy here makes a checked deriving plan
+-- independent of source defaults and prevents System FC from choosing a
+-- Haskell-level strategy.
+module Aihc.Tc.Deriving.Strategy
+  ( checkDerivingStrategy,
+  )
+where
+
+import Aihc.Parser.Syntax
+  ( DerivingStrategy (..),
+    Extension (..),
+    SourceSpan,
+  )
+import Aihc.Tc.Annotations (TcDerivingStrategy (..))
+import Aihc.Tc.Env (TyConFlavor (..))
+import Aihc.Tc.Error (TcErrorKind (..))
+import Aihc.Tc.Kind (TvKindEnv, checkSurfaceType)
+import Aihc.Tc.Monad (TcM, emitError, emitWarning)
+import Aihc.Tc.Types (Kind)
+import Control.Monad (unless, when)
+import Data.Text (Text)
+import Data.Text qualified as T
+
+checkDerivingStrategy :: [Extension] -> TyConFlavor -> Text -> TvKindEnv -> Kind -> SourceSpan -> Maybe DerivingStrategy -> TcM TcDerivingStrategy
+checkDerivingStrategy extensions targetFlavor className tvEnv targetKind sourceSpan strategy =
+  case strategy of
+    Nothing -> selectDefaultDerivingStrategy extensions targetFlavor className sourceSpan
+    Just DerivingStock -> do
+      checkStockDeriving extensions className sourceSpan
+      pure TcDerivingStock
+    Just DerivingAnyclass -> do
+      requireDerivingExtension extensions DeriveAnyClass "anyclass deriving" sourceSpan
+      pure TcDerivingAnyclass
+    Just DerivingNewtype -> do
+      requireDerivingExtension extensions GeneralizedNewtypeDeriving "newtype deriving" sourceSpan
+      unless (targetFlavor == NewtypeTyCon) $
+        emitError sourceSpan (OtherError "newtype deriving requires a newtype instance target")
+      pure TcDerivingNewtype
+    Just (DerivingVia viaType) -> do
+      requireDerivingExtension extensions DerivingViaExtension "via deriving" sourceSpan
+      TcDerivingVia <$> checkSurfaceType tvEnv viaType targetKind
+
+selectDefaultDerivingStrategy :: [Extension] -> TyConFlavor -> Text -> SourceSpan -> TcM TcDerivingStrategy
+selectDefaultDerivingStrategy extensions targetFlavor className sourceSpan =
+  case stockDerivingRequirement className of
+    Just requiredExtension
+      | maybe True (`elem` extensions) requiredExtension -> pure TcDerivingStock
+    _
+      | DeriveAnyClass `elem` extensions -> do
+          when (targetFlavor == NewtypeTyCon && GeneralizedNewtypeDeriving `elem` extensions) $
+            emitWarning sourceSpan (OtherError (derivingDefaultsWarning className))
+          pure TcDerivingAnyclass
+      | targetFlavor == NewtypeTyCon,
+        GeneralizedNewtypeDeriving `elem` extensions ->
+          pure TcDerivingNewtype
+      | otherwise -> do
+          emitError sourceSpan (OtherError (defaultStrategyError targetFlavor className))
+          pure TcDerivingStock
+
+checkStockDeriving :: [Extension] -> Text -> SourceSpan -> TcM ()
+checkStockDeriving extensions className sourceSpan =
+  case stockDerivingRequirement className of
+    Nothing ->
+      emitError sourceSpan (OtherError ("stock deriving is not available for class " <> T.unpack className))
+    Just Nothing -> pure ()
+    Just (Just extension) ->
+      requireDerivingExtension extensions extension ("stock deriving for " <> T.unpack className) sourceSpan
+
+-- | Extensions required by GHC's stock deriving mechanisms. A @Nothing@
+-- requirement denotes the six classes available for ordinary Haskell data
+-- declarations without an extension.
+stockDerivingRequirement :: Text -> Maybe (Maybe Extension)
+stockDerivingRequirement className =
+  case className of
+    "Eq" -> Just Nothing
+    "Ord" -> Just Nothing
+    "Enum" -> Just Nothing
+    "Bounded" -> Just Nothing
+    "Show" -> Just Nothing
+    "Read" -> Just Nothing
+    "Data" -> Just (Just DeriveDataTypeable)
+    "Typeable" -> Just (Just DeriveDataTypeable)
+    "Foldable" -> Just (Just DeriveFoldable)
+    "Functor" -> Just (Just DeriveFunctor)
+    "Generic" -> Just (Just DeriveGeneric)
+    "Generic1" -> Just (Just DeriveGeneric)
+    "Lift" -> Just (Just DeriveLift)
+    "Traversable" -> Just (Just DeriveTraversable)
+    _ -> Nothing
+
+requireDerivingExtension :: [Extension] -> Extension -> String -> SourceSpan -> TcM ()
+requireDerivingExtension extensions extension mechanism sourceSpan =
+  unless (extension `elem` extensions) $
+    emitError sourceSpan (OtherError (mechanism <> " requires " <> derivingExtensionName extension))
+
+derivingExtensionName :: Extension -> String
+derivingExtensionName DerivingViaExtension = "DerivingVia"
+derivingExtensionName extension = show extension
+
+derivingDefaultsWarning :: Text -> String
+derivingDefaultsWarning className =
+  "both DeriveAnyClass and GeneralizedNewtypeDeriving are enabled; defaulting to anyclass for "
+    <> T.unpack className
+
+defaultStrategyError :: TyConFlavor -> Text -> String
+defaultStrategyError targetFlavor className =
+  "cannot select a deriving strategy for "
+    <> T.unpack className
+    <> "; enable DeriveAnyClass"
+    <> if targetFlavor == NewtypeTyCon
+      then " or GeneralizedNewtypeDeriving, or use an explicit strategy"
+      else ", or use an explicit strategy"

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -28,6 +28,7 @@ import Aihc.Parser.Syntax
     DataDecl (..),
     Decl (..),
     Expr (..),
+    Extension,
     FieldDecl (..),
     ForeignDecl (..),
     ForeignDirection (..),
@@ -48,6 +49,8 @@ import Aihc.Parser.Syntax
     TypeSynDecl (..),
     UnqualifiedName (..),
     ValueDecl (..),
+    applyExtensionSetting,
+    applyImpliedExtensions,
     binderHeadName,
     binderHeadParams,
     fromAnnotation,
@@ -486,25 +489,28 @@ renderCheckedGroup checkedGroups (groupId, group) =
 annotateModuleTc :: Set.Set Text -> Module -> TcM Module
 annotateModuleTc checkedValueNames m = do
   let classMethods = collectClassMethodNames (moduleDecls m)
-  decls <- mapM (annotateDeclTc classMethods checkedValueNames) (moduleDecls m)
+      extensions =
+        applyImpliedExtensions $
+          foldr applyExtensionSetting [] (moduleLanguagePragmas m)
+  decls <- mapM (annotateDeclTc extensions classMethods checkedValueNames) (moduleDecls m)
   pure (m {moduleDecls = decls})
 
-annotateDeclTc :: Map Text [Text] -> Set.Set Text -> Decl -> TcM Decl
-annotateDeclTc classMethods checkedValueNames decl =
+annotateDeclTc :: [Extension] -> Map Text [Text] -> Set.Set Text -> Decl -> TcM Decl
+annotateDeclTc extensions classMethods checkedValueNames decl =
   case decl of
-    DeclAnn ann inner -> DeclAnn ann <$> annotateDeclTc classMethods checkedValueNames inner
+    DeclAnn ann inner -> DeclAnn ann <$> annotateDeclTc extensions classMethods checkedValueNames inner
     DeclValue valueDecl
       | valueDeclWasChecked checkedValueNames valueDecl -> do
           (ty, valueDecl') <- annotateValueDeclTc valueDecl
           pure (annotateDeclAt (valueDeclSpan valueDecl) (TcAnnotation ty [] [] []) (DeclValue valueDecl'))
       | otherwise -> pure decl
-    DeclData dataDecl -> annotateDataDeclTc dataDecl
-    DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
+    DeclData dataDecl -> annotateDataDeclTc extensions dataDecl
+    DeclNewtype newtypeDecl -> annotateNewtypeDeclTc extensions newtypeDecl
     DeclForeign foreignDecl
       | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
     DeclClass classDecl -> annotateClassDeclTc classDecl
     DeclInstance instanceDecl -> annotateInstanceDeclTc classMethods instanceDecl
-    DeclStandaloneDeriving derivingDecl -> annotateStandaloneDerivingTc derivingDecl
+    DeclStandaloneDeriving derivingDecl -> annotateStandaloneDerivingTc extensions derivingDecl
     _ -> pure decl
 
 valueDeclWasChecked :: Set.Set Text -> ValueDecl -> Bool
@@ -565,23 +571,23 @@ annotateClassMethod index methodName = do
         tcClassMethodIndex = index
       }
 
-annotateDataDeclTc :: DataDecl -> TcM Decl
-annotateDataDeclTc dataDecl = do
+annotateDataDeclTc :: [Extension] -> DataDecl -> TcM Decl
+annotateDataDeclTc extensions dataDecl = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
   ty <- tyConBindingType tyName
   constructors <- mapM annotateDataConDeclTc (dataDeclConstructors dataDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (dataDeclHead dataDecl)
       annotatedDecl = DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors})
-  annotateAttachedDerivingTc DataTyCon (dataDeclHead dataDecl) (dataDeclDeriving dataDecl) annotatedDecl
+  annotateAttachedDerivingTc extensions DataTyCon (dataDeclHead dataDecl) (dataDeclDeriving dataDecl) annotatedDecl
 
-annotateNewtypeDeclTc :: NewtypeDecl -> TcM Decl
-annotateNewtypeDeclTc newtypeDecl = do
+annotateNewtypeDeclTc :: [Extension] -> NewtypeDecl -> TcM Decl
+annotateNewtypeDeclTc extensions newtypeDecl = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
   ty <- tyConBindingType tyName
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (newtypeDeclHead newtypeDecl)
       annotatedDecl = DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor})
-  annotateAttachedDerivingTc NewtypeTyCon (newtypeDeclHead newtypeDecl) (newtypeDeclDeriving newtypeDecl) annotatedDecl
+  annotateAttachedDerivingTc extensions NewtypeTyCon (newtypeDeclHead newtypeDecl) (newtypeDeclDeriving newtypeDecl) annotatedDecl
 
 annotateBinderHeadName :: TcAnnotation -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName tcAnn head' =

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -65,6 +65,7 @@ module Aihc.Tc.Monad
     -- * Diagnostics
     emitDiagnostic,
     emitError,
+    emitWarning,
     getDiagnostics,
     withErrorTracking,
   )
@@ -423,6 +424,16 @@ emitError loc kind =
     TcDiagnostic
       { diagLoc = diagnosticLoc loc,
         diagSeverity = TcError,
+        diagKind = kind
+      }
+
+-- | Emit a warning diagnostic.
+emitWarning :: SourceSpan -> TcErrorKind -> TcM ()
+emitWarning loc kind =
+  emitDiagnostic
+    TcDiagnostic
+      { diagLoc = diagnosticLoc loc,
+        diagSeverity = TcWarning,
         diagKind = kind
       }
 

--- a/components/aihc-tc/test/Test/Fixtures/annotated/default-newtype-deriving-strategy.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/default-newtype-deriving-strategy.yaml
@@ -1,0 +1,24 @@
+annotated:
+- |-
+  {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+  module Main where
+  class C a where
+  └─ class methods: c ∷ ∀ a. (C a) ⇒ a → a
+    c :: a -> a
+  newtype N a = N a
+  │       │     └─ type: ∀ a. a → N a
+  │       └─ type: * → *
+  └─ deriving plans: newtype C (N a) [context: infer] [methods: c]
+    deriving C
+extensions:
+- GeneralizedNewtypeDeriving
+modules:
+- |
+  {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+  module Main where
+  class C a where
+    c :: a -> a
+  newtype N a = N a
+    deriving C
+reason: default deriving selects newtype when only GeneralizedNewtypeDeriving applies
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plans.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plans.yaml
@@ -26,10 +26,15 @@ annotated:
   │       └─ type: * → *
   └─ deriving plans: newtype C (N a) [context: infer] [methods: c]
     deriving newtype C
+  newtype PreferAnyclass a = PreferAnyclass a
+  │       └─ type: * → *     └─ type: ∀ a. a → PreferAnyclass a
+  └─ deriving plans: anyclass C (PreferAnyclass a) [context: infer] [methods: c]
+    deriving C
+             └─ warning: both DeriveAnyClass and GeneralizedNewtypeDeriving are enabled; defaulting to anyclass for C
   data Default a = Default a
   │    │           └─ type: ∀ a. a → Default a
   │    └─ type: * → *
-  └─ deriving plans: default C (Default a) [context: infer] [methods: c]
+  └─ deriving plans: anyclass C (Default a) [context: infer] [methods: c]
     deriving C
 extensions:
 - DeriveAnyClass
@@ -53,7 +58,9 @@ modules:
     deriving D via Wrapper a
   newtype N a = N a
     deriving newtype C
+  newtype PreferAnyclass a = PreferAnyclass a
+    deriving C
   data Default a = Default a
     deriving C
-reason: deriving clauses become typed plans without generating declarations
+reason: deriving clauses become typed plans with effective strategies but without generated declarations
 status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/deriving-strategy-errors.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/deriving-strategy-errors.yaml
@@ -1,0 +1,27 @@
+annotated:
+- |-
+  {-# LANGUAGE DerivingStrategies #-}
+  module Main where
+  class C a where
+  └─ class methods:
+  data ExplicitStock = ExplicitStock
+       └─ type: *      └─ type: ExplicitStock
+    deriving stock C
+                   └─ error: stock deriving is not available for class C
+  data NoDefault = NoDefault
+       └─ type: *  └─ type: NoDefault
+    deriving C
+             └─ error: cannot select a deriving strategy for C; enable DeriveAnyClass, or use an explicit strategy
+extensions:
+- DerivingStrategies
+modules:
+- |
+  {-# LANGUAGE DerivingStrategies #-}
+  module Main where
+  class C a where
+  data ExplicitStock = ExplicitStock
+    deriving stock C
+  data NoDefault = NoDefault
+    deriving C
+reason: TC rejects unsupported explicit stock deriving and unresolved default strategies
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/stock-deriving-strategy-selection.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/stock-deriving-strategy-selection.yaml
@@ -1,0 +1,37 @@
+annotated:
+- |-
+  {-# LANGUAGE DeriveAnyClass, DeriveFunctor, KindSignatures #-}
+  module Main where
+  data Type
+       └─ type: *
+  class Eq a where
+  └─ class methods:
+  class Functor (f :: Type -> Type) where
+  └─ class methods:
+  data E = E
+  │    │   └─ type: E
+  │    └─ type: *
+  └─ deriving plans: stock Eq E [context: infer]
+    deriving Eq
+  data F a = F a
+  │    │     └─ type: ∀ a. a → F a
+  │    └─ type: * → *
+  └─ deriving plans: stock Functor F [context: infer]
+    deriving Functor
+extensions:
+- DeriveAnyClass
+- DeriveFunctor
+- KindSignatures
+modules:
+- |
+  {-# LANGUAGE DeriveAnyClass, DeriveFunctor, KindSignatures #-}
+  module Main where
+  data Type
+  class Eq a where
+  class Functor (f :: Type -> Type) where
+  data E = E
+    deriving Eq
+  data F a = F a
+    deriving Functor
+reason: stock mechanisms take precedence over DeriveAnyClass when their enabling extensions are active
+status: pass


### PR DESCRIPTION
## Summary

- add `Aihc.Tc.Deriving.Strategy` as the single owner of extension-sensitive deriving policy
- replace the unresolved `TcDerivingDefault` state with an effective stock, newtype, anyclass, or via strategy before plans leave `aihc-tc`
- follow GHC's default precedence: enabled stock mechanisms first, then `DeriveAnyClass`, then `GeneralizedNewtypeDeriving` for newtypes
- emit the GHC-style warning when both `DeriveAnyClass` and `GeneralizedNewtypeDeriving` apply to a default newtype clause
- validate explicit stock, anyclass, newtype, and via requests against their required extensions and target representation
- evaluate extensions per source module, including implied extensions, rather than making System FC recover language policy

This PR does not infer attached instance contexts or generate methods, dictionaries, instances, or System FC. GHC oracle testing showed that context inference must solve the complete deriving batch (including sibling derived instances), so that remains the next type-checker step rather than recording unsolved superclass predicates as source contexts.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options=--hide-successes`
- `just fmt`
- `just check`

## Progress

- TC annotated golden PASS: 68 → 71
- `aihc-tc` tests: 96 → 99