### PR TITLE
fix(fc): use primitive identities in foreign calls

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -66,6 +66,7 @@ import Aihc.Tc.Types
     Unique (..),
     liftedRuntimeRep,
     mkTyCon,
+    mkTyConWithOrigin,
     runtimeRepOfType,
     setTyConKindScheme,
     tvKind,
@@ -697,6 +698,7 @@ dsForeignCcall tcAnn foreignPlan foreignDecl = do
       ForeignEntityStatic (Just name) -> pure name
       ForeignEntityOmitted -> pure (unqualifiedNameText (foreignName foreignDecl))
       _ -> desugarBug "only statically named foreign imports are supported"
+  primPackageId <- gets dsPrimPackageId
   let name = unqualifiedNameText (foreignName foreignDecl)
       wrapperType = tcAnnType tcAnn
       signature =
@@ -709,9 +711,12 @@ dsForeignCcall tcAnn foreignPlan foreignDecl = do
         FcForeignCall
           { fcForeignCallName = "$ffi$" <> name,
             fcForeignCallSymbol = symbol,
+            fcForeignCallPrimPackageId = primPackageId,
             fcForeignCallSignature = signature
           }
   wrapperVar <- freshVar name wrapperType
+  wrapperOrigin <- localDeclarationOrigin name
+  modify' (\state -> state {dsGlobalVars = Map.insert wrapperOrigin wrapperVar (dsGlobalVars state)})
   argumentVars <-
     mapM
       (\(index, marshal) -> freshVar ("$ffi_arg_" <> T.pack (show index)) (tcForeignSourceType marshal))
@@ -857,17 +862,19 @@ matchConstructorResult quantified patternType actualType substitution =
 
 makeForeignIoWrapper :: FcForeignCall -> TcForeignMarshal -> [FcExpr] -> DsM FcExpr
 makeForeignIoWrapper foreignCall resultMarshal arguments = do
-  stateVar <- freshVar "$ffi_state" statePrimRealWorldTy
-  tupleBinder <- freshVar "$ffi_result" (fcForeignCallResultType (fcForeignCallSignature foreignCall))
-  nextStateVar <- freshVar "$ffi_next_state" statePrimRealWorldTy
+  stateTy <- statePrimRealWorldTy
+  resultTupleTy <- unboxedTupleTy [stateTy, tcForeignSourceType resultMarshal]
+  stateVar <- freshVar "$ffi_state" stateTy
+  tupleBinder <- freshVar "$ffi_result" (fcForeignCallResultType foreignCall)
+  nextStateVar <- freshVar "$ffi_next_state" stateTy
   rawResultVar <- freshVar "$ffi_raw_result" (tcForeignPrimitiveType resultMarshal)
   boxedResult <- boxForeignValue resultMarshal (FcVar rawResultVar)
   tupleOrigin <- primitiveConstructorOrigin "(#,#)"
   tupleConstructorVar <-
     freshVar
       "(#,#)"
-      (TcFunTy statePrimRealWorldTy (TcFunTy (tcForeignSourceType resultMarshal) (unboxedTupleTy [statePrimRealWorldTy, tcForeignSourceType resultMarshal])))
-  let tupleConstructor = tupleConstructorVar
+      (TcFunTy stateTy (TcFunTy (tcForeignSourceType resultMarshal) resultTupleTy))
+  let tupleConstructor = tupleConstructorVar {varResolvedName = Just tupleOrigin}
   ioConstructorType <- lookupType "IO"
   ioConstructor <- freshVar "IO" ioConstructorType
   let resultTuple = FcApp (FcApp (FcVar tupleConstructor) (FcVar nextStateVar)) boxedResult
@@ -1035,17 +1042,20 @@ parsePrimitiveTypeScheme source =
     invalidPrimitiveType err =
       error ("invalid primitive type specification `" <> T.unpack source <> "`: " <> err)
 
-statePrimRealWorldTy :: TcType
-statePrimRealWorldTy = TcTyCon (TyCon "State#" 1) [realWorldTy]
+statePrimRealWorldTy :: DsM TcType
+statePrimRealWorldTy = do
+  packageId <- gets dsPrimPackageId
+  let realWorldTy = TcTyCon (mkTyConWithOrigin packageId "GHC.Prim" "RealWorld" 0 KType) []
+  pure (TcTyCon (mkTyConWithOrigin packageId "GHC.Prim" "State#" 1 (KFun KType (KTYPE (TupleRep [])))) [realWorldTy])
 
