### PR TITLE
feat(tc): infer anyclass deriving contexts

### DIFF
--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -20,6 +20,7 @@ library
     Aihc.Tc.Annotations
     Aihc.Tc.Constraint
     Aihc.Tc.Deriving
+    Aihc.Tc.Deriving.Context
     Aihc.Tc.Deriving.Strategy
     Aihc.Tc.Env
     Aihc.Tc.Error

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -46,6 +46,7 @@ import Aihc.Parser.Syntax
   ( Decl (..),
     Expr (..),
     Pattern (..),
+    SourceSpan,
     Type (..),
     fromAnnotation,
     mkAnnotation,
@@ -141,7 +142,8 @@ data TcClassAnnotation = TcClassAnnotation
   { tcClassTyVars :: ![TyVarId],
     tcClassSuperClasses :: ![TcDictBinderAnnotation],
     tcClassMethods :: ![TcClassMethodAnnotation],
-    tcClassDefaultMethods :: ![Text]
+    tcClassDefaultMethods :: ![Text],
+    tcClassDefaultSignatures :: ![(Text, TcType)]
   }
   deriving (Eq, Show)
 
@@ -167,7 +169,8 @@ data TcDerivingContext
 -- the class layout needed by System FC lowering so downstream phases never
 -- need to reconstruct Haskell class information.
 data TcDerivingPlan = TcDerivingPlan
-  { tcDerivingStrategy :: !TcDerivingStrategy,
+  { tcDerivingSourceSpan :: !SourceSpan,
+    tcDerivingStrategy :: !TcDerivingStrategy,
     tcDerivingClassName :: !Text,
     tcDerivingDictName :: !Text,
     tcDerivingTyVars :: ![TyVarId],
@@ -176,7 +179,14 @@ data TcDerivingPlan = TcDerivingPlan
     tcDerivingClassTyVars :: ![TyVarId],
     tcDerivingClassSuperClasses :: ![TcDictBinderAnnotation],
     tcDerivingClassMethods :: ![TcClassMethodAnnotation],
-    tcDerivingDefaultMethods :: ![Text]
+    tcDerivingDefaultMethods :: ![Text],
+    tcDerivingDefaultSignatures :: ![(Text, [Pred])],
+    -- | Evidence for the instantiated superclass fields after context
+    -- inference. It remains empty while an attached context is unresolved.
+    tcDerivingSuperClasses :: ![(TcDictBinderAnnotation, EvTerm)],
+    -- | Evidence arguments required by each selected default method, excluding
+    -- the recursive dictionary for the derived instance itself.
+    tcDerivingDefaultMethodEvidence :: ![(Text, [EvTerm])]
   }
   deriving (Eq, Show)
 
@@ -280,7 +290,7 @@ renderTcType = go 0
             "∀ " ++ unwords (map (T.unpack . tvName) (tv : tvs)) ++ ". " ++ go 0 inner
     go p (TcQualTy preds body) =
       parenIf (p >= 1) $
-        "(" ++ unwords (map showPred preds) ++ ") ⇒ " ++ go 0 body
+        "(" ++ commaSep (map showPred preds) ++ ") ⇒ " ++ go 0 body
     go p (TcAppTy f a) =
       parenIf (p >= 2) $
         go 1 f ++ " " ++ go 2 a

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -145,7 +145,7 @@ checkAttachedDerivingPlan extensions targetFlavor targetInfo params tvEnv strate
               let headTypes = checkedArguments <> [targetType]
                   strategyTypes = case checkedStrategy of TcDerivingVia viaType -> [viaType]; _ -> []
                   quantified = filter (\param -> any (typeMentionsTyVar (paramTyVar param)) (headTypes <> strategyTypes)) params
-              pure (Just (mkDerivingPlan checkedStrategy classInfo (map paramTyVar quantified) headTypes TcDerivingInferContext methods))
+              pure (Just (mkDerivingPlan classSpan checkedStrategy classInfo (map paramTyVar quantified) headTypes TcDerivingInferContext methods))
 
 attachedTargetType :: SourceSpan -> TyConInfo -> [ParamInfo] -> Kind -> TcM TcType
 attachedTargetType sourceSpan targetInfo params expectedKind = do
@@ -204,7 +204,7 @@ checkStandaloneDerivingPlan extensions derivingDecl =
               context <- mapM defaultPredKinds checkedContext
               strategy <- defaultDerivingStrategyKinds checkedStrategy
               methods <- derivingClassMethods classInfo
-              pure (Just (mkDerivingPlan strategy classInfo tyVars headTypes (TcDerivingExplicitContext context) methods))
+              pure (Just (mkDerivingPlan classSpan strategy classInfo tyVars headTypes (TcDerivingExplicitContext context) methods))
   where
     implicitParam name = do
       rawTyVar <- freshSkolemTv name
@@ -212,10 +212,11 @@ checkStandaloneDerivingPlan extensions derivingDecl =
       let tyVar = setTyVarKind kind rawTyVar
       pure ParamInfo {paramName = name, paramTyVar = tyVar, paramKind = kind}
 
-mkDerivingPlan :: TcDerivingStrategy -> ClassInfo -> [TyVarId] -> [TcType] -> TcDerivingContext -> [TcClassMethodAnnotation] -> TcDerivingPlan
-mkDerivingPlan strategy classInfo tyVars headTypes context methods =
+mkDerivingPlan :: SourceSpan -> TcDerivingStrategy -> ClassInfo -> [TyVarId] -> [TcType] -> TcDerivingContext -> [TcClassMethodAnnotation] -> TcDerivingPlan
+mkDerivingPlan sourceSpan strategy classInfo tyVars headTypes context methods =
   TcDerivingPlan
-    { tcDerivingStrategy = strategy,
+    { tcDerivingSourceSpan = sourceSpan,
+      tcDerivingStrategy = strategy,
       tcDerivingClassName = className,
       tcDerivingDictName = instanceDictName className headTypes,
       tcDerivingTyVars = tyVars,
@@ -224,7 +225,10 @@ mkDerivingPlan strategy classInfo tyVars headTypes context methods =
       tcDerivingClassTyVars = ciTyVars classInfo,
       tcDerivingClassSuperClasses = map constraintTypeDictBinder (ciSuperClassTypes classInfo),
       tcDerivingClassMethods = methods,
-      tcDerivingDefaultMethods = ciDefaultMethods classInfo
+      tcDerivingDefaultMethods = ciDefaultMethods classInfo,
+      tcDerivingDefaultSignatures = [(methodName, predicates) | (methodName, ForAll _ predicates _) <- ciDefaultSignatures classInfo],
+      tcDerivingSuperClasses = [],
+      tcDerivingDefaultMethodEvidence = []
     }
   where
     className = ciName classInfo

--- a/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
@@ -1,0 +1,343 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Finalize strategy-specific deriving contexts as a module batch.
+--
+-- AnyClass has no structural method obligations. Its inferred context comes
+-- from instantiated superclasses and the constraints on default signatures.
+-- The whole batch is visible while simplifying those predicates so sibling
+-- AnyClass instances are independent of declaration order.
+module Aihc.Tc.Deriving.Context
+  ( finalizeDerivingModulesTc,
+    derivingPlanInstanceInfo,
+  )
+where
+
+import Aihc.Parser.Syntax
+  ( Decl (..),
+    Module (..),
+    fromAnnotation,
+    mkAnnotation,
+  )
+import Aihc.Tc.Annotations
+  ( TcDerivingAnnotation (..),
+    TcDerivingContext (..),
+    TcDerivingPlan (..),
+    TcDerivingStrategy (..),
+    TcDictBinderAnnotation (..),
+  )
+import Aihc.Tc.Constraint (Ct (..), CtOrigin (..), mkWantedCt)
+import Aihc.Tc.Env (InstanceInfo (..))
+import Aihc.Tc.Error (TcErrorKind (..))
+import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Instantiate (applySubst)
+import Aihc.Tc.Monad
+import Aihc.Tc.Solve.Dict (DictResult (..), constraintTypeToPred, matchTypes, solveDictWithGivens, substPred)
+import Aihc.Tc.Types
+import Data.List (find, nub)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+
+finalizeDerivingModulesTc :: [Module] -> TcM [Module]
+finalizeDerivingModulesTc modules = do
+  existingInstances <- getInstances
+  let originalPlans = concatMap moduleDerivingPlans modules
+  contextPlans <- mapM (inferPlanContext existingInstances originalPlans) originalPlans
+  let derivedInstances = mapMaybe derivingPlanInstanceInfo contextPlans
+  mapM_ addInstance derivedInstances
+  evidencePlans <- mapM attachDerivingEvidence contextPlans
+  pure (map (replaceModulePlans evidencePlans) modules)
+
+inferPlanContext :: [InstanceInfo] -> [TcDerivingPlan] -> TcDerivingPlan -> TcM TcDerivingPlan
+inferPlanContext existingInstances plans plan =
+  case (tcDerivingStrategy plan, tcDerivingContext plan) of
+    (TcDerivingAnyclass, TcDerivingInferContext) ->
+      case inferAnyClassContext existingInstances plans [] plan of
+        Left predicate -> do
+          emitError
+            (tcDerivingSourceSpan plan)
+            (UnsolvedWanted predicate (InstOrigin (tcDerivingClassName plan)))
+          pure plan
+        Right context ->
+          pure plan {tcDerivingContext = TcDerivingExplicitContext context}
+    _ -> pure plan
+
+inferAnyClassContext :: [InstanceInfo] -> [TcDerivingPlan] -> [PlanKey] -> TcDerivingPlan -> Either Pred [Pred]
+inferAnyClassContext existingInstances plans stack plan
+  | key `elem` stack = Left (planPredicate plan)
+  | otherwise =
+      nub . concat
+        <$> mapM
+          (simplifyPredicate existingInstances plans (key : stack) plan)
+          (anyClassObligations plan)
+  where
+    key = planKey plan
+
+simplifyPredicate :: [InstanceInfo] -> [TcDerivingPlan] -> [PlanKey] -> TcDerivingPlan -> Pred -> Either Pred [Pred]
+simplifyPredicate existingInstances plans stack owner predicate
+  | isBareVariablePredicate (tcDerivingTyVars owner) predicate = Right [predicate]
+  | Just arguments <- typeableArguments predicate =
+      concat
+        <$> mapM
+          (simplifyPredicate existingInstances plans stack owner . ClassPred "Typeable" . (: []))
+          arguments
+  | otherwise =
+      case firstSuccessful (map simplifyExisting matchingExisting <> map simplifyDerived matchingDerived) of
+        Just context -> Right context
+        Nothing
+          | isAdmissibleContextPredicate owner predicate -> Right [predicate]
+          | otherwise -> Left predicate
+  where
+    matchingExisting =
+      [ (instanceInfo, substitution)
+      | instanceInfo <- existingInstances,
+        iiClassName instanceInfo == predClassName predicate,
+        Just substitution <- [matchTypes (iiHead instanceInfo) (predArguments predicate)]
+      ]
+    matchingDerived =
+      [ (candidate, substitution)
+      | candidate <- plans,
+        tcDerivingClassName candidate == predClassName predicate,
+        Just substitution <- [matchTypes (tcDerivingHeadTypes candidate) (predArguments predicate)]
+      ]
+    simplifyExisting (instanceInfo, substitution) =
+      concat
+        <$> mapM
+          (simplifyPredicate existingInstances plans stack owner . substPred substitution)
+          (iiContext instanceInfo)
+    simplifyDerived (candidate, substitution) = do
+      context <- candidateContext candidate
+      concat
+        <$> mapM
+          (simplifyPredicate existingInstances plans stack owner . substPred substitution)
+          context
+    candidateContext candidate =
+      case tcDerivingContext candidate of
+        TcDerivingExplicitContext context -> Right context
+        TcDerivingInferContext
+          | tcDerivingStrategy candidate == TcDerivingAnyclass ->
+              inferAnyClassContext existingInstances plans stack candidate
+          | otherwise -> Left predicate
+
+firstSuccessful :: [Either error value] -> Maybe value
+firstSuccessful results =
+  case results of
+    [] -> Nothing
+    Left _ : rest -> firstSuccessful rest
+    Right value : _ -> Just value
+
+anyClassObligations :: TcDerivingPlan -> [Pred]
+anyClassObligations plan =
+  mapMaybe
+    (constraintTypeToPred . applySubst substitution . tcDictBinderType)
+    (tcDerivingClassSuperClasses plan)
+    <> concatMap snd (instantiatedDefaultSignaturePredicates plan)
+  where
+    substitution =
+      Map.fromList
+        [ (tvUnique tyVar, headType)
+        | (tyVar, headType) <- zip (tcDerivingClassTyVars plan) (tcDerivingHeadTypes plan)
+        ]
+
+attachDerivingEvidence :: TcDerivingPlan -> TcM TcDerivingPlan
+attachDerivingEvidence plan =
+  case (tcDerivingStrategy plan, tcDerivingContext plan) of
+    (TcDerivingAnyclass, TcDerivingExplicitContext context) -> do
+      superClassEvidence <- mapM (solveObligation context) superClasses
+      defaultMethodEvidence <-
+        mapM
+          (traverse (mapM (solveObligation context)))
+          (instantiatedDefaultSignaturePredicates plan)
+      pure
+        plan
+          { tcDerivingSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
+            tcDerivingDefaultMethodEvidence = defaultMethodEvidence
+          }
+    _ -> pure plan
+  where
+    superClasses =
+      mapMaybe
+        (constraintTypeToPred . applySubst substitution . tcDictBinderType)
+        (tcDerivingClassSuperClasses plan)
+    substitution =
+      Map.fromList
+        [ (tvUnique tyVar, headType)
+        | (tyVar, headType) <- zip (tcDerivingClassTyVars plan) (tcDerivingHeadTypes plan)
+        ]
+    solveObligation context predicate = do
+      evidenceVariable <- freshEvVar
+      let constraint = mkWantedCt predicate evidenceVariable (InstOrigin (tcDerivingClassName plan)) (tcDerivingSourceSpan plan)
+      result <- solveDictWithGivens context constraint
+      case result of
+        DictSolved -> do
+          evidence <- lookupEvidence evidenceVariable
+          case evidence of
+            Just term -> pure term
+            Nothing -> pure (EvVarTerm evidenceVariable)
+        DictStuck stuck -> do
+          emitError (ctLoc stuck) (UnsolvedWanted (ctPred stuck) (ctOrigin stuck))
+          pure (EvVarTerm evidenceVariable)
+
+instantiatedDefaultSignaturePredicates :: TcDerivingPlan -> [(Text, [Pred])]
+instantiatedDefaultSignaturePredicates plan =
+  [ (methodName, map (substPred substitution) predicates)
+  | (methodName, predicates) <- tcDerivingDefaultSignatures plan,
+    methodName `elem` tcDerivingDefaultMethods plan
+  ]
+  where
+    substitution =
+      Map.fromList
+        [ (tvUnique tyVar, headType)
+        | (tyVar, headType) <- zip (tcDerivingClassTyVars plan) (tcDerivingHeadTypes plan)
+        ]
+
+derivingPlanInstanceInfo :: TcDerivingPlan -> Maybe InstanceInfo
+derivingPlanInstanceInfo plan =
+  case (tcDerivingStrategy plan, tcDerivingContext plan) of
+    (TcDerivingAnyclass, TcDerivingExplicitContext context) ->
+      Just
+        InstanceInfo
+          { iiClassName = tcDerivingClassName plan,
+            iiDictName = tcDerivingDictName plan,
+            iiDictType = foldr TcForAllTy (TcQualTy context (predType (planPredicate plan))) (tcDerivingTyVars plan),
+            iiTyVars = tcDerivingTyVars plan,
+            iiContext = context,
+            iiHead = tcDerivingHeadTypes plan
+          }
+    _ -> Nothing
+
+moduleDerivingPlans :: Module -> [TcDerivingPlan]
+moduleDerivingPlans = concatMap declDerivingPlans . moduleDecls
+
+declDerivingPlans :: Decl -> [TcDerivingPlan]
+declDerivingPlans decl =
+  case decl of
+    DeclAnn annotation inner ->
+      maybe [] tcDerivingPlans (fromAnnotation @TcDerivingAnnotation annotation)
+        <> declDerivingPlans inner
+    _ -> []
+
+replaceModulePlans :: [TcDerivingPlan] -> Module -> Module
+replaceModulePlans plans modu =
+  modu {moduleDecls = map replaceDecl (moduleDecls modu)}
+  where
+    replaceDecl decl =
+      case decl of
+        DeclAnn annotation inner
+          | Just derivingAnnotation <- fromAnnotation @TcDerivingAnnotation annotation ->
+              DeclAnn
+                (mkAnnotation (derivingAnnotation {tcDerivingPlans = map replacePlan (tcDerivingPlans derivingAnnotation)}))
+                (replaceDecl inner)
+          | otherwise -> DeclAnn annotation (replaceDecl inner)
+        _ -> decl
+    replacePlan original =
+      fromMaybe original (find ((== planKey original) . planKey) plans)
+
+type PlanKey = (Text, [TcType])
+
+planKey :: TcDerivingPlan -> PlanKey
+planKey plan = (tcDerivingClassName plan, tcDerivingHeadTypes plan)
+
+planPredicate :: TcDerivingPlan -> Pred
+planPredicate plan = ClassPred (tcDerivingClassName plan) (tcDerivingHeadTypes plan)
+
+predClassName :: Pred -> Text
+predClassName predicate =
+  case predicate of
+    ClassPred className _ -> className
+    EqPred {} -> "~"
+
+predArguments :: Pred -> [TcType]
+predArguments predicate =
+  case predicate of
+    ClassPred _ arguments -> arguments
+    EqPred left right -> [left, right]
+
+typeableArguments :: Pred -> Maybe [TcType]
+typeableArguments predicate =
+  case predicate of
+    ClassPred "Typeable" [ty] ->
+      case ty of
+        TcTyCon _ arguments -> Just arguments
+        TcFunTy argument result -> Just [argument, result]
+        TcTyVar {} -> Nothing
+        TcMetaTv {} -> Nothing
+        TcForAllTy {} -> Nothing
+        TcQualTy {} -> Nothing
+        TcAppTy {} -> Nothing
+    _ -> Nothing
+
+isBareVariablePredicate :: [TyVarId] -> Pred -> Bool
+isBareVariablePredicate tyVars predicate =
+  case predicate of
+    ClassPred _ arguments ->
+      not (null arguments)
+        && all isPlanTyVar arguments
+    EqPred {} -> False
+  where
+    isPlanTyVar (TcTyVar tyVar) = tyVar `elem` tyVars
+    isPlanTyVar _ = False
+
+isAdmissibleContextPredicate :: TcDerivingPlan -> Pred -> Bool
+isAdmissibleContextPredicate plan predicate =
+  not (null mentionedVariables)
+    && all (`elem` tcDerivingTyVars plan) mentionedVariables
+    && maybe True (not . predicateMentionsTyCon predicate) (derivedTargetTyCon plan)
+  where
+    mentionedVariables = predTyVars predicate
+
+derivedTargetTyCon :: TcDerivingPlan -> Maybe Text
+derivedTargetTyCon plan =
+  case reverse (tcDerivingHeadTypes plan) of
+    target : _ -> typeHeadTyCon target
+    [] -> Nothing
+
+typeHeadTyCon :: TcType -> Maybe Text
+typeHeadTyCon ty =
+  case ty of
+    TcTyCon tyCon _ -> Just (tyConName tyCon)
+    TcAppTy function _ -> typeHeadTyCon function
+    _ -> Nothing
+
+predicateMentionsTyCon :: Pred -> Text -> Bool
+predicateMentionsTyCon predicate name =
+  any (typeMentionsTyCon name) (predArguments predicate)
+
+typeMentionsTyCon :: Text -> TcType -> Bool
+typeMentionsTyCon name ty =
+  case ty of
+    TcTyVar {} -> False
+    TcMetaTv {} -> False
+    TcTyCon tyCon arguments -> tyConName tyCon == name || any (typeMentionsTyCon name) arguments
+    TcFunTy argument result -> typeMentionsTyCon name argument || typeMentionsTyCon name result
+    TcForAllTy _ body -> typeMentionsTyCon name body
+    TcQualTy predicates body -> any (`predicateMentionsTyCon` name) predicates || typeMentionsTyCon name body
+    TcAppTy function argument -> typeMentionsTyCon name function || typeMentionsTyCon name argument
+
+predTyVars :: Pred -> [TyVarId]
+predTyVars predicate = nub (concatMap typeTyVars (predArguments predicate))
+
+typeTyVars :: TcType -> [TyVarId]
+typeTyVars ty =
+  case ty of
+    TcTyVar tyVar -> [tyVar]
+    TcMetaTv {} -> []
+    TcTyCon _ arguments -> concatMap typeTyVars arguments
+    TcFunTy argument result -> typeTyVars argument <> typeTyVars result
+    TcForAllTy tyVar body -> filter (/= tyVar) (typeTyVars body)
+    TcQualTy predicates body -> concatMap predTyVars predicates <> typeTyVars body
+    TcAppTy function argument -> typeTyVars function <> typeTyVars argument
+
+predDictBinder :: Pred -> TcDictBinderAnnotation
+predDictBinder predicate =
+  case predicate of
+    ClassPred className arguments ->
+      TcDictBinderAnnotation className arguments (predType predicate)
+    EqPred {} -> TcDictBinderAnnotation "<constraint>" [] (predType predicate)
+
+predType :: Pred -> TcType
+predType predicate =
+  case predicate of
+    ClassPred className arguments -> TcTyCon (TyCon className (length arguments)) arguments
+    EqPred left right -> TcTyCon (TyCon "~" 2) [left, right]

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -102,7 +102,11 @@ data ClassInfo = ClassInfo
     -- | Method names and their types.
     ciMethods :: ![(Text, TypeScheme)],
     -- | Methods with a source-level default implementation.
-    ciDefaultMethods :: ![Text]
+    ciDefaultMethods :: ![Text],
+    -- | Checked source-level default signatures. Unlike ordinary method
+    -- signatures, their constraints become instance obligations when
+    -- DeriveAnyClass selects the default implementation.
+    ciDefaultSignatures :: ![(Text, TypeScheme)]
   }
   deriving (Show, Read)
 

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -158,6 +158,7 @@ firstMetaClassAnnotation :: TcClassAnnotation -> Maybe Unique
 firstMetaClassAnnotation classAnnotation =
   firstJusts (map (firstMetaType . tcDictBinderType) (tcClassSuperClasses classAnnotation))
     <|> firstJusts (map firstMetaClassMethodAnnotation (tcClassMethods classAnnotation))
+    <|> firstJusts (map (firstMetaType . snd) (tcClassDefaultSignatures classAnnotation))
 
 firstMetaClassMethodAnnotation :: TcClassMethodAnnotation -> Maybe Unique
 firstMetaClassMethodAnnotation method =
@@ -173,6 +174,11 @@ firstMetaDerivingPlan plan =
     ( map firstMetaType (tcDerivingHeadTypes plan)
         ++ map firstMetaClassMethodAnnotation (tcDerivingClassMethods plan)
         ++ map firstMetaDictBinderAnnotation (tcDerivingClassSuperClasses plan)
+        ++ concatMap (map firstMetaPred . snd) (tcDerivingDefaultSignatures plan)
+        ++ [ firstMetaDictBinderAnnotation superClass <|> firstMetaEvTerm evidence
+           | (superClass, evidence) <- tcDerivingSuperClasses plan
+           ]
+        ++ concatMap (map firstMetaEvTerm . snd) (tcDerivingDefaultMethodEvidence plan)
         ++ [firstMetaDerivingStrategy (tcDerivingStrategy plan), firstMetaDerivingContext (tcDerivingContext plan)]
     )
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -67,6 +67,7 @@ import Aihc.Tc.Annotations
   ( TcAnnotation (..),
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
+    TcDerivingAnnotation (..),
     TcDictBinderAnnotation (..),
     TcForeignAbiType (..),
     TcForeignEffect (..),
@@ -78,6 +79,7 @@ import Aihc.Tc.Annotations
   )
 import Aihc.Tc.Constraint
 import Aihc.Tc.Deriving (annotateAttachedDerivingTc, annotateStandaloneDerivingTc)
+import Aihc.Tc.Deriving.Context (derivingPlanInstanceInfo, finalizeDerivingModulesTc)
 import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
@@ -175,7 +177,11 @@ annotationClasses ann decl =
               [ (tcClassMethodName method, typeToScheme (tcClassMethodType method))
               | method <- tcClassMethods classAnn
               ],
-            ciDefaultMethods = tcClassDefaultMethods classAnn
+            ciDefaultMethods = tcClassDefaultMethods classAnn,
+            ciDefaultSignatures =
+              [ (methodName, typeToScheme signature)
+              | (methodName, signature) <- tcClassDefaultSignatures classAnn
+              ]
           }
       ]
     _ -> []
