### PR TITLE
feat(fc2): desugar values, lambda, application, and case

### DIFF
--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -31,6 +31,7 @@ library
     Aihc.Fc2
     Aihc.Fc2.Convert
     Aihc.Fc2.Desugar
+    Aihc.Fc2.FromFc
     Aihc.Fc2.Name
     Aihc.Fc2.Parser
     Aihc.Fc2.Pretty

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -7,8 +7,10 @@ module Aihc.Fc2.Desugar
   )
 where
 
-import Aihc.Fc.Desugar (DesugarConfig (..))
+import Aihc.Fc.Desugar (DesugarConfig (..), DesugarResult (..), desugarModuleWithInterface)
+import Aihc.Fc.Syntax (fcProgramModule, fcTopBinds)
 import Aihc.Fc2.Convert
+import Aihc.Fc2.FromFc (convertValueDecls)
 import Aihc.Fc2.Name
 import Aihc.Fc2.Syntax
 import Aihc.Parser.Syntax
@@ -58,7 +60,7 @@ data Fc2DesugarResult = Fc2DesugarResult
   deriving (Show)
 
 desugarModuleFc2 :: DesugarConfig -> [TcBindingResult] -> TcInterface -> Module -> Fc2DesugarResult
-desugarModuleFc2 config _bindings interface checked =
+desugarModuleFc2 config bindings interface checked =
   if not (tcModuleSuccess checked)
     then
       Fc2DesugarResult
@@ -66,7 +68,7 @@ desugarModuleFc2 config _bindings interface checked =
           ds2Success = False,
           ds2Errors = fmap show (tcModuleDiagnostics checked)
         }
-    else case desugarChecked config interface checked of
+    else case desugarChecked config bindings interface checked of
       Left errors ->
         Fc2DesugarResult
           { ds2Program = Program (ModuleId "" (fromMaybe "Main" (Syn.moduleName checked))) emptyScopeTable [],
@@ -80,16 +82,28 @@ desugarModuleFc2 config _bindings interface checked =
             ds2Errors = []
           }
 
-desugarChecked :: DesugarConfig -> TcInterface -> Module -> Either String Program
-desugarChecked config interface checked = do
+desugarChecked :: DesugarConfig -> [TcBindingResult] -> TcInterface -> Module -> Either String Program
+desugarChecked config bindings interface checked = do
   let (packageId, currentModule) = resolvedModuleOrigin checked
       moduleId = ModuleId packageId currentModule
       env = emptyConvertEnv (primPackageId config)
       dataTypes = tcInterfaceDataTypes interface
       tyCons = tcInterfaceTyCons interface
-  decls <- concat <$> mapM (dsDecl env packageId currentModule dataTypes tyCons) (Syn.moduleDecls checked)
-  let scopes = buildScopes moduleId decls
+  typeDecls <- concat <$> mapM (dsDecl env packageId currentModule dataTypes tyCons) (Syn.moduleDecls checked)
+  valueDecls <- convertFcValues config bindings interface checked env
+  let decls = typeDecls <> valueDecls
+      scopes = buildScopes moduleId decls
   pure (Program moduleId scopes decls)
+
+convertFcValues :: DesugarConfig -> [TcBindingResult] -> TcInterface -> Module -> ConvertEnv -> Either String [Decl]
+convertFcValues config bindings interface checked env =
+  let fcResult = desugarModuleWithInterface config bindings interface checked
+   in if not (dsSuccess fcResult)
+        then
+          if null (dsErrors fcResult)
+            then Right []
+            else Left (unlines (dsErrors fcResult))
+        else convertValueDecls env (fcProgramModule (dsProgram fcResult)) (fcTopBinds (dsProgram fcResult))
 
 dsDecl :: ConvertEnv -> PackageId -> Text -> [DataTypeInfo] -> [TyConInfo] -> Syn.Decl -> Either String [Decl]
 dsDecl env package moduleName' dataTypes tyCons decl =
@@ -241,6 +255,7 @@ declOrigins decl =
     DeclVal valDecl ->
       nameOriginPair (valName valDecl)
         <> typeOrigins (valType valDecl)
+        <> exprOrigins (valBody valDecl)
     DeclPrim primDecl ->
       nameOriginPair (primName primDecl)
         <> typeOrigins (primType primDecl)
@@ -251,6 +266,55 @@ conOrigins constructor =
 
 binderOrigins :: Binder -> [(PackageId, Text)]
 binderOrigins binder = typeOrigins (binderType binder)
