### PR TITLE
feat(fc2): add System FC 2 AST, pretty printer, and parser

### DIFF
--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -28,6 +28,13 @@ library
     Aihc.Fc.Pretty
     Aihc.Fc.Subst
     Aihc.Fc.Syntax
+    Aihc.Fc2
+    Aihc.Fc2.Name
+    Aihc.Fc2.Parser
+    Aihc.Fc2.Pretty
+    Aihc.Fc2.Syntax
+    Aihc.Fc2.TypeOf
+    Aihc.Fc2.Wired
 
   other-modules:
     Aihc.Fc.Desugar.Deriving
@@ -66,6 +73,8 @@ test-suite spec
     FcGolden
     Test.Fc.Properties
     Test.Fc.Suite
+    Test.Fc2.Properties
+    Test.Fc2.Suite
 
   build-depends:
     aeson,

--- a/components/aihc-fc/src/Aihc/Fc2.hs
+++ b/components/aihc-fc/src/Aihc/Fc2.hs
@@ -1,0 +1,17 @@
+-- | System FC 2 language.
+module Aihc.Fc2
+  ( module Aihc.Fc2.Syntax,
+    module Aihc.Fc2.Name,
+    renderProgram,
+    renderType,
+    renderExpr,
+    parseProgram,
+    renderParseError,
+    Fc2ParseError,
+  )
+where
+
+import Aihc.Fc2.Name
+import Aihc.Fc2.Parser (Fc2ParseError, parseProgram, renderParseError)
+import Aihc.Fc2.Pretty (renderExpr, renderProgram, renderType)
+import Aihc.Fc2.Syntax

