### PR TITLE
feat(cli): install package dependencies automatically

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -25,8 +25,10 @@ module Aihc.Cli.Install
     ParsedInterfaceFile (..),
     parseInterfaceFile,
     lookupPackagePlanSourceLineCount,
+    localDependencyResolverWithFallback,
     newPackageCheckCache,
     newPackagePlanCache,
+    packageSpecFromSource,
     packagePlanFailureShouldBeReportedForPackage,
     packageVariantLibraryId,
     renderInstallFailure,
@@ -375,7 +377,11 @@ installRequest opts = do
       pure (PackageSpec packageArgument version, hackageDependencyResolver opts)
 
 localDependencyResolver :: InstallOptions -> FilePath -> DependencyResolver
-localDependencyResolver opts rootSource =
+localDependencyResolver opts =
+  localDependencyResolverWithFallback (hackageDependencyResolver opts)
+
+localDependencyResolverWithFallback :: DependencyResolver -> FilePath -> DependencyResolver
+localDependencyResolverWithFallback fallback rootSource =
   DependencyResolver
     { resolverResolveVersion = \name -> do
         local <- localPackage name
@@ -388,16 +394,19 @@ localDependencyResolver opts rootSource =
           _ -> resolverSourcePath fallback spec
     }
   where
-    fallback = hackageDependencyResolver opts
     workspace = takeDirectory (normalise rootSource)
     localPackage name = do
-      let candidate = workspace </> name
-      exists <- doesDirectoryExist candidate
-      if exists
-        then do
-          spec <- packageSpecFromSource candidate
-          pure (Just (spec, candidate))
-        else pure Nothing
+      rootSpec <- packageSpecFromSource rootSource
+      if pkgName rootSpec == name
+        then pure (Just (rootSpec, rootSource))
+        else do
+          let candidate = workspace </> name
+          exists <- doesDirectoryExist candidate
+          if exists
+            then do
+              spec <- packageSpecFromSource candidate
+              pure (Just (spec, candidate))
+            else pure Nothing
 
 packageSpecFromSource :: FilePath -> IO PackageSpec
 packageSpecFromSource sourcePath = do

--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -5,13 +5,23 @@ module Aihc.Cli.InstallV2
   )
 where
 
-import Aihc.Cli.Install (ParsedInterfaceFile (..), parseInterfaceFile)
+import Aihc.Cli.Install
+  ( DependencyResolver (..),
+    PackagePlan (..),
+    ParsedInterfaceFile (..),
+    buildPackagePlanWithResolver,
+    localDependencyResolverWithFallback,
+    packageSpecFromSource,
+    parseInterfaceFile,
+  )
 import Aihc.Cli.Options (InstallV2Options (..))
 import Aihc.Cli.ResolveArtifact (ResolveArtifact (..), decodeResolveArtifact, encodeResolveArtifact, encodeResolveScope)
 import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact, encodeTypeArtifact, encodeTypeInterface)
 import Aihc.Hackage.Cabal qualified as HackageCabal
+import Aihc.Hackage.Download qualified as HackageDownload
 import Aihc.Hackage.Util qualified as HackageUtil
+import Aihc.Hackage.VersionResolver (getLatestVersion)
 import Aihc.Parser.Syntax (ImportDecl (..), Module, Name (..), moduleName)
 import Aihc.Parser.Syntax qualified as Syntax
 import Aihc.Resolve
@@ -29,12 +39,19 @@ import Aihc.Resolve
 import Aihc.Tc
   ( ClassInfo (..),
     DataTypeInfo (..),
+    Pred (..),
     TcInterface (..),
     TcTermKey (..),
+    TcType (..),
+    TyCon,
+    TyConFlavor (..),
     TyConInfo (..),
+    TypeScheme (..),
     tcConfig,
     tcModuleDiagnostics,
     tcModuleSuccess,
+    tyConArity,
+    tyConName,
     typecheckModuleSccWithInterfaceConfig,
   )
 import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
