### PR TITLE
fix(install): preserve module type identities

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -250,7 +250,7 @@ compileWithDependencies target wholeProgram dependencies parsed =
             then Left (CompileFrontendError ["typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules)])
             else
               let bindings = dependencyBindings dependencies <> concatMap tcModuleBindings checkedModules
-                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules moduleAsts
+                  desugared = map (desugarModuleWithBindings bindings) checkedModules
                in if not (all dsSuccess desugared)
                     then Left (CompileFrontendError (concatMap dsErrors desugared))
                     else do

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -401,7 +401,7 @@ compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedMo
                 else
                   let localBindings = concatMap tcModuleBindings checkedModules
                       bindings = compileStateBindings state <> localBindings
-                      desugared = zipWith (desugarModuleWithBindings bindings) checkedModules moduleAsts
+                      desugared = map (desugarModuleWithBindings bindings) checkedModules
                    in if not (all dsSuccess desugared)
                         then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else do

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -1260,7 +1260,7 @@ plannedPhases =
 fcArtifactValue :: PackagePlan -> InterfaceBuildResult -> Aeson.Value
 fcArtifactValue plan result =
   object
-    [ "schemaVersion" .= (2 :: Int),
+    [ "schemaVersion" .= (1 :: Int),
       "packageKey" .= packageVariantKeyValue (planPackageKey plan),
       "status" .= if null (interfaceFcDiagnostics result) then ("complete" :: String) else "partial",
       "contains" .= (["system-fc"] :: [String]),
@@ -1282,15 +1282,15 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       resolveResult = resolveWithDeps depExports (modulesInPackage currentPackage parsedModules)
       exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
       ownExports = Map.restrictKeys (extractInterface resolveResult) (Set.map (ModuleKey currentPackage) exposedModules)
-  (resolvedModuleAsts, checkedModules, tcModules, tcDiagnostics, tcInterface) <-
+  (checkedModules, tcModules, tcDiagnostics, tcInterface) <-
     typecheckInterfaceModules importedTcInterface (map snd (resolvedModules resolveResult))
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
       ownBindings = concatMap tcModuleBindings checkedModules
       allBindings = mergeBy tbIdentity [importedBindings, ownBindings]
-      fcResults = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
-      fcModules = zipWith fcModuleValue resolvedModuleAsts fcResults
+      fcResults = map (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules
+      fcModules = zipWith fcModuleValue checkedModules fcResults
       fcDiagnostics = concatMap fcModuleDiagnosticValues fcModules
   pure
     InterfaceBuildResult
@@ -1315,16 +1315,16 @@ packageVariantResolvePackage key =
       packageId = PackageId (T.intercalate "-" (packageVariantLibraryId key))
     }
 
-typecheckInterfaceModules :: TcInterface -> [Module] -> IO ([Module], [Module], [Aeson.Value], [Aeson.Value], TcInterface)
+typecheckInterfaceModules :: TcInterface -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], TcInterface)
 typecheckInterfaceModules importedTcInterface modules = do
   currentModule <- newIORef (listToMaybe sortedModules)
   result <- timeout typecheckPhaseTimeoutMicros (go currentModule)
   case result of
     Just (checkedModules, tcModules, tcInterface) ->
-      pure (sortedModules, checkedModules, tcModules, concatMap tcModuleDiagnosticValues tcModules, tcInterface)
+      pure (checkedModules, tcModules, concatMap tcModuleDiagnosticValues tcModules, tcInterface)
     Nothing -> do
       current <- readIORef currentModule
-      pure (sortedModules, [], [], [typecheckTimeoutDiagnostic current], mempty)
+      pure ([], [], [typecheckTimeoutDiagnostic current], mempty)
   where
     sortedModules = sortModulesByImports modules
     go current = do
@@ -1561,7 +1561,7 @@ unlitBird =
 interfaceArtifactValue :: PackagePlan -> InterfaceBuildResult -> Aeson.Value
 interfaceArtifactValue plan result =
   object
-    [ "schemaVersion" .= (1 :: Int),
+    [ "schemaVersion" .= (2 :: Int),
       "packageName" .= packageName currentPackage,
       "packageId" .= packageIdText (packageId currentPackage),
       "packageKey" .= packageVariantKeyValue (planPackageKey plan),

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -1280,17 +1280,19 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       resolveResult = resolveWithDeps depExports (modulesInPackage currentPackage parsedModules)
       exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
       ownExports = Map.restrictKeys (extractInterface resolveResult) (Set.map (ModuleKey currentPackage) exposedModules)
-  (checkedModules, tcModules, tcDiagnostics, tcInterface) <-
+  (resolvedModuleAsts, checkedModules, tcModules, tcDiagnostics, tcInterface) <-
     typecheckInterfaceModules importedTcInterface (map snd (resolvedModules resolveResult))
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
       ownBindings = concatMap tcModuleBindings checkedModules
       allBindings = mergeBy tbName [importedBindings, ownBindings]
-      resolvedModuleAsts = map snd (resolvedModules resolveResult)
-      fcResults = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
+      fcResults = zipWith desugarCheckedModule checkedModules resolvedModuleAsts
       fcModules = zipWith fcModuleValue resolvedModuleAsts fcResults
       fcDiagnostics = concatMap fcModuleDiagnosticValues fcModules
+      desugarCheckedModule checkedModule resolvedModule =
+        let moduleBindings = mergeBy tbName [allBindings, tcModuleBindings checkedModule]
+         in desugarModuleWithDataTypes moduleBindings (tcInterfaceDataTypes tcInterface) checkedModule resolvedModule
   pure
     InterfaceBuildResult
       { interfaceModuleExports = ownExports,
@@ -1314,16 +1316,16 @@ packageVariantResolvePackage key =
       packageId = PackageId (T.intercalate "-" (packageVariantLibraryId key))
     }
 
-typecheckInterfaceModules :: TcInterface -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], TcInterface)
+typecheckInterfaceModules :: TcInterface -> [Module] -> IO ([Module], [Module], [Aeson.Value], [Aeson.Value], TcInterface)
 typecheckInterfaceModules importedTcInterface modules = do
   currentModule <- newIORef (listToMaybe sortedModules)
   result <- timeout typecheckPhaseTimeoutMicros (go currentModule)
   case result of
     Just (checkedModules, tcModules, tcInterface) ->
-      pure (checkedModules, tcModules, concatMap tcModuleDiagnosticValues tcModules, tcInterface)
+      pure (sortedModules, checkedModules, tcModules, concatMap tcModuleDiagnosticValues tcModules, tcInterface)
     Nothing -> do
       current <- readIORef currentModule
-      pure ([], [], [typecheckTimeoutDiagnostic current], mempty)
+      pure (sortedModules, [], [], [typecheckTimeoutDiagnostic current], mempty)
   where
     sortedModules = sortModulesByImports modules
     go current = do

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -77,6 +77,7 @@ import Aihc.Resolve
   )
 import Aihc.Tc
   ( Pred (..),
+    TcBindingId (..),
     TcBindingResult (..),
     TcDiagnostic (..),
     TcInterface (..),
@@ -86,6 +87,7 @@ import Aihc.Tc
     TyVarId (..),
     Unique (..),
     renderTcType,
+    tbName,
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleSuccess,
@@ -809,7 +811,7 @@ prepareInstallScaffoldUncached cache plan = do
           depExports = foldl' Map.union Map.empty (map (interfaceModuleExports . preparedInterface) preparedDependencies)
           dependencyInterfaces = map preparedInterface preparedDependencies
           importedTcInterface = mconcat (map interfaceTcInterface dependencyInterfaces)
-          importedBindings = mergeBy tbName (map interfaceTcBindings dependencyInterfaces)
+          importedBindings = mergeBy tbIdentity (map interfaceTcBindings dependencyInterfaces)
       interfaceResult <- generatePackageInterface depExports importedTcInterface importedBindings plan
       pure $
         case blockingInterfaceFailures interfaceResult of
@@ -1258,7 +1260,7 @@ plannedPhases =
 fcArtifactValue :: PackagePlan -> InterfaceBuildResult -> Aeson.Value
 fcArtifactValue plan result =
   object
-    [ "schemaVersion" .= (1 :: Int),
+    [ "schemaVersion" .= (2 :: Int),
       "packageKey" .= packageVariantKeyValue (planPackageKey plan),
       "status" .= if null (interfaceFcDiagnostics result) then ("complete" :: String) else "partial",
       "contains" .= (["system-fc"] :: [String]),
@@ -1286,13 +1288,10 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
       ownBindings = concatMap tcModuleBindings checkedModules
-      allBindings = mergeBy tbName [importedBindings, ownBindings]
-      fcResults = zipWith desugarCheckedModule checkedModules resolvedModuleAsts
+      allBindings = mergeBy tbIdentity [importedBindings, ownBindings]
+      fcResults = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
       fcModules = zipWith fcModuleValue resolvedModuleAsts fcResults
       fcDiagnostics = concatMap fcModuleDiagnosticValues fcModules
-      desugarCheckedModule checkedModule resolvedModule =
-        let moduleBindings = mergeBy tbName [allBindings, tcModuleBindings checkedModule]
-         in desugarModuleWithDataTypes moduleBindings (tcInterfaceDataTypes tcInterface) checkedModule resolvedModule
   pure
     InterfaceBuildResult
       { interfaceModuleExports = ownExports,
@@ -1563,6 +1562,8 @@ interfaceArtifactValue :: PackagePlan -> InterfaceBuildResult -> Aeson.Value
 interfaceArtifactValue plan result =
   object
     [ "schemaVersion" .= (1 :: Int),
+      "packageName" .= packageName currentPackage,
+      "packageId" .= packageIdText (packageId currentPackage),
       "packageKey" .= packageVariantKeyValue (planPackageKey plan),
       "status" .= interfaceStatus result,
       "contains" .= (["name-resolution", "types", "fixities"] :: [String]),
@@ -1578,6 +1579,8 @@ interfaceArtifactValue plan result =
           ],
       "typecheck" .= interfaceTcModules result
     ]
+  where
+    currentPackage = packageVariantResolvePackage (planPackageKey plan)
 
 interfaceStatus :: InterfaceBuildResult -> String
 interfaceStatus result =
@@ -1644,6 +1647,8 @@ tcBindingValue :: TcBindingResult -> Aeson.Value
 tcBindingValue binding =
   object
     [ "name" .= tbName binding,
+      "packageId" .= tcBindingPackageId (tbIdentity binding),
+      "originModule" .= tcBindingModuleName (tbIdentity binding),
       "type" .= renderTcType (tbType binding),
       "typeJson" .= tcTypeValue (tbType binding)
     ]

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -125,7 +125,6 @@ data ReplStep
 
 data CheckedExpression = CheckedExpression
   { checkedExpr :: !Expr,
-    checkedResolvedModule :: !Module,
     checkedTcModule :: !Module,
     checkedType :: !TcType
   }
@@ -196,11 +195,10 @@ evaluateExpression session input = do
     Left err -> pure (Left err)
     Right checked -> do
       let expr = checkedExpr checked
-          resolvedModule = checkedResolvedModule checked
           tcResult = checkedTcModule checked
           inferredType = checkedType checked
           allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
-          dsResult = desugarModuleWithBindings allBindings tcResult resolvedModule
+          dsResult = desugarModuleWithBindings allBindings tcResult
       if not (dsSuccess dsResult)
         then pure (Left (ReplDesugarError (dsErrors dsResult)))
         else do
@@ -239,7 +237,6 @@ typecheckExpression session input = do
   Right
     CheckedExpression
       { checkedExpr = expr,
-        checkedResolvedModule = resolvedModule,
         checkedTcModule = tcResult,
         checkedType = inferredType
       }
@@ -500,8 +497,8 @@ buildBaseContext modules =
       if all tcModuleSuccess tcResults
         then do
           let allBindings = concatMap tcModuleBindings tcResults
-              dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults moduleAsts
-              bindingTypes = moduleBindingTypes moduleAsts tcResults
+              dsResults = map (desugarModuleWithBindings allBindings) tcResults
+              bindingTypes = moduleBindingTypes tcResults
           if all dsSuccess dsResults
             then
               pure
@@ -528,12 +525,12 @@ mergeImportedTerms preferred fallback =
 unionBindingTypes :: Map.Map Text (Map.Map Text TcType) -> Map.Map Text (Map.Map Text TcType) -> Map.Map Text (Map.Map Text TcType)
 unionBindingTypes = Map.unionWith Map.union
 
-moduleBindingTypes :: [Module] -> [Module] -> Map.Map Text (Map.Map Text TcType)
-moduleBindingTypes sourceModules checkedModules =
+moduleBindingTypes :: [Module] -> Map.Map Text (Map.Map Text TcType)
+moduleBindingTypes checkedModules =
   Map.fromList
     [ (moduleName', bindingTypesForModule checkedModule)
-    | (sourceModule, checkedModule) <- zip sourceModules checkedModules,
-      Just moduleName' <- [Syntax.moduleName sourceModule]
+    | checkedModule <- checkedModules,
+      Just moduleName' <- [Syntax.moduleName checkedModule]
     ]
 
 bindingTypesForModule :: Module -> Map.Map Text TcType

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -35,10 +35,11 @@ import Aihc.Parser.Syntax
     unqualifiedNameFromText,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, modulesInPackage, resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), PackageId (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, modulesInPackage, resolveWithDeps, unnamedPackage)
 import Aihc.Tc
   ( InstanceInfo,
     Pred (..),
+    TcBindingId (..),
     TcBindingResult (..),
     TcDiagnostic (..),
     TcErrorKind (..),
@@ -50,6 +51,7 @@ import Aihc.Tc
     renderPred,
     renderTcSignature,
     renderTcType,
+    tbName,
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleInstances,
@@ -82,7 +84,7 @@ import System.FilePath qualified as FilePath
 
 data ReplSession = ReplSession
   { replModuleExports :: !ModuleExports,
-    replImportedTerms :: ![(Text, TypeScheme)],
+    replImportedTerms :: ![(TcBindingId, TypeScheme)],
     replBindingTypes :: !(Map.Map Text (Map.Map Text TcType)),
     replImportedInstances :: ![InstanceInfo],
     replDependencyProgram :: !FcProgram,
@@ -465,13 +467,13 @@ dropWhileEnd predicate = reverse . dropWhile predicate . reverse
 
 data Interface = Interface
   { interfaceExports :: ModuleExports,
-    interfaceImportedTerms :: [(Text, TypeScheme)],
+    interfaceImportedTerms :: [(TcBindingId, TypeScheme)],
     interfaceBindingTypes :: Map.Map Text (Map.Map Text TcType)
   }
 
 data ReplBaseContext = ReplBaseContext
   { replBaseExports :: !ModuleExports,
-    replBaseImportedTerms :: ![(Text, TypeScheme)],
+    replBaseImportedTerms :: ![(TcBindingId, TypeScheme)],
     replBaseBindingTypes :: !(Map.Map Text (Map.Map Text TcType)),
     replBaseImportedInstances :: ![InstanceInfo],
     replBaseProgram :: !FcProgram
@@ -515,11 +517,11 @@ buildBaseContext modules =
     ResolveResult {resolveErrors} ->
       ioError (userError ("repl error: could not resolve bundled aihc-base Prelude: " <> show resolveErrors))
 
-bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
+bindingImportedTerm :: TcBindingResult -> (TcBindingId, TypeScheme)
 bindingImportedTerm binding =
-  (tbName binding, tcTypeScheme (tbType binding))
+  (tbIdentity binding, tcTypeScheme (tbType binding))
 
-mergeImportedTerms :: [(Text, TypeScheme)] -> [(Text, TypeScheme)] -> [(Text, TypeScheme)]
+mergeImportedTerms :: [(TcBindingId, TypeScheme)] -> [(TcBindingId, TypeScheme)] -> [(TcBindingId, TypeScheme)]
 mergeImportedTerms preferred fallback =
   Map.toList (Map.fromList fallback <> Map.fromList preferred)
 
@@ -540,14 +542,14 @@ bindingTypesForModule =
     . map (\binding -> (normalizeImportedBindingName (tbName binding), tbType binding))
     . tcModuleBindings
 
-importedTermBindings :: [(Text, TypeScheme)] -> [TcBindingResult]
+importedTermBindings :: [(TcBindingId, TypeScheme)] -> [TcBindingResult]
 importedTermBindings terms =
   [ TcBindingResult
-      { tbName = name,
-        tbDisplayName = name,
+      { tbIdentity = identity,
+        tbDisplayName = tcBindingName identity,
         tbType = instantiateSchemeBody scheme
       }
-  | (name, scheme) <- terms
+  | (identity, scheme) <- terms
   ]
 
 instantiateSchemeBody :: TypeScheme -> TcType
@@ -693,11 +695,13 @@ loadInterface path = do
 parseInterface :: Aeson.Value -> AesonTypes.Parser Interface
 parseInterface =
   Aeson.withObject "package interface" $ \obj -> do
+    interfacePackage <- Package <$> obj .: "packageName" <*> (PackageId <$> obj .: "packageId")
     modules <- obj .: "modules"
     tcModules <- obj .:? "typecheck" .!= []
+    mapM_ (validateTcModule interfacePackage) tcModules
     pure
       Interface
-        { interfaceExports = Map.fromList [(ModuleKey unnamedPackage (interfaceModuleName modu), interfaceModuleScope modu) | modu <- modules],
+        { interfaceExports = Map.fromList [(ModuleKey interfacePackage (interfaceModuleName modu), interfaceModuleScope interfacePackage modu) | modu <- modules],
           interfaceImportedTerms = concatMap interfaceTcModuleTerms tcModules,
           interfaceBindingTypes =
             Map.fromList
@@ -705,6 +709,19 @@ parseInterface =
               | modu <- tcModules
               ]
         }
+
+validateTcModule :: Package -> InterfaceTcModule -> AesonTypes.Parser ()
+validateTcModule interfacePackage modu =
+  mapM_ validateBinding (interfaceTcModuleBindings modu)
+  where
+    expectedPackageId = packageIdText (packageId interfacePackage)
+    expectedModuleName = interfaceTcModuleName modu
+    validateBinding binding
+      | interfaceTcBindingPackageId binding /= expectedPackageId =
+          fail "typecheck binding packageId does not match the interface packageId"
+      | interfaceTcBindingModuleName binding /= expectedModuleName =
+          fail "typecheck binding originModule does not match its typecheck module"
+      | otherwise = pure ()
 
 data InterfaceTcModule = InterfaceTcModule
   { interfaceTcModuleName :: !Text,
@@ -714,6 +731,8 @@ data InterfaceTcModule = InterfaceTcModule
 
 data InterfaceTcBinding = InterfaceTcBinding
   { interfaceTcBindingName :: !Text,
+    interfaceTcBindingPackageId :: !Text,
+    interfaceTcBindingModuleName :: !Text,
     interfaceTcBindingType :: !(Maybe TcType)
   }
   deriving (Show)
@@ -730,32 +749,34 @@ instance Aeson.FromJSON InterfaceTcBinding where
     Aeson.withObject "typecheck binding" $ \obj ->
       InterfaceTcBinding
         <$> obj .: "name"
+        <*> obj .: "packageId"
+        <*> obj .: "originModule"
         <*> (obj .:? "typeJson" >>= traverse parseTcTypeJson)
 
-interfaceTcModuleTerms :: InterfaceTcModule -> [(Text, TypeScheme)]
+interfaceTcModuleTerms :: InterfaceTcModule -> [(TcBindingId, TypeScheme)]
 interfaceTcModuleTerms modu =
-  [ (normalizeImportedBindingName name, tcTypeScheme ty)
-  | InterfaceTcBinding name (Just ty) <- interfaceTcModuleBindings modu
+  [ (TcBindingId packageId moduleName (normalizeImportedBindingName name), tcTypeScheme ty)
+  | InterfaceTcBinding name packageId moduleName (Just ty) <- interfaceTcModuleBindings modu
   ]
 
 interfaceTcModuleBindingTypes :: InterfaceTcModule -> Map.Map Text TcType
 interfaceTcModuleBindingTypes modu =
   Map.fromList
     [ (normalizeImportedBindingName name, ty)
-    | InterfaceTcBinding name (Just ty) <- interfaceTcModuleBindings modu
+    | InterfaceTcBinding name _ _ (Just ty) <- interfaceTcModuleBindings modu
     ]
 
-interfaceModuleScope :: InterfaceModule -> Scope
-interfaceModuleScope modu =
+interfaceModuleScope :: Package -> InterfaceModule -> Scope
+interfaceModuleScope interfacePackage modu =
   Scope
     { scopeTerms =
         Map.fromList
-          [ (name, resolvedTopLevel (interfaceModuleName modu) name)
+          [ (name, resolvedTopLevel interfacePackage (interfaceModuleName modu) name)
           | name <- interfaceModuleTerms modu
           ],
       scopeTypes =
         Map.fromList
-          [ (name, resolvedTopLevel (interfaceModuleName modu) name)
+          [ (name, resolvedTopLevel interfacePackage (interfaceModuleName modu) name)
           | name <- interfaceModuleTypes modu
           ],
       scopeConstructors = interfaceModuleConstructors modu,
@@ -765,9 +786,9 @@ interfaceModuleScope modu =
       scopeQualifiedModules = Map.empty
     }
 
-resolvedTopLevel :: Text -> Text -> ResolvedName
-resolvedTopLevel moduleName name =
-  ResolvedTopLevel (packageId unnamedPackage) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
+resolvedTopLevel :: Package -> Text -> Text -> ResolvedName
+resolvedTopLevel originPackage moduleName name =
+  ResolvedTopLevel (packageId originPackage) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
 
 findInstalledBaseInterface :: FilePath -> IO FilePath
 findInstalledBaseInterface storeRoot = do
@@ -815,28 +836,32 @@ isBaseManifest candidate =
 
 ensurePreludeMvpScope :: ModuleExports -> ModuleExports
 ensurePreludeMvpScope exports =
-  Map.insert preludeKey preludeScope exports
+  if any ((== "Prelude") . moduleKeyName) (Map.keys exports)
+    then Map.mapWithKey addPreludeNames exports
+    else Map.insert unnamedPreludeKey (addNames unnamedPackage emptyScope) exports
   where
-    preludeKey = ModuleKey unnamedPackage "Prelude"
-    existing = Map.findWithDefault emptyScope preludeKey exports
-    preludeScope =
+    unnamedPreludeKey = ModuleKey unnamedPackage "Prelude"
+    addPreludeNames moduleKey scope
+      | moduleKeyName moduleKey == "Prelude" = addNames (moduleKeyPackage moduleKey) scope
+      | otherwise = scope
+    addNames originPackage existing =
       existing
         { scopeTerms =
             Map.fromList
-              [ ("++", resolvedTopLevel "Prelude" "++")
+              [ ("++", resolvedTopLevel originPackage "Prelude" "++")
               ]
               <> scopeTerms existing,
           scopeTypes =
             Map.fromList
-              [ ("Char", resolvedTopLevel "Prelude" "Char"),
-                ("String", resolvedTopLevel "Prelude" "String")
+              [ ("Char", resolvedTopLevel originPackage "Prelude" "Char"),
+                ("String", resolvedTopLevel originPackage "Prelude" "String")
               ]
               <> scopeTypes existing
         }
 
-ensurePreludeMvpTerms :: [(Text, TypeScheme)] -> [(Text, TypeScheme)]
+ensurePreludeMvpTerms :: [(TcBindingId, TypeScheme)] -> [(TcBindingId, TypeScheme)]
 ensurePreludeMvpTerms terms =
-  Map.toList (Map.fromList [("++", appendScheme)] <> Map.fromList terms)
+  Map.toList (Map.fromList [(TcBindingId "" "Prelude" "++", appendScheme)] <> Map.fromList terms)
 
 ensurePreludeMvpBindingTypes :: Map.Map Text (Map.Map Text TcType) -> Map.Map Text (Map.Map Text TcType)
 ensurePreludeMvpBindingTypes =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -351,7 +351,6 @@ main =
           testCase "checks cast-style instance methods using dependency id" test_checksCastStyleDependencyId,
           testCase "checks constraint-kinded multi-parameter classes" test_checksConstraintKindedMultiParameterClasses,
           testCase "keeps class method types separate between modules" test_keepsClassMethodTypesSeparateBetweenModules,
-          testCase "keeps resolved and checked modules paired" test_keepsResolvedAndCheckedModulesPaired,
           testCase "checks packages without writing install artifacts" test_checkPackagePlanWritesNoArtifacts,
           testCase "uses local provider for base dependencies" test_usesLocalProviderForBase,
           testCase "uses local provider for ghc-prim dependencies" test_usesLocalProviderForGhcPrim,
@@ -915,56 +914,6 @@ test_keepsClassMethodTypesSeparateBetweenModules =
 
     _ <- expectInstallSuccess (writeInstallScaffold plan)
     pure ()
-
-test_keepsResolvedAndCheckedModulesPaired :: Assertion
-test_keepsResolvedAndCheckedModulesPaired =
-  withTempDir "aihc-module-pairs" $ \root -> do
-    let sourceRoot = root </> "source"
-        sourceDir = sourceRoot </> "src"
-        storeRoot = root </> "store"
-        originSource =
-          unlines
-            [ "{-# LANGUAGE NoImplicitPrelude #-}",
-              "module Origin where",
-              "data Flag = Clear | Set",
-              "class Marks a where",
-              "  mark :: a -> a",
-              "instance Marks Flag where",
-              "  mark value = value"
-            ]
-        useSource =
-          unlines
-            [ "{-# LANGUAGE NoImplicitPrelude #-}",
-              "module Use where",
-              "import Origin (Flag)",
-              "use :: Flag -> Flag",
-              "use value = value"
-            ]
-    createFixturePackageWithOtherModules sourceRoot "demo" "0.1.0.0" "Use" ["Origin"] []
-    writeFile (sourceDir </> "Origin.hs") (originSource <> fixtureTupleDeclaration)
-    writeFile (sourceDir </> "Use.hs") useSource
-    createDirectoryIfMissing True storeRoot
-    plan <- buildPackagePlanFromSource storeRoot (PackageSpec "demo" "0.1.0.0") sourceRoot
-
-    result <- expectInstallSuccess (writeInstallScaffold plan)
-    fcJson <- BL8.readFile (resultFcPath result)
-    artifact <- maybe (assertFailure "expected an FC artifact") pure (Aeson.decode fcJson)
-    let modulePrograms =
-          case artifact of
-            Aeson.Object artifactObject ->
-              case KeyMap.lookup "modules" artifactObject of
-                Just (Aeson.Array modules) ->
-                  [ (moduleName, program)
-                  | Aeson.Object moduleObject <- foldr (:) [] modules,
-                    Just (Aeson.String moduleName) <- [KeyMap.lookup "module" moduleObject],
-                    Just (Aeson.String program) <- [KeyMap.lookup "program" moduleObject]
-                  ]
-                _ -> []
-            _ -> []
-        useProgram = lookup "Use" modulePrograms
-        originProgram = lookup "Origin" modulePrograms
-    assertBool ("Use module has the wrong FC program: " <> show modulePrograms) (maybe False ("use :" `T.isInfixOf`) useProgram)
-    assertBool ("Origin module has the wrong FC program: " <> show modulePrograms) (maybe False ("$fMarksFlag" `T.isInfixOf`) originProgram)
 
 test_checksConstraintKindedMultiParameterClasses :: Assertion
 test_checksConstraintKindedMultiParameterClasses =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -47,8 +47,8 @@ import Aihc.Fc
 import Aihc.Grin qualified as Grin
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Native (NativeTarget (..))
-import Aihc.Resolve (ModuleKey (..), Scope (..), unnamedPackage)
-import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
+import Aihc.Resolve (ModuleKey (..), Package (..), PackageId (..), Scope (..))
+import Aihc.Tc (RuntimeRep (..), TcBindingId (..), TcType (..), TyCon (..), Unique (..))
 import Control.Exception (bracket)
 import Data.Aeson (object, (.=))
 import Data.Aeson qualified as Aeson
@@ -422,21 +422,39 @@ test_loadsInstalledBaseInterfaceForRepl =
       interfacePath
       ( Aeson.encode
           ( object
-              [ "modules"
+              [ "packageName" .= ("aihc-base" :: String),
+                "packageId" .= ("aihc-base-id" :: String),
+                "modules"
                   .= [ object
                          [ "module" .= ("Prelude" :: String),
-                           "terms" .= ([] :: [String]),
+                           "terms" .= (["installedValue"] :: [String]),
                            "types" .= ([] :: [String]),
                            "constructors" .= object [],
                            "recordFields" .= object [],
                            "methods" .= object []
+                         ]
+                     ],
+                "typecheck"
+                  .= [ object
+                         [ "module" .= ("Prelude" :: String),
+                           "bindings"
+                             .= [ object
+                                    [ "name" .= ("installedValue" :: String),
+                                      "packageId" .= ("aihc-base-id" :: String),
+                                      "originModule" .= ("Prelude" :: String),
+                                      "typeJson" .= object ["tag" .= ("con" :: String), "name" .= ("Int" :: String), "arity" .= (0 :: Int), "args" .= ([] :: [Aeson.Value])]
+                                    ]
+                                ]
                          ]
                      ]
               ]
           )
       )
     session <- loadReplSession (Just storeRoot)
-    case Map.lookup (ModuleKey unnamedPackage "Prelude") (replModuleExports session) of
+    let installedBase = Package "aihc-base" (PackageId "aihc-base-id")
+        installedIdentity = TcBindingId "aihc-base-id" "Prelude" "installedValue"
+    assertBool "installed binding keeps its identity" (installedIdentity `elem` map fst (replImportedTerms session))
+    case Map.lookup (ModuleKey installedBase "Prelude") (replModuleExports session) of
       Nothing -> assertFailure "Prelude scope not loaded"
       Just preludeScope -> do
         assertBool "Prelude exposes Char" (Map.member "Char" (scopeTypes preludeScope))

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -350,6 +350,8 @@ main =
           testCase "type-checks with dependency type environments" test_typeChecksWithDependencyTypeEnvironments,
           testCase "checks cast-style instance methods using dependency id" test_checksCastStyleDependencyId,
           testCase "checks constraint-kinded multi-parameter classes" test_checksConstraintKindedMultiParameterClasses,
+          testCase "keeps class method types separate between modules" test_keepsClassMethodTypesSeparateBetweenModules,
+          testCase "keeps resolved and checked modules paired" test_keepsResolvedAndCheckedModulesPaired,
           testCase "checks packages without writing install artifacts" test_checkPackagePlanWritesNoArtifacts,
           testCase "uses local provider for base dependencies" test_usesLocalProviderForBase,
           testCase "uses local provider for ghc-prim dependencies" test_usesLocalProviderForGhcPrim,
@@ -858,6 +860,93 @@ test_checksCastStyleDependencyId =
       ( "external \\\"dep" `isInfixOf` renderedFc
           && length (filter (isPrefixOf "Dep.id :") (tails renderedFc)) == 1
       )
+
+test_keepsClassMethodTypesSeparateBetweenModules :: Assertion
+test_keepsClassMethodTypesSeparateBetweenModules =
+  withTempDir "aihc-class-method-types" $ \root -> do
+    let sourceRoot = root </> "source"
+        sourceDir = sourceRoot </> "src"
+        storeRoot = root </> "store"
+        classSource =
+          unlines
+            [ "{-# LANGUAGE NoImplicitPrelude #-}",
+              "module ClassBits where",
+              "data Bool = False | True",
+              "class Bits a where",
+              "  xor :: a -> a -> a",
+              "instance Bits Bool where",
+              "  xor left _ = left",
+              "applyXor :: Bits a => a -> a -> a",
+              "applyXor = xor"
+            ]
+        collisionSource =
+          unlines
+            [ "{-# LANGUAGE NoImplicitPrelude #-}",
+              "module Collision where",
+              "import ClassBits (Bool)",
+              "xor :: Bool -> Bool",
+              "xor value = value",
+              "applyXor :: Bool -> Bool",
+              "applyXor value = value"
+            ]
+    createFixturePackageWithOtherModules sourceRoot "demo" "0.1.0.0" "ClassBits" ["Collision"] []
+    writeFile (sourceDir </> "ClassBits.hs") (classSource <> fixtureTupleDeclaration)
+    writeFile (sourceDir </> "Collision.hs") collisionSource
+    createDirectoryIfMissing True storeRoot
+    plan <- buildPackagePlanFromSource storeRoot (PackageSpec "demo" "0.1.0.0") sourceRoot
+
+    _ <- expectInstallSuccess (writeInstallScaffold plan)
+    pure ()
+
+test_keepsResolvedAndCheckedModulesPaired :: Assertion
+test_keepsResolvedAndCheckedModulesPaired =
+  withTempDir "aihc-module-pairs" $ \root -> do
+    let sourceRoot = root </> "source"
+        sourceDir = sourceRoot </> "src"
+        storeRoot = root </> "store"
+        originSource =
+          unlines
+            [ "{-# LANGUAGE NoImplicitPrelude #-}",
+              "module Origin where",
+              "data Flag = Clear | Set",
+              "class Marks a where",
+              "  mark :: a -> a",
+              "instance Marks Flag where",
+              "  mark value = value"
+            ]
+        useSource =
+          unlines
+            [ "{-# LANGUAGE NoImplicitPrelude #-}",
+              "module Use where",
+              "import Origin (Flag)",
+              "use :: Flag -> Flag",
+              "use value = value"
+            ]
+    createFixturePackageWithOtherModules sourceRoot "demo" "0.1.0.0" "Use" ["Origin"] []
+    writeFile (sourceDir </> "Origin.hs") (originSource <> fixtureTupleDeclaration)
+    writeFile (sourceDir </> "Use.hs") useSource
+    createDirectoryIfMissing True storeRoot
+    plan <- buildPackagePlanFromSource storeRoot (PackageSpec "demo" "0.1.0.0") sourceRoot
+
+    result <- expectInstallSuccess (writeInstallScaffold plan)
+    fcJson <- BL8.readFile (resultFcPath result)
+    artifact <- maybe (assertFailure "expected an FC artifact") pure (Aeson.decode fcJson)
+    let modulePrograms =
+          case artifact of
+            Aeson.Object artifactObject ->
+              case KeyMap.lookup "modules" artifactObject of
+                Just (Aeson.Array modules) ->
+                  [ (moduleName, program)
+                  | Aeson.Object moduleObject <- foldr (:) [] modules,
+                    Just (Aeson.String moduleName) <- [KeyMap.lookup "module" moduleObject],
+                    Just (Aeson.String program) <- [KeyMap.lookup "program" moduleObject]
+                  ]
+                _ -> []
+            _ -> []
+        useProgram = lookup "Use" modulePrograms
+        originProgram = lookup "Origin" modulePrograms
+    assertBool ("Use module has the wrong FC program: " <> show modulePrograms) (maybe False ("use :" `T.isInfixOf`) useProgram)
+    assertBool ("Origin module has the wrong FC program: " <> show modulePrograms) (maybe False ("$fMarksFlag" `T.isInfixOf`) originProgram)
 
 test_checksConstraintKindedMultiParameterClasses :: Assertion
 test_checksConstraintKindedMultiParameterClasses =

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -83,6 +83,7 @@ test-suite spec
     tasty-hedgehog,
     tasty-hunit,
     text,
+    transformers,
     unix,
     yaml,
 

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -163,7 +163,7 @@ renderFcCase tc =
                in if all tcModuleSuccess tcResults
                     then
                       let allBindings = moduleGroupBindings tcResults
-                          results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
+                          results = map (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults
                           fixtureResults = drop supportModuleCount results
                        in if all dsSuccess results
                             then renderResults fixtureResults

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -16,7 +16,7 @@ where
 
 import Aihc.Fc.Desugar.Deriving (dsDerivingPlans, moduleDerivingPlans)
 import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, peelForAlls, peelQuals, predType)
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsEvidence, dsMatches, dsMatchesWithEnclosingDicts, freshUnique, freshVar, lookupType, withDicts)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsEvidence, dsMatches, dsMatchesWithEnclosingDicts, freshUnique, freshVar, lookupType, lookupTypeAt, lookupTypeAtOrigin, withDicts)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Lower (lowerPseudoOps)
 import Aihc.Fc.Newtype (lowerNewtypes)
@@ -51,11 +51,10 @@ import Aihc.Parser.Syntax
     binderHeadName,
     fromAnnotation,
     moduleName,
-    nameQualifier,
     peelDeclAnn,
     unqualifiedNameText,
   )
-import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolveResult (..), ResolvedName (..), resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (ModuleOrigin (..), PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TcInterface (..), TyConFlavor (..), emptyTcInterface, renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
@@ -64,11 +63,13 @@ import Aihc.Tc.Types
   ( Kind (KFun, KTYPE, KType),
     Pred (..),
     RuntimeRep (..),
+    TcBindingId (..),
     TcType (..),
     TyCon (..),
     TyVarId (..),
     TypeScheme,
     Unique (..),
+    builtinBindingId,
     liftedRuntimeRep,
     mkTyCon,
     runtimeRepOfType,
@@ -82,7 +83,7 @@ import Control.Monad (foldM, zipWithM)
 import Control.Monad.Trans.State.Strict (gets, runStateT)
 import Data.Either (fromRight)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -162,40 +163,12 @@ desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
 
 resolvedModuleOrigin :: Module -> (Text, Text)
 resolvedModuleOrigin resolvedModule =
-  fromMaybe ("", fromMaybe "Main" (moduleName resolvedModule)) $ do
-    resolved <- listToMaybe (mapMaybe definitionResolution (moduleDecls resolvedModule))
-    case resolutionTarget resolved of
-      ResolvedTopLevel packageId name ->
-        pure (packageIdText packageId, fromMaybe (fromMaybe "Main" (moduleName resolvedModule)) (nameQualifier name))
-      _ -> Nothing
+  case mapMaybe (fromAnnotation @ModuleOrigin) (moduleAnns resolvedModule) of
+    ModuleOrigin packageId moduleName' : _ -> (packageIdText packageId, moduleName')
+    [] -> ("", fromMaybe "Main" (moduleName resolvedModule))
 
 sourceModuleId :: Module -> FcModuleId
-sourceModuleId modu = FcModuleId "" (fromMaybe "Main" (moduleName modu))
-
-definitionResolution :: Decl -> Maybe ResolutionAnnotation
-definitionResolution declaration =
-  case peelDeclAnn declaration of
-    DeclValue (FunctionBind name _) -> nameResolution name
-    DeclValue (PatternBind _ pattern' _) -> patternResolution pattern'
-    DeclData dataDeclaration -> nameResolution (binderHeadName (dataDeclHead dataDeclaration))
-    DeclNewtype newtypeDeclaration -> nameResolution (binderHeadName (newtypeDeclHead newtypeDeclaration))
-    DeclClass classDeclaration -> nameResolution (binderHeadName (classDeclHead classDeclaration))
-    _ -> Nothing
-
-patternResolution :: Pattern -> Maybe ResolutionAnnotation
-patternResolution pattern' =
-  case pattern' of
-    PVar name -> nameResolution name
-    PAnn _ inner -> patternResolution inner
-    PParen inner -> patternResolution inner
-    PStrict inner -> patternResolution inner
-    PIrrefutable inner -> patternResolution inner
-    PAs name _ -> nameResolution name
-    PTypeSig inner _ -> patternResolution inner
-    _ -> Nothing
-
-nameResolution :: UnqualifiedName -> Maybe ResolutionAnnotation
-nameResolution = listToMaybe . mapMaybe fromAnnotation . unqualifiedNameAnns
+sourceModuleId modu = uncurry FcModuleId (resolvedModuleOrigin modu)
 
 -- | Type-class evidence is ordinary term-level data in FC. Replace qualified
 -- source types with explicit dictionary arrows after desugaring has consumed
@@ -290,14 +263,14 @@ showTcFailure tcResult =
     [] -> map showBinding (tcModuleBindings tcResult)
     diagnostics -> diagnostics
 
-bindingTypeEntries :: TcBindingResult -> [(Text, TcType)]
+bindingTypeEntries :: TcBindingResult -> [(TcBindingId, TcType)]
 bindingTypeEntries b =
-  [(tbName b, tbType b)]
+  [(tbIdentity b, tbType b)]
 
-builtinTypeEntries :: [(Text, TcType)]
+builtinTypeEntries :: [(TcBindingId, TcType)]
 builtinTypeEntries =
-  [ (":", TcForAllTy aVar (TcFunTy aTy (TcFunTy listA listA))),
-    ("[]", TcForAllTy aVar listA)
+  [ (builtinBindingId ":", TcForAllTy aVar (TcFunTy aTy (TcFunTy listA listA))),
+    (builtinBindingId "[]", TcForAllTy aVar listA)
   ]
   where
     aVar = TyVarId "a" (Unique (-1000))
@@ -572,7 +545,10 @@ dsForeignCcall tcAnn foreignPlan foreignDecl = do
       case tcForeignEffect foreignPlan of
         TcForeignPure ->
           boxForeignValue (tcForeignResult foreignPlan) (FcCallForeign foreignCall arguments)
-        TcForeignRealWorld -> makeForeignIoWrapper foreignCall (tcForeignResult foreignPlan) arguments
+        TcForeignRealWorld ->
+          case tcForeignIoConstructor foreignPlan of
+            Just ioConstructor -> makeForeignIoWrapper ioConstructor foreignCall (tcForeignResult foreignPlan) arguments
+            Nothing -> desugarBug "foreign IO wrapper lacks its constructor identity"
   pure
     [ FcForeignImport foreignCall,
       FcTopBind (FcNonRec wrapperVar (foldr FcLam wrapperBody argumentVars))
@@ -604,8 +580,9 @@ unboxForeignValue binderName marshal expression continuation =
   go (tcForeignSourceType marshal) (tcForeignConstructors marshal) expression
   where
     go _ [] value = continuation value
-    go valueType (constructor : constructors) value = do
-      constructorType <- dropForAlls <$> lookupType constructor
+    go valueType (constructorIdentity : constructors) value = do
+      let constructor = tcBindingName constructorIdentity
+      constructorType <- dropForAlls <$> lookupTypeAt constructorIdentity
       fieldType <-
         case constructorType of
           TcFunTy field _ -> pure field
@@ -625,12 +602,14 @@ boxForeignValue marshal =
   applyConstructors (tcForeignSourceType marshal) (tcForeignConstructors marshal)
   where
     applyConstructors _ [] value = pure value
-    applyConstructors resultType (constructor : constructors) value = do
-      constructorType <- lookupType constructor
+    applyConstructors resultType (constructorIdentity : constructors) value = do
+      let constructor = tcBindingName constructorIdentity
+      constructorType <- lookupTypeAt constructorIdentity
       constructorVar <- freshVar constructor constructorType
+      let resolvedConstructor = constructorVar {varResolvedName = Just (FcTopLevelOrigin (tcBindingPackageId constructorIdentity) (tcBindingModuleName constructorIdentity) constructor)}
       (typeArguments, fieldType) <- instantiateUnaryConstructor constructor resultType constructorType
       fieldValue <- applyConstructors fieldType constructors value
-      pure (FcApp (foldl FcTyApp (FcVar constructorVar) typeArguments) fieldValue)
+      pure (FcApp (foldl FcTyApp (FcVar resolvedConstructor) typeArguments) fieldValue)
 
 instantiateUnaryConstructor :: Text -> TcType -> TcType -> DsM ([TcType], TcType)
 instantiateUnaryConstructor constructor expectedResult constructorType = do
@@ -693,8 +672,8 @@ matchConstructorResult quantified patternType actualType substitution =
     TcForAllTy {} -> Nothing
     TcQualTy {} -> Nothing
 
-makeForeignIoWrapper :: FcForeignCall -> TcForeignMarshal -> [FcExpr] -> DsM FcExpr
-makeForeignIoWrapper foreignCall resultMarshal arguments = do
+makeForeignIoWrapper :: TcBindingId -> FcForeignCall -> TcForeignMarshal -> [FcExpr] -> DsM FcExpr
+makeForeignIoWrapper ioConstructorIdentity foreignCall resultMarshal arguments = do
   stateVar <- freshVar "$ffi_state" statePrimRealWorldTy
   tupleBinder <- freshVar "$ffi_result" (fcForeignCallResultType (fcForeignCallSignature foreignCall))
   nextStateVar <- freshVar "$ffi_next_state" statePrimRealWorldTy
@@ -704,8 +683,9 @@ makeForeignIoWrapper foreignCall resultMarshal arguments = do
     freshVar
       "(#,#)"
       (TcFunTy statePrimRealWorldTy (TcFunTy (tcForeignSourceType resultMarshal) (unboxedTupleTy [statePrimRealWorldTy, tcForeignSourceType resultMarshal])))
-  ioConstructorType <- lookupType "IO"
+  ioConstructorType <- lookupTypeAt ioConstructorIdentity
   ioConstructor <- freshVar "IO" ioConstructorType
+  let resolvedIoConstructor = ioConstructor {varResolvedName = Just (FcTopLevelOrigin (tcBindingPackageId ioConstructorIdentity) (tcBindingModuleName ioConstructorIdentity) "IO")}
   let resultTuple = FcApp (FcApp (FcVar tupleConstructor) (FcVar nextStateVar)) boxedResult
       call = FcCallForeign foreignCall (arguments <> [FcVar stateVar])
       stateAction =
@@ -716,7 +696,7 @@ makeForeignIoWrapper foreignCall resultMarshal arguments = do
               tupleBinder
               [FcAlt (DataAlt "(#,#)") [nextStateVar, rawResultVar] resultTuple]
           )
-  pure (FcApp (FcTyApp (FcVar ioConstructor) (tcForeignSourceType resultMarshal)) stateAction)
+  pure (FcApp (FcTyApp (FcVar resolvedIoConstructor) (tcForeignSourceType resultMarshal)) stateAction)
 
 validatePrimitiveImport :: Text -> TcType -> DsM Int
 validatePrimitiveImport name ty =
@@ -1159,7 +1139,7 @@ dsInstanceMethod contextDicts methods maybeSelfDictionary headTypes classOrigin 
               Just dictionary -> pure dictionary
               Nothing -> desugarBug ("default method " <> T.unpack methodName <> " requires a recursive instance dictionary")
           let workerName = defaultMethodName methodName
-          workerType <- lookupType workerName
+          workerType <- maybe (lookupType workerName) (`lookupTypeAtOrigin` workerName) classOrigin
           worker <- freshVar workerName workerType
           let origin = fmap (\(packageName, originModule) -> FcTopLevelOrigin packageName originModule workerName) classOrigin
           pure (FcApp (foldl FcTyApp (FcVar worker {varResolvedName = origin}) headTypes) selfDictionary)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -103,7 +103,7 @@ desugarModule m =
     ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} ->
       case typecheckModulesWithInterface emptyTcInterface [resolved] of
         ([tcResult], tcInterface) ->
-          desugarModuleWithDataTypes (tcModuleBindings tcResult) (tcInterfaceDataTypes tcInterface) tcResult resolved
+          desugarModuleWithDataTypes (tcModuleBindings tcResult) (tcInterfaceDataTypes tcInterface) tcResult
         _ ->
           DesugarResult
             { dsProgram = FcProgram (sourceModuleId m) [],
@@ -120,25 +120,25 @@ desugarModule m =
 -- | Desugar a module using a type-checking result already computed by
 -- the caller. This is useful for clients such as the REPL that preload
 -- imported bindings into the type-checker environment.
-desugarModuleWithTcResult :: Module -> Module -> DesugarResult
+desugarModuleWithTcResult :: Module -> DesugarResult
 desugarModuleWithTcResult tcResult =
   desugarModuleWithBindings (tcModuleBindings tcResult) tcResult
 
-desugarModuleWithBindings :: [TcBindingResult] -> Module -> Module -> DesugarResult
+desugarModuleWithBindings :: [TcBindingResult] -> Module -> DesugarResult
 desugarModuleWithBindings bindings = desugarModuleWithDataTypes bindings []
 
-desugarModuleWithDataTypes :: [TcBindingResult] -> [DataTypeInfo] -> Module -> Module -> DesugarResult
-desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
+desugarModuleWithDataTypes :: [TcBindingResult] -> [DataTypeInfo] -> Module -> DesugarResult
+desugarModuleWithDataTypes bindings dataTypes tcResult =
   if not (tcModuleSuccess tcResult)
     then
       DesugarResult
-        { dsProgram = FcProgram (sourceModuleId resolvedModule) [],
+        { dsProgram = FcProgram (sourceModuleId tcResult) [],
           dsSuccess = False,
           dsErrors = showTcFailure tcResult
         }
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
-          (packageName, currentModuleName) = resolvedModuleOrigin resolvedModule
+          (packageName, currentModuleName) = resolvedModuleOrigin tcResult
           constructorFields =
             Map.fromList
               [ (dciName constructor, dciFields constructor)
@@ -149,7 +149,7 @@ desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
        in case runStateT (dsModule tcResult) (DsState 1000 packageName (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
             Left err ->
               DesugarResult
-                { dsProgram = FcProgram (sourceModuleId resolvedModule) [],
+                { dsProgram = FcProgram (sourceModuleId tcResult) [],
                   dsSuccess = False,
                   dsErrors = [err]
                 }
@@ -1059,8 +1059,11 @@ dsInstanceDict instAnn instanceDecl = do
             methodOrder
         pure (superClassFields <> methodFields)
       buildDictionary recursive dictVar fields = do
-        let methodTypes = map snd (tcInstanceClassMethods instAnn)
-            superClassFieldTypes = map tcDictBinderType (tcInstanceClassSuperClasses instAnn)
+        methodTypes <-
+          mapM
+            (maybe lookupType lookupTypeAtOrigin (tcInstanceClassOrigin instAnn))
+            methodOrder
+        let superClassFieldTypes = map tcDictBinderType (tcInstanceClassSuperClasses instAnn)
         (classTyVars, fieldTypes) <-
           case methodTypes of
             [] -> pure (tcInstanceClassTyVars instAnn, superClassFieldTypes)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -1079,8 +1079,8 @@ dsInstanceDict instAnn instanceDecl = do
             methodOrder
         pure (superClassFields <> methodFields)
       buildDictionary recursive dictVar fields = do
-        methodTypes <- mapM lookupType methodOrder
-        let superClassFieldTypes = map tcDictBinderType (tcInstanceClassSuperClasses instAnn)
+        let methodTypes = map snd (tcInstanceClassMethods instAnn)
+            superClassFieldTypes = map tcDictBinderType (tcInstanceClassSuperClasses instAnn)
         (classTyVars, fieldTypes) <-
           case methodTypes of
             [] -> pure (tcInstanceClassTyVars instAnn, superClassFieldTypes)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -16,7 +16,7 @@ where
 
 import Aihc.Fc.Desugar.Deriving (dsDerivingPlans, moduleDerivingPlans)
 import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, peelForAlls, peelQuals, predType)
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsEvidence, dsMatches, dsMatchesWithEnclosingDicts, freshUnique, freshVar, lookupType, lookupTypeAt, lookupTypeAtOrigin, withDicts)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), bindingIdForOrigin, desugarBug, dsEvidence, dsMatches, dsMatchesWithEnclosingDicts, freshUnique, freshVar, lookupTypeAt, withDicts)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Lower (lowerPseudoOps)
 import Aihc.Fc.Newtype (lowerNewtypes)
@@ -386,7 +386,8 @@ dsNewtypeDeclM nd = do
     Nothing -> desugarBug ("newtype " <> T.unpack tyName <> " has no constructor")
     Just con -> do
       let (conName, arity) = dsDataConPure con
-      conTy <- lookupType conName
+      conIdentity <- bindingIdForOrigin Nothing conName
+      conTy <- lookupTypeAt conIdentity
       case (arity, dropForAlls conTy) of
         (1, TcFunTy fieldTy resultTy@(TcTyCon resultTyCon resultArgs))
           | tyConName resultTyCon == tyName,
@@ -425,7 +426,8 @@ dsRecordSelectors constructorInfos declarations =
           (fieldIndex, label) <- zip [0 :: Int ..] fields
         ]
     dsSelector (selectorName, layouts) = do
-      selectorType <- lookupType selectorName
+      selectorIdentity <- bindingIdForOrigin Nothing selectorName
+      selectorType <- lookupTypeAt selectorIdentity
       let (typeVariables, qualifiedBody) = peelForAlls selectorType
           (predicates, bodyType) = peelQuals qualifiedBody
       (recordType, _fieldType) <-
@@ -875,7 +877,8 @@ collectForAlls ty = ([], ty)
 dsDataConM :: DataConDecl -> DsM (Text, [TyVarId], [TcType], TcType)
 dsDataConM con = do
   let (name, arity) = dsDataConPure con
-  ty <- lookupType name
+  identity <- bindingIdForOrigin Nothing name
+  ty <- lookupTypeAt identity
   let (quantifiedVariables, qualifiedConstructorTy) = collectForAlls ty
       (predicates, constructorTy) = splitConstructorContext qualifiedConstructorTy
       resultType = constructorResultType constructorTy
@@ -1059,10 +1062,8 @@ dsInstanceDict instAnn instanceDecl = do
             methodOrder
         pure (superClassFields <> methodFields)
       buildDictionary recursive dictVar fields = do
-        methodTypes <-
-          mapM
-            (maybe lookupType lookupTypeAtOrigin (tcInstanceClassOrigin instAnn))
-            methodOrder
+        methodIdentities <- mapM (bindingIdForOrigin (tcInstanceClassOrigin instAnn)) methodOrder
+        methodTypes <- mapM lookupTypeAt methodIdentities
         let superClassFieldTypes = map tcDictBinderType (tcInstanceClassSuperClasses instAnn)
         (classTyVars, fieldTypes) <-
           case methodTypes of
@@ -1142,7 +1143,8 @@ dsInstanceMethod contextDicts methods maybeSelfDictionary headTypes classOrigin 
               Just dictionary -> pure dictionary
               Nothing -> desugarBug ("default method " <> T.unpack methodName <> " requires a recursive instance dictionary")
           let workerName = defaultMethodName methodName
-          workerType <- maybe (lookupType workerName) (`lookupTypeAtOrigin` workerName) classOrigin
+          workerIdentity <- bindingIdForOrigin classOrigin workerName
+          workerType <- lookupTypeAt workerIdentity
           worker <- freshVar workerName workerType
           let origin = fmap (\(packageName, originModule) -> FcTopLevelOrigin packageName originModule workerName) classOrigin
           pure (FcApp (foldl FcTyApp (FcVar worker {varResolvedName = origin}) headTypes) selfDictionary)
@@ -1250,7 +1252,8 @@ barePatternName pat =
 -- | Desugar a function binding group.
 dsGroup :: DeclGroup -> DsM FcTopBind
 dsGroup grp = do
-  ty <- lookupType (dgName grp)
+  identity <- bindingIdForOrigin Nothing (dgName grp)
+  ty <- lookupTypeAt identity
   u <- freshUnique
   let var = Var (dgName grp) u ty
   body <-

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/AnyClass.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/AnyClass.hs
@@ -7,7 +7,7 @@ module Aihc.Fc.Desugar.Deriving.AnyClass
 where
 
 import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, predType)
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshUnique, freshVar, lookupType, withDicts)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, bindingIdForOrigin, desugarBug, dsEvidence, freshUnique, freshVar, lookupTypeAt, withDicts)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDictBinderAnnotation (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..))
@@ -80,7 +80,8 @@ dsAnyClassMethod plan maybeSelfDictionary fieldType method =
           Just dictionary -> pure dictionary
           Nothing -> desugarBug ("default method " <> T.unpack methodName <> " requires a recursive derived dictionary")
       let workerName = defaultMethodName methodName
-      workerType <- lookupType workerName
+      workerIdentity <- bindingIdForOrigin (tcDerivingClassOrigin plan) workerName
+      workerType <- lookupTypeAt workerIdentity
       worker <- freshVar workerName workerType
       let workerOrigin = fmap (\(packageName, moduleName) -> FcTopLevelOrigin packageName moduleName workerName) (tcDerivingClassOrigin plan)
           resolvedWorker = worker {varResolvedName = workerOrigin}

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
@@ -7,7 +7,7 @@ module Aihc.Fc.Desugar.Deriving.StockEq
 where
 
 import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, predType)
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshVar, lookupType, withDicts)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, bindingIdForOrigin, desugarBug, dsEvidence, freshVar, lookupTypeAt, withDicts)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcStockDerivingPlan (..))
@@ -201,7 +201,8 @@ negateBoolean expression = do
 
 boolConstructor :: Text -> DsM FcExpr
 boolConstructor name = do
-  constructorType <- lookupType name
+  constructorIdentity <- bindingIdForOrigin Nothing name
+  constructorType <- lookupTypeAt constructorIdentity
   constructor <- freshVar name constructorType
   pure (FcVar constructor)
 

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -79,6 +79,24 @@ import Data.Text qualified as T
 -- | Desugaring monad.
 type DsM = StateT DsState (Either String)
 
+type LocalBindingId = (Int, Text)
+
+data DictKey
+  = ExactDictKey !Text ![DictTypeKey]
+  | AlphaDictKey !Text ![DictTypeKey]
+  deriving (Eq, Ord, Show)
+
+data DictTypeKey
+  = DictTyVar !Text
+  | DictExactTyVar !Text !Int
+  | DictMetaVar !Int
+  | DictTyCon !Text ![DictTypeKey]
+  | DictFun !DictTypeKey !DictTypeKey
+  | DictApp !DictTypeKey !DictTypeKey
+  | DictForAll !DictTypeKey
+  | DictQualified !DictTypeKey
+  deriving (Eq, Ord, Show)
+
 -- | Desugaring state.
 data DsState = DsState
   { dsNextUnique :: !Int,
@@ -86,10 +104,10 @@ data DsState = DsState
     dsModuleName :: !(Maybe Text),
     -- | Map from surface name to its inferred type (from TC).
     dsTypeEnv :: !(Map TcBindingId TcType),
-    -- | Local variable bindings (pattern-bound, lambda-bound).
-    dsLocalVars :: !(Map Text Var),
-    -- | Local dictionaries, keyed by class predicate.
-    dsLocalDicts :: !(Map Text Var),
+    -- | Local variables, keyed by resolver identity.
+    dsLocalVars :: !(Map LocalBindingId Var),
+    -- | Local dictionaries, keyed by a structural class predicate.
+    dsLocalDicts :: !(Map DictKey Var),
     -- | Checked constructor fields, including source strictness.
     dsConstructorFields :: !(Map Text [DataConFieldInfo]),
     dsTupleConstructorOrigin :: !(Maybe FcSymbolOrigin)
@@ -139,12 +157,12 @@ bindingIdForOrigin maybeOrigin name =
       pure (TcBindingId (dsModulePackage st) (fromMaybe "Main" (dsModuleName st)) name)
 
 -- | Look up a local variable binding.
-lookupLocal :: Text -> DsM (Maybe Var)
-lookupLocal name =
-  Map.lookup name . dsLocalVars <$> get
+lookupLocal :: LocalBindingId -> DsM (Maybe Var)
+lookupLocal identity =
+  Map.lookup identity . dsLocalVars <$> get
 
 -- | Run an action with additional local variable bindings.
-withLocals :: [(Text, Var)] -> DsM a -> DsM a
+withLocals :: [(LocalBindingId, Var)] -> DsM a -> DsM a
 withLocals bindings action = do
   st <- get
   let oldLocals = dsLocalVars st
@@ -153,6 +171,26 @@ withLocals bindings action = do
   result <- action
   modify' (\s -> s {dsLocalVars = oldLocals})
   pure result
+
+withLocal :: UnqualifiedName -> Var -> DsM a -> DsM a
+withLocal name variable action = do
+  identity <- localBinderIdentity name
+  withLocals [(identity, variable)] action
+
+localBinderIdentity :: UnqualifiedName -> DsM LocalBindingId
+localBinderIdentity name =
+  case resolvedLocalIdentity name of
+    Just identity -> pure identity
+    Nothing -> desugarBug ("missing resolver identity for local binder: " <> T.unpack (unqualifiedNameText name))
+
+resolvedLocalIdentity :: UnqualifiedName -> Maybe LocalBindingId
+resolvedLocalIdentity name =
+  listToMaybe
+    [ (identity, unqualifiedNameText target)
+    | resolution <- mapMaybe fromAnnotation (unqualifiedNameAnns name),
+      resolutionNamespace resolution == ResolutionNamespaceTerm,
+      ResolvedLocal identity target <- [resolutionTarget resolution]
+    ]
 
 withDicts :: [ClassDict] -> DsM a -> DsM a
 withDicts dicts action = do
@@ -168,8 +206,8 @@ withDicts dicts action = do
       let className = classDictName dictionary
           arguments = classDictArgs dictionary
           variable = classDictVar dictionary
-          withFallback = Map.insertWith (\_ existing -> existing) (dictKey className arguments) variable environment
-       in Map.insert (exactDictKey className arguments) variable withFallback
+          withAlpha = Map.insertWith (\_ existing -> existing) (alphaDictionaryKey className arguments) variable environment
+       in Map.insert (exactDictionaryKey className arguments) variable withAlpha
 
 -- | Desugar a list of match equations into a Core expression.
 --
@@ -287,8 +325,8 @@ buildCaseChain scrutVars@(scrutVar : restVars) resTy matches
   | allVarPatterns matches = do
       -- Variable patterns: bind each pattern variable name to the
       -- scrutinee Var, then recurse.
-      let bindings = extractVarBindings scrutVar matches
-          innerMatches = map dropFirstPat matches
+      bindings <- extractVarBindings scrutVar matches
+      let innerMatches = map dropFirstPat matches
       withLocals bindings (buildCaseChain restVars resTy innerMatches)
   | otherwise = do
       -- Build one case alternative per first-pattern constructor. Equations
@@ -348,14 +386,14 @@ dsMatchPattern :: Var -> Pattern -> DsM FcExpr -> FcExpr -> DsM FcExpr
 dsMatchPattern scrutVar pat success failure =
   case peelPatternAnn pat of
     PVar name ->
-      withLocals [(unqualifiedNameText name, scrutVar)] success
+      withLocal name scrutVar success
     PWildcard -> success
     PParen inner -> dsMatchPattern scrutVar inner success failure
     PAs name inner ->
-      withLocals [(unqualifiedNameText name, scrutVar)] (dsMatchPattern scrutVar inner success failure)
+      withLocal name scrutVar (dsMatchPattern scrutVar inner success failure)
     PStrict inner -> dsMatchPattern scrutVar inner success failure
     PIrrefutable inner ->
-      withLocals (irrefutablePatternBindings scrutVar inner) success
+      irrefutablePatternBindings scrutVar inner >>= (`withLocals` success)
     PTypeSig inner _ -> dsMatchPattern scrutVar inner success failure
     _
       | isOverloadedIntegerPattern pat ->
@@ -414,16 +452,18 @@ dsBoxedCharPatternMatch scrutVar char success failure = do
         ]
     )
 
-irrefutablePatternBindings :: Var -> Pattern -> [(Text, Var)]
+irrefutablePatternBindings :: Var -> Pattern -> DsM [(LocalBindingId, Var)]
 irrefutablePatternBindings scrutVar pat =
   case peelPatternAnn pat of
-    PVar name -> [(unqualifiedNameText name, scrutVar)]
+    PVar name -> (: []) . (,scrutVar) <$> localBinderIdentity name
     PParen inner -> irrefutablePatternBindings scrutVar inner
-    PAs name inner -> (unqualifiedNameText name, scrutVar) : irrefutablePatternBindings scrutVar inner
+    PAs name inner -> do
+      identity <- localBinderIdentity name
+      ((identity, scrutVar) :) <$> irrefutablePatternBindings scrutVar inner
     PStrict inner -> irrefutablePatternBindings scrutVar inner
     PIrrefutable inner -> irrefutablePatternBindings scrutVar inner
     PTypeSig inner _ -> irrefutablePatternBindings scrutVar inner
-    _ -> []
+    _ -> pure []
 
 dsOrdinaryPatternMatch :: Var -> Pattern -> DsM FcExpr -> FcExpr -> DsM FcExpr
 dsOrdinaryPatternMatch scrutVar pat success failure = do
@@ -464,16 +504,16 @@ noPatternMatch [] =
 
 -- | Extract variable bindings from the first pattern of each match,
 -- mapping the pattern variable name to the scrutinee Var.
-extractVarBindings :: Var -> [Match] -> [(Text, Var)]
-extractVarBindings scrutVar = concatMap go
+extractVarBindings :: Var -> [Match] -> DsM [(LocalBindingId, Var)]
+extractVarBindings scrutVar matches = concat <$> mapM go matches
   where
     go m = case matchPats m of
       (p : _) -> extractName p
-      _ -> []
-    extractName (PVar uname) = [(unqualifiedNameText uname, scrutVar)]
+      _ -> pure []
+    extractName (PVar uname) = (: []) . (,scrutVar) <$> localBinderIdentity uname
     extractName (PAnn _ inner) = extractName inner
     extractName (PParen inner) = extractName inner
-    extractName _ = []
+    extractName _ = pure []
 
 -- | Check if all first patterns in the matches are variables or wildcards.
 allVarPatterns :: [Match] -> Bool
@@ -567,7 +607,7 @@ dsExpr (EVar name) = do
       resolvedName = resolvedOccurrenceName name
       resolvedOrigin = resolvedOccurrenceOrigin name
   -- Check local bindings first (pattern/lambda variables).
-  mLocal <- lookupLocalName resolvedName
+  mLocal <- lookupLocalName name
   case mLocal of
     Just v -> pure (FcVar v)
     Nothing -> do
@@ -614,7 +654,7 @@ dsAnnotatedVar tcAnn name _expr = do
   let n = nameText name
       resolvedName = resolvedOccurrenceName name
       resolvedOrigin = resolvedOccurrenceOrigin name
-  mLocal <- lookupLocalName resolvedName
+  mLocal <- lookupLocalName name
   variable <-
     case mLocal of
       Just local -> pure local
@@ -767,8 +807,9 @@ dsDoPatternContinuation :: Pattern -> [DoStmt Expr] -> DsM FcExpr
 dsDoPatternContinuation pat rest = do
   argTy <- lambdaPatternTypeRequired pat
   arg <- freshInternalVar "_do" argTy
+  directBindings <- directPatternBindings pat arg
   body <-
-    case directPatternBindings pat arg of
+    case directBindings of
       Just bindings -> withLocals bindings (dsDo rest)
       Nothing -> do
         failure <- noPatternMatch [arg]
@@ -1019,32 +1060,32 @@ dsPatternMatchResult :: Var -> Pattern -> DsM FcExpr -> CaseMatchResult
 dsPatternMatchResult scrutVar pattern' success =
   case peelPatternAnn pattern' of
     PVar name ->
-      CaseMatchInfallible (withLocals [(unqualifiedNameText name, scrutVar)] success)
+      CaseMatchInfallible (withLocal name scrutVar success)
     PWildcard -> CaseMatchInfallible success
     PParen inner -> dsPatternMatchResult scrutVar inner success
     PAs name inner ->
-      withCaseMatchLocals [(unqualifiedNameText name, scrutVar)] (dsPatternMatchResult scrutVar inner success)
+      withCaseMatchLocal name scrutVar (dsPatternMatchResult scrutVar inner success)
     PStrict inner ->
       adjustCaseMatchResult (forceCaseScrutinee scrutVar) (dsPatternMatchResult scrutVar inner success)
     PIrrefutable inner ->
-      CaseMatchInfallible (withLocals (irrefutablePatternBindings scrutVar inner) success)
+      CaseMatchInfallible $ do
+        bindings <- irrefutablePatternBindings scrutVar inner
+        withLocals bindings success
     PTypeSig inner _ -> dsPatternMatchResult scrutVar inner success
     _ ->
       CaseMatchFallible $ \failureAction -> do
         failure <- failureAction
         dsMatchPattern scrutVar pattern' success failure
 
-withCaseMatchLocals :: [(Text, Var)] -> CaseMatchResult -> CaseMatchResult
-withCaseMatchLocals bindings matchResult =
+withCaseMatchLocal :: UnqualifiedName -> Var -> CaseMatchResult -> CaseMatchResult
+withCaseMatchLocal name variable matchResult =
   case matchResult of
-    CaseMatchInfallible body -> CaseMatchInfallible (withLocals bindings body)
+    CaseMatchInfallible body -> CaseMatchInfallible (withLocal name variable body)
     CaseMatchFallible build ->
       CaseMatchFallible $ \failureAction -> do
-        -- Pattern binders scope over this alternative only. Build the next
-        -- alternative before extending the desugaring environment so a failed
-        -- as-pattern cannot capture names in its fall-through path.
+        -- Build the next alternative before this binder enters the scope.
         failure <- failureAction
-        withLocals bindings (build (pure failure))
+        withLocal name variable (build (pure failure))
 
 adjustCaseMatchResult :: (FcExpr -> DsM FcExpr) -> CaseMatchResult -> CaseMatchResult
 adjustCaseMatchResult adjust matchResult =
@@ -1172,9 +1213,9 @@ patternOccurrence target =
 dsLetDecls :: [Decl] -> DsM FcExpr -> DsM FcExpr
 dsLetDecls decls bodyAction = do
   groups <- groupLocalDecls decls
-  let names = map localGroupName groups
+  let identities = map localGroupIdentity groups
       vars = map localGroupBinder groups
-  let localBindings = zip names vars
+  let localBindings = zip identities vars
   withLocals localBindings $ do
     rhsBindings <- zipWithM dsLocalGroup vars groups
     body <- bodyAction
@@ -1184,48 +1225,49 @@ dsLetDecls decls bodyAction = do
         else FcLet (FcRec rhsBindings) body
 
 data LocalDeclGroup
-  = LocalFunction !Text !Var ![Match]
-  | LocalPattern !Text !Var !(Rhs Expr)
+  = LocalFunction !LocalBindingId !Text !Var ![Match]
+  | LocalPattern !LocalBindingId !Text !Var !(Rhs Expr)
 
-localGroupName :: LocalDeclGroup -> Text
-localGroupName group =
+localGroupIdentity :: LocalDeclGroup -> LocalBindingId
+localGroupIdentity group =
   case group of
-    LocalFunction name _ _ -> name
-    LocalPattern name _ _ -> name
+    LocalFunction identity _ _ _ -> identity
+    LocalPattern identity _ _ _ -> identity
 
 localGroupBinder :: LocalDeclGroup -> Var
 localGroupBinder group =
   case group of
-    LocalFunction _ var _ -> var
-    LocalPattern _ var _ -> var
+    LocalFunction _ _ var _ -> var
+    LocalPattern _ _ var _ -> var
 
 groupLocalDecls :: [Decl] -> DsM [LocalDeclGroup]
 groupLocalDecls [] = pure []
 groupLocalDecls (decl : rest) = do
   maybeFun <- extractLocalFunction decl
   case maybeFun of
-    Just (name, var, matches) -> do
+    Just (identity, name, var, matches) -> do
       let (sameNameDecls, rest') = span (hasSameLocalFunctionName name) rest
       sameGroups <- mapM extractLocalFunctionRequired sameNameDecls
-      let allMatches = matches ++ concatMap (\(_, _, ms) -> ms) sameGroups
+      let allMatches = matches ++ concatMap (\(_, _, _, ms) -> ms) sameGroups
       restGroups <- groupLocalDecls rest'
-      pure (LocalFunction name var allMatches : restGroups)
+      pure (LocalFunction identity name var allMatches : restGroups)
     Nothing -> do
       maybePattern <- extractLocalPattern decl
       restGroups <- groupLocalDecls rest
       pure (maybe restGroups (: restGroups) maybePattern)
 
-extractLocalFunction :: Decl -> DsM (Maybe (Text, Var, [Match]))
+extractLocalFunction :: Decl -> DsM (Maybe (LocalBindingId, Text, Var, [Match]))
 extractLocalFunction decl =
   case peelDeclAnn decl of
     DeclValue (FunctionBind name matches) -> do
       let localName = unqualifiedNameText name
+      identity <- localBinderIdentity name
       ty <- localDeclTypeRequired localName decl
       var <- freshVar localName ty
-      pure (Just (localName, var, matches))
+      pure (Just (identity, localName, var, matches))
     _ -> pure Nothing
 
-extractLocalFunctionRequired :: Decl -> DsM (Text, Var, [Match])
+extractLocalFunctionRequired :: Decl -> DsM (LocalBindingId, Text, Var, [Match])
 extractLocalFunctionRequired decl = do
   maybeFun <- extractLocalFunction decl
   case maybeFun of
@@ -1244,9 +1286,10 @@ extractLocalPattern decl =
     DeclValue (PatternBind _ pat rhs) ->
       case barePatternName pat of
         Just name -> do
+          identity <- localPatternBinderIdentity pat
           ty <- localDeclTypeRequired name decl
           var <- freshVar name ty
-          pure (Just (LocalPattern name var rhs))
+          pure (Just (LocalPattern identity name var rhs))
         Nothing -> pure Nothing
     _ -> pure Nothing
 
@@ -1257,6 +1300,14 @@ barePatternName pat =
     PAnn _ inner -> barePatternName inner
     PParen inner -> barePatternName inner
     _ -> Nothing
+
+localPatternBinderIdentity :: Pattern -> DsM LocalBindingId
+localPatternBinderIdentity pattern' =
+  case pattern' of
+    PVar name -> localBinderIdentity name
+    PAnn _ inner -> localPatternBinderIdentity inner
+    PParen inner -> localPatternBinderIdentity inner
+    _ -> desugarBug "local pattern binding has no resolver identity"
 
 localDeclTypeRequired :: Text -> Decl -> DsM TcType
 localDeclTypeRequired name decl =
@@ -1276,10 +1327,10 @@ localDeclType decl =
 dsLocalGroup :: Var -> LocalDeclGroup -> DsM (Var, FcExpr)
 dsLocalGroup var group =
   case group of
-    LocalFunction _ _ matches -> do
+    LocalFunction _ _ _ matches -> do
       rhs <- dsMatches (varType var) matches
       pure (var, rhs)
-    LocalPattern _ _ rhs -> do
+    LocalPattern _ _ _ rhs -> do
       rhs' <- dsRhs rhs
       pure (var, rhs')
 
@@ -1376,8 +1427,9 @@ dsCompGen elemTy body pat src rest tailExpr = do
   pure (FcLet (FcRec [(worker, workerBody)]) (FcApp (FcVar worker) src'))
 
 dsCompGenMatch :: TcType -> Expr -> Pattern -> [CompStmt] -> Var -> FcExpr -> DsM FcExpr
-dsCompGenMatch elemTy body pat rest headVar skipExpr =
-  case directPatternBindings pat headVar of
+dsCompGenMatch elemTy body pat rest headVar skipExpr = do
+  directBindings <- directPatternBindings pat headVar
+  case directBindings of
     Just bindings ->
       withLocals bindings (dsCompQuals elemTy body rest skipExpr)
     Nothing -> do
@@ -1388,8 +1440,9 @@ dsCompGenMatch elemTy body pat rest headVar skipExpr =
         _ -> do
           binderTys <- patternBinderTypesM pat (varType headVar)
           binders <- zipWithM freshVar binderNames binderTys
+          localBindings <- immediatePatternBindings (constructorSubpatterns pat) binders
           (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
-          matched <- withDicts dictionaries (withLocals (zip binderNames binders) (dsCompQuals elemTy body rest skipExpr))
+          matched <- withDicts dictionaries (withLocals localBindings (dsCompQuals elemTy body rest skipExpr))
           caseBinder <- freshInternalVar "_lc_match" (varType headVar)
           pure
             ( FcCase
@@ -1400,23 +1453,30 @@ dsCompGenMatch elemTy body pat rest headVar skipExpr =
                 ]
             )
 
-directPatternBindings :: Pattern -> Var -> Maybe [(Text, Var)]
+directPatternBindings :: Pattern -> Var -> DsM (Maybe [(LocalBindingId, Var)])
 directPatternBindings pat var =
   case pat of
-    PVar name -> Just [(unqualifiedNameText name, var)]
-    PWildcard -> Just []
+    PVar name -> Just . (: []) . (,var) <$> localBinderIdentity name
+    PWildcard -> pure (Just [])
     PAnn _ inner -> directPatternBindings inner var
     PParen inner -> directPatternBindings inner var
-    PAs name inner -> ((unqualifiedNameText name, var) :) <$> directPatternBindings inner var
+    PAs name inner -> do
+      identity <- localBinderIdentity name
+      fmap ((identity, var) :) <$> directPatternBindings inner var
     PStrict inner -> directPatternBindings inner var
-    _ -> Nothing
+    _ -> pure Nothing
+
+immediatePatternBindings :: [Pattern] -> [Var] -> DsM [(LocalBindingId, Var)]
+immediatePatternBindings patterns variables =
+  concatMap (fromMaybe []) <$> zipWithM directPatternBindings patterns variables
 
 dsLambda :: [Pattern] -> Expr -> DsM FcExpr
 dsLambda pats body = do
   argTys <- mapM lambdaPatternTypeRequired pats
   vars <- zipWithM freshInternalVar (map lambdaArgName pats) argTys
+  directBindings <- zipWithM directPatternBindings pats vars
   body' <-
-    case traverse (uncurry directPatternBindings) (zip pats vars) of
+    case sequence directBindings of
       Nothing -> do
         failure <- noPatternMatch vars
         dsMatchPatterns vars pats (dsExpr body) failure
@@ -1588,10 +1648,10 @@ dsEvidence evidence =
   case evidence of
     EvGiven (ClassPred className args) -> do
       st <- get
-      case Map.lookup (exactDictKey className args) (dsLocalDicts st) <|> Map.lookup (dictKey className args) (dsLocalDicts st) of
+      case Map.lookup (exactDictionaryKey className args) (dsLocalDicts st) <|> Map.lookup (alphaDictionaryKey className args) (dsLocalDicts st) of
         Just var -> pure (FcVar var)
         Nothing ->
-          desugarBug ("missing local dictionary for " <> T.unpack (dictKey className args))
+          desugarBug ("missing local dictionary for " <> show (ClassPred className args))
     EvGiven EqPred {} ->
       unitConstructor
     EvDict dictOrigin dictName typeArgs contextEvidence -> do
@@ -1887,40 +1947,38 @@ fcExprTypeM expr =
     FcCallForeign foreignCall _arguments ->
       pure (fcForeignCallResultType (fcForeignCallSignature foreignCall))
 
-dictKey :: Text -> [TcType] -> Text
-dictKey className args = className <> ":" <> T.intercalate "," (map typeKey args)
+exactDictionaryKey :: Text -> [TcType] -> DictKey
+exactDictionaryKey className arguments =
+  ExactDictKey className (map exactDictionaryTypeKey arguments)
 
-exactDictKey :: Text -> [TcType] -> Text
-exactDictKey className args = className <> ":exact:" <> T.intercalate "," (map exactTypeKey args)
+alphaDictionaryKey :: Text -> [TcType] -> DictKey
+alphaDictionaryKey className arguments =
+  AlphaDictKey className (map alphaDictionaryTypeKey arguments)
 
-exactTypeKey :: TcType -> Text
-exactTypeKey ty =
+exactDictionaryTypeKey :: TcType -> DictTypeKey
+exactDictionaryTypeKey ty =
   case ty of
-    TcTyVar tv -> tvName tv <> "#" <> T.pack (show (uniqueInt (tvUnique tv)))
-    TcMetaTv (Unique unique) -> "?" <> T.pack (show unique)
-    TcTyCon tc [] -> tyConName tc
-    TcTyCon (TyCon "[]" _) [elementType] -> "[" <> exactTypeKey elementType <> "]"
-    TcTyCon tc arguments -> tyConName tc <> T.concat (map (("_" <>) . exactTypeKey) arguments)
-    TcAppTy function argument -> exactTypeKey function <> "_" <> exactTypeKey argument
-    TcFunTy argument result -> exactTypeKey argument <> "->" <> exactTypeKey result
-    TcForAllTy _ body -> exactTypeKey body
-    TcQualTy _ body -> exactTypeKey body
+    TcTyVar typeVariable -> DictExactTyVar (tvName typeVariable) (uniqueValue (tvUnique typeVariable))
+    TcMetaTv (Unique unique) -> DictMetaVar unique
+    TcTyCon typeConstructor arguments -> DictTyCon (tyConName typeConstructor) (map exactDictionaryTypeKey arguments)
+    TcFunTy argument result -> DictFun (exactDictionaryTypeKey argument) (exactDictionaryTypeKey result)
+    TcAppTy function argument -> DictApp (exactDictionaryTypeKey function) (exactDictionaryTypeKey argument)
+    TcForAllTy _ body -> DictForAll (exactDictionaryTypeKey body)
+    TcQualTy _ body -> DictQualified (exactDictionaryTypeKey body)
 
-uniqueInt :: Unique -> Int
-uniqueInt (Unique unique) = unique
-
-typeKey :: TcType -> Text
-typeKey ty =
+alphaDictionaryTypeKey :: TcType -> DictTypeKey
+alphaDictionaryTypeKey ty =
   case ty of
-    TcTyVar tv -> tvName tv
-    TcMetaTv (Unique u) -> "?" <> T.pack (show u)
-    TcTyCon tc [] -> tyConName tc
-    TcTyCon (TyCon "[]" _) [elemTy] -> "[" <> typeKey elemTy <> "]"
-    TcTyCon tc args -> tyConName tc <> T.concat (map (("_" <>) . typeKey) args)
-    TcAppTy f a -> typeKey f <> "_" <> typeKey a
-    TcFunTy a b -> typeKey a <> "->" <> typeKey b
-    TcForAllTy _ body -> typeKey body
-    TcQualTy _ body -> typeKey body
+    TcTyVar typeVariable -> DictTyVar (tvName typeVariable)
+    TcMetaTv (Unique unique) -> DictMetaVar unique
+    TcTyCon typeConstructor arguments -> DictTyCon (tyConName typeConstructor) (map alphaDictionaryTypeKey arguments)
+    TcFunTy argument result -> DictFun (alphaDictionaryTypeKey argument) (alphaDictionaryTypeKey result)
+    TcAppTy function argument -> DictApp (alphaDictionaryTypeKey function) (alphaDictionaryTypeKey argument)
+    TcForAllTy _ body -> DictForAll (alphaDictionaryTypeKey body)
+    TcQualTy _ body -> DictQualified (alphaDictionaryTypeKey body)
+
+uniqueValue :: Unique -> Int
+uniqueValue (Unique value) = value
 
 boolTy :: TcType
 boolTy = TcTyCon (TyCon "Bool" 0) []
@@ -1938,13 +1996,10 @@ nameToText n = case nameQualifier n of
   Just q -> q <> "." <> nameText n
 
 lookupLocalName :: Name -> DsM (Maybe Var)
-lookupLocalName name = do
-  currentModule <- gets dsModuleName
-  case nameQualifier name of
-    Nothing -> lookupLocal (nameText name)
-    Just qualifier
-      | Just qualifier == currentModule -> lookupLocal (nameText name)
-      | otherwise -> lookupLocal (nameToText name)
+lookupLocalName name =
+  case listToMaybe [(identity, unqualifiedNameText target) | resolution <- mapMaybe fromAnnotation (nameAnns name), resolutionNamespace resolution == ResolutionNamespaceTerm, ResolvedLocal identity target <- [resolutionTarget resolution]] of
+    Just identity -> lookupLocal identity
+    Nothing -> pure Nothing
 
 lookupTypeName :: Name -> DsM TcType
 lookupTypeName name = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -20,6 +20,8 @@ module Aihc.Fc.Desugar.Expr
     freshUnique,
     freshVar,
     lookupType,
+    lookupTypeAt,
+    lookupTypeAtOrigin,
     withDicts,
   )
 where
@@ -56,11 +58,11 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Parser.Syntax qualified as Surface
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionForm (..), ResolutionNamespace (..), ResolvedName (..))
-import Aihc.Tc.Annotations (TcAnnotation (..))
+import Aihc.Tc.Annotations (TcAnnotation (..), TcIntegerLiteralAnnotation (..))
 import Aihc.Tc.Env (DataConFieldInfo (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Kind (runtimeRepToTcType)
-import Aihc.Tc.Types (Kind (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), isLiftedType, liftedRuntimeRep, mkTyCon, runtimeRepOfType, setTyVarKind, tvKind, unboxedTupleTyConName)
+import Aihc.Tc.Types (Kind (..), Pred (..), RuntimeRep (..), TcBindingId (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, builtinBindingId, isLiftedType, liftedRuntimeRep, mkTyCon, runtimeRepOfType, setTyVarKind, tvKind, unboxedTupleTyConName)
 import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
@@ -84,7 +86,7 @@ data DsState = DsState
     dsModulePackage :: !Text,
     dsModuleName :: !(Maybe Text),
     -- | Map from surface name to its inferred type (from TC).
-    dsTypeEnv :: !(Map Text TcType),
+    dsTypeEnv :: !(Map TcBindingId TcType),
     -- | Local variable bindings (pattern-bound, lambda-bound).
     dsLocalVars :: !(Map Text Var),
     -- | Local dictionaries, keyed by class predicate.
@@ -128,9 +130,18 @@ lookupType name = do
   st <- get
   case Map.lookup name (dsLocalVars st) of
     Just v -> pure (varType v)
-    Nothing -> case Map.lookup name (dsTypeEnv st) of
-      Just ty -> pure ty
-      Nothing -> desugarBug ("missing type information for name: " <> T.unpack name)
+    Nothing -> lookupTypeAt (TcBindingId (dsModulePackage st) (fromMaybe "Main" (dsModuleName st)) name)
+
+lookupTypeAt :: TcBindingId -> DsM TcType
+lookupTypeAt identity = do
+  st <- get
+  case Map.lookup identity (dsTypeEnv st) of
+    Just ty -> pure ty
+    Nothing -> desugarBug ("missing type information for binding: " <> show identity)
+
+lookupTypeAtOrigin :: (Text, Text) -> Text -> DsM TcType
+lookupTypeAtOrigin (packageId, moduleName) name =
+  lookupTypeAt (TcBindingId packageId moduleName name)
 
 -- | Look up a local variable binding.
 lookupLocal :: Text -> DsM (Maybe Var)
@@ -638,10 +649,11 @@ isGhcPrimSeq name =
 dsAnnotatedExpr :: TcAnnotation -> Expr -> DsM FcExpr
 dsAnnotatedExpr tcAnn inner = do
   body <- case inner of
-    EAnn ann (EInt value TInteger _)
+    EAnn integerAnn (EAnn ann (EInt value TInteger _))
       | Just resolution <- fromAnnotation ann,
+        Just literalAnnotation <- fromAnnotation integerAnn,
         isFromIntegerResolution resolution ->
-          dsOverloadedIntegerLiteral tcAnn resolution value
+          dsOverloadedIntegerLiteral tcAnn literalAnnotation resolution value
     EAnn _ nested -> dsExpr nested
     EVar name -> dsAnnotatedVar tcAnn name inner
     application@EApp {} -> dsApplication application
@@ -798,17 +810,18 @@ doBindOccurrence = go Nothing Nothing
            in go maybeTc' maybeResolution' inner
         _ -> (,) <$> maybeTc <*> maybeResolution
 
-dsOverloadedIntegerLiteral :: TcAnnotation -> ResolutionAnnotation -> Integer -> DsM FcExpr
-dsOverloadedIntegerLiteral tcAnn resolution value = do
+dsOverloadedIntegerLiteral :: TcAnnotation -> TcIntegerLiteralAnnotation -> ResolutionAnnotation -> Integer -> DsM FcExpr
+dsOverloadedIntegerLiteral tcAnn literalAnnotation resolution value = do
   fromIntegerExpr <- dsAnnotatedVar tcAnn (resolvedAnnotationName resolution) (EInt value TInteger (T.pack (show value)))
-  integerExpr <- dsIntegerLiteral resolution value
+  integerExpr <- dsIntegerLiteral literalAnnotation value
   pure (FcApp fromIntegerExpr integerExpr)
 
-dsIntegerLiteral :: ResolutionAnnotation -> Integer -> DsM FcExpr
-dsIntegerLiteral resolution value = do
-  conTy <- lookupType "IS"
+dsIntegerLiteral :: TcIntegerLiteralAnnotation -> Integer -> DsM FcExpr
+dsIntegerLiteral literalAnnotation value = do
+  let constructorIdentity = tcIntegerConstructor literalAnnotation
+  conTy <- lookupTypeAt constructorIdentity
   con <- freshVar "IS" conTy
-  let resolved name var = var {varResolvedName = integerHelperOrigin resolution name}
+  let resolved name var = var {varResolvedName = integerHelperOrigin constructorIdentity name}
       small integer = FcApp (FcVar (resolved "IS" con)) (FcLit (LitInt IntRep integer))
   if value >= minIntLiteral && value <= maxIntLiteral
     then pure (small value)
@@ -840,11 +853,9 @@ dsIntegerLiteral resolution value = do
     minIntLiteral = -9223372036854775808
     maxIntLiteral = 9223372036854775807
 
-integerHelperOrigin :: ResolutionAnnotation -> Text -> Maybe FcSymbolOrigin
-integerHelperOrigin resolution symbolName =
-  case resolvedNameOrigin (resolutionTarget resolution) of
-    Just (FcTopLevelOrigin packageName _ _) -> Just (FcTopLevelOrigin packageName "GHC.Internal.Integer" symbolName)
-    _ -> Nothing
+integerHelperOrigin :: TcBindingId -> Text -> Maybe FcSymbolOrigin
+integerHelperOrigin identity symbolName =
+  Just (FcTopLevelOrigin (tcBindingPackageId identity) (tcBindingModuleName identity) symbolName)
 
 resolvedAnnotationName :: ResolutionAnnotation -> Name
 resolvedAnnotationName resolution =
@@ -1078,9 +1089,10 @@ dsOverloadedIntegerPatternTest scrutValue pat =
   case integerPatternValue pat of
     Just (value, isNegative) -> do
       (fromIntegerTc, fromIntegerResolution) <- requiredPatternOccurrence "fromInteger" pat
+      literalAnnotation <- requiredIntegerPatternAnnotation pat
       (eqTc, eqResolution) <- requiredPatternOccurrence "==" pat
       fromIntegerExpr <- dsAnnotatedVar fromIntegerTc (resolvedAnnotationName fromIntegerResolution) (EInt value TInteger (T.pack (show value)))
-      integerExpr <- dsIntegerLiteral fromIntegerResolution value
+      integerExpr <- dsIntegerLiteral literalAnnotation value
       eqExpr <- dsAnnotatedVar eqTc (resolvedAnnotationName eqResolution) (EVar (resolvedAnnotationName eqResolution))
       let positiveValue = FcApp fromIntegerExpr integerExpr
       patternValue <-
@@ -1117,6 +1129,23 @@ requiredPatternOccurrence name pat =
   case patternOccurrence name pat of
     Just occurrence -> pure occurrence
     Nothing -> desugarBug ("missing " <> T.unpack name <> " annotation for overloaded integer pattern")
+
+requiredIntegerPatternAnnotation :: Pattern -> DsM TcIntegerLiteralAnnotation
+requiredIntegerPatternAnnotation pat =
+  case integerPatternAnnotation pat of
+    Just annotation -> pure annotation
+    Nothing -> desugarBug "missing constructor identity for overloaded integer pattern"
+
+integerPatternAnnotation :: Pattern -> Maybe TcIntegerLiteralAnnotation
+integerPatternAnnotation pat =
+  case pat of
+    PAnn ann inner -> (fromAnnotation ann :: Maybe TcIntegerLiteralAnnotation) <|> integerPatternAnnotation inner
+    PParen inner -> integerPatternAnnotation inner
+    PStrict inner -> integerPatternAnnotation inner
+    PIrrefutable inner -> integerPatternAnnotation inner
+    PAs _ inner -> integerPatternAnnotation inner
+    PTypeSig inner _ -> integerPatternAnnotation inner
+    _ -> Nothing
 
 patternOccurrence :: Text -> Pattern -> Maybe (TcAnnotation, ResolutionAnnotation)
 patternOccurrence target =
@@ -1459,9 +1488,9 @@ tupleConExpr flavor elemTys = do
   constructorOrigin <- gets dsTupleConstructorOrigin
   (constructorTy, resolvedOrigin) <-
     case (flavor, constructorOrigin) of
-      (_, Just origin@FcTopLevelOrigin {}) -> (,Just origin) <$> lookupType name
+      (_, Just origin@(FcTopLevelOrigin packageId moduleName _)) -> (,Just origin) <$> lookupTypeAtOrigin (packageId, moduleName) name
       (Unboxed, _) -> pure (unboxedTupleConType arity, Just (FcBuiltinOrigin name))
-      (Boxed, _) -> (,Just (FcBuiltinOrigin name)) <$> lookupType name
+      (Boxed, _) -> pure (boxedTupleConType arity, Just (FcBuiltinOrigin name))
   constructor <-
     case resolvedOrigin of
       Just FcBuiltinOrigin {} -> pure (builtinVar name (Unique (-20 - arity)) constructorTy)
@@ -1488,6 +1517,13 @@ unboxedTupleConType arity =
     resultKind = KTYPE (TupleRep [runtimeRep | variable <- valueVariables, KTYPE runtimeRep <- [tvKind variable]])
     tyConKind = foldr (KFun . tvKind) resultKind valueVariables
     resultType = TcTyCon (mkTyCon (unboxedTupleTyConName arity) arity tyConKind) (map TcTyVar valueVariables)
+
+boxedTupleConType :: Int -> TcType
+boxedTupleConType arity =
+  foldr TcForAllTy (foldr (TcFunTy . TcTyVar) resultType variables) variables
+  where
+    variables = [TyVarId ("a" <> T.pack (show index)) (Unique (-2100000 - arity * 100 - index)) | index <- [1 .. arity]]
+    resultType = TcTyCon (TyCon (boxedTupleTyConName arity) arity) (map TcTyVar variables)
 
 isTupleResolution :: ResolutionAnnotation -> Bool
 isTupleResolution resolution =
@@ -1564,7 +1600,7 @@ dsEvidence evidence =
     EvGiven EqPred {} ->
       unitConstructor
     EvDict dictOrigin dictName typeArgs contextEvidence -> do
-      dictTy <- lookupType dictName
+      dictTy <- maybe (lookupType dictName) (`lookupTypeAtOrigin` dictName) dictOrigin
       contextDicts <- mapM dsEvidence contextEvidence
       let origin = fmap (\(packageName, moduleName) -> FcTopLevelOrigin packageName moduleName dictName) dictOrigin
           dictExpr = List.foldl' FcTyApp (FcVar (Var dictName (Unique (-199)) dictTy) {varResolvedName = origin}) typeArgs
@@ -1682,7 +1718,7 @@ stringTy = listType charTy
 
 unitConstructor :: DsM FcExpr
 unitConstructor = do
-  ty <- lookupType "()"
+  let ty = TcTyCon (TyCon "Unit" 0) []
   pure (FcVar (Var "()" (Unique (-13)) ty))
 
 exprAnnotationType :: Expr -> Maybe TcType
@@ -1924,4 +1960,14 @@ lookupTypeName name = do
 lookupTypeMaybeName :: Name -> DsM (Maybe TcType)
 lookupTypeMaybeName name = do
   st <- get
-  pure (Map.lookup (nameToText name) (dsTypeEnv st) <|> Map.lookup (nameText name) (dsTypeEnv st))
+  case bindingIdentityForName name of
+    Just identity -> pure (Map.lookup identity (dsTypeEnv st))
+    Nothing -> pure Nothing
+
+bindingIdentityForName :: Name -> Maybe TcBindingId
+bindingIdentityForName name =
+  case listToMaybe [resolutionTarget resolution | resolution <- mapMaybe fromAnnotation (nameAnns name), resolutionNamespace resolution == ResolutionNamespaceTerm] of
+    Just (ResolvedTopLevel (PackageId packageId) target) ->
+      TcBindingId packageId <$> nameQualifier target <*> pure (nameText target)
+    Just (ResolvedBuiltin builtinName) -> Just (builtinBindingId builtinName)
+    _ -> Nothing

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -19,9 +19,8 @@ module Aihc.Fc.Desugar.Expr
     desugarBug,
     freshUnique,
     freshVar,
-    lookupType,
     lookupTypeAt,
-    lookupTypeAtOrigin,
+    bindingIdForOrigin,
     withDicts,
   )
 where
@@ -124,14 +123,6 @@ freshInternalVar prefix ty = do
 desugarBug :: String -> DsM a
 desugarBug = lift . Left
 
--- | Look up a name's type (locals first, then global TC env).
-lookupType :: Text -> DsM TcType
-lookupType name = do
-  st <- get
-  case Map.lookup name (dsLocalVars st) of
-    Just v -> pure (varType v)
-    Nothing -> lookupTypeAt (TcBindingId (dsModulePackage st) (fromMaybe "Main" (dsModuleName st)) name)
-
 lookupTypeAt :: TcBindingId -> DsM TcType
 lookupTypeAt identity = do
   st <- get
@@ -139,9 +130,13 @@ lookupTypeAt identity = do
     Just ty -> pure ty
     Nothing -> desugarBug ("missing type information for binding: " <> show identity)
 
-lookupTypeAtOrigin :: (Text, Text) -> Text -> DsM TcType
-lookupTypeAtOrigin (packageId, moduleName) name =
-  lookupTypeAt (TcBindingId packageId moduleName name)
+bindingIdForOrigin :: Maybe (Text, Text) -> Text -> DsM TcBindingId
+bindingIdForOrigin maybeOrigin name =
+  case maybeOrigin of
+    Just (packageId, moduleName) -> pure (TcBindingId packageId moduleName name)
+    Nothing -> do
+      st <- get
+      pure (TcBindingId (dsModulePackage st) (fromMaybe "Main" (dsModuleName st)) name)
 
 -- | Look up a local variable binding.
 lookupLocal :: Text -> DsM (Maybe Var)
@@ -1488,7 +1483,7 @@ tupleConExpr flavor elemTys = do
   constructorOrigin <- gets dsTupleConstructorOrigin
   (constructorTy, resolvedOrigin) <-
     case (flavor, constructorOrigin) of
-      (_, Just origin@(FcTopLevelOrigin packageId moduleName _)) -> (,Just origin) <$> lookupTypeAtOrigin (packageId, moduleName) name
+      (_, Just origin@(FcTopLevelOrigin packageId moduleName _)) -> (,Just origin) <$> lookupTypeAt (TcBindingId packageId moduleName name)
       (Unboxed, _) -> pure (unboxedTupleConType arity, Just (FcBuiltinOrigin name))
       (Boxed, _) -> pure (boxedTupleConType arity, Just (FcBuiltinOrigin name))
   constructor <-
@@ -1600,7 +1595,8 @@ dsEvidence evidence =
     EvGiven EqPred {} ->
       unitConstructor
     EvDict dictOrigin dictName typeArgs contextEvidence -> do
-      dictTy <- maybe (lookupType dictName) (`lookupTypeAtOrigin` dictName) dictOrigin
+      dictIdentity <- bindingIdForOrigin dictOrigin dictName
+      dictTy <- lookupTypeAt dictIdentity
       contextDicts <- mapM dsEvidence contextEvidence
       let origin = fmap (\(packageName, moduleName) -> FcTopLevelOrigin packageName moduleName dictName) dictOrigin
           dictExpr = List.foldl' FcTyApp (FcVar (Var dictName (Unique (-199)) dictTy) {varResolvedName = origin}) typeArgs

--- a/components/aihc-fc/src/Aihc/Fc/Merge.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Merge.hs
@@ -40,14 +40,13 @@ mergePrograms target programs =
     importedTypes = Map.fromList [(origin, ty) | program <- qualifiedPrograms, FcExternal origin ty <- fcTopBinds program]
     providerEntries = concatMap (programProviders importedTypes) qualifiedPrograms
     providers = Map.fromList providerEntries
-    sourceProviders = fallbackSourceProviders providerEntries
     duplicateErrors = map FcDuplicateDefinition (duplicates (map fst providerEntries))
     typeErrors = concatMap (checkExternalTypes providers) qualifiedPrograms
     merged =
       FcProgram
         target
         ( concatMap
-            (map (resolveTopBind providers sourceProviders) . filter (keepExternal providers) . fcTopBinds)
+            (map (resolveTopBind providers) . filter (keepExternal providers) . fcTopBinds)
             qualifiedPrograms
         )
 
@@ -191,13 +190,6 @@ newtypeConstructorType declaration =
   where
     body = TcFunTy (fcNewtypeRepresentation declaration) (fcNewtypeResult declaration)
 
--- The type checker does not yet attach an origin to all compiler-generated
--- evidence references. Keep the prior last-definition fallback for those
--- references. Source references with an origin never use this table.
-fallbackSourceProviders :: [(FcSymbolOrigin, Var)] -> Map Text Var
-fallbackSourceProviders entries =
-  Map.fromList [(fcOriginName origin, var) | (origin, var) <- entries]
-
 topBinders :: FcTopBind -> [Var]
 topBinders topBind =
   case topBind of
@@ -229,39 +221,37 @@ keepExternal providers topBind =
     FcExternal origin _ -> Map.notMember origin providers
     _ -> True
 
-resolveTopBind :: Map FcSymbolOrigin Var -> Map Text Var -> FcTopBind -> FcTopBind
-resolveTopBind providers sourceProviders topBind =
+resolveTopBind :: Map FcSymbolOrigin Var -> FcTopBind -> FcTopBind
+resolveTopBind providers topBind =
   case topBind of
-    FcTopBind bind -> FcTopBind (resolveBind providers sourceProviders Set.empty bind)
+    FcTopBind bind -> FcTopBind (resolveBind providers Set.empty bind)
     _ -> topBind
 
-resolveBind :: Map FcSymbolOrigin Var -> Map Text Var -> Set.Set Unique -> FcBind -> FcBind
-resolveBind providers sourceProviders bound bind =
+resolveBind :: Map FcSymbolOrigin Var -> Set.Set Unique -> FcBind -> FcBind
+resolveBind providers bound bind =
   case bind of
-    FcNonRec var rhs -> FcNonRec var (resolveExpr providers sourceProviders bound rhs)
+    FcNonRec var rhs -> FcNonRec var (resolveExpr providers bound rhs)
     FcRec bindings ->
       let recursiveBound = bound <> Set.fromList (map (varUnique . fst) bindings)
-       in FcRec [(var, resolveExpr providers sourceProviders recursiveBound rhs) | (var, rhs) <- bindings]
+       in FcRec [(var, resolveExpr providers recursiveBound rhs) | (var, rhs) <- bindings]
 
-resolveExpr :: Map FcSymbolOrigin Var -> Map Text Var -> Set.Set Unique -> FcExpr -> FcExpr
-resolveExpr providers sourceProviders bound expression =
+resolveExpr :: Map FcSymbolOrigin Var -> Set.Set Unique -> FcExpr -> FcExpr
+resolveExpr providers bound expression =
   case expression of
     FcVar var ->
       FcVar
         ( case varResolvedName var of
             Just origin -> resolveOccurrence var (Map.lookup origin providers)
-            Nothing
-              | varUnique var `Set.notMember` bound -> resolveOccurrence var (Map.lookup (varName var) sourceProviders)
-              | otherwise -> var
+            Nothing -> var
         )
     FcLit {} -> expression
     FcApp function argument -> FcApp (recur function) (recur argument)
     FcTyApp function ty -> FcTyApp (recur function) ty
-    FcLam var body -> FcLam var (resolveExpr providers sourceProviders (Set.insert (varUnique var) bound) body)
+    FcLam var body -> FcLam var (resolveExpr providers (Set.insert (varUnique var) bound) body)
     FcTyLam tyVar body -> FcTyLam tyVar (recur body)
     FcLet bind body ->
       let bodyBound = bound <> Set.fromList (map varUnique (bindersOf bind))
-       in FcLet (resolveBind providers sourceProviders bound bind) (resolveExpr providers sourceProviders bodyBound body)
+       in FcLet (resolveBind providers bound bind) (resolveExpr providers bodyBound body)
     FcCase scrutinee binder alternatives ->
       FcCase
         (recur scrutinee)
@@ -270,7 +260,6 @@ resolveExpr providers sourceProviders bound expression =
             { altRhs =
                 resolveExpr
                   providers
-                  sourceProviders
                   (bound <> Set.fromList (map varUnique (binder : altBinders alternative)))
                   (altRhs alternative)
             }
@@ -279,7 +268,7 @@ resolveExpr providers sourceProviders bound expression =
     FcCast body coercion -> FcCast (recur body) coercion
     FcCallForeign foreignCall arguments -> FcCallForeign foreignCall (map recur arguments)
   where
-    recur = resolveExpr providers sourceProviders bound
+    recur = resolveExpr providers bound
 
 resolveOccurrence :: Var -> Maybe Var -> Var
 resolveOccurrence occurrence provider =

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -14,15 +14,18 @@ module Test.Fc.Suite
 where
 
 import Aihc.Fc
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsState (..), dsEvidence, withDicts)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax qualified as Surface
-import Aihc.Tc (Kind (KType), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
-import Aihc.Tc.Evidence (Coercion (..))
+import Aihc.Tc (Kind (KType), Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
+import Aihc.Tc.Evidence (Coercion (..), EvTerm (..))
 import Aihc.Testing.EvalFixture qualified as EvalGolden
+import Control.Monad.Trans.State.Strict (runStateT)
 import Data.List (find)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import FcGolden
@@ -69,7 +72,19 @@ fcDesugarTests =
             result = desugarModule parsedModule
         assertEqual "source parses" [] parseErrors
         assertBool ("desugaring succeeds: " <> show (dsErrors result)) (dsSuccess result)
-        assertEqual "Core lint" [] (lintProgram emptyLintEnv (dsProgram result))
+        assertEqual "Core lint" [] (lintProgram emptyLintEnv (dsProgram result)),
+      testCase "keeps structurally different dictionary predicates separate" $ do
+        let firstType = TcTyCon (TyCon "A_B" 0) []
+            secondType = TcTyCon (TyCon "A" 1) [TcTyCon (TyCon "B" 0) []]
+            firstVar = Var "$first" (Unique 1) firstType
+            secondVar = Var "$second" (Unique 2) secondType
+            firstDict = ClassDict "C" [firstType] firstVar
+            secondDict = ClassDict "C" [secondType] secondVar
+            state = DsState 1000 "test" (Just "Test") Map.empty Map.empty Map.empty Map.empty Nothing
+            action = withDicts [firstDict, secondDict] (dsEvidence (EvGiven (ClassPred "C" [secondType])))
+        case runStateT action state of
+          Left err -> assertFailure err
+          Right (expression, _) -> assertEqual "selected dictionary" (FcVar secondVar) expression
     ]
   where
     declarationConstructors declaration =

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-concrete-uses.yaml
@@ -67,8 +67,6 @@ expected: |-
 
   external GHC.Classes.== : ∀ (a : TYPE BoxedRep Lifted). (Eq a) → a → a → Bool
 
-  external GHC.Internal.Integer.IS : Int# → Integer
-
   external GHC.Num.$fNumInt : Num Int
 
   external GHC.Num.$fNumInteger : Num Integer
@@ -77,18 +75,20 @@ expected: |-
 
   external GHC.Tuple.() : Unit
 
+  external GHC.Types.IS : Int# → Integer
+
   asInt : Int =
-    ((GHC.Num.fromInteger @Int) GHC.Num.$fNumInt) (GHC.Internal.Integer.IS 1#IntRep)
+    ((GHC.Num.fromInteger @Int) GHC.Num.$fNumInt) (GHC.Types.IS 1#IntRep)
 
   asInteger : Integer =
-    ((GHC.Num.fromInteger @Integer) GHC.Num.$fNumInteger) (GHC.Internal.Integer.IS 1#IntRep)
+    ((GHC.Num.fromInteger @Integer) GHC.Num.$fNumInteger) (GHC.Types.IS 1#IntRep)
 
   caseInt : Unit =
     let {
       _case_value : Int =
-        ((GHC.Num.fromInteger @Int) GHC.Num.$fNumInt) (GHC.Internal.Integer.IS 1#IntRep)
+        ((GHC.Num.fromInteger @Int) GHC.Num.$fNumInt) (GHC.Types.IS 1#IntRep)
     } in
-      case (((GHC.Classes.== @Int) GHC.Classes.$fEqInt) _case_value) (((GHC.Num.fromInteger @Int) GHC.Num.$fNumInt) (GHC.Internal.Integer.IS 1#IntRep)) as (_case_guard : Bool) of {
+      case (((GHC.Classes.== @Int) GHC.Classes.$fEqInt) _case_value) (((GHC.Num.fromInteger @Int) GHC.Num.$fNumInt) (GHC.Types.IS 1#IntRep)) as (_case_guard : Bool) of {
         True →
           GHC.Tuple.();
         False →

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-ghc-num-frominteger.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-ghc-num-frominteger.yaml
@@ -16,14 +16,14 @@ expected: |-
         }
   module Main where
 
-  external GHC.Internal.Integer.IS : Int# → Integer
+  external GHC.Num.IS : Int# → Integer
 
   external GHC.Num.fromInteger : ∀ (a : TYPE BoxedRep Lifted). (Num a) → Integer → a
 
   one : ∀ (a : TYPE BoxedRep Lifted). (Num a) → a =
     Λ(a : TYPE BoxedRep Lifted).
       λ($d0 : Num a).
-        ((GHC.Num.fromInteger @a) $d0) (GHC.Internal.Integer.IS 1#IntRep)
+        ((GHC.Num.fromInteger @a) $d0) (GHC.Num.IS 1#IntRep)
 extensions:
 - MagicHash
 modules:

--- a/components/aihc-grin/test/GrinGolden.hs
+++ b/components/aihc-grin/test/GrinGolden.hs
@@ -117,7 +117,7 @@ evaluateGrinCase fixture =
            in if all tcModuleSuccess tcResults
                 then
                   let allBindings = moduleGroupBindings tcResults
-                      desugared = zipWith (desugarModuleWithBindings allBindings) tcResults moduleAsts
+                      desugared = map (desugarModuleWithBindings allBindings) tcResults
                    in if all dsSuccess desugared
                         then
                           let programs = map (lowerProgram . dsProgram) desugared

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -17,6 +17,7 @@ module Aihc.Resolve
     ModuleKey (..),
     PackageId (..),
     Package (..),
+    ModuleOrigin (..),
     unnamedPackage,
     modulesInPackage,
     collectModuleExports,
@@ -89,6 +90,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
     mkUnqualifiedName,
+    moduleName,
     peelGuardQualifierAnn,
     peelLiteralAnn,
     peelPatternAnn,
@@ -224,7 +226,8 @@ resolveModule package exports nextLocal modu =
       modu' = modu {moduleImports = imports'}
       scope = moduleScope package exports modu'
       (nextLocal', decls') = runResolveM scope (moduleInfo package exports modu') nextLocal (resolveTopLevelDecls Map.empty (moduleDecls modu))
-   in (nextLocal', modu' {moduleDecls = decls'})
+      origin = ModuleOrigin (packageId package) (fromMaybe "Main" (moduleName modu))
+   in (nextLocal', modu' {moduleAnns = mkAnnotation origin : moduleAnns modu', moduleDecls = decls'})
 
 moduleInfo :: Package -> ModuleExports -> Module -> ModuleInfo
 moduleInfo package exports modu =

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -12,6 +12,7 @@ module Aihc.Resolve.Types
     ResolutionForm (..),
     PackageId (..),
     Package (..),
+    ModuleOrigin (..),
     unnamedPackage,
     modulesInPackage,
     ResolvedName (..),
@@ -45,6 +46,13 @@ newtype PackageId = PackageId {packageIdText :: Text}
 data Package = Package
   { packageName :: !Text,
     packageId :: !PackageId
+  }
+  deriving (Eq, Ord, Show)
+
+-- | The complete source identity of one resolved module.
+data ModuleOrigin = ModuleOrigin
+  { moduleOriginPackageId :: !PackageId,
+    moduleOriginName :: !Text
   }
   deriving (Eq, Ord, Show)
 

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -31,6 +31,7 @@ module Aihc.Tc
     -- * Result types
     TcResult (..),
     TcBindingResult (..),
+    tbName,
     TcInterface (..),
     emptyTcInterface,
 
@@ -43,6 +44,8 @@ module Aihc.Tc
 
     -- * Re-exports for convenience
     TcType (..),
+    TcBindingId (..),
+    builtinBindingId,
     Kind (..),
     RuntimeRep (..),
     Levity (..),
@@ -118,7 +121,7 @@ import Aihc.Parser.Syntax
 import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..), renderPred, renderTcSignature, renderTcType)
 import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), dataConArgTypes, dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
-import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tcModule, tcModuleScc)
+import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tbName, tcModule, tcModuleScc)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (solveConstraints)
@@ -130,7 +133,6 @@ import Control.Monad.Trans.State.Strict (State, get, put, runState)
 import Data.Data (Data, gmapM, gmapQ)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, maybeToList)
-import Data.Text (Text)
 import Data.Typeable (cast)
 
 -- | Result of type checking.
@@ -148,7 +150,7 @@ data TcResult = TcResult
 -- module groups. Implementations never cross this boundary: only the facts
 -- needed to type-check downstream source are retained.
 data TcInterface = TcInterface
-  { tcInterfaceTerms :: ![(Text, TypeScheme)],
+  { tcInterfaceTerms :: ![(TcBindingId, TypeScheme)],
     tcInterfaceTyCons :: ![TyConInfo],
     tcInterfaceDataTypes :: ![DataTypeInfo],
     tcInterfaceClasses :: ![ClassInfo],
@@ -252,12 +254,12 @@ typecheckModule =
   typecheckModuleWithEnv []
 
 -- | Type-check a single module with preloaded top-level term bindings.
-typecheckModuleWithEnv :: [(Text, TypeScheme)] -> Module -> Module
+typecheckModuleWithEnv :: [(TcBindingId, TypeScheme)] -> Module -> Module
 typecheckModuleWithEnv importedTerms =
   typecheckModuleWithEnvAndInstances importedTerms []
 
 -- | Type-check a single module with preloaded terms and class instances.
-typecheckModuleWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> Module -> Module
+typecheckModuleWithEnvAndInstances :: [(TcBindingId, TypeScheme)] -> [InstanceInfo] -> Module -> Module
 typecheckModuleWithEnvAndInstances importedTerms importedInstances m =
   case typecheckModulesWithEnvAndInstances importedTerms importedInstances [m] of
     [result] -> result
@@ -268,12 +270,12 @@ typecheckModuleWithEnvAndInstances importedTerms importedInstances m =
 -- environment. This is intentionally pragmatic: callers that have already
 -- resolved a dependency-ordered module list can feed it here so later modules
 -- see earlier data constructors and value bindings.
-typecheckModulesWithEnv :: [(Text, TypeScheme)] -> [Module] -> [Module]
+typecheckModulesWithEnv :: [(TcBindingId, TypeScheme)] -> [Module] -> [Module]
 typecheckModulesWithEnv importedTerms =
   typecheckModulesWithEnvAndInstances importedTerms []
 
 -- | Type-check modules in order with preloaded terms and class instances.
-typecheckModulesWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> [Module] -> [Module]
+typecheckModulesWithEnvAndInstances :: [(TcBindingId, TypeScheme)] -> [InstanceInfo] -> [Module] -> [Module]
 typecheckModulesWithEnvAndInstances importedTerms importedInstances =
   fst
     . typecheckModulesWithInterface
@@ -285,7 +287,7 @@ typecheckModulesWithEnvAndInstances importedTerms importedInstances =
 -- | Type-check modules with a complete imported type-checker interface and
 -- return the accumulated term schemes and type constructors for downstream
 -- modules.
-typecheckModulesWithFullEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo])
+typecheckModulesWithFullEnv :: [(TcBindingId, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(TcBindingId, TypeScheme)], [TyConInfo])
 typecheckModulesWithFullEnv importedTerms importedTyCons importedInstances modules =
   let (checkedModules, interface) =
         typecheckModulesWithInterface
@@ -297,7 +299,7 @@ typecheckModulesWithFullEnv importedTerms importedTyCons importedInstances modul
           modules
    in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface)
 
-typecheckModulesWithClassEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo], [ClassInfo])
+typecheckModulesWithClassEnv :: [(TcBindingId, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(TcBindingId, TypeScheme)], [TyConInfo], [ClassInfo])
 typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses importedInstances modules =
   let (checkedModules, interface) =
         typecheckModulesWithInterface
@@ -328,7 +330,7 @@ typecheckModulesWithInterface imported modules =
 -- | Type-check the modules in one strongly connected import component as a
 -- single incremental unit. Only the supplied imported interface is visible;
 -- implementations from predecessor components are never consumed.
-typecheckModuleSccWithFullEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo])
+typecheckModuleSccWithFullEnv :: [(TcBindingId, TypeScheme)] -> [TyConInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(TcBindingId, TypeScheme)], [TyConInfo])
 typecheckModuleSccWithFullEnv importedTerms importedTyCons importedInstances modules =
   let (checkedModules, interface) =
         typecheckModuleSccWithInterface
@@ -340,7 +342,7 @@ typecheckModuleSccWithFullEnv importedTerms importedTyCons importedInstances mod
           modules
    in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface)
 
-typecheckModuleSccWithClassEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo], [ClassInfo])
+typecheckModuleSccWithClassEnv :: [(TcBindingId, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(TcBindingId, TypeScheme)], [TyConInfo], [ClassInfo])
 typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses importedInstances modules =
   let (checkedModules, interface) =
         typecheckModuleSccWithInterface

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -231,7 +231,6 @@ data TcInstanceAnnotation = TcInstanceAnnotation
     tcInstanceClassSuperClasses :: ![TcDictBinderAnnotation],
     tcInstanceContextDicts :: ![TcDictBinderAnnotation],
     tcInstanceSuperClasses :: ![(TcDictBinderAnnotation, EvTerm)],
-    tcInstanceClassMethods :: ![(Text, TcType)],
     tcInstanceMethodOrder :: ![Text],
     tcInstanceDefaultMethods :: ![Text]
   }

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -10,6 +10,7 @@ module Aihc.Tc.Annotations
   ( -- * Annotation type
     TcAnnotation (..),
     TcForeignImportAnnotation (..),
+    TcIntegerLiteralAnnotation (..),
     TcForeignEffect (..),
     TcForeignMarshal (..),
     TcForeignAbiType (..),
@@ -55,7 +56,7 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Tc.Env (DataTypeInfo)
 import Aihc.Tc.Evidence (EvTerm, EvVar)
-import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType)
+import Aihc.Tc.Types (Pred (..), TcBindingId, TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -83,7 +84,13 @@ data TcAnnotation = TcAnnotation
 data TcForeignImportAnnotation = TcForeignImportAnnotation
   { tcForeignArguments :: ![TcForeignMarshal],
     tcForeignResult :: !TcForeignMarshal,
-    tcForeignEffect :: !TcForeignEffect
+    tcForeignEffect :: !TcForeignEffect,
+    tcForeignIoConstructor :: !(Maybe TcBindingId)
+  }
+  deriving (Eq, Show)
+
+newtype TcIntegerLiteralAnnotation = TcIntegerLiteralAnnotation
+  { tcIntegerConstructor :: TcBindingId
   }
   deriving (Eq, Show)
 
@@ -100,7 +107,7 @@ data TcForeignEffect
 data TcForeignMarshal = TcForeignMarshal
   { tcForeignSourceType :: !TcType,
     tcForeignPrimitiveType :: !TcType,
-    tcForeignConstructors :: ![Text],
+    tcForeignConstructors :: ![TcBindingId],
     tcForeignAbiType :: !TcForeignAbiType
   }
   deriving (Eq, Show)

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -224,6 +224,7 @@ data TcInstanceAnnotation = TcInstanceAnnotation
     tcInstanceClassSuperClasses :: ![TcDictBinderAnnotation],
     tcInstanceContextDicts :: ![TcDictBinderAnnotation],
     tcInstanceSuperClasses :: ![(TcDictBinderAnnotation, EvTerm)],
+    tcInstanceClassMethods :: ![(Text, TcType)],
     tcInstanceMethodOrder :: ![Text],
     tcInstanceDefaultMethods :: ![Text]
   }

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -212,6 +212,7 @@ firstMetaInstanceAnnotation ann =
   firstJusts
     ( firstMetaType (tcInstanceDictType ann)
         : map firstMetaType (tcInstanceHeadTypes ann)
+        ++ map (firstMetaType . snd) (tcInstanceClassMethods ann)
         ++ map firstMetaDictBinderAnnotation (tcInstanceClassSuperClasses ann)
         ++ map firstMetaDictBinderAnnotation (tcInstanceContextDicts ann)
         ++ [ firstMetaDictBinderAnnotation superClass <|> firstMetaEvTerm evidence

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -212,7 +212,6 @@ firstMetaInstanceAnnotation ann =
   firstJusts
     ( firstMetaType (tcInstanceDictType ann)
         : map firstMetaType (tcInstanceHeadTypes ann)
-        ++ map (firstMetaType . snd) (tcInstanceClassMethods ann)
         ++ map firstMetaDictBinderAnnotation (tcInstanceClassSuperClasses ann)
         ++ map firstMetaDictBinderAnnotation (tcInstanceContextDicts ann)
         ++ [ firstMetaDictBinderAnnotation superClass <|> firstMetaEvTerm evidence

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -109,7 +109,6 @@ import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds, defa
 import Control.Monad (foldM, forM_, unless, when, zipWithM, zipWithM_, (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
-import Data.Bifunctor (second)
 import Data.Graph (SCC (..), stronglyConnComp)
 import Data.List (find, mapAccumL, nub, nubBy, partition, (\\))
 import Data.Map.Strict (Map)
@@ -1010,7 +1009,6 @@ annotateInstanceDeclTc classMethods instanceDecl =
               Nothing -> Map.empty
           superClassTypes = maybe [] (map (substType classSubstitution) . ciSuperClassTypes) classInfo
           defaults = maybe [] ciDefaultMethods classInfo
-          classMethodTypes = maybe [] (map (second schemeToType) . ciMethods) classInfo
       superClasses <- mapM constraintTypePred superClassTypes
       superClassEvidence <- mapM (solveInstanceSuperClass classNameText context) superClasses
       let contextDicts = map predDictBinder context
@@ -1027,7 +1025,6 @@ annotateInstanceDeclTc classMethods instanceDecl =
                 tcInstanceClassSuperClasses = maybe [] (map constraintTypeDictBinder . ciSuperClassTypes) classInfo,
                 tcInstanceContextDicts = contextDicts,
                 tcInstanceSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
-                tcInstanceClassMethods = classMethodTypes,
                 tcInstanceMethodOrder = methodOrder,
                 tcInstanceDefaultMethods = defaults
               }

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -109,6 +109,7 @@ import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds, defa
 import Control.Monad (foldM, forM_, unless, when, zipWithM, (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
+import Data.Bifunctor (second)
 import Data.Graph (SCC (..), stronglyConnComp)
 import Data.List (find, mapAccumL, nub, nubBy, partition, (\\))
 import Data.Map.Strict (Map)
@@ -1004,6 +1005,7 @@ annotateInstanceDeclTc classMethods instanceDecl =
               Nothing -> Map.empty
           superClassTypes = maybe [] (map (substType classSubstitution) . ciSuperClassTypes) classInfo
           defaults = maybe [] ciDefaultMethods classInfo
+          classMethodTypes = maybe [] (map (second schemeToType) . ciMethods) classInfo
       superClasses <- mapM constraintTypePred superClassTypes
       superClassEvidence <- mapM (solveInstanceSuperClass classNameText context) superClasses
       let contextDicts = map predDictBinder context
@@ -1020,6 +1022,7 @@ annotateInstanceDeclTc classMethods instanceDecl =
                 tcInstanceClassSuperClasses = maybe [] (map constraintTypeDictBinder . ciSuperClassTypes) classInfo,
                 tcInstanceContextDicts = contextDicts,
                 tcInstanceSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
+                tcInstanceClassMethods = classMethodTypes,
                 tcInstanceMethodOrder = methodOrder,
                 tcInstanceDefaultMethods = defaults
               }

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -13,6 +13,7 @@ module Aihc.Tc.Generate.Decl
     moduleInstances,
     moduleClasses,
     TcBindingResult (..),
+    tbName,
   )
 where
 
@@ -66,13 +67,12 @@ import Aihc.Parser.Syntax
     instanceHeadTypes,
     mkAnnotation,
     moduleName,
-    nameQualifier,
     nameText,
     peelClassDeclItemAnn,
     peelDeclAnn,
     unqualifiedNameAnns,
   )
-import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
+import Aihc.Resolve (ModuleOrigin (..), PackageId (..))
 import Aihc.Tc.Annotations
   ( TcAnnotation (..),
     TcClassAnnotation (..),
@@ -106,7 +106,7 @@ import Aihc.Tc.Solve.Dict (DictResult (..), solveDictWithGivens)
 import Aihc.Tc.Solve.InertSet (InertSet (..))
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds, defaultTypeSchemeKinds, zonkType)
-import Control.Monad (foldM, forM_, unless, when, zipWithM, (>=>))
+import Control.Monad (foldM, forM_, unless, when, zipWithM, zipWithM_, (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
 import Data.Bifunctor (second)
@@ -114,7 +114,7 @@ import Data.Graph (SCC (..), stronglyConnComp)
 import Data.List (find, mapAccumL, nub, nubBy, partition, (\\))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe, maybeToList)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -132,15 +132,26 @@ peelDeclSpan ambient (DeclAnn ann inner) =
 peelDeclSpan ambient _ = ambient
 
 -- | Result of type-checking a single binding.
-data TcBindingResult = TcBindingResult
+data UnqualifiedBindingResult = UnqualifiedBindingResult
   { -- | Canonical binder identity. Symbolic binders are stored without
     -- prefix-position parentheses, e.g. @++@ rather than @(++)@.
-    tbName :: !Text,
+    ubName :: !Text,
     -- | Human-facing rendering for diagnostics and golden output.
+    ubDisplayName :: !Text,
+    ubType :: !TcType
+  }
+  deriving (Show, Read)
+
+-- | Checked type information for one fully identified global binding.
+data TcBindingResult = TcBindingResult
+  { tbIdentity :: !TcBindingId,
     tbDisplayName :: !Text,
     tbType :: !TcType
   }
   deriving (Show, Read)
+
+tbName :: TcBindingResult -> Text
+tbName = tcBindingName . tbIdentity
 
 data UserSig = UserSig
   { userSigName :: !Text,
@@ -158,7 +169,15 @@ data CheckedSig = CheckedSig
 
 moduleBindings :: Module -> [TcBindingResult]
 moduleBindings modu =
-  concatMap declBindings (moduleDecls modu)
+  map identify (concatMap declBindings (moduleDecls modu))
+  where
+    (packageId, moduleName') = resolvedModuleOrigin modu
+    identify binding =
+      TcBindingResult
+        { tbIdentity = TcBindingId packageId moduleName' (ubName binding),
+          tbDisplayName = ubDisplayName binding,
+          tbType = ubType binding
+        }
 
 -- | Recover instance-environment entries from finalized module annotations.
 moduleInstances :: Module -> [InstanceInfo]
@@ -170,37 +189,9 @@ setInstanceOrigin origin instanceInfo = instanceInfo {iiDictOrigin = Just origin
 
 resolvedModuleOrigin :: Module -> (Text, Text)
 resolvedModuleOrigin resolvedModule =
-  fromMaybe ("", fromMaybe "Main" (moduleName resolvedModule)) $ do
-    resolved <- listToMaybe (mapMaybe definitionResolution (moduleDecls resolvedModule))
-    case resolutionTarget resolved of
-      ResolvedTopLevel packageId name ->
-        pure (packageIdText packageId, fromMaybe (fromMaybe "Main" (moduleName resolvedModule)) (nameQualifier name))
-      _ -> Nothing
-
-definitionResolution :: Decl -> Maybe ResolutionAnnotation
-definitionResolution declaration =
-  case peelDeclAnn declaration of
-    DeclValue (FunctionBind name _) -> nameResolution name
-    DeclValue (PatternBind _ pattern' _) -> patternResolution pattern'
-    DeclData dataDeclaration -> nameResolution (binderHeadName (dataDeclHead dataDeclaration))
-    DeclNewtype newtypeDeclaration -> nameResolution (binderHeadName (newtypeDeclHead newtypeDeclaration))
-    DeclClass classDeclaration -> nameResolution (binderHeadName (classDeclHead classDeclaration))
-    _ -> Nothing
-
-patternResolution :: Pattern -> Maybe ResolutionAnnotation
-patternResolution pattern' =
-  case pattern' of
-    PVar name -> nameResolution name
-    PAnn _ inner -> patternResolution inner
-    PParen inner -> patternResolution inner
-    PStrict inner -> patternResolution inner
-    PIrrefutable inner -> patternResolution inner
-    PAs name _ -> nameResolution name
-    PTypeSig inner _ -> patternResolution inner
-    _ -> Nothing
-
-nameResolution :: UnqualifiedName -> Maybe ResolutionAnnotation
-nameResolution = listToMaybe . mapMaybe fromAnnotation . unqualifiedNameAnns
+  case mapMaybe (fromAnnotation @ModuleOrigin) (moduleAnns resolvedModule) of
+    ModuleOrigin packageId moduleName' : _ -> (packageIdText packageId, moduleName')
+    [] -> ("", fromMaybe "Main" (moduleName resolvedModule))
 
 -- | Recover class-environment entries from finalized module annotations.
 moduleClasses :: Module -> [ClassInfo]
@@ -279,7 +270,7 @@ dictBinderPred :: TcDictBinderAnnotation -> Pred
 dictBinderPred dictBinder =
   ClassPred (tcDictBinderClassName dictBinder) (tcDictBinderArgs dictBinder)
 
-declBindings :: Decl -> [TcBindingResult]
+declBindings :: Decl -> [UnqualifiedBindingResult]
 declBindings decl =
   case decl of
     DeclAnn ann inner ->
@@ -293,46 +284,46 @@ declBindings decl =
       concatMap dataConBindings (dataFamilyInstConstructors familyInst)
     _ -> []
 
-annotationBindings :: Annotation -> Decl -> [TcBindingResult]
+annotationBindings :: Annotation -> Decl -> [UnqualifiedBindingResult]
 annotationBindings ann decl =
   tcAnnotationBindings ann decl
     <> classAnnotationBindings ann decl
     <> instanceAnnotationBindings ann
     <> derivingAnnotationBindings ann
 
-tcAnnotationBindings :: Annotation -> Decl -> [TcBindingResult]
+tcAnnotationBindings :: Annotation -> Decl -> [UnqualifiedBindingResult]
 tcAnnotationBindings ann decl =
   case fromAnnotation ann of
     Nothing -> []
     Just tcAnn ->
       case decl of
         DeclValue valueDecl ->
-          [ TcBindingResult name displayName (tcAnnType tcAnn)
+          [ UnqualifiedBindingResult name displayName (tcAnnType tcAnn)
           | (name, displayName) <- valueDeclBindingNames valueDecl
           ]
         DeclData dataDecl ->
           let name = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn)]
+           in [UnqualifiedBindingResult name name (tcAnnType tcAnn)]
         DeclNewtype newtypeDecl ->
           let name = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn)]
+           in [UnqualifiedBindingResult name name (tcAnnType tcAnn)]
         DeclDataFamilyDecl familyDecl ->
           let name = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn)]
+           in [UnqualifiedBindingResult name name (tcAnnType tcAnn)]
         DeclForeign foreignDecl ->
           let name = unqualifiedNameText (foreignName foreignDecl)
               displayName = renderBinderName (foreignName foreignDecl)
-           in [TcBindingResult name displayName (tcAnnType tcAnn)]
+           in [UnqualifiedBindingResult name displayName (tcAnnType tcAnn)]
         _ -> []
 
-classAnnotationBindings :: Annotation -> Decl -> [TcBindingResult]
+classAnnotationBindings :: Annotation -> Decl -> [UnqualifiedBindingResult]
 classAnnotationBindings ann decl =
   case (fromAnnotation ann, decl) of
     (Just classAnn, DeclClass {}) ->
-      [ TcBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method)
+      [ UnqualifiedBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method)
       | method <- tcClassMethods classAnn
       ]
-        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method)
+        <> [ UnqualifiedBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method)
            | method <- tcClassMethods classAnn,
              tcClassMethodName method `elem` tcClassDefaultMethods classAnn
            ]
@@ -351,36 +342,36 @@ classDefaultWorkerType classAnnotation method =
            in foldr TcForAllTy qualifiedBody tyVars
     _ -> tcClassMethodType method
 
-instanceAnnotationBindings :: Annotation -> [TcBindingResult]
+instanceAnnotationBindings :: Annotation -> [UnqualifiedBindingResult]
 instanceAnnotationBindings ann =
   case fromAnnotation ann of
     Just instAnn ->
-      [TcBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)]
+      [UnqualifiedBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)]
     Nothing -> []
 
-derivingAnnotationBindings :: Annotation -> [TcBindingResult]
+derivingAnnotationBindings :: Annotation -> [UnqualifiedBindingResult]
 derivingAnnotationBindings ann =
   case fromAnnotation ann of
     Just derivingAnnotation ->
-      [ TcBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo)
+      [ UnqualifiedBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo)
       | plan <- tcDerivingPlans derivingAnnotation,
         Just instanceInfo <- [derivingPlanInstanceInfo plan]
       ]
     Nothing -> []
 
-dataConBindings :: DataConDecl -> [TcBindingResult]
+dataConBindings :: DataConDecl -> [UnqualifiedBindingResult]
 dataConBindings dataConDecl =
   case dataConDecl of
     DataConAnn ann inner ->
       case fromAnnotation ann of
         Just tcAnn ->
-          [ TcBindingResult name displayName (tcAnnType tcAnn)
+          [ UnqualifiedBindingResult name displayName (tcAnnType tcAnn)
           | (name, displayName) <- dataConBindingNames inner
           ]
         Nothing -> dataConBindings inner
     _ -> []
 
-recordSelectorBindings :: DataConDecl -> [TcBindingResult]
+recordSelectorBindings :: DataConDecl -> [UnqualifiedBindingResult]
 recordSelectorBindings declaration =
   case declaration of
     DataConAnn ann inner ->
@@ -397,7 +388,7 @@ recordSelectorBindings declaration =
               result -> ([], result)
           (fieldTypes, resultType) = splitFunctionType body
           (_, sourceFields, _) = dataConSourceLayout inner
-       in [ TcBindingResult label label (foldr TcForAllTy (qualify predicates (TcFunTy resultType fieldType)) typeVariables)
+       in [ UnqualifiedBindingResult label label (foldr TcForAllTy (qualify predicates (TcFunTy resultType fieldType)) typeVariables)
           | ((maybeLabel, _), fieldType) <- zip sourceFields fieldTypes,
             Just label <- [maybeLabel]
           ]
@@ -468,26 +459,27 @@ tcModuleScc modules = do
   -- bodies, then register value-level declarations against those expanded
   -- types. This permits forward references from synonyms to data types while
   -- making aliases available in constructor fields and class methods.
-  let declarations = concatMap moduleDecls modules
-  mapM_ registerTypeDeclHeader declarations
-  mapM_ registerTypeSynonymBody declarations
-  mapM_ (\modu -> mapM_ (registerValueLevelDecl (resolvedModuleOrigin modu)) (moduleDecls modu)) modules
+  mapM_ (inModule (mapM_ registerTypeDeclHeader . moduleDecls)) modules
+  mapM_ (inModule (mapM_ registerTypeSynonymBody . moduleDecls)) modules
+  mapM_ (inModule (\modu -> mapM_ (registerValueLevelDecl (resolvedModuleOrigin modu)) (moduleDecls modu))) modules
   -- Deriving strategy and context inference depends only on registered type,
   -- class, and explicit-instance information. Finalize the entire SCC as one
   -- batch before checking signatures and bodies so sibling derived instances
   -- are mutually visible and ordinary values can use them.
   defaultGlobalKindMetas
-  derivingAnnotated <- mapM annotateModuleDerivingTc modules
+  derivingAnnotated <- mapM (inModule annotateModuleDerivingTc) modules
   derivingFinalized <- finalizeDerivingModulesTc (map resolvedModuleOrigin modules) derivingAnnotated
   -- Phase 2: collect type signatures and convert them to schemes.
-  rawSigs <- mapM (collectUserSigs . moduleDecls) derivingFinalized
-  schemes <- mapM (traverse checkUserSig) rawSigs
-  mapM_ registerCheckedSig (concatMap Map.elems schemes)
-  pending <- zipWithM tcModuleBody schemes derivingFinalized
+  rawSigs <- mapM (inModule (collectUserSigs . moduleDecls)) derivingFinalized
+  schemes <- zipWithM (\modu -> withGlobalTermOrigin (resolvedModuleOrigin modu) . traverse checkUserSig) derivingFinalized rawSigs
+  zipWithM_ (\modu -> withGlobalTermOrigin (resolvedModuleOrigin modu) . mapM_ registerCheckedSig . Map.elems) derivingFinalized schemes
+  pending <- zipWithM (\schemes' modu -> withGlobalTermOrigin (resolvedModuleOrigin modu) (tcModuleBody schemes' modu)) schemes derivingFinalized
   -- No module interface in the SCC may retain state-local kind metavariables.
   defaultGlobalKindMetas
-  annotated <- mapM annotatePendingModule pending
-  mapM finalizeModuleTc annotated
+  annotated <- mapM (\pendingModule -> withGlobalTermOrigin (resolvedModuleOrigin (pendingSyntax pendingModule)) (annotatePendingModule pendingModule)) pending
+  mapM (inModule finalizeModuleTc) annotated
+  where
+    inModule action modu = withGlobalTermOrigin (resolvedModuleOrigin modu) (action modu)
 
 registerCheckedSig :: CheckedSig -> TcM ()
 registerCheckedSig sig =
@@ -495,7 +487,7 @@ registerCheckedSig sig =
 
 data PendingModule = PendingModule
   { pendingSyntax :: !Module,
-    pendingValueResults :: ![TcBindingResult]
+    pendingValueResults :: ![UnqualifiedBindingResult]
   }
 
 tcModuleBody :: Map TcTermKey CheckedSig -> Module -> TcM PendingModule
@@ -530,7 +522,7 @@ annotatePendingModule pending = do
   -- Only bindings that checked without errors are eligible for value
   -- annotations. Failed bindings remain in the recovery environment, but
   -- they must not be rendered as successful inferred types.
-  annotateModuleTc (Set.fromList (map tbName (pendingValueResults pending))) (pendingSyntax pending)
+  annotateModuleTc (Set.fromList (map ubName (pendingValueResults pending))) (pendingSyntax pending)
 
 defaultGlobalKindMetas :: TcM ()
 defaultGlobalKindMetas = do
@@ -633,7 +625,7 @@ defaultGlobalKindMetas = do
 
 data TcDeclGroupResult = TcDeclGroupResult
   { tcGroupId :: !Int,
-    tcGroupBindingResults :: ![TcBindingResult],
+    tcGroupBindingResults :: ![UnqualifiedBindingResult],
     tcGroupAnnotatedDecls :: !(Maybe [Decl])
   }
 
@@ -645,8 +637,8 @@ checkTopLevelUnliftedBindings sourceGroups results =
         | sourceSpan <- declGroupSourceSpan group,
           sourceSpan /= NoSourceSpan ->
             forM_ (tcGroupBindingResults result) $ \binding ->
-              when (isUnliftedType (tbType binding)) $
-                emitError sourceSpan (TopLevelUnliftedBinding (tbDisplayName binding) (tbType binding))
+              when (isUnliftedType (ubType binding)) $
+                emitError sourceSpan (TopLevelUnliftedBinding (ubDisplayName binding) (ubType binding))
       _ -> pure ()
   where
     groupsById = Map.fromList sourceGroups
@@ -886,11 +878,16 @@ checkForeignImportType sourceSpan ty = do
           _ -> (TcForeignPure, resultType)
   arguments <- mapM (checkForeignValueType sourceSpan) argumentTypes
   result <- checkForeignValueType sourceSpan valueResultType
+  ioConstructor <-
+    case effect of
+      TcForeignRealWorld -> findGlobalTermId "IO"
+      TcForeignPure -> pure Nothing
   pure
     TcForeignImportAnnotation
       { tcForeignArguments = arguments,
         tcForeignResult = result,
-        tcForeignEffect = effect
+        tcForeignEffect = effect,
+        tcForeignIoConstructor = ioConstructor
       }
 
 splitFunctionType :: TcType -> ([TcType], TcType)
@@ -904,47 +901,55 @@ splitFunctionType ty =
 checkForeignValueType :: SourceSpan -> TcType -> TcM TcForeignMarshal
 checkForeignValueType sourceSpan ty =
   case ty of
-    TcTyCon (TyCon "Int" 0) [] -> pure (intMarshal ty ["I#"])
-    TcTyCon (TyCon "Int#" 0) [] -> pure (intMarshal ty [])
-    TcTyCon (TyCon "CInt" 0) [] -> pure (int32Marshal ty ["CInt", "I32#"])
-    TcTyCon (TyCon "Int32" 0) [] -> pure (int32Marshal ty ["I32#"])
-    TcTyCon (TyCon "Int32#" 0) [] -> pure (int32Marshal ty [])
-    TcTyCon (TyCon "Word64" 0) [] -> pure (word64Marshal ty ["W64#"])
-    TcTyCon (TyCon "Word64#" 0) [] -> pure (word64Marshal ty [])
-    TcTyCon (TyCon "Addr#" 0) [] -> pure (addrMarshal ty [])
-    TcTyCon (TyCon "Ptr" 1) [_] -> pure (addrMarshal ty ["Ptr"])
+    TcTyCon (TyCon "Int" 0) [] -> intMarshal ty ["I#"]
+    TcTyCon (TyCon "Int#" 0) [] -> intMarshal ty []
+    TcTyCon (TyCon "CInt" 0) [] -> int32Marshal ty ["CInt", "I32#"]
+    TcTyCon (TyCon "Int32" 0) [] -> int32Marshal ty ["I32#"]
+    TcTyCon (TyCon "Int32#" 0) [] -> int32Marshal ty []
+    TcTyCon (TyCon "Word64" 0) [] -> word64Marshal ty ["W64#"]
+    TcTyCon (TyCon "Word64#" 0) [] -> word64Marshal ty []
+    TcTyCon (TyCon "Addr#" 0) [] -> addrMarshal ty []
+    TcTyCon (TyCon "Ptr" 1) [_] -> addrMarshal ty ["Ptr"]
     _ -> do
       emitError sourceSpan (OtherError ("unsupported foreign import value type: " <> show ty))
-      pure (int32Marshal ty [])
+      int32Marshal ty []
   where
-    intMarshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Int#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignInt
-        }
-    int32Marshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Int32#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignInt32
-        }
-    word64Marshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Word64#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignWord64
-        }
-    addrMarshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Addr#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignAddr
-        }
+    intMarshal sourceType constructorNames = do
+      constructors <- catMaybes <$> mapM findGlobalTermId constructorNames
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = TcTyCon (TyCon "Int#" 0) [],
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignInt
+          }
+    int32Marshal sourceType constructorNames = do
+      constructors <- catMaybes <$> mapM findGlobalTermId constructorNames
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = TcTyCon (TyCon "Int32#" 0) [],
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignInt32
+          }
+    word64Marshal sourceType constructorNames = do
+      constructors <- catMaybes <$> mapM findGlobalTermId constructorNames
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = TcTyCon (TyCon "Word64#" 0) [],
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignWord64
+          }
+    addrMarshal sourceType constructorNames = do
+      constructors <- catMaybes <$> mapM findGlobalTermId constructorNames
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = TcTyCon (TyCon "Addr#" 0) [],
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignAddr
+          }
 
 annotateDeclAt :: SourceSpan -> TcAnnotation -> Decl -> Decl
 annotateDeclAt NoSourceSpan tcAnn decl =
