### PR TITLE
fix(tc): use standalone tuple kind signatures

### DIFF
--- a/bin/aihc/src/Aihc/Cli/PackageInterface.hs
+++ b/bin/aihc/src/Aihc/Cli/PackageInterface.hs
@@ -380,6 +380,13 @@ tcTypeValue ty =
           "fun" .= tcTypeValue fun,
           "arg" .= tcTypeValue arg
         ]
+    TcBuiltinTyCon name arity args ->
+      Aeson.object
+        [ "tag" .= ("builtin" :: Text),
+          "name" .= name,
+          "arity" .= arity,
+          "args" .= map tcTypeValue args
+        ]
 
 parseTcTypeJson :: Aeson.Value -> AesonTypes.Parser TcType
 parseTcTypeJson =
@@ -408,6 +415,11 @@ parseTcTypeJson =
         TcAppTy
           <$> (obj .: "fun" >>= parseTcTypeJson)
           <*> (obj .: "arg" >>= parseTcTypeJson)
+      "builtin" ->
+        TcBuiltinTyCon
+          <$> obj .: "name"
+          <*> obj .: "arity"
+          <*> (obj .: "args" >>= traverse parseTcTypeJson)
       other -> fail ("unknown type tag: " <> T.unpack other)
 
 parseTyVarObject :: AesonTypes.Object -> AesonTypes.Parser TyVarId

--- a/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
+++ b/components/aihc-fc/src/Aihc/Fc/DeadCode.hs
@@ -263,6 +263,7 @@ referencesType ty =
     TcForAllTy _ body -> referencesType body
     TcQualTy predicates body -> foldMap referencesPred predicates <> referencesType body
     TcAppTy function argument -> referencesType function <> referencesType argument
+    TcBuiltinTyCon _ _ arguments -> foldMap referencesType arguments
 
 referencesPred :: Pred -> References
 referencesPred predicate =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -250,6 +250,7 @@ lowerConstraintType ty =
     TcQualTy predicates body ->
       foldr (TcFunTy . lowerConstraintType . predType) (lowerConstraintType body) predicates
     TcAppTy function argument -> TcAppTy (lowerConstraintType function) (lowerConstraintType argument)
+    TcBuiltinTyCon name arity arguments -> TcBuiltinTyCon name arity (map lowerConstraintType arguments)
 
 lowerCoercion :: Coercion -> Coercion
 lowerCoercion coercion =
@@ -673,6 +674,17 @@ matchConstructorResult quantified patternType actualType substitution =
         _ -> Nothing
     TcForAllTy {} -> Nothing
     TcQualTy {} -> Nothing
+    TcBuiltinTyCon name arity arguments ->
+      case actualType of
+        TcBuiltinTyCon actualName actualArity actualArguments
+          | name == actualName,
+            arity == actualArity,
+            length arguments == length actualArguments ->
+              foldM
+                (\current (expectedArgument, actualArgument) -> matchConstructorResult quantified expectedArgument actualArgument current)
+                substitution
+                (zip arguments actualArguments)
+        _ -> Nothing
 
 makeForeignIoWrapper :: FcForeignCall -> TcForeignMarshal -> [FcExpr] -> DsM FcExpr
 makeForeignIoWrapper foreignCall resultMarshal arguments = do
@@ -903,6 +915,7 @@ typeRuntimeRepVariables ty =
     TcForAllTy _ body -> typeRuntimeRepVariables body
     TcQualTy _ body -> typeRuntimeRepVariables body
     TcAppTy function argument -> typeRuntimeRepVariables function <> typeRuntimeRepVariables argument
+    TcBuiltinTyCon _ _ arguments -> concatMap typeRuntimeRepVariables arguments
 
 kindRuntimeRepVariables :: Kind -> [Unique]
 kindRuntimeRepVariables kind =

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1883,6 +1883,7 @@ exactTypeKey ty =
     TcFunTy argument result -> exactTypeKey argument <> "->" <> exactTypeKey result
     TcForAllTy _ body -> exactTypeKey body
     TcQualTy _ body -> exactTypeKey body
+    TcBuiltinTyCon name _ arguments -> name <> T.concat (map (("_" <>) . exactTypeKey) arguments)
 
 uniqueInt :: Unique -> Int
 uniqueInt (Unique unique) = unique
@@ -1899,6 +1900,7 @@ typeKey ty =
     TcFunTy a b -> typeKey a <> "->" <> typeKey b
     TcForAllTy _ body -> typeKey body
     TcQualTy _ body -> typeKey body
+    TcBuiltinTyCon name _ arguments -> name <> T.concat (map (("_" <>) . typeKey) arguments)
 
 charTy :: TcType
 charTy = TcTyCon (TyCon "Char" 0) []

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -495,6 +495,8 @@ renderTypeWith scope ty =
       "(" <> intercalate ", " (map (renderPred scope) predicates) <> ") ⇒ " <> renderTypeWith scope body
     TcAppTy function argument ->
       renderTypeAtomWith scope function <> " · " <> renderTypeAtomWith scope argument
+    TcBuiltinTyCon name _ arguments ->
+      unwords (T.unpack name : map (renderTypeAtomWith scope) arguments)
 
 unboxedTupleConstructorName :: Int -> String
 unboxedTupleConstructorName arity =
@@ -507,6 +509,7 @@ renderTypeAtomWith scope ty =
     TcMetaTv {} -> renderTypeWith scope ty
     TcTyCon _ [] -> renderTypeWith scope ty
     TcTyCon (TyCon "[]" _) [_] -> renderTypeWith scope ty
+    TcBuiltinTyCon _ _ [] -> renderTypeWith scope ty
     _ -> "(" <> renderTypeWith scope ty <> ")"
 
 renderTyVarBinders :: [TyVarId] -> [TyVarId] -> [String]

--- a/components/aihc-fc/src/Aihc/Fc/Subst.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Subst.hs
@@ -16,7 +16,7 @@ module Aihc.Fc.Subst
 where
 
 import Aihc.Fc.Syntax
-import Aihc.Tc.Types (Kind (..), Levity (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (tyConName), TyVarId (..), Unique (..), setTyConKind, setTyVarKind, tvKind, tyConKind)
+import Aihc.Tc.Types (Kind (..), Levity (..), Pred (..), RuntimeRep (..), TcType (..), TyCon (tyConName), TyVarId (..), Unique (..), setTyVarKind, tvKind)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -94,6 +94,7 @@ freeRigidTyVarsOf = uniqueTyVars . concatMap go
         TcForAllTy tyVar body -> filter (/= tyVar) (go body)
         TcQualTy predicates body -> concatMap goPredicate predicates <> go body
         TcAppTy function argument -> go function <> go argument
+        TcBuiltinTyCon _ _ arguments -> concatMap go arguments
 
     goPredicate predicate =
       case predicate of
@@ -115,7 +116,7 @@ substType subst ty
       Just t -> t
       Nothing -> TcTyVar (setTyVarKind (goKind s (tvKind tv)) tv)
     go _ t@(TcMetaTv _) = t
-    go s (TcTyCon tc args) = TcTyCon (setTyConKind (goKind s (tyConKind tc)) tc) (map (go s) args)
+    go s (TcTyCon tc args) = TcTyCon tc (map (go s) args)
     go s (TcFunTy a b) = TcFunTy (go s a) (go s b)
     go s (TcForAllTy tv body) =
       -- Remove the bound variable from substitution to avoid capture.
@@ -123,6 +124,7 @@ substType subst ty
        in TcForAllTy (setTyVarKind (goKind s (tvKind tv)) tv) (go s' body)
     go s (TcQualTy preds body) = TcQualTy (map (goPred s) preds) (go s body)
     go s (TcAppTy f a) = TcAppTy (go s f) (go s a)
+    go s (TcBuiltinTyCon name arity arguments) = TcBuiltinTyCon name arity (map (go s) arguments)
 
     goPred s (ClassPred cls args) = ClassPred cls (map (go s) args)
     goPred s (EqPred t1 t2) = EqPred (go s t1) (go s t2)

--- a/components/aihc-fc/test/Test/Fc/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc/Properties.hs
@@ -19,7 +19,7 @@ import Aihc.Tc.Types
     VecCount (..),
     VecElem (..),
     liftedRuntimeRep,
-    setTyConKind,
+    mkTyCon,
     setTyVarKind,
   )
 import Control.Monad (when)
@@ -311,7 +311,7 @@ genTyVar = do
   pure (setTyVarKind kind (TyVarId (generatedName "a" identifier) identifier))
 
 genTyCon :: Gen TyCon
-genTyCon = setTyConKind <$> genKind <*> (TyCon <$> genTypeName <*> Gen.int (Range.linear 0 4))
+genTyCon = mkTyCon <$> genTypeName <*> Gen.int (Range.linear 0 4) <*> genKind
 
 genKind :: Gen Kind
 genKind =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -103,14 +103,12 @@ import Aihc.Resolve.Span
 import Aihc.Resolve.Types
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, mapAndUnzipM)
-import Data.Char (isDigit)
 import Data.Data (Data, cast, gmapQ)
 import Data.List (find, mapAccumL)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
-import Data.Text qualified as T
 
 collectResolveErrors :: (Data a) => a -> [ResolveError]
 collectResolveErrors node =
@@ -387,12 +385,6 @@ resolveDecl termDefinition (DeclAnn ann inner) =
 resolveDecl termDefinition decl =
   resolveDeclCore termDefinition decl
 
-isUnboxedTupleTypeName :: UnqualifiedName -> Bool
-isUnboxedTupleTypeName name =
-  case T.stripPrefix "Tuple" (renderUnqualifiedName name) >>= T.stripSuffix "#" of
-    Just arity -> not (T.null arity) && T.all isDigit arity
-    Nothing -> False
-
 resolveDeclCore :: TermDefinition -> Decl -> ResolveM Decl
 resolveDeclCore termDefinition decl =
   case decl of
