### PR TITLE
chore: ignore example build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ result-*
 # Qwen Code
 .qwen/
 .aihc-cache/
+
+# Example build artifacts
+examples/*/*.s
+examples/*/*.core
+examples/*/*.grin
+examples/*/*.ll
+examples/*/Main


### PR DESCRIPTION
## Summary

- ignore generated assembly, Core, GRIN, and LLVM files beneath each example directory
- ignore generated `Main` executables beneath each example directory

## Why

Building examples leaves generated compiler outputs and executables in the worktree. Ignoring them keeps `git status` focused on source changes.

## Impact

No compiler or runtime behavior changes. Progress counts are unchanged.

## Validation

- `just fmt`
- `just check`
- `git check-ignore` against representative `Main`, `.s`, `.core`, `.grin`, and `.ll` paths
