### PR TITLE
fix(fc): use global desugaring identities

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -574,7 +574,8 @@ importedTermBindings terms =
       { tbName = name,
         tbDisplayName = name,
         tbType = instantiateSchemeBody scheme,
-        tbKey = Just (TcTermGlobal "" "$repl-import" name)
+        tbKey = Just (TcTermGlobal "" "$repl-import" name),
+        tbEvidenceBinders = []
       }
   | (name, scheme) <- terms
   ]

--- a/bin/aihc/src/Aihc/Cli/Repl.hs
+++ b/bin/aihc/src/Aihc/Cli/Repl.hs
@@ -48,6 +48,7 @@ import Aihc.Tc
     TcBindingResult (..),
     TcDiagnostic (..),
     TcErrorKind (..),
+    TcTermKey (..),
     TcType (..),
     TyCon (..),
     TyVarId (..),
@@ -572,7 +573,8 @@ importedTermBindings terms =
   [ TcBindingResult
       { tbName = name,
         tbDisplayName = name,
-        tbType = instantiateSchemeBody scheme
+        tbType = instantiateSchemeBody scheme,
+        tbKey = Just (TcTermGlobal "" "$repl-import" name)
       }
   | (name, scheme) <- terms
   ]

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -83,6 +83,7 @@ test-suite spec
     tasty-hedgehog,
     tasty-hunit,
     text,
+    transformers,
     unix,
     yaml,
 

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -13,7 +13,7 @@ where
 
 import Aihc.Fc.Desugar.Deriving (dsDerivingPlans, moduleDerivingPlans)
 import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, peelForAlls, peelQuals, predType)
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsEvidence, dsMatches, dsMatchesWithEnclosingDicts, freshUnique, freshVar, lookupType, withDicts)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, DsState (..), desugarBug, dsEvidence, dsMatchesWithEnclosingDicts, dsMatchesWithEvidence, freshUnique, freshVar, lookupType, withDicts)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Lower (lowerPseudoOps)
 import Aihc.Fc.Newtype (lowerNewtypes)
@@ -54,7 +54,7 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
 import Aihc.Tc (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TcTermKey (..), TyConFlavor (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess)
-import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
+import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcEvidenceBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, parseTypeScheme, typeSchemeArity, typeSchemeFromType)
 import Aihc.Tc.Types
@@ -77,7 +77,7 @@ import Aihc.Tc.Types
     unboxedTupleTyConName,
   )
 import Control.Applicative ((<|>))
-import Control.Monad (foldM, zipWithM)
+import Control.Monad (foldM, when, zipWithM)
 import Control.Monad.Trans.State.Strict (gets, runStateT)
 import Data.Either (fromRight)
 import Data.List qualified as List
@@ -145,7 +145,6 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                 dsTypeEnv = typeEnv,
                 dsLocalVars = Map.empty,
                 dsLocalDicts = Map.empty,
-                dsLocalDictOrder = [],
                 dsConstructorTypes = constructorTypes,
                 dsConstructorFields = constructorFields,
                 dsTupleConstructorOrigin = Nothing
@@ -1047,7 +1046,7 @@ dsClassDefault (methodAnn, matches) = do
       methodType = tcInstanceMethodType methodAnn
       workerName = defaultMethodName methodName
   worker <- freshVar workerName methodType
-  body <- dsMatches methodType matches
+  body <- dsMatchesWithEvidence (tcInstanceMethodEvidence methodAnn) methodType matches
   pure (FcTopBind (FcNonRec worker body))
 
 classDefaultGroups :: ClassDecl -> [(TcInstanceMethodAnnotation, [Match])]
@@ -1090,7 +1089,10 @@ dsInstanceDecl decl =
 dsInstanceDict :: TcInstanceAnnotation -> InstanceDecl -> DsM FcTopBind
 dsInstanceDict instAnn instanceDecl = do
   let methods = Map.fromListWith combineMethods (instanceMethodGroups instanceDecl)
-  contextDicts <- zipWithM mkContextDict [0 :: Int ..] (tcInstanceContextDicts instAnn)
+  when
+    (length (tcInstanceContextDicts instAnn) /= length (tcInstanceContextEvidence instAnn))
+    (desugarBug ("instance context evidence count does not match the context for " <> T.unpack (tcInstanceDictName instAnn)))
+  contextDicts <- zipWithM mkContextDict [0 :: Int ..] (tcInstanceContextEvidence instAnn)
   className <-
     case dictionaryClassName (tcInstanceDictType instAnn) of
       Just name -> pure name
@@ -1143,7 +1145,7 @@ dsInstanceDict instAnn instanceDecl = do
       dictVar <- freshVar (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)
       buildDictionary False dictVar fields
   where
-    combineMethods (newTy, newMatches) (_oldTy, oldMatches) = (newTy, oldMatches <> newMatches)
+    combineMethods (newAnnotation, newMatches) (_oldAnnotation, oldMatches) = (newAnnotation, oldMatches <> newMatches)
 
 dictionaryClassName :: TcType -> Maybe Text
 dictionaryClassName ty =
@@ -1176,16 +1178,21 @@ classTypeVariables className methodType =
     asTyVar (TcTyVar tyVar) = Just tyVar
     asTyVar _ = Nothing
 
-mkContextDict :: Int -> TcDictBinderAnnotation -> DsM ClassDict
-mkContextDict ix dictAnn = do
-  dictVar <- freshVar ("$d" <> T.pack (show ix)) (tcDictBinderType dictAnn)
-  pure (ClassDict (tcDictBinderClassName dictAnn) (tcDictBinderArgs dictAnn) dictVar)
+mkContextDict :: Int -> TcEvidenceBinderAnnotation -> DsM ClassDict
+mkContextDict ix evidenceBinder = do
+  let predicate = tcEvidenceBinderPred evidenceBinder
+  dictVar <- freshVar ("$d" <> T.pack (show ix)) (tcEvidenceBinderType evidenceBinder)
+  case predicate of
+    ClassPred className arguments ->
+      pure (ClassDict (tcEvidenceBinderVar evidenceBinder) className arguments dictVar)
+    EqPred {} ->
+      pure (ClassDict (tcEvidenceBinderVar evidenceBinder) "<constraint>" [] dictVar)
 
-dsInstanceMethod :: [ClassDict] -> Map.Map Text (TcType, [Match]) -> Maybe FcExpr -> [TcType] -> Maybe (Text, Text) -> [Text] -> Text -> DsM FcExpr
+dsInstanceMethod :: [ClassDict] -> Map.Map Text (TcInstanceMethodAnnotation, [Match]) -> Maybe FcExpr -> [TcType] -> Maybe (Text, Text) -> [Text] -> Text -> DsM FcExpr
 dsInstanceMethod contextDicts methods maybeSelfDictionary headTypes classOrigin defaults methodName =
   case Map.lookup methodName methods of
-    Just (expected, matches) ->
-      dsMatchesWithEnclosingDicts contextDicts expected matches
+    Just (methodAnnotation, matches) ->
+      dsMatchesWithEnclosingDicts contextDicts (tcInstanceMethodEvidence methodAnnotation) (tcInstanceMethodType methodAnnotation) matches
     Nothing
       | methodName `elem` defaults -> do
           selfDictionary <-
@@ -1208,11 +1215,11 @@ moduleInstances = filter isInstance
         DeclInstance {} -> True
         _ -> False
 
-instanceMethodGroups :: InstanceDecl -> [(Text, (TcType, [Match]))]
+instanceMethodGroups :: InstanceDecl -> [(Text, (TcInstanceMethodAnnotation, [Match]))]
 instanceMethodGroups instanceDecl =
   concatMap itemMethods (instanceDeclItems instanceDecl)
 
-itemMethods :: InstanceDeclItem -> [(Text, (TcType, [Match]))]
+itemMethods :: InstanceDeclItem -> [(Text, (TcInstanceMethodAnnotation, [Match]))]
 itemMethods item =
   case item of
     InstanceItemAnn ann inner
@@ -1220,15 +1227,15 @@ itemMethods item =
       | otherwise -> itemMethods inner
     _ -> []
 
-itemMethodWithAnnotation :: TcInstanceMethodAnnotation -> InstanceDeclItem -> [(Text, (TcType, [Match]))]
+itemMethodWithAnnotation :: TcInstanceMethodAnnotation -> InstanceDeclItem -> [(Text, (TcInstanceMethodAnnotation, [Match]))]
 itemMethodWithAnnotation methodAnn item =
   case item of
     InstanceItemAnn _ inner -> itemMethodWithAnnotation methodAnn inner
     InstanceItemBind (FunctionBind _ matches) ->
-      [(tcInstanceMethodName methodAnn, (tcInstanceMethodType methodAnn, matches))]
+      [(tcInstanceMethodName methodAnn, (methodAnn, matches))]
     InstanceItemBind (PatternBind _ _ rhs) ->
       [ ( tcInstanceMethodName methodAnn,
-          ( tcInstanceMethodType methodAnn,
+          ( methodAnn,
             [ Match
                 { matchAnns = [],
                   matchHeadForm = MatchHeadPrefix,
@@ -1247,47 +1254,48 @@ dropForAlls ty = ty
 
 -- | A group of top-level value declarations.
 data DeclGroup
-  = DeclFunction !Text ![Match]
-  | DeclPattern !Text !(Rhs Expr)
+  = DeclFunction !Text ![TcEvidenceBinderAnnotation] ![Match]
+  | DeclPattern !Text ![TcEvidenceBinderAnnotation] !(Rhs Expr)
 
 dgName :: DeclGroup -> Text
 dgName group =
   case group of
-    DeclFunction name _ -> name
-    DeclPattern name _ -> name
+    DeclFunction name _ _ -> name
+    DeclPattern name _ _ -> name
 
 -- | Group consecutive FunctionBind declarations with the same name and keep
 -- simple top-level pattern binds.
 groupFunctionBinds :: [Decl] -> [DeclGroup]
 groupFunctionBinds [] = []
 groupFunctionBinds (d : ds) = case extractFunBind d of
-  Just (name, matches) ->
+  Just (name, evidenceBinders, matches) ->
     let (sameNameDecls, rest) = span (hasSameName name) ds
-        allMatches = matches ++ concatMap (maybe [] snd . extractFunBind) sameNameDecls
-     in DeclFunction name allMatches : groupFunctionBinds rest
+        allMatches = matches ++ concatMap (maybe [] (\(_, _, groupMatches) -> groupMatches) . extractFunBind) sameNameDecls
+     in DeclFunction name evidenceBinders allMatches : groupFunctionBinds rest
   Nothing ->
     case extractPatternBind d of
       Just group -> group : groupFunctionBinds ds
       Nothing -> groupFunctionBinds ds
 
 -- | Extract function bind info from a declaration.
-extractFunBind :: Decl -> Maybe (Text, [Match])
-extractFunBind decl = case peelDeclAnn decl of
-  DeclValue (FunctionBind name matches) ->
-    Just (unqualifiedNameText name, matches)
-  _ -> Nothing
+extractFunBind :: Decl -> Maybe (Text, [TcEvidenceBinderAnnotation], [Match])
+extractFunBind decl =
+  case peelDeclAnn decl of
+    DeclValue (FunctionBind name matches) ->
+      Just (unqualifiedNameText name, maybe [] tcAnnEvidenceBinders (declTcAnnotation decl), matches)
+    _ -> Nothing
 
 -- | Check if a declaration is a FunctionBind with the given name.
 hasSameName :: Text -> Decl -> Bool
 hasSameName name d = case extractFunBind d of
-  Just (n, _) -> n == name
+  Just (n, _, _) -> n == name
   Nothing -> False
 
 extractPatternBind :: Decl -> Maybe DeclGroup
 extractPatternBind decl =
   case peelDeclAnn decl of
     DeclValue (PatternBind _ pat rhs) ->
-      DeclPattern <$> barePatternName pat <*> pure rhs
+      DeclPattern <$> barePatternName pat <*> pure (maybe [] tcAnnEvidenceBinders (declTcAnnotation decl)) <*> pure rhs
     _ -> Nothing
 
 barePatternName :: Pattern -> Maybe Text
@@ -1298,6 +1306,15 @@ barePatternName pat =
     PParen inner -> barePatternName inner
     _ -> Nothing
 
+declTcAnnotation :: Decl -> Maybe TcAnnotation
+declTcAnnotation decl =
+  case decl of
+    DeclAnn annotation inner ->
+      case fromAnnotation annotation of
+        Just tcAnnotation -> Just tcAnnotation
+        Nothing -> declTcAnnotation inner
+    _ -> Nothing
+
 -- | Desugar a function binding group.
 dsGroup :: DeclGroup -> DsM FcTopBind
 dsGroup grp = do
@@ -1306,8 +1323,8 @@ dsGroup grp = do
   let var = Var (dgName grp) u ty
   body <-
     case grp of
-      DeclFunction _ matches -> dsMatches ty matches
-      DeclPattern _ rhs -> dsMatches ty [rhsAsMatch rhs]
+      DeclFunction _ evidenceBinders matches -> dsMatchesWithEvidence evidenceBinders ty matches
+      DeclPattern _ evidenceBinders rhs -> dsMatchesWithEvidence evidenceBinders ty [rhsAsMatch rhs]
   pure (FcTopBind (FcNonRec var body))
 
 rhsAsMatch :: Rhs Expr -> Match

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -53,7 +53,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameText,
   )
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
-import Aihc.Tc (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TyConFlavor (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess)
+import Aihc.Tc (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TcTermKey (..), TyConFlavor (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, parseTypeScheme, typeSchemeArity, typeSchemeFromType)
@@ -80,6 +80,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (foldM, zipWithM)
 import Control.Monad.Trans.State.Strict (gets, runStateT)
 import Data.Either (fromRight)
+import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
@@ -119,7 +120,7 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
           dsErrors = showTcFailure tcResult
         }
     else
-      let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
+      let typeEnv = typeEnvironmentFromList (builtinTypeEntries <> map bindingTypeEntry bindings)
           (packageId, currentModuleName) = resolvedModuleOrigin tcResult
           constructorTypes =
             Map.fromList
@@ -134,7 +135,7 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT
+       in typeEnv `seq` case runStateT
             (dsModule tcResult)
             DsState
               { dsNextUnique = 1000,
@@ -144,6 +145,7 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                 dsTypeEnv = typeEnv,
                 dsLocalVars = Map.empty,
                 dsLocalDicts = Map.empty,
+                dsLocalDictOrder = [],
                 dsConstructorTypes = constructorTypes,
                 dsConstructorFields = constructorFields,
                 dsTupleConstructorOrigin = Nothing
@@ -161,6 +163,16 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                       dsSuccess = True,
                       dsErrors = []
                     }
+
+typeEnvironmentFromList :: [(TcTermKey, TcType)] -> Map.Map TcTermKey TcType
+typeEnvironmentFromList = List.foldl' insertType Map.empty
+  where
+    insertType environment (key, ty) =
+      case Map.lookup key environment of
+        Nothing -> Map.insert key ty environment
+        Just oldType
+          | oldType == ty -> environment
+          | otherwise -> error ("dsTypeEnv has conflicting key: " <> show key)
 
 checkedConstructorOrigin :: DataTypeInfo -> DataConInfo -> FcSymbolOrigin
 checkedConstructorOrigin dataType constructor =
@@ -310,14 +322,16 @@ showTcFailure tcResult =
     [] -> map showBinding (tcModuleBindings tcResult)
     diagnostics -> diagnostics
 
-bindingTypeEntries :: TcBindingResult -> [(Text, TcType)]
-bindingTypeEntries b =
-  [(tbName b, tbType b)]
+bindingTypeEntry :: TcBindingResult -> (TcTermKey, TcType)
+bindingTypeEntry binding =
+  case tbKey binding of
+    Just key -> (key, tbType binding)
+    Nothing -> error ("type binding has no global key: " <> T.unpack (tbName binding))
 
-builtinTypeEntries :: [(Text, TcType)]
+builtinTypeEntries :: [(TcTermKey, TcType)]
 builtinTypeEntries =
-  [ (":", TcForAllTy aVar (TcFunTy aTy (TcFunTy listA listA))),
-    ("[]", TcForAllTy aVar listA)
+  [ (TcTermGlobal "" "" ":", TcForAllTy aVar (TcFunTy aTy (TcFunTy listA listA))),
+    (TcTermGlobal "" "" "[]", TcForAllTy aVar listA)
   ]
   where
     aVar = TyVarId "a" (Unique (-1000))

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -53,7 +53,7 @@ import Aihc.Parser.Syntax
     unqualifiedNameText,
   )
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
-import Aihc.Tc (DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TyConFlavor (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess)
+import Aihc.Tc (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TcBindingResult (..), TyConFlavor (..), renderTcSignature, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess)
 import Aihc.Tc.Annotations (TcAnnotation (..), TcClassAnnotation (..), TcClassMethodAnnotation (..), TcDictBinderAnnotation (..), TcForeignAbiType (..), TcForeignEffect (..), TcForeignImportAnnotation (..), TcForeignMarshal (..), TcInstanceAnnotation (..), TcInstanceMethodAnnotation (..))
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, parseTypeScheme, typeSchemeArity, typeSchemeFromType)
@@ -71,6 +71,8 @@ import Aihc.Tc.Types
     runtimeRepOfType,
     tvKind,
     tyConKind,
+    tyConModuleName,
+    tyConPackageId,
     typeKind,
     unboxedTupleTyConName,
   )
@@ -119,14 +121,33 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
     else
       let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
           (packageId, currentModuleName) = resolvedModuleOrigin tcResult
+          constructorTypes =
+            Map.fromList
+              [ (checkedConstructorOrigin dataType constructor, checkedConstructorType constructor)
+              | dataType <- dataTypes,
+                constructor <- dtiConstructors dataType
+              ]
           constructorFields =
             Map.fromList
-              [ (dciName constructor, dciFields constructor)
+              [ (checkedConstructorOrigin dataType constructor, dciFields constructor)
               | dataType <- dataTypes,
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 (primPackageId config) (packageIdText packageId) (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
+       in case runStateT
+            (dsModule tcResult)
+            DsState
+              { dsNextUnique = 1000,
+                dsPrimPackageId = primPackageId config,
+                dsModulePackage = packageIdText packageId,
+                dsModuleName = Just currentModuleName,
+                dsTypeEnv = typeEnv,
+                dsLocalVars = Map.empty,
+                dsLocalDicts = Map.empty,
+                dsConstructorTypes = constructorTypes,
+                dsConstructorFields = constructorFields,
+                dsTupleConstructorOrigin = Nothing
+              } of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram (sourceModuleId tcResult) [],
@@ -140,6 +161,24 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                       dsSuccess = True,
                       dsErrors = []
                     }
+
+checkedConstructorOrigin :: DataTypeInfo -> DataConInfo -> FcSymbolOrigin
+checkedConstructorOrigin dataType constructor =
+  FcTopLevelOrigin
+    { fcOriginPackage = packageIdText (tyConPackageId (dtiTyCon dataType)),
+      fcOriginModule = tyConModuleName (dtiTyCon dataType),
+      fcOriginName = dciName constructor
+    }
+
+checkedConstructorType :: DataConInfo -> TcType
+checkedConstructorType constructor =
+  foldr TcForAllTy qualifiedType (dciUnivTyVars constructor <> dciExTyVars constructor)
+  where
+    functionType = foldr (TcFunTy . dcfiType) (dciResTy constructor) (dciFields constructor)
+    qualifiedType =
+      case dciTheta constructor of
+        [] -> functionType
+        predicates -> TcQualTy predicates functionType
 
 resolvedModuleOrigin :: Module -> (PackageId, Text)
 resolvedModuleOrigin resolvedModule =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/AnyClass.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/AnyClass.hs
@@ -6,10 +6,10 @@ module Aihc.Fc.Desugar.Deriving.AnyClass
   )
 where
 
-import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName, predType)
+import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, defaultMethodName)
 import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshUnique, freshVar, lookupType, withDicts)
 import Aihc.Fc.Syntax
-import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDictBinderAnnotation (..))
+import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDictBinderAnnotation (..), TcEvidenceBinderAnnotation (..))
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..))
 import Control.Monad (when, zipWithM)
 import Data.Text qualified as T
