### PR TITLE
fix(cli): preserve package identities in CLI modules

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -15,6 +15,7 @@ library
     Aihc.Cli.Compile
     Aihc.Cli.Install
     Aihc.Cli.Options
+    Aihc.Cli.PackageInterface
     Aihc.Cli.Repl
     Aihc.Cli.Runtime
     Aihc.Cli.Store

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -65,7 +65,7 @@ import Aihc.Parser.Syntax
     headerLanguageEdition,
   )
 import Aihc.Parser.Token (readModuleHeaderPragmas)
-import Aihc.Resolve (ModuleKey (..), Package (..), PackageId (..), ResolveResult (..), Scope (..), resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (ModuleKey (..), Package (..), PackageId (..), ResolveResult (..), Scope (..), resolveWithDeps)
 import Aihc.Tc (tcConfig, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterfaceConfig)
 import Aihc.Wasm qualified as Wasm
 import Control.Exception (bracket)
@@ -245,7 +245,7 @@ compileWithDependencies target wholeProgram dependencies parsed = do
             | ModuleKey package _ <- Map.keys (dependencyExports dependencies),
               packageName package == "aihc-prim"
             ]
-  case resolveWithDeps (dependencyExports dependencies) [(unnamedPackage, parsed)] of
+  case resolveWithDeps (dependencyExports dependencies) [(executablePackage, parsed)] of
     ResolveResult {resolveErrors = errors@(_ : _)} -> Left (CompileFrontendError ["resolve error: " <> show errors])
     ResolveResult {resolvedModules} ->
       let moduleAsts = map snd resolvedModules
@@ -281,6 +281,9 @@ compileWithDependencies target wholeProgram dependencies parsed = do
                         if wholeProgram
                           then compileWholeProgramArtifacts target incremental
                           else compileIncrementalArtifacts target dependencies incremental
+
+executablePackage :: Package
+executablePackage = Package "exe" (PackageId "exe")
 
 topHandlerRunMainOrigin :: DependencyArtifact -> Either CompileError Fc.FcSymbolOrigin
 topHandlerRunMainOrigin dependencies =

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -420,7 +420,7 @@ compileLoadedModules loaded = do
                           let mergedModuleId =
                                 case NonEmpty.toList programs of
                                   [program] -> fcProgramModule program
-                                  _ -> FcModuleId (T.intercalate "+" (concat libraryIds)) (T.intercalate "+" modules)
+                                  _ -> FcModuleId (PackageId (T.intercalate "+" (concat libraryIds))) (T.intercalate "+" modules)
                           sourceCore <-
                             either
                               (Left . ("System FC merge error: " <>) . show)

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -36,6 +36,18 @@ where
 
 import Aihc.Cli.Compile.Dependencies (LibraryPackage (..), installLibraries)
 import Aihc.Cli.Options (InstallErrorFormat (..), InstallOptions (..))
+import Aihc.Cli.PackageInterface
+  ( PackageInterface (..),
+    PackageInterfaceBinding (..),
+    PackageInterfaceDependency (..),
+    PackageInterfaceDiagnostics (..),
+    PackageInterfaceFlag (..),
+    PackageInterfacePackageKey (..),
+    PackageInterfacePackageSpec (..),
+    PackageInterfaceTcModule (..),
+    packageInterfaceModulesFromExports,
+    writePackageInterface,
+  )
 import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cpp qualified as Cpp
 import Aihc.Fc (DesugarResult (..), desugarModuleWithDataTypes, renderProgram)
@@ -70,22 +82,15 @@ import Aihc.Resolve
     PackageId (..),
     ResolveError (..),
     ResolveResult (..),
-    Scope (..),
     extractInterface,
     modulesInPackage,
     resolveWithDeps,
   )
 import Aihc.Tc
