### PR TITLE
fix: derive readable symbols from package identities

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -61,7 +61,7 @@ import Aihc.Native
     hostNativeTarget,
   )
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
-import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition)
+import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition, moduleName)
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
 import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
@@ -119,7 +119,8 @@ data IncrementalUnit = IncrementalUnit
 -- this structure; it is never an alternative frontend or lowering path.
 data IncrementalCompilation = IncrementalCompilation
   { incrementalDependencyUnits :: ![IncrementalUnit],
-    incrementalMainUnit :: !IncrementalUnit
+    incrementalMainUnit :: !IncrementalUnit,
+    incrementalEntryName :: !Text
   }
 
 runCompile :: CompileOptions -> IO ()
@@ -249,15 +250,15 @@ compileWithDependencies target wholeProgram dependencies parsed =
                     else
                       let mainProgram = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                        in do
-                            incremental <- compileIncrementally dependencies mainProgram
+                            incremental <- compileIncrementally (fromMaybe "Main" (moduleName parsed)) dependencies mainProgram
                             if wholeProgram
                               then compileWholeProgramArtifacts target incremental
                               else compileIncrementalArtifacts target dependencies incremental
 
 -- | Compile every module SCC to its own normalized Core and GRIN unit before any
 -- optional whole-program transformation is considered.
-compileIncrementally :: DependencyArtifact -> FcProgram -> Either CompileError IncrementalCompilation
-compileIncrementally dependencies unoptimizedMain =
+compileIncrementally :: Text -> DependencyArtifact -> FcProgram -> Either CompileError IncrementalCompilation
+compileIncrementally mainModuleName dependencies unoptimizedMain =
   do
     mainCpsGrin <- either (Left . CompileCpsGrinError) Right (Grin.toCpsGrin mainGrin)
     pure
@@ -266,13 +267,15 @@ compileIncrementally dependencies unoptimizedMain =
             [ IncrementalUnit (dependencyUnitProgram unit) (dependencyUnitGrin unit) (dependencyUnitCpsGrin unit)
             | unit <- dependencyUnits dependencies
             ],
-          incrementalMainUnit = IncrementalUnit mainCore mainGrin mainCpsGrin
+          incrementalMainUnit = IncrementalUnit mainCore mainGrin mainCpsGrin,
+          incrementalEntryName = T.intercalate "\0" (["exe"] <> T.splitOn "." mainModuleName <> ["main"])
         }
   where
     mainCore =
       Fc.optimizeProgram
         (Fc.lowerPseudoOps (Fc.lowerNewtypesWithInterface (dependencyNewtypeInterface dependencies) (eliminateDeadCode "main" unoptimizedMain)))
-    mainGrin = Grin.lowerProgramWithInterface (dependencyGrinInterface dependencies) mainCore
+    mainLinkNames = Grin.linkNamesForProgram ["exe"] (T.splitOn "." mainModuleName) mainCore
+    mainGrin = Grin.lowerProgramWithInterfaceAndLinkNames mainLinkNames (dependencyGrinInterface dependencies) mainCore
 
 -- | Link already-incremental Core units for whole-program analysis. Unique
 -- namespaces are separated only while constructing the merged view.
@@ -317,7 +320,7 @@ compileIncrementalArtifacts target dependencies compilation = do
     either
       (Left . CompileBackendError)
       Right