@@ -26,7 +26,11 @@ dsAnyClassDictionary plan context = do
   when
     (length (tcDerivingSuperClasses plan) /= length (tcDerivingClassSuperClasses plan))
     (desugarBug ("incomplete superclass evidence for " <> T.unpack (tcDerivingDictName plan)))
-  contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] context
+  let contextEvidence = tcDerivingContextEvidence plan
+  when
+    (length context /= length contextEvidence)
+    (desugarBug ("deriving context evidence count does not match the context for " <> T.unpack (tcDerivingDictName plan)))
+  contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] contextEvidence
   methodFieldTypes <-
     mapM
       (classMethodFieldType (tcDerivingClassName plan) (tcDerivingClassTyVars plan) . tcClassMethodType)
@@ -106,13 +110,15 @@ dsAnyClassMethod plan maybeSelfDictionary fieldType method =
   where
     methodName = tcClassMethodName method
 
-mkPredicateDict :: Int -> Pred -> DsM ClassDict
-mkPredicateDict index predicate = do
-  dictVar <- freshVar ("$d" <> T.pack (show index)) (predType predicate)
+mkPredicateDict :: Int -> TcEvidenceBinderAnnotation -> DsM ClassDict
+mkPredicateDict index binder = do
+  let predicate = tcEvidenceBinderPred binder
+      evidence = tcEvidenceBinderVar binder
+  dictVar <- freshVar ("$d" <> T.pack (show index)) (tcEvidenceBinderType binder)
   pure $
     case predicate of
-      ClassPred className arguments -> ClassDict className arguments dictVar
-      EqPred {} -> ClassDict "<equality>" [] dictVar
+      ClassPred className arguments -> ClassDict evidence className arguments dictVar
+      EqPred {} -> ClassDict evidence "<equality>" [] dictVar
 
 qualifyType :: [Pred] -> TcType -> TcType
 qualifyType [] body = body

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Deriving/StockEq.hs
@@ -6,15 +6,15 @@ module Aihc.Fc.Desugar.Deriving.StockEq
   )
 where
 
-import Aihc.Fc.Desugar.Dictionary (classMethodFieldType, predType)
+import Aihc.Fc.Desugar.Dictionary (classMethodFieldType)
 import Aihc.Fc.Desugar.Expr (ClassDict (..), DsM, desugarBug, dsEvidence, freshVar, lookupType, primBoolType, withDicts)
 import Aihc.Fc.Subst (substType)
 import Aihc.Fc.Syntax
-import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcStockDerivingPlan (..))
+import Aihc.Tc.Annotations (TcClassMethodAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcEvidenceBinderAnnotation (..), TcStockDerivingPlan (..))
 import Aihc.Tc.Env (DataConFieldInfo (..), DataConInfo (..), DataTypeInfo (..))
-import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Evidence (EvTerm (..), EvVar)
 import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..))
-import Control.Monad (zipWithM)
+import Control.Monad (when, zipWithM)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -34,7 +34,11 @@ dsStockEqDictionaryPlan plan =
 dsStockEqDictionary :: TcDerivingPlan -> [Pred] -> DataTypeInfo -> [[EvTerm]] -> DsM (Var, FcExpr)
 dsStockEqDictionary plan context dataType fieldEvidence = do
   eqTyCon <- stockEqTyCon plan
-  contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] context
+  let contextEvidence = tcDerivingContextEvidence plan
+  when
+    (length context /= length contextEvidence)
+    (desugarBug ("deriving context evidence count does not match the context for " <> T.unpack (tcDerivingDictName plan)))
+  contextDicts <- zipWithM mkPredicateDict [0 :: Int ..] contextEvidence
   genericMethodTypes <-
     mapM
       (classMethodFieldType "Eq" (tcDerivingClassTyVars plan) . tcClassMethodType)
@@ -43,11 +47,15 @@ dsStockEqDictionary plan context dataType fieldEvidence = do
     case reverse (tcDerivingHeadTypes plan) of
       target : _ -> pure target
       [] -> desugarBug "stock Eq deriving plan has an empty instance head"
+  selfEvidence <-
+    case tcDerivingSelfEvidence plan of
+      Just evidence -> pure evidence
+      Nothing -> desugarBug ("stock Eq plan has no self evidence for " <> T.unpack (tcDerivingDictName plan))
   constructors <-
     zipExact
       "constructor evidence"
       (dtiConstructors dataType)
-      (map (map (rewriteSelfEvidence plan targetType)) fieldEvidence)
+      (map (map (rewriteSelfEvidence plan selfEvidence targetType)) fieldEvidence)
   let dictionaryType =
         foldr
           TcForAllTy
@@ -61,7 +69,7 @@ dsStockEqDictionary plan context dataType fieldEvidence = do
           (foldl FcTyApp (FcVar dictVar) (map TcTyVar (tcDerivingTyVars plan)))
           (map (FcVar . classDictVar) contextDicts)
   selfDictionaryVar <- freshVar "$stock_eq_self" selfDictionaryType
-  let selfDictionary = ClassDict "Eq" [targetType] selfDictionaryVar
+  let selfDictionary = ClassDict selfEvidence "Eq" [targetType] selfDictionaryVar
   methodFields <-
     withDicts (selfDictionary : contextDicts) $
       mapM
@@ -221,24 +229,26 @@ stockEqTyCon plan =
         ty -> desugarBug ("invalid stock Eq dictionary type: " <> show ty)
     [] -> desugarBug "stock Eq has no class methods"
 
-mkPredicateDict :: Int -> Pred -> DsM ClassDict
-mkPredicateDict index predicate = do
-  dictVar <- freshVar ("$d" <> T.pack (show index)) (predType predicate)
+mkPredicateDict :: Int -> TcEvidenceBinderAnnotation -> DsM ClassDict
+mkPredicateDict index binder = do
+  let predicate = tcEvidenceBinderPred binder
+      evidence = tcEvidenceBinderVar binder
+  dictVar <- freshVar ("$d" <> T.pack (show index)) (tcEvidenceBinderType binder)
   pure $
     case predicate of
-      ClassPred className arguments -> ClassDict className arguments dictVar
-      EqPred {} -> ClassDict "<equality>" [] dictVar
+      ClassPred className arguments -> ClassDict evidence className arguments dictVar
+      EqPred {} -> ClassDict evidence "<equality>" [] dictVar
 
 qualifyType :: [Pred] -> TcType -> TcType
 qualifyType [] body = body
 qualifyType predicates body = TcQualTy predicates body
 
-rewriteSelfEvidence :: TcDerivingPlan -> TcType -> EvTerm -> EvTerm
-rewriteSelfEvidence plan targetType evidence =
+rewriteSelfEvidence :: TcDerivingPlan -> EvVar -> TcType -> EvTerm -> EvTerm
+rewriteSelfEvidence plan selfEvidence targetType evidence =
   case evidence of
     EvDict _ dictionaryName _ _
       | dictionaryName == tcDerivingDictName plan ->
-          EvGiven (ClassPred "Eq" [targetType])
+          EvGiven selfEvidence (ClassPred "Eq" [targetType])
     EvDict origin dictionaryName typeArguments contextEvidence ->
       EvDict origin dictionaryName typeArguments (map recurse contextEvidence)
     EvSuperClass source sourcePredicate fieldTypes fieldIndex ->
@@ -247,7 +257,7 @@ rewriteSelfEvidence plan targetType evidence =
     EvTypeable ty arguments -> EvTypeable ty (map recurse arguments)
     _ -> evidence
   where
-    recurse = rewriteSelfEvidence plan targetType
+    recurse = rewriteSelfEvidence plan selfEvidence targetType
 
 zipExact :: String -> [left] -> [right] -> DsM [(left, right)]
 zipExact context left right

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -91,8 +91,10 @@ data DsState = DsState
     dsLocalVars :: !(Map Text Var),
     -- | Local dictionaries, keyed by class predicate.
     dsLocalDicts :: !(Map Text Var),
-    -- | Checked constructor fields, including source strictness.
-    dsConstructorFields :: !(Map Text [DataConFieldInfo]),
+    -- | Checked constructor types, keyed by global source identity.
+    dsConstructorTypes :: !(Map FcSymbolOrigin TcType),
+    -- | Checked constructor fields, keyed by global source identity.
+    dsConstructorFields :: !(Map FcSymbolOrigin [DataConFieldInfo]),
     dsTupleConstructorOrigin :: !(Maybe FcSymbolOrigin)
   }
 
@@ -130,9 +132,16 @@ lookupType name = do
   st <- get
   case Map.lookup name (dsLocalVars st) of
     Just v -> pure (varType v)
-    Nothing -> case Map.lookup name (dsTypeEnv st) of
+    Nothing -> case lookupCurrentConstructorType name st <|> Map.lookup name (dsTypeEnv st) of
       Just ty -> pure ty
       Nothing -> desugarBug ("missing type information for name: " <> T.unpack name)
+
+lookupCurrentConstructorType :: Text -> DsState -> Maybe TcType
+lookupCurrentConstructorType name st = do
+  moduleName <- dsModuleName st
+  Map.lookup
+    (FcTopLevelOrigin (dsModulePackage st) moduleName name)
+    (dsConstructorTypes st)
 
 primBoolType :: DsM TcType
 primBoolType = do
@@ -700,7 +709,7 @@ constructorApplicationFields expression =
   case peelApplicationHead expression of
     EVar name -> do
       fields <- dsConstructorFields <$> get
-      pure (Map.lookup (nameText name) fields)
+      pure (resolvedOccurrenceOrigin name >>= (`Map.lookup` fields))
     _ -> pure Nothing
 
 peelApplicationHead :: Expr -> Expr
@@ -909,7 +918,9 @@ dsInfix lhs op rhs = do
   operator <- dsInfixOperator op
   left <- dsExpr lhs
   right <- dsExpr rhs
-  fields <- Map.lookup (nameText op) . dsConstructorFields <$> get
+  fields <- do
+    constructorFields <- dsConstructorFields <$> get
+    pure (resolvedOccurrenceOrigin op >>= (`Map.lookup` constructorFields))
   case fields of
     Just constructorFields
       | length constructorFields == 2 ->
@@ -1931,4 +1942,5 @@ lookupTypeName name = do
 lookupTypeMaybeName :: Name -> DsM (Maybe TcType)
 lookupTypeMaybeName name = do
   st <- get
-  pure (Map.lookup (nameToText name) (dsTypeEnv st) <|> Map.lookup (nameText name) (dsTypeEnv st))
+  let constructorType = resolvedOccurrenceOrigin name >>= (`Map.lookup` dsConstructorTypes st)
+  pure (constructorType <|> Map.lookup (nameToText name) (dsTypeEnv st) <|> Map.lookup (nameText name) (dsTypeEnv st))

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -8,6 +8,7 @@
 -- where the type checker inferred polymorphism.
 module Aihc.Fc.Desugar.Expr
   ( dsMatches,
+    dsMatchesWithEvidence,
     dsMatchesWithDicts,
     dsMatchesWithEnclosingDicts,
     dsMatchesWithGivenDicts,
@@ -59,9 +60,9 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Parser.Syntax qualified as Surface
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionForm (..), ResolutionNamespace (..), ResolvedName (..))
-import Aihc.Tc.Annotations (TcAnnotation (..))
+import Aihc.Tc.Annotations (TcAnnotation (..), TcEvidenceBinderAnnotation (..))
 import Aihc.Tc.Env (DataConFieldInfo (..))
-import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Evidence (EvTerm (..), EvVar)
 import Aihc.Tc.Kind (runtimeRepToTcType)
 import Aihc.Tc.Monad (TcTermKey (..))
 import Aihc.Tc.Types (Kind (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), isLiftedType, liftedRuntimeRep, mkTyCon, mkTyConWithOrigin, runtimeRepOfType, setTyVarKind, tvKind, unboxedTupleTyConName)
@@ -93,9 +94,7 @@ data DsState = DsState
     -- | Local variables, keyed by resolver identity.
     dsLocalVars :: !(Map DsLocalKey Var),
     -- | Local dictionaries, keyed by variable identity.
-    dsLocalDicts :: !(Map Unique ClassDict),
-    -- | Dictionary keys in lexical lookup order.
-    dsLocalDictOrder :: ![Unique],
+    dsLocalDicts :: !(Map EvVar ClassDict),
     -- | Checked constructor types, keyed by global source identity.
     dsConstructorTypes :: !(Map FcSymbolOrigin TcType),
     -- | Checked constructor fields, keyed by global source identity.
@@ -104,7 +103,8 @@ data DsState = DsState
   }
 
 data ClassDict = ClassDict
