### PR TITLE
feat(fc): add equality-saturation inlining

### DIFF
--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -32,10 +32,15 @@ library
     base >=4.16 && <5,
     bytestring,
     containers,
+    hegg >=0.6 && <0.7,
     libffi >=0.2 && <0.3,
     text >=1.2,
     transformers,
     unix,
+
+  other-modules:
+    Aihc.Fc.Optimize.EGraph
+    Aihc.Fc.Optimize.Inline
 
   ghc-options: -Wall
   default-language: GHC2021

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -208,9 +208,9 @@ evalWithEnv env expr =
       evalWithEnv env body
     FcLet bind body ->
       evalWithEnv (extendBind env bind) body
-    FcCase scrut _ alts -> do
+    FcCase scrut binder alts -> do
       value <- evalWithEnv env scrut
-      matchAlternative env value alts
+      matchAlternative (Map.insert (varName binder) value env) value alts
     FcCast inner _ ->
       evalWithEnv env inner
     FcCallForeign foreignCall arguments -> do

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -179,13 +179,14 @@ lintExpr env (FcLet bind body) = do
   case errs of
     [] -> lintExpr env' body
     (e : _) -> Left e
-lintExpr env (FcCase scrut _binder alts) = do
+lintExpr env (FcCase scrut binder alts) = do
   _scrutTy <- lintExpr env scrut
+  let alternativeEnv = extendTermEnv binder env
   case alts of
     [] -> Left (LintFailure "case expression has no alternatives")
     alt : rest -> do
-      resTy <- lintAlt env alt
-      mapM_ (lintAltWithExpected env resTy) rest
+      resTy <- lintAlt alternativeEnv alt
+      mapM_ (lintAltWithExpected alternativeEnv resTy) rest
       Right resTy
 lintExpr env (FcCast e co) = do
   eTy <- lintExpr env e

--- a/components/aihc-fc/src/Aihc/Fc/Optimize.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Optimize.hs
@@ -1,31 +1,31 @@
--- | Small, monotone System FC simplifications.
+-- | System FC simplification and equality-saturation optimization.
 --
--- Every optimization in this module must strictly simplify the Core program:
--- rules may remove structure, but must not trade one form for another form of
--- equal complexity. This makes it safe to run the complete rule set to a
--- fixpoint and keeps interactions between independent rules predictable.
+-- Local canonicalizations run to a fixpoint. Binding-aware inlining separately
+-- generates equivalent alternatives and uses an e-graph cost model to decide
+-- whether the exposed optimization opportunities justify the added code.
 module Aihc.Fc.Optimize
   ( optimizeProgram,
   )
 where
 
+import Aihc.Fc.Optimize.Inline (inlineCandidatesProgram)
 import Aihc.Fc.Syntax
-import Data.List qualified as List
+import Aihc.Tc.Types (Unique)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Text (Text)
 
-type CoreOptimization = FcProgram -> FcProgram
+-- Linked compilation units currently have independently allocated uniques.
+-- Include the printed name so an alias in one unit cannot capture an unrelated
+-- constructor or global imported from another unit.
+type VarKey = (Unique, Text)
 
--- | Apply every Core simplification until a complete pass makes no change.
+-- | Canonicalize existing aliases, then explore sharing-safe inlining
+-- alternatives. Generated non-trivial lets remain explicit sharing points.
 optimizeProgram :: FcProgram -> FcProgram
-optimizeProgram = untilStable runOptimizations
+optimizeProgram = inlineCandidatesProgram . simplifyAliases
   where
-    runOptimizations program = List.foldl' (flip ($)) program coreOptimizations
-
--- Keep this list ordered from local canonicalizations to broader rewrites so
--- later rules see the simplest output available from earlier rules.
-coreOptimizations :: [CoreOptimization]
-coreOptimizations = [copyPropagateProgram]
+    simplifyAliases = untilStable copyPropagateProgram
 
 untilStable :: (Eq value) => (value -> value) -> value -> value
 untilStable transform input =
@@ -45,7 +45,7 @@ copyPropagateProgram (FcProgram topBinds) =
         FcTopBind bind -> FcTopBind (copyBind Map.empty bind)
         _ -> topBind
 
-copyBind :: Map Var Var -> FcBind -> FcBind
+copyBind :: Map VarKey Var -> FcBind -> FcBind
 copyBind aliases bind =
   case bind of
     FcNonRec binder rhs ->
@@ -54,24 +54,24 @@ copyBind aliases bind =
       let innerAliases = removeAliases (map fst bindings) aliases
        in FcRec [(binder, copyExpr innerAliases rhs) | (binder, rhs) <- bindings]
 
-copyExpr :: Map Var Var -> FcExpr -> FcExpr
+copyExpr :: Map VarKey Var -> FcExpr -> FcExpr
 copyExpr aliases expression =
   case expression of
     FcVar var -> FcVar (resolveAlias aliases var)
     FcLit {} -> expression
     FcApp function argument -> FcApp (copyExpr aliases function) (copyExpr aliases argument)
     FcTyApp function ty -> FcTyApp (copyExpr aliases function) ty
-    FcLam binder body -> FcLam binder (copyExpr (Map.delete binder aliases) body)
+    FcLam binder body -> FcLam binder (copyExpr (Map.delete (varKey binder) aliases) body)
     FcTyLam tyVar body -> FcTyLam tyVar (copyExpr aliases body)
     FcLet (FcNonRec binder (FcVar source)) body ->
-      copyExpr (Map.insert binder (resolveAlias aliases source) aliases) body
+      copyExpr (Map.insert (varKey binder) (resolveAlias aliases source) aliases) body
     FcLet (FcRec [(binder, FcVar source)]) body
-      | binder /= source ->
-          copyExpr (Map.insert binder (resolveAlias aliases source) aliases) body
+      | varKey binder /= varKey source ->
+          copyExpr (Map.insert (varKey binder) (resolveAlias aliases source) aliases) body
     FcLet bind@(FcNonRec binder _) body ->
       FcLet
         (copyBind aliases bind)
-        (copyExpr (Map.delete binder aliases) body)
+        (copyExpr (Map.delete (varKey binder) aliases) body)
     FcLet bind@(FcRec bindings) body ->
       let binders = map fst bindings
           innerAliases = removeAliases binders aliases
@@ -80,12 +80,12 @@ copyExpr aliases expression =
       FcCase
         (copyExpr aliases scrutinee)
         binder
-        (map (copyAlt (Map.delete binder aliases)) alternatives)
+        (map (copyAlt (Map.delete (varKey binder) aliases)) alternatives)
     FcCast inner coercion -> FcCast (copyExpr aliases inner) coercion
     FcCallForeign foreignCall arguments ->
       FcCallForeign foreignCall (map (copyExpr aliases) arguments)
 
-copyAlt :: Map Var Var -> FcAlt -> FcAlt
+copyAlt :: Map VarKey Var -> FcAlt -> FcAlt
 copyAlt aliases alternative =
   alternative
     { altRhs =
@@ -94,11 +94,14 @@ copyAlt aliases alternative =
           (altRhs alternative)
     }
 
-removeAliases :: [Var] -> Map Var Var -> Map Var Var
-removeAliases binders aliases = foldr Map.delete aliases binders
+removeAliases :: [Var] -> Map VarKey Var -> Map VarKey Var
+removeAliases binders aliases = foldr (Map.delete . varKey) aliases binders
 
-resolveAlias :: Map Var Var -> Var -> Var
+resolveAlias :: Map VarKey Var -> Var -> Var
 resolveAlias aliases var =
-  case Map.lookup var aliases of
+  case Map.lookup (varKey var) aliases of
     Just target -> resolveAlias aliases target
     Nothing -> var
+
+varKey :: Var -> VarKey
+varKey var = (varUnique var, varName var)