-realWorldTy :: TcType
-realWorldTy = TcTyCon (TyCon "RealWorld" 0) []
-
-unboxedTupleTy :: [TcType] -> TcType
-unboxedTupleTy tys =
-  TcTyCon
-    (mkTyCon (unboxedTupleTyConName (length tys)) (length tys) tupleKind)
-    tys
+unboxedTupleTy :: [TcType] -> DsM TcType
+unboxedTupleTy tys = do
+  packageId <- gets dsPrimPackageId
+  pure
+    ( TcTyCon
+        (mkTyConWithOrigin packageId "GHC.Types" (unboxedTupleTyConName (length tys)) (length tys) tupleKind)
+        tys
+    )
   where
     tupleKind = foldr (KFun . typeKind) (KTYPE (TupleRep (map runtimeRep tys))) tys
     runtimeRep ty = fromRight liftedRuntimeRep (runtimeRepOfType ty)

--- a/components/aihc-fc/src/Aihc/Fc/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar.hs
@@ -65,7 +65,6 @@ import Aihc.Tc.Types
     TypeScheme (..),
     Unique (..),
     liftedRuntimeRep,
-    mkTyCon,
     mkTyConWithOrigin,
     runtimeRepOfType,
     setTyConKindScheme,

--- a/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Desugar/Expr.hs
@@ -1993,7 +1993,7 @@ fcExprTypeM expr =
         FcAlt _ _ body : _ -> fcExprTypeM body
     FcCast inner _co -> fcExprTypeM inner
     FcCallForeign foreignCall _arguments ->
-      pure (fcForeignCallResultType (fcForeignCallSignature foreignCall))
+      pure (fcForeignCallResultType foreignCall)
 
 exactDictKey :: TyCon -> [TcType] -> Text
 exactDictKey classTyCon args = tyConIdentityKey classTyCon <> ":" <> T.intercalate "," (map exactTypeKey args)

--- a/components/aihc-fc/src/Aihc/Fc/Eval.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Eval.hs
@@ -913,7 +913,7 @@ executeForeignCall foreignCall arguments
     name = fcForeignCallName foreignCall
     signature = fcForeignCallSignature foreignCall
     actualArity = length arguments
-    expectedArity = length (fcForeignOperandTypes signature)
+    expectedArity = length (fcForeignOperandTypes foreignCall)
 
 callForeign :: FcForeignCall -> [Value] -> EvalM Value
 callForeign foreignCall args

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -41,6 +41,7 @@ import Aihc.Tc.Types
     TyVarId (..),
     TypeScheme (..),
     Unique (..),
+    isUnboxedTupleType,
     kindFromTypeScheme,
     liftedTypeKind,
     runtimeRepOfType,
