### PR TITLE
feat(fc): lower stock Eq deriving

### DIFF
--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -28,6 +28,7 @@ library
   other-modules:
     Aihc.Fc.Desugar.Deriving
     Aihc.Fc.Desugar.Deriving.AnyClass
+    Aihc.Fc.Desugar.Deriving.StockEq
     Aihc.Fc.Desugar.Dictionary
 
   hs-source-dirs: src

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Strategy dispatch and dependency grouping for derived dictionaries.
 module Aihc.Fc.Desugar.Deriving
   ( dsDerivingPlans,
@@ -6,10 +8,11 @@ module Aihc.Fc.Desugar.Deriving
 where
 
 import Aihc.Fc.Desugar.Deriving.AnyClass (dsAnyClassDictionaryPlan)
-import Aihc.Fc.Desugar.Expr (DsM)
-import Aihc.Fc.Syntax (FcBind (..), FcTopBind (..))
+import Aihc.Fc.Desugar.Deriving.StockEq (dsStockEqDictionaryPlan)
+import Aihc.Fc.Desugar.Expr (DsM, desugarBug)
+import Aihc.Fc.Syntax (FcBind (..), FcExpr, FcTopBind (..), Var)
 import Aihc.Parser.Syntax (Decl (..), fromAnnotation)
-import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingAnnotation (..), TcDerivingPlan (..), TcDerivingStrategy (..))
+import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingAnnotation (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Data.Graph (SCC (..), stronglyConnComp)
 import Data.Text (Text)
@@ -18,11 +21,16 @@ dsDerivingPlans :: [TcDerivingPlan] -> DsM [FcTopBind]
 dsDerivingPlans plans =
   mapM dsDerivingScc (stronglyConnComp planNodes)
   where
-    anyClassPlans = filter ((== TcDerivingAnyclass) . tcDerivingStrategy) plans
+    supportedPlans = filter isSupportedPlan plans
     planNodes =
       [ (plan, tcDerivingDictName plan, derivingPlanDependencies plan)
-      | plan <- anyClassPlans
+      | plan <- supportedPlans
       ]
+
+isSupportedPlan :: TcDerivingPlan -> Bool
+isSupportedPlan plan =
+  tcDerivingStrategy plan == TcDerivingAnyclass
+    || (tcDerivingStrategy plan == TcDerivingStock && tcDerivingClassName plan == "Eq")
 
 -- Evidence may make sibling dictionaries depend on one another regardless of
 -- their source order. Preserve acyclic dependency order and use recursive FC
@@ -31,17 +39,26 @@ dsDerivingScc :: SCC TcDerivingPlan -> DsM FcTopBind
 dsDerivingScc scc =
   case scc of
     AcyclicSCC plan -> do
-      (dictVar, body) <- dsAnyClassDictionaryPlan plan
+      (dictVar, body) <- dsDerivingPlan plan
       pure (FcTopBind (FcNonRec dictVar body))
     CyclicSCC plans -> do
-      bindings <- mapM dsAnyClassDictionaryPlan plans
+      bindings <- mapM dsDerivingPlan plans
       pure (FcTopBind (FcRec bindings))
+
+dsDerivingPlan :: TcDerivingPlan -> DsM (Var, FcExpr)
+dsDerivingPlan plan =
+  case tcDerivingStrategy plan of
+    TcDerivingAnyclass -> dsAnyClassDictionaryPlan plan
+    TcDerivingStock
+      | tcDerivingClassName plan == "Eq" -> dsStockEqDictionaryPlan plan
+    strategy -> desugarBug ("unsupported finalized deriving strategy: " <> show strategy)
 
 derivingPlanDependencies :: TcDerivingPlan -> [Text]
 derivingPlanDependencies plan =
   selfDependency
     <> concatMap (evidenceDependencies . snd) (tcDerivingSuperClasses plan)
     <> concatMap (concatMap evidenceDependencies . snd) (tcDerivingDefaultMethodEvidence plan)
+    <> maybe [] (concatMap (concatMap evidenceDependencies) . tcStockEqFieldEvidence) (tcDerivingStockPlan plan)
   where
     selfDependency =
       [ tcDerivingDictName plan

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
@@ -1,0 +1,242 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Lower finalized stock @Eq@ plans to System FC dictionaries.
+module Aihc.Fc.Desugar.Deriving.StockEq
+  ( dsStockEqDictionaryPlan,
+  )
+where
+
+import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, predType)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshVar, lookupType, withDicts)
+import Aihc.Fc.Subst (substType)
+import Aihc.Fc.Syntax
+import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcStockDerivingPlan (..))
+import Aihc.Tc.Env (DataConFieldInfo (..), DataConInfo (..), DataTypeInfo (..))
+import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..))
+import Control.Monad (zipWithM)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+
+dsStockEqDictionaryPlan :: TcDerivingPlan -> DsM (Var, FcExpr)
+dsStockEqDictionaryPlan plan =
+  case (tcDerivingContext plan, tcDerivingDataType plan, tcDerivingStockPlan plan) of
+    (TcDerivingExplicitContext context, Just dataType, Just (TcStockEqPlan fieldEvidence)) ->
+      dsStockEqDictionary plan context dataType fieldEvidence
+    (TcDerivingInferContext, _, _) ->
+      desugarBug ("unfinalized stock Eq deriving context for " <> T.unpack (tcDerivingDictName plan))
+    (_, Nothing, _) ->
+      desugarBug ("missing datatype metadata for stock Eq deriving " <> T.unpack (tcDerivingDictName plan))
+    (_, _, Nothing) ->
+      desugarBug ("missing checked field evidence for stock Eq deriving " <> T.unpack (tcDerivingDictName plan))
+
+dsStockEqDictionary :: TcDerivingPlan -> [Pred] -> DataTypeInfo -> [[EvTerm]] -> DsM (Var, FcExpr)
+dsStockEqDictionary plan context dataType fieldEvidence = do
+  contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] context
+  genericMethodTypes <-
+    mapM
+      (classMethodFieldType "Eq" (tcDerivingClassTyVars plan) . tcClassMethodType)
+      (tcDerivingClassMethods plan)
+  targetType <-
+    case reverse (tcDerivingHeadTypes plan) of
+      target : _ -> pure target
+      [] -> desugarBug "stock Eq deriving plan has an empty instance head"
+  constructors <-
+    zipExact
+      "constructor evidence"
+      (dtiConstructors dataType)
+      (map (map (rewriteSelfEvidence plan targetType)) fieldEvidence)
+  let dictionaryType =
+        foldr
+          TcForAllTy
+          (qualifyType context (TcTyCon (TyCon "Eq" 1) [targetType]))
+          (tcDerivingTyVars plan)
+  dictVar <- freshVar (tcDerivingDictName plan) dictionaryType
+  let selfDictionaryType = TcTyCon (TyCon "Eq" 1) [targetType]
+      selfDictionaryExpression =
+        foldl
+          FcApp
+          (foldl FcTyApp (FcVar dictVar) (map TcTyVar (tcDerivingTyVars plan)))
+          (map (FcVar . classDictVar) contextDicts)
+  selfDictionaryVar <- freshVar "$stock_eq_self" selfDictionaryType
+  let selfDictionary = ClassDict "Eq" [targetType] selfDictionaryVar
+  methodFields <-
+    withDicts (selfDictionary : contextDicts) $
+      mapM
+        (dsStockEqMethod dataType constructors targetType)
+        (tcDerivingClassMethods plan)
+  let classTyVars = tcDerivingClassTyVars plan
+      dictionaryConstructor = fcDictionaryConstructorName "Eq"
+      genericDictionaryType = TcTyCon (TyCon "Eq" 1) (map TcTyVar classTyVars)
+      constructorType = foldr TcForAllTy (foldr TcFunTy genericDictionaryType genericMethodTypes) classTyVars
+  constructorVar <- freshVar dictionaryConstructor constructorType
+  let constructor = foldl FcTyApp (FcVar constructorVar) (tcDerivingHeadTypes plan)
+      dictionary =
+        FcLet
+          (FcNonRec selfDictionaryVar selfDictionaryExpression)
+          (foldl FcApp constructor methodFields)
+      body = foldr FcTyLam (foldr (FcLam . classDictVar) dictionary contextDicts) (tcDerivingTyVars plan)
+  pure (dictVar, body)
+
+dsStockEqMethod :: DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> TcClassMethodAnnotation -> DsM FcExpr
+dsStockEqMethod dataType constructors targetType method =
+  case tcClassMethodName method of
+    "==" -> dsEqualityMethod dataType constructors targetType
+    "/=" -> do
+      left <- freshVar "$stock_eq_left" targetType
+      right <- freshVar "$stock_eq_right" targetType
+      equality <- equalityBody dataType constructors targetType left right
+      negated <- negateBoolean equality
+      pure (FcLam left (FcLam right negated))
+    name -> desugarBug ("unsupported method in stock Eq dictionary: " <> T.unpack name)
+
+dsEqualityMethod :: DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> DsM FcExpr
+dsEqualityMethod dataType constructors targetType = do
+  left <- freshVar "$stock_eq_left" targetType
+  right <- freshVar "$stock_eq_right" targetType
+  body <- equalityBody dataType constructors targetType left right
+  pure (FcLam left (FcLam right body))
+
+equalityBody :: DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> Var -> Var -> DsM FcExpr
+equalityBody dataType constructors targetType left right = do
+  outerBinder <- freshVar "$stock_eq_outer" targetType
+  alternatives <- mapM (constructorEqualityAlternative dataType right targetType) constructors
+  pure (FcCase (FcVar left) outerBinder alternatives)
+
+constructorEqualityAlternative :: DataTypeInfo -> Var -> TcType -> (DataConInfo, [EvTerm]) -> DsM FcAlt
+constructorEqualityAlternative dataType right targetType (constructor, evidence) = do
+  fields <- instantiatedFields dataType targetType constructor
+  fieldEvidence <- zipExact ("field evidence for " <> T.unpack (dciName constructor)) fields evidence
+  leftFields <- zipWithM (fieldVar "$stock_eq_left_field") [0 :: Int ..] fields
+  rightFields <- zipWithM (fieldVar "$stock_eq_right_field") [0 :: Int ..] fields
+  comparisons <-
+    zipWithM
+      (fieldEquality leftFields rightFields)
+      [0 :: Int ..]
+      fieldEvidence
+  equalFields <- andComparisons comparisons
+  mismatch <- boolConstructor "False"
+  innerBinder <- freshVar "$stock_eq_inner" targetType
+  let matching = FcAlt (DataAlt (dciName constructor)) rightFields equalFields
+      different = FcAlt DefaultAlt [] mismatch
+      compareRight = FcCase (FcVar right) innerBinder [matching, different]
+  pure (FcAlt (DataAlt (dciName constructor)) leftFields compareRight)
+
+instantiatedFields :: DataTypeInfo -> TcType -> DataConInfo -> DsM [DataConFieldInfo]
+instantiatedFields dataType targetType constructor =
+  case targetType of
+    TcTyCon targetTyCon arguments
+      | tyConName targetTyCon == dtiName dataType,
+        length arguments == length (dtiTyVars dataType) ->
+          let substitution =
+                Map.fromList
+                  [ (tyVar, argument)
+                  | (tyVar, argument) <- zip (dtiTyVars dataType) arguments
+                  ]
+           in pure [field {dcfiType = substType substitution (dcfiType field)} | field <- dciFields constructor]
+    _ -> desugarBug "stock Eq target does not match its datatype metadata"
+
+fieldVar :: Text -> Int -> DataConFieldInfo -> DsM Var
+fieldVar prefix index field = freshVar (prefix <> T.pack (show index)) (dcfiType field)
+
+fieldEquality :: [Var] -> [Var] -> Int -> (DataConFieldInfo, EvTerm) -> DsM FcExpr
+fieldEquality leftFields rightFields index (field, evidence) = do
+  left <- indexVar "left" index leftFields
+  right <- indexVar "right" index rightFields
+  dictionary <- dsEvidence evidence
+  let fieldType = dcfiType field
+      methodType = TcFunTy fieldType (TcFunTy fieldType boolType)
+      dictionaryType = TcTyCon (TyCon "Eq" 1) [fieldType]
+  dictionaryBinder <- freshVar "$stock_eq_dictionary" dictionaryType
+  equalityMethod <- freshVar "$stock_eq_method" methodType
+  inequalityMethod <- freshVar "$stock_neq_method" methodType
+  pure
+    ( FcCase
+        dictionary
+        dictionaryBinder
+        [ FcAlt
+            (DataAlt (fcDictionaryConstructorName "Eq"))
+            [equalityMethod, inequalityMethod]
+            (FcApp (FcApp (FcVar equalityMethod) (FcVar left)) (FcVar right))
+        ]
+    )
+
+indexVar :: String -> Int -> [Var] -> DsM Var
+indexVar side index variables =
+  case drop index variables of
+    variable : _ -> pure variable
+    [] -> desugarBug ("missing " <> side <> " stock Eq field binder")
+
+andComparisons :: [FcExpr] -> DsM FcExpr
+andComparisons comparisons =
+  case comparisons of
+    [] -> boolConstructor "True"
+    comparison : rest -> do
+      binder <- freshVar "$stock_eq_bool" boolType
+      false <- boolConstructor "False"
+      trueBranch <- andComparisons rest
+      pure
+        ( FcCase
+            comparison
+            binder
+            [ FcAlt (DataAlt "False") [] false,
+              FcAlt (DataAlt "True") [] trueBranch
+            ]
+        )
+
+negateBoolean :: FcExpr -> DsM FcExpr
+negateBoolean expression = do
+  binder <- freshVar "$stock_eq_not" boolType
+  true <- boolConstructor "True"
+  false <- boolConstructor "False"
+  pure
+    ( FcCase
+        expression
+        binder
+        [ FcAlt (DataAlt "False") [] true,
+          FcAlt (DataAlt "True") [] false
+        ]
+    )
+
+boolConstructor :: Text -> DsM FcExpr
+boolConstructor name = do
+  constructorType <- lookupType name
+  constructor <- freshVar name constructorType
+  pure (FcVar constructor)
+
+boolType :: TcType
+boolType = TcTyCon (TyCon "Bool" 0) []
+
+mkPredicateDict :: Int -> Pred -> DsM ClassDict
+mkPredicateDict index predicate = do
+  dictVar <- freshVar ("$d" <> T.pack (show index)) (predType predicate)
+  pure $
+    case predicate of
+      ClassPred className arguments -> ClassDict className arguments dictVar
+      EqPred {} -> ClassDict "<equality>" [] dictVar
+
+qualifyType :: [Pred] -> TcType -> TcType
+qualifyType [] body = body
+qualifyType predicates body = TcQualTy predicates body
+
+rewriteSelfEvidence :: TcDerivingPlan -> TcType -> EvTerm -> EvTerm
+rewriteSelfEvidence plan targetType evidence =
+  case evidence of
+    EvDict dictionaryName _ _
+      | dictionaryName == tcDerivingDictName plan ->
+          EvGiven (ClassPred "Eq" [targetType])
+    EvDict dictionaryName typeArguments contextEvidence ->
+      EvDict dictionaryName typeArguments (map recurse contextEvidence)
+    EvSuperClass source sourcePredicate fieldTypes fieldIndex ->
+      EvSuperClass (recurse source) sourcePredicate fieldTypes fieldIndex
+    EvCast source coercion -> EvCast (recurse source) coercion
+    EvTypeable ty arguments -> EvTypeable ty (map recurse arguments)
+    _ -> evidence
+  where
+    recurse = rewriteSelfEvidence plan targetType
+
+zipExact :: String -> [left] -> [right] -> DsM [(left, right)]
+zipExact context left right
+  | length left == length right = pure (zip left right)
+  | otherwise = desugarBug (context <> " arity mismatch")

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -13,7 +13,7 @@ where
 import Aihc.Fc
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
-import Aihc.Parser (defaultConfig, parseModule)
+import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax qualified as Surface
 import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Aihc.Tc.Evidence (Coercion (..))
