### PR TITLE
feat(cli): add stored type interfaces

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -21,6 +21,7 @@ library
     Aihc.Cli.ResolveArtifact
     Aihc.Cli.Runtime
     Aihc.Cli.Store
+    Aihc.Cli.TypeArtifact
 
   other-modules:
     Aihc.Cli.Compile.Dependencies

--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -9,9 +9,10 @@ import Aihc.Cli.Install (ParsedInterfaceFile (..), parseInterfaceFile)
 import Aihc.Cli.Options (InstallV2Options (..))
 import Aihc.Cli.ResolveArtifact (ResolveArtifact (..), decodeResolveArtifact, encodeResolveArtifact, encodeResolveScope)
 import Aihc.Cli.Store (defaultStoreRoot)
+import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact, encodeTypeArtifact, encodeTypeInterface)
 import Aihc.Hackage.Cabal qualified as HackageCabal
 import Aihc.Hackage.Util qualified as HackageUtil
-import Aihc.Parser.Syntax (ImportDecl (..), Module, moduleName)
+import Aihc.Parser.Syntax (ImportDecl (..), Module, Name (..), moduleName)
 import Aihc.Parser.Syntax qualified as Syntax
 import Aihc.Resolve
   ( ModuleExports,
@@ -19,29 +20,43 @@ import Aihc.Resolve
     Package (..),
     PackageId (..),
     ResolveResult (..),
+    ResolvedName (..),
+    Scope (..),
     extractInterfaceWithDeps,
     modulesInPackage,
     resolveWithDeps,
   )
+import Aihc.Tc
+  ( ClassInfo (..),
+    DataTypeInfo (..),
+    TcInterface (..),
+    TcTermKey (..),
+    TyConInfo (..),
+    tcConfig,
+    tcModuleDiagnostics,
+    tcModuleSuccess,
+    typecheckModuleSccWithInterfaceConfig,
+  )
+import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
 import Control.Exception (IOException, try)
 import Control.Monad (foldM, unless, when)
 import Data.Bits (xor)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (nub, sort, sortOn)
+import Data.List (nub, sortOn)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Encoding qualified as TE
 import Data.Word (Word64)
 import Distribution.Package qualified as CabalPackage
 import Distribution.PackageDescription (package, packageDescription)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Pretty (prettyShow)
 import Numeric (showHex)
-import System.Directory (createDirectoryIfMissing, doesDirectoryExist)
+import System.Directory (createDirectoryIfMissing)
 import System.FilePath (makeRelative, takeDirectory, (</>))
 
 data InstallV2Result = InstallV2Result
@@ -80,37 +95,16 @@ installV2 options = do
   let packageId = package (packageDescription gpd)
       packageNameText = T.pack (CabalPackage.unPackageName (CabalPackage.packageName packageId))
       packageVersionText = T.pack (prettyShow (CabalPackage.packageVersion packageId))
-      dependencyNames = sort . nub $ concatMap (filter (/= packageNameText) . HackageCabal.fileInfoDependencies) files
-  dependencyIds <- resolveDependencyIds storeRoot dependencyNames (installV2Dependencies options)
-  verbose ("Use library dependencies: " <> show dependencyIds)
   verbose ("Parse " <> show (length files) <> " library modules")
   parsed <- mapM (parseSource root) files
-  let packageHash = stableHash (TE.encodeUtf8 "aihc-dependencies-v1" : map TE.encodeUtf8 dependencyIds)
+  let packageHash = stableHash ["aihc-dependencies-v1"]
       packageDirectory = T.unpack packageNameText <> "-" <> T.unpack packageVersionText <> "-" <> packageHash
       storePath = storeRoot </> packageDirectory
       resolvePackage = Package packageNameText (PackageId (T.pack packageDirectory))
       units = sourceModuleSccs parsed
   verbose ("Compute " <> show (length units) <> " SCC units")
-  (_, _, written, reused) <- foldM (installUnit verbose storePath resolvePackage root) (Map.empty, Map.empty, [], []) units
-  pure (InstallV2Result storePath (reverse written) (reverse reused))
-
-resolveDependencyIds :: FilePath -> [Text] -> [String] -> IO [Text]
-resolveDependencyIds storeRoot expected assignments = do
-  parsed <- mapM parseAssignment assignments
-  let selected = Map.fromList parsed
-      selectedNames = sort (Map.keys selected)
-  unless (selectedNames == expected) $ ioError (userError ("Direct library dependencies require exact --dependency inputs: " <> show expected))
-  mapM validateIdentity (Map.toAscList selected)
-  where
-    parseAssignment assignment =
-      case break (== '=') assignment of
-        (name, '=' : identity) | not (null name) && not (null identity) -> pure (T.pack name, T.pack identity)
-        _ -> ioError (userError ("Invalid dependency identity: " <> assignment))
-    validateIdentity (name, identity) = do
-      unless ((name <> "-") `T.isPrefixOf` identity) $ ioError (userError ("Dependency identity does not match " <> T.unpack name <> ": " <> T.unpack identity))
-      exists <- doesDirectoryExist (storeRoot </> T.unpack identity)
-      unless exists $ ioError (userError ("Dependency artifact is not installed: " <> T.unpack identity))
-      pure identity
+  (_, _, _, _, written, reused) <- foldM (installUnit verbose storePath resolvePackage root) (Map.empty, Map.empty, mempty, Map.empty, Set.empty, Set.empty) units
+  pure (InstallV2Result storePath (Set.toAscList written) (Set.toAscList reused))
 
 parseSource :: FilePath -> HackageCabal.FileInfo -> IO SourceModule
 parseSource root fileInfo = do
@@ -129,31 +123,141 @@ sourceModuleSccs = map flatten . stronglyConnComp . map node
     flatten (AcyclicSCC value) = [value]
     flatten (CyclicSCC values) = values
 
-installUnit :: (String -> IO ()) -> FilePath -> Package -> FilePath -> (ModuleExports, Map.Map Text Text, [Text], [Text]) -> [SourceModule] -> IO (ModuleExports, Map.Map Text Text, [Text], [Text])
-installUnit verbose storePath resolvePackage root (dependencyExports, scopeHashes, written, reused) unit = do
+installUnit :: (String -> IO ()) -> FilePath -> Package -> FilePath -> (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text) -> [SourceModule] -> IO (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text)
+installUnit verbose storePath resolvePackage root (dependencyExports, scopeHashes, dependencyTypes, typeHashes, written, reused) unit = do
   let packageModules = modulesInPackage resolvePackage (map sourceModuleAst unit)
       unitNames = map sourceName unit
       importedNames = nub (concatMap (map importDeclModule . Syntax.moduleImports . sourceModuleAst) unit)
       dependencyHashes = Map.fromList [("scope:" <> name, digest) | name <- importedNames, name `notElem` unitNames, Just digest <- [Map.lookup name scopeHashes]]
       sourceHashes = [("source:" <> T.pack (makeRelative root (sourceModulePath source)), sourceModuleHash source) | source <- unit]
       hashes = sortOn fst (sourceHashes <> Map.toList dependencyHashes)
-      artifactPath source = storePath </> moduleDirectory (sourceModuleAst source) </> "resolve.cbor"
-  cachedExports <- tryReadUnitArtifacts hashes resolvePackage artifactPath unit
-  case cachedExports of
-    Just diskExports -> do
+      resolvePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "resolve.cbor"
+      typePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "type.cbor"
+  cachedExports <- tryReadUnitArtifacts hashes resolvePackage resolvePath unit
+  (diskExports, resolveResult, resolveChanged) <- case cachedExports of
+    Just exports -> do
       mapM_ (verbose . ("Reuse resolve context: " <>) . T.unpack) unitNames