@@ -50,6 +67,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Word (Word64)
 import Distribution.Package qualified as CabalPackage
 import Distribution.PackageDescription (package, packageDescription)
@@ -57,7 +75,7 @@ import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, r
 import Distribution.Pretty (prettyShow)
 import Numeric (showHex)
 import System.Directory (createDirectoryIfMissing)
-import System.FilePath (makeRelative, takeDirectory, (</>))
+import System.FilePath (makeRelative, takeDirectory, takeFileName, (</>))
 
 data InstallV2Result = InstallV2Result
   { installV2StorePath :: !FilePath,
@@ -72,6 +90,14 @@ data SourceModule = SourceModule
     sourceModuleAst :: !Module
   }
 
+data InstalledV2Package = InstalledV2Package
+  { installedV2Result :: !InstallV2Result,
+    installedV2Exports :: !ModuleExports,
+    installedV2Types :: !TcInterface,
+    installedV2ScopeHashes :: !(Map.Map Text Text),
+    installedV2TypeHashes :: !(Map.Map Text Text)
+  }
+
 runInstallV2 :: InstallV2Options -> IO ()
 runInstallV2 options = do
   result <- installV2 options
@@ -82,6 +108,30 @@ installV2 options = do
   storeRoot <- maybe defaultStoreRoot pure (installV2StoreRoot options)
   let root = installV2PackageDirectory options
       verbose message = when (installV2Verbose options) (putStrLn message)
+      fallbackResolver = networkDependencyResolver
+      resolver = localDependencyResolverWithFallback fallbackResolver root
+  spec <- packageSpecFromSource root
+  plan <- buildPackagePlanWithResolver resolver storeRoot spec
+  installedV2Result <$> installPackagePlanV2 verbose storeRoot plan
+
+networkDependencyResolver :: DependencyResolver
+networkDependencyResolver =
+  DependencyResolver
+    { resolverResolveVersion = resolveVersion,
+      resolverSourcePath = HackageDownload.downloadPackageWithOptions HackageDownload.defaultDownloadOptions
+    }
+  where
+    resolveVersion name = do
+      result <- getLatestVersion Nothing name
+      either (ioError . userError) pure result
+
+installPackagePlanV2 :: (String -> IO ()) -> FilePath -> PackagePlan -> IO InstalledV2Package
+installPackagePlanV2 verbose storeRoot plan = do
+  dependencies <- mapM (installPackagePlanV2 verbose storeRoot) (planDependencyPlans plan)
+  installPackageV2 verbose storeRoot dependencies (planSourcePath plan)
+
+installPackageV2 :: (String -> IO ()) -> FilePath -> [InstalledV2Package] -> FilePath -> IO InstalledV2Package
+installPackageV2 verbose storeRoot dependencies root = do
   verbose ("Read Cabal package: " <> root)
   cabalFiles <- HackageUtil.findCabalFiles root
   cabalFile <- case cabalFiles of
@@ -97,14 +147,46 @@ installV2 options = do
       packageVersionText = T.pack (prettyShow (CabalPackage.packageVersion packageId))
   verbose ("Parse " <> show (length files) <> " library modules")
   parsed <- mapM (parseSource root) files
-  let packageHash = stableHash ["aihc-dependencies-v1"]
+  let dependencyIdentities = sortOn id (map (T.pack . takeFileName . installV2StorePath . installedV2Result) dependencies)
+      packageHash = stableHash (TE.encodeUtf8 "aihc-dependencies-v1" : map TE.encodeUtf8 dependencyIdentities)
       packageDirectory = T.unpack packageNameText <> "-" <> T.unpack packageVersionText <> "-" <> packageHash
       storePath = storeRoot </> packageDirectory
       resolvePackage = Package packageNameText (PackageId (T.pack packageDirectory))
       units = sourceModuleSccs parsed