@@ -403,9 +395,12 @@ resolveDeclCore termDefinition decl =
     DeclTypeSig names ty -> do
       ty' <- resolveType ty
       pure (DeclTypeSig names ty')
-    DeclStandaloneKindSig name _
-      | isUnboxedTupleTypeName name -> pure decl
-      | otherwise -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclStandaloneKindSig name kind -> do
+      scope <- currentScope
+      sp <- currentSpan
+      let rendered = renderUnqualifiedName name
+          name' = resolveUnqualifiedNameTo sp ResolutionNamespaceType (lookupType rendered scope) name
+      DeclStandaloneKindSig name' <$> resolveType kind
     DeclTypeData dataDecl ->
       DeclTypeData <$> resolveDataDecl "type data " dataDecl
     DeclData dataDecl ->

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -579,6 +579,7 @@ builtinTypeNames =
     "State#",
     "ThreadId#",
     "TYPE",
+    "Type",
     "RuntimeRep",
     "TupleRep",
     "[]",

--- a/components/aihc-resolve/test/Test/Fixtures/golden/standalone-kind-signature.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/standalone-kind-signature.yaml
@@ -2,7 +2,8 @@ annotated:
 - |-
   module Main where
   type Identity :: Type -> Type
-  └─ v Error unhandled syntax
+       └─ t Main   │       └─ t Builtin Type
+                   └─ t Builtin Type
   type Identity a = a
        └─ t Main
   x :: Identity Int

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -57,6 +57,7 @@ module Aihc.Tc
     VecElem (..),
     TyCon (..),
     tyConKind,
+    tyConKindScheme,
     TyVarId (..),
     tvKind,
     TypeScheme (..),

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -320,6 +320,10 @@ renderTcTypeInModule currentModule = go 0
     go p (TcAppTy f a) =
       parenIf (p >= 2) $
         go 1 f ++ " " ++ go 2 a
+    go _ (TcBuiltinTyCon name _ []) = T.unpack name
+    go p (TcBuiltinTyCon name _ arguments) =
+      parenIf (p >= 2) $
+        unwords (T.unpack name : map (go 2) arguments)
 
     showPred (ClassPred cls args) =
       T.unpack cls ++ " " ++ unwords (map (go 2) args)

--- a/components/aihc-tc/src/Aihc/Tc/Deriving.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving.hs
@@ -164,7 +164,7 @@ attachedTargetType sourceSpan targetInfo params expectedKind = do
   case find ((== expectedKind) . typeKind) candidates of
     Just target -> pure target
     Nothing -> do
-      emitError sourceSpan (KindMismatch expectedKind (tciKind targetInfo))
+      emitError sourceSpan (KindMismatch expectedKind (tyConKind (tciTyCon targetInfo)))
       pure (TcTyCon tyCon arguments)
 
 annotateStandaloneDerivingTc :: [Extension] -> StandaloneDerivingDecl -> TcM Decl
@@ -366,6 +366,7 @@ typeMentionsTyVar target ty =
     TcForAllTy tyVar body -> tyVar /= target && typeMentionsTyVar target body
     TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
     TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+    TcBuiltinTyCon _ _ arguments -> any (typeMentionsTyVar target) arguments
 
 predicateMentionsTyVar :: TyVarId -> Pred -> Bool
 predicateMentionsTyVar target predicate =

--- a/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Deriving/Context.hs
@@ -410,6 +410,7 @@ typeableArguments predicate =
         TcForAllTy {} -> Nothing
         TcQualTy {} -> Nothing
         TcAppTy {} -> Nothing
+        TcBuiltinTyCon _ _ arguments -> Just arguments
     _ -> Nothing
 
 isBareVariablePredicate :: [TyVarId] -> Pred -> Bool
@@ -442,6 +443,7 @@ typeHeadTyCon ty =
   case ty of
     TcTyCon tyCon _ -> Just (tyConName tyCon)
     TcAppTy function _ -> typeHeadTyCon function
+    TcBuiltinTyCon name _ _ -> Just name
     _ -> Nothing
 
 predicateMentionsTyCon :: Pred -> Text -> Bool
@@ -458,6 +460,7 @@ typeMentionsTyCon name ty =
     TcForAllTy _ body -> typeMentionsTyCon name body
     TcQualTy predicates body -> any (`predicateMentionsTyCon` name) predicates || typeMentionsTyCon name body
     TcAppTy function argument -> typeMentionsTyCon name function || typeMentionsTyCon name argument
+    TcBuiltinTyCon builtinName _ arguments -> builtinName == name || any (typeMentionsTyCon name) arguments
 
 predTyVars :: Pred -> [TyVarId]
 predTyVars predicate = nub (concatMap typeTyVars (predArguments predicate))
@@ -472,6 +475,7 @@ typeTyVars ty =
     TcForAllTy tyVar body -> filter (/= tyVar) (typeTyVars body)
     TcQualTy predicates body -> concatMap predTyVars predicates <> typeTyVars body
     TcAppTy function argument -> typeTyVars function <> typeTyVars argument
+    TcBuiltinTyCon _ _ arguments -> concatMap typeTyVars arguments
 
 predDictBinder :: Pred -> TcDictBinderAnnotation
 predDictBinder predicate =

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -72,7 +72,6 @@ data TyConInfo = TyConInfo
   { tciName :: !Text,
     tciArity :: !Int,
     tciTyCon :: !TyCon,
-    tciKind :: !Kind,
     tciFlavor :: !TyConFlavor,
     tciTypeSynonym :: !(Maybe TypeSynonymInfo)
   }

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -298,6 +298,8 @@ firstMetaType ty =
       firstJusts (map firstMetaPred preds) <|> firstMetaType body
     TcAppTy fun arg ->
       firstMetaType fun <|> firstMetaType arg
+    TcBuiltinTyCon _ _ arguments ->
+      firstJusts (map firstMetaType arguments)
 
 firstJusts :: [Maybe a] -> Maybe a
 firstJusts [] = Nothing

--- a/components/aihc-tc/src/Aihc/Tc/Generalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generalize.hs
@@ -85,6 +85,7 @@ collectMetaVars (TcFunTy a b) = collectMetaVars a ++ collectMetaVars b
 collectMetaVars (TcForAllTy _ body) = collectMetaVars body
 collectMetaVars (TcQualTy ps body) = concatMap predMetaVars ps ++ collectMetaVars body
 collectMetaVars (TcAppTy f a) = collectMetaVars f ++ collectMetaVars a
+collectMetaVars (TcBuiltinTyCon _ _ arguments) = concatMap collectMetaVars arguments
 
 -- | Collect free meta-variable uniques from a predicate.
 predMetaVars :: Pred -> [Unique]
@@ -175,6 +176,7 @@ substMetas subst = go
     go (TcForAllTy tv body) = TcForAllTy tv (go body)
     go (TcQualTy ps body) = TcQualTy (map (substMetasPred subst) ps) (go body)
     go (TcAppTy f a) = TcAppTy (go f) (go a)
+    go (TcBuiltinTyCon name arity arguments) = TcBuiltinTyCon name arity (map go arguments)
 
 -- | Substitute meta-variables in a predicate.
 substMetasPred :: [(Unique, TcType)] -> Pred -> Pred

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -2299,7 +2299,8 @@ registerTypeSynonymHeader maybeKindScheme typeSynDecl = do
       params = binderHeadParams (typeSynHead typeSynDecl)
       arity = length params
   (_, paramInfos) <- typeDeclParamInfos maybeKindScheme params
-  let inferredKind = foldr (KFun . paramKind) KType paramInfos
+  inferredResultKind <- freshKindMeta
+  let inferredKind = foldr (KFun . paramKind) inferredResultKind paramInfos
   tyCon <-
     case maybeKindScheme of
       Just kindScheme -> declaredTyConWithKindScheme tyBinder tyName arity kindScheme
@@ -2328,10 +2329,17 @@ registerTypeSynonymBody (DeclTypeSyn typeSynDecl) = do
       | Just synonym <- tciTypeSynonym info -> do
           let params = tsiParams synonym
               tvEnv = Map.fromList [(tvName param, (param, tvKind param)) | param <- params]
-          body <- checkSurfaceType tvEnv (typeSynBody typeSynDecl) KType
+              resultKind = typeResultKind (length params) (tyConKind (tciTyCon info))
+          body <- checkSurfaceType tvEnv (typeSynBody typeSynDecl) resultKind
           extendTyConEnvPermanent tyName (info {tciTypeSynonym = Just (synonym {tsiBody = Just body})})
     _ -> missingTypeInfo ("type synonym " <> T.unpack tyName)
 registerTypeSynonymBody _ = pure ()
+
+typeResultKind :: Int -> Kind -> Kind
+typeResultKind remaining kind
+  | remaining <= 0 = kind
+typeResultKind remaining (KFun _ result) = typeResultKind (remaining - 1) result
+typeResultKind _ kind = kind
 
 dataDeclTyCon :: UnqualifiedName -> Text -> Int -> Kind -> TcM TyCon
 dataDeclTyCon binder "List" 1 kind = mkDeclaredTyCon binder "[]" 1 kind

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -51,7 +51,7 @@ import Aihc.Parser.Syntax
     Rhs (..),
     SourceSpan (..),
     TupleFlavor (..),
-    TyVarBinder (..),
+    TyVarBinder,
     Type (..),
     TypeSynDecl (..),
     UnqualifiedName (..),
@@ -99,14 +99,14 @@ import Aihc.Tc.Generate.Bind (inferRhsWithLocals)
 import Aihc.Tc.Generate.Expr (inferExpr)
 import Aihc.Tc.Generate.Pattern
 import Aihc.Tc.Instantiate qualified
-import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkRuntimeType, checkSurfaceType, classPredicateArgKinds, defaultKindMetas, freeTypeVars, freshKindMeta, kindToTcType, makeParamEnv, sigToScheme, surfacePredToPred, tyConKindFromParams, tyConKindFromParamsWith)
+import Aihc.Tc.Kind (ParamInfo (..), TvKindEnv, checkRuntimeType, checkSurfaceType, classPredicateArgKinds, defaultKindMetas, freeTypeVars, freshKindMeta, kindToTcType, makeParamEnv, makeParamEnvWith, sigToScheme, standaloneKindSigToScheme, surfacePredToPred, tyConKindFromParams, tyConKindFromParamsWith, unifyKinds)
 import Aihc.Tc.Monad
 import Aihc.Tc.Solve (SolveResult (..), solveConstraints, solveWithImpls)
 import Aihc.Tc.Solve.Dict (DictResult (..), solveDictWithGivens)
 import Aihc.Tc.Solve.InertSet (InertSet (..))
 import Aihc.Tc.Types
 import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds, defaultTypeSchemeKinds, zonkType)
