### PR TITLE
ci: run generated reports each week

### DIFF
--- a/.github/workflows/generated-reports-update.yml
+++ b/.github/workflows/generated-reports-update.yml
@@ -2,7 +2,7 @@ name: Generated Reports Update
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 0"
   workflow_dispatch:
 
 permissions:
@@ -82,6 +82,6 @@ jobs:
           branch: "automation/generated-reports-update"
           title: "chore(reports): update generated reports"
           body: |
-            This PR was created automatically by the daily generated reports workflow.
+            This PR was created automatically by the weekly generated reports workflow.
 
             It updates generated README sections and report artifacts when they drift.


### PR DESCRIPTION
## Summary

- Run the generated reports workflow each Sunday at 03:17 UTC.
- Identify the automatic report pull request as a weekly update.

## Progress counts

- Decrease scheduled report runs from seven per week to one per week.

## Checks

- `just fmt`
- `just check`