### PR TITLE
feat(fc): add scope syntax

### DIFF
--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -130,7 +130,7 @@ parseFcFixture supportModules path value = do
   status <- parseStatus path statusText
   let relPath = dropRootPrefix path
       category = categoryFromPath relPath
-      expected = trim (T.unpack expectedText)
+      expected = canonicalExpected (T.unpack expectedText)
       reason = trim (T.unpack reasonText)
   pure
     FcCase
@@ -144,6 +144,22 @@ parseFcFixture supportModules path value = do
         caseStatus = status,
         caseReason = reason
       }
+
+canonicalExpected :: String -> String
+canonicalExpected expected
+  | "scope " `isPrefixOf` expected = trim expected
+  | otherwise =
+      case traverse (parseProgram . T.pack) (expectedPrograms expected) of
+        Right programs -> trim (unlines (map renderProgram programs))
+        Left _ -> trim expected
+
+expectedPrograms :: String -> [String]
+expectedPrograms = map unlines . reverse . filter (not . null) . foldl addLine [] . lines
+  where
+    addLine [] line = [[line]]
+    addLine (program : programs) line
+      | "module " `isPrefixOf` line = [line] : program : programs
+      | otherwise = (program <> [line]) : programs
 
 parseModules :: Y.Value -> Y.Parser [Text]
 parseModules = withArray "modules" $ \arr ->

--- a/components/aihc-fc/common/FcGolden.hs
+++ b/components/aihc-fc/common/FcGolden.hs
@@ -130,7 +130,7 @@ parseFcFixture supportModules path value = do
   status <- parseStatus path statusText
   let relPath = dropRootPrefix path
       category = categoryFromPath relPath
-      expected = canonicalExpected (T.unpack expectedText)
+      expected = trim (T.unpack expectedText)
       reason = trim (T.unpack reasonText)
   pure
     FcCase
@@ -144,22 +144,6 @@ parseFcFixture supportModules path value = do
         caseStatus = status,
         caseReason = reason
       }
-
-canonicalExpected :: String -> String
-canonicalExpected expected
-  | "scope " `isPrefixOf` expected = trim expected
-  | otherwise =
-      case traverse (parseProgram . T.pack) (expectedPrograms expected) of
-        Right programs -> trim (unlines (map renderProgram programs))
-        Left _ -> trim expected
-
-expectedPrograms :: String -> [String]
-expectedPrograms = map unlines . reverse . filter (not . null) . foldl addLine [] . lines
-  where
-    addLine [] line = [[line]]
-    addLine (program : programs) line
-      | "module " `isPrefixOf` line = [line] : program : programs
-      | otherwise = (program <> [line]) : programs
 
 parseModules :: Y.Value -> Y.Parser [Text]
 parseModules = withArray "modules" $ \arr ->

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -128,10 +128,19 @@ firstDuplicate = go Set.empty
       | otherwise = go (Set.insert value seen) values
 
 parseExpr :: Text -> Either FcParseError FcExpr
-parseExpr = parseWith mempty (space *> expression mempty mempty <* MP.eof) "<system-fc-expression>"
+parseExpr input =
+  parseStandalone input (\_ -> expression mempty mempty) "<system-fc-expression>"
 
 parseType :: Text -> Either FcParseError TcType
-parseType = parseWith mempty (space *> tcType mempty <* MP.eof) "<system-fc-type>"
+parseType input =
+  parseStandalone input (\_ -> tcType mempty) "<system-fc-type>"
+
+parseStandalone :: Text -> (ScopeEnv -> Parser value) -> String -> Either FcParseError value
+parseStandalone input parser sourceName
+  | "scope" `T.isPrefixOf` T.stripStart input = do
+      (scopes, body) <- parseScopeHeader input
+      parseWith scopes (space *> parser scopes <* MP.eof) sourceName body
+  | otherwise = parseWith mempty (space *> parser mempty <* MP.eof) sourceName input
 
 renderParseError :: FcParseError -> String
 renderParseError = MP.errorBundlePretty

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -19,7 +19,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (guard, void)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import Data.ByteString qualified as BS
-import Data.Char (isAlphaNum, isAscii, isAsciiUpper, isSpace, ord)
+import Data.Char (isAlphaNum, isAscii, isAsciiUpper, isDigit, isSpace, ord)
 import Data.Either (fromRight)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
@@ -318,7 +318,7 @@ constructorIdentity = MP.try scopedConstructorIdentity <|> legacyConstructorIden
 scopeReference :: Parser (Text, Text, Text)
 scopeReference = do
   requestedScope <- scopeId
-  _ <- symbol "."
+  _ <- MPC.char '.'
   symbolName <- scopeSymbolName
   (packageName, moduleName) <- scopeBinding requestedScope
   pure (packageName, moduleName, symbolName)
@@ -346,7 +346,8 @@ scopeSymbolName =
       first <- MP.satisfy (\character -> isAlphaNum character || character `elem` ("_$'" :: String))
       rest <- MP.many (MP.satisfy nameCharacter)
       following <- MP.optional (MP.lookAhead MP.anySingle)
-      guard (first /= '$' || not (null rest) || maybe True (not . (`elem` operatorNameCharacters)) following)
+      slashStartsArity <- MP.optional (MP.try (MP.lookAhead (void (MPC.char '/') *> void (MP.satisfy isDigit))))
+      guard (first /= '$' || maybe True (`notElem` operatorNameCharacters) following || slashStartsArity == Just ())
       pure (T.pack (first : rest))
 
 makeConstructorIdentity :: Text -> Text -> Text -> (Text, FcConstructorId)

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -48,23 +48,70 @@ newtype UnboxedTupleSyntax = UnboxedTupleSyntax
 
 parseProgram :: Text -> Either FcParseError FcProgram
 parseProgram input = do
+  (scopes, scopedInput) <- parseScopes input
+  let expandedInput = expandScopes scopes scopedInput
+      blocks = filter (not . T.null) (map T.strip (T.splitOn "\n\n" expandedInput))
   moduleHeaders <- traverse parseModuleHeader blocks
-  moduleId <- validateModuleDeclaration input (catMaybes moduleHeaders)
+  moduleId <- validateModuleDeclaration expandedInput (catMaybes moduleHeaders)
   let definitionBlocks =
         [ block
         | (block, Nothing) <- zip blocks moduleHeaders
         ]
   headers <- traverse parseExternalHeader definitionBlocks
-  validateExternalDeclarations input headers
+  validateExternalDeclarations expandedInput headers
   let moduleOrigin = Just (fcModulePackageText moduleId, fcModuleName moduleId)
   signatures <- traverse (parseSignatures moduleOrigin) definitionBlocks
   let globals = Map.unions (catMaybes signatures) <> externalEnv headers
   FcProgram moduleId <$> traverse (parseBlock moduleOrigin globals) definitionBlocks
   where
-    blocks = filter (not . T.null) (map T.strip (T.splitOn "\n\n" input))
     parseModuleHeader = MP.parse (space *> MP.optional (MP.try moduleDeclaration) <* MP.takeRest) "<system-fc-header>"
     parseExternalHeader = MP.parse (space *> MP.optional (MP.try externalDeclaration) <* MP.takeRest) "<system-fc-header>"
     parseBlock moduleOrigin globals = MP.parse (space *> topBind moduleOrigin globals <* MP.eof) "<system-fc>"
+
+type ScopeEnv = Map Text (Text, Text)
+
+parseScopes :: Text -> Either FcParseError (ScopeEnv, Text)
+parseScopes input = do
+  scopes <- traverse parseScope scopeLines
+  case firstDuplicate (map fst scopes) of
+    Just scopeId -> parseProgramFailure input ("duplicate System FC scope " <> T.unpack scopeId)
+    Nothing -> Right (Map.fromList scopes, T.unlines remainingLines)
+  where
+    (scopeLines, remainingLines) = span (T.isPrefixOf "scope " . T.strip) (T.lines input)
+    parseScope = MP.parse (space *> scopeDeclaration <* MP.eof) "<system-fc-scope>"
+
+scopeDeclaration :: Parser (Text, (Text, Text))
+scopeDeclaration = do
+  _ <- keyword "scope"
+  scopeId <- T.pack . show <$> int
+  _ <- symbol "="
+  packageName <- text
+  moduleName <- qualifiedName
+  pure (scopeId, (packageName, moduleName))
+
+expandScopes :: ScopeEnv -> Text -> Text
+expandScopes scopes input = Map.foldlWithKey' expandOne input scopes
+  where
+    expandOne expanded scopeId (packageName, moduleName) =
+      replaceScopeReference scopeId (quotedPackage <> " " <> moduleName <> ".") tyConsExpanded
+      where
+        modulesExpanded = T.replace ("module " <> scopeId <> ".") ("module " <> quotedPackage <> " ") expanded
+        tyConsExpanded = T.replace ("tycon " <> scopeId <> ".") ("tycon " <> quotedPackage <> " " <> quotedModule <> " ") modulesExpanded
+        quotedPackage = T.pack (show (T.unpack packageName))
+        quotedModule = T.pack (show (T.unpack moduleName))
+
+replaceScopeReference :: Text -> Text -> Text -> Text
+replaceScopeReference scopeId replacement = go True
+  where
+    reference = scopeId <> "."
+    go _ "" = ""
+    go startsToken input =
+      case T.stripPrefix reference input of
+        Just rest | startsToken -> replacement <> go False rest
+        _ ->
+          case T.uncons input of
+            Just (character, rest) -> T.singleton character <> go (not (nameCharacter character)) rest
+            Nothing -> ""
 
 validateModuleDeclaration :: Text -> [FcModuleId] -> Either FcParseError FcModuleId
 validateModuleDeclaration _ [moduleId] = Right moduleId

--- a/components/aihc-fc/src/Aihc/Fc/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Parser.hs
@@ -17,6 +17,7 @@ import Aihc.Tc.Evidence (Coercion (..), EvVar (..))
 import Aihc.Tc.Types
 import Control.Applicative ((<|>))
 import Control.Monad (guard, void)
+import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import Data.ByteString qualified as BS
 import Data.Char (isAlphaNum, isAscii, isAsciiUpper, isSpace, ord)
 import Data.Either (fromRight)
@@ -34,7 +35,7 @@ import Text.Megaparsec.Char qualified as MPC
 import Text.Megaparsec.Char.Lexer qualified as L
 import Text.Read (readMaybe)
 
-type Parser = Parsec Void Text
+type Parser = ReaderT ScopeEnv (Parsec Void Text)
 
 type FcParseError = ParseErrorBundle Text Void
 
@@ -48,70 +49,55 @@ newtype UnboxedTupleSyntax = UnboxedTupleSyntax
 
 parseProgram :: Text -> Either FcParseError FcProgram
 parseProgram input = do
-  (scopes, scopedInput) <- parseScopes input
-  let expandedInput = expandScopes scopes scopedInput
-      blocks = filter (not . T.null) (map T.strip (T.splitOn "\n\n" expandedInput))
-  moduleHeaders <- traverse parseModuleHeader blocks
-  moduleId <- validateModuleDeclaration expandedInput (catMaybes moduleHeaders)
+  (scopes, programInput) <- parseScopeHeader input
+  let blocks = filter (not . T.null) (map T.strip (T.splitOn "\n\n" programInput))
+  moduleHeaders <- traverse (parseModuleHeader scopes) blocks
+  moduleId <- validateModuleDeclaration programInput (catMaybes moduleHeaders)
   let definitionBlocks =
         [ block
         | (block, Nothing) <- zip blocks moduleHeaders
         ]
-  headers <- traverse parseExternalHeader definitionBlocks
-  validateExternalDeclarations expandedInput headers
+  headers <- traverse (parseExternalHeader scopes) definitionBlocks
+  validateExternalDeclarations programInput headers
   let moduleOrigin = Just (fcModulePackageText moduleId, fcModuleName moduleId)
-  signatures <- traverse (parseSignatures moduleOrigin) definitionBlocks
+  signatures <- traverse (parseSignatures scopes moduleOrigin) definitionBlocks
   let globals = Map.unions (catMaybes signatures) <> externalEnv headers
-  FcProgram moduleId <$> traverse (parseBlock moduleOrigin globals) definitionBlocks
-  where
-    parseModuleHeader = MP.parse (space *> MP.optional (MP.try moduleDeclaration) <* MP.takeRest) "<system-fc-header>"
-    parseExternalHeader = MP.parse (space *> MP.optional (MP.try externalDeclaration) <* MP.takeRest) "<system-fc-header>"
-    parseBlock moduleOrigin globals = MP.parse (space *> topBind moduleOrigin globals <* MP.eof) "<system-fc>"
+  FcProgram moduleId <$> traverse (parseBlock scopes moduleOrigin globals) definitionBlocks
+
+parseModuleHeader :: ScopeEnv -> Text -> Either FcParseError (Maybe FcModuleId)
+parseModuleHeader scopes = parseWith scopes (space *> MP.optional (MP.try moduleDeclaration) <* MP.takeRest) "<system-fc-header>"
+
+parseExternalHeader :: ScopeEnv -> Text -> Either FcParseError (Maybe FcTopBind)
+parseExternalHeader scopes = parseWith scopes (space *> MP.optional (MP.try externalDeclaration) <* MP.takeRest) "<system-fc-header>"
+
+parseBlock :: ScopeEnv -> Maybe (Text, Text) -> TermEnv -> Text -> Either FcParseError FcTopBind
+parseBlock scopes moduleOrigin globals = parseWith scopes (space *> topBind moduleOrigin globals <* MP.eof) "<system-fc>"
+
+parseWith :: ScopeEnv -> Parser value -> String -> Text -> Either FcParseError value
+parseWith scopes parser = MP.parse (runReaderT parser scopes)
 
 type ScopeEnv = Map Text (Text, Text)
 
-parseScopes :: Text -> Either FcParseError (ScopeEnv, Text)
-parseScopes input = do
-  scopes <- traverse parseScope scopeLines
+parseScopeHeader :: Text -> Either FcParseError (ScopeEnv, Text)
+parseScopeHeader input = do
+  (scopes, programInput) <- MP.parse parser "<system-fc-scope>" input
   case firstDuplicate (map fst scopes) of
-    Just scopeId -> parseProgramFailure input ("duplicate System FC scope " <> T.unpack scopeId)
-    Nothing -> Right (Map.fromList scopes, T.unlines remainingLines)
+    Just duplicateScope -> parseProgramFailure input ("duplicate System FC scope " <> T.unpack duplicateScope)
+    Nothing -> Right (Map.fromList scopes, programInput)
   where
-    (scopeLines, remainingLines) = span (T.isPrefixOf "scope " . T.strip) (T.lines input)
-    parseScope = MP.parse (space *> scopeDeclaration <* MP.eof) "<system-fc-scope>"
+    parser = do
+      scopes <- MP.some (runReaderT scopeDeclaration mempty)
+      programInput <- MP.takeRest
+      pure (scopes, programInput)
 
 scopeDeclaration :: Parser (Text, (Text, Text))
 scopeDeclaration = do
   _ <- keyword "scope"
-  scopeId <- T.pack . show <$> int
+  declaredScope <- T.pack . show <$> int
   _ <- symbol "="
   packageName <- text
   moduleName <- qualifiedName
-  pure (scopeId, (packageName, moduleName))
-
-expandScopes :: ScopeEnv -> Text -> Text
-expandScopes scopes input = Map.foldlWithKey' expandOne input scopes
-  where
-    expandOne expanded scopeId (packageName, moduleName) =
-      replaceScopeReference scopeId (quotedPackage <> " " <> moduleName <> ".") tyConsExpanded
-      where
-        modulesExpanded = T.replace ("module " <> scopeId <> ".") ("module " <> quotedPackage <> " ") expanded
-        tyConsExpanded = T.replace ("tycon " <> scopeId <> ".") ("tycon " <> quotedPackage <> " " <> quotedModule <> " ") modulesExpanded
-        quotedPackage = T.pack (show (T.unpack packageName))
-        quotedModule = T.pack (show (T.unpack moduleName))
-
-replaceScopeReference :: Text -> Text -> Text -> Text
-replaceScopeReference scopeId replacement = go True
-  where
-    reference = scopeId <> "."
-    go _ "" = ""
-    go startsToken input =
-      case T.stripPrefix reference input of
-        Just rest | startsToken -> replacement <> go False rest
-        _ ->
-          case T.uncons input of
-            Just (character, rest) -> T.singleton character <> go (not (nameCharacter character)) rest
-            Nothing -> ""
+  pure (declaredScope, (packageName, moduleName))
 
 validateModuleDeclaration :: Text -> [FcModuleId] -> Either FcParseError FcModuleId
 validateModuleDeclaration _ [moduleId] = Right moduleId
@@ -142,10 +128,10 @@ firstDuplicate = go Set.empty
       | otherwise = go (Set.insert value seen) values
 
 parseExpr :: Text -> Either FcParseError FcExpr
-parseExpr = MP.parse (space *> expression mempty mempty <* MP.eof) "<system-fc-expression>"
+parseExpr = parseWith mempty (space *> expression mempty mempty <* MP.eof) "<system-fc-expression>"
 
 parseType :: Text -> Either FcParseError TcType
-parseType = MP.parse (space *> tcType mempty <* MP.eof) "<system-fc-type>"
+parseType = parseWith mempty (space *> tcType mempty <* MP.eof) "<system-fc-type>"
 
 renderParseError :: FcParseError -> String
 renderParseError = MP.errorBundlePretty
@@ -165,10 +151,13 @@ topBind moduleOrigin termEnv =
 moduleDeclaration :: Parser FcModuleId
 moduleDeclaration = do
   _ <- keyword "module"
-  packageName <- MP.optional (MP.try text)
-  moduleName <- qualifiedName
+  requestedScope <- scopeId
+  _ <- symbol "."
+  declaredName <- qualifiedName
+  (packageName, moduleName) <- scopeBinding requestedScope
+  guard (moduleName == declaredName)
   _ <- keyword "where"
-  pure (FcModuleId (PackageId (fromMaybe "" packageName)) moduleName)
+  pure (FcModuleId (PackageId packageName) moduleName)
 
 externalDeclaration :: Parser FcTopBind
 externalDeclaration = do
@@ -185,9 +174,10 @@ externalEnv headers =
     | Just (FcExternal origin ty) <- headers
     ]
 
-parseSignatures :: Maybe (Text, Text) -> Text -> Either FcParseError (Maybe TermEnv)
-parseSignatures moduleOrigin =
-  MP.parse
+parseSignatures :: ScopeEnv -> Maybe (Text, Text) -> Text -> Either FcParseError (Maybe TermEnv)
+parseSignatures scopes moduleOrigin =
+  parseWith
+    scopes
     (space *> MP.optional (MP.try (declarationSignatures moduleOrigin)) <* MP.takeRest)
     "<system-fc-signature>"
 
