### PR TITLE
refactor(fc): require desugar module name

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -126,7 +126,7 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 (primPackageId config) (packageIdText packageId) (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
+       in case runStateT (dsModule tcResult) (DsState 1000 (primPackageId config) (packageIdText packageId) currentModuleName typeEnv Map.empty Map.empty constructorFields Nothing) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram (sourceModuleId tcResult) [],
@@ -955,7 +955,7 @@ localDeclarationOrigin :: Text -> DsM FcSymbolOrigin
 localDeclarationOrigin declarationName = do
   packageName <- gets dsModulePackage
   moduleName' <- gets dsModuleName
-  pure (FcTopLevelOrigin packageName (fromMaybe "Main" moduleName') declarationName)
+  pure (FcTopLevelOrigin packageName moduleName' declarationName)
 
 dsClassSelector :: Text -> Int -> [TyVarId] -> [TcType] -> TcClassMethodAnnotation -> DsM FcTopBind
 dsClassSelector dictionaryConstructor superClassCount classTyVars fieldTypes methodAnn = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -84,7 +84,7 @@ data DsState = DsState
   { dsNextUnique :: !Int,
     dsPrimPackageId :: !PackageId,
     dsModulePackage :: !Text,
-    dsModuleName :: !(Maybe Text),
+    dsModuleName :: !Text,
     -- | Map from surface name to its inferred type (from TC).
     dsTypeEnv :: !(Map Text TcType),
     -- | Local variable bindings (pattern-bound, lambda-bound).
@@ -1918,7 +1918,7 @@ lookupLocalName name = do
   case nameQualifier name of
     Nothing -> lookupLocal (nameText name)
     Just qualifier
-      | Just qualifier == currentModule -> lookupLocal (nameText name)
+      | qualifier == currentModule -> lookupLocal (nameText name)
       | otherwise -> lookupLocal (nameToText name)
 
 lookupTypeName :: Name -> DsM TcType

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -15,6 +15,7 @@ where
 
 import Aihc.Fc
 import Aihc.Fc qualified as Fc
+import Aihc.Fc.Desugar.Expr (DsState (dsModuleName))
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
@@ -52,7 +53,11 @@ fcDesugarTests :: TestTree
 fcDesugarTests =
   testGroup
     "FC desugaring"
-    [ testCase "counts every label in a grouped record field" $ do
+    [ testCase "requires a module name in the desugar state" $ do
+        let requireModuleName :: DsState -> Text
+            requireModuleName = dsModuleName
+        requireModuleName `seq` pure (),
+      testCase "counts every label in a grouped record field" $ do
         let (_, parsedModule) = parseModule defaultConfig "module Test where\ndata Pair a = Pair { left, right :: a }\n"
             constructors = concatMap declarationConstructors (Surface.moduleDecls parsedModule)
         case constructors of

--- a/components/aihc-fc/test/Test/Fc/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc/Suite.hs
@@ -15,7 +15,6 @@ where
 
 import Aihc.Fc
 import Aihc.Fc qualified as Fc
-import Aihc.Fc.Desugar.Expr (DsState (dsModuleName))
 import Aihc.Fc.Desugar.Match (dsDataConPure)
 import Aihc.Fc.Subst (freeRigidTyVarsOf)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
@@ -53,11 +52,7 @@ fcDesugarTests :: TestTree
 fcDesugarTests =
   testGroup
     "FC desugaring"
-    [ testCase "requires a module name in the desugar state" $ do
-        let requireModuleName :: DsState -> Text
-            requireModuleName = dsModuleName
-        requireModuleName `seq` pure (),
-      testCase "counts every label in a grouped record field" $ do
+    [ testCase "counts every label in a grouped record field" $ do
         let (_, parsedModule) = parseModule defaultConfig "module Test where\ndata Pair a = Pair { left, right :: a }\n"
             constructors = concatMap declarationConstructors (Surface.moduleDecls parsedModule)
         case constructors of


### PR DESCRIPTION
## Summary

- Change `dsModuleName` from `Maybe Text` to `Text`.
- Supply the resolved module name when FC desugaring creates `DsState`.
- Remove the local `Main` fallback from FC desugaring operations.

## Reason

Every module has a module name during FC desugaring.
The caller assigns `Main` when the source does not contain an explicit module name.

## Progress counts

No progress counts changed.

## Validation

- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