+      dependencyExports = Map.unions (map installedV2Exports dependencies)
+      dependencyTypes = mconcat (map installedV2Types dependencies)
+      dependencyScopeHashes = Map.unions (map installedV2ScopeHashes dependencies)
+      dependencyTypeHashes = Map.unions (map installedV2TypeHashes dependencies)
   verbose ("Compute " <> show (length units) <> " SCC units")
-  (_, _, _, _, written, reused) <- foldM (installUnit verbose storePath resolvePackage root) (Map.empty, Map.empty, mempty, Map.empty, Set.empty, Set.empty) units
-  pure (InstallV2Result storePath (Set.toAscList written) (Set.toAscList reused))
+  (allExports, allScopeHashes, _, allTypeHashes, written, reused) <-
+    foldM
+      (installUnit verbose storePath resolvePackage root)
+      (dependencyExports, dependencyScopeHashes, dependencyTypes, dependencyTypeHashes, Set.empty, Set.empty)
+      units
+  let exposedNames = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
+      ownExports =
+        Map.filterWithKey
+          (\moduleKey _ -> moduleKeyPackage moduleKey == resolvePackage && moduleKeyName moduleKey `Set.member` exposedNames)
+          allExports
+      exposedSources = filter ((`Set.member` exposedNames) . sourceName) parsed
+      typePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "type.cbor"
+  exposedTypes <- mapM (readStoredTypeInterface . typePath) exposedSources
+  pure
+    InstalledV2Package
+      { installedV2Result = InstallV2Result storePath (Set.toAscList written) (Set.toAscList reused),
+        installedV2Exports = ownExports,
+        installedV2Types = mconcat exposedTypes,
+        installedV2ScopeHashes = Map.restrictKeys allScopeHashes exposedNames,
+        installedV2TypeHashes = Map.restrictKeys allTypeHashes exposedNames
+      }
+  where
+    sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
+
+readStoredTypeInterface :: FilePath -> IO TcInterface
+readStoredTypeInterface path = do
+  bytes <- BS.readFile path
+  artifact <- either (\message -> ioError (userError ("Invalid type artifact " <> path <> ": " <> message))) pure (decodeTypeArtifact bytes)
+  pure (typeArtifactInterface artifact)
 
 parseSource :: FilePath -> HackageCabal.FileInfo -> IO SourceModule
 parseSource root fileInfo = do
@@ -191,12 +273,13 @@ installUnit verbose storePath resolvePackage root (dependencyExports, scopeHashe
 
 moduleTypeInterface :: ModuleExports -> Package -> TcInterface -> SourceModule -> TcInterface
 moduleTypeInterface exports package interface source =
-  interface
-    { tcInterfaceTerms = filter visibleTerm (tcInterfaceTerms interface),
-      tcInterfaceTyCons = filter visibleTyCon (tcInterfaceTyCons interface),
-      tcInterfaceDataTypes = filter (visibleTypeIdentity . dtiNameAndOrigin) (tcInterfaceDataTypes interface),
-      tcInterfaceClasses = filter visibleClass (tcInterfaceClasses interface)
-    }
+  addTermSupportTyCons
+    interface
+      { tcInterfaceTerms = filter visibleTerm (tcInterfaceTerms interface),
+        tcInterfaceTyCons = filter visibleTyCon (tcInterfaceTyCons interface),
+        tcInterfaceDataTypes = filter (visibleTypeIdentity . dtiNameAndOrigin) (tcInterfaceDataTypes interface),
+        tcInterfaceClasses = filter visibleClass (tcInterfaceClasses interface)
+      }
   where
     name = fromMaybe "Main" (moduleName (sourceModuleAst source))
     scope = Map.findWithDefault (error "missing resolve scope") (ModuleKey package name) exports
@@ -225,6 +308,38 @@ moduleTypeInterface exports package interface source =
     resolvedIdentity resolved = case resolved of
       ResolvedTopLevel packageId' resolvedName -> Just (packageId', fromMaybe name (nameQualifier resolvedName), nameText resolvedName)
       _ -> Nothing
