### PR TITLE
feat(base): implement GHC.Read

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,6 @@
+- ignore:
+    name: Use camelCase
+    within: Prelude
+- ignore:
+    name: Use foldl
+    within: GHC.Read.Lex

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1466,6 +1466,7 @@ patternBinderTypesM pat scrutTy =
     PCon name _ subPats -> do
       fallbackTys <- constructorFieldTypesM name (length subPats)
       zipWithM patternFieldTypeM subPats fallbackTys
+    PTuple _ [] -> pure []
     PTuple _ subPats -> tupleFieldTypesM (length subPats) scrutTy
     PVar {} -> pure [scrutTy]
     PAnn _ inner -> patternBinderTypesM inner scrutTy

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -57,7 +57,7 @@ import Aihc.Parser.Syntax qualified as Surface
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
 import Aihc.Tc.Annotations (TcAnnotation (..))
 import Aihc.Tc.Evidence (EvTerm (..))
-import Aihc.Tc.Types (Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
+import Aihc.Tc.Types (Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), isLiftedType)
 import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
@@ -266,7 +266,9 @@ buildCaseChain [] resTy [] = do
   pure (FcVar v)
 buildCaseChain scrutVars@(scrutVar : restVars) resTy matches
   | any (any requiresOrderedPatternMatch . matchPats) matches =
-      dsOrderedMatches scrutVars matches
+      dsOrderedMatches resTy scrutVars matches
+  | hasDefaultFallback matches =
+      dsOrderedMatches resTy scrutVars matches
   | allVarPatterns matches = do
       -- Variable patterns: bind each pattern variable name to the
       -- scrutinee Var, then recurse.
@@ -280,13 +282,34 @@ buildCaseChain scrutVars@(scrutVar : restVars) resTy matches
       caseBinder <- freshVar "_scrut" (varType scrutVar)
       pure (FcCase (FcVar scrutVar) caseBinder alts)
 
-dsOrderedMatches :: [Var] -> [Match] -> DsM FcExpr
-dsOrderedMatches scrutVars matches =
+dsOrderedMatches :: TcType -> [Var] -> [Match] -> DsM FcExpr
+dsOrderedMatches resultTy scrutVars matches =
   case matches of
-    [] -> noPatternMatch scrutVars
+    [] -> do
+      failureVar <- freshInternalVar "_no_match" resultTy
+      pure $
+        if isLiftedType resultTy
+          then FcLet (FcRec [(failureVar, FcVar failureVar)]) (FcVar failureVar)
+          else FcVar failureVar
     match : rest -> do
-      failure <- dsOrderedMatches scrutVars rest
-      dsMatchPatterns scrutVars (matchPats match) (dsRhs (matchRhs match)) failure
+      failure <- dsOrderedMatches resultTy scrutVars rest
+      if isLiftedType resultTy
+        then do
+          failureVar <- freshInternalVar "_next_match" resultTy
+          matched <- dsMatchPatterns scrutVars (matchPats match) (dsRhs (matchRhs match)) (FcVar failureVar)
+          pure (FcLet (FcNonRec failureVar failure) matched)
+        else dsMatchPatterns scrutVars (matchPats match) (dsRhs (matchRhs match)) failure
+
+hasDefaultFallback :: [Match] -> Bool
+hasDefaultFallback matches =
+  any ((== DefaultAlt) . firstPatternKey) matches
+    && any ((/= DefaultAlt) . firstPatternKey) matches
+
+firstPatternKey :: Match -> FcAltCon
+firstPatternKey match =
+  case matchPats match of
+    pat : _ -> patternKey pat
+    [] -> DefaultAlt
 
 dsMatchPatterns :: [Var] -> [Pattern] -> DsM FcExpr -> FcExpr -> DsM FcExpr
 dsMatchPatterns [] [] success _failure = success
@@ -318,9 +341,39 @@ dsMatchPattern scrutVar pat success failure =
 
 requiresOrderedPatternMatch :: Pattern -> Bool
 requiresOrderedPatternMatch pat =
-  isOverloadedIntegerPattern pat || case boxedCharPatternValue pat of
-    Just _ -> True
-    Nothing -> False
+  isOverloadedIntegerPattern pat
+    || requiresPatternWrapperMatch pat
+    || case boxedCharPatternValue pat of
+      Just _ -> True
+      Nothing -> False
+
+requiresPatternWrapperMatch :: Pattern -> Bool
+requiresPatternWrapperMatch (PAnn _ inner) = requiresPatternWrapperMatch inner
+requiresPatternWrapperMatch (PParen inner) = requiresPatternWrapperMatch inner
+requiresPatternWrapperMatch PAs {} = True
+requiresPatternWrapperMatch PStrict {} = True
+requiresPatternWrapperMatch PIrrefutable {} = True
+requiresPatternWrapperMatch PTypeSig {} = True
+requiresPatternWrapperMatch _ = False
+
+requiresRecursivePatternMatch :: Pattern -> Bool
+requiresRecursivePatternMatch (PAnn _ inner) = requiresRecursivePatternMatch inner
+requiresRecursivePatternMatch (PParen inner) = requiresRecursivePatternMatch inner
+requiresRecursivePatternMatch PAs {} = True
+requiresRecursivePatternMatch PStrict {} = True
+requiresRecursivePatternMatch PIrrefutable {} = True
+requiresRecursivePatternMatch PTypeSig {} = True
+requiresRecursivePatternMatch pat =
+  case constructorSubpatterns pat of
+    [] -> False
+    subpatterns -> not (all directBinderPattern subpatterns)
+
+directBinderPattern :: Pattern -> Bool
+directBinderPattern (PAnn _ inner) = directBinderPattern inner
+directBinderPattern (PParen inner) = directBinderPattern inner
+directBinderPattern PVar {} = True
+directBinderPattern PWildcard = True
+directBinderPattern _ = False
 
 boxedCharPatternValue :: Pattern -> Maybe Char
 boxedCharPatternValue pat =
@@ -374,7 +427,7 @@ dsOrdinaryPatternMatch scrutVar pat success failure = do
       binderTys <- patternBinderTypesM pat (varType scrutVar)
       binders <- zipWithM freshVar binderNames binderTys
       (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
-      matched <- withDicts dictionaries (withLocals (zip binderNames binders) success)
+      matched <- withDicts dictionaries (dsMatchPatterns binders (constructorSubpatterns pat) success failure)
       caseBinder <- freshInternalVar "_match" (varType scrutVar)
       pure
         ( FcCase
@@ -384,6 +437,17 @@ dsOrdinaryPatternMatch scrutVar pat success failure = do
               FcAlt DefaultAlt [] failure
             ]
         )
+
+constructorSubpatterns :: Pattern -> [Pattern]
+constructorSubpatterns (PAnn _ inner) = constructorSubpatterns inner
+constructorSubpatterns (PParen inner) = constructorSubpatterns inner
+constructorSubpatterns (PCon _ _ subpatterns) = subpatterns
+constructorSubpatterns (PList []) = []
+constructorSubpatterns (PList (item : items)) = [item, PList items]
+constructorSubpatterns (PInfix left operator right)
+  | nameText operator == ":" = [left, right]
+constructorSubpatterns (PTuple _ subpatterns) = subpatterns
+constructorSubpatterns _ = []
 
 noPatternMatch :: [Var] -> DsM FcExpr
 noPatternMatch (scrutVar : _) = do
@@ -458,13 +522,23 @@ buildAltGroup scrutVar restVars resTy (FirstPatternGroup pat matches) =
       body <- buildCaseChain restVars resTy []
       pure (FcAlt DefaultAlt [] body)
     _ -> do
