### PR TITLE
refactor(fc): require typed desugar input

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -10,8 +10,6 @@ module Aihc.Cli.Compile
     compileSourceToCpsGrinWithDependencies,
     compileSourceToGrinWithDependencies,
     compileSourceToWholeCoreWithDependencies,
-    compileSourceToAssembly,
-    compileSourceToAssemblyFor,
     compileSourceToAssemblyWithDependencies,
     compileSourceToAssemblyWithDependenciesFor,
     defaultCompileEnvironment,
@@ -39,7 +37,6 @@ import Aihc.Fc
   ( DesugarConfig (..),
     DesugarResult (..),
     FcProgram (..),
-    desugarModule,
     desugarModuleWithBindings,
     eliminateDeadCode,
     extractReachabilityInterface,
@@ -182,17 +179,6 @@ compileOutputPath options =
     defaultOutput
       | withoutExtension == source = source <> ".out"
       | otherwise = withoutExtension
-
-compileSourceToAssembly :: FilePath -> Text -> Either CompileError Text
-compileSourceToAssembly = compileSourceToAssemblyFor defaultCompileTarget
-
-compileSourceToAssemblyFor :: NativeTarget -> FilePath -> Text -> Either CompileError Text
-compileSourceToAssemblyFor target sourceName source = do
-  parsed <- parseCompileModule sourceName source
-  let desugared = desugarModule parsed
-  if dsSuccess desugared
-    then compiledAssembly <$> compileProgramArtifacts target (dsProgram desugared)
-    else Left (CompileFrontendError (dsErrors desugared))
 
 compileSourceToAssemblyWithDependencies :: CompileEnvironment -> FilePath -> Text -> IO (Either CompileError Text)
 compileSourceToAssemblyWithDependencies = compileSourceToAssemblyWithDependenciesFor defaultCompileTarget
@@ -390,9 +376,6 @@ reachableRuntimePrimitiveNames entry reachability programs =
           (primitive, _) <- Grin.grinPrimitives program
         ]
     )
-
-compileProgramArtifacts :: NativeTarget -> FcProgram -> Either CompileError CompileArtifacts
-compileProgramArtifacts target = compileProgramArtifactsWithEntry target "main"
 
 compileProgramArtifactsWithEntry :: NativeTarget -> Text -> FcProgram -> Either CompileError CompileArtifacts
 compileProgramArtifactsWithEntry target entryName sourceCore = do

--- a/bin/aihc/src/Aihc/Cli/Compile.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile.hs
@@ -36,7 +36,8 @@ import Aihc.Cli.Options (CompileOptions (..), GarbageCollector (..))
 import Aihc.Cli.Runtime (readWasmClangProcessWithExitCode, runtimeGarbageCollector, wasmClangCommand, wasmOptArguments)
 import Aihc.Cli.Store (defaultStoreRoot, installedRuntimeArchivePath)
 import Aihc.Fc
