### PR TITLE
feat(base): implement Data.Void

### DIFF
--- a/core-libs/aihc-base/src/Data/Void.hs
+++ b/core-libs/aihc-base/src/Data/Void.hs
@@ -1,1 +1,18 @@
-module Data.Void () where
+{-# LANGUAGE EmptyDataDecls #-}
+
+module Data.Void
+  ( Void,
+    absurd,
+    vacuous,
+  )
+where
+
+import Prelude (Functor (..), seq)
+
+data Void
+
+absurd :: Void -> a
+absurd impossible = impossible `seq` absurd impossible
+
+vacuous :: (Functor f) => f Void -> f a
+vacuous = fmap absurd

--- a/test/Test/Fixtures/eval/base/data-void.yaml
+++ b/test/Test/Fixtures/eval/base/data-void.yaml
@@ -1,0 +1,33 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Data.Void (Void, absurd, vacuous)
+
+    fromEither :: Either Void a -> a
+    fromEither value =
+      case value of
+        Left impossible -> absurd impossible
+        Right result -> result
+
+    emptyVoids :: [Void]
+    emptyVoids = []
+
+    emptyInts :: [Int]
+    emptyInts = vacuous emptyVoids
+
+    checks :: Bool
+    checks =
+      case fromEither (Right True) of
+        False -> False
+        True ->
+          case emptyInts of
+            [] -> True
+            _ : _ -> False
+output: |
+  True
+expression: checks
+status: pass
+reason: evaluates the public Data.Void eliminator and functor transformation from aihc-base


### PR DESCRIPTION
## Summary

- define the abstract, uninhabited `Void` type in `aihc-base`
- implement the strict `absurd` eliminator and functor-polymorphic `vacuous`
- add a shared FC/GRIN evaluation fixture covering elimination through `Either` and transformation of an empty functor

## Core library progress

- `BASE`: unchanged at 330 / 10055 (3.28%)
- `GHC_PRIM`: unchanged at 52 / 3425 (1.52%)
- 1 shared FC/GRIN evaluation fixture added

README progress counters are intentionally unchanged because the cron workflow owns them.

## Validation

- `just fmt`
- `just check`