-  { classDictName :: !Text,
+  { classDictEvidence :: !EvVar,
+    classDictName :: !Text,
     classDictArgs :: ![TcType],
     classDictVar :: !Var
   }
@@ -200,16 +200,14 @@ withDicts :: [ClassDict] -> DsM a -> DsM a
 withDicts dicts action = do
   st <- get
   let oldDicts = dsLocalDicts st
-      oldOrder = dsLocalDictOrder st
       newDicts = foldr insertDictionary oldDicts dicts
-      newOrder = map (varUnique . classDictVar) dicts <> oldOrder
-  modify' (\s -> s {dsLocalDicts = newDicts, dsLocalDictOrder = newOrder})
+  modify' (\s -> s {dsLocalDicts = newDicts})
   result <- action
-  modify' (\s -> s {dsLocalDicts = oldDicts, dsLocalDictOrder = oldOrder})
+  modify' (\s -> s {dsLocalDicts = oldDicts})
   pure result
   where
     insertDictionary dictionary =
-      insertUnique "dsLocalDicts" (varUnique (classDictVar dictionary)) dictionary
+      insertUnique "dsLocalDicts" (classDictEvidence dictionary) dictionary
 
 -- | Desugar a list of match equations into a Core expression.
 --
@@ -219,24 +217,27 @@ withDicts dicts action = do
 -- For a polymorphic function like @id x = x@, this wraps with
 -- type lambdas and lambdas referencing the same variable.
 dsMatches :: TcType -> [Match] -> DsM FcExpr
-dsMatches = dsMatchesWithDicts True
+dsMatches = dsMatchesWithEvidence []
 
-dsMatchesWithDicts :: Bool -> TcType -> [Match] -> DsM FcExpr
+dsMatchesWithEvidence :: [TcEvidenceBinderAnnotation] -> TcType -> [Match] -> DsM FcExpr
+dsMatchesWithEvidence = dsMatchesWithDicts True
+
+dsMatchesWithDicts :: Bool -> [TcEvidenceBinderAnnotation] -> TcType -> [Match] -> DsM FcExpr
 dsMatchesWithDicts = dsMatchesWithDictSource [] Nothing
 
 -- | Desugar matches that close over dictionaries supplied by an enclosing
 -- instance while still abstracting over the method's own constraints.
-dsMatchesWithEnclosingDicts :: [ClassDict] -> TcType -> [Match] -> DsM FcExpr
+dsMatchesWithEnclosingDicts :: [ClassDict] -> [TcEvidenceBinderAnnotation] -> TcType -> [Match] -> DsM FcExpr
 dsMatchesWithEnclosingDicts enclosingDicts = dsMatchesWithDictSource enclosingDicts Nothing True
 
 -- | Desugar matches using dictionary binders supplied by an enclosing scope.
 -- The resulting expression refers to those exact variables and does not
 -- abstract over a second set of dictionaries.
-dsMatchesWithGivenDicts :: [ClassDict] -> TcType -> [Match] -> DsM FcExpr
+dsMatchesWithGivenDicts :: [ClassDict] -> [TcEvidenceBinderAnnotation] -> TcType -> [Match] -> DsM FcExpr
 dsMatchesWithGivenDicts dicts = dsMatchesWithDictSource [] (Just dicts) False
 
-dsMatchesWithDictSource :: [ClassDict] -> Maybe [ClassDict] -> Bool -> TcType -> [Match] -> DsM FcExpr
-dsMatchesWithDictSource enclosingDicts givenDicts abstractDicts ty matches = case matches of
+dsMatchesWithDictSource :: [ClassDict] -> Maybe [ClassDict] -> Bool -> [TcEvidenceBinderAnnotation] -> TcType -> [Match] -> DsM FcExpr
+dsMatchesWithDictSource enclosingDicts givenDicts abstractDicts evidenceBinders ty matches = case matches of
   [] -> do
     v <- freshVar "_void" ty
     pure (FcVar v)
@@ -268,17 +269,22 @@ dsMatchesWithDictSource enclosingDicts givenDicts abstractDicts ty matches = cas
     dictionariesFor predicates =
       case givenDicts of
         Just dicts -> pure dicts
-        Nothing -> mapM mkClassDict (zip [0 :: Int ..] predicates)
+        Nothing ->
+          if map tcEvidenceBinderPred evidenceBinders == predicates
+            then zipWithM mkClassDict [0 :: Int ..] evidenceBinders
+            else desugarBug "dictionary evidence binders do not match the qualified type"
 
-mkClassDict :: (Int, Pred) -> DsM ClassDict
-mkClassDict (i, pred') =
-  case pred' of
-    ClassPred className args -> do
-      var <- freshVar ("$d" <> T.pack (show i)) (predType pred')
-      pure (ClassDict className args var)
-    _ -> do
-      var <- freshVar ("$d" <> T.pack (show i)) (predType pred')
-      pure (ClassDict "<constraint>" [] var)
+mkClassDict :: Int -> TcEvidenceBinderAnnotation -> DsM ClassDict
+mkClassDict i binder =
+  let pred' = tcEvidenceBinderPred binder
+      evidence = tcEvidenceBinderVar binder
+   in case pred' of
+        ClassPred className args -> do
+          var <- freshVar ("$d" <> T.pack (show i)) (predType pred')
+          pure (ClassDict evidence className args var)
+        _ -> do
+          var <- freshVar ("$d" <> T.pack (show i)) (predType pred')
+          pure (ClassDict evidence "<constraint>" [] var)
 
 -- | Generate argument names: x, y, z, x1, y1, ...
 argName :: Int -> Text
@@ -1210,48 +1216,49 @@ dsLetDecls decls bodyAction = do
         else FcLet (FcRec rhsBindings) body
 
 data LocalDeclGroup
-  = LocalFunction !DsLocalKey !Text !Var ![Match]
-  | LocalPattern !DsLocalKey !Text !Var !(Rhs Expr)
+  = LocalFunction !DsLocalKey !Text !Var ![TcEvidenceBinderAnnotation] ![Match]
+  | LocalPattern !DsLocalKey !Text !Var ![TcEvidenceBinderAnnotation] !(Rhs Expr)
 
 localGroupKey :: LocalDeclGroup -> DsLocalKey
 localGroupKey group =
   case group of
-    LocalFunction key _ _ _ -> key
-    LocalPattern key _ _ _ -> key
+    LocalFunction key _ _ _ _ -> key
+    LocalPattern key _ _ _ _ -> key
 
 localGroupBinder :: LocalDeclGroup -> Var
 localGroupBinder group =
   case group of
-    LocalFunction _ _ var _ -> var
-    LocalPattern _ _ var _ -> var
+    LocalFunction _ _ var _ _ -> var
+    LocalPattern _ _ var _ _ -> var
 
 groupLocalDecls :: [Decl] -> DsM [LocalDeclGroup]
 groupLocalDecls [] = pure []
 groupLocalDecls (decl : rest) = do
   maybeFun <- extractLocalFunction decl
   case maybeFun of
-    Just (key, name, var, matches) -> do
+    Just (key, name, var, evidenceBinders, matches) -> do
       let (sameNameDecls, rest') = span (hasSameLocalFunctionKey key) rest
       sameGroups <- mapM extractLocalFunctionRequired sameNameDecls
-      let allMatches = matches ++ concatMap (\(_, _, _, ms) -> ms) sameGroups
+      let allMatches = matches ++ concatMap (\(_, _, _, _, ms) -> ms) sameGroups
       restGroups <- groupLocalDecls rest'
-      pure (LocalFunction key name var allMatches : restGroups)
+      pure (LocalFunction key name var evidenceBinders allMatches : restGroups)
     Nothing -> do
       maybePattern <- extractLocalPattern decl
       restGroups <- groupLocalDecls rest
       pure (maybe restGroups (: restGroups) maybePattern)
 
-extractLocalFunction :: Decl -> DsM (Maybe (DsLocalKey, Text, Var, [Match]))
+extractLocalFunction :: Decl -> DsM (Maybe (DsLocalKey, Text, Var, [TcEvidenceBinderAnnotation], [Match]))
 extractLocalFunction decl =
   case peelDeclAnn decl of
     DeclValue (FunctionBind name matches) -> do
       let localName = unqualifiedNameText name
-      ty <- localDeclTypeRequired localName decl
+      tcAnnotation <- localDeclAnnotationRequired localName decl
+      let ty = tcAnnType tcAnnotation
       var <- freshVar localName ty
-      pure (Just (binderTermKey name, localName, var, matches))
+      pure (Just (binderTermKey name, localName, var, tcAnnEvidenceBinders tcAnnotation, matches))
     _ -> pure Nothing
 
-extractLocalFunctionRequired :: Decl -> DsM (DsLocalKey, Text, Var, [Match])
+extractLocalFunctionRequired :: Decl -> DsM (DsLocalKey, Text, Var, [TcEvidenceBinderAnnotation], [Match])
 extractLocalFunctionRequired decl = do
   maybeFun <- extractLocalFunction decl
   case maybeFun of
@@ -1271,8 +1278,9 @@ extractLocalPattern decl =
       case barePatternName pat of
         Just (key, name) -> do
           ty <- localDeclTypeRequired name decl
+          let evidenceBinders = maybe [] tcAnnEvidenceBinders (localDeclAnnotation decl)
           var <- freshVar name ty
-          pure (Just (LocalPattern key name var rhs))
+          pure (Just (LocalPattern key name var evidenceBinders rhs))
         Nothing -> pure Nothing
     _ -> pure Nothing
 
@@ -1291,23 +1299,41 @@ localDeclTypeRequired name decl =
     Nothing -> desugarBug ("missing type-checker annotation for local declaration " <> T.unpack name)
 
 localDeclType :: Decl -> Maybe TcType
-localDeclType decl =
+localDeclType = fmap tcAnnType . localDeclAnnotation
+
+localDeclAnnotationRequired :: Text -> Decl -> DsM TcAnnotation
+localDeclAnnotationRequired name decl =
+  case localDeclAnnotation decl of
+    Just annotation -> pure annotation
+    Nothing -> desugarBug ("missing type-checker annotation for local declaration " <> T.unpack name)
+
+localDeclAnnotation :: Decl -> Maybe TcAnnotation
+localDeclAnnotation decl =
   case decl of
     DeclAnn ann inner ->
       case fromAnnotation ann of
-        Just tcAnn -> Just (tcAnnType tcAnn)
-        Nothing -> localDeclType inner
+        Just tcAnn -> Just tcAnn
+        Nothing -> localDeclAnnotation inner
     _ -> Nothing
 
 dsLocalGroup :: Var -> LocalDeclGroup -> DsM (Var, FcExpr)
 dsLocalGroup var group =
   case group of
-    LocalFunction _ _ _ matches -> do
-      rhs <- dsMatches (varType var) matches
+    LocalFunction _ _ _ evidenceBinders matches -> do
+      rhs <- dsMatchesWithEvidence evidenceBinders (varType var) matches
       pure (var, rhs)
-    LocalPattern _ _ _ rhs -> do
-      rhs' <- dsRhs rhs
+    LocalPattern _ _ _ evidenceBinders rhs -> do
+      rhs' <- dsMatchesWithEvidence evidenceBinders (varType var) [zeroArgumentMatch rhs]
       pure (var, rhs')
+
+zeroArgumentMatch :: Rhs Expr -> Match
+zeroArgumentMatch rhs =
+  Match
+    { matchAnns = [],
+      matchHeadForm = Surface.MatchHeadPrefix,
+      matchPats = [],
+      matchRhs = rhs
+    }
 
 dsStringLiteral :: Text -> DsM FcExpr
 dsStringLiteral text =
@@ -1612,15 +1638,22 @@ listType ty =
   TcTyCon (TyCon "[]" 1) [ty]
 
 dsEvidence :: EvTerm -> DsM FcExpr
-dsEvidence evidence =
-  case evidence of
-    EvGiven (ClassPred className args) -> do
+dsEvidence evidenceTerm =
+  case evidenceTerm of
+    EvGiven evidence (ClassPred className args) -> do
       st <- get
-      case lookupLocalDictionary className args (dsLocalDictOrder st) (dsLocalDicts st) of
+      case Map.lookup evidence (dsLocalDicts st) of
         Just dictionary -> pure (FcVar (classDictVar dictionary))
         Nothing ->
-          desugarBug ("missing local dictionary for " <> T.unpack (dictKey className args))
-    EvGiven EqPred {} ->
+          desugarBug
+            ( "missing local dictionary for "
+                <> show evidence
+                <> " ("
+                <> T.unpack (dictKey className args)
+                <> "); available evidence: "
+                <> show (Map.keys (dsLocalDicts st))
+            )
+    EvGiven _ EqPred {} ->
       unitConstructor
     EvDict dictOrigin dictName typeArgs contextEvidence -> do
       dictTy <- lookupType dictName
@@ -1763,15 +1796,15 @@ patternEvidenceBinders :: Pattern -> DsM ([Var], [ClassDict])
 patternEvidenceBinders pattern' = do
   let predicates =
         case patternTcAnnotation pattern' of
-          Just annotation -> [predicate | EvGiven predicate <- tcAnnEvidenceTerms annotation]
+          Just annotation -> [(evidence, predicate) | EvGiven evidence predicate <- tcAnnEvidenceTerms annotation]
           Nothing -> []
-  binders <- mapM (freshVar "$dpattern" . predType) predicates
+  binders <- mapM (freshVar "$dpattern" . predType . snd) predicates
   pure (binders, zipWith patternDictionary predicates binders)
   where
-    patternDictionary predicate binder =
+    patternDictionary (evidence, predicate) binder =
       case predicate of
-        ClassPred className arguments -> ClassDict className arguments binder
-        EqPred {} -> ClassDict "<constraint>" [] binder
+        ClassPred className arguments -> ClassDict evidence className arguments binder
+        EqPred {} -> ClassDict evidence "<constraint>" [] binder
 
 patternTcAnnotation :: Pattern -> Maybe TcAnnotation
 patternTcAnnotation pattern' =
@@ -1917,22 +1950,6 @@ fcExprTypeM expr =
 dictKey :: Text -> [TcType] -> Text
 dictKey className args = className <> ":" <> T.intercalate "," (map typeKey args)
 
-exactTypeKey :: TcType -> Text
-exactTypeKey ty =
-  case ty of
-    TcTyVar tv -> tvName tv <> "#" <> T.pack (show (uniqueInt (tvUnique tv)))
-    TcMetaTv (Unique unique) -> "?" <> T.pack (show unique)
-    TcTyCon tc [] -> tyConName tc
-    TcTyCon (TyCon "[]" _) [elementType] -> "[" <> exactTypeKey elementType <> "]"
-    TcTyCon tc arguments -> tyConName tc <> T.concat (map (("_" <>) . exactTypeKey) arguments)
-    TcAppTy function argument -> exactTypeKey function <> "_" <> exactTypeKey argument
-    TcFunTy argument result -> exactTypeKey argument <> "->" <> exactTypeKey result
-    TcForAllTy _ body -> exactTypeKey body
-    TcQualTy _ body -> exactTypeKey body
-
-uniqueInt :: Unique -> Int
-uniqueInt (Unique unique) = unique
-
 typeKey :: TcType -> Text
 typeKey ty =
   case ty of
@@ -2019,18 +2036,3 @@ resolvedTermKey displayName resolved =
     ResolvedBuiltin name -> TcTermGlobal "" "" name
     ResolvedError message ->
       error ("resolver error for term " <> T.unpack displayName <> ": " <> message)
-
-lookupLocalDictionary :: Text -> [TcType] -> [Unique] -> Map Unique ClassDict -> Maybe ClassDict
-lookupLocalDictionary className arguments order dictionaries =
-  findDictionary exactTypeKeys <|> findDictionary typeKeys
-  where
-    findDictionary makeKeys =
-      listToMaybe
-        [ dictionary
-        | key <- order,
-          Just dictionary <- [Map.lookup key dictionaries],
-          classDictName dictionary == className,
-          makeKeys (classDictArgs dictionary) == makeKeys arguments
-        ]
-    exactTypeKeys = map exactTypeKey
-    typeKeys = map typeKey

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -15,6 +15,7 @@ module Aihc.Fc.Desugar.Expr
     dsRhs,
     DsM,
     DsState (..),
+    DsLocalKey (..),
     ClassDict (..),
     desugarBug,
     freshUnique,
@@ -22,6 +23,7 @@ module Aihc.Fc.Desugar.Expr
     lookupType,
     primBoolType,
     withDicts,
+    withLocals,
   )
 where
 
@@ -61,6 +63,7 @@ import Aihc.Tc.Annotations (TcAnnotation (..))
 import Aihc.Tc.Env (DataConFieldInfo (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Kind (runtimeRepToTcType)
+import Aihc.Tc.Monad (TcTermKey (..))
 import Aihc.Tc.Types (Kind (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), isLiftedType, liftedRuntimeRep, mkTyCon, mkTyConWithOrigin, runtimeRepOfType, setTyVarKind, tvKind, unboxedTupleTyConName)
 import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
@@ -85,12 +88,14 @@ data DsState = DsState
     dsPrimPackageId :: !PackageId,
     dsModulePackage :: !Text,
     dsModuleName :: !(Maybe Text),
-    -- | Map from surface name to its inferred type (from TC).
-    dsTypeEnv :: !(Map Text TcType),
-    -- | Local variable bindings (pattern-bound, lambda-bound).
-    dsLocalVars :: !(Map Text Var),
-    -- | Local dictionaries, keyed by class predicate.
-    dsLocalDicts :: !(Map Text Var),
+    -- | Inferred types, keyed by resolver identity.
+    dsTypeEnv :: !(Map TcTermKey TcType),
+    -- | Local variables, keyed by resolver identity.
+    dsLocalVars :: !(Map DsLocalKey Var),
+    -- | Local dictionaries, keyed by variable identity.
+    dsLocalDicts :: !(Map Unique ClassDict),
+    -- | Dictionary keys in lexical lookup order.
+    dsLocalDictOrder :: ![Unique],
     -- | Checked constructor types, keyed by global source identity.
     dsConstructorTypes :: !(Map FcSymbolOrigin TcType),
     -- | Checked constructor fields, keyed by global source identity.
@@ -103,6 +108,9 @@ data ClassDict = ClassDict
     classDictArgs :: ![TcType],
     classDictVar :: !Var
   }
+
+data DsLocalKey = DsLocalKey !Int !Text
+  deriving (Eq, Ord, Show)
 
 -- | Generate a fresh unique.
 freshUnique :: DsM Unique
@@ -130,11 +138,20 @@ desugarBug = lift . Left
 lookupType :: Text -> DsM TcType
 lookupType name = do
   st <- get
-  case Map.lookup name (dsLocalVars st) of
-    Just v -> pure (varType v)
-    Nothing -> case lookupCurrentConstructorType name st <|> Map.lookup name (dsTypeEnv st) of
-      Just ty -> pure ty
-      Nothing -> desugarBug ("missing type information for name: " <> T.unpack name)
+  let currentKey = TcTermGlobal (PackageId (dsModulePackage st)) (fromMaybe "" (dsModuleName st)) name
+      builtinKey = TcTermGlobal "" "" name
+  case lookupCurrentConstructorType name st <|> Map.lookup currentKey (dsTypeEnv st) <|> Map.lookup builtinKey (dsTypeEnv st) <|> lookupUniqueGlobalType name (dsTypeEnv st) of
+    Just ty -> pure ty
+    Nothing -> desugarBug ("missing type information for name: " <> T.unpack name)
+
+lookupUniqueGlobalType :: Text -> Map TcTermKey TcType -> Maybe TcType
+lookupUniqueGlobalType name environment =
+  case [ ty
+       | (TcTermGlobal _ _ bindingName, ty) <- Map.toList environment,
+         bindingName == name
+       ] of
+    [ty] -> Just ty
+    _ -> Nothing
 
 lookupCurrentConstructorType :: Text -> DsState -> Maybe TcType
 lookupCurrentConstructorType name st = do
@@ -148,38 +165,51 @@ primBoolType = do
   primPackageId <- gets dsPrimPackageId
   pure (TcTyCon (mkTyConWithOrigin primPackageId "GHC.Types" "Bool" 0 KType) [])
 
--- | Look up a local variable binding.
-lookupLocal :: Text -> DsM (Maybe Var)
-lookupLocal name =
-  Map.lookup name . dsLocalVars <$> get
+insertUnique :: (Ord key, Show key) => Text -> key -> value -> Map key value -> Map key value
+insertUnique mapName key value environment
+  | Map.member key environment =
+      error (T.unpack mapName <> " has duplicate key: " <> show key)
+  | otherwise = Map.insert key value environment
 
 -- | Run an action with additional local variable bindings.
-withLocals :: [(Text, Var)] -> DsM a -> DsM a
+withLocals :: [(DsLocalKey, Var)] -> DsM a -> DsM a
 withLocals bindings action = do
   st <- get
   let oldLocals = dsLocalVars st
-      newLocals = foldr (\(n, v) m -> Map.insert n v m) oldLocals bindings
+      newLocals = List.foldl' insertLocal oldLocals bindings
   modify' (\s -> s {dsLocalVars = newLocals})
   result <- action
   modify' (\s -> s {dsLocalVars = oldLocals})
   pure result
+  where
+    insertLocal environment (key, variable) =
+      case Map.lookup key environment of
+        Just oldVariable ->
+          error
+            ( "dsLocalVars has duplicate key: "
+                <> show key
+                <> " ("
+                <> T.unpack (varName oldVariable)
+                <> ", "
+                <> T.unpack (varName variable)
+                <> ")"
+            )
+        Nothing -> Map.insert key variable environment
 
 withDicts :: [ClassDict] -> DsM a -> DsM a
 withDicts dicts action = do
   st <- get
   let oldDicts = dsLocalDicts st
+      oldOrder = dsLocalDictOrder st
       newDicts = foldr insertDictionary oldDicts dicts
-  modify' (\s -> s {dsLocalDicts = newDicts})
+      newOrder = map (varUnique . classDictVar) dicts <> oldOrder
+  modify' (\s -> s {dsLocalDicts = newDicts, dsLocalDictOrder = newOrder})
   result <- action
-  modify' (\s -> s {dsLocalDicts = oldDicts})
+  modify' (\s -> s {dsLocalDicts = oldDicts, dsLocalDictOrder = oldOrder})
   pure result
   where
-    insertDictionary dictionary environment =
-      let className = classDictName dictionary
-          arguments = classDictArgs dictionary
-          variable = classDictVar dictionary
-          withFallback = Map.insertWith (\_ existing -> existing) (dictKey className arguments) variable environment
-       in Map.insert (exactDictKey className arguments) variable withFallback
+    insertDictionary dictionary =
+      insertUnique "dsLocalDicts" (varUnique (classDictVar dictionary)) dictionary
 
 -- | Desugar a list of match equations into a Core expression.
 --
@@ -358,11 +388,11 @@ dsMatchPattern :: Var -> Pattern -> DsM FcExpr -> FcExpr -> DsM FcExpr
 dsMatchPattern scrutVar pat success failure =
   case peelPatternAnn pat of
     PVar name ->
-      withLocals [(unqualifiedNameText name, scrutVar)] success
+      withLocals [(binderTermKey name, scrutVar)] success
     PWildcard -> success
     PParen inner -> dsMatchPattern scrutVar inner success failure
     PAs name inner ->
-      withLocals [(unqualifiedNameText name, scrutVar)] (dsMatchPattern scrutVar inner success failure)
+      withLocals [(binderTermKey name, scrutVar)] (dsMatchPattern scrutVar inner success failure)
     PStrict inner -> dsMatchPattern scrutVar inner success failure
     PIrrefutable inner ->
       withLocals (irrefutablePatternBindings scrutVar inner) success
@@ -424,12 +454,12 @@ dsBoxedCharPatternMatch scrutVar char success failure = do
         ]
     )
 
-irrefutablePatternBindings :: Var -> Pattern -> [(Text, Var)]
+irrefutablePatternBindings :: Var -> Pattern -> [(DsLocalKey, Var)]
 irrefutablePatternBindings scrutVar pat =
   case peelPatternAnn pat of
-    PVar name -> [(unqualifiedNameText name, scrutVar)]
+    PVar name -> [(binderTermKey name, scrutVar)]
     PParen inner -> irrefutablePatternBindings scrutVar inner
-    PAs name inner -> (unqualifiedNameText name, scrutVar) : irrefutablePatternBindings scrutVar inner
+    PAs name inner -> (binderTermKey name, scrutVar) : irrefutablePatternBindings scrutVar inner
     PStrict inner -> irrefutablePatternBindings scrutVar inner
     PIrrefutable inner -> irrefutablePatternBindings scrutVar inner
     PTypeSig inner _ -> irrefutablePatternBindings scrutVar inner
@@ -474,13 +504,13 @@ noPatternMatch [] =
 
 -- | Extract variable bindings from the first pattern of each match,
 -- mapping the pattern variable name to the scrutinee Var.
-extractVarBindings :: Var -> [Match] -> [(Text, Var)]
-extractVarBindings scrutVar = concatMap go
+extractVarBindings :: Var -> [Match] -> [(DsLocalKey, Var)]
+extractVarBindings scrutVar = Map.toList . Map.fromList . concatMap go
   where
     go m = case matchPats m of
       (p : _) -> extractName p
       _ -> []
-    extractName (PVar uname) = [(unqualifiedNameText uname, scrutVar)]
+    extractName (PVar uname) = [(binderTermKey uname, scrutVar)]
     extractName (PAnn _ inner) = extractName inner
     extractName (PParen inner) = extractName inner
     extractName _ = []
@@ -1032,11 +1062,11 @@ dsPatternMatchResult :: Var -> Pattern -> DsM FcExpr -> CaseMatchResult
 dsPatternMatchResult scrutVar pattern' success =
   case peelPatternAnn pattern' of
     PVar name ->
-      CaseMatchInfallible (withLocals [(unqualifiedNameText name, scrutVar)] success)
+      CaseMatchInfallible (withLocals [(binderTermKey name, scrutVar)] success)
     PWildcard -> CaseMatchInfallible success
     PParen inner -> dsPatternMatchResult scrutVar inner success
     PAs name inner ->
-      withCaseMatchLocals [(unqualifiedNameText name, scrutVar)] (dsPatternMatchResult scrutVar inner success)
+      withCaseMatchLocals [(binderTermKey name, scrutVar)] (dsPatternMatchResult scrutVar inner success)
     PStrict inner ->
       adjustCaseMatchResult (forceCaseScrutinee scrutVar) (dsPatternMatchResult scrutVar inner success)
     PIrrefutable inner ->
@@ -1047,7 +1077,7 @@ dsPatternMatchResult scrutVar pattern' success =
         failure <- failureAction
         dsMatchPattern scrutVar pattern' success failure
 
-withCaseMatchLocals :: [(Text, Var)] -> CaseMatchResult -> CaseMatchResult
+withCaseMatchLocals :: [(DsLocalKey, Var)] -> CaseMatchResult -> CaseMatchResult
 withCaseMatchLocals bindings matchResult =
   case matchResult of
     CaseMatchInfallible body -> CaseMatchInfallible (withLocals bindings body)
@@ -1168,9 +1198,9 @@ patternOccurrence target =
 dsLetDecls :: [Decl] -> DsM FcExpr -> DsM FcExpr
 dsLetDecls decls bodyAction = do
   groups <- groupLocalDecls decls
-  let names = map localGroupName groups
+  let keys = map localGroupKey groups
       vars = map localGroupBinder groups
-  let localBindings = zip names vars
+  let localBindings = zip keys vars
   withLocals localBindings $ do
     rhsBindings <- zipWithM dsLocalGroup vars groups
     body <- bodyAction
@@ -1180,58 +1210,58 @@ dsLetDecls decls bodyAction = do
         else FcLet (FcRec rhsBindings) body
 
 data LocalDeclGroup
-  = LocalFunction !Text !Var ![Match]
-  | LocalPattern !Text !Var !(Rhs Expr)
+  = LocalFunction !DsLocalKey !Text !Var ![Match]
+  | LocalPattern !DsLocalKey !Text !Var !(Rhs Expr)
 
-localGroupName :: LocalDeclGroup -> Text
-localGroupName group =
+localGroupKey :: LocalDeclGroup -> DsLocalKey
+localGroupKey group =
   case group of
-    LocalFunction name _ _ -> name
-    LocalPattern name _ _ -> name
+    LocalFunction key _ _ _ -> key
+    LocalPattern key _ _ _ -> key
 
 localGroupBinder :: LocalDeclGroup -> Var
 localGroupBinder group =
   case group of
-    LocalFunction _ var _ -> var
-    LocalPattern _ var _ -> var
+    LocalFunction _ _ var _ -> var
+    LocalPattern _ _ var _ -> var
 
 groupLocalDecls :: [Decl] -> DsM [LocalDeclGroup]
 groupLocalDecls [] = pure []
 groupLocalDecls (decl : rest) = do
   maybeFun <- extractLocalFunction decl
   case maybeFun of
-    Just (name, var, matches) -> do
-      let (sameNameDecls, rest') = span (hasSameLocalFunctionName name) rest
+    Just (key, name, var, matches) -> do
+      let (sameNameDecls, rest') = span (hasSameLocalFunctionKey key) rest
       sameGroups <- mapM extractLocalFunctionRequired sameNameDecls
-      let allMatches = matches ++ concatMap (\(_, _, ms) -> ms) sameGroups
+      let allMatches = matches ++ concatMap (\(_, _, _, ms) -> ms) sameGroups
       restGroups <- groupLocalDecls rest'
-      pure (LocalFunction name var allMatches : restGroups)
+      pure (LocalFunction key name var allMatches : restGroups)
     Nothing -> do
       maybePattern <- extractLocalPattern decl
       restGroups <- groupLocalDecls rest
       pure (maybe restGroups (: restGroups) maybePattern)
 
-extractLocalFunction :: Decl -> DsM (Maybe (Text, Var, [Match]))
+extractLocalFunction :: Decl -> DsM (Maybe (DsLocalKey, Text, Var, [Match]))
 extractLocalFunction decl =
   case peelDeclAnn decl of
     DeclValue (FunctionBind name matches) -> do
       let localName = unqualifiedNameText name
       ty <- localDeclTypeRequired localName decl
       var <- freshVar localName ty
-      pure (Just (localName, var, matches))
+      pure (Just (binderTermKey name, localName, var, matches))
     _ -> pure Nothing
 
-extractLocalFunctionRequired :: Decl -> DsM (Text, Var, [Match])
+extractLocalFunctionRequired :: Decl -> DsM (DsLocalKey, Text, Var, [Match])
 extractLocalFunctionRequired decl = do
   maybeFun <- extractLocalFunction decl
   case maybeFun of
     Just fun -> pure fun
     Nothing -> desugarBug ("expected local function declaration: " <> take 80 (show decl))
 
-hasSameLocalFunctionName :: Text -> Decl -> Bool
-hasSameLocalFunctionName name decl =
+hasSameLocalFunctionKey :: DsLocalKey -> Decl -> Bool
+hasSameLocalFunctionKey key decl =
   case peelDeclAnn decl of
-    DeclValue (FunctionBind declName _) -> unqualifiedNameText declName == name
+    DeclValue (FunctionBind declName _) -> binderTermKey declName == key
     _ -> False
 
 extractLocalPattern :: Decl -> DsM (Maybe LocalDeclGroup)
@@ -1239,17 +1269,17 @@ extractLocalPattern decl =
   case peelDeclAnn decl of
     DeclValue (PatternBind _ pat rhs) ->
       case barePatternName pat of
-        Just name -> do
+        Just (key, name) -> do
           ty <- localDeclTypeRequired name decl
           var <- freshVar name ty
-          pure (Just (LocalPattern name var rhs))
+          pure (Just (LocalPattern key name var rhs))
         Nothing -> pure Nothing
     _ -> pure Nothing
 
-barePatternName :: Pattern -> Maybe Text
+barePatternName :: Pattern -> Maybe (DsLocalKey, Text)
 barePatternName pat =
   case pat of
-    PVar name -> Just (unqualifiedNameText name)
+    PVar name -> Just (binderTermKey name, unqualifiedNameText name)
     PAnn _ inner -> barePatternName inner
     PParen inner -> barePatternName inner
     _ -> Nothing
@@ -1272,10 +1302,10 @@ localDeclType decl =
 dsLocalGroup :: Var -> LocalDeclGroup -> DsM (Var, FcExpr)
 dsLocalGroup var group =
   case group of
-    LocalFunction _ _ matches -> do
+    LocalFunction _ _ _ matches -> do
       rhs <- dsMatches (varType var) matches
       pure (var, rhs)
-    LocalPattern _ _ rhs -> do
+    LocalPattern _ _ _ rhs -> do
       rhs' <- dsRhs rhs
       pure (var, rhs')
 
@@ -1386,7 +1416,8 @@ dsCompGenMatch elemTy body pat rest headVar skipExpr =
           binderTys <- patternBinderTypesM pat (varType headVar)
           binders <- zipWithM freshVar binderNames binderTys
           (evidenceBinders, dictionaries) <- patternEvidenceBinders pat
-          matched <- withDicts dictionaries (withLocals (zip binderNames binders) (dsCompQuals elemTy body rest skipExpr))
+          let bindings = patternFieldBindings pat binders
+          matched <- withDicts dictionaries (withLocals bindings (dsCompQuals elemTy body rest skipExpr))
           caseBinder <- freshInternalVar "_lc_match" (varType headVar)
           pure
             ( FcCase
@@ -1397,16 +1428,23 @@ dsCompGenMatch elemTy body pat rest headVar skipExpr =
                 ]
             )
 
-directPatternBindings :: Pattern -> Var -> Maybe [(Text, Var)]
+directPatternBindings :: Pattern -> Var -> Maybe [(DsLocalKey, Var)]
 directPatternBindings pat var =
   case pat of
-    PVar name -> Just [(unqualifiedNameText name, var)]
+    PVar name -> Just [(binderTermKey name, var)]
     PWildcard -> Just []
     PAnn _ inner -> directPatternBindings inner var
     PParen inner -> directPatternBindings inner var
-    PAs name inner -> ((unqualifiedNameText name, var) :) <$> directPatternBindings inner var
+    PAs name inner -> ((binderTermKey name, var) :) <$> directPatternBindings inner var
     PStrict inner -> directPatternBindings inner var
     _ -> Nothing
+
+patternFieldBindings :: Pattern -> [Var] -> [(DsLocalKey, Var)]
+patternFieldBindings pat binders =
+  concat
+    [ fromMaybe [] (directPatternBindings subpattern binder)
+    | (subpattern, binder) <- zip (constructorSubpatterns pat) binders
+    ]
 
 dsLambda :: [Pattern] -> Expr -> DsM FcExpr
 dsLambda pats body = do
@@ -1578,8 +1616,8 @@ dsEvidence evidence =
   case evidence of
     EvGiven (ClassPred className args) -> do
       st <- get
-      case Map.lookup (exactDictKey className args) (dsLocalDicts st) <|> Map.lookup (dictKey className args) (dsLocalDicts st) of
-        Just var -> pure (FcVar var)
+      case lookupLocalDictionary className args (dsLocalDictOrder st) (dsLocalDicts st) of
+        Just dictionary -> pure (FcVar (classDictVar dictionary))
         Nothing ->
           desugarBug ("missing local dictionary for " <> T.unpack (dictKey className args))
     EvGiven EqPred {} ->
@@ -1879,9 +1917,6 @@ fcExprTypeM expr =
 dictKey :: Text -> [TcType] -> Text
 dictKey className args = className <> ":" <> T.intercalate "," (map typeKey args)
 
-exactDictKey :: Text -> [TcType] -> Text
-exactDictKey className args = className <> ":exact:" <> T.intercalate "," (map exactTypeKey args)
-
 exactTypeKey :: TcType -> Text
 exactTypeKey ty =
   case ty of
@@ -1925,12 +1960,10 @@ nameToText n = case nameQualifier n of
 
 lookupLocalName :: Name -> DsM (Maybe Var)
 lookupLocalName name = do
-  currentModule <- gets dsModuleName
-  case nameQualifier name of
-    Nothing -> lookupLocal (nameText name)
-    Just qualifier
-      | Just qualifier == currentModule -> lookupLocal (nameText name)
-      | otherwise -> lookupLocal (nameToText name)
+  locals <- gets dsLocalVars
+  pure $ do
+    key <- nameLocalKey name
+    Map.lookup key locals
 
 lookupTypeName :: Name -> DsM TcType
 lookupTypeName name = do
@@ -1943,4 +1976,61 @@ lookupTypeMaybeName :: Name -> DsM (Maybe TcType)
 lookupTypeMaybeName name = do
   st <- get
   let constructorType = resolvedOccurrenceOrigin name >>= (`Map.lookup` dsConstructorTypes st)
-  pure (constructorType <|> Map.lookup (nameToText name) (dsTypeEnv st) <|> Map.lookup (nameText name) (dsTypeEnv st))
+      bindingType = nameTermKey name >>= (`Map.lookup` dsTypeEnv st)
+      replType = Map.lookup (TcTermGlobal "" "$repl-import" (unqualifiedGlobalName (nameText name))) (dsTypeEnv st)
+      uniqueType = lookupUniqueGlobalType (unqualifiedGlobalName (nameText name)) (dsTypeEnv st)
+  pure (constructorType <|> bindingType <|> replType <|> uniqueType)
+
+unqualifiedGlobalName :: Text -> Text
+unqualifiedGlobalName = last . T.splitOn "."
+
+binderTermKey :: UnqualifiedName -> DsLocalKey
+binderTermKey name =
+  case termResolution (unqualifiedNameAnns name) of
+    Just ResolutionAnnotation {resolutionTarget = ResolvedLocal unique resolvedName} ->
+      DsLocalKey unique (unqualifiedNameText resolvedName)
+    Just resolution ->
+      error ("local binder has nonlocal resolver key: " <> show (resolutionTarget resolution))
+    Nothing -> error ("local binder has no resolver key: " <> T.unpack (unqualifiedNameText name))
+
+nameLocalKey :: Name -> Maybe DsLocalKey
+nameLocalKey name = do
+  ResolutionAnnotation {resolutionTarget = ResolvedLocal unique resolvedName} <- termResolution (nameAnns name)
+  pure (DsLocalKey unique (unqualifiedNameText resolvedName))
+
+nameTermKey :: Name -> Maybe TcTermKey
+nameTermKey name =
+  resolvedTermKey (nameText name) . resolutionTarget <$> termResolution (nameAnns name)
+
+termResolution :: [Surface.Annotation] -> Maybe ResolutionAnnotation
+termResolution annotations =
+  listToMaybe
+    [ resolution
+    | resolution <- mapMaybe fromAnnotation annotations,
+      resolutionNamespace resolution == ResolutionNamespaceTerm
+    ]
+
+resolvedTermKey :: Text -> ResolvedName -> TcTermKey
+resolvedTermKey displayName resolved =
+  case resolved of
+    ResolvedLocal unique _ -> TcTermLocal unique
+    ResolvedTopLevel packageId name ->
+      TcTermGlobal packageId (fromMaybe "" (nameQualifier name)) (nameText name)
+    ResolvedBuiltin name -> TcTermGlobal "" "" name
+    ResolvedError message ->
+      error ("resolver error for term " <> T.unpack displayName <> ": " <> message)
+
+lookupLocalDictionary :: Text -> [TcType] -> [Unique] -> Map Unique ClassDict -> Maybe ClassDict
+lookupLocalDictionary className arguments order dictionaries =
+  findDictionary exactTypeKeys <|> findDictionary typeKeys
+  where
+    findDictionary makeKeys =
+      listToMaybe
+        [ dictionary
+        | key <- order,
+          Just dictionary <- [Map.lookup key dictionaries],
+          classDictName dictionary == className,
+          makeKeys (classDictArgs dictionary) == makeKeys arguments
+        ]
+    exactTypeKeys = map exactTypeKey
+    typeKeys = map typeKey

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -15,17 +15,21 @@ where
 
 import Aihc.Fc
 import Aihc.Fc qualified as Fc
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsLocalKey (..), DsState (..), withDicts, withLocals)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax qualified as Surface
 import Aihc.Resolve (PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
-import Aihc.Tc (Kind (KType), RuntimeRep (..), TcInterface (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
+import Aihc.Tc (Kind (KType), RuntimeRep (..), TcBindingResult (..), TcInterface (..), TcTermKey (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
 import Aihc.Testing.EvalFixture qualified as EvalGolden
-import Data.List (find)
+import Control.Exception (ErrorCall, displayException, evaluate, tryJust)
+import Control.Monad.Trans.State.Strict (runStateT)
+import Data.List (find, isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import FcGolden
@@ -102,7 +106,24 @@ fcDesugarTests =
           [TcTyCon tyCon []] -> do
             assertEqual "package ID" (PackageId "aihc-prim") (tyConPackageId tyCon)
             assertEqual "module name" "GHC.Types" (tyConModuleName tyCon)
-          other -> assertFailure ("expected one Bool case binder, got: " <> show other)
+          other -> assertFailure ("expected one Bool case binder, got: " <> show other),
+      testCase "rejects duplicate type environment keys" $ do
+        let (_, parsedModule) = parseModule defaultConfig "module Test where\n"
+        (tcModule, _) <- resolveAndTypecheck parsedModule
+        let key = TcTermGlobal "test" "Test" "duplicate"
+            duplicateBinding = TcBindingResult "duplicate" "duplicate" testType (Just key)
+            conflictingBinding = TcBindingResult "duplicate" "duplicate" (TcFunTy testType testType) (Just key)
+        assertErrorCallContains
+          "dsTypeEnv has conflicting key: TcTermGlobal (PackageId {packageIdText = \"test\"}) \"Test\" \"duplicate\""
+          (desugarModuleWithBindings (DesugarConfig {primPackageId = PackageId "aihc-prim"}) [duplicateBinding, conflictingBinding] tcModule),
+      testCase "rejects duplicate local variable keys" $
+        assertErrorCallContains
+          "dsLocalVars has duplicate key: DsLocalKey 1 \"value\""
+          (runStateT (withLocals [(DsLocalKey 1 "value", testVar)] (withLocals [(DsLocalKey 1 "value", testVar)] (pure ()))) emptyDsState),
+      testCase "rejects duplicate local dictionary keys" $
+        assertErrorCallContains
+          "dsLocalDicts has duplicate key: Unique 1"
+          (runStateT (withDicts [testDictionary] (withDicts [testDictionary] (pure ()))) emptyDsState)
     ]
   where
     declarationConstructors declaration =
@@ -110,6 +131,41 @@ fcDesugarTests =
         Surface.DeclAnn _ inner -> declarationConstructors inner
         Surface.DeclData dataDeclaration -> Surface.dataDeclConstructors dataDeclaration
         _ -> []
+
+testType :: TcType
+testType = TcTyCon (TyCon "TestType" 0) []
+
+testVar :: Var
+testVar = Var "value" (Unique 1) testType
+
+testDictionary :: ClassDict
+testDictionary = ClassDict "TestClass" [] testVar
+
+emptyDsState :: DsState
+emptyDsState =
+  DsState
+    { dsNextUnique = 2,
+      dsPrimPackageId = PackageId "aihc-prim",
+      dsModulePackage = "main",
+      dsModuleName = Just "Test",
+      dsTypeEnv = Map.empty,
+      dsLocalVars = Map.empty,
+      dsLocalDicts = Map.empty,
+      dsLocalDictOrder = [],
+      dsConstructorTypes = Map.empty,
+      dsConstructorFields = Map.empty,
+      dsTupleConstructorOrigin = Nothing
+    }
+
+assertErrorCallContains :: String -> a -> IO ()
+assertErrorCallContains expected value = do
+  result <- tryJust errorCallText (evaluate value)
+  case result of
+    Left actual -> assertBool ("expected error text: " <> expected <> "\nactual error text: " <> actual) (expected `isInfixOf` actual)
+    Right _ -> assertFailure ("expected an unrecoverable error that contains: " <> expected)
+  where
+    errorCallText :: ErrorCall -> Maybe String
+    errorCallText = Just . displayException
 
 resolveAndTypecheck :: Surface.Module -> IO (Surface.Module, TcInterface)
 resolveAndTypecheck parsedModule =

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -15,15 +15,15 @@ where
 
 import Aihc.Fc
 import Aihc.Fc qualified as Fc
-import Aihc.Fc.Desugar.Expr (ClassDict (..), DsLocalKey (..), DsState (..), withDicts, withLocals)
+import Aihc.Fc.Desugar.Expr (ClassDict (..), DsLocalKey (..), DsState (..), dsEvidence, withDicts, withLocals)
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax qualified as Surface
 import Aihc.Resolve (PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (Kind (KType), RuntimeRep (..), TcBindingResult (..), TcInterface (..), TcTermKey (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
-import Aihc.Tc.Evidence (Coercion (..))
-import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
+import Aihc.Tc.Evidence (Coercion (..), EvTerm (..), EvVar (..))
+import Aihc.Tc.Types (Pred (..), tyConModuleName, tyConPackageId)
 import Aihc.Testing.EvalFixture qualified as EvalGolden
 import Control.Exception (ErrorCall, displayException, evaluate, tryJust)
 import Control.Monad.Trans.State.Strict (runStateT)
@@ -111,8 +111,8 @@ fcDesugarTests =
         let (_, parsedModule) = parseModule defaultConfig "module Test where\n"
         (tcModule, _) <- resolveAndTypecheck parsedModule
         let key = TcTermGlobal "test" "Test" "duplicate"
-            duplicateBinding = TcBindingResult "duplicate" "duplicate" testType (Just key)
-            conflictingBinding = TcBindingResult "duplicate" "duplicate" (TcFunTy testType testType) (Just key)
+            duplicateBinding = TcBindingResult "duplicate" "duplicate" testType (Just key) []
+            conflictingBinding = TcBindingResult "duplicate" "duplicate" (TcFunTy testType testType) (Just key) []
         assertErrorCallContains
           "dsTypeEnv has conflicting key: TcTermGlobal (PackageId {packageIdText = \"test\"}) \"Test\" \"duplicate\""
           (desugarModuleWithBindings (DesugarConfig {primPackageId = PackageId "aihc-prim"}) [duplicateBinding, conflictingBinding] tcModule),
@@ -122,8 +122,17 @@ fcDesugarTests =
           (runStateT (withLocals [(DsLocalKey 1 "value", testVar)] (withLocals [(DsLocalKey 1 "value", testVar)] (pure ()))) emptyDsState),
       testCase "rejects duplicate local dictionary keys" $
         assertErrorCallContains
-          "dsLocalDicts has duplicate key: Unique 1"
-          (runStateT (withDicts [testDictionary] (withDicts [testDictionary] (pure ()))) emptyDsState)
+          "dsLocalDicts has duplicate key: EvVar {evVarUnique = Unique 1}"
+          (runStateT (withDicts [testDictionary] (withDicts [testDictionary] (pure ()))) emptyDsState),
+      testCase "selects a local dictionary by evidence identity" $ do
+        let secondEvidence = EvVar (Unique 2)
+            secondVar = Var "second" (Unique 2) testType
+            secondDictionary = ClassDict secondEvidence "TestClass" [] secondVar
+            action = withDicts [testDictionary, secondDictionary] (dsEvidence (EvGiven secondEvidence (ClassPred "TestClass" [])))
+        case runStateT action emptyDsState of
+          Right (FcVar selected, _) -> assertEqual "selected dictionary" secondVar selected
+          Right (other, _) -> assertFailure ("expected the second dictionary variable, got: " <> show other)
+          Left message -> assertFailure ("dictionary selection failed: " <> message)
     ]
   where
     declarationConstructors declaration =
@@ -139,7 +148,7 @@ testVar :: Var
 testVar = Var "value" (Unique 1) testType
 
 testDictionary :: ClassDict
-testDictionary = ClassDict "TestClass" [] testVar
+testDictionary = ClassDict (EvVar (Unique 1)) "TestClass" [] testVar
 
 emptyDsState :: DsState
 emptyDsState =
@@ -151,7 +160,6 @@ emptyDsState =
       dsTypeEnv = Map.empty,
       dsLocalVars = Map.empty,
       dsLocalDicts = Map.empty,
-      dsLocalDictOrder = [],
       dsConstructorTypes = Map.empty,
       dsConstructorFields = Map.empty,
       dsTupleConstructorOrigin = Nothing

--- a/components/aihc-fc/test/Test/Fixtures/golden/derive-anyclass-dictionary.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/derive-anyclass-dictionary.yaml
@@ -34,7 +34,7 @@ expected: |-
       λ($d0 : Any a).
         λ($d1 : Required a).
           λ(x1011 : a).
-            ((required @a) $d1) x1011
+            ((required @(a : TYPE BoxedRep Lifted)) $d1) x1011
 
   data Wrapped (a : TYPE BoxedRep Lifted)
    = Wrapped (Box a)

--- a/components/aihc-fc/test/Test/Fixtures/golden/qualified-constructors-same-name.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/qualified-constructors-same-name.yaml
@@ -1,0 +1,59 @@
+extensions: []
+modules:
+  - |
+    module First where
+
+    data FirstField = FirstField
+    data First = Shared !FirstField
+  - |
+    module Second where
+
+    data SecondField = SecondField
+    data Second = Shared !SecondField
+  - |
+    module Test where
+
+    import qualified First
+    import qualified Second
+
+    makeFirst :: First.FirstField -> First.First
+    makeFirst field = First.Shared field
+
+    makeSecond :: Second.SecondField -> Second.Second
+    makeSecond field = Second.Shared field
+expected: |-
+  module First where
+
+  data FirstField
+   = FirstField
+
+  data First
+   = Shared (FirstField)
+  module Second where
+
+  data SecondField
+   = SecondField
+
+  data Second
+   = Shared (SecondField)
+  module Test where
+
+  external First.Shared : FirstField → First
+
+  external Second.Shared : SecondField → Second
+
+  makeFirst : FirstField → First =
+    λ(x1001 : FirstField).
+      case x1001 as (_strict_field1003 : FirstField) of {
+        _ →
+          First.Shared _strict_field1003
+      }
+
+  makeSecond : SecondField → Second =
+    λ(x1005 : SecondField).
+      case x1005 as (_strict_field1007 : SecondField) of {
+        _ →
+          Second.Shared _strict_field1007
+      }
+status: pass
+reason: qualified constructors with the same local name use their own checked field types

--- a/components/aihc-tc/common/TcAnnotatedRender.hs
+++ b/components/aihc-tc/common/TcAnnotatedRender.hs
@@ -241,7 +241,7 @@ renderEvTerm :: EvTerm -> String
 renderEvTerm ev =
   case ev of
     EvVarTerm evVar -> renderEvVar evVar
-    EvGiven pred' -> "given " <> renderPred pred'
+    EvGiven _ pred' -> "given " <> renderPred pred'
     EvDict _ name typeArgs evidence ->
       T.unpack name
         <> renderTypeArgs typeArgs

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -17,6 +17,8 @@ module Aihc.Tc.Annotations
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
     TcDictBinderAnnotation (..),
+    TcEvidenceBinderAnnotation (..),
+    PendingTcEvidenceBinders (..),
     TcDerivingAnnotation (..),
     TcDerivingContext (..),
     TcDerivingPlan (..),
@@ -73,6 +75,8 @@ data TcAnnotation = TcAnnotation
     tcAnnTypeArgs :: ![TcType],
     -- | Evidence terms whose dictionaries must be passed at this occurrence.
     tcAnnEvidenceTerms :: ![EvTerm],
+    -- | Evidence variables abstracted at this binding.
+    tcAnnEvidenceBinders :: ![TcEvidenceBinderAnnotation],
     -- | Term argument types made explicit for lambda-like binders.
     tcAnnTermArgTypes :: ![TcType]
   }
@@ -136,6 +140,19 @@ data TcDictBinderAnnotation = TcDictBinderAnnotation
   }
   deriving (Eq, Show)
 
+data TcEvidenceBinderAnnotation = TcEvidenceBinderAnnotation
+  { tcEvidenceBinderVar :: !EvVar,
+    tcEvidenceBinderPred :: !Pred,
+    tcEvidenceBinderType :: !TcType
+  }
+  deriving (Eq, Show, Read)
+
+-- | Evidence binders made before declaration annotations are complete.
+newtype PendingTcEvidenceBinders = PendingTcEvidenceBinders
+  { pendingTcEvidenceBinders :: [TcEvidenceBinderAnnotation]
+  }
+  deriving (Eq, Show)
+
 data TcClassMethodAnnotation = TcClassMethodAnnotation
   { tcClassMethodName :: !Text,
     tcClassMethodType :: !TcType,
@@ -195,6 +212,8 @@ data TcDerivingPlan = TcDerivingPlan
     -- target is a data or newtype constructor known to this compilation.
     tcDerivingDataType :: !(Maybe DataTypeInfo),
     tcDerivingContext :: !TcDerivingContext,
+    tcDerivingContextEvidence :: ![TcEvidenceBinderAnnotation],
+    tcDerivingSelfEvidence :: !(Maybe EvVar),
     tcDerivingStockPlan :: !(Maybe TcStockDerivingPlan),
     tcDerivingClassTyVars :: ![TyVarId],
     tcDerivingClassSuperClasses :: ![TcDictBinderAnnotation],
@@ -224,6 +243,7 @@ data TcInstanceAnnotation = TcInstanceAnnotation
     tcInstanceClassOrigin :: !(Maybe (Text, Text)),
     tcInstanceClassSuperClasses :: ![TcDictBinderAnnotation],
     tcInstanceContextDicts :: ![TcDictBinderAnnotation],
+    tcInstanceContextEvidence :: ![TcEvidenceBinderAnnotation],
     tcInstanceSuperClasses :: ![(TcDictBinderAnnotation, EvTerm)],
     tcInstanceMethodOrder :: ![Text],
     tcInstanceDefaultMethods :: ![Text]
@@ -232,7 +252,8 @@ data TcInstanceAnnotation = TcInstanceAnnotation
 
 data TcInstanceMethodAnnotation = TcInstanceMethodAnnotation
   { tcInstanceMethodName :: !Text,
-    tcInstanceMethodType :: !TcType
+    tcInstanceMethodType :: !TcType,
+    tcInstanceMethodEvidence :: ![TcEvidenceBinderAnnotation]
   }
   deriving (Eq, Show)
 

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -231,6 +231,8 @@ mkDerivingPlan sourceSpan strategy classInfo tyVars headTypes dataType context m
       tcDerivingHeadTypes = headTypes,
       tcDerivingDataType = dataType,
       tcDerivingContext = context,
+      tcDerivingContextEvidence = [],
+      tcDerivingSelfEvidence = Nothing,
       tcDerivingStockPlan = Nothing,
       tcDerivingClassTyVars = ciTyVars classInfo,
       tcDerivingClassSuperClasses = map constraintTypeDictBinder (ciSuperClassTypes classInfo),

--- a/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
@@ -26,6 +26,7 @@ import Aihc.Tc.Annotations
     TcDerivingPlan (..),
     TcDerivingStrategy (..),
     TcDictBinderAnnotation (..),
+    TcEvidenceBinderAnnotation (..),
     TcStockDerivingPlan (..),
   )
 import Aihc.Tc.Constraint (Ct (..), CtOrigin (..), mkWantedCt)
@@ -183,21 +184,30 @@ attachDerivingEvidence :: TcDerivingPlan -> TcM TcDerivingPlan
 attachDerivingEvidence plan =
   case (tcDerivingStrategy plan, tcDerivingContext plan) of
     (TcDerivingAnyclass, TcDerivingExplicitContext context) -> do
-      superClassEvidence <- mapM (solveObligation context) superClasses
+      givenEvidence <- mapM freshGiven context
+      superClassEvidence <- mapM (solveObligation givenEvidence) superClasses
       defaultMethodEvidence <-
         mapM
-          (traverse (mapM (solveObligation context)))
+          (traverse (mapM (solveObligation givenEvidence)))
           (instantiatedDefaultSignaturePredicates plan)
       pure
         plan
-          { tcDerivingSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
+          { tcDerivingContextEvidence = map evidenceBinder givenEvidence,
+            tcDerivingSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
             tcDerivingDefaultMethodEvidence = defaultMethodEvidence
           }
     (TcDerivingStock, TcDerivingExplicitContext context)
       | tcDerivingClassName plan == "Eq",
         Right obligations <- stockEqObligations plan -> do
-          fieldEvidence <- mapM (mapM (solveObligation context)) obligations
-          pure plan {tcDerivingStockPlan = Just (TcStockEqPlan fieldEvidence)}
+          givenEvidence <- mapM freshGiven context
+          selfEvidence <- freshEvVar
+          fieldEvidence <- mapM (mapM (solveObligation givenEvidence)) obligations
+          pure
+            plan
+              { tcDerivingContextEvidence = map evidenceBinder givenEvidence,
+                tcDerivingSelfEvidence = Just selfEvidence,
+                tcDerivingStockPlan = Just (TcStockEqPlan fieldEvidence)
+              }
     _ -> pure plan
   where
     superClasses =
@@ -222,6 +232,9 @@ attachDerivingEvidence plan =
         DictStuck stuck -> do
           emitError (ctLoc stuck) (UnsolvedWanted (ctPred stuck) (ctOrigin stuck))
           pure (EvVarTerm evidenceVariable)
+    freshGiven predicate = (,predicate) <$> freshEvVar
+    evidenceBinder (evidence, predicate) =
+      TcEvidenceBinderAnnotation evidence predicate (predType predicate)
 
 instantiatedDefaultSignaturePredicates :: TcDerivingPlan -> [(Text, [Pred])]
 instantiatedDefaultSignaturePredicates plan =

--- a/components/aihc-tc/src/Aihc/Tc/Evidence.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Evidence.hs
@@ -32,7 +32,7 @@ data EvTerm
   = -- | Reference to an evidence variable (given or previously solved).
     EvVarTerm !EvVar
   | -- | Given dictionary from a qualified type.
-    EvGiven !Pred
+    EvGiven !EvVar !Pred
   | -- | Dictionary construction: origin, dictionary name, type args, sub-evidence.
     EvDict !(Maybe (Text, Text)) !Text ![TcType] ![EvTerm]
   | -- | Coercion evidence (for equality constraints).

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -19,6 +19,7 @@ import Aihc.Tc.Annotations
     TcDerivingPlan (..),
     TcDerivingStrategy (..),
     TcDictBinderAnnotation (..),
+    TcEvidenceBinderAnnotation (..),
     TcInstanceAnnotation (..),
     TcInstanceMethodAnnotation (..),
     TcStockDerivingPlan (..),
@@ -71,7 +72,7 @@ annotationForPendingTc pending = do
   typeArgs <- mapM zonkType (pendingTcAnnTypeArgs pending)
   evidenceTerms <- mapM (evidenceForEvVar ty >=> zonkEvTerm) (pendingTcAnnEvidenceVars pending)
   termArgTypes <- mapM zonkType (pendingTcAnnTermArgTypes pending)
-  let ann = TcAnnotation ty typeBinders typeArgs evidenceTerms termArgTypes
+  let ann = TcAnnotation ty typeBinders typeArgs evidenceTerms [] termArgTypes
   rejectMetaTcAnnotation ann
   pure ann
 
@@ -95,8 +96,8 @@ zonkEvTerm evTerm =
   case evTerm of
     EvVarTerm ev ->
       pure (EvVarTerm ev)
-    EvGiven pred' ->
-      EvGiven <$> zonkPred pred'
+    EvGiven evidence pred' ->
+      EvGiven evidence <$> zonkPred pred'
     EvDict origin name typeArgs evidence ->
       EvDict origin name <$> mapM zonkType typeArgs <*> mapM zonkEvTerm evidence
     EvCoercion coercion ->
@@ -162,6 +163,7 @@ firstMetaTcAnnotation ann =
     ( firstMetaType (tcAnnType ann)
         : map firstMetaType (tcAnnTypeArgs ann)
         ++ map firstMetaEvTerm (tcAnnEvidenceTerms ann)
+        ++ map firstMetaEvidenceBinderAnnotation (tcAnnEvidenceBinders ann)
         ++ map firstMetaType (tcAnnTermArgTypes ann)
     )
 
@@ -186,6 +188,7 @@ firstMetaDerivingPlan plan =
         ++ maybe [] (map firstMetaDataConInfo . dtiConstructors) (tcDerivingDataType plan)
         ++ map firstMetaClassMethodAnnotation (tcDerivingClassMethods plan)
         ++ map firstMetaDictBinderAnnotation (tcDerivingClassSuperClasses plan)
+        ++ map firstMetaEvidenceBinderAnnotation (tcDerivingContextEvidence plan)
         ++ concatMap (map firstMetaPred . snd) (tcDerivingDefaultSignatures plan)
         ++ [ firstMetaDictBinderAnnotation superClass <|> firstMetaEvTerm evidence
            | (superClass, evidence) <- tcDerivingSuperClasses plan
@@ -214,6 +217,7 @@ firstMetaInstanceAnnotation ann =
         : map firstMetaType (tcInstanceHeadTypes ann)
         ++ map firstMetaDictBinderAnnotation (tcInstanceClassSuperClasses ann)
         ++ map firstMetaDictBinderAnnotation (tcInstanceContextDicts ann)
+        ++ map firstMetaEvidenceBinderAnnotation (tcInstanceContextEvidence ann)
         ++ [ firstMetaDictBinderAnnotation superClass <|> firstMetaEvTerm evidence
            | (superClass, evidence) <- tcInstanceSuperClasses ann
            ]
@@ -223,9 +227,14 @@ firstMetaDictBinderAnnotation :: TcDictBinderAnnotation -> Maybe Unique
 firstMetaDictBinderAnnotation ann =
   firstJusts (map firstMetaType (tcDictBinderArgs ann)) <|> firstMetaType (tcDictBinderType ann)
 
+firstMetaEvidenceBinderAnnotation :: TcEvidenceBinderAnnotation -> Maybe Unique
+firstMetaEvidenceBinderAnnotation ann =
+  firstMetaPred (tcEvidenceBinderPred ann) <|> firstMetaType (tcEvidenceBinderType ann)
+
 firstMetaInstanceMethodAnnotation :: TcInstanceMethodAnnotation -> Maybe Unique
 firstMetaInstanceMethodAnnotation ann =
   firstMetaType (tcInstanceMethodType ann)
+    <|> firstJusts (map firstMetaEvidenceBinderAnnotation (tcInstanceMethodEvidence ann))
 
 firstMetaDataFamilyInstance :: DataFamilyInstanceInfo -> Maybe Unique
 firstMetaDataFamilyInstance info =
@@ -244,7 +253,7 @@ firstMetaEvTerm evTerm =
   case evTerm of
     EvVarTerm {} ->
       Nothing
-    EvGiven pred' ->
+    EvGiven _ pred' ->
       firstMetaPred pred'
     EvDict _ _ typeArgs evidence ->
       firstJusts (map firstMetaType typeArgs ++ map firstMetaEvTerm evidence)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -137,7 +137,9 @@ data TcBindingResult = TcBindingResult
     tbName :: !Text,
     -- | Human-facing rendering for diagnostics and golden output.
     tbDisplayName :: !Text,
-    tbType :: !TcType
+    tbType :: !TcType,
+    -- | Resolver-selected identity for a finalized top-level binding.
+    tbKey :: !(Maybe TcTermKey)
   }
   deriving (Show, Read)
 
@@ -157,7 +159,15 @@ data CheckedSig = CheckedSig
 
 moduleBindings :: Module -> [TcBindingResult]
 moduleBindings modu =
-  concatMap declBindings (moduleDecls modu)
+  map addBindingKey (concatMap declBindings (moduleDecls modu))
+  where
+    (packageName, moduleName') = resolvedModuleOrigin modu
+    addBindingKey binding =
+      binding
+        { tbKey =
+            Just
+              (TcTermGlobal (PackageId packageName) moduleName' (tbName binding))
+        }
 
 -- | Recover instance-environment entries from finalized module annotations.
 moduleInstances :: Module -> [InstanceInfo]
@@ -306,32 +316,32 @@ tcAnnotationBindings ann decl =
     Just tcAnn ->
       case decl of
         DeclValue valueDecl ->
-          [ TcBindingResult name displayName (tcAnnType tcAnn)
+          [ TcBindingResult name displayName (tcAnnType tcAnn) Nothing
           | (name, displayName) <- valueDeclBindingNames valueDecl
           ]
         DeclData dataDecl ->
           let name = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn)]
+           in [TcBindingResult name name (tcAnnType tcAnn) Nothing]
         DeclNewtype newtypeDecl ->
           let name = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn)]
+           in [TcBindingResult name name (tcAnnType tcAnn) Nothing]
         DeclDataFamilyDecl familyDecl ->
           let name = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn)]
+           in [TcBindingResult name name (tcAnnType tcAnn) Nothing]
         DeclForeign foreignDecl ->
           let name = unqualifiedNameText (foreignName foreignDecl)
               displayName = renderBinderName (foreignName foreignDecl)
-           in [TcBindingResult name displayName (tcAnnType tcAnn)]
+           in [TcBindingResult name displayName (tcAnnType tcAnn) Nothing]
         _ -> []
 
 classAnnotationBindings :: Annotation -> Decl -> [TcBindingResult]
 classAnnotationBindings ann decl =
   case (fromAnnotation ann, decl) of
     (Just classAnn, DeclClass {}) ->
-      [ TcBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method)
+      [ TcBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method) Nothing
       | method <- tcClassMethods classAnn
       ]
-        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method)
+        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method) Nothing
            | method <- tcClassMethods classAnn,
              tcClassMethodName method `elem` tcClassDefaultMethods classAnn
            ]
@@ -354,14 +364,14 @@ instanceAnnotationBindings :: Annotation -> [TcBindingResult]
 instanceAnnotationBindings ann =
   case fromAnnotation ann of
     Just instAnn ->
-      [TcBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn)]
+      [TcBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn) Nothing]
     Nothing -> []
 
 derivingAnnotationBindings :: Annotation -> [TcBindingResult]
 derivingAnnotationBindings ann =
   case fromAnnotation ann of
     Just derivingAnnotation ->
-      [ TcBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo)
+      [ TcBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo) Nothing
       | plan <- tcDerivingPlans derivingAnnotation,
         Just instanceInfo <- [derivingPlanInstanceInfo plan]
       ]
@@ -373,7 +383,7 @@ dataConBindings dataConDecl =
     DataConAnn ann inner ->
       case fromAnnotation ann of
         Just tcAnn ->
-          [ TcBindingResult name displayName (tcAnnType tcAnn)
+          [ TcBindingResult name displayName (tcAnnType tcAnn) Nothing
           | (name, displayName) <- dataConBindingNames inner
           ]
         Nothing -> dataConBindings inner
@@ -396,7 +406,7 @@ recordSelectorBindings declaration =
               result -> ([], result)
           (fieldTypes, resultType) = splitFunctionType body
           (_, sourceFields, _) = dataConSourceLayout inner
-       in [ TcBindingResult label label (foldr TcForAllTy (qualify predicates (TcFunTy resultType fieldType)) typeVariables)
+       in [ TcBindingResult label label (foldr TcForAllTy (qualify predicates (TcFunTy resultType fieldType)) typeVariables) Nothing
           | ((maybeLabel, _), fieldType) <- zip sourceFields fieldTypes,
             Just label <- [maybeLabel]
           ]
@@ -1687,7 +1697,7 @@ tcSingleDeclGroup sigs groupId d =
             else do
               zonkedTy <- zonkType ty
               let decl' = replacePatternBindRhs rhs' d
-              pure (TcDeclGroupResult groupId [TcBindingResult "<pattern>" "<pattern>" zonkedTy] (Just [decl']))
+              pure (TcDeclGroupResult groupId [TcBindingResult "<pattern>" "<pattern>" zonkedTy Nothing] (Just [decl']))
     _ -> do
       bindings <- tcDecl d
       pure (TcDeclGroupResult groupId bindings Nothing)
@@ -1737,7 +1747,7 @@ tcFunctionWithSig displayName name sig matches = do
       -- Report the declared scheme as the binding's type.
       let declaredTy = schemeToType scheme
       zonkedTy <- zonkType declaredTy
-      pure (Just matches', [TcBindingResult name displayName zonkedTy])
+      pure (Just matches', [TcBindingResult name displayName zonkedTy Nothing])
 
 -- | Type-check a function without a type signature (infer).
 tcFunctionInfer :: Text -> Text -> [Match] -> TcM (Maybe [Match], [TcBindingResult])
@@ -1758,7 +1768,7 @@ tcFunctionInfer displayName name matches = do
       let schemeTy = schemeToType scheme
       zonkedTy <- zonkType schemeTy
       extendTermEnvPermanent name (TcIdBinder scheme Closed)
-      pure (Just matches', [TcBindingResult name displayName zonkedTy])
+      pure (Just matches', [TcBindingResult name displayName zonkedTy Nothing])
 
 generalizableResidualPreds :: SolveResult -> TcM [Pred]
 generalizableResidualPreds solveResult = do
@@ -1872,7 +1882,7 @@ registerForeignImport foreignDecl = do
       declaredTy = schemeToType scheme
   extendTermEnvPermanent name (TcIdBinder scheme Closed)
   zonkedTy <- zonkType declaredTy
-  pure [TcBindingResult name displayName zonkedTy]
+  pure [TcBindingResult name displayName zonkedTy Nothing]
 
 registerClassDecl :: (Text, Text) -> ClassDecl -> TcM [TcBindingResult]
 registerClassDecl origin classDecl = do
@@ -1926,7 +1936,7 @@ registerClassDecl origin classDecl = do
               workerScheme = maybe scheme (defaultWorkerScheme scheme) (lookup methodName defaultSignatures)
               workerType = schemeToType workerScheme
           extendTermEnvPermanent workerName (TcIdBinder workerScheme Closed)
-          pure (Just (TcBindingResult workerName workerName workerType))
+          pure (Just (TcBindingResult workerName workerName workerType Nothing))
       | otherwise = pure Nothing
 
     defaultWorkerScheme ordinaryScheme (ForAll tyVars predicates body) =
@@ -1955,7 +1965,7 @@ registerClassItem classPred classTvEnv classTyVars item =
                 displayName = renderBinderName methodName
             extendTermEnvPermanent name (TcIdBinder scheme Closed)
             zonkedTy <- zonkType declaredTy
-            pure (TcBindingResult name displayName zonkedTy)
+            pure (TcBindingResult name displayName zonkedTy Nothing)
         )
         names
     _ -> pure []
@@ -2002,7 +2012,7 @@ registerInstanceDecl origin instanceDecl =
             iiContext = context,
             iiHead = headTys
           }
-      pure [TcBindingResult dictName dictName dictTy]
+      pure [TcBindingResult dictName dictName dictTy Nothing]
 
 predType :: Pred -> TcType
 predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
@@ -2040,7 +2050,7 @@ registerDataFamilyDeclHeader familyDecl = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  pure [TcBindingResult familyName familyName (kindToTcType zonkedKind)]
+  pure [TcBindingResult familyName familyName (kindToTcType zonkedKind) Nothing]
 
 registerDataFamilyInstance :: DataFamilyInst -> TcM [TcBindingResult]
 registerDataFamilyInstance familyInst = do
@@ -2194,7 +2204,7 @@ registerDataDeclHeader dd = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
+  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind) Nothing
   pure [tyConResult]
 
 unboxedTupleDeclarationKind :: [ParamInfo] -> Kind
@@ -2251,7 +2261,7 @@ registerNewtypeDeclHeader nd = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
+  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind) Nothing
   pure [tyConResult]
 
 registerNewtypeConstructor :: NewtypeDecl -> TcM [TcBindingResult]
@@ -2296,7 +2306,7 @@ registerRecordSelectors constructors =
               (TcFunTy (dciResTy constructor) (dcfiType field))
       extendTermEnvPermanent label (TcIdBinder scheme Closed)
       zonkedType <- zonkType (schemeToType scheme)
-      pure (TcBindingResult label label zonkedType)
+      pure (TcBindingResult label label zonkedType Nothing)
     registerSelector (label, []) =
       abortTc ("record selector has no fields: " <> T.unpack label)
 
@@ -2320,7 +2330,7 @@ registerTypeSynonymHeader typeSynDecl = do
         tciFlavor = SynonymTyCon,
         tciTypeSynonym = Just synonym
       }
-  pure [TcBindingResult tyName tyName (kindToTcType declaredKind)]
+  pure [TcBindingResult tyName tyName (kindToTcType declaredKind) Nothing]
 
 registerTypeSynonymBody :: Decl -> TcM ()
 registerTypeSynonymBody (DeclAnn _ inner) = registerTypeSynonymBody inner
@@ -2400,8 +2410,8 @@ registerDataConWithResult paramInfos resTy con = case con of
       (n : _) -> do
         zonkedTy <- zonkType conTy
         let name = unqualifiedNameText n
-         in pure (TcBindingResult name name zonkedTy)
-      [] -> pure (TcBindingResult "<gadt>" "<gadt>" gadtResTy)
+         in pure (TcBindingResult name name zonkedTy Nothing)
+      [] -> pure (TcBindingResult "<gadt>" "<gadt>" gadtResTy Nothing)
   where
     paramEnv =
       Map.fromList
@@ -2426,7 +2436,7 @@ registerDataConWithResult paramInfos resTy con = case con of
         Just sourceName -> extendResolvedTermEnvPermanent sourceName (TcIdBinder scheme Closed)
         Nothing -> extendTermEnvPermanent name (TcIdBinder scheme Closed)
       zonkedTy <- zonkType (schemeToType scheme)
-      pure (TcBindingResult name name zonkedTy)
+      pure (TcBindingResult name name zonkedTy Nothing)
 
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
@@ -2550,7 +2560,7 @@ tcValueDecl (PatternBind _ pat rhs) = case patternBinderName pat of
   Nothing -> do
     (_rhs', ty) <- tcRhs rhs
     zonkedTy <- zonkType ty
-    pure [TcBindingResult "<pattern>" "<pattern>" zonkedTy]
+    pure [TcBindingResult "<pattern>" "<pattern>" zonkedTy Nothing]
 
 -- | Extract the binder name from a pattern binding's LHS, if it is a bare
 -- variable pattern.  Returns @(displayName, envName)@ for simple variable

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -74,11 +74,13 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
 import Aihc.Tc.Annotations
-  ( TcAnnotation (..),
+  ( PendingTcEvidenceBinders (..),
+    TcAnnotation (..),
     TcClassAnnotation (..),
     TcClassMethodAnnotation (..),
     TcDerivingAnnotation (..),
     TcDictBinderAnnotation (..),
+    TcEvidenceBinderAnnotation (..),
     TcForeignAbiType (..),
     TcForeignEffect (..),
     TcForeignImportAnnotation (..),
@@ -92,7 +94,7 @@ import Aihc.Tc.Deriving (annotateAttachedDerivingTc, annotateStandaloneDerivingT
 import Aihc.Tc.Deriving.Context (derivingPlanInstanceInfo, finalizeDerivingModulesTc)
 import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeSynonymInfo (..), dataFamilyAxiomName, dataFamilyRepresentationName)
 import Aihc.Tc.Error (TcErrorKind (..))
-import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Evidence (EvTerm (..), EvVar)
 import Aihc.Tc.Finalize (finalizeModuleTc)
 import Aihc.Tc.Generalize (generalizeAndCommitIgnoring, predMetaVars)
 import Aihc.Tc.Generate.Bind (inferRhsWithLocals)
@@ -139,7 +141,9 @@ data TcBindingResult = TcBindingResult
     tbDisplayName :: !Text,
     tbType :: !TcType,
     -- | Resolver-selected identity for a finalized top-level binding.
-    tbKey :: !(Maybe TcTermKey)
+    tbKey :: !(Maybe TcTermKey),
+    -- | Evidence variables abstracted at this binding.
+    tbEvidenceBinders :: ![TcEvidenceBinderAnnotation]
   }
   deriving (Show, Read)
 
@@ -316,32 +320,32 @@ tcAnnotationBindings ann decl =
     Just tcAnn ->
       case decl of
         DeclValue valueDecl ->
-          [ TcBindingResult name displayName (tcAnnType tcAnn) Nothing
+          [ TcBindingResult name displayName (tcAnnType tcAnn) Nothing []
           | (name, displayName) <- valueDeclBindingNames valueDecl
           ]
         DeclData dataDecl ->
           let name = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn) Nothing]
+           in [TcBindingResult name name (tcAnnType tcAnn) Nothing []]
         DeclNewtype newtypeDecl ->
           let name = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn) Nothing]
+           in [TcBindingResult name name (tcAnnType tcAnn) Nothing []]
         DeclDataFamilyDecl familyDecl ->
           let name = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
-           in [TcBindingResult name name (tcAnnType tcAnn) Nothing]
+           in [TcBindingResult name name (tcAnnType tcAnn) Nothing []]
         DeclForeign foreignDecl ->
           let name = unqualifiedNameText (foreignName foreignDecl)
               displayName = renderBinderName (foreignName foreignDecl)
-           in [TcBindingResult name displayName (tcAnnType tcAnn) Nothing]
+           in [TcBindingResult name displayName (tcAnnType tcAnn) Nothing []]
         _ -> []
 
 classAnnotationBindings :: Annotation -> Decl -> [TcBindingResult]
 classAnnotationBindings ann decl =
   case (fromAnnotation ann, decl) of
     (Just classAnn, DeclClass {}) ->
-      [ TcBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method) Nothing
+      [ TcBindingResult (tcClassMethodName method) (tcClassMethodName method) (tcClassMethodType method) Nothing []
       | method <- tcClassMethods classAnn
       ]
-        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method) Nothing
+        <> [ TcBindingResult (defaultMethodName (tcClassMethodName method)) (defaultMethodName (tcClassMethodName method)) (classDefaultWorkerType classAnn method) Nothing []
            | method <- tcClassMethods classAnn,
              tcClassMethodName method `elem` tcClassDefaultMethods classAnn
            ]
@@ -364,14 +368,14 @@ instanceAnnotationBindings :: Annotation -> [TcBindingResult]
 instanceAnnotationBindings ann =
   case fromAnnotation ann of
     Just instAnn ->
-      [TcBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn) Nothing]
+      [TcBindingResult (tcInstanceDictName instAnn) (tcInstanceDictName instAnn) (tcInstanceDictType instAnn) Nothing []]
     Nothing -> []
 
 derivingAnnotationBindings :: Annotation -> [TcBindingResult]
 derivingAnnotationBindings ann =
   case fromAnnotation ann of
     Just derivingAnnotation ->
-      [ TcBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo) Nothing
+      [ TcBindingResult (iiDictName instanceInfo) (iiDictName instanceInfo) (iiDictType instanceInfo) Nothing []
       | plan <- tcDerivingPlans derivingAnnotation,
         Just instanceInfo <- [derivingPlanInstanceInfo plan]
       ]
@@ -383,7 +387,7 @@ dataConBindings dataConDecl =
     DataConAnn ann inner ->
       case fromAnnotation ann of
         Just tcAnn ->
-          [ TcBindingResult name displayName (tcAnnType tcAnn) Nothing
+          [ TcBindingResult name displayName (tcAnnType tcAnn) Nothing []
           | (name, displayName) <- dataConBindingNames inner
           ]
         Nothing -> dataConBindings inner
@@ -406,7 +410,7 @@ recordSelectorBindings declaration =
               result -> ([], result)
           (fieldTypes, resultType) = splitFunctionType body
           (_, sourceFields, _) = dataConSourceLayout inner
-       in [ TcBindingResult label label (foldr TcForAllTy (qualify predicates (TcFunTy resultType fieldType)) typeVariables) Nothing
+       in [ TcBindingResult label label (foldr TcForAllTy (qualify predicates (TcFunTy resultType fieldType)) typeVariables) Nothing []
           | ((maybeLabel, _), fieldType) <- zip sourceFields fieldTypes,
             Just label <- [maybeLabel]
           ]
@@ -539,7 +543,9 @@ annotatePendingModule pending = do
   -- Only bindings that checked without errors are eligible for value
   -- annotations. Failed bindings remain in the recovery environment, but
   -- they must not be rendered as successful inferred types.
-  annotateModuleTc (Set.fromList (map tbName (pendingValueResults pending))) (pendingSyntax pending)
+  let results = pendingValueResults pending
+      evidenceBinders = Map.fromList [(tbName result, tbEvidenceBinders result) | result <- results]
+  annotateModuleTc (Set.fromList (map tbName results)) evidenceBinders (pendingSyntax pending)
 
 defaultGlobalKindMetas :: TcM ()
 defaultGlobalKindMetas = do
@@ -673,10 +679,10 @@ renderCheckedGroup :: Map Int [Decl] -> (Int, DeclGroup) -> [Decl]
 renderCheckedGroup checkedGroups (groupId, group) =
   fromMaybe (renderDeclGroup group) (Map.lookup groupId checkedGroups)
 
-annotateModuleTc :: Set.Set Text -> Module -> TcM Module
-annotateModuleTc checkedValueNames m = do
+annotateModuleTc :: Set.Set Text -> Map Text [TcEvidenceBinderAnnotation] -> Module -> TcM Module
+annotateModuleTc checkedValueNames evidenceBinders m = do
   let classMethods = collectClassMethodNames (moduleDecls m)
-  decls <- mapM (annotateDeclTc classMethods checkedValueNames) (moduleDecls m)
+  decls <- mapM (annotateDeclTc classMethods checkedValueNames evidenceBinders) (moduleDecls m)
   pure (m {moduleDecls = decls})
 
 annotateModuleDerivingTc :: Module -> TcM Module
@@ -702,25 +708,31 @@ moduleEnabledExtensions modu =
   applyImpliedExtensions $
     foldr applyExtensionSetting [] (moduleLanguagePragmas modu)
 
-annotateDeclTc :: Map Text [Text] -> Set.Set Text -> Decl -> TcM Decl
-annotateDeclTc classMethods checkedValueNames decl =
-  case decl of
-    DeclAnn ann inner -> DeclAnn ann <$> annotateDeclTc classMethods checkedValueNames inner
-    DeclValue valueDecl
-      | valueDeclWasChecked checkedValueNames valueDecl -> do
-          (ty, valueDecl') <- annotateValueDeclTc valueDecl
-          pure (annotateDeclAt (valueDeclSpan valueDecl) (TcAnnotation ty [] [] [] []) (DeclValue valueDecl'))
-      | otherwise -> pure decl
-    DeclData dataDecl -> annotateDataDeclTc dataDecl
-    DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
-    DeclDataFamilyDecl familyDecl -> annotateDataFamilyDeclTc familyDecl
-    DeclDataFamilyInst familyInst -> annotateDataFamilyInstTc familyInst
-    DeclForeign foreignDecl
-      | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
-    DeclClass classDecl -> annotateClassDeclTc classDecl
-    DeclInstance instanceDecl -> annotateInstanceDeclTc classMethods instanceDecl
-    DeclStandaloneDeriving {} -> pure decl
-    _ -> pure decl
+annotateDeclTc :: Map Text [Text] -> Set.Set Text -> Map Text [TcEvidenceBinderAnnotation] -> Decl -> TcM Decl
+annotateDeclTc classMethods checkedValueNames evidenceBinders = go []
+  where
+    go scopedEvidence decl =
+      case decl of
+        DeclAnn ann inner
+          | Just pending <- fromAnnotation @PendingTcEvidenceBinders ann ->
+              go (pendingTcEvidenceBinders pending) inner
+          | otherwise -> DeclAnn ann <$> go scopedEvidence inner
+        DeclValue valueDecl
+          | valueDeclWasChecked checkedValueNames valueDecl -> do
+              (ty, valueDecl') <- annotateValueDeclTc valueDecl
+              let binders = concatMap (\name -> Map.findWithDefault [] name evidenceBinders) (valueDeclBinderNames valueDecl)
+              pure (annotateDeclAt (valueDeclSpan valueDecl) (TcAnnotation ty [] [] [] binders []) (DeclValue valueDecl'))
+          | otherwise -> pure decl
+        DeclData dataDecl -> annotateDataDeclTc dataDecl
+        DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
+        DeclDataFamilyDecl familyDecl -> annotateDataFamilyDeclTc familyDecl
+        DeclDataFamilyInst familyInst -> annotateDataFamilyInstTc familyInst
+        DeclForeign foreignDecl
+          | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
+        DeclClass classDecl -> annotateClassDeclTc classDecl
+        DeclInstance instanceDecl -> annotateInstanceDeclTc classMethods scopedEvidence instanceDecl
+        DeclStandaloneDeriving {} -> pure decl
+        _ -> pure decl
 
 valueDeclWasChecked :: Set.Set Text -> ValueDecl -> Bool
 valueDeclWasChecked checkedValueNames valueDecl =
@@ -757,16 +769,22 @@ annotateClassDeclTc classDecl = do
         )
 
 annotateClassDefaultItem :: ClassDeclItem -> TcM ClassDeclItem
-annotateClassDefaultItem item =
-  case item of
-    ClassItemAnn ann inner -> ClassItemAnn ann <$> annotateClassDefaultItem inner
-    ClassItemDefault valueDecl ->
-      case valueDeclBinderName valueDecl of
-        Just (_, methodName) -> do
-          methodTy <- bindingType (defaultMethodName methodName)
-          pure (ClassItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy)) item)
-        Nothing -> pure item
-    _ -> pure item
+annotateClassDefaultItem = go []
+  where
+    go scopedEvidence item =
+      case item of
+        ClassItemAnn ann inner
+          | Just pending <- fromAnnotation @PendingTcEvidenceBinders ann ->
+              go (pendingTcEvidenceBinders pending) inner
+          | otherwise -> ClassItemAnn ann <$> go scopedEvidence inner
+        ClassItemDefault valueDecl ->
+          case valueDeclEnvironmentName valueDecl of
+            Just methodName -> do
+              methodTy <- bindingType (defaultMethodName methodName)
+              finalizedEvidence <- finalizeMethodEvidenceBinders methodName methodTy scopedEvidence
+              pure (ClassItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy finalizedEvidence)) item)
+            Nothing -> pure item
+        _ -> pure item
 
 annotateClassMethod :: Int -> Text -> TcM TcClassMethodAnnotation
 annotateClassMethod index methodName = do
@@ -787,7 +805,7 @@ annotateDataDeclTc dataDecl = do
   let tyName = unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))
   ty <- tyConBindingType tyName
   constructors <- mapM annotateDataConDeclTc (dataDeclConstructors dataDecl)
-  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (dataDeclHead dataDecl)
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] [] []) (dataDeclHead dataDecl)
   pure (DeclData (dataDecl {dataDeclHead = annotatedHead, dataDeclConstructors = constructors}))
 
 annotateNewtypeDeclTc :: NewtypeDecl -> TcM Decl
@@ -795,14 +813,14 @@ annotateNewtypeDeclTc newtypeDecl = do
   let tyName = unqualifiedNameText (binderHeadName (newtypeDeclHead newtypeDecl))
   ty <- tyConBindingType tyName
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
-  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (newtypeDeclHead newtypeDecl)
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] [] []) (newtypeDeclHead newtypeDecl)
   pure (DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor}))
 
 annotateDataFamilyDeclTc :: DataFamilyDecl -> TcM Decl
 annotateDataFamilyDeclTc familyDecl = do
   let familyName = unqualifiedNameText (binderHeadName (dataFamilyDeclHead familyDecl))
   ty <- tyConBindingType familyName
-  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (dataFamilyDeclHead familyDecl)
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] [] []) (dataFamilyDeclHead familyDecl)
   pure (DeclDataFamilyDecl (familyDecl {dataFamilyDeclHead = annotatedHead}))
 
 annotateDataFamilyInstTc :: DataFamilyInst -> TcM Decl
