### PR TITLE
feat: keep library Core and GRIN files

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -19,7 +19,7 @@ import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
 import Aihc.Cli.Runtime (readWasmClangProcessWithExitCode, wasmClangCommand)
 import Aihc.Cli.Store (installedLibrariesActivePath, installedLibrariesRoot)
-import Aihc.Fc (AxiomInterface, DesugarResult (..), FcModuleId (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractAxiomInterface, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, lowerPseudoOps, mergePrograms, optimizeProgram)
+import Aihc.Fc (AxiomInterface, DesugarResult (..), FcModuleId (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractAxiomInterface, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, lowerPseudoOps, mergePrograms, optimizeProgram, renderProgram)
 import Aihc.Grin qualified as Grin
 import Aihc.Llvm qualified as Llvm
 import Aihc.Native
@@ -68,7 +68,7 @@ import Aihc.Tc
   )
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket, bracketOnError)
-import Control.Monad (foldM)
+import Control.Monad (foldM, when)
 import Data.Bits (xor)
 import Data.ByteString qualified as BS
 import Data.Char (isHexDigit)
@@ -220,8 +220,8 @@ buildDependencies target environment usesImplicitPrelude buildBackend mainModule
 
 -- | Compile a package closure once, then install its frontend interfaces,
 -- whole-program bodies, and one archive set per requested target.
-installLibraries :: FilePath -> [LibraryPackage] -> [NativeTarget] -> IO (Either String FilePath)
-installLibraries storeRoot packages targets
+installLibraries :: FilePath -> [LibraryPackage] -> [NativeTarget] -> Bool -> Bool -> IO (Either String FilePath)
+installLibraries storeRoot packages targets keepCore keepGrin
   | all (null . libraryPackageFiles) packages = pure (Left "the package closure contains no library modules")
   | otherwise = do
       graphHash <- dependencyGraphHash packages
@@ -250,8 +250,30 @@ installLibraries storeRoot packages targets
           case sequence backendResults of
             Left err -> pure (Left err)
             Right _ -> do
+              writeIntermediateArtifacts artifactRoot keepCore keepGrin (dependencyUnits artifact)
               writeActiveLibraries storeRoot graphHash
               pure (Right artifactRoot)
+
+writeIntermediateArtifacts :: FilePath -> Bool -> Bool -> [DependencyUnit] -> IO ()
+writeIntermediateArtifacts artifactRoot keepCore keepGrin =
+  mapM_ writeUnit
+  where
+    writeUnit unit = do
+      let library = T.unpack (dependencyUnitPrimaryLibrary unit)
+          unitName = T.unpack (T.intercalate "+" (dependencyUnitModules unit))
+          corePath = artifactRoot </> "core" </> library </> unitName <> ".core"
+          grinRoot = artifactRoot </> "grin" </> library </> unitName
+      when keepCore $ do
+        createDirectoryIfMissing True (takeDirectory corePath)
+        TIO.writeFile corePath (withFinalNewline (renderProgram (dependencyUnitProgram unit)))
+      when keepGrin $ do
+        createDirectoryIfMissing True (takeDirectory grinRoot)
+        TIO.writeFile (grinRoot <> ".grin") (renderGrin (dependencyUnitGrin unit))
+        TIO.writeFile (grinRoot <> ".cps.grin") (renderGrin (Grin.cpsGrinProgram (dependencyUnitCpsGrin unit)))
+        TIO.writeFile (grinRoot <> ".gc.grin") (renderGrin (Grin.gcGrinProgram (Grin.lowerGc (dependencyUnitCpsGrin unit))))
+
+    renderGrin = withFinalNewline . Grin.renderProgram
+    withFinalNewline rendered = T.pack rendered <> "\n"
 
 readInstalledLibraries :: CompileEnvironment -> Bool -> IO (Either String (FilePath, DependencyArtifact))
 readInstalledLibraries environment incremental = do

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -345,7 +345,7 @@ runInstall opts = do
               hPutStrLn stderr (renderInstallFailureWithOptions opts failure)
               exitFailure
         else do