-      updatedScopeHashes <- updateScopeHashes artifactPath scopeHashes unit
-      pure (diskExports `Map.union` dependencyExports, updatedScopeHashes, written, reverse unitNames <> reused)
+      pure (exports, Nothing, False)
     Nothing -> do
       let result = resolveWithDeps dependencyExports packageModules
       unless (null (resolveErrors result)) (ioError (userError ("Name resolution failed: " <> show (resolveErrors result))))
       let exports = extractInterfaceWithDeps dependencyExports result
-      mapM_ (\source -> writeArtifact verbose hashes exports resolvePackage (artifactPath source) source) unit
-      diskExports <- readUnitArtifacts hashes resolvePackage artifactPath unit
-      updatedScopeHashes <- updateScopeHashes artifactPath scopeHashes unit
-      pure (diskExports `Map.union` dependencyExports, updatedScopeHashes, reverse unitNames <> written, reused)
+      mapM_ (\source -> writeArtifact verbose hashes exports resolvePackage (resolvePath source) source) unit
+      storedExports <- readUnitArtifacts hashes resolvePackage resolvePath unit
+      pure (storedExports, Just result, True)
+  updatedScopeHashes <- updateScopeHashes resolvePath scopeHashes unit
+  let typeInputs =
+        sortOn fst $
+          sourceHashes
+            <> Map.toList dependencyHashes
+            <> [("type:" <> name, digest) | name <- importedNames, name `notElem` unitNames, Just digest <- [Map.lookup name typeHashes]]
+  cachedTypes <- tryReadTypeArtifacts typeInputs typePath unit
+  (unitTypes, typeChanged) <- case cachedTypes of
+    Just interfaces -> do
+      mapM_ (verbose . ("Reuse type interface: " <>) . T.unpack) unitNames
+      pure (interfaces, False)
+    Nothing -> do
+      resolved <- case resolveResult of
+        Just result -> pure result
+        Nothing -> do
+          let result = resolveWithDeps dependencyExports packageModules
+          unless (null (resolveErrors result)) (ioError (userError ("Name resolution failed: " <> show (resolveErrors result))))
+          pure result
+      let (checkedModules, completeInterface) =
+            typecheckModuleSccWithInterfaceConfig
+              (tcConfig (packageId resolvePackage))
+              dependencyTypes
+              (map snd (resolvedModules resolved))
+      unless (all tcModuleSuccess checkedModules) (ioError (userError ("Type check failed: " <> show (concatMap tcModuleDiagnostics checkedModules))))
+      let interfaces = map (moduleTypeInterface diskExports resolvePackage completeInterface) unit
+      mapM_ (uncurry (writeTypeArtifact verbose typeInputs typePath)) (zip unit interfaces)
+      storedInterfaces <- readTypeArtifacts typeInputs typePath unit
+      pure (storedInterfaces, True)
+  updatedTypeHashes <- updateTypeHashes typePath typeHashes unit
+  let changed = resolveChanged || typeChanged
+      unitSet = Set.fromList unitNames
+      written' = if changed then written <> unitSet else written
+      reused' = if changed then reused else reused <> unitSet
+  pure
+    ( diskExports `Map.union` dependencyExports,
+      updatedScopeHashes,
+      dependencyTypes <> mconcat unitTypes,
+      updatedTypeHashes,
+      written',
+      reused'
+    )
   where
     sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
