### PR TITLE
fix(fc): resolve constructor imports in merged programs

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -135,7 +135,7 @@ keepTopBind :: Map Text (Int, References) -> Map Text (Int, References) -> Set T
 keepTopBind valueDefinitions typeDefinitions values types index topBind =
   case topBind of
     FcExternal {} -> True
-    FcData name _ _ -> selectedType name
+    FcData declaration -> selectedType (fcDataName declaration)
     FcAxiom declaration -> selectedType (fcAxiomName declaration)
     FcNewtype declaration -> selectedType (fcNewtypeName declaration)
     _ -> any selectedValue [name | (name, _) <- valueDefinitionsOf topBind]
@@ -157,7 +157,7 @@ valueDefinitionsOf topBind =
 typeDefinitionsOf :: FcTopBind -> [(Text, References)]
 typeDefinitionsOf topBind =
   case topBind of
-    FcData name _ constructors -> [(name, foldMap (foldMap referencesType . snd) constructors)]
+    FcData declaration -> [(fcDataName declaration, foldMap (foldMap referencesType . fcDataConFields) (fcDataConstructors declaration))]
     FcAxiom declaration ->
       [ ( fcAxiomName declaration,
           referencesType (fcAxiomLeft declaration)
@@ -175,7 +175,7 @@ typeDefinitionsOf topBind =
 typeConstructorsOf :: FcTopBind -> [(Text, [Text])]
 typeConstructorsOf topBind =
   case topBind of
-    FcData name _ constructors -> [(name, map fst constructors)]
+    FcData declaration -> [(fcDataName declaration, map fcDataConName (fcDataConstructors declaration))]
     FcAxiom {} -> []
     FcNewtype declaration -> [(fcNewtypeName declaration, [fcNewtypeConstructor declaration])]
     _ -> []

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -70,7 +70,7 @@ import Aihc.Tc.Types
   )
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, zipWithM)
-import Control.Monad.Trans.State.Strict (runStateT)
+import Control.Monad.Trans.State.Strict (gets, runStateT)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
@@ -127,6 +127,7 @@ desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
         }
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
+          (packageName, currentModuleName) = resolvedModuleOrigin resolvedModule
           constructorFields =
             Map.fromList
               [ (dciName constructor, dciFields constructor)
@@ -134,7 +135,7 @@ desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 (moduleName tcResult) typeEnv Map.empty Map.empty constructorFields) of
+       in case runStateT (dsModule tcResult) (DsState 1000 packageName (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram (sourceModuleId resolvedModule) [],
@@ -142,8 +143,7 @@ desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
                   dsErrors = [err]
                 }
             Right (binds, _) ->
-              let (packageName, currentModuleName) = resolvedModuleOrigin resolvedModule
-                  program = FcProgram (FcModuleId packageName currentModuleName) binds
+              let program = FcProgram (FcModuleId packageName currentModuleName) binds
                in DesugarResult
                     { dsProgram = declareExternalSymbols (lowerPseudoOps (lowerConstraintProgram (lowerNewtypes program))),
                       dsSuccess = True,
@@ -197,8 +197,14 @@ lowerConstraintProgram (FcProgram moduleId topBinds) =
     lowerTopBind topBind =
       case topBind of
         FcExternal origin ty -> FcExternal origin (lowerConstraintType ty)
-        FcData name tyVars constructors ->
-          FcData name tyVars [(constructor, map lowerConstraintType fields) | (constructor, fields) <- constructors]
+        FcData declaration ->
+          FcData
+            declaration
+              { fcDataConstructors =
+                  [ constructor {fcDataConFields = map lowerConstraintType (fcDataConFields constructor)}
+                  | constructor <- fcDataConstructors declaration
+                  ]
+              }
         FcAxiom declaration ->
           FcAxiom
             declaration
@@ -325,14 +331,15 @@ dsDecl _ = pure []
 dsDataDeclM :: DataDecl -> DsM [FcTopBind]
 dsDataDeclM dd = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
+  tyOrigin <- localDeclarationOrigin tyName
   constructorInfos <- mapM dsDataConM (dataDeclConstructors dd)
   let typeVariables =
         case constructorInfos of
           (_, universals, _) : _ -> universals
           [] -> []
-      constructors = [(name, fields) | (name, _, fields) <- constructorInfos]
+  constructors <- mapM (\(name, _, fields) -> FcDataConDecl <$> localDeclarationOrigin name <*> pure name <*> pure fields) constructorInfos
   selectors <- dsRecordSelectors constructorInfos (dataDeclConstructors dd)
-  pure (FcData tyName typeVariables constructors : selectors)
+  pure (FcData (FcDataDecl tyOrigin tyName typeVariables constructors) : selectors)
 
 -- | Retain a data-family instance as a fresh representation type and a
 -- nominal axiom connecting that representation to the family application.
@@ -362,12 +369,16 @@ dataFamilyRepresentation :: DataFamilyInst -> Text -> [TyVarId] -> TcType -> [(T
 dataFamilyRepresentation familyInst representationName representationTyVars representationType constructorInfos
   | dataFamilyInstIsNewtype familyInst =
       case constructorInfos of
-        [(constructorName, _, [fieldType])] ->
+        [(constructorName, _, [fieldType])] -> do
+          newtypeOrigin <- localDeclarationOrigin representationName
+          constructorOrigin <- localDeclarationOrigin constructorName
           pure
             ( FcNewtype
                 FcNewtypeDecl
-                  { fcNewtypeName = representationName,
+                  { fcNewtypeOrigin = newtypeOrigin,
+                    fcNewtypeName = representationName,
                     fcNewtypeTyVars = representationTyVars,
+                    fcNewtypeConstructorOrigin = constructorOrigin,
                     fcNewtypeConstructor = constructorName,
                     fcNewtypeRepresentation = fieldType,
                     fcNewtypeResult = representationType
@@ -375,12 +386,13 @@ dataFamilyRepresentation familyInst representationName representationTyVars repr
             )
         _ -> desugarBug "newtype family instance does not have exactly one constructor with one field"
   | otherwise =
-      pure
-        ( FcData
-            representationName
-            representationTyVars
-            [(name, fields) | (name, _, fields) <- constructorInfos]
-        )
+      do
+        dataOrigin <- localDeclarationOrigin representationName
+        constructors <- mapM (\(name, _, fields) -> FcDataConDecl <$> localDeclarationOrigin name <*> pure name <*> pure fields) constructorInfos
+        pure
+          ( FcData
+              (FcDataDecl dataOrigin representationName representationTyVars constructors)
+          )
 
 -- | Retain the nominal declaration and its representation type as an FC axiom.
 -- 'lowerNewtypes' turns all term-level construction and matching into casts.
@@ -396,12 +408,16 @@ dsNewtypeDeclM nd = do
         (1, TcFunTy fieldTy resultTy@(TcTyCon resultTyCon resultArgs))
           | tyConName resultTyCon == tyName,
             Just tyVars <- traverse asTyVar resultArgs -> do
+              newtypeOrigin <- localDeclarationOrigin tyName
+              constructorOrigin <- localDeclarationOrigin conName
               selectors <- dsRecordSelectors [(conName, tyVars, [fieldTy])] [con]
               pure
                 ( FcNewtype
                     FcNewtypeDecl
-                      { fcNewtypeName = tyName,
+                      { fcNewtypeOrigin = newtypeOrigin,
+                        fcNewtypeName = tyName,
                         fcNewtypeTyVars = tyVars,
+                        fcNewtypeConstructorOrigin = constructorOrigin,
                         fcNewtypeConstructor = conName,
                         fcNewtypeRepresentation = fieldTy,
                         fcNewtypeResult = resultTy
@@ -899,12 +915,20 @@ dsClassDeclM classDecl classAnn = do
   let fieldTypes = superClassFieldTypes <> methodFieldTypes
   selectors <- mapM (dsClassSelector dictionaryConstructor (length superClassFieldTypes) classTyVars fieldTypes) methods
   defaults <- mapM dsClassDefault (classDefaultGroups classDecl)
-  let dictionaryDeclaration = FcData className classTyVars [(dictionaryConstructor, fieldTypes)]
+  classOrigin <- localDeclarationOrigin className
+  constructorOrigin <- localDeclarationOrigin dictionaryConstructor
+  let dictionaryDeclaration = FcData (FcDataDecl classOrigin className classTyVars [FcDataConDecl constructorOrigin dictionaryConstructor fieldTypes])
   pure (dictionaryDeclaration : selectors <> defaults)
   where
     className = unqualifiedNameText (binderHeadName (classDeclHead classDecl))
     methods = tcClassMethods classAnn
     dictionaryConstructor = fcDictionaryConstructorName className
+
+localDeclarationOrigin :: Text -> DsM FcSymbolOrigin
+localDeclarationOrigin declarationName = do
+  packageName <- gets dsModulePackage
+  moduleName' <- gets dsModuleName
+  pure (FcTopLevelOrigin packageName (fromMaybe "Main" moduleName') declarationName)
 
 dsClassSelector :: Text -> Int -> [TyVarId] -> [TcType] -> TcClassMethodAnnotation -> DsM FcTopBind
 dsClassSelector dictionaryConstructor superClassCount classTyVars fieldTypes methodAnn = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -79,6 +79,7 @@ type DsM = StateT DsState (Either String)
 -- | Desugaring state.
 data DsState = DsState
   { dsNextUnique :: !Int,
+    dsModulePackage :: !Text,
     dsModuleName :: !(Maybe Text),
     -- | Map from surface name to its inferred type (from TC).
     dsTypeEnv :: !(Map Text TcType),

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -248,7 +248,7 @@ buildProgramEnv program = do
     topValueBindings _ = []
 
     directTopBindings (FcPrimitive var arity) = [(varName var, VPrim (varName var) arity [])]
-    directTopBindings (FcData _ _ constructors) = [(conName, VConstructor conName []) | (conName, _) <- constructors]
+    directTopBindings (FcData declaration) = [(fcDataConName constructor, VConstructor (fcDataConName constructor) []) | constructor <- fcDataConstructors declaration]
     directTopBindings _ = []
 
 evalExpr :: FcExpr -> IO (Either EvalError Value)

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -94,18 +94,22 @@ lintProgramWithAxiomInterface imported env0 prog = go envWithDeclarations (fcTop
         env0 {leAxioms = leAxioms env0 <> imported <> extractAxiomInterface prog}
         (fcTopBinds prog)
 
-    registerDeclaration (FcData typeName tyVars constructors) env =
+    registerDeclaration (FcData declaration) env =
       env
         { leDataCons =
             foldr
-              ( \(constructor, fields) ->
-                  let existentialVariables = filter (`notElem` tyVars) (freeRigidTyVarsOf fields)
-                   in Map.insert constructor (tyVars <> existentialVariables, fields, resultType)
+              ( \constructor ->
+                  let fields = fcDataConFields constructor
+                      existentialVariables = filter (`notElem` tyVars) (freeRigidTyVarsOf fields)
+                   in Map.insert (fcDataConName constructor) (tyVars <> existentialVariables, fields, resultType)
               )
               (leDataCons env)
               constructors
         }
       where
+        typeName = fcDataName declaration
+        tyVars = fcDataTyVars declaration
+        constructors = fcDataConstructors declaration
         resultType = TcTyCon (TyCon typeName (length tyVars)) (map TcTyVar tyVars)
     registerDeclaration (FcForeignImport foreignCall) env =
       env {leForeignCalls = Map.insert (fcForeignCallName foreignCall) foreignCall (leForeignCalls env)}

--- a/components/aihc-fc/src/Aihc/Fc/Merge.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Merge.hs
@@ -8,10 +8,10 @@ module Aihc.Fc.Merge
 where
 
 import Aihc.Fc.Pretty (declareExternalSymbols)
-import Aihc.Fc.Subst (maximumProgramUnique, programVars)
+import Aihc.Fc.Subst (freeRigidTyVarsOf, maximumProgramUnique, programVars)
 import Aihc.Fc.Syntax
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, typeSchemeFromType)
-import Aihc.Tc.Types (TcType, Unique (..))
+import Aihc.Tc.Types (TcType (..), TyCon (..), Unique (..))
 import Data.Char (isAlphaNum, ord)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
@@ -37,7 +37,8 @@ mergePrograms target programs =
   where
     freshPrograms = freshenPrograms (NonEmpty.toList programs)
     qualifiedPrograms = map qualifyTopLevelBinders freshPrograms
-    providerEntries = concatMap programProviders qualifiedPrograms
+    importedTypes = Map.fromList [(origin, ty) | program <- qualifiedPrograms, FcExternal origin ty <- fcTopBinds program]
+    providerEntries = concatMap (programProviders importedTypes) qualifiedPrograms
     providers = Map.fromList providerEntries
     sourceProviders = fallbackSourceProviders providerEntries
     duplicateErrors = map FcDuplicateDefinition (duplicates (map fst providerEntries))
@@ -152,13 +153,43 @@ globalBinderName origin =
       | isAlphaNum character = T.singleton character
       | otherwise = "_" <> T.pack (showHex (ord character) "") <> "_"
 
-programProviders :: FcProgram -> [(FcSymbolOrigin, Var)]
-programProviders program =
+programProviders :: Map FcSymbolOrigin TcType -> FcProgram -> [(FcSymbolOrigin, Var)]
+programProviders importedTypes program =
   [ (origin, var)
   | topBind <- fcTopBinds program,
-    var <- topBinders topBind,
+    var <- topBinders topBind <> declarationConstructorVars importedTypes topBind,
     Just origin <- [varResolvedName var]
   ]
+
+declarationConstructorVars :: Map FcSymbolOrigin TcType -> FcTopBind -> [Var]
+declarationConstructorVars importedTypes topBind =
+  case topBind of
+    FcData declaration ->
+      [ fcExternalVar origin (Map.findWithDefault (dataConstructorType declaration constructor) origin importedTypes)
+      | constructor <- fcDataConstructors declaration,
+        let origin = fcDataConOrigin constructor
+      ]
+    FcNewtype declaration ->
+      [fcExternalVar origin (Map.findWithDefault (newtypeConstructorType declaration) origin importedTypes)]
+      where
+        origin = fcNewtypeConstructorOrigin declaration
+    _ -> []
+
+dataConstructorType :: FcDataDecl -> FcDataConDecl -> TcType
+dataConstructorType declaration constructor =
+  foldr TcForAllTy body (universalTyVars <> existentialTyVars)
+  where
+    universalTyVars = fcDataTyVars declaration
+    fields = fcDataConFields constructor
+    existentialTyVars = filter (`notElem` universalTyVars) (freeRigidTyVarsOf fields)
+    result = TcTyCon (TyCon (fcDataName declaration) (length universalTyVars)) (map TcTyVar universalTyVars)
+    body = foldr TcFunTy result fields
+
+newtypeConstructorType :: FcNewtypeDecl -> TcType
+newtypeConstructorType declaration =
+  foldr TcForAllTy body (fcNewtypeTyVars declaration)
+  where
+    body = TcFunTy (fcNewtypeRepresentation declaration) (fcNewtypeResult declaration)
 
 -- The type checker does not yet attach an origin to all compiler-generated
 -- evidence references. Keep the prior last-definition fallback for those

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -52,12 +52,12 @@ parseProgram input = do
   let moduleOrigin = Just (fcModulePackage moduleId, fcModuleName moduleId)
   signatures <- traverse (parseSignatures moduleOrigin) definitionBlocks
   let globals = Map.unions (catMaybes signatures) <> externalEnv headers
-  FcProgram moduleId <$> traverse (parseBlock globals) definitionBlocks
+  FcProgram moduleId <$> traverse (parseBlock moduleOrigin globals) definitionBlocks
   where
     blocks = filter (not . T.null) (map T.strip (T.splitOn "\n\n" input))
     parseModuleHeader = MP.parse (space *> MP.optional (MP.try moduleDeclaration) <* MP.takeRest) "<system-fc-header>"
     parseExternalHeader = MP.parse (space *> MP.optional (MP.try externalDeclaration) <* MP.takeRest) "<system-fc-header>"
-    parseBlock globals = MP.parse (space *> topBind globals <* MP.eof) "<system-fc>"
+    parseBlock moduleOrigin globals = MP.parse (space *> topBind moduleOrigin globals <* MP.eof) "<system-fc>"
 
 validateModuleDeclaration :: Text -> [FcModuleId] -> Either FcParseError FcModuleId
 validateModuleDeclaration _ [moduleId] = Right moduleId
@@ -96,13 +96,13 @@ parseType = MP.parse (space *> tcType mempty <* MP.eof) "<system-fc-type>"
 renderParseError :: FcParseError -> String
 renderParseError = MP.errorBundlePretty
 
-topBind :: TermEnv -> Parser FcTopBind
-topBind termEnv =
+topBind :: Maybe (Text, Text) -> TermEnv -> Parser FcTopBind
+topBind moduleOrigin termEnv =
   MP.choice
     [ MP.try externalDeclaration,
-      MP.try dataDeclaration,
+      MP.try (dataDeclaration moduleOrigin),
       MP.try axiomDeclaration,
-      MP.try newtypeDeclaration,
+      MP.try (newtypeDeclaration moduleOrigin),
       MP.try primitiveDeclaration,
       MP.try foreignImportDeclaration,
       FcTopBind <$> bind termEnv mempty
@@ -140,27 +140,26 @@ parseSignatures moduleOrigin =
 declarationSignatures :: Maybe (Text, Text) -> Parser TermEnv
 declarationSignatures moduleOrigin =
   MP.choice
-    [ signaturesOf moduleOrigin <$> MP.try dataDeclaration,
-      signaturesOf moduleOrigin <$> MP.try newtypeDeclaration,
-      signaturesOf moduleOrigin <$> MP.try primitiveDeclaration,
+    [ signaturesOf <$> MP.try (dataDeclaration moduleOrigin),
+      signaturesOf <$> MP.try (newtypeDeclaration moduleOrigin),
+      signaturesOf <$> MP.try primitiveDeclaration,
       MP.try (nonRecSignature moduleOrigin),
       MP.try (recSignatures moduleOrigin)
     ]
 
-signaturesOf :: Maybe (Text, Text) -> FcTopBind -> TermEnv
-signaturesOf moduleOrigin top =
+signaturesOf :: FcTopBind -> TermEnv
+signaturesOf top =
   case top of
-    FcData dataName tyVars constructors ->
+    FcData declaration ->
       Map.fromList
         [ entry
-        | (constructorName, fields) <- constructors,
-          entry <- localSignatureEntries moduleOrigin constructorName (constructorType dataName tyVars fields)
+        | constructorDeclaration <- fcDataConstructors declaration,
+          entry <- originSignatureEntries (fcDataConOrigin constructorDeclaration) (constructorType (fcDataName declaration) (fcDataTyVars declaration) (fcDataConFields constructorDeclaration))
         ]
     FcNewtype declaration ->
       Map.fromList
-        ( localSignatureEntries
-            moduleOrigin
-            (fcNewtypeConstructor declaration)
+        ( originSignatureEntries
+            (fcNewtypeConstructorOrigin declaration)
             (newtypeConstructorType declaration)
         )
     FcPrimitive var _ -> Map.singleton (varName var) var
@@ -200,6 +199,12 @@ localSignatureEntries moduleOrigin binderName ty =
   where
     var = localVar moduleOrigin binderName ty
 
+originSignatureEntries :: FcSymbolOrigin -> TcType -> [(Text, Var)]
+originSignatureEntries origin ty =
+  [(fcOriginName origin, var), (originKey origin, var)]
+  where
+    var = fcExternalVar origin ty
+
 localVar :: Maybe (Text, Text) -> Text -> TcType -> Var
 localVar moduleOrigin binderName ty =
   (mkVar binderName ty)
@@ -209,22 +214,22 @@ localVar moduleOrigin binderName ty =
 originKey :: FcSymbolOrigin -> Text
 originKey = fcSymbolOriginText
 
-dataDeclaration :: Parser FcTopBind
-dataDeclaration = do
+dataDeclaration :: Maybe (Text, Text) -> Parser FcTopBind
+dataDeclaration moduleOrigin = do
   _ <- keyword "data"
-  dataName <- name
+  (dataName, dataOrigin) <- declarationName moduleOrigin
   tyVars <- tyVarBinders mempty
   let tyEnv = tyVarEnv tyVars
-  constructors <- MP.many (MP.try ((symbol "=" <|> symbol "|") *> constructor tyEnv))
-  pure (FcData dataName tyVars constructors)
+  constructors <- MP.many (MP.try ((symbol "=" <|> symbol "|") *> constructor moduleOrigin tyEnv))
+  pure (FcData (FcDataDecl dataOrigin dataName tyVars constructors))
 
-constructor :: TyEnv -> Parser (Text, [TcType])
-constructor tyEnv = do
+constructor :: Maybe (Text, Text) -> TyEnv -> Parser FcDataConDecl
+constructor moduleOrigin tyEnv = do
   existentialTyVars <- MP.option [] (symbol "∀" *> someTyVarBinders tyEnv <* symbol ".")
-  constructorName <- name
+  (constructorName, constructorOrigin) <- declarationName moduleOrigin
   let fieldEnv = Map.union (tyVarEnv existentialTyVars) tyEnv
   fields <- MP.many (between "(" ")" (tcType fieldEnv))
-  pure (constructorName, fields)
+  pure (FcDataConDecl constructorOrigin constructorName fields)
 
 axiomDeclaration :: Parser FcTopBind
 axiomDeclaration = do
@@ -238,18 +243,25 @@ axiomDeclaration = do
   right <- tcType tyEnv
   pure (FcAxiom (FcAxiomDecl axiomName tyVars role left right))
 
-newtypeDeclaration :: Parser FcTopBind
-newtypeDeclaration = do
+newtypeDeclaration :: Maybe (Text, Text) -> Parser FcTopBind
+newtypeDeclaration moduleOrigin = do
   _ <- keyword "newtype"
-  newtypeName <- name
+  (newtypeName, newtypeOrigin) <- declarationName moduleOrigin
   tyVars <- tyVarBinders mempty
   let tyEnv = tyVarEnv tyVars
   _ <- symbol ":"
   result <- tcType tyEnv
   _ <- symbol "="
-  constructorName <- name
+  (constructorName, constructorOrigin) <- declarationName moduleOrigin
   representation <- tcType tyEnv
-  pure (FcNewtype (FcNewtypeDecl newtypeName tyVars constructorName representation result))
+  pure (FcNewtype (FcNewtypeDecl newtypeOrigin newtypeName tyVars constructorOrigin constructorName representation result))
+
+declarationName :: Maybe (Text, Text) -> Parser (Text, FcSymbolOrigin)
+declarationName moduleOrigin = do
+  (declarationName', maybeOrigin) <- originName
+  case maybeOrigin <|> fmap (\(packageName, moduleName) -> FcTopLevelOrigin packageName moduleName declarationName') moduleOrigin of
+    Just origin -> pure (declarationName', origin)
+    Nothing -> fail "declaration has no System FC module origin"
 
 primitiveDeclaration :: Parser FcTopBind
 primitiveDeclaration = do

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -82,11 +82,11 @@ renderTopBindWith symbols topBind =
   case topBind of
     FcExternal origin ty ->
       "external " <> renderOrigin origin <> " : " <> renderType ty
-    FcData name tyVars constructors ->
+    FcData declaration ->
       "data "
-        <> T.unpack name
-        <> concatMap (" " <>) (renderTyVarBinders [] tyVars)
-        <> renderConstructors tyVars constructors
+        <> renderDeclarationName symbols (fcDataOrigin declaration) (fcDataName declaration)
+        <> concatMap (" " <>) (renderTyVarBinders [] (fcDataTyVars declaration))
+        <> renderConstructors symbols (fcDataTyVars declaration) (fcDataConstructors declaration)
     FcAxiom declaration ->
       "axiom "
         <> T.unpack (fcAxiomName declaration)
@@ -97,12 +97,12 @@ renderTopBindWith symbols topBind =
         <> renderTypeWith (fcAxiomTyVars declaration) (fcAxiomRight declaration)
     FcNewtype declaration ->
       "newtype "
-        <> T.unpack (fcNewtypeName declaration)
+        <> renderDeclarationName symbols (fcNewtypeOrigin declaration) (fcNewtypeName declaration)
         <> concatMap (" " <>) (renderTyVarBinders [] (fcNewtypeTyVars declaration))
         <> " : "
         <> renderTypeWith (fcNewtypeTyVars declaration) (fcNewtypeResult declaration)
         <> " = "
-        <> T.unpack (fcNewtypeConstructor declaration)
+        <> renderDeclarationName symbols (fcNewtypeConstructorOrigin declaration) (fcNewtypeConstructor declaration)
         <> " "
         <> renderTypeAtomWith (fcNewtypeTyVars declaration) (fcNewtypeRepresentation declaration)
     FcPrimitive var arity ->
@@ -144,6 +144,7 @@ canonicalProgramBinds (FcProgram moduleId topBinds) =
     definedNames = Set.fromList (concatMap topBindDefinedNames definitions)
     localOrigins =
       Set.fromList [origin | topBind <- definitions, var <- topBindDefinedVars topBind, Just origin <- [varResolvedName var]]
+        <> Set.fromList (concatMap topBindDefinedOrigins definitions)
         <> Set.fromList
           [ origin
           | topBind <- definitions,
@@ -160,12 +161,19 @@ topBindDefinedNames :: FcTopBind -> [T.Text]
 topBindDefinedNames topBind =
   case topBind of
     FcExternal {} -> []
-    FcData _ _ constructors -> map fst constructors
+    FcData declaration -> map fcDataConName (fcDataConstructors declaration)
     FcAxiom {} -> []
     FcNewtype declaration -> [fcNewtypeConstructor declaration]
     FcPrimitive var _ -> [varName var]
     FcForeignImport {} -> []
     FcTopBind bind -> map varName (bindersOf bind)
+
+topBindDefinedOrigins :: FcTopBind -> [FcSymbolOrigin]
+topBindDefinedOrigins topBind =
+  case topBind of
+    FcData declaration -> fcDataOrigin declaration : map fcDataConOrigin (fcDataConstructors declaration)
+    FcNewtype declaration -> [fcNewtypeOrigin declaration, fcNewtypeConstructorOrigin declaration]
+    _ -> []
 
 topBindDefinedVars :: FcTopBind -> [Var]
 topBindDefinedVars topBind =
@@ -213,20 +221,27 @@ isLocalOrigin symbols origin =
       localPackage == packageName && localModule == moduleName
     _ -> False
 
-renderConstructors :: [TyVarId] -> [(T.Text, [TcType])] -> String
-renderConstructors _ [] = ""
-renderConstructors tyVars constructors =
+renderConstructors :: RenderSymbols -> [TyVarId] -> [FcDataConDecl] -> String
+renderConstructors _ _ [] = ""
+renderConstructors symbols tyVars constructors =
   "\n" <> intercalate "\n" (zipWith renderConstructor (" = " : repeat " | ") constructors)
   where
-    renderConstructor prefix (name, fields) =
+    renderConstructor prefix declaration =
       prefix
         <> renderExistentials fields
-        <> T.unpack name
+        <> renderDeclarationName symbols (fcDataConOrigin declaration) (fcDataConName declaration)
         <> concatMap (\field -> " (" <> renderTypeWith (tyVars <> freeRigidTyVarsOf fields) field <> ")") fields
+      where
+        fields = fcDataConFields declaration
     renderExistentials fields =
       case filter (`notElem` tyVars) (freeRigidTyVarsOf fields) of
         [] -> ""
         existentialTyVars -> "∀ " <> unwords (renderTyVarBinders tyVars existentialTyVars) <> ". "
+
+renderDeclarationName :: RenderSymbols -> FcSymbolOrigin -> T.Text -> String
+renderDeclarationName symbols origin declarationName
+  | isLocalOrigin symbols origin = T.unpack declarationName
+  | otherwise = renderOrigin origin
 
 renderAxiomRole :: FcAxiomRole -> String
 renderAxiomRole role =

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -26,6 +26,8 @@ module Aihc.Fc.Syntax
     -- * Bindings
     FcBind (..),
     FcTopBind (..),
+    FcDataDecl (..),
+    FcDataConDecl (..),
     FcAxiomDecl (..),
     FcAxiomRole (..),
     FcNewtypeDecl (..),
@@ -85,9 +87,8 @@ data FcTopBind
   = -- | A term symbol defined by another compilation unit. Its type is
     -- declared once here and omitted from every occurrence.
     FcExternal !FcSymbolOrigin !TcType
-  | -- | Data type declaration: type name, type variable parameters,
-    -- list of (constructor name, field types).
-    FcData !Text ![TyVarId] ![(Text, [TcType])]
+  | -- | A data type declaration.
+    FcData !FcDataDecl
   | -- | A type equality axiom. Axioms are proof metadata and have no
     -- runtime representation.
     FcAxiom !FcAxiomDecl
@@ -108,6 +109,23 @@ data FcAxiomRole
   | FcRepresentational
   deriving (Eq, Show, Read)
 
+-- | A data type with its stable source identity.
+data FcDataDecl = FcDataDecl
+  { fcDataOrigin :: !FcSymbolOrigin,
+    fcDataName :: !Text,
+    fcDataTyVars :: ![TyVarId],
+    fcDataConstructors :: ![FcDataConDecl]
+  }
+  deriving (Eq, Show, Read)
+
+-- | A data constructor with its stable source identity.
+data FcDataConDecl = FcDataConDecl
+  { fcDataConOrigin :: !FcSymbolOrigin,
+    fcDataConName :: !Text,
+    fcDataConFields :: ![TcType]
+  }
+  deriving (Eq, Show, Read)
+
 -- | A named, parameterized type equality retained in System FC.
 data FcAxiomDecl = FcAxiomDecl
   { fcAxiomName :: !Text,
@@ -123,8 +141,10 @@ data FcAxiomDecl = FcAxiomDecl
 --
 -- This declaration is proof metadata, not a runtime constructor declaration.
 data FcNewtypeDecl = FcNewtypeDecl
-  { fcNewtypeName :: !Text,
+  { fcNewtypeOrigin :: !FcSymbolOrigin,
+    fcNewtypeName :: !Text,
     fcNewtypeTyVars :: ![TyVarId],
+    fcNewtypeConstructorOrigin :: !FcSymbolOrigin,
     fcNewtypeConstructor :: !Text,
     fcNewtypeRepresentation :: !TcType,
     fcNewtypeResult :: !TcType

--- a/components/aihc-fc/test/Test/Fc/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc/Properties.hs
@@ -127,7 +127,7 @@ prop_localSignatures = property $ do
       program =
         FcProgram
           (FcModuleId "pkg" "Module")
-          [ FcData "Bool" [] [("True", [])],
+          [ FcData (FcDataDecl (FcTopLevelOrigin "pkg" "Module" "Bool") "Bool" [] [FcDataConDecl origin "True" []]),
             FcTopBind (FcNonRec result (FcVar constructor))
           ]
       rendered = T.pack (renderProgram program)
@@ -160,7 +160,7 @@ genProgram = FcProgram (FcModuleId "test" "Test") <$> smallList genTopBind
 genTopBind :: Gen FcTopBind
 genTopBind =
   Gen.choice
-    [ FcData <$> genTypeName <*> smallList genTyVar <*> smallList genDataConstructor,
+    [ FcData <$> genDataDecl,
       FcAxiom <$> genAxiomDecl,
       FcNewtype <$> genNewtypeDecl,
       FcPrimitive <$> genVar <*> genInt,
@@ -168,8 +168,15 @@ genTopBind =
       FcTopBind <$> genBindWith genExpr
     ]
 
-genDataConstructor :: Gen (Text, [TcType])
-genDataConstructor = (,) <$> genTypeName <*> smallList genType
+genDataDecl :: Gen FcDataDecl
+genDataDecl = do
+  dataName <- genTypeName
+  FcDataDecl (testOrigin dataName) dataName <$> smallList genTyVar <*> smallList genDataConstructor
+
+genDataConstructor :: Gen FcDataConDecl
+genDataConstructor = do
+  constructorName <- genTypeName
+  FcDataConDecl (testOrigin constructorName) constructorName <$> smallList genType
 
 genAxiomDecl :: Gen FcAxiomDecl
 genAxiomDecl =
@@ -182,12 +189,20 @@ genAxiomDecl =
 
 genNewtypeDecl :: Gen FcNewtypeDecl
 genNewtypeDecl =
-  FcNewtypeDecl
-    <$> genTypeName
-    <*> smallList genTyVar
-    <*> genTypeName
-    <*> genType
-    <*> genType
+  do
+    newtypeName <- genTypeName
+    constructorName <- genTypeName
+    FcNewtypeDecl
+      (testOrigin newtypeName)
+      newtypeName
+      <$> smallList genTyVar
+      <*> pure (testOrigin constructorName)
+      <*> pure constructorName
+      <*> genType
+      <*> genType
+
+testOrigin :: Text -> FcSymbolOrigin
+testOrigin = FcTopLevelOrigin "test" "Test"
 
 genForeignCall :: Gen FcForeignCall
 genForeignCall = FcForeignCall <$> genVarName <*> genLiteralText <*> genForeignSignature

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -344,9 +344,9 @@ fcOptimizationTests =
             mainVar = Var "main" (Unique 1) liveTy
             helperVar = Var "helper" (Unique 2) liveTy
             deadVar = Var "dead" (Unique 3) deadTy
-            liveData = FcData "Live" [] [("Live", [leafTy])]
-            leafData = FcData "Leaf" [] [("Leaf", [])]
-            deadData = FcData "Dead" [] [("Dead", [])]
+            liveData = fcData "Live" [] [("Live", [leafTy])]
+            leafData = fcData "Leaf" [] [("Leaf", [])]
+            deadData = fcData "Dead" [] [("Dead", [])]
             helper = FcTopBind (FcNonRec helperVar (FcVar (Var "Live" (Unique 4) (TcFunTy leafTy liveTy))))
             mainBinding = FcTopBind (FcNonRec mainVar (FcVar helperVar))
             deadBinding = FcTopBind (FcNonRec deadVar (FcVar (Var "Dead" (Unique 5) deadTy)))
@@ -372,7 +372,7 @@ fcOptimizationTests =
           (eliminateDeadCode "main" program),
       testCase "retains ordinary dictionary constructor declarations" $ do
         let dictionaryTy = ty "Test"
-            dictionaryData = FcData "Test" [] [("$Dict$Test", [stringTy])]
+            dictionaryData = fcData "Test" [] [("$Dict$Test", [stringTy])]
             dictionaryConstructor = Var "$Dict$Test" (Unique 14) (TcFunTy stringTy dictionaryTy)
             dictionaryBinder = Var "$dictionary" (Unique 15) dictionaryTy
             methodBinder = Var "$method" (Unique 16) stringTy
@@ -397,8 +397,10 @@ fcOptimizationTests =
             intHashTy = ty "Int#"
             declaration =
               FcNewtypeDecl
-                { fcNewtypeName = "Meters",
+                { fcNewtypeOrigin = FcTopLevelOrigin "test" "Test" "Meters",
+                  fcNewtypeName = "Meters",
                   fcNewtypeTyVars = [],
+                  fcNewtypeConstructorOrigin = FcTopLevelOrigin "test" "Test" "Meters",
                   fcNewtypeConstructor = "Meters",
                   fcNewtypeRepresentation = intHashTy,
                   fcNewtypeResult = metersTy
@@ -421,8 +423,10 @@ fcOptimizationTests =
             intHashTy = ty "Int#"
             declaration =
               FcNewtypeDecl
-                { fcNewtypeName = "Wrapper",
+                { fcNewtypeOrigin = FcTopLevelOrigin "test" "Test" "Wrapper",
+                  fcNewtypeName = "Wrapper",
                   fcNewtypeTyVars = [],
+                  fcNewtypeConstructorOrigin = FcTopLevelOrigin "test" "Test" "Wrap",
                   fcNewtypeConstructor = "Wrap",
                   fcNewtypeRepresentation = intHashTy,
                   fcNewtypeResult = wrapperTy
@@ -599,3 +603,15 @@ stringTy = TcTyCon (TyCon "[]" 1) [TcTyCon (TyCon "Char" 0) []]
 
 ty :: Text -> TcType
 ty name = TcTyCon (TyCon name 0) []
+
+fcData :: Text -> [TyVarId] -> [(Text, [TcType])] -> FcTopBind
+fcData dataName tyVars constructors =
+  FcData
+    ( FcDataDecl
+        (testOrigin dataName)
+        dataName
+        tyVars
+        [FcDataConDecl (testOrigin constructorName) constructorName fields | (constructorName, fields) <- constructors]
+    )
+  where
+    testOrigin = FcTopLevelOrigin "test" "Test"

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -18,7 +18,6 @@ where
 import Aihc.Fc.Lower (lowerPseudoOps)
 import Aihc.Fc.Newtype (lowerNewtypes)
 import Aihc.Fc.Subst (substType)
-import Aihc.Fc.Subst qualified as Fc
 import Aihc.Fc.Syntax
 import Aihc.Grin.Analysis (freeExprVars)
 import Aihc.Grin.Anf (normalizeGrinProgram)
@@ -32,7 +31,7 @@ import Aihc.Tc.Types
   )
 import Control.Applicative ((<|>))
 import Control.Monad.Trans.State.Strict (State, gets, modify', runState)
-import Data.List (find, mapAccumL)
+import Data.List (mapAccumL)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -131,9 +130,9 @@ linkNamesForProgram libraryId moduleNameComponents program =
           ],
       grinConstructorNames =
         Map.fromList
-          [ (constructorSourceName name, (name, length fields))
-          | FcData _ _ constructors <- fcTopBinds program,
-            (name, fields) <- constructors
+          [ (fcSymbolOriginText (fcDataConOrigin constructor), (fcDataConName constructor, length (fcDataConFields constructor)))
+          | FcData declaration <- fcTopBinds program,
+            constructor <- fcDataConstructors declaration
           ]
     }
   where
@@ -166,31 +165,6 @@ linkNamesForProgram libraryId moduleNameComponents program =
     sourceSymbolName symbolName =
       (if packageIdentity == "" then "" else packageIdentity <> ":")
         <> T.intercalate "." (moduleNameComponents <> [symbolName])
-    constructorSourceName constructorName =
-      case matchingOrigins constructorName of
-        [origin] -> fcSymbolOriginText origin
-        origins ->
-          maybe
-            (sourceSymbolName constructorName)
-            fcSymbolOriginText
-            (findProgramOrigin origins)
-    matchingOrigins constructorName =
-      Set.toList
-        ( Set.fromList
-            [ origin
-            | var <- Fc.programVars program,
-              Just origin@FcTopLevelOrigin {} <- [varResolvedName var],
-              fcOriginName origin == constructorName || varName var == constructorName
-            ]
-        )
-    findProgramOrigin =
-      find
-        ( \case
-            FcTopLevelOrigin packageName moduleName _ ->
-              packageName == fcModulePackage (fcProgramModule program)
-                && moduleName == fcModuleName (fcProgramModule program)
-            FcBuiltinOrigin {} -> False
-        )
     packageIdentity =
       fromMaybe
         ""
@@ -370,8 +344,8 @@ lowerTopBind :: FcTopBind -> LowerM LoweredTop
 lowerTopBind topBind =
   case topBind of
     FcExternal {} -> pure mempty
-    FcData _ _ constructors ->
-      pure mempty {loweredConstructors = [(name, map (runtimeRepComponents . typeRuntimeRep) fields) | (name, fields) <- constructors]}
+    FcData declaration ->
+      pure mempty {loweredConstructors = [(fcDataConName constructor, map (runtimeRepComponents . typeRuntimeRep) (fcDataConFields constructor)) | constructor <- fcDataConstructors declaration]}
     FcAxiom {} ->
       pure mempty
     FcNewtype {} ->
@@ -1712,9 +1686,9 @@ programVars program = concatMap topVars (fcTopBinds program)
 
 programConstructors :: FcProgram -> [(Text, Int)]
 programConstructors program =
-  [ (name, length fields)
-  | FcData _ _ constructors <- fcTopBinds program,
-    (name, fields) <- constructors
+  [ (fcDataConName constructor, length (fcDataConFields constructor))
+  | FcData declaration <- fcTopBinds program,
+    constructor <- fcDataConstructors declaration
   ]
 
 programGlobalInfos :: GrinLinkNames -> FcProgram -> [(Var, Text, Text, Bool)]

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -898,7 +898,7 @@ prepareEvalProgram name program@(FcProgram _ topBinds) =
               wrapperType = TcTyCon (TyCon "__AihcEvalResultType" 0) []
               constructorVar = Var constructorName (Unique (-1000000)) (TcFunTy (varType var) wrapperType)
               wrappedVar = var {varType = wrapperType}
-              declaration = FcData "__AihcEvalResultType" [] [(constructorName, [varType var])]
+              declaration = fcData "__AihcEvalResultType" [] [(constructorName, [varType var])]
               wrappedBinding = FcTopBind (FcNonRec wrappedVar (FcApp (FcVar constructorVar) rhs))
           Right
             ( FcProgram (fcProgramModule program) (declaration : before <> (wrappedBinding : after)),
@@ -983,7 +983,7 @@ applicationProgram :: FcProgram
 applicationProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcTopBind
         ( FcNonRec
             answerVar
@@ -1043,7 +1043,7 @@ hiddenLambdaProgram :: FcExpr -> FcProgram
 hiddenLambdaProgram aliasRhs =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "Holder" [] [("Holder", [binaryFunctionTy])],
+    [ fcData "Holder" [] [("Holder", [binaryFunctionTy])],
       FcTopBind
         ( FcNonRec
             dictionaryVar
@@ -1092,7 +1092,7 @@ sharedForcedLetProgram :: FcProgram
 sharedForcedLetProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "FunctionPair" [] [("FunctionPair", [unaryFunctionTy, unaryFunctionTy])],
+    [ fcData "FunctionPair" [] [("FunctionPair", [unaryFunctionTy, unaryFunctionTy])],
       FcTopBind
         ( FcNonRec
             ownerVar
@@ -1123,7 +1123,7 @@ unboxedApplicationProgram :: FcProgram
 unboxedApplicationProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcTopBind
         ( FcNonRec
             answerVar
@@ -1142,7 +1142,7 @@ shadowingProgram :: FcProgram
 shadowingProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcTopBind
         ( FcNonRec
             answerVar
@@ -1161,7 +1161,7 @@ cafReferenceProgram :: FcProgram
 cafReferenceProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcTopBind
         ( FcNonRec
             sourceVar
@@ -1182,7 +1182,7 @@ staticConstructorProgram :: FcProgram
 staticConstructorProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcTopBind
         ( FcNonRec
             sourceVar
@@ -1349,7 +1349,7 @@ zeroWidthConstructorProgram :: FcProgram
 zeroWidthConstructorProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "StateBox" [] [("StateBox", [stateTy, boxedIntTy])],
+    [ fcData "StateBox" [] [("StateBox", [stateTy, boxedIntTy])],
       FcTopBind
         ( FcNonRec
             partialVar
@@ -1367,7 +1367,7 @@ functionClassificationProgram :: FcProgram
 functionClassificationProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcTopBind
         ( FcNonRec
             directVar
@@ -1403,7 +1403,7 @@ knownFunctionWrapperProgram :: Bool -> FcProgram
 knownFunctionWrapperProgram isEtaExpansion =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "Applicative" [] [("$Dict$Applicative", [unaryFunctionTy])],
+    [ fcData "Applicative" [] [("$Dict$Applicative", [unaryFunctionTy])],
       FcTopBind
         ( FcNonRec
             pureIoVar
@@ -1436,8 +1436,8 @@ dictionaryProgram :: FcProgram
 dictionaryProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "Box" [] [("Box", [intTy])],
-      FcData "Test" [] [("$Dict$Test", [boxedIntTy, boxedIntTy])],
+    [ fcData "Box" [] [("Box", [intTy])],
+      fcData "Test" [] [("$Dict$Test", [boxedIntTy, boxedIntTy])],
       FcTopBind
         ( FcNonRec
             answerVar
@@ -1463,7 +1463,7 @@ exceptionProgram :: FcProgram
 exceptionProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt" [] [("BoxedInt", [intTy])],
+    [ fcData "BoxedInt" [] [("BoxedInt", [intTy])],
       FcPrimitive raiseVar 1,
       FcPrimitive catchVar 3,
       FcTopBind (FcNonRec answerVar (FcApp (FcVar boxConstructorVar) caughtExpression))
@@ -2279,7 +2279,7 @@ foreignProgram :: FcProgram
 foreignProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt32" [] [("BoxedInt32", [int32Ty])],
+    [ fcData "BoxedInt32" [] [("BoxedInt32", [int32Ty])],
       FcForeignImport foreignCall,
       FcTopBind
         ( FcNonRec
@@ -2292,7 +2292,7 @@ undersaturatedForeignProgram :: FcProgram
 undersaturatedForeignProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "BoxedInt32" [] [("BoxedInt32", [int32Ty])],
+    [ fcData "BoxedInt32" [] [("BoxedInt32", [int32Ty])],
       FcForeignImport foreignCall,
       FcTopBind (FcNonRec foreignAnswerVar (FcApp (FcVar foreignBoxConstructorVar) (FcCallForeign foreignCall [])))
     ]
@@ -2323,7 +2323,7 @@ saturatedConstructorProgram :: FcProgram
 saturatedConstructorProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "Int32" [] [("I32#", [int32Ty])],
+    [ fcData "Int32" [] [("I32#", [int32Ty])],
       FcTopBind
         ( FcNonRec
             int32WrapperVar
@@ -2338,7 +2338,7 @@ tailStoredTupleProgram :: FcProgram
 tailStoredTupleProgram =
   FcProgram
     (FcModuleId "test" "Test")
-    [ FcData "Box" [] [("Box", [intTy])],
+    [ fcData "Box" [] [("Box", [intTy])],
       FcPrimitive tailStoredStateVar 0,
       FcTopBind
         ( FcNonRec
@@ -2386,7 +2386,7 @@ int32ArgumentVar = Var "value" (Unique 62) int32Ty
 
 separateConstructorPrograms :: [FcProgram]
 separateConstructorPrograms =
-  [ FcProgram (FcModuleId "test" "Test") [FcData "Int32" [] [("I32#", [int32Ty])]],
+  [ FcProgram (FcModuleId "test" "Test") [fcData "Int32" [] [("I32#", [int32Ty])]],
     FcProgram
       (FcModuleId "test" "Test")
       [ FcTopBind
@@ -2458,7 +2458,7 @@ separateBuiltinUnitPrograms :: [FcProgram]
 separateBuiltinUnitPrograms =
   [ FcProgram
       (FcModuleId "aihc-prim" "GHC.Tuple")
-      [ FcData "Unit" [] [("()", [])]
+      [ FcData (FcDataDecl (FcBuiltinOrigin "Unit") "Unit" [] [FcDataConDecl (FcBuiltinOrigin "()") "()" []])
       ],
     FcProgram
       (FcModuleId "" "Main")
@@ -2480,8 +2480,10 @@ separateNewtypePrograms =
   where
     declaration =
       FcNewtypeDecl
-        { fcNewtypeName = "Wrapper",
+        { fcNewtypeOrigin = FcTopLevelOrigin "test" "Test" "Wrapper",
+          fcNewtypeName = "Wrapper",
           fcNewtypeTyVars = [],
+          fcNewtypeConstructorOrigin = FcTopLevelOrigin "test" "Test" "Wrap",
           fcNewtypeConstructor = "Wrap",
           fcNewtypeRepresentation = intTy,
           fcNewtypeResult = wrapperTy
@@ -2511,3 +2513,15 @@ processExitProgram =
             }
         ]
     }
+
+fcData :: Text -> [TyVarId] -> [(Text, [TcType])] -> FcTopBind
+fcData dataName tyVars constructors =
+  FcData
+    ( FcDataDecl
+        (testOrigin dataName)
+        dataName
+        tyVars
+        [FcDataConDecl (testOrigin constructorName) constructorName fields | (constructorName, fields) <- constructors]
+    )
+  where
+    testOrigin = FcTopLevelOrigin "test" "Test"


### PR DESCRIPTION
## Changes

- Add stable origins to System FC data types, newtypes, and data constructors.
- Preserve declaration origins during desugaring, parsing, rendering, and GRIN lowering.
- Let System FC merge use data and newtype constructors as symbol providers.
- Remove resolved package constructor imports from whole-program Core.

## Reason

Whole-program merge did not identify data and newtype constructors as local providers.

The merged Core kept obsolete external declarations for constructors with available definitions.

## Impact

Whole-program HelloWorld Core no longer contains external package constructor declarations.

The compiler intrinsic `builtin.(#,#)` remains separate from package symbols.

## Validation

- `just fmt`
- `just check`
- Compile and run HelloWorld with `--whole-program`

## Progress counts

No fixture status changed.

No progress count changed.