### PR TITLE
feat(fc): add generalized axiom interfaces

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -64,7 +64,7 @@ import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
-import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithClassEnv)
+import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket)
 import Control.Monad (forM_, when)
@@ -235,12 +235,9 @@ compileWithDependencies target wholeProgram dependencies parsed =
   case resolveWithDeps (dependencyExports dependencies) [parsed] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
     ResolveResult {resolvedModules} ->
-      let (checkedModules, _, _, _) =
-            typecheckModulesWithClassEnv
-              (dependencyTerms dependencies)
-              (dependencyTyCons dependencies)
-              (dependencyClasses dependencies)
-              (dependencyInstances dependencies)
+      let (checkedModules, _) =
+            typecheckModulesWithInterface
+              (dependencyTcInterface dependencies)
               resolvedModules
        in if not (all tcModuleSuccess checkedModules)
             then Left (CompileFrontendError ["typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules)])
@@ -417,6 +414,7 @@ shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBi
     shiftTopBind topBind =
       case topBind of
         FcData {} -> topBind
+        FcAxiom {} -> topBind
         FcNewtype {} -> topBind
         FcPrimitive var arity -> FcPrimitive (shiftVar var) arity
         FcForeignImport {} -> topBind
@@ -454,6 +452,7 @@ topBindVarsDeep :: FcTopBind -> [Var]
 topBindVarsDeep topBind =
   case topBind of
     FcData {} -> []
+    FcAxiom {} -> []
     FcNewtype {} -> []
     FcPrimitive var _ -> [var]
     FcForeignImport {} -> []

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -19,7 +19,7 @@ import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
 import Aihc.Cli.Runtime (readWasmClangProcessWithExitCode, wasmClangCommand)
 import Aihc.Cli.Store (installedLibrariesActivePath, installedLibrariesRoot)
-import Aihc.Fc (DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, optimizeProgram)
+import Aihc.Fc (AxiomInterface, DesugarResult (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractAxiomInterface, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, optimizeProgram)
 import Aihc.Grin qualified as Grin
 import Aihc.Llvm qualified as Llvm
 import Aihc.Native
@@ -55,16 +55,12 @@ import Aihc.Resolve
     resolveWithDeps,
   )
 import Aihc.Tc
-  ( ClassInfo,
-    InstanceInfo,
-    TcBindingResult (..),
-    TyConInfo,
-    TypeScheme (..),
+  ( TcBindingResult (..),
+    TcInterface,
     tcModuleBindings,
     tcModuleDiagnostics,
-    tcModuleInstances,
     tcModuleSuccess,
-    typecheckModuleSccWithClassEnv,
+    typecheckModuleSccWithInterface,
   )
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket, bracketOnError)
@@ -109,11 +105,9 @@ newtype CompileEnvironment = CompileEnvironment
 
 data DependencyArtifact = DependencyArtifact
   { dependencyExports :: !ModuleExports,
-    dependencyTerms :: ![(Text, TypeScheme)],
-    dependencyTyCons :: ![TyConInfo],
-    dependencyClasses :: ![ClassInfo],
+    dependencyTcInterface :: !TcInterface,
     dependencyBindings :: ![TcBindingResult],
-    dependencyInstances :: ![InstanceInfo],
+    dependencyAxiomInterface :: !AxiomInterface,
     dependencyNewtypeInterface :: !NewtypeInterface,
     dependencyGrinInterface :: !Grin.GrinInterface,
     dependencyReachabilityInterface :: !ReachabilityInterface,
@@ -131,6 +125,7 @@ data DependencyUnit = DependencyUnit
     dependencyUnitProgram :: !FcProgram,
     dependencyUnitGrin :: !Grin.GrinProgram,
     dependencyUnitCpsGrin :: !Grin.CpsGrinProgram,
+    dependencyUnitAxiomInterface :: !AxiomInterface,
     dependencyUnitNewtypeInterface :: !NewtypeInterface,
     dependencyUnitGrinInterface :: !Grin.GrinInterface,
     dependencyUnitReachabilityInterface :: !ReachabilityInterface,
@@ -147,11 +142,9 @@ data DependencyUnitMetadata = DependencyUnitMetadata
 data StoredDependencyArtifact = StoredDependencyArtifact
   { storedSchemaVersion :: !Int,
     storedExports :: !StoredModuleExports,
-    storedTerms :: ![(Text, TypeScheme)],
-    storedTyCons :: ![TyConInfo],
-    storedClasses :: ![ClassInfo],
+    storedTcInterface :: !TcInterface,
     storedBindings :: ![TcBindingResult],
-    storedInstances :: ![InstanceInfo],
+    storedAxiomInterface :: !AxiomInterface,
     storedNewtypeInterface :: !NewtypeInterface,
     storedGrinInterface :: !Grin.GrinInterface,
     storedReachabilityInterface :: !ReachabilityInterface,
@@ -199,7 +192,7 @@ data LibraryPackage = LibraryPackage
   deriving (Eq, Show)
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 27
+cacheSchemaVersion = 28
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do
@@ -327,11 +320,9 @@ emptyDependencyArtifact :: DependencyArtifact
 emptyDependencyArtifact =
   DependencyArtifact
     { dependencyExports = Map.empty,
-      dependencyTerms = [],
-      dependencyTyCons = [],
-      dependencyClasses = [],
+      dependencyTcInterface = mempty,
       dependencyBindings = [],
-      dependencyInstances = [],
+      dependencyAxiomInterface = mempty,
       dependencyNewtypeInterface = mempty,
       dependencyGrinInterface = mempty,
       dependencyReachabilityInterface = mempty,
@@ -392,31 +383,26 @@ parserConfig sourceName source =
 compileLoadedModules :: [LoadedModule] -> Either String DependencyArtifact
 compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedModuleSccs loaded)
   where
-    initialState = CompileState Map.empty [] [] [] [] [] mempty mempty mempty [] []
+    initialState = CompileState Map.empty mempty [] mempty mempty mempty mempty [] []
 
     compileScc state members =
       case resolveWithDeps (compileStateExports state) (map loadedModule members) of
         ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("library resolve error: " <> show errors)
         resolved@ResolveResult {resolvedModules} ->
-          let (checkedModules, termSchemes, tyCons, classes) =
-                typecheckModuleSccWithClassEnv
-                  (compileStateTerms state)
-                  (compileStateTyCons state)
-                  (compileStateClasses state)
-                  (compileStateInstances state)
-                  resolvedModules
+          let (checkedModules, tcInterface) =
+                typecheckModuleSccWithInterface (compileStateTcInterface state) resolvedModules
            in if not (all tcModuleSuccess checkedModules)
                 then Left ("library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
                 else
                   let localBindings = concatMap tcModuleBindings checkedModules
                       bindings = compileStateBindings state <> localBindings
-                      localInstances = concatMap tcModuleInstances checkedModules
                       desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
                    in if not (all dsSuccess desugared)
                         then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else
                           let sourceCore = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                               core = optimizeProgram (lowerNewtypesWithInterface (compileStateNewtypes state) sourceCore)
+                              axioms = extractAxiomInterface core
                               newtypes = extractNewtypeInterface core
                               grinInterface = Grin.extractGrinInterface core
                               reachabilityInterface = extractReachabilityInterface core
@@ -432,6 +418,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                                             dependencyUnitProgram = core,
                                             dependencyUnitGrin = grin,
                                             dependencyUnitCpsGrin = cpsGrin,
+                                            dependencyUnitAxiomInterface = axioms,
                                             dependencyUnitNewtypeInterface = newtypes,
                                             dependencyUnitGrinInterface = grinInterface,
                                             dependencyUnitReachabilityInterface = reachabilityInterface,
@@ -440,11 +427,9 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                                    in Right
                                         CompileState
                                           { compileStateExports = compileStateExports state <> extractInterfaceWithDeps (compileStateExports state) resolved,
-                                            compileStateTerms = termSchemes,
-                                            compileStateTyCons = tyCons,
-                                            compileStateClasses = classes,
+                                            compileStateTcInterface = tcInterface,
                                             compileStateBindings = bindings,
-                                            compileStateInstances = compileStateInstances state <> localInstances,
+                                            compileStateAxioms = compileStateAxioms state <> axioms,
                                             compileStateNewtypes = compileStateNewtypes state <> newtypes,
                                             compileStateGrin = compileStateGrin state <> grinInterface,
                                             compileStateReachability = compileStateReachability state <> reachabilityInterface,
@@ -455,11 +440,9 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
     finish state =
       DependencyArtifact
         { dependencyExports = Map.restrictKeys (compileStateExports state) exposedModules,
-          dependencyTerms = compileStateTerms state,
-          dependencyTyCons = compileStateTyCons state,
-          dependencyClasses = compileStateClasses state,
+          dependencyTcInterface = compileStateTcInterface state,
           dependencyBindings = compileStateBindings state,
-          dependencyInstances = compileStateInstances state,
+          dependencyAxiomInterface = compileStateAxioms state,
           dependencyNewtypeInterface = compileStateNewtypes state,
           dependencyGrinInterface = compileStateGrin state,
           dependencyReachabilityInterface = compileStateReachability state,
@@ -486,11 +469,9 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
 
 data CompileState = CompileState
   { compileStateExports :: !ModuleExports,
-    compileStateTerms :: ![(Text, TypeScheme)],
-    compileStateTyCons :: ![TyConInfo],
-    compileStateClasses :: ![ClassInfo],
+    compileStateTcInterface :: !TcInterface,
     compileStateBindings :: ![TcBindingResult],
-    compileStateInstances :: ![InstanceInfo],
+    compileStateAxioms :: !AxiomInterface,
     compileStateNewtypes :: !NewtypeInterface,
     compileStateGrin :: !Grin.GrinInterface,
     compileStateReachability :: !ReachabilityInterface,
@@ -722,11 +703,9 @@ toStoredArtifact includeUnits artifact =
   StoredDependencyArtifact
     { storedSchemaVersion = cacheSchemaVersion,
       storedExports = toStoredExports (dependencyExports artifact),
-      storedTerms = dependencyTerms artifact,
-      storedTyCons = dependencyTyCons artifact,
-      storedClasses = dependencyClasses artifact,
+      storedTcInterface = dependencyTcInterface artifact,
       storedBindings = dependencyBindings artifact,
-      storedInstances = dependencyInstances artifact,
+      storedAxiomInterface = dependencyAxiomInterface artifact,
       storedNewtypeInterface = dependencyNewtypeInterface artifact,
       storedGrinInterface = dependencyGrinInterface artifact,
       storedReachabilityInterface = dependencyReachabilityInterface artifact,
@@ -740,11 +719,9 @@ fromStoredArtifact :: StoredDependencyArtifact -> DependencyArtifact
 fromStoredArtifact stored =
   DependencyArtifact
     { dependencyExports = fromStoredExports (storedExports stored),
-      dependencyTerms = storedTerms stored,
-      dependencyTyCons = storedTyCons stored,
-      dependencyClasses = storedClasses stored,
+      dependencyTcInterface = storedTcInterface stored,
       dependencyBindings = storedBindings stored,
-      dependencyInstances = storedInstances stored,
+      dependencyAxiomInterface = storedAxiomInterface stored,
       dependencyNewtypeInterface = storedNewtypeInterface stored,
       dependencyGrinInterface = storedGrinInterface stored,
       dependencyReachabilityInterface = storedReachabilityInterface stored,

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -71,24 +71,20 @@ import Aihc.Resolve
     resolveWithDeps,
   )
 import Aihc.Tc
-  ( ClassInfo (..),
-    InstanceInfo (..),
-    Pred (..),
+  ( Pred (..),
     TcBindingResult (..),
     TcDiagnostic (..),
+    TcInterface,
     TcSeverity (..),
     TcType (..),
     TyCon (..),
-    TyConInfo (..),
     TyVarId (..),
-    TypeScheme (..),
     Unique (..),
     renderTcType,
     tcModuleBindings,
     tcModuleDiagnostics,
-    tcModuleInstances,
     tcModuleSuccess,
-    typecheckModulesWithClassEnv,
+    typecheckModulesWithInterface,
   )
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar)
@@ -250,10 +246,7 @@ data InterfaceBuildResult = InterfaceBuildResult
     interfaceResolveDiagnostics :: ![Aeson.Value],
     interfaceTcDiagnostics :: ![Aeson.Value],
     interfaceTcModules :: ![Aeson.Value],
-    interfaceTcTerms :: ![(Text, TypeScheme)],
-    interfaceTcTyCons :: ![TyConInfo],
-    interfaceTcClasses :: ![ClassInfo],
-    interfaceTcInstances :: ![InstanceInfo],
+    interfaceTcInterface :: !TcInterface,
     interfaceTcBindings :: ![TcBindingResult],
     interfaceFcDiagnostics :: ![Aeson.Value],
     interfaceFcModules :: ![Aeson.Value]
@@ -798,12 +791,9 @@ prepareInstallScaffoldUncached cache plan = do
       let preparedDependencies = rights dependencyResults
           depExports = foldl' Map.union Map.empty (map (interfaceModuleExports . preparedInterface) preparedDependencies)
           dependencyInterfaces = map preparedInterface preparedDependencies
-          importedTerms = mergeTermSchemes (map interfaceTcTerms dependencyInterfaces)
-          importedTyCons = mergeBy tciName (map interfaceTcTyCons dependencyInterfaces)
-          importedClasses = mergeBy ciName (map interfaceTcClasses dependencyInterfaces)
-          importedInstances = mergeBy iiDictName (map interfaceTcInstances dependencyInterfaces)
+          importedTcInterface = mconcat (map interfaceTcInterface dependencyInterfaces)
           importedBindings = mergeBy tbName (map interfaceTcBindings dependencyInterfaces)
-      interfaceResult <- generatePackageInterface depExports importedTerms importedTyCons importedClasses importedInstances importedBindings plan
+      interfaceResult <- generatePackageInterface depExports importedTcInterface importedBindings plan
       pure $
         case blockingInterfaceFailures interfaceResult of
           [] ->
@@ -820,9 +810,6 @@ firstLeft :: [Either a b] -> Maybe a
 firstLeft [] = Nothing
 firstLeft (Left value : _) = Just value
 firstLeft (Right _ : rest) = firstLeft rest
-
-mergeTermSchemes :: [[(Text, TypeScheme)]] -> [(Text, TypeScheme)]
-mergeTermSchemes = Map.toAscList . Map.fromList . concat
 
 mergeBy :: (Ord key) => (value -> key) -> [[value]] -> [value]
 mergeBy key = Map.elems . Map.fromList . map (\value -> (key value, value)) . concat
@@ -1262,8 +1249,8 @@ fcArtifactValue plan result =
       "modules" .= interfaceFcModules result
     ]
 
-generatePackageInterface :: ModuleExports -> [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [TcBindingResult] -> PackagePlan -> IO InterfaceBuildResult
-generatePackageInterface depExports importedTerms importedTyCons importedClasses importedInstances importedBindings plan = do
+generatePackageInterface :: ModuleExports -> TcInterface -> [TcBindingResult] -> PackagePlan -> IO InterfaceBuildResult
+generatePackageInterface depExports importedTcInterface importedBindings plan = do
   gpd <- readPlanPackageDescription plan
   files <- HackageCabal.collectLibraryFiles gpd (planSourcePath plan)
   parsedFiles <- mapM (parseInterfaceFile (planSourcePath plan)) files
@@ -1275,8 +1262,8 @@ generatePackageInterface depExports importedTerms importedTyCons importedClasses
       resolveResult = resolveWithDeps depExports parsedModules
       exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
       ownExports = Map.restrictKeys (extractInterface resolveResult) exposedModules
-  (checkedModules, tcModules, tcDiagnostics, tcTerms, tcTyCons, tcClasses, tcInstances) <-
-    typecheckInterfaceModules importedTerms importedTyCons importedClasses importedInstances (resolvedModules resolveResult)
+  (checkedModules, tcModules, tcDiagnostics, tcInterface) <-
+    typecheckInterfaceModules importedTcInterface (resolvedModules resolveResult)
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
@@ -1295,36 +1282,32 @@ generatePackageInterface depExports importedTerms importedTyCons importedClasses
         interfaceResolveDiagnostics = resolveDiagnostics,
         interfaceTcDiagnostics = enrichedTcDiagnostics,
         interfaceTcModules = enrichedTcModules,
-        interfaceTcTerms = tcTerms,
-        interfaceTcTyCons = tcTyCons,
-        interfaceTcClasses = tcClasses,
-        interfaceTcInstances = tcInstances,
+        interfaceTcInterface = tcInterface,
         interfaceTcBindings = allBindings,
         interfaceFcDiagnostics = fcDiagnostics,
         interfaceFcModules = fcModules
       }
 
-typecheckInterfaceModules :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], [(Text, TypeScheme)], [TyConInfo], [ClassInfo], [InstanceInfo])
-typecheckInterfaceModules importedTerms importedTyCons importedClasses importedInstances modules = do
+typecheckInterfaceModules :: TcInterface -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], TcInterface)
+typecheckInterfaceModules importedTcInterface modules = do
   currentModule <- newIORef (listToMaybe sortedModules)
   result <- timeout typecheckPhaseTimeoutMicros (go currentModule)
   case result of
-    Just (checkedModules, tcModules, tcTerms, tcTyCons, tcClasses, tcInstances) ->
-      pure (checkedModules, tcModules, concatMap tcModuleDiagnosticValues tcModules, tcTerms, tcTyCons, tcClasses, tcInstances)
+    Just (checkedModules, tcModules, tcInterface) ->
+      pure (checkedModules, tcModules, concatMap tcModuleDiagnosticValues tcModules, tcInterface)
     Nothing -> do
       current <- readIORef currentModule
-      pure ([], [], [typecheckTimeoutDiagnostic current], [], [], [], [])
+      pure ([], [], [typecheckTimeoutDiagnostic current], mempty)
   where
     sortedModules = sortModulesByImports modules
     go current = do
       mapM_ (writeIORef current . Just) sortedModules
-      let (checkedModules, tcTerms, tcTyCons, tcClasses) =
-            typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses importedInstances sortedModules
+      let (checkedModules, tcInterface) =
+            typecheckModulesWithInterface importedTcInterface sortedModules
           tcModules = zipWith tcModuleValue sortedModules checkedModules
-          tcInstances = mergeBy iiDictName [importedInstances, concatMap tcModuleInstances checkedModules]
       _ <- evaluate (forceJsonValue (Aeson.toJSON tcModules))
-      length (show (tcTerms, tcTyCons, tcClasses, tcInstances)) `seq`
-        pure (checkedModules, tcModules, tcTerms, tcTyCons, tcClasses, tcInstances)
+      length (show tcInterface) `seq`
+        pure (checkedModules, tcModules, tcInterface)
 
 sortModulesByImports :: [Module] -> [Module]
 sortModulesByImports modules = reverse sorted

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -12,6 +12,7 @@ synopsis: System FC core language with desugaring and lint
 library
   exposed-modules:
     Aihc.Fc
+    Aihc.Fc.Axiom
     Aihc.Fc.DeadCode
     Aihc.Fc.Desugar
     Aihc.Fc.Desugar.Expr

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -35,9 +35,13 @@ module Aihc.Fc
     NewtypeInterface,
     extractNewtypeInterface,
     lowerNewtypesWithInterface,
+    AxiomInterface,
+    extractAxiomInterface,
+    lookupAxiomDecl,
 
     -- * Lint
     lintProgram,
+    lintProgramWithAxiomInterface,
     lintExpr,
     LintError (..),
     LintEnv (..),
@@ -51,10 +55,11 @@ module Aihc.Fc
   )
 where
 
+import Aihc.Fc.Axiom (AxiomInterface, extractAxiomInterface, lookupAxiomDecl)
 import Aihc.Fc.DeadCode (ReachabilityInterface, eliminateDeadCode, extractReachabilityInterface, reachablePrimitiveNames)
 import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
-import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram)
+import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram, lintProgramWithAxiomInterface)
 import Aihc.Fc.Newtype (NewtypeInterface, extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
 import Aihc.Fc.Optimize (optimizeProgram)
 import Aihc.Fc.Pretty (renderExpr, renderProgram, renderTopBind, renderType)

--- a/components/aihc-fc/src/Aihc/Fc/Axiom.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Axiom.hs
@@ -1,0 +1,54 @@
+-- | Type equality axioms exported across incremental compilation boundaries.
+module Aihc.Fc.Axiom
+  ( AxiomInterface,
+    extractAxiomInterface,
+    lookupAxiomDecl,
+  )
+where
+
+import Aihc.Fc.Syntax
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+-- | Equality declarations indexed by the names used in 'AxiomInstCo'.
+-- Local declarations take precedence when interfaces are combined.
+newtype AxiomInterface = AxiomInterface
+  { axiomsByName :: Map Text FcAxiomDecl
+  }
+  deriving (Eq, Show, Read)
+
+instance Semigroup AxiomInterface where
+  AxiomInterface left <> AxiomInterface right = AxiomInterface (right <> left)
+
+instance Monoid AxiomInterface where
+  mempty = AxiomInterface Map.empty
+
+-- | Collect explicit axioms and the implicit representational axioms carried
+-- by newtype declarations.
+extractAxiomInterface :: FcProgram -> AxiomInterface
+extractAxiomInterface (FcProgram topBinds) =
+  AxiomInterface
+    ( Map.fromList
+        [ (fcAxiomName declaration, declaration)
+        | topBind <- topBinds,
+          declaration <- axiomDeclarations topBind
+        ]
+    )
+  where
+    axiomDeclarations topBind =
+      case topBind of
+        FcAxiom declaration -> [declaration]
+        FcNewtype declaration ->
+          [ FcAxiomDecl
+              { fcAxiomName = fcNewtypeName declaration,
+                fcAxiomTyVars = fcNewtypeTyVars declaration,
+                fcAxiomRole = FcRepresentational,
+                fcAxiomLeft = fcNewtypeResult declaration,
+                fcAxiomRight = fcNewtypeRepresentation declaration
+              }
+          ]
+        _ -> []
+
+lookupAxiomDecl :: Text -> AxiomInterface -> Maybe FcAxiomDecl
+lookupAxiomDecl name = Map.lookup name . axiomsByName

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -125,6 +125,7 @@ keepTopBind :: Map Text (Int, References) -> Map Text (Int, References) -> Set T
 keepTopBind valueDefinitions typeDefinitions values types index topBind =
   case topBind of
     FcData name _ _ -> selectedType name
+    FcAxiom declaration -> selectedType (fcAxiomName declaration)
     FcNewtype declaration -> selectedType (fcNewtypeName declaration)
     _ -> any selectedValue [name | (name, _) <- valueDefinitionsOf topBind]
   where
@@ -138,12 +139,19 @@ valueDefinitionsOf topBind =
     FcForeignImport foreignCall -> [(fcForeignCallName foreignCall, mempty)]
     FcTopBind bind -> [(varName var, referencesTopLevelBind bind) | var <- bindersOf bind]
     FcData {} -> []
+    FcAxiom {} -> []
     FcNewtype {} -> []
 
 typeDefinitionsOf :: FcTopBind -> [(Text, References)]
 typeDefinitionsOf topBind =
   case topBind of
     FcData name _ constructors -> [(name, foldMap (foldMap referencesType . snd) constructors)]
+    FcAxiom declaration ->
+      [ ( fcAxiomName declaration,
+          referencesType (fcAxiomLeft declaration)
+            <> referencesType (fcAxiomRight declaration)
+        )
+      ]
     FcNewtype declaration ->
       [ ( fcNewtypeName declaration,
           referencesType (fcNewtypeRepresentation declaration)
@@ -156,6 +164,7 @@ typeConstructorsOf :: FcTopBind -> [(Text, [Text])]
 typeConstructorsOf topBind =
   case topBind of
     FcData name _ constructors -> [(name, map fst constructors)]
+    FcAxiom {} -> []
     FcNewtype declaration -> [(fcNewtypeName declaration, [fcNewtypeConstructor declaration])]
     _ -> []
 

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -129,6 +129,12 @@ lowerConstraintProgram (FcProgram topBinds) =
       case topBind of
         FcData name tyVars constructors ->
           FcData name tyVars [(constructor, map lowerConstraintType fields) | (constructor, fields) <- constructors]
+        FcAxiom declaration ->
+          FcAxiom
+            declaration
+              { fcAxiomLeft = lowerConstraintType (fcAxiomLeft declaration),
+                fcAxiomRight = lowerConstraintType (fcAxiomRight declaration)
+              }
         FcNewtype declaration ->
           FcNewtype
             declaration

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -15,6 +15,7 @@
 module Aihc.Fc.Lint
   ( -- * Lint
     lintProgram,
+    lintProgramWithAxiomInterface,
     lintExpr,
 
     -- * Errors
@@ -26,6 +27,7 @@ module Aihc.Fc.Lint
   )
 where
 
+import Aihc.Fc.Axiom (AxiomInterface, extractAxiomInterface, lookupAxiomDecl)
 import Aihc.Fc.Subst (freeRigidTyVarsOf, substType)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Evidence (Coercion (..))
@@ -60,8 +62,8 @@ data LintEnv = LintEnv
     leTyVars :: !(Set TyVarId),
     -- | Known data constructors: name -> (type var params, field types, result type).
     leDataCons :: !(Map Text ([TyVarId], [TcType], TcType)),
-    -- | Representational equality axioms introduced by newtypes.
-    leNewtypes :: !(Map Text FcNewtypeDecl),
+    -- | Type equality axioms visible to coercion linting.
+    leAxioms :: !AxiomInterface,
     leForeignCalls :: !(Map Text FcForeignCall)
   }
   deriving (Show)
@@ -73,18 +75,25 @@ emptyLintEnv =
     { leTerms = Map.empty,
       leTyVars = Set.empty,
       leDataCons = Map.empty,
-      leNewtypes = Map.empty,
+      leAxioms = mempty,
       leForeignCalls = Map.empty
     }
 
 -- | Lint an entire program.
 lintProgram :: LintEnv -> FcProgram -> [LintError]
-lintProgram env0 prog = go envWithDeclarations (fcTopBinds prog)
-  where
-    envWithDeclarations = foldr registerDeclaration env0 (fcTopBinds prog)
+lintProgram = lintProgramWithAxiomInterface mempty
 
-    registerDeclaration (FcNewtype declaration) env =
-      env {leNewtypes = Map.insert (fcNewtypeName declaration) declaration (leNewtypes env)}
+-- | Lint a program with equality axioms imported from independently compiled
+-- units. Local declarations take precedence over imported declarations.
+lintProgramWithAxiomInterface :: AxiomInterface -> LintEnv -> FcProgram -> [LintError]
+lintProgramWithAxiomInterface imported env0 prog = go envWithDeclarations (fcTopBinds prog)
+  where
+    envWithDeclarations =
+      foldr
+        registerDeclaration
+        env0 {leAxioms = leAxioms env0 <> imported <> extractAxiomInterface prog}
+        (fcTopBinds prog)
+
     registerDeclaration (FcData typeName tyVars constructors) env =
       env
         { leDataCons =
@@ -105,6 +114,9 @@ lintProgram env0 prog = go envWithDeclarations (fcTopBinds prog)
     go _ [] = []
     go env (FcData {} : rest) =
       -- Data declarations don't need expression-level linting.
+      go env rest
+    go env (FcAxiom {} : rest) =
+      -- Axiom declarations don't need expression-level linting.
       go env rest
     go env (FcNewtype {} : rest) =
       -- Newtype declarations don't need expression-level linting.
@@ -245,16 +257,16 @@ coercionEndpoints env (TyConAppCo tc coercions) = do
   pairs <- mapM (coercionEndpoints env) coercions
   Right (TcTyCon tc (map fst pairs), TcTyCon tc (map snd pairs))
 coercionEndpoints env (AxiomInstCo name typeArgs) =
-  case Map.lookup name (leNewtypes env) of
-    Nothing -> Left (LintFailure ("unknown newtype axiom: " ++ show name))
+  case lookupAxiomDecl name (leAxioms env) of
+    Nothing -> Left (LintFailure ("unknown coercion axiom: " ++ show name))
     Just declaration
-      | length typeArgs /= length (fcNewtypeTyVars declaration) ->
-          Left (LintFailure ("newtype axiom arity mismatch: " ++ show name))
+      | length typeArgs /= length (fcAxiomTyVars declaration) ->
+          Left (LintFailure ("coercion axiom arity mismatch: " ++ show name))
       | otherwise ->
-          let substitution = Map.fromList (zip (fcNewtypeTyVars declaration) typeArgs)
+          let substitution = Map.fromList (zip (fcAxiomTyVars declaration) typeArgs)
            in Right
-                ( substType substitution (fcNewtypeResult declaration),
-                  substType substitution (fcNewtypeRepresentation declaration)
+                ( substType substitution (fcAxiomLeft declaration),
+                  substType substitution (fcAxiomRight declaration)
                 )
 
 -- | Extend the term environment with a variable.

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -48,6 +48,19 @@ renderTopBind (FcData tyName tyVars cons) =
     ++ T.unpack tyName
     ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) tyVars
     ++ renderDataCons tyVars cons
+renderTopBind (FcAxiom declaration) =
+  "axiom "
+    ++ T.unpack (fcAxiomName declaration)
+    ++ concatMap (\tv -> " " ++ T.unpack (tvName tv)) (fcAxiomTyVars declaration)
+    ++ " : "
+    ++ renderType (fcAxiomLeft declaration)
+    ++ roleEquality (fcAxiomRole declaration)
+    ++ renderType (fcAxiomRight declaration)
+  where
+    roleEquality role =
+      case role of
+        FcNominal -> " ~N "
+        FcRepresentational -> " ~R "
 renderTopBind (FcNewtype declaration) =
   "newtype "
     ++ T.unpack (fcNewtypeName declaration)

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -22,6 +22,8 @@ module Aihc.Fc.Syntax
     -- * Bindings
     FcBind (..),
     FcTopBind (..),
+    FcAxiomDecl (..),
+    FcAxiomRole (..),
     FcNewtypeDecl (..),
     FcProgram (..),
     FcForeignCall (..),
@@ -68,6 +70,9 @@ data FcTopBind
   = -- | Data type declaration: type name, type variable parameters,
     -- list of (constructor name, field types).
     FcData !Text ![TyVarId] ![(Text, [TcType])]
+  | -- | A type equality axiom. Axioms are proof metadata and have no
+    -- runtime representation.
+    FcAxiom !FcAxiomDecl
   | -- | A nominal type with a representational equality axiom.
     FcNewtype !FcNewtypeDecl
   | -- | A primitive imported by @foreign import prim@.
@@ -77,6 +82,22 @@ data FcTopBind
     FcForeignImport !FcForeignCall
   | -- | Value binding.
     FcTopBind !FcBind
+  deriving (Eq, Show, Read)
+
+-- | The role at which an axiom proves equality.
+data FcAxiomRole
+  = FcNominal
+  | FcRepresentational
+  deriving (Eq, Show, Read)
+
+-- | A named, parameterized type equality retained in System FC.
+data FcAxiomDecl = FcAxiomDecl
+  { fcAxiomName :: !Text,
+    fcAxiomTyVars :: ![TyVarId],
+    fcAxiomRole :: !FcAxiomRole,
+    fcAxiomLeft :: !TcType,
+    fcAxiomRight :: !TcType
+  }
   deriving (Eq, Show, Read)
 
 -- | The type-level information retained for a @newtype@ after its constructor

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -17,7 +17,7 @@ import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Data.Text (Text)
 import FcGolden
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
 
 -- | Build the golden test tree from fixtures.
 fcGoldenTests :: IO TestTree
@@ -235,6 +235,48 @@ fcOptimizationTests =
           "consumer body"
           loweredConsumer
           (lowerNewtypesWithInterface (extractNewtypeInterface provider) consumer)
+        assertEqual
+          "consumer lint"
+          []
+          (lintProgramWithAxiomInterface (extractAxiomInterface provider) emptyLintEnv loweredConsumer),
+      testCase "lints explicit equality axioms" $ do
+        let familyTy = ty "Family"
+            representationTy = ty "Int#"
+            declaration =
+              FcAxiomDecl
+                { fcAxiomName = "axFamily",
+                  fcAxiomTyVars = [],
+                  fcAxiomRole = FcNominal,
+                  fcAxiomLeft = familyTy,
+                  fcAxiomRight = representationTy
+                }
+            value = Var "main" (Unique 40) familyTy
+            binding = FcTopBind (FcNonRec value (FcCast (FcLit (LitInt IntRep 42)) (Sym (AxiomInstCo "axFamily" []))))
+            program = FcProgram [FcAxiom declaration, binding]
+        assertEqual "Core lint" [] (lintProgram emptyLintEnv program)
+        assertEqual "reachable axiom" program (eliminateDeadCode "main" program)
+        assertEqual "pretty axiom" "axiom axFamily : Family ~N Int#" (renderTopBind (FcAxiom declaration)),
+      testCase "imports equality axioms across compilation units" $ do
+        let parameter = TyVarId "a" (Unique 42)
+            representationTy = ty "Int#"
+            familyTy argument = TcTyCon (TyCon "Family" 1) [argument]
+            declaration =
+              FcAxiomDecl
+                { fcAxiomName = "axFamily",
+                  fcAxiomTyVars = [parameter],
+                  fcAxiomRole = FcRepresentational,
+                  fcAxiomLeft = familyTy (TcTyVar parameter),
+                  fcAxiomRight = TcTyVar parameter
+                }
+            value = Var "main" (Unique 41) (familyTy representationTy)
+            provider = FcProgram [FcAxiom declaration]
+            consumer = FcProgram [FcTopBind (FcNonRec value (FcCast (FcLit (LitInt IntRep 42)) (Sym (AxiomInstCo "axFamily" [representationTy]))))]
+            wrongArity = FcProgram [FcTopBind (FcNonRec value (FcCast (FcLit (LitInt IntRep 42)) (Sym (AxiomInstCo "axFamily" []))))]
+            interface = extractAxiomInterface provider
+        assertBool "consumer needs imported axiom" (not (null (lintProgram emptyLintEnv consumer)))
+        assertBool "axiom arity is checked" (not (null (lintProgramWithAxiomInterface interface emptyLintEnv wrongArity)))
+        assertEqual "consumer lint" [] (lintProgramWithAxiomInterface interface emptyLintEnv consumer)
+        assertEqual "serialized interface" interface (read (show interface))
     ]
 
 fcEvalFixtureTests :: IO TestTree

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -191,6 +191,8 @@ lowerTopBind topBind =
   case topBind of
     FcData _ _ constructors ->
       pure mempty {loweredConstructors = [(name, map (runtimeRepComponents . typeRuntimeRep) fields) | (name, fields) <- constructors]}
+    FcAxiom {} ->
+      pure mempty
     FcNewtype {} ->
       pure mempty
     FcPrimitive var arity ->
@@ -1418,6 +1420,7 @@ programGlobalNames program = concatMap topGlobalNames (fcTopBinds program)
     topGlobalNames topBind =
       case topBind of
         FcData _ _ constructors -> map fst constructors
+        FcAxiom {} -> []
         FcNewtype {} -> []
         FcPrimitive {} -> []
         FcForeignImport {} -> []
@@ -1447,6 +1450,7 @@ programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds progra
     topWhnfGlobalNames topBind =
       case topBind of
         FcData _ _ constructors -> map fst constructors
+        FcAxiom {} -> []
         FcNewtype {} -> []
         FcPrimitive {} -> []
         FcForeignImport {} -> []
@@ -1538,6 +1542,7 @@ topVars :: FcTopBind -> [Var]
 topVars topBind =
   case topBind of
     FcData {} -> []
+    FcAxiom {} -> []
     FcNewtype {} -> []
     FcPrimitive var _ -> [var]
     FcForeignImport {} -> []

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -25,10 +25,14 @@ module Aihc.Tc
     typecheckModuleSccWithFullEnv,
     typecheckModulesWithClassEnv,
     typecheckModuleSccWithClassEnv,
+    typecheckModulesWithInterface,
+    typecheckModuleSccWithInterface,
 
     -- * Result types
     TcResult (..),
     TcBindingResult (..),
+    TcInterface (..),
+    emptyTcInterface,
 
     -- * Module result projections
     tcModuleBindings,
@@ -130,6 +134,41 @@ data TcResult = TcResult
   }
   deriving (Show)
 
+-- | The complete semantic interface shared between independently checked
+-- module groups. Implementations never cross this boundary: only the facts
+-- needed to type-check downstream source are retained.
+data TcInterface = TcInterface
+  { tcInterfaceTerms :: ![(Text, TypeScheme)],
+    tcInterfaceTyCons :: ![TyConInfo],
+    tcInterfaceClasses :: ![ClassInfo],
+    tcInterfaceInstances :: ![InstanceInfo]
+  }
+  deriving (Show, Read)
+
+emptyTcInterface :: TcInterface
+emptyTcInterface =
+  TcInterface
+    { tcInterfaceTerms = [],
+      tcInterfaceTyCons = [],
+      tcInterfaceClasses = [],
+      tcInterfaceInstances = []
+    }
+
+instance Semigroup TcInterface where
+  left <> right =
+    TcInterface
+      { tcInterfaceTerms = mergeInterfaceEntries fst (tcInterfaceTerms left <> tcInterfaceTerms right),
+        tcInterfaceTyCons = mergeInterfaceEntries tciName (tcInterfaceTyCons left <> tcInterfaceTyCons right),
+        tcInterfaceClasses = mergeInterfaceEntries ciName (tcInterfaceClasses left <> tcInterfaceClasses right),
+        tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcInterfaceInstances left <> tcInterfaceInstances right)
+      }
+
+instance Monoid TcInterface where
+  mempty = emptyTcInterface
+
+mergeInterfaceEntries :: (Ord key) => (value -> key) -> [value] -> [value]
+mergeInterfaceEntries key = Map.elems . Map.fromList . map (\value -> (key value, value))
+
 -- | Type-check a single expression in an empty environment.
 --
 -- This is the primary entry point for testing. For full module
@@ -220,48 +259,48 @@ typecheckModulesWithEnv importedTerms =
 -- | Type-check modules in order with preloaded terms and class instances.
 typecheckModulesWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> [Module] -> [Module]
 typecheckModulesWithEnvAndInstances importedTerms importedInstances =
-  firstOfThree . typecheckModulesWithFullEnv importedTerms [] importedInstances
-
-firstOfThree :: (a, b, c) -> a
-firstOfThree (first, _, _) = first
+  fst
+    . typecheckModulesWithInterface
+      emptyTcInterface
+        { tcInterfaceTerms = importedTerms,
+          tcInterfaceInstances = importedInstances
+        }
 
 -- | Type-check modules with a complete imported type-checker interface and
 -- return the accumulated term schemes and type constructors for downstream
 -- modules.
 typecheckModulesWithFullEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo])
 typecheckModulesWithFullEnv importedTerms importedTyCons importedInstances modules =
