### PR TITLE
fix(fc): simplify pattern failure continuations

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -26,7 +26,7 @@ where
 
 import Aihc.Fc.Desugar.Match (dsPatternPure, numericRuntimeRep)
 import Aihc.Fc.Lower (seqPseudoOpName)
-import Aihc.Fc.Subst (substExprVar, substType)
+import Aihc.Fc.Subst (OccurrenceCount (..), countExprVar, substExpr, substExprVar, substType)
 import Aihc.Fc.Syntax
 import Aihc.Parser.Syntax
   ( CaseAlt (..),
@@ -302,8 +302,19 @@ dsOrderedMatches resultTy scrutVars matches =
         then do
           failureVar <- freshInternalVar "_next_match" resultTy
           matched <- dsMatchPatterns scrutVars (matchPats match) (dsRhs (matchRhs match)) (FcVar failureVar)
-          pure (FcLet (FcNonRec failureVar failure) matched)
+          pure (shareFailure failureVar failure matched)
         else dsMatchPatterns scrutVars (matchPats match) (dsRhs (matchRhs match)) failure
+
+-- | Materialize a pattern-match failure continuation only when its decision
+-- tree contains enough failure leaves to benefit from sharing. Match binders
+-- are globally fresh, so substituting the already-built failure expression
+-- into its sole use cannot capture any of its free variables.
+shareFailure :: Var -> FcExpr -> FcExpr -> FcExpr
+shareFailure failureVar failure matched =
+  case countExprVar failureVar matched of
+    Dead -> matched
+    Once -> substExpr failureVar failure matched
+    Many -> FcLet (FcNonRec failureVar failure) matched
 
 hasDefaultFallback :: [Match] -> Bool
 hasDefaultFallback matches =

--- a/components/aihc-fc/src/Aihc/Fc/Optimize.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Optimize.hs
@@ -10,7 +10,9 @@ module Aihc.Fc.Optimize
   )
 where
 
+import Aihc.Fc.Subst (OccurrenceCount (..), countExprVar)
 import Aihc.Fc.Syntax
+import Aihc.Tc.Types (isLiftedType)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -27,7 +29,7 @@ optimizeProgram = untilStable runOptimizations
 -- Keep this list ordered from local canonicalizations to broader rewrites so
 -- later rules see the simplest output available from earlier rules.
 coreOptimizations :: [CoreOptimization]
-coreOptimizations = [copyPropagateProgram]
+coreOptimizations = [copyPropagateProgram, eliminateDeadLetsProgram]
 
 untilStable :: (Eq value) => (value -> value) -> value -> value
 untilStable transform input =
@@ -104,3 +106,43 @@ resolveAlias aliases var =
   case Map.lookup var aliases of
     Just target -> resolveAlias aliases target
     Nothing -> var
+
+-- | Remove lazy non-recursive bindings whose values are never demanded. An
+-- unlifted binding is strict, so its right-hand side must be retained even
+-- when the binder is absent from the body.
+eliminateDeadLetsProgram :: FcProgram -> FcProgram
+eliminateDeadLetsProgram (FcProgram topBinds) = FcProgram (map eliminateTopBind topBinds)
+  where
+    eliminateTopBind topBind =
+      case topBind of
+        FcTopBind bind -> FcTopBind (eliminateBind bind)
+        _ -> topBind
+
+eliminateBind :: FcBind -> FcBind
+eliminateBind bind =
+  case bind of
+    FcNonRec binder rhs -> FcNonRec binder (eliminateExpr rhs)
+    FcRec bindings -> FcRec [(binder, eliminateExpr rhs) | (binder, rhs) <- bindings]
+
+eliminateExpr :: FcExpr -> FcExpr
+eliminateExpr expression =
+  case expression of
+    FcVar {} -> expression
+    FcLit {} -> expression
+    FcApp function argument -> FcApp (eliminateExpr function) (eliminateExpr argument)
+    FcTyApp function ty -> FcTyApp (eliminateExpr function) ty
+    FcLam binder body -> FcLam binder (eliminateExpr body)
+    FcTyLam tyVar body -> FcTyLam tyVar (eliminateExpr body)
+    FcLet (FcNonRec binder rhs) body
+      | Dead <- countExprVar binder body,
+        isLiftedType (varType binder) ->
+          eliminateExpr body
+      | otherwise -> FcLet (FcNonRec binder (eliminateExpr rhs)) (eliminateExpr body)
+    FcLet bind body -> FcLet (eliminateBind bind) (eliminateExpr body)
+    FcCase scrutinee binder alternatives ->
+      FcCase
+        (eliminateExpr scrutinee)
+        binder
+        [alternative {altRhs = eliminateExpr (altRhs alternative)} | alternative <- alternatives]
+    FcCast inner coercion -> FcCast (eliminateExpr inner) coercion
+    FcCallForeign foreignCall arguments -> FcCallForeign foreignCall (map eliminateExpr arguments)