+
+exprOrigins :: Expr -> [(PackageId, Text)]
+exprOrigins expr =
+  case expr of
+    ExVar name -> nameOriginPair name
+    ExLit literal -> literalOrigins literal
+    ExApp function argument -> exprOrigins function <> exprOrigins argument
+    ExTyApp function ty -> exprOrigins function <> typeOrigins ty
+    ExLam binder body -> binderOrigins binder <> exprOrigins body
+    ExTyLam binder body -> binderOrigins binder <> exprOrigins body
+    ExLet bind body -> bindOrigins bind <> exprOrigins body
+    ExRec binds body -> concatMap bindOrigins binds <> exprOrigins body
+    ExCase scrutinee binder alts ->
+      exprOrigins scrutinee <> binderOrigins binder <> concatMap altOrigins alts
+    ExCast inner coercion -> exprOrigins inner <> coercionOrigins coercion
+
+bindOrigins :: Bind -> [(PackageId, Text)]
+bindOrigins bind = binderOrigins (bindBinder bind) <> exprOrigins (bindRhs bind)
+
+altOrigins :: Alt -> [(PackageId, Text)]
+altOrigins alternative =
+  altConOrigins (altCon alternative)
+    <> concatMap binderOrigins (altBinders alternative)
+    <> exprOrigins (altRhs alternative)
+
+altConOrigins :: AltCon -> [(PackageId, Text)]
+altConOrigins alternative =
+  case alternative of
+    AltData name -> nameOriginPair name
+    AltLit literal -> literalOrigins literal
+    AltDefault -> []
+
+literalOrigins :: Literal -> [(PackageId, Text)]
+literalOrigins literal =
+  case literal of
+    LitInt representation _ -> typeOrigins representation
+    LitChar representation _ -> typeOrigins representation
+    LitString {} -> []
+    LitAddr representation _ -> typeOrigins representation
+
+coercionOrigins :: Coercion -> [(PackageId, Text)]
+coercionOrigins coercion =
+  case coercion of
+    CoVar name -> nameOriginPair name
+    CoRefl ty -> typeOrigins ty
+    CoSym inner -> coercionOrigins inner
+    CoTrans left right -> coercionOrigins left <> coercionOrigins right
+    CoTyConApp name arguments -> nameOriginPair name <> concatMap coercionOrigins arguments
+    CoAxiom name arguments -> nameOriginPair name <> concatMap typeOrigins arguments
 
 typeOrigins :: Type -> [(PackageId, Text)]
 typeOrigins ty =