--- a/components/aihc-fc/src/Aihc/Fc/Optimize/EGraph.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Optimize/EGraph.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DeriveTraversable #-}
+
+-- | The e-graph boundary for System FC optimization.
+--
+-- Binding-aware rewrites are produced outside the e-graph, where fresh names
+-- and call-by-need substitution can be handled explicitly. For now each whole
+-- expression is an opaque e-node. This is deliberate: recursively interning a
+-- named, binder-rich syntax tree would let extraction combine subexpressions
+-- from different scopes. A future structural representation must use a
+-- scope-safe encoding such as De Bruijn indices.
+module Aihc.Fc.Optimize.EGraph
+  ( selectSmallest,
+  )
+where
+
+import Aihc.Fc.Syntax
+import Control.Monad (forM_, void)
+import Data.Equality.Extraction (extractBest)
+import Data.Equality.Graph.Classes (ClassId)
+import Data.Equality.Graph.Monad qualified as EGraph
+import Data.Equality.Utils (Fix (..))
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+-- | An opaque, scope-preserving candidate and its complete lowered-size cost.
+-- There are no recursive children yet, so an e-class can select alternatives
+-- without accidentally moving a bound variable across its scope.
+data FcAlternativeF child
+  = FcAlternativeF !(Stable FcExpr) !Int
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+
+-- Core's identity instances intentionally compare only uniques. That is useful
+-- inside one freshly generated unit, but linked units are not guaranteed to
+-- have collision-free uniques. E-graph node ordering must be stronger: if two
+-- payloads compare equal, congruence will treat them as the same syntax. The
+-- complete readable representation includes names, uniques, kinds, and types
+-- and is therefore a safe proof-of-concept key.
+newtype Stable value = Stable {stableValue :: value}
+  deriving (Show)
+
+instance (Show value) => Eq (Stable value) where
+  left == right = show (stableValue left) == show (stableValue right)
+
+instance (Show value) => Ord (Stable value) where
+  compare left right = compare (show (stableValue left)) (show (stableValue right))
+
+-- | Put all proven-equivalent candidates in one e-class and select the term
+-- whose cost best predicts the size of the strict GRIN produced downstream.
+selectSmallest :: Map Text Int -> FcExpr -> [FcExpr] -> FcExpr
+selectSmallest callCosts original candidates =
+  fromFix (extractBest graph alternativeCost root)
+  where
+    (root, graph) = EGraph.egraph (buildAlternatives callCosts original candidates)
+
+buildAlternatives :: Map Text Int -> FcExpr -> [FcExpr] -> EGraph.EGraphM () FcAlternativeF ClassId
+buildAlternatives callCosts original candidates = do
+  originalClass <- EGraph.represent (toFix callCosts original)
+  forM_ candidates $ \candidate -> do
+    candidateClass <- EGraph.represent (toFix callCosts candidate)
+    void (EGraph.merge originalClass candidateClass)
+  EGraph.rebuild
+  pure originalClass
+
+alternativeCost :: FcAlternativeF Int -> Int
+alternativeCost (FcAlternativeF _ cost) = cost
+
+-- | Types and casts disappear before runtime code generation, while calls,
+-- closures, lets, and cases all survive in some form. This deliberately
+-- optimizes for generated-code size rather than raw System FC node count.
+loweredSizeCost :: Map Text Int -> FcExpr -> Int
+loweredSizeCost callCosts expression =
+  case expression of
+    FcVar var -> Map.findWithDefault 1 (varName var) callCosts
+    FcLit {} -> 1
+    FcApp function argument -> loweredSizeCost callCosts function + loweredSizeCost callCosts argument + 2
+    FcTyApp function _ -> loweredSizeCost callCosts function
+    FcLam _ body -> loweredSizeCost callCosts body + 2
+    FcTyLam _ body -> loweredSizeCost callCosts body
+    FcLet (FcNonRec _ rhs) body -> loweredSizeCost callCosts rhs + loweredSizeCost callCosts body + 1
+    FcLet (FcRec bindings) body ->
+      sum [loweredSizeCost callCosts rhs | (_, rhs) <- bindings]
+        + loweredSizeCost callCosts body
+        + 3
+    FcCase scrutinee _ alternatives ->
+      loweredSizeCost callCosts scrutinee
+        + sum [loweredSizeCost callCosts (altRhs alternative) | alternative <- alternatives]
+        + 2
+    FcCast inner _ -> loweredSizeCost callCosts inner
+    FcCallForeign _ arguments -> sum (map (loweredSizeCost callCosts) arguments) + 2
+
+toFix :: Map Text Int -> FcExpr -> Fix FcAlternativeF
+toFix callCosts expression =
+  Fix (FcAlternativeF (Stable expression) (loweredSizeCost callCosts expression))
+
+fromFix :: Fix FcAlternativeF -> FcExpr
+fromFix (Fix (FcAlternativeF expression _)) = stableValue expression