@@ -311,13 +301,53 @@ declarationName moduleOrigin = do
     Nothing -> fail "declaration has no System FC module origin"
 
 constructorIdentity :: Parser (Text, FcConstructorId)
-constructorIdentity = do
-  packageName <- text
-  qualified <- lexeme (T.pack <$> MP.some (MP.satisfy (not . isSpace)))
-  case splitConstructorIdentity qualified of
-    Just (moduleName, constructorName) ->
+constructorIdentity = MP.try scopedConstructorIdentity <|> legacyConstructorIdentity
+  where
+    scopedConstructorIdentity = do
+      (packageName, moduleName, constructorName) <- scopeReference
       pure (makeConstructorIdentity packageName moduleName constructorName)
-    Nothing -> fail "invalid qualified System FC constructor name"
+    legacyConstructorIdentity = do
+      scopes <- ask
+      guard (Map.null scopes)
+      packageName <- text
+      qualified <- lexeme (T.pack <$> MP.some (MP.satisfy (not . isSpace)))
+      case splitConstructorIdentity qualified of
+        Just (moduleName, constructorName) -> pure (makeConstructorIdentity packageName moduleName constructorName)
+        Nothing -> fail "invalid qualified System FC constructor name"
+
+scopeReference :: Parser (Text, Text, Text)
+scopeReference = do
+  requestedScope <- scopeId
+  _ <- symbol "."
+  symbolName <- scopeSymbolName
+  (packageName, moduleName) <- scopeBinding requestedScope
+  pure (packageName, moduleName, symbolName)
+
+scopeId :: Parser Text
+scopeId = T.pack . show <$> int
+
+scopeBinding :: Text -> Parser (Text, Text)
+scopeBinding requestedScope = do
+  scopes <- ask
+  case Map.lookup requestedScope scopes of
+    Just scope -> pure scope
+    Nothing -> fail ("unknown System FC scope " <> T.unpack requestedScope)
+
+scopeSymbolName :: Parser Text
+scopeSymbolName =
+  lexeme
+    ( delimitedSymbolName '(' ')'
+        <|> delimitedSymbolName '[' ']'
+        <|> MP.try scopeOrdinaryName
+        <|> (T.pack <$> MP.some (MP.satisfy (`elem` operatorNameCharacters)))
+    )
+  where
+    scopeOrdinaryName = do
+      first <- MP.satisfy (\character -> isAlphaNum character || character `elem` ("_$'" :: String))
+      rest <- MP.many (MP.satisfy nameCharacter)
+      following <- MP.optional (MP.lookAhead MP.anySingle)
+      guard (first /= '$' || not (null rest) || maybe True (not . (`elem` operatorNameCharacters)) following)
+      pure (T.pack (first : rest))
 
 makeConstructorIdentity :: Text -> Text -> Text -> (Text, FcConstructorId)
 makeConstructorIdentity packageName moduleName constructorName =
@@ -603,13 +633,20 @@ resolvedOriginName = do
     Nothing -> fail "expected a resolved System FC symbol"
 
 topLevelOrigin :: Parser (Text, Maybe FcSymbolOrigin)
-topLevelOrigin = do
-  packageName <- MP.optional (MP.try text)
-  qualified <- lexeme (T.pack <$> MP.some (MP.satisfy qualifiedSymbolCharacter))
-  case splitConstructorIdentity qualified of
-    Just (moduleName, symbolName) ->
-      pure (symbolName, Just (FcTopLevelOrigin (fromMaybe "" packageName) moduleName symbolName))
-    Nothing -> fail "invalid qualified System FC symbol name"
+topLevelOrigin = MP.try scopedTopLevelOrigin <|> legacyTopLevelOrigin
+  where
+    scopedTopLevelOrigin = do
+      (packageName, moduleName, symbolName) <- scopeReference
+      pure (symbolName, Just (FcTopLevelOrigin packageName moduleName symbolName))
+    legacyTopLevelOrigin = do
+      scopes <- ask
+      guard (Map.null scopes)
+      packageName <- MP.optional (MP.try text)
+      qualified <- lexeme (T.pack <$> MP.some (MP.satisfy qualifiedSymbolCharacter))
+      case splitConstructorIdentity qualified of
+        Just (moduleName, symbolName) ->
+          pure (symbolName, Just (FcTopLevelOrigin (fromMaybe "" packageName) moduleName symbolName))
+        Nothing -> fail "invalid qualified System FC symbol name"
 
 builtinOrigin :: Parser (Text, Maybe FcSymbolOrigin)
 builtinOrigin = do
@@ -899,7 +936,21 @@ localTyConHead = do
   TyCon typeName <$> int
 
 externalTyConHead :: Parser TyCon
-externalTyConHead = do
+externalTyConHead = MP.try scopedExternalTyConHead <|> legacyExternalTyConHead
+
+scopedExternalTyConHead :: Parser TyCon
+scopedExternalTyConHead = do
+  _ <- keyword "tycon"
+  (packageName, moduleName, typeName) <- scopeReference
+  _ <- symbol "/"
+  arity <- int
+  scheme <- between "{" "}" tyConKindSchemeSyntax
+  pure (mkTyConWithOriginScheme (PackageId packageName) moduleName typeName arity scheme)
+
+legacyExternalTyConHead :: Parser TyCon
+legacyExternalTyConHead = do
+  scopes <- ask
+  guard (Map.null scopes)
   _ <- keyword "tycon"
   packageName <- text
   moduleName <- text

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -14,7 +14,7 @@ import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Evidence (Coercion (..), EvVar (..))
 import Aihc.Tc.Types
 import Data.ByteString qualified as BS
-import Data.Char (chr, isAlphaNum, isAsciiUpper)
+import Data.Char (chr, isAlphaNum, isAscii, isAsciiUpper, isSpace)
 import Data.List (intercalate)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
@@ -46,10 +46,11 @@ scopesInRenderedProgram :: String -> [Scope]
 scopesInRenderedProgram rendered = concatMap scopesInWords (windows 4 words') <> concatMap scopesInOrigin (windows 3 words')
   where
     words' = words rendered
-    scopesInWords ["tycon", packageName, moduleName, _] =
-      case (readMaybe packageName, readMaybe moduleName) of
-        (Just package, Just moduleName') -> [(T.pack package, T.pack moduleName')]
-        _ -> []
+    scopesInWords [prefix, packageName, moduleName, _]
+      | "tycon" `List.isSuffixOf` prefix =
+          case (readMaybe packageName, readMaybe moduleName) of
+            (Just package, Just moduleName') -> [(T.pack package, T.pack moduleName')]
+            _ -> []
     scopesInWords [packageName, qualified, _, _] =
       case (readMaybe packageName, splitQualifiedName (T.pack qualified)) of
         (Just package, Just (moduleName, _)) -> [(T.pack package, moduleName)]
@@ -68,12 +69,21 @@ windows size values
   | otherwise = take size values : windows size (drop 1 values)
 
 splitQualifiedName :: T.Text -> Maybe (T.Text, T.Text)
-splitQualifiedName qualified =
-  case T.breakOnEnd "." qualified of
-    (moduleName, symbolName)
-      | T.null moduleName || T.null symbolName || T.isPrefixOf "\"" qualified -> Nothing
-      | not (validScopeModule (T.dropEnd 1 moduleName)) -> Nothing
-      | otherwise -> Just (T.dropEnd 1 moduleName, symbolName)
+splitQualifiedName original =
+  case reverse candidates of
+    candidate : _ -> Just candidate
+    [] -> Nothing
+  where
+    qualified = T.dropWhileEnd (== '}') original
+    candidates =
+      [ (moduleName, symbolName)
+      | offset <- [1 .. T.length qualified - 1],
+        T.index qualified offset == '.',
+        let moduleName = T.take offset qualified,
+        let symbolName = T.drop (offset + 1) qualified,
+        validScopeModule moduleName,
+        validScopeName symbolName
+      ]
 
 validScopeModule :: T.Text -> Bool
 validScopeModule = all validScopeSegment . T.splitOn "."
@@ -85,7 +95,26 @@ validScopeSegment segment =
     Nothing -> False
 
 validScopeCharacter :: Char -> Bool
-validScopeCharacter character = isAlphaNum character || character `elem` ("_'" :: String)
+validScopeCharacter character = isAlphaNum character || character `elem` ("_'$#" :: String)
+
+validScopeName :: T.Text -> Bool
+validScopeName value =
+  (not (T.null value) && T.all validScopeCharacter value)
+    || (not (T.null value) && T.all (`elem` ("!#$%&*+./<=>?@\\^|-~:" :: String)) value)
+    || validDelimitedScopeName '(' ')' value
+    || validDelimitedScopeName '[' ']' value
+
+validDelimitedScopeName :: Char -> Char -> T.Text -> Bool
+validDelimitedScopeName opening closing value =
+  case (T.uncons value, T.unsnoc value) of
+    (Just (first, _), Just (contents, lastCharacter)) ->
+      first == opening
+        && lastCharacter == closing
+        && T.all validDelimitedScopeCharacter (T.drop 1 contents)
+    _ -> False
+
+validDelimitedScopeCharacter :: Char -> Bool
+validDelimitedScopeCharacter character = isAscii character && not (isAlphaNum character) && not (isSpace character)
 
 renderScopes :: Map.Map Scope Int -> String
 renderScopes = intercalate "\n" . map renderScope . Map.toAscList

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -1,539 +1,331 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Human-readable, canonical System FC syntax.
-module Aihc.Fc.Pretty
-  ( renderProgram,
-    renderExpr,
-    renderType,
-    renderTopBind,
-  )
-where
+module Aihc.Fc.Pretty (renderProgram, renderExpr, renderType, renderTopBind) where
 
 import Aihc.Fc.Syntax
 import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Evidence (Coercion (..), EvVar (..))
 import Aihc.Tc.Types
 import Data.ByteString qualified as BS
-import Data.Char (chr, isAlphaNum, isAscii, isAsciiUpper, isSpace)
+import Data.Char (chr)
 import Data.List (intercalate)
-import Data.List qualified as List
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text qualified as T
-import Text.Read (readMaybe)
-
-renderProgram :: FcProgram -> String
-renderProgram program =
-  renderScopes scopes <> "\n\n" <> replaceScopes scopes rendered
-  where
-    rendered = renderProgramWithoutScopes program
-    scopes = scopeTable rendered (fcProgramModule program)
-
-renderProgramWithoutScopes :: FcProgram -> String
-renderProgramWithoutScopes program =
-  intercalate
-    "\n\n"
-    (renderModuleDeclaration (fcProgramModule program) : map renderTopBind (fcTopBinds program))
 
 type Scope = (T.Text, T.Text)
 
-scopeTable :: String -> FcModuleId -> Map.Map Scope Int
-scopeTable rendered moduleId =
-  Map.fromList (zip scopes [1 ..])
+type ScopeTable = Map.Map Scope Int
+
+renderProgram :: FcProgram -> String
+renderProgram program = intercalate "\n\n" (renderScopes scopes : renderModuleDeclaration scopes (fcProgramModule program) : map (renderTopBindWith scopes) (fcTopBinds program))
   where
-    scopes = List.sort . List.nub $ (fcModulePackageText moduleId, fcModuleName moduleId) : scopesInRenderedProgram rendered
+    scopes = scopeTable program
 
-scopesInRenderedProgram :: String -> [Scope]
-scopesInRenderedProgram rendered = concatMap scopesInWords (windows 4 words') <> concatMap scopesInOrigin (windows 3 words')
-  where
-    words' = words rendered
-    scopesInWords [prefix, packageName, moduleName, _]
-      | "tycon" `List.isSuffixOf` prefix =
-          case (readMaybe packageName, readMaybe moduleName) of
-            (Just package, Just moduleName') -> [(T.pack package, T.pack moduleName')]
-            _ -> []
-    scopesInWords [packageName, qualified, _, _] =
-      case (readMaybe packageName, splitQualifiedName (T.pack qualified)) of
-        (Just package, Just (moduleName, _)) -> [(T.pack package, moduleName)]
-        _ -> []
-    scopesInWords _ = []
-    scopesInOrigin [previous, packageName, qualified]
-      | previous /= "module" =
-          case (readMaybe packageName, splitQualifiedName (T.pack qualified)) of
-            (Just package, Just (moduleName, _)) -> [(T.pack package, moduleName)]
-            _ -> []
-    scopesInOrigin _ = []
+scopeTable :: FcProgram -> ScopeTable
+scopeTable = Map.fromAscList . flip zip [1 ..] . Set.toAscList . programScopes
 
-windows :: Int -> [value] -> [[value]]
-windows size values
-  | length values < size = []
-  | otherwise = take size values : windows size (drop 1 values)
+programScopes :: FcProgram -> Set.Set Scope
+programScopes program = moduleScopes (fcProgramModule program) <> foldMap topBindScopes (fcTopBinds program)
 
-splitQualifiedName :: T.Text -> Maybe (T.Text, T.Text)
-splitQualifiedName original =
-  case reverse candidates of
-    candidate : _ -> Just candidate
-    [] -> Nothing
-  where
-    qualified = T.dropWhileEnd (== '}') original
-    candidates =
-      [ (moduleName, symbolName)
-      | offset <- [1 .. T.length qualified - 1],
-        T.index qualified offset == '.',
-        let moduleName = T.take offset qualified,
-        let symbolName = T.drop (offset + 1) qualified,
-        validScopeModule moduleName,
-        validScopeName symbolName
-      ]
+moduleScopes :: FcModuleId -> Set.Set Scope
+moduleScopes moduleId = Set.singleton (fcModulePackageText moduleId, fcModuleName moduleId)
 
-validScopeModule :: T.Text -> Bool
-validScopeModule = all validScopeSegment . T.splitOn "."
+topBindScopes :: FcTopBind -> Set.Set Scope
+topBindScopes topBind = case topBind of
+  FcExternal origin ty -> originScopes origin <> typeScopes ty
+  FcData declaration -> originScopes (fcDataOrigin declaration) <> foldMap dataConScopes (fcDataConstructors declaration)
+  FcAxiom declaration -> typeScopes (fcAxiomLeft declaration) <> typeScopes (fcAxiomRight declaration)
+  FcNewtype declaration -> originScopes (fcNewtypeOrigin declaration) <> constructorScopes (fcNewtypeConstructorOrigin declaration) <> typeScopes (fcNewtypeRepresentation declaration) <> typeScopes (fcNewtypeResult declaration)
+  FcPrimitive var _ -> varScopes var
+  FcForeignImport foreignCall -> foreignCallScopes foreignCall
+  FcTopBind bind -> bindScopes bind
 
-validScopeSegment :: T.Text -> Bool
-validScopeSegment segment =
-  case T.uncons segment of
-    Just (first, rest) -> isAsciiUpper first && T.all validScopeCharacter rest
-    Nothing -> False
+dataConScopes :: FcDataConDecl -> Set.Set Scope
+dataConScopes declaration = constructorScopes (fcDataConOrigin declaration) <> foldMap typeScopes (fcDataConFields declaration)
 
-validScopeCharacter :: Char -> Bool
-validScopeCharacter character = isAlphaNum character || character `elem` ("_'$#" :: String)
+foreignCallScopes :: FcForeignCall -> Set.Set Scope
+foreignCallScopes = typeScopes . fcForeignCallType . fcForeignCallSignature
 
-validScopeName :: T.Text -> Bool
-validScopeName value =
-  (not (T.null value) && T.all validScopeCharacter value)
-    || (not (T.null value) && T.all (`elem` ("!#$%&*+./<=>?@\\^|-~:" :: String)) value)
-    || validDelimitedScopeName '(' ')' value
-    || validDelimitedScopeName '[' ']' value
+bindScopes :: FcBind -> Set.Set Scope
+bindScopes bind = case bind of
+  FcNonRec var rhs -> varScopes var <> exprScopes rhs
+  FcRec bindings -> foldMap (\(var, rhs) -> varScopes var <> exprScopes rhs) bindings
 
-validDelimitedScopeName :: Char -> Char -> T.Text -> Bool
-validDelimitedScopeName opening closing value =
-  case (T.uncons value, T.unsnoc value) of
-    (Just (first, _), Just (contents, lastCharacter)) ->
-      first == opening
-        && lastCharacter == closing
-        && T.all validDelimitedScopeCharacter (T.drop 1 contents)
-    _ -> False
+exprScopes :: FcExpr -> Set.Set Scope
+exprScopes expression = case expression of
+  FcVar var -> varScopes var
+  FcLit _ ty -> typeScopes ty
+  FcApp function argument -> exprScopes function <> exprScopes argument
+  FcTyApp function argument -> exprScopes function <> typeScopes argument
+  FcLam var body -> varScopes var <> exprScopes body
+  FcTyLam _ body -> exprScopes body
+  FcLet bind body -> bindScopes bind <> exprScopes body
+  FcCase scrutinee binder alternatives -> exprScopes scrutinee <> varScopes binder <> foldMap altScopes alternatives
+  FcCast body coercion -> exprScopes body <> coercionScopes coercion
+  FcCallForeign foreignCall arguments -> foreignCallScopes foreignCall <> foldMap exprScopes arguments
 
-validDelimitedScopeCharacter :: Char -> Bool
-validDelimitedScopeCharacter character = isAscii character && not (isAlphaNum character) && not (isSpace character)
+altScopes :: FcAlt -> Set.Set Scope
+altScopes alternative = altConScopes (altCon alternative) <> foldMap varScopes (altBinders alternative) <> exprScopes (altRhs alternative)
 
-renderScopes :: Map.Map Scope Int -> String
+altConScopes :: FcAltCon -> Set.Set Scope
+altConScopes alternative = case alternative of
+  DataAlt constructor -> constructorScopes constructor
+  LitAlt _ ty -> typeScopes ty
+  DefaultAlt -> mempty
+
+varScopes :: Var -> Set.Set Scope
+varScopes var = typeScopes (varType var) <> maybe mempty originScopes (varResolvedName var)
+
+originScopes :: FcSymbolOrigin -> Set.Set Scope
+originScopes origin = case origin of
+  FcTopLevelOrigin packageName moduleName _ -> Set.singleton (packageName, moduleName)
+  FcBuiltinOrigin {} -> mempty
+
+constructorScopes :: FcConstructorId -> Set.Set Scope
+constructorScopes constructor = Set.singleton (packageIdText (fcConstructorPackage constructor), fcConstructorModule constructor)
+
+typeScopes :: TcType -> Set.Set Scope
+typeScopes ty = case ty of
+  TcTyVar {} -> mempty
+  TcMetaTv {} -> mempty
+  TcTyCon tyCon arguments -> tyConScopes tyCon <> foldMap typeScopes arguments
+  TcFunTy argument result -> typeScopes argument <> typeScopes result
+  TcForAllTy _ body -> typeScopes body
+  TcQualTy predicates body -> foldMap predScopes predicates <> typeScopes body
+  TcAppTy function argument -> typeScopes function <> typeScopes argument
+  TcBuiltinTyCon _ _ arguments -> foldMap typeScopes arguments
+
+tyConScopes :: TyCon -> Set.Set Scope
+tyConScopes tyCon = Set.singleton (packageIdText (tyConPackageId tyCon), tyConModuleName tyCon)
+
+predScopes :: Pred -> Set.Set Scope
+predScopes predicate = case predicate of
+  ClassPred tyCon arguments -> tyConScopes tyCon <> foldMap typeScopes arguments
+  EqPred left right -> typeScopes left <> typeScopes right
+
+coercionScopes :: Coercion -> Set.Set Scope
+coercionScopes coercion = case coercion of
+  CoVar {} -> mempty
+  Refl ty -> typeScopes ty
+  Sym inner -> coercionScopes inner
+  Trans left right -> coercionScopes left <> coercionScopes right
+  TyConAppCo tyCon arguments -> tyConScopes tyCon <> foldMap coercionScopes arguments
+  AxiomInstCo _ arguments -> foldMap typeScopes arguments
+
+renderScopes :: ScopeTable -> String
 renderScopes = intercalate "\n" . map renderScope . Map.toAscList
   where
