### PR TITLE
feat(fc): lower anyclass deriving dictionaries

### DIFF
--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -25,6 +25,11 @@ library
     Aihc.Fc.Subst
     Aihc.Fc.Syntax
 
+  other-modules:
+    Aihc.Fc.Desugar.Deriving
+    Aihc.Fc.Desugar.Deriving.AnyClass
+    Aihc.Fc.Desugar.Dictionary
+
   hs-source-dirs: src
   build-depends:
     aihc-parser,

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -13,6 +13,8 @@ module Aihc.Fc.Desugar
   )
 where
 
+import Aihc.Fc.Desugar.Deriving (dsDerivingPlans, moduleDerivingPlans)
+import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, peelForAlls, peelQuals, predType)
 import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsEvidence, dsMatches, dsMatchesWithEnclosingDicts, freshUnique, freshVar, lookupType, withDicts)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Newtype (lowerNewtypes)
@@ -226,10 +228,11 @@ dsModule m = do
   dataTops <- concat <$> mapM dsDecl decls
   -- Phase 2: instance dictionaries.
   instanceTops <- concat <$> mapM dsInstanceDecl (moduleInstances decls)
+  derivingTops <- dsDerivingPlans (moduleDerivingPlans decls)
   -- Phase 3: group and desugar value bindings.
   let grouped = groupFunctionBinds decls
   valueTops <- mapM dsGroup grouped
-  pure (dataTops ++ instanceTops ++ valueTops)
+  pure (dataTops ++ instanceTops ++ derivingTops ++ valueTops)
 
 -- | Desugar a single declaration (data types only; values handled by groups).
 dsDecl :: Decl -> DsM [FcTopBind]
@@ -820,23 +823,6 @@ zeroArgumentMatch rhs =
       matchRhs = rhs
     }
 
-defaultMethodName :: Text -> Text
-defaultMethodName methodName = "$dm" <> methodName
-
-peelForAlls :: TcType -> ([TyVarId], TcType)
-peelForAlls (TcForAllTy tv rest) =
-  let (tvs, inner) = peelForAlls rest
-   in (tv : tvs, inner)
-peelForAlls ty = ([], ty)
-
-peelQuals :: TcType -> ([Pred], TcType)
-peelQuals (TcQualTy preds body) = (preds, body)
-peelQuals ty = ([], ty)
-
-predType :: Pred -> TcType
-predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
-predType (EqPred left right) = TcTyCon (TyCon "~" 2) [left, right]
-
 dsInstanceDecl :: Decl -> DsM [FcTopBind]
 dsInstanceDecl decl =
   case decl of
@@ -934,28 +920,6 @@ classTypeVariables className methodType =
     (predicates, _) = peelQuals afterForAlls
     asTyVar (TcTyVar tyVar) = Just tyVar
     asTyVar _ = Nothing
-
-classMethodFieldType :: Text -> [TyVarId] -> TcType -> DsM TcType
-classMethodFieldType className classTyVars methodType = do
-  remainingPredicates <-
-    case removeClassPredicate predicates of
-      Just result -> pure result
-      Nothing -> desugarBug ("class method lacks its class predicate for " <> T.unpack className)
-  let extraTyVars = filter (`notElem` classTyVars) methodTyVars
-      qualifiedBody =
-        if null remainingPredicates
-          then body
-          else TcQualTy remainingPredicates body
-  pure (foldr TcForAllTy qualifiedBody extraTyVars)
-  where
-    (methodTyVars, afterForAlls) = peelForAlls methodType
-    (predicates, body) = peelQuals afterForAlls
-    removeClassPredicate [] = Nothing
-    removeClassPredicate (predicate : rest) =
-      case predicate of
-        ClassPred predicateClass _
-          | predicateClass == className -> Just rest
-        _ -> (predicate :) <$> removeClassPredicate rest
 
 mkContextDict :: Int -> TcDictBinderAnnotation -> DsM ClassDict
 mkContextDict ix dictAnn = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving.hs
