### PR TITLE
feat(base): add stack types API

### DIFF
--- a/core-libs/aihc-base/src/GHC/Stack/Types.hs
+++ b/core-libs/aihc-base/src/GHC/Stack/Types.hs
@@ -1,1 +1,57 @@
-module GHC.Stack.Types () where
+module GHC.Stack.Types
+  ( SrcLoc (..),
+    CallStack (..),
+    emptyCallStack,
+    freezeCallStack,
+    fromCallSiteList,
+    getCallStack,
+    pushCallStack,
+  )
+where
+
+import GHC.Base (String)
+import GHC.Int (Int)
+
+-- | A source location for one call site.
+data SrcLoc = SrcLoc
+  { srcLocPackage :: String,
+    srcLocModule :: String,
+    srcLocFile :: String,
+    srcLocStartLine :: Int,
+    srcLocStartCol :: Int,
+    srcLocEndLine :: Int,
+    srcLocEndCol :: Int
+  }
+
+-- | A call stack with an optional freeze marker.
+data CallStack
+  = EmptyCallStack
+  | PushCallStack String SrcLoc CallStack
+  | FreezeCallStack CallStack
+
+-- | Make an empty call stack.
+emptyCallStack :: CallStack
+emptyCallStack = EmptyCallStack
+
+-- | Prevent subsequent pushes to a call stack.
+freezeCallStack :: CallStack -> CallStack
+freezeCallStack stack@(FreezeCallStack _) = stack
+freezeCallStack stack = FreezeCallStack stack
+
+-- | Make a call stack from entries in most-recent-first order.
+fromCallSiteList :: [(String, SrcLoc)] -> CallStack
+fromCallSiteList [] = EmptyCallStack
+fromCallSiteList ((name, location) : entries) =
+  PushCallStack name location (fromCallSiteList entries)
+
+-- | Get call-stack entries in most-recent-first order.
+getCallStack :: CallStack -> [(String, SrcLoc)]
+getCallStack EmptyCallStack = []
+getCallStack (PushCallStack name location stack) =
+  (name, location) : getCallStack stack
+getCallStack (FreezeCallStack stack) = getCallStack stack
+
+-- | Add one entry unless the call stack is frozen.
+pushCallStack :: (String, SrcLoc) -> CallStack -> CallStack
+pushCallStack _ stack@(FreezeCallStack _) = stack
+pushCallStack (name, location) stack = PushCallStack name location stack

--- a/test/Test/Fixtures/eval/base/ghc-stack-types.yaml
+++ b/test/Test/Fixtures/eval/base/ghc-stack-types.yaml
@@ -1,0 +1,80 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import GHC.Stack.Types
+
+    firstLocation :: SrcLoc
+    firstLocation = SrcLoc "package" "Module" "File.hs" 1 2 3 4
+
+    secondLocation :: SrcLoc
+    secondLocation = SrcLoc "dependency" "Other" "Other.hs" 5 6 7 8
+
+    locationFields :: Bool
+    locationFields =
+      srcLocPackage firstLocation == "package"
+        && srcLocModule firstLocation == "Module"
+        && srcLocFile firstLocation == "File.hs"
+        && srcLocStartLine firstLocation == 1
+        && srcLocStartCol firstLocation == 2
+        && srcLocEndLine firstLocation == 3
+        && srcLocEndCol firstLocation == 4
+
+    sameLocation :: SrcLoc -> SrcLoc -> Bool
+    sameLocation
+      (SrcLoc leftPackage leftModule leftFile leftStartLine leftStartCol leftEndLine leftEndCol)
+      (SrcLoc rightPackage rightModule rightFile rightStartLine rightStartCol rightEndLine rightEndCol) =
+        leftPackage == rightPackage
+          && leftModule == rightModule
+          && leftFile == rightFile
+          && leftStartLine == rightStartLine
+          && leftStartCol == rightStartCol
+          && leftEndLine == rightEndLine
+          && leftEndCol == rightEndCol
+
+    sameEntry :: (String, SrcLoc) -> (String, SrcLoc) -> Bool
+    sameEntry (leftName, leftLocation) (rightName, rightLocation) =
+      leftName == rightName && sameLocation leftLocation rightLocation
+
+    sameEntries :: [(String, SrcLoc)] -> [(String, SrcLoc)] -> Bool
+    sameEntries [] [] = True
+    sameEntries (left : lefts) (right : rights) =
+      sameEntry left right && sameEntries lefts rights
+    sameEntries _ _ = False
+
+    expectedEntries :: [(String, SrcLoc)]
+    expectedEntries = [("first", firstLocation), ("second", secondLocation)]
+
+    constructorStack :: CallStack
+    constructorStack =
+      PushCallStack "first" firstLocation
+        (PushCallStack "second" secondLocation EmptyCallStack)
+
+    frozenPushIsIgnored :: Bool
+    frozenPushIsIgnored =
+      sameEntries
+        (getCallStack (pushCallStack ("ignored", secondLocation) (freezeCallStack constructorStack)))
+        expectedEntries
+
+    deepseqPatterns :: CallStack -> ()
+    deepseqPatterns EmptyCallStack = ()
+    deepseqPatterns (PushCallStack name location rest) =
+      name `seq` location `seq` deepseqPatterns rest
+    deepseqPatterns (FreezeCallStack rest) = deepseqPatterns rest
+
+    results :: Bool
+    results =
+      locationFields
+        && sameEntries (getCallStack emptyCallStack) []
+        && sameEntries (getCallStack constructorStack) expectedEntries
+        && sameEntries (getCallStack (fromCallSiteList expectedEntries)) expectedEntries
+        && frozenPushIsIgnored
+        && case deepseqPatterns (freezeCallStack constructorStack) of
+          () -> True
+output: "True"
+expression: results
+status: pass
+reason: GHC.Stack.Types provides the call-stack data API and the shallow stack operations that deepseq needs


### PR DESCRIPTION
## Summary

- Add the `SrcLoc` and `CallStack` data APIs.
- Add pure call-stack construction, freeze, push, and inspection functions.
- Add an FC and GRIN evaluation fixture for the API that `deepseq` uses.

## Reason

`deepseq` imports `SrcLoc` and `CallStack` constructors from `GHC.Stack.Types`.
The previous module exported no API.

This change supplies the required data API without runtime call-stack collection.

## Progress counts

- Add one passing shared base evaluation fixture.
- Add 18 matching base API entries from `GHC.Stack.Types`.
- Keep README progress text unchanged because the scheduled workflow updates it.
- Do not change parser, resolver, type-checker, or extension progress counts.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="-p ghc-stack-types --hide-successes"`
- `cabal test -v0 aihc-grin:spec --test-options="-p ghc-stack-types --hide-successes"`
- `just fmt`
- `just check`

I ran validation in a clean worktree because the source worktree contains unrelated compiler changes.