@@ -48,7 +48,22 @@ fcDesugarTests =
             constructors = concatMap declarationConstructors (Surface.moduleDecls parsedModule)
         case constructors of
           [constructor] -> assertEqual "constructor arity" ("Pair", 2) (dsDataConPure constructor)
-          _ -> assertFailure ("expected one parsed constructor, got: " <> show constructors)
+          _ -> assertFailure ("expected one parsed constructor, got: " <> show constructors),
+      testCase "stock Eq dictionaries pass Core lint" $ do
+        let source =
+              "{-# LANGUAGE DerivingStrategies #-}\n\
+              \module Test where\n\
+              \data Bool = False | True\n\
+              \class Eq a where\n\
+              \  (==) :: a -> a -> Bool\n\
+              \  (/=) :: a -> a -> Bool\n\
+              \data Tree a = Leaf a | Branch (Tree a) (Tree a) deriving stock Eq\n"
+            config = defaultConfig {parserExtensions = [Surface.DerivingStrategies]}
+            (parseErrors, parsedModule) = parseModule config source
+            result = desugarModule parsedModule
+        assertEqual "source parses" [] parseErrors
+        assertBool ("desugaring succeeds: " <> show (dsErrors result)) (dsSuccess result)
+        assertEqual "Core lint" [] (lintProgram emptyLintEnv (dsProgram result))
     ]
   where
     declarationConstructors declaration =