-    renderScope ((packageName, moduleName), scopeId) =
-      "scope " <> show scopeId <> " = " <> show (T.unpack packageName) <> " " <> T.unpack moduleName
+    renderScope ((packageName, moduleName), scopeId) = "scope " <> show scopeId <> " = " <> show (T.unpack packageName) <> " " <> T.unpack moduleName
 
-replaceScopes :: Map.Map Scope Int -> String -> String
-replaceScopes scopes programText = List.foldl' replaceOne programText replacementScopes
-  where
-    replacementScopes = List.sortOn (negate . T.length . snd . fst) (Map.toAscList scopes)
-    replaceOne text ((packageName, moduleName), scopeId) =
-      replace
-        ("module " <> fullScope <> " where")
-        ("module " <> shortScope <> "." <> T.unpack moduleName <> " where")
-        ( replace
-            ("tycon " <> showPackage <> " " <> showModule <> " ")
-            ("tycon " <> shortScope <> ".")
-            (replace (fullScope <> ".") (shortScope <> ".") text)
-        )
-      where
-        fullScope = showPackage <> " " <> T.unpack moduleName
-        shortScope = show scopeId
-        showPackage = show (T.unpack packageName)
-        showModule = show (T.unpack moduleName)
-    replace old new = T.unpack . T.replace (T.pack old) (T.pack new) . T.pack
+renderModuleDeclaration :: ScopeTable -> FcModuleId -> String
+renderModuleDeclaration scopes moduleId = "module " <> scopeReference scopes (fcModulePackageText moduleId) (fcModuleName moduleId) "" <> T.unpack (fcModuleName moduleId) <> " where"
 
-renderModuleDeclaration :: FcModuleId -> String
-renderModuleDeclaration moduleId =
-  "module " <> renderModuleOrigin (fcModulePackageText moduleId) (fcModuleName moduleId) <> " where"
-
-renderKindScheme :: TypeScheme -> String
-renderKindScheme scheme@(ForAll tyVars _ _) =
-  prefix <> renderKind (kindFromTypeScheme scheme)
-  where
-    prefix =
-      case tyVars of
-        [] -> ""
-        _ -> "∀ " <> unwords (map renderTyVarBinder tyVars) <> ". "
+scopeReference :: ScopeTable -> T.Text -> T.Text -> T.Text -> String
+scopeReference scopes packageName moduleName name = case Map.lookup (packageName, moduleName) scopes of
+  Just scopeId -> show scopeId <> "." <> T.unpack name
+  Nothing -> show (T.unpack packageName) <> " " <> T.unpack moduleName <> "." <> T.unpack name
 
 renderTopBind :: FcTopBind -> String
-renderTopBind topBind =
-  case topBind of
-    FcExternal origin ty ->
-      "external " <> renderOrigin origin <> " : " <> renderType ty
-    FcData declaration ->
-      "data "
-        <> renderDeclarationName (fcDataOrigin declaration)
-        <> concatMap ((" " <>) . renderTyVarBinder) (fcDataTyVars declaration)
-        <> renderDataResultKind declaration
-        <> renderConstructors (fcDataTyVars declaration) (fcDataConstructors declaration)
-    FcAxiom declaration ->
-      "axiom "
-        <> T.unpack (fcAxiomName declaration)
-        <> concatMap ((" " <>) . renderTyVarBinder) (fcAxiomTyVars declaration)
-        <> " : "
-        <> renderType (fcAxiomLeft declaration)
-        <> renderAxiomRole (fcAxiomRole declaration)
-        <> renderType (fcAxiomRight declaration)
-    FcNewtype declaration ->
-      "newtype "
-        <> renderDeclarationName (fcNewtypeOrigin declaration)
-        <> concatMap ((" " <>) . renderTyVarBinder) (fcNewtypeTyVars declaration)
-        <> " : "
-        <> renderType (fcNewtypeResult declaration)
-        <> " = "
-        <> renderConstructorId (fcNewtypeConstructorOrigin declaration)
-        <> " "
-        <> renderTypeAtom (fcNewtypeRepresentation declaration)
-    FcPrimitive var arity ->
-      "foreign prim " <> renderBinder var <> "/" <> show arity <> " : " <> renderType (varType var)
-    FcForeignImport foreignCall -> renderForeignImport foreignCall
-    FcTopBind bind -> renderBind 0 bind
+renderTopBind = renderTopBindWith mempty
 
-renderDataResultKind :: FcDataDecl -> String
-renderDataResultKind declaration =
-  " : " <> renderKind (fcDataResultKind declaration)
+renderTopBindWith :: ScopeTable -> FcTopBind -> String
+renderTopBindWith scopes topBind = case topBind of
+  FcExternal origin ty -> "external " <> renderOrigin scopes origin <> " : " <> renderTypeWith scopes ty
+  FcData declaration -> "data " <> renderOrigin scopes (fcDataOrigin declaration) <> concatMap ((" " <>) . renderTyVarBinder scopes) (fcDataTyVars declaration) <> " : " <> renderKind scopes (fcDataResultKind declaration) <> renderConstructors scopes (fcDataConstructors declaration)
+  FcAxiom declaration -> "axiom " <> T.unpack (fcAxiomName declaration) <> concatMap ((" " <>) . renderTyVarBinder scopes) (fcAxiomTyVars declaration) <> " : " <> renderTypeWith scopes (fcAxiomLeft declaration) <> renderAxiomRole (fcAxiomRole declaration) <> renderTypeWith scopes (fcAxiomRight declaration)
+  FcNewtype declaration -> "newtype " <> renderOrigin scopes (fcNewtypeOrigin declaration) <> concatMap ((" " <>) . renderTyVarBinder scopes) (fcNewtypeTyVars declaration) <> " : " <> renderTypeWith scopes (fcNewtypeResult declaration) <> " = " <> renderConstructorId scopes (fcNewtypeConstructorOrigin declaration) <> " " <> renderTypeAtom scopes (fcNewtypeRepresentation declaration)
+  FcPrimitive var arity -> "foreign prim " <> renderBinder scopes var <> "/" <> show arity <> " : " <> renderTypeWith scopes (varType var)
+  FcForeignImport foreignCall -> renderForeignImport scopes foreignCall
+  FcTopBind bind -> renderBind scopes 0 bind
 
-renderModuleOrigin :: T.Text -> T.Text -> String
-renderModuleOrigin packageName moduleName =
-  show (T.unpack packageName) <> " " <> T.unpack moduleName
-
-renderConstructors :: [TyVarId] -> [FcDataConDecl] -> String
+renderConstructors :: ScopeTable -> [FcDataConDecl] -> String
 renderConstructors _ [] = ""
-renderConstructors _ constructors =
-  "\n" <> intercalate "\n" (zipWith renderConstructor (" = " : repeat " | ") constructors)
+renderConstructors scopes constructors = "\n" <> intercalate "\n" (zipWith renderConstructor (" = " : repeat " | ") constructors)
   where
-    renderConstructor prefix declaration =
-      prefix
-        <> renderConstructorId (fcDataConOrigin declaration)
-        <> concatMap (\field -> " (" <> renderType field <> ")") fields
-      where
-        fields = fcDataConFields declaration
-
-renderDeclarationName :: FcSymbolOrigin -> String
-renderDeclarationName = renderOrigin
+    renderConstructor prefix declaration = prefix <> renderConstructorId scopes (fcDataConOrigin declaration) <> concatMap (\field -> " (" <> renderTypeWith scopes field <> ")") (fcDataConFields declaration)
 
 renderAxiomRole :: FcAxiomRole -> String
-renderAxiomRole role =
-  case role of
-    FcNominal -> " ~N "
-    FcRepresentational -> " ~R "
+renderAxiomRole FcNominal = " ~N "
+renderAxiomRole FcRepresentational = " ~R "
 
-renderForeignImport :: FcForeignCall -> String
-renderForeignImport foreignCall =
-  "foreign ccall "
-    <> show (T.unpack (fcForeignCallSymbol foreignCall))
-    <> " "
-    <> T.unpack (fcForeignCallName foreignCall)
-    <> " ["
-    <> intercalate ", " (map renderForeignType (fcForeignArgumentTypes signature))
-    <> " → "
-    <> renderForeignType (fcForeignResultType signature)
-    <> "; "
-    <> renderForeignEffect (fcForeignEffect signature)
-    <> "] : "
-    <> renderType (fcForeignCallType signature)
+renderForeignImport :: ScopeTable -> FcForeignCall -> String
+renderForeignImport scopes foreignCall = "foreign ccall " <> renderForeignCallHeader foreignCall <> " : " <> renderTypeWith scopes (fcForeignCallType signature)
   where
     signature = fcForeignCallSignature foreignCall
 
 renderForeignType :: FcForeignType -> String
-renderForeignType foreignType =
-  case foreignType of
-    FcForeignInt -> "Int"
-    FcForeignInt32 -> "Int32"
-    FcForeignWord64 -> "Word64"
-    FcForeignAddr -> "Addr"
+renderForeignType foreignType = case foreignType of
+  FcForeignInt -> "Int"
+  FcForeignInt32 -> "Int32"
+  FcForeignWord64 -> "Word64"
+  FcForeignAddr -> "Addr"
 
 renderForeignEffect :: FcForeignEffect -> String
-renderForeignEffect effect =
-  case effect of
-    FcForeignPure -> "pure"
-    FcForeignRealWorld -> "real-world"
+renderForeignEffect FcForeignPure = "pure"
+renderForeignEffect FcForeignRealWorld = "real-world"
 
-renderBind :: Int -> FcBind -> String
-renderBind indentation bind =
-  case bind of
-    FcNonRec var rhs -> renderOne indentation var rhs
-    FcRec [] -> indent indentation <> "rec {}"
-    FcRec bindings ->
-      indent indentation
-        <> "rec {\n"
-        <> intercalate ";\n" [indent (indentation + 2) <> renderBinder var <> " : " <> renderType (varType var) | (var, _) <- bindings]
-        <> ";\n"
-        <> intercalate
-          ";\n"
-          [ indent (indentation + 2)
-              <> renderBinder var
-              <> " =\n"
-              <> renderExprIndented (indentation + 4) rhs
-          | (var, rhs) <- bindings
-          ]
-        <> "\n"
-        <> indent indentation
-        <> "}"
+renderBind :: ScopeTable -> Int -> FcBind -> String
+renderBind scopes indentation bind = case bind of
+  FcNonRec var rhs -> renderOne scopes indentation var rhs
+  FcRec [] -> indent indentation <> "rec {}"
+  FcRec bindings -> indent indentation <> "rec {\n" <> intercalate ";\n" [indent (indentation + 2) <> renderBinder scopes var <> " : " <> renderTypeWith scopes (varType var) | (var, _) <- bindings] <> ";\n" <> intercalate ";\n" [indent (indentation + 2) <> renderBinder scopes var <> " =\n" <> renderExprIndented scopes (indentation + 4) rhs | (var, rhs) <- bindings] <> "\n" <> indent indentation <> "}"
 
-renderOne :: Int -> Var -> FcExpr -> String
-renderOne indentation var rhs =
-  indent indentation
-    <> renderBinder var
-    <> " : "
-    <> renderType (varType var)
-    <> " =\n"
-    <> renderExprIndented (indentation + 2) rhs
+renderOne :: ScopeTable -> Int -> Var -> FcExpr -> String
+renderOne scopes indentation var rhs = indent indentation <> renderBinder scopes var <> " : " <> renderTypeWith scopes (varType var) <> " =\n" <> renderExprIndented scopes (indentation + 2) rhs
 
 renderExpr :: FcExpr -> String
-renderExpr = renderExprWith 0 False
+renderExpr = renderExprWith mempty 0 False
 
-renderExprIndented :: Int -> FcExpr -> String
-renderExprIndented indentation expression =
-  indent indentation <> renderExprWith indentation False expression
+renderExprIndented :: ScopeTable -> Int -> FcExpr -> String
+renderExprIndented scopes indentation expression = indent indentation <> renderExprWith scopes indentation False expression
 
-renderExprWith :: Int -> Bool -> FcExpr -> String
-renderExprWith indentation parenthesize expression =
-  case expression of
-    FcVar var -> renderOccurrence var
-    FcLit literal ty -> "(" <> renderLiteral literal <> " : " <> renderType ty <> ")"
-    FcApp function argument ->
-      paren parenthesize (renderExprWith indentation True function <> " " <> renderExprWith indentation True argument)
-    FcTyApp function argument ->
-      paren parenthesize (renderExprWith indentation True function <> " @" <> renderTypeAtom argument)
-    FcLam var body ->
-      paren parenthesize $
-        "λ("
-          <> renderBinder var
-          <> " : "
-          <> renderType (varType var)
-          <> ").\n"
-          <> renderExprIndented (indentation + 2) body
-    FcTyLam tyVar body ->
-      paren parenthesize $
-        "Λ"
-          <> renderTyVarBinder tyVar
-          <> ".\n"
-          <> renderExprIndented (indentation + 2) body
-    FcLet bind body ->
-      paren parenthesize $
-        "let {\n"
-          <> renderBind (indentation + 2) bind
-          <> "\n"
-          <> indent indentation
-          <> "} in\n"
-          <> renderExprIndented (indentation + 2) body
-    FcCase scrutinee binder alternatives ->
-      paren parenthesize $
-        "case "
-          <> renderExprWith indentation False scrutinee
-          <> " as ("
-          <> renderBinder binder
-          <> " : "
-          <> renderType (varType binder)
-          <> ") of "
-          <> renderAlternatives binder alternatives
-    FcCast body coercion ->
-      paren parenthesize (renderExprWith indentation True body <> " ▷ " <> renderCoercion coercion)
-    FcCallForeign foreignCall arguments ->
-      paren parenthesize $
-        "foreign-call "
-          <> renderForeignCallHeader foreignCall
-          <> concatMap ((" " <>) . renderExprWith indentation True) arguments
+renderExprWith :: ScopeTable -> Int -> Bool -> FcExpr -> String
+renderExprWith scopes indentation parenthesize expression = case expression of
+  FcVar var -> renderOccurrence scopes var
+  FcLit literal ty -> "(" <> renderLiteral literal <> " : " <> renderTypeWith scopes ty <> ")"
+  FcApp function argument -> paren parenthesize (renderExprWith scopes indentation True function <> " " <> renderExprWith scopes indentation True argument)
+  FcTyApp function argument -> paren parenthesize (renderExprWith scopes indentation True function <> " @" <> renderTypeAtom scopes argument)
+  FcLam var body -> paren parenthesize ("λ(" <> renderBinder scopes var <> " : " <> renderTypeWith scopes (varType var) <> ").\n" <> renderExprIndented scopes (indentation + 2) body)
+  FcTyLam tyVar body -> paren parenthesize ("Λ" <> renderTyVarBinder scopes tyVar <> ".\n" <> renderExprIndented scopes (indentation + 2) body)
+  FcLet bind body -> paren parenthesize ("let {\n" <> renderBind scopes (indentation + 2) bind <> "\n" <> indent indentation <> "} in\n" <> renderExprIndented scopes (indentation + 2) body)
+  FcCase scrutinee binder alternatives -> paren parenthesize ("case " <> renderExprWith scopes indentation False scrutinee <> " as (" <> renderBinder scopes binder <> " : " <> renderTypeWith scopes (varType binder) <> ") of " <> renderAlternatives alternatives)
+  FcCast body coercion -> paren parenthesize (renderExprWith scopes indentation True body <> " ▷ " <> renderCoercion scopes coercion)
+  FcCallForeign foreignCall arguments -> paren parenthesize ("foreign-call " <> renderForeignCallHeader foreignCall <> concatMap ((" " <>) . renderExprWith scopes indentation True) arguments)
   where
