### PR TITLE
feat(tc): support standalone data-family instances

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -192,7 +192,7 @@ data LibraryPackage = LibraryPackage
   deriving (Eq, Show)
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 28
+cacheSchemaVersion = 29
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -27,6 +27,7 @@ import Aihc.Parser.Syntax
     ClassDeclItem (..),
     DataConDecl,
     DataDecl (..),
+    DataFamilyInst (..),
     Decl (..),
     Expr,
     Extension (..),
@@ -54,7 +55,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameText,
   )
 import Aihc.Resolve (ResolveResult (..), resolve)
-import Aihc.Tc (TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
+import Aihc.Tc (DataFamilyInstanceInfo (..), TcBindingResult (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModule)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
@@ -235,6 +236,8 @@ dsModule m = do
 dsDecl :: Decl -> DsM [FcTopBind]
 dsDecl (DeclData dd) = (: []) <$> dsDataDeclM dd
 dsDecl (DeclNewtype nd) = (: []) <$> dsNewtypeDeclM nd
+dsDecl (DeclAnn ann (DeclDataFamilyInst familyInst))
+  | Just familyInfo <- fromAnnotation ann = dsDataFamilyInstM familyInfo familyInst
 dsDecl (DeclAnn ann inner)
   | Just foreignAnn <- fromAnnotation ann,
     Just (tcAnn, foreignDecl) <- annotatedForeignDecl inner =
@@ -245,6 +248,7 @@ dsDecl (DeclAnn ann (DeclClass classDecl))
   | Just classAnn <- fromAnnotation ann = dsClassDeclM classDecl classAnn
 dsDecl (DeclAnn _ inner) = dsDecl inner
 dsDecl DeclClass {} = desugarBug "missing type-checker annotation for class declaration"
+dsDecl DeclDataFamilyInst {} = desugarBug "missing type-checker annotation for data-family instance"
 dsDecl _ = pure []
 
 -- | Desugar a data declaration.
@@ -258,6 +262,54 @@ dsDataDeclM dd = do
           [] -> []
       constructors = [(name, fields) | (name, _, fields) <- constructorInfos]
   pure (FcData tyName typeVariables constructors)
+
+-- | Retain a data-family instance as a fresh representation type and a
+-- nominal axiom connecting that representation to the family application.
+dsDataFamilyInstM :: DataFamilyInstanceInfo -> DataFamilyInst -> DsM [FcTopBind]
+dsDataFamilyInstM familyInfo familyInst = do
+  constructorInfos <- mapM dsDataConM (dataFamilyInstConstructors familyInst)
+  case constructorInfos of
+    [] -> desugarBug "data-family instance has no constructors"
+    _ -> do
+      let representationTyCon = dfiiRepresentationTyCon familyInfo
+          representationName = tyConName representationTyCon
+          representationTyVars = dfiiTyVars familyInfo
+          representationType = TcTyCon representationTyCon (map TcTyVar representationTyVars)
+          axiom =
+            FcAxiom
+              FcAxiomDecl
+                { fcAxiomName = dfiiAxiomName familyInfo,
+                  fcAxiomTyVars = representationTyVars,
+                  fcAxiomRole = FcNominal,
+                  fcAxiomLeft = dfiiFamilyType familyInfo,
+                  fcAxiomRight = representationType
+                }
+      representation <- dataFamilyRepresentation familyInst representationName representationTyVars representationType constructorInfos
+      pure [representation, axiom]
+
+dataFamilyRepresentation :: DataFamilyInst -> Text -> [TyVarId] -> TcType -> [(Text, [TyVarId], [TcType])] -> DsM FcTopBind
+dataFamilyRepresentation familyInst representationName representationTyVars representationType constructorInfos
+  | dataFamilyInstIsNewtype familyInst =
+      case constructorInfos of
+        [(constructorName, _, [fieldType])] ->
+          pure
+            ( FcNewtype
+                FcNewtypeDecl
+                  { fcNewtypeName = representationName,
+                    fcNewtypeTyVars = representationTyVars,
+                    fcNewtypeConstructor = constructorName,
+                    fcNewtypeRepresentation = fieldType,
+                    fcNewtypeResult = representationType
+                  }
+            )
+        _ -> desugarBug "newtype family instance does not have exactly one constructor with one field"
+  | otherwise =
+      pure
+        ( FcData
+            representationName
+            representationTyVars
+            [(name, fields) | (name, _, fields) <- constructorInfos]
+        )
 
 -- | Retain the nominal declaration and its representation type as an FC axiom.
 -- 'lowerNewtypes' turns all term-level construction and matching into casts.

--- a/components/aihc-fc/test/Test/Fixtures/golden/data-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/data-family-instance.yaml
@@ -1,0 +1,14 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data family Payload a
+    data instance Payload a = PayloadValue a
+expected: |
+  data $R$Payload$PayloadValue a
+   = PayloadValue a
+
+  axiom $ax$Payload$PayloadValue a : Payload a ~N $R$Payload$PayloadValue a
+status: pass
+reason: data-family instances retain an explicit representation type and nominal equality axiom in System FC

--- a/components/aihc-fc/test/Test/Fixtures/golden/newtype-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/newtype-family-instance.yaml
@@ -1,0 +1,17 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data Unit = Unit
+    data family Wrapped a
+    newtype instance Wrapped Unit = WrappedUnit Unit
+expected: |
+  data Unit
+   = Unit
+
+  newtype $R$Wrapped$WrappedUnit = WrappedUnit Unit
+
+  axiom $ax$Wrapped$WrappedUnit : Wrapped Unit ~N $R$Wrapped$WrappedUnit
+status: pass
+reason: newtype-family instances retain a representation newtype and their nominal family equation

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -36,6 +36,8 @@ import Aihc.Parser.Syntax
     CompStmt (..),
     DataConDecl (..),
     DataDecl (..),
+    DataFamilyDecl (..),
+    DataFamilyInst (..),
     Decl (..),
     DerivingClause (..),
     DerivingStrategy (..),
@@ -405,9 +407,11 @@ resolveDeclCore termDefinition decl =
     DeclStandaloneDeriving derivingDecl ->
       DeclStandaloneDeriving <$> resolveStandaloneDerivingDecl derivingDecl
     DeclTypeFamilyDecl {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
-    DeclDataFamilyDecl {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclDataFamilyDecl dataFamilyDecl ->
+      DeclDataFamilyDecl <$> resolveDataFamilyDecl dataFamilyDecl
     DeclTypeFamilyInst {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
-    DeclDataFamilyInst {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclDataFamilyInst dataFamilyInst ->
+      DeclDataFamilyInst <$> resolveDataFamilyInst dataFamilyInst
 
 resolveValueDecl :: TermDefinition -> ValueDecl -> ResolveM ValueDecl
 resolveValueDecl termDefinition valueDecl =
@@ -1115,6 +1119,41 @@ resolveDataDecl keyword dataDecl = do
         dataDeclKind = kind',
         dataDeclConstructors = map (resolveDataConDefinitions scope) constructors',
         dataDeclDeriving = deriving'
+      }
+
+resolveDataFamilyDecl :: DataFamilyDecl -> ResolveM DataFamilyDecl
+resolveDataFamilyDecl familyDecl = do
+  scope <- currentScope
+  declSpan <- currentSpan
+  let resolveHeadName name =
+        let rendered = renderUnqualifiedName name
+            span' = declKeywordNameSpan "data family " declSpan rendered
+         in resolveUnqualifiedNameTo span' ResolutionNamespaceType (lookupType rendered scope) name
+      head' =
+        case dataFamilyDeclHead familyDecl of
+          PrefixBinderHead name params -> PrefixBinderHead (resolveHeadName name) params
+          InfixBinderHead lhs name rhs params -> InfixBinderHead lhs (resolveHeadName name) rhs params
+  kind' <- traverse resolveType (dataFamilyDeclKind familyDecl)
+  pure familyDecl {dataFamilyDeclHead = head', dataFamilyDeclKind = kind'}
+
+resolveDataFamilyInst :: DataFamilyInst -> ResolveM DataFamilyInst
+resolveDataFamilyInst familyInst = do
+  scope <- currentScope
+  (forallScope, forallBinders') <- bindTyVarBinders (dataFamilyInstForall familyInst)
+  (head', kind', constructors', deriving') <-
+    extendScope forallScope $
+      (,,,)
+        <$> resolveType (dataFamilyInstHead familyInst)
+        <*> traverse resolveType (dataFamilyInstKind familyInst)
+        <*> mapM resolveDataConDecl (dataFamilyInstConstructors familyInst)
+        <*> mapM resolveDerivingClause (dataFamilyInstDeriving familyInst)
+  pure
+    familyInst
+      { dataFamilyInstForall = forallBinders',
+        dataFamilyInstHead = head',
+        dataFamilyInstKind = kind',
+        dataFamilyInstConstructors = map (resolveDataConDefinitions scope) constructors',
+        dataFamilyInstDeriving = deriving'
       }
 
 resolveTypeSynDecl :: TypeSynDecl -> ResolveM TypeSynDecl

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -32,6 +32,8 @@ import Aihc.Parser.Syntax
     ClassDeclItem (..),
     DataConDecl (..),
     DataDecl (..),
+    DataFamilyDecl (..),
+    DataFamilyInst (..),
     Decl (..),
     ExportSpec (..),
     FieldDecl (..),
@@ -52,6 +54,7 @@ import Aihc.Parser.Syntax
     RecordField (..),
     SourceSpan (..),
     TupleFlavor (..),
+    Type (..),
     TypeSynDecl (..),
     UnqualifiedName,
     ValueDecl (..),
@@ -60,6 +63,7 @@ import Aihc.Parser.Syntax
     moduleExports,
     moduleName,
     peelPatternAnn,
+    peelTypeHead,
     qualifyName,
     recordFieldValue,
     renderUnqualifiedName,
@@ -224,8 +228,37 @@ declExportedNames decl =
           termNames = maybe [] dataConDeclNames (newtypeDeclConstructor newtypeDecl)
           constructorNames = maybe [] dataConDeclConstructorNames (newtypeDeclConstructor newtypeDecl)
        in DeclExports termNames [typeName] (constructorMap typeName constructorNames) (maybe Map.empty (recordFieldMap . (: [])) (newtypeDeclConstructor newtypeDecl)) Map.empty Map.empty
+    DeclDataFamilyDecl familyDecl ->
+      DeclExports [] [binderHeadName (dataFamilyDeclHead familyDecl)] Map.empty Map.empty Map.empty Map.empty
+    DeclDataFamilyInst familyInst -> dataFamilyInstExports familyInst
     DeclTypeSyn typeSynDecl -> DeclExports [] [binderHeadName (typeSynHead typeSynDecl)] Map.empty Map.empty Map.empty Map.empty
     _ -> DeclExports [] [] Map.empty Map.empty Map.empty Map.empty
+
+dataFamilyInstExports :: DataFamilyInst -> DeclExports
+dataFamilyInstExports familyInst =
+  case dataFamilyHeadName (dataFamilyInstHead familyInst) of
+    Nothing -> DeclExports termNames [] Map.empty recordFields Map.empty Map.empty
+    Just familyName ->
+      DeclExports
+        termNames
+        []
+        (constructorMap familyName constructorNames)
+        recordFields
+        Map.empty
+        Map.empty
+  where
+    constructors = dataFamilyInstConstructors familyInst
+    termNames = dataDeclConstructorNames constructors
+    constructorNames = concatMap dataConDeclConstructorNames constructors
+    recordFields = recordFieldMap constructors
+
+dataFamilyHeadName :: Type -> Maybe UnqualifiedName
+dataFamilyHeadName ty =
+  case peelTypeHead ty of
+    TCon name _ -> Just (mkUnqualifiedName (nameType name) (nameText name))
+    TApp function _ -> dataFamilyHeadName function
+    TTypeApp function _ -> dataFamilyHeadName function
+    _ -> Nothing
 
 dataDeclExports :: BinderHead UnqualifiedName -> [DataConDecl] -> DeclExports
 dataDeclExports headBinder constructors =

--- a/components/aihc-resolve/test/Test/Fixtures/golden/data-family-instance.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/data-family-instance.yaml
@@ -1,0 +1,39 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Provider (Unit(..), Payload(..)) where
+    data Unit = Unit
+    data family Payload a
+    data instance Payload Unit = PayloadUnit Unit
+  - |
+    module Consumer where
+    import Provider (Unit(..), Payload(..))
+    value :: Payload Unit
+    value = PayloadUnit Unit
+annotated:
+  - |
+    module Consumer where
+    import Provider (Unit(..), Payload(..))
+    value :: Payload Unit
+    │        │       └─ t Provider
+    │        └─ t Provider
+    └─ v Consumer
+    value = PayloadUnit Unit
+    │       │           └─ v Provider
+    │       └─ v Provider
+    └─ v Consumer
+  - |
+    module Provider (Unit(..), Payload(..)) where
+    data Unit = Unit
+         │      └─ v Provider
+         └─ t Provider
+    data family Payload a
+                └─ t Provider
+    data instance Payload Unit = PayloadUnit Unit
+                  │       │      │           └─ t Provider
+                  │       │      └─ v Provider
+                  │       └─ t Provider
+                  └─ t Provider
+status: pass
+reason: standalone data families and their instance constructors participate in ordinary type and term resolution

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -56,6 +56,9 @@ module Aihc.Tc
     boxedTupleTyConName,
     Pred (..),
     InstanceInfo (..),
+    DataFamilyInstanceInfo (..),
+    dataFamilyAxiomName,
+    dataFamilyRepresentationName,
     ClassInfo (..),
     TyConFlavor (..),
     TyConInfo (..),
@@ -106,7 +109,7 @@ import Aihc.Parser.Syntax
     mkAnnotation,
   )
 import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), renderPred, renderTcSignature, renderTcType)
-import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..))
+import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tcModule, tcModuleScc)
 import Aihc.Tc.Generate.Expr (inferExpr)