-      (compileBackendProgramWithDependencies target layout (dependencyInitializerSymbols dependencies) "main" mainGcGrin)
+      (compileBackendProgramWithDependencies target layout (dependencyInitializerSymbols dependencies) (incrementalEntryName compilation) mainGcGrin)
   pure
     CompileArtifacts
       { compiledCore = renderCore mainCore,
@@ -406,12 +409,12 @@ maximumProgramUnique :: FcProgram -> Int
 maximumProgramUnique = maximum . (0 :) . map varUniqueInt . programVars
 
 varUniqueInt :: Var -> Int
-varUniqueInt Var {varUnique = Unique unique} = unique
+varUniqueInt var = case varUnique var of Unique unique -> unique
 
 shiftProgramVars :: Int -> FcProgram -> FcProgram
 shiftProgramVars offset (FcProgram topBinds) = FcProgram (map shiftTopBind topBinds)
   where
-    shiftVar var@Var {varUnique = Unique unique} = var {varUnique = Unique (unique + offset)}
+    shiftVar var = case varUnique var of Unique unique -> var {varUnique = Unique (unique + offset)}
 
     shiftTopBind topBind =
       case topBind of

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -30,6 +30,7 @@ import Aihc.Native
     buildLinkLayoutFromInterfaces,
     extractLinkInterface,
     nativeTargetTriple,
+    renderLinkedFunctionSymbol,
   )
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax
@@ -69,7 +70,7 @@ import Data.Bits (xor)
 import Data.ByteString qualified as BS
 import Data.Char (isHexDigit)
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (sort, sortOn)
+import Data.List (intercalate, sort, sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Set qualified as Set
@@ -122,6 +123,7 @@ data DependencyArtifact = DependencyArtifact
 data DependencyUnit = DependencyUnit
   { dependencyUnitLibraries :: ![Text],
     dependencyUnitModules :: ![Text],
+    dependencyUnitInitializer :: !Text,
     dependencyUnitProgram :: !FcProgram,
     dependencyUnitGrin :: !Grin.GrinProgram,
     dependencyUnitCpsGrin :: !Grin.CpsGrinProgram,
@@ -135,7 +137,8 @@ data DependencyUnit = DependencyUnit
 
 data DependencyUnitMetadata = DependencyUnitMetadata
   { dependencyMetadataLibraries :: ![Text],
-    dependencyMetadataModules :: ![Text]
+    dependencyMetadataModules :: ![Text],
+    dependencyMetadataInitializer :: !Text
   }
   deriving (Eq, Show, Read)
 
@@ -178,6 +181,7 @@ data StoredResolvedName
 
 data LoadedModule = LoadedModule
   { loadedLibrary :: !Text,
+    loadedLibraryId :: ![Text],
     loadedModuleExposed :: !Bool,
     loadedModule :: !Module
   }
@@ -185,6 +189,7 @@ data LoadedModule = LoadedModule
 -- | One Cabal-selected library package in an installation closure.
 data LibraryPackage = LibraryPackage
   { libraryPackageName :: !Text,
+    libraryPackageId :: ![Text],
     libraryPackageRoot :: !FilePath,
     libraryPackageFiles :: ![FilePath],
     libraryPackageExposedModules :: ![Text]
@@ -192,7 +197,7 @@ data LibraryPackage = LibraryPackage
   deriving (Eq, Show)
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 30
+cacheSchemaVersion = 32
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do
@@ -305,13 +310,7 @@ backendMetadataArtifacts artifactRoot metadata =
     libraries = sort (Set.toList (Set.fromList (map metadataPrimaryLibrary metadata)))
 
 metadataInitializerSymbol :: DependencyUnitMetadata -> Text
-metadataInitializerSymbol metadata =
-  "_aihc_init_"
-    <> symbolHex
-      ( metadataPrimaryLibrary metadata
-          <> "\0"
-          <> T.intercalate "\0" (dependencyMetadataModules metadata)
-      )
+metadataInitializerSymbol = dependencyMetadataInitializer
 
 metadataPrimaryLibrary :: DependencyUnitMetadata -> Text
 metadataPrimaryLibrary = fromMaybe "dependencies" . listToMaybe . dependencyMetadataLibraries
@@ -342,7 +341,7 @@ loadLibraryPackages packages = do
     loadPackage package =
       sequence
         <$> mapM
-          (parseModuleFile (libraryPackageName package) (Set.fromList (libraryPackageExposedModules package)))
+          (parseModuleFile (libraryPackageName package) (libraryPackageId package) (Set.fromList (libraryPackageExposedModules package)))
           (sort (libraryPackageFiles package))
 
     rejectDuplicateModules loaded = snd <$> foldM insertModule (Map.empty, []) loaded
@@ -362,12 +361,12 @@ loadLibraryPackages packages = do
                     <> T.unpack (loadedLibrary modu)
                 )
 
-parseModuleFile :: Text -> Set.Set Text -> FilePath -> IO (Either String LoadedModule)
-parseModuleFile library exposedModules path = do
+parseModuleFile :: Text -> [Text] -> Set.Set Text -> FilePath -> IO (Either String LoadedModule)
+parseModuleFile library libraryId exposedModules path = do
   source <- Utf8.readFile path
   pure $
     case parseModule (parserConfig path source) source of
-      ([], modu) -> Right (LoadedModule library (maybe False (`Set.member` exposedModules) (moduleName modu)) modu)
+      ([], modu) -> Right (LoadedModule library libraryId (maybe False (`Set.member` exposedModules) (moduleName modu)) modu)
       (errors, _) -> Left ("failed to parse library module " <> path <> ": " <> show errors)
 
 parserConfig :: FilePath -> Text -> ParserConfig
@@ -400,21 +399,34 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                    in if not (all dsSuccess desugared)
                         then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else
-                          let sourceCore = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
+                          let libraries = sort (Set.toList (Set.fromList (map loadedLibrary members)))
+                              libraryIds = sort (Set.toList (Set.fromList (map loadedLibraryId members)))
+                              modules = sort (map loadedModuleName members)
+                              initializer = unitInitializerSymbol libraryIds modules
+                              linkNames =
+                                mconcat
+                                  [ Grin.linkNamesForProgram
+                                      (loadedLibraryId member)
+                                      (T.splitOn "." (loadedModuleName member))
+                                      (dsProgram desugaredModule)
+                                  | (member, desugaredModule) <- zip members desugared
+                                  ]
+                              sourceCore = FcProgram (concatMap (fcTopBinds . dsProgram) desugared)
                               core = optimizeProgram (lowerPseudoOps (lowerNewtypesWithInterface (compileStateNewtypes state) sourceCore))
                               axioms = extractAxiomInterface core
                               newtypes = extractNewtypeInterface core
-                              grinInterface = Grin.extractGrinInterface core
+                              grinInterface = Grin.extractGrinInterfaceWithLinkNames linkNames core
                               reachabilityInterface = extractReachabilityInterface core
-                              grin = Grin.lowerProgramWithInterface (compileStateGrin state) core
+                              grin = Grin.lowerProgramWithInterfaceAndLinkNames linkNames (compileStateGrin state) core
                               linkInterface = extractLinkInterface grin
                            in case Grin.toCpsGrin grin of
                                 Left err -> Left ("library CPS-GRIN error: " <> show err)
                                 Right cpsGrin ->
                                   let unit =
                                         DependencyUnit
-                                          { dependencyUnitLibraries = sort (Set.toList (Set.fromList (map loadedLibrary members))),
-                                            dependencyUnitModules = sort (map loadedModuleName members),
+                                          { dependencyUnitLibraries = libraries,
+                                            dependencyUnitModules = modules,
+                                            dependencyUnitInitializer = initializer,
                                             dependencyUnitProgram = core,
                                             dependencyUnitGrin = grin,
                                             dependencyUnitCpsGrin = cpsGrin,
@@ -532,13 +544,24 @@ backendUnit objectRoot unit =
   where
     library = dependencyUnitPrimaryLibrary unit
     unitName = T.intercalate "+" (dependencyUnitModules unit)
-    initializer = "_aihc_init_" <> symbolHex (library <> "\0" <> T.intercalate "\0" (dependencyUnitModules unit))
+    initializer = dependencyUnitInitializer unit
+
+unitInitializerSymbol :: [[Text]] -> [Text] -> Text
+unitInitializerSymbol libraryIds modules =
+  "_aihc_init_" <> renderLinkedFunctionSymbol (T.intercalate "\0" components)
+  where
+    components =
+      case libraryIds of
+        [] -> "dependencies" : moduleComponents
+        ids -> intercalate ["with"] ids <> moduleComponents
+    moduleComponents = concatMap (T.splitOn ".") modules
 
 dependencyMetadata :: DependencyUnit -> DependencyUnitMetadata
 dependencyMetadata unit =
   DependencyUnitMetadata
     { dependencyMetadataLibraries = dependencyUnitLibraries unit,
-      dependencyMetadataModules = dependencyUnitModules unit
+      dependencyMetadataModules = dependencyUnitModules unit,
+      dependencyMetadataInitializer = dependencyUnitInitializer unit
     }
 
 backendUnitLibrary :: BackendUnit -> Text
@@ -546,11 +569,6 @@ backendUnitLibrary = dependencyUnitPrimaryLibrary . backendDependencyUnit
 
 dependencyUnitPrimaryLibrary :: DependencyUnit -> Text
 dependencyUnitPrimaryLibrary unit = fromMaybe "dependencies" (listToMaybe (dependencyUnitLibraries unit))
-
-symbolHex :: Text -> Text
-symbolHex = T.concat . map renderByte . BS.unpack . Text.encodeUtf8
-  where
-    renderByte byte = T.pack (padLeft 2 '0' (showHex byte ""))
 
 buildObject :: NativeTarget -> LinkLayout -> BackendUnit -> IO (Either String ())
 buildObject target layout unit = do
@@ -643,9 +661,10 @@ dependencyGraphHash packages = do
     packageChunks package = do
       files <- concat <$> mapM (fileChunks package) (sort (libraryPackageFiles package))
       pure
-        ( Text.encodeUtf8 (frameText (libraryPackageName package))
-            : Text.encodeUtf8 (frameText (T.intercalate "," (sort (libraryPackageExposedModules package))))
-            : files
+        ( [Text.encodeUtf8 (frameText (libraryPackageName package))]
+            <> map (Text.encodeUtf8 . frameText) (libraryPackageId package)
+            <> [Text.encodeUtf8 (frameText (T.intercalate "," (sort (libraryPackageExposedModules package))))]
+            <> files
         )
 
     fileChunks package path = do

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -26,6 +26,7 @@ module Aihc.Cli.Install
     newPackageCheckCache,
     newPackagePlanCache,
     packagePlanFailureShouldBeReportedForPackage,
+    packageVariantLibraryId,
     renderInstallFailure,
     renderInstallFailureWithOptions,
     runInstall,
@@ -201,6 +202,17 @@ data PackageVariantKey = PackageVariantKey
     packageKeyDependencies :: ![ResolvedDependency]
   }
   deriving (Eq, Show)
+
+-- | Readable, globally unique library identity components. The package hash
+-- already covers flags, dependency variants, Cabal input, and compiler phase
+-- configuration, so it must not be recomputed later in the pipeline.
+packageVariantLibraryId :: PackageVariantKey -> [Text]
+packageVariantLibraryId key =
+  T.splitOn "-" (T.pack (pkgName spec))
+    <> T.splitOn "." (T.pack (pkgVersion spec))
+    <> [T.pack (unPackageHash (packageKeyHash key))]
+  where
+    spec = packageKeySpec key
 
 data SourceAnalysis = SourceAnalysis
   { sourceCabalFile :: !FilePath,
@@ -408,6 +420,7 @@ installPackageLibraries targets plan = do
       pure
         LibraryPackage
           { libraryPackageName = T.pack (pkgName (packageKeySpec (planPackageKey package))),
+            libraryPackageId = packageVariantLibraryId (planPackageKey package),
             libraryPackageRoot = planSourcePath package,
             libraryPackageFiles = map HackageCabal.fileInfoPath files,
             libraryPackageExposedModules = HackageCabal.collectLibraryExposedModules gpd

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -16,6 +16,7 @@ import Aihc.Cli.Install
   ( DependencyResolver (..),
     InstallFailure (..),
     InstallResult (..),
+    PackageHash (..),
     PackagePlan (..),
     PackageVariantKey (..),
     ResolvedDependency (..),
@@ -25,6 +26,7 @@ import Aihc.Cli.Install
     checkPackagePlan,
     dryRunInstallScaffold,
     installPackageLibraries,
+    packageVariantLibraryId,
     renderInstallFailure,
     renderInstallFailureWithOptions,
     writeInstallScaffold,
@@ -313,7 +315,12 @@ main =
         ],
       testGroup
         "install"
-        [ testCase "builds stable store paths" test_stableStorePath,
+        [ testCase "forms readable package-variant library identities" $
+            assertEqual
+              "library id"
+              ["aihc", "base", "4", "21", "2", "0", "dephash"]
+              (packageVariantLibraryId (PackageVariantKey (PackageSpec "aihc-base" "4.21.2.0") (PackageHash "dephash") [] [])),
+          testCase "builds stable store paths" test_stableStorePath,
           testCase "recursive dependencies affect store paths" test_recursiveDependenciesAffectStorePaths,
           testCase "plans library components without executables" test_plansLibraryComponentsWithoutExecutables,
           testCase "writes scaffold artifacts" test_writeInstallScaffold,
@@ -1003,8 +1010,10 @@ test_installedPackage =
             [ "{-# LANGUAGE MagicHash #-}",
               "{-# LANGUAGE NoImplicitPrelude #-}",
               "module Main where",
-              "import GHC.Prim",
-              "main = Unit"
+              "import qualified GHC.Prim as Prim",
+              "data Local = Local",
+              "identity value = value",
+              "main = Prim.identity Local"
             ]
         privateMainSource =
           T.unlines
@@ -1034,8 +1043,9 @@ test_installedPackage =
       ( unlines
           [ "{-# LANGUAGE MagicHash #-}",
             "{-# LANGUAGE NoImplicitPrelude #-}",
-            "module GHC.Prim (Unit(..)) where",
-            "import GHC.Prim.Internal (Unit(..))"
+            "module GHC.Prim (Unit(..), identity) where",
+            "import GHC.Prim.Internal (Unit(..))",
+            "identity value = value"
           ]
       )
     createDirectoryIfMissing True (takeDirectory internalSource)
@@ -1056,7 +1066,10 @@ test_installedPackage =
     compileResult <- compileSourceToAssemblyWithDependenciesFor Llvm environment "Main.hs" mainSource
     case compileResult of
       Left err -> assertFailure (show err)
-      Right assembly -> assertBool "expected installed dependency initializer" ("_aihc_init_" `T.isInfixOf` assembly)
+      Right assembly -> do
+        let identitySymbol = T.intercalate "_" (packageVariantLibraryId (planPackageKey plan) <> ["GHC", "Prim", "identity"])
+        assertBool "expected installed dependency initializer" ("_aihc_init_" `T.isInfixOf` assembly)
+        assertBool ("expected readable dependency symbol " <> T.unpack identitySymbol) (identitySymbol `T.isInfixOf` assembly)
     privateCompileResult <- compileSourceToAssemblyWithDependenciesFor Llvm environment "PrivateMain.hs" privateMainSource
     case privateCompileResult of
       Left err -> assertBool ("expected private module error, got: " <> show err) ("GHC.Prim.Internal" `isInfixOf` show err)

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen/Runtime.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen/Runtime.hs
@@ -65,6 +65,7 @@ where
 
 import Aihc.Grin.Cps (ContinuationFrameKind, continuationFrameKindCode)
 import Aihc.Grin.Syntax
+import Aihc.Native (renderLinkedFunctionSymbol)
 import Aihc.Native.BlockLayout qualified as BlockLayout
 import Aihc.Native.RegisterAllocate (Location (..))
 import Aihc.Tc.Types (RuntimeRep (..))
@@ -78,7 +79,6 @@ import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Numeric (showHex)
 
 data Amd64Error
   = Amd64MissingEntry !Text
@@ -647,10 +647,7 @@ localFunctionLabelWith exposeAllFunctions index function
         Nothing -> functionLabel index
 
 linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel name =
-  "aihc_entry_" <> T.concatMap encode name
-  where
-    encode character = T.pack (showHex (ord character) "_")
+linkedFunctionLabel = renderLinkedFunctionSymbol
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot =

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -296,8 +296,8 @@ tests =
         case compileModule (buildLinkLayout [program]) "_aihc_init_direct_call" (expectGcGrin program) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> do
-            assertBool "exports caller entry" (".globl aihc_entry_63_61_6c_6c_65_72_" `T.isInfixOf` assembly)
-            assertBool "branches to dependency entry" ("jmp aihc_entry_69_64_65_6e_74_69_74_79_" `T.isInfixOf` assembly)
+            assertBool "exports caller entry" (".globl aihc_entry_caller" `T.isInfixOf` assembly)
+            assertBool "branches to dependency entry" ("jmp aihc_entry_identity" `T.isInfixOf` assembly)
             assertBool "does not publish direct-call arguments through the machine" (not ("mov QWORD PTR [r15], r12" `T.isInfixOf` assembly)),
       testGroup "raw GRIN heap snapshots" (map snapshotTest snapshotCases),
       testCase "case and apply never evaluate operands implicitly" $ do

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen/Runtime.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen/Runtime.hs
@@ -64,6 +64,7 @@ where
 
 import Aihc.Grin.Cps (ContinuationFrameKind, continuationFrameKindCode)
 import Aihc.Grin.Syntax
+import Aihc.Native (renderLinkedFunctionSymbol)
 import Aihc.Native.BlockLayout qualified as BlockLayout
 import Aihc.Native.RegisterAllocate (Location (..))
 import Aihc.Tc.Types (RuntimeRep (..))
@@ -77,7 +78,6 @@ import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Numeric (showHex)
 
 data Arm64Error
   = Arm64MissingEntry !Text
@@ -524,9 +524,7 @@ localFunctionLabelWith exposeAllFunctions index function
         Nothing -> functionLabel index
 
 linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel name = "_aihc_entry_" <> T.concatMap encode name
-  where
-    encode character = T.pack (showHex (ord character) "_")
+linkedFunctionLabel = ("_" <>) . renderLinkedFunctionSymbol
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot = ["  ldr x9, [x22, #0]", storeAt "x0" "x9" slot]

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -289,8 +289,8 @@ tests =
         case compileModule (buildLinkLayout [program]) "_aihc_init_direct_call" (expectGcGrin program) of
           Left err -> assertFailure ("native compilation failed: " <> show err)
           Right assembly -> do
-            assertBool "exports caller entry" (".globl _aihc_entry_63_61_6c_6c_65_72_" `T.isInfixOf` assembly)
-            assertBool "branches to dependency entry" ("b _aihc_entry_69_64_65_6e_74_69_74_79_" `T.isInfixOf` assembly)
+            assertBool "exports caller entry" (".globl _aihc_entry_caller" `T.isInfixOf` assembly)
+            assertBool "branches to dependency entry" ("b _aihc_entry_identity" `T.isInfixOf` assembly)
             assertBool "does not publish direct-call arguments through the machine" (not ("str x8, [x22, #0]" `T.isInfixOf` assembly)),
       testGroup "raw GRIN heap snapshots" (map snapshotTest snapshotCases),
       testCase "case and apply never evaluate operands implicitly" $ do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -46,6 +46,7 @@ import Aihc.Parser.Syntax
     ValueDecl (..),
     binderHeadName,
     fromAnnotation,
+    moduleName,
     peelDeclAnn,
     unqualifiedNameText,
   )
@@ -109,7 +110,7 @@ desugarModuleWithBindings bindings tcResult _m =
         }
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
-       in case runStateT (dsModule tcResult) (DsState 1000 typeEnv Map.empty Map.empty) of
+       in case runStateT (dsModule tcResult) (DsState 1000 (moduleName tcResult) typeEnv Map.empty Map.empty) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram [],

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -62,7 +62,7 @@ import Aihc.Tc.Types (Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVar
 import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.State.Strict (StateT, get, modify')
+import Control.Monad.Trans.State.Strict (StateT, get, gets, modify')
 import Data.ByteString qualified as BS
 import Data.Char (ord)
 import Data.List qualified as List
@@ -78,6 +78,7 @@ type DsM = StateT DsState (Either String)
 -- | Desugaring state.
 data DsState = DsState
   { dsNextUnique :: !Int,
+    dsModuleName :: !(Maybe Text),
     -- | Map from surface name to its inferred type (from TC).
     dsTypeEnv :: !(Map Text TcType),
     -- | Local variable bindings (pattern-bound, lambda-bound).
@@ -535,15 +536,16 @@ dsExpr (EAnn ann inner)
   | Just tcAnn <- fromAnnotation ann =
       dsAnnotatedExpr tcAnn inner
 dsExpr (EVar name) = do
-  let n = nameToText name
+  let n = nameText name
+      resolvedName = resolvedOccurrenceName name
   -- Check local bindings first (pattern/lambda variables).
-  mLocal <- lookupLocalName name
+  mLocal <- lookupLocalName resolvedName
   case mLocal of
     Just v -> pure (FcVar v)
     Nothing -> do
-      ty <- lookupTypeName name
+      ty <- lookupTypeName resolvedName
       v <- freshVar n ty
-      pure (FcVar v)
+      pure (FcVar v {varResolvedName = nameToResolvedText resolvedName})
 dsExpr (EInt i numericType _) = pure (FcLit (LitInt (numericRuntimeRep numericType) i))
 dsExpr (EChar c _) = pure (boxCharLiteral c)
 dsExpr (ECharHash c _) = pure (FcLit (LitChar WordRep c))
@@ -582,14 +584,16 @@ dsExpr expr =
 
 dsAnnotatedVar :: TcAnnotation -> Name -> Expr -> DsM FcExpr
 dsAnnotatedVar tcAnn name _expr = do
-  let n = nameToText name
-  mLocal <- lookupLocalName name
+  let n = nameText name
+      resolvedName = resolvedOccurrenceName name
+  mLocal <- lookupLocalName resolvedName
   variable <-
     case mLocal of
       Just local -> pure local
       Nothing -> do
-        ty <- lookupTypeName name
-        freshVar n ty
+        ty <- lookupTypeName resolvedName
+        imported <- freshVar n ty
+        pure imported {varResolvedName = nameToResolvedText resolvedName}
   let occurrenceVar
         | isGhcPrimSeq name = variable {varName = seqPseudoOpName}
         | otherwise = variable
@@ -738,10 +742,22 @@ dsIntegerLiteral value = do
 resolvedAnnotationName :: ResolutionAnnotation -> Name
 resolvedAnnotationName resolution =
   case resolutionTarget resolution of
-    ResolvedTopLevel name -> mkName Nothing (nameType name) (nameText name)
+    ResolvedTopLevel name -> mkName (nameQualifier name) (nameType name) (nameText name)
     ResolvedLocal _ name -> qualifyName Nothing name
     ResolvedBuiltin name -> mkName Nothing NameVarId name
     ResolvedError {} -> mkName Nothing NameVarId (resolutionName resolution)
+
+resolvedOccurrenceName :: Name -> Name
+resolvedOccurrenceName name =
+  maybe
+    name
+    resolvedAnnotationName
+    ( listToMaybe
+        [ resolution
+        | resolution <- mapMaybe fromAnnotation (nameAnns name),
+          resolutionNamespace resolution == ResolutionNamespaceTerm
+        ]
+    )
 
 isFromIntegerResolution :: ResolutionAnnotation -> Bool
 isFromIntegerResolution resolution =
@@ -1709,12 +1725,17 @@ nameToText n = case nameQualifier n of
   Nothing -> nameText n
   Just q -> q <> "." <> nameText n
 
+nameToResolvedText :: Name -> Maybe Text
+nameToResolvedText name = (<> "." <> nameText name) <$> nameQualifier name
+
 lookupLocalName :: Name -> DsM (Maybe Var)
 lookupLocalName name = do
-  local <- lookupLocal (nameToText name)
-  case local of
-    Just var -> pure (Just var)
+  currentModule <- gets dsModuleName
+  case nameQualifier name of
     Nothing -> lookupLocal (nameText name)
+    Just qualifier
+      | Just qualifier == currentModule -> lookupLocal (nameText name)
+      | otherwise -> lookupLocal (nameToText name)
 
 lookupTypeName :: Name -> DsM TcType
 lookupTypeName name = do

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -- | System FC core language.
 --
@@ -17,7 +18,7 @@ module Aihc.Fc.Syntax
     FcExpr (..),
 
     -- * Variables
-    Var (..),
+    Var (Var, varName, varUnique, varType, varResolvedName),
 
     -- * Bindings
     FcBind (..),
@@ -181,12 +182,23 @@ fcDictionaryConstructorName :: Text -> Text
 fcDictionaryConstructorName className = "$Dict$" <> className
 
 -- | A typed variable.
-data Var = Var
+data Var = ResolvedVar
   { varName :: !Text,
     varUnique :: !Unique,
-    varType :: !TcType
+    varType :: !TcType,
+    -- | Resolver identity for an imported occurrence. Kept separate from the
+    -- display name so whole-program FC evaluation remains source-readable.
+    varResolvedName :: !(Maybe Text)
   }
   deriving (Show, Read)
+
+-- | Construct a variable without a separate imported identity.
+pattern Var :: Text -> Unique -> TcType -> Var
+pattern Var name unique ty <- ResolvedVar name unique ty _
+  where
+    Var name unique ty = ResolvedVar name unique ty Nothing
+
+{-# COMPLETE Var #-}
 
 -- Eq/Ord on Unique only, mirroring TyVarId.
 instance Eq Var where

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -19,9 +19,14 @@ module Aihc.Grin
     gcUpdateFunction,
     lowerGc,
     lowerProgram,
+    GrinLinkNames,
+    linkNamesForProgram,
+    lowerProgramWithLinkNames,
     GrinInterface,
     extractGrinInterface,
+    extractGrinInterfaceWithLinkNames,
     lowerProgramWithInterface,
+    lowerProgramWithInterfaceAndLinkNames,
     lintProgram,
     GrinLintError (..),
     GrinParseError,
@@ -59,7 +64,17 @@ import Aihc.Grin.Cps
 import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcFunctionContinuations, gcGrinProgram, gcUpdateFunction, lowerGc)
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramFunctionSnapshot, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
-import Aihc.Grin.Lower (GrinInterface, extractGrinInterface, lowerProgram, lowerProgramWithInterface)
+import Aihc.Grin.Lower
+  ( GrinInterface,
+    GrinLinkNames,
+    extractGrinInterface,
+    extractGrinInterfaceWithLinkNames,
+    linkNamesForProgram,
+    lowerProgram,
+    lowerProgramWithInterface,
+    lowerProgramWithInterfaceAndLinkNames,
+    lowerProgramWithLinkNames,
+  )
 import Aihc.Grin.Parser (GrinParseError, parseExpr, parseProgram, renderParseError)
 import Aihc.Grin.Pretty (renderExpr, renderProgram)
 import Aihc.Grin.Snapshot

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -4,9 +4,14 @@
 -- | Lowering from non-strict System FC to strict, runtime-explicit GRIN.
 module Aihc.Grin.Lower
   ( GrinInterface,
+    GrinLinkNames,
+    linkNamesForProgram,
     extractGrinInterface,
+    extractGrinInterfaceWithLinkNames,
     lowerProgram,
+    lowerProgramWithLinkNames,
     lowerProgramWithInterface,
+    lowerProgramWithInterfaceAndLinkNames,
   )
 where
 
@@ -23,7 +28,9 @@ import Aihc.Tc.Types
     liftedRuntimeRep,
     runtimeRepOfType,
   )
+import Control.Applicative ((<|>))
 import Control.Monad.Trans.State.Strict (State, gets, modify', runState)
+import Data.List (mapAccumL)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -38,15 +45,19 @@ data LowerState = LowerState
     lowerFunctionsRev :: ![GrinFunction],
     lowerConstructorArities :: !(Map Text Int),
     lowerPrimitiveArities :: !(Map Text Int),
-    lowerCodeInfos :: !(Map Text GrinCodeInfo),
-    lowerLocalCodeNames :: !(Set Text),
-    lowerReferencedExternalCodeNames :: !(Set Text),
+    lowerLocalCodeInfosByUnique :: !(Map Unique [(TcType, GrinCodeInfo)]),
+    lowerCodeInfosByName :: !(Map Text GrinCodeInfo),
+    lowerLocalCodeLinkNames :: !(Set Text),
+    lowerReferencedExternalCodeLinkNames :: !(Set Text),
     lowerLocalGlobalNames :: !(Set Text),
     lowerReferencedExternalGlobalNames :: !(Set Text),
-    lowerGlobalNames :: !(Set Text),
-    lowerWhnfGlobalNames :: !(Set Text),
+    lowerGlobalNames :: !(Map Text Text),
+    lowerWhnfGlobalNames :: !(Map Text Text),
     lowerLocalVars :: !(Map (Text, Unique) [GrinVar]),
-    lowerCurrentProvenance :: !(Maybe Text)
+    lowerCurrentProvenance :: !(Maybe Text),
+    lowerUseIncrementalCodeLookup :: !Bool,
+    lowerLinkNames :: !GrinLinkNames,
+    lowerLinkNameOccurrences :: !(Map Unique Int)
   }
 
 type LowerM = State LowerState
@@ -78,15 +89,83 @@ instance Monoid LoweredTop where
 lowerProgram :: FcProgram -> GrinProgram
 lowerProgram = lowerProgramWithInterface mempty
 
--- | Runtime facts exported by one compiled unit. Lowering consumers need to
--- know which external names are globals, already in WHNF, constructors, or
--- primitives, but never need the defining FC expressions.
+-- | Linker identities for top-level FC values, keyed by their compiler
+-- unique. The text representation uses NUL only as an internal component
+-- separator; native backends render it into a readable object symbol.
+data GrinLinkNames = GrinLinkNames
+  { grinNativeLinkNames :: !(Map Unique [Text]),
+    grinSourceLinkNames :: !(Map Unique [Text]),
+    grinConstructorNames :: !(Map Text (Text, Int))
+  }
+  deriving (Eq, Show, Read)
+
+instance Semigroup GrinLinkNames where
+  left <> right =
+    GrinLinkNames
+      { grinNativeLinkNames = Map.unionWith (<>) (grinNativeLinkNames left) (grinNativeLinkNames right),
+        grinSourceLinkNames = Map.unionWith (<>) (grinSourceLinkNames left) (grinSourceLinkNames right),
+        grinConstructorNames = grinConstructorNames left <> grinConstructorNames right
+      }
+
+instance Monoid GrinLinkNames where
+  mempty = GrinLinkNames Map.empty Map.empty Map.empty
+
+-- | Assign every top-level value in a program a linker identity consisting
+-- of the supplied package-and-module components followed by its source name.
+linkNamesForProgram :: [Text] -> [Text] -> FcProgram -> GrinLinkNames
+linkNamesForProgram libraryId moduleNameComponents program =
+  GrinLinkNames
+    { grinNativeLinkNames =
+        Map.fromListWith
+          (flip (<>))
+          [ (varUnique var, [T.intercalate "\0" (libraryId <> moduleNameComponents <> symbolComponents ordinal var)])
+          | (var, ordinal) <- topLevelVarsWithOrdinals
+          ],
+      grinSourceLinkNames =
+        Map.fromListWith
+          (flip (<>))
+          [ (varUnique var, [T.intercalate "." (moduleNameComponents <> [varName var])])
+          | (var, _) <- topLevelVarsWithOrdinals
+          ],
+      grinConstructorNames =
+        Map.fromList
+          [ (T.intercalate "." (moduleNameComponents <> [name]), (name, length fields))
+          | FcData _ _ constructors <- fcTopBinds program,
+            (name, fields) <- constructors
+          ]
+    }
+  where
+    topLevelVars = [var | FcTopBind bind <- fcTopBinds program, var <- topBindVars bind]
+    nameCounts = Map.fromListWith (+) [(varName var, 1 :: Int) | var <- topLevelVars]
+    topLevelVarsWithOrdinals = snd (mapAccumL annotate Map.empty topLevelVars)
+    annotate :: Map Text Int -> Var -> (Map Text Int, (Var, Int))
+    annotate ordinals var =
+      let ordinal = Map.findWithDefault 0 (varName var) ordinals + 1
+       in (Map.insert (varName var) ordinal ordinals, (var, ordinal))
+    symbolComponents ordinal var =
+      [varName var]
+        <> ["u" <> T.pack (show (sourceUnique var)) <> "n" <> T.pack (show ordinal) | Map.findWithDefault 0 (varName var) nameCounts > 1]
+    topBindVars bind =
+      case bind of
+        FcNonRec var _ -> [var]
+        FcRec bindings -> map fst bindings
+
+-- | Lower one standalone compilation unit with an explicit linker identity
+-- for each link-visible top-level definition.
+lowerProgramWithLinkNames :: GrinLinkNames -> FcProgram -> GrinProgram
+lowerProgramWithLinkNames linkNames = lowerProgramWithInterfaceAndLinkNames linkNames mempty
+
+-- | Runtime facts exported by one compiled unit. Function facts retain their
+-- unit-local compiler unique and source name; lowering never compares uniques
+-- from different units.
 data GrinInterface = GrinInterface
-  { grinInterfaceGlobals :: !(Set Text),
-    grinInterfaceWhnfGlobals :: !(Set Text),
+  { grinInterfaceGlobals :: !(Map Text Text),
+    grinInterfaceWhnfGlobals :: !(Map Text Text),
     grinInterfaceConstructorArities :: !(Map Text Int),
     grinInterfacePrimitiveArities :: !(Map Text Int),
-    grinInterfaceCodeInfos :: !(Map Text GrinCodeInfo)
+    grinInterfaceCodeInfosByUnique :: !(Map Unique [(TcType, GrinCodeInfo)]),
+    grinInterfaceCodeInfosByName :: !(Map Text GrinCodeInfo),
+    grinInterfaceCodeInfosByLinkName :: !(Map Text GrinCodeInfo)
   }
   deriving (Eq, Show, Read)
 
@@ -97,38 +176,78 @@ instance Semigroup GrinInterface where
         grinInterfaceWhnfGlobals = grinInterfaceWhnfGlobals left <> grinInterfaceWhnfGlobals right,
         grinInterfaceConstructorArities = grinInterfaceConstructorArities left <> grinInterfaceConstructorArities right,
         grinInterfacePrimitiveArities = grinInterfacePrimitiveArities left <> grinInterfacePrimitiveArities right,
-        grinInterfaceCodeInfos = grinInterfaceCodeInfos left <> grinInterfaceCodeInfos right
+        grinInterfaceCodeInfosByUnique = Map.unionWith (<>) (grinInterfaceCodeInfosByUnique left) (grinInterfaceCodeInfosByUnique right),
+        grinInterfaceCodeInfosByName = grinInterfaceCodeInfosByName left <> grinInterfaceCodeInfosByName right,
+        grinInterfaceCodeInfosByLinkName = grinInterfaceCodeInfosByLinkName left <> grinInterfaceCodeInfosByLinkName right
       }
 
 instance Monoid GrinInterface where
-  mempty = GrinInterface Set.empty Set.empty Map.empty Map.empty Map.empty
+  mempty = GrinInterface Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
 
 extractGrinInterface :: FcProgram -> GrinInterface
-extractGrinInterface = extractPreparedGrinInterface . lowerRequiredFc
+extractGrinInterface = extractGrinInterfaceWithLinkNames mempty
 
-extractPreparedGrinInterface :: FcProgram -> GrinInterface
-extractPreparedGrinInterface program =
+-- | Extract runtime facts whose native code labels identify each definition's
+-- package and module. Source-level lookup keys deliberately remain unchanged.
+extractGrinInterfaceWithLinkNames :: GrinLinkNames -> FcProgram -> GrinInterface
+extractGrinInterfaceWithLinkNames linkNames = extractPreparedGrinInterface linkNames . lowerRequiredFc
+
+extractPreparedGrinInterface :: GrinLinkNames -> FcProgram -> GrinInterface
+extractPreparedGrinInterface linkNames program =
   GrinInterface
-    { grinInterfaceGlobals = Set.fromList (programGlobalNames program),
-      grinInterfaceWhnfGlobals = Set.fromList (programWhnfGlobalNames program),
-      grinInterfaceConstructorArities = Map.fromList (programConstructors program),
+    { grinInterfaceGlobals =
+        Map.fromList
+          ( [(name, name) | (name, _) <- programConstructors program]
+              <> [(sourceName, name) | (sourceName, (name, _)) <- constructorNames]
+              <> [ (sourceName, linkedName)
+                 | (var, qualifiedName, linkedName, _) <- globalInfos,
+                   sourceName <- [varName var, qualifiedName]
+                 ]
+          ),
+      grinInterfaceWhnfGlobals =
+        Map.fromList
+          ( [(name, name) | (name, arity) <- programConstructors program, arity == 0]
+              <> [(sourceName, name) | (sourceName, (name, 0)) <- constructorNames]
+              <> [ (sourceName, linkedName)
+                 | (var, qualifiedName, linkedName, True) <- globalInfos,
+                   sourceName <- [varName var, qualifiedName]
+                 ]
+          ),
+      grinInterfaceConstructorArities = Map.fromList (programConstructors program <> [(sourceName, arity) | (sourceName, (_, arity)) <- constructorNames]),
       grinInterfacePrimitiveArities =
         Map.fromList
           [ (varName var, arity)
           | FcPrimitive var arity <- fcTopBinds program,
             varName var /= "seq"
           ],
-      grinInterfaceCodeInfos = Map.fromList (programCodeInfos program)
+      grinInterfaceCodeInfosByUnique = Map.fromListWith (<>) [(varUnique var, [(varType var, info)]) | (var, _, info) <- codeInfos],
+      grinInterfaceCodeInfosByName =
+        Map.fromList
+          [ (sourceName, info)
+          | (var, qualifiedName, info) <- codeInfos,
+            sourceName <- [varName var, qualifiedName]
+          ],
+      grinInterfaceCodeInfosByLinkName = Map.fromList [(grinCodeSourceName info, info) | (_, _, info) <- codeInfos]
     }
+  where
+    codeInfos = programCodeInfos linkNames program
+    globalInfos = programGlobalInfos linkNames program
+    constructorNames = Map.toList (grinConstructorNames linkNames)
 
 -- | Apply compulsory FC lowering, then lower one SCC using only the exported
 -- runtime facts of predecessor SCCs. Optional FC optimizations are the
 -- caller's choice and are never required for correct GRIN semantics.
 lowerProgramWithInterface :: GrinInterface -> FcProgram -> GrinProgram
-lowerProgramWithInterface imported sourceProgram =
-  lowerProgramWithEnvironment (programEnvironment (imported <> extractPreparedGrinInterface program)) program
+lowerProgramWithInterface = lowerProgramWithInterfaceAndLinkNames mempty
+
+-- | Lower one compilation unit against imported runtime facts with an
+-- explicit linker identity for each local top-level definition.
+lowerProgramWithInterfaceAndLinkNames :: GrinLinkNames -> GrinInterface -> FcProgram -> GrinProgram
+lowerProgramWithInterfaceAndLinkNames linkNames imported sourceProgram =
+  lowerProgramWithEnvironment linkNames imported localInterface (programEnvironment (localInterface <> imported)) program
   where
     program = lowerRequiredFc sourceProgram
+    localInterface = extractPreparedGrinInterface linkNames program
 
 -- | Establish the System FC forms required by GRIN lowering. These semantic
 -- lowerings are deliberately independent of optional FC optimization.
@@ -136,25 +255,25 @@ lowerRequiredFc :: FcProgram -> FcProgram
 lowerRequiredFc = lowerPseudoOps . lowerNewtypes
 
 data ProgramEnvironment = ProgramEnvironment
-  { programEnvironmentGlobals :: !(Set Text),
-    programEnvironmentWhnfGlobals :: !(Set Text),
+  { programEnvironmentGlobals :: !(Map Text Text),
+    programEnvironmentWhnfGlobals :: !(Map Text Text),
     programEnvironmentConstructorArities :: !(Map Text Int),
     programEnvironmentPrimitiveArities :: !(Map Text Int),
-    programEnvironmentCodeInfos :: !(Map Text GrinCodeInfo)
+    programEnvironmentCodeInfosByName :: !(Map Text GrinCodeInfo)
   }
 
 programEnvironment :: GrinInterface -> ProgramEnvironment
 programEnvironment interface =
   ProgramEnvironment
-    { programEnvironmentGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceGlobals interface,
-      programEnvironmentWhnfGlobals = Set.fromList (map fst builtinConstructors) <> grinInterfaceWhnfGlobals interface,
+    { programEnvironmentGlobals = Map.fromList [(name, name) | (name, _) <- builtinConstructors] <> grinInterfaceGlobals interface,
+      programEnvironmentWhnfGlobals = Map.fromList [(name, name) | (name, layouts) <- builtinConstructors, null layouts] <> grinInterfaceWhnfGlobals interface,
       programEnvironmentConstructorArities = Map.fromList [(name, length layouts) | (name, layouts) <- builtinConstructors] <> grinInterfaceConstructorArities interface,
       programEnvironmentPrimitiveArities = grinInterfacePrimitiveArities interface,
-      programEnvironmentCodeInfos = grinInterfaceCodeInfos interface
+      programEnvironmentCodeInfosByName = grinInterfaceCodeInfosByName interface
     }
 
-lowerProgramWithEnvironment :: ProgramEnvironment -> FcProgram -> GrinProgram
-lowerProgramWithEnvironment environment program =
+lowerProgramWithEnvironment :: GrinLinkNames -> GrinInterface -> GrinInterface -> ProgramEnvironment -> FcProgram -> GrinProgram
+lowerProgramWithEnvironment linkNames imported local environment program =
   GrinProgram
     { grinConstructors = loweredConstructors tops,
       grinPrimitives = loweredPrimitives tops,
@@ -173,23 +292,27 @@ lowerProgramWithEnvironment environment program =
           lowerFunctionsRev = [],
           lowerConstructorArities = programEnvironmentConstructorArities environment,
           lowerPrimitiveArities = programEnvironmentPrimitiveArities environment,
-          lowerCodeInfos = programEnvironmentCodeInfos environment,
-          lowerLocalCodeNames = localCodeNames,
-          lowerReferencedExternalCodeNames = Set.empty,
-          lowerLocalGlobalNames = Set.fromList (programGlobalNames program),
+          lowerLocalCodeInfosByUnique = grinInterfaceCodeInfosByUnique local,
+          lowerCodeInfosByName = programEnvironmentCodeInfosByName environment,
+          lowerLocalCodeLinkNames = localCodeLinkNames,
+          lowerReferencedExternalCodeLinkNames = Set.empty,
+          lowerLocalGlobalNames = Set.fromList [linkedName | (_, _, linkedName, _) <- programGlobalInfos linkNames program],
           lowerReferencedExternalGlobalNames = Set.empty,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,
           lowerLocalVars = Map.empty,
-          lowerCurrentProvenance = Nothing
+          lowerCurrentProvenance = Nothing,
+          lowerUseIncrementalCodeLookup = not (grinLinkNamesEmpty linkNames),
+          lowerLinkNames = linkNames,
+          lowerLinkNameOccurrences = Map.empty
         }
     (topParts, finalState) = runState (mapM lowerTopBind (fcTopBinds program)) initialState
     tops = mconcat topParts
-    localCodeNames = Map.keysSet (Map.fromList (programCodeInfos program))
+    localCodeLinkNames = Set.fromList [grinCodeSourceName info | (_, _, info) <- programCodeInfos linkNames program]
     externalCodeInfos =
       [ info
-      | (name, info) <- Map.toAscList (programEnvironmentCodeInfos environment),
-        name `Set.member` lowerReferencedExternalCodeNames finalState
+      | (linkName', info) <- Map.toAscList (grinInterfaceCodeInfosByLinkName imported),
+        linkName' `Set.member` lowerReferencedExternalCodeLinkNames finalState
       ]
 
 lowerTopBind :: FcTopBind -> LowerM LoweredTop
@@ -205,7 +328,7 @@ lowerTopBind topBind =
       pure
         mempty
           { loweredPrimitives =
-              [ (lowerGlobalVar var, arity)
+              [ (plainGlobalVar var, arity)
               | varName var `notElem` ["unsafeCoerce#", "raise#", "catch#", "seq"]
               ]
           }
@@ -222,13 +345,14 @@ lowerTopValueBind bind =
   where
     lowerBinding var expr =
       withProvenance (varName var) $ do
+        linkedName <- nextLinkName var
         if isDirectFunction expr
           then do
-            emitTopFunction var expr
+            emitTopFunction linkedName var expr
             pure mempty
           else do
             staticNode <- lowerStaticNode expr
-            topVar <- freshTopVar var
+            topVar <- freshTopVar linkedName
             case staticNode of
               Just node -> pure mempty {loweredWhnfGlobals = [(topVar, node)]}
               Nothing -> do
@@ -247,17 +371,17 @@ isDirectFunction expr =
     FcCast inner _ -> isDirectFunction inner
     _ -> False
 
-emitTopFunction :: Var -> FcExpr -> LowerM ()
-emitTopFunction var expr = do
+emitTopFunction :: Text -> Var -> FcExpr -> LowerM ()
+emitTopFunction linkedName _var expr = do
   let (binders, body) = collectLeadingLambdas expr
-      functionName = topFunctionName var
+      functionName = linkedFunctionName linkedName
   (parameters, loweredBody) <- withFreshLocalVars binders $ \groups -> do
     body' <- lowerExpr body
     pure (concat groups, body')
   emitFunction
     GrinFunction
       { grinFunctionName = functionName,
-        grinFunctionLinkName = Just (varName var),
+        grinFunctionLinkName = Just linkedName,
         grinFunctionParameters = parameters,
         grinFunctionResultRep = exprRuntimeRep body,
         grinFunctionBody = loweredBody
@@ -742,16 +866,17 @@ lowerStaticValues expr =
       | otherwise -> do
           constructorArity <- lookupConstructorArity var
           isWhnfGlobal <- isWhnfGlobalVar var
+          global <- lowerGlobalVar var
           localGlobalNames <- gets lowerLocalGlobalNames
           case constructorArity of
             Just 0 -> do
               noteExternalGlobalReference var
-              pure (Just [GrinVarValue (lowerGlobalVar var)])
+              pure (Just [GrinVarValue global])
             _
               | isWhnfGlobal,
-                varName var `Set.notMember` localGlobalNames -> do
+                grinVarName global `Set.notMember` localGlobalNames -> do
                   noteExternalGlobalReference var
-                  pure (Just [GrinVarValue (lowerGlobalVar var)])
+                  pure (Just [GrinVarValue global])
               | otherwise -> pure Nothing
     FcTyApp inner _ -> lowerStaticValues inner
     FcCast inner _ -> lowerStaticValues inner
@@ -931,11 +1056,11 @@ freshVar hint runtimeRep = do
   modify' $ \state -> state {lowerNextUnique = unique + 1}
   pure (GrinVar ("$grin_" <> hint <> "_" <> T.pack (show unique)) unique runtimeRep)
 
-freshTopVar :: Var -> LowerM GrinVar
-freshTopVar var = do
+freshTopVar :: Text -> LowerM GrinVar
+freshTopVar linkedName = do
   unique <- gets lowerNextUnique
   modify' $ \state -> state {lowerNextUnique = unique + 1}
-  pure (GrinVar (varName var) unique liftedRuntimeRep)
+  pure (GrinVar linkedName unique liftedRuntimeRep)
 
 freshFunction :: Text -> LowerM FunctionName
 freshFunction kind = do
@@ -996,7 +1121,7 @@ lookupFunctionResultRep owner functionName
   | functionName == grinFunctionName owner = pure (grinFunctionResultRep owner)
   | otherwise = do
       localFunctions <- gets lowerFunctionsRev
-      codeInfos <- gets lowerCodeInfos
+      codeInfos <- gets lowerCodeInfosByName
       case [grinFunctionResultRep function | function <- localFunctions, grinFunctionName function == functionName]
         <> [grinCodeResultRep info | info <- Map.elems codeInfos, grinCodeFunctionName info == functionName] of
         resultRep : _ -> pure resultRep
@@ -1060,8 +1185,18 @@ freeVarsAlt :: FcAlt -> Set Var
 freeVarsAlt alt =
   freeVars (altRhs alt) `Set.difference` Set.fromList (altBinders alt)
 
-lowerGlobalVar :: Var -> GrinVar
-lowerGlobalVar var = GrinVar (varName var) (sourceUnique var) liftedRuntimeRep
+plainGlobalVar :: Var -> GrinVar
+plainGlobalVar var = GrinVar (varName var) (sourceUnique var) liftedRuntimeRep
+
+lowerGlobalVar :: Var -> LowerM GrinVar
+lowerGlobalVar var = do
+  globalNames <- gets lowerGlobalNames
+  incremental <- gets lowerUseIncrementalCodeLookup
+  let sourceName
+        | incremental = fromMaybe (varName var) (varResolvedName var)
+        | otherwise = varName var
+      linkedName = Map.findWithDefault (varName var) sourceName globalNames
+  pure (GrinVar linkedName (sourceUnique var) liftedRuntimeRep)
 
 capturesFor :: FcExpr -> LowerM [GrinVar]
 capturesFor expr =
@@ -1083,9 +1218,13 @@ isGlobalVar :: Var -> LowerM Bool
 isGlobalVar var = do
   localVars <- gets lowerLocalVars
   globalNames <- gets lowerGlobalNames
+  incremental <- gets lowerUseIncrementalCodeLookup
+  let sourceName
+        | incremental = fromMaybe (varName var) (varResolvedName var)
+        | otherwise = varName var
   pure
     ( varKey var `Map.notMember` localVars
-        && (varName var `Set.member` globalNames || isUnboxedTupleConstructor (varName var))
+        && (sourceName `Map.member` globalNames || isUnboxedTupleConstructor (varName var))
     )
 
 -- | Values that can be embedded directly in a non-allocating GRIN operation.
@@ -1109,7 +1248,8 @@ lowerDirectValues expr =
         _
           | isWhnfGlobal -> do
               noteExternalGlobalReference var
-              pure (Just [GrinVarValue (lowerGlobalVar var)])
+              global <- lowerGlobalVar var
+              pure (Just [GrinVarValue global])
           | not isGlobal && runtimeRep /= liftedRuntimeRep ->
               Just . map GrinVarValue <$> lookupLocalVars var
           | otherwise -> pure Nothing
@@ -1153,7 +1293,8 @@ lookupRuntimeVars var = do
         then case runtimeReps of
           [_] -> do
             noteExternalGlobalReference var
-            pure [lowerGlobalVar var]
+            globalVar <- lowerGlobalVar var
+            pure [globalVar]
           _ -> error "GRIN lowering found a global with a multi-value runtime representation"
         else lookupLocalVars var
 
@@ -1166,12 +1307,13 @@ lookupRuntimeVar var =
 noteExternalGlobalReference :: Var -> LowerM ()
 noteExternalGlobalReference var = do
   localGlobalNames <- gets lowerLocalGlobalNames
-  if varName var `Set.member` localGlobalNames
+  global <- lowerGlobalVar var
+  if grinVarName global `Set.member` localGlobalNames
     then pure ()
     else modify' $ \state ->
       state
         { lowerReferencedExternalGlobalNames =
-            Set.insert (varName var) (lowerReferencedExternalGlobalNames state)
+            Set.insert (grinVarName global) (lowerReferencedExternalGlobalNames state)
         }
 
 lookupAliasVars :: FcExpr -> LowerM (Maybe [GrinVar])
@@ -1189,19 +1331,30 @@ lookupAliasVars expr =
 lookupCodeInfo :: Var -> LowerM (Maybe GrinCodeInfo)
 lookupCodeInfo var = do
   locals <- gets lowerLocalVars
-  codeInfos <- gets lowerCodeInfos
-  localCodeNames <- gets lowerLocalCodeNames
+  localCodeInfosByUnique <- gets lowerLocalCodeInfosByUnique
+  codeInfosByName <- gets lowerCodeInfosByName
+  localCodeLinkNames <- gets lowerLocalCodeLinkNames
+  incremental <- gets lowerUseIncrementalCodeLookup
+  let localInfo =
+        case varResolvedName var of
+          Nothing -> Map.lookup (varUnique var) localCodeInfosByUnique >>= lookup (varType var)
+          Just _ -> Nothing
+      sourceName
+        | incremental = fromMaybe (varName var) (varResolvedName var)
+        | otherwise = varName var
+      sourceInfo = Map.lookup sourceName codeInfosByName
+      selected = if incremental then localInfo <|> sourceInfo else sourceInfo
   if varKey var `Map.member` locals
     then pure Nothing
-    else case Map.lookup (varName var) codeInfos of
+    else case selected of
       Nothing -> pure Nothing
       Just info -> do
-        if varName var `Set.member` localCodeNames
+        if grinCodeSourceName info `Set.member` localCodeLinkNames
           then pure ()
           else modify' $ \state ->
             state
-              { lowerReferencedExternalCodeNames =
-                  Set.insert (varName var) (lowerReferencedExternalCodeNames state)
+              { lowerReferencedExternalCodeLinkNames =
+                  Set.insert (grinCodeSourceName info) (lowerReferencedExternalCodeLinkNames state)
               }
         pure (Just info)
 
@@ -1277,7 +1430,11 @@ isWhnfGlobalVar :: Var -> LowerM Bool
 isWhnfGlobalVar var = do
   localVars <- gets lowerLocalVars
   whnfGlobalNames <- gets lowerWhnfGlobalNames
-  pure (varKey var `Map.notMember` localVars && varName var `Set.member` whnfGlobalNames)
+  incremental <- gets lowerUseIncrementalCodeLookup
+  let sourceName
+        | incremental = fromMaybe (varName var) (varResolvedName var)
+        | otherwise = varName var
+  pure (varKey var `Map.notMember` localVars && sourceName `Map.member` whnfGlobalNames)
 
 withFreshLocalVars :: [Var] -> ([[GrinVar]] -> LowerM a) -> LowerM a
 withFreshLocalVars vars action = do
@@ -1445,26 +1602,6 @@ functionArgumentRep function =
 programVars :: FcProgram -> [Var]
 programVars program = concatMap topVars (fcTopBinds program)
 
-programGlobalNames :: FcProgram -> [Text]
-programGlobalNames program = concatMap topGlobalNames (fcTopBinds program)
-  where
-    topGlobalNames topBind =
-      case topBind of
-        FcData _ _ constructors -> map fst constructors
-        FcAxiom {} -> []
-        FcNewtype {} -> []
-        FcPrimitive {} -> []
-        FcForeignImport {} -> []
-        FcTopBind bind ->
-          [ varName var
-          | (var, expr) <- topBindings bind,
-            not (isDirectFunction expr)
-          ]
-    topBindings bind =
-      case bind of
-        FcNonRec var expr -> [(var, expr)]
-        FcRec bindings -> bindings
-
 programConstructors :: FcProgram -> [(Text, Int)]
 programConstructors program =
   [ (name, length fields)
@@ -1472,47 +1609,40 @@ programConstructors program =
     (name, fields) <- constructors
   ]
 
-programWhnfGlobalNames :: FcProgram -> [Text]
-programWhnfGlobalNames program = concatMap topWhnfGlobalNames (fcTopBinds program)
+programGlobalInfos :: GrinLinkNames -> FcProgram -> [(Var, Text, Text, Bool)]
+programGlobalInfos linkNames program = concat (snd (mapAccumL buildInfo Map.empty bindings))
   where
     constructorArities =
       Map.fromList [(name, length layouts) | (name, layouts) <- builtinConstructors]
         <> Map.fromList (programConstructors program)
-    topWhnfGlobalNames topBind =
-      case topBind of
-        FcData _ _ constructors -> map fst constructors
-        FcAxiom {} -> []
-        FcNewtype {} -> []
-        FcPrimitive {} -> []
-        FcForeignImport {} -> []
-        FcTopBind bind ->
-          [ varName var
-          | (var, expr) <- topBindings bind,
-            isStaticWhnf constructorArities expr
-          ]
+    bindings = [(var, expr) | FcTopBind bind <- fcTopBinds program, (var, expr) <- topBindings bind]
+    buildInfo occurrences (var, expr) =
+      let (occurrences', index, linkedName) = linkNameAt linkNames occurrences var
+          sourceName = sourceNameAt linkNames index var
+       in (occurrences', [(var, sourceName, linkedName, isStaticWhnf constructorArities expr) | not (isDirectFunction expr)])
     topBindings bind =
       case bind of
         FcNonRec var expr -> [(var, expr)]
-        FcRec bindings -> bindings
+        FcRec recursiveBindings -> recursiveBindings
 
-programCodeInfos :: FcProgram -> [(Text, GrinCodeInfo)]
-programCodeInfos program =
-  [ (varName var, codeInfoFor var expr)
-  | FcTopBind bind <- fcTopBinds program,
-    (var, expr) <- topBindings bind,
-    isDirectFunction expr
-  ]
+programCodeInfos :: GrinLinkNames -> FcProgram -> [(Var, Text, GrinCodeInfo)]
+programCodeInfos linkNames program = concat (snd (mapAccumL buildInfo Map.empty bindings))
   where
+    bindings = [(var, expr) | FcTopBind bind <- fcTopBinds program, (var, expr) <- topBindings bind]
+    buildInfo occurrences (var, expr) =
+      let (occurrences', index, linkedName) = linkNameAt linkNames occurrences var
+          sourceName = sourceNameAt linkNames index var
+       in (occurrences', [(var, sourceName, codeInfoFor linkedName var expr) | isDirectFunction expr])
     topBindings bind =
       case bind of
         FcNonRec var expr -> [(var, expr)]
-        FcRec bindings -> bindings
+        FcRec recursiveBindings -> recursiveBindings
 
-codeInfoFor :: Var -> FcExpr -> GrinCodeInfo
-codeInfoFor var expr =
+codeInfoFor :: Text -> Var -> FcExpr -> GrinCodeInfo
+codeInfoFor linkedName _var expr =
   GrinCodeInfo
-    { grinCodeSourceName = varName var,
-      grinCodeFunctionName = topFunctionName var,
+    { grinCodeSourceName = linkedName,
+      grinCodeFunctionName = linkedFunctionName linkedName,
       grinCodeParameterLayouts =
         [ runtimeRepComponents (typeRuntimeRep (varType binder))
         | binder <- binders
@@ -1522,8 +1652,36 @@ codeInfoFor var expr =
   where
     (binders, body) = collectLeadingLambdas expr
 
-topFunctionName :: Var -> FunctionName
-topFunctionName var = FunctionName ("$entry$" <> varName var)
+linkedFunctionName :: Text -> FunctionName
+linkedFunctionName linkedName = FunctionName ("$entry$" <> linkedName)
+
+nextLinkName :: Var -> LowerM Text
+nextLinkName var = do
+  names <- gets lowerLinkNames
+  occurrences <- gets lowerLinkNameOccurrences
+  let (occurrences', _, linkedName) = linkNameAt names occurrences var
+  modify' (\state -> state {lowerLinkNameOccurrences = occurrences'})
+  pure linkedName
+
+linkNameAt :: GrinLinkNames -> Map Unique Int -> Var -> (Map Unique Int, Int, Text)
+linkNameAt names occurrences var =
+  (Map.insert unique (index + 1) occurrences, index, linkedName)
+  where
+    unique = varUnique var
+    index = Map.findWithDefault 0 unique occurrences
+    linkedName = fromMaybe (varName var) (Map.lookup unique (grinNativeLinkNames names) >>= atIndex index)
+
+sourceNameAt :: GrinLinkNames -> Int -> Var -> Text
+sourceNameAt names index var =
+  fromMaybe (varName var) (Map.lookup (varUnique var) (grinSourceLinkNames names) >>= atIndex index)
+
+atIndex :: Int -> [a] -> Maybe a
+atIndex position values = case drop position values of
+  value : _ -> Just value
+  [] -> Nothing
+
+grinLinkNamesEmpty :: GrinLinkNames -> Bool
+grinLinkNamesEmpty = Map.null . grinNativeLinkNames
 
 collectLeadingLambdas :: FcExpr -> ([Var], FcExpr)
 collectLeadingLambdas expr =

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -557,6 +557,53 @@ grinUnitTests =
             assertBool "direct dependency call" ("call @(BoxedRep Lifted) $entry$identity" `isInfixOf` rendered)
             assertBool "dependency function has no global slot" (not ("global identity" `isInfixOf` rendered))
           programs -> assertFailure ("expected two FC programs, got " <> show (length programs)),
+      testCase "separate FC units identify link-visible definitions" $ do
+        case (separateLinkableFunctionPrograms "Data.Provider" 80, separateLinkableFunctionPrograms "Data.Other" 90) of
+          ([providerCore, consumerCore], [otherProviderCore, otherConsumerCore]) -> do
+            let providerNames = linkNamesForProgram ["aihc", "base", "4", "21", "2", "0", "dephash"] ["Data", "Provider"] providerCore
+                otherProviderNames = linkNamesForProgram ["aihc", "base", "4", "21", "2", "0", "dephash"] ["Data", "Other"] otherProviderCore
+                consumerNames = linkNamesForProgram ["exe"] ["Main"] consumerCore
+                providerInterface = extractGrinInterfaceWithLinkNames providerNames providerCore
+                otherProviderInterface = extractGrinInterfaceWithLinkNames otherProviderNames otherProviderCore
+                combinedInterface = providerInterface <> otherProviderInterface
+                provider = lowerProgramWithLinkNames providerNames providerCore
+                otherProvider = lowerProgramWithLinkNames otherProviderNames otherProviderCore
+                consumer = lowerProgramWithInterfaceAndLinkNames consumerNames combinedInterface consumerCore
+                otherConsumer = lowerProgramWithInterfaceAndLinkNames consumerNames combinedInterface otherConsumerCore
+                linkedNames program = [name | function <- grinFunctions program, Just name <- [grinFunctionLinkName function]]
+            assertEqual "provider link name" [T.intercalate "\0" ["aihc", "base", "4", "21", "2", "0", "dephash", "Data", "Provider", "identity"]] (linkedNames provider)
+            assertEqual "other provider link name" [T.intercalate "\0" ["aihc", "base", "4", "21", "2", "0", "dephash", "Data", "Other", "identity"]] (linkedNames otherProvider)
+            assertEqual "external link name" [T.intercalate "\0" ["aihc", "base", "4", "21", "2", "0", "dephash", "Data", "Provider", "identity"]] (map grinCodeSourceName (grinExternalFunctions consumer))
+            assertEqual "other external link name" [T.intercalate "\0" ["aihc", "base", "4", "21", "2", "0", "dephash", "Data", "Other", "identity"]] (map grinCodeSourceName (grinExternalFunctions otherConsumer))
+          programs -> assertFailure ("expected two pairs of FC programs, got " <> show programs),
+      testCase "duplicate generated names receive readable unique suffixes" $ do
+        let firstVar = Var "xor" (Unique 100) (TcFunTy boxedIntTy boxedIntTy)
+            firstArgument = Var "value" (Unique 101) boxedIntTy
+            secondVar = Var "xor" (Unique 102) (TcFunTy boxedIntTy boxedIntTy)
+            secondArgument = Var "value" (Unique 103) boxedIntTy
+            core =
+              FcProgram
+                [ FcTopBind (FcNonRec firstVar (FcLam firstArgument (FcVar firstArgument))),
+                  FcTopBind (FcNonRec secondVar (FcLam secondArgument (FcVar secondArgument)))
+                ]
+            program = lowerProgramWithLinkNames (linkNamesForProgram ["package"] ["Module"] core) core
+            linkedNames = [name | function <- grinFunctions program, Just name <- [grinFunctionLinkName function]]
+        assertEqual
+          "link names"
+          [T.intercalate "\0" ["package", "Module", "xor", "u100n1"], T.intercalate "\0" ["package", "Module", "xor", "u102n2"]]
+          linkedNames,
+      testCase "separate FC units namespace global slots" $ do
+        case (separateLinkableGlobalPrograms "Data.Provider" 110, separateLinkableGlobalPrograms "Data.Other" 120) of
+          ([providerCore, consumerCore], [otherProviderCore, otherConsumerCore]) -> do
+            let libraryId = ["aihc", "base", "4", "21", "2", "0", "dephash"]
+                providerNames = linkNamesForProgram libraryId ["Data", "Provider"] providerCore
+                otherProviderNames = linkNamesForProgram libraryId ["Data", "Other"] otherProviderCore
+                combinedInterface = extractGrinInterfaceWithLinkNames providerNames providerCore <> extractGrinInterfaceWithLinkNames otherProviderNames otherProviderCore
+                consumer = lowerProgramWithInterfaceAndLinkNames (linkNamesForProgram ["exe"] ["Main"] consumerCore) combinedInterface consumerCore
+                otherConsumer = lowerProgramWithInterfaceAndLinkNames (linkNamesForProgram ["exe"] ["OtherMain"] otherConsumerCore) combinedInterface otherConsumerCore
+            assertEqual "provider external global" [T.intercalate "\0" (libraryId <> ["Data", "Provider", "value"])] (grinExternalGlobals consumer)
+            assertEqual "other external global" [T.intercalate "\0" (libraryId <> ["Data", "Other", "value"])] (grinExternalGlobals otherConsumer)
+          programs -> assertFailure ("expected two global pairs, got " <> show programs),
       testCase "separate FC units store saturated dependency constructors directly" $ do
         case separateConstructorPrograms of
           [providerCore, consumerCore] -> do
@@ -2134,6 +2181,28 @@ separateFunctionPrograms =
     identityVar = Var "identity" (Unique 81) (TcFunTy boxedIntTy boxedIntTy)
     argumentVar = Var "argument" (Unique 82) boxedIntTy
     answerVar = Var "answer" (Unique 83) boxedIntTy
+
+separateLinkableFunctionPrograms :: Text -> Int -> [FcProgram]
+separateLinkableFunctionPrograms qualifier uniqueBase =
+  [ FcProgram [FcTopBind (FcNonRec identityVar (FcLam argumentVar (FcVar argumentVar)))],
+    FcProgram [FcTopBind (FcNonRec answerVar (FcApp (FcVar importedIdentityVar) (FcLit (LitString "argument"))))]
+  ]
+  where
+    identityType = TcFunTy boxedIntTy boxedIntTy
+    identityVar = Var "identity" (Unique uniqueBase) identityType
+    importedIdentityVar = (Var "identity" (Unique uniqueBase) identityType) {varResolvedName = Just (qualifier <> ".identity")}
+    argumentVar = Var "argument" (Unique (uniqueBase + 1)) boxedIntTy
+    answerVar = Var "answer" (Unique (uniqueBase + 2)) boxedIntTy
+
+separateLinkableGlobalPrograms :: Text -> Int -> [FcProgram]
+separateLinkableGlobalPrograms qualifier uniqueBase =
+  [ FcProgram [FcTopBind (FcNonRec valueVar (FcLit (LitString "provider")))],
+    FcProgram [FcTopBind (FcNonRec answerVar (FcVar importedValueVar))]
+  ]
+  where
+    valueVar = Var "value" (Unique uniqueBase) boxedIntTy
+    importedValueVar = (Var "value" (Unique uniqueBase) boxedIntTy) {varResolvedName = Just (qualifier <> ".value")}
+    answerVar = Var "answer" (Unique (uniqueBase + 1)) boxedIntTy
 
 separateNewtypePrograms :: [FcProgram]
 separateNewtypePrograms =

--- a/components/aihc-llvm/src/Aihc/Llvm/Codegen.hs
+++ b/components/aihc-llvm/src/Aihc/Llvm/Codegen.hs
@@ -25,6 +25,7 @@ import Aihc.Native
     buildAddrLiteralPool,
     buildLinkLayout,
     nativeRuntimePrimitiveCall,
+    renderLinkedFunctionSymbol,
     supportedNativePrimitiveNames,
   )
 import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
@@ -39,7 +40,6 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Numeric (showHex)
 
 data LlvmError
   = LlvmMissingEntry !Text
@@ -1886,7 +1886,7 @@ localFunctionLabel :: Int -> GrinFunction -> Text
 localFunctionLabel index function = maybe ("aihc_llvm_function_" <> tshow index) linkedFunctionLabel (grinFunctionLinkName function)
 
 linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel name = "aihc_entry_" <> T.concatMap (\character -> T.pack (showHex (ord character) "_")) name
+linkedFunctionLabel = renderLinkedFunctionSymbol
 
 llvmLabel :: Text -> Text
 llvmLabel = T.map (\character -> if character `elem` ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> ['_'] then character else '_')

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -21,6 +21,7 @@ module Aihc.Native
     nativeCpsPrimitiveCall,
     nativeRuntimePrimitiveCall,
     parseNativeTarget,
+    renderLinkedFunctionSymbol,
     renderNativeTarget,
     runtimePlan,
     snapshotSourcePath,
@@ -31,9 +32,13 @@ where
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep)
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Char (chr)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as Text
+import Numeric (showHex)
 import Paths_aihc_native (getDataFileName)
 import System.FilePath (takeDirectory)
 import System.Info qualified as System
@@ -76,6 +81,28 @@ parseNativeTarget value =
     "wasm32-wasip3" -> Right Wasm32Wasip3
     "wasip3" -> Right Wasm32Wasip3
     _ -> Left "target must be apple-arm64, linux-amd64, llvm, or wasm32-wasip3"
+
+-- | Render a NUL-separated logical linker identity as a readable, reversible
+-- object symbol. ASCII letters and digits stay intact, components use a single
+-- underscore separator, and only literal underscores or unsafe UTF-8 bytes
+-- are escaped.
+renderLinkedFunctionSymbol :: Text -> Text
+renderLinkedFunctionSymbol logicalName =
+  case T.splitOn "\0" logicalName of
+    [unstructured] -> "aihc_entry_" <> renderComponent unstructured
+    components -> T.intercalate "_" (map renderComponent components)
+  where
+    renderComponent = T.concat . map renderByte . BS.unpack . Text.encodeUtf8
+    renderByte byte
+      | asciiAlphaNumeric byte = T.singleton (chr (fromIntegral byte))
+      | byte == 95 = "__u"
+      | otherwise = "__x" <> T.pack (padByte (showHex byte ""))
+    asciiAlphaNumeric byte =
+      (byte >= 48 && byte <= 57)
+        || (byte >= 65 && byte <= 90)
+        || (byte >= 97 && byte <= 122)
+    padByte [digit] = ['0', digit]
+    padByte digits = digits
 
 hostNativeTarget :: Maybe NativeTarget
 hostNativeTarget

--- a/components/aihc-native/test/Test/Native/Compiler.hs
+++ b/components/aihc-native/test/Test/Native/Compiler.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Test.Native.Compiler
   ( tests,
   )
 where
 
-import Aihc.Native (NativeTarget (Llvm), backendCompiler)
+import Aihc.Native (NativeTarget (Llvm), backendCompiler, renderLinkedFunctionSymbol)
+import Data.Text qualified as T
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 
@@ -15,5 +18,17 @@ tests =
         (compiler, arguments) <- backendCompiler Llvm
         assertEqual "LLVM compiler" "clang" compiler
         assertBool "LLVM optimization flag" ("-O2" `elem` arguments)
-        assertEqual "module-warning flag count" 1 (length (filter (== "-Wno-override-module") arguments))
+        assertEqual "module-warning flag count" 1 (length (filter (== "-Wno-override-module") arguments)),
+      testCase "renders common linker identities readably" $ do
+        assertEqual
+          "library symbol"
+          "aihc_base_4_21_2_0_dephash_Data_Foldable_toList"
+          (renderLinkedFunctionSymbol (T.intercalate "\0" ["aihc", "base", "4", "21", "2", "0", "dephash", "Data", "Foldable", "toList"]))
+        assertEqual "executable symbol" "exe_Main_main" (renderLinkedFunctionSymbol (T.intercalate "\0" ["exe", "Main", "main"])),
+      testCase "escapes unsafe symbol bytes without collisions" $ do
+        assertEqual "underscore escape" "aihc_entry_foo__ubar" (renderLinkedFunctionSymbol "foo_bar")
+        assertEqual "punctuation escape" "aihc_entry_foo__x2ebar" (renderLinkedFunctionSymbol "foo.bar")
+        assertBool
+          "component boundaries cannot imitate escapes"
+          (renderLinkedFunctionSymbol (T.intercalate "\0" ["foo", "x2e", "bar"]) /= renderLinkedFunctionSymbol "foo.bar")
     ]

--- a/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
+++ b/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
@@ -17,7 +17,7 @@ where
 import Aihc.Grin.Cps (ContinuationFrameKind (..), continuationFrameKindCode)
 import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcGrinProgram, gcUpdateFunction)
 import Aihc.Grin.Syntax
-import Aihc.Native (LinkLayout (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, supportedNativePrimitiveNames)
+import Aihc.Native (LinkLayout (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, renderLinkedFunctionSymbol, supportedNativePrimitiveNames)
 import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
 import Control.Monad (forM)
 import Data.ByteString qualified as BS
@@ -28,8 +28,6 @@ import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Encoding qualified as Text
-import Numeric (showHex)
 
 data WasmError
   = WasmMissingEntry !Text
@@ -1257,9 +1255,7 @@ localFunctionLabel :: Int -> GrinFunction -> Text
 localFunctionLabel index function = maybe (".Laihc_wasm_function_" <> tshow index) linkedFunctionLabel (grinFunctionLinkName function)
 
 linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel name = "aihc_link_" <> T.concat [T.pack (pad2 (showHex byte "")) | byte <- BS.unpack (Text.encodeUtf8 name)]
-  where
-    pad2 value = replicate (2 - length value) '0' <> value
+linkedFunctionLabel = renderLinkedFunctionSymbol
 
 boolInteger :: Bool -> Text
 boolInteger True = "1"

--- a/components/aihc-wasm/test/Test/Wasm/Suite.hs
+++ b/components/aihc-wasm/test/Test/Wasm/Suite.hs
@@ -62,7 +62,7 @@ testWasmLocals =
       case compileModule (buildLinkLayout [directCallProgram]) "_aihc_init_wasm_locals" (lowerGc cps) of
         Left err -> assertFailure (show err)
         Right source -> do
-          let (_, fromFastEntry) = T.breakOn "aihc_link_63616c6c6572:" source
+          let (_, fromFastEntry) = T.breakOn "aihc_entry_caller:" source
               fastEntry = fst (T.breakOn "\tend_function" fromFastEntry)
           assertBool "reads the incoming parameter directly" ("local.get\t1" `T.isInfixOf` fastEntry)
           assertBool "does not copy fast-entry parameters from memory" (not ("i64.load" `T.isInfixOf` fastEntry))
@@ -102,8 +102,8 @@ testDirectCallArguments =
       case compileModule (buildLinkLayout [directCallProgram]) "_aihc_init_direct_call" (lowerGc cps) of
         Left err -> assertFailure (show err)
         Right source -> do
-          assertBool "declares the exact external fast-entry signature" ("\t.functype\taihc_link_6964656e74697479 (i32, i64, i64) -> ()" `T.isInfixOf` source)
-          assertBool "tail-calls the known entry" ("return_call\taihc_link_6964656e74697479" `T.isInfixOf` source)
+          assertBool "declares the exact external fast-entry signature" ("\t.functype\taihc_entry_identity (i32, i64, i64) -> ()" `T.isInfixOf` source)
+          assertBool "tail-calls the known entry" ("return_call\taihc_entry_identity" `T.isInfixOf` source)
           assertBool "does not route known calls through C" (not ("call\taihc_wasm_transfer_direct" `T.isInfixOf` source))
 
 testObjectEntryAdapters :: IO ()


### PR DESCRIPTION
## Summary

- derive each library symbol from the existing package variant ID, defining module, and source symbol
- derive executable symbols from `exe`, the defining module, and the source symbol
- preserve canonical resolved names through FC so imported definitions cannot capture same-named local definitions
- assign identities per module before SCC concatenation and namespace runtime global slots as well as code entries
- render logical identities readably across LLVM, AMD64, ARM64, and Wasm, with reversible escaping only where required

## Root cause

Incremental compilation previously assigned one namespace after combining an SCC. That discarded the defining-module boundary, so same-named definitions such as `Data.Foldable.toList` and `Data.List.NonEmpty.toList` could receive the same native identity. FC also discarded the canonical module qualifier before incremental interface lookup, allowing an imported definition to be mistaken for a same-named local binder.

## Impact

Library symbols now look like `aihc_base_4_21_2_0_<dependency-hash>_Data_Foldable_toList`, while executable symbols look like `exe_Main_main`. ASCII letters and digits remain readable; underscores and unsafe bytes use a reversible escape.

## Core-library progress

- no progress-count change

## Validation

- installed-package regression with a qualified imported function and a same-named local function
- GRIN regressions for same-named definitions from separate modules, duplicate generated names, and runtime global slots
- native symbol-rendering tests across LLVM, AMD64, ARM64, and Wasm
- `just fmt`
- `just check`