-    renderAlternatives _ [] = "{}"
-    renderAlternatives _ alternatives' =
-      "{\n"
-        <> intercalate ";\n" (map (renderAlt (indentation + 2)) alternatives')
-        <> "\n"
-        <> indent indentation
-        <> "}"
+    renderAlternatives [] = "{}"
+    renderAlternatives alternatives = "{\n" <> intercalate ";\n" (map (renderAlt scopes (indentation + 2)) alternatives) <> "\n" <> indent indentation <> "}"
 
-renderAlt :: Int -> FcAlt -> String
-renderAlt indentation alternative =
-  indent indentation
-    <> renderAltCon (altCon alternative)
-    <> concatMap (\binder -> " (" <> renderBinder binder <> " : " <> renderType (varType binder) <> ")") binders
-    <> " →\n"
-    <> renderExprIndented (indentation + 2) (altRhs alternative)
-  where
-    binders = altBinders alternative
+renderAlt :: ScopeTable -> Int -> FcAlt -> String
+renderAlt scopes indentation alternative = indent indentation <> renderAltCon scopes (altCon alternative) <> concatMap (\binder -> " (" <> renderBinder scopes binder <> " : " <> renderTypeWith scopes (varType binder) <> ")") (altBinders alternative) <> " →\n" <> renderExprIndented scopes (indentation + 2) (altRhs alternative)
 
-renderAltCon :: FcAltCon -> String
-renderAltCon alternative =
-  case alternative of
-    DataAlt constructor -> renderConstructorId constructor
-    LitAlt literal ty -> "(" <> renderLiteral literal <> " : " <> renderType ty <> ")"
-    DefaultAlt -> "_"
+renderAltCon :: ScopeTable -> FcAltCon -> String
+renderAltCon scopes alternative = case alternative of
+  DataAlt constructor -> renderConstructorId scopes constructor
+  LitAlt literal ty -> "(" <> renderLiteral literal <> " : " <> renderTypeWith scopes ty <> ")"
+  DefaultAlt -> "_"
 
-renderConstructorId :: FcConstructorId -> String
-renderConstructorId constructor =
-  show (T.unpack (packageIdText (fcConstructorPackage constructor)))
-    <> " "
-    <> T.unpack (fcConstructorModule constructor)
-    <> "."
-    <> T.unpack (fcConstructorName constructor)
+renderConstructorId :: ScopeTable -> FcConstructorId -> String
+renderConstructorId scopes constructor = scopeReference scopes (packageIdText (fcConstructorPackage constructor)) (fcConstructorModule constructor) (fcConstructorName constructor)
 
-renderBinder :: Var -> String
-renderBinder = renderVarReference
+renderBinder :: ScopeTable -> Var -> String
+renderBinder scopes var = T.unpack (varName var) <> "{unique " <> renderUnique (varUnique var) <> "}" <> maybe "" (renderVarOrigin scopes) (varResolvedName var)
 
-renderVarReference :: Var -> String
-renderVarReference var =
-  T.unpack (varName var)
-    <> "{unique "
-    <> renderUnique (varUnique var)
-    <> "}"
-    <> maybe "" renderVarOrigin (varResolvedName var)
+renderOccurrence :: ScopeTable -> Var -> String
+renderOccurrence scopes var = "(" <> renderBinder scopes var <> " : " <> renderTypeWith scopes (varType var) <> ")"
 
-renderOccurrence :: Var -> String
-renderOccurrence var =
-  "(" <> renderVarReference var <> " : " <> renderType (varType var) <> ")"
+renderVarOrigin :: ScopeTable -> FcSymbolOrigin -> String
+renderVarOrigin scopes origin = "{origin " <> renderOrigin scopes origin <> "}"
 
-renderVarOrigin :: FcSymbolOrigin -> String
-renderVarOrigin origin = "{origin " <> renderOrigin origin <> "}"
-
-renderOrigin :: FcSymbolOrigin -> String
-renderOrigin origin =
-  case origin of
-    FcTopLevelOrigin packageName moduleName symbolName ->
-      show (T.unpack packageName)
-        <> " "
-        <> T.unpack moduleName
-        <> "."
-        <> T.unpack symbolName
-    FcBuiltinOrigin symbolName -> "builtin." <> T.unpack symbolName
+renderOrigin :: ScopeTable -> FcSymbolOrigin -> String
+renderOrigin scopes origin = case origin of
+  FcTopLevelOrigin packageName moduleName symbolName -> scopeReference scopes packageName moduleName symbolName
+  FcBuiltinOrigin symbolName -> "builtin." <> T.unpack symbolName
 
 renderForeignCallHeader :: FcForeignCall -> String
-renderForeignCallHeader foreignCall =
-  show (T.unpack (fcForeignCallSymbol foreignCall))
-    <> " "
-    <> T.unpack (fcForeignCallName foreignCall)
-    <> " ["
-    <> intercalate ", " (map renderForeignType (fcForeignArgumentTypes signature))
-    <> " → "
-    <> renderForeignType (fcForeignResultType signature)
-    <> "; "
-    <> renderForeignEffect (fcForeignEffect signature)
-    <> "]"
+renderForeignCallHeader foreignCall = show (T.unpack (fcForeignCallSymbol foreignCall)) <> " " <> T.unpack (fcForeignCallName foreignCall) <> " [" <> intercalate ", " (map renderForeignType (fcForeignArgumentTypes signature)) <> " → " <> renderForeignType (fcForeignResultType signature) <> "; " <> renderForeignEffect (fcForeignEffect signature) <> "]"
   where
     signature = fcForeignCallSignature foreignCall
 
 renderLiteral :: Literal -> String
-renderLiteral literal =
-  case literal of
-    LitInt runtimeRep value -> show value <> "#" <> renderRuntimeRep runtimeRep
-    LitChar runtimeRep value -> show value <> "#" <> renderRuntimeRep runtimeRep
-    LitString value -> show (T.unpack value)
-    LitAddr value -> show (map (chr . fromIntegral) (BS.unpack value)) <> "#AddrRep"
+renderLiteral literal = case literal of
+  LitInt runtimeRep value -> show value <> "#" <> renderRuntimeRep runtimeRep
+  LitChar runtimeRep value -> show value <> "#" <> renderRuntimeRep runtimeRep
+  LitString value -> show (T.unpack value)
+  LitAddr value -> show (map (chr . fromIntegral) (BS.unpack value)) <> "#AddrRep"
 
 renderType :: TcType -> String
-renderType ty =
-  case ty of
-    TcTyVar tyVar -> renderTyVarBinder tyVar
-    TcMetaTv (Unique unique) -> "?" <> show unique
-    TcTyCon tyCon [] -> renderTyConHead tyCon
-    TcTyCon tyCon arguments ->
-      renderTyConHead tyCon <> "[" <> intercalate ", " (map renderType arguments) <> "]"
-    TcFunTy argument result -> renderTypeAtom argument <> " → " <> renderType result
-    TcForAllTy tyVar body ->
-      "∀ " <> renderTyVarBinder tyVar <> ". " <> renderType body
-    TcQualTy predicates body ->
-      "(" <> intercalate ", " (map renderPred predicates) <> ") ⇒ " <> renderType body
-    TcAppTy function argument ->
-      renderTypeAtom function <> " · " <> renderTypeAtom argument
-    TcBuiltinTyCon name arity arguments ->
-      "builtin " <> T.unpack name <> "/" <> show arity <> "[" <> intercalate ", " (map renderType arguments) <> "]"
+renderType = renderTypeWith mempty
 
-renderTyConHead :: TyCon -> String
-renderTyConHead tyCon =
-  "tycon "
-    <> show (T.unpack (packageIdText (tyConPackageId tyCon)))
-    <> " "
-    <> show (T.unpack (tyConModuleName tyCon))
-    <> " "
-    <> T.unpack (tyConName tyCon)
-    <> "/"
-    <> show (tyConArity tyCon)
-    <> " { :: "
-    <> renderKindScheme (tyConKindScheme tyCon)
-    <> " }"
+renderTypeWith :: ScopeTable -> TcType -> String
+renderTypeWith scopes ty = case ty of
+  TcTyVar tyVar -> renderTyVarBinder scopes tyVar
+  TcMetaTv (Unique unique) -> "?" <> show unique
+  TcTyCon tyCon [] -> renderTyConHead scopes tyCon
+  TcTyCon tyCon arguments -> renderTyConHead scopes tyCon <> "[" <> intercalate ", " (map (renderTypeWith scopes) arguments) <> "]"
+  TcFunTy argument result -> renderTypeAtom scopes argument <> " → " <> renderTypeWith scopes result
+  TcForAllTy tyVar body -> "∀ " <> renderTyVarBinder scopes tyVar <> ". " <> renderTypeWith scopes body
+  TcQualTy predicates body -> "(" <> intercalate ", " (map (renderPred scopes) predicates) <> ") ⇒ " <> renderTypeWith scopes body
+  TcAppTy function argument -> renderTypeAtom scopes function <> " · " <> renderTypeAtom scopes argument
+  TcBuiltinTyCon name arity arguments -> "builtin " <> T.unpack name <> "/" <> show arity <> "[" <> intercalate ", " (map (renderTypeWith scopes) arguments) <> "]"
 
-renderTypeAtom :: TcType -> String
-renderTypeAtom ty =
-  case ty of
-    TcTyVar {} -> renderType ty
-    TcMetaTv {} -> renderType ty
-    TcTyCon {} -> renderType ty
-    TcBuiltinTyCon {} -> renderType ty
-    _ -> "(" <> renderType ty <> ")"
+renderTyConHead :: ScopeTable -> TyCon -> String
+renderTyConHead scopes tyCon = "tycon " <> scopeName <> "/" <> show (tyConArity tyCon) <> " { :: " <> renderKindScheme scopes (tyConKindScheme tyCon) <> " }"
+  where
+    scopeName = case Map.lookup (packageIdText (tyConPackageId tyCon), tyConModuleName tyCon) scopes of
+      Just scopeId -> show scopeId <> "." <> T.unpack (tyConName tyCon)
+      Nothing -> show (T.unpack (packageIdText (tyConPackageId tyCon))) <> " " <> show (T.unpack (tyConModuleName tyCon)) <> " " <> T.unpack (tyConName tyCon)
 
-renderTyVarBinder :: TyVarId -> String
-renderTyVarBinder tyVar =
-  "("
-    <> T.unpack (tvName tyVar)
-    <> "{unique "
-    <> renderUnique (tvUnique tyVar)
-    <> "} : "
-    <> renderKind (tvKind tyVar)
-    <> ")"
+renderKindScheme :: ScopeTable -> TypeScheme -> String
+renderKindScheme scopes scheme@(ForAll tyVars _ _) = prefix <> renderKind scopes (kindFromTypeScheme scheme)
+  where
+    prefix = case tyVars of [] -> ""; _ -> "∀ " <> unwords (map (renderTyVarBinder scopes) tyVars) <> ". "
 
-renderPred :: Pred -> String
-renderPred predicate =
-  case predicate of
-    ClassPred classTyCon arguments -> renderTypeAtom (TcTyCon classTyCon arguments)
-    EqPred left right -> renderTypeAtom left <> " ~ " <> renderTypeAtom right
+renderTypeAtom :: ScopeTable -> TcType -> String
+renderTypeAtom scopes ty = case ty of
+  TcTyVar {} -> renderTypeWith scopes ty
+  TcMetaTv {} -> renderTypeWith scopes ty
+  TcTyCon {} -> renderTypeWith scopes ty
+  TcBuiltinTyCon {} -> renderTypeWith scopes ty
+  _ -> "(" <> renderTypeWith scopes ty <> ")"
 
-renderKind :: Kind -> String
-renderKind kind =
-  case kind of
-    KTYPE (BoxedRep Lifted) -> "Type"
-    KTYPE (BoxedRep Unlifted) -> "TYPE UnliftedRep"
-    KTYPE runtimeRep -> "TYPE " <> renderRuntimeRep runtimeRep
-    KConstraint -> "Constraint"
-    KRuntimeRep -> "RuntimeRep"
-    KLevity -> "Levity"
-    KVecCount -> "VecCount"
-    KVecElem -> "VecElem"
-    KFun argument result -> renderKindAtom argument <> " → " <> renderKind result
-    KMeta (Unique unique) -> "?k" <> show unique
+renderTyVarBinder :: ScopeTable -> TyVarId -> String
+renderTyVarBinder scopes tyVar = "(" <> T.unpack (tvName tyVar) <> "{unique " <> renderUnique (tvUnique tyVar) <> "} : " <> renderKind scopes (tvKind tyVar) <> ")"
 
-renderKindAtom :: Kind -> String
-renderKindAtom kind =
-  case kind of
-    KFun {} -> "(" <> renderKind kind <> ")"
-    _ -> renderKind kind
+renderPred :: ScopeTable -> Pred -> String
+renderPred scopes predicate = case predicate of
+  ClassPred classTyCon arguments -> renderTypeAtom scopes (TcTyCon classTyCon arguments)
+  EqPred left right -> renderTypeAtom scopes left <> " ~ " <> renderTypeAtom scopes right
+
+renderKind :: ScopeTable -> Kind -> String
+renderKind scopes kind = case kind of
+  KTYPE (BoxedRep Lifted) -> "Type"
+  KTYPE (BoxedRep Unlifted) -> "TYPE UnliftedRep"
+  KTYPE runtimeRep -> "TYPE " <> renderRuntimeRep runtimeRep
+  KConstraint -> "Constraint"
+  KRuntimeRep -> "RuntimeRep"
+  KLevity -> "Levity"
+  KVecCount -> "VecCount"
+  KVecElem -> "VecElem"
+  KFun argument result -> renderKindAtom scopes argument <> " → " <> renderKind scopes result
+  KMeta (Unique unique) -> "?k" <> show unique
+
+renderKindAtom :: ScopeTable -> Kind -> String
+renderKindAtom scopes kind = case kind of
+  KFun {} -> "(" <> renderKind scopes kind <> ")"
+  _ -> renderKind scopes kind
 
 renderRuntimeRep :: RuntimeRep -> String
-renderRuntimeRep runtimeRep =
-  case runtimeRep of
-    VecRep count element -> "VecRep " <> show count <> " " <> show element
-    TupleRep fields -> "TupleRep [" <> intercalate ", " (map renderRuntimeRep fields) <> "]"
-    SumRep fields -> "SumRep [" <> intercalate ", " (map renderRuntimeRep fields) <> "]"
-    BoxedRep levity -> "BoxedRep " <> show levity
-    IntRep -> "IntRep"
-    Int8Rep -> "Int8Rep"
-    Int16Rep -> "Int16Rep"
-    Int32Rep -> "Int32Rep"
-    Int64Rep -> "Int64Rep"
-    WordRep -> "WordRep"
-    Word8Rep -> "Word8Rep"
-    Word16Rep -> "Word16Rep"
-    Word32Rep -> "Word32Rep"
-    Word64Rep -> "Word64Rep"
-    AddrRep -> "AddrRep"
-    FloatRep -> "FloatRep"
-    DoubleRep -> "DoubleRep"
-    RuntimeRepVar unique -> "RuntimeRepVar " <> showUnique unique
-    RuntimeRepMeta (Unique unique) -> "RuntimeRepMeta " <> show unique
-  where
-    showUnique (Unique unique) = show unique
+renderRuntimeRep runtimeRep = case runtimeRep of
+  VecRep count element -> "VecRep " <> show count <> " " <> show element
+  TupleRep fields -> "TupleRep [" <> intercalate ", " (map renderRuntimeRep fields) <> "]"
+  SumRep fields -> "SumRep [" <> intercalate ", " (map renderRuntimeRep fields) <> "]"
+  BoxedRep levity -> "BoxedRep " <> show levity
+  IntRep -> "IntRep"
+  Int8Rep -> "Int8Rep"
+  Int16Rep -> "Int16Rep"
+  Int32Rep -> "Int32Rep"
+  Int64Rep -> "Int64Rep"
+  WordRep -> "WordRep"
+  Word8Rep -> "Word8Rep"
+  Word16Rep -> "Word16Rep"
+  Word32Rep -> "Word32Rep"
+  Word64Rep -> "Word64Rep"
+  AddrRep -> "AddrRep"
+  FloatRep -> "FloatRep"
+  DoubleRep -> "DoubleRep"
+  RuntimeRepVar (Unique unique) -> "RuntimeRepVar " <> show unique
+  RuntimeRepMeta (Unique unique) -> "RuntimeRepMeta " <> show unique
 
-renderCoercion :: Coercion -> String
-renderCoercion coercion =
-  case coercion of
-    CoVar (EvVar (Unique unique)) -> "co#" <> show unique
-    Refl ty -> "refl (" <> renderType ty <> ")"
-    Sym inner -> "sym (" <> renderCoercion inner <> ")"
-    Trans left right -> "trans (" <> renderCoercion left <> ") (" <> renderCoercion right <> ")"
-    TyConAppCo tyCon arguments ->
-      "tycon-co " <> renderTyConHead tyCon <> concatMap (\argument -> " (" <> renderCoercion argument <> ")") arguments
-    AxiomInstCo name arguments ->
-      "axiom-co " <> T.unpack name <> concatMap (\argument -> " @" <> renderTypeAtom argument) arguments
+renderCoercion :: ScopeTable -> Coercion -> String
+renderCoercion scopes coercion = case coercion of
+  CoVar (EvVar (Unique unique)) -> "co#" <> show unique
+  Refl ty -> "refl (" <> renderTypeWith scopes ty <> ")"
+  Sym inner -> "sym (" <> renderCoercion scopes inner <> ")"
+  Trans left right -> "trans (" <> renderCoercion scopes left <> ") (" <> renderCoercion scopes right <> ")"
+  TyConAppCo tyCon arguments -> "tycon-co " <> renderTyConHead scopes tyCon <> concatMap (\argument -> " (" <> renderCoercion scopes argument <> ")") arguments
+  AxiomInstCo name arguments -> "axiom-co " <> T.unpack name <> concatMap (\argument -> " @" <> renderTypeAtom scopes argument) arguments
 
 paren :: Bool -> String -> String
 paren False value = value

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -14,17 +14,104 @@ import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Evidence (Coercion (..), EvVar (..))
 import Aihc.Tc.Types
 import Data.ByteString qualified as BS
-import Data.Char (chr)
+import Data.Char (chr, isAlphaNum, isAsciiUpper)
 import Data.List (intercalate)
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
+import Text.Read (readMaybe)
 
 renderProgram :: FcProgram -> String
 renderProgram program =
+  renderScopes scopes <> "\n\n" <> replaceScopes scopes rendered
+  where
+    rendered = renderProgramWithoutScopes program
+    scopes = scopeTable rendered (fcProgramModule program)
+
+renderProgramWithoutScopes :: FcProgram -> String
+renderProgramWithoutScopes program =
   intercalate
     "\n\n"
-    (renderModuleDeclaration (fcProgramModule program) : map renderTopBind topBinds)
+    (renderModuleDeclaration (fcProgramModule program) : map renderTopBind (fcTopBinds program))
+
+type Scope = (T.Text, T.Text)
+
+scopeTable :: String -> FcModuleId -> Map.Map Scope Int
+scopeTable rendered moduleId =
+  Map.fromList (zip scopes [1 ..])
   where
-    topBinds = fcTopBinds program
+    scopes = List.sort . List.nub $ (fcModulePackageText moduleId, fcModuleName moduleId) : scopesInRenderedProgram rendered
+
+scopesInRenderedProgram :: String -> [Scope]
+scopesInRenderedProgram rendered = concatMap scopesInWords (windows 4 words') <> concatMap scopesInOrigin (windows 3 words')
+  where
+    words' = words rendered
+    scopesInWords ["tycon", packageName, moduleName, _] =
+      case (readMaybe packageName, readMaybe moduleName) of
+        (Just package, Just moduleName') -> [(T.pack package, T.pack moduleName')]
+        _ -> []
+    scopesInWords [packageName, qualified, _, _] =
+      case (readMaybe packageName, splitQualifiedName (T.pack qualified)) of
+        (Just package, Just (moduleName, _)) -> [(T.pack package, moduleName)]
+        _ -> []
+    scopesInWords _ = []
+    scopesInOrigin [previous, packageName, qualified]
+      | previous /= "module" =
+          case (readMaybe packageName, splitQualifiedName (T.pack qualified)) of
+            (Just package, Just (moduleName, _)) -> [(T.pack package, moduleName)]
+            _ -> []
+    scopesInOrigin _ = []
+
+windows :: Int -> [value] -> [[value]]
+windows size values
+  | length values < size = []
+  | otherwise = take size values : windows size (drop 1 values)
+
+splitQualifiedName :: T.Text -> Maybe (T.Text, T.Text)
+splitQualifiedName qualified =
+  case T.breakOnEnd "." qualified of
+    (moduleName, symbolName)
+      | T.null moduleName || T.null symbolName || T.isPrefixOf "\"" qualified -> Nothing
+      | not (validScopeModule (T.dropEnd 1 moduleName)) -> Nothing
+      | otherwise -> Just (T.dropEnd 1 moduleName, symbolName)
+
+validScopeModule :: T.Text -> Bool
+validScopeModule = all validScopeSegment . T.splitOn "."
+
+validScopeSegment :: T.Text -> Bool
+validScopeSegment segment =
+  case T.uncons segment of
+    Just (first, rest) -> isAsciiUpper first && T.all validScopeCharacter rest
+    Nothing -> False
+
+validScopeCharacter :: Char -> Bool
+validScopeCharacter character = isAlphaNum character || character `elem` ("_'" :: String)
+
+renderScopes :: Map.Map Scope Int -> String
+renderScopes = intercalate "\n" . map renderScope . Map.toAscList
+  where
+    renderScope ((packageName, moduleName), scopeId) =
+      "scope " <> show scopeId <> " = " <> show (T.unpack packageName) <> " " <> T.unpack moduleName
+
+replaceScopes :: Map.Map Scope Int -> String -> String
+replaceScopes scopes programText = List.foldl' replaceOne programText replacementScopes
+  where
+    replacementScopes = List.sortOn (negate . T.length . snd . fst) (Map.toAscList scopes)
+    replaceOne text ((packageName, moduleName), scopeId) =
+      replace
+        ("module " <> fullScope <> " where")
+        ("module " <> shortScope <> "." <> T.unpack moduleName <> " where")
+        ( replace
+            ("tycon " <> showPackage <> " " <> showModule <> " ")
+            ("tycon " <> shortScope <> ".")
+            (replace (fullScope <> ".") (shortScope <> ".") text)
+        )
+      where
+        fullScope = showPackage <> " " <> T.unpack moduleName
+        shortScope = show scopeId
+        showPackage = show (T.unpack packageName)
+        showModule = show (T.unpack moduleName)
+    replace old new = T.unpack . T.replace (T.pack old) (T.pack new) . T.pack
 
 renderModuleDeclaration :: FcModuleId -> String
 renderModuleDeclaration moduleId =