--- a/components/aihc-fc/src/Aihc/Fc/Subst.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Subst.hs
@@ -4,6 +4,9 @@
 -- instantiated with a concrete type.
 module Aihc.Fc.Subst
   ( substType,
+    OccurrenceCount (..),
+    countExprVar,
+    substExpr,
     substExprVar,
     freeRigidTyVars,
     freeRigidTyVarsOf,
@@ -15,6 +18,24 @@ import Aihc.Tc.Types (Pred (..), TcType (..), TyVarId (..))
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+
+-- | A deliberately capped occurrence count. Simplifications only need to
+-- distinguish dead variables, single uses, and uses that may benefit from
+-- sharing.
+data OccurrenceCount
+  = Dead
+  | Once
+  | Many
+  deriving (Eq, Show)
+
+instance Semigroup OccurrenceCount where
+  Dead <> count = count
+  Once <> Dead = Once
+  Once <> _ = Many
+  Many <> _ = Many
+
+instance Monoid OccurrenceCount where
+  mempty = Dead
 
 -- | Free rigid type variables in stable left-to-right order.
 freeRigidTyVars :: TcType -> [TyVarId]
@@ -66,20 +87,52 @@ substType subst ty
     goPred s (ClassPred cls args) = ClassPred cls (map (go s) args)
     goPred s (EqPred t1 t2) = EqPred (go s t1) (go s t2)
 
--- | Scope-aware substitution of one System FC term variable. The replacement
--- must be fresh for the expression's scope.
---
--- Case lowering uses this to make the evaluated case binder authoritative in
--- an alternative. In particular, primitives that consume an already-entered
--- value must not receive the original thunk merely because the source body
--- referred to the scrutinee by its old name.
-substExprVar :: Var -> Var -> FcExpr -> FcExpr
-substExprVar source replacement = go
+-- | Count the free occurrences of a System FC term variable, stopping once
+-- more than one occurrence has been found.
+countExprVar :: Var -> FcExpr -> OccurrenceCount
+countExprVar target = go
   where
     go expression =
       case expression of
         FcVar var
-          | var == source -> FcVar replacement
+          | var == target -> Once
+          | otherwise -> Dead
+        FcLit {} -> Dead
+        FcApp function argument -> go function <> go argument
+        FcTyApp function _ -> go function
+        FcLam binder body
+          | binder == target -> Dead
+          | otherwise -> go body
+        FcTyLam _ body -> go body
+        FcLet bind body ->
+          case bind of
+            FcNonRec binder rhs ->
+              go rhs <> if binder == target then Dead else go body
+            FcRec bindings
+              | target `elem` map fst bindings -> Dead
+              | otherwise -> foldMap (go . snd) bindings <> go body
+        FcCase scrutinee binder alternatives ->
+          go scrutinee
+            <> if binder == target
+              then Dead
+              else foldMap goAlternative alternatives
+        FcCast inner _ -> go inner
+        FcCallForeign _ arguments -> foldMap go arguments
+
+    goAlternative alternative
+      | target `elem` altBinders alternative = Dead
+      | otherwise = go (altRhs alternative)
+
+-- | Scope-aware substitution of one System FC term variable with an
+-- expression. Free variables in the replacement must be fresh for the target
+-- expression's nested scopes.
+substExpr :: Var -> FcExpr -> FcExpr -> FcExpr
+substExpr source replacement = go
+  where
+    go expression =
+      case expression of
+        FcVar var
+          | var == source -> replacement
           | otherwise -> expression
         FcLit {} -> expression
         FcApp function argument -> FcApp (go function) (go argument)
@@ -108,3 +161,13 @@ substExprVar source replacement = go
     goAlternative alternative
       | source `elem` altBinders alternative = alternative
       | otherwise = alternative {altRhs = go (altRhs alternative)}
+
+-- | Scope-aware substitution of one System FC term variable. The replacement
+-- must be fresh for the expression's scope.
+--
+-- Case lowering uses this to make the evaluated case binder authoritative in
+-- an alternative. In particular, primitives that consume an already-entered
+-- value must not receive the original thunk merely because the source body
+-- referred to the scrutinee by its old name.
+substExprVar :: Var -> Var -> FcExpr -> FcExpr
+substExprVar source replacement = substExpr source (FcVar replacement)

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -261,6 +261,22 @@ fcOptimizationTests =
             computed = FcApp (FcVar identity) (FcVar value)
             source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcNonRec binder computed) (FcVar binder)))]
         assertEqual "optimized program" source (optimizeProgram source),