@@ -1026,7 +1031,7 @@ annotateInstanceDeclTc classMethods instanceDecl =
                 tcInstanceMethodOrder = methodOrder,
                 tcInstanceDefaultMethods = defaults
               }
-      items <- mapM (annotateInstanceItemTc headTys) (instanceDeclItems instanceDecl)
+      items <- mapM (annotateInstanceItemTc (classInfo >>= ciOrigin) headTys) (instanceDeclItems instanceDecl)
       pure (DeclAnn (mkAnnotation instAnn) (DeclInstance (instanceDecl {instanceDeclItems = items})))
 
 solveInstanceSuperClass :: Text -> [Pred] -> Pred -> TcM EvTerm
@@ -1044,18 +1049,18 @@ solveInstanceSuperClass className givens predicate = do
       emitError (ctLoc stuck) (UnsolvedWanted (ctPred stuck) (ctOrigin stuck))
       pure (EvVarTerm evidenceVariable)
 
-annotateInstanceItemTc :: [TcType] -> InstanceDeclItem -> TcM InstanceDeclItem
-annotateInstanceItemTc headTys item =
+annotateInstanceItemTc :: Maybe (Text, Text) -> [TcType] -> InstanceDeclItem -> TcM InstanceDeclItem
+annotateInstanceItemTc classOrigin headTys item =
   case item of