+
+addTermSupportTyCons :: TcInterface -> TcInterface
+addTermSupportTyCons interface =
+  interface {tcInterfaceTyCons = Map.elems (existing <> support)}
+  where
+    existing = Map.fromList [(tciTyCon info, info) | info <- tcInterfaceTyCons interface]
+    referenced = concatMap (typeSchemeTyCons . snd) (tcInterfaceTerms interface)
+    support =
+      Map.fromList
+        [ (tyCon, TyConInfo (tyConName tyCon) (tyConArity tyCon) tyCon DataTyCon Nothing)
+        | tyCon <- referenced,
+          tyCon `Map.notMember` existing
+        ]
+
+typeSchemeTyCons :: TypeScheme -> [TyCon]
+typeSchemeTyCons (ForAll _ predicates body) = concatMap predTyCons predicates <> typeTyCons body
+
+predTyCons :: Pred -> [TyCon]
+predTyCons predicate = case predicate of
+  ClassPred _ arguments -> concatMap typeTyCons arguments
+  EqPred left right -> typeTyCons left <> typeTyCons right
+
+typeTyCons :: TcType -> [TyCon]
+typeTyCons ty = case ty of
+  TcTyVar {} -> []
+  TcMetaTv {} -> []
+  TcTyCon tyCon arguments -> tyCon : concatMap typeTyCons arguments
+  TcFunTy argument result -> typeTyCons argument <> typeTyCons result
+  TcForAllTy _ body -> typeTyCons body
+  TcQualTy predicates body -> concatMap predTyCons predicates <> typeTyCons body
+  TcAppTy function argument -> typeTyCons function <> typeTyCons argument
+  TcBuiltinTyCon _ _ arguments -> concatMap typeTyCons arguments
 
 writeTypeArtifact :: (String -> IO ()) -> [(Text, Text)] -> (SourceModule -> FilePath) -> SourceModule -> TcInterface -> IO ()
 writeTypeArtifact verbose hashes artifactPath source interface = do

--- a/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
+++ b/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
@@ -60,7 +60,7 @@ encodeTypeArtifact artifact =
   Builder.toLazyByteString $
     cborArray 5
       <> cborText "aihc-type"
-      <> cborWord 1
+      <> cborWord 2
       <> cborText (typeArtifactModuleName artifact)
       <> encodeList encodeHash (typeArtifactInputHashes artifact)
       <> putInterface (typeArtifactInterface artifact)
@@ -82,7 +82,7 @@ getArtifact :: Get.Get TypeArtifact
 getArtifact = do
   expectArray 5
   expectText "aihc-type"
-  expectWord 1
+  expectWord 2
   typeArtifactModuleName <- getText
   typeArtifactInputHashes <- getList getHash
   typeArtifactInterface <- getInterface

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -8,7 +8,7 @@ import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact)
 import Aihc.Tc (TcInterface (..), tcTermKeyIdentifier)
 import Control.Exception (bracket)
 import Data.ByteString qualified as BS
-import Data.List (sort)
+import Data.List (isPrefixOf, sort)
 import Data.Maybe (mapMaybe)
 import Hedgehog (Property, property, success)
 import System.Directory
@@ -16,6 +16,7 @@ import System.Directory
     createDirectoryIfMissing,
     doesFileExist,
     getTemporaryDirectory,
+    listDirectory,
     removeDirectoryRecursive,
     removeFile,
   )
@@ -329,6 +330,7 @@ main =
           testCase "rebuilds a module when a predecessor resolve artifact changes" test_installV2ResolveDependencies,
           testCase "rebuilds a module when a predecessor type interface changes" test_installV2TypeDependencies,
           testCase "duplicates re-exported term signatures in type interfaces" test_installV2TypeReexports,
