### PR TITLE
feat(base): implement Data.Foldable

### DIFF
--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -1372,13 +1372,18 @@ exprType expr =
     FcCast inner _ -> exprType inner
     FcCallForeign foreignCall _arguments ->
       Just (fcForeignCallResultType (fcForeignCallSignature foreignCall))
-  where
-    functionResultType functionType =
-      case functionType of
-        TcFunTy _ result -> Just result
-        TcQualTy [] body -> functionResultType body
-        TcQualTy (_ : predicates) body -> Just (if null predicates then body else TcQualTy predicates body)
-        _ -> Nothing
+
+-- A default class method can be specialized to its class constructor before
+-- its method type variables, then applied to the instance dictionary. Preserve
+-- those still-polymorphic binders while consuming the runtime argument.
+functionResultType :: TcType -> Maybe TcType
+functionResultType functionType =
+  case functionType of
+    TcFunTy _ result -> Just result
+    TcForAllTy tyVar body -> TcForAllTy tyVar <$> functionResultType body
+    TcQualTy [] body -> functionResultType body
+    TcQualTy (_ : predicates) body -> Just (if null predicates then body else TcQualTy predicates body)
+    _ -> Nothing
 
 typeRuntimeRep :: TcType -> RuntimeRep
 typeRuntimeRep ty =
@@ -1391,13 +1396,6 @@ applicationResultRep function =
   case exprType function >>= functionResultType of
     Just result -> typeRuntimeRep result
     Nothing -> error ("GRIN lowering could not determine application result type: " <> show function)
-  where
-    functionResultType functionType =
-      case functionType of
-        TcFunTy _ result -> Just result
-        TcQualTy [] body -> functionResultType body
-        TcQualTy (_ : predicates) body -> Just (if null predicates then body else TcQualTy predicates body)
-        _ -> Nothing
 
 functionArgumentRep :: FcExpr -> RuntimeRep
 functionArgumentRep function =
@@ -1408,6 +1406,7 @@ functionArgumentRep function =
     functionArgumentType functionType =
       case functionType of
         TcFunTy argument _ -> Just argument
+        TcForAllTy _ body -> functionArgumentType body
         TcQualTy [] body -> functionArgumentType body
         _ -> Nothing
 

--- a/core-libs/aihc-base/src/Control/Applicative.hs
+++ b/core-libs/aihc-base/src/Control/Applicative.hs
@@ -1,6 +1,30 @@
 module Control.Applicative
   ( Applicative (..),
+    Alternative (..),
   )
 where
 
-import Prelude (Applicative (..))
+import Prelude (Applicative (..), Functor (..), Maybe (..), (++))
+
+class (Applicative f) => Alternative f where
+  empty :: f a
+  (<|>) :: f a -> f a -> f a
+  some :: f a -> f [a]
+  many :: f a -> f [a]
+
+  some value = fmap prepend value <*> many value
+  many value = some value <|> pure []
+
+infixl 3 <|>
+
+prepend :: a -> [a] -> [a]
+prepend value values = value : values
+
+instance Alternative [] where
+  empty = []
+  (<|>) = (++)
+
+instance Alternative Maybe where
+  empty = Nothing
+  Nothing <|> value = value
+  value <|> _ = value

--- a/core-libs/aihc-base/src/Control/Monad.hs
+++ b/core-libs/aihc-base/src/Control/Monad.hs
@@ -1,7 +1,20 @@
 module Control.Monad
   ( Monad (..),
+    MonadPlus (..),
     (=<<),
   )
 where
 
-import Prelude (Monad (..), (=<<))
+import Control.Applicative (Alternative (..))
+import Prelude (Maybe, Monad (..), (=<<))
+
+class (Alternative m, Monad m) => MonadPlus m where
+  mzero :: m a
+  mplus :: m a -> m a -> m a
+
+  mzero = empty
+  mplus = (<|>)
+
+instance MonadPlus []
+
+instance MonadPlus Maybe