--- a/components/aihc-fc/test/Test/Fixtures/golden/derive-stock-eq.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/derive-stock-eq.yaml
@@ -1,0 +1,128 @@
+extensions:
+  - DerivingStrategies
+modules:
+  - |
+    {-# LANGUAGE DerivingStrategies #-}
+    module Test where
+
+    data Bool = False | True
+
+    class Eq a where
+      (==) :: a -> a -> Bool
+      (/=) :: a -> a -> Bool
+
+    data Tree a = Leaf a | Branch (Tree a) (Tree a)
+      deriving stock Eq
+
+    sameTree :: Eq a => Tree a -> Tree a -> Bool
+    sameTree = (==)
+expected: |-
+  data Bool
+   = False
+   | True
+
+  data Eq a
+   = $Dict$Eq (a → a → Bool) (a → a → Bool)
+
+  == : ∀ a. (Eq a) → a → a → Bool =
+    Λa.
+      λ$d0 : Eq a.
+        case $d0 as $dict : Eq a of
+          $Dict$Eq $method0 $method1 →
+            $method0
+
+  /= : ∀ a. (Eq a) → a → a → Bool =
+    Λa.
+      λ$d0 : Eq a.
+        case $d0 as $dict : Eq a of
+          $Dict$Eq $method0 $method1 →
+            $method1
+
+  data Tree a
+   = Leaf a
+   | Branch (Tree a) (Tree a)
+
+  rec
+    $fEqTreea : ∀ a. (Eq a) → Eq (Tree a) =
+      Λa.
+        λ$d0 : Eq a.
+          let
+            $stock_eq_self : Eq (Tree a) =
+              $fEqTreea @a $d0
+          in
+            $Dict$Eq @(Tree a) (λ$stock_eq_left : Tree a.
+              λ$stock_eq_right : Tree a.
+                case $stock_eq_left as $stock_eq_outer : Tree a of
+                  Leaf $stock_eq_left_field0 →
+                    case $stock_eq_right as $stock_eq_inner : Tree a of
+                      Leaf $stock_eq_right_field0 →
+                        case case $d0 as $stock_eq_dictionary : Eq a of
+                          $Dict$Eq $stock_eq_method $stock_neq_method →
+                            $stock_eq_method $stock_eq_left_field0 $stock_eq_right_field0 as $stock_eq_bool : Bool of
+                          False →
+                            False
+                          True →
+                            True
+                      _ →
+                        False
+                  Branch $stock_eq_left_field0 $stock_eq_left_field1 →
+                    case $stock_eq_right as $stock_eq_inner : Tree a of
+                      Branch $stock_eq_right_field0 $stock_eq_right_field1 →
+                        case case $stock_eq_self as $stock_eq_dictionary : Eq (Tree a) of
+                          $Dict$Eq $stock_eq_method $stock_neq_method →
+                            $stock_eq_method $stock_eq_left_field0 $stock_eq_right_field0 as $stock_eq_bool : Bool of
+                          False →
+                            False
+                          True →
+                            case case $stock_eq_self as $stock_eq_dictionary : Eq (Tree a) of
+                              $Dict$Eq $stock_eq_method $stock_neq_method →
+                                $stock_eq_method $stock_eq_left_field1 $stock_eq_right_field1 as $stock_eq_bool : Bool of
+                              False →
+                                False
+                              True →
+                                True
+                      _ →
+                        False) (λ$stock_eq_left : Tree a.
+              λ$stock_eq_right : Tree a.
+                case case $stock_eq_left as $stock_eq_outer : Tree a of
+                  Leaf $stock_eq_left_field0 →
+                    case $stock_eq_right as $stock_eq_inner : Tree a of
+                      Leaf $stock_eq_right_field0 →
+                        case case $d0 as $stock_eq_dictionary : Eq a of
+                          $Dict$Eq $stock_eq_method $stock_neq_method →
+                            $stock_eq_method $stock_eq_left_field0 $stock_eq_right_field0 as $stock_eq_bool : Bool of
+                          False →
+                            False
+                          True →
+                            True
+                      _ →
+                        False
+                  Branch $stock_eq_left_field0 $stock_eq_left_field1 →
+                    case $stock_eq_right as $stock_eq_inner : Tree a of
+                      Branch $stock_eq_right_field0 $stock_eq_right_field1 →
+                        case case $stock_eq_self as $stock_eq_dictionary : Eq (Tree a) of
+                          $Dict$Eq $stock_eq_method $stock_neq_method →
+                            $stock_eq_method $stock_eq_left_field0 $stock_eq_right_field0 as $stock_eq_bool : Bool of
+                          False →
+                            False
+                          True →
+                            case case $stock_eq_self as $stock_eq_dictionary : Eq (Tree a) of
+                              $Dict$Eq $stock_eq_method $stock_neq_method →
+                                $stock_eq_method $stock_eq_left_field1 $stock_eq_right_field1 as $stock_eq_bool : Bool of
+                              False →
+                                False
+                              True →
+                                True
+                      _ →
+                        False as $stock_eq_not : Bool of
+                  False →
+                    True
+                  True →
+                    False)
+
+  sameTree : ∀ a. (Eq a) → (Tree a) → (Tree a) → Bool =
+    Λa.
+      λ$d0 : Eq a.
+        == @(Tree a) ($fEqTreea @a $d0)
+status: pass
+reason: stock Eq lowering consumes checked constructor layouts and field evidence

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -80,6 +80,7 @@ module Aihc.Tc
     TcDerivingContext (..),
     TcDerivingPlan (..),
     TcDerivingStrategy (..),
+    TcStockDerivingPlan (..),
     TcDiagnostic (..),
     TcErrorKind (..),
     TcSeverity (..),
@@ -114,7 +115,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
-import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), renderPred, renderTcSignature, renderTcType)
+import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..), renderPred, renderTcSignature, renderTcType)
 import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), dataConArgTypes, dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tcModule, tcModuleScc)

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -20,6 +20,7 @@ module Aihc.Tc.Annotations
     TcDerivingAnnotation (..),
     TcDerivingContext (..),
     TcDerivingPlan (..),