-      let innerMatches = map dropFirstPat matches
-          (con, binderNames) = dsPatternPure pat
-      binderTys <- patternBinderTypesM pat (varType scrutVar)
-      binders <- zipWithM freshVar binderNames binderTys
-      (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
-      body <- withDicts dictionaries (withLocals (zip binderNames binders) (buildCaseChain restVars resTy innerMatches))
-      pure (FcAlt con (evidenceBinders <> binders) body)
+      case dsPatternPure pat of
+        (DefaultAlt, _) -> do
+          body <- dsOrderedMatches resTy (scrutVar : restVars) matches
+          pure (FcAlt DefaultAlt [] body)
+        (con, binderNames) -> do
+          let innerMatches = map expandFirstConstructorPattern matches
+          binderTys <- patternBinderTypesM pat (varType scrutVar)
+          binders <- zipWithM freshVar binderNames binderTys
+          (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
+          body <- withDicts dictionaries (buildCaseChain (binders <> restVars) resTy innerMatches)
+          pure (FcAlt con (evidenceBinders <> binders) body)
+
+expandFirstConstructorPattern :: Match -> Match
+expandFirstConstructorPattern match =
+  case matchPats match of
+    [] -> match
+    pat : pats -> match {matchPats = constructorSubpatterns pat <> pats}
 
 dsRhs :: Rhs Expr -> DsM FcExpr
 dsRhs (UnguardedRhs _sp expr maybeDecls) =
@@ -708,7 +782,7 @@ dsCase scrut alts = do
       Just ty -> pure ty
       Nothing -> fcExprTypeM scrut'
   binder <- freshVar "_case" scrutTy
-  if any (isOverloadedIntegerPattern . caseAltPattern) alts
+  if any (requiresOrderedCasePatternMatch . caseAltPattern) alts
     then do
       scrutValue <- freshVar "_case_value" scrutTy
       body <- dsCaseAlternatives scrutValue alts
@@ -716,6 +790,10 @@ dsCase scrut alts = do
     else do
       alts' <- mapM (dsCaseAlt scrutTy) alts
       pure (FcCase scrut' binder alts')
+
+requiresOrderedCasePatternMatch :: Pattern -> Bool
+requiresOrderedCasePatternMatch pat =
+  requiresOrderedPatternMatch pat || requiresRecursivePatternMatch pat
 
 isOverloadedIntegerPattern :: Pattern -> Bool
 isOverloadedIntegerPattern pat =
@@ -1382,6 +1460,8 @@ patternBinderTypesM pat scrutTy =
     PInfix _lhs op _rhs
       | nameText op == ":" ->
           (\elemTy -> [elemTy, scrutTy]) <$> listElemTyM scrutTy
+    PList (_ : _) ->
+      (\elemTy -> [elemTy, scrutTy]) <$> listElemTyM scrutTy
     PCon _ _ [] -> pure []
     PCon name _ subPats -> do
       fallbackTys <- constructorFieldTypesM name (length subPats)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Match.hs
@@ -39,6 +39,8 @@ dsPatternPure (PCon name _typeArgs subPats) =
    in (DataAlt conName, binderNames)
 dsPatternPure (PList []) =
   (DataAlt "[]", [])
+dsPatternPure (PList (_ : _)) =
+  (DataAlt ":", ["_head", "_tail"])
 dsPatternPure (PInfix lhs op rhs)
   | nameText op == ":" =
       (DataAlt ":", [subPatName lhs, subPatName rhs])

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -14,9 +14,10 @@ where
 import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Syntax
-import Aihc.Tc.Types (RuntimeRep (..), TcType (..), TyCon (..))
+import Aihc.Tc.Types (RuntimeRep (..), TcType (..), TyCon (..), Unique)
+import Control.Applicative ((<|>))
 import Control.Exception (SomeException, displayException, try)
-import Control.Monad (zipWithM, (<=<), (>=>))
+import Control.Monad (forM, forM_, zipWithM, (<=<), (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, catchE, runExceptT, throwE)
 import Data.Bits (countLeadingZeros, countTrailingZeros, popCount, shiftL, shiftR, xor, (.&.), (.|.))
@@ -44,13 +45,14 @@ data EvalError
   = EvalUnboundVariable Text
   | EvalMissingBinding Text
   | EvalApplyNonFunction Value
-  | EvalNoMatchingAlternative Value
+  | EvalNoMatchingAlternative Value [FcAltCon]
   | EvalPrimitiveArity Text Int
   | EvalPrimitiveTypeError Text Value
   | EvalForeignArity Text Int Int
   | EvalForeignTypeError Text Value
   | EvalForeignLookupError Text Text
   | EvalInvalidIOResult Value
+  | EvalBlackholedThunk
   | EvalInvalidByteArrayRange Text Integer Integer Int
   | EvalBlockedOnMVar Text
   | EvalRaisedException Value
@@ -69,8 +71,21 @@ data Value
   | VMVar EvalMVar
   | VMutVar EvalMutVar
   | VStateToken
-  | VThunk Env FcExpr
+  | VThunk EvalThunk
   deriving (Eq, Show)
+
+newtype EvalThunk = EvalThunk (IORef EvalThunkState)
+
+instance Eq EvalThunk where
+  EvalThunk left == EvalThunk right = left == right
+
+instance Show EvalThunk where
+  show _ = "<thunk>"
+
+data EvalThunkState
+  = ThunkSuspended !Env !FcExpr
+  | ThunkEvaluated !Value
+  | ThunkEvaluating
 
 newtype EvalMutVar = EvalMutVar (IORef Value)
 
@@ -134,13 +149,43 @@ instance Eq EvalIORequest where
 instance Show EvalIORequest where
   show _ = "<io-request>"
 
-type Env = Map Text Value
+data Env = Env
+  { envLocals :: !(Map Unique Value),
+    envGlobals :: !(Map Text Value)
+  }
+  deriving (Eq, Show)
+
+emptyEnv :: Env
+emptyEnv = Env Map.empty Map.empty
+
+globalEnv :: [(Text, Value)] -> Env
+globalEnv = Env Map.empty . Map.fromList
+
+unionEnv :: Env -> Env -> Env
+unionEnv left right =
+  Env
+    { envLocals = envLocals left `Map.union` envLocals right,
+      envGlobals = envGlobals left `Map.union` envGlobals right
+    }
+
+lookupEnvVar :: Var -> Env -> Maybe Value
+lookupEnvVar var env =
+  Map.lookup (varUnique var) (envLocals env)
+    <|> Map.lookup (varName var) (envGlobals env)
+
+insertLocal :: Var -> Value -> Env -> Env
+insertLocal var value env =
+  env {envLocals = Map.insert (varUnique var) value (envLocals env)}
+
+localEnv :: [(Var, Value)] -> Env
+localEnv bindings = Env (Map.fromList [(varUnique var, value) | (var, value) <- bindings]) Map.empty
 
 type EvalM = ExceptT EvalError IO
 
 evalProgramBinding :: Text -> FcProgram -> IO (Either EvalError Value)
-evalProgramBinding name sourceProgram = runExceptT $
-  case Map.lookup name env of
+evalProgramBinding name sourceProgram = runExceptT $ do
+  env <- buildProgramEnv program
+  case Map.lookup name (envGlobals env) of
     Just value -> do
       forced <- forceValue value
       if name `Map.member` ioBindings
@@ -156,32 +201,37 @@ evalProgramBinding name sourceProgram = runExceptT $
           var <- bindersOf bind,
           isIOType (varType var)
         ]
-    env = primitiveTopEnv `Map.union` topEnv `Map.union` builtinConstructorEnv
-    primitiveTopEnv = Map.fromList (concatMap primitiveTopBindingValues (fcTopBinds program))
-    topEnv = Map.fromList (concatMap topBindingValues (fcTopBinds program))
-    primitiveTopBindingValues (FcPrimitive var arity) =
-      [(varName var, VPrim (varName var) arity [])]
-    primitiveTopBindingValues _ =
-      []
-    topBindingValues (FcTopBind (FcNonRec var expr)) =
-      [(varName var, VThunk env expr)]
-    topBindingValues (FcTopBind (FcRec bindings)) =
-      [(varName var, VThunk env expr) | (var, expr) <- bindings]
-    topBindingValues (FcData _ _ constructors) =
-      [(conName, VConstructor conName []) | (conName, _) <- constructors]
-    topBindingValues FcNewtype {} =
-      []
-    topBindingValues FcPrimitive {} =
-      []
-    topBindingValues FcForeignImport {} =
-      []
+
+buildProgramEnv :: FcProgram -> EvalM Env
+buildProgramEnv program = do
+  thunkBindings <- mapM allocateTopBinding valueBindings
+  let env = globalEnv (directBindings <> [(varName var, VThunk thunk) | (var, _, thunk) <- thunkBindings]) `unionEnv` builtinConstructorEnv
+  forM_ thunkBindings $ \(_, expression, EvalThunk ref) ->
+    lift (writeIORef ref (ThunkSuspended env expression))
+  pure env
+  where
+    topBinds = fcTopBinds program
+    valueBindings = concatMap topValueBindings topBinds
+    directBindings = concatMap directTopBindings topBinds
+
+    allocateTopBinding (var, expression) = do
+      ref <- lift (newIORef ThunkEvaluating)
+      pure (var, expression, EvalThunk ref)
+
+    topValueBindings (FcTopBind (FcNonRec var expression)) = [(var, expression)]
+    topValueBindings (FcTopBind (FcRec bindings)) = bindings
+    topValueBindings _ = []
+
+    directTopBindings (FcPrimitive var arity) = [(varName var, VPrim (varName var) arity [])]
+    directTopBindings (FcData _ _ constructors) = [(conName, VConstructor conName []) | (conName, _) <- constructors]
+    directTopBindings _ = []
 
 evalExpr :: FcExpr -> IO (Either EvalError Value)
 evalExpr = runExceptT . evalWithEnv builtinConstructorEnv
 
 builtinConstructorEnv :: Env
 builtinConstructorEnv =
-  Map.fromList
+  globalEnv
     [ ("C#", VConstructor "C#" []),
       ("[]", VConstructor "[]" []),
       (":", VConstructor ":" []),
@@ -192,14 +242,15 @@ evalWithEnv :: Env -> FcExpr -> EvalM Value
 evalWithEnv env expr =
   case expr of
     FcVar var ->
-      case Map.lookup (varName var) env of
+      case lookupEnvVar var env of
         Just value -> forceValue value
         Nothing -> throwE (EvalUnboundVariable (varName var))
     FcLit lit ->
       pure (VLit lit)
     FcApp fun arg -> do
       funValue <- evalWithEnv env fun
-      applyValue funValue (VThunk env arg)
+      argumentValue <- lazyArgument env arg
+      applyValue funValue argumentValue
     FcTyApp inner _ ->
       evalWithEnv env inner
     FcLam var body ->
@@ -207,7 +258,7 @@ evalWithEnv env expr =
     FcTyLam _ body ->
       evalWithEnv env body
     FcLet bind body ->
-      evalWithEnv (extendBind env bind) body
+      extendBind env bind >>= \extended -> evalWithEnv extended body
     FcCase scrut _ alts -> do
       value <- evalWithEnv env scrut
       matchAlternative env value alts
@@ -217,10 +268,35 @@ evalWithEnv env expr =
       values <- mapM (evalWithEnv env >=> forceValue) arguments
       executeForeignCall foreignCall values
 
+lazyArgument :: Env -> FcExpr -> EvalM Value
+lazyArgument env expression =
+  case expression of
+    FcVar var ->
+      case lookupEnvVar var env of
+        Just value -> pure value
+        Nothing -> throwE (EvalUnboundVariable (varName var))
+    _ -> VThunk <$> newThunk env expression
+
+newThunk :: Env -> FcExpr -> EvalM EvalThunk
+newThunk env expression =
+  EvalThunk <$> lift (newIORef (ThunkSuspended env expression))
+
 forceValue :: Value -> EvalM Value
 forceValue value =
   case value of
-    VThunk env expr -> evalWithEnv env expr
+    VThunk (EvalThunk ref) -> do
+      state <- lift (readIORef ref)
+      case state of
+        ThunkEvaluated result -> pure result
+        ThunkEvaluating -> throwE EvalBlackholedThunk
+        ThunkSuspended env expression -> do
+          lift (writeIORef ref ThunkEvaluating)
+          result <-
+            evalWithEnv env expression `catchE` \err -> do
+              lift (writeIORef ref state)
+              throwE err
+          lift (writeIORef ref (ThunkEvaluated result))
+          pure result
     VPrim name 0 [] -> evalPrimitive name []
     _ -> pure value
 
@@ -236,7 +312,7 @@ applyValue value arg = do
   forced <- forceValue value
   case forced of
     VClosure closureEnv var body ->
-      evalWithEnv (Map.insert (varName var) arg closureEnv) body
+      evalWithEnv (insertLocal var arg closureEnv) body
     VConstructor name args ->
       pure (VConstructor name (args <> [arg]))
     VPrim name arity args ->
@@ -923,39 +999,44 @@ forceCharPrimitiveArg name value = do
     VLit (LitChar _ charValue) -> pure charValue
     other -> throwE (EvalPrimitiveTypeError name other)
 
-extendBind :: Env -> FcBind -> Env
+extendBind :: Env -> FcBind -> EvalM Env
 extendBind env bind =
   case bind of
-    FcNonRec var expr ->
-      Map.insert (varName var) (VThunk env expr) env
-    FcRec bindings ->
-      recEnv
-      where
-        recEnv = foldr insertBinding env bindings
-        insertBinding (var, expr) = Map.insert (varName var) (VThunk recEnv expr)
+    FcNonRec var expr -> do
+      thunk <- newThunk env expr
+      pure (insertLocal var (VThunk thunk) env)
+    FcRec bindings -> do
+      allocated <- forM bindings $ \(var, expression) -> do
+        ref <- lift (newIORef ThunkEvaluating)
+        pure (var, expression, EvalThunk ref)
+      let recEnv = foldr (\(var, _, thunk) -> insertLocal var (VThunk thunk)) env allocated
+      forM_ allocated $ \(_, expression, EvalThunk ref) ->
+        lift (writeIORef ref (ThunkSuspended recEnv expression))
+      pure recEnv
 
 matchAlternative :: Env -> Value -> [FcAlt] -> EvalM Value
-matchAlternative env value =
-  go
+matchAlternative env value alternatives =
+  go alternatives
   where
-    go [] = throwE (EvalNoMatchingAlternative value)
+    expected = map altCon alternatives
+    go [] = throwE (EvalNoMatchingAlternative value expected)
     go (alt : rest) =
       case matchAlt value alt of
-        Just bindings -> evalWithEnv (bindings <> env) (altRhs alt)
+        Just bindings -> evalWithEnv (bindings `unionEnv` env) (altRhs alt)
         Nothing -> go rest
 
 matchAlt :: Value -> FcAlt -> Maybe Env
 matchAlt value alt =
   case (altCon alt, value) of
     (DefaultAlt, _) ->
-      Just (Map.fromList [(varName var, value) | var <- altBinders alt])
+      Just (localEnv [(var, value) | var <- altBinders alt])
     (LitAlt expected, VLit actual)
       | expected == actual ->
-          Just Map.empty
+          Just emptyEnv
     (DataAlt expected, VConstructor actual args)
       | expected == actual,
         length args == length (altBinders alt) ->
-          Just (Map.fromList (zipWith (\var arg -> (varName var, arg)) (altBinders alt) args))
+          Just (localEnv (zip (altBinders alt) args))
     _ ->
       Nothing
 

--- a/components/aihc-fc/test/Test/Fixtures/golden/read-dictionary-forwarding.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/read-dictionary-forwarding.yaml
@@ -1,0 +1,32 @@
+expected: |-
+  data Result
+   = Result
+
+  data Read a
+   = $Dict$Read (Result → a)
+
+  reads : ∀ a. (Read a) → Result → a =
+    Λa.
+      λ$d0 : Read a.
+        case $d0 as $dict : Read a of
+          $Dict$Read $method0 →
+            $method0
+
+  parse : ∀ a. (Read a) → Result → a =
+    Λa.
+      λ$d0 : Read a.
+        reads @a $d0
+extensions: []
+modules:
+- |
+  module Test where
+
+  data Result = Result
+
+  class Read a where
+    reads :: Result -> a
+
+  parse :: Read a => Result -> a
+  parse = reads
+reason: forwards a supplied Read dictionary
+status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -27,6 +27,7 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     TupleFlavor (..),
     Type,
+    UnqualifiedName,
     fromAnnotation,
     mkAnnotation,
   )
@@ -273,8 +274,25 @@ inferLambda sp pats body = do
   (body', bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferExpr body)
   remainingCts <- solvePatternBranch sp patCheck bodyTy bodyCts
   let funTy = foldr TcFunTy bodyTy argTys
-      pats' = map (annotatePatternBindings (pcBindings patCheck)) (pcPatterns patCheck)
+      pats' = zipWith (annotateLambdaPattern (pcBindings patCheck)) argTys (pcPatterns patCheck)
   pure (ELambdaPats pats' body', funTy, remainingCts)
+
+annotateLambdaPattern :: [(UnqualifiedName, TcType)] -> TcType -> Pattern -> Pattern
+annotateLambdaPattern bindings argTy pat =
+  let annotated = annotatePatternBindings bindings pat
+   in if lambdaPatternCarriesBinderType annotated
+        then annotated
+        else PAnn (mkAnnotation (pendingAnnotation argTy [] [] [])) annotated
+
+lambdaPatternCarriesBinderType :: Pattern -> Bool
+lambdaPatternCarriesBinderType (PAnn _ inner) = lambdaPatternCarriesBinderType inner
+lambdaPatternCarriesBinderType PVar {} = True
+lambdaPatternCarriesBinderType (PParen inner) = lambdaPatternCarriesBinderType inner
+lambdaPatternCarriesBinderType PAs {} = True
+lambdaPatternCarriesBinderType (PStrict inner) = lambdaPatternCarriesBinderType inner
+lambdaPatternCarriesBinderType (PIrrefutable inner) = lambdaPatternCarriesBinderType inner
+lambdaPatternCarriesBinderType (PTypeSig inner _) = lambdaPatternCarriesBinderType inner
+lambdaPatternCarriesBinderType _ = False
 
 inferLambdaCase :: SourceSpan -> [CaseAlt Expr] -> TcM (Expr, TcType, [Ct])
 inferLambdaCase sp alts = do

--- a/core-libs/aihc-base/aihc-base.cabal
+++ b/core-libs/aihc-base/aihc-base.cabal
@@ -254,6 +254,7 @@ library
     GHC.Internal.Char
     GHC.Internal.Classes
     GHC.Internal.Integer
+    GHC.Read.Lex
 
   hs-source-dirs: src
   build-depends: aihc-prim ==0.13.0

--- a/core-libs/aihc-base/src/GHC/Read.hs
+++ b/core-libs/aihc-base/src/GHC/Read.hs
@@ -1,1 +1,251 @@
-module GHC.Read () where
+module GHC.Read
+  ( Read (..),
+    ReadS,
+    lex,
+    lexLitChar,
+    readLitChar,
+    lexDigits,
+    lexP,
+    expectP,
+    paren,
+    parens,
+    list,
+    choose,
+    readListDefault,
+    readListPrecDefault,
+    readNumber,
+    readField,
+    readFieldHash,
+    readSymField,
+    readParen,
+  )
+where
+
+import GHC.Read.Lex
+  ( Lexeme (..),
+    NumberToken (..),
+    expectP,
+    lex,
+    lexDigits,
+    lexLitChar,
+    lexP,
+    parseSignedInteger,
+    readLitChar,
+    stringEqual,
+  )
+import Prelude hiding (lex)
+
+readListDefault :: (Read a) => ReadS [a]
+readListDefault = readPrec_to_S readListPrec minPrec
+
+readListPrecDefault :: (Read a) => ReadPrec [a]
+readListPrecDefault = list readPrec
+
+paren :: ReadPrec a -> ReadPrec a
+paren parser = do
+  expectP (Punc "(")
+  value <- reset parser
+  expectP (Punc ")")
+  return value
+
+parens :: ReadPrec a -> ReadPrec a
+parens parser = parser +++ paren (parens parser)
+
+list :: ReadPrec a -> ReadPrec [a]
+list parser =
+  parens
+    ( do
+        expectP (Punc "[")
+        emptyList +++ nonEmptyList
+    )
+  where
+    emptyList = do
+      expectP (Punc "]")
+      return []
+    nonEmptyList = do
+      value <- reset parser
+      values <- listTail
+      return (value : values)
+    listTail =
+      ( do
+          expectP (Punc "]")
+          return []
+      )
+        +++ do
+          expectP (Punc ",")
+          nonEmptyList
+
+choose :: [(String, ReadPrec a)] -> ReadPrec a
+choose [] = pfail
+choose ((name, parser) : alternatives) = chooseOne +++ choose alternatives
+  where
+    chooseOne = do
+      token <- lexP
+      case token of
+        Ident actual -> ifStringsEqual actual
+        Symbol actual -> ifStringsEqual actual
+        _ -> pfail
+    ifStringsEqual actual =
+      case stringEqual actual name of
+        True -> parser
+        False -> pfail
+
+readNumber :: (Num a) => (Lexeme -> ReadPrec a) -> ReadPrec a
+readNumber convert =
+  parens
+    ( do
+        token <- lexP
+        case token of
+          Symbol sign ->
+            case stringEqual sign "-" of
+              True -> do
+                magnitude <- lexP
+                value <- convert magnitude
+                return (negate value)
+              False -> convert token
+          _ -> convert token
+    )
+
+readField :: String -> ReadPrec a -> ReadPrec a
+readField name parser = do
+  expectP (Ident name)
+  expectP (Punc "=")
+  parser
+
+readFieldHash :: String -> ReadPrec a -> ReadPrec a
+readFieldHash name parser = do
+  expectP (Ident name)
+  expectP (Symbol "#")
+  expectP (Punc "=")
+  parser
+
+readSymField :: String -> ReadPrec a -> ReadPrec a
+readSymField name parser = do
+  expectP (Punc "(")
+  expectP (Symbol name)
+  expectP (Punc ")")
+  expectP (Punc "=")
+  parser
+
+readIntegralPrec :: (Num a) => ReadPrec a
+readIntegralPrec =
+  ReadPrec (\_ input -> convertIntegralResults (parseSignedInteger input))
+
+convertIntegralResults :: (Num a) => [(Integer, String)] -> [(a, String)]
+convertIntegralResults [] = []
+convertIntegralResults ((value, rest) : results) =
+  (fromInteger value, rest) : convertIntegralResults results
+
+instance Read Bool where
+  readPrec = parens (choose [("False", return False), ("True", return True)])
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance Read Ordering where
+  readPrec = parens (choose [("LT", return LT), ("EQ", return EQ), ("GT", return GT)])
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance Read Int where
+  readPrec = readIntegralPrec
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance Read Integer where
+  readPrec = readIntegralPrec
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance (Integral a, Read a) => Read (Ratio a) where
+  readPrec =
+    parens
+      ( prec
+          7
+          ( do
+              numeratorValue <- step readPrec
+              expectP (Symbol "%")
+              denominatorValue <- step readPrec
+              return (numeratorValue % denominatorValue)
+          )
+      )
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance Read () where
+  readPrec = parens (paren (return ()))
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance Read Char where
+  readPrec =
+    parens
+      ( do
+          token <- lexP
+          case token of
+            Char value -> return value
+            _ -> pfail
+      )
+  readListPrec =
+    parens
+      ( ( do
+            token <- lexP
+            case token of
+              String value -> return value
+              _ -> pfail
+        )
+          +++ readListPrecDefault
+      )
+  readList = readListDefault
+
+instance (Read a) => Read [a] where
+  readPrec = readListPrec
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance (Read a) => Read (Maybe a) where
+  readPrec =
+    parens
+      ( choose [("Nothing", return Nothing)]
+          +++ prec 10 (do expectP (Ident "Just"); value <- step readPrec; return (Just value))
+      )
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance (Read a, Read b) => Read (Either a b) where
+  readPrec =
+    parens
+      ( prec 10 (do expectP (Ident "Left"); value <- step readPrec; return (Left value))
+          +++ prec 10 (do expectP (Ident "Right"); value <- step readPrec; return (Right value))
+      )
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance (Read a, Read b) => Read (a, b) where
+  readPrec =
+    parens
+      ( paren
+          ( do
+              first <- readPrec
+              expectP (Punc ",")
+              second <- readPrec
+              return (first, second)
+          )
+      )
+  readListPrec = readListPrecDefault
+  readList = readListDefault
+
+instance (Read a, Read b, Read c) => Read (a, b, c) where
+  readPrec =
+    parens
+      ( paren
+          ( do
+              first <- readPrec
+              expectP (Punc ",")
+              second <- readPrec
+              expectP (Punc ",")
+              third <- readPrec
+              return (first, second, third)
+          )
+      )
+  readListPrec = readListPrecDefault
+  readList = readListDefault

--- a/core-libs/aihc-base/src/GHC/Read/Lex.hs
+++ b/core-libs/aihc-base/src/GHC/Read/Lex.hs
@@ -1,0 +1,397 @@
+{-# LANGUAGE MagicHash #-}
+
+module GHC.Read.Lex
+  ( Lexeme (..),
+    NumberToken (..),
+    lex,
+    lexDigits,
+    lexLitChar,
+    readLitChar,
+    lexP,
+    expectP,
+    parseSignedInteger,
+    stringEqual,
+  )
+where
+
+import GHC.Int (Int (..))
+import GHC.Internal.Integer (eqInteger#)
+import GHC.Prim (chr#, ord#, (<#), (==#))
+import Prelude
+
+newtype NumberToken = NumberToken Integer
+
+data Lexeme
+  = Char Char
+  | String String
+  | Punc String
+  | Ident String
+  | Symbol String
+  | Number NumberToken
+  | EOF
+
+lexDigits :: ReadS String
+lexDigits input =
+  case takeDigits input of
+    ([], _) -> []
+    (digits, rest) -> [(digits, rest)]
+
+lexLitChar :: ReadS String
+lexLitChar input =
+  case readLitCharWithSpelling input of
+    [] -> []
+    (_, spelling, rest) : _ -> [(spelling, rest)]
+
+readLitChar :: ReadS Char
+readLitChar input =
+  case readLitCharWithSpelling input of
+    [] -> []
+    (char, _, rest) : _ -> [(char, rest)]
+
+lexP :: ReadPrec Lexeme
+lexP =
+  ReadPrec
+    ( \_ input ->
+        case lexLexeme input of
+          [] -> []
+          (token, rest) : _ -> [(token, rest)]
+    )
+
+expectP :: Lexeme -> ReadPrec ()
+expectP expected = do
+  actual <- lexP
+  case sameLexeme expected actual of
+    True -> return ()
+    False -> pfail
+
+sameLexeme :: Lexeme -> Lexeme -> Bool
+sameLexeme (Char left) (Char right) = charEqual left right
+sameLexeme (String left) (String right) = stringEqual left right
+sameLexeme (Punc left) (Punc right) = stringEqual left right
+sameLexeme (Ident left) (Ident right) = stringEqual left right
+sameLexeme (Symbol left) (Symbol right) = stringEqual left right
+sameLexeme (Number (NumberToken left)) (Number (NumberToken right)) = integerEqual left right
+sameLexeme EOF EOF = True
+sameLexeme _ _ = False
+
+lexLexeme :: String -> [(Lexeme, String)]
+lexLexeme input =
+  case skipReadSpaces input of
+    [] -> [(EOF, [])]
+    rest ->
+      case lexTokenWithSpelling rest of
+        [] -> []
+        (_, token, remaining) : _ -> [(token, remaining)]
+
+lexTokenWithSpelling :: String -> [(String, Lexeme, String)]
+lexTokenWithSpelling input =
+  case input of
+    '\'' : rest -> lexCharacterToken rest
+    '"' : rest -> lexStringToken rest
+    char : rest ->
+      case isPunctuation char of
+        True -> [([char], Punc [char], rest)]
+        False ->
+          case isIdentifierStart char of
+            True ->
+              case takeWhileRead isIdentifierContinue rest of
+                (suffix, remaining) ->
+                  let spelling = char : suffix
+                   in [(spelling, Ident spelling, remaining)]
+            False ->
+              case isDecimalDigit char of
+                True -> lexNumberToken input
+                False ->
+                  case isSymbolCharacter char of
+                    True ->
+                      case takeWhileRead isSymbolCharacter rest of
+                        (suffix, remaining) ->
+                          let spelling = char : suffix
+                           in [(spelling, classifySymbol spelling, remaining)]
+                    False -> []
+    [] -> [([], EOF, [])]
+
+lexCharacterToken :: String -> [(String, Lexeme, String)]
+lexCharacterToken input =
+  case readLitCharWithSpelling input of
+    [] -> []
+    (char, spelling, '\'' : rest) : _ -> [("'" ++ spelling ++ "'", Char char, rest)]
+    _ -> []
+
+lexStringToken :: String -> [(String, Lexeme, String)]
+lexStringToken = lexStringCharacters [] []
+
+lexStringCharacters :: String -> String -> String -> [(String, Lexeme, String)]
+lexStringCharacters values spelling input =
+  case input of
+    '"' : rest -> [("\"" ++ reverseRead spelling ++ "\"", String (reverseRead values), rest)]
+    '\\' : afterSlash ->
+      case afterSlash of
+        '&' : rest -> lexStringCharacters values ('&' : '\\' : spelling) rest
+        _ -> continueStringCharacters values spelling input
+    _ -> continueStringCharacters values spelling input
+
+continueStringCharacters :: String -> String -> String -> [(String, Lexeme, String)]
+continueStringCharacters values spelling input =
+  case readLitCharWithSpelling input of
+    [] -> []
+    (char, consumed, rest) : _ ->
+      lexStringCharacters (char : values) (reverseAppend consumed spelling) rest
+
+lexNumberToken :: String -> [(String, Lexeme, String)]
+lexNumberToken input =
+  case input of
+    '0' : afterZero -> lexZeroNumber afterZero
+    _ ->
+      lexBasedNumber 10 isDecimalDigit input []
+
+lexZeroNumber :: String -> [(String, Lexeme, String)]
+lexZeroNumber input =
+  case input of
+    'x' : rest -> lexBasedNumber 16 isHexDigitRead rest "0x"
+    'X' : rest -> lexBasedNumber 16 isHexDigitRead rest "0X"
+    'o' : rest -> lexBasedNumber 8 isOctalDigit rest "0o"
+    'O' : rest -> lexBasedNumber 8 isOctalDigit rest "0O"
+    'b' : rest -> lexBasedNumber 2 isBinaryDigit rest "0b"
+    'B' : rest -> lexBasedNumber 2 isBinaryDigit rest "0B"
+    _ -> lexBasedNumber 10 isDecimalDigit ('0' : input) []
+
+lexBasedNumber :: Integer -> (Char -> Bool) -> String -> String -> [(String, Lexeme, String)]
+lexBasedNumber base predicate chars prefix =
+  case takeWhileRead predicate chars of
+    ([], _) -> []
+    (digits, rest) ->
+      let spelling = prefix ++ digits
+       in [(spelling, Number (NumberToken (digitsToInteger base digits)), rest)]
+
+classifySymbol :: String -> Lexeme
+classifySymbol symbol =
+  case isReservedSymbol symbol of
+    True -> Punc symbol
+    False -> Symbol symbol
+
+isReservedSymbol :: String -> Bool
+isReservedSymbol symbol =
+  stringEqual symbol ".."
+    || stringEqual symbol ":"
+    || stringEqual symbol "::"
+    || stringEqual symbol "="
+    || stringEqual symbol "\\"
+    || stringEqual symbol "|"
+    || stringEqual symbol "<-"
+    || stringEqual symbol "->"
+    || stringEqual symbol "@"
+    || stringEqual symbol "~"
+    || stringEqual symbol "=>"
+
+skipReadSpaces :: String -> String
+skipReadSpaces [] = []
+skipReadSpaces (char : rest) =
+  case isReadSpace char of
+    True -> skipReadSpaces rest
+    False -> char : rest
+
+isReadSpace :: Char -> Bool
+isReadSpace ' ' = True
+isReadSpace '\t' = True
+isReadSpace '\n' = True
+isReadSpace '\r' = True
+isReadSpace '\f' = True
+isReadSpace '\v' = True
+isReadSpace _ = False
+
+isPunctuation :: Char -> Bool
+isPunctuation ',' = True
+isPunctuation ';' = True
+isPunctuation '(' = True
+isPunctuation ')' = True
+isPunctuation '[' = True
+isPunctuation ']' = True
+isPunctuation '{' = True
+isPunctuation '}' = True
+isPunctuation '`' = True
+isPunctuation _ = False
+
+isIdentifierStart :: Char -> Bool
+isIdentifierStart char = isAsciiLetter char || charEqual char '_'
+
+isIdentifierContinue :: Char -> Bool
+isIdentifierContinue char = isIdentifierStart char || isDecimalDigit char || charEqual char '\''
+
+isAsciiLetter :: Char -> Bool
+isAsciiLetter char = charBetween 'a' 'z' char || charBetween 'A' 'Z' char
+
+isDecimalDigit :: Char -> Bool
+isDecimalDigit = charBetween '0' '9'
+
+isOctalDigit :: Char -> Bool
+isOctalDigit = charBetween '0' '7'
+
+isBinaryDigit :: Char -> Bool
+isBinaryDigit char = charEqual char '0' || charEqual char '1'
+
+isHexDigitRead :: Char -> Bool
+isHexDigitRead char =
+  isDecimalDigit char
+    || charBetween 'a' 'f' char
+    || charBetween 'A' 'F' char
+
+isSymbolCharacter :: Char -> Bool
+isSymbolCharacter '!' = True
+isSymbolCharacter '#' = True
+isSymbolCharacter '$' = True
+isSymbolCharacter '%' = True
+isSymbolCharacter '&' = True
+isSymbolCharacter '*' = True
+isSymbolCharacter '+' = True
+isSymbolCharacter '.' = True
+isSymbolCharacter '/' = True
+isSymbolCharacter '<' = True
+isSymbolCharacter '=' = True
+isSymbolCharacter '>' = True
+isSymbolCharacter '?' = True
+isSymbolCharacter '@' = True
+isSymbolCharacter '\\' = True
+isSymbolCharacter '^' = True
+isSymbolCharacter '|' = True
+isSymbolCharacter '-' = True
+isSymbolCharacter '~' = True
+isSymbolCharacter ':' = True
+isSymbolCharacter _ = False
+
+takeWhileRead :: (Char -> Bool) -> String -> (String, String)
+takeWhileRead _ [] = ([], [])
+takeWhileRead predicate input@(char : rest) =
+  case predicate char of
+    False -> ([], input)
+    True ->
+      case takeWhileRead predicate rest of
+        (matched, remaining) -> (char : matched, remaining)
+
+takeDigits :: String -> (String, String)
+takeDigits = takeWhileRead isDecimalDigit
+
+digitsToInteger :: Integer -> String -> Integer
+digitsToInteger base = go 0
+  where
+    go value [] = value
+    go value (digit : digits) = go (value * base + fromIntegral (digitValue digit)) digits
+
+digitValue :: Char -> Int
+digitValue char =
+  case charBetween '0' '9' char of
+    True -> charCode char - charCode '0'
+    False ->
+      case charBetween 'a' 'f' char of
+        True -> charCode char - charCode 'a' + 10
+        False -> charCode char - charCode 'A' + 10
+
+charEqual :: Char -> Char -> Bool
+charEqual (C# left) (C# right) =
+  case (==#) (ord# left) (ord# right) of
+    0# -> False
+    _ -> True
+
+stringEqual :: String -> String -> Bool
+stringEqual [] [] = True
+stringEqual [] (_ : _) = False
+stringEqual (_ : _) [] = False
+stringEqual (left : lefts) (right : rights) =
+  case charEqual left right of
+    True -> stringEqual lefts rights
+    False -> False
+
+integerEqual :: Integer -> Integer -> Bool
+integerEqual left right =
+  case eqInteger# left right of
+    0# -> False
+    _ -> True
+
+charBetween :: Char -> Char -> Char -> Bool
+charBetween (C# lower) (C# upper) (C# value) =
+  case (<#) (ord# value) (ord# lower) of
+    1# -> False
+    _ ->
+      case (<#) (ord# upper) (ord# value) of
+        1# -> False
+        _ -> True
+
+charCode :: Char -> Int
+charCode (C# char) = I# (ord# char)
+
+readLitCharWithSpelling :: String -> [(Char, String, String)]
+readLitCharWithSpelling [] = []
+readLitCharWithSpelling ('\\' : rest) = readEscape rest
+readLitCharWithSpelling (char : rest) = [(char, [char], rest)]
+
+readEscape :: String -> [(Char, String, String)]
+readEscape [] = []
+readEscape ('a' : rest) = [('\a', "\\a", rest)]
+readEscape ('b' : rest) = [('\b', "\\b", rest)]
+readEscape ('f' : rest) = [('\f', "\\f", rest)]
+readEscape ('n' : rest) = [('\n', "\\n", rest)]
+readEscape ('r' : rest) = [('\r', "\\r", rest)]
+readEscape ('t' : rest) = [('\t', "\\t", rest)]
+readEscape ('v' : rest) = [('\v', "\\v", rest)]
+readEscape ('\\' : rest) = [('\\', "\\\\", rest)]
+readEscape ('\'' : rest) = [('\'', "\\'", rest)]
+readEscape ('"' : rest) = [('"', "\\\"", rest)]
+readEscape input@(char : _) =
+  case isDecimalDigit char of
+    True ->
+      case takeDigits input of
+        (digits, rest) -> [(characterFromDigits 10 digits, '\\' : digits, rest)]
+    False -> []
+readEscape _ = []
+
+characterFromDigits :: Int -> String -> Char
+characterFromDigits base digits =
+  case digitsToInt base digits of
+    I# value -> C# (chr# value)
+
+digitsToInt :: Int -> String -> Int
+digitsToInt base = go 0
+  where
+    go value [] = value
+    go value (digit : digits) = go (value * base + digitValue digit) digits
+
+reverseRead :: [a] -> [a]
+reverseRead values = reverseAppend values []
+
+reverseAppend :: [a] -> [a] -> [a]
+reverseAppend [] suffix = suffix
+reverseAppend (value : values) suffix = reverseAppend values (value : suffix)
+
+parseSignedInteger :: ReadS Integer
+parseSignedInteger input =
+  case lexLexeme input of
+    (Symbol sign, afterSign) : _ ->
+      case stringEqual sign "-" of
+        True -> negateIntegerResults (parseUnsignedInteger afterSign)
+        False -> []
+    (Punc open, afterOpen) : _ ->
+      case stringEqual open "(" of
+        True -> closeIntegerResults (parseSignedInteger afterOpen)
+        False -> []
+    _ -> parseUnsignedInteger input
+
+parseUnsignedInteger :: ReadS Integer
+parseUnsignedInteger input =
+  case lexLexeme input of
+    (Number (NumberToken value), rest) : _ -> [(value, rest)]
+    _ -> []
+
+negateIntegerResults :: [(Integer, String)] -> [(Integer, String)]
+negateIntegerResults [] = []
+negateIntegerResults ((value, rest) : results) =
+  (negate value, rest) : negateIntegerResults results
+
+closeIntegerResults :: [(Integer, String)] -> [(Integer, String)]
+closeIntegerResults [] = []
+closeIntegerResults ((value, input) : results) =
+  case lexLexeme input of
+    (Punc close, rest) : _ ->
+      case stringEqual close ")" of
+        True -> (value, rest) : closeIntegerResults results
+        False -> closeIntegerResults results
+    _ -> closeIntegerResults results

--- a/core-libs/aihc-base/src/GHC/Read/Lex.hs
+++ b/core-libs/aihc-base/src/GHC/Read/Lex.hs
@@ -89,7 +89,7 @@ lexTokenWithSpelling input =
     '\'' : rest -> lexCharacterToken rest
     '"' : rest -> lexStringToken rest
     char : rest ->
-      case isPunctuation char of
+      case isLexPunctuation char of
         True -> [([char], Punc [char], rest)]
         False ->
           case isIdentifierStart char of
@@ -200,17 +200,17 @@ isReadSpace '\f' = True
 isReadSpace '\v' = True
 isReadSpace _ = False
 
-isPunctuation :: Char -> Bool
-isPunctuation ',' = True
-isPunctuation ';' = True
-isPunctuation '(' = True
-isPunctuation ')' = True
-isPunctuation '[' = True
-isPunctuation ']' = True
-isPunctuation '{' = True
-isPunctuation '}' = True
-isPunctuation '`' = True
-isPunctuation _ = False
+isLexPunctuation :: Char -> Bool
+isLexPunctuation ',' = True
+isLexPunctuation ';' = True
+isLexPunctuation '(' = True
+isLexPunctuation ')' = True
+isLexPunctuation '[' = True
+isLexPunctuation ']' = True
+isLexPunctuation '{' = True
+isLexPunctuation '}' = True
+isLexPunctuation '`' = True
+isLexPunctuation _ = False
 
 isIdentifierStart :: Char -> Bool
 isIdentifierStart char = isAsciiLetter char || charEqual char '_'

--- a/core-libs/aihc-base/src/Prelude.hs
+++ b/core-libs/aihc-base/src/Prelude.hs
@@ -26,6 +26,9 @@ module Prelude
     Ratio,
     Real (..),
     RealFrac (..),
+    Read (..),
+    ReadPrec (..),
+    ReadS,
     Show (..),
     ShowS,
     String,
@@ -53,6 +56,22 @@ module Prelude
     showParen,
     shows,
     showString,
+    reads,
+    readParen,
+    lex,
+    Prec,
+    minPrec,
+    prec,
+    step,
+    reset,
+    get,
+    look,
+    (+++),
+    (<++),
+    pfail,
+    choice,
+    readPrec_to_S,
+    readS_to_Prec,
     realToFrac,
     (%),
     (^),
@@ -99,6 +118,214 @@ data List a = [] | a : [a]
 infixr 5 :
 
 type String = [Char]
+
+type ReadS a = String -> [(a, String)]
+
+type Prec = Int
+
+minPrec :: Prec
+minPrec = 0
+
+newtype ReadPrec a = ReadPrec (Prec -> ReadS a)
+
+instance Functor ReadPrec where
+  fmap f (ReadPrec parser) =
+    ReadPrec (\precedence input -> mapReadResults f (parser precedence input))
+
+instance Applicative ReadPrec where
+  pure value = ReadPrec (\_ input -> [(value, input)])
+
+  ReadPrec functionParser <*> ReadPrec valueParser =
+    ReadPrec
+      ( \precedence input ->
+          applyReadResults precedence valueParser (functionParser precedence input)
+      )
+
+instance Monad ReadPrec where
+  ReadPrec parser >>= next =
+    ReadPrec
+      ( \precedence input ->
+          bindReadResults precedence next (parser precedence input)
+      )
+
+  ReadPrec first >> ReadPrec second =
+    ReadPrec
+      ( \precedence input ->
+          thenReadResults precedence second (first precedence input)
+      )
+
+  return = pure
+
+mapReadResults :: (a -> b) -> [(a, String)] -> [(b, String)]
+mapReadResults _ [] = []
+mapReadResults f ((value, rest) : results) = (f value, rest) : mapReadResults f results
+
+applyReadResults :: Prec -> (Prec -> ReadS a) -> [(a -> b, String)] -> [(b, String)]
+applyReadResults _ _ [] = []
+applyReadResults precedence parser ((f, rest) : results) =
+  mapReadResults f (parser precedence rest) ++ applyReadResults precedence parser results
+
+bindReadResults :: Prec -> (a -> ReadPrec b) -> [(a, String)] -> [(b, String)]
+bindReadResults _ _ [] = []
+bindReadResults precedence next ((value, rest) : results) =
+  runReadPrec (next value) precedence rest ++ bindReadResults precedence next results
+
+thenReadResults :: Prec -> (Prec -> ReadS b) -> [(a, String)] -> [(b, String)]
+thenReadResults _ _ [] = []
+thenReadResults precedence parser ((_, rest) : results) =
+  parser precedence rest ++ thenReadResults precedence parser results
+
+runReadPrec :: ReadPrec a -> Prec -> ReadS a
+runReadPrec (ReadPrec parser) = parser
+
+readPrec_to_S :: ReadPrec a -> Prec -> ReadS a
+readPrec_to_S = runReadPrec
+
+readS_to_Prec :: (Prec -> ReadS a) -> ReadPrec a
+readS_to_Prec = ReadPrec
+
+prec :: Prec -> ReadPrec a -> ReadPrec a
+prec required parser =
+  ReadPrec
+    ( \context input ->
+        case context <= required of
+          True -> runReadPrec parser required input
+          False -> []
+    )
+
+step :: ReadPrec a -> ReadPrec a
+step parser = ReadPrec (\context -> runReadPrec parser (context + 1))
+
+reset :: ReadPrec a -> ReadPrec a
+reset parser = ReadPrec (\_ -> runReadPrec parser minPrec)
+
+get :: ReadPrec Char
+get =
+  ReadPrec
+    ( \_ input ->
+        case input of
+          [] -> []
+          char : rest -> [(char, rest)]
+    )
+
+look :: ReadPrec String
+look = ReadPrec (\_ input -> [(input, input)])
+
+(+++) :: ReadPrec a -> ReadPrec a -> ReadPrec a
+ReadPrec left +++ ReadPrec right =
+  ReadPrec (\precedence input -> left precedence input ++ right precedence input)
+
+infixr 5 +++
+
+(<++) :: ReadPrec a -> ReadPrec a -> ReadPrec a
+ReadPrec left <++ ReadPrec right =
+  ReadPrec
+    ( \precedence input ->
+        case left precedence input of
+          [] -> right precedence input
+          results -> results
+    )
+
+infixr 5 <++
+
+pfail :: ReadPrec a
+pfail = ReadPrec (\_ _ -> [])
+
+choice :: [ReadPrec a] -> ReadPrec a
+choice = foldrRead (+++) pfail
+
+foldrRead :: (a -> b -> b) -> b -> [a] -> b
+foldrRead _ initial [] = initial
+foldrRead combine initial (value : values) = combine value (foldrRead combine initial values)
+
+class Read a where
+  readsPrec :: Int -> ReadS a
+  readList :: ReadS [a]
+  readPrec :: ReadPrec a
+  readListPrec :: ReadPrec [a]
+
+  readsPrec = readPrec_to_S readPrec
+  readList = readPrec_to_S readListPrec minPrec
+  readPrec = readS_to_Prec readsPrec
+  readListPrec = readS_to_Prec defaultReadListParser
+
+defaultReadListParser :: (Read a) => Prec -> ReadS [a]
+defaultReadListParser _ = readList
+
+reads :: (Read a) => ReadS a
+reads = readsPrec minPrec
+
+readParen :: Bool -> ReadS a -> ReadS a
+readParen required parser =
+  case required of
+    True -> mandatory
+    False -> optional
+  where
+    optional input = parser input ++ mandatory input
+    mandatory input = bindPreludeReadS (matchPreludeLexeme "(" input) afterOpen
+    afterOpen _ input = bindPreludeReadS (optional input) afterValue
+    afterValue value input = bindPreludeReadS (matchPreludeLexeme ")" input) (afterClose value)
+    afterClose value _ rest = [(value, rest)]
+
+bindPreludeReadS :: [(a, String)] -> (a -> String -> [(b, String)]) -> [(b, String)]
+bindPreludeReadS [] _ = []
+bindPreludeReadS ((value, rest) : results) next =
+  next value rest ++ bindPreludeReadS results next
+
+matchPreludeLexeme :: String -> ReadS String
+matchPreludeLexeme expected input =
+  case lex input of
+    (actual, rest) : _ ->
+      case actual == expected of
+        True -> [(actual, rest)]
+        False -> []
+    _ -> []
+
+lex :: ReadS String
+lex input =
+  case skipPreludeReadSpaces input of
+    [] -> [([], [])]
+    char : rest ->
+      case isPreludeReadPunctuation char of
+        True -> [([char], rest)]
+        False ->
+          case takePreludeReadToken (char : rest) of
+            (token, remaining) -> [(token, remaining)]
+
+skipPreludeReadSpaces :: String -> String
+skipPreludeReadSpaces [] = []
+skipPreludeReadSpaces (' ' : rest) = skipPreludeReadSpaces rest
+skipPreludeReadSpaces ('\t' : rest) = skipPreludeReadSpaces rest
+skipPreludeReadSpaces ('\n' : rest) = skipPreludeReadSpaces rest
+skipPreludeReadSpaces ('\r' : rest) = skipPreludeReadSpaces rest
+skipPreludeReadSpaces input = input
+
+takePreludeReadToken :: String -> (String, String)
+takePreludeReadToken [] = ([], [])
+takePreludeReadToken input@(char : rest) =
+  case isPreludeReadDelimiter char of
+    True -> ([], input)
+    False ->
+      case takePreludeReadToken rest of
+        (token, remaining) -> (char : token, remaining)
+
+isPreludeReadDelimiter :: Char -> Bool
+isPreludeReadDelimiter ' ' = True
+isPreludeReadDelimiter '\t' = True
+isPreludeReadDelimiter '\n' = True
+isPreludeReadDelimiter '\r' = True
+isPreludeReadDelimiter char = isPreludeReadPunctuation char
+
+isPreludeReadPunctuation :: Char -> Bool
+isPreludeReadPunctuation '(' = True
+isPreludeReadPunctuation ')' = True
+isPreludeReadPunctuation '[' = True
+isPreludeReadPunctuation ']' = True
+isPreludeReadPunctuation '{' = True
+isPreludeReadPunctuation '}' = True
+isPreludeReadPunctuation ',' = True
+isPreludeReadPunctuation ';' = True
+isPreludeReadPunctuation _ = False
 
 id :: a -> a
 id x = x
@@ -368,9 +595,12 @@ showLitCode char code =
       case (==#) code 127# of
         1# -> showString "\\DEL"
         _ ->
-          case (<#) code 160# of
-            1# -> showNumericEscape code
-            _ -> showChar char
+          case (<#) code 128# of
+            1# -> showChar char
+            _ ->
+              case (<#) code 160# of
+                1# -> showNumericEscape code
+                _ -> showChar char
 
 asciiControlName :: Int# -> String
 asciiControlName code =

--- a/core-libs/aihc-base/src/Text/ParserCombinators/ReadPrec.hs
+++ b/core-libs/aihc-base/src/Text/ParserCombinators/ReadPrec.hs
@@ -1,1 +1,34 @@
-module Text.ParserCombinators.ReadPrec () where
+module Text.ParserCombinators.ReadPrec
+  ( ReadPrec,
+    Prec,
+    minPrec,
+    prec,
+    step,
+    reset,
+    get,
+    look,
+    (+++),
+    (<++),
+    pfail,
+    choice,
+    readPrec_to_S,
+    readS_to_Prec,
+  )
+where
+
+import Prelude
+  ( Prec,
+    ReadPrec,
+    choice,
+    get,
+    look,
+    minPrec,
+    pfail,
+    prec,
+    readPrec_to_S,
+    readS_to_Prec,
+    reset,
+    step,
+    (+++),
+    (<++),
+  )

--- a/core-libs/aihc-base/src/Text/Read.hs
+++ b/core-libs/aihc-base/src/Text/Read.hs
@@ -1,1 +1,22 @@
-module Text.Read () where
+module Text.Read
+  ( Read (..),
+    ReadS,
+    reads,
+    Lexeme (..),
+    lexP,
+    parens,
+    readListDefault,
+    readListPrecDefault,
+  )
+where
+
+import GHC.Read
+  ( Read (..),
+    ReadS,
+    lexP,
+    parens,
+    readListDefault,
+    readListPrecDefault,
+  )
+import GHC.Read.Lex (Lexeme (..))
+import Prelude (reads)

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -203,6 +203,7 @@ in rec {
         pathStr = toString path;
         isHaskell = pkgs.lib.hasSuffix ".hs" baseName;
         isCabal = pkgs.lib.hasSuffix ".cabal" baseName;
+        isHlintConfig = baseName == ".hlint.yaml";
         isFixture = pkgs.lib.hasInfix "/test/Test/Fixtures/" pathStr;
         inComponents = pkgs.lib.hasInfix "/components/" pathStr;
         inTooling = pkgs.lib.hasInfix "/tooling/" pathStr;
@@ -211,7 +212,7 @@ in rec {
         inNixHaskell = pkgs.lib.hasInfix "/scripts/nix/ucd2haskell-aihc/" pathStr;
         inTestSupport = pkgs.lib.hasInfix "/test/support/" pathStr;
       in
-        type == "directory" || ((inComponents || inTooling || inBin || inCoreLibs || inNixHaskell || inTestSupport) && (isCabal || (isHaskell && !isFixture)));
+        type == "directory" || isHlintConfig || ((inComponents || inTooling || inBin || inCoreLibs || inNixHaskell || inTestSupport) && (isCabal || (isHaskell && !isFixture)));
     };
 
   # Cabal formatting should not be invalidated by ordinary Haskell changes.

--- a/test/Test/Fixtures/eval/base/nested-unit-constructor-pattern.yaml
+++ b/test/Test/Fixtures/eval/base/nested-unit-constructor-pattern.yaml
@@ -1,0 +1,17 @@
+dependencies:
+  - aihc-base
+extensions: []
+modules:
+  - |
+    module Test where
+
+    data Result a = Result a
+
+    containsUnit :: Result () -> Bool
+    containsUnit (Result ()) = True
+output: |
+  True
+expression: |
+  containsUnit (Result ())
+status: pass
+reason: nested unit patterns require no tuple field type information

--- a/test/Test/Fixtures/eval/base/read-custom.yaml
+++ b/test/Test/Fixtures/eval/base/read-custom.yaml
@@ -1,0 +1,80 @@
+dependencies:
+  - aihc-base
+extensions: []
+modules:
+  - |
+    module Test where
+
+    import GHC.Read
+    import Text.ParserCombinators.ReadPrec (ReadPrec, prec, readPrec_to_S, step)
+    import Text.Read (Lexeme(..))
+
+    data Wrapped = Wrapped Bool
+
+    instance Eq Wrapped where
+      Wrapped left == Wrapped right = left == right
+      Wrapped left /= Wrapped right = left /= right
+
+    instance Read Wrapped where
+      readPrec =
+        parens
+          (prec 10
+            (do
+              expectP (Ident "Wrapped")
+              value <- step readPrec
+              return (Wrapped value)))
+      readListPrec = readListPrecDefault
+
+    data Named = Named Bool
+
+    instance Eq Named where
+      Named left == Named right = left == right
+      Named left /= Named right = left /= right
+
+    instance Read Named where
+      readPrec =
+        parens
+          (do
+            expectP (Ident "Named")
+            expectP (Punc "{")
+            value <- readField "named" readPrec
+            expectP (Punc "}")
+            return (Named value))
+      readListPrec = readListPrecDefault
+
+    fullyReads :: (Read a, Eq a) => a -> String -> Bool
+    fullyReads expected input =
+      case reads input of
+        [(actual, rest)] -> actual == expected && emptyString rest
+        _ -> False
+
+    emptyString :: String -> Bool
+    emptyString [] = True
+    emptyString (_ : _) = False
+
+    readsWith :: ReadPrec a -> String -> [(a, String)]
+    readsWith parser = readPrec_to_S parser 0
+
+    checks :: [Bool]
+    checks =
+      [ fullyReads (Wrapped False) "Wrapped False",
+        fullyReads (Wrapped True) "(Wrapped True)",
+        fullyReads (Named True) "Named { named = True }",
+        boolResult True (readsWith (readFieldHash "named" readPrec) "named# =True"),
+        boolResult False (readsWith (readSymField "#" readPrec) "(#)=False")
+      ]
+
+    boolResult :: Bool -> [(Bool, String)] -> Bool
+    boolResult expected [(value, rest)] = value == expected && emptyString rest
+    boolResult _ _ = False
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : values) = allTrue values
+    allTrue (False : _) = False
+output: |
+  True
+expression: |
+  allTrue checks
+status: pass
+reason: GHC.Read supports precedence-sensitive and record-style user instances

--- a/test/Test/Fixtures/eval/base/read-lexer.yaml
+++ b/test/Test/Fixtures/eval/base/read-lexer.yaml
@@ -1,0 +1,46 @@
+dependencies:
+  - aihc-base
+extensions: []
+modules:
+  - |
+    module Test where
+
+    import GHC.Read
+    import Text.ParserCombinators.ReadPrec (readPrec_to_S)
+    import Text.Read (Lexeme(..))
+
+    stringResult :: String -> String -> [(String, String)] -> Bool
+    stringResult expectedValue expectedRest [(value, rest)] =
+      value == expectedValue && rest == expectedRest
+    stringResult _ _ _ = False
+
+    charResult :: Char -> String -> [(Char, String)] -> Bool
+    charResult expectedValue expectedRest [(value, rest)] =
+      value == expectedValue && rest == expectedRest
+    charResult _ _ _ = False
+
+    boolResult :: Bool -> String -> [(Bool, String)] -> Bool
+    boolResult expectedValue expectedRest [(value, rest)] =
+      value == expectedValue && rest == expectedRest
+    boolResult _ _ _ = False
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : values) = allTrue values
+    allTrue (False : _) = False
+
+    checks :: [Bool]
+    checks =
+      [ stringResult "Just" " False!" (lex "  Just False!"),
+        stringResult "" "" (lex "   "),
+        stringResult "123" "abc" (lexDigits "123abc"),
+        stringResult "\\n" "rest" (lexLitChar "\\nrest"),
+        charResult '\n' "rest" (readLitChar "\\nrest"),
+        boolResult True "!" (readPrec_to_S (choose [("False", return False), ("True", return True)]) 0 "True!")
+      ]
+output: |
+  True
+expression: |
+  allTrue checks
+status: pass
+reason: GHC.Read exposes compatible lexical and ReadPrec helpers

--- a/test/Test/Fixtures/eval/base/read-primitives.yaml
+++ b/test/Test/Fixtures/eval/base/read-primitives.yaml
@@ -1,0 +1,54 @@
+dependencies:
+  - aihc-base
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+
+    import GHC.Int (Int(I#))
+    import GHC.Read
+
+    fullyReads :: (Read a, Eq a) => a -> String -> Bool
+    fullyReads expected input =
+      case reads input of
+        [(actual, rest)] -> actual == expected && emptyString rest
+        _ -> False
+
+    emptyString :: String -> Bool
+    emptyString [] = True
+    emptyString (_ : _) = False
+
+    readsUnit :: String -> Bool
+    readsUnit input =
+      case (reads input :: [((), String)]) of
+        [(_, rest)] -> emptyString rest
+        _ -> False
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : values) = allTrue values
+    allTrue (False : _) = False
+
+    checks :: [Bool]
+    checks =
+      [ fullyReads False "False",
+        fullyReads True "((True))",
+        fullyReads (I# 42#) "42",
+        fullyReads (negate (I# 42#)) "-42",
+        fullyReads (255 :: Integer) "0xff",
+        fullyReads (10 :: Integer) "0b1010",
+        fullyReads (123456789 :: Integer) "123456789",
+        fullyReads (1 % 2 :: Rational) "1 % 2",
+        readsUnit "()",
+        fullyReads GT "GT",
+        fullyReads ('a' :: Char) "'a'",
+        fullyReads ('\n' :: Char) "'\\n'",
+        fullyReads ("a\n\"\\" :: String) "\"a\\n\\\"\\\\\""
+      ]
+output: |
+  True
+expression: |
+  allTrue checks
+status: pass
+reason: GHC.Read parses primitive values, numeric bases, escapes, and parentheses

--- a/test/Test/Fixtures/eval/base/read-structures.yaml
+++ b/test/Test/Fixtures/eval/base/read-structures.yaml
@@ -1,0 +1,55 @@
+dependencies:
+  - aihc-base
+extensions:
+  - MagicHash
+modules:
+  - |
+    module Test where
+
+    import GHC.Int (Int(I#))
+    import GHC.Read
+
+    fullyReads :: (Read a, Eq a) => a -> String -> Bool
+    fullyReads expected input =
+      case reads input of
+        [(actual, rest)] -> actual == expected && emptyString rest
+        _ -> False
+
+    emptyString :: String -> Bool
+    emptyString [] = True
+    emptyString (_ : _) = False
+
+    readsPair :: String -> Bool
+    readsPair input =
+      case (reads input :: [((Bool, Maybe Bool), String)]) of
+        [((False, Just True), rest)] -> emptyString rest
+        _ -> False
+
+    readsTriple :: String -> Bool
+    readsTriple input =
+      case (reads input :: [((Bool, Maybe Bool, Int), String)]) of
+        [((False, Just True, I# 2#), rest)] -> emptyString rest
+        _ -> False
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : values) = allTrue values
+    allTrue (False : _) = False
+
+    checks :: [Bool]
+    checks =
+      [ fullyReads ([] :: [Bool]) "[]",
+        fullyReads [False, True] "[False, True]",
+        fullyReads (Nothing :: Maybe Bool) "Nothing",
+        fullyReads (Just True) "Just True",
+        fullyReads (Left False :: Either Bool Int) "Left False",
+        fullyReads (Right (I# 2#) :: Either Bool Int) "Right 2",
+        readsPair "(False, Just True)",
+        readsTriple "(False, Just True, 2)"
+      ]
+output: |
+  True
+expression: |
+  allTrue checks
+status: pass
+reason: GHC.Read parses lists, optional values, sums, and tuples


### PR DESCRIPTION
## Summary

- implement the base-4.22 `GHC.Read` API, `ReadPrec` support, lexer helpers, and core `Read` instances
- teach type checking and System FC desugaring the pattern information needed by the implementation
- share pattern-match fall-through continuations and memoize evaluator thunks, preventing the prior exponential memory growth
- add FC golden coverage and shared FC/GRIN evaluation fixtures for primitives, structures, custom readers, and lexer helpers

## Progress

- `BASE`: 234 / 10055 (2.33%) -> 241 / 10055 (2.40%), +7 matches
- `GHC_PRIM`: 51 / 3425 (1.49%), unchanged

## Validation

- `just fmt`
- `just check`
- full check peak resident memory: approximately 2.17 GB