@@ -155,7 +156,7 @@ lintProgramWithAxiomInterface imported env0 prog = go envWithDeclarations (fcTop
       lintValueTypeErrors "primitive declaration" env (varType var)
         <> go (extendTermEnv var env) rest
     go env (FcForeignImport foreignCall : rest) =
-      lintValueTypeErrors "foreign declaration" env (fcForeignCallType (fcForeignCallSignature foreignCall))
+      lintValueTypeErrors "foreign declaration" env (fcForeignCallType foreignCall)
         <> go env rest
     go env (FcTopBind bind : rest) =
       let (errs, env') = lintBind env bind
@@ -260,12 +261,12 @@ lintExpr env (FcCallForeign foreignCall arguments) = do
       | declared /= foreignCall -> Left (ForeignCallDescriptorMismatch (fcForeignCallName foreignCall))
       | otherwise -> Right ()
   argumentTypes <- mapM (lintExpr env) arguments
-  let expectedTypes = fcForeignOperandTypes (fcForeignCallSignature foreignCall)
+  let expectedTypes = fcForeignOperandTypes foreignCall
   if length argumentTypes /= length expectedTypes
     then Left (LintFailure ("foreign call arity mismatch for " ++ show (fcForeignCallName foreignCall)))
     else do
       mapM_ checkArgument (zip expectedTypes argumentTypes)
-      let resultType = fcForeignCallResultType (fcForeignCallSignature foreignCall)
+      let resultType = fcForeignCallResultType foreignCall
       _ <- lintValueType "foreign call result" env resultType
       pure resultType
   where
@@ -299,14 +300,27 @@ lintAlt env scrutineeType (FcAlt con binders rhs) = do
             then pure ()
             else Left (TypeMismatch "literal alternative" scrutineeType literalType)
         DataAlt constructor ->
-          case Map.lookup (fcConstructorSymbolOrigin constructor) (leDataCons env) of
-            Nothing -> Left (LintFailure ("unknown case alternative constructor: " ++ show constructor))
-            Just (_, fields, resultType) -> do
-              substitution <- matchConstructorResult resultType scrutineeType
-              let expectedFields = map (substType substitution) fields
-              if length expectedFields /= length alternativeBinders
-                then Left (LintFailure ("case alternative binder count does not match constructor: " ++ show constructor))
-                else mapM_ checkField (zip expectedFields alternativeBinders)
+          case unboxedTupleFields constructor scrutineeType of
+            Just fields -> checkFields constructor alternativeBinders fields
+            Nothing ->
+              case Map.lookup (fcConstructorSymbolOrigin constructor) (leDataCons env) of
+                Nothing -> Left (LintFailure ("unknown case alternative constructor: " ++ show constructor))
+                Just (_, fields, resultType) -> do
+                  substitution <- matchConstructorResult resultType scrutineeType
+                  checkFields constructor alternativeBinders (map (substType substitution) fields)
+
+    unboxedTupleFields constructor tupleType
+      | fcConstructorModule constructor == "GHC.Types",
+        fcConstructorName constructor == "(#,#)",
+        TcTyCon _ fields <- tupleType,
+        isUnboxedTupleType tupleType =
+          Just fields
+      | otherwise = Nothing
+
+    checkFields constructor fieldBinders expectedFields =
+      if length expectedFields /= length fieldBinders
+        then Left (LintFailure ("case alternative binder count does not match constructor: " ++ show constructor))
+        else mapM_ checkField (zip expectedFields fieldBinders)
 
     checkField (expected, binder)
       | typesEqual expected (varType binder) = pure ()

--- a/components/aihc-fc/src/Aihc/Fc/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lint.hs
@@ -41,7 +41,6 @@ import Aihc.Tc.Types
     TyVarId (..),
     TypeScheme (..),
     Unique (..),
-    isUnboxedTupleType,
     kindFromTypeScheme,
     liftedTypeKind,
     runtimeRepOfType,
@@ -300,22 +299,11 @@ lintAlt env scrutineeType (FcAlt con binders rhs) = do
             then pure ()
             else Left (TypeMismatch "literal alternative" scrutineeType literalType)
         DataAlt constructor ->
-          case unboxedTupleFields constructor scrutineeType of
-            Just fields -> checkFields constructor alternativeBinders fields
-            Nothing ->
-              case Map.lookup (fcConstructorSymbolOrigin constructor) (leDataCons env) of
-                Nothing -> Left (LintFailure ("unknown case alternative constructor: " ++ show constructor))
-                Just (_, fields, resultType) -> do
-                  substitution <- matchConstructorResult resultType scrutineeType
-                  checkFields constructor alternativeBinders (map (substType substitution) fields)
-
-    unboxedTupleFields constructor tupleType
-      | fcConstructorModule constructor == "GHC.Types",
-        fcConstructorName constructor == "(#,#)",
-        TcTyCon _ fields <- tupleType,
-        isUnboxedTupleType tupleType =
-          Just fields
-      | otherwise = Nothing
+          case Map.lookup (fcConstructorSymbolOrigin constructor) (leDataCons env) of
+            Nothing -> Left (LintFailure ("unknown case alternative constructor: " ++ show constructor))
+            Just (_, fields, resultType) -> do
+              substitution <- matchConstructorResult resultType scrutineeType
+              checkFields constructor alternativeBinders (map (substType substitution) fields)
 
     checkFields constructor fieldBinders expectedFields =
       if length expectedFields /= length fieldBinders

--- a/components/aihc-fc/src/Aihc/Fc/Lower.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Lower.hs
@@ -133,7 +133,7 @@ expressionType expression =
         alternative : _ -> expressionType (altRhs alternative)
         [] -> Nothing
     FcCast inner _ -> expressionType inner
-    FcCallForeign foreignCall _ -> Just (fcForeignCallResultType (fcForeignCallSignature foreignCall))
+    FcCallForeign foreignCall _ -> Just (fcForeignCallResultType foreignCall)
   where
     functionResultType = \case
       TcFunTy _ result -> Just result

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -344,7 +344,7 @@ foreignCallHeader = do
   foreignSymbol <- text
   foreignName <- name
   signature <- between "[" "]" foreignSignature
-  pure (FcForeignCall foreignName foreignSymbol signature)
+  pure (FcForeignCall foreignName foreignSymbol (PackageId "aihc-prim") signature)
 
 foreignSignature :: Parser FcForeignSignature
 foreignSignature = do

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -115,7 +115,7 @@ renderForeignImport foreignCall =
     <> "; "
     <> renderForeignEffect (fcForeignEffect signature)
     <> "] : "
-    <> renderType (fcForeignCallType signature)
+    <> renderType (fcForeignCallType foreignCall)
   where
     signature = fcForeignCallSignature foreignCall
 

--- a/components/aihc-fc/src/Aihc/Fc/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Syntax.hs
@@ -216,6 +216,7 @@ data FcNewtypeDecl = FcNewtypeDecl
 data FcForeignCall = FcForeignCall
   { fcForeignCallName :: !Text,
     fcForeignCallSymbol :: !Text,
+    fcForeignCallPrimPackageId :: !PackageId,
     fcForeignCallSignature :: !FcForeignSignature
   }
   deriving (Eq, Show, Read)
@@ -244,39 +245,47 @@ data FcForeignType
   | FcForeignAddr
   deriving (Eq, Show, Read)
 
-fcForeignOperandTypes :: FcForeignSignature -> [TcType]
-fcForeignOperandTypes signature =
-  map foreignPrimitiveType (fcForeignArgumentTypes signature)
+fcForeignOperandTypes :: FcForeignCall -> [TcType]
+fcForeignOperandTypes foreignCall =
+  map (foreignPrimitiveType packageId) (fcForeignArgumentTypes signature)
     <> case fcForeignEffect signature of
       FcForeignPure -> []
-      FcForeignRealWorld -> [statePrimRealWorldType]
+      FcForeignRealWorld -> [statePrimRealWorldType packageId]
+  where
+    packageId = fcForeignCallPrimPackageId foreignCall
+    signature = fcForeignCallSignature foreignCall
 
-fcForeignCallResultType :: FcForeignSignature -> TcType
-fcForeignCallResultType signature =
+fcForeignCallResultType :: FcForeignCall -> TcType
+fcForeignCallResultType foreignCall =
   case fcForeignEffect signature of
-    FcForeignPure -> foreignPrimitiveType (fcForeignResultType signature)
+    FcForeignPure -> foreignPrimitiveType packageId (fcForeignResultType signature)
     FcForeignRealWorld ->
-      let fields = [statePrimRealWorldType, foreignPrimitiveType (fcForeignResultType signature)]
+      let fields = [statePrimRealWorldType packageId, foreignPrimitiveType packageId (fcForeignResultType signature)]
           fieldRep field = fromRight liftedRuntimeRep (runtimeRepOfType field)
           resultKind = KTYPE (TupleRep (map fieldRep fields))
           tupleKind = foldr (KFun . typeKind) resultKind fields
-       in TcTyCon (mkTyCon (unboxedTupleTyConName 2) 2 tupleKind) fields
+       in TcTyCon (mkTyConWithOrigin packageId "GHC.Types" (unboxedTupleTyConName 2) 2 tupleKind) fields
+  where
+    packageId = fcForeignCallPrimPackageId foreignCall
+    signature = fcForeignCallSignature foreignCall
 
-fcForeignCallType :: FcForeignSignature -> TcType
-fcForeignCallType signature =
-  foldr TcFunTy (fcForeignCallResultType signature) (fcForeignOperandTypes signature)
+fcForeignCallType :: FcForeignCall -> TcType
+fcForeignCallType foreignCall =
+  foldr TcFunTy (fcForeignCallResultType foreignCall) (fcForeignOperandTypes foreignCall)
 
-foreignPrimitiveType :: FcForeignType -> TcType
-foreignPrimitiveType foreignType =
+foreignPrimitiveType :: PackageId -> FcForeignType -> TcType
+foreignPrimitiveType packageId foreignType =
   case foreignType of
-    FcForeignInt -> TcTyCon (TyCon "Int#" 0) []
-    FcForeignInt32 -> TcTyCon (TyCon "Int32#" 0) []
-    FcForeignWord64 -> TcTyCon (TyCon "Word64#" 0) []
-    FcForeignAddr -> TcTyCon (TyCon "Addr#" 0) []
+    FcForeignInt -> primitiveType "Int#"
+    FcForeignInt32 -> primitiveType "Int32#"
+    FcForeignWord64 -> primitiveType "Word64#"
+    FcForeignAddr -> primitiveType "Addr#"
+  where
+    primitiveType name = TcTyCon (mkTyConWithOrigin packageId "GHC.Prim" name 0 (KTYPE liftedRuntimeRep)) []
 
-statePrimRealWorldType :: TcType
-statePrimRealWorldType =
-  TcTyCon (TyCon "State#" 1) [TcTyCon (TyCon "RealWorld" 0) []]
+statePrimRealWorldType :: PackageId -> TcType
+statePrimRealWorldType packageId =
+  TcTyCon (mkTyConWithOrigin packageId "GHC.Prim" "State#" 1 (KTYPE liftedRuntimeRep)) [TcTyCon (mkTyConWithOrigin packageId "GHC.Prim" "RealWorld" 0 (KTYPE liftedRuntimeRep)) []]
 
 fcDictionaryConstructorName :: Text -> Text
 fcDictionaryConstructorName className = "$Dict$" <> className

--- a/components/aihc-fc/test/Test/Fc/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc/Properties.hs
@@ -369,7 +369,7 @@ genNewtypeDecl =
       <*> genType
 
 genForeignCall :: Gen FcForeignCall
-genForeignCall = FcForeignCall <$> genVarName <*> genLiteralText <*> genForeignSignature
+genForeignCall = FcForeignCall <$> genVarName <*> genLiteralText <*> pure (PackageId "aihc-prim") <*> genForeignSignature
 
 genForeignSignature :: Gen FcForeignSignature
 genForeignSignature =

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
@@ -4,33 +4,35 @@ expected: |-
   data "aihc-prim" GHC.Prim.Addr# : TYPE AddrRep
 
   data "aihc-prim" GHC.Prim.Int32# : TYPE Int32Rep
+
+  data "aihc-prim" GHC.Prim.State# (s{unique 22} : Type) : TYPE TupleRep []
+
+  data "aihc-prim" GHC.Prim.RealWorld : Type
   module "" Test where
 
-  data "" Test.State# (s{unique 24} : Type) : TYPE TupleRep []
-
-  data "" Test.RealWorld : Type
+  external "aihc-prim" GHC.Types.(#,#) : tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }] → tycon "" "Test" CInt/0 { :: Type } → tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → Type → TYPE TupleRep [TupleRep [], BoxedRep Lifted] }[tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }], tycon "" "Test" CInt/0 { :: Type }]
 
   data "" Test.Int32 : Type
    = "" Test.I32# (tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep })
 
   newtype "" Test.CInt : tycon "" "Test" CInt/0 { :: Type } = "" Test.CInt tycon "" "Test" Int32/0 { :: Type }
 
-  newtype "" Test.IO (a{unique 26} : Type) : tycon "" "Test" IO/1 { :: Type → Type }[(a{unique 26} : Type)] = "" Test.IO (tycon "" "Test" State#/1 { :: Type → TYPE TupleRep [] }[tycon "" "Test" RealWorld/0 { :: Type }] → tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → Type → TYPE TupleRep [TupleRep [], BoxedRep Lifted] }[tycon "" "Test" State#/1 { :: Type → TYPE TupleRep [] }[tycon "" "Test" RealWorld/0 { :: Type }], (a{unique 26} : Type)])
+  newtype "" Test.IO (a{unique 27} : Type) : tycon "" "Test" IO/1 { :: Type → Type }[(a{unique 27} : Type)] = "" Test.IO (tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }] → tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → Type → TYPE TupleRep [TupleRep [], BoxedRep Lifted] }[tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }], (a{unique 27} : Type)])
 
