### PR TITLE
feat(resolve): support package-qualified imports

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -63,7 +63,7 @@ import Aihc.Native
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension (ImplicitPrelude), LanguageEdition (Haskell98Edition), Module, effectiveExtensions, headerExtensionSettings, headerLanguageEdition, moduleName)
 import Aihc.Parser.Token (readModuleHeaderPragmas)
-import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
+import Aihc.Resolve (ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (Unique (..), tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket)
@@ -233,18 +233,19 @@ compileSourceToArtifactsWithDependencies target wholeProgram environment sourceN
 
 compileWithDependencies :: NativeTarget -> Bool -> DependencyArtifact -> Module -> Either CompileError CompileArtifacts
 compileWithDependencies target wholeProgram dependencies parsed =
-  case resolveWithDeps (dependencyExports dependencies) [parsed] of
+  case resolveWithDeps (dependencyExports dependencies) [(unnamedPackage, parsed)] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
     ResolveResult {resolvedModules} ->
-      let (checkedModules, _) =
+      let moduleAsts = map snd resolvedModules
+          (checkedModules, _) =
             typecheckModulesWithInterface
               (dependencyTcInterface dependencies)
-              resolvedModules
+              moduleAsts
        in if not (all tcModuleSuccess checkedModules)
             then Left (CompileFrontendError ["typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules)])
             else
               let bindings = dependencyBindings dependencies <> concatMap tcModuleBindings checkedModules
-                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
+                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules moduleAsts
                in if not (all dsSuccess desugared)
                     then Left (CompileFrontendError (concatMap dsErrors desugared))
                     else

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -48,6 +48,7 @@ import Aihc.Parser.Syntax
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve
   ( ModuleExports,
+    ModuleKey (..),
     OperatorFixity,
     ResolveResult (..),
     ResolvedName (..),
@@ -211,7 +212,7 @@ buildDependencies target environment usesImplicitPrelude buildBackend mainModule
       case installed of
         Left err -> pure (Left err)
         Right (artifactRoot, artifact) ->
-          case filter (`Map.notMember` dependencyExports artifact) requiredModules of
+          case filter (\name -> Map.notMember (ModuleKey Nothing name) (dependencyExports artifact)) requiredModules of
             missing@(_ : _) -> pure (Left ("library modules are not installed: " <> T.unpack (T.intercalate ", " missing)))
             []
               | buildBackend -> attachInstalledBackend target artifactRoot artifact
@@ -451,7 +452,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
 
     finish state =
       DependencyArtifact
-        { dependencyExports = Map.restrictKeys (compileStateExports state) exposedModules,
+        { dependencyExports = Map.restrictKeys (compileStateExports state) (Set.map (ModuleKey Nothing) exposedModules),
           dependencyTcInterface = compileStateTcInterface state,
           dependencyBindings = compileStateBindings state,
           dependencyAxiomInterface = compileStateAxioms state,
@@ -753,10 +754,12 @@ fromStoredArtifact stored =
     }
 
 toStoredExports :: ModuleExports -> StoredModuleExports
-toStoredExports = StoredModuleExports . map (fmap toStoredScope) . Map.toAscList
+toStoredExports = StoredModuleExports . map toStoredExport . Map.toAscList
+  where
+    toStoredExport (key, scope) = (moduleKeyName key, toStoredScope scope)
 
 fromStoredExports :: StoredModuleExports -> ModuleExports
-fromStoredExports (StoredModuleExports exports) = Map.fromList (map (fmap fromStoredScope) exports)
+fromStoredExports (StoredModuleExports exports) = Map.fromList [(ModuleKey Nothing name, fromStoredScope scope) | (name, scope) <- exports]
 
 toStoredScope :: Scope -> StoredScope
 toStoredScope scope =
@@ -786,6 +789,7 @@ toStoredResolvedName :: ResolvedName -> StoredResolvedName
 toStoredResolvedName resolved =
   case resolved of
     ResolvedTopLevel Name {nameQualifier, nameType, nameText} -> StoredTopLevel nameQualifier nameType nameText
+    ResolvedPackageTopLevel _ Name {nameQualifier, nameType, nameText} -> StoredTopLevel nameQualifier nameType nameText
     ResolvedLocal unique UnqualifiedName {unqualifiedNameType, unqualifiedNameText} -> StoredLocal unique unqualifiedNameType unqualifiedNameText
     ResolvedBuiltin name -> StoredBuiltin name
     ResolvedError err -> StoredError err

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -50,11 +50,14 @@ import Aihc.Resolve
   ( ModuleExports,
     ModuleKey (..),
     OperatorFixity,
+    PackageId (..),
     ResolveResult (..),
     ResolvedName (..),
     Scope (..),
     extractInterfaceWithDeps,
+    modulesInPackage,
     resolveWithDeps,
+    unnamedPackage,
   )
 import Aihc.Tc
   ( TcBindingResult (..),
@@ -174,7 +177,7 @@ data StoredScope = StoredScope
   deriving (Show, Read)
 
 data StoredResolvedName
-  = StoredTopLevel !(Maybe Text) !NameType !Text
+  = StoredTopLevel !Text !(Maybe Text) !NameType !Text
   | StoredLocal !Int !NameType !Text
   | StoredBuiltin !Text
   | StoredError !String
@@ -198,7 +201,7 @@ data LibraryPackage = LibraryPackage
   deriving (Eq, Show)
 
 cacheSchemaVersion :: Int
-cacheSchemaVersion = 32
+cacheSchemaVersion = 33
 
 buildDependencies :: NativeTarget -> CompileEnvironment -> Bool -> Bool -> Module -> IO (Either String DependencyArtifact)
 buildDependencies target environment usesImplicitPrelude buildBackend mainModule = do
@@ -212,7 +215,7 @@ buildDependencies target environment usesImplicitPrelude buildBackend mainModule
       case installed of
         Left err -> pure (Left err)
         Right (artifactRoot, artifact) ->
-          case filter (\name -> Map.notMember (ModuleKey Nothing name) (dependencyExports artifact)) requiredModules of
+          case filter (\name -> Map.notMember (ModuleKey unnamedPackage name) (dependencyExports artifact)) requiredModules of
             missing@(_ : _) -> pure (Left ("library modules are not installed: " <> T.unpack (T.intercalate ", " missing)))
             []
               | buildBackend -> attachInstalledBackend target artifactRoot artifact
@@ -386,17 +389,18 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
     initialState = CompileState Map.empty mempty [] mempty mempty mempty mempty [] []
 
     compileScc state members =
-      case resolveWithDeps (compileStateExports state) (map loadedModule members) of
+      case resolveWithDeps (compileStateExports state) (modulesInPackage unnamedPackage (map loadedModule members)) of
         ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("library resolve error: " <> show errors)
         resolved@ResolveResult {resolvedModules} ->
-          let (checkedModules, tcInterface) =
-                typecheckModuleSccWithInterface (compileStateTcInterface state) resolvedModules
+          let moduleAsts = map snd resolvedModules
+              (checkedModules, tcInterface) =
+                typecheckModuleSccWithInterface (compileStateTcInterface state) moduleAsts
            in if not (all tcModuleSuccess checkedModules)
                 then Left ("library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
                 else
                   let localBindings = concatMap tcModuleBindings checkedModules
                       bindings = compileStateBindings state <> localBindings
-                      desugared = zipWith (desugarModuleWithBindings bindings) checkedModules resolvedModules
+                      desugared = zipWith (desugarModuleWithBindings bindings) checkedModules moduleAsts
                    in if not (all dsSuccess desugared)
                         then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else
@@ -452,7 +456,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
 
     finish state =
       DependencyArtifact
-        { dependencyExports = Map.restrictKeys (compileStateExports state) (Set.map (ModuleKey Nothing) exposedModules),
+        { dependencyExports = Map.restrictKeys (compileStateExports state) (Set.map (ModuleKey unnamedPackage) exposedModules),
           dependencyTcInterface = compileStateTcInterface state,
           dependencyBindings = compileStateBindings state,
           dependencyAxiomInterface = compileStateAxioms state,
@@ -759,7 +763,7 @@ toStoredExports = StoredModuleExports . map toStoredExport . Map.toAscList
     toStoredExport (key, scope) = (moduleKeyName key, toStoredScope scope)
 
 fromStoredExports :: StoredModuleExports -> ModuleExports
-fromStoredExports (StoredModuleExports exports) = Map.fromList [(ModuleKey Nothing name, fromStoredScope scope) | (name, scope) <- exports]
+fromStoredExports (StoredModuleExports exports) = Map.fromList [(ModuleKey unnamedPackage name, fromStoredScope scope) | (name, scope) <- exports]
 
 toStoredScope :: Scope -> StoredScope
 toStoredScope scope =
@@ -788,8 +792,7 @@ fromStoredScope scope =
 toStoredResolvedName :: ResolvedName -> StoredResolvedName
 toStoredResolvedName resolved =
   case resolved of
-    ResolvedTopLevel Name {nameQualifier, nameType, nameText} -> StoredTopLevel nameQualifier nameType nameText
-    ResolvedPackageTopLevel _ Name {nameQualifier, nameType, nameText} -> StoredTopLevel nameQualifier nameType nameText
+    ResolvedTopLevel (PackageId identity) Name {nameQualifier, nameType, nameText} -> StoredTopLevel identity nameQualifier nameType nameText
     ResolvedLocal unique UnqualifiedName {unqualifiedNameType, unqualifiedNameText} -> StoredLocal unique unqualifiedNameType unqualifiedNameText
     ResolvedBuiltin name -> StoredBuiltin name
     ResolvedError err -> StoredError err
@@ -797,7 +800,7 @@ toStoredResolvedName resolved =
 fromStoredResolvedName :: StoredResolvedName -> ResolvedName
 fromStoredResolvedName stored =
   case stored of
-    StoredTopLevel qualifier nameType name -> ResolvedTopLevel (Name qualifier nameType name [])
+    StoredTopLevel identity qualifier nameType name -> ResolvedTopLevel (PackageId identity) (Name qualifier nameType name [])
     StoredLocal unique nameType name -> ResolvedLocal unique (UnqualifiedName nameType name [])
     StoredBuiltin name -> ResolvedBuiltin name
     StoredError err -> ResolvedError err

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -70,7 +70,9 @@ import Aihc.Resolve
     ResolveResult (..),
     Scope (..),
     extractInterface,
+    modulesInPackage,
     resolveWithDeps,
+    unnamedPackage,
   )
 import Aihc.Tc
   ( Pred (..),
@@ -1273,18 +1275,19 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       enrichDiagnostics = map (addDiagnosticSourceLines sourceLinesByFile)
       parseDiagnostics = enrichDiagnostics (concatMap parsedFileParseDiagnostics parsedFiles)
       cppDiagnostics = enrichDiagnostics (concatMap parsedFileCppDiagnostics parsedFiles)
-      resolveResult = resolveWithDeps depExports parsedModules
+      resolveResult = resolveWithDeps depExports (modulesInPackage unnamedPackage parsedModules)
       exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
-      ownExports = Map.restrictKeys (extractInterface resolveResult) (Set.map (ModuleKey Nothing) exposedModules)
+      ownExports = Map.restrictKeys (extractInterface resolveResult) (Set.map (ModuleKey unnamedPackage) exposedModules)
   (checkedModules, tcModules, tcDiagnostics, tcInterface) <-
-    typecheckInterfaceModules importedTcInterface (resolvedModules resolveResult)
+    typecheckInterfaceModules importedTcInterface (map snd (resolvedModules resolveResult))
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
       ownBindings = concatMap tcModuleBindings checkedModules
       allBindings = mergeBy tbName [importedBindings, ownBindings]
-      fcResults = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules (resolvedModules resolveResult)
-      fcModules = zipWith fcModuleValue (resolvedModules resolveResult) fcResults
+      resolvedModuleAsts = map snd (resolvedModules resolveResult)
+      fcResults = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
+      fcModules = zipWith fcModuleValue resolvedModuleAsts fcResults
       fcDiagnostics = concatMap fcModuleDiagnosticValues fcModules
   pure
     InterfaceBuildResult

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -65,6 +65,7 @@ import Aihc.Parser.Syntax qualified as Syntax
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve
   ( ModuleExports,
+    ModuleKey (..),
     ResolveError (..),
     ResolveResult (..),
     Scope (..),
@@ -1274,7 +1275,7 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       cppDiagnostics = enrichDiagnostics (concatMap parsedFileCppDiagnostics parsedFiles)
       resolveResult = resolveWithDeps depExports parsedModules
       exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
-      ownExports = Map.restrictKeys (extractInterface resolveResult) exposedModules
+      ownExports = Map.restrictKeys (extractInterface resolveResult) (Set.map (ModuleKey Nothing) exposedModules)
   (checkedModules, tcModules, tcDiagnostics, tcInterface) <-
     typecheckInterfaceModules importedTcInterface (resolvedModules resolveResult)
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
@@ -1576,14 +1577,14 @@ interfaceStatus result =
 moduleExportsValue :: ModuleExports -> [Aeson.Value]
 moduleExportsValue exports =
   [ object
-      [ "module" .= moduleNameText,
+      [ "module" .= moduleKeyName moduleKey,
         "terms" .= Map.keys (scopeTerms scope),
         "types" .= Map.keys (scopeTypes scope),
         "constructors" .= scopeConstructors scope,
         "recordFields" .= scopeRecordFields scope,
         "methods" .= scopeMethods scope
       ]
-  | (moduleNameText, scope) <- Map.toAscList exports
+  | (moduleKey, scope) <- Map.toAscList exports
   ]
 
 tcModuleValue :: Module -> Module -> Aeson.Value

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -35,7 +35,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameFromText,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
 import Aihc.Tc
   ( InstanceInfo,
     Pred (..),
@@ -254,7 +254,7 @@ handleBrowseCommand session rawModuleName
       pure (ReplContinue (Just "usage: :browse <module>"))
   | otherwise =
       pure . ReplContinue . Just $
-        case Map.lookup moduleName' (replModuleExports session) of
+        case Map.lookup (ModuleKey Nothing moduleName') (replModuleExports session) of
           Nothing -> "unknown module: " <> rawModuleName
           Just scope -> renderBrowseScope session moduleName' scope
   where
@@ -303,6 +303,11 @@ resolvedBindingKey browsingModule exportedName resolved =
         ( fromMaybe browsingModule (nameQualifier name),
           normalizeImportedBindingName (nameText name)
         )
+    ResolvedPackageTopLevel _ name ->
+      Just
+        ( fromMaybe browsingModule (nameQualifier name),
+          normalizeImportedBindingName (nameText name)
+        )
     ResolvedBuiltin _ -> Just (browsingModule, exportedName)
     _ -> Nothing
 
@@ -312,7 +317,7 @@ replCompletion session =
     pure
       [ Haskeline.simpleCompletion candidate
       | trim (reverse reversedBeforeWord) == ":browse",
-        candidate <- map T.unpack (Map.keys (replModuleExports session)),
+        candidate <- map (T.unpack . moduleKeyName) (Map.keys (replModuleExports session)),
         word `isPrefixOf` candidate
       ]
 
@@ -689,7 +694,7 @@ parseInterface =
     tcModules <- obj .:? "typecheck" .!= []
     pure
       Interface
-        { interfaceExports = Map.fromList [(interfaceModuleName modu, interfaceModuleScope modu) | modu <- modules],
+        { interfaceExports = Map.fromList [(ModuleKey Nothing (interfaceModuleName modu), interfaceModuleScope modu) | modu <- modules],
           interfaceImportedTerms = concatMap interfaceTcModuleTerms tcModules,
           interfaceBindingTypes =
             Map.fromList
@@ -807,9 +812,10 @@ isBaseManifest candidate =
 
 ensurePreludeMvpScope :: ModuleExports -> ModuleExports
 ensurePreludeMvpScope exports =
-  Map.insert "Prelude" preludeScope exports
+  Map.insert preludeKey preludeScope exports
   where
-    existing = Map.findWithDefault emptyScope "Prelude" exports
+    preludeKey = ModuleKey Nothing "Prelude"
+    existing = Map.findWithDefault emptyScope preludeKey exports
     preludeScope =
       existing
         { scopeTerms =

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -35,7 +35,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameFromText,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ModuleKey (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, modulesInPackage, resolveWithDeps, unnamedPackage)
 import Aihc.Tc
   ( InstanceInfo,
     Pred (..),
@@ -217,13 +217,13 @@ typecheckExpression session input = do
       ParseOk parsed -> Right parsed
       ParseErr _ -> Left ReplParseError
   let parsedModule = replModule expr
-      resolved = resolveWithDeps (replModuleExports session) [parsedModule]
+      resolved = resolveWithDeps (replModuleExports session) [(unnamedPackage, parsedModule)]
   case resolveErrors resolved of
     [] -> pure ()
     errors -> Left (ReplResolveError errors)
   resolvedModule <-
     case resolvedModules resolved of
-      [modu] -> Right modu
+      [(_, modu)] -> Right modu
       _ -> Left (ReplResolveError [ResolveNotImplemented "REPL resolver returned no module"])
   let tcResult = typecheckModuleWithEnvAndInstances (replImportedTerms session) (replImportedInstances session) resolvedModule
   if tcModuleSuccess tcResult
@@ -254,7 +254,7 @@ handleBrowseCommand session rawModuleName
       pure (ReplContinue (Just "usage: :browse <module>"))
   | otherwise =
       pure . ReplContinue . Just $
-        case Map.lookup (ModuleKey Nothing moduleName') (replModuleExports session) of
+        case Map.lookup (ModuleKey unnamedPackage moduleName') (replModuleExports session) of
           Nothing -> "unknown module: " <> rawModuleName
           Just scope -> renderBrowseScope session moduleName' scope
   where
@@ -298,12 +298,7 @@ renderBrowseName name =
 resolvedBindingKey :: Text -> Text -> ResolvedName -> Maybe (Text, Text)
 resolvedBindingKey browsingModule exportedName resolved =
   case resolved of
-    ResolvedTopLevel name ->
-      Just
-        ( fromMaybe browsingModule (nameQualifier name),
-          normalizeImportedBindingName (nameText name)
-        )
-    ResolvedPackageTopLevel _ name ->
+    ResolvedTopLevel _ name ->
       Just
         ( fromMaybe browsingModule (nameQualifier name),
           normalizeImportedBindingName (nameText name)
@@ -495,14 +490,15 @@ loadAihcBaseContext = do
 
 buildBaseContext :: [Module] -> IO ReplBaseContext
 buildBaseContext modules =
-  case resolveWithDeps Map.empty modules of
+  case resolveWithDeps Map.empty (modulesInPackage unnamedPackage modules) of
     resolved@ResolveResult {resolveErrors = [], resolvedModules} -> do
-      let tcResults = typecheckModulesWithEnv [] resolvedModules
+      let moduleAsts = map snd resolvedModules
+          tcResults = typecheckModulesWithEnv [] moduleAsts
       if all tcModuleSuccess tcResults
         then do
           let allBindings = concatMap tcModuleBindings tcResults
-              dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
-              bindingTypes = moduleBindingTypes resolvedModules tcResults
+              dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults moduleAsts
+              bindingTypes = moduleBindingTypes moduleAsts tcResults
           if all dsSuccess dsResults
             then
               pure
@@ -694,7 +690,7 @@ parseInterface =
     tcModules <- obj .:? "typecheck" .!= []
     pure
       Interface
-        { interfaceExports = Map.fromList [(ModuleKey Nothing (interfaceModuleName modu), interfaceModuleScope modu) | modu <- modules],
+        { interfaceExports = Map.fromList [(ModuleKey unnamedPackage (interfaceModuleName modu), interfaceModuleScope modu) | modu <- modules],
           interfaceImportedTerms = concatMap interfaceTcModuleTerms tcModules,
           interfaceBindingTypes =
             Map.fromList
@@ -764,7 +760,7 @@ interfaceModuleScope modu =
 
 resolvedTopLevel :: Text -> Text -> ResolvedName
 resolvedTopLevel moduleName name =
-  ResolvedTopLevel (qualifyName (Just moduleName) (unqualifiedNameFromText name))
+  ResolvedTopLevel (packageId unnamedPackage) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
 
 findInstalledBaseInterface :: FilePath -> IO FilePath
 findInstalledBaseInterface storeRoot = do
@@ -814,7 +810,7 @@ ensurePreludeMvpScope :: ModuleExports -> ModuleExports
 ensurePreludeMvpScope exports =
   Map.insert preludeKey preludeScope exports
   where
-    preludeKey = ModuleKey Nothing "Prelude"
+    preludeKey = ModuleKey unnamedPackage "Prelude"
     existing = Map.findWithDefault emptyScope preludeKey exports
     preludeScope =
       existing

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -46,7 +46,7 @@ import Aihc.Fc
 import Aihc.Grin qualified as Grin
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Native (NativeTarget (..))
-import Aihc.Resolve (Scope (..))
+import Aihc.Resolve (ModuleKey (..), Scope (..))
 import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
 import Control.Exception (bracket)
 import Data.Aeson (object, (.=))
@@ -422,7 +422,7 @@ test_loadsInstalledBaseInterfaceForRepl =
           )
       )
     session <- loadReplSession (Just storeRoot)
-    case Map.lookup "Prelude" (replModuleExports session) of
+    case Map.lookup (ModuleKey Nothing "Prelude") (replModuleExports session) of
       Nothing -> assertFailure "Prelude scope not loaded"
       Just preludeScope -> do
         assertBool "Prelude exposes Char" (Map.member "Char" (scopeTypes preludeScope))

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -46,7 +46,7 @@ import Aihc.Fc
 import Aihc.Grin qualified as Grin
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Native (NativeTarget (..))
-import Aihc.Resolve (ModuleKey (..), Scope (..))
+import Aihc.Resolve (ModuleKey (..), Scope (..), unnamedPackage)
 import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
 import Control.Exception (bracket)
 import Data.Aeson (object, (.=))
@@ -422,7 +422,7 @@ test_loadsInstalledBaseInterfaceForRepl =
           )
       )
     session <- loadReplSession (Just storeRoot)
-    case Map.lookup (ModuleKey Nothing "Prelude") (replModuleExports session) of
+    case Map.lookup (ModuleKey unnamedPackage "Prelude") (replModuleExports session) of
       Nothing -> assertFailure "Prelude scope not loaded"
       Just preludeScope -> do
         assertBool "Prelude exposes Char" (Map.member "Char" (scopeTypes preludeScope))

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -23,7 +23,7 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
-import Aihc.Resolve (ResolveResult (..), resolve)
+import Aihc.Resolve (ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, TcInterface (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
@@ -148,13 +148,14 @@ evaluateFcCase tc =
    in case sequence parsedModules of
         Left errMsg -> classifyFailure tc ("parse error: " <> errMsg)
         Right modules ->
-          case resolve modules of
+          case resolveWithDeps mempty (modulesInPackage unnamedPackage modules) of
             ResolveResult {resolvedModules, resolveErrors = []} ->
-              let (tcResults, tcInterface) = typecheckModulesWithInterface emptyTcInterface resolvedModules
+              let moduleAsts = map snd resolvedModules
+                  (tcResults, tcInterface) = typecheckModulesWithInterface emptyTcInterface moduleAsts
                in if all tcModuleSuccess tcResults
                     then
                       let allBindings = moduleGroupBindings tcResults
-                          results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults resolvedModules
+                          results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
                           fixtureResults = drop supportModuleCount results
                        in if all dsSuccess results
                             then classifySuccess tc (renderResults fixtureResults)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -53,7 +53,7 @@ import Aihc.Parser.Syntax
     peelDeclAnn,
     unqualifiedNameText,
   )
-import Aihc.Resolve (ResolveResult (..), resolve)
+import Aihc.Resolve (ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TcInterface (..), TyConFlavor (..), emptyTcInterface, renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
@@ -86,8 +86,8 @@ data DesugarResult = DesugarResult
 -- but deliberately unoptimized Core.
 desugarModule :: Module -> DesugarResult
 desugarModule m =
-  case resolve [m] of
-    ResolveResult {resolvedModules = [resolved], resolveErrors = []} ->
+  case resolveWithDeps mempty [(unnamedPackage, m)] of
+    ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} ->
       case typecheckModulesWithInterface emptyTcInterface [resolved] of
         ([tcResult], tcInterface) ->
           desugarModuleWithDataTypes (tcModuleBindings tcResult) (tcInterfaceDataTypes tcInterface) tcResult resolved

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -609,10 +609,7 @@ isGhcPrimSeq name =
     isSeqResolution resolution =
       resolutionNamespace resolution == ResolutionNamespaceTerm
         && case resolutionTarget resolution of
-          ResolvedTopLevel target ->
-            nameQualifier target == Just "GHC.Prim"
-              && nameText target == "seq"
-          ResolvedPackageTopLevel _ target ->
+          ResolvedTopLevel _ target ->
             nameQualifier target == Just "GHC.Prim"
               && nameText target == "seq"
           _ -> False
@@ -820,8 +817,7 @@ dsIntegerLiteral value = do
 resolvedAnnotationName :: ResolutionAnnotation -> Name
 resolvedAnnotationName resolution =
   case resolutionTarget resolution of
-    ResolvedTopLevel name -> mkName (nameQualifier name) (nameType name) (nameText name)
-    ResolvedPackageTopLevel _ name -> mkName (nameQualifier name) (nameType name) (nameText name)
+    ResolvedTopLevel _ name -> mkName (nameQualifier name) (nameType name) (nameText name)
     ResolvedLocal _ name -> qualifyName Nothing name
     ResolvedBuiltin name -> mkName Nothing NameVarId name
     ResolvedError {} -> mkName Nothing NameVarId (resolutionName resolution)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -612,6 +612,9 @@ isGhcPrimSeq name =
           ResolvedTopLevel target ->
             nameQualifier target == Just "GHC.Prim"
               && nameText target == "seq"
+          ResolvedPackageTopLevel _ target ->
+            nameQualifier target == Just "GHC.Prim"
+              && nameText target == "seq"
           _ -> False
 
 dsAnnotatedExpr :: TcAnnotation -> Expr -> DsM FcExpr
@@ -818,6 +821,7 @@ resolvedAnnotationName :: ResolutionAnnotation -> Name
 resolvedAnnotationName resolution =
   case resolutionTarget resolution of
     ResolvedTopLevel name -> mkName (nameQualifier name) (nameType name) (nameText name)
+    ResolvedPackageTopLevel _ name -> mkName (nameQualifier name) (nameType name) (nameText name)
     ResolvedLocal _ name -> qualifyName Nothing name
     ResolvedBuiltin name -> mkName Nothing NameVarId name
     ResolvedError {} -> mkName Nothing NameVarId (resolutionName resolution)

--- a/components/aihc-grin/test/GrinGolden.hs
+++ b/components/aihc-grin/test/GrinGolden.hs
@@ -14,7 +14,7 @@ import Aihc.Fc (DesugarResult (..), desugarModuleWithBindings)
 import Aihc.Grin (lintProgram, lowerProgram, renderProgram)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
-import Aihc.Resolve (ResolveResult (..), resolve)
+import Aihc.Resolve (ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheck)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withObject)
@@ -110,13 +110,14 @@ evaluateGrinCase fixture =
   case parseSource fixture of
     Left err -> classifyFailure fixture ("parse error: " <> err)
     Right parsed ->
-      case resolve [parsed] of
+      case resolveWithDeps mempty [(unnamedPackage, parsed)] of
         ResolveResult {resolvedModules, resolveErrors = []} ->
-          let tcResults = typecheck resolvedModules
+          let moduleAsts = map snd resolvedModules
+              tcResults = typecheck moduleAsts
            in if all tcModuleSuccess tcResults
                 then
                   let allBindings = moduleGroupBindings tcResults
-                      desugared = zipWith (desugarModuleWithBindings allBindings) tcResults resolvedModules
+                      desugared = zipWith (desugarModuleWithBindings allBindings) tcResults moduleAsts
                    in if all dsSuccess desugared
                         then
                           let programs = map (lowerProgram . dsProgram) desugared

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -36,6 +36,8 @@ import Aihc.Resolve
     ResolutionNamespace (..),
     ResolveResult (..),
     ResolvedName (..),
+    parsePackageId,
+    renderPackageId,
     resolvePackages,
   )
 import Aihc.Testing.AnnotatedModule (renderAnnotatedModuleSources)
@@ -145,7 +147,9 @@ parseModules value = parseList value <|> parsePackages value
   where
     parseList = withArray "modules" $ \arr -> mapM (fmap (Nothing,) . parseModuleEntry) (toList arr)
     parsePackages = withObject "package modules" $ \obj -> concat <$> mapM parsePackage (KeyMap.toList obj)
-    parsePackage (packageId, entries) = withArray "package module list" (mapM (fmap (Just (PackageId (Key.toText packageId)),) . parseModuleEntry) . toList) entries
+    parsePackage (packageIdKey, entries) = do
+      packageId <- maybe (fail ("invalid package id: " <> show (Key.toText packageIdKey))) pure (parsePackageId (Key.toText packageIdKey))
+      withArray "package module list" (mapM (fmap (Just packageId,) . parseModuleEntry) . toList) entries
     toList = foldr (:) []
     parseModuleEntry (Y.String t) = pure t
     parseModuleEntry _ = fail "each module must be a string"
@@ -238,7 +242,7 @@ renderConciseOrigin :: ResolvedName -> Text
 renderConciseOrigin resolvedName =
   case resolvedName of
     ResolvedTopLevel name -> fromMaybe (renderName name) (nameQualifier name)
-    ResolvedPackageTopLevel (PackageId packageId) name -> packageId <> ":" <> fromMaybe (renderName name) (nameQualifier name)
+    ResolvedPackageTopLevel packageId name -> renderPackageId packageId <> ":" <> fromMaybe (renderName name) (nameQualifier name)
     ResolvedLocal uniqueId _ -> T.pack (show uniqueId)
     ResolvedBuiltin name -> "Builtin " <> name
     ResolvedError msg -> T.pack ("Error " <> msg)

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module ResolverGolden
   ( ExpectedStatus (..),
@@ -30,14 +31,18 @@ import Aihc.Parser.Syntax
     renderName,
   )
 import Aihc.Resolve
-  ( ResolutionAnnotation (..),
+  ( PackageId (..),
+    ResolutionAnnotation (..),
     ResolutionNamespace (..),
     ResolveResult (..),
     ResolvedName (..),
-    resolve,
+    resolvePackages,
   )
 import Aihc.Testing.AnnotatedModule (renderAnnotatedModuleSources)
+import Control.Applicative ((<|>))
 import Data.Aeson ((.!=), (.:), (.:?))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort, sortOn)
@@ -69,7 +74,7 @@ data ResolverCase = ResolverCase
     caseCategory :: !String,
     casePath :: !FilePath,
     caseExtensions :: ![Extension],
-    caseModules :: ![Text],
+    caseModules :: ![(Maybe PackageId, Text)],
     caseAnnotated :: ![String],
     caseStatus :: !ExpectedStatus,
     caseReason :: !String
@@ -120,7 +125,7 @@ parseResolverCaseText path source = do
         caseReason = reason
       }
 
-parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [Text], [Text], Text, Text)
+parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [(Maybe PackageId, Text)], [Text], Text, Text)
 parseYamlFixture path value =
   case parseEither
     ( withObject "resolver fixture" $ \obj -> do
@@ -135,10 +140,12 @@ parseYamlFixture path value =
     Left err -> Left ("Invalid resolver fixture schema in " <> path <> ": " <> err)
     Right parsed -> Right parsed
 
-parseModules :: Y.Value -> Y.Parser [Text]
-parseModules = withArray "modules" $ \arr ->
-  mapM parseModuleEntry (toList arr)
+parseModules :: Y.Value -> Y.Parser [(Maybe PackageId, Text)]
+parseModules value = parseList value <|> parsePackages value
   where
+    parseList = withArray "modules" $ \arr -> mapM (fmap (Nothing,) . parseModuleEntry) (toList arr)
+    parsePackages = withObject "package modules" $ \obj -> concat <$> mapM parsePackage (KeyMap.toList obj)
+    parsePackage (packageId, entries) = withArray "package module list" (mapM (fmap (Just (PackageId (Key.toText packageId)),) . parseModuleEntry) . toList) entries
     toList = foldr (:) []
     parseModuleEntry (Y.String t) = pure t
     parseModuleEntry _ = fail "each module must be a string"
@@ -152,11 +159,11 @@ parseAnnotatedList = withArray "annotated" $ \arr -> do
 
 evaluateResolverCase :: ResolverCase -> (Outcome, String)
 evaluateResolverCase meta =
-  let parsedModules = map parseOne (caseModules meta)
+  let parsedModules = map (traverse parseOne) (caseModules meta)
    in case sequence parsedModules of
         Left errMsg -> (OutcomeFail, "parse error: " <> errMsg)
         Right modules ->
-          let result = resolve modules
+          let result = resolvePackages modules
               actualAnnotated = showAnnotated result
               outputMatches = actualAnnotated == caseAnnotated meta
            in case caseStatus meta of
@@ -183,7 +190,7 @@ evaluateResolverCase meta =
        in if null errs
             then Right ast
             else Left (formatParseErrors (T.unpack (T.takeWhile (/= '\n') input)) (Just input) errs)
-    showAnnotated = renderAnnotatedResolveResult (caseModules meta)
+    showAnnotated = renderAnnotatedResolveResult (map snd (caseModules meta))
 
 progressSummary :: [(ResolverCase, Outcome, String)] -> (Int, Int, Int, Int)
 progressSummary outcomes =
@@ -231,6 +238,7 @@ renderConciseOrigin :: ResolvedName -> Text
 renderConciseOrigin resolvedName =
   case resolvedName of
     ResolvedTopLevel name -> fromMaybe (renderName name) (nameQualifier name)
+    ResolvedPackageTopLevel (PackageId packageId) name -> packageId <> ":" <> fromMaybe (renderName name) (nameQualifier name)
     ResolvedLocal uniqueId _ -> T.pack (show uniqueId)
     ResolvedBuiltin name -> "Builtin " <> name
     ResolvedError msg -> T.pack ("Error " <> msg)

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -31,13 +31,12 @@ import Aihc.Parser.Syntax
     renderName,
   )
 import Aihc.Resolve
-  ( PackageId (..),
+  ( Package (..),
+    PackageId (..),
     ResolutionAnnotation (..),
     ResolutionNamespace (..),
     ResolveResult (..),
     ResolvedName (..),
-    parsePackageId,
-    renderPackageId,
     resolvePackages,
   )
 import Aihc.Testing.AnnotatedModule (renderAnnotatedModuleSources)
@@ -76,7 +75,7 @@ data ResolverCase = ResolverCase
     caseCategory :: !String,
     casePath :: !FilePath,
     caseExtensions :: ![Extension],
-    caseModules :: ![(Maybe PackageId, Text)],
+    caseModules :: ![(Maybe Package, Text)],
     caseAnnotated :: ![String],
     caseStatus :: !ExpectedStatus,
     caseReason :: !String
@@ -127,7 +126,7 @@ parseResolverCaseText path source = do
         caseReason = reason
       }
 
-parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [(Maybe PackageId, Text)], [Text], Text, Text)
+parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [(Maybe Package, Text)], [Text], Text, Text)
 parseYamlFixture path value =
   case parseEither
     ( withObject "resolver fixture" $ \obj -> do
@@ -142,14 +141,18 @@ parseYamlFixture path value =
     Left err -> Left ("Invalid resolver fixture schema in " <> path <> ": " <> err)
     Right parsed -> Right parsed
 
-parseModules :: Y.Value -> Y.Parser [(Maybe PackageId, Text)]
+parseModules :: Y.Value -> Y.Parser [(Maybe Package, Text)]
 parseModules value = parseList value <|> parsePackages value
   where
     parseList = withArray "modules" $ \arr -> mapM (fmap (Nothing,) . parseModuleEntry) (toList arr)
     parsePackages = withObject "package modules" $ \obj -> concat <$> mapM parsePackage (KeyMap.toList obj)
-    parsePackage (packageIdKey, entries) = do
-      packageId <- maybe (fail ("invalid package id: " <> show (Key.toText packageIdKey))) pure (parsePackageId (Key.toText packageIdKey))
-      withArray "package module list" (mapM (fmap (Just packageId,) . parseModuleEntry) . toList) entries
+    parsePackage (packageIdKey, entry) = withObject "package modules" parsePackageEntry entry
+      where
+        parsePackageEntry obj = do
+          visibleName <- obj .: "package"
+          entries <- obj .: "modules"
+          let package = Package visibleName (PackageId (Key.toText packageIdKey))
+          withArray "package module list" (mapM (fmap (Just package,) . parseModuleEntry) . toList) entries
     toList = foldr (:) []
     parseModuleEntry (Y.String t) = pure t
     parseModuleEntry _ = fail "each module must be a string"
@@ -242,7 +245,7 @@ renderConciseOrigin :: ResolvedName -> Text
 renderConciseOrigin resolvedName =
   case resolvedName of
     ResolvedTopLevel name -> fromMaybe (renderName name) (nameQualifier name)
-    ResolvedPackageTopLevel packageId name -> renderPackageId packageId <> ":" <> fromMaybe (renderName name) (nameQualifier name)
+    ResolvedPackageTopLevel identity name -> packageIdText identity <> ":" <> fromMaybe (renderName name) (nameQualifier name)
     ResolvedLocal uniqueId _ -> T.pack (show uniqueId)
     ResolvedBuiltin name -> "Builtin " <> name
     ResolvedError msg -> T.pack ("Error " <> msg)

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -37,7 +37,8 @@ import Aihc.Resolve
     ResolutionNamespace (..),
     ResolveResult (..),
     ResolvedName (..),
-    resolvePackages,
+    resolveWithDeps,
+    unnamedPackage,
   )
 import Aihc.Testing.AnnotatedModule (renderAnnotatedModuleSources)
 import Control.Applicative ((<|>))
@@ -75,7 +76,7 @@ data ResolverCase = ResolverCase
     caseCategory :: !String,
     casePath :: !FilePath,
     caseExtensions :: ![Extension],
-    caseModules :: ![(Maybe Package, Text)],
+    caseModules :: ![(Package, Text)],
     caseAnnotated :: ![String],
     caseStatus :: !ExpectedStatus,
     caseReason :: !String
@@ -126,7 +127,7 @@ parseResolverCaseText path source = do
         caseReason = reason
       }
 
-parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [(Maybe Package, Text)], [Text], Text, Text)
+parseYamlFixture :: FilePath -> Y.Value -> Either String ([Text], [(Package, Text)], [Text], Text, Text)
 parseYamlFixture path value =
   case parseEither
     ( withObject "resolver fixture" $ \obj -> do
@@ -141,10 +142,10 @@ parseYamlFixture path value =
     Left err -> Left ("Invalid resolver fixture schema in " <> path <> ": " <> err)
     Right parsed -> Right parsed
 
-parseModules :: Y.Value -> Y.Parser [(Maybe Package, Text)]
+parseModules :: Y.Value -> Y.Parser [(Package, Text)]
 parseModules value = parseList value <|> parsePackages value
   where
-    parseList = withArray "modules" $ \arr -> mapM (fmap (Nothing,) . parseModuleEntry) (toList arr)
+    parseList = withArray "modules" $ \arr -> mapM (fmap (unnamedPackage,) . parseModuleEntry) (toList arr)
     parsePackages = withObject "package modules" $ \obj -> concat <$> mapM parsePackage (KeyMap.toList obj)
     parsePackage (packageIdKey, entry) = withObject "package modules" parsePackageEntry entry
       where
@@ -152,7 +153,7 @@ parseModules value = parseList value <|> parsePackages value
           visibleName <- obj .: "package"
           entries <- obj .: "modules"
           let package = Package visibleName (PackageId (Key.toText packageIdKey))
-          withArray "package module list" (mapM (fmap (Just package,) . parseModuleEntry) . toList) entries
+          withArray "package module list" (mapM (fmap (package,) . parseModuleEntry) . toList) entries
     toList = foldr (:) []
     parseModuleEntry (Y.String t) = pure t
     parseModuleEntry _ = fail "each module must be a string"
@@ -170,7 +171,7 @@ evaluateResolverCase meta =
    in case sequence parsedModules of
         Left errMsg -> (OutcomeFail, "parse error: " <> errMsg)
         Right modules ->
-          let result = resolvePackages modules
+          let result = resolveWithDeps mempty modules
               actualAnnotated = showAnnotated result
               outputMatches = actualAnnotated == caseAnnotated meta
            in case caseStatus meta of
@@ -218,7 +219,7 @@ renderAnnotatedResolveResult sources result =
       let moduleSources = sortOn (moduleDisplayName . fst) (zip modules sources)
        in renderAnnotatedModuleSources resolutionAnnotationDoc (map snd moduleSources) (map fst moduleSources)
   where
-    modules = resolvedModules result
+    modules = map snd (resolvedModules result)
 
 resolutionAnnotationDoc :: Annotation -> Maybe (Doc ann)
 resolutionAnnotationDoc annotation = do
@@ -244,8 +245,9 @@ renderConciseNamespace namespace =
 renderConciseOrigin :: ResolvedName -> Text
 renderConciseOrigin resolvedName =
   case resolvedName of
-    ResolvedTopLevel name -> fromMaybe (renderName name) (nameQualifier name)
-    ResolvedPackageTopLevel identity name -> packageIdText identity <> ":" <> fromMaybe (renderName name) (nameQualifier name)
+    ResolvedTopLevel identity name
+      | packageIdText identity == "" -> fromMaybe (renderName name) (nameQualifier name)
+      | otherwise -> packageIdText identity <> ":" <> fromMaybe (renderName name) (nameQualifier name)
     ResolvedLocal uniqueId _ -> T.pack (show uniqueId)
     ResolvedBuiltin name -> "Builtin " <> name
     ResolvedError msg -> T.pack ("Error " <> msg)

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -18,6 +18,8 @@ module Aihc.Resolve
     ModuleExports,
     ModuleKey (..),
     PackageId (..),
+    parsePackageId,
+    renderPackageId,
     collectModuleExports,
     ResolveError (..),
     ResolveResult (..),

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -8,9 +8,7 @@ module Aihc.Resolve
     pattern ImportResolution,
     pattern PResolution,
     pattern TResolution,
-    resolve,
     resolveWithDeps,
-    resolvePackages,
     extractInterface,
     extractInterfaceWithDeps,
     OperatorFixity (..),
@@ -19,9 +17,12 @@ module Aihc.Resolve
     ModuleKey (..),
     PackageId (..),
     Package (..),
+    unnamedPackage,
+    modulesInPackage,
     collectModuleExports,
     ResolveError (..),
     ResolveResult (..),
+    resolvedModuleAsts,
     ResolutionNamespace (..),
     ResolvedName (..),
     ResolutionAnnotation (..),
@@ -104,26 +105,6 @@ import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
-
-resolve :: [Module] -> ResolveResult
-resolve = resolveWithDeps Map.empty
-
--- | Resolve modules whose defining installed packages are known.  A missing
--- package id denotes the current, anonymous package used by simple callers.
-resolvePackages :: [(Maybe Package, Module)] -> ResolveResult
-resolvePackages packageModules =
-  ResolveResult
-    { resolvedModules = modules',
-      resolveErrors = collectResolveErrors modules'
-    }
-  where
-    exports =
-      List.foldl'
-        (\acc (packageId, modules) -> collectPackageModuleExports packageId acc modules `Map.union` acc)
-        Map.empty
-        (Map.toList (Map.fromListWith (<>) (map (fmap (: [])) packageModules)))
-    (_, modules') = List.mapAccumL resolveOnePackage 0 packageModules
-    resolveOnePackage nextLocal (packageId, modu) = resolveModule packageId exports nextLocal modu
 
 collectResolveErrors :: (Data a) => a -> [ResolveError]
 collectResolveErrors node =
@@ -209,19 +190,20 @@ annotationResolveError resolution =
     ResolvedBuiltin _ -> Nothing
     _ -> Nothing
 
-resolveWithDeps :: ModuleExports -> [Module] -> ResolveResult
-resolveWithDeps depExports modules =
+resolveWithDeps :: ModuleExports -> [(Package, Module)] -> ResolveResult
+resolveWithDeps depExports packageModules =
   ResolveResult
-    { resolvedModules = modules',
+    { resolvedModules = packageModules',
       resolveErrors = collectResolveErrors modules'
     }
   where
-    step currentNextLocal modu =
-      let (nextLocal', modu') = resolveModule Nothing exports currentNextLocal modu
+    step currentNextLocal (package, modu) =
+      let (nextLocal', modu') = resolveModule package exports currentNextLocal modu
        in (nextLocal', modu')
-    (_, resolved) = mapAccumL step 0 modules
+    (_, resolved) = mapAccumL step 0 packageModules
     modules' = resolved
-    ownExports = collectModuleExportsWithDeps depExports modules
+    packageModules' = zip (map fst packageModules) modules'
+    ownExports = collectModuleExportsWithDeps depExports packageModules
     exports = ownExports `Map.union` depExports
 
 extractInterface :: ResolveResult -> ModuleExports
@@ -230,29 +212,29 @@ extractInterface = collectModuleExports . resolvedModules
 extractInterfaceWithDeps :: ModuleExports -> ResolveResult -> ModuleExports
 extractInterfaceWithDeps depExports = collectModuleExportsWithDeps depExports . resolvedModules
 
-resolveModule :: Maybe Package -> ModuleExports -> Int -> Module -> (Int, Module)
-resolveModule packageId exports nextLocal modu =
-  let imports' = resolveModuleImports packageId exports (moduleImports modu)
+resolveModule :: Package -> ModuleExports -> Int -> Module -> (Int, Module)
+resolveModule package exports nextLocal modu =
+  let imports' = resolveModuleImports package exports (moduleImports modu)
       modu' = modu {moduleImports = imports'}
-      scope = moduleScope packageId exports modu'
-      (nextLocal', decls') = runResolveM scope (moduleInfo exports modu') nextLocal (resolveTopLevelDecls Map.empty (moduleDecls modu))
+      scope = moduleScope package exports modu'
+      (nextLocal', decls') = runResolveM scope (moduleInfo package exports modu') nextLocal (resolveTopLevelDecls Map.empty (moduleDecls modu))
    in (nextLocal', modu' {moduleDecls = decls'})
 
-moduleInfo :: ModuleExports -> Module -> ModuleInfo
-moduleInfo exports modu =
+moduleInfo :: Package -> ModuleExports -> Module -> ModuleInfo
+moduleInfo package exports modu =
   ModuleInfo
     { moduleInfoExtensions =
         applyImpliedExtensions $
           foldr applyExtensionSetting [] (moduleLanguagePragmas modu),
       moduleInfoExplicitPreludeImport =
         any ((== "Prelude") . importDeclModule) (moduleImports modu),
-      moduleInfoGhcBaseScope = lookupImportedModule Nothing Nothing "GHC.Base" exports,
-      moduleInfoGhcClassesScope = lookupImportedModule Nothing Nothing "GHC.Classes" exports,
-      moduleInfoGhcNumScope = lookupImportedModule Nothing Nothing "GHC.Num" exports
+      moduleInfoGhcBaseScope = lookupImportedModule package Nothing "GHC.Base" exports,
+      moduleInfoGhcClassesScope = lookupImportedModule package Nothing "GHC.Classes" exports,
+      moduleInfoGhcNumScope = lookupImportedModule package Nothing "GHC.Num" exports
     }
 
-resolveModuleImports :: Maybe Package -> ModuleExports -> [ImportDecl] -> [ImportDecl]
-resolveModuleImports packageId exports =
+resolveModuleImports :: Package -> ModuleExports -> [ImportDecl] -> [ImportDecl]
+resolveModuleImports package exports =
   map resolveModuleImport
   where
     resolveModuleImport importDecl
@@ -261,7 +243,7 @@ resolveModuleImports packageId exports =
       | null matches = annotateImport (missingModuleImportAnnotation "not found" importDecl) importDecl
       | otherwise = annotateImport (missingModuleImportAnnotation "ambiguous" importDecl) importDecl
       where
-        matches = matchingModuleScopes packageId (importDeclPackage importDecl) (importDeclModule importDecl) exports
+        matches = matchingModuleScopes package (importDeclPackage importDecl) (importDeclModule importDecl) exports
 
 missingModuleImportAnnotation :: String -> ImportDecl -> ResolutionAnnotation
 missingModuleImportAnnotation message importDecl =
@@ -733,11 +715,7 @@ resolveIntegerLiteral expr = do
 rebindableFromInteger :: ModuleInfo -> Scope -> ResolvedName
 rebindableFromInteger info scope =
   case lookupTerm "fromInteger" scope of
-    ResolvedTopLevel name
-      | nameQualifier name == Just "Prelude",
-        not (moduleInfoExplicitPreludeImport info) ->
-          ResolvedError "unbound"
-    ResolvedPackageTopLevel _ name
+    ResolvedTopLevel _ name
       | nameQualifier name == Just "Prelude",
         not (moduleInfoExplicitPreludeImport info) ->
           ResolvedError "unbound"
@@ -785,11 +763,7 @@ builtinSyntaxTerm info name =
 rebindableSyntaxTerm :: ModuleInfo -> Scope -> Text -> ResolvedName
 rebindableSyntaxTerm info scope name =
   case lookupTerm name scope of
-    ResolvedTopLevel resolved
-      | nameQualifier resolved == Just "Prelude",
-        not (moduleInfoExplicitPreludeImport info) ->
-          ResolvedError "unbound"
-    ResolvedPackageTopLevel _ resolved
+    ResolvedTopLevel _ resolved
       | nameQualifier resolved == Just "Prelude",
         not (moduleInfoExplicitPreludeImport info) ->
           ResolvedError "unbound"

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -18,8 +18,7 @@ module Aihc.Resolve
     ModuleExports,
     ModuleKey (..),
     PackageId (..),
-    parsePackageId,
-    renderPackageId,
+    Package (..),
     collectModuleExports,
     ResolveError (..),
     ResolveResult (..),
@@ -111,7 +110,7 @@ resolve = resolveWithDeps Map.empty
 
 -- | Resolve modules whose defining installed packages are known.  A missing
 -- package id denotes the current, anonymous package used by simple callers.
-resolvePackages :: [(Maybe PackageId, Module)] -> ResolveResult
+resolvePackages :: [(Maybe Package, Module)] -> ResolveResult
 resolvePackages packageModules =
   ResolveResult
     { resolvedModules = modules',
@@ -231,7 +230,7 @@ extractInterface = collectModuleExports . resolvedModules
 extractInterfaceWithDeps :: ModuleExports -> ResolveResult -> ModuleExports
 extractInterfaceWithDeps depExports = collectModuleExportsWithDeps depExports . resolvedModules
 
-resolveModule :: Maybe PackageId -> ModuleExports -> Int -> Module -> (Int, Module)
+resolveModule :: Maybe Package -> ModuleExports -> Int -> Module -> (Int, Module)
 resolveModule packageId exports nextLocal modu =
   let imports' = resolveModuleImports packageId exports (moduleImports modu)
       modu' = modu {moduleImports = imports'}
@@ -252,7 +251,7 @@ moduleInfo exports modu =
       moduleInfoGhcNumScope = lookupImportedModule Nothing Nothing "GHC.Num" exports
     }
 
-resolveModuleImports :: Maybe PackageId -> ModuleExports -> [ImportDecl] -> [ImportDecl]
+resolveModuleImports :: Maybe Package -> ModuleExports -> [ImportDecl] -> [ImportDecl]
 resolveModuleImports packageId exports =
   map resolveModuleImport
   where

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -10,11 +10,14 @@ module Aihc.Resolve
     pattern TResolution,
     resolve,
     resolveWithDeps,
+    resolvePackages,
     extractInterface,
     extractInterfaceWithDeps,
     OperatorFixity (..),
     Scope (..),
     ModuleExports,
+    ModuleKey (..),
+    PackageId (..),
     collectModuleExports,
     ResolveError (..),
     ResolveResult (..),
@@ -103,6 +106,23 @@ import Data.Text (Text)
 
 resolve :: [Module] -> ResolveResult
 resolve = resolveWithDeps Map.empty
+
+-- | Resolve modules whose defining installed packages are known.  A missing
+-- package id denotes the current, anonymous package used by simple callers.
+resolvePackages :: [(Maybe PackageId, Module)] -> ResolveResult
+resolvePackages packageModules =
+  ResolveResult
+    { resolvedModules = modules',
+      resolveErrors = collectResolveErrors modules'
+    }
+  where
+    exports =
+      List.foldl'
+        (\acc (packageId, modules) -> collectPackageModuleExports packageId acc modules `Map.union` acc)
+        Map.empty
+        (Map.toList (Map.fromListWith (<>) (map (fmap (: [])) packageModules)))
+    (_, modules') = List.mapAccumL resolveOnePackage 0 packageModules
+    resolveOnePackage nextLocal (packageId, modu) = resolveModule packageId exports nextLocal modu
 
 collectResolveErrors :: (Data a) => a -> [ResolveError]
 collectResolveErrors node =
@@ -196,7 +216,7 @@ resolveWithDeps depExports modules =
     }
   where
     step currentNextLocal modu =
-      let (nextLocal', modu') = resolveModule exports currentNextLocal modu
+      let (nextLocal', modu') = resolveModule Nothing exports currentNextLocal modu
        in (nextLocal', modu')
     (_, resolved) = mapAccumL step 0 modules
     modules' = resolved
@@ -209,11 +229,11 @@ extractInterface = collectModuleExports . resolvedModules
 extractInterfaceWithDeps :: ModuleExports -> ResolveResult -> ModuleExports
 extractInterfaceWithDeps depExports = collectModuleExportsWithDeps depExports . resolvedModules
 
-resolveModule :: ModuleExports -> Int -> Module -> (Int, Module)
-resolveModule exports nextLocal modu =
-  let imports' = resolveModuleImports exports (moduleImports modu)
+resolveModule :: Maybe PackageId -> ModuleExports -> Int -> Module -> (Int, Module)
+resolveModule packageId exports nextLocal modu =
+  let imports' = resolveModuleImports packageId exports (moduleImports modu)
       modu' = modu {moduleImports = imports'}
-      scope = moduleScope exports modu'
+      scope = moduleScope packageId exports modu'
       (nextLocal', decls') = runResolveM scope (moduleInfo exports modu') nextLocal (resolveTopLevelDecls Map.empty (moduleDecls modu))
    in (nextLocal', modu' {moduleDecls = decls'})
 
@@ -225,28 +245,31 @@ moduleInfo exports modu =
           foldr applyExtensionSetting [] (moduleLanguagePragmas modu),
       moduleInfoExplicitPreludeImport =
         any ((== "Prelude") . importDeclModule) (moduleImports modu),
-      moduleInfoGhcBaseScope = Map.findWithDefault emptyScope "GHC.Base" exports,
-      moduleInfoGhcClassesScope = Map.findWithDefault emptyScope "GHC.Classes" exports,
-      moduleInfoGhcNumScope = Map.findWithDefault emptyScope "GHC.Num" exports
+      moduleInfoGhcBaseScope = lookupImportedModule Nothing Nothing "GHC.Base" exports,
+      moduleInfoGhcClassesScope = lookupImportedModule Nothing Nothing "GHC.Classes" exports,
+      moduleInfoGhcNumScope = lookupImportedModule Nothing Nothing "GHC.Num" exports
     }
 
-resolveModuleImports :: ModuleExports -> [ImportDecl] -> [ImportDecl]
-resolveModuleImports exports =
+resolveModuleImports :: Maybe PackageId -> ModuleExports -> [ImportDecl] -> [ImportDecl]
+resolveModuleImports packageId exports =
   map resolveModuleImport
   where
     resolveModuleImport importDecl
-      | Just originScope <- Map.lookup (importDeclModule importDecl) exports =
+      | [originScope] <- matches =
           annotateMissingImportItems originScope importDecl
-      | otherwise = annotateImport (missingModuleImportAnnotation importDecl) importDecl
+      | null matches = annotateImport (missingModuleImportAnnotation "not found" importDecl) importDecl
+      | otherwise = annotateImport (missingModuleImportAnnotation "ambiguous" importDecl) importDecl
+      where
+        matches = matchingModuleScopes packageId (importDeclPackage importDecl) (importDeclModule importDecl) exports
 
-missingModuleImportAnnotation :: ImportDecl -> ResolutionAnnotation
-missingModuleImportAnnotation importDecl =
+missingModuleImportAnnotation :: String -> ImportDecl -> ResolutionAnnotation
+missingModuleImportAnnotation message importDecl =
   let importedModule = importDeclModule importDecl
    in ResolutionAnnotation
         (importModuleNameSpan importDecl)
         importedModule
         ResolutionNamespaceModule
-        (ResolvedError "not found")
+        (ResolvedError message)
 
 annotateMissingImportItems :: Scope -> ImportDecl -> ImportDecl
 annotateMissingImportItems originScope importDecl =
@@ -713,6 +736,10 @@ rebindableFromInteger info scope =
       | nameQualifier name == Just "Prelude",
         not (moduleInfoExplicitPreludeImport info) ->
           ResolvedError "unbound"
+    ResolvedPackageTopLevel _ name
+      | nameQualifier name == Just "Prelude",
+        not (moduleInfoExplicitPreludeImport info) ->
+          ResolvedError "unbound"
     resolved -> resolved
 
 annotateIntegerPatternLiteral :: Pattern -> Literal -> ResolveM Pattern
@@ -758,6 +785,10 @@ rebindableSyntaxTerm :: ModuleInfo -> Scope -> Text -> ResolvedName
 rebindableSyntaxTerm info scope name =
   case lookupTerm name scope of
     ResolvedTopLevel resolved
+      | nameQualifier resolved == Just "Prelude",
+        not (moduleInfoExplicitPreludeImport info) ->
+          ResolvedError "unbound"
+    ResolvedPackageTopLevel _ resolved
       | nameQualifier resolved == Just "Prelude",
         not (moduleInfoExplicitPreludeImport info) ->
           ResolvedError "unbound"

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -7,7 +7,6 @@ module Aihc.Resolve.Scope
     ModuleKey (..),
     collectModuleExports,
     collectModuleExportsWithDeps,
-    collectPackageModuleExports,
     moduleScope,
     moduleKey,
     matchingModuleScopes,
@@ -98,41 +97,38 @@ data OperatorFixity = OperatorFixity
   deriving (Eq, Show, Read)
 
 data ModuleKey = ModuleKey
-  { moduleKeyPackage :: !(Maybe Package),
+  { moduleKeyPackage :: !Package,
     moduleKeyName :: !Text
   }
   deriving (Eq, Ord, Show)
 
 type ModuleExports = Map.Map ModuleKey Scope
 
-collectModuleExports :: [Module] -> ModuleExports
-collectModuleExports = collectPackageModuleExports Nothing Map.empty
+collectModuleExports :: [(Package, Module)] -> ModuleExports
+collectModuleExports = collectModuleExportsWithDeps Map.empty
 
 -- | Extract interfaces for a compilation unit while allowing its explicit
 -- export lists to re-export names supplied by predecessor units.
-collectModuleExportsWithDeps :: ModuleExports -> [Module] -> ModuleExports
-collectModuleExportsWithDeps = collectPackageModuleExports Nothing
-
-collectPackageModuleExports :: Maybe Package -> ModuleExports -> [Module] -> ModuleExports
-collectPackageModuleExports package depExports modules = Map.restrictKeys (closeExports initialExports) moduleKeys
+collectModuleExportsWithDeps :: ModuleExports -> [(Package, Module)] -> ModuleExports
+collectModuleExportsWithDeps depExports packageModules = Map.restrictKeys (closeExports initialExports) moduleKeys
   where
     moduleKeys = Map.keysSet localExports
     localExports =
       Map.fromList
-        [ (exportKey modu, emptyScope)
-        | modu <- modules
+        [ (exportKey package modu, emptyScope)
+        | (package, modu) <- packageModules
         ]
     initialExports =
       localExports `Map.union` depExports
 
     closeExports exports =
       let exports' =
-            Map.fromList [(exportKey modu, exportedScope package exports modu) | modu <- modules]
+            Map.fromList [(exportKey package modu, exportedScope package exports modu) | (package, modu) <- packageModules]
               `Map.union` depExports
        in if exports' == exports then exports else closeExports exports'
-    exportKey modu = ModuleKey package (moduleKey modu)
+    exportKey package modu = ModuleKey package (moduleKey modu)
 
-exportedScope :: Maybe Package -> ModuleExports -> Module -> Scope
+exportedScope :: Package -> ModuleExports -> Module -> Scope
 exportedScope package exports modu =
   case moduleExports modu of
     Nothing -> topLevelScope package modu
@@ -186,14 +182,12 @@ allTypeMembers name scope =
 exportBundledMemberName :: IEBundledMember -> Text
 exportBundledMemberName = nameText . ieBundledMemberName
 
-topLevelScope :: Maybe Package -> Module -> Scope
+topLevelScope :: Package -> Module -> Scope
 topLevelScope package modu =
   List.foldl' addDecl emptyScope (moduleDecls modu)
   where
     moduleKeyText = moduleKey modu
-    qualify name = case package of
-      Nothing -> ResolvedTopLevel (qualifyName (Just moduleKeyText) name)
-      Just definingPackage -> ResolvedPackageTopLevel (packageId definingPackage) (qualifyName (Just moduleKeyText) name)
+    qualify = ResolvedTopLevel (packageId package) . qualifyName (Just moduleKeyText)
     addDecl scope decl =
       let DeclExports termNames typeNames constructors recordFields methods fixities = declExportedNames decl
           scope' = List.foldl' (\acc name -> insertTerm (renderUnqualifiedName name) (qualify name) acc) scope termNames
@@ -375,7 +369,7 @@ bars n
   | n <= 0 = ""
   | otherwise = T.replicate n "|"
 
-moduleScope :: Maybe Package -> ModuleExports -> Module -> Scope
+moduleScope :: Package -> ModuleExports -> Module -> Scope
 moduleScope packageId exports modu =
   ownScope `unionScope` importedScope packageId exports modu `unionScope` implicitPrelude `unionScope` builtinScope
   where
@@ -384,7 +378,7 @@ moduleScope packageId exports modu =
     -- Implicit Prelude: names available unqualified AND as Prelude.xxx
     implicitPrelude = preludeScope {scopeQualifiedModules = Map.singleton "Prelude" preludeScope}
 
-importedScope :: Maybe Package -> ModuleExports -> Module -> Scope
+importedScope :: Package -> ModuleExports -> Module -> Scope
 importedScope packageId exports modu =
   List.foldl' addImport emptyScope (moduleImports modu)
   where
@@ -399,7 +393,7 @@ importedScope packageId exports modu =
         qualifier = fromMaybe originModule (importDeclAs importDecl)
         imported = filterImportSpec (importDeclSpec importDecl) (lookupImportedModule packageId (importDeclPackage importDecl) originModule exports)
 
-lookupImportedModule :: Maybe Package -> Maybe Text -> Text -> ModuleExports -> Scope
+lookupImportedModule :: Package -> Maybe Text -> Text -> ModuleExports -> Scope
 lookupImportedModule currentPackage requestedPackage moduleName' exports =
   case matchingScopes of
     [scope] -> scope
@@ -407,18 +401,18 @@ lookupImportedModule currentPackage requestedPackage moduleName' exports =
   where
     matchingScopes = matchingModuleScopes currentPackage requestedPackage moduleName' exports
 
-matchingModuleScopes :: Maybe Package -> Maybe Text -> Text -> ModuleExports -> [Scope]
+matchingModuleScopes :: Package -> Maybe Text -> Text -> ModuleExports -> [Scope]
 matchingModuleScopes currentPackage requestedPackage moduleName' exports =
   [ scope
-  | (ModuleKey packageId name, scope) <- Map.toList exports,
+  | (ModuleKey package name, scope) <- Map.toList exports,
     name == moduleName',
-    packageMatches packageId
+    packageMatches package
   ]
   where
-    packageMatches packageId = case requestedPackage of
+    packageMatches package = case requestedPackage of
       Nothing -> True
-      Just "this" -> packageId == currentPackage
-      Just requested -> maybe False ((== requested) . packageName) packageId
+      Just "this" -> package == currentPackage
+      Just requested -> requested == packageName package
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =
@@ -494,8 +488,7 @@ resolveQualifiedName scope lookupName qualifier name =
     Nothing -> ResolvedError ("unknown qualified import: " <> T.unpack qualifier)
     Just qualifiedScope ->
       case lookupName (nameText name) qualifiedScope of
-        ResolvedTopLevel resolved -> ResolvedTopLevel resolved
-        ResolvedPackageTopLevel packageId resolved -> ResolvedPackageTopLevel packageId resolved
+        ResolvedTopLevel packageId resolved -> ResolvedTopLevel packageId resolved
         other -> other
 
 moduleKey :: Module -> Text

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -98,7 +98,7 @@ data OperatorFixity = OperatorFixity
   deriving (Eq, Show, Read)
 
 data ModuleKey = ModuleKey
-  { moduleKeyPackage :: !(Maybe PackageId),
+  { moduleKeyPackage :: !(Maybe Package),
     moduleKeyName :: !Text
   }
   deriving (Eq, Ord, Show)
@@ -113,8 +113,8 @@ collectModuleExports = collectPackageModuleExports Nothing Map.empty
 collectModuleExportsWithDeps :: ModuleExports -> [Module] -> ModuleExports
 collectModuleExportsWithDeps = collectPackageModuleExports Nothing
 
-collectPackageModuleExports :: Maybe PackageId -> ModuleExports -> [Module] -> ModuleExports
-collectPackageModuleExports packageId depExports modules = Map.restrictKeys (closeExports initialExports) moduleKeys
+collectPackageModuleExports :: Maybe Package -> ModuleExports -> [Module] -> ModuleExports
+collectPackageModuleExports package depExports modules = Map.restrictKeys (closeExports initialExports) moduleKeys
   where
     moduleKeys = Map.keysSet localExports
     localExports =
@@ -127,23 +127,23 @@ collectPackageModuleExports packageId depExports modules = Map.restrictKeys (clo
 
     closeExports exports =
       let exports' =
-            Map.fromList [(exportKey modu, exportedScope packageId exports modu) | modu <- modules]
+            Map.fromList [(exportKey modu, exportedScope package exports modu) | modu <- modules]
               `Map.union` depExports
        in if exports' == exports then exports else closeExports exports'
-    exportKey modu = ModuleKey packageId (moduleKey modu)
+    exportKey modu = ModuleKey package (moduleKey modu)
 
-exportedScope :: Maybe PackageId -> ModuleExports -> Module -> Scope
-exportedScope packageId exports modu =
+exportedScope :: Maybe Package -> ModuleExports -> Module -> Scope
+exportedScope package exports modu =
   case moduleExports modu of
-    Nothing -> topLevelScope packageId modu
+    Nothing -> topLevelScope package modu
     Just specs -> List.foldl' unionScope emptyScope (map exportSpecScope specs)
   where
-    availableScope = topLevelScope packageId modu `unionScope` importedScope packageId exports modu
+    availableScope = topLevelScope package modu `unionScope` importedScope package exports modu
 
     exportSpecScope spec =
       case spec of
         ExportAnn _ inner -> exportSpecScope inner
-        ExportModule _ exportModuleName -> lookupImportedModule packageId Nothing exportModuleName exports
+        ExportModule _ exportModuleName -> lookupImportedModule package Nothing exportModuleName exports
         ExportVar _ _ name -> selectTerm (nameText name) availableScope
         ExportAbs _ _ name -> selectType (nameText name) availableScope
         ExportAll _ _ name -> selectTypeWithMembers (nameText name) availableScope (allTypeMembers (nameText name) availableScope)
@@ -186,14 +186,14 @@ allTypeMembers name scope =
 exportBundledMemberName :: IEBundledMember -> Text
 exportBundledMemberName = nameText . ieBundledMemberName
 
-topLevelScope :: Maybe PackageId -> Module -> Scope
-topLevelScope packageId modu =
+topLevelScope :: Maybe Package -> Module -> Scope
+topLevelScope package modu =
   List.foldl' addDecl emptyScope (moduleDecls modu)
   where
     moduleKeyText = moduleKey modu
-    qualify name = case packageId of
+    qualify name = case package of
       Nothing -> ResolvedTopLevel (qualifyName (Just moduleKeyText) name)
-      Just pkg -> ResolvedPackageTopLevel pkg (qualifyName (Just moduleKeyText) name)
+      Just definingPackage -> ResolvedPackageTopLevel (packageId definingPackage) (qualifyName (Just moduleKeyText) name)
     addDecl scope decl =
       let DeclExports termNames typeNames constructors recordFields methods fixities = declExportedNames decl
           scope' = List.foldl' (\acc name -> insertTerm (renderUnqualifiedName name) (qualify name) acc) scope termNames
@@ -375,7 +375,7 @@ bars n
   | n <= 0 = ""
   | otherwise = T.replicate n "|"
 
-moduleScope :: Maybe PackageId -> ModuleExports -> Module -> Scope
+moduleScope :: Maybe Package -> ModuleExports -> Module -> Scope
 moduleScope packageId exports modu =
   ownScope `unionScope` importedScope packageId exports modu `unionScope` implicitPrelude `unionScope` builtinScope
   where
@@ -384,7 +384,7 @@ moduleScope packageId exports modu =
     -- Implicit Prelude: names available unqualified AND as Prelude.xxx
     implicitPrelude = preludeScope {scopeQualifiedModules = Map.singleton "Prelude" preludeScope}
 
-importedScope :: Maybe PackageId -> ModuleExports -> Module -> Scope
+importedScope :: Maybe Package -> ModuleExports -> Module -> Scope
 importedScope packageId exports modu =
   List.foldl' addImport emptyScope (moduleImports modu)
   where
@@ -399,7 +399,7 @@ importedScope packageId exports modu =
         qualifier = fromMaybe originModule (importDeclAs importDecl)
         imported = filterImportSpec (importDeclSpec importDecl) (lookupImportedModule packageId (importDeclPackage importDecl) originModule exports)
 
-lookupImportedModule :: Maybe PackageId -> Maybe Text -> Text -> ModuleExports -> Scope
+lookupImportedModule :: Maybe Package -> Maybe Text -> Text -> ModuleExports -> Scope
 lookupImportedModule currentPackage requestedPackage moduleName' exports =
   case matchingScopes of
     [scope] -> scope
@@ -407,7 +407,7 @@ lookupImportedModule currentPackage requestedPackage moduleName' exports =
   where
     matchingScopes = matchingModuleScopes currentPackage requestedPackage moduleName' exports
 
-matchingModuleScopes :: Maybe PackageId -> Maybe Text -> Text -> ModuleExports -> [Scope]
+matchingModuleScopes :: Maybe Package -> Maybe Text -> Text -> ModuleExports -> [Scope]
 matchingModuleScopes currentPackage requestedPackage moduleName' exports =
   [ scope
   | (ModuleKey packageId name, scope) <- Map.toList exports,
@@ -418,10 +418,7 @@ matchingModuleScopes currentPackage requestedPackage moduleName' exports =
     packageMatches packageId = case requestedPackage of
       Nothing -> True
       Just "this" -> packageId == currentPackage
-      Just requested -> maybe False (packageIdMatches requested) packageId
-
-packageIdMatches :: Text -> PackageId -> Bool
-packageIdMatches requested packageId = requested == packageIdName packageId
+      Just requested -> maybe False ((== requested) . packageName) packageId
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -421,8 +421,7 @@ matchingModuleScopes currentPackage requestedPackage moduleName' exports =
       Just requested -> maybe False (packageIdMatches requested) packageId
 
 packageIdMatches :: Text -> PackageId -> Bool
-packageIdMatches requested (PackageId installed) =
-  requested == installed || requested `T.isPrefixOf` installed && T.isPrefixOf "-" (T.drop (T.length requested) installed)
+packageIdMatches requested packageId = requested == packageIdName packageId
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -4,10 +4,14 @@ module Aihc.Resolve.Scope
   ( Scope (..),
     OperatorFixity (..),
     ModuleExports,
+    ModuleKey (..),
     collectModuleExports,
     collectModuleExportsWithDeps,
+    collectPackageModuleExports,
     moduleScope,
     moduleKey,
+    matchingModuleScopes,
+    lookupImportedModule,
     emptyScope,
     unionScope,
     insertTerm,
@@ -93,20 +97,29 @@ data OperatorFixity = OperatorFixity
   }
   deriving (Eq, Show, Read)
 
-type ModuleExports = Map.Map Text Scope
+data ModuleKey = ModuleKey
+  { moduleKeyPackage :: !(Maybe PackageId),
+    moduleKeyName :: !Text
+  }
+  deriving (Eq, Ord, Show)
+
+type ModuleExports = Map.Map ModuleKey Scope
 
 collectModuleExports :: [Module] -> ModuleExports
-collectModuleExports = collectModuleExportsWithDeps Map.empty
+collectModuleExports = collectPackageModuleExports Nothing Map.empty
 
 -- | Extract interfaces for a compilation unit while allowing its explicit
 -- export lists to re-export names supplied by predecessor units.
 collectModuleExportsWithDeps :: ModuleExports -> [Module] -> ModuleExports
-collectModuleExportsWithDeps depExports modules = Map.restrictKeys (closeExports initialExports) moduleKeys
+collectModuleExportsWithDeps = collectPackageModuleExports Nothing
+
+collectPackageModuleExports :: Maybe PackageId -> ModuleExports -> [Module] -> ModuleExports
+collectPackageModuleExports packageId depExports modules = Map.restrictKeys (closeExports initialExports) moduleKeys
   where
     moduleKeys = Map.keysSet localExports
     localExports =
       Map.fromList
-        [ (moduleKey modu, emptyScope)
+        [ (exportKey modu, emptyScope)
         | modu <- modules
         ]
     initialExports =
@@ -114,22 +127,23 @@ collectModuleExportsWithDeps depExports modules = Map.restrictKeys (closeExports
 
     closeExports exports =
       let exports' =
-            Map.fromList [(moduleKey modu, exportedScope exports modu) | modu <- modules]
+            Map.fromList [(exportKey modu, exportedScope packageId exports modu) | modu <- modules]
               `Map.union` depExports
        in if exports' == exports then exports else closeExports exports'
+    exportKey modu = ModuleKey packageId (moduleKey modu)
 
-exportedScope :: ModuleExports -> Module -> Scope
-exportedScope exports modu =
+exportedScope :: Maybe PackageId -> ModuleExports -> Module -> Scope
+exportedScope packageId exports modu =
   case moduleExports modu of
-    Nothing -> topLevelScope modu
+    Nothing -> topLevelScope packageId modu
     Just specs -> List.foldl' unionScope emptyScope (map exportSpecScope specs)
   where
-    availableScope = topLevelScope modu `unionScope` importedScope exports modu
+    availableScope = topLevelScope packageId modu `unionScope` importedScope packageId exports modu
 
     exportSpecScope spec =
       case spec of
         ExportAnn _ inner -> exportSpecScope inner
-        ExportModule _ exportModuleName -> Map.findWithDefault emptyScope exportModuleName exports
+        ExportModule _ exportModuleName -> lookupImportedModule packageId Nothing exportModuleName exports
         ExportVar _ _ name -> selectTerm (nameText name) availableScope
         ExportAbs _ _ name -> selectType (nameText name) availableScope
         ExportAll _ _ name -> selectTypeWithMembers (nameText name) availableScope (allTypeMembers (nameText name) availableScope)
@@ -172,12 +186,14 @@ allTypeMembers name scope =
 exportBundledMemberName :: IEBundledMember -> Text
 exportBundledMemberName = nameText . ieBundledMemberName
 
-topLevelScope :: Module -> Scope
-topLevelScope modu =
+topLevelScope :: Maybe PackageId -> Module -> Scope
+topLevelScope packageId modu =
   List.foldl' addDecl emptyScope (moduleDecls modu)
   where
     moduleKeyText = moduleKey modu
-    qualify = ResolvedTopLevel . qualifyName (Just moduleKeyText)
+    qualify name = case packageId of
+      Nothing -> ResolvedTopLevel (qualifyName (Just moduleKeyText) name)
+      Just pkg -> ResolvedPackageTopLevel pkg (qualifyName (Just moduleKeyText) name)
     addDecl scope decl =
       let DeclExports termNames typeNames constructors recordFields methods fixities = declExportedNames decl
           scope' = List.foldl' (\acc name -> insertTerm (renderUnqualifiedName name) (qualify name) acc) scope termNames
@@ -359,17 +375,17 @@ bars n
   | n <= 0 = ""
   | otherwise = T.replicate n "|"
 
-moduleScope :: ModuleExports -> Module -> Scope
-moduleScope exports modu =
-  ownScope `unionScope` importedScope exports modu `unionScope` implicitPrelude `unionScope` builtinScope
+moduleScope :: Maybe PackageId -> ModuleExports -> Module -> Scope
+moduleScope packageId exports modu =
+  ownScope `unionScope` importedScope packageId exports modu `unionScope` implicitPrelude `unionScope` builtinScope
   where
-    ownScope = topLevelScope modu
-    preludeScope = Map.findWithDefault emptyScope "Prelude" exports
+    ownScope = topLevelScope packageId modu
+    preludeScope = lookupImportedModule packageId Nothing "Prelude" exports
     -- Implicit Prelude: names available unqualified AND as Prelude.xxx
     implicitPrelude = preludeScope {scopeQualifiedModules = Map.singleton "Prelude" preludeScope}
 
-importedScope :: ModuleExports -> Module -> Scope
-importedScope exports modu =
+importedScope :: Maybe PackageId -> ModuleExports -> Module -> Scope
+importedScope packageId exports modu =
   List.foldl' addImport emptyScope (moduleImports modu)
   where
     addImport acc importDecl
@@ -381,7 +397,32 @@ importedScope exports modu =
       where
         originModule = importDeclModule importDecl
         qualifier = fromMaybe originModule (importDeclAs importDecl)
-        imported = filterImportSpec (importDeclSpec importDecl) (Map.findWithDefault emptyScope originModule exports)
+        imported = filterImportSpec (importDeclSpec importDecl) (lookupImportedModule packageId (importDeclPackage importDecl) originModule exports)
+
+lookupImportedModule :: Maybe PackageId -> Maybe Text -> Text -> ModuleExports -> Scope
+lookupImportedModule currentPackage requestedPackage moduleName' exports =
+  case matchingScopes of
+    [scope] -> scope
+    _ -> emptyScope
+  where
+    matchingScopes = matchingModuleScopes currentPackage requestedPackage moduleName' exports
+
+matchingModuleScopes :: Maybe PackageId -> Maybe Text -> Text -> ModuleExports -> [Scope]
+matchingModuleScopes currentPackage requestedPackage moduleName' exports =
+  [ scope
+  | (ModuleKey packageId name, scope) <- Map.toList exports,
+    name == moduleName',
+    packageMatches packageId
+  ]
+  where
+    packageMatches packageId = case requestedPackage of
+      Nothing -> True
+      Just "this" -> packageId == currentPackage
+      Just requested -> maybe False (packageIdMatches requested) packageId
+
+packageIdMatches :: Text -> PackageId -> Bool
+packageIdMatches requested (PackageId installed) =
+  requested == installed || requested `T.isPrefixOf` installed && T.isPrefixOf "-" (T.drop (T.length requested) installed)
 
 filterImportSpec :: Maybe ImportSpec -> Scope -> Scope
 filterImportSpec maybeSpec scope =
@@ -458,6 +499,7 @@ resolveQualifiedName scope lookupName qualifier name =
     Just qualifiedScope ->
       case lookupName (nameText name) qualifiedScope of
         ResolvedTopLevel resolved -> ResolvedTopLevel resolved
+        ResolvedPackageTopLevel packageId resolved -> ResolvedPackageTopLevel packageId resolved
         other -> other
 
 moduleKey :: Module -> Text

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -10,8 +9,7 @@ module Aihc.Resolve.Types
     pattern TResolution,
     ResolutionNamespace (..),
     PackageId (..),
-    parsePackageId,
-    renderPackageId,
+    Package (..),
     ResolvedName (..),
     ResolutionAnnotation (..),
     ResolveError (..),
@@ -33,35 +31,17 @@ import Aihc.Parser.Syntax
   )
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
-import Data.Text qualified as T
 
--- | An installed package identity, split at the unambiguous version and hash
--- suffix so package names may themselves contain dashes.
-data PackageId = PackageId
-  { packageIdName :: !Text,
-    packageIdVersion :: !Text,
-    packageIdHash :: !Text
-  }
+-- | An opaque identity for one installed package instance.
+newtype PackageId = PackageId {packageIdText :: Text}
   deriving (Eq, Ord, Show)
 
-parsePackageId :: Text -> Maybe PackageId
-parsePackageId raw =
-  case reverse (T.splitOn "-" raw) of
-    packageHash : version : reversedName
-      | not (T.null packageHash),
-        validVersion version,
-        not (null reversedName),
-        let packageName = T.intercalate "-" (reverse reversedName),
-        not (T.null packageName) ->
-          Just (PackageId packageName version packageHash)
-    _ -> Nothing
-  where
-    validVersion version =
-      all (\component -> not (T.null component) && T.all (`elem` ['0' .. '9']) component) (T.splitOn "." version)
-
-renderPackageId :: PackageId -> Text
-renderPackageId packageId =
-  T.intercalate "-" [packageIdName packageId, packageIdVersion packageId, packageIdHash packageId]
+-- | The user-visible package name used in imports and its opaque identity.
+data Package = Package
+  { packageName :: !Text,
+    packageId :: !PackageId
+  }
+  deriving (Eq, Ord, Show)
 
 data ResolvedName
   = ResolvedTopLevel Name

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -10,10 +11,13 @@ module Aihc.Resolve.Types
     ResolutionNamespace (..),
     PackageId (..),
     Package (..),
+    unnamedPackage,
+    modulesInPackage,
     ResolvedName (..),
     ResolutionAnnotation (..),
     ResolveError (..),
     ResolveResult (..),
+    resolvedModuleAsts,
   )
 where
 
@@ -43,9 +47,16 @@ data Package = Package
   }
   deriving (Eq, Ord, Show)
 
+unnamedPackage :: Package
+unnamedPackage = Package "" (PackageId "")
+
+modulesInPackage :: Package -> [Module] -> [(Package, Module)]
+modulesInPackage package = map pairWithPackage
+  where
+    pairWithPackage modu = (package, modu)
+
 data ResolvedName
-  = ResolvedTopLevel Name
-  | ResolvedPackageTopLevel PackageId Name
+  = ResolvedTopLevel PackageId Name
   | ResolvedLocal Int UnqualifiedName
   | ResolvedBuiltin Text
   | ResolvedError String
@@ -76,10 +87,13 @@ data ResolveError
   deriving (Eq, Show)
 
 data ResolveResult = ResolveResult
-  { resolvedModules :: [Module],
+  { resolvedModules :: [(Package, Module)],
     resolveErrors :: [ResolveError]
   }
   deriving (Show)
+
+resolvedModuleAsts :: ResolveResult -> [Module]
+resolvedModuleAsts = map snd . resolvedModules
 
 pattern DeclResolution :: ResolutionAnnotation -> Decl
 pattern DeclResolution resolution <- DeclAnn (fromAnnotation -> Just resolution) _

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -9,6 +10,8 @@ module Aihc.Resolve.Types
     pattern TResolution,
     ResolutionNamespace (..),
     PackageId (..),
+    parsePackageId,
+    renderPackageId,
     ResolvedName (..),
     ResolutionAnnotation (..),
     ResolveError (..),
@@ -30,11 +33,35 @@ import Aihc.Parser.Syntax
   )
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
+import Data.Text qualified as T
 
--- | An installed package identity.  The textual form is kept intact because
--- package hashes are compiler/package-manager specific.
-newtype PackageId = PackageId {renderPackageId :: Text}
+-- | An installed package identity, split at the unambiguous version and hash
+-- suffix so package names may themselves contain dashes.
+data PackageId = PackageId
+  { packageIdName :: !Text,
+    packageIdVersion :: !Text,
+    packageIdHash :: !Text
+  }
   deriving (Eq, Ord, Show)
+
+parsePackageId :: Text -> Maybe PackageId
+parsePackageId raw =
+  case reverse (T.splitOn "-" raw) of
+    packageHash : version : reversedName
+      | not (T.null packageHash),
+        validVersion version,
+        not (null reversedName),
+        let packageName = T.intercalate "-" (reverse reversedName),
+        not (T.null packageName) ->
+          Just (PackageId packageName version packageHash)
+    _ -> Nothing
+  where
+    validVersion version =
+      all (\component -> not (T.null component) && T.all (`elem` ['0' .. '9']) component) (T.splitOn "." version)
+
+renderPackageId :: PackageId -> Text
+renderPackageId packageId =
+  T.intercalate "-" [packageIdName packageId, packageIdVersion packageId, packageIdHash packageId]
 
 data ResolvedName
   = ResolvedTopLevel Name

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -8,6 +8,7 @@ module Aihc.Resolve.Types
     pattern PResolution,
     pattern TResolution,
     ResolutionNamespace (..),
+    PackageId (..),
     ResolvedName (..),
     ResolutionAnnotation (..),
     ResolveError (..),
@@ -30,8 +31,14 @@ import Aihc.Parser.Syntax
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
 
+-- | An installed package identity.  The textual form is kept intact because
+-- package hashes are compiler/package-manager specific.
+newtype PackageId = PackageId {renderPackageId :: Text}
+  deriving (Eq, Ord, Show)
+
 data ResolvedName
   = ResolvedTopLevel Name
+  | ResolvedPackageTopLevel PackageId Name
   | ResolvedLocal Int UnqualifiedName
   | ResolvedBuiltin Text
   | ResolvedError String

--- a/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-import-ambiguous.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-import-ambiguous.yaml
@@ -1,0 +1,34 @@
+extensions: [PackageImports]
+modules:
+  "app-1.0-main":
+    - |
+      module Main where
+      import "pkgA-1.0" Shared
+      result = value
+  "pkgA-1.0-abc":
+    - |
+      module Shared where
+      value = 10
+  "pkgA-1.0-def":
+    - |
+      module Shared where
+      value = 20
+annotated:
+  - |
+    module Main where
+    import "pkgA-1.0" Shared
+    └─ m Error ambiguous
+    result = value
+    │        └─ v Error unbound
+    └─ v app-1.0-main:Main
+  - |
+    module Shared where
+    value = 10
+    │       └─ v Error unbound
+    └─ v pkgA-1.0-abc:Shared
+  - |
+    module Shared where
+    value = 20
+    │       └─ v Error unbound
+    └─ v pkgA-1.0-def:Shared
+status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-import-ambiguous.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-import-ambiguous.yaml
@@ -1,19 +1,25 @@
 extensions: [PackageImports]
 modules:
   "app-1.0-main":
-    - |
-      module Main where
-      import "pkg-a" Shared
-      import qualified "pkg-a-1.0" Shared as Versioned
-      result = value
+    package: app
+    modules:
+      - |
+        module Main where
+        import "pkg-a" Shared
+        import qualified "pkg-a-1.0" Shared as Versioned
+        result = value
   "pkg-a-1.0-abc":
-    - |
-      module Shared where
-      value = 10
+    package: pkg-a
+    modules:
+      - |
+        module Shared where
+        value = 10
   "pkg-a-2.0-def":
-    - |
-      module Shared where
-      value = 20
+    package: pkg-a
+    modules:
+      - |
+        module Shared where
+        value = 20
 annotated:
   - |
     module Main where

--- a/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-import-ambiguous.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-import-ambiguous.yaml
@@ -3,21 +3,24 @@ modules:
   "app-1.0-main":
     - |
       module Main where
-      import "pkgA-1.0" Shared
+      import "pkg-a" Shared
+      import qualified "pkg-a-1.0" Shared as Versioned
       result = value
-  "pkgA-1.0-abc":
+  "pkg-a-1.0-abc":
     - |
       module Shared where
       value = 10
-  "pkgA-1.0-def":
+  "pkg-a-2.0-def":
     - |
       module Shared where
       value = 20
 annotated:
   - |
     module Main where
-    import "pkgA-1.0" Shared
+    import "pkg-a" Shared
     └─ m Error ambiguous
+    import qualified "pkg-a-1.0" Shared as Versioned
+    └─ m Error not found
     result = value
     │        └─ v Error unbound
     └─ v app-1.0-main:Main
@@ -25,10 +28,10 @@ annotated:
     module Shared where
     value = 10
     │       └─ v Error unbound
-    └─ v pkgA-1.0-abc:Shared
+    └─ v pkg-a-1.0-abc:Shared
   - |
     module Shared where
     value = 20
     │       └─ v Error unbound
-    └─ v pkgA-1.0-def:Shared
+    └─ v pkg-a-2.0-def:Shared
 status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-imports.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-imports.yaml
@@ -1,0 +1,39 @@
+extensions: [PackageImports]
+modules:
+  "app-1.0-main":
+    - |
+      module Main where
+      import qualified "pkgA-1.0" Shared as Old
+      import qualified "pkgA-1.1" Shared as New
+      old = Old.value
+      new = New.value
+  "pkgA-1.0-abc":
+    - |
+      module Shared where
+      value = 10
+  "pkgA-1.1-def":
+    - |
+      module Shared where
+      value = 11
+annotated:
+  - |
+    module Main where
+    import qualified "pkgA-1.0" Shared as Old
+    import qualified "pkgA-1.1" Shared as New
+    old = Old.value
+    │     └─ v pkgA-1.0-abc:Shared
+    └─ v app-1.0-main:Main
+    new = New.value
+    │     └─ v pkgA-1.1-def:Shared
+    └─ v app-1.0-main:Main
+  - |
+    module Shared where
+    value = 10
+    │       └─ v Error unbound
+    └─ v pkgA-1.0-abc:Shared
+  - |
+    module Shared where
+    value = 11
+    │       └─ v Error unbound
+    └─ v pkgA-1.1-def:Shared
+status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-imports.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-imports.yaml
@@ -3,37 +3,37 @@ modules:
   "app-1.0-main":
     - |
       module Main where
-      import qualified "pkgA-1.0" Shared as Old
-      import qualified "pkgA-1.1" Shared as New
-      old = Old.value
-      new = New.value
-  "pkgA-1.0-abc":
+      import qualified "pkg-a" Shared as A
+      import qualified "pkg-b" Shared as B
+      a = A.value
+      b = B.value
+  "pkg-a-1.0-abc":
     - |
       module Shared where
       value = 10
-  "pkgA-1.1-def":
+  "pkg-b-1.1-def":
     - |
       module Shared where
       value = 11
 annotated:
   - |
     module Main where
-    import qualified "pkgA-1.0" Shared as Old
-    import qualified "pkgA-1.1" Shared as New
-    old = Old.value
-    │     └─ v pkgA-1.0-abc:Shared
+    import qualified "pkg-a" Shared as A
+    import qualified "pkg-b" Shared as B
+    a = A.value
+    │   └─ v pkg-a-1.0-abc:Shared
     └─ v app-1.0-main:Main
-    new = New.value
-    │     └─ v pkgA-1.1-def:Shared
+    b = B.value
+    │   └─ v pkg-b-1.1-def:Shared
     └─ v app-1.0-main:Main
   - |
     module Shared where
     value = 10
     │       └─ v Error unbound
-    └─ v pkgA-1.0-abc:Shared
+    └─ v pkg-a-1.0-abc:Shared
   - |
     module Shared where
     value = 11
     │       └─ v Error unbound
-    └─ v pkgA-1.1-def:Shared
+    └─ v pkg-b-1.1-def:Shared
 status: pass

--- a/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-imports.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/package-qualified-imports.yaml
@@ -1,20 +1,26 @@
 extensions: [PackageImports]
 modules:
   "app-1.0-main":
-    - |
-      module Main where
-      import qualified "pkg-a" Shared as A
-      import qualified "pkg-b" Shared as B
-      a = A.value
-      b = B.value
+    package: app
+    modules:
+      - |
+        module Main where
+        import qualified "pkg-a" Shared as A
+        import qualified "pkg-b" Shared as B
+        a = A.value
+        b = B.value
   "pkg-a-1.0-abc":
-    - |
-      module Shared where
-      value = 10
+    package: pkg-a
+    modules:
+      - |
+        module Shared where
+        value = 10
   "pkg-b-1.1-def":
-    - |
-      module Shared where
-      value = 11
+    package: pkg-b
+    modules:
+      - |
+        module Shared where
+        value = 11
 annotated:
   - |
     module Main where

--- a/components/aihc-resolve/test/Test/Resolver/Suite.hs
+++ b/components/aihc-resolve/test/Test/Resolver/Suite.hs
@@ -7,7 +7,7 @@ module Test.Resolver.Suite
 where
 
 import Aihc.Parser (defaultConfig, parseModule)
-import Aihc.Resolve (ResolveResult (..), extractInterface, resolve, resolveWithDeps)
+import Aihc.Resolve (ResolveResult (..), extractInterface, resolveWithDeps, unnamedPackage)
 import Control.Monad (when)
 import Data.Text (Text)
 import qualified ResolverGolden as RG
@@ -25,8 +25,8 @@ testDependencyBackedGhcNum :: Assertion
 testDependencyBackedGhcNum =
   case (parse "GHC.Num" numSource, parse "Prelude" preludeSource) of
     (Right numModule, Right preludeModule) -> do
-      let dependencyResult = resolve [numModule]
-          result = resolveWithDeps (extractInterface dependencyResult) [preludeModule]
+      let dependencyResult = resolveWithDeps mempty [(unnamedPackage, numModule)]
+          result = resolveWithDeps (extractInterface dependencyResult) [(unnamedPackage, preludeModule)]
       case resolveErrors dependencyResult of
         [] ->
           case resolveErrors result of

--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -25,7 +25,7 @@ import Aihc.Parser.Syntax
   ( Extension,
     parseExtensionName,
   )
-import Aihc.Resolve (ResolveResult (..), resolve)
+import Aihc.Resolve (ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
 import Aihc.Tc (typecheck)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
@@ -135,9 +135,9 @@ evaluateTcAnnotatedCase tc =
    in case sequence parsedModules of
         Left errMsg -> classifyFailure tc ("parse error: " <> errMsg)
         Right modules ->
-          case resolve modules of
+          case resolveWithDeps mempty (modulesInPackage unnamedPackage modules) of
             ResolveResult {resolvedModules, resolveErrors = []} ->
-              let results = typecheck resolvedModules
+              let results = typecheck (map snd resolvedModules)
                   actual = renderAnnotatedTcResults (caseModules tc) results
                in classifySuccess tc actual
             ResolveResult {resolveErrors} ->

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -358,6 +358,8 @@ resolvedNameTermKey displayName resolved =
       pure (TcTermLocal unique)
     ResolvedTopLevel name ->
       pure (TcTermGlobal (nameText name))
+    ResolvedPackageTopLevel _ name ->
+      pure (TcTermGlobal (nameText name))
     ResolvedBuiltin name ->
       pure (TcTermGlobal name)
     ResolvedError msg ->

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -356,9 +356,7 @@ resolvedNameTermKey displayName resolved =
   case resolved of
     ResolvedLocal unique _ ->
       pure (TcTermLocal unique)
-    ResolvedTopLevel name ->
-      pure (TcTermGlobal (nameText name))
-    ResolvedPackageTopLevel _ name ->
+    ResolvedTopLevel _ name ->
       pure (TcTermGlobal (nameText name))
     ResolvedBuiltin name ->
       pure (TcTermGlobal name)

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -29,7 +29,8 @@ import Aihc.Parser.Syntax
     mkAnnotation,
     stripAnnotations,
   )
-import Aihc.Resolve (ResolveResult (..), extractInterface, resolve, resolveWithDeps)
+import Aihc.Resolve (ResolveResult (..), extractInterface, modulesInPackage, unnamedPackage)
+import Aihc.Resolve qualified as Resolve
 import Aihc.Tc
 import Aihc.Tc.Annotations (PendingTcAnnotation, TcClassAnnotation (..), TcClassMethodAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..), pendingAnnotation)
 import Aihc.Tc.Evidence (EvTerm (..))
@@ -128,7 +129,7 @@ hasResolveErrors input =
   let config = defaultConfig {parserSourceName = "<test>"}
       (errs, modu) = parseModule config input
    in null errs
-        && case resolve [modu] of
+        && case resolveModules [modu] of
           ResolveResult {resolveErrors} -> not (null resolveErrors)
 
 -- Helper to check that a type is a specific TyCon
@@ -231,7 +232,7 @@ dataFamilyTests :: [TestTree]
 dataFamilyTests =
   [ testCase "exports standalone data-family instances across module groups" $ do
       let providerResult =
-            resolve
+            resolveModules
               [ parseOnlyWithExtensions
                   [TypeFamilies]
                   "module Provider (Unit(..), Payload(..)) where\n\
@@ -242,7 +243,7 @@ dataFamilyTests =
           providerExports = extractInterface providerResult
       case providerResult of
         ResolveResult {resolvedModules = providerModules, resolveErrors = []} -> do
-          let (checkedProvider, interface) = typecheckModuleSccWithInterface mempty providerModules
+          let (checkedProvider, interface) = typecheckModuleSccWithInterface mempty (map snd providerModules)
           assertBool
             ("provider should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedProvider))
             (all tcModuleSuccess checkedProvider)
@@ -266,9 +267,9 @@ dataFamilyTests =
                   \import Provider\n\
                   \unwrap :: Payload Unit -> Unit\n\
                   \unwrap payload = case payload of PayloadValue value -> value\n"
-          case resolveWithDeps providerExports [consumer] of
+          case resolveModulesWithDeps providerExports [consumer] of
             ResolveResult {resolvedModules = consumerModules, resolveErrors = []} -> do
-              let (checkedConsumer, _) = typecheckModuleSccWithInterface interface consumerModules
+              let (checkedConsumer, _) = typecheckModuleSccWithInterface interface (map snd consumerModules)
               assertBool
                 ("consumer should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedConsumer))
                 (all tcModuleSuccess checkedConsumer)
@@ -357,9 +358,9 @@ kindTests =
             \data Product (f :: Type -> Type) (g :: Type -> Type) a = Pair (f a) (g a)\n\
             \instance (FunctorLike f, FunctorLike g) => FunctorLike (Product f g) where\n\
             \  mapLike function (Pair first second) = Pair (mapLike function first) (mapLike function second)\n"
-      case resolve [parseOnly source] of
+      case resolveModules [parseOnly source] of
         ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
-          let (checkedModules, interface) = typecheckModuleSccWithInterface mempty modules
+          let (checkedModules, interface) = typecheckModuleSccWithInterface mempty (map snd modules)
               instances = [info | info <- tcInterfaceInstances interface, iiClassName info == "FunctorLike"]
           assertBool
             ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules))
@@ -433,27 +434,27 @@ kindTests =
                 \fn = N\n"
       assertBool "module should typecheck" (tcModuleSuccess result),
     testCase "infers the kind of an imported class parameter" $ do
-      let baseResult = resolve [parseOnly "module Base (Monad) where\nclass Monad m where\n"]
+      let baseResult = resolveModules [parseOnly "module Base (Monad) where\nclass Monad m where\n"]
           depExports = extractInterface baseResult
           target = parseOnly "module Test where\nimport Base\nliftedId :: Monad m => m a -> m a\nliftedId x = x\n"
-          resolved = resolveWithDeps depExports [target]
+          resolved = resolveModulesWithDeps depExports [target]
       case resolved of
-        ResolveResult {resolvedModules = [modu], resolveErrors = []} -> do
+        ResolveResult {resolvedModules = [(_, modu)], resolveErrors = []} -> do
           let result = typecheckModule modu
           assertBool ("module should typecheck, got: " <> show (tcModuleDiagnostics result)) (tcModuleSuccess result)
         ResolveResult {resolveErrors} ->
           assertFailure ("Resolve error in imported-class kind test: " <> show resolveErrors),
     testCase "uses imported type constructor arities" $ do
-      let baseResult = resolve [parseOnly "module Base (Box) where\ndata Box a = Box a\n"]
+      let baseResult = resolveModules [parseOnly "module Base (Box) where\ndata Box a = Box a\n"]
           depExports = extractInterface baseResult
       case baseResult of
         ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
-          let (checkedBase, _, importedTyCons) = typecheckModulesWithFullEnv [] [] [] baseModules
+          let (checkedBase, _, importedTyCons) = typecheckModulesWithFullEnv [] [] [] (map snd baseModules)
           assertBool "dependency should typecheck" (all tcModuleSuccess checkedBase)
           let target = parseOnly "module Test where\nimport Base\ndata Unit = Unit\nkeep :: Box Unit -> Box Unit\nkeep x = x\n"
-          case resolveWithDeps depExports [target] of
+          case resolveModulesWithDeps depExports [target] of
             ResolveResult {resolvedModules = targetModules, resolveErrors = []} -> do
-              let (checkedTarget, _, _) = typecheckModulesWithFullEnv [] importedTyCons [] targetModules
+              let (checkedTarget, _, _) = typecheckModulesWithFullEnv [] importedTyCons [] (map snd targetModules)
               assertBool
                 ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedTarget))
                 (all tcModuleSuccess checkedTarget)
@@ -463,7 +464,7 @@ kindTests =
           assertFailure ("Resolve error in dependency-type test: " <> show resolveErrors),
     testCase "transports a complete semantic interface between module groups" $ do
       let baseResult =
-            resolve
+            resolveModules
               [ parseOnly
                   "module Base (Unit(..), Identity(..)) where\n\
                   \data Unit = Unit\n\
@@ -475,7 +476,7 @@ kindTests =
           depExports = extractInterface baseResult
       case baseResult of
         ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
-          let (checkedBase, interface) = typecheckModuleSccWithInterface mempty baseModules
+          let (checkedBase, interface) = typecheckModuleSccWithInterface mempty (map snd baseModules)
           assertBool "dependency should typecheck" (all tcModuleSuccess checkedBase)
           assertBool "constructor term exported" ("Unit" `elem` map fst (tcInterfaceTerms interface))
           assertBool "method term exported" ("identity" `elem` map fst (tcInterfaceTerms interface))
@@ -483,9 +484,9 @@ kindTests =
           assertBool "class exported" ("Identity" `elem` map ciName (tcInterfaceClasses interface))
           assertBool "instance exported" ("$fIdentityUnit" `elem` map iiDictName (tcInterfaceInstances interface))
           let target = parseOnly "module Test where\nimport Base\nanswer :: Unit\nanswer = identity Unit\n"
-          case resolveWithDeps depExports [target] of
+          case resolveModulesWithDeps depExports [target] of
             ResolveResult {resolvedModules = targetModules, resolveErrors = []} -> do
-              let (checkedTarget, _) = typecheckModuleSccWithInterface interface targetModules
+              let (checkedTarget, _) = typecheckModuleSccWithInterface interface (map snd targetModules)
               assertBool
                 ("consumer should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedTarget))
                 (all tcModuleSuccess checkedTarget)
@@ -644,7 +645,7 @@ annotationTests =
       assertBool "superclass evidence is checked in TC" (not (all (null . tcDerivingSuperClasses) plans)),
     testCase "deriving plans consume checked datatype metadata across interfaces" $ do
       let baseResult =
-            resolve
+            resolveModules
               [ parseOnlyWithExtensions
                   [ExistentialQuantification]
                   "{-# LANGUAGE ExistentialQuantification #-}\n\
@@ -659,7 +660,7 @@ annotationTests =
           dependencyExports = extractInterface baseResult
       case baseResult of
         ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
-          let (checkedBase, interface) = typecheckModuleSccWithInterface mempty baseModules
+          let (checkedBase, interface) = typecheckModuleSccWithInterface mempty (map snd baseModules)
           assertBool ("provider should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedBase)) (all tcModuleSuccess checkedBase)
           assertBool "record selectors are emitted as term bindings" (all (`elem` concatMap (map tbName . tcModuleBindings) checkedBase) ["left", "right"])
           assertBool "record selectors are exported through T(..)" (all (`elem` map fst (tcInterfaceTerms interface)) ["left", "right"])
@@ -694,9 +695,9 @@ annotationTests =
                       \deriving anyclass instance Marker (T a)\n\
                       \select :: T a -> a\n\
                       \select = left\n"
-              case resolveWithDeps dependencyExports [target] of
+              case resolveModulesWithDeps dependencyExports [target] of
                 ResolveResult {resolvedModules = targetModules, resolveErrors = []} -> do
-                  let (checkedTarget, _) = typecheckModuleSccWithInterface interface targetModules
+                  let (checkedTarget, _) = typecheckModuleSccWithInterface interface (map snd targetModules)
                   assertBool ("consumer should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedTarget)) (all tcModuleSuccess checkedTarget)
                   case concatMap derivingPlans checkedTarget of
                     [plan] -> assertEqual "imported constructor layout reaches deriving plan" (Just dataType) (tcDerivingDataType plan)
@@ -871,12 +872,18 @@ parseM = parseMWithExtensions []
 
 parseMWithExtensions :: [Extension] -> Text -> Module
 parseMWithExtensions extensions input =
-  case resolve [parseOnlyWithExtensions extensions input] of
-    ResolveResult {resolvedModules = [resolved], resolveErrors = []} -> resolved
+  case resolveModules [parseOnlyWithExtensions extensions input] of
+    ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} -> resolved
     ResolveResult {resolveErrors} -> error ("Resolve error in test: " ++ show resolveErrors)
 
 parseOnly :: Text -> Module
 parseOnly = parseOnlyWithExtensions []
+
+resolveModules :: [Module] -> ResolveResult
+resolveModules = resolveModulesWithDeps mempty
+
+resolveModulesWithDeps :: Resolve.ModuleExports -> [Module] -> ResolveResult
+resolveModulesWithDeps depExports = Resolve.resolveWithDeps depExports . modulesInPackage unnamedPackage
 
 parseOnlyWithExtensions :: [Extension] -> Text -> Module
 parseOnlyWithExtensions extensions input =

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -37,7 +37,7 @@ import Aihc.Parser.Syntax
     mkUnqualifiedName,
     parseExtensionName,
   )
-import Aihc.Resolve (ResolveResult (..), resolveWithDeps)
+import Aihc.Resolve (ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, TcInterface (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception (bracket, mask, onException)
@@ -220,14 +220,15 @@ compileEvalCase tc =
       case dependencyModules of
         Left errMsg -> pure (Left errMsg)
         Right deps ->
-          let resolved = resolveWithDeps mempty (deps <> evalModules)
+          let resolved = resolveWithDeps mempty (modulesInPackage unnamedPackage (deps <> evalModules))
            in case resolved of
                 ResolveResult {resolvedModules, resolveErrors = []} ->
-                  let (tcResults, tcInterface) = typecheckModulesWithInterface emptyTcInterface resolvedModules
+                  let moduleAsts = map snd resolvedModules
+                      (tcResults, tcInterface) = typecheckModulesWithInterface emptyTcInterface moduleAsts
                    in if all tcModuleSuccess tcResults
                         then do
                           let allBindings = moduleGroupBindings tcResults
-                              results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults resolvedModules
+                              results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
                           if all dsSuccess results
                             then pure (Right (concatPrograms (map dsProgram results)))
                             else pure (Left ("desugar error: " <> unlines (concatMap dsErrors results)))

--- a/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
@@ -30,7 +30,7 @@ module BootInterface
 where
 
 import Aihc.Parser.Syntax (NameType (..), mkUnqualifiedName, qualifyName)
-import Aihc.Resolve (ModuleExports, ResolvedName (..), Scope (..))
+import Aihc.Resolve (ModuleExports, ModuleKey (..), ResolvedName (..), Scope (..))
 import Control.Exception (IOException, try)
 import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
 import Data.Aeson qualified as Aeson
@@ -155,7 +155,7 @@ instance FromJSON BootModuleInterface where
 bootIfaceToModuleExports :: BootPackageInterface -> ModuleExports
 bootIfaceToModuleExports bpi =
   Map.fromList
-    [(bmiModule bmi, bootModuleToScope bmi) | bmi <- bpiModules bpi]
+    [(ModuleKey Nothing (bmiModule bmi), bootModuleToScope bmi) | bmi <- bpiModules bpi]
 
 -- | Convert a single module interface to a Scope.
 bootModuleToScope :: BootModuleInterface -> Scope

--- a/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/BootInterface.hs
@@ -30,7 +30,7 @@ module BootInterface
 where
 
 import Aihc.Parser.Syntax (NameType (..), mkUnqualifiedName, qualifyName)
-import Aihc.Resolve (ModuleExports, ModuleKey (..), ResolvedName (..), Scope (..))
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), ResolvedName (..), Scope (..), unnamedPackage)
 import Control.Exception (IOException, try)
 import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
 import Data.Aeson qualified as Aeson
@@ -155,7 +155,7 @@ instance FromJSON BootModuleInterface where
 bootIfaceToModuleExports :: BootPackageInterface -> ModuleExports
 bootIfaceToModuleExports bpi =
   Map.fromList
-    [(ModuleKey Nothing (bmiModule bmi), bootModuleToScope bmi) | bmi <- bpiModules bpi]
+    [(ModuleKey unnamedPackage (bmiModule bmi), bootModuleToScope bmi) | bmi <- bpiModules bpi]
 
 -- | Convert a single module interface to a Scope.
 bootModuleToScope :: BootModuleInterface -> Scope
@@ -189,7 +189,7 @@ bootModuleToScope bmi =
 
     resolve :: Text -> Text -> ResolvedName
     resolve qual n =
-      ResolvedTopLevel (qualifyName (Just qual) (mkUnqualifiedName (inferNameType n) n))
+      ResolvedTopLevel (packageId unnamedPackage) (qualifyName (Just qual) (mkUnqualifiedName (inferNameType n) n))
 
 -- | Infer the NameType from a name's lexical form.
 inferNameType :: Text -> NameType

--- a/tooling/aihc-dev/app/resolve-stackage-progress/ResolvePackage.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/ResolvePackage.hs
@@ -20,7 +20,7 @@ where
 
 import Aihc.Hackage.Stackage (loadStackageSnapshot)
 import Aihc.Hackage.Types (PackageSpec (..))
-import Aihc.Resolve (ModuleExports, Scope (..))
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Scope (..))
 import BootInterface (bootPackageNames, loadBootInterfaces)
 import Control.Exception (SomeException, try)
 import Data.Aeson (ToJSON (..), object, (.=))
@@ -130,7 +130,7 @@ interfaceFromExports :: Text -> ModuleExports -> ResolvePackageIface
 interfaceFromExports pkg iface =
   ResolvePackageIface
     { rpiPackage = pkg,
-      rpiModules = map (uncurry moduleIfaceFromScope) (Map.toAscList iface)
+      rpiModules = map (\(key, scope) -> moduleIfaceFromScope (moduleKeyName key) scope) (Map.toAscList iface)
     }
 
 moduleIfaceFromScope :: Text -> Scope -> ResolveModuleIface

--- a/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
+++ b/tooling/aihc-dev/app/resolve-stackage-progress/ResolveStackageProgress.hs
@@ -42,7 +42,7 @@ import Aihc.Parser.Syntax
     parseLanguageEdition,
   )
 import Aihc.Parser.Token (readModuleHeaderPragmas)
-import Aihc.Resolve (ModuleExports, ResolveError (..), ResolveResult (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, Package (..), PackageId (..), ResolveError (..), ResolveResult (..), extractInterface, modulesInPackage, resolveWithDeps)
 import BootInterface (bootPackageNames, loadBootInterfaces)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
@@ -292,7 +292,7 @@ resolveOnePackage offline pkg info depExports = do
     Right status -> status
 
 resolveOnePackageOrThrow :: Bool -> Text -> PackageInfo -> ModuleExports -> IO PackageStatus
-resolveOnePackageOrThrow _offline _pkg info depExports = do
+resolveOnePackageOrThrow _offline pkg info depExports = do
   let rawFiles = piFiles info
   if null rawFiles
     then pure (PkgSuccess depExports)
@@ -304,7 +304,7 @@ resolveOnePackageOrThrow _offline _pkg info depExports = do
         [] -> do
           let modules = map fst pairs
               srcTexts = Map.fromList [(path, src) | (_, (path, src)) <- pairs]
-              resolveResult = resolveWithDeps depExports modules
+              resolveResult = resolveWithDeps depExports (modulesInPackage (Package pkg (PackageId pkg)) modules)
           case resolveErrors resolveResult of
             [] -> pure (PkgSuccess (extractInterface resolveResult))
             resolveErrs -> pure (PkgFailed (unlines (map (renderResolveError srcTexts) resolveErrs)))

--- a/tooling/aihc-dev/test/Test/ResolvePackage.hs
+++ b/tooling/aihc-dev/test/Test/ResolvePackage.hs
@@ -6,7 +6,7 @@ module Test.ResolvePackage
 where
 
 import Aihc.Parser.Syntax (NameType (..), mkUnqualifiedName, qualifyName)
-import Aihc.Resolve (ModuleKey (..), ResolvedName (..), Scope (..))
+import Aihc.Resolve (ModuleKey (..), Package (..), ResolvedName (..), Scope (..), unnamedPackage)
 import Data.ByteString.Lazy.Char8 qualified as BL8
 import Data.List (isInfixOf)
 import Data.Map.Strict qualified as Map
@@ -71,8 +71,8 @@ test_renderInterfaceJSON = do
         interfaceFromExports
           "demo"
           ( Map.fromList
-              [ (ModuleKey Nothing "Z", mkScope ["zterm"] ["Zed"]),
-                (ModuleKey Nothing "A", (mkScope ["beta", "alpha"] ["Thing"]) {scopeConstructors = Map.singleton "Thing" ["MkThing"], scopeMethods = Map.singleton "Classy" ["method"]})
+              [ (ModuleKey unnamedPackage "Z", mkScope ["zterm"] ["Zed"]),
+                (ModuleKey unnamedPackage "A", (mkScope ["beta", "alpha"] ["Thing"]) {scopeConstructors = Map.singleton "Thing" ["MkThing"], scopeMethods = Map.singleton "Classy" ["method"]})
               ]
           )
       rendered = BL8.unpack (renderInterfaceJSON iface)
@@ -122,4 +122,4 @@ mkScope terms types =
     }
   where
     resolve name =
-      ResolvedTopLevel (qualifyName (Just "M") (mkUnqualifiedName NameVarId name))
+      ResolvedTopLevel (packageId unnamedPackage) (qualifyName (Just "M") (mkUnqualifiedName NameVarId name))

--- a/tooling/aihc-dev/test/Test/ResolvePackage.hs
+++ b/tooling/aihc-dev/test/Test/ResolvePackage.hs
@@ -6,7 +6,7 @@ module Test.ResolvePackage
 where
 
 import Aihc.Parser.Syntax (NameType (..), mkUnqualifiedName, qualifyName)
-import Aihc.Resolve (ResolvedName (..), Scope (..))
+import Aihc.Resolve (ModuleKey (..), ResolvedName (..), Scope (..))
 import Data.ByteString.Lazy.Char8 qualified as BL8
 import Data.List (isInfixOf)
 import Data.Map.Strict qualified as Map
@@ -71,8 +71,8 @@ test_renderInterfaceJSON = do
         interfaceFromExports
           "demo"
           ( Map.fromList
-              [ ("Z", mkScope ["zterm"] ["Zed"]),
-                ("A", (mkScope ["beta", "alpha"] ["Thing"]) {scopeConstructors = Map.singleton "Thing" ["MkThing"], scopeMethods = Map.singleton "Classy" ["method"]})
+              [ (ModuleKey Nothing "Z", mkScope ["zterm"] ["Zed"]),
+                (ModuleKey Nothing "A", (mkScope ["beta", "alpha"] ["Thing"]) {scopeConstructors = Map.singleton "Thing" ["MkThing"], scopeMethods = Map.singleton "Classy" ["method"]})
               ]
           )
       rendered = BL8.unpack (renderInterfaceJSON iface)

--- a/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
+++ b/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
@@ -13,7 +13,7 @@ import Aihc.Parser.Syntax
     qualifyName,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
 import Control.Exception (bracket)
 import Data.Aeson (Value, encode, object, (.=))
 import Data.ByteString qualified as BS
@@ -58,8 +58,8 @@ test_extractsInterfaceForGeneratedPathsPackage =
     written <- BL.readFile ifaceFile
     assertBool "expected interface JSON to be written" (not (BL.null written))
 
-    assertBool "expected user module in interface" (Map.member "PathsUser" iface)
-    case Map.lookup "Paths_paths_demo" iface of
+    assertBool "expected user module in interface" (Map.member (ModuleKey Nothing "PathsUser") iface)
+    case Map.lookup (ModuleKey Nothing "Paths_paths_demo") iface of
       Nothing -> assertFailure "expected generated Paths module in interface"
       Just pathsScope -> do
         assertBool "expected version export" (Map.member "version" (scopeTerms pathsScope))
@@ -88,15 +88,16 @@ parseFileInfo packageRoot info = do
 
 baseExports :: ModuleExports
 baseExports =
-  Map.fromList
-    [ ("GHC.Classes", mkScope "GHC.Classes" ["=="] []),
-      ("GHC.Num", mkScope "GHC.Num" ["fromInteger"] []),
-      ("Prelude", mkScope "Prelude" ["return", "++", "==", "otherwise", "fromInteger"] ["IO", "FilePath", "String", "Char", "Bool"]),
-      ("Control.Exception", mkScope "Control.Exception" ["catch"] ["IOException"]),
-      ("Data.List", mkScope "Data.List" ["last"] []),
-      ("Data.Version", mkScope "Data.Version" ["Version"] ["Version"]),
-      ("System.Environment", mkScope "System.Environment" ["getEnv"] [])
-    ]
+  Map.mapKeys (ModuleKey Nothing) $
+    Map.fromList
+      [ ("GHC.Classes", mkScope "GHC.Classes" ["=="] []),
+        ("GHC.Num", mkScope "GHC.Num" ["fromInteger"] []),
+        ("Prelude", mkScope "Prelude" ["return", "++", "==", "otherwise", "fromInteger"] ["IO", "FilePath", "String", "Char", "Bool"]),
+        ("Control.Exception", mkScope "Control.Exception" ["catch"] ["IOException"]),
+        ("Data.List", mkScope "Data.List" ["last"] []),
+        ("Data.Version", mkScope "Data.Version" ["Version"] ["Version"]),
+        ("System.Environment", mkScope "System.Environment" ["getEnv"] [])
+      ]
 
 mkScope :: Text -> [Text] -> [Text] -> Scope
 mkScope moduleName terms types =
@@ -128,11 +129,11 @@ interfaceJson iface =
   object
     [ "modules"
         .= [ object
-               [ "module" .= moduleName,
+               [ "module" .= moduleKeyName moduleKey,
                  "terms" .= Map.keys (scopeTerms scope),
                  "types" .= Map.keys (scopeTypes scope)
                ]
-           | (moduleName, scope) <- Map.toList iface
+           | (moduleKey, scope) <- Map.toList iface
            ]
     ]
 

--- a/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
+++ b/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
@@ -13,7 +13,7 @@ import Aihc.Parser.Syntax
     qualifyName,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ModuleKey (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, modulesInPackage, resolveWithDeps, unnamedPackage)
 import Control.Exception (bracket)
 import Data.Aeson (Value, encode, object, (.=))
 import Data.ByteString qualified as BS
@@ -50,7 +50,7 @@ test_extractsInterfaceForGeneratedPathsPackage =
 
     files <- findTargetFiles root
     modules <- mapM (parseFileInfo root) files
-    let result = resolveWithDeps baseExports modules
+    let result = resolveWithDeps baseExports (modulesInPackage unnamedPackage modules)
     assertEqual "expected generated Paths package to resolve cleanly" [] (resolveErrors result)
 
     let iface = extractInterface result
@@ -58,8 +58,8 @@ test_extractsInterfaceForGeneratedPathsPackage =
     written <- BL.readFile ifaceFile
     assertBool "expected interface JSON to be written" (not (BL.null written))
 
-    assertBool "expected user module in interface" (Map.member (ModuleKey Nothing "PathsUser") iface)
-    case Map.lookup (ModuleKey Nothing "Paths_paths_demo") iface of
+    assertBool "expected user module in interface" (Map.member (ModuleKey unnamedPackage "PathsUser") iface)
+    case Map.lookup (ModuleKey unnamedPackage "Paths_paths_demo") iface of
       Nothing -> assertFailure "expected generated Paths module in interface"
       Just pathsScope -> do
         assertBool "expected version export" (Map.member "version" (scopeTerms pathsScope))
@@ -88,7 +88,7 @@ parseFileInfo packageRoot info = do
 
 baseExports :: ModuleExports
 baseExports =
-  Map.mapKeys (ModuleKey Nothing) $
+  Map.mapKeys (ModuleKey unnamedPackage) $
     Map.fromList
       [ ("GHC.Classes", mkScope "GHC.Classes" ["=="] []),
         ("GHC.Num", mkScope "GHC.Num" ["fromInteger"] []),
@@ -112,7 +112,7 @@ mkScope moduleName terms types =
     }
   where
     resolve name =
-      ResolvedTopLevel (qualifyName (Just moduleName) (mkUnqualifiedName (inferNameType name) name))
+      ResolvedTopLevel (packageId unnamedPackage) (qualifyName (Just moduleName) (mkUnqualifiedName (inferNameType name) name))
 
 inferNameType :: Text -> NameType
 inferNameType name =


### PR DESCRIPTION
## Summary

- extend resolver golden fixtures so `modules` may map installed package IDs to module source lists while preserving the existing flat list for single-package tests
- key resolver exports by package identity and module name, and retain the defining package in resolved top-level identifiers
- model the user-visible package name separately from its opaque package identity string
- require every resolver input, output, export key, and top-level symbol to carry package ownership; existing single-package callers use an explicit unnamed package
- resolve package-qualified imports by exact user-visible package name only
- diagnose imports as ambiguous when multiple opaque package identities have the requested package name
- expose `resolveWithDeps` as the single resolver entrypoint
- update resolver consumers for the richer module key and resolved-name representation

## Why

`ModuleExports` was keyed only by module name, so two packages exporting the same module overwrote or clashed with one another. The resolver also had no package identity to use when interpreting the parser's package qualifier.

## Impact

Duplicate module names can coexist across packages. Package-qualified imports select an exact user-visible package name, including names containing dashes. An import fails explicitly when more than one package identity is registered under that name. The resolver treats identity strings such as `network-1.0-blah` as opaque values and does not parse their contents.

Package ownership is mandatory throughout the resolver. `ResolvedTopLevel` always carries a package identity, and `ResolveResult` retains `(Package, Module)` pairs. The former `resolve` and `resolvePackages` entrypoints have been removed.

Resolver progress increases by 2 passing golden fixtures. README progress counts are intentionally unchanged because they are maintained by the scheduled workflow.

## Validation

- `just fmt`
- `just check`
- `git diff --check`