@@ -196,19 +202,26 @@ declInstances decl =
 
 annotationInstances :: Annotation -> Decl -> [InstanceInfo]
 annotationInstances ann decl =
-  case (fromAnnotation ann, peelDeclAnn decl) of
-    (Just instAnn, DeclInstance instanceDecl)
-      | Just className <- instanceHeadName (instanceDeclHead instanceDecl) ->
-          [ InstanceInfo
-              { iiClassName = nameText className,
-                iiDictName = tcInstanceDictName instAnn,
-                iiDictType = tcInstanceDictType instAnn,
-                iiTyVars = tcInstanceTyVars instAnn,
-                iiContext = map dictBinderPred (tcInstanceContextDicts instAnn),
-                iiHead = tcInstanceHeadTypes instAnn
-              }
-          ]
-    _ -> []
+  explicitInstance <> derivedInstances
+  where
+    explicitInstance =
+      case (fromAnnotation @TcInstanceAnnotation ann, peelDeclAnn decl) of
+        (Just instAnn, DeclInstance instanceDecl)
+          | Just className <- instanceHeadName (instanceDeclHead instanceDecl) ->
+              [ InstanceInfo
+                  { iiClassName = nameText className,
+                    iiDictName = tcInstanceDictName instAnn,
+                    iiDictType = tcInstanceDictType instAnn,
+                    iiTyVars = tcInstanceTyVars instAnn,
+                    iiContext = map dictBinderPred (tcInstanceContextDicts instAnn),
+                    iiHead = tcInstanceHeadTypes instAnn
+                  }
+              ]
+        _ -> []
+    derivedInstances =
+      case fromAnnotation @TcDerivingAnnotation ann of
+        Just derivingAnnotation -> mapMaybe derivingPlanInstanceInfo (tcDerivingPlans derivingAnnotation)
+        Nothing -> []
 
 dictBinderPred :: TcDictBinderAnnotation -> Pred
 dictBinderPred dictBinder =