+          testCase "installs direct local dependencies" test_installV2LocalDependencies,
           testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope
         ],
       testProperty "Hedgehog options" prop_dummy
@@ -434,6 +436,51 @@ test_installV2TypeReexports =
     artifact <- either assertFailure pure (decodeTypeArtifact bytes)
     let termNames = mapMaybe (tcTermKeyIdentifier . fst) (tcInterfaceTerms (typeArtifactInterface artifact))
     assertBool "re-exported signature" ("fn" `elem` termNames)
+
+test_installV2LocalDependencies :: Assertion
+test_installV2LocalDependencies =
+  withTempDir "aihc-install-v2-local-dependencies" $ \root -> do
+    let sourceRoot = root </> "demo"
+        dependencyRoot = root </> "dep"
+        storeRoot = root </> "store"
+        options = InstallV2Options sourceRoot (Just storeRoot) False
+    createDirectoryIfMissing True (sourceRoot </> "src")
+    createDirectoryIfMissing True (dependencyRoot </> "src")
+    writeFile
+      (dependencyRoot </> "dep.cabal")
+      ( unlines
+          [ "cabal-version: 3.0",
+            "name: dep",
+            "version: 1.0.0",
+            "library",
+            "  exposed-modules: Dep",
+            "  hs-source-dirs: src",
+            "  default-language: Haskell2010"
+          ]
+      )
+    writeFile (dependencyRoot </> "src" </> "Dep.hs") "module Dep where\nidentity x = x\n"
+    writeFile
+      (sourceRoot </> "demo.cabal")
+      ( unlines
+          [ "cabal-version: 3.0",
+            "name: demo",
+            "version: 0.1.0.0",
+            "library",
+            "  exposed-modules: Demo",
+            "  hs-source-dirs: src",
+            "  build-depends: dep",
+            "  default-language: Haskell2010"
+          ]
+      )
+    writeFile (sourceRoot </> "src" </> "Demo.hs") "module Demo where\nimport Dep\nresult = identity\n"
+    _ <- installV2 options
+    storeEntries <- listDirectory storeRoot
+    let dependencyStores = filter ("dep-1.0.0-" `isPrefixOf`) storeEntries
+    case dependencyStores of
+      [dependencyStore] -> do
+        assertFileExists (storeRoot </> dependencyStore </> "Dep" </> "resolve.cbor")
+        assertFileExists (storeRoot </> dependencyStore </> "Dep" </> "type.cbor")
+      _ -> assertFailure ("expected one installed dependency, got " <> show dependencyStores)
 
 test_installV2ResolveDependencies :: Assertion
 test_installV2ResolveDependencies =

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -331,6 +331,7 @@ main =
           testCase "rebuilds a module when a predecessor type interface changes" test_installV2TypeDependencies,
           testCase "duplicates re-exported term signatures in type interfaces" test_installV2TypeReexports,
           testCase "installs direct local dependencies" test_installV2LocalDependencies,
+          testCase "rebuilds stale type artifact schemas" test_installV2StaleTypeArtifact,
           testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope
         ],
       testProperty "Hedgehog options" prop_dummy
@@ -481,6 +482,33 @@ test_installV2LocalDependencies =
         assertFileExists (storeRoot </> dependencyStore </> "Dep" </> "resolve.cbor")
         assertFileExists (storeRoot </> dependencyStore </> "Dep" </> "type.cbor")
       _ -> assertFailure ("expected one installed dependency, got " <> show dependencyStores)