@@ -141,7 +144,8 @@ data TcInterface = TcInterface
   { tcInterfaceTerms :: ![(Text, TypeScheme)],
     tcInterfaceTyCons :: ![TyConInfo],
     tcInterfaceClasses :: ![ClassInfo],
-    tcInterfaceInstances :: ![InstanceInfo]
+    tcInterfaceInstances :: ![InstanceInfo],
+    tcInterfaceDataFamilyInstances :: ![DataFamilyInstanceInfo]
   }
   deriving (Show, Read)
 
@@ -151,7 +155,8 @@ emptyTcInterface =
     { tcInterfaceTerms = [],
       tcInterfaceTyCons = [],
       tcInterfaceClasses = [],
-      tcInterfaceInstances = []
+      tcInterfaceInstances = [],
+      tcInterfaceDataFamilyInstances = []
     }
 
 instance Semigroup TcInterface where
@@ -160,7 +165,8 @@ instance Semigroup TcInterface where
       { tcInterfaceTerms = mergeInterfaceEntries fst (tcInterfaceTerms left <> tcInterfaceTerms right),
         tcInterfaceTyCons = mergeInterfaceEntries tciName (tcInterfaceTyCons left <> tcInterfaceTyCons right),
         tcInterfaceClasses = mergeInterfaceEntries ciName (tcInterfaceClasses left <> tcInterfaceClasses right),
-        tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcInterfaceInstances left <> tcInterfaceInstances right)
+        tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcInterfaceInstances left <> tcInterfaceInstances right),
+        tcInterfaceDataFamilyInstances = mergeInterfaceEntries dfiiAxiomName (tcInterfaceDataFamilyInstances left <> tcInterfaceDataFamilyInstances right)
       }
 
 instance Monoid TcInterface where
