### PR TITLE
refactor(tc): load list constructor types from GHC.Types

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -289,15 +289,15 @@ main =
             boolStep <- handleReplInput session ":t (+) (1::Bool)"
             assertEqual "missing concrete instance" (ReplContinue (Just "type error: no instance for Num Bool")) boolStep,
           testCase "evaluates string expressions through the pipeline" $ do
-            session <- testReplSession
+            session <- loadReplSession Nothing
             step <- handleReplInput session "\"hello world\""
             assertEqual "step" (ReplContinue (Just "\"hello world\"")) step,
           testCase "evaluates let-bound strings through the pipeline" $ do
-            session <- testReplSession
+            session <- loadReplSession Nothing
             step <- handleReplInput session "let a = \"hello world\" in a"
             assertEqual "step" (ReplContinue (Just "\"hello world\"")) step,
           testCase "evaluateExpression returns string values" $ do
-            session <- testReplSession
+            session <- loadReplSession Nothing
             result <- evaluateExpression session "\"hello world\""
             assertEqual "result" (Right "\"hello world\"") result,
           testCase "evaluateExpression reports parse errors" $ do
@@ -305,7 +305,7 @@ main =
             result <- evaluateExpression session "1 +"
             assertEqual "result" (Left ReplParseError) result,
           testCase "sets evaluation detail output from the repl" $ do
-            session <- testReplSession
+            session <- loadReplSession Nothing
             setStep <- handleReplInput session ":set +pretty"
             assertEqual "set step" (ReplContinue (Just "settings: +parsed-pretty -parsed-shorthand -type -system-fc")) setStep
             setStep2 <- handleReplInput session ":set +shorthand"
@@ -318,7 +318,7 @@ main =
                 assertBool "expected final value" ("\"hello\"" `isSuffixOf` output)
               other -> assertFailure ("expected output, got " <> show other),
           testCase "sets type and system-fc output from the repl" $ do
-            session <- testReplSession
+            session <- loadReplSession Nothing
             _ <- handleReplInput session ":set +type"
             _ <- handleReplInput session ":set +fc"
             result <- evaluateExpression session "\"hello\""
@@ -734,7 +734,7 @@ test_reportsTypeCheckErrorsAndWritesNoArtifacts =
   withTempDir "aihc-cli" $ \root -> do
     let sourceRoot = root </> "source"
         storeRoot = root </> "store"
-    createFixturePackageWithSource sourceRoot "demo" "0.1.0.0" "Demo" [] "module Demo where\nx = [(), 'a']\n"
+    createFixturePackageWithSource sourceRoot "demo" "0.1.0.0" "Demo" [] "module Demo where\ndata List a = [] | a : [a]\nx = [(), 'a']\n"
     createDirectoryIfMissing True storeRoot
     plan <- buildPackagePlanFromSource storeRoot (PackageSpec "demo" "0.1.0.0") sourceRoot
 

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -25,7 +25,7 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax (Extension, Module, parseExtensionName)
-import Aihc.Resolve (PackageId (..), ResolveResult (..), modulesInPackage, resolveWithDeps, unnamedPackage)
+import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
 import Aihc.Tc (TcBindingResult, TcInterface (..), emptyTcInterface, tcModuleBindings, tcModuleDiagnostics, tcModuleSuccess, typecheckModulesWithInterface)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
@@ -74,7 +74,7 @@ loadFcCases = do
     then pure []
     else do
       paths <- listFixtureFiles fixtureRoot
-      mapM (loadFcCase [tupleSupportModule]) paths
+      mapM (loadFcCase [listSupportModule, tupleSupportModule]) paths
 
 -- Golden modules deliberately omit core-library dependencies. Keep their
 -- primitive tuple support source-defined while limiting the fixture to the
@@ -85,6 +85,14 @@ tupleSupportModule =
     [ "module GHC.Tuple where",
       "data Unit = ()",
       "data Tuple2 a b = (a, b)"
+    ]
+
+listSupportModule :: Text
+listSupportModule =
+  T.unlines
+    [ "module GHC.Types (List(..)) where",
+      "data List a = [] | a : [a]",
+      "infixr 5 :"
     ]
 
 loadFcCase :: [Text] -> FilePath -> IO FcCase
@@ -151,12 +159,12 @@ evaluateFcCase tc =
 
 renderFcCase :: FcCase -> Either String String
 renderFcCase tc =
-  let supportModuleCount = length (caseSupportModules tc)
-      parsedModules = map parseOne (caseSupportModules tc <> caseModules tc)
+  let supportModuleCount = length supportModules
+      parsedModules = map parseOne (supportModules <> caseModules tc)
    in case sequence parsedModules of
         Left errMsg -> Left ("parse error: " <> errMsg)
         Right modules ->
-          case resolveWithDeps mempty (modulesInPackage unnamedPackage modules) of
+          case resolveWithDeps mempty (zipWith modulePackage [0 :: Int ..] modules) of
             ResolveResult {resolvedModules, resolveErrors = []} ->
               let moduleAsts = map snd resolvedModules
                   (tcResults, tcInterface) = typecheckModulesWithInterface emptyTcInterface moduleAsts
@@ -175,6 +183,13 @@ renderFcCase tc =
             ResolveResult {resolveErrors} ->
               Left ("resolve error: " <> show resolveErrors)
   where
+    hasFixtureGhcTypes = any (T.isPrefixOf "module GHC.Types" . T.stripStart) (caseModules tc)
+    hasListSupport = not hasFixtureGhcTypes
+    supportModules = if hasFixtureGhcTypes then drop 1 (caseSupportModules tc) else caseSupportModules tc
+    modulePackage index modu
+      | hasListSupport && index == 0 =
+          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
+      | otherwise = (unnamedPackage, modu)
     parseOne input =
       let config =
             defaultConfig

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -117,7 +117,7 @@ desugarModuleWithDataTypes config bindings dataTypes tcResult =
           dsErrors = showTcFailure tcResult
         }
     else