-    InstanceItemAnn ann inner -> InstanceItemAnn ann <$> annotateInstanceItemTc headTys inner
+    InstanceItemAnn ann inner -> InstanceItemAnn ann <$> annotateInstanceItemTc classOrigin headTys inner
     InstanceItemBind (FunctionBind name matches) -> do
       let methodName = unqualifiedNameText name
-      methodTy <- methodExpectedType headTys (unqualifiedNameText name)
+      methodTy <- methodExpectedType classOrigin headTys (unqualifiedNameText name)
       pure (InstanceItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy)) (InstanceItemBind (FunctionBind name matches)))
     InstanceItemBind (PatternBind anns pat rhs) ->
       case patternBinderName pat of
         Just (_, methodName) -> do
-          methodTy <- methodExpectedType headTys methodName
+          methodTy <- methodExpectedType classOrigin headTys methodName
           pure (InstanceItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy)) (InstanceItemBind (PatternBind anns pat rhs)))
         Nothing -> pure item
     _ -> pure item
@@ -1112,18 +1117,19 @@ tcInstanceDeclBodies (DeclInstance instanceDecl) =
       rawGivens <- mapM (surfacePredToPred tvEnv) (instanceDeclContext instanceDecl)
       headTys <- mapM defaultTypeKinds rawHeadTys
       givens <- mapM defaultPredKinds rawGivens