-  let (checkedModules, terms, tyCons, _) = typecheckModulesWithClassEnv importedTerms importedTyCons [] importedInstances modules
-   in (checkedModules, terms, tyCons)
+  let (checkedModules, interface) =
+        typecheckModulesWithInterface
+          emptyTcInterface
+            { tcInterfaceTerms = importedTerms,
+              tcInterfaceTyCons = importedTyCons,
+              tcInterfaceInstances = importedInstances
+            }
+          modules
+   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface)
 
 typecheckModulesWithClassEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo], [ClassInfo])
 typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses importedInstances modules =
-  let (checkedModules, finalState) = go initState modules
-   in ( checkedModules,
-        [ (name, scheme)
-        | (name, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms finalState)
-        ],
-        Map.elems (tcsGlobalTyCons finalState),
-        Map.elems (tcsClasses finalState)
-      )
-  where
-    initState =
-      initTcState
-        { tcsGlobalTerms =
-            Map.fromList
-              [ (name, TcIdBinder scheme Closed)
-              | (name, scheme) <- importedTerms
-              ]
-              <> tcsGlobalTerms initTcState,
-          tcsGlobalTyCons =
-            Map.fromList
-              [ (tciName tyCon, tyCon)
-              | tyCon <- importedTyCons
-              ]
-              <> tcsGlobalTyCons initTcState,
-          tcsClasses = Map.fromList [(ciName classInfo, classInfo) | classInfo <- importedClasses],
-          tcsInstances = importedInstances
-        }
+  let (checkedModules, interface) =
+        typecheckModulesWithInterface
+          TcInterface
+            { tcInterfaceTerms = importedTerms,
+              tcInterfaceTyCons = importedTyCons,
+              tcInterfaceClasses = importedClasses,
+              tcInterfaceInstances = importedInstances
+            }
+          modules
+   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
 
