### PR TITLE
feat(base): implement GHC.Ix

### DIFF
--- a/core-libs/aihc-base/src/Data/Ix.hs
+++ b/core-libs/aihc-base/src/Data/Ix.hs
@@ -1,1 +1,6 @@
-module Data.Ix () where
+module Data.Ix
+  ( Ix (range, index, inRange, rangeSize),
+  )
+where
+
+import GHC.Ix (Ix (inRange, index, range, rangeSize))

--- a/core-libs/aihc-base/src/GHC/Ix.hs
+++ b/core-libs/aihc-base/src/GHC/Ix.hs
@@ -1,1 +1,95 @@
-module GHC.Ix () where
+module GHC.Ix
+  ( Ix (..),
+    indexError,
+  )
+where
+
+import Prelude
+
+class (Ord a) => Ix a where
+  range :: (a, a) -> [a]
+  index :: (a, a) -> a -> Int
+  unsafeIndex :: (a, a) -> a -> Int
+  inRange :: (a, a) -> a -> Bool
+  rangeSize :: (a, a) -> Int
+  unsafeRangeSize :: (a, a) -> Int
+
+  index bounds value =
+    case inRange bounds value of
+      True -> unsafeIndex bounds value
+      False -> hopelessIndexError
+
+  unsafeIndex = index
+
+  rangeSize bounds@(_, upper) =
+    case inRange bounds upper of
+      True -> unsafeIndex bounds upper + 1
+      False -> 0
+
+  unsafeRangeSize bounds@(_, upper) = unsafeIndex bounds upper + 1
+
+indexError :: (Show a) => (a, a) -> a -> String -> b
+indexError = indexError
+
+hopelessIndexError :: Int
+hopelessIndexError = hopelessIndexError
+
+instance Ix Bool where
+  range = enumBounds
+  unsafeIndex (lower, _) value = fromEnum value - fromEnum lower
+  index bounds value =
+    case inRange bounds value of
+      True -> unsafeIndex bounds value
+      False -> indexError bounds value "Bool"
+  inRange = enumInRange
+
+instance Ix Ordering where
+  range = orderingRange
+  unsafeIndex (lower, _) value = orderingIndex value - orderingIndex lower
+  index bounds value =
+    case inRange bounds value of
+      True -> unsafeIndex bounds value
+      False -> indexError bounds value "Ordering"
+  inRange = enumInRangeBy orderingIndex
+
+instance Ix Int where
+  range = enumBounds
+  unsafeIndex (lower, _) value = value - lower
+  index bounds value =
+    case inRange bounds value of
+      True -> unsafeIndex bounds value
+      False -> indexError bounds value "Int"
+  inRange (lower, upper) value = lower <= value && value <= upper
+
+instance Ix Integer where
+  range = enumBounds
+  unsafeIndex (lower, _) value = fromInteger (value - lower)
+  index bounds value =
+    case inRange bounds value of
+      True -> unsafeIndex bounds value
+      False -> indexError bounds value "Integer"
+  inRange (lower, upper) value = lower <= value && value <= upper
+
+enumBounds :: (Enum a) => (a, a) -> [a]
+enumBounds (lower, upper) = enumFromTo lower upper
+
+enumInRange :: (Enum a) => (a, a) -> a -> Bool
+enumInRange = enumInRangeBy fromEnum
+
+enumInRangeBy :: (a -> Int) -> (a, a) -> a -> Bool
+enumInRangeBy toIndex (lower, upper) value =
+  toIndex lower <= toIndex value && toIndex value <= toIndex upper
+
+orderingRange :: (Ordering, Ordering) -> [Ordering]
+orderingRange (LT, LT) = [LT]
+orderingRange (LT, EQ) = [LT, EQ]
+orderingRange (LT, GT) = [LT, EQ, GT]
+orderingRange (EQ, EQ) = [EQ]
+orderingRange (EQ, GT) = [EQ, GT]
+orderingRange (GT, GT) = [GT]
+orderingRange _ = []
+
+orderingIndex :: Ordering -> Int
+orderingIndex LT = 0
+orderingIndex EQ = 1
+orderingIndex GT = 2

--- a/test/Test/Fixtures/eval/base/ghc-ix-api.yaml
+++ b/test/Test/Fixtures/eval/base/ghc-ix-api.yaml
@@ -1,0 +1,61 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Ix (Ix (index, inRange, range, rangeSize))
+    import GHC.Ix (unsafeIndex, unsafeRangeSize)
+
+    boolResults :: ([Bool], [Bool], (Int, Int, Int), (Bool, Bool))
+    boolResults =
+      ( range (False, True),
+        range (True, False),
+        (index (False, True) True, rangeSize (False, True), rangeSize (True, False)),
+        (inRange (False, True) False, inRange (True, True) False)
+      )
+
+    orderingResults :: ([Ordering], Int, Bool)
+    orderingResults =
+      ( range (LT, GT),
+        index (LT, GT) EQ,
+        inRange (EQ, GT) LT
+      )
+
+    twoInt :: Int
+    twoInt = 2
+
+    threeInt :: Int
+    threeInt = 3
+
+    fourInt :: Int
+    fourInt = 4
+
+    fiveInt :: Int
+    fiveInt = 5
+
+    intResults :: ([Int], (Int, Int), (Bool, Bool))
+    intResults =
+      ( range (twoInt, fourInt),
+        (index (twoInt, fourInt) threeInt, unsafeIndex (twoInt, fourInt) fourInt),
+        (inRange (twoInt, fourInt) twoInt, inRange (twoInt, fourInt) fiveInt)
+      )
+
+    threeInteger :: Integer
+    threeInteger = 3
+
+    fiveInteger :: Integer
+    fiveInteger = 5
+
+    integerResults :: ([Integer], (Int, Int))
+    integerResults =
+      ( range (threeInteger, fiveInteger),
+        (index (threeInteger, fiveInteger) fiveInteger, unsafeRangeSize (threeInteger, fiveInteger))
+      )
+output: |
+  ((((: False (: True [])),[],((I# 1),(I# 2),(I# 0)),(True,False)),((: LT (: EQ (: GT []))),(I# 1),False)),(((: (I# 2) (: (I# 3) (: (I# 4) []))),((I# 1),(I# 2)),(True,False)),((: (IS 3) (: (IS 4) (: (IS 5) []))),((I# 2),(I# 3)))))
+expression: |
+  ((boolResults, orderingResults), (intResults, integerResults))
+status: pass
+reason: evaluates the GHC.Ix class, scalar instances, safe Data.Ix API, and unsafe GHC.Ix methods


### PR DESCRIPTION
## Summary

- implement the `GHC.Ix` class, its default methods, and `indexError`
- add `Ix` instances for `Bool`, `Ordering`, `Int`, and `Integer`
- expose the standard safe subset from `Data.Ix`
- add a shared FC/GRIN evaluation fixture covering ranges, indexing, membership, empty ranges, range sizes, and unsafe operations

## Impact

Programs using the scalar `Ix` API can now compile and evaluate against `aihc-base`, including consumers that import the portable `Data.Ix` surface.

## API progress

- `base`: 241/10,055 (2.40%) → 248/10,055 (2.47%), +7 matched items
- extra `base` exports: unchanged at 49
- `ghc-prim`: unchanged at 52/3,425 (1.52%)

README progress counts are intentionally unchanged because they are cron-managed.

## Validation

- `just fmt`
- `just check`
- focused FC shared evaluation fixture
- focused GRIN shared evaluation fixture