--- a/components/aihc-fc/src/Aihc/Fc/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc/Pretty.hs
@@ -24,7 +24,18 @@ renderProgram program = intercalate "\n\n" (renderScopes scopes : renderModuleDe
     scopes = scopeTable program
 
 scopeTable :: FcProgram -> ScopeTable
-scopeTable = Map.fromAscList . flip zip [1 ..] . Set.toAscList . programScopes
+scopeTable = scopeTableFrom . programScopes
+
+scopeTableFrom :: Set.Set Scope -> ScopeTable
+scopeTableFrom = Map.fromAscList . flip zip [1 ..] . Set.toAscList
+
+renderStandalone :: Set.Set Scope -> (ScopeTable -> String) -> String
+renderStandalone scopes render =
+  case Set.null scopes of
+    True -> render mempty
+    False -> renderScopes table <> "\n\n" <> render table
+  where
+    table = scopeTableFrom scopes
 
 programScopes :: FcProgram -> Set.Set Scope
 programScopes program = moduleScopes (fcProgramModule program) <> foldMap topBindScopes (fcTopBinds program)
@@ -125,10 +136,10 @@ renderModuleDeclaration scopes moduleId = "module " <> scopeReference scopes (fc
 scopeReference :: ScopeTable -> T.Text -> T.Text -> T.Text -> String
 scopeReference scopes packageName moduleName name = case Map.lookup (packageName, moduleName) scopes of
   Just scopeId -> show scopeId <> "." <> T.unpack name
-  Nothing -> show (T.unpack packageName) <> " " <> T.unpack moduleName <> "." <> T.unpack name
+  Nothing -> error ("missing System FC scope for " <> show (packageName, moduleName))
 
 renderTopBind :: FcTopBind -> String
-renderTopBind = renderTopBindWith mempty
+renderTopBind topBind = renderStandalone (topBindScopes topBind) (`renderTopBindWith` topBind)
 
 renderTopBindWith :: ScopeTable -> FcTopBind -> String
 renderTopBindWith scopes topBind = case topBind of
@@ -176,7 +187,7 @@ renderOne :: ScopeTable -> Int -> Var -> FcExpr -> String
 renderOne scopes indentation var rhs = indent indentation <> renderBinder scopes var <> " : " <> renderTypeWith scopes (varType var) <> " =\n" <> renderExprIndented scopes (indentation + 2) rhs
 
 renderExpr :: FcExpr -> String
-renderExpr = renderExprWith mempty 0 False
+renderExpr expression = renderStandalone (exprScopes expression) (\scopes -> renderExprWith scopes 0 False expression)
 
 renderExprIndented :: ScopeTable -> Int -> FcExpr -> String
 renderExprIndented scopes indentation expression = indent indentation <> renderExprWith scopes indentation False expression
@@ -236,7 +247,7 @@ renderLiteral literal = case literal of
   LitAddr value -> show (map (chr . fromIntegral) (BS.unpack value)) <> "#AddrRep"
 
 renderType :: TcType -> String
-renderType = renderTypeWith mempty
+renderType ty = renderStandalone (typeScopes ty) (`renderTypeWith` ty)
 
 renderTypeWith :: ScopeTable -> TcType -> String
 renderTypeWith scopes ty = case ty of
@@ -251,11 +262,14 @@ renderTypeWith scopes ty = case ty of
   TcBuiltinTyCon name arity arguments -> "builtin " <> T.unpack name <> "/" <> show arity <> "[" <> intercalate ", " (map (renderTypeWith scopes) arguments) <> "]"
 
 renderTyConHead :: ScopeTable -> TyCon -> String
-renderTyConHead scopes tyCon = "tycon " <> scopeName <> "/" <> show (tyConArity tyCon) <> " { :: " <> renderKindScheme scopes (tyConKindScheme tyCon) <> " }"
-  where
-    scopeName = case Map.lookup (packageIdText (tyConPackageId tyCon), tyConModuleName tyCon) scopes of
-      Just scopeId -> show scopeId <> "." <> T.unpack (tyConName tyCon)
-      Nothing -> show (T.unpack (packageIdText (tyConPackageId tyCon))) <> " " <> show (T.unpack (tyConModuleName tyCon)) <> " " <> T.unpack (tyConName tyCon)
+renderTyConHead scopes tyCon =
+  "tycon "
+    <> scopeReference scopes (packageIdText (tyConPackageId tyCon)) (tyConModuleName tyCon) (tyConName tyCon)
+    <> "/"
+    <> show (tyConArity tyCon)
+    <> " { :: "
+    <> renderKindScheme scopes (tyConKindScheme tyCon)
+    <> " }"
 
 renderKindScheme :: ScopeTable -> TypeScheme -> String
 renderKindScheme scopes scheme@(ForAll tyVars _ _) = prefix <> renderKind scopes (kindFromTypeScheme scheme)

--- a/components/aihc-fc/test/Test/Fc/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc/Properties.hs
@@ -181,8 +181,8 @@ prop_repeatedTyConIdentity = property $ do
       expression = FcApp left right
       rendered = T.pack (renderExpr expression)
   annotate (T.unpack rendered)
-  T.isPrefixOf "(left{unique 1} :" rendered === True
-  T.count "tycon \"pkg\" \"Module\" T/0" rendered === 2
+  T.isPrefixOf "scope 1 = \"pkg\" Module" rendered === True
+  T.count "tycon 1.T/0" rendered === 2
   roundTrip renderExpr parseExpr expression
 
 prop_constructorIdentity :: Property

--- a/components/aihc-fc/test/Test/Fc/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc/Properties.hs
@@ -167,7 +167,8 @@ prop_tyConKindSignature = property $ do
       program = FcProgram (FcModuleId "test" "Test") [FcExternal (FcBuiltinOrigin "value") ty]
       rendered = T.pack (renderProgram program)
   annotate (T.unpack rendered)
-  T.isInfixOf "external builtin.value : tycon \"pkg\" \"GHC.Prim\" MutVar#/2 { :: Type → Type → TYPE UnliftedRep }" rendered === True
+  T.isInfixOf "scope 1 = \"pkg\" GHC.Prim" rendered === True
+  T.isInfixOf "external builtin.value : tycon 1.MutVar#/2 { :: Type → Type → TYPE UnliftedRep }" rendered === True
   T.count "\n\ntycon " rendered === 0
   roundTrip renderProgram parseProgram program
 
@@ -191,7 +192,7 @@ prop_constructorIdentity = property $ do
       program = FcProgram (FcModuleId "test" "Test") [FcData declaration]
       rendered = T.pack (renderProgram program)
   annotate (T.unpack rendered)
-  T.isInfixOf "= \"test\" Test.J" rendered === True
+  T.isInfixOf "= 1.J" rendered === True
   roundTrip renderProgram parseProgram program
 
 prop_dependentRuntimeRep :: Property
@@ -236,8 +237,8 @@ prop_externalSignatures = property $ do
       program = FcProgram (FcModuleId "test" "Test") [FcExternal origin ty, FcTopBind (FcNonRec result (FcVar imported))]
       rendered = T.pack (renderProgram program)
   annotate (T.unpack rendered)
-  T.count "Module.id :" rendered === 1
-  T.count "\"pkg\" Module.id" rendered === 2
+  T.count "1.id :" rendered === 1
+  T.count "origin 1.id" rendered === 1
   roundTrip renderProgram parseProgram program
   where
     typeVariable = setTyVarKind (KTYPE liftedRuntimeRep) (TyVarId "a" (Unique 3))

--- a/components/aihc-fc/test/Test/Fixtures/golden/bool-id-not.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/bool-id-not.yaml
@@ -1,24 +1,26 @@
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
 
-  data "" Test.Bool : Type
-   = "" Test.True
-   | "" Test.False
+  module 1.Test where
+
+  data 1.Bool : Type
+   = 1.True
+   | 1.False
 
   rec {
     id{unique 1000} : ∀ (a{unique 31} : Type). (a{unique 31} : Type) → (a{unique 31} : Type);
-    not{unique 1001} : tycon "" "Test" Bool/0 { :: Type } → tycon "" "Test" Bool/0 { :: Type };
+    not{unique 1001} : tycon 1.Bool/0 { :: Type } → tycon 1.Bool/0 { :: Type };
     id{unique 1000} =
       Λ(a{unique 31} : Type).
         λ(x1002{unique 1002} : (a{unique 31} : Type)).
           (x1002{unique 1002} : (a{unique 31} : Type));
     not{unique 1001} =
-      λ(x1003{unique 1003} : tycon "" "Test" Bool/0 { :: Type }).
-        case (x1003{unique 1003} : tycon "" "Test" Bool/0 { :: Type }) as (_scrut{unique 1004} : tycon "" "Test" Bool/0 { :: Type }) of {
-          "" Test.True →
-            (False{unique -2286087477}{origin "" Test.False} : tycon "" "Test" Bool/0 { :: Type });
-          "" Test.False →
-            (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type })
+      λ(x1003{unique 1003} : tycon 1.Bool/0 { :: Type }).
+        case (x1003{unique 1003} : tycon 1.Bool/0 { :: Type }) as (_scrut{unique 1004} : tycon 1.Bool/0 { :: Type }) of {
+          1.True →
+            (False{unique -2286087477}{origin 1.False} : tycon 1.Bool/0 { :: Type });
+          1.False →
+            (True{unique -2360662326}{origin 1.True} : tycon 1.Bool/0 { :: Type })
         }
   }
 extensions: []

--- a/components/aihc-fc/test/Test/Fixtures/golden/case-bang-variable-uses-evaluated-binder.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/case-bang-variable-uses-evaluated-binder.yaml
@@ -1,18 +1,20 @@
 extensions:
   - BangPatterns
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
 
-  data "" Test.Box : Type
-   = "" Test.Box
+  module 1.Test where
+
+  data 1.Box : Type
+   = 1.Box
 
   rec {
-    forceBox{unique 1000} : tycon "" "Test" Box/0 { :: Type } → tycon "" "Test" Box/0 { :: Type };
+    forceBox{unique 1000} : tycon 1.Box/0 { :: Type } → tycon 1.Box/0 { :: Type };
     forceBox{unique 1000} =
-      λ(x1001{unique 1001} : tycon "" "Test" Box/0 { :: Type }).
-        case (x1001{unique 1001} : tycon "" "Test" Box/0 { :: Type }) as (_bang1002{unique 1002} : tycon "" "Test" Box/0 { :: Type }) of {
+      λ(x1001{unique 1001} : tycon 1.Box/0 { :: Type }).
+        case (x1001{unique 1001} : tycon 1.Box/0 { :: Type }) as (_bang1002{unique 1002} : tycon 1.Box/0 { :: Type }) of {
           _ →
-            (_bang1002{unique 1002} : tycon "" "Test" Box/0 { :: Type })
+            (_bang1002{unique 1002} : tycon 1.Box/0 { :: Type })
         }
   }
 modules:

--- a/components/aihc-fc/test/Test/Fixtures/golden/class-constraints-become-value-dictionaries.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/class-constraints-become-value-dictionaries.yaml
@@ -17,38 +17,43 @@ modules:
 
     class Parent a => Child a where
       child :: a -> Flag
-expected: |
-  module "" Parent where
+expected: |-
+  scope 1 = "" Parent
 
-  data "" Parent.Flag : Type
-   = "" Parent.Off
-   | "" Parent.On
+  module 1.Parent where
 
-  data "" Parent.Parent (a{unique 20} : Type) : Type
-   = "" Parent.$Dict$Parent ((a{unique 20} : Type) → tycon "" "Parent" Flag/0 { :: Type })
+  data 1.Flag : Type
+   = 1.Off
+   | 1.On
 
-  parent{unique 1000} : ∀ (a{unique 20} : Type). tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → tycon "" "Parent" Flag/0 { :: Type } =
+  data 1.Parent (a{unique 20} : Type) : Type
+   = 1.$Dict$Parent ((a{unique 20} : Type) → tycon 1.Flag/0 { :: Type })
+
+  parent{unique 1000} : ∀ (a{unique 20} : Type). tycon 1.Parent/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → tycon 1.Flag/0 { :: Type } =
     Λ(a{unique 20} : Type).
-      λ($d0{unique 1001} : tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 20} : Type)]).
-        case ($d0{unique 1001} : tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
-          "" Parent.$Dict$Parent ($method0{unique 1003} : (a{unique 20} : Type) → tycon "" "Parent" Flag/0 { :: Type }) →
-            ($method0{unique 1003} : (a{unique 20} : Type) → tycon "" "Parent" Flag/0 { :: Type })
+      λ($d0{unique 1001} : tycon 1.Parent/1 { :: Type → Type }[(a{unique 20} : Type)]).
+        case ($d0{unique 1001} : tycon 1.Parent/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon 1.Parent/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
+          1.$Dict$Parent ($method0{unique 1003} : (a{unique 20} : Type) → tycon 1.Flag/0 { :: Type }) →
+            ($method0{unique 1003} : (a{unique 20} : Type) → tycon 1.Flag/0 { :: Type })
         }
 
-  $fParentFlag{unique 1005} : tycon "" "Parent" Parent/1 { :: Type → Type }[tycon "" "Parent" Flag/0 { :: Type }] =
-    (($Dict$Parent{unique 1006}{origin "" Parent.$Dict$Parent} : ∀ (a{unique 20} : Type). ((a{unique 20} : Type) → tycon "" "Parent" Flag/0 { :: Type }) → tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 20} : Type)]) @tycon "" "Parent" Flag/0 { :: Type }) (λ(x1004{unique 1004} : tycon "" "Parent" Flag/0 { :: Type }).
-      (x1004{unique 1004} : tycon "" "Parent" Flag/0 { :: Type }))
-  module "" Child where
+  $fParentFlag{unique 1005} : tycon 1.Parent/1 { :: Type → Type }[tycon 1.Flag/0 { :: Type }] =
+    (($Dict$Parent{unique 1006}{origin 1.$Dict$Parent} : ∀ (a{unique 20} : Type). ((a{unique 20} : Type) → tycon 1.Flag/0 { :: Type }) → tycon 1.Parent/1 { :: Type → Type }[(a{unique 20} : Type)]) @tycon 1.Flag/0 { :: Type }) (λ(x1004{unique 1004} : tycon 1.Flag/0 { :: Type }).
+      (x1004{unique 1004} : tycon 1.Flag/0 { :: Type }))
+  scope 1 = "" Child
+  scope 2 = "" Parent
 
-  data "" Child.Child (a{unique 23} : Type) : Type
-   = "" Child.$Dict$Child (tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 23} : Type)]) ((a{unique 23} : Type) → tycon "" "Parent" Flag/0 { :: Type })
+  module 1.Child where
 
-  child{unique 1000} : ∀ (a{unique 23} : Type). tycon "" "Child" Child/1 { :: Type → Type }[(a{unique 23} : Type)] → (a{unique 23} : Type) → tycon "" "Parent" Flag/0 { :: Type } =
+  data 1.Child (a{unique 23} : Type) : Type
+   = 1.$Dict$Child (tycon 2.Parent/1 { :: Type → Type }[(a{unique 23} : Type)]) ((a{unique 23} : Type) → tycon 2.Flag/0 { :: Type })
+
+  child{unique 1000} : ∀ (a{unique 23} : Type). tycon 1.Child/1 { :: Type → Type }[(a{unique 23} : Type)] → (a{unique 23} : Type) → tycon 2.Flag/0 { :: Type } =
     Λ(a{unique 23} : Type).