+
+test_installV2StaleTypeArtifact :: Assertion
+test_installV2StaleTypeArtifact =
+  withTempDir "aihc-install-v2-stale-type" $ \root -> do
+    let sourceRoot = root </> "source"
+        sourceDir = sourceRoot </> "src"
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+    createDirectoryIfMissing True sourceDir
+    writeFile
+      (sourceRoot </> "demo.cabal")
+      ( unlines
+          [ "cabal-version: 3.0",
+            "name: demo",
+            "version: 0.1.0.0",
+            "library",
+            "  exposed-modules: Demo",
+            "  hs-source-dirs: src",
+            "  default-language: Haskell2010"
+          ]
+      )
+    writeFile (sourceDir </> "Demo.hs") "module Demo where\nvalue = value\n"
+    first <- installV2 options
+    let artifactPath = installV2StorePath first </> "Demo" </> "type.cbor"
+    artifact <- BS.readFile artifactPath
+    BS.writeFile artifactPath (BS.take 11 artifact <> BS.singleton 1 <> BS.drop 12 artifact)
+    rebuilt <- installV2 options
+    assertEqual "rebuilt module" ["Demo"] (installV2WrittenModules rebuilt)
 
 test_installV2ResolveDependencies :: Assertion
 test_installV2ResolveDependencies =

--- a/components/aihc-tc/aihc-tc.cabal
+++ b/components/aihc-tc/aihc-tc.cabal
@@ -92,6 +92,7 @@ test-suite spec
   other-modules:
     TcAnnotatedGolden
     TcAnnotatedRender