@@ -289,7 +295,8 @@ typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses import
             { tcInterfaceTerms = importedTerms,
               tcInterfaceTyCons = importedTyCons,
               tcInterfaceClasses = importedClasses,
-              tcInterfaceInstances = importedInstances
+              tcInterfaceInstances = importedInstances,
+              tcInterfaceDataFamilyInstances = []
             }
           modules
    in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
@@ -330,7 +337,8 @@ typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses impo
             { tcInterfaceTerms = importedTerms,
               tcInterfaceTyCons = importedTyCons,
               tcInterfaceClasses = importedClasses,
-              tcInterfaceInstances = importedInstances
+              tcInterfaceInstances = importedInstances,
+              tcInterfaceDataFamilyInstances = []
             }
           modules
    in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
@@ -358,7 +366,8 @@ initialTcState imported =
           ]
           <> tcsGlobalTyCons initTcState,
       tcsClasses = Map.fromList [(ciName classInfo, classInfo) | classInfo <- tcInterfaceClasses imported],
-      tcsInstances = tcInterfaceInstances imported
+      tcsInstances = tcInterfaceInstances imported,
+      tcsDataFamilyInstances = tcInterfaceDataFamilyInstances imported
     }
 
 tcInterfaceFromState :: TcState -> TcInterface