+
+moduleTypeInterface :: ModuleExports -> Package -> TcInterface -> SourceModule -> TcInterface
+moduleTypeInterface exports package interface source =
+  interface
+    { tcInterfaceTerms = filter visibleTerm (tcInterfaceTerms interface),
+      tcInterfaceTyCons = filter visibleTyCon (tcInterfaceTyCons interface),
+      tcInterfaceDataTypes = filter (visibleTypeIdentity . dtiNameAndOrigin) (tcInterfaceDataTypes interface),
+      tcInterfaceClasses = filter visibleClass (tcInterfaceClasses interface)
+    }
+  where
+    name = fromMaybe "Main" (moduleName (sourceModuleAst source))
+    scope = Map.findWithDefault (error "missing resolve scope") (ModuleKey package name) exports
+    termIdentities = Set.fromList (mapMaybe resolvedIdentity (Map.elems (scopeTerms scope)))
+    typeIdentities = Set.fromList (mapMaybe resolvedIdentity (Map.elems (scopeTypes scope)))
+    localIdentity identifier = (packageId package, name, identifier)
+    visibleTerm (TcTermGlobal packageId' moduleName' identifier, _) =
+      let identity = (packageId', moduleName', identifier)
+       in Map.member identifier (scopeTerms scope) || identity `Set.member` termIdentities || identity == localIdentity identifier
+    visibleTerm (TcTermLocal {}, _) = False
+    visibleTyCon info =
+      let tyCon = tciTyCon info
+          identity = (tyConPackageId tyCon, tyConModuleName tyCon, tciName info)
+       in Map.member (tciName info) (scopeTypes scope) || identity `Set.member` typeIdentities || identity == localIdentity (tciName info)
+    dtiNameAndOrigin info =
+      let tyCon = dtiTyCon info
+       in (tyConPackageId tyCon, tyConModuleName tyCon, dtiName info)
+    visibleTypeIdentity identity = Map.member (third identity) (scopeTypes scope) || identity `Set.member` typeIdentities || identity == localIdentity (third identity)
+    visibleClass info =
+      case ciOrigin info of
+        Just (packageIdText, moduleName') ->
+          let identity = (PackageId packageIdText, moduleName', ciName info)
+           in Map.member (ciName info) (scopeTypes scope) || identity `Set.member` typeIdentities || identity == localIdentity (ciName info)
+        Nothing -> False
+    third (_, _, value) = value
+    resolvedIdentity resolved = case resolved of
+      ResolvedTopLevel packageId' resolvedName -> Just (packageId', fromMaybe name (nameQualifier resolvedName), nameText resolvedName)
+      _ -> Nothing
+
+writeTypeArtifact :: (String -> IO ()) -> [(Text, Text)] -> (SourceModule -> FilePath) -> SourceModule -> TcInterface -> IO ()
+writeTypeArtifact verbose hashes artifactPath source interface = do
+  let path = artifactPath source
+      name = fromMaybe "Main" (moduleName (sourceModuleAst source))
+  createDirectoryIfMissing True (takeDirectory path)
+  BL.writeFile path (encodeTypeArtifact (TypeArtifact name hashes interface))
+  verbose ("Write type interface: " <> T.unpack name)
+
+tryReadTypeArtifacts :: [(Text, Text)] -> (SourceModule -> FilePath) -> [SourceModule] -> IO (Maybe [TcInterface])
+tryReadTypeArtifacts expected artifactPath unit = do
+  result <- try (readTypeArtifacts expected artifactPath unit) :: IO (Either IOException [TcInterface])
+  pure (either (const Nothing) Just result)
+
+readTypeArtifacts :: [(Text, Text)] -> (SourceModule -> FilePath) -> [SourceModule] -> IO [TcInterface]
+readTypeArtifacts expected artifactPath = mapM readOne
+  where
+    readOne source = do
+      let path = artifactPath source
+      bytes <- BS.readFile path
+      artifact <- either (\message -> ioError (userError ("Invalid type artifact " <> path <> ": " <> message))) pure (decodeTypeArtifact bytes)
+      unless (typeArtifactInputHashes artifact == expected) (ioError (userError ("Invalid type artifact " <> path <> ": input hashes do not match")))
+      pure (typeArtifactInterface artifact)
+
+updateTypeHashes :: (SourceModule -> FilePath) -> Map.Map Text Text -> [SourceModule] -> IO (Map.Map Text Text)
+updateTypeHashes artifactPath previous unit = do
+  hashes <- mapM artifactHash unit
+  pure (foldl' (\result (name, digest) -> Map.insert name digest result) previous hashes)
+  where
+    artifactHash source = do
+      bytes <- BS.readFile (artifactPath source)
+      artifact <- either (\message -> ioError (userError ("Invalid type artifact while hashing interface: " <> message))) pure (decodeTypeArtifact bytes)
+      pure (typeArtifactModuleName artifact, T.pack (stableHash [BL.toStrict (encodeTypeInterface (typeArtifactInterface artifact))]))
 
 updateScopeHashes :: (SourceModule -> FilePath) -> Map.Map Text Text -> [SourceModule] -> IO (Map.Map Text Text)
 updateScopeHashes artifactPath previous unit = do

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -73,8 +73,7 @@ data InstallOptions = InstallOptions
 data InstallV2Options = InstallV2Options
   { installV2PackageDirectory :: !FilePath,
     installV2StoreRoot :: !(Maybe FilePath),
-    installV2Verbose :: !Bool,
-    installV2Dependencies :: ![String]
+    installV2Verbose :: !Bool
   }
   deriving (Eq, Show)
 
@@ -308,13 +307,6 @@ installV2OptionsParser =
       ( OA.long "verbose"
           <> OA.short 'v'
           <> OA.help "Print each installation step"
-      )
-    <*> many
-      ( OA.strOption
-          ( OA.long "dependency"
-              <> OA.metavar "NAME=FULL_ID"
-              <> OA.help "Select one direct library dependency artifact"
-          )
       )
 
 errorFormatParser :: OA.Parser InstallErrorFormat

--- a/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
+++ b/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
@@ -1,0 +1,645 @@
+module Aihc.Cli.TypeArtifact
+  ( TypeArtifact (..),
+    decodeTypeArtifact,
+    encodeTypeArtifact,
+    encodeTypeInterface,
+  )
+where
+
+import Aihc.Resolve (PackageId (..))
+import Aihc.Tc
+  ( ClassInfo (..),
+    DataConFieldInfo (..),
+    DataConFieldUnpack (..),
+    DataConInfo (..),
+    DataConSourceForm (..),
+    DataFamilyInstanceInfo (..),
+    DataTypeInfo (..),
+    InstanceInfo (..),
+    Kind (..),
+    Levity (..),
+    Pred (..),
+    RuntimeRep (..),
+    TcInterface (..),
+    TcTermKey (..),
+    TcType (..),
+    TyCon,
+    TyConFlavor (..),
+    TyConInfo (..),
+    TyVarId (..),
+    TypeScheme (..),
+    Unique (..),
+    VecCount (..),
+    VecElem (..),
+    tvKind,
+    tyConArity,
+    tyConKindScheme,
+    tyConName,
+  )
+import Aihc.Tc.Env (TypeSynonymInfo (..))
+import Aihc.Tc.Types (mkTyConWithOriginScheme, setTyVarKind, tyConModuleName, tyConPackageId)
+import Control.Monad (replicateM, unless)
+import Data.Binary.Get qualified as Get
+import Data.Bits (shiftR)
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
+import Data.Text.Encoding qualified as TE
+import Data.Word (Word64, Word8)
+
+data TypeArtifact = TypeArtifact
+  { typeArtifactModuleName :: !Text,
+    typeArtifactInputHashes :: ![(Text, Text)],
+    typeArtifactInterface :: !TcInterface
+  }
+  deriving (Show)
+
+encodeTypeArtifact :: TypeArtifact -> BL.ByteString
+encodeTypeArtifact artifact =
+  Builder.toLazyByteString $
+    cborArray 5
+      <> cborText "aihc-type"
+      <> cborWord 1
+      <> cborText (typeArtifactModuleName artifact)
+      <> encodeList encodeHash (typeArtifactInputHashes artifact)
+      <> putInterface (typeArtifactInterface artifact)
+  where
+    encodeHash (name, digest) = cborArray 2 <> cborText name <> cborText digest
+
+encodeTypeInterface :: TcInterface -> BL.ByteString
+encodeTypeInterface = Builder.toLazyByteString . putInterface
+
+decodeTypeArtifact :: BS.ByteString -> Either String TypeArtifact
+decodeTypeArtifact bytes =
+  case Get.runGetOrFail getArtifact (BL.fromStrict bytes) of
+    Left (_, _, message) -> Left message
+    Right (remaining, _, artifact)
+      | BL.null remaining -> Right artifact
+      | otherwise -> Left "invalid trailing data"
+
+getArtifact :: Get.Get TypeArtifact
+getArtifact = do
+  expectArray 5
+  expectText "aihc-type"
+  expectWord 1
+  typeArtifactModuleName <- getText
+  typeArtifactInputHashes <- getList getHash
+  typeArtifactInterface <- getInterface
+  pure TypeArtifact {typeArtifactModuleName, typeArtifactInputHashes, typeArtifactInterface}
+  where
+    getHash = expectArray 2 >> ((,) <$> getText <*> getText)
+
+putInterface :: TcInterface -> Builder.Builder
+putInterface interface =
+  cborArray 6
+    <> encodeList putTerm (tcInterfaceTerms interface)
+    <> encodeList putTyConInfo (tcInterfaceTyCons interface)
+    <> encodeList putDataTypeInfo (tcInterfaceDataTypes interface)
+    <> encodeList putClassInfo (tcInterfaceClasses interface)
+    <> encodeList putInstanceInfo (tcInterfaceInstances interface)
+    <> encodeList putDataFamilyInstanceInfo (tcInterfaceDataFamilyInstances interface)
+
+getInterface :: Get.Get TcInterface
+getInterface = do
+  expectArray 6
+  tcInterfaceTerms <- getList getTerm
+  tcInterfaceTyCons <- getList getTyConInfo
+  tcInterfaceDataTypes <- getList getDataTypeInfo
+  tcInterfaceClasses <- getList getClassInfo
+  tcInterfaceInstances <- getList getInstanceInfo
+  tcInterfaceDataFamilyInstances <- getList getDataFamilyInstanceInfo
+  pure TcInterface {tcInterfaceTerms, tcInterfaceTyCons, tcInterfaceDataTypes, tcInterfaceClasses, tcInterfaceInstances, tcInterfaceDataFamilyInstances}
+
+putTerm :: (TcTermKey, TypeScheme) -> Builder.Builder
+putTerm (key, scheme) = cborArray 2 <> putTermKey key <> putTypeScheme scheme
+
+getTerm :: Get.Get (TcTermKey, TypeScheme)
+getTerm = expectArray 2 >> ((,) <$> getTermKey <*> getTypeScheme)
+
+putTermKey :: TcTermKey -> Builder.Builder
+putTermKey key = case key of
+  TcTermLocal unique -> cborArray 2 <> cborWord 0 <> cborInt unique
+  TcTermGlobal (PackageId packageId) moduleName identifier -> cborArray 4 <> cborWord 1 <> cborText packageId <> cborText moduleName <> cborText identifier
+
+getTermKey :: Get.Get TcTermKey
+getTermKey = do
+  length' <- getArrayLength
+  tag <- getWord
+  case (length', tag) of
+    (2, 0) -> TcTermLocal <$> getInt
+    (4, 1) -> (TcTermGlobal . PackageId <$> getText) <*> getText <*> getText
+    _ -> fail "unsupported term key"
+
+putTypeScheme :: TypeScheme -> Builder.Builder
+putTypeScheme (ForAll variables predicates body) = cborArray 3 <> encodeList putTyVar variables <> encodeList putPred predicates <> putType body
+
+getTypeScheme :: Get.Get TypeScheme
+getTypeScheme = expectArray 3 >> (ForAll <$> getList getTyVar <*> getList getPred <*> getType)
+
+putTyVar :: TyVarId -> Builder.Builder
+putTyVar variable = cborArray 3 <> cborText (tvName variable) <> putUnique (tvUnique variable) <> putKind (tvKind variable)
+
+getTyVar :: Get.Get TyVarId
+getTyVar = do
+  expectArray 3
+  name <- getText
+  unique <- getUnique
+  kind <- getKind
+  pure (setTyVarKind kind (TyVarId name unique))
+
+putUnique :: Unique -> Builder.Builder
+putUnique (Unique value) = cborInt value
+
+getUnique :: Get.Get Unique
+getUnique = Unique <$> getInt
+
+putTyCon :: TyCon -> Builder.Builder
+putTyCon tyCon =
+  cborArray 5
+    <> putPackageId (tyConPackageId tyCon)
+    <> cborText (tyConModuleName tyCon)
+    <> cborText (tyConName tyCon)
+    <> cborInt (tyConArity tyCon)
+    <> putTypeScheme (tyConKindScheme tyCon)
+
+getTyCon :: Get.Get TyCon
+getTyCon = do
+  expectArray 5
+  mkTyConWithOriginScheme <$> getPackageId <*> getText <*> getText <*> getInt <*> getTypeScheme
+
+putPackageId :: PackageId -> Builder.Builder
+putPackageId (PackageId identity) = cborText identity
+
+getPackageId :: Get.Get PackageId
+getPackageId = PackageId <$> getText
+
+putKind :: Kind -> Builder.Builder
+putKind kind = case kind of
+  KTYPE representation -> sum1 0 (putRuntimeRep representation)
+  KConstraint -> sum0 1
+  KRuntimeRep -> sum0 2
+  KLevity -> sum0 3
+  KVecCount -> sum0 4
+  KVecElem -> sum0 5
+  KFun argument result -> sum2 6 (putKind argument) (putKind result)
+  KMeta unique -> sum1 7 (putUnique unique)
+
+getKind :: Get.Get Kind
+getKind = do
+  length' <- getArrayLength
+  tag <- getWord
+  case (length', tag) of
+    (2, 0) -> KTYPE <$> getRuntimeRep
+    (1, 1) -> pure KConstraint
+    (1, 2) -> pure KRuntimeRep
+    (1, 3) -> pure KLevity
+    (1, 4) -> pure KVecCount
+    (1, 5) -> pure KVecElem
+    (3, 6) -> KFun <$> getKind <*> getKind
+    (2, 7) -> KMeta <$> getUnique
+    _ -> fail "unsupported kind"
+
+putRuntimeRep :: RuntimeRep -> Builder.Builder
+putRuntimeRep representation = case representation of
+  VecRep count element -> sum2 0 (putVecCount count) (putVecElem element)
+  TupleRep fields -> sum1 1 (encodeList putRuntimeRep fields)
+  SumRep fields -> sum1 2 (encodeList putRuntimeRep fields)
+  BoxedRep levity -> sum1 3 (putLevity levity)
+  IntRep -> sum0 4
+  Int8Rep -> sum0 5
+  Int16Rep -> sum0 6
+  Int32Rep -> sum0 7
+  Int64Rep -> sum0 8
+  WordRep -> sum0 9
+  Word8Rep -> sum0 10
+  Word16Rep -> sum0 11
+  Word32Rep -> sum0 12
+  Word64Rep -> sum0 13
+  AddrRep -> sum0 14
+  FloatRep -> sum0 15
+  DoubleRep -> sum0 16
+  RuntimeRepVar unique -> sum1 17 (putUnique unique)
+  RuntimeRepMeta unique -> sum1 18 (putUnique unique)
+
+getRuntimeRep :: Get.Get RuntimeRep
+getRuntimeRep = do
+  length' <- getArrayLength
+  tag <- getWord
+  case (length', tag) of
+    (3, 0) -> VecRep <$> getVecCount <*> getVecElem
+    (2, 1) -> TupleRep <$> getList getRuntimeRep
+    (2, 2) -> SumRep <$> getList getRuntimeRep
+    (2, 3) -> BoxedRep <$> getLevity
+    (1, 4) -> pure IntRep
+    (1, 5) -> pure Int8Rep
+    (1, 6) -> pure Int16Rep
+    (1, 7) -> pure Int32Rep
+    (1, 8) -> pure Int64Rep
+    (1, 9) -> pure WordRep
+    (1, 10) -> pure Word8Rep
+    (1, 11) -> pure Word16Rep
+    (1, 12) -> pure Word32Rep
+    (1, 13) -> pure Word64Rep
+    (1, 14) -> pure AddrRep
+    (1, 15) -> pure FloatRep
+    (1, 16) -> pure DoubleRep
+    (2, 17) -> RuntimeRepVar <$> getUnique
+    (2, 18) -> RuntimeRepMeta <$> getUnique
+    _ -> fail "unsupported runtime representation"
+
+putType :: TcType -> Builder.Builder
+putType ty = case ty of
+  TcTyVar variable -> sum1 0 (putTyVar variable)
+  TcMetaTv unique -> sum1 1 (putUnique unique)
+  TcTyCon tyCon arguments -> sum2 2 (putTyCon tyCon) (encodeList putType arguments)
+  TcFunTy argument result -> sum2 3 (putType argument) (putType result)
+  TcForAllTy variable body -> sum2 4 (putTyVar variable) (putType body)
+  TcQualTy predicates body -> sum2 5 (encodeList putPred predicates) (putType body)
+  TcAppTy function argument -> sum2 6 (putType function) (putType argument)
+  TcBuiltinTyCon name arity arguments -> cborArray 4 <> cborWord 7 <> cborText name <> cborInt arity <> encodeList putType arguments
+
+getType :: Get.Get TcType
+getType = do
+  length' <- getArrayLength
+  tag <- getWord
+  case (length', tag) of
+    (2, 0) -> TcTyVar <$> getTyVar
+    (2, 1) -> TcMetaTv <$> getUnique
+    (3, 2) -> TcTyCon <$> getTyCon <*> getList getType
+    (3, 3) -> TcFunTy <$> getType <*> getType
+    (3, 4) -> TcForAllTy <$> getTyVar <*> getType
+    (3, 5) -> TcQualTy <$> getList getPred <*> getType
+    (3, 6) -> TcAppTy <$> getType <*> getType
+    (4, 7) -> TcBuiltinTyCon <$> getText <*> getInt <*> getList getType
+    _ -> fail "unsupported type"
+
+putPred :: Pred -> Builder.Builder
+putPred predicate = case predicate of
+  ClassPred name arguments -> sum2 0 (cborText name) (encodeList putType arguments)
+  EqPred left right -> sum2 1 (putType left) (putType right)
+
+getPred :: Get.Get Pred
+getPred = do
+  expectArray 3
+  tag <- getWord
+  case tag of
+    0 -> ClassPred <$> getText <*> getList getType
+    1 -> EqPred <$> getType <*> getType
+    _ -> fail "unsupported predicate"
+
+putTyConInfo :: TyConInfo -> Builder.Builder
+putTyConInfo info = cborArray 5 <> cborText (tciName info) <> cborInt (tciArity info) <> putTyCon (tciTyCon info) <> putTyConFlavor (tciFlavor info) <> putMaybe putTypeSynonymInfo (tciTypeSynonym info)
+
+getTyConInfo :: Get.Get TyConInfo
+getTyConInfo = do
+  expectArray 5
+  tciName <- getText
+  tciArity <- getInt
+  tciTyCon <- getTyCon
+  tciFlavor <- getTyConFlavor
+  tciTypeSynonym <- getMaybe getTypeSynonymInfo
+  pure TyConInfo {tciName, tciArity, tciTyCon, tciFlavor, tciTypeSynonym}
+
+putTypeSynonymInfo :: TypeSynonymInfo -> Builder.Builder
+putTypeSynonymInfo info = cborArray 2 <> encodeList putTyVar (tsiParams info) <> putMaybe putType (tsiBody info)
+
+getTypeSynonymInfo :: Get.Get TypeSynonymInfo
+getTypeSynonymInfo = expectArray 2 >> (TypeSynonymInfo <$> getList getTyVar <*> getMaybe getType)
+
+putDataTypeInfo :: DataTypeInfo -> Builder.Builder
+putDataTypeInfo info = cborArray 5 <> cborText (dtiName info) <> putTyCon (dtiTyCon info) <> encodeList putTyVar (dtiTyVars info) <> putTyConFlavor (dtiFlavor info) <> encodeList putDataConInfo (dtiConstructors info)
+
+getDataTypeInfo :: Get.Get DataTypeInfo
+getDataTypeInfo = do
+  expectArray 5
+  dtiName <- getText
+  dtiTyCon <- getTyCon
+  dtiTyVars <- getList getTyVar
+  dtiFlavor <- getTyConFlavor
+  dtiConstructors <- getList getDataConInfo
+  pure DataTypeInfo {dtiName, dtiTyCon, dtiTyVars, dtiFlavor, dtiConstructors}
+
+putDataConInfo :: DataConInfo -> Builder.Builder
+putDataConInfo info =
+  cborArray 8
+    <> cborText (dciName info)
+    <> putOrigin (dciOrigin info)
+    <> encodeList putTyVar (dciUnivTyVars info)
+    <> encodeList putTyVar (dciExTyVars info)
+    <> encodeList putPred (dciTheta info)
+    <> encodeList putDataConFieldInfo (dciFields info)
+    <> putType (dciResTy info)
+    <> putDataConSourceForm (dciSourceForm info)
+
+getDataConInfo :: Get.Get DataConInfo
+getDataConInfo = do
+  expectArray 8
+  dciName <- getText
+  dciOrigin <- getOrigin
+  dciUnivTyVars <- getList getTyVar
+  dciExTyVars <- getList getTyVar
+  dciTheta <- getList getPred
+  dciFields <- getList getDataConFieldInfo
+  dciResTy <- getType
+  dciSourceForm <- getDataConSourceForm
+  pure DataConInfo {dciName, dciOrigin, dciUnivTyVars, dciExTyVars, dciTheta, dciFields, dciResTy, dciSourceForm}
+
+putDataConFieldInfo :: DataConFieldInfo -> Builder.Builder
+putDataConFieldInfo info = cborArray 5 <> putMaybe cborText (dcfiLabel info) <> putType (dcfiType info) <> putBool (dcfiStrict info) <> putBool (dcfiLazy info) <> putDataConFieldUnpack (dcfiUnpack info)
+
+getDataConFieldInfo :: Get.Get DataConFieldInfo
+getDataConFieldInfo = do
+  expectArray 5
+  dcfiLabel <- getMaybe getText
+  dcfiType <- getType
+  dcfiStrict <- getBool
+  dcfiLazy <- getBool
+  dcfiUnpack <- getDataConFieldUnpack
+  pure DataConFieldInfo {dcfiLabel, dcfiType, dcfiStrict, dcfiLazy, dcfiUnpack}
+
+putClassInfo :: ClassInfo -> Builder.Builder
+putClassInfo info =
+  cborArray 7
+    <> cborText (ciName info)
+    <> putMaybe putTextOrigin (ciOrigin info)
+    <> encodeList putTyVar (ciTyVars info)
+    <> encodeList putType (ciSuperClassTypes info)
+    <> encodeList putNamedScheme (ciMethods info)
+    <> encodeList cborText (ciDefaultMethods info)
+    <> encodeList putNamedScheme (ciDefaultSignatures info)
+
+getClassInfo :: Get.Get ClassInfo
+getClassInfo = do
+  expectArray 7
+  ciName <- getText
+  ciOrigin <- getMaybe getTextOrigin
+  ciTyVars <- getList getTyVar
+  ciSuperClassTypes <- getList getType
+  ciMethods <- getList getNamedScheme
+  ciDefaultMethods <- getList getText
+  ciDefaultSignatures <- getList getNamedScheme
+  pure ClassInfo {ciName, ciOrigin, ciTyVars, ciSuperClassTypes, ciMethods, ciDefaultMethods, ciDefaultSignatures}
+
+putInstanceInfo :: InstanceInfo -> Builder.Builder
+putInstanceInfo info =
+  cborArray 7
+    <> cborText (iiClassName info)
+    <> cborText (iiDictName info)
+    <> putMaybe putTextOrigin (iiDictOrigin info)
+    <> putType (iiDictType info)
+    <> encodeList putTyVar (iiTyVars info)
+    <> encodeList putPred (iiContext info)
+    <> encodeList putType (iiHead info)
+
+getInstanceInfo :: Get.Get InstanceInfo
+getInstanceInfo = do
+  expectArray 7
+  iiClassName <- getText
+  iiDictName <- getText
+  iiDictOrigin <- getMaybe getTextOrigin
+  iiDictType <- getType
+  iiTyVars <- getList getTyVar
+  iiContext <- getList getPred
+  iiHead <- getList getType
+  pure InstanceInfo {iiClassName, iiDictName, iiDictOrigin, iiDictType, iiTyVars, iiContext, iiHead}
+
+putDataFamilyInstanceInfo :: DataFamilyInstanceInfo -> Builder.Builder
+putDataFamilyInstanceInfo info =
+  cborArray 7
+    <> cborText (dfiiFamilyName info)
+    <> putType (dfiiFamilyType info)
+    <> encodeList putTyVar (dfiiTyVars info)
+    <> putTyCon (dfiiRepresentationTyCon info)
+    <> cborText (dfiiAxiomName info)
+    <> encodeList cborText (dfiiConstructorNames info)
+    <> putBool (dfiiIsNewtype info)
+
+getDataFamilyInstanceInfo :: Get.Get DataFamilyInstanceInfo
+getDataFamilyInstanceInfo = do
+  expectArray 7
+  dfiiFamilyName <- getText
+  dfiiFamilyType <- getType
+  dfiiTyVars <- getList getTyVar
+  dfiiRepresentationTyCon <- getTyCon
+  dfiiAxiomName <- getText
+  dfiiConstructorNames <- getList getText
+  dfiiIsNewtype <- getBool
+  pure DataFamilyInstanceInfo {dfiiFamilyName, dfiiFamilyType, dfiiTyVars, dfiiRepresentationTyCon, dfiiAxiomName, dfiiConstructorNames, dfiiIsNewtype}
+
+putOrigin :: (PackageId, Text) -> Builder.Builder
+putOrigin (packageId, moduleName) = cborArray 2 <> putPackageId packageId <> cborText moduleName
+
+getOrigin :: Get.Get (PackageId, Text)
+getOrigin = expectArray 2 >> ((,) <$> getPackageId <*> getText)
+
+putTextOrigin :: (Text, Text) -> Builder.Builder
+putTextOrigin (packageId, moduleName) = cborArray 2 <> cborText packageId <> cborText moduleName
+
+getTextOrigin :: Get.Get (Text, Text)
+getTextOrigin = expectArray 2 >> ((,) <$> getText <*> getText)
+
+putNamedScheme :: (Text, TypeScheme) -> Builder.Builder
+putNamedScheme (name, scheme) = cborArray 2 <> cborText name <> putTypeScheme scheme
+
+getNamedScheme :: Get.Get (Text, TypeScheme)
+getNamedScheme = expectArray 2 >> ((,) <$> getText <*> getTypeScheme)
+
+encodeList :: (value -> Builder.Builder) -> [value] -> Builder.Builder
+encodeList encode values = cborArray (length values) <> foldMap encode values
+
+getList :: Get.Get value -> Get.Get [value]
+getList getValue = getArrayLength >>= (`replicateM` getValue)
+
+putMaybe :: (value -> Builder.Builder) -> Maybe value -> Builder.Builder
+putMaybe encode value = case value of
+  Nothing -> cborArray 1 <> cborWord 0
+  Just item -> cborArray 2 <> cborWord 1 <> encode item
+
+getMaybe :: Get.Get value -> Get.Get (Maybe value)
+getMaybe getValue = do
+  length' <- getArrayLength
+  tag <- getWord
+  case (length', tag) of
+    (1, 0) -> pure Nothing
+    (2, 1) -> Just <$> getValue
+    _ -> fail "unsupported optional value"
+
+putBool :: Bool -> Builder.Builder
+putBool value = cborWord (if value then 1 else 0)
+
+getBool :: Get.Get Bool
+getBool = do
+  value <- getWord
+  case value of
+    0 -> pure False
+    1 -> pure True
+    _ -> fail "unsupported Boolean value"
+
+putTyConFlavor :: TyConFlavor -> Builder.Builder
+putTyConFlavor flavor = cborWord $ case flavor of
+  ClassTyCon -> 0
+  DataTyCon -> 1
+  DataFamilyTyCon -> 2
+  NewtypeTyCon -> 3
+  SynonymTyCon -> 4
+
+getTyConFlavor :: Get.Get TyConFlavor
+getTyConFlavor = getTagged "type constructor flavor" [(0, ClassTyCon), (1, DataTyCon), (2, DataFamilyTyCon), (3, NewtypeTyCon), (4, SynonymTyCon)]
+
+putDataConSourceForm :: DataConSourceForm -> Builder.Builder
+putDataConSourceForm sourceForm = cborWord $ case sourceForm of
+  PrefixDataCon -> 0
+  InfixDataCon -> 1
+  RecordDataCon -> 2
+
+getDataConSourceForm :: Get.Get DataConSourceForm
+getDataConSourceForm = getTagged "constructor source form" [(0, PrefixDataCon), (1, InfixDataCon), (2, RecordDataCon)]
+
+putDataConFieldUnpack :: DataConFieldUnpack -> Builder.Builder
+putDataConFieldUnpack unpack = cborWord $ case unpack of
+  NoFieldUnpack -> 0
+  UnpackField -> 1
+  NoUnpackField -> 2
+
+getDataConFieldUnpack :: Get.Get DataConFieldUnpack
+getDataConFieldUnpack = getTagged "field unpack mode" [(0, NoFieldUnpack), (1, UnpackField), (2, NoUnpackField)]
+
+putLevity :: Levity -> Builder.Builder
+putLevity levity = cborWord $ case levity of
+  Lifted -> 0
+  Unlifted -> 1
+
+getLevity :: Get.Get Levity
+getLevity = getTagged "levity" [(0, Lifted), (1, Unlifted)]
+
+putVecCount :: VecCount -> Builder.Builder
+putVecCount count = cborWord $ case count of
+  Vec2 -> 0
+  Vec4 -> 1
+  Vec8 -> 2
+  Vec16 -> 3
+  Vec32 -> 4
+  Vec64 -> 5
+
+getVecCount :: Get.Get VecCount
+getVecCount = getTagged "vector count" [(0, Vec2), (1, Vec4), (2, Vec8), (3, Vec16), (4, Vec32), (5, Vec64)]
+
+putVecElem :: VecElem -> Builder.Builder
+putVecElem element = cborWord $ case element of
+  Int8ElemRep -> 0
+  Int16ElemRep -> 1
+  Int32ElemRep -> 2
+  Int64ElemRep -> 3
+  Word8ElemRep -> 4
+  Word16ElemRep -> 5
+  Word32ElemRep -> 6
+  Word64ElemRep -> 7
+  FloatElemRep -> 8
+  DoubleElemRep -> 9
+
+getVecElem :: Get.Get VecElem
+getVecElem =
+  getTagged
+    "vector element"
+    [ (0, Int8ElemRep),
+      (1, Int16ElemRep),
+      (2, Int32ElemRep),
+      (3, Int64ElemRep),
+      (4, Word8ElemRep),
+      (5, Word16ElemRep),
+      (6, Word32ElemRep),
+      (7, Word64ElemRep),
+      (8, FloatElemRep),
+      (9, DoubleElemRep)
+    ]
+
+getTagged :: String -> [(Word64, value)] -> Get.Get value
+getTagged label values = do
+  tag <- getWord
+  case lookup tag values of
+    Just value -> pure value
+    Nothing -> fail ("unsupported " <> label)
+
+sum0 :: Word64 -> Builder.Builder
+sum0 tag = cborArray 1 <> cborWord tag
+
+sum1 :: Word64 -> Builder.Builder -> Builder.Builder
+sum1 tag first = cborArray 2 <> cborWord tag <> first
+
+sum2 :: Word64 -> Builder.Builder -> Builder.Builder -> Builder.Builder
+sum2 tag first second = cborArray 3 <> cborWord tag <> first <> second
+
+expectArray :: Int -> Get.Get ()
+expectArray expected = do
+  actual <- getArrayLength
+  unless (actual == expected) (fail "unexpected CBOR array length")
+
+expectText :: Text -> Get.Get ()
+expectText expected = do
+  actual <- getText
+  unless (actual == expected) (fail "unexpected artifact kind")
+
+expectWord :: Word64 -> Get.Get ()
+expectWord expected = do
+  actual <- getWord
+  unless (actual == expected) (fail "unsupported schema version")
+
+cborArray :: Int -> Builder.Builder
+cborArray = cborMajor 4 . fromIntegral
+
+cborText :: Text -> Builder.Builder
+cborText value = cborMajor 3 (fromIntegral (BS.length bytes)) <> Builder.byteString bytes
+  where
+    bytes = TE.encodeUtf8 value
+
+cborInt :: Int -> Builder.Builder
+cborInt value
+  | value >= 0 = cborMajor 0 (fromIntegral value)
+  | otherwise = cborMajor 1 (fromIntegral (-1 - value))
+
+cborWord :: Word64 -> Builder.Builder
+cborWord = cborMajor 0
+
+cborMajor :: Word8 -> Word64 -> Builder.Builder
+cborMajor major value
+  | value < 24 = Builder.word8 (major * 32 + fromIntegral value)
+  | value <= 255 = Builder.word8 (major * 32 + 24) <> Builder.word8 (fromIntegral value)
+  | value <= 65535 = Builder.word8 (major * 32 + 25) <> Builder.word16BE (fromIntegral value)
+  | value <= 4294967295 = Builder.word8 (major * 32 + 26) <> Builder.word32BE (fromIntegral value)
+  | otherwise = Builder.word8 (major * 32 + 27) <> Builder.word64BE value
+
+getArrayLength :: Get.Get Int
+getArrayLength = fromIntegral <$> getMajor 4
+
+getText :: Get.Get Text
+getText = do
+  length' <- getMajor 3
+  TE.decodeUtf8 <$> Get.getByteString (fromIntegral length')
+
+getInt :: Get.Get Int
+getInt = do
+  initial <- Get.lookAhead Get.getWord8
+  let major = initial `shiftR` 5
+  value <- getMajor major
+  case major of
+    0 -> pure (fromIntegral value)
+    1 -> pure (-1 - fromIntegral value)
+    _ -> fail "unexpected CBOR integer"
+
+getWord :: Get.Get Word64
+getWord = getMajor 0
+
+getMajor :: Word8 -> Get.Get Word64
+getMajor expected = do
+  initial <- Get.getWord8
+  let major = initial `shiftR` 5
+      info = initial `mod` 32
+  unless (major == expected) (fail "unexpected CBOR major type")
+  case info of
+    value | value < 24 -> pure (fromIntegral value)
+    24 -> fromIntegral <$> Get.getWord8
+    25 -> fromIntegral <$> Get.getWord16be
+    26 -> fromIntegral <$> Get.getWord32be
+    27 -> Get.getWord64be
+    _ -> fail "unsupported CBOR length"

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -4,9 +4,12 @@ module Main (main) where
 
 import Aihc.Cli.InstallV2 (InstallV2Result (..), installV2)
 import Aihc.Cli.Options (InstallV2Options (..))
+import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact)
+import Aihc.Tc (TcInterface (..), tcTermKeyIdentifier)
 import Control.Exception (bracket)
 import Data.ByteString qualified as BS
 import Data.List (sort)
+import Data.Maybe (mapMaybe)
 import Hedgehog (Property, property, success)
 import System.Directory
   ( createDirectory,
@@ -19,7 +22,7 @@ import System.Directory
 import System.FilePath ((</>))
 import System.IO (hClose, openTempFile)
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, testCase)
+import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Test.Tasty.Hedgehog (testProperty)
 
 main :: IO ()
@@ -134,8 +137,6 @@ main =
       --         "command"
       --         (Right (CmdInstallV2 (InstallV2Options "core-libs/aihc-prim" (Just "/tmp/aihc-store") True)))
       --         (parseCommandPure ["install-v2", "core-libs/aihc-prim", "--store", "/tmp/aihc-store", "--verbose"]),
-      --     testCase "rejects explicit dependency variants" $
-      --       assertLeftContains "dependency" (parseCommandPure ["install", "a", "--dependency", "b=1.0.0:abcdef"]),
       --     testCase "parses repl" $
       --       assertEqual "command" (Right (CmdRepl (ReplOptions Nothing))) (parseCommandPure ["repl"]),
       --     testCase "parses repl store" $
@@ -326,8 +327,9 @@ main =
         "install-v2"
         [ testCase "writes one resolve artifact for each module and reuses equal SCC inputs" test_installV2ResolveArtifacts,
           testCase "rebuilds a module when a predecessor resolve artifact changes" test_installV2ResolveDependencies,
-          testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope,
-          testCase "uses full library dependency identities in dephash" test_installV2DependencyHash
+          testCase "rebuilds a module when a predecessor type interface changes" test_installV2TypeDependencies,
+          testCase "duplicates re-exported term signatures in type interfaces" test_installV2TypeReexports,
+          testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope
         ],
       testProperty "Hedgehog options" prop_dummy
     ]
@@ -341,7 +343,48 @@ test_installV2ResolveArtifacts =
     let sourceRoot = root </> "source"
         storeRoot = root </> "store"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just storeRoot) False []
+        options = InstallV2Options sourceRoot (Just storeRoot) False
+    createDirectoryIfMissing True sourceDir
+    writeFile
+      (sourceRoot </> "demo.cabal")
+      ( unlines
+          [ "cabal-version: 3.0",
+            "name: demo",
+            "version: 0.1.0.0",
+            "library",
+            "  exposed-modules: Demo.A, Demo.B",
+            "  hs-source-dirs: src",
+            "  default-language: Haskell2010"
+          ]
+      )
+    writeFile (sourceDir </> "A.hs") "module Demo.A where\nimport Demo.B\na = a\n"
+    writeFile (sourceDir </> "B.hs") "module Demo.B where\nimport Demo.A\nb = b\n"
+    first <- installV2 options
+    assertEqual "written modules" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules first))
+    assertFileExists (installV2StorePath first </> "Demo" </> "A" </> "resolve.cbor")
+    assertFileExists (installV2StorePath first </> "Demo" </> "B" </> "resolve.cbor")
+    assertFileExists (installV2StorePath first </> "Demo" </> "A" </> "type.cbor")
+    assertFileExists (installV2StorePath first </> "Demo" </> "B" </> "type.cbor")
+    second <- installV2 options
+    assertEqual "reused modules" ["Demo.A", "Demo.B"] (sort (installV2ReusedModules second))
+    assertEqual "stable package directory" (installV2StorePath first) (installV2StorePath second)
+    writeFile (sourceDir </> "B.hs") "module Demo.B where\nimport Demo.A\nb = (b)\n"
+    changed <- installV2 options
+    assertEqual "source changes keep the package directory" (installV2StorePath first) (installV2StorePath changed)
+    assertEqual "source changes rebuild the complete SCC" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules changed))
+    let artifact = installV2StorePath first </> "Demo" </> "A" </> "resolve.cbor"
+    artifactBytes <- BS.readFile artifact
+    BS.writeFile artifact (BS.init artifactBytes)
+    repaired <- installV2 options
+    assertEqual "repairs the complete corrupt SCC" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules repaired))
+    assertEqual "does not reuse a corrupt SCC" [] (installV2ReusedModules repaired)
+
+test_installV2TypeDependencies :: Assertion
+test_installV2TypeDependencies =
+  withTempDir "aihc-install-v2-type-dependencies" $ \root -> do
+    let sourceRoot = root </> "source"
+        sourceDir = sourceRoot </> "src" </> "Demo"
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -356,31 +399,48 @@ test_installV2ResolveArtifacts =
           ]
       )
     writeFile (sourceDir </> "A.hs") "module Demo.A where\nimport Demo.B\na = b\n"