-      let typeEnv = Map.fromList (builtinTypeEntries <> concatMap bindingTypeEntries bindings)
+      let typeEnv = Map.fromList (concatMap bindingTypeEntries bindings)
           (packageId, currentModuleName) = resolvedModuleOrigin tcResult
           constructorFields =
             Map.fromList
@@ -274,16 +274,6 @@ showTcFailure tcResult =
 bindingTypeEntries :: TcBindingResult -> [(Text, TcType)]
 bindingTypeEntries b =
   [(tbName b, tbType b)]
-
-builtinTypeEntries :: [(Text, TcType)]
-builtinTypeEntries =
-  [ (":", TcForAllTy aVar (TcFunTy aTy (TcFunTy listA listA))),
-    ("[]", TcForAllTy aVar listA)
-  ]
-  where
-    aVar = TyVarId "a" (Unique (-1000))
-    aTy = TcTyVar aVar
-    listA = TcTyCon (TyCon "[]" 1) [aTy]
 
 -- | Desugar a module's declarations.
 dsModule :: Module -> DsM [FcTopBind]

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1269,8 +1269,10 @@ dsLocalGroup var group =
       pure (var, rhs')
 
 dsStringLiteral :: Text -> DsM FcExpr
-dsStringLiteral text =
-  pure (T.foldr consChar (nilList charTy) text)
+dsStringLiteral text = do
+  nil <- nilList charTy
+  cons <- consExpr charTy
+  pure (T.foldr (applyConsChar cons) nil text)
 
 primitiveStringBytes :: Text -> DsM BS.ByteString
 primitiveStringBytes text =
@@ -1286,14 +1288,18 @@ dsList :: TcAnnotation -> [Expr] -> DsM FcExpr
 dsList tcAnn elems =
   case tcAnnTypeArgs tcAnn of
     [elemTy] ->
-      foldr (consList elemTy) (nilList elemTy) <$> mapM dsExpr elems
+      do
+        nil <- nilList elemTy
+        cons <- consExpr elemTy
+        foldr (applyCons cons) nil <$> mapM dsExpr elems
     elemTys ->
       desugarBug ("list annotation arity mismatch: expected 1 type argument, got " <> show (length elemTys))
 
 dsListComp :: TcAnnotation -> Expr -> [CompStmt] -> DsM FcExpr
 dsListComp tcAnn body quals = do
   elemTy <- listCompElemTy tcAnn
-  dsCompQuals elemTy body quals (nilList elemTy)
+  nil <- nilList elemTy
+  dsCompQuals elemTy body quals nil
 
 listCompElemTy :: TcAnnotation -> DsM TcType
 listCompElemTy tcAnn =
@@ -1308,7 +1314,8 @@ dsCompQuals elemTy body quals tailExpr =
   case quals of
     [] -> do
       body' <- dsExpr body
-      pure (consList elemTy body' tailExpr)
+      cons <- consExpr elemTy
+      pure (applyCons cons body' tailExpr)
     qual : rest ->
       case peelCompStmtAnn qual of
         CompGen pat src -> dsCompGen elemTy body pat src rest tailExpr
@@ -1519,9 +1526,9 @@ tupleConName flavor arity =
     Boxed -> "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
     Unboxed -> "(#" <> T.replicate (max 0 (arity - 1)) "," <> "#)"
 
-consChar :: Char -> FcExpr -> FcExpr
-consChar char =
-  consList charTy (boxCharLiteral char)
+applyConsChar :: FcExpr -> Char -> FcExpr -> FcExpr
+applyConsChar cons char =
+  applyCons cons (boxCharLiteral char)
 
 boxCharLiteral :: Char -> FcExpr
 boxCharLiteral char =
@@ -1529,30 +1536,28 @@ boxCharLiteral char =
     (FcVar (builtinVar "C#" (Unique (-12)) (TcFunTy charHashTy charTy)))
     (FcLit (LitChar WordRep char))
 
-consList :: TcType -> FcExpr -> FcExpr -> FcExpr
-consList elemTy headExpr =
-  FcApp (FcApp (consExpr elemTy) headExpr)
+applyCons :: FcExpr -> FcExpr -> FcExpr -> FcExpr
+applyCons cons headExpr =
+  FcApp (FcApp cons headExpr)
 
-nilList :: TcType -> FcExpr
-nilList =
-  FcTyApp (FcVar (builtinVar "[]" (Unique (-10)) nilListType))
+nilList :: TcType -> DsM FcExpr
+nilList elemTy = do
+  constructor <- listConstructorVar "[]" (Unique (-10))
+  pure (FcTyApp (FcVar constructor) elemTy)
 
-consExpr :: TcType -> FcExpr
-consExpr =
-  FcTyApp (FcVar (builtinVar ":" (Unique (-11)) consListType))
+consExpr :: TcType -> DsM FcExpr
+consExpr elemTy = do
+  constructor <- listConstructorVar ":" (Unique (-11))
+  pure (FcTyApp (FcVar constructor) elemTy)
 
-nilListType :: TcType
-nilListType =
-  TcForAllTy listElemVar (listType (TcTyVar listElemVar))
-
-consListType :: TcType
-consListType =
-  TcForAllTy listElemVar (TcFunTy elemTy (TcFunTy (listType elemTy) (listType elemTy)))
-  where
-    elemTy = TcTyVar listElemVar
-
-listElemVar :: TyVarId
-listElemVar = TyVarId "a" (Unique (-2000))
+listConstructorVar :: Text -> Unique -> DsM Var
+listConstructorVar name unique = do
+  constructorType <- lookupType name
+  packageId <- gets dsPrimPackageId
+  pure
+    (Var name unique constructorType)
+      { varResolvedName = Just (FcTopLevelOrigin (packageIdText packageId) "GHC.Types" name)
+      }
 
 builtinVar :: Text -> Unique -> TcType -> Var
 builtinVar name unique ty =
@@ -1660,6 +1665,10 @@ dsTypeRepresentation ty arguments =
   case typeableTypeView ty of
     Nothing -> desugarBug ("cannot construct TypeRep for " <> show ty)
     Just (name, _) -> do
+      charNil <- nilList charTy
+      charCons <- consExpr charTy
+      argumentNil <- nilList typeRepTy
+      argumentCons <- consExpr typeRepTy
       let tyConConstructor =
             Var "TyCon" (Unique (-2102)) (TcFunTy stringTy tyConTy)
           typeRepConstructor =
@@ -1667,8 +1676,8 @@ dsTypeRepresentation ty arguments =
               "TypeRep"
               (Unique (-2103))
               (TcFunTy tyConTy (TcFunTy (listType typeRepTy) typeRepTy))
-          tyCon = FcApp (FcVar tyConConstructor) (T.foldr consChar (nilList charTy) name)
-          argumentList = foldr (consList typeRepTy) (nilList typeRepTy) arguments
+          tyCon = FcApp (FcVar tyConConstructor) (T.foldr (applyConsChar charCons) charNil name)
+          argumentList = foldr (applyCons argumentCons) argumentNil arguments
       pure (FcApp (FcApp (FcVar typeRepConstructor) tyCon) argumentList)
 
 typeableTypeView :: TcType -> Maybe (Text, [TcType])

--- a/components/aihc-fc/test/Test/Fixtures/golden/list-comprehension-direct-recursion.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/list-comprehension-direct-recursion.yaml
@@ -1,9 +1,9 @@
 expected: |-
   module Test where
 
-  external builtin.: : ∀ (a : TYPE BoxedRep Lifted). a → [a] → [a]
+  external "aihc-prim" GHC.Types.: : ∀ (a : TYPE BoxedRep Lifted). a → [a] → [a]
 
-  external builtin.[] : ∀ (a : TYPE BoxedRep Lifted). [a]
+  external "aihc-prim" GHC.Types.[] : ∀ (a : TYPE BoxedRep Lifted). [a]
 
   data Bool
    = False
@@ -20,11 +20,11 @@ expected: |-
                 λ(_lc_list1004 : [a]).
                   case _lc_list1004 as (_lc_scrut1007 : [a]) of {
                     [] →
-                      builtin.[] @a;
+                      "aihc-prim" GHC.Types.[] @a;
                     : (_lc_head1005 : a) (_lc_tail1006 : [a]) →
                       case x1001 _lc_head1005 as (_lc_guard1008 : Bool) of {
                         True →
-                          ((builtin.: @a) _lc_head1005) ($lc1003 _lc_tail1006);
+                          (("aihc-prim" GHC.Types.: @a) _lc_head1005) ($lc1003 _lc_tail1006);
                         False →
                           $lc1003 _lc_tail1006
                       }

--- a/components/aihc-fc/test/Test/Fixtures/golden/list-type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/list-type-application.yaml
@@ -9,15 +9,15 @@ modules:
 expected: |-
   module Test where
 
-  external builtin.: : ∀ (a : TYPE BoxedRep Lifted). a → [a] → [a]
+  external "aihc-prim" GHC.Types.: : ∀ (a : TYPE BoxedRep Lifted). a → [a] → [a]
 
-  external builtin.[] : ∀ (a : TYPE BoxedRep Lifted). [a]
+  external "aihc-prim" GHC.Types.[] : ∀ (a : TYPE BoxedRep Lifted). [a]
 
   data Bool
    = True
    | False
 
   xs : [Bool] =
-    ((builtin.: @Bool) True) (builtin.[] @Bool)
+    (("aihc-prim" GHC.Types.: @Bool) True) ("aihc-prim" GHC.Types.[] @Bool)
 status: pass
 reason: reifies list constructor type arguments from type-checker annotations

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -242,7 +242,11 @@ extractPreparedGrinInterface linkNames program =
                    sourceName <- [varName var, qualifiedName]
                  ]
           ),
-      grinInterfaceConstructorArities = Map.fromList (programConstructors program <> [(sourceName, arity) | (sourceName, (_, arity)) <- constructorNames]),
+      grinInterfaceConstructorArities =
+        Map.fromList
+          ( programConstructors program
+              <> [(sourceName, arity) | (sourceName, (_, arity)) <- constructorNames]
+          ),
       grinInterfacePrimitiveArities =
         Map.fromList
           [ (varName var, arity)

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -303,11 +303,7 @@ isPointerRuntimeRep runtimeRep =
 -- interpretation, linting, and native code generation agree on which global
 -- constructor values exist before the program starts.
 builtinConstructors :: [(Text, [[RuntimeRep]])]
-builtinConstructors =
-  [ ("C#", [[WordRep]]),
-    ("[]", []),
-    (":", [[liftedRuntimeRep], [liftedRuntimeRep]])
-  ]
+builtinConstructors = [("C#", [[WordRep]])]
 
 -- | Flattened storage layouts for runtime-supplied constructors. Source-level
 -- argument boundaries matter for arity, while heap snapshots describe the

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -167,12 +167,18 @@ parseAnnotatedList = withArray "annotated" $ \arr -> do
 
 evaluateResolverCase :: ResolverCase -> (Outcome, String)
 evaluateResolverCase meta =
-  let parsedModules = map (traverse parseOne) (caseModules meta)
+  let supportModules =
+        [ (Package "aihc-prim" (PackageId "aihc-prim"), listSupportModule)
+        | not (any (T.isPrefixOf "module GHC.Types" . T.stripStart . snd) (caseModules meta))
+        ]
+      supportModuleCount = length supportModules
+      parsedModules = map (traverse parseOne) (supportModules <> caseModules meta)
    in case sequence parsedModules of
         Left errMsg -> (OutcomeFail, "parse error: " <> errMsg)
         Right modules ->
           let result = resolveWithDeps mempty modules
-              actualAnnotated = showAnnotated result
+              fixtureResult = result {resolvedModules = drop supportModuleCount (resolvedModules result)}
+              actualAnnotated = showAnnotated fixtureResult
               outputMatches = actualAnnotated == caseAnnotated meta
            in case caseStatus meta of
                 StatusPass
@@ -199,6 +205,14 @@ evaluateResolverCase meta =
             then Right ast
             else Left (formatParseErrors (T.unpack (T.takeWhile (/= '\n') input)) (Just input) errs)
     showAnnotated = renderAnnotatedResolveResult (map snd (caseModules meta))
+
+listSupportModule :: Text
+listSupportModule =
+  T.unlines
+    [ "module GHC.Types (List(..)) where",
+      "data List a = [] | a : [a]",
+      "infixr 5 :"
+    ]
 
 progressSummary :: [(ResolverCase, Outcome, String)] -> (Int, Int, Int, Int)
 progressSummary outcomes =

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -371,12 +371,18 @@ bars n
 
 moduleScope :: Package -> ModuleExports -> Module -> Scope
 moduleScope packageId exports modu =
-  ownScope `unionScope` importedScope packageId exports modu `unionScope` implicitPrelude `unionScope` builtinScope
+  ownScope
+    `unionScope` importedScope packageId exports modu
+    `unionScope` implicitPrelude
+    `unionScope` listConstructorScope
+    `unionScope` builtinScope
   where
     ownScope = topLevelScope packageId modu
     preludeScope = lookupImportedModule packageId Nothing "Prelude" exports
     -- Implicit Prelude: names available unqualified AND as Prelude.xxx
     implicitPrelude = preludeScope {scopeQualifiedModules = Map.singleton "Prelude" preludeScope}
+    ghcTypesScope = lookupImportedModule packageId Nothing "GHC.Types" exports
+    listConstructorScope = selectTerm ":" ghcTypesScope `unionScope` selectTerm "[]" ghcTypesScope
 
 importedScope :: Package -> ModuleExports -> Module -> Scope
 importedScope packageId exports modu =
@@ -499,8 +505,6 @@ emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty M
 
 -- | Scope containing fixed Haskell names that are always available.
 --
--- The list cons name has the fixed @aihc-prim:GHC.Types.:@ source identity.
---
 -- Type namespace: primitive and special types that are not defined in any
 -- parsed source module and cannot be imported from @base@ in the ordinary
 -- way (unboxed primitive types, @TYPE@, @RuntimeRep@, the function arrow,
@@ -511,7 +515,7 @@ emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty M
 builtinScope :: Scope
 builtinScope =
   Scope
-    { scopeTerms = Map.singleton ":" listConsResolvedName,
+    { scopeTerms = Map.empty,
       scopeTypes = Map.fromList (map mkBuiltinType builtinTypeNames),
       scopeConstructors = Map.empty,
       scopeRecordFields = Map.empty,
@@ -521,12 +525,6 @@ builtinScope =
     }
   where
     mkBuiltinType n = (n, ResolvedBuiltin n)
-
-listConsResolvedName :: ResolvedName
-listConsResolvedName =
-  ResolvedTopLevel
-    (PackageId "aihc-prim")
-    (qualifyName (Just "GHC.Types") (mkUnqualifiedName NameConSym ":"))
 
 -- | Wired-in type-namespace names: primitive types that are not defined in
 -- any parsed source module.  Prelude types like @Int@, @Bool@, @Maybe@, etc.

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -497,15 +497,9 @@ moduleKey modu = fromMaybe (T.pack "Main") (moduleName modu)
 emptyScope :: Scope
 emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
 
--- | Scope containing all wired-in Haskell built-ins that have no defining
--- source module but act like regular names during name resolution.
+-- | Scope containing fixed Haskell names that are always available.
 --
--- Term namespace: constructors for special syntax that cannot be expressed
--- as ordinary Haskell declarations (list cons @(:)@, the empty list @[]@,
--- tuple constructors, unboxed-tuple/sum constructors).  Normal Prelude
--- constructors like @True@, @False@, @Just@, @Nothing@, @Left@, @Right@ are
--- /not/ included here — they are defined in @base@ and reach a module via the
--- implicit Prelude import.
+-- The list cons name has the fixed @aihc-prim:GHC.Types.:@ source identity.
 --
 -- Type namespace: primitive and special types that are not defined in any
 -- parsed source module and cannot be imported from @base@ in the ordinary
@@ -517,7 +511,7 @@ emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty M
 builtinScope :: Scope
 builtinScope =
   Scope
-    { scopeTerms = Map.fromList (map mkBuiltinTerm builtinTermNames),
+    { scopeTerms = Map.singleton ":" listConsResolvedName,
       scopeTypes = Map.fromList (map mkBuiltinType builtinTypeNames),
       scopeConstructors = Map.empty,
       scopeRecordFields = Map.empty,
@@ -526,22 +520,13 @@ builtinScope =
       scopeQualifiedModules = Map.empty
     }
   where
-    mkBuiltinTerm n = (n, ResolvedBuiltin n)
     mkBuiltinType n = (n, ResolvedBuiltin n)
 
--- | Wired-in term-namespace names: special syntax constructors that have no
--- defining source declaration.  Normal Prelude constructors (@True@, @False@,
--- @Just@, etc.) are intentionally excluded — they live in @base@ and arrive
--- via the implicit Prelude import.
---
--- Note: names here must match exactly what the parser emits as the 'Name'
--- text inside 'EVar'.  For example, the cons operator appears as @":"@ (not
--- @"(:)"@), because the surrounding parens are stripped by the parser.
-builtinTermNames :: [T.Text]
-builtinTermNames =
-  [ -- Cons operator — the only list constructor that surfaces as EVar
-    ":"
-  ]
+listConsResolvedName :: ResolvedName
+listConsResolvedName =
+  ResolvedTopLevel
+    (PackageId "aihc-prim")
+    (qualifyName (Just "GHC.Types") (mkUnqualifiedName NameConSym ":"))
 
 -- | Wired-in type-namespace names: primitive types that are not defined in
 -- any parsed source module.  Prelude types like @Int@, @Bool@, @Maybe@, etc.

--- a/components/aihc-resolve/test/Test/Fixtures/golden/builtin-cons-operator.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/builtin-cons-operator.yaml
@@ -6,12 +6,12 @@ annotated:
   cons x xs = (:) x xs
   │    │ └─ v 1│  │ └─ v 1
   │    └─ v 0  │  └─ v 0
-  └─ v Main    └─ v Builtin :
+  └─ v Main    └─ v aihc-prim:GHC.Types
 extensions: []
 modules:
 - |
   module Main where
   cons :: a -> [a] -> [a]
   cons x xs = (:) x xs
-reason: ''
+reason: resolves list cons directly to aihc-prim GHC.Types
 status: pass

--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -26,8 +26,8 @@ import Aihc.Parser.Syntax
     moduleName,
     parseExtensionName,
   )
-import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), resolveWithDeps, unnamedPackage)
-import Aihc.Tc (typecheck)
+import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), extractInterface, resolveWithDeps, unnamedPackage)
+import Aihc.Tc (emptyTcInterface, typecheckModulesWithInterface)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
@@ -136,14 +136,24 @@ evaluateTcAnnotatedCase tc =
    in case sequence parsedModules of
         Left errMsg -> classifyFailure tc ("parse error: " <> errMsg)
         Right modules ->
-          case resolveWithDeps mempty (map modulePackage modules) of
+          case resolveWithDeps coreExports (map modulePackage modules) of
             ResolveResult {resolvedModules, resolveErrors = []} ->
-              let results = typecheck (map snd resolvedModules)
+              let (results, _) = typecheckModulesWithInterface coreInterface (map snd resolvedModules)
                   actual = renderAnnotatedTcResults (caseModules tc) results
                in classifySuccess tc actual
             ResolveResult {resolveErrors} ->
               classifyFailure tc ("resolve error: " <> show resolveErrors)
   where
+    corePackage = Package "aihc-prim" (PackageId "aihc-prim")
+    coreSource = "module GHC.Types (List(..)) where\ndata List a = [] | a : [a]\ninfixr 5 :\n"
+    coreModule = parseCoreModule coreSource
+    coreResolved = resolveWithDeps mempty [(corePackage, coreModule)]
+    coreExports = extractInterface coreResolved
+    coreInterface =
+      case coreResolved of
+        ResolveResult {resolvedModules = [(_, resolvedCore)], resolveErrors = []} ->
+          snd (typecheckModulesWithInterface emptyTcInterface [resolvedCore])
+        _ -> emptyTcInterface
     modulePackage modu
       | moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
           (Package "aihc-prim" (PackageId "aihc-prim"), modu)
@@ -158,6 +168,10 @@ evaluateTcAnnotatedCase tc =
        in if null errs
             then Right ast
             else Left (show errs)
+    parseCoreModule input =
+      let config = defaultConfig {parserSourceName = "GHC.Types"}
+          (errs, ast) = parseModule config input
+       in if null errs then ast else error (show errs)
 
 classifySuccess :: TcAnnotatedCase -> [String] -> (Outcome, String)
 classifySuccess tc actual =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -2424,7 +2424,10 @@ registerDataConWithResult paramInfos resTy con = case con of
           scheme = ForAll (paramVarIds <> constructorTyVars) predicates conTy
       case maybeName of
         Just sourceName -> extendResolvedTermEnvPermanent sourceName (TcIdBinder scheme Closed)
-        Nothing -> extendTermEnvPermanent name (TcIdBinder scheme Closed)
+        Nothing ->
+          case resTy of
+            TcTyCon resultTyCon _ -> extendTyConTermEnvPermanent resultTyCon name (TcIdBinder scheme Closed)
+            _ -> extendTermEnvPermanent name (TcIdBinder scheme Closed)
       zonkedTy <- zonkType (schemeToType scheme)
       pure (TcBindingResult name name zonkedTy)
 

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -606,28 +606,40 @@ tupleTyConModule flavor =
 
 inferList :: SourceSpan -> [Expr] -> TcM (Expr, TcType, [Ct])
 inferList sp elems = do
-  listTyCon' <- resolvedListTyCon
+  nilInstantiation <- instantiateListConstructor sp "[]"
+  nilCts <- mapM (predToCt sp "[]") (instPreds nilInstantiation)
   case elems of
     [] -> do
-      elemTy <- freshMetaTv
-      let listTy = TcTyCon listTyCon' [elemTy]
-          pending = pendingAnnotation listTy [elemTy] [] []
-      pure (annotatePendingExprAt sp pending (EList []), listTy, [])
-    (e : es) -> do
-      let headSp = exprSpan e `orSourceSpan` sp
-      (headExpr, headTy, headCts) <- inferExpr e
-      results <- mapM inferElem es
-      let elems' = headExpr : map (\(expr, _, _, _) -> expr) results
-          tailCts = concatMap (\(_, _, elemCts, _) -> elemCts) results
-      eqCts <- mapM (mkElemEq headSp headTy) results
-      let listTy = TcTyCon listTyCon' [headTy]
-          pending = pendingAnnotation listTy [headTy] [] []
-      pure (annotatePendingExprAt sp pending (EList elems'), listTy, headCts ++ tailCts ++ eqCts)
+      let listTy = instType nilInstantiation
+          pending = pendingAnnotation listTy (instTypeArgs nilInstantiation) (map ctEvVar nilCts) []
+      pure (annotatePendingExprAt sp pending (EList []), listTy, nilCts)
+    _ -> do
+      results <- mapM inferElem elems
+      consInstantiation <- instantiateListConstructor sp ":"
+      consPredicateCts <- mapM (predToCt sp ":") (instPreds consInstantiation)
+      case instType consInstantiation of
+        TcFunTy sourceElemTy (TcFunTy sourceTailTy sourceResultTy) -> do
+          let elems' = map (\(element, _, _, _) -> element) results
+              elemCts = concatMap (\(_, _, cts, _) -> cts) results
+              (firstElemTy, firstElemSp) = case results of
+                (_, ty, _, elemSp) : _ -> (ty, elemSp)
+                [] -> (sourceElemTy, sp)
+              pending = pendingAnnotation sourceResultTy [sourceElemTy] [] []
+          firstConstructorCt <- constructorEqualityCt firstElemSp firstElemTy sourceElemTy
+          nilConstructorCt <- constructorEqualityCt sp (instType nilInstantiation) sourceTailTy
+          resultConstructorCt <- constructorEqualityCt sp sourceResultTy sourceTailTy
+          elementEqualityCts <- mapM (elementEqualityCt firstElemSp firstElemTy) (drop 1 results)
+          let constructorCts = nilCts <> consPredicateCts <> [firstConstructorCt, nilConstructorCt, resultConstructorCt]
+          pure (annotatePendingExprAt sp pending (EList elems'), sourceResultTy, elemCts <> elementEqualityCts <> constructorCts)
+        _ -> abortTc "GHC.Types list cons constructor has an invalid type"
   where
     inferElem elemExpr = do
       (elemExpr', elemTy, elemCts) <- inferExpr elemExpr
       pure (elemExpr', elemTy, elemCts, exprSpan elemExpr `orSourceSpan` sp)
-    mkElemEq headSp headTy (_, elemTy, _, elemSp) = do
+    constructorEqualityCt loc left right = do
+      ev <- freshEvVar
+      pure (mkWantedCt (EqPred left right) ev (AppOrigin loc) loc)
+    elementEqualityCt firstElemSp firstElemTy (_, elemTy, _, elemSp) = do
       ev <- freshEvVar
       pure $
         mkWantedEqCt
@@ -637,13 +649,24 @@ inferList sp elems = do
               typeTraceOrigin = ExpressionTypeOrigin elemSp
             }
           TypeTrace
-            { typeTraceType = headTy,
+            { typeTraceType = firstElemTy,
               typeTraceRole = ExpectedType,
-              typeTraceOrigin = ListElementTypeOrigin headSp
+              typeTraceOrigin = ListElementTypeOrigin firstElemSp
             }
           ev
           (AppOrigin elemSp)
           elemSp
+
+instantiateListConstructor :: SourceSpan -> Text -> TcM Instantiation
+instantiateListConstructor sp name = do
+  sourceBinder <- lookupTerm name
+  maybeBinder <- maybe (lookupKnownTerm "GHC.Types" name) (pure . Just) sourceBinder
+  case maybeBinder of
+    Just (TcIdBinder scheme _) -> instantiateWithArgs scheme
+    Just TcMonoIdBinder {} ->
+      abortTc ("GHC.Types list constructor is monomorphic at " <> show sp <> ": " <> show name)
+    Nothing ->
+      abortTc ("GHC.Types list constructor is missing at " <> show sp <> ": " <> show name)
 
 inferListComp :: SourceSpan -> Expr -> [CompStmt] -> TcM (Expr, TcType, [Ct])
 inferListComp sp body quals = do

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -122,12 +122,7 @@ checkPatternCore gadtHandling sp pat scrutTy =
       checkConPattern gadtHandling sp pat name subPats scrutTy
     PInfix lhs op rhs ->
       checkConPattern gadtHandling sp pat op [lhs, rhs] scrutTy
-    PList items -> do
-      elemTy <- freshMetaTv
-      listTy <- listType elemTy
-      eqCt <- wantedEq sp scrutTy listTy
-      itemChecks <- checkPatternsWith gadtHandling sp [(item, elemTy) | item <- items]
-      pure itemChecks {pcWantedCts = eqCt : pcWantedCts itemChecks, pcPatterns = [PList (pcPatterns itemChecks)]}
+    PList items -> checkListPattern gadtHandling sp items scrutTy
     PTuple flavor items -> do
       elemTys <- mapM (const freshMetaTv) items
       let arity = length items
@@ -149,6 +144,55 @@ checkPatternCore gadtHandling sp pat scrutTy =
 
 checkedOnly :: Pattern -> PatternCheck
 checkedOnly pat = mempty {pcPatterns = [pat]}
+
+checkListPattern :: GadtHandling -> SourceSpan -> [Pattern] -> TcType -> TcM PatternCheck
+checkListPattern gadtHandling sp items scrutTy =
+  case items of
+    [] -> do
+      scheme <- listConstructorScheme "[]"
+      (nilTy, _typeArgs, predicates, skolems) <- instantiateConstructorPattern scheme
+      scrutCts <- constructorScrutineeCt gadtHandling sp "[]" scrutTy nilTy
+      predicateGivens <- mapM (constructorGiven sp "[]") predicates
+      pure
+        mempty
+          { pcWantedCts = fst scrutCts,
+            pcGivenCts = predicateGivens <> snd scrutCts,
+            pcSkolems = skolems,
+            pcPatterns = [PList []]
+          }
+    item : rest -> do
+      scheme <- listConstructorScheme ":"
+      (consTy, _typeArgs, predicates, skolems) <- instantiateConstructorPattern scheme
+      (argumentTypes, resultTy) <- splitConTy 2 consTy
+      case argumentTypes of
+        [itemTy, tailTy] -> do
+          scrutCts <- constructorScrutineeCt gadtHandling sp ":" scrutTy resultTy
+          itemCheck <- checkPatternWith gadtHandling sp item itemTy
+          tailCheck <- checkListPattern gadtHandling sp rest tailTy
+          predicateGivens <- mapM (constructorGiven sp ":") predicates
+          let nestedCheck = itemCheck <> tailCheck
+              checkedTailItems = case checkedPattern tailCheck of
+                PAnn _ (PList patterns) -> patterns
+                PList patterns -> patterns
+                _ -> rest
+              checkedItems = checkedPattern itemCheck : checkedTailItems
+          pure
+            nestedCheck
+              { pcWantedCts = fst scrutCts <> pcWantedCts nestedCheck,
+                pcGivenCts = predicateGivens <> snd scrutCts <> pcGivenCts nestedCheck,
+                pcSkolems = skolems <> pcSkolems nestedCheck,
+                pcPatterns = [PList checkedItems]
+              }
+        _ -> abortTc "GHC.Types list cons constructor has an invalid arity"
+
+listConstructorScheme :: Text -> TcM TypeScheme
+listConstructorScheme name = do
+  sourceBinder <- lookupTerm name
+  maybeBinder <- maybe (lookupKnownTerm "GHC.Types" name) (pure . Just) sourceBinder
+  case maybeBinder of
+    Just (TcIdBinder scheme _) -> pure scheme
+    Just TcMonoIdBinder {} -> abortTc ("GHC.Types list constructor is monomorphic: " <> T.unpack name)
+    Nothing -> abortTc ("GHC.Types list constructor is missing: " <> T.unpack name)
 
 checkedPattern :: PatternCheck -> Pattern
 checkedPattern check =
@@ -487,11 +531,6 @@ withPatternBindings :: [(UnqualifiedName, TcType)] -> TcM a -> TcM a
 withPatternBindings [] action = action
 withPatternBindings ((name, ty) : rest) action =
   extendResolvedTermEnv name (TcMonoIdBinder ty) (withPatternBindings rest action)
-
-listType :: TcType -> TcM TcType
-listType elemTy = do
-  maybeInfo <- lookupTyCon "[]"
-  pure (TcTyCon (maybe (mkTyCon "[]" 1 (KFun KType KType)) tciTyCon maybeInfo) [elemTy])
 
 tupleTyConText :: TupleFlavor -> Int -> Text
 tupleTyConText flavor arity =

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -44,6 +44,7 @@ module Aihc.Tc.Monad
     emptyTcEnv,
     mkKnownTyCon,
     lookupTerm,
+    lookupKnownTerm,
     lookupResolvedTerm,
     resolvedTermKey,
     resolvedTermTarget,
@@ -52,6 +53,7 @@ module Aihc.Tc.Monad
     extendTermEnv,
     extendResolvedTermEnv,
     extendTermEnvPermanent,
+    extendTyConTermEnvPermanent,
     extendResolvedTermEnvPermanent,
     getTermEnv,
     lookupTyCon,
@@ -242,7 +244,7 @@ initTcState =
       tcsRuntimeRepDependencies = Map.empty,
       tcsEvBinds = Map.empty,
       tcsDiagnostics = [],
-      tcsGlobalTerms = builtinTerms,
+      tcsGlobalTerms = Map.empty,
       tcsGlobalTyCons = Map.empty,
       tcsDataTypes = Map.empty,
       tcsClasses = Map.empty,
@@ -250,19 +252,6 @@ initTcState =
       tcsDataFamilyInstances = [],
       tcsGadtCons = Set.empty
     }
-
-builtinTerms :: Map TcTermKey TcBinder
-builtinTerms =
-  Map.fromList
-    [ (unqualifiedTermKey ":", TcIdBinder consScheme Closed),
-      (unqualifiedTermKey "[]", TcIdBinder nilScheme Closed)
-    ]
-  where
-    aVar = TyVarId "a" (Unique (-1000))
-    aTy = TcTyVar aVar
-    listA = TcTyCon (TyCon "[]" 1) [aTy]
-    consScheme = ForAll [aVar] [] (TcFunTy aTy (TcFunTy listA listA))
-    nilScheme = ForAll [aVar] [] listA
 
 -- | Allocate a fresh 'Unique'.
 freshUnique :: TcM Unique
@@ -349,6 +338,11 @@ lookupTerm :: Text -> TcM (Maybe TcBinder)
 lookupTerm name =
   lift $ gets $ \s -> Map.lookup (unqualifiedTermKey name) (tcsGlobalTerms s)
 
+lookupKnownTerm :: Text -> Text -> TcM (Maybe TcBinder)
+lookupKnownTerm moduleName name = do
+  TcConfig packageId <- asks tcEnvConfig
+  lookupTermKey (TcTermGlobal packageId moduleName name)
+
 lookupResolvedTerm :: Text -> ResolvedName -> TcM (Maybe TcBinder)
 lookupResolvedTerm displayName resolved = do
   exact <- resolvedNameTermKey displayName resolved >>= lookupTermKey
@@ -412,6 +406,18 @@ extendResolvedTermEnv name binder action = do
 extendTermEnvPermanent :: Text -> TcBinder -> TcM ()
 extendTermEnvPermanent name binder = lift $ modify' $ \s ->
   s {tcsGlobalTerms = Map.insert (unqualifiedTermKey name) binder (tcsGlobalTerms s)}
+
+extendTyConTermEnvPermanent :: TyCon -> Text -> TcBinder -> TcM ()
+extendTyConTermEnvPermanent tyCon name binder = do
+  extendTermEnvPermanent name binder
+  lift $ modify' $ \state ->
+    state
+      { tcsGlobalTerms =
+          Map.insert
+            (TcTermGlobal (tyConPackageId tyCon) (tyConModuleName tyCon) name)
+            binder
+            (tcsGlobalTerms state)
+      }
 
 -- | Add a source binder under its resolver identity and its source name.
 extendResolvedTermEnvPermanent :: UnqualifiedName -> TcBinder -> TcM ()

--- a/components/aihc-tc/test/Test/Tc/Suite.hs
+++ b/components/aihc-tc/test/Test/Tc/Suite.hs
@@ -880,6 +880,7 @@ annotationModule :: Module
 annotationModule =
   parseM
     "module Test where\n\
+    \data List a = [] | a : [a]\n\
     \data Bool = False | True\n\
     \class Eq a where\n\
     \  (==) :: a -> a -> Bool\n\

--- a/core-libs/aihc-base/src/GHC/Base.hs
+++ b/core-libs/aihc-base/src/GHC/Base.hs
@@ -19,10 +19,7 @@ import Data.Kind (Type)
 import GHC.IO (IO (..))
 import GHC.Internal.Char (Char)
 import GHC.Prim (RealWorld, State#)
-
-data List a = [] | a : [a]
-
-infixr 5 :
+import GHC.Types (List (..))
 
 type String = [Char]
 

--- a/core-libs/aihc-prim/src/GHC/Types.hs
+++ b/core-libs/aihc-prim/src/GHC/Types.hs
@@ -6,7 +6,8 @@
 {-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 module GHC.Types
-  ( Int (..),
+  ( List (..),
+    Int (..),
     Bool (..),
     Ordering (..),
     TYPE,
@@ -80,6 +81,10 @@ module GHC.Types
     Tuple64# (..),
   )
 where
+
+data List a = [] | a : [a]
+
+infixr 5 :
 
 data Int = I# Int#
 

--- a/test/support/Aihc/Testing/EvalFixture.hs
+++ b/test/support/Aihc/Testing/EvalFixture.hs
@@ -252,7 +252,8 @@ compileEvalCase tc =
       case dependencyModules of
         Left errMsg -> pure (Left errMsg)
         Right deps ->
-          let resolved = resolveWithDeps mempty (map modulePackage (deps <> evalModules))
+          let allModules = addListSupport (deps <> evalModules)
+              resolved = resolveWithDeps mempty (map modulePackage allModules)
            in case resolved of
                 ResolveResult {resolvedModules, resolveErrors = []} ->
                   let moduleAsts = map snd resolvedModules
@@ -271,6 +272,13 @@ compileEvalCase tc =
                 ResolveResult {resolveErrors} ->
                   pure (Left ("resolve error: " <> show resolveErrors))
   where
+    addListSupport modules
+      | any ((== Just "GHC.Types") . Surface.moduleName) modules = modules
+      | otherwise = listSupportModule : modules
+    listSupportModule =
+      case parseOneModule "GHC.Types" [] "module GHC.Types (List(..)) where\ndata List a = [] | a : [a]\ninfixr 5 :\n" of
+        Right modu -> modu
+        Left err -> error err
     modulePackage modu
       | Surface.moduleName modu `elem` [Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
           (Package "aihc-prim" (PackageId "aihc-prim"), modu)

--- a/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
+++ b/tooling/aihc-dev/test/Test/ResolveStackageProgress/PathsModule.hs
@@ -92,6 +92,7 @@ baseExports =
     Map.fromList
       [ ("GHC.Classes", mkScope "GHC.Classes" ["=="] []),
         ("GHC.Num", mkScope "GHC.Num" ["fromInteger"] []),
+        ("GHC.Types", mkScope "GHC.Types" [":", "[]"] ["[]"]),
         ("Prelude", mkScope "Prelude" ["return", "++", "==", "otherwise", "fromInteger"] ["IO", "FilePath", "String", "Char", "Bool"]),
         ("Control.Exception", mkScope "Control.Exception" ["catch"] ["IOException"]),
         ("Data.List", mkScope "Data.List" ["last"] []),


### PR DESCRIPTION
## Summary

- Move the `List` declaration from `GHC.Base` to `GHC.Types`.
- Re-export `List` from `GHC.Base`.
- Load list constructor schemes from type-checker interfaces.
- Give System FC list constructors their `GHC.Types` source origin.
- Add resolver and System FC golden coverage.
- Add no unit tests.

## Checks

- `just fmt`
- `just check`

## Progress counts

No progress count changed.