+-- | Type-check dependency-ordered modules with a complete imported semantic
+-- interface and return the accumulated interface for downstream modules.
+typecheckModulesWithInterface :: TcInterface -> [Module] -> ([Module], TcInterface)
+typecheckModulesWithInterface imported modules =
+  let (checkedModules, finalState) = go (initialTcState imported) modules
+   in (checkedModules, tcInterfaceFromState finalState)
+  where
     go st [] = ([], st)
     go st (m : ms) =
       let (result, st') = typecheckModuleWithState st m
@@ -273,38 +312,65 @@ typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses import
 -- implementations from predecessor components are never consumed.
 typecheckModuleSccWithFullEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo])
 typecheckModuleSccWithFullEnv importedTerms importedTyCons importedInstances modules =
-  let (checkedModules, terms, tyCons, _) = typecheckModuleSccWithClassEnv importedTerms importedTyCons [] importedInstances modules
-   in (checkedModules, terms, tyCons)
+  let (checkedModules, interface) =
+        typecheckModuleSccWithInterface
+          emptyTcInterface
+            { tcInterfaceTerms = importedTerms,
+              tcInterfaceTyCons = importedTyCons,
+              tcInterfaceInstances = importedInstances
+            }
+          modules
+   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface)
 
 typecheckModuleSccWithClassEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo], [ClassInfo])
 typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses importedInstances modules =