--- a/components/aihc-fc/src/Aihc/Fc2/Name.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Name.hs
@@ -1,0 +1,116 @@
+-- | Names, sorts, and scopes for System FC 2.
+module Aihc.Fc2.Name
+  ( Sort (..),
+    NameClass (..),
+    nameClass,
+    Origin (..),
+    Name (..),
+    nameEquals,
+    ModuleId (..),
+    ScopeTable (..),
+    emptyScopeTable,
+    lookupScope,
+    insertScope,
+    scopeEntries,
+    localUnique,
+    Vis (..),
+  )
+where
+
+import Aihc.Resolve (PackageId)
+import Aihc.Tc.Types (Unique (..))
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+-- | The sort of one name in the single namespace.
+data Sort
+  = SortTypeConstructor
+  | SortDataConstructor
+  | SortValue
+  | SortTypeVariable
+  | SortAxiom
+  | SortSynonym
+  deriving (Eq, Ord, Show, Read)
+
+-- | Equality class for a name. A free @t@ name may match a synonym.
+data NameClass
+  = NameClassType
+  | NameClassValue
+  | NameClassAxiom
+  | NameClassTypeVar
+  deriving (Eq, Ord, Show, Read)
+
+nameClass :: Sort -> NameClass
+nameClass sort =
+  case sort of
+    SortTypeConstructor -> NameClassType
+    SortSynonym -> NameClassType
+    SortValue -> NameClassValue
+    SortDataConstructor -> NameClassValue
+    SortAxiom -> NameClassAxiom
+    SortTypeVariable -> NameClassTypeVar
+
+-- | Where a name is bound.
+data Origin
+  = OriginLocal Unique
+  | OriginTop PackageId Text
+  deriving (Eq, Ord, Show, Read)
+
+-- | A name. Equality uses origin, text, and name class.
+data Name = Name
+  { nameText :: Text,
+    nameSort :: Sort,
+    nameOrigin :: Origin
+  }
+  deriving (Show, Read)
+
+instance Eq Name where
+  left == right = nameEquals left right
+
+instance Ord Name where
+  compare left right =
+    compare
+      (nameClass (nameSort left), nameText left, nameOrigin left)
+      (nameClass (nameSort right), nameText right, nameOrigin right)
+
+nameEquals :: Name -> Name -> Bool
+nameEquals left right =
+  nameClass (nameSort left) == nameClass (nameSort right)
+    && nameText left == nameText right
+    && nameOrigin left == nameOrigin right
+
+data ModuleId = ModuleId
+  { modulePackage :: PackageId,
+    moduleName :: Text
+  }
+  deriving (Eq, Ord, Show, Read)
+
+newtype ScopeTable = ScopeTable (Map Int (PackageId, Text))
+  deriving (Eq, Ord, Show, Read)
+
+emptyScopeTable :: ScopeTable
+emptyScopeTable = ScopeTable Map.empty
+
+lookupScope :: Int -> ScopeTable -> Maybe (PackageId, Text)
+lookupScope scopeId (ScopeTable table) = Map.lookup scopeId table
+
+insertScope :: Int -> PackageId -> Text -> ScopeTable -> ScopeTable
+insertScope scopeId package moduleName (ScopeTable table) =
+  ScopeTable (Map.insert scopeId (package, moduleName) table)
+
+scopeEntries :: ScopeTable -> [(Int, PackageId, Text)]
+scopeEntries (ScopeTable table) =
+  [(scopeId, package, moduleName) | (scopeId, (package, moduleName)) <- Map.toAscList table]
+
+localUnique :: Name -> Maybe Unique
+localUnique name =
+  case nameOrigin name of
+    OriginLocal unique -> Just unique
+    OriginTop {} -> Nothing
+
+-- | Export visibility.
+data Vis
+  = Pub
+  | Private
+  deriving (Eq, Ord, Show, Read)

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -1,0 +1,972 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Parse System FC 2 text.
+module Aihc.Fc2.Parser
+  ( Fc2ParseError,
+    parseProgram,
+    renderParseError,
+  )
+where
+
+import Aihc.Fc2.Name
+import Aihc.Fc2.Syntax
+import Aihc.Fc2.TypeOf
+import Aihc.Fc2.Wired (primPackageFromScopes)
+import Aihc.Resolve (PackageId (..))
+import Aihc.Tc.Types (Unique (..))
+import Control.Applicative ((<|>))
+import Control.Monad (zipWithM)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
+import Data.Char (isAlpha, isAlphaNum)
+import Data.Functor (($>))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Void (Void)
+import Text.Megaparsec (ParseErrorBundle, Parsec)
+import Text.Megaparsec qualified as MP
+import Text.Megaparsec.Char qualified as MPC
+import Text.Megaparsec.Char.Lexer qualified as L
+
+type Parser = ReaderT ScopeTable (Parsec Void Text)
+
+type Fc2ParseError = ParseErrorBundle Text Void
+
+data OpenType
+  = OpenVar Name
+  | OpenCon Name
+  | OpenApp OpenType OpenType
+  | OpenFun OpenType OpenType
+  | OpenForAll Name OpenType OpenType
+  | OpenEq OpenType OpenType
+  | OpenExplicit Type
+  deriving (Eq, Show)
+
+parseProgram :: Text -> Either Fc2ParseError Program
+parseProgram input = do
+  (scopes, body) <- parseScopeHeader input
+  parseWith scopes (space *> program scopes <* MP.eof) "<system-fc2>" body
+
+renderParseError :: Fc2ParseError -> String
+renderParseError = MP.errorBundlePretty
+
+parseWith :: ScopeTable -> Parser value -> String -> Text -> Either Fc2ParseError value
+parseWith scopes parser = MP.parse (runReaderT parser scopes)
+
+parseScopeHeader :: Text -> Either Fc2ParseError (ScopeTable, Text)
+parseScopeHeader = MP.parse parser "<system-fc2-scope>"
+  where
+    parser = do
+      scopes <- runReaderT (MP.many scopeDeclaration) emptyScopeTable
+      body <- MP.takeRest
+      pure (foldr (\(scopeId, package, moduleName) table -> insertScope scopeId package moduleName table) emptyScopeTable scopes, body)
+
+scopeDeclaration :: Parser (Int, PackageId, Text)
+scopeDeclaration = do
+  _ <- keyword "scope"
+  scopeId <- int
+  _ <- symbol "="
+  package <- stringLiteral
+  moduleName <- qualifiedModuleName
+  pure (scopeId, PackageId package, moduleName)
+
+program :: ScopeTable -> Parser Program
+program scopes = do
+  moduleId <- moduleHeader
+  openDecls <- MP.many (declaration scopes)
+  fillProgram scopes moduleId openDecls
+
+moduleHeader :: Parser ModuleId
+moduleHeader = do
+  _ <- keyword "module"
+  (package, moduleName) <- scopedModuleName
+  _ <- keyword "where"
+  pure (ModuleId package moduleName)
+
+scopedModuleName :: Parser (PackageId, Text)
+scopedModuleName = do
+  scopeId <- int
+  _ <- symbol "."
+  moduleName <- qualifiedModuleName
+  scopes <- ask
+  case lookupScope scopeId scopes of
+    Just (package, boundName)
+      | boundName == moduleName -> pure (package, moduleName)
+      | otherwise -> fail ("module name does not match scope " <> show scopeId)
+    Nothing -> fail ("unknown scope " <> show scopeId)
+
+data OpenBinder = OpenBinder Name OpenType
+  deriving (Eq, Show)
+
+data OpenDecl
+  = OpenTypeDecl Vis Name [OpenBinder] OpenType [Role] [OpenCon]
+  | OpenSynonymDecl Vis Name [OpenBinder] OpenType OpenType
+  | OpenAxiomDecl Vis Name [OpenBinder] Role OpenType OpenType
+  | OpenValDecl Vis Name OpenType OpenExpr
+  | OpenPrimDecl Vis Name OpenType
+  deriving (Eq, Show)
+
+data OpenCon = OpenConDecl Vis Name OpenType
+  deriving (Eq, Show)
+
+data OpenExpr
+  = OVar Name
+  | OLit Literal
+  | OApp OpenExpr OpenExpr
+  | OTyApp OpenExpr OpenType
+  | OLam OpenBinder OpenExpr
+  | OTyLam OpenBinder OpenExpr
+  | OLet OpenBind OpenExpr
+  | ORec [OpenBind] OpenExpr
+  | OCase OpenExpr OpenBinder [OpenAlt]
+  | OCast OpenExpr OpenCoercion
+  deriving (Eq, Show)
+
+data OpenBind = OpenBind OpenBinder OpenExpr
+  deriving (Eq, Show)
+
+data OpenAlt = OpenAlt AltCon [OpenBinder] OpenExpr
+  deriving (Eq, Show)
+
+data OpenCoercion
+  = OCoVar Name
+  | OCoRefl OpenType
+  | OCoSym OpenCoercion
+  | OCoTrans OpenCoercion OpenCoercion
+  | OCoTyConApp Name [OpenCoercion]
+  | OCoAxiom Name [OpenType]
+  deriving (Eq, Show)
+
+declaration :: ScopeTable -> Parser OpenDecl
+declaration scopes =
+  MP.choice
+    [ MP.try (typeOrSynonym scopes),
+      MP.try (axiomDeclaration scopes),
+      MP.try (primDeclaration scopes),
+      valDeclaration scopes
+    ]
+
+typeOrSynonym :: ScopeTable -> Parser OpenDecl
+typeOrSynonym scopes = do
+  vis <- optionalPub
+  _ <- keyword "type"
+  name <- topName scopes SortTypeConstructor
+  binders <- MP.many openPiBinder
+  _ <- symbol "::"
+  result <- fcType
+  roles <- MP.option [] roleList
+  MP.choice
+    [ do
+        _ <- symbol "="
+        OpenSynonymDecl vis name binders result <$> fcType,
+      do
+        constructors <- constructorBlock scopes
+        pure (OpenTypeDecl vis name binders result roles constructors)
+    ]
+
+constructorBlock :: ScopeTable -> Parser [OpenCon]
+constructorBlock scopes = braces (MP.many (constructorDecl scopes))
+
+constructorDecl :: ScopeTable -> Parser OpenCon
+constructorDecl scopes = do
+  vis <- optionalPub
+  name <- topName scopes SortDataConstructor
+  _ <- symbol "::"
+  OpenConDecl vis name <$> fcType
+
+axiomDeclaration :: ScopeTable -> Parser OpenDecl
+axiomDeclaration scopes = do
+  vis <- optionalPub
+  _ <- keyword "axiom"
+  name <- topName scopes SortAxiom
+  binders <- MP.option [] (MP.try (MP.some openPiBinder))
+  _ <- symbol ":"
+  left <- fcType
+  role <- parseAxiomRole
+  OpenAxiomDecl vis name binders role left <$> fcType
+
+primDeclaration :: ScopeTable -> Parser OpenDecl
+primDeclaration scopes = do
+  _ <- keyword "foreign"
+  _ <- keyword "import"
+  _ <- keyword "prim"
+  name <- topName scopes SortValue
+  _ <- symbol "::"
+  OpenPrimDecl Pub name <$> fcType
+
+valDeclaration :: ScopeTable -> Parser OpenDecl
+valDeclaration scopes = do
+  vis <- optionalPub
+  _ <- keyword "val"
+  name <- topName scopes SortValue
+  _ <- symbol "::"
+  ty <- fcType
+  _ <- symbol "="
+  OpenValDecl vis name ty <$> expression
+
+optionalPub :: Parser Vis
+optionalPub = MP.option Private (keyword "pub" $> Pub)
+
+roleList :: Parser [Role]
+roleList = MP.some (symbol "@" *> roleTag)
+
+roleTag :: Parser Role
+roleTag =
+  MP.choice
+    [ symbol "N" $> Nominal,
+      symbol "R" $> Representational,
+      symbol "P" $> Phantom
+    ]
+
+parseAxiomRole :: Parser Role
+parseAxiomRole =
+  MP.choice
+    [ symbol "~N" $> Nominal,
+      symbol "~R" $> Representational,
+      symbol "~P" $> Phantom
+    ]
+
+fcType :: Parser OpenType
+fcType = forallType
+
+forallType :: Parser OpenType
+forallType =
+  MP.choice
+    [ do
+        _ <- symbol "∀"
+        binders <- MP.some openPiBinder
+        _ <- symbol "."
+        body <- forallType
+        pure (foldr (\(OpenBinder name kind) -> OpenForAll name kind) body binders),
+      funType
+    ]
+
+funType :: Parser OpenType
+funType = do
+  left <- eqType
+  MP.option left $ do
+    _ <- symbol "→" <|> symbol "->"
+    OpenFun left <$> funType
+
+eqType :: Parser OpenType
+eqType = do
+  left <- appType
+  MP.option left $ do
+    _ <- symbol "~"
+    OpenEq left <$> appType
+
+appType :: Parser OpenType
+appType = do
+  explicit <- MP.optional (MP.try explicitFun)
+  case explicit of
+    Just ty -> pure ty
+    Nothing -> do
+      function <- typeAtom
+      arguments <- MP.many typeAtom
+      pure (foldl OpenApp function arguments)
+
+explicitFun :: Parser OpenType
+explicitFun = do
+  _ <- keyword "FUN"
+  r1 <- symbol "@" *> typeAtom
+  r2 <- symbol "@" *> typeAtom
+  argument <- typeAtom
+  OpenExplicit . TyFun (demandType r1) (demandType r2) (demandType argument) . demandType <$> typeAtom
+
+demandType :: OpenType -> Type
+demandType open =
+  case open of
+    OpenVar name -> TyVar name
+    OpenCon name -> TyCon name
+    OpenApp function argument -> TyApp (demandType function) (demandType argument)
+    OpenFun argument result ->
+      TyFun (demandType argument) (demandType result) (demandType argument) (demandType result)
+    OpenForAll name kind body ->
+      TyForAll (Binder name (demandType kind)) (demandType body)
+    OpenEq left right -> TyEq (demandType left) (demandType right)
+    OpenExplicit ty -> ty
+
+typeAtom :: Parser OpenType
+typeAtom =
+  MP.choice
+    [ parens fcType,
+      OpenVar <$> MP.try typeLocalName,
+      OpenCon <$> topNameWithSort
+    ]
+
+reservedWords :: [Text]
+reservedWords =
+  [ "pub",
+    "val",
+    "type",
+    "axiom",
+    "foreign",
+    "import",
+    "prim",
+    "module",
+    "where",
+    "let",
+    "rec",
+    "in",
+    "case",
+    "as",
+    "of",
+    "FUN",
+    "refl",
+    "sym",
+    "trans",
+    "tycon-co",
+    "axiom-co"
+  ]
+
+openPiBinder :: Parser OpenBinder
+openPiBinder = parens $ do
+  name <- localBinderName SortTypeVariable
+  _ <- symbol ":"
+  OpenBinder name <$> fcType
+
+expression :: Parser OpenExpr
+expression =
+  MP.choice
+    [ lambdaExpr,
+      typeLambdaExpr,
+      letExpr,
+      recExpr,
+      caseExpr,
+      castOrApp
+    ]
+
+lambdaExpr :: Parser OpenExpr
+lambdaExpr = do
+  _ <- symbol "λ"
+  binder <- openTermBinder SortValue
+  _ <- symbol "."
+  OLam binder <$> expression
+
+typeLambdaExpr :: Parser OpenExpr
+typeLambdaExpr = do
+  _ <- symbol "Λ"
+  binder <- openTermBinder SortTypeVariable
+  _ <- symbol "."
+  OTyLam binder <$> expression
+
+openTermBinder :: Sort -> Parser OpenBinder
+openTermBinder sort = parens $ do
+  name <- localBinderName sort
+  _ <- symbol ":"
+  OpenBinder name <$> fcType
+
+letExpr :: Parser OpenExpr
+letExpr = do
+  _ <- keyword "let"
+  bind <- braces openBind
+  _ <- keyword "in"
+  OLet bind <$> expression
+
+recExpr :: Parser OpenExpr
+recExpr = do
+  _ <- keyword "rec"
+  binds <- braces (MP.sepBy openBind (symbol ";"))
+  _ <- keyword "in"
+  ORec binds <$> expression
+
+openBind :: Parser OpenBind
+openBind = do
+  name <- localBinderName SortValue
+  _ <- symbol ":"
+  ty <- fcType
+  _ <- symbol "="
+  OpenBind (OpenBinder name ty) <$> expression
+
+caseExpr :: Parser OpenExpr
+caseExpr = do
+  _ <- keyword "case"
+  scrutinee <- expression
+  _ <- keyword "as"
+  binder <- openTermBinder SortValue
+  _ <- keyword "of"
+  alts <- braces (MP.sepBy caseAlt (symbol ";"))
+  pure (OCase scrutinee binder alts)
+
+caseAlt :: Parser OpenAlt
+caseAlt =
+  MP.choice
+    [ do
+        _ <- symbol "_"
+        _ <- symbol "→" <|> symbol "->"
+        OpenAlt AltDefault [] <$> expression,
+      do
+        constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort)
+        binders <- MP.many (openTermBinder SortValue)
+        _ <- symbol "→" <|> symbol "->"
+        OpenAlt constructor binders <$> expression
+    ]
+
+castOrApp :: Parser OpenExpr
+castOrApp = do
+  function <- appExpr
+  MP.option function $ do
+    _ <- symbol "▷"
+    OCast function <$> coercion
+
+appExpr :: Parser OpenExpr
+appExpr = do
+  function <- exprAtom
+  rest <- MP.many appArgument
+  pure (foldl applyArg function rest)
+  where
+    applyArg function argument =
+      case argument of
+        Left ty -> OTyApp function ty
+        Right expr -> OApp function expr
+
+appArgument :: Parser (Either OpenType OpenExpr)
+appArgument =
+  MP.choice
+    [ Left <$> (symbol "@" *> typeAtom),
+      Right <$> exprAtom
+    ]
+
+exprAtom :: Parser OpenExpr
+exprAtom =
+  MP.choice
+    [ parens expression,
+      OLit <$> MP.try literal,
+      OVar <$> MP.try localName,
+      OVar <$> topNameWithSort
+    ]
+
+coercion :: Parser OpenCoercion
+coercion =
+  MP.choice
+    [ do
+        _ <- keyword "refl"
+        OCoRefl <$> typeAtom,
+      do
+        _ <- keyword "sym"
+        OCoSym <$> parens coercion,
+      do
+        _ <- keyword "trans"
+        left <- parens coercion
+        right <- parens coercion
+        pure (OCoTrans left right),
+      do
+        _ <- keyword "tycon-co"
+        name <- topNameWithSort
+        arguments <- MP.many (parens coercion)
+        pure (OCoTyConApp name arguments),
+      do
+        _ <- keyword "axiom-co"
+        name <- topNameWithSort
+        arguments <- MP.many (symbol "@" *> typeAtom)
+        pure (OCoAxiom name arguments),
+      OCoVar <$> localName
+    ]
+
+literal :: Parser Literal
+literal =
+  MP.choice
+    [ MP.try hashedLiteral,
+      LitString <$> stringLiteral
+    ]
+
+hashedLiteral :: Parser Literal
+hashedLiteral =
+  MP.choice
+    [ do
+        value <- integerLiteral
+        _ <- MPC.char '#'
+        representation <- representationType
+        pure (LitInt representation value),
+      do
+        value <- charLiteral
+        _ <- MPC.char '#'
+        representation <- representationType
+        pure (LitChar representation value),
+      do
+        value <- stringLiteral
+        _ <- MPC.char '#'
+        representation <- representationType
+        case representationName representation of
+          Just name
+            | nameText name == "AddrRep" ->
+                pure (LitAddr representation (TE.encodeUtf8 value))
+          _ -> fail "address literal representation must be AddrRep"
+    ]
+
+representationType :: Parser Type
+representationType = do
+  name <- MP.try localName <|> topNameWithSort
+  pure (TyCon name)
+
+representationName :: Type -> Maybe Name
+representationName ty =
+  case ty of
+    TyCon name -> Just name
+    _ -> Nothing
+
+topNameWithSort :: Parser Name
+topNameWithSort = do
+  scopes <- ask
+  topName scopes SortValue
+
+topName :: ScopeTable -> Sort -> Parser Name
+topName scopes defaultSort = lexeme $ do
+  scopeId <- L.decimal
+  _ <- MPC.char '.'
+  (printed, sort) <- printedName defaultSort
+  case lookupScope scopeId scopes of
+    Just (package, moduleName) -> pure (Name printed sort (OriginTop package moduleName))
+    Nothing -> fail ("unknown scope " <> show scopeId)
+
+printedName :: Sort -> Parser (Text, Sort)
+printedName defaultSort =
+  MP.choice
+    [ do
+        prefix <- MP.optional (MP.satisfy (\character -> character == 't' || character == 'v'))
+        raw <- rawName
+        let sort =
+              case prefix of
+                Just 't' -> SortTypeConstructor
+                Just 'v' -> SortValue
+                _ | "$ax$" `T.isPrefixOf` raw -> SortAxiom
+                _ -> defaultSort
+        pure (raw, sort)
+    ]
+
+rawName :: Parser Text
+rawName =
+  MP.choice
+    [ "[]" <$ MPC.string "[]",
+      MP.try identName,
+      operatorName
+    ]
+
+identName :: Parser Text
+identName = do
+  first <- MP.satisfy identStart
+  rest <- MP.many (MP.satisfy identContinue)
+  let value = T.pack (first : rest)
+  following <- MP.optional (MP.lookAhead MP.anySingle)
+  case following of
+    Just next
+      | first == '$' && next `elem` operatorNameCharacters -> fail "operator"
+    _
+      | value `elem` reservedWords -> fail "reserved word"
+      | otherwise -> pure value
+
+operatorName :: Parser Text
+operatorName = do
+  value <- T.pack <$> MP.some (MP.satisfy (`elem` operatorNameCharacters))
+  if value `elem` reservedOperators
+    then fail "reserved operator"
+    else pure value
+
+reservedOperators :: [Text]
+reservedOperators = ["=", "::", "→", "->", "~", "@", "▷", "|"]
+
+localName :: Parser Name
+localName = lexeme $ do
+  text <- rawName
+  unique <- MP.option 0 bracesInt
+  pure (Name text SortValue (OriginLocal (Unique unique)))
+
+typeLocalName :: Parser Name
+typeLocalName = lexeme $ do
+  text <- rawName
+  unique <- MP.option 0 bracesInt
+  pure (Name text SortTypeVariable (OriginLocal (Unique unique)))
+
+localBinderName :: Sort -> Parser Name
+localBinderName sort = lexeme $ do
+  text <- rawName
+  unique <- MP.option 0 bracesInt
+  pure (Name text sort (OriginLocal (Unique unique)))
+
+bracesInt :: Parser Int
+bracesInt = do
+  _ <- MPC.char '{'
+  value <- L.decimal
+  _ <- MPC.char '}'
+  pure value
+
+fillProgram :: ScopeTable -> ModuleId -> [OpenDecl] -> Parser Program
+fillProgram scopes moduleId openDecls =
+  case fillDecls scopes openDecls of
+    Left message -> fail message
+    Right decls -> pure (normalizeProgram (Program moduleId scopes decls))
+
+fillDecls :: ScopeTable -> [OpenDecl] -> Either String [Decl]
+fillDecls scopes openDecls = do
+  let headers = collectHeaders scopes openDecls
+  mapM (fillDecl headers) openDecls
+
+collectHeaders :: ScopeTable -> [OpenDecl] -> TypeEnv
+collectHeaders scopes =
+  foldl add empty {tePrimPackage = primPackageFromScopes scopes}
+  where
+    empty = emptyTypeEnv
+    add env decl =
+      case decl of
+        OpenTypeDecl _ name binders result _ _
+          | Right closedBinders <- mapM (closeBinder env) binders,
+            Right closed <- closeType (extendBinders env closedBinders) result ->
+              env {teHeaders = Map.insert name (headerType closedBinders closed) (teHeaders env)}
+        OpenSynonymDecl _ name binders result body
+          | Right closedBinders <- mapM (closeBinder env) binders,
+            Right closedResult <- closeType (extendBinders env closedBinders) result,
+            Right closedBody <- closeType (extendBinders env closedBinders) body ->
+              env
+                { teHeaders = Map.insert name (headerType closedBinders closedResult) (teHeaders env),
+                  teSynonyms = Map.insert name (foldr TyForAll closedBody closedBinders) (teSynonyms env)
+                }
+        _ -> env
+
+fillDecl :: TypeEnv -> OpenDecl -> Either String Decl
+fillDecl env decl =
+  case decl of
+    OpenTypeDecl vis name binders result roles constructors -> do
+      closedBinders <- mapM (closeBinder env) binders
+      let binderEnv = extendBinders env closedBinders
+      closedResult <- closeType binderEnv result
+      closedCons <- mapM (fillCon binderEnv) constructors
+      pure (DeclType (TypeDecl vis name closedBinders closedResult roles closedCons))
+    OpenSynonymDecl vis name binders result body -> do
+      closedBinders <- mapM (closeBinder env) binders
+      let binderEnv = extendBinders env closedBinders
+      closedResult <- closeType binderEnv result
+      closedBody <- closeType binderEnv body
+      pure (DeclSynonym (SynonymDecl vis name closedBinders closedResult closedBody))
+    OpenAxiomDecl vis name binders role left right -> do
+      closedBinders <- mapM (closeBinder env) binders
+      let binderEnv = extendBinders env closedBinders
+      closedLeft <- closeType binderEnv left
+      closedRight <- closeType binderEnv right
+      pure (DeclAxiom (AxiomDecl vis name closedBinders role closedLeft closedRight))
+    OpenValDecl vis name ty body -> do
+      closedType <- closeType env ty
+      closedBody <- fillExpr env body
+      pure (DeclVal (ValDecl vis name closedType closedBody))
+    OpenPrimDecl vis name ty -> do
+      closedType <- closeType env ty
+      pure (DeclPrim (PrimDecl vis name closedType))
+
+fillCon :: TypeEnv -> OpenCon -> Either String ConDecl
+fillCon env (OpenConDecl vis name ty) = do
+  closed <- closeType env ty
+  pure (ConDecl vis name closed)
+
+fillExpr :: TypeEnv -> OpenExpr -> Either String Expr
+fillExpr env expr =
+  case expr of
+    OVar name -> Right (ExVar name)
+    OLit literalValue -> Right (ExLit literalValue)
+    OApp function argument -> ExApp <$> fillExpr env function <*> fillExpr env argument
+    OTyApp function ty -> ExTyApp <$> fillExpr env function <*> closeType env ty
+    OLam binder body -> do
+      closedBinder <- closeBinder env binder
+      ExLam closedBinder <$> fillExpr (extend env closedBinder) body
+    OTyLam binder body -> do
+      closedBinder <- closeBinder env binder
+      ExTyLam closedBinder <$> fillExpr (extend env closedBinder) body
+    OLet (OpenBind binder rhs) body -> do
+      closedBinder <- closeBinder env binder
+      (ExLet . Bind closedBinder <$> fillExpr env rhs) <*> fillExpr (extend env closedBinder) body
+    ORec binds body -> do
+      closedBinders <- mapM (\(OpenBind binder _) -> closeBinder env binder) binds
+      let recEnv = extendBinders env closedBinders
+      ExRec
+        <$> zipWithM
+          ( \(OpenBind _ rhs) closedBinder ->
+              Bind closedBinder <$> fillExpr recEnv rhs
+          )
+          binds
+          closedBinders
+        <*> fillExpr recEnv body
+    OCase scrutinee binder alts -> do
+      closedBinder <- closeBinder env binder
+      ExCase
+        <$> fillExpr env scrutinee
+        <*> pure closedBinder
+        <*> mapM (fillAlt (extend env closedBinder)) alts
+    OCast body coercionValue -> ExCast <$> fillExpr env body <*> fillCoercion env coercionValue
+
+fillAlt :: TypeEnv -> OpenAlt -> Either String Alt
+fillAlt env (OpenAlt con binders rhs) = do
+  closedBinders <- mapM (closeBinder env) binders
+  closed <- fillExpr (extendBinders env closedBinders) rhs
+  pure (Alt con closedBinders closed)
+
+fillCoercion :: TypeEnv -> OpenCoercion -> Either String Coercion
+fillCoercion env coercionValue =
+  case coercionValue of
+    OCoVar name -> Right (CoVar name)
+    OCoRefl ty -> CoRefl <$> closeType env ty
+    OCoSym inner -> CoSym <$> fillCoercion env inner
+    OCoTrans left right -> CoTrans <$> fillCoercion env left <*> fillCoercion env right
+    OCoTyConApp name arguments -> CoTyConApp name <$> mapM (fillCoercion env) arguments
+    OCoAxiom name arguments -> CoAxiom name <$> mapM (closeType env) arguments
+
+closeBinder :: TypeEnv -> OpenBinder -> Either String Binder
+closeBinder env (OpenBinder name ty) = Binder name <$> closeType env ty
+
+extend :: TypeEnv -> Binder -> TypeEnv
+extend env binder =
+  env {teBinders = Map.insert (binderName binder) (binderType binder) (teBinders env)}
+
+extendBinders :: TypeEnv -> [Binder] -> TypeEnv
+extendBinders = foldl extend
+
+normalizeProgram :: Program -> Program
+normalizeProgram parsed =
+  parsed {programDecls = map (normalizeDecl table) (programDecls parsed)}
+  where
+    table = declaredSorts (programScopes parsed) (programDecls parsed)
+
+declaredSorts :: ScopeTable -> [Decl] -> Map.Map Name Sort
+declaredSorts scopes decls =
+  Map.fromList (wired ++ concatMap declSorts decls)
+  where
+    wired =
+      case primPackageFromScopes scopes of
+        Nothing -> []
+        Just package ->
+          [ (Name "Type" SortTypeConstructor (OriginTop package "GHC.Types"), SortSynonym),
+            (Name "LiftedRep" SortTypeConstructor (OriginTop package "GHC.Types"), SortSynonym),
+            (Name "UnliftedRep" SortTypeConstructor (OriginTop package "GHC.Types"), SortSynonym)
+          ]
+    declSorts decl =
+      case decl of
+        DeclType typeDecl ->
+          (typeName typeDecl, SortTypeConstructor)
+            : [(conName constructor, SortDataConstructor) | constructor <- typeCons typeDecl]
+        DeclSynonym synonymDecl -> [(synName synonymDecl, SortSynonym)]
+        DeclAxiom axiomDecl -> [(axiomName axiomDecl, SortAxiom)]
+        DeclVal valDecl -> [(valName valDecl, SortValue)]
+        DeclPrim primDecl -> [(primName primDecl, SortValue)]
+
+normalizeDecl :: Map.Map Name Sort -> Decl -> Decl
+normalizeDecl table decl =
+  case decl of
+    DeclType typeDecl ->
+      DeclType
+        typeDecl
+          { typeName = rewriteName table (typeName typeDecl),
+            typeBinders = map (normalizeBinder table) (typeBinders typeDecl),
+            typeResult = normalizeType table (typeResult typeDecl),
+            typeRoles = defaultRoles (typeBinders typeDecl) (typeRoles typeDecl),
+            typeCons = map (normalizeCon table) (typeCons typeDecl)
+          }
+    DeclSynonym synonymDecl ->
+      DeclSynonym
+        synonymDecl
+          { synName = rewriteName table (synName synonymDecl),
+            synBinders = map (normalizeBinder table) (synBinders synonymDecl),
+            synResult = normalizeType table (synResult synonymDecl),
+            synBody = normalizeType table (synBody synonymDecl)
+          }
+    DeclAxiom axiomDecl ->
+      DeclAxiom
+        axiomDecl
+          { axiomName = rewriteName table (axiomName axiomDecl),
+            axiomBinders = map (normalizeBinder table) (axiomBinders axiomDecl),
+            axiomLeft = normalizeType table (axiomLeft axiomDecl),
+            axiomRight = normalizeType table (axiomRight axiomDecl)
+          }
+    DeclVal valDecl ->
+      DeclVal
+        valDecl
+          { valName = rewriteName table (valName valDecl),
+            valType = normalizeType table (valType valDecl),
+            valBody = normalizeExpr table (valBody valDecl)
+          }
+    DeclPrim primDecl ->
+      DeclPrim
+        primDecl
+          { primName = rewriteName table (primName primDecl),
+            primType = normalizeType table (primType primDecl)
+          }
+
+defaultRoles :: [Binder] -> [Role] -> [Role]
+defaultRoles binders roles
+  | null roles && not (null binders) = replicate (length binders) Representational
+  | otherwise = roles
+
+normalizeCon :: Map.Map Name Sort -> ConDecl -> ConDecl
+normalizeCon table conDecl =
+  conDecl
+    { conName = rewriteName table (conName conDecl),
+      conType = normalizeType table (conType conDecl)
+    }
+
+normalizeBinder :: Map.Map Name Sort -> Binder -> Binder
+normalizeBinder table binder =
+  binder
+    { binderName = rewriteName table (binderName binder),
+      binderType = normalizeType table (binderType binder)
+    }
+
+normalizeType :: Map.Map Name Sort -> Type -> Type
+normalizeType table ty =
+  case ty of
+    TyVar name -> TyVar (rewriteName table name)
+    TyCon name -> TyCon (rewriteName table name)
+    TyApp function argument -> TyApp (normalizeType table function) (normalizeType table argument)
+    TyFun r1 r2 argument result ->
+      TyFun (normalizeType table r1) (normalizeType table r2) (normalizeType table argument) (normalizeType table result)
+    TyForAll binder body -> TyForAll (normalizeBinder table binder) (normalizeType table body)
+    TyEq left right -> TyEq (normalizeType table left) (normalizeType table right)
+
+normalizeExpr :: Map.Map Name Sort -> Expr -> Expr
+normalizeExpr table expr =
+  case expr of
+    ExVar name -> ExVar (rewriteName table name)
+    ExLit literalValue -> ExLit (normalizeLiteral table literalValue)
+    ExApp function argument -> ExApp (normalizeExpr table function) (normalizeExpr table argument)
+    ExTyApp function ty -> ExTyApp (normalizeExpr table function) (normalizeType table ty)
+    ExLam binder body -> ExLam (normalizeBinder table binder) (normalizeExpr table body)
+    ExTyLam binder body -> ExTyLam (normalizeBinder table binder) (normalizeExpr table body)
+    ExLet bind body -> ExLet (normalizeBind table bind) (normalizeExpr table body)
+    ExRec binds body -> ExRec (map (normalizeBind table) binds) (normalizeExpr table body)
+    ExCase scrutinee binder alts ->
+      ExCase (normalizeExpr table scrutinee) (normalizeBinder table binder) (map (normalizeAlt table) alts)
+    ExCast body coercionValue -> ExCast (normalizeExpr table body) (normalizeCoercion table coercionValue)
+
+normalizeBind :: Map.Map Name Sort -> Bind -> Bind
+normalizeBind table bind =
+  bind
+    { bindBinder = normalizeBinder table (bindBinder bind),
+      bindRhs = normalizeExpr table (bindRhs bind)
+    }
+
+normalizeAlt :: Map.Map Name Sort -> Alt -> Alt
+normalizeAlt table alternative =
+  alternative
+    { altCon = normalizeAltCon table (altCon alternative),
+      altBinders = map (normalizeBinder table) (altBinders alternative),
+      altRhs = normalizeExpr table (altRhs alternative)
+    }
+
+normalizeAltCon :: Map.Map Name Sort -> AltCon -> AltCon
+normalizeAltCon table alt =
+  case alt of
+    AltData name -> AltData (rewriteName table name)
+    AltLit literalValue -> AltLit (normalizeLiteral table literalValue)
+    AltDefault -> AltDefault
+
+normalizeLiteral :: Map.Map Name Sort -> Literal -> Literal
+normalizeLiteral table literalValue =
+  case literalValue of
+    LitInt representation value -> LitInt (normalizeType table representation) value
+    LitChar representation value -> LitChar (normalizeType table representation) value
+    LitString value -> LitString value
+    LitAddr representation value -> LitAddr (normalizeType table representation) value
+
+normalizeCoercion :: Map.Map Name Sort -> Coercion -> Coercion
+normalizeCoercion table coercionValue =
+  case coercionValue of
+    CoVar name -> CoVar (rewriteName table name)
+    CoRefl ty -> CoRefl (normalizeType table ty)
+    CoSym inner -> CoSym (normalizeCoercion table inner)
+    CoTrans left right -> CoTrans (normalizeCoercion table left) (normalizeCoercion table right)
+    CoTyConApp name arguments -> CoTyConApp (rewriteName table name) (map (normalizeCoercion table) arguments)
+    CoAxiom name arguments -> CoAxiom (rewriteName table name) (map (normalizeType table) arguments)
+
+rewriteName :: Map.Map Name Sort -> Name -> Name
+rewriteName table name =
+  case Map.lookup name table of
+    Just sort -> name {nameSort = sort}
+    Nothing -> name
+
+closeType :: TypeEnv -> OpenType -> Either String Type
+closeType env open =
+  case open of
+    OpenVar name -> Right (TyVar name)
+    OpenCon name -> Right (TyCon name)
+    OpenApp function argument -> TyApp <$> closeType env function <*> closeType env argument
+    OpenFun argument result -> do
+      closedArgument <- closeType env argument
+      closedResult <- closeType env result
+      case (repOf env closedArgument, repOf env closedResult) of
+        (Just r1, Just r2) -> Right (TyFun r1 r2 closedArgument closedResult)
+        _ -> Left "cannot rebuild RuntimeRep for implicit FUN"
+    OpenForAll name kind body -> do
+      closedKind <- closeType env kind
+      let binder = Binder name closedKind
+      TyForAll binder <$> closeType (extend env binder) body
+    OpenEq left right ->
+      TyEq <$> closeType env left <*> closeType env right
+    OpenExplicit ty -> Right ty
+
+-- Lexer
+
+space :: Parser ()
+space = lift (L.space MPC.space1 (L.skipLineComment "--") (L.skipBlockComment "{-" "-}"))
+
+lexeme :: Parser a -> Parser a
+lexeme parser = parser <* space
+
+symbol :: Text -> Parser Text
+symbol value = lexeme (MPC.string value)
+
+keyword :: Text -> Parser Text
+keyword value = lexeme $ do
+  _ <- MPC.string value
+  following <- MP.optional (MP.lookAhead MP.anySingle)
+  case following of
+    Just character
+      | identContinue character -> fail "keyword prefix"
+    _ -> pure value
+
+int :: Parser Int
+int = lexeme L.decimal
+
+integerLiteral :: Parser Integer
+integerLiteral = lexeme L.decimal
+
+stringLiteral :: Parser Text
+stringLiteral = lexeme $ do
+  _ <- MPC.char '"'
+  characters <- MP.many stringChar
+  _ <- MPC.char '"'
+  pure (T.pack characters)
+
+charLiteral :: Parser Char
+charLiteral = lexeme $ do
+  _ <- MPC.char '\''
+  character <- stringChar
+  _ <- MPC.char '\''
+  pure character
+
+stringChar :: Parser Char
+stringChar =
+  MP.choice
+    [ MP.satisfy (\character -> character /= '"' && character /= '\'' && character /= '\\'),
+      MPC.string "\\\\" $> '\\',
+      MPC.string "\\\"" $> '"',
+      MPC.string "\\'" $> '\'',
+      MPC.string "\\n" $> '\n'
+    ]
+
+qualifiedModuleName :: Parser Text
+qualifiedModuleName = lexeme $ do
+  first <- identName
+  rest <- MP.many (MPC.char '.' *> identName)
+  pure (T.intercalate "." (first : rest))
+
+parens :: Parser a -> Parser a
+parens = MP.between (symbol "(") (symbol ")")
+
+braces :: Parser a -> Parser a
+braces = MP.between (symbol "{") (symbol "}")
+
+identStart :: Char -> Bool
+identStart character = isAlpha character || character == '_' || character == '$'
+
+identContinue :: Char -> Bool
+identContinue character = isAlphaNum character || character `elem` ("_$#'" :: String)
+
+operatorNameCharacters :: [Char]
+operatorNameCharacters = "!#$%&*+./<=>?@\\^|-~:"

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -1,0 +1,389 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Human-readable System FC 2 text.
+module Aihc.Fc2.Pretty
+  ( renderProgram,
+    renderType,
+    renderExpr,
+  )
+where
+
+import Aihc.Fc2.Name
+import Aihc.Fc2.Syntax
+import Aihc.Fc2.TypeOf
+import Aihc.Resolve (PackageId (..), packageIdText)
+import Aihc.Tc.Types (Unique (..))
+import Data.ByteString qualified as BS
+import Data.Char (chr)
+import Data.List (intercalate)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+
+data Prec
+  = PrecAtom
+  | PrecApp
+  | PrecFun
+  | PrecEq
+  | PrecForAll
+  deriving (Eq, Ord)
+
+renderProgram :: Program -> String
+renderProgram program =
+  intercalate "\n\n" (filter (not . null) (renderScopes scopes : renderModule scopes (programModule program) : map (renderDecl env scopes Set.empty) (programDecls program)))
+  where
+    scopes = programScopes program
+    env = typeEnvFromProgram program
+
+renderScopes :: ScopeTable -> String
+renderScopes table =
+  intercalate "\n" [renderScopeEntry scopeId package moduleName | (scopeId, package, moduleName) <- scopeEntries table]
+
+renderScopeEntry :: Int -> PackageId -> Text -> String
+renderScopeEntry scopeId package moduleName =
+  "scope " <> show scopeId <> " = " <> show (T.unpack (packageIdText package)) <> " " <> T.unpack moduleName
+
+renderModule :: ScopeTable -> ModuleId -> String
+renderModule scopes moduleId =
+  "module " <> scopePrefix scopes (modulePackage moduleId) (moduleName moduleId) <> T.unpack (moduleName moduleId) <> " where"
+
+renderDecl :: TypeEnv -> ScopeTable -> Set Text -> Decl -> String
+renderDecl env scopes seen decl =
+  case decl of
+    DeclType declaration -> renderTypeDecl env scopes seen declaration
+    DeclSynonym declaration -> renderSynonymDecl env scopes seen declaration
+    DeclAxiom declaration -> renderAxiomDecl env scopes seen declaration
+    DeclVal declaration -> renderValDecl env scopes seen declaration
+    DeclPrim declaration -> renderPrimDecl env scopes seen declaration
+
+renderVis :: Vis -> String
+renderVis Pub = "pub "
+renderVis Private = ""
+
+renderTypeDecl :: TypeEnv -> ScopeTable -> Set Text -> TypeDecl -> String
+renderTypeDecl env scopes seen declaration =
+  renderVis (typeVis declaration)
+    <> "type "
+    <> renderTopName scopes (typeName declaration)
+    <> renderHeaderBinders env scopes seen (typeBinders declaration)
+    <> " :: "
+    <> renderTypeWith (headerBinderEnv env (typeBinders declaration)) scopes seen PrecForAll (typeResult declaration)
+    <> renderRoleList (typeRoles declaration)
+    <> renderConstructors env scopes seen (typeCons declaration)
+
+renderHeaderBinders :: TypeEnv -> ScopeTable -> Set Text -> [Binder] -> String
+renderHeaderBinders env scopes seen =
+  concatMap ((" " <>) . renderPiBinder env scopes seen)
+
+renderConstructors :: TypeEnv -> ScopeTable -> Set Text -> [ConDecl] -> String
+renderConstructors _ _ _ [] = " {}"
+renderConstructors env scopes seen constructors =
+  " {\n"
+    <> intercalate "\n" (map (renderConDecl env scopes seen) constructors)
+    <> "\n}"
+
+renderConDecl :: TypeEnv -> ScopeTable -> Set Text -> ConDecl -> String
+renderConDecl env scopes seen declaration =
+  "    "
+    <> renderVis (conVis declaration)
+    <> renderTopName scopes (conName declaration)
+    <> " :: "
+    <> renderTypeWith env scopes seen PrecForAll (conType declaration)
+
+renderSynonymDecl :: TypeEnv -> ScopeTable -> Set Text -> SynonymDecl -> String
+renderSynonymDecl env scopes seen declaration =
+  renderVis (synVis declaration)
+    <> "type "
+    <> renderTopName scopes (synName declaration)
+    <> renderHeaderBinders env scopes seen (synBinders declaration)
+    <> " :: "
+    <> renderTypeWith (headerBinderEnv env (synBinders declaration)) scopes seen PrecForAll (synResult declaration)
+    <> " =\n "
+    <> renderTypeWith (headerBinderEnv env (synBinders declaration)) scopes seen PrecForAll (synBody declaration)
+
+renderAxiomDecl :: TypeEnv -> ScopeTable -> Set Text -> AxiomDecl -> String
+renderAxiomDecl env scopes seen declaration =
+  renderVis (axiomVis declaration)
+    <> "axiom "
+    <> renderTopName scopes (axiomName declaration)
+    <> renderForAllBinders env scopes seen (axiomBinders declaration)
+    <> " : "
+    <> renderTypeWith binderEnv scopes seen PrecForAll (axiomLeft declaration)
+    <> " "
+    <> renderAxiomRole (axiomRole declaration)
+    <> " "
+    <> renderTypeWith binderEnv scopes seen PrecForAll (axiomRight declaration)
+  where
+    binderEnv = headerBinderEnv env (axiomBinders declaration)
+
+renderForAllBinders :: TypeEnv -> ScopeTable -> Set Text -> [Binder] -> String
+renderForAllBinders _ _ _ [] = ""
+renderForAllBinders env scopes seen binders =
+  " " <> unwords (map (renderPiBinder env scopes seen) binders)
+
+renderAxiomRole :: Role -> String
+renderAxiomRole Nominal = "~N"
+renderAxiomRole Representational = "~R"
+renderAxiomRole Phantom = "~P"
+
+renderRoleList :: [Role] -> String
+renderRoleList roles
+  | all (== Representational) roles = ""
+  | otherwise = concatMap ((" @" <>) . renderRoleTag) roles
+
+renderRoleTag :: Role -> String
+renderRoleTag Nominal = "N"
+renderRoleTag Representational = "R"
+renderRoleTag Phantom = "P"
+
+renderValDecl :: TypeEnv -> ScopeTable -> Set Text -> ValDecl -> String
+renderValDecl env scopes seen declaration =
+  renderVis (valVis declaration)
+    <> "val "
+    <> renderTopName scopes (valName declaration)
+    <> " :: "
+    <> renderTypeWith env scopes seen PrecForAll (valType declaration)
+    <> "\n = "
+    <> renderExprWith env scopes seen 0 (valBody declaration)
+
+renderPrimDecl :: TypeEnv -> ScopeTable -> Set Text -> PrimDecl -> String
+renderPrimDecl env scopes seen declaration =
+  "foreign import prim "
+    <> renderTopName scopes (primName declaration)
+    <> " :: "
+    <> renderTypeWith env scopes seen PrecForAll (primType declaration)
+
+renderType :: Program -> Type -> String
+renderType program =
+  renderTypeWith (typeEnvFromProgram program) (programScopes program) Set.empty PrecForAll
+
+renderTypeWith :: TypeEnv -> ScopeTable -> Set Text -> Prec -> Type -> String
+renderTypeWith env scopes seen prec ty =
+  case ty of
+    TyVar name -> renderName scopes seen name
+    TyCon name -> renderName scopes seen name
+    TyApp function argument ->
+      paren (prec < PrecApp) (renderTypeWith env scopes seen PrecApp function <> " " <> renderTypeWith env scopes seen PrecAtom argument)
+    TyFun r1 r2 argument result
+      | canHideFun env argument result r1 r2 ->
+          paren (prec < PrecFun) (renderTypeWith env scopes seen PrecApp argument <> " → " <> renderTypeWith env scopes seen PrecFun result)
+      | otherwise ->
+          paren
+            (prec < PrecApp)
+            ( "FUN @"
+                <> renderTypeWith env scopes seen PrecAtom r1
+                <> " @"
+                <> renderTypeWith env scopes seen PrecAtom r2
+                <> " "
+                <> renderTypeWith env scopes seen PrecAtom argument
+                <> " "
+                <> renderTypeWith env scopes seen PrecAtom result
+            )
+    TyForAll binder body ->
+      let nextSeen = bindText seen binder
+          env' = extendPrettyEnv env binder
+       in paren
+            (prec < PrecForAll)
+            ( "∀"
+                <> renderPiBinder env scopes seen binder
+                <> forallTail env' scopes nextSeen body
+            )
+    TyEq left right ->
+      paren (prec < PrecEq) (renderTypeWith env scopes seen PrecApp left <> " ~ " <> renderTypeWith env scopes seen PrecApp right)
+
+forallTail :: TypeEnv -> ScopeTable -> Set Text -> Type -> String
+forallTail env scopes seen ty =
+  case ty of
+    TyForAll binder body ->
+      " " <> renderPiBinder env scopes seen binder <> forallTail (extendPrettyEnv env binder) scopes (bindText seen binder) body
+    _ -> ". " <> renderTypeWith env scopes seen PrecForAll ty
+
+renderPiBinder :: TypeEnv -> ScopeTable -> Set Text -> Binder -> String
+renderPiBinder env scopes seen binder =
+  "("
+    <> renderLocalBinder seen (binderName binder)
+    <> " : "
+    <> renderTypeWith env scopes seen PrecForAll (binderType binder)
+    <> ")"
+
+canHideFun :: TypeEnv -> Type -> Type -> Type -> Type -> Bool
+canHideFun env argument result r1 r2 =
+  case (repOf env argument, repOf env result) of
+    (Just left, Just right) -> left == r1 && right == r2
+    _ -> False
+
+extendPrettyEnv :: TypeEnv -> Binder -> TypeEnv
+extendPrettyEnv env binder =
+  env {teBinders = Map.insert (binderName binder) (binderType binder) (teBinders env)}
+
+headerBinderEnv :: TypeEnv -> [Binder] -> TypeEnv
+headerBinderEnv = foldl (\env binder -> env {teBinders = Map.insert (binderName binder) (binderType binder) (teBinders env)})
+
+renderExpr :: Program -> Expr -> String
+renderExpr program =
+  renderExprWith (typeEnvFromProgram program) (programScopes program) Set.empty 0
+
+renderExprWith :: TypeEnv -> ScopeTable -> Set Text -> Int -> Expr -> String
+renderExprWith env scopes seen indent expr =
+  case expr of
+    ExVar name -> renderName scopes seen name
+    ExLit literal -> renderLiteral scopes seen literal
+    ExApp function argument ->
+      renderApp env scopes seen indent function <> " " <> renderExprAtom env scopes seen indent argument
+    ExTyApp function argument ->
+      renderApp env scopes seen indent function <> " @" <> renderTypeWith env scopes seen PrecAtom argument
+    ExLam binder body ->
+      "λ" <> renderPiBinder env scopes seen binder <> ".\n" <> indentLine (indent + 1) (renderExprWith (extendPrettyEnv env binder) scopes (bindText seen binder) (indent + 1) body)
+    ExTyLam binder body ->
+      "Λ" <> renderPiBinder env scopes seen binder <> ".\n" <> indentLine (indent + 1) (renderExprWith (extendPrettyEnv env binder) scopes (bindText seen binder) (indent + 1) body)
+    ExLet bind body ->
+      "let {\n"
+        <> indentLine (indent + 2) (renderBind env scopes seen (indent + 2) bind)
+        <> "\n"
+        <> indentLine indent "} in\n"
+        <> indentLine (indent + 2) (renderExprWith (extendPrettyEnv env (bindBinder bind)) scopes (bindText seen (bindBinder bind)) (indent + 2) body)
+    ExRec binds body ->
+      "rec {\n"
+        <> intercalate ";\n" (map (indentLine (indent + 2) . renderBind recEnv scopes recSeen (indent + 2)) binds)
+        <> "\n"
+        <> indentLine indent "} in\n"
+        <> indentLine (indent + 2) (renderExprWith recEnv scopes recSeen (indent + 2) body)
+      where
+        recSeen = foldl bindText seen (map bindBinder binds)
+        recEnv = foldl extendPrettyEnv env (map bindBinder binds)
+    ExCase scrutinee binder alts ->
+      "case "
+        <> renderExprWith env scopes seen indent scrutinee
+        <> " as "
+        <> renderPiBinder env scopes seen binder
+        <> " of {\n"
+        <> intercalate ";\n" (map (indentLine (indent + 2) . renderAlt (extendPrettyEnv env binder) scopes (bindText seen binder) (indent + 2)) alts)
+        <> "\n"
+        <> indentLine indent "}"
+    ExCast body coercion ->
+      renderExprAtom env scopes seen indent body <> " ▷ " <> renderCoercion env scopes seen coercion
+
+renderApp :: TypeEnv -> ScopeTable -> Set Text -> Int -> Expr -> String
+renderApp env scopes seen indent expr =
+  case expr of
+    ExApp {} -> renderExprWith env scopes seen indent expr
+    ExTyApp {} -> renderExprWith env scopes seen indent expr
+    _ -> renderExprAtom env scopes seen indent expr
+
+renderExprAtom :: TypeEnv -> ScopeTable -> Set Text -> Int -> Expr -> String
+renderExprAtom env scopes seen indent expr =
+  case expr of
+    ExVar {} -> renderExprWith env scopes seen indent expr
+    ExLit {} -> renderExprWith env scopes seen indent expr
+    _ -> "(" <> renderExprWith env scopes seen indent expr <> ")"
+
+renderBind :: TypeEnv -> ScopeTable -> Set Text -> Int -> Bind -> String
+renderBind env scopes seen indent bind =
+  renderLocalBinder seen (binderName (bindBinder bind))
+    <> " : "
+    <> renderTypeWith env scopes seen PrecForAll (binderType (bindBinder bind))
+    <> " =\n"
+    <> indentLine (indent + 2) (renderExprWith env scopes (bindText seen (bindBinder bind)) (indent + 2) (bindRhs bind))
+
+renderAlt :: TypeEnv -> ScopeTable -> Set Text -> Int -> Alt -> String
+renderAlt env scopes seen indent alternative =
+  case altCon alternative of
+    AltDefault -> "_ →\n" <> indentLine (indent + 2) (renderExprWith env scopes seen (indent + 2) (altRhs alternative))
+    AltLit literal ->
+      renderLiteral scopes seen literal <> altBinderText <> " →\n" <> indentLine (indent + 2) (renderExprWith env scopes nextSeen (indent + 2) (altRhs alternative))
+    AltData name ->
+      renderName scopes seen name <> altBinderText <> " →\n" <> indentLine (indent + 2) (renderExprWith env scopes nextSeen (indent + 2) (altRhs alternative))
+  where
+    altBinderText = concatMap ((" " <>) . renderPiBinder env scopes seen) (altBinders alternative)
+    nextSeen = foldl bindText seen (altBinders alternative)
+
+renderCoercion :: TypeEnv -> ScopeTable -> Set Text -> Coercion -> String
+renderCoercion env scopes seen coercion =
+  case coercion of
+    CoVar name -> renderName scopes seen name
+    CoRefl ty -> "refl " <> renderTypeWith env scopes seen PrecAtom ty
+    CoSym inner -> "sym (" <> renderCoercion env scopes seen inner <> ")"
+    CoTrans left right -> "trans (" <> renderCoercion env scopes seen left <> ") (" <> renderCoercion env scopes seen right <> ")"
+    CoTyConApp name arguments ->
+      unwords ("tycon-co" : renderName scopes seen name : map (\argument -> "(" <> renderCoercion env scopes seen argument <> ")") arguments)
+    CoAxiom name arguments ->
+      unwords ("axiom-co" : renderName scopes seen name : map (\argument -> "@" <> renderTypeWith env scopes seen PrecAtom argument) arguments)
+
+renderLiteral :: ScopeTable -> Set Text -> Literal -> String
+renderLiteral scopes seen literal =
+  case literal of
+    LitInt representation value -> show value <> "#" <> renderName scopes seen (repName representation)
+    LitChar representation value -> show value <> "#" <> renderName scopes seen (repName representation)
+    LitString value -> show (T.unpack value)
+    LitAddr representation value -> show (map (chr . fromIntegral) (BS.unpack value)) <> "#" <> renderName scopes seen (repName representation)
+
+repName :: Type -> Name
+repName ty =
+  case ty of
+    TyCon name -> name
+    TyVar name -> name
+    _ -> Name "AddrRep" SortDataConstructor (OriginLocal (Unique 0))
+
+renderName :: ScopeTable -> Set Text -> Name -> String
+renderName scopes _seen name =
+  case nameOrigin name of
+    OriginLocal {} -> renderLocalUse name
+    OriginTop {} -> renderTopName scopes name
+
+renderTopName :: ScopeTable -> Name -> String
+renderTopName scopes name =
+  case nameOrigin name of
+    OriginTop package moduleName ->
+      scopePrefix scopes package moduleName <> printedName name
+    OriginLocal {} ->
+      printedName name
+
+scopePrefix :: ScopeTable -> PackageId -> Text -> String
+scopePrefix scopes package moduleName =
+  case lookupScopeId scopes package moduleName of
+    Just scopeId -> show scopeId <> "."
+    Nothing -> error ("missing System FC 2 scope for " <> show (packageIdText package, moduleName))
+
+lookupScopeId :: ScopeTable -> PackageId -> Text -> Maybe Int
+lookupScopeId table package moduleName =
+  lookup (package, moduleName) [((entryPackage, entryModule), scopeId) | (scopeId, entryPackage, entryModule) <- scopeEntries table]
+
+printedName :: Name -> String
+printedName name =
+  case nameClass (nameSort name) of
+    NameClassType -> "t" <> rawPrinted (nameText name)
+    NameClassValue -> "v" <> rawPrinted (nameText name)
+    NameClassAxiom -> T.unpack (nameText name)
+    NameClassTypeVar -> T.unpack (nameText name)
+
+rawPrinted :: Text -> String
+rawPrinted = T.unpack
+
+renderLocalBinder :: Set Text -> Name -> String
+renderLocalBinder seen name =
+  T.unpack (nameText name) <> uniqueSuffix True seen name
+
+renderLocalUse :: Name -> String
+renderLocalUse name =
+  T.unpack (nameText name) <> uniqueSuffix False Set.empty name
+
+uniqueSuffix :: Bool -> Set Text -> Name -> String
+uniqueSuffix isBinder seen name =
+  case nameOrigin name of
+    OriginLocal (Unique unique)
+      | unique /= 0 -> "{" <> show unique <> "}"
+      | isBinder && nameText name `Set.member` seen -> "{0}"
+      | otherwise -> ""
+    OriginTop {} -> ""
+
+bindText :: Set Text -> Binder -> Set Text
+bindText seen binder = Set.insert (nameText (binderName binder)) seen
+
+paren :: Bool -> String -> String
+paren False value = value
+paren True value = "(" <> value <> ")"
+
+indentLine :: Int -> String -> String
+indentLine count value = replicate (count * 2) ' ' <> value