+    TcStockDerivingPlan (..),
     TcDerivingStrategy (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
@@ -170,6 +171,14 @@ data TcDerivingContext
   | TcDerivingExplicitContext ![Pred]
   deriving (Eq, Show)
 
+-- | Strategy-specific proof payload for stock deriving. Each constructor's
+-- equality evidence is aligned with its checked runtime fields.
+newtype TcStockDerivingPlan
+  = TcStockEqPlan
+  { tcStockEqFieldEvidence :: [[EvTerm]]
+  }
+  deriving (Eq, Show)
+
 -- | Typed input to strategy-specific deriving. This deliberately contains
 -- the class layout needed by System FC lowering so downstream phases never
 -- need to reconstruct Haskell class information.
@@ -184,6 +193,7 @@ data TcDerivingPlan = TcDerivingPlan
     -- target is a data or newtype constructor known to this compilation.
     tcDerivingDataType :: !(Maybe DataTypeInfo),
     tcDerivingContext :: !TcDerivingContext,
+    tcDerivingStockPlan :: !(Maybe TcStockDerivingPlan),
     tcDerivingClassTyVars :: ![TyVarId],
     tcDerivingClassSuperClasses :: ![TcDictBinderAnnotation],
     tcDerivingClassMethods :: ![TcClassMethodAnnotation],

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -226,6 +226,7 @@ mkDerivingPlan sourceSpan strategy classInfo tyVars headTypes dataType context m
       tcDerivingHeadTypes = headTypes,
       tcDerivingDataType = dataType,
       tcDerivingContext = context,
+      tcDerivingStockPlan = Nothing,
       tcDerivingClassTyVars = ciTyVars classInfo,
       tcDerivingClassSuperClasses = map constraintTypeDictBinder (ciSuperClassTypes classInfo),
       tcDerivingClassMethods = methods,

--- a/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
@@ -3,10 +3,10 @@
 
 -- | Finalize strategy-specific deriving contexts as a module batch.
 --
--- AnyClass has no structural method obligations. Its inferred context comes
--- from instantiated superclasses and the constraints on default signatures.
--- The whole batch is visible while simplifying those predicates so sibling
--- AnyClass instances are independent of declaration order.
+-- AnyClass contexts come from instantiated superclasses and default
+-- signatures. Stock Eq contexts come from checked constructor fields. The
+-- whole batch is visible while simplifying those predicates so recursive and
+-- mutually recursive derived dictionaries are independent of source order.
 module Aihc.Tc.Deriving.Context
   ( finalizeDerivingModulesTc,
     derivingPlanInstanceInfo,
@@ -20,14 +20,16 @@ import Aihc.Parser.Syntax
     mkAnnotation,
   )
 import Aihc.Tc.Annotations
-  ( TcDerivingAnnotation (..),
+  ( TcClassMethodAnnotation (..),
+    TcDerivingAnnotation (..),
     TcDerivingContext (..),
     TcDerivingPlan (..),
     TcDerivingStrategy (..),
     TcDictBinderAnnotation (..),
+    TcStockDerivingPlan (..),
   )
 import Aihc.Tc.Constraint (Ct (..), CtOrigin (..), mkWantedCt)
-import Aihc.Tc.Env (InstanceInfo (..))
+import Aihc.Tc.Env (DataConFieldInfo (..), DataConInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Instantiate (applySubst)
@@ -61,6 +63,24 @@ inferPlanContext existingInstances plans plan =
           pure plan
         Right context ->
           pure plan {tcDerivingContext = TcDerivingExplicitContext context}
+    (TcDerivingStock, context)
+      | tcDerivingClassName plan == "Eq" ->
+          case stockEqObligations plan of
+            Left message -> do
+              emitError (tcDerivingSourceSpan plan) (OtherError message)
+              pure plan
+            Right obligations ->
+              case context of
+                TcDerivingExplicitContext {} -> pure plan
+                TcDerivingInferContext ->
+                  case inferStockEqContext existingInstances plans [] plan obligations of
+                    Left predicate -> do
+                      emitError
+                        (tcDerivingSourceSpan plan)
+                        (UnsolvedWanted predicate (InstOrigin "Eq"))
+                      pure plan
+                    Right inferred ->
+                      pure plan {tcDerivingContext = TcDerivingExplicitContext inferred}
     _ -> pure plan
 
 inferAnyClassContext :: [InstanceInfo] -> [TcDerivingPlan] -> [PlanKey] -> TcDerivingPlan -> Either Pred [Pred]
@@ -74,9 +94,23 @@ inferAnyClassContext existingInstances plans stack plan
   where
     key = planKey plan
 
+inferStockEqContext :: [InstanceInfo] -> [TcDerivingPlan] -> [PlanKey] -> TcDerivingPlan -> [[Pred]] -> Either Pred [Pred]
+inferStockEqContext existingInstances plans stack plan obligations
+  | key `elem` stack = Right []
+  | otherwise =
+      nub . concat
+        <$> mapM
+          (simplifyPredicate existingInstances plans (key : stack) plan)
+          (concat obligations)
+  where
+    key = planKey plan
+
 simplifyPredicate :: [InstanceInfo] -> [TcDerivingPlan] -> [PlanKey] -> TcDerivingPlan -> Pred -> Either Pred [Pred]
 simplifyPredicate existingInstances plans stack owner predicate
   | isBareVariablePredicate (tcDerivingTyVars owner) predicate = Right [predicate]
+  | Just key <- predicatePlanKey predicate,
+    key `elem` stack =
+      Right []
   | Just arguments <- typeableArguments predicate =
       concat
         <$> mapM
@@ -118,6 +152,10 @@ simplifyPredicate existingInstances plans stack owner predicate
         TcDerivingInferContext
           | tcDerivingStrategy candidate == TcDerivingAnyclass ->
               inferAnyClassContext existingInstances plans stack candidate
+          | tcDerivingStrategy candidate == TcDerivingStock,
+            tcDerivingClassName candidate == "Eq",
+            Right obligations <- stockEqObligations candidate ->
+              inferStockEqContext existingInstances plans stack candidate obligations
           | otherwise -> Left predicate
 
 firstSuccessful :: [Either error value] -> Maybe value
@@ -154,6 +192,11 @@ attachDerivingEvidence plan =
           { tcDerivingSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
             tcDerivingDefaultMethodEvidence = defaultMethodEvidence
           }
+    (TcDerivingStock, TcDerivingExplicitContext context)
+      | tcDerivingClassName plan == "Eq",
+        Right obligations <- stockEqObligations plan -> do
+          fieldEvidence <- mapM (mapM (solveObligation context)) obligations
+          pure plan {tcDerivingStockPlan = Just (TcStockEqPlan fieldEvidence)}
     _ -> pure plan
   where
     superClasses =
@@ -195,17 +238,106 @@ instantiatedDefaultSignaturePredicates plan =
 derivingPlanInstanceInfo :: TcDerivingPlan -> Maybe InstanceInfo
 derivingPlanInstanceInfo plan =
   case (tcDerivingStrategy plan, tcDerivingContext plan) of
-    (TcDerivingAnyclass, TcDerivingExplicitContext context) ->
-      Just
-        InstanceInfo
-          { iiClassName = tcDerivingClassName plan,
-            iiDictName = tcDerivingDictName plan,
-            iiDictType = foldr TcForAllTy (TcQualTy context (predType (planPredicate plan))) (tcDerivingTyVars plan),
-            iiTyVars = tcDerivingTyVars plan,
-            iiContext = context,
-            iiHead = tcDerivingHeadTypes plan
-          }
+    (strategy, TcDerivingExplicitContext context)
+      | strategy == TcDerivingAnyclass || isValidStockEqPlan plan ->
+          Just
+            InstanceInfo
+              { iiClassName = tcDerivingClassName plan,
+                iiDictName = tcDerivingDictName plan,
+                iiDictType = foldr TcForAllTy (TcQualTy context (predType (planPredicate plan))) (tcDerivingTyVars plan),
+                iiTyVars = tcDerivingTyVars plan,
+                iiContext = context,
+                iiHead = tcDerivingHeadTypes plan
+              }
     _ -> Nothing
+
+isValidStockEqPlan :: TcDerivingPlan -> Bool
+isValidStockEqPlan plan =
+  tcDerivingStrategy plan == TcDerivingStock
+    && tcDerivingClassName plan == "Eq"
+    && case stockEqObligations plan of
+      Right {} -> True
+      Left {} -> False
+
+stockEqObligations :: TcDerivingPlan -> Either String [[Pred]]
+stockEqObligations plan = do
+  dataType <-
+    maybe
+      (Left "stock Eq deriving requires checked datatype metadata")
+      Right
+      (tcDerivingDataType plan)
+  targetArguments <- stockEqTargetArguments dataType plan
+  validateStockEqClass plan
+  validateStockEqDataType dataType
+  let substitution =
+        Map.fromList
+          [ (tvUnique tyVar, argument)
+          | (tyVar, argument) <- zip (dtiTyVars dataType) targetArguments
+          ]
+  pure
+    [ [ClassPred "Eq" [applySubst substitution (dcfiType field)] | field <- dciFields constructor]
+    | constructor <- dtiConstructors dataType
+    ]
+
+stockEqTargetArguments :: DataTypeInfo -> TcDerivingPlan -> Either String [TcType]
+stockEqTargetArguments dataType plan =
+  case reverse (tcDerivingHeadTypes plan) of
+    TcTyCon tyCon arguments : _
+      | tyConName tyCon == dtiName dataType,
+        length arguments == length (dtiTyVars dataType) ->
+          Right arguments
+    _ -> Left "stock Eq deriving target does not match its checked datatype metadata"
+
+validateStockEqClass :: TcDerivingPlan -> Either String ()
+validateStockEqClass plan
+  | [_] <- tcDerivingClassTyVars plan,
+    null (tcDerivingClassSuperClasses plan),
+    map tcClassMethodName (tcDerivingClassMethods plan) == ["==", "/="],
+    all validMethod (tcDerivingClassMethods plan) =
+      Right ()
+  | otherwise = Left "stock Eq deriving requires the standard Eq class layout"
+  where
+    validMethod method =
+      tcClassMethodName method `elem` ["==", "/="]
+        && case methodTypeParts (tcClassMethodType method) of
+          ( [classVar],
+            [ClassPred "Eq" [TcTyVar predicateVar]],
+            TcFunTy (TcTyVar left) (TcFunTy (TcTyVar right) (TcTyCon boolTyCon []))
+            ) ->
+              [classVar] == tcDerivingClassTyVars plan
+                && predicateVar == classVar
+                && left == classVar
+                && right == classVar
+                && tyConName boolTyCon == "Bool"
+          _ -> False
+
+    methodTypeParts ty =
+      let (tyVars, qualified) = peelMethodForAlls ty
+       in case qualified of
+            TcQualTy predicates body -> (tyVars, predicates, body)
+            body -> (tyVars, [], body)
+
+    peelMethodForAlls (TcForAllTy tyVar body) =
+      let (tyVars, inner) = peelMethodForAlls body
+       in (tyVar : tyVars, inner)
+    peelMethodForAlls ty = ([], ty)
+
+validateStockEqDataType :: DataTypeInfo -> Either String ()
+validateStockEqDataType dataType
+  | dtiFlavor dataType `notElem` [DataTyCon, NewtypeTyCon] =
+      Left "stock Eq deriving requires a data or newtype declaration"
+  | null constructors =
+      Left "stock Eq deriving does not yet support empty data declarations"
+  | not (all (null . dciExTyVars) constructors) =
+      Left "stock Eq deriving does not yet support existential constructors"
+  | not (all (null . dciTheta) constructors) =
+      Left "stock Eq deriving does not yet support constrained constructors"
+  | any ((/= expectedResult) . dciResTy) constructors =
+      Left "stock Eq deriving does not yet support refined GADT result types"
+  | otherwise = Right ()
+  where
+    constructors = dtiConstructors dataType
+    expectedResult = TcTyCon (dtiTyCon dataType) (map TcTyVar (dtiTyVars dataType))
 
 moduleDerivingPlans :: Module -> [TcDerivingPlan]
 moduleDerivingPlans = concatMap declDerivingPlans . moduleDecls
@@ -238,6 +370,12 @@ type PlanKey = (Text, [TcType])
 
 planKey :: TcDerivingPlan -> PlanKey
 planKey plan = (tcDerivingClassName plan, tcDerivingHeadTypes plan)
+
+predicatePlanKey :: Pred -> Maybe PlanKey
+predicatePlanKey predicate =
+  case predicate of
+    ClassPred className arguments -> Just (className, arguments)
+    EqPred {} -> Nothing
 
 planPredicate :: TcDerivingPlan -> Pred
 planPredicate plan = ClassPred (tcDerivingClassName plan) (tcDerivingHeadTypes plan)

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -21,6 +21,7 @@ import Aihc.Tc.Annotations
     TcDictBinderAnnotation (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
+    TcStockDerivingPlan (..),
   )
 import Aihc.Tc.Env (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..))
 import Aihc.Tc.Evidence (Coercion (..), EvTerm (..), EvVar)
@@ -190,6 +191,7 @@ firstMetaDerivingPlan plan =
            | (superClass, evidence) <- tcDerivingSuperClasses plan
            ]
         ++ concatMap (map firstMetaEvTerm . snd) (tcDerivingDefaultMethodEvidence plan)
+        ++ maybe [] (concatMap (map firstMetaEvTerm) . tcStockEqFieldEvidence) (tcDerivingStockPlan plan)
         ++ [firstMetaDerivingStrategy (tcDerivingStrategy plan), firstMetaDerivingContext (tcDerivingContext plan)]
     )
 