-          libraryResult <- installPackageLibraries (installTargets opts) plan
+          libraryResult <- installPackageLibraries (installTargets opts) (installKeepCore opts) (installKeepGrin opts) plan
           artifactRoot <- either (ioError . userError) pure libraryResult
           putStrLn ("libraries: " <> artifactRoot)
   where
@@ -413,10 +413,10 @@ packageSpecFromSource sourcePath = do
 
 -- | Install the compiled library closure represented by a generic package
 -- plan. Cabal chooses the modules; callers never enumerate them.
-installPackageLibraries :: [NativeTarget] -> PackagePlan -> IO (Either String FilePath)
-installPackageLibraries targets plan = do
+installPackageLibraries :: [NativeTarget] -> Bool -> Bool -> PackagePlan -> IO (Either String FilePath)
+installPackageLibraries targets keepCore keepGrin plan = do
   packages <- mapM packageLibrary (flattenPackagePlan plan)
-  installLibraries (planStoreRoot plan) packages targets
+  installLibraries (planStoreRoot plan) packages targets keepCore keepGrin
   where
     packageLibrary package = do
       gpd <- readPlanPackageDescription package

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -60,6 +60,8 @@ data InstallOptions = InstallOptions
     installStoreRoot :: !(Maybe FilePath),
     installOffline :: !Bool,
     installDryRun :: !Bool,
+    installKeepCore :: !Bool,
+    installKeepGrin :: !Bool,
     installTargets :: ![NativeTarget],
     installFirstErrorModule :: !Bool,
     installErrorFormat :: !InstallErrorFormat
@@ -262,6 +264,14 @@ installOptionsParser =
     <*> OA.switch
       ( OA.long "dry-run"
           <> OA.help "Plan the install without writing store artifacts or package cache files"
+      )
+    <*> OA.switch
+      ( OA.long "keep-core"
+          <> OA.help "Keep the generated System FC core in the library cache"
+      )
+    <*> OA.switch
+      ( OA.long "keep-grin"
+          <> OA.help "Keep the generated GRIN in the library cache"
       )
     <*> many nativeTargetOption
     <*> OA.switch

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -155,33 +155,39 @@ main =
           testCase "parses install package" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False [] False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False False False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text"]),
           testCase "parses install version" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" (Just "2.1") Nothing False False [] False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" (Just "2.1") Nothing False False False False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--version", "2.1"]),
           testCase "parses install offline and store" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") True False [] False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") True False False False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--offline", "--store", "/tmp/aihc-store"]),
           testCase "parses install dry run" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False True [] False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False True False False [] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--dry-run"]),
           testCase "parses first error module and JSON errors" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False [] True InstallErrorsJson)))
+              (Right (CmdInstall (InstallOptions "text" Nothing Nothing False False False False [] True InstallErrorsJson)))
               (parseCommandPure ["install", "text", "--first-error-module", "--json-errors"]),
           testCase "parses install targets" $
             assertEqual
               "command"
-              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") False False [Llvm, Wasm32Wasip3] False InstallErrorsHuman)))
+              (Right (CmdInstall (InstallOptions "text" Nothing (Just "/tmp/aihc-store") False False False False [Llvm, Wasm32Wasip3] False InstallErrorsHuman)))
               (parseCommandPure ["install", "text", "--store", "/tmp/aihc-store", "--target", "llvm", "--target", "wasm32-wasip3"]),
+          testCase "parses install keep-core and keep-grin" $
+            case parseCommandPure ["install", "text", "--target", "llvm", "--keep-core", "--keep-grin"] of
+              Right (CmdInstall options) -> do
+                assertBool "keeps Core" (installKeepCore options)
+                assertBool "keeps GRIN" (installKeepGrin options)
+              result -> assertFailure ("expected install options, got: " <> show result),
           testCase "rejects explicit dependency variants" $
             assertLeftContains "dependency" (parseCommandPure ["install", "a", "--dependency", "b=1.0.0:abcdef"]),
           testCase "parses repl" $