-import Control.Monad (foldM, forM_, unless, when, zipWithM, (>=>))
+import Control.Monad (foldM, forM_, unless, when, zipWithM, zipWithM_, (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
 import Data.Graph (SCC (..), stronglyConnComp)
@@ -468,7 +468,9 @@ tcModuleScc modules = do
   -- types. This permits forward references from synonyms to data types while
   -- making aliases available in constructor fields and class methods.
   let declarations = concatMap moduleDecls modules
-  mapM_ registerTypeDeclHeader declarations
+      standaloneKindSignatures = collectStandaloneKindSignatures declarations
+  standaloneKindSchemes <- traverse (standaloneKindSigToScheme >=> defaultTypeSchemeKinds) standaloneKindSignatures
+  mapM_ (registerTypeDeclHeader standaloneKindSchemes) declarations
   mapM_ registerTypeSynonymBody declarations
   mapM_ (\modu -> mapM_ (registerValueLevelDecl (resolvedModuleOrigin modu)) (moduleDecls modu)) modules
   -- Deriving strategy and context inference depends only on registered type,
@@ -594,12 +596,15 @@ defaultGlobalKindMetas = do
             dciResTy = resultType
           }
     finalizeTyConKind kind tyCon =
-      mkTyConWithOrigin
-        (tyConPackageId tyCon)
-        (tyConModuleName tyCon)
-        (tyConName tyCon)
-        (tyConArity tyCon)
-        kind
+      case tyConKindScheme tyCon of
+        Just _ -> setTyConKind kind tyCon
+        Nothing ->
+          mkTyConWithOrigin
+            (tyConPackageId tyCon)
+            (tyConModuleName tyCon)
+            (tyConName tyCon)
+            (tyConArity tyCon)
+            kind
     defaultDataConFieldKinds field = do
       fieldType' <- defaultTypeKinds (dcfiType field)
       pure field {dcfiType = fieldType'}
@@ -1840,13 +1845,34 @@ zonkPred pred' =
     ClassPred className args -> ClassPred className <$> mapM zonkType args
     EqPred left right -> EqPred <$> zonkType left <*> zonkType right
 
-registerTypeDeclHeader :: Decl -> TcM [TcBindingResult]
-registerTypeDeclHeader (DeclData dataDecl) = registerDataDeclHeader dataDecl
-registerTypeDeclHeader (DeclNewtype newtypeDecl) = registerNewtypeDeclHeader newtypeDecl
-registerTypeDeclHeader (DeclDataFamilyDecl familyDecl) = registerDataFamilyDeclHeader familyDecl
-registerTypeDeclHeader (DeclTypeSyn typeSynDecl) = registerTypeSynonymHeader typeSynDecl
-registerTypeDeclHeader (DeclAnn _ inner) = registerTypeDeclHeader inner
-registerTypeDeclHeader _ = pure []
+type TcTypeKey = (PackageId, Text, Text)
+
+collectStandaloneKindSignatures :: [Decl] -> Map TcTypeKey Type
+collectStandaloneKindSignatures = Map.fromList . mapMaybe collect
+  where
+    collect declaration =
+      case declaration of
+        DeclAnn _ inner -> collect inner
+        DeclStandaloneKindSig name kind -> (,kind) <$> resolvedTypeKey name
+        _ -> Nothing
+
+resolvedTypeKey :: UnqualifiedName -> Maybe TcTypeKey
+resolvedTypeKey name = do
+  ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} <- nameResolution name
+  moduleName' <- nameQualifier resolvedName
+  pure (packageId, moduleName', nameText resolvedName)
+
+registerTypeDeclHeader :: Map TcTypeKey TypeScheme -> Decl -> TcM [TcBindingResult]
+registerTypeDeclHeader kindSchemes (DeclData dataDecl) =
+  registerDataDeclHeader (resolvedTypeKey (binderHeadName (dataDeclHead dataDecl)) >>= (`Map.lookup` kindSchemes)) dataDecl
+registerTypeDeclHeader kindSchemes (DeclNewtype newtypeDecl) =
+  registerNewtypeDeclHeader (resolvedTypeKey (binderHeadName (newtypeDeclHead newtypeDecl)) >>= (`Map.lookup` kindSchemes)) newtypeDecl
+registerTypeDeclHeader kindSchemes (DeclDataFamilyDecl familyDecl) =
+  registerDataFamilyDeclHeader (resolvedTypeKey (binderHeadName (dataFamilyDeclHead familyDecl)) >>= (`Map.lookup` kindSchemes)) familyDecl
+registerTypeDeclHeader kindSchemes (DeclTypeSyn typeSynDecl) =
+  registerTypeSynonymHeader (resolvedTypeKey (binderHeadName (typeSynHead typeSynDecl)) >>= (`Map.lookup` kindSchemes)) typeSynDecl
+registerTypeDeclHeader kindSchemes (DeclAnn _ inner) = registerTypeDeclHeader kindSchemes inner
+registerTypeDeclHeader _ _ = pure []
 
 registerValueLevelDecl :: (Text, Text) -> Decl -> TcM [TcBindingResult]
 registerValueLevelDecl _ (DeclData dataDecl) = registerDataConstructors dataDecl
@@ -2020,15 +2046,19 @@ typeSuffix ty =
     TcTyCon tc args -> tyConName tc <> T.concat (map typeSuffix args)
     _ -> "T"
 
-registerDataFamilyDeclHeader :: DataFamilyDecl -> TcM [TcBindingResult]
-registerDataFamilyDeclHeader familyDecl = do
+registerDataFamilyDeclHeader :: Maybe TypeScheme -> DataFamilyDecl -> TcM [TcBindingResult]
+registerDataFamilyDeclHeader maybeKindScheme familyDecl = do
   let familyBinder = binderHeadName (dataFamilyDeclHead familyDecl)
       familyName = unqualifiedNameText familyBinder
       params = binderHeadParams (dataFamilyDeclHead familyDecl)
       arity = length params
-  paramInfos <- makeParamEnv params
-  declaredKind <- tyConKindFromParams paramInfos (dataFamilyDeclKind familyDecl)
-  familyTyCon <- mkDeclaredTyCon familyBinder familyName arity declaredKind
+  (_, paramInfos) <- typeDeclParamInfos maybeKindScheme params
+  inferredKind <- tyConKindFromParams paramInfos (dataFamilyDeclKind familyDecl)
+  familyTyCon <-
+    case maybeKindScheme of
+      Just kindScheme -> declaredTyConWithKindScheme familyBinder familyName arity kindScheme
+      Nothing -> mkDeclaredTyCon familyBinder familyName arity inferredKind
+  let declaredKind = maybe inferredKind (const (tyConKind familyTyCon)) maybeKindScheme
   extendTyConEnvPermanent
     familyName
     TyConInfo
@@ -2109,80 +2139,56 @@ dataFamilyInstanceParams familyInst = do
 --   - @Bool :: *@
 --   - @True :: Bool@
 --   - @False :: Bool@
-dataDeclParamInfos :: DataDecl -> TcM ([ParamInfo], [ParamInfo])
-dataDeclParamInfos declaration =
-  case unboxedTupleDataDeclArity declaration of
-    Just arity
-      | arity == length params -> pure (unboxedTupleParamInfos arity params)
-    _ -> ([],) <$> makeParamEnv params
+typeDeclParamInfos :: Maybe TypeScheme -> [TyVarBinder] -> TcM ([ParamInfo], [ParamInfo])
+typeDeclParamInfos maybeKindScheme params =
+  case maybeKindScheme of
+    Nothing -> ([],) <$> makeParamEnv params
+    Just scheme@(ForAll kindTyVars _ _) -> do
+      let kindParams = map kindParam kindTyVars
+          kindEnv = Map.fromList [(paramName param, (paramTyVar param, paramKind param)) | param <- kindParams]
+          expectedKinds = takeVisibleArgumentKinds (length params) (kindFromTypeScheme scheme)
+      paramInfos <- makeParamEnvWith kindEnv params
+      if length expectedKinds == length params
+        then do
+          zipWithM_ (unifyKinds . paramKind) paramInfos expectedKinds
+          let checkedParams = zipWith setParamKind expectedKinds paramInfos
+          pure (kindParams, checkedParams)
+        else do
+          emitError NoSourceSpan (OtherError "standalone kind signature arity does not match its type declaration")
+          pure (kindParams, paramInfos)
   where
-    params = binderHeadParams (dataDeclHead declaration)
+    kindParam tyVar = ParamInfo (tvName tyVar) tyVar (tvKind tyVar)
+    setParamKind kind param =
+      param
+        { paramTyVar = setTyVarKind kind (paramTyVar param),
+          paramKind = kind
+        }
 
-unboxedTupleDataDeclArity :: DataDecl -> Maybe Int
-unboxedTupleDataDeclArity declaration =
-  case dataDeclConstructors declaration of
-    [constructor] -> tupleConstructorArity constructor
-    _ -> Nothing
+dataDeclParamInfos :: Maybe TypeScheme -> DataDecl -> TcM ([ParamInfo], [ParamInfo])
+dataDeclParamInfos maybeKindScheme declaration =
+  typeDeclParamInfos maybeKindScheme (binderHeadParams (dataDeclHead declaration))
+
+takeVisibleArgumentKinds :: Int -> Kind -> [Kind]
+takeVisibleArgumentKinds = go
   where
-    tupleConstructorArity dataConstructor =
-      case dataConstructor of
-        DataConAnn _ inner -> tupleConstructorArity inner
-        TupleCon _ _ Unboxed fields -> Just (length fields)
-        _ -> Nothing
+    go remaining (KFun argument result)
+      | remaining > 0 = argument : go (remaining - 1) result
+    go _ _ = []
 
-unboxedTupleParamInfos :: Int -> [TyVarBinder] -> ([ParamInfo], [ParamInfo])
-unboxedTupleParamInfos arity params = (kindParams, valueParams)
-  where
-    kindParams =
-      [ ParamInfo name (setTyVarKind KRuntimeRep (TyVarId name (tupleKindUnique index))) KRuntimeRep
-      | (index, name) <- zip [1 ..] (tupleRuntimeRepNames params)
-      ]
-    valueParams =
-      [ ParamInfo name (setTyVarKind kind (TyVarId name (tupleValueUnique index))) kind
-      | (index, binder, kindParam) <- zip3 [1 ..] params kindParams,
-        let name = tyVarBinderName binder
-            kind = KTYPE (RuntimeRepVar (tvUnique (paramTyVar kindParam)))
-      ]
-    tupleKindUnique index = Unique (-1000000 - arity * 200 - index)
-    tupleValueUnique index = Unique (-1000000 - arity * 200 - 100 - index)
-
-tupleRuntimeRepNames :: [TyVarBinder] -> [Text]
-tupleRuntimeRepNames = mapMaybe (tyVarBinderKind >=> runtimeRepVariableName)
-  where
-    runtimeRepVariableName ty =
-      case ty of
-        TAnn _ inner -> runtimeRepVariableName inner
-        TParen inner -> runtimeRepVariableName inner
-        TApp function representation
-          | surfaceTypeConstructorName function == Just "TYPE" -> surfaceTypeVariableName representation
-        _ -> Nothing
-    surfaceTypeConstructorName ty =
-      case ty of
-        TAnn _ inner -> surfaceTypeConstructorName inner
-        TParen inner -> surfaceTypeConstructorName inner
-        TCon name _ -> Just (nameText name)
-        _ -> Nothing
-    surfaceTypeVariableName ty =
-      case ty of
-        TAnn _ inner -> surfaceTypeVariableName inner
-        TParen inner -> surfaceTypeVariableName inner
-        TVar name -> Just (unqualifiedNameText name)
-        _ -> Nothing
-
-registerDataDeclHeader :: DataDecl -> TcM [TcBindingResult]
-registerDataDeclHeader dd = do
+registerDataDeclHeader :: Maybe TypeScheme -> DataDecl -> TcM [TcBindingResult]
+registerDataDeclHeader maybeKindScheme dd = do
   let tyBinder = binderHeadName (dataDeclHead dd)
       tyName = unqualifiedNameText tyBinder
       params = binderHeadParams (dataDeclHead dd)
       arity = length params
-  (kindParams, paramInfos) <- dataDeclParamInfos dd
+  (kindParams, paramInfos) <- dataDeclParamInfos maybeKindScheme dd
   let kindEnv = Map.fromList [(paramName param, (paramTyVar param, paramKind param)) | param <- kindParams]
-  declaredKind <-
-    case unboxedTupleDataDeclArity dd of
-      Just tupleArity
-        | tupleArity == arity -> pure (unboxedTupleDeclarationKind paramInfos)
-      _ -> tyConKindFromParamsWith kindEnv paramInfos (dataDeclKind dd)
-  tc <- dataDeclTyCon tyBinder tyName arity declaredKind
+  inferredKind <- tyConKindFromParamsWith kindEnv paramInfos (dataDeclKind dd)
+  tc <-
+    case maybeKindScheme of
+      Just kindScheme -> declaredTyConWithKindScheme tyBinder tyName arity kindScheme
+      Nothing -> dataDeclTyCon tyBinder tyName arity inferredKind
+  let declaredKind = maybe inferredKind (const (tyConKind tc)) maybeKindScheme
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2197,15 +2203,6 @@ registerDataDeclHeader dd = do
   let tyConResult = TcBindingResult tyName tyName (kindToTcType zonkedKind)
   pure [tyConResult]
 
-unboxedTupleDeclarationKind :: [ParamInfo] -> Kind
-unboxedTupleDeclarationKind params =
-  foldr (KFun . paramKind) (KTYPE (TupleRep (map paramRuntimeRep params))) params
-  where
-    paramRuntimeRep param =
-      case paramKind param of
-        KTYPE runtimeRep -> runtimeRep
-        _ -> liftedRuntimeRep
-
 registerDataConstructors :: DataDecl -> TcM [TcBindingResult]
 registerDataConstructors dataDecl = do
   let tyBinder = binderHeadName (dataDeclHead dataDecl)
@@ -2214,7 +2211,7 @@ registerDataConstructors dataDecl = do
   case maybeInfo of
     Nothing -> missingTypeInfo ("data type " <> T.unpack tyName)
     Just info -> do
-      (kindParams, paramInfos) <- dataDeclParamInfos dataDecl
+      (kindParams, paramInfos) <- dataDeclParamInfos (tyConKindScheme (tciTyCon info)) dataDecl
       bindings <- mapM (registerDataCon (tciTyCon info) kindParams paramInfos) (dataDeclConstructors dataDecl)
       constructors <- concat <$> mapM checkedDataConInfos (dataDeclConstructors dataDecl)
       selectorBindings <- registerRecordSelectors constructors
@@ -2231,15 +2228,19 @@ registerDataConstructors dataDecl = do
 -- | Register a newtype declaration's type constructor and representation
 -- constructor.  Newtype erasure/coercion semantics are handled elsewhere; at
 -- this stage the type checker only needs the source-level names and types.
-registerNewtypeDeclHeader :: NewtypeDecl -> TcM [TcBindingResult]
-registerNewtypeDeclHeader nd = do
+registerNewtypeDeclHeader :: Maybe TypeScheme -> NewtypeDecl -> TcM [TcBindingResult]
+registerNewtypeDeclHeader maybeKindScheme nd = do
   let tyBinder = binderHeadName (newtypeDeclHead nd)
       tyName = unqualifiedNameText tyBinder
       params = binderHeadParams (newtypeDeclHead nd)
       arity = length params
-  paramInfos <- makeParamEnv params
-  declaredKind <- tyConKindFromParams paramInfos (newtypeDeclKind nd)
-  tc <- mkDeclaredTyCon tyBinder tyName arity declaredKind
+  (_, paramInfos) <- typeDeclParamInfos maybeKindScheme params
+  inferredKind <- tyConKindFromParams paramInfos (newtypeDeclKind nd)
+  tc <-
+    case maybeKindScheme of
+      Just kindScheme -> declaredTyConWithKindScheme tyBinder tyName arity kindScheme
+      Nothing -> mkDeclaredTyCon tyBinder tyName arity inferredKind
+  let declaredKind = maybe inferredKind (const (tyConKind tc)) maybeKindScheme
   extendTyConEnvPermanent
     tyName
     TyConInfo
@@ -2262,8 +2263,8 @@ registerNewtypeConstructor newtypeDecl = do
   case maybeInfo of
     Nothing -> missingTypeInfo ("newtype " <> T.unpack tyName)
     Just info -> do
-      paramInfos <- makeParamEnv (binderHeadParams (newtypeDeclHead newtypeDecl))
-      constructor <- mapM (registerDataCon (tciTyCon info) [] paramInfos) (newtypeDeclConstructor newtypeDecl)
+      (kindParams, paramInfos) <- typeDeclParamInfos (tyConKindScheme (tciTyCon info)) (binderHeadParams (newtypeDeclHead newtypeDecl))
+      constructor <- mapM (registerDataCon (tciTyCon info) kindParams paramInfos) (newtypeDeclConstructor newtypeDecl)
       constructors <- maybe (pure []) checkedDataConInfos (newtypeDeclConstructor newtypeDecl)
       selectorBindings <- registerRecordSelectors constructors
       addDataType
@@ -2300,15 +2301,19 @@ registerRecordSelectors constructors =
     registerSelector (label, []) =
       abortTc ("record selector has no fields: " <> T.unpack label)
 
-registerTypeSynonymHeader :: TypeSynDecl -> TcM [TcBindingResult]
-registerTypeSynonymHeader typeSynDecl = do
+registerTypeSynonymHeader :: Maybe TypeScheme -> TypeSynDecl -> TcM [TcBindingResult]
+registerTypeSynonymHeader maybeKindScheme typeSynDecl = do
   let tyBinder = binderHeadName (typeSynHead typeSynDecl)
       tyName = unqualifiedNameText tyBinder
       params = binderHeadParams (typeSynHead typeSynDecl)
       arity = length params
-  paramInfos <- makeParamEnv params
-  let declaredKind = foldr (KFun . paramKind) KType paramInfos
-  tyCon <- mkDeclaredTyCon tyBinder tyName arity declaredKind
+  (_, paramInfos) <- typeDeclParamInfos maybeKindScheme params
+  let inferredKind = foldr (KFun . paramKind) KType paramInfos
+  tyCon <-
+    case maybeKindScheme of
+      Just kindScheme -> declaredTyConWithKindScheme tyBinder tyName arity kindScheme
+      Nothing -> mkDeclaredTyCon tyBinder tyName arity inferredKind
+  let declaredKind = maybe inferredKind (const (tyConKind tyCon)) maybeKindScheme
   let synonym = TypeSynonymInfo (map paramTyVar paramInfos) Nothing
   extendTyConEnvPermanent
     tyName
@@ -2348,6 +2353,14 @@ mkDeclaredTyCon binder name arity kind =
     Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName}
       | Just definingModuleName <- nameQualifier resolvedName ->
           pure (mkTyConWithOrigin packageId definingModuleName name arity kind)
+    _ -> abortTc ("type declaration has no package or module identity: " <> T.unpack name)
+
+declaredTyConWithKindScheme :: UnqualifiedName -> Text -> Int -> TypeScheme -> TcM TyCon
+declaredTyConWithKindScheme binder name arity kindScheme =
+  case nameResolution binder of
+    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName}
+      | Just definingModuleName <- nameQualifier resolvedName ->
+          pure (mkTyConWithOriginAndKindScheme packageId definingModuleName name arity kindScheme)
     _ -> abortTc ("type declaration has no package or module identity: " <> T.unpack name)
 
 -- | Register a single data constructor as a polymorphic binding.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -696,6 +696,7 @@ annotateDeclTc classMethods checkedValueNames decl =
       | otherwise -> pure decl
     DeclData dataDecl -> annotateDataDeclTc dataDecl
     DeclNewtype newtypeDecl -> annotateNewtypeDeclTc newtypeDecl
+    DeclTypeSyn typeSynDecl -> annotateTypeSynDeclTc typeSynDecl
     DeclDataFamilyDecl familyDecl -> annotateDataFamilyDeclTc familyDecl
     DeclDataFamilyInst familyInst -> annotateDataFamilyInstTc familyInst
     DeclForeign foreignDecl
@@ -780,6 +781,13 @@ annotateNewtypeDeclTc newtypeDecl = do
   constructor <- mapM annotateDataConDeclTc (newtypeDeclConstructor newtypeDecl)
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (newtypeDeclHead newtypeDecl)
   pure (DeclNewtype (newtypeDecl {newtypeDeclHead = annotatedHead, newtypeDeclConstructor = constructor}))
+
+annotateTypeSynDeclTc :: TypeSynDecl -> TcM Decl
+annotateTypeSynDeclTc typeSynDecl = do
+  let tyName = unqualifiedNameText (binderHeadName (typeSynHead typeSynDecl))
+  ty <- tyConBindingType tyName
+  let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (typeSynHead typeSynDecl)
+  pure (DeclTypeSyn (typeSynDecl {typeSynHead = annotatedHead}))
 
 annotateDataFamilyDeclTc :: DataFamilyDecl -> TcM Decl
 annotateDataFamilyDeclTc familyDecl = do

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -105,7 +105,7 @@ import Aihc.Tc.Solve (SolveResult (..), solveConstraints, solveWithImpls)
 import Aihc.Tc.Solve.Dict (DictResult (..), solveDictWithGivens)
 import Aihc.Tc.Solve.InertSet (InertSet (..))
 import Aihc.Tc.Types
