### PR TITLE
feat(base): implement GHC.ST and GHC.STRef

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -623,6 +623,7 @@ primitiveImportSpecs =
       primitive "raise#" "a -> b",
       primitive "unsafeCoerce#" "a -> b",
       primitive "realWorld#" "State# RealWorld",
+      primitive "noDuplicate#" "State# d -> State# d",
       primitive
         "catch#"
         "(State# RealWorld -> (# State# RealWorld, a #)) -> (b -> State# RealWorld -> (# State# RealWorld, a #)) -> State# RealWorld -> (# State# RealWorld, a #)",
@@ -637,6 +638,7 @@ primitiveImportSpecs =
       primitive "newMutVar#" "a -> State# d -> (# State# d, MutVar# d a #)",
       primitive "readMutVar#" "MutVar# d a -> State# d -> (# State# d, a #)",
       primitive "writeMutVar#" "MutVar# d a -> a -> State# d -> State# d",
+      primitive "sameMutVar#" "MutVar# d a -> MutVar# d a -> Int#",
       primitive "newByteArray#" "Int# -> State# d -> (# State# d, MutableByteArray# d #)",
       primitive "newPinnedByteArray#" "Int# -> State# d -> (# State# d, MutableByteArray# d #)",
       primitive "newAlignedPinnedByteArray#" "Int# -> Int# -> State# d -> (# State# d, MutableByteArray# d #)",

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -613,12 +613,13 @@ dsAnnotatedVar tcAnn name _expr = do
   pure (List.foldl' FcApp typedExpr dicts)
 
 dsAnnotatedExpr :: TcAnnotation -> Expr -> DsM FcExpr
-dsAnnotatedExpr tcAnn inner =
-  case inner of
+dsAnnotatedExpr tcAnn inner = do
+  body <- case inner of
     EAnn ann (EInt value TInteger _)
       | Just resolution <- fromAnnotation ann,
         isFromIntegerResolution resolution ->
           dsOverloadedIntegerLiteral tcAnn resolution value
+    EAnn _ nested -> dsExpr nested
     EVar name -> dsAnnotatedVar tcAnn name inner
     EApp fun arg -> FcApp <$> dsExpr fun <*> dsExpr arg
     ELetDecls decls body -> dsLetDecls decls (dsExpr body)
@@ -633,6 +634,7 @@ dsAnnotatedExpr tcAnn inner =
     EInfix lhs op rhs -> dsInfix lhs op rhs
     ECase scrut alts -> dsCase scrut alts
     _ -> desugarBug ("unsupported annotated expression form after type checking: " <> take 80 (show inner))
+  pure (foldr FcTyLam body (tcAnnTypeBinders tcAnn))
 
 dsDo :: [DoStmt Expr] -> DsM FcExpr
 dsDo stmts =

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -397,6 +397,8 @@ evalPrimitive "unsafeCoerce#" [value] =
   forceValue value
 evalPrimitive "realWorld#" [] =
   pure VStateToken
+evalPrimitive "noDuplicate#" [state] =
+  pure state
 evalPrimitive "catch#" [action, handler, state] =
   applyValue action state `catchE` handleRaised
   where
@@ -438,6 +440,10 @@ evalPrimitive "writeMutVar#" [mutVar, value, state] = do
   EvalMutVar ref <- forceMutVarPrimitiveArg "writeMutVar#" mutVar
   lift (writeIORef ref value)
   pure state
+evalPrimitive "sameMutVar#" [left, right] = do
+  leftReference <- forceMutVarPrimitiveArg "sameMutVar#" left
+  rightReference <- forceMutVarPrimitiveArg "sameMutVar#" right
+  pure (intPrimitiveValue (if leftReference == rightReference then 1 else 0))
 evalPrimitive "newByteArray#" [size, state] = do
   byteArray <- allocateByteArray "newByteArray#" False 8 =<< forceIntPrimitiveArg "newByteArray#" size
   pure (VConstructor "(#,#)" [state, VByteArray byteArray])

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -764,6 +764,7 @@ evalPrimitive "chr#" [value] = do
     then pure [RuntimeLit (GrinLitChar WordRep (Char.chr (fromIntegral intValue)))]
     else throwInterpret (InterpretPrimitiveTypeError "chr#" (RuntimeLit (GrinLitInt IntRep intValue)))
 evalPrimitive "realWorld#" [] = pure []
+evalPrimitive "noDuplicate#" [] = pure []
 evalPrimitive "raise#" [exception] =
   throwE (EvalRaised exception)
 evalPrimitive "catch#" [action, handler] =
@@ -779,6 +780,10 @@ evalPrimitive "writeMutVar#" [mutVar, value] = do
   GrinMutVar reference <- expectMutVarPrimitiveArgument "writeMutVar#" mutVar
   liftEvalIO (writeIORef reference value)
   pure []
+evalPrimitive "sameMutVar#" [left, right] = do
+  leftReference <- expectMutVarPrimitiveArgument "sameMutVar#" left
+  rightReference <- expectMutVarPrimitiveArgument "sameMutVar#" right
+  pure [intRuntimeValue (if leftReference == rightReference then 1 else 0)]
 evalPrimitive "newByteArray#" [size] = do
   byteArray <- allocateByteArray "newByteArray#" False 8 =<< expectIntPrimitiveArgument "newByteArray#" size
   pure [RuntimeByteArray byteArray]

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -34,6 +34,7 @@ module Aihc.Tc.Annotations
     annotateExpr,
     annotateDecl,
     pendingAnnotation,
+    pendingTypeLambdaAnnotation,
 
     -- * Pretty-printing
     renderPred,
@@ -63,6 +64,8 @@ import Data.Text qualified as T
 data TcAnnotation = TcAnnotation
   { -- | The inferred/checked type of this node.
     tcAnnType :: !TcType,
+    -- | Type variables abstracted at this expression.
+    tcAnnTypeBinders :: ![TyVarId],
     -- | Type arguments made explicit at this occurrence.
     tcAnnTypeArgs :: ![TcType],
     -- | Evidence terms whose dictionaries must be passed at this occurrence.
@@ -116,6 +119,7 @@ data TcForeignAbiType
 -- ordinary 'TcAnnotation' values after solving.
 data PendingTcAnnotation = PendingTcAnnotation
   { pendingTcAnnType :: !TcType,
+    pendingTcAnnTypeBinders :: ![TyVarId],
     pendingTcAnnTypeArgs :: ![TcType],
     pendingTcAnnEvidenceVars :: ![EvVar],
     pendingTcAnnTermArgTypes :: ![TcType]
@@ -240,7 +244,10 @@ annotateDecl :: TcAnnotation -> Decl -> Decl
 annotateDecl ann = DeclAnn (mkAnnotation ann)
 
 pendingAnnotation :: TcType -> [TcType] -> [EvVar] -> [TcType] -> PendingTcAnnotation
-pendingAnnotation = PendingTcAnnotation
+pendingAnnotation ty = PendingTcAnnotation ty []
+
+pendingTypeLambdaAnnotation :: TcType -> [TyVarId] -> PendingTcAnnotation
+pendingTypeLambdaAnnotation ty binders = PendingTcAnnotation ty binders [] [] []
 
 -- | Render a binder and its 'TcType' as a human-readable signature.
 renderTcSignature :: Text -> TcType -> String

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -25,7 +25,7 @@ import Aihc.Tc.Annotations
 import Aihc.Tc.Env (DataFamilyInstanceInfo (..))
 import Aihc.Tc.Evidence (Coercion (..), EvTerm (..), EvVar)
 import Aihc.Tc.Monad
-import Aihc.Tc.Types (Pred (..), TcType (..), Unique (..))
+import Aihc.Tc.Types (Pred (..), TcType (..), TyVarId, Unique (..))
 import Aihc.Tc.Zonk (zonkType)
 import Control.Applicative ((<|>))
 import Control.Monad ((>=>))
@@ -66,12 +66,20 @@ finalizeAnnotationTc ann =
 annotationForPendingTc :: PendingTcAnnotation -> TcM TcAnnotation
 annotationForPendingTc pending = do
   ty <- zonkType (pendingTcAnnType pending)
+  typeBinders <- mapM zonkTypeBinder (pendingTcAnnTypeBinders pending)
   typeArgs <- mapM zonkType (pendingTcAnnTypeArgs pending)
   evidenceTerms <- mapM (evidenceForEvVar ty >=> zonkEvTerm) (pendingTcAnnEvidenceVars pending)
   termArgTypes <- mapM zonkType (pendingTcAnnTermArgTypes pending)
-  let ann = TcAnnotation ty typeArgs evidenceTerms termArgTypes
+  let ann = TcAnnotation ty typeBinders typeArgs evidenceTerms termArgTypes
   rejectMetaTcAnnotation ann
   pure ann
+
+zonkTypeBinder :: TyVarId -> TcM TyVarId
+zonkTypeBinder binder = do
+  binderType <- zonkType (TcTyVar binder)
+  case binderType of
+    TcTyVar binder' -> pure binder'
+    _ -> abortTc "internal type annotation error: type binder zonked to a non-variable"
 
 evidenceForEvVar :: TcType -> EvVar -> TcM EvTerm
 evidenceForEvVar contextType ev = do

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -591,7 +591,7 @@ annotateDeclTc classMethods checkedValueNames decl =
     DeclValue valueDecl
       | valueDeclWasChecked checkedValueNames valueDecl -> do
           (ty, valueDecl') <- annotateValueDeclTc valueDecl
-          pure (annotateDeclAt (valueDeclSpan valueDecl) (TcAnnotation ty [] [] []) (DeclValue valueDecl'))
+          pure (annotateDeclAt (valueDeclSpan valueDecl) (TcAnnotation ty [] [] [] []) (DeclValue valueDecl'))
       | otherwise -> pure decl
     DeclData dataDecl -> annotateDataDeclTc dataDecl
     DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
@@ -669,7 +669,7 @@ annotateDataDeclTc dataDecl = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
   ty <- tyConBindingType tyName
   constructors <- mapM annotateDataConDeclTc (dataDeclConstructors dataDecl)
-  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (dataDeclHead dataDecl)
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (dataDeclHead dataDecl)
   pure (DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors}))
 
 annotateNewtypeDeclTc :: NewtypeDecl -> TcM Decl
@@ -677,14 +677,14 @@ annotateNewtypeDeclTc newtypeDecl = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
   ty <- tyConBindingType tyName
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
-  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (newtypeDeclHead newtypeDecl)
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (newtypeDeclHead newtypeDecl)
   pure (DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor}))
 
 annotateDataFamilyDeclTc :: DataFamilyDecl -> TcM Decl
 annotateDataFamilyDeclTc familyDecl = do
   let familyName = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
   ty <- tyConBindingType familyName
-  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] []) (dataFamilyDeclHead familyDecl)
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (dataFamilyDeclHead familyDecl)
   pure (DeclDataFamilyDecl (familyDecl {dataFamilyDeclHead = annotatedHead}))
 
 annotateDataFamilyInstTc :: DataFamilyInst -> TcM Decl
@@ -713,7 +713,7 @@ annotateRegisteredDataConDeclTc dataConDecl =
   where
     annotateWithType ty = do
       zonkedTy <- zonkType ty
-      pure (DataConAnn (mkAnnotation (TcAnnotation zonkedTy [] [] [])) dataConDecl)
+      pure (DataConAnn (mkAnnotation (TcAnnotation zonkedTy [] [] [] [])) dataConDecl)
 
 annotateBinderHeadName :: TcAnnotation -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName tcAnn head' =
@@ -733,7 +733,7 @@ annotateDataConDeclTc dataConDecl = do
     [] -> pure dataConDecl
     (name, _) : _ -> do
       ty <- dataConBindingType name
-      pure (DataConAnn (mkAnnotation (TcAnnotation ty [] [] [])) dataConDecl)
+      pure (DataConAnn (mkAnnotation (TcAnnotation ty [] [] [] [])) dataConDecl)
 
 dataConBindingType :: Text -> TcM TcType
 dataConBindingType name = do
@@ -747,7 +747,7 @@ annotateForeignDeclTc :: ForeignDecl -> TcM Decl
 annotateForeignDeclTc foreignDecl = do
   ty <- bindingType (unqualifiedNameText (foreignName foreignDecl))
   let sourceSpan = unqualifiedNameSpan (foreignName foreignDecl)
-      annotated = annotateDeclAt sourceSpan (TcAnnotation ty [] [] []) (DeclForeign foreignDecl)
+      annotated = annotateDeclAt sourceSpan (TcAnnotation ty [] [] [] []) (DeclForeign foreignDecl)
   case foreignCallConv foreignDecl of
     CCall -> do
       plan <- checkForeignImportType sourceSpan ty

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -32,16 +32,19 @@ import Aihc.Parser.Syntax
     mkAnnotation,
   )
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
-import Aihc.Tc.Annotations (PendingTcAnnotation (..), pendingAnnotation)
+import Aihc.Tc.Annotations (PendingTcAnnotation (..), pendingAnnotation, pendingTypeLambdaAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Generate.Bind (inferLocalDecls, inferRhsWithLocals)
 import Aihc.Tc.Generate.Pattern
 import Aihc.Tc.Generate.PatternBranch (solvePatternBranch)
-import Aihc.Tc.Instantiate (Instantiation (..), instantiateWithArgs)
+import Aihc.Tc.Instantiate (Instantiation (..), applySubst, instantiateWithArgs)
 import Aihc.Tc.Kind (checkSurfaceType)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
+import Aihc.Tc.Unify (unify)
+import Aihc.Tc.Zonk (zonkType)
+import Control.Monad (when)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
@@ -154,8 +157,10 @@ inferNameOccurrence ambient nameSyntax = do
               (map ctEvVar cts)
               []
       pure (elaborationAnnotation pending, instType inst, cts)
-    Just (TcMonoIdBinder ty) ->
-      pure (Nothing, ty, [])
+    Just (TcMonoIdBinder ty) -> do
+      (instantiatedTy, typeArgs) <- instantiateSigmaType ty
+      let pending = pendingAnnotation instantiatedTy typeArgs [] []
+      pure (elaborationAnnotation pending, instantiatedTy, [])
     Nothing ->
       abortTc ("resolved term missing from type environment: " <> show name <> " resolved as " <> show target)
 
@@ -378,11 +383,102 @@ inferRhs = inferRhsWithLocals inferExpr
 inferApp :: SourceSpan -> Expr -> Expr -> TcM (Expr, TcType, [Ct])
 inferApp sp fun arg = do
   (fun', funTy, funCts) <- inferExpr fun
-  (arg', argTy, argCts) <- inferExpr arg
-  resTy <- freshMetaTv
-  ev <- freshEvVar
-  let eqCt = mkWantedCt (EqPred funTy (TcFunTy argTy resTy)) ev (AppOrigin sp) sp
-  pure (EApp fun' arg', resTy, funCts ++ argCts ++ [eqCt])
+  zonkedFunTy <- zonkType funTy
+  case zonkedFunTy of
+    TcFunTy expectedArgTy resultTy
+      | hasLeadingForAll expectedArgTy -> do
+          (arg', argCts) <- checkHigherRankArgument sp expectedArgTy arg
+          pure (EApp fun' arg', resultTy, funCts <> argCts)
+    _ -> do
+      (arg', argTy, argCts) <- inferExpr arg
+      resTy <- freshMetaTv
+      ev <- freshEvVar
+      let eqCt = mkWantedCt (EqPred funTy (TcFunTy argTy resTy)) ev (AppOrigin sp) sp
+      pure (EApp fun' arg', resTy, funCts <> argCts <> [eqCt])
+
+checkHigherRankArgument :: SourceSpan -> TcType -> Expr -> TcM (Expr, [Ct])
+checkHigherRankArgument sp expectedTy arg = do
+  boundary <- getUniqueBoundary
+  (arg', actualTy, argCts) <- inferExpr arg
+  (skolems, expectedBody) <- skolemizeSigmaType expectedTy
+  unify sp (AppOrigin sp) actualTy expectedBody
+  rejectEscapingHigherRankMetas sp boundary skolems actualTy
+  let annotatedArg = annotatePendingExprAt sp (pendingTypeLambdaAnnotation expectedTy skolems) arg'
+  pure (annotatedArg, argCts)
+
+hasLeadingForAll :: TcType -> Bool
+hasLeadingForAll TcForAllTy {} = True
+hasLeadingForAll _ = False
+
+instantiateSigmaType :: TcType -> TcM (TcType, [TcType])
+instantiateSigmaType = go []
+  where
+    go arguments (TcForAllTy binder body) = do
+      argument <- freshMetaTv
+      go (arguments <> [argument]) (applySubst (Map.singleton (tvUnique binder) argument) body)
+    go arguments ty = pure (ty, arguments)
+
+skolemizeSigmaType :: TcType -> TcM ([TyVarId], TcType)
+skolemizeSigmaType = go []
+  where
+    go skolems (TcForAllTy binder body) = do
+      skolem <- setTyVarKind (tvKind binder) <$> freshSkolemTv (tvName binder)
+      go (skolems <> [skolem]) (applySubst (Map.singleton (tvUnique binder) (TcTyVar skolem)) body)
+    go skolems ty = pure (skolems, ty)
+
+rejectEscapingHigherRankMetas :: SourceSpan -> Unique -> [TyVarId] -> TcType -> TcM ()
+rejectEscapingHigherRankMetas sp (Unique boundaryInt) skolems actualTy = do
+  let olderMetas = filter (isOlderThan boundaryInt) (typeMetaVariables actualTy)
+  escaped <- anyM (metaMentionsAnySkolem skolems) olderMetas
+  when escaped $
+    emitError sp (OtherError "higher-rank type variable escapes its argument")
+  where
+    isOlderThan threshold (Unique metaInt) = metaInt < threshold
+
+metaMentionsAnySkolem :: [TyVarId] -> Unique -> TcM Bool
+metaMentionsAnySkolem skolems meta = do
+  ty <- zonkType (TcMetaTv meta)
+  pure (any (`typeMentionsTyVar` ty) skolems)
+
+anyM :: (a -> TcM Bool) -> [a] -> TcM Bool
+anyM _ [] = pure False
+anyM predicate (value : values) = do
+  matches <- predicate value
+  if matches then pure True else anyM predicate values
+
+typeMetaVariables :: TcType -> [Unique]
+typeMetaVariables ty =
+  case ty of
+    TcTyVar {} -> []
+    TcMetaTv meta -> [meta]
+    TcTyCon _ arguments -> concatMap typeMetaVariables arguments
+    TcFunTy argument result -> typeMetaVariables argument <> typeMetaVariables result
+    TcForAllTy _ body -> typeMetaVariables body
+    TcQualTy predicates body -> concatMap predicateMetaVariables predicates <> typeMetaVariables body
+    TcAppTy function argument -> typeMetaVariables function <> typeMetaVariables argument
+
+predicateMetaVariables :: Pred -> [Unique]
+predicateMetaVariables predicate =
+  case predicate of
+    ClassPred _ arguments -> concatMap typeMetaVariables arguments
+    EqPred left right -> typeMetaVariables left <> typeMetaVariables right
+
+typeMentionsTyVar :: TyVarId -> TcType -> Bool
+typeMentionsTyVar target ty =
+  case ty of
+    TcTyVar tyVar -> tyVar == target
+    TcMetaTv {} -> False
+    TcTyCon _ arguments -> any (typeMentionsTyVar target) arguments
+    TcFunTy argument result -> typeMentionsTyVar target argument || typeMentionsTyVar target result
+    TcForAllTy binder body -> binder /= target && typeMentionsTyVar target body
+    TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
+    TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+
+predicateMentionsTyVar :: TyVarId -> Pred -> Bool
+predicateMentionsTyVar target predicate =
+  case predicate of
+    ClassPred _ arguments -> any (typeMentionsTyVar target) arguments
+    EqPred left right -> typeMentionsTyVar target left || typeMentionsTyVar target right
 
 inferTypeApp :: SourceSpan -> Expr -> Type -> TcM (Expr, TcType, [Ct])
 inferTypeApp sp fun tyArg = do

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -17,6 +17,7 @@ module Aihc.Tc.Monad
     freshMetaTv,
     freshSkolemTv,
     freshEvVar,
+    getUniqueBoundary,
 
     -- * Meta-variable solutions
     writeMetaTv,
@@ -245,6 +246,11 @@ freshSkolemTv name = do
 -- | Allocate a fresh evidence variable.
 freshEvVar :: TcM EvVar
 freshEvVar = EvVar <$> freshUnique
+
+-- | Snapshot the unique supply. Uniques below this boundary were allocated
+-- before the current type-checking region.
+getUniqueBoundary :: TcM Unique
+getUniqueBoundary = Unique <$> lift (gets tcsNextUnique)
 
 -- | Record the solution for a meta-variable.
 writeMetaTv :: Unique -> TcType -> TcM ()

--- a/components/aihc-tc/test/Test/Fixtures/annotated/rank-n-argument.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/rank-n-argument.yaml
@@ -1,0 +1,52 @@
+extensions:
+  - RankNTypes
+modules:
+  - |
+    module Test where
+
+    data State s a = State a
+    data World = World
+    data Result = Result
+
+    runState :: (forall s. State s a) -> a
+    runState action = runWorld action
+
+    runWorld :: State World a -> a
+    runWorld (State value) = value
+
+    result :: Result
+    result = runState (State Result)
+annotated:
+  - |-
+    module Test where
+
+    data State s a = State a
+         │           └─ type: ∀ s a. a → State s a
+         └─ type: * → * → *
+    data World = World
+         │       └─ type: World
+         └─ type: *
+    data Result = Result
+         │        └─ type: Result
+         └─ type: *
+
+    runState :: (forall s. State s a) -> a
+    runState action = runWorld action
+    │        │        │        └─ type: State World a; type-args: World
+    │        │        └─ type: State World a → a; type-args: a
+    │        └─ type: ∀ s. State s a
+    └─ type: ∀ a. (∀ s. State s a) → a
+
+    runWorld :: State World a -> a
+    runWorld (State value) = value
+    │               └─ type: a
+    └─ type: ∀ a. State World a → a
+
+    result :: Result
+    result = runState (State Result)
+    │        ││         └─ type: Result → State s Result; type-args: s, Result
+    │        └─ type: ∀ s. State s Result
+    │        └─ type: (∀ s. State s Result) → Result; type-args: Result
+    └─ type: Result
+status: pass
+reason: checks and elaborates a monomorphic expression against a rank-N function argument

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -162,7 +162,43 @@ applicationTests :: [TestTree]
 applicationTests =
   [ testCase "application infers result type" $ do
       let result = tcWithDecls "f x = x\narg = True\n" "f arg"
-      assertBool "should succeed" (tcResultSuccess result)
+      assertBool "should succeed" (tcResultSuccess result),
+    testCase "application checks a rank-N argument" $ do
+      let result =
+            typecheckModule $
+              parseMWithExtensions
+                [RankNTypes]
+                "module Test where\n\
+                \data State s a = State a\n\
+                \data World = World\n\
+                \data Result = Result\n\
+                \runState :: (forall s. State s a) -> a\n\
+                \runState action = runWorld action\n\
+                \runWorld :: State World a -> a\n\
+                \runWorld (State value) = value\n\
+                \result = runState (State Result)\n"
+          typeBinders = concatMap tcAnnTypeBinders (exprAnnotations result)
+      assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
+      assertBool "rank-N checking should record an explicit type abstraction" (not (null typeBinders)),
+    testCase "application rejects an escaping rank-N skolem" $ do
+      let result =
+            typecheckModule $
+              parseMWithExtensions
+                [RankNTypes]
+                "module Test where\n\
+                \data State s a = State a\n\
+                \data World = World\n\
+                \runState :: (forall s. State s a) -> a\n\
+                \runState action = runWorld action\n\
+                \runWorld :: State World a -> a\n\
+                \runWorld (State value) = value\n\
+                \escape action = (action, runState action)\n"
+          isEscapeDiagnostic diagnostic =
+            case diagKind diagnostic of
+              OtherError "higher-rank type variable escapes its argument" -> True
+              _ -> False
+      assertBool "escaping skolem should fail typechecking" (not (tcModuleSuccess result))
+      assertBool "escape should have a focused diagnostic" (any isEscapeDiagnostic (tcModuleDiagnostics result))
   ]
 
 -- | Tests for if-then-else.

--- a/core-libs/aihc-base/src/GHC/ST.hs
+++ b/core-libs/aihc-base/src/GHC/ST.hs
@@ -1,1 +1,108 @@
-module GHC.ST () where
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module GHC.ST
+  ( ST (..),
+    STret (..),
+    STRep,
+    runST,
+    liftST,
+    unsafeInterleaveST,
+    unsafeDupableInterleaveST,
+  )
+where
+
+import GHC.Base (Applicative (..), Functor (..), Monad (..))
+import GHC.Prim (RealWorld, State#, noDuplicate#, realWorld#)
+import GHC.Show (Show (..), showString)
+
+-- | The strict state-thread monad.
+newtype ST s a = ST (STRep s a)
+
+-- | The unwrapped representation of an 'ST' computation.
+type STRep s a = State# s -> (# State# s, a #)
+
+instance Functor (ST s) where
+  fmap f (ST action) =
+    ST
+      ( \state ->
+          case action state of
+            (# nextState, value #) -> (# nextState, f value #)
+      )
+
+instance Applicative (ST s) where
+  pure value = ST (returnSTState value)
+
+  ST function <*> ST argument =
+    ST
+      ( \state ->
+          case function state of
+            (# functionState, f #) ->
+              case argument functionState of
+                (# resultState, value #) -> (# resultState, f value #)
+      )
+
+instance Monad (ST s) where
+  ST action >>= next =
+    ST
+      ( \state ->
+          case action state of
+            (# nextState, value #) ->
+              case next value of
+                ST nextAction -> nextAction nextState
+      )
+
+  ST action >> ST nextAction =
+    ST
+      ( \state ->
+          case action state of
+            (# nextState, _ #) -> nextAction nextState
+      )
+
+  return = pure
+
+returnSTState :: a -> STRep s a
+returnSTState value state = (# state, value #)
+
+-- | A lifted result from an 'ST' computation.
+data STret s a = STret (State# s) a
+
+instance Show (ST s a) where
+  showsPrec _ _ = showString "<<ST action>>"
+
+-- | Run an 'ST' computation while retaining its final state token.
+liftST :: ST s a -> State# s -> STret s a
+liftST (ST action) state =
+  case action state of
+    (# nextState, value #) -> STret nextState value
+
+-- | Defer an 'ST' computation until its result is demanded.
+unsafeInterleaveST :: ST s a -> ST s a
+unsafeInterleaveST action = unsafeDupableInterleaveST (noDuplicateST >> action)
+
+noDuplicateST :: ST s ()
+noDuplicateST = ST (\state -> (# noDuplicate# state, () #))
+
+-- | Defer an 'ST' computation without preventing duplicate evaluation.
+unsafeDupableInterleaveST :: ST s a -> ST s a
+unsafeDupableInterleaveST (ST action) =
+  ST
+    ( \state ->
+        let result =
+              case action state of
+                (# _, value #) -> value
+         in (# state, result #)
+    )
+
+-- | Return the value computed by a state thread.
+runST :: (forall s. ST s a) -> a
+runST action = runSTRealWorld (instantiateST action)
+
+instantiateST :: (forall s. ST s a) -> ST RealWorld a
+instantiateST action = action
+
+runSTRealWorld :: ST RealWorld a -> a
+runSTRealWorld (ST action) =
+  case action realWorld# of
+    (# _, value #) -> value

--- a/core-libs/aihc-base/src/GHC/STRef.hs
+++ b/core-libs/aihc-base/src/GHC/STRef.hs
@@ -1,1 +1,49 @@
-module GHC.STRef () where
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module GHC.STRef
+  ( STRef (..),
+    newSTRef,
+    readSTRef,
+    writeSTRef,
+  )
+where
+
+import Data.Bool (Bool (..), not)
+import GHC.Internal.Classes (Eq (..))
+import GHC.Prim (MutVar#, newMutVar#, readMutVar#, sameMutVar#, writeMutVar#)
+import GHC.ST (ST (..))
+
+-- | A mutable variable in state thread @s@ containing a value of type @a@.
+data STRef s a = STRef (MutVar# s a)
+
+-- | Build a new 'STRef' in the current state thread.
+newSTRef :: a -> ST s (STRef s a)
+newSTRef initial =
+  ST
+    ( \state ->
+        case newMutVar# initial state of
+          (# nextState, reference #) -> (# nextState, STRef reference #)
+    )
+
+-- | Read the value of an 'STRef'.
+readSTRef :: STRef s a -> ST s a
+readSTRef (STRef reference) = ST (readMutVar# reference)
+
+-- | Write a new value into an 'STRef'.
+writeSTRef :: STRef s a -> a -> ST s ()
+writeSTRef (STRef reference) value =
+  ST
+    ( \state ->
+        case writeMutVar# reference value state of
+          nextState -> (# nextState, () #)
+    )
+
+-- Pointer equality, matching @base@.
+instance Eq (STRef s a) where
+  STRef left == STRef right =
+    case sameMutVar# left right of
+      0# -> False
+      _ -> True
+
+  left /= right = not (left == right)

--- a/core-libs/aihc-prim/src/GHC/Prim.hs
+++ b/core-libs/aihc-prim/src/GHC/Prim.hs
@@ -35,6 +35,7 @@ module GHC.Prim
     newMVar#,
     newMutVar#,
     newPinnedByteArray#,
+    noDuplicate#,
     not#,
     ord#,
     or#,
@@ -49,6 +50,7 @@ module GHC.Prim
     readMVar#,
     readMutVar#,
     resizeMutableByteArray#,
+    sameMutVar#,
     shrinkMutableByteArray#,
     sizeofByteArray#,
     subIntC#,
@@ -107,6 +109,8 @@ foreign import prim raise# :: a -> b
 foreign import prim unsafeCoerce# :: a -> b
 
 foreign import prim realWorld# :: State# RealWorld
+
+foreign import prim noDuplicate# :: State# d -> State# d
 
 foreign import prim compareInt# :: Int# -> Int# -> Int#
 
@@ -195,6 +199,8 @@ foreign import prim putMVar# :: MVar# d a -> a -> State# d -> State# d
 foreign import prim readMutVar# :: MutVar# d a -> State# d -> (# State# d, a #)
 
 foreign import prim writeMutVar# :: MutVar# d a -> a -> State# d -> State# d
+
+foreign import prim sameMutVar# :: MutVar# d a -> MutVar# d a -> Int#
 
 foreign import prim newByteArray# :: Int# -> State# d -> (# State# d, MutableByteArray# d #)
 

--- a/test/Test/Fixtures/eval/base/ghc-st-stref.yaml
+++ b/test/Test/Fixtures/eval/base/ghc-st-stref.yaml
@@ -1,0 +1,49 @@
+extensions:
+  - MagicHash
+  - UnboxedTuples
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import GHC.ST (ST(..), STret(..), liftST, runST, unsafeDupableInterleaveST, unsafeInterleaveST)
+    import GHC.STRef (newSTRef, readSTRef, writeSTRef)
+
+    updateReference :: Int
+    updateReference = runST (do
+      reference <- newSTRef 1
+      writeSTRef reference 42
+      readSTRef reference)
+
+    compareReferences :: (Bool, Bool)
+    compareReferences = runST (do
+      first <- newSTRef True
+      second <- newSTRef True
+      return (first == first, first == second))
+
+    functorValue :: Bool
+    functorValue = runST (fmap not (return False))
+
+    applicativeValue :: Bool
+    applicativeValue = runST (return not <*> return False)
+
+    interleavedValues :: (Bool, Bool)
+    interleavedValues = runST (do
+      first <- unsafeInterleaveST (return True)
+      second <- unsafeDupableInterleaveST (return False)
+      return (first, second))
+
+    liftedValue :: Bool
+    liftedValue = runST (ST (\state ->
+      case liftST (return True) state of
+        STret nextState value -> (# nextState, value #)))
+
+    showValue :: Bool
+    showValue = show (return True :: ST Bool Bool) == "<<ST action>>"
+output: |
+  (((I# 42),(True,False)),((True,True),(True,False),True,True))
+expression: |
+  ((updateReference, compareReferences), ((functorValue, applicativeValue), interleavedValues, liftedValue, showValue))
+status: pass
+reason: runs rank-N state threads and preserves STRef mutation and pointer identity through FC and GRIN

--- a/test/Test/Fixtures/eval/rank-n-church-list.yaml
+++ b/test/Test/Fixtures/eval/rank-n-church-list.yaml
@@ -1,0 +1,65 @@
+extensions:
+  - RankNTypes
+dependencies: []
+modules:
+  - |
+    module Test where
+
+    foldr :: (a -> b -> b) -> b -> [a] -> b
+    foldr _ initial [] = initial
+    foldr combine initial (value : values) =
+      combine value (foldr combine initial values)
+
+    -- | Laws:
+    --
+    -- > runList (fromList xs) (:) [] == xs
+    -- > runList (fromList xs) f z == foldr f z xs
+    -- > foldr f z (toList xs) == runList xs f z
+    newtype ChurchList a =
+      ChurchList (forall r. (a -> r -> r) -> r -> r)
+
+    runList :: ChurchList a -> (a -> r -> r) -> r -> r
+    runList (ChurchList build) = build
+
+    -- | Make a 'ChurchList' out of a regular list.
+    fromList :: [a] -> ChurchList a
+    fromList xs = ChurchList (\k z -> foldr k z xs)
+
+    -- | Turn a 'ChurchList' into a regular list.
+    toList :: ChurchList a -> [a]
+    toList xs = runList xs (:) []
+
+    -- | The 'ChurchList' counterpart to '(:)'.
+    cons :: a -> ChurchList a -> ChurchList a
+    cons x xs = ChurchList (\k z -> k x (runList xs k z))
+
+    -- | Append two 'ChurchList's in O(1) time.
+    append :: ChurchList a -> ChurchList a -> ChurchList a
+    append xs ys = ChurchList (\k z -> runList xs k (runList ys k z))
+
+    nil :: ChurchList a
+    nil = ChurchList (\_ z -> z)
+
+    singleton :: a -> ChurchList a
+    singleton x = ChurchList (\k z -> k x z)
+
+    snoc :: ChurchList a -> a -> ChurchList a
+    snoc xs x = ChurchList (\k z -> runList xs k (k x z))
+
+    data Item = A | B | C
+
+    sample :: [Item]
+    sample = [A, B, C]
+
+    church :: ChurchList Item
+    church = append (cons A nil) (snoc (singleton B) C)
+output: |
+  ((: A (: B (: C []))),((: A (: B (: C []))),(: A (: B (: C [])))),((: A (: B (: C []))),(: A (: B (: C [])))),(: A (: B (: C []))))
+expression: |
+  ( toList (fromList sample),
+    (runList (fromList sample) (:) [], foldr (:) [] sample),
+    (foldr (:) [] (toList church), runList church (:) []),
+    toList church
+  )
+status: pass
+reason: evaluates Church-encoded lists whose representation quantifies over the fold result type


### PR DESCRIPTION
## Summary

- implement the documented `GHC.ST` API, including strict `Functor`, `Applicative`, and `Monad` instances, `runST`, lifted results, unsafe interleaving, and `Show`
- implement `GHC.STRef` allocation, reads, writes, and pointer equality
- add higher-rank application subsumption to `aihc-tc`, including skolem escape rejection and explicit System FC type abstractions/applications
- add `sameMutVar#` and `noDuplicate#` support through aihc-prim, System FC evaluation, and GRIN interpretation
- cover RankN checking independently and exercise ST/STRef behavior through both FC and GRIN

## API progress

- `aihc-base`: 227 -> 251 (+24)
- `aihc-prim`: 51 -> 52 (+1)

README progress counters are intentionally unchanged because the cron workflow owns them.

## Validation

- `just fmt`
- `just check`
- focused `aihc-tc`, `aihc-fc`, and `aihc-grin` suites