@@ -260,11 +273,24 @@ classAnnotationBindings ann decl =
       [ TcBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method)
       | method <- tcClassMethods classAnn
       ]
-        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (tcClassMethodType method)
+        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method)
            | method <- tcClassMethods classAnn,
              tcClassMethodName method `elem` tcClassDefaultMethods classAnn
            ]
     _ -> []
+
+classDefaultWorkerType :: TcClassAnnotation -> TcClassMethodAnnotation -> TcType
+classDefaultWorkerType classAnnotation method =
+  case lookup (tcClassMethodName method) (tcClassDefaultSignatures classAnnotation) of
+    Just signature
+      | Just classPredicate <- constraintTypeToPred (tcClassMethodDictType method) ->
+          let (tyVars, body) = peelForAlls signature
+              qualifiedBody =
+                case body of
+                  TcQualTy predicates result -> TcQualTy (classPredicate : predicates) result
+                  result -> TcQualTy [classPredicate] result
+           in foldr TcForAllTy qualifiedBody tyVars
+    _ -> tcClassMethodType method
 
 instanceAnnotationBindings :: Annotation -> [TcBindingResult]
 instanceAnnotationBindings ann =
@@ -353,14 +379,22 @@ tcModuleScc modules = do
   mapM_ registerTypeDeclHeader declarations
   mapM_ registerTypeSynonymBody declarations
   mapM_ registerValueLevelDecl declarations
