### PR TITLE
refactor(native): describe runtime primitive calls

### DIFF
--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen/Function.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen/Function.hs
@@ -13,6 +13,7 @@ import Aihc.Grin.Syntax
 import Aihc.Native
   ( NativeCpsCall (..),
     NativeCpsTransfer (..),
+    NativeRuntimeCall (..),
     nativeCpsPrimitiveCall,
     nativeRuntimePrimitiveCall,
   )
@@ -327,43 +328,6 @@ compileDirectBinding env vars expression =
     GrinFetch _ pointer -> liftEither (materializeValue env pointer) >>= storeSingleResult
     GrinUpdate pointer value -> compileUpdateBinding False "aihc_update" pointer value
     GrinUpdateBlackhole pointer value -> compileUpdateBinding True "aihc_update_blackhole" pointer value
-    GrinPrimitiveCall _ "newArray#" arguments@[_, _] -> do
-      (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-      case argumentSlots of
-        [sizeSlot, initialSlot] ->
-          storeSingleResult
-            ( argumentLines
-                <> [ "  mov rdi, r15",
-                     loadAt "rsi" "r14" sizeSlot,
-                     loadAt "rdx" "r14" initialSlot,
-                     "  call aihc_array_new"
-                   ]
-            )
-        _ -> lift (Left (Amd64UnsupportedExpression "boxed-array allocation arity"))
-    GrinPrimitiveCall _ "newMutVar#" arguments@[_] -> do
-      (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-      case argumentSlots of
-        [initialSlot] ->
-          storeSingleResult
-            ( argumentLines
-                <> [ "  mov rdi, r15",
-                     loadAt "rsi" "r14" initialSlot,
-                     "  call aihc_mutvar_new"
-                   ]
-            )
-        _ -> lift (Left (Amd64UnsupportedExpression "mutable-reference allocation arity"))
-    GrinPrimitiveCall _ "makeStableName#" arguments@[_] -> do
-      (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-      case argumentSlots of
-        [valueSlot] ->
-          storeSingleResult
-            ( argumentLines
-                <> [ "  mov rdi, r15",
-                     loadAt "rsi" "r14" valueSlot,
-                     "  call aihc_stable_name_make"
-                   ]
-            )
-        _ -> lift (Left (Amd64UnsupportedExpression "stable-name allocation arity"))
     GrinPrimitiveCall _ name [left, right]
       | Just instructions <- lookup name singleResultBinaryPrimitives ->
           compileBinary "r10" "rax" storeSingleResult instructions left right
@@ -412,11 +376,11 @@ compileDirectBinding env vars expression =
           valueLines <- liftEither (materializeValue env value)
           storeSingleResult (valueLines <> instructions)
     GrinPrimitiveCall _ name arguments
-      | Just foreignCall <- nativeRuntimePrimitiveCall name -> do
-          callLines <- compileForeignCallLines env foreignCall arguments
-          case vars of
-            [] -> pure callLines
-            [_] -> storeSingleResult callLines
+      | Just runtimeCall <- nativeRuntimePrimitiveCall name -> do
+          callLines <- compileRuntimeCallLines env runtimeCall arguments
+          case nativeRuntimeCallResultCount runtimeCall of
+            0 | null vars -> pure callLines
+            1 -> storeSingleResult callLines
             _ -> lift (Left (Amd64UnsupportedExpression ("runtime primitive result arity " <> name)))
       | compileAllowUnsupportedPrimitives (valueCompileEnv env) ->
           pure ["  call aihc_unsupported_primitive"]
@@ -507,9 +471,17 @@ compileDirectBinding env vars expression =
       )
 
 compileForeignCallLines :: ValueEnv -> GrinForeignCall -> [GrinValue] -> FunctionM [Text]
-compileForeignCallLines env foreignCall arguments = do
+compileForeignCallLines env = compileCallLines env False
+
+compileRuntimeCallLines :: ValueEnv -> NativeRuntimeCall -> [GrinValue] -> FunctionM [Text]
+compileRuntimeCallLines env runtimeCall =
+  compileCallLines env (nativeRuntimeCallPassMachine runtimeCall) (nativeRuntimeCallForeignCall runtimeCall)
+
+compileCallLines :: ValueEnv -> Bool -> GrinForeignCall -> [GrinValue] -> FunctionM [Text]
+compileCallLines env passMachine foreignCall arguments = do
   let signature = grinForeignCallSignature foreignCall
-      abiArity = length (grinForeignArgumentTypes signature)
+      operandArity = length (grinForeignArgumentTypes signature)
+      abiArity = operandArity + fromEnum passMachine
       expectedArity = length (grinForeignOperandReps signature)
   if length arguments /= expectedArity
     then lift (Left (Amd64UnsupportedExpression "foreign call arity mismatch"))
@@ -518,13 +490,14 @@ compileForeignCallLines env foreignCall arguments = do
         then lift (Left (Amd64UnsupportedExpression "foreign calls with more than six arguments"))
         else do
           (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-          let abiSlots = take abiArity argumentSlots
+          let argumentRegisters = drop (fromEnum passMachine) foreignArgumentRegisters
               loadAbiArguments =
                 [ loadAt register "r14" slot
-                | (register, slot) <- zip foreignArgumentRegisters abiSlots
+                | (register, slot) <- zip argumentRegisters argumentSlots
                 ]
               callLines =
                 argumentLines
+                  <> ["  mov rdi, r15" | passMachine]
                   <> loadAbiArguments
                   <> ["  call " <> grinForeignCallSymbol foreignCall]
                   <> normalizeForeignResult (grinForeignResultType signature)

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen/Function.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen/Function.hs
@@ -13,6 +13,7 @@ import Aihc.Grin.Syntax
 import Aihc.Native
   ( NativeCpsCall (..),
     NativeCpsTransfer (..),
+    NativeRuntimeCall (..),
     nativeCpsPrimitiveCall,
     nativeRuntimePrimitiveCall,
   )
@@ -320,43 +321,6 @@ compileDirectBinding env vars expression =
     GrinFetch _ pointer -> liftEither (materializeValue env pointer) >>= storeSingleResult
     GrinUpdate pointer value -> compileUpdateBinding False "_aihc_update" pointer value
     GrinUpdateBlackhole pointer value -> compileUpdateBinding True "_aihc_update_blackhole" pointer value
-    GrinPrimitiveCall _ "newArray#" arguments@[_, _] -> do
-      (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-      case argumentSlots of
-        [sizeSlot, initialSlot] ->
-          storeSingleResult
-            ( argumentLines
-                <> [ "  mov x0, x22",
-                     loadAt "x1" "x19" sizeSlot,
-                     loadAt "x2" "x19" initialSlot,
-                     "  bl _aihc_array_new"
-                   ]
-            )
-        _ -> lift (Left (Arm64UnsupportedExpression "boxed-array allocation arity"))
-    GrinPrimitiveCall _ "newMutVar#" arguments@[_] -> do
-      (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-      case argumentSlots of
-        [initialSlot] ->
-          storeSingleResult
-            ( argumentLines
-                <> [ "  mov x0, x22",
-                     loadAt "x1" "x19" initialSlot,
-                     "  bl _aihc_mutvar_new"
-                   ]
-            )
-        _ -> lift (Left (Arm64UnsupportedExpression "mutable-reference allocation arity"))
-    GrinPrimitiveCall _ "makeStableName#" arguments@[_] -> do
-      (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-      case argumentSlots of
-        [valueSlot] ->
-          storeSingleResult
-            ( argumentLines
-                <> [ "  mov x0, x22",
-                     loadAt "x1" "x19" valueSlot,
-                     "  bl _aihc_stable_name_make"
-                   ]
-            )
-        _ -> lift (Left (Arm64UnsupportedExpression "stable-name allocation arity"))
     GrinPrimitiveCall _ name [left, right]
       | Just instructions <- lookup name singleResultBinaryPrimitives ->
           compileBinary storeSingleResult instructions left right
@@ -419,11 +383,11 @@ compileDirectBinding env vars expression =
           valueLines <- liftEither (materializeValue env value)
           storeSingleResult (valueLines <> instructions)
     GrinPrimitiveCall _ name arguments
-      | Just foreignCall <- nativeRuntimePrimitiveCall name -> do
-          callLines <- compileForeignCallLines env foreignCall arguments
-          case vars of
-            [] -> pure callLines
-            [_] -> storeSingleResult callLines
+      | Just runtimeCall <- nativeRuntimePrimitiveCall name -> do
+          callLines <- compileRuntimeCallLines env runtimeCall arguments
+          case nativeRuntimeCallResultCount runtimeCall of
+            0 | null vars -> pure callLines
+            1 -> storeSingleResult callLines
             _ -> lift (Left (Arm64UnsupportedExpression ("runtime primitive result arity " <> name)))
       | compileAllowUnsupportedPrimitives (valueCompileEnv env) ->
           pure ["  bl _aihc_unsupported_primitive"]
@@ -513,9 +477,17 @@ compileDirectBinding env vars expression =
       )
 
 compileForeignCallLines :: ValueEnv -> GrinForeignCall -> [GrinValue] -> FunctionM [Text]
-compileForeignCallLines env foreignCall arguments = do
+compileForeignCallLines env = compileCallLines env False
+
+compileRuntimeCallLines :: ValueEnv -> NativeRuntimeCall -> [GrinValue] -> FunctionM [Text]
+compileRuntimeCallLines env runtimeCall =
+  compileCallLines env (nativeRuntimeCallPassMachine runtimeCall) (nativeRuntimeCallForeignCall runtimeCall)
+
+compileCallLines :: ValueEnv -> Bool -> GrinForeignCall -> [GrinValue] -> FunctionM [Text]
+compileCallLines env passMachine foreignCall arguments = do
   let signature = grinForeignCallSignature foreignCall
-      abiArity = length (grinForeignArgumentTypes signature)
+      operandArity = length (grinForeignArgumentTypes signature)
+      abiArity = operandArity + fromEnum passMachine
       expectedArity = length (grinForeignOperandReps signature)
   if length arguments /= expectedArity
     then lift (Left (Arm64UnsupportedExpression "foreign call arity mismatch"))
@@ -524,13 +496,14 @@ compileForeignCallLines env foreignCall arguments = do
         then lift (Left (Arm64UnsupportedExpression "foreign calls with more than eight arguments"))
         else do
           (argumentLines, argumentSlots) <- materializeIntoFreshSlots env arguments
-          let abiSlots = take abiArity argumentSlots
+          let argumentRegisters = drop (fromEnum passMachine) ["x" <> tshow index | index <- [0 :: Int .. 7]]
               loadAbiArguments =
-                [ loadAt ("x" <> tshow index) "x19" slot
-                | (index, slot) <- zip [0 :: Int ..] abiSlots
+                [ loadAt register "x19" slot
+                | (register, slot) <- zip argumentRegisters argumentSlots
                 ]
               callLines =
                 argumentLines
+                  <> ["  mov x0, x22" | passMachine]
                   <> loadAbiArguments
                   <> ["  bl _" <> grinForeignCallSymbol foreignCall]
                   <> normalizeForeignResult (grinForeignResultType signature)

--- a/components/aihc-llvm/src/Aihc/Llvm/Codegen.hs
+++ b/components/aihc-llvm/src/Aihc/Llvm/Codegen.hs
@@ -22,6 +22,7 @@ import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunction
 import Aihc.Grin.Syntax
 import Aihc.Native
   ( LinkLayout (..),
+    NativeRuntimeCall (..),
     buildAddrLiteralPool,
     buildLinkLayout,
     nativeRuntimePrimitiveCall,
@@ -845,8 +846,8 @@ compileDirectBinding env vars expression =
     GrinPrimitiveCall runtimeRep "realWorld#" []
       | null vars && null (runtimeRepComponents runtimeRep) -> pure []
     GrinPrimitiveCall _ name arguments
-      | Just foreignCall <- nativeRuntimePrimitiveCall name -> do
-          result <- compileForeignCall env foreignCall arguments
+      | Just runtimeCall <- nativeRuntimePrimitiveCall name -> do
+          result <- compileForeignCall env (nativeRuntimeCallForeignCall runtimeCall) arguments
           case vars of
             [] -> pure (fst result)
             [_] -> storeOne result
@@ -1656,22 +1657,22 @@ renderForeignDeclarations program =
       <> " @"
       <> grinForeignCallSymbol foreignCall
       <> "("
-      <> T.intercalate ", " (map llvmForeignType (grinForeignArgumentTypes signature))
+      <> T.intercalate ", " (["ptr" | passMachine] <> map llvmForeignType (grinForeignArgumentTypes signature))
       <> ")"
-  | foreignCall <- foreignCalls,
+  | (passMachine, foreignCall) <- foreignCalls,
     let signature = grinForeignCallSignature foreignCall
   ]
     <> ["" | not (null foreignCalls)]
   where
     foreignCalls =
       Map.elems . Map.fromList $
-        [ (grinForeignCallSymbol foreignCall, foreignCall)
-        | foreignCall <- grinForeignCalls program <> runtimePrimitiveCalls
+        [ (grinForeignCallSymbol foreignCall, call)
+        | call@(_, foreignCall) <- [(False, programForeignCall) | programForeignCall <- grinForeignCalls program] <> runtimePrimitiveCalls
         ]
     runtimePrimitiveCalls =
-      [ foreignCall
+      [ (nativeRuntimeCallPassMachine runtimeCall, nativeRuntimeCallForeignCall runtimeCall)
       | primitive <- supportedNativePrimitiveNames,
-        Just foreignCall <- [nativeRuntimePrimitiveCall primitive]
+        Just runtimeCall <- [nativeRuntimePrimitiveCall primitive]
       ]
 
 renderExternalFunctionDeclarations :: CompileEnv -> GrinProgram -> [Text]
@@ -1715,9 +1716,6 @@ renderRuntimeDeclarations =
     "declare ptr @aihc_make_node(ptr, ptr)",
     "declare ptr @aihc_make_node_unchecked(ptr, ptr)",
     "declare void @aihc_ensure_heap(ptr, i64, i64, ptr)",
-    "declare ptr @aihc_array_new(ptr, i64, i64)",
-    "declare ptr @aihc_mutvar_new(ptr, i64)",
-    "declare ptr @aihc_stable_name_make(ptr, ptr)",
     "declare void @aihc_set_field(ptr, i64, i64)",
     "declare void @aihc_update(ptr, ptr)",
     "declare void @aihc_update_blackhole(ptr, ptr, ptr)",

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -4,6 +4,7 @@
 module Aihc.Native
   ( NativeCpsCall (..),
     NativeCpsTransfer (..),
+    NativeRuntimeCall (..),
     NativeTarget (..),
     RuntimeGarbageCollector (..),
     RuntimePlan (..),
@@ -245,9 +246,6 @@ supportedNativePrimitiveNames =
     "gtWord#",
     "geWord#",
     "realWorld#",
-    "newMutVar#",
-    "makeStableName#",
-    "newArray#",
     "unsafeFreezeArray#",
     "unsafeThawArray#",
     "unsafeFreezeByteArray#",
@@ -268,6 +266,17 @@ data NativeCpsCall = NativeCpsCall
     nativeCpsCallOperandCount :: !Int,
     nativeCpsCallPassContinuation :: !Bool,
     nativeCpsCallTransfer :: !NativeCpsTransfer
+  }
+  deriving (Eq, Show)
+
+-- | Architecture-neutral native ABI description for a direct runtime
+-- primitive. The machine is an implicit runtime argument rather than a GRIN
+-- operand, and the result count describes the logical GRIN result independently
+-- of the C function's return type.
+data NativeRuntimeCall = NativeRuntimeCall
+  { nativeRuntimeCallForeignCall :: !GrinForeignCall,
+    nativeRuntimeCallPassMachine :: !Bool,
+    nativeRuntimeCallResultCount :: !Int
   }
   deriving (Eq, Show)
 
@@ -292,13 +301,16 @@ nativeCpsPrimitiveCalls =
 
 -- | Runtime calls shared by native backends. Representation-preserving
 -- primitives such as freeze and thaw deliberately have no entry here.
-nativeRuntimePrimitiveCall :: Text -> Maybe GrinForeignCall
+nativeRuntimePrimitiveCall :: Text -> Maybe NativeRuntimeCall
 nativeRuntimePrimitiveCall name = lookup name nativeRuntimePrimitiveCalls
 
-nativeRuntimePrimitiveCalls :: [(Text, GrinForeignCall)]
+nativeRuntimePrimitiveCalls :: [(Text, NativeRuntimeCall)]
 nativeRuntimePrimitiveCalls =
-  [ call "readMutVar#" "aihc_mutvar_read" [GrinForeignAddr] GrinForeignWord64,
-    call "writeMutVar#" "aihc_mutvar_write" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
+  [ machineCall "newArray#" "aihc_array_new" [GrinForeignWord64, GrinForeignWord64] GrinForeignAddr,
+    machineCall "newMutVar#" "aihc_mutvar_new" [GrinForeignWord64] GrinForeignAddr,
+    machineCall "makeStableName#" "aihc_stable_name_make" [GrinForeignAddr] GrinForeignAddr,
+    call "readMutVar#" "aihc_mutvar_read" [GrinForeignAddr] GrinForeignWord64,
+    procedure "writeMutVar#" "aihc_mutvar_write" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
     call "aihcCasMutVarFlag" "aihc_mutvar_compare_and_swap" [GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
     call "sameMutVar#" "aihc_mutvar_same" [GrinForeignAddr, GrinForeignAddr] GrinForeignWord64,
     call "eqStableName#" "aihc_stable_name_equal" [GrinForeignAddr, GrinForeignAddr] GrinForeignWord64,
@@ -308,7 +320,7 @@ nativeRuntimePrimitiveCalls =
     call "indexWord64OffAddr#" "aihc_addr_index_word64" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
     call "indexArray#" "aihc_array_index" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
     call "readArray#" "aihc_array_index" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
-    call "writeArray#" "aihc_array_write" [GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
+    procedure "writeArray#" "aihc_array_write" [GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
     call "sameMutableArray#" "aihc_array_same" [GrinForeignAddr, GrinForeignAddr] GrinForeignWord64,
     call "newByteArray#" "aihc_byte_array_new" [GrinForeignWord64] GrinForeignAddr,
     call "newPinnedByteArray#" "aihc_byte_array_new_pinned" [GrinForeignWord64] GrinForeignAddr,
@@ -317,31 +329,39 @@ nativeRuntimePrimitiveCalls =
     call "isByteArrayPinned#" "aihc_byte_array_is_pinned" [GrinForeignAddr] GrinForeignWord64,
     call "byteArrayContents#" "aihc_byte_array_contents" [GrinForeignAddr] GrinForeignAddr,
     call "mutableByteArrayContents#" "aihc_byte_array_contents" [GrinForeignAddr] GrinForeignAddr,
-    call "shrinkMutableByteArray#" "aihc_byte_array_shrink" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
+    procedure "shrinkMutableByteArray#" "aihc_byte_array_shrink" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
     call "resizeMutableByteArray#" "aihc_byte_array_resize" [GrinForeignAddr, GrinForeignWord64] GrinForeignAddr,
     call "sizeofByteArray#" "aihc_byte_array_get_size" [GrinForeignAddr] GrinForeignWord64,
     call "getSizeofMutableByteArray#" "aihc_byte_array_get_size" [GrinForeignAddr] GrinForeignWord64,
-    call "copyAddrToByteArray#" "aihc_byte_array_copy_from_addr" [GrinForeignAddr, GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
+    procedure "copyAddrToByteArray#" "aihc_byte_array_copy_from_addr" [GrinForeignAddr, GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
     call "indexWordArray#" "aihc_byte_array_index_word" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
     call "readWordArray#" "aihc_byte_array_read_word" [GrinForeignAddr, GrinForeignWord64] GrinForeignWord64,
-    call "writeWordArray#" "aihc_byte_array_write_word" [GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
-    call "copyByteArray#" "aihc_byte_array_copy" [GrinForeignAddr, GrinForeignWord64, GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
+    procedure "writeWordArray#" "aihc_byte_array_write_word" [GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
+    procedure "copyByteArray#" "aihc_byte_array_copy" [GrinForeignAddr, GrinForeignWord64, GrinForeignAddr, GrinForeignWord64, GrinForeignWord64] GrinForeignWord64,
     call "clz#" "aihc_word_clz" [GrinForeignWord64] GrinForeignWord64,
     call "ctz#" "aihc_word_ctz" [GrinForeignWord64] GrinForeignWord64,
     call "popCnt#" "aihc_word_popcount" [GrinForeignWord64] GrinForeignWord64
   ]
   where
-    call primitive symbol arguments result =
+    call = runtimeCall False 1
+    procedure = runtimeCall False 0
+    machineCall = runtimeCall True 1
+    runtimeCall passMachine resultCount primitive symbol arguments result =
       ( primitive,
-        GrinForeignCall
-          { grinForeignCallName = "$runtime$" <> symbol,
-            grinForeignCallSymbol = symbol,
-            grinForeignCallSignature =
-              GrinForeignSignature
-                { grinForeignArgumentTypes = arguments,
-                  grinForeignResultType = result,
-                  grinForeignEffect = GrinForeignPure
-                }
+        NativeRuntimeCall
+          { nativeRuntimeCallForeignCall =
+              GrinForeignCall
+                { grinForeignCallName = "$runtime$" <> symbol,
+                  grinForeignCallSymbol = symbol,
+                  grinForeignCallSignature =
+                    GrinForeignSignature
+                      { grinForeignArgumentTypes = arguments,
+                        grinForeignResultType = result,
+                        grinForeignEffect = GrinForeignPure
+                      }
+                },
+            nativeRuntimeCallPassMachine = passMachine,
+            nativeRuntimeCallResultCount = resultCount
           }
       )
 

--- a/components/aihc-native/test/Test/Native/Primitive.hs
+++ b/components/aihc-native/test/Test/Native/Primitive.hs
@@ -5,7 +5,7 @@ module Test.Native.Primitive
   )
 where
 
-import Aihc.Grin.Syntax (GrinForeignType (..), grinForeignArgumentTypes, grinForeignCallSignature, grinForeignCallSymbol)
+import Aihc.Grin.Syntax (grinForeignCallSymbol)
 import Aihc.Native
   ( NativeCpsCall (..),
     NativeCpsTransfer (..),
@@ -100,18 +100,6 @@ tests =
                 (nativeCpsPrimitiveCall primitive)
           )
           cpsRuntimeCalls,
-      testCase "describes allocating primitive runtime signatures" $
-        mapM_
-          ( \(primitive, symbol, operands) ->
-              assertEqual
-                ("allocating runtime call for " <> show primitive)
-                (Just (symbol, operands, True, 1))
-                (runtimeCallDescription <$> nativeRuntimePrimitiveCall primitive)
-          )
-          [ ("newArray#", "aihc_array_new", [GrinForeignWord64, GrinForeignWord64]),
-            ("newMutVar#", "aihc_mutvar_new", [GrinForeignWord64]),
-            ("makeStableName#", "aihc_stable_name_make", [GrinForeignAddr])
-          ],
       testCase "accepts the Prelude Int# primitive API in native programs" $
         mapM_
           (\primitive -> assertEqual ("native support for " <> show primitive) True (primitive `elem` supportedNativePrimitiveNames))
@@ -120,14 +108,6 @@ tests =
 
 runtimeCallSymbol :: NativeRuntimeCall -> Text
 runtimeCallSymbol = grinForeignCallSymbol . nativeRuntimeCallForeignCall
-
-runtimeCallDescription :: NativeRuntimeCall -> (Text, [GrinForeignType], Bool, Int)
-runtimeCallDescription runtimeCall =
-  ( runtimeCallSymbol runtimeCall,
-    grinForeignArgumentTypes (grinForeignCallSignature (nativeRuntimeCallForeignCall runtimeCall)),
-    nativeRuntimeCallPassMachine runtimeCall,
-    nativeRuntimeCallResultCount runtimeCall
-  )
 
 byteArrayRuntimeSymbols :: [(Text, Text)]
 byteArrayRuntimeSymbols =

--- a/components/aihc-native/test/Test/Native/Primitive.hs
+++ b/components/aihc-native/test/Test/Native/Primitive.hs
@@ -5,10 +5,11 @@ module Test.Native.Primitive
   )
 where
 
-import Aihc.Grin.Syntax (grinForeignCallSymbol)
+import Aihc.Grin.Syntax (GrinForeignType (..), grinForeignArgumentTypes, grinForeignCallSignature, grinForeignCallSymbol)
 import Aihc.Native
   ( NativeCpsCall (..),
     NativeCpsTransfer (..),
+    NativeRuntimeCall (..),
     nativeCpsPrimitiveCall,
     nativeRuntimePrimitiveCall,
     supportedNativePrimitiveNames,
@@ -27,7 +28,7 @@ tests =
               assertEqual
                 ("runtime call for " <> show primitive)
                 (Just symbol)
-                (grinForeignCallSymbol <$> nativeRuntimePrimitiveCall primitive)
+                (runtimeCallSymbol <$> nativeRuntimePrimitiveCall primitive)
           )
           byteArrayRuntimeSymbols,
       testCase "maps address indexing primitives to the shared runtime ABI" $
@@ -36,7 +37,7 @@ tests =
               assertEqual
                 ("runtime call for " <> show primitive)
                 (Just symbol)
-                (grinForeignCallSymbol <$> nativeRuntimePrimitiveCall primitive)
+                (runtimeCallSymbol <$> nativeRuntimePrimitiveCall primitive)
           )
           addressIndexRuntimeSymbols,
       testCase "maps boxed-array primitives to the shared runtime ABI" $
@@ -45,7 +46,7 @@ tests =
               assertEqual
                 ("runtime call for " <> show primitive)
                 (Just symbol)
-                (grinForeignCallSymbol <$> nativeRuntimePrimitiveCall primitive)
+                (runtimeCallSymbol <$> nativeRuntimePrimitiveCall primitive)
           )
           arrayRuntimeSymbols,
       testCase "maps mutable-reference primitives to the shared runtime ABI" $
@@ -54,7 +55,7 @@ tests =
               assertEqual
                 ("runtime call for " <> show primitive)
                 (Just symbol)
-                (grinForeignCallSymbol <$> nativeRuntimePrimitiveCall primitive)
+                (runtimeCallSymbol <$> nativeRuntimePrimitiveCall primitive)
           )
           mutVarRuntimeSymbols,
       testCase "maps stable-name primitives to the shared runtime ABI" $
@@ -63,7 +64,7 @@ tests =
               assertEqual
                 ("runtime call for " <> show primitive)
                 (Just symbol)
-                (grinForeignCallSymbol <$> nativeRuntimePrimitiveCall primitive)
+                (runtimeCallSymbol <$> nativeRuntimePrimitiveCall primitive)
           )
           stableNameRuntimeSymbols,
       testCase "keeps freeze and thaw representation-preserving" $
@@ -99,11 +100,34 @@ tests =
                 (nativeCpsPrimitiveCall primitive)
           )
           cpsRuntimeCalls,
+      testCase "describes allocating primitive runtime signatures" $
+        mapM_
+          ( \(primitive, symbol, operands) ->
+              assertEqual
+                ("allocating runtime call for " <> show primitive)
+                (Just (symbol, operands, True, 1))
+                (runtimeCallDescription <$> nativeRuntimePrimitiveCall primitive)
+          )
+          [ ("newArray#", "aihc_array_new", [GrinForeignWord64, GrinForeignWord64]),
+            ("newMutVar#", "aihc_mutvar_new", [GrinForeignWord64]),
+            ("makeStableName#", "aihc_stable_name_make", [GrinForeignAddr])
+          ],
       testCase "accepts the Prelude Int# primitive API in native programs" $
         mapM_
           (\primitive -> assertEqual ("native support for " <> show primitive) True (primitive `elem` supportedNativePrimitiveNames))
           ["+#", "-#", "*#", "compareInt#", "<#", "==#", "ord#", "chr#"]
     ]
+
+runtimeCallSymbol :: NativeRuntimeCall -> Text
+runtimeCallSymbol = grinForeignCallSymbol . nativeRuntimeCallForeignCall
+
+runtimeCallDescription :: NativeRuntimeCall -> (Text, [GrinForeignType], Bool, Int)
+runtimeCallDescription runtimeCall =
+  ( runtimeCallSymbol runtimeCall,
+    grinForeignArgumentTypes (grinForeignCallSignature (nativeRuntimeCallForeignCall runtimeCall)),
+    nativeRuntimeCallPassMachine runtimeCall,
+    nativeRuntimeCallResultCount runtimeCall
+  )
 
 byteArrayRuntimeSymbols :: [(Text, Text)]
 byteArrayRuntimeSymbols =

--- a/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
+++ b/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
@@ -17,7 +17,7 @@ where
 import Aihc.Grin.Cps (ContinuationFrameKind (..), continuationFrameKindCode)
 import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcGrinProgram, gcUpdateFunction)
 import Aihc.Grin.Syntax
-import Aihc.Native (LinkLayout (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, renderLinkedFunctionSymbol, supportedNativePrimitiveNames)
+import Aihc.Native (LinkLayout (..), NativeRuntimeCall (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, renderLinkedFunctionSymbol, supportedNativePrimitiveNames)
 import Aihc.Tc.Types (Levity (..), RuntimeRep (..))
 import Control.Monad (forM)
 import Data.ByteString qualified as BS
@@ -612,8 +612,8 @@ compileDirectBinding env vars expression =
             <> ["i64.extend_i32_u"]
         )
     GrinPrimitiveCall _ name arguments
-      | Just foreignCall <- nativeRuntimePrimitiveCall name -> do
-          instructions <- compileForeignCall env foreignCall arguments
+      | Just runtimeCall <- nativeRuntimePrimitiveCall name -> do
+          instructions <- compileForeignCall env (nativeRuntimeCallForeignCall runtimeCall) arguments
           case vars of
             [] -> pure (instructions <> ["drop"])
             [_] -> storeSingle instructions


### PR DESCRIPTION
## Summary

- add an architecture-neutral `NativeRuntimeCall` descriptor for direct runtime primitives
- describe operand types, logical result count, and the implicit machine argument in the shared native primitive table
- lower `newArray#`, `newMutVar#`, and `makeStableName#` through the generic ARM64 and AMD64 runtime-call path
- derive LLVM runtime declarations from the same descriptor and retain the existing LLVM/Wasm lowering behavior

## Why

ARM64 and AMD64 repeated the same materialize/load/call/store sequence for every allocating runtime primitive. The shared descriptor makes those calls declarative and keeps backend code responsible only for rendering its ABI.

New calls such as a one-operand, one-result allocation can now be added to the shared table without adding architecture-specific lowering branches.

## Impact

Generated calling conventions are unchanged. Runtime primitives that logically return no GRIN values now declare that explicitly instead of relying on the number of binders at each call site.

Progress counts are unchanged.

## Validation

- `cabal test -v0 aihc-native --test-options=--hide-successes`
- `cabal test -v0 aihc-arm64 --test-options=--hide-successes`
- `cabal test -v0 aihc-amd64 --test-options=--hide-successes`
- `just fmt`
- `just check`