-  ( Pred (..),
-    TcBindingResult (..),
+  ( TcBindingResult (..),
     TcDiagnostic (..),
     TcInterface (..),
     TcSeverity (..),
-    TcType (..),
-    TyCon (..),
-    TyVarId (..),
-    Unique (..),
-    renderTcType,
     tcConfig,
     tcModuleBindings,
     tcModuleDiagnostics,
@@ -104,7 +109,6 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as BL
 import Data.Either (rights)
-import Data.Foldable (toList)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (nub, nubBy, sort, sortOn)
 import Data.Map.Strict qualified as Map
@@ -262,7 +266,7 @@ data InterfaceBuildResult = InterfaceBuildResult
     interfaceCppDiagnostics :: ![Aeson.Value],
     interfaceResolveDiagnostics :: ![Aeson.Value],
     interfaceTcDiagnostics :: ![Aeson.Value],
-    interfaceTcModules :: ![Aeson.Value],
+    interfaceTcModules :: ![PackageInterfaceTcModule],
     interfaceTcInterface :: !TcInterface,
     interfaceTcBindings :: ![TcBindingResult],
     interfaceFcDiagnostics :: ![Aeson.Value],
@@ -848,7 +852,7 @@ writeOnePreparedInstallScaffold plan interfaceResult = do
   createDirectoryIfMissing True (takeDirectory interfacePath)
   createDirectoryIfMissing True (takeDirectory fcPath)
   BL.writeFile manifestPath (Aeson.encode manifest)
-  BL.writeFile interfacePath (Aeson.encode (interfaceArtifactValue plan interfaceResult))
+  writePackageInterface interfacePath (packageInterfaceArtifact plan interfaceResult)
   BL.writeFile fcPath (Aeson.encode (fcArtifactValue plan interfaceResult))
 
 blockingInterfaceFailures :: InterfaceBuildResult -> [(String, [Aeson.Value])]
@@ -1148,19 +1152,12 @@ diagnosticSummary =
 
 type DiagnosticSourceMap = Map.Map FilePath (Map.Map Int Text)
 
-addTcModuleDiagnosticSourceLines :: DiagnosticSourceMap -> Aeson.Value -> Aeson.Value
-addTcModuleDiagnosticSourceLines sourceLinesByFile value =
-  case value of
-    Aeson.Object obj ->
-      case KeyMap.lookup "diagnostics" obj of
-        Just (Aeson.Array diagnostics) ->
-          Aeson.Object $
-            KeyMap.insert
-              "diagnostics"
-              (Aeson.toJSON (map (addDiagnosticSourceLines sourceLinesByFile) (toList diagnostics)))
-              obj
-        _ -> value
-    _ -> value
+addTcModuleDiagnosticSourceLines :: DiagnosticSourceMap -> PackageInterfaceTcModule -> PackageInterfaceTcModule
+addTcModuleDiagnosticSourceLines sourceLinesByFile modu =
+  modu
+    { packageInterfaceTcModuleDiagnostics =
+        map (addDiagnosticSourceLines sourceLinesByFile) (packageInterfaceTcModuleDiagnostics modu)
+    }
 
 addDiagnosticSourceLines :: DiagnosticSourceMap -> Aeson.Value -> Aeson.Value
 addDiagnosticSourceLines sourceLinesByFile diagnostic =
@@ -1325,7 +1322,7 @@ packageVariantResolvePackage key =
       packageId = PackageId (T.intercalate "-" (packageVariantLibraryId key))
     }
 
-typecheckInterfaceModules :: PackageId -> TcInterface -> [Module] -> IO ([Module], [Aeson.Value], [Aeson.Value], TcInterface)
+typecheckInterfaceModules :: PackageId -> TcInterface -> [Module] -> IO ([Module], [PackageInterfaceTcModule], [Aeson.Value], TcInterface)
 typecheckInterfaceModules primPackageId importedTcInterface modules = do
   currentModule <- newIORef (listToMaybe sortedModules)
   result <- timeout typecheckPhaseTimeoutMicros (go currentModule)
@@ -1568,27 +1565,26 @@ unlitBird =
       Just ('>', rest) -> rest
       _ -> ""
 
-interfaceArtifactValue :: PackagePlan -> InterfaceBuildResult -> Aeson.Value
-interfaceArtifactValue plan result =
-  object
-    [ "schemaVersion" .= (1 :: Int),
-      "packageKey" .= packageVariantKeyValue (planPackageKey plan),
-      "status" .= interfaceStatus result,
-      "contains" .= (["name-resolution", "types", "fixities"] :: [String]),
-      "sourceFiles" .= interfaceSourceFiles result,
-      "moduleCount" .= interfaceModuleCount result,
-      "modules" .= moduleExportsValue (interfaceModuleExports result),
-      "diagnostics"
-        .= object
-          [ "cpp" .= interfaceCppDiagnostics result,
-            "parse" .= interfaceParseDiagnostics result,
-            "resolve" .= interfaceResolveDiagnostics result,
-            "typecheck" .= interfaceTcDiagnostics result
-          ],
-      "typecheck" .= interfaceTcModules result
-    ]
+packageInterfaceArtifact :: PackagePlan -> InterfaceBuildResult -> PackageInterface
+packageInterfaceArtifact plan result =
+  PackageInterface
+    { packageInterfacePackageKey = packageInterfaceKey (planPackageKey plan),
+      packageInterfaceStatus = interfaceStatus result,
+      packageInterfaceContains = ["name-resolution", "types", "fixities"],
+      packageInterfaceSourceFiles = interfaceSourceFiles result,
+      packageInterfaceModuleCount = interfaceModuleCount result,
+      packageInterfaceModules = packageInterfaceModulesFromExports (interfaceModuleExports result),
+      packageInterfaceDiagnostics =
+        PackageInterfaceDiagnostics
+          { packageInterfaceCppDiagnostics = interfaceCppDiagnostics result,
+            packageInterfaceParseDiagnostics = interfaceParseDiagnostics result,
+            packageInterfaceResolveDiagnostics = interfaceResolveDiagnostics result,
+            packageInterfaceTcDiagnostics = interfaceTcDiagnostics result
+          },
+      packageInterfaceTypecheck = interfaceTcModules result
+    }
 
-interfaceStatus :: InterfaceBuildResult -> String
+interfaceStatus :: InterfaceBuildResult -> Text
 interfaceStatus result =
   if null (interfaceCppDiagnostics result)
     && null (interfaceParseDiagnostics result)
@@ -1597,34 +1593,19 @@ interfaceStatus result =
     then "complete"
     else "partial"
 
-moduleExportsValue :: ModuleExports -> [Aeson.Value]
-moduleExportsValue exports =
-  [ object
-      [ "module" .= moduleKeyName moduleKey,
-        "terms" .= Map.keys (scopeTerms scope),
-        "types" .= Map.keys (scopeTypes scope),
-        "constructors" .= scopeConstructors scope,
-        "recordFields" .= scopeRecordFields scope,
-        "methods" .= scopeMethods scope
-      ]
-  | (moduleKey, scope) <- Map.toAscList exports
-  ]
-
-tcModuleValue :: Module -> Module -> Aeson.Value
+tcModuleValue :: Module -> Module -> PackageInterfaceTcModule
 tcModuleValue modu result =
-  object
-    [ "module" .= moduleDisplayName modu,
-      "success" .= tcModuleSuccess result,
-      "bindings" .= map tcBindingValue (tcModuleBindings result),
-      "diagnostics" .= map (tcDiagnosticValue (moduleDisplayName modu)) (tcModuleDiagnostics result)
-    ]
+  PackageInterfaceTcModule
+    { packageInterfaceTcModuleName = moduleDisplayName modu,
+      packageInterfaceTcModuleSuccess = tcModuleSuccess result,
+      packageInterfaceTcModuleBindings = map tcBinding (tcModuleBindings result),
+      packageInterfaceTcModuleDiagnostics = map (tcDiagnosticValue (moduleDisplayName modu)) (tcModuleDiagnostics result)
+    }
+  where
+    tcBinding binding = PackageInterfaceBinding (tbName binding) (tbType binding)
 
-tcModuleDiagnosticValues :: Aeson.Value -> [Aeson.Value]
-tcModuleDiagnosticValues (Aeson.Object obj) =
-  case KeyMap.lookup "diagnostics" obj of
-    Just (Aeson.Array arr) -> foldr (:) [] arr
-    _ -> []
-tcModuleDiagnosticValues _ = []
+tcModuleDiagnosticValues :: PackageInterfaceTcModule -> [Aeson.Value]
+tcModuleDiagnosticValues = packageInterfaceTcModuleDiagnostics
 
 fcModuleValue :: Module -> DesugarResult -> Aeson.Value
 fcModuleValue modu result =
@@ -1648,86 +1629,6 @@ fcModuleDiagnosticValues (Aeson.Object obj) =
     Just (Aeson.Array arr) -> foldr (:) [] arr
     _ -> []
 fcModuleDiagnosticValues _ = []
-
-tcBindingValue :: TcBindingResult -> Aeson.Value
-tcBindingValue binding =
-  object
-    [ "name" .= tbName binding,
-      "type" .= renderTcType (tbType binding),
-      "typeJson" .= tcTypeValue (tbType binding)
-    ]
-
-tcTypeValue :: TcType -> Aeson.Value
-tcTypeValue ty =
-  case ty of
-    TcTyVar tv ->
-      object
-        [ "tag" .= ("var" :: String),
-          "name" .= tvName tv,
-          "unique" .= uniqueValue (tvUnique tv)
-        ]
-    TcMetaTv unique ->
-      object
-        [ "tag" .= ("meta" :: String),
-          "unique" .= uniqueValue unique
-        ]
-    TcTyCon tyCon args ->
-      object
-        [ "tag" .= ("con" :: String),
-          "name" .= tyConName tyCon,
-          "arity" .= tyConArity tyCon,
-          "args" .= map tcTypeValue args
-        ]
-    TcFunTy arg result ->
-      object
-        [ "tag" .= ("fun" :: String),
-          "arg" .= tcTypeValue arg,
-          "result" .= tcTypeValue result
-        ]
-    TcForAllTy tv body ->
-      object
-        [ "tag" .= ("forall" :: String),
-          "binder" .= tyVarValue tv,
-          "body" .= tcTypeValue body
-        ]
-    TcQualTy preds body ->
-      object
-        [ "tag" .= ("qual" :: String),
-          "predicates" .= map predValue preds,
-          "body" .= tcTypeValue body
-        ]
-    TcAppTy fun arg ->
-      object
-        [ "tag" .= ("app" :: String),
-          "fun" .= tcTypeValue fun,
-          "arg" .= tcTypeValue arg
-        ]
-
-predValue :: Pred -> Aeson.Value
-predValue pred' =
-  case pred' of
-    ClassPred cls args ->
-      object
-        [ "tag" .= ("class" :: String),
-          "class" .= cls,
-          "args" .= map tcTypeValue args
-        ]
-    EqPred left right ->
-      object
-        [ "tag" .= ("eq" :: String),
-          "left" .= tcTypeValue left,
-          "right" .= tcTypeValue right
-        ]
-
-tyVarValue :: TyVarId -> Aeson.Value
-tyVarValue tv =
-  object
-    [ "name" .= tvName tv,
-      "unique" .= uniqueValue (tvUnique tv)
-    ]
-
-uniqueValue :: Unique -> Int
-uniqueValue (Unique unique) = unique
 
 tcDiagnosticValue :: Text -> TcDiagnostic -> Aeson.Value
 tcDiagnosticValue moduleName diag =
@@ -1835,27 +1736,30 @@ packageSpecValue spec =
     ]
 
 packageVariantKeyValue :: PackageVariantKey -> Aeson.Value
-packageVariantKeyValue key =
-  object
-    [ "hash" .= unPackageHash (packageKeyHash key),
-      "package" .= packageSpecValue (packageKeySpec key),
-      "flags" .= map flagAssignmentValue (packageKeyFlags key),
-      "dependencies" .= map resolvedDependencyValue (packageKeyDependencies key)
-    ]
+packageVariantKeyValue = Aeson.toJSON . packageInterfaceKey
 
-resolvedDependencyValue :: ResolvedDependency -> Aeson.Value
-resolvedDependencyValue dependency =
-  object
-    [ "package" .= packageSpecValue (resolvedDependencySpec dependency),
-      "hash" .= unPackageHash (resolvedDependencyHash dependency)
-    ]
+packageInterfaceKey :: PackageVariantKey -> PackageInterfacePackageKey
+packageInterfaceKey key =
+  PackageInterfacePackageKey
+    { packageInterfaceKeyHash = T.pack (unPackageHash (packageKeyHash key)),
+      packageInterfaceKeyPackage = packageInterfaceSpec (packageKeySpec key),
+      packageInterfaceKeyFlags = [PackageInterfaceFlag (T.pack name) enabled | (name, enabled) <- packageKeyFlags key],
+      packageInterfaceKeyDependencies = map packageInterfaceDependency (packageKeyDependencies key)
+    }
 
-flagAssignmentValue :: (String, Bool) -> Aeson.Value
-flagAssignmentValue (flag, enabled) =
-  object
-    [ "name" .= flag,
-      "enabled" .= enabled
-    ]
+packageInterfaceSpec :: PackageSpec -> PackageInterfacePackageSpec
+packageInterfaceSpec spec =
+  PackageInterfacePackageSpec
+    { packageInterfacePackageName = T.pack (pkgName spec),
+      packageInterfacePackageVersion = T.pack (pkgVersion spec)
+    }
+
+packageInterfaceDependency :: ResolvedDependency -> PackageInterfaceDependency
+packageInterfaceDependency dependency =
+  PackageInterfaceDependency
+    { packageInterfaceDependencyPackage = packageInterfaceSpec (resolvedDependencySpec dependency),
+      packageInterfaceDependencyHash = T.pack (unPackageHash (resolvedDependencyHash dependency))
+    }
 
 packageFlagAssignments :: GenericPackageDescription -> [(String, Bool)]
 packageFlagAssignments gpd =