-      items <- mapM (tcInstanceItemBody givens headTys) (instanceDeclItems instanceDecl)
+      classInfo <- lookupClass (nameText className)
+      items <- mapM (tcInstanceItemBody (classInfo >>= ciOrigin) givens headTys) (instanceDeclItems instanceDecl)
       pure (DeclInstance (instanceDecl {instanceDeclItems = items}))
 tcInstanceDeclBodies decl =
   pure decl
 
-tcInstanceItemBody :: [Pred] -> [TcType] -> InstanceDeclItem -> TcM InstanceDeclItem
-tcInstanceItemBody givens headTys item =
+tcInstanceItemBody :: Maybe (Text, Text) -> [Pred] -> [TcType] -> InstanceDeclItem -> TcM InstanceDeclItem
+tcInstanceItemBody classOrigin givens headTys item =
   case item of
     InstanceItemAnn ann inner ->
-      InstanceItemAnn ann <$> tcInstanceItemBody givens headTys inner
+      InstanceItemAnn ann <$> tcInstanceItemBody classOrigin givens headTys inner
     InstanceItemBind (FunctionBind name matches) -> do
-      methodScheme <- methodExpectedScheme headTys (unqualifiedNameText name)
+      methodScheme <- methodExpectedScheme classOrigin headTys (unqualifiedNameText name)
       (methodGivens, methodTy) <- skolemizeQualified methodScheme
       let (argTys, resTy) = splitFunTy methodTy (matchArity matches)
       results <- mapM (tcMatchEquation Nothing argTys resTy) matches