-      λ($d0{unique 1001} : tycon "" "Child" Child/1 { :: Type → Type }[(a{unique 23} : Type)]).
-        case ($d0{unique 1001} : tycon "" "Child" Child/1 { :: Type → Type }[(a{unique 23} : Type)]) as ($dict{unique 1002} : tycon "" "Child" Child/1 { :: Type → Type }[(a{unique 23} : Type)]) of {
-          "" Child.$Dict$Child ($method0{unique 1003} : tycon "" "Parent" Parent/1 { :: Type → Type }[(a{unique 23} : Type)]) ($method1{unique 1004} : (a{unique 23} : Type) → tycon "" "Parent" Flag/0 { :: Type }) →
-            ($method1{unique 1004} : (a{unique 23} : Type) → tycon "" "Parent" Flag/0 { :: Type })
+      λ($d0{unique 1001} : tycon 1.Child/1 { :: Type → Type }[(a{unique 23} : Type)]).
+        case ($d0{unique 1001} : tycon 1.Child/1 { :: Type → Type }[(a{unique 23} : Type)]) as ($dict{unique 1002} : tycon 1.Child/1 { :: Type → Type }[(a{unique 23} : Type)]) of {
+          1.$Dict$Child ($method0{unique 1003} : tycon 2.Parent/1 { :: Type → Type }[(a{unique 23} : Type)]) ($method1{unique 1004} : (a{unique 23} : Type) → tycon 2.Flag/0 { :: Type }) →
+            ($method1{unique 1004} : (a{unique 23} : Type) → tycon 2.Flag/0 { :: Type })
         }
 reason: Class constraints become value dictionary types and keep their checked source identity.
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/data-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/data-family-instance.yaml
@@ -6,11 +6,14 @@ modules:
     data family Payload a
     data instance Payload a = PayloadValue a
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+  scope 2 = "aihc-internal" Aihc.Internal
 
-  data "" Test.$R$Payload$PayloadValue (a{unique 22} : Type) : Type
-   = "" Test.PayloadValue ((a{unique 22} : Type))
+  module 1.Test where
 
-  axiom $ax$Payload$PayloadValue (a{unique 22} : Type) : tycon "" "Test" Payload/1 { :: Type → Type }[(a{unique 22} : Type)] ~N tycon "aihc-internal" "Aihc.Internal" $R$Payload$PayloadValue/1 { :: Type → Type }[(a{unique 22} : Type)]
+  data 1.$R$Payload$PayloadValue (a{unique 22} : Type) : Type
+   = 1.PayloadValue ((a{unique 22} : Type))
+
+  axiom $ax$Payload$PayloadValue (a{unique 22} : Type) : tycon 1.Payload/1 { :: Type → Type }[(a{unique 22} : Type)] ~N tycon 2.$R$Payload$PayloadValue/1 { :: Type → Type }[(a{unique 22} : Type)]
 status: pass
 reason: data-family instances retain an explicit representation type and nominal equality axiom in System FC

--- a/components/aihc-fc/test/Test/Fixtures/golden/dictionary-method-constraints.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/dictionary-method-constraints.yaml
@@ -1,31 +1,33 @@
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
 
-  data "" Test.Result : Type
-   = "" Test.Result
+  module 1.Test where
 
-  data "" Test.Render (a{unique 20} : Type) : Type
-   = "" Test.$Dict$Render ((a{unique 20} : Type) → tycon "" "Test" Result/0 { :: Type })
+  data 1.Result : Type
+   = 1.Result
 
-  render{unique 1000} : ∀ (a{unique 20} : Type). tycon "" "Test" Render/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → tycon "" "Test" Result/0 { :: Type } =
+  data 1.Render (a{unique 20} : Type) : Type
+   = 1.$Dict$Render ((a{unique 20} : Type) → tycon 1.Result/0 { :: Type })
+
+  render{unique 1000} : ∀ (a{unique 20} : Type). tycon 1.Render/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → tycon 1.Result/0 { :: Type } =
     Λ(a{unique 20} : Type).
-      λ($d0{unique 1001} : tycon "" "Test" Render/1 { :: Type → Type }[(a{unique 20} : Type)]).
-        case ($d0{unique 1001} : tycon "" "Test" Render/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon "" "Test" Render/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
-          "" Test.$Dict$Render ($method0{unique 1003} : (a{unique 20} : Type) → tycon "" "Test" Result/0 { :: Type }) →
-            ($method0{unique 1003} : (a{unique 20} : Type) → tycon "" "Test" Result/0 { :: Type })
+      λ($d0{unique 1001} : tycon 1.Render/1 { :: Type → Type }[(a{unique 20} : Type)]).
+        case ($d0{unique 1001} : tycon 1.Render/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon 1.Render/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
+          1.$Dict$Render ($method0{unique 1003} : (a{unique 20} : Type) → tycon 1.Result/0 { :: Type }) →
+            ($method0{unique 1003} : (a{unique 20} : Type) → tycon 1.Result/0 { :: Type })
         }
 
-  data "" Test.Convert (a{unique 22} : Type) : Type
-   = "" Test.$Dict$Convert (∀ (b{unique 24} : Type). tycon "" "Test" Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon "" "Test" Result/0 { :: Type })
+  data 1.Convert (a{unique 22} : Type) : Type
+   = 1.$Dict$Convert (∀ (b{unique 24} : Type). tycon 1.Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon 1.Result/0 { :: Type })
 
-  convert{unique 1004} : ∀ (a{unique 22} : Type). ∀ (b{unique 24} : Type). tycon "" "Test" Convert/1 { :: Type → Type }[(a{unique 22} : Type)] → tycon "" "Test" Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon "" "Test" Result/0 { :: Type } =
+  convert{unique 1004} : ∀ (a{unique 22} : Type). ∀ (b{unique 24} : Type). tycon 1.Convert/1 { :: Type → Type }[(a{unique 22} : Type)] → tycon 1.Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon 1.Result/0 { :: Type } =
     Λ(a{unique 22} : Type).
       Λ(b{unique 24} : Type).
-        λ($d0{unique 1005} : tycon "" "Test" Convert/1 { :: Type → Type }[(a{unique 22} : Type)]).
-          λ($d1{unique 1006} : tycon "" "Test" Render/1 { :: Type → Type }[(b{unique 24} : Type)]).
-            case ($d0{unique 1005} : tycon "" "Test" Convert/1 { :: Type → Type }[(a{unique 22} : Type)]) as ($dict{unique 1007} : tycon "" "Test" Convert/1 { :: Type → Type }[(a{unique 22} : Type)]) of {
-              "" Test.$Dict$Convert ($method0{unique 1008} : ∀ (b{unique 24} : Type). tycon "" "Test" Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon "" "Test" Result/0 { :: Type }) →
-                (($method0{unique 1008} : ∀ (b{unique 24} : Type). tycon "" "Test" Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon "" "Test" Result/0 { :: Type }) @(b{unique 24} : Type)) ($d1{unique 1006} : tycon "" "Test" Render/1 { :: Type → Type }[(b{unique 24} : Type)])
+        λ($d0{unique 1005} : tycon 1.Convert/1 { :: Type → Type }[(a{unique 22} : Type)]).
+          λ($d1{unique 1006} : tycon 1.Render/1 { :: Type → Type }[(b{unique 24} : Type)]).
+            case ($d0{unique 1005} : tycon 1.Convert/1 { :: Type → Type }[(a{unique 22} : Type)]) as ($dict{unique 1007} : tycon 1.Convert/1 { :: Type → Type }[(a{unique 22} : Type)]) of {
+              1.$Dict$Convert ($method0{unique 1008} : ∀ (b{unique 24} : Type). tycon 1.Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon 1.Result/0 { :: Type }) →
+                (($method0{unique 1008} : ∀ (b{unique 24} : Type). tycon 1.Render/1 { :: Type → Type }[(b{unique 24} : Type)] → (a{unique 22} : Type) → (b{unique 24} : Type) → tycon 1.Result/0 { :: Type }) @(b{unique 24} : Type)) ($d1{unique 1006} : tycon 1.Render/1 { :: Type → Type }[(b{unique 24} : Type)])
             }
 extensions: []
 modules:

--- a/components/aihc-fc/test/Test/Fixtures/golden/distinct-module-constructor-identities.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/distinct-module-constructor-identities.yaml
@@ -22,36 +22,44 @@ modules:
     second :: Second.Value -> Second.Item
     second (Second.Shared value) = value
 expected: |-
-  module "" First where
+  scope 1 = "" First
 
-  data "" First.Item : Type
-   = "" First.FirstItem
+  module 1.First where
 
-  data "" First.Value : Type
-   = "" First.Shared (tycon "" "First" Item/0 { :: Type })
-  module "" Second where
+  data 1.Item : Type
+   = 1.FirstItem
 
-  data "" Second.Item : Type
-   = "" Second.SecondItem
+  data 1.Value : Type
+   = 1.Shared (tycon 1.Item/0 { :: Type })
+  scope 1 = "" Second
 
-  data "" Second.Value : Type
-   = "" Second.Shared (tycon "" "Second" Item/0 { :: Type })
-  module "" Test where
+  module 1.Second where
+
+  data 1.Item : Type
+   = 1.SecondItem
+
+  data 1.Value : Type
+   = 1.Shared (tycon 1.Item/0 { :: Type })
+  scope 1 = "" First
+  scope 2 = "" Second
+  scope 3 = "" Test
+
+  module 3.Test where
 
   rec {
-    first{unique 1000} : tycon "" "First" Value/0 { :: Type } → tycon "" "First" Item/0 { :: Type };
-    second{unique 1001} : tycon "" "Second" Value/0 { :: Type } → tycon "" "Second" Item/0 { :: Type };
+    first{unique 1000} : tycon 1.Value/0 { :: Type } → tycon 1.Item/0 { :: Type };
+    second{unique 1001} : tycon 2.Value/0 { :: Type } → tycon 2.Item/0 { :: Type };
     first{unique 1000} =
-      λ(x1002{unique 1002} : tycon "" "First" Value/0 { :: Type }).
-        case (x1002{unique 1002} : tycon "" "First" Value/0 { :: Type }) as (_scrut{unique 1004} : tycon "" "First" Value/0 { :: Type }) of {
-          "" First.Shared (value{unique 1003} : tycon "" "First" Item/0 { :: Type }) →
-            (value{unique 1003} : tycon "" "First" Item/0 { :: Type })
+      λ(x1002{unique 1002} : tycon 1.Value/0 { :: Type }).
+        case (x1002{unique 1002} : tycon 1.Value/0 { :: Type }) as (_scrut{unique 1004} : tycon 1.Value/0 { :: Type }) of {
+          1.Shared (value{unique 1003} : tycon 1.Item/0 { :: Type }) →
+            (value{unique 1003} : tycon 1.Item/0 { :: Type })
         };
     second{unique 1001} =
-      λ(x1005{unique 1005} : tycon "" "Second" Value/0 { :: Type }).
-        case (x1005{unique 1005} : tycon "" "Second" Value/0 { :: Type }) as (_scrut{unique 1007} : tycon "" "Second" Value/0 { :: Type }) of {
-          "" Second.Shared (value{unique 1006} : tycon "" "Second" Item/0 { :: Type }) →
-            (value{unique 1006} : tycon "" "Second" Item/0 { :: Type })
+      λ(x1005{unique 1005} : tycon 2.Value/0 { :: Type }).
+        case (x1005{unique 1005} : tycon 2.Value/0 { :: Type }) as (_scrut{unique 1007} : tycon 2.Value/0 { :: Type }) of {
+          2.Shared (value{unique 1006} : tycon 2.Item/0 { :: Type }) →
+            (value{unique 1006} : tycon 2.Item/0 { :: Type })
         }
   }
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/do-bind-keeps-resolved-origin.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/do-bind-keeps-resolved-origin.yaml
@@ -11,36 +11,42 @@ modules:
     value <- action
     Box value
 expected: |-
-  module "" GHC.Base where
+  scope 1 = "" GHC
+  scope 2 = "" GHC.Base
 
-  data "" GHC.Base.Box (a{unique 22} : Type) : Type
-   = "" GHC.Base.Box ((a{unique 22} : Type))
+  module 2.GHC.Base where
+
+  data 2.Box (a{unique 22} : Type) : Type
+   = 2.Box ((a{unique 22} : Type))
 
   rec {
-    >>={unique 1000} : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type);
+    >>={unique 1000} : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type);
     >>={unique 1000} =
       Λ(a{unique 34} : Type).
         Λ(b{unique 35} : Type).
-          λ(x1001{unique 1001} : tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 34} : Type)]).
+          λ(x1001{unique 1001} : tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)]).
             λ(y1002{unique 1002} : (a{unique 34} : Type) → (b{unique 35} : Type)).
-              case (x1001{unique 1001} : tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 34} : Type)]) as (_scrut{unique 1004} : tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 34} : Type)]) of {
-                "" GHC.Base.Box (value{unique 1003} : (a{unique 34} : Type)) →
+              case (x1001{unique 1001} : tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)]) as (_scrut{unique 1004} : tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)]) of {
+                2.Box (value{unique 1003} : (a{unique 34} : Type)) →
                   (y1002{unique 1002} : (a{unique 34} : Type) → (b{unique 35} : Type)) (value{unique 1003} : (a{unique 34} : Type))
               }
   }
-  module "" Test where
+  scope 1 = "" GHC.Base
+  scope 2 = "" Test
 
-  external "" GHC.Base.>>= : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type)
+  module 2.Test where
 
-  external "" GHC.Base.Box : ∀ (a{unique 22} : Type). (a{unique 22} : Type) → tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 22} : Type)]
+  external 1.>>= : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon 1.Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type)
+
+  external 1.Box : ∀ (a{unique 22} : Type). (a{unique 22} : Type) → tycon 1.Box/1 { :: Type → Type }[(a{unique 22} : Type)]
 
   rec {
-    run{unique 1000} : ∀ (a{unique 47} : Type). tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 47} : Type)] → tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 47} : Type)];
+    run{unique 1000} : ∀ (a{unique 47} : Type). tycon 1.Box/1 { :: Type → Type }[(a{unique 47} : Type)] → tycon 1.Box/1 { :: Type → Type }[(a{unique 47} : Type)];
     run{unique 1000} =
       Λ(a{unique 47} : Type).
-        λ(x1001{unique 1001} : tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 47} : Type)]).
-          ((((>>={unique -2089863582}{origin "" GHC.Base.>>=} : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type)) @(a{unique 47} : Type)) @tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 47} : Type)]) (x1001{unique 1001} : tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 47} : Type)])) (λ(_do1002{unique 1002} : (a{unique 47} : Type)).
-            ((Box{unique -2833621277}{origin "" GHC.Base.Box} : ∀ (a{unique 22} : Type). (a{unique 22} : Type) → tycon "" "GHC.Base" Box/1 { :: Type → Type }[(a{unique 22} : Type)]) @(a{unique 47} : Type)) (_do1002{unique 1002} : (a{unique 47} : Type)))
+        λ(x1001{unique 1001} : tycon 1.Box/1 { :: Type → Type }[(a{unique 47} : Type)]).
+          ((((>>={unique -2089863582}{origin 1.>>=} : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon 1.Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type)) @(a{unique 47} : Type)) @tycon 1.Box/1 { :: Type → Type }[(a{unique 47} : Type)]) (x1001{unique 1001} : tycon 1.Box/1 { :: Type → Type }[(a{unique 47} : Type)])) (λ(_do1002{unique 1002} : (a{unique 47} : Type)).
+            ((Box{unique -2833621277}{origin 1.Box} : ∀ (a{unique 22} : Type). (a{unique 22} : Type) → tycon 1.Box/1 { :: Type → Type }[(a{unique 22} : Type)]) @(a{unique 47} : Type)) (_do1002{unique 1002} : (a{unique 47} : Type)))
   }
 reason: keeps the resolved GHC.Base origin on the do-notation bind operation
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/do-bind-keeps-resolved-origin.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/do-bind-keeps-resolved-origin.yaml
@@ -11,23 +11,22 @@ modules:
     value <- action
     Box value
 expected: |-
-  scope 1 = "" GHC
-  scope 2 = "" GHC.Base
+  scope 1 = "" GHC.Base
 
-  module 2.GHC.Base where
+  module 1.GHC.Base where
 
-  data 2.Box (a{unique 22} : Type) : Type
-   = 2.Box ((a{unique 22} : Type))
+  data 1.Box (a{unique 22} : Type) : Type
+   = 1.Box ((a{unique 22} : Type))
 
   rec {
-    >>={unique 1000} : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type);
+    >>={unique 1000} : ∀ (a{unique 34} : Type). ∀ (b{unique 35} : Type). tycon 1.Box/1 { :: Type → Type }[(a{unique 34} : Type)] → ((a{unique 34} : Type) → (b{unique 35} : Type)) → (b{unique 35} : Type);
     >>={unique 1000} =
       Λ(a{unique 34} : Type).
         Λ(b{unique 35} : Type).
-          λ(x1001{unique 1001} : tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)]).
+          λ(x1001{unique 1001} : tycon 1.Box/1 { :: Type → Type }[(a{unique 34} : Type)]).
             λ(y1002{unique 1002} : (a{unique 34} : Type) → (b{unique 35} : Type)).
-              case (x1001{unique 1001} : tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)]) as (_scrut{unique 1004} : tycon 2.Box/1 { :: Type → Type }[(a{unique 34} : Type)]) of {
-                2.Box (value{unique 1003} : (a{unique 34} : Type)) →
+              case (x1001{unique 1001} : tycon 1.Box/1 { :: Type → Type }[(a{unique 34} : Type)]) as (_scrut{unique 1004} : tycon 1.Box/1 { :: Type → Type }[(a{unique 34} : Type)]) of {
+                1.Box (value{unique 1003} : (a{unique 34} : Type)) →
                   (y1002{unique 1002} : (a{unique 34} : Type) → (b{unique 35} : Type)) (value{unique 1003} : (a{unique 34} : Type))
               }
   }

--- a/components/aihc-fc/test/Test/Fixtures/golden/empty-data-keeps-checked-kind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/empty-data-keeps-checked-kind.yaml
@@ -12,8 +12,11 @@ modules:
     type MutVar# :: Type -> Type -> TYPE ('BoxedRep 'Unlifted)
     data MutVar# d a
 expected: |-
-  module "aihc-prim" GHC.Prim where
+  scope 1 = "aihc-prim" GHC
+  scope 2 = "aihc-prim" GHC.Prim
 
-  data "aihc-prim" GHC.Prim.MutVar# (d{unique 28} : Type) (a{unique 30} : Type) : TYPE UnliftedRep
+  module 2.GHC.Prim where
+
+  data 2.MutVar# (d{unique 28} : Type) (a{unique 30} : Type) : TYPE UnliftedRep
 status: pass
 reason: keeps checked parameters and the checked result kind for data declarations without constructors

--- a/components/aihc-fc/test/Test/Fixtures/golden/empty-data-keeps-checked-kind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/empty-data-keeps-checked-kind.yaml
@@ -12,11 +12,10 @@ modules:
     type MutVar# :: Type -> Type -> TYPE ('BoxedRep 'Unlifted)
     data MutVar# d a
 expected: |-
-  scope 1 = "aihc-prim" GHC
-  scope 2 = "aihc-prim" GHC.Prim
+  scope 1 = "aihc-prim" GHC.Prim
 
-  module 2.GHC.Prim where
+  module 1.GHC.Prim where
 
-  data 2.MutVar# (d{unique 28} : Type) (a{unique 30} : Type) : TYPE UnliftedRep
+  data 1.MutVar# (d{unique 28} : Type) (a{unique 30} : Type) : TYPE UnliftedRep
 status: pass
 reason: keeps checked parameters and the checked result kind for data declarations without constructors

