### PR TITLE
fix(resolve): require imports for promoted primitive constructors

### DIFF
--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -90,9 +90,11 @@ tupleSupportModule =
 listSupportModule :: Text
 listSupportModule =
   T.unlines
-    [ "module GHC.Types (Bool(..), List(..), Type, TYPE) where",
+    [ "module GHC.Types (Bool(..), Levity(..), List(..), RuntimeRep(..), Type, TYPE) where",
       "data Bool = False | True",
+      "data Levity = Lifted | Unlifted",
       "data List a = [] | a : [a]",
+      "data RuntimeRep = BoxedRep Levity",
       "data Type",
       "data TYPE rep",
       "infixr 5 :"

--- a/components/aihc-fc/test/Test/Fixtures/golden/empty-data-keeps-checked-kind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/empty-data-keeps-checked-kind.yaml
@@ -7,7 +7,7 @@ modules:
   - |
     module GHC.Prim where
 
-    import GHC.Types (Type, TYPE)
+    import GHC.Types (Levity (Unlifted), RuntimeRep (BoxedRep), Type, TYPE)
 
     type MutVar# :: Type -> Type -> TYPE ('BoxedRep 'Unlifted)
     data MutVar# d a

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -505,6 +505,8 @@ emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty M
 
 -- | Scope containing fixed Haskell names that are always available.
 --
+-- The term namespace is empty.
+-- Promoted constructors from @aihc-prim@ use ordinary name resolution.
 -- The type namespace contains only the function arrow and @Constraint@.
 -- Types from @aihc-prim@ use ordinary name resolution.
 --
@@ -526,43 +528,7 @@ builtinScope =
     mkBuiltinType n = (n, ResolvedBuiltin n)
 
 builtinPromotedConstructorNames :: [T.Text]
-builtinPromotedConstructorNames =
-  [ "AddrRep",
-    "BoxedRep",
-    "DoubleRep",
-    "FloatRep",
-    "Int16Rep",
-    "Int32Rep",
-    "Int64Rep",
-    "Int8Rep",
-    "IntRep",
-    "SumRep",
-    "TupleRep",
-    "VecRep",
-    "Word16Rep",
-    "Word32Rep",
-    "Word64Rep",
-    "Word8Rep",
-    "WordRep",
-    "Lifted",
-    "Unlifted",
-    "Vec16",
-    "Vec2",
-    "Vec32",
-    "Vec4",
-    "Vec64",
-    "Vec8",
-    "DoubleElemRep",
-    "FloatElemRep",
-    "Int16ElemRep",
-    "Int32ElemRep",
-    "Int64ElemRep",
-    "Int8ElemRep",
-    "Word16ElemRep",
-    "Word32ElemRep",
-    "Word64ElemRep",
-    "Word8ElemRep"
-  ]
+builtinPromotedConstructorNames = []
 
 -- | Wired-in type-namespace names.
 --

--- a/components/aihc-resolve/test/Test/Fixtures/golden/promoted-prim-constructor-requires-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/promoted-prim-constructor-requires-import.yaml
@@ -1,0 +1,14 @@
+extensions:
+- DataKinds
+modules:
+- |
+  module Main where
+  type Rep = 'IntRep
+annotated:
+- |-
+  module Main where
+  type Rep = 'IntRep
+       │      └─ t Error unbound
+       └─ t Main
+status: pass
+reason: aihc-prim promoted constructors require ordinary name resolution


### PR DESCRIPTION
## Summary

- Empty the built-in promoted constructor name list.
- Resolve promoted `aihc-prim` constructors through ordinary `GHC.Types` imports.
- Add the required constructors to the FC test support module.
- Add a resolver regression fixture for a missing promoted constructor import.

## Progress counts

- Increase resolver golden fixtures from 50 to 51.
- Increase passing resolver golden fixtures from 49 to 50.
- Keep resolver expected-failure fixtures at 1.
- Increase resolver completion from 98.00% to 98.04%.

## Validation

- `just fmt`
- `just check`