@@ -1132,7 +1138,7 @@ tcInstanceItemBody givens headTys item =
     InstanceItemBind (PatternBind _ pat rhs) ->
       case patternBinderName pat of
         Just (_, methodName) -> do
-          methodScheme <- methodExpectedScheme headTys methodName
+          methodScheme <- methodExpectedScheme classOrigin headTys methodName
           (methodGivens, methodTy) <- skolemizeQualified methodScheme
           results <- mapM (tcMatchEquation Nothing [] methodTy) [zeroArgMatch (patternSpan pat) rhs]
           solveInstanceBodyConstraints (givens <> methodGivens) [(cts, impls) | (_match, cts, impls) <- results]
@@ -1183,12 +1189,12 @@ binderType :: TcBinder -> TcType
 binderType (TcIdBinder scheme _) = schemeToType scheme
 binderType (TcMonoIdBinder ty) = ty
 
-methodExpectedType :: [TcType] -> Text -> TcM TcType
-methodExpectedType headTys methodName = schemeToType <$> methodExpectedScheme headTys methodName
+methodExpectedType :: Maybe (Text, Text) -> [TcType] -> Text -> TcM TcType
+methodExpectedType classOrigin headTys methodName = schemeToType <$> methodExpectedScheme classOrigin headTys methodName
 