@@ -1,0 +1,72 @@
+-- | Strategy dispatch and dependency grouping for derived dictionaries.
+module Aihc.Fc.Desugar.Deriving
+  ( dsDerivingPlans,
+    moduleDerivingPlans,
+  )
+where
+
+import Aihc.Fc.Desugar.Deriving.AnyClass (dsAnyClassDictionaryPlan)
+import Aihc.Fc.Desugar.Expr (DsM)
+import Aihc.Fc.Syntax (FcBind (..), FcTopBind (..))
+import Aihc.Parser.Syntax (Decl (..), fromAnnotation)
+import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingAnnotation (..), TcDerivingPlan (..), TcDerivingStrategy (..))
+import Aihc.Tc.Evidence (EvTerm (..))
+import Data.Graph (SCC (..), stronglyConnComp)
+import Data.Text (Text)
+
+dsDerivingPlans :: [TcDerivingPlan] -> DsM [FcTopBind]
+dsDerivingPlans plans =
+  mapM dsDerivingScc (stronglyConnComp planNodes)
+  where
+    anyClassPlans = filter ((== TcDerivingAnyclass) . tcDerivingStrategy) plans
+    planNodes =
+      [ (plan, tcDerivingDictName plan, derivingPlanDependencies plan)
+      | plan <- anyClassPlans
+      ]
+
+-- Evidence may make sibling dictionaries depend on one another regardless of
+-- their source order. Preserve acyclic dependency order and use recursive FC
+-- groups only for genuine cycles (including a default worker's self dictionary).
+dsDerivingScc :: SCC TcDerivingPlan -> DsM FcTopBind
+dsDerivingScc scc =
+  case scc of
+    AcyclicSCC plan -> do
+      (dictVar, body) <- dsAnyClassDictionaryPlan plan
+      pure (FcTopBind (FcNonRec dictVar body))
+    CyclicSCC plans -> do
+      bindings <- mapM dsAnyClassDictionaryPlan plans
+      pure (FcTopBind (FcRec bindings))
+
+derivingPlanDependencies :: TcDerivingPlan -> [Text]
+derivingPlanDependencies plan =
+  selfDependency
+    <> concatMap (evidenceDependencies . snd) (tcDerivingSuperClasses plan)
+    <> concatMap (concatMap evidenceDependencies . snd) (tcDerivingDefaultMethodEvidence plan)
+  where
+    selfDependency =
+      [ tcDerivingDictName plan
+      | any
+          ((`elem` tcDerivingDefaultMethods plan) . tcClassMethodName)
+          (tcDerivingClassMethods plan)
+      ]
+
+evidenceDependencies :: EvTerm -> [Text]
+evidenceDependencies evidence =
+  case evidence of
+    EvGiven {} -> []
+    EvDict dictName _ contextEvidence -> dictName : concatMap evidenceDependencies contextEvidence
+    EvCoercion {} -> []
+    EvSuperClass source _ _ _ -> evidenceDependencies source
+    EvCast source _ -> evidenceDependencies source
+    EvTypeable _ arguments -> concatMap evidenceDependencies arguments
+    EvVarTerm {} -> []
+
+moduleDerivingPlans :: [Decl] -> [TcDerivingPlan]
+moduleDerivingPlans = concatMap declDerivingPlans
+
+declDerivingPlans :: Decl -> [TcDerivingPlan]
+declDerivingPlans decl =
+  case decl of
+    DeclAnn ann inner ->
+      maybe [] tcDerivingPlans (fromAnnotation ann) <> declDerivingPlans inner
+    _ -> []

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/AnyClass.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/AnyClass.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Lower finalized @DeriveAnyClass@ plans to System FC dictionaries.
+module Aihc.Fc.Desugar.Deriving.AnyClass
+  ( dsAnyClassDictionaryPlan,
+  )
+where
+
+import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, predType)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshUnique, freshVar, lookupType, withDicts)
+import Aihc.Fc.Syntax
+import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDictBinderAnnotation (..))
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..))
+import Control.Monad (when, zipWithM)
+import Data.Text qualified as T
+
+dsAnyClassDictionaryPlan :: TcDerivingPlan -> DsM (Var, FcExpr)
+dsAnyClassDictionaryPlan plan =
+  case tcDerivingContext plan of
+    TcDerivingExplicitContext context -> dsAnyClassDictionary plan context
+    TcDerivingInferContext ->
+      desugarBug ("unfinalized AnyClass deriving context for " <> T.unpack (tcDerivingDictName plan))
+
+dsAnyClassDictionary :: TcDerivingPlan -> [Pred] -> DsM (Var, FcExpr)
+dsAnyClassDictionary plan context = do
+  when
+    (length (tcDerivingSuperClasses plan) /= length (tcDerivingClassSuperClasses plan))
+    (desugarBug ("incomplete superclass evidence for " <> T.unpack (tcDerivingDictName plan)))
+  contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] context
+  methodFieldTypes <-
+    mapM
+      (classMethodFieldType (tcDerivingClassName plan) (tcDerivingClassTyVars plan) . tcClassMethodType)
+      (tcDerivingClassMethods plan)
+  let superClassFieldTypes = map tcDictBinderType (tcDerivingClassSuperClasses plan)
+      fieldTypes = superClassFieldTypes <> methodFieldTypes
+      dictionaryType =
+        foldr
+          TcForAllTy
+          (qualifyType context (TcTyCon (TyCon (tcDerivingClassName plan) (length (tcDerivingClassTyVars plan))) (tcDerivingHeadTypes plan)))
+          (tcDerivingTyVars plan)
+      selfDictionary dictVar =
+        foldl
+          FcApp
+          (foldl FcTyApp (FcVar dictVar) (map TcTyVar (tcDerivingTyVars plan)))
+          (map (FcVar . classDictVar) contextDicts)
+      usesDefaultMethod =
+        any
+          ((`elem` tcDerivingDefaultMethods plan) . tcClassMethodName)
+          (tcDerivingClassMethods plan)
+  dictVar <- freshVar (tcDerivingDictName plan) dictionaryType
+  let maybeSelfDictionary
+        | usesDefaultMethod = Just (selfDictionary dictVar)
+        | otherwise = Nothing
+  fields <-
+    withDicts contextDicts $ do
+      superClassFields <- mapM (dsEvidence . snd) (tcDerivingSuperClasses plan)
+      methodFields <-
+        zipWithM
+          (dsAnyClassMethod plan maybeSelfDictionary)
+          methodFieldTypes
+          (tcDerivingClassMethods plan)
+      pure (superClassFields <> methodFields)
+  constructorUnique <- freshUnique
+  let classTyVars = tcDerivingClassTyVars plan
+      dictionaryConstructor = fcDictionaryConstructorName (tcDerivingClassName plan)
+      genericDictionaryType = TcTyCon (TyCon (tcDerivingClassName plan) (length classTyVars)) (map TcTyVar classTyVars)
+      constructorType = foldr TcForAllTy (foldr TcFunTy genericDictionaryType fieldTypes) classTyVars
+      constructorVar = Var dictionaryConstructor constructorUnique constructorType
+      constructor = foldl FcTyApp (FcVar constructorVar) (tcDerivingHeadTypes plan)
+      dictionary = foldl FcApp constructor fields
+      body = foldr FcTyLam (foldr (FcLam . classDictVar) dictionary contextDicts) (tcDerivingTyVars plan)
+  pure (dictVar, body)
+
+dsAnyClassMethod :: TcDerivingPlan -> Maybe FcExpr -> TcType -> TcClassMethodAnnotation -> DsM FcExpr
+dsAnyClassMethod plan maybeSelfDictionary fieldType method =
+  if methodName `elem` tcDerivingDefaultMethods plan
+    then do
+      selfDictionary <-
+        case maybeSelfDictionary of
+          Just dictionary -> pure dictionary
+          Nothing -> desugarBug ("default method " <> T.unpack methodName <> " requires a recursive derived dictionary")
+      let workerName = defaultMethodName methodName
+      workerType <- lookupType workerName
+      worker <- freshVar workerName workerType
+      checkedEvidence <-
+        case lookup methodName (tcDerivingDefaultMethodEvidence plan) of
+          Just terms -> pure terms
+          Nothing
+            | methodName `elem` map fst (tcDerivingDefaultSignatures plan) ->
+                desugarBug ("missing default-signature evidence for " <> T.unpack methodName)
+            | otherwise -> pure []
+      evidence <- mapM dsEvidence checkedEvidence
+      pure
+        ( foldl
+            FcApp
+            (FcApp (foldl FcTyApp (FcVar worker) (tcDerivingHeadTypes plan)) selfDictionary)
+            evidence
+        )
+    else do
+      -- A method omitted by DeriveAnyClass denotes bottom. Keep that fact in
+      -- FC without introducing a dependency on a particular exception runtime.
+      missingMethod <- freshVar ("$missing$" <> methodName) fieldType
+      pure (FcLet (FcRec [(missingMethod, FcVar missingMethod)]) (FcVar missingMethod))
+  where
+    methodName = tcClassMethodName method
+
+mkPredicateDict :: Int -> Pred -> DsM ClassDict
+mkPredicateDict index predicate = do
+  dictVar <- freshVar ("$d" <> T.pack (show index)) (predType predicate)
+  pure $
+    case predicate of
+      ClassPred className arguments -> ClassDict className arguments dictVar
+      EqPred {} -> ClassDict "<equality>" [] dictVar
+
+qualifyType :: [Pred] -> TcType -> TcType
+qualifyType [] body = body
+qualifyType predicates body = TcQualTy predicates body

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Dictionary.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Dictionary.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Shared System FC dictionary-layout operations.
+module Aihc.Fc.Desugar.Dictionary
+  ( classMethodFieldType,
+    defaultMethodName,
+    peelForAlls,
+    peelQuals,
+    predType,
+  )
+where
+
+import Aihc.Fc.Desugar.Expr (DsM, desugarBug)
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId)
+import Data.Text (Text)
+import Data.Text qualified as T
+
+defaultMethodName :: Text -> Text
+defaultMethodName methodName = "$dm" <> methodName
+
+peelForAlls :: TcType -> ([TyVarId], TcType)
+peelForAlls (TcForAllTy tv rest) =
+  let (tvs, inner) = peelForAlls rest
+   in (tv : tvs, inner)
+peelForAlls ty = ([], ty)
+
+peelQuals :: TcType -> ([Pred], TcType)
+peelQuals (TcQualTy preds body) = (preds, body)
+peelQuals ty = ([], ty)
+
+predType :: Pred -> TcType
+predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
+predType (EqPred left right) = TcTyCon (TyCon "~" 2) [left, right]
+
+classMethodFieldType :: Text -> [TyVarId] -> TcType -> DsM TcType
+classMethodFieldType className classTyVars methodType = do
+  remainingPredicates <-
+    case removeClassPredicate predicates of
+      Just result -> pure result
+      Nothing -> desugarBug ("class method lacks its class predicate for " <> T.unpack className)
+  let extraTyVars = filter (`notElem` classTyVars) methodTyVars
+      qualifiedBody =
+        if null remainingPredicates
+          then body
+          else TcQualTy remainingPredicates body
+  pure (foldr TcForAllTy qualifiedBody extraTyVars)
+  where
+    (methodTyVars, afterForAlls) = peelForAlls methodType
+    (predicates, body) = peelQuals afterForAlls
+    removeClassPredicate [] = Nothing
+    removeClassPredicate (predicate : rest) =
+      case predicate of
+        ClassPred predicateClass _
+          | predicateClass == className -> Just rest
+        _ -> (predicate :) <$> removeClassPredicate rest