@@ -370,7 +379,8 @@ tcInterfaceFromState state =
         ],
       tcInterfaceTyCons = Map.elems (tcsGlobalTyCons state),
       tcInterfaceClasses = Map.elems (tcsClasses state),
-      tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcsInstances state)
+      tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcsInstances state),
+      tcInterfaceDataFamilyInstances = mergeInterfaceEntries dfiiAxiomName (tcsDataFamilyInstances state)
     }
 
 typecheckModuleSccWithState :: TcState -> [Module] -> ([Module], TcState)

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Global and class environments.
 --
 -- These are built once per module from the parsed declarations and carry
@@ -20,6 +22,11 @@ module Aihc.Tc.Env
 
     -- * Instance info
     InstanceInfo (..),
+
+    -- * Data family instances
+    DataFamilyInstanceInfo (..),
+    dataFamilyAxiomName,
+    dataFamilyRepresentationName,
   )
 where
 
@@ -51,6 +58,7 @@ emptyGlobalEnv =
 data TyConFlavor
   = ClassTyCon
   | DataTyCon
+  | DataFamilyTyCon
   | NewtypeTyCon
   | SynonymTyCon
   deriving (Eq, Show, Read)
@@ -124,3 +132,25 @@ data InstanceInfo = InstanceInfo
     iiHead :: ![TcType]
   }
   deriving (Show, Read)
+
+-- | A checked standalone data-family instance equation. The representation
+-- type and nominal axiom are compiler-internal names derived from the first
+-- (globally unique) constructor of the instance.
+data DataFamilyInstanceInfo = DataFamilyInstanceInfo
+  { dfiiFamilyName :: !Text,
+    dfiiFamilyType :: !TcType,
+    dfiiTyVars :: ![TyVarId],
+    dfiiRepresentationTyCon :: !TyCon,
+    dfiiAxiomName :: !Text,
+    dfiiConstructorNames :: ![Text],
+    dfiiIsNewtype :: !Bool
+  }
+  deriving (Show, Read)
+
+dataFamilyRepresentationName :: Text -> Text -> Text
+dataFamilyRepresentationName familyName firstConstructor =
+  "$R$" <> familyName <> "$" <> firstConstructor
+
+dataFamilyAxiomName :: Text -> Text -> Text
+dataFamilyAxiomName familyName firstConstructor =
+  "$ax$" <> familyName <> "$" <> firstConstructor

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -22,6 +22,7 @@ import Aihc.Tc.Annotations
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
   )
+import Aihc.Tc.Env (DataFamilyInstanceInfo (..))
 import Aihc.Tc.Evidence (Coercion (..), EvTerm (..), EvVar)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types (Pred (..), TcType (..), Unique (..))
@@ -133,6 +134,7 @@ rejectMetaFinalAnnotation ann = do
   traverseReject "deriving annotation" (firstMetaDerivingAnnotation <$> fromAnnotation @TcDerivingAnnotation ann)
   traverseReject "instance annotation" (firstMetaInstanceAnnotation <$> fromAnnotation @TcInstanceAnnotation ann)
   traverseReject "instance method annotation" (firstMetaInstanceMethodAnnotation <$> fromAnnotation @TcInstanceMethodAnnotation ann)
+  traverseReject "data-family instance annotation" (firstMetaDataFamilyInstance <$> fromAnnotation @DataFamilyInstanceInfo ann)
   where
     traverseReject _ Nothing = pure ()
     traverseReject context (Just maybeMeta) = rejectMeta ("finalized " <> context) maybeMeta
@@ -213,6 +215,10 @@ firstMetaDictBinderAnnotation ann =
 firstMetaInstanceMethodAnnotation :: TcInstanceMethodAnnotation -> Maybe Unique
 firstMetaInstanceMethodAnnotation ann =
   firstMetaType (tcInstanceMethodType ann)
+
+firstMetaDataFamilyInstance :: DataFamilyInstanceInfo -> Maybe Unique
+firstMetaDataFamilyInstance info =
+  firstMetaType (dfiiFamilyType info)
 
 firstMetaEvTerm :: EvTerm -> Maybe Unique
 firstMetaEvTerm evTerm =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -26,6 +26,8 @@ import Aihc.Parser.Syntax
     ClassDeclItem (..),
     DataConDecl (..),
     DataDecl (..),
+    DataFamilyDecl (..),
+    DataFamilyInst (..),
     Decl (..),
     Expr (..),
     Extension,
@@ -80,7 +82,7 @@ import Aihc.Tc.Annotations
 import Aihc.Tc.Constraint
 import Aihc.Tc.Deriving (annotateAttachedDerivingTc, annotateStandaloneDerivingTc)
 import Aihc.Tc.Deriving.Context (derivingPlanInstanceInfo, finalizeDerivingModulesTc)