@@ -831,7 +849,7 @@ annotateRegisteredDataConDeclTc dataConDecl =
   where
     annotateWithType ty = do
       zonkedTy <- zonkType ty
-      pure (DataConAnn (mkAnnotation (TcAnnotation zonkedTy [] [] [] [])) dataConDecl)
+      pure (DataConAnn (mkAnnotation (TcAnnotation zonkedTy [] [] [] [] [])) dataConDecl)
 
 annotateBinderHeadName :: TcAnnotation -> BinderHead UnqualifiedName -> BinderHead UnqualifiedName
 annotateBinderHeadName tcAnn head' =
@@ -852,7 +870,7 @@ annotateDataConDeclTc dataConDecl = do
     (name, _) : _ -> do
       ty <- dataConBindingType name
       selectors <- annotateRecordSelectorNames dataConDecl
-      pure (DataConAnn (mkAnnotation (TcAnnotation ty [] [] [] [])) selectors)
+      pure (DataConAnn (mkAnnotation (TcAnnotation ty [] [] [] [] [])) selectors)
 
 annotateRecordSelectorNames :: DataConDecl -> TcM DataConDecl
 annotateRecordSelectorNames declaration =
@@ -868,7 +886,7 @@ annotateRecordSelectorNames declaration =
       pure field {fieldNames = names}
     annotateSelectorName name = do
       ty <- bindingType (unqualifiedNameText name)