-  foreign ccall "puts" $ffi$puts [Addr → Int32; real-world] : tycon "aihc-internal" "Aihc.Internal" Addr#/0 { :: TYPE AddrRep } → tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }] → tycon "aihc-internal" "Aihc.Internal" Tuple2#/2 { :: TYPE TupleRep [] → TYPE Int32Rep → TYPE TupleRep [TupleRep [], Int32Rep] }[tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }], tycon "aihc-internal" "Aihc.Internal" Int32#/0 { :: TYPE Int32Rep }]
+  foreign ccall "puts" $ffi$puts [Addr → Int32; real-world] : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep } → tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }] → tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → TYPE Int32Rep → TYPE TupleRep [TupleRep [], Int32Rep] }[tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }], tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep }]
 
   puts{unique 1000} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep } → tycon "" "Test" IO/1 { :: Type → Type }[tycon "" "Test" CInt/0 { :: Type }] =
     λ($ffi_arg_0{unique 1001} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep }).
-      (λ($ffi_state{unique 1002} : tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }]).
-        case foreign-call "puts" $ffi$puts [Addr → Int32; real-world] ($ffi_arg_0{unique 1001} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep }) ($ffi_state{unique 1002} : tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }]) as ($ffi_result{unique 1003} : tycon "aihc-internal" "Aihc.Internal" Tuple2#/2 { :: TYPE TupleRep [] → TYPE Int32Rep → TYPE TupleRep [TupleRep [], Int32Rep] }[tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }], tycon "aihc-internal" "Aihc.Internal" Int32#/0 { :: TYPE Int32Rep }]) of {
-          "aihc-prim" GHC.Types.(#,#) ($ffi_next_state{unique 1004} : tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }]) ($ffi_raw_result{unique 1005} : tycon "aihc-internal" "Aihc.Internal" Int32#/0 { :: TYPE Int32Rep }) →
-            (((#,#){unique 1008} : tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }] → tycon "" "Test" CInt/0 { :: Type } → tycon "aihc-internal" "Aihc.Internal" Tuple2#/2 { :: TYPE TupleRep [] → Type → TYPE TupleRep [TupleRep [], BoxedRep Lifted] }[tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }], tycon "" "Test" CInt/0 { :: Type }]) ($ffi_next_state{unique 1004} : tycon "aihc-internal" "Aihc.Internal" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-internal" "Aihc.Internal" RealWorld/0 { :: Type }])) (((I32#{unique 1007}{origin "" Test.I32#} : tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep } → tycon "" "Test" Int32/0 { :: Type }) ($ffi_raw_result{unique 1005} : tycon "aihc-internal" "Aihc.Internal" Int32#/0 { :: TYPE Int32Rep })) ▷ sym (axiom-co CInt))
+      (λ($ffi_state{unique 1002} : tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }]).
+        case foreign-call "puts" $ffi$puts [Addr → Int32; real-world] ($ffi_arg_0{unique 1001} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep }) ($ffi_state{unique 1002} : tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }]) as ($ffi_result{unique 1003} : tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → TYPE Int32Rep → TYPE TupleRep [TupleRep [], Int32Rep] }[tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }], tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep }]) of {
+          "aihc-prim" GHC.Types.(#,#) ($ffi_next_state{unique 1004} : tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }]) ($ffi_raw_result{unique 1005} : tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep }) →
+            (((#,#){unique -2604723145}{origin "aihc-prim" GHC.Types.(#,#)} : tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }] → tycon "" "Test" CInt/0 { :: Type } → tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → Type → TYPE TupleRep [TupleRep [], BoxedRep Lifted] }[tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }], tycon "" "Test" CInt/0 { :: Type }]) ($ffi_next_state{unique 1004} : tycon "aihc-prim" "GHC.Prim" State#/1 { :: Type → TYPE TupleRep [] }[tycon "aihc-prim" "GHC.Prim" RealWorld/0 { :: Type }])) (((I32#{unique 1007}{origin "" Test.I32#} : tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep } → tycon "" "Test" Int32/0 { :: Type }) ($ffi_raw_result{unique 1005} : tycon "aihc-prim" "GHC.Prim" Int32#/0 { :: TYPE Int32Rep })) ▷ sym (axiom-co CInt))
         }) ▷ sym (axiom-co IO @tycon "" "Test" CInt/0 { :: Type })
 
   rec {
     main{unique 1010} : tycon "" "Test" IO/1 { :: Type → Type }[tycon "" "Test" CInt/0 { :: Type }];
     main{unique 1010} =
-      (puts{unique -2724360239}{origin "" Test.puts} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep } → tycon "" "Test" IO/1 { :: Type → Type }[tycon "" "Test" CInt/0 { :: Type }]) ("hello world\n"#AddrRep : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep })
+      (puts{unique 1000} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep } → tycon "" "Test" IO/1 { :: Type → Type }[tycon "" "Test" CInt/0 { :: Type }]) ("hello world\n"#AddrRep : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep })
   }
 extensions:
 - ForeignFunctionInterface
@@ -41,13 +43,13 @@ modules:
   module GHC.Prim where
   data Addr#
   data Int32#
+  data State# s
+  data RealWorld
 - |
   module Test where
 
-  import GHC.Prim (Addr#, Int32#)
+  import GHC.Prim (Addr#, Int32#, State#, RealWorld)
 
-  data State# s
-  data RealWorld
   data Int32 = I32# Int32#
   newtype CInt = CInt Int32
   newtype IO a = IO (State# RealWorld -> (# State# RealWorld, a #))
@@ -56,5 +58,5 @@ modules:
 
   main :: IO CInt
   main = puts "hello world\n"#
-reason: FC lint finds internal primitive types in the foreign descriptor and a different identity for the local puts occurrence
-status: xfail
+reason: foreign calls use the installed aihc-prim type identities
+status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-ccall-addr.yaml
@@ -58,5 +58,5 @@ modules:
 
   main :: IO CInt
   main = puts "hello world\n"#
-reason: foreign calls use the installed aihc-prim type identities
-status: pass
+reason: System FC lacks a declaration for the imported GHC.Types.(#,#) constructor
+status: xfail

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -1723,7 +1723,7 @@ exprType expr =
         [] -> Nothing
     FcCast inner _ -> exprType inner
     FcCallForeign foreignCall _arguments ->
-      Just (fcForeignCallResultType (fcForeignCallSignature foreignCall))
+      Just (fcForeignCallResultType foreignCall)
 
 -- A default class method can be specialized to its class constructor before
 -- its method type variables, then applied to the instance dictionary. Preserve

--- a/components/aihc-grin/test/Test/Grin/Suite.hs
+++ b/components/aihc-grin/test/Test/Grin/Suite.hs
@@ -10,6 +10,7 @@ where
 import Aihc.Fc.Newtype (extractNewtypeInterface, lowerNewtypes, lowerNewtypesWithInterface)
 import Aihc.Fc.Syntax
 import Aihc.Grin
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc (Kind (..), Levity (..), RuntimeRep (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), runtimeRepOfType, typeKind)
 import Aihc.Tc.Evidence (Coercion (..))
 import Aihc.Tc.Types (mkTyCon)
@@ -2339,6 +2340,7 @@ foreignCall =
   FcForeignCall
     { fcForeignCallName = "$ffi$abs",
       fcForeignCallSymbol = "abs",
+      fcForeignCallPrimPackageId = PackageId "aihc-prim",
       fcForeignCallSignature =
         FcForeignSignature
           { fcForeignArgumentTypes = [FcForeignInt32],

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -921,47 +921,56 @@ splitFunctionType ty =
 checkForeignValueType :: SourceSpan -> TcType -> TcM TcForeignMarshal
 checkForeignValueType sourceSpan ty =
   case ty of
-    TcTyCon (TyCon "Int" 0) [] -> pure (intMarshal ty ["I#"])
-    TcTyCon (TyCon "Int#" 0) [] -> pure (intMarshal ty [])
-    TcTyCon (TyCon "CInt" 0) [] -> pure (int32Marshal ty ["CInt", "I32#"])
-    TcTyCon (TyCon "Int32" 0) [] -> pure (int32Marshal ty ["I32#"])
-    TcTyCon (TyCon "Int32#" 0) [] -> pure (int32Marshal ty [])
-    TcTyCon (TyCon "Word64" 0) [] -> pure (word64Marshal ty ["W64#"])
-    TcTyCon (TyCon "Word64#" 0) [] -> pure (word64Marshal ty [])
-    TcTyCon (TyCon "Addr#" 0) [] -> pure (addrMarshal ty [])
-    TcTyCon (TyCon "Ptr" 1) [_] -> pure (addrMarshal ty ["Ptr"])
+    TcTyCon (TyCon "Int" 0) [] -> intMarshal ty ["I#"]
+    TcTyCon (TyCon "Int#" 0) [] -> intMarshal ty []
+    TcTyCon (TyCon "CInt" 0) [] -> int32Marshal ty ["CInt", "I32#"]
+    TcTyCon (TyCon "Int32" 0) [] -> int32Marshal ty ["I32#"]
+    TcTyCon (TyCon "Int32#" 0) [] -> int32Marshal ty []
+    TcTyCon (TyCon "Word64" 0) [] -> word64Marshal ty ["W64#"]
+    TcTyCon (TyCon "Word64#" 0) [] -> word64Marshal ty []
+    TcTyCon (TyCon "Addr#" 0) [] -> addrMarshal ty []
+    TcTyCon (TyCon "Ptr" 1) [_] -> addrMarshal ty ["Ptr"]
     _ -> do
       emitError sourceSpan (OtherError ("unsupported foreign import value type: " <> show ty))
-      pure (int32Marshal ty [])
+      int32Marshal ty []
   where
-    intMarshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Int#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignInt
-        }
-    int32Marshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Int32#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignInt32
-        }
-    word64Marshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Word64#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignWord64
-        }
-    addrMarshal sourceType constructors =
-      TcForeignMarshal
-        { tcForeignSourceType = sourceType,
-          tcForeignPrimitiveType = TcTyCon (TyCon "Addr#" 0) [],
-          tcForeignConstructors = constructors,
-          tcForeignAbiType = TcForeignAddr
-        }
+    intMarshal sourceType constructors = do
+      primitiveTy <- primitiveType "Int#"
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = primitiveTy,
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignInt
+          }
+    int32Marshal sourceType constructors = do
+      primitiveTy <- primitiveType "Int32#"
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = primitiveTy,
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignInt32
+          }
+    word64Marshal sourceType constructors = do
+      primitiveTy <- primitiveType "Word64#"
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = primitiveTy,
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignWord64
+          }
+    addrMarshal sourceType constructors = do
+      primitiveTy <- primitiveType "Addr#"
+      pure
+        TcForeignMarshal
+          { tcForeignSourceType = sourceType,
+            tcForeignPrimitiveType = primitiveTy,
+            tcForeignConstructors = constructors,
+            tcForeignAbiType = TcForeignAddr
+          }
+    primitiveType name = TcTyCon <$> mkKnownTyCon "GHC.Prim" name 0 liftedTypeKind <*> pure []
 
 annotateDeclAt :: SourceSpan -> TcAnnotation -> Decl -> Decl
 annotateDeclAt NoSourceSpan tcAnn decl =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -931,7 +931,9 @@ numericLiteralType numericType =
     TWord64Hash -> primType "Word64#"
 
 primType :: Text -> TcM TcType
-primType = knownTyConType "GHC.Prim"
+primType name = do
+  tyCon <- mkKnownTyCon "GHC.Prim" name 0 liftedTypeKind
+  pure (TcTyCon tyCon [])
 
 knownTyConType :: Text -> Text -> TcM TcType
 knownTyConType moduleName name = do


### PR DESCRIPTION
## Summary

- Use the configured `aihc-prim` package ID for primitive literals and foreign marshalling types.
- Keep foreign call operands, results, state tokens, and tuple results in `aihc-prim`.
- Remove the System FC linter tuple exception.
- Track the missing imported tuple constructor as XFAIL.

## Progress counts

No progress count changes.

## Checks

- `cabal test -v0 aihc-fc:spec --test-options='--pattern foreign-ccall-addr --hide-successes'`
- `just check`