+      testCase "eliminates unused lifted non-recursive lets" $ do
+        let value = Var "value" (Unique 17) stringTy
+            unused = Var "unused" (Unique 18) stringTy
+            result = Var "result" (Unique 19) stringTy
+            compute = Var "compute" (Unique 20) (TcFunTy stringTy stringTy)
+            source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcNonRec unused (FcApp (FcVar compute) (FcVar value))) (FcLit (LitString "result"))))]
+            expected = FcProgram [FcTopBind (FcNonRec result (FcLit (LitString "result")))]
+        assertEqual "optimized program" expected (optimizeProgram source),
+      testCase "retains unused unlifted non-recursive lets" $ do
+        let intHashTy = ty "Int#"
+            value = Var "value" (Unique 21) intHashTy
+            unused = Var "unused" (Unique 22) intHashTy
+            result = Var "result" (Unique 23) stringTy
+            compute = Var "compute" (Unique 24) (TcFunTy intHashTy intHashTy)
+            source = FcProgram [FcTopBind (FcNonRec result (FcLet (FcNonRec unused (FcApp (FcVar compute) (FcVar value))) (FcLit (LitString "result"))))]
+        assertEqual "optimized program" source (optimizeProgram source),
       testCase "eliminates values and types unreachable from the entry point" $ do
         let liveTy = ty "Live"
             leafTy = ty "Leaf"

--- a/components/aihc-fc/test/Test/Fixtures/golden/pattern-failure-continuation-sharing.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/pattern-failure-continuation-sharing.yaml
@@ -1,0 +1,64 @@
+extensions: []
+modules:
+  - |
+    module Test where
+
+    data Bool = False | True
+    data MaybeBool = Nothing | Just Bool
+
+    unused :: Bool -> Bool
+    unused value =
+      case value of
+        _ -> True
+        False -> False
+
+    single :: [Bool] -> Bool
+    single [] = True
+    single _ = False
+
+    shared :: MaybeBool -> Bool
+    shared (Just True) = True
+    shared _ = False
+expected: |-
+  module Test where
+
+  data Bool
+   = False
+   | True
+
+  data MaybeBool
+   = Nothing
+   | Just (Bool)
+
+  unused : Bool → Bool =
+    λ(x1001 : Bool).
+      True
+
+  single : [Bool] → Bool =
+    λ(x1004 : [Bool]).
+      case x1004 as (_match1010 : [Bool]) of {
+        [] →
+          True;
+        _ →
+          False
+      }
+
+  shared : MaybeBool → Bool =
+    λ(x1012 : MaybeBool).
+      let {
+        _next_match1016 : Bool =
+          False
+      } in
+        case x1012 as (_match1020 : MaybeBool) of {
+          Just (_pat : Bool) →
+            case _pat as (_match1019 : Bool) of {
+              True →
+                True;
+              _ →
+                _next_match1016
+            };
+          _ →
+            _next_match1016
+        }
+status: pass
+reason: pattern failure continuations are omitted, inlined, or shared according to their occurrence count


### PR DESCRIPTION
## Summary

- count pattern-failure continuation occurrences during System FC desugaring
- omit unused continuations, inline single-use continuations, and retain sharing for multiple failure leaves
- add conservative dead lifted-let elimination to the optional FC optimizer
- add focused optimizer tests and a golden decision-tree regression

## Root cause

`dsOrderedMatches` unconditionally materialized every lifted failure continuation before `dsMatchPatterns` revealed whether the generated decision tree referenced it. This left dead and single-use administrative lets for later pipeline stages.

## Impact

Generated System FC now has smaller pattern-match decision trees without sacrificing sharing when a continuation has multiple uses. Unused strict unlifted lets remain intact.

## Progress counts

- FC golden fixtures: +1 passing fixture
- FC optimizer unit cases: +2 passing cases
- README counts unchanged; they remain cron-managed

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"` (209 tests)
- `just fmt`
- `just check`