@@ -330,6 +336,7 @@ main =
           testCase "plans library components without executables" test_plansLibraryComponentsWithoutExecutables,
           testCase "writes scaffold artifacts" test_writeInstallScaffold,
           testCase "writes dependency scaffold artifacts first" test_writeInstallScaffoldWritesDependencies,
+          testCase "keeps selected library intermediate files" test_keepsLibraryIntermediateFiles,
           testCase "reports parse errors and writes no artifacts" test_reportsParseErrorsAndWritesNoArtifacts,
           testCase "reports rename errors and writes no artifacts" test_reportsRenameErrorsAndWritesNoArtifacts,
           testCase "renders preprocessed source for rename errors" test_rendersPreprocessedSourceForRenameErrors,
@@ -557,6 +564,32 @@ test_writeInstallScaffoldWritesDependencies =
     assertFileExists (planStorePath dependencyPlan </> "interfaces" </> "package-interface.json")
     assertFileExists (planStorePath dependencyPlan </> "fc" </> "package-fc.json")
 
+test_keepsLibraryIntermediateFiles :: Assertion
+test_keepsLibraryIntermediateFiles =
+  withTempDir "aihc-library-intermediates" $ \root -> do
+    let sourceRoot = root </> "source"
+        storeRoot = root </> "store"
+    createFixturePackage sourceRoot "demo" "0.1.0.0" "Demo" []
+    createDirectoryIfMissing True storeRoot
+    plan <- buildPackagePlanFromSource storeRoot (PackageSpec "demo" "0.1.0.0") sourceRoot
+    initialResult <- installPackageLibraries [Llvm] False False plan
+    artifactRoot <- either assertFailure pure initialResult
+    let corePath = artifactRoot </> "core" </> "demo" </> "Demo.core"
+        grinPath = artifactRoot </> "grin" </> "demo" </> "Demo.grin"
+        cpsGrinPath = artifactRoot </> "grin" </> "demo" </> "Demo.cps.grin"
+        gcGrinPath = artifactRoot </> "grin" </> "demo" </> "Demo.gc.grin"
+    assertFileDoesNotExist corePath
+    assertFileDoesNotExist grinPath
+    coreResult <- installPackageLibraries [Llvm] True False plan
+    either assertFailure (assertEqual "Core artifact root" artifactRoot) coreResult
+    assertFileExists corePath
+    assertFileDoesNotExist grinPath
+    grinResult <- installPackageLibraries [Llvm] False True plan
+    either assertFailure (assertEqual "GRIN artifact root" artifactRoot) grinResult
+    assertFileExists grinPath
+    assertFileExists cpsGrinPath
+    assertFileExists gcGrinPath
+
 test_reportsParseErrorsAndWritesNoArtifacts :: Assertion
 test_reportsParseErrorsAndWritesNoArtifacts =
   withTempDir "aihc-cli" $ \root -> do
@@ -668,7 +701,7 @@ test_rendersPreprocessedSourceForRenameErrors =
 
 defaultInstallOptionsForTest :: InstallOptions
 defaultInstallOptionsForTest =
-  InstallOptions "demo" Nothing Nothing False False [] False InstallErrorsHuman
+  InstallOptions "demo" Nothing Nothing False False False False [] False InstallErrorsHuman
 
 syntheticInstallFailure :: InstallFailure
 syntheticInstallFailure =
@@ -1080,7 +1113,7 @@ test_installedPackage =
           ]
       )
     plan <- buildPackagePlanFromSource storeRoot (PackageSpec "prim-fixture" "0.1.0.0") sourceRoot
-    installResult <- installPackageLibraries [Llvm] plan
+    installResult <- installPackageLibraries [Llvm] False False plan
     case installResult of
       Left err -> assertFailure err
       Right _ -> pure ()


### PR DESCRIPTION
## Summary

- Add `--keep-core` and `--keep-grin` to `aihc install`.
- Store Core files by library and module unit in the library cache.
- Store standard, CPS, and GC GRIN files by library and module unit.
- Keep intermediate files disabled by default.

## User impact

Users can inspect cached library compiler output after an install for one or more targets.

## Validation

- Run `just fmt`.
- Run `just check`.

## Progress counts

This change does not change progress counts.