--- a/components/aihc-fc/test/Test/Fixtures/golden/derive-anyclass-dictionary.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/derive-anyclass-dictionary.yaml
@@ -1,0 +1,114 @@
+expected: |-
+  data Unit
+   = Unit
+
+  data Box a
+   = Box a
+
+  data Required a
+   = $Dict$Required (a → a)
+
+  required : ∀ a. (Required a) → a → a =
+    Λa.
+      λ$d0 : Required a.
+        case $d0 as $dict : Required a of
+          $Dict$Required $method0 →
+            $method0
+
+  data Any a
+   = $Dict$Any (a → a)
+
+  anyValue : ∀ a. (Any a) → a → a =
+    Λa.
+      λ$d0 : Any a.
+        case $d0 as $dict : Any a of
+          $Dict$Any $method0 →
+            $method0
+
+  $dmanyValue : ∀ a. (Any a) → (Required a) → a → a =
+    Λa.
+      λ$d0 : Any a.
+        λ$d1 : Required a.
+          λx1011 : a.
+            required @a $d1 x1011
+
+  data Wrapped a
+   = Wrapped (Box a)
+
+  data Parent a
+   = $Dict$Parent
+
+  data Child a
+   = $Dict$Child (Parent a)
+
+  data Both
+   = Both
+
+  $fRequiredBoxa : ∀ a. (Required a) → Required (Box a) =
+    Λa.
+      λ$d0 : Required a.
+        $Dict$Required @(Box a) (λx1014 : Box a.
+          x1014)
+
+  $fRequiredWrappeda : ∀ a. (Required a) → Required (Wrapped a) =
+    Λa.
+      λ$d0 : Required a.
+        $Dict$Required @(Wrapped a) (λx1018 : Wrapped a.
+          x1018)
+
+  $fParentBoth : Parent Both =
+    $Dict$Parent @Both
+
+  $fChildBoth : Child Both =
+    $Dict$Child @Both $fParentBoth
+
+  rec
+    $fAnyWrappeda : ∀ a. (Required a) → Any (Wrapped a) =
+      Λa.
+        λ$d0 : Required a.
+          $Dict$Any @(Wrapped a) ($dmanyValue @(Wrapped a) ($fAnyWrappeda @a $d0) ($fRequiredWrappeda @a $d0))
+
+  useAny : ∀ a. (Required a) → (Wrapped a) → Wrapped a =
+    Λa.
+      λ$d0 : Required a.
+        anyValue @(Wrapped a) ($fAnyWrappeda @a $d0)
+extensions:
+- DefaultSignatures
+- DeriveAnyClass
+- DerivingStrategies
+modules:
+- |
+  {-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies #-}
+  module Test where
+
+  data Unit = Unit
+  data Box a = Box a
+
+  class Required a where
+    required :: a -> a
+
+  instance Required a => Required (Box a) where
+    required value = value
+
+  class Any a where
+    anyValue :: a -> a
+    default anyValue :: Required a => a -> a
+    anyValue value = required value
+
+  data Wrapped a = Wrapped (Box a)
+    deriving anyclass Any
+
+  instance Required a => Required (Wrapped a) where
+    required value = value
+
+  class Parent a where
+  class Parent a => Child a where
+
+  data Both = Both
+    deriving anyclass (Child, Parent)
+
+  useAny :: Required a => Wrapped a -> Wrapped a
+  useAny = anyValue
+reason: AnyClass lowering consumes finalized contexts, superclass evidence, and
+  default-method evidence attached by the type checker
+status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -243,6 +243,7 @@ annotationBindings ann decl =
   tcAnnotationBindings ann decl
     <> classAnnotationBindings ann decl
     <> instanceAnnotationBindings ann
+    <> derivingAnnotationBindings ann
 
 tcAnnotationBindings :: Annotation -> Decl -> [TcBindingResult]
 tcAnnotationBindings ann decl =
@@ -297,6 +298,16 @@ instanceAnnotationBindings ann =
   case fromAnnotation ann of
     Just instAnn ->
       [TcBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)]