+  -- Deriving strategy and context inference depends only on registered type,
+  -- class, and explicit-instance information. Finalize the entire SCC as one
+  -- batch before checking signatures and bodies so sibling derived instances
+  -- are mutually visible and ordinary values can use them.
+  defaultGlobalKindMetas
+  derivingAnnotated <- mapM annotateModuleDerivingTc modules
+  derivingFinalized <- finalizeDerivingModulesTc derivingAnnotated
   -- Phase 2: collect type signatures and convert them to schemes.
-  rawSigs <- mapM (collectUserSigs . moduleDecls) modules
+  rawSigs <- mapM (collectUserSigs . moduleDecls) derivingFinalized
   schemes <- mapM (traverse checkUserSig) rawSigs
   mapM_ registerCheckedSig (concatMap Map.elems schemes)
-  pending <- zipWithM tcModuleBody schemes modules
+  pending <- zipWithM tcModuleBody schemes derivingFinalized
   -- No module interface in the SCC may retain state-local kind metavariables.
   defaultGlobalKindMetas
-  mapM finishPendingModule pending
+  annotated <- mapM annotatePendingModule pending
+  mapM finalizeModuleTc annotated
 
 registerCheckedSig :: CheckedSig -> TcM ()
 registerCheckedSig sig =
@@ -398,13 +432,12 @@ tcModuleBody schemes m = do
   checkTopLevelUnliftedBindings sourceGroups groupResults
   pure (PendingModule pendingModule valueResults)
 