-import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeSynonymInfo (..))
+import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeSynonymInfo (..), dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Finalize (finalizeModuleTc)
@@ -100,7 +102,7 @@ import Control.Monad (foldM, forM_, unless, when, zipWithM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (mapAccumL, nub, nubBy, partition, (\\))
+import Data.List (find, mapAccumL, nub, nubBy, partition, (\\))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe, maybeToList)
@@ -236,6 +238,8 @@ declBindings decl =
       concatMap dataConBindings (dataDeclConstructors dataDecl)
     DeclNewtype newtypeDecl ->
       maybe [] dataConBindings (newtypeDeclConstructor newtypeDecl)
+    DeclDataFamilyInst familyInst ->
+      concatMap dataConBindings (dataFamilyInstConstructors familyInst)
     _ -> []
 
 annotationBindings :: Annotation -> Decl -> [TcBindingResult]
@@ -259,6 +263,9 @@ tcAnnotationBindings ann decl =
            in [TcBindingResult name name (tcAnnType tcAnn)]
         DeclNewtype newtypeDecl ->
           let name = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
+           in [TcBindingResult name name (tcAnnType tcAnn)]
+        DeclDataFamilyDecl familyDecl ->
+          let name = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
            in [TcBindingResult name name (tcAnnType tcAnn)]
         DeclForeign foreignDecl ->
           let name = unqualifiedNameText (foreignName foreignDecl)
@@ -446,13 +453,15 @@ defaultGlobalKindMetas = do
   tyCons <- traverse defaultTyConInfoKinds (tcsGlobalTyCons state)
   classes <- traverse defaultClassKinds (tcsClasses state)
   instances <- mapM defaultInstanceKinds (tcsInstances state)
+  dataFamilyInstances <- mapM defaultDataFamilyInstanceKinds (tcsDataFamilyInstances state)
   lift $
     modify' $ \current ->
       current
         { tcsGlobalTerms = terms,
           tcsGlobalTyCons = tyCons,
           tcsClasses = classes,
-          tcsInstances = instances
+          tcsInstances = instances,
+          tcsDataFamilyInstances = dataFamilyInstances
         }
   where
     defaultBinderKinds binder =
@@ -489,6 +498,21 @@ defaultGlobalKindMetas = do
         <*> mapM defaultTyVarKinds (iiTyVars info)
         <*> mapM defaultPredKinds (iiContext info)
         <*> mapM defaultTypeKinds (iiHead info)
+    defaultDataFamilyInstanceKinds info = do
+      familyType <- defaultTypeKinds (dfiiFamilyType info)
+      tyVars <- mapM defaultTyVarKinds (dfiiTyVars info)
+      let representationTyCon = dfiiRepresentationTyCon info
+      representationKind <- defaultKindMetas (tyConKind representationTyCon)
+      pure
+        info
+          { dfiiFamilyType = familyType,
+            dfiiTyVars = tyVars,
+            dfiiRepresentationTyCon =
+              mkTyCon
+                (tyConName representationTyCon)
+                (tyConArity representationTyCon)
+                representationKind
+          }
 
 data TcDeclGroupResult = TcDeclGroupResult
   { tcGroupId :: !Int,
@@ -560,6 +584,8 @@ annotateDeclTc classMethods checkedValueNames decl =
       | otherwise -> pure decl
     DeclData dataDecl -> annotateDataDeclTc dataDecl
     DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
+    DeclDataFamilyDecl familyDecl -> annotateDataFamilyDeclTc familyDecl
+    DeclDataFamilyInst familyInst -> annotateDataFamilyInstTc familyInst
     DeclForeign foreignDecl
       | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
     DeclClass classDecl -> annotateClassDeclTc classDecl
@@ -642,6 +668,41 @@ annotateNewtypeDeclTc newtypeDecl = do
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (newtypeDeclHead newtypeDecl)
   pure (DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor}))
+
+annotateDataFamilyDeclTc :: DataFamilyDecl -> TcM Decl
+annotateDataFamilyDeclTc familyDecl = do
+  let familyName = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
+  ty <- tyConBindingType familyName
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (dataFamilyDeclHead familyDecl)
+  pure (DeclDataFamilyDecl (familyDecl {dataFamilyDeclHead = annotatedHead}))
+
+annotateDataFamilyInstTc :: DataFamilyInst -> TcM Decl
+annotateDataFamilyInstTc familyInst = do
+  constructors <- mapM annotateRegisteredDataConDeclTc (dataFamilyInstConstructors familyInst)
+  let annotated = DeclDataFamilyInst (familyInst {dataFamilyInstConstructors = constructors})
+      constructorNames = concatMap (map fst . dataConBindingNames) constructors
+  familyInstances <- getDataFamilyInstances
+  case constructorNames of
+    firstConstructor : _ ->
+      case find (elem firstConstructor . dfiiConstructorNames) familyInstances of
+        Just familyInstance -> pure (DeclAnn (mkAnnotation familyInstance) annotated)
+        Nothing -> pure annotated
+    [] -> pure annotated
+
+annotateRegisteredDataConDeclTc :: DataConDecl -> TcM DataConDecl
+annotateRegisteredDataConDeclTc dataConDecl =
+  case dataConBindingNames dataConDecl of
+    [] -> pure dataConDecl
+    (name, _) : _ -> do
+      maybeBinder <- lookupTerm name
+      case maybeBinder of
+        Just (TcIdBinder scheme _) -> annotateWithType (schemeToType scheme)
+        Just (TcMonoIdBinder ty) -> annotateWithType ty
+        Nothing -> pure dataConDecl
+  where
+    annotateWithType ty = do
+      zonkedTy <- zonkType ty
+      pure (DataConAnn (mkAnnotation (TcAnnotation zonkedTy [] [] [])) dataConDecl)
 
 annotateBinderHeadName :: TcAnnotation -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName tcAnn head' =