-      pure (annotateUnqualifiedName (TcAnnotation ty [] [] [] []) name)
+      pure (annotateUnqualifiedName (TcAnnotation ty [] [] [] [] []) name)
 
 dataConBindingType :: Text -> TcM TcType
 dataConBindingType name = do
@@ -882,7 +900,7 @@ annotateForeignDeclTc :: ForeignDecl -> TcM Decl
 annotateForeignDeclTc foreignDecl = do
   ty <- bindingType (unqualifiedNameText (foreignName foreignDecl))
   let sourceSpan = unqualifiedNameSpan (foreignName foreignDecl)
-      annotated = annotateDeclAt sourceSpan (TcAnnotation ty [] [] [] []) (DeclForeign foreignDecl)
+      annotated = annotateDeclAt sourceSpan (TcAnnotation ty [] [] [] [] []) (DeclForeign foreignDecl)
   case foreignCallConv foreignDecl of
     CCall -> do
       plan <- checkForeignImportType sourceSpan ty
@@ -996,8 +1014,8 @@ annotateValueDeclTc valueDecl =
           ty <- missingTypeInfo ("top-level pattern binding " <> show pat)
           pure (ty, valueDecl)
 
-annotateInstanceDeclTc :: Map Text [Text] -> InstanceDecl -> TcM Decl
-annotateInstanceDeclTc classMethods instanceDecl =
+annotateInstanceDeclTc :: Map Text [Text] -> [TcEvidenceBinderAnnotation] -> InstanceDecl -> TcM Decl
+annotateInstanceDeclTc classMethods contextEvidenceBinders instanceDecl =
   case (instanceHeadName (instanceDeclHead instanceDecl), instanceHeadTypes (instanceDeclHead instanceDecl)) of
     (_, []) -> pure (DeclInstance instanceDecl)
     (Nothing, _) -> pure (DeclInstance instanceDecl)