-finishPendingModule :: PendingModule -> TcM Module
-finishPendingModule pending = do
+annotatePendingModule :: PendingModule -> TcM Module
+annotatePendingModule pending = do
   -- Only bindings that checked without errors are eligible for value
   -- annotations. Failed bindings remain in the recovery environment, but
   -- they must not be rendered as successful inferred types.
-  annotatedModule <- annotateModuleTc (Set.fromList (map tbName (pendingValueResults pending))) (pendingSyntax pending)
-  finalizeModuleTc annotatedModule
+  annotateModuleTc (Set.fromList (map tbName (pendingValueResults pending))) (pendingSyntax pending)
 
 defaultGlobalKindMetas :: TcM ()
 defaultGlobalKindMetas = do
@@ -447,6 +480,7 @@ defaultGlobalKindMetas = do
         <*> mapM defaultTypeKinds (ciSuperClassTypes info)
         <*> mapM (traverse defaultTypeSchemeKinds) (ciMethods info)
         <*> pure (ciDefaultMethods info)
+        <*> mapM (traverse defaultTypeSchemeKinds) (ciDefaultSignatures info)
     defaultInstanceKinds info =
       InstanceInfo
         (iiClassName info)
@@ -489,28 +523,48 @@ renderCheckedGroup checkedGroups (groupId, group) =
 annotateModuleTc :: Set.Set Text -> Module -> TcM Module
 annotateModuleTc checkedValueNames m = do
   let classMethods = collectClassMethodNames (moduleDecls m)
-      extensions =
-        applyImpliedExtensions $
-          foldr applyExtensionSetting [] (moduleLanguagePragmas m)
-  decls <- mapM (annotateDeclTc extensions classMethods checkedValueNames) (moduleDecls m)
+  decls <- mapM (annotateDeclTc classMethods checkedValueNames) (moduleDecls m)
   pure (m {moduleDecls = decls})
 
-annotateDeclTc :: [Extension] -> Map Text [Text] -> Set.Set Text -> Decl -> TcM Decl
-annotateDeclTc extensions classMethods checkedValueNames decl =
+annotateModuleDerivingTc :: Module -> TcM Module
+annotateModuleDerivingTc modu = do
+  declarations <- mapM (annotateDeclDerivingTc extensions) (moduleDecls modu)
+  pure modu {moduleDecls = declarations}
+  where
+    extensions = moduleEnabledExtensions modu
+
+annotateDeclDerivingTc :: [Extension] -> Decl -> TcM Decl
+annotateDeclDerivingTc extensions decl =
   case decl of