@@ -1619,6 +1680,7 @@ zonkPred pred' =
 registerTypeDeclHeader :: Decl -> TcM [TcBindingResult]
 registerTypeDeclHeader (DeclData dataDecl) = registerDataDeclHeader dataDecl
 registerTypeDeclHeader (DeclNewtype newtypeDecl) = registerNewtypeDeclHeader newtypeDecl
+registerTypeDeclHeader (DeclDataFamilyDecl familyDecl) = registerDataFamilyDeclHeader familyDecl
 registerTypeDeclHeader (DeclTypeSyn typeSynDecl) = registerTypeSynonymHeader typeSynDecl
 registerTypeDeclHeader (DeclAnn _ inner) = registerTypeDeclHeader inner
 registerTypeDeclHeader _ = pure []
@@ -1626,6 +1688,7 @@ registerTypeDeclHeader _ = pure []
 registerValueLevelDecl :: Decl -> TcM [TcBindingResult]
 registerValueLevelDecl (DeclData dataDecl) = registerDataConstructors dataDecl
 registerValueLevelDecl (DeclNewtype newtypeDecl) = registerNewtypeConstructor newtypeDecl
+registerValueLevelDecl (DeclDataFamilyInst familyInst) = registerDataFamilyInstance familyInst
 registerValueLevelDecl (DeclClass classDecl) = registerClassDecl classDecl
 registerValueLevelDecl (DeclInstance instanceDecl) = registerInstanceDecl instanceDecl
 registerValueLevelDecl (DeclForeign foreignDecl)
@@ -1793,6 +1856,88 @@ typeSuffix ty =
     TcTyCon tc args -> tyConName tc <> T.concat (map typeSuffix args)
     _ -> "T"
 
+registerDataFamilyDeclHeader :: DataFamilyDecl -> TcM [TcBindingResult]
+registerDataFamilyDeclHeader familyDecl = do
+  let familyName = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
+      params = binderHeadParams (dataFamilyDeclHead familyDecl)
+      arity = length params
+  paramInfos <- makeParamEnv params
+  declaredKind <- tyConKindFromParams paramInfos (dataFamilyDeclKind familyDecl)
+  let familyTyCon = mkTyCon familyName arity declaredKind
+  extendTyConEnvPermanent
+    familyName
+    TyConInfo
+      { tciName = familyName,
+        tciArity = arity,
+        tciTyCon = familyTyCon,
+        tciKind = declaredKind,
+        tciFlavor = DataFamilyTyCon,
+        tciTypeSynonym = Nothing
+      }
+  zonkedKind <- defaultKindMetas declaredKind
+  pure [TcBindingResult familyName familyName (kindToTcType zonkedKind)]
+
+registerDataFamilyInstance :: DataFamilyInst -> TcM [TcBindingResult]
+registerDataFamilyInstance familyInst = do
+  paramInfos <- dataFamilyInstanceParams familyInst
+  let tvEnv =
+        Map.fromList
+          [ (paramName param, (paramTyVar param, paramKind param))
+          | param <- paramInfos
+          ]
+      constructorNames = concatMap (map fst . dataConBindingNames) (dataFamilyInstConstructors familyInst)
+  familyType <- checkSurfaceType tvEnv (dataFamilyInstHead familyInst) KType
+  case (familyType, constructorNames) of
+    (_, []) -> do
+      emitError NoSourceSpan (OtherError "data-family instances without constructors are not supported")
+      pure []
+    (TcTyCon familyTyCon _, firstConstructor : _) -> do
+      maybeFamilyInfo <- lookupTyCon (tyConName familyTyCon)
+      case maybeFamilyInfo of
+        Just familyInfo
+          | tciFlavor familyInfo == DataFamilyTyCon -> do
+              representationKind <- tyConKindFromParams paramInfos (dataFamilyInstKind familyInst)
+              let familyName = tciName familyInfo
+                  representationName = dataFamilyRepresentationName familyName firstConstructor
+                  representationTyCon = mkTyCon representationName (length paramInfos) representationKind
+                  axiomName = dataFamilyAxiomName familyName firstConstructor
+                  instanceInfo =
+                    DataFamilyInstanceInfo
+                      { dfiiFamilyName = familyName,
+                        dfiiFamilyType = familyType,
+                        dfiiTyVars = map paramTyVar paramInfos,
+                        dfiiRepresentationTyCon = representationTyCon,
+                        dfiiAxiomName = axiomName,
+                        dfiiConstructorNames = constructorNames,
+                        dfiiIsNewtype = dataFamilyInstIsNewtype familyInst
+                      }
+              addDataFamilyInstance instanceInfo
+              mapM (registerDataConWithResult paramInfos familyType) (dataFamilyInstConstructors familyInst)
+        _ -> do
+          emitError NoSourceSpan (OtherError ("data-family instance head does not name a data family: " <> T.unpack (tyConName familyTyCon)))
+          pure []
+    _ -> do
+      emitError NoSourceSpan (OtherError ("invalid data-family instance head: " <> show familyType))
+      pure []
+
+dataFamilyInstanceParams :: DataFamilyInst -> TcM [ParamInfo]
+dataFamilyInstanceParams familyInst = do
+  explicitParams <- makeParamEnv (dataFamilyInstForall familyInst)
+  let explicitNames = map paramName explicitParams
+      implicitNames = freeTypeVars (dataFamilyInstHead familyInst) \\ explicitNames
+  implicitParams <- mapM makeImplicitParam implicitNames
+  pure (explicitParams <> implicitParams)
+  where
+    makeImplicitParam name = do
+      rawTyVar <- freshSkolemTv name
+      kind <- freshKindMeta
+      pure
+        ParamInfo
+          { paramName = name,
+            paramTyVar = setTyVarKind kind rawTyVar,
+            paramKind = kind
+          }
+
 -- | Register a data declaration's type constructor and data constructors.
 --
 -- For @data Bool = True | False@, this produces:
@@ -1910,8 +2055,12 @@ dataDeclTyCon name arity kind = mkTyCon name arity kind
 -- | Register a single data constructor as a polymorphic binding.
 -- Returns the binding result for the constructor.
 registerDataCon :: TyCon -> [ParamInfo] -> DataConDecl -> TcM TcBindingResult
-registerDataCon tc paramInfos con = case con of
-  DataConAnn _ inner -> registerDataCon tc paramInfos inner
+registerDataCon tc paramInfos =
+  registerDataConWithResult paramInfos (TcTyCon tc (map (TcTyVar . paramTyVar) paramInfos))
+
+registerDataConWithResult :: [ParamInfo] -> TcType -> DataConDecl -> TcM TcBindingResult
+registerDataConWithResult paramInfos resTy con = case con of
+  DataConAnn _ inner -> registerDataConWithResult paramInfos resTy inner
   PrefixCon forallVars context conName args ->
     registerH98DataCon forallVars context (unqualifiedNameText conName) (map bangType args)
   InfixCon forallVars context lhs conName rhs ->
@@ -1952,7 +2101,6 @@ registerDataCon tc paramInfos con = case con of
         | param <- paramInfos
         ]
     paramVarIds = map paramTyVar paramInfos
-    resTy = TcTyCon tc (map TcTyVar paramVarIds)
     registerH98DataCon forallVars context name fieldTypes = do
       constructorParams <- makeParamEnv forallVars
       let constructorEnv =

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -54,6 +54,8 @@ module Aihc.Tc.Monad
     withTcLevel,
     addInstance,
     getInstances,
+    addDataFamilyInstance,
+    getDataFamilyInstances,
     addClass,
     getClasses,
     lookupClass,
@@ -73,7 +75,7 @@ where
 
 import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameText, unqualifiedNameText)
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
-import Aihc.Tc.Env (ClassInfo (..), InstanceInfo, TyConInfo)
+import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo, InstanceInfo, TyConInfo)
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
 import Aihc.Tc.Types
@@ -185,6 +187,8 @@ data TcState = TcState
     tcsClasses :: !(Map Text ClassInfo),
     -- | Class instances in scope.
     tcsInstances :: ![InstanceInfo],
+    -- | Standalone data-family instance equations in scope.
+    tcsDataFamilyInstances :: ![DataFamilyInstanceInfo],
     -- | Names of GADT constructors (have non-trivial result types).
     tcsGadtCons :: !(Set Text)
   }
@@ -203,6 +207,7 @@ initTcState =
       tcsGlobalTyCons = Map.empty,
       tcsClasses = Map.empty,
       tcsInstances = [],
+      tcsDataFamilyInstances = [],
       tcsGadtCons = Set.empty
     }
 
@@ -376,6 +381,13 @@ addInstance instanceInfo = lift $ modify' $ \s ->
 
 getInstances :: TcM [InstanceInfo]
 getInstances = lift $ gets tcsInstances
+
+addDataFamilyInstance :: DataFamilyInstanceInfo -> TcM ()
+addDataFamilyInstance instanceInfo = lift $ modify' $ \state ->
+  state {tcsDataFamilyInstances = instanceInfo : tcsDataFamilyInstances state}
+
+getDataFamilyInstances :: TcM [DataFamilyInstanceInfo]
+getDataFamilyInstances = lift $ gets tcsDataFamilyInstances
 
 addClass :: ClassInfo -> TcM ()
 addClass classInfo = lift $ modify' $ \state ->

