### PR TITLE
fix(tc): preserve type constructor identities

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -258,7 +258,7 @@ compileWithDependencies target wholeProgram dependencies parsed = do
             then Left (CompileFrontendError ["typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules)])
             else
               let bindings = dependencyBindings dependencies <> concatMap tcModuleBindings checkedModules
-                  desugared = zipWith (desugarModuleWithBindings bindings) checkedModules moduleAsts
+                  desugared = zipWith (desugarModuleWithBindings primPackageId bindings) checkedModules moduleAsts
                in if not (all dsSuccess desugared)
                     then Left (CompileFrontendError (concatMap dsErrors desugared))
                     else do

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -66,13 +66,13 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Parser.Token (readModuleHeaderPragmas)
 import Aihc.Resolve (ModuleKey (..), Package (..), PackageId (..), ResolveResult (..), Scope (..), resolveWithDeps, unnamedPackage)
-import Aihc.Tc (tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
+import Aihc.Tc (tcConfig, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterfaceConfig)
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket)
 import Control.Monad (forM_, when)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -237,13 +237,21 @@ compileSourceToArtifactsWithDependencies target wholeProgram environment sourceN
         compileWithDependencies target wholeProgram artifact parsed
 
 compileWithDependencies :: NativeTarget -> Bool -> DependencyArtifact -> Module -> Either CompileError CompileArtifacts
-compileWithDependencies target wholeProgram dependencies parsed =
+compileWithDependencies target wholeProgram dependencies parsed = do
+  let primPackageId =
+        fromMaybe (PackageId "aihc-prim") $
+          listToMaybe
+            [ packageId package
+            | ModuleKey package _ <- Map.keys (dependencyExports dependencies),
+              packageName package == "aihc-prim"
+            ]
   case resolveWithDeps (dependencyExports dependencies) [(unnamedPackage, parsed)] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
     ResolveResult {resolvedModules} ->
       let moduleAsts = map snd resolvedModules
           (checkedModules, _) =
-            typecheckModulesWithInterface
+            typecheckModulesWithInterfaceConfig
+              (tcConfig primPackageId)
               (dependencyTcInterface dependencies)
               moduleAsts
        in if not (all tcModuleSuccess checkedModules)

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -408,7 +408,7 @@ compileLoadedModules loaded = do
                 else
                   let localBindings = concatMap tcModuleBindings checkedModules
                       bindings = compileStateBindings state <> localBindings
-                      desugared = zipWith (desugarModuleWithBindings bindings) checkedModules moduleAsts
+                      desugared = zipWith (desugarModuleWithBindings primPackageId bindings) checkedModules moduleAsts
                    in if not (all dsSuccess desugared)
                         then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else do

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -61,10 +61,11 @@ import Aihc.Resolve
 import Aihc.Tc
   ( TcBindingResult (..),
     TcInterface,
+    tcConfig,
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleSuccess,
-    typecheckModuleSccWithInterface,
+    typecheckModuleSccWithInterfaceConfig,
   )
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket, bracketOnError)
@@ -73,7 +74,7 @@ import Data.Bits (xor)
 import Data.ByteString qualified as BS
 import Data.Char (isHexDigit)
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (intercalate, sort, sortOn)
+import Data.List (find, intercalate, sort, sortOn)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe)
@@ -385,17 +386,23 @@ parserConfig sourceName source =
     language = fromMaybe Haskell98Edition (headerLanguageEdition header)
 
 compileLoadedModules :: [LoadedModule] -> Either String DependencyArtifact
-compileLoadedModules loaded = finish <$> foldM compileScc initialState (loadedModuleSccs loaded)
+compileLoadedModules loaded = do
+  let primPackageId =
+        maybe
+          (PackageId "aihc-prim")
+          packageId
+          (find ((== "aihc-prim") . packageName) (map loadedResolvePackage loaded))
+  finish <$> foldM (compileScc primPackageId) initialState (loadedModuleSccs loaded)
   where
     initialState = CompileState Map.empty mempty [] mempty mempty mempty mempty [] []
 
-    compileScc state members =
+    compileScc primPackageId state members =
       case resolveWithDeps (compileStateExports state) [(loadedResolvePackage member, loadedModule member) | member <- members] of
         ResolveResult {resolveErrors = errors@(_ : _)} -> Left ("library resolve error: " <> show errors)
         resolved@ResolveResult {resolvedModules} ->
           let moduleAsts = map snd resolvedModules
               (checkedModules, tcInterface) =
-                typecheckModuleSccWithInterface (compileStateTcInterface state) moduleAsts
+                typecheckModuleSccWithInterfaceConfig (tcConfig primPackageId) (compileStateTcInterface state) moduleAsts
            in if not (all tcModuleSuccess checkedModules)
                 then Left ("library typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules))
                 else

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -1299,7 +1299,7 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       ownBindings = concatMap tcModuleBindings checkedModules
       allBindings = mergeBy tbName [importedBindings, ownBindings]
       resolvedModuleAsts = map snd (resolvedModules resolveResult)
-      fcResults = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
+      fcResults = zipWith (desugarModuleWithDataTypes primIdentity allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
       fcModules = zipWith fcModuleValue resolvedModuleAsts fcResults
       fcDiagnostics = concatMap fcModuleDiagnosticValues fcModules
   pure

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -86,10 +86,11 @@ import Aihc.Tc
     TyVarId (..),
     Unique (..),
     renderTcType,
+    tcConfig,
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleSuccess,
-    typecheckModulesWithInterface,
+    typecheckModulesWithInterfaceConfig,
   )
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar)
@@ -1280,8 +1281,18 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       resolveResult = resolveWithDeps depExports (modulesInPackage currentPackage parsedModules)
       exposedModules = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
       ownExports = Map.restrictKeys (extractInterface resolveResult) (Set.map (ModuleKey currentPackage) exposedModules)
+      primPackageId =
+        if packageName currentPackage == "aihc-prim"
+          then Just (packageId currentPackage)
+          else
+            listToMaybe
+              [ packageId package
+              | ModuleKey package _ <- Map.keys depExports,
+                packageName package == "aihc-prim"
+              ]
+  let primIdentity = fromMaybe (PackageId "aihc-prim") primPackageId
   (checkedModules, tcModules, tcDiagnostics, tcInterface) <-
-    typecheckInterfaceModules importedTcInterface (map snd (resolvedModules resolveResult))
+    typecheckInterfaceModules primIdentity importedTcInterface (map snd (resolvedModules resolveResult))
   let resolveDiagnostics = enrichDiagnostics (map resolveErrorValue (resolveErrors resolveResult))
       enrichedTcDiagnostics = enrichDiagnostics tcDiagnostics
       enrichedTcModules = map (addTcModuleDiagnosticSourceLines sourceLinesByFile) tcModules
@@ -1314,8 +1325,8 @@ packageVariantResolvePackage key =
       packageId = PackageId (T.intercalate "-" (packageVariantLibraryId key))
     }
 
-typecheckInterfaceModules :: TcInterface -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], TcInterface)
-typecheckInterfaceModules importedTcInterface modules = do
+typecheckInterfaceModules :: PackageId -> TcInterface -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], TcInterface)
+typecheckInterfaceModules primPackageId importedTcInterface modules = do
   currentModule <- newIORef (listToMaybe sortedModules)
   result <- timeout typecheckPhaseTimeoutMicros (go currentModule)
   case result of
@@ -1329,7 +1340,7 @@ typecheckInterfaceModules importedTcInterface modules = do
     go current = do
       mapM_ (writeIORef current . Just) sortedModules
       let (checkedModules, tcInterface) =
-            typecheckModulesWithInterface importedTcInterface sortedModules
+            typecheckModulesWithInterfaceConfig (tcConfig primPackageId) importedTcInterface sortedModules
           tcModules = zipWith tcModuleValue sortedModules checkedModules
       _ <- evaluate (forceJsonValue (Aeson.toJSON tcModules))
       length (show tcInterface) `seq`

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -200,7 +200,7 @@ evaluateExpression session input = do
           tcResult = checkedTcModule checked
           inferredType = checkedType checked
           allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
-          dsResult = desugarModuleWithBindings allBindings tcResult resolvedModule
+          dsResult = desugarModuleWithBindings (PackageId "aihc-prim") allBindings tcResult resolvedModule
       if not (dsSuccess dsResult)
         then pure (Left (ReplDesugarError (dsErrors dsResult)))
         else do
@@ -511,7 +511,7 @@ buildBaseContext modules =
       if all tcModuleSuccess tcResults
         then do
           let allBindings = concatMap tcModuleBindings tcResults
-              dsResults = zipWith (desugarModuleWithBindings allBindings) tcResults moduleAsts
+              dsResults = zipWith (desugarModuleWithBindings (PackageId "aihc-prim") allBindings) tcResults moduleAsts
               bindingTypes = moduleBindingTypes moduleAsts tcResults
           if all dsSuccess dsResults
             then

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -35,7 +35,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameFromText,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, modulesInPackage, resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), PackageId (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps, unnamedPackage)
 import Aihc.Tc
   ( InstanceInfo,
     Pred (..),
@@ -47,15 +47,17 @@ import Aihc.Tc
     TyVarId (..),
     TypeScheme (..),
     Unique (..),
+    emptyTcInterface,
     renderPred,
     renderTcSignature,
     renderTcType,
+    tcConfig,
     tcModuleBindings,
     tcModuleDiagnostics,
     tcModuleInstances,
     tcModuleSuccess,
     typecheckModuleWithEnvAndInstances,
-    typecheckModulesWithEnv,
+    typecheckModulesWithInterfaceConfig,
   )
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson ((.!=), (.:), (.:?))
@@ -491,10 +493,14 @@ loadAihcBaseContext = do
 
 buildBaseContext :: [Module] -> IO ReplBaseContext
 buildBaseContext modules =
-  case resolveWithDeps Map.empty (modulesInPackage unnamedPackage modules) of
+  case resolveWithDeps Map.empty (map modulePackage modules) of
     resolved@ResolveResult {resolveErrors = [], resolvedModules} -> do
       let moduleAsts = map snd resolvedModules
-          tcResults = typecheckModulesWithEnv [] moduleAsts
+          (tcResults, _) =
+            typecheckModulesWithInterfaceConfig
+              (tcConfig (PackageId "aihc-prim"))
+              emptyTcInterface
+              moduleAsts
       if all tcModuleSuccess tcResults
         then do
           let allBindings = concatMap tcModuleBindings tcResults
@@ -514,6 +520,11 @@ buildBaseContext modules =
         else ioError (userError ("repl error: could not type-check bundled aihc-base Prelude: " <> unwords (concatMap (map show . tcModuleDiagnostics) tcResults)))
     ResolveResult {resolveErrors} ->
       ioError (userError ("repl error: could not resolve bundled aihc-base Prelude: " <> show resolveErrors))
+  where
+    modulePackage modu
+      | Syntax.moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
+          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
+      | otherwise = (unnamedPackage, modu)
 
 bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
 bindingImportedTerm binding =

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -160,7 +160,7 @@ loadReplSession maybeStoreRoot = do
       installedBindingTypes = maybe Map.empty interfaceBindingTypes installedInterface
   pure
     ReplSession
-      { replModuleExports = replBaseExports baseContext `Map.union` ensurePreludeMvpScope installedExports,
+      { replModuleExports = ensurePreludeMvpScope (unionModuleExports (replBaseExports baseContext) installedExports),
         replImportedTerms = mergeImportedTerms (replBaseImportedTerms baseContext) (ensurePreludeMvpTerms installedTerms),
         replBindingTypes =
           ensurePreludeMvpBindingTypes
@@ -257,11 +257,16 @@ handleBrowseCommand session rawModuleName
       pure (ReplContinue (Just "usage: :browse <module>"))
   | otherwise =
       pure . ReplContinue . Just $
-        case Map.lookup (ModuleKey unnamedPackage moduleName') (replModuleExports session) of
-          Nothing -> "unknown module: " <> rawModuleName
-          Just scope -> renderBrowseScope session moduleName' scope
+        case matchingScopes of
+          [scope] -> renderBrowseScope session moduleName' scope
+          _ -> "unknown module: " <> rawModuleName
   where
     moduleName' = T.pack rawModuleName
+    matchingScopes =
+      [ scope
+      | (moduleKey, scope) <- Map.toList (replModuleExports session),
+        moduleKeyName moduleKey == moduleName'
+      ]
 
 renderBrowseScope :: ReplSession -> Text -> Scope -> String
 renderBrowseScope session browsingModule scope =
@@ -485,15 +490,17 @@ loadAihcBaseContext = do
   primRoot <- defaultAihcPrimRoot
   modulesResult <-
     loadTransitiveModules
-      [("aihc-base", baseRoot), ("aihc-prim", primRoot)]
+      [ (Package "aihc-base" (PackageId "aihc-base"), baseRoot),
+        (Package "aihc-prim" (PackageId "aihc-prim"), primRoot)
+      ]
       (Set.singleton "Prelude")
   case modulesResult of
     Left err -> ioError (userError ("repl error: could not load bundled aihc-base Prelude: " <> err))
     Right modules -> buildBaseContext modules
 
-buildBaseContext :: [Module] -> IO ReplBaseContext
+buildBaseContext :: [(Package, Module)] -> IO ReplBaseContext
 buildBaseContext modules =
-  case resolveWithDeps Map.empty (map modulePackage modules) of
+  case resolveWithDeps Map.empty modules of
     resolved@ResolveResult {resolveErrors = [], resolvedModules} -> do
       let moduleAsts = map snd resolvedModules
           (tcResults, _) =
@@ -520,11 +527,6 @@ buildBaseContext modules =
         else ioError (userError ("repl error: could not type-check bundled aihc-base Prelude: " <> unwords (concatMap (map show . tcModuleDiagnostics) tcResults)))
     ResolveResult {resolveErrors} ->
       ioError (userError ("repl error: could not resolve bundled aihc-base Prelude: " <> show resolveErrors))
-  where
-    modulePackage modu
-      | Syntax.moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
-          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
-      | otherwise = (unnamedPackage, modu)
 
 bindingImportedTerm :: TcBindingResult -> (Text, TypeScheme)
 bindingImportedTerm binding =
@@ -533,6 +535,13 @@ bindingImportedTerm binding =
 mergeImportedTerms :: [(Text, TypeScheme)] -> [(Text, TypeScheme)] -> [(Text, TypeScheme)]
 mergeImportedTerms preferred fallback =
   Map.toList (Map.fromList fallback <> Map.fromList preferred)
+
+unionModuleExports :: ModuleExports -> ModuleExports -> ModuleExports
+unionModuleExports preferred fallback =
+  preferred `Map.union` Map.filterWithKey keepFallback fallback
+  where
+    preferredNames = Set.fromList (map moduleKeyName (Map.keys preferred))
+    keepFallback moduleKey _ = moduleKeyName moduleKey `Set.notMember` preferredNames
 
 unionBindingTypes :: Map.Map Text (Map.Map Text TcType) -> Map.Map Text (Map.Map Text TcType) -> Map.Map Text (Map.Map Text TcType)
 unionBindingTypes = Map.unionWith Map.union
@@ -614,7 +623,7 @@ defaultCoreLibraryRoot sourceEnv packageName = do
             then pure candidate
             else findUp parent
 
-loadTransitiveModules :: [(Text, FilePath)] -> Set.Set Text -> IO (Either String [Module])
+loadTransitiveModules :: [(Package, FilePath)] -> Set.Set Text -> IO (Either String [(Package, Module)])
 loadTransitiveModules packageRoots initialModules =
   fmap snd <$> go Set.empty [] (Set.toAscList initialModules)
   where
@@ -627,9 +636,9 @@ loadTransitiveModules packageRoots initialModules =
           maybePath <- findModulePathInDependencies packageRoots moduleName
           case maybePath of
             Nothing -> do
-              let dependencyNames = T.intercalate ", " (map fst packageRoots)
+              let dependencyNames = T.intercalate ", " (map (packageName . fst) packageRoots)
               pure (Left ("dependency module " <> T.unpack moduleName <> " not found in dependencies: " <> T.unpack dependencyNames))
-            Just path -> do
+            Just (package, path) -> do
               source <- Utf8.readFile path
               case parseOneModule path source of
                 Left errMsg -> pure (Left ("dependency module " <> T.unpack moduleName <> " parse error: " <> errMsg))
@@ -640,15 +649,15 @@ loadTransitiveModules packageRoots initialModules =
                   case depResult of
                     Left errMsg -> pure (Left errMsg)
                     Right (seenWithDeps, loadedWithDeps) ->
-                      go seenWithDeps (loadedWithDeps <> [modu]) pending
+                      go seenWithDeps (loadedWithDeps <> [(package, modu)]) pending
 
-findModulePathInDependencies :: [(Text, FilePath)] -> Text -> IO (Maybe FilePath)
+findModulePathInDependencies :: [(Package, FilePath)] -> Text -> IO (Maybe (Package, FilePath))
 findModulePathInDependencies [] _ = pure Nothing
-findModulePathInDependencies ((_dependency, root) : rest) moduleName = do
+findModulePathInDependencies ((package, root) : rest) moduleName = do
   let path = root </> "src" </> moduleNamePath moduleName
   exists <- doesFileExist path
   if exists
-    then pure (Just path)
+    then pure (Just (package, path))
     else findModulePathInDependencies rest moduleName
 
 moduleNamePath :: Text -> FilePath
@@ -828,21 +837,28 @@ ensurePreludeMvpScope :: ModuleExports -> ModuleExports
 ensurePreludeMvpScope exports =
   Map.insert preludeKey preludeScope exports
   where
-    preludeKey = ModuleKey unnamedPackage "Prelude"
+    preludeKey =
+      fromMaybe
+        (ModuleKey unnamedPackage "Prelude")
+        (find ((== "Prelude") . moduleKeyName) (Map.keys exports))
     existing = Map.findWithDefault emptyScope preludeKey exports
+    resolvePreludeName =
+      ResolvedTopLevel (packageId (moduleKeyPackage preludeKey))
+        . qualifyName (Just "Prelude")
+        . unqualifiedNameFromText
     preludeScope =
       existing
         { scopeTerms =
-            Map.fromList
-              [ ("++", resolvedTopLevel "Prelude" "++")
-              ]
-              <> scopeTerms existing,
+            scopeTerms existing
+              <> Map.fromList
+                [ ("++", resolvePreludeName "++")
+                ],
           scopeTypes =
-            Map.fromList
-              [ ("Char", resolvedTopLevel "Prelude" "Char"),
-                ("String", resolvedTopLevel "Prelude" "String")
-              ]
-              <> scopeTypes existing
+            scopeTypes existing
+              <> Map.fromList
+                [ ("Char", resolvePreludeName "Char"),
+                  ("String", resolvePreludeName "String")
+                ]
         }
 
 ensurePreludeMvpTerms :: [(Text, TypeScheme)] -> [(Text, TypeScheme)]

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -47,7 +47,7 @@ import Aihc.Fc
 import Aihc.Grin qualified as Grin
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Native (NativeTarget (..))
-import Aihc.Resolve (ModuleKey (..), Scope (..), unnamedPackage)
+import Aihc.Resolve (ModuleKey (..), Package (..), PackageId (..), Scope (..), unnamedPackage)
 import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
 import Control.Exception (bracket)
 import Data.Aeson (object, (.=))
@@ -323,6 +323,18 @@ main =
             session <- loadReplSession Nothing
             result <- evaluateExpression session "otherwise"
             assertEqual "result" (Right "True") result,
+          testCase "keeps bundled package identities" $ do
+            session <- loadReplSession Nothing
+            let exports = replModuleExports session
+            assertBool
+              "aihc-base Prelude"
+              (Map.member (ModuleKey (Package "aihc-base" (PackageId "aihc-base")) "Prelude") exports)
+            assertBool
+              "aihc-prim GHC.Types"
+              (Map.member (ModuleKey (Package "aihc-prim" (PackageId "aihc-prim")) "GHC.Types") exports)
+            assertBool
+              "no unnamed Prelude"
+              (Map.notMember (ModuleKey unnamedPackage "Prelude") exports),
           testCase "loads installed base interface for Prelude MVP scope" test_loadsInstalledBaseInterfaceForRepl
         ],
       testGroup
@@ -435,7 +447,7 @@ test_loadsInstalledBaseInterfaceForRepl =
           )
       )
     session <- loadReplSession (Just storeRoot)
