### PR TITLE
fix(grin): normalize nested binds before CPS

### DIFF
--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -17,6 +17,7 @@ flag fuzz
 library
   exposed-modules:
     Aihc.Grin
+    Aihc.Grin.Anf
     Aihc.Grin.Cps
     Aihc.Grin.Gc
     Aihc.Grin.Interpret

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -1,6 +1,8 @@
 -- | AIHC's strict Graph Reduction Intermediate Notation dialect.
 module Aihc.Grin
   ( module Aihc.Grin.Syntax,
+    normalizeGrinProgram,
+    normalizeGrinExpr,
     CpsGrinProgram,
     CpsGrinError (..),
     ContinuationFrameKind (..),
@@ -49,6 +51,7 @@ module Aihc.Grin
   )
 where
 
+import Aihc.Grin.Anf (normalizeGrinExpr, normalizeGrinProgram)
 import Aihc.Grin.Cps
   ( ContinuationFrameKind (..),
     CpsGrinError (..),

--- a/components/aihc-grin/src/Aihc/Grin/Anf.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Anf.hs
@@ -1,0 +1,63 @@
+-- | Administrative-normal-form normalization for GRIN.
+--
+-- GRIN binds may syntactically contain another bind as their value expression.
+-- Reassociate such binds so that sequencing is represented by one flat spine:
+--
+-- @
+-- x <- (y <- value; inner)
+-- body
+-- @
+--
+-- becomes:
+--
+-- @
+-- y <- value
+-- x <- inner
+-- body
+-- @
+--
+-- 'GrinVar' uniques make the harmless scope extension of @y@ unambiguous.
+module Aihc.Grin.Anf
+  ( normalizeGrinProgram,
+    normalizeGrinExpr,
+  )
+where
+
+import Aihc.Grin.Syntax
+
+-- | Normalize every function body in a GRIN program.
+normalizeGrinProgram :: GrinProgram -> GrinProgram
+normalizeGrinProgram program =
+  program
+    { grinFunctions = map normalizeFunction (grinFunctions program)
+    }
+  where
+    normalizeFunction function =
+      function {grinFunctionBody = normalizeGrinExpr (grinFunctionBody function)}
+
+-- | Reassociate nested binds into a flat sequencing spine.
+--
+-- Case alternatives and recursive-allocation bodies form their own spines and
+-- are normalized recursively. Cases are deliberately not distributed through
+-- binds: doing so would duplicate the bind body.
+normalizeGrinExpr :: GrinExpr -> GrinExpr
+normalizeGrinExpr expression = normalizeInto expression id
+  where
+    -- Passing the enclosing spine as a function reassociates every bind in
+    -- linear time. Repeatedly peeling an already-normalized value expression
+    -- would make deeply nested constructor applications quadratic.
+    normalizeInto current continue =
+      case current of
+        GrinBind resultVars valueExpression body ->
+          normalizeInto valueExpression $ \normalizedValue ->
+            GrinBind resultVars normalizedValue (normalizeInto body continue)
+        GrinStoreRec bindings body ->
+          continue (GrinStoreRec bindings (normalizeInto body id))
+        GrinStoreRecUnchecked bindings body ->
+          continue (GrinStoreRecUnchecked bindings (normalizeInto body id))
+        GrinCase scrutinee binder alternatives ->
+          continue (GrinCase scrutinee binder (map normalizeAlternative alternatives))
+        _ -> continue current
+
+    normalizeAlternative alternative =
+      alternative {grinAltRhs = normalizeGrinExpr (grinAltRhs alternative)}

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -21,6 +21,7 @@ module Aihc.Grin.Cps
 where
 
 import Aihc.Grin.Analysis (freeExprVars)
+import Aihc.Grin.Anf (normalizeGrinProgram)
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types (RuntimeRep (..), liftedRuntimeRep)
 import Control.Monad.Trans.Class (lift)
@@ -83,7 +84,7 @@ data CpsState = CpsState
 type CpsM = StateT CpsState (Either CpsGrinError)
 
 toCpsGrin :: GrinProgram -> Either CpsGrinError CpsGrinProgram
-toCpsGrin program = do
+toCpsGrin sourceProgram = do
   ((functions, updateFunction), finalState) <- runStateT transform initialState
   let continuationFrames =
         Map.insert (grinFunctionName updateFunction) ContinuationFrameUpdate (cpsContinuationFramesState finalState)
@@ -103,6 +104,7 @@ toCpsGrin program = do
         cpsUpdateFunction = grinFunctionName updateFunction
       }
   where