--- a/components/aihc-fc/src/Aihc/Fc/Optimize/Inline.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Optimize/Inline.hs
@@ -1,0 +1,764 @@
+-- | Binding-aware candidate generation for equality saturation.
+--
+-- System FC is lazy, so ordinary substitution is not a valid general-purpose
+-- inliner: it can duplicate work or turn a shared thunk into several thunks.
+-- This module performs call-by-need beta reduction. Non-trivial arguments used
+-- more than once remain let-bound, and unlifted arguments remain case-bound so
+-- their evaluation point is not moved.
+module Aihc.Fc.Optimize.Inline
+  ( inlineCandidatesProgram,
+  )
+where
+
+import Aihc.Fc.Optimize.EGraph (selectSmallest)
+import Aihc.Fc.Syntax
+import Aihc.Tc.Evidence (Coercion (..), EvVar (..))
+import Aihc.Tc.Types
+  ( Pred (..),
+    TcType (..),
+    TyCon (tyConName),
+    TyVarId (..),
+    Unique (..),
+    isUnliftedType,
+    setTyVarKind,
+    tvKind,
+  )
+import Control.Monad.Trans.State.Strict (State, evalState, get, put)
+import Data.Graph (SCC (..), stronglyConnComp)
+import Data.List qualified as List
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+data InlineEnv = InlineEnv
+  { inlineFunctions :: !(Map Text FcExpr),
+    staticValues :: !(Map Text FcExpr),
+    constructorArities :: !(Map Text Int)
+  }
+
+type VarKey = (Unique, Text)
+
+type TyVarKey = (Unique, Text)
+
+type TypeSubstitution = Map TyVarKey TcType
+
+data CallArgument
+  = TypeArgument !TcType
+  | TermArgument !FcExpr
+
+-- | Generate a binding-safe alternative, add it to a per-expression e-graph,
+-- and retain the lowest lowered-size representation.
+inlineCandidatesProgram :: FcProgram -> FcProgram
+inlineCandidatesProgram program@(FcProgram topBinds) =
+  FcProgram (evalState (traverse optimizeTopBind topBinds) (nextUnique program))
+  where
+    environment = buildInlineEnv program
+
+    optimizeTopBind topBind =
+      case topBind of
+        FcTopBind bind -> FcTopBind <$> optimizeBind environment bind
+        _ -> pure topBind
+
+optimizeBind :: InlineEnv -> FcBind -> State Int FcBind
+optimizeBind environment bind =
+  case bind of
+    FcNonRec binder rhs -> FcNonRec binder <$> optimizeExpr environment rhs
+    FcRec bindings ->
+      FcRec <$> traverse (\(binder, rhs) -> (binder,) <$> optimizeExpr environment rhs) bindings
+
+optimizeExpr :: InlineEnv -> FcExpr -> State Int FcExpr
+optimizeExpr environment original = do
+  candidate <- normalizeExpr environment 48 original
+  pure
+    ( if candidate == original
+        then original
+        else selectSmallest callCosts original [candidate]
+    )
+  where
+    -- A direct call carries the generated body behind it. Charging a small
+    -- multiple of that body lets extraction recognize when unfolding exposes
+    -- enough beta/case reduction to be smaller than the opaque call path.
+    callCosts = Map.map ((8 *) . expressionSize) (inlineFunctions environment)
+
+buildInlineEnv :: FcProgram -> InlineEnv
+buildInlineEnv (FcProgram topBinds) =
+  InlineEnv
+    { inlineFunctions =
+        Map.filterWithKey
+          (\name rhs -> name `Set.member` acyclic && isDirectFunction rhs && expressionSize rhs <= inlineThreshold)
+          values,
+      staticValues = values,
+      constructorArities = constructors
+    }
+  where
+    values =
+      Map.fromList
+        [ (varName binder, rhs)
+        | FcTopBind (FcNonRec binder rhs) <- topBinds
+        ]
+    topLevelVariables = Map.keysSet values
+    dependencyNodes =
+      [ ( (key, rhs),
+          key,
+          Set.toList (freeVariableKeys rhs `Set.intersection` topLevelVariables)
+        )
+      | (key, rhs) <- Map.toList values
+      ]
+    acyclic =
+      Set.fromList
+        [ key
+        | AcyclicSCC (key, _) <- stronglyConnComp dependencyNodes
+        ]
+    constructors =
+      Map.fromList
+        [ (constructor, length fields)
+        | FcData _ _ declarations <- topBinds,
+          (constructor, fields) <- declarations
+        ]
+
+-- Large functions are left opaque in this first version. The important
+-- library combinators and dictionary selectors are comfortably below this
+-- limit, while the limit prevents accidental whole-program code explosion.
+inlineThreshold :: Int
+inlineThreshold = 80
+
+isDirectFunction :: FcExpr -> Bool
+isDirectFunction expression =
+  case expression of
+    FcTyLam _ body -> isDirectFunction body
+    FcLam {} -> True
+    FcCast body _ -> isDirectFunction body
+    _ -> False
+
+expressionSize :: FcExpr -> Int
+expressionSize expression =
+  1 + case expression of
+    FcVar {} -> 0
+    FcLit {} -> 0
+    FcApp function argument -> expressionSize function + expressionSize argument
+    FcTyApp function _ -> expressionSize function
+    FcLam _ body -> expressionSize body
+    FcTyLam _ body -> expressionSize body
+    FcLet (FcNonRec _ rhs) body -> expressionSize rhs + expressionSize body
+    FcLet (FcRec bindings) body -> sum (map (expressionSize . snd) bindings) + expressionSize body
+    FcCase scrutinee _ alternatives -> expressionSize scrutinee + sum (map (expressionSize . altRhs) alternatives)
+    FcCast body _ -> expressionSize body
+    FcCallForeign _ arguments -> sum (map expressionSize arguments)
+
+normalizeExpr :: InlineEnv -> Int -> FcExpr -> State Int FcExpr
+normalizeExpr _ fuel expression | fuel <= 0 = pure expression
+normalizeExpr environment fuel expression = do
+  children <- normalizeChildren environment (fuel - 1) expression
+  proposed <- rewriteRoot environment children
+  let typePreserving = preservesExpressionType children proposed
+      rewritten
+        | typePreserving = proposed
+        | otherwise = children
+  if rewritten == children
+    then pure children
+    else normalizeExpr environment (fuel - 1) rewritten
+
+-- Every rewrite is an equality only at one result type. Rejecting a candidate
+-- locally is safer than allowing a malformed unboxed value to escape into a
+-- lifted context and relying on a later lint pass to find it.
+preservesExpressionType :: FcExpr -> FcExpr -> Bool
+preservesExpressionType before after =
+  case (expressionType before, expressionType after) of
+    (Just beforeType, Just afterType) ->
+      sameTypeShape beforeType afterType
+        || (returnsIo beforeType && returnsIo afterType)
+    _ -> True
+
+-- IO's linked dictionary currently contains method annotations whose rigid
+-- identities do not agree with the selector's annotations. Both forms erase
+-- to lifted values, and the concrete result remains IO, so permit that narrow
+-- discrepancy to expose the state-transformer implementation of bind.
+returnsIo :: TcType -> Bool
+returnsIo ty =
+  case ty of
+    TcFunTy _ result -> returnsIo result
+    TcForAllTy _ body -> returnsIo body
+    TcQualTy _ body -> returnsIo body
+    TcTyCon tyCon _ -> tyConName tyCon == Text.pack "IO"
+    TcAppTy function _ -> returnsIoHead function
+    _ -> False
+  where
+    returnsIoHead function =
+      case function of
+        TcTyCon tyCon _ -> tyConName tyCon == Text.pack "IO"
+        TcAppTy inner _ -> returnsIoHead inner
+        _ -> False
+
+-- Linked units currently allocate rigid variables independently, so their
+-- identities cannot be compared directly here. Shape equality distinguishes
+-- concrete lifted and unlifted types while accepting alpha-renamed
+-- polymorphic library definitions.
+sameTypeShape :: TcType -> TcType -> Bool
+sameTypeShape left right =
+  case (left, right) of
+    (TcTyVar leftVar, TcTyVar rightVar) -> tvKind leftVar == tvKind rightVar
+    (TcMetaTv leftUnique, TcMetaTv rightUnique) -> leftUnique == rightUnique
+    (TcTyCon leftCon leftArguments, TcTyCon rightCon rightArguments) ->
+      leftCon == rightCon
+        && length leftArguments == length rightArguments
+        && and (zipWith sameTypeShape leftArguments rightArguments)
+    (TcFunTy leftArgument leftResult, TcFunTy rightArgument rightResult) ->
+      sameTypeShape leftArgument rightArgument && sameTypeShape leftResult rightResult
+    (TcForAllTy leftVar leftBody, TcForAllTy rightVar rightBody) ->
+      tvKind leftVar == tvKind rightVar && sameTypeShape leftBody rightBody
+    (TcQualTy leftPredicates leftBody, TcQualTy rightPredicates rightBody) ->
+      length leftPredicates == length rightPredicates
+        && and (zipWith samePredicateShape leftPredicates rightPredicates)
+        && sameTypeShape leftBody rightBody
+    (TcAppTy (TcTyCon leftCon leftArguments) leftArgument, TcTyCon rightCon rightArguments) ->
+      sameTypeShape
+        (TcTyCon leftCon (leftArguments <> [leftArgument]))
+        (TcTyCon rightCon rightArguments)
+    (TcTyCon leftCon leftArguments, TcAppTy (TcTyCon rightCon rightArguments) rightArgument) ->
+      sameTypeShape
+        (TcTyCon leftCon leftArguments)
+        (TcTyCon rightCon (rightArguments <> [rightArgument]))
+    (TcAppTy leftFunction leftArgument, TcAppTy rightFunction rightArgument) ->
+      sameTypeShape leftFunction rightFunction && sameTypeShape leftArgument rightArgument
+    _ -> False
+
+samePredicateShape :: Pred -> Pred -> Bool
+samePredicateShape left right =
+  case (left, right) of
+    (ClassPred leftClass leftArguments, ClassPred rightClass rightArguments) ->
+      leftClass == rightClass
+        && length leftArguments == length rightArguments
+        && and (zipWith sameTypeShape leftArguments rightArguments)
+    (EqPred leftFirst leftSecond, EqPred rightFirst rightSecond) ->
+      sameTypeShape leftFirst rightFirst && sameTypeShape leftSecond rightSecond
+    _ -> False
+
+expressionType :: FcExpr -> Maybe TcType
+expressionType expression =
+  case expression of
+    FcVar var -> Just (varType var)
+    FcLit literal -> literalType literal
+    FcApp function _ -> do
+      functionType <- expressionType function
+      case functionType of
+        TcFunTy _ resultType -> Just resultType
+        _ -> Nothing
+    FcTyApp function argument -> do
+      functionType <- expressionType function
+      case functionType of
+        TcForAllTy tyVar body ->
+          Just (substituteType (Map.singleton (tyVarKey tyVar) argument) body)
+        _ -> Nothing
+    FcLam binder body -> TcFunTy (varType binder) <$> expressionType body
+    FcTyLam tyVar body -> TcForAllTy tyVar <$> expressionType body
+    FcLet _ body -> expressionType body
+    FcCase _ _ alternatives ->
+      case alternatives of
+        alternative : _ -> expressionType (altRhs alternative)
+        [] -> Nothing
+    FcCast body (Refl _) -> expressionType body
+    FcCast {} -> Nothing
+    FcCallForeign foreignCall _ ->
+      Just (fcForeignCallResultType (fcForeignCallSignature foreignCall))
+
+normalizeChildren :: InlineEnv -> Int -> FcExpr -> State Int FcExpr
+normalizeChildren environment fuel expression =
+  case expression of
+    FcVar {} -> pure expression
+    FcLit {} -> pure expression
+    FcApp function argument ->
+      FcApp <$> normalizeExpr environment fuel function <*> normalizeExpr environment fuel argument
+    FcTyApp function ty -> FcTyApp <$> normalizeExpr environment fuel function <*> pure ty
+    FcLam binder body -> FcLam binder <$> normalizeExpr environment fuel body
+    FcTyLam tyVar body -> FcTyLam tyVar <$> normalizeExpr environment fuel body
+    FcLet bind body -> FcLet <$> normalizeBind environment fuel bind <*> normalizeExpr environment fuel body
+    FcCase scrutinee binder alternatives ->
+      FcCase
+        <$> normalizeExpr environment fuel scrutinee
+        <*> pure binder
+        <*> traverse normalizeAlternative alternatives
+    FcCast body coercion -> FcCast <$> normalizeExpr environment fuel body <*> pure coercion
+    FcCallForeign foreignCall arguments ->
+      FcCallForeign foreignCall <$> traverse (normalizeExpr environment fuel) arguments
+  where
+    normalizeAlternative alternative =
+      (\rhs -> alternative {altRhs = rhs})
+        <$> normalizeExpr environment fuel (altRhs alternative)
+
+normalizeBind :: InlineEnv -> Int -> FcBind -> State Int FcBind
+normalizeBind environment fuel bind =
+  case bind of
+    FcNonRec binder rhs -> FcNonRec binder <$> normalizeExpr environment fuel rhs
+    FcRec bindings ->
+      FcRec <$> traverse (\(binder, rhs) -> (binder,) <$> normalizeExpr environment fuel rhs) bindings
+
+rewriteRoot :: InlineEnv -> FcExpr -> State Int FcExpr
+rewriteRoot environment expression =
+  case expression of
+    FcTyApp (FcTyLam tyVar body) argument ->
+      pure (substituteTypes (Map.singleton (tyVarKey tyVar) argument) body)
+    FcApp (FcLam binder body) argument ->
+      pure (bindArgument binder argument body)
+    FcCase scrutinee binder alternatives
+      | Just reduced <- reduceKnownCase environment scrutinee binder alternatives -> pure reduced
+    FcCast body (Refl _) -> pure body
+    _
+      | Just (function, arguments) <- collectCall expression,
+        Just rhs <- Map.lookup (varName function) (inlineFunctions environment) -> do
+          freshRhs <- freshenExpression rhs
+          pure (fromMaybe expression (applyCallArguments freshRhs arguments))
+    _ -> pure expression
+
+isTrivial :: FcExpr -> Bool
+isTrivial expression =
+  case expression of
+    FcVar {} -> True
+    FcLit {} -> True
+    FcTyApp function _ -> isTrivial function
+    FcCast body (Refl _) -> isTrivial body
+    _ -> False
+
+bindArgument :: Var -> FcExpr -> FcExpr -> FcExpr
+bindArgument binder argument body
+  | isUnliftedType (varType binder) =
+      FcCase argument binder [FcAlt DefaultAlt [] body]
+  | uses == 0 = body
+  | uses == 1 || isTrivial argument = substituteTerm binder argument body
+  | otherwise = FcLet (FcNonRec binder argument) body
+  where
+    uses = occurrenceCount binder body
+
+applyCallArguments :: FcExpr -> [CallArgument] -> Maybe FcExpr
+applyCallArguments = go False
+  where
+    go consumed expression arguments =
+      case (expression, arguments) of
+        (FcTyLam tyVar body, TypeArgument ty : rest) ->
+          go True (substituteTypes (Map.singleton (tyVarKey tyVar) ty) body) rest
+        (FcLam binder body, TermArgument argument : rest) ->
+          go True (bindArgument binder argument body) rest
+        (_, [])
+          | consumed && not (isBinder expression) -> Just expression
+          | otherwise -> Nothing
+        _
+          | consumed -> Just (rebuildCall expression arguments)
+          | otherwise -> Nothing
+
+    isBinder FcTyLam {} = True
+    isBinder FcLam {} = True
+    isBinder _ = False
+
+collectCall :: FcExpr -> Maybe (Var, [CallArgument])
+collectCall = go []
+  where
+    go arguments expression =
+      case expression of
+        FcApp function argument -> go (TermArgument argument : arguments) function
+        FcTyApp function ty -> go (TypeArgument ty : arguments) function
+        FcVar function
+          | not (null arguments) -> Just (function, arguments)
+        _ -> Nothing
+
+rebuildCall :: FcExpr -> [CallArgument] -> FcExpr
+rebuildCall = List.foldl' apply
+  where
+    apply function argument =
+      case argument of
+        TypeArgument ty -> FcTyApp function ty
+        TermArgument value -> FcApp function value
+
+reduceKnownCase :: InlineEnv -> FcExpr -> Var -> [FcAlt] -> Maybe FcExpr
+reduceKnownCase environment scrutinee binder alternatives =
+  case knownCaseValue environment Set.empty scrutinee of
+    Just (KnownConstructor constructor fields) -> do
+      (isExact, alternative) <- findAlternative (DataAlt constructor) alternatives
+      if isExact
+        then
+          if length fields == length (altBinders alternative)
+            then
+              let withFields =
+                    foldr
+                      (\(fieldBinder, field) body -> bindArgument fieldBinder field body)
+                      (altRhs alternative)
+                      (zip (altBinders alternative) fields)
+               in Just (bindArgument binder scrutinee withFields)
+            else Nothing
+        else Just (bindDefaultAlternative binder scrutinee alternative)
+    Just (KnownLiteral literal) -> do
+      (isExact, alternative) <- findAlternative (LitAlt literal) alternatives
+      if isExact
+        then Just (bindArgument binder scrutinee (altRhs alternative))
+        else Just (bindDefaultAlternative binder scrutinee alternative)
+    Nothing -> Nothing
+
+-- DEFAULT binders denote the complete scrutinee, not the fields of a known
+-- constructor. Alias them through the case binder so the scrutinee remains a
+-- single call-by-need computation even when several binders are referenced.
+bindDefaultAlternative :: Var -> FcExpr -> FcAlt -> FcExpr
+bindDefaultAlternative binder scrutinee alternative =
+  bindArgument binder scrutinee body
+  where
+    body =
+      foldr
+        (\defaultBinder -> substituteTerm defaultBinder (FcVar binder))
+        (altRhs alternative)
+        (altBinders alternative)
+
+data KnownCaseValue
+  = KnownConstructor !Text ![FcExpr]
+  | KnownLiteral !Literal
+
+knownCaseValue :: InlineEnv -> Set Text -> FcExpr -> Maybe KnownCaseValue
+knownCaseValue environment visited expression =
+  case expression of
+    FcLit literal -> Just (KnownLiteral literal)
+    FcVar var
+      | varName var `Set.notMember` visited,
+        Just rhs <- Map.lookup (varName var) (staticValues environment) ->
+          knownCaseValue environment (Set.insert (varName var) visited) rhs
+    _ -> do
+      (constructor, arguments) <- collectConstructor expression
+      arity <- Map.lookup (varName constructor) (constructorArities environment)
+      let fields = [field | TermArgument field <- arguments]
+      if length fields == arity
+        then Just (KnownConstructor (varName constructor) fields)
+        else Nothing
+
+collectConstructor :: FcExpr -> Maybe (Var, [CallArgument])
+collectConstructor = go []
+  where
+    go arguments expression =
+      case expression of
+        FcApp function argument -> go (TermArgument argument : arguments) function
+        FcTyApp function ty -> go (TypeArgument ty : arguments) function
+        FcVar constructor -> Just (constructor, arguments)
+        _ -> Nothing
+
+findAlternative :: FcAltCon -> [FcAlt] -> Maybe (Bool, FcAlt)
+findAlternative constructor alternatives =
+  case List.find ((== constructor) . altCon) alternatives of
+    Just alternative -> Just (True, alternative)
+    Nothing -> (False,) <$> List.find ((== DefaultAlt) . altCon) alternatives
+
+substituteTerm :: Var -> FcExpr -> FcExpr -> FcExpr
+substituteTerm target replacement = go
+  where
+    go expression =
+      case expression of
+        FcVar var
+          | sameVar var target -> replacement
+          | otherwise -> expression
+        FcLit {} -> expression
+        FcApp function argument -> FcApp (go function) (go argument)
+        FcTyApp function ty -> FcTyApp (go function) ty
+        FcLam binder body
+          | sameVar binder target -> expression
+          | otherwise -> FcLam binder (go body)
+        FcTyLam tyVar body -> FcTyLam tyVar (go body)
+        FcLet (FcNonRec binder rhs) body ->
+          FcLet
+            (FcNonRec binder (go rhs))
+            (if sameVar binder target then body else go body)
+        FcLet (FcRec bindings) body
+          | any (sameVar target . fst) bindings -> expression
+          | otherwise -> FcLet (FcRec [(binder, go rhs) | (binder, rhs) <- bindings]) (go body)
+        FcCase scrutinee binder alternatives ->
+          FcCase
+            (go scrutinee)
+            binder
+            [ if sameVar binder target || any (sameVar target) (altBinders alternative)
+                then alternative
+                else alternative {altRhs = go (altRhs alternative)}
+            | alternative <- alternatives
+            ]
+        FcCast body coercion -> FcCast (go body) coercion
+        FcCallForeign foreignCall arguments -> FcCallForeign foreignCall (map go arguments)
+
+occurrenceCount :: Var -> FcExpr -> Int
+occurrenceCount target = go
+  where
+    go expression =
+      case expression of
+        FcVar var -> fromEnum (sameVar var target)
+        FcLit {} -> 0
+        FcApp function argument -> go function + go argument
+        FcTyApp function _ -> go function
+        FcLam binder body
+          | sameVar binder target -> 0
+          | otherwise -> go body
+        FcTyLam _ body -> go body
+        FcLet (FcNonRec binder rhs) body ->
+          go rhs + if sameVar binder target then 0 else go body
+        FcLet (FcRec bindings) body
+          | any (sameVar target . fst) bindings -> 0
+          | otherwise -> sum (map (go . snd) bindings) + go body
+        FcCase scrutinee binder alternatives ->
+          go scrutinee
+            + sum
+              [ if sameVar binder target || any (sameVar target) (altBinders alternative)
+                  then 0
+                  else go (altRhs alternative)
+              | alternative <- alternatives
+              ]
+        FcCast body _ -> go body
+        FcCallForeign _ arguments -> sum (map go arguments)
+
+freeVariableKeys :: FcExpr -> Set Text
+freeVariableKeys expression =
+  case expression of
+    FcVar var -> Set.singleton (varName var)
+    FcLit {} -> Set.empty
+    FcApp function argument -> freeVariableKeys function <> freeVariableKeys argument
+    FcTyApp function _ -> freeVariableKeys function
+    FcLam binder body -> Set.delete (varName binder) (freeVariableKeys body)
+    FcTyLam _ body -> freeVariableKeys body
+    FcLet (FcNonRec binder rhs) body ->
+      freeVariableKeys rhs <> Set.delete (varName binder) (freeVariableKeys body)
+    FcLet (FcRec bindings) body ->
+      let binders = Set.fromList (map (varName . fst) bindings)
+       in (Set.unions (map (freeVariableKeys . snd) bindings) <> freeVariableKeys body) Set.\\ binders
+    FcCase scrutinee binder alternatives ->
+      freeVariableKeys scrutinee
+        <> Set.unions
+          [ freeVariableKeys (altRhs alternative)
+              Set.\\ Set.fromList (map varName (binder : altBinders alternative))
+          | alternative <- alternatives
+          ]
+    FcCast body _ -> freeVariableKeys body
+    FcCallForeign _ arguments -> Set.unions (map freeVariableKeys arguments)
+
+varKey :: Var -> VarKey
+varKey var = (varUnique var, varName var)
+
+sameVar :: Var -> Var -> Bool
+sameVar left right = varKey left == varKey right
+
+substituteTypes :: TypeSubstitution -> FcExpr -> FcExpr
+substituteTypes = go
+  where
+    go current expression =
+      case expression of
+        FcVar var -> FcVar (substituteVarType current var)
+        FcLit {} -> expression
+        FcApp function argument -> FcApp (go current function) (go current argument)
+        FcTyApp function ty -> FcTyApp (go current function) (substituteType current ty)
+        FcLam binder body -> FcLam (substituteVarType current binder) (go current body)
+        FcTyLam tyVar body -> FcTyLam tyVar (go (Map.delete (tyVarKey tyVar) current) body)
+        FcLet bind body -> FcLet (goBind current bind) (go current body)
+        FcCase scrutinee binder alternatives ->
+          FcCase
+            (go current scrutinee)
+            (substituteVarType current binder)
+            [ alternative
+                { altBinders = map (substituteVarType current) (altBinders alternative),
+                  altRhs = go current (altRhs alternative)
+                }
+            | alternative <- alternatives
+            ]
+        FcCast body coercion -> FcCast (go current body) (substituteCoercion current coercion)
+        FcCallForeign foreignCall arguments -> FcCallForeign foreignCall (map (go current) arguments)
+
+    goBind current bind =
+      case bind of
+        FcNonRec binder rhs -> FcNonRec (substituteVarType current binder) (go current rhs)
+        FcRec bindings ->
+          FcRec
+            [ (substituteVarType current binder, go current rhs)
+            | (binder, rhs) <- bindings
+            ]
+
+substituteVarType :: TypeSubstitution -> Var -> Var
+substituteVarType substitutions var = var {varType = substituteType substitutions (varType var)}
+
+substituteCoercion :: TypeSubstitution -> Coercion -> Coercion
+substituteCoercion substitutions coercion =
+  case coercion of
+    CoVar {} -> coercion
+    Refl ty -> Refl (substituteType substitutions ty)
+    Sym inner -> Sym (substituteCoercion substitutions inner)
+    Trans left right -> Trans (substituteCoercion substitutions left) (substituteCoercion substitutions right)
+    TyConAppCo tyCon arguments -> TyConAppCo tyCon (map (substituteCoercion substitutions) arguments)
+    AxiomInstCo name arguments -> AxiomInstCo name (map (substituteType substitutions) arguments)
+
+substituteType :: TypeSubstitution -> TcType -> TcType
+substituteType substitutions ty =
+  case ty of
+    TcTyVar tyVar -> Map.findWithDefault ty (tyVarKey tyVar) substitutions
+    TcMetaTv {} -> ty
+    TcTyCon tyCon arguments -> TcTyCon tyCon (map (substituteType substitutions) arguments)
+    TcFunTy argument result -> TcFunTy (substituteType substitutions argument) (substituteType substitutions result)
+    TcForAllTy tyVar body ->
+      TcForAllTy tyVar (substituteType (Map.delete (tyVarKey tyVar) substitutions) body)
+    TcQualTy predicates body ->
+      TcQualTy (map substitutePredicate predicates) (substituteType substitutions body)
+    TcAppTy function argument -> TcAppTy (substituteType substitutions function) (substituteType substitutions argument)
+  where
+    substitutePredicate predicate =
+      case predicate of
+        ClassPred className arguments -> ClassPred className (map (substituteType substitutions) arguments)
+        EqPred left right -> EqPred (substituteType substitutions left) (substituteType substitutions right)
+
+freshenExpression :: FcExpr -> State Int FcExpr
+freshenExpression = freshen Map.empty Map.empty
+  where
+    freshen termRenames typeRenames expression =
+      case expression of
+        FcVar var -> pure (FcVar (renameVar termRenames typeRenames var))
+        FcLit {} -> pure expression
+        FcApp function argument ->
+          FcApp <$> freshen termRenames typeRenames function <*> freshen termRenames typeRenames argument
+        FcTyApp function ty ->
+          FcTyApp <$> freshen termRenames typeRenames function <*> pure (renameType typeRenames ty)
+        FcLam binder body -> do
+          freshBinder <- freshVar typeRenames binder
+          FcLam freshBinder <$> freshen (Map.insert (varKey binder) freshBinder termRenames) typeRenames body
+        FcTyLam tyVar body -> do
+          freshTyVar <- freshTypeVariable tyVar
+          let innerTypes = Map.insert (tyVarKey tyVar) freshTyVar typeRenames
+          FcTyLam freshTyVar <$> freshen termRenames innerTypes body
+        FcLet (FcNonRec binder rhs) body -> do
+          freshRhs <- freshen termRenames typeRenames rhs
+          freshBinder <- freshVar typeRenames binder
+          freshBody <- freshen (Map.insert (varKey binder) freshBinder termRenames) typeRenames body
+          pure (FcLet (FcNonRec freshBinder freshRhs) freshBody)
+        FcLet (FcRec bindings) body -> do
+          freshBinders <- traverse (freshVar typeRenames . fst) bindings
+          let innerTerms = Map.union (Map.fromList (zip (map (varKey . fst) bindings) freshBinders)) termRenames
+          freshRhss <- traverse (freshen innerTerms typeRenames . snd) bindings
+          freshBody <- freshen innerTerms typeRenames body
+          pure (FcLet (FcRec (zip freshBinders freshRhss)) freshBody)
+        FcCase scrutinee binder alternatives -> do
+          freshScrutinee <- freshen termRenames typeRenames scrutinee
+          freshBinder <- freshVar typeRenames binder
+          freshAlternatives <- traverse (freshAlternative (Map.insert (varKey binder) freshBinder termRenames) typeRenames) alternatives
+          pure (FcCase freshScrutinee freshBinder freshAlternatives)
+        FcCast body coercion ->
+          FcCast <$> freshen termRenames typeRenames body <*> pure (renameCoercion typeRenames coercion)
+        FcCallForeign foreignCall arguments ->
+          FcCallForeign foreignCall <$> traverse (freshen termRenames typeRenames) arguments
+
+    freshAlternative termRenames typeRenames alternative = do
+      freshBinders <- traverse (freshVar typeRenames) (altBinders alternative)
+      let innerTerms = Map.union (Map.fromList (zip (map varKey (altBinders alternative)) freshBinders)) termRenames
+      freshRhs <- freshen innerTerms typeRenames (altRhs alternative)
+      pure alternative {altBinders = freshBinders, altRhs = freshRhs}
+
+renameVar :: Map VarKey Var -> Map TyVarKey TyVarId -> Var -> Var
+renameVar termRenames typeRenames var =
+  fromMaybe
+    var {varType = renameType typeRenames (varType var)}
+    (Map.lookup (varKey var) termRenames)
+
+renameType :: Map TyVarKey TyVarId -> TcType -> TcType
+renameType renames = substituteType (TcTyVar <$> renames)
+
+renameCoercion :: Map TyVarKey TyVarId -> Coercion -> Coercion
+renameCoercion renames = substituteCoercion (TcTyVar <$> renames)
+
+freshVar :: Map TyVarKey TyVarId -> Var -> State Int Var
+freshVar typeRenames var = do
+  unique <- freshUnique
+  let freshName = varName var <> Text.pack "$inl" <> Text.pack (show (uniqueInt unique))
+  pure
+    var
+      { varName = freshName,
+        varUnique = unique,
+        varType = renameType typeRenames (varType var)
+      }
+
+freshTypeVariable :: TyVarId -> State Int TyVarId
+freshTypeVariable tyVar =
+  setTyVarKind (tvKind tyVar) . TyVarId (tvName tyVar) <$> freshUnique
+
+freshUnique :: State Int Unique
+freshUnique = do
+  next <- get
+  put (next + 1)
+  pure (Unique next)
+
+nextUnique :: FcProgram -> Int
+nextUnique program =
+  case programUniques program of
+    [] -> 1
+    uniques -> maximum uniques + 1
+
+programUniques :: FcProgram -> [Int]
+programUniques (FcProgram topBinds) = concatMap topBindUniques topBinds
+
+topBindUniques :: FcTopBind -> [Int]
+topBindUniques topBind =
+  case topBind of
+    FcData _ tyVars constructors -> concatMap tyVarUniques tyVars <> concatMap (concatMap typeUniques . snd) constructors
+    FcNewtype declaration ->
+      concatMap tyVarUniques (fcNewtypeTyVars declaration)
+        <> typeUniques (fcNewtypeRepresentation declaration)
+        <> typeUniques (fcNewtypeResult declaration)
+    FcPrimitive var _ -> varUniques var
+    FcForeignImport {} -> []
+    FcTopBind bind -> bindUniques bind
+
+bindUniques :: FcBind -> [Int]
+bindUniques bind =
+  case bind of
+    FcNonRec binder rhs -> varUniques binder <> expressionUniques rhs
+    FcRec bindings -> concatMap (\(binder, rhs) -> varUniques binder <> expressionUniques rhs) bindings
+
+expressionUniques :: FcExpr -> [Int]
+expressionUniques expression =
+  case expression of
+    FcVar var -> varUniques var
+    FcLit {} -> []
+    FcApp function argument -> expressionUniques function <> expressionUniques argument
+    FcTyApp function ty -> expressionUniques function <> typeUniques ty
+    FcLam binder body -> varUniques binder <> expressionUniques body
+    FcTyLam tyVar body -> tyVarUniques tyVar <> expressionUniques body
+    FcLet bind body -> bindUniques bind <> expressionUniques body
+    FcCase scrutinee binder alternatives ->
+      expressionUniques scrutinee
+        <> varUniques binder
+        <> concatMap (\alternative -> concatMap varUniques (altBinders alternative) <> expressionUniques (altRhs alternative)) alternatives
+    FcCast body coercion -> expressionUniques body <> coercionUniques coercion
+    FcCallForeign _ arguments -> concatMap expressionUniques arguments
+
+varUniques :: Var -> [Int]
+varUniques var = uniqueInt (varUnique var) : typeUniques (varType var)
+
+tyVarUniques :: TyVarId -> [Int]
+tyVarUniques = pure . uniqueInt . tvUnique
+
+typeUniques :: TcType -> [Int]
+typeUniques ty =
+  case ty of
+    TcTyVar tyVar -> tyVarUniques tyVar
+    TcMetaTv unique -> [uniqueInt unique]
+    TcTyCon _ arguments -> concatMap typeUniques arguments
+    TcFunTy argument result -> typeUniques argument <> typeUniques result
+    TcForAllTy tyVar body -> tyVarUniques tyVar <> typeUniques body
+    TcQualTy predicates body -> concatMap predicateUniques predicates <> typeUniques body
+    TcAppTy function argument -> typeUniques function <> typeUniques argument
+
+predicateUniques :: Pred -> [Int]
+predicateUniques predicate =
+  case predicate of
+    ClassPred _ arguments -> concatMap typeUniques arguments
+    EqPred left right -> typeUniques left <> typeUniques right
+
+coercionUniques :: Coercion -> [Int]
+coercionUniques coercion =
+  case coercion of
+    CoVar (EvVar unique) -> [uniqueInt unique]
+    Refl ty -> typeUniques ty
+    Sym inner -> coercionUniques inner
+    Trans left right -> coercionUniques left <> coercionUniques right
+    TyConAppCo _ arguments -> concatMap coercionUniques arguments
+    AxiomInstCo _ arguments -> concatMap typeUniques arguments
+
+uniqueInt :: Unique -> Int
+uniqueInt (Unique value) = value
+
+tyVarKey :: TyVarId -> TyVarKey
+tyVarKey tyVar = (tvUnique tyVar, tvName tyVar)

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -15,7 +15,8 @@ import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Data.Text (Text)
-import FcGolden
+import FcGolden hiding (FcCase)
+import FcGolden qualified
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 
@@ -26,7 +27,7 @@ fcGoldenTests = do
   let tests = map mkTest cases
   pure (testGroup "FC golden tests" tests)
 