-    case Map.lookup (ModuleKey unnamedPackage "Prelude") (replModuleExports session) of
+    case Map.lookup (ModuleKey (Package "aihc-base" (PackageId "aihc-base")) "Prelude") (replModuleExports session) of
       Nothing -> assertFailure "Prelude scope not loaded"
       Just preludeScope -> do
         assertBool "Prelude exposes Char" (Map.member "Char" (scopeTypes preludeScope))

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -25,7 +25,7 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
-import Aihc.Resolve (ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (PackageId (..), ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, TcInterface (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
@@ -163,7 +163,7 @@ renderFcCase tc =
                in if all tcModuleSuccess tcResults
                     then
                       let allBindings = moduleGroupBindings tcResults
-                          results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
+                          results = zipWith (desugarModuleWithDataTypes (PackageId "aihc-prim") allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
                           fixtureResults = drop supportModuleCount results
                        in if all dsSuccess results
                             then renderResults fixtureResults

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -102,7 +102,7 @@ desugarModule m =
     ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} ->
       case typecheckModulesWithInterface emptyTcInterface [resolved] of
         ([tcResult], tcInterface) ->
-          desugarModuleWithDataTypes (tcModuleBindings tcResult) (tcInterfaceDataTypes tcInterface) tcResult resolved
+          desugarModuleWithDataTypes (PackageId "aihc-prim") (tcModuleBindings tcResult) (tcInterfaceDataTypes tcInterface) tcResult resolved
         _ ->
           DesugarResult
             { dsProgram = FcProgram (sourceModuleId m) [],
@@ -119,15 +119,15 @@ desugarModule m =
 -- | Desugar a module using a type-checking result already computed by
 -- the caller. This is useful for clients such as the REPL that preload
 -- imported bindings into the type-checker environment.
-desugarModuleWithTcResult :: Module -> Module -> DesugarResult
-desugarModuleWithTcResult tcResult =
-  desugarModuleWithBindings (tcModuleBindings tcResult) tcResult
+desugarModuleWithTcResult :: PackageId -> Module -> Module -> DesugarResult
+desugarModuleWithTcResult primPackageId tcResult =
+  desugarModuleWithBindings primPackageId (tcModuleBindings tcResult) tcResult
 
-desugarModuleWithBindings :: [TcBindingResult] -> Module -> Module -> DesugarResult
-desugarModuleWithBindings bindings = desugarModuleWithDataTypes bindings []
+desugarModuleWithBindings :: PackageId -> [TcBindingResult] -> Module -> Module -> DesugarResult
+desugarModuleWithBindings primPackageId bindings = desugarModuleWithDataTypes primPackageId bindings []
 
-desugarModuleWithDataTypes :: [TcBindingResult] -> [DataTypeInfo] -> Module -> Module -> DesugarResult
-desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
+desugarModuleWithDataTypes :: PackageId -> [TcBindingResult] -> [DataTypeInfo] -> Module -> Module -> DesugarResult
+desugarModuleWithDataTypes primPackageId bindings dataTypes tcResult resolvedModule =
   if not (tcModuleSuccess tcResult)
     then
       DesugarResult
@@ -145,7 +145,7 @@ desugarModuleWithDataTypes bindings dataTypes tcResult resolvedModule =
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 packageName (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
+       in case runStateT (dsModule tcResult) (DsState 1000 primPackageId packageName (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram (sourceModuleId resolvedModule) [],

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
@@ -33,6 +33,7 @@ dsStockEqDictionaryPlan plan =
 
 dsStockEqDictionary :: TcDerivingPlan -> [Pred] -> DataTypeInfo -> [[EvTerm]] -> DsM (Var, FcExpr)
 dsStockEqDictionary plan context dataType fieldEvidence = do
+  eqTyCon <- stockEqTyCon plan
   contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] context
   genericMethodTypes <-
     mapM
@@ -50,10 +51,10 @@ dsStockEqDictionary plan context dataType fieldEvidence = do
   let dictionaryType =
         foldr
           TcForAllTy
-          (qualifyType context (TcTyCon (TyCon "Eq" 1) [targetType]))
+          (qualifyType context (TcTyCon eqTyCon [targetType]))
           (tcDerivingTyVars plan)
   dictVar <- freshVar (tcDerivingDictName plan) dictionaryType
-  let selfDictionaryType = TcTyCon (TyCon "Eq" 1) [targetType]
+  let selfDictionaryType = TcTyCon eqTyCon [targetType]
       selfDictionaryExpression =
         foldl
           FcApp
@@ -64,11 +65,11 @@ dsStockEqDictionary plan context dataType fieldEvidence = do
   methodFields <-
     withDicts (selfDictionary : contextDicts) $
       mapM
-        (dsStockEqMethod dataType constructors targetType)
+        (dsStockEqMethod eqTyCon dataType constructors targetType)
         (tcDerivingClassMethods plan)
   let classTyVars = tcDerivingClassTyVars plan
       dictionaryConstructor = fcDictionaryConstructorName "Eq"
-      genericDictionaryType = TcTyCon (TyCon "Eq" 1) (map TcTyVar classTyVars)
+      genericDictionaryType = TcTyCon eqTyCon (map TcTyVar classTyVars)
       constructorType = foldr TcForAllTy (foldr TcFunTy genericDictionaryType genericMethodTypes) classTyVars
   constructorVar <- freshVar dictionaryConstructor constructorType
   let constructor = foldl FcTyApp (FcVar constructorVar) (tcDerivingHeadTypes plan)
@@ -79,40 +80,40 @@ dsStockEqDictionary plan context dataType fieldEvidence = do
       body = foldr FcTyLam (foldr (FcLam . classDictVar) dictionary contextDicts) (tcDerivingTyVars plan)
   pure (dictVar, body)
 
-dsStockEqMethod :: DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> TcClassMethodAnnotation -> DsM FcExpr
-dsStockEqMethod dataType constructors targetType method =
+dsStockEqMethod :: TyCon -> DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> TcClassMethodAnnotation -> DsM FcExpr
+dsStockEqMethod eqTyCon dataType constructors targetType method =
   case tcClassMethodName method of
-    "==" -> dsEqualityMethod dataType constructors targetType
+    "==" -> dsEqualityMethod eqTyCon dataType constructors targetType
     "/=" -> do
       left <- freshVar "$stock_eq_left" targetType
       right <- freshVar "$stock_eq_right" targetType
-      equality <- equalityBody dataType constructors targetType left right
+      equality <- equalityBody eqTyCon dataType constructors targetType left right
       negated <- negateBoolean equality
       pure (FcLam left (FcLam right negated))
     name -> desugarBug ("unsupported method in stock Eq dictionary: " <> T.unpack name)
 
-dsEqualityMethod :: DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> DsM FcExpr
-dsEqualityMethod dataType constructors targetType = do
+dsEqualityMethod :: TyCon -> DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> DsM FcExpr
+dsEqualityMethod eqTyCon dataType constructors targetType = do
   left <- freshVar "$stock_eq_left" targetType
   right <- freshVar "$stock_eq_right" targetType
-  body <- equalityBody dataType constructors targetType left right
+  body <- equalityBody eqTyCon dataType constructors targetType left right
   pure (FcLam left (FcLam right body))
 
-equalityBody :: DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> Var -> Var -> DsM FcExpr
-equalityBody dataType constructors targetType left right = do
+equalityBody :: TyCon -> DataTypeInfo -> [(DataConInfo, [EvTerm])] -> TcType -> Var -> Var -> DsM FcExpr
+equalityBody eqTyCon dataType constructors targetType left right = do
   outerBinder <- freshVar "$stock_eq_outer" targetType
-  alternatives <- mapM (constructorEqualityAlternative dataType right targetType) constructors
+  alternatives <- mapM (constructorEqualityAlternative eqTyCon dataType right targetType) constructors
   pure (FcCase (FcVar left) outerBinder alternatives)
 
-constructorEqualityAlternative :: DataTypeInfo -> Var -> TcType -> (DataConInfo, [EvTerm]) -> DsM FcAlt
-constructorEqualityAlternative dataType right targetType (constructor, evidence) = do
+constructorEqualityAlternative :: TyCon -> DataTypeInfo -> Var -> TcType -> (DataConInfo, [EvTerm]) -> DsM FcAlt
+constructorEqualityAlternative eqTyCon dataType right targetType (constructor, evidence) = do
   fields <- instantiatedFields dataType targetType constructor
   fieldEvidence <- zipExact ("field evidence for " <> T.unpack (dciName constructor)) fields evidence
   leftFields <- zipWithM (fieldVar "$stock_eq_left_field") [0 :: Int ..] fields
   rightFields <- zipWithM (fieldVar "$stock_eq_right_field") [0 :: Int ..] fields
   comparisons <-
     zipWithM
-      (fieldEquality leftFields rightFields)
+      (fieldEquality eqTyCon leftFields rightFields)
       [0 :: Int ..]
       fieldEvidence
   equalFields <- andComparisons comparisons
@@ -140,14 +141,15 @@ instantiatedFields dataType targetType constructor =
 fieldVar :: Text -> Int -> DataConFieldInfo -> DsM Var
 fieldVar prefix index field = freshVar (prefix <> T.pack (show index)) (dcfiType field)
 
-fieldEquality :: [Var] -> [Var] -> Int -> (DataConFieldInfo, EvTerm) -> DsM FcExpr
-fieldEquality leftFields rightFields index (field, evidence) = do
+fieldEquality :: TyCon -> [Var] -> [Var] -> Int -> (DataConFieldInfo, EvTerm) -> DsM FcExpr
+fieldEquality eqTyCon leftFields rightFields index (field, evidence) = do
   left <- indexVar "left" index leftFields
   right <- indexVar "right" index rightFields
   dictionary <- dsEvidence evidence
+  boolTy <- boolType
   let fieldType = dcfiType field
-      methodType = TcFunTy fieldType (TcFunTy fieldType boolType)
-      dictionaryType = TcTyCon (TyCon "Eq" 1) [fieldType]
+      methodType = TcFunTy fieldType (TcFunTy fieldType boolTy)
+      dictionaryType = TcTyCon eqTyCon [fieldType]
   dictionaryBinder <- freshVar "$stock_eq_dictionary" dictionaryType
   equalityMethod <- freshVar "$stock_eq_method" methodType
   inequalityMethod <- freshVar "$stock_neq_method" methodType
@@ -173,7 +175,8 @@ andComparisons comparisons =
   case comparisons of
     [] -> boolConstructor "True"
     comparison : rest -> do
-      binder <- freshVar "$stock_eq_bool" boolType
+      boolTy <- boolType
+      binder <- freshVar "$stock_eq_bool" boolTy
       false <- boolConstructor "False"
       trueBranch <- andComparisons rest
       pure
@@ -187,7 +190,8 @@ andComparisons comparisons =
 
 negateBoolean :: FcExpr -> DsM FcExpr
 negateBoolean expression = do
-  binder <- freshVar "$stock_eq_not" boolType
+  boolTy <- boolType
+  binder <- freshVar "$stock_eq_not" boolTy
   true <- boolConstructor "True"
   false <- boolConstructor "False"
   pure
@@ -205,8 +209,17 @@ boolConstructor name = do
   constructor <- freshVar name constructorType
   pure (FcVar constructor)
 
-boolType :: TcType
-boolType = TcTyCon (TyCon "Bool" 0) []
+boolType :: DsM TcType
+boolType = lookupType "True"
+
+stockEqTyCon :: TcDerivingPlan -> DsM TyCon
+stockEqTyCon plan =
+  case tcDerivingClassMethods plan of
+    method : _ ->
+      case tcClassMethodDictType method of
+        TcTyCon tyCon [_] -> pure tyCon
+        ty -> desugarBug ("invalid stock Eq dictionary type: " <> show ty)
+    [] -> desugarBug "stock Eq has no class methods"
 
 mkPredicateDict :: Int -> Pred -> DsM ClassDict
 mkPredicateDict index predicate = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
@@ -7,7 +7,7 @@ module Aihc.Fc.Desugar.Deriving.StockEq
 where
 
 import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, predType)
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshVar, lookupType, withDicts)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshVar, lookupType, primBoolType, withDicts)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
 import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcStockDerivingPlan (..))
@@ -210,7 +210,7 @@ boolConstructor name = do
   pure (FcVar constructor)
 
 boolType :: DsM TcType
-boolType = lookupType "True"
+boolType = primBoolType
 
 stockEqTyCon :: TcDerivingPlan -> DsM TyCon
 stockEqTyCon plan =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -20,6 +20,7 @@ module Aihc.Fc.Desugar.Expr
     freshUnique,
     freshVar,
     lookupType,
+    primBoolType,
     withDicts,
   )
 where
@@ -60,7 +61,7 @@ import Aihc.Tc.Annotations (TcAnnotation (..))
 import Aihc.Tc.Env (DataConFieldInfo (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Kind (runtimeRepToTcType)
-import Aihc.Tc.Types (Kind (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), isLiftedType, liftedRuntimeRep, mkTyCon, runtimeRepOfType, setTyVarKind, tvKind, unboxedTupleTyConName)
+import Aihc.Tc.Types (Kind (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), isLiftedType, liftedRuntimeRep, mkTyCon, mkTyConWithOrigin, runtimeRepOfType, setTyVarKind, tvKind, unboxedTupleTyConName)
 import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
@@ -81,6 +82,7 @@ type DsM = StateT DsState (Either String)
 -- | Desugaring state.
 data DsState = DsState
   { dsNextUnique :: !Int,
+    dsPrimPackageId :: !PackageId,
     dsModulePackage :: !Text,
     dsModuleName :: !(Maybe Text),
     -- | Map from surface name to its inferred type (from TC).
@@ -131,6 +133,11 @@ lookupType name = do
     Nothing -> case Map.lookup name (dsTypeEnv st) of
       Just ty -> pure ty
       Nothing -> desugarBug ("missing type information for name: " <> T.unpack name)
+
+primBoolType :: DsM TcType
+primBoolType = do
+  primPackageId <- gets dsPrimPackageId
+  pure (TcTyCon (mkTyConWithOrigin primPackageId "GHC.Types" "Bool" 0 KType) [])
 
 -- | Look up a local variable binding.
 lookupLocal :: Text -> DsM (Maybe Var)
@@ -920,7 +927,7 @@ dsIf cond thenE elseE = do
   cond' <- dsExpr cond
   then' <- dsExpr thenE
   else' <- dsExpr elseE
-  boolTy <- lookupType "True"
+  boolTy <- primBoolType
   binder <- freshVar "_if" boolTy
   pure
     ( FcCase
@@ -1064,7 +1071,7 @@ dsOverloadedIntegerPatternMatch :: Var -> Pattern -> DsM FcExpr -> FcExpr -> DsM
 dsOverloadedIntegerPatternMatch scrutVar pat success failure = do
   test <- dsOverloadedIntegerPatternTest (FcVar scrutVar) pat
   trueBranch <- success
-  boolTy <- lookupType "True"
+  boolTy <- primBoolType
   binder <- freshVar "_case_guard" boolTy
   pure
     ( FcCase
@@ -1321,7 +1328,7 @@ dsCompGuard :: TcType -> Expr -> Expr -> [CompStmt] -> FcExpr -> DsM FcExpr
 dsCompGuard elemTy body guard rest tailExpr = do
   guard' <- dsExpr guard
   trueBranch <- dsCompQuals elemTy body rest tailExpr
-  boolTy <- lookupType "True"
+  boolTy <- primBoolType
   binder <- freshInternalVar "_lc_guard" boolTy
   pure
     ( FcCase

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -920,6 +920,7 @@ dsIf cond thenE elseE = do
   cond' <- dsExpr cond
   then' <- dsExpr thenE
   else' <- dsExpr elseE
+  boolTy <- lookupType "True"
   binder <- freshVar "_if" boolTy
   pure
     ( FcCase
@@ -1063,6 +1064,7 @@ dsOverloadedIntegerPatternMatch :: Var -> Pattern -> DsM FcExpr -> FcExpr -> DsM
 dsOverloadedIntegerPatternMatch scrutVar pat success failure = do
   test <- dsOverloadedIntegerPatternTest (FcVar scrutVar) pat
   trueBranch <- success
+  boolTy <- lookupType "True"
   binder <- freshVar "_case_guard" boolTy
   pure
     ( FcCase
@@ -1319,6 +1321,7 @@ dsCompGuard :: TcType -> Expr -> Expr -> [CompStmt] -> FcExpr -> DsM FcExpr
 dsCompGuard elemTy body guard rest tailExpr = do
   guard' <- dsExpr guard
   trueBranch <- dsCompQuals elemTy body rest tailExpr
+  boolTy <- lookupType "True"
   binder <- freshInternalVar "_lc_guard" boolTy
   pure
     ( FcCase
@@ -1889,9 +1892,6 @@ typeKey ty =
     TcFunTy a b -> typeKey a <> "->" <> typeKey b
     TcForAllTy _ body -> typeKey body
     TcQualTy _ body -> typeKey body
-
-boolTy :: TcType
-boolTy = TcTyCon (TyCon "Bool" 0) []
 
 charTy :: TcType
 charTy = TcTyCon (TyCon "Char" 0) []

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -159,8 +159,14 @@ canonicalProgramBinds (FcProgram moduleId topBinds) =
             varName var `Set.member` definedNames,
             Just origin <- [varResolvedName var]
           ]
+    localBuiltinOrigins =
+      Set.fromList
+        [ origin
+        | FcPrimitive var _ <- definitions,
+          Just origin@FcBuiltinOrigin {} <- [varResolvedName var]
+        ]
     originIsLocal origin@(FcTopLevelOrigin packageName moduleName _) = origin `Set.member` localOrigins || Just (packageName, moduleName) == moduleOrigin
-    originIsLocal origin@FcBuiltinOrigin {} = origin `Set.member` localOrigins
+    originIsLocal origin@FcBuiltinOrigin {} = origin `Set.member` localBuiltinOrigins
     isHeader FcExternal {} = True
     isHeader _ = False
 

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -136,7 +136,7 @@ renderSymbols moduleId topBinds =
 
 renderModuleOrigin :: T.Text -> T.Text -> String
 renderModuleOrigin packageName moduleName =
-  (if packageName == "" then "" else show (T.unpack packageName) <> " ") <> T.unpack moduleName
+  (if packageName `elem` ["", "main"] then "" else show (T.unpack packageName) <> " ") <> T.unpack moduleName
 
 canonicalProgramBinds :: FcProgram -> [FcTopBind]
 canonicalProgramBinds (FcProgram moduleId topBinds) =
@@ -433,7 +433,7 @@ renderOrigin :: FcSymbolOrigin -> String
 renderOrigin origin =
   case origin of
     FcTopLevelOrigin packageName moduleName symbolName ->
-      (if packageName == "" then "" else show (T.unpack packageName) <> " ")
+      (if packageName `elem` ["", "main"] then "" else show (T.unpack packageName) <> " ")
         <> T.unpack moduleName
         <> "."
         <> T.unpack symbolName

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -56,6 +56,7 @@ module Aihc.Fc.Syntax
   )
 where
 
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Evidence (Coercion)
 import Aihc.Tc.Types
   ( Kind (..),
@@ -66,6 +67,7 @@ import Aihc.Tc.Types
     Unique (..),
     liftedRuntimeRep,
     mkTyCon,
+    mkTyConWithOrigin,
     runtimeRepOfType,
     setTyVarKind,
     tvKind,
@@ -133,10 +135,21 @@ data FcDataDecl = FcDataDecl
 
 fcDataTyCon :: FcDataDecl -> TyCon
 fcDataTyCon declaration =
-  mkTyCon
-    (fcDataName declaration)
-    (length (fcDataTyVars declaration))
-    (foldr (KFun . tvKind) (fcDataResultKind declaration) (fcDataTyVars declaration))
+  case fcDataOrigin declaration of
+    FcTopLevelOrigin packageId moduleName _ ->
+      mkTyConWithOrigin
+        (PackageId packageId)
+        moduleName
+        (fcDataName declaration)
+        (length (fcDataTyVars declaration))
+        kind
+    FcBuiltinOrigin {} ->
+      mkTyCon
+        (fcDataName declaration)
+        (length (fcDataTyVars declaration))
+        kind
+  where
+    kind = foldr (KFun . tvKind) (fcDataResultKind declaration) (fcDataTyVars declaration)
 
 fcDataKindTyVars :: FcDataDecl -> [TyVarId]
 fcDataKindTyVars declaration =

--- a/components/aihc-fc/test/Test/Fc/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc/Properties.hs
@@ -43,6 +43,7 @@ fcPropertyTests =
       testProperty "dependent runtime representations use their binder" prop_dependentRuntimeRep,
       testProperty "package origins distinguish equal symbol names" prop_packageOrigins,
       testProperty "external signatures occur once" prop_externalSignatures,
+      testProperty "non-primitive bindings do not define built-in symbols" prop_nonPrimitiveBuiltinOrigin,
       testProperty "local definition signatures serve local occurrences" prop_localSignatures,
       testProperty "undeclared external occurrences are rejected" prop_undeclaredExternal,
       testProperty "duplicate external declarations are rejected" prop_duplicateExternal
@@ -109,6 +110,18 @@ prop_externalSignatures = property $ do
   roundTrip renderProgram parseProgram program
   where
     typeVariable = setTyVarKind (KTYPE liftedRuntimeRep) (TyVarId "a" (Unique 3))
+
+prop_nonPrimitiveBuiltinOrigin :: Property
+prop_nonPrimitiveBuiltinOrigin = property $ do
+  let ty = TcTyCon (TyCon "Int" 0) []
+      origin = FcBuiltinOrigin "value"
+      binder = (Var "local" (Unique 1) ty) {varResolvedName = Just origin}
+      occurrence = (Var "external" (Unique 2) ty) {varResolvedName = Just origin}
+      program = FcProgram (FcModuleId "test" "Test") [FcTopBind (FcRec [(binder, FcVar occurrence)])]
+      rendered = T.pack (renderProgram program)
+  annotate (T.unpack rendered)
+  T.count "external builtin.value" rendered === 1
+  roundTrip renderProgram parseProgram program
 
 prop_undeclaredExternal :: Property
 prop_undeclaredExternal = property $ do

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -371,8 +371,15 @@ fcOptimizationTests =
           (FcProgram (FcModuleId "test" "Test") [FcTopBind (FcNonRec mainVar (FcLam local (FcVar local)))])
           (eliminateDeadCode "main" program),
       testCase "retains ordinary dictionary constructor declarations" $ do
-        let dictionaryTy = ty "Test"
-            dictionaryData = fcData "Test" [] [("$Dict$Test", [stringTy])]
+        let dictionaryDeclaration =
+              FcDataDecl
+                (FcTopLevelOrigin "test" "Test" "Test")
+                "Test"
+                []
+                KType
+                [FcDataConDecl (FcTopLevelOrigin "test" "Test" "$Dict$Test") "$Dict$Test" [stringTy]]
+            dictionaryTy = fcDataResultType dictionaryDeclaration
+            dictionaryData = FcData dictionaryDeclaration
             dictionaryConstructor = Var "$Dict$Test" (Unique 14) (TcFunTy stringTy dictionaryTy)
             dictionaryBinder = Var "$dictionary" (Unique 15) dictionaryTy
             methodBinder = Var "$method" (Unique 16) stringTy

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -14,12 +14,15 @@ module Test.Fc.Suite
 where
 
 import Aihc.Fc
+import Aihc.Fc qualified as Fc
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax qualified as Surface
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc (Kind (KType), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Aihc.Tc.Evidence (Coercion (..))
+import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Data.List (find)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -69,7 +72,25 @@ fcDesugarTests =
             result = desugarModule parsedModule
         assertEqual "source parses" [] parseErrors
         assertBool ("desugaring succeeds: " <> show (dsErrors result)) (dsSuccess result)
-        assertEqual "Core lint" [] (lintProgram emptyLintEnv (dsProgram result))
+        assertEqual "Core lint" [] (lintProgram emptyLintEnv (dsProgram result)),
+      testCase "uses the aihc-prim Bool type for if binders" $ do
+        let source =
+              "module Test where\n\
+              \data Bool = False | True\n\
+              \value = if True then True else False\n"
+            (parseErrors, parsedModule) = parseModule defaultConfig source
+            result = desugarModule parsedModule
+            ifBinderTypes =
+              [ varType binder
+              | FcTopBind (FcNonRec _ (Fc.FcCase _ binder _)) <- fcTopBinds (dsProgram result)
+              ]
+        assertEqual "source parses" [] parseErrors
+        assertBool ("desugaring succeeds: " <> show (dsErrors result)) (dsSuccess result)
+        case ifBinderTypes of
+          [TcTyCon tyCon []] -> do
+            assertEqual "package ID" (PackageId "aihc-prim") (tyConPackageId tyCon)
+            assertEqual "module name" "GHC.Types" (tyConModuleName tyCon)
+          other -> assertFailure ("expected one Bool case binder, got: " <> show other)
     ]
   where
     declarationConstructors declaration =

--- a/components/aihc-grin/test/GrinGolden.hs
+++ b/components/aihc-grin/test/GrinGolden.hs
@@ -14,7 +14,7 @@ import Aihc.Fc (DesugarResult (..), desugarModuleWithBindings)
 import Aihc.Grin (lintProgram, lowerProgram, renderProgram)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
-import Aihc.Resolve (ResolveResult (..), resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheck)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withObject)
@@ -117,7 +117,7 @@ evaluateGrinCase fixture =
            in if all tcModuleSuccess tcResults
                 then
                   let allBindings = moduleGroupBindings tcResults
-                      desugared = zipWith (desugarModuleWithBindings allBindings) tcResults moduleAsts
+                      desugared = zipWith (desugarModuleWithBindings (PackageId "aihc-prim") allBindings) tcResults moduleAsts
                    in if all dsSuccess desugared
                         then
                           let programs = map (lowerProgram . dsProgram) desugared

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -246,7 +246,7 @@ renderConciseOrigin :: ResolvedName -> Text
 renderConciseOrigin resolvedName =
   case resolvedName of
     ResolvedTopLevel identity name
-      | packageIdText identity == "" -> fromMaybe (renderName name) (nameQualifier name)
+      | packageIdText identity `elem` ["", "main"] -> fromMaybe (renderName name) (nameQualifier name)
       | otherwise -> packageIdText identity <> ":" <> fromMaybe (renderName name) (nameQualifier name)
     ResolvedLocal uniqueId _ -> T.pack (show uniqueId)
     ResolvedBuiltin name -> "Builtin " <> name

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -49,7 +49,7 @@ data Package = Package
   deriving (Eq, Ord, Show)
 
 unnamedPackage :: Package
-unnamedPackage = Package "" (PackageId "")
+unnamedPackage = Package "" (PackageId "main")
 
 modulesInPackage :: Package -> [Module] -> [(Package, Module)]
 modulesInPackage package = map pairWithPackage

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -39,7 +39,7 @@ import Data.Text (Text)
 
 -- | An opaque identity for one installed package instance.
 newtype PackageId = PackageId {packageIdText :: Text}
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | The user-visible package name used in imports and its opaque identity.
 data Package = Package

--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -23,9 +23,10 @@ import Aihc.Parser
   )
 import Aihc.Parser.Syntax
   ( Extension,
+    moduleName,
     parseExtensionName,
   )
-import Aihc.Resolve (ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (typecheck)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
@@ -135,7 +136,7 @@ evaluateTcAnnotatedCase tc =
    in case sequence parsedModules of
         Left errMsg -> classifyFailure tc ("parse error: " <> errMsg)
         Right modules ->
-          case resolveWithDeps mempty (modulesInPackage unnamedPackage modules) of
+          case resolveWithDeps mempty (map modulePackage modules) of
             ResolveResult {resolvedModules, resolveErrors = []} ->
               let results = typecheck (map snd resolvedModules)
                   actual = renderAnnotatedTcResults (caseModules tc) results
@@ -143,6 +144,10 @@ evaluateTcAnnotatedCase tc =
             ResolveResult {resolveErrors} ->
               classifyFailure tc ("resolve error: " <> show resolveErrors)
   where
+    modulePackage modu
+      | moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
+          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
+      | otherwise = (unnamedPackage, modu)
     parseOne input =
       let config =
             defaultConfig

--- a/components/aihc-tc/common/TcAnnotatedRender.hs
+++ b/components/aihc-tc/common/TcAnnotatedRender.hs
@@ -13,7 +13,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     moduleName,
   )
-import Aihc.Tc (TcType (..), renderTcSignature, renderTcType)
+import Aihc.Tc (TcType (..), renderTcSignature, renderTcType, renderTcTypeInModule)
 import Aihc.Tc.Annotations
   ( TcAnnotation (..),
     TcClassAnnotation (..),
@@ -44,15 +44,18 @@ renderAnnotatedTcResults sources results =
     GT -> error "renderAnnotatedTcResults: more source texts than modules"
     EQ ->
       let moduleSources = sortOn (moduleDisplayName . snd) (zip sources results)
-       in renderAnnotatedModuleSources renderTcAnnotation (map fst moduleSources) (map snd moduleSources)
+       in concatMap renderModule moduleSources
+  where
+    renderModule (source, modu) =
+      renderAnnotatedModuleSources (renderTcAnnotation (moduleName modu)) [source] [modu]
 
 moduleDisplayName :: Module -> Text
 moduleDisplayName modu = fromMaybe "<unnamed>" (moduleName modu)
 
-renderTcAnnotation :: Annotation -> Maybe (Doc ann)
-renderTcAnnotation annotation =
+renderTcAnnotation :: Maybe Text -> Annotation -> Maybe (Doc ann)
+renderTcAnnotation currentModule annotation =
   pretty
-    <$> ( renderTypeAnnotation <$> fromAnnotation @TcAnnotation annotation
+    <$> ( renderTypeAnnotation currentModule <$> fromAnnotation @TcAnnotation annotation
             <|> renderClassAnnotation <$> fromAnnotation @TcClassAnnotation annotation
             <|> renderDerivingAnnotation <$> fromAnnotation @TcDerivingAnnotation annotation
             <|> renderInstanceAnnotation <$> fromAnnotation @TcInstanceAnnotation annotation
@@ -60,9 +63,9 @@ renderTcAnnotation annotation =
             <|> renderDiagnostic <$> fromAnnotation @TcDiagnostic annotation
         )
 
-renderTypeAnnotation :: TcAnnotation -> String
-renderTypeAnnotation ann =
-  intercalate "; " ("type: " <> renderTcType (tcAnnType ann) : renderElaboration ann)
+renderTypeAnnotation :: Maybe Text -> TcAnnotation -> String
+renderTypeAnnotation currentModule ann =
+  intercalate "; " ("type: " <> renderTcTypeInModule currentModule (tcAnnType ann) : renderElaboration ann)
 
 renderClassAnnotation :: TcClassAnnotation -> String
 renderClassAnnotation classAnnotation =

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -31,6 +31,8 @@ module Aihc.Tc
     -- * Result types
     TcResult (..),
     TcBindingResult (..),
+    TcTermKey (..),
+    tcTermKeyIdentifier,
     TcInterface (..),
     emptyTcInterface,
 
@@ -128,6 +130,7 @@ import Aihc.Tc.Zonk (zonkType)
 import Control.Applicative ((<|>))
 import Control.Monad ((<=<))
 import Control.Monad.Trans.State.Strict (State, get, put, runState)
+import Data.Bifunctor qualified as Bifunctor
 import Data.Data (Data, gmapM, gmapQ)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, maybeToList)
@@ -149,7 +152,7 @@ data TcResult = TcResult
 -- module groups. Implementations never cross this boundary: only the facts
 -- needed to type-check downstream source are retained.
 data TcInterface = TcInterface
-  { tcInterfaceTerms :: ![(Text, TypeScheme)],
+  { tcInterfaceTerms :: ![(TcTermKey, TypeScheme)],
     tcInterfaceTyCons :: ![TyConInfo],
     tcInterfaceDataTypes :: ![DataTypeInfo],
     tcInterfaceClasses :: ![ClassInfo],
@@ -185,6 +188,24 @@ instance Monoid TcInterface where
 
 mergeInterfaceEntries :: (Ord key) => (value -> key) -> [value] -> [value]
 mergeInterfaceEntries key = Map.elems . Map.fromList . map (\value -> (key value, value))
+
+tcTermKeyIdentifier :: TcTermKey -> Maybe Text
+tcTermKeyIdentifier key =
+  case key of
+    TcTermLocal {} -> Nothing
+    TcTermGlobal _ _ identifier -> Just identifier
+
+importedTermEntries :: [(Text, TypeScheme)] -> [(TcTermKey, TypeScheme)]
+importedTermEntries = map (Bifunctor.first unqualifiedTermKey)
+
+exportedTermEntries :: TcInterface -> [(Text, TypeScheme)]
+exportedTermEntries interface =
+  Map.toList $
+    Map.fromList
+      [ (name, scheme)
+      | (key, scheme) <- tcInterfaceTerms interface,
+        Just name <- [tcTermKeyIdentifier key]
+      ]
 
 -- | Type-check a single expression in an empty environment.
 --
@@ -279,7 +300,7 @@ typecheckModulesWithEnvAndInstances importedTerms importedInstances =
   fst
     . typecheckModulesWithInterface
       emptyTcInterface
-        { tcInterfaceTerms = importedTerms,
+        { tcInterfaceTerms = importedTermEntries importedTerms,
           tcInterfaceInstances = importedInstances
         }
 
@@ -291,19 +312,19 @@ typecheckModulesWithFullEnv importedTerms importedTyCons importedInstances modul
   let (checkedModules, interface) =
         typecheckModulesWithInterface
           emptyTcInterface
-            { tcInterfaceTerms = importedTerms,
+            { tcInterfaceTerms = importedTermEntries importedTerms,
               tcInterfaceTyCons = importedTyCons,
               tcInterfaceInstances = importedInstances
             }
           modules
-   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface)
+   in (checkedModules, exportedTermEntries interface, tcInterfaceTyCons interface)
 
 typecheckModulesWithClassEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo], [ClassInfo])
 typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses importedInstances modules =
   let (checkedModules, interface) =
         typecheckModulesWithInterface
           TcInterface
-            { tcInterfaceTerms = importedTerms,
+            { tcInterfaceTerms = importedTermEntries importedTerms,
               tcInterfaceTyCons = importedTyCons,
               tcInterfaceDataTypes = [],
               tcInterfaceClasses = importedClasses,
@@ -311,7 +332,7 @@ typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses import
               tcInterfaceDataFamilyInstances = []
             }
           modules
-   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
+   in (checkedModules, exportedTermEntries interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
 
 -- | Type-check dependency-ordered modules with a complete imported semantic
 -- interface and return the accumulated interface for downstream modules.
@@ -334,19 +355,19 @@ typecheckModuleSccWithFullEnv importedTerms importedTyCons importedInstances mod
   let (checkedModules, interface) =
         typecheckModuleSccWithInterface
           emptyTcInterface
-            { tcInterfaceTerms = importedTerms,
+            { tcInterfaceTerms = importedTermEntries importedTerms,
               tcInterfaceTyCons = importedTyCons,
               tcInterfaceInstances = importedInstances
             }
           modules
-   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface)
+   in (checkedModules, exportedTermEntries interface, tcInterfaceTyCons interface)
 
 typecheckModuleSccWithClassEnv :: [(Text, TypeScheme)] -> [TyConInfo] -> [ClassInfo] -> [InstanceInfo] -> [Module] -> ([Module], [(Text, TypeScheme)], [TyConInfo], [ClassInfo])
 typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses importedInstances modules =
   let (checkedModules, interface) =
         typecheckModuleSccWithInterface
           TcInterface
-            { tcInterfaceTerms = importedTerms,
+            { tcInterfaceTerms = importedTermEntries importedTerms,
               tcInterfaceTyCons = importedTyCons,
               tcInterfaceDataTypes = [],
               tcInterfaceClasses = importedClasses,
@@ -354,7 +375,7 @@ typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses impo
               tcInterfaceDataFamilyInstances = []
             }
           modules
-   in (checkedModules, tcInterfaceTerms interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
+   in (checkedModules, exportedTermEntries interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
 
 -- | Type-check one strongly connected module component using only the
 -- supplied imported interface.
@@ -368,8 +389,8 @@ initialTcState imported =
   initTcState
     { tcsGlobalTerms =
         Map.fromList
-          [ (name, TcIdBinder scheme Closed)
-          | (name, scheme) <- tcInterfaceTerms imported
+          [ (key, TcIdBinder scheme Closed)
+          | (key, scheme) <- tcInterfaceTerms imported
           ]
           <> tcsGlobalTerms initTcState,
       tcsGlobalTyCons =
@@ -388,8 +409,8 @@ tcInterfaceFromState :: TcState -> TcInterface
 tcInterfaceFromState state =
   TcInterface
     { tcInterfaceTerms =
-        [ (name, scheme)
-        | (name, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms state)
+        [ (key, scheme)
+        | (key, TcIdBinder scheme _) <- Map.toList (tcsGlobalTerms state)
         ],
       tcInterfaceTyCons = Map.elems (tcsGlobalTyCons state),
       tcInterfaceDataTypes = Map.elems (tcsDataTypes state),

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -16,6 +16,7 @@ module Aihc.Tc
   ( -- * Entry point
     typecheck,
     typecheckExpr,
+    typecheckExprWithConfig,
     typecheckModule,
     typecheckModuleWithEnv,
     typecheckModuleWithEnvAndInstances,
@@ -26,10 +27,14 @@ module Aihc.Tc
     typecheckModulesWithClassEnv,
     typecheckModuleSccWithClassEnv,
     typecheckModulesWithInterface,
+    typecheckModulesWithInterfaceConfig,
     typecheckModuleSccWithInterface,
+    typecheckModuleSccWithInterfaceConfig,
 
     -- * Result types
     TcResult (..),
+    TcConfig,
+    tcConfig,
     TcBindingResult (..),
     TcTermKey (..),
     tcTermKeyIdentifier,
@@ -118,6 +123,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..), renderPred, renderTcSignature, renderTcType, renderTcTypeInModule)
 import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), dataConArgTypes, dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
@@ -135,6 +141,7 @@ import Data.Data (Data, gmapM, gmapQ)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Typeable (cast)
 
 -- | Result of type checking.
@@ -212,8 +219,11 @@ exportedTermEntries interface =
 -- This is the primary entry point for testing. For full module
 -- type-checking, use 'typecheck'.
 typecheckExpr :: Expr -> TcResult
-typecheckExpr expr =
-  case runTcM emptyTcEnv initTcState (typecheckExprM expr) of
+typecheckExpr = typecheckExprWithConfig defaultTcConfig
+
+typecheckExprWithConfig :: TcConfig -> Expr -> TcResult
+typecheckExprWithConfig config expr =
+  case runTcM emptyTcEnv {tcEnvConfig = config} initTcState (typecheckExprM expr) of
     Left _abort ->
       TcResult
         { tcResultType = TcMetaTv (Unique (-1)),
@@ -270,13 +280,11 @@ tcModuleSuccess =
 -- | Type-check a single module, processing data declarations and
 -- value bindings.
 typecheckModule :: Module -> Module
-typecheckModule =
-  typecheckModuleWithEnv []
+typecheckModule = typecheckModuleWithEnv []
 
 -- | Type-check a single module with preloaded top-level term bindings.
 typecheckModuleWithEnv :: [(Text, TypeScheme)] -> Module -> Module
-typecheckModuleWithEnv importedTerms =
-  typecheckModuleWithEnvAndInstances importedTerms []
+typecheckModuleWithEnv importedTerms = typecheckModuleWithEnvAndInstances importedTerms []
 
 -- | Type-check a single module with preloaded terms and class instances.
 typecheckModuleWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> Module -> Module
@@ -291,8 +299,7 @@ typecheckModuleWithEnvAndInstances importedTerms importedInstances m =
 -- resolved a dependency-ordered module list can feed it here so later modules
 -- see earlier data constructors and value bindings.
 typecheckModulesWithEnv :: [(Text, TypeScheme)] -> [Module] -> [Module]
-typecheckModulesWithEnv importedTerms =
-  typecheckModulesWithEnvAndInstances importedTerms []
+typecheckModulesWithEnv importedTerms = typecheckModulesWithEnvAndInstances importedTerms []
 
 -- | Type-check modules in order with preloaded terms and class instances.
 typecheckModulesWithEnvAndInstances :: [(Text, TypeScheme)] -> [InstanceInfo] -> [Module] -> [Module]
@@ -337,13 +344,16 @@ typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses import
 -- | Type-check dependency-ordered modules with a complete imported semantic
 -- interface and return the accumulated interface for downstream modules.
 typecheckModulesWithInterface :: TcInterface -> [Module] -> ([Module], TcInterface)
-typecheckModulesWithInterface imported modules =
+typecheckModulesWithInterface = typecheckModulesWithInterfaceConfig defaultTcConfig
+
+typecheckModulesWithInterfaceConfig :: TcConfig -> TcInterface -> [Module] -> ([Module], TcInterface)
+typecheckModulesWithInterfaceConfig config imported modules =
   let (checkedModules, finalState) = go (initialTcState imported) modules
    in (checkedModules, tcInterfaceFromState finalState)
   where
     go st [] = ([], st)
     go st (m : ms) =
-      let (result, st') = typecheckModuleWithState st m
+      let (result, st') = typecheckModuleWithState config st m
           (results, finalState) = go st' ms
        in (result : results, finalState)
 
@@ -380,8 +390,11 @@ typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses impo
 -- | Type-check one strongly connected module component using only the
 -- supplied imported interface.
 typecheckModuleSccWithInterface :: TcInterface -> [Module] -> ([Module], TcInterface)
-typecheckModuleSccWithInterface imported modules =
-  let (checkedModules, finalState) = typecheckModuleSccWithState (initialTcState imported) modules
+typecheckModuleSccWithInterface = typecheckModuleSccWithInterfaceConfig defaultTcConfig
+
+typecheckModuleSccWithInterfaceConfig :: TcConfig -> TcInterface -> [Module] -> ([Module], TcInterface)
+typecheckModuleSccWithInterfaceConfig config imported modules =
+  let (checkedModules, finalState) = typecheckModuleSccWithState config (initialTcState imported) modules
    in (checkedModules, tcInterfaceFromState finalState)
 
 initialTcState :: TcInterface -> TcState
@@ -419,8 +432,8 @@ tcInterfaceFromState state =
       tcInterfaceDataFamilyInstances = mergeInterfaceEntries dfiiAxiomName (tcsDataFamilyInstances state)
     }
 
-typecheckModuleSccWithState :: TcState -> [Module] -> ([Module], TcState)
-typecheckModuleSccWithState st modules =
+typecheckModuleSccWithState :: TcConfig -> TcState -> [Module] -> ([Module], TcState)
+typecheckModuleSccWithState config st modules =
   case runTcM tcEnv (st {tcsDiagnostics = []}) (tcModuleScc modules) of
     Left abort ->
       ( case modules of
@@ -442,7 +455,8 @@ typecheckModuleSccWithState st modules =
   where
     tcEnv =
       emptyTcEnv
-        { tcEnvMonoLocalBinds = any (elem MonoLocalBinds . moduleExtensions) modules,
+        { tcEnvConfig = config,
+          tcEnvMonoLocalBinds = any (elem MonoLocalBinds . moduleExtensions) modules,
           tcEnvMonomorphismRestriction = any (elem MonomorphismRestriction . moduleExtensions) modules
         }
     moduleExtensions m =
@@ -469,8 +483,8 @@ moduleSourceNames modu =
     SourceSpan {sourceSpanSourceName = sourceName} -> [sourceName]
     NoSourceSpan -> []
 
-typecheckModuleWithState :: TcState -> Module -> (Module, TcState)
-typecheckModuleWithState st m =
+typecheckModuleWithState :: TcConfig -> TcState -> Module -> (Module, TcState)
+typecheckModuleWithState config st m =
   case runTcM tcEnv (st {tcsDiagnostics = []}) (tcModule m) of
     Left abort ->
       ( annotateModuleDiagnostics [internalAbortDiagnostic (tcAbortMessage abort)] m,
@@ -490,7 +504,8 @@ typecheckModuleWithState st m =
   where
     tcEnv =
       emptyTcEnv
-        { tcEnvMonoLocalBinds = MonoLocalBinds `elem` enabledExtensions,
+        { tcEnvConfig = config,
+          tcEnvMonoLocalBinds = MonoLocalBinds `elem` enabledExtensions,
           tcEnvMonomorphismRestriction = MonomorphismRestriction `elem` enabledExtensions
         }
     enabledExtensions =
@@ -500,6 +515,9 @@ typecheckModuleWithState st m =
 -- | Type-check a list of modules.
 typecheck :: [Module] -> [Module]
 typecheck = typecheckModulesWithEnv []
+
+defaultTcConfig :: TcConfig
+defaultTcConfig = tcConfig (PackageId (T.pack "aihc-prim"))
 
 annotateModuleDiagnostics :: [TcDiagnostic] -> Module -> Module
 annotateModuleDiagnostics diagnostics m =

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -87,6 +87,7 @@ module Aihc.Tc
     renderPred,
     renderTcSignature,
     renderTcType,
+    renderTcTypeInModule,
   )
 where
 
@@ -115,7 +116,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
-import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..), renderPred, renderTcSignature, renderTcType)
+import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..), renderPred, renderTcSignature, renderTcType, renderTcTypeInModule)
 import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), dataConArgTypes, dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tcModule, tcModuleScc)
@@ -172,7 +173,7 @@ instance Semigroup TcInterface where
   left <> right =
     TcInterface
       { tcInterfaceTerms = mergeInterfaceEntries fst (tcInterfaceTerms left <> tcInterfaceTerms right),
-        tcInterfaceTyCons = mergeInterfaceEntries tciName (tcInterfaceTyCons left <> tcInterfaceTyCons right),
+        tcInterfaceTyCons = mergeInterfaceEntries tciTyCon (tcInterfaceTyCons left <> tcInterfaceTyCons right),
         tcInterfaceDataTypes = mergeInterfaceEntries dtiName (tcInterfaceDataTypes left <> tcInterfaceDataTypes right),
         tcInterfaceClasses = mergeInterfaceEntries ciName (tcInterfaceClasses left <> tcInterfaceClasses right),
         tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcInterfaceInstances left <> tcInterfaceInstances right),
@@ -373,7 +374,7 @@ initialTcState imported =
           <> tcsGlobalTerms initTcState,
       tcsGlobalTyCons =
         Map.fromList
-          [ (tciName tyCon, tyCon)
+          [ (tciTyCon tyCon, tyCon)
           | tyCon <- tcInterfaceTyCons imported
           ]
           <> tcsGlobalTyCons initTcState,

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -40,6 +40,7 @@ module Aihc.Tc.Annotations
     -- * Pretty-printing
     renderPred,
     renderTcType,
+    renderTcTypeInModule,
     renderTcSignature,
   )
 where
@@ -55,7 +56,7 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Tc.Env (DataTypeInfo)
 import Aihc.Tc.Evidence (EvTerm, EvVar)
-import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType)
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType, tyConModuleName)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -285,7 +286,10 @@ renderPred pred' =
 --   1 = parens needed for function types (left of ->)
 --   2 = parens needed for function types and type applications (inside type con args)
 renderTcType :: TcType -> String
-renderTcType = go 0
+renderTcType = renderTcTypeInModule Nothing
+
+renderTcTypeInModule :: Maybe Text -> TcType -> String
+renderTcTypeInModule currentModule = go 0
   where
     go :: Int -> TcType -> String
     go _ (TcTyVar tv) = T.unpack (tvName tv)
@@ -299,10 +303,10 @@ renderTcType = go 0
     go _ tupleType@(TcTyCon _ args)
       | isUnboxedTupleType tupleType =
           "(# " ++ commaSep (map (go 0) args) ++ " #)"
-    go _ (TcTyCon tc []) = T.unpack (tyConName tc)
+    go _ (TcTyCon tc []) = T.unpack (renderTyConName tc)
     go p (TcTyCon tc args) =
       parenIf (p >= 2) $
-        unwords (T.unpack (tyConName tc) : map (go 2) args)
+        unwords (T.unpack (renderTyConName tc) : map (go 2) args)
     go p (TcFunTy a b) =
       parenIf (p >= 1) $
         go 1 a ++ " → " ++ go 0 b
@@ -329,6 +333,14 @@ renderTcType = go 0
 
     isBoxedTupleCon name arity =
       arity /= 1 && name == boxedTupleTyConName arity
+
+    renderTyConName tyCon
+      | T.null definingModule = tyConName tyCon
+      | Nothing <- currentModule = tyConName tyCon
+      | Just definingModule == currentModule = tyConName tyCon
+      | otherwise = definingModule <> T.pack "." <> tyConName tyCon
+      where
+        definingModule = tyConModuleName tyCon
 
 -- | Collect nested forall binders into a list.
 collectForAlls :: TcType -> ([TyVarId], TcType)

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -335,7 +335,7 @@ renderTcTypeInModule currentModule = go 0
       arity /= 1 && name == boxedTupleTyConName arity
 
     renderTyConName tyCon
-      | T.null definingModule = tyConName tyCon
+      | definingModule `elem` map T.pack ["Aihc.Internal", "GHC.Prim", "GHC.Tuple", "GHC.Types"] = tyConName tyCon
       | Nothing <- currentModule = tyConName tyCon
       | Just definingModule == currentModule = tyConName tyCon
       | otherwise = definingModule <> T.pack "." <> tyConName tyCon

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -33,6 +33,7 @@ import Aihc.Parser.Syntax
     tyVarBinderName,
     unqualifiedNameText,
   )
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Annotations
   ( TcClassMethodAnnotation (..),
     TcDerivingAnnotation (..),
@@ -248,7 +249,7 @@ derivingClassMethods classInfo =
   where
     method index (methodName, scheme) = do
       let methodType = schemeToType scheme
-      dictType <- selectorDictTypeTc methodName methodType
+          dictType = classDictionaryType classInfo
       pure
         TcClassMethodAnnotation
           { tcClassMethodName = methodName,
@@ -258,11 +259,24 @@ derivingClassMethods classInfo =
             tcClassMethodIndex = index
           }
 
-selectorDictTypeTc :: Text -> TcType -> TcM TcType
-selectorDictTypeTc methodName methodType =
-  case snd (peelForAlls methodType) of
-    TcQualTy (predicate : _) _ -> pure (predType predicate)
-    _ -> missingTypeInfo ("class dictionary type for method selector " <> T.unpack methodName)
+classDictionaryType :: ClassInfo -> TcType
+classDictionaryType classInfo =
+  TcTyCon classTyCon (map TcTyVar (ciTyVars classInfo))
+  where
+    classTyCon =
+      case ciOrigin classInfo of
+        Just (packageId, moduleName) ->
+          mkTyConWithOrigin
+            (PackageId packageId)
+            moduleName
+            (ciName classInfo)
+            (length (ciTyVars classInfo))
+            (foldr (KFun . tvKind) KType (ciTyVars classInfo))
+        Nothing ->
+          mkTyCon
+            (ciName classInfo)
+            (length (ciTyVars classInfo))
+            (foldr (KFun . tvKind) KType (ciTyVars classInfo))
 
 derivingStrategyTypes :: Maybe DerivingStrategy -> [Type]
 derivingStrategyTypes (Just (DerivingVia viaType)) = [viaType]
@@ -317,10 +331,6 @@ collectTypeApplications ty =
       let (headType, arguments) = collectTypeApplications function
        in (headType, arguments <> [argument])
     _ -> (ty, [])
-
-predType :: Pred -> TcType
-predType (ClassPred className arguments) = TcTyCon (TyCon className (length arguments)) arguments
-predType (EqPred left right) = TcTyCon (TyCon "~" 2) [left, right]
 
 instanceDictName :: Text -> [TcType] -> Text
 instanceDictName className types = "$f" <> className <> T.concat (map typeSuffix types)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -1754,7 +1754,7 @@ tcFunctionInfer displayName name matches = do
   if failed
     then pure (Nothing, [])
     else do
-      scheme <- generalizeAndCommitIgnoring (Set.singleton (TcTermGlobal name)) ty residualPreds
+      scheme <- generalizeAndCommitIgnoring (Set.singleton (unqualifiedTermKey name)) ty residualPreds
       let schemeTy = schemeToType scheme
       zonkedTy <- zonkType schemeTy
       extendTermEnvPermanent name (TcIdBinder scheme Closed)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -561,7 +561,7 @@ defaultGlobalKindMetas = do
       let tyCon = tciTyCon info
       pure
         info
-          { tciTyCon = mkTyCon (tyConName tyCon) (tyConArity tyCon) kind,
+          { tciTyCon = finalizeTyConKind kind tyCon,
             tciKind = kind,
             tciTypeSynonym = synonym
           }
@@ -575,7 +575,7 @@ defaultGlobalKindMetas = do
       kind <- defaultKindMetas (tyConKind (dtiTyCon info))
       pure
         info
-          { dtiTyCon = mkTyCon (dtiName info) (tyConArity (dtiTyCon info)) kind,
+          { dtiTyCon = finalizeTyConKind kind (dtiTyCon info),
             dtiTyVars = tyVars,
             dtiConstructors = constructors
           }
@@ -593,6 +593,13 @@ defaultGlobalKindMetas = do
             dciFields = fields,
             dciResTy = resultType
           }
+    finalizeTyConKind kind tyCon =
+      mkTyConWithOrigin
+        (tyConPackageId tyCon)
+        (tyConModuleName tyCon)
+        (tyConName tyCon)
+        (tyConArity tyCon)
+        kind
     defaultDataConFieldKinds field = do
       fieldType' <- defaultTypeKinds (dcfiType field)
       pure field {dcfiType = fieldType'}
@@ -623,11 +630,7 @@ defaultGlobalKindMetas = do
         info
           { dfiiFamilyType = familyType,
             dfiiTyVars = tyVars,
-            dfiiRepresentationTyCon =
-              mkTyCon
-                (tyConName representationTyCon)
-                (tyConArity representationTyCon)
-                representationKind
+            dfiiRepresentationTyCon = setTyConKind representationKind representationTyCon
           }
 
 data TcDeclGroupResult = TcDeclGroupResult
@@ -1873,7 +1876,8 @@ registerForeignImport foreignDecl = do
 
 registerClassDecl :: (Text, Text) -> ClassDecl -> TcM [TcBindingResult]
 registerClassDecl origin classDecl = do
-  let className = unqualifiedNameText (binderHeadName (classDeclHead classDecl))
+  let classBinder = binderHeadName (classDeclHead classDecl)
+      className = unqualifiedNameText classBinder
       params = binderHeadParams (classDeclHead classDecl)
   paramInfos <- makeParamEnv params
   let paramTyVars = map paramTyVar paramInfos
@@ -1887,7 +1891,7 @@ registerClassDecl origin classDecl = do
     TyConInfo
       { tciName = className,
         tciArity = length params,
-        tciTyCon = mkTyCon className (length params) classKind,
+        tciTyCon = mkDeclaredTyCon classBinder className (length params) classKind,
         tciKind = classKind,
         tciFlavor = ClassTyCon,
         tciTypeSynonym = Nothing
@@ -2017,12 +2021,13 @@ typeSuffix ty =
 
 registerDataFamilyDeclHeader :: DataFamilyDecl -> TcM [TcBindingResult]
 registerDataFamilyDeclHeader familyDecl = do
-  let familyName = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
+  let familyBinder = binderHeadName (dataFamilyDeclHead familyDecl)
+      familyName = unqualifiedNameText familyBinder
       params = binderHeadParams (dataFamilyDeclHead familyDecl)
       arity = length params
   paramInfos <- makeParamEnv params
   declaredKind <- tyConKindFromParams paramInfos (dataFamilyDeclKind familyDecl)
-  let familyTyCon = mkTyCon familyName arity declaredKind
+  let familyTyCon = mkDeclaredTyCon familyBinder familyName arity declaredKind
   extendTyConEnvPermanent
     familyName
     TyConInfo
@@ -2051,7 +2056,7 @@ registerDataFamilyInstance familyInst = do
       emitError NoSourceSpan (OtherError "data-family instances without constructors are not supported")
       pure []
     (TcTyCon familyTyCon _, firstConstructor : _) -> do
-      maybeFamilyInfo <- lookupTyCon (tyConName familyTyCon)
+      maybeFamilyInfo <- lookupTyConByIdentity familyTyCon
       case maybeFamilyInfo of
         Just familyInfo
           | tciFlavor familyInfo == DataFamilyTyCon -> do
@@ -2165,7 +2170,8 @@ tupleRuntimeRepNames = mapMaybe (tyVarBinderKind >=> runtimeRepVariableName)
 
 registerDataDeclHeader :: DataDecl -> TcM [TcBindingResult]
 registerDataDeclHeader dd = do
-  let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dd))
+  let tyBinder = binderHeadName (dataDeclHead dd)
+      tyName = unqualifiedNameText tyBinder
       params = binderHeadParams (dataDeclHead dd)
       arity = length params
   (kindParams, paramInfos) <- dataDeclParamInfos dd
@@ -2175,7 +2181,7 @@ registerDataDeclHeader dd = do
       Just tupleArity
         | tupleArity == arity -> pure (unboxedTupleDeclarationKind paramInfos)
       _ -> tyConKindFromParamsWith kindEnv paramInfos (dataDeclKind dd)
-  let tc = dataDeclTyCon tyName arity declaredKind
+  let tc = dataDeclTyCon tyBinder tyName arity declaredKind
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2201,8 +2207,12 @@ unboxedTupleDeclarationKind params =
 
 registerDataConstructors :: DataDecl -> TcM [TcBindingResult]
 registerDataConstructors dataDecl = do
-  let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
-  maybeInfo <- lookupTyCon tyName
+  let tyBinder = binderHeadName (dataDeclHead dataDecl)
+      tyName = unqualifiedNameText tyBinder
+  maybeInfo <-
+    if tyName == "List"
+      then lookupTyConByIdentity (TyCon "[]" 1)
+      else lookupDeclaredTyCon tyBinder
   case maybeInfo of
     Nothing -> missingTypeInfo ("data type " <> T.unpack tyName)
     Just info -> do
@@ -2225,12 +2235,13 @@ registerDataConstructors dataDecl = do
 -- this stage the type checker only needs the source-level names and types.
 registerNewtypeDeclHeader :: NewtypeDecl -> TcM [TcBindingResult]
 registerNewtypeDeclHeader nd = do
-  let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead nd))
+  let tyBinder = binderHeadName (newtypeDeclHead nd)
+      tyName = unqualifiedNameText tyBinder
       params = binderHeadParams (newtypeDeclHead nd)
       arity = length params
   paramInfos <- makeParamEnv params
   declaredKind <- tyConKindFromParams paramInfos (newtypeDeclKind nd)
-  let tc = mkTyCon tyName arity declaredKind
+  let tc = mkDeclaredTyCon tyBinder tyName arity declaredKind
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2247,8 +2258,9 @@ registerNewtypeDeclHeader nd = do
 
 registerNewtypeConstructor :: NewtypeDecl -> TcM [TcBindingResult]
 registerNewtypeConstructor newtypeDecl = do
-  let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
-  maybeInfo <- lookupTyCon tyName
+  let tyBinder = binderHeadName (newtypeDeclHead newtypeDecl)
+      tyName = unqualifiedNameText tyBinder
+  maybeInfo <- lookupDeclaredTyCon tyBinder
   case maybeInfo of
     Nothing -> missingTypeInfo ("newtype " <> T.unpack tyName)
     Just info -> do
@@ -2292,12 +2304,13 @@ registerRecordSelectors constructors =
 
 registerTypeSynonymHeader :: TypeSynDecl -> TcM [TcBindingResult]
 registerTypeSynonymHeader typeSynDecl = do
-  let tyName = unqualifiedNameText (binderHeadName (typeSynHead typeSynDecl))
+  let tyBinder = binderHeadName (typeSynHead typeSynDecl)
+      tyName = unqualifiedNameText tyBinder
       params = binderHeadParams (typeSynHead typeSynDecl)
       arity = length params
   paramInfos <- makeParamEnv params
   let declaredKind = foldr (KFun . paramKind) KType paramInfos
-      tyCon = mkTyCon tyName arity declaredKind
+      tyCon = mkDeclaredTyCon tyBinder tyName arity declaredKind
       synonym = TypeSynonymInfo (map paramTyVar paramInfos) Nothing
   extendTyConEnvPermanent
     tyName
@@ -2314,8 +2327,9 @@ registerTypeSynonymHeader typeSynDecl = do
 registerTypeSynonymBody :: Decl -> TcM ()
 registerTypeSynonymBody (DeclAnn _ inner) = registerTypeSynonymBody inner
 registerTypeSynonymBody (DeclTypeSyn typeSynDecl) = do
-  let tyName = unqualifiedNameText (binderHeadName (typeSynHead typeSynDecl))
-  maybeInfo <- lookupTyCon tyName
+  let tyBinder = binderHeadName (typeSynHead typeSynDecl)
+      tyName = unqualifiedNameText tyBinder
+  maybeInfo <- lookupDeclaredTyCon tyBinder
   case maybeInfo of
     Just info
       | Just synonym <- tciTypeSynonym info -> do
@@ -2326,9 +2340,23 @@ registerTypeSynonymBody (DeclTypeSyn typeSynDecl) = do
     _ -> missingTypeInfo ("type synonym " <> T.unpack tyName)
 registerTypeSynonymBody _ = pure ()
 
-dataDeclTyCon :: Text -> Int -> Kind -> TyCon
-dataDeclTyCon "List" 1 kind = mkTyCon "[]" 1 kind
-dataDeclTyCon name arity kind = mkTyCon name arity kind
+dataDeclTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TyCon
+dataDeclTyCon _ "List" 1 kind = mkTyCon "[]" 1 kind
+dataDeclTyCon binder name arity kind = mkDeclaredTyCon binder name arity kind
+
+mkDeclaredTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TyCon
+mkDeclaredTyCon binder name arity kind =
+  if isWiredInTyConName name
+    then mkTyCon name arity kind
+    else case nameResolution binder of
+      Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} ->
+        mkTyConWithOrigin
+          (packageIdText packageId)
+          (fromMaybe "" (nameQualifier resolvedName))
+          name
+          arity
+          kind
+      _ -> mkTyCon name arity kind
 
 -- | Register a single data constructor as a polymorphic binding.
 -- Returns the binding result for the constructor.
@@ -2340,17 +2368,17 @@ registerDataConWithResult :: [ParamInfo] -> TcType -> DataConDecl -> TcM TcBindi
 registerDataConWithResult paramInfos resTy con = case con of
   DataConAnn _ inner -> registerDataConWithResult paramInfos resTy inner
   PrefixCon forallVars context conName args ->
-    registerH98DataCon forallVars context (unqualifiedNameText conName) (map bangType args)
+    registerH98DataCon forallVars context (Just conName) (unqualifiedNameText conName) (map bangType args)
   InfixCon forallVars context lhs conName rhs ->
-    registerH98DataCon forallVars context (unqualifiedNameText conName) (map bangType [lhs, rhs])
+    registerH98DataCon forallVars context (Just conName) (unqualifiedNameText conName) (map bangType [lhs, rhs])
   RecordCon forallVars context conName fields ->
-    registerH98DataCon forallVars context (unqualifiedNameText conName) (map bangType (recordBangFields fields))
+    registerH98DataCon forallVars context (Just conName) (unqualifiedNameText conName) (map bangType (recordBangFields fields))
   TupleCon forallVars context flavor fields ->
-    registerH98DataCon forallVars context (tupleConText flavor (length fields)) (map bangType fields)
+    registerH98DataCon forallVars context Nothing (tupleConText flavor (length fields)) (map bangType fields)
   UnboxedSumCon forallVars context pos arity field ->
-    registerH98DataCon forallVars context (unboxedSumConText pos arity) [bangType field]
+    registerH98DataCon forallVars context Nothing (unboxedSumConText pos arity) [bangType field]
   ListCon forallVars context ->
-    registerH98DataCon forallVars context "[]" []
+    registerH98DataCon forallVars context Nothing "[]" []
   GadtCon forallBinders context names body -> do
     constructorParams <- makeParamEnv (concatMap forallTelescopeBinders forallBinders)
     let constructorEnv =
@@ -2372,7 +2400,7 @@ registerDataConWithResult paramInfos resTy con = case con of
     mapM_
       ( \n -> do
           let nm = unqualifiedNameText n
-          extendTermEnvPermanent nm (TcIdBinder gadtScheme Closed)
+          extendResolvedTermEnvPermanent n (TcIdBinder gadtScheme Closed)
           markGadtCon nm
       )
       names
@@ -2389,7 +2417,7 @@ registerDataConWithResult paramInfos resTy con = case con of
         | param <- paramInfos
         ]
     paramVarIds = map paramTyVar paramInfos
-    registerH98DataCon forallVars context name fieldTypes = do
+    registerH98DataCon forallVars context maybeName name fieldTypes = do
       constructorParams <- makeParamEnv forallVars
       let constructorEnv =
             Map.fromList
@@ -2402,7 +2430,9 @@ registerDataConWithResult paramInfos resTy con = case con of
       predicates <- mapM (surfacePredToPred constructorEnv) context
       let conTy = foldr TcFunTy resTy argTys
           scheme = ForAll (paramVarIds <> constructorTyVars) predicates conTy
-      extendTermEnvPermanent name (TcIdBinder scheme Closed)
+      case maybeName of
+        Just sourceName -> extendResolvedTermEnvPermanent sourceName (TcIdBinder scheme Closed)
+        Nothing -> extendTermEnvPermanent name (TcIdBinder scheme Closed)
       zonkedTy <- zonkType (schemeToType scheme)
       pure (TcBindingResult name name zonkedTy)
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -1886,12 +1886,13 @@ registerClassDecl origin classDecl = do
       classPred = ClassPred className (map TcTyVar paramTyVars)
   superClassTypes <- mapM (\ty -> checkSurfaceType paramTvEnv ty KConstraint) (fromMaybe [] (classDeclContext classDecl))
   classKind <- defaultKindMetas (foldr KFun KConstraint paramKinds)
+  classTyCon <- mkDeclaredTyCon classBinder className (length params) classKind
   extendTyConEnvPermanent
     className
     TyConInfo
       { tciName = className,
         tciArity = length params,
-        tciTyCon = mkDeclaredTyCon classBinder className (length params) classKind,
+        tciTyCon = classTyCon,
         tciKind = classKind,
         tciFlavor = ClassTyCon,
         tciTypeSynonym = Nothing
@@ -2027,7 +2028,7 @@ registerDataFamilyDeclHeader familyDecl = do
       arity = length params
   paramInfos <- makeParamEnv params
   declaredKind <- tyConKindFromParams paramInfos (dataFamilyDeclKind familyDecl)
-  let familyTyCon = mkDeclaredTyCon familyBinder familyName arity declaredKind
+  familyTyCon <- mkDeclaredTyCon familyBinder familyName arity declaredKind
   extendTyConEnvPermanent
     familyName
     TyConInfo
@@ -2181,7 +2182,7 @@ registerDataDeclHeader dd = do
       Just tupleArity
         | tupleArity == arity -> pure (unboxedTupleDeclarationKind paramInfos)
       _ -> tyConKindFromParamsWith kindEnv paramInfos (dataDeclKind dd)
-  let tc = dataDeclTyCon tyBinder tyName arity declaredKind
+  tc <- dataDeclTyCon tyBinder tyName arity declaredKind
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2209,10 +2210,7 @@ registerDataConstructors :: DataDecl -> TcM [TcBindingResult]
 registerDataConstructors dataDecl = do
   let tyBinder = binderHeadName (dataDeclHead dataDecl)
       tyName = unqualifiedNameText tyBinder
-  maybeInfo <-
-    if tyName == "List"
-      then lookupTyConByIdentity (TyCon "[]" 1)
-      else lookupDeclaredTyCon tyBinder
+  maybeInfo <- lookupDeclaredTyCon tyBinder
   case maybeInfo of
     Nothing -> missingTypeInfo ("data type " <> T.unpack tyName)
     Just info -> do
@@ -2241,7 +2239,7 @@ registerNewtypeDeclHeader nd = do
       arity = length params
   paramInfos <- makeParamEnv params
   declaredKind <- tyConKindFromParams paramInfos (newtypeDeclKind nd)
-  let tc = mkDeclaredTyCon tyBinder tyName arity declaredKind
+  tc <- mkDeclaredTyCon tyBinder tyName arity declaredKind
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2310,8 +2308,8 @@ registerTypeSynonymHeader typeSynDecl = do
       arity = length params
   paramInfos <- makeParamEnv params
   let declaredKind = foldr (KFun . paramKind) KType paramInfos
-      tyCon = mkDeclaredTyCon tyBinder tyName arity declaredKind
-      synonym = TypeSynonymInfo (map paramTyVar paramInfos) Nothing
+  tyCon <- mkDeclaredTyCon tyBinder tyName arity declaredKind
+  let synonym = TypeSynonymInfo (map paramTyVar paramInfos) Nothing
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2340,23 +2338,17 @@ registerTypeSynonymBody (DeclTypeSyn typeSynDecl) = do
     _ -> missingTypeInfo ("type synonym " <> T.unpack tyName)
 registerTypeSynonymBody _ = pure ()
 
-dataDeclTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TyCon
-dataDeclTyCon _ "List" 1 kind = mkTyCon "[]" 1 kind
+dataDeclTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TcM TyCon
+dataDeclTyCon binder "List" 1 kind = mkDeclaredTyCon binder "[]" 1 kind
 dataDeclTyCon binder name arity kind = mkDeclaredTyCon binder name arity kind
 
-mkDeclaredTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TyCon
+mkDeclaredTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TcM TyCon
 mkDeclaredTyCon binder name arity kind =
-  if isWiredInTyConName name
-    then mkTyCon name arity kind
-    else case nameResolution binder of
-      Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} ->
-        mkTyConWithOrigin
-          (packageIdText packageId)
-          (fromMaybe "" (nameQualifier resolvedName))
-          name
-          arity
-          kind
-      _ -> mkTyCon name arity kind
+  case nameResolution binder of
+    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName}
+      | Just definingModuleName <- nameQualifier resolvedName ->
+          pure (mkTyConWithOrigin packageId definingModuleName name arity kind)
+    _ -> abortTc ("type declaration has no package or module identity: " <> T.unpack name)
 
 -- | Register a single data constructor as a polymorphic binding.
 -- Returns the binding result for the constructor.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -67,18 +67,19 @@ inferExprAt ambient expr = case expr of
         inferOverloadedIntegerLiteral ambient ann resolution inner
   EVar name ->
     inferVar (exprSpan expr `orSourceSpan` ambient) name
-  EInt _ numericType _ ->
-    pure (expr, numericLiteralType numericType, [])
+  EInt _ numericType _ -> do
+    literalTy <- numericLiteralType numericType
+    pure (expr, literalTy, [])
   EFloat {} ->
-    pure (expr, doubleTyCon, [])
+    literalResult expr doubleTyCon
   EChar _ _ ->
-    pure (expr, charTyCon, [])
+    literalResult expr (resolvedType "Char")
   ECharHash _ _ ->
-    pure (expr, charHashTyCon, [])
+    literalResult expr (primType "Char#")
   EString _ _ ->
-    pure (expr, stringTyCon, [])
+    literalResult expr stringTyCon
   EStringHash _ _ ->
-    pure (expr, addrHashTyCon, [])
+    literalResult expr (primType "Addr#")
   ELambdaPats pats body ->
     inferLambda (exprSpan expr `orSourceSpan` ambient) pats body
   ELambdaCase alts ->
@@ -121,6 +122,11 @@ inferExprAt ambient expr = case expr of
     emitError (exprSpan expr `orSourceSpan` ambient) (OtherError ("unsupported expression form in TC MVP: " ++ take 50 (show other)))
     ty <- freshMetaTv
     pure (expr, ty, [])
+
+literalResult :: Expr -> TcM TcType -> TcM (Expr, TcType, [Ct])
+literalResult expr typeAction = do
+  ty <- typeAction
+  pure (expr, ty, [])
 
 -- | Infer the type of a variable reference.
 inferVar :: SourceSpan -> Name -> TcM (Expr, TcType, [Ct])
@@ -193,8 +199,11 @@ inferOverloadedIntegerLiteral ambient resolutionAnn resolution literalExpr = do
   (methodTy, typeArgs, methodCts) <- inferResolvedFromInteger sp resolution
   resultTy <- freshMetaTv
   ev <- freshEvVar
-  let integerArgTy = TcTyCon (TyCon "Integer" 0) []
-      expectedMethodTy = TcFunTy integerArgTy resultTy
+  integerArgTy <-
+    case methodTy of
+      TcFunTy argumentTy _ -> pure argumentTy
+      _ -> abortTc "fromInteger does not have a function type"
+  let expectedMethodTy = TcFunTy integerArgTy resultTy
       methodEq =
         mkWantedEqCt
           TypeTrace
@@ -549,7 +558,8 @@ inferIf sp cond thenE elseE = do
   (thenE', thenTy, thenCts) <- inferExpr thenE
   (elseE', elseTy, elseCts) <- inferExpr elseE
   condEv <- freshEvVar
-  let condCt = mkWantedCt (EqPred condTy boolTyCon) condEv (AppOrigin sp) sp
+  expectedBoolTy <- boolTyCon
+  let condCt = mkWantedCt (EqPred condTy expectedBoolTy) condEv (AppOrigin sp) sp
   branchEv <- freshEvVar
   let branchCt = mkWantedCt (EqPred thenTy elseTy) branchEv (AppOrigin sp) sp
   pure (EIf cond' thenE' elseE', thenTy, condCts ++ thenCts ++ elseCts ++ [condCt, branchCt])
@@ -567,8 +577,11 @@ inferTuple sp flavor elems = do
         case flavor of
           Boxed -> foldr (KFun . typeKind) KType tys
           Unboxed -> foldr (KFun . typeKind) (KTYPE (TupleRep (map (fromRight liftedRuntimeRep . runtimeRepOfType) tys))) tys
-      tc = maybe (mkTyCon typeName n fallbackKind) tciTyCon maybeTyCon
-      tupleTy = TcTyCon tc tys
+  tc <-
+    case maybeTyCon of
+      Just info -> pure (tciTyCon info)
+      Nothing -> mkKnownTyCon (tupleTyConModule flavor) typeName n fallbackKind
+  let tupleTy = TcTyCon tc tys
       pending = pendingAnnotation tupleTy tys [] []
   pure (annotatePendingExprAt sp pending (ETuple flavor elems'), tupleTy, cts)
   where
@@ -585,25 +598,32 @@ tupleTyConText flavor arity =
     Boxed -> boxedTupleTyConName arity
     Unboxed -> unboxedTupleTyConName arity
 
+tupleTyConModule :: TupleFlavor -> Text
+tupleTyConModule flavor =
+  case flavor of
+    Boxed -> "GHC.Tuple"
+    Unboxed -> "GHC.Types"
+
 inferList :: SourceSpan -> [Expr] -> TcM (Expr, TcType, [Ct])
-inferList sp elems = case elems of
-  [] -> do
-    elemTy <- freshMetaTv
-    let listTy = TcTyCon listTyCon' [elemTy]
-        pending = pendingAnnotation listTy [elemTy] [] []
-    pure (annotatePendingExprAt sp pending (EList []), listTy, [])
-  (e : es) -> do
-    let headSp = exprSpan e `orSourceSpan` sp
-    (headExpr, headTy, headCts) <- inferExpr e
-    results <- mapM inferElem es
-    let elems' = headExpr : map (\(expr, _, _, _) -> expr) results
-        tailCts = concatMap (\(_, _, elemCts, _) -> elemCts) results
-    eqCts <- mapM (mkElemEq headSp headTy) results
-    let listTy = TcTyCon listTyCon' [headTy]
-        pending = pendingAnnotation listTy [headTy] [] []
-    pure (annotatePendingExprAt sp pending (EList elems'), listTy, headCts ++ tailCts ++ eqCts)
+inferList sp elems = do
+  listTyCon' <- resolvedListTyCon
+  case elems of
+    [] -> do
+      elemTy <- freshMetaTv
+      let listTy = TcTyCon listTyCon' [elemTy]
+          pending = pendingAnnotation listTy [elemTy] [] []
+      pure (annotatePendingExprAt sp pending (EList []), listTy, [])
+    (e : es) -> do
+      let headSp = exprSpan e `orSourceSpan` sp
+      (headExpr, headTy, headCts) <- inferExpr e
+      results <- mapM inferElem es
+      let elems' = headExpr : map (\(expr, _, _, _) -> expr) results
+          tailCts = concatMap (\(_, _, elemCts, _) -> elemCts) results
+      eqCts <- mapM (mkElemEq headSp headTy) results
+      let listTy = TcTyCon listTyCon' [headTy]
+          pending = pendingAnnotation listTy [headTy] [] []
+      pure (annotatePendingExprAt sp pending (EList elems'), listTy, headCts ++ tailCts ++ eqCts)
   where
-    listTyCon' = TyCon {tyConName = "[]", tyConArity = 1}
     inferElem elemExpr = do
       (elemExpr', elemTy, elemCts) <- inferExpr elemExpr
       pure (elemExpr', elemTy, elemCts, exprSpan elemExpr `orSourceSpan` sp)
@@ -627,21 +647,20 @@ inferList sp elems = case elems of
 
 inferListComp :: SourceSpan -> Expr -> [CompStmt] -> TcM (Expr, TcType, [Ct])
 inferListComp sp body quals = do
-  (quals', body', bodyTy, cts) <- inferCompQuals sp quals (inferExpr body)
-  let resultTy = listType bodyTy
+  listTyCon' <- resolvedListTyCon
+  (quals', body', bodyTy, cts) <- inferCompQuals listTyCon' sp quals (inferExpr body)
+  let resultTy = listType listTyCon' bodyTy
       pending = pendingAnnotation resultTy [bodyTy] [] []
   pure (annotatePendingExprAt sp pending (EListComp body' quals'), resultTy, cts)
   where
-    listType elemTy = TcTyCon listTyCon' [elemTy]
-    listTyCon' = TyCon {tyConName = "[]", tyConArity = 1}
-
-    inferCompQuals _ [] action = do
+    listType tyCon elemTy = TcTyCon tyCon [elemTy]
+    inferCompQuals _ _ [] action = do
       (body', bodyTy, bodyCts) <- action
       pure ([], body', bodyTy, bodyCts)
-    inferCompQuals ambient (qual : rest) action =
+    inferCompQuals listTyCon' ambient (qual : rest) action =
       case qual of
         CompAnn ann inner -> do
-          (stmts', body', bodyTy, cts) <- inferCompQuals (compStmtSpan qual `orSourceSpan` ambient) (inner : rest) action
+          (stmts', body', bodyTy, cts) <- inferCompQuals listTyCon' (compStmtSpan qual `orSourceSpan` ambient) (inner : rest) action
           case stmts' of
             inner' : rest' -> pure (CompAnn ann inner' : rest', body', bodyTy, cts)
             [] -> pure ([], body', bodyTy, cts)
@@ -651,32 +670,38 @@ inferListComp sp body quals = do
           patCheck <- checkPattern ambient pat elemTy
           ev <- freshEvVar
           let srcSp = exprSpan src `orSourceSpan` ambient
-              srcListCt = mkWantedCt (EqPred srcTy (listType elemTy)) ev (AppOrigin srcSp) srcSp
-          (rest', body', bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferCompQuals ambient rest action)
+              srcListCt = mkWantedCt (EqPred srcTy (listType listTyCon' elemTy)) ev (AppOrigin srcSp) srcSp
+          (rest', body', bodyTy, bodyCts) <- withPatternBindings (pcBindings patCheck) (inferCompQuals listTyCon' ambient rest action)
           remainingCts <- solvePatternBranch ambient patCheck bodyTy bodyCts
           pure (CompGen (annotatePatternBindings (pcBindings patCheck) (checkedPattern patCheck)) src' : rest', body', bodyTy, srcCts ++ [srcListCt] ++ remainingCts)
         CompGuard guard -> do
           (guard', guardTy, guardCts) <- inferExpr guard
           ev <- freshEvVar
+          expectedBoolTy <- boolTyCon
           let guardSp = exprSpan guard `orSourceSpan` ambient
-              guardCt = mkWantedCt (EqPred guardTy boolTyCon) ev (AppOrigin guardSp) guardSp
-          (rest', body', bodyTy, bodyCts) <- inferCompQuals ambient rest action
+              guardCt = mkWantedCt (EqPred guardTy expectedBoolTy) ev (AppOrigin guardSp) guardSp
+          (rest', body', bodyTy, bodyCts) <- inferCompQuals listTyCon' ambient rest action
           pure (CompGuard guard' : rest', body', bodyTy, guardCts ++ [guardCt] ++ bodyCts)
         CompLetDecls decls -> do
           (decls', (rest', body'), bodyTy, bodyCts) <-
             inferLocalDecls inferExpr decls $ do
-              (rest', body', bodyTy, bodyCts) <- inferCompQuals ambient rest action
+              (rest', body', bodyTy, bodyCts) <- inferCompQuals listTyCon' ambient rest action
               pure ((rest', body'), bodyTy, bodyCts)
           pure (CompLetDecls decls' : rest', body', bodyTy, bodyCts)
-        CompThen {} -> unsupportedQual qual ambient rest action
-        CompThenBy {} -> unsupportedQual qual ambient rest action
-        CompGroupUsing {} -> unsupportedQual qual ambient rest action
-        CompGroupByUsing {} -> unsupportedQual qual ambient rest action
+        CompThen {} -> unsupportedQual listTyCon' qual ambient rest action
+        CompThenBy {} -> unsupportedQual listTyCon' qual ambient rest action
+        CompGroupUsing {} -> unsupportedQual listTyCon' qual ambient rest action
+        CompGroupByUsing {} -> unsupportedQual listTyCon' qual ambient rest action
 
-    unsupportedQual qual ambient rest action = do
+    unsupportedQual listTyCon' qual ambient rest action = do
       let qualSp = compStmtSpan qual `orSourceSpan` ambient
       emitError qualSp (OtherError ("unsupported list comprehension qualifier in TC MVP: " ++ take 50 (show qual)))
-      inferCompQuals ambient rest action
+      inferCompQuals listTyCon' ambient rest action
+
+resolvedListTyCon :: TcM TyCon
+resolvedListTyCon = do
+  maybeInfo <- lookupTyCon "[]"
+  pure (maybe (mkTyCon "[]" 1 (KFun KType KType)) tciTyCon maybeInfo)
 
 inferDo :: SourceSpan -> DoFlavor -> [DoStmt Expr] -> TcM (Expr, TcType, [Ct])
 inferDo sp flavor stmts =
@@ -860,47 +885,48 @@ nameToText n = case nameQualifier n of
   Nothing -> nameText n
   Just q -> q <> "." <> nameText n
 
-intTyCon :: TcType
-intTyCon = TcTyCon (TyCon "Int" 0) []
+intTyCon :: TcM TcType
+intTyCon = TcTyCon <$> mkKnownTyCon "GHC.Types" "Int" 0 liftedTypeKind <*> pure []
 
-intHashTyCon :: TcType
-intHashTyCon = TcTyCon (TyCon "Int#" 0) []
-
-wordHashTyCon :: TcType
-wordHashTyCon = TcTyCon (TyCon "Word#" 0) []
-
-numericLiteralType :: NumericType -> TcType
+numericLiteralType :: NumericType -> TcM TcType
 numericLiteralType numericType =
   case numericType of
     TInteger -> intTyCon
-    TIntHash -> intHashTyCon
-    TWordHash -> wordHashTyCon
-    TInt8Hash -> primNumericTyCon "Int8#"
-    TInt16Hash -> primNumericTyCon "Int16#"
-    TInt32Hash -> primNumericTyCon "Int32#"
-    TInt64Hash -> primNumericTyCon "Int64#"
-    TWord8Hash -> primNumericTyCon "Word8#"
-    TWord16Hash -> primNumericTyCon "Word16#"
-    TWord32Hash -> primNumericTyCon "Word32#"
-    TWord64Hash -> primNumericTyCon "Word64#"
+    TIntHash -> primType "Int#"
+    TWordHash -> primType "Word#"
+    TInt8Hash -> primType "Int8#"
+    TInt16Hash -> primType "Int16#"
+    TInt32Hash -> primType "Int32#"
+    TInt64Hash -> primType "Int64#"
+    TWord8Hash -> primType "Word8#"
+    TWord16Hash -> primType "Word16#"
+    TWord32Hash -> primType "Word32#"
+    TWord64Hash -> primType "Word64#"
 
-primNumericTyCon :: Text -> TcType
-primNumericTyCon name = TcTyCon (TyCon name 0) []
+primType :: Text -> TcM TcType
+primType name = TcTyCon <$> mkKnownTyCon "GHC.Prim" name 0 liftedTypeKind <*> pure []
 
-doubleTyCon :: TcType
-doubleTyCon = TcTyCon (TyCon "Double" 0) []
+doubleTyCon :: TcM TcType
+doubleTyCon = do
+  maybeInfo <- lookupTyCon "Double"
+  case maybeInfo of
+    Just info -> pure (TcTyCon (tciTyCon info) [])
+    Nothing -> TcTyCon <$> mkKnownTyCon "GHC.Types" "Double" 0 liftedTypeKind <*> pure []
 
-charTyCon :: TcType
-charTyCon = TcTyCon (TyCon "Char" 0) []
+resolvedType :: Text -> TcM TcType
+resolvedType name = do
+  maybeInfo <- lookupTyCon name
+  pure (TcTyCon (maybe (mkTyCon name 0 liftedTypeKind) tciTyCon maybeInfo) [])
 
-charHashTyCon :: TcType
-charHashTyCon = TcTyCon (TyCon "Char#" 0) []
+stringTyCon :: TcM TcType
+stringTyCon = do
+  listTyCon <- resolvedListTyCon
+  charType <- resolvedType "Char"
+  pure (TcTyCon listTyCon [charType])
 
-addrHashTyCon :: TcType
-addrHashTyCon = TcTyCon (TyCon "Addr#" 0) []
-
-stringTyCon :: TcType
-stringTyCon = TcTyCon (TyCon "[]" 1) [charTyCon]
-
-boolTyCon :: TcType
-boolTyCon = TcTyCon (TyCon "Bool" 0) []
+boolTyCon :: TcM TcType
+boolTyCon = do
+  maybeInfo <- lookupTyCon "Bool"
+  case maybeInfo of
+    Just info -> pure (TcTyCon (tciTyCon info) [])
+    Nothing -> TcTyCon <$> mkKnownTyCon "GHC.Types" "Bool" 0 liftedTypeKind <*> pure []

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Shared type-checking support for term patterns.
@@ -100,8 +101,9 @@ checkPatternCore gadtHandling sp pat scrutTy =
       innerCheck <- checkPatternWith gadtHandling sp inner scrutTy
       pure innerCheck {pcPatterns = [PParen (checkedPattern innerCheck)]}
     PWildcard {} -> pure (checkedOnly pat)
-    PLit lit ->
-      case charLiteralPatternType lit of
+    PLit lit -> do
+      maybeLiteralTy <- charLiteralPatternType lit
+      case maybeLiteralTy of
         Just literalTy -> do
           eqCt <- wantedEq sp scrutTy literalTy
           pure (checkedOnly pat) {pcWantedCts = [eqCt]}
@@ -122,7 +124,7 @@ checkPatternCore gadtHandling sp pat scrutTy =
       checkConPattern gadtHandling sp pat op [lhs, rhs] scrutTy
     PList items -> do
       elemTy <- freshMetaTv
-      let listTy = listType elemTy
+      listTy <- listType elemTy
       eqCt <- wantedEq sp scrutTy listTy
       itemChecks <- checkPatternsWith gadtHandling sp [(item, elemTy) | item <- items]
       pure itemChecks {pcWantedCts = eqCt : pcWantedCts itemChecks, pcPatterns = [PList (pcPatterns itemChecks)]}
@@ -135,7 +137,11 @@ checkPatternCore gadtHandling sp pat scrutTy =
             case flavor of
               Boxed -> foldr (KFun . typeKind) KType elemTys
               Unboxed -> foldr (KFun . typeKind) (KTYPE (TupleRep (map (fromRight liftedRuntimeRep . runtimeRepOfType) elemTys))) elemTys
-          tupleTy = TcTyCon (maybe (mkTyCon typeName arity fallbackKind) tciTyCon maybeTyCon) elemTys
+      tupleTyCon <-
+        case maybeTyCon of
+          Just info -> pure (tciTyCon info)
+          Nothing -> mkKnownTyCon (tupleTyConModule flavor) typeName arity fallbackKind
+      let tupleTy = TcTyCon tupleTyCon elemTys
       eqCt <- wantedEq sp scrutTy tupleTy
       itemChecks <- checkPatternsWith gadtHandling sp (zip items elemTys)
       pure itemChecks {pcWantedCts = eqCt : pcWantedCts itemChecks, pcPatterns = [PTuple flavor (pcPatterns itemChecks)]}
@@ -150,12 +156,16 @@ checkedPattern check =
     [pat] -> pat
     _ -> error "checkedPattern: expected exactly one checked pattern"
 
-charLiteralPatternType :: Literal -> Maybe TcType
+charLiteralPatternType :: Literal -> TcM (Maybe TcType)
 charLiteralPatternType literal =
   case peelLiteralAnn literal of
-    LitChar {} -> Just (TcTyCon (TyCon "Char" 0) [])
-    LitCharHash {} -> Just (TcTyCon (TyCon "Char#" 0) [])
-    _ -> Nothing
+    LitChar {} -> do
+      maybeInfo <- lookupTyCon "Char"
+      pure (Just (TcTyCon (maybe (mkTyCon "Char" 0 liftedTypeKind) tciTyCon maybeInfo) []))
+    LitCharHash {} -> do
+      tyCon <- mkKnownTyCon "GHC.Prim" "Char#" 0 liftedTypeKind
+      pure (Just (TcTyCon tyCon []))
+    _ -> pure Nothing
 
 overloadedIntegerPatternLiteral :: Pattern -> Maybe Bool
 overloadedIntegerPatternLiteral pat =
@@ -174,13 +184,20 @@ isOverloadedIntegerLiteral lit =
 
 checkOverloadedIntegerPattern :: SourceSpan -> Pattern -> Bool -> TcType -> TcM PatternCheck
 checkOverloadedIntegerPattern sp pat isNegative scrutTy = do
-  (fromIntegerPending, fromIntegerCts) <- checkPatternMethod sp pat "fromInteger" scrutTy (TcFunTy integerTy scrutTy)
+  (fromIntegerPending, fromIntegerCts) <-
+    checkPatternMethodWithExpected sp pat "fromInteger" $ \case
+      TcFunTy integerTy _ -> pure (scrutTy, TcFunTy integerTy scrutTy)
+      _ -> abortTc "fromInteger does not have a function type"
   negateCheck <-
     if isNegative
       then Just <$> checkPatternMethod sp pat "negate" scrutTy (TcFunTy scrutTy scrutTy)
       else pure Nothing
-  let eqTy = TcFunTy scrutTy (TcFunTy scrutTy boolTy)
-  (eqPending, eqCts) <- checkPatternMethod sp pat "==" eqTy eqTy
+  (eqPending, eqCts) <-
+    checkPatternMethodWithExpected sp pat "==" $ \case
+      TcFunTy _ (TcFunTy _ boolTy) ->
+        let expectedTy = TcFunTy scrutTy (TcFunTy scrutTy boolTy)
+         in pure (expectedTy, expectedTy)
+      _ -> abortTc "== does not have a binary function type"
   let methodAnnotations =
         [("fromInteger", fromIntegerPending)]
           <> maybe [] (\(pending, _) -> [("negate", pending)]) negateCheck
@@ -197,9 +214,14 @@ checkOverloadedIntegerPattern sp pat isNegative scrutTy = do
       }
 
 checkPatternMethod :: SourceSpan -> Pattern -> Text -> TcType -> TcType -> TcM (PendingTcAnnotation, [Ct])
-checkPatternMethod sp pat name annotationTy expectedTy = do
+checkPatternMethod sp pat name annotationTy expectedTy =
+  checkPatternMethodWithExpected sp pat name (const (pure (annotationTy, expectedTy)))
+
+checkPatternMethodWithExpected :: SourceSpan -> Pattern -> Text -> (TcType -> TcM (TcType, TcType)) -> TcM (PendingTcAnnotation, [Ct])
+checkPatternMethodWithExpected sp pat name expectedTypes = do
   resolution <- requiredPatternResolution name pat
   (actualTy, typeArgs, methodCts) <- inferResolvedPatternMethod sp name resolution
+  (annotationTy, expectedTy) <- expectedTypes actualTy
   methodEq <- wantedMethodEq sp name actualTy expectedTy
   pure
     ( pendingAnnotation
@@ -209,12 +231,6 @@ checkPatternMethod sp pat name annotationTy expectedTy = do
         [],
       methodCts <> [methodEq]
     )
-
-integerTy :: TcType
-integerTy = TcTyCon (TyCon "Integer" 0) []
-
-boolTy :: TcType
-boolTy = TcTyCon (TyCon "Bool" 0) []
 
 wantedMethodEq :: SourceSpan -> Text -> TcType -> TcType -> TcM Ct
 wantedMethodEq sp method actual expected = do
@@ -472,14 +488,22 @@ withPatternBindings [] action = action
 withPatternBindings ((name, ty) : rest) action =
   extendResolvedTermEnv name (TcMonoIdBinder ty) (withPatternBindings rest action)
 
-listType :: TcType -> TcType
-listType elemTy = TcTyCon (TyCon "[]" 1) [elemTy]
+listType :: TcType -> TcM TcType
+listType elemTy = do
+  maybeInfo <- lookupTyCon "[]"
+  pure (TcTyCon (maybe (mkTyCon "[]" 1 (KFun KType KType)) tciTyCon maybeInfo) [elemTy])
 
 tupleTyConText :: TupleFlavor -> Int -> Text
 tupleTyConText flavor arity =
   case flavor of
     Boxed -> boxedTupleTyConName arity
     Unboxed -> unboxedTupleTyConName arity
+
+tupleTyConModule :: TupleFlavor -> Text
+tupleTyConModule flavor =
+  case flavor of
+    Boxed -> "GHC.Tuple"
+    Unboxed -> "GHC.Types"
 
 patternNameText :: Name -> Text
 patternNameText name =

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -174,8 +174,11 @@ convertNonSynonymTypeWithKinds tvEnv ty =
           fallbackKind = foldr (KFun . typeKind) fallbackResultKind tys
           typeName = tupleTyConText flavor arity
       maybeTyCon <- lookupTyCon typeName
-      let tyCon = maybe (mkTyCon typeName arity fallbackKind) tciTyCon maybeTyCon
-          tupleType = TcTyCon tyCon tys
+      tyCon <-
+        case maybeTyCon of
+          Just info -> pure (tciTyCon info)
+          Nothing -> mkKnownTyCon (tupleTyConModule flavor) typeName arity fallbackKind
+      let tupleType = TcTyCon tyCon tys
       pure (tupleType, typeKind tupleType)
     TUnboxedSum args -> do
       tys <- mapM (checkRuntimeType tvEnv) args
@@ -185,7 +188,8 @@ convertNonSynonymTypeWithKinds tvEnv ty =
       pure (TcTyCon (mkTyCon ("(#" <> bars (arity - 1) <> "#)") arity tyConKind') tys, resultKind)
     TList Unpromoted [arg] -> do
       argTy <- checkSurfaceType tvEnv arg KType
-      pure (listType argTy, KType)
+      listTy <- listType argTy
+      pure (listTy, KType)
     TList Promoted args -> do
       elemKind <- freshKindMeta
       args' <- mapM (\arg -> checkSurfaceType tvEnv arg elemKind) args
@@ -304,9 +308,8 @@ inferTypeConstructor promoted name =
     Promoted -> inferPromotedTypeConstructor (nameText name)
     Unpromoted ->
       case nameText name of
-        "String" -> pure (listType (TcTyCon (TyCon "Char" 0) []), KType)
-        "Type" -> pure (TcTyCon (TyCon "Type" 0) [], KType)
-        "Constraint" -> pure (TcTyCon (TyCon "Constraint" 0) [], KType)
+        "Type" -> knownType "GHC.Types" "Type" KType
+        "Constraint" -> knownType "GHC.Types" "Constraint" KType
         raw -> do
           mInfo <- lookupResolvedTyCon name
           case mInfo of
@@ -317,20 +320,36 @@ inferBuiltinTypeConstructor :: TypeBuiltinCon -> TcM (TcType, Kind)
 inferBuiltinTypeConstructor builtin =
   case builtin of
     TBuiltinList ->
-      pure (TcTyCon (TyCon "[]" 1) [], KFun KType KType)
+      do
+        maybeInfo <- lookupTyCon "[]"
+        pure (TcTyCon (maybe (mkTyCon "[]" 1 (KFun KType KType)) tciTyCon maybeInfo) [], KFun KType KType)
     TBuiltinCons ->
       pure (TcTyCon (TyCon ":" 2) [], KFun KType (KFun (listTypeKind KType) (listTypeKind KType)))
     TBuiltinTuple arity ->
       let argKinds = replicate arity KType
-       in pure (TcTyCon (TyCon (tupleTyConText Boxed arity) arity) [], foldr KFun KType argKinds)
+          kind = foldr KFun KType argKinds
+       in knownTypeWithArity "GHC.Tuple" (tupleTyConText Boxed arity) arity kind
     TBuiltinArrow ->
       pure (TcTyCon (TyCon "(->)" 2) [], KFun KType (KFun KType KType))
 
 inferBuiltinOrOpenTypeConstructor :: Text -> TcM (TcType, Kind)
 inferBuiltinOrOpenTypeConstructor name =
   case wiredInTypeKind name of
-    Just kind -> pure (TcTyCon (mkTyCon name 0 kind) [], kind)
+    Just kind -> knownType (knownTypeModule name) name kind
     Nothing -> inferOpenTypeConstructor name
+
+knownType :: Text -> Text -> Kind -> TcM (TcType, Kind)
+knownType moduleName name = knownTypeWithArity moduleName name 0
+
+knownTypeWithArity :: Text -> Text -> Int -> Kind -> TcM (TcType, Kind)
+knownTypeWithArity moduleName name arity kind = do
+  tyCon <- mkKnownTyCon moduleName name arity kind
+  pure (TcTyCon tyCon [], kind)
+
+knownTypeModule :: Text -> Text
+knownTypeModule name
+  | "#" `T.isSuffixOf` name = "GHC.Prim"
+  | otherwise = "GHC.Types"
 
 inferPromotedTypeConstructor :: Text -> TcM (TcType, Kind)
 inferPromotedTypeConstructor name =
@@ -483,8 +502,10 @@ applyType :: TcType -> TcType -> TcType
 applyType (TcTyCon tc args) arg = TcTyCon tc (args ++ [arg])
 applyType f arg = TcAppTy f arg
 
-listType :: TcType -> TcType
-listType ty = TcTyCon (TyCon "[]" 1) [ty]
+listType :: TcType -> TcM TcType
+listType ty = do
+  maybeInfo <- lookupTyCon "[]"
+  pure (TcTyCon (maybe (mkTyCon "[]" 1 (KFun KType KType)) tciTyCon maybeInfo) [ty])
 
 listTypeKind :: Kind -> Kind
 listTypeKind kind = KFun kind kind
@@ -703,6 +724,12 @@ tupleTyConText flavor arity =
   case flavor of
     Boxed -> boxedTupleTyConName arity
     Unboxed -> unboxedTupleTyConName arity
+
+tupleTyConModule :: TupleFlavor -> Text
+tupleTyConModule flavor =
+  case flavor of
+    Boxed -> "GHC.Tuple"
+    Unboxed -> "GHC.Types"
 
 bars :: Int -> Text
 bars n

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -210,7 +210,7 @@ expandTypeSynonym :: TvKindEnv -> Type -> TcM (Maybe (TcType, Kind))
 expandTypeSynonym tvEnv ty =
   case typeApplicationSpine ty of
     (TCon name Unpromoted, arguments) -> do
-      maybeInfo <- lookupTyCon (nameText name)
+      maybeInfo <- lookupResolvedTyCon name
       case maybeInfo >>= tciTypeSynonym of
         Just synonym
           | Just {} <- tsiBody synonym -> Just <$> instantiateTypeSynonym tvEnv (nameText name) synonym arguments
@@ -264,7 +264,7 @@ expandTcTypeSynonyms expanding ty =
     TcMetaTv {} -> pure ty
     TcTyCon tyCon arguments -> do
       expandedArguments <- mapM (expandTcTypeSynonyms expanding) arguments
-      maybeInfo <- lookupTyCon (tyConName tyCon)
+      maybeInfo <- lookupTyConByIdentity tyCon
       case maybeInfo >>= tciTypeSynonym of
         Just synonym
           | Just body <- tsiBody synonym,
@@ -308,7 +308,7 @@ inferTypeConstructor promoted name =
         "Type" -> pure (TcTyCon (TyCon "Type" 0) [], KType)
         "Constraint" -> pure (TcTyCon (TyCon "Constraint" 0) [], KType)
         raw -> do
-          mInfo <- lookupTyCon raw
+          mInfo <- lookupResolvedTyCon name
           case mInfo of
             Just info -> pure (TcTyCon (tciTyCon info) [], tciKind info)
             Nothing -> inferBuiltinOrOpenTypeConstructor raw

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -48,8 +48,12 @@ module Aihc.Tc.Monad
     extendTermEnv,
     extendResolvedTermEnv,
     extendTermEnvPermanent,
+    extendResolvedTermEnvPermanent,
     getTermEnv,
     lookupTyCon,
+    lookupResolvedTyCon,
+    lookupDeclaredTyCon,
+    lookupTyConByIdentity,
     extendTyConEnvPermanent,
     getTyConEnv,
     addDataType,
@@ -82,8 +86,8 @@ module Aihc.Tc.Monad
 where
 
 import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameText, unqualifiedNameText)
-import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
-import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo, DataTypeInfo (..), InstanceInfo, TyConInfo)
+import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
+import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo, DataTypeInfo (..), InstanceInfo, TyConInfo (..))
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
 import Aihc.Tc.Types
@@ -93,7 +97,7 @@ import Control.Monad.Trans.State.Strict (StateT, get, gets, modify', runStateT)
 import Data.List (find)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -195,7 +199,7 @@ data TcState = TcState
     -- selected global name to retrieve the type.
     tcsGlobalTerms :: !(Map Text TcBinder),
     -- | Global type constructors accumulated by top-level declarations.
-    tcsGlobalTyCons :: !(Map Text TyConInfo),
+    tcsGlobalTyCons :: !(Map TyCon TyConInfo),
     -- | Checked constructor layouts for data and newtype declarations.
     tcsDataTypes :: !(Map Text DataTypeInfo),
     -- | Type classes in scope, including their superclass layouts and defaults.
@@ -328,8 +332,11 @@ lookupTerm name =
   lift $ gets $ \s -> Map.lookup name (tcsGlobalTerms s)
 
 lookupResolvedTerm :: Text -> ResolvedName -> TcM (Maybe TcBinder)
-lookupResolvedTerm displayName resolved =
-  resolvedNameTermKey displayName resolved >>= lookupTermKey
+lookupResolvedTerm displayName resolved = do
+  exact <- resolvedNameTermKey displayName resolved >>= lookupTermKey
+  case (exact, resolved) of
+    (Nothing, ResolvedTopLevel _ name) -> lookupTerm (nameText name)
+    _ -> pure exact
 
 lookupTermKey :: TcTermKey -> TcM (Maybe TcBinder)
 lookupTermKey key =
@@ -356,8 +363,8 @@ resolvedNameTermKey displayName resolved =
   case resolved of
     ResolvedLocal unique _ ->
       pure (TcTermLocal unique)
-    ResolvedTopLevel _ name ->
-      pure (TcTermGlobal (nameText name))
+    ResolvedTopLevel packageId name ->
+      pure (TcTermGlobal (resolvedGlobalKey packageId name))
     ResolvedBuiltin name ->
       pure (TcTermGlobal name)
     ResolvedError msg ->
@@ -388,6 +395,19 @@ extendTermEnvPermanent :: Text -> TcBinder -> TcM ()
 extendTermEnvPermanent name binder = lift $ modify' $ \s ->
   s {tcsGlobalTerms = Map.insert name binder (tcsGlobalTerms s)}
 
+-- | Add a source binder under its resolver identity and its source name.
+extendResolvedTermEnvPermanent :: UnqualifiedName -> TcBinder -> TcM ()
+extendResolvedTermEnvPermanent name binder = do
+  extendTermEnvPermanent (unqualifiedNameText name) binder
+  case termResolution (unqualifiedNameAnns name) of
+    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} ->
+      extendTermEnvPermanent (resolvedGlobalKey packageId resolvedName) binder
+    _ -> pure ()
+
+resolvedGlobalKey :: PackageId -> Name -> Text
+resolvedGlobalKey packageId name =
+  packageIdText packageId <> "\NUL" <> fromMaybe "" (nameQualifier name) <> "\NUL" <> nameText name
+
 resolvedTermTarget :: Name -> TcM ResolvedName
 resolvedTermTarget name =
   case termResolution (nameAnns name) of
@@ -412,14 +432,49 @@ termResolution =
     . mapMaybe fromAnnotation
 
 lookupTyCon :: Text -> TcM (Maybe TyConInfo)
-lookupTyCon name = lift $ gets $ \s -> Map.lookup name (tcsGlobalTyCons s)
+lookupTyCon name =
+  lift $ gets $ find ((== name) . tciName) . Map.elems . tcsGlobalTyCons
 
-getTyConEnv :: TcM (Map Text TyConInfo)
+lookupResolvedTyCon :: Name -> TcM (Maybe TyConInfo)
+lookupResolvedTyCon name =
+  case typeResolution (nameAnns name) of
+    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
+      exact <- lookupTyConOrigin (packageIdText packageId) (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+      maybe (lookupTyCon (nameText name)) (pure . Just) exact
+    _ -> lookupTyCon (nameText name)
+
+lookupDeclaredTyCon :: UnqualifiedName -> TcM (Maybe TyConInfo)
+lookupDeclaredTyCon name =
+  case typeResolution (unqualifiedNameAnns name) of
+    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
+      exact <- lookupTyConOrigin (packageIdText packageId) (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+      maybe (lookupTyCon (unqualifiedNameText name)) (pure . Just) exact
+    _ -> lookupTyCon (unqualifiedNameText name)
+
+lookupTyConByIdentity :: TyCon -> TcM (Maybe TyConInfo)
+lookupTyConByIdentity tyCon = lift $ gets $ Map.lookup tyCon . tcsGlobalTyCons
+
+lookupTyConOrigin :: Text -> Text -> Text -> TcM (Maybe TyConInfo)
+lookupTyConOrigin packageId moduleName name =
+  lift $ gets $ find matches . Map.elems . tcsGlobalTyCons
+  where
+    matches info =
+      let tyCon = tciTyCon info
+       in tyConPackageId tyCon == packageId
+            && tyConModuleName tyCon == moduleName
+            && tyConName tyCon == name
+
+typeResolution :: [Annotation] -> Maybe ResolutionAnnotation
+typeResolution =
+  find ((== ResolutionNamespaceType) . resolutionNamespace)
+    . mapMaybe fromAnnotation
+
+getTyConEnv :: TcM (Map TyCon TyConInfo)
 getTyConEnv = lift $ gets tcsGlobalTyCons
 
 extendTyConEnvPermanent :: Text -> TyConInfo -> TcM ()
-extendTyConEnvPermanent name info = lift $ modify' $ \s ->
-  s {tcsGlobalTyCons = Map.insert name info (tcsGlobalTyCons s)}
+extendTyConEnvPermanent _ info = lift $ modify' $ \s ->
+  s {tcsGlobalTyCons = Map.insert (tciTyCon info) info (tcsGlobalTyCons s)}
 
 addDataType :: DataTypeInfo -> TcM ()
 addDataType info = lift $ modify' $ \state ->

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -37,6 +37,7 @@ module Aihc.Tc.Monad
     TcEnv (..),
     TcBinder (..),
     TcTermKey (..),
+    unqualifiedTermKey,
     Closedness (..),
     emptyTcEnv,
     lookupTerm,
@@ -160,8 +161,11 @@ data TcBinder
 
 data TcTermKey
   = TcTermLocal !Int
-  | TcTermGlobal !Text
-  deriving (Eq, Ord, Show)
+  | TcTermGlobal !PackageId !Text !Text
+  deriving (Eq, Ord, Show, Read)
+
+unqualifiedTermKey :: Text -> TcTermKey
+unqualifiedTermKey = TcTermGlobal (PackageId "") ""
 
 -- | An empty environment at the top level.
 emptyTcEnv :: TcEnv
@@ -193,11 +197,9 @@ data TcState = TcState
     -- | Global term bindings accumulated from declarations and imported
     -- interfaces.
     --
-    -- This map remains text-keyed because it is not used to decide lexical
-    -- scope. Occurrences reach it only after @aihc-resolve@ has attached a
-    -- 'ResolvedTopLevel' or 'ResolvedBuiltin' target; TC then uses the target's
-    -- selected global name to retrieve the type.
-    tcsGlobalTerms :: !(Map Text TcBinder),
+    -- Global keys store the package, module, and identifier selected by
+    -- @aihc-resolve@.
+    tcsGlobalTerms :: !(Map TcTermKey TcBinder),
     -- | Global type constructors accumulated by top-level declarations.
     tcsGlobalTyCons :: !(Map TyCon TyConInfo),
     -- | Checked constructor layouts for data and newtype declarations.
@@ -233,11 +235,11 @@ initTcState =
       tcsGadtCons = Set.empty
     }
 
-builtinTerms :: Map Text TcBinder
+builtinTerms :: Map TcTermKey TcBinder
 builtinTerms =
   Map.fromList
-    [ (":", TcIdBinder consScheme Closed),
-      ("[]", TcIdBinder nilScheme Closed)
+    [ (unqualifiedTermKey ":", TcIdBinder consScheme Closed),
+      (unqualifiedTermKey "[]", TcIdBinder nilScheme Closed)
     ]
   where
     aVar = TyVarId "a" (Unique (-1000))
@@ -329,7 +331,7 @@ lookupEvidence (EvVar u) = lift $ gets $ \s ->
 -- | Look up a global term by its selected global name.
 lookupTerm :: Text -> TcM (Maybe TcBinder)
 lookupTerm name =
-  lift $ gets $ \s -> Map.lookup name (tcsGlobalTerms s)
+  lift $ gets $ \s -> Map.lookup (unqualifiedTermKey name) (tcsGlobalTerms s)
 
 lookupResolvedTerm :: Text -> ResolvedName -> TcM (Maybe TcBinder)
 lookupResolvedTerm displayName resolved = do
@@ -343,8 +345,8 @@ lookupTermKey key =
   case key of
     TcTermLocal _ ->
       asks $ \env -> Map.lookup key (tcEnvTerms env)
-    TcTermGlobal name ->
-      lift $ gets $ \s -> Map.lookup name (tcsGlobalTerms s)
+    TcTermGlobal {} ->
+      lift $ gets $ \s -> Map.lookup key (tcsGlobalTerms s)
 
 resolvedTermKey :: Name -> TcM TcTermKey
 resolvedTermKey name =
@@ -364,9 +366,9 @@ resolvedNameTermKey displayName resolved =
     ResolvedLocal unique _ ->
       pure (TcTermLocal unique)
     ResolvedTopLevel packageId name ->
-      pure (TcTermGlobal (resolvedGlobalKey packageId name))
+      pure (TcTermGlobal packageId (fromMaybe "" (nameQualifier name)) (nameText name))
     ResolvedBuiltin name ->
-      pure (TcTermGlobal name)
+      pure (unqualifiedTermKey name)
     ResolvedError msg ->
       abortTc ("resolver error reached type checker for term " <> show displayName <> ": " <> msg)
 
@@ -375,7 +377,7 @@ getTermEnv :: TcM (Map TcTermKey TcBinder)
 getTermEnv = do
   locals <- asks tcEnvTerms
   globals <- lift $ gets tcsGlobalTerms
-  pure (locals <> Map.mapKeys TcTermGlobal globals)
+  pure (locals <> globals)
 
 -- | Extend the term environment with a new binding for the duration
 -- of the given computation.
@@ -393,7 +395,7 @@ extendResolvedTermEnv name binder action = do
 -- declarations like data constructors and top-level bindings).
 extendTermEnvPermanent :: Text -> TcBinder -> TcM ()
 extendTermEnvPermanent name binder = lift $ modify' $ \s ->
-  s {tcsGlobalTerms = Map.insert name binder (tcsGlobalTerms s)}
+  s {tcsGlobalTerms = Map.insert (unqualifiedTermKey name) binder (tcsGlobalTerms s)}
 
 -- | Add a source binder under its resolver identity and its source name.
 extendResolvedTermEnvPermanent :: UnqualifiedName -> TcBinder -> TcM ()
@@ -401,12 +403,15 @@ extendResolvedTermEnvPermanent name binder = do
   extendTermEnvPermanent (unqualifiedNameText name) binder
   case termResolution (unqualifiedNameAnns name) of
     Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} ->
-      extendTermEnvPermanent (resolvedGlobalKey packageId resolvedName) binder
+      lift $ modify' $ \state ->
+        state
+          { tcsGlobalTerms =
+              Map.insert
+                (TcTermGlobal packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName))
+                binder
+                (tcsGlobalTerms state)
+          }
     _ -> pure ()
-
-resolvedGlobalKey :: PackageId -> Name -> Text
-resolvedGlobalKey packageId name =
-  packageIdText packageId <> "\NUL" <> fromMaybe "" (nameQualifier name) <> "\NUL" <> nameText name
 
 resolvedTermTarget :: Name -> TcM ResolvedName
 resolvedTermTarget name =

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -34,12 +34,15 @@ module Aihc.Tc.Monad
     lookupEvidence,
 
     -- * Environment
+    TcConfig,
+    tcConfig,
     TcEnv (..),
     TcBinder (..),
     TcTermKey (..),
     unqualifiedTermKey,
     Closedness (..),
     emptyTcEnv,
+    mkKnownTyCon,
     lookupTerm,
     lookupResolvedTerm,
     resolvedTermKey,
@@ -130,7 +133,8 @@ tcAbortMessage (TcAbort msg) = msg
 
 -- | The local typing environment (read-only within a scope).
 data TcEnv = TcEnv
-  { -- | Local term bindings in scope.
+  { tcEnvConfig :: !TcConfig,
+    -- | Local term bindings in scope.
     --
     -- The keys come from @aihc-resolve@'s 'ResolvedLocal' identifiers, not
     -- from source text. This lets TC preserve lexical identity without doing
@@ -144,6 +148,17 @@ data TcEnv = TcEnv
     tcEnvTcLevel :: !TcLevel
   }
   deriving (Show)
+
+newtype TcConfig = TcConfig PackageId
+  deriving (Show)
+
+tcConfig :: PackageId -> TcConfig
+tcConfig = TcConfig
+
+mkKnownTyCon :: Text -> Text -> Int -> Kind -> TcM TyCon
+mkKnownTyCon moduleName name arity kind = do
+  TcConfig packageIdentity <- asks tcEnvConfig
+  pure (mkTyConWithOrigin packageIdentity moduleName name arity kind)
 
 -- | Whether a polymorphic binding is known to have no free type variables.
 data Closedness
@@ -171,7 +186,8 @@ unqualifiedTermKey = TcTermGlobal (PackageId "") ""
 emptyTcEnv :: TcEnv
 emptyTcEnv =
   TcEnv
-    { tcEnvTerms = Map.empty,
+    { tcEnvConfig = tcConfig (PackageId "aihc-prim"),
+      tcEnvTerms = Map.empty,
       tcEnvMonoLocalBinds = True,
       tcEnvMonomorphismRestriction = True,
       tcEnvTcLevel = topTcLevel
@@ -438,13 +454,15 @@ termResolution =
 
 lookupTyCon :: Text -> TcM (Maybe TyConInfo)
 lookupTyCon name =
-  lift $ gets $ find ((== name) . tciName) . Map.elems . tcsGlobalTyCons
+  lift $ gets $ find matches . Map.elems . tcsGlobalTyCons
+  where
+    matches info = tciName info == name || tyConName (tciTyCon info) == name
 
 lookupResolvedTyCon :: Name -> TcM (Maybe TyConInfo)
 lookupResolvedTyCon name =
   case typeResolution (nameAnns name) of
     Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
-      exact <- lookupTyConOrigin (packageIdText packageId) (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+      exact <- lookupTyConOrigin packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
       maybe (lookupTyCon (nameText name)) (pure . Just) exact
     _ -> lookupTyCon (nameText name)
 
@@ -452,14 +470,14 @@ lookupDeclaredTyCon :: UnqualifiedName -> TcM (Maybe TyConInfo)
 lookupDeclaredTyCon name =
   case typeResolution (unqualifiedNameAnns name) of
     Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
-      exact <- lookupTyConOrigin (packageIdText packageId) (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+      exact <- lookupTyConOrigin packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
       maybe (lookupTyCon (unqualifiedNameText name)) (pure . Just) exact
     _ -> lookupTyCon (unqualifiedNameText name)
 
 lookupTyConByIdentity :: TyCon -> TcM (Maybe TyConInfo)
 lookupTyConByIdentity tyCon = lift $ gets $ Map.lookup tyCon . tcsGlobalTyCons
 
-lookupTyConOrigin :: Text -> Text -> Text -> TcM (Maybe TyConInfo)
+lookupTyConOrigin :: PackageId -> Text -> Text -> TcM (Maybe TyConInfo)
 lookupTyConOrigin packageId moduleName name =
   lift $ gets $ find matches . Map.elems . tcsGlobalTyCons
   where

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -28,7 +28,6 @@ module Aihc.Tc.Types
     tyConKind,
     mkTyCon,
     mkTyConWithOrigin,
-    isWiredInTyConName,
     setTyConKind,
     Kind (KTYPE, KConstraint, KRuntimeRep, KLevity, KVecCount, KVecElem, KFun, KMeta, KType),
     RuntimeRep (..),
@@ -56,7 +55,8 @@ module Aihc.Tc.Types
   )
 where
 
-import Data.Maybe (fromMaybe, isJust)
+import Aihc.Resolve (PackageId (..))
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -104,7 +104,7 @@ instance Ord TyVarId where
 -- | Type constructor. Every constructor carries its fully applied kind so
 -- downstream phases can recover the kind of any 'TcType' without consulting
 -- the type-checker environment.
-data TyCon = TyConInternal !Text !Text !Text !Int !Kind
+data TyCon = TyConInternal !PackageId !Text !Text !Int !Kind
   deriving (Show, Read)
 
 instance Eq TyCon where
@@ -121,24 +121,24 @@ instance Ord TyCon where
 pattern TyCon :: Text -> Int -> TyCon
 pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity _
   where
-    TyCon name arity = TyConInternal "" "" name arity (wiredInTyConKind name arity)
+    TyCon name arity = TyConInternal (PackageId "aihc-internal") "Aihc.Internal" name arity (wiredInTyConKind name arity)
 
 {-# COMPLETE TyCon #-}
 
 tyConKind :: TyCon -> Kind
 tyConKind (TyConInternal _ _ _ _ kind) = kind
 
-tyConPackageId :: TyCon -> Text
+tyConPackageId :: TyCon -> PackageId
 tyConPackageId (TyConInternal packageId _ _ _ _) = packageId
 
 tyConModuleName :: TyCon -> Text
 tyConModuleName (TyConInternal _ moduleName _ _ _) = moduleName
 
 mkTyCon :: Text -> Int -> Kind -> TyCon
-mkTyCon = mkTyConWithOrigin "" ""
+mkTyCon = mkTyConWithOrigin (PackageId "aihc-internal") "Aihc.Internal"
 
 -- | Make a type constructor with its installed package and module identity.
-mkTyConWithOrigin :: Text -> Text -> Text -> Int -> Kind -> TyCon
+mkTyConWithOrigin :: PackageId -> Text -> Text -> Int -> Kind -> TyCon
 mkTyConWithOrigin packageId moduleName name arity inferredKind =
   TyConInternal packageId moduleName name arity (fromMaybe inferredKind (fixedTyConKind name))
 
@@ -334,19 +334,6 @@ fixedTyConKind name =
               ("[]", KFun liftedTypeKind liftedTypeKind),
               (":", KFun liftedTypeKind (KFun (KFun liftedTypeKind liftedTypeKind) (KFun liftedTypeKind liftedTypeKind)))
             ]
-
-isWiredInTyConName :: Text -> Bool
-isWiredInTyConName name =
-  name `elem` ["Int", "Integer", "Double", "Float", "Char", "Bool", "Unit", "Solo"]
-    || isJust (fixedTyConKind name)
-    || isTupleTyConName name
-  where
-    isTupleTyConName candidate =
-      case T.stripPrefix "Tuple" candidate of
-        Just suffix ->
-          let digits = T.dropWhileEnd (== '#') suffix
-           in not (T.null digits) && T.all (`elem` ['0' .. '9']) digits
-        Nothing -> False
 
 defaultTyConKind :: Text -> Int -> Kind
 defaultTyConKind _ arity = foldr KFun liftedTypeKind (replicate arity liftedTypeKind)

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -23,8 +23,12 @@ module Aihc.Tc.Types
     -- * Types
     TcType (..),
     TyCon (TyCon, tyConName, tyConArity),
+    tyConPackageId,
+    tyConModuleName,
     tyConKind,
     mkTyCon,
+    mkTyConWithOrigin,
+    isWiredInTyConName,
     setTyConKind,
     Kind (KTYPE, KConstraint, KRuntimeRep, KLevity, KVecCount, KVecElem, KFun, KMeta, KType),
     RuntimeRep (..),
@@ -52,7 +56,7 @@ module Aihc.Tc.Types
   )
 where
 
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -100,36 +104,50 @@ instance Ord TyVarId where
 -- | Type constructor. Every constructor carries its fully applied kind so
 -- downstream phases can recover the kind of any 'TcType' without consulting
 -- the type-checker environment.
-data TyCon = TyConInternal !Text !Int !Kind
+data TyCon = TyConInternal !Text !Text !Text !Int !Kind
   deriving (Show, Read)
 
 instance Eq TyCon where
   left == right =
-    (tyConName left, tyConArity left) == (tyConName right, tyConArity right)
+    (tyConPackageId left, tyConModuleName left, tyConName left, tyConArity left)
+      == (tyConPackageId right, tyConModuleName right, tyConName right, tyConArity right)
 
 instance Ord TyCon where
   compare left right =
-    compare (tyConName left, tyConArity left) (tyConName right, tyConArity right)
+    compare
+      (tyConPackageId left, tyConModuleName left, tyConName left, tyConArity left)
+      (tyConPackageId right, tyConModuleName right, tyConName right, tyConArity right)
 
 pattern TyCon :: Text -> Int -> TyCon
-pattern TyCon {tyConName, tyConArity} <- TyConInternal tyConName tyConArity _
+pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity _
   where
-    TyCon name arity = TyConInternal name arity (wiredInTyConKind name arity)
+    TyCon name arity = TyConInternal "" "" name arity (wiredInTyConKind name arity)
 
 {-# COMPLETE TyCon #-}
 
 tyConKind :: TyCon -> Kind
-tyConKind (TyConInternal _ _ kind) = kind
+tyConKind (TyConInternal _ _ _ _ kind) = kind
+
+tyConPackageId :: TyCon -> Text
+tyConPackageId (TyConInternal packageId _ _ _ _) = packageId
+
+tyConModuleName :: TyCon -> Text
+tyConModuleName (TyConInternal _ moduleName _ _ _) = moduleName
 
 mkTyCon :: Text -> Int -> Kind -> TyCon
-mkTyCon name arity inferredKind =
-  TyConInternal name arity (fromMaybe inferredKind (fixedTyConKind name))
+mkTyCon = mkTyConWithOrigin "" ""
+
+-- | Make a type constructor with its installed package and module identity.
+mkTyConWithOrigin :: Text -> Text -> Text -> Int -> Kind -> TyCon
+mkTyConWithOrigin packageId moduleName name arity inferredKind =
+  TyConInternal packageId moduleName name arity (fromMaybe inferredKind (fixedTyConKind name))
 
 -- | Replace a type constructor's kind without applying wired-in defaults.
 -- This is used when reconstructing canonical System FC syntax, where the
 -- serialized kind is authoritative.
 setTyConKind :: Kind -> TyCon -> TyCon
-setTyConKind kind (TyConInternal name arity _) = TyConInternal name arity kind
+setTyConKind kind (TyConInternal packageId moduleName name arity _) =
+  TyConInternal packageId moduleName name arity kind
 
 -- | Kinds for the type language checked by @aihc-tc@.
 data Kind
@@ -316,6 +334,19 @@ fixedTyConKind name =
               ("[]", KFun liftedTypeKind liftedTypeKind),
               (":", KFun liftedTypeKind (KFun (KFun liftedTypeKind liftedTypeKind) (KFun liftedTypeKind liftedTypeKind)))
             ]
+
+isWiredInTyConName :: Text -> Bool
+isWiredInTyConName name =
+  name `elem` ["Int", "Integer", "Double", "Float", "Char", "Bool", "Unit", "Solo"]
+    || isJust (fixedTyConKind name)
+    || isTupleTyConName name
+  where
+    isTupleTyConName candidate =
+      case T.stripPrefix "Tuple" candidate of
+        Just suffix ->
+          let digits = T.dropWhileEnd (== '#') suffix
+           in not (T.null digits) && T.all (`elem` ['0' .. '9']) digits
+        Nothing -> False
 
 defaultTyConKind :: Text -> Int -> Kind
 defaultTyConKind _ arity = foldr KFun liftedTypeKind (replicate arity liftedTypeKind)

--- a/components/aihc-tc/src/Aihc/Tc/Zonk.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Zonk.hs
@@ -29,7 +29,7 @@ zonkType ty = case ty of
   TcTyVar tv -> TcTyVar <$> zonkTyVar tv
   TcTyCon tc args -> do
     kind <- zonkKind (tyConKind tc)
-    TcTyCon (mkTyCon (tyConName tc) (tyConArity tc) kind) <$> mapM zonkType args
+    TcTyCon (finalizeTyConKind kind tc) <$> mapM zonkType args
   TcFunTy a b -> TcFunTy <$> zonkType a <*> zonkType b
   TcForAllTy tv body -> TcForAllTy <$> zonkTyVar tv <*> zonkType body
   TcQualTy preds body -> TcQualTy <$> mapM zonkPred preds <*> zonkType body
@@ -89,12 +89,21 @@ defaultTypeKinds ty =
     TcTyVar tv -> TcTyVar <$> defaultTyVarKinds tv
     TcTyCon tyCon args -> do
       kind <- defaultKindMetas (tyConKind tyCon)
-      let tyCon' = mkTyCon (tyConName tyCon) (tyConArity tyCon) kind
+      let tyCon' = finalizeTyConKind kind tyCon
       TcTyCon tyCon' <$> mapM defaultTypeKinds args
     TcFunTy argument result -> TcFunTy <$> defaultTypeKinds argument <*> defaultTypeKinds result
     TcForAllTy tv body -> TcForAllTy <$> defaultTyVarKinds tv <*> defaultTypeKinds body
     TcQualTy predicates body -> TcQualTy <$> mapM defaultPredKinds predicates <*> defaultTypeKinds body
     TcAppTy function argument -> TcAppTy <$> defaultTypeKinds function <*> defaultTypeKinds argument
+
+finalizeTyConKind :: Kind -> TyCon -> TyCon
+finalizeTyConKind kind tyCon =
+  mkTyConWithOrigin
+    (tyConPackageId tyCon)
+    (tyConModuleName tyCon)
+    (tyConName tyCon)
+    (tyConArity tyCon)
+    kind
 
 defaultTypeSchemeKinds :: TypeScheme -> TcM TypeScheme
 defaultTypeSchemeKinds (ForAll tyVars predicates body) =

--- a/components/aihc-tc/test/Test/Fixtures/annotated/distinct-module-type-constructors.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/distinct-module-type-constructors.yaml
@@ -1,0 +1,35 @@
+annotated:
+- |-
+  module A where
+  data Ty = Con
+       │    └─ type: Ty
+       └─ type: *
+- |-
+  module B where
+  data Ty = Con
+       │    └─ type: Ty
+       └─ type: *
+- |-
+  module C where
+  import qualified A
+  import qualified B
+  val1 = A.Con
+  └─ type: A.Ty
+  val2 = B.Con
+  └─ type: B.Ty
+extensions: []
+modules:
+- |
+  module A where
+  data Ty = Con
+- |
+  module B where
+  data Ty = Con
+- |
+  module C where
+  import qualified A
+  import qualified B
+  val1 = A.Con
+  val2 = B.Con
+reason: Different module namespaces must not clash
+status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
@@ -1,13 +1,17 @@
 annotated:
 - |-
-  {-# LANGUAGE KindSignatures, RebindableSyntax #-}
-  module Test where
-
-  data Type
-       └─ type: *
+  module GHC.Types where
   data Bool = False | True
        │      │       └─ type: Bool
        │      └─ type: Bool
+       └─ type: *
+- |-
+  {-# LANGUAGE KindSignatures, RebindableSyntax #-}
+  module Test where
+
+  import GHC.Types (Bool)
+
+  data Type
        └─ type: *
 
   class Applicative (m :: Type -> Type) where
@@ -40,11 +44,15 @@ extensions:
 - RebindableSyntax
 modules:
 - |
+  module GHC.Types where
+  data Bool = False | True
+- |
   {-# LANGUAGE KindSignatures, RebindableSyntax #-}
   module Test where
 
+  import GHC.Types (Bool)
+
   data Type
-  data Bool = False | True
 
   class Applicative (m :: Type -> Type) where
     pure :: a -> m a

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
@@ -1,10 +1,13 @@
 annotated:
 - |-
-  module Test where
+  module GHC.Types where
   data Bool = True | False
        │      │      └─ type: Bool
        │      └─ type: Bool
        └─ type: *
+- |-
+  module Test where
+  import GHC.Types (Bool)
   filter f list = [ x | x <- list, f x ]
   │      │ │      │     └─ type: a
   │      │ │      └─ type: [a]; type-args: a
@@ -14,8 +17,11 @@ annotated:
 extensions: []
 modules:
 - |
-  module Test where
+  module GHC.Types where
   data Bool = True | False
+- |
+  module Test where
+  import GHC.Types (Bool)
   filter f list = [ x | x <- list, f x ]
 reason: list comprehension guards must typecheck as Bool
 status: pass

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -29,7 +29,7 @@ import Aihc.Parser.Syntax
     mkAnnotation,
     stripAnnotations,
   )
-import Aihc.Resolve (ResolveResult (..), extractInterface, modulesInPackage, unnamedPackage)
+import Aihc.Resolve (PackageId (..), ResolveResult (..), extractInterface, modulesInPackage, unnamedPackage)
 import Aihc.Resolve qualified as Resolve
 import Aihc.Tc
 import Aihc.Tc.Annotations (PendingTcAnnotation, TcClassAnnotation (..), TcClassMethodAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..), pendingAnnotation)
@@ -491,9 +491,13 @@ kindTests =
       case baseResult of
         ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
           let (checkedBase, interface) = typecheckModuleSccWithInterface mempty (map snd baseModules)
+              interfaceTermNames = mapMaybe (tcTermKeyIdentifier . fst) (tcInterfaceTerms interface)
           assertBool "dependency should typecheck" (all tcModuleSuccess checkedBase)
-          assertBool "constructor term exported" ("Unit" `elem` map fst (tcInterfaceTerms interface))
-          assertBool "method term exported" ("identity" `elem` map fst (tcInterfaceTerms interface))
+          assertBool "constructor term exported" ("Unit" `elem` interfaceTermNames)
+          assertBool "method term exported" ("identity" `elem` interfaceTermNames)
+          assertBool
+            "constructor term keeps its resolved identity"
+            (TcTermGlobal (PackageId "") "Base" "Unit" `elem` map fst (tcInterfaceTerms interface))
           assertBool "type constructor exported" ("Unit" `elem` map tciName (tcInterfaceTyCons interface))
           assertBool "class exported" ("Identity" `elem` map ciName (tcInterfaceClasses interface))
           assertBool "instance exported" ("$fIdentityUnit" `elem` map iiDictName (tcInterfaceInstances interface))
@@ -675,9 +679,10 @@ annotationTests =
       case baseResult of
         ResolveResult {resolvedModules = baseModules, resolveErrors = []} -> do
           let (checkedBase, interface) = typecheckModuleSccWithInterface mempty (map snd baseModules)
+              interfaceTermNames = mapMaybe (tcTermKeyIdentifier . fst) (tcInterfaceTerms interface)
           assertBool ("provider should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedBase)) (all tcModuleSuccess checkedBase)
           assertBool "record selectors are emitted as term bindings" (all (`elem` concatMap (map tbName . tcModuleBindings) checkedBase) ["left", "right"])
-          assertBool "record selectors are exported through T(..)" (all (`elem` map fst (tcInterfaceTerms interface)) ["left", "right"])
+          assertBool "record selectors are exported through T(..)" (all (`elem` interfaceTermNames) ["left", "right"])
           assertEqual
             "interface serialization round-trip"
             (show interface)

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -21,15 +21,17 @@ import Aihc.Parser.Syntax
     Match (..),
     Module (..),
     Name (..),
+    NumericType (..),
     Pattern (..),
     Rhs (..),
     SourceSpan,
     ValueDecl (..),
     fromAnnotation,
     mkAnnotation,
+    moduleName,
     stripAnnotations,
   )
-import Aihc.Resolve (PackageId (..), ResolveResult (..), extractInterface, modulesInPackage, unnamedPackage)
+import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), extractInterface, unnamedPackage)
 import Aihc.Resolve qualified as Resolve
 import Aihc.Tc
 import Aihc.Tc.Annotations (PendingTcAnnotation, TcClassAnnotation (..), TcClassMethodAnnotation (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..), pendingAnnotation)
@@ -40,7 +42,7 @@ import Aihc.Tc.Instantiate (Instantiation (..), instantiateWithArgs)
 import Aihc.Tc.Kind (freeTypeVars)
 import Aihc.Tc.Monad (emptyTcEnv, initTcState, runTcM)
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, parseTypeScheme)
-import Aihc.Tc.Types (mkTyCon)
+import Aihc.Tc.Types (mkTyCon, tyConModuleName, tyConPackageId)
 import Aihc.Tc.Unify (unifyTypes)
 import Aihc.Tc.Zonk (zonkType)
 import Data.Data (Data, gmapQ)
@@ -105,8 +107,9 @@ tcWithDecls :: Text -> Text -> TcResult
 tcWithDecls decls expr =
   let modu =
         typecheckModule $
-          parseM
-            ( "module Test where\n\
+          parseMInPackage
+            (Package "aihc-prim" (PackageId "aihc-prim"))
+            ( "module GHC.Types where\n\
               \data Bool = False | True\n"
                 <> decls
                 <> "\n__result = "
@@ -311,7 +314,28 @@ variableTests =
 
 kindTests :: [TestTree]
 kindTests =
-  [ testCase "explicit forall removes every occurrence of its bound variables" $ do
+  [ testCase "an Int declaration keeps its resolver identity" $ do
+      let package = Package "test-package" (PackageId "test-package-id")
+          result = Resolve.resolveWithDeps mempty [(package, parseOnly "module Custom.Int where\ndata Int = MkInt\n")]
+      case result of
+        ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} -> do
+          let (_, interface) = typecheckModulesWithInterface mempty [resolved]
+              intTyCons = [tciTyCon info | info <- tcInterfaceTyCons interface, tciName info == "Int"]
+          case intTyCons of
+            [intTyCon] -> do
+              assertEqual "package identity" (PackageId "test-package-id") (tyConPackageId intTyCon)
+              assertEqual "module identity" "Custom.Int" (tyConModuleName intTyCon)
+            other -> assertFailure ("expected one Int type constructor, got: " <> show other)
+        ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
+    testCase "an Int literal uses the caller package identity" $ do
+      let primId = PackageId "aihc-prim-test-id"
+          result = typecheckExprWithConfig (tcConfig primId) (EInt 1 TInteger "1")
+      case tcResultType result of
+        TcTyCon intTyCon [] -> do
+          assertEqual "package identity" primId (tyConPackageId intTyCon)
+          assertEqual "module identity" "GHC.Types" (tyConModuleName intTyCon)
+        other -> assertFailure ("expected an Int type, got: " <> show other),
+    testCase "explicit forall removes every occurrence of its bound variables" $ do
       case parseSignatureType defaultConfig {parserExtensions = [ExplicitForAll]} "forall a. a -> a" of
         ParseOk signature -> assertEqual "free type variables" [] (freeTypeVars signature)
         ParseErr errors -> assertFailure ("signature should parse: " <> show errors),
@@ -497,7 +521,7 @@ kindTests =
           assertBool "method term exported" ("identity" `elem` interfaceTermNames)
           assertBool
             "constructor term keeps its resolved identity"
-            (TcTermGlobal (PackageId "") "Base" "Unit" `elem` map fst (tcInterfaceTerms interface))
+            (TcTermGlobal (PackageId "main") "Base" "Unit" `elem` map fst (tcInterfaceTerms interface))
           assertBool "type constructor exported" ("Unit" `elem` map tciName (tcInterfaceTyCons interface))
           assertBool "class exported" ("Identity" `elem` map ciName (tcInterfaceClasses interface))
           assertBool "instance exported" ("$fIdentityUnit" `elem` map iiDictName (tcInterfaceInstances interface))
@@ -889,6 +913,12 @@ annotationModule =
 parseM :: Text -> Module
 parseM = parseMWithExtensions []
 
+parseMInPackage :: Package -> Text -> Module
+parseMInPackage package input =
+  case Resolve.resolveWithDeps mempty [(package, parseOnly input)] of
+    ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} -> resolved
+    ResolveResult {resolveErrors} -> error ("Resolve error in test: " ++ show resolveErrors)
+
 parseMWithExtensions :: [Extension] -> Text -> Module
 parseMWithExtensions extensions input =
   case resolveModules [parseOnlyWithExtensions extensions input] of
@@ -902,7 +932,12 @@ resolveModules :: [Module] -> ResolveResult
 resolveModules = resolveModulesWithDeps mempty
 
 resolveModulesWithDeps :: Resolve.ModuleExports -> [Module] -> ResolveResult
-resolveModulesWithDeps depExports = Resolve.resolveWithDeps depExports . modulesInPackage unnamedPackage
+resolveModulesWithDeps depExports = Resolve.resolveWithDeps depExports . map modulePackage
+  where
+    modulePackage modu
+      | moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
+          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
+      | otherwise = (unnamedPackage, modu)
 
 parseOnlyWithExtensions :: [Extension] -> Text -> Module
 parseOnlyWithExtensions extensions input =

--- a/core-libs/aihc-base/src/GHC/Int.hs
+++ b/core-libs/aihc-base/src/GHC/Int.hs
@@ -10,8 +10,7 @@ module GHC.Int
 where
 
 import GHC.Prim ((*#), (+#), (-#))
-
-data Int = I# Int#
+import GHC.Types (Int (..))
 
 data Int8 = I8# Int8#
 

--- a/core-libs/aihc-prim/src/GHC/Types.hs
+++ b/core-libs/aihc-prim/src/GHC/Types.hs
@@ -6,7 +6,8 @@
 {-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 module GHC.Types
-  ( Bool (..),
+  ( Int (..),
+    Bool (..),
     Ordering (..),
     TYPE,
     Levity (..),
@@ -79,6 +80,8 @@ module GHC.Types
     Tuple64# (..),
   )
 where
+
+data Int = I# Int#
 
 data Bool = False | True
 

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -38,7 +38,8 @@ import Aihc.Parser.Syntax
     mkUnqualifiedName,
     parseExtensionName,
   )
-import Aihc.Resolve (ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
+import Aihc.Parser.Syntax qualified as Surface
+import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, TcInterface (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception (bracket, mask, onException)
@@ -251,7 +252,7 @@ compileEvalCase tc =
       case dependencyModules of
         Left errMsg -> pure (Left errMsg)
         Right deps ->
-          let resolved = resolveWithDeps mempty (modulesInPackage unnamedPackage (deps <> evalModules))
+          let resolved = resolveWithDeps mempty (map modulePackage (deps <> evalModules))
            in case resolved of
                 ResolveResult {resolvedModules, resolveErrors = []} ->
                   let moduleAsts = map snd resolvedModules
@@ -266,6 +267,11 @@ compileEvalCase tc =
                         else pure (Left ("typecheck error: " <> renderTcErrors tcResults))
                 ResolveResult {resolveErrors} ->
                   pure (Left ("resolve error: " <> show resolveErrors))
+  where
+    modulePackage modu
+      | Surface.moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
+          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
+      | otherwise = (unnamedPackage, modu)
 
 parseInputs :: EvalCase -> Either String ([Module], Expr)
 parseInputs tc = do

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -260,7 +260,7 @@ compileEvalCase tc =
                    in if all tcModuleSuccess tcResults
                         then do
                           let allBindings = moduleGroupBindings tcResults
-                              results = zipWith (desugarModuleWithDataTypes allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
+                              results = zipWith (desugarModuleWithDataTypes (PackageId "aihc-prim") allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
                           if all dsSuccess results
                             then pure (Right (concatPrograms (map dsProgram results)))
                             else pure (Left ("desugar error: " <> unlines (concatMap dsErrors results)))


### PR DESCRIPTION
## Summary

- Store each type constructor package ID, module name, name, arity, and kind.
- Store structured package, module, and name fields in each global term key.
- Remove the special type-name identity rules.
- Receive the `aihc-prim` package ID from each type-checker caller.
- Use resolver identities for ordinary types, including user-defined `Int` and `Bool` types.
- Define `Int` in `aihc-prim:GHC.Types`.
- Re-export `Int` from `aihc-base:GHC.Int`.
- Retain type identities during type checks and System FC generation.
- Keep each bundled REPL module with its source package during module loading.
- Use `aihc-prim:GHC.Types.Bool` for System FC case binders.

## Reason

Type constructors with the same name and arity had the same identity.
This error caused types from different modules to conflict.
Special type-name rules also removed the defining package and module.
The REPL loader also discarded each source package after it found the module path.
System FC desugaring found `Bool` through the current term scope.

## Effect

All resolved types retain their defining package and module.
The type-checker only needs the caller-provided `aihc-prim` package ID for compiler-known types.
Bundled REPL modules retain the `aihc-base` or `aihc-prim` package identity.
System FC desugaring uses the caller-provided prim package ID for `GHC.Types.Bool`.

## Progress counts

- TC annotated pass fixtures: +1.
- All other progress counts: no change.

## Validation

- `just fmt`
- `just check`