### PR TITLE
feat(base): add applicative wrapper types

### DIFF
--- a/core-libs/aihc-base/src/Control/Applicative.hs
+++ b/core-libs/aihc-base/src/Control/Applicative.hs
@@ -1,10 +1,33 @@
+{-# LANGUAGE PolyKinds #-}
+
 module Control.Applicative
   ( Applicative (..),
     Alternative (..),
+    Const (..),
+    ZipList (..),
   )
 where
 
+import Data.Monoid (Monoid (..))
 import Prelude (Applicative (..), Functor (..), Maybe (..), (++))
+
+newtype Const a b = Const {getConst :: a}
+
+instance Functor (Const a) where
+  fmap _ (Const value) = Const value
+
+instance (Monoid a) => Applicative (Const a) where
+  pure _ = Const mempty
+  Const left <*> Const right = Const (left `mappend` right)
+
+newtype ZipList a = ZipList {getZipList :: [a]}
+
+instance Functor ZipList where
+  fmap f (ZipList values) = ZipList (mapZipList f values)
+
+instance Applicative ZipList where
+  pure value = ZipList (repeatZipList value)
+  ZipList functions <*> ZipList values = ZipList (applyZipList functions values)
 
 class (Applicative f) => Alternative f where
   empty :: f a
@@ -19,6 +42,18 @@ infixl 3 <|>
 
 prepend :: a -> [a] -> [a]
 prepend value values = value : values
+
+mapZipList :: (a -> b) -> [a] -> [b]
+mapZipList _ [] = []
+mapZipList f (value : values) = f value : mapZipList f values
+
+repeatZipList :: a -> [a]
+repeatZipList value = value : repeatZipList value
+
+applyZipList :: [a -> b] -> [a] -> [b]
+applyZipList [] _ = []
+applyZipList _ [] = []
+applyZipList (f : functions) (value : values) = f value : applyZipList functions values
 
 instance Alternative [] where
   empty = []

--- a/test/Test/Fixtures/eval/base/control-applicative-wrappers.yaml
+++ b/test/Test/Fixtures/eval/base/control-applicative-wrappers.yaml
@@ -1,0 +1,42 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+    import Control.Applicative
+
+    flipBool :: Bool -> Bool
+    flipBool False = True
+    flipBool True = False
+
+    constFunction :: Const [Bool] (Bool -> Bool)
+    constFunction = Const [True]
+
+    constValue :: Const [Bool] Bool
+    constValue = Const [False]
+
+    constResult :: [Bool]
+    constResult = getConst (constFunction <*> constValue)
+
+    zipListFunctions :: ZipList (Bool -> Bool)
+    zipListFunctions = ZipList [flipBool, flipBool]
+
+    zipListValues :: ZipList Bool
+    zipListValues = ZipList [False]
+
+    zipListResult :: [Bool]
+    zipListResult = getZipList (zipListFunctions <*> zipListValues)
+
+    zipListPureFunctions :: ZipList (Bool -> Bool)
+    zipListPureFunctions = pure flipBool
+
+    zipListPureResult :: [Bool]
+    zipListPureResult = getZipList (zipListPureFunctions <*> ZipList [False, True])
+
+output: |
+  ((: True (: False [])),((: True []),(: True (: False []))))
+expression: |
+  (constResult, (zipListResult, zipListPureResult))
+status: pass
+reason: Control.Applicative exports Const and ZipList with their access functions and applicative behavior


### PR DESCRIPTION
## Summary

- Add the polymorphic `Const` type and its access function.
- Add the `ZipList` type and its access function.
- Add `Functor` and `Applicative` instances for both types.
- Add one FC and GRIN evaluation fixture for the new API.

## Reason

`deepseq` imports these wrapper types from `Control.Applicative`.
The module did not export them.

## Progress counts

- Add four `base` API items: `Const`, `getConst`, `ZipList`, and `getZipList`.
- Do not change parser, resolver, type-checker, FC, or GRIN progress counts.
- Do not update README progress counts.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--pattern control-applicative-wrappers.yaml --hide-successes"`
- `cabal test -v0 aihc-grin:spec --test-options="--pattern control-applicative-wrappers.yaml --hide-successes"`
- `just fmt`
- `just check`