### PR TITLE
feat(base): add fixed-width integer types

### DIFF
--- a/core-libs/aihc-base/src/Data/Int.hs
+++ b/core-libs/aihc-base/src/Data/Int.hs
@@ -1,7 +1,10 @@
 module Data.Int
-  ( Int,
+  ( Int (..),
+    Int8 (..),
+    Int16 (..),
     Int32 (..),
+    Int64 (..),
   )
 where
 
-import GHC.Int (Int, Int32 (..))
+import GHC.Int (Int (..), Int16 (..), Int32 (..), Int64 (..), Int8 (..))

--- a/core-libs/aihc-base/src/Data/Word.hs
+++ b/core-libs/aihc-base/src/Data/Word.hs
@@ -1,1 +1,10 @@
-module Data.Word () where
+module Data.Word
+  ( Word (..),
+    Word8 (..),
+    Word16 (..),
+    Word32 (..),
+    Word64 (..),
+  )
+where
+
+import GHC.Word (Word (..), Word16 (..), Word32 (..), Word64 (..), Word8 (..))

--- a/core-libs/aihc-base/src/GHC/Int.hs
+++ b/core-libs/aihc-base/src/GHC/Int.hs
@@ -2,7 +2,10 @@
 
 module GHC.Int
   ( Int (..),
+    Int8 (..),
+    Int16 (..),
     Int32 (..),
+    Int64 (..),
   )
 where
 
@@ -10,4 +13,10 @@ import GHC.Prim ((*#), (+#), (-#))
 
 data Int = I# Int#
 
+data Int8 = I8# Int8#
+
+data Int16 = I16# Int16#
+
 data Int32 = I32# Int32#
+
+data Int64 = I64# Int64#

--- a/core-libs/aihc-base/src/GHC/Word.hs
+++ b/core-libs/aihc-base/src/GHC/Word.hs
@@ -1,1 +1,20 @@
-module GHC.Word () where
+{-# LANGUAGE MagicHash #-}
+
+module GHC.Word
+  ( Word (..),
+    Word8 (..),
+    Word16 (..),
+    Word32 (..),
+    Word64 (..),
+  )
+where
+
+data Word = W# Word#
+
+data Word8 = W8# Word8#
+
+data Word16 = W16# Word16#
+
+data Word32 = W32# Word32#
+
+data Word64 = W64# Word64#

--- a/test/Test/Fixtures/eval/base/data-int-word.yaml
+++ b/test/Test/Fixtures/eval/base/data-int-word.yaml
@@ -1,0 +1,47 @@
+extensions:
+  - MagicHash
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Int (Int (..), Int8 (..), Int16 (..), Int32 (..), Int64 (..))
+    import Data.Word (Word (..), Word8 (..), Word16 (..), Word32 (..), Word64 (..))
+
+    unwrapInt :: Int -> Int#
+    unwrapInt (I# value) = value
+
+    unwrapInt8 :: Int8 -> Int8#
+    unwrapInt8 (I8# value) = value
+
+    unwrapInt16 :: Int16 -> Int16#
+    unwrapInt16 (I16# value) = value
+
+    unwrapInt32 :: Int32 -> Int32#
+    unwrapInt32 (I32# value) = value
+
+    unwrapInt64 :: Int64 -> Int64#
+    unwrapInt64 (I64# value) = value
+
+    unwrapWord :: Word -> Word#
+    unwrapWord (W# value) = value
+
+    unwrapWord8 :: Word8 -> Word8#
+    unwrapWord8 (W8# value) = value
+
+    unwrapWord16 :: Word16 -> Word16#
+    unwrapWord16 (W16# value) = value
+
+    unwrapWord32 :: Word32 -> Word32#
+    unwrapWord32 (W32# value) = value
+
+    unwrapWord64 :: Word64 -> Word64#
+    unwrapWord64 (W64# value) = value
+
+    results :: Bool
+    results = True
+output: "True"
+expression: results
+status: pass
+reason: Data.Int and Data.Word expose each fixed-width wrapper with its matching primitive representation


### PR DESCRIPTION
## Summary

- Add the fixed-width signed integer wrappers to `GHC.Int` and `Data.Int`.
- Add `Word` and the fixed-width unsigned integer wrappers to `GHC.Word` and `Data.Word`.
- Add one FC and GRIN evaluation fixture for all wrapper representations.

## Reason

`deepseq` imports these scalar types. The previous modules did not export all required wrappers.

## Progress counts

- Increase base compatibility from 483/10,055 to 491/10,055.
- Keep ghc-prim compatibility at 52/3,425.
- Keep extra declarations at 18 for ghc-prim and 49 for base.

## Validation

- `just fmt`
- `just check`
- `aihc-dev core-libs-progress`