--- a/components/aihc-fc/test/Test/Fixtures/golden/external-instance-keeps-origin.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/external-instance-keeps-origin.yaml
@@ -19,52 +19,57 @@ modules:
   eqBool :: Bool -> Bool -> Bool
   eqBool = (==)
 expected: |-
-  module "" Types where
+  scope 1 = "" Types
 
-  data "" Types.Bool : Type
-   = "" Types.False
-   | "" Types.True
+  module 1.Types where
 
-  data "" Types.Eq (a{unique 20} : Type) : Type
-   = "" Types.$Dict$Eq ((a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type })
+  data 1.Bool : Type
+   = 1.False
+   | 1.True
 
-  =={unique 1000} : ∀ (a{unique 20} : Type). tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type } =
+  data 1.Eq (a{unique 20} : Type) : Type
+   = 1.$Dict$Eq ((a{unique 20} : Type) → (a{unique 20} : Type) → tycon 1.Bool/0 { :: Type })
+
+  =={unique 1000} : ∀ (a{unique 20} : Type). tycon 1.Eq/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → (a{unique 20} : Type) → tycon 1.Bool/0 { :: Type } =
     Λ(a{unique 20} : Type).
-      λ($d0{unique 1001} : tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)]).
-        case ($d0{unique 1001} : tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
-          "" Types.$Dict$Eq ($method0{unique 1003} : (a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type }) →
-            ($method0{unique 1003} : (a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type })
+      λ($d0{unique 1001} : tycon 1.Eq/1 { :: Type → Type }[(a{unique 20} : Type)]).
+        case ($d0{unique 1001} : tycon 1.Eq/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon 1.Eq/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
+          1.$Dict$Eq ($method0{unique 1003} : (a{unique 20} : Type) → (a{unique 20} : Type) → tycon 1.Bool/0 { :: Type }) →
+            ($method0{unique 1003} : (a{unique 20} : Type) → (a{unique 20} : Type) → tycon 1.Bool/0 { :: Type })
         }
 
-  $fEqBool{unique 1009} : tycon "" "Types" Eq/1 { :: Type → Type }[tycon "" "Types" Bool/0 { :: Type }] =
-    (($Dict$Eq{unique 1010}{origin "" Types.$Dict$Eq} : ∀ (a{unique 20} : Type). ((a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type }) → tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)]) @tycon "" "Types" Bool/0 { :: Type }) (λ(x1004{unique 1004} : tycon "" "Types" Bool/0 { :: Type }).
-      λ(y1005{unique 1005} : tycon "" "Types" Bool/0 { :: Type }).
-        case (x1004{unique 1004} : tycon "" "Types" Bool/0 { :: Type }) as (_scrut{unique 1008} : tycon "" "Types" Bool/0 { :: Type }) of {
-          "" Types.False →
-            case (y1005{unique 1005} : tycon "" "Types" Bool/0 { :: Type }) as (_scrut{unique 1006} : tycon "" "Types" Bool/0 { :: Type }) of {
-              "" Types.False →
-                (True{unique -2407171572}{origin "" Types.True} : tycon "" "Types" Bool/0 { :: Type });
-              "" Types.True →
-                (False{unique -2697294943}{origin "" Types.False} : tycon "" "Types" Bool/0 { :: Type })
+  $fEqBool{unique 1009} : tycon 1.Eq/1 { :: Type → Type }[tycon 1.Bool/0 { :: Type }] =
+    (($Dict$Eq{unique 1010}{origin 1.$Dict$Eq} : ∀ (a{unique 20} : Type). ((a{unique 20} : Type) → (a{unique 20} : Type) → tycon 1.Bool/0 { :: Type }) → tycon 1.Eq/1 { :: Type → Type }[(a{unique 20} : Type)]) @tycon 1.Bool/0 { :: Type }) (λ(x1004{unique 1004} : tycon 1.Bool/0 { :: Type }).
+      λ(y1005{unique 1005} : tycon 1.Bool/0 { :: Type }).
+        case (x1004{unique 1004} : tycon 1.Bool/0 { :: Type }) as (_scrut{unique 1008} : tycon 1.Bool/0 { :: Type }) of {
+          1.False →
+            case (y1005{unique 1005} : tycon 1.Bool/0 { :: Type }) as (_scrut{unique 1006} : tycon 1.Bool/0 { :: Type }) of {
+              1.False →
+                (True{unique -2407171572}{origin 1.True} : tycon 1.Bool/0 { :: Type });
+              1.True →
+                (False{unique -2697294943}{origin 1.False} : tycon 1.Bool/0 { :: Type })
             };
-          "" Types.True →
-            case (y1005{unique 1005} : tycon "" "Types" Bool/0 { :: Type }) as (_scrut{unique 1007} : tycon "" "Types" Bool/0 { :: Type }) of {
-              "" Types.False →
-                (False{unique -2697294943}{origin "" Types.False} : tycon "" "Types" Bool/0 { :: Type });
-              "" Types.True →
-                (True{unique -2407171572}{origin "" Types.True} : tycon "" "Types" Bool/0 { :: Type })
+          1.True →
+            case (y1005{unique 1005} : tycon 1.Bool/0 { :: Type }) as (_scrut{unique 1007} : tycon 1.Bool/0 { :: Type }) of {
+              1.False →
+                (False{unique -2697294943}{origin 1.False} : tycon 1.Bool/0 { :: Type });
+              1.True →
+                (True{unique -2407171572}{origin 1.True} : tycon 1.Bool/0 { :: Type })
             }
         })
-  module "" Test where
+  scope 1 = "" Test
+  scope 2 = "" Types
 
-  external "" Types.$fEqBool : tycon "" "Types" Eq/1 { :: Type → Type }[tycon "" "Types" Bool/0 { :: Type }]
+  module 1.Test where
 
-  external "" Types.== : ∀ (a{unique 20} : Type). tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type }
+  external 2.$fEqBool : tycon 2.Eq/1 { :: Type → Type }[tycon 2.Bool/0 { :: Type }]
+
+  external 2.== : ∀ (a{unique 20} : Type). tycon 2.Eq/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → (a{unique 20} : Type) → tycon 2.Bool/0 { :: Type }
 
   rec {
-    eqBool{unique 1000} : tycon "" "Types" Bool/0 { :: Type } → tycon "" "Types" Bool/0 { :: Type } → tycon "" "Types" Bool/0 { :: Type };
+    eqBool{unique 1000} : tycon 2.Bool/0 { :: Type } → tycon 2.Bool/0 { :: Type } → tycon 2.Bool/0 { :: Type };
     eqBool{unique 1000} =
-      ((=={unique -2712074822}{origin "" Types.==} : ∀ (a{unique 20} : Type). tycon "" "Types" Eq/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → (a{unique 20} : Type) → tycon "" "Types" Bool/0 { :: Type }) @tycon "" "Types" Bool/0 { :: Type }) ($fEqBool{unique -2108977551}{origin "" Types.$fEqBool} : tycon "" "Types" Eq/1 { :: Type → Type }[tycon "" "Types" Bool/0 { :: Type }])
+      ((=={unique -2712074822}{origin 2.==} : ∀ (a{unique 20} : Type). tycon 2.Eq/1 { :: Type → Type }[(a{unique 20} : Type)] → (a{unique 20} : Type) → (a{unique 20} : Type) → tycon 2.Bool/0 { :: Type }) @tycon 2.Bool/0 { :: Type }) ($fEqBool{unique -2108977551}{origin 2.$fEqBool} : tycon 2.Eq/1 { :: Type → Type }[tycon 2.Bool/0 { :: Type }])
   }
 reason: keeps the defining module origin on an imported instance dictionary
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden/foreign-prim-type-variable-normalization.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/foreign-prim-type-variable-normalization.yaml
@@ -1,11 +1,14 @@
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
 
-  data "" Test.State# (s{unique 26} : Type) : TYPE TupleRep []
+  module 1.Test where
 
-  data "" Test.MutVar# (d{unique 28} : Type) (a{unique 30} : Type) : TYPE UnliftedRep
+  data 1.State# (s{unique 26} : Type) : TYPE TupleRep []
 
-  foreign prim newMutVar#{unique 1000}/2 : ∀ (a{unique 35} : Type). ∀ (d{unique 36} : Type). (a{unique 35} : Type) → tycon "" "Test" State#/1 { :: Type → TYPE TupleRep [] }[(d{unique 36} : Type)] → tycon "aihc-prim" "GHC.Types" Tuple2#/2 { :: TYPE TupleRep [] → TYPE UnliftedRep → TYPE TupleRep [TupleRep [], BoxedRep Unlifted] }[tycon "" "Test" State#/1 { :: Type → TYPE TupleRep [] }[(d{unique 36} : Type)], tycon "" "Test" MutVar#/2 { :: Type → Type → TYPE UnliftedRep }[(d{unique 36} : Type), (a{unique 35} : Type)]]
+  data 1.MutVar# (d{unique 28} : Type) (a{unique 30} : Type) : TYPE UnliftedRep
+
+  foreign prim newMutVar#{unique 1000}/2 : ∀ (a{unique 35} : Type). ∀ (d{unique 36} : Type). (a{unique 35} : Type) → tycon 1.State#/1 { :: Type → TYPE TupleRep [] }[(d{unique 36} : Type)] → tycon 2.Tuple2#/2 { :: TYPE TupleRep [] → TYPE UnliftedRep → TYPE TupleRep [TupleRep [], BoxedRep Unlifted] }[tycon 1.State#/1 { :: Type → TYPE TupleRep [] }[(d{unique 36} : Type)], tycon 1.MutVar#/2 { :: Type → Type → TYPE UnliftedRep }[(d{unique 36} : Type), (a{unique 35} : Type)]]
 extensions:
 - ForeignFunctionInterface
 - GHCForeignImportPrim

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-ghc-num-frominteger.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-ghc-num-frominteger.yaml
@@ -1,28 +1,26 @@
 expected: |-
-  scope 1 = "aihc-prim" GHC
+  scope 1 = "aihc-prim" GHC.Prim
+
+  module 1.GHC.Prim where
+
+  data 1.Int# : TYPE IntRep
+  scope 1 = "" GHC.Num
   scope 2 = "aihc-prim" GHC.Prim
 
-  module 2.GHC.Prim where
+  module 1.GHC.Num where
 
-  data 2.Int# : TYPE IntRep
-  scope 1 = "" GHC
-  scope 2 = "" GHC.Num
-  scope 3 = "aihc-prim" GHC.Prim
+  data 1.Integer : Type
+   = 1.IS (tycon 2.Int#/0 { :: TYPE IntRep })
 
-  module 2.GHC.Num where
+  data 1.Num (a{unique 20} : Type) : Type
+   = 1.$Dict$Num (tycon 1.Integer/0 { :: Type } → (a{unique 20} : Type))
 
-  data 2.Integer : Type
-   = 2.IS (tycon 3.Int#/0 { :: TYPE IntRep })
-
-  data 2.Num (a{unique 20} : Type) : Type
-   = 2.$Dict$Num (tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type))
-
-  fromInteger{unique 1000} : ∀ (a{unique 20} : Type). tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type) =
+  fromInteger{unique 1000} : ∀ (a{unique 20} : Type). tycon 1.Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon 1.Integer/0 { :: Type } → (a{unique 20} : Type) =
     Λ(a{unique 20} : Type).
-      λ($d0{unique 1001} : tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)]).
-        case ($d0{unique 1001} : tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
-          2.$Dict$Num ($method0{unique 1003} : tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type)) →
-            ($method0{unique 1003} : tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type))
+      λ($d0{unique 1001} : tycon 1.Num/1 { :: Type → Type }[(a{unique 20} : Type)]).
+        case ($d0{unique 1001} : tycon 1.Num/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon 1.Num/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
+          1.$Dict$Num ($method0{unique 1003} : tycon 1.Integer/0 { :: Type } → (a{unique 20} : Type)) →
+            ($method0{unique 1003} : tycon 1.Integer/0 { :: Type } → (a{unique 20} : Type))
         }
   scope 1 = "" GHC.Num
   scope 2 = "" Main

--- a/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-ghc-num-frominteger.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/integer-literal-ghc-num-frominteger.yaml
@@ -1,34 +1,45 @@
 expected: |-
-  module "aihc-prim" GHC.Prim where
+  scope 1 = "aihc-prim" GHC
+  scope 2 = "aihc-prim" GHC.Prim
 
-  data "aihc-prim" GHC.Prim.Int# : TYPE IntRep
-  module "" GHC.Num where
+  module 2.GHC.Prim where
 
-  data "" GHC.Num.Integer : Type
-   = "" GHC.Num.IS (tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep })
+  data 2.Int# : TYPE IntRep
+  scope 1 = "" GHC
+  scope 2 = "" GHC.Num
+  scope 3 = "aihc-prim" GHC.Prim
 
-  data "" GHC.Num.Num (a{unique 20} : Type) : Type
-   = "" GHC.Num.$Dict$Num (tycon "" "GHC.Num" Integer/0 { :: Type } → (a{unique 20} : Type))
+  module 2.GHC.Num where
 
-  fromInteger{unique 1000} : ∀ (a{unique 20} : Type). tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon "" "GHC.Num" Integer/0 { :: Type } → (a{unique 20} : Type) =
+  data 2.Integer : Type
+   = 2.IS (tycon 3.Int#/0 { :: TYPE IntRep })
+
+  data 2.Num (a{unique 20} : Type) : Type
+   = 2.$Dict$Num (tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type))
+
+  fromInteger{unique 1000} : ∀ (a{unique 20} : Type). tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type) =
     Λ(a{unique 20} : Type).
-      λ($d0{unique 1001} : tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 20} : Type)]).
-        case ($d0{unique 1001} : tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
-          "" GHC.Num.$Dict$Num ($method0{unique 1003} : tycon "" "GHC.Num" Integer/0 { :: Type } → (a{unique 20} : Type)) →
-            ($method0{unique 1003} : tycon "" "GHC.Num" Integer/0 { :: Type } → (a{unique 20} : Type))
+      λ($d0{unique 1001} : tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)]).
+        case ($d0{unique 1001} : tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)]) as ($dict{unique 1002} : tycon 2.Num/1 { :: Type → Type }[(a{unique 20} : Type)]) of {
+          2.$Dict$Num ($method0{unique 1003} : tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type)) →
+            ($method0{unique 1003} : tycon 2.Integer/0 { :: Type } → (a{unique 20} : Type))
         }
-  module "" Main where
+  scope 1 = "" GHC.Num
+  scope 2 = "" Main
+  scope 3 = "aihc-prim" GHC.Prim
 
-  external "" GHC.Num.IS : tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep } → tycon "" "GHC.Num" Integer/0 { :: Type }
+  module 2.Main where
 
-  external "" GHC.Num.fromInteger : ∀ (a{unique 20} : Type). tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon "" "GHC.Num" Integer/0 { :: Type } → (a{unique 20} : Type)
+  external 1.IS : tycon 3.Int#/0 { :: TYPE IntRep } → tycon 1.Integer/0 { :: Type }
+
+  external 1.fromInteger : ∀ (a{unique 20} : Type). tycon 1.Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon 1.Integer/0 { :: Type } → (a{unique 20} : Type)
 
   rec {
-    one{unique 1000} : ∀ (a{unique 27} : Type). tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 27} : Type)] → (a{unique 27} : Type);
+    one{unique 1000} : ∀ (a{unique 27} : Type). tycon 1.Num/1 { :: Type → Type }[(a{unique 27} : Type)] → (a{unique 27} : Type);
     one{unique 1000} =
       Λ(a{unique 27} : Type).