-methodExpectedScheme :: [TcType] -> Text -> TcM TypeScheme
-methodExpectedScheme headTys methodName = do
-  mBinder <- lookupTerm methodName
+methodExpectedScheme :: Maybe (Text, Text) -> [TcType] -> Text -> TcM TypeScheme
+methodExpectedScheme classOrigin headTys methodName = do
+  mBinder <- maybe (lookupTerm methodName) (`lookupTermAtOrigin` methodName) classOrigin
   case mBinder of
     Just (TcIdBinder (ForAll tyVars predicates body) _) ->
       case splitClassReceiver predicates headTys of
@@ -1687,7 +1693,7 @@ tcSingleDeclGroup sigs groupId d =
             else do
               zonkedTy <- zonkType ty
               let decl' = replacePatternBindRhs rhs' d
-              pure (TcDeclGroupResult groupId [TcBindingResult "<pattern>" "<pattern>" zonkedTy] (Just [decl']))
+              pure (TcDeclGroupResult groupId [UnqualifiedBindingResult "<pattern>" "<pattern>" zonkedTy] (Just [decl']))
     _ -> do
       bindings <- tcDecl d
       pure (TcDeclGroupResult groupId bindings Nothing)
@@ -1711,7 +1717,7 @@ tcMergedFunctionGroup sigs groupId binder decls matches = do
 -- The signature's type variables are opened as rigid skolems so that
 -- the body is checked against them. GADT patterns generate implication
 -- constraints using the signature's skolems as given equalities.
-tcFunctionWithSig :: Text -> Text -> CheckedSig -> [Match] -> TcM (Maybe [Match], [TcBindingResult])
+tcFunctionWithSig :: Text -> Text -> CheckedSig -> [Match] -> TcM (Maybe [Match], [UnqualifiedBindingResult])
 tcFunctionWithSig displayName name sig matches = do
   let scheme = checkedSigScheme sig
   (matches', failed) <-
@@ -1737,10 +1743,10 @@ tcFunctionWithSig displayName name sig matches = do
       -- Report the declared scheme as the binding's type.
       let declaredTy = schemeToType scheme
       zonkedTy <- zonkType declaredTy
-      pure (Just matches', [TcBindingResult name displayName zonkedTy])
+      pure (Just matches', [UnqualifiedBindingResult name displayName zonkedTy])
 
 -- | Type-check a function without a type signature (infer).
-tcFunctionInfer :: Text -> Text -> [Match] -> TcM (Maybe [Match], [TcBindingResult])
+tcFunctionInfer :: Text -> Text -> [Match] -> TcM (Maybe [Match], [UnqualifiedBindingResult])
 tcFunctionInfer displayName name matches = do
   placeholderTy <- freshMetaTv
   ((matches', ty, residualPreds), failed) <-
@@ -1754,11 +1760,12 @@ tcFunctionInfer displayName name matches = do
   if failed
     then pure (Nothing, [])
     else do
-      scheme <- generalizeAndCommitIgnoring (Set.singleton (TcTermGlobal name)) ty residualPreds
+      bindingKey <- currentTermKey name
+      scheme <- generalizeAndCommitIgnoring (Set.singleton bindingKey) ty residualPreds
       let schemeTy = schemeToType scheme
       zonkedTy <- zonkType schemeTy
       extendTermEnvPermanent name (TcIdBinder scheme Closed)
-      pure (Just matches', [TcBindingResult name displayName zonkedTy])
+      pure (Just matches', [UnqualifiedBindingResult name displayName zonkedTy])
 
 generalizableResidualPreds :: SolveResult -> TcM [Pred]
 generalizableResidualPreds solveResult = do
@@ -1840,7 +1847,7 @@ zonkPred pred' =
     ClassPred className args -> ClassPred className <$> mapM zonkType args
     EqPred left right -> EqPred <$> zonkType left <*> zonkType right
 
-registerTypeDeclHeader :: Decl -> TcM [TcBindingResult]
+registerTypeDeclHeader :: Decl -> TcM [UnqualifiedBindingResult]
 registerTypeDeclHeader (DeclData dataDecl) = registerDataDeclHeader dataDecl
 registerTypeDeclHeader (DeclNewtype newtypeDecl) = registerNewtypeDeclHeader newtypeDecl
 registerTypeDeclHeader (DeclDataFamilyDecl familyDecl) = registerDataFamilyDeclHeader familyDecl
@@ -1848,7 +1855,7 @@ registerTypeDeclHeader (DeclTypeSyn typeSynDecl) = registerTypeSynonymHeader typ
 registerTypeDeclHeader (DeclAnn _ inner) = registerTypeDeclHeader inner
 registerTypeDeclHeader _ = pure []
 
-registerValueLevelDecl :: (Text, Text) -> Decl -> TcM [TcBindingResult]
+registerValueLevelDecl :: (Text, Text) -> Decl -> TcM [UnqualifiedBindingResult]
 registerValueLevelDecl _ (DeclData dataDecl) = registerDataConstructors dataDecl
 registerValueLevelDecl _ (DeclNewtype newtypeDecl) = registerNewtypeConstructor newtypeDecl
 registerValueLevelDecl _ (DeclDataFamilyInst familyInst) = registerDataFamilyInstance familyInst
@@ -1864,7 +1871,7 @@ isForeignImport :: ForeignDecl -> Bool
 isForeignImport foreignDecl =
   foreignDirection foreignDecl == ForeignImport
 
-registerForeignImport :: ForeignDecl -> TcM [TcBindingResult]
+registerForeignImport :: ForeignDecl -> TcM [UnqualifiedBindingResult]
 registerForeignImport foreignDecl = do
   scheme <- sigToScheme (foreignType foreignDecl)
   let name = unqualifiedNameText (foreignName foreignDecl)
@@ -1872,9 +1879,9 @@ registerForeignImport foreignDecl = do
       declaredTy = schemeToType scheme
   extendTermEnvPermanent name (TcIdBinder scheme Closed)
   zonkedTy <- zonkType declaredTy
-  pure [TcBindingResult name displayName zonkedTy]
+  pure [UnqualifiedBindingResult name displayName zonkedTy]
 
-registerClassDecl :: (Text, Text) -> ClassDecl -> TcM [TcBindingResult]
+registerClassDecl :: (Text, Text) -> ClassDecl -> TcM [UnqualifiedBindingResult]
 registerClassDecl origin classDecl = do
   let className = unqualifiedNameText (binderHeadName (classDeclHead classDecl))
       params = binderHeadParams (classDeclHead classDecl)
@@ -1924,7 +1931,7 @@ registerClassDecl origin classDecl = do
               workerScheme = maybe scheme (defaultWorkerScheme scheme) (lookup methodName defaultSignatures)
               workerType = schemeToType workerScheme
           extendTermEnvPermanent workerName (TcIdBinder workerScheme Closed)
-          pure (Just (TcBindingResult workerName workerName workerType))
+          pure (Just (UnqualifiedBindingResult workerName workerName workerType))
       | otherwise = pure Nothing
 
     defaultWorkerScheme ordinaryScheme (ForAll tyVars predicates body) =
@@ -1932,7 +1939,7 @@ registerClassDecl origin classDecl = do
         ForAll _ (classPredicate : _) _ -> ForAll tyVars (classPredicate : predicates) body
         _ -> ForAll tyVars predicates body
 
-registerClassItem :: Pred -> TvKindEnv -> [TyVarId] -> ClassDeclItem -> TcM [TcBindingResult]
+registerClassItem :: Pred -> TvKindEnv -> [TyVarId] -> ClassDeclItem -> TcM [UnqualifiedBindingResult]
 registerClassItem classPred classTvEnv classTyVars item =
   case peelClassDeclItemAnn item of
     ClassItemTypeSig names ty -> do
@@ -1953,7 +1960,7 @@ registerClassItem classPred classTvEnv classTyVars item =
                 displayName = renderBinderName methodName
             extendTermEnvPermanent name (TcIdBinder scheme Closed)
             zonkedTy <- zonkType declaredTy
-            pure (TcBindingResult name displayName zonkedTy)
+            pure (UnqualifiedBindingResult name displayName zonkedTy)
         )
         names
     _ -> pure []
@@ -1978,7 +1985,7 @@ registerClassDefaultSignature classTvEnv classTyVars item =
         )
     _ -> pure Nothing
 
-registerInstanceDecl :: (Text, Text) -> InstanceDecl -> TcM [TcBindingResult]
+registerInstanceDecl :: (Text, Text) -> InstanceDecl -> TcM [UnqualifiedBindingResult]
 registerInstanceDecl origin instanceDecl =
   case instanceHeadName (instanceDeclHead instanceDecl) of
     Nothing -> pure []
@@ -2000,7 +2007,7 @@ registerInstanceDecl origin instanceDecl =
             iiContext = context,
             iiHead = headTys
           }
-      pure [TcBindingResult dictName dictName dictTy]
+      pure [UnqualifiedBindingResult dictName dictName dictTy]
 
 predType :: Pred -> TcType
 predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
@@ -2018,7 +2025,7 @@ typeSuffix ty =
     TcTyCon tc args -> tyConName tc <> T.concat (map typeSuffix args)
     _ -> "T"
 
-registerDataFamilyDeclHeader :: DataFamilyDecl -> TcM [TcBindingResult]
+registerDataFamilyDeclHeader :: DataFamilyDecl -> TcM [UnqualifiedBindingResult]
 registerDataFamilyDeclHeader familyDecl = do
   let familyName = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
       params = binderHeadParams (dataFamilyDeclHead familyDecl)
@@ -2037,9 +2044,9 @@ registerDataFamilyDeclHeader familyDecl = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  pure [TcBindingResult familyName familyName (kindToTcType zonkedKind)]
+  pure [UnqualifiedBindingResult familyName familyName (kindToTcType zonkedKind)]
 
-registerDataFamilyInstance :: DataFamilyInst -> TcM [TcBindingResult]
+registerDataFamilyInstance :: DataFamilyInst -> TcM [UnqualifiedBindingResult]
 registerDataFamilyInstance familyInst = do
   paramInfos <- dataFamilyInstanceParams familyInst
   let tvEnv =
@@ -2166,7 +2173,7 @@ tupleRuntimeRepNames = mapMaybe (tyVarBinderKind >=> runtimeRepVariableName)
         TVar name -> Just (unqualifiedNameText name)
         _ -> Nothing
 
-registerDataDeclHeader :: DataDecl -> TcM [TcBindingResult]
+registerDataDeclHeader :: DataDecl -> TcM [UnqualifiedBindingResult]
 registerDataDeclHeader dd = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
       params = binderHeadParams (dataDeclHead dd)
@@ -2190,7 +2197,7 @@ registerDataDeclHeader dd = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
+  let tyConResult = UnqualifiedBindingResult tyName tyName (kindToTcType zonkedKind)
   pure [tyConResult]
 
 unboxedTupleDeclarationKind :: [ParamInfo] -> Kind
@@ -2202,7 +2209,7 @@ unboxedTupleDeclarationKind params =
         KTYPE runtimeRep -> runtimeRep
         _ -> liftedRuntimeRep
 
-registerDataConstructors :: DataDecl -> TcM [TcBindingResult]
+registerDataConstructors :: DataDecl -> TcM [UnqualifiedBindingResult]
 registerDataConstructors dataDecl = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
   maybeInfo <- lookupTyCon tyName
@@ -2226,7 +2233,7 @@ registerDataConstructors dataDecl = do
 -- | Register a newtype declaration's type constructor and representation
 -- constructor.  Newtype erasure/coercion semantics are handled elsewhere; at
 -- this stage the type checker only needs the source-level names and types.
-registerNewtypeDeclHeader :: NewtypeDecl -> TcM [TcBindingResult]
+registerNewtypeDeclHeader :: NewtypeDecl -> TcM [UnqualifiedBindingResult]
 registerNewtypeDeclHeader nd = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead nd))
       params = binderHeadParams (newtypeDeclHead nd)
@@ -2245,10 +2252,10 @@ registerNewtypeDeclHeader nd = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
+  let tyConResult = UnqualifiedBindingResult tyName tyName (kindToTcType zonkedKind)
   pure [tyConResult]
 
-registerNewtypeConstructor :: NewtypeDecl -> TcM [TcBindingResult]
+registerNewtypeConstructor :: NewtypeDecl -> TcM [UnqualifiedBindingResult]
 registerNewtypeConstructor newtypeDecl = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
   maybeInfo <- lookupTyCon tyName
@@ -2269,7 +2276,7 @@ registerNewtypeConstructor newtypeDecl = do
           }
       pure (maybeToList constructor <> selectorBindings)
 
-registerRecordSelectors :: [DataConInfo] -> TcM [TcBindingResult]
+registerRecordSelectors :: [DataConInfo] -> TcM [UnqualifiedBindingResult]
 registerRecordSelectors constructors =
   mapM registerSelector (Map.toList selectors)
   where
@@ -2289,11 +2296,11 @@ registerRecordSelectors constructors =
               (TcFunTy (dciResTy constructor) (dcfiType field))
       extendTermEnvPermanent label (TcIdBinder scheme Closed)
       zonkedType <- zonkType (schemeToType scheme)
-      pure (TcBindingResult label label zonkedType)
+      pure (UnqualifiedBindingResult label label zonkedType)
     registerSelector (label, []) =
       abortTc ("record selector has no fields: " <> T.unpack label)
 
-registerTypeSynonymHeader :: TypeSynDecl -> TcM [TcBindingResult]
+registerTypeSynonymHeader :: TypeSynDecl -> TcM [UnqualifiedBindingResult]
 registerTypeSynonymHeader typeSynDecl = do
   let tyName = unqualifiedNameText (binderHeadName (typeSynHead typeSynDecl))
       params = binderHeadParams (typeSynHead typeSynDecl)
@@ -2312,7 +2319,7 @@ registerTypeSynonymHeader typeSynDecl = do
         tciFlavor = SynonymTyCon,
         tciTypeSynonym = Just synonym
       }
-  pure [TcBindingResult tyName tyName (kindToTcType declaredKind)]
+  pure [UnqualifiedBindingResult tyName tyName (kindToTcType declaredKind)]
 
 registerTypeSynonymBody :: Decl -> TcM ()
 registerTypeSynonymBody (DeclAnn _ inner) = registerTypeSynonymBody inner
@@ -2335,11 +2342,11 @@ dataDeclTyCon name arity kind = mkTyCon name arity kind
 
 -- | Register a single data constructor as a polymorphic binding.
 -- Returns the binding result for the constructor.
-registerDataCon :: TyCon -> [ParamInfo] -> [ParamInfo] -> DataConDecl -> TcM TcBindingResult
+registerDataCon :: TyCon -> [ParamInfo] -> [ParamInfo] -> DataConDecl -> TcM UnqualifiedBindingResult
 registerDataCon tc kindParams paramInfos =
   registerDataConWithResult (kindParams <> paramInfos) (TcTyCon tc (map (TcTyVar . paramTyVar) paramInfos))
 
-registerDataConWithResult :: [ParamInfo] -> TcType -> DataConDecl -> TcM TcBindingResult
+registerDataConWithResult :: [ParamInfo] -> TcType -> DataConDecl -> TcM UnqualifiedBindingResult
 registerDataConWithResult paramInfos resTy con = case con of
   DataConAnn _ inner -> registerDataConWithResult paramInfos resTy inner
   PrefixCon forallVars context conName args ->
@@ -2383,8 +2390,8 @@ registerDataConWithResult paramInfos resTy con = case con of
       (n : _) -> do
         zonkedTy <- zonkType conTy
         let name = unqualifiedNameText n
-         in pure (TcBindingResult name name zonkedTy)
-      [] -> pure (TcBindingResult "<gadt>" "<gadt>" gadtResTy)
+         in pure (UnqualifiedBindingResult name name zonkedTy)
+      [] -> pure (UnqualifiedBindingResult "<gadt>" "<gadt>" gadtResTy)
   where
     paramEnv =
       Map.fromList
@@ -2407,7 +2414,7 @@ registerDataConWithResult paramInfos resTy con = case con of
           scheme = ForAll (paramVarIds <> constructorTyVars) predicates conTy
       extendTermEnvPermanent name (TcIdBinder scheme Closed)
       zonkedTy <- zonkType (schemeToType scheme)
-      pure (TcBindingResult name name zonkedTy)
+      pure (UnqualifiedBindingResult name name zonkedTy)
 
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
@@ -2510,13 +2517,13 @@ recordSourceFields = concatMap $ \field ->
   [(Just (unqualifiedNameText label), fieldType field) | label <- fieldNames field]
 
 -- | Type-check a declaration, returning binding results for value bindings.
-tcDecl :: Decl -> TcM [TcBindingResult]
+tcDecl :: Decl -> TcM [UnqualifiedBindingResult]
 tcDecl (DeclValue vd) = tcValueDecl vd
 tcDecl (DeclAnn _ inner) = tcDecl inner
 tcDecl _ = pure []
 
 -- | Type-check a value declaration.
-tcValueDecl :: ValueDecl -> TcM [TcBindingResult]
+tcValueDecl :: ValueDecl -> TcM [UnqualifiedBindingResult]
 tcValueDecl (FunctionBind binder matches) = do
   let name = unqualifiedNameText binder
       displayName = renderBinderName binder
@@ -2531,7 +2538,7 @@ tcValueDecl (PatternBind _ pat rhs) = case patternBinderName pat of
   Nothing -> do
     (_rhs', ty) <- tcRhs rhs
     zonkedTy <- zonkType ty
-    pure [TcBindingResult "<pattern>" "<pattern>" zonkedTy]
+    pure [UnqualifiedBindingResult "<pattern>" "<pattern>" zonkedTy]
 
 -- | Extract the binder name from a pattern binding's LHS, if it is a bare
 -- variable pattern.  Returns @(displayName, envName)@ for simple variable

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -32,7 +32,7 @@ import Aihc.Parser.Syntax
     mkAnnotation,
   )
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
-import Aihc.Tc.Annotations (PendingTcAnnotation (..), pendingAnnotation, pendingTypeLambdaAnnotation)
+import Aihc.Tc.Annotations (PendingTcAnnotation (..), TcIntegerLiteralAnnotation (..), pendingAnnotation, pendingTypeLambdaAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (TyConInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
@@ -193,6 +193,7 @@ inferOverloadedIntegerLiteral ambient resolutionAnn resolution literalExpr = do
   (methodTy, typeArgs, methodCts) <- inferResolvedFromInteger sp resolution
   resultTy <- freshMetaTv
   ev <- freshEvVar
+  integerConstructor <- uniqueGlobalTermId "IS"
   let integerArgTy = TcTyCon (TyCon "Integer" 0) []
       expectedMethodTy = TcFunTy integerArgTy resultTy
       methodEq =
@@ -216,7 +217,7 @@ inferOverloadedIntegerLiteral ambient resolutionAnn resolution literalExpr = do
           typeArgs
           (map ctEvVar methodCts)
           []
-  pure (annotatePendingExprAt sp pending (EAnn resolutionAnn literalExpr), resultTy, methodCts <> [methodEq])
+  pure (annotatePendingExprAt sp pending (EAnn (mkAnnotation (TcIntegerLiteralAnnotation integerConstructor)) (EAnn resolutionAnn literalExpr)), resultTy, methodCts <> [methodEq])
 
 inferResolvedFromInteger :: SourceSpan -> ResolutionAnnotation -> TcM (TcType, [TcType], [Ct])
 inferResolvedFromInteger sp resolution = do

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -28,7 +28,7 @@ import Aihc.Parser.Syntax
     peelPatternAnn,
   )
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
-import Aihc.Tc.Annotations (PendingTcAnnotation, pendingAnnotation)
+import Aihc.Tc.Annotations (PendingTcAnnotation, TcIntegerLiteralAnnotation (..), pendingAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (TyConInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
@@ -174,6 +174,7 @@ isOverloadedIntegerLiteral lit =
 
 checkOverloadedIntegerPattern :: SourceSpan -> Pattern -> Bool -> TcType -> TcM PatternCheck
 checkOverloadedIntegerPattern sp pat isNegative scrutTy = do
+  integerConstructor <- uniqueGlobalTermId "IS"
   (fromIntegerPending, fromIntegerCts) <- checkPatternMethod sp pat "fromInteger" scrutTy (TcFunTy integerTy scrutTy)
   negateCheck <-
     if isNegative
@@ -185,7 +186,7 @@ checkOverloadedIntegerPattern sp pat isNegative scrutTy = do
         [("fromInteger", fromIntegerPending)]
           <> maybe [] (\(pending, _) -> [("negate", pending)]) negateCheck
           <> [("==", eqPending)]
-      pat' = foldr (uncurry attachPendingPatternAnnotation) pat methodAnnotations
+      pat' = PAnn (mkAnnotation (TcIntegerLiteralAnnotation integerConstructor)) (foldr (uncurry attachPendingPatternAnnotation) pat methodAnnotations)
       negateCts = maybe [] snd negateCheck
   pure
     PatternCheck

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -40,14 +40,19 @@ module Aihc.Tc.Monad
     Closedness (..),
     emptyTcEnv,
     lookupTerm,
+    lookupTermAtOrigin,
+    uniqueGlobalTermId,
+    findGlobalTermId,
     lookupResolvedTerm,
     resolvedTermKey,
     resolvedTermTarget,
     resolvedUnqualifiedTermKey,
     resolvedLocalTermKey,
+    currentTermKey,
     extendTermEnv,
     extendResolvedTermEnv,
     extendTermEnvPermanent,
+    withGlobalTermOrigin,
     getTermEnv,
     lookupTyCon,
     extendTyConEnvPermanent,
@@ -81,8 +86,8 @@ module Aihc.Tc.Monad
   )
 where
 
-import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameText, unqualifiedNameText)
-import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
+import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameQualifier, nameText, unqualifiedNameText)
+import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
 import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo, DataTypeInfo (..), InstanceInfo, TyConInfo)
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
@@ -97,6 +102,7 @@ import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 
 -- | The type checker monad.
 --
@@ -131,6 +137,8 @@ data TcEnv = TcEnv
     -- from source text. This lets TC preserve lexical identity without doing
     -- name resolution or conflating duplicate textual names.
     tcEnvTerms :: !(Map TcTermKey TcBinder),
+    -- | Package and module identity for generated global bindings.
+    tcEnvGlobalTermOrigin :: !(Text, Text),
     -- | Whether local binding groups follow GHC's MonoLocalBinds rule.
     tcEnvMonoLocalBinds :: !Bool,
     -- | Whether the monomorphism restriction is active.
@@ -156,7 +164,7 @@ data TcBinder
 
 data TcTermKey
   = TcTermLocal !Int
-  | TcTermGlobal !Text
+  | TcTermGlobal !TcBindingId
   deriving (Eq, Ord, Show)
 
 -- | An empty environment at the top level.
@@ -164,6 +172,7 @@ emptyTcEnv :: TcEnv
 emptyTcEnv =
   TcEnv
     { tcEnvTerms = Map.empty,
+      tcEnvGlobalTermOrigin = ("", "Main"),
       tcEnvMonoLocalBinds = True,
       tcEnvMonomorphismRestriction = True,
       tcEnvTcLevel = topTcLevel
@@ -188,12 +197,7 @@ data TcState = TcState
     tcsDiagnostics :: ![TcDiagnostic],
     -- | Global term bindings accumulated from declarations and imported
     -- interfaces.
-    --
-    -- This map remains text-keyed because it is not used to decide lexical
-    -- scope. Occurrences reach it only after @aihc-resolve@ has attached a
-    -- 'ResolvedTopLevel' or 'ResolvedBuiltin' target; TC then uses the target's
-    -- selected global name to retrieve the type.
-    tcsGlobalTerms :: !(Map Text TcBinder),
+    tcsGlobalTerms :: !(Map TcBindingId TcBinder),
     -- | Global type constructors accumulated by top-level declarations.
     tcsGlobalTyCons :: !(Map Text TyConInfo),
     -- | Checked constructor layouts for data and newtype declarations.
@@ -229,11 +233,11 @@ initTcState =
       tcsGadtCons = Set.empty
     }
 
-builtinTerms :: Map Text TcBinder
+builtinTerms :: Map TcBindingId TcBinder
 builtinTerms =
   Map.fromList
-    [ (":", TcIdBinder consScheme Closed),
-      ("[]", TcIdBinder nilScheme Closed)
+    [ (builtinBindingId ":", TcIdBinder consScheme Closed),
+      (builtinBindingId "[]", TcIdBinder nilScheme Closed)
     ]
   where
     aVar = TyVarId "a" (Unique (-1000))
@@ -324,8 +328,33 @@ lookupEvidence (EvVar u) = lift $ gets $ \s ->
 
 -- | Look up a global term by its selected global name.
 lookupTerm :: Text -> TcM (Maybe TcBinder)
-lookupTerm name =
-  lift $ gets $ \s -> Map.lookup name (tcsGlobalTerms s)
+lookupTerm name = do
+  identity <- currentBindingId name
+  lift $ gets $ \s -> Map.lookup identity (tcsGlobalTerms s)
+
+lookupTermAtOrigin :: (Text, Text) -> Text -> TcM (Maybe TcBinder)
+lookupTermAtOrigin (packageId, moduleName) name =
+  lift $ gets $ \state -> Map.lookup (TcBindingId packageId moduleName name) (tcsGlobalTerms state)
+
+uniqueGlobalTermId :: Text -> TcM TcBindingId
+uniqueGlobalTermId name = do
+  identities <- globalTermIds name
+  case identities of
+    [identity] -> pure identity
+    [] -> abortTc ("missing global binding identity for " <> T.unpack name)
+    _ -> abortTc ("ambiguous global binding identity for " <> T.unpack name)
+
+findGlobalTermId :: Text -> TcM (Maybe TcBindingId)
+findGlobalTermId name = do
+  identities <- globalTermIds name
+  case identities of
+    [identity] -> pure (Just identity)
+    [] -> pure Nothing
+    _ -> abortTc ("ambiguous global binding identity for " <> T.unpack name)
+
+globalTermIds :: Text -> TcM [TcBindingId]
+globalTermIds name =
+  lift $ gets $ filter ((== name) . tcBindingName) . Map.keys . tcsGlobalTerms
 
 lookupResolvedTerm :: Text -> ResolvedName -> TcM (Maybe TcBinder)
 lookupResolvedTerm displayName resolved =
@@ -336,8 +365,8 @@ lookupTermKey key =
   case key of
     TcTermLocal _ ->
       asks $ \env -> Map.lookup key (tcEnvTerms env)
-    TcTermGlobal name ->
-      lift $ gets $ \s -> Map.lookup name (tcsGlobalTerms s)
+    TcTermGlobal identity ->
+      lift $ gets $ \s -> Map.lookup identity (tcsGlobalTerms s)
 
 resolvedTermKey :: Name -> TcM TcTermKey
 resolvedTermKey name =
@@ -356,10 +385,10 @@ resolvedNameTermKey displayName resolved =
   case resolved of
     ResolvedLocal unique _ ->
       pure (TcTermLocal unique)
-    ResolvedTopLevel _ name ->
-      pure (TcTermGlobal (nameText name))
+    ResolvedTopLevel packageId name ->
+      TcTermGlobal <$> topLevelBindingId displayName packageId name
     ResolvedBuiltin name ->
-      pure (TcTermGlobal name)
+      pure (TcTermGlobal (builtinBindingId name))
     ResolvedError msg ->
       abortTc ("resolver error reached type checker for term " <> show displayName <> ": " <> msg)
 
@@ -385,8 +414,28 @@ extendResolvedTermEnv name binder action = do
 -- | Permanently extend the global term environment (for top-level
 -- declarations like data constructors and top-level bindings).
 extendTermEnvPermanent :: Text -> TcBinder -> TcM ()
-extendTermEnvPermanent name binder = lift $ modify' $ \s ->
-  s {tcsGlobalTerms = Map.insert name binder (tcsGlobalTerms s)}
+extendTermEnvPermanent name binder = do
+  identity <- currentBindingId name
+  lift $ modify' $ \s ->
+    s {tcsGlobalTerms = Map.insert identity binder (tcsGlobalTerms s)}
+
+currentTermKey :: Text -> TcM TcTermKey
+currentTermKey = fmap TcTermGlobal . currentBindingId
+
+currentBindingId :: Text -> TcM TcBindingId
+currentBindingId name = do
+  (packageId, moduleName) <- asks tcEnvGlobalTermOrigin
+  pure (TcBindingId packageId moduleName name)
+
+withGlobalTermOrigin :: (Text, Text) -> TcM a -> TcM a
+withGlobalTermOrigin origin =
+  local (\environment -> environment {tcEnvGlobalTermOrigin = origin})
+
+topLevelBindingId :: Text -> PackageId -> Name -> TcM TcBindingId
+topLevelBindingId displayName packageId name =
+  case nameQualifier name of
+    Just moduleName -> pure (TcBindingId (packageIdText packageId) moduleName (nameText name))
+    Nothing -> abortTc ("top-level resolver identity lacks a module for " <> show displayName)
 
 resolvedTermTarget :: Name -> TcM ResolvedName
 resolvedTermTarget name =

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -12,7 +12,11 @@
 -- functionally equivalent. The module structure supports migrating to
 -- STRef-backed meta-variables later without changing the public interface.
 module Aihc.Tc.Types
-  ( -- * Unique identifiers
+  ( -- * Binding identifiers
+    TcBindingId (..),
+    builtinBindingId,
+
+    -- * Unique identifiers
     Unique (..),
 
     -- * Type variables
@@ -55,6 +59,18 @@ where
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+
+-- | Complete identity for one global term binding.
+data TcBindingId = TcBindingId
+  { tcBindingPackageId :: !Text,
+    tcBindingModuleName :: !Text,
+    tcBindingName :: !Text
+  }
+  deriving (Eq, Ord, Show, Read)
+
+-- | Complete identity for a compiler-provided term binding.
+builtinBindingId :: Text -> TcBindingId
+builtinBindingId = TcBindingId "<builtin>" "<builtin>"
 
 -- | Source-level names of the lifted tuple types declared by @ghc-prim@.
 -- Their data constructors retain the familiar parenthesized comma syntax.

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -306,7 +306,37 @@ lambdaTests =
 variableTests :: [TestTree]
 variableTests =
   [ testCase "unbound variable is rejected by resolver before TC" $ do
-      assertBool "resolver should reject unbound variable" (hasResolveErrors "module Test where\nx = undefined_var\n")
+      assertBool "resolver should reject unbound variable" (hasResolveErrors "module Test where\nx = undefined_var\n"),
+    testCase "global bindings keep package and module identities" $ do
+      let leftSource = parseOnly "module Left where\ndata LeftType = LeftValue\nvalue :: LeftType\nvalue = LeftValue\nuse = value\n"
+          rightSource = parseOnly "module Right where\ndata RightType = RightValue\nvalue :: RightType\nvalue = RightValue\nuse = value\n"
+          resolved =
+            Resolve.resolveWithDeps
+              mempty
+              [ (Resolve.Package "left" (Resolve.PackageId "left-id"), leftSource),
+                (Resolve.Package "right" (Resolve.PackageId "right-id"), rightSource)
+              ]
+      case resolved of
+        ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
+          let (checkedModules, _) = typecheckModuleSccWithInterface mempty (map snd modules)
+              identities = concatMap (map tbIdentity . tcModuleBindings) checkedModules
+          assertBool ("modules should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules)) (all tcModuleSuccess checkedModules)
+          assertBool "left value identity" (TcBindingId "left-id" "Left" "value" `elem` identities)
+          assertBool "right value identity" (TcBindingId "right-id" "Right" "value" `elem` identities)
+        ResolveResult {resolveErrors} -> assertFailure ("modules should resolve, got: " <> show resolveErrors),
+    testCase "foreign-only modules keep package and module identities" $ do
+      let source =
+            parseOnlyWithExtensions
+              [ForeignFunctionInterface, MagicHash]
+              "{-# LANGUAGE ForeignFunctionInterface, MagicHash #-}\nmodule GHC.Prim.PtrEq where\nforeign import prim eqStableName# :: Int# -> Int#\n"
+          resolved = Resolve.resolveWithDeps mempty [(Resolve.Package "aihc-prim" (Resolve.PackageId "aihc-prim-id"), source)]
+      case resolved of
+        ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
+          let (checkedModules, _) = typecheckModuleSccWithInterface mempty (map snd modules)
+              identities = concatMap (map tbIdentity . tcModuleBindings) checkedModules
+          assertBool ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules)) (all tcModuleSuccess checkedModules)
+          assertBool "foreign binding identity" (TcBindingId "aihc-prim-id" "GHC.Prim.PtrEq" "eqStableName#" `elem` identities)
+        ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors)
   ]
 
 kindTests :: [TestTree]
@@ -492,8 +522,8 @@ kindTests =
         ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
           let (checkedBase, interface) = typecheckModuleSccWithInterface mempty (map snd baseModules)
           assertBool "dependency should typecheck" (all tcModuleSuccess checkedBase)
-          assertBool "constructor term exported" ("Unit" `elem` map fst (tcInterfaceTerms interface))
-          assertBool "method term exported" ("identity" `elem` map fst (tcInterfaceTerms interface))
+          assertBool "constructor term exported" ("Unit" `elem` map (tcBindingName . fst) (tcInterfaceTerms interface))
+          assertBool "method term exported" ("identity" `elem` map (tcBindingName . fst) (tcInterfaceTerms interface))
           assertBool "type constructor exported" ("Unit" `elem` map tciName (tcInterfaceTyCons interface))
           assertBool "class exported" ("Identity" `elem` map ciName (tcInterfaceClasses interface))
           assertBool "instance exported" ("$fIdentityUnit" `elem` map iiDictName (tcInterfaceInstances interface))
@@ -677,7 +707,7 @@ annotationTests =
           let (checkedBase, interface) = typecheckModuleSccWithInterface mempty (map snd baseModules)
           assertBool ("provider should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedBase)) (all tcModuleSuccess checkedBase)
           assertBool "record selectors are emitted as term bindings" (all (`elem` concatMap (map tbName . tcModuleBindings) checkedBase) ["left", "right"])
-          assertBool "record selectors are exported through T(..)" (all (`elem` map fst (tcInterfaceTerms interface)) ["left", "right"])
+          assertBool "record selectors are exported through T(..)" (all (`elem` map (tcBindingName . fst) (tcInterfaceTerms interface)) ["left", "right"])
           assertEqual
             "interface serialization round-trip"
             (show interface)

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -259,7 +259,7 @@ compileEvalCase tc =
                    in if all tcModuleSuccess tcResults
                         then do
                           let allBindings = moduleGroupBindings tcResults
-                              results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
+                              results = map (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults
                           if all dsSuccess results
                             then pure (Right (concatPrograms (map dsProgram results)))
                             else pure (Left ("desugar error: " <> unlines (concatMap dsErrors results)))


### PR DESCRIPTION
## Summary

- Give each resolved module an explicit package ID and module name.
- Identify each global binding by its package ID, module name, and binding name.
- Identify each local variable with its complete resolver identity.
- Use structural dictionary predicate keys instead of serialized text keys.
- Use complete identities in type-check interfaces and System FC type environments.
- Pass each checked module directly from `aihc-tc` to `aihc-fc`.
- Keep complete identities for class methods, dictionaries, literals, and foreign wrappers.
- Remove the name-only fallback from System FC module merge.
- Store complete binding identities in package interface schema version 2.
- Validate package and module identities when the REPL loads an installed interface.
- Add regression tests for equal names, dictionary key shapes, foreign imports, and installed interfaces.

## Validation

- `just fmt`
- `just check`
- `cabal run -v0 aihc -- install core-libs/aihc-base --offline --store <temporary-store>`

The local `aihc-base` installation completed on `aarch64-darwin`.

## Progress counts

No progress count changed.