-  ( DesugarResult (..),
+  ( DesugarConfig (..),
+    DesugarResult (..),
     FcProgram (..),
     desugarModule,
     desugarModuleWithBindings,
@@ -258,7 +259,7 @@ compileWithDependencies target wholeProgram dependencies parsed = do
             then Left (CompileFrontendError ["typecheck error: " <> show (concatMap tcModuleDiagnostics checkedModules)])
             else
               let bindings = dependencyBindings dependencies <> concatMap tcModuleBindings checkedModules
-                  desugared = zipWith (desugarModuleWithBindings primPackageId bindings) checkedModules moduleAsts
+                  desugared = map (desugarModuleWithBindings (DesugarConfig {primPackageId = primPackageId}) bindings) checkedModules
                in if not (all dsSuccess desugared)
                     then Left (CompileFrontendError (concatMap dsErrors desugared))
                     else do

--- a/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
+++ b/bin/aihc/src/Aihc/Cli/Compile/Dependencies.hs
@@ -19,7 +19,7 @@ import Aihc.Amd64 qualified as Amd64
 import Aihc.Arm64 qualified as Arm64
 import Aihc.Cli.Runtime (readWasmClangProcessWithExitCode, wasmClangCommand)
 import Aihc.Cli.Store (installedLibrariesActivePath, installedLibrariesRoot)
-import Aihc.Fc (AxiomInterface, DesugarResult (..), FcModuleId (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractAxiomInterface, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, lowerPseudoOps, mergePrograms, optimizeProgram, renderProgram)
+import Aihc.Fc (AxiomInterface, DesugarConfig (..), DesugarResult (..), FcModuleId (..), FcProgram (..), NewtypeInterface, ReachabilityInterface, desugarModuleWithBindings, extractAxiomInterface, extractNewtypeInterface, extractReachabilityInterface, lowerNewtypesWithInterface, lowerPseudoOps, mergePrograms, optimizeProgram, renderProgram)
 import Aihc.Grin qualified as Grin
 import Aihc.Llvm qualified as Llvm
 import Aihc.Native
@@ -408,7 +408,7 @@ compileLoadedModules loaded = do
                 else
                   let localBindings = concatMap tcModuleBindings checkedModules
                       bindings = compileStateBindings state <> localBindings
-                      desugared = zipWith (desugarModuleWithBindings primPackageId bindings) checkedModules moduleAsts
+                      desugared = map (desugarModuleWithBindings (DesugarConfig {primPackageId = primPackageId}) bindings) checkedModules
                    in if not (all dsSuccess desugared)
                         then Left ("library desugar error: " <> unlines (concatMap dsErrors desugared))
                         else do

--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -50,7 +50,7 @@ import Aihc.Cli.PackageInterface
   )
 import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cpp qualified as Cpp
-import Aihc.Fc (DesugarResult (..), desugarModuleWithDataTypes, renderProgram)
+import Aihc.Fc (DesugarConfig (..), DesugarResult (..), desugarModuleWithDataTypes, renderProgram)
 import Aihc.Hackage.Cabal qualified as HackageCabal
 import Aihc.Hackage.Cache (sanitizeName)
 import Aihc.Hackage.Cpp (cppMacrosFromOptions, injectSyntheticCppMacros, minVersionMacroNamesFromDeps)
@@ -1296,7 +1296,10 @@ generatePackageInterface depExports importedTcInterface importedBindings plan = 
       ownBindings = concatMap tcModuleBindings checkedModules
       allBindings = mergeBy tbName [importedBindings, ownBindings]
       resolvedModuleAsts = map snd (resolvedModules resolveResult)
-      fcResults = zipWith (desugarModuleWithDataTypes primIdentity allBindings (tcInterfaceDataTypes tcInterface)) checkedModules resolvedModuleAsts
+      fcResults =
+        map
+          (desugarModuleWithDataTypes (DesugarConfig {primPackageId = primIdentity}) allBindings (tcInterfaceDataTypes tcInterface))
+          checkedModules
       fcModules = zipWith fcModuleValue resolvedModuleAsts fcResults
       fcDiagnostics = concatMap fcModuleDiagnosticValues fcModules
   pure

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -21,7 +21,7 @@ import Aihc.Cli.PackageInterface
     packageInterfaceExports,
     readPackageInterface,
   )
-import Aihc.Fc (DesugarResult (..), FcModuleId (..), FcProgram (..), desugarModuleWithBindings, evalProgramBinding, mergePrograms, renderProgram, renderValue)
+import Aihc.Fc (DesugarConfig (..), DesugarResult (..), FcModuleId (..), FcProgram (..), desugarModuleWithBindings, evalProgramBinding, mergePrograms, renderProgram, renderValue)
 import Aihc.Parser (ParseResult (..), ParserConfig (..), defaultConfig, parseExpr, parseModule)
 import Aihc.Parser.Shorthand (Shorthand (..))
 import Aihc.Parser.Syntax
@@ -201,11 +201,10 @@ evaluateExpression session input = do
     Left err -> pure (Left err)
     Right checked -> do
       let expr = checkedExpr checked
-          resolvedModule = checkedResolvedModule checked
           tcResult = checkedTcModule checked
           inferredType = checkedType checked
           allBindings = importedTermBindings (replImportedTerms session) <> tcModuleBindings tcResult
-          dsResult = desugarModuleWithBindings (PackageId "aihc-prim") allBindings tcResult resolvedModule
+          dsResult = desugarModuleWithBindings (DesugarConfig {primPackageId = PackageId "aihc-prim"}) allBindings tcResult
       if not (dsSuccess dsResult)
         then pure (Left (ReplDesugarError (dsErrors dsResult)))
         else do
@@ -519,7 +518,7 @@ buildBaseContext modules =
       if all tcModuleSuccess tcResults
         then do
           let allBindings = concatMap tcModuleBindings tcResults
-              dsResults = zipWith (desugarModuleWithBindings (PackageId "aihc-prim") allBindings) tcResults moduleAsts
+              dsResults = map (desugarModuleWithBindings (DesugarConfig {primPackageId = PackageId "aihc-prim"}) allBindings) tcResults
               bindingTypes = moduleBindingTypes moduleAsts tcResults
           if all dsSuccess dsResults
             then

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -16,7 +16,7 @@ module FcGolden
   )
 where
 