--- a/components/aihc-tc/test/Test/Fixtures/annotated/data-family-instance.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/data-family-instance.yaml
@@ -1,0 +1,26 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data Unit = Unit
+    data family Payload a
+    data instance Payload Unit = PayloadUnit Unit
+    unwrap :: Payload Unit -> Unit
+    unwrap payload = case payload of PayloadUnit value -> value
+annotated:
+  - |
+    module Test where
+    data Unit = Unit
+         │      └─ type: ()
+         └─ type: *
+    data family Payload a
+                └─ type: * → *
+    data instance Payload Unit = PayloadUnit Unit
+                                 └─ type: () → Payload ()
+    unwrap :: Payload Unit -> Unit
+    unwrap payload = case payload of PayloadUnit value -> value
+    │      └─ type: Payload ()                   └─ type: ()
+    └─ type: Payload () → ()
+status: pass
+reason: data-family kinds, instance heads, constructors, and pattern uses are checked together

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -51,6 +51,7 @@ tcTests =
     [ testGroup "literals" literalTests,
       testGroup "application" applicationTests,
       testGroup "case" caseTests,
+      testGroup "data families" dataFamilyTests,
       testGroup "if-then-else" ifTests,
       testGroup "lambda" lambdaTests,
       testGroup "variables" variableTests,
@@ -180,6 +181,71 @@ caseTests =
       let result = tc "\\x -> case x of { y -> y }"
       assertBool "should succeed" (tcResultSuccess result)
       assertBool "should be function type" (isFunTy (tcResultType result))
+  ]
+
+dataFamilyTests :: [TestTree]
+dataFamilyTests =
+  [ testCase "exports standalone data-family instances across module groups" $ do
+      let providerResult =
+            resolve
+              [ parseOnlyWithExtensions
+                  [TypeFamilies]
+                  "module Provider (Unit(..), Payload(..)) where\n\
+                  \data Unit = Unit\n\
+                  \data family Payload a\n\
+                  \data instance Payload a = PayloadValue a\n"
+              ]
+          providerExports = extractInterface providerResult
+      case providerResult of
+        ResolveResult {resolvedModules = providerModules, resolveErrors = []} -> do
+          let (checkedProvider, interface) = typecheckModuleSccWithInterface mempty providerModules
+          assertBool
+            ("provider should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedProvider))
+            (all tcModuleSuccess checkedProvider)
+          assertBool
+            "checked syntax carries the family representation equation"
+            (any (containsParserAnnotation (isJust . fromAnnotation @DataFamilyInstanceInfo)) checkedProvider)
+          assertBool "family type constructor exported" ("Payload" `elem` map tciName (tcInterfaceTyCons interface))
+          case tcInterfaceDataFamilyInstances interface of
+            [familyInstance] -> do
+              assertEqual "family name" "Payload" (dfiiFamilyName familyInstance)
+              assertEqual "one instance variable" 1 (length (dfiiTyVars familyInstance))
+              assertEqual "representation name" "$R$Payload$PayloadValue" (tyConName (dfiiRepresentationTyCon familyInstance))
+              assertEqual "axiom name" "$ax$Payload$PayloadValue" (dfiiAxiomName familyInstance)
+              assertEqual "constructors" ["PayloadValue"] (dfiiConstructorNames familyInstance)
+              assertBool "data instance is not a newtype" (not (dfiiIsNewtype familyInstance))
+            familyInstances -> assertFailure ("expected one exported family instance, got: " <> show familyInstances)
+          let consumer =
+                parseOnlyWithExtensions
+                  [TypeFamilies]
+                  "module Consumer where\n\
+                  \import Provider\n\
+                  \unwrap :: Payload Unit -> Unit\n\
+                  \unwrap payload = case payload of PayloadValue value -> value\n"
+          case resolveWithDeps providerExports [consumer] of
+            ResolveResult {resolvedModules = consumerModules, resolveErrors = []} -> do
+              let (checkedConsumer, _) = typecheckModuleSccWithInterface interface consumerModules
+              assertBool
+                ("consumer should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedConsumer))
+                (all tcModuleSuccess checkedConsumer)
+            ResolveResult {resolveErrors} ->
+              assertFailure ("Resolve error in data-family consumer: " <> show resolveErrors)
+        ResolveResult {resolveErrors} ->
+          assertFailure ("Resolve error in data-family provider: " <> show resolveErrors),
+    testCase "rejects an instance whose head is not a data family" $ do
+      let result =
+            typecheckModule $
+              parseMWithExtensions
+                [TypeFamilies]
+                "module Test where\n\
+                \data Ordinary a = Ordinary a\n\
+                \data instance Ordinary a = InvalidOrdinary a\n"
+          isInvalidHead diagnostic =
+            case diagKind diagnostic of
+              OtherError "data-family instance head does not name a data family: Ordinary" -> True
+              _ -> False
+      assertBool "module should fail" (not (tcModuleSuccess result))
+      assertBool ("expected an invalid family-head diagnostic, got: " <> show (tcModuleDiagnostics result)) (any isInvalidHead (tcModuleDiagnostics result))
   ]
 
 -- | Tests for lambda expressions.


### PR DESCRIPTION
## Summary

- resolve standalone `data family` declarations and `data`/`newtype instance` declarations, including constructor exports through `Family(..)`
- register data families and checked instance equations in the type checker, carry those facts in annotated syntax and `TcInterface`, and preserve them across module groups
- lower checked data-family instances to distinct System FC representation declarations plus nominal equality axioms
- bump the dependency cache schema to 29 for the extended serialized type-checker interface

## Why

The generalized interface and axiom foundation from #1382 now has its first source-language producer. Resolver, TC, and FC agree on one checked representation equation instead of asking FC to reconstruct Haskell family typing from syntax.

## Scope

This PR deliberately covers standalone data families and H98-style standalone data/newtype instances. Associated families, overlap/apartness checking, deriving for family instances, and term-level constructor/pattern cast lowering remain follow-up work. Consequently, family declarations and their semantic interfaces are now represented end to end, but libraries that execute family constructor uses are not installable yet.

## Validation

- `just fmt`
- `just check`
- focused resolver, type-checker, and System FC suites while developing the new golden fixtures

## Progress counts

- `aihc-resolve`: 46 -> 47 tests
- `aihc-tc`: 102 -> 105 tests
- `aihc-fc`: 139 -> 141 tests
- No README files updated.