-  let initState = initialTcState importedTerms importedTyCons importedClasses importedInstances
-      (checkedModules, finalState) = typecheckModuleSccWithState initState modules
-   in ( checkedModules,
-        [ (name, scheme)
-        | (name, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms finalState)
-        ],
-        Map.elems (tcsGlobalTyCons finalState),
-        Map.elems (tcsClasses finalState)
-      )
+  let (checkedModules, interface) =
+        typecheckModuleSccWithInterface
+          TcInterface
+            { tcInterfaceTerms = importedTerms,
+              tcInterfaceTyCons = importedTyCons,
+              tcInterfaceClasses = importedClasses,
+              tcInterfaceInstances = importedInstances
+            }
+          modules
+   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
 
-initialTcState :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> TcState
-initialTcState importedTerms importedTyCons importedClasses importedInstances =
+-- | Type-check one strongly connected module component using only the
+-- supplied imported interface.
+typecheckModuleSccWithInterface :: TcInterface -> [Module] -> ([Module], TcInterface)
+typecheckModuleSccWithInterface imported modules =
+  let (checkedModules, finalState) = typecheckModuleSccWithState (initialTcState imported) modules
+   in (checkedModules, tcInterfaceFromState finalState)
+
+initialTcState :: TcInterface -> TcState
+initialTcState imported =
   initTcState
     { tcsGlobalTerms =
         Map.fromList
           [ (name, TcIdBinder scheme Closed)
-          | (name, scheme) <- importedTerms
+          | (name, scheme) <- tcInterfaceTerms imported
           ]
           <> tcsGlobalTerms initTcState,
       tcsGlobalTyCons =
         Map.fromList
           [ (tciName tyCon, tyCon)
-          | tyCon <- importedTyCons
+          | tyCon <- tcInterfaceTyCons imported
           ]
           <> tcsGlobalTyCons initTcState,
-      tcsClasses = Map.fromList [(ciName classInfo, classInfo) | classInfo <- importedClasses],
-      tcsInstances = importedInstances
+      tcsClasses = Map.fromList [(ciName classInfo, classInfo) | classInfo <- tcInterfaceClasses imported],
+      tcsInstances = tcInterfaceInstances imported
+    }
+
+tcInterfaceFromState :: TcState -> TcInterface
+tcInterfaceFromState state =
+  TcInterface
+    { tcInterfaceTerms =
+        [ (name, scheme)
+        | (name, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms state)
+        ],
+      tcInterfaceTyCons = Map.elems (tcsGlobalTyCons state),
+      tcInterfaceClasses = Map.elems (tcsClasses state),
+      tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcsInstances state)
     }
 
 typecheckModuleSccWithState :: TcState -> [Module] -> ([Module], TcState)

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -317,7 +317,39 @@ kindTests =
             ResolveResult {resolveErrors} ->
               assertFailure ("Resolve error in imported-type test: " <> show resolveErrors)
         ResolveResult {resolveErrors} ->