-import Aihc.Fc.Desugar (DesugarResult (..), desugarModuleWithDataTypes)
+import Aihc.Fc.Desugar (DesugarConfig (..), DesugarResult (..), desugarModuleWithDataTypes)
 import Aihc.Fc.Parser (parseProgram, renderParseError)
 import Aihc.Fc.Pretty (renderProgram)
 import Aihc.Parser
@@ -163,7 +163,10 @@ renderFcCase tc =
                in if all tcModuleSuccess tcResults
                     then
                       let allBindings = moduleGroupBindings tcResults
-                          results = zipWith (desugarModuleWithDataTypes (PackageId "aihc-prim") allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
+                          results =
+                            map
+                              (desugarModuleWithDataTypes (DesugarConfig {primPackageId = PackageId "aihc-prim"}) allBindings (tcInterfaceDataTypes tcInterface))
+                              tcResults
                           fixtureResults = drop supportModuleCount results
                        in if all dsSuccess results
                             then renderResults fixtureResults

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -72,13 +72,14 @@ module Aihc.Fc
     desugarModuleWithBindings,
     desugarModuleWithDataTypes,
     desugarModuleWithTcResult,
+    DesugarConfig (..),
     DesugarResult (..),
   )
 where
 
 import Aihc.Fc.Axiom (AxiomInterface, extractAxiomInterface, lookupAxiomDecl)
 import Aihc.Fc.DeadCode (ReachabilityInterface, eliminateDeadCode, extractReachabilityInterface, reachablePrimitiveNames)
-import Aihc.Fc.Desugar (DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithDataTypes, desugarModuleWithTcResult)
+import Aihc.Fc.Desugar (DesugarConfig (..), DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithDataTypes, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram, lintProgramWithAxiomInterface)
 import Aihc.Fc.Lower (lowerPseudoOps)

--- a/components/aihc-fc/src/Aihc/Fc.hs
+++ b/components/aihc-fc/src/Aihc/Fc.hs
@@ -68,7 +68,6 @@ module Aihc.Fc
     emptyLintEnv,
 
     -- * Desugaring
-    desugarModule,
     desugarModuleWithBindings,
     desugarModuleWithDataTypes,
     desugarModuleWithTcResult,
@@ -79,7 +78,7 @@ where
 
 import Aihc.Fc.Axiom (AxiomInterface, extractAxiomInterface, lookupAxiomDecl)
 import Aihc.Fc.DeadCode (ReachabilityInterface, eliminateDeadCode, extractReachabilityInterface, reachablePrimitiveNames)
-import Aihc.Fc.Desugar (DesugarConfig (..), DesugarResult (..), desugarModule, desugarModuleWithBindings, desugarModuleWithDataTypes, desugarModuleWithTcResult)
+import Aihc.Fc.Desugar (DesugarConfig (..), DesugarResult (..), desugarModuleWithBindings, desugarModuleWithDataTypes, desugarModuleWithTcResult)
 import Aihc.Fc.Eval (EvalError (..), Value (..), evalExpr, evalProgramBinding, renderRawValue, renderValue)
 import Aihc.Fc.Lint (LintEnv (..), LintError (..), emptyLintEnv, lintExpr, lintProgram, lintProgramWithAxiomInterface)
 import Aihc.Fc.Lower (lowerPseudoOps)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -10,6 +10,7 @@ module Aihc.Fc.Desugar
     desugarModuleWithBindings,
     desugarModuleWithDataTypes,
     desugarModuleWithTcResult,
+    DesugarConfig (..),
     DesugarResult (..),
   )
 where