--- a/bin/aihc/src/Aihc/Cli/PackageInterface.hs
+++ b/bin/aihc/src/Aihc/Cli/PackageInterface.hs
@@ -1,0 +1,460 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | The installed package interface JSON format.
+module Aihc.Cli.PackageInterface
+  ( PackageInterface (..),
+    PackageInterfaceBinding (..),
+    PackageInterfaceDependency (..),
+    PackageInterfaceDiagnostics (..),
+    PackageInterfaceFlag (..),
+    PackageInterfaceModule (..),
+    PackageInterfacePackageKey (..),
+    PackageInterfacePackageSpec (..),
+    PackageInterfaceTcModule (..),
+    packageInterfaceExports,
+    packageInterfaceModulesFromExports,
+    packageInterfacePackage,
+    readPackageInterface,
+    writePackageInterface,
+  )
+where
+
+import Aihc.Parser.Syntax (qualifyName, unqualifiedNameFromText)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), PackageId (..), ResolvedName (..), Scope (..))
+import Aihc.Tc (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), renderTcType)
+import Control.Monad (when)
+import Data.Aeson ((.:), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as AesonTypes
+import Data.ByteString.Lazy qualified as BL
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+
+data PackageInterface = PackageInterface
+  { packageInterfacePackageKey :: !PackageInterfacePackageKey,
+    packageInterfaceStatus :: !Text,
+    packageInterfaceContains :: ![Text],
+    packageInterfaceSourceFiles :: ![FilePath],
+    packageInterfaceModuleCount :: !Int,
+    packageInterfaceModules :: ![PackageInterfaceModule],
+    packageInterfaceDiagnostics :: !PackageInterfaceDiagnostics,
+    packageInterfaceTypecheck :: ![PackageInterfaceTcModule]
+  }
+  deriving (Eq, Show)
+
+data PackageInterfacePackageKey = PackageInterfacePackageKey
+  { packageInterfaceKeyHash :: !Text,
+    packageInterfaceKeyPackage :: !PackageInterfacePackageSpec,
+    packageInterfaceKeyFlags :: ![PackageInterfaceFlag],
+    packageInterfaceKeyDependencies :: ![PackageInterfaceDependency]
+  }
+  deriving (Eq, Show)
+
+data PackageInterfacePackageSpec = PackageInterfacePackageSpec
+  { packageInterfacePackageName :: !Text,
+    packageInterfacePackageVersion :: !Text
+  }
+  deriving (Eq, Show)
+
+data PackageInterfaceFlag = PackageInterfaceFlag
+  { packageInterfaceFlagName :: !Text,
+    packageInterfaceFlagEnabled :: !Bool
+  }
+  deriving (Eq, Show)
+
+data PackageInterfaceDependency = PackageInterfaceDependency
+  { packageInterfaceDependencyPackage :: !PackageInterfacePackageSpec,
+    packageInterfaceDependencyHash :: !Text
+  }
+  deriving (Eq, Show)
+
+data PackageInterfaceModule = PackageInterfaceModule
+  { packageInterfaceModuleName :: !Text,
+    packageInterfaceModuleTerms :: ![Text],
+    packageInterfaceModuleTypes :: ![Text],
+    packageInterfaceModuleConstructors :: !(Map.Map Text [Text]),
+    packageInterfaceModuleRecordFields :: !(Map.Map Text [Text]),
+    packageInterfaceModuleMethods :: !(Map.Map Text [Text])
+  }
+  deriving (Eq, Show)
+
+data PackageInterfaceDiagnostics = PackageInterfaceDiagnostics
+  { packageInterfaceCppDiagnostics :: ![Aeson.Value],
+    packageInterfaceParseDiagnostics :: ![Aeson.Value],
+    packageInterfaceResolveDiagnostics :: ![Aeson.Value],
+    packageInterfaceTcDiagnostics :: ![Aeson.Value]
+  }
+  deriving (Eq, Show)
+
+data PackageInterfaceTcModule = PackageInterfaceTcModule
+  { packageInterfaceTcModuleName :: !Text,
+    packageInterfaceTcModuleSuccess :: !Bool,
+    packageInterfaceTcModuleBindings :: ![PackageInterfaceBinding],
+    packageInterfaceTcModuleDiagnostics :: ![Aeson.Value]
+  }
+  deriving (Eq, Show)
+
+data PackageInterfaceBinding = PackageInterfaceBinding
+  { packageInterfaceBindingName :: !Text,
+    packageInterfaceBindingType :: !TcType
+  }
+  deriving (Eq, Show)
+
+packageInterfaceSchemaVersion :: Int
+packageInterfaceSchemaVersion = 1
+
+instance Aeson.ToJSON PackageInterface where
+  toJSON interface =
+    Aeson.object
+      [ "schemaVersion" .= packageInterfaceSchemaVersion,
+        "packageKey" .= packageInterfacePackageKey interface,
+        "status" .= packageInterfaceStatus interface,
+        "contains" .= packageInterfaceContains interface,
+        "sourceFiles" .= packageInterfaceSourceFiles interface,
+        "moduleCount" .= packageInterfaceModuleCount interface,
+        "modules" .= packageInterfaceModules interface,
+        "diagnostics" .= packageInterfaceDiagnostics interface,
+        "typecheck" .= packageInterfaceTypecheck interface
+      ]
+
+instance Aeson.FromJSON PackageInterface where
+  parseJSON =
+    Aeson.withObject "package interface" $ \obj -> do
+      schemaVersion <- obj .: "schemaVersion"
+      when (schemaVersion /= packageInterfaceSchemaVersion) $
+        fail ("unsupported package interface schema version: " <> show (schemaVersion :: Int))
+      PackageInterface
+        <$> obj .: "packageKey"
+        <*> obj .: "status"
+        <*> obj .: "contains"
+        <*> obj .: "sourceFiles"
+        <*> obj .: "moduleCount"
+        <*> obj .: "modules"
+        <*> obj .: "diagnostics"
+        <*> obj .: "typecheck"
+
+instance Aeson.ToJSON PackageInterfacePackageKey where
+  toJSON key =
+    Aeson.object
+      [ "hash" .= packageInterfaceKeyHash key,
+        "package" .= packageInterfaceKeyPackage key,
+        "flags" .= packageInterfaceKeyFlags key,
+        "dependencies" .= packageInterfaceKeyDependencies key
+      ]
+
+instance Aeson.FromJSON PackageInterfacePackageKey where
+  parseJSON =
+    Aeson.withObject "package key" $ \obj ->
+      PackageInterfacePackageKey
+        <$> obj .: "hash"
+        <*> obj .: "package"
+        <*> obj .: "flags"
+        <*> obj .: "dependencies"
+
+instance Aeson.ToJSON PackageInterfacePackageSpec where
+  toJSON spec =
+    Aeson.object
+      [ "name" .= packageInterfacePackageName spec,
+        "version" .= packageInterfacePackageVersion spec
+      ]
+
+instance Aeson.FromJSON PackageInterfacePackageSpec where
+  parseJSON =
+    Aeson.withObject "package" $ \obj ->
+      PackageInterfacePackageSpec
+        <$> obj .: "name"
+        <*> obj .: "version"
+
+instance Aeson.ToJSON PackageInterfaceFlag where
+  toJSON flag =
+    Aeson.object
+      [ "name" .= packageInterfaceFlagName flag,
+        "enabled" .= packageInterfaceFlagEnabled flag
+      ]
+
+instance Aeson.FromJSON PackageInterfaceFlag where
+  parseJSON =
+    Aeson.withObject "package flag" $ \obj ->
+      PackageInterfaceFlag
+        <$> obj .: "name"
+        <*> obj .: "enabled"
+
+instance Aeson.ToJSON PackageInterfaceDependency where
+  toJSON dependency =
+    Aeson.object
+      [ "package" .= packageInterfaceDependencyPackage dependency,
+        "hash" .= packageInterfaceDependencyHash dependency
+      ]
+
+instance Aeson.FromJSON PackageInterfaceDependency where
+  parseJSON =
+    Aeson.withObject "package dependency" $ \obj ->
+      PackageInterfaceDependency
+        <$> obj .: "package"
+        <*> obj .: "hash"
+
+instance Aeson.ToJSON PackageInterfaceModule where
+  toJSON modu =
+    Aeson.object
+      [ "module" .= packageInterfaceModuleName modu,
+        "terms" .= packageInterfaceModuleTerms modu,
+        "types" .= packageInterfaceModuleTypes modu,
+        "constructors" .= packageInterfaceModuleConstructors modu,
+        "recordFields" .= packageInterfaceModuleRecordFields modu,
+        "methods" .= packageInterfaceModuleMethods modu
+      ]
+
+instance Aeson.FromJSON PackageInterfaceModule where
+  parseJSON =
+    Aeson.withObject "interface module" $ \obj ->
+      PackageInterfaceModule
+        <$> obj .: "module"
+        <*> obj .: "terms"
+        <*> obj .: "types"
+        <*> obj .: "constructors"
+        <*> obj .: "recordFields"
+        <*> obj .: "methods"
+
+instance Aeson.ToJSON PackageInterfaceDiagnostics where
+  toJSON diagnostics =
+    Aeson.object
+      [ "cpp" .= packageInterfaceCppDiagnostics diagnostics,
+        "parse" .= packageInterfaceParseDiagnostics diagnostics,
+        "resolve" .= packageInterfaceResolveDiagnostics diagnostics,
+        "typecheck" .= packageInterfaceTcDiagnostics diagnostics
+      ]
+
+instance Aeson.FromJSON PackageInterfaceDiagnostics where
+  parseJSON =
+    Aeson.withObject "package interface diagnostics" $ \obj ->
+      PackageInterfaceDiagnostics
+        <$> obj .: "cpp"
+        <*> obj .: "parse"
+        <*> obj .: "resolve"
+        <*> obj .: "typecheck"
+
+instance Aeson.ToJSON PackageInterfaceTcModule where
+  toJSON modu =
+    Aeson.object
+      [ "module" .= packageInterfaceTcModuleName modu,
+        "success" .= packageInterfaceTcModuleSuccess modu,
+        "bindings" .= packageInterfaceTcModuleBindings modu,
+        "diagnostics" .= packageInterfaceTcModuleDiagnostics modu
+      ]
+
+instance Aeson.FromJSON PackageInterfaceTcModule where
+  parseJSON =
+    Aeson.withObject "typecheck module" $ \obj ->
+      PackageInterfaceTcModule
+        <$> obj .: "module"
+        <*> obj .: "success"
+        <*> obj .: "bindings"
+        <*> obj .: "diagnostics"
+
+instance Aeson.ToJSON PackageInterfaceBinding where
+  toJSON binding =
+    Aeson.object
+      [ "name" .= packageInterfaceBindingName binding,
+        "type" .= renderTcType (packageInterfaceBindingType binding),
+        "typeJson" .= tcTypeValue (packageInterfaceBindingType binding)
+      ]
+
+instance Aeson.FromJSON PackageInterfaceBinding where
+  parseJSON =
+    Aeson.withObject "typecheck binding" $ \obj ->
+      PackageInterfaceBinding
+        <$> obj .: "name"
+        <*> (obj .: "typeJson" >>= parseTcTypeJson)
+
+readPackageInterface :: FilePath -> IO (Either String PackageInterface)
+readPackageInterface path = Aeson.eitherDecode <$> BL.readFile path
+
+writePackageInterface :: FilePath -> PackageInterface -> IO ()
+writePackageInterface path = BL.writeFile path . Aeson.encode
+
+packageInterfacePackage :: PackageInterfacePackageKey -> Package
+packageInterfacePackage key =
+  Package
+    { packageName = packageInterfacePackageName spec,
+      packageId = PackageId identity
+    }
+  where
+    spec = packageInterfaceKeyPackage key
+    identity =
+      T.intercalate
+        "-"
+        ( T.splitOn "-" (packageInterfacePackageName spec)
+            <> T.splitOn "." (packageInterfacePackageVersion spec)
+            <> [packageInterfaceKeyHash key]
+        )
+
+packageInterfaceModulesFromExports :: ModuleExports -> [PackageInterfaceModule]
+packageInterfaceModulesFromExports exports =
+  [ PackageInterfaceModule
+      { packageInterfaceModuleName = moduleKeyName moduleKey,
+        packageInterfaceModuleTerms = Map.keys (scopeTerms scope),
+        packageInterfaceModuleTypes = Map.keys (scopeTypes scope),
+        packageInterfaceModuleConstructors = scopeConstructors scope,
+        packageInterfaceModuleRecordFields = scopeRecordFields scope,
+        packageInterfaceModuleMethods = scopeMethods scope
+      }
+  | (moduleKey, scope) <- Map.toAscList exports
+  ]
+
+packageInterfaceExports :: PackageInterface -> ModuleExports
+packageInterfaceExports interface =
+  Map.fromList
+    [ (ModuleKey package (packageInterfaceModuleName modu), packageInterfaceModuleScope package modu)
+    | modu <- packageInterfaceModules interface
+    ]
+  where
+    package = packageInterfacePackage (packageInterfacePackageKey interface)
+
+packageInterfaceModuleScope :: Package -> PackageInterfaceModule -> Scope
+packageInterfaceModuleScope package modu =
+  Scope
+    { scopeTerms =
+        Map.fromList
+          [ (name, resolvedTopLevel package (packageInterfaceModuleName modu) name)
+          | name <- packageInterfaceModuleTerms modu
+          ],
+      scopeTypes =
+        Map.fromList
+          [ (name, resolvedTopLevel package (packageInterfaceModuleName modu) name)
+          | name <- packageInterfaceModuleTypes modu
+          ],
+      scopeConstructors = packageInterfaceModuleConstructors modu,
+      scopeRecordFields = packageInterfaceModuleRecordFields modu,
+      scopeMethods = packageInterfaceModuleMethods modu,
+      scopeFixities = Map.empty,
+      scopeQualifiedModules = Map.empty
+    }
+
+resolvedTopLevel :: Package -> Text -> Text -> ResolvedName
+resolvedTopLevel package moduleName name =
+  ResolvedTopLevel (packageId package) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
+
+tcTypeValue :: TcType -> Aeson.Value
+tcTypeValue ty =
+  case ty of
+    TcTyVar tv ->
+      Aeson.object
+        [ "tag" .= ("var" :: Text),
+          "name" .= tvName tv,
+          "unique" .= uniqueValue (tvUnique tv)
+        ]
+    TcMetaTv unique ->
+      Aeson.object
+        [ "tag" .= ("meta" :: Text),
+          "unique" .= uniqueValue unique
+        ]
+    TcTyCon tyCon args ->
+      Aeson.object
+        [ "tag" .= ("con" :: Text),
+          "name" .= tyConName tyCon,
+          "arity" .= tyConArity tyCon,
+          "args" .= map tcTypeValue args
+        ]
+    TcFunTy arg result ->
+      Aeson.object
+        [ "tag" .= ("fun" :: Text),
+          "arg" .= tcTypeValue arg,
+          "result" .= tcTypeValue result
+        ]
+    TcForAllTy tv body ->
+      Aeson.object
+        [ "tag" .= ("forall" :: Text),
+          "binder" .= tyVarValue tv,
+          "body" .= tcTypeValue body
+        ]
+    TcQualTy preds body ->
+      Aeson.object
+        [ "tag" .= ("qual" :: Text),
+          "predicates" .= map predValue preds,
+          "body" .= tcTypeValue body
+        ]
+    TcAppTy fun arg ->
+      Aeson.object
+        [ "tag" .= ("app" :: Text),
+          "fun" .= tcTypeValue fun,
+          "arg" .= tcTypeValue arg
+        ]
+
+parseTcTypeJson :: Aeson.Value -> AesonTypes.Parser TcType
+parseTcTypeJson =
+  Aeson.withObject "type" $ \obj -> do
+    tag <- obj .: "tag" :: AesonTypes.Parser Text
+    case tag of
+      "var" -> TcTyVar <$> parseTyVarObject obj
+      "meta" -> TcMetaTv . Unique <$> obj .: "unique"
+      "con" ->
+        TcTyCon
+          <$> (TyCon <$> obj .: "name" <*> obj .: "arity")
+          <*> (obj .: "args" >>= traverse parseTcTypeJson)
+      "fun" ->
+        TcFunTy
+          <$> (obj .: "arg" >>= parseTcTypeJson)
+          <*> (obj .: "result" >>= parseTcTypeJson)
+      "forall" ->
+        TcForAllTy
+          <$> (obj .: "binder" >>= parseTyVarValue)
+          <*> (obj .: "body" >>= parseTcTypeJson)
+      "qual" ->
+        TcQualTy
+          <$> (obj .: "predicates" >>= traverse parsePredJson)
+          <*> (obj .: "body" >>= parseTcTypeJson)
+      "app" ->
+        TcAppTy
+          <$> (obj .: "fun" >>= parseTcTypeJson)
+          <*> (obj .: "arg" >>= parseTcTypeJson)
+      other -> fail ("unknown type tag: " <> T.unpack other)
+
+parseTyVarObject :: AesonTypes.Object -> AesonTypes.Parser TyVarId
+parseTyVarObject obj =
+  TyVarId <$> obj .: "name" <*> (Unique <$> obj .: "unique")
+
+parseTyVarValue :: Aeson.Value -> AesonTypes.Parser TyVarId
+parseTyVarValue =
+  Aeson.withObject "type variable" parseTyVarObject
+
+parsePredJson :: Aeson.Value -> AesonTypes.Parser Pred
+parsePredJson =
+  Aeson.withObject "predicate" $ \obj -> do
+    tag <- obj .: "tag" :: AesonTypes.Parser Text
+    case tag of
+      "class" ->
+        ClassPred
+          <$> obj .: "class"
+          <*> (obj .: "args" >>= traverse parseTcTypeJson)
+      "eq" ->
+        EqPred
+          <$> (obj .: "left" >>= parseTcTypeJson)
+          <*> (obj .: "right" >>= parseTcTypeJson)
+      other -> fail ("unknown predicate tag: " <> T.unpack other)
+
+predValue :: Pred -> Aeson.Value
+predValue pred' =
+  case pred' of
+    ClassPred cls args ->
+      Aeson.object
+        [ "tag" .= ("class" :: Text),
+          "class" .= cls,
+          "args" .= map tcTypeValue args
+        ]
+    EqPred left right ->
+      Aeson.object
+        [ "tag" .= ("eq" :: Text),
+          "left" .= tcTypeValue left,
+          "right" .= tcTypeValue right
+        ]
+
+tyVarValue :: TyVarId -> Aeson.Value
+tyVarValue tv =
+  Aeson.object
+    [ "name" .= tvName tv,
+      "unique" .= uniqueValue (tvUnique tv)
+    ]
+
+uniqueValue :: Unique -> Int
+uniqueValue (Unique unique) = unique

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -35,7 +35,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameFromText,
   )
 import Aihc.Parser.Syntax qualified as Syntax