--- a/core-libs/aihc-base/src/Data/Foldable.hs
+++ b/core-libs/aihc-base/src/Data/Foldable.hs
@@ -1,1 +1,257 @@
-module Data.Foldable () where
+{-# LANGUAGE KindSignatures #-}
+
+module Data.Foldable
+  ( Foldable (..),
+    foldrM,
+    foldlM,
+    traverse_,
+    for_,
+    sequenceA_,
+    asum,
+    mapM_,
+    forM_,
+    sequence_,
+    msum,
+    concat,
+    concatMap,
+    and,
+    or,
+    any,
+    all,
+    maximumBy,
+    minimumBy,
+    notElem,
+    find,
+  )
+where
+
+import Control.Applicative (Alternative (..))
+import Control.Monad (MonadPlus (..))
+import Data.Kind (Type)
+import Data.Monoid (Monoid (..))
+import Data.Semigroup (Semigroup (..))
+import Prelude
+  ( Applicative (..),
+    Bool (..),
+    Either (..),
+    Eq (..),
+    Functor (..),
+    Int,
+    Maybe (..),
+    Monad (..),
+    Num (..),
+    Ord (..),
+    Ordering (..),
+    id,
+    not,
+    (&&),
+    (++),
+    (.),
+    (||),
+  )
+
+class Foldable (t :: Type -> Type) where
+  fold :: (Monoid m) => t m -> m
+  foldMap :: (Monoid m) => (a -> m) -> t a -> m
+  foldMap' :: (Monoid m) => (a -> m) -> t a -> m
+  foldr :: (a -> b -> b) -> b -> t a -> b
+  foldr' :: (a -> b -> b) -> b -> t a -> b
+  foldl :: (b -> a -> b) -> b -> t a -> b
+  foldl' :: (b -> a -> b) -> b -> t a -> b
+  foldr1 :: (a -> a -> a) -> t a -> a
+  foldl1 :: (a -> a -> a) -> t a -> a
+  toList :: t a -> [a]
+  null :: t a -> Bool
+  length :: t a -> Int
+  elem :: (Eq a) => a -> t a -> Bool
+  maximum :: (Ord a) => t a -> a
+  minimum :: (Ord a) => t a -> a
+  sum :: (Num a) => t a -> a
+  product :: (Num a) => t a -> a
+
+  fold = foldMap identityFoldable
+  foldMap f = foldr (\value rest -> f value <> rest) mempty
+  foldMap' f = foldl' (\rest value -> rest <> f value) mempty
+  foldr f initial structure = applyEndo (foldMap (Endo . f) structure) initial
+  foldr' f initial structure = foldl strictRightStep id structure initial
+    where
+      strictRightStep continuation value rest =
+        case f value rest of
+          result -> continuation result
+  foldl f initial structure = foldr leftStep id structure initial
+    where
+      leftStep value continuation rest = continuation (f rest value)
+  foldl' f initial structure = foldr strictLeftStep id structure initial
+    where
+      strictLeftStep value continuation rest =
+        case f rest value of
+          result -> continuation result
+  foldr1 f structure = fromMaybeFoldable emptyStructure (foldr rightStep Nothing structure)
+    where
+      rightStep value Nothing = Just value
+      rightStep value (Just rest) = Just (f value rest)
+  foldl1 f structure = fromMaybeFoldable emptyStructure (foldl leftStep Nothing structure)
+    where
+      leftStep Nothing value = Just value
+      leftStep (Just rest) value = Just (f rest value)
+  toList = foldr (:) []
+  null = foldr (\_ _ -> False) True
+  length = foldl' (\count _ -> count + 1) 0
+  elem target = foldr (\value rest -> value == target || rest) False
+  maximum = foldr1 maximumValue
+  minimum = foldr1 minimumValue
+  sum = foldl' (+) 0
+  product = foldl' (*) 1
+
+infix 4 `elem`
+
+identityFoldable :: a -> a
+identityFoldable value = value
+
+fromMaybeFoldable :: a -> Maybe a -> a
+fromMaybeFoldable fallback Nothing = fallback
+fromMaybeFoldable _ (Just value) = value
+
+maximumValue :: (Ord a) => a -> a -> a
+maximumValue = max
+
+minimumValue :: (Ord a) => a -> a -> a
+minimumValue = min
+
+newtype Endo a = Endo (a -> a)
+
+applyEndo :: Endo a -> a -> a
+applyEndo (Endo f) = f
+
+instance Semigroup (Endo a) where
+  Endo left <> Endo right = Endo (left . right)
+
+instance Monoid (Endo a) where
+  mempty = Endo id
+
+emptyStructure :: a
+emptyStructure = emptyStructure
+
+instance Foldable [] where
+  foldr _ initial [] = initial
+  foldr f initial (value : values) = f value (foldr f initial values)
+
+  foldl _ initial [] = initial
+  foldl f initial (value : values) = foldl f (f initial value) values
+
+  foldl' _ initial [] = initial
+  foldl' f initial (value : values) =
+    case f initial value of
+      result -> foldl' f result values
+
+  null [] = True
+  null (_ : _) = False
+
+instance Foldable Maybe where
+  foldr _ initial Nothing = initial
+  foldr f initial (Just value) = f value initial
+
+  foldl _ initial Nothing = initial
+  foldl f initial (Just value) = f initial value
+
+  null Nothing = True
+  null (Just _) = False
+
+instance Foldable (Either e) where
+  foldr _ initial (Left _) = initial
+  foldr f initial (Right value) = f value initial
+
+  foldl _ initial (Left _) = initial
+  foldl f initial (Right value) = f initial value
+
+  null (Left _) = True
+  null (Right _) = False
+
+instance Foldable ((,) e) where
+  foldr f initial (_, value) = f value initial
+  foldl f initial (_, value) = f initial value
+  null _ = False
+
+foldrM :: (Foldable t, Monad m) => (a -> b -> m b) -> b -> t a -> m b
+foldrM f initial structure = foldl step pure structure initial
+  where
+    step continuation value rest = f value rest >>= continuation
+
+foldlM :: (Foldable t, Monad m) => (b -> a -> m b) -> b -> t a -> m b
+foldlM f initial structure = foldr step pure structure initial
+  where
+    step value continuation rest = f rest value >>= continuation
+
+traverse_ :: (Foldable t, Applicative f) => (a -> f b) -> t a -> f ()
+traverse_ f = foldr (thenApplicative . f) (pure ())
+
+for_ :: (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
+for_ structure f = traverse_ f structure
+
+sequenceA_ :: (Foldable t, Applicative f) => t (f a) -> f ()
+sequenceA_ = foldr thenApplicative (pure ())
+
+asum :: (Foldable t, Alternative f) => t (f a) -> f a
+asum = foldr (<|>) empty
+
+mapM_ :: (Foldable t, Monad m) => (a -> m b) -> t a -> m ()
+mapM_ = traverse_
+
+forM_ :: (Foldable t, Monad m) => t a -> (a -> m b) -> m ()
+forM_ = for_
+
+sequence_ :: (Foldable t, Monad m) => t (m a) -> m ()
+sequence_ = sequenceA_
+
+msum :: (Foldable t, MonadPlus m) => t (m a) -> m a
+msum = foldr mplus mzero
+
+concat :: (Foldable t) => t [a] -> [a]
+concat = foldr (++) []
+
+concatMap :: (Foldable t) => (a -> [b]) -> t a -> [b]
+concatMap f = foldr (\value rest -> f value ++ rest) []
+
+and :: (Foldable t) => t Bool -> Bool
+and = foldr (&&) True
+
+or :: (Foldable t) => t Bool -> Bool
+or = foldr (||) False
+
+any :: (Foldable t) => (a -> Bool) -> t a -> Bool
+any predicate = foldr (\value rest -> predicate value || rest) False
+
+all :: (Foldable t) => (a -> Bool) -> t a -> Bool
+all predicate = foldr (\value rest -> predicate value && rest) True
+
+maximumBy :: (Foldable t) => (a -> a -> Ordering) -> t a -> a
+maximumBy compareValues = foldr1 choose
+  where
+    choose left right =
+      case compareValues left right of
+        GT -> left
+        _ -> right
+
+minimumBy :: (Foldable t) => (a -> a -> Ordering) -> t a -> a
+minimumBy compareValues = foldr1 choose
+  where
+    choose left right =
+      case compareValues left right of
+        GT -> right
+        _ -> left
+
+notElem :: (Foldable t, Eq a) => a -> t a -> Bool
+notElem target structure = not (target `elem` structure)
+
+infix 4 `notElem`
+
+find :: (Foldable t) => (a -> Bool) -> t a -> Maybe a
+find predicate = foldr choose Nothing
+  where
+    choose value rest =
+      case predicate value of
+        True -> Just value
+        False -> rest
+
+thenApplicative :: (Applicative f) => f a -> f b -> f b
+thenApplicative first second = fmap (\_ value -> value) first <*> second

--- a/core-libs/aihc-base/src/Data/Monoid.hs
+++ b/core-libs/aihc-base/src/Data/Monoid.hs
@@ -1,1 +1,34 @@
-module Data.Monoid () where
+module Data.Monoid
+  ( Monoid (..),
+  )
+where
+
+import Data.Semigroup (Semigroup (..))
+import Prelude (Maybe (..))
+
+class (Semigroup a) => Monoid a where
+  mempty :: a
+  mappend :: a -> a -> a
+  mconcat :: [a] -> a
+
+  mappend = (<>)
+  mconcat = foldMonoid
+
+infixr 6 `mappend`
+
+{- HLINT ignore foldMonoid "Use foldr" -}
+foldMonoid :: (Monoid a) => [a] -> a
+foldMonoid [] = mempty
+foldMonoid (value : values) = value <> foldMonoid values
+
+instance Monoid [a] where
+  mempty = []
+
+instance (Semigroup a) => Monoid (Maybe a) where
+  mempty = Nothing
+
+instance Monoid () where
+  mempty = ()
+
+instance (Monoid a, Monoid b) => Monoid (a, b) where
+  mempty = (mempty, mempty)

--- a/core-libs/aihc-base/src/Data/Semigroup.hs
+++ b/core-libs/aihc-base/src/Data/Semigroup.hs
@@ -1,1 +1,25 @@
-module Data.Semigroup () where
+module Data.Semigroup
+  ( Semigroup (..),
+  )
+where
+
+import Prelude (Maybe (..), (++))
+
+class Semigroup a where
+  (<>) :: a -> a -> a
+
+infixr 6 <>
+
+instance Semigroup [a] where
+  (<>) = (++)
+
+instance (Semigroup a) => Semigroup (Maybe a) where
+  Nothing <> value = value
+  value <> Nothing = value
+  Just left <> Just right = Just (left <> right)
+
+instance Semigroup () where
+  _ <> _ = ()
+
+instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
+  (leftA, leftB) <> (rightA, rightB) = (leftA <> rightA, leftB <> rightB)

--- a/test/Test/Fixtures/eval/base/data-foldable.yaml
+++ b/test/Test/Fixtures/eval/base/data-foldable.yaml
@@ -1,0 +1,112 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Control.Applicative (Alternative (..))
+    import Control.Monad (MonadPlus (..))
+    import Data.Foldable
+    import Data.Monoid (Monoid (..))
+    import Data.Semigroup (Semigroup (..))
+
+    data Tree a = Leaf a | Branch (Tree a) (Tree a)
+
+    instance Functor Tree where
+      fmap f (Leaf x) = Leaf (f x)
+      fmap f (Branch left right) = Branch (fmap f left) (fmap f right)
+
+    instance Foldable Tree where
+      foldr f z (Leaf x) = f x z
+      foldr f z (Branch left right) = foldr f (foldr f z right) left
+
+    data Append a = Append [a]
+
+    instance Semigroup (Append a) where
+      Append xs <> Append ys = Append (xs ++ ys)
+
+    instance Monoid (Append a) where
+      mempty = Append []
+
+    tree :: Tree Int
+    tree = Branch (Leaf 1) (Branch (Leaf 2) (Leaf 3))
+
+    appendValues :: Append a -> [a]
+    appendValues (Append xs) = xs
+
+    positive :: Int -> Maybe Int
+    positive x = if x > 0 then Just x else Nothing
+
+    prependM :: Int -> [Int] -> Maybe [Int]
+    prependM x xs = Just (x : xs)
+
+    reversePrependM :: [Int] -> Int -> Maybe [Int]
+    reversePrependM xs x = Just (x : xs)
+
+    fromMaybeList :: Maybe [a] -> [a]
+    fromMaybeList Nothing = []
+    fromMaybeList (Just xs) = xs
+
+    isJustValue :: Maybe a -> Bool
+    isJustValue Nothing = False
+    isJustValue (Just _) = True
+
+    fromMaybeValue :: a -> Maybe a -> a
+    fromMaybeValue fallback Nothing = fallback
+    fromMaybeValue _ (Just value) = value
+
+    checks :: [Bool]
+    checks =
+      [ appendValues (Append [True] <> Append [False, True]) == [True, False, True],
+        appendValues (mappend (Append [True]) (Append [False])) == [True, False],
+        appendValues (mconcat [Append [True], Append [False], Append [True]]) == [True, False, True],
+        appendValues (foldMap (\x -> Append [x]) tree) == [1, 2, 3],
+        appendValues (fold (fmap (\x -> Append [x]) tree)) == [1, 2, 3],
+        appendValues (foldMap' (\x -> Append [x]) tree) == [1, 2, 3],
+        foldr (:) [] tree == [1, 2, 3],
+        foldr' (:) [] tree == [1, 2, 3],
+        foldl (\xs x -> x : xs) [] tree == [3, 2, 1],
+        foldl' (\xs x -> x : xs) [] tree == [3, 2, 1],
+        foldr1 (-) tree == 2,
+        foldl1 (-) tree == negate 4,
+        toList tree == [1, 2, 3],
+        null (Branch (Leaf True) (Leaf False)) == False,
+        null (Nothing :: Maybe Bool) == True,
+        length tree == 3,
+        elem 2 tree,
+        maximum tree == 3,
+        minimum tree == 1,
+        sum tree == 6,
+        product tree == 6,
+        fromMaybeList (foldrM prependM [] tree) == [1, 2, 3],
+        fromMaybeList (foldlM reversePrependM [] tree) == [3, 2, 1],
+        isJustValue (traverse_ positive tree),
+        isJustValue (for_ tree positive),
+        isJustValue (sequenceA_ (Branch (Leaf (Just True)) (Leaf (Just False)))),
+        fromMaybeValue False (asum (Branch (Leaf Nothing) (Leaf (Just True)))),
+        isJustValue (mapM_ positive tree),
+        isJustValue (forM_ tree positive),
+        isJustValue (sequence_ (Branch (Leaf (Just True)) (Leaf (Just False)))),
+        fromMaybeValue False (msum (Branch (Leaf Nothing) (Leaf (Just True)))),
+        concat (Branch (Leaf [True, False]) (Leaf [True])) == [True, False, True],
+        concatMap (\x -> [x, x]) tree == [1, 1, 2, 2, 3, 3],
+        and (Branch (Leaf True) (Leaf False)) == False,
+        or (Branch (Leaf False) (Leaf True)) == True,
+        any (\x -> x > 2) tree,
+        all (\x -> x > 0) tree,
+        maximumBy compare tree == 3,
+        minimumBy compare tree == 1,
+        notElem 4 tree,
+        fromMaybeValue 0 (find (\x -> x > 1) tree) == 2,
+        toList [True, False, True] == [True, False, True],
+        toList (Just True) == [True],
+        toList (Left False :: Either Bool Int) == [],
+        toList (Right 1 :: Either Bool Int) == [1],
+        fromMaybeValue False (empty <|> Just True),
+        fromMaybeValue False (mzero `mplus` Just True)
+      ]
+output: |
+  True
+expression: and checks
+status: pass
+reason: evaluates the Data.Foldable API, Foldable instances, and its prerequisite algebra classes from aihc-base


### PR DESCRIPTION
## Summary

- implement the base 4.22 `Data.Foldable` class interface, defaults, specialized folds, action folds, and searches
- add the prerequisite `Semigroup`, `Monoid`, `Alternative`, and `MonadPlus` classes with core list, `Maybe`, `Either`, unit, and tuple instances where applicable
- preserve polymorphic binders while GRIN lowering consumes default-method dictionary arguments
- add a shared FC/GRIN evaluation fixture covering fold direction, algebraic defaults, action ordering, searches, and concrete instances

## Core library progress

- `BASE`: 241 / 10055 (2.40%) → 276 / 10055 (2.74%), **+35 symbols**
- `GHC_PRIM`: unchanged at 52 / 3425 (1.52%)

## Validation

- `just fmt`
- `just check`
