### PR TITLE
build: cap RTS heap at 10 GiB

### DIFF
--- a/bin/aihc-fmt/aihc-fmt.cabal
+++ b/bin/aihc-fmt/aihc-fmt.cabal
@@ -67,6 +67,6 @@ test-suite spec
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: GHC2021

--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -64,7 +64,7 @@ executable aihc
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: GHC2021
 
@@ -94,5 +94,9 @@ test-suite spec
     text,
     time,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/components/aihc-amd64/aihc-amd64.cabal
+++ b/components/aihc-amd64/aihc-amd64.cabal
@@ -68,5 +68,9 @@ test-suite spec
     unix,
     yaml,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/components/aihc-arm64/aihc-arm64.cabal
+++ b/components/aihc-arm64/aihc-arm64.cabal
@@ -68,5 +68,9 @@ test-suite spec
     unix,
     yaml,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -76,6 +76,6 @@ test-suite spec
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: GHC2021

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -109,6 +109,6 @@ test-suite spec
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: GHC2021

--- a/components/aihc-llvm/aihc-llvm.cabal
+++ b/components/aihc-llvm/aihc-llvm.cabal
@@ -54,5 +54,9 @@ test-suite spec
     tasty-quickcheck,
     text,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/components/aihc-native/aihc-native.cabal
+++ b/components/aihc-native/aihc-native.cabal
@@ -63,5 +63,9 @@ test-suite spec
     tasty-quickcheck,
     text,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/components/aihc-resolve/aihc-resolve.cabal
+++ b/components/aihc-resolve/aihc-resolve.cabal
@@ -61,6 +61,6 @@ test-suite spec
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: Haskell2010

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -115,6 +115,6 @@ test-suite spec
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: GHC2021

--- a/components/aihc-wasm/aihc-wasm.cabal
+++ b/components/aihc-wasm/aihc-wasm.cabal
@@ -64,5 +64,9 @@ test-suite spec
     tasty-quickcheck,
     text,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/tooling/aihc-dev/aihc-dev.cabal
+++ b/tooling/aihc-dev/aihc-dev.cabal
@@ -159,5 +159,9 @@ test-suite spec
     time,
     yaml >=0.11 && <0.12,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/tooling/aihc-hackage/aihc-hackage.cabal
+++ b/tooling/aihc-hackage/aihc-hackage.cabal
@@ -58,5 +58,9 @@ test-suite spec
     text,
     zlib,
 
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -rtsopts
+    -with-rtsopts=-M10G
+
   default-language: GHC2021

--- a/tooling/aihc-testing/aihc-testing.cabal
+++ b/tooling/aihc-testing/aihc-testing.cabal
@@ -44,6 +44,6 @@ test-suite spec
     -Wall
     -threaded
     -rtsopts
-    -with-rtsopts=-N
+    "-with-rtsopts=-N -M10G"
 
   default-language: GHC2021


### PR DESCRIPTION
## Summary

- set the `aihc` executable's default RTS heap limit to 10 GiB
- apply the same `-M10G` default to every local Cabal test suite
- preserve existing `-N` defaults where present

## Why

The compiler and test processes previously had no heap ceiling, so an unexpected allocation spike could consume all available machine memory. The embedded RTS default now terminates a process at 10 GiB instead.

## Impact

Normal compiler and test behavior is unchanged below the limit. Processes that would exceed 10 GiB now fail under the GHC RTS memory cap rather than continuing to allocate without a project-defined bound.

## Validation

- `just fmt`
- `just check`
- all 14 local test suites include `-M10G`

## Progress counts

Unchanged; this configuration-only change adds no fixtures or language coverage.