+    program = normalizeGrinProgram sourceProgram
     sourceFunctions = grinFunctions program
     initialState =
       CpsState

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -20,6 +20,7 @@ import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Grin.Analysis (freeExprVars)
+import Aihc.Grin.Anf (normalizeGrinProgram)
 import Aihc.Grin.Syntax
 import Aihc.Tc.Types
   ( RuntimeRep (..),
@@ -274,16 +275,17 @@ programEnvironment interface =
 
 lowerProgramWithEnvironment :: GrinLinkNames -> GrinInterface -> GrinInterface -> ProgramEnvironment -> FcProgram -> GrinProgram
 lowerProgramWithEnvironment linkNames imported local environment program =
-  GrinProgram
-    { grinConstructors = loweredConstructors tops,
-      grinPrimitives = loweredPrimitives tops,
-      grinForeignCalls = loweredForeignCalls tops,
-      grinExternalGlobals = Set.toAscList (lowerReferencedExternalGlobalNames finalState),
-      grinExternalFunctions = externalCodeInfos,
-      grinWhnfGlobals = loweredWhnfGlobals tops,
-      grinCafs = loweredCafs tops,
-      grinFunctions = reverse (lowerFunctionsRev finalState)
-    }
+  normalizeGrinProgram
+    GrinProgram
+      { grinConstructors = loweredConstructors tops,
+        grinPrimitives = loweredPrimitives tops,
+        grinForeignCalls = loweredForeignCalls tops,
+        grinExternalGlobals = Set.toAscList (lowerReferencedExternalGlobalNames finalState),
+        grinExternalFunctions = externalCodeInfos,
+        grinWhnfGlobals = loweredWhnfGlobals tops,
+        grinCafs = loweredCafs tops,
+        grinFunctions = reverse (lowerFunctionsRev finalState)
+      }
   where
     initialState =
       LowerState

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -147,6 +147,27 @@ grinUnitTests =
         assertEqual "lint" [] (lintProgram program)
         assertBool "primitive wrapper contains explicit catch" ("catch " `isInfixOf` rendered)
         assertEqual "catch# is represented by GRIN control nodes" [] (grinPrimitives program),
+      testCase "GRIN ANF normalization reassociates nested binds" $ do
+        let normalized = normalizeGrinProgram nestedDirectBindProgram
+        assertBool "source contains a nested bind" (programHasNestedBind nestedDirectBindProgram)
+        assertBool "normalized program has a flat bind spine" (not (programHasNestedBind normalized))
+        assertEqual "normalization is idempotent" normalized (normalizeGrinProgram normalized),
+      testCase "GRIN ANF normalization preserves nested-bind semantics" $ do
+        original <- interpretProgramFunctionSnapshot nestedDirectBindEntry nestedDirectBindProgram
+        normalized <- interpretProgramFunctionSnapshot nestedDirectBindEntry (normalizeGrinProgram nestedDirectBindProgram)
+        assertEqual "normalized result" original normalized,
+      testCase "CPS-GRIN does not reify continuations for nested direct binds" $ do
+        cps <- expectCpsGrin nestedDirectBindProgram
+        assertEqual
+          "normal continuations"
+          Set.empty
+          (cpsContinuationFunctions cps `Set.difference` Set.singleton (cpsUpdateFunction cps)),
+      testCase "CPS-GRIN retains transfers found inside nested binds" $ do
+        cps <- expectCpsGrin nestedCallBindProgram
+        assertEqual
+          "one call continuation"
+          1
+          (Set.size (cpsContinuationFunctions cps `Set.difference` Set.singleton (cpsUpdateFunction cps))),
       testCase "CPS-GRIN allocates and applies ordinary continuation closures" $ do
         cps <- expectCpsGrin callBindProgram
         let program = cpsGrinProgram cps
@@ -671,6 +692,20 @@ expressionStoredNodes expression =
     GrinStoreRecUnchecked bindings body -> map snd bindings <> expressionStoredNodes body
     GrinCase _ _ alternatives -> concatMap (expressionStoredNodes . grinAltRhs) alternatives
     _ -> []
+
+programHasNestedBind :: GrinProgram -> Bool
+programHasNestedBind = any (hasNestedBind . grinFunctionBody) . grinFunctions
+
+hasNestedBind :: GrinExpr -> Bool
+hasNestedBind expression =
+  case expression of
+    GrinBind _ (GrinBind {}) _ -> True
+    GrinBind _ valueExpression body ->
+      hasNestedBind valueExpression || hasNestedBind body
+    GrinStoreRec _ body -> hasNestedBind body
+    GrinStoreRecUnchecked _ body -> hasNestedBind body
+    GrinCase _ _ alternatives -> any (hasNestedBind . grinAltRhs) alternatives
+    _ -> False
 
 updateContinuationNodes :: FunctionName -> GrinProgram -> [(FunctionName, GrinNode)]
 updateContinuationNodes updateName program =
@@ -1737,6 +1772,75 @@ directBindProgram =
           grinAltBinders = [],
           grinAltRhs = GrinConstant [GrinVarValue pointer]
         }