@@ -1018,7 +1036,11 @@ annotateInstanceDeclTc classMethods instanceDecl =
           superClassTypes = maybe [] (map (substType classSubstitution) . ciSuperClassTypes) classInfo
           defaults = maybe [] ciDefaultMethods classInfo
       superClasses <- mapM constraintTypePred superClassTypes
-      superClassEvidence <- mapM (solveInstanceSuperClass classNameText context) superClasses
+      when (length contextEvidenceBinders /= length context) $
+        abortTc "internal type annotation error: instance context evidence count does not match the checked context"
+      let finalizedContextEvidence = zipWith setEvidenceBinderPredicate contextEvidenceBinders context
+          contextEvidence = map evidenceBinderPair finalizedContextEvidence
+      superClassEvidence <- mapM (solveInstanceSuperClass classNameText contextEvidence) superClasses
       let contextDicts = map predDictBinder context
           dictTy = foldr TcForAllTy (TcQualTy context (predType (ClassPred classNameText headTys))) tvIds
           methodOrder = maybe (fromMaybe [] (Map.lookup classNameText classMethods)) (map fst . ciMethods) classInfo
@@ -1032,6 +1054,7 @@ annotateInstanceDeclTc classMethods instanceDecl =
                 tcInstanceClassOrigin = classInfo >>= ciOrigin,
                 tcInstanceClassSuperClasses = maybe [] (map constraintTypeDictBinder . ciSuperClassTypes) classInfo,
                 tcInstanceContextDicts = contextDicts,