+    Test.Tc.Interface
     Test.Tc.Properties
     Test.Tc.Suite
 

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -184,7 +184,7 @@ instance Semigroup TcInterface where
   left <> right =
     TcInterface
       { tcInterfaceTerms = mergeInterfaceEntries fst (tcInterfaceTerms left <> tcInterfaceTerms right),
-        tcInterfaceTyCons = mergeInterfaceEntries tciTyCon (tcInterfaceTyCons left <> tcInterfaceTyCons right),
+        tcInterfaceTyCons = mergeTyConInfos (tcInterfaceTyCons left <> tcInterfaceTyCons right),
         tcInterfaceDataTypes = mergeInterfaceEntries dtiName (tcInterfaceDataTypes left <> tcInterfaceDataTypes right),
         tcInterfaceClasses = mergeInterfaceEntries ciName (tcInterfaceClasses left <> tcInterfaceClasses right),
         tcInterfaceInstances = mergeInterfaceEntries iiDictName (tcInterfaceInstances left <> tcInterfaceInstances right),
@@ -196,6 +196,15 @@ instance Monoid TcInterface where
 
 mergeInterfaceEntries :: (Ord key) => (value -> key) -> [value] -> [value]
 mergeInterfaceEntries key = Map.elems . Map.fromList . map (\value -> (key value, value))
+
+mergeTyConInfos :: [TyConInfo] -> [TyConInfo]
+mergeTyConInfos = Map.elems . foldr insertInfo Map.empty
+  where
+    insertInfo info = Map.insertWith preferSourceName (tciTyCon info) info
+    preferSourceName new old
+      | isSupportName new && not (isSupportName old) = old
+      | otherwise = new
+    isSupportName info = tciName info == tyConName (tciTyCon info)
 
 tcTermKeyIdentifier :: TcTermKey -> Maybe Text
 tcTermKeyIdentifier key =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -911,7 +911,7 @@ nameToText n = case nameQualifier n of
   Just q -> q <> "." <> nameText n
 
 intTyCon :: TcM TcType
-intTyCon = TcTyCon <$> mkKnownTyCon "GHC.Types" "Int" 0 liftedTypeKind <*> pure []
+intTyCon = knownTyConType "GHC.Types" "Int"
 
 numericLiteralType :: NumericType -> TcM TcType
 numericLiteralType numericType =
@@ -929,7 +929,13 @@ numericLiteralType numericType =
     TWord64Hash -> primType "Word64#"
 
 primType :: Text -> TcM TcType
-primType name = TcTyCon <$> mkKnownTyCon "GHC.Prim" name 0 liftedTypeKind <*> pure []
+primType = knownTyConType "GHC.Prim"
+
+knownTyConType :: Text -> Text -> TcM TcType
+knownTyConType moduleName name = do
+  maybeInfo <- lookupTyCon name
+  tyCon <- maybe (mkKnownTyCon moduleName name 0 liftedTypeKind) (pure . tciTyCon) maybeInfo
+  pure (TcTyCon tyCon [])
 
 doubleTyCon :: TcM TcType
 doubleTyCon = do

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -398,7 +398,8 @@ knownType moduleName name = knownTypeWithArity moduleName name 0
 
 knownTypeWithArity :: Text -> Text -> Int -> Kind -> TcM (TcType, Kind)
 knownTypeWithArity moduleName name arity kind = do
-  tyCon <- mkKnownTyCon moduleName name arity kind
+  maybeInfo <- lookupTyCon name
+  tyCon <- maybe (mkKnownTyCon moduleName name arity kind) (pure . tciTyCon) maybeInfo
   pure (TcTyCon tyCon [], kind)
 
 knownTypeModule :: Text -> Text

--- a/components/aihc-tc/test/Spec.hs
+++ b/components/aihc-tc/test/Spec.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import Test.Tasty
+import Test.Tc.Interface (tcInterfaceTests)
 import Test.Tc.Properties (tcProperties)
 import Test.Tc.Suite (tcAnnotatedGoldenTests)
 
@@ -13,6 +14,7 @@ main = do
     ( testGroup
         "aihc-tc"
         [ annotatedGolden,
+          tcInterfaceTests,
           tcProperties
         ]
     )

--- a/components/aihc-tc/test/Test/Tc/Interface.hs
+++ b/components/aihc-tc/test/Test/Tc/Interface.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Tc.Interface (tcInterfaceTests) where
+
+import Aihc.Resolve (PackageId (..))
+import Aihc.Tc
+import Aihc.Tc.Types (mkTyConWithOrigin)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+tcInterfaceTests :: TestTree
+tcInterfaceTests =
+  testGroup
+    "type interface"
+    [ testCase "keeps the source type name during support merges" $ do
+        assertEqual "canonical then support" ["List"] (map tciName (tcInterfaceTyCons (canonicalInterface <> supportInterface)))
+        assertEqual "support then canonical" ["List"] (map tciName (tcInterfaceTyCons (supportInterface <> canonicalInterface)))
+    ]
+  where
+    listTyCon = mkTyConWithOrigin (PackageId "aihc-prim") "GHC.Types" "[]" 1 (KFun liftedTypeKind liftedTypeKind)
+    canonicalInfo = TyConInfo "List" 1 listTyCon DataTyCon Nothing
+    supportInfo = TyConInfo "[]" 1 listTyCon DataTyCon Nothing
+    canonicalInterface = emptyTcInterface {tcInterfaceTyCons = [canonicalInfo]}
+    supportInterface = emptyTcInterface {tcInterfaceTyCons = [supportInfo]}


### PR DESCRIPTION
## Summary

- Install each package dependency before the requested package.
- Use local sibling packages before the Hackage source.
- Pass dependency scopes and type interfaces to each direct dependent package.
- Include dependency store identities in the package hash.
- Keep source type names when support type constructors have internal names.
- Use imported identities for known primitive and tuple type constructors.
- Rebuild old type artifacts that contain invalid package identities.

## Purpose

`install-v2` previously installed only the requested package. Imports from package dependencies could not resolve.

## Effect

`install-v2` now builds the package plan and installs it in dependency order. It writes resolve and type artifacts for each dependency.

The command now installs `aihc-prim` automatically when it installs `aihc-base`.

## Test progress

The `install-v2` test count increases from 5 to 7.

The `aihc-tc` test count increases from 80 to 81.

The new tests cover dependency installation, stale artifacts, and source type names during interface merges.

## Validation

- `just fmt`
- `just check`
- `cabal run -v0 aihc -- install-v2 core-libs/aihc-base --store <temporary-directory>`
- `cabal run aihc -- install-v2 core-libs/aihc-base`