-import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), PackageId (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), PackageId (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
 import Aihc.Tc
   ( InstanceInfo,
     Pred (..),
@@ -220,7 +220,7 @@ typecheckExpression session input = do
       ParseOk parsed -> Right parsed
       ParseErr _ -> Left ReplParseError
   let parsedModule = replModule expr
-      resolved = resolveWithDeps (replModuleExports session) [(unnamedPackage, parsedModule)]
+      resolved = resolveWithDeps (replModuleExports session) [(replPackage, parsedModule)]
   case resolveErrors resolved of
     [] -> pure ()
     errors -> Left (ReplResolveError errors)
@@ -429,6 +429,15 @@ replModule expr =
 replBindingName :: Text
 replBindingName = "__aihc_repl_it"
 
+replPackage :: Package
+replPackage = Package "repl" (PackageId "repl")
+
+aihcBasePackage :: Package
+aihcBasePackage = Package "aihc-base" (PackageId "aihc-base")
+
+aihcPrimPackage :: Package
+aihcPrimPackage = Package "aihc-prim" (PackageId "aihc-prim")
+
 renderReplError :: ReplError -> String
 renderReplError err =
   case err of
@@ -490,8 +499,8 @@ loadAihcBaseContext = do
   primRoot <- defaultAihcPrimRoot
   modulesResult <-
     loadTransitiveModules
-      [ (Package "aihc-base" (PackageId "aihc-base"), baseRoot),
-        (Package "aihc-prim" (PackageId "aihc-prim"), primRoot)
+      [ (aihcBasePackage, baseRoot),
+        (aihcPrimPackage, primRoot)
       ]
       (Set.singleton "Prelude")
   case modulesResult of
@@ -713,11 +722,12 @@ loadInterface path = do
 parseInterface :: Aeson.Value -> AesonTypes.Parser Interface
 parseInterface =
   Aeson.withObject "package interface" $ \obj -> do
+    package <- obj .: "packageKey" >>= parseInterfacePackage
     modules <- obj .: "modules"
     tcModules <- obj .:? "typecheck" .!= []
     pure
       Interface
-        { interfaceExports = Map.fromList [(ModuleKey unnamedPackage (interfaceModuleName modu), interfaceModuleScope modu) | modu <- modules],
+        { interfaceExports = Map.fromList [(ModuleKey package (interfaceModuleName modu), interfaceModuleScope package modu) | modu <- modules],
           interfaceImportedTerms = concatMap interfaceTcModuleTerms tcModules,
           interfaceBindingTypes =
             Map.fromList
@@ -725,6 +735,19 @@ parseInterface =
               | modu <- tcModules
               ]
         }
+
+parseInterfacePackage :: Aeson.Value -> AesonTypes.Parser Package
+parseInterfacePackage =
+  Aeson.withObject "package key" $ \obj -> do
+    hash <- obj .: "hash"
+    spec <- obj .: "package"
+    Aeson.withObject "package" (parsePackageSpec hash) spec
+  where
+    parsePackageSpec hash obj = do
+      name <- obj .: "name"
+      version <- obj .: "version"
+      let identity = T.intercalate "-" (T.splitOn "-" name <> T.splitOn "." version <> [hash])
+      pure (Package name (PackageId identity))
 
 data InterfaceTcModule = InterfaceTcModule
   { interfaceTcModuleName :: !Text,
@@ -765,17 +788,17 @@ interfaceTcModuleBindingTypes modu =
     | InterfaceTcBinding name (Just ty) <- interfaceTcModuleBindings modu
     ]
 
-interfaceModuleScope :: InterfaceModule -> Scope
-interfaceModuleScope modu =
+interfaceModuleScope :: Package -> InterfaceModule -> Scope
+interfaceModuleScope package modu =
   Scope
     { scopeTerms =
         Map.fromList
-          [ (name, resolvedTopLevel (interfaceModuleName modu) name)
+          [ (name, resolvedTopLevel package (interfaceModuleName modu) name)
           | name <- interfaceModuleTerms modu
           ],
       scopeTypes =
         Map.fromList
-          [ (name, resolvedTopLevel (interfaceModuleName modu) name)
+          [ (name, resolvedTopLevel package (interfaceModuleName modu) name)
           | name <- interfaceModuleTypes modu
           ],
       scopeConstructors = interfaceModuleConstructors modu,
@@ -785,9 +808,9 @@ interfaceModuleScope modu =
       scopeQualifiedModules = Map.empty
     }
 
-resolvedTopLevel :: Text -> Text -> ResolvedName
-resolvedTopLevel moduleName name =
-  ResolvedTopLevel (packageId unnamedPackage) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
+resolvedTopLevel :: Package -> Text -> Text -> ResolvedName
+resolvedTopLevel package moduleName name =
+  ResolvedTopLevel (packageId package) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
 
 findInstalledBaseInterface :: FilePath -> IO FilePath
 findInstalledBaseInterface storeRoot = do
@@ -839,7 +862,7 @@ ensurePreludeMvpScope exports =
   where
     preludeKey =
       fromMaybe
-        (ModuleKey unnamedPackage "Prelude")
+        (ModuleKey aihcBasePackage "Prelude")
         (find ((== "Prelude") . moduleKeyName) (Map.keys exports))
     existing = Map.findWithDefault emptyScope preludeKey exports
     resolvePreludeName =

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -14,6 +14,13 @@ module Aihc.Cli.Repl
   )
 where
 
+import Aihc.Cli.PackageInterface
+  ( PackageInterface (..),
+    PackageInterfaceBinding (..),
+    PackageInterfaceTcModule (..),
+    packageInterfaceExports,
+    readPackageInterface,
+  )
 import Aihc.Fc (DesugarResult (..), FcModuleId (..), FcProgram (..), desugarModuleWithBindings, evalProgramBinding, mergePrograms, renderProgram, renderValue)
 import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExpr, parseModule)
 import Aihc.Parser.Shorthand (Shorthand (..))
@@ -38,7 +45,6 @@ import Aihc.Parser.Syntax qualified as Syntax
 import Aihc.Resolve (ModuleExports, ModuleKey (..), Package (..), PackageId (..), ResolveError (..), ResolveResult (..), ResolvedName (..), Scope (..), extractInterface, resolveWithDeps)
 import Aihc.Tc
   ( InstanceInfo,
-    Pred (..),
     TcBindingResult (..),
     TcDiagnostic (..),
     TcErrorKind (..),
@@ -60,9 +66,8 @@ import Aihc.Tc
     typecheckModulesWithInterfaceConfig,
   )
 import Control.Monad.IO.Class (liftIO)
-import Data.Aeson ((.!=), (.:), (.:?))
+import Data.Aeson ((.:))
 import Data.Aeson qualified as Aeson
-import Data.Aeson.Types qualified as AesonTypes
 import Data.ByteString.Lazy qualified as BL
 import Data.Char (isAlpha, isSpace)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -155,7 +160,7 @@ loadReplSession maybeStoreRoot = do
   baseContext <- loadAihcBaseContext
   installedInterface <- loadExplicitStoreInterface maybeStoreRoot
   settingsRef <- newIORef defaultReplSettings
-  let installedExports = maybe Map.empty interfaceExports installedInterface
+  let installedExports = maybe Map.empty packageInterfaceExports installedInterface
       installedTerms = maybe [] interfaceImportedTerms installedInterface
       installedBindingTypes = maybe Map.empty interfaceBindingTypes installedInterface
   pure
@@ -479,12 +484,6 @@ trim = dropWhileEnd isSpace . dropWhile isSpace
 dropWhileEnd :: (a -> Bool) -> [a] -> [a]
 dropWhileEnd predicate = reverse . dropWhile predicate . reverse
 
-data Interface = Interface
-  { interfaceExports :: ModuleExports,
-    interfaceImportedTerms :: [(Text, TypeScheme)],
-    interfaceBindingTypes :: Map.Map Text (Map.Map Text TcType)
-  }
-
 data ReplBaseContext = ReplBaseContext
   { replBaseExports :: !ModuleExports,
     replBaseImportedTerms :: ![(Text, TypeScheme)],
@@ -596,11 +595,37 @@ concatPrograms programs =
         id
         (mergePrograms (FcModuleId "repl" "Interactive") nonEmptyPrograms)
 
-loadExplicitStoreInterface :: Maybe FilePath -> IO (Maybe Interface)
+loadExplicitStoreInterface :: Maybe FilePath -> IO (Maybe PackageInterface)
 loadExplicitStoreInterface Nothing = pure Nothing
 loadExplicitStoreInterface (Just storeRoot) = do
   interfacePath <- findInstalledBaseInterface storeRoot
   Just <$> loadInterface interfacePath
+
+loadInterface :: FilePath -> IO PackageInterface
+loadInterface path = do
+  result <- readPackageInterface path
+  case result of
+    Left err -> ioError (userError (renderReplError (ReplInvalidInterface path err)))
+    Right interface -> pure interface
+
+interfaceImportedTerms :: PackageInterface -> [(Text, TypeScheme)]
+interfaceImportedTerms interface =
+  [ (normalizeImportedBindingName (packageInterfaceBindingName binding), tcTypeScheme (packageInterfaceBindingType binding))
+  | modu <- packageInterfaceTypecheck interface,
+    binding <- packageInterfaceTcModuleBindings modu
+  ]
+
+interfaceBindingTypes :: PackageInterface -> Map.Map Text (Map.Map Text TcType)
+interfaceBindingTypes interface =
+  Map.fromList
+    [ ( packageInterfaceTcModuleName modu,
+        Map.fromList
+          [ (normalizeImportedBindingName (packageInterfaceBindingName binding), packageInterfaceBindingType binding)
+          | binding <- packageInterfaceTcModuleBindings modu
+          ]
+      )
+    | modu <- packageInterfaceTypecheck interface
+    ]
 
 defaultAihcBaseRoot :: IO FilePath
 defaultAihcBaseRoot = defaultCoreLibraryRoot "AIHC_BASE_SRC" "aihc-base"
@@ -687,130 +712,6 @@ parseOneModule sourceName input =
 importedModuleNames :: [Module] -> Set.Set Text
 importedModuleNames modules =
   Set.fromList [importDeclModule importDecl | modu <- modules, importDecl <- moduleImports modu]
-
-data InterfaceModule = InterfaceModule
-  { interfaceModuleName :: !Text,
-    interfaceModuleTerms :: ![Text],
-    interfaceModuleTypes :: ![Text],
-    interfaceModuleConstructors :: !(Map.Map Text [Text]),
-    interfaceModuleRecordFields :: !(Map.Map Text [Text]),
-    interfaceModuleMethods :: !(Map.Map Text [Text])
-  }
-  deriving (Show)
-
-instance Aeson.FromJSON InterfaceModule where
-  parseJSON =
-    Aeson.withObject "interface module" $ \obj ->
-      InterfaceModule
-        <$> obj .: "module"
-        <*> obj .: "terms"
-        <*> obj .: "types"
-        <*> obj .: "constructors"
-        <*> obj .: "recordFields"
-        <*> obj .: "methods"
-
-loadInterface :: FilePath -> IO Interface
-loadInterface path = do
-  bytes <- BL.readFile path
-  case Aeson.eitherDecode bytes of
-    Left err -> ioError (userError (renderReplError (ReplInvalidInterface path err)))
-    Right value ->
-      case AesonTypes.parseEither parseInterface value of
-        Left err -> ioError (userError (renderReplError (ReplInvalidInterface path err)))
-        Right interface -> pure interface
-
-parseInterface :: Aeson.Value -> AesonTypes.Parser Interface
-parseInterface =
-  Aeson.withObject "package interface" $ \obj -> do
-    package <- obj .: "packageKey" >>= parseInterfacePackage
-    modules <- obj .: "modules"
-    tcModules <- obj .:? "typecheck" .!= []
-    pure
-      Interface
-        { interfaceExports = Map.fromList [(ModuleKey package (interfaceModuleName modu), interfaceModuleScope package modu) | modu <- modules],
-          interfaceImportedTerms = concatMap interfaceTcModuleTerms tcModules,
-          interfaceBindingTypes =
-            Map.fromList
-              [ (interfaceTcModuleName modu, interfaceTcModuleBindingTypes modu)
-              | modu <- tcModules
-              ]
-        }
-
-parseInterfacePackage :: Aeson.Value -> AesonTypes.Parser Package
-parseInterfacePackage =
-  Aeson.withObject "package key" $ \obj -> do
-    hash <- obj .: "hash"
-    spec <- obj .: "package"
-    Aeson.withObject "package" (parsePackageSpec hash) spec
-  where
-    parsePackageSpec hash obj = do
-      name <- obj .: "name"
-      version <- obj .: "version"
-      let identity = T.intercalate "-" (T.splitOn "-" name <> T.splitOn "." version <> [hash])
-      pure (Package name (PackageId identity))
-
-data InterfaceTcModule = InterfaceTcModule
-  { interfaceTcModuleName :: !Text,
-    interfaceTcModuleBindings :: [InterfaceTcBinding]
-  }
-  deriving (Show)
-
-data InterfaceTcBinding = InterfaceTcBinding
-  { interfaceTcBindingName :: !Text,
-    interfaceTcBindingType :: !(Maybe TcType)
-  }
-  deriving (Show)
-
-instance Aeson.FromJSON InterfaceTcModule where
-  parseJSON =
-    Aeson.withObject "typecheck module" $ \obj ->
-      InterfaceTcModule
-        <$> obj .: "module"
-        <*> obj .: "bindings"
-
-instance Aeson.FromJSON InterfaceTcBinding where
-  parseJSON =
-    Aeson.withObject "typecheck binding" $ \obj ->
-      InterfaceTcBinding
-        <$> obj .: "name"
-        <*> (obj .:? "typeJson" >>= traverse parseTcTypeJson)
-
-interfaceTcModuleTerms :: InterfaceTcModule -> [(Text, TypeScheme)]
-interfaceTcModuleTerms modu =
-  [ (normalizeImportedBindingName name, tcTypeScheme ty)
-  | InterfaceTcBinding name (Just ty) <- interfaceTcModuleBindings modu
-  ]
-
-interfaceTcModuleBindingTypes :: InterfaceTcModule -> Map.Map Text TcType
-interfaceTcModuleBindingTypes modu =
-  Map.fromList
-    [ (normalizeImportedBindingName name, ty)
-    | InterfaceTcBinding name (Just ty) <- interfaceTcModuleBindings modu
-    ]
-
-interfaceModuleScope :: Package -> InterfaceModule -> Scope
-interfaceModuleScope package modu =
-  Scope
-    { scopeTerms =
-        Map.fromList
-          [ (name, resolvedTopLevel package (interfaceModuleName modu) name)
-          | name <- interfaceModuleTerms modu
-          ],
-      scopeTypes =
-        Map.fromList
-          [ (name, resolvedTopLevel package (interfaceModuleName modu) name)
-          | name <- interfaceModuleTypes modu
-          ],
-      scopeConstructors = interfaceModuleConstructors modu,
-      scopeRecordFields = interfaceModuleRecordFields modu,
-      scopeMethods = interfaceModuleMethods modu,
-      scopeFixities = Map.empty,
-      scopeQualifiedModules = Map.empty
-    }
-
-resolvedTopLevel :: Package -> Text -> Text -> ResolvedName
-resolvedTopLevel package moduleName name =
-  ResolvedTopLevel (packageId package) (qualifyName (Just moduleName) (unqualifiedNameFromText name))
 
 findInstalledBaseInterface :: FilePath -> IO FilePath
 findInstalledBaseInterface storeRoot = do
@@ -920,58 +821,6 @@ collectForAlls (TcForAllTy tv body) =
   let (tvs, inner) = collectForAlls body
    in (tv : tvs, inner)
 collectForAlls ty = ([], ty)
-
-parseTcTypeJson :: Aeson.Value -> AesonTypes.Parser TcType
-parseTcTypeJson =
-  Aeson.withObject "type" $ \obj -> do
-    tag <- obj .: "tag" :: AesonTypes.Parser Text
-    case tag of
-      "var" -> TcTyVar <$> parseTyVarObject obj
-      "meta" -> TcMetaTv . Unique <$> obj .: "unique"
-      "con" ->
-        TcTyCon
-          <$> (TyCon <$> obj .: "name" <*> obj .: "arity")
-          <*> (obj .: "args" >>= traverse parseTcTypeJson)
-      "fun" ->
-        TcFunTy
-          <$> (obj .: "arg" >>= parseTcTypeJson)
-          <*> (obj .: "result" >>= parseTcTypeJson)
-      "forall" ->
-        TcForAllTy
-          <$> (obj .: "binder" >>= parseTyVarValue)
-          <*> (obj .: "body" >>= parseTcTypeJson)
-      "qual" ->
-        TcQualTy
-          <$> (obj .: "predicates" >>= traverse parsePredJson)
-          <*> (obj .: "body" >>= parseTcTypeJson)
-      "app" ->
-        TcAppTy
-          <$> (obj .: "fun" >>= parseTcTypeJson)
-          <*> (obj .: "arg" >>= parseTcTypeJson)
-      other -> fail ("unknown type tag: " <> T.unpack other)
-
-parseTyVarObject :: AesonTypes.Object -> AesonTypes.Parser TyVarId
-parseTyVarObject obj =
-  TyVarId <$> obj .: "name" <*> (Unique <$> obj .: "unique")
-
-parseTyVarValue :: Aeson.Value -> AesonTypes.Parser TyVarId
-parseTyVarValue =
-  Aeson.withObject "type variable" parseTyVarObject
-
-parsePredJson :: Aeson.Value -> AesonTypes.Parser Pred
-parsePredJson =
-  Aeson.withObject "predicate" $ \obj -> do
-    tag <- obj .: "tag" :: AesonTypes.Parser Text
-    case tag of
-      "class" ->
-        ClassPred
-          <$> obj .: "class"
-          <*> (obj .: "args" >>= traverse parseTcTypeJson)
-      "eq" ->
-        EqPred
-          <$> (obj .: "left" >>= parseTcTypeJson)
-          <*> (obj .: "right" >>= parseTcTypeJson)
-      other -> fail ("unknown predicate tag: " <> T.unpack other)
 
 emptyScope :: Scope
 emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -32,6 +32,19 @@ import Aihc.Cli.Install
     writeInstallScaffold,
   )
 import Aihc.Cli.Options (Command (..), CompileOptions (..), GarbageCollector (..), InstallErrorFormat (..), InstallOptions (..), PrepareRuntimeOptions (..), ReplOptions (..), parseCommandPure)
+import Aihc.Cli.PackageInterface
+  ( PackageInterface (..),
+    PackageInterfaceBinding (..),
+    PackageInterfaceDependency (..),
+    PackageInterfaceDiagnostics (..),
+    PackageInterfaceFlag (..),
+    PackageInterfaceModule (..),
+    PackageInterfacePackageKey (..),
+    PackageInterfacePackageSpec (..),
+    PackageInterfaceTcModule (..),
+    packageInterfaceExports,
+    readPackageInterface,
+  )
 import Aihc.Cli.Repl (ReplError (..), ReplSession (..), ReplStep (..), defaultReplSettings, evaluateExpression, handleReplInput, loadReplSession, replCompletion)
 import Aihc.Cli.Runtime (prepareRuntimeArchive, readWasmClangProcessWithExitCode)
 import Aihc.Fc
@@ -48,7 +61,7 @@ import Aihc.Grin qualified as Grin
 import Aihc.Hackage.Types (PackageSpec (..))
 import Aihc.Native (NativeTarget (..))
 import Aihc.Resolve (ModuleKey (..), Package (..), PackageId (..), Scope (..), unnamedPackage)
-import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), Unique (..))
+import Aihc.Tc (RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
 import Control.Exception (bracket)
 import Data.Aeson (object, (.=))
 import Data.Aeson qualified as Aeson
@@ -335,7 +348,11 @@ main =
             assertBool
               "no unnamed Prelude"
               (Map.notMember (ModuleKey unnamedPackage "Prelude") exports),
-          testCase "loads installed base interface for Prelude MVP scope" test_loadsInstalledBaseInterfaceForRepl
+          testCase "loads installed base interface for Prelude MVP scope" test_loadsInstalledBaseInterfaceForRepl,
+          testCase "round-trips the shared package interface" test_packageInterfaceRoundTrip,
+          testCase "rejects unsupported package interface schemas" $
+            let decoded = Aeson.eitherDecode (Aeson.encode (object ["schemaVersion" .= (2 :: Int)])) :: Either String PackageInterface
+             in assertLeftContains "unsupported package interface schema version" decoded
         ],
       testGroup
         "install"
@@ -433,11 +450,18 @@ test_loadsInstalledBaseInterfaceForRepl =
       interfacePath
       ( Aeson.encode
           ( object
-              [ "packageKey"
+              [ "schemaVersion" .= (1 :: Int),
+                "packageKey"
                   .= object
                     [ "hash" .= ("dephash" :: String),
-                      "package" .= object ["name" .= ("aihc-base" :: String), "version" .= ("4.21.2.0" :: String)]
+                      "package" .= object ["name" .= ("aihc-base" :: String), "version" .= ("4.21.2.0" :: String)],
+                      "flags" .= ([] :: [Aeson.Value]),
+                      "dependencies" .= ([] :: [Aeson.Value])
                     ],
+                "status" .= ("complete" :: String),
+                "contains" .= (["name-resolution", "types", "fixities"] :: [String]),
+                "sourceFiles" .= ([] :: [FilePath]),
+                "moduleCount" .= (2 :: Int),
                 "modules"
                   .= [ object
                          [ "module" .= ("Prelude" :: String),
@@ -455,7 +479,15 @@ test_loadsInstalledBaseInterfaceForRepl =
                            "recordFields" .= object [],
                            "methods" .= object []
                          ]
-                     ]
+                     ],
+                "diagnostics"
+                  .= object
+                    [ "cpp" .= ([] :: [Aeson.Value]),
+                      "parse" .= ([] :: [Aeson.Value]),
+                      "resolve" .= ([] :: [Aeson.Value]),
+                      "typecheck" .= ([] :: [Aeson.Value])
+                    ],
+                "typecheck" .= ([] :: [Aeson.Value])
               ]
           )
       )
@@ -479,6 +511,45 @@ test_loadsInstalledBaseInterfaceForRepl =
       Right output ->
         assertBool ("expected [Char] type, got:\n" <> T.unpack output) ("type:\n[Char]" `T.isInfixOf` output)
       Left err -> assertFailure ("expected typed string success, got " <> show err)
+
+test_packageInterfaceRoundTrip :: Assertion
+test_packageInterfaceRoundTrip = do
+  let typeVariable = TyVarId "a" (Unique 11)
+      identityType = TcForAllTy typeVariable (TcFunTy (TcTyVar typeVariable) (TcTyVar typeVariable))
+      packageKey =
+        PackageInterfacePackageKey
+          { packageInterfaceKeyHash = "dephash",
+            packageInterfaceKeyPackage = PackageInterfacePackageSpec "demo" "1.2.3",
+            packageInterfaceKeyFlags = [PackageInterfaceFlag "debug" True],
+            packageInterfaceKeyDependencies =
+              [PackageInterfaceDependency (PackageInterfacePackageSpec "base" "4.21.2.0") "basehash"]
+          }
+      interface =
+        PackageInterface
+          { packageInterfacePackageKey = packageKey,
+            packageInterfaceStatus = "complete",
+            packageInterfaceContains = ["name-resolution", "types", "fixities"],
+            packageInterfaceSourceFiles = ["src/Demo.hs"],
+            packageInterfaceModuleCount = 1,
+            packageInterfaceModules =
+              [ PackageInterfaceModule
+                  { packageInterfaceModuleName = "Demo",
+                    packageInterfaceModuleTerms = ["identity"],
+                    packageInterfaceModuleTypes = [],
+                    packageInterfaceModuleConstructors = Map.empty,
+                    packageInterfaceModuleRecordFields = Map.empty,
+                    packageInterfaceModuleMethods = Map.empty
+                  }
+              ],
+            packageInterfaceDiagnostics = PackageInterfaceDiagnostics [] [] [] [],
+            packageInterfaceTypecheck =
+              [PackageInterfaceTcModule "Demo" True [PackageInterfaceBinding "identity" identityType] []]
+          }
+      decoded = Aeson.eitherDecode (Aeson.encode interface)
+  assertEqual "package interface" (Right interface) decoded
+  assertBool
+    "decoded package identity"
+    (Map.member (ModuleKey (Package "demo" (PackageId "demo-1-2-3-dephash")) "Demo") (packageInterfaceExports interface))
 
 test_stableStorePath :: Assertion
 test_stableStorePath =
@@ -575,6 +646,10 @@ test_writeInstallScaffold =
     assertBool "interface includes modules" ("modules" `isInfixOf` renderedInterface)
     assertBool "interface includes typecheck data" ("typecheck" `isInfixOf` renderedInterface)
     assertBool "interface is implemented" (not ("unimplemented" `isInfixOf` renderedInterface))
+    decodedInterface <- readPackageInterface (resultInterfacePath result)
+    case decodedInterface of
+      Left err -> assertFailure ("expected valid package interface, got " <> err)
+      Right interface -> assertEqual "decoded interface module count" 1 (packageInterfaceModuleCount interface)
 
     fcJson <- BL8.readFile (resultFcPath result)
     let renderedFc = BL8.unpack fcJson

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -314,7 +314,7 @@ main =
                 assertBool ("expected type output, got:\n" <> T.unpack output) ("type:\n[Char]" `T.isInfixOf` output)
                 assertBool
                   ("expected system-fc output, got:\n" <> T.unpack output)
-                  ( "system-fc:\nmodule Aihc.Repl where" `T.isInfixOf` output
+                  ( "system-fc:\nmodule \"repl\" Aihc.Repl where" `T.isInfixOf` output
                       && "__aihc_repl_it : [Char] =" `T.isInfixOf` output
                   )
                 assertBool ("expected desugared char list, got:\n" <> T.unpack output) (not ("LitString" `T.isInfixOf` output))
@@ -433,9 +433,22 @@ test_loadsInstalledBaseInterfaceForRepl =
       interfacePath
       ( Aeson.encode
           ( object
-              [ "modules"
+              [ "packageKey"
+                  .= object
+                    [ "hash" .= ("dephash" :: String),
+                      "package" .= object ["name" .= ("aihc-base" :: String), "version" .= ("4.21.2.0" :: String)]
+                    ],
+                "modules"
                   .= [ object
                          [ "module" .= ("Prelude" :: String),
+                           "terms" .= ([] :: [String]),
+                           "types" .= ([] :: [String]),
+                           "constructors" .= object [],
+                           "recordFields" .= object [],
+                           "methods" .= object []
+                         ],
+                       object
+                         [ "module" .= ("Data.Installed" :: String),
                            "terms" .= ([] :: [String]),
                            "types" .= ([] :: [String]),
                            "constructors" .= object [],
@@ -447,6 +460,12 @@ test_loadsInstalledBaseInterfaceForRepl =
           )
       )
     session <- loadReplSession (Just storeRoot)
+    assertBool
+      "installed package identity"
+      ( Map.member
+          (ModuleKey (Package "aihc-base" (PackageId "aihc-base-4-21-2-0-dephash")) "Data.Installed")
+          (replModuleExports session)
+      )
     case Map.lookup (ModuleKey (Package "aihc-base" (PackageId "aihc-base")) "Prelude") (replModuleExports session) of
       Nothing -> assertFailure "Prelude scope not loaded"
       Just preludeScope -> do
@@ -1147,6 +1166,8 @@ test_installedPackage =
       Left err -> assertFailure (show err)
       Right core -> do
         assertBool "expected qualified generated entry point" ("$g$exe$Main$_24_aihc_2e_main" `T.isInfixOf` core)
+        assertBool "expected executable source binding" ("$g$exe$Main$main" `T.isInfixOf` core)
+        assertBool "expected no unnamed source binding" (not ("$g$main$Main$main" `T.isInfixOf` core))
         assertBool "expected top-level handler call" ("runMainIO" `T.isInfixOf` core)
         assertBool "expected installed dependency body" ("main" `T.isInfixOf` core)
         assertBool ("expected no external references in:\n" <> T.unpack core) (not ("external " `T.isInfixOf` core))

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -137,7 +137,7 @@ desugarModuleWithDataTypes primPackageId bindings dataTypes tcResult resolvedMod
         }
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
-          (packageName, currentModuleName) = resolvedModuleOrigin resolvedModule
+          (packageId, currentModuleName) = resolvedModuleOrigin resolvedModule
           constructorFields =
             Map.fromList
               [ (dciName constructor, dciFields constructor)
@@ -145,7 +145,7 @@ desugarModuleWithDataTypes primPackageId bindings dataTypes tcResult resolvedMod
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 primPackageId packageName (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
+       in case runStateT (dsModule tcResult) (DsState 1000 primPackageId (packageIdText packageId) (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram (sourceModuleId resolvedModule) [],
@@ -153,20 +153,20 @@ desugarModuleWithDataTypes primPackageId bindings dataTypes tcResult resolvedMod
                   dsErrors = [err]
                 }
             Right (binds, _) ->
-              let program = FcProgram (FcModuleId packageName currentModuleName) binds
+              let program = FcProgram (FcModuleId packageId currentModuleName) binds
                in DesugarResult
                     { dsProgram = declareExternalSymbols (lowerPseudoOps (lowerConstraintProgram (lowerNewtypes program))),
                       dsSuccess = True,
                       dsErrors = []
                     }
 
-resolvedModuleOrigin :: Module -> (Text, Text)
+resolvedModuleOrigin :: Module -> (PackageId, Text)
 resolvedModuleOrigin resolvedModule =
   fromMaybe ("", fromMaybe "Main" (moduleName resolvedModule)) $ do
     resolved <- listToMaybe (mapMaybe definitionResolution (moduleDecls resolvedModule))
     case resolutionTarget resolved of
       ResolvedTopLevel packageId name ->
-        pure (packageIdText packageId, fromMaybe (fromMaybe "Main" (moduleName resolvedModule)) (nameQualifier name))
+        pure (packageId, fromMaybe (fromMaybe "Main" (moduleName resolvedModule)) (nameQualifier name))
       _ -> Nothing
 
 sourceModuleId :: Module -> FcModuleId

--- a/components/aihc-fc/src/Aihc/Fc/Merge.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Merge.hs
@@ -86,7 +86,7 @@ qualifyTopLevelBinders program =
     globalOrigin var =
       fromMaybe
         ( FcTopLevelOrigin
-            { fcOriginPackage = fcModulePackage moduleId,
+            { fcOriginPackage = fcModulePackageText moduleId,
               fcOriginModule = fcModuleName moduleId,
               fcOriginName = varName var
             }

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -14,6 +14,7 @@ where
 
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Fc.Syntax
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Evidence (Coercion (..), EvVar (..))
 import Aihc.Tc.Types
 import Control.Applicative ((<|>))
@@ -55,7 +56,7 @@ parseProgram input = do
   let definitionBlocks = [block | (block, Nothing) <- zip blocks moduleHeaders]
   headers <- traverse parseExternalHeader definitionBlocks
   validateExternalDeclarations input headers
-  let moduleOrigin = Just (fcModulePackage moduleId, fcModuleName moduleId)
+  let moduleOrigin = Just (fcModulePackageText moduleId, fcModuleName moduleId)
   signatures <- traverse (parseSignatures moduleOrigin) definitionBlocks
   let globals = Map.unions (catMaybes signatures) <> externalEnv headers
   FcProgram moduleId <$> traverse (parseBlock moduleOrigin globals) definitionBlocks
@@ -120,7 +121,7 @@ moduleDeclaration = do
   packageName <- MP.optional (MP.try text)
   moduleName <- qualifiedName
   _ <- keyword "where"
-  pure (FcModuleId (fromMaybe "" packageName) moduleName)
+  pure (FcModuleId (PackageId (fromMaybe "" packageName)) moduleName)
 
 externalDeclaration :: Parser FcTopBind
 externalDeclaration = do

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -32,7 +32,7 @@ renderProgram program =
 
 renderModuleDeclaration :: FcModuleId -> String
 renderModuleDeclaration moduleId =
-  "module " <> renderModuleOrigin (fcModulePackage moduleId) (fcModuleName moduleId) <> " where"
+  "module " <> renderModuleOrigin (fcModulePackageText moduleId) (fcModuleName moduleId) <> " where"
 
 -- | Materialize the one-per-origin external signature table represented by
 -- the canonical syntax. Desugaring calls this as well as rendering so the
@@ -130,7 +130,7 @@ renderSymbols :: FcModuleId -> [FcTopBind] -> RenderSymbols
 renderSymbols moduleId topBinds =
   RenderSymbols
     { renderExternalOrigins = Set.fromList [origin | FcExternal origin _ <- topBinds],
-      renderLocalOrigin = Just (fcModulePackage moduleId, fcModuleName moduleId),
+      renderLocalOrigin = Just (fcModulePackageText moduleId, fcModuleName moduleId),
       renderLocalNames = Set.fromList (concatMap topBindDefinedNames topBinds)
     }
 
@@ -144,7 +144,7 @@ canonicalProgramBinds (FcProgram moduleId topBinds) =
     <> definitions
   where
     definitions = [topBind | topBind <- topBinds, not (isHeader topBind)]
-    moduleOrigin = Just (fcModulePackage moduleId, fcModuleName moduleId)
+    moduleOrigin = Just (fcModulePackageText moduleId, fcModuleName moduleId)
     declaredTypes = Map.fromList [(origin, ty) | FcExternal origin ty <- topBinds]
     referencedTypes = Map.fromList [(origin, varType var) | var <- concatMap topBindOccurrences definitions, Just origin <- [varResolvedName var]]
     externalTypes = Map.union declaredTypes referencedTypes

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -35,6 +35,7 @@ module Aihc.Fc.Syntax
     FcAxiomRole (..),
     FcNewtypeDecl (..),
     FcModuleId (..),
+    fcModulePackageText,
     FcProgram (..),
     FcForeignCall (..),
     FcForeignSignature (..),
@@ -83,10 +84,13 @@ import Data.Text qualified as T
 
 -- | The required identity of one System FC module container.
 data FcModuleId = FcModuleId
-  { fcModulePackage :: !Text,
+  { fcModulePackage :: !PackageId,
     fcModuleName :: !Text
   }
   deriving (Eq, Ord, Show, Read)
+
+fcModulePackageText :: FcModuleId -> Text
+fcModulePackageText = packageIdText . fcModulePackage
 
 -- | A System FC program with one module identity.
 data FcProgram = FcProgram

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -209,7 +209,11 @@ fcMergeTests =
         assertBool "missing module declaration" (isLeft (parseProgram "value : Int =\n  1"))
         assertBool
           "multiple module declarations"
-          (isLeft (parseProgram "module \"one\" One where\n\nmodule \"two\" Two where"))
+          (isLeft (parseProgram "module \"one\" One where\n\nmodule \"two\" Two where")),
+      testCase "parses the module package as a package ID" $
+        case parseProgram "module \"example\" Example where" of
+          Left err -> assertFailure (renderParseError err)
+          Right program -> assertEqual "package ID" (PackageId "example") (fcModulePackage (fcProgramModule program))
     ]
   where
     binders bind =

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -171,7 +171,7 @@ linkNamesForProgram libraryId moduleNameComponents program =
     packageIdentity =
       fromMaybe
         ""
-        (Just (fcModulePackage (fcProgramModule program)))
+        (Just (fcModulePackageText (fcProgramModule program)))
     topBindVars bind =
       case bind of
         FcNonRec var _ -> [var]

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -35,11 +35,16 @@ import Aihc.Parser.Syntax
     fromAnnotation,
   )
 import Data.Maybe (listToMaybe, mapMaybe)
+import Data.String (IsString (..))
 import Data.Text (Text)
+import Data.Text qualified as T
 
 -- | An opaque identity for one installed package instance.
 newtype PackageId = PackageId {packageIdText :: Text}
   deriving (Eq, Ord, Show, Read)
+
+instance IsString PackageId where
+  fromString = PackageId . T.pack
 
 -- | The user-visible package name used in imports and its opaque identity.
 data Package = Package


### PR DESCRIPTION
## Summary

- Assign the `exe` package to executable source modules.
- Assign the `repl` package to interactive modules.
- Add a shared package interface format module.
- Use the shared format in the installer and REPL.
- Keep package identities from installed interface package keys.
- Store `PackageId` in `FcModuleId`.
- Add checks for package identities, format round trips, and schema versions.

## Reason

The compile and REPL paths used `unnamedPackage`.
This gave their source modules the default `main` identity.

The installer and REPL also defined separate code for the same interface format.
This format difference caused the REPL to discard installed package identities.

System FC module identities used `Text` for their package field.
This removed the package type after name resolution.

## Impact

CLI source modules now have explicit package identities.
One typed module now controls package interface encoding and decoding.
The shared reader rejects unsupported schema versions.
System FC keeps `PackageId` in each module identity.
Text conversion now occurs only at format and symbol boundaries.

## Progress counts

- CLI tests increase from 80 to 82.
- FC tests increase from 223 to 224.
- No README progress counts change.

## Validation

- `just fmt`
- `just check`