-    writeFile (sourceDir </> "B.hs") "module Demo.B where\nimport Demo.A\nb = a\n"
-    first <- installV2 options
-    assertEqual "written modules" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules first))
-    assertFileExists (installV2StorePath first </> "Demo" </> "A" </> "resolve.cbor")
-    assertFileExists (installV2StorePath first </> "Demo" </> "B" </> "resolve.cbor")
-    second <- installV2 options
-    assertEqual "reused modules" ["Demo.A", "Demo.B"] (sort (installV2ReusedModules second))
-    assertEqual "stable package directory" (installV2StorePath first) (installV2StorePath second)
-    writeFile (sourceDir </> "B.hs") "module Demo.B where\nimport Demo.A\nb = (a)\n"
+    writeFile (sourceDir </> "B.hs") "module Demo.B where\nb x = x\n"
+    _ <- installV2 options
+    writeFile (sourceDir </> "B.hs") "module Demo.B where\nb x y = x\n"
     changed <- installV2 options
-    assertEqual "source changes keep the package directory" (installV2StorePath first) (installV2StorePath changed)
-    assertEqual "source changes rebuild the complete SCC" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules changed))
-    let artifact = installV2StorePath first </> "Demo" </> "A" </> "resolve.cbor"
-    artifactBytes <- BS.readFile artifact
-    BS.writeFile artifact (BS.init artifactBytes)
-    repaired <- installV2 options
-    assertEqual "repairs the complete corrupt SCC" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules repaired))
-    assertEqual "does not reuse a corrupt SCC" [] (installV2ReusedModules repaired)
+    assertEqual "type change and direct dependent" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules changed))
+    assertEqual "no reused dependent after type change" [] (installV2ReusedModules changed)
+
+test_installV2TypeReexports :: Assertion
+test_installV2TypeReexports =
+  withTempDir "aihc-install-v2-type-reexports" $ \root -> do
+    let sourceRoot = root </> "source"
+        sourceDir = sourceRoot </> "src" </> "Demo"
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+    createDirectoryIfMissing True sourceDir
+    writeFile
+      (sourceRoot </> "demo.cabal")
+      ( unlines
+          [ "cabal-version: 3.0",
+            "name: demo",
+            "version: 0.1.0.0",
+            "library",
+            "  exposed-modules: Demo.A, Demo.B",
+            "  hs-source-dirs: src",
+            "  default-language: Haskell2010"
+          ]
+      )
+    writeFile
+      (sourceDir </> "A.hs")
+      "module Demo.A where\ndata Box a = Box a\nclass Identity a where\n  identity :: a -> a\nfn x = x\n"
+    writeFile (sourceDir </> "B.hs") "module Demo.B (module Demo.A) where\nimport Demo.A\n"
+    result <- installV2 options
+    bytes <- BS.readFile (installV2StorePath result </> "Demo" </> "B" </> "type.cbor")
+    artifact <- either assertFailure pure (decodeTypeArtifact bytes)
+    let termNames = mapMaybe (tcTermKeyIdentifier . fst) (tcInterfaceTerms (typeArtifactInterface artifact))
+    assertBool "re-exported signature" ("fn" `elem` termNames)
 
 test_installV2ResolveDependencies :: Assertion
 test_installV2ResolveDependencies =
   withTempDir "aihc-install-v2-dependencies" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False []
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -406,43 +466,12 @@ test_installV2ResolveDependencies =
     assertEqual "changed scope and dependent modules" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules scopeChanged))
     assertEqual "no reused dependent after scope change" [] (installV2ReusedModules scopeChanged)
 