--- a/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Convert System FC terms into System FC 2 values.
+module Aihc.Fc2.FromFc
+  ( convertValueDecls,
+  )
+where
+
+import Aihc.Fc.Syntax qualified as Fc
+import Aihc.Fc2.Convert
+import Aihc.Fc2.Name
+import Aihc.Fc2.Syntax
+import Aihc.Resolve (PackageId (..))
+import Aihc.Tc.Evidence qualified as Ev
+import Aihc.Tc.Types (RuntimeRep (..), Unique (..))
+import Data.Char (isAsciiUpper)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+
+type TopVars = Map Unique Name
+
+convertValueDecls :: ConvertEnv -> Fc.FcModuleId -> [Fc.FcTopBind] -> Either String [Decl]
+convertValueDecls env moduleId topBinds =
+  let tops = Map.fromList (concatMap (topBindVars moduleId) topBinds)
+   in fmap concat (mapM (convertTopBind env moduleId tops) topBinds)
+
+topBindVars :: Fc.FcModuleId -> Fc.FcTopBind -> [(Unique, Name)]
+topBindVars moduleId topBind =
+  case topBind of
+    Fc.FcTopBind bind -> bindVars moduleId bind
+    _ -> []
+
+bindVars :: Fc.FcModuleId -> Fc.FcBind -> [(Unique, Name)]
+bindVars moduleId bind =
+  case bind of
+    Fc.FcNonRec var _ -> [(Fc.varUnique var, topVarName moduleId var)]
+    Fc.FcRec bindings -> [(Fc.varUnique var, topVarName moduleId var) | (var, _) <- bindings]
+
+convertTopBind :: ConvertEnv -> Fc.FcModuleId -> TopVars -> Fc.FcTopBind -> Either String [Decl]
+convertTopBind env moduleId tops topBind =
+  case topBind of
+    Fc.FcTopBind bind -> convertBindDecls env moduleId tops bind
+    _ -> Right []
+
+convertBindDecls :: ConvertEnv -> Fc.FcModuleId -> TopVars -> Fc.FcBind -> Either String [Decl]
+convertBindDecls env moduleId tops bind =
+  case bind of
+    Fc.FcNonRec var expr -> (: []) . DeclVal <$> convertVal env moduleId tops var expr
+    Fc.FcRec bindings -> mapM (fmap DeclVal . uncurry (convertVal env moduleId tops)) bindings
+
+convertVal :: ConvertEnv -> Fc.FcModuleId -> TopVars -> Fc.Var -> Fc.FcExpr -> Either String ValDecl
+convertVal env moduleId tops var expr = do
+  ty <- convertType env (Fc.varType var)
+  body <- convertExpr env tops expr
+  pure
+    ValDecl
+      { valVis = Pub,
+        valName = topVarName moduleId var,
+        valType = ty,
+        valBody = body
+      }
+
+convertExpr :: ConvertEnv -> TopVars -> Fc.FcExpr -> Either String Expr
+convertExpr env tops expression =
+  case expression of
+    Fc.FcVar var -> Right (ExVar (varNameFc2 tops var))
+    Fc.FcLit literal _ -> ExLit <$> convertLiteral env literal
+    Fc.FcApp function argument -> ExApp <$> convertExpr env tops function <*> convertExpr env tops argument
+    Fc.FcTyApp function ty -> ExTyApp <$> convertExpr env tops function <*> convertType env ty
+    Fc.FcLam var body -> do
+      binder <- convertTermBinder env tops var
+      ExLam binder <$> convertExpr env tops body
+    Fc.FcTyLam tyVar body -> do
+      binder <- tyVarBinder env tyVar
+      ExTyLam binder <$> convertExpr (withTyVar tyVar env) tops body
+    Fc.FcLet bind body ->
+      case bind of
+        Fc.FcNonRec var expr -> do
+          binder <- convertTermBinder env tops var
+          rhs <- convertExpr env tops expr
+          ExLet (Bind binder rhs) <$> convertExpr env tops body
+        Fc.FcRec bindings -> do
+          converted <- mapM (convertRecBind env tops) bindings
+          ExRec converted <$> convertExpr env tops body
+    Fc.FcCase scrutinee binder alternatives -> do
+      scrutinee' <- convertExpr env tops scrutinee
+      caseBinder <- convertTermBinder env tops binder
+      alts <- mapM (convertAlt env tops) alternatives
+      pure (ExCase scrutinee' caseBinder alts)
+    Fc.FcCast inner coercion ->
+      ExCast <$> convertExpr env tops inner <*> convertCoercion env coercion
+    Fc.FcCallForeign {} ->
+      Left "foreign-call terms are not in System FC 2 yet"
+
+convertRecBind :: ConvertEnv -> TopVars -> (Fc.Var, Fc.FcExpr) -> Either String Bind
+convertRecBind env tops (var, expr) = do
+  binder <- convertTermBinder env tops var
+  Bind binder <$> convertExpr env tops expr
+
+convertAlt :: ConvertEnv -> TopVars -> Fc.FcAlt -> Either String Alt
+convertAlt env tops alternative = do
+  con <- convertAltCon env (Fc.altCon alternative)
+  binders <- mapM (convertTermBinder env tops) (Fc.altBinders alternative)
+  rhs <- convertExpr env tops (Fc.altRhs alternative)
+  pure (Alt con binders rhs)
+
+convertAltCon :: ConvertEnv -> Fc.FcAltCon -> Either String AltCon
+convertAltCon env alternative =
+  case alternative of
+    Fc.DataAlt constructor ->
+      Right
+        ( AltData
+            ( Name
+                (Fc.fcConstructorName constructor)
+                SortDataConstructor
+                (OriginTop (Fc.fcConstructorPackage constructor) (Fc.fcConstructorModule constructor))
+            )
+        )
+    Fc.LitAlt literal _ -> AltLit <$> convertLiteral env literal
+    Fc.DefaultAlt -> Right AltDefault
+
+convertLiteral :: ConvertEnv -> Fc.Literal -> Either String Literal
+convertLiteral env literal =
+  case literal of
+    Fc.LitInt runtimeRep value -> LitInt <$> convertRep env runtimeRep <*> pure value
+    Fc.LitChar runtimeRep value -> LitChar <$> convertRep env runtimeRep <*> pure value
+    Fc.LitString value -> Right (LitString value)
+    Fc.LitAddr value -> LitAddr <$> convertRep env AddrRep <*> pure value
+
+convertCoercion :: ConvertEnv -> Ev.Coercion -> Either String Coercion
+convertCoercion env coercion =
+  case coercion of
+    Ev.CoVar (Ev.EvVar unique) ->
+      Right (CoVar (Name "c" SortValue (OriginLocal unique)))
+    Ev.Refl ty -> CoRefl <$> convertType env ty
+    Ev.Sym inner -> CoSym <$> convertCoercion env inner
+    Ev.Trans left right -> CoTrans <$> convertCoercion env left <*> convertCoercion env right
+    Ev.TyConAppCo tyCon arguments ->
+      CoTyConApp (tyConNameFc2 tyCon) <$> mapM (convertCoercion env) arguments
+    Ev.AxiomInstCo name arguments ->
+      CoAxiom (Name name SortAxiom (OriginLocal (Unique 0))) <$> mapM (convertType env) arguments
+
+convertTermBinder :: ConvertEnv -> TopVars -> Fc.Var -> Either String Binder
+convertTermBinder env tops var = do
+  ty <- convertType env (Fc.varType var)
+  pure (Binder (varNameFc2 tops var) ty)
+
+topVarName :: Fc.FcModuleId -> Fc.Var -> Name
+topVarName moduleId var =
+  case Fc.varResolvedName var of
+    Just (Fc.FcTopLevelOrigin package moduleName' name) ->
+      Name name SortValue (OriginTop (PackageId package) moduleName')
+    _ ->
+      Name
+        (displayName var)
+        SortValue
+        (OriginTop (Fc.fcModulePackage moduleId) (Fc.fcModuleName moduleId))
+
+varNameFc2 :: TopVars -> Fc.Var -> Name
+varNameFc2 tops var =
+  case Map.lookup (Fc.varUnique var) tops of
+    Just name -> name
+    Nothing ->
+      case Fc.varResolvedName var of
+        Just (Fc.FcTopLevelOrigin package moduleName' name) ->
+          let sort =
+                if startsWithConstructor name
+                  then SortDataConstructor
+                  else SortValue
+           in Name name sort (OriginTop (PackageId package) moduleName')
+        Just (Fc.FcBuiltinOrigin name) ->
+          Name name SortValue (OriginLocal (Fc.varUnique var))
+        Nothing ->
+          Name (displayName var) SortValue (OriginLocal (Fc.varUnique var))
+
+displayName :: Fc.Var -> Text
+displayName var = fromMaybe (Fc.varName var) (stripUniqueSuffix (Fc.varName var) (Fc.varUnique var))
+
+stripUniqueSuffix :: Text -> Unique -> Maybe Text
+stripUniqueSuffix name (Unique unique) = do
+  stripped <- T.stripSuffix (T.pack (show unique)) name
+  if T.null stripped then Nothing else Just stripped
+
+startsWithConstructor :: Text -> Bool
+startsWithConstructor name =
+  case T.uncons name of
+    Just (first, _) -> first == ':' || first == '[' || isAsciiUpper first
+    Nothing -> False

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-not.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-not.yaml
@@ -1,0 +1,28 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = True | False
+    not True = False
+    not False = True
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tBool :: 2.tType {
+      pub 1.vTrue :: 1.tBool
+      pub 1.vFalse :: 1.tBool
+  }
+
+  pub val 1.vnot :: 1.tBool → 1.tBool
+   = λ(x{1001} : 1.tBool).
+    case x{1001} as (_scrut{1002} : 1.tBool) of {
+        1.vTrue →
+            1.vFalse;
+        1.vFalse →
+            1.vTrue
+    }
+status: pass
+reason: Pattern matches on Bool become a Core case.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/identity.yaml
@@ -1,0 +1,17 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    id x = x
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub val 1.vid :: ∀(a{14} : 2.tType). a{14} → a{14}
+   = Λ(a{14} : 2.tType).
+    λ(x{1001} : a{14}).
+      x{1001}
+status: pass
+reason: A polymorphic identity becomes type and term lambdas.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/lambda-identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/lambda-identity.yaml
@@ -1,0 +1,17 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    id = \x -> x
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub val 1.vid :: ∀(a{12} : 2.tType). a{12} → a{12}
+   = Λ(a{12} : 2.tType).
+    λ(x{1001} : a{12}).
+      x{1001}
+status: pass
+reason: An inferred polymorphic lambda keeps its binder type.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-application.yaml
@@ -1,0 +1,28 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Bool = True | False
+    id x = x
+    true :: Bool
+    true = id True
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tBool :: 2.tType {
+      pub 1.vTrue :: 1.tBool
+      pub 1.vFalse :: 1.tBool
+  }
+
+  pub val 1.vid :: ∀(a{14} : 2.tType). a{14} → a{14}
+   = Λ(a{14} : 2.tType).
+    λ(x{1002} : a{14}).
+      x{1002}
+
+  pub val 1.vtrue :: 1.tBool
+   = 1.vid @1.tBool 1.vTrue
+status: pass
+reason: A polymorphic use inserts a type application.


### PR DESCRIPTION
## Summary

Convert checked value bindings into System FC 2.
Keep `Aihc.Fc` and its tests.

`desugarModuleFc2` still emits data types and synonyms.
It now also emits `val` bindings from the current System FC terms.
Uses have no type.
Binders keep their type.

A top-level use such as `id` keeps its module origin.
A constructor use such as `True` keeps its constructor origin.

## Tests

Add golden-v2 fixtures:

- `identity.yaml`
- `lambda-identity.yaml`
- `bool-not.yaml`
- `type-application.yaml`

## Progress

No README progress counts change.
This PR does not switch current Fc goldens.

## Plan

This is PR 3 of the System FC 2 plan.
The next PR desugars classes to dictionary data types.