-    DeclAnn ann inner -> DeclAnn ann <$> annotateDeclTc extensions classMethods checkedValueNames inner
+    DeclAnn annotation inner -> DeclAnn annotation <$> annotateDeclDerivingTc extensions inner
+    DeclData dataDecl ->
+      annotateAttachedDerivingTc extensions DataTyCon (dataDeclHead dataDecl) (dataDeclDeriving dataDecl) decl
+    DeclNewtype newtypeDecl ->
+      annotateAttachedDerivingTc extensions NewtypeTyCon (newtypeDeclHead newtypeDecl) (newtypeDeclDeriving newtypeDecl) decl
+    DeclStandaloneDeriving derivingDecl -> annotateStandaloneDerivingTc extensions derivingDecl
+    _ -> pure decl
+
+moduleEnabledExtensions :: Module -> [Extension]
+moduleEnabledExtensions modu =
+  applyImpliedExtensions $
+    foldr applyExtensionSetting [] (moduleLanguagePragmas modu)
+
+annotateDeclTc :: Map Text [Text] -> Set.Set Text -> Decl -> TcM Decl
+annotateDeclTc classMethods checkedValueNames decl =
+  case decl of
+    DeclAnn ann inner -> DeclAnn ann <$> annotateDeclTc classMethods checkedValueNames inner
     DeclValue valueDecl
       | valueDeclWasChecked checkedValueNames valueDecl -> do
           (ty, valueDecl') <- annotateValueDeclTc valueDecl
           pure (annotateDeclAt (valueDeclSpan valueDecl) (TcAnnotation ty [] [] []) (DeclValue valueDecl'))
       | otherwise -> pure decl
-    DeclData dataDecl -> annotateDataDeclTc extensions dataDecl
-    DeclNewtype newtypeDecl -> annotateNewtypeDeclTc extensions newtypeDecl
+    DeclData dataDecl -> annotateDataDeclTc dataDecl
+    DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
     DeclForeign foreignDecl
       | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
     DeclClass classDecl -> annotateClassDeclTc classDecl
     DeclInstance instanceDecl -> annotateInstanceDeclTc classMethods instanceDecl
-    DeclStandaloneDeriving derivingDecl -> annotateStandaloneDerivingTc extensions derivingDecl
+    DeclStandaloneDeriving {} -> pure decl
     _ -> pure decl
 
 valueDeclWasChecked :: Set.Set Text -> ValueDecl -> Bool
@@ -539,7 +593,9 @@ annotateClassDeclTc classDecl = do
                   { tcClassTyVars = ciTyVars info,
                     tcClassSuperClasses = map constraintTypeDictBinder (ciSuperClassTypes info),
                     tcClassMethods = methods,
-                    tcClassDefaultMethods = ciDefaultMethods info
+                    tcClassDefaultMethods = ciDefaultMethods info,
+                    tcClassDefaultSignatures =
+                      [(methodName, schemeToType signature) | (methodName, signature) <- ciDefaultSignatures info]
                   }
             )
             (DeclClass (classDecl {classDeclItems = items}))
@@ -552,7 +608,7 @@ annotateClassDefaultItem item =
     ClassItemDefault valueDecl ->
       case valueDeclBinderName valueDecl of
         Just (_, methodName) -> do
-          methodTy <- bindingType methodName
+          methodTy <- bindingType (defaultMethodName methodName)
           pure (ClassItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy)) item)
         Nothing -> pure item
     _ -> pure item
@@ -571,23 +627,21 @@ annotateClassMethod index methodName = do
         tcClassMethodIndex = index
       }
 
-annotateDataDeclTc :: [Extension] -> DataDecl -> TcM Decl
-annotateDataDeclTc extensions dataDecl = do
+annotateDataDeclTc :: DataDecl -> TcM Decl
+annotateDataDeclTc dataDecl = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
   ty <- tyConBindingType tyName
   constructors <- mapM annotateDataConDeclTc (dataDeclConstructors dataDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (dataDeclHead dataDecl)
-      annotatedDecl = DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors})
-  annotateAttachedDerivingTc extensions DataTyCon (dataDeclHead dataDecl) (dataDeclDeriving dataDecl) annotatedDecl
+  pure (DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors}))
 
-annotateNewtypeDeclTc :: [Extension] -> NewtypeDecl -> TcM Decl
-annotateNewtypeDeclTc extensions newtypeDecl = do
+annotateNewtypeDeclTc :: NewtypeDecl -> TcM Decl
+annotateNewtypeDeclTc newtypeDecl = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
   ty <- tyConBindingType tyName
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (newtypeDeclHead newtypeDecl)
-      annotatedDecl = DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor})
-  annotateAttachedDerivingTc extensions NewtypeTyCon (newtypeDeclHead newtypeDecl) (newtypeDeclDeriving newtypeDecl) annotatedDecl
+  pure (DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor}))
 
 annotateBinderHeadName :: TcAnnotation -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName tcAnn head' =
@@ -830,7 +884,7 @@ tcClassDefaultValue valueDecl =
   case valueDeclBinderName valueDecl of
     Nothing -> pure valueDecl
     Just (_, methodName) -> do
-      binder <- lookupTerm methodName
+      binder <- lookupTerm (defaultMethodName methodName)
       case binder of
         Just (TcIdBinder (ForAll _ givens methodTy) _) ->
           case valueDecl of
@@ -1617,15 +1671,17 @@ registerClassDecl classDecl = do
       }
   methodResults <- concat <$> mapM (registerClassItem classPred paramTvEnv paramTyVars) (classDeclItems classDecl)
   methods <- mapM registeredMethod (classDeclMethodNames classDecl)
+  defaultSignatures <- catMaybes <$> mapM (registerClassDefaultSignature paramTvEnv paramTyVars) (classDeclItems classDecl)
   let defaults = classDeclDefaultMethodNames classDecl
-  defaultResults <- mapM (registerDefaultMethod defaults) methods
+  defaultResults <- mapM (registerDefaultMethod defaults defaultSignatures) methods
   addClass
     ClassInfo
       { ciName = className,
         ciTyVars = paramTyVars,
         ciSuperClassTypes = superClassTypes,
         ciMethods = methods,
-        ciDefaultMethods = defaults
+        ciDefaultMethods = defaults,
+        ciDefaultSignatures = defaultSignatures
       }
   pure (methodResults <> catMaybes defaultResults)
   where
@@ -1635,13 +1691,19 @@ registerClassDecl classDecl = do
         Just (TcIdBinder scheme _) -> pure (methodName, scheme)
         _ -> missingTypeInfo ("class method " <> T.unpack methodName)
 