-test_installV2DependencyHash :: Assertion
-test_installV2DependencyHash =
-  withTempDir "aihc-install-v2-dephash" $ \root -> do
-    let sourceRoot = root </> "source"
-        sourceDir = sourceRoot </> "src"
-        storeRoot = root </> "store"
-        firstDependency = storeRoot </> "dep-1.0-first-full-id"
-        secondDependency = storeRoot </> "dep-1.0-second-full-id"
-        optionsFor identity = InstallV2Options sourceRoot (Just storeRoot) False ["dep=" <> identity]
-    createDirectoryIfMissing True sourceDir
-    createDirectoryIfMissing True firstDependency
-    writeFile
-      (sourceRoot </> "demo.cabal")
-      ( unlines
-          [ "cabal-version: 3.0",
-            "name: demo",
-            "version: 0.1.0.0",
-            "library",
-            "  exposed-modules: Demo",
-            "  hs-source-dirs: src",
-            "  build-depends: dep",
-            "  default-language: Haskell2010"
-          ]
-      )
-    writeFile (sourceDir </> "Demo.hs") "module Demo where\nx = x\n"
-    first <- installV2 (optionsFor "dep-1.0-first-full-id")
-    removeDirectoryRecursive firstDependency
-    createDirectoryIfMissing True secondDependency
-    second <- installV2 (optionsFor "dep-1.0-second-full-id")
-    assertBool "dependency identity changes dephash" (installV2StorePath first /= installV2StorePath second)
-
 test_installV2StopsAtEqualScope :: Assertion
 test_installV2StopsAtEqualScope =
   withTempDir "aihc-install-v2-scope-boundary" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False []
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -263,7 +263,7 @@ The resolver must then write one interface for each module. Each file contains o
 
 The type interface contains the semantic facts needed to type-check dependent modules.
 