-          assertFailure ("Resolve error in dependency-type test: " <> show resolveErrors)
+          assertFailure ("Resolve error in dependency-type test: " <> show resolveErrors),
+    testCase "transports a complete semantic interface between module groups" $ do
+      let baseResult =
+            resolve
+              [ parseOnly
+                  "module Base (Unit(..), Identity(..)) where\n\
+                  \data Unit = Unit\n\
+                  \class Identity a where\n\
+                  \  identity :: a -> a\n\
+                  \instance Identity Unit where\n\
+                  \  identity value = value\n"
+              ]
+          depExports = extractInterface baseResult
+      case baseResult of
+        ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
+          let (checkedBase, interface) = typecheckModuleSccWithInterface mempty baseModules
+          assertBool "dependency should typecheck" (all tcModuleSuccess checkedBase)
+          assertBool "constructor term exported" ("Unit" `elem` map fst (tcInterfaceTerms interface))
+          assertBool "method term exported" ("identity" `elem` map fst (tcInterfaceTerms interface))
+          assertBool "type constructor exported" ("Unit" `elem` map tciName (tcInterfaceTyCons interface))
+          assertBool "class exported" ("Identity" `elem` map ciName (tcInterfaceClasses interface))
+          assertBool "instance exported" ("$fIdentityUnit" `elem` map iiDictName (tcInterfaceInstances interface))
+          let target = parseOnly "module Test where\nimport Base\nanswer :: Unit\nanswer = identity Unit\n"
+          case resolveWithDeps depExports [target] of
+            ResolveResult {resolvedModules = targetModules, resolveErrors = []} -> do
+              let (checkedTarget, _) = typecheckModuleSccWithInterface interface targetModules
+              assertBool
+                ("consumer should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedTarget))
+                (all tcModuleSuccess checkedTarget)
+            ResolveResult {resolveErrors} ->
+              assertFailure ("Resolve error in semantic-interface consumer: " <> show resolveErrors)
+        ResolveResult {resolveErrors} ->
+          assertFailure ("Resolve error in semantic-interface provider: " <> show resolveErrors)
   ]
   where
     isKindMismatch diag =