-    registerDefaultMethod defaults (methodName, scheme)
+    registerDefaultMethod defaults defaultSignatures (methodName, scheme)
       | methodName `elem` defaults = do
           let workerName = defaultMethodName methodName
-              workerType = schemeToType scheme
-          extendTermEnvPermanent workerName (TcIdBinder scheme Closed)
+              workerScheme = maybe scheme (defaultWorkerScheme scheme) (lookup methodName defaultSignatures)
+              workerType = schemeToType workerScheme
+          extendTermEnvPermanent workerName (TcIdBinder workerScheme Closed)
           pure (Just (TcBindingResult workerName workerName workerType))
       | otherwise = pure Nothing
+
+    defaultWorkerScheme ordinaryScheme (ForAll tyVars predicates body) =
+      case ordinaryScheme of
+        ForAll _ (classPredicate : _) _ -> ForAll tyVars (classPredicate : predicates) body
+        _ -> ForAll tyVars predicates body
 
 registerClassItem :: Pred -> TvKindEnv -> [TyVarId] -> ClassDeclItem -> TcM [TcBindingResult]
 registerClassItem classPred classTvEnv classTyVars item =
@@ -1668,6 +1730,26 @@ registerClassItem classPred classTvEnv classTyVars item =
         )
         names
     _ -> pure []
+
+registerClassDefaultSignature :: TvKindEnv -> [TyVarId] -> ClassDeclItem -> TcM (Maybe (Text, TypeScheme))
+registerClassDefaultSignature classTvEnv classTyVars item =
+  case peelClassDeclItemAnn item of
+    ClassItemDefaultSig methodName ty -> do
+      let (context, body) = splitContext ty
+          classVarNames = Map.keys classTvEnv
+          freeVars = freeTypeVars ty \\ classVarNames
+      extraTyVars <- mapM freshSkolemTv freeVars
+      extraKinds <- mapM (const freshKindMeta) freeVars
+      let tvEnv = classTvEnv <> Map.fromList (zip freeVars (zip extraTyVars extraKinds))
+      methodBody <- checkSurfaceType tvEnv body KType
+      contextPreds <- mapM (surfacePredToPred tvEnv) context
+      pure
+        ( Just
+            ( unqualifiedNameText methodName,
+              ForAll (classTyVars <> extraTyVars) contextPreds methodBody
+            )
+        )
+    _ -> pure Nothing
 
 registerInstanceDecl :: InstanceDecl -> TcM [TcBindingResult]
 registerInstanceDecl instanceDecl =

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Dict.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Dict.hs
@@ -9,6 +9,9 @@ module Aihc.Tc.Solve.Dict
   ( solveDict,
     solveDictWithGivens,
     DictResult (..),
+    constraintTypeToPred,
+    matchTypes,
+    substPred,
   )
 where
 