-The interface must contain declarations that this module defines and exports. It must not copy declarations that this module only re-exports.
+The interface must contain type/kind signatures for every exported symbol, even re-exports.
 
 The interface must contain every class and family instance that this module exports. This set includes locally defined and imported instances.
 
@@ -299,9 +299,9 @@ TermInterface
   typeScheme
 ```
 
-Store one term entry for each locally defined and exported value. The type scheme includes quantified variables, kinds, and constraints.
+Store one term entry for each exported value. This set includes locally defined and re-exported values.
 
-Do not store a term entry for a re-exported value. Its defining module already stores its type scheme.
+The type scheme includes quantified variables, kinds, and constraints. Keep the original definition identity for a re-exported value.
 
 Constructor and method types can occur in their declaration records. Do not duplicate them in `terms`.
 
@@ -472,13 +472,19 @@ The type checker must process all modules in one SCC together. It must use prede
 
 Load the type interface for each directly imported module.
 
-Inspect each imported name-resolution interface for definition identities from other modules. Load the type interface for each provider module.
+The imported interface contains the type signatures for its re-exported names. Do not load provider interfaces for those signatures.
 
-Inspect definition identities in each loaded type interface. Continue to load provider type interfaces until the provider set does not change.
+Thus, the incremental input relation is:
 
-For example, module `C` can import module `B`, which re-exports a definition from module `A`. In this case, load both type interfaces.
+```text
+Haskell module + scopes of direct module dependencies + type interfaces of direct module dependencies -> type.cbor
+```
 
-An artifact store locates a provider package directory from the `PackageIdentity` in its definition identity.
+Regenerate `type.cbor` if its Haskell module changes. Also regenerate it if a direct dependency scope or type interface changes.
+
+Hash only the semantic type interface for dependent checks. Do not include the source hash or dependency hashes in this hash.
+
+If a regenerated semantic interface has the same hash, do not regenerate its dependents for this change.
 
 The type checker must produce one type interface for each module. A file must not contain the combined interface for the complete SCC.
 


### PR DESCRIPTION
## Summary

- Add deterministic CBOR encoding and decoding for `TcInterface` data.
- Write one `type.cbor` artifact for each module.
- Reuse stored type interfaces when source, scope, and type inputs do not change.
- Include term signatures for module re-exports.
- Remove the unused manual dependency selection option.
- Document direct type interface inputs and invalidation rules.

## Purpose

Dependent modules need stored type facts for separate type checks. These facts include terms, kinds, data types, classes, and instances.

## Effect

The installer now checks each module SCC with predecessor type interfaces. A semantic interface change invalidates each direct dependent module.

The type interface hash excludes source and dependency hashes. Equal semantic output stops further invalidation.

## Test progress

The `install-v2` test count increases from 4 to 5.

The new tests cover artifact reuse, type dependency invalidation, re-exported term signatures, data types, and classes.

## Validation

- `just fmt`
- `just check`