-mkTest :: FcCase -> TestTree
+mkTest :: FcGolden.FcCase -> TestTree
 mkTest tc = testCase (caseId tc) $ do
   let (outcome, details) = evaluateFcCase tc
   case outcome of
@@ -137,6 +138,132 @@ fcOptimizationTests =
             computed = FcApp (FcVar identity) (FcVar value)
             source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcNonRec binder computed) (FcVar binder)))]
         assertEqual "optimized program" source (optimizeProgram source),
+      testCase "inlines a direct function at every call site" $ do
+        let argument = Var "argument" (Unique 20) stringTy
+            identity = Var "identity" (Unique 21) (TcFunTy stringTy stringTy)
+            firstValue = Var "firstValue" (Unique 22) stringTy
+            secondValue = Var "secondValue" (Unique 23) stringTy
+            first = Var "first" (Unique 24) stringTy
+            second = Var "second" (Unique 25) stringTy
+            source =
+              FcProgram
+                [ FcTopBind (FcNonRec identity (FcLam argument (FcVar argument))),
+                  FcTopBind (FcNonRec first (FcApp (FcVar identity) (FcVar firstValue))),
+                  FcTopBind (FcNonRec second (FcApp (FcVar identity) (FcVar secondValue)))
+                ]
+            optimized = optimizeProgram source
+        assertEqual "first call" (Just (FcVar firstValue)) (topBindingRhs "first" optimized)
+        assertEqual "second call" (Just (FcVar secondValue)) (topBindingRhs "second" optimized),
+      testCase "preserves sharing when an inlined argument is used twice" $ do
+        let pairTy = ty "Pair"
+            pair = Var "Pair" (Unique 30) (TcFunTy stringTy (TcFunTy stringTy pairTy))
+            expensive = Var "expensive" (Unique 31) (TcFunTy stringTy stringTy)
+            sourceValue = Var "source" (Unique 32) stringTy
+            duplicate = Var "duplicate" (Unique 33) (TcFunTy stringTy pairTy)
+            argument = Var "argument" (Unique 34) stringTy
+            mainVar = Var "main" (Unique 35) pairTy
+            duplicateRhs = FcLam argument (FcApp (FcApp (FcVar pair) (FcVar argument)) (FcVar argument))
+            computed = FcApp (FcVar expensive) (FcVar sourceValue)
+            program =
+              FcProgram
+                [ FcData "Pair" [] [("Pair", [stringTy, stringTy])],
+                  FcPrimitive expensive 1,
+                  FcTopBind (FcNonRec duplicate duplicateRhs),
+                  FcTopBind (FcNonRec mainVar (FcApp (FcVar duplicate) computed))
+                ]
+            mainRhs = topBindingRhs "main" (optimizeProgram program)
+        assertEqual "callee removed" 0 (maybe 0 (countVariableName "duplicate") mainRhs)
+        assertEqual "argument computation retained once" 1 (maybe 0 (countVariableName "expensive") mainRhs)
+        assertEqual "shared through a let" True (maybe False containsNonRecursiveLet mainRhs),
+      testCase "does not inline a computed CAF" $ do
+        let expensive = Var "expensive" (Unique 40) (TcFunTy stringTy stringTy)
+            sourceValue = Var "source" (Unique 41) stringTy
+            cached = Var "cached" (Unique 42) stringTy
+            mainVar = Var "main" (Unique 43) stringTy
+            program =
+              FcProgram
+                [ FcPrimitive expensive 1,
+                  FcTopBind (FcNonRec cached (FcApp (FcVar expensive) (FcVar sourceValue))),
+                  FcTopBind (FcNonRec mainVar (FcVar cached))
+                ]
+        assertEqual "computed thunk retained" program (optimizeProgram program),
+      testCase "keeps an unused unlifted argument strict" $ do
+        let intHashTy = ty "Int#"
+            unitTy = ty "Unit"
+            force = Var "force" (Unique 50) (TcFunTy intHashTy intHashTy)
+            sourceValue = Var "source" (Unique 51) intHashTy
+            ignore = Var "ignore" (Unique 52) (TcFunTy intHashTy unitTy)
+            argument = Var "argument" (Unique 53) intHashTy
+            unitValue = Var "()" (Unique 54) unitTy
+            mainVar = Var "main" (Unique 55) unitTy
+            forcedArgument = FcApp (FcVar force) (FcVar sourceValue)
+            program =
+              FcProgram
+                [ FcData "Unit" [] [("()", [])],
+                  FcPrimitive force 1,
+                  FcTopBind (FcNonRec ignore (FcLam argument (FcVar unitValue))),
+                  FcTopBind (FcNonRec mainVar (FcApp (FcVar ignore) forcedArgument))
+                ]
+        case topBindingRhs "main" (optimizeProgram program) of
+          Just (FcCase scrutinee _ [FcAlt DefaultAlt [] (FcVar result)]) -> do
+            assertEqual "strict argument" forcedArgument scrutinee
+            assertEqual "result" unitValue result
+          other -> assertFailure ("expected a strict case binding, got: " <> show other),
+      testCase "eliminates repeated dictionary-dispatched binds" $ do
+        let unitTy = ty "Unit"
+            dictionaryTy = ty "MonadBox"
+            continuationTy = TcFunTy unitTy unitTy
+            methodTy = TcFunTy unitTy (TcFunTy continuationTy unitTy)
+            constructor = Var "$Dict$MonadBox" (Unique 60) (TcFunTy methodTy dictionaryTy)
+            selector = Var ">>=" (Unique 61) (TcFunTy dictionaryTy methodTy)
+            dictionary = Var "$fMonadBox" (Unique 62) dictionaryTy
+            implementation = Var "bindBox" (Unique 63) methodTy
+            dictionaryArgument = Var "$dictionary" (Unique 64) dictionaryTy
+            caseBinder = Var "$case" (Unique 65) dictionaryTy
+            selectedMethod = Var "$method" (Unique 66) methodTy
+            valueArgument = Var "value" (Unique 67) unitTy
+            continuation = Var "continuation" (Unique 68) continuationTy
+            ignoredFirst = Var "ignoredFirst" (Unique 69) unitTy
+            ignoredSecond = Var "ignoredSecond" (Unique 70) unitTy
+            firstAction = Var "firstAction" (Unique 71) unitTy
+            secondAction = Var "secondAction" (Unique 72) unitTy
+            finalAction = Var "finalAction" (Unique 73) unitTy
+            mainVar = Var "main" (Unique 74) unitTy
+            selectorRhs =
+              FcLam
+                dictionaryArgument
+                ( FcCase
+                    (FcVar dictionaryArgument)
+                    caseBinder
+                    [FcAlt (DataAlt "$Dict$MonadBox") [selectedMethod] (FcVar selectedMethod)]
+                )
+            implementationRhs =
+              FcLam valueArgument (FcLam continuation (FcApp (FcVar continuation) (FcVar valueArgument)))
+            callBind action = FcApp (FcApp (FcApp (FcVar selector) (FcVar dictionary)) action)
+            mainRhs =
+              callBind
+                (FcVar firstAction)
+                ( FcLam
+                    ignoredFirst
+                    ( callBind
+                        (FcVar secondAction)
+                        (FcLam ignoredSecond (FcVar finalAction))
+                    )
+                )
+            program =
+              FcProgram
+                [ FcData "Unit" [] [("()", [])],
+                  FcData "MonadBox" [] [("$Dict$MonadBox", [methodTy])],
+                  FcTopBind (FcNonRec selector selectorRhs),
+                  FcTopBind (FcNonRec implementation implementationRhs),
+                  FcTopBind (FcNonRec dictionary (FcApp (FcVar constructor) (FcVar implementation))),
+                  FcTopBind (FcNonRec mainVar mainRhs)
+                ]
+            optimizedMain = topBindingRhs "main" (optimizeProgram program)
+        assertEqual "bind chain" (Just (FcVar finalAction)) optimizedMain
+        assertEqual "selector eliminated" 0 (maybe 0 (countVariableName ">>=") optimizedMain)
+        assertEqual "dictionary eliminated" 0 (maybe 0 (countVariableName "$fMonadBox") optimizedMain)
+        assertEqual "implementation eliminated" 0 (maybe 0 (countVariableName "bindBox") optimizedMain),
       testCase "eliminates values and types unreachable from the entry point" $ do
         let liveTy = ty "Live"
             leafTy = ty "Leaf"