--- a/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
@@ -1,0 +1,163 @@
+-- | System FC 2 abstract syntax.
+module Aihc.Fc2.Syntax
+  ( Type (..),
+    Binder (..),
+    Expr (..),
+    Bind (..),
+    Alt (..),
+    AltCon (..),
+    Literal (..),
+    Role (..),
+    Coercion (..),
+    Program (..),
+    Decl (..),
+    TypeDecl (..),
+    ConDecl (..),
+    SynonymDecl (..),
+    AxiomDecl (..),
+    ValDecl (..),
+    PrimDecl (..),
+  )
+where
+
+import Aihc.Fc2.Name
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+
+-- | A type. Kinds are types.
+data Type
+  = TyVar Name
+  | TyCon Name
+  | TyApp Type Type
+  | -- | @FUN r1 r2 a b@.
+    TyFun Type Type Type Type
+  | TyForAll Binder Type
+  | TyEq Type Type
+  deriving (Eq, Ord, Show, Read)
+
+data Binder = Binder
+  { binderName :: Name,
+    binderType :: Type
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data Expr
+  = ExVar Name
+  | ExLit Literal
+  | ExApp Expr Expr
+  | ExTyApp Expr Type
+  | ExLam Binder Expr
+  | ExTyLam Binder Expr
+  | ExLet Bind Expr
+  | ExRec [Bind] Expr
+  | ExCase Expr Binder [Alt]
+  | ExCast Expr Coercion
+  deriving (Eq, Ord, Show, Read)
+
+data Bind = Bind
+  { bindBinder :: Binder,
+    bindRhs :: Expr
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data Alt = Alt
+  { altCon :: AltCon,
+    altBinders :: [Binder],
+    altRhs :: Expr
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data AltCon
+  = AltData Name
+  | AltLit Literal
+  | AltDefault
+  deriving (Eq, Ord, Show, Read)
+
+-- | A literal. Integer, character, and address store the representation type.
+data Literal
+  = LitInt Type Integer
+  | LitChar Type Char
+  | LitString Text
+  | LitAddr Type ByteString
+  deriving (Eq, Ord, Show, Read)
+
+data Role
+  = Nominal
+  | Representational
+  | Phantom
+  deriving (Eq, Ord, Show, Read)
+
+data Coercion
+  = CoVar Name
+  | CoRefl Type
+  | CoSym Coercion
+  | CoTrans Coercion Coercion
+  | CoTyConApp Name [Coercion]
+  | CoAxiom Name [Type]
+  deriving (Eq, Ord, Show, Read)
+
+data Program = Program
+  { programModule :: ModuleId,
+    programScopes :: ScopeTable,
+    programDecls :: [Decl]
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data Decl
+  = DeclType TypeDecl
+  | DeclSynonym SynonymDecl
+  | DeclAxiom AxiomDecl
+  | DeclVal ValDecl
+  | DeclPrim PrimDecl
+  deriving (Eq, Ord, Show, Read)
+
+data TypeDecl = TypeDecl
+  { typeVis :: Vis,
+    typeName :: Name,
+    typeBinders :: [Binder],
+    typeResult :: Type,
+    typeRoles :: [Role],
+    typeCons :: [ConDecl]
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data ConDecl = ConDecl
+  { conVis :: Vis,
+    conName :: Name,
+    conType :: Type
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data SynonymDecl = SynonymDecl
+  { synVis :: Vis,
+    synName :: Name,
+    synBinders :: [Binder],
+    synResult :: Type,
+    synBody :: Type
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data AxiomDecl = AxiomDecl
+  { axiomVis :: Vis,
+    axiomName :: Name,
+    axiomBinders :: [Binder],
+    axiomRole :: Role,
+    axiomLeft :: Type,
+    axiomRight :: Type
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data ValDecl = ValDecl
+  { valVis :: Vis,
+    valName :: Name,
+    valType :: Type,
+    valBody :: Expr
+  }
+  deriving (Eq, Ord, Show, Read)
+
+data PrimDecl = PrimDecl
+  { primVis :: Vis,
+    primName :: Name,
+    primType :: Type
+  }
+  deriving (Eq, Ord, Show, Read)

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | typeOf and unfold tables for implicit FUN representations.
+module Aihc.Fc2.TypeOf
+  ( TypeEnv (..),
+    emptyTypeEnv,
+    typeEnvFromProgram,
+    typeOf,
+    unfoldType,
+    unfoldRep,
+    repOf,
+    headerType,
+    applyType,
+    lookupBinderType,
+  )
+where
+
+import Aihc.Fc2.Name
+import Aihc.Fc2.Syntax
+import Aihc.Fc2.Wired
+import Aihc.Resolve (PackageId)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+-- | Local headers, synonym bodies, and binder types used by typeOf.
+data TypeEnv = TypeEnv
+  { tePrimPackage :: Maybe PackageId,
+    teHeaders :: Map Name Type,
+    teSynonyms :: Map Name Type,
+    teBinders :: Map Name Type
+  }
+  deriving (Eq, Show)
+
+emptyTypeEnv :: TypeEnv
+emptyTypeEnv =
+  TypeEnv
+    { tePrimPackage = Nothing,
+      teHeaders = Map.empty,
+      teSynonyms = Map.empty,
+      teBinders = Map.empty
+    }
+
+typeEnvFromProgram :: Program -> TypeEnv
+typeEnvFromProgram program =
+  foldl addDecl baseEnv (programDecls program)
+  where
+    baseEnv =
+      emptyTypeEnv
+        { tePrimPackage = primPackageFromScopes (programScopes program)
+        }
+    addDecl env decl =
+      case decl of
+        DeclType declaration ->
+          env {teHeaders = Map.insert (typeName declaration) (headerType (typeBinders declaration) (typeResult declaration)) (teHeaders env)}
+        DeclSynonym declaration ->
+          env
+            { teHeaders = Map.insert (synName declaration) (headerType (synBinders declaration) (synResult declaration)) (teHeaders env),
+              teSynonyms = Map.insert (synName declaration) (foldr TyForAll (synBody declaration) (synBinders declaration)) (teSynonyms env)
+            }
+        DeclAxiom {} -> env
+        DeclVal {} -> env
+        DeclPrim {} -> env
+
+headerType :: [Binder] -> Type -> Type
+headerType binders result = foldr TyForAll result binders
+
+lookupBinderType :: TypeEnv -> Name -> Maybe Type
+lookupBinderType env name = Map.lookup name (teBinders env)
+
+typeOf :: TypeEnv -> Type -> Maybe Type
+typeOf env ty =
+  case ty of
+    TyVar name ->
+      Map.lookup name (teBinders env)
+    TyCon name ->
+      case Map.lookup name (teHeaders env) of
+        Just header -> Just header
+        Nothing -> wiredTypeOf env name
+    TyApp function argument ->
+      do
+        functionType <- typeOf env function
+        applyType functionType argument
+    TyFun {} ->
+      typeSynonym <$> tePrimPackage env
+    TyForAll binder body ->
+      typeOf (extendBinder env binder) body
+    TyEq {} ->
+      TyCon . constraintName <$> tePrimPackage env
+
+applyType :: Type -> Type -> Maybe Type
+applyType function argument =
+  case function of
+    TyForAll binder body ->
+      Just (substType (binderName binder) argument body)
+    TyFun _ _ _ result ->
+      Just result
+    _ ->
+      Nothing
+
+unfoldType :: TypeEnv -> Type -> Type
+unfoldType env ty =
+  case ty of
+    TyCon name
+      | isWiredName env name "Type",
+        Just representation <- liftedRepType env ->
+          typeAppTYPE env representation
+      | isWiredName env name "Constraint",
+        Just representation <- liftedRepType env ->
+          typeAppTYPE env representation
+      | Just body <- Map.lookup name (teSynonyms env) ->
+          unfoldType env (stripForAlls body)
+      | isWiredName env name "TYPE" -> ty
+      | isWiredName env name "RuntimeRep" -> ty
+      | isWiredName env name "Levity" -> ty
+      | otherwise -> ty
+    TyApp (TyCon name) argument
+      | isWiredName env name "TYPE" -> TyApp (TyCon name) argument
+      | otherwise -> ty
+    _ -> ty
+
+unfoldRep :: TypeEnv -> Type -> Type
+unfoldRep env ty =
+  case ty of
+    TyCon name
+      | isWiredName env name "LiftedRep",
+        Just package <- tePrimPackage env ->
+          TyApp (TyCon (boxedRepName package)) (TyCon (liftedName package))
+      | isWiredName env name "UnliftedRep",
+        Just package <- tePrimPackage env ->
+          TyApp (TyCon (boxedRepName package)) (TyCon (unliftedName package))
+      | otherwise -> ty
+    TyApp (TyCon name) argument
+      | isWiredName env name "BoxedRep" -> TyApp (TyCon name) argument
+      | otherwise -> ty
+    _ -> ty
+
+repOf :: TypeEnv -> Type -> Maybe Type
+repOf env ty = do
+  kind <- typeOf env ty
+  case unfoldType env kind of
+    TyApp (TyCon name) representation
+      | isWiredName env name "TYPE" -> Just representation
+    _ -> Nothing
+
+extendBinder :: TypeEnv -> Binder -> TypeEnv
+extendBinder env binder =
+  env {teBinders = Map.insert (binderName binder) (binderType binder) (teBinders env)}
+
+stripForAlls :: Type -> Type
+stripForAlls ty =
+  case ty of
+    TyForAll _ body -> stripForAlls body
+    _ -> ty
+
+substType :: Name -> Type -> Type -> Type
+substType target replacement = go
+  where
+    go ty =
+      case ty of
+        TyVar name
+          | name == target -> replacement
+          | otherwise -> ty
+        TyCon {} -> ty
+        TyApp function argument -> TyApp (go function) (go argument)
+        TyFun r1 r2 argument result -> TyFun (go r1) (go r2) (go argument) (go result)
+        TyForAll binder body
+          | binderName binder == target -> TyForAll binder {binderType = go (binderType binder)} body
+          | otherwise -> TyForAll binder {binderType = go (binderType binder)} (go body)
+        TyEq left right -> TyEq (go left) (go right)
+
+isWiredName :: TypeEnv -> Name -> Text -> Bool
+isWiredName env name expected =
+  case tePrimPackage env of
+    Nothing -> False
+    Just package ->
+      isGhcTypesOrigin package name && nameText name == expected
+
+wiredTypeOf :: TypeEnv -> Name -> Maybe Type
+wiredTypeOf env name =
+  case tePrimPackage env of
+    Nothing -> Nothing
+    Just package
+      | not (isGhcTypesOrigin package name) -> Nothing
+      | nameText name == "Type" -> Just (typeSynonym package)
+      | nameText name == "Constraint" -> Just (typeSynonym package)
+      | nameText name == "TYPE" ->
+          do
+            lifted <- liftedRepType env
+            Just (TyFun lifted lifted (TyCon (runtimeRepConstructor package)) (typeSynonym package))
+      | nameText name == "RuntimeRep" -> Just (typeSynonym package)
+      | nameText name == "Levity" -> Just (typeSynonym package)
+      | nameText name == "LiftedRep" -> Just (TyCon (runtimeRepConstructor package))
+      | nameText name == "UnliftedRep" -> Just (TyCon (runtimeRepConstructor package))
+      | otherwise -> Nothing
+
+typeAppTYPE :: TypeEnv -> Type -> Type
+typeAppTYPE env representation =
+  case tePrimPackage env of
+    Nothing -> representation
+    Just package -> TyApp (TyCon (typeConstructor package)) representation
+
+liftedRepType :: TypeEnv -> Maybe Type
+liftedRepType env =
+  TyCon . liftedRepName <$> tePrimPackage env

--- a/components/aihc-fc/src/Aihc/Fc2/Wired.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Wired.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Wired GHC.Types names for System FC 2.
+module Aihc.Fc2.Wired
+  ( wiredGhcTypes,
+    typeSynonym,
+    typeConstructor,
+    runtimeRepConstructor,
+    levityConstructor,
+    constraintName,
+    liftedRepName,
+    unliftedRepName,
+    boxedRepName,
+    liftedName,
+    unliftedName,
+    ghcTypesModule,
+    isGhcTypesOrigin,
+    primPackageFromScopes,
+  )
+where
+
+import Aihc.Fc2.Name
+import Aihc.Fc2.Syntax
+import Aihc.Resolve (PackageId (..))
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+
+ghcTypesModule :: Text
+ghcTypesModule = "GHC.Types"
+
+wiredGhcTypes :: PackageId -> Text -> Sort -> Name
+wiredGhcTypes package name sort =
+  Name name sort (OriginTop package ghcTypesModule)
+
+typeSynonym :: PackageId -> Type
+typeSynonym package =
+  TyCon (wiredGhcTypes package "Type" SortSynonym)
+
+typeConstructor :: PackageId -> Name
+typeConstructor package =
+  wiredGhcTypes package "TYPE" SortTypeConstructor
+
+runtimeRepConstructor :: PackageId -> Name
+runtimeRepConstructor package =
+  wiredGhcTypes package "RuntimeRep" SortTypeConstructor
+
+levityConstructor :: PackageId -> Name
+levityConstructor package =
+  wiredGhcTypes package "Levity" SortTypeConstructor
+
+constraintName :: PackageId -> Name
+constraintName package =
+  wiredGhcTypes package "Constraint" SortTypeConstructor
+
+liftedRepName :: PackageId -> Name
+liftedRepName package =
+  wiredGhcTypes package "LiftedRep" SortSynonym
+
+unliftedRepName :: PackageId -> Name
+unliftedRepName package =
+  wiredGhcTypes package "UnliftedRep" SortSynonym
+
+boxedRepName :: PackageId -> Name
+boxedRepName package =
+  wiredGhcTypes package "BoxedRep" SortDataConstructor
+
+liftedName :: PackageId -> Name
+liftedName package =
+  wiredGhcTypes package "Lifted" SortDataConstructor
+
+unliftedName :: PackageId -> Name
+unliftedName package =
+  wiredGhcTypes package "Unlifted" SortDataConstructor
+
+isGhcTypesOrigin :: PackageId -> Name -> Bool
+isGhcTypesOrigin package name =
+  case nameOrigin name of
+    OriginTop originPackage moduleName ->
+      originPackage == package && moduleName == ghcTypesModule
+    OriginLocal {} -> False
+
+-- | The package identity of the GHC.Types scope, if the table has one.
+primPackageFromScopes :: ScopeTable -> Maybe PackageId
+primPackageFromScopes table =
+  listToMaybe
+    [ package
+    | (_, package, moduleName) <- scopeEntries table,
+      moduleName == ghcTypesModule
+    ]

--- a/components/aihc-fc/test/Spec.hs
+++ b/components/aihc-fc/test/Spec.hs
@@ -4,6 +4,8 @@ import FcGolden (updateFcGoldens)
 import System.Environment (lookupEnv)
 import Test.Fc.Properties (fcPropertyTests)
 import Test.Fc.Suite (fcGoldenTests, fcLintTests)
+import Test.Fc2.Properties (fc2PropertyTests)
+import Test.Fc2.Suite (fc2FixtureTests)
 import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
@@ -13,4 +15,5 @@ main = do
     Just "1" -> updateFcGoldens
     _ -> do
       golden <- fcGoldenTests
-      defaultMain (testGroup "aihc-fc" [fcLintTests, golden, fcPropertyTests])
+      fc2 <- fc2FixtureTests
+      defaultMain (testGroup "aihc-fc" [fcLintTests, golden, fcPropertyTests, fc2, fc2PropertyTests])

--- a/components/aihc-fc/test/Test/Fc2/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc2/Properties.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Fc2.Properties
+  ( fc2PropertyTests,
+  )
+where
+
+import Aihc.Fc2
+import Aihc.Resolve (PackageId (..))
+import Aihc.Tc.Types (Unique (..))
+import Data.Text (Text)
+import Data.Text qualified as T
+import Hedgehog (Gen, Property, annotate, failure, forAll, property, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+fc2PropertyTests :: TestTree
+fc2PropertyTests =
+  testGroup
+    "SystemFC2 properties"
+    [ testProperty "parseProgram . renderProgram = id" prop_programRoundTrip,
+      testProperty "t prefix stores Bool" prop_prefixStrip,
+      testProperty "uses have no type suffix" prop_noUseTypes
+    ]
+
+prop_programRoundTrip :: Property
+prop_programRoundTrip = property $ do
+  program <- forAll genProgram
+  let printed = T.pack (renderProgram program)
+  annotate (T.unpack printed)
+  case parseProgram printed of
+    Left parseError -> do
+      annotate (renderParseError parseError)
+      failure
+    Right parsed -> parsed === program
+
+prop_prefixStrip :: Property
+prop_prefixStrip = property $ do
+  let printed = T.pack (renderProgram boolProgram)
+  annotate (T.unpack printed)
+  T.isInfixOf "1.tBool" printed === True
+  nameText (typeName (boolDecl boolProgram)) === "Bool"
+
+prop_noUseTypes :: Property
+prop_noUseTypes = property $ do
+  let printed = T.pack (renderProgram boolProgram)
+  annotate (T.unpack printed)
+  T.isInfixOf " : tycon" printed === False
+  T.isInfixOf ") : " printed === False
+
+boolDecl :: Program -> TypeDecl
+boolDecl program =
+  case programDecls program of
+    DeclType declaration : _ -> declaration
+    _ -> error "expected Bool type"
+
+boolProgram :: Program
+boolProgram = identityProgram
+
+primPackage :: PackageId
+primPackage = PackageId "aihc-prim"
+
+testPackage :: PackageId
+testPackage = PackageId ""
+
+scopes :: ScopeTable
+scopes =
+  insertScope 2 primPackage "GHC.Types" (insertScope 1 testPackage "Test" emptyScopeTable)
+
+typeNameTop :: Text -> Name
+typeNameTop text = Name text SortTypeConstructor (OriginTop testPackage "Test")
+
+valueNameTop :: Text -> Name
+valueNameTop text = Name text SortValue (OriginTop testPackage "Test")
+
+dataNameTop :: Text -> Name
+dataNameTop text = Name text SortDataConstructor (OriginTop testPackage "Test")
+
+typeWired :: Text -> Name
+typeWired text = Name text SortSynonym (OriginTop primPackage "GHC.Types")
+
+localType :: Text -> Name
+localType text = Name text SortTypeVariable (OriginLocal (Unique 0))
+
+localValue :: Text -> Name
+localValue text = Name text SortValue (OriginLocal (Unique 0))
+
+identityProgram :: Program
+identityProgram =
+  Program
+    { programModule = ModuleId testPackage "Test",
+      programScopes = scopes,
+      programDecls =
+        [ DeclType
+            TypeDecl
+              { typeVis = Pub,
+                typeName = typeNameTop "Bool",
+                typeBinders = [],
+                typeResult = TyCon (typeWired "Type"),
+                typeRoles = [],
+                typeCons =
+                  [ ConDecl Pub (dataNameTop "False") (TyCon (typeNameTop "Bool")),
+                    ConDecl Pub (dataNameTop "True") (TyCon (typeNameTop "Bool"))
+                  ]
+              },
+          DeclVal
+            ValDecl
+              { valVis = Private,
+                valName = valueNameTop "id",
+                valType =
+                  TyForAll
+                    (Binder (localType "a") (TyCon (typeWired "Type")))
+                    ( TyFun
+                        (TyCon (typeWired "LiftedRep"))
+                        (TyCon (typeWired "LiftedRep"))
+                        (TyVar (localType "a"))
+                        (TyVar (localType "a"))
+                    ),
+                valBody =
+                  ExTyLam
+                    (Binder (localType "a") (TyCon (typeWired "Type")))
+                    ( ExLam
+                        (Binder (localValue "x") (TyVar (localType "a")))
+                        (ExVar (localValue "x"))
+                    )
+              }
+        ]
+    }
+
+genProgram :: Gen Program
+genProgram = do
+  suffix <- Gen.text (Range.linear 1 4) Gen.lower
+  let typeName = typeNameTop ("T" <> suffix)
+      consName = dataNameTop ("C" <> suffix)
+      valName = valueNameTop ("f" <> suffix)
+      result = TyCon (typeWired "Type")
+  pure
+    Program
+      { programModule = ModuleId testPackage "Test",
+        programScopes = scopes,
+        programDecls =
+          [ DeclType
+              TypeDecl
+                { typeVis = Pub,
+                  typeName = typeName,
+                  typeBinders = [],
+                  typeResult = result,
+                  typeRoles = [],
+                  typeCons = [ConDecl Pub consName (TyCon typeName)]
+                },
+            DeclVal
+              ValDecl
+                { valVis = Pub,
+                  valName = valName,
+                  valType =
+                    TyFun
+                      (TyCon (typeWired "LiftedRep"))
+                      (TyCon (typeWired "LiftedRep"))
+                      (TyCon typeName)
+                      (TyCon typeName),
+                  valBody =
+                    ExLam
+                      (Binder (localValue "x") (TyCon typeName))
+                      (ExVar (localValue "x"))
+                }
+          ]
+      }

--- a/components/aihc-fc/test/Test/Fc2/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc2/Suite.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Fixture tests for System FC 2 text.
+module Test.Fc2.Suite
+  ( fc2FixtureTests,
+  )
+where
+
+import Aihc.Fc2 (parseProgram, renderParseError, renderProgram)
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import System.Directory (doesDirectoryExist, listDirectory)
+import System.FilePath (takeExtension, (</>))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+
+fixtureRoot :: FilePath
+fixtureRoot = "test/Test/Fixtures/fc2"
+
+fc2FixtureTests :: IO TestTree
+fc2FixtureTests = do
+  exists <- doesDirectoryExist fixtureRoot
+  if not exists
+    then pure (testGroup "SystemFC2 fixtures" [])
+    else do
+      names <- listDirectory fixtureRoot
+      let files = [fixtureRoot </> name | name <- names, takeExtension name == ".fc2"]
+      pure (testGroup "SystemFC2 fixtures" (map fixtureTest files))
+
+fixtureTest :: FilePath -> TestTree
+fixtureTest path = testCase path $ do
+  source <- TIO.readFile path
+  case parseProgram source of
+    Left parseError -> assertFailure (renderParseError parseError)
+    Right program ->
+      let printed = T.pack (renderProgram program)
+       in case parseProgram printed of
+            Left reprintError -> assertFailure ("reprint parse failed: " <> renderParseError reprintError)
+            Right reprinted -> do
+              assertEqual "parse then pretty then parse" program reprinted
+              assertEqual "pretty matches fixture" (normalize source) (normalize printed)
+
+normalize :: Text -> Text
+normalize = T.pack . trim . T.unpack
+  where
+    trim = dropWhileEnd isSpace . dropWhile isSpace

--- a/components/aihc-fc/test/Test/Fixtures/fc2/bool-id.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/bool-id.fc2
@@ -1,0 +1,14 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vid :: ∀(a : 2.tType). a → a
+ = Λ(a : 2.tType).
+  λ(x : a).
+    x

--- a/components/aihc-fc/test/Test/Fixtures/fc2/dollar-names.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/dollar-names.fc2
@@ -1,0 +1,21 @@
+scope 1 = "" Parent
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Parent where
+
+pub type 1.tFlag :: 2.tType {
+    pub 1.vOff :: 1.tFlag
+    pub 1.vOn :: 1.tFlag
+}
+
+pub type 1.t$Dict$Parent (a : 2.tType) :: 2.tType {
+    pub 1.v$Dict$Parent :: ∀(a : 2.tType). (a → 1.tFlag) → 1.t$Dict$Parent a
+}
+
+pub val 1.vparent :: ∀(a : 2.tType). 1.t$Dict$Parent a → a → 1.tFlag
+ = Λ(a : 2.tType).
+  λ($d0 : 1.t$Dict$Parent a).
+    case $d0 as ($dict : 1.t$Dict$Parent a) of {
+        1.v$Dict$Parent ($method0 : a → 1.tFlag) →
+            $method0
+    }

--- a/components/aihc-fc/test/Test/Fixtures/fc2/fun-explicit.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/fun-explicit.fc2
@@ -1,0 +1,8 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+val 1.vidBool :: FUN @2.tLiftedRep @2.tLiftedRep 2.tBool 2.tBool
+ = λ(x : 2.tBool).
+  x

--- a/components/aihc-fc/test/Test/Fixtures/fc2/list.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/list.fc2
@@ -1,0 +1,9 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.t[] (a : 2.tType) :: 2.tType {
+    pub 1.v[] :: ∀(a : 2.tType). 1.t[] a
+    pub 1.v: :: ∀(a : 2.tType). a → 1.t[] a → 1.t[] a
+}


### PR DESCRIPTION
## Summary

Add the first System FC 2 language modules in `Aihc.Fc2`.
Keep `Aihc.Fc` and its tests.

The new text has one namespace. The `t` and `v` marks are print and parse only.
Each binder has a type. A use has no type.
`FUN` stores both `RuntimeRep` arguments. Print `a → b` when this file can rebuild them.

## Tests

- Fc2 text fixtures in `test/Test/Fixtures/fc2/`
- Hedgehog `parseProgram . renderProgram = id` on self-contained programs

Haskell source cannot produce Fc2 until desugar exists.
These fixtures hold Fc2 text and check parse and pretty.

## Progress

No README progress counts change.
This PR does not switch current Fc goldens.

## Plan

This is PR 1 of the System FC 2 plan.
Later PRs add desugar and `install-v2` `core-v2` output.