### PR TITLE
feat(base): add monoid and semigroup wrappers

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Newtype.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Newtype.hs
@@ -16,22 +16,27 @@ where
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Evidence (Coercion (..))
-import Aihc.Tc.Types (TcType (..), TyCon (..), Unique (..))
+import Aihc.Tc.Types (TcType (..), TyCon (..), Unique (..), tyConModuleName)
+import Control.Applicative ((<|>))
 import Control.Monad.Trans.State.Strict (State, evalState, state)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 
-newtype NewtypeInterface = NewtypeInterface
-  { newtypesByConstructor :: Map Text FcNewtypeDecl
+data NewtypeInterface = NewtypeInterface
+  { newtypesByOrigin :: Map FcSymbolOrigin FcNewtypeDecl,
+    newtypesByConstructor :: Map Text [FcNewtypeDecl]
   }
   deriving (Eq, Show, Read)
 
 instance Semigroup NewtypeInterface where
-  NewtypeInterface left <> NewtypeInterface right = NewtypeInterface (right <> left)
+  NewtypeInterface leftOrigins leftConstructors <> NewtypeInterface rightOrigins rightConstructors =
+    NewtypeInterface
+      (rightOrigins <> leftOrigins)
+      (Map.unionWith (<>) rightConstructors leftConstructors)
 
 instance Monoid NewtypeInterface where
-  mempty = NewtypeInterface Map.empty
+  mempty = NewtypeInterface Map.empty Map.empty
 
 type NewtypeEnv = NewtypeInterface
 
@@ -50,7 +55,13 @@ extractNewtypeInterface :: FcProgram -> NewtypeInterface
 extractNewtypeInterface (FcProgram _ topBinds) =
   NewtypeInterface
     ( Map.fromList
-        [ (fcNewtypeConstructor declaration, declaration)
+        [ (fcNewtypeConstructorOrigin declaration, declaration)
+        | FcNewtype declaration <- topBinds
+        ]
+    )
+    ( Map.fromListWith
+        (<>)
+        [ (fcNewtypeConstructor declaration, [declaration])
         | FcNewtype declaration <- topBinds
         ]
     )
@@ -79,7 +90,7 @@ lowerExpr :: NewtypeEnv -> FcExpr -> LowerM FcExpr
 lowerExpr env expr =
   case expr of
     FcVar var ->
-      case Map.lookup (varName var) (newtypesByConstructor env) of
+      case lookupNewtypeConstructor env var of
         Just declaration -> lowerConstructorValue declaration []
         Nothing -> pure expr
     FcLit {} -> pure expr
@@ -113,7 +124,7 @@ lowerConstructorValue declaration typeArgs = do
 
 lowerCase :: NewtypeEnv -> FcExpr -> Var -> [FcAlt] -> LowerM FcExpr
 lowerCase env scrutinee binder alternatives =
-  case firstNewtypeAlternative env alternatives of
+  case firstNewtypeAlternative env (varType binder) alternatives of
     Just (declaration, fieldBinder, rhs) -> do
       scrutinee' <- lowerExpr env scrutinee
       rhs' <- lowerExpr env rhs
@@ -134,12 +145,12 @@ lowerAlt env alternative = do
   rhs <- lowerExpr env (altRhs alternative)
   pure alternative {altRhs = rhs}
 
-firstNewtypeAlternative :: NewtypeEnv -> [FcAlt] -> Maybe (FcNewtypeDecl, Var, FcExpr)
-firstNewtypeAlternative env alternatives =
+firstNewtypeAlternative :: NewtypeEnv -> TcType -> [FcAlt] -> Maybe (FcNewtypeDecl, Var, FcExpr)
+firstNewtypeAlternative env scrutineeType alternatives =
   case [ (declaration, fieldBinder, altRhs alternative)
        | alternative <- alternatives,
          DataAlt constructor <- [altCon alternative],
-         Just declaration <- [Map.lookup constructor (newtypesByConstructor env)],
+         Just declaration <- [lookupNewtypeByResultType env constructor scrutineeType],
          [fieldBinder] <- [altBinders alternative]
        ] of
     match : _ -> Just match
@@ -151,8 +162,49 @@ newtypeConstructorSpine env = go []
     go typeArgs expression =
       case expression of
         FcTyApp inner ty -> go (ty : typeArgs) inner
-        FcVar var -> (,typeArgs) <$> Map.lookup (varName var) (newtypesByConstructor env)
+        FcVar var -> (,typeArgs) <$> lookupNewtypeConstructor env var
         _ -> Nothing
+
+lookupNewtypeConstructor :: NewtypeEnv -> Var -> Maybe FcNewtypeDecl
+lookupNewtypeConstructor env var =
+  case varResolvedName var of
+    Just origin -> Map.lookup origin (newtypesByOrigin env) <|> lookupByResultType
+    Nothing -> lookupByResultType
+  where
+    lookupByResultType = lookupNewtypeByResultType env (varName var) (constructorResultType (varType var))
+
+lookupNewtypeByResultType :: NewtypeEnv -> Text -> TcType -> Maybe FcNewtypeDecl
+lookupNewtypeByResultType env constructor resultType =
+  firstMatching (Map.findWithDefault [] constructor (newtypesByConstructor env))
+  where
+    firstMatching [] = Nothing
+    firstMatching (declaration : declarations)
+      | sameTypeConstructor (typeConstructor (fcNewtypeResult declaration)) (typeConstructor resultType) = Just declaration
+      | otherwise = firstMatching declarations
+
+constructorResultType :: TcType -> TcType
+constructorResultType ty =
+  case ty of
+    TcForAllTy _ body -> constructorResultType body
+    TcQualTy _ body -> constructorResultType body
+    TcFunTy _ result -> constructorResultType result
+    _ -> ty
+
+typeConstructor :: TcType -> Maybe TyCon
+typeConstructor ty =
+  case ty of
+    TcTyCon tyCon _ -> Just tyCon
+    TcAppTy function _ -> typeConstructor function
+    _ -> Nothing
+
+sameTypeConstructor :: Maybe TyCon -> Maybe TyCon -> Bool
+sameTypeConstructor (Just left) (Just right) =
+  sameNameAndArity
+    && (not (hasSourceIdentity left && hasSourceIdentity right) || left == right)
+  where
+    sameNameAndArity = (tyConName left, tyConArity left) == (tyConName right, tyConArity right)
+    hasSourceIdentity tyCon = tyConModuleName tyCon /= "Aihc.Internal"
+sameTypeConstructor _ _ = False
 
 wrapNewtype :: FcNewtypeDecl -> [TcType] -> FcExpr -> FcExpr
 wrapNewtype declaration typeArgs expression =
@@ -175,8 +227,8 @@ instantiateRepresentation declaration typeArgs =
 newtypeArguments :: FcNewtypeDecl -> TcType -> [TcType]
 newtypeArguments declaration ty =
   case ty of
-    TcTyCon (TyCon name _) arguments
-      | name == fcNewtypeName declaration -> arguments
+    TcTyCon tyCon arguments
+      | sameTypeConstructor (Just tyCon) (typeConstructor (fcNewtypeResult declaration)) -> arguments
     _ -> []
 
 completeTypeArgs :: FcNewtypeDecl -> [TcType] -> [TcType]

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -459,7 +459,10 @@ fcOptimizationTests =
                   fcNewtypeRepresentation = intHashTy,
                   fcNewtypeResult = wrapperTy
                 }
-            constructor = Var "Wrap" (Unique 30) (TcFunTy intHashTy wrapperTy)
+            constructor =
+              (Var "Wrap" (Unique 30) (TcFunTy intHashTy wrapperTy))
+                { varResolvedName = Just (FcTopLevelOrigin "consumer" "Test" "Wrap")
+                }
             value = Var "value" (Unique 31) wrapperTy
             literal = FcLit (LitInt IntRep 42)
             provider = FcProgram (FcModuleId "test" "Test") [FcNewtype declaration]
@@ -473,6 +476,54 @@ fcOptimizationTests =
           "consumer lint"
           []
           (lintProgramWithAxiomInterface (extractAxiomInterface provider) emptyLintEnv loweredConsumer),
+      testCase "does not lower a data constructor with an imported newtype constructor name" $ do
+        let intHashTy = ty "Int#"
+            importedTy = ty "ImportedFirst"
+            localTy = ty "Local"
+            importedOrigin = FcTopLevelOrigin "dependency" "Data.Wrapper" "First"
+            localTypeOrigin = FcTopLevelOrigin "test" "Test" "Local"
+            localConstructorOrigin = FcTopLevelOrigin "test" "Test" "First"
+            importedDeclaration =
+              FcNewtypeDecl
+                { fcNewtypeOrigin = FcTopLevelOrigin "dependency" "Data.Wrapper" "ImportedFirst",
+                  fcNewtypeName = "ImportedFirst",
+                  fcNewtypeTyVars = [],
+                  fcNewtypeConstructorOrigin = importedOrigin,
+                  fcNewtypeConstructor = "First",
+                  fcNewtypeRepresentation = intHashTy,
+                  fcNewtypeResult = importedTy
+                }
+            localDeclaration =
+              FcDataDecl
+                { fcDataOrigin = localTypeOrigin,
+                  fcDataName = "Local",
+                  fcDataTyVars = [],
+                  fcDataResultKind = KType,
+                  fcDataConstructors = [FcDataConDecl localConstructorOrigin "First" [intHashTy]]
+                }
+            constructor =
+              (Var "First" (Unique 50) (TcFunTy intHashTy localTy))
+                { varResolvedName = Just localConstructorOrigin
+                }
+            caseBinder = Var "value" (Unique 51) localTy
+            fieldBinder = Var "field" (Unique 52) intHashTy
+            result = Var "result" (Unique 53) intHashTy
+            source =
+              FcProgram
+                (FcModuleId "test" "Test")
+                [ FcData localDeclaration,
+                  FcTopBind
+                    ( FcNonRec
+                        result
+                        ( Aihc.Fc.FcCase
+                            (FcApp (FcVar constructor) (FcLit (LitInt IntRep 42)))
+                            caseBinder
+                            [FcAlt (DataAlt "First") [fieldBinder] (FcVar fieldBinder)]
+                        )
+                    )
+                ]
+            imported = extractNewtypeInterface (FcProgram (FcModuleId "dependency" "Data.Wrapper") [FcNewtype importedDeclaration])
+        assertEqual "unchanged data constructor" source (lowerNewtypesWithInterface imported source),
       testCase "lints explicit equality axioms" $ do
         let familyTy = ty "Family"
             representationTy = ty "Int#"

--- a/core-libs/aihc-base/src/Data/Monoid.hs
+++ b/core-libs/aihc-base/src/Data/Monoid.hs
@@ -1,10 +1,30 @@
 module Data.Monoid
   ( Monoid (..),
+    (<>),
+    Dual (..),
+    All (..),
+    Any (..),
+    Sum (..),
+    Product (..),
+    First (..),
+    Last (..),
   )
 where
 
-import Data.Semigroup (Semigroup (..))
-import Prelude (Maybe (..))
+import Data.Semigroup
+  ( Max (..),
+    Min (..),
+    Semigroup (..),
+    WrappedMonoid (..),
+  )
+import Prelude
+  ( Bool (..),
+    Bounded (..),
+    Maybe (..),
+    Num (..),
+    (&&),
+    (||),
+  )
 
 class (Semigroup a) => Monoid a where
   mempty :: a
@@ -15,6 +35,73 @@ class (Semigroup a) => Monoid a where
   mconcat = foldMonoid
 
 infixr 6 `mappend`
+
+newtype Dual a = Dual {getDual :: a}
+
+newtype All = All {getAll :: Bool}
+
+newtype Any = Any {getAny :: Bool}
+
+newtype Sum a = Sum {getSum :: a}
+
+newtype Product a = Product {getProduct :: a}
+
+newtype First a = First {getFirst :: Maybe a}
+
+newtype Last a = Last {getLast :: Maybe a}
+
+instance (Semigroup a) => Semigroup (Dual a) where
+  Dual left <> Dual right = Dual (right <> left)
+
+instance (Monoid a) => Monoid (Dual a) where
+  mempty = Dual mempty
+
+instance Semigroup All where
+  All left <> All right = All (left && right)
+
+instance Monoid All where
+  mempty = All True
+
+instance Semigroup Any where
+  Any left <> Any right = Any (left || right)
+
+instance Monoid Any where
+  mempty = Any False
+
+instance (Num a) => Semigroup (Sum a) where
+  Sum left <> Sum right = Sum (left + right)
+
+instance (Num a) => Monoid (Sum a) where
+  mempty = Sum 0
+
+instance (Num a) => Semigroup (Product a) where
+  Product left <> Product right = Product (left * right)
+
+instance (Num a) => Monoid (Product a) where
+  mempty = Product 1
+
+instance Semigroup (First a) where
+  First Nothing <> right = right
+  left <> _ = left
+
+instance Monoid (First a) where
+  mempty = First Nothing
+
+instance Semigroup (Last a) where
+  left <> Last Nothing = left
+  _ <> right = right
+
+instance Monoid (Last a) where
+  mempty = Last Nothing
+
+instance (Ord a, Bounded a) => Monoid (Min a) where
+  mempty = Min maxBound
+
+instance (Ord a, Bounded a) => Monoid (Max a) where
+  mempty = Max minBound
+
+instance (Monoid m) => Monoid (WrappedMonoid m) where
+  mempty = WrapMonoid mempty
 
 {- HLINT ignore foldMonoid "Use foldr" -}
 foldMonoid :: (Monoid a) => [a] -> a

--- a/core-libs/aihc-base/src/Data/Semigroup.hs
+++ b/core-libs/aihc-base/src/Data/Semigroup.hs
@@ -1,14 +1,72 @@
 module Data.Semigroup
   ( Semigroup (..),
+    Min (..),
+    Max (..),
+    First (..),
+    Last (..),
+    WrappedMonoid (..),
+    Arg (..),
+    ArgMin,
+    ArgMax,
   )
 where
 
-import Prelude (Maybe (..), (++))
+import Prelude (Eq (..), Maybe (..), Ord (..), (++))
 
 class Semigroup a where
   (<>) :: a -> a -> a
 
 infixr 6 <>
+
+newtype Min a = Min {getMin :: a}
+
+newtype Max a = Max {getMax :: a}
+
+newtype First a = First {getFirst :: a}
+
+newtype Last a = Last {getLast :: a}
+
+newtype WrappedMonoid m = WrapMonoid {unwrapMonoid :: m}
+
+data Arg a b = Arg a b
+
+type ArgMin a b = Min (Arg a b)
+
+type ArgMax a b = Max (Arg a b)
+
+instance (Ord a) => Semigroup (Min a) where
+  Min left <> Min right = Min (min left right)
+
+instance (Ord a) => Semigroup (Max a) where
+  Max left <> Max right = Max (max left right)
+
+instance Semigroup (First a) where
+  left <> _ = left
+
+instance Semigroup (Last a) where
+  _ <> right = right
+
+instance (Semigroup m) => Semigroup (WrappedMonoid m) where
+  WrapMonoid left <> WrapMonoid right = WrapMonoid (left <> right)
+
+instance (Eq a) => Eq (Arg a b) where
+  Arg left _ == Arg right _ = left == right
+  Arg left _ /= Arg right _ = left /= right
+
+instance (Ord a) => Ord (Arg a b) where
+  compare (Arg left _) (Arg right _) = compare left right
+  left < right = compare left right == LT
+  left <= right = compare left right /= GT
+  left > right = compare left right == GT
+  left >= right = compare left right /= LT
+  min left@(Arg leftKey _) right@(Arg rightKey _) =
+    case leftKey <= rightKey of
+      True -> left
+      False -> right
+  max left@(Arg leftKey _) right@(Arg rightKey _) =
+    case leftKey >= rightKey of
+      True -> left
+      False -> right
 
 instance Semigroup [a] where
   (<>) = (++)

--- a/test/Test/Fixtures/eval/base/data-monoid-wrappers.yaml
+++ b/test/Test/Fixtures/eval/base/data-monoid-wrappers.yaml
@@ -1,0 +1,37 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Monoid
+
+    combinedDual :: Dual [Bool]
+    combinedDual = Dual [True] <> Dual [False]
+
+    combinedSum :: Sum Int
+    combinedSum = mconcat [Sum 2, Sum 3, Sum 4]
+
+    combinedProduct :: Product Int
+    combinedProduct = mconcat [Product 2, Product 3, Product 4]
+
+    combinedFirst :: First Bool
+    combinedFirst = First Nothing <> First (Just True)
+
+    combinedLast :: Last Bool
+    combinedLast = Last (Just False) <> Last (Just True)
+
+    wrappersWork :: Bool
+    wrappersWork =
+      getDual combinedDual == [False, True]
+        && getAll (All True <> All False) == False
+        && getAny (Any False <> Any True) == True
+        && getSum combinedSum == 9
+        && getProduct combinedProduct == 24
+        && getFirst combinedFirst == Just True
+        && getLast combinedLast == Just True
+output: "True"
+expression: wrappersWork
+status: pass
+reason: Data.Monoid provides the deepseq wrapper types and their monoid behavior

--- a/test/Test/Fixtures/eval/base/data-semigroup-wrappers.yaml
+++ b/test/Test/Fixtures/eval/base/data-semigroup-wrappers.yaml
@@ -1,0 +1,39 @@
+extensions: []
+dependencies:
+  - aihc-base
+modules:
+  - |
+    module Test where
+
+    import Data.Semigroup
+
+    combinedMin :: Min Int
+    combinedMin = Min 7 <> Min 3
+
+    combinedMax :: Max Int
+    combinedMax = Max 7 <> Max 3
+
+    combinedArg :: Min (Arg Int Bool)
+    combinedArg = Min (Arg 1 False) <> Min (Arg 1 True)
+
+    combinedFirst :: First Bool
+    combinedFirst = First False <> First True
+
+    combinedLast :: Last Bool
+    combinedLast = Last False <> Last True
+
+    wrappersWork :: Bool
+    wrappersWork =
+      getMin combinedMin == 3
+        && getMax combinedMax == 7
+        && getFirst combinedFirst == False
+        && getLast combinedLast == True
+        && unwrapMonoid (WrapMonoid [True] <> WrapMonoid [False]) == [True, False]
+        && argValue (getMin combinedArg) == False
+
+    argValue :: Arg a b -> b
+    argValue (Arg _ value) = value
+output: "True"
+expression: wrappersWork
+status: pass
+reason: Data.Semigroup provides the deepseq wrapper types and their semigroup behavior


### PR DESCRIPTION
## Summary

- Add the deepseq wrapper types to `Data.Monoid`.
- Add the deepseq wrapper types to `Data.Semigroup`.
- Add wrapper evaluation tests for FC and GRIN.
- Use resolved origins and type identities during newtype lowering.
- Add newtype collision and interface fallback regression tests.

## Effect

The base API match count increases from 483 to 508.
This change adds 25 matched API items.
The base API coverage increases from 4.80 percent to 5.05 percent.

## Validation

- `just fmt`
- `just check`
- `nix build .#checks.aarch64-darwin.examples-tests --no-link`