@@ -274,6 +401,47 @@ renderEvalResult result =
   case result of
     Left err -> pure (Left err)
     Right value -> renderValue value
+
+topBindingRhs :: Text -> FcProgram -> Maybe FcExpr
+topBindingRhs name (FcProgram topBinds) =
+  case [ rhs
+       | FcTopBind (FcNonRec binder rhs) <- topBinds,
+         varName binder == name
+       ] of
+    rhs : _ -> Just rhs
+    [] -> Nothing
+
+countVariableName :: Text -> FcExpr -> Int
+countVariableName name expression =
+  case expression of
+    FcVar variable -> fromEnum (varName variable == name)
+    FcLit {} -> 0
+    FcApp function argument -> countVariableName name function + countVariableName name argument
+    FcTyApp function _ -> countVariableName name function
+    FcLam _ body -> countVariableName name body
+    FcTyLam _ body -> countVariableName name body
+    FcLet (FcNonRec _ rhs) body -> countVariableName name rhs + countVariableName name body
+    FcLet (FcRec bindings) body -> sum (map (countVariableName name . snd) bindings) + countVariableName name body
+    FcCase scrutinee _ alternatives ->
+      countVariableName name scrutinee + sum (map (countVariableName name . altRhs) alternatives)
+    FcCast body _ -> countVariableName name body
+    FcCallForeign _ arguments -> sum (map (countVariableName name) arguments)
+
+containsNonRecursiveLet :: FcExpr -> Bool
+containsNonRecursiveLet expression =
+  case expression of
+    FcVar {} -> False
+    FcLit {} -> False
+    FcApp function argument -> containsNonRecursiveLet function || containsNonRecursiveLet argument
+    FcTyApp function _ -> containsNonRecursiveLet function
+    FcLam _ body -> containsNonRecursiveLet body
+    FcTyLam _ body -> containsNonRecursiveLet body
+    FcLet FcNonRec {} _ -> True
+    FcLet (FcRec bindings) body -> any (containsNonRecursiveLet . snd) bindings || containsNonRecursiveLet body
+    FcCase scrutinee _ alternatives ->
+      containsNonRecursiveLet scrutinee || any (containsNonRecursiveLet . altRhs) alternatives
+    FcCast body _ -> containsNonRecursiveLet body
+    FcCallForeign _ arguments -> any containsNonRecursiveLet arguments
 
 var :: Text -> TcType -> Var
 var name = Var name (Unique 0)