-import Aihc.Tc.Zonk (defaultPredKinds, defaultTyVarKinds, defaultTypeKinds, defaultTypeSchemeKinds, zonkType)
+import Aihc.Tc.Zonk (defaultPredKinds, defaultTyConKindScheme, defaultTyVarKinds, defaultTypeKinds, defaultTypeSchemeKinds, zonkType)
 import Control.Monad (foldM, forM_, unless, when, zipWithM, zipWithM_, (>=>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (get, modify')
@@ -558,13 +558,11 @@ defaultGlobalKindMetas = do
         TcIdBinder scheme closedness -> TcIdBinder <$> defaultTypeSchemeKinds scheme <*> pure closedness
         TcMonoIdBinder ty -> TcMonoIdBinder <$> defaultTypeKinds ty
     defaultTyConInfoKinds info = do
-      kind <- defaultKindMetas (tciKind info)
+      kindScheme <- defaultTyConKindScheme (tyConKindScheme (tciTyCon info))
       synonym <- traverse defaultTypeSynonymKinds (tciTypeSynonym info)
-      let tyCon = tciTyCon info
       pure
         info
-          { tciTyCon = finalizeTyConKind kind tyCon,
-            tciKind = kind,
+          { tciTyCon = setTyConKindScheme kindScheme (tciTyCon info),
             tciTypeSynonym = synonym
           }
     defaultTypeSynonymKinds synonym =
@@ -574,10 +572,10 @@ defaultGlobalKindMetas = do
     defaultDataTypeKinds info = do
       tyVars <- mapM defaultTyVarKinds (dtiTyVars info)
       constructors <- mapM defaultDataConKinds (dtiConstructors info)
-      kind <- defaultKindMetas (tyConKind (dtiTyCon info))
+      kindScheme <- defaultTyConKindScheme (tyConKindScheme (dtiTyCon info))
       pure
         info
-          { dtiTyCon = finalizeTyConKind kind (dtiTyCon info),
+          { dtiTyCon = setTyConKindScheme kindScheme (dtiTyCon info),
             dtiTyVars = tyVars,
             dtiConstructors = constructors
           }
@@ -595,16 +593,6 @@ defaultGlobalKindMetas = do
             dciFields = fields,
             dciResTy = resultType
           }
-    finalizeTyConKind kind tyCon =
-      case tyConKindScheme tyCon of
-        Just _ -> setTyConKind kind tyCon
-        Nothing ->
-          mkTyConWithOrigin
-            (tyConPackageId tyCon)
-            (tyConModuleName tyCon)
-            (tyConName tyCon)
-            (tyConArity tyCon)
-            kind
     defaultDataConFieldKinds field = do
       fieldType' <- defaultTypeKinds (dcfiType field)
       pure field {dcfiType = fieldType'}
@@ -630,12 +618,12 @@ defaultGlobalKindMetas = do
       familyType <- defaultTypeKinds (dfiiFamilyType info)
       tyVars <- mapM defaultTyVarKinds (dfiiTyVars info)
       let representationTyCon = dfiiRepresentationTyCon info
-      representationKind <- defaultKindMetas (tyConKind representationTyCon)
+      representationKindScheme <- defaultTyConKindScheme (tyConKindScheme representationTyCon)
       pure
         info
           { dfiiFamilyType = familyType,
             dfiiTyVars = tyVars,
-            dfiiRepresentationTyCon = setTyConKind representationKind representationTyCon
+            dfiiRepresentationTyCon = setTyConKindScheme representationKindScheme representationTyCon
           }
 
 data TcDeclGroupResult = TcDeclGroupResult
@@ -973,7 +961,7 @@ tyConBindingType :: Text -> TcM TcType
 tyConBindingType name = do
   mInfo <- lookupTyCon name
   case mInfo of
-    Just info -> kindToTcType <$> defaultKindMetas (tciKind info)
+    Just info -> kindToTcType <$> defaultKindMetas (tyConKind (tciTyCon info))
     Nothing -> missingTypeInfo ("type constructor " <> T.unpack name)
 
 annotateValueDeclTc :: ValueDecl -> TcM (TcType, ValueDecl)
@@ -1815,6 +1803,7 @@ typeMentionsTyVar target ty =
     TcForAllTy tyVar body -> tyVar /= target && typeMentionsTyVar target body
     TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
     TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+    TcBuiltinTyCon _ _ arguments -> any (typeMentionsTyVar target) arguments
 
 kindMentionsUnique :: Unique -> Kind -> Bool
 kindMentionsUnique target kind =
@@ -1919,7 +1908,6 @@ registerClassDecl origin classDecl = do
       { tciName = className,
         tciArity = length params,
         tciTyCon = classTyCon,
-        tciKind = classKind,
         tciFlavor = ClassTyCon,
         tciTypeSynonym = Nothing
       }
@@ -2065,7 +2053,6 @@ registerDataFamilyDeclHeader maybeKindScheme familyDecl = do
       { tciName = familyName,
         tciArity = arity,
         tciTyCon = familyTyCon,
-        tciKind = declaredKind,
         tciFlavor = DataFamilyTyCon,
         tciTypeSynonym = Nothing
       }
@@ -2168,6 +2155,12 @@ dataDeclParamInfos :: Maybe TypeScheme -> DataDecl -> TcM ([ParamInfo], [ParamIn
 dataDeclParamInfos maybeKindScheme declaration =
   typeDeclParamInfos maybeKindScheme (binderHeadParams (dataDeclHead declaration))
 
+quantifiedKindScheme :: TyCon -> Maybe TypeScheme
+quantifiedKindScheme tyCon =
+  case tyConKindScheme tyCon of
+    ForAll [] _ _ -> Nothing
+    scheme -> Just scheme
+
 takeVisibleArgumentKinds :: Int -> Kind -> [Kind]
 takeVisibleArgumentKinds = go
   where
@@ -2195,7 +2188,6 @@ registerDataDeclHeader maybeKindScheme dd = do
       { tciName = tyName,
         tciArity = arity,
         tciTyCon = tc,
-        tciKind = declaredKind,
         tciFlavor = DataTyCon,
         tciTypeSynonym = Nothing
       }
@@ -2211,7 +2203,7 @@ registerDataConstructors dataDecl = do
   case maybeInfo of
     Nothing -> missingTypeInfo ("data type " <> T.unpack tyName)
     Just info -> do
-      (kindParams, paramInfos) <- dataDeclParamInfos (tyConKindScheme (tciTyCon info)) dataDecl
+      (kindParams, paramInfos) <- dataDeclParamInfos (quantifiedKindScheme (tciTyCon info)) dataDecl
       bindings <- mapM (registerDataCon (tciTyCon info) kindParams paramInfos) (dataDeclConstructors dataDecl)
       constructors <- concat <$> mapM checkedDataConInfos (dataDeclConstructors dataDecl)
       selectorBindings <- registerRecordSelectors constructors
@@ -2247,7 +2239,6 @@ registerNewtypeDeclHeader maybeKindScheme nd = do
       { tciName = tyName,
         tciArity = arity,
         tciTyCon = tc,
-        tciKind = declaredKind,
         tciFlavor = NewtypeTyCon,
         tciTypeSynonym = Nothing
       }
@@ -2263,7 +2254,7 @@ registerNewtypeConstructor newtypeDecl = do
   case maybeInfo of
     Nothing -> missingTypeInfo ("newtype " <> T.unpack tyName)
     Just info -> do
-      (kindParams, paramInfos) <- typeDeclParamInfos (tyConKindScheme (tciTyCon info)) (binderHeadParams (newtypeDeclHead newtypeDecl))
+      (kindParams, paramInfos) <- typeDeclParamInfos (quantifiedKindScheme (tciTyCon info)) (binderHeadParams (newtypeDeclHead newtypeDecl))
       constructor <- mapM (registerDataCon (tciTyCon info) kindParams paramInfos) (newtypeDeclConstructor newtypeDecl)
       constructors <- maybe (pure []) checkedDataConInfos (newtypeDeclConstructor newtypeDecl)
       selectorBindings <- registerRecordSelectors constructors
@@ -2321,7 +2312,6 @@ registerTypeSynonymHeader maybeKindScheme typeSynDecl = do
       { tciName = tyName,
         tciArity = arity,
         tciTyCon = tyCon,
-        tciKind = declaredKind,
         tciFlavor = SynonymTyCon,
         tciTypeSynonym = Just synonym
       }
@@ -2360,7 +2350,7 @@ declaredTyConWithKindScheme binder name arity kindScheme =
   case nameResolution binder of
     Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName}
       | Just definingModuleName <- nameQualifier resolvedName ->
-          pure (mkTyConWithOriginAndKindScheme packageId definingModuleName name arity kindScheme)
+          pure (mkTyConWithOriginScheme packageId definingModuleName name arity kindScheme)
     _ -> abortTc ("type declaration has no package or module identity: " <> T.unpack name)
 
 -- | Register a single data constructor as a polymorphic binding.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -466,6 +466,7 @@ typeMetaVariables ty =
     TcForAllTy _ body -> typeMetaVariables body
     TcQualTy predicates body -> concatMap predicateMetaVariables predicates <> typeMetaVariables body
     TcAppTy function argument -> typeMetaVariables function <> typeMetaVariables argument
+    TcBuiltinTyCon _ _ arguments -> concatMap typeMetaVariables arguments
 
 predicateMetaVariables :: Pred -> [Unique]
 predicateMetaVariables predicate =
@@ -483,6 +484,7 @@ typeMentionsTyVar target ty =
     TcForAllTy binder body -> binder /= target && typeMentionsTyVar target body
     TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
     TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+    TcBuiltinTyCon _ _ arguments -> any (typeMentionsTyVar target) arguments
 
 predicateMentionsTyVar :: TyVarId -> Pred -> Bool
 predicateMentionsTyVar target predicate =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -424,6 +424,7 @@ typeTyVars ty =
     TcForAllTy tyVar body -> Set.delete (tvUnique tyVar) (typeTyVars body)
     TcQualTy predicates body -> Set.unions (typeTyVars body : map predTyVars predicates)
     TcAppTy function argument -> typeTyVars function <> typeTyVars argument
+    TcBuiltinTyCon _ _ arguments -> Set.unions (map typeTyVars arguments)
 
 predTyVars :: Pred -> Set.Set Unique
 predTyVars predicate =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/PatternBranch.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/PatternBranch.hs
@@ -60,6 +60,7 @@ typeMentionsTyVar target ty =
     TcForAllTy tyVar body -> tyVar /= target && typeMentionsTyVar target body
     TcQualTy predicates body -> any (predicateMentionsTyVar target) predicates || typeMentionsTyVar target body
     TcAppTy function argument -> typeMentionsTyVar target function || typeMentionsTyVar target argument
+    TcBuiltinTyCon _ _ arguments -> any (typeMentionsTyVar target) arguments
 
 predicateMentionsTyVar :: TyVarId -> Pred -> Bool
 predicateMentionsTyVar target predicate =

--- a/components/aihc-tc/src/Aihc/Tc/Instantiate.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Instantiate.hs
@@ -97,6 +97,7 @@ applySubst subst = go
     go (TcQualTy preds body) =
       TcQualTy (map (substPred subst) preds) (go body)
     go (TcAppTy f a) = applyType (go f) (go a)
+    go (TcBuiltinTyCon name arity arguments) = TcBuiltinTyCon name arity (map go arguments)
 
     applyType (TcTyCon tc args) arg = TcTyCon tc (args <> [arg])
     applyType f arg = TcAppTy f arg

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -16,9 +16,11 @@ module Aihc.Tc.Kind
     makeParamEnvWith,
     runtimeRepToTcType,
     sigToScheme,
+    standaloneKindSigToScheme,
     surfacePredToPred,
     tyConKindFromParams,
     tyConKindFromParamsWith,
+    unifyKinds,
     zonkKind,
   )
 where
@@ -43,10 +45,10 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Tc.Env (TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
-import Aihc.Tc.Instantiate (applySubst)
+import Aihc.Tc.Instantiate (applySubst, instantiate)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types
-import Control.Monad (zipWithM)
+import Control.Monad (unless, zipWithM)
 import Data.List (nub)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -84,6 +86,50 @@ sigToScheme ty = do
   tcTy <- checkRuntimeType tvEnv body
   preds <- mapM (surfacePredToPred tvEnv) context
   pure (ForAll (implicitTvs <> explicitTvs) preds tcTy)
+
+standaloneKindSigToScheme :: Type -> TcM TypeScheme
+standaloneKindSigToScheme ty = do
+  let (explicitBinders, bodyType) = splitForalls ty
+      freeVars = freeTypeVars ty
+      representationVars = Set.fromList (runtimeRepVariables ty)
+      variableKind name
+        | name `Set.member` representationVars = KRuntimeRep
+        | otherwise = KType
+  rawTyVars <- mapM freshSkolemTv freeVars
+  let implicitTyVars = zipWith (setTyVarKind . variableKind) freeVars rawTyVars
+      implicitEnv = Map.fromList [(tvName tyVar, (tyVar, tvKind tyVar)) | tyVar <- implicitTyVars]
+  explicitParams <- makeParamEnvWith implicitEnv explicitBinders
+  let explicitTyVars = map paramTyVar explicitParams
+      tyVarEnv =
+        implicitEnv
+          <> Map.fromList
+            [ (paramName param, (paramTyVar param, paramKind param))
+            | param <- explicitParams
+            ]
+  body <- checkSurfaceType tyVarEnv bodyType KType
+  pure (ForAll (implicitTyVars <> explicitTyVars) [] body)
+
+runtimeRepVariables :: Type -> [Text]
+runtimeRepVariables = nub . go
+  where
+    go surfaceType =
+      case peelTypeHead surfaceType of
+        TApp function runtimeRep
+          | TCon name Unpromoted <- peelTypeHead function,
+            nameText name == "TYPE" ->
+              freeTypeVars runtimeRep
+        TApp function argument -> go function <> go argument
+        TTypeApp function argument -> go function <> go argument
+        TInfix left _ _ right -> go left <> go right
+        TFun _ argument result -> go argument <> go result
+        TTuple _ _ arguments -> concatMap go arguments
+        TUnboxedSum arguments -> concatMap go arguments
+        TList _ arguments -> concatMap go arguments
+        TKindSig inner kind -> go inner <> go kind
+        TContext predicates body -> concatMap go predicates <> go body
+        TForall telescope body -> concatMap binderKindVariables (forallTelescopeBinders telescope) <> go body
+        _ -> []
+    binderKindVariables binder = maybe [] go (tyVarBinderKind binder)
 
 convertSurfaceType :: Map Text TyVarId -> Type -> TcM TcType
 convertSurfaceType tvMap ty = do
@@ -313,8 +359,18 @@ inferTypeConstructor promoted name =
         raw -> do
           mInfo <- lookupResolvedTyCon name
           case mInfo of
-            Just info -> pure (TcTyCon (tciTyCon info) [], tciKind info)
+            Just info -> do
+              kind <- instantiateTyConKind info
+              pure (TcTyCon (tciTyCon info) [], kind)
             Nothing -> inferBuiltinOrOpenTypeConstructor raw
+
+instantiateTyConKind :: TyConInfo -> TcM Kind
+instantiateTyConKind info =
+  case tyConKindScheme (tciTyCon info) of
+    Nothing -> pure (tciKind info)
+    Just scheme -> do
+      (kindType, _) <- instantiate scheme
+      pure (kindFromTypeScheme (ForAll [] [] kindType))
 
 inferBuiltinTypeConstructor :: TypeBuiltinCon -> TcM (TcType, Kind)
 inferBuiltinTypeConstructor builtin =
@@ -421,8 +477,9 @@ unifyKinds expected actual = do
   case (expected', actual') of
     (KMeta u, kind) -> bindKindMeta u kind
     (kind, KMeta u) -> bindKindMeta u kind
-    (KTYPE expectedRep, KTYPE actualRep)
-      | expectedRep == actualRep -> pure ()
+    (KTYPE expectedRep, KTYPE actualRep) -> do
+      unified <- unifyRuntimeReps expectedRep actualRep
+      unless unified (emitError NoSourceSpan (KindMismatch expected' actual'))
     (KConstraint, KConstraint) -> pure ()
     (KRuntimeRep, KRuntimeRep) -> pure ()
     (KLevity, KLevity) -> pure ()
@@ -430,6 +487,21 @@ unifyKinds expected actual = do
     (KVecElem, KVecElem) -> pure ()
     (KFun a1 b1, KFun a2 b2) -> unifyKinds a1 a2 >> unifyKinds b1 b2
     _ -> emitError NoSourceSpan (KindMismatch expected' actual')
+
+unifyRuntimeReps :: RuntimeRep -> RuntimeRep -> TcM Bool
+unifyRuntimeReps expected actual =
+  case (expected, actual) of
+    (RuntimeRepMeta left, RuntimeRepMeta right)
+      | left == right -> pure True
+    (RuntimeRepMeta unique, runtimeRep) ->
+      writeMetaTv unique (runtimeRepToTcType runtimeRep) >> pure True
+    (runtimeRep, RuntimeRepMeta unique) ->
+      writeMetaTv unique (runtimeRepToTcType runtimeRep) >> pure True
+    (TupleRep expectedFields, TupleRep actualFields)
+      | length expectedFields == length actualFields -> and <$> zipWithM unifyRuntimeReps expectedFields actualFields
+    (SumRep expectedFields, SumRep actualFields)
+      | length expectedFields == length actualFields -> and <$> zipWithM unifyRuntimeReps expectedFields actualFields
+    _ -> pure (expected == actual)
 
 bindKindMeta :: Unique -> Kind -> TcM ()
 bindKindMeta u kind
@@ -446,12 +518,22 @@ zonkKind kind =
         Nothing -> pure kind
         Just solved -> zonkKind solved
     KFun a b -> KFun <$> zonkKind a <*> zonkKind b
-    KTYPE runtimeRep -> pure (KTYPE runtimeRep)
+    KTYPE runtimeRep -> KTYPE <$> zonkRuntimeRep runtimeRep
     KConstraint -> pure KConstraint
     KRuntimeRep -> pure KRuntimeRep
     KLevity -> pure KLevity
     KVecCount -> pure KVecCount
     KVecElem -> pure KVecElem
+
+zonkRuntimeRep :: RuntimeRep -> TcM RuntimeRep
+zonkRuntimeRep runtimeRep =
+  case runtimeRep of
+    RuntimeRepMeta unique -> do
+      solution <- readMetaTv unique
+      pure (maybe runtimeRep runtimeRepFromType solution)
+    TupleRep fields -> TupleRep <$> mapM zonkRuntimeRep fields
+    SumRep fields -> SumRep <$> mapM zonkRuntimeRep fields
+    _ -> pure runtimeRep
 
 defaultKindMetas :: Kind -> TcM Kind
 defaultKindMetas kind =
@@ -644,11 +726,18 @@ runtimeRepToTcType runtimeRep =
             (TyVarId ("rep" <> T.pack (showUnique unique)) unique)
         )
     RuntimeRepMeta unique -> TcMetaTv unique
-    TupleRep _ -> promoted "TupleRep"
-    SumRep _ -> promoted "SumRep"
-    VecRep {} -> promoted "VecRep"
+    TupleRep fields -> promotedListRep "TupleRep" fields
+    SumRep fields -> promotedListRep "SumRep" fields
+    VecRep count element ->
+      TcTyCon
+        (TyCon "'VecRep" 2)
+        [promoted (T.pack (show count)), promoted (T.pack (show element))]
   where
     promoted name = TcTyCon (TyCon ("'" <> name) 0) []
+    promotedListRep name fields =
+      TcTyCon
+        (TyCon ("'" <> name) 1)
+        [TcTyCon (TyCon "'[]" (length fields)) (map runtimeRepToTcType fields)]
     showUnique (Unique value) = show value
 
 freeTypeVars :: Type -> [Text]

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -335,6 +335,8 @@ expandTcTypeSynonyms expanding ty =
     TcForAllTy tyVar body -> TcForAllTy tyVar <$> expandTcTypeSynonyms expanding body
     TcQualTy predicates body -> TcQualTy <$> mapM expandPredicate predicates <*> expandTcTypeSynonyms expanding body
     TcAppTy function argument -> applyType <$> expandTcTypeSynonyms expanding function <*> expandTcTypeSynonyms expanding argument
+    TcBuiltinTyCon name arity arguments ->
+      TcBuiltinTyCon name arity <$> mapM (expandTcTypeSynonyms expanding) arguments
   where
     expandPredicate predicate =
       case predicate of
@@ -365,12 +367,9 @@ inferTypeConstructor promoted name =
             Nothing -> inferBuiltinOrOpenTypeConstructor raw
 
 instantiateTyConKind :: TyConInfo -> TcM Kind
-instantiateTyConKind info =
-  case tyConKindScheme (tciTyCon info) of
-    Nothing -> pure (tciKind info)
-    Just scheme -> do
-      (kindType, _) <- instantiate scheme
-      pure (kindFromTypeScheme (ForAll [] [] kindType))
+instantiateTyConKind info = do
+  (kindType, _) <- instantiate (tyConKindScheme (tciTyCon info))
+  pure (kindFromTypeScheme (ForAll [] [] kindType))
 
 inferBuiltinTypeConstructor :: TypeBuiltinCon -> TcM (TcType, Kind)
 inferBuiltinTypeConstructor builtin =
@@ -797,7 +796,7 @@ classPredicateArgKinds :: Text -> Int -> TcM [Kind]
 classPredicateArgKinds className argCount = do
   mInfo <- lookupTyCon className
   case mInfo of
-    Just info -> takeClassArgKinds argCount <$> defaultKindMetas (tciKind info)
+    Just info -> takeClassArgKinds argCount <$> defaultKindMetas (tyConKind (tciTyCon info))
     Nothing -> mapM (const freshKindMeta) [1 .. argCount]
 
 takeClassArgKinds :: Int -> Kind -> [Kind]

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Dict.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Dict.hs
@@ -147,6 +147,7 @@ typeableArguments ty =
     TcForAllTy {} -> Nothing
     TcQualTy {} -> Nothing
     TcAppTy {} -> Nothing
+    TcBuiltinTyCon _ _ arguments -> Just arguments
 
 classFieldTypes :: ClassInfo -> Map Unique TcType -> [TcType]
 classFieldTypes classInfo substitution =

--- a/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Solve/Equality.hs
@@ -108,6 +108,7 @@ occursIn u = go
     go (TcForAllTy _ body) = go body
     go (TcQualTy preds body) = any goPred preds || go body
     go (TcAppTy f a) = go f || go a
+    go (TcBuiltinTyCon _ _ arguments) = any go arguments
 
     goPred (ClassPred _ args) = any go args
     goPred (EqPred a b) = go a || go b

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -26,8 +26,10 @@ module Aihc.Tc.Types
     tyConPackageId,
     tyConModuleName,
     tyConKind,
+    tyConKindScheme,
     mkTyCon,
     mkTyConWithOrigin,
+    mkTyConWithOriginAndKindScheme,
     setTyConKind,
     Kind (KTYPE, KConstraint, KRuntimeRep, KLevity, KVecCount, KVecElem, KFun, KMeta, KType),
     RuntimeRep (..),
@@ -35,6 +37,7 @@ module Aihc.Tc.Types
     VecCount (..),
     VecElem (..),
     TypeScheme (..),
+    kindFromTypeScheme,
     boxedTupleTyConName,
     unboxedTupleTyConName,
     isUnboxedTupleType,
@@ -42,6 +45,7 @@ module Aihc.Tc.Types
     liftedTypeKind,
     typeKind,
     runtimeRepOfType,
+    runtimeRepFromType,
     isLiftedType,
     isUnliftedType,
 
@@ -56,7 +60,9 @@ module Aihc.Tc.Types
 where
 
 import Aihc.Resolve (PackageId (..))
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -104,7 +110,7 @@ instance Ord TyVarId where
 -- | Type constructor. Every constructor carries its fully applied kind so
 -- downstream phases can recover the kind of any 'TcType' without consulting
 -- the type-checker environment.
-data TyCon = TyConInternal !PackageId !Text !Text !Int !Kind
+data TyCon = TyConInternal !PackageId !Text !Text !Int !Kind !(Maybe TypeScheme)
   deriving (Show, Read)
 
 instance Eq TyCon where
@@ -119,20 +125,23 @@ instance Ord TyCon where
       (tyConPackageId right, tyConModuleName right, tyConName right, tyConArity right)
 
 pattern TyCon :: Text -> Int -> TyCon
-pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity _
+pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity _ _
   where
-    TyCon name arity = TyConInternal (PackageId "aihc-internal") "Aihc.Internal" name arity (wiredInTyConKind name arity)
+    TyCon name arity = TyConInternal (PackageId "aihc-internal") "Aihc.Internal" name arity (wiredInTyConKind name arity) Nothing
 
 {-# COMPLETE TyCon #-}
 
 tyConKind :: TyCon -> Kind
-tyConKind (TyConInternal _ _ _ _ kind) = kind
+tyConKind (TyConInternal _ _ _ _ kind _) = kind
+
+tyConKindScheme :: TyCon -> Maybe TypeScheme
+tyConKindScheme (TyConInternal _ _ _ _ _ scheme) = scheme
 
 tyConPackageId :: TyCon -> PackageId
-tyConPackageId (TyConInternal packageId _ _ _ _) = packageId
+tyConPackageId (TyConInternal packageId _ _ _ _ _) = packageId
 
 tyConModuleName :: TyCon -> Text
-tyConModuleName (TyConInternal _ moduleName _ _ _) = moduleName
+tyConModuleName (TyConInternal _ moduleName _ _ _ _) = moduleName
 
 mkTyCon :: Text -> Int -> Kind -> TyCon
 mkTyCon = mkTyConWithOrigin (PackageId "aihc-internal") "Aihc.Internal"
@@ -140,14 +149,19 @@ mkTyCon = mkTyConWithOrigin (PackageId "aihc-internal") "Aihc.Internal"
 -- | Make a type constructor with its installed package and module identity.
 mkTyConWithOrigin :: PackageId -> Text -> Text -> Int -> Kind -> TyCon
 mkTyConWithOrigin packageId moduleName name arity inferredKind =
-  TyConInternal packageId moduleName name arity (fromMaybe inferredKind (fixedTyConKind name))
+  TyConInternal packageId moduleName name arity (fromMaybe inferredKind (fixedTyConKind name)) Nothing
+
+-- | Make a type constructor whose standalone source signature is authoritative.
+mkTyConWithOriginAndKindScheme :: PackageId -> Text -> Text -> Int -> TypeScheme -> TyCon
+mkTyConWithOriginAndKindScheme packageId moduleName name arity scheme =
+  TyConInternal packageId moduleName name arity (kindFromTypeScheme scheme) (Just scheme)
 
 -- | Replace a type constructor's kind without applying wired-in defaults.
 -- This is used when reconstructing canonical System FC syntax, where the
 -- serialized kind is authoritative.
 setTyConKind :: Kind -> TyCon -> TyCon
-setTyConKind kind (TyConInternal packageId moduleName name arity _) =
-  TyConInternal packageId moduleName name arity kind
+setTyConKind kind (TyConInternal packageId moduleName name arity _ scheme) =
+  TyConInternal packageId moduleName name arity kind scheme
 
 -- | Kinds for the type language checked by @aihc-tc@.
 data Kind
@@ -260,14 +274,11 @@ typeKind ty =
   case ty of
     TcTyVar tyVar -> tvKind tyVar
     TcMetaTv {} -> liftedTypeKind
-    tupleType@(TcTyCon _ args)
-      | isUnboxedTupleType tupleType ->
-          KTYPE (TupleRep (map runtimeRepOrLifted args))
     TcTyCon tyCon args
       | isUnboxedSumTyCon (tyConName tyCon) (tyConArity tyCon),
         length args == tyConArity tyCon ->
           KTYPE (SumRep (map runtimeRepOrLifted args))
-      | otherwise -> applyKindArgumentCount (tyConKind tyCon) (length args)
+      | otherwise -> applyTyConKind tyCon args
     TcFunTy {} -> liftedTypeKind
     TcForAllTy _ body -> typeKind body
     TcQualTy _ body -> typeKind body
@@ -284,13 +295,88 @@ applyKindArgumentCount kind count
 applyKindArgumentCount (KFun _ result) count = applyKindArgumentCount result (count - 1)
 applyKindArgumentCount kind _ = kind
 
+applyTyConKind :: TyCon -> [TcType] -> Kind
+applyTyConKind tyCon = go Map.empty authoritativeKind
+  where
+    authoritativeKind = maybe (tyConKind tyCon) kindFromTypeScheme (tyConKindScheme tyCon)
+    quantified =
+      kindParameterRuntimeRepVariables authoritativeKind
+        <> maybe
+          Set.empty
+          (\(ForAll tyVars _ _) -> Set.fromList (map tvUnique tyVars))
+          (tyConKindScheme tyCon)
+
+    go substitution kind [] = substituteKindRuntimeReps substitution kind
+    go substitution (KFun formal result) (argument : arguments) =
+      let formal' = substituteKindRuntimeReps substitution formal
+          actual = typeKind argument
+          substitution' = matchKindRuntimeReps quantified formal' actual <> substitution
+       in go substitution' (substituteKindRuntimeReps substitution' result) arguments
+    go substitution kind _ = substituteKindRuntimeReps substitution kind
+
+kindParameterRuntimeRepVariables :: Kind -> Set.Set Unique
+kindParameterRuntimeRepVariables kind =
+  case kind of
+    KFun parameter result -> runtimeRepVariablesInKind parameter <> kindParameterRuntimeRepVariables result
+    _ -> Set.empty
+
+runtimeRepVariablesInKind :: Kind -> Set.Set Unique
+runtimeRepVariablesInKind kind =
+  case kind of
+    KTYPE runtimeRep -> runtimeRepVariables runtimeRep
+    KFun argument result -> runtimeRepVariablesInKind argument <> runtimeRepVariablesInKind result
+    _ -> Set.empty
+  where
+    runtimeRepVariables runtimeRep =
+      case runtimeRep of
+        RuntimeRepVar unique -> Set.singleton unique
+        TupleRep fields -> Set.unions (map runtimeRepVariables fields)
+        SumRep fields -> Set.unions (map runtimeRepVariables fields)
+        _ -> Set.empty
+
+matchKindRuntimeReps :: Set.Set Unique -> Kind -> Kind -> Map.Map Unique RuntimeRep
+matchKindRuntimeReps quantified formal actual =
+  case (formal, actual) of
+    (KTYPE formalRep, KTYPE actualRep) -> matchRuntimeRep formalRep actualRep
+    (KFun formalArgument formalResult, KFun actualArgument actualResult) ->
+      matchKindRuntimeReps quantified formalArgument actualArgument
+        <> matchKindRuntimeReps quantified formalResult actualResult
+    _ -> Map.empty
+  where
+    matchRuntimeRep formalRep actualRep =
+      case (formalRep, actualRep) of
+        (RuntimeRepVar unique, _)
+          | unique `Set.member` quantified -> Map.singleton unique actualRep
+        (TupleRep formalFields, TupleRep actualFields) ->
+          Map.unionsWith const (zipWith matchRuntimeRep formalFields actualFields)
+        (SumRep formalFields, SumRep actualFields) ->
+          Map.unionsWith const (zipWith matchRuntimeRep formalFields actualFields)
+        _ -> Map.empty
+
+substituteKindRuntimeReps :: Map.Map Unique RuntimeRep -> Kind -> Kind
+substituteKindRuntimeReps substitution kind =
+  case kind of
+    KTYPE runtimeRep -> KTYPE (substituteRuntimeRep runtimeRep)
+    KFun argument result ->
+      KFun
+        (substituteKindRuntimeReps substitution argument)
+        (substituteKindRuntimeReps substitution result)
+    _ -> kind
+  where
+    substituteRuntimeRep runtimeRep =
+      case runtimeRep of
+        RuntimeRepVar unique -> Map.findWithDefault runtimeRep unique substitution
+        TupleRep fields -> TupleRep (map substituteRuntimeRep fields)
+        SumRep fields -> SumRep (map substituteRuntimeRep fields)
+        _ -> runtimeRep
+
 -- | Test whether a constructed type has an explicit unboxed-tuple representation.
 isUnboxedTupleType :: TcType -> Bool
 isUnboxedTupleType (TcTyCon tyCon arguments) =
   let arity = length arguments
    in tyConName tyCon == unboxedTupleTyConName arity
         && arity == tyConArity tyCon
-        && case applyKindArgumentCount (tyConKind tyCon) (length arguments) of
+        && case applyTyConKind tyCon arguments of
           KTYPE (TupleRep fields) -> length fields == length arguments
           _ -> False
 isUnboxedTupleType _ = False
@@ -384,6 +470,108 @@ primitiveRuntimeRep name =
 -- represents @forall a b. Eq a => a -> b -> Bool@.
 data TypeScheme = ForAll ![TyVarId] ![Pred] !TcType
   deriving (Eq, Show, Read)
+
+kindFromTypeScheme :: TypeScheme -> Kind
+kindFromTypeScheme (ForAll _ _ body) = typeAsKind body
+
+typeAsKind :: TcType -> Kind
+typeAsKind ty =
+  case ty of
+    TcTyCon tyCon []
+      | tyConName tyCon `elem` ["*", "Type"] -> KType
+      | tyConName tyCon == "Constraint" -> KConstraint
+      | tyConName tyCon == "RuntimeRep" -> KRuntimeRep
+      | tyConName tyCon == "Levity" -> KLevity
+      | tyConName tyCon == "VecCount" -> KVecCount
+      | tyConName tyCon == "VecElem" -> KVecElem
+    TcTyCon tyCon [runtimeRep]
+      | tyConName tyCon == "TYPE" -> KTYPE (runtimeRepFromType runtimeRep)
+    TcFunTy argument result -> KFun (typeAsKind argument) (typeAsKind result)
+    TcForAllTy _ body -> typeAsKind body
+    TcMetaTv unique -> KMeta unique
+    TcTyVar tyVar -> tvKind tyVar
+    _ -> KType
+
+runtimeRepFromType :: TcType -> RuntimeRep
+runtimeRepFromType ty =
+  case ty of
+    TcTyVar tyVar -> RuntimeRepVar (tvUnique tyVar)
+    TcMetaTv unique -> RuntimeRepMeta unique
+    TcTyCon tyCon [] ->
+      fromMaybe liftedRuntimeRep (runtimeRepConstructorByName (tyConName tyCon))
+    TcTyCon tyCon [levity]
+      | bareName (tyConName tyCon) == "BoxedRep" -> BoxedRep (typeAsLevity levity)
+    TcTyCon tyCon [fields]
+      | bareName (tyConName tyCon) == "TupleRep" -> TupleRep (map runtimeRepFromType (promotedListItems fields))
+      | bareName (tyConName tyCon) == "SumRep" -> SumRep (map runtimeRepFromType (promotedListItems fields))
+    TcTyCon tyCon [count, element]
+      | bareName (tyConName tyCon) == "VecRep" -> VecRep (typeAsVecCount count) (typeAsVecElem element)
+    _ -> liftedRuntimeRep
+
+typeAsLevity :: TcType -> Levity
+typeAsLevity (TcTyCon tyCon [])
+  | bareName (tyConName tyCon) == "Unlifted" = Unlifted
+typeAsLevity _ = Lifted
+
+typeAsVecCount :: TcType -> VecCount
+typeAsVecCount (TcTyCon tyCon []) =
+  case bareName (tyConName tyCon) of
+    "Vec2" -> Vec2
+    "Vec4" -> Vec4
+    "Vec8" -> Vec8
+    "Vec16" -> Vec16
+    "Vec32" -> Vec32
+    "Vec64" -> Vec64
+    _ -> Vec2
+typeAsVecCount _ = Vec2
+
+typeAsVecElem :: TcType -> VecElem
+typeAsVecElem (TcTyCon tyCon []) =
+  fromMaybe Int8ElemRep (lookup (bareName (tyConName tyCon)) vecElemNames)
+typeAsVecElem _ = Int8ElemRep
+
+vecElemNames :: [(Text, VecElem)]
+vecElemNames =
+  [ ("Int8ElemRep", Int8ElemRep),
+    ("Int16ElemRep", Int16ElemRep),
+    ("Int32ElemRep", Int32ElemRep),
+    ("Int64ElemRep", Int64ElemRep),
+    ("Word8ElemRep", Word8ElemRep),
+    ("Word16ElemRep", Word16ElemRep),
+    ("Word32ElemRep", Word32ElemRep),
+    ("Word64ElemRep", Word64ElemRep),
+    ("FloatElemRep", FloatElemRep),
+    ("DoubleElemRep", DoubleElemRep)
+  ]
+
+promotedListItems :: TcType -> [TcType]
+promotedListItems (TcTyCon tyCon items)
+  | bareName (tyConName tyCon) == "[]" = items
+promotedListItems _ = []
+
+runtimeRepConstructorByName :: Text -> Maybe RuntimeRep
+runtimeRepConstructorByName name =
+  lookup
+    (bareName name)
+    [ ("LiftedRep", liftedRuntimeRep),
+      ("UnliftedRep", BoxedRep Unlifted),
+      ("IntRep", IntRep),
+      ("Int8Rep", Int8Rep),
+      ("Int16Rep", Int16Rep),
+      ("Int32Rep", Int32Rep),
+      ("Int64Rep", Int64Rep),
+      ("WordRep", WordRep),
+      ("Word8Rep", Word8Rep),
+      ("Word16Rep", Word16Rep),
+      ("Word32Rep", Word32Rep),
+      ("Word64Rep", Word64Rep),
+      ("AddrRep", AddrRep),
+      ("FloatRep", FloatRep),
+      ("DoubleRep", DoubleRep)
+    ]
+
+bareName :: Text -> Text
+bareName = T.dropWhile (== '\'')
 
 -- | A predicate (primitive constraint).
 --

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -29,8 +29,8 @@ module Aihc.Tc.Types
     tyConKindScheme,
     mkTyCon,
     mkTyConWithOrigin,
-    mkTyConWithOriginAndKindScheme,
-    setTyConKind,
+    mkTyConWithOriginScheme,
+    setTyConKindScheme,
     Kind (KTYPE, KConstraint, KRuntimeRep, KLevity, KVecCount, KVecElem, KFun, KMeta, KType),
     RuntimeRep (..),
     Levity (..),
@@ -107,10 +107,8 @@ instance Eq TyVarId where
 instance Ord TyVarId where
   compare a b = compare (tvUnique a) (tvUnique b)
 
--- | Type constructor. Every constructor carries its fully applied kind so
--- downstream phases can recover the kind of any 'TcType' without consulting
--- the type-checker environment.
-data TyCon = TyConInternal !PackageId !Text !Text !Int !Kind !(Maybe TypeScheme)
+-- | Type constructor. The kind scheme is the only stored kind representation.
+data TyCon = TyConInternal !PackageId !Text !Text !Int !TypeScheme
   deriving (Show, Read)
 
 instance Eq TyCon where
@@ -125,23 +123,29 @@ instance Ord TyCon where
       (tyConPackageId right, tyConModuleName right, tyConName right, tyConArity right)
 
 pattern TyCon :: Text -> Int -> TyCon
-pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity _ _
+pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity _
   where
-    TyCon name arity = TyConInternal (PackageId "aihc-internal") "Aihc.Internal" name arity (wiredInTyConKind name arity) Nothing
+    TyCon name arity =
+      TyConInternal
+        (PackageId "aihc-internal")
+        "Aihc.Internal"
+        name
+        arity
+        (kindSchemeFromKind (wiredInTyConKind name arity))
 
 {-# COMPLETE TyCon #-}
 
 tyConKind :: TyCon -> Kind
-tyConKind (TyConInternal _ _ _ _ kind _) = kind
+tyConKind = kindFromTypeScheme . tyConKindScheme
 
-tyConKindScheme :: TyCon -> Maybe TypeScheme
-tyConKindScheme (TyConInternal _ _ _ _ _ scheme) = scheme
+tyConKindScheme :: TyCon -> TypeScheme
+tyConKindScheme (TyConInternal _ _ _ _ scheme) = scheme
 
 tyConPackageId :: TyCon -> PackageId
-tyConPackageId (TyConInternal packageId _ _ _ _ _) = packageId
+tyConPackageId (TyConInternal packageId _ _ _ _) = packageId
 
 tyConModuleName :: TyCon -> Text
-tyConModuleName (TyConInternal _ moduleName _ _ _ _) = moduleName
+tyConModuleName (TyConInternal _ moduleName _ _ _) = moduleName
 
 mkTyCon :: Text -> Int -> Kind -> TyCon
 mkTyCon = mkTyConWithOrigin (PackageId "aihc-internal") "Aihc.Internal"
@@ -149,19 +153,16 @@ mkTyCon = mkTyConWithOrigin (PackageId "aihc-internal") "Aihc.Internal"
 -- | Make a type constructor with its installed package and module identity.
 mkTyConWithOrigin :: PackageId -> Text -> Text -> Int -> Kind -> TyCon
 mkTyConWithOrigin packageId moduleName name arity inferredKind =
-  TyConInternal packageId moduleName name arity (fromMaybe inferredKind (fixedTyConKind name)) Nothing
+  TyConInternal packageId moduleName name arity (kindSchemeFromKind (fromMaybe inferredKind (fixedTyConKind name)))
 
--- | Make a type constructor whose standalone source signature is authoritative.
-mkTyConWithOriginAndKindScheme :: PackageId -> Text -> Text -> Int -> TypeScheme -> TyCon
-mkTyConWithOriginAndKindScheme packageId moduleName name arity scheme =
-  TyConInternal packageId moduleName name arity (kindFromTypeScheme scheme) (Just scheme)
+-- | Make a type constructor from its authoritative kind scheme.
+mkTyConWithOriginScheme :: PackageId -> Text -> Text -> Int -> TypeScheme -> TyCon
+mkTyConWithOriginScheme = TyConInternal
 
--- | Replace a type constructor's kind without applying wired-in defaults.
--- This is used when reconstructing canonical System FC syntax, where the
--- serialized kind is authoritative.
-setTyConKind :: Kind -> TyCon -> TyCon
-setTyConKind kind (TyConInternal packageId moduleName name arity _ scheme) =
-  TyConInternal packageId moduleName name arity kind scheme
+-- | Replace a type constructor's authoritative kind scheme.
+setTyConKindScheme :: TypeScheme -> TyCon -> TyCon
+setTyConKindScheme scheme (TyConInternal packageId moduleName name arity _) =
+  TyConInternal packageId moduleName name arity scheme
 
 -- | Kinds for the type language checked by @aihc-tc@.
 data Kind
@@ -247,6 +248,8 @@ data TcType
     TcQualTy ![Pred] !TcType
   | -- | Unsaturated type application @f a@.
     TcAppTy !TcType !TcType
+  | -- | A primitive type constructor used to define kind schemes without a recursive 'TyCon'.
+    TcBuiltinTyCon !Text !Int ![TcType]
   deriving (Eq, Show, Read)
 
 -- | Whether a type has an unlifted runtime representation in the subset of
@@ -283,6 +286,8 @@ typeKind ty =
     TcForAllTy _ body -> typeKind body
     TcQualTy _ body -> typeKind body
     TcAppTy function _ -> applyKindArgumentCount (typeKind function) 1
+    TcBuiltinTyCon name arity arguments ->
+      applyKindArgumentCount (wiredInTyConKind name arity) (length arguments)
   where
     runtimeRepOrLifted argument =
       case runtimeRepOfType argument of
@@ -298,13 +303,11 @@ applyKindArgumentCount kind _ = kind
 applyTyConKind :: TyCon -> [TcType] -> Kind
 applyTyConKind tyCon = go Map.empty authoritativeKind
   where
-    authoritativeKind = maybe (tyConKind tyCon) kindFromTypeScheme (tyConKindScheme tyCon)
+    scheme@(ForAll kindTyVars _ _) = tyConKindScheme tyCon
+    authoritativeKind = kindFromTypeScheme scheme
     quantified =
       kindParameterRuntimeRepVariables authoritativeKind
-        <> maybe
-          Set.empty
-          (\(ForAll tyVars _ _) -> Set.fromList (map tvUnique tyVars))
-          (tyConKindScheme tyCon)
+        <> Set.fromList (map tvUnique kindTyVars)
 
     go substitution kind [] = substituteKindRuntimeReps substitution kind
     go substitution (KFun formal result) (argument : arguments) =
@@ -471,6 +474,60 @@ primitiveRuntimeRep name =
 data TypeScheme = ForAll ![TyVarId] ![Pred] !TcType
   deriving (Eq, Show, Read)
 
+kindSchemeFromKind :: Kind -> TypeScheme
+kindSchemeFromKind = ForAll [] [] . kindAsType
+
+kindAsType :: Kind -> TcType
+kindAsType kind =
+  case kind of
+    KTYPE runtimeRep
+      | runtimeRep == liftedRuntimeRep -> builtin "Type" 0 []
+      | otherwise -> builtin "TYPE" 1 [runtimeRepAsType runtimeRep]
+    KConstraint -> builtin "Constraint" 0 []
+    KRuntimeRep -> builtin "RuntimeRep" 0 []
+    KLevity -> builtin "Levity" 0 []
+    KVecCount -> builtin "VecCount" 0 []
+    KVecElem -> builtin "VecElem" 0 []
+    KMeta unique -> TcMetaTv unique
+    KFun argument result -> TcFunTy (kindAsType argument) (kindAsType result)
+  where
+    builtin = TcBuiltinTyCon
+
+runtimeRepAsType :: RuntimeRep -> TcType
+runtimeRepAsType runtimeRep =
+  case runtimeRep of
+    BoxedRep Lifted -> promoted "LiftedRep" 0 []
+    BoxedRep Unlifted -> promoted "UnliftedRep" 0 []
+    IntRep -> nullary "IntRep"
+    Int8Rep -> nullary "Int8Rep"
+    Int16Rep -> nullary "Int16Rep"
+    Int32Rep -> nullary "Int32Rep"
+    Int64Rep -> nullary "Int64Rep"
+    WordRep -> nullary "WordRep"
+    Word8Rep -> nullary "Word8Rep"
+    Word16Rep -> nullary "Word16Rep"
+    Word32Rep -> nullary "Word32Rep"
+    Word64Rep -> nullary "Word64Rep"
+    AddrRep -> nullary "AddrRep"
+    FloatRep -> nullary "FloatRep"
+    DoubleRep -> nullary "DoubleRep"
+    RuntimeRepVar unique ->
+      TcTyVar (setTyVarKind KRuntimeRep (TyVarId ("rep" <> T.pack (showUnique unique)) unique))
+    RuntimeRepMeta unique -> TcMetaTv unique
+    TupleRep fields -> promotedList "TupleRep" fields
+    SumRep fields -> promotedList "SumRep" fields
+    VecRep count element ->
+      promoted
+        "VecRep"
+        2
+        [nullary (T.pack (show count)), nullary (T.pack (show element))]
+  where
+    nullary name = promoted name 0 []
+    promoted name = TcBuiltinTyCon ("'" <> name)
+    promotedList name fields =
+      promoted name 1 [promoted "[]" (length fields) (map runtimeRepAsType fields)]
+    showUnique (Unique value) = show value
+
 kindFromTypeScheme :: TypeScheme -> Kind
 kindFromTypeScheme (ForAll _ _ body) = typeAsKind body
 
@@ -490,6 +547,20 @@ typeAsKind ty =
     TcForAllTy _ body -> typeAsKind body
     TcMetaTv unique -> KMeta unique
     TcTyVar tyVar -> tvKind tyVar
+    TcBuiltinTyCon name _ arguments -> typeAsBuiltinKind name arguments
+    _ -> KType
+
+typeAsBuiltinKind :: Text -> [TcType] -> Kind
+typeAsBuiltinKind name arguments =
+  case (bareName name, arguments) of
+    ("*", []) -> KType
+    ("Type", []) -> KType
+    ("Constraint", []) -> KConstraint
+    ("RuntimeRep", []) -> KRuntimeRep
+    ("Levity", []) -> KLevity
+    ("VecCount", []) -> KVecCount
+    ("VecElem", []) -> KVecElem
+    ("TYPE", [runtimeRep]) -> KTYPE (runtimeRepFromType runtimeRep)
     _ -> KType
 
 runtimeRepFromType :: TcType -> RuntimeRep
@@ -506,11 +577,24 @@ runtimeRepFromType ty =
       | bareName (tyConName tyCon) == "SumRep" -> SumRep (map runtimeRepFromType (promotedListItems fields))
     TcTyCon tyCon [count, element]
       | bareName (tyConName tyCon) == "VecRep" -> VecRep (typeAsVecCount count) (typeAsVecElem element)
+    TcBuiltinTyCon name _ arguments -> runtimeRepFromBuiltin name arguments
+    _ -> liftedRuntimeRep
+
+runtimeRepFromBuiltin :: Text -> [TcType] -> RuntimeRep
+runtimeRepFromBuiltin name arguments =
+  case (bareName name, arguments) of
+    ("BoxedRep", [levity]) -> BoxedRep (typeAsLevity levity)
+    ("TupleRep", [fields]) -> TupleRep (map runtimeRepFromType (promotedListItems fields))
+    ("SumRep", [fields]) -> SumRep (map runtimeRepFromType (promotedListItems fields))
+    ("VecRep", [count, element]) -> VecRep (typeAsVecCount count) (typeAsVecElem element)
+    (constructor, []) -> fromMaybe liftedRuntimeRep (runtimeRepConstructorByName constructor)
     _ -> liftedRuntimeRep
 
 typeAsLevity :: TcType -> Levity
 typeAsLevity (TcTyCon tyCon [])
   | bareName (tyConName tyCon) == "Unlifted" = Unlifted
+typeAsLevity (TcBuiltinTyCon name _ [])
+  | bareName name == "Unlifted" = Unlifted
 typeAsLevity _ = Lifted
 
 typeAsVecCount :: TcType -> VecCount
@@ -523,11 +607,25 @@ typeAsVecCount (TcTyCon tyCon []) =
     "Vec32" -> Vec32
     "Vec64" -> Vec64
     _ -> Vec2
+typeAsVecCount (TcBuiltinTyCon name _ []) = typeAsVecCountName (bareName name)
 typeAsVecCount _ = Vec2
+
+typeAsVecCountName :: Text -> VecCount
+typeAsVecCountName name =
+  case name of
+    "Vec2" -> Vec2
+    "Vec4" -> Vec4
+    "Vec8" -> Vec8
+    "Vec16" -> Vec16
+    "Vec32" -> Vec32
+    "Vec64" -> Vec64
+    _ -> Vec2
 
 typeAsVecElem :: TcType -> VecElem
 typeAsVecElem (TcTyCon tyCon []) =
   fromMaybe Int8ElemRep (lookup (bareName (tyConName tyCon)) vecElemNames)
+typeAsVecElem (TcBuiltinTyCon name _ []) =
+  fromMaybe Int8ElemRep (lookup (bareName name) vecElemNames)
 typeAsVecElem _ = Int8ElemRep
 
 vecElemNames :: [(Text, VecElem)]
@@ -547,6 +645,8 @@ vecElemNames =
 promotedListItems :: TcType -> [TcType]
 promotedListItems (TcTyCon tyCon items)
   | bareName (tyConName tyCon) == "[]" = items
+promotedListItems (TcBuiltinTyCon name _ items)
+  | bareName name == "[]" = items
 promotedListItems _ = []
 
 runtimeRepConstructorByName :: Text -> Maybe RuntimeRep

--- a/components/aihc-tc/src/Aihc/Tc/Unify.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Unify.hs
@@ -86,6 +86,7 @@ occursIn u = go
     go (TcForAllTy _ body) = go body
     go (TcQualTy preds body) = any goPred preds || go body
     go (TcAppTy f a) = go f || go a
+    go (TcBuiltinTyCon _ _ arguments) = any go arguments
 
     goPred (ClassPred _ args) = any go args
     goPred (EqPred a b) = go a || go b

--- a/components/aihc-tc/src/Aihc/Tc/Zonk.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Zonk.hs
@@ -8,12 +8,13 @@ module Aihc.Tc.Zonk
     zonkPred,
     defaultTypeKinds,
     defaultTypeSchemeKinds,
+    defaultTyConKindScheme,
     defaultPredKinds,
     defaultTyVarKinds,
   )
 where
 
-import Aihc.Tc.Kind (defaultKindMetas, runtimeRepToTcType, zonkKind)
+import Aihc.Tc.Kind (defaultKindMetas, kindToTcType, runtimeRepToTcType, zonkKind)
 import Aihc.Tc.Monad (TcM, readMetaTv, readRuntimeRepDependency, writeMetaTv)
 import Aihc.Tc.Types
 
@@ -28,12 +29,20 @@ zonkType ty = case ty of
     resolveRuntimeRepDependency u resolved
   TcTyVar tv -> TcTyVar <$> zonkTyVar tv
   TcTyCon tc args -> do
-    kind <- zonkKind (tyConKind tc)
-    TcTyCon (finalizeTyConKind kind tc) <$> mapM zonkType args
+    kindScheme <- zonkTyConKindScheme (tyConKindScheme tc)
+    TcTyCon (setTyConKindScheme kindScheme tc) <$> mapM zonkType args
   TcFunTy a b -> TcFunTy <$> zonkType a <*> zonkType b
   TcForAllTy tv body -> TcForAllTy <$> zonkTyVar tv <*> zonkType body
   TcQualTy preds body -> TcQualTy <$> mapM zonkPred preds <*> zonkType body
   TcAppTy f a -> TcAppTy <$> zonkType f <*> zonkType a
+  TcBuiltinTyCon name arity arguments -> TcBuiltinTyCon name arity <$> mapM zonkType arguments
+
+zonkTyConKindScheme :: TypeScheme -> TcM TypeScheme
+zonkTyConKindScheme scheme@(ForAll tyVars predicates _) = do
+  tyVars' <- mapM zonkTyVar tyVars
+  predicates' <- mapM zonkPred predicates
+  kind <- zonkKind (kindFromTypeScheme scheme)
+  pure (ForAll tyVars' predicates' (kindToTcType kind))
 
 resolveRuntimeRepDependency :: Unique -> TcType -> TcM TcType
 resolveRuntimeRepDependency unique unresolved@(TcMetaTv unresolvedUnique)
@@ -63,6 +72,7 @@ containsMetaVariable ty =
     TcForAllTy _ body -> containsMetaVariable body
     TcQualTy predicates body -> any containsMetaPred predicates || containsMetaVariable body
     TcAppTy function argument -> containsMetaVariable function || containsMetaVariable argument
+    TcBuiltinTyCon _ _ arguments -> any containsMetaVariable arguments
   where
     containsMetaPred predicate =
       case predicate of
@@ -88,25 +98,14 @@ defaultTypeKinds ty =
     TcMetaTv {} -> pure ty
     TcTyVar tv -> TcTyVar <$> defaultTyVarKinds tv
     TcTyCon tyCon args -> do
-      kind <- defaultKindMetas (tyConKind tyCon)
-      let tyCon' = finalizeTyConKind kind tyCon
+      kindScheme <- defaultTyConKindScheme (tyConKindScheme tyCon)
+      let tyCon' = setTyConKindScheme kindScheme tyCon
       TcTyCon tyCon' <$> mapM defaultTypeKinds args
     TcFunTy argument result -> TcFunTy <$> defaultTypeKinds argument <*> defaultTypeKinds result
     TcForAllTy tv body -> TcForAllTy <$> defaultTyVarKinds tv <*> defaultTypeKinds body
     TcQualTy predicates body -> TcQualTy <$> mapM defaultPredKinds predicates <*> defaultTypeKinds body
     TcAppTy function argument -> TcAppTy <$> defaultTypeKinds function <*> defaultTypeKinds argument
-
-finalizeTyConKind :: Kind -> TyCon -> TyCon
-finalizeTyConKind kind tyCon =
-  case tyConKindScheme tyCon of
-    Just _ -> setTyConKind kind tyCon
-    Nothing ->
-      mkTyConWithOrigin
-        (tyConPackageId tyCon)
-        (tyConModuleName tyCon)
-        (tyConName tyCon)
-        (tyConArity tyCon)
-        kind
+    TcBuiltinTyCon name arity arguments -> TcBuiltinTyCon name arity <$> mapM defaultTypeKinds arguments
 
 defaultTypeSchemeKinds :: TypeScheme -> TcM TypeScheme
 defaultTypeSchemeKinds (ForAll tyVars predicates body) =
@@ -114,6 +113,13 @@ defaultTypeSchemeKinds (ForAll tyVars predicates body) =
     <$> mapM defaultTyVarKinds tyVars
     <*> mapM defaultPredKinds predicates
     <*> defaultTypeKinds body
+
+defaultTyConKindScheme :: TypeScheme -> TcM TypeScheme
+defaultTyConKindScheme scheme@(ForAll tyVars predicates _) = do
+  tyVars' <- mapM defaultTyVarKinds tyVars
+  predicates' <- mapM defaultPredKinds predicates
+  kind <- defaultKindMetas (kindFromTypeScheme scheme)
+  pure (ForAll tyVars' predicates' (kindToTcType kind))
 
 defaultPredKinds :: Pred -> TcM Pred
 defaultPredKinds predicate =

--- a/components/aihc-tc/src/Aihc/Tc/Zonk.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Zonk.hs
@@ -98,12 +98,15 @@ defaultTypeKinds ty =
 
 finalizeTyConKind :: Kind -> TyCon -> TyCon
 finalizeTyConKind kind tyCon =
-  mkTyConWithOrigin
-    (tyConPackageId tyCon)
-    (tyConModuleName tyCon)
-    (tyConName tyCon)
-    (tyConArity tyCon)
-    kind
+  case tyConKindScheme tyCon of
+    Just _ -> setTyConKind kind tyCon
+    Nothing ->
+      mkTyConWithOrigin
+        (tyConPackageId tyCon)
+        (tyConModuleName tyCon)
+        (tyConName tyCon)
+        (tyConArity tyCon)
+        kind
 
 defaultTypeSchemeKinds :: TypeScheme -> TcM TypeScheme
 defaultTypeSchemeKinds (ForAll tyVars predicates body) =

--- a/components/aihc-tc/test/Test/Fixtures/annotated/nested-unboxed-tuple-type-synonym.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/nested-unboxed-tuple-type-synonym.yaml
@@ -1,0 +1,16 @@
+extensions:
+  - UnboxedTuples
+modules:
+  - |
+    module Test where
+    data Void
+    type X = (# (# #), Void #)
+annotated:
+  - |-
+    module Test where
+    data Void
+         └─ type: *
+    type X = (# (# #), Void #)
+         └─ type: TYPE ('TupleRep ('[] ('TupleRep '[]) 'LiftedRep))
+status: pass
+reason: preserves nested tuple and lifted field runtime representations in an inferred synonym kind

--- a/components/aihc-tc/test/Test/Fixtures/annotated/standalone-kind-signature.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/standalone-kind-signature.yaml
@@ -1,0 +1,20 @@
+extensions:
+  - DataKinds
+  - KindSignatures
+  - MagicHash
+  - StandaloneKindSignatures
+  - UnboxedTuples
+modules:
+  - |
+    module Test where
+    type Tuple2# :: TYPE r1 -> TYPE r2 -> TYPE ('TupleRep '[r2, r1])
+    data Tuple2# (a1 :: TYPE r1) (a2 :: TYPE r2) = (# a1, a2 #)
+annotated:
+  - |-
+    module Test where
+    type Tuple2# :: TYPE r1 -> TYPE r2 -> TYPE ('TupleRep '[r2, r1])
+    data Tuple2# (a1 :: TYPE r1) (a2 :: TYPE r2) = (# a1, a2 #)
+         │                                         └─ type: ∀ r1 r2 a1 a2. a1 → a2 → (# a1, a2 #)
+         └─ type: TYPE rep0 → TYPE rep1 → TYPE ('TupleRep ('[] rep1 rep0))
+status: pass
+reason: uses the standalone kind signature as the type constructor kind

--- a/components/aihc-tc/test/Test/Fixtures/annotated/top-level-unlifted-bindings.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/top-level-unlifted-bindings.yaml
@@ -21,7 +21,7 @@ annotated:
   - |-
     module Test where
     data State# s
-         └─ type: * → *
+         └─ type: * → TYPE ('TupleRep '[])
     data RealWorld
          └─ type: *
     data Box# = MkBox#

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym-parameterized.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym-parameterized.yaml
@@ -17,7 +17,9 @@ annotated:
          │      └─ type: Bool
          └─ type: *
     type Pair a b = (a, b)
+         └─ type: * → * → *
     type Wrapped a = Box a
+         └─ type: * → *
     data Box a = Box a
          │       └─ type: ∀ a. a → Box a
          └─ type: * → *

--- a/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/type-synonym.yaml
@@ -10,6 +10,7 @@ annotated:
   - |-
     module Test where
     type MyBool = Bool
+         └─ type: *
     data Bool = True | False
          │      │      └─ type: Bool
          │      └─ type: Bool

--- a/components/aihc-tc/test/Test/Fixtures/annotated/unboxed-unit-type-synonym.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/unboxed-unit-type-synonym.yaml
@@ -1,0 +1,12 @@
+extensions:
+  - UnboxedTuples
+modules:
+  - |
+    module Test where
+    type Nil = (# #)
+annotated:
+  - |-
+    module Test where
+    type Nil = (# #)
+status: pass
+reason: infers TYPE (TupleRep []) for an unboxed unit type synonym

--- a/components/aihc-tc/test/Test/Fixtures/annotated/unboxed-unit-type-synonym.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/unboxed-unit-type-synonym.yaml
@@ -8,5 +8,6 @@ annotated:
   - |-
     module Test where
     type Nil = (# #)
+         └─ type: TYPE ('TupleRep '[])
 status: pass
 reason: infers TYPE (TupleRep []) for an unboxed unit type synonym

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -488,6 +488,26 @@ kindTests =
                 (typeKind (TcTyCon tupleTyCon [intHash, wordHash]))
             other -> assertFailure ("expected one Tuple2# type constructor, got: " <> show other)
         ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
+    testCase "infers the unboxed unit type synonym kind" $ do
+      let source =
+            "{-# LANGUAGE UnboxedTuples #-}\n\
+            \module Test where\n\
+            \type Nil = (# #)\n"
+      case resolveModules [parseOnly source] of
+        ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
+          let (checkedModules, interface) = typecheckModuleSccWithInterface mempty (map snd modules)
+              nilTyCons = [tciTyCon info | info <- tcInterfaceTyCons interface, tciName info == "Nil"]
+          assertBool
+            ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules))
+            (all tcModuleSuccess checkedModules)
+          case nilTyCons of
+            [nilTyCon] ->
+              assertEqual
+                "inferred kind"
+                (KTYPE (TupleRep []))
+                (tyConKind nilTyCon)
+            other -> assertFailure ("expected one Nil type constructor, got: " <> show other)
+        ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
     testCase "accepts GHC's levity-polymorphic casMutVar# type" $ do
       let result =
             typecheckModule $

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -437,6 +437,57 @@ kindTests =
           assertEqual "result representation argument" repVar resultRepVar
           assertEqual "result value argument" valueVar resultValueVar
         other -> assertFailure ("unexpected R constructor types: " <> show other),
+    testCase "stores an ordinary standalone kind signature" $ do
+      let source =
+            "{-# LANGUAGE StandaloneKindSignatures #-}\n\
+            \module Test where\n\
+            \type Identity :: Type -> Type\n\
+            \type Identity a = a\n"
+      case resolveModules [parseOnly source] of
+        ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
+          let (checkedModules, interface) = typecheckModuleSccWithInterface mempty (map snd modules)
+              identityTyCons = [tciTyCon info | info <- tcInterfaceTyCons interface, tciName info == "Identity"]
+          assertBool
+            ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules))
+            (all tcModuleSuccess checkedModules)
+          assertEqual
+            "interface serialization round-trip"
+            (show interface)
+            (show (read (show interface) :: TcInterface))
+          case identityTyCons of
+            [identityTyCon] -> do
+              assertEqual "kind" (KFun KType KType) (tyConKind identityTyCon)
+              assertBool "kind scheme should be stored" (isJust (tyConKindScheme identityTyCon))
+            other -> assertFailure ("expected one Identity type constructor, got: " <> show other)
+        ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
+    testCase "uses the standalone kind signature representation" $ do
+      let source =
+            "{-# LANGUAGE DataKinds #-}\n\
+            \{-# LANGUAGE KindSignatures #-}\n\
+            \{-# LANGUAGE MagicHash #-}\n\
+            \{-# LANGUAGE StandaloneKindSignatures #-}\n\
+            \{-# LANGUAGE UnboxedTuples #-}\n\
+            \module Test where\n\
+            \type Tuple2# :: TYPE r1 -> TYPE r2 -> TYPE ('TupleRep '[r2, r1])\n\
+            \data Tuple2# (a1 :: TYPE r1) (a2 :: TYPE r2) = (# a1, a2 #)\n\
+            \data Holder = Holder (Tuple2# Int# Word#)\n"
+      case resolveModules [parseOnly source] of
+        ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
+          let (checkedModules, interface) = typecheckModuleSccWithInterface mempty (map snd modules)
+              tupleTyCons = [tciTyCon info | info <- tcInterfaceTyCons interface, tciName info == "Tuple2#"]
+              intHash = TcTyCon (TyCon "Int#" 0) []
+              wordHash = TcTyCon (TyCon "Word#" 0) []
+          assertBool
+            ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules))
+            (all tcModuleSuccess checkedModules)
+          case tupleTyCons of
+            [tupleTyCon] ->
+              assertEqual
+                "source representation"
+                (KTYPE (TupleRep [WordRep, IntRep]))
+                (typeKind (TcTyCon tupleTyCon [intHash, wordHash]))
+            other -> assertFailure ("expected one Tuple2# type constructor, got: " <> show other)
+        ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
     testCase "accepts GHC's levity-polymorphic casMutVar# type" $ do
       let result =
             typecheckModule $

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -42,7 +42,7 @@ import Aihc.Tc.Instantiate (Instantiation (..), instantiateWithArgs)
 import Aihc.Tc.Kind (freeTypeVars)
 import Aihc.Tc.Monad (emptyTcEnv, initTcState, runTcM)
 import Aihc.Tc.TypeScheme (equivalentTypeSchemes, parseTypeScheme)
-import Aihc.Tc.Types (mkTyCon, tyConModuleName, tyConPackageId)
+import Aihc.Tc.Types (kindFromTypeScheme, mkTyCon, tyConModuleName, tyConPackageId)
 import Aihc.Tc.Unify (unifyTypes)
 import Aihc.Tc.Zonk (zonkType)
 import Data.Data (Data, gmapQ)
@@ -457,7 +457,7 @@ kindTests =
           case identityTyCons of
             [identityTyCon] -> do
               assertEqual "kind" (KFun KType KType) (tyConKind identityTyCon)
-              assertBool "kind scheme should be stored" (isJust (tyConKindScheme identityTyCon))
+              assertEqual "stored kind scheme" (KFun KType KType) (kindFromTypeScheme (tyConKindScheme identityTyCon))
             other -> assertFailure ("expected one Identity type constructor, got: " <> show other)
         ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
     testCase "uses the standalone kind signature representation" $ do
@@ -603,6 +603,7 @@ kindTests =
         TcForAllTy tv body -> kindHasMeta (tvKind tv) || hasKindMeta body
         TcQualTy predicates body -> any predHasKindMeta predicates || hasKindMeta body
         TcAppTy function argument -> hasKindMeta function || hasKindMeta argument
+        TcBuiltinTyCon _ _ arguments -> any hasKindMeta arguments
     predHasKindMeta predicate =
       case predicate of
         ClassPred _ args -> any hasKindMeta args
@@ -1028,6 +1029,7 @@ hasMetaTcType ty =
     TcQualTy preds body -> any hasMetaPred preds || hasMetaTcType body
     TcAppTy fun arg -> hasMetaTcType fun || hasMetaTcType arg
     TcTyVar {} -> False
+    TcBuiltinTyCon _ _ arguments -> any hasMetaTcType arguments
   where
     hasMetaPred (ClassPred _ args) = any hasMetaTcType args
     hasMetaPred (EqPred left right) = hasMetaTcType left || hasMetaTcType right

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -488,26 +488,6 @@ kindTests =
                 (typeKind (TcTyCon tupleTyCon [intHash, wordHash]))
             other -> assertFailure ("expected one Tuple2# type constructor, got: " <> show other)
         ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
-    testCase "infers the unboxed unit type synonym kind" $ do
-      let source =
-            "{-# LANGUAGE UnboxedTuples #-}\n\
-            \module Test where\n\
-            \type Nil = (# #)\n"
-      case resolveModules [parseOnly source] of
-        ResolveResult {resolvedModules = modules, resolveErrors = []} -> do
-          let (checkedModules, interface) = typecheckModuleSccWithInterface mempty (map snd modules)
-              nilTyCons = [tciTyCon info | info <- tcInterfaceTyCons interface, tciName info == "Nil"]
-          assertBool
-            ("module should typecheck, got: " <> show (concatMap tcModuleDiagnostics checkedModules))
-            (all tcModuleSuccess checkedModules)
-          case nilTyCons of
-            [nilTyCon] ->
-              assertEqual
-                "inferred kind"
-                (KTYPE (TupleRep []))
-                (tyConKind nilTyCon)
-            other -> assertFailure ("expected one Nil type constructor, got: " <> show other)
-        ResolveResult {resolveErrors} -> assertFailure ("module should resolve, got: " <> show resolveErrors),
     testCase "accepts GHC's levity-polymorphic casMutVar# type" $ do
       let result =
             typecheckModule $

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -366,7 +366,12 @@ loadDependencyModules tc evalModules = do
   let dependencies = evalCaseDependencies tc
       transitiveDependencies = nub (dependencies <> ["aihc-prim"])
       initialModules
-        | null dependencies = ["GHC.Tuple"]
+        | null dependencies =
+            "GHC.Tuple"
+              : [ "GHC.Types"
+                | Just unboxedTuples <- [parseExtensionName "UnboxedTuples"],
+                  unboxedTuples `elem` evalCaseExtensions tc
+                ]
         | otherwise = initialDependencyModules evalModules
   roots <- traverse resolveDependencyRoot transitiveDependencies
   case sequence roots of


### PR DESCRIPTION
## Summary

- Resolve standalone kind signatures for all type constructors.
- Store one mandatory kind type scheme on each type constructor.
- Remove the duplicate kind field from type constructors and type constructor information.
- Instantiate kind schemes for type constructor applications.
- Use the source signature to calculate unboxed tuple representations.
- Infer type-synonym result kinds from their bodies.
- Print inferred kinds on type-synonym declarations.
- Remove tuple-specific declaration kind construction.
- Preserve structured tuple, sum, and vector runtime representations.
- Add source fixtures and unit tests for declared and inferred kinds.

## Design

Kinds use the existing type representation.
`Kind` remains a temporary form for unification and runtime representation checks.
It is not stored as type constructor metadata.

## Root cause

The type checker ignored standalone kind signatures.
It rebuilt unboxed tuple representations from tuple arguments.
It also forced type-synonym results to lifted `Type`.
Type-synonym declarations did not receive type-checker annotations.

## Validation

- `just fmt`
- `just check`

## Progress counts

The type-checker annotated golden count increases from 75 to 78.
The type-checker unit count increases from 44 to 46.
No compiler progress counts change.