@@ -94,6 +95,12 @@ data DesugarResult = DesugarResult
   }
   deriving (Show)
 
+-- | Configuration for desugaring.
+newtype DesugarConfig = DesugarConfig
+  { primPackageId :: PackageId
+  }
+  deriving (Eq, Show)
+
 -- | Desugar a module: parse, typecheck, then translate to compulsorily lowered
 -- but deliberately unoptimized Core.
 desugarModule :: Module -> DesugarResult
@@ -102,7 +109,11 @@ desugarModule m =
     ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} ->
       case typecheckModulesWithInterface emptyTcInterface [resolved] of
         ([tcResult], tcInterface) ->
-          desugarModuleWithDataTypes (PackageId "aihc-prim") (tcModuleBindings tcResult) (tcInterfaceDataTypes tcInterface) tcResult resolved
+          desugarModuleWithDataTypes
+            (DesugarConfig {primPackageId = PackageId "aihc-prim"})
+            (tcModuleBindings tcResult)
+            (tcInterfaceDataTypes tcInterface)
+            tcResult
         _ ->
           DesugarResult
             { dsProgram = FcProgram (sourceModuleId m) [],
@@ -119,25 +130,25 @@ desugarModule m =
 -- | Desugar a module using a type-checking result already computed by
 -- the caller. This is useful for clients such as the REPL that preload
 -- imported bindings into the type-checker environment.
-desugarModuleWithTcResult :: PackageId -> Module -> Module -> DesugarResult
-desugarModuleWithTcResult primPackageId tcResult =
-  desugarModuleWithBindings primPackageId (tcModuleBindings tcResult) tcResult
+desugarModuleWithTcResult :: DesugarConfig -> Module -> DesugarResult
+desugarModuleWithTcResult config tcResult =
+  desugarModuleWithBindings config (tcModuleBindings tcResult) tcResult
 
-desugarModuleWithBindings :: PackageId -> [TcBindingResult] -> Module -> Module -> DesugarResult
-desugarModuleWithBindings primPackageId bindings = desugarModuleWithDataTypes primPackageId bindings []
+desugarModuleWithBindings :: DesugarConfig -> [TcBindingResult] -> Module -> DesugarResult
+desugarModuleWithBindings config bindings = desugarModuleWithDataTypes config bindings []
 
-desugarModuleWithDataTypes :: PackageId -> [TcBindingResult] -> [DataTypeInfo] -> Module -> Module -> DesugarResult
-desugarModuleWithDataTypes primPackageId bindings dataTypes tcResult resolvedModule =
+desugarModuleWithDataTypes :: DesugarConfig -> [TcBindingResult] -> [DataTypeInfo] -> Module -> DesugarResult
+desugarModuleWithDataTypes config bindings dataTypes tcResult =
   if not (tcModuleSuccess tcResult)
     then
       DesugarResult
-        { dsProgram = FcProgram (sourceModuleId resolvedModule) [],
+        { dsProgram = FcProgram (sourceModuleId tcResult) [],
           dsSuccess = False,
           dsErrors = showTcFailure tcResult
         }
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
-          (packageId, currentModuleName) = resolvedModuleOrigin resolvedModule
+          (packageId, currentModuleName) = resolvedModuleOrigin tcResult
           constructorFields =
             Map.fromList
               [ (dciName constructor, dciFields constructor)
@@ -145,10 +156,10 @@ desugarModuleWithDataTypes primPackageId bindings dataTypes tcResult resolvedMod
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 primPackageId (packageIdText packageId) (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
+       in case runStateT (dsModule tcResult) (DsState 1000 (primPackageId config) (packageIdText packageId) (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
             Left err ->
               DesugarResult
-                { dsProgram = FcProgram (sourceModuleId resolvedModule) [],
+                { dsProgram = FcProgram (sourceModuleId tcResult) [],
                   dsSuccess = False,
                   dsErrors = [err]
                 }

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Desugaring from type-checked surface AST to System FC Core.
---
--- The entry point 'desugarModule' takes a parsed module, runs the type
--- checker, and produces an 'FcProgram'.
 module Aihc.Fc.Desugar
   ( -- * Entry point
-    desugarModule,
     desugarModuleWithBindings,
     desugarModuleWithDataTypes,
     desugarModuleWithTcResult,
@@ -56,8 +52,8 @@ import Aihc.Parser.Syntax
     peelDeclAnn,
     unqualifiedNameText,
   )
-import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolveResult (..), ResolvedName (..), resolveWithDeps, unnamedPackage)
-import Aihc.Tc (DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TcInterface (..), TyConFlavor (..), emptyTcInterface, renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
+import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
+import Aihc.Tc (DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TyConFlavor (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, parseTypeScheme, typeSchemeArity, typeSchemeFromType)
@@ -100,32 +96,6 @@ newtype DesugarConfig = DesugarConfig
   { primPackageId :: PackageId
   }
   deriving (Eq, Show)
-
--- | Desugar a module: parse, typecheck, then translate to compulsorily lowered
--- but deliberately unoptimized Core.
-desugarModule :: Module -> DesugarResult
-desugarModule m =
-  case resolveWithDeps mempty [(unnamedPackage, m)] of
-    ResolveResult {resolvedModules = [(_, resolved)], resolveErrors = []} ->
-      case typecheckModulesWithInterface emptyTcInterface [resolved] of
-        ([tcResult], tcInterface) ->
-          desugarModuleWithDataTypes
-            (DesugarConfig {primPackageId = PackageId "aihc-prim"})
-            (tcModuleBindings tcResult)
-            (tcInterfaceDataTypes tcInterface)
-            tcResult
-        _ ->
-          DesugarResult
-            { dsProgram = FcProgram (sourceModuleId m) [],
-              dsSuccess = False,
-              dsErrors = ["type checker did not return the requested module"]
-            }
-    ResolveResult {resolveErrors} ->
-      DesugarResult
-        { dsProgram = FcProgram (sourceModuleId m) [],
-          dsSuccess = False,
-          dsErrors = ["resolve error: " <> show resolveErrors]
-        }
 
 -- | Desugar a module using a type-checking result already computed by
 -- the caller. This is useful for clients such as the REPL that preload

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -19,8 +19,8 @@ import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax qualified as Surface
-import Aihc.Resolve (PackageId (..))
-import Aihc.Tc (Kind (KType), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..))
+import Aihc.Resolve (PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
+import Aihc.Tc (Kind (KType), RuntimeRep (..), TcInterface (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
 import Aihc.Testing.EvalFixture qualified as EvalGolden
@@ -69,8 +69,14 @@ fcDesugarTests =
               \data Tree a = Leaf a | Branch (Tree a) (Tree a) deriving stock Eq\n"
             config = defaultConfig {parserExtensions = [Surface.DerivingStrategies]}
             (parseErrors, parsedModule) = parseModule config source
-            result = desugarModule parsedModule
         assertEqual "source parses" [] parseErrors
+        (tcModule, tcInterface) <- resolveAndTypecheck parsedModule
+        let result =
+              desugarModuleWithDataTypes
+                (DesugarConfig {primPackageId = PackageId "aihc-prim"})
+                (tcModuleBindings tcModule)
+                (tcInterfaceDataTypes tcInterface)
+                tcModule
         assertBool ("desugaring succeeds: " <> show (dsErrors result)) (dsSuccess result)
         assertEqual "Core lint" [] (lintProgram emptyLintEnv (dsProgram result)),
       testCase "uses the aihc-prim Bool type for if binders" $ do
@@ -79,12 +85,18 @@ fcDesugarTests =
               \data Bool = False | True\n\
               \value = if True then True else False\n"
             (parseErrors, parsedModule) = parseModule defaultConfig source
-            result = desugarModule parsedModule
+        assertEqual "source parses" [] parseErrors
+        (tcModule, tcInterface) <- resolveAndTypecheck parsedModule
+        let result =
+              desugarModuleWithDataTypes
+                (DesugarConfig {primPackageId = PackageId "aihc-prim"})
+                (tcModuleBindings tcModule)
+                (tcInterfaceDataTypes tcInterface)
+                tcModule
             ifBinderTypes =
               [ varType binder
               | FcTopBind (FcNonRec _ (Fc.FcCase _ binder _)) <- fcTopBinds (dsProgram result)
               ]
-        assertEqual "source parses" [] parseErrors
         assertBool ("desugaring succeeds: " <> show (dsErrors result)) (dsSuccess result)
         case ifBinderTypes of
           [TcTyCon tyCon []] -> do
@@ -98,6 +110,17 @@ fcDesugarTests =
         Surface.DeclAnn _ inner -> declarationConstructors inner
         Surface.DeclData dataDeclaration -> Surface.dataDeclConstructors dataDeclaration
         _ -> []
+
+resolveAndTypecheck :: Surface.Module -> IO (Surface.Module, TcInterface)
+resolveAndTypecheck parsedModule =
+  case resolveWithDeps mempty [(unnamedPackage, parsedModule)] of
+    ResolveResult {resolvedModules = [(_, resolvedModule)], resolveErrors = []} ->
+      case typecheckModulesWithInterface emptyTcInterface [resolvedModule] of
+        ([tcModule], tcInterface)
+          | tcModuleSuccess tcModule -> pure (tcModule, tcInterface)
+          | otherwise -> assertFailure ("type-check errors: " <> show (tcModuleDiagnostics tcModule))
+        (tcModules, _) -> assertFailure ("unexpected type-check module count: " <> show (length tcModules))
+    ResolveResult {resolveErrors} -> assertFailure ("resolve errors: " <> show resolveErrors)
 
 fcEvalTests :: TestTree
 fcEvalTests =

--- a/components/aihc-grin/test/GrinGolden.hs
+++ b/components/aihc-grin/test/GrinGolden.hs
@@ -10,7 +10,7 @@ module GrinGolden
   )
 where
 
-import Aihc.Fc (DesugarResult (..), desugarModuleWithBindings)
+import Aihc.Fc (DesugarConfig (..), DesugarResult (..), desugarModuleWithBindings)
 import Aihc.Grin (lintProgram, lowerProgram, renderProgram)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
@@ -117,7 +117,7 @@ evaluateGrinCase fixture =
            in if all tcModuleSuccess tcResults
                 then
                   let allBindings = moduleGroupBindings tcResults
-                      desugared = zipWith (desugarModuleWithBindings (PackageId "aihc-prim") allBindings) tcResults moduleAsts
+                      desugared = map (desugarModuleWithBindings (DesugarConfig {primPackageId = PackageId "aihc-prim"}) allBindings) tcResults
                    in if all dsSuccess desugared
                         then
                           let programs = map (lowerProgram . dsProgram) desugared

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -16,7 +16,7 @@ module Aihc.Testing.EvalFixture
   )
 where
 
-import Aihc.Fc (DesugarResult (..), FcBind (..), FcModuleId (..), FcProgram (..), FcSymbolOrigin (..), FcTopBind (..), Var (..), desugarModuleWithDataTypes, mergePrograms)
+import Aihc.Fc (DesugarConfig (..), DesugarResult (..), FcBind (..), FcModuleId (..), FcProgram (..), FcSymbolOrigin (..), FcTopBind (..), Var (..), desugarModuleWithDataTypes, mergePrograms)
 import Aihc.Parser
   ( ParseResult (..),
     ParserConfig (..),
@@ -260,7 +260,10 @@ compileEvalCase tc =
                    in if all tcModuleSuccess tcResults
                         then do
                           let allBindings = moduleGroupBindings tcResults
-                              results = zipWith (desugarModuleWithDataTypes (PackageId "aihc-prim") allBindings (tcInterfaceDataTypes tcInterface)) tcResults moduleAsts
+                              results =
+                                map
+                                  (desugarModuleWithDataTypes (DesugarConfig {primPackageId = PackageId "aihc-prim"}) allBindings (tcInterfaceDataTypes tcInterface))
+                                  tcResults
                           if all dsSuccess results
                             then pure (Right (concatPrograms (map dsProgram results)))
                             else pure (Left ("desugar error: " <> unlines (concatMap dsErrors results)))


### PR DESCRIPTION
## Summary

- Add `DesugarConfig` with the `primPackageId` field.
- Make each desugar API accept one type-checked module.
- Remove the untyped `desugarModule` entry.
- Remove the unused dependency-free assembly entries.
- Update all callers to use type-checker resolution annotations.

## Impact

The API now shows the primitive package configuration in its type.
The FC component now accepts only type-checked modules.
Callers no longer pass the same module data two times.

## Progress counts

- FC test fixture counts: no change.
- Other progress counts: no change.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just check`