+                tcInstanceContextEvidence = finalizedContextEvidence,
                 tcInstanceSuperClasses = zip (map predDictBinder superClasses) superClassEvidence,
                 tcInstanceMethodOrder = methodOrder,
                 tcInstanceDefaultMethods = defaults
@@ -1039,7 +1062,7 @@ annotateInstanceDeclTc classMethods instanceDecl =
       items <- mapM (annotateInstanceItemTc headTys) (instanceDeclItems instanceDecl)
       pure (DeclAnn (mkAnnotation instAnn) (DeclInstance (instanceDecl {instanceDeclItems = items})))
 
-solveInstanceSuperClass :: Text -> [Pred] -> Pred -> TcM EvTerm
+solveInstanceSuperClass :: Text -> [(EvVar, Pred)] -> Pred -> TcM EvTerm
 solveInstanceSuperClass className givens predicate = do
   evidenceVariable <- freshEvVar
   let constraint = mkWantedCt predicate evidenceVariable (InstOrigin className) NoSourceSpan
@@ -1055,59 +1078,93 @@ solveInstanceSuperClass className givens predicate = do
       pure (EvVarTerm evidenceVariable)
 
 annotateInstanceItemTc :: [TcType] -> InstanceDeclItem -> TcM InstanceDeclItem
-annotateInstanceItemTc headTys item =
-  case item of
-    InstanceItemAnn ann inner -> InstanceItemAnn ann <$> annotateInstanceItemTc headTys inner
-    InstanceItemBind (FunctionBind name matches) -> do
-      let methodName = unqualifiedNameText name
-      methodTy <- methodExpectedType headTys (unqualifiedNameText name)
-      pure (InstanceItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy)) (InstanceItemBind (FunctionBind name matches)))
-    InstanceItemBind (PatternBind anns pat rhs) ->
-      case patternBinderName pat of
-        Just (_, methodName) -> do
+annotateInstanceItemTc headTys = go []
+  where
+    go scopedEvidence item =
+      case item of
+        InstanceItemAnn ann inner
+          | Just pending <- fromAnnotation @PendingTcEvidenceBinders ann ->
+              go (pendingTcEvidenceBinders pending) inner
+          | otherwise -> InstanceItemAnn ann <$> go scopedEvidence inner
+        InstanceItemBind (FunctionBind name matches) -> do
+          let methodName = unqualifiedNameText name
           methodTy <- methodExpectedType headTys methodName
-          pure (InstanceItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy)) (InstanceItemBind (PatternBind anns pat rhs)))
-        Nothing -> pure item
-    _ -> pure item
+          finalizedEvidence <- finalizeMethodEvidenceBinders methodName methodTy scopedEvidence
+          pure (InstanceItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy finalizedEvidence)) (InstanceItemBind (FunctionBind name matches)))
+        InstanceItemBind (PatternBind anns pat rhs) ->
+          case patternBinderName pat of
+            Just (_, methodName) -> do
+              methodTy <- methodExpectedType headTys methodName
+              finalizedEvidence <- finalizeMethodEvidenceBinders methodName methodTy scopedEvidence
+              pure (InstanceItemAnn (mkAnnotation (TcInstanceMethodAnnotation methodName methodTy finalizedEvidence)) (InstanceItemBind (PatternBind anns pat rhs)))
+            Nothing -> pure item
+        _ -> pure item
 
 tcClassDeclBodies :: Decl -> TcM Decl
 tcClassDeclBodies (DeclAnn ann inner) =
   DeclAnn ann <$> tcClassDeclBodies inner
 tcClassDeclBodies (DeclClass classDecl) = do
-  items <- mapM tcClassDefaultBody (classDeclItems classDecl)
+  scopes <- classDefaultEvidenceScopes (classDeclItems classDecl)
+  items <- mapM (tcClassDefaultBody scopes) (classDeclItems classDecl)
   pure (DeclClass (classDecl {classDeclItems = items}))
 tcClassDeclBodies decl = pure decl
 
-tcClassDefaultBody :: ClassDeclItem -> TcM ClassDeclItem
-tcClassDefaultBody item =
-  case item of
-    ClassItemAnn ann inner -> ClassItemAnn ann <$> tcClassDefaultBody inner
-    ClassItemDefault valueDecl -> do
-      checked <- tcClassDefaultValue valueDecl
-      pure (ClassItemDefault checked)
-    _ -> pure item
+type MethodEvidenceScope = ([(EvVar, Pred)], TcType)
 
-tcClassDefaultValue :: ValueDecl -> TcM ValueDecl
-tcClassDefaultValue valueDecl =
-  case valueDeclBinderName valueDecl of
-    Nothing -> pure valueDecl
-    Just (_, methodName) -> do
+classDefaultEvidenceScopes :: [ClassDeclItem] -> TcM (Map Text MethodEvidenceScope)
+classDefaultEvidenceScopes items =
+  Map.fromList <$> mapM makeScope (nub (mapMaybe classDefaultItemName items))
+  where
+    makeScope methodName = do
       binder <- lookupTerm (defaultMethodName methodName)
       case binder of
-        Just (TcIdBinder (ForAll _ givens methodTy) _) ->
-          case valueDecl of
+        Just (TcIdBinder scheme _) -> do
+          (predicates, methodType) <- skolemizeQualified scheme
+          evidence <- freshGivenEvidence predicates
+          pure (methodName, (evidence, methodType))
+        _ -> missingTypeInfo ("class default method " <> T.unpack methodName)
+
+classDefaultItemName :: ClassDeclItem -> Maybe Text
+classDefaultItemName item =
+  case item of
+    ClassItemAnn _ inner -> classDefaultItemName inner
+    ClassItemDefault valueDecl -> valueDeclEnvironmentName valueDecl
+    _ -> Nothing
+
+tcClassDefaultBody :: Map Text MethodEvidenceScope -> ClassDeclItem -> TcM ClassDeclItem
+tcClassDefaultBody scopes item =
+  case item of
+    ClassItemAnn ann inner -> ClassItemAnn ann <$> tcClassDefaultBody scopes inner
+    ClassItemDefault valueDecl -> do
+      (checked, evidenceBinders) <- tcClassDefaultValue scopes valueDecl
+      pure
+        ( ClassItemAnn
+            (mkAnnotation (PendingTcEvidenceBinders evidenceBinders))
+            (ClassItemDefault checked)
+        )
+    _ -> pure item
+
+tcClassDefaultValue :: Map Text MethodEvidenceScope -> ValueDecl -> TcM (ValueDecl, [TcEvidenceBinderAnnotation])
+tcClassDefaultValue scopes valueDecl =
+  case valueDeclEnvironmentName valueDecl of
+    Nothing -> pure (valueDecl, [])
+    Just methodName -> do
+      case Map.lookup methodName scopes of
+        Just (givenEvidence, methodTy) -> do
+          checked <- case valueDecl of
             FunctionBind name matches -> do
               let (argumentTypes, resultType) = splitFunTy methodTy (matchArity matches)
               results <- mapM (tcMatchEquation Nothing argumentTypes resultType) matches