--- a/components/aihc-tc/test/Test/Fixtures/annotated/stock-deriving-strategy-selection.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/stock-deriving-strategy-selection.yaml
@@ -4,14 +4,20 @@ annotated:
   module Main where
   data Type
        └─ type: *
+  data Bool = False | True
+       │      │       └─ type: Bool
+       │      └─ type: Bool
+       └─ type: *
   class Eq a where
-  └─ class methods:
+  └─ class methods: == ∷ ∀ a. (Eq a) ⇒ a → a → Bool, /= ∷ ∀ a. (Eq a) ⇒ a → a → Bool
+    (==) :: a -> a -> Bool
+    (/=) :: a -> a -> Bool
   class Functor (f :: Type -> Type) where
   └─ class methods:
   data E = E
   │    │   └─ type: E
   │    └─ type: *
-  └─ deriving plans: stock Eq E [context: infer]
+  └─ deriving plans: stock Eq E [context: ()] [methods: ==, /=]
     deriving Eq
   data F a = F a
   │    │     └─ type: ∀ a. a → F a
@@ -27,7 +33,10 @@ modules:
   {-# LANGUAGE DeriveAnyClass, DeriveFunctor, KindSignatures #-}
   module Main where
   data Type
+  data Bool = False | True
   class Eq a where
+    (==) :: a -> a -> Bool
+    (/=) :: a -> a -> Bool
   class Functor (f :: Type -> Type) where
   data E = E
     deriving Eq

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -37,7 +37,7 @@ import Aihc.Tc.Finalize (finalizeModuleTc)
 import Aihc.Tc.Monad (emptyTcEnv, initTcState, runTcM)
 import Aihc.Tc.Types (mkTyCon)
 import Data.Data (Data, gmapQ)
-import Data.List (find)
+import Data.List (find, isInfixOf)
 import Data.Maybe (isJust, mapMaybe, maybeToList)
 import Data.Text (Text)
 import Data.Typeable (cast)
@@ -605,6 +605,56 @@ annotationTests =
                   assertFailure ("Resolve error in datatype-interface consumer: " <> show resolveErrors)
         ResolveResult {resolveErrors} ->
           assertFailure ("Resolve error in datatype-interface provider: " <> show resolveErrors),
+    testCase "stock Eq deriving infers field contexts and recursive evidence" $ do
+      let result =
+            typecheckModule $
+              parseMWithExtensions
+                [DerivingStrategies]
+                "{-# LANGUAGE DerivingStrategies #-}\n\
+                \module Test where\n\
+                \data Bool = False | True\n\
+                \class Eq a where\n\
+                \  (==) :: a -> a -> Bool\n\
+                \  (/=) :: a -> a -> Bool\n\
+                \instance Eq Bool where\n\
+                \  False == False = True\n\
+                \  True == True = True\n\
+                \  _ == _ = False\n\
+                \  False /= False = False\n\
+                \  True /= True = False\n\
+                \  _ /= _ = True\n\
+                \data Tree a = Leaf a | Branch (Tree a) (Tree a) deriving stock Eq\n"
+      assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
+      case derivingPlans result of
+        [plan] -> do
+          case tcDerivingContext plan of
+            TcDerivingExplicitContext [ClassPred "Eq" [TcTyVar contextVar]] ->
+              assertBool "context variable is quantified by the plan" (contextVar `elem` tcDerivingTyVars plan)
+            context -> assertFailure ("unexpected inferred context: " <> show context)
+          case tcDerivingStockPlan plan of
+            Nothing -> assertFailure "stock Eq evidence plan is missing"
+            Just (TcStockEqPlan constructorEvidence) -> do
+              assertEqual "evidence follows constructor fields" [1, 2] (map length constructorEvidence)
+              assertBool
+                "recursive fields select the derived dictionary"
+                (all (elem "$fEqTreea" . concatMap evDictNames) (drop 1 constructorEvidence))
+        plans -> assertFailure ("expected one stock Eq plan, got: " <> show plans),
+    testCase "stock Eq deriving rejects existential constructors in TC" $ do
+      let result =
+            typecheckModule $
+              parseMWithExtensions
+                [DerivingStrategies, ExistentialQuantification]
+                "{-# LANGUAGE DerivingStrategies, ExistentialQuantification #-}\n\
+                \module Test where\n\
+                \data Bool = False | True\n\
+                \class Eq a where\n\
+                \  (==) :: a -> a -> Bool\n\
+                \  (/=) :: a -> a -> Bool\n\
+                \data Hidden = forall a. Hidden a deriving stock Eq\n"
+      assertBool "module should fail" (not (tcModuleSuccess result))
+      assertBool
+        "diagnostic should identify the unsupported constructor shape"
+        (any (isInfixOf "existential constructors" . show . diagKind) (tcModuleDiagnostics result)),
     testCase "instance methods retain method-local constraints" $ do
       let result =
             typecheckModule $

--- a/test/Test/Fixtures/eval/derive-stock-eq.yaml
+++ b/test/Test/Fixtures/eval/derive-stock-eq.yaml
@@ -1,0 +1,46 @@
+extensions:
+  - DerivingStrategies
+  - StandaloneDeriving
+dependencies: []
+modules:
+  - |
+    {-# LANGUAGE DerivingStrategies, StandaloneDeriving #-}
+    module Test where
+
+    data Bool = False | True
+    data Results = Results Bool Bool Bool Bool Bool
+
+    class Eq a where
+      (==) :: a -> a -> Bool
+      (/=) :: a -> a -> Bool
+
+    instance Eq Bool where
+      False == False = True
+      True == True = True
+      _ == _ = False
+
+      False /= False = False
+      True /= True = False
+      _ /= _ = True
+
+    data Pair a = None | Pair a a
+      deriving stock Eq
+
+    newtype Wrapped a = Wrapped a
+      deriving stock Eq
+
+    data Solo a = Solo a
+    deriving stock instance Eq a => Eq (Solo a)
+
+    result :: Results
+    result =
+      Results
+        (Pair True False == Pair True False)
+        (Pair True False == Pair False True)
+        (None /= Pair True True)
+        (Wrapped True == Wrapped True)
+        (Solo False /= Solo True)
+expression: result
+output: Results True False True True True
+status: pass
+reason: executes generated equality, constructor mismatch, field mismatch, and inequality


### PR DESCRIPTION
## Summary

- validate stock `Eq` requests in `aihc-tc` against the standard class layout and checked datatype metadata
- infer derived contexts from instantiated constructor field types, including recursive and mutually recursive derived instances
- attach per-constructor, per-field dictionary evidence to finalized deriving plans and export the resulting instances
- lower checked plans to recursive System FC dictionaries implementing both `(==)` and `(/=)`
- compare constructor tags and fields with short-circuiting Boolean cases, selecting methods directly from checked field dictionaries
- support ordinary data declarations, newtypes, attached clauses, and standalone deriving
- reject existential, constrained, refined-GADT, and empty datatype shapes with TC diagnostics rather than failing in FC

## Why

This is the first stock deriving implementation built on the datatype metadata contract from #1385. Haskell context inference and evidence selection remain in TC; FC consumes only the finalized constructor layout and evidence, so it does not reconstruct or solve Haskell types.

Recursive field evidence is represented by a local self-dictionary in the generated binding. The focused Core-lint regression verifies that the resulting recursive dictionary is structurally typed and contains no unbound selector references.

## Validation

- focused TC context/evidence and rejection tests
- focused FC Core-lint unit test
- FC structural golden for recursive `Tree` equality
- shared FC/GRIN evaluation fixture covering equality, inequality, constructor mismatch, field mismatch, newtypes, and standalone deriving
- `just fmt`
- `just check`

## Progress counts

- `aihc-tc`: 109 -> 111 tests
- `aihc-fc`: 149 -> 152 tests
- `aihc-grin`: 169 -> 170 tests
- No README files updated.