-        λ($d0{unique 1001} : tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 27} : Type)]).
-          (((fromInteger{unique -2983985473}{origin "" GHC.Num.fromInteger} : ∀ (a{unique 20} : Type). tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon "" "GHC.Num" Integer/0 { :: Type } → (a{unique 20} : Type)) @(a{unique 27} : Type)) ($d0{unique 1001} : tycon "" "GHC.Num" Num/1 { :: Type → Type }[(a{unique 27} : Type)])) ((IS{unique -2633234173}{origin "" GHC.Num.IS} : tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep } → tycon "" "GHC.Num" Integer/0 { :: Type }) (1#IntRep : tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep }))
+        λ($d0{unique 1001} : tycon 1.Num/1 { :: Type → Type }[(a{unique 27} : Type)]).
+          (((fromInteger{unique -2983985473}{origin 1.fromInteger} : ∀ (a{unique 20} : Type). tycon 1.Num/1 { :: Type → Type }[(a{unique 20} : Type)] → tycon 1.Integer/0 { :: Type } → (a{unique 20} : Type)) @(a{unique 27} : Type)) ($d0{unique 1001} : tycon 1.Num/1 { :: Type → Type }[(a{unique 27} : Type)])) ((IS{unique -2633234173}{origin 1.IS} : tycon 3.Int#/0 { :: TYPE IntRep } → tycon 1.Integer/0 { :: Type }) (1#IntRep : tycon 3.Int#/0 { :: TYPE IntRep }))
   }
 extensions:
 - MagicHash

--- a/components/aihc-fc/test/Test/Fixtures/golden/lambda-annotation.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/lambda-annotation.yaml
@@ -1,15 +1,17 @@
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
 
-  data "" Test.Bool : Type
-   = "" Test.True
-   | "" Test.False
+  module 1.Test where
+
+  data 1.Bool : Type
+   = 1.True
+   | 1.False
 
   rec {
-    idBool{unique 1000} : tycon "" "Test" Bool/0 { :: Type } → tycon "" "Test" Bool/0 { :: Type };
+    idBool{unique 1000} : tycon 1.Bool/0 { :: Type } → tycon 1.Bool/0 { :: Type };
     idBool{unique 1000} =
-      λ(x1001{unique 1001} : tycon "" "Test" Bool/0 { :: Type }).
-        (x1001{unique 1001} : tycon "" "Test" Bool/0 { :: Type })
+      λ(x1001{unique 1001} : tycon 1.Bool/0 { :: Type }).
+        (x1001{unique 1001} : tycon 1.Bool/0 { :: Type })
   }
 extensions: []
 modules:

--- a/components/aihc-fc/test/Test/Fixtures/golden/lambda-polymorphic-identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/lambda-polymorphic-identity.yaml
@@ -1,5 +1,7 @@
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+
+  module 1.Test where
 
   rec {
     id{unique 1000} : ∀ (a{unique 22} : Type). (a{unique 22} : Type) → (a{unique 22} : Type);

--- a/components/aihc-fc/test/Test/Fixtures/golden/list-type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/list-type-application.yaml
@@ -7,20 +7,23 @@ modules:
     xs :: [Bool]
     xs = [True]
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
 
-  external "aihc-prim" GHC.Types.: : ∀ (a{unique 4} : Type). (a{unique 4} : Type) → tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[(a{unique 4} : Type)] → tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[(a{unique 4} : Type)]
+  module 1.Test where
 
-  external "aihc-prim" GHC.Types.[] : ∀ (a{unique 4} : Type). tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[(a{unique 4} : Type)]
+  external 2.: : ∀ (a{unique 4} : Type). (a{unique 4} : Type) → tycon 2.[]/1 { :: Type → Type }[(a{unique 4} : Type)] → tycon 2.[]/1 { :: Type → Type }[(a{unique 4} : Type)]
 
-  data "" Test.Bool : Type
-   = "" Test.True
-   | "" Test.False
+  external 2.[] : ∀ (a{unique 4} : Type). tycon 2.[]/1 { :: Type → Type }[(a{unique 4} : Type)]
+
+  data 1.Bool : Type
+   = 1.True
+   | 1.False
 
   rec {
-    xs{unique 1000} : tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[tycon "" "Test" Bool/0 { :: Type }];
+    xs{unique 1000} : tycon 2.[]/1 { :: Type → Type }[tycon 1.Bool/0 { :: Type }];
     xs{unique 1000} =
-      (((:{unique -2321805554}{origin "aihc-prim" GHC.Types.:} : ∀ (a{unique 4} : Type). (a{unique 4} : Type) → tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[(a{unique 4} : Type)] → tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[(a{unique 4} : Type)]) @tycon "" "Test" Bool/0 { :: Type }) (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type })) (([]{unique -2285220283}{origin "aihc-prim" GHC.Types.[]} : ∀ (a{unique 4} : Type). tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[(a{unique 4} : Type)]) @tycon "" "Test" Bool/0 { :: Type })
+      (((:{unique -2321805554}{origin 2.:} : ∀ (a{unique 4} : Type). (a{unique 4} : Type) → tycon 2.[]/1 { :: Type → Type }[(a{unique 4} : Type)] → tycon 2.[]/1 { :: Type → Type }[(a{unique 4} : Type)]) @tycon 1.Bool/0 { :: Type }) (True{unique -2360662326}{origin 1.True} : tycon 1.Bool/0 { :: Type })) (([]{unique -2285220283}{origin 2.[]} : ∀ (a{unique 4} : Type). tycon 2.[]/1 { :: Type → Type }[(a{unique 4} : Type)]) @tycon 1.Bool/0 { :: Type })
   }
 status: pass
 reason: reifies list constructor type arguments from type-checker annotations

--- a/components/aihc-fc/test/Test/Fixtures/golden/newtype-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/newtype-family-instance.yaml
@@ -7,13 +7,16 @@ modules:
     data family Wrapped a
     newtype instance Wrapped Unit = WrappedUnit Unit
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+  scope 2 = "aihc-internal" Aihc.Internal
 
-  data "" Test.Unit : Type
-   = "" Test.Unit
+  module 1.Test where
 
-  newtype "" Test.$R$Wrapped$WrappedUnit : tycon "aihc-internal" "Aihc.Internal" $R$Wrapped$WrappedUnit/0 { :: Type } = "" Test.WrappedUnit tycon "" "Test" Unit/0 { :: Type }
+  data 1.Unit : Type
+   = 1.Unit
 
-  axiom $ax$Wrapped$WrappedUnit : tycon "" "Test" Wrapped/1 { :: Type → Type }[tycon "" "Test" Unit/0 { :: Type }] ~N tycon "aihc-internal" "Aihc.Internal" $R$Wrapped$WrappedUnit/0 { :: Type }
+  newtype 1.$R$Wrapped$WrappedUnit : tycon 2.$R$Wrapped$WrappedUnit/0 { :: Type } = 1.WrappedUnit tycon 1.Unit/0 { :: Type }
+
+  axiom $ax$Wrapped$WrappedUnit : tycon 1.Wrapped/1 { :: Type → Type }[tycon 1.Unit/0 { :: Type }] ~N tycon 2.$R$Wrapped$WrappedUnit/0 { :: Type }
 status: pass
 reason: newtype-family instances retain a representation newtype and their nominal family equation

--- a/components/aihc-fc/test/Test/Fixtures/golden/noinline-pragma.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/noinline-pragma.yaml
@@ -5,7 +5,9 @@ modules:
     id x = x
     {-# NOINLINE id #-}
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+
+  module 1.Test where
 
   rec {
     id{unique 1000} : ∀ (a{unique 24} : Type). (a{unique 24} : Type) → (a{unique 24} : Type);

--- a/components/aihc-fc/test/Test/Fixtures/golden/pattern-failure-continuation-sharing.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/pattern-failure-continuation-sharing.yaml
@@ -20,49 +20,51 @@ modules:
     shared (Just True) = True
     shared _ = False
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
 
-  data "" Test.Bool : Type
-   = "" Test.False
-   | "" Test.True
+  module 1.Test where
 
-  data "" Test.MaybeBool : Type
-   = "" Test.Nothing
-   | "" Test.Just (tycon "" "Test" Bool/0 { :: Type })
+  data 1.Bool : Type
+   = 1.False
+   | 1.True
+
+  data 1.MaybeBool : Type
+   = 1.Nothing
+   | 1.Just (tycon 1.Bool/0 { :: Type })
 
   rec {
-    unused{unique 1000} : tycon "" "Test" Bool/0 { :: Type } → tycon "" "Test" Bool/0 { :: Type };
-    single{unique 1001} : tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[tycon "" "Test" Bool/0 { :: Type }] → tycon "" "Test" Bool/0 { :: Type };
-    shared{unique 1002} : tycon "" "Test" MaybeBool/0 { :: Type } → tycon "" "Test" Bool/0 { :: Type };
+    unused{unique 1000} : tycon 1.Bool/0 { :: Type } → tycon 1.Bool/0 { :: Type };
+    single{unique 1001} : tycon 2.[]/1 { :: Type → Type }[tycon 1.Bool/0 { :: Type }] → tycon 1.Bool/0 { :: Type };
+    shared{unique 1002} : tycon 1.MaybeBool/0 { :: Type } → tycon 1.Bool/0 { :: Type };
     unused{unique 1000} =
-      λ(x1003{unique 1003} : tycon "" "Test" Bool/0 { :: Type }).
-        (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type });
+      λ(x1003{unique 1003} : tycon 1.Bool/0 { :: Type }).
+        (True{unique -2360662326}{origin 1.True} : tycon 1.Bool/0 { :: Type });
     single{unique 1001} =
-      λ(x1004{unique 1004} : tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[tycon "" "Test" Bool/0 { :: Type }]).
-        case (x1004{unique 1004} : tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[tycon "" "Test" Bool/0 { :: Type }]) as (_match1008{unique 1008} : tycon "aihc-prim" "GHC.Types" []/1 { :: Type → Type }[tycon "" "Test" Bool/0 { :: Type }]) of {
-          "aihc-prim" GHC.Types.[] →
-            (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type });
+      λ(x1004{unique 1004} : tycon 2.[]/1 { :: Type → Type }[tycon 1.Bool/0 { :: Type }]).
+        case (x1004{unique 1004} : tycon 2.[]/1 { :: Type → Type }[tycon 1.Bool/0 { :: Type }]) as (_match1008{unique 1008} : tycon 2.[]/1 { :: Type → Type }[tycon 1.Bool/0 { :: Type }]) of {
+          2.[] →
+            (True{unique -2360662326}{origin 1.True} : tycon 1.Bool/0 { :: Type });
           _ →
-            (False{unique -2286087477}{origin "" Test.False} : tycon "" "Test" Bool/0 { :: Type })
+            (False{unique -2286087477}{origin 1.False} : tycon 1.Bool/0 { :: Type })
         };
     shared{unique 1002} =
-      λ(x1009{unique 1009} : tycon "" "Test" MaybeBool/0 { :: Type }).
+      λ(x1009{unique 1009} : tycon 1.MaybeBool/0 { :: Type }).
         let {
-          _next_match1012{unique 1012} : tycon "" "Test" Bool/0 { :: Type } =
-            (False{unique -2286087477}{origin "" Test.False} : tycon "" "Test" Bool/0 { :: Type })
+          _next_match1012{unique 1012} : tycon 1.Bool/0 { :: Type } =
+            (False{unique -2286087477}{origin 1.False} : tycon 1.Bool/0 { :: Type })
         } in
-          case (x1009{unique 1009} : tycon "" "Test" MaybeBool/0 { :: Type }) as (_match1015{unique 1015} : tycon "" "Test" MaybeBool/0 { :: Type }) of {
-            "" Test.Just (_pat{unique 1013} : tycon "" "Test" Bool/0 { :: Type }) →
-              case (_pat{unique 1013} : tycon "" "Test" Bool/0 { :: Type }) as (_match1014{unique 1014} : tycon "" "Test" Bool/0 { :: Type }) of {
-                "" Test.True →
-                  (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type });
+          case (x1009{unique 1009} : tycon 1.MaybeBool/0 { :: Type }) as (_match1015{unique 1015} : tycon 1.MaybeBool/0 { :: Type }) of {
+            1.Just (_pat{unique 1013} : tycon 1.Bool/0 { :: Type }) →
+              case (_pat{unique 1013} : tycon 1.Bool/0 { :: Type }) as (_match1014{unique 1014} : tycon 1.Bool/0 { :: Type }) of {
+                1.True →
+                  (True{unique -2360662326}{origin 1.True} : tycon 1.Bool/0 { :: Type });
                 _ →
-                  (_next_match1012{unique 1012} : tycon "" "Test" Bool/0 { :: Type })
+                  (_next_match1012{unique 1012} : tycon 1.Bool/0 { :: Type })
               };
             _ →
-              (_next_match1012{unique 1012} : tycon "" "Test" Bool/0 { :: Type })
+              (_next_match1012{unique 1012} : tycon 1.Bool/0 { :: Type })
           }
   }
-
 status: pass
 reason: pattern failure continuations are omitted, inlined, or shared according to their occurrence count

--- a/components/aihc-fc/test/Test/Fixtures/golden/primitive-literals-keep-checked-origin.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/primitive-literals-keep-checked-origin.yaml
@@ -17,26 +17,32 @@ modules:
     intValue = BoxInt 1#
     addrValue = BoxAddr "test"#
 expected: |-
-  module "aihc-prim" GHC.Prim where
+  scope 1 = "aihc-prim" GHC
+  scope 2 = "aihc-prim" GHC.Prim
 
-  data "aihc-prim" GHC.Prim.Int# : TYPE IntRep
+  module 2.GHC.Prim where
 
-  data "aihc-prim" GHC.Prim.Addr# : TYPE AddrRep
-  module "" Test where
+  data 2.Int# : TYPE IntRep
 
-  data "" Test.BoxInt : Type
-   = "" Test.BoxInt (tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep })
+  data 2.Addr# : TYPE AddrRep
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Prim
 
-  data "" Test.BoxAddr : Type
-   = "" Test.BoxAddr (tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep })
+  module 1.Test where
+
+  data 1.BoxInt : Type
+   = 1.BoxInt (tycon 2.Int#/0 { :: TYPE IntRep })
+
+  data 1.BoxAddr : Type
+   = 1.BoxAddr (tycon 2.Addr#/0 { :: TYPE AddrRep })
 
   rec {
-    intValue{unique 1000} : tycon "" "Test" BoxInt/0 { :: Type };
-    addrValue{unique 1001} : tycon "" "Test" BoxAddr/0 { :: Type };
+    intValue{unique 1000} : tycon 1.BoxInt/0 { :: Type };
+    addrValue{unique 1001} : tycon 1.BoxAddr/0 { :: Type };
     intValue{unique 1000} =
-      (BoxInt{unique -2930103777}{origin "" Test.BoxInt} : tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep } → tycon "" "Test" BoxInt/0 { :: Type }) (1#IntRep : tycon "aihc-prim" "GHC.Prim" Int#/0 { :: TYPE IntRep });
+      (BoxInt{unique -2930103777}{origin 1.BoxInt} : tycon 2.Int#/0 { :: TYPE IntRep } → tycon 1.BoxInt/0 { :: Type }) (1#IntRep : tycon 2.Int#/0 { :: TYPE IntRep });
     addrValue{unique 1001} =
-      (BoxAddr{unique -2012464927}{origin "" Test.BoxAddr} : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep } → tycon "" "Test" BoxAddr/0 { :: Type }) ("test"#AddrRep : tycon "aihc-prim" "GHC.Prim" Addr#/0 { :: TYPE AddrRep })
+      (BoxAddr{unique -2012464927}{origin 1.BoxAddr} : tycon 2.Addr#/0 { :: TYPE AddrRep } → tycon 1.BoxAddr/0 { :: Type }) ("test"#AddrRep : tycon 2.Addr#/0 { :: TYPE AddrRep })
   }
 status: pass
 reason: keeps checked GHC.Prim identities on primitive Core literals

--- a/components/aihc-fc/test/Test/Fixtures/golden/primitive-literals-keep-checked-origin.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/primitive-literals-keep-checked-origin.yaml
@@ -17,14 +17,13 @@ modules:
     intValue = BoxInt 1#
     addrValue = BoxAddr "test"#
 expected: |-
-  scope 1 = "aihc-prim" GHC
-  scope 2 = "aihc-prim" GHC.Prim
+  scope 1 = "aihc-prim" GHC.Prim
 
-  module 2.GHC.Prim where
+  module 1.GHC.Prim where
 
-  data 2.Int# : TYPE IntRep
+  data 1.Int# : TYPE IntRep
 
-  data 2.Addr# : TYPE AddrRep
+  data 1.Addr# : TYPE AddrRep
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Prim
 

--- a/components/aihc-fc/test/Test/Fixtures/golden/top-level-shared-identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/top-level-shared-identity.yaml
@@ -6,7 +6,9 @@ modules:
     second x = shared x
     shared x = x
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
+
+  module 1.Test where
 
   rec {
     first{unique 1000} : ∀ (a{unique 40} : Type). (a{unique 40} : Type) → (a{unique 40} : Type);

--- a/components/aihc-fc/test/Test/Fixtures/golden/tuple-type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/tuple-type-application.yaml
@@ -7,20 +7,23 @@ modules:
     pair :: (Bool, ())
     pair = (True, ())
 expected: |-
-  module "" Test where
+  scope 1 = "" GHC.Tuple
+  scope 2 = "" Test
 
-  external "" GHC.Tuple.() : tycon "" "GHC.Tuple" Unit/0 { :: Type }
+  module 2.Test where
 
-  external "" GHC.Tuple.(,) : ∀ (a{unique 14} : Type). ∀ (b{unique 16} : Type). (a{unique 14} : Type) → (b{unique 16} : Type) → tycon "" "GHC.Tuple" Tuple2/2 { :: Type → Type → Type }[(a{unique 14} : Type), (b{unique 16} : Type)]
+  external 1.() : tycon 1.Unit/0 { :: Type }
 
-  data "" Test.Bool : Type
-   = "" Test.True
-   | "" Test.False
+  external 1.(,) : ∀ (a{unique 14} : Type). ∀ (b{unique 16} : Type). (a{unique 14} : Type) → (b{unique 16} : Type) → tycon 1.Tuple2/2 { :: Type → Type → Type }[(a{unique 14} : Type), (b{unique 16} : Type)]
+
+  data 2.Bool : Type
+   = 2.True
+   | 2.False
 
   rec {
-    pair{unique 1000} : tycon "" "GHC.Tuple" Tuple2/2 { :: Type → Type → Type }[tycon "" "Test" Bool/0 { :: Type }, tycon "" "GHC.Tuple" Unit/0 { :: Type }];
+    pair{unique 1000} : tycon 1.Tuple2/2 { :: Type → Type → Type }[tycon 2.Bool/0 { :: Type }, tycon 1.Unit/0 { :: Type }];
     pair{unique 1000} =
-      (((((,){unique -2368007840}{origin "" GHC.Tuple.(,)} : ∀ (a{unique 14} : Type). ∀ (b{unique 16} : Type). (a{unique 14} : Type) → (b{unique 16} : Type) → tycon "" "GHC.Tuple" Tuple2/2 { :: Type → Type → Type }[(a{unique 14} : Type), (b{unique 16} : Type)]) @tycon "" "Test" Bool/0 { :: Type }) @tycon "" "GHC.Tuple" Unit/0 { :: Type }) (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type })) ((){unique -2533499005}{origin "" GHC.Tuple.()} : tycon "" "GHC.Tuple" Unit/0 { :: Type })
+      (((((,){unique -2368007840}{origin 1.(,)} : ∀ (a{unique 14} : Type). ∀ (b{unique 16} : Type). (a{unique 14} : Type) → (b{unique 16} : Type) → tycon 1.Tuple2/2 { :: Type → Type → Type }[(a{unique 14} : Type), (b{unique 16} : Type)]) @tycon 2.Bool/0 { :: Type }) @tycon 1.Unit/0 { :: Type }) (True{unique -2360662326}{origin 2.True} : tycon 2.Bool/0 { :: Type })) ((){unique -2533499005}{origin 1.()} : tycon 1.Unit/0 { :: Type })
   }
 status: pass
 reason: reifies tuple constructor type arguments from type-checker annotations

--- a/components/aihc-fc/test/Test/Fixtures/golden/type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/type-application.yaml
@@ -1,19 +1,21 @@
 expected: |-
-  module "" Test where
+  scope 1 = "" Test
 
-  data "" Test.Bool : Type
-   = "" Test.True
-   | "" Test.False
+  module 1.Test where
+
+  data 1.Bool : Type
+   = 1.True
+   | 1.False
 
   rec {
     id{unique 1000} : ∀ (a{unique 24} : Type). (a{unique 24} : Type) → (a{unique 24} : Type);
-    true{unique 1001} : tycon "" "Test" Bool/0 { :: Type };
+    true{unique 1001} : tycon 1.Bool/0 { :: Type };
     id{unique 1000} =
       Λ(a{unique 24} : Type).
         λ(x1002{unique 1002} : (a{unique 24} : Type)).
           (x1002{unique 1002} : (a{unique 24} : Type));
     true{unique 1001} =
-      ((id{unique 1000} : ∀ (a{unique 24} : Type). (a{unique 24} : Type) → (a{unique 24} : Type)) @tycon "" "Test" Bool/0 { :: Type }) (True{unique -2360662326}{origin "" Test.True} : tycon "" "Test" Bool/0 { :: Type })
+      ((id{unique 1000} : ∀ (a{unique 24} : Type). (a{unique 24} : Type) → (a{unique 24} : Type)) @tycon 1.Bool/0 { :: Type }) (True{unique -2360662326}{origin 1.True} : tycon 1.Bool/0 { :: Type })
   }
 extensions: []
 modules:


### PR DESCRIPTION
## Summary

Add sorted System FC scope declarations.

Use scope references for package and module prefixes.

Keep legacy FC golden expectations valid during migration.

## Progress counts

No progress counts change.

## Validation

Run `just check`.

Run `cabal test -v0 aihc-fc:spec --test-options=--hide-successes`.