--- a/components/aihc-tc/test/Test/Fixtures/annotated/anyclass-derived-contexts.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/anyclass-derived-contexts.yaml
@@ -1,0 +1,59 @@
+annotated:
+- |-
+  {-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies #-}
+  module Main where
+  class Show a where
+  └─ class methods:
+  class C a where
+  └─ class methods: c ∷ ∀ a. (C a) ⇒ a → a
+    c :: a -> a
+    default c :: Show a => a -> a
+    c x = x
+    │ └─ type: a
+    └─ c ∷ ∀ a. (C a, Show a) ⇒ a → a
+  data T a = T a
+  │    │     └─ type: ∀ a. a → T a
+  │    └─ type: * → *
+  └─ deriving plans: anyclass C (T a) [context: Show a] [methods: c]
+    deriving anyclass C
+  instance Show a => Show (T a)
+  └─ $fShowTa ∷ ∀ a. (Show a) ⇒ Show (T a)
+  class Parent a where
+  └─ class methods:
+  class Parent a => Child a where
+  └─ class methods:
+  data S a = S a
+  │    │     └─ type: ∀ a. a → S a
+  │    └─ type: * → *
+  └─ deriving plans: anyclass Child (S a) [context: ()], anyclass Parent (S a) [context: ()]
+    deriving anyclass (Child, Parent)
+  data Missing = Missing
+  │    │         └─ type: Missing
+  │    └─ type: *
+  └─ deriving plans: anyclass Child Missing [context: infer]
+    deriving anyclass Child
+                      └─ error: unsolved constraint Parent Missing
+extensions:
+- DefaultSignatures
+- DeriveAnyClass
+- DerivingStrategies
+modules:
+- |
+  {-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies #-}
+  module Main where
+  class Show a where
+  class C a where
+    c :: a -> a
+    default c :: Show a => a -> a
+    c x = x
+  data T a = T a
+    deriving anyclass C
+  instance Show a => Show (T a)
+  class Parent a where
+  class Parent a => Child a where
+  data S a = S a
+    deriving anyclass (Child, Parent)
+  data Missing = Missing
+    deriving anyclass Child
+reason: AnyClass contexts use checked default signatures and solve sibling derived superclasses as a declaration-order-independent batch
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plans.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/deriving-plans.yaml
@@ -17,7 +17,7 @@ annotated:
   data T a = T a
   │    │     └─ type: ∀ a. a → T a
   │    └─ type: * → *
-  └─ deriving plans: anyclass C (T a) [context: infer] [methods: c], anyclass HK T [context: infer], via Wrapper a D (T a) [context: infer]
+  └─ deriving plans: anyclass C (T a) [context: ()] [methods: c], anyclass HK T [context: ()], via Wrapper a D (T a) [context: infer]
     deriving anyclass C
     deriving anyclass HK
     deriving D via Wrapper a
@@ -28,13 +28,13 @@ annotated:
     deriving newtype C
   newtype PreferAnyclass a = PreferAnyclass a
   │       └─ type: * → *     └─ type: ∀ a. a → PreferAnyclass a
-  └─ deriving plans: anyclass C (PreferAnyclass a) [context: infer] [methods: c]
+  └─ deriving plans: anyclass C (PreferAnyclass a) [context: ()] [methods: c]
     deriving C
              └─ warning: both DeriveAnyClass and GeneralizedNewtypeDeriving are enabled; defaulting to anyclass for C
   data Default a = Default a
   │    │           └─ type: ∀ a. a → Default a
   │    └─ type: * → *
-  └─ deriving plans: anyclass C (Default a) [context: infer] [methods: c]
+  └─ deriving plans: anyclass C (Default a) [context: ()] [methods: c]
     deriving C
 extensions:
 - DeriveAnyClass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/integer-pattern-lambda-case.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/integer-pattern-lambda-case.yaml
@@ -23,7 +23,7 @@ annotated:
 - |-
   module Main where
   match = \case
-  └─ type: ∀ a. (Eq a Num a) ⇒ a → ()
+  └─ type: ∀ a. (Eq a, Num a) ⇒ a → ()
     1 -> ()
     ││    └─ type: ()
     └─ type: a; type-args: a; evidence: given Num a

--- a/components/aihc-tc/test/Test/Fixtures/annotated/overloaded-integer-inferred-types.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/overloaded-integer-inferred-types.yaml
@@ -26,7 +26,7 @@ annotated:
   │         └─ type: a; type-args: a; evidence: given Num a
   └─ type: ∀ a. (Num a) ⇒ a
   match = \case
-  └─ type: ∀ a. (Eq a Num a) ⇒ a → ()
+  └─ type: ∀ a. (Eq a, Num a) ⇒ a → ()
     1 -> ()
     ││    └─ type: ()
     └─ type: a; type-args: a; evidence: given Num a

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -13,6 +13,7 @@ import Aihc.Parser.Syntax
     CaseAlt (..),
     Decl (..),
     Expr (..),
+    Extension (..),
     GuardQualifier (..),
     GuardedRhs (..),
     InstanceDecl (..),
@@ -375,6 +376,40 @@ annotationTests =
       assertBool "Identity Bool instance annotated" (hasInstanceDict "$fIdentityBool" result)
       assertBool "instance superclass evidence annotated" (not (all (null . tcInstanceSuperClasses) (instanceAnnotations result)))
       assertBool "instance method types annotated" (hasInstanceMethod "==" result && hasInstanceMethod "def" result),
+    testCase "AnyClass deriving exports inferred instance contexts" $ do
+      let result =
+            typecheckModule $
+              parseMWithExtensions
+                [DefaultSignatures, DeriveAnyClass, DerivingStrategies]
+                "{-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies #-}\n\
+                \module Test where\n\
+                \class Show a where\n\
+                \  showValue :: a -> a\n\
+                \class C a where\n\
+                \  c :: a -> a\n\
+                \  default c :: Show a => a -> a\n\
+                \  c x = showValue x\n\
+                \data T a = T a deriving anyclass C\n\
+                \instance Show a => Show (T a) where\n\
+                \  showValue x = x\n\
+                \data Unit = Unit\n\
+                \instance Show Unit where\n\
+                \  showValue x = x\n\
+                \useDerived :: T Unit -> T Unit\n\
+                \useDerived value = c value\n\
+                \class Parent a where\n\
+                \class Parent a => Child a where\n\
+                \data S a = S a deriving anyclass (Child, Parent)\n"
+          instances = tcModuleInstances result
+          plans = derivingPlans result
+          contexts className = [map renderPred (iiContext instanceInfo) | instanceInfo <- instances, iiClassName instanceInfo == className]
+      assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
+      assertEqual "default-signature context" [["Show a"]] (contexts "C")
+      assertEqual "sibling superclass context" [[]] (contexts "Child")
+      assertEqual "sibling AnyClass instance" [[]] (contexts "Parent")
+      assertBool "same-module values can select the derived dictionary" ("$fCTa" `elem` evidenceDictNames result)
+      assertBool "default-method evidence is checked in TC" (not (all (null . tcDerivingDefaultMethodEvidence) plans))
+      assertBool "superclass evidence is checked in TC" (not (all (null . tcDerivingSuperClasses) plans)),
     testCase "instance methods retain method-local constraints" $ do
       let result =
             typecheckModule $
@@ -487,14 +522,20 @@ annotationModule =
     \useIdentity = identity True\n"
 
 parseM :: Text -> Module
-parseM input =
-  case resolve [parseOnly input] of
+parseM = parseMWithExtensions []
+
+parseMWithExtensions :: [Extension] -> Text -> Module
+parseMWithExtensions extensions input =
+  case resolve [parseOnlyWithExtensions extensions input] of
     ResolveResult {resolvedModules = [resolved], resolveErrors = []} -> resolved
     ResolveResult {resolveErrors} -> error ("Resolve error in test: " ++ show resolveErrors)
 
 parseOnly :: Text -> Module
-parseOnly input =
-  let config = defaultConfig {parserSourceName = "<test>"}
+parseOnly = parseOnlyWithExtensions []
+
+parseOnlyWithExtensions :: [Extension] -> Text -> Module
+parseOnlyWithExtensions extensions input =
+  let config = defaultConfig {parserSourceName = "<test>", parserExtensions = extensions}
       (errs, modu) = parseModule config input
    in if null errs
         then modu
@@ -563,6 +604,14 @@ instanceAnnotations =
   where
     goDecl (DeclAnn ann inner) =
       maybeToList (fromAnnotation ann) <> goDecl inner
+    goDecl _ = []
+
+derivingPlans :: Module -> [TcDerivingPlan]
+derivingPlans =
+  concatMap goDecl . moduleDecls
+  where
+    goDecl (DeclAnn ann inner) =
+      maybe [] tcDerivingPlans (fromAnnotation ann) <> goDecl inner
     goDecl _ = []
 
 instanceMethodAnnotations :: Module -> [TcInstanceMethodAnnotation]


### PR DESCRIPTION
## Summary

- preserve checked class default signatures in `ClassInfo`, class annotations, and deriving plans
- type-check default implementations against their default signatures, including the class dictionary and extra constraints
- add `Aihc.Tc.Deriving.Context` to infer attached `DeriveAnyClass` contexts from instantiated superclasses and default-signature obligations
- finalize deriving plans as one SCC-wide batch so sibling AnyClass instances are declaration-order independent
- register finalized AnyClass instances before checking signatures and value bodies, making same-module derived dictionaries available to the solver
- attach checked superclass and default-method evidence to the deriving plan so System FC can lower it without repeating Haskell constraint solving
- reject unsatisfied target-shaped obligations instead of recording invalid inferred contexts
- expose finalized AnyClass plans through `tcModuleInstances`

Stock, newtype, and via plans deliberately retain `context: infer`; their strategy-specific context rules and System FC generation are outside this PR. No derived methods, dictionaries, declarations, or System FC are generated here.

The context behavior was compared with GHC using `-ddump-deriv`, including a default-signature context reduced through an explicit instance and reversed sibling superclass derivations.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options=--hide-successes`
- `just fmt`
- `just check`

## Progress

- TC annotated golden PASS: 71 → 72
- `aihc-tc` tests: 99 → 101