### PR TITLE
feat(base): implement Data.Version

### DIFF
--- a/core-libs/aihc-base/src/Data/Version.hs
+++ b/core-libs/aihc-base/src/Data/Version.hs
@@ -1,1 +1,210 @@
-module Data.Version () where
+{-# HLINT ignore "Use foldl" #-}
+{-# HLINT ignore "Use foldr" #-}
+
+module Data.Version
+  ( Version (Version),
+    versionBranch,
+    versionTags,
+    showVersion,
+    parseVersion,
+    makeVersion,
+  )
+where
+
+import Data.Char (isAlphaNum, isDigit, ord)
+import GHC.Read ()
+import Text.ParserCombinators.ReadP
+  ( ReadP,
+    readS_to_P,
+  )
+import Prelude
+
+data Version = Version [Int] [String]
+
+versionBranch :: Version -> [Int]
+versionBranch (Version branch _) = branch
+
+versionTags :: Version -> [String]
+versionTags (Version _ tags) = tags
+
+instance Eq Version where
+  left == right =
+    versionBranch left
+      == versionBranch right
+      && equalTagBags (versionTags left) (versionTags right)
+
+  left /= right = not (left == right)
+
+instance Ord Version where
+  compare left right = compare (versionBranch left) (versionBranch right)
+  left < right = versionBranch left < versionBranch right
+  left <= right = versionBranch left <= versionBranch right
+  left > right = versionBranch left > versionBranch right
+  left >= right = versionBranch left >= versionBranch right
+  max left right =
+    case compare left right of
+      GT -> left
+      _ -> right
+  min left right =
+    case compare left right of
+      GT -> right
+      _ -> left
+
+instance Show Version where
+  showsPrec precedence (Version branch tags) =
+    showParen
+      (precedence > 10)
+      ( showString "Version {versionBranch = "
+          . shows branch
+          . showString ", versionTags = "
+          . shows tags
+          . showChar '}'
+      )
+
+instance Read Version where
+  readsPrec precedence = readParen (precedence > 10) readVersionRecord
+  readList = readVersionList
+
+readVersionRecord :: ReadS Version
+readVersionRecord input =
+  bindVersionRead (matchLexeme "Version" input) afterVersion
+  where
+    afterVersion _ rest = bindVersionRead (matchLexeme "{" rest) afterOpen
+    afterOpen _ rest = bindVersionRead (matchLexeme "versionBranch" rest) afterBranchName
+    afterBranchName _ rest = bindVersionRead (matchLexeme "=" rest) afterBranchEquals
+    afterBranchEquals _ rest = bindVersionRead (reads rest) afterBranch
+    afterBranch branch rest = bindVersionRead (matchLexeme "," rest) (afterComma branch)
+    afterComma branch _ rest = bindVersionRead (matchLexeme "versionTags" rest) (afterTagsName branch)
+    afterTagsName branch _ rest = bindVersionRead (matchLexeme "=" rest) (afterTagsEquals branch)
+    afterTagsEquals branch _ rest = bindVersionRead (reads rest) (afterTags branch)
+    afterTags branch tags rest = bindVersionRead (matchLexeme "}" rest) (afterClose branch tags)
+    afterClose branch tags _ rest = [(Version branch tags, rest)]
+
+readVersionList :: ReadS [Version]
+readVersionList input =
+  bindVersionRead (matchLexeme "[" input) afterOpen
+  where
+    afterOpen _ rest =
+      case matchLexeme "]" rest of
+        (_, remaining) : _ -> [([], remaining)]
+        [] -> bindVersionRead (reads rest) afterValue
+    afterValue value rest = bindVersionRead (readVersionListTail rest) (afterTail value)
+    afterTail value values rest = [(value : values, rest)]
+
+readVersionListTail :: ReadS [Version]
+readVersionListTail input =
+  case matchLexeme "]" input of
+    (_, rest) : _ -> [([], rest)]
+    [] -> bindVersionRead (matchLexeme "," input) afterComma
+  where
+    afterComma _ rest = bindVersionRead (reads rest) afterValue
+    afterValue value rest = bindVersionRead (readVersionListTail rest) (afterTail value)
+    afterTail value values rest = [(value : values, rest)]
+
+matchLexeme :: String -> ReadS String
+matchLexeme expected input =
+  case lex input of
+    (actual, rest) : _ ->
+      case equalStrings actual expected of
+        True -> [(actual, rest)]
+        False -> []
+    [] -> []
+
+bindVersionRead :: [(a, String)] -> (a -> String -> [(b, String)]) -> [(b, String)]
+bindVersionRead [] _ = []
+bindVersionRead ((value, rest) : results) next =
+  next value rest ++ bindVersionRead results next
+
+showVersion :: Version -> String
+showVersion (Version branch tags) =
+  showBranch branch ++ showTags tags
+
+showBranch :: [Int] -> String
+showBranch [] = []
+showBranch (component : components) = show component ++ showBranchTail components
+
+showBranchTail :: [Int] -> String
+showBranchTail [] = []
+showBranchTail (component : components) = '.' : show component ++ showBranchTail components
+
+showTags :: [String] -> String
+showTags [] = []
+showTags (tag : tags) = '-' : tag ++ showTags tags
+
+parseVersion :: ReadP Version
+parseVersion = readS_to_P parseVersionString
+
+parseVersionString :: ReadS Version
+parseVersionString input =
+  case spanVersion isDigit input of
+    ([], _) -> []
+    (digits, rest) -> parseBranch [versionDigitsToInt 0 digits] rest
+
+parseBranch :: [Int] -> ReadS Version
+parseBranch branch input =
+  (Version branch [], input)
+    : case input of
+      '.' : rest ->
+        case spanVersion isDigit rest of
+          ([], _) -> []
+          (digits, remaining) ->
+            parseBranch (appendVersionList branch [versionDigitsToInt 0 digits]) remaining
+      _ -> parseTags branch [] input
+
+parseTags :: [Int] -> [String] -> ReadS Version
+parseTags branch tags input =
+  case input of
+    '-' : rest ->
+      case spanVersion isAlphaNum rest of
+        ([], _) -> []
+        (tag, remaining) ->
+          let nextTags = appendVersionList tags [tag]
+           in (Version branch nextTags, remaining) : parseTags branch nextTags remaining
+    _ -> []
+
+spanVersion :: (Char -> Bool) -> String -> (String, String)
+spanVersion _ [] = ([], [])
+spanVersion predicate input@(value : values) =
+  case predicate value of
+    False -> ([], input)
+    True ->
+      case spanVersion predicate values of
+        (matched, rest) -> (value : matched, rest)
+
+versionDigitsToInt :: Int -> String -> Int
+versionDigitsToInt value [] = value
+versionDigitsToInt value (digit : digits) =
+  versionDigitsToInt (value * 10 + ord digit - ord '0') digits
+
+appendVersionList :: [a] -> [a] -> [a]
+appendVersionList [] suffix = suffix
+appendVersionList (value : values) suffix = value : appendVersionList values suffix
+
+makeVersion :: [Int] -> Version
+makeVersion branch = Version branch []
+
+equalTagBags :: [String] -> [String] -> Bool
+equalTagBags [] [] = True
+equalTagBags [] (_ : _) = False
+equalTagBags (_ : _) [] = False
+equalTagBags (tag : tags) candidates =
+  case removeTag tag candidates of
+    Nothing -> False
+    Just remaining -> equalTagBags tags remaining
+
+removeTag :: String -> [String] -> Maybe [String]
+removeTag _ [] = Nothing
+removeTag tag (candidate : candidates) =
+  case equalStrings tag candidate of
+    True -> Just candidates
+    False ->
+      case removeTag tag candidates of
+        Nothing -> Nothing
+        Just remaining -> Just (candidate : remaining)
+
+equalStrings :: String -> String -> Bool
+equalStrings [] [] = True
+equalStrings [] (_ : _) = False
+equalStrings (_ : _) [] = False
+equalStrings (left : lefts) (right : rights) =
+  left == right && equalStrings lefts rights

--- a/core-libs/aihc-base/src/Text/ParserCombinators/ReadP.hs
+++ b/core-libs/aihc-base/src/Text/ParserCombinators/ReadP.hs
@@ -1,1 +1,66 @@
-module Text.ParserCombinators.ReadP () where
+{-# HLINT ignore "Use camelCase" #-}
+
+module Text.ParserCombinators.ReadP
+  ( ReadP,
+    ReadS,
+    readP_to_S,
+    readS_to_P,
+  )
+where
+
+import Prelude
+  ( Applicative (..),
+    Functor (..),
+    Monad (..),
+    ReadS,
+    String,
+    (++),
+    (.),
+  )
+
+newtype ReadP a = ReadP (ReadS a)
+
+instance Functor ReadP where
+  fmap function (ReadP parser) =
+    ReadP (readPMapResults function . parser)
+
+instance Applicative ReadP where
+  pure value = ReadP (\input -> [(value, input)])
+
+  ReadP functionParser <*> ReadP valueParser =
+    ReadP (readPApplyResults valueParser . functionParser)
+
+instance Monad ReadP where
+  ReadP parser >>= next =
+    ReadP (readPBindResults next . parser)
+
+  ReadP first >> ReadP second =
+    ReadP (readPThenResults second . first)
+
+  return = pure
+
+readPMapResults :: (a -> b) -> [(a, String)] -> [(b, String)]
+readPMapResults _ [] = []
+readPMapResults function ((value, rest) : results) =
+  (function value, rest) : readPMapResults function results
+
+readPApplyResults :: ReadS a -> [(a -> b, String)] -> [(b, String)]
+readPApplyResults _ [] = []
+readPApplyResults parser ((function, rest) : results) =
+  readPMapResults function (parser rest) ++ readPApplyResults parser results
+
+readPBindResults :: (a -> ReadP b) -> [(a, String)] -> [(b, String)]
+readPBindResults _ [] = []
+readPBindResults next ((value, rest) : results) =
+  readP_to_S (next value) rest ++ readPBindResults next results
+
+readPThenResults :: ReadS b -> [(a, String)] -> [(b, String)]
+readPThenResults _ [] = []
+readPThenResults parser ((_, rest) : results) =
+  parser rest ++ readPThenResults parser results
+
+readP_to_S :: ReadP a -> ReadS a
+readP_to_S (ReadP parser) = parser
+
+readS_to_P :: ReadS a -> ReadP a
+readS_to_P = ReadP

--- a/test/Test/Fixtures/eval/base/data-version.yaml
+++ b/test/Test/Fixtures/eval/base/data-version.yaml
@@ -1,0 +1,96 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Version
+    import Text.ParserCombinators.ReadP (readP_to_S)
+
+    class NFData a where
+      rnf :: a -> ()
+
+    instance NFData Int where
+      rnf value = value `seq` ()
+
+    instance NFData Char where
+      rnf value = value `seq` ()
+
+    instance NFData a => NFData [a] where
+      rnf [] = ()
+      rnf (value : values) = rnf value `seq` rnf values
+
+    instance NFData Version where
+      rnf (Version branch tags) = rnf branch `seq` rnf tags
+
+    deepseqStyleInstanceWorks :: Bool
+    deepseqStyleInstanceWorks =
+      case rnf (Version [1, 2, 3] ["alpha", "beta"]) of
+        () -> True
+
+    fullyParsed :: String -> [Version]
+    fullyParsed input = collectComplete (readP_to_S parseVersion input)
+
+    collectComplete :: [(Version, String)] -> [Version]
+    collectComplete [] = []
+    collectComplete ((version, rest) : results) =
+      case rest of
+        [] -> version : collectComplete results
+        _ : _ -> collectComplete results
+
+    parsesAs :: String -> Version -> Bool
+    parsesAs input expected = fullyParsed input == [expected]
+
+    partialParseMatchesGhc :: Bool
+    partialParseMatchesGhc =
+      case readP_to_S parseVersion "1.2-tag!" of
+        [ (first, firstRest),
+          (second, secondRest),
+          (third, thirdRest)
+          ] ->
+            first == Version [1] []
+              && firstRest == ".2-tag!"
+              && second == Version [1, 2] []
+              && secondRest == "-tag!"
+              && third == Version [1, 2] ["tag"]
+              && thirdRest == "!"
+        _ -> False
+
+    allTrue :: [Bool] -> Bool
+    allTrue [] = True
+    allTrue (True : values) = allTrue values
+    allTrue (False : _) = False
+
+    results :: Bool
+    results =
+      allTrue
+        [ makeVersion [] == Version [] [],
+          makeVersion [1, 2, 3] == Version [1, 2, 3] [],
+          showVersion (Version [] []) == "",
+          showVersion (Version [1, 2, 3] []) == "1.2.3",
+          showVersion (Version [1, 2, 3] ["alpha1", "beta"]) == "1.2.3-alpha1-beta",
+          versionBranch (Version [1, 2, 3] ["alpha"]) == [1, 2, 3],
+          versionTags (Version [1, 2, 3] ["alpha"]) == ["alpha"],
+          parsesAs "1" (Version [1] []),
+          parsesAs "01.002" (Version [1, 2] []),
+          parsesAs "1.2.3-alpha1-beta" (Version [1, 2, 3] ["alpha1", "beta"]),
+          fullyParsed "" == [],
+          fullyParsed "1-" == [],
+          fullyParsed "1-alpha_beta" == [],
+          partialParseMatchesGhc,
+          Version [1] ["beta", "alpha"] == Version [1] ["alpha", "beta"],
+          Version [1] ["alpha", "alpha"] /= Version [1] ["alpha"],
+          compare (Version [1, 2] ["z"]) (Version [1, 2] ["a"]) == EQ,
+          Version [1, 2, 1] [] > Version [1, 2] ["release"],
+          deepseqStyleInstanceWorks,
+          show (Version [] []) == "Version {versionBranch = [], versionTags = []}",
+          show (Version [1, 2, 3] ["alpha", "beta"])
+            == "Version {versionBranch = [1,2,3], versionTags = [\"alpha\",\"beta\"]}"
+        ]
+output: |
+  True
+expression: |
+  results
+status: pass
+reason: Data.Version matches base rendering, parsing, tag equality, branch ordering, and Read/Show behavior


### PR DESCRIPTION
## Summary

- implement the public `Data.Version` API with `Version`, branch/tag selectors, `makeVersion`, `showVersion`, and `parseVersion`
- provide base-compatible `Eq`, `Ord`, `Show`, and `Read` behavior, including order-insensitive tag bags and branch-only version ordering
- add the runnable `ReadP` representation and conversion helpers required by the public `parseVersion` signature
- add a shared FC/GRIN evaluation fixture covering empty and multi-component versions, legacy tags, partial parses, ordering, selector access, and a `deepseq`-shaped `NFData Version` instance

## Root cause

`Data.Version` and `Text.ParserCombinators.ReadP` were empty compatibility stubs. As a result, ecosystem packages could not resolve the `Version` type or constructor, and the standard parser helper had no usable public result type.

## Impact

Packages can now construct, inspect, render, parse, compare, read, and show versions through `aihc-base`. The positional `Version` constructor and exported selector functions also support the normal-form instance used by `deepseq`.

## Progress

- ghc-prim API coverage: **52 / 3425 (1.52%)** — unchanged
- base API coverage: **389 / 10055 (3.87%)** — **+6 matching interface items**
- base compatibility surface: **+2 selector exports**
- shared evaluation coverage: **+1 fixture**, exercised through both FC and GRIN

README progress counts are intentionally unchanged because they are maintained by the cron workflow.

## Validation

- compared subtle `parseVersion` partial-result behavior with GHC 9.12.4 / base 4.21.2.0
- focused FC evaluation: `base/data-version.yaml`
- focused GRIN evaluation: `base/data-version.yaml`
- `just fmt`
- `just check`

Closes #1417
