### PR TITLE
refactor(grin): remove repeated layout arities

### DIFF
--- a/components/aihc-grin/src/Aihc/Grin/Parser.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Parser.hs
@@ -106,12 +106,11 @@ constructorDeclaration = do
   keyword "constructor"
   horizontal1
   constructorName <- name
-  _ <- MPC.char '/'
-  arity <- natural
+  legacyArity <- optional (MPC.char '/' *> natural)
   horizontal1
   fieldLayouts <- constructorLayouts
   lineEnd
-  when (arity /= length fieldLayouts) $ fail "constructor arity does not match its layout"
+  when (maybe False (/= length fieldLayouts) legacyArity) $ fail "constructor arity does not match its layout"
   pure (TopConstructor (constructorName, fieldLayouts))
 
 primitiveDeclaration :: Parser TopDeclaration
@@ -145,8 +144,7 @@ externalFunctionDeclaration = do
   keyword "external"
   horizontal1
   sourceName <- name
-  _ <- MPC.char '/'
-  arity <- natural
+  legacyArity <- optional (MPC.char '/' *> natural)
   horizontal1
   parameterLayouts <- layouts
   horizontal1
@@ -158,7 +156,7 @@ externalFunctionDeclaration = do
   horizontal1
   functionName <- FunctionName <$> name
   lineEnd
-  when (arity /= length parameterLayouts) $ fail "external function arity does not match its layouts"
+  when (maybe False (/= length parameterLayouts) legacyArity) $ fail "external function arity does not match its layouts"
   pure
     ( TopExternalFunction
         GrinCodeInfo

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -30,8 +30,6 @@ renderExternalFunction :: GrinCodeInfo -> String
 renderExternalFunction info =
   "external "
     <> renderName (grinCodeSourceName info)
-    <> "/"
-    <> show (length (grinCodeParameterLayouts info))
     <> " "
     <> renderLayouts (grinCodeParameterLayouts info)
     <> " -> "
@@ -43,8 +41,6 @@ renderConstructor :: (T.Text, [[RuntimeRep]]) -> String
 renderConstructor (name, fieldLayouts) =
   "constructor "
     <> renderName name
-    <> "/"
-    <> show (length fieldLayouts)
     <> " ["
     <> intercalate ", " (map renderLayout fieldLayouts)
     <> "]"
@@ -262,7 +258,7 @@ renderNodeTag nodeTag =
         <> "/"
         <> if all (== [BoxedRep Lifted]) argumentLayouts
           then show (length argumentLayouts)
-          else show (length argumentLayouts) <> renderLayouts argumentLayouts
+          else renderLayouts argumentLayouts
     GrinThunk functionName -> "F" <> renderFunctionName functionName
 
 renderLiteral :: GrinLiteral -> String

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -59,6 +59,27 @@ grinUnitTests =
               ]
           )
           (renderProgram program <> "\n"),
+      testCase "pretty printer does not repeat layout arities" $ do
+        let layouts = [[IntRep], []]
+            externalInfo = GrinCodeInfo "source" (FunctionName "external_code") layouts IntRep
+            function =
+              GrinFunction
+                { grinFunctionName = FunctionName "entry",
+                  grinFunctionLinkName = Nothing,
+                  grinFunctionParameters = [],
+                  grinFunctionResultRep = BoxedRep Lifted,
+                  grinFunctionBody = GrinStore (GrinNode (GrinClosure (FunctionName "worker") layouts) [])
+                }
+            program =
+              emptyGrinProgram
+                { grinConstructors = [("Pair", layouts)],
+                  grinExternalFunctions = [externalInfo],
+                  grinFunctions = [function]
+                }
+            rendered = renderProgram program
+        assertBool "constructor has only its layouts" ("constructor Pair [IntRep, []]" `isInfixOf` rendered)
+        assertBool "external function has only its layouts" ("external source [[IntRep], []] -> IntRep" `isInfixOf` rendered)
+        assertBool "closure has only its layouts" ("store (Pworker/[[IntRep], []])" `isInfixOf` rendered),
       testCase "FC lowering passes known WHNF arguments without thunk cells" $ do
         let program = lowerProgram applicationProgram
             rendered = renderProgram program
@@ -394,7 +415,7 @@ grinUnitTests =
         let program = lowerProgram zeroWidthSaturatedApplicationProgram
             rendered = renderProgram program
         assertEqual "lint" [] (lintProgram program)
-        assertBool "one logical argument remains" ("P$entry$zeroWidthTarget/1" `isInfixOf` rendered)
+        assertBool "one logical argument remains" ("P$entry$zeroWidthTarget/[[]]" `isInfixOf` rendered)
         assertBool "closure is not saturated" (not ("P$entry$zeroWidthTarget/0" `isInfixOf` rendered)),
       testCase "FC lowering preserves a zero-width application" $ do
         let program = lowerProgram zeroWidthUnknownApplicationProgram

--- a/test/Test/Fixtures/grin/boxed-int-field.yaml
+++ b/test/Test/Fixtures/grin/boxed-int-field.yaml
@@ -1,5 +1,5 @@
 expected: |-
-  constructor Box/1 [IntRep]
+  constructor Box [IntRep]
 
   global value%1002 :: BoxedRep Lifted = (CBox (42 :: IntRep))
 extensions:

--- a/test/Test/Fixtures/grin/narrow-integer-fields.yaml
+++ b/test/Test/Fixtures/grin/narrow-integer-fields.yaml
@@ -1,5 +1,5 @@
 expected: |-
-  constructor Narrow/2 [Int8Rep, Word16Rep]
+  constructor Narrow [Int8Rep, Word16Rep]
 
   global value%1002 :: BoxedRep Lifted = (CNarrow (123 :: Int8Rep) (456 :: Word16Rep))
 extensions:

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -1,5 +1,5 @@
 expected: |-
-  constructor IS/1 [IntRep]
+  constructor IS [IntRep]
 
   caf value%1003 :: BoxedRep Lifted = (Fvalue_thunk)
 

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -1,5 +1,5 @@
 expected: |-
-  constructor Box/1 [IntRep]
+  constructor Box [IntRep]
 
   caf value%1007 :: BoxedRep Lifted = (Fvalue_thunk)
 

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -1,5 +1,5 @@
 expected: |-
-  constructor Box/1 [IntRep]
+  constructor Box [IntRep]
 
   primitive realWorld#%1000 :: BoxedRep Lifted/0
 


### PR DESCRIPTION
## Summary

- Remove repeated arities from constructor and external-function output.
- Print non-default closure layouts without a repeated arity.
- Keep the old parser forms valid.
- Add a regression test and update GRIN golden results.

## Reason

The layout list already defines the arity. A repeated arity can disagree with its layout list.

The new output keeps all GRIN information without repeated data. Old GRIN input remains valid.

## Progress counts

Progress counts do not change.

## Validation

- Ran 10,000 generated GRIN round-trip tests.
- Ran all 218 GRIN tests.
- Ran `just fmt`.
- Ran `just check`.