-              solveInstanceBodyConstraints givens [(constraints, implications) | (_, constraints, implications) <- results]
+              solveInstanceBodyConstraints givenEvidence [(constraints, implications) | (_, constraints, implications) <- results]
               pure (FunctionBind name [match | (match, _, _) <- results])
             PatternBind annotations pattern' rhs -> do
               results <- mapM (tcMatchEquation Nothing [] methodTy) [zeroArgMatch (patternSpan pattern') rhs]
-              solveInstanceBodyConstraints givens [(constraints, implications) | (_, constraints, implications) <- results]
+              solveInstanceBodyConstraints givenEvidence [(constraints, implications) | (_, constraints, implications) <- results]
               case results of
                 [(match, _, _)] -> pure (PatternBind annotations pattern' (matchRhs match))
                 _ -> pure valueDecl
-        _ -> missingTypeInfo ("class default method " <> T.unpack methodName)
+          pure (checked, map evidenceBinderAnnotation givenEvidence)
+        Nothing -> missingTypeInfo ("class default method " <> T.unpack methodName)
 
 tcInstanceDeclBodies :: Decl -> TcM Decl
 tcInstanceDeclBodies (DeclAnn ann inner) =
@@ -1122,49 +1179,98 @@ tcInstanceDeclBodies (DeclInstance instanceDecl) =
       rawGivens <- mapM (surfacePredToPred tvEnv) (instanceDeclContext instanceDecl)
       headTys <- mapM defaultTypeKinds rawHeadTys
       givens <- mapM defaultPredKinds rawGivens
-      items <- mapM (tcInstanceItemBody givens headTys) (instanceDeclItems instanceDecl)
-      pure (DeclInstance (instanceDecl {instanceDeclItems = items}))
+      givenEvidence <- freshGivenEvidence givens
+      methodScopes <- instanceMethodEvidenceScopes headTys (instanceDeclItems instanceDecl)
+      items <- mapM (tcInstanceItemBody givenEvidence methodScopes) (instanceDeclItems instanceDecl)
+      pure
+        ( DeclAnn
+            (mkAnnotation (PendingTcEvidenceBinders (map evidenceBinderAnnotation givenEvidence)))
+            (DeclInstance (instanceDecl {instanceDeclItems = items}))
+        )
 tcInstanceDeclBodies decl =
   pure decl
 
-tcInstanceItemBody :: [Pred] -> [TcType] -> InstanceDeclItem -> TcM InstanceDeclItem
-tcInstanceItemBody givens headTys item =
+instanceMethodEvidenceScopes :: [TcType] -> [InstanceDeclItem] -> TcM (Map Text MethodEvidenceScope)
+instanceMethodEvidenceScopes headTypes items =
+  Map.fromList <$> mapM makeScope (nub (mapMaybe instanceItemMethodName items))
+  where
+    makeScope methodName = do
+      methodScheme <- methodExpectedScheme headTypes methodName
+      (predicates, methodType) <- skolemizeQualified methodScheme
+      evidence <- freshGivenEvidence predicates
+      pure (methodName, (evidence, methodType))
+
+instanceItemMethodName :: InstanceDeclItem -> Maybe Text
+instanceItemMethodName item =
+  case item of
+    InstanceItemAnn _ inner -> instanceItemMethodName inner
+    InstanceItemBind valueDecl -> valueDeclEnvironmentName valueDecl
+    _ -> Nothing
+
+tcInstanceItemBody :: [(EvVar, Pred)] -> Map Text MethodEvidenceScope -> InstanceDeclItem -> TcM InstanceDeclItem
+tcInstanceItemBody givens methodScopes item =
   case item of
     InstanceItemAnn ann inner ->
-      InstanceItemAnn ann <$> tcInstanceItemBody givens headTys inner
+      InstanceItemAnn ann <$> tcInstanceItemBody givens methodScopes inner
     InstanceItemBind (FunctionBind name matches) -> do
-      methodScheme <- methodExpectedScheme headTys (unqualifiedNameText name)
-      (methodGivens, methodTy) <- skolemizeQualified methodScheme
+      let methodName = unqualifiedNameText name
+      (methodEvidence, methodTy) <- methodEvidenceScope methodName methodScopes
       let (argTys, resTy) = splitFunTy methodTy (matchArity matches)
       results <- mapM (tcMatchEquation Nothing argTys resTy) matches
-      solveInstanceBodyConstraints (givens <> methodGivens) [(cts, impls) | (_match, cts, impls) <- results]
-      pure (InstanceItemBind (FunctionBind name [match | (match, _cts, _impls) <- results]))
+      solveInstanceBodyConstraints (givens <> methodEvidence) [(cts, impls) | (_match, cts, impls) <- results]
+      pure
+        ( InstanceItemAnn
+            (mkAnnotation (PendingTcEvidenceBinders (map evidenceBinderAnnotation methodEvidence)))
+            (InstanceItemBind (FunctionBind name [match | (match, _cts, _impls) <- results]))
+        )
     InstanceItemBind (PatternBind _ pat rhs) ->
       case patternBinderName pat of
         Just (_, methodName) -> do
-          methodScheme <- methodExpectedScheme headTys methodName
-          (methodGivens, methodTy) <- skolemizeQualified methodScheme
+          (methodEvidence, methodTy) <- methodEvidenceScope methodName methodScopes
           results <- mapM (tcMatchEquation Nothing [] methodTy) [zeroArgMatch (patternSpan pat) rhs]
-          solveInstanceBodyConstraints (givens <> methodGivens) [(cts, impls) | (_match, cts, impls) <- results]
+          solveInstanceBodyConstraints (givens <> methodEvidence) [(cts, impls) | (_match, cts, impls) <- results]
           case results of
             [(match, _cts, _impls)] ->
-              pure (replaceInstancePatternBindRhs (matchRhs match) item)
+              pure
+                ( InstanceItemAnn
+                    (mkAnnotation (PendingTcEvidenceBinders (map evidenceBinderAnnotation methodEvidence)))
+                    (replaceInstancePatternBindRhs (matchRhs match) item)
+                )
             _ -> pure item
         Nothing -> pure item
     _ -> pure item
+
+methodEvidenceScope :: Text -> Map Text MethodEvidenceScope -> TcM MethodEvidenceScope
+methodEvidenceScope methodName scopes =
+  case Map.lookup methodName scopes of
+    Just scope -> pure scope
+    Nothing -> missingTypeInfo ("instance method evidence for " <> T.unpack methodName)
+
+finalizeMethodEvidenceBinders :: Text -> TcType -> [TcEvidenceBinderAnnotation] -> TcM [TcEvidenceBinderAnnotation]
+finalizeMethodEvidenceBinders methodName methodType binders = do
+  let predicates = qualifiedTypePredicates methodType
+  when (length binders /= length predicates) $
+    abortTc ("internal type annotation error: method evidence count does not match the type for " <> T.unpack methodName)
+  pure (zipWith setEvidenceBinderPredicate binders predicates)
+
+qualifiedTypePredicates :: TcType -> [Pred]
+qualifiedTypePredicates ty =
+  case snd (peelForAlls ty) of
+    TcQualTy predicates _ -> predicates
+    _ -> []
 
 matchArity :: [Match] -> Int
 matchArity (match : _) = length (matchPats match)
 matchArity [] = 0
 
-solveInstanceBodyConstraints :: [Pred] -> [([Ct], [Implication])] -> TcM ()
+solveInstanceBodyConstraints :: [(EvVar, Pred)] -> [([Ct], [Implication])] -> TcM ()
 solveInstanceBodyConstraints givens results = do
   let (ctsList, implsList) = unzip results
       cts = concat ctsList
       impls = concat implsList
   solveBodyConstraintsWithGivens givens cts impls
 
-solveBodyConstraintsWithGivens :: [Pred] -> [Ct] -> [Implication] -> TcM ()
+solveBodyConstraintsWithGivens :: [(EvVar, Pred)] -> [Ct] -> [Implication] -> TcM ()
 solveBodyConstraintsWithGivens givens cts impls = do
   implications <- mapM addOuterGivens impls
   _ <- solveWithImpls cts implications
@@ -1173,8 +1279,7 @@ solveBodyConstraintsWithGivens givens cts impls = do
     addOuterGivens implication = do
       outerGivens <- mapM givenConstraint givens
       pure (implication {implGivenCts = outerGivens <> implGivenCts implication})
-    givenConstraint predicate = do
-      evidence <- freshEvVar
+    givenConstraint (evidence, predicate) = do
       let origin = InstOrigin "class body"
       pure ((mkWantedCt predicate evidence origin NoSourceSpan) {ctFlavor = Given})
     solveClassCt ct@Ct {ctPred = ClassPred {}} = do
@@ -1298,14 +1403,14 @@ classDeclDefaultMethodNames classDecl = mapMaybe classItemDefaultMethodName (cla
 classItemDefaultMethodName :: ClassDeclItem -> Maybe Text
 classItemDefaultMethodName item =
   case peelClassDeclItemAnn item of
-    ClassItemDefault valueDecl -> snd <$> valueDeclBinderName valueDecl
+    ClassItemDefault valueDecl -> valueDeclEnvironmentName valueDecl
     _ -> Nothing
 
-valueDeclBinderName :: ValueDecl -> Maybe (Text, Text)
-valueDeclBinderName valueDecl =
+valueDeclEnvironmentName :: ValueDecl -> Maybe Text
+valueDeclEnvironmentName valueDecl =
   case valueDecl of
-    FunctionBind name _ -> Just (binderBindingName name)
-    PatternBind _ pat _ -> patternBinderName pat
+    FunctionBind name _ -> Just (unqualifiedNameText name)
+    PatternBind _ pat _ -> snd <$> patternBinderName pat
 
 defaultMethodName :: Text -> Text
 defaultMethodName methodName = "$dm" <> methodName
@@ -1697,7 +1802,7 @@ tcSingleDeclGroup sigs groupId d =
             else do
               zonkedTy <- zonkType ty
               let decl' = replacePatternBindRhs rhs' d
-              pure (TcDeclGroupResult groupId [TcBindingResult "<pattern>" "<pattern>" zonkedTy Nothing] (Just [decl']))
+              pure (TcDeclGroupResult groupId [TcBindingResult "<pattern>" "<pattern>" zonkedTy Nothing []] (Just [decl']))
     _ -> do
       bindings <- tcDecl d
       pure (TcDeclGroupResult groupId bindings Nothing)
@@ -1724,11 +1829,11 @@ tcMergedFunctionGroup sigs groupId binder decls matches = do
 tcFunctionWithSig :: Text -> Text -> CheckedSig -> [Match] -> TcM (Maybe [Match], [TcBindingResult])
 tcFunctionWithSig displayName name sig matches = do
   let scheme = checkedSigScheme sig
+  (sigPreds, sigTy) <- skolemizeQualified scheme
+  givenEvidence <- freshGivenEvidence sigPreds
   (matches', failed) <-
     withErrorTracking $ do
       extendTermEnvPermanent name (TcIdBinder scheme Closed)
-      -- Open the scheme with skolems (not metas) for checking.
-      (sigPreds, sigTy) <- skolemizeQualified scheme
       let nArgs = case matches of
             (m : _) -> length (matchPats m)
             [] -> 0
@@ -1738,7 +1843,7 @@ tcFunctionWithSig displayName name sig matches = do
       let (_matches', ctsList, implsList) = unzip3 results
           allCts = concat ctsList
           allImpls = concat implsList
-      solveBodyConstraintsWithGivens sigPreds allCts allImpls
+      solveBodyConstraintsWithGivens givenEvidence allCts allImpls
       rejectEscapingExistentials sigTy allImpls
       pure _matches'
   if failed
@@ -1747,30 +1852,35 @@ tcFunctionWithSig displayName name sig matches = do
       -- Report the declared scheme as the binding's type.
       let declaredTy = schemeToType scheme
       zonkedTy <- zonkType declaredTy
-      pure (Just matches', [TcBindingResult name displayName zonkedTy Nothing])
+      declaredPredicates <- mapM zonkPred (typeSchemePredicates scheme)
+      when (length givenEvidence /= length declaredPredicates) $
+        abortTc "internal type annotation error: signature evidence count does not match the declared context"
+      let evidenceBinders = zipWith setEvidenceBinderPredicate (map evidenceBinderAnnotation givenEvidence) declaredPredicates
+      pure (Just matches', [TcBindingResult name displayName zonkedTy Nothing evidenceBinders])
 
 -- | Type-check a function without a type signature (infer).
 tcFunctionInfer :: Text -> Text -> [Match] -> TcM (Maybe [Match], [TcBindingResult])
 tcFunctionInfer displayName name matches = do
   placeholderTy <- freshMetaTv
-  ((matches', ty, residualPreds), failed) <-
+  ((matches', ty, residualPreds, evidenceBinders), failed) <-
     withErrorTracking $ do
       extendTermEnvPermanent name (TcMonoIdBinder placeholderTy)
       (matches', ty, cts', impls') <- tcMatches matches
       solveResult <- solveWithImpls cts' impls'
       rejectEscapingExistentials ty impls'
-      residualPreds <- generalizableResidualPreds solveResult
-      pure (matches', ty, residualPreds)
+      (residualPreds, evidenceBinders) <- generalizableResidualPreds solveResult
+      pure (matches', ty, residualPreds, evidenceBinders)
   if failed
     then pure (Nothing, [])
     else do
       scheme <- generalizeAndCommitIgnoring (Set.singleton (unqualifiedTermKey name)) ty residualPreds
       let schemeTy = schemeToType scheme
       zonkedTy <- zonkType schemeTy
+      zonkedEvidenceBinders <- mapM zonkEvidenceBinder evidenceBinders
       extendTermEnvPermanent name (TcIdBinder scheme Closed)
-      pure (Just matches', [TcBindingResult name displayName zonkedTy Nothing])
+      pure (Just matches', [TcBindingResult name displayName zonkedTy Nothing zonkedEvidenceBinders])
 
-generalizableResidualPreds :: SolveResult -> TcM [Pred]
+generalizableResidualPreds :: SolveResult -> TcM ([Pred], [TcEvidenceBinderAnnotation])
 generalizableResidualPreds solveResult = do
   residualCts <- mapM zonkCtPred (srResidual solveResult <> inertDicts (srInerts solveResult))
   let uniqueResidualCts = nubBy sameCtPred residualCts
@@ -1778,19 +1888,48 @@ generalizableResidualPreds solveResult = do
   -- Every occurrence still needs evidence, even when equal predicates share
   -- one constraint in the generalized type.
   forM_ residualCts $ \ct ->
-    when (predicateCanGeneralize (ctPred ct)) $
-      bindEvidence (ctEvVar ct) (EvGiven (ctPred ct))
+    case find (sameCtPred ct) polymorphicCts of
+      Just binder -> bindEvidence (ctEvVar ct) (EvGiven (ctEvVar binder) (ctPred binder))
+      Nothing -> pure ()
   -- A fully concrete residual cannot be discharged by a caller-supplied
   -- dictionary, so reject it at the originating expression.
   forM_ concreteCts $ \ct ->
     emitError (ctLoc ct) (UnsolvedWanted (ctPred ct) (ctOrigin ct))
-  pure (map ctPred polymorphicCts)
+  pure
+    ( map ctPred polymorphicCts,
+      map (evidenceBinderAnnotation . (\ct -> (ctEvVar ct, ctPred ct))) polymorphicCts
+    )
   where
     zonkCtPred ct = do
       pred' <- zonkPred (ctPred ct)
       pure (ct {ctPred = pred'})
-
     sameCtPred left right = ctPred left == ctPred right
+
+freshGivenEvidence :: [Pred] -> TcM [(EvVar, Pred)]
+freshGivenEvidence = mapM (\predicate -> (,predicate) <$> freshEvVar)
+
+evidenceBinderAnnotation :: (EvVar, Pred) -> TcEvidenceBinderAnnotation
+evidenceBinderAnnotation (evidence, predicate) =
+  TcEvidenceBinderAnnotation evidence predicate (predType predicate)
+
+evidenceBinderPair :: TcEvidenceBinderAnnotation -> (EvVar, Pred)
+evidenceBinderPair binder =
+  (tcEvidenceBinderVar binder, tcEvidenceBinderPred binder)
+
+setEvidenceBinderPredicate :: TcEvidenceBinderAnnotation -> Pred -> TcEvidenceBinderAnnotation
+setEvidenceBinderPredicate binder predicate =
+  binder
+    { tcEvidenceBinderPred = predicate,
+      tcEvidenceBinderType = predType predicate
+    }
+
+zonkEvidenceBinder :: TcEvidenceBinderAnnotation -> TcM TcEvidenceBinderAnnotation
+zonkEvidenceBinder binder = do
+  predicate <- zonkPred (tcEvidenceBinderPred binder)
+  pure (setEvidenceBinderPredicate binder predicate)
+
+typeSchemePredicates :: TypeScheme -> [Pred]
+typeSchemePredicates (ForAll _ predicates _) = predicates
 
 predicateCanGeneralize :: Pred -> Bool
 predicateCanGeneralize =
@@ -1882,7 +2021,7 @@ registerForeignImport foreignDecl = do
       declaredTy = schemeToType scheme
   extendTermEnvPermanent name (TcIdBinder scheme Closed)
   zonkedTy <- zonkType declaredTy
-  pure [TcBindingResult name displayName zonkedTy Nothing]
+  pure [TcBindingResult name displayName zonkedTy Nothing []]
 
 registerClassDecl :: (Text, Text) -> ClassDecl -> TcM [TcBindingResult]
 registerClassDecl origin classDecl = do
@@ -1936,7 +2075,7 @@ registerClassDecl origin classDecl = do
               workerScheme = maybe scheme (defaultWorkerScheme scheme) (lookup methodName defaultSignatures)
               workerType = schemeToType workerScheme
           extendTermEnvPermanent workerName (TcIdBinder workerScheme Closed)
-          pure (Just (TcBindingResult workerName workerName workerType Nothing))
+          pure (Just (TcBindingResult workerName workerName workerType Nothing []))
       | otherwise = pure Nothing
 
     defaultWorkerScheme ordinaryScheme (ForAll tyVars predicates body) =
@@ -1965,7 +2104,7 @@ registerClassItem classPred classTvEnv classTyVars item =
                 displayName = renderBinderName methodName
             extendTermEnvPermanent name (TcIdBinder scheme Closed)
             zonkedTy <- zonkType declaredTy
-            pure (TcBindingResult name displayName zonkedTy Nothing)
+            pure (TcBindingResult name displayName zonkedTy Nothing [])
         )
         names
     _ -> pure []
@@ -2012,7 +2151,7 @@ registerInstanceDecl origin instanceDecl =
             iiContext = context,
             iiHead = headTys
           }
-      pure [TcBindingResult dictName dictName dictTy Nothing]
+      pure [TcBindingResult dictName dictName dictTy Nothing []]
 
 predType :: Pred -> TcType
 predType (ClassPred className args) = TcTyCon (TyCon className (length args)) args
@@ -2050,7 +2189,7 @@ registerDataFamilyDeclHeader familyDecl = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  pure [TcBindingResult familyName familyName (kindToTcType zonkedKind) Nothing]
+  pure [TcBindingResult familyName familyName (kindToTcType zonkedKind) Nothing []]
 
 registerDataFamilyInstance :: DataFamilyInst -> TcM [TcBindingResult]
 registerDataFamilyInstance familyInst = do
@@ -2204,7 +2343,7 @@ registerDataDeclHeader dd = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind) Nothing
+  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind) Nothing []
   pure [tyConResult]
 
 unboxedTupleDeclarationKind :: [ParamInfo] -> Kind
@@ -2261,7 +2400,7 @@ registerNewtypeDeclHeader nd = do
         tciTypeSynonym = Nothing
       }
   zonkedKind <- defaultKindMetas declaredKind
-  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind) Nothing
+  let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind) Nothing []
   pure [tyConResult]
 
 registerNewtypeConstructor :: NewtypeDecl -> TcM [TcBindingResult]
@@ -2306,7 +2445,7 @@ registerRecordSelectors constructors =
               (TcFunTy (dciResTy constructor) (dcfiType field))
       extendTermEnvPermanent label (TcIdBinder scheme Closed)
       zonkedType <- zonkType (schemeToType scheme)
-      pure (TcBindingResult label label zonkedType Nothing)
+      pure (TcBindingResult label label zonkedType Nothing [])
     registerSelector (label, []) =
       abortTc ("record selector has no fields: " <> T.unpack label)
 
@@ -2330,7 +2469,7 @@ registerTypeSynonymHeader typeSynDecl = do
         tciFlavor = SynonymTyCon,
         tciTypeSynonym = Just synonym
       }
-  pure [TcBindingResult tyName tyName (kindToTcType declaredKind) Nothing]
+  pure [TcBindingResult tyName tyName (kindToTcType declaredKind) Nothing []]
 
 registerTypeSynonymBody :: Decl -> TcM ()
 registerTypeSynonymBody (DeclAnn _ inner) = registerTypeSynonymBody inner
@@ -2410,8 +2549,8 @@ registerDataConWithResult paramInfos resTy con = case con of
       (n : _) -> do
         zonkedTy <- zonkType conTy
         let name = unqualifiedNameText n
-         in pure (TcBindingResult name name zonkedTy Nothing)
-      [] -> pure (TcBindingResult "<gadt>" "<gadt>" gadtResTy Nothing)
+         in pure (TcBindingResult name name zonkedTy Nothing [])
+      [] -> pure (TcBindingResult "<gadt>" "<gadt>" gadtResTy Nothing [])
   where
     paramEnv =
       Map.fromList
@@ -2436,7 +2575,7 @@ registerDataConWithResult paramInfos resTy con = case con of
         Just sourceName -> extendResolvedTermEnvPermanent sourceName (TcIdBinder scheme Closed)
         Nothing -> extendTermEnvPermanent name (TcIdBinder scheme Closed)
       zonkedTy <- zonkType (schemeToType scheme)
-      pure (TcBindingResult name name zonkedTy Nothing)
+      pure (TcBindingResult name name zonkedTy Nothing [])
 
 tupleConText :: TupleFlavor -> Int -> Text
 tupleConText flavor arity =
@@ -2560,7 +2699,7 @@ tcValueDecl (PatternBind _ pat rhs) = case patternBinderName pat of
   Nothing -> do
     (_rhs', ty) <- tcRhs rhs
     zonkedTy <- zonkType ty
-    pure [TcBindingResult "<pattern>" "<pattern>" zonkedTy Nothing]
+    pure [TcBindingResult "<pattern>" "<pattern>" zonkedTy Nothing []]
 
 -- | Extract the binder name from a pattern binding's LHS, if it is a bare
 -- variable pattern.  Returns @(displayName, envName)@ for simple variable

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -372,7 +372,7 @@ checkConPattern gadtHandling sp originalPat conSyntax subPats scrutTy = do
 constructorGiven :: SourceSpan -> Text -> Pred -> TcM Ct
 constructorGiven sp constructorName predicate = do
   evidence <- freshEvVar
-  bindEvidence evidence (EvGiven predicate)
+  bindEvidence evidence (EvGiven evidence predicate)
   let origin = OccurrenceOf constructorName
   pure
     Ct

--- a/components/aihc-tc/src/Aihc/Tc/Solve.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve.hs
@@ -21,6 +21,7 @@ where
 
 import Aihc.Tc.Constraint
 import Aihc.Tc.Error (TcErrorKind (..))
+import Aihc.Tc.Evidence (EvVar)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve.Canonicalize
 import Aihc.Tc.Solve.Dict (DictResult (..), solveDict, solveDictWithGivens)
@@ -116,14 +117,14 @@ solveImplication :: Implication -> TcM ()
 solveImplication impl = withTcLevel $ do
   let rawGivens = implGivenCts impl
       wanteds = implWantedCts impl
-      givenPredicates = map ctPred rawGivens
+      givenEvidence = map (\given -> (ctEvVar given, ctPred given)) rawGivens
   -- Canonicalize the given equalities by structural decomposition.
   givenEqs <- concat <$> mapM canonicalizeGiven rawGivens
   -- Equalities refine the types mentioned by dictionary wanteds, so preserve
   -- the main worklist's equality-before-dictionary ordering inside branches.
   let (equalityWanteds, dictionaryWanteds) = partitionWanteds wanteds
-  mapM_ (solveWantedWithGivens givenPredicates givenEqs) equalityWanteds
-  mapM_ (solveWantedWithGivens givenPredicates givenEqs) dictionaryWanteds
+  mapM_ (solveWantedWithGivens givenEvidence givenEqs) equalityWanteds
+  mapM_ (solveWantedWithGivens givenEvidence givenEqs) dictionaryWanteds
 
 partitionWanteds :: [Ct] -> ([Ct], [Ct])
 partitionWanteds = foldr partitionOne ([], [])
@@ -171,8 +172,8 @@ applyGivenSubst givens ty = foldr applyOne ty givens
 -- | Attempt to solve a wanted constraint using given equalities.
 -- Rewrites both sides of the wanted using the given substitution and
 -- then tries to solve the resulting equality.
-solveWantedWithGivens :: [Pred] -> [(TcType, TcType)] -> Ct -> TcM ()
-solveWantedWithGivens givenPredicates givenEqualities ct = case ctPred ct of
+solveWantedWithGivens :: [(EvVar, Pred)] -> [(TcType, TcType)] -> Ct -> TcM ()
+solveWantedWithGivens givenEvidence givenEqualities ct = case ctPred ct of
   EqPred t1 t2 -> do
     t1' <- zonkType t1
     t2' <- zonkType t2
@@ -191,7 +192,7 @@ solveWantedWithGivens givenPredicates givenEqualities ct = case ctPred ct of
   ClassPred className arguments -> do
     arguments' <- mapM zonkType arguments
     let rewritten = ClassPred className (map (applyGivenSubst givenEqualities) arguments')
-        rewrittenGivens = map (rewritePred givenEqualities) givenPredicates
+        rewrittenGivens = map (fmap (rewritePred givenEqualities)) givenEvidence
     result <- solveDictWithGivens rewrittenGivens (ct {ctPred = rewritten})
     case result of
       DictSolved -> pure ()

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Dict.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Dict.hs
@@ -17,7 +17,7 @@ where
 
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (ClassInfo (..), InstanceInfo (..))
-import Aihc.Tc.Evidence (EvTerm (..))
+import Aihc.Tc.Evidence (EvTerm (..), EvVar)
 import Aihc.Tc.Instantiate (applySubst)
 import Aihc.Tc.Monad (TcM, bindEvidence, freshEvVar, getInstances, lookupClass, lookupEvidence)
 import Aihc.Tc.Types
@@ -44,7 +44,7 @@ data DictResult
 solveDict :: Ct -> TcM DictResult
 solveDict = solveDictWithGivens []
 
-solveDictWithGivens :: [Pred] -> Ct -> TcM DictResult
+solveDictWithGivens :: [(EvVar, Pred)] -> Ct -> TcM DictResult
 solveDictWithGivens givens ct =
   case ctPred ct of
     ClassPred className args -> do
@@ -67,10 +67,10 @@ solveDictWithGivens givens ct =
       firstGivenOrSuperclass (ClassPred className args) givens
 
     firstGivenOrSuperclass _ [] = pure Nothing
-    firstGivenOrSuperclass target (given : rest)
-      | target == given = pure (Just (EvGiven given))
+    firstGivenOrSuperclass target ((givenEvidence, given) : rest)
+      | target == given = pure (Just (EvGiven givenEvidence given))
       | otherwise = do
-          projected <- superclassEvidence [] target (EvGiven given) given
+          projected <- superclassEvidence [] target (EvGiven givenEvidence given) given
           case projected of
             Just evidence -> pure (Just evidence)
             Nothing -> firstGivenOrSuperclass target rest

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -961,7 +961,7 @@ hasGivenClass :: Text -> Module -> Bool
 hasGivenClass className =
   any (any isGiven . tcAnnEvidenceTerms) . exprAnnotations
   where
-    isGiven (EvGiven (ClassPred cls _)) = cls == className
+    isGiven (EvGiven _ (ClassPred cls _)) = cls == className
     isGiven (EvDict _ _ _ evidence) = any isGiven evidence
     isGiven (EvSuperClass ev _ _ _) = isGiven ev
     isGiven (EvCast ev _) = isGiven ev


### PR DESCRIPTION
## Summary

- Use exact evidence identities for local dictionary selection.
- Stop with a fatal error when a local dictionary key conflicts.
- Revert the three later global type lookup refactors.

## Progress

- System FC tests stay at 229.
- Type checker tests stay at 121.

## Checks

- just fmt
- just check