+
+nestedDirectBindEntry :: FunctionName
+nestedDirectBindEntry = FunctionName "nested_direct_bind"
+
+nestedDirectBindProgram :: GrinProgram
+nestedDirectBindProgram =
+  emptyGrinProgram
+    { grinConstructors = [("Box", [[IntRep]])],
+      grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = nestedDirectBindEntry,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [outer]
+                  ( GrinBind
+                      [middle]
+                      ( GrinBind
+                          [inner]
+                          (GrinStore box)
+                          (GrinConstant [GrinVarValue inner])
+                      )
+                      (GrinConstant [GrinVarValue middle])
+                  )
+                  (GrinConstant [GrinVarValue outer])
+            }
+        ]
+    }
+  where
+    inner = GrinVar "inner" 220 (BoxedRep Lifted)
+    middle = GrinVar "middle" 221 (BoxedRep Lifted)
+    outer = GrinVar "outer" 222 (BoxedRep Lifted)
+    box = GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)]
+
+nestedCallBindProgram :: GrinProgram
+nestedCallBindProgram =
+  nestedDirectBindProgram
+    { grinFunctions =
+        [ GrinFunction
+            { grinFunctionName = nestedDirectBindEntry,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody =
+                GrinBind
+                  [outer]
+                  ( GrinBind
+                      [inner]
+                      (GrinCall (BoxedRep Lifted) callee [])
+                      (GrinConstant [GrinVarValue inner])
+                  )
+                  (GrinConstant [GrinVarValue outer])
+            },
+          GrinFunction
+            { grinFunctionName = callee,
+              grinFunctionLinkName = Nothing,
+              grinFunctionParameters = [],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinStore box
+            }
+        ]
+    }
+  where
+    callee = FunctionName "nested_call_callee"
+    inner = GrinVar "inner" 223 (BoxedRep Lifted)
+    outer = GrinVar "outer" 224 (BoxedRep Lifted)
+    box = GrinNode (GrinConstructor "Box" 0) [GrinLitValue (GrinLitInt IntRep 1)]
 
 gcRootProgram :: GrinProgram
 gcRootProgram =

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -4,11 +4,11 @@ expected: |-
   caf value%1007 :: BoxedRep Lifted = (Fvalue_thunk)
 
   value_thunk -> BoxedRep Lifted =
+    $grin__case_value_0_1009%1009 :: IntRep, $grin__case_value_1_1010%1010 :: WordRep <-
+      constant (1 :: IntRep) (2 :: WordRep)
+    $grin_tuple_1011%1011 :: IntRep, $grin_tuple_1012%1012 :: WordRep <-
+      constant ($grin__case_value_0_1009%1009 :: IntRep) ($grin__case_value_1_1010%1010 :: WordRep)
     $grin_argument_1008%1008 :: IntRep <-
-      $grin__case_value_0_1009%1009 :: IntRep, $grin__case_value_1_1010%1010 :: WordRep <-
-        constant (1 :: IntRep) (2 :: WordRep)
-      $grin_tuple_1011%1011 :: IntRep, $grin_tuple_1012%1012 :: WordRep <-
-        constant ($grin__case_value_0_1009%1009 :: IntRep) ($grin__case_value_1_1010%1010 :: WordRep)
       constant ($grin_tuple_1011%1011 :: IntRep)
     store (CBox ($grin_argument_1008%1008 :: IntRep))
 extensions:


### PR DESCRIPTION
## Summary

- add a linear-time GRIN ANF normalization pass that reassociates nested bind value expressions into flat sequencing spines
- normalize FC-lowered GRIN and defensively normalize arbitrary GRIN at the CPS boundary
- preserve genuine transfer points while avoiding continuation closures for nested direct operations
- refresh the unboxed-tuple GRIN golden to its canonical flat form

## Root cause

Argument lowering can place a complete `GrinBind` computation in another bind's value-expression position. The CPS pass classifies direct operations locally, so the compound value expression was treated as potentially transferring even when its entire spine contained only stores. This reified one heap continuation per nesting level.

## Impact

Nested constructor construction is emitted in canonical ANF before CPS. Direct allocation spines no longer allocate artificial continuation closures or trigger their downstream GC reservations. Calls and other real transfer operations still receive continuations.

## Progress

- GRIN suite: 4 focused unit cases added (205 to 209 total tests)
- README progress counts unchanged; they remain cron-managed

## Validation

- `just fmt`
- `cabal test -v0 aihc-grin:spec --test-options=--hide-successes`
- `just check`