### PR TITLE
fix(grin): keep local nullary constructors local

### DIFF
--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -335,7 +335,11 @@ lowerProgramWithEnvironment linkNames imported local environment program =
           lowerCodeInfosByName = programEnvironmentCodeInfosByName environment,
           lowerLocalCodeLinkNames = localCodeLinkNames,
           lowerReferencedExternalCodeLinkNames = Set.empty,
-          lowerLocalGlobalNames = Set.fromList [linkedName | (_, _, linkedName, _) <- programGlobalInfos linkNames program],
+          lowerLocalGlobalNames =
+            Set.fromList
+              ( [name | (name, arity) <- programConstructors program, arity == 0]
+                  <> [linkedName | (_, _, linkedName, _) <- programGlobalInfos linkNames program]
+              ),
           lowerReferencedExternalGlobalNames = Set.empty,
           lowerGlobalNames = programEnvironmentGlobals environment,
           lowerWhnfGlobalNames = programEnvironmentWhnfGlobals environment,

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -337,7 +337,7 @@ lowerProgramWithEnvironment linkNames imported local environment program =
           lowerReferencedExternalCodeLinkNames = Set.empty,
           lowerLocalGlobalNames =
             Set.fromList
-              ( [name | (name, arity) <- programConstructors program, arity == 0]
+              ( Map.elems (grinInterfaceWhnfGlobals local)
                   <> [linkedName | (_, _, linkedName, _) <- programGlobalInfos linkNames program]
               ),
           lowerReferencedExternalGlobalNames = Set.empty,

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -598,6 +598,21 @@ grinUnitTests =
         assertBool "no projection operation" (not ("project " `isInfixOf` rendered))
         result <- interpretProgramBinding "answer" program
         assertEqual "selected field is evaluated" (Right "Box 2") result,
+      testCase "FC lowering keeps local nullary constructors out of external globals" $ do
+        let localTy = TcTyCon (TyCon "Local" 0) []
+            localConstructor = Var "Local" (Unique 60) localTy
+            boxConstructor = Var "Box" (Unique 61) (TcFunTy localTy boxedIntTy)
+            answer = Var "answer" (Unique 62) boxedIntTy
+            core =
+              FcProgram
+                (FcModuleId "test" "Test")
+                [ fcData "Local" [] [("Local", [])],
+                  fcData "Box" [] [("Box", [localTy])],
+                  FcTopBind (FcNonRec answer (FcApp (FcVar boxConstructor) (FcVar localConstructor)))
+                ]
+            program = lowerProgramWithLinkNames (linkNamesForProgram ["test"] ["Test"] core) core
+        assertEqual "lint" [] (lintProgram program)
+        assertEqual "external globals" [] (grinExternalGlobals program),
       testCase "separate FC units do not capture dependency globals" $ do
         case separatePrograms of
           [providerCore, consumerCore] -> do


### PR DESCRIPTION
## Summary

- Derive local WHNF global ownership from the local GRIN interface.
- Prevent local constructor references from producing external global declarations.
- Add a regression test for a local constructor in a static value.

## Root cause

The link-name change built the local global set only from `FcTopBind` values.
It omitted nullary constructors from `FcData` declarations.

The GRIN interface already records which local values are WHNF globals.
External reference tracking now consumes that interface fact.

## Validation

- `just fmt`
- `just check`
- `cabal test -v0 aihc-grin:spec --test-options="--hide-successes"`

## Progress counts

- Increase the GRIN unit test count from 217 to 218.
- No fixture status count changes.