### PR DESCRIPTION
## Summary

- replace positional type-checker dependency environments with a serializable `TcInterface` record and use it throughout installation and compilation
- add role-annotated System FC equality declarations plus an `AxiomInterface` that supports local and imported coercion linting
- synthesize generalized axiom entries for existing newtypes, preserving their representational casts
- persist TC and axiom interfaces in installed dependency artifacts and bump the cache schema to 28
- teach FC pretty-printing, dead-code elimination, constraint lowering, and GRIN lowering about proof-only axiom declarations

## Why

Data-family declarations and instances need semantic facts to cross module, package, and cache boundaries without adding another set of positional parameters at every compiler call site. They also need their representation equations to survive in System FC as named coercion axioms.

This PR establishes those two extensible boundaries first. A follow-up can add data-family facts to `TcInterface` and emit `FcAxiom` declarations without redesigning installer or dependency-cache plumbing.

## Scope

This foundation does not yet parse or type-check data-family declarations or instances. It deliberately leaves source-language acceptance to the next PR.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options=--hide-successes`
- `cabal test -v0 aihc-fc:spec --test-options=--hide-successes`
- `cabal test -v0 aihc:spec --test-options=--hide-successes`
- `just fmt`
- `just check` after rebasing onto `origin/main`

## Progress counts

- `aihc-tc` tests: 99 -> 100
- `aihc-fc` tests: 137 -> 139
- No fixture progress-count changes; no README files updated.