+    Nothing -> []
+
+derivingAnnotationBindings :: Annotation -> [TcBindingResult]
+derivingAnnotationBindings ann =
+  case fromAnnotation ann of
+    Just derivingAnnotation ->
+      [ TcBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo)
+      | plan <- tcDerivingPlans derivingAnnotation,
+        Just instanceInfo <- [derivingPlanInstanceInfo plan]
+      ]
     Nothing -> []
 
 dataConBindings :: DataConDecl -> [TcBindingResult]

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -440,6 +440,7 @@ annotationTests =
       assertEqual "sibling superclass context" [[]] (contexts "Child")
       assertEqual "sibling AnyClass instance" [[]] (contexts "Parent")
       assertBool "same-module values can select the derived dictionary" ("$fCTa" `elem` evidenceDictNames result)
+      assertBool "derived dictionary type is exported downstream" (any ((== "$fCTa") . tbName) (tcModuleBindings result))
       assertBool "default-method evidence is checked in TC" (not (all (null . tcDerivingDefaultMethodEvidence) plans))
       assertBool "superclass evidence is checked in TC" (not (all (null . tcDerivingSuperClasses) plans)),
     testCase "instance methods retain method-local constraints" $ do

--- a/test/Test/Fixtures/eval/derive-anyclass-default-method.yaml
+++ b/test/Test/Fixtures/eval/derive-anyclass-default-method.yaml
@@ -1,0 +1,40 @@
+extensions:
+  - DefaultSignatures
+  - DeriveAnyClass
+  - DerivingStrategies
+modules:
+  - |
+    {-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies #-}
+    module Test where
+
+    data Unit = Unit
+    data Box a = Box a
+
+    class Required a where
+      required :: a -> a
+
+    instance Required Unit where
+      required value = value
+
+    instance Required a => Required (Box a) where
+      required value = value
+
+    class Any a where
+      anyValue :: a -> a
+      default anyValue :: Required a => a -> a
+      anyValue value = required value
+
+    data Wrapped a = Wrapped (Box a)
+      deriving anyclass Any
+
+    instance Required a => Required (Wrapped a) where
+      required value = value
+
+    answer :: Wrapped Unit
+    answer = anyValue (Wrapped (Box Unit))
+output: |
+  Wrapped (Box Unit)
+expression: |
+  answer
+status: pass
+reason: evaluates a constrained default method through a derived AnyClass dictionary


### PR DESCRIPTION
## Summary

- add an `aihc-fc` deriving dispatcher that consumes finalized type-checker plans and groups generated dictionaries by their evidence dependency SCCs
- lower `DeriveAnyClass` plans into System FC dictionary bindings without performing Haskell constraint solving downstream
- populate superclass fields from checked `tcDerivingSuperClasses` evidence
- select recursive class default workers and apply checked default-signature evidence from `tcDerivingDefaultMethodEvidence`
- represent omitted AnyClass methods as typed bottom and leave non-AnyClass strategies untouched
- export finalized derived dictionary types through `tcModuleBindings`, so current and dependent FC units can type dictionary occurrences
- extract shared dictionary-layout helpers for explicit instances and future deriving strategies

The structural golden covers an inferred context reduced through an explicit instance, a constrained default method, and reversed sibling superclass derivations. The shared evaluation fixture executes the constrained default method through the generated dictionary.

Stock, newtype, and via lowering remain outside this PR. Their plans continue to be ignored by the FC dispatcher until their strategy-specific generation is implemented.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes -p AnyClass"`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes -p derive-anyclass"`
- `just fmt`
- `just check`

## Progress

- FC golden PASS: 21 → 22
- `aihc-fc` tests: 139 → 141
- `aihc-tc` tests: 101 → 102