### PR TITLE
refactor(fc): store module package as PackageId

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -126,7 +126,7 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
                 dtiFlavor dataType == DataTyCon,
                 constructor <- dtiConstructors dataType
               ]
-       in case runStateT (dsModule tcResult) (DsState 1000 (primPackageId config) (packageIdText packageId) (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
+       in case runStateT (dsModule tcResult) (DsState 1000 (primPackageId config) packageId (Just currentModuleName) typeEnv Map.empty Map.empty constructorFields Nothing) of
             Left err ->
               DesugarResult
                 { dsProgram = FcProgram (sourceModuleId tcResult) [],
@@ -953,9 +953,9 @@ dsClassDeclM classDecl classAnn = do
 
 localDeclarationOrigin :: Text -> DsM FcSymbolOrigin
 localDeclarationOrigin declarationName = do
-  packageName <- gets dsModulePackage
+  packageId <- gets dsModulePackage
   moduleName' <- gets dsModuleName
-  pure (FcTopLevelOrigin packageName (fromMaybe "Main" moduleName') declarationName)
+  pure (FcTopLevelOrigin (packageIdText packageId) (fromMaybe "Main" moduleName') declarationName)
 
 dsClassSelector :: Text -> Int -> [TyVarId] -> [TcType] -> TcClassMethodAnnotation -> DsM FcTopBind
 dsClassSelector dictionaryConstructor superClassCount classTyVars fieldTypes methodAnn = do

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -83,7 +83,7 @@ type DsM = StateT DsState (Either String)
 data DsState = DsState
   { dsNextUnique :: !Int,
     dsPrimPackageId :: !PackageId,
-    dsModulePackage :: !Text,
+    dsModulePackage :: !PackageId,
     dsModuleName :: !(Maybe Text),
     -- | Map from surface name to its inferred type (from TC).
     dsTypeEnv :: !(Map Text TcType),


### PR DESCRIPTION
## Summary

- Store `dsModulePackage` as `PackageId`.
- Convert the package ID to `Text` only for `FcTopLevelOrigin`.

## Impact

This change keeps the package identity typed during desugaring.
It does not change program behavior.

## Progress counts

No progress counts change.

## Checks

- `just fmt`
- `just check`

No unit tests were added.