--- a/components/aihc-fc/test/Test/Fixtures/golden/constrained-existential-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/constrained-existential-constructor.yaml
@@ -31,6 +31,8 @@ expected: |-
     λx1005 : Box.
       case x1005 as _scrut : Box of
         Box $dpattern value →
-          mark @a $dpattern value
+          case $dpattern as $dict$inl1016 : Markable a of
+            $Dict$Markable $method0$inl1017 →
+              $method0$inl1017 value
 status: pass
 reason: System FC stores the constructor dictionary and binds it before the existential payload

--- a/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/dictionary-application.yaml
@@ -31,7 +31,21 @@ expected: |-
                 True)
 
   eqBool : Bool → Bool → Bool =
-    == @Bool $fEqBool
+    λx1004 : Bool.
+      λy1005 : Bool.
+        case x1004 as _scrut : Bool of
+          False →
+            case y1005 as _scrut : Bool of
+              False →
+                True
+              True →
+                False
+          True →
+            case y1005 as _scrut : Bool of
+              False →
+                False
+              True →
+                True
 extensions: []
 modules:
 - |

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
@@ -20,7 +20,12 @@ expected: |-
             (#,#) $ffi_next_state ((I32# $ffi_raw_result) ▷ <co>)) ▷ <co>
 
   main : IO CInt =
-    puts "hello world\n"#
+    case "hello world\n"# as $ffi_arg_0$inl1012 : Addr# of
+      _ →
+        (λ$ffi_state$inl1013 : State# RealWorld.
+          case foreign-call $ffi$puts $ffi_arg_0$inl1012 $ffi_state$inl1013 as $ffi_result$inl1014 : (#,#) (State# RealWorld) Int32# of
+            (#,#) $ffi_next_state$inl1015 $ffi_raw_result$inl1016 →
+              (#,#) $ffi_next_state$inl1015 ((I32# $ffi_raw_result$inl1016) ▷ <co>)) ▷ <co>
 extensions:
 - ForeignFunctionInterface
 - MagicHash

--- a/components/aihc-fc/test/Test/Fixtures/golden/type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/type-application.yaml
@@ -9,7 +9,7 @@ expected: |-
         x1001
 
   true : Bool =
-    id @Bool True
+    True
 extensions: []
 modules:
 - |

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -11,7 +11,6 @@ module Aihc.Grin.Lower
 where
 
 import Aihc.Fc.Newtype (lowerNewtypes)
-import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Analysis (freeExprVars)
@@ -76,9 +75,7 @@ instance Monoid LoweredTop where
 -- representations, closure-convert lambdas and thunks, and make evaluation,
 -- application, allocation, and exception control explicit.
 lowerProgram :: FcProgram -> GrinProgram
-lowerProgram sourceProgram = lowerProgramWithInterface mempty program
-  where
-    program = optimizeProgram (lowerNewtypes sourceProgram)
+lowerProgram sourceProgram = lowerProgramWithInterface mempty (lowerNewtypes sourceProgram)
 
 -- | Runtime facts exported by one compiled unit. Lowering consumers need to
 -- know which external names are globals, already in WHNF, constructors, or
@@ -106,7 +103,7 @@ instance Monoid GrinInterface where
   mempty = GrinInterface Set.empty Set.empty Map.empty Map.empty Map.empty
 
 extractGrinInterface :: FcProgram -> GrinInterface
-extractGrinInterface sourceProgram =
+extractGrinInterface program =
   GrinInterface
     { grinInterfaceGlobals = Set.fromList (programGlobalNames program),
       grinInterfaceWhnfGlobals = Set.fromList (programWhnfGlobalNames program),
@@ -118,16 +115,12 @@ extractGrinInterface sourceProgram =
           ],
       grinInterfaceCodeInfos = Map.fromList (programCodeInfos program)
     }
-  where
-    program = optimizeProgram sourceProgram
 
 -- | Lower one SCC using only the exported runtime facts of predecessor SCCs.
 -- The supplied program must already have completed its FC transformations.
 lowerProgramWithInterface :: GrinInterface -> FcProgram -> GrinProgram
-lowerProgramWithInterface imported sourceProgram =
+lowerProgramWithInterface imported program =
   lowerProgramWithEnvironment (programEnvironment (imported <> extractGrinInterface program)) program
-  where
-    program = optimizeProgram sourceProgram
 
 data ProgramEnvironment = ProgramEnvironment
   { programEnvironmentGlobals :: !(Set Text),


### PR DESCRIPTION
## Summary

- add a hegg-backed equality-class extraction boundary for scope-safe whole-Core alternatives, using estimated lowered GRIN size as the first cost model
- add call-by-need direct-function inlining at every call site, with fresh binders, retained sharing lets, strict unlifted case bindings, constructor/dictionary case reduction, type beta reduction, and cycle/CAF/size guards
- preserve binder scope explicitly; structural e-graph saturation remains deferred until Core has a scope-safe representation such as De Bruijn indices
- bind Core case binders in the evaluator and linter, and keep FC optimization in the FC phase instead of rerunning it during GRIN lowering

The motivating `examples/green-threads/Main.hs` now compiles with no `>>=`, `$fMonadIO`, or `bindIO` references in `main`, while producing the same output.

## Validation

- `just fmt`
- `just check` (all test executables compiled with a 10 GiB default RTS heap limit for this run)
- `aihc-fc`: 136 tests passed
- `aihc-grin`: 156 tests passed
- compiled and ran `examples/green-threads/Main.hs` with `--whole-program --keep-core` and `-M10G`

## Progress

- FC optimizer unit tests: +5
- FC golden expectations updated for newly exposed reductions: 4
- README progress counts: unchanged, per repository policy